### PR TITLE
snmp: reconcile the SNMP subsystem on every commit (#3967)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,47 @@
+## 2026-07-03 — #3967: SNMP agent / trap-groups were start-once-at-boot → a day-2 commit that enabled SNMP, added a community/trap target, or disabled SNMP sat inert until a daemon restart
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-059 (MEDIUM, config-lifecycle). The SNMP
+    agent listener + link-state trap monitor were created ONCE at daemon
+    boot (`daemon_run.go` boot block). `applyConfigLocked` only did an
+    in-place `UpdateConfig` on an ALREADY-running agent (#2008), so
+    enabling SNMP on a running firewall (agent was nil) never started the
+    listener, disabling it never stopped it, and adding the FIRST trap
+    group never started the link-state monitor — the change sat in the
+    config, inert until a restart (a silent config-doesn't-take-effect +
+    monitoring-gap surprise).
+  - **Fix**: new `reconcileSNMP` (`pkg/daemon/daemon_snmp_reconcile.go`),
+    called from `applyConfigLocked` in place of the bare `UpdateConfig`
+    guard, reconciles the whole subsystem on every commit: disabled→enabled
+    starts the listener (+ monitor if trap groups), enabled→disabled stops
+    it, enabled→enabled swaps community/authorization/v3/trap-target state
+    in place (no listener bounce), and a newly-added trap group starts the
+    monitor without a restart. Idempotent: an unchanged SNMP stanza is a
+    no-op gated on `snmpConfigHash` (FNV over the raw secret-bearing
+    fields). The boot block now calls the shared `startSNMPLocked` + sets
+    `snmpBootReady` (the gate that keeps the boot apply and boot block from
+    double-starting); a shared `snmpEnabled` predicate makes boot and day-2
+    agree. Agent + monitor bind to a `d.daemonCtx`-derived lifetime context;
+    `teardownSNMP` stops them at shutdown. Concurrency: `teardownSNMPLocked`
+    cancels + joins the goroutines before nilling `d.snmpAgent`, so the
+    monitor's `emitLinkStateTrap` reads never race the clear (verified with
+    `-race`).
+  - **File(s)**: `pkg/daemon/daemon_snmp_reconcile.go` (new),
+    `pkg/daemon/daemon.go` (reconcile state fields + serve/boots seams),
+    `pkg/daemon/daemon_apply.go` (reconcileSNMP wiring),
+    `pkg/daemon/daemon_run.go` (boot block → startSNMPLocked +
+    snmpBootReady; shutdown teardownSNMP; drop now-unused imports),
+    `pkg/daemon/daemon_snmp_reconcile_test.go` (RED-on-revert lifecycle
+    tests), `pkg/snmp/README.md` (reconcile section).
+  - **Validation**: RED-on-revert confirmed (reverting the apply wiring to
+    the pre-fix `if d.snmpAgent != nil { UpdateConfig }` fails all three
+    lifecycle tests — enable, disable, trap-group-add). `go test
+    ./pkg/snmp/ ./pkg/daemon/` green; `-race` on the daemon SNMP/linkstate
+    paths clean; `go build ./...`, `gofmt`, `go vet` clean. (Pre-existing
+    unrelated `-race` flake in `pkg/snmp/traps_async_2991_test.go` —
+    `trapSender` package-var reassignment races `trapWorker`; untouched
+    by this change.)
+
 ## 2026-07-03 — #3962: buildScreenSnapshots ranged the zones map in nondeterministic order → wire byte order varied per build → snapshotContentHash dedup missed → dataplane re-applied the screen config on every reconcile
 
 - **Timestamp**: 2026-07-03

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -225,15 +225,41 @@ type Daemon struct {
 	// when a reconcile's NewExporter build failed and the OLD exporters were
 	// kept running so export stayed up; cleared on the next successful
 	// reconcile. Surfaced via FlowExportError().
-	flowExportErr             error
-	ipfixBundlePtr            atomic.Pointer[ipfixBundle]
-	ipfixHash                 [32]byte
-	ipfixHashSet              bool
-	ipfixCBOnce               sync.Once
-	ipfixReconMu              sync.Mutex
-	ipfixExportErr            error
-	dhcpRelay                 *dhcprelay.Manager
-	snmpAgent                 *snmp.Agent
+	flowExportErr  error
+	ipfixBundlePtr atomic.Pointer[ipfixBundle]
+	ipfixHash      [32]byte
+	ipfixHashSet   bool
+	ipfixCBOnce    sync.Once
+	ipfixReconMu   sync.Mutex
+	ipfixExportErr error
+	dhcpRelay      *dhcprelay.Manager
+	snmpAgent      *snmp.Agent
+
+	// --- SNMP subsystem reconcile-on-commit state (#3967) ---
+	// The SNMP agent is a start-once-at-boot subsystem: the boot block in
+	// daemon_run.go performs the first start (respecting config-only /
+	// bootstrap modes), and every later commit reconciles through
+	// reconcileSNMP (called from applyConfigLocked). snmpReconMu serializes
+	// the reconcile against itself; the agent's own cfgMu still guards the
+	// live authorization/community swap done by UpdateConfig.
+	snmpReconMu        sync.Mutex
+	snmpCtx            context.Context    // lifetime context for the agent + monitor goroutines
+	snmpCancel         context.CancelFunc // cancels snmpCtx (day-2 disable / shutdown)
+	snmpWg             *sync.WaitGroup    // joins the listener + link-state monitor goroutines
+	snmpHash           uint64             // FxHash-free FNV of the live SNMP stanza (idempotence gate)
+	snmpHashSet        bool               // true once snmpHash reflects a running agent
+	snmpMonitorRunning bool               // true while the link-state trap monitor goroutine is live
+	snmpBootReady      bool               // set true after the boot block; gates the reconcile START path
+	// snmpServe runs the agent's UDP/161 listener for the lifetime of ctx.
+	// nil ⇒ agent.Start (binds UDP/161, needs CAP_NET_BIND_SERVICE). The
+	// reconcile unit test injects a seam so it can drive enable/disable
+	// without binding a privileged socket (#3967).
+	snmpServe func(ctx context.Context, agent *snmp.Agent)
+	// snmpBootsPath overrides the SNMPv3 engineBoots persistence path passed
+	// to snmp.NewAgentWithBootsPath. Empty ⇒ the package default. Tests inject
+	// a temp path so a reconcile-triggered start does not touch /var/lib/xpf
+	// (#3967).
+	snmpBootsPath             string
 	lldpMgr                   *lldp.Manager
 	lldpApplied               *lldp.LLDPConfig // last effective LLDP config Apply()'d (#2372 diff-guard); nil = stopped
 	lldpApplyInit             bool             // true once reconcileLLDP has run at least once

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -440,13 +440,17 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 		return nil
 	}
 
-	// Reconcile the SNMP agent's live authorization/identity config FIRST
-	// (#2008 H17, Codex r2). The agent is created once at startup
-	// (daemon_run.go) and keeps serving on UDP/161; without this step a
-	// commit that flips a community read-write -> read-only, deletes a
-	// community, or changes the v3 user set would not reach the running agent
-	// until a daemon restart, leaving the SET access-control gate reading
-	// stale authorization.
+	// Reconcile the whole SNMP subsystem FIRST (#2008 H17, Codex r2; extended
+	// to full lifecycle reconcile in #3967). reconcileSNMP matches the running
+	// agent + trap-group monitor to the committed config on EVERY commit:
+	//   - enable a previously-disabled agent (start the UDP/161 listener),
+	//   - disable a running agent (stop the listener),
+	//   - swap community authorization / v3 users / trap targets in place on a
+	//     still-enabled agent (no listener bounce),
+	//   - and start the link-state trap monitor when trap groups appear.
+	// Before #3967 only the in-place authorization swap existed and only when
+	// SNMP was already enabled at boot — enabling SNMP or adding a trap target
+	// day-2 sat inert in the config until a daemon restart.
 	//
 	// This MUST run before any reconcile step that can abort applyConfigLocked
 	// early — specifically the dataplane apply below, which returns early on a
@@ -460,15 +464,12 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// is unconditionally before every early-return path in the body (the only
 	// aborting one is the dataplane apply at compileErrorMustAbortApply).
 	//
-	// The swap is in-place (UpdateConfig holds the agent's cfgMu) so the UDP
-	// listener and in-flight polls are not interrupted, and it is idempotent —
-	// an atomic pointer/table swap, safe to call once per apply. Guarded on a
-	// non-nil agent: if SNMP was not enabled at startup there is no running
-	// listener to reconcile (enabling SNMP for the first time still requires a
-	// restart, matching the other start-once subsystems).
-	if d.snmpAgent != nil {
-		d.snmpAgent.UpdateConfig(cfg.System.SNMP)
-	}
+	// reconcileSNMP is idempotent: an unchanged SNMP stanza is a no-op (no
+	// listener bounce). The in-place swap holds the agent's cfgMu so the UDP
+	// listener and in-flight polls are not interrupted. During the boot apply
+	// it no-ops the start (snmpBootReady is still false) so the boot block
+	// owns the first start, which honors config-only / bootstrap suppression.
+	d.reconcileSNMP(cfg)
 
 	// #1922 Item 2 bootstrap exit: the FIRST apply of a non-empty config
 	// (an interface-claiming confirmed commit, or a cluster SyncApply from

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -17,8 +17,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/vishvananda/netlink"
-
 	"github.com/psaab/xpf/pkg/api"
 	"github.com/psaab/xpf/pkg/cli"
 	"github.com/psaab/xpf/pkg/cluster"
@@ -42,7 +40,6 @@ import (
 	"github.com/psaab/xpf/pkg/ra"
 	"github.com/psaab/xpf/pkg/routing"
 	"github.com/psaab/xpf/pkg/rpm"
-	"github.com/psaab/xpf/pkg/snmp"
 	"github.com/psaab/xpf/pkg/vrrp"
 )
 
@@ -1014,84 +1011,23 @@ func (d *Daemon) Run(ctx context.Context) error {
 		}
 	}
 
-	// Start SNMP agent if configured (unless system processes snmp disable).
-	if cfg := d.store.ActiveConfig(); cfg != nil && cfg.System.SNMP != nil && (len(cfg.System.SNMP.Communities) > 0 || len(cfg.System.SNMP.V3Users) > 0) && !isProcessDisabled(cfg, "snmpd") {
-		d.snmpAgent = snmp.NewAgent(cfg.System.SNMP)
-		d.snmpAgent.SetIfDataFn(func() []snmp.IfData {
-			links, err := netlink.LinkList()
-			if err != nil {
-				return nil
-			}
-			var result []snmp.IfData
-			for _, link := range links {
-				attrs := link.Attrs()
-				if attrs.Name == "lo" {
-					continue
-				}
-				ifType := 6 // ethernetCsmacd
-				switch link.Type() {
-				case "vrf":
-					ifType = 53 // propVirtual
-				case "gre", "ip6tnl", "xfrm":
-					ifType = 131 // tunnel
-				case "veth":
-					ifType = 53
-				}
-				admin := 2 // down
-				if attrs.Flags&net.FlagUp != 0 {
-					admin = 1
-				}
-				oper := 2 // down
-				if attrs.OperState == netlink.OperUp || attrs.OperState == netlink.OperUnknown {
-					oper = 1
-				}
-				speed := uint32(0)
-				if attrs.TxQLen > 0 {
-					speed = 1000000000 // default 1Gbps
-				}
-				var stats *netlink.LinkStatistics
-				if attrs.Statistics != nil {
-					stats = attrs.Statistics
-				}
-				entry := snmp.IfData{
-					IfIndex:     attrs.Index,
-					IfDescr:     attrs.Name,
-					IfType:      ifType,
-					IfMtu:       attrs.MTU,
-					IfSpeed:     speed,
-					AdminStatus: admin,
-					OperStatus:  oper,
-					IfName:      attrs.Name,
-					IfHighSpeed: speed / 1_000_000, // bps -> Mbps
-				}
-				if stats != nil {
-					entry.InOctets = uint32(stats.RxBytes)
-					entry.OutOctets = uint32(stats.TxBytes)
-					entry.HCInOctets = stats.RxBytes
-					entry.HCInUcastPkts = stats.RxPackets
-					entry.HCOutOctets = stats.TxBytes
-					entry.HCOutUcastPkts = stats.TxPackets
-					entry.InMulticastPkts = uint32(stats.Multicast)
-				}
-				result = append(result, entry)
-			}
-			return result
-		})
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			d.snmpAgent.Start(ctx)
-		}()
-
-		// Start link state monitor for SNMP traps.
-		if len(cfg.System.SNMP.TrapGroups) > 0 {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				d.monitorLinkState(ctx)
-			}()
-		}
+	// Start the SNMP agent if configured (#3967). This is the FIRST start; it
+	// runs regardless of config-only / bootstrap mode (unlike the boot
+	// applyConfig, which is gated on !NoDataplane and suppressed in bootstrap)
+	// so the agent serves even in degraded modes, matching pre-#3967 behavior.
+	// The agent + link-state monitor are bound to a lifetime context derived
+	// from d.daemonCtx (via startSNMPLocked) and torn down explicitly at
+	// shutdown (teardownSNMP), NOT on this run WaitGroup. Setting snmpBootReady
+	// hands day-2 lifecycle changes over to reconcileSNMP (applyConfigLocked):
+	// an earlier boot apply left the start gated on snmpBootReady==false so the
+	// boot apply and this block never double-start.
+	d.snmpReconMu.Lock()
+	if cfg := d.store.ActiveConfig(); snmpEnabled(cfg) {
+		d.startSNMPLocked(cfg)
+		d.snmpHash, d.snmpHashSet = snmpConfigHash(cfg), true
 	}
+	d.snmpBootReady = true
+	d.snmpReconMu.Unlock()
 
 	// Start periodic neighbor resolution to keep ARP entries warm for
 	// known forwarding targets (DNAT pools, gateways, address-book hosts).
@@ -1690,6 +1626,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// Cancel context to stop background goroutines, then wait for them.
 	stop()
 	wg.Wait()
+
+	// Stop the SNMP agent + link-state trap monitor (#3967). Their goroutines
+	// bind to d.daemonCtx (never cancelled in production) rather than the run
+	// WaitGroup, so wg.Wait above does not cover them — teardownSNMP cancels
+	// the agent's lifetime context, joins the goroutines, and releases UDP/161.
+	d.teardownSNMP()
 
 	// Clean up flow exporters.
 	d.stopFlowExporter()

--- a/pkg/daemon/daemon_snmp_reconcile.go
+++ b/pkg/daemon/daemon_snmp_reconcile.go
@@ -1,0 +1,336 @@
+package daemon
+
+import (
+	"context"
+	"encoding/binary"
+	"hash/fnv"
+	"log/slog"
+	"net"
+	"sort"
+	"sync"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/snmp"
+)
+
+// snmpEnabled reports whether the committed config asks for a running SNMP
+// agent. It is the SINGLE source of truth shared by the boot start block
+// (daemon_run.go) and the day-2 reconcile (reconcileSNMP) so the two can never
+// diverge on what "SNMP is on" means: an SNMP stanza with at least one
+// community or v3 user, and the snmpd process not administratively disabled.
+func snmpEnabled(cfg *config.Config) bool {
+	if cfg == nil || cfg.System.SNMP == nil {
+		return false
+	}
+	s := cfg.System.SNMP
+	if len(s.Communities) == 0 && len(s.V3Users) == 0 {
+		return false
+	}
+	return !isProcessDisabled(cfg, "snmpd")
+}
+
+// snmpConfigHash is a deterministic fingerprint of the live SNMP stanza used as
+// the reconcile idempotence gate: an unchanged stanza hashes equal, so a commit
+// that does not touch SNMP is a true no-op (no listener bounce, no in-place
+// swap). It hashes the RAW secret-bearing fields (community strings, v3
+// passwords) directly rather than the redacting MarshalJSON surface, so a
+// community rename or a password rotation is detected as a change. Maps are
+// walked in sorted-key order so the hash is stable across map iteration order.
+func snmpConfigHash(cfg *config.Config) uint64 {
+	h := fnv.New64a()
+	if cfg == nil || cfg.System.SNMP == nil {
+		return h.Sum64()
+	}
+	s := cfg.System.SNMP
+	write := func(str string) {
+		var l [8]byte
+		binary.LittleEndian.PutUint64(l[:], uint64(len(str)))
+		_, _ = h.Write(l[:])
+		_, _ = h.Write([]byte(str))
+	}
+	write(s.Location)
+	write(s.Contact)
+	write(s.Description)
+
+	commNames := make([]string, 0, len(s.Communities))
+	for name := range s.Communities {
+		commNames = append(commNames, name)
+	}
+	sort.Strings(commNames)
+	write("communities")
+	for _, name := range commNames {
+		c := s.Communities[name]
+		write(name)
+		if c != nil {
+			write(c.Authorization)
+		}
+	}
+
+	tgNames := make([]string, 0, len(s.TrapGroups))
+	for name := range s.TrapGroups {
+		tgNames = append(tgNames, name)
+	}
+	sort.Strings(tgNames)
+	write("trap-groups")
+	for _, name := range tgNames {
+		tg := s.TrapGroups[name]
+		write(name)
+		if tg != nil {
+			write(tg.Version)
+			targets := append([]string(nil), tg.Targets...)
+			sort.Strings(targets)
+			for _, t := range targets {
+				write(t)
+			}
+		}
+	}
+
+	userNames := make([]string, 0, len(s.V3Users))
+	for name := range s.V3Users {
+		userNames = append(userNames, name)
+	}
+	sort.Strings(userNames)
+	write("v3-users")
+	for _, name := range userNames {
+		u := s.V3Users[name]
+		write(name)
+		if u != nil {
+			write(u.AuthProtocol)
+			write(string(u.AuthPassword))
+			write(u.PrivProtocol)
+			write(string(u.PrivPassword))
+		}
+	}
+	return h.Sum64()
+}
+
+// buildSNMPIfData returns the live interface table for the SNMP ifTable /
+// ifXTable, read from netlink at call time. It is the SetIfDataFn callback
+// wired onto every agent the daemon starts (both the boot start and a day-2
+// reconcile start), so the agent always reports the current kernel interface
+// state regardless of when it was started (#3967 extracted this from the boot
+// block so the two start paths share one implementation).
+func buildSNMPIfData() []snmp.IfData {
+	links, err := netlink.LinkList()
+	if err != nil {
+		return nil
+	}
+	var result []snmp.IfData
+	for _, link := range links {
+		attrs := link.Attrs()
+		if attrs.Name == "lo" {
+			continue
+		}
+		ifType := 6 // ethernetCsmacd
+		switch link.Type() {
+		case "vrf":
+			ifType = 53 // propVirtual
+		case "gre", "ip6tnl", "xfrm":
+			ifType = 131 // tunnel
+		case "veth":
+			ifType = 53
+		}
+		admin := 2 // down
+		if attrs.Flags&net.FlagUp != 0 {
+			admin = 1
+		}
+		oper := 2 // down
+		if attrs.OperState == netlink.OperUp || attrs.OperState == netlink.OperUnknown {
+			oper = 1
+		}
+		speed := uint32(0)
+		if attrs.TxQLen > 0 {
+			speed = 1000000000 // default 1Gbps
+		}
+		var stats *netlink.LinkStatistics
+		if attrs.Statistics != nil {
+			stats = attrs.Statistics
+		}
+		entry := snmp.IfData{
+			IfIndex:     attrs.Index,
+			IfDescr:     attrs.Name,
+			IfType:      ifType,
+			IfMtu:       attrs.MTU,
+			IfSpeed:     speed,
+			AdminStatus: admin,
+			OperStatus:  oper,
+			IfName:      attrs.Name,
+			IfHighSpeed: speed / 1_000_000, // bps -> Mbps
+		}
+		if stats != nil {
+			entry.InOctets = uint32(stats.RxBytes)
+			entry.OutOctets = uint32(stats.TxBytes)
+			entry.HCInOctets = stats.RxBytes
+			entry.HCInUcastPkts = stats.RxPackets
+			entry.HCOutOctets = stats.TxBytes
+			entry.HCOutUcastPkts = stats.TxPackets
+			entry.InMulticastPkts = uint32(stats.Multicast)
+		}
+		result = append(result, entry)
+	}
+	return result
+}
+
+// reconcileSNMP reconciles the running SNMP subsystem against the committed
+// config on every apply (#3967). Before this, the agent + trap-group monitor
+// were started ONCE at boot; a day-2 commit that enabled SNMP, added a
+// community/trap target, or disabled SNMP sat inert in the config until a
+// daemon restart. reconcileSNMP closes that gap by matching the live subsystem
+// to the config on each commit:
+//
+//   - disabled -> enabled: create and start the agent listener (and the
+//     link-state trap monitor if trap groups are configured).
+//   - enabled  -> disabled: stop the listener and the monitor.
+//   - enabled  -> enabled (config changed): swap the live authorization /
+//     community / trap-target set in place via UpdateConfig (no listener
+//     bounce — the UDP socket and in-flight polls are preserved), and start
+//     the link-state monitor if trap groups appeared and it is not yet running.
+//   - enabled  -> enabled (unchanged): no-op (idempotence gate on snmpConfigHash).
+//
+// It returns true when it changed the running subsystem. It runs BEFORE the
+// dataplane apply in applyConfigLocked, mirroring the pre-#3967 UpdateConfig
+// placement, so a committed change reaches the agent even on an apply that
+// aborts early on a dataplane protocol-gate error.
+//
+// The START path requires d.snmpBootReady (set after the boot block) and
+// d.daemonCtx. During the boot apply, snmpBootReady is still false so this
+// no-ops the start and the boot block owns the first start (which respects
+// config-only / bootstrap suppression). The UpdateConfig and disable paths do
+// not depend on snmpBootReady, so an agent that IS running is always reconciled.
+func (d *Daemon) reconcileSNMP(cfg *config.Config) bool {
+	d.snmpReconMu.Lock()
+	defer d.snmpReconMu.Unlock()
+
+	desired := snmpEnabled(cfg)
+
+	// Disable path: stop a running agent; no-op when already stopped.
+	if !desired {
+		if d.snmpAgent == nil {
+			return false
+		}
+		d.teardownSNMPLocked()
+		d.snmpHash, d.snmpHashSet = 0, false
+		slog.Info("SNMP agent stopped (configuration disabled)")
+		return true
+	}
+
+	h := snmpConfigHash(cfg)
+
+	// Enable path, no agent running: start it. Gated on the boot handoff so
+	// the boot apply does not race the boot block into a double-start, and on
+	// daemonCtx so we have a lifetime to bind the goroutines to.
+	if d.snmpAgent == nil {
+		if !d.snmpBootReady || d.daemonCtx == nil {
+			return false
+		}
+		d.startSNMPLocked(cfg)
+		d.snmpHash, d.snmpHashSet = h, true
+		return true
+	}
+
+	// Agent already running: idempotent no-op when the stanza is unchanged.
+	if d.snmpHashSet && h == d.snmpHash {
+		return false
+	}
+
+	// Live in-place reconcile: swap authorization / community / trap targets
+	// without dropping the UDP listener.
+	d.snmpAgent.UpdateConfig(cfg.System.SNMP)
+
+	// Bring up the link-state trap monitor if trap groups appeared after the
+	// agent started (the boot start only launches the monitor when trap groups
+	// exist at boot). Requires daemonCtx (present whenever the agent is
+	// running via the normal paths).
+	if len(cfg.System.SNMP.TrapGroups) > 0 && !d.snmpMonitorRunning && d.snmpCtx != nil {
+		d.startSNMPMonitorLocked()
+	}
+
+	d.snmpHash, d.snmpHashSet = h, true
+	slog.Info("SNMP agent configuration reconciled")
+	return true
+}
+
+// startSNMPLocked creates the SNMP agent for cfg and starts its UDP/161
+// listener (and the link-state trap monitor when trap groups are configured)
+// on a fresh lifetime context derived from d.daemonCtx. The caller MUST hold
+// snmpReconMu and MUST have verified snmpEnabled(cfg). Shared by the boot start
+// block and reconcileSNMP so both go through one implementation (#3967).
+func (d *Daemon) startSNMPLocked(cfg *config.Config) {
+	ctx, cancel := context.WithCancel(d.daemonCtx)
+	agent := snmp.NewAgentWithBootsPath(cfg.System.SNMP, d.snmpBootsPath)
+	agent.SetIfDataFn(buildSNMPIfData)
+
+	serve := d.snmpServe
+	if serve == nil {
+		serve = func(ctx context.Context, a *snmp.Agent) { _ = a.Start(ctx) }
+	}
+
+	wg := &sync.WaitGroup{}
+	d.snmpAgent = agent
+	d.snmpCtx = ctx
+	d.snmpCancel = cancel
+	d.snmpWg = wg
+	d.snmpMonitorRunning = false
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		serve(ctx, agent)
+	}()
+
+	if len(cfg.System.SNMP.TrapGroups) > 0 {
+		d.startSNMPMonitorLocked()
+	}
+	slog.Info("SNMP agent started",
+		"communities", len(cfg.System.SNMP.Communities),
+		"v3_users", len(cfg.System.SNMP.V3Users),
+		"trap_groups", len(cfg.System.SNMP.TrapGroups))
+}
+
+// startSNMPMonitorLocked launches the netlink link-state trap monitor on the
+// agent's lifetime context. The caller MUST hold snmpReconMu, MUST have a
+// running agent (d.snmpAgent != nil, d.snmpCtx != nil), and MUST check
+// d.snmpMonitorRunning first so the monitor is never started twice.
+func (d *Daemon) startSNMPMonitorLocked() {
+	d.snmpMonitorRunning = true
+	d.snmpWg.Add(1)
+	go func() {
+		defer d.snmpWg.Done()
+		d.monitorLinkState(d.snmpCtx)
+	}()
+}
+
+// teardownSNMPLocked cancels the agent's lifetime context, joins the listener
+// and monitor goroutines, closes the UDP socket, and clears the per-agent
+// handles. The caller MUST hold snmpReconMu. Joining before nilling d.snmpAgent
+// establishes a happens-before edge so the monitor goroutine's reads of
+// d.snmpAgent (emitLinkStateTrap) never race the clear. Nil-safe / idempotent.
+func (d *Daemon) teardownSNMPLocked() {
+	if d.snmpCancel != nil {
+		d.snmpCancel()
+	}
+	if d.snmpWg != nil {
+		d.snmpWg.Wait()
+	}
+	if d.snmpAgent != nil {
+		d.snmpAgent.Stop()
+	}
+	d.snmpAgent = nil
+	d.snmpCtx = nil
+	d.snmpCancel = nil
+	d.snmpWg = nil
+	d.snmpMonitorRunning = false
+}
+
+// teardownSNMP stops the SNMP subsystem during daemon shutdown. The agent
+// goroutines bind to d.daemonCtx (never cancelled in production), so an
+// explicit teardown is needed to release UDP/161 and join the goroutines on
+// stop. Nil-safe / idempotent.
+func (d *Daemon) teardownSNMP() {
+	d.snmpReconMu.Lock()
+	defer d.snmpReconMu.Unlock()
+	d.teardownSNMPLocked()
+	d.snmpHash, d.snmpHashSet = 0, false
+}

--- a/pkg/daemon/daemon_snmp_reconcile_test.go
+++ b/pkg/daemon/daemon_snmp_reconcile_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/vishvananda/netlink"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -124,5 +127,199 @@ func TestApplyConfigLockedReconcilesSNMPBeforeDataplaneAbort(t *testing.T) {
 			"abort: a committed read-write -> read-only downgrade is still " +
 			"serving the stale read-write gate because applyConfigLocked " +
 			"aborted early before reaching the SNMP reconcile")
+	}
+}
+
+// snmpServeRecorder is a snmpServe seam that counts how many times the SNMP
+// UDP listener was (re)started and blocks until its context is cancelled,
+// mirroring the real agent.Start blocking contract so teardownSNMP's wg.Wait
+// joins cleanly. A listener "bounce" (stop+restart) increments the count; an
+// idempotent reconcile must not.
+type snmpServeRecorder struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (r *snmpServeRecorder) serve(ctx context.Context, _ *snmp.Agent) {
+	r.mu.Lock()
+	r.calls++
+	r.mu.Unlock()
+	<-ctx.Done()
+}
+
+func (r *snmpServeRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+// newSNMPReconcileDaemon builds a daemon wired to drive the REAL
+// applyConfigLocked -> reconcileSNMP lifecycle path (#3967) without binding
+// UDP/161 or touching real netlink: the listener runs on the injected serve
+// seam, the link-state monitor on hermetic subscribe/list seams, and the
+// SNMPv3 engineBoots file on a temp path. snmpBootReady=true simulates the
+// post-boot state in which day-2 commits own the SNMP lifecycle.
+func newSNMPReconcileDaemon(t *testing.T, serve func(context.Context, *snmp.Agent)) *Daemon {
+	t.Helper()
+	installFakeNetworkctl(t)
+	d := &Daemon{
+		applySem:      semaphore.NewWeighted(1),
+		dp:            &runtimeOnlyApplyTestDP{},
+		vrrpMgr:       vrrp.NewManager(),
+		store:         newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		opts:          Options{NoDataplane: true},
+		daemonCtx:     context.Background(),
+		snmpBootReady: true,
+		snmpServe:     serve,
+		snmpBootsPath: filepath.Join(t.TempDir(), "engineboots"),
+		// Keep the link-state monitor hermetic: return an established
+		// subscription that streams nothing and exits on ctx cancel, and an
+		// empty link list for the boot seed.
+		linkStateSubscribe: func(_ chan<- netlink.LinkUpdate, done <-chan struct{}, _ func(error)) error {
+			go func() { <-done }()
+			return nil
+		},
+		linkStateList: func() ([]netlink.Link, error) { return nil, nil },
+	}
+	t.Cleanup(d.teardownSNMP)
+	return d
+}
+
+// snmpEnabledConfig is a minimal SNMP-enabled config (one read-only community).
+func snmpEnabledConfig() *config.Config {
+	return &config.Config{
+		System: config.SystemConfig{
+			SNMP: &config.SNMPConfig{
+				Communities: map[string]*config.SNMPCommunity{
+					"public": {Name: "public", Authorization: "read-only"},
+				},
+			},
+		},
+	}
+}
+
+// snmpEnabledWithTrapConfig adds a trap group to snmpEnabledConfig so a day-2
+// commit that introduces trap targets must bring up the link-state monitor.
+func snmpEnabledWithTrapConfig() *config.Config {
+	return &config.Config{
+		System: config.SystemConfig{
+			SNMP: &config.SNMPConfig{
+				Communities: map[string]*config.SNMPCommunity{
+					"public": {Name: "public", Authorization: "read-only"},
+				},
+				TrapGroups: map[string]*config.SNMPTrapGroup{
+					"managers": {Name: "managers", Targets: []string{"192.0.2.1"}, Version: "v2"},
+				},
+			},
+		},
+	}
+}
+
+// TestApplyConfigLockedStartsSNMPWhenEnabledDay2 is the #3967 RED-on-revert
+// test for the primary defect: enabling SNMP on a running daemon must start the
+// agent listener via the apply path, not sit inert until a restart. It drives
+// the REAL applyConfigLocked so it fails if reconcileSNMP's start wiring is
+// removed from the apply body.
+//
+// Mutation check: delete the d.reconcileSNMP(cfg) call from applyConfigLocked
+// (or revert its start branch) and this test fails — d.snmpAgent stays nil and
+// the listener never starts after a day-2 enable.
+func TestApplyConfigLockedStartsSNMPWhenEnabledDay2(t *testing.T) {
+	rec := &snmpServeRecorder{}
+	d := newSNMPReconcileDaemon(t, rec.serve)
+
+	if d.snmpAgent != nil {
+		t.Fatal("precondition: no SNMP agent should be running before the enable commit")
+	}
+
+	if err := d.applyConfigLocked(context.Background(), snmpEnabledConfig()); err != nil {
+		t.Fatalf("applyConfigLocked(enable): %v", err)
+	}
+
+	if d.snmpAgent == nil {
+		t.Fatal("day-2 SNMP enable was NOT reconciled into the running subsystem: " +
+			"the agent is still nil after the commit (inert until restart)")
+	}
+	if !waitUntil(t, time.Second, func() bool { return rec.count() == 1 }) {
+		t.Fatalf("SNMP listener did not start on a day-2 enable: serve invocations = %d, want 1", rec.count())
+	}
+}
+
+// TestApplyConfigLockedStopsSNMPWhenDisabledDay2 proves the enable->disable
+// half: a commit that removes SNMP stops the running listener rather than
+// leaving it bound until a restart.
+func TestApplyConfigLockedStopsSNMPWhenDisabledDay2(t *testing.T) {
+	rec := &snmpServeRecorder{}
+	d := newSNMPReconcileDaemon(t, rec.serve)
+
+	if err := d.applyConfigLocked(context.Background(), snmpEnabledConfig()); err != nil {
+		t.Fatalf("applyConfigLocked(enable): %v", err)
+	}
+	if d.snmpAgent == nil {
+		t.Fatal("precondition: agent should be running after the enable commit")
+	}
+
+	if err := d.applyConfigLocked(context.Background(), snmpDowngradeDisabledConfig()); err != nil {
+		t.Fatalf("applyConfigLocked(disable): %v", err)
+	}
+	if d.snmpAgent != nil {
+		t.Fatal("day-2 SNMP disable was NOT reconciled: the agent is still running after the commit")
+	}
+}
+
+// snmpDowngradeDisabledConfig is an SNMP-absent config (the disable target).
+func snmpDowngradeDisabledConfig() *config.Config { return &config.Config{} }
+
+// TestReconcileSNMPUnchangedIsNoOp proves idempotence: re-committing an
+// identical SNMP stanza must NOT bounce the UDP listener — the serve seam is
+// invoked exactly once across two identical enable commits and the agent
+// pointer is preserved.
+func TestReconcileSNMPUnchangedIsNoOp(t *testing.T) {
+	rec := &snmpServeRecorder{}
+	d := newSNMPReconcileDaemon(t, rec.serve)
+
+	if err := d.applyConfigLocked(context.Background(), snmpEnabledConfig()); err != nil {
+		t.Fatalf("applyConfigLocked(enable #1): %v", err)
+	}
+	if !waitUntil(t, time.Second, func() bool { return rec.count() == 1 }) {
+		t.Fatalf("listener not started on first enable: serve = %d", rec.count())
+	}
+	first := d.snmpAgent
+
+	if err := d.applyConfigLocked(context.Background(), snmpEnabledConfig()); err != nil {
+		t.Fatalf("applyConfigLocked(enable #2, unchanged): %v", err)
+	}
+	if got := rec.count(); got != 1 {
+		t.Fatalf("unchanged SNMP commit bounced the listener: serve invocations = %d, want 1", got)
+	}
+	if d.snmpAgent != first {
+		t.Fatal("unchanged SNMP commit replaced the running agent (listener bounce)")
+	}
+}
+
+// TestReconcileSNMPStartsMonitorOnTrapGroupAddedDay2 proves the trap-group half
+// of the defect: an agent already running WITHOUT trap groups must bring up the
+// link-state trap monitor when a commit adds a trap group — without bouncing
+// the UDP listener.
+func TestReconcileSNMPStartsMonitorOnTrapGroupAddedDay2(t *testing.T) {
+	rec := &snmpServeRecorder{}
+	d := newSNMPReconcileDaemon(t, rec.serve)
+
+	if err := d.applyConfigLocked(context.Background(), snmpEnabledConfig()); err != nil {
+		t.Fatalf("applyConfigLocked(enable, no trap groups): %v", err)
+	}
+	if d.snmpMonitorRunning {
+		t.Fatal("precondition: link-state monitor should not run without trap groups")
+	}
+
+	if err := d.applyConfigLocked(context.Background(), snmpEnabledWithTrapConfig()); err != nil {
+		t.Fatalf("applyConfigLocked(add trap group): %v", err)
+	}
+	if !d.snmpMonitorRunning {
+		t.Fatal("adding a trap group day-2 did NOT start the SNMP link-state monitor " +
+			"(link traps would never flow to the new target until a restart)")
+	}
+	if got := rec.count(); got != 1 {
+		t.Fatalf("adding a trap group bounced the UDP listener: serve invocations = %d, want 1", got)
 	}
 }

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -150,14 +150,38 @@ requires of an authoritative engine:
 
 ## Live reconfigure (commit-time reconcile)
 
-The agent is created once at daemon startup and keeps serving on UDP/161.
-`UpdateConfig(cfg *config.SNMPConfig)` swaps the live authorization/identity
-config and rederives the USM v3 user table in place, so a commit that changes
-community authorization (`read-write` -> `read-only`, or a deleted community)
-or the v3 user set reaches the running agent without a restart — restarting
-would drop the UDP listener and interrupt in-flight polls. The daemon calls it
-from `applyConfigLocked` (guarded on a non-nil agent; enabling SNMP for the
-first time still requires a restart, like the other start-once subsystems).
+The full SNMP subsystem is reconciled on **every** commit, not just at boot
+(#3967). The daemon's `reconcileSNMP` (`pkg/daemon/daemon_snmp_reconcile.go`),
+called from `applyConfigLocked`, matches the running agent + link-state trap
+monitor to the committed config:
+
+- **disabled → enabled** — a commit that enables SNMP (an `snmp` stanza with a
+  community or v3 user, `snmpd` not `disable`d) creates and starts the agent
+  listener via `startSNMPLocked`, and the link-state trap monitor if trap
+  groups are configured. No restart needed.
+- **enabled → disabled** — a commit that removes SNMP (or `set system processes
+  snmpd disable`) stops the listener and the monitor (`teardownSNMPLocked`
+  cancels the lifetime context, joins the goroutines, and closes UDP/161).
+- **enabled → enabled (changed)** — `UpdateConfig(cfg *config.SNMPConfig)` swaps
+  the live authorization/identity config and rederives the USM v3 user table
+  **in place**, so a commit that changes community authorization (`read-write`
+  -> `read-only`, or a deleted community), the v3 user set, or a trap-group
+  target reaches the running agent without dropping the UDP listener or
+  interrupting in-flight polls. Trap targets are read live from `snapshotCfg`,
+  so an added/changed target takes effect immediately; a newly-added trap group
+  also starts the link-state monitor if it was not already running.
+- **enabled → enabled (unchanged)** — a no-op, gated on an FNV fingerprint of
+  the SNMP stanza (`snmpConfigHash`): an unchanged stanza never bounces the
+  listener.
+
+`snmpEnabled` is the single predicate both the boot start (`daemon_run.go`) and
+`reconcileSNMP` use, so boot and day-2 can never disagree on what "SNMP is on"
+means. The boot block performs the FIRST start (it runs even in config-only /
+bootstrap mode, unlike the boot `applyConfig`) and sets `snmpBootReady`, which
+hands day-2 lifecycle changes to `reconcileSNMP`; the `snmpBootReady` gate keeps
+the boot apply and the boot block from double-starting the agent. The agent +
+monitor goroutines bind to a lifetime context derived from `d.daemonCtx` and are
+torn down explicitly at shutdown (`teardownSNMP`).
 
 The reconcile runs **early** in `applyConfigLocked` — before the dataplane
 apply, which can abort the reconcile pipeline early (it returns on


### PR DESCRIPTION
Closes #3967

## Problem

The SNMP agent listener and link-state trap monitor were created **once at
daemon boot** (the boot block in `daemon_run.go`). `applyConfigLocked` only
did an in-place `UpdateConfig` on an **already-running** agent (#2008), so a
day-2 config change touching `snmp` was not fully reconciled:

- **enable SNMP on a running firewall** (agent was `nil`) → listener never
  started;
- **disable SNMP** → listener kept running;
- **add the first trap group** → link-state monitor never started, so link
  traps never flowed to the new target.

The change sat in the config, **inert until a daemon restart** — a silent
config-doesn't-take-effect surprise and a monitoring gap.

## Fix

New `reconcileSNMP` (`pkg/daemon/daemon_snmp_reconcile.go`), called from
`applyConfigLocked` in place of the bare `UpdateConfig` guard, matches the
running subsystem to the committed config on **every** commit:

| transition | action |
|---|---|
| disabled → enabled | create + start the listener (and monitor if trap groups) |
| enabled → disabled | stop the listener and monitor |
| enabled → enabled (changed) | in-place `UpdateConfig` (no listener bounce); start monitor if a trap group appeared |
| enabled → enabled (unchanged) | no-op, gated on `snmpConfigHash` (FNV of the stanza) |

- A shared `snmpEnabled` predicate is the single source of truth for boot and
  day-2, so they can never diverge.
- The boot block calls the shared `startSNMPLocked` and sets `snmpBootReady`,
  the gate that stops the earlier boot apply and the boot block from
  double-starting the agent. The boot block still runs in config-only /
  bootstrap mode (unlike the boot `applyConfig`), preserving degraded-mode
  behavior.
- Agent + monitor bind to a `d.daemonCtx`-derived lifetime context (not the
  run WaitGroup); `teardownSNMP` stops them at shutdown. `teardownSNMPLocked`
  cancels + joins the goroutines **before** nilling `d.snmpAgent`, so the
  monitor's `emitLinkStateTrap` reads never race the clear.
- The reconcile keeps its position early in `applyConfigLocked` (before the
  dataplane apply, which can abort the pipeline early), so a committed change
  reaches the agent even on an apply that aborts on a dataplane protocol gate.

## Tests (RED-on-revert)

Daemon-package tests drive the **real** `applyConfigLocked` → `reconcileSNMP`
path through injected seams (no UDP/161 bind, hermetic link-state seams, temp
engineBoots path):

- `TestApplyConfigLockedStartsSNMPWhenEnabledDay2` — day-2 enable starts the
  listener (primary defect);
- `TestApplyConfigLockedStopsSNMPWhenDisabledDay2` — day-2 disable stops it;
- `TestReconcileSNMPUnchangedIsNoOp` — unchanged commit does not bounce the
  listener (serve invoked once, agent pointer preserved);
- `TestReconcileSNMPStartsMonitorOnTrapGroupAddedDay2` — a trap group starts
  the monitor without bouncing the listener.

All three lifecycle tests go RED when the apply wiring is reverted to the
pre-fix `if d.snmpAgent != nil { UpdateConfig }` guard (verified).

## Validation

- `go test ./pkg/snmp/ ./pkg/daemon/` — green.
- `-race` on the daemon SNMP + link-state paths — clean.
- `go build ./...`, `gofmt`, `go vet ./pkg/daemon/ ./pkg/snmp/` — clean.
- Pre-existing unrelated `-race` flake in
  `pkg/snmp/traps_async_2991_test.go` (`trapSender` package-var reassignment
  races `trapWorker`) is untouched by this change.

Docs: `pkg/snmp/README.md` "Live reconfigure" section rewritten to describe
the full per-commit reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
