### PR TITLE
test/cluster-deploy: fix secondary-node detection so a rolling deploy stops the SECONDARY first (no spurious mid-deploy failover) (#4009)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,47 @@
+## 2026-07-03 — #4009: cluster-deploy secondary-node detection grep never matched → deploy restarted the PRIMARY first ~50% of the time (spurious mid-deploy failover)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-093 (MEDIUM, test-infra). A rolling
+    `cluster-setup.sh deploy all` must restart the SECONDARY node first so the
+    primary keeps forwarding. `deploy_rolling` (the default raw-push fast path,
+    driven by `make cluster-deploy`) detected the secondary with an inline
+    `grep "secondary:node0"` against `show chassis cluster status`. That output
+    (FormatStatus, `pkg/cluster/status.go`) renders space-separated, lowercase
+    per-node rows (`node0  200  primary` / `node1  100  secondary`) with no
+    `secondary:node0` token anywhere, so the grep NEVER matched. Detection
+    always fell through to the fixed default `secondary=1, primary=0`, so
+    whenever node0 was the RG0 SECONDARY the deploy restarted node1 (the
+    PRIMARY) first → a spurious mid-deploy failover that churned cluster state
+    and left downstream smoke (`apply-cos-config.sh`, `test-failover`) starting
+    from an unexpected primary ~50% of the time — the root cause of the
+    force-node0-primary workaround in the HA batch-tf scripts. (The sibling
+    `deploy_rolling_deb` had a separate, working `show chassis cluster
+    information` / `Local state:` grep; the two detections had diverged.)
+  - **Fix**: extracted ONE tested SSOT parser `deploy_rolling_secondary_node`
+    into `test/incus/deploy-lib.sh` — reads `show chassis cluster status` on
+    stdin, scopes to the `Redundancy group: 0` header, and echoes 0 when
+    node0's RG0 Status is `secondary`/`secondary-hold` (upgrade node0 first)
+    else 1; defaults to 1 (node0-primary steady state) on empty/unparseable
+    input. `rolling_detect_secondary` in `cluster-setup.sh` wires it to node0
+    live. BOTH `deploy_rolling` and `deploy_rolling_deb` now use it. Added a
+    belt-and-braces `reassert_primary_node0` (RG ids via `deploy_rolling_rg_ids`)
+    that resets manual failover + forces node0 primary for every RG after a
+    rolling deploy, so smoke always starts from the documented node0-primary
+    state regardless of preempt config — best-effort, non-fatal. The #1875
+    lock + sha-verify/verify-dataplane gate are untouched.
+  - **Validation**: 7 new offline captured-output tests in
+    `deploy-lib-selftest.sh` (`make test-deploy-lib`, 19/19 pass) covering
+    node0-primary→1, node0-secondary→0, active-active RG0-scoping→0,
+    secondary-hold→0, peer-down→1, empty→1, and rg-id extraction. RED-on-revert
+    demonstrated: the retired `grep "secondary:node0"` returns 1 (node1-first)
+    on the node0-secondary sample → would restart the primary first. shellcheck
+    clean (warning+) on all three scripts; `go build ./...` green; existing
+    `cluster_status_parse_test.py` still passes. No live cluster run (shared
+    loss cluster — validated by reasoning + captured-output tests only).
+  - **File(s)**: `test/incus/deploy-lib.sh`,
+    `test/incus/cluster-setup.sh`, `test/incus/deploy-lib-selftest.sh`,
+    `docs/ha-cluster-test-plan.md`, `_Log.md`
+
 ## 2026-07-03 — #4005: `monitor traffic matching "<filter>"` truncated the pcap filter to the first token
 
 - **Timestamp**: 2026-07-03

--- a/docs/ha-cluster-test-plan.md
+++ b/docs/ha-cluster-test-plan.md
@@ -435,6 +435,30 @@ make cluster-start/stop/restart  # Service lifecycle (NODE=0|1|all)
 4. Ensure `/etc/xpf/node-id` exists
 5. Install and enable systemd service
 
+### Rolling order for `deploy all` (secondary first, #4009)
+
+`deploy all` upgrades the **SECONDARY node first** so the primary keeps
+forwarding, then upgrades the primary (the standby, now upgraded, takes over
+via VRRP). The secondary is detected by running `show chassis cluster status`
+on node0 and reading node0's own **RG0 Status** row — parsed by
+`deploy_rolling_secondary_node` in `test/incus/deploy-lib.sh`
+(unit-tested in `deploy-lib-selftest.sh`, run by `make test-deploy-lib`).
+
+Before #4009 the detection used an inline `grep "secondary:node0"` that never
+matched the space-separated, lowercase status rows, so the deploy always fell
+through to a fixed "node1 first" order. Whenever node0 was the RG0 **secondary**
+that restarted the **primary (node1) first** — a spurious mid-deploy failover
+that churned cluster state and left downstream smoke (`apply-cos-config.sh`,
+`test-failover`) starting from an unexpected primary ~50% of the time (the root
+cause of the force-node0-primary workaround in the HA batch scripts).
+
+After the correct-order deploy, `reassert_primary_node0` best-effort resets
+manual failover and forces node0 primary for **every** redundancy group (RG ids
+enumerated by `deploy_rolling_rg_ids`), so smoke always starts from the
+documented node0-primary steady state regardless of the cluster's preempt
+setting. Both the raw-push (`deploy_rolling`) and dogfood-deb
+(`deploy_rolling_deb`) paths share the same detection + reassert helpers.
+
 ## Test Cases
 
 ### TC-1: Cluster Formation

--- a/test/incus/cluster-setup.sh
+++ b/test/incus/cluster-setup.sh
@@ -697,26 +697,56 @@ deploy_vm_deb() {
 	info "Cut-over complete for $vm."
 }
 
-# deploy_rolling_deb sequences the deb cut across both nodes (secondary
-# first), so the cluster keeps forwarding through the whole upgrade.
+# rolling_detect_secondary queries node0's `show chassis cluster status` and
+# echoes the RG0 SECONDARY node index (0 or 1) — the node to upgrade FIRST so
+# the primary keeps forwarding. The parse lives in deploy_rolling_secondary_node
+# (deploy-lib.sh, unit-tested in deploy-lib-selftest.sh, #4009). Best-effort: a
+# failed query falls through to the parser default (node1) without aborting the
+# set -e pipeline.
 #
-# Determine which node is secondary by asking node0 for ITS OWN local RG
-# state via `show chassis cluster information` (FormatInformation emits
-# "  Local state: Primary|Secondary"). The legacy deploy_rolling grep
-# pattern "secondary:node0" never matched the space-separated status rows
-# (AGY r1) and silently always upgraded node1 first; this checks the real
-# field. If node0 is Secondary, upgrade it first; else node1.
-deploy_rolling_deb() {
-	local secondary=1 primary=0
-	if incus exec "$(r "$VM0")" -- cli -c "show chassis cluster information" 2>/dev/null \
-		| grep -qiE '^[[:space:]]*Local state:[[:space:]]+Secondary'; then
-		secondary=0
-		primary=1
+# #4009: this REPLACES two divergent, defective detections — deploy_rolling's
+# inline `grep "secondary:node0"` (never matched the space-separated status
+# rows, so it silently upgraded node1 first even when node0 was the secondary →
+# a spurious mid-deploy failover) and deploy_rolling_deb's `show chassis cluster
+# information` / `Local state:` grep — with ONE tested SSOT parser.
+rolling_detect_secondary() {
+	incus exec "$(r "$VM0")" -- cli -c "show chassis cluster status" 2>/dev/null \
+		| deploy_rolling_secondary_node || true
+}
+
+# reassert_primary_node0 leaves node0 the primary for EVERY redundancy group
+# after a rolling deploy, so downstream smoke (apply-cos-config, test-failover)
+# starts from the documented node0-primary steady state regardless of preempt
+# config — removing the force-node0-primary workaround the HA batch scripts
+# needed (#4009). Best-effort: a failed request is logged, never fatal.
+reassert_primary_node0() {
+	local status rg did=0
+	status=$(incus exec "$(r "$VM0")" -- cli -c "show chassis cluster status" 2>/dev/null || true)
+	while read -r rg; do
+		[[ -n "$rg" ]] || continue
+		incus exec "$(r "$VM0")" -- cli -c "request chassis cluster failover reset redundancy-group $rg" >/dev/null 2>&1 || true
+		incus exec "$(r "$VM0")" -- cli -c "request chassis cluster failover redundancy-group $rg node 0" >/dev/null 2>&1 || true
+		did=1
+	done < <(printf '%s\n' "$status" | deploy_rolling_rg_ids)
+	if [[ "$did" == 1 ]]; then
+		info "Re-asserted node0 primary for all redundancy groups (post-deploy)."
+	else
+		warn "Post-deploy primary reassert skipped — could not read cluster status from node0."
 	fi
+}
+
+# deploy_rolling_deb sequences the deb cut across both nodes (secondary
+# first), so the cluster keeps forwarding through the whole upgrade, then
+# re-asserts node0 primary for a deterministic post-deploy state (#4009).
+deploy_rolling_deb() {
+	local secondary primary
+	secondary=$(rolling_detect_secondary)
+	primary=$(( secondary == 0 ? 1 : 0 ))
 	info "Rolling deb deploy: secondary=node${secondary}, primary=node${primary}"
 	deploy_vm_deb "$secondary"
 	sleep 5
 	deploy_vm_deb "$primary"
+	reassert_primary_node0
 	info "Rolling deb deploy complete."
 }
 
@@ -725,13 +755,15 @@ deploy_rolling_deb() {
 # the secondary upgrades, then the upgraded secondary takes over when
 # the primary restarts.
 deploy_rolling() {
-	# Determine which node is currently secondary (deploy it first).
-	local secondary=1
-	local primary=0
-	if incus exec "$(r "$VM0")" -- cli -c "show chassis cluster status" 2>/dev/null | grep -q "secondary:node0"; then
-		secondary=0
-		primary=1
-	fi
+	# Determine which node is currently the RG0 secondary (deploy it first).
+	# #4009: the old inline `grep "secondary:node0"` never matched the
+	# space-separated `show chassis cluster status` rows, so this ALWAYS fell
+	# through to node1-first — restarting the PRIMARY first (a spurious
+	# mid-deploy failover) whenever node0 was the secondary. Now via the
+	# tested parser in deploy-lib.sh.
+	local secondary primary
+	secondary=$(rolling_detect_secondary)
+	primary=$(( secondary == 0 ? 1 : 0 ))
 
 	info "Rolling deploy: secondary=node${secondary}, primary=node${primary}"
 
@@ -760,6 +792,10 @@ deploy_rolling() {
 	# Phase 2: Deploy to primary (secondary takes over via VRRP).
 	info "Phase 2: Deploying to primary (node${primary})..."
 	deploy_vm "$primary"
+
+	# #4009: leave node0 the primary so downstream smoke starts from a known
+	# state regardless of preempt config.
+	reassert_primary_node0
 
 	info "Rolling deploy complete."
 }

--- a/test/incus/deploy-lib-selftest.sh
+++ b/test/incus/deploy-lib-selftest.sh
@@ -349,7 +349,125 @@ test_verify_running_stale_binary_hardfails() {
 	rm -f "$lb"; teardown_fake_vm
 }
 
+# ── Rolling-deploy node ordering (#4009) ─────────────────────────────
+# Captured `cli -c "show chassis cluster status"` samples (FormatStatus,
+# pkg/cluster/status.go). deploy_rolling_secondary_node must echo the RG0
+# SECONDARY node index (upgrade it FIRST). RED-on-revert: the retired
+# inline `grep "secondary:node0"` never matched these space-separated,
+# lowercase rows, so a node0-secondary cluster wrongly resolved to
+# node1-first — restarting the PRIMARY first → a spurious mid-deploy failover.
+
+STATUS_NODE0_PRIMARY="Monitor Failure codes:
+    CS  Cold Sync monitoring        FL  Fabric Connection monitoring
+
+Cluster ID: 1
+Node name: node0
+
+Node    Priority  Status         Preempt  Manual   Monitor-failures
+
+Redundancy group: 0 , Failover count: 0
+node0   200       primary        no       no       None
+  Takeover ready: yes
+  Transfer ready: yes
+node1   100       secondary      no       no       None
+"
+
+STATUS_NODE0_SECONDARY="Redundancy group: 0 , Failover count: 1
+node0   100       secondary      no       no       None
+node1   200       primary        no       no       None
+"
+
+# Active-active: node0 is SECONDARY for RG0 but PRIMARY for RG1. The decision
+# must be scoped to RG0 (the mastership that steers the WAN path) → node0 first.
+STATUS_MULTI_RG_NODE0_SEC_RG0="Redundancy group: 0 , Failover count: 1
+node0   200       secondary      no       no       None
+node1   100       primary        no       no       None
+
+Redundancy group: 1 , Failover count: 2
+node0   200       primary        no       no       None
+node1   100       secondary      no       no       None
+"
+
+STATUS_SECONDARY_HOLD="Redundancy group: 0 , Failover count: 0
+node0   100       secondary-hold no       no       None
+node1   200       primary        no       no       None
+"
+
+STATUS_PEER_DOWN="Redundancy group: 0 , Failover count: 0
+node0   200       primary        no       no       None
+"
+
+test_rolling_secondary_node0_primary() {
+	local got; got=$(printf '%s' "$STATUS_NODE0_PRIMARY" | deploy_rolling_secondary_node)
+	if [[ "$got" == 1 ]]; then
+		ok "rolling: node0 primary -> upgrade node1 (secondary) first"
+	else
+		bad "rolling: node0 primary -> expected 1, got '$got'"
+	fi
+}
+
+test_rolling_secondary_node0_secondary() {
+	local got; got=$(printf '%s' "$STATUS_NODE0_SECONDARY" | deploy_rolling_secondary_node)
+	if [[ "$got" == 0 ]]; then
+		ok "rolling: node0 secondary -> upgrade node0 first (no spurious failover)"
+	else
+		bad "rolling: node0 secondary -> expected 0, got '$got' (retired secondary:node0 grep gives 1 -> restarts PRIMARY first)"
+	fi
+}
+
+test_rolling_secondary_multi_rg_scoped_to_rg0() {
+	local got; got=$(printf '%s' "$STATUS_MULTI_RG_NODE0_SEC_RG0" | deploy_rolling_secondary_node)
+	if [[ "$got" == 0 ]]; then
+		ok "rolling: multi-RG decision scoped to RG0 (node0 secondary in RG0)"
+	else
+		bad "rolling: multi-RG -> expected 0 (RG0), got '$got'"
+	fi
+}
+
+test_rolling_secondary_hold_counts_as_secondary() {
+	local got; got=$(printf '%s' "$STATUS_SECONDARY_HOLD" | deploy_rolling_secondary_node)
+	if [[ "$got" == 0 ]]; then
+		ok "rolling: node0 secondary-hold -> upgrade node0 first"
+	else
+		bad "rolling: secondary-hold -> expected 0, got '$got'"
+	fi
+}
+
+test_rolling_secondary_peer_down_defaults() {
+	local got; got=$(printf '%s' "$STATUS_PEER_DOWN" | deploy_rolling_secondary_node)
+	if [[ "$got" == 1 ]]; then
+		ok "rolling: node0 primary (peer down) -> default node1 first"
+	else
+		bad "rolling: peer-down -> expected 1, got '$got'"
+	fi
+}
+
+test_rolling_secondary_empty_defaults() {
+	local got; got=$(printf '' | deploy_rolling_secondary_node)
+	if [[ "$got" == 1 ]]; then
+		ok "rolling: empty/unparseable status -> default node1 first"
+	else
+		bad "rolling: empty -> expected 1, got '$got'"
+	fi
+}
+
+test_rolling_rg_ids() {
+	local got; got=$(printf '%s' "$STATUS_MULTI_RG_NODE0_SEC_RG0" | deploy_rolling_rg_ids | tr '\n' ' ')
+	if [[ "$got" == "0 1 " ]]; then
+		ok "rolling: rg-id extraction lists '0 1' for the post-deploy reassert"
+	else
+		bad "rolling: rg-ids -> expected '0 1 ', got '$got'"
+	fi
+}
+
 # ── Run ───────────────────────────────────────────────────────────────
+test_rolling_secondary_node0_primary
+test_rolling_secondary_node0_secondary
+test_rolling_secondary_multi_rg_scoped_to_rg0
+test_rolling_secondary_hold_counts_as_secondary
+test_rolling_secondary_peer_down_defaults
+test_rolling_secondary_empty_defaults
+test_rolling_rg_ids
 test_verify_pushed_sha_match
 test_verify_pushed_sha_mismatch_hardfails
 test_verify_pushed_sha_absent_hardfails

--- a/test/incus/deploy-lib.sh
+++ b/test/incus/deploy-lib.sh
@@ -172,3 +172,52 @@ deploy_verify_running_xpfd() {
 	fi
 	info "Verified running xpfd on $rinst matches the pushed build ($local_sum, ExecStart=$exec_path)."
 }
+
+# ── Rolling-deploy node ordering (#4009) ─────────────────────────────
+# A rolling cluster deploy must restart the SECONDARY node first (traffic
+# stays on the primary), then the primary. Getting the order wrong restarts
+# the primary while the standby is not yet upgraded/ready → a spurious
+# mid-deploy failover that masks real failover behavior in downstream smoke.
+#
+# These parsers are PURE (stdin → stdout, no incus, no info/warn/die) so the
+# selftest can exercise them offline against captured `show chassis cluster
+# status` samples.
+
+# deploy_rolling_secondary_node reads `cli -c "show chassis cluster status"`
+# output (run on node0) on stdin and echoes the node index (0 or 1) to upgrade
+# FIRST — the RG0 SECONDARY. node0's own RG0 row reports node0's role directly:
+#
+#   Redundancy group: 0 , Failover count: 0
+#   node0   200       primary        no       no       None
+#   node1   100       secondary      no       no       None
+#
+# If node0's RG0 Status is "secondary" (or "secondary-hold"), node0 is the
+# secondary and is upgraded first → echo 0. Otherwise node1 is the secondary
+# → echo 1. Defaults to 1 (node0 primary / node1 secondary — the documented
+# steady state) when RG0's node0 row is absent or unparseable.
+#
+# #4009: the legacy inline grep pattern "secondary:node0" never matched this
+# space-separated, lowercase status output, so detection ALWAYS fell through to
+# the default (node1 first). Whenever node0 was actually the RG0 secondary, the
+# deploy then restarted node1 (the PRIMARY) first → a spurious mid-deploy
+# failover. The RG number is read from the "Redundancy group: N" header so the
+# decision is scoped to RG0 even in active-active (multi-RG) layouts.
+deploy_rolling_secondary_node() {
+	awk '
+		/^Redundancy group:[[:space:]]/ { rg = $3; next }
+		(rg == "0") && ($1 == "node0") {
+			st = tolower($3)
+			if (st ~ /^secondary/) { print 0 } else { print 1 }
+			found = 1
+			exit
+		}
+		END { if (found != 1) print 1 }
+	'
+}
+
+# deploy_rolling_rg_ids reads `show chassis cluster status` on stdin and echoes
+# the redundancy-group ids present (one per line, ascending, deduplicated).
+# Used by the post-deploy node0-primary reassert to iterate every RG.
+deploy_rolling_rg_ids() {
+	awk '/^Redundancy group:[[:space:]]/ { print $3 }' | sort -n -u
+}


### PR DESCRIPTION
Closes #4009

## Problem (fable-161 F-093, MEDIUM test-infra)

A rolling `cluster-setup.sh deploy all` must restart the **SECONDARY** node
first (primary keeps forwarding), then the primary. The default raw-push path
`deploy_rolling` — the one `make cluster-deploy` runs — detected the secondary
with an inline `grep "secondary:node0"` against `show chassis cluster status`.

That output (`FormatStatus`, `pkg/cluster/status.go`) renders space-separated,
lowercase per-node rows:

```
Redundancy group: 0 , Failover count: 0
node0   200       primary        no       no       None
node1   100       secondary      no       no       None
```

There is **no `secondary:node0` token anywhere**, so the grep NEVER matched and
detection always fell through to the fixed default (`secondary=1, primary=0`).
Whenever node0 was the RG0 **secondary**, the deploy restarted node1 (the
**primary**) first → a spurious mid-deploy failover. That churned cluster state
and left downstream smoke (`apply-cos-config.sh`, `test-failover`) starting from
an unexpected primary ~50% of the time — the root cause of the
force-node0-primary workaround in the HA batch-tf scripts.

(The sibling deb path `deploy_rolling_deb` had a *separate*, working
`show chassis cluster information` / `Local state:` grep — the two detections
had diverged.)

## Fix

- **One tested SSOT parser** `deploy_rolling_secondary_node` in
  `test/incus/deploy-lib.sh` (pure stdin→stdout): scopes to the
  `Redundancy group: 0` header and reads node0's own RG0 Status → echo `0` when
  node0 is `secondary`/`secondary-hold` (upgrade node0 first) else `1`; defaults
  to `1` (node0-primary steady state) on empty/unparseable input.
- **Both** `deploy_rolling` and `deploy_rolling_deb` now use it (via
  `rolling_detect_secondary`), so the true secondary is always restarted first.
- **Belt-and-braces** `reassert_primary_node0`: after the rolling cut,
  best-effort reset manual failover + force node0 primary for every RG (ids from
  `deploy_rolling_rg_ids`), so smoke starts from the documented node0-primary
  state regardless of the preempt setting. Non-fatal (`|| true`).
- The #1875 cluster lock, sha-verify, and verify-dataplane gate are untouched.

## Validation (no live cluster run — shared loss cluster)

- 7 new offline captured-output tests in `deploy-lib-selftest.sh`
  (`make test-deploy-lib`, **19/19 pass**): node0-primary→1, node0-secondary→0,
  active-active RG0-scoping→0, secondary-hold→0, peer-down→1, empty→1, rg-ids.
- **RED-on-revert** demonstrated: the retired `grep "secondary:node0"` returns
  `1` (node1-first) on the node0-secondary sample → would restart the primary
  first.
- `shellcheck -S warning` clean on all three scripts; `go build ./...` green;
  existing `cluster_status_parse_test.py` still passes.

Script-logic fix validated by reasoning + captured-output tests; no
`cluster-deploy` / live cluster execution was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
