### PR TITLE
fwdstatus: sampler consumes cached status instead of a redundant 1 Hz control-socket poll

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,43 @@
+## 2026-07-03 — #3970: fwdstatus Sampler issued its OWN redundant 1 Hz control-socket status poll on top of the primary status poll → 2/s on the shared control socket, starving session installs during bulk sync
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-070 (MEDIUM, control-socket contention).
+    The forwarding-status CPU `Sampler` (`pkg/fwdstatus/sampler.go`) ran a
+    1 Hz timer goroutine and on every tick called `us.Status()` on the
+    dataplane accessor, which bottoms out in
+    `userspace.Manager.Status()` → `requestLocked({Type:"status"})` — a
+    control-socket round-trip. The userspace manager ALSO runs its own
+    primary 1 Hz status poll (`statusLoop`, `process.go`) that issues the
+    same `status` request and caches the result in `m.lastStatus`. Net =
+    two independent 1 Hz status requests (2/s) on the socket shared by
+    session installs, HA sync, and snapshot sync — violating the CLAUDE.md
+    ">1/s starves session installs during bulk sync" budget.
+  - **Fix**: added `Manager.CachedStatus() (ProcessStatus, bool)` that
+    returns the last-captured `m.lastStatus` under lock WITHOUT a
+    control-socket request (ok=false when nothing captured yet). Threaded
+    it through `LegacyDataPlaneAdapter.CachedStatus()` and the daemon
+    accessor (`forwardingStatusDaemonUserspaceDataPlane.CachedStatus()` +
+    `userspaceCachedStatusProbe`). The Sampler now type-asserts to
+    `CachedStatus()` and consumes the cache the primary poll already
+    fetched — it adds zero control-socket traffic. On a cache miss the
+    worker counters hold at their previous values, matching the old
+    Status()-error path (series monotonicity preserved). `Build()`
+    (on-demand `show chassis forwarding`) still calls `Status()` — a rare
+    CLI diagnostic, not a periodic poller, so not a rate violation.
+  - **Test**: `TestSamplerConsumesCachedStatusNoControlSocketPoll` +
+    `TestSamplerCacheMissHoldsCountersNoPoll` — a counting accessor mocks
+    both `Status()` (control socket) and `CachedStatus()` (cache) over N
+    sampler ticks and asserts `statusCalls==0`, `cachedCalls==N`, and the
+    worker counters are still populated from the cache. RED-on-revert
+    verified: reverting the Sampler to call `Status()` fails with "5
+    Status() control-socket request(s); want 0". `go test ./pkg/fwdstatus
+    ./pkg/daemon ./pkg/grpcapi ./pkg/cli ./pkg/dataplane/userspace` green,
+    `go build ./...`, gofmt, vet clean.
+  - **File(s)**: pkg/fwdstatus/sampler.go, pkg/fwdstatus/sampler_test.go,
+    pkg/fwdstatus/README.md, pkg/dataplane/userspace/manager.go,
+    pkg/dataplane/userspace/legacy_dataplane.go,
+    pkg/daemon/daemon_forwarding_status.go, _Log.md
+
 ## 2026-07-03 — #3967: SNMP agent / trap-groups were start-once-at-boot → a day-2 commit that enabled SNMP, added a community/trap target, or disabled SNMP sat inert until a daemon restart
 
 - **Timestamp**: 2026-07-03

--- a/pkg/daemon/daemon_forwarding_status.go
+++ b/pkg/daemon/daemon_forwarding_status.go
@@ -63,6 +63,18 @@ func (a forwardingStatusDaemonUserspaceDataPlane) Status() (dpuserspace.ProcessS
 	return a.daemon.userspaceDataplaneStatus()
 }
 
+// CachedStatus returns the last control-socket-captured ProcessStatus
+// without issuing a new request (#3970). The fwdstatus CPU sampler
+// consumes this instead of Status() so it reads worker telemetry off
+// the primary 1 Hz status poll rather than doubling the shared
+// control-socket status rate.
+func (a forwardingStatusDaemonUserspaceDataPlane) CachedStatus() (dpuserspace.ProcessStatus, bool) {
+	if a.daemon == nil {
+		return dpuserspace.ProcessStatus{}, false
+	}
+	return a.daemon.userspaceDataplaneCachedStatus()
+}
+
 // userspaceStatusProbe matches the userspace adapter's Status()
 // method without re-importing the dataplane.DataPlane interface.
 // Satisfied by *dataplane/userspace.LegacyDataPlaneAdapter. The
@@ -74,6 +86,13 @@ type userspaceStatusProbe interface {
 	Status() (dpuserspace.ProcessStatus, error)
 }
 
+// userspaceCachedStatusProbe matches the userspace adapter's
+// CachedStatus() method (#3970), which reads the last captured
+// ProcessStatus without a control-socket request.
+type userspaceCachedStatusProbe interface {
+	CachedStatus() (dpuserspace.ProcessStatus, bool)
+}
+
 func (d *Daemon) userspaceDataplaneStatus() (dpuserspace.ProcessStatus, error) {
 	if d == nil || d.dp == nil {
 		return dpuserspace.ProcessStatus{}, errors.New("userspace status unavailable")
@@ -83,6 +102,17 @@ func (d *Daemon) userspaceDataplaneStatus() (dpuserspace.ProcessStatus, error) {
 		return dpuserspace.ProcessStatus{}, errors.New("userspace status unavailable")
 	}
 	return provider.Status()
+}
+
+func (d *Daemon) userspaceDataplaneCachedStatus() (dpuserspace.ProcessStatus, bool) {
+	if d == nil || d.dp == nil {
+		return dpuserspace.ProcessStatus{}, false
+	}
+	provider, ok := d.dp.(userspaceCachedStatusProbe)
+	if !ok {
+		return dpuserspace.ProcessStatus{}, false
+	}
+	return provider.CachedStatus()
 }
 
 // forwardingStatusDataplane builds the fwdstatus accessor used by

--- a/pkg/dataplane/userspace/legacy_dataplane.go
+++ b/pkg/dataplane/userspace/legacy_dataplane.go
@@ -457,6 +457,17 @@ func (a *LegacyDataPlaneAdapter) Status() (ProcessStatus, error) {
 	return m.Status()
 }
 
+// CachedStatus returns the last control-socket-captured ProcessStatus
+// without issuing a new request (#3970). Returns ok=false when the
+// manager is unavailable or no status has been captured yet.
+func (a *LegacyDataPlaneAdapter) CachedStatus() (ProcessStatus, bool) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return ProcessStatus{}, false
+	}
+	return m.CachedStatus()
+}
+
 func (a *LegacyDataPlaneAdapter) SetForwardingArmed(armed bool) (ProcessStatus, error) {
 	m, err := a.managerOrErr()
 	if err != nil {

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -1640,6 +1640,29 @@ func (m *Manager) Status() (ProcessStatus, error) {
 	return status, nil
 }
 
+// CachedStatus returns the most recent ProcessStatus captured by a
+// control-socket round-trip (primarily the 1 Hz statusLoop, which
+// refreshes m.lastStatus every second via applyHelperStatusLocked),
+// WITHOUT issuing a new control-socket request. The bool is false
+// when no status has been captured yet (helper not started or never
+// polled), in which case the caller should hold its previous values.
+//
+// This exists so low-priority periodic consumers -- specifically the
+// fwdstatus CPU sampler -- can read worker telemetry off the shared
+// status poll instead of issuing their own redundant 1 Hz "status"
+// request, which would double the control-socket status rate and
+// starve session installs during bulk sync (#3970; CLAUDE.md
+// "Control socket contention"). Unlike Status(), this MUST NOT touch
+// the control socket.
+func (m *Manager) CachedStatus() (ProcessStatus, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.lastStatus.PID == 0 {
+		return ProcessStatus{}, false
+	}
+	return m.lastStatus, true
+}
+
 func (m *Manager) SetForwardingArmed(armed bool) (ProcessStatus, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/fwdstatus/README.md
+++ b/pkg/fwdstatus/README.md
@@ -30,6 +30,19 @@ root `pkg/dataplane` package, `pkg/cli`, or `pkg/grpcapi`.
   its own ring buffer and timer goroutine started via
   `Sampler.Start(ctx)`. The renderer consumes already-windowed
   values from the Sampler.
+- The Sampler reads worker telemetry off the **cached** ProcessStatus
+  (`DataPlaneAccessor.CachedStatus()`), NOT its own `Status()` call
+  (#3970). The userspace manager's primary 1 Hz status poll
+  (`statusLoop`) already fetches full `ProcessStatus` over the shared
+  control socket every second and caches it; the Sampler consumes that
+  cache so it adds **zero** control-socket traffic. A second periodic
+  `Status()` here would double the status rate (2/s) on the socket
+  shared with session installs and starve them during bulk sync
+  (CLAUDE.md "Control socket contention"). On a cache miss (helper not
+  yet polled) the worker counters hold at their previous values,
+  preserving series monotonicity. `Build()` (on-demand `show chassis
+  forwarding`) still calls `Status()` directly — that is a rare CLI
+  diagnostic, not a periodic poller, so it is not a rate violation.
 - The eBPF mode renders the worker-thread row as `N/A — eBPF path
   has no worker threads`. Don't add code that fakes a worker entry
   there; the N/A is informative.

--- a/pkg/fwdstatus/sampler.go
+++ b/pkg/fwdstatus/sampler.go
@@ -27,10 +27,10 @@ const (
 // cpuSample is one tick of the cumulative-counter ring.  All
 // counters are monotonic nanoseconds.
 type cpuSample struct {
-	wall            time.Time
-	daemonCPUNs     uint64 // /proc/self/stat utime+stime, converted to ns
-	workerThreadNs  uint64 // Σ WorkerRuntimeStatus.thread_cpu_ns across workers
-	workerWallNs    uint64 // Σ WorkerRuntimeStatus.wall_ns across workers
+	wall           time.Time
+	daemonCPUNs    uint64 // /proc/self/stat utime+stime, converted to ns
+	workerThreadNs uint64 // Σ WorkerRuntimeStatus.thread_cpu_ns across workers
+	workerWallNs   uint64 // Σ WorkerRuntimeStatus.wall_ns across workers
 }
 
 // Sampler maintains a ring of cumulative CPU counters.  One
@@ -97,12 +97,23 @@ func (s *Sampler) sample(now time.Time) {
 	daemonNs := ticksToNanos(selfStat.UtimeTicks + selfStat.StimeTicks)
 
 	// Worker counters — userspace-dp only.
+	//
+	// #3970: consume the CACHED ProcessStatus that the manager's
+	// primary 1 Hz status poll (statusLoop) already fetched, rather
+	// than issuing our own Status() control-socket request. Two
+	// independent 1 Hz "status" requests doubled the shared
+	// control-socket rate and starved session installs during bulk
+	// sync (CLAUDE.md "Control socket contention"). CachedStatus()
+	// MUST NOT touch the control socket; on a miss (helper not yet
+	// polled) the worker counters hold at their previous values,
+	// preserving series monotonicity exactly as the old Status()
+	// error path did.
 	workerThread, workerWall := s.lastWorkerThread, s.lastWorkerWall
 	if s.dp != nil {
 		if us, ok := s.dp.(interface {
-			Status() (userspace.ProcessStatus, error)
+			CachedStatus() (userspace.ProcessStatus, bool)
 		}); ok {
-			if st, err := us.Status(); err == nil {
+			if st, ok := us.CachedStatus(); ok {
 				var tc, w uint64
 				for _, wr := range st.WorkerRuntime {
 					tc += wr.ThreadCPUNS
@@ -164,13 +175,16 @@ func (s *Sampler) Snapshot() SamplerSnapshot {
 // wall ≤ newest.wall − W.
 //
 // Daemon %: (Δdaemon_cpu_ns / Δwall_ns) × 100 — per-core percent;
-//          can exceed 100% on multi-core.
+//
+//	can exceed 100% on multi-core.
+//
 // Worker %: (Δworker_thread_cpu_ns / Δworker_wall_ns) × 100 —
-//          per-worker-average OS thread CPU via CLOCK_THREAD_CPUTIME_ID,
-//          summed across workers.  Busy-poll mode shows ~100% regardless
-//          of traffic (known false-positive); eBPF path has no workers
-//          so Δworker_wall_ns stays 0 and the window flags as invalid.
-//          See #883 / #884 for why we don't use active_ns here.
+//
+//	per-worker-average OS thread CPU via CLOCK_THREAD_CPUTIME_ID,
+//	summed across workers.  Busy-poll mode shows ~100% regardless
+//	of traffic (known false-positive); eBPF path has no workers
+//	so Δworker_wall_ns stays 0 and the window flags as invalid.
+//	See #883 / #884 for why we don't use active_ns here.
 func computeCPUWindows(snap SamplerSnapshot) (
 	daemonPct, workerPct [numCPUWindows]float64,
 	daemonValid, workerValid [numCPUWindows]bool,

--- a/pkg/fwdstatus/sampler_test.go
+++ b/pkg/fwdstatus/sampler_test.go
@@ -3,7 +3,121 @@ package fwdstatus
 import (
 	"testing"
 	"time"
+
+	"github.com/psaab/xpf/pkg/dataplane/userspace"
 )
+
+// countingAccessor is a fwdstatus.DataPlaneAccessor that also exposes
+// both Status() and CachedStatus(), counting how many times each is
+// invoked. Used to prove the Sampler reads worker telemetry off the
+// cached status (no control-socket request) and never issues its own
+// Status() poll (#3970).
+type countingAccessor struct {
+	status       userspace.ProcessStatus
+	statusCalls  int // Status() → control-socket request (must stay 0)
+	cachedCalls  int // CachedStatus() → cache read (no control socket)
+	cachedHasVal bool
+}
+
+func (c *countingAccessor) IsLoaded() bool          { return true }
+func (c *countingAccessor) GetMapStats() []MapStats { return nil }
+
+func (c *countingAccessor) Status() (userspace.ProcessStatus, error) {
+	c.statusCalls++
+	return c.status, nil
+}
+
+func (c *countingAccessor) CachedStatus() (userspace.ProcessStatus, bool) {
+	c.cachedCalls++
+	if !c.cachedHasVal {
+		return userspace.ProcessStatus{}, false
+	}
+	return c.status, true
+}
+
+// fixedProcReader returns a valid /proc/self/stat so sample() reaches
+// the worker-telemetry path instead of dropping the sample early.
+type fixedProcReader struct{}
+
+func (fixedProcReader) ReadSelfStat() (ProcSelfStat, error) {
+	return ProcSelfStat{UtimeTicks: 10, StimeTicks: 5, StartTimeTicks: 1000}, nil
+}
+func (fixedProcReader) ReadSelfStatm() (ProcSelfStatm, error) { return ProcSelfStatm{}, nil }
+func (fixedProcReader) ReadStat() (ProcStat, error)           { return ProcStat{BootTime: 1}, nil }
+func (fixedProcReader) ReadMemInfo() (ProcMemInfo, error) {
+	return ProcMemInfo{MemTotalBytes: 1 << 30}, nil
+}
+func (fixedProcReader) ReadCgroupMemoryMax() (uint64, error) { return 0, nil }
+
+// The Sampler MUST read worker telemetry from the cached status the
+// primary 1 Hz poll already fetched, and MUST NOT issue its own
+// Status() control-socket request (#3970). This goes RED on revert:
+// reverting the Sampler to call Status() flips statusCalls from 0 to
+// N — a second redundant 1 Hz request (2/s total) on the shared
+// control socket.
+func TestSamplerConsumesCachedStatusNoControlSocketPoll(t *testing.T) {
+	acc := &countingAccessor{
+		status: userspace.ProcessStatus{
+			PID: 4242,
+			WorkerRuntime: []userspace.WorkerRuntimeStatus{
+				{ThreadCPUNS: 100, WallNS: 200},
+				{ThreadCPUNS: 300, WallNS: 400},
+			},
+		},
+		cachedHasVal: true,
+	}
+	s := NewSampler(acc, fixedProcReader{})
+
+	const ticks = 5
+	base := time.Now()
+	for i := 0; i < ticks; i++ {
+		s.sample(base.Add(time.Duration(i) * time.Second))
+	}
+
+	if acc.statusCalls != 0 {
+		t.Fatalf("Sampler issued %d Status() control-socket request(s); want 0 "+
+			"(worker telemetry must come from the shared cached status, #3970)",
+			acc.statusCalls)
+	}
+	if acc.cachedCalls != ticks {
+		t.Errorf("CachedStatus() called %d times; want %d (once per sample)",
+			acc.cachedCalls, ticks)
+	}
+
+	// The fwdstatus worker data must still be populated from the shared
+	// poll: the newest ring sample carries the summed worker counters.
+	snap := s.Snapshot()
+	if len(snap.Samples) != ticks {
+		t.Fatalf("snapshot has %d samples; want %d", len(snap.Samples), ticks)
+	}
+	newest := snap.Samples[len(snap.Samples)-1]
+	if newest.workerThreadNs != 400 || newest.workerWallNs != 600 {
+		t.Errorf("worker counters not populated from cached status: "+
+			"thread=%d wall=%d; want thread=400 wall=600",
+			newest.workerThreadNs, newest.workerWallNs)
+	}
+}
+
+// On a cache miss (helper not yet polled) the Sampler holds worker
+// counters at their previous values and still issues NO Status()
+// control-socket request.
+func TestSamplerCacheMissHoldsCountersNoPoll(t *testing.T) {
+	acc := &countingAccessor{cachedHasVal: false}
+	s := NewSampler(acc, fixedProcReader{})
+	s.sample(time.Now())
+
+	if acc.statusCalls != 0 {
+		t.Fatalf("Sampler issued %d Status() request(s) on cache miss; want 0", acc.statusCalls)
+	}
+	snap := s.Snapshot()
+	if len(snap.Samples) != 1 {
+		t.Fatalf("snapshot has %d samples; want 1", len(snap.Samples))
+	}
+	if snap.Samples[0].workerThreadNs != 0 || snap.Samples[0].workerWallNs != 0 {
+		t.Errorf("cache miss should hold worker counters at zero, got thread=%d wall=%d",
+			snap.Samples[0].workerThreadNs, snap.Samples[0].workerWallNs)
+	}
+}
 
 // buildSnapshot constructs a deterministic snapshot for testing
 // window lookups. Samples are 1s apart ending at `now`.
@@ -31,8 +145,8 @@ func TestComputeCPUWindows_Populated(t *testing.T) {
 	// Worker: 2 workers; active = 400 Mns per worker-second = 40%.
 	now := time.Now()
 	snap := buildSnapshot(now, 400,
-		500_000_000,          // daemonRate: 500 Mns per sec = 50%/core
-		800_000_000,          // activeRate: 800 Mns/total-sec → per 2 workers = 400 Mns/worker/sec = 40%
+		500_000_000, // daemonRate: 500 Mns per sec = 50%/core
+		800_000_000, // activeRate: 800 Mns/total-sec → per 2 workers = 400 Mns/worker/sec = 40%
 		2)
 
 	dPct, wPct, dValid, wValid := computeCPUWindows(snap)
@@ -166,7 +280,7 @@ func TestFindSampleAtOrBefore(t *testing.T) {
 		{base.Add(-1 * time.Second), -1}, // before all
 		{base.Add(0 * time.Second), 0},   // exact oldest
 		{base.Add(1500 * time.Millisecond), 1},
-		{base.Add(3 * time.Second), 3}, // exact newest
+		{base.Add(3 * time.Second), 3},  // exact newest
 		{base.Add(10 * time.Second), 3}, // after all → newest
 	}
 	for _, c := range cases {


### PR DESCRIPTION
Closes #3970.

## Problem

The forwarding-status CPU `Sampler` (`pkg/fwdstatus/sampler.go`) ran its own 1 Hz timer goroutine and on every tick called `us.Status()` on the dataplane accessor. That bottoms out in `userspace.Manager.Status()` → `requestLocked({Type:"status"})` — a control-socket round-trip.

But the userspace manager ALSO runs a **primary 1 Hz status poll** (`statusLoop`, `pkg/dataplane/userspace/process.go:465`) that issues the same `status` request every second and caches the result in `m.lastStatus`.

Net = **two independent 1 Hz status requests (2/s)** on the control socket shared by session installs, HA sync, and snapshot sync — violating the CLAUDE.md "Control socket contention" budget (">1/s will starve session installs during bulk sync"). During failover/failback bulk session sync the redundant poll slowed install convergence, and the worker telemetry it fetched was already available from the primary poll's cache.

## Fix

- Add `Manager.CachedStatus() (ProcessStatus, bool)` — returns the last-captured `m.lastStatus` under lock **without** a control-socket request (`ok=false` when nothing captured yet, matching the `PID==0` sentinel `Status()` already uses for its stale-cache fallback).
- Thread it through `LegacyDataPlaneAdapter.CachedStatus()` and the daemon accessor (`forwardingStatusDaemonUserspaceDataPlane.CachedStatus()` + a `userspaceCachedStatusProbe`).
- The Sampler now type-asserts to `CachedStatus()` and consumes the cache the primary poll already fetched — it adds **zero** control-socket traffic. Net status rate stays 1/s.

On a cache miss (helper not yet polled) the worker counters hold at their previous values, matching the old `Status()`-error path exactly, so the cumulative CPU series stays monotonic. `Build()` (on-demand `show chassis forwarding`) still calls `Status()` directly — a rare CLI diagnostic, not a periodic poller, so not a rate violation.

## Tests (RED-on-revert)

`TestSamplerConsumesCachedStatusNoControlSocketPoll` + `TestSamplerCacheMissHoldsCountersNoPoll` use a counting accessor mocking both `Status()` (control socket) and `CachedStatus()` (cache) over N sampler ticks, and assert `statusCalls==0`, `cachedCalls==N`, and that the worker counters are still populated from the cache.

RED-on-revert verified: reverting the Sampler to call `Status()` fails with:
```
--- FAIL: TestSamplerConsumesCachedStatusNoControlSocketPoll
    sampler_test.go:78: Sampler issued 5 Status() control-socket request(s); want 0
```

`go test ./pkg/fwdstatus ./pkg/daemon ./pkg/grpcapi ./pkg/cli ./pkg/dataplane/userspace` green, `go build ./...`, gofmt, vet clean. Doc: `pkg/fwdstatus/README.md` gotcha added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
