### PR TITLE
configstore: write secret-bearing config files 0600, not 0644 (#4056)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -31610,3 +31610,33 @@ top.
   - **File(s)**: pkg/daemon/daemon.go, pkg/daemon/daemon_ha_fabric.go,
     pkg/daemon/daemon_ha_sync.go, pkg/daemon/daemon_ha_fabric_test.go,
     docs/fabric-cross-chassis-fwd.md, _Log.md
+
+- **Timestamp**: 2026-07-03
+  - **Action**: #4056 — configstore secret-bearing files 0644→0600
+    (world-readable secrets at rest). VERIFY-FIRST confirmed the rollback
+    text slots (`<config>.N`), config archives (`config-*.conf`),
+    `rescue.conf`, AND the active/candidate/rollback JSON DB were all
+    written mode 0644 (world-readable). The text copies come from
+    `config.Format()`, which never redacts/encrypts, so they ALWAYS carry
+    cleartext IKE PSK / auth keys / SNMP community; the JSON DB is
+    AES-GCM-encrypted only when `system master-password` is set, cleartext
+    otherwise. Either way 0644 exposed secrets to any local user and
+    defeated master-password encryption. Fix: mode 0600 on
+    `db.go writeTreeMarked`, `store_commit.go saveRollbackFiles` (durable
+    slot 1 + atomic slots 2..N), `store_persist.go writeArchive` and
+    `SaveRescueConfig`; `.configdb` dir 0700 (mkdir + idempotent Chmod for
+    upgrades) and archive dir 0700. `master.key` was already 0600. The v2
+    audit journal stays 0644 (metadata-only, no secrets, #1896). fsatomic
+    enforces the mode on the temp fd before rename, so an existing 0644
+    file is re-created 0600 on the next commit; daemon owns the files so
+    read-back is unaffected. Shipped perms only; the encryption-in-rollback
+    design (encrypt/redact secrets in the persisted TEXT copies when
+    master-password is set, with decrypt-on-restore) is deferred to an
+    issue comment. RED-on-revert: `file_perms_4056_test.go` asserts each
+    file 0600 + dirs 0700 + read-back + cleartext secret present; reverting
+    to 0644/0755 fails all four. Validated: `go test ./pkg/configstore/...`,
+    `go build ./...`, gofmt + vet clean.
+  - **File(s)**: pkg/configstore/db.go, pkg/configstore/store_commit.go,
+    pkg/configstore/store_persist.go,
+    pkg/configstore/file_perms_4056_test.go,
+    pkg/configstore/README.md, _Log.md

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -13,6 +13,41 @@ dereferences the DB, so the old "falling back to file-only" warning was
 describing code that never existed, followed by a nil-pointer panic on
 the first Load/Save/commit.
 
+## File permissions — secrets at rest (#4056)
+
+Every persisted copy of the full config carries the config's secret
+leaves (IKE/IPsec PSKs, WireGuard/auth keys, SNMP community, routing
+auth). Those leaves are stored **cleartext** unless `system
+master-password` is set (which AES-GCM-encrypts only the JSON DB body,
+not the text copies). So all secret-bearing files are written
+**owner-only 0600**, never world-readable 0644 — a 0644 copy exposed
+every firewall secret to any local user and defeated the point of
+master-password encryption. `fsatomic` enforces the mode on the temp fd
+before the rename (`WriteFileAtomic`/`WriteFileDurable` replace the
+inode on every write), so an existing 0644 file from a pre-#4056 build is
+re-created 0600 on the next commit.
+
+| File | Path | Mode | Writer |
+|------|------|------|--------|
+| Active / candidate / rollback DB | `.configdb/{active,candidate,rollback.N}.json` | 0600 | `db.go writeTreeMarked` |
+| `master.key` | `.configdb/master.key` | 0600 | `crypto.go readOrCreateMasterKey` |
+| Text rollback slots | `<config>.N` (e.g. `xpf.conf.1`) | 0600 | `store_commit.go saveRollbackFiles` |
+| Rescue config | `rescue.conf` | 0600 | `store_persist.go SaveRescueConfig` |
+| Config archives | `<archive-dir>/config-*.conf` | 0600 | `store_persist.go writeArchive` |
+
+The `.configdb` and archive directories are created **0700** (they hold
+only secret-bearing files); the daemon owns them, so read-back is
+unaffected. The v2 audit journal (`.config.journal`) stays 0644 by
+design — it is compact metadata only (timestamp/action/detail), never
+config content or secret values (#1896).
+
+**Follow-up (design, not shipped here):** when master-password is set,
+the text rollback/archive/rescue copies still hold **cleartext** secrets
+(only the JSON DB body is encrypted). Encrypting or redacting secrets in
+those persisted text copies — with a decrypt-on-restore round-trip —
+needs a design decision (see the #4056 issue comment). This change ships
+the 0600 perms fix only.
+
 ## Entry points
 
 - `Store` — high-level API. Public methods include `ShowCandidate`,

--- a/pkg/configstore/db.go
+++ b/pkg/configstore/db.go
@@ -38,8 +38,22 @@ func NewDB(dir string) (*DB, error) {
 	// entry itself must survive power loss, or a commit that reported
 	// success can vanish with the whole directory. WriteFileDurable
 	// only fsyncs .configdb (the file's parent), not /etc/xpf.
-	if err := fsatomic.MkdirAllDurable(dir, 0755); err != nil {
+	//
+	// Owner-only 0700 (#4056): this directory holds master.key plus the
+	// active/candidate/rollback config DB — every file that may carry a
+	// cleartext IKE PSK / auth key when master-password is not set. It is
+	// a dedicated, xpf-owned subdirectory, so 0700 leaks nothing an
+	// operator needs. The FILES themselves are 0600 (writeTreeMarked); the
+	// dir mode is defense-in-depth so a non-owner cannot even enumerate
+	// the slot names.
+	if err := fsatomic.MkdirAllDurable(dir, 0700); err != nil {
 		return nil, fmt.Errorf("create db dir: %w", err)
+	}
+	// MkdirAllDurable does not chmod an already-existing directory, so an
+	// upgrade from a pre-#4056 build inherits the old 0755. Enforce 0700
+	// here — the daemon owns the dir, so this is idempotent and cheap.
+	if err := os.Chmod(dir, 0700); err != nil {
+		return nil, fmt.Errorf("restrict db dir perms: %w", err)
 	}
 	// Sweep temp files leaked by a crash mid-write (#1894). fsatomic
 	// names its temps ".<base>.tmp-<random>", so a daemon killed between
@@ -203,7 +217,13 @@ func (db *DB) writeTreeMarked(path string, tree *config.ConfigTree, committed bo
 	// committed stamps the #1922 step-0 marker.
 	data = wrapEnvelope(data, db.writerVersion, committed)
 
-	if err := fsatomic.WriteFileDurable(path, data, 0644); err != nil {
+	// Owner-only 0600 (#4056): active.json / candidate.json /
+	// rollback.N.json carry the full config, including secret leaves (IKE
+	// PSK, WireGuard/auth keys, SNMP community). When master-password is
+	// set the body is AES-GCM encrypted, but when it is not the secrets are
+	// cleartext — either way the DB must not be world-readable. The daemon
+	// runs as the owner, so 0600 does not affect read-back.
+	if err := fsatomic.WriteFileDurable(path, data, 0600); err != nil {
 		return fmt.Errorf("persist %s: %w", path, err)
 	}
 	return nil

--- a/pkg/configstore/file_perms_4056_test.go
+++ b/pkg/configstore/file_perms_4056_test.go
@@ -1,0 +1,192 @@
+package configstore
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// secretToken is an identifiable cleartext credential embedded in the
+// committed config so the tests below can prove BOTH that the persisted
+// copy really contains the secret (i.e. the exposure is real) AND that the
+// file is not world-readable.
+const secretToken = "SUPERSECRET-PSK-4056"
+
+// commitSecretConfig enters configure, sets a secret-bearing leaf (an SNMP
+// community — one of the credential leaves called out in #4056), and
+// commits. It returns the store so the caller can inspect the persisted
+// files.
+func commitSecretConfig(t *testing.T, s *Store) {
+	t.Helper()
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := s.SetFromInput("snmp community " + secretToken); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+}
+
+// assertOwnerOnlyFile fails the test unless path exists as a regular file
+// with mode exactly 0600. This is the load-bearing #4056 assertion: it goes
+// RED on revert (0644 world-readable).
+func assertOwnerOnlyFile(t *testing.T, path string) {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Errorf("%s mode = %#o, want 0600 (world-readable secrets defeat encryption, #4056)", path, got)
+	}
+}
+
+// assertContainsSecret confirms the persisted copy actually holds the
+// cleartext credential — so the 0600 assertion is guarding a real secret,
+// not an empty file. (When master-password is unset the config text/JSON is
+// cleartext; this is exactly the case the perms fix protects.)
+func assertContainsSecret(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !strings.Contains(string(data), secretToken) {
+		t.Fatalf("%s does not contain the committed secret %q; test is not exercising a secret-bearing file", path, secretToken)
+	}
+}
+
+// TestRollbackSlotOwnerOnly_4056 pins that the text rollback slot
+// (xpf.conf.1) — which always holds the full config text including cleartext
+// secret leaves — is written 0600, and that the daemon can still read it
+// back.
+//
+// RED on revert: saveRollbackFiles writes the slot 0644 (world-readable),
+// so assertOwnerOnlyFile fails.
+func TestRollbackSlotOwnerOnly_4056(t *testing.T) {
+	s := newTestStore(t)
+	// First commit lands the secret; a second commit pushes the
+	// secret-bearing config into rollback slot 1 (history is prior states,
+	// most-recent-first). Commit keeps the configure lock, so both commits
+	// happen in one configure session.
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := s.SetFromInput("snmp community " + secretToken); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("first Commit: %v", err)
+	}
+	if err := s.SetFromInput("system host-name post-secret"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("second Commit: %v", err)
+	}
+
+	slot1 := s.rollbackPath(1)
+	assertContainsSecret(t, slot1)
+	assertOwnerOnlyFile(t, slot1)
+
+	// Read-back still works at 0600 (daemon owns the file). The text slots
+	// are consumed by loadRollbackHistory; confirm the on-disk text is
+	// readable by the owner.
+	if _, rerr := os.ReadFile(slot1); rerr != nil {
+		t.Fatalf("owner cannot read back 0600 rollback slot: %v", rerr)
+	}
+}
+
+// TestActiveDBOwnerOnly_4056 pins that the active-config JSON DB
+// (active.json) — full config, secrets cleartext when master-password is
+// unset — is written 0600, and that the .configdb directory holding it (plus
+// master.key) is 0700.
+//
+// RED on revert: writeTreeMarked writes 0644 and NewDB creates .configdb
+// 0755.
+func TestActiveDBOwnerOnly_4056(t *testing.T) {
+	s := newTestStore(t)
+	commitSecretConfig(t, s)
+
+	dbDir := filepath.Join(filepath.Dir(s.filePath), ".configdb")
+	active := filepath.Join(dbDir, "active.json")
+	assertContainsSecret(t, active)
+	assertOwnerOnlyFile(t, active)
+
+	// Directory holding master.key + the config DB must be owner-only 0700.
+	fi, err := os.Stat(dbDir)
+	if err != nil {
+		t.Fatalf("stat %s: %v", dbDir, err)
+	}
+	if got := fi.Mode().Perm(); got != 0o700 {
+		t.Errorf(".configdb mode = %#o, want 0700 (#4056)", got)
+	}
+
+	// Read-back through the store must still work at 0600.
+	if tree, err := s.db.ReadActive(); err != nil || tree == nil {
+		t.Fatalf("owner cannot read back 0600 active DB: tree=%v err=%v", tree, err)
+	}
+}
+
+// TestRescueConfigOwnerOnly_4056 pins that rescue.conf — the full active
+// config text with cleartext secrets — is written 0600 and still loads back.
+//
+// RED on revert: SaveRescueConfig writes 0644.
+func TestRescueConfigOwnerOnly_4056(t *testing.T) {
+	s := newTestStore(t)
+	commitSecretConfig(t, s)
+
+	if err := s.SaveRescueConfig(); err != nil {
+		t.Fatalf("SaveRescueConfig: %v", err)
+	}
+	rescue := s.rescuePath()
+	assertContainsSecret(t, rescue)
+	assertOwnerOnlyFile(t, rescue)
+
+	txt, err := s.LoadRescueConfig()
+	if err != nil {
+		t.Fatalf("LoadRescueConfig: %v", err)
+	}
+	if !strings.Contains(txt, secretToken) {
+		t.Fatalf("LoadRescueConfig could not read back the 0600 rescue config")
+	}
+}
+
+// TestArchiveOwnerOnly_4056 pins that a config archive file (config-*.conf,
+// full config text with cleartext secrets) is written 0600 and its directory
+// 0700.
+//
+// RED on revert: writeArchive writes the file 0644 and the dir 0755.
+func TestArchiveOwnerOnly_4056(t *testing.T) {
+	s := newTestStore(t)
+	commitSecretConfig(t, s)
+
+	archiveDir := filepath.Join(t.TempDir(), "archive")
+	if err := s.ArchiveConfig(archiveDir, 10); err != nil {
+		t.Fatalf("ArchiveConfig: %v", err)
+	}
+
+	fi, err := os.Stat(archiveDir)
+	if err != nil {
+		t.Fatalf("stat %s: %v", archiveDir, err)
+	}
+	if got := fi.Mode().Perm(); got != 0o700 {
+		t.Errorf("archive dir mode = %#o, want 0700 (#4056)", got)
+	}
+
+	entries, err := os.ReadDir(archiveDir)
+	if err != nil {
+		t.Fatalf("read archive dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("no archive file was written")
+	}
+	for _, e := range entries {
+		p := filepath.Join(archiveDir, e.Name())
+		assertContainsSecret(t, p)
+		assertOwnerOnlyFile(t, p)
+	}
+}

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -597,10 +597,16 @@ func (s *Store) saveRollbackFiles() {
 		path := s.rollbackPath(i + 1)
 		data := entry.Config.Format()
 		var err error
+		// Owner-only 0600 (#4056): the rollback slots (xpf.conf.N) hold the
+		// full committed config TEXT, which always includes cleartext secret
+		// leaves (IKE PSK, auth keys, SNMP community) — Format() does not
+		// redact or encrypt. World-readable 0644 exposed every firewall
+		// secret to any local user; 0600 keeps them owner-only. The daemon
+		// owns the files, so loadRollbackHistory still reads them back.
 		if i == 0 {
-			err = rbWriteFileDurable(path, []byte(data), 0644)
+			err = rbWriteFileDurable(path, []byte(data), 0600)
 		} else {
-			err = rbWriteFileAtomic(path, []byte(data), 0644)
+			err = rbWriteFileAtomic(path, []byte(data), 0600)
 		}
 		if err != nil {
 			slog.Warn("failed to write rollback file", "path", path, "err", err)

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -308,7 +308,12 @@ func (s *Store) ArchiveConfig(archiveDir string, maxArchives int) error {
 // rotateArchives uses stays chronological (ts dominates; the 20-digit
 // zero-padded seq only breaks same-ts ties, in monotonic commit order).
 func writeArchive(archiveDir string, maxArchives int, data string, ts time.Time, seq uint64) error {
-	if err := os.MkdirAll(archiveDir, 0755); err != nil {
+	// Owner-only 0700 (#4056): the archive directory holds only timestamped
+	// copies of the full config text (each with cleartext secrets), so it
+	// must not be world-traversable. MkdirAll does not chmod an existing
+	// dir, so an upgrade keeps its old mode; the archive FILES are 0600
+	// regardless, which is the load-bearing protection.
+	if err := os.MkdirAll(archiveDir, 0700); err != nil {
 		return fmt.Errorf("create archive dir: %w", err)
 	}
 
@@ -317,7 +322,11 @@ func writeArchive(archiveDir string, maxArchives int, data string, ts time.Time,
 	// AtomicGeneratedConfig (#1894): archives are best-effort history
 	// copies — atomic so a crash never leaves a torn archive, but not
 	// worth an fsync.
-	if err := rbWriteFileAtomic(path, []byte(data), 0644); err != nil {
+	//
+	// Owner-only 0600 (#4056): an archive is the full committed config TEXT
+	// with cleartext secret leaves (IKE PSK, auth keys); 0644 leaked them to
+	// any local user.
+	if err := rbWriteFileAtomic(path, []byte(data), 0600); err != nil {
 		return fmt.Errorf("write archive: %w", err)
 	}
 
@@ -386,7 +395,12 @@ func (s *Store) SaveRescueConfig() error {
 	path := s.rescuePath()
 	// DurableState (#1894): the rescue config is the operator's
 	// explicitly-requested safety net — it must survive power loss.
-	if err := fsatomic.WriteFileDurable(path, []byte(data), 0644); err != nil {
+	//
+	// Owner-only 0600 (#4056): rescue.conf is the full active config TEXT
+	// with cleartext secret leaves (IKE PSK, auth keys, SNMP community);
+	// 0644 exposed them to any local user. The daemon owns the file, so
+	// LoadRescueConfig still reads it back.
+	if err := fsatomic.WriteFileDurable(path, []byte(data), 0600); err != nil {
 		return fmt.Errorf("save rescue config: %w", err)
 	}
 	slog.Info("rescue configuration saved", "path", path)


### PR DESCRIPTION
Refs #4056.

## Problem

The config store persisted the full committed config to disk at mode **0644 (world-readable)** in four places, each of which carries the config's secret leaves (IKE/IPsec PSKs, WireGuard/auth keys, SNMP community, routing auth):

| File | Path | Was | Writer |
|------|------|-----|--------|
| Active / candidate / rollback DB | `.configdb/{active,candidate,rollback.N}.json` | 0644 | `db.go writeTreeMarked` |
| Text rollback slots | `<config>.N` (e.g. `xpf.conf.1`) | 0644 | `store_commit.go saveRollbackFiles` |
| Rescue config | `rescue.conf` | 0644 | `store_persist.go SaveRescueConfig` |
| Config archives | `<archive-dir>/config-*.conf` | 0644 | `store_persist.go writeArchive` |

The text copies come from `config.Format()`, which never redacts/encrypts — so they **always** hold cleartext secrets. The JSON DB body is AES-GCM-encrypted only when `system master-password` is set, cleartext otherwise. Either way, 0644 let any local user read every firewall secret off disk, and **defeated master-password encryption** (the rollback/archive copies leaked the plaintext the active config was encrypting). `master.key` was already correctly 0600.

## Fix (perms only)

- Mode **0600** on all four write paths. `fsatomic` enforces the mode on the temp fd before the atomic rename, so an existing 0644 file from a pre-fix build is re-created 0600 on the next commit.
- `.configdb` and archive directories created **0700** (they hold only secret-bearing files); `.configdb` gets an idempotent `Chmod` so an upgrade tightens the old 0755.
- Daemon runs as the owner → 0600 does not affect read-back (`loadRollbackHistory`, `LoadRescueConfig`, `ReadActive`).
- v2 audit journal (`.config.journal`) intentionally stays 0644 — compact metadata only, no config content or secret values (#1896).

## Deferred (design, tracked on the issue — why this is Refs, not Closes)

When master-password is set, the **text** rollback/archive/rescue copies still hold cleartext secrets (only the JSON DB body is encrypted). Encrypting/redacting the persisted text copies with a decrypt-on-restore round-trip is a separate design decision, described in a comment on #4056. This PR ships the 0600 perms fix only; the issue stays open for that half.

## Test — RED on revert

`pkg/configstore/file_perms_4056_test.go` commits a secret-bearing config and asserts, for the rollback slot / active DB / rescue.conf / archive: file mode is 0600, the enclosing secret dir is 0700, the owner can still read it back, and the persisted copy actually contains the committed secret (so the assertion guards a real secret). Reverting any mode to 0644/0755 fails all four tests (verified).

## Validation

- `go test ./pkg/configstore/...` — green
- `go build ./...` — clean
- `gofmt` + `go vet ./pkg/configstore/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi