### PR TITLE
config: stop false 'not in address-book' warnings for literal/any/feed policy refs (#3958)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,38 @@
+## 2026-07-03 — #3958: ValidateConfig warn pass emitted false "not in address-book" warnings for literal / any-ipv4 / any-ipv6 / dynamic-address-feed policy references → alarm fatigue
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-045 (MEDIUM, UX/alarm-fatigue). The
+    non-fatal `ValidateConfig` warn pass (`compiler_validate_warn.go`)
+    checked a policy source/destination-address token against only the
+    address-book entry set plus the bare `any` keyword, so it emitted a
+    spurious `policy … not in address-book` warning for every OTHER valid
+    reference form on a perfectly good policy: a literal IPv4/IPv6 address
+    or CIDR (incl. the `0.0.0.0/0` / `::/0` that `compilePolicy` normalizes
+    `any-ipv4` / `any-ipv6` to), the `any-ipv4` / `any-ipv6` wildcards, and
+    a dynamic-address FEED binding name. Spurious warnings on normal commits
+    train operators to ignore validation output, burying a REAL undefined
+    reference.
+  - **Fix**: extracted the strict gate's acceptance logic
+    (`validatePolicyMatchAddressesStrict`, #2008/#3294) into two shared
+    helpers in `compiler_validate_strict.go` —
+    `policyMatchNamedAddressRefs` (address-book entries + feed bindings) and
+    `policyMatchAddressTokenRecognized` (the any/literal/named predicate) —
+    and had BOTH the strict gate and the warn pass call them, so they cannot
+    diverge again. The warn pass now warns only for a token that is NONE of
+    {any/any-ipv4/any-ipv6, literal CIDR/IP, feed binding, address-book
+    entry}. The address-set MEMBER validation keeps its own
+    address-book-only set (feed-in-set stays not strict-accepted, #3294).
+  - **File(s)**: `pkg/config/compiler_validate_warn.go`,
+    `pkg/config/compiler_validate_strict.go`,
+    `pkg/config/compiler_addrbook_warn_3958_test.go` (new),
+    `pkg/config/README.md`, `_Log.md`
+  - **Validation**: new `TestValidateWarnAddressRefFormsNoFalsePositive`
+    (RED-on-revert: reverting the predicate re-emits false warnings for the
+    literal / any-ipv4 / any-ipv6 / feed forms) +
+    `TestValidateWarnAddressRefUndefinedStillWarns` (a genuinely undefined
+    token still warns). `go test ./pkg/config/...` green; `go build ./...`,
+    gofmt, and `go vet ./pkg/config/` clean.
+
 ## 2026-07-03 — #3954: RSS idempotence probe misparsed `ethtool -x` when the hash key's first byte was decimal-looking → spurious `ethtool -X` rewrite mid-traffic (~39% of boots)
 
 - **Timestamp**: 2026-07-03

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -257,6 +257,31 @@ such a policy, so a leniently-loaded bad config is no worse off, now flagged. Th
 lenient path and for unreferenced sets (which never reach the runtime gate, so
 they stay warn-only). Same fail-closed-on-load doctrine as #3144/#3146.
 
+**Warn pass must agree with strict on the valid address-reference forms
+(#3958):** the non-fatal `ValidateConfig` warn pass
+(`compiler_validate_warn.go`) emits a `policy … source/destination-address …
+not in address-book` advisory for a policy address token it does not recognize.
+It previously excluded only the bare `any` keyword and address-book entry names,
+so it drew a FALSE warning for every OTHER valid reference form on a perfectly
+good policy: a literal IPv4/IPv6 address or CIDR (`10.0.0.0/8`, `2001:db8::/32`
+— including the `0.0.0.0/0` / `::/0` that `compilePolicy` normalizes `any-ipv4` /
+`any-ipv6` to), the `any-ipv4` / `any-ipv6` wildcards, and a dynamic-address
+FEED binding name (a direct #2049/#3294 reference). Spurious warnings on normal
+commits train operators to ignore validation output (alarm fatigue), burying a
+REAL undefined-reference warning. The strict commit gate
+`validatePolicyMatchAddressesStrict` (#2008/#3294) already accepts exactly these
+forms; the warn pass had drifted. The acceptance logic is now a single source of
+truth — `policyMatchNamedAddressRefs` (address-book entries + feed bindings) and
+`policyMatchAddressTokenRecognized` (the `any`/literal/named predicate) in
+`compiler_validate_strict.go` — that BOTH the strict gate and the warn pass call,
+so they cannot diverge again. The warn pass now warns only for a token that is
+NONE of {`any`/`any-ipv4`/`any-ipv6`, literal CIDR/IP, feed binding, address-book
+entry} — a genuinely undefined reference, which still warns (and is hard-rejected
+by #2008 on the strict commit path). The address-set MEMBER validation keeps its
+own address-book-only set: a feed binding nested in an address-set stays
+deliberately NOT strict-accepted (#3294 anti-Option-C), so it is not added to the
+member-check set.
+
 **Zone-local address books (#3061):** Junos supports both the global
 `security address-book global { ... }` and a per-zone book attached inline
 under `security zones security-zone <z> address-book { address ...;

--- a/pkg/config/compiler_addrbook_warn_3958_test.go
+++ b/pkg/config/compiler_addrbook_warn_3958_test.go
@@ -1,0 +1,131 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// buildTree3958 compiles a flat set-command list into a ConfigTree via the
+// ParseSetCommand + SetPath loop the CLI uses (NewParser merges newline-
+// separated set lines into one node and must not be used for set syntax — see
+// CLAUDE.md "Testing flat set syntax").
+func buildTree3958(t *testing.T, cmds []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// policyAddrBookWarnings returns the "not in address-book" warnings emitted by
+// ValidateConfig for a POLICY source/destination-address reference. It excludes
+// the distinct address-set MEMBER warning ("address-set %q: member ...") which
+// also carries the "not in address-book" phrase but is a different check.
+func policyAddrBookWarnings(cfg *Config) []string {
+	var out []string
+	for _, w := range ValidateConfig(cfg) {
+		if strings.Contains(w, "not in address-book") && strings.HasPrefix(w, "policy ") {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+// TestValidateWarnAddressRefFormsNoFalsePositive is the #3958 RED-on-revert
+// guard. The ValidateConfig warn pass must NOT emit a spurious "not in
+// address-book" warning for any legitimate policy source/destination-address
+// reference form that is not a plain address-book name:
+//
+//   - a literal IPv4/IPv6 address or CIDR,
+//   - the any / any-ipv4 / any-ipv6 wildcards (any-ipv4/any-ipv6 also surface as
+//     the literal 0.0.0.0/0 / ::/0 after compilePolicy normalization),
+//   - a dynamic-address feed binding name (a direct #2049/#3294 feed reference),
+//   - an address-book address-set name.
+//
+// RED-on-revert: restore the old `addr != "any" && !addrs[addr]` check in
+// compiler_validate_warn.go and every literal / any-ipv4 / any-ipv6 / feed
+// reference below draws a false warning, turning this test RED. (The address-set
+// form was already covered by the folded book set, so it is asserted here as a
+// contract but is not by itself the reverting signal.)
+func TestValidateWarnAddressRefFormsNoFalsePositive(t *testing.T) {
+	cmds := []string{
+		// dynamic-address feed binding
+		"set security dynamic-address feed-server threat url https://feeds.example/list.txt",
+		"set security dynamic-address feed-server threat feed-name malware path /malware.txt",
+		"set security dynamic-address address-name bad-actors profile feed-name malware",
+		// address-book entry + address-set
+		"set security address-book global address good-host 10.0.0.0/8",
+		"set security address-book global address-set trusted address good-host",
+		"set security zones security-zone lan interfaces ge-0-0-1.0",
+		"set security zones security-zone wan interfaces ge-0-0-2.0",
+
+		// literal IPv4 CIDR + bare IPv6 literal
+		"set security policies from-zone lan to-zone wan policy lit match source-address 10.0.0.0/8",
+		"set security policies from-zone lan to-zone wan policy lit match destination-address 2001:db8::/32",
+		"set security policies from-zone lan to-zone wan policy lit match application any",
+		"set security policies from-zone lan to-zone wan policy lit then permit",
+
+		// any / any-ipv4 / any-ipv6 wildcards
+		"set security policies from-zone lan to-zone wan policy wild match source-address any-ipv4",
+		"set security policies from-zone lan to-zone wan policy wild match destination-address any-ipv6",
+		"set security policies from-zone lan to-zone wan policy wild match application any",
+		"set security policies from-zone lan to-zone wan policy wild then permit",
+
+		// feed binding name (direct) + address-set name
+		"set security policies from-zone lan to-zone wan policy named match source-address bad-actors",
+		"set security policies from-zone lan to-zone wan policy named match destination-address trusted",
+		"set security policies from-zone lan to-zone wan policy named match application any",
+		"set security policies from-zone lan to-zone wan policy named then deny",
+	}
+	tree := buildTree3958(t, cmds)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		// The strict gate accepts every one of these forms; a failure here would
+		// mean the warn/strict paths disagree, which is exactly what #3958 fixes.
+		t.Fatalf("CompileConfig rejected a legitimate policy address form: %v", err)
+	}
+	if got := policyAddrBookWarnings(cfg); len(got) != 0 {
+		t.Fatalf("expected NO policy 'not in address-book' warning for legitimate "+
+			"literal/any/feed/address-set references, got: %v", got)
+	}
+}
+
+// TestValidateWarnAddressRefUndefinedStillWarns pins the other half of the
+// contract: a genuinely undefined policy address name (none of literal / any /
+// feed / address-set / address-book entry) must STILL warn. Compiled on the
+// lenient path so the strict #2008 gate does not hard-reject it before the warn
+// pass runs (an already-persisted / peer-synced config an older binary
+// accepted).
+func TestValidateWarnAddressRefUndefinedStillWarns(t *testing.T) {
+	cmds := []string{
+		"set security zones security-zone lan interfaces ge-0-0-1.0",
+		"set security zones security-zone wan interfaces ge-0-0-2.0",
+		"set security policies from-zone lan to-zone wan policy p match source-address totally-bogus",
+		"set security policies from-zone lan to-zone wan policy p match destination-address any",
+		"set security policies from-zone lan to-zone wan policy p match application any",
+		"set security policies from-zone lan to-zone wan policy p then permit",
+	}
+	tree := buildTree3958(t, cmds)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile must not fail on a typo'd policy address: %v", err)
+	}
+	found := false
+	for _, w := range policyAddrBookWarnings(cfg) {
+		if strings.Contains(w, "totally-bogus") && strings.Contains(w, "source-address") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a 'not in address-book' warning for the undefined token "+
+			"totally-bogus, got: %v", ValidateConfig(cfg))
+	}
+}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -1990,46 +1990,72 @@ func validateApplicationSetMembersStrict(cfg *Config) error {
 // are an address-book construct (expanded to /32s under the book) and
 // are referenced from a policy only by book NAME, so no range form
 // reaches this token list.
+// policyMatchNamedAddressRefs collects every NAME that is a valid non-literal
+// policy source/destination-address reference: an address-book entry (an
+// Address or an AddressSet, global or already folded from a zone-local book)
+// and a dynamic-address feed binding name. It is the single source of truth for
+// the named-reference set that both the strict commit gate
+// (validatePolicyMatchAddressesStrict, #2008/#3294) and the non-fatal warn pass
+// (compiler_validate_warn.go, #3958) consult, so the two cannot drift and emit
+// a spurious "not in address-book" warning for a form the strict path accepts.
+//
+// The dynamic-address feed binding NAME is included because the userspace
+// dataplane resolves it as a DIRECT policy address token via the feed overlay
+// (#2049/#3294) and enforces the live feed prefixes. Scope note: this set is
+// for the DIRECT policy reference only — policyMatchAddressBookResolves (#3149)
+// stays feed-UNaware so a feed member nested in an address-set still poisons its
+// set at strict (the anti-Option-C guardrail; feed-in-set enforcement rides the
+// dataplane set-row merge, not a strict-accept here).
+func policyMatchNamedAddressRefs(cfg *Config) map[string]bool {
+	names := make(map[string]bool)
+	if cfg == nil {
+		return names
+	}
+	if ab := cfg.Security.AddressBook; ab != nil {
+		for name := range ab.Addresses {
+			names[name] = true
+		}
+		for name := range ab.AddressSets {
+			names[name] = true
+		}
+	}
+	for name := range cfg.Security.DynamicAddress.AddressBindings {
+		names[name] = true
+	}
+	return names
+}
+
+// policyMatchAddressTokenRecognized reports whether tok is a syntactically
+// recognized policy source/destination-address reference of ANY form: the
+// reserved wildcards (`any` / `any-ipv4` / `any-ipv6` / the empty token), a
+// literal CIDR or bare IP, or a name in `named` (an address-book entry or a
+// dynamic-address feed binding — see policyMatchNamedAddressRefs). It is the
+// exact acceptance predicate validatePolicyMatchAddressesStrict (#2008/#3294)
+// uses, factored out so the warn pass agrees with strict (#3958). It reports
+// only that the token is a well-formed reference form, NOT that a named
+// address-set's members fully resolve — that deeper check is #3149's domain
+// (validatePolicyMatchAddressSetMembersStrict).
+func policyMatchAddressTokenRecognized(tok string, named map[string]bool) bool {
+	switch tok {
+	case "", "any", "any-ipv4", "any-ipv6":
+		return true
+	}
+	if named[tok] {
+		return true
+	}
+	if _, _, err := net.ParseCIDR(tok); err == nil {
+		return true
+	}
+	return net.ParseIP(tok) != nil
+}
+
 func validatePolicyMatchAddressesStrict(cfg *Config) error {
 	if cfg == nil {
 		return nil
 	}
-	// Collect valid address-book names (Addresses + AddressSets).
-	bookNames := make(map[string]bool)
-	if ab := cfg.Security.AddressBook; ab != nil {
-		for name := range ab.Addresses {
-			bookNames[name] = true
-		}
-		for name := range ab.AddressSets {
-			bookNames[name] = true
-		}
-	}
-	// #3294: a dynamic-address feed binding NAME is a valid DIRECT policy
-	// address token — the userspace dataplane resolves it via the feed overlay
-	// (#2049) and enforces the live feed prefixes. Recognize it here so a direct
-	// feed reference COMMITS instead of being rejected as an undefined token
-	// (the documented #2049 feed-in-policy feature was un-committable under
-	// strict). Deliberately scoped to THIS top-level gate only:
-	// policyMatchAddressBookResolves (#3149) must stay feed-UNaware so a feed
-	// member nested in an address-set still poisons its set at strict — feeding
-	// it through the shared recursive resolver would strict-accept feed-in-set
-	// (the anti-Option-C guardrail; feed-in-set enforcement on the lenient path
-	// is handled by the dataplane set-row merge, not by strict-accepting it).
-	for name := range cfg.Security.DynamicAddress.AddressBindings {
-		bookNames[name] = true
-	}
+	bookNames := policyMatchNamedAddressRefs(cfg)
 	validToken := func(tok string) bool {
-		switch tok {
-		case "", "any", "any-ipv4", "any-ipv6":
-			return true
-		}
-		if bookNames[tok] {
-			return true
-		}
-		if _, _, err := net.ParseCIDR(tok); err == nil {
-			return true
-		}
-		return net.ParseIP(tok) != nil
+		return policyMatchAddressTokenRecognized(tok, bookNames)
 	}
 	check := func(scope string, pol *Policy) error {
 		if pol == nil {

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -84,7 +84,10 @@ func ValidateConfig(cfg *Config) []string {
 		zones[name] = true
 	}
 
-	// Collect valid address-book entries
+	// Collect valid address-book entries (Addresses + AddressSets). Used by the
+	// address-set member validation below, which deliberately does NOT accept a
+	// dynamic-address feed binding as a set member (feed-in-set is enforced on
+	// the dataplane set-row merge, not strict-accepted — #3294).
 	addrs := make(map[string]bool)
 	if ab := cfg.Security.AddressBook; ab != nil {
 		for name := range ab.Addresses {
@@ -94,6 +97,20 @@ func ValidateConfig(cfg *Config) []string {
 			addrs[name] = true
 		}
 	}
+
+	// #3958: a policy source/destination-address reference is valid in several
+	// forms that are NOT plain address-book names — the `any`/`any-ipv4`/
+	// `any-ipv6` wildcards, a literal IPv4/IPv6 address or CIDR, and a
+	// dynamic-address feed binding name. The previous warn check only excluded
+	// `any` and address-book entries, so it emitted a false "not in
+	// address-book" warning for every literal / any-ipv4 / any-ipv6 / feed
+	// reference in a perfectly valid policy — alarm fatigue that trains
+	// operators to ignore validation warnings. Mirror the strict gate
+	// (validatePolicyMatchAddressesStrict, #2008/#3294) EXACTLY via the shared
+	// policyMatchAddressTokenRecognized predicate so the warn pass and the
+	// strict path cannot diverge; only a token recognized by NONE of the valid
+	// forms — a genuinely undefined reference — still warns.
+	policyAddrRefs := policyMatchNamedAddressRefs(cfg)
 
 	// Validate application port specs and protocols
 	for name, app := range cfg.Applications.Applications {
@@ -149,13 +166,13 @@ func ValidateConfig(cfg *Config) []string {
 				continue
 			}
 			for _, addr := range p.Match.SourceAddresses {
-				if addr != "any" && !addrs[addr] {
+				if !policyMatchAddressTokenRecognized(addr, policyAddrRefs) {
 					warnings = append(warnings, fmt.Sprintf(
 						"policy %q: source-address %q not in address-book", p.Name, addr))
 				}
 			}
 			for _, addr := range p.Match.DestinationAddresses {
-				if addr != "any" && !addrs[addr] {
+				if !policyMatchAddressTokenRecognized(addr, policyAddrRefs) {
 					warnings = append(warnings, fmt.Sprintf(
 						"policy %q: destination-address %q not in address-book", p.Name, addr))
 				}


### PR DESCRIPTION
Closes #3958

## Problem

The non-fatal `ValidateConfig` warn pass (`compiler_validate_warn.go`)
checked a policy `match source-address` / `match destination-address`
token against only the address-book entry set plus the bare `any`
keyword. Every OTHER legitimate reference form drew a spurious
`policy … not in address-book` warning on a perfectly valid policy:

- a literal IPv4/IPv6 address or CIDR (`10.0.0.0/8`, `2001:db8::/32`) —
  including the `0.0.0.0/0` / `::/0` that `compilePolicy` normalizes
  `any-ipv4` / `any-ipv6` to;
- the family-scoped wildcards `any-ipv4` / `any-ipv6`;
- a dynamic-address FEED binding name (a direct #2049/#3294 feed
  reference the dataplane resolves via the feed overlay).

Spurious warnings on normal commits train operators to ignore
validation output (alarm fatigue) so a REAL undefined-reference warning
gets lost in the noise.

## Fix

The strict commit gate `validatePolicyMatchAddressesStrict`
(#2008/#3294) already accepts exactly these forms; the warn pass had
drifted from it. Extract the strict gate's acceptance logic into two
shared helpers in `compiler_validate_strict.go` —
`policyMatchNamedAddressRefs` (address-book entries + feed bindings) and
`policyMatchAddressTokenRecognized` (the any/literal/named predicate) —
and have BOTH the strict gate and the warn pass call them, so the two
paths cannot diverge again. The warn pass now warns only for a token
that is NONE of {`any`/`any-ipv4`/`any-ipv6`, literal CIDR/IP, feed
binding, address-book entry} — a genuinely undefined reference (still
hard-rejected by #2008 on the strict commit path).

Address-set names were already covered (the warn set folds
`AddressSets`); the address-set MEMBER validation keeps its own
address-book-only set — a feed binding nested in an address-set stays
deliberately NOT strict-accepted (#3294 anti-Option-C).

## Testing

- `TestValidateWarnAddressRefFormsNoFalsePositive` — a literal CIDR,
  bare IPv6 literal, `any-ipv4` / `any-ipv6`, a feed binding name, and an
  address-set name all COMMIT under strict and draw NO
  `not in address-book` warning. **RED-on-revert**: temporarily
  restoring the old `addr != "any" && !addrs[addr]` predicate re-emitted
  the false warnings for `10.0.0.0/8`, `2001:db8::/32`, `0.0.0.0/0`,
  `::/0`, and the feed binding `bad-actors` (verified).
- `TestValidateWarnAddressRefUndefinedStillWarns` — a genuinely
  undefined token still warns on the lenient path.
- `go test ./pkg/config/...` green; `go build ./...`, gofmt, and
  `go vet ./pkg/config/` clean.

Docs: `pkg/config/README.md` (warn/strict single-source-of-truth),
`_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
