### PR TITLE
userspace-dp HA: O(N+M) RG-activation prewarm dedup (#4069)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-07-04 — #4069: RG-activation reverse-prewarm used O(N·M) Vec::contains dedup on the failover critical path → slow prewarm on a busy cluster
+
+- **Timestamp**: 2026-07-04
+  - **Action**: Fixed fable-161 F-192 (MEDIUM, HA failover perf).
+    `prewarm_reverse_synced_sessions_for_owner_rgs`
+    (`userspace-dp/src/afxdp/shared_ops.rs`) runs on RG activation — the
+    failover critical path (~60ms/~130ms budget). It unions the forward
+    owner-RG session keys (M) with the narrower reverse-prewarm keys (N).
+    The dedup was `candidate_keys.contains(&key)` inside a per-reverse-key
+    loop — a linear scan of the growing forward Vec per key, i.e. O(N·M).
+    On a busy cluster (thousands of synced sessions) this quadratic scan
+    measurably slowed how quickly a newly-primary node fully forwarded.
+    Fix: extract `merge_owner_rg_candidate_keys(forward, reverse)`, which
+    seeds a `FastSet<SessionKey>` (FxHashSet) from the forward keys once
+    (O(M)) and probes each reverse key in O(1) → O(N+M). Result set AND its
+    order are identical to the old dedup (forward keys first, then
+    not-yet-seen reverse keys in first-seen order; `insert` returning true
+    is exactly `!contains`, and it also folds within-`reverse` duplicates).
+    RED-on-revert: `merge_owner_rg_candidate_keys_scales_linearly_not_
+    quadratically` merges N=M=200k distinct keys under a 5s budget (fix
+    ~ms; a Vec::contains revert is ~4e10 comparisons → tens of seconds to
+    minutes → RED). `merge_owner_rg_candidate_keys_preserves_order_and_
+    dedups` pins the order/dedup contract. Validation: FULL `cargo test
+    --release` green; `go build ./...` green; rustfmt clean. test-failover
+    WARRANTED (RG-activation/failover path) — batch-validate.
+  - **File(s)**: userspace-dp/src/afxdp/shared_ops.rs,
+    userspace-dp/src/afxdp/ha_tests.rs,
+    userspace-dp/src/afxdp/README.md, _Log.md
+
 ## 2026-07-04 — #4067: read-only / config-viewer login class could run `monitor traffic` (root tcpdump packet capture) → unprivileged capture / privilege gap
 
 - **Timestamp**: 2026-07-04

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -658,6 +658,23 @@ status reads in `state_writer.rs` / `slowpath.rs` keep
 `.lock().map(..).unwrap_or_default()` deliberately (a momentary
 default-mode status read is harmless and not on the session path).
 
+## RG-activation prewarm dedup is O(N+M) (#4069)
+
+`prewarm_reverse_synced_sessions_for_owner_rgs` runs on RG activation —
+i.e. on the failover critical path (~60ms/~130ms budget). It unions the
+forward owner-RG session keys (M) with the narrower reverse-prewarm keys
+(N) before restoring forward entries and synthesizing reverse companions.
+That union is deduplicated by `merge_owner_rg_candidate_keys`, which seeds
+a `FastSet<SessionKey>` from the forward keys once (O(M)) and then probes
+each reverse key in O(1) — O(N+M) total. The prior inline dedup used
+`candidate_keys.contains(&key)`, a linear scan of the growing forward Vec
+once per reverse key (O(N·M)); on a busy cluster with thousands of synced
+sessions that quadratic scan measurably slowed how quickly a newly-primary
+node fully forwarded. The result set and its order are identical to the old
+dedup — forward keys first, then not-yet-seen reverse keys in first-seen
+order — only the membership data structure changed. `ha_tests.rs` pins the
+order/dedup contract and a large-N (N=M=200k) linear-time guard.
+
 ## Hot-path constants
 
 - `RX_BATCH_SIZE = 64`

--- a/userspace-dp/src/afxdp/ha_tests.rs
+++ b/userspace-dp/src/afxdp/ha_tests.rs
@@ -578,6 +578,68 @@ fn prewarm_recovers_from_poisoned_shared_session_mutex() {
     );
 }
 
+// --- #4069 RG-activation prewarm dedup is O(N+M), not O(N·M) --------------
+
+#[test]
+fn merge_owner_rg_candidate_keys_preserves_order_and_dedups() {
+    // The merge must be a stable, deduplicated union: forward keys in their
+    // original order, then each reverse key not already present in first-seen
+    // order, with duplicates (cross-list AND repeated within reverse) removed.
+    // This is the exact semantic contract the O(N+M) hash-set rewrite must
+    // preserve versus the former O(N·M) `Vec::contains` dedup.
+    let key = |port: u16| SessionKey {
+        src_port: port,
+        ..test_key()
+    };
+    let forward = vec![key(1), key(2), key(3)];
+    // reverse: key(2) is already in forward (drop), key(10)/key(11) are new,
+    // the second key(10) is a within-reverse duplicate (drop).
+    let reverse = vec![key(2), key(10), key(11), key(10)];
+
+    let merged = merge_owner_rg_candidate_keys(forward, reverse);
+
+    assert_eq!(
+        merged,
+        vec![key(1), key(2), key(3), key(10), key(11)],
+        "merge must keep forward order then append new reverse keys, deduped"
+    );
+}
+
+#[test]
+fn merge_owner_rg_candidate_keys_scales_linearly_not_quadratically() {
+    // RED-on-revert: the former O(N·M) `Vec::contains` dedup re-scanned the
+    // growing forward Vec once per reverse key. At N = M = 200_000 that is on
+    // the order of 4e10 SessionKey comparisons — tens of seconds to minutes.
+    // The O(N+M) hash-set merge completes in well under a second, so this
+    // generous 5s budget passes on the fix and blows out (RED) on a quadratic
+    // regression. Every key is distinct, so nothing is deduped and the merge
+    // performs the full N+M of work (worst case for the old linear scan too,
+    // which never finds a match and walks the entire forward Vec each time).
+    const N: u32 = 200_000;
+    let distinct_key = |i: u32| SessionKey {
+        // 10.x.x.x — encode i into the low 24 bits so every key is unique.
+        src_ip: IpAddr::V4(Ipv4Addr::from(0x0a00_0000 | (i & 0x00ff_ffff))),
+        ..test_key()
+    };
+    let forward: Vec<SessionKey> = (0..N).map(distinct_key).collect();
+    let reverse: Vec<SessionKey> = (N..2 * N).map(distinct_key).collect();
+
+    let start = std::time::Instant::now();
+    let merged = merge_owner_rg_candidate_keys(forward, reverse);
+    let elapsed = start.elapsed();
+
+    assert_eq!(
+        merged.len() as u32,
+        2 * N,
+        "all keys are distinct — the union must contain every one"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(5),
+        "O(N+M) prewarm merge took {elapsed:?} for N=M={N}; a quadratic \
+         Vec::contains regression (O(N·M)) would blow this 5s budget"
+    );
+}
+
 // --- #2170 install-generation guard (helper-side belt-and-suspenders) -----
 
 fn synced_entry_with_generation(generation: u64) -> SyncedSessionEntry {

--- a/userspace-dp/src/afxdp/shared_ops.rs
+++ b/userspace-dp/src/afxdp/shared_ops.rs
@@ -215,6 +215,37 @@ pub(super) fn synced_replica_entry(entry: &SyncedSessionEntry) -> SyncedSessionE
     replica
 }
 
+/// Union the forward owner-RG session keys with the narrower
+/// reverse-prewarm keys, deduplicated, preserving order: every `forward`
+/// key first (in its original order), then each `reverse` key not already
+/// present, in first-seen order.
+///
+/// #4069: membership is tested against a hash set built once (O(M)), so the
+/// merge is O(N+M) — N reverse keys, M forward keys. The prior inline
+/// `forward.contains(&key)` re-scanned the growing forward Vec once per
+/// reverse key, i.e. O(N·M). This merge runs on the RG-activation prewarm,
+/// which is on the failover critical path (~60ms/~130ms budget); on a busy
+/// cluster with thousands of synced sessions the quadratic scan measurably
+/// slowed how quickly a newly-primary node fully forwarded. The result set
+/// (and its order) is identical to the old dedup — only the membership data
+/// structure changed.
+pub(super) fn merge_owner_rg_candidate_keys(
+    mut forward: Vec<SessionKey>,
+    reverse: Vec<SessionKey>,
+) -> Vec<SessionKey> {
+    // Seed the membership set with the forward keys (O(M)), then probe each
+    // reverse key in O(1). `insert` returns true only for a not-yet-seen
+    // key, which is exactly the old `!forward.contains(&key)` predicate and
+    // also folds out duplicates within `reverse` itself.
+    let mut seen: FastSet<SessionKey> = forward.iter().cloned().collect();
+    for key in reverse {
+        if seen.insert(key.clone()) {
+            forward.push(key);
+        }
+    }
+    forward
+}
+
 /// Pre-warm reverse companions in shared session maps at RG activation.
 ///
 /// With deterministic reverse companions (#310), the Go sync path already
@@ -248,21 +279,21 @@ pub(super) fn prewarm_reverse_synced_sessions_for_owner_rgs(
     }
     let publish_session_map = session_map_fd >= 0;
     let owner_rg_set: std::collections::BTreeSet<i32> = owner_rgs.iter().copied().collect();
-    let mut candidate_keys = owner_rg_session_keys_serialized(
-        shared_sessions,
-        &shared_owner_rg_indexes.sessions,
-        owner_rgs,
+    // #4069: dedup the forward and reverse-prewarm key sets in O(N+M) via a
+    // hash set (see merge_owner_rg_candidate_keys) instead of the former
+    // O(N·M) `Vec::contains` scan on this failover-critical prewarm path.
+    let candidate_keys = merge_owner_rg_candidate_keys(
+        owner_rg_session_keys_serialized(
+            shared_sessions,
+            &shared_owner_rg_indexes.sessions,
+            owner_rgs,
+        ),
+        owner_rg_session_keys_serialized(
+            shared_sessions,
+            &shared_owner_rg_indexes.reverse_prewarm_sessions,
+            owner_rgs,
+        ),
     );
-    let reverse_candidate_keys = owner_rg_session_keys_serialized(
-        shared_sessions,
-        &shared_owner_rg_indexes.reverse_prewarm_sessions,
-        owner_rgs,
-    );
-    for key in reverse_candidate_keys {
-        if !candidate_keys.contains(&key) {
-            candidate_keys.push(key);
-        }
-    }
     // #2402: acquire the shared-session guard with poison RECOVERY. The
     // prior `.lock().map(..).unwrap_or_default()` swallowed a poisoned
     // lock into EMPTY (forward_entries, reverse_entries) — so if a worker


### PR DESCRIPTION
## Summary

Closes #4069 (fable-161 F-192, MEDIUM — HA failover perf).

`prewarm_reverse_synced_sessions_for_owner_rgs` (`userspace-dp/src/afxdp/shared_ops.rs`) runs on RG activation, i.e. on the failover critical path (~60ms/~130ms budget). It unions the forward owner-RG session keys (M) with the narrower reverse-prewarm keys (N) before restoring forward entries and synthesizing reverse companions.

The dedup that built that union was:

```rust
for key in reverse_candidate_keys {
    if !candidate_keys.contains(&key) {   // linear scan of the growing forward Vec, per key
        candidate_keys.push(key);
    }
}
```

That is **O(N·M)** — `Vec::contains` re-scans the whole forward Vec once per reverse key. On a busy cluster (thousands of synced sessions) the quadratic scan measurably slowed how quickly a newly-primary node fully forwarded after a failover.

## Fix

Extract `merge_owner_rg_candidate_keys(forward, reverse)`, which seeds a `FastSet<SessionKey>` (FxHashSet) from the forward keys once (O(M)) and probes each reverse key in O(1) — **O(N+M)** total. `SessionKey` already derives `Hash + Eq` (it is a shared-map key), so no new bounds are needed.

Semantics are preserved exactly: the result set and its order are identical to the old dedup — forward keys first in their original order, then each not-yet-seen reverse key in first-seen order. `seen.insert(k)` returning `true` is precisely the old `!contains` predicate, and it additionally folds out any duplicate within `reverse` itself (same as the old growing-Vec behavior).

## Tests (`ha_tests.rs`)

- `merge_owner_rg_candidate_keys_preserves_order_and_dedups` — pins the order + cross-list + within-`reverse` dedup contract.
- `merge_owner_rg_candidate_keys_scales_linearly_not_quadratically` — merges N=M=200k distinct keys under a generous 5s budget.

### RED-on-revert proof (standalone, same N=M=200k, `rustc -O`)

```
FIX    (O(N+M)):   103.6 ms   len=400000   under_5s=true
REVERT (O(N*M)):  207.47 s    len=400000   under_5s=false
RESULTS IDENTICAL: true
```

The O(N+M) merge finishes in ~100ms; the reverted `Vec::contains` dedup takes **207 seconds** — a ~2000x regression that blows the 5s budget (RED), while the union it produces is byte-identical.

## Validation

- FULL `cargo test --release` (`--test-threads=1`): **3541 passed, 0 failed** (lib suite 11.59s single-threaded, incl. the 200k-key timing test).
- `go build ./...`: clean.
- rustfmt: no new drift (pre-existing repo-formatter hunks untouched).
- Doc: `afxdp/README.md` gains an "RG-activation prewarm dedup is O(N+M)" subsection.

**test-failover WARRANTED** (RG-activation / failover critical path) — for batch validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi