### PR TITLE
userspace-dp: enforce zone policy on the flowless MissingNeighbor path (#4024)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,45 @@
+## 2026-07-03 — #4024: a flowless (session-less) MissingNeighbor transit packet was FIB-reinjected past the zone security policy → deny-all fail-open for flowless fragments
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-259 (MEDIUM, security fail-open). In
+    `userspace-dp` the flowless (non-first fragment / no-L4) transit path
+    enforced the zone security policy only for the `ForwardCandidate`
+    disposition (#3291), deferring `MissingNeighbor` to "its own cold-path
+    arm". That arm's #1913 policy gate is `if let Some(flow)`, which is
+    never true for a flowless packet (`flow == None`), so a flowless
+    fragment whose next-hop neighbor was unresolved fell through — no
+    policy check — to the `pending_neigh` buffer + the trailing #1913
+    slow-path reinject. Under a `deny-all` zone pair the kernel FIB then
+    forwarded the transit: a zone-policy bypass for flowless fragments (and
+    the pre-session missing-neighbor window). The route resolves (egress /
+    to-zone are known), so the policy IS evaluable; MissingNeighbor
+    (unresolved next-hop MAC) is orthogonal to permit/deny and must not be
+    a policy escape hatch.
+  - **Fix**: added an `else` (flow == None) branch to the `MissingNeighbor`
+    match arm that rebuilds the L3 tuple
+    (`frame::l3_session_flow_from_meta`) and runs the SAME
+    `evaluate_policy_result_l3_aware(.., l4_present = false)` gate the
+    flow-backed arm (#1913) and the flowless ForwardCandidate arm (#3291)
+    use — BEFORE the neg-cache probe / #1769 resolver enqueue / kernel
+    ARP-NDP probe / pending_neigh buffer / reinject. A deny emits the
+    PolicyDeny event (silent drop — a fragment has no L4 header to reject),
+    converts the disposition to `PolicyDenied` (so the #1913 reinject
+    chokepoint drops it fail-closed), and recycles the frame. A permit
+    keeps `MissingNeighbor` and takes the normal buffer-and-retry forward
+    path — no over-gating of legitimate flowless forwarding. Fail-closed:
+    an underivable L3 tuple leaves the arm on the same reinject path (only
+    reached for a permit / non-derivable case).
+  - **Tests**: `flowless_non_first_fragment_missing_neighbor_dropped_by_deny_all_4024`
+    (deny-all + flowless MissingNeighbor → policy_deny == 1, pending_neigh
+    empty; RED on revert: policy_deny == 0, buffered) and
+    `flowless_non_first_fragment_missing_neighbor_permitted_forwards_4024`
+    (an `application any` permit → not denied, still buffered for retry —
+    no over-gating). Both drive a real non-first fragment through
+    `poll_binding_process_descriptor` via `txn_run_descriptor`.
+  - **File(s)**: userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+    userspace-dp/src/afxdp/tests.rs, userspace-dp/src/afxdp/README.md,
+    _Log.md
+
 ## 2026-07-03 — #4017: image bake signed the appliance manifest BEFORE the validation gate → a FAILED/invalid image got a minisign signature and was publishable (false trust)
 
 - **Timestamp**: 2026-07-03

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -265,9 +265,23 @@ sync.
     route lookup against the override table when a PBR term matched;
     (3) zone policy via `evaluate_policy_result_l3_aware(.., l4_present =
     false)` — gated to `ForwardCandidate` (transit) so host-inbound
-    (#3292) / NoRoute / MissingNeighbor / fabric arms are untouched. A
-    non-Permit verdict is a SILENT drop (a fragment has no L4 header to
-    synthesize a TCP RST / reject from) plus a `PolicyDeny` event. The
+    (#3292) / NoRoute / fabric arms are untouched. The `MissingNeighbor`
+    flowless case is enforced separately (#4024): #3291 deferred it to
+    "its own cold-path arm", but that arm's #1913 policy gate is
+    `if let Some(flow)` and so never fired for a flowless (flow == None)
+    packet — a flowless fragment whose next-hop neighbor was unresolved
+    was FIB-reinjected and the kernel forwarded it, so a `deny-all` zone
+    pair FAILED OPEN for it. The `MissingNeighbor` arm now has an `else`
+    (flow == None) branch that rebuilds the L3 tuple
+    (`frame::l3_session_flow_from_meta`) and runs the SAME
+    `evaluate_policy_result_l3_aware(.., l4_present = false)` gate BEFORE
+    the neg-cache probe / `#1769` resolver enqueue / kernel ARP-NDP probe
+    / `pending_neigh` buffer / trailing reinject — a deny converts the
+    disposition to `PolicyDenied` so the #1913 reinject chokepoint drops
+    it fail-closed; a permit stays `MissingNeighbor` and takes the normal
+    buffer-and-retry forward path. A non-Permit verdict is a SILENT drop
+    (a fragment has no L4 header to synthesize a TCP RST / reject from)
+    plus a `PolicyDeny` event. The
     `l4_present = false` flag makes PORT-BEARING application/filter terms
     fail closed (a flowless packet's port 0 can never confirm an
     `application junos-http` or a `destination-port 80` term), while

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -3291,8 +3291,12 @@ pub(super) fn poll_binding_process_descriptor(
                     // (3) Zone security policy — only for TRANSIT
                     //     (ForwardCandidate). Local delivery (host-inbound) is
                     //     #3292; NoRoute drops anyway; MissingNeighbor keeps its
-                    //     own cold-path arm; FabricRedirect is HA peer-owned and
-                    //     enforced on the peer. A non-Permit verdict is a SILENT
+                    //     own cold-path arm, which now enforces this SAME zone
+                    //     policy on its flowless (flow == None) branch (#4024 —
+                    //     before which a flowless MissingNeighbor fragment was
+                    //     FIB-reinjected past a deny-all); FabricRedirect is HA
+                    //     peer-owned and enforced on the peer. A non-Permit
+                    //     verdict is a SILENT
                     //     drop (no L4 header to reject), with a PolicyDeny event
                     //     for observability — same record the flow-backed deny
                     //     emits, with ports = 0.
@@ -4171,13 +4175,115 @@ pub(super) fn poll_binding_process_descriptor(
                                     binding.scratch.scratch_recycle.push(desc.addr);
                                     continue;
                                 }
+                            } else {
+                                // #4024: a FLOWLESS packet (non-first fragment /
+                                // no-L4) that resolves to MissingNeighbor still
+                                // carries FULL L3 identity — src/dst/protocol/
+                                // ingress+egress zones — so it MUST pass the zone
+                                // security policy BEFORE any neighbor-resolution
+                                // side-effect (neg-cache probe, #1769 resolver
+                                // enqueue, kernel ARP/NDP probe, pending_neigh
+                                // buffer) OR the trailing slow-path reinject.
+                                //
+                                // Before #4024 the flowless case fell through
+                                // here to the reinject path (documented as
+                                // "preserving the pre-#1913 behavior — a flowless
+                                // MissingNeighbor packet was always slow-path-
+                                // eligible"). That FAILED OPEN: under a `deny-all`
+                                // zone pair, a flowless fragment whose next-hop
+                                // neighbor was unresolved was FIB-reinjected and
+                                // the kernel forwarded it — a zone-policy bypass.
+                                // #3291 enforces zone policy on the flowless
+                                // ForwardCandidate arm but deferred MissingNeighbor
+                                // to "its own cold-path arm" (this one), whose
+                                // #1913 gate is `if let Some(flow)` and so never
+                                // fired for a flowless (flow == None) packet.
+                                //
+                                // `l3_session_flow_from_meta` rebuilds the L3
+                                // tuple the shim stamped even for a fragment; the
+                                // synthetic flow is evaluated with ports = 0 /
+                                // l4_present = false, so port-bearing application
+                                // terms fail closed while address/protocol/`any`
+                                // still match — parity with the #3291 flowless
+                                // ForwardCandidate gate and the #1913 flow-backed
+                                // gate above, with no over-gating of a permitted
+                                // flowless flow. `from_zone_id`/`to_zone_id` were
+                                // resolved at the top of this arm (MissingNeighbor
+                                // has a valid egress_ifindex). A deny is a SILENT
+                                // drop — a fragment has no L4 header to synthesize
+                                // a reject from — with a PolicyDeny event for
+                                // observability, then PolicyDenied so the trailing
+                                // #1913 reinject chokepoint drops it fail-closed.
+                                if let Some(l3_flow) =
+                                    crate::afxdp::frame::l3_session_flow_from_meta(meta)
+                                {
+                                    let policy_icmp = policy_packet_icmp(packet_frame, meta);
+                                    let policy_result =
+                                        crate::policy::evaluate_policy_result_l3_aware(
+                                            &worker_ctx.forwarding.policy,
+                                            from_zone_id,
+                                            to_zone_id,
+                                            l3_flow.src_ip,
+                                            l3_flow.dst_ip,
+                                            meta.protocol,
+                                            0,
+                                            0,
+                                            policy_icmp,
+                                            desc.len as u64,
+                                            // L4 header ABSENT — port-bearing app
+                                            // terms fail closed.
+                                            false,
+                                        );
+                                    if !matches!(policy_result.action, PolicyAction::Permit) {
+                                        let owner_rg_id = owner_rg_for_resolution(
+                                            worker_ctx.forwarding,
+                                            decision.resolution,
+                                        );
+                                        emit_policy_deny_event(
+                                            worker_ctx.event_stream,
+                                            &l3_flow,
+                                            &decision.nat,
+                                            meta,
+                                            from_zone_id,
+                                            to_zone_id,
+                                            owner_rg_id,
+                                            policy_result.policy_id,
+                                            policy_result.action,
+                                            // No L4 port for a flowless packet →
+                                            // no AppID.
+                                            0,
+                                            // #3615: a flowless deny is ALWAYS a
+                                            // silent drop — no reply can be
+                                            // synthesized — so a `reject` term
+                                            // logs the truthful DENY.
+                                            false,
+                                            now_ns,
+                                        );
+                                        telemetry.dbg.policy_deny += 1;
+                                        decision.resolution.disposition =
+                                            ForwardingDisposition::PolicyDenied;
+                                        record_forwarding_disposition(
+                                            &worker_ctx.ident,
+                                            DispositionCounters::Hot(telemetry.counters),
+                                            decision.resolution,
+                                            desc.len as u32,
+                                            Some(meta),
+                                            debug.as_ref(),
+                                            worker_ctx.recent_exceptions,
+                                            worker_ctx.last_resolution,
+                                            worker_ctx.forwarding,
+                                        );
+                                        binding.scratch.scratch_recycle.push(desc.addr);
+                                        continue;
+                                    }
+                                }
+                                // Flowless permit (or no derivable L3 tuple):
+                                // fall through to the negative-cache / probe /
+                                // reinject path. A permitted flowless fragment is
+                                // legitimately forwarded once the neighbor
+                                // resolves — `MissingNeighbor` stays slow-path-
+                                // eligible for it.
                             }
-                            // No flow tuple (e.g. non-first fragment) skips
-                            // the early policy gate and falls through to the
-                            // negative-cache / probe / reinject path,
-                            // preserving the pre-#1913 behavior —
-                            // `MissingNeighbor` for a flowless packet was
-                            // always slow-path-eligible.
                             // #1651 B3: dead-host fast-fail gate. Runs at
                             // the very top of the MissingNeighbor arm,
                             // BEFORE the kernel probe, session seed, and

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -12802,6 +12802,114 @@ fn flowless_non_first_fragment_steered_by_pbr_routing_instance_3291() {
     );
 }
 
+// ---- #4024: flowless / non-first-fragment MISSING-NEIGHBOR ENFORCEMENT ----
+//
+// #3291 enforced zone policy on the flowless ForwardCandidate arm but deferred
+// MissingNeighbor to "its own cold-path arm" — whose #1913 policy gate is
+// `if let Some(flow)` and so never fired for a flowless (flow == None) packet.
+// So a flowless fragment whose next-hop neighbor was unresolved fell through to
+// the FIB reinject, and a `deny-all` zone pair FAILED OPEN for it (kernel
+// forwarded the transit). #4024 adds the flowless (flow == None) policy gate to
+// the MissingNeighbor arm. Reverting the gate flips the deny case from a
+// policy-deny drop back to a buffered-and-reinjected forward, turning the
+// asserts RED.
+
+#[test]
+fn flowless_non_first_fragment_missing_neighbor_dropped_by_deny_all_4024() {
+    // lan->wan is default-deny (policy_deny_snapshot only permits dmz->wan).
+    // With NO neighbor for 172.16.80.200 the connected WAN route resolves but
+    // ARP is unresolved -> MissingNeighbor. A flowless (non-first fragment) that
+    // hits that cold path MUST be DROPPED by zone policy, not FIB-reinjected.
+    // RED-on-revert: the flowless MissingNeighbor arm used to skip the policy
+    // gate (dbg.policy_deny == 0) and buffer the frame for retry
+    // (pending_neigh not empty) while the trailing chokepoint reinjected it.
+    let mut snapshot = policy_deny_snapshot();
+    // Empty neighbors => the WAN connected route resolves egress but no MAC =>
+    // MissingNeighbor (the cold path under test), not ForwardCandidate.
+    snapshot.neighbors.clear();
+    let forwarding = build_forwarding_state(&snapshot);
+
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 24, 0);
+    binding.interface = Arc::<str>::from("reth1.0");
+    let mut sessions = SessionTable::new();
+    let ha_state = BTreeMap::new();
+    let frame = frag_v4_transit_frame();
+    let (_batch, dbg) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        frag_v4_transit_meta(),
+    );
+
+    assert_eq!(
+        dbg.missing_neigh, 1,
+        "#4024: no neighbor for the connected WAN dst must resolve MissingNeighbor \
+         (the flowless cold path under test)"
+    );
+    assert_eq!(
+        dbg.policy_deny, 1,
+        "#4024: a deny-all zone pair must DROP a flowless MissingNeighbor fragment \
+         via the policy gate (RED on revert: 0 — flowless skipped the gate)"
+    );
+    assert!(
+        binding.pending_neigh.is_empty(),
+        "#4024: a denied flowless MissingNeighbor fragment must NOT be buffered \
+         for neighbor retry (RED on revert: buffered before the reinject leak)"
+    );
+}
+
+#[test]
+fn flowless_non_first_fragment_missing_neighbor_permitted_forwards_4024() {
+    // An `application any` permit for lan->wan must NOT deny a flowless
+    // MissingNeighbor fragment — the gate must not over-block legitimate
+    // flowless forwarding. The permitted fragment stays on the cold path
+    // (buffered for in-place retry once the neighbor resolves).
+    let mut snapshot = policy_deny_snapshot();
+    snapshot.policies = vec![PolicyRuleSnapshot {
+        name: "permit-lan-wan".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec!["any".to_string()],
+        application_terms: Vec::new(),
+        action: "permit".to_string(),
+        ..Default::default()
+    }];
+    snapshot.neighbors.clear();
+    let forwarding = build_forwarding_state(&snapshot);
+
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 24, 0);
+    binding.interface = Arc::<str>::from("reth1.0");
+    let mut sessions = SessionTable::new();
+    let ha_state = BTreeMap::new();
+    let frame = frag_v4_transit_frame();
+    let (_batch, dbg) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        frag_v4_transit_meta(),
+    );
+
+    assert_eq!(
+        dbg.missing_neigh, 1,
+        "#4024: the permitted fragment still resolves MissingNeighbor"
+    );
+    assert_eq!(
+        dbg.policy_deny, 0,
+        "#4024: an `application any` permit must not deny the flowless fragment"
+    );
+    assert!(
+        !binding.pending_neigh.is_empty(),
+        "#4024: a PERMITTED flowless MissingNeighbor fragment must still take the \
+         forward/retry path (buffered for neighbor resolution) — no over-gating"
+    );
+}
+
 // ---- #2364: seeded fabric queue hash ------------------------------------
 
 /// Build N attacker-constructible flowless v4 metas differing only in the


### PR DESCRIPTION
## Summary

Closes #4024.

A **flowless** (session-less) transit packet — a non-first fragment, or a pre-session packet whose L4 header is absent — that resolved to a `MissingNeighbor` forwarding result was **FIB-reinjected to the kernel for transit WITHOUT passing the zone security policy**. Under a `deny-all` (or any restrictive) zone pair the kernel then forwarded that traffic: a **security fail-open / policy bypass** for flowless fragments and for the pre-session missing-neighbor window.

## Root cause

- The `MissingNeighbor` match arm's #1913 policy gate is guarded by `if let Some(flow)`, which is **never true for a flowless packet** (`flow == None`).
- #3291 added zone-policy enforcement on the flowless arm but only for the `ForwardCandidate` disposition, explicitly deferring `MissingNeighbor` to *"its own cold-path arm"* — the very arm whose gate never fires for a flowless packet.
- So a flowless `MissingNeighbor` packet fell through both gates to the `pending_neigh` buffer and the trailing #1913 slow-path reinject chokepoint (`MissingNeighbor` is slow-path-eligible), and the kernel FIB forwarded it.

The route **resolves** for a `MissingNeighbor` result, so the egress interface and therefore the to-zone are known and the policy **is** evaluable. An unresolved next-hop MAC is orthogonal to permit/deny and must not be a policy escape hatch.

## Fix

`userspace-dp/src/afxdp/poll_descriptor/mod.rs` — add an `else` (`flow == None`) branch to the `MissingNeighbor` arm that rebuilds the L3 tuple via `frame::l3_session_flow_from_meta` and runs the **same** `evaluate_policy_result_l3_aware(.., l4_present = false)` gate the flow-backed arm (#1913) and the flowless `ForwardCandidate` arm (#3291) use — **before** any neighbor-resolution side effect (neg-cache probe, #1769 resolver enqueue, kernel ARP/NDP probe, `pending_neigh` buffer) and the reinject.

- Ports forced to `0` / `l4_present = false` → port-bearing application terms fail closed; address/protocol/`any` still match.
- **Deny** → emit the `PolicyDeny` event (silent drop — a fragment has no L4 header to synthesize a reject from), convert the disposition to `PolicyDenied` so the #1913 reinject chokepoint drops it fail-closed, recycle the frame.
- **Permit** → keep `MissingNeighbor` and take the normal buffer-and-retry forward path — legitimately-permitted flowless forwarding is preserved (no over-gating).
- Fail-closed: an underivable L3 tuple leaves the arm on the existing path (only reachable for a permit / non-derivable case).

## Tests (RED-on-revert)

Both drive a real non-first fragment through `poll_binding_process_descriptor` via `txn_run_descriptor`:

- `flowless_non_first_fragment_missing_neighbor_dropped_by_deny_all_4024` — deny-all + flowless `MissingNeighbor` → `policy_deny == 1` and `pending_neigh` empty. **Verified RED on revert**: neutralizing the new gate flips `policy_deny` to `0` (fell through to reinject) and the frame is buffered.
- `flowless_non_first_fragment_missing_neighbor_permitted_forwards_4024` — an `application any` permit → not denied, still buffered for retry (no over-gating).

## Validation

- Full `cargo test --release` green (lib: 3466 passed, 0 failed; all integration suites pass).
- `go build ./...` green.
- RED-on-revert confirmed by temporarily neutralizing the gate (`left: 0, right: 1` on the deny assertion).
- Docs updated: `userspace-dp/src/afxdp/README.md` flowless-enforcement section + the flowless step-(3) comment now state that `MissingNeighbor` is policy-enforced on its cold-path arm for flowless packets.

Note (for the maintainer's batch validation): this touches the session-less forwarding path; a `make test-failover` run would add confidence, though the change is drop-only for denied flowless fragments and leaves permitted/flow-backed traffic on its existing path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi