### PR TITLE
lldp: bound the received-neighbor table with a per-interface cap (#4044)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,37 @@
+## 2026-07-03 — #4044: the LLDP received-neighbor table was unbounded → an LLDP frame flood (many spoofed chassis/port ids) grew it without limit → OOM (L2 DoS)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-177 (MEDIUM, DoS — unbounded LLDP neighbor
+    table). LLDP is an unauthenticated L2 protocol; any device on the segment
+    can send frames carrying arbitrary (spoofed) chassis-id / port-id pairs,
+    one distinct neighbor entry per distinct pair. `rxLoop` stored every
+    learned frame unconditionally (`m.neighbors[key] = neighbor`), so a flood
+    of distinct-id frames grew the map without bound until the daemon was
+    OOM-killed. `expiryLoop` reaps only *expired* entries every 10s, so a flood
+    faster than the reap interval — or advertising a large TTL — grew the table
+    unbounded between reaps.
+  - **Fix**: bounded the table per local interface. The receive path now routes
+    every learned neighbor through `learnNeighbor`, which caps at
+    `maxNeighborsPerInterface` (64) per interface: a refresh of an already-known
+    `ifname/chassis/port` key updates in place (never grows the map, so an
+    established neighbor's re-advertisements are never dropped), and a genuinely
+    new neighbor past the cap is DROPPED with a warn rate-limited to once per
+    60s per interface (so the flood floods neither the table nor the log). The
+    effective global bound is the cap times the operator-configured
+    LLDP-enabled interface count, so no separate global cap is needed.
+    `expiryLoop` still reaps aged-out entries, so once a transient flood stops
+    the table shrinks back below the cap. The warn dampener is reset alongside
+    the neighbor table in `Stop()`.
+  - **File(s)**: pkg/lldp/lldp.go, pkg/lldp/lldp_test.go,
+    pkg/lldp/socket_test.go, pkg/lldp/README.md
+  - **Validation**: `go test -race ./pkg/lldp/...` green; new
+    `TestLearnNeighborCapPerInterface` (cap/refresh/per-interface budget, RED on
+    revert), `TestLearnNeighborCapWarnsRateLimited` (exactly one warn for 10
+    drops), and `TestRxLoopBoundsNeighborTableUnderFlood` (real receive path,
+    cap+50 distinct-id frames bounded at the cap — grows to 114 on revert). All
+    three verified RED with the cap disabled. `go build ./...`, `gofmt`,
+    `go vet` clean.
+
 ## 2026-07-03 — #4043: received LLDP TLV strings logged/displayed without control-char sanitization → ANSI-escape / CRLF log-injection from a crafted L2 frame
 
 - **Timestamp**: 2026-07-03

--- a/pkg/lldp/README.md
+++ b/pkg/lldp/README.md
@@ -2,7 +2,8 @@
 
 IEEE 802.1AB Link Layer Discovery Protocol. Sends periodic LLDP frames
 out unmanaged interfaces, receives neighbor announcements, and ages
-entries by TTL.
+entries by TTL. The received-neighbor table is bounded per interface so a
+frame flood cannot exhaust memory (#4044).
 
 ## Entry points
 
@@ -125,6 +126,30 @@ Two properties keep this safe (#2372 review findings 3 + 6):
   rejected rather than cached under an empty `ifname//` key with TTL 0
   (#2551). A valid 2-byte TTL of 0 is a legitimate shutdown advert and is
   still accepted (the gate is "the TLV parsed", not "TTL != 0").
+- **Bounded neighbor table (#4044):** LLDP is unauthenticated L2 — any
+  station on the segment can flood frames carrying arbitrary (spoofed)
+  chassis-id / port-id pairs, one distinct neighbor entry per distinct
+  pair, and a switching loop can multiply frames. Left unbounded the
+  table grew until the daemon was OOM-killed (an L2-local DoS);
+  `expiryLoop` reaps only *expired* entries every 10s, so a flood faster
+  than the reap interval — or advertising a large TTL — grew the table
+  without bound between reaps. The receive path routes every learned
+  neighbor through `learnNeighbor` (`lldp.go`), which caps the table at
+  `maxNeighborsPerInterface` (64) **per local interface**: a refresh of an
+  already-known `ifname/chassis/port` key always updates in place (never
+  grows the map, so an established neighbor's re-advertisements are never
+  dropped), but a genuinely new neighbor past the cap is **dropped** with a
+  warn rate-limited to once per 60s per interface (so the flood floods
+  neither the table nor the log). A real switch port sees one, maybe a
+  handful, of neighbors, so 64 is far above any legitimate topology; the
+  effective global bound is the cap times the operator-configured
+  LLDP-enabled interface count, so no separate global cap is needed.
+  `expiryLoop` still reaps aged-out entries, so once a transient flood
+  stops the table shrinks back below the cap and new legitimate neighbors
+  are admitted again. Because the table is bounded at the cap per
+  interface, the per-interface count on the new-neighbor path iterates a
+  small, bounded set. The warn dampener is reset alongside the neighbor
+  table in `Stop()`, so a fresh `Apply` generation warns again.
 - **Control-char sanitization on receive (#4043):** LLDP is an
   unauthenticated L2 protocol — any device on the segment can craft a frame
   whose free-text TLVs carry ANSI escape sequences, CR/LF, or other control

--- a/pkg/lldp/lldp.go
+++ b/pkg/lldp/lldp.go
@@ -100,6 +100,12 @@ type Manager struct {
 	// re-Apply (which would Stop()/rebuild the generation and wipe the neighbor
 	// table). Atomic so a test reading it does not race a concurrent Apply.
 	applyCount atomic.Uint64
+
+	// capDropLastWarn rate-limits the "neighbor table full" warning per local
+	// interface so an LLDP flood (a dropped frame every packet) cannot itself
+	// become a log flood. Keyed by interface name, guarded by mu (only touched
+	// from learnNeighbor, which already holds mu). See #4044.
+	capDropLastWarn map[string]time.Time
 }
 
 // ifSession owns the RX and TX AF_PACKET sockets for one interface for the life
@@ -214,7 +220,8 @@ func (s *ifSession) close() {
 // New creates a new LLDP manager.
 func New() *Manager {
 	return &Manager{
-		neighbors: make(map[string]*Neighbor),
+		neighbors:       make(map[string]*Neighbor),
+		capDropLastWarn: make(map[string]time.Time),
 	}
 }
 
@@ -324,6 +331,7 @@ func (m *Manager) Stop() {
 
 	m.mu.Lock()
 	m.neighbors = make(map[string]*Neighbor)
+	m.capDropLastWarn = make(map[string]time.Time)
 	m.mu.Unlock()
 }
 
@@ -496,10 +504,76 @@ func (m *Manager) rxLoop(ctx context.Context, sess *ifSession) {
 		neighbor.ExpiresAt = time.Now().Add(time.Duration(neighbor.TTL) * time.Second)
 
 		key := fmt.Sprintf("%s/%s/%s", iface.Name, neighbor.ChassisID, neighbor.PortID)
-		m.mu.Lock()
-		m.neighbors[key] = neighbor
-		m.mu.Unlock()
+		m.learnNeighbor(key, neighbor)
 	}
+}
+
+// maxNeighborsPerInterface bounds the number of distinct LLDP neighbors the
+// receive path caches per local interface. LLDP is an unauthenticated L2
+// protocol: any device on the segment can flood frames carrying arbitrary
+// (spoofed) chassis-id / port-id values, and each distinct pair would create a
+// new neighbor entry. Without a cap the table grows without bound until the
+// daemon is OOM-killed — an L2-local DoS: whoever can put frames on the wire
+// (or a switching loop that multiplies frames) can exhaust memory. A real
+// switch port sees one, occasionally a handful, of LLDP neighbors; 64 is far
+// above any legitimate topology while still bounding a flood. The effective
+// global bound is this cap times the number of LLDP-enabled interfaces (a
+// small, operator-configured set), so no separate global cap is needed (#4044).
+const maxNeighborsPerInterface = 64
+
+// capDropWarnInterval rate-limits the per-interface "neighbor table full"
+// warning so an ongoing flood (one drop per frame) does not itself flood the
+// log.
+const capDropWarnInterval = 60 * time.Second
+
+// learnNeighbor installs or refreshes a received neighbor under the
+// per-interface cap. A refresh of an already-known (ifname/chassis/port) key
+// updates in place and never grows the table, so an established neighbor's
+// periodic re-advertisements always take effect. A genuinely NEW neighbor is
+// admitted only while its interface is below maxNeighborsPerInterface; past the
+// cap it is DROPPED with a rate-limited warn, so an LLDP flood of distinct
+// spoofed ids cannot grow the table without bound (#4044). expiryLoop still
+// reaps aged-out entries, so once a transient flood stops advertising the table
+// shrinks back below the cap and new legitimate neighbors are admitted again.
+// Returns true if the neighbor was stored, false if it was dropped by the cap.
+func (m *Manager) learnNeighbor(key string, n *Neighbor) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.neighbors[key]; exists {
+		// Refresh of a known neighbor: update in place. Does not grow the map,
+		// so it is always allowed even at the cap.
+		m.neighbors[key] = n
+		return true
+	}
+
+	// New neighbor: enforce the per-interface cap. The table is bounded at the
+	// cap per interface, so this count iterates a small, bounded set.
+	count := 0
+	for _, existing := range m.neighbors {
+		if existing.Interface == n.Interface {
+			count++
+		}
+	}
+	if count >= maxNeighborsPerInterface {
+		m.warnNeighborCapDroppedLocked(n.Interface)
+		return false
+	}
+	m.neighbors[key] = n
+	return true
+}
+
+// warnNeighborCapDroppedLocked logs (at most once per capDropWarnInterval per
+// interface) that the neighbor table is full and a new neighbor was dropped.
+// The caller must hold m.mu.
+func (m *Manager) warnNeighborCapDroppedLocked(iface string) {
+	now := time.Now()
+	if last, ok := m.capDropLastWarn[iface]; ok && now.Sub(last) < capDropWarnInterval {
+		return
+	}
+	m.capDropLastWarn[iface] = now
+	slog.Warn("LLDP: neighbor table full, dropping new neighbor",
+		"interface", iface, "cap", maxNeighborsPerInterface)
 }
 
 // expiryLoop periodically removes expired neighbors.

--- a/pkg/lldp/lldp_test.go
+++ b/pkg/lldp/lldp_test.go
@@ -1,9 +1,13 @@
 package lldp
 
 import (
+	"context"
 	"encoding/binary"
+	"fmt"
+	"log/slog"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 	"unicode"
@@ -545,4 +549,146 @@ func TestStopIdempotent(t *testing.T) {
 	m := New()
 	m.Stop() // should not panic
 	m.Stop() // double stop should be fine
+}
+
+// mkNeighbor builds a Neighbor for the cap tests.
+func mkNeighbor(iface, chassis, port string) *Neighbor {
+	return &Neighbor{
+		ChassisID: chassis,
+		PortID:    port,
+		TTL:       120,
+		Interface: iface,
+		LastSeen:  time.Now(),
+		ExpiresAt: time.Now().Add(120 * time.Second),
+	}
+}
+
+func neighborKey(iface, chassis, port string) string {
+	return fmt.Sprintf("%s/%s/%s", iface, chassis, port)
+}
+
+// TestLearnNeighborCapPerInterface is the fail-on-revert unit test for the
+// #4044 neighbor-table cap. It asserts:
+//   - exactly maxNeighborsPerInterface distinct neighbors are admitted on one
+//     interface;
+//   - a genuinely NEW neighbor past the cap is DROPPED (returns false) and does
+//     not grow the table (so a flood of distinct spoofed ids cannot OOM the
+//     daemon);
+//   - a refresh of an already-known key still succeeds at the cap and updates in
+//     place without growing the table (an established neighbor's periodic
+//     re-advertisement is never dropped);
+//   - the cap is PER INTERFACE — a second interface has its own budget.
+//
+// On revert (learnNeighbor storing unconditionally) the over-cap add grows the
+// table to cap+1, so the bounded-length assertions fail.
+func TestLearnNeighborCapPerInterface(t *testing.T) {
+	m := New()
+
+	// Fill eth0 exactly to the cap. Every add is a distinct new key.
+	for i := 0; i < maxNeighborsPerInterface; i++ {
+		chassis := fmt.Sprintf("02:00:00:00:00:%02x", i)
+		if !m.learnNeighbor(neighborKey("eth0", chassis, "p"), mkNeighbor("eth0", chassis, "p")) {
+			t.Fatalf("add %d within cap should be admitted", i)
+		}
+	}
+	if got := len(m.Neighbors()); got != maxNeighborsPerInterface {
+		t.Fatalf("after filling to cap: got %d neighbors, want %d", got, maxNeighborsPerInterface)
+	}
+
+	// One more DISTINCT neighbor on eth0 must be dropped, not stored.
+	overChassis := "02:00:00:00:ff:ff"
+	if m.learnNeighbor(neighborKey("eth0", overChassis, "p"), mkNeighbor("eth0", overChassis, "p")) {
+		t.Fatal("a new neighbor past the per-interface cap must be dropped (returned true)")
+	}
+	if got := len(m.Neighbors()); got != maxNeighborsPerInterface {
+		t.Fatalf("table grew past the cap: got %d, want %d", got, maxNeighborsPerInterface)
+	}
+
+	// A refresh of an EXISTING key must still be accepted at the cap and update
+	// in place (no growth). Bump the TTL so we can confirm the update landed.
+	refreshChassis := "02:00:00:00:00:00"
+	refreshed := mkNeighbor("eth0", refreshChassis, "p")
+	refreshed.TTL = 999
+	if !m.learnNeighbor(neighborKey("eth0", refreshChassis, "p"), refreshed) {
+		t.Fatal("a refresh of an existing neighbor must be accepted even at the cap")
+	}
+	if got := len(m.Neighbors()); got != maxNeighborsPerInterface {
+		t.Fatalf("refresh must not grow the table: got %d, want %d", got, maxNeighborsPerInterface)
+	}
+	m.mu.RLock()
+	gotTTL := m.neighbors[neighborKey("eth0", refreshChassis, "p")].TTL
+	m.mu.RUnlock()
+	if gotTTL != 999 {
+		t.Fatalf("refresh did not update in place: TTL got %d, want 999", gotTTL)
+	}
+
+	// The cap is per interface: a neighbor on eth1 has its own budget.
+	if !m.learnNeighbor(neighborKey("eth1", "02:00:00:00:01:00", "p"), mkNeighbor("eth1", "02:00:00:00:01:00", "p")) {
+		t.Fatal("a neighbor on a different interface must be admitted (cap is per-interface)")
+	}
+	if got := len(m.Neighbors()); got != maxNeighborsPerInterface+1 {
+		t.Fatalf("per-interface cap should allow eth1 entry: got %d, want %d", got, maxNeighborsPerInterface+1)
+	}
+}
+
+// captureHandler is a slog.Handler that records emitted records for assertions.
+type captureHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	h.records = append(h.records, r.Clone())
+	h.mu.Unlock()
+	return nil
+}
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler      { return h }
+
+// TestLearnNeighborCapWarnsRateLimited asserts the cap fires a warn when a new
+// neighbor is dropped, and that the warn is rate-limited to once per interval
+// per interface so an ongoing flood cannot flood the log too (#4044).
+func TestLearnNeighborCapWarnsRateLimited(t *testing.T) {
+	h := &captureHandler{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	m := New()
+	// Fill to the cap (no drops, no warns yet).
+	for i := 0; i < maxNeighborsPerInterface; i++ {
+		chassis := fmt.Sprintf("02:00:00:00:00:%02x", i)
+		m.learnNeighbor(neighborKey("eth0", chassis, "p"), mkNeighbor("eth0", chassis, "p"))
+	}
+	// Now drop 10 distinct new neighbors past the cap.
+	for i := 0; i < 10; i++ {
+		chassis := fmt.Sprintf("02:00:00:00:aa:%02x", i)
+		if m.learnNeighbor(neighborKey("eth0", chassis, "p"), mkNeighbor("eth0", chassis, "p")) {
+			t.Fatalf("over-cap add %d should have been dropped", i)
+		}
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	warns := 0
+	var lastIface string
+	for _, r := range h.records {
+		if r.Level == slog.LevelWarn && strings.Contains(r.Message, "neighbor table full") {
+			warns++
+			r.Attrs(func(a slog.Attr) bool {
+				if a.Key == "interface" {
+					lastIface = a.Value.String()
+				}
+				return true
+			})
+		}
+	}
+	if warns != 1 {
+		t.Fatalf("expected exactly 1 rate-limited cap warn for 10 drops, got %d", warns)
+	}
+	if lastIface != "eth0" {
+		t.Fatalf("cap warn carried interface %q, want eth0", lastIface)
+	}
 }

--- a/pkg/lldp/socket_test.go
+++ b/pkg/lldp/socket_test.go
@@ -375,6 +375,80 @@ func TestRxLoopBackoffInterruptedByCancel(t *testing.T) {
 	}
 }
 
+// TestRxLoopBoundsNeighborTableUnderFlood is the end-to-end fail-on-revert
+// regression test for the #4044 unbounded-neighbor-table DoS. It drives the
+// real receive path (rxLoop) through the recvFn seam with a flood of
+// maxNeighborsPerInterface+50 LLDP frames, each carrying a DISTINCT chassis id
+// (distinct source MAC) so every frame is a genuinely new neighbor. The
+// per-interface cap must bound the table at exactly maxNeighborsPerInterface no
+// matter how many distinct-id frames arrive.
+//
+// Non-tautological / fail-on-revert: with the cap removed (rxLoop storing every
+// learned neighbor unconditionally, the pre-#4044 behavior) all flood frames
+// are stored and the table grows to flood == cap+50, so the bounded assertion
+// fails. The flood advertises a large TTL, so expiryLoop cannot mask the growth.
+func TestRxLoopBoundsNeighborTableUnderFlood(t *testing.T) {
+	const flood = maxNeighborsPerInterface + 50
+
+	frames := make([][]byte, flood)
+	for i := range frames {
+		// Distinct source MAC per frame => distinct chassis id => distinct key.
+		mac := net.HardwareAddr{0x02, 0x00, 0x00, byte(i >> 16), byte(i >> 8), byte(i)}
+		f, err := BuildFrame(mac, "flood0", 3600, "attacker", "")
+		if err != nil {
+			t.Fatalf("BuildFrame %d: %v", i, err)
+		}
+		frames[i] = f
+	}
+
+	var idx int32
+	allDelivered := make(chan struct{})
+	var once sync.Once
+	gate := make(chan struct{})
+	sess := &ifSession{
+		iface: &net.Interface{Name: "flood0", Index: 1},
+		recvFn: func(buf []byte) (int, int, error) {
+			i := int(atomic.AddInt32(&idx, 1)) - 1
+			if i < flood {
+				return copy(buf, frames[i]), unix.PACKET_HOST, nil
+			}
+			// recv is re-entered only after the previous frame is fully
+			// processed, so by this call all `flood` frames are learned.
+			once.Do(func() { close(allDelivered) })
+			<-gate
+			return 0, 0, unix.EBADF
+		},
+	}
+
+	m := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	loopDone := make(chan struct{})
+	go func() {
+		m.rxLoop(ctx, sess)
+		close(loopDone)
+	}()
+
+	select {
+	case <-allDelivered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("rxLoop did not consume all flood frames within 5s")
+	}
+
+	if got := len(m.Neighbors()); got != maxNeighborsPerInterface {
+		t.Fatalf("neighbor table not bounded under flood: got %d neighbors, want cap %d "+
+			"(revert removes the cap and the table grows to %d)",
+			got, maxNeighborsPerInterface, flood)
+	}
+
+	cancel()
+	close(gate)
+	select {
+	case <-loopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("rxLoop did not exit after ctx cancellation")
+	}
+}
+
 // TestApplySkipsInterfaceOnSocketError verifies that a session construction
 // failure (e.g. CAP_NET_RAW missing) is surfaced at Apply time by skipping the
 // interface, and that Stop() afterwards is still a clean no-op.


### PR DESCRIPTION
Closes #4044.

## Problem

The LLDP received-neighbor table (`m.neighbors` in `pkg/lldp/lldp.go`)
had no size limit. LLDP is an unauthenticated L2 protocol: any device on
the local segment can send frames carrying arbitrary (spoofed)
chassis-id / port-id values, one distinct neighbor entry per distinct
pair. `rxLoop` stored every learned frame unconditionally
(`m.neighbors[key] = neighbor`), so a flood of distinct-id frames grew
the map without bound until the daemon was OOM-killed — an L2-local DoS
(whoever can put frames on the wire, or a switching loop that multiplies
frames, can exhaust memory). `expiryLoop` reaps only *expired* entries
every 10s, so a flood faster than the reap interval — or advertising a
large TTL — grows the table unbounded between reaps.

## Fix

Bound the table with a **per-interface cap**. The receive path routes
every learned neighbor through `learnNeighbor`, which:

- always updates an already-known `ifname/chassis/port` key in place — an
  established neighbor's periodic re-advertisements never grow the map and
  are never dropped;
- admits a genuinely new neighbor only while its interface is below
  `maxNeighborsPerInterface` (64); past the cap the new neighbor is
  **dropped** with a warn rate-limited to once per 60s per interface, so
  the flood floods neither the table nor the log.

A real switch port sees one, occasionally a handful, of LLDP neighbors;
64 is far above any legitimate topology. The effective global bound is
the cap times the operator-configured LLDP interface count, so no
separate global cap is needed. `expiryLoop` still reaps aged-out entries,
so once a transient flood stops the table shrinks back below the cap and
new legitimate neighbors are admitted again. Because the table is bounded
at the cap per interface, the per-interface count on the new-neighbor
path iterates only a small, bounded set. The warn dampener is reset
alongside the neighbor table in `Stop()`.

## Tests (fail-on-revert)

- `TestLearnNeighborCapPerInterface` — exactly the cap admitted on one
  interface; a new neighbor past the cap dropped without growth; a refresh
  of an existing key still accepted at the cap and updated in place; a
  second interface has its own budget.
- `TestLearnNeighborCapWarnsRateLimited` — 10 drops emit exactly one warn
  (rate-limited per interface) carrying the interface attribute.
- `TestRxLoopBoundsNeighborTableUnderFlood` — drives the real receive path
  (`rxLoop` via the `recvFn` seam) with cap+50 distinct-id frames
  (large TTL so `expiryLoop` can't mask it) and asserts the table is
  bounded at the cap.

All three go RED with the cap disabled (the flood test grows to 114 vs.
the cap of 64). Verified green under `-race`; `go build ./...`, `gofmt`,
`go vet` clean. Module doc (`pkg/lldp/README.md`) and `_Log.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
