### PR TITLE
appid: don't fan an explicit `protocol 0` app out to TCP+UDP (#4008)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-03 — #4008: explicit `protocol 0` in an application fanned out to TCP+UDP (over-broad app match)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-164 (MEDIUM, appid — over-broad protocol
+    match). The app-identification catalog builder keyed its "any L4" TCP+UDP
+    fan-out on the RESOLVED protocol number being 0 (`proto == 0`), which
+    conflated three distinct cases that all resolve to 0: an OMITTED protocol
+    (the intended fan-out), an EXPLICIT `protocol 0` (IANA HOPOPT, which
+    `appid.ProtocolNumber("0")` resolves to `(0, true)` — a specific protocol,
+    NOT a wildcard), and an unrepresentable token on the tolerant-load path
+    (`ok == false`). So a single-protocol `protocol 0` application compiled to
+    BOTH a TCP (6) and a UDP (17) catalog entry, and a policy referencing that
+    app over-matched — a TCP-only intent also matched the UDP flow on the same
+    port (over-permit / over-broad classification). Verified genuine and Go-
+    scoped (the fan-out is in the Go compile, NOT the Rust dataplane match):
+    scratch catalog build showed `protocol 0` → `[6 17]` (bug), `protocol tcp`
+    → `[6]` (correct), omitted → `[6 17]` (deliberate default).
+  - **Fix**: key the fan-out on the protocol being ABSENT
+    (`strings.TrimSpace(app.Protocol) == ""`) instead of the resolved number
+    being 0. Only an omitted spec fans out to TCP+UDP; every explicit protocol
+    (including `protocol 0`) stays a single entry. The redundant
+    `app.Protocol != "icmp"` guard is subsumed — a non-empty protocol never
+    fans out. Applied to `pkg/appid/catalog.go` (the LIVE catalog shipped to
+    the userspace-dp helper via `pkg/dataplane/userspace/flow.go` →
+    `AppCatalogEntrySnapshot`) and mirrored in `pkg/dataplane/compiler.go`
+    (retired-eBPF; its `SetApplication`/`SetAppRange` writes are no-ops, but
+    keeping the fan-out identical preserves the documented parity invariant).
+    The omitted-protocol default (`any-l4` fan-out, `TestAppCatalogEntryPorts
+    AndProtos`) is unchanged.
+  - **Validation**: added `pkg/appid/catalog_proto0_4008_test.go` — RED-on-
+    revert on both `TestCatalogExplicitProtocol0DoesNotFanOut` and the full
+    config-parse `TestCatalogProtocol0FromParsedConfig` (revert → `protocol 0`
+    → `[6 17]`, both FAIL; fix → `[0]`, PASS). `go test ./pkg/appid/...
+    ./pkg/config/... ./pkg/dataplane/` green; `go build ./...`, `go vet`,
+    `gofmt` clean.
+  - **File(s)**: pkg/appid/catalog.go, pkg/dataplane/compiler.go,
+    pkg/appid/catalog_proto0_4008_test.go, pkg/appid/README.md, _Log.md
+
 ## 2026-07-03 — #4000: bare `commit` during a pending confirm window silently dropped newly-staged edits
 
 - **Timestamp**: 2026-07-03

--- a/pkg/appid/README.md
+++ b/pkg/appid/README.md
@@ -148,6 +148,30 @@ the bad entry — never MISLABEL a session as a wrong-but-plausible application:
   fixed identically; `TestAppCatalogParityOnTolerantLoadPortEdges` pins them
   byte-identical and dangling-free.
 
+## Protocol fan-out: omitted vs explicit `protocol 0` (#4008)
+
+An application with **no** `protocol` spec means "any L4": `BuildCatalog`
+(`catalog.go`) and the retired-eBPF mirror `compileApplications`
+(`pkg/dataplane/compiler.go`) each install ONE `CatalogEntry` per **TCP (6)**
+and **UDP (17)** under a single shared `app_id` (the Junos custom-application
+default). ICMP is naturally excluded — an ICMP app carries a non-empty
+protocol.
+
+An **explicit** `protocol <n>` — including `protocol 0` (IANA HOPOPT) — names a
+single, specific protocol and compiles to exactly one `CatalogEntry` for that
+protocol. Before #4008 the fan-out was keyed on the *resolved* protocol number
+being 0 (`proto == 0`), which conflated three distinct cases that all resolve to
+0: an omitted protocol (intended fan-out), an explicit `protocol 0`
+(`ProtocolNumber("0") == (0, true)`), and an unrepresentable token on the
+tolerant-load path (`ok == false`). So a single-protocol `protocol 0` app fanned
+out to BOTH TCP and UDP, and a policy referencing it over-matched (a TCP-only
+intent also matched the UDP flow on the same port). The fan-out is now keyed on
+the protocol being **absent** (`strings.TrimSpace(app.Protocol) == ""`), so only
+an omitted spec fans out; every explicit protocol stays single. Regression pins:
+`TestCatalogExplicitProtocol0DoesNotFanOut`,
+`TestCatalogProtocol0FromParsedConfig`, and `TestCatalogOmittedProtocolFansOut`
+in `catalog_proto0_4008_test.go`.
+
 ## ICMP type/code labeling (#3781 interim)
 
 The catalog wire (`AppCatalogEntrySnapshot`, `CatalogEntry`) is **L3/L4 only** —

--- a/pkg/appid/catalog.go
+++ b/pkg/appid/catalog.go
@@ -177,10 +177,26 @@ func BuildCatalog(cfg *config.Config) (Catalog, error) {
 			// type/code constraint (junos-icmp-all, a user protocol-only ICMP app)
 			// is unaffected and still ships its protocol-only row.
 			if !icmpTypeConstrained(app) {
-				// Omitted protocol means "any L4"; compileApplications installs
-				// both TCP and UDP entries (ICMP is excluded from that fan-out).
+				// An OMITTED protocol (empty spec) means "any L4":
+				// compileApplications installs one entry per TCP and UDP (the
+				// Junos custom-application default). An EXPLICIT protocol —
+				// including `protocol 0` (HOPOPT), which ProtocolNumber resolves
+				// to (0, true) — matches that single protocol only.
+				//
+				// #4008: the old trigger keyed the fan-out on the RESOLVED number
+				// being 0 (`proto == 0`), which conflated three distinct cases
+				// that all yield proto 0: an omitted protocol (the intended
+				// fan-out), an EXPLICIT `protocol 0` (a specific IANA protocol,
+				// NOT a wildcard), and an unrepresentable token on the tolerant-
+				// load path (ProtocolNumber ok=false). So a single-protocol
+				// `protocol 0` app fanned out to BOTH TCP and UDP → a policy
+				// referencing it over-matched (a TCP-only intent also matched the
+				// UDP flow). Key the fan-out on the protocol being ABSENT instead:
+				// only an omitted spec fans out; an explicit protocol (0 or any
+				// other) stays single. The `app.Protocol != "icmp"` guard is now
+				// subsumed — a non-empty protocol never fans out.
 				protos := []uint8{proto}
-				if proto == 0 && app.Protocol != "icmp" {
+				if strings.TrimSpace(app.Protocol) == "" {
 					protos = []uint8{6, 17}
 				}
 				for _, p := range protos {

--- a/pkg/appid/catalog_proto0_4008_test.go
+++ b/pkg/appid/catalog_proto0_4008_test.go
@@ -1,0 +1,120 @@
+package appid
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// catalogProtosFor builds the catalog for a config carrying exactly `app` and
+// returns the sorted set of protocol numbers the app's CatalogEntry rows use.
+func catalogProtosFor(t *testing.T, app *config.Application) []uint8 {
+	t.Helper()
+	cfg := &config.Config{}
+	cfg.Services.ApplicationIdentification = true
+	cfg.Applications.Applications = map[string]*config.Application{app.Name: app}
+	cat, err := BuildCatalog(cfg)
+	if err != nil {
+		t.Fatalf("BuildCatalog: %v", err)
+	}
+	var protos []uint8
+	for _, e := range cat.Entries {
+		if e.Name == app.Name {
+			protos = append(protos, e.Protocol)
+		}
+	}
+	sort.Slice(protos, func(i, j int) bool { return protos[i] < protos[j] })
+	return protos
+}
+
+// TestCatalogExplicitProtocol0DoesNotFanOut is the #4008 RED-on-revert guard.
+//
+// An application term with an EXPLICIT `protocol 0` names IANA protocol 0
+// (HOPOPT) — a single, specific protocol, NOT a wildcard. It must compile to a
+// SINGLE catalog entry for protocol 0. The old builder keyed the "any L4"
+// fan-out on the RESOLVED protocol number being 0 (`proto == 0`), so an explicit
+// `protocol 0` (which ProtocolNumber resolves to (0, true)) fanned out to BOTH
+// TCP (6) and UDP (17) — a policy referencing the app then over-matched (a
+// single-protocol intent also matched the TCP and UDP flows on the same port).
+//
+// On revert this goes RED: the reverted builder emits {6, 17} for `protocol 0`.
+func TestCatalogExplicitProtocol0DoesNotFanOut(t *testing.T) {
+	got := catalogProtosFor(t, &config.Application{
+		Name: "p0", Protocol: "0", DestinationPort: "80",
+	})
+	if len(got) != 1 || got[0] != 0 {
+		t.Fatalf("explicit `protocol 0` protos = %v, want [0] (a single "+
+			"protocol-0 entry, NOT a TCP+UDP fan-out)", got)
+	}
+}
+
+// TestCatalogOmittedProtocolFansOut pins the DELIBERATE default: an application
+// with NO protocol spec means "any L4" and fans out to both TCP and UDP. #4008
+// must not regress this — only the RESOLVED-number-0 conflation is removed.
+func TestCatalogOmittedProtocolFansOut(t *testing.T) {
+	got := catalogProtosFor(t, &config.Application{
+		Name: "pomit", DestinationPort: "80",
+	})
+	want := []uint8{6, 17}
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("omitted protocol protos = %v, want %v (TCP+UDP fan-out is "+
+			"the documented Junos default for a portless/omitted protocol)", got, want)
+	}
+}
+
+// TestCatalogExplicitTCPMatchesOnlyTCP is the companion invariant: a normal
+// `protocol tcp` term matches ONLY TCP and is unaffected by the #4008 fix.
+func TestCatalogExplicitTCPMatchesOnlyTCP(t *testing.T) {
+	got := catalogProtosFor(t, &config.Application{
+		Name: "ptcp", Protocol: "tcp", DestinationPort: "80",
+	})
+	if len(got) != 1 || got[0] != 6 {
+		t.Fatalf("`protocol tcp` protos = %v, want [6] (TCP only)", got)
+	}
+	gotUDP := catalogProtosFor(t, &config.Application{
+		Name: "pudp", Protocol: "udp", DestinationPort: "80",
+	})
+	if len(gotUDP) != 1 || gotUDP[0] != 17 {
+		t.Fatalf("`protocol udp` protos = %v, want [17] (UDP only)", gotUDP)
+	}
+}
+
+// TestCatalogProtocol0FromParsedConfig drives the full config-parse path
+// (ParseSetCommand + SetPath, the mandated flat-set test shape) so the fix is
+// proven end-to-end: `set applications application hopopt protocol 0` compiles
+// to a single protocol-0 catalog entry, not a TCP+UDP fan-out.
+func TestCatalogProtocol0FromParsedConfig(t *testing.T) {
+	tree := &config.ConfigTree{}
+	setLines := []string{
+		"set applications application hopopt protocol 0",
+		"set services application-identification",
+	}
+	for _, line := range setLines {
+		path, err := config.ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%v): %v", path, err)
+		}
+	}
+	cfg, err := config.CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	cat, err := BuildCatalog(cfg)
+	if err != nil {
+		t.Fatalf("BuildCatalog: %v", err)
+	}
+	var protos []uint8
+	for _, e := range cat.Entries {
+		if e.Name == "hopopt" {
+			protos = append(protos, e.Protocol)
+		}
+	}
+	if len(protos) != 1 || protos[0] != 0 {
+		t.Fatalf("parsed `protocol 0` protos = %v, want [0] (single protocol-0 "+
+			"entry, NOT a TCP+UDP fan-out)", protos)
+	}
+}

--- a/pkg/dataplane/compiler.go
+++ b/pkg/dataplane/compiler.go
@@ -612,9 +612,17 @@ func compileApplications(dp DataPlane, cfg *config.Config, result *CompileResult
 		algType := algTypeFromString(app.ALG)
 
 		// When no protocol is specified, install entries for both TCP and UDP
-		// (matching Junos behavior where omitted protocol means any L4).
+		// (matching Junos behavior where omitted protocol means any L4). An
+		// EXPLICIT protocol — including `protocol 0` (HOPOPT) — matches that
+		// single protocol only. #4008: keying the fan-out on the resolved number
+		// being 0 conflated an explicit `protocol 0` (and an unrepresentable
+		// token) with the omitted case, fanning a single-protocol app out to
+		// TCP+UDP → over-broad match. Key on the protocol being ABSENT instead.
+		// This mirrors appid.BuildCatalog (the LIVE catalog shipped to the
+		// helper); the SetApplication / SetAppRange writes below are the retired
+		// eBPF path (#1476), so this parity keeps the documented invariant true.
 		protos := []uint8{proto}
-		if proto == 0 && app.Protocol != "icmp" {
+		if strings.TrimSpace(app.Protocol) == "" {
 			protos = []uint8{6, 17} // TCP + UDP
 		}
 


### PR DESCRIPTION
## Summary

Closes #4008 (fable-161 F-164, MEDIUM — appid over-broad protocol match).

The app-identification catalog builder keyed its "any L4" TCP+UDP fan-out on the **resolved** protocol number being 0 (`proto == 0`). That conflates three cases that all resolve to protocol 0:

- an **omitted** protocol — the intended fan-out (Junos custom-application default);
- an **explicit** `protocol 0` (IANA HOPOPT), which `appid.ProtocolNumber("0")` deliberately resolves to `(0, true)` — a specific protocol, NOT a wildcard;
- an unrepresentable token on the tolerant-load path (`ok == false`).

So a single-protocol `protocol 0` application compiled to **both** a TCP (6) and a UDP (17) catalog entry under one `app_id`, and any policy referencing it over-matched — a TCP-only intent also matched the UDP flow on the same port (over-permit / over-broad classification).

## Verify-first finding

Genuine, and **Go-scoped** — the fan-out is in the Go compile, not the Rust dataplane match. The live path is `pkg/appid.BuildCatalog` → `Catalog.Entries` → shipped to the userspace-dp helper via `pkg/dataplane/userspace/flow.go` (`AppCatalogEntrySnapshot`). Scratch catalog build before the fix:

```
protocol 0   -> [6 17]   (bug: fans out)
omitted      -> [6 17]   (deliberate "any L4" default)
protocol tcp -> [6]      (correct)
protocol udp -> [17]     (correct)
protocol 47  -> [47]     (correct)
```

## Fix

Key the fan-out on the protocol being **absent** (`strings.TrimSpace(app.Protocol) == ""`) rather than the resolved number being 0. Only an omitted spec fans out; every explicit protocol — including `protocol 0` — stays a single entry. The redundant `app.Protocol != "icmp"` guard is subsumed (a non-empty protocol never fans out).

- `pkg/appid/catalog.go` — the LIVE catalog path.
- `pkg/dataplane/compiler.go` — mirrored to keep the documented `BuildCatalog` parity invariant true. This is the retired-eBPF path (`SetApplication`/`SetAppRange` are no-ops since #1476), so it has no live effect; the mirror is for consistency/parity only.

The omitted-protocol default (`any-l4` fan-out) is unchanged.

## Tests (RED-on-revert)

`pkg/appid/catalog_proto0_4008_test.go`:

- `TestCatalogExplicitProtocol0DoesNotFanOut` — `protocol 0` → `[0]` (RED on revert: `[6 17]`).
- `TestCatalogProtocol0FromParsedConfig` — same via the full `ParseSetCommand` + `SetPath` + `CompileConfig` path (RED on revert).
- `TestCatalogOmittedProtocolFansOut` — pins the preserved any-l4 default `[6 17]`.
- `TestCatalogExplicitTCPMatchesOnlyTCP` — pins the normal single-protocol path.

Revert proof:

```
--- FAIL: TestCatalogExplicitProtocol0DoesNotFanOut
    explicit `protocol 0` protos = [6 17], want [0]
--- FAIL: TestCatalogProtocol0FromParsedConfig
    parsed `protocol 0` protos = [6 17], want [0]
```

## Validation

- `go test ./pkg/appid/... ./pkg/config/... ./pkg/dataplane/` — green.
- `go build ./...`, `go vet ./pkg/appid/...`, `gofmt -l` — clean.

Docs: added a "Protocol fan-out" subsection to `pkg/appid/README.md`; logged in `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi