### PR TITLE
dhcp: abandon lease on RENEWING/REBINDING DHCPNAK instead of holding it until T2 (#3956)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-07-03 — #3956: DHCPv4 client kept a revoked address until T2 — a RENEWING DHCPNAK was treated like a renew timeout
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-173 (MEDIUM, DHCP correctness, RFC 2131
+    §4.4.5). The DHCPv4 client's `doDHCPv4` returned an indistinguishable
+    error string for both a renew TIMEOUT and a DHCPNAK, so `runDHCPv4`
+    could not tell them apart: a NAK in the RENEWING state fell through the
+    "waiting for T2" branch and the client kept configuring/using the
+    revoked address until the REBINDING attempt at T2 (minutes) — address
+    conflict / blackhole risk. A DHCPNAK is an explicit lease REVOCATION;
+    RFC 2131 §4.4.5 requires the client to stop using the address
+    immediately and return to INIT (restart DISCOVER). Added an
+    `errDHCPNAK` sentinel wrapped by `doDHCPv4` on a NAK reply, and made
+    `runDHCPv4` distinguish it via `errors.Is`. On a NAK at T1 (RENEWING)
+    or T2 (REBINDING) the new `abandonLeaseAfterNAK` deconfigures the
+    interface (removes the kernel address), drops the lease record, and
+    fires `onGatewayChange` outside `m.mu` — mirroring `finishClient`'s
+    removal ordering + the #1844 coupling rule — then the loop restarts a
+    fresh DORA from INIT with `committed=nil`. A genuine renew TIMEOUT
+    still falls through to the T2 rebind; the T2 timeout path keeps the
+    existing lease-expiry fallback. RED-on-revert proven: neutering the
+    two NAK branches makes the RENEWING test see a REBIND at exchange 2
+    (instead of a fresh DISCOVER) and the REBINDING test keep the revoked
+    lease recorded across the re-acquire. `go test ./pkg/dhcp/...` green,
+    `go build ./...` green, gofmt/vet clean.
+  - **File(s)**: pkg/dhcp/dhcp.go, pkg/dhcp/renew_test.go, pkg/dhcp/README.md
+
 ## 2026-07-03 — #3952: swanctl PSK secrets carried no `id` selectors → with 2+ PSK VPNs the wrong PSK matched a peer
 
 - **Timestamp**: 2026-07-03

--- a/pkg/dhcp/README.md
+++ b/pkg/dhcp/README.md
@@ -102,13 +102,21 @@ the debounced `onAddressChange` callback when content changed.
   `Lease.v6ServerDUID` fields so a later RENEW can target the original
   server. DHCPv6 stateless mode has no binding, so every refresh stays
   an Information-Request regardless of mode.
-- **Only renewal failure re-acquires**: a NAK/timeout at T1 falls
-  through to the T2 rebind; a second failure (or a failure to apply
-  the renewed address) falls back to full re-acquisition — RFC 2131
-  §4.4.5 / RFC 8415 §18.2.4-5 behavior. A transient renew failure
-  retains the old lease and address until then (`docs/dns-ownership.md`).
-  Any malformed/unmatched renew is therefore fail-safe: it degrades to
-  the previous full-acquisition path, never to a worse state.
+- **Timeout falls through, NAK abandons (#3956)**: a renew *timeout*
+  (no reply) at T1 falls through to the T2 rebind; a second timeout (or
+  a failure to apply the renewed address) falls back to full
+  re-acquisition, retaining the old lease and address until then
+  (`docs/dns-ownership.md`). A DHCPNAK is different — it is an explicit
+  lease REVOCATION (the server reassigned the address or the client
+  changed subnets). Per RFC 2131 §4.4.5 a NAK in the RENEWING *or*
+  REBINDING state deconfigures the interface immediately
+  (`abandonLeaseAfterNAK`: remove the kernel address, drop the lease
+  record, fire `onGatewayChange`) and returns to INIT — a fresh DISCOVER
+  with no prior lease — rather than keeping the revoked address until
+  T2. `doDHCPv4` wraps the sentinel `errDHCPNAK` on a NAK reply so the
+  run loop distinguishes the two via `errors.Is`. A malformed/unmatched
+  timeout renew is therefore still fail-safe (degrades to the previous
+  full-acquisition path), and an explicit revocation is honored at once.
 - **Address moves are re-acquisition-equivalent**: if a renewal returns
   a different address, the old one is removed and the new one applied
   via the same netlink mechanisms the fresh-acquisition path uses.
@@ -156,13 +164,17 @@ External only: `github.com/insomniacslk/dhcp`, `github.com/vishvananda/netlink`.
   address reconciliation on DHCP-marked interfaces.
 - DHCP-learned default routes go into FRR with admin distance 200 — lower
   priority than static routes, so a configured static default wins.
-- **Lease records are NOT expired by the clock.** During a failed
-  re-acquisition (T2 rebind failed, fresh DORA in progress) the lease
-  record and the kernel address intentionally persist until replaced
-  — consumers (FRR DHCP routes, ip-monitoring resolved next-hops)
-  keep the last-known gateway. This deliberately diverges from RFC
-  2131 §4.4.5 (an expired lease should stop being used). **Coupling
-  rule (#1844):** if expiry is ever implemented, the lease-record
-  removal MUST route through a path that fires `onGatewayChange`
-  (`finishClient` already does), so the ip-monitoring overlay
+- **Lease records are NOT expired by the wall clock.** During a
+  *timeout-driven* failed re-acquisition (T2 rebind timed out, fresh
+  DORA in progress) the lease record and the kernel address
+  intentionally persist until replaced — consumers (FRR DHCP routes,
+  ip-monitoring resolved next-hops) keep the last-known gateway. This
+  deliberately diverges from RFC 2131 §4.4.5 for the *timeout* case (an
+  expired lease should stop being used). An explicit **DHCPNAK is
+  honored** (#3956): it deconfigures immediately via
+  `abandonLeaseAfterNAK` — see "Timeout falls through, NAK abandons"
+  above. **Coupling rule (#1844):** any lease-record removal (the NAK
+  path and, if clock expiry is ever implemented, that path too) MUST
+  route through a path that fires `onGatewayChange` (`finishClient` and
+  `abandonLeaseAfterNAK` both do), so the ip-monitoring overlay
   withdraws its resolved next-hop in lock-step with the address.

--- a/pkg/dhcp/dhcp.go
+++ b/pkg/dhcp/dhcp.go
@@ -6,6 +6,7 @@ package dhcp
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -761,6 +762,18 @@ func (m *Manager) runDHCPv4(ctx context.Context, ifaceName string) {
 					"lease_time", renewed.LeaseTime)
 				continue
 			}
+			// A DHCPNAK in RENEWING is an explicit lease REVOCATION: the
+			// address is no longer valid (reassigned / moved subnet). Per
+			// RFC 2131 §4.4.5 abandon it immediately and return to INIT
+			// (fresh DISCOVER) — do NOT keep using it until T2 (#3956). A
+			// genuine renew TIMEOUT still falls through to the T2 rebind.
+			if errors.Is(rerr, errDHCPNAK) {
+				slog.Warn("DHCPv4: RENEWING NAK — lease revoked, deconfiguring and restarting DISCOVER",
+					"interface", ifaceName)
+				m.abandonLeaseAfterNAK(key, committed)
+				committed = nil
+				break // outer loop → fresh DORA from INIT
+			}
 			slog.Warn("DHCPv4: T1 renewal failed, waiting for T2",
 				"interface", ifaceName, "err", rerr)
 
@@ -789,11 +802,51 @@ func (m *Manager) runDHCPv4(ctx context.Context, ifaceName string) {
 					"lease_time", renewed.LeaseTime)
 				continue
 			}
+			// A DHCPNAK in REBINDING is also a revocation (RFC 2131
+			// §4.4.5): deconfigure now and re-DISCOVER from INIT with no
+			// prior lease. A rebind TIMEOUT is left to the existing
+			// lease-expiry fallback, which retains the address until the
+			// re-acquire replaces it (#1844 last-known-gateway note in
+			// README) — only an explicit NAK forces immediate abandon.
+			if errors.Is(rerr, errDHCPNAK) {
+				slog.Warn("DHCPv4: REBINDING NAK — lease revoked, deconfiguring and restarting DISCOVER",
+					"interface", ifaceName)
+				m.abandonLeaseAfterNAK(key, committed)
+				committed = nil
+				break // outer loop → fresh DORA from INIT
+			}
 			slog.Warn("DHCPv4: T2 rebind failed, lease will expire, re-acquiring",
 				"interface", ifaceName, "err", rerr)
 			break // fall back to a fresh DORA
 		}
 	}
+}
+
+// errDHCPNAK is returned (wrapped) by doDHCPv4 when the server answers a
+// RENEWING/REBINDING DHCPREQUEST with a DHCPNAK. It is a sentinel so the
+// run loop can distinguish an explicit lease REVOCATION (RFC 2131
+// §4.4.5: stop using the address immediately and return to INIT) from a
+// renew TIMEOUT (which still falls through to the T2 rebind). The
+// discriminator is errors.Is(err, errDHCPNAK); see runDHCPv4 (#3956).
+var errDHCPNAK = errors.New("DHCPv4 server sent NAK")
+
+// abandonLeaseAfterNAK deconfigures the interface and drops the lease
+// record after a DHCPNAK revoked the lease (RFC 2131 §4.4.5). The client
+// must stop using the address immediately and return to INIT — it must
+// NOT wait for T2. This mirrors finishClient's removal ordering (the
+// established lease-record-removal owner): remove the kernel address,
+// delete the lease record under m.mu, then fire the gateway-change hook
+// OUTSIDE m.mu so the ip-monitoring overlay withdraws its resolved
+// next-hop in lock-step with the address (the #1844 coupling rule).
+// Callers hold no lock. committed may be nil (nothing to remove).
+func (m *Manager) abandonLeaseAfterNAK(key clientKey, committed *Lease) {
+	if committed != nil && committed.Address.IsValid() {
+		m.removeAddress(key.iface, committed)
+	}
+	m.mu.Lock()
+	delete(m.leases, key)
+	m.mu.Unlock()
+	m.fireGatewayChange()
 }
 
 // doDHCPv4 performs a single DHCPv4 exchange for the given mode:
@@ -839,7 +892,11 @@ func (m *Manager) doDHCPv4(ctx context.Context, ifaceName string, mode dhcpExcha
 			return nil, fmt.Errorf("DHCPv4 %s: %w", mode, err)
 		}
 		if resp.MessageType() == dhcpv4.MessageTypeNak {
-			return nil, fmt.Errorf("DHCPv4 %s: server sent NAK", mode)
+			// A DHCPNAK is an explicit lease REVOCATION, not a transient
+			// renew failure — wrap the sentinel so the run loop abandons
+			// the address and returns to INIT immediately rather than
+			// waiting for T2 (RFC 2131 §4.4.5). See runDHCPv4 / #3956.
+			return nil, fmt.Errorf("DHCPv4 %s: %w", mode, errDHCPNAK)
 		}
 		ack = resp
 	default:

--- a/pkg/dhcp/renew_test.go
+++ b/pkg/dhcp/renew_test.go
@@ -2,6 +2,7 @@ package dhcp
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/netip"
 	"testing"
@@ -278,5 +279,161 @@ func TestRunDHCPv6RenewUsesRenewNotSolicit(t *testing.T) {
 	}
 	if got := m.LeaseFor("wan0", AFInet6); got == nil || got.Address != leaseA.Address {
 		t.Errorf("lease after renew = %v, want preserved %s", got, leaseA.Address)
+	}
+}
+
+// TestRunDHCPv4RenewingNAKRestartsDiscover pins RFC 2131 §4.4.5 (#3956): a
+// DHCPNAK received in the RENEWING state must abandon the address and
+// return to INIT (fresh DISCOVER) IMMEDIATELY — it must NOT fall through
+// to the T2 REBINDING attempt. Reverting the fix (treating a NAK like a
+// renew timeout) turns this RED: the third exchange would be a REBIND and
+// the revoked lease would still be recorded.
+func TestRunDHCPv4RenewingNAKRestartsDiscover(t *testing.T) {
+	leaseA := &Lease{
+		Interface: "wan0",
+		Family:    AFInet,
+		Address:   netip.MustParsePrefix("192.0.2.50/24"),
+		Gateway:   netip.MustParseAddr("192.0.2.1"),
+		serverID:  netip.MustParseAddr("192.0.2.1"),
+		LeaseTime: 100 * time.Second,
+	}
+
+	var modes []dhcpExchangeMode
+	var leaseAtRestart *Lease
+	gwHooks := 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := &Manager{
+		leases:          map[clientKey]*Lease{},
+		delegatedPDs:    map[string][]DelegatedPrefix{},
+		v4opts:          map[string]*DHCPv4Options{"wan0": {}},
+		afterForTest:    immediateAfter,
+		onGatewayChange: func() { gwHooks++ },
+	}
+	m.doV4ExchangeForTest = func(_ context.Context, _ string, mode dhcpExchangeMode, _ *Lease) (*Lease, error) {
+		modes = append(modes, mode)
+		switch len(modes) {
+		case 1: // initial acquire
+			return leaseA, nil
+		case 2: // T1 renew — server NAKs (lease revoked)
+			return nil, fmt.Errorf("DHCPv4 renew: %w", errDHCPNAK)
+		default: // must be a fresh DISCOVER, not a REBIND
+			leaseAtRestart = m.LeaseFor("wan0", AFInet)
+			cancel()
+			return nil, context.Canceled
+		}
+	}
+
+	done := make(chan struct{})
+	go func() { m.runDHCPv4(ctx, "wan0"); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("runDHCPv4 did not terminate")
+	}
+
+	want := []dhcpExchangeMode{exchangeAcquire, exchangeRenew, exchangeAcquire}
+	if len(modes) != len(want) {
+		t.Fatalf("got %d exchanges, want %d: %v", len(modes), len(want), modes)
+	}
+	for i, w := range want {
+		if modes[i] != w {
+			t.Errorf("exchange %d = %s, want %s", i, modes[i], w)
+		}
+	}
+	// The anti-regression: the exchange AFTER the RENEWING NAK is a fresh
+	// DISCOVER (INIT restart), NOT a REBIND (waiting for T2).
+	if modes[2] != exchangeAcquire {
+		t.Fatalf("post-NAK exchange = %s, want acquire (NAK must not wait for T2)", modes[2])
+	}
+	// The revoked lease must be gone by the time the client re-DISCOVERs.
+	if leaseAtRestart != nil {
+		t.Errorf("lease still recorded after RENEWING NAK = %v, want removed", leaseAtRestart)
+	}
+	if got := m.LeaseFor("wan0", AFInet); got != nil {
+		t.Errorf("lease after RENEWING NAK = %v, want nil (deconfigured)", got)
+	}
+	// Deconfigure must fire the gateway-change hook so the ip-monitoring
+	// overlay withdraws the resolved next-hop (once for the initial commit,
+	// once for the abandon).
+	if gwHooks < 2 {
+		t.Errorf("onGatewayChange fired %d times, want >=2 (commit + abandon)", gwHooks)
+	}
+}
+
+// TestRunDHCPv4RebindingNAKRestartsDiscover pins the REBINDING half of
+// RFC 2131 §4.4.5 (#3956): a renew TIMEOUT at T1 still falls through to
+// the T2 REBINDING attempt, but a DHCPNAK there abandons the address and
+// restarts DISCOVER from INIT. Reverting the fix keeps the revoked lease
+// recorded across the re-acquire.
+func TestRunDHCPv4RebindingNAKRestartsDiscover(t *testing.T) {
+	leaseA := &Lease{
+		Interface: "wan0",
+		Family:    AFInet,
+		Address:   netip.MustParsePrefix("192.0.2.50/24"),
+		Gateway:   netip.MustParseAddr("192.0.2.1"),
+		serverID:  netip.MustParseAddr("192.0.2.1"),
+		LeaseTime: 100 * time.Second,
+	}
+
+	var modes []dhcpExchangeMode
+	var leaseAtRestart *Lease
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := &Manager{
+		leases:       map[clientKey]*Lease{},
+		delegatedPDs: map[string][]DelegatedPrefix{},
+		v4opts:       map[string]*DHCPv4Options{"wan0": {}},
+		afterForTest: immediateAfter,
+	}
+	m.doV4ExchangeForTest = func(_ context.Context, _ string, mode dhcpExchangeMode, _ *Lease) (*Lease, error) {
+		modes = append(modes, mode)
+		switch len(modes) {
+		case 1: // initial acquire
+			return leaseA, nil
+		case 2: // T1 renew — genuine TIMEOUT, must fall through to T2
+			return nil, context.DeadlineExceeded
+		case 3: // T2 rebind — server NAKs (lease revoked)
+			return nil, fmt.Errorf("DHCPv4 rebind: %w", errDHCPNAK)
+		default: // must be a fresh DISCOVER
+			leaseAtRestart = m.LeaseFor("wan0", AFInet)
+			cancel()
+			return nil, context.Canceled
+		}
+	}
+
+	done := make(chan struct{})
+	go func() { m.runDHCPv4(ctx, "wan0"); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("runDHCPv4 did not terminate")
+	}
+
+	want := []dhcpExchangeMode{exchangeAcquire, exchangeRenew, exchangeRebind, exchangeAcquire}
+	if len(modes) != len(want) {
+		t.Fatalf("got %d exchanges, want %d: %v", len(modes), len(want), modes)
+	}
+	for i, w := range want {
+		if modes[i] != w {
+			t.Errorf("exchange %d = %s, want %s", i, modes[i], w)
+		}
+	}
+	// A timeout at T1 still reaches REBIND (unchanged from prior behavior).
+	if modes[2] != exchangeRebind {
+		t.Fatalf("post-T1-timeout exchange = %s, want rebind", modes[2])
+	}
+	// The REBINDING NAK abandons the lease before the re-DISCOVER.
+	if leaseAtRestart != nil {
+		t.Errorf("lease still recorded after REBINDING NAK = %v, want removed", leaseAtRestart)
+	}
+	if got := m.LeaseFor("wan0", AFInet); got != nil {
+		t.Errorf("lease after REBINDING NAK = %v, want nil (deconfigured)", got)
 	}
 }


### PR DESCRIPTION
Closes #3956

## Problem

The DHCPv4 client (`pkg/dhcp`), while in the RENEWING state, treated a
received DHCPNAK the same as a renew TIMEOUT. `doDHCPv4` returned an
indistinguishable generic error for both a NAK and a timeout, so
`runDHCPv4` could not tell them apart — a NAK at T1 fell through the
`"waiting for T2"` branch and the client kept configuring and using the
**revoked** address until the REBINDING attempt at T2 (potentially
minutes). A DHCPNAK is an explicit lease REVOCATION (the server
reassigned the address, or the client moved subnets). RFC 2131 §4.4.5
requires the client to stop using the address immediately and return to
INIT (restart DISCOVER), not wait for T2 — otherwise an address conflict
(another host may now hold it) or a black-holed interface persists until
the delayed rebind.

## Fix

- `errDHCPNAK` sentinel (`pkg/dhcp/dhcp.go`) — `doDHCPv4` wraps it on a
  NAK reply in the RENEWING/REBINDING exchange, so the run loop
  distinguishes a revocation from a transient timeout via `errors.Is`.
- `abandonLeaseAfterNAK` — on a NAK at T1 (RENEWING) or T2 (REBINDING),
  deconfigure the interface (remove the kernel address), drop the lease
  record under `m.mu`, and fire `onGatewayChange` **outside** `m.mu` —
  mirroring `finishClient`'s lease-removal ordering and the #1844
  coupling rule so the ip-monitoring overlay withdraws its resolved
  next-hop in lock-step with the address. The loop then breaks to a
  fresh DORA from INIT with `committed=nil` (no prior lease).
- A genuine renew **timeout** still falls through to the T2 rebind, and
  the T2 timeout path keeps the existing lease-expiry fallback (retain
  the address until re-acquire replaces it) — only an explicit NAK
  forces the immediate abandon.

## Tests (RED-on-revert proven)

- `TestRunDHCPv4RenewingNAKRestartsDiscover` — NAK at T1 → exchange
  sequence `acquire → renew → acquire` (no REBIND), revoked lease removed
  before the re-DISCOVER, `onGatewayChange` fired on abandon. Neutering
  the fix makes exchange 2 a REBIND — **RED**.
- `TestRunDHCPv4RebindingNAKRestartsDiscover` — timeout at T1 still
  reaches T2 REBIND (unchanged), but a NAK there abandons the lease and
  re-DISCOVERs. Neutering keeps the revoked lease recorded across the
  re-acquire — **RED**.

Verified RED-on-revert by temporarily forcing both `errors.Is(rerr,
errDHCPNAK)` branches false: the RENEWING test then sees `exchange 2 =
rebind, want acquire` and the REBINDING test sees the lease still
recorded after the NAK.

## Validation

- `go test ./pkg/dhcp/...` green (also `-race`).
- `go build ./...` green; `gofmt -l` clean; `go vet ./pkg/dhcp/...`
  clean.
- `pkg/dhcp/README.md` renewal-semantics + gotcha sections updated;
  `_Log.md` entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
