### PR TITLE
userspace-dp: build screen snapshots in deterministic zone order (#3962)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-03 — #3962: buildScreenSnapshots ranged the zones map in nondeterministic order → wire byte order varied per build → snapshotContentHash dedup missed → dataplane re-applied the screen config on every reconcile
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-074 (MEDIUM, perf/churn). Both
+    `buildScreenSnapshots` and its sibling `buildScreenMissingProfileRefs`
+    (`pkg/dataplane/userspace/screens.go`) ranged the
+    `cfg.Security.Zones` map (`map[string]*ZoneConfig`) directly and
+    appended each row to a slice. Go map iteration order is randomized per
+    run, so the serialized `Screens` / `ScreenMissingProfiles` byte order
+    varied build-to-build even for an UNCHANGED config. That shifted
+    `snapshotContentHash` (`builder.go`) every build, the reconcile's
+    duplicate-publish dedup never matched, and the dataplane re-applied the
+    whole screen config on every reconcile (needless control-socket +
+    dataplane work; a screen re-apply can re-arm SYN-cookie state).
+  - **Fix**: both builders now collect the zone names, `sort.Strings` them,
+    and range in sorted-by-name order (the wire key == the map key) so the
+    serialized bytes are stable and the content hash matches → the reconcile
+    skips an unchanged screen snapshot. Matches the long-standing sorted
+    pattern in `buildZoneSnapshots` / `buildSYNCookieMasterKey`.
+  - **Audit**: swept the sibling snapshot builders. `buildZoneSnapshots`
+    and every zone-host-inbound builder (`zones.go`) already sort;
+    `buildSYNCookieMasterKey` sorts its hash input; the NAT / static-NAT /
+    NAT64 / tunnel / neighbor builders range config SLICES (already
+    ordered). The two screen builders were the only map-range-into-wire
+    nondeterminism feeding the content hash.
+  - **Test**: `TestBuildScreenSnapshotsDeterministicOrder`
+    (`manager_test.go`) builds a 10-zone config 64× and asserts the
+    marshaled `Screens` bytes + sha256 are identical every build (and the
+    output is sorted ascending), plus the same 64× byte-stability assertion
+    on `buildScreenMissingProfileRefs`. RED-on-revert verified: restoring
+    the bare `range cfg.Security.Zones` fails the test
+    (`snapshots not sorted by zone: "voice" before "video"`).
+  - **Validation**: `go test ./pkg/dataplane/...` green; `go build ./...`
+    green; `gofmt -l` clean; `go vet ./pkg/dataplane/userspace/` clean.
+  - **File(s)**: `pkg/dataplane/userspace/screens.go`,
+    `pkg/dataplane/userspace/manager_test.go`,
+    `docs/userspace-dataplane-architecture.md`, `_Log.md`
+
 ## 2026-07-03 — #3958: ValidateConfig warn pass emitted false "not in address-book" warnings for literal / any-ipv4 / any-ipv6 / dynamic-address-feed policy references → alarm fatigue
 
 - **Timestamp**: 2026-07-03

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -961,6 +961,24 @@ overlay. Four correctness invariants (#3770/#3772):
   was caught, so a two-table cycle burned to `MAX_NEXT_TABLE_DEPTH`)
   (#3768 M5+M6, `userspace-dp/src/afxdp/forwarding/mod.rs`).
 
+**Deterministic emission applies to EVERY map-backed snapshot builder, not
+just routes (#3962).** Any builder that ranges a Go `map` and appends the
+result into a `ConfigSnapshot` slice must iterate the map in a stable order,
+because that slice is serialized into the JSON that `snapshotContentHash`
+(`builder.go`) hashes for the duplicate-publish dedup. Go map iteration order
+is randomized per run, so ranging `cfg.Security.Zones` (a
+`map[string]*ZoneConfig`) directly produces a different wire byte order every
+build for an UNCHANGED config — the hash differs, the reconcile never skips,
+and the dataplane re-applies the config on every reconcile (needless
+control-socket + dataplane work; a screen re-apply can also re-arm SYN-cookie
+state). `buildScreenSnapshots` and its sibling `buildScreenMissingProfileRefs`
+(`screens.go`, feeding `Screens` / `ScreenMissingProfiles`) now collect the
+zone names, `sort.Strings` them, and range in sorted order — matching the
+long-standing pattern in `buildZoneSnapshots` (`zones.go`) and
+`buildSYNCookieMasterKey`. The syn-cookie master-key hash and all
+zone-host-inbound builders already sorted; the NAT / tunnel / neighbor
+builders range config SLICES (already ordered), so they were never affected.
+
 **Dynamic-address feed overlay (#2049).** The snapshot's address books carry
 the live `security dynamic-address` feed prefixes, not just the static
 `security address-book`. The daemon joins each `address-name ... profile

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -1,6 +1,8 @@
 package userspace
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -4317,6 +4319,86 @@ func TestBuildScreenSnapshotsMatchesZoneToProfile(t *testing.T) {
 	}
 	if snaps[0].ICMPFloodThreshold != 50 {
 		t.Fatalf("ICMPFloodThreshold = %d, want 50", snaps[0].ICMPFloodThreshold)
+	}
+}
+
+// #3962: buildScreenSnapshots must serialize the per-zone screen profiles in a
+// deterministic (sorted-by-zone-name) order. Before the fix it ranged the
+// cfg.Security.Zones map directly, so the wire byte order varied build-to-build
+// even for an UNCHANGED config. That shifted the snapshotContentHash every
+// build, defeated the reconcile dedup, and re-applied the whole screen config
+// on every reconcile. Building the snapshot many times from the same config
+// must yield byte-identical (and equal-hash) Screens output. Goes RED on
+// revert because map iteration order randomizes per run.
+func TestBuildScreenSnapshotsDeterministicOrder(t *testing.T) {
+	cfg := &config.Config{}
+	// Many zones, each enabling a screen check, so map-order randomization is
+	// overwhelmingly likely to reorder the output across N builds pre-fix.
+	cfg.Security.Zones = map[string]*config.ZoneConfig{}
+	cfg.Security.Screen = map[string]*config.ScreenProfile{}
+	zoneNames := []string{"trust", "untrust", "dmz", "wan", "lan", "guest", "mgmt", "iot", "voice", "video"}
+	for i, zn := range zoneNames {
+		profile := "prof-" + zn
+		cfg.Security.Zones[zn] = &config.ZoneConfig{Name: zn, ScreenProfile: profile}
+		cfg.Security.Screen[profile] = &config.ScreenProfile{
+			Name: profile,
+			TCP:  config.TCPScreen{Land: true, SynFin: i%2 == 0},
+			ICMP: config.ICMPScreen{FloodThreshold: i + 1},
+		}
+	}
+
+	first := buildScreenSnapshots(cfg)
+	if len(first) != len(zoneNames) {
+		t.Fatalf("len(first) = %d, want %d", len(first), len(zoneNames))
+	}
+	// Pin the deterministic contract: output is sorted ascending by zone name.
+	for i := 1; i < len(first); i++ {
+		if first[i-1].Zone >= first[i].Zone {
+			t.Fatalf("snapshots not sorted by zone: %q before %q", first[i-1].Zone, first[i].Zone)
+		}
+	}
+
+	firstJSON, err := json.Marshal(first)
+	if err != nil {
+		t.Fatalf("marshal first: %v", err)
+	}
+	firstHash := sha256.Sum256(firstJSON)
+
+	const iterations = 64
+	for n := 0; n < iterations; n++ {
+		got := buildScreenSnapshots(cfg)
+		gotJSON, err := json.Marshal(got)
+		if err != nil {
+			t.Fatalf("marshal iteration %d: %v", n, err)
+		}
+		if !bytes.Equal(firstJSON, gotJSON) {
+			t.Fatalf("iteration %d: screen snapshot bytes differ (nondeterministic order)\nfirst: %s\ngot:   %s",
+				n, firstJSON, gotJSON)
+		}
+		if sha256.Sum256(gotJSON) != firstHash {
+			t.Fatalf("iteration %d: content hash differs from first build", n)
+		}
+	}
+
+	// The missing-profile-refs sibling feeds ConfigSnapshot.ScreenMissingProfiles
+	// and so also feeds the content hash — it must be deterministic too. Point a
+	// few zones at undefined profiles.
+	for _, zn := range []string{"trust", "wan", "iot"} {
+		cfg.Security.Zones[zn].ScreenProfile = "does-not-exist-" + zn
+	}
+	firstMissing, err := json.Marshal(buildScreenMissingProfileRefs(cfg))
+	if err != nil {
+		t.Fatalf("marshal first missing: %v", err)
+	}
+	for n := 0; n < iterations; n++ {
+		gotMissing, err := json.Marshal(buildScreenMissingProfileRefs(cfg))
+		if err != nil {
+			t.Fatalf("marshal missing iteration %d: %v", n, err)
+		}
+		if !bytes.Equal(firstMissing, gotMissing) {
+			t.Fatalf("iteration %d: missing-profile-refs bytes differ (nondeterministic order)\nfirst: %s\ngot:   %s",
+				n, firstMissing, gotMissing)
+		}
 	}
 }
 

--- a/pkg/dataplane/userspace/screens.go
+++ b/pkg/dataplane/userspace/screens.go
@@ -13,7 +13,22 @@ func buildScreenSnapshots(cfg *config.Config) []ScreenProfileSnapshot {
 		return nil
 	}
 	var out []ScreenProfileSnapshot
-	for _, zone := range cfg.Security.Zones {
+	// Iterate zones in a deterministic (sorted-by-name) order. Ranging the
+	// cfg.Security.Zones map directly yields nondeterministic iteration order,
+	// which shifts the serialized snapshot's byte order build-to-build even
+	// for an UNCHANGED config. That defeats the snapshotContentHash dedup
+	// (builder.go) — the hash differs every build, the reconcile never skips,
+	// and the dataplane re-applies the whole screen config on every reconcile
+	// (needless control-socket + dataplane work, can re-arm SYN-cookie state).
+	// Sorting by zone name (the wire key, == the map key) makes the wire bytes
+	// stable so the content hash matches and the reconcile skips (#3962).
+	zoneNames := make([]string, 0, len(cfg.Security.Zones))
+	for name := range cfg.Security.Zones {
+		zoneNames = append(zoneNames, name)
+	}
+	sort.Strings(zoneNames)
+	for _, name := range zoneNames {
+		zone := cfg.Security.Zones[name]
 		if zone == nil || zone.ScreenProfile == "" {
 			continue
 		}
@@ -104,7 +119,17 @@ func buildScreenMissingProfileRefs(cfg *config.Config) []ScreenMissingProfileRef
 		return nil
 	}
 	var out []ScreenMissingProfileRef
-	for _, zone := range cfg.Security.Zones {
+	// Same determinism requirement as buildScreenSnapshots (#3962): this slice
+	// is carried in ConfigSnapshot.ScreenMissingProfiles and so feeds the
+	// snapshotContentHash dedup. Ranging the zones map directly would shift the
+	// wire byte order build-to-build. Sort by zone name for a stable order.
+	zoneNames := make([]string, 0, len(cfg.Security.Zones))
+	for name := range cfg.Security.Zones {
+		zoneNames = append(zoneNames, name)
+	}
+	sort.Strings(zoneNames)
+	for _, name := range zoneNames {
+		zone := cfg.Security.Zones[name]
 		if zone == nil || zone.ScreenProfile == "" {
 			// No screen configured for this zone — legit Pass, not a
 			// missing reference.


### PR DESCRIPTION
## Summary

Closes #3962 (fable-161 F-074, MEDIUM perf/churn).

`buildScreenSnapshots` and its sibling `buildScreenMissingProfileRefs`
(`pkg/dataplane/userspace/screens.go`) ranged the `cfg.Security.Zones`
map (`map[string]*ZoneConfig`) directly and appended each row to a slice.
Go map iteration order is randomized per run, so the serialized
`Screens` / `ScreenMissingProfiles` wire byte order varied
build-to-build even for an UNCHANGED config.

Both slices are carried in the `ConfigSnapshot` that `snapshotContentHash`
(`builder.go`) hashes for the reconcile's duplicate-publish dedup. Because
the bytes differed every build, the content hash differed, the dedup never
matched, and the dataplane re-applied the entire screen config on **every**
reconcile (every commit, every periodic sync) — needless control-socket +
dataplane work, and a screen re-apply can briefly reset screen counters /
re-arm the SYN-cookie state.

## Fix

Both builders now collect the zone names, `sort.Strings` them, and range
in sorted-by-name order (the wire key == the map key). The serialized
bytes are then stable for an unchanged config, the content hash matches,
and the reconcile correctly skips the re-apply. This matches the
long-standing sorted-iteration pattern already used by `buildZoneSnapshots`
(`zones.go`) and `buildSYNCookieMasterKey`.

## Sibling audit

- `buildScreenMissingProfileRefs` — **same bug, fixed in this PR** (feeds
  `ScreenMissingProfiles`).
- `buildZoneSnapshots` + every zone-host-inbound builder (`zones.go`) —
  already sort.
- `buildSYNCookieMasterKey` — already sorts its hash input.
- NAT / static-NAT / NAT64 / tunnel / neighbor builders — range config
  **slices** (already ordered), never affected.

## Test / RED-on-revert

`TestBuildScreenSnapshotsDeterministicOrder` (`manager_test.go`) builds a
10-zone config 64× and asserts the marshaled `Screens` bytes + sha256 are
identical every build and the output is sorted ascending, plus the same
64× byte-stability assertion on `buildScreenMissingProfileRefs`.

RED-on-revert verified: restoring the bare `range cfg.Security.Zones`
fails with `snapshots not sorted by zone: "voice" before "video"`.

## Validation

- `go test ./pkg/dataplane/...` green
- `go build ./...` green
- `gofmt -l` clean, `go vet ./pkg/dataplane/userspace/` clean

Doc: added a companion snapshot-builder determinism invariant to
`docs/userspace-dataplane-architecture.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi