### PR TITLE
cluster: per-fabric refresh channel so dual-fabric events aren't dropped (#4038)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -31370,3 +31370,27 @@ top.
     test/incus/test-active-active.sh, test/incus/test-restart-connectivity.sh,
     test/incus/test-private-rg.sh, Makefile, docs/engineering-style.md,
     CLAUDE.md, _Log.md
+
+- **Timestamp**: 2026-07-03
+  - **Action**: #4038 — dual-fabric refresh: give fab1 its own refresh
+    channel. Dual-fabric (fabric-link + fabric-link-1) IS supported
+    (`populateFabricFwd1` launched from `startClusterComms` when
+    `cc.Fabric1Interface`/`Fabric1PeerAddress` are set). The fab0 loop
+    (`populateFabricFwd`) and fab1 loop (`populateFabricFwd1`) both
+    selected on ONE shared `fabricRefreshCh` (cap 1). `monitorFabricState`
+    does not tag events per fabric, so `triggerFabricRefresh()`'s single
+    non-blocking send was received by exactly ONE waiting goroutine —
+    fab0 OR fab1, whichever won the race — and the other fabric's
+    link/neighbor event was dropped until its 30s safety-net tick,
+    degrading the second fabric's sub-second convergence. Fix: add
+    `fabricRefreshCh1`; fab1 reads it; `triggerFabricRefresh()` signals
+    BOTH channels (non-blocking; a nil fab1 channel in single-fabric mode
+    falls through `default`). Mirrors the synchronous `RefreshFabricFwd()`,
+    which already refreshes both entries. RED-on-revert: dropping the fab1
+    send makes `TestTriggerFabricRefreshWakesBothFabrics` fail on the fab1
+    assertion. Validated: gofmt/vet clean, `go build ./...`, and
+    `go test -race ./pkg/daemon/... ./pkg/cluster/...` all green.
+    test-failover WARRANTED (HA fabric) — batch-validate.
+  - **File(s)**: pkg/daemon/daemon.go, pkg/daemon/daemon_ha_fabric.go,
+    pkg/daemon/daemon_ha_sync.go, pkg/daemon/daemon_ha_fabric_test.go,
+    docs/fabric-cross-chassis-fwd.md, _Log.md

--- a/docs/fabric-cross-chassis-fwd.md
+++ b/docs/fabric-cross-chassis-fwd.md
@@ -69,6 +69,21 @@ re-syncs the fabric state, rather than dying permanently, and it closes BOTH
 netlink sockets on every path so neither fd leaks (#4031). It exits only on
 context cancellation.
 
+**Per-fabric refresh channels (dual-fabric, #4038):** in a redundant
+`fabric-link` + `fabric-link-1` cluster the fab0 loop (`populateFabricFwd`)
+and the fab1 loop (`populateFabricFwd1`) each own a refresh channel
+(`fabricRefreshCh` / `fabricRefreshCh1`). `monitorFabricState` does not tag
+events per fabric, so `triggerFabricRefresh()` signals BOTH channels (non-
+blocking, capacity 1) and every configured fabric re-resolves on any event —
+matching the synchronous `RefreshFabricFwd()`, which already refreshes both
+entries. A single shared channel was wrong: a Go send is received by exactly
+one waiting goroutine, so one trigger woke only fab0 OR fab1 (whichever won
+the receive) and the other fabric's link/neighbor event was dropped until its
+30s safety-net tick — degrading the second fabric's sub-second convergence.
+A single-fabric cluster leaves `fabricRefreshCh1` nil; the non-blocking send
+falls through its `default` arm, so `triggerFabricRefresh()` is a no-op for
+the absent fabric.
+
 ### Fix 2: VRRP Coordinated Preemption (Defense-in-depth)
 
 **Concept:** All VRRP instances preempt simultaneously when `ReleaseSyncHold()`

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -431,7 +431,8 @@ type Daemon struct {
 	fabricPeerIP1    net.IP        // secondary fabric peer IP
 	fabricPopulated  bool          // true after first successful fab0 write
 	fabric1Populated bool          // true after first successful fab1 write
-	fabricRefreshCh  chan struct{} // triggers immediate fabric_fwd refresh
+	fabricRefreshCh  chan struct{} // wakes the fab0 populateFabricFwd loop
+	fabricRefreshCh1 chan struct{} // wakes the fab1 populateFabricFwd1 loop (#4038)
 	lastFabricProbe  time.Time     // rate-limit active fab0 neighbor probes
 	lastFabricProbe1 time.Time     // rate-limit active fab1 neighbor probes
 	lastFabricLog0   time.Time     // rate-limit fab0 refresh failure logs

--- a/pkg/daemon/daemon_ha_fabric.go
+++ b/pkg/daemon/daemon_ha_fabric.go
@@ -220,7 +220,8 @@ func (d *Daemon) populateFabricFwd(ctx context.Context, fabIface, overlay, peerA
 	}
 
 	// Periodic refresh every 30s as safety net, plus event-driven
-	// refresh via fabricRefreshCh from netlink monitor (#124).
+	// refresh via fabricRefreshCh from the netlink monitor (#124). fab0
+	// reads its own channel; fab1 reads fabricRefreshCh1 (#4038).
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -613,7 +614,11 @@ func (d *Daemon) populateFabricFwd1(ctx context.Context, fabIface, overlay, peer
 	}
 
 	// Periodic refresh every 30s as safety net, plus event-driven
-	// refresh via fabricRefreshCh from netlink monitor (#124).
+	// refresh via fabricRefreshCh1 from netlink monitor (#124). fab1 has
+	// its OWN channel (#4038): a single shared channel is drained by
+	// exactly one waiting goroutine per send, so with both fab0 and fab1
+	// selecting on one channel a trigger woke only one of them and the
+	// other fabric's event was dropped until the 30s safety-net tick.
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -622,7 +627,7 @@ func (d *Daemon) populateFabricFwd1(ctx context.Context, fabIface, overlay, peer
 			return
 		case <-ticker.C:
 			d.refreshFabricFwd1(ctx, fabIface, overlay, peerIP, false)
-		case <-d.fabricRefreshCh:
+		case <-d.fabricRefreshCh1:
 			d.refreshFabricFwd1(ctx, fabIface, overlay, peerIP, false)
 		}
 	}
@@ -933,12 +938,28 @@ func (d *Daemon) runFabricStateSubscription(ctx context.Context) bool {
 	}
 }
 
-// triggerFabricRefresh sends a non-blocking signal to the fabric refresh
-// channel, waking populateFabricFwd/populateFabricFwd1 loops.
+// triggerFabricRefresh sends a non-blocking signal to BOTH fabric refresh
+// channels, waking the populateFabricFwd (fab0) and populateFabricFwd1
+// (fab1) loops. The netlink monitor and readiness gate do not tag events
+// per-fabric, so any fabric event re-resolves both entries — matching the
+// synchronous RefreshFabricFwd, which also refreshes fab0 and fab1.
+//
+// Each fabric owns its own channel (#4038). A single shared channel is
+// received by exactly one waiting goroutine per send, so a lone trigger
+// woke only fab0 or fab1 (whichever won the race) and the other fabric's
+// event was lost until the 30s safety-net tick. Signaling both channels
+// guarantees every configured fabric acts on the event immediately.
 func (d *Daemon) triggerFabricRefresh() {
 	select {
 	case d.fabricRefreshCh <- struct{}{}:
 	default:
-		// Already pending — no need to queue another.
+		// fab0 already has a refresh pending — no need to queue another.
+	}
+	select {
+	case d.fabricRefreshCh1 <- struct{}{}:
+	default:
+		// fab1 already has a refresh pending (or fab1 is not configured
+		// and its channel is nil — a nil-channel send never fires, so
+		// the default arm handles that too). No need to queue another.
 	}
 }

--- a/pkg/daemon/daemon_ha_fabric_test.go
+++ b/pkg/daemon/daemon_ha_fabric_test.go
@@ -42,3 +42,72 @@ func TestRetainFabricFwdOnNeighborMissWithCachedSecondaryEntry(t *testing.T) {
 		t.Fatal("cached secondary fabric entry should remain populated")
 	}
 }
+
+// TestTriggerFabricRefreshWakesBothFabrics asserts that a single fabric
+// event wakes BOTH the fab0 and fab1 refresh loops. The netlink monitor
+// does not tag events per-fabric, so any fabric link/neighbor change must
+// re-resolve both entries. Before #4038 both loops selected on ONE shared
+// channel, so a lone non-blocking send was received by exactly one waiting
+// goroutine and the other fabric's event was lost until the 30s tick.
+//
+// RED-on-revert: drop the fab1 send from triggerFabricRefresh (or point
+// populateFabricFwd1 back at the shared channel) and the fab1 assertion
+// fails — the dual-fabric event is dropped.
+func TestTriggerFabricRefreshWakesBothFabrics(t *testing.T) {
+	d := &Daemon{
+		fabricRefreshCh:  make(chan struct{}, 1),
+		fabricRefreshCh1: make(chan struct{}, 1),
+	}
+
+	d.triggerFabricRefresh()
+
+	select {
+	case <-d.fabricRefreshCh:
+	default:
+		t.Fatal("fab0 refresh channel not signaled by triggerFabricRefresh")
+	}
+	select {
+	case <-d.fabricRefreshCh1:
+	default:
+		t.Fatal("fab1 refresh channel not signaled — dual-fabric event lost (#4038)")
+	}
+}
+
+// TestTriggerFabricRefreshCoalesces verifies the non-blocking sends coalesce:
+// a second trigger before either loop drains leaves exactly one pending
+// signal per channel (capacity 1) and never blocks the caller.
+func TestTriggerFabricRefreshCoalesces(t *testing.T) {
+	d := &Daemon{
+		fabricRefreshCh:  make(chan struct{}, 1),
+		fabricRefreshCh1: make(chan struct{}, 1),
+	}
+
+	d.triggerFabricRefresh()
+	d.triggerFabricRefresh() // must not block even though both are full.
+
+	if got := len(d.fabricRefreshCh); got != 1 {
+		t.Fatalf("fab0 channel depth = %d, want coalesced to 1", got)
+	}
+	if got := len(d.fabricRefreshCh1); got != 1 {
+		t.Fatalf("fab1 channel depth = %d, want coalesced to 1", got)
+	}
+}
+
+// TestTriggerFabricRefreshSingleFabricNoPanic verifies the single-fabric
+// case: fab1 is not configured so fabricRefreshCh1 is nil. A non-blocking
+// send on a nil channel is never ready, so the default arm runs and the
+// caller must not block or panic.
+func TestTriggerFabricRefreshSingleFabricNoPanic(t *testing.T) {
+	d := &Daemon{
+		fabricRefreshCh: make(chan struct{}, 1),
+		// fabricRefreshCh1 intentionally left nil (single-fabric cluster).
+	}
+
+	d.triggerFabricRefresh()
+
+	select {
+	case <-d.fabricRefreshCh:
+	default:
+		t.Fatal("fab0 refresh channel not signaled in single-fabric mode")
+	}
+}

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -783,8 +783,13 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 				go d.runDHCPLeaseSyncLoop(commsCtx)
 			}
 
-			// Initialize fabric refresh channel for event-driven updates (#124).
+			// Initialize per-fabric refresh channels for event-driven
+			// updates (#124). Each fabric owns its own channel so a
+			// single netlink-triggered refresh wakes both the fab0 and
+			// fab1 loops rather than only whichever won a shared-channel
+			// receive (#4038).
 			d.fabricRefreshCh = make(chan struct{}, 1)
+			d.fabricRefreshCh1 = make(chan struct{}, 1)
 
 			// Populate fabric_fwd BPF map for cross-chassis redirect,
 			// then periodically refresh to correct neighbor drift.


### PR DESCRIPTION
## Summary

Closes #4038.

Dual-fabric HA (`fabric-link` + `fabric-link-1`) IS supported —
`populateFabricFwd1` is launched from `startClusterComms` when
`cc.Fabric1Interface`/`Fabric1PeerAddress` are set. The defect is genuine:

- The fab0 refresh loop (`populateFabricFwd`, `pkg/daemon/daemon_ha_fabric.go`)
  and the fab1 loop (`populateFabricFwd1`) both `select`ed on ONE shared
  `d.fabricRefreshCh` (capacity 1).
- `monitorFabricState` does not tag events per fabric; `triggerFabricRefresh()`
  did a single non-blocking send.
- A Go channel send is received by **exactly one** waiting goroutine, so the
  lone signal woke only fab0 **or** fab1 (whichever won the receive race). The
  other fabric's link/neighbor event was **lost** until its 30s safety-net
  ticker — the second fabric lost the sub-second event-driven convergence #124
  added.

## Fix

Give each fabric its own refresh channel:

- Add `fabricRefreshCh1`; the fab1 loop reads it.
- `triggerFabricRefresh()` signals **both** channels (non-blocking, cap 1,
  coalescing) — mirroring the synchronous `RefreshFabricFwd()`, which already
  re-resolves both fab0 and fab1 on any trigger.
- Both channels are initialized in `startClusterComms` before the loops start.
- Single-fabric leaves `fabricRefreshCh1` nil; a non-blocking send on a nil
  channel is never ready, so it falls through `default` — no panic, no
  single-fabric behavior change.

## RED-on-revert

`TestTriggerFabricRefreshWakesBothFabrics` asserts a single
`triggerFabricRefresh()` wakes both channels. Dropping the fab1 send fails the
fab1 assertion (`fab1 refresh channel not signaled — dual-fabric event lost`).
Additional tests: coalescing to depth 1 without blocking, and single-fabric
nil-channel no-panic.

## Validation

- `gofmt` + `go vet` clean
- `go build ./...`
- `go test -race ./pkg/daemon/... ./pkg/cluster/...` all green
- Doc: `docs/fabric-cross-chassis-fwd.md` updated

`test-failover` is warranted (HA fabric path) for batch validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi