### PR TITLE
image bake: validate before sign — a failed image is never signed (#4017)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-03 — #4017: image bake signed the appliance manifest BEFORE the validation gate → a FAILED/invalid image got a minisign signature and was publishable (false trust)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-092 (MEDIUM, build/supply-chain). In
+    `scripts/image/bake.py` the minisign SIGN step ran at export time,
+    BEFORE the in-guest verify-dataplane validation gate. A validation
+    failure aborted via `die()` (exit non-zero) but the signed
+    `xpf-<ver>.SHA256SUMS.minisig` already existed in the output dir. A
+    signature is a TRUST artifact — downstream publish
+    (`scripts/dist/publish.py`) and operators read a signed image as a
+    validated one (the #1864 secure-boot chain assumes signed ⇒ validated)
+    — so a signed-but-invalid image was publishable: false trust, worse
+    than no signature.
+  - **Fix**: reordered so VALIDATE runs strictly before SIGN. The checksum
+    manifest (SHA256SUMS) and the `.manifest` traceability record are still
+    written at export (they are not trust artifacts; publish refuses
+    unsigned trees anyway), but the `.minisig` signature is produced ONLY
+    after the validation gate returns success. Extracted three module-level
+    helpers — `validation_gate_step()`, `sign_manifest_step()`, and
+    `finalize_artifacts(validate_step, sign_step)` which enforces the
+    validate-then-sign ordering. On a gate failure `validation_gate_step`
+    calls `die()` (SystemExit, non-zero) inside `finalize_artifacts` BEFORE
+    `sign_step` is reached, so no `.minisig` is ever written for a failed
+    bake. `--skip-validate` still downgrades the gate to a loud
+    "not publishable" warning.
+  - **Test**: `scripts/image/test_bake_sign_ordering.py` (unittest, run as
+    `python3 scripts/image/test_bake_sign_ordering.py`). Drives
+    `finalize_artifacts` with injected steps: a failing validate
+    (exception AND `die()`-style SystemExit) asserts sign never runs, exits
+    non-zero, and leaves NO `.minisig` on disk; a passing validate asserts
+    sign runs after. RED-on-revert proven: swapping the two lines in
+    `finalize_artifacts` (sign before validate) fails 5 of 6 tests.
+    `python3 -m py_compile scripts/image/bake.py` clean; `go build ./...`
+    unaffected (green — Python-only change).
+  - **File(s)**: scripts/image/bake.py,
+    scripts/image/test_bake_sign_ordering.py, docs/install-images.md,
+    _Log.md
+
 ## 2026-07-03 — #4013: SNMP ifTable GETBULK/GETNEXT read the interface list (a full netlink LinkList) TWICE per returned varbind → O(N)/O(N²) RTM_GETLINK storm per SNMP walk
 
 - **Timestamp**: 2026-07-03

--- a/docs/install-images.md
+++ b/docs/install-images.md
@@ -112,10 +112,8 @@ Pipeline (offline — the image is never booted to provision it):
 5. `virt-sysprep` seal: machine-id, ssh host keys, logs, tmp files,
    bash history, package caches, random seed; `/etc/xpf` factory-empty.
 6. Export compressed qcow2 + incus metadata tarball + the per-version
-   `xpf-<ver>.SHA256SUMS` manifest, minisign-signed to
-   `xpf-<ver>.SHA256SUMS.minisig` when `XPF_SIGN_SECKEY` (a path) is set
-   (#1924). An unsigned dev bake warns "not publishable"; `make dist-publish`
-   refuses it.
+   `xpf-<ver>.SHA256SUMS` checksum manifest. The manifest is NOT signed
+   yet — signing is deferred to AFTER the validation gate (step 8, #4017).
 7. **Validation gate** (default on): the image is imported into local
    incus and the FULL first-boot matrix runs — factory boot (fxp0
    DHCP, sshd posture via `sshd -T`, -generic kernel flavor + full
@@ -125,6 +123,15 @@ Pipeline (offline — the image is never booted to provision it):
    verifier-failing shim (#1864/#1869 discipline). Use
    `--skip-validate` only for iteration; such artifacts are not
    publishable.
+8. **Sign — ONLY after validation passes (#4017):** the SHA256SUMS
+   manifest is minisign-signed to `xpf-<ver>.SHA256SUMS.minisig` when
+   `XPF_SIGN_SECKEY` (a path) is set (#1924). A signature is a TRUST
+   artifact — downstream publish (`scripts/dist/publish.py`) and
+   operators read a signed image as a validated one (#1864 secure-boot
+   chain) — so signing runs strictly AFTER the gate. A bake that FAILS
+   validation exits non-zero at step 7 and leaves NO `.minisig` behind:
+   there is never a signed-but-invalid image. An unsigned dev bake warns
+   "not publishable"; `make dist-publish` refuses it.
 
 Each bake also writes `dist/xpf-<ver>.manifest` recording the exact
 inputs (base image URL + release + verified SHA256, git commit, bake

--- a/scripts/image/bake.py
+++ b/scripts/image/bake.py
@@ -19,7 +19,9 @@ cannot move the verifier floor (#1930), networkd, init_on_alloc=0,
 `apt-get install ./xpf.deb` which stages the binaries + creates the
 /usr/local/sbin symlinks + enables the units via its postinst)
 -> virt-sysprep seal -> virt-sparsify+compress export -> checksums +
-manifest -> in-guest verify-dataplane validation gate (validate.py).
+manifest -> in-guest verify-dataplane validation gate (validate.py) ->
+minisign the manifest ONLY after the gate passes (#4017: a signature is a
+trust artifact, so a failed bake must never leave a signed image).
 
 Requirements: make/go/cargo, libguestfs-tools, qemu-utils, curl; incus for
 the validation gate. /dev/kvm makes libguestfs fast.
@@ -440,6 +442,76 @@ def virt_customize(work_qcow, xpf_deb):
     run(argv)
 
 
+def validation_gate_step(skip_validate, qcow_out, meta_out):
+    """Run the in-guest verify-dataplane validation gate (validate.py).
+
+    Aborts the bake (via die(), exit non-zero) if the gate FAILS, so a
+    validation failure stops BEFORE signing (#4017). --skip-validate
+    downgrades to a loud warning and skips the gate — the resulting
+    artifacts are marked non-publishable.
+    """
+    if skip_validate:
+        print("WARNING: --skip-validate — artifacts have NOT passed the in-guest "
+              "verify-dataplane gate; do not publish them.", file=sys.stderr)
+        return
+    info("running validation gate (factory boot + in-guest verify-dataplane + "
+         "valid/invalid day-0 drives)...")
+    if subprocess.run([sys.executable, os.path.join(HERE, "validate.py"),
+                       "--qcow2", qcow_out, "--metadata", meta_out,
+                       "all"]).returncode != 0:
+        die("validation gate FAILED — artifacts are NOT publishable")
+
+
+def sign_manifest_step(out_dir, sums, ver):
+    """Sign the checksum manifest with minisign (#1924 §5.1).
+
+    #4017: the signature is a TRUST artifact — downstream publish and
+    operators read a signed image as a validated one — so this step is
+    ordered strictly AFTER the validation gate (see finalize_artifacts). A
+    bake that fails validation never reaches this step, so no
+    signed-but-invalid image can exist. Fail-OPEN at bake (a dev bake
+    without a key still produces artifacts); fail-CLOSED at publish
+    (scripts/dist/publish.py refuses unsigned artifacts). XPF_SIGN_SECKEY
+    is a PATH to the secret key; the bytes never enter this process. The
+    pinned public key is copied into dist/ so the published tree is
+    self-describing (its trust root remains the in-repo checked-in copy,
+    not this convenience copy).
+    """
+    seckey = os.environ.get("XPF_SIGN_SECKEY")
+    if not seckey:
+        print("WARNING: XPF_SIGN_SECKEY unset — manifest NOT signed. This "
+              "dev artifact is NOT publishable; `make dist-publish` will "
+              "refuse it. Set XPF_SIGN_SECKEY=<path-to-minisign-seckey> to "
+              "sign (#1924).", file=sys.stderr)
+        return
+    try:
+        sign.require_minisign()
+        sig = sign.sign_manifest(sums, seckey,
+                                 comment=f"xpf image {ver} sha256sums")
+        info(f"signed manifest: {os.path.basename(sig)}")
+        pub_src = sign.DEFAULT_IMAGE_PUBKEY
+        if os.path.isfile(pub_src):
+            shutil.copyfile(pub_src, os.path.join(out_dir, "xpf-image.pub"))
+    except sign.SignError as e:
+        die(f"image signing FAILED: {e}")
+
+
+def finalize_artifacts(*, validate_step, sign_step):
+    """#4017 ordering invariant: VALIDATE strictly before SIGN.
+
+    Runs the validation gate first; the manifest signature (a TRUST
+    artifact — downstream publish/operators read a signed image as a good
+    one, per the #1864 secure-boot chain) is produced ONLY after the gate
+    returns success. If validate_step aborts — die()/SystemExit or any
+    exception — sign_step is never reached, so a bake that fails validation
+    leaves NO signed artifact behind. Extracted as a standalone,
+    dependency-free function so the ordering is unit-testable with injected
+    steps (scripts/image/test_bake_sign_ordering.py).
+    """
+    validate_step()
+    sign_step()
+
+
 def main():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -570,30 +642,11 @@ def main():
         info("checksums:")
         print(open(sums).read(), end="")
 
-        # Sign the manifest with minisign (#1924 §5.1). Fail-OPEN at bake
-        # (a dev bake without a key still produces artifacts), fail-CLOSED
-        # at publish (scripts/dist/publish.py refuses unsigned artifacts).
-        # XPF_SIGN_SECKEY is a PATH to the secret key; the bytes never enter
-        # this process. The pinned public key is copied into dist/ so the
-        # published tree is self-describing (its trust root remains the
-        # in-repo checked-in copy, not this convenience copy).
-        seckey = os.environ.get("XPF_SIGN_SECKEY")
-        if seckey:
-            try:
-                sign.require_minisign()
-                sig = sign.sign_manifest(sums, seckey,
-                                         comment=f"xpf image {ver} sha256sums")
-                info(f"signed manifest: {os.path.basename(sig)}")
-                pub_src = sign.DEFAULT_IMAGE_PUBKEY
-                if os.path.isfile(pub_src):
-                    shutil.copyfile(pub_src, os.path.join(a.out, "xpf-image.pub"))
-            except sign.SignError as e:
-                die(f"image signing FAILED: {e}")
-        else:
-            print("WARNING: XPF_SIGN_SECKEY unset — manifest NOT signed. This "
-                  "dev artifact is NOT publishable; `make dist-publish` will "
-                  "refuse it. Set XPF_SIGN_SECKEY=<path-to-minisign-seckey> to "
-                  "sign (#1924).", file=sys.stderr)
+        # NOTE(#4017): the manifest is SIGNED below, AFTER the validation
+        # gate — not here. The checksum manifest itself is not a trust
+        # artifact (publish refuses unsigned trees), but the .minisig
+        # signature is, so it must never exist for an image that failed the
+        # gate. See finalize_artifacts() at the end of the pipeline.
 
         try:
             commit = out_text(["git", "-C", ROOT, "rev-parse", "HEAD"]).strip()
@@ -634,16 +687,18 @@ def main():
                     + proto_lines)
         info(f"manifest: {manifest}")
 
-        # 7. validation gate
-        if a.skip_validate:
-            print("WARNING: --skip-validate — artifacts have NOT passed the in-guest "
-                  "verify-dataplane gate; do not publish them.", file=sys.stderr)
-        else:
-            info("running validation gate (factory boot + in-guest verify-dataplane + "
-                 "valid/invalid day-0 drives)...")
-            if subprocess.run([sys.executable, os.path.join(HERE, "validate.py"),
-                               "--qcow2", qcow_out, "--metadata", meta_out, "all"]).returncode != 0:
-                die(f"validation gate FAILED — artifacts in {a.out} are NOT publishable")
+        # 7. validation gate, THEN sign (#4017). The manifest signature is a
+        # TRUST artifact — downstream publish (scripts/dist/publish.py) and
+        # operators read a signed image as a validated one (#1864 secure-boot
+        # chain), so it must never exist for an image that failed the gate.
+        # finalize_artifacts enforces validate-before-sign: the gate runs
+        # first and signing happens ONLY on success. A gate failure aborts
+        # (die(), exit non-zero) BEFORE any .minisig is written.
+        finalize_artifacts(
+            validate_step=lambda: validation_gate_step(
+                a.skip_validate, qcow_out, meta_out),
+            sign_step=lambda: sign_manifest_step(a.out, sums, ver),
+        )
 
         info(f"bake complete: {qcow_out}")
         info("deploy quickstarts: docs/install-images.md")

--- a/scripts/image/test_bake_sign_ordering.py
+++ b/scripts/image/test_bake_sign_ordering.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Unit tests for the #4017 bake step ordering: VALIDATE before SIGN.
+
+The appliance bake (scripts/image/bake.py) must run the in-guest
+verify-dataplane validation gate BEFORE it minisign-signs the checksum
+manifest. The signature is a trust artifact — downstream publish
+(scripts/dist/publish.py) and operators read a signed image as a
+validated one (#1864 secure-boot chain) — so a bake that fails validation
+must NOT leave a signed .minisig behind (fable-161 F-092).
+
+These tests drive bake.finalize_artifacts() with injected validate/sign
+steps and assert the sign step never runs when validation fails. On
+revert (sign ordered before validate) the failure-path tests go RED: the
+sign step runs and a .minisig is produced despite the validation failure.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "bake", Path(__file__).with_name("bake.py")
+)
+bake = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(bake)
+
+
+class FinalizeOrderingTests(unittest.TestCase):
+    """finalize_artifacts must call validate_step, then sign_step, and must
+    never reach sign_step if validate_step aborts."""
+
+    def test_success_signs_after_validation(self):
+        calls = []
+        bake.finalize_artifacts(
+            validate_step=lambda: calls.append("validate"),
+            sign_step=lambda: calls.append("sign"),
+        )
+        # Order is load-bearing: validate strictly precedes sign.
+        self.assertEqual(calls, ["validate", "sign"])
+
+    def test_validation_exception_skips_sign(self):
+        calls = []
+
+        def validate():
+            calls.append("validate")
+            raise RuntimeError("gate failed")
+
+        def sign():
+            calls.append("sign")
+
+        with self.assertRaises(RuntimeError):
+            bake.finalize_artifacts(validate_step=validate, sign_step=sign)
+        self.assertIn("validate", calls)
+        # RED on revert (sign ordered before validate): "sign" would appear.
+        self.assertNotIn("sign", calls)
+
+    def test_validation_die_is_nonzero_and_skips_sign(self):
+        """A real gate failure aborts via bake.die() -> SystemExit non-zero,
+        BEFORE signing. Mirrors validation_gate_step()'s die() on rc != 0."""
+        calls = []
+
+        def validate():
+            calls.append("validate")
+            bake.die("validation gate FAILED — artifacts are NOT publishable")
+
+        def sign():
+            calls.append("sign")
+
+        with self.assertRaises(SystemExit) as ctx:
+            bake.finalize_artifacts(validate_step=validate, sign_step=sign)
+        # die() passes a message string to sys.exit -> non-zero process exit.
+        self.assertIsNotNone(ctx.exception.code)
+        self.assertNotEqual(ctx.exception.code, 0)
+        self.assertNotIn("sign", calls)
+
+
+class NoSignedArtifactOnValidationFailureTests(unittest.TestCase):
+    """End-to-end ordering check against the filesystem: a validation
+    failure must leave NO signed output. The sign_step here actually writes
+    a .minisig into the out dir, so a revert (sign-before-validate) leaves
+    the file on disk and the assertion goes RED."""
+
+    def _sign_step(self, out_dir, recorded):
+        def _sign():
+            recorded.append("sign")
+            # Simulate sign.sign_manifest producing the trust artifact.
+            Path(out_dir, "xpf-test.SHA256SUMS.minisig").write_text("sig\n")
+        return _sign
+
+    def test_failed_validation_leaves_no_minisig(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            recorded = []
+
+            def validate():
+                bake.die("validation gate FAILED")
+
+            with self.assertRaises(SystemExit) as ctx:
+                bake.finalize_artifacts(
+                    validate_step=validate,
+                    sign_step=self._sign_step(out_dir, recorded),
+                )
+            self.assertNotEqual(ctx.exception.code, 0)
+            self.assertNotIn("sign", recorded)
+            minisigs = [f for f in os.listdir(out_dir) if f.endswith(".minisig")]
+            # RED on revert: sign runs first and leaves a signed artifact.
+            self.assertEqual(minisigs, [], f"unexpected signed artifact: {minisigs}")
+
+    def test_passing_validation_signs_after(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            recorded = []
+            bake.finalize_artifacts(
+                validate_step=lambda: recorded.append("validate"),
+                sign_step=self._sign_step(out_dir, recorded),
+            )
+            self.assertEqual(recorded, ["validate", "sign"])
+            self.assertTrue(
+                os.path.isfile(os.path.join(out_dir, "xpf-test.SHA256SUMS.minisig"))
+            )
+
+
+class ValidationGateStepTests(unittest.TestCase):
+    """--skip-validate downgrades the gate to a warning (no die), so a bake
+    can proceed to sign; the default path dies non-zero on gate failure."""
+
+    def test_skip_validate_does_not_die(self):
+        # Should return without raising; qcow/meta paths are unused when skipped.
+        bake.validation_gate_step(True, "/nonexistent.qcow2", "/nonexistent.meta")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem (fable-161 F-092, MEDIUM — build/supply-chain)

`scripts/image/bake.py` minisign-signed the per-version `SHA256SUMS`
manifest at **export** time — BEFORE the in-guest verify-dataplane
**validation gate** (`validate.py`). On a validation failure the bake
aborted via `die()` (exit non-zero), but the signed
`xpf-<ver>.SHA256SUMS.minisig` **already existed** in the output dir.

A signature is a **trust artifact**: downstream publish
(`scripts/dist/publish.py`) and operators read a signed image as a
validated one, and the #1864 secure-boot chain assumes *signed ⇒
validated*. So a **signed-but-invalid image was publishable** — false
trust, worse than no signature.

The old source order in `main()`: write SHA256SUMS → **sign** (old L573-596)
→ write `.manifest` → **validation gate** (old L637-646, `die` on failure).

## Fix

Reorder so **VALIDATE runs strictly before SIGN**. The checksum manifest
and the `.manifest` traceability record are still written at export (not
trust artifacts; publish refuses unsigned trees), but the `.minisig`
signature is produced **only after** the gate returns success.

Three module-level helpers make the ordering explicit and unit-testable:

- `validation_gate_step(skip_validate, qcow_out, meta_out)` — runs
  `validate.py`; `die()`s (exit non-zero) on failure; `--skip-validate`
  downgrades to a loud "not publishable" warning.
- `sign_manifest_step(out_dir, sums, ver)` — the minisign step
  (unchanged fail-open-at-bake / fail-closed-at-publish semantics).
- `finalize_artifacts(validate_step, sign_step)` — enforces the
  invariant: `validate_step()` first; if it aborts (`die()`/SystemExit
  or any exception) `sign_step()` is never reached, so a failed bake
  leaves **no** signed artifact. Since signing only happens after a
  passing gate, there is no signed partial to clean up and the bake
  still exits non-zero.

## Test — RED on revert

`scripts/image/test_bake_sign_ordering.py` (unittest, run with
`python3 scripts/image/test_bake_sign_ordering.py`) drives
`finalize_artifacts` with injected steps:

- failing validate (plain exception **and** `die()`-style SystemExit) →
  asserts sign **never runs**, process exits **non-zero**, and **no
  `.minisig`** is left on disk;
- passing validate → asserts sign runs **after** validate.

RED-on-revert proven: swapping the two lines in `finalize_artifacts`
(sign before validate) fails **5 of 6** tests. `python3 -m py_compile
scripts/image/bake.py` clean; `go build ./...` unaffected (Python-only).

## Docs

`docs/install-images.md` now describes the pipeline as
export → validate → **sign (step 8)**, noting the signature must never
exist for an image that failed the gate.

Closes #4017