### PR TITLE
config: handle bracketed multi-value leaf in deactivate/activate (#3975)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-07-03 — #3975: `deactivate`/`activate` on a bracketed multi-value leaf errored + broke round-trip (setInactiveAtPath lacked the #2419 multi-value handling deletePath got in #3846)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-034 (MEDIUM, config-mode parity).
+    `setInactiveAtPath` (`pkg/config/ast_edit.go`), the shared
+    `deactivate`/`activate` config-mode edit, did NOT handle the bracketed
+    multi-value leaf shape (#2419) that `deletePath` got in #3846/#3848/#3879.
+    A `multi: true` value-list leaf collapses `[ a b c ]` onto ONE node's
+    `Keys=["field","a","b","c"]`, but the schema-driven traversal ate the
+    first member as an extra key (`nodeKeyCount == 2`) then treated the rest
+    as container tokens: `deactivate ... from protocol tcp udp icmp` — the
+    EXACT line `show | display set` emits for an inactive bracket leaf —
+    errored `container "protocol tcp" does not exist`. So an inactive
+    bracket leaf did NOT round-trip: replaying its display-set errored and
+    the leaf reloaded ACTIVE, silently losing the operator's deactivate
+    intent (the deactivate-side counterpart of the #3846 delete-side fail).
+  - **Fix**: added the same multi-leaf interception `deletePath` uses to
+    `setInactiveAtPath` (gate `multi && (children == nil || valueList) &&
+    args == 1`), routing to a new `markMultiLeafMembersInactive` helper that
+    mirrors `removeMultiLeafMembers`: no member → toggle the whole leaf;
+    named members → toggle the whole node when any rides on `Keys[1:]` (the
+    flat/bracket shape — `Inactive` is node-level, a bracket list is one
+    statement), and for a plain value-list leaf ALSO toggle named child nodes
+    (block shape); absent member → not-found error. `args == 1` gate keeps
+    keyed multi entries (`address <name> <prefix>`) on whole-node toggle.
+  - **Test**: `pkg/config/deactivate_multi_leaf_3975_test.go` — firewall
+    `from protocol` (whole expanded list / no-member / member /
+    absent-member-errors / activate-reverses / display-set round-trip),
+    policy match `source-address`, block-shape `system-services` member
+    toggle, single-value-leaf and keyed-entry non-regression. RED-on-revert
+    verified: reverting the branch makes the whole-list/member/round-trip/
+    activate assertions error `container "protocol tcp" does not exist`.
+    Full `go test ./pkg/config/...` green; `go build ./...`, gofmt, vet clean.
+  - **File(s)**: `pkg/config/ast_edit.go`,
+    `pkg/config/deactivate_multi_leaf_3975_test.go`, `docs/config-schema.md`,
+    `_Log.md`.
+
 ## 2026-07-03 — #3970: fwdstatus Sampler issued its OWN redundant 1 Hz control-socket status poll on top of the primary status poll → 2/s on the shared control socket, starving session installs during bulk sync
 
 - **Timestamp**: 2026-07-03

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -161,6 +161,41 @@ a1` still removes that whole entry, not just its name token. Covered by
 protocol`, host-inbound-traffic `system-services`, policy match
 `source-address`, and the keyed-entry `address` non-regression).
 
+**Deactivate-side contract: toggle the whole bracket leaf, round-trippably
+(#3975).** `deactivate` / `activate` (`setInactiveAtPath`, `ast_edit.go`)
+needed the SAME multi-leaf interception the delete side got in #3846. The
+`Inactive` marker is a NODE-level flag and a bracket list collapses onto ONE
+node's `Keys[1:]`, so a bracket-list leaf can only be toggled whole — but the
+pre-#3975 schema-driven traversal ate the first member as an extra key
+(`nodeKeyCount == 2`) and then treated the remaining members as container
+tokens, so `deactivate ... from protocol tcp udp icmp` ERRORED with
+`container "protocol tcp" does not exist`. That is exactly the line
+`show | display set` emits for an inactive bracket leaf (`ast_format.go`
+expands `deactivate <path> tcp udp icmp`), so an inactive bracket leaf did NOT
+round-trip: replaying its display-set errored and the leaf reloaded ACTIVE — a
+silent loss of the operator's deactivate intent, the deactivate-side
+counterpart of the #3846 fail. `setInactiveAtPath` now intercepts value-list
+multi-leaves (`multi: true`, `children == nil` or `valueList`, `args == 1`) and
+routes them to `markMultiLeafMembersInactive`, which:
+
+- with no trailing member (`deactivate ... from protocol`), toggles the whole
+  leaf (via `markMatchingNodeInactive`);
+- with trailing member token(s), toggles the WHOLE node when any named member
+  rides on `Keys[1:]` (the flat/bracket shape — a bracket list is one statement
+  and cannot be half-deactivated), and for a plain value-list leaf ALSO toggles
+  any named child node (the hierarchical block shape, e.g.
+  `system-services { ssh; https; }`);
+- reports a member that is not present anywhere as not-found, matching
+  `removeMultiLeafMembers`'s contract.
+
+The `args == 1` gate keeps keyed multi entries (`address <name> <prefix>`,
+`args: 2`) on whole-node toggle semantics, exactly like the delete side.
+Covered by `pkg/config/deactivate_multi_leaf_3975_test.go` (firewall `from
+protocol` whole-list / no-member / member / absent-member / activate-reverse /
+display-set round-trip, policy match `source-address`, block-shape
+`system-services` member toggle, single-value-leaf and keyed-entry
+non-regression).
+
 **Firewall-filter `source/destination-prefix-list` refs are dual-AST too
 (#3843).** These `from` leaves are NOT `multi: true` value-tails — each
 reference carries an optional trailing `except` modifier, so they compile
@@ -3857,7 +3892,11 @@ replay paths (`LoadSet`, `LoadMerge`, and the hierarchical
 `ConfigTree.DeactivatePath` / `ActivatePath` (`ast_edit.go`). So display-set
 output round-trips: an inactive node reloads inactive rather than being
 skipped (and silently reactivated) or parsed as a junk path beginning
-"deactivate".
+"deactivate". A bracket-list (`multi: true`) leaf round-trips too: its
+display-set `deactivate` line carries the fully-expanded member list
+(`deactivate ... from protocol tcp udp icmp`), and `setInactiveAtPath` routes
+that shape through the multi-leaf branch (#3975, see "Deactivate-side contract"
+above) instead of erroring on the trailing members.
 
 **Interactive `activate` / `deactivate` config-mode verbs (#2051).** The two
 verbs are first-class config-mode edits on all four surfaces. The store

--- a/pkg/config/ast_edit.go
+++ b/pkg/config/ast_edit.go
@@ -491,6 +491,26 @@ func setInactiveAtPath(current *[]*Node, path []string, schema *schemaNode, i in
 		return markMatchingNodeInactive(current, path[i:], inactive)
 	}
 
+	// Value-list multi-leaf: the same bracket-list class deletePath intercepts
+	// (see the deletePath comment). A `multi: true` leaf with a single value slot
+	// and no children (or a valueList leaf with modifier children, #3872) carries
+	// its members on Keys[1:] AND/OR one child node per member — the #2419 dual
+	// AST shape. Without this branch the schema-driven consumption below eats the
+	// first member as an extra key (nodeKeyCount == 2), then treats the remaining
+	// members as container tokens and errors ("container \"protocol tcp\" does not
+	// exist"): the display-set emit of an inactive bracket leaf is exactly
+	// `deactivate ... from protocol tcp udp icmp`, so an inactive multi-value leaf
+	// did NOT round-trip — it reloaded ACTIVE (#3975, the deactivate-side
+	// counterpart of the #3846 delete-side fail). Route it through the member
+	// matcher instead: a bare `deactivate ... protocol` toggles the whole leaf;
+	// naming members toggles the whole leaf (flat/bracket — Inactive is a
+	// node-level flag, a bracket list is one statement) or the named child nodes
+	// (block shape). Gate on args == 1 so keyed multi entries (address <name>
+	// <prefix>, args == 2) keep whole-node toggle semantics.
+	if childSchema.multi && (childSchema.children == nil || childSchema.valueList) && childSchema.args == 1 {
+		return markMultiLeafMembersInactive(current, keyword, path[i+1:], childSchema.valueList, inactive)
+	}
+
 	nodeKeyCount := 1 + childSchema.args
 	if i+nodeKeyCount > len(path) {
 		return markMatchingNodeInactive(current, path[i:], inactive)
@@ -627,6 +647,75 @@ func removeMultiLeafMembers(nodes *[]*Node, keyword string, members []string, mo
 	}
 	*nodes = out
 	if !removedAny {
+		return fmt.Errorf("path not found: no member %q of %q",
+			strings.Join(members, " "), keyword)
+	}
+	return nil
+}
+
+// markMultiLeafMembersInactive is the deactivate/activate counterpart of
+// removeMultiLeafMembers for a value-list multi-leaf (#3975). keyword is the
+// leaf's first key ("protocol", "system-services", "next-hop"); members are the
+// trailing tokens. Unlike delete, the Inactive marker is a NODE-level flag, so a
+// bracket list — collapsed onto ONE node's Keys[1:] — can only be toggled whole,
+// never per-value; block-shape members (one child node each) can be toggled
+// individually.
+//
+//   - members empty  → toggle the whole leaf (mirrors markMatchingNodeInactive's
+//     prefix match), so `deactivate ... protocol` toggles the list.
+//   - members named  → for every node whose first key is keyword, toggle the
+//     WHOLE node when any named member rides on Keys[1:] (the flat/bracket shape —
+//     this is what display-set emits: `deactivate ... protocol tcp udp icmp`), and
+//     for a plain value-list leaf ALSO toggle any child node the members name
+//     (the hierarchical block shape). This restores round-trip of an inactive
+//     bracket leaf, which errored before #3975.
+//
+// modifierChildren mirrors removeMultiLeafMembers: when true (a valueList leaf
+// whose children are MODIFIERS of the value, e.g. static next-hop's interface),
+// the children are never members, so only the Keys[1:] flat match applies.
+//
+// Returns an error when no named member was found anywhere, mirroring
+// removeMultiLeafMembers' not-found contract.
+func markMultiLeafMembersInactive(nodes *[]*Node, keyword string, members []string, modifierChildren, inactive bool) error {
+	if len(members) == 0 {
+		return markMatchingNodeInactive(nodes, []string{keyword}, inactive)
+	}
+	drop := make(map[string]bool, len(members))
+	for _, m := range members {
+		drop[m] = true
+	}
+	matched := false
+	for _, n := range *nodes {
+		if len(n.Keys) == 0 || n.Keys[0] != keyword {
+			continue
+		}
+		// Flat / bracket shape: members ride on Keys[1:]. Inactive is node-level,
+		// so any named member present toggles the whole statement.
+		flatMatch := false
+		for _, v := range n.Keys[1:] {
+			if drop[v] {
+				flatMatch = true
+				break
+			}
+		}
+		if flatMatch {
+			n.Inactive = inactive
+			matched = true
+			continue
+		}
+		if modifierChildren {
+			// valueList node: children are MODIFIERS, never members.
+			continue
+		}
+		// Block shape: one child node per member — toggle only the named ones.
+		for _, c := range n.Children {
+			if len(c.Keys) >= 1 && drop[c.Keys[0]] {
+				c.Inactive = inactive
+				matched = true
+			}
+		}
+	}
+	if !matched {
 		return fmt.Errorf("path not found: no member %q of %q",
 			strings.Join(members, " "), keyword)
 	}

--- a/pkg/config/deactivate_multi_leaf_3975_test.go
+++ b/pkg/config/deactivate_multi_leaf_3975_test.go
@@ -1,0 +1,379 @@
+package config
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestDeactivateMultiLeaf_3975 pins the deactivate/activate counterpart of the
+// #2419 multi-value-leaf class. On a `multi: true` value-list leaf that holds a
+// bracket list (`from protocol [ tcp udp icmp ]`, policy match values,
+// host-inbound-services), `deactivate`/`activate` must toggle the leaf's
+// Inactive marker across the WHOLE bracket-list node — before #3975 the
+// schema-driven traversal ate the first member as an extra key and then treated
+// the remaining members as container tokens, so:
+//
+//   - `deactivate ... from protocol tcp udp icmp` (exactly what display-set
+//     emits for an inactive bracket leaf) ERRORED with "container \"protocol
+//     tcp\" does not exist"; and
+//   - an inactive bracket leaf therefore did NOT round-trip — FormatSet emitted
+//     the expanded `deactivate` line and replaying it errored, so the leaf
+//     reloaded ACTIVE (a silent loss of the operator's deactivate intent).
+//
+// fail-on-revert: reverting the markMultiLeafMembersInactive branch makes the
+// whole-list / round-trip / activate assertions RED (deactivate errors and the
+// leaf reloads active, so the compiler sees the protocols instead of an empty
+// match).
+
+// deactivateProtocols reads the compiled `from protocol` match values for a
+// firewall-filter term (the read side). An inactive leaf is pruned by the
+// compiler, so the returned slice is empty.
+func deactivateProtocols(t *testing.T, tree *ConfigTree, filter, term string) []string {
+	t.Helper()
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	f := cfg.Firewall.FiltersInet[filter]
+	if f == nil {
+		t.Fatalf("filter %q not found", filter)
+	}
+	for _, tm := range f.Terms {
+		if tm.Name == term {
+			got := append([]string(nil), tm.Protocols...)
+			sort.Strings(got)
+			return got
+		}
+	}
+	t.Fatalf("term %q not found in filter %q", term, filter)
+	return nil
+}
+
+func mustDeactivate(t *testing.T, tree *ConfigTree, cmd string) {
+	t.Helper()
+	path, err := ParseSetCommand(cmd)
+	if err != nil {
+		t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+	}
+	if err := tree.DeactivatePath(path); err != nil {
+		t.Fatalf("DeactivatePath(%q): %v", cmd, err)
+	}
+}
+
+func mustActivate(t *testing.T, tree *ConfigTree, cmd string) {
+	t.Helper()
+	path, err := ParseSetCommand(cmd)
+	if err != nil {
+		t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+	}
+	if err := tree.ActivatePath(path); err != nil {
+		t.Fatalf("ActivatePath(%q): %v", cmd, err)
+	}
+}
+
+func TestDeactivateMultiLeaf_FirewallProtocol(t *testing.T) {
+	base := "set firewall family inet filter F term T from protocol [ tcp udp icmp ]"
+	accept := "set firewall family inet filter F term T then accept"
+	allProtos := []string{"icmp", "tcp", "udp"}
+
+	// (1) Whole expanded list — the exact line display-set emits. Before #3975
+	// this ERRORED; now it marks the whole leaf inactive so the compiler prunes it.
+	t.Run("deactivate-whole-expanded-list", func(t *testing.T) {
+		tree := buildTree3846(t, base, accept)
+		mustDeactivate(t, tree, "deactivate firewall family inet filter F term T from protocol tcp udp icmp")
+		if got := deactivateProtocols(t, tree, "F", "T"); len(got) != 0 {
+			t.Fatalf("after deactivate expanded list: protocols = %v, want empty (leaf inactive)", got)
+		}
+	})
+
+	// (2) Bare `deactivate ... from protocol` (no member) toggles the whole leaf.
+	t.Run("deactivate-no-member", func(t *testing.T) {
+		tree := buildTree3846(t, base, accept)
+		mustDeactivate(t, tree, "deactivate firewall family inet filter F term T from protocol")
+		if got := deactivateProtocols(t, tree, "F", "T"); len(got) != 0 {
+			t.Fatalf("after deactivate no-member: protocols = %v, want empty", got)
+		}
+	})
+
+	// (3) Naming a single member toggles the whole bracket-list statement
+	// (Inactive is node-level — a bracket list cannot be half-deactivated).
+	t.Run("deactivate-single-member-toggles-whole-leaf", func(t *testing.T) {
+		tree := buildTree3846(t, base, accept)
+		mustDeactivate(t, tree, "deactivate firewall family inet filter F term T from protocol udp")
+		if got := deactivateProtocols(t, tree, "F", "T"); len(got) != 0 {
+			t.Fatalf("after deactivate one member: protocols = %v, want empty", got)
+		}
+	})
+
+	// (4) Deactivating an absent member is a not-found error (delete's contract).
+	t.Run("deactivate-absent-member-errors", func(t *testing.T) {
+		tree := buildTree3846(t, base, accept)
+		path, _ := ParseSetCommand("deactivate firewall family inet filter F term T from protocol gre")
+		if err := tree.DeactivatePath(path); err == nil {
+			t.Fatal("deactivating an absent member should return an error")
+		}
+		if got := deactivateProtocols(t, tree, "F", "T"); !equalStrs3846(got, allProtos) {
+			t.Fatalf("failed deactivate must not disturb the leaf: protocols = %v, want %v", got, allProtos)
+		}
+	})
+
+	// (5) activate reverses the deactivate — the leaf compiles again.
+	t.Run("activate-reverses", func(t *testing.T) {
+		tree := buildTree3846(t, base, accept)
+		mustDeactivate(t, tree, "deactivate firewall family inet filter F term T from protocol tcp udp icmp")
+		if got := deactivateProtocols(t, tree, "F", "T"); len(got) != 0 {
+			t.Fatalf("precondition: leaf should be inactive, protocols = %v", got)
+		}
+		mustActivate(t, tree, "activate firewall family inet filter F term T from protocol tcp udp icmp")
+		if got := deactivateProtocols(t, tree, "F", "T"); !equalStrs3846(got, allProtos) {
+			t.Fatalf("after activate: protocols = %v, want %v", got, allProtos)
+		}
+	})
+
+	// (6) Round-trip: deactivate -> FormatSet -> replay every line -> the leaf
+	// is STILL inactive and the compiler STILL prunes it. This is the core
+	// RED-on-revert: on revert the replayed `deactivate ... protocol tcp udp
+	// icmp` line errors, the leaf reloads ACTIVE, and the compiler sees the
+	// protocols again.
+	t.Run("round-trip-through-display-set", func(t *testing.T) {
+		tree := buildTree3846(t, base, accept)
+		mustDeactivate(t, tree, "deactivate firewall family inet filter F term T from protocol")
+
+		flat := tree.FormatSet()
+		if !strings.Contains(flat, "deactivate firewall family inet filter F term T from protocol tcp udp icmp") {
+			t.Fatalf("FormatSet missing the expanded deactivate line:\n%s", flat)
+		}
+
+		replay := &ConfigTree{}
+		for _, line := range strings.Split(flat, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			verb, p, err := ParseSetVerb(line)
+			if err != nil {
+				t.Fatalf("ParseSetVerb(%q): %v", line, err)
+			}
+			switch verb {
+			case "deactivate":
+				err = replay.DeactivatePath(p)
+			case "activate":
+				err = replay.ActivatePath(p)
+			case "delete":
+				err = replay.DeletePath(p)
+			default:
+				err = replay.SetPath(p)
+			}
+			if err != nil {
+				t.Fatalf("replay %q (%s): %v", line, verb, err)
+			}
+		}
+		if got := deactivateProtocols(t, replay, "F", "T"); len(got) != 0 {
+			t.Fatalf("round-trip lost the deactivate: protocols = %v, want empty (leaf reloaded ACTIVE)", got)
+		}
+		// Re-serializing the replayed tree reproduces the deactivate line.
+		if again := replay.FormatSet(); !strings.Contains(again,
+			"deactivate firewall family inet filter F term T from protocol tcp udp icmp") {
+			t.Fatalf("second FormatSet dropped the deactivate marker:\n%s", again)
+		}
+	})
+}
+
+// TestDeactivateMultiLeaf_PolicyMatchSourceAddress exercises the fix on a
+// security-policy match value list (source-address). Naming one member toggles
+// the whole source-address statement; because a security policy REQUIRES a
+// source-address (the #3044 gate), the deactivated leaf is a legitimately
+// uncompilable "parked" edit — assert on the AST node + display-set round-trip,
+// and prove the policy compiles again once re-activated.
+func TestDeactivateMultiLeaf_PolicyMatchSourceAddress(t *testing.T) {
+	build := func() *ConfigTree {
+		return buildTree3846(t,
+			"set security zones security-zone trust",
+			"set security zones security-zone untrust",
+			"set security address-book global address a1 10.0.1.0/24",
+			"set security address-book global address a2 10.0.2.0/24",
+			"set security policies from-zone trust to-zone untrust policy p1 match source-address [ a1 a2 ]",
+			"set security policies from-zone trust to-zone untrust policy p1 match destination-address any",
+			"set security policies from-zone trust to-zone untrust policy p1 match application any",
+			"set security policies from-zone trust to-zone untrust policy p1 then permit",
+		)
+	}
+	srcNode := func(tree *ConfigTree) *Node {
+		return tree.FindChild("security").FindChild("policies").FindChild("from-zone").
+			FindChild("policy").FindChild("match").FindChild("source-address")
+	}
+
+	tree := build()
+	// Baseline compiles.
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("baseline compile: %v", err)
+	}
+
+	// Naming one member toggles the whole source-address statement.
+	mustDeactivate(t, tree, "deactivate security policies from-zone trust to-zone untrust policy p1 match source-address a1")
+	sn := srcNode(tree)
+	if sn == nil || !sn.Inactive {
+		t.Fatalf("source-address leaf should be inactive after member deactivate: %+v", sn)
+	}
+	// A parked source-address is intentionally uncompilable (#3044 required-criterion).
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("policy with a deactivated source-address should fail the required-criterion gate")
+	}
+
+	// FormatSet round-trips the deactivate on the expanded member list.
+	flat := tree.FormatSet()
+	if !strings.Contains(flat, "deactivate security policies from-zone trust to-zone untrust policy p1 match source-address a1 a2") {
+		t.Fatalf("FormatSet missing expanded deactivate line:\n%s", flat)
+	}
+	replay := &ConfigTree{}
+	for _, line := range strings.Split(flat, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		verb, p, err := ParseSetVerb(line)
+		if err != nil {
+			t.Fatalf("ParseSetVerb(%q): %v", line, err)
+		}
+		switch verb {
+		case "deactivate":
+			err = replay.DeactivatePath(p)
+		case "activate":
+			err = replay.ActivatePath(p)
+		case "delete":
+			err = replay.DeletePath(p)
+		default:
+			err = replay.SetPath(p)
+		}
+		if err != nil {
+			t.Fatalf("replay %q (%s): %v", line, verb, err)
+		}
+	}
+	if rn := srcNode(replay); rn == nil || !rn.Inactive {
+		t.Fatalf("round-trip lost the deactivate: source-address reloaded ACTIVE: %+v", rn)
+	}
+
+	// activate restores both members and the policy compiles again.
+	mustActivate(t, tree, "activate security policies from-zone trust to-zone untrust policy p1 match source-address a1 a2")
+	if sn := srcNode(tree); sn == nil || sn.Inactive {
+		t.Fatalf("activate should clear the inactive flag: %+v", sn)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile after activate: %v", err)
+	}
+	var got []string
+	for _, pr := range cfg.Security.Policies {
+		if pr.FromZone == "trust" && pr.ToZone == "untrust" {
+			for _, p := range pr.Policies {
+				if p.Name == "p1" {
+					got = append([]string(nil), p.Match.SourceAddresses...)
+				}
+			}
+		}
+	}
+	sort.Strings(got)
+	if !equalStrs3846(got, []string{"a1", "a2"}) {
+		t.Fatalf("after activate source-address: %v, want [a1 a2]", got)
+	}
+}
+
+// TestDeactivateMultiLeaf_BlockShapeMember exercises the hierarchical block
+// shape of a value-list leaf (one child node per member): a member named on
+// `deactivate` toggles ONLY that child node, leaving its siblings active.
+func TestDeactivateMultiLeaf_BlockShapeMember(t *testing.T) {
+	// Block shape only comes from hierarchical text (NewParser); the flat-set
+	// path always yields the bracket shape.
+	tree := mustParse(t, `security {
+    zones {
+        security-zone trust {
+            host-inbound-traffic {
+                system-services {
+                    ssh;
+                    https;
+                    ping;
+                }
+            }
+        }
+    }
+}`)
+	mustDeactivate(t, tree, "deactivate security zones security-zone trust host-inbound-traffic system-services ssh")
+
+	svc := tree.FindChild("security").FindChild("zones").FindChild("security-zone").
+		FindChild("host-inbound-traffic").FindChild("system-services")
+	if svc == nil {
+		t.Fatalf("system-services node not found: %+v", tree.Children)
+	}
+	if svc.Inactive {
+		t.Fatal("member deactivate must NOT toggle the parent system-services container")
+	}
+	for _, c := range svc.Children {
+		if len(c.Keys) == 0 {
+			continue
+		}
+		switch c.Keys[0] {
+		case "ssh":
+			if !c.Inactive {
+				t.Fatal("ssh child should be inactive")
+			}
+		default:
+			if c.Inactive {
+				t.Fatalf("sibling %q should stay active", c.Keys[0])
+			}
+		}
+	}
+
+	// activate reverses it.
+	mustActivate(t, tree, "activate security zones security-zone trust host-inbound-traffic system-services ssh")
+	for _, c := range svc.Children {
+		if c.Inactive {
+			t.Fatalf("child %v should be active after activate", c.Keys)
+		}
+	}
+}
+
+// TestDeactivateMultiLeaf_SingleValueLeafUnchanged asserts a non-multi
+// (single-value) leaf keeps the pre-#3975 whole-node toggle: the new
+// multi-leaf branch must not fire for it.
+func TestDeactivateMultiLeaf_SingleValueLeafUnchanged(t *testing.T) {
+	tree := buildTree3846(t,
+		"set system host-name parked",
+	)
+	mustDeactivate(t, tree, "deactivate system host-name parked")
+	hn := tree.FindChild("system").FindChild("host-name")
+	if hn == nil || !hn.Inactive {
+		t.Fatalf("single-value host-name leaf should be inactive: %+v", hn)
+	}
+	mustActivate(t, tree, "activate system host-name parked")
+	if hn.Inactive {
+		t.Fatal("activate should clear the single-value leaf")
+	}
+}
+
+// TestDeactivateMultiLeaf_KeyedEntryUnchanged asserts the args==2 keyed multi
+// entry (address <name> <prefix>) keeps whole-node toggle semantics — the new
+// args==1 member branch must NOT fire for it.
+func TestDeactivateMultiLeaf_KeyedEntryUnchanged(t *testing.T) {
+	tree := buildTree3846(t,
+		"set security address-book global address a1 10.0.1.0/24",
+		"set security address-book global address a2 10.0.2.0/24",
+	)
+	mustDeactivate(t, tree, "deactivate security address-book global address a1")
+	book := tree.FindChild("security").FindChild("address-book").FindChild("global")
+	if book == nil {
+		t.Fatalf("address-book global not found: %+v", tree.Children)
+	}
+	for _, c := range book.Children {
+		if len(c.Keys) >= 2 && c.Keys[0] == "address" && c.Keys[1] == "a1" {
+			if !c.Inactive {
+				t.Fatal("address a1 should be inactive")
+			}
+		}
+		if len(c.Keys) >= 2 && c.Keys[0] == "address" && c.Keys[1] == "a2" {
+			if c.Inactive {
+				t.Fatal("address a2 should stay active")
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3975 (fable-161 F-034, MEDIUM config-mode parity). `setInactiveAtPath`
— the shared `deactivate`/`activate` config-mode edit in
`pkg/config/ast_edit.go` — did NOT handle the bracketed multi-value leaf shape
(#2419) that `deletePath` got in #3846/#3848/#3879.

A `multi: true` value-list leaf collapses a bracket list `[ a b c ]` onto ONE
node's `Keys=["field","a","b","c"]`. The schema-driven traversal in
`setInactiveAtPath` ate the first member as an extra key (`nodeKeyCount == 2`)
and then treated the remaining members as container tokens, so:

- `deactivate ... from protocol tcp udp icmp` — the **exact** line
  `show | display set` emits for an inactive bracket leaf — errored with
  `path not found: container "protocol tcp" does not exist`; and
- an inactive bracket-list leaf therefore did **not** round-trip: replaying
  its own display-set output errored and the leaf reloaded **ACTIVE**, silently
  discarding the operator's deactivate intent (the deactivate-side counterpart
  of the #3846 delete-side fail-wide).

## Fix

Intercept value-list multi-leaves in `setInactiveAtPath` with the same gate
`deletePath` uses (`multi && (children == nil || valueList) && args == 1`) and
route them to a new `markMultiLeafMembersInactive` helper that mirrors
`removeMultiLeafMembers`:

- **no member** (`deactivate ... from protocol`) toggles the whole leaf;
- **named members** toggle the WHOLE node when any rides on `Keys[1:]` (the
  flat/bracket shape — `Inactive` is a node-level flag and a bracket list is one
  statement, so it cannot be half-deactivated), and for a plain value-list leaf
  ALSO toggle any named child node (the hierarchical block shape, e.g.
  `system-services { ssh; https; }`);
- an **absent member** is reported not-found, matching the delete contract.

The `args == 1` gate keeps keyed multi entries (`address <name> <prefix>`,
`args: 2`) on whole-node toggle semantics. Single-value (non-multi) leaves are
unchanged.

## Validation

- New `pkg/config/deactivate_multi_leaf_3975_test.go`: firewall `from protocol`
  (whole expanded list / no-member / single member / absent-member error /
  activate reverses / display-set round-trip), policy match `source-address`,
  block-shape `system-services` member toggle, and single-value-leaf +
  keyed-entry non-regression.
- **RED-on-revert verified**: reverting the new branch makes the whole-list /
  member / round-trip / activate assertions error `container "protocol tcp"
  does not exist`.
- Full `go test ./pkg/config/...` green; `go build ./...`, `gofmt`, and
  `go vet ./pkg/config/` clean.
- `docs/config-schema.md` gains a "Deactivate-side contract" section mirroring
  the existing delete-side one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
