### PR TITLE
config API: redact secrets on raw-AST render paths (REST show/export/search/rollback + gRPC ShowConfig) (#4051)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,42 @@
+## 2026-07-03 — #4051: raw-AST config render paths (REST show/export/search/rollback + gRPC ShowConfig) emitted cleartext secrets (IKE PSK, auth-keys, SNMP community, WG/DDNS keys) — #2053 only redacted the typed-struct /config JSON path
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-020 (security, secret exposure). #2053
+    made the TYPED compiled-config marshal safe (`config.Secret` newtype ->
+    `GET /api/v1/config` redacts), but the RAW-AST render surface
+    (`pkg/config/ast_format.go` `Format`/`FormatSet`/`FormatJSON`/`FormatXML`/
+    `FormatInheritance`/`FormatCompare`) prints leaf tokens verbatim. The REST
+    config **show / export / search / rollback** handlers (`pkg/api/config.go`)
+    and the gRPC **ShowConfig / ShowCompare / ShowRollback** RPCs
+    (`pkg/grpcapi/server_config.go`) returned every operator secret in
+    CLEARTEXT to any API/gRPC client — worse with a non-loopback REST bind.
+  - **Fix**: `ConfigTree.RedactedClone()` (new `pkg/config/ast_redact.go`) —
+    a DISPLAY-only deep clone masking every secret leaf with
+    `config.SecretDataPlaceholder` (`##SECRET-DATA##`). Matches secrets on the
+    FLATTENED key path (handles both AST shapes). Secret-leaf set = #2053's
+    `config.Secret` field set resolved to keyword signatures (distinctive
+    keywords `pre-shared-key`/`authentication-key`/`authentication-password`/
+    `privacy-password`/`encrypted-password`/`simple-password`/`api-key`/
+    `tsig-secret`/`api-token`/`aws-secret-key`/`private-key`/`preshared-key`;
+    generic `key`/`password`/`community` disambiguated by ancestor context so
+    a GRE tunnel `key`, a chassis identity `key`, a routing-policy `community`
+    or a public `aws-access-key`/`username` are NOT masked). New redacted
+    `Store.Show*Redacted` variants (`pkg/configstore/store_format.go`) render
+    the clone; the REST + gRPC display handlers call them. The cleartext
+    `Show*` SSOT is UNCHANGED — HA config sync (`daemon_ha_sync.go`), the DR
+    archive (`daemon_flow.go`), persistence/rollback, and the on-box CLI still
+    get real secrets.
+  - **Validation**: RED-on-revert proven — with `RedactedClone` neutered, the
+    config, api and grpcapi redaction tests all FAIL with cleartext secrets
+    present (placeholder absent). `go test ./pkg/config/ ./pkg/configstore/
+    ./pkg/api/ ./pkg/grpcapi/ ./pkg/daemon/` all green; `go build ./...` green;
+    `gofmt`/`go vet` clean. On-box CLI kept cleartext (operator-reads-own-
+    secrets, Junos parity); remote `cli` covered transitively via gRPC.
+  - **File(s)**: pkg/config/ast_redact.go, pkg/config/ast_redact_test.go,
+    pkg/configstore/store_format.go, pkg/api/config.go,
+    pkg/api/config_raw_ast_redaction_test.go, pkg/grpcapi/server_config.go,
+    pkg/grpcapi/server_config_redaction_test.go, docs/config-schema.md, _Log.md
+
 ## 2026-07-03 — #4049: LLDP resolved its socket with the Junos slash name (ge-0/0/0) instead of the kernel dash name (ge-0-0-0) → net.InterfaceByName failed → LLDP never started on any renamed data port
 
 - **Timestamp**: 2026-07-03

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3150,9 +3150,10 @@ redaction is done with targeted marshallers — `SNMPCommunity.MarshalJSON`
 redacts the `Name` field, and `SNMPConfig.MarshalJSON` renders the
 `Communities` map as a sorted slice so the secret never leaks as a JSON
 object key. Text `show snmp` / `show configuration` print the map key, not
-the marshalled struct, and are deliberately OUT OF SCOPE (operators read
-their own secrets — Junos parity; `show configuration` redaction is a
-separate concern).
+the marshalled struct, so the #2053 marshaller does not cover them — the
+raw-AST render path is closed separately in **#4051 below** for the remote
+surfaces (REST + gRPC), while the on-box CLI stays cleartext (operators read
+their own secrets — Junos parity).
 
 **Borderline fields left as plain string** (rulings): `MasterPassword`
 (commit-encryption PRF selector, not a user secret), `ArchiveSitesWithPassword`
@@ -3166,6 +3167,60 @@ every reader). Do NOT feed `Reveal()` output into a log line. Regression
 coverage: `pkg/config/secret_test.go` (marshal/unmarshal/slice/map/SNMP) and
 `pkg/api/config_secret_redaction_test.go` (the live `GET /api/v1/config`
 leak net + in-memory-cleartext-preserved render guard).
+
+### #4051 — Raw-AST secret redaction on the config display endpoints
+
+#2053 closed the leak on the TYPED compiled-config marshal (`GET
+/api/v1/config`) but NOT on the raw-AST render surface. The
+`*ConfigTree` serializers in `ast_format.go` (`Format` / `FormatSet` /
+`FormatJSON` / `FormatXML` / `FormatInheritance` / `FormatCompare`) print
+leaf key tokens VERBATIM, so the endpoints that render the AST returned the
+same secrets in CLEARTEXT: the REST config **show / export / search /
+rollback** handlers (`pkg/api/config.go`) and the gRPC **ShowConfig /
+ShowCompare / ShowRollback** RPCs (`pkg/grpcapi/server_config.go`). Combined
+with a non-loopback REST bind an attacker could read every PSK / auth-key /
+SNMP community. Junos redacts secrets in `show configuration`
+(`SECRET-DATA`); xpf's raw-AST paths did not (fable-161 F-020).
+
+The fix is a DISPLAY-only AST transform. **`ConfigTree.RedactedClone()`**
+(`pkg/config/ast_redact.go`) returns a deep clone with every secret leaf
+value masked by **`config.SecretDataPlaceholder`** (`##SECRET-DATA##`, the
+Junos `SECRET-DATA` idiom — deliberately distinct from the typed-struct
+`<redacted>` sentinel so the two surfaces stay independently greppable). It
+walks the tree on the FLATTENED key path so a secret is matched identically
+in both AST shapes (hierarchical parse vs a flat-set collapsed leaf,
+CLAUDE.md dual-shape rule). The masked render is byte-identical to the
+cleartext render except at the secret tokens and stays structurally valid
+(the placeholder is quoted where needed).
+
+**Secret-leaf set = #2053's `config.Secret` field set** resolved to AST
+keyword signatures (verified against the compiler's `Secret(...)` sites):
+distinctive keywords `pre-shared-key` (keeps the `ascii-text`/`hexadecimal`
+qualifier), `authentication-key`, `authentication-password`,
+`privacy-password`, `encrypted-password`, `simple-password`, `api-key`,
+`tsig-secret`, `api-token`, `aws-secret-key`, `private-key`,
+`preshared-key`; and three GENERIC keywords disambiguated by required
+ancestor context so a non-secret look-alike is never masked — `key` only
+under `authentication md5 <id>` (OSPF hello key, not a GRE tunnel `key` or a
+chassis device-map identity `key`), `password` only under `api-auth` /
+`dynamic-dns` (not a future non-secret `password`), and `community` only
+directly under `snmp` (the v1/v2c community IS the secret — masked as a
+container-identity token — not a `policy-options community` routing object).
+
+**Redaction is applied at the REST + gRPC boundary only.** The cleartext
+`Store.Show*` methods remain the SSOT for **HA config sync**
+(`daemon_ha_sync.go` → the peer must receive real secrets), the
+**DR/compliance archive** (`daemon_flow.go`), on-disk **persistence +
+rollback** (`configstore`), and the **on-box CLI** (operator reads own
+secrets). The display endpoints call new redacted siblings
+(`ShowActive*Redacted` / `ShowCandidate*Redacted` / `ShowRollback*Redacted`
+/ `ShowCompare*Redacted` in `store_format.go`) that render a `RedactedClone`
+of the source tree. The remote `cli` binary is covered transitively (it goes
+through gRPC ShowConfig). Regression coverage: `pkg/config/ast_redact_test.go`
+(mask-every-format + no-source-mutation + no-over-masking + qualifier-kept),
+`pkg/api/config_raw_ast_redaction_test.go` (REST show/export/search),
+`pkg/grpcapi/server_config_redaction_test.go` (gRPC ShowConfig incl.
+path-scoped).
 
 ### #1979 — flow / flow-export NUM_WIDTH commit-time validation (Layer B)
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -175,24 +175,27 @@ func (s *Server) configShowHandler(w http.ResponseWriter, r *http.Request) {
 	format := r.URL.Query().Get("format")
 	target := r.URL.Query().Get("target")
 
+	// Secrets are masked on every raw-AST render endpoint (#4051), matching
+	// the #2053 typed-struct redaction; the cleartext Show* SSOT still backs
+	// HA config sync, the DR archive and persistence.
 	var output string
 	switch {
 	case target == "active" && format == "set":
-		output = s.store.ShowActiveSet()
+		output = s.store.ShowActiveSetRedacted(nil)
 	case target == "active" && format == "json":
-		output = s.store.ShowActiveJSON()
+		output = s.store.ShowActiveJSONRedacted(nil)
 	case target == "active" && format == "xml":
-		output = s.store.ShowActiveXML()
+		output = s.store.ShowActiveXMLRedacted(nil)
 	case target == "active":
-		output = s.store.ShowActive()
+		output = s.store.ShowActiveRedacted(nil)
 	case format == "set":
-		output = s.store.ShowCandidateSet()
+		output = s.store.ShowCandidateSetRedacted(nil)
 	case format == "json":
-		output = s.store.ShowCandidateJSON()
+		output = s.store.ShowCandidateJSONRedacted(nil)
 	case format == "xml":
-		output = s.store.ShowCandidateXML()
+		output = s.store.ShowCandidateXMLRedacted(nil)
 	default:
-		output = s.store.ShowCandidate()
+		output = s.store.ShowCandidateRedacted(nil)
 	}
 	writeOK(w, TextResponse{Output: output})
 }
@@ -205,13 +208,13 @@ func (s *Server) configExportHandler(w http.ResponseWriter, r *http.Request) {
 	var output string
 	switch format {
 	case "set":
-		output = s.store.ShowActiveSet()
+		output = s.store.ShowActiveSetRedacted(nil)
 	case "text":
-		output = s.store.ShowActive()
+		output = s.store.ShowActiveRedacted(nil)
 	case "json":
-		output = s.store.ShowActiveJSON()
+		output = s.store.ShowActiveJSONRedacted(nil)
 	case "xml":
-		output = s.store.ShowActiveXML()
+		output = s.store.ShowActiveXMLRedacted(nil)
 	default:
 		writeError(w, http.StatusBadRequest, "unsupported format: "+format+"; use set, text, json, or xml")
 		return
@@ -230,7 +233,7 @@ func (s *Server) configCompareHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if rollbackN > 0 {
-		diff, err := s.store.ShowCompareRollback(rollbackN)
+		diff, err := s.store.ShowCompareRollbackRedacted(rollbackN)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
@@ -238,7 +241,7 @@ func (s *Server) configCompareHandler(w http.ResponseWriter, r *http.Request) {
 		writeOK(w, TextResponse{Output: diff})
 		return
 	}
-	writeOK(w, TextResponse{Output: s.store.ShowCompare()})
+	writeOK(w, TextResponse{Output: s.store.ShowCompareRedacted()})
 }
 
 func (s *Server) configHistoryHandler(w http.ResponseWriter, _ *http.Request) {
@@ -259,7 +262,9 @@ func (s *Server) configSearchHandler(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "missing q parameter")
 		return
 	}
-	text := s.store.ShowActive()
+	// Search over the redacted render so a matching line never returns a
+	// cleartext secret in its snippet (#4051).
+	text := s.store.ShowActiveRedacted(nil)
 	var results []ConfigSearchResult
 	for i, line := range strings.Split(text, "\n") {
 		if strings.Contains(line, query) {
@@ -354,9 +359,9 @@ func (s *Server) configShowRollbackHandler(w http.ResponseWriter, r *http.Reques
 	var output string
 	var err error
 	if format == "set" {
-		output, err = s.store.ShowRollbackSet(n)
+		output, err = s.store.ShowRollbackSetRedacted(n)
 	} else {
-		output, err = s.store.ShowRollback(n)
+		output, err = s.store.ShowRollbackRedacted(n)
 	}
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())

--- a/pkg/api/config_raw_ast_redaction_test.go
+++ b/pkg/api/config_raw_ast_redaction_test.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// allSecretLeaks is the full cleartext set staged by stageSecretConfig — the
+// secretSentinels plus the four well-formed-hash / key consts — that must not
+// appear in ANY raw-AST render endpoint (#4051).
+func allSecretLeaks() []string {
+	return append(append([]string(nil), secretSentinels...),
+		rootCryptSentinel, loginCryptSentinel, tsigSecretSentinel, wgPrivkeySentinel)
+}
+
+// assertRedacted fails if any cleartext secret appears in body, and fails if
+// the redaction placeholder is absent (redaction not applied at all).
+func assertRedacted(t *testing.T, label, body string) {
+	t.Helper()
+	for _, leak := range allSecretLeaks() {
+		if strings.Contains(body, leak) {
+			t.Errorf("%s: leaked cleartext secret %q in raw-AST render:\n%s", label, leak, body)
+		}
+	}
+	if !strings.Contains(body, config.SecretDataPlaceholder) {
+		t.Errorf("%s: redaction placeholder %q absent — redaction not applied?\n%s",
+			label, config.SecretDataPlaceholder, body)
+	}
+}
+
+// TestConfigShowHandlerRedactsRawAST drives the REST `show config` endpoint
+// (configShowHandler → ShowActive*Redacted) across text/set/json/xml and
+// asserts secrets are masked. This is the #4051 RED-on-revert net for the
+// raw-AST path: it goes RED (cleartext PSK/community/keys) against pre-fix
+// code that called the cleartext Show* methods.
+func TestConfigShowHandlerRedactsRawAST(t *testing.T) {
+	s, _ := stageSecretConfig(t)
+	for _, format := range []string{"", "set", "json", "xml"} {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/v1/config/show?target=active&format="+format, nil)
+		s.configShowHandler(rr, req)
+		if rr.Code != 200 {
+			t.Fatalf("format %q: status = %d, body: %s", format, rr.Code, rr.Body.String())
+		}
+		assertRedacted(t, "show active format="+format, rr.Body.String())
+	}
+}
+
+// TestConfigExportHandlerRedactsRawAST drives the REST `export` endpoint
+// across set/text/json/xml.
+func TestConfigExportHandlerRedactsRawAST(t *testing.T) {
+	s, _ := stageSecretConfig(t)
+	for _, format := range []string{"set", "text", "json", "xml"} {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/v1/config/export?format="+format, nil)
+		s.configExportHandler(rr, req)
+		if rr.Code != 200 {
+			t.Fatalf("format %q: status = %d, body: %s", format, rr.Code, rr.Body.String())
+		}
+		assertRedacted(t, "export format="+format, rr.Body.String())
+	}
+}
+
+// TestConfigSearchHandlerRedactsRawAST drives the REST `search` endpoint —
+// a matching line must never carry a cleartext secret in its snippet.
+func TestConfigSearchHandlerRedactsRawAST(t *testing.T) {
+	s, _ := stageSecretConfig(t)
+	rr := httptest.NewRecorder()
+	// Search for the IKE PSK keyword so the matching line is a secret leaf.
+	req := httptest.NewRequest("GET", "/api/v1/config/search?q=pre-shared-key", nil)
+	s.configSearchHandler(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, body: %s", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	for _, leak := range allSecretLeaks() {
+		if strings.Contains(body, leak) {
+			t.Errorf("search leaked cleartext secret %q:\n%s", leak, body)
+		}
+	}
+}

--- a/pkg/config/ast_redact.go
+++ b/pkg/config/ast_redact.go
@@ -1,0 +1,158 @@
+package config
+
+// ast_redact.go masks secret leaf VALUES in the raw-AST render paths.
+//
+// #2053 made the TYPED compiled-config render safe: the config.Secret newtype
+// redacts every operator secret on JSON/YAML marshal, so GET /api/v1/config
+// (which json-encodes the compiled *config.Config) no longer leaks cleartext.
+// But the AST-render surface — Format / FormatSet / FormatJSON / FormatXML /
+// FormatInheritance / FormatCompare in ast_format.go — walks the *ConfigTree
+// AST and prints leaf key tokens VERBATIM. That surface backs the REST config
+// show / export / search / rollback endpoints and the gRPC ShowConfig RPC, so
+// those returned the same secrets (#2053 protects) in CLEARTEXT (#4051, fable
+// F-020). Junos redacts secrets in `show configuration` (SECRET-DATA); xpf's
+// raw-AST paths did not.
+//
+// RedactedClone masks the secret leaf values so the AST-render display paths
+// mirror the #2053 guarantee. It is a DISPLAY-only transform applied at the
+// REST + gRPC boundary: the cleartext Format() on the real tree still backs HA
+// config sync (daemon_ha_sync.go), the DR/compliance archive (daemon_flow.go),
+// on-disk persistence + rollback (configstore) and the on-box CLI, none of
+// which may lose the real secret.
+//
+// The secret-leaf set is exactly #2053's Secret-typed field set, resolved to
+// its AST leaf signatures (verified against the compiler's Secret(...) sites):
+//
+//	pre-shared-key            IKE policy / IPsec VPN PSK   (keeps ascii-text|hexadecimal qualifier)
+//	authentication-key        OSPF/IS-IS/RIP/BGP/VRRP auth key + BGP TCP-MD5
+//	simple-password           OSPF simple-password auth (same AuthKey field)
+//	key (under authentication md5 <id>)   OSPF hello md5 key
+//	authentication-password   SNMPv3 USM auth password
+//	privacy-password          SNMPv3 USM privacy password
+//	encrypted-password        root / login crypt(3) hash
+//	api-key                   REST API bearer/X-API-Key token(s)
+//	password (under api-auth | dynamic-dns)  REST basic-auth / DDNS HTTP password
+//	tsig-secret               RFC 2136 / DDNS TSIG HMAC key
+//	api-token                 Cloudflare / DuckDNS DDNS API token
+//	aws-secret-key            Route 53 DDNS AWS secret access key
+//	private-key               WireGuard local static private key
+//	preshared-key             WireGuard per-peer PSK
+//	community (under snmp)     SNMP v1/v2c community string (the identity token)
+
+// SecretDataPlaceholder is the mask emitted in place of a secret leaf value on
+// the raw-AST render/display paths. It mirrors the Junos SECRET-DATA idiom and
+// is deliberately distinct from the typed-struct redaction sentinel
+// (SecretRedacted, "<redacted>") so the two surfaces stay independently
+// greppable. It contains non-identifier characters, so a text/set/XML render
+// quotes it — the output stays structurally valid.
+const SecretDataPlaceholder = "##SECRET-DATA##"
+
+// RedactedClone returns a deep copy of the tree with every secret leaf value
+// masked by SecretDataPlaceholder, for the raw-AST DISPLAY paths (REST config
+// show / export / search / rollback + gRPC ShowConfig / ShowCompare /
+// ShowRollback). Structure, ordering, inactive markers and all non-secret
+// values are preserved, so the redacted render is byte-identical to the
+// cleartext render except at the masked value tokens. Returns nil for a nil
+// receiver (callers mirror the nil handling of their cleartext siblings).
+//
+// It operates on a clone so the live tree — the SSOT for HA sync, the DR
+// archive and persistence — is never mutated.
+func (t *ConfigTree) RedactedClone() *ConfigTree {
+	if t == nil {
+		return nil
+	}
+	c := t.Clone()
+	redactNodes(c.Children, nil)
+	return c
+}
+
+// redactNodes walks nodes maintaining the flattened key path of all ancestors
+// (base). A secret token is identified on the FULL flattened path so it is
+// matched identically whether the parser produced a hierarchical tree (secret
+// split across nested block nodes) or a flat SetPath collapsed the whole
+// branch onto one leaf's Keys (the dual AST shape, CLAUDE.md). Each secret
+// index is masked in whichever node's own Keys slice owns it (idx >= len(base))
+// — so a container-identity secret (an SNMP community name) is masked once, on
+// the node that introduces it, and its descendants skip it.
+func redactNodes(nodes []*Node, base []string) {
+	for _, n := range nodes {
+		full := append(append([]string(nil), base...), n.Keys...)
+		for _, idx := range secretIndices(full) {
+			if idx >= len(base) && idx < len(full) {
+				n.Keys[idx-len(base)] = SecretDataPlaceholder
+			}
+		}
+		if !n.IsLeaf {
+			redactNodes(n.Children, full)
+		}
+	}
+}
+
+// secretIndices returns the indices into the flattened key path fp that carry
+// a secret value and must be masked. It reuses #2053's secret-leaf set (see
+// the file header) resolved to keyword signatures; generic keywords (key,
+// password, community) are disambiguated by required ancestor context so a
+// GRE tunnel `key`, a chassis identity `key` or a routing-policy `community`
+// (all non-secret) are never masked.
+func secretIndices(fp []string) []int {
+	var out []int
+	for i, k := range fp {
+		switch k {
+		case "pre-shared-key":
+			// Value token(s) follow; keep a leading ascii-text|hexadecimal
+			// format qualifier so the render stays structurally valid.
+			j := i + 1
+			if j < len(fp) && (fp[j] == "ascii-text" || fp[j] == "hexadecimal") {
+				j++
+			}
+			for ; j < len(fp); j++ {
+				out = append(out, j)
+			}
+		case "authentication-key", "authentication-password", "privacy-password",
+			"encrypted-password", "simple-password", "api-key", "tsig-secret",
+			"api-token", "aws-secret-key", "private-key", "preshared-key":
+			// Distinctive secret keywords: every token after the keyword is
+			// secret value (covers multi-token / bracketed list values too).
+			for j := i + 1; j < len(fp); j++ {
+				out = append(out, j)
+			}
+		case "password":
+			// Generic keyword — secret only under REST api-auth or a DDNS
+			// provider; other `password` uses do not exist today but the
+			// context gate keeps a future non-secret `password` unmasked.
+			if containsAnyOf(fp[:i], "api-auth", "dynamic-dns") {
+				for j := i + 1; j < len(fp); j++ {
+					out = append(out, j)
+				}
+			}
+		case "key":
+			// Generic keyword — secret only as the OSPF hello md5 key:
+			// `authentication md5 <key-id> key <secret>`. A GRE tunnel `key`
+			// or a chassis device-map identity `key` has no such context.
+			if i >= 3 && fp[i-2] == "md5" && fp[i-3] == "authentication" && i+1 < len(fp) {
+				out = append(out, i+1)
+			}
+		case "community":
+			// SNMP v1/v2c community string is the container-identity token
+			// directly under `snmp` (the whole point of the community is a
+			// shared secret). A policy-options `community` is a routing object
+			// under policy-options, not snmp — left unmasked.
+			if i >= 1 && fp[i-1] == "snmp" && i+1 < len(fp) {
+				out = append(out, i+1)
+			}
+		}
+	}
+	return out
+}
+
+// containsAnyOf reports whether seq contains any of names.
+func containsAnyOf(seq []string, names ...string) bool {
+	for _, s := range seq {
+		for _, n := range names {
+			if s == n {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/config/ast_redact_test.go
+++ b/pkg/config/ast_redact_test.go
@@ -1,0 +1,155 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// buildRedactTree replays flat `set` commands into a fresh AST the way the config
+// store does (ParseSetCommand + SetPath) — NOT NewParser, which merges lines.
+func buildRedactTree(t *testing.T, lines []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		toks, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(toks); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	return tree
+}
+
+// redactionSecretSet mirrors the #2053 secret-bearing leaves (the same set the
+// pkg/api typed-struct redaction test stages), one distinctive sentinel per
+// secret leaf so a single leak is identifiable in the raw-AST render.
+var redactionSecretSet = []string{
+	"set security ike policy pol1 pre-shared-key ascii-text LEAK-IKE-PSK",
+	"set security ipsec vpn site-a pre-shared-key LEAK-IPSEC-VPN-PSK",
+	"set protocols ospf area 0.0.0.0 interface ge-0-0-1 authentication md5 1 key LEAK-OSPF-MD5KEY",
+	"set protocols ospf area 0.0.0.0 interface ge-0-0-9 authentication simple-password LEAK-OSPF-SIMPLE",
+	"set protocols rip authentication-key LEAK-RIP-AUTHKEY",
+	"set protocols isis authentication-key LEAK-ISIS-AREA-AUTHKEY",
+	"set protocols isis interface ge-0-0-2 authentication-key LEAK-ISIS-IFACE-AUTHKEY",
+	"set protocols bgp group external authentication-key LEAK-BGP-AUTHPW",
+	"set interfaces ge-0-0-3 unit 0 family inet address 10.0.3.1/24 vrrp-group 1 authentication-key LEAK-VRRP-AUTHKEY",
+	"set system services web-management api-auth user admin password LEAK-API-USER-PW",
+	"set system services web-management api-auth api-key LEAK-API-KEY-TOKEN",
+	"set snmp v3 usm local-engine user admin authentication-sha256 authentication-password LEAK-SNMPV3-AUTHPW",
+	"set snmp v3 usm local-engine user admin privacy-des privacy-password LEAK-SNMPV3-PRIVPW",
+	"set snmp community LEAK-SNMP-COMMUNITY authorization read-only",
+	"set system services dhcp-local-server dynamic-dns tsig-secret LEAK-TSIG-SECRET",
+	"set system services dynamic-dns provider cf backend cloudflare",
+	"set system services dynamic-dns provider cf api-token LEAK-DDNS-APITOKEN",
+	"set system services dynamic-dns provider r53 backend route53",
+	"set system services dynamic-dns provider r53 aws-secret-key LEAK-DDNS-AWSSECRET",
+	"set system services dynamic-dns provider dy backend dyndns2",
+	"set system services dynamic-dns provider dy password LEAK-DDNS-HTTP-PW",
+	"set interfaces wg0 tunnel wireguard private-key LEAK-WG-PRIVKEY",
+	"set interfaces wg0 tunnel wireguard peer p1 preshared-key LEAK-WG-PSK",
+	`set system root-authentication encrypted-password "$6$LEAKr$rootHASHrootHASH"`,
+	`set system login user op authentication encrypted-password "$6$LEAKl$loginHASHloginHASH"`,
+}
+
+var redactionSentinels = []string{
+	"LEAK-IKE-PSK", "LEAK-IPSEC-VPN-PSK", "LEAK-OSPF-MD5KEY", "LEAK-OSPF-SIMPLE",
+	"LEAK-RIP-AUTHKEY", "LEAK-ISIS-AREA-AUTHKEY", "LEAK-ISIS-IFACE-AUTHKEY",
+	"LEAK-BGP-AUTHPW", "LEAK-VRRP-AUTHKEY", "LEAK-API-USER-PW", "LEAK-API-KEY-TOKEN",
+	"LEAK-SNMPV3-AUTHPW", "LEAK-SNMPV3-PRIVPW", "LEAK-SNMP-COMMUNITY",
+	"LEAK-TSIG-SECRET", "LEAK-DDNS-APITOKEN", "LEAK-DDNS-AWSSECRET", "LEAK-DDNS-HTTP-PW",
+	"LEAK-WG-PRIVKEY", "LEAK-WG-PSK", "rootHASHrootHASH", "loginHASHloginHASH",
+}
+
+// TestRedactedCloneMasksEverySecretAcrossFormats is the #4051 RED-on-revert
+// net: it renders a secret-bearing tree through every raw-AST format after
+// RedactedClone and asserts no cleartext secret survives while the placeholder
+// does. It goes RED (cleartext secrets present) if RedactedClone is a no-op.
+func TestRedactedCloneMasksEverySecretAcrossFormats(t *testing.T) {
+	tree := buildRedactTree(t, redactionSecretSet)
+	red := tree.RedactedClone()
+
+	renders := map[string]string{
+		"Format":      red.Format(),
+		"FormatSet":   red.FormatSet(),
+		"FormatJSON":  red.FormatJSON(),
+		"FormatXML":   red.FormatXML(),
+		"Inheritance": red.FormatInheritance(),
+	}
+	for name, out := range renders {
+		for _, leak := range redactionSentinels {
+			if strings.Contains(out, leak) {
+				t.Errorf("%s leaked cleartext secret %q:\n%s", name, leak, out)
+			}
+		}
+		if !strings.Contains(out, SecretDataPlaceholder) {
+			t.Errorf("%s did not emit the %s placeholder; redaction not applied?\n%s",
+				name, SecretDataPlaceholder, out)
+		}
+	}
+}
+
+// TestRedactedCloneDoesNotMutateSource proves masking is display-only: the
+// live tree still carries cleartext for HA sync / the DR archive / persistence.
+func TestRedactedCloneDoesNotMutateSource(t *testing.T) {
+	tree := buildRedactTree(t, redactionSecretSet)
+	_ = tree.RedactedClone()
+
+	out := tree.Format() + tree.FormatSet()
+	for _, want := range redactionSentinels {
+		if !strings.Contains(out, want) {
+			t.Errorf("source tree lost cleartext secret %q after RedactedClone (mutation!)\n%s", want, out)
+		}
+	}
+}
+
+// TestRedactedCloneKeepsNonSecrets guards against over-masking: generic
+// keyword look-alikes that are NOT secrets must render verbatim.
+func TestRedactedCloneKeepsNonSecrets(t *testing.T) {
+	lines := []string{
+		"set system host-name fw-edge-1",                                             // plain
+		"set snmp community LEAK-SNMP-COMMUNITY clients 10.0.0.0/8",                  // community NAME is secret, CIDR is not
+		"set interfaces gr-0-0-0 unit 0 tunnel key 4242",                             // GRE tunnel key — not a secret
+		"set system services dynamic-dns provider r53 aws-access-key AKIA-PUBLIC-ID", // access-key ID is public
+		"set system services dynamic-dns provider dy username joeuser",               // username is not a secret
+		"set policy-options community CUST members 65000:100",                        // routing community — not a secret
+	}
+	tree := buildRedactTree(t, lines)
+	out := tree.RedactedClone().FormatSet()
+
+	keep := []string{"fw-edge-1", "10.0.0.0/8", "4242", "AKIA-PUBLIC-ID", "joeuser", "65000:100", "CUST"}
+	for _, w := range keep {
+		if !strings.Contains(out, w) {
+			t.Errorf("non-secret value %q was masked (over-redaction):\n%s", w, out)
+		}
+	}
+	// The SNMP community NAME must still be masked even though its sibling
+	// CIDR is not.
+	if strings.Contains(out, "LEAK-SNMP-COMMUNITY") {
+		t.Errorf("SNMP community string leaked:\n%s", out)
+	}
+	if !strings.Contains(out, SecretDataPlaceholder) {
+		t.Errorf("community NAME not masked; expected placeholder:\n%s", out)
+	}
+}
+
+// TestRedactedClonePreservesFormatQualifier confirms an IKE pre-shared-key
+// keeps its ascii-text/hexadecimal format qualifier (structural validity)
+// while only the key material is masked.
+func TestRedactedClonePreservesFormatQualifier(t *testing.T) {
+	tree := buildRedactTree(t, []string{
+		"set security ike policy pol1 pre-shared-key ascii-text SUPERSECRET",
+	})
+	out := tree.RedactedClone().FormatSet()
+	// The placeholder contains '#', a non-identifier char, so FormatSet quotes
+	// it: `pre-shared-key ascii-text "##SECRET-DATA##"`. The qualifier is
+	// retained and the key material is masked.
+	if !strings.Contains(out, "pre-shared-key ascii-text") ||
+		!strings.Contains(out, SecretDataPlaceholder) {
+		t.Errorf("expected qualifier retained + key masked; got:\n%s", out)
+	}
+	if strings.Contains(out, "SUPERSECRET") {
+		t.Errorf("pre-shared-key material leaked:\n%s", out)
+	}
+}

--- a/pkg/configstore/store_format.go
+++ b/pkg/configstore/store_format.go
@@ -294,6 +294,189 @@ func (s *Store) ShowCompare() string {
 	return diff
 }
 
+// --- Redacted display renderers (#4051) ---------------------------------
+//
+// The raw-AST render endpoints (REST config show / export / search /
+// rollback + gRPC ShowConfig / ShowCompare / ShowRollback) must not leak
+// operator secrets in cleartext the way the typed-struct /config JSON stopped
+// leaking them in #2053. These variants render a RedactedClone of the source
+// tree — secrets masked with config.SecretDataPlaceholder — so all AST-render
+// display formats (text/set/json/xml/inheritance/compare) are redacted at one
+// place. The cleartext Show* siblings above stay unchanged: they back HA
+// config sync (daemon_ha_sync.go), the DR/compliance archive (daemon_flow.go),
+// persistence + rollback, and the on-box CLI, none of which may lose the real
+// secret. Each redacted method mirrors its cleartext sibling's nil-source
+// default so behaviour is identical except for the masking, and each accepts a
+// path (nil/empty selects the whole tree, matching FormatPath(nil) == Format).
+
+// forDisplay returns a redacted deep clone of t, or nil if t is nil.
+func forDisplay(t *config.ConfigTree) *config.ConfigTree {
+	return t.RedactedClone()
+}
+
+// ShowActiveRedacted renders the active config (optional subtree) as
+// hierarchical text with secrets masked.
+func (s *Store) ShowActiveRedacted(path []string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return forDisplay(s.active).FormatPath(path)
+}
+
+// ShowActiveSetRedacted renders the active config (optional subtree) as flat
+// set commands with secrets masked.
+func (s *Store) ShowActiveSetRedacted(path []string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return forDisplay(s.active).FormatPathSet(path)
+}
+
+// ShowActiveJSONRedacted renders the active config (optional subtree) as JSON
+// with secrets masked.
+func (s *Store) ShowActiveJSONRedacted(path []string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return forDisplay(s.active).FormatPathJSON(path)
+}
+
+// ShowActiveXMLRedacted renders the active config (optional subtree) as XML
+// with secrets masked.
+func (s *Store) ShowActiveXMLRedacted(path []string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return forDisplay(s.active).FormatPathXML(path)
+}
+
+// ShowActiveInheritanceRedacted renders the active config (optional subtree)
+// with inheritance annotations and secrets masked.
+func (s *Store) ShowActiveInheritanceRedacted(path []string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return forDisplay(s.active).FormatPathInheritance(path)
+}
+
+// ShowCandidateRedacted renders the candidate config (optional subtree) as
+// hierarchical text with secrets masked.
+func (s *Store) ShowCandidateRedacted(path []string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.candidate == nil {
+		return ""
+	}
+	return forDisplay(s.candidate).FormatPath(path)
+}
+
+// ShowCandidateSetRedacted renders the candidate config (optional subtree) as
+// flat set commands with secrets masked.
+func (s *Store) ShowCandidateSetRedacted(path []string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.candidate == nil {
+		return ""
+	}
+	return forDisplay(s.candidate).FormatPathSet(path)
+}
+
+// ShowCandidateJSONRedacted renders the candidate config (optional subtree) as
+// JSON with secrets masked. Mirrors the split nil default: "{}\n" for the
+// whole tree, "" for a subtree path.
+func (s *Store) ShowCandidateJSONRedacted(path []string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.candidate == nil {
+		if len(path) == 0 {
+			return "{}\n"
+		}
+		return ""
+	}
+	return forDisplay(s.candidate).FormatPathJSON(path)
+}
+
+// ShowCandidateXMLRedacted renders the candidate config (optional subtree) as
+// XML with secrets masked. Mirrors the split nil default: the empty-config XML
+// document for the whole tree, "" for a subtree path.
+func (s *Store) ShowCandidateXMLRedacted(path []string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.candidate == nil {
+		if len(path) == 0 {
+			return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<configuration>\n</configuration>\n"
+		}
+		return ""
+	}
+	return forDisplay(s.candidate).FormatPathXML(path)
+}
+
+// ShowCandidateInheritanceRedacted renders the candidate config (optional
+// subtree) with inheritance annotations and secrets masked.
+func (s *Store) ShowCandidateInheritanceRedacted(path []string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.candidate == nil {
+		return ""
+	}
+	return forDisplay(s.candidate).FormatPathInheritance(path)
+}
+
+// ShowRollbackRedacted renders rollback slot n (1-based) as hierarchical text
+// with secrets masked.
+func (s *Store) ShowRollbackRedacted(n int) (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, err := s.history.Get(n - 1)
+	if err != nil {
+		return "", err
+	}
+	return forDisplay(entry.Config).Format(), nil
+}
+
+// ShowRollbackSetRedacted renders rollback slot n (1-based) as flat set
+// commands with secrets masked.
+func (s *Store) ShowRollbackSetRedacted(n int) (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, err := s.history.Get(n - 1)
+	if err != nil {
+		return "", err
+	}
+	return forDisplay(entry.Config).FormatSet(), nil
+}
+
+// ShowCompareRedacted returns a hierarchical diff between the active and
+// candidate configs with secrets masked on BOTH sides. A secret CHANGE
+// therefore shows as no-change (both masked) rather than leaking either
+// value — the safe display choice absent a Junos-style $9$ ciphertext.
+func (s *Store) ShowCompareRedacted() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.candidate == nil {
+		return ""
+	}
+	diff := config.FormatCompare(forDisplay(s.active), forDisplay(s.candidate))
+	if diff == "" {
+		return "[no changes]\n"
+	}
+	return diff
+}
+
+// ShowCompareRollbackRedacted returns a diff between rollback slot n and the
+// candidate with secrets masked on both sides.
+func (s *Store) ShowCompareRollbackRedacted(n int) (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.candidate == nil {
+		return "", fmt.Errorf("not in configuration mode")
+	}
+	entry, err := s.history.Get(n - 1)
+	if err != nil {
+		return "", err
+	}
+	diff := config.FormatCompare(forDisplay(entry.Config), forDisplay(s.candidate))
+	if diff == "" {
+		return "[no changes]\n", nil
+	}
+	return diff, nil
+}
+
 // splitLines splits a string into non-empty lines.
 func splitLines(s string) []string {
 	var lines []string

--- a/pkg/grpcapi/server_config.go
+++ b/pkg/grpcapi/server_config.go
@@ -264,69 +264,37 @@ func configWarnings(cfg *config.Config) []string {
 }
 
 func (s *Server) ShowConfig(_ context.Context, req *pb.ShowConfigRequest) (*pb.ShowConfigResponse, error) {
+	// Secrets are masked on this raw-AST render RPC (#4051), matching the
+	// #2053 typed-struct redaction. The redacted renderers take the path
+	// directly (nil/empty selects the whole tree) and mirror the cleartext
+	// siblings' nil-source defaults; the cleartext Show* SSOT still backs HA
+	// config sync, the DR archive and persistence.
+	var path []string
+	if len(req.Path) > 0 {
+		path = req.Path
+	}
 	var output string
-	hasPath := len(req.Path) > 0
 	switch {
 	case req.Target == pb.ConfigTarget_ACTIVE && req.Format == pb.ConfigFormat_JSON:
-		if hasPath {
-			output = s.store.ShowActivePathJSON(req.Path)
-		} else {
-			output = s.store.ShowActiveJSON()
-		}
+		output = s.store.ShowActiveJSONRedacted(path)
 	case req.Target == pb.ConfigTarget_ACTIVE && req.Format == pb.ConfigFormat_SET:
-		if hasPath {
-			output = s.store.ShowActivePathSet(req.Path)
-		} else {
-			output = s.store.ShowActiveSet()
-		}
+		output = s.store.ShowActiveSetRedacted(path)
 	case req.Target == pb.ConfigTarget_ACTIVE && req.Format == pb.ConfigFormat_XML:
-		if hasPath {
-			output = s.store.ShowActivePathXML(req.Path)
-		} else {
-			output = s.store.ShowActiveXML()
-		}
+		output = s.store.ShowActiveXMLRedacted(path)
 	case req.Target == pb.ConfigTarget_ACTIVE && req.Format == pb.ConfigFormat_INHERITANCE:
-		if hasPath {
-			output = s.store.ShowActivePathInheritance(req.Path)
-		} else {
-			output = s.store.ShowActiveInheritance()
-		}
+		output = s.store.ShowActiveInheritanceRedacted(path)
 	case req.Target == pb.ConfigTarget_ACTIVE:
-		if hasPath {
-			output = s.store.ShowActivePath(req.Path)
-		} else {
-			output = s.store.ShowActive()
-		}
+		output = s.store.ShowActiveRedacted(path)
 	case req.Format == pb.ConfigFormat_JSON:
-		if hasPath {
-			output = s.store.ShowCandidatePathJSON(req.Path)
-		} else {
-			output = s.store.ShowCandidateJSON()
-		}
+		output = s.store.ShowCandidateJSONRedacted(path)
 	case req.Format == pb.ConfigFormat_SET:
-		if hasPath {
-			output = s.store.ShowCandidatePathSet(req.Path)
-		} else {
-			output = s.store.ShowCandidateSet()
-		}
+		output = s.store.ShowCandidateSetRedacted(path)
 	case req.Format == pb.ConfigFormat_XML:
-		if hasPath {
-			output = s.store.ShowCandidatePathXML(req.Path)
-		} else {
-			output = s.store.ShowCandidateXML()
-		}
+		output = s.store.ShowCandidateXMLRedacted(path)
 	case req.Format == pb.ConfigFormat_INHERITANCE:
-		if hasPath {
-			output = s.store.ShowCandidatePathInheritance(req.Path)
-		} else {
-			output = s.store.ShowCandidateInheritance()
-		}
+		output = s.store.ShowCandidateInheritanceRedacted(path)
 	default:
-		if hasPath {
-			output = s.store.ShowCandidatePath(req.Path)
-		} else {
-			output = s.store.ShowCandidate()
-		}
+		output = s.store.ShowCandidateRedacted(path)
 	}
 	return &pb.ShowConfigResponse{Output: output}, nil
 }
@@ -341,22 +309,22 @@ func (s *Server) ShowCompare(_ context.Context, req *pb.ShowCompareRequest) (*pb
 			"invalid rollback_n %d: must be non-negative (0 = candidate vs active)", req.RollbackN)
 	}
 	if req.RollbackN > 0 {
-		diff, err := s.store.ShowCompareRollback(int(req.RollbackN))
+		diff, err := s.store.ShowCompareRollbackRedacted(int(req.RollbackN))
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		return &pb.ShowCompareResponse{Output: diff}, nil
 	}
-	return &pb.ShowCompareResponse{Output: s.store.ShowCompare()}, nil
+	return &pb.ShowCompareResponse{Output: s.store.ShowCompareRedacted()}, nil
 }
 
 func (s *Server) ShowRollback(_ context.Context, req *pb.ShowRollbackRequest) (*pb.ShowRollbackResponse, error) {
 	var output string
 	var err error
 	if req.Format == pb.ConfigFormat_SET {
-		output, err = s.store.ShowRollbackSet(int(req.N))
+		output, err = s.store.ShowRollbackSetRedacted(int(req.N))
 	} else {
-		output, err = s.store.ShowRollback(int(req.N))
+		output, err = s.store.ShowRollbackRedacted(int(req.N))
 	}
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)

--- a/pkg/grpcapi/server_config_redaction_test.go
+++ b/pkg/grpcapi/server_config_redaction_test.go
@@ -1,0 +1,96 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// grpcSecretSet stages the secrets the #4051 issue names explicitly (IKE PSK +
+// SNMP community) plus representative others, each with a distinctive cleartext
+// sentinel so a leak is identifiable.
+var grpcSecretSet = []string{
+	"set security ike policy pol1 pre-shared-key ascii-text GRPC-LEAK-IKE-PSK",
+	"set snmp community GRPC-LEAK-SNMP-COMMUNITY authorization read-only",
+	"set protocols bgp group ext authentication-key GRPC-LEAK-BGP-AUTHPW",
+	"set interfaces wg0 tunnel wireguard private-key GRPC-LEAK-WG-PRIVKEY",
+}
+
+var grpcSecretSentinels = []string{
+	"GRPC-LEAK-IKE-PSK", "GRPC-LEAK-SNMP-COMMUNITY",
+	"GRPC-LEAK-BGP-AUTHPW", "GRPC-LEAK-WG-PRIVKEY",
+}
+
+func newSecretServer(t *testing.T) *Server {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure(): %v", err)
+	}
+	if _, err := store.LoadSet(strings.Join(grpcSecretSet, "\n")); err != nil {
+		t.Fatalf("LoadSet(): %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit(): %v", err)
+	}
+	return &Server{store: store}
+}
+
+// TestShowConfigRedactsRawAST is the #4051 RED-on-revert net for the gRPC
+// ShowConfig RPC: it renders the active config across every format and asserts
+// no cleartext secret survives while the redaction placeholder does. It goes
+// RED (cleartext IKE PSK / SNMP community / keys) against pre-fix code that
+// called the cleartext Show* methods.
+func TestShowConfigRedactsRawAST(t *testing.T) {
+	s := newSecretServer(t)
+	formats := []pb.ConfigFormat{
+		pb.ConfigFormat_HIERARCHICAL,
+		pb.ConfigFormat_SET,
+		pb.ConfigFormat_JSON,
+		pb.ConfigFormat_XML,
+		pb.ConfigFormat_INHERITANCE,
+	}
+	for _, f := range formats {
+		resp, err := s.ShowConfig(context.Background(), &pb.ShowConfigRequest{
+			Target: pb.ConfigTarget_ACTIVE,
+			Format: f,
+		})
+		if err != nil {
+			t.Fatalf("ShowConfig(format=%v): %v", f, err)
+		}
+		out := resp.Output
+		for _, leak := range grpcSecretSentinels {
+			if strings.Contains(out, leak) {
+				t.Errorf("ShowConfig(format=%v) leaked cleartext secret %q:\n%s", f, leak, out)
+			}
+		}
+		if !strings.Contains(out, config.SecretDataPlaceholder) {
+			t.Errorf("ShowConfig(format=%v) missing redaction placeholder %q:\n%s",
+				f, config.SecretDataPlaceholder, out)
+		}
+	}
+}
+
+// TestShowConfigActivePathRedacts confirms a path-scoped ShowConfig (subtree
+// render) also redacts.
+func TestShowConfigActivePathRedacts(t *testing.T) {
+	s := newSecretServer(t)
+	resp, err := s.ShowConfig(context.Background(), &pb.ShowConfigRequest{
+		Target: pb.ConfigTarget_ACTIVE,
+		Format: pb.ConfigFormat_SET,
+		Path:   []string{"security"},
+	})
+	if err != nil {
+		t.Fatalf("ShowConfig(path=security): %v", err)
+	}
+	if strings.Contains(resp.Output, "GRPC-LEAK-IKE-PSK") {
+		t.Errorf("path-scoped ShowConfig leaked IKE PSK:\n%s", resp.Output)
+	}
+	if !strings.Contains(resp.Output, config.SecretDataPlaceholder) {
+		t.Errorf("path-scoped ShowConfig missing placeholder:\n%s", resp.Output)
+	}
+}


### PR DESCRIPTION
Closes #4051

## Problem (fable-161 F-020, security)

#2053 redacted operator secrets only on the **typed** compiled-config
marshal (`GET /api/v1/config`, via the `config.Secret` newtype). The
**raw-AST** render surface — `Format` / `FormatSet` / `FormatJSON` /
`FormatXML` / `FormatInheritance` / `FormatCompare` in `ast_format.go` —
prints leaf key tokens verbatim, so the endpoints that render the
`*ConfigTree` AST returned the same secrets in **cleartext**:

- REST config **show / export / search / rollback** (`pkg/api/config.go`)
- gRPC **ShowConfig / ShowCompare / ShowRollback** (`pkg/grpcapi/server_config.go`)

An API/gRPC client could read every IKE/IPsec PSK, OSPF/IS-IS/RIP/BGP/VRRP
auth key, SNMPv3 password, SNMP v1/v2c community, WireGuard key, DDNS
token and crypt(3) hash — worse combined with a non-loopback REST bind.
Junos redacts these in `show configuration` (`SECRET-DATA`); xpf's
raw-AST paths did not.

## Fix

`ConfigTree.RedactedClone()` (new `pkg/config/ast_redact.go`) — a
**display-only** deep clone masking every secret leaf value with
`config.SecretDataPlaceholder` (`##SECRET-DATA##`). Secrets are matched
on the **flattened key path** so a secret is identified identically in
both AST shapes (hierarchical parse vs a flat-set collapsed leaf).

**Secret-leaf set = #2053's `config.Secret` field set**, resolved to AST
keyword signatures (verified against the compiler's `Secret(...)` sites).
Distinctive keywords: `pre-shared-key` (keeps `ascii-text`/`hexadecimal`),
`authentication-key`, `authentication-password`, `privacy-password`,
`encrypted-password`, `simple-password`, `api-key`, `tsig-secret`,
`api-token`, `aws-secret-key`, `private-key`, `preshared-key`. Three
generic keywords are disambiguated by required ancestor context so a
non-secret look-alike is never masked: `key` only under `authentication
md5 <id>` (OSPF hello key — not a GRE tunnel `key` or a chassis
device-map identity `key`), `password` only under `api-auth` /
`dynamic-dns`, and `community` only directly under `snmp` (not a
`policy-options community` routing object).

Redaction is applied at the **REST + gRPC boundary only**, via new
`Store.Show*Redacted` methods. The cleartext `Show*` SSOT is unchanged —
**HA config sync** (`daemon_ha_sync.go`), the **DR/compliance archive**
(`daemon_flow.go`), persistence/rollback and the **on-box CLI** still get
real secrets (the peer/archive must; the on-box operator reads their own —
Junos parity). The remote `cli` binary is covered transitively via gRPC.

## Validation

- **RED-on-revert:** with `RedactedClone` neutered, the config, api and
  grpcapi redaction tests all FAIL with cleartext secrets present.
- `pkg/config/ast_redact_test.go` — mask-every-format, no-source-mutation,
  no-over-masking, pre-shared-key qualifier retained.
- `pkg/api/config_raw_ast_redaction_test.go` — REST show/export/search.
- `pkg/grpcapi/server_config_redaction_test.go` — gRPC ShowConfig
  (every format + path-scoped).
- `go test ./pkg/config/ ./pkg/configstore/ ./pkg/api/ ./pkg/grpcapi/
  ./pkg/daemon/ ./pkg/cli/ ./cmd/...` green; `go build ./...` green;
  `gofmt`/`go vet` clean. Doc: `docs/config-schema.md` #4051 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
