### PR TITLE
configstore: release exclusive config lock on session exit (#3979)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -30426,3 +30426,37 @@ top.
     pkg/dataplane/userspace/mirrors.go, pkg/dataplane/userspace/builder.go,
     pkg/dataplane/userspace/manager_test.go,
     docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md, _Log.md
+
+- **Timestamp**: 2026-07-03
+  - **Action**: #3979 — `configure exclusive` lock never released on session
+    exit → permanent config lockout. VERIFY FIRST confirmed the defect (also
+    already flagged in `cmd/cli/shared.go` #1563 comment): `EnterConfigureExclusive`
+    records the holder in `exclusiveHolder` and leaves `configHolder` empty, but
+    `ExitConfigureSession`'s release guard compared only `configHolder`. So an
+    exclusive holder's own exit saw `configHolder("") != sessionID` and returned
+    false WITHOUT clearing anything → the exclusive lock persisted with no live
+    holder → every subsequent `configure` / `configure exclusive` /
+    `configure private` rejected until daemon restart. The disconnect
+    auto-release (`configLockInterceptor`, pkg/grpcapi/server.go) routes through
+    `ExitConfigureSession`, so it silently failed too — a single operator running
+    `configure exclusive` then disconnecting bricked all future config edits.
+    FIX (pkg/configstore/store_lock.go): added `effectiveHolderLocked()`
+    (exclusiveHolder if set, else configHolder); `ExitConfigureSession` now
+    compares the session against the effective holder, releasing whichever lock
+    THIS session actually holds. Matching the effective holder ALSO restores the
+    stale-holder reclaim on disconnect (the interceptor path). `ConfigHolder()`
+    now reports the effective holder so `clear system config-lock` / diag
+    attributes an exclusive lock to its real holder instead of an empty string.
+    Live-holder-blocks-others preserved (`EnterConfigure*` still rejects with
+    ErrConfigLocked while configDir set; a non-holder exit can't steal the lock);
+    shared/private release unchanged. RED-on-revert (proven by restoring the old
+    `configHolder` guard): TestExclusiveLockReleasedOnSessionExit,
+    TestExclusiveLockReacquireCycle, TestLiveExclusiveHolderBlocksOthers all FAIL
+    on the old guard while TestSharedLockUnaffected stays GREEN (shared mode was
+    never broken). `go test ./pkg/cli/... ./pkg/configstore/...` green;
+    `go build ./...`, gofmt, vet clean. Docs: pkg/configstore/README.md new
+    "Config lock: shared/private vs. exclusive holders (#3979)" section; updated
+    the now-outdated cmd/cli/shared.go #1563 comment.
+  - **File(s)**: pkg/configstore/store_lock.go,
+    pkg/configstore/store_lock_3979_test.go, pkg/configstore/README.md,
+    cmd/cli/shared.go, _Log.md

--- a/cmd/cli/shared.go
+++ b/cmd/cli/shared.go
@@ -223,11 +223,14 @@ func (c *ctl) dispatchOperational(line string) error {
 		// interceptor — it only fires while an RPC is in flight, never
 		// on connection close. Issuing EnterConfigure here and exiting
 		// would leak the daemon-side config lock until daemon restart.
-		// Exclusive locks are especially bad: EnterConfigureExclusive
-		// sets `exclusiveHolder`, but ExitConfigureSession only
-		// releases when the session matches `configHolder`, so even
-		// an explicit teardown call wouldn't recover them.
-		// See #1563.
+		// Exclusive locks were historically worse: EnterConfigureExclusive
+		// records the holder in `exclusiveHolder`, but ExitConfigureSession
+		// used to release only when the session matched `configHolder`, so
+		// even an explicit teardown could not recover them. #3979 fixed the
+		// release path to match the effective holder; this -c leak is
+		// unaffected by that fix because it stems from the interceptor never
+		// firing on an idle connection close, not the holder mismatch.
+		// See #1563, #3979.
 		if c.rl == nil {
 			return fmt.Errorf(
 				"configuration mode requires an interactive terminal " +

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -161,6 +161,42 @@ config to the dataplane. A subsequent restart therefore re-classifies into
 bootstrap (the marker disambiguates never-committed from
 operator-committed-empty).
 
+### Config lock: shared/private vs. exclusive holders (#3979)
+
+Only one session edits config at a time. The store tracks the holder in
+two fields depending on the mode the session entered:
+
+- **shared / private** (`EnterConfigure`, `EnterConfigureSession`) —
+  holder recorded in `configHolder`.
+- **exclusive** (`EnterConfigureExclusive`, from `configure exclusive`) —
+  holder recorded in `exclusiveHolder`; `configHolder` stays empty.
+  `IsExclusiveLocked()` keys off `exclusiveHolder != ""`.
+
+The release path (`ExitConfigureSession`) must match the session against
+**whichever field its acquiring mode set**. It compares against
+`effectiveHolderLocked()` — `exclusiveHolder` when set, else
+`configHolder` — so a session releases the exact lock it holds.
+
+**#3979 (fixed):** the release guard previously compared only
+`configHolder`. An exclusive holder sets `exclusiveHolder` and leaves
+`configHolder` empty, so the guard saw `configHolder("") != sessionID`
+and returned `false` **without clearing anything**. The exclusive lock
+then persisted with no live holder, and every subsequent
+`configure` / `configure exclusive` / `configure private` was rejected
+until daemon restart — a single operator running `configure exclusive`
+then disconnecting bricked all future config edits. The disconnect
+auto-release (`configLockInterceptor` in `pkg/grpcapi/server.go`) routes
+through `ExitConfigureSession`, so it silently failed too; matching the
+effective holder restores that stale-holder reclaim on disconnect.
+
+`ConfigHolder()` likewise reports the effective holder, so
+`clear system config-lock` / diagnostic output attributes an exclusive
+lock to its real holder instead of an empty string. A genuinely-active
+holder still blocks other sessions (`EnterConfigure*` rejects with
+`ErrConfigLocked` while `configDir` is set), and a non-holder's exit
+cannot steal the lock. `ForceExitConfigure` (`clear system config-lock`)
+remains the unconditional operator override.
+
 ### Cluster read-only gate (#3893)
 
 On an HA chassis cluster the RG0 primary is the sole config authority;

--- a/pkg/configstore/store_lock.go
+++ b/pkg/configstore/store_lock.go
@@ -78,15 +78,40 @@ func (s *Store) EnterConfigureExclusive(holder string) error {
 	return nil
 }
 
+// effectiveHolderLocked returns the session ID that currently holds the config
+// lock, regardless of mode. Exclusive mode records the holder in
+// exclusiveHolder; shared/private mode records it in configHolder. Callers MUST
+// hold s.mu. Returns "" when no session identifier was supplied at acquire time
+// (the internal EnterConfigure()/daemon path) or when unlocked.
+func (s *Store) effectiveHolderLocked() string {
+	if s.exclusiveHolder != "" {
+		return s.exclusiveHolder
+	}
+	return s.configHolder
+}
+
 // ExitConfigureSession exits configuration mode only if the given session holds
 // the lock. Returns true if the lock was released.
+//
+// #3979: the release guard must match against whichever holder field the
+// acquiring mode actually set. EnterConfigureExclusive records the holder in
+// exclusiveHolder and leaves configHolder empty; the previous guard compared
+// only configHolder, so an exclusive holder could NEVER release its own lock —
+// the guard saw configHolder("") != sessionID and bailed out early. The lock
+// then persisted with no live holder (the disconnect auto-release in
+// configLockInterceptor routes through here too, so it silently failed), and
+// every subsequent configure/configure exclusive/configure private was
+// rejected until daemon restart — a single operator using `configure exclusive`
+// then disconnecting bricked all future config edits. Comparing against the
+// effective holder releases whichever lock THIS session holds and restores the
+// stale-holder reclaim on disconnect.
 func (s *Store) ExitConfigureSession(sessionID string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if !s.configDir {
 		return false
 	}
-	if sessionID != "" && s.configHolder != sessionID {
+	if sessionID != "" && s.effectiveHolderLocked() != sessionID {
 		return false
 	}
 	s.candidate = nil
@@ -117,11 +142,14 @@ func (s *Store) ForceExitConfigure() {
 }
 
 // ConfigHolder returns the session ID of the current config lock holder
-// and whether the lock is held.
+// and whether the lock is held. #3979: report the effective holder so an
+// exclusive lock (tracked in exclusiveHolder, with configHolder empty) is
+// attributed to its real holder in `clear system config-lock` / diagnostic
+// output instead of an empty string.
 func (s *Store) ConfigHolder() (string, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.configHolder, s.configDir
+	return s.effectiveHolderLocked(), s.configDir
 }
 
 // IsExclusiveLocked returns true if exclusive mode is active.

--- a/pkg/configstore/store_lock_3979_test.go
+++ b/pkg/configstore/store_lock_3979_test.go
@@ -1,0 +1,152 @@
+package configstore
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestExclusiveLockReleasedOnSessionExit is the RED-on-revert guard for #3979.
+//
+// `configure exclusive` records the holder in exclusiveHolder (configHolder
+// stays empty). The pre-fix ExitConfigureSession guard compared only
+// configHolder, so an exclusive holder could never release its own lock: the
+// guard saw configHolder("") != sessionID and returned false without clearing
+// anything. The exclusive lock then persisted with no live holder and every
+// subsequent configure was rejected until daemon restart.
+//
+// On revert this test goes RED: sessionA's ExitConfigureSession returns false
+// (lock stuck) and sessionB's EnterConfigureSession returns ErrConfigLocked.
+func TestExclusiveLockReleasedOnSessionExit(t *testing.T) {
+	s := newTestStore(t)
+
+	// Session A takes the exclusive lock.
+	if err := s.EnterConfigureExclusive("sessionA"); err != nil {
+		t.Fatalf("EnterConfigureExclusive(sessionA): %v", err)
+	}
+	if !s.InConfigMode() {
+		t.Fatal("expected config mode after EnterConfigureExclusive")
+	}
+	if !s.IsExclusiveLocked() {
+		t.Fatal("expected IsExclusiveLocked true after EnterConfigureExclusive")
+	}
+	// #3979: ConfigHolder must attribute the lock to its real holder, not "".
+	if holder, locked := s.ConfigHolder(); !locked || holder != "sessionA" {
+		t.Fatalf("ConfigHolder() = (%q, %v), want (\"sessionA\", true)", holder, locked)
+	}
+
+	// Session A exits / disconnects. This is the exact call the gRPC
+	// configLockInterceptor makes on client disconnect.
+	if released := s.ExitConfigureSession("sessionA"); !released {
+		t.Fatal("ExitConfigureSession(sessionA) returned false — exclusive lock stuck (the #3979 bug)")
+	}
+	if s.InConfigMode() {
+		t.Fatal("still in config mode after the exclusive holder exited")
+	}
+	if s.IsExclusiveLocked() {
+		t.Fatal("still exclusive-locked after the exclusive holder exited")
+	}
+
+	// Session B must now be able to enter — the lock was released.
+	if err := s.EnterConfigureSession("sessionB"); err != nil {
+		t.Fatalf("EnterConfigureSession(sessionB) after A released: %v", err)
+	}
+	s.ExitConfigureSession("sessionB")
+}
+
+// TestExclusiveLockReacquireCycle exercises the full acquire -> release ->
+// reacquire cycle across simulated sessions in both modes.
+func TestExclusiveLockReacquireCycle(t *testing.T) {
+	s := newTestStore(t)
+
+	// exclusive -> release -> exclusive (different session) -> release
+	if err := s.EnterConfigureExclusive("A"); err != nil {
+		t.Fatalf("EnterConfigureExclusive(A): %v", err)
+	}
+	if !s.ExitConfigureSession("A") {
+		t.Fatal("ExitConfigureSession(A) failed to release exclusive lock")
+	}
+	if err := s.EnterConfigureExclusive("B"); err != nil {
+		t.Fatalf("EnterConfigureExclusive(B) after release: %v", err)
+	}
+	if !s.ExitConfigureSession("B") {
+		t.Fatal("ExitConfigureSession(B) failed to release exclusive lock")
+	}
+
+	// shared -> release -> exclusive -> release (modes interleave cleanly)
+	if err := s.EnterConfigureSession("C"); err != nil {
+		t.Fatalf("EnterConfigureSession(C): %v", err)
+	}
+	if s.IsExclusiveLocked() {
+		t.Fatal("shared/private session must not report exclusive lock")
+	}
+	if !s.ExitConfigureSession("C") {
+		t.Fatal("ExitConfigureSession(C) failed to release shared lock")
+	}
+	if err := s.EnterConfigureExclusive("D"); err != nil {
+		t.Fatalf("EnterConfigureExclusive(D) after shared release: %v", err)
+	}
+	if !s.ExitConfigureSession("D") {
+		t.Fatal("ExitConfigureSession(D) failed to release exclusive lock")
+	}
+}
+
+// TestLiveExclusiveHolderBlocksOthers verifies that a genuinely-active
+// exclusive holder still blocks other sessions and cannot have its lock stolen
+// by a non-holder's exit — the live-holder-blocks-others behavior must survive
+// the #3979 fix.
+func TestLiveExclusiveHolderBlocksOthers(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.EnterConfigureExclusive("owner"); err != nil {
+		t.Fatalf("EnterConfigureExclusive(owner): %v", err)
+	}
+
+	// Another session must be rejected (both plain and exclusive entry).
+	if err := s.EnterConfigureSession("intruder"); !errors.Is(err, ErrConfigLocked) {
+		t.Fatalf("EnterConfigureSession(intruder) = %v, want ErrConfigLocked", err)
+	}
+	if err := s.EnterConfigureExclusive("intruder"); !errors.Is(err, ErrConfigLocked) {
+		t.Fatalf("EnterConfigureExclusive(intruder) = %v, want ErrConfigLocked", err)
+	}
+
+	// A non-holder's exit must NOT steal the live owner's lock.
+	if s.ExitConfigureSession("intruder") {
+		t.Fatal("ExitConfigureSession(intruder) stole the live owner's exclusive lock")
+	}
+	if !s.InConfigMode() || !s.IsExclusiveLocked() {
+		t.Fatal("owner's exclusive lock was disturbed by a non-holder exit")
+	}
+
+	// The real owner still holds it and can release.
+	if !s.ExitConfigureSession("owner") {
+		t.Fatal("ExitConfigureSession(owner) failed to release the live lock")
+	}
+}
+
+// TestSharedLockUnaffected confirms the shared/private-mode release path is
+// unchanged by the #3979 fix.
+func TestSharedLockUnaffected(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.EnterConfigureSession("A"); err != nil {
+		t.Fatalf("EnterConfigureSession(A): %v", err)
+	}
+	if holder, locked := s.ConfigHolder(); !locked || holder != "A" {
+		t.Fatalf("ConfigHolder() = (%q, %v), want (\"A\", true)", holder, locked)
+	}
+	// Same-session re-entry is a no-op success.
+	if err := s.EnterConfigureSession("A"); err != nil {
+		t.Fatalf("EnterConfigureSession(A) re-entry: %v", err)
+	}
+	// A non-holder cannot release it.
+	if s.ExitConfigureSession("B") {
+		t.Fatal("ExitConfigureSession(B) released A's shared lock")
+	}
+	// The holder releases it.
+	if !s.ExitConfigureSession("A") {
+		t.Fatal("ExitConfigureSession(A) failed to release shared lock")
+	}
+	if s.InConfigMode() {
+		t.Fatal("still in config mode after shared holder exited")
+	}
+}


### PR DESCRIPTION
Closes #3979

## Problem

`configure exclusive` takes an exclusive config lock recorded in
`exclusiveHolder` (leaving `configHolder` empty), but the release path
`ExitConfigureSession` compared the exiting session **only** against
`configHolder`. So an exclusive holder's own exit saw
`configHolder("") != sessionID` and returned `false` **without clearing
any state** — the exclusive lock persisted with no live holder.

Every subsequent `configure` / `configure exclusive` / `configure private`
was then rejected until daemon restart. Because the gRPC disconnect
auto-release (`configLockInterceptor`) also routes through
`ExitConfigureSession`, it silently failed too: a single operator running
`configure exclusive` and disconnecting **bricked all future config edits**.

The bug was already called out in the `cmd/cli/shared.go` #1563 comment
("even an explicit teardown call wouldn't recover them").

## Fix

`pkg/configstore/store_lock.go`:

- Add `effectiveHolderLocked()` — returns `exclusiveHolder` when set, else
  `configHolder`.
- `ExitConfigureSession` compares the exiting session against the effective
  holder, so a session releases whichever lock it actually holds. This also
  restores the **stale-holder reclaim on disconnect** (the interceptor path).
- `ConfigHolder()` reports the effective holder, so `clear system config-lock`
  / diagnostics attribute an exclusive lock to its real holder instead of an
  empty string.

Live-holder-blocks-others is preserved (`EnterConfigure*` still rejects with
`ErrConfigLocked` while a session is active; a non-holder exit can't steal the
lock). Shared/private release is unchanged.

## Tests (RED-on-revert)

`pkg/configstore/store_lock_3979_test.go` covers the exclusive
acquire→release→reacquire cycle across simulated sessions, a live exclusive
holder blocking others, and the shared path. Restoring the old
`configHolder`-only guard makes the three exclusive tests FAIL while
`TestSharedLockUnaffected` stays GREEN (shared mode was never broken):

```
--- FAIL: TestExclusiveLockReleasedOnSessionExit
--- FAIL: TestExclusiveLockReacquireCycle
--- FAIL: TestLiveExclusiveHolderBlocksOthers
--- PASS: TestSharedLockUnaffected
```

## Validation

- `go test ./pkg/cli/... ./pkg/configstore/...` green
- `go build ./...`, `gofmt`, `go vet` clean

## Docs

- New configstore README section "Config lock: shared/private vs. exclusive
  holders (#3979)".
- Refreshed the now-outdated `cmd/cli/shared.go` #1563 comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi