### PR TITLE
test/incus: lock the destructive HA smoke against the shared cluster (#4020)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ make test-deploy     # Build -> push xpfd+cli+helper (each sha256-verified ==
                      #   sbin symlinks, #2162/#2176). Override target instance with
                      #   XPF_INSTANCE=<name> (default xpf-fw).
 make test-deploy-lib # Self-test the deploy reconcile/sha-verify helpers (no VM)
+make test-cluster-lock-lib # Self-test the #1875 lock + #4020 destructive-smoke
+                     #   lock preamble (no cluster — private lock path, mocked incus)
 make test-ssh        # Shell into VM
 make test-status     # Instance + service + network info
 make test-logs       # journalctl -u xpfd -n 50
@@ -109,13 +111,19 @@ The Makefile `cluster-*` targets now default to that userspace cluster via
 older loss cluster, and set `CLUSTER_ENV=` only when intentionally exercising
 the original local `xpf-fw0/xpf-fw1` regression environment.
 
-**Cluster ownership (#1875):** the loss cluster is SHARED. Deploys and
-`apply-cos-config.sh` self-lock `/tmp/xpf-cluster.lock` (they may
-visibly queue behind another agent — wait, NEVER kill another holder,
-NEVER `rm` the lock file). Wrap multi-command work in a lock cell:
-`./test/incus/with-cluster.sh "purpose" -- cmd...`. NEVER hand-roll
-`incus file push` binary deploys — they bypass the lock and the
-verify-dataplane gate. Full protocol: `docs/engineering-style.md`.
+**Cluster ownership (#1875):** the loss cluster is SHARED. Deploys,
+`apply-cos-config.sh`, AND the destructive HA smoke targets
+(`test-failover` / `test-ha-crash` / `test-double-failover` /
+`test-stress-failover` / `test-chained-crash` / `test-active-active` /
+`test-restart-connectivity` / `test-private-rg` — they reboot /
+force-stop / fail over a node) self-lock `/tmp/xpf-cluster.lock` via the
+`cluster-cell.sh` preamble (#4020), so a reboot QUEUES behind another
+agent's deploy/smoke instead of colliding — wait, NEVER kill another
+holder, NEVER `rm` the lock file. Wrap multi-command work in a lock
+cell: `./test/incus/with-cluster.sh "purpose" -- cmd...`. NEVER
+hand-roll `incus file push` binary deploys — they bypass the lock and
+the verify-dataplane gate. `make test-cluster-lock-lib` self-tests the
+lock (no cluster). Full protocol: `docs/engineering-style.md`.
 
 ```bash
 # === SMOKE (loss userspace cluster, default for all userspace-dp validation) ===

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ clean:
 # The standalone instance name defaults to xpf-fw; override it for an
 # ad-hoc/renamed VM with `XPF_INSTANCE=<name> make test-deploy` (#2162). The
 # env var flows through to setup.sh (INSTANCE_NAME=${XPF_INSTANCE:-xpf-fw}).
-.PHONY: test-env-init test-vm standalone-test-vm test-ct test-deploy test-deploy-lib test-ssh test-destroy test-status test-start test-stop test-restart test-logs test-journal
+.PHONY: test-env-init test-vm standalone-test-vm test-ct test-deploy test-deploy-lib test-cluster-lock-lib test-ssh test-destroy test-status test-start test-stop test-restart test-logs test-journal
 
 test-env-init:
 	./test/incus/setup.sh init
@@ -232,6 +232,15 @@ test-deploy: build build-ctl
 # against a mocked fake VM. No incus, no cluster, no network — pure bash logic.
 test-deploy-lib:
 	bash ./test/incus/deploy-lib-selftest.sh
+
+# Self-test the #1875 shared-cluster lock cell (with-cluster.sh contention
+# matrix) and the #4020 destructive-smoke lock preamble (every reboot/
+# force-stop/failover smoke script routes through the lock, and the cell
+# serializes/queues/re-enters correctly). Private lock path, mocked incus —
+# no cluster, no network. Run this after touching the lock or smoke wiring.
+test-cluster-lock-lib:
+	bash ./test/incus/with-cluster-selftest.sh
+	bash ./test/incus/cluster-cell-selftest.sh
 
 test-ssh:
 	./test/incus/setup.sh ssh

--- a/_Log.md
+++ b/_Log.md
@@ -31084,3 +31084,46 @@ top.
   - **File(s)**: pkg/ipsec/policy.go, pkg/ipsec/ipsec_test.go,
     pkg/config/parser_security_test.go, pkg/config/schema_security.go,
     docs/phases.md, _Log.md
+
+- **Timestamp**: 2026-07-03
+  - **Action**: #4020 — route the destructive HA smoke targets through
+    the #1875 shared-cluster lock. The reboot / force-stop / failover
+    smoke scripts (`test-failover`, `test-ha-crash`,
+    `test-double-failover`, `test-stress-failover`, `test-chained-crash`,
+    `test-active-active`, `test-restart-connectivity`, `test-private-rg`)
+    historically took NO cluster lock — a `test-failover` that reboots
+    fw0 mid-iperf on the SHARED loss cluster could collide with a
+    concurrent agent's deploy/smoke (half-deployed node; garbage loss
+    numbers). Deploys (`cluster-setup.sh` mutating verbs) and
+    `apply-cos-config.sh` already self-lock; the destructive smoke did
+    not. New `test/incus/cluster-cell.sh` preamble exports
+    `xpf_enter_destructive_cluster_cell`, which (1) re-execs under the
+    incus-admin group forwarding BPFRX_*/XPF_* so the
+    `XPF_CLUSTER_LOCK_HELD` marker survives sg, then (2) re-execs the
+    whole script through `with-cluster.sh` when not already inside a
+    live cell — a reboot now QUEUES behind a held lock instead of
+    colliding. Each destructive script's old inline `sg incus-admin`
+    block was replaced with a source + call of the shared preamble.
+    Unconditional lock (matches `cluster-setup.sh`, which locks the
+    legacy local cluster too — single dev-box mutex, fail toward
+    serialize). Read-only `test-connectivity.sh` left lock-free. New
+    `test/incus/cluster-cell-selftest.sh` (wired as
+    `make test-cluster-lock-lib`, which also runs the previously
+    orphaned `with-cluster-selftest.sh`): STATIC RED-on-revert — asserts
+    every destructive script sources `cluster-cell.sh` and takes the
+    lock before any node mutation, and that `test-connectivity.sh` stays
+    lock-free; BEHAVIORAL — private lock path + mocked incus prove a
+    standalone run acquires the lock, a concurrent run queues (exit 75)
+    instead of colliding, and a run inside a `with-cluster.sh` cell runs
+    lock-free (reentrant, no deadlock). Verified: RED-on-revert (restore
+    one script to origin/master → static check FAILs naming it),
+    shellcheck clean on all changed scripts + the new helper/selftest,
+    `go build ./...` green. No live cluster run — script-wiring fix
+    validated by reasoning + the no-cluster self-test.
+  - **File(s)**: test/incus/cluster-cell.sh (new),
+    test/incus/cluster-cell-selftest.sh (new), test/incus/test-failover.sh,
+    test/incus/test-ha-crash.sh, test/incus/test-double-failover.sh,
+    test/incus/test-stress-failover.sh, test/incus/test-chained-crash.sh,
+    test/incus/test-active-active.sh, test/incus/test-restart-connectivity.sh,
+    test/incus/test-private-rg.sh, Makefile, docs/engineering-style.md,
+    CLAUDE.md, _Log.md

--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -420,6 +420,7 @@ they repeatedly bite:
   |---|---|
   | `cluster-setup.sh` deploy/start/stop/restart/create/destroy/init | self-locks (re-execs through `with-cluster.sh`; the build stays outside the lock) |
   | `apply-cos-config.sh` | self-locks the same way |
+  | Destructive HA smoke (`test-failover`, `test-ha-crash`, `test-double-failover`, `test-stress-failover`, `test-chained-crash`, `test-active-active`, `test-restart-connectivity`, `test-private-rg`) | self-locks the same way via the `cluster-cell.sh` preamble (#4020) — a reboot / force-stop / failover QUEUES behind a held lock instead of colliding with a concurrent deploy/smoke. Read-only `test-connectivity.sh` stays lock-free |
   | Multi-command measurement cells (deploy → apply-cos → measure) | wrap the WHOLE cell: `./test/incus/with-cluster.sh "purpose" -- cmd...` |
   | `wg-interop.sh` | self-locks per command standalone; runs lock-free inside a cell (marker-aware) |
   | Ad-hoc one-liners around commands that do NOT self-lock | `flock /tmp/xpf-cluster.lock sg incus-admin -c "..."` still valid |
@@ -441,6 +442,18 @@ they repeatedly bite:
     loops) to the cluster — they bypass the lock AND the #1864/#1869
     verify-dataplane gate. Deploys go through `cluster-setup.sh
     deploy` / `make cluster-deploy`.
+  - **Destructive HA smoke self-locks (#4020).** A `test-failover`
+    that reboots a node mid-iperf is FAR more disruptive than a
+    deploy, so the reboot/force-stop/failover smoke scripts share the
+    `cluster-cell.sh` preamble (`xpf_enter_destructive_cluster_cell`):
+    they re-exec through `with-cluster.sh` and QUEUE behind a held
+    lock rather than colliding with a concurrent agent's deploy/smoke.
+    Add a new destructive smoke script by sourcing `cluster-cell.sh`
+    in its preamble; the `make test-cluster-lock-lib` self-test (also
+    covers the `with-cluster.sh` contention matrix) asserts every
+    destructive script takes the lock before it mutates a node and
+    fails RED if one drops the wiring. No cluster needed — private
+    lock path, mocked incus.
   - Queue diagnosis: `cat /tmp/xpf-cluster.owner` +
     `fuser -v /tmp/xpf-cluster.lock`. A dead recorded pid with the
     lock still held means a child inherited the fd (pre-#1875 raw

--- a/test/incus/cluster-cell-selftest.sh
+++ b/test/incus/cluster-cell-selftest.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# #4020 — self-test for the destructive-smoke lock preamble
+# (test/incus/cluster-cell.sh, helper xpf_enter_destructive_cluster_cell).
+#
+# Two halves, both runnable ANYWHERE — no incus, no cluster, no network,
+# and NEVER touching the real /tmp/xpf-cluster.lock (a PRIVATE lock path
+# under a temp dir is used throughout):
+#
+#   STATIC   — every DESTRUCTIVE HA smoke script routes through the
+#              #1875 lock cell (sources cluster-cell.sh AND calls
+#              xpf_enter_destructive_cluster_cell in its preamble). This
+#              is the RED-on-revert guard: reverting #4020 drops the
+#              wiring and this half fails, naming the unprotected script.
+#              Read-only test-connectivity.sh must stay lock-free.
+#
+#   BEHAVIORAL — the helper actually serializes: a standalone run
+#              acquires the lock and runs its body; a second concurrent
+#              run QUEUES (blocks) behind the held lock instead of
+#              colliding; and a run already inside a with-cluster.sh
+#              cell runs lock-free (reentrant, no deadlock).
+#
+# Usage: ./test/incus/cluster-cell-selftest.sh   (rc 0 = all pass)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WC="${SCRIPT_DIR}/with-cluster.sh"
+
+PASS=0
+ok()   { PASS=$((PASS + 1)); echo "PASS ($PASS): $*"; }
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+waitfor() { # waitfor <seconds> <desc> <cmd...>
+	local n=$(( $1 * 10 )) desc="$2"; shift 2
+	while (( n-- > 0 )); do
+		if "$@" 2>/dev/null; then return 0; fi
+		sleep 0.1
+	done
+	fail "timeout waiting for: $desc"
+}
+
+# ── STATIC: every destructive smoke script routes through the lock ────
+#
+# These are the scripts whose Makefile targets reboot / force-stop /
+# fail over / restart a node on the SHARED loss cluster. Each MUST
+# source cluster-cell.sh and call the entry helper in its preamble.
+DESTRUCTIVE=(
+	test-failover.sh
+	test-ha-crash.sh
+	test-double-failover.sh
+	test-stress-failover.sh
+	test-chained-crash.sh
+	test-active-active.sh
+	test-restart-connectivity.sh
+	test-private-rg.sh
+)
+
+for s in "${DESTRUCTIVE[@]}"; do
+	p="${SCRIPT_DIR}/${s}"
+	[[ -f "$p" ]] || fail "static: missing destructive smoke script $s"
+	# The wiring must sit in the preamble (first 60 lines), BEFORE any
+	# incus mutation — assert both the source and the call are present
+	# and appear before the first destructive incus/systemctl op.
+	head_n="$(head -n 60 "$p")"
+	# Literal match of the source line — the ${...} must NOT expand.
+	# shellcheck disable=SC2016
+	grep -q 'source "\${_CELL_DIR}/cluster-cell.sh"' <<<"$head_n" \
+		|| fail "static: $s does not source cluster-cell.sh in its preamble (#4020 lock dropped?)"
+	call_line=$(grep -n 'xpf_enter_destructive_cluster_cell' "$p" | head -1 | cut -d: -f1)
+	[[ -n "$call_line" ]] \
+		|| fail "static: $s never calls xpf_enter_destructive_cluster_cell (#4020 lock dropped?)"
+	# First line that reboots / force-stops / fails over / restarts a
+	# node. The lock call must precede it so we never mutate the shared
+	# cluster before acquiring the lock. Skip comment lines so a "Phase
+	# 1: incus stop --force" doc line is not mistaken for a real op.
+	mut_line=$(awk '
+		/^[[:space:]]*#/ { next }
+		/failover reset/ { next }
+		/incus (stop|start|restart) |sysrq|systemctl (stop|restart)|request chassis cluster failover redundancy-group/ { print NR; exit }
+	' "$p" || true)
+	if [[ -n "$mut_line" ]]; then
+		(( call_line < mut_line )) \
+			|| fail "static: $s mutates the cluster (line $mut_line) before taking the lock (line $call_line)"
+	fi
+	ok "static: $s takes the #1875 lock (line $call_line) before any node mutation"
+done
+
+# Read-only connectivity test must NOT take the cluster lock (the lock
+# header forbids read-only verbs from holding it — e.g. interactive ssh).
+if grep -q 'cluster-cell.sh' "${SCRIPT_DIR}/test-connectivity.sh"; then
+	fail "static: read-only test-connectivity.sh must not take the cluster lock"
+fi
+ok "static: read-only test-connectivity.sh stays lock-free"
+
+# ── BEHAVIORAL: private lock path + fake incus, no cluster ────────────
+T=$(mktemp -d /tmp/xpf-cell-selftest.XXXXXX)
+trap 'rm -rf "$T"' EXIT
+export XPF_CLUSTER_LOCK="$T/lock"
+export XPF_CLUSTER_OWNER="$T/owner"
+
+# Fake `incus` on PATH: succeeds so the helper's incus-admin sg branch
+# is never taken (keeps the test hermetic — no group juggling, no real
+# incus). The helper then exercises the pure lock-cell logic.
+mkdir -p "$T/bin"
+cat >"$T/bin/incus" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$T/bin/incus"
+export PATH="$T/bin:$PATH"
+
+# Fixture: a stand-in destructive script. Enters the cell, then (with
+# the lock held transitively) records that it started and optionally
+# lingers so a concurrent run can observe the held lock.
+FIX="$T/fixture.sh"
+cat >"$FIX" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+_CELL_DIR="${SCRIPT_DIR}"
+# shellcheck source=/dev/null
+source "\${_CELL_DIR}/cluster-cell.sh"
+xpf_enter_destructive_cluster_cell "fixture \$*" "\$0" "\$@"
+echo started >"\${FIX_START}"
+sleep "\${FIX_SLEEP:-0}"
+STUB
+chmod +x "$FIX"
+
+# (a) standalone run acquires the lock and runs its body.
+FIX_START="$T/a.start" FIX_SLEEP=0 "$FIX" || fail "(a) standalone fixture failed"
+[[ -f "$T/a.start" ]] || fail "(a) fixture body did not run under the lock"
+[[ ! -f "$XPF_CLUSTER_OWNER" ]] || fail "(a) owner file leaked after standalone run"
+ok "standalone destructive run acquires the lock and runs its body"
+
+# (b) a second run QUEUES behind a held lock instead of colliding.
+FIX_START="$T/b.start" FIX_SLEEP=6 "$FIX" &
+B_HOLDER=$!
+waitfor 5 "holder fixture started" test -f "$T/b.start"
+set +e
+FIX_START="$T/b2.start" FIX_SLEEP=0 XPF_CLUSTER_LOCK_TIMEOUT=1 "$FIX" >"$T/b2.out" 2>&1
+B2_RC=$?
+set -e
+[[ $B2_RC -eq 75 ]] \
+	|| fail "(b) concurrent run expected to queue+timeout (75), got $B2_RC — did it collide?"
+[[ ! -f "$T/b2.start" ]] || fail "(b) queued run ran its body despite a held lock (collision!)"
+grep -q "fixture" "$T/b2.out" || fail "(b) waiter did not report the holding fixture cell"
+wait "$B_HOLDER" || true
+ok "concurrent destructive run queues behind a held lock (no collision)"
+
+# (c) reentrant: inside a with-cluster.sh cell the fixture runs
+#     lock-free (marker held) — no second acquire, no deadlock.
+set +e
+FIX_START="$T/c.start" FIX_SLEEP=0 timeout 20 "$WC" "outer cell" -- "$FIX" >"$T/c.out" 2>&1
+C_RC=$?
+set -e
+[[ $C_RC -eq 0 ]] || fail "(c) reentrant fixture inside a cell failed/deadlocked (rc=$C_RC)"
+[[ -f "$T/c.start" ]] || fail "(c) reentrant fixture body did not run"
+ok "destructive run inside a with-cluster.sh cell runs lock-free (reentrant, no deadlock)"
+
+echo "ALL ${PASS} CASES PASS"

--- a/test/incus/cluster-cell.sh
+++ b/test/incus/cluster-cell.sh
@@ -1,0 +1,90 @@
+# shellcheck shell=bash
+#
+# #1875 / #4020 — destructive-smoke lock preamble (sourced, never
+# executed).
+#
+# The DESTRUCTIVE HA smoke scripts — test-failover, test-ha-crash,
+# test-double-failover, test-stress-failover, test-chained-crash,
+# test-active-active, test-restart-connectivity, test-private-rg —
+# reboot / force-stop / fail over a node on the SHARED loss userspace
+# cluster (loss:xpf-userspace-fw0/fw1). That is FAR more disruptive
+# than a deploy, yet historically they took NO cluster lock: a reboot
+# could collide with a concurrent agent's deploy or smoke (a deploy
+# pushing binaries while a node reboots -> half-deployed node; a
+# concurrent test-failover measuring loss while another reboots ->
+# garbage results). #4020.
+#
+# This preamble serializes the destructive smoke under the SAME
+# advisory flock on /tmp/xpf-cluster.lock that cluster-setup.sh
+# mutating verbs and apply-cos-config.sh already self-lock, so a
+# test-failover QUEUES behind (or blocks on) a held lock instead of
+# colliding. It never weakens the deploy/apply-cos lock — it is the
+# identical re-exec-through-with-cluster.sh mechanism.
+#
+# Usage — source AFTER `set -euo pipefail`, BEFORE any incus/cluster
+# work, passing the script's own path + args:
+#
+#   set -euo pipefail
+#   _CELL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   # shellcheck source=cluster-cell.sh
+#   source "${_CELL_DIR}/cluster-cell.sh"
+#   xpf_enter_destructive_cluster_cell "test-failover $*" "$0" "$@"
+#
+# xpf_enter_destructive_cluster_cell <purpose> <script-path> [args...]:
+#   1. Re-execs under the incus-admin group if `incus` is not usable,
+#      forwarding BPFRX_*/XPF_* explicitly. sg env preservation is not
+#      guaranteed on every platform, and losing XPF_CLUSTER_LOCK_HELD
+#      across the sg boundary would deadlock a run started inside a
+#      with-cluster.sh cell (same reasoning as cluster-setup.sh's sg
+#      re-exec — #1875 plan A3 / SMR r2 S1).
+#   2. Serializes as a #1875 lock cell: inside a live with-cluster.sh
+#      cell (valid marker from a live ancestor holder) it returns
+#      immediately and the caller runs lock-free (cells nest); when
+#      standalone it re-execs the WHOLE script through with-cluster.sh,
+#      which blocks with a named-holder report until the cluster is
+#      ours and re-runs the script with the marker set.
+#
+# The unconditional lock matches the deploy path: cluster-setup.sh's
+# init/create/destroy/start/stop/restart take the lock for EVERY
+# cluster env (including the legacy local xpf-fw0/1), not just the
+# shared loss cluster. /tmp/xpf-cluster.lock is a single dev-box mutex;
+# taking it for the rarely-used legacy local cluster is the safe
+# direction (serialize, never collide) and needs no shared-vs-local
+# detection.
+#
+# On return the caller holds (transitively) the cluster lock for the
+# rest of its run; the kernel releases the flock when the cell's
+# process tree exits (with-cluster.sh runs the cell with fd 9 closed).
+
+_XPF_CELL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=cluster-lock.sh
+source "${_XPF_CELL_DIR}/cluster-lock.sh"
+
+xpf_enter_destructive_cluster_cell() { # <purpose> <script-path> [args...]
+	local purpose="$1"; shift
+	local script="$1"; shift
+
+	# (1) incus-admin group re-exec. Forward BPFRX_*/XPF_* explicitly
+	# so the #1875 lock marker (XPF_CLUSTER_LOCK_HELD) survives the sg
+	# env boundary — otherwise a run started inside a with-cluster.sh
+	# cell would lose the marker here and deadlock re-acquiring its own
+	# ancestor's lock.
+	if ! incus list &>/dev/null 2>&1; then
+		if getent group incus-admin &>/dev/null && id -nG | grep -qw incus-admin; then
+			local fwd="" _v
+			for _v in "${!BPFRX_@}" "${!XPF_@}"; do
+				fwd+="${_v}=$(printf '%q' "${!_v}") "
+			done
+			exec sg incus-admin -c "${fwd}$(printf '%q ' "$script" "$@")"
+		fi
+	fi
+
+	# (2) #1875 lock cell. Inside a valid, live-ancestor cell -> run
+	# lock-free; otherwise re-exec the whole script through
+	# with-cluster.sh, which blocks on a held lock (queues behind a
+	# concurrent deploy/smoke) instead of colliding with it.
+	if xpf_cluster_lock_held; then
+		return 0
+	fi
+	exec "${_XPF_CELL_DIR}/with-cluster.sh" "$purpose" -- "$script" "$@"
+}

--- a/test/incus/test-active-active.sh
+++ b/test/incus/test-active-active.sh
@@ -24,12 +24,15 @@
 
 set -euo pipefail
 
-# Re-exec under incus-admin group if needed
-if ! incus list &>/dev/null 2>&1; then
-	if getent group incus-admin &>/dev/null && id -nG | grep -qw incus-admin; then
-		exec sg incus-admin -c "$(printf '%q ' "$0" "$@")"
-	fi
-fi
+# #1875/#4020: this DESTRUCTIVE smoke reboots / force-stops / fails
+# over a node on the SHARED loss cluster. Re-exec under the
+# incus-admin group if needed, then serialize as a #1875 lock cell
+# so a concurrent deploy/smoke can't collide with our reboot (it
+# queues behind a held /tmp/xpf-cluster.lock instead of colliding).
+_CELL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=cluster-cell.sh
+source "${_CELL_DIR}/cluster-cell.sh"
+xpf_enter_destructive_cluster_cell "test-active-active $*" "$0" "$@"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=test/incus/cluster-env.sh

--- a/test/incus/test-chained-crash.sh
+++ b/test/incus/test-chained-crash.sh
@@ -25,12 +25,15 @@
 
 set -euo pipefail
 
-# Re-exec under incus-admin group if needed
-if ! incus list &>/dev/null 2>&1; then
-	if getent group incus-admin &>/dev/null && id -nG | grep -qw incus-admin; then
-		exec sg incus-admin -c "$(printf '%q ' "$0" "$@")"
-	fi
-fi
+# #1875/#4020: this DESTRUCTIVE smoke reboots / force-stops / fails
+# over a node on the SHARED loss cluster. Re-exec under the
+# incus-admin group if needed, then serialize as a #1875 lock cell
+# so a concurrent deploy/smoke can't collide with our reboot (it
+# queues behind a held /tmp/xpf-cluster.lock instead of colliding).
+_CELL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=cluster-cell.sh
+source "${_CELL_DIR}/cluster-cell.sh"
+xpf_enter_destructive_cluster_cell "test-chained-crash $*" "$0" "$@"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=test/incus/cluster-env.sh

--- a/test/incus/test-double-failover.sh
+++ b/test/incus/test-double-failover.sh
@@ -26,12 +26,15 @@
 
 set -euo pipefail
 
-# Re-exec under incus-admin group if needed
-if ! incus list &>/dev/null 2>&1; then
-	if getent group incus-admin &>/dev/null && id -nG | grep -qw incus-admin; then
-		exec sg incus-admin -c "$(printf '%q ' "$0" "$@")"
-	fi
-fi
+# #1875/#4020: this DESTRUCTIVE smoke reboots / force-stops / fails
+# over a node on the SHARED loss cluster. Re-exec under the
+# incus-admin group if needed, then serialize as a #1875 lock cell
+# so a concurrent deploy/smoke can't collide with our reboot (it
+# queues behind a held /tmp/xpf-cluster.lock instead of colliding).
+_CELL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=cluster-cell.sh
+source "${_CELL_DIR}/cluster-cell.sh"
+xpf_enter_destructive_cluster_cell "test-double-failover $*" "$0" "$@"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=test/incus/cluster-env.sh

--- a/test/incus/test-failover.sh
+++ b/test/incus/test-failover.sh
@@ -19,12 +19,15 @@
 
 set -euo pipefail
 
-# Re-exec under incus-admin group if needed
-if ! incus list &>/dev/null 2>&1; then
-	if getent group incus-admin &>/dev/null && id -nG | grep -qw incus-admin; then
-		exec sg incus-admin -c "$(printf '%q ' "$0" "$@")"
-	fi
-fi
+# #1875/#4020: this DESTRUCTIVE smoke reboots / force-stops / fails
+# over a node on the SHARED loss cluster. Re-exec under the
+# incus-admin group if needed, then serialize as a #1875 lock cell
+# so a concurrent deploy/smoke can't collide with our reboot (it
+# queues behind a held /tmp/xpf-cluster.lock instead of colliding).
+_CELL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=cluster-cell.sh
+source "${_CELL_DIR}/cluster-cell.sh"
+xpf_enter_destructive_cluster_cell "test-failover $*" "$0" "$@"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=test/incus/cluster-env.sh

--- a/test/incus/test-ha-crash.sh
+++ b/test/incus/test-ha-crash.sh
@@ -33,12 +33,15 @@
 
 set -euo pipefail
 
-# Re-exec under incus-admin group if needed
-if ! incus list &>/dev/null 2>&1; then
-	if getent group incus-admin &>/dev/null && id -nG | grep -qw incus-admin; then
-		exec sg incus-admin -c "$(printf '%q ' "$0" "$@")"
-	fi
-fi
+# #1875/#4020: this DESTRUCTIVE smoke reboots / force-stops / fails
+# over a node on the SHARED loss cluster. Re-exec under the
+# incus-admin group if needed, then serialize as a #1875 lock cell
+# so a concurrent deploy/smoke can't collide with our reboot (it
+# queues behind a held /tmp/xpf-cluster.lock instead of colliding).
+_CELL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=cluster-cell.sh
+source "${_CELL_DIR}/cluster-cell.sh"
+xpf_enter_destructive_cluster_cell "test-ha-crash $*" "$0" "$@"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=test/incus/cluster-env.sh

--- a/test/incus/test-private-rg.sh
+++ b/test/incus/test-private-rg.sh
@@ -16,12 +16,15 @@
 
 set -euo pipefail
 
-# Re-exec under incus-admin group if needed
-if ! incus list &>/dev/null 2>&1; then
-	if getent group incus-admin &>/dev/null && id -nG | grep -qw incus-admin; then
-		exec sg incus-admin -c "$(printf '%q ' "$0" "$@")"
-	fi
-fi
+# #1875/#4020: this DESTRUCTIVE smoke reboots / force-stops / fails
+# over a node on the SHARED loss cluster. Re-exec under the
+# incus-admin group if needed, then serialize as a #1875 lock cell
+# so a concurrent deploy/smoke can't collide with our reboot (it
+# queues behind a held /tmp/xpf-cluster.lock instead of colliding).
+_CELL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=cluster-cell.sh
+source "${_CELL_DIR}/cluster-cell.sh"
+xpf_enter_destructive_cluster_cell "test-private-rg $*" "$0" "$@"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=test/incus/cluster-env.sh

--- a/test/incus/test-restart-connectivity.sh
+++ b/test/incus/test-restart-connectivity.sh
@@ -20,12 +20,15 @@
 
 set -euo pipefail
 
-# Re-exec under incus-admin group if needed
-if ! incus list &>/dev/null 2>&1; then
-	if getent group incus-admin &>/dev/null && id -nG | grep -qw incus-admin; then
-		exec sg incus-admin -c "$(printf '%q ' "$0" "$@")"
-	fi
-fi
+# #1875/#4020: this DESTRUCTIVE smoke reboots / force-stops / fails
+# over a node on the SHARED loss cluster. Re-exec under the
+# incus-admin group if needed, then serialize as a #1875 lock cell
+# so a concurrent deploy/smoke can't collide with our reboot (it
+# queues behind a held /tmp/xpf-cluster.lock instead of colliding).
+_CELL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=cluster-cell.sh
+source "${_CELL_DIR}/cluster-cell.sh"
+xpf_enter_destructive_cluster_cell "test-restart-connectivity $*" "$0" "$@"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=test/incus/cluster-env.sh

--- a/test/incus/test-stress-failover.sh
+++ b/test/incus/test-stress-failover.sh
@@ -25,12 +25,15 @@
 
 set -euo pipefail
 
-# Re-exec under incus-admin group if needed
-if ! incus list &>/dev/null 2>&1; then
-	if getent group incus-admin &>/dev/null && id -nG | grep -qw incus-admin; then
-		exec sg incus-admin -c "$(printf '%q ' "$0" "$@")"
-	fi
-fi
+# #1875/#4020: this DESTRUCTIVE smoke reboots / force-stops / fails
+# over a node on the SHARED loss cluster. Re-exec under the
+# incus-admin group if needed, then serialize as a #1875 lock cell
+# so a concurrent deploy/smoke can't collide with our reboot (it
+# queues behind a held /tmp/xpf-cluster.lock instead of colliding).
+_CELL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=cluster-cell.sh
+source "${_CELL_DIR}/cluster-cell.sh"
+xpf_enter_destructive_cluster_cell "test-stress-failover $*" "$0" "$@"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=test/incus/cluster-env.sh


### PR DESCRIPTION
Closes #4020.

## Problem

The destructive HA smoke scripts — `test-failover`, `test-ha-crash`,
`test-double-failover`, `test-stress-failover`, `test-chained-crash`,
`test-active-active`, `test-restart-connectivity`, `test-private-rg` —
reboot / force-stop / fail over a node on the **SHARED** loss userspace
cluster (`loss:xpf-userspace-fw0/fw1`), yet they took **no** #1875
cluster lock.

Deploys (`cluster-setup.sh` mutating verbs) and `apply-cos-config.sh`
already self-lock `/tmp/xpf-cluster.lock` so they queue behind one
another instead of colliding. The destructive smoke did not — and a
`test-failover` that reboots fw0 mid-iperf is far more disruptive than a
deploy. If another agent was mid-deploy (pushing binaries) or mid-smoke
(measuring loss) when the reboot landed, both operations corrupted each
other's cluster state (half-deployed node; garbage loss numbers).

VERIFY-FIRST confirmed the gap: none of the destructive scripts
reference the lock (`with-cluster.sh` / `xpf_cluster_lock_held` /
`XPF_CLUSTER_LOCK`), while `cluster-setup.sh` and `apply-cos-config.sh`
both self-lock via `require_cluster_cell` / a `with-cluster.sh` re-exec.

## Fix

New `test/incus/cluster-cell.sh` preamble exports
`xpf_enter_destructive_cluster_cell`, and the eight destructive scripts
route through it (replacing each script's old inline `sg incus-admin`
block). The helper:

1. Re-execs under the incus-admin group when needed, forwarding
   `BPFRX_*`/`XPF_*` explicitly so the `XPF_CLUSTER_LOCK_HELD` marker
   survives the `sg` env boundary (losing it would deadlock a run
   started inside a `with-cluster.sh` cell — same reasoning as
   `cluster-setup.sh`'s sg re-exec).
2. Re-execs the whole script through `with-cluster.sh` when not already
   inside a live lock cell. A reboot now **queues** behind a held lock
   instead of colliding; inside an outer cell it runs lock-free (cells
   nest, so `test-private-rg`'s inner `make cluster-deploy` doesn't
   deadlock).

The lock is unconditional, matching the deploy path (`cluster-setup.sh`
locks every cluster env, including the legacy local `xpf-fw0/1` — a
single dev-box mutex, fail toward serialize). It does **not** weaken the
existing deploy/apply-cos lock — it's the identical
re-exec-through-`with-cluster.sh` mechanism. Read-only
`test-connectivity.sh` is intentionally left lock-free.

## Test (RED-on-revert, no cluster needed)

`test/incus/cluster-cell-selftest.sh`, wired as
`make test-cluster-lock-lib` (which also runs the previously unwired
`with-cluster-selftest.sh`). Private lock path + mocked incus, runnable
anywhere:

- **STATIC (RED-on-revert)** — asserts every destructive script sources
  `cluster-cell.sh` and calls the helper before the first node
  mutation, and that `test-connectivity.sh` stays lock-free. Restoring
  `test-failover.sh` to `origin/master` fails the static half with
  `does not source cluster-cell.sh in its preamble (#4020 lock
  dropped?)` — verified.
- **BEHAVIORAL** — a standalone run acquires the lock and runs its body;
  a concurrent run **queues** and times out (EX_TEMPFAIL 75) instead of
  colliding (body never runs); a run inside a `with-cluster.sh` cell
  runs lock-free (reentrant, no deadlock).

`make test-cluster-lock-lib` → `ALL 10 CASES PASS` + `ALL 12 CASES PASS`.

## Validation

- `make test-cluster-lock-lib` green (22 cases).
- shellcheck clean on `cluster-cell.sh`, `cluster-cell-selftest.sh`, and
  all eight patched scripts (no new findings; remaining SC2034/SC1091
  are pre-existing).
- `go build ./...` green (unaffected — shell/Makefile only).
- No live cluster run — script-wiring fix validated by reasoning +
  inspection + the no-cluster self-test.

Docs: `docs/engineering-style.md` #1875 table + rule, `CLAUDE.md`
cluster-ownership note + test-env list, `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
