### PR TITLE
cli: stop the monitor stdin-reader goroutine on exit (#3985)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,39 @@
+## 2026-07-03 — #3985: `monitor interface` leaked a stdin-reader goroutine that stole the next command's keystroke
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-021 (MEDIUM, CLI UX). Both
+    `monitorInterfaceSingle` and `monitorInterfaceTraffic`
+    (`pkg/cli/monitor_interface.go`) spawned a goroutine that looped on a
+    blocking `os.Stdin.Read` to detect the quit key. `setRawMode` used
+    `VMIN=1`/`VTIME=0`, so the read blocked indefinitely. When the monitor
+    returned on `q`/ESC/Ctrl-C the goroutine was left parked mid-read; the
+    operator's NEXT command's first keystroke went to the dead monitor's
+    reader instead of the CLI prompt, and each `monitor interface`
+    invocation leaked another reader competing for stdin.
+  - **Fix**: switched `setRawMode` to `VMIN=0`/`VTIME=1` (poll-with-timeout:
+    Read returns immediately with data, else `(0, nil)` after ~100ms).
+    Extracted the reader loop into a testable `keyReader(r, keyCh, done)`
+    that re-checks `done` between polls (`continue` on `n==0`) and discards a
+    byte read after `done` is closed rather than forwarding it. Added
+    `startKeyReader(r) -> (keyCh, stop)`; `stop` closes `done` and
+    `wg.Wait()`s the goroutine (idempotent via `sync.Once`). Both monitors
+    now `defer stop()`, ordered (LIFO) to stop the reader BEFORE the terminal
+    is restored — so once the command returns no goroutine is competing for
+    stdin.
+  - **Test**: `pkg/cli/monitor_interface_stdin_3985_test.go` — a `fakeTTY`
+    poll reader drives `keyReader`/`startKeyReader`. Asserts keys forward
+    while running, the goroutine stays alive across idle polls and returns
+    promptly once `done` closes, a post-`done` key is not forwarded, and
+    `stop()` blocks until the goroutine drains (and is idempotent).
+    RED-on-revert verified: reverting `keyReader` to the pre-fix body fails
+    both `TestKeyReaderLifecycle` ("returned while running") and
+    `TestKeyReaderDiscardsKeyAfterDone` ("key forwarded after done closed").
+    `go test ./pkg/cli/ -race` green; `go build ./...`, gofmt clean (vet
+    unchanged — pre-existing `cli.go:503` unreachable-code note only).
+  - **File(s)**: `pkg/cli/monitor_interface.go`,
+    `pkg/cli/monitor_interface_stdin_3985_test.go`,
+    `docs/monitor-interface-research.md`, `_Log.md`.
+
 ## 2026-07-03 — #3980: path-scoped `show configuration <path>` / `| display set` showed only the FIRST sibling at a repeated-keyword level (navigatePath terminal single-key match was FindChild-first)
 
 - **Timestamp**: 2026-07-03

--- a/docs/monitor-interface-research.md
+++ b/docs/monitor-interface-research.md
@@ -97,6 +97,22 @@ Interface='i'  Switch to specific interface (prompts)
 - "Current delta" = change since last refresh
 - Delay: cur/avg/max processing delay
 
+### Terminal Input Handling (implementation)
+Both `monitor interface <name>` and `monitor interface traffic` put stdin in
+raw mode (`setRawMode`) and run a background goroutine (`keyReader`, launched
+via `startKeyReader`) that reads single bytes and forwards them to the render
+loop so keys like `q`/`f`/`n` take effect immediately.
+
+The raw terminal is configured `VMIN=0`/`VTIME=1` (poll-with-timeout): a read
+returns immediately when a key is available and otherwise returns `(0, nil)`
+after ~100ms. This lets `keyReader` observe its `done` channel between reads
+and return. On exit the monitor's deferred stop function closes `done` and
+**waits for the goroutine to return before restoring the terminal**, so no
+reader is left parked in `os.Stdin.Read` after the monitor exits. Using
+`VMIN=1`/`VTIME=0` (blocking read) instead would leave the goroutine parked
+forever, and it would steal the first keystroke of the operator's next command
+(#3985).
+
 ## 2. `monitor interface traffic` — All-Interfaces Summary
 
 ```

--- a/pkg/cli/monitor_interface.go
+++ b/pkg/cli/monitor_interface.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -43,6 +44,14 @@ func (a monitorInterfaceRuntimeDataPlane) ReadInterfaceCounters(ifindex int) (mo
 }
 
 // setRawMode puts the terminal into raw mode for single-character reads.
+//
+// VMIN=0/VTIME=1 selects a poll-with-timeout read: os.Stdin.Read returns
+// immediately when a key is available and otherwise returns (0, nil) after
+// 100ms with no data. This lets the key-reader goroutine observe its stop
+// signal between reads and return, instead of staying parked forever in a
+// blocking Read after the monitor exits (which would steal the next command's
+// keystroke — #3985). VMIN=1/VTIME=0 would block indefinitely and could not be
+// stopped without a keypress.
 func setRawMode(fd int) (*unix.Termios, error) {
 	old, err := unix.IoctlGetTermios(fd, unix.TCGETS)
 	if err != nil {
@@ -50,12 +59,66 @@ func setRawMode(fd int) (*unix.Termios, error) {
 	}
 	raw := *old
 	raw.Lflag &^= unix.ECHO | unix.ICANON | unix.ISIG
-	raw.Cc[unix.VMIN] = 1
-	raw.Cc[unix.VTIME] = 0
+	raw.Cc[unix.VMIN] = 0
+	raw.Cc[unix.VTIME] = 1
 	if err := unix.IoctlSetTermios(fd, unix.TCSETS, &raw); err != nil {
 		return nil, err
 	}
 	return old, nil
+}
+
+// keyReader reads single bytes from r and forwards them on keyCh until done is
+// closed, then returns. r must be a poll-mode reader (a raw tty configured with
+// VMIN=0/VTIME>0 via setRawMode) so that Read returns periodically with n==0
+// when idle, letting the loop observe done and return. Without this the
+// goroutine would remain blocked in Read after the monitor exits and consume
+// the operator's next keystroke (#3985). A byte read after done is closed is
+// discarded rather than forwarded, so no stale monitor input reaches a caller.
+func keyReader(r io.Reader, keyCh chan<- byte, done <-chan struct{}) {
+	buf := make([]byte, 1)
+	for {
+		select {
+		case <-done:
+			return
+		default:
+		}
+		n, err := r.Read(buf)
+		if err != nil {
+			return
+		}
+		if n == 0 {
+			// VTIME poll timeout with no data — loop and re-check done.
+			continue
+		}
+		select {
+		case keyCh <- buf[0]:
+		case <-done:
+			return
+		}
+	}
+}
+
+// startKeyReader launches a keyReader goroutine reading from r and returns the
+// key channel plus a stop function. The stop function closes the done channel
+// and blocks until the goroutine has returned, guaranteeing that no reader is
+// left competing for stdin once the monitor exits (#3985). Callers defer stop
+// so it runs before the terminal is restored and control returns to the CLI.
+func startKeyReader(r io.Reader) (<-chan byte, func()) {
+	keyCh := make(chan byte, 8)
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		keyReader(r, keyCh, done)
+	}()
+	var once sync.Once
+	return keyCh, func() {
+		once.Do(func() {
+			close(done)
+			wg.Wait()
+		})
+	}
 }
 
 func restoreTermMode(fd int, old *unix.Termios) {
@@ -195,17 +258,10 @@ func (c *CLI) monitorInterfaceSingle(ifaceName string) error {
 	fmt.Print(enterAltScreen + hideCursor)
 	defer fmt.Print(showCursor + exitAltScreen)
 
-	keyCh := make(chan byte, 8)
-	go func() {
-		buf := make([]byte, 1)
-		for {
-			n, err := os.Stdin.Read(buf)
-			if err != nil || n == 0 {
-				return
-			}
-			keyCh <- buf[0]
-		}
-	}()
+	// Stop the stdin reader before restoring the terminal so no goroutine is
+	// left parked in os.Stdin.Read stealing the next command's key (#3985).
+	keyCh, stopKeys := startKeyReader(os.Stdin)
+	defer stopKeys()
 
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
@@ -283,17 +339,10 @@ func (c *CLI) monitorInterfaceTraffic(mode monitoriface.SummaryMode) error {
 	fmt.Print(enterAltScreen + hideCursor)
 	defer fmt.Print(showCursor + exitAltScreen)
 
-	keyCh := make(chan byte, 8)
-	go func() {
-		buf := make([]byte, 1)
-		for {
-			n, err := os.Stdin.Read(buf)
-			if err != nil || n == 0 {
-				return
-			}
-			keyCh <- buf[0]
-		}
-	}()
+	// Stop the stdin reader before restoring the terminal so no goroutine is
+	// left parked in os.Stdin.Read stealing the next command's key (#3985).
+	keyCh, stopKeys := startKeyReader(os.Stdin)
+	defer stopKeys()
 
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()

--- a/pkg/cli/monitor_interface_stdin_3985_test.go
+++ b/pkg/cli/monitor_interface_stdin_3985_test.go
@@ -1,0 +1,151 @@
+package cli
+
+import (
+	"io"
+	"testing"
+	"time"
+)
+
+// fakeTTY models a raw terminal opened with VMIN=0/VTIME>0 (as setRawMode now
+// configures): Read returns a queued byte immediately, and otherwise returns
+// (0, nil) after a short idle timeout — the poll-with-timeout behavior the
+// #3985 fix relies on to let the key-reader goroutine observe its stop signal.
+type fakeTTY struct {
+	ch   chan byte
+	idle time.Duration
+}
+
+func (f *fakeTTY) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	select {
+	case b, ok := <-f.ch:
+		if !ok {
+			return 0, io.EOF
+		}
+		p[0] = b
+		return 1, nil
+	case <-time.After(f.idle):
+		// VTIME poll timeout with no data available.
+		return 0, nil
+	}
+}
+
+// TestKeyReaderLifecycle exercises the full lifecycle of the monitor's stdin
+// key-reader goroutine (#3985): it forwards keys while running, stays alive
+// across idle polls, and returns promptly once its done channel is closed.
+//
+// RED-on-revert: the pre-#3985 loop body was
+//
+//	for {
+//	    n, err := r.Read(buf)
+//	    if err != nil || n == 0 { return }
+//	    keyCh <- buf[0]
+//	}
+//
+// which has no done handling and returns on the first n==0 poll. Against this
+// VMIN=0/VTIME reader it exits within one idle interval, so the "still alive
+// while running" assertion below fails (the goroutine is gone). With the old
+// VMIN=1/VTIME=0 termios the same loop instead blocked forever in Read after
+// the monitor exited, parking the goroutine so it stole the operator's next
+// keystroke — the defect this test guards against.
+func TestKeyReaderLifecycle(t *testing.T) {
+	tty := &fakeTTY{ch: make(chan byte, 8), idle: 2 * time.Millisecond}
+	keyCh := make(chan byte, 8)
+	done := make(chan struct{})
+	exited := make(chan struct{})
+	go func() {
+		keyReader(tty, keyCh, done)
+		close(exited)
+	}()
+
+	// The monitor must still receive keystrokes (e.g. 'q' to quit).
+	tty.ch <- 'q'
+	select {
+	case k := <-keyCh:
+		if k != 'q' {
+			t.Fatalf("forwarded key = %q, want 'q'", k)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("key 'q' was not forwarded to the monitor")
+	}
+
+	// While done is open the reader must keep polling, not exit on an idle
+	// poll. The pre-#3985 code returns on the first n==0 read and fails here.
+	select {
+	case <-exited:
+		t.Fatal("keyReader returned while running (early-exit / leak regression — #3985)")
+	case <-time.After(100 * time.Millisecond):
+		// Still alive after many idle polls — correct.
+	}
+
+	// Closing done must make the goroutine return promptly: no stdin reader is
+	// left competing for the operator's next keystroke.
+	close(done)
+	select {
+	case <-exited:
+		// Returned cleanly.
+	case <-time.After(2 * time.Second):
+		t.Fatal("keyReader did not return after done closed — leaked stdin reader (#3985)")
+	}
+}
+
+// TestKeyReaderDiscardsKeyAfterDone verifies that a byte read concurrently with
+// the stop signal is discarded rather than forwarded once done is closed, so a
+// late monitor keystroke cannot leak past the exiting monitor.
+func TestKeyReaderDiscardsKeyAfterDone(t *testing.T) {
+	tty := &fakeTTY{ch: make(chan byte, 8), idle: time.Hour} // never idles out
+	keyCh := make(chan byte)                                 // unbuffered: forwarding requires a live receiver
+	done := make(chan struct{})
+	exited := make(chan struct{})
+	go func() {
+		keyReader(tty, keyCh, done)
+		close(exited)
+	}()
+
+	close(done)   // stop before any key is available
+	tty.ch <- 'x' // key arrives after done closed
+
+	select {
+	case k := <-keyCh:
+		t.Fatalf("key %q forwarded after done closed (leaked-reader keystroke theft — #3985)", k)
+	case <-exited:
+		// Reader returned without forwarding the post-done key — correct.
+	case <-time.After(2 * time.Second):
+		t.Fatal("keyReader did not return after done closed (#3985)")
+	}
+}
+
+// TestStartKeyReaderStopDrains verifies the stop function returned by
+// startKeyReader blocks until the reader goroutine has actually returned, and
+// is safe to call more than once.
+func TestStartKeyReaderStopDrains(t *testing.T) {
+	tty := &fakeTTY{ch: make(chan byte, 8), idle: 2 * time.Millisecond}
+	keyCh, stop := startKeyReader(tty)
+
+	tty.ch <- 'q'
+	select {
+	case k := <-keyCh:
+		if k != 'q' {
+			t.Fatalf("forwarded key = %q, want 'q'", k)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("key not forwarded via startKeyReader")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		stop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+		// stop() returned: wg.Wait completed, so the goroutine is gone.
+	case <-time.After(2 * time.Second):
+		t.Fatal("stop() did not return — reader goroutine not draining (#3985)")
+	}
+
+	// Idempotent: a second stop must not panic on a re-closed channel.
+	stop()
+}


### PR DESCRIPTION
Closes #3985

## Problem
`monitor interface <if>` and `monitor interface traffic` (`pkg/cli/monitor_interface.go`) each spawn a goroutine that loops on a blocking `os.Stdin.Read` to detect the quit key. `setRawMode` configured the terminal `VMIN=1`/`VTIME=0`, so that read **blocks indefinitely**. When the monitor returns (on `q`/ESC/Ctrl-C) the goroutine is left **parked mid-read** with no way to stop it:

- the operator's next command's first keystroke is consumed by the dead monitor's reader instead of reaching the CLI prompt;
- every `monitor interface` invocation leaks another reader competing for stdin.

## Fix
- **`setRawMode` → `VMIN=0`/`VTIME=1`** (poll-with-timeout): the read returns immediately when a key is available and otherwise returns `(0, nil)` after ~100ms, so the reader can observe a stop signal between reads.
- **Extract `keyReader(r, keyCh, done)`** — re-checks `done` on each idle poll (`continue` on `n==0`) and discards a byte read after `done` is closed rather than forwarding it.
- **Add `startKeyReader(r) -> (keyCh, stop)`** — `stop` closes `done` and `wg.Wait()`s the goroutine (idempotent via `sync.Once`).
- Both monitors now `defer stop()`, ordered (LIFO) so the reader is stopped **before** the terminal is restored. Once the command returns, no goroutine is competing for stdin.

## Test — `pkg/cli/monitor_interface_stdin_3985_test.go`
A `fakeTTY` poll reader drives `keyReader`/`startKeyReader` and asserts: keys forward while running; the goroutine stays alive across idle polls and returns promptly once `done` closes; a post-`done` key is **not** forwarded; `stop()` blocks until the goroutine drains (and is idempotent).

**RED-on-revert:** restoring the pre-fix loop body fails both `TestKeyReaderLifecycle` ("returned while running") and `TestKeyReaderDiscardsKeyAfterDone` ("key forwarded after done closed").

## Validation
- `go test ./pkg/cli/ -race -count=1` — green
- `go build ./...` — green
- `gofmt` clean on touched files (pre-existing `cli.go`/`completion_panic_test.go` formatting and the pre-existing `cli.go:503` vet note are untouched)

Docs: `docs/monitor-interface-research.md` gains a "Terminal Input Handling" note; `_Log.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi