### PR TITLE
config: hard-reject invalid port-mirroring entries (fix whole-table fail-close)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -30261,3 +30261,43 @@ top.
     pkg/dhcprelay/README.md #3960 giaddr-re-resolution bullet.
   - **File(s)**: pkg/dhcprelay/relay.go, pkg/dhcprelay/relay_test.go,
     pkg/dhcprelay/README.md, _Log.md
+
+- **Timestamp**: 2026-07-03
+  - **Action**: #3972 — port-mirroring invalid-entry fail mode. VERIFY FIRST
+    refuted the issue's stated fail-mode: the "warn + drop whole table" lived in
+    `pkg/dataplane/userspace/mirrors.go` `buildMirrorConfigSnapshotsFailClosed`
+    (the LIVE userspace snapshot path — `pkg/dataplane/compiler.go` port-mirror
+    compile is retired eBPF), NOT the Go compiler, and the Go compiler
+    (`compilePortMirroring`) did NO validation at all (silently accepted a
+    negative rate and a duplicate ingress). The #1376 plan
+    (docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md line 19)
+    intended the reject at COMMIT TIME; the implementation deferred it to the
+    snapshot builder, where one bad entry (duplicate ingress ifindex or negative
+    rate) returned an error that `buildMirrorConfigSnapshotsFailClosed` turned
+    into a whole-table drop with only a `slog.Warn` — 3 valid mirror sessions +
+    1 typo → all 4 lost silently. FIX = HARD-REJECT at commit (the issue's
+    preferred mode, matching the project's strict-commit-reject posture):
+    `config.compilePortMirroring` now returns a specific error naming the
+    offending instance on a duplicate ingress source (normalized via
+    `LinuxIfName` so vSRX/Linux spellings collide — one output per ingress
+    interface), a negative input rate, or a non-numeric rate (previously
+    swallowed → silently became rate 0 = mirror-all). `rate 0` stays valid
+    (mirror every packet, per the #1376 sampling model), so only negative /
+    non-numeric are rejected. Defense-in-depth: `buildMirrorConfigSnapshots`
+    converted from whole-table-fail-closed to SCOPE-DROP (skip only the bad
+    entry + specific warn, keep the valid sessions) and its `FailClosed` wrapper
+    removed (builder.go calls it directly). RED-on-revert (proven by restoring
+    origin/master source via `git show` in the worktree): the 3 new pkg/config
+    reject tests (`TestPortMirroringRejectsNegativeRateFlatSet`,
+    `...RejectsNonNumericRateFlatSet`, `...RejectsDuplicateIngressFlatSet`, all
+    ParseSetCommand+SetPath per CLAUDE.md) FAIL against the old compiler
+    (CompileConfig went green). All-valid config compiles all 3 instances
+    (`...AllValidFlatSetCompilesAllEntries`). Updated userspace tests to assert
+    scope-drop (`...ScopeDropsDuplicateIngressIfindex`,
+    `...ScopeDropsNegativeInputRate`). `go test ./pkg/config/...` +
+    `./pkg/dataplane/...` green; `go build ./...`, gofmt, vet clean.
+  - **File(s)**: pkg/config/compiler_services.go,
+    pkg/config/parser_routing_test.go,
+    pkg/dataplane/userspace/mirrors.go, pkg/dataplane/userspace/builder.go,
+    pkg/dataplane/userspace/manager_test.go,
+    docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md, _Log.md

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md
@@ -18,6 +18,40 @@ Add `MirrorConfig { output_ifindex, rate }` to the userspace snapshot and Rust
 state. Preserve the current eBPF data model: one mirror entry per ingress
 ifindex. Duplicate ingress ifindex config must be rejected at commit time.
 
+### Commit-Time Validation (#3972)
+
+The commit-time reject the design above called for was originally missing:
+`config.compilePortMirroring` accepted any input and the duplicate-ingress /
+negative-rate checks lived only in the snapshot builder
+(`buildMirrorConfigSnapshots`), where a single bad entry made
+`buildMirrorConfigSnapshotsFailClosed` drop the **entire** mirror table with
+only a `slog.Warn`. An operator with three valid mirror sessions plus one
+typo'd fourth (duplicate ingress or negative rate) lost **all** mirroring
+silently.
+
+`config.compilePortMirroring` now hard-rejects at commit, naming the offending
+instance:
+
+- **Duplicate ingress source** — the same interface used as an ingress source
+  by more than one instance (or twice in one instance). The mirror table
+  contract is one output per ingress interface. Ingress names are normalized
+  with `LinuxIfName`, so the vSRX (`ge-0/0/0.0`) and Linux (`ge-0-0-0.0`)
+  spellings of one interface collide.
+- **Negative input rate** — a negative rate would wrap in
+  `uint32(InputRate)`.
+- **Non-numeric input rate** — previously swallowed silently (`strconv.Atoi`
+  error ignored), which turned a typo'd `rate` into rate 0 = mirror every
+  packet. Now a specific reject.
+
+`rate 0` remains valid (mirror every packet, per the sampling model below), so
+only negative / non-numeric rates are rejected.
+
+The snapshot builder (`buildMirrorConfigSnapshots`) is now **scope-drop**
+defense-in-depth: if an invalid entry ever reaches it (e.g. a stale on-disk
+config written by an older build), it skips only the offending entry with a
+specific warning and still publishes the valid mirror sessions — it no longer
+fail-closes the whole table.
+
 Mirroring runs after ingress policy/forwarding decision while the original
 packet bytes are still available. A matched mirror allocates a clone frame,
 copies the full L2 frame with no truncation, and queues it to the configured
@@ -119,8 +153,10 @@ survival under mirror pressure.
 - Go/Rust: status/counter wire round-trips include
   `mirrored_packets`, `mirrored_bytes`, `mirror_drops_no_frame`,
   `mirror_drops_no_binding`, and `mirror_drops_queue_full`.
-- Go: commit validation rejects duplicate ingress mirror entries and logs/skips
-  nonexistent output ifindex consistently with current compiler behavior.
+- Go: commit validation (`config.compilePortMirroring`, #3972) hard-rejects
+  duplicate ingress mirror entries, negative rates, and non-numeric rates,
+  naming the offending instance; the snapshot builder scope-drops (rather than
+  whole-table fail-closes) and logs/skips a nonexistent output ifindex.
 - Go: `deriveUserspaceCapabilities()` admits port-mirroring configs now that
   snapshot/runtime support is wired, without emitting the stale unsupported
   reason.

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -1297,21 +1297,54 @@ func compilePortMirroring(node *Node, fo *ForwardingOptionsConfig) error {
 		Instances: make(map[string]*PortMirrorInstance),
 	}
 
+	// #3972: an invalid port-mirroring entry is a HARD commit reject naming
+	// the offending instance, NOT a green commit that later fail-closes the
+	// WHOLE mirror table with only a warn in the snapshot builder. This
+	// realizes the #1376 design ("Duplicate ingress ifindex config must be
+	// rejected at commit time", docs/pr/1373-retire-ebpf-dataplane/
+	// plan-1376-port-mirroring.md) which the original implementation deferred
+	// to buildMirrorConfigSnapshots — where one bad entry dropped every valid
+	// mirror session silently. Reject up front so an operator with 3 good
+	// sessions + 1 typo'd 4th sees the specific error and fixes it instead of
+	// losing all mirroring.
+	//
+	// The mirror table contract is one output per ingress interface, so an
+	// ingress source may be used only ONCE across all instances. Ingress
+	// names are normalized with LinuxIfName so the vSRX ("ge-0/0/0.0") and
+	// Linux ("ge-0-0-0.0") spellings of one interface are recognized as the
+	// same source (matching the snapshot builder's ifindex dedup).
+	ingressOwner := make(map[string]string)
+
 	for _, inst := range namedInstances(node.FindChildren("instance")) {
 		mi := &PortMirrorInstance{Name: inst.name}
 
 		if inputNode := inst.node.FindChild("input"); inputNode != nil {
 			if rateNode := inputNode.FindChild("rate"); rateNode != nil {
 				if v := nodeVal(rateNode); v != "" {
-					if n, err := strconv.Atoi(v); err == nil {
-						mi.InputRate = n
+					n, err := strconv.Atoi(v)
+					if err != nil {
+						return fmt.Errorf("port-mirroring instance %q: invalid input rate %q: must be a non-negative integer (0 mirrors every packet)", inst.name, v)
 					}
+					if n < 0 {
+						// uint32(InputRate) in the snapshot builder would wrap a
+						// negative rate into a huge 1-in-N sampling divisor.
+						return fmt.Errorf("port-mirroring instance %q: input rate must not be negative, got %d", inst.name, n)
+					}
+					mi.InputRate = n
 				}
 			}
 			if ingressNode := inputNode.FindChild("ingress"); ingressNode != nil {
 				for _, child := range ingressNode.Children {
 					if child.Name() == "interface" {
 						if v := nodeVal(child); v != "" {
+							key := LinuxIfName(v)
+							if owner, dup := ingressOwner[key]; dup {
+								if owner == inst.name {
+									return fmt.Errorf("port-mirroring instance %q: duplicate ingress interface %q", inst.name, v)
+								}
+								return fmt.Errorf("port-mirroring: ingress interface %q is mirrored by both instance %q and %q (one output per ingress interface)", v, owner, inst.name)
+							}
+							ingressOwner[key] = inst.name
 							mi.Input = append(mi.Input, v)
 						}
 					}

--- a/pkg/config/parser_routing_test.go
+++ b/pkg/config/parser_routing_test.go
@@ -2441,6 +2441,114 @@ func TestPortMirroringSetSyntaxMultiInput(t *testing.T) {
 	}
 }
 
+// compilePortMirroringSet is a flat-set helper: it runs each `set` command
+// through ParseSetCommand + tree.SetPath (NEVER NewParser — the parser merges
+// newline-separated set lines into one node) then compiles the tree.
+func compilePortMirroringSet(t *testing.T, cmds ...string) (*Config, error) {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return CompileConfig(tree)
+}
+
+// #3972: an invalid port-mirroring entry (negative rate, duplicate ingress
+// source) must be a HARD commit reject naming the bad entry — NOT a green
+// commit that later fail-closes the WHOLE mirror table with only a warn in the
+// snapshot builder. RED-on-revert: pre-#3972 the compiler silently accepted a
+// negative rate (InputRate=-5) and a cross-instance duplicate ingress, the
+// commit went green, and buildMirrorConfigSnapshots then dropped every valid
+// mirror session. These tests go RED against that behavior.
+func TestPortMirroringRejectsNegativeRateFlatSet(t *testing.T) {
+	// 3 valid instances + 1 with a negative rate.
+	cfg, err := compilePortMirroringSet(t,
+		"set forwarding-options port-mirroring instance span1 input rate 10",
+		"set forwarding-options port-mirroring instance span1 input ingress interface ge-0/0/0.0",
+		"set forwarding-options port-mirroring instance span1 output interface mon0",
+		"set forwarding-options port-mirroring instance span2 input rate 20",
+		"set forwarding-options port-mirroring instance span2 input ingress interface ge-0/0/1.0",
+		"set forwarding-options port-mirroring instance span2 output interface mon0",
+		"set forwarding-options port-mirroring instance span3 input ingress interface ge-0/0/2.0",
+		"set forwarding-options port-mirroring instance span3 output interface mon0",
+		"set forwarding-options port-mirroring instance bad input rate -5",
+		"set forwarding-options port-mirroring instance bad input ingress interface ge-0/0/3.0",
+		"set forwarding-options port-mirroring instance bad output interface mon0",
+	)
+	if err == nil {
+		t.Fatalf("CompileConfig succeeded, want reject for negative rate; PortMirroring=%+v", cfg.ForwardingOptions.PortMirroring)
+	}
+	if !strings.Contains(err.Error(), `instance "bad"`) || !strings.Contains(err.Error(), "negative") {
+		t.Fatalf("error = %v, want a specific negative-rate reject naming instance \"bad\"", err)
+	}
+}
+
+func TestPortMirroringRejectsNonNumericRateFlatSet(t *testing.T) {
+	_, err := compilePortMirroringSet(t,
+		"set forwarding-options port-mirroring instance span1 input rate notanumber",
+		"set forwarding-options port-mirroring instance span1 input ingress interface ge-0/0/0.0",
+		"set forwarding-options port-mirroring instance span1 output interface mon0",
+	)
+	if err == nil || !strings.Contains(err.Error(), `instance "span1"`) || !strings.Contains(err.Error(), "invalid input rate") {
+		t.Fatalf("error = %v, want invalid-input-rate reject naming instance \"span1\"", err)
+	}
+}
+
+// A duplicate ingress source across two instances is rejected — the mirror
+// table contract is one output per ingress interface. Names are normalized so
+// the vSRX ("ge-0/0/0.0") and Linux ("ge-0-0-0.0") spellings collide.
+func TestPortMirroringRejectsDuplicateIngressFlatSet(t *testing.T) {
+	_, err := compilePortMirroringSet(t,
+		"set forwarding-options port-mirroring instance span1 input ingress interface ge-0/0/0.0",
+		"set forwarding-options port-mirroring instance span1 output interface mon0",
+		"set forwarding-options port-mirroring instance span2 input ingress interface ge-0-0-0.0",
+		"set forwarding-options port-mirroring instance span2 output interface mon1",
+	)
+	if err == nil {
+		t.Fatal("CompileConfig succeeded, want reject for duplicate ingress interface across instances")
+	}
+	if !strings.Contains(err.Error(), `"span1"`) || !strings.Contains(err.Error(), `"span2"`) {
+		t.Fatalf("error = %v, want a duplicate-ingress reject naming both instances", err)
+	}
+}
+
+// An all-valid config compiles every instance. rate 0 (mirror every packet) is
+// valid per the #1376 design, so it is NOT rejected.
+func TestPortMirroringAllValidFlatSetCompilesAllEntries(t *testing.T) {
+	cfg, err := compilePortMirroringSet(t,
+		"set forwarding-options port-mirroring instance span1 input rate 10",
+		"set forwarding-options port-mirroring instance span1 input ingress interface ge-0/0/0.0",
+		"set forwarding-options port-mirroring instance span1 output interface mon0",
+		"set forwarding-options port-mirroring instance span2 input rate 20",
+		"set forwarding-options port-mirroring instance span2 input ingress interface ge-0/0/1.0",
+		"set forwarding-options port-mirroring instance span2 output interface mon0",
+		"set forwarding-options port-mirroring instance span3 input rate 0",
+		"set forwarding-options port-mirroring instance span3 input ingress interface ge-0/0/2.0",
+		"set forwarding-options port-mirroring instance span3 output interface mon1",
+	)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	pm := cfg.ForwardingOptions.PortMirroring
+	if pm == nil || len(pm.Instances) != 3 {
+		t.Fatalf("PortMirroring = %+v, want 3 instances", pm)
+	}
+	if got := pm.Instances["span3"].InputRate; got != 0 {
+		t.Fatalf("span3 InputRate = %d, want 0 (mirror all)", got)
+	}
+	for _, name := range []string{"span1", "span2", "span3"} {
+		if pm.Instances[name] == nil {
+			t.Fatalf("instance %q missing after compile", name)
+		}
+	}
+}
+
 func TestPortMirroringHierarchicalSimple(t *testing.T) {
 	input := `forwarding-options {
     port-mirroring {

--- a/pkg/dataplane/userspace/builder.go
+++ b/pkg/dataplane/userspace/builder.go
@@ -113,7 +113,7 @@ func buildSnapshotWithSchedulerStateAndNATCounters(cfg *config.Config, ucfg conf
 		ThreeColorPolicers:    buildThreeColorPolicerSnapshots(cfg),
 		ClassOfService:        buildClassOfServiceSnapshot(cfg),
 		FlowExport:            buildFlowExportSnapshot(cfg),
-		MirrorConfigs:         buildMirrorConfigSnapshotsFailClosed(cfg, interfaces),
+		MirrorConfigs:         buildMirrorConfigSnapshots(cfg, interfaces),
 		AddressBooks:          addressBooks,
 		AppCatalog:            appCatalog,
 		Config:                cfg,

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -2976,10 +2976,7 @@ func TestBuildMirrorConfigSnapshots(t *testing.T) {
 		{Name: "ge-0/0/1.0", LinuxName: "ge-0-0-1.0", Ifindex: 22},
 	}
 
-	got, err := buildMirrorConfigSnapshots(cfg, interfaces)
-	if err != nil {
-		t.Fatalf("buildMirrorConfigSnapshots: %v", err)
-	}
+	got := buildMirrorConfigSnapshots(cfg, interfaces)
 	want := []MirrorConfigSnapshot{{IngressIfindex: 11, OutputIfindex: 22, Rate: 50}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("mirror snapshots = %+v, want %+v", got, want)
@@ -3019,7 +3016,11 @@ func TestBuildSnapshotIncludesMirrorConfigsFromRealInterfaceSnapshot(t *testing.
 	}
 }
 
-func TestBuildMirrorConfigSnapshotsRejectsDuplicateIngressIfindex(t *testing.T) {
+// #3972: a duplicate ingress ifindex is now a SCOPE-DROP at snapshot build
+// (the commit gate hard-rejects it up front). The first instance by sorted
+// name owns the ingress; the conflicting one is skipped and the valid mirror
+// table is still published, rather than the whole table being fail-closed.
+func TestBuildMirrorConfigSnapshotsScopeDropsDuplicateIngressIfindex(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.ForwardingOptions.PortMirroring = &config.PortMirroringConfig{
 		Instances: map[string]*config.PortMirrorInstance{
@@ -3040,9 +3041,10 @@ func TestBuildMirrorConfigSnapshotsRejectsDuplicateIngressIfindex(t *testing.T) 
 		{Name: "ge-0/0/1.0", LinuxName: "ge-0-0-1.0", Ifindex: 22},
 	}
 
-	_, err := buildMirrorConfigSnapshots(cfg, interfaces)
-	if err == nil || !strings.Contains(err.Error(), "duplicate port-mirroring ingress ifindex 11") {
-		t.Fatalf("error = %v, want duplicate ingress ifindex rejection", err)
+	got := buildMirrorConfigSnapshots(cfg, interfaces)
+	want := []MirrorConfigSnapshot{{IngressIfindex: 11, OutputIfindex: 22, Rate: 0}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mirror snapshots = %+v, want first-owner entry kept, duplicate scope-dropped %+v", got, want)
 	}
 }
 
@@ -3062,23 +3064,29 @@ func TestBuildMirrorConfigSnapshotsSkipsMissingOutputIfindex(t *testing.T) {
 		{Name: "ge-0/0/9.0", LinuxName: "ge-0-0-9.0", Ifindex: 0},
 	}
 
-	got, err := buildMirrorConfigSnapshots(cfg, interfaces)
-	if err != nil {
-		t.Fatalf("buildMirrorConfigSnapshots: %v", err)
-	}
+	got := buildMirrorConfigSnapshots(cfg, interfaces)
 	if len(got) != 0 {
 		t.Fatalf("mirror snapshots = %+v, want missing output ifindex skipped", got)
 	}
 }
 
-func TestBuildMirrorConfigSnapshotsRejectsNegativeInputRate(t *testing.T) {
+// #3972: a negative rate is scope-dropped at snapshot build (commit gate
+// rejects it up front); the other instances survive. Here the lone instance
+// is skipped, yielding an empty table without a whole-table fail-close.
+func TestBuildMirrorConfigSnapshotsScopeDropsNegativeInputRate(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.ForwardingOptions.PortMirroring = &config.PortMirroringConfig{
 		Instances: map[string]*config.PortMirrorInstance{
-			"span1": {
-				Name:      "span1",
+			"bad": {
+				Name:      "bad",
 				InputRate: -1,
 				Input:     []string{"ge-0/0/0.0"},
+				Output:    "ge-0/0/1.0",
+			},
+			"good": {
+				Name:      "good",
+				InputRate: 5,
+				Input:     []string{"ge-0/0/2.0"},
 				Output:    "ge-0/0/1.0",
 			},
 		},
@@ -3086,11 +3094,13 @@ func TestBuildMirrorConfigSnapshotsRejectsNegativeInputRate(t *testing.T) {
 	interfaces := []InterfaceSnapshot{
 		{Name: "ge-0/0/0.0", LinuxName: "ge-0-0-0.0", Ifindex: 11},
 		{Name: "ge-0/0/1.0", LinuxName: "ge-0-0-1.0", Ifindex: 22},
+		{Name: "ge-0/0/2.0", LinuxName: "ge-0-0-2.0", Ifindex: 33},
 	}
 
-	_, err := buildMirrorConfigSnapshots(cfg, interfaces)
-	if err == nil || !strings.Contains(err.Error(), "negative input rate") {
-		t.Fatalf("error = %v, want negative input rate rejection", err)
+	got := buildMirrorConfigSnapshots(cfg, interfaces)
+	want := []MirrorConfigSnapshot{{IngressIfindex: 33, OutputIfindex: 22, Rate: 5}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mirror snapshots = %+v, want negative-rate instance dropped, valid one kept %+v", got, want)
 	}
 }
 

--- a/pkg/dataplane/userspace/mirrors.go
+++ b/pkg/dataplane/userspace/mirrors.go
@@ -1,28 +1,29 @@
 package userspace
 
 import (
-	"fmt"
 	"log/slog"
 	"sort"
 
 	"github.com/psaab/xpf/pkg/config"
 )
 
-func buildMirrorConfigSnapshotsFailClosed(cfg *config.Config, interfaces []InterfaceSnapshot) []MirrorConfigSnapshot {
-	mirrors, err := buildMirrorConfigSnapshots(cfg, interfaces)
-	if err != nil {
-		// The mirror table contract is one output per ingress ifindex. Keep
-		// snapshot publication fail-closed by omitting an ambiguous mirror table
-		// if this helper is called on an invalid config.
-		slog.Warn("userspace snapshot: invalid port-mirroring config skipped", "err", err)
-		return nil
-	}
-	return mirrors
-}
-
-func buildMirrorConfigSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot) ([]MirrorConfigSnapshot, error) {
+// buildMirrorConfigSnapshots resolves forwarding-options port-mirroring into
+// the per-ingress mirror table. The table contract is one output per ingress
+// ifindex, so a duplicate ingress ifindex (the same physical interface used as
+// an ingress source by more than one instance) or a negative sampling rate is
+// a SCOPE-DROP: the offending entry is skipped with a specific warning and the
+// remaining valid entries are still published (#3972). One typo must never
+// silently disable ALL mirroring.
+//
+// config.compilePortMirroring already HARD-REJECTS these cases at commit time,
+// so this scope-drop is defense-in-depth for a config that reaches the
+// snapshot builder without passing the commit gate (e.g. a stale on-disk
+// config written by an older build). It replaces the pre-#3972
+// whole-table-fail-closed-on-warn behavior that dropped every valid mirror
+// session on a single bad entry.
+func buildMirrorConfigSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot) []MirrorConfigSnapshot {
 	if cfg == nil || cfg.ForwardingOptions.PortMirroring == nil || len(cfg.ForwardingOptions.PortMirroring.Instances) == 0 {
-		return nil, nil
+		return nil
 	}
 	ifindexByName := make(map[string]int, len(interfaces))
 	for _, iface := range interfaces {
@@ -51,6 +52,13 @@ func buildMirrorConfigSnapshots(cfg *config.Config, interfaces []InterfaceSnapsh
 			slog.Warn("port-mirroring instance has no output interface", "name", name)
 			continue
 		}
+		if inst.InputRate < 0 {
+			// A negative rate would wrap in uint32(inst.InputRate) below. Drop
+			// only this instance; the commit gate rejects it up front.
+			slog.Warn("port-mirroring: skipping instance with negative input rate",
+				"name", name, "rate", inst.InputRate)
+			continue
+		}
 		outputIfindex := ifindexByName[inst.Output]
 		if outputIfindex <= 0 {
 			outputIfindex = ifindexByName[config.LinuxIfName(inst.Output)]
@@ -72,10 +80,11 @@ func buildMirrorConfigSnapshots(cfg *config.Config, interfaces []InterfaceSnapsh
 				continue
 			}
 			if previous, ok := seenIngress[ingressIfindex]; ok {
-				return nil, fmt.Errorf("duplicate port-mirroring ingress ifindex %d in instances %q and %q", ingressIfindex, previous, name)
-			}
-			if inst.InputRate < 0 {
-				return nil, fmt.Errorf("port-mirroring instance %q has negative input rate %d", name, inst.InputRate)
+				// One output per ingress ifindex: the first instance (sorted
+				// by name) owns it. Skip the conflicting entry, keep the rest.
+				slog.Warn("port-mirroring: skipping duplicate ingress interface (one output per ingress interface)",
+					"name", name, "interface", input, "ifindex", ingressIfindex, "owner", previous)
+				continue
 			}
 			seenIngress[ingressIfindex] = name
 			out = append(out, MirrorConfigSnapshot{
@@ -85,5 +94,5 @@ func buildMirrorConfigSnapshots(cfg *config.Config, interfaces []InterfaceSnapsh
 			})
 		}
 	}
-	return out, nil
+	return out
 }


### PR DESCRIPTION
## Summary

Closes #3972.

An invalid `forwarding-options port-mirroring` entry — a **duplicate ingress source**, a **negative sampling rate**, or a **non-numeric rate** — used to commit green, then silently disable **all** mirroring.

### What was actually happening (the issue's premise, refined)

The issue described a "warn + drop the whole table" fail mode. Verification found it, but not in the Go compiler the fix-note pointed at:

- `config.compilePortMirroring` (`pkg/config/compiler_services.go`) did **no validation at all** — it stored a negative rate as-is and appended duplicate ingress interfaces without complaint.
- The duplicate-ingress / negative-rate checks lived only in the **live userspace snapshot builder** `buildMirrorConfigSnapshots` (`pkg/dataplane/userspace/mirrors.go`). On any single bad entry it returned an error that `buildMirrorConfigSnapshotsFailClosed` turned into a `nil` mirror table with only a `slog.Warn`. (`pkg/dataplane/compiler.go`'s port-mirror compile is retired-eBPF dead code.)

Result: an operator with 3 valid mirror sessions + 1 typo'd 4th lost **all 4** — traffic analysis / IDS feed / packet capture silently stopped, with only a log warning.

The #1376 design already required this reject **at commit time** ("Duplicate ingress ifindex config must be rejected at commit time"); the implementation deferred it to the snapshot builder. This PR restores the intended posture.

## Fix — hard-reject at commit (issue's preferred mode)

`config.compilePortMirroring` now returns a specific commit error naming the offending instance on:

- **Duplicate ingress source** — same interface as an ingress source in more than one instance (or twice in one). One output per ingress interface. Names normalized via `LinuxIfName` so `ge-0/0/0.0` and `ge-0-0-0.0` collide (matching the builder's ifindex dedup).
- **Negative input rate** — would wrap in `uint32(InputRate)`.
- **Non-numeric input rate** — previously swallowed by an ignored `strconv.Atoi` error, silently turning a typo into rate 0 = mirror every packet.

`rate 0` stays valid (mirror every packet, per the #1376 sampling model), so only negative / non-numeric rates are rejected.

### Defense-in-depth

`buildMirrorConfigSnapshots` no longer whole-table fail-closes. It **scope-drops** the offending entry (specific warn, valid sessions kept) for any config that reaches it without passing the commit gate (e.g. a stale on-disk config from an older build). The `FailClosed` wrapper is removed; `builder.go` calls the builder directly.

## Tests

RED-on-revert (proven by restoring `origin/master` source via `git show` in the worktree — all three fail against the pre-fix compiler, which committed green):

- `TestPortMirroringRejectsNegativeRateFlatSet` — 3 valid + 1 negative-rate instance → reject naming `"bad"`.
- `TestPortMirroringRejectsNonNumericRateFlatSet`.
- `TestPortMirroringRejectsDuplicateIngressFlatSet` — cross-instance dup via vSRX/Linux spellings.
- `TestPortMirroringAllValidFlatSetCompilesAllEntries` — all-valid config compiles every instance, `rate 0` accepted.

All use `ParseSetCommand` + `tree.SetPath` (not `NewParser`), per CLAUDE.md. Userspace tests updated to assert scope-drop (`...ScopeDropsDuplicateIngressIfindex`, `...ScopeDropsNegativeInputRate`).

`go test ./pkg/config/...` + `./pkg/dataplane/...` green; `go build ./...`, `gofmt`, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
