### PR TITLE
feeds: cap dynamic address-feed body size + entry count (#3934)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,39 @@
+## 2026-07-03 — #3934: dynamic address-feed fetch had no body-size / entry cap → remote OOM DoS (plaintext-http MITM can amplify)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-179 (MEDIUM, DoS). `pkg/feeds/parseFeed`
+    read the HTTP response body with an unbounded `bufio.Scanner` and parsed
+    ALL entries with no cap, so a feed server returning a huge/infinite/chunked
+    body — or a MITM on a plaintext-http feed URL — could buffer an arbitrarily
+    large body into memory and OOM the daemon (remote-triggerable DoS); a
+    legitimately large feed OOMs by accident.
+  - **Fix**: (a) body-size cap — `parseFeed` now reads through
+    `io.LimitReader(r, maxFeedBodyBytes+1)` (32 MiB) wrapped in a
+    `countingReader`; a body exceeding the cap fails the whole fetch. (b)
+    entry cap — the parse loop bails with an error once parsed entries exceed
+    `maxFeedPrefixes` (1,048,576), bounding slice memory during parse and never
+    installing a partial-but-huge set. (c) timeout — the pre-existing 30 s
+    client timeout is now the named const `httpClientTimeout` (slow-loris
+    protection). Both over-limit conditions return an error, so
+    `fetchFeed→recordFailure` KEEPS the last-good snapshot (the #2050 fail-safe)
+    rather than wiping or truncating the enforced set. Added a one-time
+    `slog.Warn` at `Apply` for plaintext `http://` feed URLs (integrity risk).
+    Caps sit well under the 64 MiB userspace-dp control-request cap
+    (`MaxControlRequestBytes`, #2744) so a single feed cannot dominate the
+    apply snapshot.
+  - **RED-on-revert**: `feeds_sizecap_3934_test.go` — over-size body rejected
+    with a size error (RED: unbounded read returns success), over-entry-count
+    body rejected (RED: unbounded entry set), full HTTP path retains last-good
+    on an over-size fetch (RED: clobbers with the over-size body's prefix), a
+    slow server hits the client timeout and retains last-good, an under-cap
+    feed still installs fully, plaintext-http predicate pinned. Verified all
+    three cap tests go RED under a simulated revert. `go test -count=1
+    ./pkg/feeds/...` green, `go build ./...`, gofmt, vet clean. Doc:
+    pkg/feeds/README.md (fail-safe + gotchas, corrected the stale #2744
+    "NOT bounded by a total-entry cap" note).
+  - **File(s)**: pkg/feeds/feeds.go, pkg/feeds/feeds_sizecap_3934_test.go,
+    pkg/feeds/README.md, _Log.md
+
 ## 2026-07-03 — #3918: flow-cache neighbor_mac_epoch stamped AFTER neighbor resolve → resolve→stamp TOCTOU re-opens the #3048 stale-MAC blackhole on VRRP gateway failover
 
 - **Timestamp**: 2026-07-03

--- a/pkg/feeds/README.md
+++ b/pkg/feeds/README.md
@@ -22,6 +22,20 @@ applies a *retain-last-good* policy rather than installing a partial/empty set:
   per-line cap (`maxLineBytes`, 1 MiB); an overlong line (`bufio.ErrTooLong`)
   or a mid-stream read error returns an error. The whole read fails — a
   truncated set is never installed. `scanner.Err()` is checked after the loop.
+- **body-size + entry caps bound the fetch (#3934).** The response body is
+  read through an `io.LimitReader` capped at `maxFeedBodyBytes` (32 MiB) and the
+  parsed set is capped at `maxFeedPrefixes` (1,048,576 entries). A body larger
+  than the size cap, or one producing more than the entry cap, fails the whole
+  fetch (retain last-good) rather than buffering an arbitrarily large body into
+  memory or installing a partial-but-huge set. This closes a remote OOM DoS: a
+  feed server (or a MITM on a plaintext-http feed) returning a huge/infinite
+  body cannot exhaust daemon memory. The size cap sits well under the 64 MiB
+  userspace-dp control-request cap (`MaxControlRequestBytes`, #2744) so a single
+  feed cannot dominate the apply snapshot. The 30 s client timeout
+  (`httpClientTimeout`) bounds a slow-loris server that dribbles bytes.
+- **plaintext-http feeds are warned (#3934).** A feed URL using `http://`
+  (no transport integrity — a MITM can substitute the body) logs a one-time
+  `slog.Warn` at `Apply`. `https` is strongly preferred for any feed source.
 - **content-based change detection.** Prefixes are canonicalized (parsed to
   masked CIDR / `/32` / `/128`), deduped, sorted, and SHA-256 hashed. The
   `onUpdate` recompile callback fires only when the hash changes — a same-count
@@ -74,8 +88,9 @@ applies a *retain-last-good* policy rather than installing a partial/empty set:
 
 ## Gotchas
 
-- HTTP client timeout is 30 s. Timeouts log a warning but do not stop the
-  manager — the next refresh tick retries.
+- HTTP client timeout is 30 s (`httpClientTimeout`, slow-loris protection).
+  Timeouts log a warning but do not stop the manager — the next refresh tick
+  retries.
 - Multiple feeds can share a server; each feed's path is appended to the
   base URL.
 - Default refresh interval is 1 hour; the Junos config can override via
@@ -89,14 +104,17 @@ applies a *retain-last-good* policy rather than installing a partial/empty set:
 - A successful fetch always replaces the snapshot and stamps success, but
   the `onUpdate` recompile fires only when the canonical content hash
   changes — not on every fetch and not merely on a count change.
-- **Feed size vs. the dataplane control-socket cap (#2744):** feed prefixes
-  are carried inline as CIDR text in the userspace-dp `apply_snapshot`
+- **Feed size vs. the dataplane control-socket cap (#2744 / #3934):** feed
+  prefixes are carried inline as CIDR text in the userspace-dp `apply_snapshot`
   (`buildAddressBookTableWithFeeds`, `pkg/dataplane/userspace/policies.go`).
-  Feeds are bounded only by the per-line scanner cap above, NOT by a
-  total-entry cap, so a very large feed dominates the serialized snapshot
-  size. The control socket caps a single request at `MaxControlRequestBytes`
-  (64 MiB, in lockstep with the Rust `MAX_CONTROL_REQUEST_BYTES`); at
-  ~45 B per IPv6 CIDR that covers ~1.4M prefixes. A snapshot past the cap is
-  surfaced as a config error at apply time (Go pre-flight in
+  Each feed is now bounded at fetch time by BOTH a total body-size cap
+  (`maxFeedBodyBytes`, 32 MiB) and a total-entry cap (`maxFeedPrefixes`,
+  1,048,576) (#3934), so a single feed can no longer buffer an unbounded body
+  or dominate the serialized snapshot. The control socket separately caps a
+  single request at `MaxControlRequestBytes` (64 MiB, in lockstep with the Rust
+  `MAX_CONTROL_REQUEST_BYTES`); at ~45 B per IPv6 CIDR that covers ~1.4M
+  prefixes. The per-feed 32 MiB body cap keeps a single feed's serialized
+  contribution comfortably under that ceiling. A snapshot past the control cap
+  is still surfaced as a config error at apply time (Go pre-flight in
   `pkg/dataplane/userspace/process.go`) rather than silently rejected by the
   helper after commit.

--- a/pkg/feeds/feeds.go
+++ b/pkg/feeds/feeds.go
@@ -38,6 +38,32 @@ const maxLineBytes = 1 << 20 // 1 MiB
 // without the sample growing unbounded for a wholesale-garbage body.
 const maxInvalidSample = 5
 
+// maxFeedBodyBytes caps the total HTTP response body a single feed fetch will
+// buffer (#3934). Without a cap, a feed server that returns a huge (or
+// infinite/chunked) body — or a MITM on a plaintext-http feed URL — can make
+// the fetcher buffer an arbitrarily large body into memory and OOM the daemon
+// (a remote-triggerable DoS). The body is read through an io.LimitReader; a
+// body exceeding this cap fails the whole fetch (retain last-good) rather than
+// buffering unboundedly. 32 MiB is comfortably above any legitimate CIDR feed
+// yet well under the 64 MiB userspace-dp control-request cap
+// (MaxControlRequestBytes, #2744) so a single feed cannot dominate the apply
+// snapshot.
+const maxFeedBodyBytes = 32 << 20 // 32 MiB
+
+// maxFeedPrefixes caps the number of parsed entries a single feed may install
+// (#3934). This is a secondary guard on top of the byte cap: a body of many
+// short lines (e.g. bare IPv4 addresses) can stay under the byte cap while
+// producing an entry count that would blow the dataplane address-book map. A
+// feed exceeding this count fails the whole fetch (retain last-good) — a
+// partial-but-huge set is never installed. The count is measured on parsed
+// (pre-dedup) entries so memory is bounded during the parse loop.
+const maxFeedPrefixes = 1 << 20 // 1,048,576 entries
+
+// httpClientTimeout bounds a single feed fetch end-to-end (connect + headers +
+// body read), so a slow-loris feed server that dribbles bytes cannot hold the
+// fetch open indefinitely (#3934). The next refresh tick retries.
+const httpClientTimeout = 30 * time.Second
+
 // Manager manages dynamic address feed servers and their periodic updates.
 type Manager struct {
 	mu       sync.RWMutex
@@ -88,7 +114,7 @@ func New(onUpdate func()) *Manager {
 	return &Manager{
 		feeds: make(map[string]*feedState),
 		client: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: httpClientTimeout,
 		},
 		onUpdate: onUpdate,
 		now:      time.Now,
@@ -105,6 +131,18 @@ func resolveBaseURL(fsCfg *config.FeedServer) string {
 		return "https://" + strings.TrimRight(fsCfg.Hostname, "/")
 	}
 	return ""
+}
+
+// warnPlaintextFeed emits a one-time (per Apply) warning when a feed URL uses
+// plaintext http:// (#3934). A plaintext feed has no transport integrity: a
+// MITM can substitute an arbitrary body (including an over-size body aimed at
+// the OOM path guarded by maxFeedBodyBytes, or a hostile prefix set). https
+// is strongly preferred for any denylist/allowlist source.
+func warnPlaintextFeed(name, url string) {
+	if strings.HasPrefix(strings.ToLower(url), "http://") {
+		slog.Warn("dynamic-address: feed URL is plaintext http (no integrity — a MITM can substitute the feed body); prefer https",
+			"name", name, "url", url)
+	}
 }
 
 // resolveHoldInterval maps the configured hold-interval (seconds) to a
@@ -169,6 +207,7 @@ func (m *Manager) Apply(ctx context.Context, daCfg *config.DynamicAddressConfig)
 					cancel:       cancel,
 				}
 				m.feeds[fe.Name] = fs
+				warnPlaintextFeed(fe.Name, feedURL)
 				go m.refreshLoop(feedCtx, fs, interval)
 				slog.Info("dynamic address feed started",
 					"name", fe.Name, "server", fsCfg.Name, "url", feedURL,
@@ -188,6 +227,7 @@ func (m *Manager) Apply(ctx context.Context, daCfg *config.DynamicAddressConfig)
 				cancel:       cancel,
 			}
 			m.feeds[key] = fs
+			warnPlaintextFeed(key, baseURL)
 			go m.refreshLoop(feedCtx, fs, interval)
 			slog.Info("dynamic address feed started",
 				"name", key, "url", baseURL, "interval", interval, "hold", holdStr)
@@ -392,9 +432,11 @@ func (m *Manager) fetchFeed(ctx context.Context, fs *feedState) {
 // readFeed issues the HTTP request and parses the body into a canonical set.
 // It returns an error (and no snapshot is installed) on transport failure,
 // non-200 status, a scanner error (including bufio.ErrTooLong for an overlong
-// line), or a zero-prefix successful response (treated as suspect — a hijacked
-// or misconfigured endpoint serving an empty body must not silently wipe an
-// enforced set).
+// line), an over-size body / over-count entry set (maxFeedBodyBytes /
+// maxFeedPrefixes, #3934), or a zero-prefix successful response (treated as
+// suspect — a hijacked or misconfigured endpoint serving an empty body must
+// not silently wipe an enforced set). The transport itself is bounded by the
+// client's httpClientTimeout (slow-loris protection).
 func (m *Manager) readFeed(ctx context.Context, fs *feedState) (fetchResult, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", fs.url, nil)
 	if err != nil {
@@ -414,13 +456,41 @@ func (m *Manager) readFeed(ctx context.Context, fs *feedState) (fetchResult, err
 	return parseFeed(resp.Body)
 }
 
+// countingReader wraps an io.Reader and tracks the total number of bytes read
+// through it, so parseFeed can DETECT (not merely truncate at) an over-size
+// body: the body is read through io.LimitReader(r, maxFeedBodyBytes+1), and if
+// the counter passes maxFeedBodyBytes the feed exceeded the cap (#3934).
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+	return n, err
+}
+
 // parseFeed reads CIDR/IP lines from r and returns a canonicalized set.
 // Reads io.Reader (not http.Response) so it is unit-testable in isolation.
+//
+// The body is bounded on TWO axes (#3934) so a huge/infinite body or a MITM on
+// a plaintext-http feed cannot OOM the daemon:
+//   - total bytes: read through io.LimitReader(r, maxFeedBodyBytes+1); a body
+//     larger than maxFeedBodyBytes fails the whole fetch (retain last-good),
+//   - parsed entries: a body producing more than maxFeedPrefixes parsed entries
+//     fails the whole fetch (never install a partial-but-huge set).
+//
+// Both over-limit conditions return an error so fetchFeed→recordFailure keeps
+// the last-good snapshot rather than wiping or truncating the enforced set.
 func parseFeed(r io.Reader) (fetchResult, error) {
 	var prefixes []string
 	var invalidLines int
 	var invalidSample []string
-	scanner := bufio.NewScanner(r)
+	// Cap the total bytes buffered. Read one byte past the cap so a body that
+	// exactly fills the cap is accepted while anything larger is detected.
+	cr := &countingReader{r: io.LimitReader(r, maxFeedBodyBytes+1)}
+	scanner := bufio.NewScanner(cr)
 	scanner.Buffer(make([]byte, 0, 64*1024), maxLineBytes)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -449,11 +519,23 @@ func parseFeed(r io.Reader) (fetchResult, error) {
 				invalidSample = append(invalidSample, line)
 			}
 		}
+		// Entry cap: bail as soon as the parsed set exceeds the per-feed limit
+		// so the slice memory stays bounded during the loop and a huge feed is
+		// rejected rather than truncated-and-installed (#3934).
+		if len(prefixes) > maxFeedPrefixes {
+			return fetchResult{}, fmt.Errorf("feed exceeds max entry count %d", maxFeedPrefixes)
+		}
 	}
 	if err := scanner.Err(); err != nil {
 		// Overlong line (bufio.ErrTooLong) or transport read error mid-stream.
 		// Treat the entire read as failed — never install a truncated set.
 		return fetchResult{}, fmt.Errorf("read body: %w", err)
+	}
+	if cr.n > maxFeedBodyBytes {
+		// Body exceeded the size cap (the LimitReader delivered the extra
+		// sentinel byte). Fail the whole fetch — never install a truncated set,
+		// and keep the last-good snapshot (#3934).
+		return fetchResult{}, fmt.Errorf("feed body exceeds max size %d bytes", maxFeedBodyBytes)
 	}
 
 	canon := canonicalize(prefixes)

--- a/pkg/feeds/feeds_sizecap_3934_test.go
+++ b/pkg/feeds/feeds_sizecap_3934_test.go
@@ -1,0 +1,262 @@
+package feeds
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// This file is the #3934 fail-on-revert suite: the dynamic-address feed
+// fetcher must bound both the body SIZE and the parsed ENTRY count so a
+// huge/infinite body — or a MITM on a plaintext-http feed — cannot OOM the
+// daemon, and an over-limit feed must RETAIN the last-good snapshot rather
+// than wipe or truncate the enforced set.
+
+// repeatReader endlessly cycles a fixed chunk, so a test can synthesize an
+// arbitrarily large body without allocating it. Bound it with an
+// io.LimitReader to keep the synthetic body finite (a reverted parseFeed with
+// no io.LimitReader then terminates rather than hanging).
+type repeatReader struct {
+	chunk []byte
+	off   int
+}
+
+func (r *repeatReader) Read(p []byte) (int, error) {
+	n := 0
+	for n < len(p) {
+		if r.off >= len(r.chunk) {
+			r.off = 0
+		}
+		c := copy(p[n:], r.chunk[r.off:])
+		r.off += c
+		n += c
+	}
+	return n, nil
+}
+
+// oversizeCommentChunk is a 64 KiB comment line (well under maxLineBytes) that
+// parses as a skipped comment — padding to inflate the body byte count without
+// inflating the parsed entry count, so a test isolates the BYTE cap from the
+// ENTRY cap.
+func oversizeCommentChunk() []byte {
+	return []byte("#" + strings.Repeat("a", 64*1024-2) + "\n")
+}
+
+// TestParseFeedOverSizeBodyRejected drives the maxFeedBodyBytes cap directly.
+// A body larger than the cap must fail the parse with a size error. On revert
+// (no io.LimitReader / no size check) parseFeed reads the whole body and
+// returns success — this goes RED.
+func TestParseFeedOverSizeBodyRejected(t *testing.T) {
+	// One valid prefix, then >maxFeedBodyBytes of 64 KiB comment lines. The
+	// entry count stays at 1 so the BYTE cap is what trips.
+	prefix := strings.NewReader("203.0.113.0/24\n")
+	pad := io.LimitReader(&repeatReader{chunk: oversizeCommentChunk()}, maxFeedBodyBytes+64*1024)
+	body := io.MultiReader(prefix, pad)
+
+	_, err := parseFeed(body)
+	if err == nil {
+		t.Fatal("expected error for over-size body, got nil (unbounded read → OOM path)")
+	}
+	if !strings.Contains(err.Error(), "max size") {
+		t.Fatalf("expected max-size rejection, got %v", err)
+	}
+}
+
+// TestParseFeedOverEntryCountRejected drives the maxFeedPrefixes cap. A body
+// producing more than maxFeedPrefixes parsed entries must fail with an
+// entry-count error rather than install a partial-but-huge set. On revert (no
+// entry cap) parseFeed accepts it and returns success — this goes RED.
+func TestParseFeedOverEntryCountRejected(t *testing.T) {
+	var b strings.Builder
+	// A tiny valid line repeated past the entry cap. Duplicates count toward
+	// the pre-dedup entry cap (memory bound), and the whole body stays well
+	// under maxFeedBodyBytes so the ENTRY cap is what trips, not the byte cap.
+	const line = "1.1.1.1\n"
+	b.Grow((maxFeedPrefixes + 2) * len(line))
+	for i := 0; i < maxFeedPrefixes+2; i++ {
+		b.WriteString(line)
+	}
+
+	_, err := parseFeed(strings.NewReader(b.String()))
+	if err == nil {
+		t.Fatal("expected error for over-entry-count body, got nil (unbounded entry set)")
+	}
+	if !strings.Contains(err.Error(), "max entry count") {
+		t.Fatalf("expected max-entry-count rejection, got %v", err)
+	}
+}
+
+// TestParseFeedUnderCapsInstalls is the no-regression guard: a legitimately
+// large feed (many prefixes, comfortably under both caps) still parses and
+// installs — the caps must not reject a normal feed.
+func TestParseFeedUnderCapsInstalls(t *testing.T) {
+	var b strings.Builder
+	const n = 1000
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, "10.%d.%d.0/24\n", i/256, i%256)
+	}
+	res, err := parseFeed(strings.NewReader(b.String()))
+	if err != nil {
+		t.Fatalf("under-cap feed rejected: %v", err)
+	}
+	if len(res.prefixes) != n {
+		t.Fatalf("got %d prefixes, want %d (under-cap feed must install fully)", len(res.prefixes), n)
+	}
+}
+
+// oversizeServer serves a small good body until switched to over-size, when it
+// streams a DIFFERENT leading prefix followed by >maxFeedBodyBytes of comment
+// padding. The different prefix lets the retention assertion distinguish
+// "retained last-good" (fixed) from "installed the over-size body" (revert).
+type oversizeServer struct {
+	mu   sync.Mutex
+	over bool
+}
+
+func (s *oversizeServer) setOver(o bool) {
+	s.mu.Lock()
+	s.over = o
+	s.mu.Unlock()
+}
+
+func (s *oversizeServer) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		s.mu.Lock()
+		over := s.over
+		s.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		if !over {
+			_, _ = io.WriteString(w, "203.0.113.0/24\n")
+			return
+		}
+		// A different valid prefix leads; if the size cap were absent this
+		// would REPLACE the last-good set.
+		_, _ = io.WriteString(w, "198.51.100.0/24\n")
+		_, _ = io.CopyN(w, &repeatReader{chunk: oversizeCommentChunk()}, maxFeedBodyBytes+64*1024)
+	}
+}
+
+// TestFetchFeedOverSizeRetainsLastGood exercises the full HTTP fetch path plus
+// the retain-last-good fail-safe: an over-size body must be rejected and the
+// previously-installed prefixes retained (never wiped or replaced by a
+// truncated set). On revert the over-size body installs [198.51.100.0/24],
+// clobbering the last-good — the retention assertion goes RED.
+func TestFetchFeedOverSizeRetainsLastGood(t *testing.T) {
+	var calls int
+	m := New(func() { calls++ })
+	srv := &oversizeServer{}
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	fs := m.newFeed("f", ts.URL, time.Hour)
+	ctx := context.Background()
+
+	// Install last-good.
+	m.fetchFeed(ctx, fs)
+	if got := m.GetPrefixes("f"); len(got) != 1 || got[0] != "203.0.113.0/24" {
+		t.Fatalf("initial install failed: got %v", got)
+	}
+	installCalls := calls
+
+	// Switch to an over-size body.
+	srv.setOver(true)
+	m.fetchFeed(ctx, fs)
+
+	if got := m.GetPrefixes("f"); len(got) != 1 || got[0] != "203.0.113.0/24" {
+		t.Fatalf("over-size fetch clobbered last-good: got %v, want [203.0.113.0/24]", got)
+	}
+	if fs.lastError == "" {
+		t.Error("expected lastError recorded for over-size fetch")
+	}
+	if calls != installCalls {
+		t.Errorf("onUpdate fired on rejected over-size fetch: calls went %d -> %d", installCalls, calls)
+	}
+}
+
+// slowServer serves a body immediately until switched to slow, when it sleeps
+// past the client timeout before responding.
+type slowServer struct {
+	mu    sync.Mutex
+	slow  bool
+	delay time.Duration
+	body  string
+}
+
+func (s *slowServer) setSlow(b bool) {
+	s.mu.Lock()
+	s.slow = b
+	s.mu.Unlock()
+}
+
+func (s *slowServer) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		s.mu.Lock()
+		slow, delay, body := s.slow, s.delay, s.body
+		s.mu.Unlock()
+		if slow {
+			time.Sleep(delay)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, body)
+	}
+}
+
+// TestFetchFeedSlowServerTimesOut guards the client timeout (slow-loris
+// protection): a server that stalls past the timeout must fail the fetch and
+// retain the last-good snapshot, not block the refresh indefinitely. The
+// timeout is overridden to a short value so the test is fast.
+func TestFetchFeedSlowServerTimesOut(t *testing.T) {
+	m := New(func() {})
+	m.client.Timeout = 150 * time.Millisecond
+
+	srv := &slowServer{delay: 2 * time.Second, body: "203.0.113.0/24\n"}
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	fs := m.newFeed("f", ts.URL, time.Hour)
+	ctx := context.Background()
+
+	// Fast install.
+	m.fetchFeed(ctx, fs)
+	if got := m.GetPrefixes("f"); len(got) != 1 || got[0] != "203.0.113.0/24" {
+		t.Fatalf("initial install failed: got %v", got)
+	}
+
+	// Stall the next fetch past the client timeout.
+	srv.setSlow(true)
+	start := time.Now()
+	m.fetchFeed(ctx, fs)
+	elapsed := time.Since(start)
+	if elapsed > time.Second {
+		t.Fatalf("fetch did not honor the client timeout: took %v", elapsed)
+	}
+	if got := m.GetPrefixes("f"); len(got) != 1 || got[0] != "203.0.113.0/24" {
+		t.Errorf("timeout wiped last-good: got %v", got)
+	}
+	if fs.lastError == "" {
+		t.Error("expected lastError recorded on timeout")
+	}
+}
+
+// TestWarnPlaintextFeedPredicate pins the plaintext-http detection used to warn
+// operators about an integrity-free feed source (#3934).
+func TestWarnPlaintextFeedPredicate(t *testing.T) {
+	cases := map[string]bool{
+		"http://feeds.example/deny.txt":  true,
+		"HTTP://feeds.example/deny.txt":  true,
+		"https://feeds.example/deny.txt": false,
+		"https://http.example/deny.txt":  false,
+	}
+	for url, wantPlain := range cases {
+		gotPlain := strings.HasPrefix(strings.ToLower(url), "http://")
+		if gotPlain != wantPlain {
+			t.Errorf("plaintext detection for %q = %v, want %v", url, gotPlain, wantPlain)
+		}
+	}
+}


### PR DESCRIPTION
Closes #3934

## Problem

The dynamic address-feed fetcher (`pkg/feeds`) read the HTTP response
body with an unbounded `bufio.Scanner` and parsed ALL entries with no
cap. A feed server returning a huge/infinite/chunked body — or a MITM on
a plaintext-`http://` feed URL — could buffer an arbitrarily large body
into memory and OOM the daemon (a remote-triggerable DoS whenever an
attacker controls or can MITM the feed URL). A legitimately large feed
OOMs by accident.

## Fix

`pkg/feeds/feeds.go`:

- **Body-size cap** — `parseFeed` reads through
  `io.LimitReader(r, maxFeedBodyBytes+1)` (32 MiB) wrapped in a
  `countingReader`; a body exceeding the cap fails the whole fetch. The
  `+1` sentinel lets the parser DETECT an over-size body (`n > cap`)
  rather than silently truncate at the limit.
- **Entry cap** — the parse loop bails with an error once the parsed
  (pre-dedup) set exceeds `maxFeedPrefixes` (1,048,576), bounding slice
  memory during the loop and never installing a partial-but-huge set
  that would blow the dataplane address-book map.
- **Timeout** — the pre-existing 30 s client timeout is now the named
  const `httpClientTimeout` (slow-loris protection).
- **Fail-safe** — both over-limit conditions return an error, so
  `fetchFeed → recordFailure` KEEPS the last-good snapshot (#2050) rather
  than wiping or truncating the enforced prefix set.
- **Plaintext-http warn** — a one-time `slog.Warn` fires at `Apply` for
  `http://` feed URLs (no transport integrity).

The 32 MiB body cap sits well under the 64 MiB userspace-dp
control-request cap (`MaxControlRequestBytes`, #2744), so a single feed
cannot dominate the apply snapshot.

## RED-on-revert test

`pkg/feeds/feeds_sizecap_3934_test.go`:

- over-size body rejected (RED on revert: unbounded read returns success)
- over-entry-count body rejected (RED: unbounded entry set installs)
- full HTTP path retains last-good on an over-size fetch — the over-size
  body leads with a DIFFERENT prefix so retention is distinguishable
  from a re-install (RED: clobbers last-good)
- slow server hits the client timeout and retains last-good
- under-cap feed with many prefixes still installs fully (no regression)
- plaintext-http warn predicate pinned

Synthetic bodies stream from a cycling `repeatReader` bounded by an
`io.LimitReader`, so a reverted `parseFeed` terminates rather than hangs.
Verified all three cap tests go RED under a simulated revert of the caps.

## Validation

- `go test -count=1 ./pkg/feeds/...` green
- `go build ./...`, `gofmt`, `go vet` clean
- Docs: `pkg/feeds/README.md` updated (fail-safe + gotchas; corrected the
  stale #2744 "NOT bounded by a total-entry cap" note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
