### PR TITLE
cluster: enumerate configured RGs in full-resync export (not 0..15) (#4028)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-07-03 — #4028: full-resync RG enumeration hardcoded 0..15 → RG >= 16 never resynced (fable-161 F-166)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed `handleEventStreamFullResync` enumerating owned
+    redundancy-groups with a hardcoded `for rgID := 0; rgID < 16` loop, which
+    silently skipped any configured RG with id >= 16. On a FullResync (a #2874
+    sequence gap / #2442 delta-ring overflow), that RG's owned sessions were
+    never re-exported to the standby → dropped on a failover of RG >= 16.
+    Verified genuine first: the `<group-id>` config slot has no validator and
+    is parsed via an unbounded `strconv.Atoi` (`compiler_system.go`), so RG
+    ids > 15 are configurable (Junos allows high RG ids).
+  - **Fix**: extracted `primaryOwnerRGIDs(cfg)`
+    (`pkg/daemon/daemon_ha_userspace.go`) — it walks
+    `cfg.Chassis.Cluster.RedundancyGroups` (the same live active config
+    `buildZoneIDs` reads, already in hand in the caller) and keeps every id the
+    node `IsLocalPrimary` for, skipping nil RG entries (#3494). This mirrors the
+    live-config enumeration the watchdog/fence paths use (`currentRedundancyGroups`,
+    #3917). `handleEventStreamFullResync` now calls it instead of the 0..15 loop.
+  - **File(s)**: `pkg/daemon/daemon_ha_userspace.go`,
+    `pkg/daemon/userspace_sync_test.go`, `docs/session-sync-architecture.md`,
+    `_Log.md`
+  - **Validation**: new `TestPrimaryOwnerRGIDsIncludesHighID` (RED-on-revert:
+    reverting the helper body to 0..15 yields `[0 1]`, dropping RG 20 → FAIL)
+    + `TestPrimaryOwnerRGIDsFollowsConfigAndOwnership` (config/ownership filter,
+    nil-RG skip, nil-cluster/nil-config → nil). `go test ./pkg/cluster/...
+    ./pkg/daemon/...` green, `-race` on the resync/enum tests green,
+    `go build ./...` + gofmt + vet clean. HA session-sync change — test-failover
+    warranted (batch-validated).
+
 ## 2026-07-03 — #4021: interface-level class-of-service binding was silently dropped (fable-161 F-028)
 
 - **Timestamp**: 2026-07-03

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -402,6 +402,19 @@ event stream signals a FullResync after a #2874 sequence gap or a #2442
 delta-ring overflow (loss-of-sync), and the export republishes the full owned set
 from table truth. It is not the same thing as the steady-state delta drain.
 
+The `rgIDs` handed to the export are enumerated from the **configured
+redundancy-group set** — `handleEventStreamFullResync` calls
+`primaryOwnerRGIDs(cfg)`, which walks `cfg.Chassis.Cluster.RedundancyGroups`
+(the same live active config `buildZoneIDs` reads) and keeps every id the node
+is `IsLocalPrimary` for. It does **not** iterate a fixed `0..15` range. Junos
+redundancy-group ids are not bounded to 15 (the `<group-id>` config slot has no
+validator and is parsed via an unbounded `strconv.Atoi`), so the old hardcoded
+`for rgID := 0; rgID < 16` loop silently skipped any RG with id >= 16 — its
+owned sessions were never re-exported on a FullResync, so the standby never
+received them and they were dropped on a failover of that RG (#4028). This
+mirrors the live-config enumeration the watchdog/fence paths use
+(`currentRedundancyGroups`, #3917).
+
 **The export ack-wait runs OFF the global `ServerState` lock (#2962).** The
 helper-side control-socket dispatcher (`server/handlers/mod.rs`) holds a single
 `Mutex<ServerState>` across its request `match`, which serializes every control

--- a/pkg/daemon/daemon_ha_userspace.go
+++ b/pkg/daemon/daemon_ha_userspace.go
@@ -658,12 +658,7 @@ func (d *Daemon) handleEventStreamFullResync() bool {
 	if cfg == nil {
 		return false
 	}
-	var rgIDs []int
-	for rgID := 0; rgID < 16; rgID++ {
-		if d.cluster.IsLocalPrimary(rgID) {
-			rgIDs = append(rgIDs, rgID)
-		}
-	}
+	rgIDs := d.primaryOwnerRGIDs(cfg)
 	if len(rgIDs) == 0 {
 		return false
 	}
@@ -864,6 +859,33 @@ func (d *Daemon) drainUserspaceSessionDeltasWithConfig(
 		}
 	}
 	return total, nil
+}
+
+// primaryOwnerRGIDs returns the redundancy-group IDs in cfg for which this node
+// is the local primary. It enumerates the ACTUAL configured redundancy groups
+// (from cfg, the same active config the zone IDs are built from) rather than a
+// hardcoded 0..15 range. Junos redundancy-group ids are not bounded to 15 (the
+// `<group-id>` config slot has no validator and is parsed via an unbounded
+// strconv.Atoi), so a hardcoded 0..15 loop silently skipped any RG with id >=
+// 16 — its owned sessions were never re-exported on a full resync, so the
+// standby never received them and they were dropped on failover of that RG
+// (#4028). Reading the configured RG set closes that hole for every id.
+// Returns nil when there is no cluster manager or the config has no cluster/RGs;
+// every caller must tolerate an empty slice. Nil RG entries (#3494) are skipped.
+func (d *Daemon) primaryOwnerRGIDs(cfg *config.Config) []int {
+	if d.cluster == nil || cfg == nil || cfg.Chassis.Cluster == nil {
+		return nil
+	}
+	var rgIDs []int
+	for _, rg := range cfg.Chassis.Cluster.RedundancyGroups {
+		if rg == nil {
+			continue
+		}
+		if d.cluster.IsLocalPrimary(rg.ID) {
+			rgIDs = append(rgIDs, rg.ID)
+		}
+	}
+	return rgIDs
 }
 
 func (d *Daemon) exportUserspaceOwnerRGSessionsWithConfig(

--- a/pkg/daemon/userspace_sync_test.go
+++ b/pkg/daemon/userspace_sync_test.go
@@ -882,6 +882,91 @@ func TestHandleEventStreamFullResyncRequiresHAReady(t *testing.T) {
 	}
 }
 
+// clusterManagerPrimaryForRGs builds a standalone cluster.Manager (no control
+// interface) that elects the local node primary for every listed RG id. With no
+// control interface, electSingleNode() promotes every weight>0 RG immediately,
+// so IsLocalPrimary(id) is true for each configured id.
+func clusterManagerPrimaryForRGs(ids ...int) *cluster.Manager {
+	m := cluster.NewManager(0, 1)
+	rgs := make([]*config.RedundancyGroup, 0, len(ids))
+	for _, id := range ids {
+		rgs = append(rgs, &config.RedundancyGroup{
+			ID:             id,
+			NodePriorities: map[int]int{0: 200},
+			Preempt:        true,
+		})
+	}
+	m.UpdateConfig(&config.ClusterConfig{RethCount: 1, RedundancyGroups: rgs})
+	return m
+}
+
+// TestPrimaryOwnerRGIDsIncludesHighID is the #4028 RED-on-revert guard: the
+// full-resync RG enumeration must follow the configured redundancy-group set,
+// not a hardcoded 0..15 range. A cluster with an RG id >= 16 must have that RG
+// enumerated so its sessions are re-exported to the standby on a full resync.
+// Reverting primaryOwnerRGIDs to the old `for rgID := 0; rgID < 16` loop drops
+// RG 20 here and turns this test RED.
+func TestPrimaryOwnerRGIDsIncludesHighID(t *testing.T) {
+	d := &Daemon{cluster: clusterManagerPrimaryForRGs(0, 1, 20)}
+	// Sanity: the manager must actually consider the node primary for RG 20.
+	if !d.cluster.IsLocalPrimary(20) {
+		t.Fatal("test setup: node should be primary for RG 20")
+	}
+
+	cfg := &config.Config{}
+	cfg.Chassis.Cluster = &config.ClusterConfig{
+		RethCount: 1,
+		RedundancyGroups: []*config.RedundancyGroup{
+			{ID: 0}, {ID: 1}, {ID: 20},
+		},
+	}
+
+	got := d.primaryOwnerRGIDs(cfg)
+	want := map[int]bool{0: true, 1: true, 20: true}
+	if len(got) != len(want) {
+		t.Fatalf("primaryOwnerRGIDs() = %v, want ids %v", got, want)
+	}
+	for _, id := range got {
+		if !want[id] {
+			t.Fatalf("primaryOwnerRGIDs() returned unexpected RG %d (got %v)", id, got)
+		}
+		delete(want, id)
+	}
+	if len(want) != 0 {
+		t.Fatalf("primaryOwnerRGIDs() missing RGs %v (got %v) — RG >= 16 skipped?", want, got)
+	}
+}
+
+// TestPrimaryOwnerRGIDsFollowsConfigAndOwnership verifies the enumeration only
+// returns configured RGs the node owns, skips nil entries (#3494), and returns
+// nil when there is no cluster or no cluster config.
+func TestPrimaryOwnerRGIDsFollowsConfigAndOwnership(t *testing.T) {
+	// Node owns RG 0 and 20, but the config only lists 0 and 5. RG 5 is not
+	// owned, RG 20 is owned but not configured — neither should appear.
+	d := &Daemon{cluster: clusterManagerPrimaryForRGs(0, 20)}
+	cfg := &config.Config{}
+	cfg.Chassis.Cluster = &config.ClusterConfig{
+		RedundancyGroups: []*config.RedundancyGroup{
+			{ID: 0},
+			nil, // #3494: nil RG entry must not panic and must be skipped
+			{ID: 5},
+		},
+	}
+	got := d.primaryOwnerRGIDs(cfg)
+	if len(got) != 1 || got[0] != 0 {
+		t.Fatalf("primaryOwnerRGIDs() = %v, want [0]", got)
+	}
+
+	// No cluster manager → nil.
+	if ids := (&Daemon{}).primaryOwnerRGIDs(cfg); ids != nil {
+		t.Fatalf("primaryOwnerRGIDs() with nil cluster = %v, want nil", ids)
+	}
+	// No cluster config → nil.
+	if ids := d.primaryOwnerRGIDs(&config.Config{}); ids != nil {
+		t.Fatalf("primaryOwnerRGIDs() with no cluster config = %v, want nil", ids)
+	}
+}
+
 func TestWireUserspaceEventStreamCallbacksStandaloneWiresSessionAndFullResync(t *testing.T) {
 	socketPath := filepath.Join(t.TempDir(), "events.sock")
 	es := dpuserspace.NewEventStream(socketPath)


### PR DESCRIPTION
## Summary

`handleEventStreamFullResync` (the HA full session-resync handler on the
event-stream path) built its owned-RG list with a hardcoded
`for rgID := 0; rgID < 16` loop, so any configured redundancy-group with an
id **>= 16 was silently skipped**. On a FullResync (a #2874 event-stream
sequence gap or a #2442 delta-ring overflow) the export republishes the full
owned session set from table truth to the standby — but with the 0..15 cap,
sessions owned by an RG with id >= 16 were never re-exported. The standby held
no synced state for that RG, and on a **failover of RG >= 16 those connections
were dropped**.

## Genuine? Yes — RG >= 16 is configurable

The `redundancy-group <group-id>` config slot has **no validator** (`schema_chassis.go`)
and the id is parsed via an unbounded `strconv.Atoi` (`compiler_system.go`),
and Junos permits high RG ids. So a cluster using an RG id above 15 has a real
silent session-sync hole.

## Fix

Extract `primaryOwnerRGIDs(cfg)` (`pkg/daemon/daemon_ha_userspace.go`), which
walks the **configured** redundancy-group set (`cfg.Chassis.Cluster.RedundancyGroups`
— the same live active config `buildZoneIDs` already reads in the caller) and
keeps every id the node is `IsLocalPrimary` for, skipping nil RG entries (#3494).
`handleEventStreamFullResync` now calls it instead of the fixed 0..15 loop, so
every configured RG re-exports on a full resync regardless of id. This mirrors
the live-config enumeration the watchdog / peer-fence paths use
(`currentRedundancyGroups`, #3917). Behavior for RGs 0..15 is unchanged.

## Validation

- **RED-on-revert:** `TestPrimaryOwnerRGIDsIncludesHighID` — reverting the
  helper body to the old `0..15` loop returns `[0 1]`, dropping RG 20, and the
  test FAILS (proven). Restored → passes.
- `TestPrimaryOwnerRGIDsFollowsConfigAndOwnership` — config/ownership filter,
  nil-RG skip, nil-cluster / nil-config → nil.
- `go test ./pkg/cluster/... ./pkg/daemon/...` green; `-race` on the resync/enum
  tests green; `go build ./...` + gofmt + vet clean.
- Doc updated: `docs/session-sync-architecture.md` "Bulk Owner-RG Export".
- **HA session-sync change — `make test-failover` warranted** (flagged for batch validation).

Closes #4028

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi