### PR TITLE
flowexport: export protocolIdentifier from the numeric protocol (#3939)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-03 — #3939: NetFlow v9 / IPFIX protocolIdentifier was 0 for GRE/ESP/AH (parsed protocol NAME, not rec.ProtocolNum) → exported flows misattributed
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-058 (MEDIUM, observability/correctness). The
+    NetFlow v9 / IPFIX exporters set `FlowRecord.Protocol` from
+    `SessionCloseData.Protocol`, which the daemon callbacks filled via
+    `parseProtocol(rec.Protocol)` — a NAME→number table covering only
+    TCP/UDP/ICMP/ICMPv6. GRE (47), ESP (50), AH (51) and every other protocol
+    fell through to 0, so a collector saw those flows as protocol 0 (HOPOPT)
+    and could not distinguish an ESP tunnel from a GRE flow.
+  - **Fix**: source the exported `protocolIdentifier` (IE 4) directly from
+    `EventRecord.ProtocolNum` (the raw numeric IP protocol, 0-255, the
+    dataplane stamps and `pkg/logging/ringbuf.go` decodes verbatim) in BOTH
+    `ExportSessionClose` builders (netflow.go, ipfix.go). Also set
+    `SessionCloseData.Protocol = rec.ProtocolNum` in both daemon callbacks and
+    removed the now-unused `parseProtocol` — this eliminates the lossy value at
+    the root and additionally corrects the non-TCP `flowStartTime` duration
+    heuristic. The rendered protocol NAME (`EventRecord.Protocol`) stays a
+    display-only string for `show` output; only the exported numeric field
+    changed.
+  - **RED-on-revert**: `pkg/flowexport/protocol_num_test.go` encodes GRE/ESP/AH
+    + TCP/UDP/ICMP for both v9 and IPFIX (v4 + v6) and asserts the encoded
+    protocolIdentifier byte equals the numeric protocol; the SessionCloseData
+    carries the pre-fix lossy 0 so reverting the exporter to `evt.Protocol`
+    makes every case encode 0 → RED (verified by temporarily reverting both
+    exporters: v4/ICMP FlowRecord.Protocol=0 want 1). `go test -count=1
+    ./pkg/flowexport/...` green, daemon flowexport tests green, `go build
+    ./...`, gofmt, vet clean. Doc: pkg/flowexport/README.md (#3939 subsection).
+  - **File(s)**: pkg/flowexport/netflow.go, pkg/flowexport/ipfix.go,
+    pkg/daemon/daemon_flowexport.go, pkg/daemon/daemon_flow.go,
+    pkg/flowexport/protocol_num_test.go, pkg/flowexport/README.md, _Log.md
+
 ## 2026-07-03 — #3934: dynamic address-feed fetch had no body-size / entry cap → remote OOM DoS (plaintext-http MITM can amplify)
 
 - **Timestamp**: 2026-07-03

--- a/pkg/daemon/daemon_flow.go
+++ b/pkg/daemon/daemon_flow.go
@@ -214,20 +214,6 @@ func parseSrcPort(addr string) uint16 {
 	return 0
 }
 
-func parseProtocol(proto string) uint8 {
-	switch proto {
-	case "TCP":
-		return 6
-	case "UDP":
-		return 17
-	case "ICMP":
-		return 1
-	case "ICMPv6":
-		return 58
-	}
-	return 0
-}
-
 // archiveConfig transfers the active config to remote archive sites
 // when system { archival { configuration { transfer-on-commit; } } } is set.
 //

--- a/pkg/daemon/daemon_flowexport.go
+++ b/pkg/daemon/daemon_flowexport.go
@@ -467,9 +467,15 @@ func (d *Daemon) flowExportCallback(rec logging.EventRecord, raw []byte) {
 		return
 	}
 	sd := flowexport.SessionCloseData{
-		SrcPort:  parseSrcPort(rec.SrcAddr),
-		DstPort:  parseSrcPort(rec.DstAddr),
-		Protocol: parseProtocol(rec.Protocol),
+		SrcPort: parseSrcPort(rec.SrcAddr),
+		DstPort: parseSrcPort(rec.DstAddr),
+		// #3939: carry the record's raw numeric IP protocol (rec.ProtocolNum,
+		// 0-255) verbatim. The prior parseProtocol(rec.Protocol) name lookup
+		// only covered TCP/UDP/ICMP/ICMPv6, so GRE/ESP/AH and every other
+		// protocol collapsed to 0. The exporter sources protocolIdentifier from
+		// rec.ProtocolNum directly; keeping sd.Protocol consistent here also
+		// fixes the flowStartTime duration heuristic for non-TCP protocols.
+		Protocol: rec.ProtocolNum,
 		// #2749: ingress ifindex (SNMP ifIndex) for the NetFlow v9
 		// ingressInterface field; carried on the close frame since #2615.
 		InIf: rec.IngressIfindex,
@@ -521,9 +527,12 @@ func (d *Daemon) ipfixExportCallback(rec logging.EventRecord, raw []byte) {
 		return
 	}
 	sd := flowexport.SessionCloseData{
-		SrcPort:  parseSrcPort(rec.SrcAddr),
-		DstPort:  parseSrcPort(rec.DstAddr),
-		Protocol: parseProtocol(rec.Protocol),
+		SrcPort: parseSrcPort(rec.SrcAddr),
+		DstPort: parseSrcPort(rec.DstAddr),
+		// #3939: carry the record's raw numeric IP protocol (rec.ProtocolNum,
+		// 0-255) verbatim — see the NetFlow callback above. parseProtocol's
+		// name table dropped GRE/ESP/AH (and all non-TCP/UDP/ICMP) to 0.
+		Protocol: rec.ProtocolNum,
 		// #2749: ingress ifindex (SNMP ifIndex) for the IPFIX
 		// ingressInterface field; carried on the close frame since #2615.
 		InIf: rec.IngressIfindex,

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -186,6 +186,28 @@ ingress pins in `ingress_interface_test.go`; the Rust side pins the stamping
 (`test_encode_session_close_rt_flow_v4_wire_layout`); the Go decode round-trip
 is pinned by `TestDecodeRawEventCloseCarriesCosBlock`.
 
+**#3939 — `protocolIdentifier` (IE 4) sourced from the record's numeric
+protocol, not a name re-lookup.** The exporters previously set
+`FlowRecord.Protocol` from `SessionCloseData.Protocol`, which the daemon
+callbacks filled via `parseProtocol(rec.Protocol)` — a NAME→number table that
+covered only `TCP`/`UDP`/`ICMP`/`ICMPv6`. Every other protocol (GRE 47, ESP 50,
+AH 51, and any numeric-only protocol) fell through to `0`, so a collector saw
+those tunnel/other flows all reported as protocol 0 (HOPOPT) and could not tell
+an ESP tunnel from a GRE flow — tunnel-traffic capacity/security analytics were
+wrong. The fix sources the exported `protocolIdentifier` directly from
+`EventRecord.ProtocolNum` — the raw numeric IP protocol (0-255) the dataplane
+stamps on the close frame and `pkg/logging/ringbuf.go` decodes verbatim — in
+both `ExportSessionClose` builders. The daemon callbacks now also set
+`SessionCloseData.Protocol = rec.ProtocolNum` (removing the lossy
+`parseProtocol`), which additionally corrects the non-TCP `flowStartTime`
+duration heuristic. The rendered protocol NAME (`EventRecord.Protocol`) stays a
+display-only string for `show` output; only the exported numeric field changed.
+Fail-on-revert is pinned by `protocol_num_test.go`
+(`TestNetflowProtocolIdentifierFromProtocolNum` /
+`TestIPFIXProtocolIdentifierFromProtocolNum`), which encode GRE/ESP/AH +
+TCP/UDP/ICMP and assert the wire byte equals the numeric protocol; reverting to
+the name lookup makes every case encode 0.
+
 **#3270 — `flowDirection` (IE 61) populated from the per-zone
 sampling-direction, opt-in.** flowDirection is exported again, but only when a
 template configures `export-extension flow-dir`, and the value is a REAL signal

--- a/pkg/flowexport/ipfix.go
+++ b/pkg/flowexport/ipfix.go
@@ -848,11 +848,17 @@ func (e *IPFIXExporter) ExportSessionClose(rec logging.EventRecord, evt SessionC
 		e.routeMaskUnresolved.Add(maskMisses)
 	}
 	fr := FlowRecord{
-		SrcIP:    evt.SrcIP,
-		DstIP:    evt.DstIP,
-		SrcPort:  evt.SrcPort,
-		DstPort:  evt.DstPort,
-		Protocol: evt.Protocol,
+		SrcIP:   evt.SrcIP,
+		DstIP:   evt.DstIP,
+		SrcPort: evt.SrcPort,
+		DstPort: evt.DstPort,
+		// #3939: source protocolIdentifier (IE 4) from the record's raw numeric
+		// IP protocol (rec.ProtocolNum, 0-255) — NOT a protocol-NAME re-lookup.
+		// The daemon callback derived evt.Protocol via a name table that only
+		// covered TCP/UDP/ICMP/ICMPv6, so GRE (47), ESP (50), AH (51) and every
+		// other protocol exported as 0 and were misattributed at the collector.
+		// rec.ProtocolNum is the authoritative number the dataplane stamped.
+		Protocol: rec.ProtocolNum,
 		Packets:  rec.SessionPkts,
 		Bytes:    rec.SessionBytes,
 		// #3746: RFC 5103 biflow reverse (server→client) volume. Since #2501

--- a/pkg/flowexport/netflow.go
+++ b/pkg/flowexport/netflow.go
@@ -599,11 +599,17 @@ func (e *Exporter) ExportSessionClose(rec logging.EventRecord, evt SessionCloseD
 		e.routeMaskUnresolved.Add(maskMisses)
 	}
 	fr := FlowRecord{
-		SrcIP:     evt.SrcIP,
-		DstIP:     evt.DstIP,
-		SrcPort:   evt.SrcPort,
-		DstPort:   evt.DstPort,
-		Protocol:  evt.Protocol,
+		SrcIP:   evt.SrcIP,
+		DstIP:   evt.DstIP,
+		SrcPort: evt.SrcPort,
+		DstPort: evt.DstPort,
+		// #3939: source protocolIdentifier (IE 4) from the record's raw numeric
+		// IP protocol (rec.ProtocolNum, 0-255) — NOT a protocol-NAME re-lookup.
+		// The daemon callback derived evt.Protocol via a name table that only
+		// covered TCP/UDP/ICMP/ICMPv6, so GRE (47), ESP (50), AH (51) and every
+		// other protocol exported as 0 and were misattributed at the collector.
+		// rec.ProtocolNum is the authoritative number the dataplane stamped.
+		Protocol:  rec.ProtocolNum,
 		Packets:   rec.SessionPkts,
 		Bytes:     rec.SessionBytes,
 		StartTime: startTime,

--- a/pkg/flowexport/protocol_num_test.go
+++ b/pkg/flowexport/protocol_num_test.go
@@ -1,0 +1,147 @@
+package flowexport
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/logging"
+)
+
+// #3939 fail-on-revert pins: the exported protocolIdentifier (NetFlow v9 IE 4 /
+// IPFIX IE 4) must come from the record's raw numeric IP protocol
+// (rec.ProtocolNum, 0-255), NOT from the daemon callback's protocol-NAME
+// lookup. The old parseProtocol() name table covered only TCP/UDP/ICMP/ICMPv6,
+// so GRE (47), ESP (50), AH (51) and every other protocol exported as 0 and
+// were misattributed at the collector.
+//
+// These tests deliberately set the pre-#3939 lossy value (SessionCloseData.
+// Protocol = 0, exactly what parseProtocol returned for GRE/ESP/AH) on the
+// SessionCloseData while carrying the real number on rec.ProtocolNum. A correct
+// exporter ignores the lossy sd.Protocol and encodes rec.ProtocolNum. Reverting
+// the exporter to `Protocol: evt.Protocol` makes EVERY case encode 0 → RED.
+
+// protocolNumCases covers the tunnel/other protocols that regressed to 0 plus
+// the TCP/UDP/ICMP names that always resolved, proving both keep the right
+// number.
+var protocolNumCases = []struct {
+	name  string
+	proto uint8
+}{
+	{"ICMP", 1},
+	{"TCP", 6},
+	{"UDP", 17},
+	{"GRE", 47},
+	{"ESP", 50},
+	{"AH", 51},
+}
+
+// closeRecordForProto builds a SESSION_CLOSE EventRecord carrying the real
+// numeric protocol on rec.ProtocolNum, paired with a SessionCloseData whose
+// Protocol field holds the pre-#3939 lossy 0. Reverting the fix makes the
+// exporter read the lossy 0 instead of the record's number.
+func closeRecordForProto(proto uint8, v6 bool) (logging.EventRecord, SessionCloseData) {
+	rec := logging.EventRecord{
+		Type:        "SESSION_CLOSE",
+		Time:        time.Unix(1_700_000_100, 0),
+		Created:     1_700_000_000,
+		ProtocolNum: proto, // authoritative numeric protocol the dataplane stamped
+	}
+	sd := SessionCloseData{
+		SrcPort:  40000,
+		DstPort:  80,
+		Protocol: 0, // pre-#3939 lossy value (parseProtocol dropped GRE/ESP/AH to 0)
+		IsIPv6:   v6,
+	}
+	if v6 {
+		sd.SrcIP = net.ParseIP("fd00::1")
+		sd.DstIP = net.ParseIP("2001:db8::200")
+	} else {
+		sd.SrcIP = net.IPv4(10, 0, 1, 100)
+		sd.DstIP = net.IPv4(172, 16, 80, 200)
+	}
+	return rec, sd
+}
+
+// TestNetflowProtocolIdentifierFromProtocolNum asserts the encoded NetFlow v9
+// protocolIdentifier (IE 4) equals rec.ProtocolNum for every protocol,
+// including GRE/ESP/AH which regressed to 0 under the name lookup (#3939).
+func TestNetflowProtocolIdentifierFromProtocolNum(t *testing.T) {
+	boot := time.Unix(1_700_000_000, 0)
+	opts := DefaultV9TemplateOptions()
+	for _, fam := range []struct {
+		label  string
+		v6     bool
+		fields []templateField
+	}{
+		{"v4", false, netflowTemplateFieldsV4},
+		{"v6", true, netflowTemplateFieldsV6},
+	} {
+		protoOff, ok := netflowFieldBodyOffset(fam.fields, fieldProtocol)
+		if !ok {
+			t.Fatalf("%s: template missing protocolIdentifier (IE 4)", fam.label)
+		}
+		for _, tc := range protocolNumCases {
+			var e Exporter
+			rec, sd := closeRecordForProto(tc.proto, fam.v6)
+			e.ExportSessionClose(rec, sd)
+			v4recs, v6recs := e.batch.drain()
+			recs := v4recs
+			if fam.v6 {
+				recs = v6recs
+			}
+			if len(recs) != 1 {
+				t.Fatalf("%s/%s: drained %d records, want 1", fam.label, tc.name, len(recs))
+			}
+			if recs[0].Protocol != tc.proto {
+				t.Fatalf("%s/%s: FlowRecord.Protocol = %d, want %d (exporter must source rec.ProtocolNum)",
+					fam.label, tc.name, recs[0].Protocol, tc.proto)
+			}
+			fs := encodeDataFlowSet(recs, boot, opts)
+			if got := fs[4+protoOff]; got != tc.proto {
+				t.Fatalf("%s/%s: encoded protocolIdentifier = %d, want %d "+
+					"(#3939: name-lookup drops GRE/ESP/AH to 0)", fam.label, tc.name, got, tc.proto)
+			}
+		}
+	}
+}
+
+// TestIPFIXProtocolIdentifierFromProtocolNum mirrors the check for IPFIX
+// (protocolIdentifier IE 4, 1 byte).
+func TestIPFIXProtocolIdentifierFromProtocolNum(t *testing.T) {
+	for _, fam := range []struct {
+		label  string
+		v6     bool
+		fields []ipfixField
+	}{
+		{"v4", false, ipfixTemplateV4},
+		{"v6", true, ipfixTemplateV6},
+	} {
+		protoOff, ok := ipfixFieldBodyOffset(fam.fields, ipfixProtocolIdentifier)
+		if !ok {
+			t.Fatalf("%s: template missing protocolIdentifier (IE 4)", fam.label)
+		}
+		for _, tc := range protocolNumCases {
+			var e IPFIXExporter
+			rec, sd := closeRecordForProto(tc.proto, fam.v6)
+			e.ExportSessionClose(rec, sd)
+			v4recs, v6recs := e.batch.drain()
+			recs := v4recs
+			if fam.v6 {
+				recs = v6recs
+			}
+			if len(recs) != 1 {
+				t.Fatalf("%s/%s: drained %d records, want 1", fam.label, tc.name, len(recs))
+			}
+			if recs[0].Protocol != tc.proto {
+				t.Fatalf("%s/%s: FlowRecord.Protocol = %d, want %d (exporter must source rec.ProtocolNum)",
+					fam.label, tc.name, recs[0].Protocol, tc.proto)
+			}
+			ds := encodeIPFIXDataSet(recs)
+			if got := ds[4+protoOff]; got != tc.proto {
+				t.Fatalf("%s/%s: encoded protocolIdentifier = %d, want %d "+
+					"(#3939: name-lookup drops GRE/ESP/AH to 0)", fam.label, tc.name, got, tc.proto)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #3939 (fable-161 F-058, MEDIUM observability/correctness).

The NetFlow v9 / IPFIX session-close exporters set `FlowRecord.Protocol` from `SessionCloseData.Protocol`, which the daemon callbacks filled via `parseProtocol(rec.Protocol)` — a protocol NAME→number table covering only TCP/UDP/ICMP/ICMPv6. Every other protocol fell through to `0`: **GRE (47), ESP (50), AH (51)** and any numeric-only protocol exported `protocolIdentifier` (IE 4) as **0**. A collector saw those tunnel/other flows all reported as protocol 0 (HOPOPT) and could not distinguish an ESP tunnel from a GRE flow → tunnel-traffic capacity/security analytics were wrong.

## Fix

- Source the exported `protocolIdentifier` directly from `EventRecord.ProtocolNum` — the raw numeric IP protocol (0-255) the dataplane stamps on the SESSION_CLOSE frame and `pkg/logging/ringbuf.go` decodes verbatim — in both `ExportSessionClose` builders (`netflow.go`, `ipfix.go`).
- Set `SessionCloseData.Protocol = rec.ProtocolNum` in both daemon callbacks (`daemon_flowexport.go`) and remove the now-unused `parseProtocol` helper. This eliminates the lossy value at the root and additionally corrects the non-TCP `flowStartTime` duration heuristic.
- The rendered protocol NAME (`EventRecord.Protocol`) stays a display-only string for `show` output; only the exported numeric field changed.

## Test (RED-on-revert)

`pkg/flowexport/protocol_num_test.go` encodes **GRE/ESP/AH + TCP/UDP/ICMP** for both NetFlow v9 and IPFIX (v4 and v6) and asserts the encoded `protocolIdentifier` byte equals the numeric protocol. The `SessionCloseData` carries the pre-fix lossy `0`, so reverting either exporter to `evt.Protocol` makes every case encode `0`.

Verified RED on a simulated revert:
```
--- FAIL: TestNetflowProtocolIdentifierFromProtocolNum
    protocol_num_test.go:97: v4/ICMP: FlowRecord.Protocol = 0, want 1 (exporter must source rec.ProtocolNum)
--- FAIL: TestIPFIXProtocolIdentifierFromProtocolNum
    protocol_num_test.go:137: v4/ICMP: FlowRecord.Protocol = 0, want 1 (exporter must source rec.ProtocolNum)
```

`go test ./pkg/flowexport/...` green, daemon flow-export tests green, `go build ./...`, gofmt, vet clean. Documented in `pkg/flowexport/README.md` (#3939 subsection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi