### PR TITLE
ipsec: fix inverted df-bit set/clear action (#4015)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -30981,3 +30981,28 @@ top.
     Quick Start, docs/testing.md, docs/testing-procedures.md.
   - **File(s)**: Makefile, README.md, CLAUDE.md, docs/testing.md,
     docs/testing-procedures.md, _Log.md
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fix inverted IPsec `df-bit set`/`df-bit clear` action (#4015).
+    Traced the whole path — config parse → compile (`compiler_ipsec.go`
+    stores `DFBit` verbatim) → strongSwan config generation
+    (`pkg/ipsec/policy.go`). The df-bit action is applied entirely in Go via
+    strongSwan `copy_df`; NO Rust dataplane involvement (the only Rust DF
+    logic is NAT64, unrelated). strongSwan `copy_df`: `yes` (default) copies
+    the inner DF to the outer header (= Junos `copy`); `no` forces the outer
+    DF to 0 (= Junos `clear`, allow fragmentation). The old mapping emitted
+    `copy_df = no` for `set` (which CLEARS DF) and let `clear` fall through
+    to the default `copy_df = yes` (which COPIES/preserves DF) — set and
+    clear were inverted. Impact: `df-bit clear` (intended to allow
+    fragmentation into a tunnel) instead preserved/set DF → PMTUD blackhole
+    for oversized packets. Fix: single-point switch — `copy`/`set` →
+    `copy_df = yes` (strongSwan cannot force DF=1; copy_df=yes is the
+    DF-preserving/PMTUD behavior), `clear` → `copy_df = no`. Updated the
+    existing `TestGenerateConfig_DFBit` to encode the correct mapping
+    (RED-on-revert: `set`/`clear` subtests fail on the old branch) and added
+    `TestIPsecDFBitSetSyntaxCompile` (ParseSetCommand + tree.SetPath compile
+    leg). Schema desc `(copy|set)` → `(copy|set|clear)`; docs/phases.md
+    df-bit entry expanded to all three modes.
+  - **File(s)**: pkg/ipsec/policy.go, pkg/ipsec/ipsec_test.go,
+    pkg/config/parser_security_test.go, pkg/config/schema_security.go,
+    docs/phases.md, _Log.md

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -834,7 +834,7 @@ Gap audit: `docs/archived/userspace-forwarding-and-failover-gap-audit.md` (PR #3
 - **DataPlane interface update:** `SetApplication()` signature extended with `srcPortLow, srcPortHigh uint16`; eBPF + DPDK parity
 
 ### IPsec Enhancements
-- **df-bit copy:** `set security ipsec vpn X df-bit copy` → strongSwan `copy_df=yes` / `fragmentation=yes`
+- **df-bit (copy|set|clear):** `set security ipsec vpn X df-bit <mode>` → strongSwan `copy_df`. `copy` and `set` → `copy_df=yes` (outer DF copied from / preserved with inner; strongSwan cannot force outer DF=1, so `set` keeps PMTUD rather than clearing DF). `clear` → `copy_df=no` (outer DF forced to 0 — allow fragmentation of oversized packets into the tunnel). #4015 fixed a set/clear inversion where `set` emitted `copy_df=no` (clearing DF) and `clear` fell through to the default (`copy_df=yes`).
 - **establish-tunnels immediately:** Auto-establish at boot → strongSwan `auto=start` (vs `auto=route`)
 - **IKE gateway dynamic hostname:** DNS hostname for peer → strongSwan `right=hostname`
 - **IKE gateway local-address:** Explicit local address → strongSwan `left=X.X.X.X`

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -5747,3 +5747,39 @@ func TestIPsecDynamicHostnameNotResponderOnly(t *testing.T) {
 		t.Errorf("dynamic-hostname gateway must NOT be responder-only")
 	}
 }
+
+// TestIPsecDFBitSetSyntaxCompile verifies the df-bit action compiles through
+// the flat-set parse path (ParseSetCommand + tree.SetPath) into the stored
+// IPsecVPN.DFBit value for every Junos mode (copy|set|clear). The semantic
+// mapping to strongSwan copy_df (and the #4015 set/clear inversion fix) is
+// asserted in pkg/ipsec TestGenerateConfig_DFBit; this test guards the
+// config-compile leg that feeds it.
+func TestIPsecDFBitSetSyntaxCompile(t *testing.T) {
+	for _, mode := range []string{"copy", "set", "clear"} {
+		tree := &ConfigTree{}
+		cmds := []string{
+			"set security ipsec vpn tun bind-interface st0.0",
+			"set security ipsec vpn tun df-bit " + mode,
+		}
+		for _, cmd := range cmds {
+			path, err := ParseSetCommand(cmd)
+			if err != nil {
+				t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+			}
+			if err := tree.SetPath(path); err != nil {
+				t.Fatalf("SetPath(%q): %v", cmd, err)
+			}
+		}
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("df-bit %q: CompileConfig: %v", mode, err)
+		}
+		vpn := cfg.Security.IPsec.VPNs["tun"]
+		if vpn == nil {
+			t.Fatalf("df-bit %q: VPN tun not compiled", mode)
+		}
+		if vpn.DFBit != mode {
+			t.Errorf("df-bit %q: compiled DFBit = %q, want %q", mode, vpn.DFBit, mode)
+		}
+	}
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -849,7 +849,7 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 		}},
 		"vpn": {desc: "IPsec VPN tunnel name", args: 1, placeholder: "<vpn-name>", children: map[string]*schemaNode{
 			"bind-interface":    {desc: "XFRM tunnel interface to bind", args: 1, placeholder: "<interface-name>", children: nil},
-			"df-bit":            {desc: "Outer-header DF bit handling (copy|set)", args: 1, placeholder: "<mode>", children: nil},
+			"df-bit":            {desc: "Outer-header DF bit handling (copy|set|clear)", args: 1, placeholder: "<mode>", children: nil},
 			"establish-tunnels": {desc: "Tunnel establishment (immediately = initiate at commit)", args: 1, placeholder: "<mode>", children: nil},
 			"local-identity":    {desc: "Local identity (default local traffic selector)", args: 1, placeholder: "<identity>", children: nil},
 			"remote-identity":   {desc: "Remote identity (default remote traffic selector)", args: 1, placeholder: "<identity>", children: nil},

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -890,9 +890,13 @@ func TestGenerateConfig_DFBit(t *testing.T) {
 		want    string
 		notWant string
 	}{
+		// #4015: df-bit set/clear were inverted. strongSwan copy_df=no CLEARS
+		// the outer DF bit, so it must map to Junos "clear" (allow
+		// fragmentation), NOT "set". "set" (and "copy") preserve/copy the DF
+		// bit via copy_df=yes (strongSwan cannot force DF=1).
 		{"copy", "copy", "copy_df = yes", "copy_df = no"},
-		{"set", "set", "copy_df = no", "copy_df = yes"},
-		{"clear", "clear", "", "copy_df"},
+		{"set", "set", "copy_df = yes", "copy_df = no"},
+		{"clear", "clear", "copy_df = no", "copy_df = yes"},
 		{"empty", "", "", "copy_df"},
 	}
 	for _, tt := range tests {

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -184,9 +184,22 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 				fmt.Fprintf(&b, "        rekey_time = %ds\n", espLifetime)
 				b.WriteString("        rand_time = 0s\n")
 			}
-			if vpn.DFBit == "copy" {
+			// Junos df-bit → strongSwan copy_df (outer/ESP-header DF handling).
+			// strongSwan copy_df has two states: yes (default) copies the inner
+			// DF bit to the outer header; no forces the outer DF bit to 0
+			// (XFRM_STATE_NOPMTUDISC), which allows the encapsulated packet to be
+			// fragmented. There is no "force outer DF=1" — copy_df=yes is the
+			// closest DF-preserving / PMTUD-enabling behavior.
+			//   copy  → copy_df = yes   (outer DF = inner DF)
+			//   set   → copy_df = yes   (preserve DF / keep PMTUD; can't force 1)
+			//   clear → copy_df = no    (outer DF = 0, allow fragmentation)
+			// #4015: previously "set" emitted copy_df=no (which CLEARS DF) and
+			// "clear" fell through to the default copy_df=yes, i.e. set/clear were
+			// inverted — a "df-bit clear" blackholed oversized packets via PMTUD.
+			switch vpn.DFBit {
+			case "copy", "set":
 				fmt.Fprintf(&b, "        copy_df = yes\n")
-			} else if vpn.DFBit == "set" {
+			case "clear":
 				fmt.Fprintf(&b, "        copy_df = no\n")
 			}
 			if vpn.EstablishTunnels == "immediately" {


### PR DESCRIPTION
## Summary

Fixes the inverted IPsec VPN `df-bit set` / `df-bit clear` action (fable-161 F-066, #4015). The outer/ESP-header Don't-Fragment bit ended up the opposite of what the operator configured.

## Verify-first: Go-scoped, not Rust

Traced the whole path — config parse → compile (`pkg/config/compiler_ipsec.go` stores `DFBit` verbatim) → strongSwan config generation (`pkg/ipsec/policy.go`). The df-bit action is applied **entirely in Go** via strongSwan `copy_df`. There is **no Rust dataplane involvement** (the only Rust DF logic is NAT64, unrelated). So the single point of inversion is in Go.

## The inversion

strongSwan `copy_df` has two states:
- `yes` (default) — copy the inner DF bit to the outer header (= Junos `copy`)
- `no` — force outer DF to 0 via `XFRM_STATE_NOPMTUDISC` (= Junos `clear`, allow fragmentation)

There is no "force outer DF=1", so `copy_df=yes` is the closest DF-preserving / PMTUD behavior for `set`.

The old mapping (`pkg/ipsec/policy.go`) emitted `copy_df = no` for `set` (which **clears** DF) and let `clear` fall through to the default `copy_df = yes` (which **copies/preserves** DF) — set and clear were reversed:

- `df-bit clear` (intended to allow fragmentation into a tunnel) instead preserved/set DF → oversized packets dropped with a PMTUD "fragmentation needed" → **blackhole** for large packets.
- `df-bit set` (intended to force DF / PMTUD) instead cleared it → packets silently fragmented.

Concretely (traced through the full `ParseSetCommand → CompileConfig → generateConfig` path before the fix):

| config | old strongSwan | new strongSwan |
|---|---|---|
| `df-bit copy`  | `copy_df = yes` | `copy_df = yes` |
| `df-bit set`   | `copy_df = no`  | `copy_df = yes` |
| `df-bit clear` | (default `yes`) | `copy_df = no`  |

## Fix

Single-point switch: `copy`/`set` → `copy_df = yes`, `clear` → `copy_df = no`.

## Tests (RED-on-revert)

- `TestGenerateConfig_DFBit` updated to the correct mapping — with the old branch restored, the `set` and `clear` subtests fail (verified), `copy`/`empty` stay green.
- `TestIPsecDFBitSetSyntaxCompile` added — parses `df-bit copy|set|clear` via `ParseSetCommand + tree.SetPath + CompileConfig` and asserts the stored `IPsecVPN.DFBit` (config-compile leg).

`go test ./pkg/config/... ./pkg/ipsec/...` green; `go build ./...`, `gofmt`, `go vet` clean.

## Docs

Schema desc `(copy|set)` → `(copy|set|clear)`; `docs/phases.md` df-bit entry expanded to all three modes.

Closes #4015

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi