### PR TITLE
vrrp: adopt master's advertised interval for Master_Down_Interval (#4061)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -31678,3 +31678,30 @@ top.
     pkg/configstore/store_persist.go,
     pkg/configstore/file_perms_4056_test.go,
     pkg/configstore/README.md, _Log.md
+
+- **Timestamp**: 2026-07-04
+  - **Action**: #4061 VRRP RFC 5798 §6.1/§6.4.2 — a BACKUP now adopts the
+    MASTER's advertised interval (Master_Adver_Interval) when computing
+    Master_Down_Interval, instead of its own configured AdvertiseInterval.
+    `VRRPPacket.MaxAdvertInt` was parsed (packet.go) but never consumed:
+    `masterDownInterval()` used `vi.advertInterval()` (local cfg), so a
+    master/backup interval mismatch (a rolling `reth-advertise-interval`
+    change or a misconfig) timed the master out on the wrong cadence — a
+    shorter local interval failed over prematurely (flapping), a longer one
+    detected master-down too late (traffic loss). Fix: new sticky field
+    `masterAdverInterval` set in `recordMasterAdvert` from the received
+    advert's Max Adver Int (centiseconds on the wire → ×10 ms Duration,
+    zero-field guarded); `masterDownInterval()` and the #2082/#2850
+    staleness-horizon replicas (`shouldPreemptObservedMaster`,
+    `preemptingLiveLowerMaster`) now use the learned interval via a shared
+    `effectiveAdvertInterval` helper, falling back to the local interval
+    before any advert is heard. Skew_Time still uses the local priority
+    (§6.1). Matching-interval case (RETH 30 ms both sides) is bit-identical
+    → ~60 ms failover preserved. RED-on-revert: reverting
+    `masterDownInterval` to the local-only computation makes
+    `TestMasterAdverInterval_LearnedFromAdvert` fail (108 ms from local
+    30 ms vs 3.609 s from the master's advertised 1000 ms). Validated:
+    `go test -race ./pkg/vrrp/`, `go build ./...`, gofmt + vet clean.
+    test-failover WARRANTED (VRRP failover timing) — batch-validate.
+  - **File(s)**: pkg/vrrp/instance.go,
+    pkg/vrrp/instance_master_interval_test.go, pkg/vrrp/README.md, _Log.md

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -104,6 +104,21 @@ This is the package that drives chassis-cluster failover.
 ## Failover timing (CLAUDE.md authoritative)
 
 - ~60 ms with 30 ms RETH advertisements (masterDownInterval ~97 ms).
+- Master_Adver_Interval adoption (#4061, RFC 5798 §6.1/§6.4.2): a BACKUP
+  computes `Master_Down_Interval = 3×Master_Adver_Interval + Skew_Time`
+  from the interval the **current master advertises**, learned from the
+  received advert's Max Adver Int field (centiseconds on the wire, 10 ms
+  units), NOT from its own `cfg.AdvertiseInterval`. `recordMasterAdvert`
+  stores it in `masterAdverInterval` for every non-zero-priority advert;
+  `masterDownInterval()` (and the #2082/#2850 staleness-horizon replicas
+  `shouldPreemptObservedMaster`/`preemptingLiveLowerMaster`) use it, with
+  the local interval as the pre-first-advert fallback. Skew_Time still uses
+  the **local** priority (§6.1). When master and backup are configured with
+  the SAME interval (the common case — RETH 30 ms both sides) the learned
+  value equals the local one, so the ~60 ms failover is unchanged; a
+  mismatch (a rolling `reth-advertise-interval` change, or a misconfig) no
+  longer times the master out on the wrong cadence (a shorter local interval
+  → premature failover/flapping; a longer one → delayed detection/loss).
 - Planned shutdown: 3× priority-0 advert burst → peer takeover ~1 ms.
 - Heartbeat 200 ms, threshold 5 (1 s detection).
 - Async GARP: first pair <1 ms; remaining sent at 50 ms intervals in a

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -88,6 +88,21 @@ type vrrpInstance struct {
 	lastMasterPriority int       // last non-zero peer advert priority
 	lastMasterSeen     time.Time // when lastMasterPriority was recorded
 
+	// masterAdverInterval is the advertisement interval LEARNED from the
+	// current master's advertisement — RFC 5798 §6.1/§6.4.2 Master_Adver_Interval
+	// — derived from the received advert's Max Adver Int field (centiseconds on
+	// the wire, 10 ms units, converted to a Duration). A BACKUP must compute its
+	// Master_Down_Interval + Skew_Time from the MASTER's advertised cadence, NOT
+	// its own locally-configured cfg.AdvertiseInterval: when the master and
+	// backup are configured with different intervals (a rolling change or a
+	// misconfig), timing the master out on the local interval fails over too
+	// early (shorter local interval → flapping) or too late (longer → traffic
+	// loss). Recorded by recordMasterAdvert for every non-zero-priority advert,
+	// alongside lastMasterPriority/lastMasterSeen. 0 = none learned yet
+	// (cold-start / pre-first-advert), in which case the local interval is the
+	// fallback. Guarded by mu.
+	masterAdverInterval time.Duration
+
 	state   VRRPState
 	iface   *net.Interface
 	eventCh chan<- VRRPEvent
@@ -529,6 +544,7 @@ func (vi *vrrpInstance) shouldPreemptObservedMaster() bool {
 	trackIface := vi.cfg.TrackInterface
 	trackCost := vi.cfg.TrackPriorityCost
 	advertMS := vi.cfg.AdvertiseInterval
+	masterAdver := vi.masterAdverInterval
 	lastMasterPriority := vi.lastMasterPriority
 	lastMasterSeen := vi.lastMasterSeen
 	vi.mu.RUnlock()
@@ -552,11 +568,11 @@ func (vi *vrrpInstance) shouldPreemptObservedMaster() bool {
 	}
 
 	// masterDownInterval staleness horizon — replicates masterDownInterval()
-	// (3*advert + skew) from the snapshot using the effective priority.
-	advert := time.Duration(advertMS) * time.Millisecond
-	if advertMS <= 0 {
-		advert = 1000 * time.Millisecond
-	}
+	// (3*advert + skew) from the snapshot using the effective priority AND the
+	// master's LEARNED advertised interval (RFC 5798 §6.1/§6.4.2), so the
+	// "is the observed master still live" horizon matches the master's cadence,
+	// not the local config, exactly as masterDownInterval() now does.
+	advert := effectiveAdvertInterval(advertMS, masterAdver)
 	skew := time.Duration(256-effective) * advert / 256
 	masterDown := 3*advert + skew
 
@@ -593,11 +609,38 @@ func (vi *vrrpInstance) advertInterval() time.Duration {
 	return time.Duration(ms) * time.Millisecond
 }
 
+// effectiveAdvertInterval picks the advertisement interval that drives the
+// Master_Down_Interval / Skew_Time computation. Per RFC 5798 §6.1/§6.4.2 a
+// BACKUP times the master out on the interval the MASTER advertises
+// (Master_Adver_Interval, learned from the received advert's Max Adver Int),
+// falling back to the locally-configured interval only before any advert has
+// been heard (cold-start). localMS is cfg.AdvertiseInterval in milliseconds;
+// learned is the last value recorded by recordMasterAdvert (0 = none yet).
+func effectiveAdvertInterval(localMS int, learned time.Duration) time.Duration {
+	if learned > 0 {
+		return learned
+	}
+	if localMS <= 0 {
+		return 1000 * time.Millisecond
+	}
+	return time.Duration(localMS) * time.Millisecond
+}
+
 // masterDownInterval returns the master-down timer value.
-// Per RFC 5798: Master_Down_Interval = (3 * Advertisement_Interval) + Skew_Time
-// Skew_Time = ((256 - priority) * Master_Advert_Interval) / 256
+// Per RFC 5798: Master_Down_Interval = (3 * Master_Adver_Interval) + Skew_Time
+// Skew_Time = ((256 - priority) * Master_Adver_Interval) / 256
+//
+// Master_Adver_Interval is the interval ADVERTISED BY THE CURRENT MASTER
+// (learned from the received advert's Max Adver Int, §6.4.2), NOT this node's
+// own configured AdvertiseInterval. Before any advert has been heard
+// (masterAdverInterval == 0) the local interval is the fallback. The local
+// priority is used for Skew_Time (RFC 5798 §6.1).
 func (vi *vrrpInstance) masterDownInterval() time.Duration {
-	advert := vi.advertInterval()
+	vi.mu.RLock()
+	localMS := vi.cfg.AdvertiseInterval
+	learned := vi.masterAdverInterval
+	vi.mu.RUnlock()
+	advert := effectiveAdvertInterval(localMS, learned)
 	skew := time.Duration(256-vi.getPriority()) * advert / 256
 	return 3*advert + skew
 }
@@ -636,6 +679,7 @@ func (vi *vrrpInstance) preemptingLiveLowerMaster() bool {
 	trackIface := vi.cfg.TrackInterface
 	trackCost := vi.cfg.TrackPriorityCost
 	advertMS := vi.cfg.AdvertiseInterval
+	masterAdver := vi.masterAdverInterval
 	lastMasterPriority := vi.lastMasterPriority
 	lastMasterSeen := vi.lastMasterSeen
 	vi.mu.RUnlock()
@@ -650,10 +694,10 @@ func (vi *vrrpInstance) preemptingLiveLowerMaster() bool {
 		}
 	}
 
-	advert := time.Duration(advertMS) * time.Millisecond
-	if advertMS <= 0 {
-		advert = 1000 * time.Millisecond
-	}
+	// Master-down staleness horizon from the master's LEARNED interval (RFC
+	// 5798 §6.1/§6.4.2), matching masterDownInterval(); falls back to the local
+	// interval before any advert is heard.
+	advert := effectiveAdvertInterval(advertMS, masterAdver)
 	skew := time.Duration(256-effective) * advert / 256
 	masterDown := 3*advert + skew
 
@@ -1424,6 +1468,14 @@ func (vi *vrrpInstance) recordMasterAdvert(pkt *VRRPPacket) {
 	vi.mu.Lock()
 	vi.lastMasterPriority = int(pkt.Priority)
 	vi.lastMasterSeen = time.Now()
+	// Adopt the master's advertised interval (RFC 5798 §6.1/§6.4.2
+	// Master_Adver_Interval). Max Adver Int is centiseconds on the wire (10 ms
+	// units); convert to a Duration. A zero/absent field is ignored so
+	// masterDownInterval falls back to the local interval rather than computing
+	// a zero (flapping) master-down timer from a malformed advert.
+	if pkt.MaxAdvertInt > 0 {
+		vi.masterAdverInterval = time.Duration(pkt.MaxAdvertInt) * 10 * time.Millisecond
+	}
 	vi.mu.Unlock()
 }
 

--- a/pkg/vrrp/instance_master_interval_test.go
+++ b/pkg/vrrp/instance_master_interval_test.go
@@ -1,0 +1,171 @@
+package vrrp
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// Tests for RFC 5798 §6.1/§6.4.2 Master_Adver_Interval adoption (#4061). A
+// BACKUP must compute Master_Down_Interval + Skew_Time from the interval the
+// MASTER advertises (learned from the received advert's Max Adver Int field),
+// NOT from its own locally-configured AdvertiseInterval. These tests inject an
+// advert with a specific Max Adver Int and assert the learned interval and the
+// resulting master-down timer.
+//
+// RED-on-revert: reverting the fix (masterDownInterval computing from the local
+// cfg.AdvertiseInterval) makes the master-down assertion below fail because the
+// backup's local interval (30 ms) differs from the master's advertised interval
+// (1000 ms).
+
+// newMasterIntervalTestInstance builds a BACKUP instance with a chosen local
+// advertise interval and priority, GARP suppressed so no stray goroutine runs.
+func newMasterIntervalTestInstance(t *testing.T, priority, localAdvertMS int) *vrrpInstance {
+	t.Helper()
+	vi := newInstance(Instance{
+		Interface:         "eth0",
+		GroupID:           101,
+		Priority:          priority,
+		Preempt:           true,
+		AdvertiseInterval: localAdvertMS,
+	}, &net.Interface{Name: "eth0"}, make(chan VRRPEvent, 16), nil)
+	vi.setLocalIP(net.IPv4(10, 0, 0, 1))
+	vi.suppressGARP.Store(true)
+	vi.setState(StateBackup)
+	return vi
+}
+
+// TestMasterAdverInterval_LearnedFromAdvert verifies that receiving a master
+// advertisement with a Max Adver Int different from the backup's local interval
+// makes the backup adopt the MASTER's interval and compute the master-down
+// timer from it. This is the core #4061 assertion — it goes RED on revert.
+func TestMasterAdverInterval_LearnedFromAdvert(t *testing.T) {
+	// Backup configured with a 30 ms local interval, priority 100.
+	vi := newMasterIntervalTestInstance(t, 100, 30)
+
+	// Master advertises 1000 ms → Max Adver Int = 100 centiseconds.
+	// (Wire is centiseconds/10 ms units; 1000 ms = 100 cs.)
+	pkt := &VRRPPacket{
+		VRID:         101,
+		Priority:     120, // >= ours → worthy master
+		MaxAdvertInt: 100, // 100 cs = 1000 ms
+		SrcIP:        net.IPv4(10, 0, 0, 2),
+	}
+
+	masterDown := time.NewTimer(time.Hour)
+	defer masterDown.Stop()
+	preemptHold := time.NewTimer(time.Hour)
+	defer preemptHold.Stop()
+	vi.handleBackupRx(pkt, masterDown, preemptHold)
+
+	// 1) The learned interval must be the master's 1000 ms, not the local 30 ms.
+	vi.mu.RLock()
+	learned := vi.masterAdverInterval
+	vi.mu.RUnlock()
+	if learned != 1000*time.Millisecond {
+		t.Fatalf("masterAdverInterval = %v, want 1000ms (learned from Max Adver Int, not local 30ms)", learned)
+	}
+
+	// 2) masterDownInterval must be computed from the LEARNED 1000 ms:
+	//    Skew = (256-100)*1000ms/256 = 609.375ms → 609ms (integer Duration math)
+	//    Master_Down = 3*1000ms + 609ms = 3609ms.
+	// If reverted to the local 30 ms interval it would be:
+	//    Skew = (256-100)*30ms/256 = 18ms; Master_Down = 90+18 = 108ms.
+	want := 3*1000*time.Millisecond + time.Duration(256-100)*1000*time.Millisecond/256
+	if got := vi.masterDownInterval(); got != want {
+		t.Fatalf("masterDownInterval() = %v, want %v (from master's advertised 1000ms, NOT local 30ms → ~108ms on revert)", got, want)
+	}
+
+	// Sanity: the reverted (local-interval) value must be materially different,
+	// so this test genuinely discriminates the fix.
+	localSkew := time.Duration(256-100) * 30 * time.Millisecond / 256
+	revertValue := 3*30*time.Millisecond + localSkew
+	if want == revertValue {
+		t.Fatalf("test does not discriminate: learned (%v) == local (%v)", want, revertValue)
+	}
+}
+
+// TestMasterAdverInterval_CentisecondConversion checks the wire conversion:
+// Max Adver Int is centiseconds (10 ms units). A 3-cs advert (the 30 ms RETH
+// default) must learn 30 ms exactly, so the common matching-interval case is
+// unchanged and the ~60 ms failover is preserved.
+func TestMasterAdverInterval_CentisecondConversion(t *testing.T) {
+	cases := []struct {
+		cs   uint16
+		want time.Duration
+	}{
+		{3, 30 * time.Millisecond},     // 30 ms RETH default
+		{100, 1000 * time.Millisecond}, // 1 s default
+		{5, 50 * time.Millisecond},     // reth-advertise-interval 50
+		{200, 2000 * time.Millisecond}, // 2 s
+	}
+	for _, c := range cases {
+		vi := newMasterIntervalTestInstance(t, 100, 30)
+		vi.recordMasterAdvert(&VRRPPacket{Priority: 100, MaxAdvertInt: c.cs})
+		vi.mu.RLock()
+		got := vi.masterAdverInterval
+		vi.mu.RUnlock()
+		if got != c.want {
+			t.Errorf("MaxAdvertInt=%d cs: learned %v, want %v", c.cs, got, c.want)
+		}
+	}
+}
+
+// TestMasterAdverInterval_MatchingIntervalUnchanged verifies the common case:
+// when the master advertises the SAME interval the backup is configured with
+// (30 ms), the master-down timer is exactly what the old local-only computation
+// produced — no regression to the ~60 ms failover behavior.
+func TestMasterAdverInterval_MatchingIntervalUnchanged(t *testing.T) {
+	vi := newMasterIntervalTestInstance(t, 100, 30)
+
+	// Before any advert the fallback is the local interval.
+	local := vi.masterDownInterval()
+	wantLocal := 3*30*time.Millisecond + time.Duration(256-100)*30*time.Millisecond/256
+	if local != wantLocal {
+		t.Fatalf("pre-advert masterDownInterval() = %v, want local fallback %v", local, wantLocal)
+	}
+
+	// Master advertises the matching 30 ms (3 cs). Master-down must be identical.
+	vi.recordMasterAdvert(&VRRPPacket{Priority: 120, MaxAdvertInt: 3})
+	if got := vi.masterDownInterval(); got != wantLocal {
+		t.Fatalf("matching-interval masterDownInterval() = %v, want unchanged %v", got, wantLocal)
+	}
+}
+
+// TestMasterAdverInterval_ZeroFieldIgnored verifies a malformed advert with a
+// zero Max Adver Int does NOT set a zero interval (which would collapse the
+// master-down timer to Skew_Time only and cause flapping) — the local interval
+// stays the fallback.
+func TestMasterAdverInterval_ZeroFieldIgnored(t *testing.T) {
+	vi := newMasterIntervalTestInstance(t, 100, 30)
+	vi.recordMasterAdvert(&VRRPPacket{Priority: 120, MaxAdvertInt: 0})
+	vi.mu.RLock()
+	learned := vi.masterAdverInterval
+	vi.mu.RUnlock()
+	if learned != 0 {
+		t.Fatalf("masterAdverInterval = %v, want 0 (zero Max Adver Int must be ignored)", learned)
+	}
+	// Falls back to the local 30 ms interval.
+	wantLocal := 3*30*time.Millisecond + time.Duration(256-100)*30*time.Millisecond/256
+	if got := vi.masterDownInterval(); got != wantLocal {
+		t.Fatalf("masterDownInterval() = %v, want local fallback %v after zero-field advert", got, wantLocal)
+	}
+}
+
+// TestMasterAdverInterval_LowerPriorityAdvertNotAdopted verifies that a
+// priority-0 (resignation) advert does not update the learned interval — the
+// recordMasterAdvert contract skips priority-0 (#2082), and a zero interval
+// must never leak in through that path.
+func TestMasterAdverInterval_Priority0NotAdopted(t *testing.T) {
+	vi := newMasterIntervalTestInstance(t, 100, 30)
+	// Seed a learned interval from a real master.
+	vi.recordMasterAdvert(&VRRPPacket{Priority: 120, MaxAdvertInt: 100})
+	// A priority-0 resign advert (even with a bogus interval) must not disturb it.
+	vi.recordMasterAdvert(&VRRPPacket{Priority: 0, MaxAdvertInt: 5})
+	vi.mu.RLock()
+	learned := vi.masterAdverInterval
+	vi.mu.RUnlock()
+	if learned != 1000*time.Millisecond {
+		t.Fatalf("masterAdverInterval = %v, want 1000ms preserved (priority-0 advert must not update it)", learned)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #4061. RFC 5798 §6.1/§6.4.2: a BACKUP must compute
`Master_Down_Interval = (3 × Master_Adver_Interval) + Skew_Time` from the
interval the **current master advertises** (learned from the received
advert's Max Adver Int field), not from its own configured
`AdvertiseInterval`.

**The bug (genuine):** `VRRPPacket.MaxAdvertInt` was parsed
(`packet.go:105,152`) but never consumed. `masterDownInterval()`
(`instance.go`) computed from `vi.advertInterval()` — the local
`cfg.AdvertiseInterval`. A cluster whose master and backup have different
configured intervals (a rolling `reth-advertise-interval` change, or a
misconfig) times the master out on the wrong cadence: a shorter local
interval fails over prematurely (flapping); a longer one detects
master-down too late (traffic loss).

## Fix

- New sticky field `masterAdverInterval`, set in `recordMasterAdvert`
  from the received advert's Max Adver Int (centiseconds on the wire, 10 ms
  units → `Duration`; a zero/absent field is ignored so a malformed advert
  cannot collapse the timer to Skew-only).
- `masterDownInterval()` and the #2082/#2850 staleness-horizon replicas
  (`shouldPreemptObservedMaster`, `preemptingLiveLowerMaster`) use the
  learned interval via a shared `effectiveAdvertInterval` helper, falling
  back to the local interval before any advert is heard (cold-start).
- Skew_Time keeps using the **local** priority per §6.1.
- Learning happens at the existing observed-master chokepoint
  (`recordMasterAdvert`), so a step-down from MASTER also times the new
  master out on its cadence.

**No regression for the common case:** when master and backup share the
interval (RETH 30 ms both sides) the learned value equals the local one,
the computation is bit-identical, and ~60 ms failover / the 30 ms RETH
default are unchanged.

## Tests (`instance_master_interval_test.go`)

- `TestMasterAdverInterval_LearnedFromAdvert` — backup at 30 ms local
  receives a master advertising 1000 ms (100 cs) → learns 1000 ms,
  `masterDownInterval()` = 3.609 s (not the 108 ms local value).
  **RED-on-revert:** reverting `masterDownInterval` to the local-only
  computation fails this (108 ms vs 3.609 s).
- Centisecond→ms conversion table (3/100/5/200 cs), matching-interval
  no-regression, zero-field guard, priority-0 skip.

## Validation

`go test -race ./pkg/vrrp/` green, `go build ./...`, gofmt + vet clean.
`make test-failover` warranted (VRRP failover timing) — batch-validated by
the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
