### PR TITLE
userspace-dp: recycle the direct-TX diagnostic frame exactly once (#4041)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,38 @@
+## 2026-07-03 — #4041: the debug-log direct-TX diagnostic double-recycled a UMEM frame offset on a tuple-mismatch → the offset aliased an in-flight TX frame (on-wire corruption / double-free, debug-log build)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-079 (MEDIUM, Rust dataplane, debug-log build).
+    On the cross-binding direct-TX path in `enqueue_pending_forwards`
+    (`userspace-dp/src/afxdp/tx/dispatch/mod.rs`), the `debug-log`-gated
+    tuple-mismatch diagnostic (`if cfg!(feature = "debug-log")`) pushed the
+    built frame's `tx_offset` back onto `free_tx_frames` AND set
+    `build_failed = true`. The shared `if build_failed` handler immediately
+    below then pushed the SAME `tx_offset` a second time. The offset landed on
+    the free-list twice → it was popped for two later TX descriptors that
+    aliased one in-flight UMEM frame → on-wire corruption / double-free. Only
+    the direct-TX path was affected: the three sibling debug-log mismatch sites
+    (segmentation + the two Vec-copy fallbacks) operate on owned `Vec` frames,
+    not free-list offsets, and forward-anyway without recycling.
+  - **Fix**: removed the recycle push from the diagnostic branch. The mismatch
+    is still recorded via `record_exception`, and `build_failed = true` routes
+    the drop through the SINGLE `if build_failed` recycle — the offset returns
+    to `free_tx_frames` exactly once. A correct builder can never trip the
+    mismatch (`enforce_expected_ports` makes built ports == expected), so the
+    RED-on-revert test reaches the branch via a new `#[cfg(test)]`
+    `FORCE_TUPLE_MISMATCH` hook (mirrors the #2208 `FORCE_OVERSIZED` pattern,
+    routed through a `direct_tx_tuple_mismatch_reason` wrapper that DCEs out of
+    release). Test `direct_tx_tuple_mismatch_recycles_frame_exactly_once`
+    asserts no duplicate offset on the free-list (both builds) and, under
+    `--features debug-log`, pool-conservation + a recorded mismatch exception.
+  - **Validation**: RED-on-revert proven — reinstating the duplicate push fails
+    the test with `tx_offset 0 recycled 2 times` (run with
+    `--features debug-log`). FULL `cargo test --release` green; the new test
+    green under `--features debug-log`; `go build ./...` green. rustfmt touched
+    only the added lines (pre-existing repo quirks left alone).
+  - **File(s)**: userspace-dp/src/afxdp/tx/dispatch/mod.rs,
+    userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs,
+    userspace-dp/src/afxdp/tx/README.md, _Log.md
+
 ## 2026-07-03 — #4034: a non-fatal error in the tail of the config apply path skipped syncConfigToPeer → the standby never got the committed config (HA divergence)
 
 - **Timestamp**: 2026-07-03

--- a/userspace-dp/src/afxdp/tx/README.md
+++ b/userspace-dp/src/afxdp/tx/README.md
@@ -48,6 +48,15 @@ writer to synchronize against.
   `tx_shared_recycle_unknown_slot_drops` on the worker status surface with
   bounded one-line logging per drain; never push a foreign offset into an
   arbitrary binding's fill ring.
+- The cross-binding direct-TX build's `debug-log` tuple-mismatch diagnostic
+  (`dispatch/mod.rs`) drops the built frame by setting `build_failed`; the
+  frame's `tx_offset` is recycled to `free_tx_frames` through the SINGLE
+  `if build_failed` handler. The diagnostic branch records the mismatch
+  exception but must NOT push the offset itself. Recycling the same offset in
+  both the diagnostic branch and the `build_failed` handler double-frees it —
+  the offset is then handed out for two later TX descriptors that alias one
+  in-flight frame (on-wire corruption / double-free on the debug-log build).
+  Regression: `direct_tx_tuple_mismatch_recycles_frame_exactly_once` (#4041).
 - `Ordering::Relaxed` is intentional and correct given the
   single-writer invariant. Don't promote without proving a second
   writer exists.

--- a/userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs
@@ -707,6 +707,9 @@ impl Drop for ForceFaultGuard {
     fn drop(&mut self) {
         super::cos::FORCE_ENQUEUE_ERR.with(|c| c.set(false));
         super::FORCE_OVERSIZED.with(|c| c.set(false));
+        // #4041: reset the direct-TX tuple-mismatch injection so a panicking
+        // assertion cannot leak it into the next test on the same thread.
+        super::FORCE_TUPLE_MISMATCH.with(|c| c.set(false));
     }
 }
 
@@ -1473,4 +1476,143 @@ fn shared_exact_policy_handles_unknown_queue() {
         !request_runs_under_shared_exact_policy(&cos_fast_interfaces, 999, Some(5)),
         "an unknown egress_ifindex must not be reported as shared_exact policy"
     );
+}
+
+// #4041: the direct-TX diagnostic tuple-mismatch branch (debug-log build) must
+// recycle the frame's `tx_offset` onto `free_tx_frames` EXACTLY once. Before
+// the fix the mismatch branch pushed the offset AND the shared `if build_failed`
+// handler pushed it again — the same UMEM offset landed on the free-list twice,
+// so it was handed out for two later TX descriptors that then aliased one
+// in-flight frame (on-wire corruption / double-free on the debug-log build).
+//
+// A correct builder never trips the mismatch (`enforce_expected_ports` makes the
+// built L4 ports equal the expected tuple), so the branch is reached via the
+// `#[cfg(test)] FORCE_TUPLE_MISMATCH` hook. The branch itself only exists under
+// the `debug-log` feature (`if cfg!(feature = "debug-log")`), so the
+// single-recycle assertions are gated on that feature; the non-debug-log build
+// exercises the normal direct-TX forward (offset consumed by the TX pipeline).
+//
+// RED-on-revert (run with `--features debug-log`): reinstating the duplicate
+// `push_front` makes the popped offset appear twice in `free_tx_frames` and the
+// pool length grow by one — both assertions below fail.
+#[test]
+fn direct_tx_tuple_mismatch_recycles_frame_exactly_once() {
+    let _guard = ForceFaultGuard;
+    // Two bindings on SEPARATE UMEMs so `can_rewrite_in_place` is false and
+    // dispatch takes the cross-binding direct-TX path. Unlike the cp2 harness
+    // the egress pool is left populated so a direct-TX frame is available.
+    let mut bindings = vec![
+        BindingWorker::new_for_mirror_test(0, 0, 11, 0),
+        BindingWorker::new_for_mirror_test(1, 0, 22, 0),
+    ];
+    let original_frame = build_ipv4_test_packet(0);
+    unsafe {
+        bindings[0]
+            .umem
+            .area()
+            .slice_mut_unchecked(0, original_frame.len())
+    }
+    .expect("ingress frame")
+    .copy_from_slice(&original_frame);
+
+    let egress_free_before = bindings[1].tx_pipeline.free_tx_frames.len();
+    let front_offset = *bindings[1]
+        .tx_pipeline
+        .free_tx_frames
+        .front()
+        .expect("egress pool populated");
+
+    let forwarding = test_forwarding_with_egress_mtu(1500);
+    let lookup = WorkerBindingLookup::from_bindings(&bindings);
+    let mirror_targets = MirrorTargetMap::default();
+    let mut pending = vec![test_live_forward_request_for_frame(
+        original_frame.len(),
+        test_forwarding_decision_to_bound_ifindex(22),
+    )];
+    let mut post_recycles = Vec::new();
+    let ingress_ident = bindings[0].identity();
+    let ingress_live = &*bindings[0].live as *const BindingLiveState;
+    let local_tunnel_deliveries: Arc<ArcSwap<BTreeMap<i32, LocalTunnelDelivery>>> =
+        Arc::new(ArcSwap::from_pointee(BTreeMap::new()));
+    let recent_exceptions = Arc::new(Mutex::new(VecDeque::new()));
+    let worker_commands_by_id: BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>> = BTreeMap::new();
+    let mut dbg = DebugPollCounters::default();
+
+    // Force the direct-TX tuple-mismatch diagnostic branch to fire.
+    super::FORCE_TUPLE_MISMATCH.with(|c| c.set(true));
+
+    let (left, rest) = bindings.split_at_mut(0);
+    let (ingress, right) = rest.split_first_mut().expect("ingress binding");
+    enqueue_pending_forwards(
+        left,
+        0,
+        ingress,
+        right,
+        &lookup,
+        &mirror_targets,
+        &mut pending,
+        &mut post_recycles,
+        1,
+        &forwarding,
+        &ingress_ident,
+        unsafe { &*ingress_live },
+        None,
+        &local_tunnel_deliveries,
+        &recent_exceptions,
+        &mut dbg,
+        &mut BatchCounters::default(),
+        0,
+        &worker_commands_by_id,
+    );
+
+    let free = &bindings[1].tx_pipeline.free_tx_frames;
+    // Regardless of build: the popped offset must never appear twice on the
+    // free-list — a duplicate is the aliasing bug.
+    let dup = free.iter().filter(|&&o| o == front_offset).count();
+    assert!(
+        dup <= 1,
+        "#4041: tx_offset {front_offset} recycled {dup} times — a duplicate \
+         free-list entry aliases an in-flight TX frame"
+    );
+
+    if cfg!(feature = "debug-log") {
+        // The mismatch fired: the frame was dropped and its offset returned to
+        // the pool exactly once, so the pool length is unchanged.
+        assert_eq!(
+            free.len(),
+            egress_free_before,
+            "#4041: a mismatch drop must recycle the offset exactly once \
+             (pool conserved); a second push grows the pool by one"
+        );
+        assert_eq!(
+            dup, 1,
+            "the recycled offset must be present exactly once after a mismatch drop"
+        );
+        let reasons: Vec<String> = recent_exceptions
+            .lock()
+            .expect("exceptions")
+            .iter()
+            .map(|e| e.reason.clone())
+            .collect();
+        assert!(
+            reasons
+                .iter()
+                .any(|r| r.starts_with("forward_tuple_mismatch")),
+            "the mismatch must still be recorded for operators: {reasons:?}"
+        );
+        assert_eq!(
+            dbg.enqueue_ok, 0,
+            "a dropped mismatch frame is not a successful TX"
+        );
+    } else {
+        // Without the debug-log feature the mismatch branch is compiled out; the
+        // direct-TX forward succeeds and the offset is consumed by the TX
+        // pipeline (one fewer free frame), never duplicated.
+        assert_eq!(
+            free.len(),
+            egress_free_before - 1,
+            "the direct-TX forward consumes exactly one free frame"
+        );
+        assert_eq!(dbg.enqueue_ok, 1, "the direct-TX forward is enqueued");
+    }
 }

--- a/userspace-dp/src/afxdp/tx/dispatch/mod.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/mod.rs
@@ -82,6 +82,36 @@ fn copy_frame_is_oversized(cp_len: usize) -> bool {
     cp_len > tx_frame_capacity()
 }
 
+// #4041: test-only fault injection for the direct-TX tuple-mismatch
+// diagnostic. The mismatch is a builder-bug paranoia check that a CORRECT
+// builder can never trip — `enforce_expected_ports()` in
+// `build_forwarded_frame_into_from_frame` makes the built L4 ports equal the
+// expected tuple, so `forward_tuple_mismatch_reason` always returns `None`
+// on a real frame. To exercise the single-recycle invariant on the diagnostic
+// branch (where the frame's `tx_offset` must be returned to `free_tx_frames`
+// EXACTLY once), this thread-local forces the branch. Like `FORCE_OVERSIZED`
+// above it is `#[cfg(test)]` only and DCEs out of release builds.
+#[cfg(test)]
+thread_local! {
+    static FORCE_TUPLE_MISMATCH: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+// #4041: wrapper around `forward_tuple_mismatch_reason` that lets the dispatch
+// tests force the direct-TX mismatch branch. The hot path is a single tail call
+// (the `#[cfg(test)]` block DCEs out), so release builds keep the bare check.
+#[inline(always)]
+fn direct_tx_tuple_mismatch_reason(
+    source_ports: Option<(u16, u16)>,
+    expected_ports: Option<(u16, u16)>,
+    built_ports: Option<(u16, u16)>,
+) -> Option<String> {
+    #[cfg(test)]
+    if FORCE_TUPLE_MISMATCH.with(|c| c.get()) {
+        return Some("forward_tuple_mismatch:forced-test".to_string());
+    }
+    forward_tuple_mismatch_reason(source_ports, expected_ports, built_ports)
+}
+
 #[inline]
 fn recycle_ingress_frame(ingress_binding: &mut BindingWorker, source_offset: u64, now_ns: u64) {
     ingress_binding
@@ -890,15 +920,23 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                                         request.meta.protocol,
                                     )
                                 });
-                                if let Some(reason) = forward_tuple_mismatch_reason(
+                                if let Some(reason) = direct_tx_tuple_mismatch_reason(
                                     live_frame_ports_from_meta_bytes(source_frame, request.meta),
                                     expected_ports,
                                     built_ports,
                                 ) {
-                                    target_binding
-                                        .tx_pipeline
-                                        .free_tx_frames
-                                        .push_front(tx_offset);
+                                    // #4041: DO NOT recycle `tx_offset` here.
+                                    // Setting `build_failed` routes this frame
+                                    // through the single `if build_failed`
+                                    // recycle below, which pushes the offset
+                                    // back onto `free_tx_frames` exactly once.
+                                    // Pushing it in this diagnostic branch too
+                                    // double-recycled the offset — it would be
+                                    // handed out twice on a later TX and alias
+                                    // an in-flight frame (on-wire corruption /
+                                    // double-free on the debug-log build). The
+                                    // `record_exception` below still surfaces
+                                    // the mismatch to operators.
                                     record_exception(
                                         recent_exceptions,
                                         ingress_ident,


### PR DESCRIPTION
Closes #4041

## Problem

On the cross-binding **direct-TX** path in `enqueue_pending_forwards`
(`userspace-dp/src/afxdp/tx/dispatch/mod.rs`), the `debug-log`-gated
tuple-mismatch diagnostic double-recycled a UMEM frame offset:

1. The diagnostic branch (`if let Some(reason) = forward_tuple_mismatch_reason(...)`)
   pushed the built frame's `tx_offset` back onto `free_tx_frames` **and** set
   `build_failed = true`.
2. The shared `if build_failed { ... push_front(tx_offset) }` handler immediately
   below pushed the **same** `tx_offset` a second time.

The offset landed on the free-list **twice**, so it was later popped for two TX
descriptors that aliased one in-flight UMEM frame — on-wire corruption (the
second writer overwrites the first frame before it is transmitted) or a
double-free. This only affects the **debug-log** build (used for diagnostics);
the release hot path compiles the branch out.

Only the direct-TX path is affected. The three sibling debug-log mismatch sites
(TCP segmentation + the two Vec-copy fallbacks) operate on owned `Vec` frames,
not free-list offsets, and forward-anyway without recycling.

## Fix

Remove the recycle push from the diagnostic branch. The mismatch is still
surfaced to operators via `record_exception`, and setting `build_failed = true`
routes the drop through the **single** `if build_failed` recycle — the offset
returns to `free_tx_frames` exactly once.

## Testing

A correct builder can never trip the mismatch: `enforce_expected_ports` makes the
built L4 ports equal the expected tuple, so `forward_tuple_mismatch_reason`
always returns `None` on a real frame. The regression test reaches the branch via
a new `#[cfg(test)] FORCE_TUPLE_MISMATCH` hook wired through a
`direct_tx_tuple_mismatch_reason` wrapper — mirroring the existing #2208
`FORCE_OVERSIZED` pattern (both DCE out of release).

`direct_tx_tuple_mismatch_recycles_frame_exactly_once` asserts the popped offset
never appears twice on the free-list (both builds) and, under `--features
debug-log`, that the pool is conserved (single recycle) plus the mismatch
exception is still recorded.

- **RED-on-revert** (run with `--features debug-log`): reinstating the duplicate
  push fails the test with `tx_offset 0 recycled 2 times — a duplicate free-list
  entry aliases an in-flight TX frame`.
- **Full `cargo test --release`**: green (3467 + 46 + 16 + 8 + 1 passed, 0 failed).
- **Full `cargo test --release --features debug-log`**: green (same counts).
- **`go build ./...`**: green.
- rustfmt touched only the added lines (pre-existing repo quirks left alone).

Docs: added a "Notable invariants" bullet to `userspace-dp/src/afxdp/tx/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
