### PR TITLE
config: keep all siblings for repeated keyed-list leaves (ntp server, archive-sites, api-key, traceoptions flag)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -34,6 +34,62 @@
     `pkg/cli/monitor_interface_stdin_3985_test.go`,
     `docs/monitor-interface-research.md`, `_Log.md`.
 
+## 2026-07-03 — #3984: repeated keyed-list leaves (`ntp server`, `archive-sites`, `api-key`, traceoptions `flag`) collapsed to the LAST on flat-set/load-set replay
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-041 (MEDIUM, config data loss — SET side of
+    the repeated-keyed-list class). The leaves `system ntp server <ip>`,
+    `system archival configuration archive-sites <url>`, `system services
+    web-management api-auth api-key <key>` and `security flow traceoptions
+    flag <flag>` were declared in `setSchema` as `{args: 1, children: nil}`
+    WITHOUT `multi: true`. Each is a REPEATED single-value statement whose
+    compiler reads EVERY sibling via `FindChildren` (`compiler_system.go`
+    NTP/archive-sites/api-key, `compiler_security.go` traceoptions flag),
+    accumulating into a slice. But `SetPath`'s terminal-leaf branch
+    (`pkg/config/ast_edit.go`, the `i >= len(path)` case) took the
+    single-value-REPLACE path for an `args > 0, !multi, children == nil` leaf,
+    so a SECOND `set ... server 2.2.2.2` REPLACED the first. A flat-set /
+    `load set` / `| display set` round-trip of a multi-value config therefore
+    DROPPED all but the LAST value silently. The compiler was already
+    multi-value (FindChildren) — the config was internally multi but the SET
+    path collapsed it.
+    FIX (schema markers only): added `multi: true` to the four leaves
+    (`schema_system.go` server:100, archive-sites:78, api-key:348;
+    `schema_security.go` flag:693). With `multi: true` the terminal-leaf
+    branch DEDUPs and APPENDs instead of replacing, so each `set` keeps a
+    distinct sibling; the compiler read is unchanged (still FindChildren).
+    Mechanism note: this is the SEPARATE-STATEMENTS use of `multi` (distinct
+    siblings), not the #2419 bracket-collapse — each `set` consumes exactly
+    `1+args` tokens with no trailing token, so the collapse branch (which
+    needs trailing tokens) never runs. `archive-sites`'s optional trailing
+    `password <s>` rides on `Keys[2:]` of the leaf and the compiler already
+    reads it there; the existing `flat_set_password` test stays green because
+    a passworded site is a distinct leaf either way. Delete/deactivate of
+    these leaves now inherit member-wise editing for free (the multi-leaf
+    branch in deletePath/setInactiveAtPath, #3846/#3975).
+    AUDIT (step 3): swept every raw (non-`namedInstances`) `FindChildren` read
+    against its schema decl. Only four leaves were in the collapse class
+    (children:nil, !multi, compiler accumulates siblings): the four fixed.
+    NOT bugs — `key-exchange`/`as-path`/`vlan-id-list`/`code-points` already
+    `multi`; ddns `server` read singly via a props map; `priority-cost` /
+    `track-priority-cost` are scalars validated in a loop (track-interface
+    capped at 1/vrrp-group); CoS rewrite `code-point` returns the first value
+    only; policy-`then` actions are one-per-then. Keyed CONTAINERS (`route`,
+    `security-zone`, `policy`, ...) have schema children so SetPath treats
+    them as containers → distinct siblings, never collapsed.
+    RED-on-revert: `pkg/config/set_repeated_leaf_3984_test.go` — 3× NTP
+    server, 3× archive-sites (one passworded), 2× api-key, 2× trace flag via
+    ParseSetCommand + SetPath assert all siblings survive + compiler reads
+    all; a display-set round-trip (FormatSet → re-apply) reproduces all 3 NTP
+    servers; single-server anti-over-broadening guard. Reverting the four
+    markers fails exactly the 5 collapse cases while the single-value guard
+    stays green. `go test ./pkg/config/... ./pkg/cli/...` green; `go build
+    ./...`, gofmt, vet clean. Docs: `docs/config-schema.md` new subsection
+    "`multi: true` ALSO prevents single-value REPLACE for repeated keyed-list
+    leaves (#3984)".
+  - **File(s)**: pkg/config/schema_system.go, pkg/config/schema_security.go,
+    pkg/config/set_repeated_leaf_3984_test.go, docs/config-schema.md, _Log.md
+
 ## 2026-07-03 — #3982: config-mode `rename` of a non-first same-keyword sibling failed (matched only the first sibling)
 
 - **Timestamp**: 2026-07-03

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -108,6 +108,41 @@ allowed-ips folds are covered by the `security-nat-static-multi-zone` and
 `interfaces-wireguard-allowed-ips-multi` dual-AST fixtures plus
 `TestWireguardAllowedIPsBracketList{FlatSet,Hierarchical}`.
 
+**`multi: true` ALSO prevents single-value REPLACE for repeated keyed-list
+leaves (#3984).** The `#2419` discussion above is about ONE statement with a
+bracket list. The SAME `multi: true` marker fixes a second, distinct shape:
+a keyed-list leaf that the operator writes as SEPARATE `set` statements, one
+value per line, which the compiler reads back as DISTINCT siblings via
+`FindChildren`:
+
+```
+set system ntp server 1.1.1.1
+set system ntp server 2.2.2.2
+set system ntp server 3.3.3.3
+```
+
+Each statement consumes exactly `1 + args` tokens with NO trailing token, so
+`SetPath` reaches its terminal-leaf branch (`i >= len(path)`). For a leaf
+declared `args > 0, children: nil` WITHOUT `multi`, that branch takes the
+**single-value REPLACE** path (correct for a scalar such as `host-name`): the
+SECOND `set` replaces the first, and the config silently collapses to the
+LAST value on any flat-set / `load set` / `| display set` round-trip. A leaf
+whose compiler reads MULTIPLE siblings (accumulating into a slice) is NOT a
+scalar — it must be `multi: true` so the terminal branch instead DEDUPs and
+APPENDS, keeping each occurrence a distinct sibling. The leaves in this class
+are `system ntp server`, `system archival configuration archive-sites`,
+`system services web-management api-auth api-key`, and `security flow
+traceoptions flag` (joining the already-`multi` `name-server` /
+`domain-search`). The compiler stays `FindChildren`-based and unchanged — the
+bug was purely the SetPath collapse. `archive-sites` also carries an optional
+trailing `password <s>` modifier, which lands on `Keys[2:]` of the collapsed
+leaf and is read there (`compiler_system.go`). Pinned by
+`pkg/config/set_repeated_leaf_3984_test.go` (RED on revert of the markers).
+This is the SET-side sibling of the display-side #3980 (`navigatePath` renders
+all N siblings) and the delete/deactivate-side #3846/#3975 (member-wise edit,
+which these leaves now inherit for free because `delete`/`deactivate` route a
+`multi: true, children: nil, args == 1` leaf through the member matcher).
+
 **`valueList` — a bracketed value list on a multi leaf that ALSO has a
 modifier child (#3872).** The bracket-absorption above fires only for a
 `multi: true` leaf with `children: nil`. The static-route `next-hop` leaf is

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -685,7 +685,12 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 		"power-mode-disable":           {desc: "Disable power mode", children: nil},
 		"traceoptions": {desc: "Flow trace debugging options", children: map[string]*schemaNode{
 			"file": {desc: "Trace file name (with size/files options)", args: 1, placeholder: "<filename>", children: nil},
-			"flag": {desc: "Trace flag (e.g. basic-datapath, session)", args: 1, placeholder: "<flag>", children: nil},
+			// #3984: repeated keyed-list leaf — the compiler accumulates
+			// every traceoptions `flag` sibling into Traceoptions.Flags via
+			// FindChildren (compiler_security.go). `multi: true` keeps each
+			// `set ... flag <flag>` a distinct sibling instead of replacing
+			// the previous one.
+			"flag": {desc: "Trace flag (e.g. basic-datapath, session)", args: 1, multi: true, placeholder: "<flag>", children: nil},
 			"packet-filter": {desc: "Trace packet filter name", args: 1, placeholder: "<filter-name>", children: map[string]*schemaNode{
 				"source-prefix":      {desc: "Source prefix to trace", args: 1, placeholder: "<prefix>", children: nil},
 				"destination-prefix": {desc: "Destination prefix to trace", args: 1, placeholder: "<prefix>", children: nil},

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -68,7 +68,14 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 	"archival": {desc: "Configuration archival", children: map[string]*schemaNode{
 		"configuration": {desc: "Configuration archival", children: map[string]*schemaNode{
 			"transfer-on-commit": {desc: "Transfer on commit", children: nil},
-			"archive-sites":      {desc: "Archive site URL", args: 1, placeholder: "<url>", children: nil},
+			// #3984: a repeated keyed-list leaf — an operator writes one
+			// `set ... archive-sites <url>` per site and the compiler reads
+			// every sibling via FindChildren (compiler_system.go). Without
+			// `multi: true` SetPath's single-value-REPLACE branch dropped all
+			// but the LAST site on a flat-set / load-set / display-set
+			// round-trip. A trailing `password <s>` modifier rides on the
+			// leaf's Keys[2:], which the compiler already reads.
+			"archive-sites": {desc: "Archive site URL", args: 1, multi: true, placeholder: "<url>", children: nil},
 		}},
 	}},
 	"master-password": {desc: "Master password", children: map[string]*schemaNode{
@@ -84,7 +91,13 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 		"no-ipv6-reject-zero-hop-limit": {desc: "Do not reject IPv6 packets with zero hop limit", children: nil},
 	}},
 	"ntp": {desc: "NTP configuration", children: map[string]*schemaNode{
-		"server": {desc: "NTP server", args: 1, placeholder: "<address>", children: nil},
+		// #3984: a repeated keyed-list leaf — one `set system ntp server
+		// <ip>` per server, and the compiler reads every sibling via
+		// FindChildren("server") (compiler_system.go). Without `multi: true`
+		// SetPath's single-value-REPLACE branch collapsed a multi-server
+		// config to the LAST server on a flat-set / load-set / display-set
+		// round-trip.
+		"server": {desc: "NTP server", args: 1, multi: true, placeholder: "<address>", children: nil},
 		"threshold": {desc: "Threshold", args: 1, placeholder: "<seconds>", children: map[string]*schemaNode{
 			"action": {desc: "Action on threshold", args: 1, placeholder: "<action>", children: nil},
 		}},
@@ -327,7 +340,12 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 				"user": {desc: "User name", wildcard: &schemaNode{desc: "Basic-auth user name for the REST API", placeholder: "<username>", children: map[string]*schemaNode{
 					"password": {desc: "Password", args: 1, placeholder: "<password>", children: nil},
 				}}},
-				"api-key": {desc: "API key", args: 1, placeholder: "<key>", children: nil},
+				// #3984: repeated keyed-list leaf — the compiler accumulates
+				// every `api-key` sibling into APIAuth.APIKeys via
+				// FindChildren (compiler_system.go). `multi: true` keeps each
+				// `set ... api-key <key>` a distinct sibling instead of
+				// replacing the previous one.
+				"api-key": {desc: "API key", args: 1, multi: true, placeholder: "<key>", children: nil},
 			}},
 		}},
 		"dns": {desc: "DNS service", children: nil},

--- a/pkg/config/set_repeated_leaf_3984_test.go
+++ b/pkg/config/set_repeated_leaf_3984_test.go
@@ -1,0 +1,215 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3984: the keyed-list LEAVES `system ntp server <ip>`,
+// `system archival configuration archive-sites <url>`,
+// `system services web-management api-auth api-key <key>` and
+// `security flow traceoptions flag <flag>` are repeated single-value
+// statements — an operator writes one `set` line per value and the
+// compiler reads EVERY sibling via FindChildren, accumulating them into a
+// slice. Before this fix they were declared in setSchema as
+// `{args:1, children:nil}` and were NOT `multi: true`, so SetPath's
+// single-value-REPLACE branch treated a SECOND `set ... server 2.2.2.2` as
+// a replacement of the first rather than an addition. A flat-set /
+// `load set` / display-set round-trip of a multi-value config therefore
+// DROPPED all but the LAST value silently.
+//
+// These are RED-on-revert guards: reverting the `multi: true` markers in
+// setSchema collapses each list to its last member and fails the count
+// assertions below. Every test drives the flat-set path (ParseSetCommand +
+// SetPath), never NewParser — the hierarchical parser already appends one
+// node per statement and would mask the SetPath collapse.
+
+// TestSetRepeatedNTPServers proves three distinct `set system ntp server`
+// statements survive SetPath as three sibling nodes and the compiler reads
+// all three. RED on revert: collapsed to the last, only one present.
+func TestSetRepeatedNTPServers(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set system ntp server 1.1.1.1",
+		"set system ntp server 2.2.2.2",
+		"set system ntp server 3.3.3.3",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	want := []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"}
+	if len(cfg.System.NTPServers) != len(want) {
+		t.Fatalf("NTPServers = %v, want %v (SetPath collapsed the repeated leaf)",
+			cfg.System.NTPServers, want)
+	}
+	for _, ip := range want {
+		found := false
+		for _, got := range cfg.System.NTPServers {
+			if got == ip {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("NTP server %q missing after SetPath; got %v", ip, cfg.System.NTPServers)
+		}
+	}
+}
+
+// TestSetSingleNTPServerUnchanged is the anti-over-broadening guard: a
+// single server still compiles to exactly one entry.
+func TestSetSingleNTPServerUnchanged(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set system ntp server 1.1.1.1",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if len(cfg.System.NTPServers) != 1 || cfg.System.NTPServers[0] != "1.1.1.1" {
+		t.Fatalf("NTPServers = %v, want [1.1.1.1]", cfg.System.NTPServers)
+	}
+}
+
+// TestSetRepeatedNTPServersDisplaySetRoundTrip proves a display-set backup
+// round-trips: render the SetPath-built tree via FormatSet (`| display
+// set`), re-apply every emitted line through ParseSetCommand + SetPath (the
+// load-set path), and reproduce all three servers. Before the fix the
+// re-applied lines collapsed back to the last server.
+func TestSetRepeatedNTPServersDisplaySetRoundTrip(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set system ntp server 1.1.1.1",
+		"set system ntp server 2.2.2.2",
+		"set system ntp server 3.3.3.3",
+	})
+	set := tree.FormatSet()
+	for _, ip := range []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"} {
+		if !strings.Contains(set, "set system ntp server "+ip) {
+			t.Fatalf("FormatSet() missing server %q; got:\n%s", ip, set)
+		}
+	}
+
+	reloaded := &ConfigTree{}
+	for _, line := range strings.Split(strings.TrimSpace(set), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		toks, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := reloaded.SetPath(toks); err != nil {
+			t.Fatalf("SetPath(%v): %v", toks, err)
+		}
+	}
+	cfg, err := CompileConfig(reloaded)
+	if err != nil {
+		t.Fatalf("compile error after round-trip: %v", err)
+	}
+	if len(cfg.System.NTPServers) != 3 {
+		t.Fatalf("round-trip NTPServers = %v, want 3 servers", cfg.System.NTPServers)
+	}
+}
+
+// TestSetRepeatedArchiveSites proves repeated `archive-sites` statements
+// survive SetPath, including a site that carries a `password` modifier
+// (which lands on the leaf's trailing keys and must not defeat the
+// distinct-sibling behaviour). RED on revert: collapsed to the last site.
+func TestSetRepeatedArchiveSites(t *testing.T) {
+	tree := buildTree(t, []string{
+		`set system archival configuration archive-sites "scp://a@host1/c" password s3cret`,
+		`set system archival configuration archive-sites "scp://b@host2/c"`,
+		`set system archival configuration archive-sites "ftp://c@host3/c"`,
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if cfg.System.Archival == nil {
+		t.Fatal("archival config missing")
+	}
+	want := []string{
+		"scp://a@host1/c",
+		"scp://b@host2/c",
+		"ftp://c@host3/c",
+	}
+	if len(cfg.System.Archival.ArchiveSites) != len(want) {
+		t.Fatalf("ArchiveSites = %v, want %v (SetPath collapsed the repeated leaf)",
+			cfg.System.Archival.ArchiveSites, want)
+	}
+	for _, url := range want {
+		found := false
+		for _, got := range cfg.System.Archival.ArchiveSites {
+			if got == url {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("archive-site %q missing; got %v", url, cfg.System.Archival.ArchiveSites)
+		}
+	}
+	// The site with a password modifier must still be recognized as such.
+	if len(cfg.System.Archival.ArchiveSitesWithPassword) != 1 ||
+		cfg.System.Archival.ArchiveSitesWithPassword[0] != "scp://a@host1/c" {
+		t.Errorf("ArchiveSitesWithPassword = %v, want [scp://a@host1/c]",
+			cfg.System.Archival.ArchiveSitesWithPassword)
+	}
+}
+
+// TestSetRepeatedAPIKeys proves repeated REST-API keys survive SetPath as
+// distinct siblings and the compiler reads every one. RED on revert:
+// collapsed to the last key.
+func TestSetRepeatedAPIKeys(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set system services web-management api-auth api-key key-alpha",
+		"set system services web-management api-auth api-key key-bravo",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if cfg.System.Services == nil || cfg.System.Services.WebManagement == nil ||
+		cfg.System.Services.WebManagement.APIAuth == nil {
+		t.Fatal("api-auth config missing")
+	}
+	keys := cfg.System.Services.WebManagement.APIAuth.APIKeys
+	if len(keys) != 2 {
+		t.Fatalf("APIKeys = %v, want 2 (SetPath collapsed the repeated leaf)", keys)
+	}
+	if string(keys[0]) != "key-alpha" || string(keys[1]) != "key-bravo" {
+		t.Errorf("APIKeys = [%q %q], want [key-alpha key-bravo]", keys[0], keys[1])
+	}
+}
+
+// TestSetRepeatedTraceFlags proves repeated flow-traceoptions `flag`
+// statements survive SetPath and the compiler reads every one. RED on
+// revert: collapsed to the last flag.
+func TestSetRepeatedTraceFlags(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security flow traceoptions flag basic-datapath",
+		"set security flow traceoptions flag session",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if cfg.Security.Flow.Traceoptions == nil {
+		t.Fatal("flow traceoptions config missing")
+	}
+	flags := cfg.Security.Flow.Traceoptions.Flags
+	if len(flags) != 2 {
+		t.Fatalf("trace Flags = %v, want 2 (SetPath collapsed the repeated leaf)", flags)
+	}
+	want := map[string]bool{"basic-datapath": false, "session": false}
+	for _, f := range flags {
+		if _, ok := want[f]; ok {
+			want[f] = true
+		}
+	}
+	for f, seen := range want {
+		if !seen {
+			t.Errorf("trace flag %q missing; got %v", f, flags)
+		}
+	}
+}


### PR DESCRIPTION
Closes #3984

## Problem

The keyed-list leaves `system ntp server <ip>`, `system archival
configuration archive-sites <url>`, `system services web-management
api-auth api-key <key>` and `security flow traceoptions flag <flag>` were
declared in `setSchema` as `{args: 1, children: nil}` **without**
`multi: true`. Each is a REPEATED single-value statement whose compiler
reads every sibling via `FindChildren` (accumulating into a slice), but
`SetPath`'s terminal-leaf branch (`ast_edit.go`, the `i >= len(path)`
case) takes the **single-value-REPLACE** path for an
`args > 0, !multi, children == nil` leaf. So a second
`set system ntp server 2.2.2.2` *replaced* the first, and a flat-set /
`load set` / `| display set` round-trip of a multi-value config silently
**dropped all but the last** value.

The config was internally multi-value (the compiler already read all
siblings) — only the SET path collapsed it. This is the SET-side sibling
of the display-side #3980 (`navigatePath` renders all N) and the
delete/deactivate-side #3846/#3975.

## Fix

Add `multi: true` to the four leaves. The terminal-leaf branch then
DEDUPs and APPENDs instead of replacing, keeping each `set` a distinct
sibling. The compiler read is unchanged (still `FindChildren`-based).

This is the **separate-statements** use of `multi` (one distinct sibling
per `set` line), not the #2419 single-statement bracket-collapse — each
`set` consumes exactly `1 + args` tokens with no trailing token, so the
bracket-absorption branch (which needs trailing tokens) never runs. The
`archive-sites` optional trailing `password <s>` modifier rides on
`Keys[2:]` and the compiler already reads it there. Delete/deactivate of
these leaves now inherit member-wise editing for free (the multi-leaf
branch in `deletePath`/`setInactiveAtPath`).

## Audit (issue step 3)

Swept every raw (non-`namedInstances`) `FindChildren` read against its
schema decl. Only four leaves were in the collapse class (children:nil,
!multi, compiler accumulates siblings) — the four fixed. Not bugs:
`key-exchange`/`as-path`/`vlan-id-list`/`code-points` already `multi`;
ddns `server` read singly via a props map; `priority-cost` /
`track-priority-cost` are scalars validated in a loop (track-interface
capped at 1/vrrp-group); CoS rewrite `code-point` returns the first
value only; policy-`then` actions are one-per-then. Keyed containers
(`route`, `security-zone`, `policy`, ...) have schema children so
SetPath already keeps them as distinct siblings.

## Validation

- `pkg/config/set_repeated_leaf_3984_test.go` (RED on revert): 3× NTP
  server, 3× archive-sites (one passworded), 2× api-key, 2× trace flag
  via `ParseSetCommand` + `SetPath` assert all siblings survive and the
  compiler reads every one; a display-set round-trip (`FormatSet` →
  re-apply) reproduces all three NTP servers; a single-server guard pins
  the anti-over-broadening case.
- Reverting the four `multi: true` markers fails exactly the five
  collapse cases; the single-value guard stays green.
- `go test ./pkg/config/... ./pkg/cli/...` green; `go build ./...`,
  gofmt, vet clean.
- Docs: `docs/config-schema.md` new subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
