### PR TITLE
userspace-dp policy: legacy address parser keeps `any` mixed with literals match-all (#3947)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -259,6 +259,30 @@
   - **File(s)**: pkg/routing/routes.go, pkg/routing/routeformat.go,
     pkg/grpcapi/server_routing.go, pkg/routing/routes_multipath_test.go,
     pkg/routing/README.md, _Log.md
+## 2026-07-03 — #3947: legacy address parser drops a bare `any` mixed with literals → deny narrows (fail-open)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-084 (MEDIUM, security fail-open on the
+    drift / hand-built-snapshot / mixed-version-decode legacy path). The
+    legacy address parser `parse_legacy_address_set` handled a bare `any`
+    token with a no-op match arm (`"any" | "" => {}`), leaning on the legacy
+    empty→`MatchAny` convention — which only yields match-all when the list
+    is otherwise empty. A list MIXING `any` with a literal (e.g.
+    `[ any 10.0.0.0/8 ]`) therefore DROPPED the `any` and NARROWED the match
+    set to just the literal. For a DENY term that narrowing is a fail-OPEN: a
+    deny meant to match every source matched only the listed literal, so
+    other sources fell through to a later permit / default-permit. Fix mirrors
+    `parse_v3_literal_set` EXACTLY: a bare `any` now sets BOTH per-family
+    match-all flags (`any_v4 = true; any_v6 = true`), so an `any` anywhere in
+    the list is match-all for both families regardless of accompanying
+    literals or family-scoped wildcards. The empty (`""`) token is split into
+    its own no-op arm (distinct from `any`), preserving the legacy
+    empty→`MatchAny` convention for an otherwise-empty list while a mixed
+    `[ "" 10.0.0.0/8 ]` keeps the literal scoping.
+  - **File(s)**: userspace-dp/src/policy.rs (arm + fn doc comment),
+    userspace-dp/src/policy_tests.rs (4 RED-on-revert unit tests),
+    docs/userspace-dataplane-architecture.md (#3947 paragraph), _Log.md.
+
 ## 2026-07-03 — #3941: deleting an IPsec VPN never terminates its live SAs (--load-all only unloads config)
 
 - **Timestamp**: 2026-07-03

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -678,6 +678,22 @@ snapshot only ever emits parseable, family-separated literals / `any` / family
 wildcards, so these rejects guard against a corrupt / hand-built / mixed-version
 HA peer-sync snapshot; the preflight keeps the previous good forwarding state.
 
+**Legacy `any` mixed with literals stays match-all (#3947).** `parse_legacy_address_set`
+now treats a bare `any` token exactly like `parse_v3_literal_set` — it sets
+BOTH per-family match-all flags (`any_v4`/`any_v6` → `MatchAny`), regardless of
+any literals or family-scoped wildcards present in the same list. The pre-fix
+no-op arm (`"any" | "" => {}`) leaned on the legacy empty→`MatchAny` convention,
+which only yields match-all when the list is otherwise EMPTY; a list MIXING
+`any` with a literal (`[ any 10.0.0.0/8 ]`) DROPPED the `any` and NARROWED the
+match set to just the literal. For a DENY term that narrowing is a fail-OPEN: a
+deny meant to match every source (`any`) matched only the listed literal, so
+traffic from other sources fell through to a later permit / default-permit. The
+empty (`""`) token remains a no-op — distinct from `any` — so an otherwise-empty
+list still collapses to `MatchAny` via `from_prefixes`, but a mixed
+`[ "" 10.0.0.0/8 ]` keeps the literal scoping. This only bites the drift /
+hand-built / mixed-version-decode legacy path; a normal Go v3 snapshot never
+uses the legacy field.
+
 **Duplicate rule-identity fail-closed (#3713).** `parse_policy_state_with_counters`
 preflights rule-identity uniqueness BEFORE it allocates any per-rule hit counter
 or builds a `PolicyRule` entry — the FIRST validation in the function, so no

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -3045,7 +3045,16 @@ pub(crate) fn parse_policy_state_with_counters(
 /// family is explicitly excluded), NOT MatchAny. Only when NO
 /// family-scoped wildcard appears does the legacy "empty = MatchAny"
 /// convention apply (via `from_prefixes`), preserving back-compat for
-/// the unconstrained / `any` / all-malformed cases.
+/// the unconstrained / all-malformed cases.
+///
+/// #3947: a bare `any` token now sets BOTH per-family any-flags
+/// (mirroring `parse_v3_literal_set`) instead of being a no-op that
+/// relied on the empty→MatchAny convention. The old no-op arm only
+/// yielded MatchAny when the list was otherwise empty; a list mixing
+/// `any` with a literal (`[ any 10.0.0.0/8 ]`) dropped the `any` and
+/// NARROWED to the literal — a fail-OPEN for a deny term. An `any`
+/// anywhere in the list is match-all for both families regardless of
+/// any accompanying literals or family-scoped wildcards.
 ///
 /// #3367: the returned `Option<String>` carries the FIRST token that was
 /// non-empty, non-`any`, non-family-wildcard, and unparseable as an IP/CIDR.
@@ -3060,10 +3069,26 @@ fn parse_legacy_address_set(addresses: &[String]) -> (PrefixSetV4, PrefixSetV6, 
     let mut malformed: Option<String> = None;
     for tok in addresses {
         match tok.as_str() {
-            // Bare `any` is the unconstrained both-families wildcard;
-            // it leaves no per-family scoping and falls through to the
-            // legacy empty→MatchAny convention below for both families.
-            "any" | "" => {}
+            // #3947: a bare `any` is the both-families match-all wildcard.
+            // Mirror `parse_v3_literal_set` EXACTLY — set BOTH per-family
+            // any-flags. The pre-fix no-op arm leaned on the legacy
+            // empty→MatchAny convention below, which only holds when the list
+            // is otherwise EMPTY: a list MIXING `any` with a literal (e.g.
+            // `[ any 10.0.0.0/8 ]`) then DROPPED the `any` and NARROWED the
+            // match to just the literal — a fail-OPEN for a deny term (the
+            // deny that should match every source matched only the listed
+            // one). Setting the flags here keeps the set match-all regardless
+            // of any accompanying literals.
+            "any" => {
+                any_v4 = true;
+                any_v6 = true;
+            }
+            // The empty token contributes nothing to either family; it stays a
+            // no-op (matches `parse_v3_literal_set`). It is NOT `any`: an
+            // otherwise-empty list still collapses to MatchAny via the legacy
+            // `from_prefixes` convention below, but a mixed `[ "" 10.0.0.0/8 ]`
+            // keeps the literal scoping rather than widening to match-all.
+            "" => {}
             "any-ipv4" => any_v4 = true,
             "any-ipv6" => any_v6 = true,
             s => {

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -1144,6 +1144,78 @@ fn legacy_address_valid_literals_and_wildcards_still_parse() {
 }
 
 #[test]
+fn legacy_address_any_mixed_with_literal_stays_match_all() {
+    // #3947 RED-on-revert: the LEGACY address parser must treat a bare `any`
+    // MIXED with literal addresses as match-all on both families, mirroring
+    // `parse_v3_literal_set`. The pre-fix no-op `"any" | "" => {}` arm DROPPED
+    // the `any` and let `[ any 10.0.0.0/8 ]` collapse to just the literal
+    // (10.0.0.0/8), NARROWING the match set. For a DENY term that narrowing is
+    // a fail-OPEN: a source outside 10.0.0.0/8 that should be denied would be
+    // permitted. Reverting the fix makes `v4.is_match_any()` false
+    // (Linear{10.0.0.0/8}), so this assertion goes RED — non-tautological.
+    let (v4, v6, malformed) =
+        parse_legacy_address_set(&["any".to_string(), "10.0.0.0/8".to_string()]);
+    assert!(malformed.is_none(), "no malformed token expected");
+    assert!(
+        v4.is_match_any(),
+        "`any` mixed with a v4 literal must be v4 match-all, not narrowed to the literal"
+    );
+    // A bare `any` sets BOTH families — the v6 side is match-all too.
+    assert!(
+        v6.is_match_any(),
+        "a bare `any` is match-all for v6 as well"
+    );
+    // Behavioral proof: an address OUTSIDE the literal still matches (match-all).
+    // A narrowed Linear{10.0.0.0/8} would reject it.
+    assert!(v4.contains("192.168.1.1".parse().unwrap()));
+}
+
+#[test]
+fn legacy_address_bare_any_alone_is_match_all_both_families() {
+    // #3947: a bare `any` alone stays match-all for both families. This was
+    // already correct via the empty→MatchAny convention; after the fix it is
+    // reached via the explicit any-flags. Guards against a regression that would
+    // drop the standalone-any case.
+    let (v4, v6, malformed) = parse_legacy_address_set(&["any".to_string()]);
+    assert!(malformed.is_none());
+    assert!(v4.is_match_any(), "bare `any` must be v4 match-all");
+    assert!(v6.is_match_any(), "bare `any` must be v6 match-all");
+}
+
+#[test]
+fn legacy_address_any_mixed_with_v6_literal_stays_match_all() {
+    // #3947 (v6 arm): `any` mixed with a v6 literal must be v6 (and v4)
+    // match-all, not narrowed to 2001:db8::/32. RED on revert:
+    // `v6.is_match_any()` is false (Linear{2001:db8::/32}).
+    let (v4, v6, malformed) =
+        parse_legacy_address_set(&["any".to_string(), "2001:db8::/32".to_string()]);
+    assert!(malformed.is_none());
+    assert!(
+        v6.is_match_any(),
+        "`any` mixed with a v6 literal must be v6 match-all"
+    );
+    assert!(v4.is_match_any(), "`any` is match-all for v4 as well");
+    // Behavioral proof: a v6 address outside 2001:db8::/32 still matches.
+    assert!(v6.contains("2001:4860::1".parse().unwrap()));
+}
+
+#[test]
+fn legacy_address_literal_only_list_is_not_widened() {
+    // #3947 guard: the fix must NOT widen a literal-only list. `[ 10.0.0.0/8 ]`
+    // with no `any` stays scoped to that prefix on v4 (matches 10.x, rejects
+    // others). The v4-only list leaves v6 at the pre-existing legacy
+    // empty→MatchAny convention — that is unchanged by this fix.
+    let (v4, _v6, malformed) = parse_legacy_address_set(&["10.0.0.0/8".to_string()]);
+    assert!(malformed.is_none());
+    assert!(
+        !v4.is_match_any(),
+        "a literal-only list must stay scoped, not match-all"
+    );
+    assert!(v4.contains("10.1.2.3".parse().unwrap()));
+    assert!(!v4.contains("192.168.1.1".parse().unwrap()));
+}
+
+#[test]
 fn go_unsupported_sentinel_fails_closed() {
     // Cross-language contract: the Go capability gate emits a "__unsupported__"
     // sentinel term for an unrepresentable application; Rust must drop it and


### PR DESCRIPTION
## Summary

Fixes #3947 (fable-161 F-084, MEDIUM security fail-open on the drift /
hand-built-snapshot / mixed-version-decode legacy path).

The legacy (non-v3-shaped) address parser `parse_legacy_address_set`
handled a bare `any` token with a no-op match arm (`"any" | "" => {}`),
relying on the legacy empty→`MatchAny` convention that only yields
match-all when the token list is otherwise EMPTY. A list that MIXED a
bare `any` with a literal address (e.g. `[ any 10.0.0.0/8 ]`) therefore
DROPPED the `any` and NARROWED the match set to just the literal.

For a DENY term that narrowing is a security fail-OPEN: a deny meant to
match every source (`any`) matched only the listed literal, so traffic
from other sources fell through to a later permit / default-permit and
was PERMITTED. The primary v3 parser (`parse_v3_literal_set`) already
handled `any` correctly by setting `any_v4`/`any_v6`.

## Fix

`userspace-dp/src/policy.rs` — mirror `parse_v3_literal_set` exactly. A
bare `any` now sets BOTH per-family match-all flags
(`any_v4 = true; any_v6 = true`), so an `any` anywhere in the list forces
`MatchAny` on both families regardless of any accompanying literals or
family-scoped wildcards — the legacy path can no longer produce a
narrower (fail-open) match set than v3. The empty (`""`) token is split
into its own no-op arm, distinct from `any`: an otherwise-empty list
still collapses to `MatchAny` via `from_prefixes`, but a mixed
`[ "" 10.0.0.0/8 ]` keeps its literal scoping.

## Validation

- **FULL `cargo test --release` green** (`CARGO_TARGET_DIR=/dev/shm/cargo-3947`,
  `--test-threads=1` to avoid the pre-existing parallel `__skb_wait_for_more_packets`
  socket-test env hang): main binary 3460 passed / 0 failed / 2 ignored,
  plus all integration targets (46, 8, 16, 1) green, cargo exit 0.
- **`go build ./...`** green.
- **4 RED-on-revert unit tests** on `parse_legacy_address_set`
  (`userspace-dp/src/policy_tests.rs`): mixed `any` + v4 literal → v4
  `MatchAny` not narrowed; bare `any` alone → both families `MatchAny`;
  mixed `any` + v6 literal → v6 `MatchAny`; literal-only list unchanged /
  not widened. Verified RED-on-revert: restoring the old `"any" | "" => {}`
  arm makes the two mixed tests FAIL (`any` dropped, match narrowed) while
  the bare-any-alone and literal-only guards correctly still pass.
- Doc: updated the malformed-address fail-closed section of
  `docs/userspace-dataplane-architecture.md` with the #3947 legacy-any
  semantics.

Closes #3947

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
