### PR TITLE
config: show all siblings for path-scoped show configuration on a repeated keyword

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,44 @@
+## 2026-07-03 — #3980: path-scoped `show configuration <path>` / `| display set` showed only the FIRST sibling at a repeated-keyword level (navigatePath terminal single-key match was FindChild-first)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-037 (MEDIUM, config-display fidelity).
+    `navigatePath` (`pkg/config/ast.go`), the node selector behind every
+    path-scoped `FormatPath*` renderer (`show configuration <path>`,
+    `| display set`, JSON, XML, inheritance), resolved a path ending on a
+    bare keyword by returning `[]*Node{n}` — the FIRST matching sibling
+    only. A hierarchy level may hold multiple DISTINCT statements with the
+    same leading keyword (several `system ntp server <addr>`, many
+    `routing-options static route <dest>`, repeated `archive-sites`), so
+    `show configuration system ntp server` and its `| display set` showed
+    only the first entry, hiding the rest; a scoped `display set` backup
+    taken that way silently dropped the hidden statements on restore. The
+    full-tree `Format`/`FormatSet` (no path) already walked each sibling and
+    were unaffected — this was the path-scoped selector only.
+  - **Fix**: at the terminal path element, gather EVERY sibling whose first
+    key equals the keyword (FindChildren-not-FindChild), the display-side
+    sibling of the #3377 all-nodes walk / #3842 / #2419 read-all-siblings
+    class. Naming a specific keyed value (`... server 2.2.2.2`) still routes
+    through the keyword+value multi-key branch to that one entry.
+  - **Test**: `pkg/config/show_config_repeated_keyword_3980_test.go` —
+    path-scoped ntp-server render (hierarchical + display set), path-scoped
+    static-route render, static-route `display set` round-trip (render →
+    ParseSetCommand re-apply → all routes reproduced), full-tree control,
+    single-statement no-regression. RED-on-revert verified: reverting
+    `ast.go` renders only the first sibling and the render/round-trip
+    assertions fail; control + no-regression stay green. Full
+    `go test ./pkg/config/...` green; `go build ./...`, gofmt, vet clean.
+  - **Note**: a separate, orthogonal construction defect still collapses the
+    keyed-list LEAVES `system ntp server` / `archive-sites` on flat-set
+    replay — non-`multi` `args:1` schema entries hit `SetPath`'s
+    single-value-replace branch and keep only the LAST, though the compiler
+    reads all via `FindChildren`. That is a schema/SetPath fix (mark
+    keyed-list + read `firewallMatchValues`), not a renderer change; tracked
+    separately. The round-trip test uses static routes (a keyed container
+    that round-trips cleanly) to isolate the display-side fix.
+  - **File(s)**: `pkg/config/ast.go`,
+    `pkg/config/show_config_repeated_keyword_3980_test.go`,
+    `pkg/config/README.md`, `_Log.md`.
+
 ## 2026-07-03 — #3975: `deactivate`/`activate` on a bracketed multi-value leaf errored + broke round-trip (setInactiveAtPath lacked the #2419 multi-value handling deletePath got in #3846)
 
 - **Timestamp**: 2026-07-03

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -704,6 +704,36 @@ warning). The deny gate additionally unions `hasLog` across all deny nodes to
 match the compiler's per-node `applyCollapsedDenyModifiers` accumulation onto
 `pol.Log`.
 
+**Path-scoped `show configuration <path>` returns ALL siblings sharing the
+terminal keyword (#3980 — the display-side sibling of the #3377 all-nodes
+walk):** `navigatePath` (`ast.go`, the node selector behind every
+`FormatPath*` renderer — hierarchical text, `display set`, JSON, XML,
+inheritance) resolves a path that ends on a bare keyword. A hierarchy level
+may hold multiple DISTINCT statements with the same leading keyword — several
+`system ntp server <addr>`, repeated `system archival configuration
+archive-sites <url>`, many `routing-options static route <dest>`. The
+terminal single-key match previously returned `[]*Node{n}` (the FIRST
+sibling only), so `show configuration system ntp server` — and, worse, its
+`| display set` — showed only `server 1.1.1.1`, hiding the rest; a scoped
+`display set` backup taken that way silently dropped the hidden statements on
+restore. The fix gathers EVERY sibling whose first key equals the keyword
+(FindChildren-not-FindChild) at the terminal element. The FULL-tree
+serializers (`Format` / `FormatSet`, no path) already walked each sibling
+slice element and were never affected; naming a specific keyed value
+(`... server 2.2.2.2`) still resolves via the keyword+value multi-key branch
+to that one entry. Regression coverage:
+`pkg/config/show_config_repeated_keyword_3980_test.go` (path-scoped ntp +
+static-route render, static-route `display set` round-trip, full-tree
+control, single-statement no-regression). NOTE: a separate, orthogonal
+construction defect still collapses the *keyed-list leaves* `system ntp
+server` / `system archival configuration archive-sites` on flat-set replay —
+their `setSchema` entries are `args:1, children:nil` non-`multi`, so
+`SetPath`'s single-value-replace branch (`ast_edit.go`) keeps only the LAST
+on `set ...`/`load set`, even though the compiler reads all of them via
+`FindChildren` (`compiler_system.go`). That is a schema/SetPath fix (mark
+them keyed-list + read via `firewallMatchValues`), not a renderer change, and
+is tracked separately.
+
 **Security policies missing a required `match` criterion are rejected at commit
 (#3044 — codex-review-061 finding 061-03):** Junos/vSRX requires every security
 policy `match` clause to specify all three core dimensions — `source-address`,

--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -216,10 +216,29 @@ func navigatePath(nodes []*Node, path []string) []*Node {
 		found := false
 		for _, n := range current {
 			if len(n.Keys) > 0 && n.Keys[0] == keyword {
-				i++
-				if i >= len(path) {
-					return []*Node{n}
+				if i+1 >= len(path) {
+					// Terminal path element on a bare keyword: return
+					// EVERY sibling sharing this leading keyword (#3980),
+					// not just the first. A hierarchy level may hold
+					// multiple DISTINCT statements with the same leading
+					// keyword — e.g. `ntp server 1.1.1.1` /
+					// `ntp server 2.2.2.2`, several `from-zone` policy
+					// contexts, repeated `archive-sites`. Returning only
+					// the first hid the rest from a path-scoped
+					// `show configuration <path>` and, worse, from its
+					// `| display set`, so a scoped display-set backup
+					// silently dropped the hidden statements on restore.
+					// FindChildren-not-FindChild, the display-side sibling
+					// of the #3842 / #2419 read-all-siblings class.
+					var all []*Node
+					for _, sib := range current {
+						if len(sib.Keys) > 0 && sib.Keys[0] == keyword {
+							all = append(all, sib)
+						}
+					}
+					return all
 				}
+				i++
 				current = n.Children
 				found = true
 				break

--- a/pkg/config/show_config_repeated_keyword_3980_test.go
+++ b/pkg/config/show_config_repeated_keyword_3980_test.go
@@ -1,0 +1,186 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3980: a path-scoped `show configuration <path>` (and its
+// `| display set` / xml renderers) that terminates on a bare keyword must
+// emit EVERY sibling statement sharing that leading keyword, not just the
+// first. navigatePath's terminal single-key match previously returned
+// `[]*Node{n}` — the first sibling only — so `show configuration system
+// ntp server` and `show configuration system ntp server | display set`
+// showed only `server 1.1.1.1`, hiding 2.2.2.2 / 3.3.3.3. A scoped
+// display-set backup taken that way silently dropped the hidden servers on
+// restore. These are fail-on-revert guards: reverting navigatePath to
+// return only the first match drops the trailing siblings and fails the
+// count assertions below.
+//
+// The FULL-tree renderers (Format / FormatSet, no path) already walked
+// every sibling slice element and are exercised here as the control that
+// must stay correct.
+
+// buildRepeatedNTP builds a tree with three distinct `system ntp server`
+// statements sharing the `server` leading keyword, using the hierarchical
+// parser (which appends one node per statement — the shape a committed
+// config loads into).
+func buildRepeatedNTP(t *testing.T) *ConfigTree {
+	t.Helper()
+	src := `system {
+    ntp {
+        server 1.1.1.1;
+        server 2.2.2.2;
+        server 3.3.3.3;
+    }
+}`
+	tree, perrs := NewParser(src).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse errors: %v", perrs)
+	}
+	return tree
+}
+
+func TestShowConfigRepeatedKeywordPathScoped(t *testing.T) {
+	tree := buildRepeatedNTP(t)
+	want := []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"}
+
+	// Path-scoped hierarchical: `show configuration system ntp server`.
+	hier := tree.FormatPath([]string{"system", "ntp", "server"})
+	for _, ip := range want {
+		if !strings.Contains(hier, "server "+ip) {
+			t.Errorf("FormatPath([system ntp server]) missing %q; got:\n%s", ip, hier)
+		}
+	}
+	if n := strings.Count(hier, "server "); n != len(want) {
+		t.Errorf("FormatPath([system ntp server]) rendered %d servers, want %d; got:\n%s", n, len(want), hier)
+	}
+
+	// Path-scoped display-set: `show configuration system ntp server | display set`.
+	set := tree.FormatPathSet([]string{"system", "ntp", "server"})
+	for _, ip := range want {
+		if !strings.Contains(set, "set system ntp server "+ip) {
+			t.Errorf("FormatPathSet([system ntp server]) missing %q; got:\n%s", ip, set)
+		}
+	}
+	if n := strings.Count(set, "set system ntp server "); n != len(want) {
+		t.Errorf("FormatPathSet([system ntp server]) rendered %d set lines, want %d; got:\n%s", n, len(want), set)
+	}
+}
+
+// TestShowConfigRepeatedRoutePathScoped covers static routes — a keyed
+// container class the issue names ("several static route entries") — for
+// the same navigatePath terminal-keyword defect. `show configuration
+// routing-options static route` must list every route, not just the first.
+// RED on revert (navigatePath returned only the first `route` node).
+func TestShowConfigRepeatedRoutePathScoped(t *testing.T) {
+	src := `routing-options {
+    static {
+        route 10.0.0.0/24 next-hop 192.168.1.1;
+        route 10.0.1.0/24 next-hop 192.168.1.2;
+        route 10.0.2.0/24 next-hop 192.168.1.3;
+    }
+}`
+	tree, perrs := NewParser(src).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse errors: %v", perrs)
+	}
+	dests := []string{"10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"}
+
+	set := tree.FormatPathSet([]string{"routing-options", "static", "route"})
+	for _, d := range dests {
+		if !strings.Contains(set, "route "+d+" next-hop") {
+			t.Errorf("FormatPathSet([...static route]) missing route %q; got:\n%s", d, set)
+		}
+	}
+
+	hier := tree.FormatPath([]string{"routing-options", "static", "route"})
+	if n := strings.Count(hier, "route "); n != len(dests) {
+		t.Errorf("FormatPath([...static route]) rendered %d routes, want %d; got:\n%s", n, len(dests), hier)
+	}
+}
+
+// TestShowConfigRepeatedRouteDisplaySetRoundTrip proves a scoped
+// display-set backup round-trips faithfully for a keyed container: render
+// `| display set`, re-apply those lines via ParseSetCommand + SetPath (the
+// load-set path), and reproduce every route. Before the navigatePath fix
+// only the first route's set lines were emitted, so the reloaded tree lost
+// the other two destinations.
+func TestShowConfigRepeatedRouteDisplaySetRoundTrip(t *testing.T) {
+	src := `routing-options {
+    static {
+        route 10.0.0.0/24 next-hop 192.168.1.1;
+        route 10.0.1.0/24 next-hop 192.168.1.2;
+        route 10.0.2.0/24 next-hop 192.168.1.3;
+    }
+}`
+	tree, perrs := NewParser(src).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse errors: %v", perrs)
+	}
+	set := tree.FormatPathSet([]string{"routing-options", "static", "route"})
+
+	reloaded := &ConfigTree{}
+	for _, line := range strings.Split(strings.TrimSpace(set), "\n") {
+		if line == "" {
+			continue
+		}
+		toks, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := reloaded.SetPath(toks); err != nil {
+			t.Fatalf("SetPath(%v): %v", toks, err)
+		}
+	}
+	out := reloaded.FormatPathSet([]string{"routing-options", "static", "route"})
+	for _, pair := range [][2]string{
+		{"10.0.0.0/24", "192.168.1.1"},
+		{"10.0.1.0/24", "192.168.1.2"},
+		{"10.0.2.0/24", "192.168.1.3"},
+	} {
+		want := "set routing-options static route " + pair[0] + " next-hop " + pair[1]
+		if !strings.Contains(out, want) {
+			t.Errorf("display-set round-trip lost %q; reloaded:\n%s", want, out)
+		}
+	}
+}
+
+// TestShowConfigRepeatedKeywordFullTreeControl is the control: the full
+// (unscoped) renderers already walk every sibling and must keep rendering
+// all three servers.
+func TestShowConfigRepeatedKeywordFullTreeControl(t *testing.T) {
+	tree := buildRepeatedNTP(t)
+	want := []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"}
+
+	full := tree.Format()
+	if n := strings.Count(full, "server "); n != len(want) {
+		t.Errorf("Format() rendered %d servers, want %d; got:\n%s", n, len(want), full)
+	}
+	fullSet := tree.FormatSet()
+	if n := strings.Count(fullSet, "set system ntp server "); n != len(want) {
+		t.Errorf("FormatSet() rendered %d set lines, want %d; got:\n%s", n, len(want), fullSet)
+	}
+}
+
+// TestShowConfigPathScopedSingleStatementUnchanged guards against
+// over-broadening: a single, non-repeated statement path-scoped render is
+// unchanged (still exactly one line), and naming a specific keyed value
+// (`... server 2.2.2.2`) still resolves to that one entry, not all
+// siblings.
+func TestShowConfigPathScopedSingleStatementUnchanged(t *testing.T) {
+	single, perrs := NewParser("system { host-name fw1; }").Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse errors: %v", perrs)
+	}
+	got := single.FormatPathSet([]string{"system", "host-name"})
+	if strings.TrimSpace(got) != "set system host-name fw1" {
+		t.Errorf("FormatPathSet([system host-name]) = %q, want single host-name line", got)
+	}
+
+	tree := buildRepeatedNTP(t)
+	one := tree.FormatPathSet([]string{"system", "ntp", "server", "2.2.2.2"})
+	if strings.TrimSpace(one) != "set system ntp server 2.2.2.2" {
+		t.Errorf("FormatPathSet([system ntp server 2.2.2.2]) = %q, want only the named entry", one)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3980 (fable-161 F-037, MEDIUM config-display fidelity).

A path-scoped `show configuration <path>` — and its `| display set`, JSON, XML, and inheritance variants — that terminated on a bare keyword emitted only the **first** statement when the hierarchy level held multiple **distinct** statements sharing that leading keyword (several `system ntp server <addr>`, many `routing-options static route <dest>`, repeated `archive-sites`). So `show configuration system ntp server` and, worse, its `| display set` showed only the first entry, hiding the rest; a scoped `display set` backup taken that way silently dropped the hidden statements on restore.

## Root cause

`navigatePath` (`pkg/config/ast.go`), the node selector behind every `FormatPath*` renderer, resolved the terminal single-key match by returning `[]*Node{n}` — the first matching sibling only. This is a FindChild-first bug, the display-side sibling of the #3377 all-nodes walk and the #3842 / #2419 read-all-siblings class.

## Fix

At the terminal path element, gather **every** sibling whose first key equals the keyword (FindChildren-not-FindChild). The full-tree serializers (`Format` / `FormatSet`, no path) already walked each sibling and were never affected; naming a specific keyed value (`... server 2.2.2.2`) still resolves through the keyword+value multi-key branch to that one entry, so single-statement and specific-value lookups are unchanged.

## Tests

`pkg/config/show_config_repeated_keyword_3980_test.go`:
- path-scoped ntp-server render (hierarchical + display set)
- path-scoped static-route render
- static-route `display set` round-trip (render → `ParseSetCommand` re-apply reproduces every route)
- full-tree control (already correct, must stay correct)
- single-statement / specific-value no-regression

**RED-on-revert verified**: reverting `ast.go` renders only the first sibling and fails the render + round-trip assertions while the control and no-regression tests stay green.

`go test ./pkg/config/...` green; `go build ./...`, gofmt, vet clean.

## Scope note

A separate, orthogonal construction defect still collapses the keyed-list **leaves** `system ntp server` and `archive-sites` on flat-set replay — their non-`multi` `args:1` `setSchema` entries hit `SetPath`'s single-value-replace branch and keep only the **last**, even though the compiler reads all of them via `FindChildren` (`compiler_system.go`). That is a schema/SetPath fix (mark keyed-list + read `firewallMatchValues`), not a renderer change, and is tracked separately. The round-trip test uses static routes (a keyed container that round-trips cleanly) to isolate the display-side fix here.

Closes #3980

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi