### PR TITLE
config: rename non-first same-keyword sibling by full identity (#3982)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-07-03 — #3982: config-mode `rename` of a non-first same-keyword sibling failed (matched only the first sibling)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-036 (MEDIUM, config-mode edit parity).
+    `RenamePath` (`pkg/config/ast_edit.go`) — the `rename <old> to <new>`
+    config-mode verb — resolved the source through `removeNode`
+    (`pkg/config/ast.go`), whose per-level loop broke on the FIRST child
+    whose FIRST key matched (`matchNodeKeys > 0` returns `1` for a
+    keyword-only match). With several same-keyword siblings (`policy A/B/C`,
+    `term X/Y/Z`) renaming a NON-FIRST one — `rename policy B to B2` with
+    `[A B C]` — matched `policy A`, descended into it for `B`, and failed
+    `source not found` (other shapes could rename the wrong first node). The
+    operator could not rename the 2nd+ occurrence; the only recourse was
+    delete + re-add, losing ordering and sub-config. This is the config-edit
+    sibling of the #3842 / #2419 / #3975 / #3980 read-all-siblings class.
+  - **Fix**: rewrote `RenamePath` to resolve the source through
+    `findNodeWithParent` (prefers the LONGEST key match, so it selects
+    `policy B` by full identity, not the first `policy` keyword). A rename
+    that only changes the name (destination parent == source parent) is done
+    IN PLACE, preserving sibling order and the node's children/sub-config; a
+    cross-parent rename detaches and re-appends via a new `childrenAtPath`
+    helper, keeping the subtree. Added a collision guard: a rename whose new
+    identity duplicates an existing sibling under the destination parent
+    (`rename policy B to C` when `C` exists) is rejected rather than creating
+    a duplicate. Removed the now-dead first-keyword-match `removeNode` helper.
+  - **File(s)**: `pkg/config/ast_edit.go` (RenamePath rewrite + childrenAtPath),
+    `pkg/config/ast.go` (removeNode deleted), `pkg/config/parser_ast_test.go`
+    (TestRenameNonFirstSibling — RED on revert), `docs/config-schema.md`
+    (rename-side contract section).
+  - **Validation**: `TestRenameNonFirstSibling` RED on revert (`source not
+    found: ... policy B`), GREEN with the fix; `go test ./pkg/config/...`,
+    `go build ./...`, `gofmt`, `go vet ./pkg/config/` all clean.
+
 ## 2026-07-03 — #3975: `deactivate`/`activate` on a bracketed multi-value leaf errored + broke round-trip (setInactiveAtPath lacked the #2419 multi-value handling deletePath got in #3846)
 
 - **Timestamp**: 2026-07-03

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -196,6 +196,37 @@ display-set round-trip, policy match `source-address`, block-shape
 `system-services` member toggle, single-value-leaf and keyed-entry
 non-regression).
 
+**Rename-side contract: resolve the SPECIFIC named sibling by full identity
+(#3982).** `rename <old> to <new>` (`RenamePath`, `ast_edit.go`) is the same
+read-all-siblings class as the delete/deactivate fixes above, but on a
+named-entity axis: with several same-keyword siblings (`policy A/B/C`,
+`term X/Y/Z`) the operator must be able to rename the 2nd+ occurrence. The
+pre-#3982 implementation resolved the source through `removeNode`, whose
+per-level loop broke on the FIRST child whose FIRST key matched
+(`matchNodeKeys > 0` returns `1` for a keyword-only match). So `rename policy B
+to B2` with siblings `[A B C]` matched `policy A`, descended into it looking for
+`B`, and failed `source not found` (for other shapes it could rename the wrong,
+first node). The operator's only recourse was delete + re-add, losing ordering
+and sub-config. `RenamePath` now:
+
+- resolves the source through `findNodeWithParent`, which prefers the LONGEST
+  key match (`consumed > bestConsumed`) and so selects the specific `policy B`
+  by its full identity, not the first `policy` keyword;
+- renames IN PLACE when the destination parent is the source parent (the common
+  case — only the name changes), preserving sibling order and the node's
+  children/sub-config; a cross-parent rename detaches the node and appends it
+  under the new parent (via `childrenAtPath`), also keeping its subtree;
+- rejects a rename whose new identity collides with an existing sibling under
+  the destination parent (`rename policy B to C` when `C` exists), so a rename
+  never silently creates a duplicate named entity.
+
+The now-dead `removeNode` helper (first-keyword-match, order-destroying
+append-on-reinsert) was removed. Covered by `TestRenameNonFirstSibling` in
+`pkg/config/parser_ast_test.go` (non-first `B->B2` renames exactly B with
+`[A B C]` order preserved and `then permit` sub-config intact, first-sibling
+`A->A2` still works, colliding `B->C` rejected with the tree unchanged, and a
+post-rename `CompileConfig` seeing `[A B2 C]`).
+
 **Firewall-filter `source/destination-prefix-list` refs are dual-AST too
 (#3843).** These `from` leaves are NOT `multi: true` value-tails — each
 reference carries an optional trailing `except` modifier, so they compile

--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -286,45 +286,6 @@ func (t *ConfigTree) findNode(path []string) (*Node, error) {
 	return navigateToNode(t.Children, path)
 }
 
-// removeNode removes and returns a node at the given path.
-func (t *ConfigTree) removeNode(path []string) (*Node, error) {
-	if len(path) == 0 {
-		return nil, fmt.Errorf("empty path")
-	}
-	// Navigate to the parent, then find and remove the target child.
-	parentChildren := &t.Children
-	pos := 0
-	// We need to find where the last node starts.
-	// Walk until we can identify the target node at the end.
-	for pos < len(path) {
-		// Try to match a child and see if it's the final node.
-		var bestChild *Node
-		bestConsumed := 0
-		bestIdx := -1
-		for i, child := range *parentChildren {
-			consumed := matchNodeKeys(child, path, pos)
-			if consumed > 0 {
-				bestChild = child
-				bestConsumed = consumed
-				bestIdx = i
-				break
-			}
-		}
-		if bestChild == nil {
-			return nil, fmt.Errorf("path element %q not found", path[pos])
-		}
-		if pos+bestConsumed >= len(path) {
-			// This is the target node — remove it.
-			*parentChildren = append((*parentChildren)[:bestIdx], (*parentChildren)[bestIdx+1:]...)
-			return bestChild, nil
-		}
-		// Descend into this child's children.
-		parentChildren = &bestChild.Children
-		pos += bestConsumed
-	}
-	return nil, fmt.Errorf("path not found")
-}
-
 // insertNode inserts a node as a child at the given parent path.
 func (t *ConfigTree) insertNode(parentPath []string, node *Node) error {
 	children := &t.Children

--- a/pkg/config/ast_edit.go
+++ b/pkg/config/ast_edit.go
@@ -27,11 +27,28 @@ func (t *ConfigTree) CopyPath(src, dst []string) error {
 }
 
 // RenamePath moves a subtree from src to dst path.
+//
+// The source node is resolved by its FULL identity (the named key, e.g.
+// `policy <name>` / `term <name>`) via findNodeWithParent, which prefers the
+// longest key match over the first keyword match. This is what lets a
+// NON-FIRST same-keyword sibling be renamed: the earlier removeNode-based
+// implementation broke on the first child whose FIRST key matched, so
+// `rename policy B to B2` with siblings [A B C] resolved `policy A`, descended
+// into it, and failed "source not found" (the #3982 read-all-siblings defect,
+// the config-edit sibling of #3842/#2419/#3975/#3980).
+//
+// A rename that only changes the name (the common case: destination parent ==
+// source parent) is performed IN PLACE so sibling order is preserved. A rename
+// that moves the node under a different parent removes it from the source and
+// appends it to the destination. Either way the renamed node keeps its
+// children / sub-config. A rename whose new identity collides with an existing
+// sibling under the destination parent is rejected rather than creating a
+// duplicate.
 func (t *ConfigTree) RenamePath(src, dst []string) error {
 	if len(src) == 0 || len(dst) == 0 {
 		return fmt.Errorf("empty path")
 	}
-	srcNode, err := t.removeNode(src)
+	srcNode, srcParent, err := t.findNodeWithParent(src)
 	if err != nil {
 		return fmt.Errorf("source not found: %s", strings.Join(src, " "))
 	}
@@ -39,9 +56,62 @@ func (t *ConfigTree) RenamePath(src, dst []string) error {
 	if len(dst) < nk {
 		return fmt.Errorf("destination path too short")
 	}
-	srcNode.Keys = append([]string(nil), dst[len(dst)-nk:]...)
+	newKeys := append([]string(nil), dst[len(dst)-nk:]...)
 	dstParentPath := dst[:len(dst)-nk]
-	return t.insertNode(dstParentPath, srcNode)
+	dstParent, err := t.childrenAtPath(dstParentPath)
+	if err != nil {
+		return fmt.Errorf("destination parent not found: %s", strings.Join(dstParentPath, " "))
+	}
+	// Collision guard: reject a rename whose new identity duplicates an
+	// existing sibling under the destination parent (excluding the node being
+	// renamed, so renaming to the same name is a no-op rather than an error).
+	for _, n := range *dstParent {
+		if n != srcNode && keysEqual(n.Keys, newKeys) {
+			return fmt.Errorf("rename target already exists: %s", strings.Join(dst, " "))
+		}
+	}
+	if dstParent == srcParent {
+		// Same parent: rename in place, preserving sibling order and children.
+		srcNode.Keys = newKeys
+		return nil
+	}
+	// Different parent: detach from the source parent and append to the
+	// destination parent, keeping the node's children/sub-config.
+	for i, n := range *srcParent {
+		if n == srcNode {
+			*srcParent = append((*srcParent)[:i], (*srcParent)[i+1:]...)
+			break
+		}
+	}
+	srcNode.Keys = newKeys
+	*dstParent = append(*dstParent, srcNode)
+	return nil
+}
+
+// childrenAtPath navigates to the node identified by path and returns a pointer
+// to its children slice. An empty path returns the tree root's children. Like
+// findNodeWithParent it prefers the longest key match at each level so a
+// same-keyword sibling in the path is resolved by full identity.
+func (t *ConfigTree) childrenAtPath(path []string) (*[]*Node, error) {
+	children := &t.Children
+	pos := 0
+	for pos < len(path) {
+		var bestChild *Node
+		bestConsumed := 0
+		for _, child := range *children {
+			consumed := matchNodeKeys(child, path, pos)
+			if consumed > bestConsumed {
+				bestChild = child
+				bestConsumed = consumed
+			}
+		}
+		if bestChild == nil {
+			return nil, fmt.Errorf("path element %q not found", path[pos])
+		}
+		children = &bestChild.Children
+		pos += bestConsumed
+	}
+	return children, nil
 }
 
 // InsertBefore moves an existing element before another element in the same

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -685,6 +685,167 @@ func TestInsertBeforeAfter(t *testing.T) {
 	}
 }
 
+// TestRenameNonFirstSibling covers #3982: `rename <old> to <new>` must resolve
+// the target by full identity and rename the SPECIFIC same-keyword sibling,
+// including a NON-FIRST one. Before the fix RenamePath removed the target via
+// removeNode, which broke on the first child whose FIRST key matched, so
+// renaming the 2nd of several `policy <name>` errored "source not found" (or,
+// under other shapes, renamed the wrong/first node). This test goes RED on
+// revert.
+func TestRenameNonFirstSibling(t *testing.T) {
+	build := func() *ConfigTree {
+		tree := &ConfigTree{}
+		cmds := []string{
+			"set security zones security-zone trust",
+			"set security zones security-zone untrust",
+		}
+		for _, name := range []string{"A", "B", "C"} {
+			p := "set security policies from-zone trust to-zone untrust policy " + name
+			cmds = append(cmds,
+				p+" match source-address any",
+				p+" match destination-address any",
+				p+" match application any",
+				p+" then permit",
+			)
+		}
+		for _, cmd := range cmds {
+			path, err := ParseSetCommand(cmd)
+			if err != nil {
+				t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+			}
+			if err := tree.SetPath(path); err != nil {
+				t.Fatalf("SetPath: %v", err)
+			}
+		}
+		return tree
+	}
+	base := []string{"security", "policies", "from-zone", "trust", "to-zone", "untrust", "policy"}
+	path := func(name string) []string {
+		return append(append([]string{}, base...), name)
+	}
+	// policyNode returns the policy node with the given name, or nil.
+	policyNode := func(tree *ConfigTree, name string) *Node {
+		for _, c := range tree.Children {
+			if len(c.Keys) == 0 || c.Keys[0] != "security" {
+				continue
+			}
+			for _, c2 := range c.Children {
+				if len(c2.Keys) == 0 || c2.Keys[0] != "policies" {
+					continue
+				}
+				for _, c3 := range c2.Children {
+					if len(c3.Keys) >= 4 && c3.Keys[1] == "trust" && c3.Keys[3] == "untrust" {
+						for _, p := range c3.Children {
+							if len(p.Keys) >= 2 && p.Keys[0] == "policy" && p.Keys[1] == name {
+								return p
+							}
+						}
+					}
+				}
+			}
+		}
+		return nil
+	}
+	order := func(tree *ConfigTree) []string {
+		var names []string
+		for _, c := range tree.Children {
+			if len(c.Keys) == 0 || c.Keys[0] != "security" {
+				continue
+			}
+			for _, c2 := range c.Children {
+				if len(c2.Keys) == 0 || c2.Keys[0] != "policies" {
+					continue
+				}
+				for _, c3 := range c2.Children {
+					if len(c3.Keys) >= 4 && c3.Keys[1] == "trust" && c3.Keys[3] == "untrust" {
+						for _, p := range c3.Children {
+							if len(p.Keys) >= 2 && p.Keys[0] == "policy" {
+								names = append(names, p.Keys[1])
+							}
+						}
+					}
+				}
+			}
+		}
+		return names
+	}
+
+	// (1) Rename the NON-FIRST sibling B -> B2. A + C untouched, order preserved.
+	tree := build()
+	if err := tree.RenamePath(path("B"), path("B2")); err != nil {
+		t.Fatalf("RenamePath(B->B2): %v", err)
+	}
+	if got := order(tree); len(got) != 3 || got[0] != "A" || got[1] != "B2" || got[2] != "C" {
+		t.Fatalf("after rename B->B2: expected [A B2 C], got %v", got)
+	}
+	if policyNode(tree, "B") != nil {
+		t.Errorf("old name B should be gone after rename")
+	}
+	// Renamed node keeps its sub-config (the `then permit` child).
+	b2 := policyNode(tree, "B2")
+	if b2 == nil {
+		t.Fatalf("renamed policy B2 not found")
+	}
+	foundPermit := false
+	for _, ch := range b2.Children {
+		if len(ch.Keys) >= 1 && ch.Keys[0] == "then" {
+			for _, gc := range ch.Children {
+				if len(gc.Keys) >= 1 && gc.Keys[0] == "permit" {
+					foundPermit = true
+				}
+			}
+		}
+	}
+	if !foundPermit {
+		t.Errorf("renamed policy B2 lost its `then permit` sub-config: %+v", b2.Children)
+	}
+
+	// (2) Renaming the FIRST sibling still works.
+	tree = build()
+	if err := tree.RenamePath(path("A"), path("A2")); err != nil {
+		t.Fatalf("RenamePath(A->A2): %v", err)
+	}
+	if got := order(tree); len(got) != 3 || got[0] != "A2" || got[1] != "B" || got[2] != "C" {
+		t.Fatalf("after rename A->A2: expected [A2 B C], got %v", got)
+	}
+
+	// (3) Rename to a COLLIDING existing sibling name is rejected, tree unchanged.
+	tree = build()
+	if err := tree.RenamePath(path("B"), path("C")); err == nil {
+		t.Fatalf("RenamePath(B->C) should be rejected (C already exists)")
+	}
+	if got := order(tree); len(got) != 3 || got[0] != "A" || got[1] != "B" || got[2] != "C" {
+		t.Fatalf("after rejected rename: expected [A B C] unchanged, got %v", got)
+	}
+
+	// (4) Renamed config still compiles and the zone pair sees the new name.
+	tree = build()
+	if err := tree.RenamePath(path("B"), path("B2")); err != nil {
+		t.Fatalf("RenamePath(B->B2): %v", err)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig after rename: %v", err)
+	}
+	var zp *ZonePairPolicies
+	for _, p := range cfg.Security.Policies {
+		if p.FromZone == "trust" && p.ToZone == "untrust" {
+			zp = p
+			break
+		}
+	}
+	if zp == nil {
+		t.Fatal("zone pair trust->untrust not found after rename")
+	}
+	if len(zp.Policies) != 3 || zp.Policies[0].Name != "A" || zp.Policies[1].Name != "B2" || zp.Policies[2].Name != "C" {
+		var names []string
+		for _, p := range zp.Policies {
+			names = append(names, p.Name)
+		}
+		t.Errorf("compiled policy names after rename: expected [A B2 C], got %v", names)
+	}
+}
+
 func TestInsertFirewallFilterTerms(t *testing.T) {
 	tree := &ConfigTree{}
 	setCommands := []string{"set firewall family inet filter my-filter term allow-ssh from protocol tcp", "set firewall family inet filter my-filter term allow-ssh from destination-port 22", "set firewall family inet filter my-filter term allow-ssh then accept", "set firewall family inet filter my-filter term allow-http from protocol tcp", "set firewall family inet filter my-filter term allow-http from destination-port 80", "set firewall family inet filter my-filter term allow-http then accept", "set firewall family inet filter my-filter term deny-all then discard"}


### PR DESCRIPTION
Closes #3982.

## Problem

The config-mode `rename <old> to <new>` verb (`ConfigTree.RenamePath` in
`pkg/config/ast_edit.go`) resolved the source node through `removeNode`,
whose per-level loop broke on the FIRST child whose FIRST key matched.
`matchNodeKeys` returns `1` for a keyword-only match, so with several
same-keyword siblings (`policy A/B/C`, `term X/Y/Z`) renaming a
**non-first** one — `rename policy B to B2` with siblings `[A B C]` —
matched `policy A`, descended into it looking for `B`, and failed
`source not found` (for other shapes it could rename the wrong, first
node). The operator could not rename the 2nd+ occurrence and had to
delete + re-add, losing sibling ordering and sub-config.

This is the config-edit sibling of the #3842 / #2419 / #3975 / #3980
read-all-siblings class — the rename path matched first-keyword-only
instead of the specific named sibling.

## Fix

Rewrite `RenamePath` to resolve the source through `findNodeWithParent`,
which prefers the longest key match (`consumed > bestConsumed`) and so
selects the specific `policy B` by its **full identity** rather than the
first `policy` keyword.

- A rename that only changes the name (destination parent == source
  parent, the common case) is done **in place**, preserving sibling
  order and the node's children/sub-config.
- A cross-parent rename detaches the node and appends it under the new
  parent (via a new `childrenAtPath` helper), keeping the subtree.
- **Collision guard**: a rename whose new identity duplicates an
  existing sibling under the destination parent (`rename policy B to C`
  when `C` exists) is rejected instead of silently creating a duplicate.
- The now-dead, first-keyword-match `removeNode` helper is removed.

## Test (RED on revert)

`TestRenameNonFirstSibling` in `pkg/config/parser_ast_test.go` builds
three `policy A/B/C` via `ParseSetCommand` + `SetPath` (not `NewParser`,
per CLAUDE.md) and asserts:

- non-first `B -> B2` renames exactly B with `[A B C]` order preserved
  and the `then permit` sub-config intact;
- first-sibling `A -> A2` still works;
- colliding `B -> C` is rejected with the tree unchanged;
- a post-rename `CompileConfig` sees `[A B2 C]`.

On revert (removeNode restored) the test goes RED with
`RenamePath(B->B2): source not found: security policies from-zone trust
to-zone untrust policy B`.

## Validation

- `go test ./pkg/config/... ./pkg/configstore/... ./pkg/cli/...` — green
- `go build ./...`, `gofmt`, `go vet ./pkg/config/` — clean
- `docs/config-schema.md` updated with the rename-side full-identity
  contract; `_Log.md` recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
