### PR TITLE
snmp: honor trap-group version so a v1 group emits SNMPv1 traps

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,29 @@
+## 2026-07-03 — #3948: SNMP trap-group `version` had no typed field → a `version v1` group emitted v2c traps
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-069 (MEDIUM, observability/interop). An SNMP
+    trap-group's `version` (schema enum v1|v2|all) was parsed only to satisfy
+    the unknown-key rejection (#2990) but had NO typed field, so it was dropped
+    and the emitter always built an SNMPv2c trap. A trap-group configured
+    `version v1` therefore emitted v2c traps that a v1-only receiver drops —
+    the operator's traps silently never arrive. Added `Version` to
+    `config.SNMPTrapGroup`, populated it in the compiler
+    (`tg.Version = nodeVal(prop)`), and threaded it to the emitter.
+    `sendLinkTraps` now builds the trap PER GROUP via `buildLinkTrapsForVersion`
+    (community stays global): `v1` -> new `buildLinkTrapV1` (SNMPv1 Trap-PDU,
+    RFC 1157: message version 0, PDU tag 0xa4, enterprise=snmpTraps
+    1.3.6.1.6.3.1.1.5, agent-addr 0.0.0.0, generic-trap 2/3, specific-trap 0,
+    time-stamp, ifIndex/ifDescr/ifOperStatus varbinds — per RFC 2576 §3.1),
+    `v2`/unspecified -> existing v2c `buildLinkTrap` (unchanged default), `all`
+    -> BOTH. RED-on-revert proven both sides: dropping the compiler line leaves
+    Version empty (TestSNMPTrapGroup_VersionCarried RED); building v2c
+    regardless makes TestSendLinkTraps_VersionV1_EmitsV1 receive version=1/
+    tag=0xa7 and TestSendLinkTraps_VersionAll_EmitsBoth get only 1 packet.
+  - **File(s)**: pkg/config/types_system.go, pkg/config/compiler_system.go,
+    pkg/snmp/traps.go, pkg/snmp/traps_version_3948_test.go,
+    pkg/config/compiler_snmp_trapgroup_2990_test.go, pkg/snmp/README.md,
+    _Log.md
+
 ## 2026-07-03 — #3941: deleting an IPsec VPN never terminates its live SAs (--load-all only unloads config)
 
 - **Timestamp**: 2026-07-03

--- a/pkg/config/compiler_snmp_trapgroup_2990_test.go
+++ b/pkg/config/compiler_snmp_trapgroup_2990_test.go
@@ -134,6 +134,60 @@ func TestSNMPTrapGroup_ValidAccepted(t *testing.T) {
 	}
 }
 
+// TestSNMPTrapGroup_VersionCarried is the config->struct half of the #3948
+// fix: a trap-group `version` (v1|v2|all) must land on SNMPTrapGroup.Version so
+// the emitter can honor it. Before the fix the compiler recognized `version`
+// only to avoid the unknown-key rejection but dropped its value, so every group
+// emitted v2c. Reverting the `tg.Version = nodeVal(prop)` line leaves Version
+// empty here and fails these assertions.
+func TestSNMPTrapGroup_VersionCarried(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want string
+	}{
+		{"v1", "set snmp trap-group g1 version v1", "v1"},
+		{"v2", "set snmp trap-group g1 version v2", "v2"},
+		{"all", "set snmp trap-group g1 version all", "all"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := compileSNMPLines(t, []string{
+				"set snmp trap-group g1 targets 10.0.0.10",
+				tc.line,
+			})
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			tg := cfg.System.SNMP.TrapGroups["g1"]
+			if tg == nil {
+				t.Fatal("trap-group 'g1' missing from compiled config")
+			}
+			if tg.Version != tc.want {
+				t.Fatalf("Version = %q, want %q", tg.Version, tc.want)
+			}
+		})
+	}
+}
+
+// TestSNMPTrapGroup_VersionUnspecifiedEmpty confirms an unspecified version
+// stays empty in the typed config; the emitter defaults that to v2c (#3948).
+func TestSNMPTrapGroup_VersionUnspecifiedEmpty(t *testing.T) {
+	cfg, err := compileSNMPLines(t, []string{
+		"set snmp trap-group g1 targets 10.0.0.10",
+	})
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	tg := cfg.System.SNMP.TrapGroups["g1"]
+	if tg == nil {
+		t.Fatal("trap-group 'g1' missing from compiled config")
+	}
+	if tg.Version != "" {
+		t.Fatalf("Version = %q, want empty (unspecified)", tg.Version)
+	}
+}
+
 // TestSNMPTrapGroup_BracketedTargets confirms a bracketed/flat-set list of
 // targets accumulates (the multi-value leaf contract, docs/config-schema.md).
 func TestSNMPTrapGroup_BracketedTargets(t *testing.T) {

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -910,8 +910,16 @@ func compileSNMP(node *Node, sys *SystemConfig, cfg *Config, lenient bool) error
 						// (hierarchical `targets { a; b; }`) and/or packed in
 						// the leaf Keys (flat-set / bracketed list).
 						tg.Targets = append(tg.Targets, firewallMatchValues(prop)...)
-					case "version", "categories":
-						// Accepted trap-group leaves (schema-declared). Not
+					case "version":
+						// #3948: carry the trap-group SNMP version to the
+						// emitter. Schema enum is v1|v2|all; an empty value
+						// (unspecified) defaults to v2c in pkg/snmp/traps.go.
+						// Without this the version was parsed but dropped, so a
+						// `version v1` group silently emitted v2c traps that a
+						// v1-only receiver drops.
+						tg.Version = nodeVal(prop)
+					case "categories":
+						// Accepted trap-group leaf (schema-declared). Not
 						// consumed by the link-trap runtime today; recognized
 						// here so a valid key does not trip the unknown-key
 						// rejection below.

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -518,6 +518,13 @@ func (c SNMPCommunity) MarshalYAML() (any, error) {
 type SNMPTrapGroup struct {
 	Name    string
 	Targets []string // IP addresses
+	// Version selects the SNMP protocol version used to emit this group's
+	// traps: "v1" emits an SNMPv1 Trap-PDU, "v2" an SNMPv2c trap (the
+	// default), and "all" emits both a v1 and a v2c trap. An empty string
+	// (unspecified) defaults to v2c. The schema enum is v1|v2|all (Junos
+	// semantics); the emitter honors it in pkg/snmp/traps.go so a
+	// `version v1` group is not silently sent as v2c (#3948).
+	Version string
 }
 
 // SNMPv3User defines an SNMPv3 USM user with authentication and privacy.

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -253,6 +253,19 @@ authorization surface: every request is dropped because no community matches.
   community saw flaky traps and a less-privileged community could leak
   through the wrong credential boundary. Trap groups are likewise iterated
   in sorted order so dispatch and log output are reproducible.
+- **Trap-group `version` selects the emitted PDU shape (#3948).** Each trap
+  group carries a `version` (`v1` | `v2` | `all`, schema enum in
+  `pkg/config/schema_system.go`) compiled onto `config.SNMPTrapGroup.Version`.
+  `sendLinkTraps` builds the trap **per group** and honors it via
+  `buildLinkTrapsForVersion`: `v1` emits an SNMPv1 Trap-PDU
+  (`buildLinkTrapV1` — message version field 0, PDU tag 0xa4, the trap type
+  carried in the enterprise/generic-trap/specific-trap/time-stamp fields per
+  RFC 1157, with ifIndex/ifDescr/ifOperStatus varbinds; enterprise =
+  `snmpTraps` 1.3.6.1.6.3.1.1.5 and agent-addr 0.0.0.0 per the RFC 2576 §3.1
+  SNMPv2→SNMPv1 mapping), `v2` (or an unspecified/empty version — the default)
+  emits the SNMPv2c trap (`buildLinkTrap`, version 1, PDU tag 0xa7), and `all`
+  emits BOTH. Before #3948 the version was parsed but had no typed field, so a
+  `version v1` group silently emitted v2c traps that a v1-only receiver drops.
 - Don't add a third BER library to this package. The hand-coded encoder
   is intentional; keeping the surface small avoids bringing in an SNMP
   framework with its own poll loop and threading model.

--- a/pkg/snmp/traps.go
+++ b/pkg/snmp/traps.go
@@ -14,10 +14,33 @@ import (
 // SNMPv2-Trap PDU type (context-specific, constructed, tag 7).
 const pduSNMPv2Trap = 0xa7
 
+// SNMPv1 Trap-PDU type (context-specific, constructed, tag 4). RFC 1157.
+const pduSNMPv1Trap = 0xa4
+
+// snmpVersion1 is the message version field value for SNMPv1 (0). The v2c
+// message version (1) is snmpVersion2c in agent.go.
+const snmpVersion1 = 0
+
+// tagIPAddress is the ASN.1 application tag (class application, primitive,
+// number 0) for IpAddress / NetworkAddress — the agent-addr field of an
+// SNMPv1 Trap-PDU.
+const tagIPAddress = 0x40
+
+// SNMPv1 generic-trap values (RFC 1157). specific-trap is 0 for these.
+const (
+	genericTrapLinkDown = 2
+	genericTrapLinkUp   = 3
+)
+
 // Standard trap OIDs.
 var (
 	// snmpTrapOID.0: 1.3.6.1.6.3.1.1.4.1.0
 	oidSnmpTrapOID = []int{1, 3, 6, 1, 6, 3, 1, 1, 4, 1, 0}
+
+	// snmpTraps node: 1.3.6.1.6.3.1.1.5 — the enterprise field of an SNMPv1
+	// Trap-PDU carrying a standard generic trap, per RFC 2576 §3.1
+	// (SNMPv2->SNMPv1 notification mapping).
+	oidSnmpTraps = []int{1, 3, 6, 1, 6, 3, 1, 1, 5}
 
 	// linkDown: 1.3.6.1.6.3.1.1.5.3
 	oidLinkDown = []int{1, 3, 6, 1, 6, 3, 1, 1, 5, 3}
@@ -100,6 +123,89 @@ func (a *Agent) buildLinkTrap(community string, linkUp bool, ifindex int, ifname
 	return berEncodeTLV(tagSequence, msgBody)
 }
 
+// buildLinkTrapV1 builds an SNMPv1 Trap-PDU (RFC 1157) for a link up/down
+// event, for a trap group configured `version v1` (#3948). A v1-only receiver
+// drops the SNMPv2c trap buildLinkTrap emits, so a v1 group must send the
+// distinct v1 PDU shape: the trap type is carried in the generic-trap /
+// specific-trap / time-stamp fields (not as sysUpTime.0 + snmpTrapOID.0
+// varbinds), and the message version field is 0. The enterprise is the
+// snmpTraps node and agent-addr is 0.0.0.0, per the RFC 2576 §3.1
+// SNMPv2->SNMPv1 mapping for a standard generic trap.
+func (a *Agent) buildLinkTrapV1(community string, linkUp bool, ifindex int, ifname string) []byte {
+	// sysUpTime in hundredths of a second.
+	uptime := int(time.Since(a.startTime).Milliseconds() / 10)
+
+	genericTrap := genericTrapLinkDown
+	operStatus := 2 // down
+	if linkUp {
+		genericTrap = genericTrapLinkUp
+		operStatus = 1 // up
+	}
+
+	// Varbinds: ifIndex, ifDescr, ifOperStatus. sysUpTime.0 and snmpTrapOID.0
+	// are NOT repeated as varbinds in v1 — they map to the time-stamp field
+	// and the generic-trap/enterprise fields respectively.
+	ifIndexOID := append(append([]int{}, oidIfIndex...), ifindex)
+	vb1OID := berEncodeTLV(tagObjectIdentifier, berEncodeOID(ifIndexOID))
+	vb1Val := berEncodeIntegerTLV(ifindex)
+	vb1 := berEncodeTLV(tagSequence, append(vb1OID, vb1Val...))
+
+	ifDescrOID := append(append([]int{}, oidIfDescr...), ifindex)
+	vb2OID := berEncodeTLV(tagObjectIdentifier, berEncodeOID(ifDescrOID))
+	vb2Val := berEncodeTLV(tagOctetString, []byte(ifname))
+	vb2 := berEncodeTLV(tagSequence, append(vb2OID, vb2Val...))
+
+	ifOperOID := append(append([]int{}, oidIfOperStatus...), ifindex)
+	vb3OID := berEncodeTLV(tagObjectIdentifier, berEncodeOID(ifOperOID))
+	vb3Val := berEncodeIntegerTLV(operStatus)
+	vb3 := berEncodeTLV(tagSequence, append(vb3OID, vb3Val...))
+
+	var vbList []byte
+	vbList = append(vbList, vb1...)
+	vbList = append(vbList, vb2...)
+	vbList = append(vbList, vb3...)
+	vbListEncoded := berEncodeTLV(tagSequence, vbList)
+
+	// Trap-PDU body: enterprise, agent-addr, generic-trap, specific-trap,
+	// time-stamp, variable-bindings.
+	var pduBody []byte
+	pduBody = append(pduBody, berEncodeTLV(tagObjectIdentifier, berEncodeOID(oidSnmpTraps))...)
+	pduBody = append(pduBody, berEncodeTLV(tagIPAddress, []byte{0, 0, 0, 0})...)
+	pduBody = append(pduBody, berEncodeIntegerTLV(genericTrap)...)
+	pduBody = append(pduBody, berEncodeIntegerTLV(0)...) // specific-trap
+	pduBody = append(pduBody, berEncodeTLV(tagTimeTicks, berEncodeTimeTicks(uptime))...)
+	pduBody = append(pduBody, vbListEncoded...)
+
+	pduEncoded := berEncodeTLV(pduSNMPv1Trap, pduBody)
+
+	// Message: version(v1=0), community, PDU.
+	msgBody := berEncodeIntegerTLV(snmpVersion1)
+	msgBody = append(msgBody, berEncodeTLV(tagOctetString, []byte(community))...)
+	msgBody = append(msgBody, pduEncoded...)
+
+	return berEncodeTLV(tagSequence, msgBody)
+}
+
+// buildLinkTrapsForVersion returns the pre-built trap packet(s) a trap group
+// with the given configured version emits for a link event (#3948). Junos
+// trap-group version semantics: "v1" emits an SNMPv1 Trap-PDU, "v2" (or an
+// empty/unspecified value — the default) emits an SNMPv2c trap, and "all"
+// emits BOTH. Any unrecognized value defaults to v2c (the pre-#3948 behavior)
+// rather than dropping the notification.
+func (a *Agent) buildLinkTrapsForVersion(community, version string, linkUp bool, ifindex int, ifname string) [][]byte {
+	switch version {
+	case "v1":
+		return [][]byte{a.buildLinkTrapV1(community, linkUp, ifindex, ifname)}
+	case "all":
+		return [][]byte{
+			a.buildLinkTrapV1(community, linkUp, ifindex, ifname),
+			a.buildLinkTrap(community, linkUp, ifindex, ifname),
+		}
+	default: // "v2", "" (unspecified), or anything else -> v2c
+		return [][]byte{a.buildLinkTrap(community, linkUp, ifindex, ifname)}
+	}
+}
+
 // trapSender delivers a single pre-built trap to a target. It is a package
 // var (not a direct call) so tests can inject a deliberately slow/blocking
 // sender to prove the link-monitor caller does not block on trap delivery
@@ -150,27 +256,31 @@ func (a *Agent) sendLinkTraps(linkUp bool, ifindex int, ifname string) {
 
 	community := selectTrapCommunity(cfg)
 
-	pkt := a.buildLinkTrap(community, linkUp, ifindex, ifname)
-
 	direction := "down"
 	if linkUp {
 		direction = "up"
 	}
 
-	// Enqueue one job per target. The blocking dial/write happens on the
-	// trap worker so a dead or slow target never stalls the link monitor
-	// (#2991). Iterate trap groups in deterministic (sorted) order so log
-	// output and dispatch ordering are stable across runs.
+	// Enqueue one job per target. The trap PDU is built per group because the
+	// SNMP version is a per-trap-group setting (#3948): a `version v1` group
+	// gets an SNMPv1 Trap-PDU, `v2`/unspecified a v2c trap, and `all` both.
+	// The blocking dial/write happens on the trap worker so a dead or slow
+	// target never stalls the link monitor (#2991). Iterate trap groups in
+	// deterministic (sorted) order so log output and dispatch ordering are
+	// stable across runs.
 	for _, tg := range sortedTrapGroups(cfg) {
+		pkts := a.buildLinkTrapsForVersion(community, tg.Version, linkUp, ifindex, ifname)
 		for _, target := range tg.Targets {
-			a.enqueueTrap(trapJob{
-				target:  target,
-				pkt:     pkt,
-				group:   tg.Name,
-				event:   "link" + direction,
-				iface:   ifname,
-				ifindex: ifindex,
-			})
+			for _, pkt := range pkts {
+				a.enqueueTrap(trapJob{
+					target:  target,
+					pkt:     pkt,
+					group:   tg.Name,
+					event:   "link" + direction,
+					iface:   ifname,
+					ifindex: ifindex,
+				})
+			}
 		}
 	}
 }

--- a/pkg/snmp/traps_version_3948_test.go
+++ b/pkg/snmp/traps_version_3948_test.go
@@ -1,0 +1,223 @@
+package snmp
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// decodeTrapVersionAndPDU walks an SNMP trap message down to its PDU and
+// returns the message version field and the PDU tag.
+func decodeTrapVersionAndPDU(t *testing.T, pkt []byte) (version int, pduTag byte) {
+	t.Helper()
+	tag, body, err := berDecodeHeader(pkt)
+	if err != nil || tag != tagSequence {
+		t.Fatalf("outer SEQUENCE: tag=0x%02x err=%v", tag, err)
+	}
+	version, rest, err := berDecodeInteger(body)
+	if err != nil {
+		t.Fatalf("decode version: %v", err)
+	}
+	_, rest, err = berDecodeOctetString(rest)
+	if err != nil {
+		t.Fatalf("decode community: %v", err)
+	}
+	pduTag, _, err = berDecodeHeader(rest)
+	if err != nil {
+		t.Fatalf("decode PDU header: %v", err)
+	}
+	return version, pduTag
+}
+
+// TestBuildLinkTrapV1_Structure verifies the SNMPv1 Trap-PDU shape (#3948):
+// version field 0, PDU tag 0xa4, the snmpTraps enterprise OID, the correct
+// generic-trap code (2=linkDown, 3=linkUp), specific-trap 0, and 3 varbinds
+// (ifIndex, ifDescr, ifOperStatus — sysUpTime.0/snmpTrapOID.0 are NOT repeated
+// as varbinds in v1).
+func TestBuildLinkTrapV1_Structure(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		linkUp      bool
+		wantGeneric int
+	}{
+		{"linkDown", false, genericTrapLinkDown},
+		{"linkUp", true, genericTrapLinkUp},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &Agent{startTime: time.Now().Add(-30 * time.Second)}
+			pkt := a.buildLinkTrapV1("public", tc.linkUp, 5, "ge-0-0-0")
+
+			version, pduTag := decodeTrapVersionAndPDU(t, pkt)
+			if version != snmpVersion1 {
+				t.Fatalf("version = %d, want %d (v1)", version, snmpVersion1)
+			}
+			if pduTag != pduSNMPv1Trap {
+				t.Fatalf("PDU tag = 0x%02x, want 0x%02x (v1 Trap-PDU)", pduTag, pduSNMPv1Trap)
+			}
+
+			// Re-walk to the PDU body to inspect the v1-specific fields.
+			_, body, _ := berDecodeHeader(pkt)
+			_, rest, _ := berDecodeInteger(body)    // version
+			_, rest, _ = berDecodeOctetString(rest) // community
+			_, pduBody, _ := berDecodeHeader(rest)  // Trap-PDU body
+
+			// enterprise OID == snmpTraps
+			entTag, entVal, err := berDecodeHeader(pduBody)
+			if err != nil || entTag != tagObjectIdentifier {
+				t.Fatalf("enterprise: tag=0x%02x err=%v", entTag, err)
+			}
+			entOID, err := berDecodeOID(entVal)
+			if err != nil {
+				t.Fatalf("decode enterprise OID: %v", err)
+			}
+			if !oidEqual(entOID, oidSnmpTraps) {
+				t.Fatalf("enterprise OID = %v, want snmpTraps %v", entOID, oidSnmpTraps)
+			}
+			pduBody = pduBody[berEncodedLen(pduBody):]
+
+			// agent-addr: IpAddress (tag 0x40)
+			addrTag, addrVal, err := berDecodeHeader(pduBody)
+			if err != nil || addrTag != tagIPAddress {
+				t.Fatalf("agent-addr: tag=0x%02x err=%v", addrTag, err)
+			}
+			if len(addrVal) != 4 {
+				t.Fatalf("agent-addr length = %d, want 4", len(addrVal))
+			}
+			pduBody = pduBody[berEncodedLen(pduBody):]
+
+			// generic-trap
+			generic, pduBody2, err := berDecodeInteger(pduBody)
+			if err != nil {
+				t.Fatalf("generic-trap: %v", err)
+			}
+			if generic != tc.wantGeneric {
+				t.Fatalf("generic-trap = %d, want %d", generic, tc.wantGeneric)
+			}
+
+			// specific-trap == 0
+			specific, pduBody3, err := berDecodeInteger(pduBody2)
+			if err != nil {
+				t.Fatalf("specific-trap: %v", err)
+			}
+			if specific != 0 {
+				t.Fatalf("specific-trap = %d, want 0", specific)
+			}
+
+			// time-stamp: TimeTicks (tag 0x43)
+			tsTag, _, err := berDecodeHeader(pduBody3)
+			if err != nil || tsTag != tagTimeTicks {
+				t.Fatalf("time-stamp: tag=0x%02x err=%v", tsTag, err)
+			}
+			pduBody3 = pduBody3[berEncodedLen(pduBody3):]
+
+			// varbind list: 3 varbinds
+			vbTag, vbList, err := berDecodeHeader(pduBody3)
+			if err != nil || vbTag != tagSequence {
+				t.Fatalf("varbind list: tag=0x%02x err=%v", vbTag, err)
+			}
+			count := 0
+			for len(vbList) > 0 {
+				n := berEncodedLen(vbList)
+				if n <= 0 || n > len(vbList) {
+					break
+				}
+				vbList = vbList[n:]
+				count++
+			}
+			if count != 3 {
+				t.Fatalf("v1 varbind count = %d, want 3", count)
+			}
+		})
+	}
+}
+
+// recvTrapVersions enqueues a link trap for a trap group with the given version
+// and returns the (version, pduTag) of every UDP packet the agent emits.
+func recvTrapVersions(t *testing.T, groupVersion string, want int) [][2]int {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer pc.Close()
+	addr := pc.LocalAddr().String()
+
+	a := &Agent{
+		cfg: &config.SNMPConfig{
+			Communities: map[string]*config.SNMPCommunity{
+				"public": {Name: "public", Authorization: "read-only"},
+			},
+			TrapGroups: map[string]*config.SNMPTrapGroup{
+				"managers": {Name: "managers", Targets: []string{addr}, Version: groupVersion},
+			},
+		},
+		startTime: time.Now().Add(-10 * time.Second),
+	}
+	a.NotifyLinkDown(3, "ge-0-0-1")
+
+	var got [][2]int
+	buf := make([]byte, 4096)
+	for i := 0; i < want; i++ {
+		pc.SetReadDeadline(time.Now().Add(2 * time.Second))
+		n, _, err := pc.ReadFrom(buf)
+		if err != nil {
+			t.Fatalf("read trap %d/%d (version=%q): %v", i+1, want, groupVersion, err)
+		}
+		v, tag := decodeTrapVersionAndPDU(t, append([]byte(nil), buf[:n]...))
+		got = append(got, [2]int{v, int(tag)})
+	}
+	return got
+}
+
+// TestSendLinkTraps_VersionV1_EmitsV1 is the config->emit RED-on-revert guard.
+// A trap group configured `version v1` must put an SNMPv1 Trap-PDU (version
+// field 0, PDU tag 0xa4) on the wire. Before the fix sendLinkTraps built a v2c
+// trap regardless of the group version, so this receives version 1 / tag 0xa7
+// and fails.
+func TestSendLinkTraps_VersionV1_EmitsV1(t *testing.T) {
+	got := recvTrapVersions(t, "v1", 1)
+	if got[0][0] != snmpVersion1 || byte(got[0][1]) != pduSNMPv1Trap {
+		t.Fatalf("version v1 group emitted version=%d pduTag=0x%02x, want version=%d pduTag=0x%02x",
+			got[0][0], got[0][1], snmpVersion1, pduSNMPv1Trap)
+	}
+}
+
+// TestSendLinkTraps_VersionV2_EmitsV2c confirms `version v2` stays v2c.
+func TestSendLinkTraps_VersionV2_EmitsV2c(t *testing.T) {
+	got := recvTrapVersions(t, "v2", 1)
+	if got[0][0] != snmpVersion2c || byte(got[0][1]) != pduSNMPv2Trap {
+		t.Fatalf("version v2 group emitted version=%d pduTag=0x%02x, want version=%d pduTag=0x%02x",
+			got[0][0], got[0][1], snmpVersion2c, pduSNMPv2Trap)
+	}
+}
+
+// TestSendLinkTraps_VersionUnspecified_EmitsV2c confirms the unspecified
+// (empty) version defaults to v2c — the pre-#3948 behavior is preserved for
+// groups that never set a version.
+func TestSendLinkTraps_VersionUnspecified_EmitsV2c(t *testing.T) {
+	got := recvTrapVersions(t, "", 1)
+	if got[0][0] != snmpVersion2c || byte(got[0][1]) != pduSNMPv2Trap {
+		t.Fatalf("unspecified version emitted version=%d pduTag=0x%02x, want v2c version=%d pduTag=0x%02x",
+			got[0][0], got[0][1], snmpVersion2c, pduSNMPv2Trap)
+	}
+}
+
+// TestSendLinkTraps_VersionAll_EmitsBoth confirms `version all` puts BOTH a v1
+// and a v2c trap on the wire (Junos semantics).
+func TestSendLinkTraps_VersionAll_EmitsBoth(t *testing.T) {
+	got := recvTrapVersions(t, "all", 2)
+	sawV1, sawV2c := false, false
+	for _, g := range got {
+		switch {
+		case g[0] == snmpVersion1 && byte(g[1]) == pduSNMPv1Trap:
+			sawV1 = true
+		case g[0] == snmpVersion2c && byte(g[1]) == pduSNMPv2Trap:
+			sawV2c = true
+		}
+	}
+	if !sawV1 || !sawV2c {
+		t.Fatalf("version all: sawV1=%v sawV2c=%v (packets=%v), want both", sawV1, sawV2c, got)
+	}
+}


### PR DESCRIPTION
Closes #3948

## Problem

An SNMP trap-group's `version` (schema enum `v1`|`v2`|`all`) was parsed
only to satisfy the #2990 unknown-key rejection but had **no typed field**
carrying it to the trap emitter. The value was dropped and the emitter
unconditionally built an SNMPv2c trap, so a trap-group configured
`version v1` emitted v2c traps. A legacy trap receiver that understands
only SNMPv1 (or an NMS configured to accept only v1 from this device)
**drops** the v2c datagrams — the operator's link traps silently never
arrive. An interop break for a v1-only trap sink (fable-161 F-069).

## Fix

Thread the version config→emit:

- Add `Version` to `config.SNMPTrapGroup` and populate it in the SNMP
  compiler (`tg.Version = nodeVal(prop)`). An empty/unspecified value
  keeps the v2c default (pre-#3948 behavior).
- `sendLinkTraps` now builds the trap **per group** (community stays a
  single global selection) via `buildLinkTrapsForVersion`: `v1` emits the
  new `buildLinkTrapV1`, `v2`/unspecified the existing v2c `buildLinkTrap`,
  and `all` emits **both** (Junos semantics).
- `buildLinkTrapV1` constructs a proper SNMPv1 Trap-PDU (RFC 1157):
  message version field 0, PDU tag `0xa4`, the trap type carried in the
  enterprise/generic-trap/specific-trap/time-stamp fields (not repeated as
  `sysUpTime.0` + `snmpTrapOID.0` varbinds), enterprise = `snmpTraps`
  (1.3.6.1.6.3.1.1.5) and agent-addr 0.0.0.0 per the RFC 2576 §3.1
  SNMPv2→SNMPv1 mapping, generic-trap 2=linkDown/3=linkUp, specific-trap 0,
  and `ifIndex`/`ifDescr`/`ifOperStatus` varbinds.

## Tests (RED-on-revert)

- `pkg/config`: `TestSNMPTrapGroup_VersionCarried` (v1/v2/all land on
  `Version`) + `TestSNMPTrapGroup_VersionUnspecifiedEmpty`. Dropping the
  compiler assignment leaves `Version` empty → RED.
- `pkg/snmp`: `TestBuildLinkTrapV1_Structure` (full v1 PDU shape),
  `TestSendLinkTraps_VersionV1_EmitsV1` (end-to-end over UDP: version 0 /
  tag 0xa4), `..._VersionV2_EmitsV2c`, `..._VersionUnspecified_EmitsV2c`,
  `..._VersionAll_EmitsBoth`. Building v2c regardless makes the v1 test
  receive version=1/tag=0xa7 and the `all` test get only one packet → RED.

Both revert paths were exercised and confirmed RED before committing.

## Validation

`go build ./...`, `gofmt`, `go vet`, and `go test ./pkg/snmp/ ./pkg/config/`
all green. Updated `pkg/snmp/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi