### PR TITLE
scheduler: parse start/stop date in system-local zone (#3988)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,39 @@
+## 2026-07-03 — #3988: scheduler start/stop date parsed as UTC instead of system local time
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-052 (MEDIUM, config correctness).
+    `withinDateRange` (`pkg/scheduler/scheduler.go`) parsed a scheduler's
+    `start-date`/`stop-date` with `time.Parse("2006-01-02", …)`, whose
+    default zone is UTC. The parsed midnight instant was then compared
+    against `now` (`time.Now()` / the evaluation ticker, both `time.Local`),
+    so the calendar boundary sat on UTC midnight instead of local midnight
+    and the whole range shifted by the local UTC offset. Under UTC-7 a
+    `start-date 2026-07-01` range went active at 17:00 local on 2026-06-30
+    (~7 h early) and a `stop-date` closed the window ~7 h early on the stop
+    date — a time-based firewall policy (maintenance-window allow,
+    business-hours block) engaged at the wrong wall-clock, off by the offset.
+  - **Fix**: parse both dates with
+    `time.ParseInLocation("2006-01-02", …, now.Location())` so the boundary
+    lands on LOCAL midnight. Deriving the zone from `now` (rather than
+    reading `time.Local` directly) makes the boundary consistent with the
+    same clock the window is compared against, needs no global test seam,
+    and leaves a UTC-offset-0 host bit-identical (local == UTC). Audited the
+    daily `start-time`/`stop-time` path: already zone-safe — it forms no
+    instant, comparing only wall-clock H/M/S components (`parseTimeOfDay` vs
+    `timeOfDay`, both in `now`'s zone) — so only the date-range parse needed
+    the change.
+  - **Test**: `pkg/scheduler/scheduler_localtz_3988_test.go`. Builds `now`
+    in a fixed UTC-7 zone; `TestWithinDateRange_StartDateIsLocalMidnight`
+    and `TestWithinDateRange_StopDateInclusiveLocal` assert the local-midnight
+    boundary and go RED on revert (fire/close ~7 h early);
+    `TestWithinDateRange_UTCOffsetZeroUnchanged` (offset-0 unchanged) and
+    `TestWithinDateRange_DailyWindowZoneSafe` (daily window local before &
+    after) stay green on revert. Deterministic — the zone is injected via
+    `now.Location()`, not the host TZ.
+  - **File(s)**: `pkg/scheduler/scheduler.go`,
+    `pkg/scheduler/scheduler_localtz_3988_test.go`,
+    `pkg/scheduler/README.md`, `_Log.md`.
+
 ## 2026-07-03 — #3985: `monitor interface` leaked a stdin-reader goroutine that stole the next command's keystroke
 
 - **Timestamp**: 2026-07-03

--- a/pkg/scheduler/README.md
+++ b/pkg/scheduler/README.md
@@ -50,6 +50,21 @@ grouped by the `schedulers` entry in `setSchema`
 `start-date`/`stop-date` value slots are typed so a malformed window is
 rejected at commit (`ValidateTimeOfDay` / `ValidateDate`).
 
+**Time zone — system local (#3988).** Scheduler dates and times are Junos
+local wall-clock. `withinDateRange` parses `StartDate`/`StopDate` with
+`time.ParseInLocation("2006-01-02", …, now.Location())`, so the calendar
+boundary lands on **local midnight**; every production caller supplies `now`
+from `time.Now()` or the evaluation ticker, both of which carry `time.Local`.
+Parsing the date with `time.Parse` (its UTC default) put the boundary on UTC
+midnight and shifted the whole range by the local UTC offset — a
+`start-date 2026-07-01` range under UTC-7 went active at 17:00 local on
+2026-06-30, ~7 h early. The daily `start-time`/`stop-time` window is already
+local-safe and unchanged: it never forms an instant, comparing only wall-clock
+H/M/S components (`parseTimeOfDay` vs `timeOfDay`, both in `now`'s zone). A
+UTC-offset-0 host is unaffected (local == UTC). Deriving the zone from `now`
+rather than reading `time.Local` directly keeps the boundary consistent with
+the same clock the window is compared against and needs no global test seam.
+
 **Fail-closed invariant (#3849 — security).** `isWithinWindow` treats an
 ABSENT window as **inactive**, never always-on. A scheduler that resolves
 to no window for a given instant — no daily window, no applicable per-day

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -317,9 +317,22 @@ func isWithinWindow(now time.Time, sched *config.SchedulerConfig) bool {
 
 // withinDateRange reports whether now is inside sched's calendar range.
 // ok is false when a configured date fails to parse (caller fails closed).
+//
+// #3988: the calendar boundary is interpreted in the SYSTEM LOCAL time zone,
+// matching the Junos convention that a scheduler start-date/stop-date is a
+// local wall-clock date. The date is parsed in now.Location() rather than with
+// time.Parse (which defaults to UTC): every production caller supplies now from
+// time.Now() or the evaluation ticker, both of which carry time.Local, so the
+// date boundary lands on LOCAL midnight. Parsing as UTC shifted the boundary by
+// the local UTC offset (e.g. a start-date 2026-07-01 range under UTC-7 went
+// active at 17:00 local on 2026-06-30 — 7h early). Deriving the zone from now
+// keeps the boundary consistent with the same clock the window is compared
+// against, needs no global seam, and leaves a UTC-offset-0 host unchanged
+// (local == UTC).
 func withinDateRange(now time.Time, sched *config.SchedulerConfig) (inRange, ok bool) {
+	loc := now.Location()
 	if sched.StartDate != "" {
-		startDate, err := time.Parse("2006-01-02", sched.StartDate)
+		startDate, err := time.ParseInLocation("2006-01-02", sched.StartDate, loc)
 		if err != nil {
 			slog.Warn("scheduler: invalid start date", "name", sched.Name, "date", sched.StartDate, "err", err)
 			return false, false
@@ -329,7 +342,7 @@ func withinDateRange(now time.Time, sched *config.SchedulerConfig) (inRange, ok 
 		}
 	}
 	if sched.StopDate != "" {
-		stopDate, err := time.Parse("2006-01-02", sched.StopDate)
+		stopDate, err := time.ParseInLocation("2006-01-02", sched.StopDate, loc)
 		if err != nil {
 			slog.Warn("scheduler: invalid stop date", "name", sched.Name, "date", sched.StopDate, "err", err)
 			return false, false
@@ -421,6 +434,15 @@ func parseTimeOfDay(s string) (tod, error) {
 	return tod{h: t.Hour(), m: t.Minute(), s: t.Second()}, nil
 }
 
+// timeOfDay extracts t's wall-clock hour/minute/second in t's own location.
+//
+// #3988 audit: the daily start-time/stop-time window is zone-safe as-is. Both
+// sides of the comparison use wall-clock components — parseTimeOfDay reads the
+// H/M/S of the configured "HH:MM:SS", and timeOfDay reads now's LOCAL H/M/S
+// (now carries time.Local in every production caller). No instant is formed, so
+// the configured 09:00:00 is compared against 09:00:00 local regardless of the
+// UTC offset. Only the calendar date-range parse (withinDateRange) formed a
+// UTC instant and had to move to now.Location().
 func timeOfDay(t time.Time) tod {
 	return tod{h: t.Hour(), m: t.Minute(), s: t.Second()}
 }

--- a/pkg/scheduler/scheduler_localtz_3988_test.go
+++ b/pkg/scheduler/scheduler_localtz_3988_test.go
@@ -1,0 +1,119 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// pdt is a fixed UTC-7 zone standing in for a non-UTC operator timezone. The
+// scheduler date-range boundary must land on LOCAL midnight in this zone, not
+// UTC midnight (which is 07:00 local — a 7h shift).
+var pdt = time.FixedZone("PDT", -7*3600)
+
+// TestWithinDateRange_StartDateIsLocalMidnight is the #3988 RED-on-revert
+// guard. In a UTC-7 zone a scheduler whose calendar range opens on 2026-07-01
+// must NOT be active at 23:30 LOCAL on 2026-06-30 — the range has not started
+// yet. With the fix (ParseInLocation using now.Location()) the start boundary
+// is 2026-07-01 00:00 local, so 2026-06-30 23:30 local is before it and the
+// scheduler is inactive.
+//
+// On revert to time.Parse (UTC default) the boundary becomes 2026-07-01 00:00
+// UTC == 2026-06-30 17:00 local, so 23:30 local (00:30 UTC on 2026-07-01) is
+// AFTER it — the scheduler activates ~6.5h early and this test goes RED.
+//
+// now is built in the fixed zone and the parse derives its zone from
+// now.Location(), so the assertion is deterministic and does not depend on the
+// host's TZ (which is UTC in CI).
+func TestWithinDateRange_StartDateIsLocalMidnight(t *testing.T) {
+	sched := &config.SchedulerConfig{
+		Name:      "maint-window",
+		StartDate: "2026-07-01",
+		// Date-range-only scheduler: active for the whole local calendar range.
+	}
+
+	// 2026-06-30 23:30 local (still June 30 in the operator's wall-clock).
+	nowBefore := time.Date(2026, 6, 30, 23, 30, 0, 0, pdt)
+	if isWithinWindow(nowBefore, sched) {
+		t.Errorf("start-date 2026-07-01 must NOT be active at %s (local June 30, before the range); "+
+			"parsed as UTC the boundary shifts %+d and it fires early (#3988)", nowBefore, -7)
+	}
+
+	// 2026-07-01 00:30 local — just inside the range on the start date.
+	nowInside := time.Date(2026, 7, 1, 0, 30, 0, 0, pdt)
+	if !isWithinWindow(nowInside, sched) {
+		t.Errorf("start-date 2026-07-01 must be active at %s (local July 1, inside the range)", nowInside)
+	}
+}
+
+// TestWithinDateRange_StopDateInclusiveLocal confirms the inclusive stop-date
+// boundary is also interpreted in local time. A range ending 2026-07-01 must
+// still be active at 23:30 LOCAL on 2026-07-01 (the whole stop date is
+// inclusive) and inactive at 00:30 LOCAL on 2026-07-02.
+//
+// On revert the UTC stop boundary (2026-07-02 00:00 UTC == 2026-07-01 17:00
+// local) closes the window ~7h early on the stop date, so the first assertion
+// goes RED.
+func TestWithinDateRange_StopDateInclusiveLocal(t *testing.T) {
+	sched := &config.SchedulerConfig{
+		Name:     "maint-window",
+		StopDate: "2026-07-01",
+	}
+
+	// 2026-07-01 23:30 local — the stop date is inclusive, still active.
+	nowLastEvening := time.Date(2026, 7, 1, 23, 30, 0, 0, pdt)
+	if !isWithinWindow(nowLastEvening, sched) {
+		t.Errorf("stop-date 2026-07-01 (inclusive) must be active at %s (local July 1 evening); "+
+			"parsed as UTC the boundary closes the window early (#3988)", nowLastEvening)
+	}
+
+	// 2026-07-02 00:30 local — the day after the stop date, inactive.
+	nowNextDay := time.Date(2026, 7, 2, 0, 30, 0, 0, pdt)
+	if isWithinWindow(nowNextDay, sched) {
+		t.Errorf("stop-date 2026-07-01 must NOT be active at %s (local July 2, after the range)", nowNextDay)
+	}
+}
+
+// TestWithinDateRange_UTCOffsetZeroUnchanged pins the "don't regress a
+// UTC-offset-0 host" requirement: when now is in UTC, local == UTC and the
+// boundary behaves exactly as before the fix.
+func TestWithinDateRange_UTCOffsetZeroUnchanged(t *testing.T) {
+	sched := &config.SchedulerConfig{
+		Name:      "campaign",
+		StartDate: "2026-03-01",
+		StopDate:  "2026-03-31",
+	}
+	if isWithinWindow(time.Date(2026, 2, 28, 23, 30, 0, 0, time.UTC), sched) {
+		t.Error("Feb 28 UTC must be before the March range (offset-0 unchanged)")
+	}
+	if !isWithinWindow(time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC), sched) {
+		t.Error("March 1 00:00 UTC must be inside the range (offset-0 unchanged)")
+	}
+	if !isWithinWindow(time.Date(2026, 3, 31, 23, 59, 0, 0, time.UTC), sched) {
+		t.Error("March 31 23:59 UTC must be inside the inclusive range (offset-0 unchanged)")
+	}
+	if isWithinWindow(time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC), sched) {
+		t.Error("April 1 12:00 UTC must be after the inclusive range (offset-0 unchanged)")
+	}
+}
+
+// TestWithinDateRange_DailyWindowZoneSafe documents that the daily
+// start-time/stop-time window (which #3988 audited) is already interpreted in
+// local wall-clock: 09:00-17:00 is active at 12:00 local and inactive at 20:00
+// local regardless of the UTC offset, because both sides compare wall-clock
+// components (see timeOfDay / parseTimeOfDay). This stays green before and
+// after the fix — it is the audit evidence that no instant is formed there.
+func TestWithinDateRange_DailyWindowZoneSafe(t *testing.T) {
+	sched := &config.SchedulerConfig{
+		Name:      "business-hours",
+		StartTime: "09:00:00",
+		StopTime:  "17:00:00",
+	}
+	if !isWithinWindow(time.Date(2026, 7, 1, 12, 0, 0, 0, pdt), sched) {
+		t.Error("12:00 local must be inside the 09:00-17:00 daily window")
+	}
+	if isWithinWindow(time.Date(2026, 7, 1, 20, 0, 0, 0, pdt), sched) {
+		t.Error("20:00 local must be outside the 09:00-17:00 daily window")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #3988 (fable-161 F-052, MEDIUM — config correctness).

`withinDateRange` (`pkg/scheduler/scheduler.go`) parsed a scheduler's
`start-date`/`stop-date` with `time.Parse("2006-01-02", …)`, whose default
zone is **UTC**. The resulting midnight instant was compared against `now`,
which every production caller supplies from `time.Now()` or the evaluation
ticker — both `time.Local`. The calendar boundary therefore landed on **UTC
midnight** instead of **local midnight**, shifting the whole range by the
local UTC offset.

Junos scheduler dates are local wall-clock. Under UTC-7 a `start-date
2026-07-01` range went active at 17:00 local on 2026-06-30 (~7 h early), and a
`stop-date` closed ~7 h early on the stop date — a time-based firewall policy
(maintenance-window allow, business-hours block) engaged at the wrong
wall-clock hour, off by the UTC offset.

## Fix

Parse both dates with `time.ParseInLocation("2006-01-02", …, now.Location())`
so the boundary lands on LOCAL midnight. Deriving the zone from `now` (rather
than reading `time.Local` directly) keeps the boundary consistent with the same
clock the window is compared against, needs no global test seam, and leaves a
UTC-offset-0 host bit-identical (local == UTC).

**Audit of the other scheduler time fields:** the daily `start-time`/`stop-time`
window is already zone-safe and unchanged — it forms no instant, comparing only
wall-clock H/M/S components (`parseTimeOfDay` vs `timeOfDay`, both in `now`'s
zone), so `09:00:00` is compared against `09:00:00` local regardless of the
offset. Only the date-range parse formed a UTC instant and needed the change.

## Test / RED-on-revert

`pkg/scheduler/scheduler_localtz_3988_test.go` builds `now` in a fixed UTC-7
zone (deterministic, independent of the host TZ which is UTC in CI):

| Test | With fix | On revert (UTC parse) |
|------|----------|-----------------------|
| `TestWithinDateRange_StartDateIsLocalMidnight` | PASS | **RED** (fires ~7 h early) |
| `TestWithinDateRange_StopDateInclusiveLocal` | PASS | **RED** (closes ~7 h early) |
| `TestWithinDateRange_UTCOffsetZeroUnchanged` | PASS | PASS (offset-0 unchanged) |
| `TestWithinDateRange_DailyWindowZoneSafe` | PASS | PASS (daily window local) |

`go test ./pkg/config/... ./pkg/scheduler/... ./pkg/daemon/...` green;
`go build ./...`, `gofmt`, `go vet` clean.

## Docs

`pkg/scheduler/README.md` gains a "Time zone — system local (#3988)"
subsection; `_Log.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi