### PR TITLE
userspace: scale control-socket deadline with request size (#4036)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -65,6 +65,38 @@
     `TestSleepCtx*` (RED-on-revert: retry loop honours ctx cancel instead of
     spinning the full 60s budget). Full `pkg/cluster` + `pkg/daemon` suites
     green with `-race`. test-failover WARRANTED (HA heartbeat) — batch-validate.
+## 2026-07-03 — #4036: control-socket fixed 3s deadline false-times-out a large (up to 64MB) apply_snapshot (fable-161 F-182)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed the userspace-dp control-socket round-trip
+    (`requestDetailedLocked`) using a FIXED 3s read/write deadline for EVERY
+    request type. An `apply_snapshot` can be up to `MaxControlRequestBytes`
+    (64 MiB, #2744) of feed-backed address-book CIDR text; the Rust helper
+    receives+decodes+APPLIES the whole body (LPM tables, binding plan, AF_XDP
+    reconcile) before replying, which can exceed 3s → Go's `Decode` timed out
+    and reported the apply FAILED while the helper had actually applied it and
+    the dataplane was forwarding live with the new config (spurious commit
+    failure / needless rollback / false HA dp-failure).
+  - **Fix**: new pure helper `controlRoundtripDeadline(bodyLen)` sizes the
+    deadline to the serialized request length — historical 3s base for any
+    sub-1-MiB request (status poll and small forwarding/HA/session requests
+    unchanged, poll stays responsive per #182), +1s per mebibyte, capped at
+    120s. 64 MiB → 3s+64s = 67s. Computed from the same `len(body)` the #2744
+    pre-flight already serializes (no extra marshal). The dedicated
+    session-sync socket keeps the flat 3s (small per-session installs; bulk
+    export/drain run over the main socket and get the scaled deadline).
+  - **Tests**: `control_socket_deadline_4036_test.go` — pins the sizing math
+    (small=base, per-MiB scaling, 120s cap, monotone); a fail-on-revert
+    round-trip where a mock helper drains a >=3 MiB apply_snapshot then sleeps
+    3.5s (> old 3s, < scaled 6s) before replying OK; and a hung-helper case
+    that still times out at the base deadline. RED-on-revert verified: with the
+    deadline reverted to a fixed 3s the large-apply test FAILS at 3.01s
+    ("i/o timeout") while the math + hung tests stay green.
+  - **File(s)**: `pkg/dataplane/userspace/process.go`,
+    `pkg/dataplane/userspace/control_socket_deadline_4036_test.go`,
+    `docs/userspace-dataplane-architecture.md`
+  - **Follow-up**: no HA state/session-sync code touched (deadline sizing only)
+    — test-failover not warranted.
 
 ## 2026-07-03 — #4031: monitorFabricState exits + leaks sibling netlink socket on ENOBUFS (fable-161 F-167)
 

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -1297,6 +1297,42 @@ identical**; the relationship is pinned by
 `legitimate_feed_above_old_16mib_cap_is_now_accepted` /
 `request_above_new_cap_is_still_rejected` fail-on-revert tests (Rust).
 
+### Control-socket round-trip deadline (#4036)
+
+The Go sender (`requestDetailedLocked`, `pkg/dataplane/userspace/process.go`)
+sets a single read/write deadline on the control connection covering the
+whole round-trip: write the request body, then block on the helper's JSON
+response. The helper reads the whole body, decodes it, **applies** it, and
+only then writes the response, so the deadline must cover the helper's apply
+time — not just the socket transfer.
+
+The deadline is **sized to the serialized request length** rather than fixed.
+A fixed 3s was correct for the small frequent requests but too short for a
+large `apply_snapshot`: at the 64 MiB ceiling the helper must decode ~1.4M
+feed-backed address-book CIDRs, build the address-book LPM tables, plan
+bindings, and reconcile AF_XDP before replying, which can exceed 3s. Under
+the fixed deadline Go's `Decode` timed out and reported the apply **FAILED**
+while the helper had actually applied the snapshot and the dataplane was
+forwarding live with the new config — a spurious commit failure that could
+trigger a needless rollback/retry or a false HA dp-failure.
+
+`controlRoundtripDeadline(bodyLen)` computes the deadline: it keeps the
+historical **3s base** for any sub-1-MiB request (so the 1/s status poll and
+the small forwarding/HA/session requests are byte-for-byte unchanged and the
+poll stays responsive per the #182 contention discipline) and adds **1s per
+mebibyte** on top, capped at **120s**. At the 64 MiB request ceiling this is
+`3s + 64s = 67s`, comfortably under the cap — generous enough for a legitimate
+feed-heavy apply while still bounding a genuinely-hung helper (the caller holds
+`m.mu` across the round-trip, so an unbounded wait would freeze status polls
+and session installs). The length is the same `len(body)` the #2744 pre-flight
+already serializes, so no extra marshal. The dedicated session-sync socket
+(`requestSessionSync`) keeps the flat 3s: it carries only small per-session
+installs; the bulk session export/drain paths run over this main control
+socket and so already get the scaled deadline. Sizing math and a fail-on-revert
+round-trip (a slow-but-successful large apply that trips a fixed 3s but not the
+scaled deadline; a hung helper that still times out) are pinned by
+`control_socket_deadline_4036_test.go`.
+
 ## Limitations and Mixed Boundaries
 
 This section is a high-level architecture note. The authoritative current gate

--- a/pkg/dataplane/userspace/control_socket_deadline_4036_test.go
+++ b/pkg/dataplane/userspace/control_socket_deadline_4036_test.go
@@ -1,0 +1,248 @@
+package userspace
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// oldFixedControlDeadline is the pre-#4036 control-socket round-trip deadline.
+// It is hard-coded (NOT derived from controlBaseDeadline) so the fail-on-revert
+// assertions below go RED if the deadline is reverted to a fixed 3s for a large
+// apply_snapshot.
+const oldFixedControlDeadline = 3 * time.Second
+
+// TestControlRoundtripDeadlineScales pins the deadline-sizing math (#4036).
+// A small request keeps the base deadline (status poll stays responsive); a
+// large apply_snapshot scales up per-MiB; the deadline is capped and monotone.
+func TestControlRoundtripDeadlineScales(t *testing.T) {
+	// Small requests (sub-1-MiB) keep EXACTLY the base — the frequent 1/s
+	// status poll and per-session installs must not be slowed or given a
+	// looser give-up point than before.
+	for _, small := range []int{0, 1, 1024, (1 << 20) - 1} {
+		if got := controlRoundtripDeadline(small); got != controlBaseDeadline {
+			t.Fatalf("controlRoundtripDeadline(%d) = %v, want base %v (small requests unchanged)",
+				small, got, controlBaseDeadline)
+		}
+	}
+	// A negative length can never happen (len is non-negative) but must not
+	// underflow into a tiny/negative deadline.
+	if got := controlRoundtripDeadline(-1); got != controlBaseDeadline {
+		t.Fatalf("controlRoundtripDeadline(-1) = %v, want base %v", got, controlBaseDeadline)
+	}
+
+	// Per-MiB scaling.
+	cases := []struct {
+		bodyLen int
+		want    time.Duration
+	}{
+		{1 << 20, controlBaseDeadline + controlDeadlinePerMiB},     // 1 MiB
+		{2 << 20, controlBaseDeadline + 2*controlDeadlinePerMiB},   // 2 MiB
+		{20 << 20, controlBaseDeadline + 20*controlDeadlinePerMiB}, // 20 MiB feed
+		{64 << 20, controlBaseDeadline + 64*controlDeadlinePerMiB}, // 64 MiB ceiling
+		{MaxControlRequestBytes, controlBaseDeadline + 64*controlDeadlinePerMiB},
+	}
+	for _, c := range cases {
+		if got := controlRoundtripDeadline(c.bodyLen); got != c.want {
+			t.Fatalf("controlRoundtripDeadline(%d) = %v, want %v", c.bodyLen, got, c.want)
+		}
+	}
+
+	// The 64 MiB apply_snapshot deadline is materially larger than the old
+	// fixed 3s — this is the core of #4036 (a legit 64 MiB apply no longer
+	// false-times-out at 3s).
+	if got := controlRoundtripDeadline(MaxControlRequestBytes); got <= oldFixedControlDeadline {
+		t.Fatalf("64 MiB deadline %v must exceed the old fixed %v (that is the #4036 fix)",
+			got, oldFixedControlDeadline)
+	}
+	// ...yet it stays within the sane cap so a hung helper eventually times out.
+	if got := controlRoundtripDeadline(MaxControlRequestBytes); got > controlMaxDeadline {
+		t.Fatalf("64 MiB deadline %v must not exceed the cap %v", got, controlMaxDeadline)
+	}
+	// A body far past the cap (cannot occur — the #2744 pre-flight rejects it —
+	// but the sizing must clamp regardless) hits the cap exactly.
+	if got := controlRoundtripDeadline(1 << 30); got != controlMaxDeadline {
+		t.Fatalf("controlRoundtripDeadline(1 GiB) = %v, want cap %v", got, controlMaxDeadline)
+	}
+
+	// Monotone non-decreasing.
+	prev := controlRoundtripDeadline(0)
+	for mb := 1; mb <= 200; mb++ {
+		got := controlRoundtripDeadline(mb << 20)
+		if got < prev {
+			t.Fatalf("deadline not monotone at %d MiB: %v < %v", mb, got, prev)
+		}
+		prev = got
+	}
+}
+
+// largeApplySnapshotBody builds an apply_snapshot ControlRequest whose
+// serialized JSON body exceeds minBytes, using a feed-shaped address book of
+// IPv6 CIDR text (the dominant scaling dimension per #2744). Returns the
+// request and its serialized length.
+func largeApplySnapshotBody(t *testing.T, minBytes int) (ControlRequest, int) {
+	t.Helper()
+	// Each "2001:db8:xxxx:yyyy::/64" entry serializes to ~28 bytes of JSON
+	// (quotes + comma). Over-provision the count so we comfortably clear the
+	// target, then assert the actual body size.
+	n := (minBytes / 24) + 4096
+	prefixes := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		prefixes = append(prefixes, fmt.Sprintf("2001:db8:%04x:%04x::/64", i&0xffff, (i>>16)&0xffff))
+	}
+	req := ControlRequest{
+		Type: "apply_snapshot",
+		Snapshot: &ConfigSnapshot{
+			Version: ProtocolVersion,
+			AddressBooks: []AddressBookSnapshot{
+				{ID: 1, Name: "threat-feed", PrefixesV6: prefixes},
+			},
+		},
+	}
+	body, err := json.Marshal(&req)
+	if err != nil {
+		t.Fatalf("marshal large apply_snapshot: %v", err)
+	}
+	if len(body) < minBytes {
+		t.Fatalf("generated body %d bytes < required %d", len(body), minBytes)
+	}
+	if len(body) > MaxControlRequestBytes {
+		t.Fatalf("generated body %d bytes exceeds the #2744 cap %d", len(body), MaxControlRequestBytes)
+	}
+	return req, len(body)
+}
+
+// TestLargeApplySnapshotDoesNotFalseTimeout is the #4036 fail-on-revert proof.
+// A large apply_snapshot whose helper-side apply takes LONGER than the old
+// fixed 3s deadline (but well under the scaled deadline) must round-trip and
+// report SUCCESS. Reverting requestDetailedLocked to a fixed 3s deadline makes
+// this RED: Decode times out at 3s and reports the apply FAILED while the
+// (mock) helper actually applied it.
+func TestLargeApplySnapshotDoesNotFalseTimeout(t *testing.T) {
+	// Body >= 3 MiB => scaled deadline >= base + 3s = 6s. The mock helper
+	// sleeps 3.5s (> old fixed 3s, < scaled 6s) before replying.
+	const bodyFloor = 3 << 20
+	req, bodyLen := largeApplySnapshotBody(t, bodyFloor)
+
+	scaled := controlRoundtripDeadline(bodyLen)
+	const applyDelay = 3500 * time.Millisecond
+	if applyDelay <= oldFixedControlDeadline {
+		t.Fatalf("mock apply delay %v must exceed the old fixed deadline %v to prove the fix",
+			applyDelay, oldFixedControlDeadline)
+	}
+	if scaled <= applyDelay {
+		t.Fatalf("scaled deadline %v must exceed the mock apply delay %v (test misconfigured)",
+			scaled, applyDelay)
+	}
+
+	dir := t.TempDir()
+	controlSock := filepath.Join(dir, "control.sock")
+	ln, err := net.Listen("unix", controlSock)
+	if err != nil {
+		t.Fatalf("listen control socket: %v", err)
+	}
+	defer ln.Close()
+
+	gotType := make(chan string, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		// Drain the whole request first so the client's Write completes, then
+		// model a slow-but-successful apply before replying.
+		var got ControlRequest
+		if err := json.NewDecoder(conn).Decode(&got); err != nil {
+			return
+		}
+		gotType <- got.Type
+		time.Sleep(applyDelay)
+		_ = json.NewEncoder(conn).Encode(ControlResponse{OK: true, Status: &ProcessStatus{}})
+	}()
+
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("FindProcess: %v", err)
+	}
+	m := New()
+	m.proc = &exec.Cmd{Process: proc}
+	m.cfg.ControlSocket = controlSock
+
+	start := time.Now()
+	m.mu.Lock()
+	resp, err := m.requestDetailedLocked(req)
+	m.mu.Unlock()
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("large apply_snapshot falsely failed after %v (fixed-3s regression): %v", elapsed, err)
+	}
+	if !resp.OK {
+		t.Fatalf("large apply_snapshot response not OK: %+v", resp)
+	}
+	if elapsed <= oldFixedControlDeadline {
+		t.Fatalf("mock did not exercise the >3s window (elapsed %v) — test would not catch a revert", elapsed)
+	}
+	select {
+	case typ := <-gotType:
+		if typ != "apply_snapshot" {
+			t.Fatalf("helper received unexpected request type %q", typ)
+		}
+	default:
+		t.Fatal("helper never received the request — it did not round-trip")
+	}
+}
+
+// TestHungHelperTimesOutAtScaledDeadline proves the scaled deadline still
+// bounds a genuinely-hung helper: a small request whose helper accepts but
+// never replies must time out (at the base deadline) rather than block forever.
+func TestHungHelperTimesOutAtScaledDeadline(t *testing.T) {
+	dir := t.TempDir()
+	controlSock := filepath.Join(dir, "control.sock")
+	ln, err := net.Listen("unix", controlSock)
+	if err != nil {
+		t.Fatalf("listen control socket: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		// Read the request, then hang forever without replying.
+		var got ControlRequest
+		_ = json.NewDecoder(conn).Decode(&got)
+		select {} // block; the connection is closed when the process exits
+	}()
+
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("FindProcess: %v", err)
+	}
+	m := New()
+	m.proc = &exec.Cmd{Process: proc}
+	m.cfg.ControlSocket = controlSock
+
+	// A small request keeps the base deadline (3s). Assert it returns an error
+	// bounded by that deadline plus slack — never an unbounded hang.
+	start := time.Now()
+	m.mu.Lock()
+	_, err = m.requestDetailedLocked(ControlRequest{Type: "ping"})
+	m.mu.Unlock()
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("a hung helper must eventually time out, got nil error")
+	}
+	if elapsed > controlBaseDeadline+2*time.Second {
+		t.Fatalf("timeout took %v, expected ~%v (deadline not enforced)", elapsed, controlBaseDeadline)
+	}
+	if elapsed < controlBaseDeadline-500*time.Millisecond {
+		t.Fatalf("timeout fired too early at %v (base deadline is %v)", elapsed, controlBaseDeadline)
+	}
+}

--- a/pkg/dataplane/userspace/control_socket_deadline_4036_test.go
+++ b/pkg/dataplane/userspace/control_socket_deadline_4036_test.go
@@ -210,15 +210,24 @@ func TestHungHelperTimesOutAtScaledDeadline(t *testing.T) {
 	}
 	defer ln.Close()
 
+	// done bounds the mock helper goroutine's lifetime to the test: it holds
+	// the connection open (never replying) so the client hits its deadline,
+	// then EXITS deterministically at test end instead of leaking a goroutine
+	// + unclosed conn that could perturb -race or later tests.
+	done := make(chan struct{})
+	t.Cleanup(func() { close(done) })
+
 	go func() {
 		conn, err := ln.Accept()
 		if err != nil {
 			return
 		}
-		// Read the request, then hang forever without replying.
+		defer conn.Close()
+		// Read the request, then hold the connection without replying until
+		// the test signals shutdown — models a genuinely-hung helper.
 		var got ControlRequest
 		_ = json.NewDecoder(conn).Decode(&got)
-		select {} // block; the connection is closed when the process exits
+		<-done
 	}()
 
 	proc, err := os.FindProcess(os.Getpid())

--- a/pkg/dataplane/userspace/process.go
+++ b/pkg/dataplane/userspace/process.go
@@ -212,6 +212,53 @@ func findBinary(explicit string) (string, error) {
 // silent control-socket rejection after a successful commit.
 const MaxControlRequestBytes = 64 * 1024 * 1024
 
+const (
+	// controlBaseDeadline is the round-trip read/write deadline for a SMALL
+	// control-socket request (the 1/s status poll, forwarding arm/disarm,
+	// HA-state push, per-session install, ...). It is preserved unchanged at
+	// the historical 3s so the frequent status poll stays responsive per the
+	// #182 control-socket-contention discipline: a sub-1-MiB request gets
+	// exactly this deadline, no more.
+	controlBaseDeadline = 3 * time.Second
+	// controlDeadlinePerMiB is the additional round-trip budget granted per
+	// mebibyte of serialized request body. A large apply_snapshot — up to
+	// MaxControlRequestBytes (64 MiB, #2744) of feed-backed address-book CIDR
+	// text — needs the helper to receive, JSON-decode, and APPLY the whole
+	// body (building the address-book LPM tables, planning bindings,
+	// reconciling AF_XDP) and then write its response inside the deadline.
+	// A fixed 3s falsely timed a large apply out (#4036): Go reported the
+	// apply FAILED while the Rust helper had actually applied the snapshot and
+	// the dataplane was forwarding live with the new config — a spurious
+	// commit failure / needless rollback / false HA dp-failure.
+	controlDeadlinePerMiB = 1 * time.Second
+	// controlMaxDeadline caps the scaled deadline so a genuinely-hung helper
+	// still eventually times out rather than blocking the caller (which holds
+	// m.mu across the round-trip) forever. At the 64 MiB request ceiling the
+	// scaled deadline is base + 64s = 67s, comfortably under this cap.
+	controlMaxDeadline = 120 * time.Second
+)
+
+// controlRoundtripDeadline sizes the control-socket read/write deadline to the
+// serialized request length so a large apply_snapshot is not falsely timed out
+// (#4036). It is a pure function of the body length: a sub-1-MiB request keeps
+// the base deadline (small requests unchanged — the status poll stays
+// responsive), and each additional mebibyte adds controlDeadlinePerMiB up to
+// controlMaxDeadline. The deadline is generous enough for a legitimate 64 MiB
+// feed-heavy apply while still bounding a hung helper.
+func controlRoundtripDeadline(bodyLen int) time.Duration {
+	if bodyLen < 0 {
+		bodyLen = 0
+	}
+	// floor(bodyLen / 1 MiB): 0 for any request under 1 MiB, so small
+	// requests keep exactly controlBaseDeadline.
+	mib := bodyLen >> 20
+	d := controlBaseDeadline + time.Duration(mib)*controlDeadlinePerMiB
+	if d > controlMaxDeadline {
+		d = controlMaxDeadline
+	}
+	return d
+}
+
 func (m *Manager) requestDetailedLocked(req ControlRequest) (ControlResponse, error) {
 	if m.cfg.ControlSocket == "" {
 		return ControlResponse{}, errors.New("userspace dataplane control socket not configured")
@@ -240,7 +287,15 @@ func (m *Manager) requestDetailedLocked(req ControlRequest) (ControlResponse, er
 		return ControlResponse{}, err
 	}
 	defer conn.Close()
-	_ = conn.SetDeadline(time.Now().Add(3 * time.Second))
+	// Size the round-trip deadline to the request body (#4036). A fixed 3s was
+	// too short for a large apply_snapshot (up to MaxControlRequestBytes / 64
+	// MiB of feed-backed address-book CIDRs): the helper receives+decodes+
+	// applies the whole body before replying, which can exceed 3s, so Go timed
+	// out and reported the apply FAILED while the dataplane had applied it live.
+	// controlRoundtripDeadline keeps the 3s base for small requests (status
+	// poll stays responsive) and scales up for a large apply, capped so a hung
+	// helper still times out.
+	_ = conn.SetDeadline(time.Now().Add(controlRoundtripDeadline(len(body))))
 	// Reuse the pre-flight-serialized body; the Rust receiver frames on a
 	// single trailing newline (json.Encoder appends one).
 	if _, err := conn.Write(append(body, '\n')); err != nil {


### PR DESCRIPTION
Closes #4036

## Problem

The userspace-dp control-socket round-trip (`requestDetailedLocked`,
`pkg/dataplane/userspace/process.go`) set a **fixed 3s** read/write deadline
(`conn.SetDeadline(time.Now().Add(3 * time.Second))`) for **every** request
type. But an `apply_snapshot` request carries a `ConfigSnapshot` up to
`MaxControlRequestBytes` (**64 MiB**, #2744) — dominated by dynamic-feed-backed
address books that carry feed prefixes inline as CIDR text.

The Rust helper (`handle_stream`) reads the whole body, JSON-decodes it, and
**applies** it — building the address-book LPM tables, planning bindings, and
reconciling AF_XDP — *before* it writes the response. (Its own 5s per-syscall
socket timeout is a read/write inactivity timeout, not a bound on the apply.)
A large apply's receive+decode+apply+respond can exceed 3s, at which point Go's
`Decode` hits the fixed deadline and reports the apply **FAILED** — even though
the helper had actually applied the snapshot and the dataplane was forwarding
live with the new config. That is a spurious commit failure that can trigger a
needless rollback/retry or a false HA dp-failure.

Nothing scaled the deadline: it was a hardcoded `3 * time.Second` applied
uniformly regardless of `req.Type` or `len(body)`.

## Fix

Size the round-trip deadline to the serialized request length. New pure helper
`controlRoundtripDeadline(bodyLen)`:

- keeps the historical **3s base** for any sub-1-MiB request, so the frequent
  1/s status poll and the small forwarding/HA/session requests are unchanged
  and the poll stays responsive per the #182 control-socket-contention
  discipline;
- adds **1s per mebibyte** on top;
- caps at **120s** so a genuinely-hung helper still eventually times out (the
  caller holds `m.mu` across the round-trip, so an unbounded wait would freeze
  status polls / session installs).

At the 64 MiB ceiling the deadline is `3s + 64s = 67s`, comfortably under the
cap. The length is the same `len(body)` the #2744 pre-flight already
serializes, so there is no extra marshal. The dedicated session-sync socket
(`requestSessionSync`) keeps the flat 3s — it carries only small per-session
installs; the bulk session export/drain paths run over this main control socket
and so already get the scaled deadline.

`file:line`: `pkg/dataplane/userspace/process.go` — `controlRoundtripDeadline`
+ `conn.SetDeadline(time.Now().Add(controlRoundtripDeadline(len(body))))`.

Formula: `deadline = min(120s, 3s + 1s * floor(bodyLen / 1 MiB))`.

## Tests (`control_socket_deadline_4036_test.go`)

- **`TestControlRoundtripDeadlineScales`** — pins the math: small=base,
  per-MiB scaling, 120s cap, monotone; 64 MiB deadline > old fixed 3s and <=
  cap.
- **`TestLargeApplySnapshotDoesNotFalseTimeout`** — fail-on-revert proof. A
  >=3 MiB feed-shaped `apply_snapshot` round-trips against a mock helper that
  drains the body, sleeps 3.5s (> old 3s, < scaled 6s), then replies OK; must
  report SUCCESS.
- **`TestHungHelperTimesOutAtScaledDeadline`** — a small request whose helper
  accepts but never replies still times out at the base deadline.

**RED-on-revert verified:** with the deadline reverted to a fixed 3s,
`TestLargeApplySnapshotDoesNotFalseTimeout` FAILS at ~3.01s (`i/o timeout`)
while the math + hung tests stay green.

`go test ./pkg/dataplane/...` green; `-race` green on the control tests.
Docs: control-socket round-trip deadline section in
`docs/userspace-dataplane-architecture.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
