### PR TITLE
config: expand interfaces interface-range into member interfaces (#4027)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-03 — #4027: `interfaces interface-range` created a phantom admin-down interface and dropped member config (fable-161 F-029)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed the compiler mishandling `interfaces interface-range
+    <name> { member <if>; <shared cfg> }`. Verified first with a scratch
+    repro (ParseSetCommand + tree.SetPath): the generic `interfaces` wildcard
+    treated `interface-range` as an interface NAME, so the compiler minted a
+    PHANTOM `InterfaceConfig` keyed `interface-range` (matching no kernel NIC,
+    later reconciled admin-down) while the shared config (mtu, unit/family
+    addresses) AND the member interfaces themselves were silently dropped — a
+    genuine config-parity defect (interface-range was entirely unimplemented,
+    only referenced in a Junos help-text doc).
+  - **Fix**: added `expandInterfaceRanges` (`compiler_interface_range.go`), an
+    AST pre-pass called in `compileExpanded` BEFORE section compilation and the
+    H9/H10 unsupported-stanza gate. It rewrites every interface-range stanza
+    into its member interfaces: the range's shared statements are flattened to
+    `set`-command suffixes and replayed through `ConfigTree.SetPath` under each
+    member's name (schema-driven re-nesting, so compileInterfaces reads them
+    identically to a normal per-interface config), merged with the member's own
+    config re-applied LAST so member-local knobs win on a scalar conflict while
+    additive statements (addresses) accumulate. `member-range <a> to <b>`
+    expands over the trailing decimal (prefix-shared, capped). Handles both the
+    flat-set (range name in each leaf's Keys[0]) and hierarchical (range name in
+    the node's Keys[1]) AST shapes, mutates the group-expanded/inactive-pruned
+    clone in place, and is a strict no-op when no interface-range is present.
+    No networkd change needed — the phantom never reaches the reconcile because
+    it never enters the compiled `cfg.Interfaces`.
+  - **File(s)**: pkg/config/compiler_interface_range.go,
+    pkg/config/compiler.go,
+    pkg/config/compiler_interface_range_4027_test.go,
+    docs/config-schema.md
+  - **Validation**: new config tests (member expansion + NO phantom; shared
+    unit/family deep-apply; member override precedence + address accumulation;
+    hierarchical shape; member-range; multiple flat-set ranges; no-stanza
+    no-op) — all RED on revert of the expansion pass except the no-op test.
+    `go test ./pkg/config/... ./pkg/networkd/...` green, `go build ./...`,
+    gofmt, vet clean.
+
 ## 2026-07-03 — #4021: interface-level class-of-service binding was silently dropped (fable-161 F-028)
 
 - **Timestamp**: 2026-07-03

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1625,6 +1625,36 @@ reserved for whole-dataplane selection where a rewrite shim
   no-op knob, not a false dataplane/identity promise — and its real
   implementation is split to /research. Regression coverage:
   `pkg/config/compiler_interfaces_unsupported_test.go`.
+- **#4027 (interface-range expansion):** `interfaces interface-range
+  <name> { member <if>; [member-range <a> to <b>;] <shared cfg> }` is a
+  Junos construct that applies a shared configuration block to a SET of
+  member interfaces. Before the fix xpf had no handling: the generic
+  `interfaces` wildcard treated `interface-range` itself as an interface
+  NAME, so the compiler minted a PHANTOM `InterfaceConfig` keyed
+  `interface-range` (matching no kernel NIC, later reconciled admin-down)
+  and both the shared config and the member interfaces were silently
+  dropped. `expandInterfaceRanges` (`compiler_interface_range.go`) now
+  rewrites every interface-range stanza into its member interfaces as an
+  AST pre-pass in `compileExpanded`, BEFORE section compilation and the
+  H9/H10 gate above (so both see the real members, never the phantom).
+  Each member gets the range's shared statements — flattened to
+  `set`-command suffixes and replayed through `ConfigTree.SetPath`, so
+  they re-nest with the exact schema-driven shape a normal per-interface
+  config would have — merged with the member's own per-interface config:
+  the member's own statements are re-applied LAST so they WIN on a scalar
+  conflict (e.g. a member-local `mtu` overrides the range `mtu`) while
+  additive statements (addresses) accumulate. `member-range <a> to <b>`
+  expands over the trailing decimal (endpoints must share a prefix; capped
+  at `interfaceRangeMaxMembers` to bound a typo). The pass handles BOTH AST
+  shapes (flat-set replay packs the range name into each leaf's `Keys[0]`;
+  the hierarchical parser packs it into the `interface-range` node's
+  `Keys[1]`) and is a strict no-op — the tree is left byte-identical —
+  when no interface-range stanza is present. This is a compile-time AST
+  rewrite, not a `setSchema` change: adding schema children for `member` /
+  `member-range` would alter the flat-set grouping the expansion depends
+  on, so the construct stays out of the grammar SSOT and is normalized
+  before any typed-leaf walk. Regression coverage:
+  `pkg/config/compiler_interface_range_4027_test.go`.
 - **#3444 (destination-NAT rule-set `to` scope reject):** a Junos
   destination-NAT rule-set has only a `from` clause (zone | interface |
   routing-instance) — DNAT translates the destination on inbound, so there

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1805,6 +1805,17 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		return nil, err
 	}
 
+	// #4027 interface-range expansion. Rewrites every `interfaces
+	// interface-range <name> { member <if>; <shared cfg> }` stanza into its
+	// member interfaces BEFORE section compilation (and before the
+	// unsupported-stanza gate below, so that gate and compileInterfaces both
+	// see the expanded members, not a phantom "interface-range" interface).
+	// Runs on the group-expanded, inactive-pruned clone (apply-groups-
+	// inherited ranges expanded; `inactive:` ranges already stripped) and
+	// MUTATES the clone in place. A config with no interface-range stanza is
+	// left byte-identical. See compiler_interface_range.go.
+	ifaceRangeWarnings := expandInterfaceRanges(tree)
+
 	// #2008 H9/H10 interface silent-drop gate. Runs on the group-expanded,
 	// inactive-pruned tree (apply-groups-inherited stanzas covered;
 	// `inactive:` stanzas already stripped upstream) and BEFORE section
@@ -2042,6 +2053,7 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	cfg.Warnings = append(cfg.Warnings, flowTraceFileWarnings...)
 	cfg.Warnings = append(cfg.Warnings, flowTraceFilterWarnings...)
 	cfg.Warnings = append(cfg.Warnings, flowTraceSizeWarnings...)
+	cfg.Warnings = append(cfg.Warnings, ifaceRangeWarnings...)
 	cfg.Warnings = append(cfg.Warnings, unsupportedIfaceWarnings...)
 	cfg.Warnings = append(cfg.Warnings, appCollisionWarnings...)
 	cfg.Warnings = append(cfg.Warnings, fwFilterFamilyWarnings...)

--- a/pkg/config/compiler_interface_range.go
+++ b/pkg/config/compiler_interface_range.go
@@ -1,0 +1,311 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// compiler_interface_range.go implements the #4027 interface-range
+// expansion pre-pass.
+//
+// Junos `interfaces interface-range <name> { member <if>; ... }` groups a
+// SET of member interfaces so a common block of configuration is applied to
+// each one at once. Before this pass xpf had no interface-range handling:
+// the generic `interfaces` wildcard treated `interface-range` itself as an
+// interface NAME, so the compiler minted a PHANTOM InterfaceConfig keyed
+// "interface-range" (matching no kernel NIC, later reconciled admin-down) and
+// the range's shared configuration — plus the member interfaces themselves —
+// were silently dropped.
+//
+// expandInterfaceRanges rewrites every interface-range stanza into its member
+// interfaces BEFORE section compilation: each member interface gets the
+// range's shared configuration, merged with the member's own per-interface
+// configuration (the member's own statements win on a scalar conflict), and
+// no interface named after the range survives. It runs in compileExpanded on
+// the group-expanded, inactive-pruned clone (so an apply-groups-inherited
+// interface-range is expanded and an `inactive:` range is ignored for free),
+// and it MUTATES the clone in place — the caller's tree is untouched.
+//
+// The rewrite is done by flattening the range's shared statements into
+// `set`-command token suffixes and replaying them through ConfigTree.SetPath
+// under each member's name. SetPath re-nests the tokens with the exact
+// schema-driven shape a normal per-interface config would have, so the
+// downstream compileInterfaces reads them identically whether they arrived
+// via a real interface stanza or an interface-range — and both the flat-set
+// (`set interfaces interface-range R member geX`) and the hierarchical
+// (`interface-range R { member geX; ... }`) AST shapes normalize to the same
+// member interfaces.
+
+// interfaceRangeDef is one parsed `interface-range <name>` definition: its
+// member interface names and the shared configuration statements (each a
+// `set`-command token suffix, i.e. the tokens that would follow
+// `set interfaces <member>`).
+type interfaceRangeDef struct {
+	name    string
+	members []string
+	shared  [][]string
+}
+
+// expandInterfaceRanges expands every `interfaces interface-range` stanza in
+// the tree into its member interfaces (#4027). It mutates tree in place and
+// returns operator-visible warnings (malformed range, member-range that
+// cannot be expanded, a range with no members). It is a no-op — returning nil
+// and leaving the tree byte-identical — when there is no interface-range
+// stanza, so a config without the construct is unaffected.
+func expandInterfaceRanges(tree *ConfigTree) []string {
+	var ifaces *Node
+	for _, n := range tree.Children {
+		if n.Name() == "interfaces" {
+			ifaces = n
+			break
+		}
+	}
+	if ifaces == nil {
+		return nil
+	}
+
+	// Separate interface-range definitions from real interface children.
+	var ranges []interfaceRangeDef
+	var warnings []string
+	sawRange := false
+	kept := make([]*Node, 0, len(ifaces.Children))
+	for _, child := range ifaces.Children {
+		if child.Name() != "interface-range" {
+			kept = append(kept, child)
+			continue
+		}
+		sawRange = true
+		if len(child.Keys) >= 2 {
+			// Hierarchical: Keys=["interface-range", <name>], children are
+			// the member/config nodes directly.
+			rd, w := parseHierInterfaceRange(child)
+			warnings = append(warnings, w...)
+			if rd != nil {
+				ranges = append(ranges, *rd)
+			}
+		} else {
+			// Flat-set: Keys=["interface-range"], each child is a leaf whose
+			// Keys[0] is the range name and Keys[1:] the config statement.
+			rds, w := parseFlatInterfaceRanges(child)
+			warnings = append(warnings, w...)
+			ranges = append(ranges, rds...)
+		}
+	}
+	if !sawRange {
+		// No interface-range stanza present — leave the tree untouched.
+		return nil
+	}
+	// Strip every interface-range node so the range name is never compiled as
+	// a phantom interface, even if the stanza was malformed and yielded no
+	// expandable range.
+	ifaces.Children = kept
+
+	// Build the ordered, de-duplicated member set and, per member, the
+	// concatenation of every containing range's shared statements (range
+	// definition order preserved).
+	memberShared := map[string][][]string{}
+	inRange := map[string]bool{}
+	var memberOrder []string
+	for _, rd := range ranges {
+		if len(rd.members) == 0 {
+			warnings = append(warnings, fmt.Sprintf(
+				"interfaces interface-range %s: no members; shared configuration is not applied to any interface",
+				rd.name))
+			continue
+		}
+		for _, m := range rd.members {
+			if m == "" {
+				continue
+			}
+			if !inRange[m] {
+				inRange[m] = true
+				memberOrder = append(memberOrder, m)
+			}
+			memberShared[m] = append(memberShared[m], rd.shared...)
+		}
+	}
+
+	// Snapshot and remove each member's existing explicit interface node so
+	// its own statements can be re-applied LAST — SetPath replaces a
+	// single-value leaf (e.g. mtu), so applying shared config first and the
+	// member's own config last gives the member precedence on a conflict
+	// while additive statements (addresses) accumulate.
+	memberOwn := map[string][][]string{}
+	remaining := ifaces.Children[:0]
+	for _, child := range ifaces.Children {
+		name := child.Name()
+		if inRange[name] && !child.IsLeaf {
+			memberOwn[name] = flattenNodesToPaths(child.Children, nil)
+			continue
+		}
+		remaining = append(remaining, child)
+	}
+	ifaces.Children = remaining
+
+	for _, m := range memberOrder {
+		for _, p := range memberShared[m] {
+			if err := tree.SetPath(append([]string{"interfaces", m}, p...)); err != nil {
+				warnings = append(warnings, fmt.Sprintf(
+					"interfaces interface-range: applying shared config to %s: %v", m, err))
+			}
+		}
+		for _, p := range memberOwn[m] {
+			if err := tree.SetPath(append([]string{"interfaces", m}, p...)); err != nil {
+				warnings = append(warnings, fmt.Sprintf(
+					"interfaces %s: re-applying member config: %v", m, err))
+			}
+		}
+	}
+	return warnings
+}
+
+// parseHierInterfaceRange parses a hierarchical `interface-range <name> { ... }`
+// node (Keys=["interface-range", <name>]) into an interfaceRangeDef.
+func parseHierInterfaceRange(node *Node) (*interfaceRangeDef, []string) {
+	if len(node.Keys) < 2 {
+		return nil, []string{"interfaces interface-range: definition with no name; ignored"}
+	}
+	rd := &interfaceRangeDef{name: node.Keys[1]}
+	var warnings []string
+	for _, c := range node.Children {
+		switch c.Name() {
+		case "member":
+			// `member <if>` or bracketed `member [ a b ]` — every name lands
+			// on Keys[1:] (flat-set replay may also split trailing names into
+			// leaf children).
+			for _, m := range c.Keys[1:] {
+				if m != "" {
+					rd.members = append(rd.members, m)
+				}
+			}
+			for _, ch := range c.Children {
+				if n := ch.Name(); n != "" {
+					rd.members = append(rd.members, n)
+				}
+			}
+		case "member-range":
+			ms, w := expandMemberRange(rd.name, c.Keys[1:])
+			rd.members = append(rd.members, ms...)
+			warnings = append(warnings, w...)
+		default:
+			rd.shared = append(rd.shared, flattenNodesToPaths([]*Node{c}, nil)...)
+		}
+	}
+	return rd, warnings
+}
+
+// parseFlatInterfaceRanges parses the flat-set `interface-range` node
+// (Keys=["interface-range"], children are per-statement leaves prefixed by
+// the range name) into one interfaceRangeDef per distinct range name,
+// preserving first-seen order.
+func parseFlatInterfaceRanges(node *Node) ([]interfaceRangeDef, []string) {
+	byName := map[string]*interfaceRangeDef{}
+	var order []string
+	var warnings []string
+	for _, c := range node.Children {
+		if len(c.Keys) < 2 {
+			warnings = append(warnings,
+				"interfaces interface-range: malformed entry (no range name); ignored")
+			continue
+		}
+		rname := c.Keys[0]
+		tokens := c.Keys[1:]
+		rd := byName[rname]
+		if rd == nil {
+			rd = &interfaceRangeDef{name: rname}
+			byName[rname] = rd
+			order = append(order, rname)
+		}
+		switch tokens[0] {
+		case "member":
+			for _, m := range tokens[1:] {
+				if m != "" {
+					rd.members = append(rd.members, m)
+				}
+			}
+		case "member-range":
+			ms, w := expandMemberRange(rname, tokens[1:])
+			rd.members = append(rd.members, ms...)
+			warnings = append(warnings, w...)
+		default:
+			rd.shared = append(rd.shared, append([]string(nil), tokens...))
+		}
+	}
+	out := make([]interfaceRangeDef, 0, len(order))
+	for _, n := range order {
+		out = append(out, *byName[n])
+	}
+	return out, warnings
+}
+
+// interfaceRangeMaxMembers caps a single member-range expansion so a typo
+// like `member-range ge-0/0/0 to ge-0/0/999999` cannot mint a runaway
+// interface list.
+const interfaceRangeMaxMembers = 4096
+
+// expandMemberRange expands a `member-range <start> to <end>` selector into
+// the individual member names. start and end must share a common prefix and
+// differ only in a trailing decimal number (e.g. ge-0/0/1 to ge-0/0/4). An
+// unparseable or inverted range is skipped with a warning.
+func expandMemberRange(rangeName string, toks []string) ([]string, []string) {
+	if len(toks) != 3 || toks[1] != "to" {
+		return nil, []string{fmt.Sprintf(
+			"interfaces interface-range %s: malformed member-range (expected `<start> to <end>`); ignored",
+			rangeName)}
+	}
+	start, end := toks[0], toks[2]
+	sp, sn, ok1 := splitTrailingInt(start)
+	ep, en, ok2 := splitTrailingInt(end)
+	if !ok1 || !ok2 || sp != ep || sn > en {
+		return nil, []string{fmt.Sprintf(
+			"interfaces interface-range %s: cannot expand member-range %s to %s "+
+				"(endpoints must share a prefix and differ only in a trailing number); ignored",
+			rangeName, start, end)}
+	}
+	if en-sn+1 > interfaceRangeMaxMembers {
+		return nil, []string{fmt.Sprintf(
+			"interfaces interface-range %s: member-range %s to %s exceeds %d interfaces; ignored",
+			rangeName, start, end, interfaceRangeMaxMembers)}
+	}
+	out := make([]string, 0, en-sn+1)
+	for i := sn; i <= en; i++ {
+		out = append(out, fmt.Sprintf("%s%d", sp, i))
+	}
+	return out, nil
+}
+
+// splitTrailingInt splits s into a leading prefix and a trailing decimal
+// number (e.g. "ge-0/0/12" -> "ge-0/0/", 12). ok is false when s has no
+// trailing digit run or the digits do not parse as an int.
+func splitTrailingInt(s string) (prefix string, num int, ok bool) {
+	i := len(s)
+	for i > 0 && s[i-1] >= '0' && s[i-1] <= '9' {
+		i--
+	}
+	if i == len(s) {
+		return "", 0, false
+	}
+	n, err := strconv.Atoi(s[i:])
+	if err != nil {
+		return "", 0, false
+	}
+	return s[:i], n, true
+}
+
+// flattenNodesToPaths flattens a list of AST nodes into `set`-command token
+// suffixes: each leaf (or empty container) yields one token slice of its full
+// key path from the given prefix. It is the inverse of ConfigTree.SetPath's
+// re-nesting and mirrors formatSetNodes, so a member's own config and a
+// range's hierarchical shared config can both be replayed through SetPath.
+func flattenNodesToPaths(nodes []*Node, prefix []string) [][]string {
+	var out [][]string
+	for _, c := range nodes {
+		path := append(append([]string(nil), prefix...), c.Keys...)
+		if c.IsLeaf || len(c.Children) == 0 {
+			out = append(out, path)
+			continue
+		}
+		out = append(out, flattenNodesToPaths(c.Children, path)...)
+	}
+	return out
+}

--- a/pkg/config/compiler_interface_range_4027_test.go
+++ b/pkg/config/compiler_interface_range_4027_test.go
@@ -1,0 +1,225 @@
+package config
+
+import "testing"
+
+// TestInterfaceRangeExpandsMembers is the #4027 RED-on-revert guard: an
+// `interfaces interface-range <name>` stanza must expand into its member
+// interfaces (each getting the range's shared config) and must NOT mint a
+// phantom interface named after the range. Before the fix the range name was
+// compiled as a real interface (phantom, later brought admin-down) and the
+// shared config + members were dropped — this test goes RED on that behavior.
+func TestInterfaceRangeExpandsMembers(t *testing.T) {
+	tree := setTree(t,
+		"set interfaces interface-range uplinks member ge-0/0/1",
+		"set interfaces interface-range uplinks member ge-0/0/2",
+		"set interfaces interface-range uplinks mtu 9000",
+		// A normal interface, unrelated to the range: must be unaffected.
+		"set interfaces ge-0/0/3 mtu 1500",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	ifaces := cfg.Interfaces.Interfaces
+
+	// No phantom interface for the range name (in either spelling).
+	if _, ok := ifaces["interface-range"]; ok {
+		t.Errorf("phantom interface %q was created for the range name", "interface-range")
+	}
+	if _, ok := ifaces["uplinks"]; ok {
+		t.Errorf("phantom interface %q was created for the range name", "uplinks")
+	}
+
+	// Both members exist and carry the range's shared MTU.
+	for _, m := range []string{"ge-0/0/1", "ge-0/0/2"} {
+		ifc, ok := ifaces[m]
+		if !ok {
+			t.Errorf("member %s not compiled from the interface-range", m)
+			continue
+		}
+		if ifc.Disable {
+			t.Errorf("member %s must not be admin-down", m)
+		}
+		if ifc.MTU != 9000 {
+			t.Errorf("member %s MTU = %d, want 9000 (range shared config)", m, ifc.MTU)
+		}
+	}
+
+	// The unrelated normal interface is unchanged.
+	if ge3, ok := ifaces["ge-0/0/3"]; !ok {
+		t.Errorf("normal interface ge-0/0/3 missing")
+	} else if ge3.MTU != 1500 {
+		t.Errorf("ge-0/0/3 MTU = %d, want 1500 (unchanged)", ge3.MTU)
+	}
+}
+
+// TestInterfaceRangeSharedUnitAndPrecedence checks that shared config is
+// deep-applied (unit/family addresses reach each member) and that a member's
+// own per-interface statements win over the shared value on a scalar conflict
+// while additive statements (addresses) accumulate.
+func TestInterfaceRangeSharedUnitAndPrecedence(t *testing.T) {
+	tree := setTree(t,
+		"set interfaces interface-range R member ge-0/0/1",
+		"set interfaces interface-range R member ge-0/0/2",
+		"set interfaces interface-range R mtu 9000",
+		"set interfaces interface-range R unit 0 family inet address 10.5.5.5/24",
+		// ge-0/0/1 overrides mtu and adds its own address.
+		"set interfaces ge-0/0/1 mtu 1400",
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.9.9.9/24",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	ifaces := cfg.Interfaces.Interfaces
+
+	ge1 := ifaces["ge-0/0/1"]
+	if ge1 == nil {
+		t.Fatalf("ge-0/0/1 missing")
+	}
+	// Member's own mtu 1400 wins over the shared 9000.
+	if ge1.MTU != 1400 {
+		t.Errorf("ge-0/0/1 MTU = %d, want 1400 (member override wins)", ge1.MTU)
+	}
+	// Both the shared and the member's own address accumulate.
+	if u0 := ge1.Units[0]; u0 == nil {
+		t.Errorf("ge-0/0/1 unit 0 missing")
+	} else {
+		if !containsStr(u0.Addresses, "10.5.5.5/24") {
+			t.Errorf("ge-0/0/1 missing shared address 10.5.5.5/24; have %v", u0.Addresses)
+		}
+		if !containsStr(u0.Addresses, "10.9.9.9/24") {
+			t.Errorf("ge-0/0/1 missing own address 10.9.9.9/24; have %v", u0.Addresses)
+		}
+	}
+
+	ge2 := ifaces["ge-0/0/2"]
+	if ge2 == nil {
+		t.Fatalf("ge-0/0/2 missing")
+	}
+	if ge2.MTU != 9000 {
+		t.Errorf("ge-0/0/2 MTU = %d, want 9000 (shared)", ge2.MTU)
+	}
+	if u0 := ge2.Units[0]; u0 == nil || !containsStr(u0.Addresses, "10.5.5.5/24") {
+		t.Errorf("ge-0/0/2 missing shared address 10.5.5.5/24")
+	}
+}
+
+// TestInterfaceRangeHierarchical exercises the braced (hierarchical) AST shape
+// produced by the file parser, not just the flat-set replay path.
+func TestInterfaceRangeHierarchical(t *testing.T) {
+	input := `
+interfaces {
+    interface-range R {
+        member ge-0/0/1;
+        member ge-0/0/2;
+        mtu 9000;
+        unit 0 {
+            family inet {
+                address 10.5.5.5/24;
+            }
+        }
+    }
+    ge-0/0/3 {
+        mtu 1500;
+    }
+}
+`
+	tree, errs := NewParser(input).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	ifaces := cfg.Interfaces.Interfaces
+	if _, ok := ifaces["interface-range"]; ok {
+		t.Errorf("phantom interface-range interface created (hierarchical)")
+	}
+	for _, m := range []string{"ge-0/0/1", "ge-0/0/2"} {
+		ifc := ifaces[m]
+		if ifc == nil {
+			t.Errorf("member %s missing (hierarchical)", m)
+			continue
+		}
+		if ifc.MTU != 9000 {
+			t.Errorf("member %s MTU = %d, want 9000 (hierarchical shared)", m, ifc.MTU)
+		}
+		if u0 := ifc.Units[0]; u0 == nil || !containsStr(u0.Addresses, "10.5.5.5/24") {
+			t.Errorf("member %s missing shared address (hierarchical)", m)
+		}
+	}
+	if ge3 := ifaces["ge-0/0/3"]; ge3 == nil || ge3.MTU != 1500 {
+		t.Errorf("normal ge-0/0/3 changed by hierarchical range expansion")
+	}
+}
+
+// TestInterfaceRangeMemberRange expands the `member-range <start> to <end>`
+// selector into each interface in the numeric range.
+func TestInterfaceRangeMemberRange(t *testing.T) {
+	tree := setTree(t,
+		"set interfaces interface-range R member-range ge-0/0/1 to ge-0/0/3",
+		"set interfaces interface-range R mtu 9000",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	ifaces := cfg.Interfaces.Interfaces
+	for _, m := range []string{"ge-0/0/1", "ge-0/0/2", "ge-0/0/3"} {
+		if ifc := ifaces[m]; ifc == nil {
+			t.Errorf("member-range member %s not expanded", m)
+		} else if ifc.MTU != 9000 {
+			t.Errorf("member-range member %s MTU = %d, want 9000", m, ifc.MTU)
+		}
+	}
+}
+
+// TestInterfaceRangeMultipleRangesFlatSet checks that two distinct range names
+// under the single flat-set interface-range node are kept separate.
+func TestInterfaceRangeMultipleRangesFlatSet(t *testing.T) {
+	tree := setTree(t,
+		"set interfaces interface-range r1 member ge-0/0/1",
+		"set interfaces interface-range r1 mtu 9000",
+		"set interfaces interface-range r2 member ge-0/0/2",
+		"set interfaces interface-range r2 mtu 1400",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	ifaces := cfg.Interfaces.Interfaces
+	if ge1 := ifaces["ge-0/0/1"]; ge1 == nil || ge1.MTU != 9000 {
+		t.Errorf("r1 member ge-0/0/1 MTU wrong: %+v", ge1)
+	}
+	if ge2 := ifaces["ge-0/0/2"]; ge2 == nil || ge2.MTU != 1400 {
+		t.Errorf("r2 member ge-0/0/2 MTU wrong: %+v", ge2)
+	}
+	if _, ok := ifaces["r1"]; ok {
+		t.Errorf("phantom r1 interface")
+	}
+	if _, ok := ifaces["r2"]; ok {
+		t.Errorf("phantom r2 interface")
+	}
+}
+
+// TestInterfaceRangeNoStanzaUnchanged asserts the pass is a no-op for a config
+// with no interface-range: a plain interface compiles bit-identically.
+func TestInterfaceRangeNoStanzaUnchanged(t *testing.T) {
+	tree := setTree(t,
+		"set interfaces ge-0/0/0 mtu 1500",
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	ifc := cfg.Interfaces.Interfaces["ge-0/0/0"]
+	if ifc == nil || ifc.MTU != 1500 {
+		t.Fatalf("plain interface disturbed: %+v", ifc)
+	}
+	if u0 := ifc.Units[0]; u0 == nil || !containsStr(u0.Addresses, "10.0.0.1/24") {
+		t.Fatalf("plain interface unit 0 address lost")
+	}
+}


### PR DESCRIPTION
Closes #4027

## Problem (verified first)

`interfaces interface-range <name> { member <if>; <shared cfg> }` — a
Junos construct that applies a shared config block to a SET of member
interfaces — was entirely unimplemented (only referenced in a Junos
help-text reference doc). A scratch repro (`ParseSetCommand` +
`tree.SetPath`) confirmed the defect:

```
set interfaces interface-range R member ge-0/0/1
set interfaces interface-range R member ge-0/0/2
set interfaces interface-range R mtu 9000
```

compiled to:

```
iface "interface-range": MTU=0 Units=0        <- PHANTOM (range name as an interface)
```

i.e. the generic `interfaces` wildcard treated `interface-range` itself
as an interface NAME → a phantom `InterfaceConfig` keyed `interface-range`
(matching no kernel NIC, later reconciled admin-down), while the shared
config (`mtu 9000`, unit/family addresses) AND the member interfaces
`ge-0/0/1` / `ge-0/0/2` were silently dropped. Both halves of the issue's
predicted symptom confirmed.

## Fix

`expandInterfaceRanges` (`pkg/config/compiler_interface_range.go`), an AST
pre-pass run in `compileExpanded` BEFORE section compilation and the
H9/H10 unsupported-stanza gate (so both see the real members, never the
phantom):

- Rewrites every interface-range stanza into its member interfaces. The
  range's shared statements are flattened to `set`-command suffixes and
  replayed through `ConfigTree.SetPath` under each member's name, so they
  re-nest with the exact schema-driven shape a normal per-interface config
  would have and `compileInterfaces` reads them identically.
- Shared config is merged with each member's own per-interface config; the
  member's own statements are re-applied LAST so they win on a scalar
  conflict (a member-local `mtu` overrides the range `mtu`) while additive
  statements (addresses) accumulate.
- `member-range <a> to <b>` expands over the trailing decimal (endpoints
  must share a prefix; capped to bound a typo).
- Handles BOTH AST shapes (flat-set replay packs the range name into each
  leaf's `Keys[0]`; the hierarchical parser packs it into the
  interface-range node's `Keys[1]`).
- Strict no-op when no interface-range stanza is present (tree untouched).
  Runs on the group-expanded / inactive-pruned clone, so apply-groups
  inheritance and `inactive:` are handled for free.

No `pkg/networkd` change is needed: the phantom never reaches the
interface reconcile because it never enters the compiled `cfg.Interfaces`.
Kept as a compile-time AST rewrite rather than a `setSchema` change —
adding schema children for `member` / `member-range` would alter the
flat-set grouping the expansion depends on.

## RED-on-revert coverage

`pkg/config/compiler_interface_range_4027_test.go`: member expansion + no
phantom; shared unit/family deep-apply; member-override precedence +
address accumulation; hierarchical shape; member-range; multiple flat-set
ranges; and a no-op guard for a config with no interface-range. Every
assertion except the no-op test goes RED when `expandInterfaceRanges` is
stubbed out (phantom present, members/shared config dropped).

## Validation

- `go test ./pkg/config/... ./pkg/networkd/...` green
- `go build ./...`, `gofmt`, `go vet ./pkg/config/` clean

Docs: `docs/config-schema.md` documents the expansion alongside the other
config-mode compile gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
