### PR TITLE
cli: capture the full multi-token filter in monitor traffic matching (#4005)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-07-03 — #4005: `monitor traffic matching "<filter>"` truncated the pcap filter to the first token
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-022 (MEDIUM, CLI — wrong packet capture
+    filter). `monitor traffic interface <if> matching "tcp port 80"` captured
+    on just `tcp`, silently dropping `port 80` — any multi-token BPF filter
+    (`host 10.0.0.1 and port 443`, `udp and not port 53`) was reduced to its
+    first whitespace token, so the operator's diagnostic capture showed far
+    more traffic than requested. Root cause: the operational CLI tokenizes the
+    command line with `strings.Fields` (cli_dispatch.go), which splits on
+    whitespace and does NOT honor shell quoting, so a quoted filter reaches
+    `handleMonitorTraffic` as separate tokens (`"tcp`, `port`, `80"`). The old
+    `case "matching"` read only `args[i+1]` (the first token, with a literal
+    quote) and let the rest fall through the switch and be discarded.
+  - **Fix**: extracted `parseMonitorTrafficArgs` — the `matching` clause is now
+    greedy: it consumes every following token up to the next recognized option
+    keyword (`interface`/`count`, none of which are pcap primitives), joins
+    them into one filter expression, and strips a single balanced layer of
+    surrounding quotes via `stripSurroundingQuotes`. `buildMonitorTrafficArgv`
+    passes the full filter to tcpdump as trailing argv tokens exactly as
+    libpcap consumes a filter. A `count` following the filter is no longer
+    swallowed; a single-token filter (`icmp`) and and/or/not operators are
+    preserved verbatim.
+  - **File(s)**: pkg/cli/cli_request.go, docs/bugs.md,
+    pkg/cli/monitor_traffic_filter_4005_test.go (RED-on-revert: reverting the
+    parse to the first-token read drops `port 80` — filter=`"tcp` — and the
+    argv places only `"tcp` after the interface flags). go test ./pkg/cli/...
+    green; go build ./... green; gofmt clean.
+
 ## 2026-07-03 — #4000: bare `commit` during a pending confirm window silently dropped newly-staged edits
 
 - **Timestamp**: 2026-07-03

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -1034,6 +1034,11 @@ These bugs were discovered testing iperf3 (~4.7 Gbps reverse mode) through the c
 - **Root cause:** Same as #135 — tcpdump attached to IPVLAN overlay instead of physical parent
 - **Fix:** Resolve fabric overlay name to physical parent before starting packet capture
 
+### monitor traffic matching truncates multi-token pcap filter to first token (FIXED #4005)
+- **Symptom:** `monitor traffic interface ge-0-0-0 matching "tcp port 80"` captures on just `tcp` — the `port 80` narrowing is silently dropped, so the operator's diagnostic capture shows far more traffic than requested. Any multi-token BPF filter (`host 10.0.0.1 and port 443`, `udp and not port 53`) is reduced to its first whitespace token.
+- **Root cause:** The operational CLI tokenizes the command line with `strings.Fields` (`cli_dispatch.go`), which splits on whitespace and does NOT honor shell quoting. A quoted filter `"tcp port 80"` therefore reaches `handleMonitorTraffic` as three separate tokens `"tcp`, `port`, `80"`. The old `case "matching"` read only `args[i+1]` (the first token, `"tcp`, with a literal quote) and the remaining tokens fell through the switch and were discarded.
+- **Fix:** `parseMonitorTrafficArgs` (`pkg/cli/cli_request.go`) makes the `matching` clause greedy — it consumes every following token up to the next recognized option keyword (`interface`/`count`, none of which are pcap primitives), joins them into one filter expression, and strips a single balanced layer of surrounding quotes via `stripSurroundingQuotes`. `buildMonitorTrafficArgv` passes the full filter to tcpdump as trailing argv tokens, exactly as libpcap consumes a filter. A `count` following the filter is no longer swallowed. Regression guard: `pkg/cli/monitor_traffic_filter_4005_test.go`.
+
 ### try_fabric_redirect missing inc_iface_tx — TX counters undercount (FIXED #137, `6fd6124`)
 - **Symptom:** Fabric TX traffic not counted in `show interfaces statistics` or `monitor interface`. Packets forwarded via `try_fabric_redirect()` in xdp_zone.c bypass TX counter instrumentation
 - **Root cause:** `try_fabric_redirect()` calls `bpf_redirect_map` but never calls `inc_iface_tx(meta, fabric_ifindex)` before returning

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -489,10 +489,29 @@ func (c *CLI) handleMonitor(args []string) error {
 	}
 }
 
-// handleMonitorTraffic wraps tcpdump for live packet capture.
-func (c *CLI) handleMonitorTraffic(args []string) error {
-	var iface, filter string
-	count := "0" // 0 = unlimited
+// monitorTrafficKeywords are the option keywords the monitor traffic
+// grammar recognizes. They terminate a greedy `matching <filter>`
+// expression so a multi-token filter never swallows a following option
+// (e.g. `matching tcp port 80 count 20`).
+var monitorTrafficKeywords = map[string]bool{
+	"interface": true,
+	"matching":  true,
+	"count":     true,
+}
+
+// parseMonitorTrafficArgs parses the `monitor traffic ...` argument
+// vector into the interface name, the pcap/BPF filter expression, and the
+// packet count. The CLI tokenizer (strings.Fields) splits on whitespace
+// and does NOT honor shell quoting, so a multi-token filter typed as
+// `matching "tcp port 80"` arrives as the separate tokens `"tcp`, `port`,
+// `80"`. The `matching` clause therefore consumes EVERY following token up
+// to the next recognized option keyword (none of which are pcap
+// primitives), joins them into one filter expression, and strips any
+// surrounding quotes the operator typed. Reading only the first token
+// truncated `tcp port 80` down to `tcp` and silently captured far more
+// traffic than requested (#4005).
+func parseMonitorTrafficArgs(args []string) (iface, filter, count string) {
+	count = "0" // 0 = unlimited
 
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -502,10 +521,15 @@ func (c *CLI) handleMonitorTraffic(args []string) error {
 				iface = args[i]
 			}
 		case "matching":
-			if i+1 < len(args) {
-				i++
-				filter = args[i]
+			rest := make([]string, 0, len(args)-i-1)
+			for j := i + 1; j < len(args); j++ {
+				if monitorTrafficKeywords[args[j]] {
+					break
+				}
+				rest = append(rest, args[j])
 			}
+			i += len(rest)
+			filter = stripSurroundingQuotes(strings.Join(rest, " "))
 		case "count":
 			if i+1 < len(args) {
 				i++
@@ -513,6 +537,45 @@ func (c *CLI) handleMonitorTraffic(args []string) error {
 			}
 		}
 	}
+	return iface, filter, count
+}
+
+// stripSurroundingQuotes removes one layer of matching leading/trailing
+// single or double quotes. The CLI tokenizer does not honor shell quoting,
+// so an operator who wraps a multi-token pcap filter in quotes
+// (`matching "tcp port 80"`) leaves literal quote characters on the first
+// and last tokens; tcpdump/libpcap would reject those literal quotes, so
+// peel one balanced layer here.
+func stripSurroundingQuotes(s string) string {
+	if len(s) >= 2 {
+		q := s[0]
+		if (q == '"' || q == '\'') && s[len(s)-1] == q {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+// buildMonitorTrafficArgv assembles the tcpdump argv for a live capture.
+// The full filter expression is passed as trailing arguments exactly as
+// tcpdump/libpcap expects a filter (all tokens, verbatim).
+func buildMonitorTrafficArgv(iface, filter, count string) []string {
+	cmdArgs := []string{"tcpdump", "-i", iface, "-n", "-l"}
+	if count != "0" {
+		cmdArgs = append(cmdArgs, "-c", count)
+	}
+	if filter != "" {
+		// tcpdump accepts the filter expression as separate argv tokens;
+		// splitting on whitespace keeps a multi-token filter intact and
+		// matches how tcpdump joins its own trailing filter arguments.
+		cmdArgs = append(cmdArgs, strings.Fields(filter)...)
+	}
+	return cmdArgs
+}
+
+// handleMonitorTraffic wraps tcpdump for live packet capture.
+func (c *CLI) handleMonitorTraffic(args []string) error {
+	iface, filter, count := parseMonitorTrafficArgs(args)
 
 	if iface == "" {
 		fmt.Println("usage: monitor traffic interface <name> [matching <filter>] [count <N>]")
@@ -530,13 +593,7 @@ func (c *CLI) handleMonitorTraffic(args []string) error {
 		fmt.Println()
 	}
 
-	cmdArgs := []string{"tcpdump", "-i", iface, "-n", "-l"}
-	if count != "0" {
-		cmdArgs = append(cmdArgs, "-c", count)
-	}
-	if filter != "" {
-		cmdArgs = append(cmdArgs, filter)
-	}
+	cmdArgs := buildMonitorTrafficArgv(iface, filter, count)
 
 	fmt.Printf("Monitoring traffic on %s (Ctrl+C to stop)...\n", iface)
 

--- a/pkg/cli/monitor_traffic_filter_4005_test.go
+++ b/pkg/cli/monitor_traffic_filter_4005_test.go
@@ -1,0 +1,159 @@
+package cli
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestParseMonitorTrafficMultiTokenFilter is the #4005 regression guard:
+// `monitor traffic ... matching "tcp port 80"` must apply the FULL
+// multi-token BPF filter, not just the first token. The CLI tokenizer
+// (strings.Fields) splits on whitespace and drops shell quotes, so the
+// quoted filter arrives as the separate tokens `"tcp`, `port`, `80"`.
+// Before the fix the parser read only the first token → the capture
+// filtered on `"tcp` (a literal-quote token) and silently dropped
+// `port 80`, capturing far more traffic than the operator asked for.
+func TestParseMonitorTrafficMultiTokenFilter(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantIface  string
+		wantFilter string
+		wantCount  string
+	}{
+		{
+			// The headline #4005 case: whitespace-split quoted filter.
+			name:       "quoted multi-token filter",
+			args:       []string{"interface", "ge-0-0-0", "matching", `"tcp`, "port", `80"`},
+			wantIface:  "ge-0-0-0",
+			wantFilter: "tcp port 80",
+			wantCount:  "0",
+		},
+		{
+			// Bare (unquoted) multi-token filter must also survive whole.
+			name:       "bare multi-token filter",
+			args:       []string{"interface", "ge-0-0-0", "matching", "tcp", "port", "80"},
+			wantIface:  "ge-0-0-0",
+			wantFilter: "tcp port 80",
+			wantCount:  "0",
+		},
+		{
+			// Single-token filter is unchanged.
+			name:       "single-token filter",
+			args:       []string{"interface", "ge-0-0-0", "matching", "icmp"},
+			wantIface:  "ge-0-0-0",
+			wantFilter: "icmp",
+			wantCount:  "0",
+		},
+		{
+			// and/or/not boolean operators are preserved verbatim.
+			name:       "boolean operators preserved",
+			args:       []string{"interface", "ge-0-0-1", "matching", `"host`, "10.0.0.1", "and", "port", `443"`},
+			wantIface:  "ge-0-0-1",
+			wantFilter: "host 10.0.0.1 and port 443",
+			wantCount:  "0",
+		},
+		{
+			name:       "not operator preserved",
+			args:       []string{"interface", "ge-0-0-2", "matching", "udp", "and", "not", "port", "53"},
+			wantIface:  "ge-0-0-2",
+			wantFilter: "udp and not port 53",
+			wantCount:  "0",
+		},
+		{
+			// A count following a multi-token filter must NOT be swallowed
+			// into the filter — the keyword terminates the greedy match.
+			name:       "count after matching not swallowed",
+			args:       []string{"interface", "ge-0-0-0", "matching", "tcp", "port", "80", "count", "20"},
+			wantIface:  "ge-0-0-0",
+			wantFilter: "tcp port 80",
+			wantCount:  "20",
+		},
+		{
+			// count before matching still works; filter runs to end.
+			name:       "count before matching",
+			args:       []string{"interface", "ge-0-0-0", "count", "10", "matching", "tcp", "port", "80"},
+			wantIface:  "ge-0-0-0",
+			wantFilter: "tcp port 80",
+			wantCount:  "10",
+		},
+		{
+			// Single-quoted filter is de-quoted the same as double.
+			name:       "single-quoted filter",
+			args:       []string{"interface", "ge-0-0-0", "matching", `'udp`, "or", `tcp'`},
+			wantIface:  "ge-0-0-0",
+			wantFilter: "udp or tcp",
+			wantCount:  "0",
+		},
+		{
+			// No matching clause at all: empty filter (capture everything).
+			name:       "no filter",
+			args:       []string{"interface", "ge-0-0-0", "count", "5"},
+			wantIface:  "ge-0-0-0",
+			wantFilter: "",
+			wantCount:  "5",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iface, filter, count := parseMonitorTrafficArgs(tt.args)
+			if iface != tt.wantIface {
+				t.Errorf("iface = %q, want %q", iface, tt.wantIface)
+			}
+			if filter != tt.wantFilter {
+				t.Errorf("filter = %q, want %q (multi-token truncation regression?)", filter, tt.wantFilter)
+			}
+			if count != tt.wantCount {
+				t.Errorf("count = %q, want %q", count, tt.wantCount)
+			}
+		})
+	}
+}
+
+// TestBuildMonitorTrafficArgvFilterReachesTcpdump asserts the full
+// multi-token filter reaches the tcpdump invocation as trailing argv
+// tokens (the pcap filter expression), matching how tcpdump/libpcap
+// consumes a filter. Goes RED on revert — the truncated filter would
+// place only `tcp` (or `"tcp`) after the interface flags.
+func TestBuildMonitorTrafficArgvFilterReachesTcpdump(t *testing.T) {
+	iface, filter, count := parseMonitorTrafficArgs(
+		[]string{"interface", "ge-0-0-0", "matching", `"tcp`, "port", `80"`, "count", "20"},
+	)
+	argv := buildMonitorTrafficArgv(iface, filter, count)
+	want := []string{"tcpdump", "-i", "ge-0-0-0", "-n", "-l", "-c", "20", "tcp", "port", "80"}
+	if !reflect.DeepEqual(argv, want) {
+		t.Fatalf("buildMonitorTrafficArgv =\n  %v\nwant\n  %v", argv, want)
+	}
+
+	// The full filter expression must be present as a contiguous trailing
+	// run — assert the joined tail equals the intended BPF filter.
+	dashL := indexOf(argv, "-l")
+	tail := argv[dashL+1:]
+	// Skip the -c <count> option to isolate the filter tail.
+	if len(tail) >= 2 && tail[0] == "-c" {
+		tail = tail[2:]
+	}
+	if got := strings.Join(tail, " "); got != "tcp port 80" {
+		t.Fatalf("filter tail = %q, want %q", got, "tcp port 80")
+	}
+}
+
+func TestStripSurroundingQuotes(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{`"tcp port 80"`, "tcp port 80"},
+		{`'udp or tcp'`, "udp or tcp"},
+		{"icmp", "icmp"},
+		{"tcp port 80", "tcp port 80"},
+		{`"unbalanced`, `"unbalanced`},
+		{`mismatched"`, `mismatched"`},
+		{`"`, `"`},
+		{"", ""},
+		{`""`, ""},
+	}
+	for _, tt := range tests {
+		if got := stripSurroundingQuotes(tt.in); got != tt.want {
+			t.Errorf("stripSurroundingQuotes(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #4005 (fable-161 F-022, MEDIUM, CLI — wrong packet capture filter).

`monitor traffic interface <if> matching "tcp port 80"` captured on just
`tcp` — the `port 80` narrowing was silently dropped. Any multi-token BPF
filter (`host 10.0.0.1 and port 443`, `udp and not port 53`) was reduced to
its first whitespace token, so the operator's diagnostic capture showed far
more traffic than requested.

## Root cause

The operational CLI tokenizes the command line with `strings.Fields`
(`pkg/cli/cli_dispatch.go`), which splits on whitespace and does **not** honor
shell quoting. A quoted filter `"tcp port 80"` therefore reaches
`handleMonitorTraffic` as three separate tokens `"tcp`, `port`, `80"`. The old
`case "matching"` read only `args[i+1]` (the first token, `"tcp`, with a
literal quote) and let the remaining tokens fall through the switch and be
discarded.

## Fix

`parseMonitorTrafficArgs` (`pkg/cli/cli_request.go`) makes the `matching`
clause greedy: it consumes every following token up to the next recognized
option keyword (`interface`/`count`, neither of which is a pcap primitive),
joins them into one filter expression, and strips a single balanced layer of
surrounding quotes via `stripSurroundingQuotes`. `buildMonitorTrafficArgv`
passes the full filter to tcpdump as trailing argv tokens exactly as libpcap
consumes a filter.

- A `count` following the filter is no longer swallowed (the keyword
  terminates the greedy match).
- A single-token filter (`icmp`) is unchanged.
- `and`/`or`/`not` boolean operators are preserved verbatim.

## Tests (RED on revert)

`pkg/cli/monitor_traffic_filter_4005_test.go` asserts the parse output and the
built tcpdump argv. Reverting the parse to the first-token read makes the
suite RED — `filter=\"tcp\"` and the argv places only `"tcp` after the
interface flags.

- `go test ./pkg/cli/...` green
- `go build ./...` green
- gofmt clean

## Docs

`docs/bugs.md` gets a FIXED entry next to the existing monitor-traffic capture
bugs; `_Log.md` records the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi