### PR TITLE
ipsec: enable DPD for bare / interval-only dead-peer-detection forms (#3994)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -30691,3 +30691,27 @@ top.
   - **File(s)**: pkg/configstore/store_lock.go,
     pkg/configstore/store_lock_3979_test.go, pkg/configstore/README.md,
     cmd/cli/shared.go, _Log.md
+
+- **Timestamp**: 2026-07-03
+  - **Action**: #3994 — IKE dead-peer-detection bare / interval-only /
+    threshold-only forms now enable DPD. The compiler overloaded the
+    `DeadPeerDetect` mode string as the enable flag, so a bare
+    `dead-peer-detection;` produced an empty mode read as DISABLED downstream
+    (no `dpd_delay`), and an interval-only / threshold-only stanza let
+    `nodeVal()` capture the sub-field token ("interval"/"threshold") as a bogus
+    mode. Added `IPsecGateway.DPDEnable` as the single enable source of truth;
+    rewrote `parseDeadPeerDetectionNode` to set it for every form and to scan
+    both node Keys and children for mode/interval/threshold; gated `deriveDPD`
+    on `DPDEnable` (mode-string fallback kept) and gave the bare/default form a
+    concrete `dpd_action` (restart/clear, Junos-optimized default) instead of
+    leaning on strongSwan's implicit default; updated both `show security`
+    DPD-display sites to gate on `DPDEnable`. Tests: config-layer form matrix
+    (`TestIKEDeadPeerDetectionForms`) + end-to-end swanctl render
+    (`TestGenerateConfig_DPDBareAndTuningForms`, RED-on-revert: bare form loses
+    `dpd_delay = 10s` when the fix is reverted — proven). go build ./..., gofmt,
+    vet clean; pkg/config + pkg/ipsec + pkg/cli + pkg/grpcapi suites green.
+    Docs: pkg/ipsec/README.md DPD bullet rewritten.
+  - **File(s)**: pkg/config/types_security.go, pkg/config/compiler_ipsec.go,
+    pkg/config/parser_security_test.go, pkg/ipsec/ike.go, pkg/ipsec/ipsec_test.go,
+    pkg/cli/cli_show_security_ipsec.go, pkg/grpcapi/server_show_security_text.go,
+    pkg/ipsec/README.md, _Log.md

--- a/pkg/cli/cli_show_security_ipsec.go
+++ b/pkg/cli/cli_show_security_ipsec.go
@@ -243,8 +243,12 @@ func (c *CLI) showIKE(args []string) error {
 			ver = "v1+v2"
 		}
 		fmt.Printf("  IKE version:        %s\n", ver)
-		if gw.DeadPeerDetect != "" {
-			fmt.Printf("  DPD:                %s\n", gw.DeadPeerDetect)
+		if gw.DPDEnable || gw.DeadPeerDetect != "" {
+			mode := gw.DeadPeerDetect
+			if mode == "" {
+				mode = "enabled"
+			}
+			fmt.Printf("  DPD:                %s\n", mode)
 			if gw.DPDInterval > 0 {
 				fmt.Printf("  DPD interval:       %ds\n", gw.DPDInterval)
 			}

--- a/pkg/config/compiler_ipsec.go
+++ b/pkg/config/compiler_ipsec.go
@@ -194,13 +194,54 @@ func compileIKE(node *Node, sec *SecurityConfig) error {
 	return nil
 }
 
+// parseDeadPeerDetectionNode compiles a `dead-peer-detection` stanza on an IKE
+// gateway. The presence of the stanza — in ANY form — enables DPD (#3994):
+//
+//   - bare `dead-peer-detection;`            → enable with Junos defaults
+//   - `dead-peer-detection interval <n>;`    → enable + tune the probe interval
+//   - `dead-peer-detection threshold <n>;`   → enable + tune the retry count
+//   - `dead-peer-detection always-send;`     → enable + explicit mode
+//     (also optimized / probe-idle-tunnel)
+//
+// Enablement is tracked on gw.DPDEnable, independent of the mode. The previous
+// implementation overloaded the DeadPeerDetect mode string as the enable flag,
+// which mishandled two forms: the bare statement produced an empty mode and was
+// read as DISABLED downstream, and an interval-only / threshold-only stanza let
+// nodeVal() pick up the sub-field name ("interval"/"threshold") as a bogus mode
+// (DPD enabled but with a mode that mapped to no dpd_action). Both forms now
+// enable DPD with the mode left empty (Junos default behaviour), and only a
+// real mode keyword sets DeadPeerDetect.
+//
+// Tokens may ride on the node's own Keys (compact-hierarchical
+// `dead-peer-detection always-send` / `dead-peer-detection interval 10`) or on
+// child nodes (flat-set and block forms), so both are scanned.
 func parseDeadPeerDetectionNode(node *Node, gw *IPsecGateway) {
 	if gw == nil || node == nil {
 		return
 	}
 
-	if v := nodeVal(node); v != "" {
-		gw.DeadPeerDetect = v
+	gw.DPDEnable = true
+
+	keys := node.Keys
+	for i := 1; i < len(keys); i++ {
+		switch keys[i] {
+		case "always-send", "optimized", "probe-idle-tunnel":
+			gw.DeadPeerDetect = keys[i]
+		case "interval":
+			if i+1 < len(keys) {
+				if n, err := strconv.Atoi(keys[i+1]); err == nil {
+					gw.DPDInterval = n
+				}
+				i++
+			}
+		case "threshold":
+			if i+1 < len(keys) {
+				if n, err := strconv.Atoi(keys[i+1]); err == nil {
+					gw.DPDThreshold = n
+				}
+				i++
+			}
+		}
 	}
 
 	for _, c := range node.Children {
@@ -216,10 +257,6 @@ func parseDeadPeerDetectionNode(node *Node, gw *IPsecGateway) {
 				gw.DPDThreshold = n
 			}
 		}
-	}
-
-	if gw.DeadPeerDetect == "" && (len(node.Children) > 0 || len(node.Keys) > 1) {
-		gw.DeadPeerDetect = "always-send"
 	}
 }
 

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -1973,6 +1973,101 @@ func TestIKEGatewayLocalCertificateAndTrafficSelectorSetSyntax(t *testing.T) {
 	}
 }
 
+// TestIKEDeadPeerDetectionForms exercises every DPD stanza shape through the
+// flat-set compile path (#3994). The bare statement must ENABLE DPD (not be
+// read as disabled), and the interval-only / threshold-only forms must enable
+// DPD + capture the tuning value WITHOUT leaving the mode string holding the
+// bogus sub-field token ("interval"/"threshold").
+func TestIKEDeadPeerDetectionForms(t *testing.T) {
+	compile := func(t *testing.T, cmds []string) *IPsecGateway {
+		t.Helper()
+		tree := &ConfigTree{}
+		for _, cmd := range cmds {
+			path, err := ParseSetCommand(cmd)
+			if err != nil {
+				t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+			}
+			if err := tree.SetPath(path); err != nil {
+				t.Fatalf("SetPath(%v): %v", path, err)
+			}
+		}
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		return cfg.Security.IPsec.Gateways["g"]
+	}
+
+	cases := []struct {
+		name          string
+		cmds          []string
+		wantEnable    bool
+		wantMode      string
+		wantInterval  int
+		wantThreshold int
+	}{
+		{
+			name:       "bare enables DPD with defaults",
+			cmds:       []string{`set security ike gateway g dead-peer-detection`},
+			wantEnable: true,
+			wantMode:   "",
+		},
+		{
+			name:         "interval-only enables + tunes, no bogus mode",
+			cmds:         []string{`set security ike gateway g dead-peer-detection interval 10`},
+			wantEnable:   true,
+			wantMode:     "",
+			wantInterval: 10,
+		},
+		{
+			name:          "threshold-only enables + tunes, no bogus mode",
+			cmds:          []string{`set security ike gateway g dead-peer-detection threshold 3`},
+			wantEnable:    true,
+			wantMode:      "",
+			wantThreshold: 3,
+		},
+		{
+			name:       "always-send mode",
+			cmds:       []string{`set security ike gateway g dead-peer-detection always-send`},
+			wantEnable: true,
+			wantMode:   "always-send",
+		},
+		{
+			name:         "optimized mode with tuning",
+			cmds:         []string{`set security ike gateway g dead-peer-detection optimized`, `set security ike gateway g dead-peer-detection interval 15`, `set security ike gateway g dead-peer-detection threshold 4`},
+			wantEnable:   true,
+			wantMode:     "optimized",
+			wantInterval: 15, wantThreshold: 4,
+		},
+		{
+			name:       "no DPD stanza leaves DPD off",
+			cmds:       []string{`set security ike gateway g address 1.2.3.4`},
+			wantEnable: false,
+			wantMode:   "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := compile(t, tc.cmds)
+			if gw == nil {
+				t.Fatal("missing gateway g")
+			}
+			if gw.DPDEnable != tc.wantEnable {
+				t.Errorf("DPDEnable = %v, want %v", gw.DPDEnable, tc.wantEnable)
+			}
+			if gw.DeadPeerDetect != tc.wantMode {
+				t.Errorf("DeadPeerDetect = %q, want %q", gw.DeadPeerDetect, tc.wantMode)
+			}
+			if gw.DPDInterval != tc.wantInterval {
+				t.Errorf("DPDInterval = %d, want %d", gw.DPDInterval, tc.wantInterval)
+			}
+			if gw.DPDThreshold != tc.wantThreshold {
+				t.Errorf("DPDThreshold = %d, want %d", gw.DPDThreshold, tc.wantThreshold)
+			}
+		})
+	}
+}
+
 func TestIKEAdvancedSetSyntax(t *testing.T) {
 	setCommands := []string{`set security ike proposal ike-p1 authentication-method pre-shared-keys`, `set security ike proposal ike-p1 dh-group group14`, `set security ike proposal ike-p1 encryption-algorithm aes-256-cbc`, `set security ike policy pol1 mode main`, `set security ike policy pol1 proposals ike-p1`, `set security ike policy pol1 pre-shared-key ascii-text mysecret`, `set security ike gateway gw1 ike-policy pol1`, `set security ike gateway gw1 address 10.0.0.1`, `set security ike gateway gw1 version v2-only`, `set security ike gateway gw1 no-nat-traversal`, `set security ike gateway gw1 dead-peer-detection always-send`, `set security ike gateway gw1 local-identity hostname vpn.test.com`, `set security ike gateway gw1 remote-identity inet 10.0.0.1`, `set security ipsec proposal esp-p2 protocol esp`, `set security ipsec proposal esp-p2 encryption-algorithm aes-256-cbc`, `set security ipsec proposal esp-p2 authentication-algorithm hmac-sha-256-128`, `set security ipsec policy ipsec-pol perfect-forward-secrecy keys group5`, `set security ipsec policy ipsec-pol proposals esp-p2`, `set security ipsec vpn tun1 bind-interface st0.0`, `set security ipsec vpn tun1 df-bit copy`, `set security ipsec vpn tun1 establish-tunnels immediately`, `set security ipsec vpn tun1 ike gateway gw1`, `set security ipsec vpn tun1 ike ipsec-policy ipsec-pol`}
 	tree := &ConfigTree{}

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -1024,13 +1024,19 @@ type IPsecGateway struct {
 	Version          string // "v1-only", "v2-only" (empty = both)
 	NoNATTraversal   bool   // disable NAT-T (legacy, use NATTraversal)
 	NATTraversal     string // "enable" (default), "disable", "force"
-	DeadPeerDetect   string // "always-send", "optimized", "probe-idle"
-	DPDInterval      int    // seconds
-	DPDThreshold     int    // retry count before peer is considered dead
-	LocalIDType      string // "hostname", "inet", "fqdn"
-	LocalIDValue     string // identity value
-	RemoteIDType     string // "hostname", "inet", "fqdn"
-	RemoteIDValue    string // identity value
+	// DPDEnable records that a `dead-peer-detection` stanza is present, so a
+	// bare `dead-peer-detection;` (Junos: enable DPD with defaults) or an
+	// interval-only / threshold-only form enables DPD even though no explicit
+	// mode keyword was given. It is the single source of truth for "is DPD
+	// on"; DeadPeerDetect only carries the explicit mode keyword (#3994).
+	DPDEnable      bool
+	DeadPeerDetect string // explicit mode: "always-send", "optimized", "probe-idle-tunnel" (empty = Junos default / bare stanza)
+	DPDInterval    int    // seconds
+	DPDThreshold   int    // retry count before peer is considered dead
+	LocalIDType    string // "hostname", "inet", "fqdn"
+	LocalIDValue   string // identity value
+	RemoteIDType   string // "hostname", "inet", "fqdn"
+	RemoteIDValue  string // identity value
 	// DynamicHostnameExtras holds tokens that rode past the FQDN on a
 	// compact-hierarchical `dynamic hostname <fqdn> <extra>` line (#3332).
 	// The flat-set form lands `hostname <fqdn>` as a scalar child the generic

--- a/pkg/grpcapi/server_show_security_text.go
+++ b/pkg/grpcapi/server_show_security_text.go
@@ -948,8 +948,12 @@ func (s *Server) showIKE(cfg *config.Config, buf *strings.Builder) {
 				ver = "v1+v2"
 			}
 			fmt.Fprintf(buf, "  IKE version:        %s\n", ver)
-			if gw.DeadPeerDetect != "" {
-				fmt.Fprintf(buf, "  DPD:                %s\n", gw.DeadPeerDetect)
+			if gw.DPDEnable || gw.DeadPeerDetect != "" {
+				mode := gw.DeadPeerDetect
+				if mode == "" {
+					mode = "enabled"
+				}
+				fmt.Fprintf(buf, "  DPD:                %s\n", mode)
 				if gw.DPDInterval > 0 {
 					fmt.Fprintf(buf, "  DPD interval:       %ds\n", gw.DPDInterval)
 				}

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -106,9 +106,25 @@ all files stay in `package ipsec`, so the public API is unchanged.
 - Traffic selectors are auto-derived from the policy source / destination
   prefixes when not given explicitly. Mixing explicit and derived
   selectors is supported but the explicit set wins.
-- DPD (dead-peer detection) profiles auto-generate from IKE/ESP
-  lifetimes. Operators can override with explicit `dead-peer-detection
-  delay/timeout`.
+- **DPD (dead-peer detection).** A `dead-peer-detection` stanza on an IKE
+  gateway is compiled by `parseDeadPeerDetectionNode` (`pkg/config`
+  `compiler_ipsec.go`) into `gw.DPDEnable` + mode/interval/threshold, and
+  rendered by `deriveDPD` (`pkg/ipsec/ike.go`) into swanctl `dpd_delay`,
+  `dpd_timeout`, and `dpd_action`. Every Junos form enables DPD (#3994):
+  - a bare `dead-peer-detection;` enables DPD with defaults — 10s delay,
+    threshold 5 (→ `dpd_timeout = delay × threshold`), and `dpd_action`
+    from the default/optimized mapping (`restart` for a
+    `establish-tunnels immediately` tunnel, else `clear`);
+  - `interval <n>` tunes `dpd_delay`; `threshold <n>` tunes the retry
+    count feeding `dpd_timeout`;
+  - the mode keyword maps to `dpd_action`: `always-send` → `restart`,
+    `optimized` → `clear`/`restart`, `probe-idle-tunnel` → `trap`/`restart`.
+
+  `DPDEnable` is the single source of truth for "is DPD on"; the mode
+  string only carries the explicit keyword. Before #3994 the enable check
+  was `DeadPeerDetect != ""`, so a bare statement was read as DISABLED and
+  an interval-only / threshold-only stanza captured the sub-field name as a
+  bogus mode.
 - XFRM interface ID is derived from the bind-interface name via
   `xfrmiIfID()`. The same name → same numeric ID across reboots — don't
   rename a bind interface without expecting a reset of the SAs that ride

--- a/pkg/ipsec/ike.go
+++ b/pkg/ipsec/ike.go
@@ -171,8 +171,16 @@ func resolveESPSettings(cfg *config.IPsecConfig, vpn *config.IPsecVPN) (string, 
 }
 
 // deriveDPD computes the dead-peer-detection settings for a connection.
+//
+// DPD is enabled whenever the gateway carries a `dead-peer-detection` stanza
+// (gw.DPDEnable), regardless of whether an explicit mode keyword was given. A
+// bare `dead-peer-detection;` therefore yields a DPD-enabled connection with
+// the strongSwan defaults (10s delay, restart/clear action) — before #3994 the
+// enable check was gw.DeadPeerDetect != "", so the bare form was silently
+// treated as disabled. gw.DeadPeerDetect != "" is still honoured as a fallback
+// so a hand-built gateway that sets only the mode still enables DPD.
 func deriveDPD(gw *config.IPsecGateway, vpn *config.IPsecVPN) dpdSettings {
-	if gw == nil || gw.DeadPeerDetect == "" {
+	if gw == nil || (!gw.DPDEnable && gw.DeadPeerDetect == "") {
 		return dpdSettings{}
 	}
 
@@ -202,8 +210,17 @@ func deriveDPD(gw *config.IPsecGateway, vpn *config.IPsecVPN) dpdSettings {
 			action = "trap"
 		}
 	default:
+		// No explicit mode keyword (bare `dead-peer-detection;`). Junos
+		// treats a bare stanza as its default DPD behaviour, which matches
+		// the "optimized" mode: restart an always-on tunnel, otherwise clear
+		// the dead SA so it re-establishes on the next packet. Emitting a
+		// concrete action here means the bare form gets a sensible
+		// dpd_action instead of relying on strongSwan's implicit default
+		// (#3994).
 		if vpn != nil && vpn.EstablishTunnels == "immediately" {
 			action = "restart"
+		} else {
+			action = "clear"
 		}
 	}
 

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -1015,6 +1015,85 @@ func TestGenerateConfig_DPDModes(t *testing.T) {
 	}
 }
 
+// TestGenerateConfig_DPDBareAndTuningForms compiles a full tunnel from flat-set
+// commands and renders the swanctl config, asserting the DPD stanza forms flow
+// end-to-end (#3994). It builds the config through the real compile path (no
+// hand-set DeadPeerDetect/DPDEnable), so it goes RED on revert of the parse +
+// deriveDPD fix: a bare `dead-peer-detection` would compile to a disabled DPD
+// and the rendered config would lack dpd_delay.
+func TestGenerateConfig_DPDBareAndTuningForms(t *testing.T) {
+	compileFromSet := func(t *testing.T, cmds []string) *config.IPsecConfig {
+		t.Helper()
+		tree := &config.ConfigTree{}
+		for _, cmd := range cmds {
+			path, err := config.ParseSetCommand(cmd)
+			if err != nil {
+				t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+			}
+			if err := tree.SetPath(path); err != nil {
+				t.Fatalf("SetPath(%v): %v", path, err)
+			}
+		}
+		cfg, err := config.CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		return &cfg.Security.IPsec
+	}
+
+	base := []string{
+		`set security ike proposal ike-p1 authentication-method pre-shared-keys`,
+		`set security ike proposal ike-p1 dh-group group14`,
+		`set security ike proposal ike-p1 encryption-algorithm aes-256-cbc`,
+		`set security ike policy pol1 mode main`,
+		`set security ike policy pol1 proposals ike-p1`,
+		`set security ike policy pol1 pre-shared-key ascii-text mysecret`,
+		`set security ike gateway gw1 ike-policy pol1`,
+		`set security ike gateway gw1 address 203.0.113.1`,
+		`set security ipsec proposal esp-p2 protocol esp`,
+		`set security ipsec proposal esp-p2 encryption-algorithm aes-256-cbc`,
+		`set security ipsec proposal esp-p2 authentication-algorithm hmac-sha-256-128`,
+		`set security ipsec policy ipsec-pol proposals esp-p2`,
+		`set security ipsec vpn tun1 bind-interface st0.0`,
+		`set security ipsec vpn tun1 ike gateway gw1`,
+		`set security ipsec vpn tun1 ike ipsec-policy ipsec-pol`,
+	}
+	with := func(extra ...string) []string {
+		return append(append([]string{}, base...), extra...)
+	}
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+
+	t.Run("bare enables DPD with defaults", func(t *testing.T) {
+		out := m.generateConfig(compileFromSet(t, with(`set security ike gateway gw1 dead-peer-detection`)))
+		for _, want := range []string{"dpd_delay = 10s", "dpd_timeout = 50s", "dpd_action = clear"} {
+			if !strings.Contains(out, want) {
+				t.Fatalf("bare dead-peer-detection did not enable DPD (missing %q):\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("interval-only tunes delay", func(t *testing.T) {
+		out := m.generateConfig(compileFromSet(t, with(`set security ike gateway gw1 dead-peer-detection interval 20`)))
+		if !strings.Contains(out, "dpd_delay = 20s") {
+			t.Fatalf("interval-only DPD: want dpd_delay = 20s:\n%s", out)
+		}
+	})
+
+	t.Run("always-send maps to restart", func(t *testing.T) {
+		out := m.generateConfig(compileFromSet(t, with(`set security ike gateway gw1 dead-peer-detection always-send`)))
+		if !strings.Contains(out, "dpd_action = restart") {
+			t.Fatalf("always-send DPD: want dpd_action = restart:\n%s", out)
+		}
+	})
+
+	t.Run("no DPD stanza emits no dpd", func(t *testing.T) {
+		out := m.generateConfig(compileFromSet(t, base))
+		if strings.Contains(out, "dpd_delay") {
+			t.Fatalf("no DPD stanza should not emit dpd_delay:\n%s", out)
+		}
+	})
+}
+
 func TestGenerateConfig_JunosObfuscatedPSK(t *testing.T) {
 	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
 	cfg := &config.IPsecConfig{


### PR DESCRIPTION
Closes #3994

## Problem

The IKE `dead-peer-detection` (DPD) compiler overloaded the
`DeadPeerDetect` mode string as both the enable flag and the mode, which
mishandled two Junos configuration forms:

- **Bare `dead-peer-detection;`** (Junos: enable DPD with defaults)
  produced an empty mode. `deriveDPD` gated enablement on
  `DeadPeerDetect != ""`, so the bare form was silently treated as
  **DISABLED** — the rendered swanctl config had no `dpd_delay`, and a
  dead IKE peer's tunnel was never detected (traffic blackholes over the
  stale SA until it expires).
- **Interval-only / threshold-only** (`dead-peer-detection interval 10;`)
  let `nodeVal()` capture the sub-field token (`"interval"`/`"threshold"`)
  as a bogus mode string. DPD was enabled but the mode was garbage and
  mapped to no concrete `dpd_action`.

Confirmed with a scratch repro: bare compiled to `DeadPeerDetect=""`
(identical to no-DPD), interval-only compiled to `DeadPeerDetect="interval"`.

## Fix

- Add `IPsecGateway.DPDEnable` as the single source of truth for "is DPD
  on", set by `parseDeadPeerDetectionNode` for **every** stanza form
  (`pkg/config/compiler_ipsec.go`).
- The parser now scans both the node's own `Keys` (compact-hierarchical
  `dead-peer-detection always-send` / `... interval 10`) and its children
  (flat-set / block forms) for the mode keyword and interval/threshold
  values, and no longer forces a bogus mode string.
- `deriveDPD` (`pkg/ipsec/ike.go`) gates on `DPDEnable` (keeping the
  `DeadPeerDetect != ""` fallback so a hand-built gateway that sets only
  the mode still enables DPD). The default/bare mapping now emits a
  concrete `dpd_action` — `restart` for an `establish-tunnels immediately`
  tunnel, else `clear` — matching the Junos "optimized" default instead of
  relying on strongSwan's implicit default.
- Both `show security ... ike gateway` DPD-display sites gate on
  `DPDEnable` so a bare-form gateway reports DPD as enabled.

### Mode → dpd_action mapping (unchanged, now reachable for the bare form)

| Junos form | dpd_delay | dpd_action (on-traffic / immediately) |
|---|---|---|
| bare `dead-peer-detection;` | 10s (default) | clear / restart |
| `interval <n>` | `<n>`s | clear / restart |
| `threshold <n>` | 10s, timeout `10×n` | clear / restart |
| `always-send` | 10s | restart |
| `optimized` | 10s | clear / restart |
| `probe-idle-tunnel` | 10s | trap / restart |

## RED-on-revert proof

`TestGenerateConfig_DPDBareAndTuningForms` builds a full tunnel from
set-commands and renders swanctl, asserting only on the rendered output
(no new field referenced). Temporarily restoring the original
`deriveDPD` enable gate made the bare-form sub-test FAIL (the rendered
config lost `dpd_delay = 10s`); with the fix it passes.

## Tests

- `TestIKEDeadPeerDetectionForms` (pkg/config) — form matrix: bare /
  interval-only / threshold-only / always-send / optimized+tuning / none.
- `TestGenerateConfig_DPDBareAndTuningForms` (pkg/ipsec) — end-to-end
  compile → swanctl render.
- `go build ./...`, gofmt, vet clean; pkg/config + pkg/ipsec + pkg/cli +
  pkg/grpcapi suites green (incl. pre-existing `TestGenerateConfig_DPDModes`
  which exercises the `DeadPeerDetect != ""` fallback).

Docs: `pkg/ipsec/README.md` DPD bullet rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
