### PR TITLE
routing: start GRE keepalive on the userspace-dp anchor path (#4071)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-07-04 — #4071: GRE keepalive accepted-but-inert on the userspace-dp (anchor) path — re-wire the #1918 engine onto `applyAnchorLocked`
+
+- **Timestamp**: 2026-07-04
+  - **Action**: Fixed fable-161 F-063 (MEDIUM, feature-gap). A configured
+    GRE `keepalive`/`keepalive-retry` compiled into `TunnelConfig` but was
+    a silent no-op on the production dataplane: the #1918 ICMP-echo
+    keepalive engine (`tunnel_keepalive.go` + `startKeepalive`/
+    `keepaliveLoop`/`keepaliveTick`) was started ONLY from the legacy
+    kernel-tunnel branch (`applyKernelTunnelLocked`), while the daemon
+    always takes the anchor branch (`anchorOnly=true`) →
+    `applyAnchorLocked`, which unconditionally `stopKeepaliveLocked`'d the
+    runner and never started one. So a dead GRE far-end was never detected
+    and the interface-down → route-withdrawal action never fired.
+    Fix (Go-only re-wire, `pkg/routing/tunnel.go` `applyAnchorLocked`):
+    start the EXISTING engine on the anchor path, reconciled by identity
+    exactly like the legacy branch — start when `tc.Keepalive > 0`, retain
+    an unchanged runner across applies, restart on a config change, stop
+    when keepalive is removed. Ported the legacy guards: drain-before-
+    recreate + `linkGen` bump (only a genuine recreate — present-but-
+    incompatible or not-found — drains; a transient lookup error keeps the
+    live runner via the EEXIST-adopt path), and skip-`LinkSetUp`-when-a-
+    retained-runner-holds-the-link-down. Down-action stays `LinkSetDown` on
+    the anchor TUN (the Junos-faithful semantic). The prober is dataplane-
+    agnostic (raw ICMP over the underlay FIB) so no Rust change is needed;
+    userspace-dp GRE local-origin TUN-reader tolerance of an admin-down
+    anchor is a loss-cluster VALIDATION item (TUN fd stays valid under
+    admin-down — expected safe).
+    RED-on-revert: `TestAnchorKeepaliveStartsRunnerLifecycle` (a keepalive
+    anchor config STARTS a runner — reverting to the old unconditional
+    `stopKeepaliveLocked` leaves no runner), plus retain/no-op, remove-
+    stops, and the anchor-started runner's `LinkSetDown` on threshold.
+    Validation: `go test ./pkg/routing/... ./pkg/daemon/...` green
+    (+ `-race` on the lifecycle test); `go build ./...`, gofmt, vet clean.
+  - **File(s)**: pkg/routing/tunnel.go,
+    pkg/routing/tunnel_anchor_keepalive_test.go,
+    pkg/routing/README.md, _Log.md
+
 ## 2026-07-04 — #4069: RG-activation reverse-prewarm used O(N·M) Vec::contains dedup on the failover critical path → slow prewarm on a busy cluster
 
 - **Timestamp**: 2026-07-04

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -305,13 +305,22 @@ when the existing kernel link is genuinely incompatible:
   config-wants-none is identity-gated: only when the current master IS
   the claimed RI's `vrf-` device; transient errors retain the claim
   for retry.
-- **Keepalives** (legacy branch only — anchors never probe): runners
+- **Keepalives** (BOTH the anchor and the legacy branch, #4071): runners
   are reconciled by normalized identity `(remote, source, interval,
   retry<=0→3)` and survive unrelated applies; `LinkSetUp` is SKIPPED
   when a retained runner holds the tunnel down (the down-transition in
   `keepaliveLoop` is gated on `state.Up`, so re-upping would strand
   the link admin UP). A change to the tunnel SOURCE restarts the runner
-  (#1918 §5c): the source is the probe bind address.
+  (#1918 §5c): the source is the probe bind address. The prober is
+  dataplane-agnostic (raw ICMP over the underlay FIB), so the production
+  userspace-dp anchor path (`applyAnchorLocked`) starts the SAME engine as
+  the legacy kernel-tunnel branch (`applyKernelTunnelLocked`) — a
+  configured `keepalive` on a GRE anchor tunnel now probes the far end and
+  LinkSetDowns the anchor TUN on peer death (the down oif withdraws its
+  connected/overlay routes, driving OSPF/BGP/static-nexthop dependents to
+  reconverge — the Junos gr-/st0 interface-down semantic). Before #4071
+  the anchor path unconditionally stopped the runner, so a configured
+  keepalive was accepted-but-inert on the only production dataplane.
 
 ## Keepalive liveness probing (`tunnel_keepalive.go`, #1918)
 
@@ -355,12 +364,15 @@ peer behind a valid route read up forever and the fail-safe
   retries next tick (never a lost or half-applied transition), and a
   racing `GetStatus` never blocks behind a slow netlink op nor observes
   an uncommitted `Up`.
-- **Recreate safety**: `applyKernelTunnelLocked` cancels + DRAINS the
-  existing keepalive runner BEFORE it deletes/recreates the kernel link
-  (drain-before-recreate), so no stale runner can issue a `LinkSet*`
-  against a recreated link that reused the ifindex. A per-tunnel
-  `linkGen` (`*atomic.Uint64`, read LOCK-FREE by the runner — it never
-  takes `t.mu`) is the defense-in-depth backstop; the runner drops any
+- **Recreate safety**: both `applyKernelTunnelLocked` and (since #4071)
+  `applyAnchorLocked` cancel + DRAIN the existing keepalive runner BEFORE
+  they delete/recreate the kernel link (drain-before-recreate), so no
+  stale runner can issue a `LinkSet*` against a recreated link that reused
+  the ifindex. A transient (non-not-found) lookup error is NOT treated as
+  a recreate on either path — the EEXIST-adopt fallback keeps the link, so
+  a live runner is retained rather than drained. A per-tunnel `linkGen`
+  (`*atomic.Uint64`, read LOCK-FREE by the runner — it never takes
+  `t.mu`) is the defense-in-depth backstop; the runner drops any
   transition whose captured generation no longer matches.
 
 `Clear()`/`ClearTunnels` keep delete-everything semantics and reset the

--- a/pkg/routing/tunnel.go
+++ b/pkg/routing/tunnel.go
@@ -488,15 +488,44 @@ func anchorReusable(link netlink.Link) bool {
 
 // applyAnchorLocked reconciles one AnchorOnly TUN device (the
 // production userspace-dp path). Caller MUST hold mu.
+//
+// #4071: the #1918 keepalive engine now runs on the anchor path too. A
+// configured `keepalive`/`keepalive-retry` on a GRE anchor tunnel starts
+// the ICMP-echo prober whose down-action LinkSetDowns the anchor TUN on
+// peer death — the Junos-faithful "gr-/st0 interface-down →
+// route-withdrawal" semantic. The prober is dataplane-agnostic (raw ICMP
+// over the underlay FIB), identical to the legacy branch's runner; only
+// the START/STOP wiring differs. The keepalive is reconciled by identity
+// exactly like applyKernelTunnelLocked: an unchanged runner is retained
+// across applies (probe state survives commits), restarted on a config
+// change, and stopped when keepalive is removed.
 func (t *tunnelManager) applyAnchorLocked(tc *config.TunnelConfig, adopting bool) {
-	// A leftover keepalive runner (legacy→anchor mode change) must not
-	// keep probing: anchors never run keepalives (probes LinkSetDown
-	// the device on failure — a behavior the anchor path never had).
-	t.stopKeepaliveLocked(tc.Name)
+	// Drain-before-recreate + linkGen bump (#1918 §6 Axis D F7, ported to
+	// the anchor path in #4071). Decide up front whether this apply will
+	// recreate the anchor TUN. If so, CANCEL + DRAIN any existing keepalive
+	// runner BEFORE the LinkDel/LinkAdd and bump the generation, so no
+	// stale runner tick can LinkSet* a recreated device that reused the
+	// ifindex; linkGen is the lock-free defense-in-depth backstop. A
+	// TRANSIENT lookup error is NOT a recreate: the LinkAdd-EEXIST fallback
+	// below adopts a still-present TUN in place, so draining a live runner
+	// then would needlessly reset probe state (mirrors the legacy branch's
+	// transient-lookup discipline, TestApplyTransientLookupKeepsRunner).
+	existing, lookupErr := t.ops.LinkByName(tc.Name)
+	willRecreate := false
+	switch {
+	case lookupErr == nil:
+		willRecreate = !anchorReusable(existing)
+	case isLinkNotFound(lookupErr):
+		willRecreate = true
+	}
+	if willRecreate {
+		t.stopKeepaliveLocked(tc.Name)
+		t.bumpLinkGenLocked(tc.Name)
+	}
 
 	var link netlink.Link
 	created := false
-	if existing, lookupErr := t.ops.LinkByName(tc.Name); lookupErr == nil {
+	if lookupErr == nil {
 		if anchorReusable(existing) {
 			// Operate on the kernel-fetched link (real ifindex and
 			// attributes), never a fresh ifindex-less struct (#1706).
@@ -526,15 +555,15 @@ func (t *tunnelManager) applyAnchorLocked(tc *config.TunnelConfig, adopting bool
 			// KERNEL-FETCHED link (its Fds is nil, so the
 			// closeTuntapFiles below is skipped with it); anything else
 			// fails this apply (no unbounded retry).
-			existing, lkErr := t.ops.LinkByName(tc.Name)
-			if lkErr != nil || !anchorReusable(existing) {
+			existingAdopt, lkErr := t.ops.LinkByName(tc.Name)
+			if lkErr != nil || !anchorReusable(existingAdopt) {
 				slog.Warn("failed to create tunnel anchor",
 					"name", tc.Name, "err", addErr)
 				return
 			}
 			slog.Info("tunnel anchor already exists as TUN, reusing",
 				"name", tc.Name)
-			link = existing
+			link = existingAdopt
 		} else {
 			closeTuntapFiles(anchor.Fds)
 			link = anchor
@@ -555,7 +584,36 @@ func (t *tunnelManager) applyAnchorLocked(tc *config.TunnelConfig, adopting bool
 	if !created {
 		t.reconcileAnchorMTULocked(tc, link, adopting)
 	}
-	t.finishTunnelLocked(tc, link, false, "tunnel anchor")
+
+	// Keepalive reconcile (#4071, mirroring applyKernelTunnelLocked's
+	// #1884 A.7 identity reconcile). Retain an identity-unchanged runner
+	// so probe state survives commits; the retained-and-DOWN case must
+	// SKIP the LinkSetUp in finishTunnelLocked so the reconcile does not
+	// fight a keepalive-down state — keepaliveLoop's down-transition is
+	// gated on state.Up==true, so re-upping the link here would strand it
+	// admin UP forever while probes keep failing. When willRecreate drained
+	// the runner above, hasRunner is false → restartKA starts a fresh one.
+	runner, hasRunner := t.keepalives[tc.Name]
+	restartKA := tc.Keepalive > 0 && (!hasRunner || created || !runner.matches(tc))
+	skipUp := false
+	if tc.Keepalive > 0 && hasRunner && !restartKA {
+		runner.state.mu.Lock()
+		skipUp = !runner.state.Up
+		runner.state.mu.Unlock()
+	}
+
+	t.finishTunnelLocked(tc, link, skipUp, "tunnel anchor")
+
+	if tc.Keepalive > 0 {
+		if restartKA {
+			// startKeepalive stops+drains any predecessor itself; runs
+			// AFTER a recreate so the fresh runner probes the new device.
+			// tc.Source is the probe bind endpoint (#1918 §5c).
+			t.startKeepalive(tc.Name, tc.Source, tc.Destination, tc.Keepalive, tc.KeepaliveRetry)
+		}
+	} else if hasRunner {
+		t.stopKeepaliveLocked(tc.Name)
+	}
 }
 
 // reconcileAnchorMTULocked applies the #1884 MTU ownership rule to a

--- a/pkg/routing/tunnel_anchor_keepalive_test.go
+++ b/pkg/routing/tunnel_anchor_keepalive_test.go
@@ -1,0 +1,261 @@
+package routing
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #4071 anchor-path keepalive tests. Before #4071 the production
+// userspace-dp anchor path (applyAnchorLocked) unconditionally
+// stopKeepaliveLocked'd and never started a runner, so a configured GRE
+// `keepalive` was accepted-but-inert on the only runtime dataplane. These
+// tests pin that applyAnchorLocked now starts/retains/stops the #1918
+// engine by identity exactly like the legacy applyKernelTunnelLocked
+// branch, and that the anchor-started runner's LinkSetDown down-action
+// fires on threshold. RED-on-revert: reverting to the old unconditional
+// stop leaves no runner (TestAnchorKeepaliveStartsRunnerLifecycle).
+
+func anchorKATC(name string, keepalive, retry int) *config.TunnelConfig {
+	return &config.TunnelConfig{
+		Name:           name,
+		AnchorOnly:     true,
+		Source:         "198.51.100.1",
+		Destination:    "203.0.113.1",
+		Keepalive:      keepalive,
+		KeepaliveRetry: retry,
+	}
+}
+
+// runnerFor reads the keepalive runner for a tunnel under mu.
+func runnerFor(tm *tunnelManager, name string) (*keepaliveRunner, bool) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	r, ok := tm.keepalives[name]
+	return r, ok
+}
+
+// --- #4071 core (RED-on-revert): a keepalive anchor config STARTS a
+// runner; an unchanged apply RETAINS the same runner (probe state
+// survives commits); removing keepalive STOPS it. ---
+func TestAnchorKeepaliveStartsRunnerLifecycle(t *testing.T) {
+	ops := newFakeLinkOps()
+	// A pre-existing reusable anchor TUN → reuse-in-place (no recreate),
+	// so the runner is started purely by the keepalive reconcile.
+	seedAnchor(ops, "gr-0-0-0", 10, 1500)
+	tm, _ := newReconcileManager(ops)
+	// Inject an alive fake prober so the runner goroutine performs no real
+	// network I/O; interval 60s keeps its ticker from firing during the
+	// test (identity/lifecycle only — no ticks driven here).
+	tm.prober = &fakeProber{results: []probeOutcome{{result: ProbeAlive, kind: UnsupportedNone}}}
+
+	tc := anchorKATC("gr-0-0-0", 60, 3)
+
+	// Apply 1: keepalive configured → a runner is started (RED on revert:
+	// the old applyAnchorLocked stopped it → this map entry is absent).
+	if err := tm.Apply([]*config.TunnelConfig{tc}); err != nil {
+		t.Fatalf("Apply 1: %v", err)
+	}
+	r1, ok := runnerFor(tm, "gr-0-0-0")
+	if !ok {
+		t.Fatal("anchor path must START a keepalive runner when keepalive is configured (accepted-but-inert regression, #4071)")
+	}
+	if r1.remote != "203.0.113.1" || r1.source != "198.51.100.1" ||
+		r1.interval != 60 || r1.maxRetries != 3 {
+		t.Fatalf("runner identity mismatch: remote=%q source=%q interval=%d retries=%d",
+			r1.remote, r1.source, r1.interval, r1.maxRetries)
+	}
+
+	// Apply 2: identical config → the SAME runner object is retained (a
+	// no-op reconcile, not a restart that would reset probe state).
+	if err := tm.Apply([]*config.TunnelConfig{tc}); err != nil {
+		t.Fatalf("Apply 2: %v", err)
+	}
+	r2, ok := runnerFor(tm, "gr-0-0-0")
+	if !ok || r2 != r1 {
+		t.Fatalf("unchanged apply must retain the same runner (no restart); r1=%p r2=%p ok=%v", r1, r2, ok)
+	}
+
+	// Apply 3: keepalive removed → the runner is stopped and removed.
+	if err := tm.Apply([]*config.TunnelConfig{anchorKATC("gr-0-0-0", 0, 0)}); err != nil {
+		t.Fatalf("Apply 3: %v", err)
+	}
+	if _, ok := runnerFor(tm, "gr-0-0-0"); ok {
+		t.Fatal("removing keepalive must STOP the anchor runner")
+	}
+}
+
+// --- #4071: a config change (here the tunnel SOURCE, §5c bind) RESTARTS
+// the runner — a new runner object with the new identity. ---
+func TestAnchorKeepaliveIdentityChangeRestarts(t *testing.T) {
+	ops := newFakeLinkOps()
+	seedAnchor(ops, "gr-0-0-0", 10, 1500)
+	tm, _ := newReconcileManager(ops)
+	tm.prober = &fakeProber{results: []probeOutcome{{result: ProbeAlive, kind: UnsupportedNone}}}
+
+	if err := tm.Apply([]*config.TunnelConfig{anchorKATC("gr-0-0-0", 60, 3)}); err != nil {
+		t.Fatalf("Apply 1: %v", err)
+	}
+	r1, ok := runnerFor(tm, "gr-0-0-0")
+	if !ok {
+		t.Fatal("first apply must start a runner")
+	}
+
+	changed := anchorKATC("gr-0-0-0", 60, 3)
+	changed.Source = "192.0.2.9" // source change → §5c restart
+	if err := tm.Apply([]*config.TunnelConfig{changed}); err != nil {
+		t.Fatalf("Apply 2: %v", err)
+	}
+	r2, ok := runnerFor(tm, "gr-0-0-0")
+	if !ok {
+		t.Fatal("changed apply must keep a runner")
+	}
+	if r2 == r1 {
+		t.Fatal("a source change must RESTART the runner (new object), not retain the old bind")
+	}
+	if r2.source != "192.0.2.9" {
+		t.Fatalf("restarted runner must bind the new source, got %q", r2.source)
+	}
+
+	// Drain the live goroutine.
+	tm.mu.Lock()
+	tm.stopKeepaliveLocked("gr-0-0-0")
+	tm.mu.Unlock()
+}
+
+// --- #4071: the anchor-started runner's down-action (LinkSetDown on the
+// anchor TUN) fires after MaxRetries dead probes. The recreate from the
+// (non-TUN Dummy) seed also bumps the generation. ---
+func TestAnchorKeepaliveDownActionOnThreshold(t *testing.T) {
+	ops := newKaOps() // records LinkSetUp/Down; LinkByName returns a Dummy
+	tm := &tunnelManager{
+		ops:       ops,
+		vrfBinder: noopVRFBinder{},
+		prober:    &fakeProber{results: []probeOutcome{{result: ProbeAlive, kind: UnsupportedNone}}},
+	}
+	tc := anchorKATC("gr-0-0-0", 1, 3)
+
+	tm.mu.Lock()
+	tm.ensureReconcileStateLocked()
+	tm.applyAnchorLocked(tc, true)
+	runner, ok := tm.keepalives["gr-0-0-0"]
+	if !ok {
+		tm.mu.Unlock()
+		t.Fatal("anchor path must start a runner for the down-action test")
+	}
+	state := runner.state
+	gen := runner.linkGen
+	startGen := runner.startGen
+	// Stop the live goroutine so our manual ticks are the only driver.
+	tm.stopKeepaliveLocked("gr-0-0-0")
+	// The Dummy→TUN replacement is a recreate → the generation was bumped,
+	// and the runner captured the post-bump value.
+	if startGen == 0 {
+		tm.mu.Unlock()
+		t.Fatal("a recreate must bump the linkGen (startGen should be > 0)")
+	}
+	if gen.Load() != startGen {
+		tm.mu.Unlock()
+		t.Fatalf("runner startGen %d != current gen %d", startGen, gen.Load())
+	}
+	tm.mu.Unlock()
+
+	dead := &fakeProber{results: []probeOutcome{{result: ProbeDead, kind: UnsupportedNone}}}
+	// Below threshold (MaxRetries=3): failures climb, no LinkSetDown yet.
+	tickN(tm, "gr-0-0-0", state, dead, gen, startGen, 2)
+	if ops.downs() != 0 {
+		t.Fatalf("no LinkSetDown before MaxRetries, got %d", ops.downs())
+	}
+	if !state.Up {
+		t.Fatal("tunnel must stay up below threshold")
+	}
+	// Threshold tick → exactly one LinkSetDown, Up=false.
+	tm.keepaliveTick("gr-0-0-0", state, dead, gen, startGen)
+	if ops.downs() != 1 {
+		t.Fatalf("expected exactly one LinkSetDown at threshold, got %d", ops.downs())
+	}
+	if state.Up {
+		t.Fatal("expected Up=false after the anchor keepalive down-action")
+	}
+}
+
+// --- #4071: a retained runner that currently holds the tunnel DOWN must
+// SKIP the LinkSetUp in finishTunnelLocked, so the reconcile does not
+// fight the keepalive-down state (ported skip-LinkSetUp-when-held-down
+// guard). ---
+func TestAnchorKeepaliveRetainedDownSkipsLinkUp(t *testing.T) {
+	ops := newFakeLinkOps()
+	seedAnchor(ops, "gr-0-0-0", 10, 1500)
+	tm, _ := newReconcileManager(ops)
+
+	tm.mu.Lock()
+	tm.ensureReconcileStateLocked()
+	// Seed a retained runner (matching the config identity) that holds the
+	// tunnel DOWN, with a pre-closed done so any drain is instant.
+	state := &KeepaliveState{
+		Up: false, RemoteAddr: "203.0.113.1", SourceAddr: "198.51.100.1",
+		Interval: 60, MaxRetries: 3,
+	}
+	gen := tm.linkGenForLocked("gr-0-0-0")
+	seededDone := make(chan struct{})
+	close(seededDone)
+	tm.keepalives["gr-0-0-0"] = &keepaliveRunner{
+		cancel: func() {}, state: state, done: seededDone,
+		remote: "203.0.113.1", source: "198.51.100.1", interval: 60, maxRetries: 3,
+		linkGen: gen, startGen: gen.Load(),
+	}
+	tm.mu.Unlock()
+
+	if err := tm.Apply([]*config.TunnelConfig{anchorKATC("gr-0-0-0", 60, 3)}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(ops.setUpLinks) != 0 {
+		t.Fatalf("retained keepalive-down runner must skip LinkSetUp, got %d", len(ops.setUpLinks))
+	}
+	r, ok := runnerFor(tm, "gr-0-0-0")
+	if !ok {
+		t.Fatal("matching runner must be retained across the apply")
+	}
+	if r.state.Up {
+		t.Fatal("retained runner must still hold the tunnel down (no fight)")
+	}
+}
+
+// --- #4071: a TRANSIENT (non-not-found) lookup error must NOT drain the
+// live anchor keepalive runner nor bump the generation — the EEXIST-adopt
+// fallback keeps the link, so the runner is preserved (mirrors the legacy
+// TestApplyTransientLookupKeepsRunner). ---
+func TestAnchorKeepaliveTransientLookupKeepsRunner(t *testing.T) {
+	ops := newFakeLinkOps()
+	ops.byNameHardErr["gr-0-0-0"] = errors.New("transient netlink transport error")
+	ops.addExisting = true // LinkAdd reports EEXIST → no create path
+	tm, _ := newReconcileManager(ops)
+
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	tm.ensureReconcileStateLocked()
+
+	state := &KeepaliveState{
+		Up: true, RemoteAddr: "203.0.113.1", SourceAddr: "198.51.100.1",
+		Interval: 60, MaxRetries: 3,
+	}
+	gen := tm.linkGenForLocked("gr-0-0-0")
+	startGen := gen.Load()
+	seededDone := make(chan struct{})
+	close(seededDone)
+	tm.keepalives["gr-0-0-0"] = &keepaliveRunner{
+		cancel: func() {}, state: state, done: seededDone,
+		remote: "203.0.113.1", source: "198.51.100.1", interval: 60, maxRetries: 3,
+		linkGen: gen, startGen: startGen,
+	}
+
+	tm.applyAnchorLocked(anchorKATC("gr-0-0-0", 60, 3), false)
+
+	if _, ok := tm.keepalives["gr-0-0-0"]; !ok {
+		t.Fatal("transient lookup error must NOT drain the anchor keepalive runner")
+	}
+	if gen.Load() != startGen {
+		t.Fatalf("transient lookup error must NOT bump the generation: %d -> %d", startGen, gen.Load())
+	}
+}


### PR DESCRIPTION
Closes #4071

## Problem

A configured GRE `keepalive`/`keepalive-retry` was accepted and compiled
into `TunnelConfig` but was a **silent no-op on the production
userspace-dp dataplane** — no probes, no tracking, no down-action. A dead
GRE far-end stayed UP and blackholed traffic; the keepalive-driven
interface-down / route-withdrawal never fired.

The #1918 ICMP-echo keepalive engine (prober + loop + the `LinkSetDown`
down-action in `tunnel_keepalive.go` and `startKeepalive`/`keepaliveLoop`/
`keepaliveTick`) already exists, but `startKeepalive` was wired **only**
into the legacy kernel-tunnel branch (`applyKernelTunnelLocked`). The
daemon always sets `AnchorOnly=true` (userspace is the default and only
runtime dataplane), so every commit routes through `applyAnchorLocked`,
which **unconditionally** called `stopKeepaliveLocked` and never started a
runner.

## Fix (Go-only re-wire, `pkg/routing`)

Re-wire the existing engine onto the anchor path. The prober is
dataplane-agnostic (raw ICMP over the underlay FIB, bound to the tunnel
source), so it is identical to the legacy branch's runner — only the
start/stop wiring differed.

`applyAnchorLocked` now reconciles the keepalive **by normalized
identity**, exactly like `applyKernelTunnelLocked`:
- start a runner when `tc.Keepalive > 0`;
- **retain** an unchanged runner across applies (probe state survives
  commits — no restart churn);
- **restart** on a config change (e.g. the §5c source bind);
- **stop** when keepalive is removed.

Two guards ported from the legacy branch:
1. **Drain-before-recreate + `linkGen` bump** — only a genuine recreate (a
   present-but-incompatible link, or a not-found link) drains the runner
   and bumps the generation before the `LinkDel`/`LinkAdd`, so no stale
   tick can `LinkSet*` a recreated device that reused the ifindex. A
   transient (non-not-found) lookup error is **not** a recreate: the
   `LinkAdd`-EEXIST fallback adopts the still-present TUN in place, so a
   live runner is retained rather than needlessly reset.
2. **Skip `LinkSetUp` when a retained runner holds the link down** — so
   the reconcile does not fight a keepalive-down state (`keepaliveLoop`'s
   down-transition is gated on `state.Up==true`; re-upping here would
   strand the link admin UP while probes keep failing).

The down-action stays `LinkSetDown` on the anchor TUN — the Junos-faithful
"gr-/st0 interface-down → route-withdrawal" semantic: the down oif
withdraws its connected/overlay routes and drives OSPF/BGP/static-nexthop
dependents to reconverge.

## Tests

`pkg/routing/tunnel_anchor_keepalive_test.go` (new): start/retain/stop
lifecycle (the RED-on-revert anchor), identity-change restart, the
anchor-started runner's `LinkSetDown` on threshold, the
skip-`LinkSetUp`-when-held-down guard, and the transient-lookup keeps-runner
guard. Restoring `applyAnchorLocked` to its pre-#4071 form fails all five
(primary: "must START a keepalive runner").

`go test ./pkg/routing/... ./pkg/daemon/...` green; lifecycle/identity/
down-action pass under `-race`. `go build ./...`, `gofmt`, `go vet` clean.
README updated (`pkg/routing/README.md`): both apply paths now probe and
drain-before-recreate.

## Validation flag (for maintainer)

No Rust change is required — the prober is control-plane / underlay-routed.
A **loss-cluster smoke is warranted** to confirm the userspace-dp GRE
local-origin TUN reader (`afxdp/tunnel.rs`) **tolerates an admin-down
anchor** (the #1918-deferred concern the anchor path never exercised). The
TUN fd stays valid under admin-down — only kernel routing to it stops — so
this is **expected safe**; the fatal-errno predicates
(`ENODEV/ENXIO/EBADF/EBADFD/EINVAL`) are not triggered by admin-down. Please
validate the down/up transition on the loss cluster before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
