### PR TITLE
config: keep every prefix in a bracketed prefix-list definition (#3996)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-03 — #3996: policy-options prefix-list bracketed-list definition collapsed to first prefix
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-042 (MEDIUM, config-parity). A
+    `policy-options prefix-list NAME` definition written as a bracketed
+    list — `set policy-options prefix-list NAME [ p1 p2 p3 ]` — compiled to
+    only its FIRST prefix. The lexer strips `[`/`]` and packs every prefix
+    onto a SINGLE child node's `Keys` (the #2419/#3842 dual-AST class), but
+    `compilePolicyOptions` (`pkg/config/compiler_routing.go`) read only
+    `entry.Keys[0]` for each child, so the bracketed list dropped all but the
+    first prefix → an under-populated prefix-list (a route-filter, firewall
+    filter, or dynamic address group matched a partial prefix set with no
+    commit error). The separate-command form (`set ... prefix-list NAME <p>`
+    per line), the brace-block form, and the multi-block merge (#2641) were
+    already correct — each produced one child per prefix — which is why the
+    defect hid.
+  - **Fix**: read the FULL `Keys` slice of every child (`for _, p := range
+    entry.Keys`), not just `Keys[0]`. Read from index 0 (NOT `Keys[1:]`)
+    because a prefix-list entry carries no field-name prefix — the child's
+    keys ARE the prefix values — so `firewallMatchValues` (which skips
+    `Keys[0]`) is the wrong helper here. Single-key children (the existing
+    shapes) are unaffected. Validation: new
+    `compiler_prefix_list_bracket_3996_test.go` — bracketed all-three +
+    display-set round-trip (both RED on revert to the `Keys[0]`-only read),
+    plus separate-command / single-prefix regression guards.
+    `go test ./pkg/config/...` green; `go build ./...`, gofmt, vet clean.
+    Doc: docs/config-schema.md new "prefix-list DEFINITION body is dual-AST
+    too (#3996)" note.
+  - **File(s)**: pkg/config/compiler_routing.go,
+    pkg/config/compiler_prefix_list_bracket_3996_test.go,
+    docs/config-schema.md, _Log.md
+
 ## 2026-07-03 — #3988: scheduler start/stop date parsed as UTC instead of system local time
 
 - **Timestamp**: 2026-07-03

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -289,6 +289,28 @@ dropped scope is impossible. Coverage:
 `compiler_prefix_list_hier_leaf_3843_test.go` (single-name source/dest/except +
 undefined-reject fail-on-revert, plus block / flat-set regression guards).
 
+**The prefix-list DEFINITION body is dual-AST too (#3996).** Distinct from the
+`from source/destination-prefix-list` *reference* above, this is the
+`policy-options prefix-list NAME { <p1>; <p2>; ... }` *definition*. Its schema
+leaf (`schemaPolicyOptions`, `schema_routing.go`) is `args: 1` (the name) with
+`children: nil`, so every prefix under the name lands as a CHILD of the named
+node. Two child shapes occur: one child per prefix (a `set ... prefix-list NAME
+<p>` per line, or a brace block with one `<p>;` per line — each child holds a
+single prefix in `Keys[0]`), OR the bracketed-list form `set ... prefix-list
+NAME [ p1 p2 p3 ]`, where the lexer strips `[`/`]` and packs EVERY prefix onto a
+SINGLE child node's `Keys`. `compilePolicyOptions` (`compiler_routing.go`) reads
+the FULL `Keys` slice of each child — note it reads from `Keys[0]`, NOT
+`Keys[1:]`, because a prefix-list entry carries no field-name prefix (the child's
+keys ARE the prefix values), so `firewallMatchValues` (which skips `Keys[0]`) is
+the WRONG helper here. Before #3996 the loop read only `entry.Keys[0]`, so a
+bracketed list kept just the FIRST prefix and silently dropped the rest → an
+under-populated prefix-list (a route-filter, firewall filter, or dynamic address
+group matched a partial prefix set with no commit error). The separate-command
+and single-prefix shapes were unaffected (each child had exactly one key).
+Coverage: `compiler_prefix_list_bracket_3996_test.go` (bracketed all-three +
+display-set round-trip fail-on-revert, plus separate-command / single-prefix
+regression guards); the multi-block MERGE case is `compiler_prefix_list_merge_2641_test.go`.
+
 **NAT `match` axes are multi-value (#3431).** The source/destination NAT rule
 `match` leaves `application`, `protocol` (DNAT), `source-address-name`, and
 `destination-address-name` are all `multi: true` (alongside the already-plural

--- a/pkg/config/compiler_prefix_list_bracket_3996_test.go
+++ b/pkg/config/compiler_prefix_list_bracket_3996_test.go
@@ -1,0 +1,131 @@
+package config
+
+import "testing"
+
+// #3996: a policy-options prefix-list DEFINITION written as a bracketed list
+// (`set policy-options prefix-list NAME [ p1 p2 p3 ]`) collapsed in
+// compilation — the lexer strips the brackets and packs every prefix onto a
+// SINGLE child node's Keys (the #2419/#3842 dual-shape class), but the
+// prefix-list compiler read only that child's Keys[0], keeping just the FIRST
+// prefix and silently dropping the rest. An under-populated prefix-list used by
+// a route-filter, a firewall filter, or a dynamic address group then matches a
+// partial prefix set.
+//
+// Fix (compiler_routing.go compilePolicyOptions): read the FULL Keys slice of
+// every child, not just Keys[0].
+//
+// Fail-on-revert: restore the `entry.Keys[0]`-only read and the bracketed-list
+// assertion below drops to a single prefix, so the test goes RED. The
+// single-prefix and separate-command forms are unaffected either way.
+
+func TestPrefixListBracketedListKeepsAllPrefixes(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set policy-options prefix-list PL [ 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 ]",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	pl := cfg.PolicyOptions.PrefixLists["PL"]
+	if pl == nil {
+		t.Fatalf("prefix-list PL not compiled")
+	}
+	want := []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
+	if len(pl.Prefixes) != len(want) || !containsAll(pl.Prefixes, want) {
+		t.Fatalf("bracketed prefix-list PL = %v (N=%d), want all %v (N=%d) — "+
+			"the bracketed list collapsed to first-only (#3996)",
+			pl.Prefixes, len(pl.Prefixes), want, len(want))
+	}
+}
+
+// The separate-set-command form (one prefix per line) and the single-prefix
+// form must remain intact — the fix must not disturb the existing shapes.
+func TestPrefixListSeparateCommandsKeepAllPrefixes(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set policy-options prefix-list PL 10.0.0.0/8",
+		"set policy-options prefix-list PL 172.16.0.0/12",
+		"set policy-options prefix-list PL 192.168.0.0/16",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	pl := cfg.PolicyOptions.PrefixLists["PL"]
+	if pl == nil {
+		t.Fatalf("prefix-list PL not compiled")
+	}
+	want := []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
+	if len(pl.Prefixes) != len(want) || !containsAll(pl.Prefixes, want) {
+		t.Fatalf("separate-command prefix-list PL = %v, want all %v", pl.Prefixes, want)
+	}
+}
+
+func TestPrefixListSinglePrefixUnchanged(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set policy-options prefix-list PL 10.0.0.0/8",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	pl := cfg.PolicyOptions.PrefixLists["PL"]
+	if pl == nil {
+		t.Fatalf("prefix-list PL not compiled")
+	}
+	if len(pl.Prefixes) != 1 || pl.Prefixes[0] != "10.0.0.0/8" {
+		t.Fatalf("single-prefix prefix-list PL = %v, want [10.0.0.0/8]", pl.Prefixes)
+	}
+}
+
+// The bracketed-list body must survive a display-set round-trip: FormatSet →
+// re-parse (ParseSetCommand + SetPath) → compile must still yield all three
+// prefixes. A drop anywhere in that chain leaves a partial prefix-list.
+func TestPrefixListBracketedListDisplaySetRoundTrip(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set policy-options prefix-list PL [ 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 ]",
+	})
+	setOut := tree.FormatSet()
+
+	rt := &ConfigTree{}
+	for _, line := range splitNonEmptyLines(setOut) {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := rt.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(rt)
+	if err != nil {
+		t.Fatalf("CompileConfig(round-trip): %v", err)
+	}
+	pl := cfg.PolicyOptions.PrefixLists["PL"]
+	if pl == nil {
+		t.Fatalf("prefix-list PL not compiled after round-trip (display-set:\n%s)", setOut)
+	}
+	want := []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
+	if len(pl.Prefixes) != len(want) || !containsAll(pl.Prefixes, want) {
+		t.Fatalf("round-trip prefix-list PL = %v, want all %v (display-set:\n%s)",
+			pl.Prefixes, want, setOut)
+	}
+}
+
+func splitNonEmptyLines(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			if line := s[start:i]; line != "" {
+				out = append(out, line)
+			}
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		if line := s[start:]; line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -531,9 +531,22 @@ func compilePolicyOptions(node *Node, po *PolicyOptionsConfig) error {
 			pl = &PrefixList{Name: inst.name}
 			po.PrefixLists[inst.name] = pl
 		}
+		// Read EVERY prefix entry. A prefix-list body may carry its prefixes as
+		// distinct sibling children (one `set ... prefix-list NAME <p>` per line,
+		// or a brace block with one `<p>;` per line — each child then holds a
+		// single prefix in Keys[0]) OR, via the bracketed-list form
+		// `set ... prefix-list NAME [ p1 p2 p3 ]`, collapsed onto a SINGLE child
+		// node's Keys (the lexer strips `[`/`]` and packs every token onto one
+		// leaf — the #2419/#3842 dual-shape class). Read the FULL Keys slice of
+		// each child, not just Keys[0]; the prior `entry.Keys[0]`-only read kept
+		// just the FIRST prefix of a bracketed list and silently dropped the
+		// rest → an under-populated prefix-list (route-filter / firewall-filter /
+		// dynamic address group matched a partial prefix set) (#3996).
 		for _, entry := range inst.node.Children {
-			if len(entry.Keys) > 0 {
-				pl.Prefixes = append(pl.Prefixes, entry.Keys[0])
+			for _, p := range entry.Keys {
+				if p != "" {
+					pl.Prefixes = append(pl.Prefixes, p)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Closes #3996 (fable-161 F-042, MEDIUM config-parity).

A `policy-options prefix-list NAME` definition written as a **bracketed list** —
`set policy-options prefix-list NAME [ p1 p2 p3 ]` — compiled to only its **first
prefix**.

The lexer strips `[`/`]` and packs every prefix onto a **single** child node's
`Keys` (the #2419/#3842 dual-AST class), but `compilePolicyOptions`
(`pkg/config/compiler_routing.go`) read only `entry.Keys[0]` for each child. So a
bracketed list silently dropped all but the first prefix → an under-populated
prefix-list. A route-filter, firewall filter, or dynamic address group then
matched a **partial prefix set with no commit error**.

## Verify-first

Confirmed the collapse before writing any fix (scratch `ParseSetCommand` +
`tree.SetPath` repro):

| Definition form | Before fix | After fix |
|---|---|---|
| separate `set ... prefix-list PL <p>` per line | N=3 (OK) | N=3 |
| brace block / multi-block merge (#2641) | N=2 (OK) | N=2 |
| **bracketed `[ p1 p2 p3 ]`** | **N=1 (dropped 2)** | **N=3** |

Only the bracketed shape was broken — the others produce one child per prefix,
so the `Keys[0]`-only read happened to capture them. That is why the defect hid.

## Fix

Read the **full `Keys` slice** of every child, not just `Keys[0]`. Read from
index 0 (**not** `Keys[1:]`) because a prefix-list entry carries no field-name
prefix — the child's keys *are* the prefix values — so `firewallMatchValues`
(which skips `Keys[0]`) is the wrong helper here. Single-key children (the
existing shapes) are unaffected.

## RED-on-revert

`compiler_prefix_list_bracket_3996_test.go`:
- `TestPrefixListBracketedListKeepsAllPrefixes` — RED (N=1) on revert to `Keys[0]`-only
- `TestPrefixListBracketedListDisplaySetRoundTrip` — RED on revert
- `TestPrefixListSeparateCommandsKeepAllPrefixes` / `TestPrefixListSinglePrefixUnchanged` — regression guards (green both ways)

## Validation

`go test ./pkg/config/...` green; `go build ./...`, gofmt, vet clean. Doc:
`docs/config-schema.md` new "prefix-list DEFINITION body is dual-AST too (#3996)"
note; `_Log.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi