### PR TITLE
lldp: sanitize received TLV control chars (ANSI/CRLF log injection) (#4043)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-07-03 — #4043: received LLDP TLV strings logged/displayed without control-char sanitization → ANSI-escape / CRLF log-injection from a crafted L2 frame
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-178 (MEDIUM, security — log/terminal
+    injection via LLDP). LLDP is an unauthenticated L2 protocol; any device on
+    the segment can send a frame whose free-text TLVs (system-name,
+    system-description, port-description, port-id, non-MAC chassis-id) carry
+    ANSI escape sequences, CR/LF, or other control characters. `ParseTLVs`
+    stored those strings verbatim in the neighbor table, so `expiryLoop`'s log
+    line and the `show lldp neighbors` table (both grpcapi and CLI) emitted the
+    raw bytes — cursor/screen ANSI spoofing on an operator terminal and
+    forged/split syslog lines (log injection).
+  - **Fix**: added `sanitizeTLVString` (rune-aware `strings.Map` +
+    `unicode.IsControl`, replacing every C0/C1/DEL control rune with a space,
+    preserving legitimate multi-byte UTF-8) and applied it at the parse/store
+    boundary in `ParseTLVs` for all five wire-sourced operator-visible fields.
+    Sanitizing at store means the neighbor table holds clean strings, so the
+    log AND both show paths read already-sanitized values from one chokepoint.
+    This is the LLDP-receive counterpart of the #1798/#3900 free-text
+    control-char sanitizer.
+  - **File(s)**: pkg/lldp/lldp.go, pkg/lldp/lldp_test.go, pkg/lldp/README.md
+  - **Validation**: `go test ./pkg/lldp/...` green; new `TestSanitizeTLVString`
+    (table-driven helper unit test) + `TestParseTLVs_SanitizesControlChars`
+    (end-to-end store boundary, RED-on-revert across all five fields) +
+    `TestParseTLVs_CleanStringsUnchanged` (negative control — a clean name is
+    stored verbatim). `go build ./...`, `gofmt`, `go vet` clean.
+
 ## 2026-07-03 — #4034: a non-fatal error in the tail of the config apply path skipped syncConfigToPeer → the standby never got the committed config (HA divergence)
 
 - **Timestamp**: 2026-07-03

--- a/pkg/lldp/README.md
+++ b/pkg/lldp/README.md
@@ -125,3 +125,17 @@ Two properties keep this safe (#2372 review findings 3 + 6):
   rejected rather than cached under an empty `ifname//` key with TTL 0
   (#2551). A valid 2-byte TTL of 0 is a legitimate shutdown advert and is
   still accepted (the gate is "the TLV parsed", not "TTL != 0").
+- **Control-char sanitization on receive (#4043):** LLDP is an
+  unauthenticated L2 protocol — any device on the segment can craft a frame
+  whose free-text TLVs carry ANSI escape sequences, CR/LF, or other control
+  characters. `ParseTLVs` runs every operator-visible received string
+  (system-name, system-description, port-description, port-id, and the
+  non-MAC chassis-id) through `sanitizeTLVString` at the store boundary
+  before it lands in the neighbor table, so both the expiry log line and the
+  `show lldp neighbors` table read already-clean strings. Each Unicode
+  control rune (C0 `0x00-0x1F` including ESC/CR/LF, DEL `0x7F`, and C1
+  `0x80-0x9F`) is replaced by a space; a legitimate multi-byte UTF-8 name is
+  preserved unchanged (`strings.Map` is rune-aware). This is the
+  LLDP-receive counterpart of the #1798/#3900 free-text sanitizer and
+  neutralizes terminal-escape spoofing (`show lldp neighbors`) and syslog
+  log-injection (a forged/split log line) from a hostile neighbor.

--- a/pkg/lldp/lldp.go
+++ b/pkg/lldp/lldp.go
@@ -11,9 +11,11 @@ import (
 	"log/slog"
 	"net"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode"
 
 	"github.com/psaab/xpf/pkg/linuxsock"
 	"golang.org/x/sys/unix"
@@ -638,6 +640,35 @@ func encodeTTL(seconds int) []byte {
 	return val
 }
 
+// sanitizeTLVString neutralizes control characters in an LLDP TLV string
+// received from the wire before it is stored in the neighbor table — and so
+// before expiryLoop logs it or `show lldp neighbors` displays it. LLDP is an
+// unauthenticated L2 protocol: any device on the segment can send a frame
+// whose system-name / system-description / port-description / port-id /
+// chassis-id TLV carries ANSI escape sequences, CR/LF, or other control
+// characters. Left raw, those bytes reach an operator's terminal (cursor
+// moves, screen clears, spoofed output via `show lldp neighbors`) or forge /
+// split a syslog line (log injection). Every Unicode control character — the
+// C0 set (0x00-0x1F, which includes ESC 0x1B, CR and LF), DEL (0x7F), and the
+// C1 set (0x80-0x9F) — is replaced by a single space. This is the
+// LLDP-receive counterpart of the #1798/#3900 free-text control-char
+// sanitizer. strings.Map is rune-aware, so a legitimate multi-byte UTF-8
+// system name passes through unchanged and only control runes are
+// neutralized; an invalid UTF-8 byte decodes to U+FFFD (not a control rune)
+// so no raw byte escapes. Replacing rather than deleting keeps adjacent words
+// readable.
+func sanitizeTLVString(s string) string {
+	if strings.IndexFunc(s, unicode.IsControl) < 0 {
+		return s
+	}
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, s)
+}
+
 // ParseTLVs parses LLDP TLVs from raw payload (after Ethernet header).
 // Returns nil if any mandatory TLV (Chassis ID, Port ID, TTL) is missing OR
 // truncated: a mandatory TLV is only counted present once its value parsed
@@ -678,14 +709,19 @@ func ParseTLVs(data []byte) *Neighbor {
 				// MAC subtype with len 2..6 is truncated for its own subtype —
 				// do not accept it.
 			} else if len(value) >= 2 {
-				n.ChassisID = string(value[1:])
+				// Non-MAC chassis-id subtypes carry a free-text identifier
+				// straight off the wire — sanitize control chars (#4043).
+				n.ChassisID = sanitizeTLVString(string(value[1:]))
 				hasChassis = true
 			}
 		case tlvPortID:
 			// Same gating as Chassis ID: a subtype byte with no identifier
 			// (len < 2) is truncated, so leave hasPort false (#2551).
 			if len(value) >= 2 {
-				n.PortID = string(value[1:])
+				// Port-id is untrusted L2 input — sanitize control chars so a
+				// crafted TLV can't inject ANSI/CRLF into the log or the
+				// `show lldp neighbors` table (#4043).
+				n.PortID = sanitizeTLVString(string(value[1:]))
 				hasPort = true
 			}
 		case tlvTTL:
@@ -698,11 +734,13 @@ func ParseTLVs(data []byte) *Neighbor {
 				hasTTL = true
 			}
 		case tlvSystemName:
-			n.SystemName = string(value)
+			// Operator-visible free-text TLVs from an untrusted neighbor —
+			// sanitize control chars before storing (#4043).
+			n.SystemName = sanitizeTLVString(string(value))
 		case tlvSystemDesc:
-			n.SystemDesc = string(value)
+			n.SystemDesc = sanitizeTLVString(string(value))
 		case tlvPortDesc:
-			n.PortDesc = string(value)
+			n.PortDesc = sanitizeTLVString(string(value))
 		}
 	}
 

--- a/pkg/lldp/lldp_test.go
+++ b/pkg/lldp/lldp_test.go
@@ -3,8 +3,10 @@ package lldp
 import (
 	"encoding/binary"
 	"net"
+	"strings"
 	"testing"
 	"time"
+	"unicode"
 )
 
 func TestEncodeTLV(t *testing.T) {
@@ -301,6 +303,125 @@ func TestParseTLVs_ValidShutdownTTL(t *testing.T) {
 	}
 	if n.PortID != "trust0" {
 		t.Errorf("port ID: got %s, want trust0", n.PortID)
+	}
+}
+
+// TestSanitizeTLVString unit-tests the LLDP-receive control-char sanitizer
+// (#4043): every C0/C1/DEL control character is replaced by a space, a normal
+// ASCII or multi-byte UTF-8 string is returned unchanged, and no control byte
+// survives. LLDP TLV strings are untrusted L2 input; leaving ESC/CR/LF raw
+// would let a crafted neighbor inject ANSI sequences into an operator's
+// terminal or forge/split a syslog line.
+func TestSanitizeTLVString(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain ascii unchanged", "switch-core-1", "switch-core-1"},
+		{"utf8 preserved", "café-λ-世界", "café-λ-世界"},
+		{"ansi escape stripped", "\x1b[31mred", " [31mred"},
+		{"crlf log injection", "a\r\nDROP", "a  DROP"},
+		{"nul and c0", "x\x00y\x07z", "x y z"},
+		{"del stripped", "a\x7fb", "a b"},
+		{"c1 stripped", "aC", "a C"},
+		{"trailing newline", "port0\n", "port0 "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeTLVString(tc.in)
+			if got != tc.want {
+				t.Errorf("sanitizeTLVString(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if i := strings.IndexFunc(got, unicode.IsControl); i >= 0 {
+				t.Errorf("sanitizeTLVString(%q) retained a control char at byte %d: %q", tc.in, i, got)
+			}
+		})
+	}
+}
+
+// TestParseTLVs_SanitizesControlChars asserts the end-to-end store boundary:
+// a received LLDP frame whose free-text TLVs (system-name, system-desc,
+// port-desc, port-id, non-MAC chassis-id) carry ESC + CRLF + C0/DEL control
+// characters is parsed into a neighbor whose stored strings are control-char
+// free, so neither expiryLoop's log line nor the `show lldp neighbors` table
+// can be poisoned by a hostile neighbor (#4043). Readable payload survives.
+func TestParseTLVs_SanitizesControlChars(t *testing.T) {
+	sysName := "\x1b[31mroot\r\nfake-log-line"
+	sysDesc := "desc\x1b]0;title\x07"
+	portDesc := "port\x00\x0bdesc"
+	portID := "eth\x1b[2J0\n"
+	// Non-MAC chassis-id subtype (7 = locally assigned) carrying a CRLF.
+	chassisRaw := append([]byte{7}, []byte("host\r\nA")...)
+
+	data := concat(
+		rawTLV(tlvChassisID, chassisRaw),
+		mustEncodeTLV(tlvPortID, encodePortID(portID)),
+		mustEncodeTLV(tlvTTL, encodeTTL(120)),
+		mustEncodeTLV(tlvSystemName, []byte(sysName)),
+		mustEncodeTLV(tlvSystemDesc, []byte(sysDesc)),
+		mustEncodeTLV(tlvPortDesc, []byte(portDesc)),
+		mustEncodeTLV(tlvEnd, nil),
+	)
+
+	n := ParseTLVs(data)
+	if n == nil {
+		t.Fatal("ParseTLVs returned nil for a valid (if hostile) frame")
+	}
+
+	for name, got := range map[string]string{
+		"SystemName": n.SystemName,
+		"SystemDesc": n.SystemDesc,
+		"PortDesc":   n.PortDesc,
+		"PortID":     n.PortID,
+		"ChassisID":  n.ChassisID,
+	} {
+		if i := strings.IndexFunc(got, unicode.IsControl); i >= 0 {
+			t.Errorf("%s retained a control char at byte %d: %q", name, i, got)
+		}
+	}
+
+	// The printable payload survives (control chars become spaces, not drops).
+	if !strings.Contains(n.SystemName, "root") || !strings.Contains(n.SystemName, "fake-log-line") {
+		t.Errorf("SystemName lost readable text: %q", n.SystemName)
+	}
+	if strings.ContainsAny(n.PortID, "\x1b\n") {
+		t.Errorf("PortID still carries ESC/LF: %q", n.PortID)
+	}
+	if !strings.HasPrefix(n.ChassisID, "host") {
+		t.Errorf("ChassisID lost readable text: %q", n.ChassisID)
+	}
+}
+
+// TestParseTLVs_CleanStringsUnchanged is the negative control for #4043: a
+// frame whose TLV strings contain no control characters is stored verbatim, so
+// the sanitizer never mangles a normal neighbor name.
+func TestParseTLVs_CleanStringsUnchanged(t *testing.T) {
+	mac := net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
+	data := concat(
+		mustEncodeTLV(tlvChassisID, encodeChassisID(mac)),
+		mustEncodeTLV(tlvPortID, encodePortID("ge-0/0/1")),
+		mustEncodeTLV(tlvTTL, encodeTTL(120)),
+		mustEncodeTLV(tlvSystemName, []byte("switch-core-1")),
+		mustEncodeTLV(tlvSystemDesc, []byte("Juniper EX4300")),
+		mustEncodeTLV(tlvPortDesc, []byte("uplink to spine")),
+		mustEncodeTLV(tlvEnd, nil),
+	)
+	n := ParseTLVs(data)
+	if n == nil {
+		t.Fatal("ParseTLVs returned nil for a valid clean frame")
+	}
+	if n.PortID != "ge-0/0/1" {
+		t.Errorf("PortID: got %q, want %q", n.PortID, "ge-0/0/1")
+	}
+	if n.SystemName != "switch-core-1" {
+		t.Errorf("SystemName: got %q, want %q", n.SystemName, "switch-core-1")
+	}
+	if n.SystemDesc != "Juniper EX4300" {
+		t.Errorf("SystemDesc: got %q, want %q", n.SystemDesc, "Juniper EX4300")
+	}
+	if n.PortDesc != "uplink to spine" {
+		t.Errorf("PortDesc: got %q, want %q", n.PortDesc, "uplink to spine")
 	}
 }
 


### PR DESCRIPTION
Closes #4043

## Problem

LLDP is an unauthenticated L2 protocol. `ParseTLVs` (`pkg/lldp/lldp.go`) stored the received free-text TLV strings — **system-name, system-description, port-description, port-id, and the non-MAC chassis-id** — verbatim in the neighbor table. From there:

- `expiryLoop` logs the chassis/port fields (slog), and
- both `show lldp neighbors` renderers (`pkg/grpcapi/server_show_dhcp_lldp_snmp.go`, `pkg/cli/cli_show_services.go`) print them straight to the operator's terminal.

Any device on the local segment can send an LLDP frame whose TLV carries ANSI escape sequences, CR/LF, or other control characters, and thereby:

- inject ANSI escapes into an operator's terminal via `show lldp neighbors` (cursor moves, screen clear, output spoofing); or
- forge / split a syslog line via embedded CR/LF (log injection).

This is the LLDP-receive member of the #1798/#3900 free-text control-char sanitization class — a neighbor is untrusted input.

## Fix

Added `sanitizeTLVString` — a rune-aware `strings.Map` that replaces every Unicode control rune (C0 `0x00-0x1F` incl. ESC/CR/LF, DEL `0x7F`, C1 `0x80-0x9F`) with a single space while leaving legitimate multi-byte UTF-8 unchanged — and applied it at the **parse/store boundary** in `ParseTLVs` for all five wire-sourced operator-visible fields.

Sanitizing at store means the neighbor table holds clean strings, so the expiry log **and** both show paths read already-sanitized values from a single chokepoint (and the map key built from ChassisID/PortID can no longer carry raw control bytes). The MAC-subtype chassis-id branch is structurally safe (a formatted MAC) and left untouched.

## Tests

- `TestSanitizeTLVString` — table-drives the helper: plain ASCII and multi-byte UTF-8 pass through unchanged; C0/C1/DEL/ESC/CRLF are neutralized.
- `TestParseTLVs_SanitizesControlChars` — end-to-end: a crafted frame whose five free-text TLVs carry ESC + CRLF + NUL is parsed, and every stored field is asserted control-char free while readable payload survives. **Goes RED on revert** (raw control chars pass through) for all five fields.
- `TestParseTLVs_CleanStringsUnchanged` — negative control: a clean frame is stored verbatim.

`go test ./pkg/lldp/...` green; `go build ./...`, `gofmt`, `go vet` clean. Module README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
