### PR TITLE
daemon/rss: bound ethtool -x scan to the indirection table (#3954)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-03 — #3954: RSS idempotence probe misparsed `ethtool -x` when the hash key's first byte was decimal-looking → spurious `ethtool -X` rewrite mid-traffic (~39% of boots)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-056 (MEDIUM, robustness). The D3 RSS
+    idempotence probe (`indirectionTableMatches` /
+    `indirectionTableIsDefault` in `pkg/daemon/rss_indirection.go`) parses
+    `ethtool -x <iface>` to decide skip-vs-rewrite. `ethtool -x` prints the
+    indirection table first, then an `RSS hash key:` section whose bytes
+    render as colon-separated hex (e.g. `09:5c:8e:...`). The row scanner
+    treated any colon-bearing line with a numeric prefix as a table row.
+    When the first key byte was a decimal-looking hex value (both nibbles
+    0-9: `00-09`, `10-19`, ..., `90-99` = 100/256 ≈ 39% of random keys),
+    `strconv.Atoi("09")` succeeded, so the key line was misread as row "9"
+    whose remaining hex bytes then failed to parse → false "current !=
+    desired" verdict → a spurious `ethtool -X` rewrite on ~39% of
+    boots/reconciles, re-steering in-flight flows to other RX queues (and
+    forcing an AF_XDP queue rebind).
+  - **Fix**: added a single shared `parseIndirectionTable` helper that
+    bounds the row scan to the indirection-table section — it breaks at the
+    first line whose first 8 bytes fold to `RSS hash` (the key /
+    hash-function headers) and, as an order-independent belt-and-braces
+    guard, rejects any candidate row whose post-colon remainder still
+    contains a colon (real rows carry only whitespace-separated integers;
+    the key line is `:`-separated hex). Both idempotence functions now
+    consume the parser's rows, so an already-correct RSS config compares
+    EQUAL and the probe skips the rewrite. WHAT RSS config is desired is
+    unchanged — only the parse/compare is corrected.
+  - **Validation**: added golden fixtures (captured-shape 128-entry table +
+    40-byte Toeplitz key beginning `09:`, plus a round-robin-default variant)
+    and 5 tests, including a RED-on-revert end-to-end test asserting the
+    `ethtool -X` call count. Temporarily neutered the two guards to confirm
+    RED — the neutered parser reproduced the exact spurious
+    `-X ge-0-0-2 weight 1 1 1 1 0 0` rewrite; restored → green.
+    `go test ./pkg/daemon/` green (3.9s), `go build ./...`, gofmt, vet clean.
+  - **File(s)**: `pkg/daemon/rss_indirection.go`,
+    `pkg/daemon/rss_indirection_test.go`, `docs/pr/805-rss-refresh/plan.md`,
+    `_Log.md`
+
 ## 2026-07-03 — #3950: monitorLinkState exited permanently on netlink ENOBUFS → SNMP link traps went dark for the daemon's lifetime
 
 - **Timestamp**: 2026-07-03

--- a/docs/pr/805-rss-refresh/plan.md
+++ b/docs/pr/805-rss-refresh/plan.md
@@ -92,6 +92,43 @@ once" (Codex MED #3): a custom table that hits every queue once
 in non-round-robin order would fail this check, so the daemon
 would correctly reset it to true round-robin on the next apply.
 
+### 4.1 Row-scan must stop at the "RSS hash key:" section (#3954)
+
+`ethtool -x` prints the indirection table first, then an
+`RSS hash key:` section whose bytes render as colon-separated hex,
+e.g.:
+
+```
+RSS hash key:
+09:5c:8e:3a:7f:...
+```
+
+The idempotence probe (`indirectionTableMatches` /
+`indirectionTableIsDefault`) originally scanned every colon-bearing
+line for a numeric prefix. When the first key byte was a
+decimal-looking hex value — both nibbles in 0-9: `00-09`, `10-19`,
+..., `90-99` = 100 of 256 values, ~39% of randomly generated keys —
+`strconv.Atoi("09")` succeeded, so the key line was misread as
+indirection row "9" whose remaining hex bytes (`5c`, `8e`, ...)
+then failed to parse. That returned a false "current != desired"
+verdict and issued a **spurious `ethtool -X` rewrite mid-traffic**
+on ~39% of boots/reconciles, re-steering in-flight flows to
+different RX queues (and forcing an AF_XDP queue rebind).
+
+Fix (`parseIndirectionTable`, `pkg/daemon/rss_indirection.go`): a
+single shared parser bounds the row scan to the indirection-table
+section — it stops at the first line whose first eight bytes fold
+to `RSS hash` (the key / hash-function headers). A second,
+order-independent guard rejects any candidate row whose post-colon
+remainder still contains a colon (real rows carry only
+whitespace-separated integers; the key line is `:`-separated hex).
+Both `indirectionTableMatches` and `indirectionTableIsDefault`
+consume the parser's rows, so an already-correct RSS config now
+compares EQUAL and the probe skips the rewrite. Pinned by a golden
+fixture (captured-shape 128-entry table + 40-byte Toeplitz key
+beginning `09:`) with a RED-on-revert test asserting the `-X` call
+count.
+
 ## 5. Skip-reason discrimination (Codex R1 MED #5 fix)
 
 Don't parse the human string from `computeWeightVector`. The

--- a/pkg/daemon/rss_indirection.go
+++ b/pkg/daemon/rss_indirection.go
@@ -348,6 +348,86 @@ func maybeRestoreDefault(iface string, queues int, execer rssExecutor) {
 		"reason", "workers>=queues with stale constrained table")
 }
 
+// indirectionRow is one parsed data row of the `ethtool -x` RSS
+// indirection table: the printed row index (the value before the colon,
+// e.g. 0, 8, 16 for an 8-column dump) and the queue indices that follow
+// it, in column order.
+type indirectionRow struct {
+	idx     int
+	entries []int
+}
+
+// parseIndirectionTable extracts the indirection-table data rows from
+// `ethtool -x <iface>` output. Each row carries its printed index and the
+// queue entries in column order.
+//
+// The scan is bounded to the indirection-table section and STOPS at the
+// "RSS hash key:" (or "RSS hash function:") header. This bound is
+// load-bearing (#3954): the hash-key line that follows the table is
+// colon-separated hex, e.g.
+//
+//	RSS hash key:
+//	09:5c:8e:3a:7f:...
+//
+// When the first key byte is a decimal-looking hex value — 0x00-0x09,
+// 0x10-0x19, ..., 0x90-0x99, i.e. both nibbles in 0-9 (100 of 256 byte
+// values, ~39% of randomly generated keys) — strconv.Atoi("09") succeeds,
+// so without this bound the key line is misread as indirection row "9"
+// whose remaining hex bytes ("5c", "8e", ...) then fail to parse. That
+// produced a spurious "current != desired" verdict on ~39% of boots and an
+// unnecessary `ethtool -X` rewrite mid-traffic, re-steering in-flight flows
+// to different RX queues (and, on the AF_XDP path, forcing a queue rebind).
+//
+// A second, order-independent guard rejects any candidate row whose
+// post-colon remainder still contains a colon: real indirection rows carry
+// only whitespace-separated integers after the row index, whereas the
+// hash-key line is ":"-separated hex. This defends the misparse even if a
+// future ethtool reorders its output sections.
+//
+// ok is false when an in-section row carried a non-integer queue token (a
+// genuinely unparseable table); callers treat that as "cannot confirm the
+// desired layout" and fall through to a rewrite.
+func parseIndirectionTable(output []byte) (rows []indirectionRow, ok bool) {
+	for _, line := range bytes.Split(output, []byte{'\n'}) {
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) == 0 {
+			continue
+		}
+		// Everything from the "RSS hash key" / "RSS hash function" header
+		// onward is colon-separated hex or key:value pairs, not table
+		// rows — stop here so the hash-key line is never parsed (#3954).
+		if len(trimmed) >= 8 && bytes.EqualFold(trimmed[:8], []byte("RSS hash")) {
+			break
+		}
+		colon := bytes.IndexByte(trimmed, ':')
+		if colon <= 0 {
+			continue
+		}
+		rowIdx, err := strconv.Atoi(string(trimmed[:colon]))
+		if err != nil {
+			continue
+		}
+		remainder := trimmed[colon+1:]
+		// A real indirection row has only whitespace-separated integers
+		// after the colon; the hash-key line has further colons. Reject
+		// any remainder that still contains a colon (#3954, belt-and-braces
+		// so the fix holds regardless of ethtool section ordering).
+		if bytes.IndexByte(remainder, ':') >= 0 {
+			continue
+		}
+		row := indirectionRow{idx: rowIdx}
+		for _, tok := range bytes.Fields(remainder) {
+			q, err := strconv.Atoi(string(tok))
+			if err != nil {
+				return rows, false
+			}
+			row.entries = append(row.entries, q)
+		}
+		rows = append(rows, row)
+	}
+	return rows, true
+}
+
 // indirectionTableIsDefault reports true iff the live `ethtool -x`
 // output describes a round-robin indirection table where
 // entry[i] == i mod queueCount. This is the exact shape mlx5
@@ -366,26 +446,14 @@ func indirectionTableIsDefault(output []byte, queueCount int) bool {
 	if queueCount <= 0 {
 		return false
 	}
+	rows, ok := parseIndirectionTable(output)
+	if !ok {
+		return false
+	}
 	sawAnyEntry := false
-	for _, line := range bytes.Split(output, []byte{'\n'}) {
-		trimmed := bytes.TrimSpace(line)
-		if len(trimmed) == 0 {
-			continue
-		}
-		colon := bytes.IndexByte(trimmed, ':')
-		if colon <= 0 {
-			continue
-		}
-		rowIdx, err := strconv.Atoi(string(trimmed[:colon]))
-		if err != nil {
-			continue
-		}
-		for j, tok := range bytes.Fields(trimmed[colon+1:]) {
-			q, err := strconv.Atoi(string(tok))
-			if err != nil {
-				return false
-			}
-			expected := (rowIdx + j) % queueCount
+	for _, row := range rows {
+		for j, q := range row.entries {
+			expected := (row.idx + j) % queueCount
 			if q != expected {
 				return false
 			}
@@ -439,7 +507,9 @@ func computeWeightVector(workers, queues int) ([]int, string) {
 //
 // i.e. no queue index >= activeCount appears. We conservatively treat any
 // appearance of a queue >= activeCount as a mismatch so the reapply goes
-// through.
+// through. Parsing is delegated to parseIndirectionTable, which bounds the
+// scan to the indirection-table section so the trailing "RSS hash key:"
+// line is never misread as a table row (#3954).
 func indirectionTableMatches(output []byte, weights []int) bool {
 	if len(weights) == 0 {
 		return false
@@ -454,34 +524,21 @@ func indirectionTableMatches(output []byte, weights []int) bool {
 		return false
 	}
 
-	// Lines of interest start with whitespace + digits + ':', e.g.
-	// "    0:      0     1     2     3     0     1".
-	sawAnyRow := false
-	for _, line := range bytes.Split(output, []byte{'\n'}) {
-		trimmed := bytes.TrimSpace(line)
-		if len(trimmed) == 0 {
-			continue
-		}
-		// Only parse lines of the form "<index>: <qn> <qn> ..."
-		colon := bytes.IndexByte(trimmed, ':')
-		if colon <= 0 {
-			continue
-		}
-		if _, err := strconv.Atoi(string(trimmed[:colon])); err != nil {
-			continue
-		}
-		sawAnyRow = true
-		for _, tok := range bytes.Fields(trimmed[colon+1:]) {
-			q, err := strconv.Atoi(string(tok))
-			if err != nil {
-				return false
-			}
+	// Parse only the indirection-table rows (parseIndirectionTable stops
+	// at the "RSS hash key:" section so a decimal-looking key byte cannot
+	// be misread as a table row — #3954).
+	rows, ok := parseIndirectionTable(output)
+	if !ok {
+		return false
+	}
+	for _, row := range rows {
+		for _, q := range row.entries {
 			if q < 0 || q >= active {
 				return false
 			}
 		}
 	}
-	return sawAnyRow
+	return len(rows) > 0
 }
 
 // isExecNotFound returns true if err indicates the ethtool binary is

--- a/pkg/daemon/rss_indirection_test.go
+++ b/pkg/daemon/rss_indirection_test.go
@@ -869,6 +869,167 @@ func TestApplyRSSIndirectionOne_QueueCountOne_NoOp(t *testing.T) {
 	}
 }
 
+// ─── #3954: hash-key line must not be misparsed as a table row ───────
+//
+// Real mlx5 `ethtool -x` output ends with an "RSS hash key:" section whose
+// bytes are printed colon-separated hex ("09:5c:8e:..."). When the first
+// key byte is a decimal-looking hex value (both nibbles 0-9: 0x00-0x09,
+// 0x10-0x19, ..., 0x90-0x99 — 100 of 256 values, ~39% of random keys) the
+// "09" prefix parses as a valid decimal via strconv.Atoi, so the idempotence
+// probe used to misread the key line as an indirection-table row whose
+// remaining hex bytes then failed to parse → a false "current != desired"
+// verdict → a spurious `ethtool -X` rewrite mid-traffic.
+//
+// These fixtures are captured-shape mlx5 output (128-entry table, 40-byte
+// Toeplitz key) with a first key byte of 0x09 to pin the fix.
+
+// capturedConstrainedTableDecimalKey: a live-shape `ethtool -x` dump whose
+// indirection table only uses queues 0..3 (the layout mlx5 writes for
+// weight vector [1 1 1 1 0 0]) AND whose RSS hash key begins with a
+// decimal-looking byte (09). indirectionTableMatches([1,1,1,1,0,0]) must
+// return true on this — i.e. the desired config is already applied.
+const capturedConstrainedTableDecimalKey = `RX flow hash indirection table for ge-0-0-2 with 6 RX ring(s):
+    0:      0     1     2     3     0     1     2     3
+    8:      0     1     2     3     0     1     2     3
+   16:      0     1     2     3     0     1     2     3
+   24:      0     1     2     3     0     1     2     3
+   32:      0     1     2     3     0     1     2     3
+   40:      0     1     2     3     0     1     2     3
+   48:      0     1     2     3     0     1     2     3
+   56:      0     1     2     3     0     1     2     3
+   64:      0     1     2     3     0     1     2     3
+   72:      0     1     2     3     0     1     2     3
+   80:      0     1     2     3     0     1     2     3
+   88:      0     1     2     3     0     1     2     3
+   96:      0     1     2     3     0     1     2     3
+  104:      0     1     2     3     0     1     2     3
+  112:      0     1     2     3     0     1     2     3
+  120:      0     1     2     3     0     1     2     3
+RSS hash key:
+09:5c:8e:3a:7f:c1:d2:0b:44:91:6a:2e:88:fd:03:57:be:19:e4:7c:35:a0:6d:f2:48:9b:11:cc:82:5f:30:a7:6e:d9:04:53:bf:1a:e5:7d
+RSS hash function:
+    toeplitz: on
+    xor: off
+    crc32: off
+`
+
+// capturedDefaultTableDecimalKey: a live-shape `ethtool -x` dump whose
+// indirection table is the kernel round-robin default across all 6 queues
+// (entry[i] == i mod 6) AND whose RSS hash key begins with a decimal-looking
+// byte (09). indirectionTableIsDefault(_, 6) must return true on this.
+const capturedDefaultTableDecimalKey = `RX flow hash indirection table for ge-0-0-2 with 6 RX ring(s):
+    0:      0     1     2     3     4     5     0     1
+    8:      2     3     4     5     0     1     2     3
+   16:      4     5     0     1     2     3     4     5
+   24:      0     1     2     3     4     5     0     1
+RSS hash key:
+09:5c:8e:3a:7f:c1:d2:0b:44:91:6a:2e:88:fd:03:57:be:19:e4:7c:35:a0:6d:f2:48:9b:11:cc:82:5f:30:a7:6e:d9:04:53:bf:1a:e5:7d
+RSS hash function:
+    toeplitz: on
+    xor: off
+    crc32: off
+`
+
+// #3954 test 1 (RED on revert): the desired constrained layout is already
+// live and the RSS key's first byte is decimal-looking (09). The probe must
+// report "already applied" — the key line must not be misread as a table
+// row. On revert the misparse makes indirectionTableMatches return false.
+func TestIndirectionTableMatches_DecimalFirstKeyByte_StillMatches(t *testing.T) {
+	if !indirectionTableMatches([]byte(capturedConstrainedTableDecimalKey), []int{1, 1, 1, 1, 0, 0}) {
+		t.Fatal("constrained table with a decimal-looking RSS key byte must still match desired [1 1 1 1 0 0] " +
+			"(#3954: the RSS hash key line must not be parsed as a table row)")
+	}
+}
+
+// #3954 test 2: the round-robin default layout with a decimal-looking RSS
+// key byte must still parse as default. On revert the key line "09:5c:..."
+// is misread as row 9 whose entry "5c:8e:..." fails to parse → false.
+func TestIndirectionTableIsDefault_DecimalFirstKeyByte_StillDefault(t *testing.T) {
+	if !indirectionTableIsDefault([]byte(capturedDefaultTableDecimalKey), 6) {
+		t.Fatal("round-robin default table with a decimal-looking RSS key byte must still parse as default " +
+			"(#3954)")
+	}
+}
+
+// #3954 test 3 (RED on revert, end-to-end): drive the full
+// applyRSSIndirectionOne probe path with the golden fixture that already
+// matches the desired weight vector. The probe must SKIP the rewrite — the
+// only ethtool call is the `-x` probe, no `-X weight`. On revert the
+// hash-key misparse forces a spurious `ethtool -X` weight rewrite (2 calls).
+func TestApplyRSSIndirectionOne_MatchingTableDecimalKey_SkipsWrite(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers:  map[string]string{"ge-0-0-2": mlx5Driver},
+		queues:   map[string]int{"ge-0-0-2": 6},
+		ethtoolX: map[string][]byte{"ge-0-0-2": []byte(capturedConstrainedTableDecimalKey)},
+	}
+	// workers=4, queues=6 → desired weights [1 1 1 1 0 0], already live.
+	applyRSSIndirectionOne("ge-0-0-2", 4, f)
+
+	if len(f.calls) != 1 {
+		t.Fatalf("want exactly 1 ethtool call (probe only), got %d: %v (#3954: spurious -X rewrite)",
+			len(f.calls), f.calls)
+	}
+	if f.calls[0][0] != "-x" {
+		t.Fatalf("the single call must be the -x probe, got %v", f.calls[0])
+	}
+	for _, c := range f.calls {
+		if c[0] == "-X" {
+			t.Fatalf("already-correct RSS config must not trigger `ethtool -X`, got %v", c)
+		}
+	}
+}
+
+// #3954 test 4: the negative path still fires. When the live table is the
+// full round-robin default (queues 0..5) but only 4 workers are desired, the
+// config genuinely differs → exactly one `ethtool -X weight` rewrite. Pins
+// that the section-bounded parser did not over-suppress writes.
+func TestApplyRSSIndirectionOne_DifferingTableDecimalKey_WritesOnce(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers:  map[string]string{"ge-0-0-2": mlx5Driver},
+		queues:   map[string]int{"ge-0-0-2": 6},
+		ethtoolX: map[string][]byte{"ge-0-0-2": []byte(capturedDefaultTableDecimalKey)},
+	}
+	applyRSSIndirectionOne("ge-0-0-2", 4, f)
+
+	writes := 0
+	for _, c := range f.calls {
+		if len(c) >= 3 && c[0] == "-X" && c[2] == "weight" {
+			writes++
+			want := []string{"-X", "ge-0-0-2", "weight", "1", "1", "1", "1", "0", "0"}
+			if !reflect.DeepEqual(c, want) {
+				t.Fatalf("weight argv mismatch: want %v, got %v", want, c)
+			}
+		}
+	}
+	if writes != 1 {
+		t.Fatalf("genuinely-different config must issue exactly one -X weight, got %d: %v",
+			writes, f.calls)
+	}
+}
+
+// #3954 test 5 (unit, parser): the shared parser stops at the RSS hash key
+// section so the decimal-first-byte key line contributes no rows, and the
+// preceding table rows all parse. Guards the section bound directly.
+func TestParseIndirectionTable_StopsAtHashKey(t *testing.T) {
+	rows, ok := parseIndirectionTable([]byte(capturedConstrainedTableDecimalKey))
+	if !ok {
+		t.Fatal("parse must succeed (all in-section tokens are integers)")
+	}
+	if len(rows) != 16 {
+		t.Fatalf("want 16 indirection rows (key/function sections excluded), got %d", len(rows))
+	}
+	for _, row := range rows {
+		if len(row.entries) != 8 {
+			t.Fatalf("row %d: want 8 entries, got %d", row.idx, len(row.entries))
+		}
+		for _, q := range row.entries {
+			if q < 0 || q > 3 {
+				t.Fatalf("row %d: constrained table must only use queues 0..3, saw %d", row.idx, q)
+			}
+		}
+	}
+}
+
 // Sanity: the production isExecNotFound detects the stable sentinel that
 // `exec.Command("missing").CombinedOutput()` wraps, without substring
 // matching (Go MEDIUM #1).


### PR DESCRIPTION
## Summary

Fixes #3954 (fable-161 F-056, MEDIUM robustness). The D3 RSS idempotence probe misparsed `ethtool -x <iface>` output when the RSS hash key's first byte rendered as a decimal-looking hex value, concluding `current != desired` even when identical → a **spurious `ethtool -X` RSS rewrite mid-traffic on ~39% of boots/reconciles**, re-steering in-flight flows to different RX queues (and forcing an AF_XDP queue rebind).

## The misparse (file:line)

`pkg/daemon/rss_indirection.go` — `indirectionTableMatches` and `indirectionTableIsDefault`.

`ethtool -x` prints the indirection table, then an `RSS hash key:` section whose bytes are colon-separated hex:

```
RSS hash key:
09:5c:8e:3a:7f:...
```

The row scanner accepted any colon-bearing line whose pre-colon prefix parsed as a decimal int as a table row. When the first key byte's two hex digits are both 0-9 (`00-09`, `10-19`, ..., `90-99` = 100/256 ≈ **39%** of random keys), `strconv.Atoi("09")` succeeds → the key line is misread as indirection row "9" whose remaining hex bytes (`5c`, `8e`, ...) then fail `Atoi` → `return false` (mismatch) → spurious `ethtool -X` weight rewrite. The pre-existing `TestIndirectionTableIsDefault_EmptyOutput_False` fixture happened to use a key starting `0a:` (which `Atoi` rejects), dodging the bug.

## The fix

A single shared `parseIndirectionTable` helper bounds the row scan to the indirection-table section:
- **breaks** at the first line whose first 8 bytes fold to `RSS hash` (the key / hash-function headers), and
- as an order-independent belt-and-braces guard, **rejects any candidate row whose post-colon remainder still contains a colon** (real rows carry only whitespace-separated integers; the key line is `:`-separated hex).

Both idempotence functions now consume the parser's rows, so an already-correct RSS config compares EQUAL → the probe skips the rewrite. **WHAT RSS config is desired is unchanged** — only the parse/compare is corrected.

## Golden fixture + RED-on-revert

Added captured-shape fixtures (128-entry indirection table + 40-byte Toeplitz key beginning `09:`; plus a round-robin-default variant) and 5 tests:
- `TestIndirectionTableMatches_DecimalFirstKeyByte_StillMatches` / `TestIndirectionTableIsDefault_DecimalFirstKeyByte_StillDefault`
- `TestApplyRSSIndirectionOne_MatchingTableDecimalKey_SkipsWrite` — end-to-end, asserts the only ethtool call is the `-x` probe (no `-X`)
- `TestApplyRSSIndirectionOne_DifferingTableDecimalKey_WritesOnce` — genuinely-different config → exactly one `-X weight`
- `TestParseIndirectionTable_StopsAtHashKey` — pins the section bound

**RED-on-revert proof:** temporarily neutering the two guards reproduced the exact bug — `TestApplyRSSIndirectionOne_MatchingTableDecimalKey_SkipsWrite` failed with `got 2: [[-x ge-0-0-2] [-X ge-0-0-2 weight 1 1 1 1 0 0]]` (the spurious rewrite). With the guards restored, all pass.

## Validation

- `go test ./pkg/daemon/` green (3.9s)
- `go build ./...`, `gofmt -l`, `go vet ./pkg/daemon/` clean
- Docs: `docs/pr/805-rss-refresh/plan.md` §4.1 + `_Log.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
