### PR TITLE
cos: clear pop_snapshot_stack at start of build_cos_batch_from_queue (#3968)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,52 @@
+## 2026-07-03 — #3968: non-exact CoS shaper path (`build_cos_batch_from_queue`) never cleared `pop_snapshot_stack` across batches → committed-batch snapshots accumulated on the hot path → unbounded scratch growth (realloc / stale re-read past the TX_BATCH_SIZE bound)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-078 (MEDIUM, Rust dataplane —
+    reused-scratch-not-cleared). The MQFQ pop
+    (`cos_queue_pop_known_bucket_inner`) pushes a rollback snapshot onto
+    the per-queue `FlowFairState::pop_snapshot_stack` (bounded to
+    `TX_BATCH_SIZE`). A partial-commit `cos_queue_push_front` pops one per
+    RETRIED item, but a whole-batch commit consumes none —
+    `restore_cos_local_items_inner` push_fronts only retried items — so a
+    fully-committed batch leaves ALL its snapshots resident. The EXACT
+    drains (`drain_exact_{local,prepared}_items_to_scratch_flow_fair`,
+    `queue_service/drain.rs:162,461`) clear the stack at batch start; the
+    NON-exact `build_cos_batch_from_queue` (`queue_service/mod.rs`) did
+    NOT. `drain_shaped_tx` builds one non-exact batch per call and the
+    outer TX loop calls it repeatedly, so a saturated promoted non-exact
+    flow-fair queue with more than `TX_BATCH_SIZE` resident items is
+    drained across consecutive builds with NO intervening
+    `cos_queue_push_back` (the only other clear site). Each build then
+    pushed on top of the prior batch's stale snapshots, growing the stack
+    past its documented bound (hot-path realloc / stale re-read; the
+    per-pop `debug_assert` trips in dev builds).
+  - **Fix**: `build_cos_batch_from_queue` now clears
+    `pop_snapshot_stack` unconditionally at entry (guarded by
+    `flow_fair_state.as_mut()`), mirroring the exact drains. Safe because
+    the previous batch's submit and its synchronous rollback complete
+    before the next build, so no live snapshot is dropped.
+  - **Audit**: swept sibling reused scratch in the same hot path. The
+    only reused scratch Vec on the `build_cos_batch_from_queue` path is
+    `pop_snapshot_stack`; the submit sidecars (`sidecar`, `enq_sidecar`)
+    are fresh stack arrays, and `scratch_{local,prepared}_tx` /
+    `shared_recycles` are caller-owned and cleared by their callers. No
+    other missing-clear found.
+  - **Test**: added
+    `build_cos_batch_clears_pop_snapshot_stack_across_batches`
+    (`queue_service/tests.rs`) — two sequential builds on a saturated
+    promoted non-exact flow-fair queue (full commit, no push_back
+    between); asserts the second batch's stack holds ONLY its own 64
+    snapshots (len == batch2, capacity == TX_BATCH_SIZE, no realloc).
+    RED-on-revert: without the clear the second stack held 128 (64 stale
+    + 64 new) in release; the per-pop `debug_assert` panics in dev.
+  - **Validation**: FULL `cargo test --release --test-threads=1` green
+    (main bin 3461 passed / 0 failed / 2 ignored; all integration suites
+    green). `go build ./...` clean. rustfmt touched only the added lines
+    (no blanket-format; pre-existing master drift left untouched).
+  - **File(s)**: `userspace-dp/src/afxdp/cos/queue_service/mod.rs`,
+    `userspace-dp/src/afxdp/cos/queue_service/tests.rs`,
+    `userspace-dp/src/afxdp/cos/README.md`, `_Log.md`
+
 ## 2026-07-03 — #3962: buildScreenSnapshots ranged the zones map in nondeterministic order → wire byte order varied per build → snapshotContentHash dedup missed → dataplane re-applied the screen config on every reconcile
 
 - **Timestamp**: 2026-07-03

--- a/userspace-dp/src/afxdp/cos/README.md
+++ b/userspace-dp/src/afxdp/cos/README.md
@@ -144,6 +144,19 @@ mod.rs for further file-level breakdown.
   runnable now or a parked queue's wake tick is due. Not-yet-due
   parked queues skip timer-wheel advance and shared-root lease top-up
   because no queue can service on that drain call.
+- **Pop-snapshot stack is cleared at batch start on BOTH drain paths
+  (#785 exact, #3968 non-exact).** Each MQFQ pop pushes a rollback
+  snapshot onto the per-queue `FlowFairState::pop_snapshot_stack`
+  (bounded to `TX_BATCH_SIZE`); a partial-commit `cos_queue_push_front`
+  pops one per RETRIED item, but a whole-batch commit consumes none and
+  leaves the batch's snapshots resident. `cos_queue_push_back` clears
+  them on the next enqueue, but a saturated queue is drained across
+  consecutive batches with no intervening enqueue. So every batch build
+  clears the stack at entry: the exact drains
+  (`drain_exact_{local,prepared}_items_to_scratch_flow_fair`) and the
+  non-exact `build_cos_batch_from_queue`. Any snapshots resident at
+  build entry belong to an already-submitted batch and are stale — the
+  submit and its synchronous rollback completed before the next build.
 - Scheduler-map queues without a positive explicit scheduler
   `transmit-rate` are residual-only under a shaped root. They keep an
   effective rate for burst sizing and surplus weight, but

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -1623,6 +1623,28 @@ fn build_cos_batch_from_queue(
     secondary_budget: u64,
     phase: CoSServicePhase,
 ) -> Option<CoSBatch> {
+    // #3968: clear the pop-snapshot stack at batch start — the
+    // non-exact analog of the clear `drain_exact_local_items_to_scratch_flow_fair`
+    // / `drain_exact_prepared_items_to_scratch_flow_fair` already do
+    // (queue_service/drain.rs). A fully-committed non-exact batch
+    // leaves ALL of its snapshots on the stack:
+    // `restore_cos_local_items_inner` pops one only per RETRIED item,
+    // so a whole-batch commit consumes none. `drain_shaped_tx` builds
+    // one batch per call and the outer TX loop calls it repeatedly, so
+    // a saturated promoted non-exact queue with more than
+    // `TX_BATCH_SIZE` resident items is drained across consecutive
+    // `build_cos_batch_from_queue` calls with NO intervening
+    // `cos_queue_push_back` (the only other clear site). Without this,
+    // the next build pushes on top of the prior batch's stale
+    // snapshots, growing the stack past its documented `TX_BATCH_SIZE`
+    // bound (hot-path realloc / stale re-read; the per-pop
+    // `debug_assert` in `cos_queue_pop_known_bucket_inner` trips in dev
+    // builds). Cleared unconditionally at entry: any snapshots resident
+    // here belong to an already-submitted batch and are stale — the
+    // submit (and its synchronous rollback) completed before this call.
+    if let Some(ff) = queue.flow_fair_state.as_mut() {
+        ff.pop_snapshot_stack.clear();
+    }
     let head = cos_queue_front(queue)?;
     match head {
         CoSPendingTxItem::Local(_) => {

--- a/userspace-dp/src/afxdp/cos/queue_service/tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests.rs
@@ -3507,3 +3507,135 @@ fn sojourn_zero_stamp_items_record_nothing_end_to_end() {
         "enqueue_ns == 0 must be treated as no-data, never a sample",
     );
 }
+
+/// #3968: the NON-exact flow-fair service path
+/// (`build_cos_batch_from_queue`) must clear the pop-snapshot stack
+/// at batch start — the analog of the clear the exact drain path
+/// (`drain_exact_*_flow_fair`) already performs (drain.rs).
+///
+/// A fully-committed non-exact batch leaves ALL of its snapshots on
+/// the stack: `restore_cos_local_items_inner` only pops a snapshot
+/// per RETRIED item, so a batch the TX ring accepted whole consumes
+/// none. `drain_shaped_tx` builds one batch per call and the outer
+/// TX loop calls it repeatedly, so a saturated promoted non-exact
+/// queue with more than `TX_BATCH_SIZE` resident items is drained
+/// across consecutive `build_cos_batch_from_queue` calls with NO
+/// intervening `push_back` (the only other clear site). Without the
+/// batch-start clear the second build pushes on top of the first
+/// batch's stale snapshots, growing the stack past its documented
+/// `TX_BATCH_SIZE` bound — a hot-path realloc / stale re-read (and
+/// the per-pop `debug_assert` in `cos_queue_pop_known_bucket_inner`
+/// trips in dev builds).
+///
+/// RED-on-revert: without the clear, the second batch's stack holds
+/// `TX_BATCH_SIZE + 64` snapshots (release) or the per-pop
+/// `debug_assert` panics (dev). A single build is unaffected.
+#[test]
+fn build_cos_batch_clears_pop_snapshot_stack_across_batches() {
+    let mut root = test_cos_runtime_with_queues(
+        25_000_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 0,
+            forwarding_class: "best-effort".into(),
+            priority: 5,
+            transmit_rate_bytes: 1_000_000_000 / 8,
+            guarantee_enabled: true,
+            // NON-exact: exercises the build_cos_batch_from_queue
+            // service path (the exact path drains via
+            // drain_exact_*_flow_fair, which already clears).
+            exact: false,
+            surplus_sharing: false,
+            equal_flow_enforcement: false,
+            equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+            surplus_weight: 1,
+            buffer_bytes: 8 * 1024 * 1024,
+            dscp_rewrite: None,
+            codel_target_ns: 0,
+        }],
+    );
+    let queue = &mut root.queues[0];
+    enable_test_flow_fair(queue);
+
+    let pre_cap = test_flow_fair_state(queue).pop_snapshot_stack.capacity();
+    assert_eq!(
+        pre_cap, TX_BATCH_SIZE,
+        "stack must be preallocated to TX_BATCH_SIZE",
+    );
+
+    // Saturate: TX_BATCH_SIZE + 64 items across two flows so the
+    // MQFQ min-finish scan does real selection and the first build
+    // pops a full TX_BATCH_SIZE batch with 64 items left resident.
+    let total = TX_BATCH_SIZE + 64;
+    for i in 0..total {
+        let src_port = if i % 2 == 0 { 9001u16 } else { 9002u16 };
+        cos_queue_push_back(queue, test_flow_cos_item(src_port, 100));
+    }
+
+    // Batch 1: build_cos_batch_from_queue pops TX_BATCH_SIZE items,
+    // pushing one rollback snapshot per pop. Budgets = u64::MAX so
+    // nothing caps the batch below the frame-count bound.
+    let batch1 = build_cos_batch_from_queue(
+        &mut root.queues[0],
+        0,
+        u64::MAX,
+        u64::MAX,
+        CoSServicePhase::Guarantee,
+    )
+    .expect("first batch built");
+    let batch1_len = match &batch1 {
+        CoSBatch::Local { items, .. } => items.len(),
+        CoSBatch::Prepared { items, .. } => items.len(),
+    };
+    assert_eq!(
+        batch1_len, TX_BATCH_SIZE,
+        "first batch fills a full TX_BATCH_SIZE batch",
+    );
+    assert_eq!(
+        test_flow_fair_state(&root.queues[0])
+            .pop_snapshot_stack
+            .len(),
+        TX_BATCH_SIZE,
+        "one snapshot per popped item",
+    );
+
+    // Full commit: the TX ring accepted every item, so nothing is
+    // push_fronted back and no snapshot is consumed. Drop the batch
+    // WITHOUT a push_back (which would clear the stack) — mirrors
+    // the drain_shaped_tx full-commit hot path exactly.
+    drop(batch1);
+
+    // Batch 2: drain the remaining 64 items with NO intervening
+    // push_back. With the batch-start clear the stack holds ONLY the
+    // second batch's own snapshots.
+    let batch2 = build_cos_batch_from_queue(
+        &mut root.queues[0],
+        0,
+        u64::MAX,
+        u64::MAX,
+        CoSServicePhase::Guarantee,
+    )
+    .expect("second batch built");
+    let batch2_len = match &batch2 {
+        CoSBatch::Local { items, .. } => items.len(),
+        CoSBatch::Prepared { items, .. } => items.len(),
+    };
+    assert_eq!(
+        batch2_len, 64,
+        "second batch drains the remaining resident items",
+    );
+    assert_eq!(
+        test_flow_fair_state(&root.queues[0])
+            .pop_snapshot_stack
+            .len(),
+        batch2_len,
+        "#3968: the second batch's stack holds ONLY its own \
+         snapshots — no stale first-batch residue",
+    );
+    assert_eq!(
+        test_flow_fair_state(&root.queues[0])
+            .pop_snapshot_stack
+            .capacity(),
+        pre_cap,
+        "#3968: stack must not realloc past TX_BATCH_SIZE",
+    );
+}


### PR DESCRIPTION
## Summary

Closes #3968 (fable-161 F-078, MEDIUM — reused-scratch-not-cleared).

The non-exact CoS shaper service path (`build_cos_batch_from_queue`,
`userspace-dp/src/afxdp/cos/queue_service/mod.rs`) never reset the
per-queue MQFQ rollback scratch (`FlowFairState::pop_snapshot_stack`)
between batches, so committed-batch snapshots accumulated on the hot
path and grew the Vec past its documented `TX_BATCH_SIZE` bound.

## Root cause

Each MQFQ pop (`cos_queue_pop_known_bucket_inner`) pushes a rollback
snapshot onto `pop_snapshot_stack`. A partial-commit
`cos_queue_push_front` pops one per **retried** item, but a whole-batch
commit consumes none — `restore_cos_local_items_inner` push_fronts only
retried items, so a fully-committed batch leaves **all** of its
snapshots resident.

The **exact** drains
(`drain_exact_{local,prepared}_items_to_scratch_flow_fair`,
`queue_service/drain.rs:162,461`) already clear the stack at batch
start; the **non-exact** `build_cos_batch_from_queue` did **not**.
`drain_shaped_tx` builds one non-exact batch per call and the outer TX
loop calls it repeatedly, so a saturated promoted non-exact flow-fair
queue with more than `TX_BATCH_SIZE` resident items is drained across
consecutive builds with **no** intervening `cos_queue_push_back` (the
only other clear site). Each build then pushed on top of the prior
batch's stale snapshots — unbounded growth (hot-path realloc + stale
re-read past the bound; the per-pop `debug_assert` trips in dev builds).

The existing bound test (`pop_tests.rs::mqfq_pop_snapshot_stack_bounded_to_tx_batch_size`)
even calls `.clear()` manually between batches with the comment
"Simulate what `drain_exact_*_flow_fair` does at batch start. This is
the fix point." — the non-exact path was the missing site.

## Fix

`build_cos_batch_from_queue` now clears `pop_snapshot_stack`
unconditionally at entry (guarded by `flow_fair_state.as_mut()`),
mirroring the exact drains. Safe: the previous batch's submit and its
synchronous rollback complete before the next build is entered, so no
live snapshot is discarded — any snapshot resident at build entry
belongs to an already-submitted batch and is stale.

Audited sibling reused scratch on the same hot path: the only reused
scratch Vec is `pop_snapshot_stack`; the submit sidecars are fresh
stack arrays and `scratch_{local,prepared}_tx` / `shared_recycles` are
caller-owned. No other missing-clear.

## Test (RED-on-revert)

`build_cos_batch_clears_pop_snapshot_stack_across_batches`: two
sequential builds on a saturated promoted non-exact flow-fair queue
(full commit, no push_back between); asserts the second batch's stack
holds **only** its own 64 snapshots (capacity unchanged, no realloc).
On revert the second stack held **128** (64 stale + 64 new) in release;
the per-pop `debug_assert` panics in dev.

## Validation

- FULL `cargo test --release --test-threads=1` green (main bin **3461
  passed / 0 failed / 2 ignored**; all integration suites green)
- `go build ./...` clean
- rustfmt touched only the added lines (no blanket-format; pre-existing
  master drift left untouched)
- `cos/README.md` documents the batch-start clear contract for both
  drain paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi