### PR TITLE
dhcprelay: re-resolve giaddr on a same-ifindex address change (#3960)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -30037,3 +30037,39 @@ top.
   - **File(s)**: pkg/daemon/daemon.go, pkg/daemon/daemon_flow.go,
     pkg/daemon/daemon_flowtrace_3932_test.go, pkg/logging/trace.go,
     pkg/logging/README.md, _Log.md
+- **Timestamp**: 2026-07-03
+  - **Action**: #3960 — DHCP relay `giaddr` not re-resolved on a same-ifindex
+    interface address change → relayed reply path silently breaks. The relay
+    (`pkg/dhcprelay`) resolved `giaddr` (its own interface IPv4, the source the
+    upstream server unicasts `OFFER`/`ACK` back to at `giaddr:67`) ONCE at
+    session start in `runRelaySession`, then consumed it in three places: the
+    server conn's `giaddr:67` bind, the per-packet `GatewayIPAddr` stamp, and
+    the raw-L2 reply source IP. A same-ifindex readdress (DHCP lease renew to a
+    new IP, static readdress, HA VIP move on the same netdev) left all three
+    STALE — the server replied to the old address AND the server conn stayed
+    bound to the old `giaddr:67`, so replies were blackholed and relayed clients
+    stopped getting leases. The #2347 ifindex-drift watcher only rebuilt on an
+    ifindex change, never on an address change. Fix: fold primary-IPv4
+    re-resolution into that same periodic watcher — on each tick it now
+    re-resolves `m.resolveGIAddr(ifaceName)` and compares against the session's
+    bound `giaddr`; a real, differing address records a new `sessionReaddr`
+    outcome and cancels the session context (reusing the #1915 close-on-cancel +
+    WaitGroup teardown). `runRelay` rebuilds immediately, which re-resolves the
+    `giaddr`, rebinds the server conn to the new `giaddr:67`, and makes the new
+    main loop stamp the current address — fixing all three consumers atomically
+    (a bare per-relay re-stamp would be WORSE: the server would reply to the new
+    `giaddr:67` with nothing bound there until the rebuild). Tolerant like the
+    ifindex probe: a momentarily unaddressed interface (resolve failure) keeps
+    the last-known-good `giaddr` and never tears down or stamps a bogus giaddr;
+    idempotent (unchanged address => no rebuild). RED-on-revert tests
+    (`relay_test.go`): `TestRunRelay_AddressReaddr_RebindsGiaddr` (readdress →
+    gen-2 server conn rebinds to the NEW giaddr; revert → no rebuild → 2 factory
+    calls → RED), `TestRunRelay_AddressReaddr_StampsNewGiaddr` (seeded gen-2
+    request carries the new giaddr end to end), plus negative controls
+    `TestRunRelay_AddressStable_NoRebind` and
+    `TestRunRelay_AddressResolveFailure_KeepsListener`. Confirmed RED by
+    neutering the readdr rebuild (both positive tests failed). `go test -race
+    ./pkg/dhcprelay/` green, `go build ./...`, gofmt, vet clean. Doc:
+    pkg/dhcprelay/README.md #3960 giaddr-re-resolution bullet.
+  - **File(s)**: pkg/dhcprelay/relay.go, pkg/dhcprelay/relay_test.go,
+    pkg/dhcprelay/README.md, _Log.md

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -309,6 +309,28 @@ OFFER/ACK to forward in the first place; clients still dedupe on
   rather than triggering a spurious rebind. Drift detection is per-interface,
   so a rebind on one segment never drops relays on the others. This mirrors
   the #2294 VRRP instance-restart-on-ifindex-drift fix for the relay listener.
+- **giaddr re-resolution on a same-ifindex readdress (#3960).** The `giaddr`
+  is the relay's own interface address — the source the upstream server
+  unicasts its `OFFER`/`ACK` back to (`giaddr:67`, above). It is resolved
+  **once** at session start and consumed in three places: the server conn's
+  `giaddr:67` bind, the per-packet `GatewayIPAddr` stamp, and the raw-L2 reply
+  source IP. If the interface's **primary IPv4 changes while its ifindex stays
+  the same** (a DHCP-learned lease renewing to a different IP, a static
+  readdress, or an HA VIP move on the same netdev), all three go **stale**: the
+  relay keeps stamping the old `giaddr`, the server replies to the old
+  (now-invalid) address, and even a corrected stamp would not help because the
+  server conn is still bound to the old `giaddr:67` — the reply is
+  **blackholed** and relayed clients silently stop getting leases. The
+  ifindex-drift watcher above now **also** re-resolves the primary IPv4 on each
+  tick and compares it against the `giaddr` the session bound at start; on a
+  real, differing address it records a **readdress** (`sessionReaddr`) and
+  cancels the session context, reusing the same #1915 teardown. The rebuild
+  re-resolves the `giaddr`, **rebinds the server conn** to the new
+  `giaddr:67`, and makes the new main loop stamp the current address — fixing
+  all three consumers atomically. Like the ifindex probe it is **tolerant**: a
+  momentarily unaddressed interface (resolve failure) keeps the last-known-good
+  `giaddr` and never tears down a working listener or stamps a bogus `giaddr`,
+  and it is **idempotent** (unchanged address => no rebuild).
 
 ## Gotchas
 

--- a/pkg/dhcprelay/relay.go
+++ b/pkg/dhcprelay/relay.go
@@ -81,6 +81,17 @@ const (
 	// sessionDrift means the interface's live kernel ifindex moved away from
 	// the bound ifindex (#2347); the supervisor rebuilds immediately to rebind.
 	sessionDrift
+	// sessionReaddr means the interface's PRIMARY IPv4 address changed while its
+	// ifindex stayed the same (#3960) — e.g. a DHCP-learned lease renewing to a
+	// different IP, a static readdress, or an HA VIP move on the same netdev. The
+	// session's giaddr (the source the DHCP server unicasts its reply back to) was
+	// resolved once at session start and is now STALE: the relay would keep
+	// stamping the old giaddr AND the server conn would stay bound to the old
+	// giaddr:67, so replies to the new address are blackholed and relayed clients
+	// stop getting leases. Like sessionDrift the supervisor rebuilds immediately,
+	// which re-resolves the giaddr, rebinds the server conn to the new address,
+	// and makes the new main loop stamp the current giaddr.
+	sessionReaddr
 	// sessionRetry means a TRANSIENT socket bind/listen failure occurred
 	// before the session could start (#2787). The supervisor waits the
 	// bounded, ctx-cancelable retry interval and rebuilds, so the relay
@@ -719,6 +730,17 @@ func (m *Manager) runRelay(ctx context.Context, cancel context.CancelFunc,
 			}
 			slog.Info("dhcp-relay: interface ifindex changed, rebinding listener",
 				"interface", ir.ifaceName)
+		case sessionReaddr:
+			// The interface's primary IPv4 changed under a stable ifindex
+			// (#3960): rebuild immediately so the giaddr is re-resolved, the
+			// server conn rebinds to the new giaddr:67, and the new main loop
+			// stamps the current address. No delay — the reply path is broken
+			// until the rebuild completes.
+			if ctx.Err() != nil {
+				return
+			}
+			slog.Info("dhcp-relay: interface address changed, re-resolving giaddr",
+				"interface", ir.ifaceName)
 		case sessionRetry:
 			// A transient socket bind/listen failure (interface not yet up,
 			// IP not yet bound, EADDRINUSE on a quick reload). Do NOT kill the
@@ -769,10 +791,12 @@ func (m *Manager) runRelaySession(ctx context.Context,
 	sctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// driftDetected is set by the watcher under no lock other than its own
-	// happens-before with wg.Wait(): the watcher writes it then the session
-	// returns after wg.Wait() joins the watcher, so the read below is safe.
+	// driftDetected (ifindex, #2347) and readdrDetected (primary-IPv4 change,
+	// #3960) are set by the watcher under no lock other than its own
+	// happens-before with wg.Wait(): the watcher writes them then the session
+	// returns after wg.Wait() joins the watcher, so the reads below are safe.
 	var driftDetected atomic.Bool
+	var readdrDetected atomic.Bool
 
 	// Axis C1: resolve giaddr with bounded, ctx-cancelable retry. Re-resolve
 	// the interface every attempt so a dynamic interface recreated under the
@@ -909,15 +933,20 @@ func (m *Manager) runRelaySession(ctx context.Context,
 		_ = serverConn.Close()
 	}()
 
-	// #2347 ifindex-drift watcher. Periodically re-resolve the interface name
-	// to its live ifindex and compare against the baseline captured at bind. On
-	// a real, differing index it records drift and cancels THIS session ctx,
-	// which trips the close-on-cancel watcher above (clean teardown) and makes
-	// runRelay rebuild bound to the new ifindex. A resolve FAILURE is treated
-	// as "no drift" (tolerant) so a transient netlink hiccup / mid-rename window
-	// never tears down a working listener. Disabled when ifindexCheck<=0 or no
-	// resolver, and a degraded baseline (boundIfindex==0) means we only treat a
-	// later real index as drift if the baseline was real — see the guard below.
+	// #2347 ifindex-drift + #3960 primary-IPv4 (giaddr) re-resolution watcher.
+	// Periodically re-resolve the interface. On a real, differing live ifindex it
+	// records drift (#2347); on a real, differing primary IPv4 it records a
+	// readdress (#3960). Either cancels THIS session ctx, which trips the
+	// close-on-cancel watcher above (clean teardown) and makes runRelay rebuild —
+	// rebinding to the new ifindex (#2347) and/or re-resolving the giaddr + the
+	// server conn's giaddr:67 bind (#3960). A resolve FAILURE (either lookup) is
+	// treated as "no change" (tolerant) so a transient netlink hiccup, a
+	// mid-rename window, or a momentarily unaddressed interface never tears down a
+	// working listener — and never stamps a bogus giaddr, since the session keeps
+	// its last-known-good giaddr until a real new address appears. Disabled when
+	// ifindexCheck<=0 or no ifindex resolver; a degraded ifindex baseline
+	// (boundIfindex==0) treats a later real index as drift only if the baseline
+	// was real (see the guard below).
 	if m.ifindexCheck > 0 && m.resolveIfindex != nil {
 		wg.Add(1)
 		go func() {
@@ -929,27 +958,48 @@ func (m *Manager) runRelaySession(ctx context.Context,
 				case <-sctx.Done():
 					return
 				case <-ticker.C:
-					live, lerr := m.resolveIfindex(ifaceName)
-					if lerr != nil {
+					// #2347: ifindex drift.
+					if live, lerr := m.resolveIfindex(ifaceName); lerr != nil {
 						// Tolerant: keep the listener; this is not drift.
 						slog.Debug("dhcp-relay: ifindex re-resolve failed, keeping listener",
 							"interface", ifaceName, "err", lerr)
-						continue
-					}
-					// Only a real baseline can be compared. boundIfindex==0
-					// (degraded capture) adopts the first real reading as the
-					// baseline rather than treating it as drift.
-					if boundIfindex == 0 {
+					} else if boundIfindex == 0 {
+						// Degraded capture: adopt the first real reading as the
+						// baseline rather than treating it as drift.
 						boundIfindex = live
-						continue
-					}
-					if live != boundIfindex {
+					} else if live != boundIfindex {
 						slog.Info("dhcp-relay: detected ifindex drift",
 							"interface", ifaceName,
 							"old_ifindex", boundIfindex, "new_ifindex", live)
 						driftDetected.Store(true)
 						cancel()
 						return
+					}
+
+					// #3960: primary-IPv4 (giaddr) change under a stable ifindex.
+					// Re-resolve the current primary address and compare against
+					// the giaddr this session bound at start. A differing address
+					// means the DHCP server would unicast its OFFER/ACK to the old
+					// (now-invalid) giaddr:67 and the reply is blackholed — rebuild
+					// so the giaddr is re-resolved, the server conn rebinds to the
+					// new giaddr:67, and the new main loop stamps the current
+					// address. Runs every tick regardless of the ifindex result
+					// (an address can change while the ifindex is stable).
+					if m.resolveGIAddr != nil {
+						if cur, gerr := m.resolveGIAddr(ifaceName); gerr != nil {
+							// Tolerant: a momentary unaddressed window keeps the
+							// last-known-good giaddr rather than tearing down (and
+							// so never stamps a bogus giaddr).
+							slog.Debug("dhcp-relay: giaddr re-resolve failed, keeping listener",
+								"interface", ifaceName, "err", gerr)
+						} else if !cur.Equal(giaddr) {
+							slog.Info("dhcp-relay: detected giaddr address change",
+								"interface", ifaceName,
+								"old_giaddr", giaddr, "new_giaddr", cur)
+							readdrDetected.Store(true)
+							cancel()
+							return
+						}
 					}
 				}
 			}
@@ -1062,10 +1112,15 @@ func (m *Manager) runRelaySession(ctx context.Context,
 	// closed both conns and the response goroutine's ReadFrom is unblocked.
 	wg.Wait()
 
-	// The drift watcher (joined above) is the only writer of driftDetected; its
-	// store happens-before this read through wg.Wait().
+	// The watcher (joined above) is the only writer of driftDetected /
+	// readdrDetected; its store happens-before these reads through wg.Wait().
+	// Both outcomes rebuild immediately in runRelay (a giaddr change breaks the
+	// reply path just as an ifindex drift breaks the request path).
 	if driftDetected.Load() {
 		return sessionDrift
+	}
+	if readdrDetected.Load() {
+		return sessionReaddr
 	}
 	return sessionStop
 }

--- a/pkg/dhcprelay/relay_test.go
+++ b/pkg/dhcprelay/relay_test.go
@@ -1555,6 +1555,196 @@ func TestRunRelay_DegradedBaseline_AdoptsFirstRealIfindex(t *testing.T) {
 	}
 }
 
+// --- #3960 primary-IPv4 (giaddr) re-resolution ---
+
+// giaddrResolver returns an ifaceResolver backed by an atomic address (so a test
+// can readdress the interface mid-flight) plus an atomic error toggle (so a test
+// can simulate the interface losing its address). It also counts calls. The
+// stored value is always a net.IP, so atomic.Value's same-type rule holds.
+func giaddrResolver(initial net.IP) (ifaceResolver, *atomic.Value, *atomic.Bool, *atomic.Int64) {
+	addr := &atomic.Value{}
+	addr.Store(initial)
+	failing := &atomic.Bool{}
+	calls := &atomic.Int64{}
+	r := func(ifaceName string) (net.IP, error) {
+		calls.Add(1)
+		if failing.Load() {
+			return nil, errors.New("no IPv4 address")
+		}
+		return addr.Load().(net.IP), nil
+	}
+	return r, addr, failing, calls
+}
+
+// serverConnBinds returns, in factory-call order, the bind IPs of the server
+// conns (the non-wildcard binds; the client listener binds 0.0.0.0).
+func serverConnBinds(calls []factoryCall) []net.IP {
+	var out []net.IP
+	for _, c := range calls {
+		if !c.bindAddr.IP.Equal(net.IPv4zero) {
+			out = append(out, c.bindAddr.IP)
+		}
+	}
+	return out
+}
+
+// TestRunRelay_AddressReaddr_RebindsGiaddr proves the #3960 fix: when the relay
+// interface's PRIMARY IPv4 changes under a STABLE ifindex (DHCP renew to a new
+// IP, static readdress, HA VIP move on the same netdev), the relay tears down
+// the session and rebuilds — re-resolving the giaddr so the server conn rebinds
+// to the NEW giaddr:67. Asserted via the factory: gen-1 opens 2 conns bound to
+// the old giaddr; after readdress the supervisor rebuilds, opening 2 more with
+// the server conn bound to the NEW giaddr.
+//
+// FAIL-ON-REVERT: revert the #3960 re-resolution and the watcher never detects
+// the address change → no rebuild → stuck at 2 factory calls → waitCalls times
+// out → RED. The server stays bound to the old (now-invalid) giaddr:67 and every
+// reply is blackholed.
+func TestRunRelay_AddressReaddr_RebindsGiaddr(t *testing.T) {
+	factory, getCalls := recordingFactory()
+	m := testManager(factory)
+	defer m.Stop()
+
+	resolve, addr, _, _ := giaddrResolver(net.IPv4(10, 0, 0, 254))
+	m.resolveGIAddr = resolve
+	m.ifindexCheck = 5 * time.Millisecond // reuse the watcher cadence
+
+	m.Apply(context.Background(), singleInterfaceConfig())
+	waitRelays(t, m, 1, 2*time.Second)
+	calls := waitCalls(t, getCalls, 2, 2*time.Second) // gen-1 client + server
+
+	if binds := serverConnBinds(calls); len(binds) != 1 ||
+		!binds[0].Equal(net.IPv4(10, 0, 0, 254)) {
+		t.Fatalf("gen-1 server conn binds = %v, want [10.0.0.254]", binds)
+	}
+
+	// Interface readdressed under the SAME ifindex.
+	addr.Store(net.IPv4(10, 0, 0, 99))
+
+	// The readdr watcher must cancel the session and the supervisor rebuild,
+	// producing 2 more factory calls (gen-2 client + server).
+	calls = waitCalls(t, getCalls, 4, 2*time.Second)
+
+	binds := serverConnBinds(calls)
+	if len(binds) < 2 {
+		t.Fatalf("expected >=2 server conns (original + rebind), got %d: %v", len(binds), binds)
+	}
+	if last := binds[len(binds)-1]; !last.Equal(net.IPv4(10, 0, 0, 99)) {
+		t.Errorf("rebound server conn bound %v, want the NEW giaddr 10.0.0.99 "+
+			"(server replies to giaddr:67 blackhole on the old address, #3960)", last)
+	}
+}
+
+// TestRunRelay_AddressReaddr_StampsNewGiaddr proves the request-side of the
+// #3960 fix end to end: after a same-ifindex readdress the NEXT relayed request
+// carries the NEW giaddr (not the stale one the server would reply to and
+// blackhole). The gen-2 client conn is seeded with a DHCPREQUEST; the rebuilt
+// session relays it stamped with the new address.
+func TestRunRelay_AddressReaddr_StampsNewGiaddr(t *testing.T) {
+	client1 := newFakeConn()
+	server1 := newFakeConn()
+	client2 := newFakeConn()
+	client2.pending = [][]byte{makeRequest(t)}
+	server2 := newFakeConn()
+	factory, getCalls := recordingFactory(client1, server1, client2, server2)
+	m := testManager(factory)
+	defer m.Stop()
+
+	resolve, addr, _, _ := giaddrResolver(net.IPv4(10, 0, 0, 254))
+	m.resolveGIAddr = resolve
+	m.ifindexCheck = 5 * time.Millisecond
+
+	m.Apply(context.Background(), singleInterfaceConfig())
+	waitRelays(t, m, 1, 2*time.Second)
+	waitCalls(t, getCalls, 2, 2*time.Second) // gen-1 client + server
+
+	// Readdress -> rebuild -> gen-2 relays the seeded request.
+	addr.Store(net.IPv4(10, 0, 0, 99))
+	waitCalls(t, getCalls, 4, 2*time.Second) // gen-2 client + server
+
+	deadline := time.Now().Add(2 * time.Second)
+	for server2.writeCount() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if server2.writeCount() == 0 {
+		t.Fatal("gen-2 session did not relay the request after readdress")
+	}
+	relayed, err := dhcpv4.FromBytes(server2.firstWrite(t))
+	if err != nil {
+		t.Fatalf("relayed datagram does not parse: %v", err)
+	}
+	if !relayed.GatewayIPAddr.Equal(net.IPv4(10, 0, 0, 99)) {
+		t.Errorf("relayed giaddr = %v, want the NEW 10.0.0.99 "+
+			"(stale giaddr -> server reply blackholed, #3960)", relayed.GatewayIPAddr)
+	}
+}
+
+// TestRunRelay_AddressStable_NoRebind proves idempotency: with the primary IPv4
+// never changing, the watcher re-resolves the giaddr repeatedly but never
+// restarts the session. The factory is called exactly twice for the lifetime.
+func TestRunRelay_AddressStable_NoRebind(t *testing.T) {
+	factory, getCalls := recordingFactory()
+	m := testManager(factory)
+	defer m.Stop()
+
+	resolve, _, _, calls := giaddrResolver(net.IPv4(10, 0, 0, 254))
+	m.resolveGIAddr = resolve
+	m.ifindexCheck = 2 * time.Millisecond
+
+	m.Apply(context.Background(), singleInterfaceConfig())
+	waitRelays(t, m, 1, 2*time.Second)
+	waitCalls(t, getCalls, 2, 2*time.Second)
+
+	// Let the watcher tick many times against a stable address.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) && calls.Load() < 10 {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if calls.Load() < 5 {
+		t.Fatalf("giaddr watcher did not run enough to be meaningful (%d resolves)", calls.Load())
+	}
+	if got := len(getCalls()); got != 2 {
+		t.Errorf("stable address must NOT rebind: got %d factory calls, want 2", got)
+	}
+}
+
+// TestRunRelay_AddressResolveFailure_KeepsListener proves the tolerant-resolve
+// invariant for #3960: a momentarily unaddressed interface (resolver errors "no
+// IPv4 address") must NOT tear down a working session (no rebuild, no socket
+// close) and must NOT stamp a bogus giaddr — the session keeps its
+// last-known-good giaddr until a real new address appears.
+func TestRunRelay_AddressResolveFailure_KeepsListener(t *testing.T) {
+	client := newFakeConn()
+	server := newFakeConn()
+	factory, getCalls := recordingFactory(client, server)
+	m := testManager(factory)
+	defer m.Stop()
+
+	resolve, _, failing, calls := giaddrResolver(net.IPv4(10, 0, 0, 254))
+	m.resolveGIAddr = resolve
+	m.ifindexCheck = 2 * time.Millisecond
+
+	m.Apply(context.Background(), singleInterfaceConfig())
+	waitRelays(t, m, 1, 2*time.Second)
+	waitCalls(t, getCalls, 2, 2*time.Second)
+
+	// The interface loses its address on every subsequent re-resolve.
+	failing.Store(true)
+
+	deadline := time.Now().Add(200 * time.Millisecond)
+	base := calls.Load()
+	for time.Now().Before(deadline) && calls.Load() < base+10 {
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	if got := len(getCalls()); got != 2 {
+		t.Errorf("giaddr resolve failure must NOT rebind: got %d factory calls, want 2", got)
+	}
+	if client.isClosed() || server.isClosed() {
+		t.Error("giaddr resolve failure must NOT tear down the working listener")
+	}
+}
+
 // makeRequest builds a DHCPREQUEST client packet for the master-gate tests.
 func makeRequest(t *testing.T) []byte {
 	t.Helper()


### PR DESCRIPTION
Closes #3960

## Problem

The DHCP relay (`pkg/dhcprelay`) resolves `giaddr` — its own interface
IPv4, the source the upstream server unicasts `OFFER`/`ACK` back to at
`giaddr:67` — **once** at session start in `runRelaySession`, then
consumes it in three places: the server conn's `giaddr:67` bind, the
per-packet `GatewayIPAddr` stamp, and the raw-L2 reply source IP.

When the interface's primary IPv4 changes while its **ifindex stays the
same** (a DHCP-learned lease renewing to a different IP, a static
readdress, or an HA VIP move on the same netdev) all three go stale:

- the relay keeps stamping the old `giaddr` → the server replies to the
  old (now-invalid) address, and
- even a corrected stamp would not help because the server conn is still
  bound to the old `giaddr:67`.

The reply is **blackholed** and relayed clients silently stop getting
leases (the relay still forwards requests). The #2347 ifindex-drift
watcher only rebuilt on an *ifindex* change, never on an address change
under a stable ifindex.

## Fix

Fold primary-IPv4 re-resolution into the same periodic watcher (`relay.go`,
`runRelaySession`). On each tick it re-resolves `m.resolveGIAddr(ifaceName)`
and compares against the `giaddr` the session bound at start; a real,
differing address records a new `sessionReaddr` outcome and cancels the
session context, reusing the #1915 close-on-cancel + WaitGroup teardown.
`runRelay` rebuilds immediately, which **re-resolves the giaddr, rebinds
the server conn to the new `giaddr:67`, and makes the new main loop stamp
the current address** — fixing all three consumers atomically.

A bare per-relay re-stamp alone would be *worse*: the server would reply
to the new `giaddr:67` with nothing bound there until the rebuild. The
watcher-rebuild is the atomic unit, so the request side (stamp) and the
reply side (server conn bind) never diverge.

Tolerant like the ifindex probe: a momentarily unaddressed interface
(resolve failure) keeps the last-known-good `giaddr` — it never tears down
a working listener or stamps a bogus giaddr — and it is idempotent
(unchanged address => no rebuild).

## Tests (RED-on-revert)

- `TestRunRelay_AddressReaddr_RebindsGiaddr` — a same-ifindex readdress
  rebuilds and the gen-2 server conn rebinds to the **new** giaddr. Revert
  the re-resolution → no rebuild → stuck at 2 factory calls → RED.
- `TestRunRelay_AddressReaddr_StampsNewGiaddr` — the next relayed request
  carries the new giaddr end to end (seeded gen-2 client → gen-2 server
  conn write parsed).
- `TestRunRelay_AddressStable_NoRebind` — negative control: unchanged
  address never rebuilds.
- `TestRunRelay_AddressResolveFailure_KeepsListener` — negative control: a
  lost-address window keeps the working session (no rebuild, no close).

Confirmed RED by neutering the readdr rebuild — both positive tests
failed. `go test -race ./pkg/dhcprelay/` green, `go build ./...`, `gofmt`,
`go vet` clean. Doc: `pkg/dhcprelay/README.md` #3960 bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
