### PR TITLE
cli: gate `monitor traffic` root capture behind control permission (#4067)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-07-04 — #4067: read-only / config-viewer login class could run `monitor traffic` (root tcpdump packet capture) → unprivileged capture / privilege gap
+
+- **Timestamp**: 2026-07-04
+  - **Action**: Fixed fable-161 F-023 (MEDIUM, security/RBAC). The
+    `monitor traffic` operational command spawns a root `tcpdump` live
+    packet capture (`handleMonitorTraffic`, `pkg/cli/cli_request.go`), but
+    the CLI RBAC gate (`checkPermission`, `pkg/cli/permissions.go`) gated
+    it only on the top-level word `monitor` → `PermView`. A `read-only` /
+    `config-viewer` class (intended only to VIEW config/status) has
+    `PermView`, so those unprivileged roles could run a root packet capture
+    and read other users' cleartext traffic. `request`/shell-out commands
+    were already gated at `PermControl`; `monitor traffic` (the other
+    shell-out-to-root family) was not. Fix: made `checkPermission` take the
+    resolved command line (`parts []string`) and added a subcommand-aware
+    `requiredPermission` helper — `monitor traffic` now requires
+    `PermControl` (operator + super-user allowed; read-only /
+    config-viewer / unauthorized denied), mirroring Junos' maintenance
+    gating. The subcommand is resolved with the SAME prefix matcher the
+    `monitor` dispatcher uses, so `monitor tr` is gated identically and the
+    abbreviation cannot bypass the gate. Surgical: other `monitor`
+    subcommands (interface stats, security flow) and read-only `show`
+    stay view-level. RED-on-revert: dropping the `monitor traffic` special
+    case makes the read-only / config-viewer subtests of
+    `TestCheckPermission_MonitorTrafficRequiresControl` FAIL (capture
+    allowed). Validated: `go test ./pkg/cli/...`, `go build ./...`,
+    gofmt + vet clean (the cli.go:503 unreachable-code vet note is
+    pre-existing on origin/master, unrelated).
+  - **File(s)**: pkg/cli/permissions.go, pkg/cli/cli_dispatch.go,
+    pkg/cli/permissions_monitor_traffic_4067_test.go,
+    docs/system-login.md, _Log.md
+
 ## 2026-07-03 — #4054: export_all_sessions ran push_delta_lossless / frame serialization UNDER the global ServerState lock → a large bulk session export could starve the status poll → false dp-failure → needless helper restart
 
 - **Timestamp**: 2026-07-03

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -55,6 +55,33 @@ runtime RBAC table can never drift apart: adding a class in one place
 without the other is impossible. An empty/unset class keeps the legacy
 allow-everything behavior (no class configured = no RBAC restriction).
 
+### Command-to-permission mapping
+
+Gating is on the resolved **top-level** command word:
+
+| Command | Required permission |
+|---|---|
+| `show`, `ping`, `traceroute`, `monitor` | view |
+| `clear` | clear |
+| `request`, `test` | control |
+| `configure` | config |
+| anything else | super-user (all) |
+
+**Privileged-subcommand exception — `monitor traffic` (#4067).** Almost
+every command is gated on the top-level word alone, but `monitor traffic`
+spawns a **root `tcpdump` live packet capture** on a data interface, so it
+is gated at the **control** level (the same bucket as the `request` /
+shell-out family) instead of the plain `view` level the rest of `monitor`
+(interface stats, security-flow trace) uses. A `read-only` / `config-viewer`
+class — intended only to VIEW config and status — is therefore **denied**
+`monitor traffic`; `operator` and `super-user` are allowed. This mirrors
+Junos, which gates `monitor traffic` behind the maintenance permission, not
+plain read-only. The exception lives in `requiredPermission`
+(`pkg/cli/permissions.go`) and resolves the subcommand with the same prefix
+matcher the dispatcher uses, so an abbreviated `monitor tr` is gated
+identically to the fully-spelled form and cannot bypass the gate. Other
+`monitor` subcommands and read-only `show` commands are unaffected.
+
 ### Generating a hash
 
 ```

--- a/pkg/cli/cli_dispatch.go
+++ b/pkg/cli/cli_dispatch.go
@@ -221,7 +221,7 @@ func (c *CLI) dispatchOperational(line string) error {
 	}
 	parts[0] = resolved
 
-	if err := c.checkPermission(parts[0]); err != nil {
+	if err := c.checkPermission(parts); err != nil {
 		return err
 	}
 

--- a/pkg/cli/permissions.go
+++ b/pkg/cli/permissions.go
@@ -6,14 +6,22 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/psaab/xpf/pkg/config"
 )
 
-// checkPermission verifies the current user's login class permits the given action.
-// If userClass is empty (not set), all actions are allowed for backward compatibility.
-func (c *CLI) checkPermission(action string) error {
+// checkPermission verifies the current user's login class permits the given
+// command. `parts` is the resolved operational command line (parts[0] is the
+// canonical top-level word, parts[1:] its arguments). Most commands are gated
+// on the top-level word alone, but a few privileged subcommands need a finer
+// gate (see requiredPermission). If userClass is empty (not set), all actions
+// are allowed for backward compatibility.
+func (c *CLI) checkPermission(parts []string) error {
 	if c.userClass == "" {
+		return nil
+	}
+	if len(parts) == 0 {
 		return nil
 	}
 
@@ -22,20 +30,7 @@ func (c *CLI) checkPermission(action string) error {
 		return fmt.Errorf("permission denied: unknown login class %q", c.userClass)
 	}
 
-	// Determine required permission for the action.
-	var required config.LoginClassPermission
-	switch action {
-	case "show", "ping", "traceroute", "monitor":
-		required = config.PermView
-	case "clear":
-		required = config.PermClear
-	case "request", "test":
-		required = config.PermControl
-	case "configure":
-		required = config.PermConfig
-	default:
-		required = config.PermAll
-	}
+	required := requiredPermission(parts)
 
 	for _, p := range perms {
 		if p == config.PermAll || p == required {
@@ -43,5 +38,57 @@ func (c *CLI) checkPermission(action string) error {
 		}
 	}
 
-	return fmt.Errorf("permission denied: %q requires class super-user or higher", action)
+	return fmt.Errorf("permission denied: %q requires a higher login class", strings.Join(parts, " "))
+}
+
+// requiredPermission returns the login-class permission a resolved operational
+// command needs. Gating is on the top-level word (parts[0]) for almost every
+// command, with one important exception: `monitor traffic` spawns a root
+// tcpdump live packet capture, so it must require the same control-level
+// permission as the `request`/shell-out command family rather than the plain
+// view permission the rest of `monitor` (interface stats, flow trace) uses.
+// Without this a read-only / config-viewer class — intended only to VIEW
+// config and status — could run an unprivileged root packet capture and read
+// other users' cleartext traffic (#4067).
+func requiredPermission(parts []string) config.LoginClassPermission {
+	action := parts[0]
+
+	// `monitor traffic` = privileged capture (root tcpdump). Gate it at the
+	// control level even though the `monitor` top-level word is view-level.
+	if action == "monitor" && monitorSubcommandIsTraffic(parts[1:]) {
+		return config.PermControl
+	}
+
+	switch action {
+	case "show", "ping", "traceroute", "monitor":
+		return config.PermView
+	case "clear":
+		return config.PermClear
+	case "request", "test":
+		return config.PermControl
+	case "configure":
+		return config.PermConfig
+	default:
+		return config.PermAll
+	}
+}
+
+// monitorSubcommandIsTraffic reports whether the monitor arguments resolve to
+// the `traffic` subcommand. It applies the same prefix resolution the monitor
+// dispatcher uses (`handleMonitor`), so an abbreviated `monitor tr` is gated
+// identically to the fully-spelled `monitor traffic` — the RBAC gate and the
+// dispatcher can never disagree about what a token resolves to.
+func monitorSubcommandIsTraffic(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	monNode, ok := operationalTree["monitor"]
+	if !ok || monNode == nil {
+		return false
+	}
+	resolved, err := resolveCommand(args[0], keysFromTree(monNode.Children))
+	if err != nil {
+		return false
+	}
+	return resolved == "traffic"
 }

--- a/pkg/cli/permissions_monitor_traffic_4067_test.go
+++ b/pkg/cli/permissions_monitor_traffic_4067_test.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCheckPermission_MonitorTrafficRequiresControl asserts that the
+// privileged `monitor traffic` capture (which spawns a root tcpdump) is gated
+// behind the control permission: read-only / config-viewer / unauthorized
+// classes are DENIED, while operator and super-user are allowed. Reverting the
+// #4067 gate (mapping `monitor traffic` back to plain PermView) makes the
+// read-only / config-viewer subtests go RED (the capture becomes allowed).
+func TestCheckPermission_MonitorTrafficRequiresControl(t *testing.T) {
+	tests := []struct {
+		class     string
+		allowGood bool // monitor traffic allowed?
+	}{
+		{"super-user", true},
+		{"operator", true},
+		{"read-only", false},
+		{"config-viewer", false},
+		{"unauthorized", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.class, func(t *testing.T) {
+			c := &CLI{userClass: tc.class}
+
+			// monitor traffic (fully spelled) — the privileged capture.
+			err := c.checkPermission([]string{"monitor", "traffic", "interface", "ge-0-0-0"})
+			if tc.allowGood && err != nil {
+				t.Errorf("monitor traffic denied for %q: %v (want allowed)", tc.class, err)
+			}
+			if !tc.allowGood && err == nil {
+				t.Errorf("monitor traffic ALLOWED for %q (want denied — spawns root tcpdump)", tc.class)
+			}
+
+			// Abbreviated `monitor tr` must resolve to traffic and be gated
+			// identically — the gate must not be bypassable via prefix.
+			errAbbrev := c.checkPermission([]string{"monitor", "tr", "interface", "ge-0-0-0"})
+			if tc.allowGood && errAbbrev != nil {
+				t.Errorf("monitor tr denied for %q: %v (want allowed)", tc.class, errAbbrev)
+			}
+			if !tc.allowGood && errAbbrev == nil {
+				t.Errorf("monitor tr ALLOWED for %q (abbreviation bypassed the gate)", tc.class)
+			}
+		})
+	}
+}
+
+// TestCheckPermission_MonitorViewSubcommandsStayViewLevel asserts the gate is
+// surgical: read-only can still run the view-level monitor subcommands
+// (interface stats, security flow trace) — only the root-tcpdump traffic
+// capture is elevated. This guards against over-gating the whole `monitor`
+// family.
+func TestCheckPermission_MonitorViewSubcommandsStayViewLevel(t *testing.T) {
+	c := &CLI{userClass: "read-only"}
+
+	viewOK := [][]string{
+		{"monitor", "interface", "ge-0-0-0"},
+		{"monitor", "security", "flow"},
+		{"monitor"}, // bare monitor (help) stays view-level
+	}
+	for _, parts := range viewOK {
+		if err := c.checkPermission(parts); err != nil {
+			t.Errorf("read-only denied %q: %v (want allowed — view-level)", strings.Join(parts, " "), err)
+		}
+	}
+}
+
+// TestCheckPermission_ReadOnlyBaselineUnaffected asserts the change did not
+// disturb the existing per-class gating for the other command families.
+func TestCheckPermission_ReadOnlyBaselineUnaffected(t *testing.T) {
+	readOnly := &CLI{userClass: "read-only"}
+
+	// show / ping / traceroute remain allowed (view).
+	for _, cmd := range [][]string{{"show", "version"}, {"ping", "1.1.1.1"}, {"traceroute", "1.1.1.1"}} {
+		if err := readOnly.checkPermission(cmd); err != nil {
+			t.Errorf("read-only denied view command %q: %v", strings.Join(cmd, " "), err)
+		}
+	}
+	// clear / request / configure remain denied for read-only.
+	for _, cmd := range [][]string{{"clear", "security", "flow", "session"}, {"request", "system", "reboot"}, {"configure"}} {
+		if err := readOnly.checkPermission(cmd); err == nil {
+			t.Errorf("read-only ALLOWED elevated command %q (want denied)", strings.Join(cmd, " "))
+		}
+	}
+
+	// Unset class keeps the legacy allow-everything behavior.
+	unset := &CLI{userClass: ""}
+	if err := unset.checkPermission([]string{"monitor", "traffic", "interface", "ge-0-0-0"}); err != nil {
+		t.Errorf("unset class denied monitor traffic: %v (want allowed — legacy no-RBAC)", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #4067 (fable-161 F-023, security/RBAC — unprivileged packet capture).

`monitor traffic` spawns a **root `tcpdump`** live packet capture on a data
interface (`handleMonitorTraffic`, `pkg/cli/cli_request.go`). The CLI RBAC gate
(`checkPermission`, `pkg/cli/permissions.go`) gated it only on the resolved
top-level word `monitor`, which maps to `PermView`. A `read-only` /
`config-viewer` login class — intended only to VIEW config and status — has
`PermView`, so those unprivileged roles could run a root packet capture and read
other users' cleartext traffic. The `request`/shell-out family was already gated
at `PermControl`; `monitor traffic` (the other shell-out-to-root path) was not.
Junos gates `monitor traffic` behind the maintenance permission, not read-only.

## Fix

- `checkPermission` now takes the resolved command line (`parts []string`)
  instead of just the top-level word.
- New `requiredPermission` helper: `monitor traffic` requires `PermControl`.
  Everything else keeps its existing top-level-word gating.
- **Allowed:** `operator` ({view,clear,control}), `super-user` ({all}).
  **Denied:** `read-only` ({view}), `config-viewer` ({view}), `unauthorized` ({}).
- The subcommand is resolved with the **same prefix matcher** the `monitor`
  dispatcher (`handleMonitor`) uses, so an abbreviated `monitor tr` is gated
  identically and cannot bypass the gate.
- Surgical: other `monitor` subcommands (interface stats, security-flow trace)
  and read-only `show` commands stay view-level; the unset-class legacy
  allow-everything path is unchanged.

## Test

`permissions_monitor_traffic_4067_test.go` — login-class RBAC gate across all
five classes (fully-spelled + abbreviated), view-level monitor subcommands stay
allowed for read-only, and the other command families are undisturbed.

**RED-on-revert:** dropping the `monitor traffic` special case makes the
`read-only` / `config-viewer` subtests of
`TestCheckPermission_MonitorTrafficRequiresControl` FAIL (capture allowed).

Validated: `go test ./pkg/cli/...` green, `go build ./...` clean, gofmt clean on
the changed files. Doc updated: `docs/system-login.md` (command-to-permission
mapping + the `monitor traffic` privileged-subcommand exception).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi