### PR TITLE
observability/perf: O(P+C) snapshot-and-release policy-counter read (#3965)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,52 @@
+## 2026-07-03 — #3965: ReadPolicyCounters was O(P·(P+C)) under the policy mutex → every Prometheus scrape stalled + starved commit/apply at scale
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-073 (MEDIUM, perf/scalability). The
+    Prometheus `xpf_policy_hits_total` collector
+    (`pkg/api/metrics_counters.go collectPolicyCounters`) and the REST
+    `GET /api/v1/security/policies` inventory
+    (`pkg/api/security.go policiesHandler`) read per-policy hit counters by
+    looping the single-policy `dp.ReadPolicyCounters(policyID)`. Each call
+    rebuilt the whole ruleID->counter index (O(C)) and rescanned the config
+    (O(P)) UNDER the userspace dataplane's policy mutex `m.mu`, so a scrape
+    of P policies was O(P·(P+C)) with `m.mu` held the entire time. On a
+    firewall with hundreds–thousands of policies every scrape (~15s) stalled
+    for seconds AND starved every other `m.mu` user — commit/apply and
+    session classification — for the duration.
+  - **Fix**: new `Manager.ReadAllPolicyCounters(cfg)`
+    (`pkg/dataplane/userspace/policycounters.go`) snapshots the
+    helper-published counter slice under ONE brief lock, releases it, then
+    builds the ruleID->counter index ONCE and walks the config ONCE outside
+    the lock — O(P+C), lock held only for the copy. New
+    `dpuserspace.NewPolicyCounterReader(dp, cfg, fallback)` wraps that bulk
+    snapshot behind a per-policy reader closure: when the dataplane provides
+    the bulk snapshot (the real userspace Manager) it does O(1) map lookups;
+    otherwise (test fakes / retired eBPF) it returns the per-policy
+    `fallback` unchanged. The two `pkg/api` callers now build one reader per
+    read and look each policy up through it. The retired bpfShim
+    policy_counters array is not consulted (never incremented in userspace
+    mode). Counter values, the skip-and-bump (#3345/#3408) contract, and the
+    REST HTTP-500 degraded-read contract are all preserved.
+  - **Tests**: `pkg/dataplane/userspace/policycounters_bulk_test.go` —
+    (1) correctness: the bulk read matches the single ReadPolicyCounters for
+    zone-pair, global, and default-sentinel handles, and an unpublished
+    policy is absent (same skip/error signal); (2) O(P+C) RED-on-revert:
+    1024 policies build the index EXACTLY ONCE (the per-policy read builds it
+    1024×); (3) snapshot-and-release RED-on-revert: the policy mutex is free
+    during resolution (a resolve-phase observer's `TryLock` succeeds).
+    Verified RED-on-revert: the naive "hold-lock + rebuild-per-policy" form
+    fails tests (2) and (3). `go test ./pkg/dataplane/userspace/ ./pkg/api/`
+    green; `go build ./...`, gofmt, vet clean.
+  - **File(s)**: pkg/dataplane/userspace/policycounters.go,
+    pkg/dataplane/userspace/policycounters_bulk_test.go,
+    pkg/api/metrics_counters.go, pkg/api/security.go, pkg/api/README.md,
+    _Log.md
+  - **Scope note**: the gRPC text (`show security policies hit-count`) and
+    interactive CLI surfaces share the same per-policy loop but are
+    operator-triggered (not the recurring 15s scrape). They keep the
+    per-policy read; `NewPolicyCounterReader` makes their later adoption a
+    one-line change if desired.
+
 ## 2026-07-03 — #3962: buildScreenSnapshots ranged the zones map in nondeterministic order → wire byte order varied per build → snapshotContentHash dedup missed → dataplane re-applied the screen config on every reconcile
 
 - **Timestamp**: 2026-07-03

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -53,6 +53,19 @@ liveness/readiness. Prometheus metrics endpoint. SSE event streams.
     validation is unambiguous on the canonical metrics surface. Each rule
     also carries the runtime `policy_id` (the RT_FLOW/session-table join
     key, #3336). #3623: `policy_id` is emitted ALWAYS (no `omitempty`).
+    #3965: both this endpoint and the `xpf_policy_hits_total` collector read
+    the WHOLE policy set from ONE dataplane snapshot rather than calling
+    `ReadPolicyCounters` once per policy. The per-policy read rebuilt the
+    ruleID->counter index and rescanned the config UNDER the dataplane's
+    policy mutex on every call, so a scrape of P policies was `O(P*(P+C))`
+    with the mutex held the entire time — periodically stalling the scrape
+    AND starving commit/apply and session classification on a firewall with
+    many policies. `dpuserspace.NewPolicyCounterReader` now builds the index
+    ONCE (`O(P+C)`) from a snapshot taken under a single brief lock (the
+    userspace `Manager.ReadAllPolicyCounters`), then resolves outside the
+    lock; a dataplane without the bulk snapshot (test fakes / retired eBPF)
+    transparently falls back to the per-policy read, and the skip-and-bump
+    (#3345/#3408) / HTTP-500 degraded-read contracts are unchanged.
     The first rule of the first zone-pair set legitimately has runtime id
     0 (`policySetID*MaxRulesPerPolicy + ruleIndex = 0`), and since #3057
     the implicit default policy uses a distinct sentinel (`0xFFFFFFFF`),

--- a/pkg/api/metrics_counters.go
+++ b/pkg/api/metrics_counters.go
@@ -265,6 +265,17 @@ func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp api
 	// unaffected.
 	statsEnabled := cfg.Security.PolicyStatsEnabled
 
+	// #3965: read the whole policy set from ONE snapshot instead of calling
+	// ReadPolicyCounters once per policy. The per-policy read rebuilt the
+	// ruleID->counter index and rescanned the config under the dataplane's
+	// policy mutex on EVERY call, so a scrape of P policies was O(P*(P+C)) with
+	// the mutex held the entire time — starving commit/apply. NewPolicyCounter
+	// Reader builds the index once (O(P+C), one brief lock) when the dataplane
+	// provides the bulk snapshot, and falls back to the per-policy read
+	// otherwise. A policy the helper has not published yields an error, so the
+	// skip-and-bump contract (#3345/#3408) below is unchanged.
+	readPolicy := dpuserspace.NewPolicyCounterReader(dp, cfg, dp.ReadPolicyCounters)
+
 	var policySetID uint32
 	for _, zpp := range cfg.Security.Policies {
 		// #3476: the compile path normalizes nil entries out, but the
@@ -285,7 +296,7 @@ func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp api
 				continue
 			}
 			policyID := policyCounterID(policySetID, i)
-			ctrs, err := dp.ReadPolicyCounters(policyID)
+			ctrs, err := readPolicy(policyID)
 			if err != nil {
 				c.counterReadErrors.Add(1)
 				continue
@@ -304,7 +315,7 @@ func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp api
 			continue
 		}
 		policyID := policyCounterID(policySetID, i)
-		ctrs, err := dp.ReadPolicyCounters(policyID)
+		ctrs, err := readPolicy(policyID)
 		if err != nil {
 			c.counterReadErrors.Add(1)
 			continue
@@ -335,7 +346,7 @@ func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp api
 	// that was previously uncounted. Gated on policy-stats like the per-rule
 	// metrics above so all surfaces agree.
 	if statsEnabled {
-		if ctrs, err := dp.ReadPolicyCounters(dataplane.DefaultPolicySentinelID); err != nil {
+		if ctrs, err := readPolicy(dataplane.DefaultPolicySentinelID); err != nil {
 			c.counterReadErrors.Add(1)
 		} else {
 			ch <- prometheus.MustNewConstMetric(c.policyHitsTotal, prometheus.CounterValue,

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -151,6 +151,15 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 	// #3408: surface a per-policy counter read failure as HTTP 500 after
 	// building, rather than reporting clean-zero hit counts.
 	var readErr error
+	// #3965: read the policy set from ONE snapshot (O(P+C), one brief dataplane
+	// lock) instead of a per-policy ReadPolicyCounters loop that held the policy
+	// mutex across an O(P*(P+C)) walk. Built only when the dataplane is loaded so
+	// no snapshot is taken on a config-only boot; falls back to the per-policy
+	// read for dataplanes without the bulk snapshot (test fakes / retired eBPF).
+	var readPolicy func(uint32) (dataplane.CounterValue, error)
+	if s.dp != nil && s.dp.IsLoaded() {
+		readPolicy = dpuserspace.NewPolicyCounterReader(s.dp, cfg, s.dp.ReadPolicyCounters)
+	}
 	// #3336: span-accumulated runtime/RT_FLOW policy IDs keyed
 	// [policySetID, sliceIndex] — the identity the event path logs, so
 	// automation can join a policy_id back to a rule. The raw ordinal stays the
@@ -226,7 +235,7 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 				pr.Applications = []string{}
 			}
 
-			if (statsEnabled || rule.Count) && s.dp != nil && s.dp.IsLoaded() {
+			if (statsEnabled || rule.Count) && readPolicy != nil {
 				// #3474: the counter read handle MUST use the RAW slice index i,
 				// not len(pi.Rules) (the compacted, nil-skipped count). The
 				// resolver (policyRuleIDForCounter) and every other caller —
@@ -239,7 +248,7 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 				// SSOT. (Nil rules are not reachable via any production config
 				// path today; this is defensive SSOT-alignment, like #3476/#3494.)
 				policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
-				if ctrs, err := s.dp.ReadPolicyCounters(policyID); err == nil {
+				if ctrs, err := readPolicy(policyID); err == nil {
 					pr.HitPackets = ctrs.Packets
 					pr.HitBytes = ctrs.Bytes
 				} else if readErr == nil {
@@ -313,9 +322,9 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 				pr.Applications = []string{}
 			}
 
-			if (statsEnabled || rule.Count) && s.dp != nil && s.dp.IsLoaded() {
+			if (statsEnabled || rule.Count) && readPolicy != nil {
 				policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
-				if ctrs, err := s.dp.ReadPolicyCounters(policyID); err == nil {
+				if ctrs, err := readPolicy(policyID); err == nil {
 					pr.HitPackets = ctrs.Packets
 					pr.HitBytes = ctrs.Bytes
 				} else if readErr == nil {

--- a/pkg/dataplane/userspace/policycounters.go
+++ b/pkg/dataplane/userspace/policycounters.go
@@ -7,7 +7,26 @@ import (
 	"github.com/psaab/xpf/pkg/dataplane"
 )
 
+// Test-only observability hooks. Both are nil in production, so the only
+// runtime cost is a nil check on the 1/15s counter-read path.
+//
+//   - policyRuleCounterIndexBuildObserver fires each time the ruleID->counter
+//     index is built. A bulk ReadAllPolicyCounters builds it EXACTLY ONCE
+//     (O(P+C)); a test asserts the read did not regress to the per-policy
+//     rebuild the pre-#3965 ReadPolicyCounters loop performed (O(P*(P+C))).
+//   - policyCounterResolveObserver fires AFTER ReadAllPolicyCounters releases
+//     the snapshot lock, during the lock-free resolution phase. A test uses it
+//     to assert the policy mutex is not held across the whole read
+//     (snapshot-and-release), so a concurrent commit/apply is not starved.
+var (
+	policyRuleCounterIndexBuildObserver func()
+	policyCounterResolveObserver        func()
+)
+
 func buildPolicyRuleCounterIndex(status *ProcessStatus) map[string]PolicyRuleCounterStatus {
+	if policyRuleCounterIndexBuildObserver != nil {
+		policyRuleCounterIndexBuildObserver()
+	}
 	index := make(map[string]PolicyRuleCounterStatus)
 	if status == nil {
 		return index
@@ -142,6 +161,135 @@ func (m *Manager) ReadPolicyCounters(policyID uint32) (dataplane.CounterValue, e
 	total.Packets += counter.Packets
 	total.Bytes += counter.Bytes
 	return total, nil
+}
+
+// ErrPolicyCounterUnpublished is returned by the reader NewPolicyCounterReader
+// builds for a policy whose per-rule counter the helper has not published. It
+// mirrors the error the per-policy ReadPolicyCounters returned in userspace mode
+// for the same case (the retired bpfShim map-not-found error surfaced when the
+// helper counter was absent), so callers keep their existing degraded-read
+// handling (Prometheus skip-and-bump, REST HTTP 500).
+var ErrPolicyCounterUnpublished = errors.New("policy counter not published")
+
+// ReadAllPolicyCounters returns every published per-policy counter keyed by the
+// numeric policy-counter handle the read callers compute
+// (policySetID*MaxRulesPerPolicy + sliceIndex, plus DefaultPolicySentinelID for
+// the implicit default policy). It is the O(P+C), snapshot-and-release bulk read
+// that replaces looping the per-policy ReadPolicyCounters on the observability
+// paths (#3965).
+//
+// The pre-#3965 pattern — a Prometheus scrape (every ~15s) calling
+// ReadPolicyCounters once per policy — was O(P*(P+C)) AND held the policy mutex
+// m.mu for the ENTIRE read: each call rebuilt the whole ruleID->counter index
+// (O(C)) and rescanned the config (O(P)) under the lock, so a firewall with many
+// policies periodically starved commit/apply and session classification for the
+// duration of the scrape. This method instead:
+//
+//   - takes m.mu only briefly to COPY the helper-published counter slice
+//     (and, if the caller passes a nil config, the last snapshot config), then
+//     releases it before doing any resolution/formatting;
+//   - builds the ruleID->counter index EXACTLY ONCE (O(C));
+//   - walks the config ONCE (O(P)), resolving each policy's handle -> ruleID ->
+//     counter.
+//
+// The caller SHOULD pass the same config it walks for labels (the active
+// config), so the returned handles line up with the caller's computed handles.
+// A nil config falls back to the last published snapshot config.
+//
+// The retired-eBPF bpfShim policy_counters array is intentionally NOT consulted:
+// it is never incremented in userspace mode (the only runtime forwarding path),
+// so it contributes zero. The single-policy ReadPolicyCounters retains the
+// bpfShim add solely for legacy API parity.
+func (m *Manager) ReadAllPolicyCounters(cfg *config.Config) (map[uint32]dataplane.CounterValue, error) {
+	m.mu.Lock()
+	if cfg == nil && m.lastSnapshot != nil {
+		cfg = m.lastSnapshot.Config
+	}
+	counters := append([]PolicyRuleCounterStatus(nil), m.lastStatus.PolicyRuleCounters...)
+	m.mu.Unlock()
+
+	if policyCounterResolveObserver != nil {
+		policyCounterResolveObserver()
+	}
+
+	result := make(map[uint32]dataplane.CounterValue)
+	if cfg == nil {
+		return result, nil
+	}
+	index := buildPolicyRuleCounterIndex(&ProcessStatus{PolicyRuleCounters: counters})
+
+	put := func(policyID uint32, ruleID string) {
+		if c, ok := index[ruleID]; ok {
+			result[policyID] = dataplane.CounterValue{Packets: c.Packets, Bytes: c.Bytes}
+		}
+	}
+
+	var policySetID uint32
+	for _, zpp := range cfg.Security.Policies {
+		if zpp == nil {
+			// A nil zone-pair slot still consumes a policy-set ID, matching
+			// policyRuleIDForCounter and every counter caller.
+			policySetID++
+			continue
+		}
+		for i, rule := range zpp.Policies {
+			if rule == nil {
+				continue
+			}
+			put(policySetID*dataplane.MaxRulesPerPolicy+uint32(i),
+				stablePolicyRuleID(zpp.FromZone, zpp.ToZone, rule.Name))
+		}
+		policySetID++
+	}
+	for i, rule := range cfg.Security.GlobalPolicies {
+		if rule == nil {
+			continue
+		}
+		put(policySetID*dataplane.MaxRulesPerPolicy+uint32(i),
+			stablePolicyRuleID("junos-global", "junos-global", rule.Name))
+	}
+	// #3363: the implicit default-policy hit counter is published under the
+	// stable rule id dataplane.DefaultPolicyName and read via the reserved
+	// sentinel handle.
+	put(dataplane.DefaultPolicySentinelID, dataplane.DefaultPolicyName)
+
+	return result, nil
+}
+
+// NewPolicyCounterReader returns a per-policy counter reader that the
+// observability surfaces (Prometheus collector, REST inventory) use in place of
+// looping ReadPolicyCounters. When dp provides the bulk ReadAllPolicyCounters
+// snapshot (the userspace Manager), the whole policy set is read O(P+C) with a
+// single brief lock: the reader closes over the snapshot map and does O(1)
+// lookups, returning ErrPolicyCounterUnpublished for a policy the helper has not
+// published (the same skip/error signal the per-policy read produced). Otherwise
+// (the retired eBPF Manager, test fakes) it returns fallback unchanged — the
+// per-policy read path, bit-for-bit as before.
+//
+// cfg should be the config the caller walks for labels/handles so the snapshot's
+// handles line up. dp is taken as any so callers can pass their narrow runtime
+// interface without a shared type.
+func NewPolicyCounterReader(dp any, cfg *config.Config, fallback func(uint32) (dataplane.CounterValue, error)) func(uint32) (dataplane.CounterValue, error) {
+	provider, ok := dp.(interface {
+		ReadAllPolicyCounters(*config.Config) (map[uint32]dataplane.CounterValue, error)
+	})
+	if !ok {
+		return fallback
+	}
+	bulk, err := provider.ReadAllPolicyCounters(cfg)
+	if err != nil {
+		// Surface the read failure through the same per-policy error channel so
+		// callers keep their existing degraded-read handling.
+		return func(uint32) (dataplane.CounterValue, error) {
+			return dataplane.CounterValue{}, err
+		}
+	}
+	return func(policyID uint32) (dataplane.CounterValue, error) {
+		if v, ok := bulk[policyID]; ok {
+			return v, nil
+		}
+		return dataplane.CounterValue{}, ErrPolicyCounterUnpublished
+	}
 }
 
 func (m *Manager) ClearPolicyCounters() error {

--- a/pkg/dataplane/userspace/policycounters_bulk_test.go
+++ b/pkg/dataplane/userspace/policycounters_bulk_test.go
@@ -1,0 +1,170 @@
+package userspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// buildManyPolicyConfig returns a config with `sets` zone-pair sets each holding
+// `perSet` rules (perSet must stay below MaxRulesPerPolicy so the
+// policySetID*MaxRulesPerPolicy+sliceIndex handle encoding is valid), the
+// matching helper-published per-rule counters, and every valid policy handle.
+// The k-th rule of set s gets packets = s*perSet+k+1, bytes = (s*perSet+k+1)*10.
+func buildManyPolicyConfig(sets, perSet int) (*config.Config, []PolicyRuleCounterStatus, []uint32) {
+	var zpps []*config.ZonePairPolicies
+	var counters []PolicyRuleCounterStatus
+	var ids []uint32
+	for s := 0; s < sets; s++ {
+		from := fmt.Sprintf("z%d", s)
+		rules := make([]*config.Policy, perSet)
+		for k := 0; k < perSet; k++ {
+			name := fmt.Sprintf("rule-%d-%d", s, k)
+			rules[k] = &config.Policy{Name: name}
+			v := uint64(s*perSet + k + 1)
+			counters = append(counters, PolicyRuleCounterStatus{
+				RuleID:  stablePolicyRuleID(from, "wan", name),
+				Packets: v,
+				Bytes:   v * 10,
+			})
+			ids = append(ids, uint32(s)*dataplane.MaxRulesPerPolicy+uint32(k))
+		}
+		zpps = append(zpps, &config.ZonePairPolicies{FromZone: from, ToZone: "wan", Policies: rules})
+	}
+	cfg := &config.Config{Security: config.SecurityConfig{Policies: zpps}}
+	return cfg, counters, ids
+}
+
+// TestReadAllPolicyCountersMatchesPerPolicy pins the bulk read's correctness: the
+// per-policy value it returns is identical to the single ReadPolicyCounters for
+// every handle (zone-pair rule, global rule, default-policy sentinel), and an
+// unpublished policy is absent from the map (the same skip/error signal the
+// per-policy read produced).
+func TestReadAllPolicyCountersMatchesPerPolicy(t *testing.T) {
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			Policies: []*config.ZonePairPolicies{{
+				FromZone: "lan",
+				ToZone:   "wan",
+				Policies: []*config.Policy{{Name: "allow-web"}, {Name: "allow-dns"}},
+			}},
+			GlobalPolicies: []*config.Policy{{Name: "global-allow"}},
+		},
+	}
+	m := New()
+	m.lastSnapshot = &ConfigSnapshot{Config: cfg}
+	m.lastStatus = ProcessStatus{PolicyRuleCounters: []PolicyRuleCounterStatus{
+		{RuleID: stablePolicyRuleID("lan", "wan", "allow-dns"), Packets: 7, Bytes: 700},
+		{RuleID: stablePolicyRuleID("junos-global", "junos-global", "global-allow"), Packets: 9, Bytes: 900},
+		{RuleID: dataplane.DefaultPolicyName, Packets: 3, Bytes: 300},
+	}}
+
+	all, err := m.ReadAllPolicyCounters(cfg)
+	if err != nil {
+		t.Fatalf("ReadAllPolicyCounters: %v", err)
+	}
+
+	for _, id := range []uint32{1, dataplane.MaxRulesPerPolicy, dataplane.DefaultPolicySentinelID} {
+		want, werr := m.ReadPolicyCounters(id)
+		if werr != nil {
+			t.Fatalf("ReadPolicyCounters(%d): %v", id, werr)
+		}
+		got, ok := all[id]
+		if !ok {
+			t.Fatalf("ReadAllPolicyCounters missing policy %d", id)
+		}
+		if got != want {
+			t.Fatalf("policy %d: bulk=%+v single=%+v", id, got, want)
+		}
+	}
+
+	// allow-web (slot 0) has no published counter: absent from the bulk map, and
+	// the single read reports the unpublished signal (error).
+	if v, ok := all[0]; ok {
+		t.Fatalf("policy 0 (unpublished) unexpectedly present: %+v", v)
+	}
+	if _, err := m.ReadPolicyCounters(0); err == nil {
+		t.Fatal("ReadPolicyCounters(0) returned nil error for an unpublished policy; expected the unpublished signal")
+	}
+}
+
+// TestReadAllPolicyCountersBuildsIndexOnce is the O(P+C) RED-on-revert pin: the
+// bulk read builds the ruleID->counter index EXACTLY ONCE for P policies, while
+// the per-policy read (the pre-#3965 form the scrape used) rebuilds it on every
+// call — O(P^2). Reverting ReadAllPolicyCounters to a per-policy index rebuild
+// makes the want-1 assertion go RED.
+func TestReadAllPolicyCountersBuildsIndexOnce(t *testing.T) {
+	const sets, perSet = 16, 64
+	const n = sets * perSet // 1024 policies
+	cfg, counters, ids := buildManyPolicyConfig(sets, perSet)
+	m := New()
+	m.lastSnapshot = &ConfigSnapshot{Config: cfg}
+	m.lastStatus = ProcessStatus{PolicyRuleCounters: counters}
+
+	var builds int
+	policyRuleCounterIndexBuildObserver = func() { builds++ }
+	defer func() { policyRuleCounterIndexBuildObserver = nil }()
+
+	result, err := m.ReadAllPolicyCounters(cfg)
+	if err != nil {
+		t.Fatalf("ReadAllPolicyCounters: %v", err)
+	}
+	if builds != 1 {
+		t.Fatalf("ReadAllPolicyCounters built the counter index %d times for %d policies; want 1 (O(P+C), not O(P^2))", builds, n)
+	}
+	if len(result) != n {
+		t.Fatalf("ReadAllPolicyCounters returned %d counters; want %d", len(result), n)
+	}
+	// Spot-check: set 4, rule 10 -> value 4*64+10+1 = 267.
+	if got := result[uint32(4)*dataplane.MaxRulesPerPolicy+10]; got != (dataplane.CounterValue{Packets: 267, Bytes: 2670}) {
+		t.Fatalf("set4/rule10 counter = %+v, want {Packets:267 Bytes:2670}", got)
+	}
+
+	// Contrast: the pre-#3965 per-policy read rebuilt the index on EVERY call, so
+	// the same P-policy read was O(P^2). Prove the scaling difference is real.
+	builds = 0
+	for _, id := range ids {
+		if _, err := m.ReadPolicyCounters(id); err != nil {
+			t.Fatalf("ReadPolicyCounters(%d): %v", id, err)
+		}
+	}
+	if builds != n {
+		t.Fatalf("per-policy read built the index %d times for %d policies; want %d (the O(P^2) form)", builds, n, n)
+	}
+}
+
+// TestReadAllPolicyCountersReleasesLockBeforeResolution is the mutex-hold
+// RED-on-revert pin: the bulk read holds the policy mutex only to copy the
+// counter snapshot, then releases it and resolves the config OUTSIDE the lock.
+// The resolve observer (which fires during the resolution phase) can therefore
+// acquire m.mu. Reverting to hold m.mu across the whole read (e.g. a top-level
+// `defer m.mu.Unlock()`) makes TryLock fail and the assertion go RED — the
+// regression that starved commit/apply during a Prometheus scrape.
+func TestReadAllPolicyCountersReleasesLockBeforeResolution(t *testing.T) {
+	cfg, counters, _ := buildManyPolicyConfig(1, 64)
+	m := New()
+	m.lastSnapshot = &ConfigSnapshot{Config: cfg}
+	m.lastStatus = ProcessStatus{PolicyRuleCounters: counters}
+
+	var fired, lockFree bool
+	policyCounterResolveObserver = func() {
+		fired = true
+		if m.mu.TryLock() {
+			m.mu.Unlock()
+			lockFree = true
+		}
+	}
+	defer func() { policyCounterResolveObserver = nil }()
+
+	if _, err := m.ReadAllPolicyCounters(cfg); err != nil {
+		t.Fatalf("ReadAllPolicyCounters: %v", err)
+	}
+	if !fired {
+		t.Fatal("resolve observer never fired; ReadAllPolicyCounters did not reach the resolution phase")
+	}
+	if !lockFree {
+		t.Fatal("policy mutex was held during resolution — snapshot-and-release regressed (read holds m.mu across the whole read, starving commit/apply)")
+	}
+}


### PR DESCRIPTION
Closes #3965

## Problem

`ReadPolicyCounters(policyID)` (userspace `Manager`) resolves the policy
id against the config and **rebuilds the whole ruleID->counter index under
the policy mutex `m.mu` on every call**. The Prometheus
`xpf_policy_hits_total` collector (`collectPolicyCounters`) and the REST
`GET /api/v1/security/policies` inventory (`policiesHandler`) call it once
per policy, so a read of P policies is **O(P·(P+C)) with `m.mu` held the
entire time**. On a firewall with hundreds–thousands of policies every
Prometheus scrape (~15s) stalls for seconds AND starves every other
`m.mu` user — commit/apply and session classification — for the duration.

## Fix

- **`Manager.ReadAllPolicyCounters(cfg)`** (`pkg/dataplane/userspace/policycounters.go`):
  snapshots the helper-published counter slice under **one brief lock**,
  releases it, then builds the ruleID->counter index **once** and walks the
  config **once outside the lock** → **O(P+C)**, mutex held only for the
  copy. Keyed by the same `policySetID*MaxRulesPerPolicy+sliceIndex` handle
  the callers compute (plus `DefaultPolicySentinelID`). The retired bpfShim
  `policy_counters` array is not consulted — it is never incremented in
  userspace mode (contributes zero); the single-policy read keeps the
  bpfShim add only for legacy API parity.
- **`NewPolicyCounterReader(dp, cfg, fallback)`**: builds the snapshot once
  and returns a per-policy reader doing O(1) lookups when the dataplane
  provides the bulk snapshot; otherwise returns `fallback` unchanged so
  test fakes and the retired eBPF Manager keep the per-policy path
  bit-for-bit.
- The two `pkg/api` callers now build one reader per read. A policy the
  helper has not published still yields an error, so the collector
  skip-and-bump (#3345/#3408) and the REST HTTP-500 degraded-read contracts
  are **unchanged**.

## RED-on-revert tests

`pkg/dataplane/userspace/policycounters_bulk_test.go`:

1. **Correctness** — the bulk read matches the single `ReadPolicyCounters`
   for zone-pair, global, and default-sentinel handles; an unpublished
   policy is absent (same skip/error signal).
2. **O(P+C)** — 1024 policies build the counter index **exactly once**;
   the per-policy read builds it 1024×. Reverting `ReadAllPolicyCounters`
   to a per-policy rebuild → RED.
3. **Snapshot-and-release** — the policy mutex is **free during the
   resolution phase** (a resolve-phase observer's `TryLock` succeeds).
   Reverting to hold `m.mu` across the whole read → RED.

Verified: the naive "hold-lock + rebuild-per-policy" form fails tests (2)
and (3).

## Validation

`go test ./pkg/dataplane/... ./pkg/api/... ./pkg/grpcapi/... ./pkg/cli/...`
green; `go build ./...`, `gofmt`, `go vet` clean. Module doc updated
(`pkg/api/README.md`).

## Scope note

The gRPC text (`show security policies hit-count`) and interactive CLI
hit-count surfaces share the loop shape but are operator-triggered (not the
recurring ~15s scrape), so they keep the per-policy read;
`NewPolicyCounterReader` makes their later adoption a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
