### PR TITLE
userspace-dp: run export_all_sessions push off the global ServerState lock (#4054)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,55 @@
+## 2026-07-03 — #4054: export_all_sessions ran push_delta_lossless / frame serialization UNDER the global ServerState lock → a large bulk session export could starve the status poll → false dp-failure → needless helper restart
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-086 (MEDIUM, HA availability). The
+    `export_all_sessions` control verb
+    (`Coordinator::export_all_sessions_to_event_stream`, `pkg` =
+    `userspace-dp/src/afxdp/ha.rs`) is the coordinator-driven bulk export used
+    on peer connect / FullResync. It iterated the shared session table and then
+    pushed each qualifying local forward session through the event stream via
+    `push_delta_lossless`, which retries a full/backpressured event-stream
+    channel up to a **5 s** per-delta lossless-queue timeout. The whole thing —
+    table iteration AND the serialization loop — ran inside the control-socket
+    dispatcher's `ServerState` `match` arm (`server/handlers/mod.rs`), i.e.
+    UNDER the single global lock that serializes every control RPC (status poll,
+    session install, snapshot/FIB bump, HA state update). On a firewall with
+    many sessions a bulk export against a slow peer stream could hold the lock
+    long enough for the status poll to miss the control plane's liveness
+    deadline → a false dataplane-failure → a needless helper restart (drops all
+    sessions + flaps forwarding) — exactly at failover, the worst time. The
+    session-TABLE lock (`sessions.synced`) was already released before the push
+    (a partial pre-existing correctness), but the GLOBAL lock was not. The
+    owner-RG export path was already fixed for exactly this in #2962; the
+    all-sessions path was not.
+  - **Fix**: split the handler off the global lock, mirroring #2962. New
+    `Coordinator::snapshot_all_sessions_export` runs the LOCKED phase (iterate
+    the table under a brief `sessions.synced` lock, copy each qualifying session
+    into an Open `SessionDelta`, capture the Arc-cheap event-stream handle + an
+    OWNED clone of the zone-name→id map) and returns an `AllSessionsExport`.
+    `AllSessionsExport::push` runs the `push_delta_lossless` loop with the
+    global lock RELEASED. Dispatcher: `export_all_sessions` now only calls
+    `all_kick` (snapshot) under the lock, captures `all_export`, drops the lock,
+    then runs `all_push` — with the deferred status attach re-derived under a
+    fresh short-lived lock (byte-identical to the #2962 `export_wait` pattern).
+    Correctness: the exported set is the same consistent point-in-time snapshot
+    (deltas built under `sessions.synced`, zone map cloned in the same locked
+    phase); event-stream ordering stays governed by `producer_seq_lock` inside
+    `push_delta_lossless`, not the `ServerState` lock, so the lossless seq
+    contract (#2874 / #3878) is untouched — only the GLOBAL lock scope shrinks.
+  - **Validation**: RED-on-revert proven — a dispatcher test
+    (`export_all_sessions_does_not_hold_state_lock_during_push`) installs a
+    connected single-slot event stream + 4 qualifying local forward sessions so
+    the bulk-export push blocks against the full channel, then asserts a
+    concurrent `status` poll is served in < 1 s. With the push moved back under
+    the lock (revert sim) the status poll blocked **4.85 s** (the 5 s lossless
+    timeout) → RED; with the fix it returns promptly. FULL cargo test --release
+    green; `go build ./...` green; rustfmt clean on changed lines. test-failover
+    WARRANTED (HA session export) — flagged for batch validation.
+  - **File(s)**: userspace-dp/src/afxdp/ha.rs,
+    userspace-dp/src/afxdp/mod.rs, userspace-dp/src/server/handlers/export.rs,
+    userspace-dp/src/server/handlers/mod.rs, userspace-dp/src/server/tests.rs,
+    docs/session-sync-architecture.md, _Log.md
+
 ## 2026-07-03 — #4049: LLDP resolved its socket with the Junos slash name (ge-0/0/0) instead of the kernel dash name (ge-0-0-0) → net.InterfaceByName failed → LLDP never started on any renamed data port
 
 - **Timestamp**: 2026-07-03

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -441,6 +441,40 @@ advance their ack atomics (monotonic seq) and push into their delta buffers —
 both `Arc`-shared and lock-free — so the snapshot observes their progress
 faithfully. The 15 s deadline and the timeout error are preserved verbatim.
 
+**The all-sessions bulk export push ALSO runs OFF the global `ServerState`
+lock (#4054).** The `export_all_sessions` verb
+(`Coordinator::snapshot_all_sessions_export` → `AllSessionsExport::push`) is the
+coordinator-driven bulk export used on peer connect / FullResync. It iterates the
+shared session table and pushes each qualifying local forward session as an Open
+delta through the event stream via `push_delta_lossless`, which retries a full
+event-stream channel up to a **5 s** per-delta lossless-queue timeout. Pre-#4054
+the whole export — the table iteration AND the `push_delta_lossless` serialization
+loop — ran inside the dispatcher's `ServerState` `match` arm, i.e. UNDER the global
+lock. On a firewall with many sessions, a bulk export against a slow/backpressured
+peer stream could hold the lock long enough for the status poll to miss the control
+plane's liveness deadline → a false dataplane-failure → a needless helper restart
+(which drops all sessions and flaps forwarding) — precisely at failover, the worst
+time. The handler is therefore split like the owner-RG path:
+
+- **Locked phase** (`Coordinator::snapshot_all_sessions_export`, dispatcher
+  `all_kick`): under the global lock, iterate the session table once under a brief
+  `sessions.synced` lock, copy each qualifying session into an Open `SessionDelta`,
+  and capture the Arc-cheap event-stream worker handle plus an OWNED clone of the
+  zone-name→id map. Returns an `AllSessionsExport` immediately — no push yet.
+- **Lock-free phase** (`AllSessionsExport::push`): the dispatcher drops the
+  `ServerState` lock, then runs the `push_delta_lossless` loop over the captured
+  snapshot. Status is re-derived afterward under a fresh short-lived lock. While
+  one bulk export serializes/backpressures, all other control RPCs proceed.
+
+The exported set is a consistent point-in-time snapshot (deltas built under
+`sessions.synced`, zone map cloned in the same locked phase), so a session or zone
+mutation racing the push is simply not in THIS bulk export — it rides the
+incremental delta stream — identical to the pre-#4054 semantics, which already
+snapshotted the deltas under `sessions.synced` before serializing (only the GLOBAL
+lock scope changes). Event-stream ordering stays governed by `producer_seq_lock`
+inside `push_delta_lossless`, not the `ServerState` lock, so releasing the latter
+does not affect the lossless seq contract (#2874 / #3878).
+
 ### Delta-ring overflow → loss-of-sync resync (#2442)
 
 Each worker buffers session open/close deltas in an in-worker ring

--- a/userspace-dp/src/afxdp/ha.rs
+++ b/userspace-dp/src/afxdp/ha.rs
@@ -601,22 +601,43 @@ impl super::Coordinator {
         0
     }
 
-    /// Export all locally-owned forward sessions through the event stream.
+    /// Snapshot all locally-owned forward sessions for a bulk HA export
+    /// WITHOUT pushing them (#4054).
     ///
     /// Called on peer connect instead of the old BulkSync path. Iterates the
-    /// shared session table and pushes each qualifying session as an Open event
-    /// through the event stream, where the Go daemon's handleEventStreamDelta
-    /// callback will queue it to the peer via QueueSessionV4/V6.
+    /// shared session table once under a BRIEF `sessions.synced` lock, copies
+    /// each qualifying session into an Open [`SessionDelta`], and captures the
+    /// (Arc-cheap) event-stream handle plus an OWNED clone of the zone-name→id
+    /// map. The returned [`AllSessionsExport`] carries everything the push loop
+    /// needs, so the caller can run the potentially-blocking
+    /// `push_delta_lossless` serialization with the global `ServerState` lock
+    /// RELEASED — mirroring the owner-RG two-phase split (#2962). Before #4054
+    /// the whole export (iteration + serialization + up to a 5 s per-delta
+    /// lossless-queue backpressure wait) ran under the global lock, so a large
+    /// bulk export at failover could starve the status poll / trip the control
+    /// plane's liveness deadline and self-inflict a needless helper restart.
     ///
-    /// Returns the number of sessions exported.
-    pub fn export_all_sessions_to_event_stream(&self) -> Result<usize, String> {
+    /// The exported set is a consistent point-in-time snapshot: the delta
+    /// vector is built under the `sessions.synced` lock, and the zone map is
+    /// cloned within the same locked dispatcher phase, so a session or zone
+    /// mutation racing the subsequent push is simply not reflected in THIS bulk
+    /// export (it rides the incremental delta stream instead) — identical
+    /// semantics to the pre-#4054 code, which likewise snapshotted the deltas
+    /// under the same lock before serializing. Event-stream ordering is still
+    /// governed by `producer_seq_lock` inside `push_delta_lossless`, not the
+    /// `ServerState` lock, so releasing the latter does not affect the lossless
+    /// seq contract (#2874 / #3878).
+    pub fn snapshot_all_sessions_export(&self) -> Result<AllSessionsExport, String> {
         let es = self
             .event_stream
             .as_ref()
             .ok_or_else(|| "event stream not started".to_string())?;
         let handle = es.worker_handle();
 
-        let zone_name_to_id = &self.forwarding.zone_name_to_id;
+        // Clone the zone map so the push loop can run off the global lock:
+        // `push_delta_lossless` borrows it, and a borrow of `self.forwarding`
+        // would otherwise pin coordinator state across the (blocking) push.
+        let zone_name_to_id = self.forwarding.zone_name_to_id.clone();
 
         let sessions = self
             .sessions.synced
@@ -677,14 +698,97 @@ impl super::Coordinator {
         }
         drop(sessions);
 
-        let count = deltas.len();
-        for delta in &deltas {
-            handle.push_delta_lossless(delta, zone_name_to_id)?;
+        Ok(AllSessionsExport {
+            handle,
+            zone_name_to_id,
+            deltas,
+        })
+    }
+
+    /// #4054 test seam: install a qualifying LOCAL forward session (owner-RG 0
+    /// so the RG-active gate is bypassed, `ForwardCandidate` disposition, local
+    /// `ForwardFlow` origin so it is not skipped as peer-synced) so a dispatcher
+    /// test can drive a non-empty bulk export against a backpressured event
+    /// stream. `idx` gives each call a distinct 5-tuple.
+    #[cfg(test)]
+    pub(crate) fn test_install_local_forward_session(&self, idx: u16) {
+        use std::net::{IpAddr, Ipv4Addr};
+        let key = SessionKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+            src_port: 40000 + idx,
+            dst_port: 5201,
+        };
+        let resolution = ForwardingResolution {
+            disposition: ForwardingDisposition::ForwardCandidate,
+            local_ifindex: 0,
+            egress_ifindex: 12,
+            tx_ifindex: 12,
+            tunnel_endpoint_id: 0,
+            next_hop: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 50, 1))),
+            neighbor_mac: Some([0, 1, 2, 3, 4, 5]),
+            src_mac: Some([6, 7, 8, 9, 10, 11]),
+            tx_vlan_id: 0,
+        };
+        let metadata = SessionMetadata {
+            ingress_zone: 1,
+            egress_zone: 3,
+            owner_rg_id: 0,
+            fabric_ingress: false,
+            is_reverse: false,
+            nat64_reverse: None,
+            log_session_init: false,
+            log_session_close: false,
+            policy_id: 0,
+            inactivity_timeout_ns: None,
+            policy_counter_idx: 0,
+            policy_counter: None,
+        };
+        self.upsert_synced_session(SyncedSessionEntry {
+            key,
+            decision: SessionDecision {
+                resolution,
+                nat: NatDecision::default(),
+            },
+            metadata,
+            origin: SessionOrigin::ForwardFlow,
+            protocol: PROTO_TCP,
+            tcp_flags: 0,
+            generation: 0,
+        });
+    }
+}
+
+/// A prepared bulk session export captured by
+/// [`Coordinator::snapshot_all_sessions_export`] under the global
+/// `ServerState` lock, so the (potentially blocking) lossless push loop can
+/// run with that lock RELEASED (#4054). Mirrors [`OwnerRgExportWait`]'s
+/// off-lock design (#2962): everything the push needs — the Arc-cheap
+/// event-stream worker handle, an OWNED zone-name→id map, and the point-in-time
+/// session-delta snapshot — is captured by value, so no coordinator borrow is
+/// held across `push`.
+pub struct AllSessionsExport {
+    handle: crate::event_stream::EventStreamWorkerHandle,
+    zone_name_to_id: FxHashMap<String, u16>,
+    deltas: Vec<crate::session::SessionDelta>,
+}
+
+impl AllSessionsExport {
+    /// Push the snapshotted Open deltas through the lossless event-stream
+    /// producer. Runs WITHOUT the global `ServerState` lock (#4054), so a large
+    /// or backpressured bulk export (each `push_delta_lossless` retries up to
+    /// the 5 s lossless-queue timeout) can no longer freeze status polls,
+    /// session installs, or HA state updates on that lock. Returns the number
+    /// of sessions pushed on success.
+    pub fn push(self) -> Result<usize, String> {
+        let count = self.deltas.len();
+        for delta in &self.deltas {
+            self.handle
+                .push_delta_lossless(delta, &self.zone_name_to_id)?;
         }
-        eprintln!(
-            "xpf-ha: exported {} sessions to event stream for bulk sync",
-            count
-        );
+        eprintln!("xpf-ha: exported {count} sessions to event stream for bulk sync");
         Ok(count)
     }
 }

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -444,6 +444,10 @@ pub(crate) use self::coordinator::ReconcileError;
 // kick_owner_rg_export so it can run the blocking ack-wait off the
 // global ServerState lock.
 pub(crate) use self::ha::OwnerRgExportWait;
+// #4054: re-export the two-phase all-sessions bulk export handle so the
+// control-socket dispatcher can run the lossless push loop off the global
+// ServerState lock (mirrors the OwnerRgExportWait split, #2962).
+pub(crate) use self::ha::AllSessionsExport;
 // #1636: re-export the warmer types/consts into afxdp scope so the
 // neighbor-warmer loop in neighbor.rs (which uses `use super::*`) and
 // the unit tests can name them without a fully-qualified path.

--- a/userspace-dp/src/server/handlers/export.rs
+++ b/userspace-dp/src/server/handlers/export.rs
@@ -8,9 +8,8 @@
 // runs `OwnerRgExportWait::wait_and_collect` (the blocking 15 s ack-wait)
 // lock-free, so a slow worker can no longer freeze the whole control plane.
 
-use super::super::helpers::refresh_status;
 use super::super::ServerState;
-use crate::afxdp::OwnerRgExportWait;
+use crate::afxdp::{AllSessionsExport, OwnerRgExportWait};
 use crate::{ControlResponse, SessionExportRequest};
 
 /// Locked phase: enqueue the owner-RG export to every worker and capture the
@@ -47,14 +46,35 @@ pub(super) fn owner_rg_collect(
     }
 }
 
-pub(super) fn all(guard: &mut ServerState, response: &mut ControlResponse) {
-    match guard.afxdp.export_all_sessions_to_event_stream() {
-        Ok(_count) => {
-            refresh_status(guard);
-        }
+/// Locked phase of `export_all_sessions` (#4054): snapshot the bulk export
+/// under the global `ServerState` lock and return the lock-free push handle.
+/// The (potentially blocking) `push_delta_lossless` loop runs in `all_push`
+/// AFTER the dispatcher drops the lock — mirroring the owner-RG `owner_rg_kick`
+/// split (#2962) — so a large or backpressured bulk export can no longer starve
+/// the status poll / trip the control plane's liveness deadline and self-inflict
+/// a needless helper restart. On error (event stream not started) the error is
+/// folded into `response` and `None` is returned, so the dispatcher runs no
+/// push phase.
+pub(super) fn all_kick(
+    guard: &mut ServerState,
+    response: &mut ControlResponse,
+) -> Option<AllSessionsExport> {
+    match guard.afxdp.snapshot_all_sessions_export() {
+        Ok(export) => Some(export),
         Err(err) => {
             response.ok = false;
             response.error = err;
+            None
         }
+    }
+}
+
+/// Lock-free phase of `export_all_sessions` (#4054): run the lossless push loop
+/// with the global `ServerState` lock RELEASED. Called by the dispatcher after
+/// it drops the lock. Mirrors `owner_rg_collect`.
+pub(super) fn all_push(export: AllSessionsExport, response: &mut ControlResponse) {
+    if let Err(err) = export.push() {
+        response.ok = false;
+        response.error = err;
     }
 }

--- a/userspace-dp/src/server/handlers/mod.rs
+++ b/userspace-dp/src/server/handlers/mod.rs
@@ -110,6 +110,14 @@ pub(crate) fn handle_stream(
     // the post-match status attach is also deferred until after the wait so
     // the reported status reflects the drained state.
     let mut export_wait: Option<crate::afxdp::OwnerRgExportWait> = None;
+    // #4054: the all-sessions bulk export follows the same off-lock split. The
+    // locked `match` arm only SNAPSHOTS the export (session-table copy + Arc
+    // handle + cloned zone map); the blocking `push_delta_lossless` loop runs
+    // below, AFTER the lock is dropped, so a large/backpressured bulk export can
+    // no longer freeze status polls, session installs, snapshot/FIB bumps, and
+    // HA state updates. As with `export_wait`, the post-match status attach is
+    // deferred until after the push.
+    let mut all_export: Option<crate::afxdp::AllSessionsExport> = None;
 
     {
         let mut guard = state.lock().expect("server state poisoned");
@@ -218,7 +226,11 @@ pub(crate) fn handle_stream(
                 // handle. The blocking ack-wait runs after the lock drops.
                 export_wait = Some(export::owner_rg_kick(&mut guard, request.session_export));
             }
-            "export_all_sessions" => export::all(&mut guard, &mut response),
+            "export_all_sessions" => {
+                // #4054: locked phase only — snapshot + capture the push
+                // handle. The blocking push loop runs after the lock drops.
+                all_export = export::all_kick(&mut guard, &mut response);
+            }
             "rebind" => rebind::handle(&mut guard, &mut persist_state),
             "stop_workers" => stop_workers::handle(&mut guard, &mut persist_state),
             "shutdown" => {
@@ -231,10 +243,11 @@ pub(crate) fn handle_stream(
                 response.error = format!("unknown request type {other}");
             }
         }
-        // #2962: defer status attach for the export verb — it is computed
-        // after the lock-free ack-wait below so it reflects the drained
-        // state (and is not produced while holding the lock across a wait).
-        if export_wait.is_none() && !suppress_status {
+        // #2962/#4054: defer status attach for the export verbs — it is
+        // computed after the lock-free ack-wait / push below so it reflects the
+        // drained state (and is not produced while holding the lock across a
+        // wait or a blocking push).
+        if export_wait.is_none() && all_export.is_none() && !suppress_status {
             refresh_status(&mut guard);
             response.status = Some(guard.status.clone());
         }
@@ -246,6 +259,19 @@ pub(crate) fn handle_stream(
     // lock acquisition (the wait is already done).
     if let Some(wait) = export_wait {
         export::owner_rg_collect(wait, &mut response, &mut persist_state);
+        if !suppress_status {
+            let mut guard = state.lock().expect("server state poisoned");
+            refresh_status(&mut guard);
+            response.status = Some(guard.status.clone());
+        }
+    }
+
+    // #4054: all-sessions bulk export push runs here, with the global
+    // ServerState lock RELEASED, so the control plane stays responsive while a
+    // large/backpressured bulk export serializes. Status is then re-derived
+    // under a fresh short-lived lock acquisition (the push is already done).
+    if let Some(export) = all_export {
+        export::all_push(export, &mut response);
         if !suppress_status {
             let mut guard = state.lock().expect("server state poisoned");
             refresh_status(&mut guard);

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -1643,6 +1643,79 @@ fn export_owner_rg_does_not_hold_state_lock_during_ack_wait() {
     ack_thread.join().expect("ack thread");
 }
 
+// --- #4054: all-sessions bulk export must not hold the ServerState lock ----
+
+/// Fail-on-revert: the all-sessions bulk export (`export_all_sessions`) must run
+/// its (potentially blocking) `push_delta_lossless` serialization WITHOUT
+/// holding the global `ServerState` lock, so a large or backpressured bulk
+/// export at failover cannot freeze the control plane and self-inflict a
+/// needless helper restart. This installs a CONNECTED event stream whose
+/// channel holds a single slot and several qualifying local forward sessions,
+/// so after the first delta the push loop blocks against the full channel (up
+/// to the 5 s lossless-queue timeout). It then proves a concurrent `status`
+/// poll is still served promptly. If the push runs under the lock again (the
+/// bug), the status poll blocks until the push drains/times out — RED.
+#[test]
+fn export_all_sessions_does_not_hold_state_lock_during_push() {
+    use crate::event_stream::EventStreamSender;
+    use std::time::{Duration, Instant};
+
+    let state = new_state(ProcessStatus::default());
+
+    // Connected event stream, single-slot channel: the first pushed delta fills
+    // it, and every later delta retries against the full channel. Keep `rx`
+    // alive — dropping it disconnects the channel, which makes push fail
+    // IMMEDIATELY instead of blocking (and would mask the bug on revert).
+    let rx = {
+        let mut guard = state.lock().expect("lock state");
+        let (sender, rx) = EventStreamSender::test_sender(true, 1);
+        guard.afxdp.event_stream = Some(sender);
+        for i in 0..4u16 {
+            guard.afxdp.test_install_local_forward_session(i);
+        }
+        rx
+    };
+
+    // Kick the bulk export in the background: it snapshots the session set under
+    // a BRIEF lock, releases the global ServerState lock, then blocks in the
+    // push loop against the full channel.
+    let export_state = state.clone();
+    let export_thread =
+        std::thread::spawn(move || run_request(export_state, req("export_all_sessions")));
+
+    // Let the export reach its (blocked) push.
+    std::thread::sleep(Duration::from_millis(150));
+
+    // The control plane MUST answer a status poll WHILE the export's push loop
+    // is blocked. With the push under the global lock (the #4054 bug) this
+    // blocks until the 5 s lossless timeout releases the lock → RED.
+    let t0 = Instant::now();
+    let resp = run_request(state.clone(), req("status"));
+    let elapsed = t0.elapsed();
+    assert!(resp.ok, "status poll failed: {}", resp.error);
+    assert!(
+        elapsed < Duration::from_millis(1000),
+        "status poll blocked {elapsed:?} during all-sessions bulk export — \
+         ServerState lock held across push_delta_lossless (#4054 regression)"
+    );
+
+    // Drain the channel so the blocked push loop makes progress and the export
+    // thread finishes promptly instead of waiting the full 5 s per-delta
+    // timeout. Stop once no frame arrives for a short grace period (export done
+    // pushing).
+    let drainer = std::thread::spawn(move || {
+        while rx.recv_timeout(Duration::from_millis(300)).is_ok() {}
+    });
+
+    let export_resp = export_thread.join().expect("export thread");
+    drainer.join().expect("drainer thread");
+    assert!(
+        export_resp.ok,
+        "bulk export failed: {}",
+        export_resp.error
+    );
+}
+
 /// #3773 (L4): an `update_fabrics` that CHANGES the fabric set must fold the
 /// freshly-resolved FabricSnapshots into the STORED snapshot AND persist. The
 /// helper starts with `snapshot: None` and never self-restores, so the


### PR DESCRIPTION
Closes #4054.

## Problem (fable-161 F-086, MEDIUM — HA availability)

The `export_all_sessions` control verb — the coordinator-driven bulk HA
session export used on peer connect / FullResync
(`Coordinator::export_all_sessions_to_event_stream`,
`userspace-dp/src/afxdp/ha.rs`) — ran the whole export UNDER the global
`ServerState` lock in the control-socket dispatcher
(`server/handlers/mod.rs`). That includes the `push_delta_lossless`
serialization loop, which retries a full or backpressured event-stream
channel up to a **5 s** per-delta lossless-queue timeout.

On a firewall with many sessions, a bulk export against a slow peer
stream could hold the single `Mutex<ServerState>` — shared by the status
poll, session installs, snapshot/FIB bumps, and HA state updates — long
enough for the status poll to miss the control plane's liveness deadline.
The control plane then concludes the dataplane has FAILED and restarts the
helper, dropping all sessions and flapping forwarding — exactly during a
failover, the worst possible time. So a large bulk export self-inflicts a
needless dp-failure restart.

The session-table lock (`sessions.synced`) was already released before the
push, but the GLOBAL lock was not. The owner-RG export path was already
fixed for exactly this in #2962; the all-sessions path was not.

## Fix — snapshot-and-release, mirroring #2962

- `Coordinator::snapshot_all_sessions_export` (dispatcher `all_kick`) runs
  the LOCKED phase: iterate the table under a brief `sessions.synced` lock,
  copy each qualifying local forward session into an Open `SessionDelta`,
  and capture the Arc-cheap event-stream worker handle plus an OWNED clone
  of the zone-name→id map. Returns an `AllSessionsExport` — no push yet.
- `AllSessionsExport::push` (dispatcher `all_push`) runs the
  `push_delta_lossless` loop with the global lock RELEASED. The dispatcher
  captures the handle in `all_export`, drops the lock, pushes, then
  re-derives the status attach under a fresh short-lived lock — identical
  to the existing `export_wait` deferral.

**Correctness preserved:** the exported set is the same consistent
point-in-time snapshot (deltas built under `sessions.synced`, zone map
cloned in the same locked phase), so a session/zone mutation racing the
push is simply not in this bulk export — it rides the incremental delta
stream — identical to the pre-change semantics. Only the global-lock scope
shrinks. Event-stream ordering stays governed by `producer_seq_lock`
inside `push_delta_lossless`, not the `ServerState` lock, so the lossless
seq contract (#2874 / #3878) is untouched.

## RED-on-revert proof

`export_all_sessions_does_not_hold_state_lock_during_push` installs a
connected single-slot event stream + 4 qualifying local forward sessions
so the bulk-export push blocks against the full channel, then asserts a
concurrent `status` poll returns in < 1 s. With the push moved back under
the lock (revert simulation) the status poll blocked **4.85 s** (the 5 s
lossless timeout) → RED. With the fix it returns promptly.

## Validation

- FULL `cargo test --release --test-threads=1` green (main binary 3468
  passed, 0 failed; all integration binaries pass).
- `go build ./...` green.
- rustfmt clean on changed lines (repo house style preserved).
- Docs: `docs/session-sync-architecture.md` gains the all-sessions
  off-lock note alongside the #2962 owner-RG note.

**test-failover is warranted** (HA session-export path) — flagging for
batch validation; not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi