### PR TITLE
config: reject the ##SECRET-DATA## redaction placeholder on commit-ingest (#4060)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -31678,3 +31678,41 @@ top.
     pkg/configstore/store_persist.go,
     pkg/configstore/file_perms_4056_test.go,
     pkg/configstore/README.md, _Log.md
+
+- **Timestamp**: 2026-07-04
+  - **Action**: #4060 — reject the `##SECRET-DATA##` redaction placeholder on
+    commit-ingest (symmetric guard for the #4051 raw-AST secret redaction).
+    RedactedClone masks every secret leaf with `config.SecretDataPlaceholder`
+    ("##SECRET-DATA##") for the REST config show/export + gRPC ShowConfig
+    display surfaces. Those renders are display-only and NOT restorable, but
+    had NO commit-ingest guard — unlike the typed-struct sentinel
+    "<redacted>" which `Secret.UnmarshalJSON` refuses via
+    errRedactedSecretIngest. Re-applying a redacted export (a load/commit of
+    the exported text) would silently commit "##SECRET-DATA##" as the LITERAL
+    secret for every secret leaf → IKE PSK / key / community becomes a nonsense
+    string → IPsec/auth breaks. Fix: new `errRedactionPlaceholderIngest` +
+    `checkRedactionPlaceholder` in `pkg/config/ast_redact.go`, walking the tree
+    with the SAME secret-leaf set (`secretIndices`) RedactedClone uses to
+    PRODUCE the placeholder — exact scope symmetry, so a non-secret leaf that
+    happens to carry the literal string is not rejected. Hooked into the single
+    commit-ingest schema gate `SchemaValidateWithDefinitions`
+    (`pkg/config/schema_walk.go`): STRICT on the operator commit / commit-check
+    path (fails the commit), downgraded to a WARNING on the tolerant
+    Load/SyncApply path (compileTreeLenient) — the same #1319 strict/lenient
+    doctrine. RED-on-revert: removing the schema_walk hook makes
+    TestRedactionPlaceholderIngestRejected FAIL (opaque secret leaves like IKE
+    PSK / community / api-key have no typed-leaf validator, so they would
+    silently commit; only encrypted-password is coincidentally caught by its
+    hash validator, with a different error). Tests: pkg/config
+    ast_redact_test.go (full-set + per-leaf reject, normal-secret passes,
+    non-secret-scope), pkg/configstore redaction_placeholder_4060_test.go
+    (CommitCheck+Commit reject, CheckText reject, real secret commits, Load
+    warn-boots then strict CommitCheck rejects). Doc:
+    docs/junos-config-display-reference.md §7.1 — REST export is secret-redacted,
+    not a restorable backup; use the DR archive / `request system configuration
+    rescue save`. Validated: go test ./pkg/config/... ./pkg/configstore/...,
+    go build ./..., gofmt + vet clean.
+  - **File(s)**: pkg/config/ast_redact.go, pkg/config/schema_walk.go,
+    pkg/config/ast_redact_test.go,
+    pkg/configstore/redaction_placeholder_4060_test.go,
+    docs/junos-config-display-reference.md, _Log.md

--- a/docs/junos-config-display-reference.md
+++ b/docs/junos-config-display-reference.md
@@ -1104,6 +1104,20 @@ Junos adds `##` comments in the output for various conditions:
 - `inactive:` prefix -- deactivated config stanzas
 - `## Warning: 'ssh-dsa' is deprecated` -- deprecation notices
 
+**xpf secret redaction (#4051/#4060):** xpf masks secret leaf values with the
+placeholder `##SECRET-DATA##` on every raw-AST DISPLAY surface — the REST
+`show` / `export` / `search` endpoints and the gRPC `ShowConfig` /
+`ShowCompare` / `ShowRollback` RPCs. This mirrors Junos `## SECRET-DATA` and the
+typed-struct redaction on `GET /api/v1/config`. Consequently a REST `export`
+(or any `show configuration` render) is **secret-redacted, not a full-fidelity
+restorable backup**: re-applying it would commit `##SECRET-DATA##` as the
+literal secret for every secret leaf, so xpf **rejects the placeholder on
+commit-ingest** (`## SECRET-DATA` cannot round-trip). For a restorable backup use
+the cleartext DR/compliance archive or `request system configuration rescue
+save`; to restore, load from that archive/rescue or re-enter the secret in
+cleartext. (The cleartext SSOT still backs HA config sync, the DR archive and
+on-disk persistence — only the display surfaces redact.)
+
 ### 7.2 `{ ... }` Collapse in max-depth
 
 When `display max-depth` truncates children, it uses `{ ... }` notation.

--- a/pkg/config/ast_redact.go
+++ b/pkg/config/ast_redact.go
@@ -1,5 +1,11 @@
 package config
 
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
 // ast_redact.go masks secret leaf VALUES in the raw-AST render paths.
 //
 // #2053 made the TYPED compiled-config render safe: the config.Secret newtype
@@ -155,4 +161,73 @@ func containsAnyOf(seq []string, names ...string) bool {
 		}
 	}
 	return false
+}
+
+// errRedactionPlaceholderIngest is returned by checkRedactionPlaceholder when a
+// SECRET leaf carries the raw-AST redaction placeholder (SecretDataPlaceholder,
+// "##SECRET-DATA##"). It is the symmetric commit-ingest guard for the raw-AST
+// display redaction, mirroring errRedactedSecretIngest (secret.go), which
+// refuses the typed-struct sentinel ("<redacted>") on a JSON round-trip.
+//
+// Why this exists (#4060): RedactedClone masks every secret leaf with the
+// placeholder for the REST config show / export + gRPC ShowConfig surfaces
+// (#4051). Those renders are DISPLAY-only and deliberately NOT restorable — the
+// cleartext SSOT still backs HA sync, the DR/compliance archive and persistence.
+// But an operator who does a REST `export` (now secret-redacted) and then
+// re-applies that text (a `load`/commit) would otherwise silently commit
+// "##SECRET-DATA##" as the LITERAL secret for every secret leaf — the IKE PSK,
+// key or community becomes the nonsense string and the tunnel/auth breaks. The
+// guard rejects that on commit-ingest so the redacted export cannot masquerade
+// as a restorable backup.
+var errRedactionPlaceholderIngest = errors.New(
+	"config contains the redaction placeholder " + SecretDataPlaceholder +
+		" — this is a redacted export (REST show/export / gRPC ShowConfig), not a " +
+		"restorable config; restore from the DR archive (request system " +
+		"configuration rescue) or re-enter the secret in cleartext")
+
+// checkRedactionPlaceholder rejects a tree whose SECRET leaf value is exactly
+// SecretDataPlaceholder ("##SECRET-DATA##"). It is invoked by the commit-ingest
+// schema gate (SchemaValidateWithDefinitions), so on the strict operator commit
+// / commit-check path it FAILS the commit, while the tolerant Load / SyncApply
+// path downgrades it to a warning (compileTreeLenient) — the same strict/lenient
+// doctrine the #1319 typed-leaf gate uses.
+//
+// Scope is exactly RedactedClone's: the SAME secret-leaf set (secretIndices) is
+// used to detect the placeholder that RedactedClone used to PRODUCE it. A
+// non-secret leaf that happens to carry the literal "##SECRET-DATA##" string is
+// NOT rejected — RedactedClone never masks it, so ingesting it is harmless and
+// rejecting it would be an over-reach. The returned error names the offending
+// config path for the operator.
+func checkRedactionPlaceholder(t *ConfigTree) error {
+	if t == nil {
+		return nil
+	}
+	if path := findRedactionPlaceholder(t.Children, nil); path != "" {
+		return fmt.Errorf("%w (at %q)", errRedactionPlaceholderIngest, path)
+	}
+	return nil
+}
+
+// findRedactionPlaceholder walks nodes maintaining the flattened key path of all
+// ancestors (base), mirroring redactNodes. It returns the flattened path (up to
+// and including the offending value token) of the FIRST secret leaf whose value
+// equals SecretDataPlaceholder, or "" if none. A secret index is only inspected
+// in whichever node's own Keys slice owns it (idx >= len(base)) — matching how
+// redactNodes masks the token — so the detection is exactly symmetric with the
+// masking regardless of the dual (hierarchical vs flat-set) AST shape.
+func findRedactionPlaceholder(nodes []*Node, base []string) string {
+	for _, n := range nodes {
+		full := append(append([]string(nil), base...), n.Keys...)
+		for _, idx := range secretIndices(full) {
+			if idx >= len(base) && idx < len(full) && n.Keys[idx-len(base)] == SecretDataPlaceholder {
+				return strings.Join(full[:idx+1], " ")
+			}
+		}
+		if !n.IsLeaf {
+			if hit := findRedactionPlaceholder(n.Children, full); hit != "" {
+				return hit
+			}
+		}
+	}
+	return ""
 }

--- a/pkg/config/ast_redact_test.go
+++ b/pkg/config/ast_redact_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -131,6 +132,111 @@ func TestRedactedCloneKeepsNonSecrets(t *testing.T) {
 	}
 	if !strings.Contains(out, SecretDataPlaceholder) {
 		t.Errorf("community NAME not masked; expected placeholder:\n%s", out)
+	}
+}
+
+// TestRedactionPlaceholderIngestRejected is the #4060 RED-on-revert net for
+// the symmetric commit-ingest guard: re-applying a secret-redacted REST export
+// (every secret leaf carries the "##SECRET-DATA##" placeholder) must be
+// REJECTED, not silently committed with the placeholder as a literal secret.
+//
+// It re-ingests the redacted render of the full secret set the way the config
+// store does (ParseSetCommand + SetPath), then asserts checkRedactionPlaceholder
+// AND the commit-ingest schema gate (SchemaValidate) reject it. It goes RED (a
+// redacted export commits with placeholder secrets) if the guard is a no-op.
+func TestRedactionPlaceholderIngestRejected(t *testing.T) {
+	// Build the cleartext tree, redact it (as REST export does), render it to
+	// `set` lines, and replay those lines back into a fresh tree — exactly the
+	// operator foot-gun the guard closes.
+	cleartext := buildRedactTree(t, redactionSecretSet)
+	redactedSet := cleartext.RedactedClone().FormatSet()
+	if !strings.Contains(redactedSet, SecretDataPlaceholder) {
+		t.Fatalf("redacted export did not contain the placeholder; test precondition broken:\n%s", redactedSet)
+	}
+
+	reingested := &ConfigTree{}
+	for _, line := range strings.Split(redactedSet, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		toks, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := reingested.SetPath(toks); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+
+	if err := checkRedactionPlaceholder(reingested); err == nil {
+		t.Fatal("checkRedactionPlaceholder accepted a redacted export; want rejection")
+	} else if !errors.Is(err, errRedactionPlaceholderIngest) {
+		t.Fatalf("checkRedactionPlaceholder err = %v, want errRedactionPlaceholderIngest", err)
+	}
+
+	// The commit-ingest schema gate (the production strict-commit hook) must
+	// also reject it.
+	if err := SchemaValidate(reingested, nil); err == nil {
+		t.Fatal("SchemaValidate accepted a redacted export; want rejection")
+	} else if !errors.Is(err, errRedactionPlaceholderIngest) {
+		t.Fatalf("SchemaValidate err = %v, want errRedactionPlaceholderIngest", err)
+	}
+}
+
+// TestRedactionPlaceholderIngest_PerSecretLeaf confirms the guard fires for
+// EVERY secret-leaf signature individually (mirroring RedactedClone's set), so
+// a redacted export of ANY single secret is rejected — not just the first in
+// the full-set render.
+func TestRedactionPlaceholderIngest_PerSecretLeaf(t *testing.T) {
+	for _, line := range redactionSecretSet {
+		line := line
+		// Skip the pure-selector lines that carry no secret value (they set a
+		// DDNS provider backend, not a secret).
+		if strings.Contains(line, "backend") {
+			continue
+		}
+		t.Run(line, func(t *testing.T) {
+			redacted := buildRedactTree(t, []string{line}).RedactedClone()
+			err := checkRedactionPlaceholder(redacted)
+			if err == nil {
+				t.Fatalf("guard missed a redacted secret leaf:\n%s", redacted.FormatSet())
+			}
+			if !errors.Is(err, errRedactionPlaceholderIngest) {
+				t.Fatalf("err = %v, want errRedactionPlaceholderIngest", err)
+			}
+		})
+	}
+}
+
+// TestRedactionPlaceholderIngest_NormalSecretPasses proves the guard rejects
+// ONLY the exact placeholder: a real cleartext secret (the un-redacted set)
+// still commits cleanly through the same gate.
+func TestRedactionPlaceholderIngest_NormalSecretPasses(t *testing.T) {
+	cleartext := buildRedactTree(t, redactionSecretSet)
+	if err := checkRedactionPlaceholder(cleartext); err != nil {
+		t.Fatalf("checkRedactionPlaceholder rejected a normal cleartext config: %v", err)
+	}
+	if err := SchemaValidate(cleartext, nil); err != nil {
+		t.Fatalf("SchemaValidate rejected a normal cleartext config: %v", err)
+	}
+}
+
+// TestRedactionPlaceholderIngest_NonSecretScoped confirms the guard is
+// secret-leaf-scoped (matching RedactedClone): a NON-secret leaf that happens to
+// carry the literal "##SECRET-DATA##" string is NOT rejected — RedactedClone
+// never masks such a leaf, so ingesting it is harmless.
+func TestRedactionPlaceholderIngest_NonSecretScoped(t *testing.T) {
+	tree := buildRedactTree(t, []string{
+		// host-name is not a secret leaf; even the literal placeholder value is
+		// fine here (it would never have been produced by RedactedClone).
+		`set system host-name "` + SecretDataPlaceholder + `"`,
+		// A GRE tunnel `key` is a non-secret generic keyword (secretIndices
+		// gates `key` to the OSPF md5 context only).
+		`set interfaces gr-0-0-0 unit 0 tunnel key "` + SecretDataPlaceholder + `"`,
+	})
+	if err := checkRedactionPlaceholder(tree); err != nil {
+		t.Fatalf("guard over-reached onto a non-secret leaf: %v", err)
 	}
 }
 

--- a/pkg/config/schema_walk.go
+++ b/pkg/config/schema_walk.go
@@ -81,6 +81,16 @@ func SchemaValidateWithDefinitions(tree, defsSource *ConfigTree, cfg *Config) er
 	// no-op (no clone) when nothing is deactivated.
 	tree = tree.WithoutInactive()
 	defsSource = defsSource.WithoutInactive()
+	// #4060: reject the raw-AST redaction placeholder ("##SECRET-DATA##") on
+	// commit-ingest. This is the symmetric guard for the #4051 display
+	// redaction — re-applying a secret-redacted REST export must not silently
+	// commit the placeholder as a literal secret (breaking IPsec/auth with a
+	// nonsense key). Strict on the operator commit path (fails the commit),
+	// downgraded to a warning on the tolerant Load / SyncApply path
+	// (compileTreeLenient), the same doctrine as the typed-leaf gate below.
+	if err := checkRedactionPlaceholder(tree); err != nil {
+		return err
+	}
 	refs := collectSchemaRefs(tree)
 	if defsSource != nil {
 		for name := range collectSchemaRefs(defsSource).forwardingClasses {

--- a/pkg/configstore/redaction_placeholder_4060_test.go
+++ b/pkg/configstore/redaction_placeholder_4060_test.go
@@ -1,0 +1,125 @@
+package configstore
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #4060 — symmetric commit-ingest guard for the #4051 raw-AST secret redaction.
+//
+// RedactedClone masks every secret leaf with config.SecretDataPlaceholder
+// ("##SECRET-DATA##") for the REST config show / export + gRPC ShowConfig
+// surfaces. Those renders are display-only and NOT restorable. An operator who
+// re-applies a redacted export (a load/commit of that text) must be REJECTED at
+// commit-ingest — otherwise the placeholder is silently committed as the LITERAL
+// secret for every secret leaf, breaking IPsec/auth with a nonsense key.
+//
+// The IKE pre-shared-key is deliberately used as the probe: it is opaque free
+// text to the #1319 typed-leaf validators (no per-leaf validator would reject
+// "##SECRET-DATA##"), so ONLY the #4060 placeholder guard catches it — proving
+// the guard is load-bearing rather than a coincidental typed-leaf rejection.
+
+// redactedPSKLine is the config-mode `set` input (no `set` prefix, for
+// SetFromInput) that a REST `export` of a configured IKE PSK renders after
+// redaction: the ascii-text qualifier is kept, the key material is the masked
+// placeholder (quoted by FormatSet because '#' is a non-identifier char).
+const redactedPSKLine = `security ike policy pol1 pre-shared-key ascii-text "` + config.SecretDataPlaceholder + `"`
+
+// TestCommitCheck_RejectsRedactionPlaceholder is the strict-path e2e: an
+// operator committing a re-applied redacted export is rejected at both
+// CommitCheck and Commit with the #4060 placeholder error.
+func TestCommitCheck_RejectsRedactionPlaceholder(t *testing.T) {
+	s := newTestStoreAt(t, filepath.Join(t.TempDir(), "config"))
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := s.SetFromInput(redactedPSKLine); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	_, err := s.CommitCheck()
+	if err == nil {
+		t.Fatal("expected CommitCheck to reject the ##SECRET-DATA## placeholder, got nil")
+	}
+	if !strings.Contains(err.Error(), config.SecretDataPlaceholder) {
+		t.Fatalf("CommitCheck error should name the redaction placeholder: %v", err)
+	}
+	if !strings.Contains(err.Error(), "pre-shared-key") {
+		t.Fatalf("CommitCheck error should name the offending config path: %v", err)
+	}
+	if _, err := s.Commit(); err == nil {
+		t.Fatal("expected Commit to reject the ##SECRET-DATA## placeholder, got nil")
+	}
+}
+
+// TestCheckText_RejectsRedactionPlaceholder proves the same rejection through
+// the CheckText gate (the #1879 `xpfd check-config` day-0 path), which parses
+// full config text — the shape a REST `load`/`import` of an exported file takes.
+func TestCheckText_RejectsRedactionPlaceholder(t *testing.T) {
+	redactedText := `security {
+    ike {
+        policy pol1 {
+            pre-shared-key ascii-text "` + config.SecretDataPlaceholder + `";
+        }
+    }
+}`
+	_, err := CheckText(redactedText, -1)
+	if err == nil {
+		t.Fatal("expected CheckText to reject the ##SECRET-DATA## placeholder, got nil")
+	}
+	if !strings.Contains(err.Error(), config.SecretDataPlaceholder) {
+		t.Fatalf("CheckText error should name the redaction placeholder: %v", err)
+	}
+}
+
+// TestCommitCheck_AcceptsRealSecret proves the guard rejects ONLY the exact
+// placeholder: a normal cleartext IKE PSK still commits cleanly.
+func TestCommitCheck_AcceptsRealSecret(t *testing.T) {
+	s := newTestStoreAt(t, filepath.Join(t.TempDir(), "config"))
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := s.SetFromInput("security ike policy pol1 pre-shared-key ascii-text realsupersecret"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := s.CommitCheck(); err != nil {
+		t.Fatalf("a real cleartext secret must pass CommitCheck, got: %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("a real cleartext secret must Commit, got: %v", err)
+	}
+}
+
+// TestLoad_ToleratesStoredRedactionPlaceholder is the boot-safety half: a
+// placeholder that somehow reached persisted state must WARN-boot (lenient
+// path), not blackout the daemon — the same strict/lenient doctrine as the
+// #1319 typed-leaf gate. RedactedClone is display-only so this should never
+// happen in practice, but the tolerant path stays fail-open on ingest of a
+// config the operator did not just author; the next strict commit rejects it.
+func TestLoad_ToleratesStoredRedactionPlaceholder(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config")
+	writeStoredConfig(t, cfgPath,
+		`set security ike policy pol1 pre-shared-key ascii-text "`+config.SecretDataPlaceholder+`"`)
+
+	s := newTestStoreAt(t, cfgPath)
+	if err := s.Load(); err != nil {
+		t.Fatalf("Load() must tolerate a stored placeholder (warn, not blackout), got: %v", err)
+	}
+	if s.ActiveConfig() == nil {
+		t.Fatal("ActiveConfig() is nil after tolerated Load")
+	}
+
+	// The next STRICT operator commit must still reject it.
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	_, err := s.CommitCheck()
+	if err == nil {
+		t.Fatal("CommitCheck must stay strict after a tolerated Load, got nil")
+	}
+	if !strings.Contains(err.Error(), config.SecretDataPlaceholder) {
+		t.Fatalf("CommitCheck error should name the redaction placeholder: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #4051/#4057 (raw-AST secret redaction). Adds the missing
**symmetric commit-ingest guard** for the `##SECRET-DATA##` redaction
placeholder, mirroring the existing `<redacted>` (`errRedactedSecretIngest`)
refusal in `Secret.UnmarshalJSON`.

### The hazard
`RedactedClone` masks every secret leaf with `config.SecretDataPlaceholder`
(`##SECRET-DATA##`) on the REST config show / export / search endpoints and the
gRPC `ShowConfig` / `ShowCompare` / `ShowRollback` RPCs. Those renders are
**display-only and not restorable** — the cleartext SSOT backs HA sync, the DR
archive and persistence.

The placeholder had **no commit-ingest guard**. An operator who did a REST
`export` (now secret-redacted) and re-applied that text (a `load`/commit) would
silently commit `##SECRET-DATA##` as the **literal secret** for every secret
leaf → the IKE PSK / auth key / SNMP community becomes the nonsense placeholder
string → the tunnel/auth breaks, with the operator unaware the export was never
restorable.

### The fix
- `pkg/config/ast_redact.go`: new `errRedactionPlaceholderIngest` +
  `checkRedactionPlaceholder`, walking the tree with the **same secret-leaf set
  (`secretIndices`)** that `RedactedClone` uses to *produce* the placeholder —
  exact scope symmetry across the dual (hierarchical vs flat-set) AST shape. A
  non-secret leaf that happens to carry the literal string is **not** rejected
  (`RedactedClone` never masks it).
- `pkg/config/schema_walk.go`: hooked into the single commit-ingest schema gate
  `SchemaValidateWithDefinitions`. **Strict** on the operator commit /
  commit-check path (fails the commit); downgraded to a **warning** on the
  tolerant Load / SyncApply path (`compileTreeLenient`) — the #1319
  strict/lenient doctrine, so a placeholder that somehow reached persisted state
  warn-boots instead of blacking out the daemon.
- `docs/junos-config-display-reference.md` §7.1: operator note that a REST
  export/show render is secret-redacted and not a restorable backup — restore
  from the DR archive / `request system configuration rescue save`, or re-enter
  the secret.

### Tests (RED-on-revert)
- `pkg/config/ast_redact_test.go` — re-ingest the redacted `FormatSet` render of
  the full secret set and assert `checkRedactionPlaceholder` + `SchemaValidate`
  reject; per-leaf reject; normal cleartext secret passes; non-secret-scoped leaf
  not rejected. Removing the `schema_walk` hook makes this FAIL (opaque leaves
  like IKE PSK / community / api-key have no typed-leaf validator and would
  commit silently).
- `pkg/configstore/redaction_placeholder_4060_test.go` — production commit path
  with an IKE PSK probe (opaque to typed-leaf validators, so only the #4060
  guard catches it): `CommitCheck`+`Commit` reject, `CheckText` rejects, a real
  secret commits, and a stored placeholder warn-boots via lenient `Load` then is
  rejected by the next strict `CommitCheck`.

Validated: `go test ./pkg/config/... ./pkg/configstore/...`, `go build ./...`,
gofmt + vet clean.

Closes #4060

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi