### PR TITLE
lldp: resolve kernel (dash-form) ifname before socket lookup (#4049)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-07-03 — #4049: LLDP resolved its socket with the Junos slash name (ge-0/0/0) instead of the kernel dash name (ge-0-0-0) → net.InterfaceByName failed → LLDP never started on any renamed data port
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-068 (MEDIUM, LLDP broken on renamed
+    interfaces). `Manager.Apply` (`pkg/lldp/lldp.go`) opened its AF_PACKET
+    socket via `net.InterfaceByName(lldpIf.Name)`, where `lldpIf.Name` is the
+    Junos display name copied verbatim from the `protocols lldp interface
+    <name>` stanza (compiler `pkg/config/compiler_protocols.go` ->
+    `effectiveLLDPConfig` `pkg/daemon/daemon_apply.go`, both verbatim). xpfd
+    renames the kernel device to dash form (`ge-0-0-0`) via its `.link` files,
+    so a kernel ifname never contains a slash — `net.InterfaceByName("ge-0/0/0")`
+    always failed with "no such network interface", the socket was never
+    opened, and LLDP silently did not run on exactly the renamed ge-*/reth*
+    ports an operator configures it on. Only a (rare) non-renamed name would
+    have worked.
+  - **Fix**: resolve the kernel name with the existing
+    `config.LinuxIfName` helper (slash->dash) before the lookup. `LinuxIfName`
+    is a no-op on a name already in kernel form, so a non-renamed interface is
+    unaffected. The lookup is taken through a new `interfaceByNameFn` seam
+    (mirrors the existing `newIfSessionFn` seam) so the resolution is
+    unit-testable without a host device. `pkg/config` carries no dependency on
+    `pkg/lldp` (`go list -deps ./pkg/config` shows no `pkg/lldp`), so importing
+    config into lldp introduces no cycle.
+  - **Validation**: RED-on-revert proven — reverting the `LinuxIfName`
+    conversion (keeping the seam) fails `TestApplyResolvesKernelIfName` with
+    `lookup[0] = "ge-0/0/0", want kernel name "ge-0-0-0"`; a kernel-form name
+    (`em0`) passes through unchanged. `go test ./pkg/lldp/...` green; `go build
+    ./...` green; `gofmt`/`go vet` clean.
+  - **File(s)**: pkg/lldp/lldp.go, pkg/lldp/socket_test.go,
+    pkg/lldp/README.md, _Log.md
+
 ## 2026-07-03 — #4041: the debug-log direct-TX diagnostic double-recycled a UMEM frame offset on a tuple-mismatch → the offset aliased an in-flight TX frame (on-wire corruption / double-free, debug-log build)
 
 - **Timestamp**: 2026-07-03

--- a/pkg/lldp/README.md
+++ b/pkg/lldp/README.md
@@ -29,7 +29,9 @@ frame flood cannot exhaust memory (#4044).
 
 ## Dependencies
 
-Standard library + `golang.org/x/sys/unix`. No internal `pkg/*` imports.
+Standard library + `golang.org/x/sys/unix`, plus `pkg/linuxsock` (raw-socket
+open) and `pkg/config` (the `LinuxIfName` slash->dash helper, see the
+interface-name gotcha below).
 
 ## Socket lifecycle (#2035)
 
@@ -114,6 +116,18 @@ Two properties keep this safe (#2372 review findings 3 + 6):
 - Uses AF_PACKET raw sockets — the daemon needs `CAP_NET_RAW`. Without
   it, session setup fails at `Apply()` time, the interface is skipped,
   and the neighbor table stays empty for it.
+- **Config names are Junos display names; the socket needs the kernel
+  name (#4049).** The `protocols lldp interface <name>` stanza carries a
+  Junos name (`ge-0/0/0`, `reth0.50`), but xpfd renames the kernel device
+  to dash form (`ge-0-0-0`) via its `.link` files. `Apply()` runs each
+  config name through `config.LinuxIfName` (slash->dash) before
+  `net.InterfaceByName` — a kernel ifname never contains a slash, so
+  passing the raw Junos name failed the lookup and LLDP silently never
+  opened a socket on the renamed data ports. `LinuxIfName` is a no-op on a
+  name already in kernel form, so a non-renamed interface is unaffected.
+  The lookup goes through the `interfaceByNameFn` seam so the resolution
+  is unit-tested (`TestApplyResolvesKernelIfName`, `socket_test.go`)
+  without a host device present.
 - TTL countdown is per-neighbor; expired entries auto-purge from the
   `Neighbors()` snapshot.
 - The neighbor map is RWMutex-guarded. `Neighbors()` returns a copy, not

--- a/pkg/lldp/lldp.go
+++ b/pkg/lldp/lldp.go
@@ -17,6 +17,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/linuxsock"
 	"golang.org/x/sys/unix"
 )
@@ -129,6 +130,11 @@ type ifSession struct {
 	// it nil.
 	recvFn func(buf []byte) (int, int, error)
 }
+
+// interfaceByNameFn is the interface-resolution seam. Tests override it to
+// assert Apply resolves the kernel (dash-form) device name before the lookup,
+// and to avoid depending on a host device being present.
+var interfaceByNameFn = net.InterfaceByName
 
 // newIfSessionFn is the construction seam for ifSession. Tests override it to
 // inject a socketpair(2)-backed session so the Stop-unblocks-recv contract can
@@ -255,9 +261,17 @@ func (m *Manager) Apply(ctx context.Context, cfg *LLDPConfig) {
 		if lldpIf.Disable {
 			continue
 		}
-		iface, err := net.InterfaceByName(lldpIf.Name)
+		// Config interfaces carry Junos display names (ge-0/0/0, reth0.50);
+		// xpfd renames the kernel device to dash form (ge-0-0-0) via .link
+		// files, so net.InterfaceByName must be handed the kernel name — a
+		// slash never appears in a kernel ifname and the lookup would fail,
+		// silently skipping LLDP on exactly the renamed data ports. LinuxIfName
+		// is a no-op on a name that is already kernel-form (no slash).
+		kernelName := config.LinuxIfName(lldpIf.Name)
+		iface, err := interfaceByNameFn(kernelName)
 		if err != nil {
-			slog.Warn("LLDP: interface not found", "interface", lldpIf.Name, "err", err)
+			slog.Warn("LLDP: interface not found", "interface", lldpIf.Name,
+				"kernel", kernelName, "err", err)
 			continue
 		}
 

--- a/pkg/lldp/socket_test.go
+++ b/pkg/lldp/socket_test.go
@@ -581,3 +581,69 @@ func TestRxLoopSkipsSelfTransmittedFrames(t *testing.T) {
 		t.Fatal("rxLoop did not exit after ctx cancellation")
 	}
 }
+
+// TestApplyResolvesKernelIfName is the regression test for #4049: the LLDP
+// manager must hand the LINUX KERNEL device name (dash form, ge-0-0-0) to the
+// interface lookup, not the JUNOS display name copied verbatim from the
+// `protocols lldp interface <name>` config stanza (slash form, ge-0/0/0). xpfd
+// renames the kernel device to dash form via its .link files; a slash never
+// appears in a kernel ifname, so passing ge-0/0/0 to net.InterfaceByName fails
+// and LLDP silently never opens a socket on the renamed data port.
+//
+// It stubs the interfaceByNameFn seam to capture the name actually passed to
+// the lookup, and stubs newIfSessionFn to a no-op error so no real socket or
+// goroutine is created. Against the pre-fix code (net.InterfaceByName(lldpIf
+// .Name) with no LinuxIfName conversion) the captured name is "ge-0/0/0" and
+// the slash-form assertion fails.
+func TestApplyResolvesKernelIfName(t *testing.T) {
+	var gotNames []string
+	prevLookup := interfaceByNameFn
+	interfaceByNameFn = func(name string) (*net.Interface, error) {
+		gotNames = append(gotNames, name)
+		// Return a valid-looking interface so Apply proceeds to newIfSessionFn.
+		return &net.Interface{
+			Index:        1,
+			Name:         name,
+			HardwareAddr: net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x01},
+		}, nil
+	}
+	prevSess := newIfSessionFn
+	// Fail session setup deliberately: this test only asserts the name handed
+	// to the lookup, so it must not spawn TX/RX goroutines or open sockets.
+	newIfSessionFn = func(iface *net.Interface) (*ifSession, error) {
+		return nil, errStubNoSocket
+	}
+	t.Cleanup(func() {
+		interfaceByNameFn = prevLookup
+		newIfSessionFn = prevSess
+	})
+
+	m := New()
+	cfg := &LLDPConfig{
+		Interfaces: []LLDPInterface{
+			{Name: "ge-0/0/0"}, // Junos slash name -> kernel ge-0-0-0
+			{Name: "em0"},      // already kernel-form -> unchanged
+		},
+		Interval: 30,
+	}
+	m.Apply(context.Background(), cfg)
+	t.Cleanup(m.Stop)
+
+	want := []string{"ge-0-0-0", "em0"}
+	if len(gotNames) != len(want) {
+		t.Fatalf("interfaceByNameFn called with %v, want %v", gotNames, want)
+	}
+	for i, w := range want {
+		if gotNames[i] != w {
+			t.Errorf("lookup[%d] = %q, want kernel name %q "+
+				"(config name must be slash->dash converted before the lookup)",
+				i, gotNames[i], w)
+		}
+	}
+}
+
+var errStubNoSocket = errStub("stub: no socket")
+
+type errStub string
+
+func (e errStub) Error() string { return string(e) }


### PR DESCRIPTION
Closes #4049

## Problem

`lldp.Manager.Apply` (`pkg/lldp/lldp.go`) opened its AF_PACKET socket via
`net.InterfaceByName(lldpIf.Name)`, where `lldpIf.Name` is the **Junos display
name** copied verbatim from the `protocols lldp interface <name>` stanza:

- compiler (`pkg/config/compiler_protocols.go`) stores `LLDPInterface{Name: v}`
  from `nodeVal` verbatim, and
- `effectiveLLDPConfig` (`pkg/daemon/daemon_apply.go`) copies `iface.Name`
  verbatim into the `lldp.LLDPConfig`.

xpfd renames the kernel device to **dash form** (`ge-0-0-0`) via its `.link`
files, and a kernel ifname never contains a slash. So
`net.InterfaceByName("ge-0/0/0")` always failed with "no such network
interface", the socket was never opened, and LLDP silently did **not** run on
exactly the renamed `ge-*`/`reth*` data ports an operator configures it on.

## Fix

Resolve the kernel name with the existing `config.LinuxIfName` helper
(`strings.ReplaceAll(name, "/", "-")`) before the lookup. `LinuxIfName` is a
no-op on a name already in kernel form, so a non-renamed interface is
unaffected. The lookup now runs through a new `interfaceByNameFn` seam
(mirroring the existing `newIfSessionFn` seam) so the resolution is
unit-testable without a host device present.

`pkg/config` carries no dependency on `pkg/lldp` (`go list -deps ./pkg/config`
shows none), so importing config into lldp introduces no cycle.

## Test — RED on revert

`TestApplyResolvesKernelIfName` (`pkg/lldp/socket_test.go`) drives `Apply` with
a Junos slash name (`ge-0/0/0`) and a kernel-form name (`em0`), captures the
names handed to the lookup seam, and asserts they are `ge-0-0-0` and `em0`.
Reverting the `LinuxIfName` conversion (keeping the seam) fails with:

```
lookup[0] = "ge-0/0/0", want kernel name "ge-0-0-0"
  (config name must be slash->dash converted before the lookup)
```

## Validation

- `go test ./pkg/lldp/...` green
- `go build ./...` green
- `gofmt` / `go vet ./pkg/lldp/...` clean
- Docs: `pkg/lldp/README.md` gotcha + corrected Dependencies line; `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
