### PR TITLE
Makefile: gate the Rust userspace-dp suite in `make test` (#4006)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,10 @@ make build           # Build xpfd daemon (uses the git-tracked shim .o — does
                      # NOT require make generate)
 make build-ctl       # Build remote CLI client
 make build-userspace-dp # Build the primary Rust AF_XDP dataplane helper
-make test            # Run Go tests
+make test            # Run BOTH the Go suite AND the Rust userspace-dp
+                     # cargo suite (#4006) — a Rust dataplane regression
+                     # fails `make test`. `make test-go` / `make test-rust`
+                     # run one leg. The Rust leg needs cargo (~minutes).
 ```
 
 ## Test Environment (Incus VM)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ BUILD_TIME ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.buildTime=$(BUILD_TIME)
 
 # eBPF compilation flags
-.PHONY: all generate generate-userspace-xdp build-userspace-xdp build build-ctl build-userspace-dp build-userspace-dp-debug-log proto install clean test audit-check test-connectivity test-failover test-double-failover test-active-active test-stress-failover test-ha-crash test-chained-crash test-private-rg test-restart-connectivity
+.PHONY: all generate generate-userspace-xdp build-userspace-xdp build build-ctl build-userspace-dp build-userspace-dp-debug-log proto install clean test test-go test-rust audit-check test-connectivity test-failover test-double-failover test-active-active test-stress-failover test-ha-crash test-chained-crash test-private-rg test-restart-connectivity
 
 all: generate build build-ctl
 
@@ -67,7 +67,19 @@ install: build build-ctl
 	install -m 0755 $(BINARY) $(PREFIX)/sbin/$(BINARY)
 	install -m 0755 cli $(PREFIX)/bin/cli
 
-test:
+# The single pre-commit gate. `test` runs BOTH the Go suite AND the Rust
+# userspace-dp cargo suite (#4006). The Rust AF_XDP dataplane is the only
+# runtime forwarding path after the #1373/#1476 eBPF retirement, so a
+# forwarding / CoS / NAT / session-correctness regression there must fail
+# `make test`. Before #4006 this target ran only `go test ./...`, giving a
+# false all-clear for the most critical code (a broken Rust dataplane test
+# passed `make test` green). Each prerequisite recipe is a plain command,
+# so a non-zero exit from either leg aborts the target (Make stops at the
+# first failing prerequisite) — a Rust test failure now fails `make test`.
+test: test-go test-rust
+
+# Go suite. Invocation preserved exactly from the pre-#4006 `test` target.
+test-go:
 	# go vet gate scoped to pkg/flowexport (#2224): catches the
 	# atomic.Uint64-copy regression class (ExportConfig embeds the live
 	# 1-in-N sampleCounter and must never be copied by value). NOT
@@ -76,6 +88,32 @@ test:
 	# code); widen to ./... once those are resolved.
 	$(GO) vet ./pkg/flowexport/...
 	$(GO) test ./...
+
+# Rust userspace-dp correctness suite (#4006). userspace-dp is a
+# binary-only crate (no [lib] target), so its unit tests live in the bin
+# and are reached via --bins; --tests adds any tests/ integration tests.
+# Run in --release, matching build-userspace-dp so compiled artifacts are
+# shared rather than rebuilt.
+#
+#   --bins --tests         select the correctness suite. Benches are
+#                          deliberately excluded: they are performance
+#                          gates run via `cargo bench`, and criterion's
+#                          harness (harness = false) rejects libtest's
+#                          --test-threads flag, so running them here would
+#                          break the run.
+#   -- --test-threads=1    serialize the harness. Some dataplane socket
+#                          tests can wedge in __skb_wait_for_more_packets
+#                          when run concurrently; single-threaded execution
+#                          avoids the intermittent hang. Runtime for the
+#                          full suite is a few minutes (thousands of tests)
+#                          — slower than the Go suite but a real gate.
+#
+# A non-zero cargo exit propagates: this is a plain recipe line, so Make
+# fails the target on any command that exits non-zero (no `-` prefix / no
+# `|| true` swallows the failure).
+test-rust:
+	$(CARGO) test --manifest-path userspace-dp/Cargo.toml --release \
+		--bins --tests -- --test-threads=1
 
 # Drift guard for the committed refactoring heatmap (#1661 item 8).
 # Regenerates scripts/refactoring-audit.sh output to a temp file and

--- a/README.md
+++ b/README.md
@@ -238,7 +238,12 @@ make build              # Build xpfd daemon (uses the git-tracked shim object;
                         # does NOT require make generate)
 make build-ctl          # Build remote CLI client
 make build-userspace-dp # Build the Rust AF_XDP dataplane binary (needs cargo)
-make test               # Run the Go test suite
+make test               # Run BOTH suites: Go (test-go) + Rust userspace-dp
+                        # cargo suite (test-rust). A Rust dataplane
+                        # regression fails `make test` (#4006). The Rust
+                        # leg needs cargo and takes a few minutes.
+make test-go            # Go test suite only
+make test-rust          # Rust userspace-dp cargo suite only (needs cargo)
 make deb                # Package the binaries into a .deb
 make image              # Bake the appliance image (qcow2 + incus metadata)
 ```

--- a/_Log.md
+++ b/_Log.md
@@ -30847,3 +30847,27 @@ top.
     pkg/config/parser_security_test.go, pkg/ipsec/ike.go, pkg/ipsec/ipsec_test.go,
     pkg/cli/cli_show_security_ipsec.go, pkg/grpcapi/server_show_security_text.go,
     pkg/ipsec/README.md, _Log.md
+
+- **Timestamp**: 2026-07-03
+  - **Action**: #4006 — `make test` now runs BOTH the Go suite AND the Rust
+    userspace-dp cargo suite. Before this change `test` ran only `go vet` +
+    `go test ./...`, so a regression in the Rust AF_XDP dataplane — the ONLY
+    runtime forwarding path after the #1373/#1476 eBPF retirement — passed
+    `make test` green (a false all-clear for the most critical code). Split the
+    old `test` recipe into `test-go` (unchanged: `go vet ./pkg/flowexport/...`
+    then `go test ./...`) and a new `test-rust`
+    (`cargo test --manifest-path userspace-dp/Cargo.toml --release --bins
+    --tests -- --test-threads=1`), and made `test: test-go test-rust`. Each leg
+    is a plain prerequisite recipe, so a non-zero exit from either aborts the
+    target — a Rust test failure now fails `make test` (verified: a throwaway
+    Makefile with the same prerequisite shape and a `false` in test-rust exited
+    non-zero and never ran the trailing line; RED-on-revert semantics hold).
+    userspace-dp is a binary-only crate (no [lib]), so `--bins` reaches its
+    unit tests and `--tests` adds integration tests; benches are excluded
+    (criterion `harness = false` rejects libtest's `--test-threads`, and they
+    are perf gates run via `cargo bench`). `--test-threads=1` dodges the
+    intermittent `__skb_wait_for_more_packets` socket-test hang. `go build
+    ./...` unaffected (green). Docs updated: README build section, CLAUDE.md
+    Quick Start, docs/testing.md, docs/testing-procedures.md.
+  - **File(s)**: Makefile, README.md, CLAUDE.md, docs/testing.md,
+    docs/testing-procedures.md, _Log.md

--- a/docs/testing-procedures.md
+++ b/docs/testing-procedures.md
@@ -4,7 +4,9 @@
 
 | Test | Command | Duration | When to Run |
 |------|---------|----------|-------------|
-| Unit tests | `make test` | ~30s | Every code change |
+| Unit tests (Go + Rust) | `make test` | ~minutes | Every code change |
+| Go unit tests only | `make test-go` | ~30s | Go-only change |
+| Rust dataplane tests only | `make test-rust` | ~minutes | userspace-dp change |
 | Connectivity | `make test-connectivity` | ~60s | After deploy |
 | Failover | `make test-failover` | ~120s | Cluster/VRRP/session sync changes |
 | Hard crash | `make test-ha-crash` | ~120s | Cluster state machine changes |
@@ -15,7 +17,15 @@
 
 ### 1. Unit Tests (`make test`)
 
-Run 880+ Go tests across 30 packages. Covers:
+`make test` runs BOTH suites (#4006): the Go suite (`make test-go`) and
+the Rust userspace-dp cargo suite (`make test-rust`). A failure in either
+fails `make test`. Before #4006 this target ran only the Go suite, so a
+Rust dataplane regression — a forwarding / CoS / NAT / session break in
+the ONLY runtime forwarding path (#1373/#1476) — passed `make test`
+green. The Go leg is ~30s; the Rust leg compiles + runs a few thousand
+tests in `--release` and takes a few minutes.
+
+**Go suite** (`make test-go`) — 880+ tests across 30 packages. Covers:
 - Config parser (hierarchical + flat set syntax)
 - Config compiler (Junos AST -> typed structs)
 - Cluster election logic (dual-active, preempt, non-preempt)
@@ -23,6 +33,14 @@ Run 880+ Go tests across 30 packages. Covers:
 - Session sync protocol
 - Address book compilation
 - NAT rule compilation
+
+**Rust suite** (`make test-rust`) — `cargo test --release --bins --tests`
+for `userspace-dp` (a binary-only crate, so `--bins` reaches the bin's
+unit tests and `--tests` adds any integration tests), run with
+`--test-threads=1` to avoid the intermittent `__skb_wait_for_more_packets`
+socket-test hang. This is the primary correctness gate for packet
+forwarding, CoS shaping, NAT, and session handling. Benches are excluded
+(perf gates run via `cargo bench`).
 
 **Must pass before any commit.**
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -130,7 +130,9 @@ make generate && make build
 # Primary userspace dataplane helper
 make build-userspace-dp
 
-# Run unit tests (266 tests across 12 packages)
+# Run unit tests — Go suite AND Rust userspace-dp cargo suite (#4006).
+# A Rust dataplane regression fails `make test`. `make test-go` /
+# `make test-rust` run one leg; the Rust leg needs cargo (~minutes).
 make test
 
 # Deploy to Incus VM


### PR DESCRIPTION
## Summary

`make test` ran only `go vet ./pkg/flowexport/...` + `go test ./...`. The
Rust AF_XDP `userspace-dp` is the ONLY runtime forwarding path after the
#1373/#1476 eBPF retirement, so a forwarding / CoS / NAT / session
regression in the Rust dataplane passed `make test` completely green — a
false all-clear for the most critical code, with the ~3500 cargo tests run
only by hand.

This wires the Rust cargo suite into `make test` so a Rust test failure
fails the single pre-commit command.

## Change

Split the `test` recipe into two prerequisites:

```make
test: test-go test-rust

test-go:   # unchanged pre-#4006 recipe (go vet gate + go test ./...)
	$(GO) vet ./pkg/flowexport/...
	$(GO) test ./...

test-rust:
	$(CARGO) test --manifest-path userspace-dp/Cargo.toml --release \
		--bins --tests -- --test-threads=1
```

Both legs are plain prerequisite recipes, so a non-zero exit from either
aborts `test` (Make stops at the first failing prerequisite) — no `-`
prefix / no `|| true` swallows the failure.

**Invocation rationale**
- `userspace-dp` is a **binary-only crate** (no `[lib]`), so `--bins`
  reaches the bin's unit tests and `--tests` adds integration tests
  (`--lib` errors: "no library targets found").
- `--release` matches `build-userspace-dp` so compiled artifacts are
  shared, not rebuilt.
- **benches excluded**: they are perf gates run via `cargo bench`, and
  criterion (`harness = false`) rejects libtest's `--test-threads`, so
  running them here would break the run.
- `--test-threads=1` serializes the harness to dodge the intermittent
  `__skb_wait_for_more_packets` socket-test hang.

Docs updated: README build section, CLAUDE.md Quick Start, `docs/testing.md`,
`docs/testing-procedures.md`.

## Validation

- `make -n test` shows `go vet` + `go test ./...` + the cargo line.
- Full `make test-rust`: **3463 passed**. `make` propagated a test failure
  as `make: *** [Makefile] Error 101` (exit non-zero) — this is the
  RED-on-revert / gate behavior the issue asks for.
  - The one failing test, `tx_latency_hist_cross_thread_snapshot_skew_within_bound`,
    is a **pre-existing load-induced flake** (a cross-thread timing/skew
    test whose own comment warns it "would risk flakes on schedulers with
    more jitter"). It passed **3/3 in isolation** under lower load; this PR
    touches zero Rust source. Not fixed here (out of scope — a dataplane
    test-robustness issue, not the Makefile wiring).
- **Exit-code propagation proven both ways**: a passing subset returns
  cargo exit `0`; a throwaway Makefile with the same `test: test-go
  test-rust` shape and a `false` in `test-rust` exits non-zero (`Error 1`,
  make exit 2) and never runs the trailing recipe line.
- `go build ./...` unaffected (green). The Go invocation is preserved
  byte-for-byte in `test-go`.

Closes #4006

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
