### PR TITLE
config: accept raise-only NAT pool-utilization-alarm (#4077)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -31889,3 +31889,28 @@ top.
     test-failover WARRANTED (VRRP failover timing) — batch-validate.
   - **File(s)**: pkg/vrrp/instance.go,
     pkg/vrrp/instance_master_interval_test.go, pkg/vrrp/README.md, _Log.md
+
+- **Timestamp**: 2026-07-04
+  - **Action**: #4077 — NAT source pool-utilization-alarm accept raise-only
+    config (clear-threshold optional). VERIFY-FIRST repro confirmed the
+    genuine defect: `set security nat source pool-utilization-alarm
+    raise-threshold 90` (no clear-threshold) was REJECTED at commit
+    (`validatePoolUtilizationAlarm`, clear=0 tripped `clear-threshold must be
+    in 1..raise-threshold-1`), and even had it been accepted the runtime
+    monitor (`pkg/natpoolalarm`) treats clear<=0 as disabled. Junos makes
+    clear-threshold optional. Fix: default clear-threshold at PARSE time in
+    `compiler_nat.go` when the operator supplies only raise — new
+    `defaultPoolAlarmClearThreshold(raise) = max(1, raise-10)` (10-point
+    hysteresis margin: raise 90 → clear 80, raise 5 → clear 1). A presence
+    flag (`clearSet`) distinguishes an OMITTED clear from an EXPLICIT one, so
+    an explicit `clear-threshold 0` (and inverted/equal/bare/out-of-range) is
+    still rejected — the #2079 gate is unchanged and only ever sees an
+    invalid clear the operator typed. RED-on-revert: neutralizing the default
+    makes `TestPoolUtilizationAlarmRaiseOnlyDefaultsClear` +
+    `...RaiseOnlyLowRaiseFloorsClear` fail (clear=0 raise=90/5 rejected).
+    Validated: `go test ./pkg/config/... ./pkg/natpoolalarm/...`, `go build
+    ./...`, gofmt + vet clean. Docs: docs/deterministic-nat-cgnat.md,
+    docs/config-schema.md.
+  - **File(s)**: pkg/config/compiler_nat.go,
+    pkg/config/compiler_nat_pool_alarm_test.go,
+    docs/deterministic-nat-cgnat.md, docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3376,7 +3376,16 @@ a Tier-3 compiler-side validation with the standard **strict-vs-lenient** split
 (same doctrine as #1979 / tcp-mss). `validatePoolUtilizationAlarm`
 (`pkg/config/compiler_nat.go`, invoked from the typed-config phase of
 `compileExpanded` in `compiler.go`) requires `0 < clear-threshold <
-raise-threshold <= 100`:
+raise-threshold <= 100`.
+
+`clear-threshold` is OPTIONAL (#4077, Junos-faithful). A raise-only config
+(`raise-threshold` with no `clear-threshold`) is legal: the parser defaults the
+clear-threshold to a 10-point hysteresis margin below raise
+(`defaultPoolAlarmClearThreshold`, floored at 1 — raise 90 → clear 80, raise 5 →
+clear 1) BEFORE the gate runs, so the raise-only config both commits and arms
+the runtime monitor. The default always lands inside `0 < clear < raise`, so the
+gate below only ever sees a zero/invalid clear when the operator EXPLICITLY
+provided one (an explicit `clear-threshold 0` is still rejected).
 
 - **Strict (`commit` / `commit check`):** a bare `pool-utilization-alarm;`
   (raise=0/clear=0, an always-firing alarm) and inverted/equal thresholds are
@@ -3394,7 +3403,8 @@ raise-threshold <= 100`:
 The thresholds are a single GLOBAL pair (no per-pool override syntax in the
 parsed Junos grammar). Regression coverage:
 `pkg/config/compiler_nat_pool_alarm_test.go` (strict reject + lenient
-accept-with-warning + valid-no-warning). The runtime consumer (#2079) is
+accept-with-warning + valid-no-warning + raise-only default + explicit-clear
+still-validated). The runtime consumer (#2079) is
 documented in `docs/deterministic-nat-cgnat.md`.
 
 NOTE: `pool-utilization-alarm` is not yet a typed `setSchema` leaf (no

--- a/docs/deterministic-nat-cgnat.md
+++ b/docs/deterministic-nat-cgnat.md
@@ -81,13 +81,27 @@ set security nat source pool-utilization-alarm clear-threshold 70
 
 This is a single GLOBAL raise/clear pair (matching Junos `set security nat
 source pool-utilization-alarm` scope); the same thresholds apply to every
-source pool. Validation requires `0 < clear-threshold < raise-threshold <= 100`
-with the standard strict-vs-lenient split (`validatePoolUtilizationAlarm`,
+source pool. `clear-threshold` is OPTIONAL (#4077, Junos-faithful): a raise-only
+config —
+
+```
+set security nat source pool-utilization-alarm raise-threshold 90
+```
+
+— commits, with `clear-threshold` defaulted at parse time to a 10-point
+hysteresis margin below raise (`defaultPoolAlarmClearThreshold`, floored at 1),
+so raise 90 → clear 80, raise 50 → clear 40, raise 5 → clear 1. The default
+always lands inside `0 < clear < raise`, so the runtime monitor arms the alarm
+(it treats `clear <= 0` as disabled).
+
+When BOTH are set, validation requires `0 < clear-threshold < raise-threshold
+<= 100` with the standard strict-vs-lenient split (`validatePoolUtilizationAlarm`,
 `compiler_nat.go`): a bare `pool-utilization-alarm;` (raise=0/clear=0) and
-inverted/equal thresholds are hard `commit`/`commit check` errors, but the
-tolerant load / HA peer-sync path downgrades them to a warning so a node that
-committed a legacy config before this gate existed still boots (the runtime
-monitor treats raise<=0 as disabled, so a leniently-loaded bad config is inert).
+inverted/equal thresholds — and an EXPLICIT `clear-threshold 0` — are hard
+`commit`/`commit check` errors, but the tolerant load / HA peer-sync path
+downgrades them to a warning so a node that committed a legacy config before
+this gate existed still boots (the runtime monitor treats raise<=0 as disabled,
+so a leniently-loaded bad config is inert).
 
 Runtime behaviour (vSRX-faithful) is driven by a slow (10s) daemon-resident
 monitor (`pkg/natpoolalarm`) over the helper's LAST-APPLIED NAT pool snapshot

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -8,16 +8,44 @@ import (
 	"strings"
 )
 
+// defaultPoolAlarmHysteresis is the gap, in utilization percentage points,
+// placed below the raise-threshold when an operator configures a raise-only
+// pool-utilization-alarm (no explicit clear-threshold). A 10-point gap gives
+// the alarm state machine hysteresis so it does not flap around the raise
+// boundary, and keeps the defaulted clear inside the valid 1..raise-1 band for
+// every realistic raise (>= 2). Junos allows a raise-only alarm; xpf mirrors
+// that by synthesizing this clear rather than requiring the operator to name
+// one (#4077).
+const defaultPoolAlarmHysteresis = 10
+
+// defaultPoolAlarmClearThreshold returns the clear-threshold to use when the
+// operator supplied only a raise-threshold. It is raise minus a fixed
+// hysteresis margin, floored at 1 so it stays a valid percentage. For raise >=
+// 2 the result is strictly less than raise (0 < clear < raise), so it passes
+// the commit gate and enables the runtime alarm; e.g. raise 90 -> clear 80,
+// raise 50 -> clear 40, raise 5 -> clear 1.
+func defaultPoolAlarmClearThreshold(raise int) int {
+	clear := raise - defaultPoolAlarmHysteresis
+	if clear < 1 {
+		clear = 1
+	}
+	return clear
+}
+
 // validatePoolUtilizationAlarm is the #2079 strict-vs-lenient gate for the
 // `security nat source pool-utilization-alarm raise-threshold/clear-threshold`
-// thresholds. Junos requires raise > clear; a bare `pool-utilization-alarm;`
-// compiles to raise=0/clear=0 (an always-firing alarm) and inverted/equal
-// thresholds make hysteresis meaningless. Strict (commit / commit-check):
-// hard-reject. Lenient (load / peer-sync, #1979 doctrine): return the message
-// as a warning so a config committed before this gate existed still boots
-// (#1960 fail-closed-on-compile-failure would otherwise brick the daemon on
-// restart). The runtime monitor treats raise<=0 as disabled, so a leniently
-// loaded bad config is inert, not always-firing.
+// thresholds. Junos requires only raise-threshold; clear-threshold is optional
+// and, when omitted, is defaulted at parse time to a hysteresis margin below
+// raise (defaultPoolAlarmClearThreshold, #4077) so a raise-only alarm both
+// commits and runs. This gate therefore only ever sees a zero/invalid
+// clear-threshold when the operator EXPLICITLY provided one. A bare
+// `pool-utilization-alarm;` compiles to raise=0/clear=0 (an always-firing
+// alarm) and inverted/equal thresholds make hysteresis meaningless. Strict
+// (commit / commit-check): hard-reject. Lenient (load / peer-sync, #1979
+// doctrine): return the message as a warning so a config committed before this
+// gate existed still boots (#1960 fail-closed-on-compile-failure would
+// otherwise brick the daemon on restart). The runtime monitor treats raise<=0
+// as disabled, so a leniently loaded bad config is inert, not always-firing.
 func validatePoolUtilizationAlarm(cfg *Config, lenient bool) ([]string, error) {
 	if cfg == nil {
 		return nil, nil
@@ -1449,6 +1477,15 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 	// Parse pool-utilization-alarm
 	if alarmNode := node.FindChild("pool-utilization-alarm"); alarmNode != nil {
 		alarm := &PoolUtilizationAlarmConfig{}
+		// clearSet records whether the operator explicitly provided a
+		// clear-threshold token. Junos makes clear-threshold OPTIONAL: a
+		// raise-only alarm is legal (#4077). When it is omitted we default it
+		// to a hysteresis margin below raise (defaultPoolAlarmClearThreshold),
+		// so the raise-only config compiles AND the runtime monitor enables the
+		// alarm (it treats clear<=0 as disabled). An EXPLICIT clear-threshold —
+		// even an invalid one like 0 or >= raise — is preserved verbatim so the
+		// commit gate still rejects it.
+		clearSet := false
 		for _, ap := range alarmNode.Children {
 			switch ap.Name() {
 			case "raise-threshold":
@@ -1458,6 +1495,7 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 					}
 				}
 			case "clear-threshold":
+				clearSet = true
 				if v := nodeVal(ap); v != "" {
 					if n, err := strconv.Atoi(v); err == nil {
 						alarm.ClearThreshold = n
@@ -1473,10 +1511,16 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 				}
 			}
 			if alarmNode.Keys[i] == "clear-threshold" && i+1 < len(alarmNode.Keys) {
+				clearSet = true
 				if n, err := strconv.Atoi(alarmNode.Keys[i+1]); err == nil {
 					alarm.ClearThreshold = n
 				}
 			}
+		}
+		// Raise-only config: default the clear-threshold to a hysteresis margin
+		// below raise so the alarm is usable without an explicit clear.
+		if alarm.RaiseThreshold > 0 && !clearSet {
+			alarm.ClearThreshold = defaultPoolAlarmClearThreshold(alarm.RaiseThreshold)
 		}
 		sec.NAT.PoolUtilizationAlarm = alarm
 	}

--- a/pkg/config/compiler_nat_pool_alarm_test.go
+++ b/pkg/config/compiler_nat_pool_alarm_test.go
@@ -38,6 +38,66 @@ func TestPoolUtilizationAlarmRejectsBareStanza(t *testing.T) {
 	}
 }
 
+// #4077: a raise-only alarm (no clear-threshold) is legal in Junos. It must
+// COMMIT, with clear-threshold defaulted to a hysteresis margin below raise so
+// the runtime monitor (which treats clear<=0 as disabled) actually arms it.
+// Goes RED on revert (validation rejects raise=90/clear=0).
+func TestPoolUtilizationAlarmRaiseOnlyDefaultsClear(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security nat source pool-utilization-alarm raise-threshold 90",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("raise-only alarm must compile, got: %v", err)
+	}
+	a := cfg.Security.NAT.PoolUtilizationAlarm
+	if a == nil {
+		t.Fatal("alarm not stored")
+	}
+	if a.RaiseThreshold != 90 {
+		t.Fatalf("raise-threshold not stored: %+v", a)
+	}
+	// raise 90 - hysteresis 10 = 80; must be a valid clear (0 < clear < raise)
+	// so the runtime monitor enables the alarm.
+	if a.ClearThreshold != 80 {
+		t.Fatalf("clear-threshold should default to 80 (raise-10), got %d", a.ClearThreshold)
+	}
+	if !(a.ClearThreshold > 0 && a.ClearThreshold < a.RaiseThreshold) {
+		t.Fatalf("defaulted clear must satisfy 0 < clear < raise, got clear=%d raise=%d", a.ClearThreshold, a.RaiseThreshold)
+	}
+}
+
+// A low raise-threshold floors the defaulted clear at 1 (never below 1) and
+// keeps it strictly below raise.
+func TestPoolUtilizationAlarmRaiseOnlyLowRaiseFloorsClear(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security nat source pool-utilization-alarm raise-threshold 5",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("raise-only alarm (low raise) must compile, got: %v", err)
+	}
+	a := cfg.Security.NAT.PoolUtilizationAlarm
+	if a == nil || a.RaiseThreshold != 5 {
+		t.Fatalf("alarm not stored correctly: %+v", a)
+	}
+	if a.ClearThreshold != 1 {
+		t.Fatalf("clear-threshold should floor at 1 for raise=5, got %d", a.ClearThreshold)
+	}
+}
+
+// An EXPLICIT clear-threshold is preserved and still validated: a raise-only
+// default must NOT paper over an explicitly invalid clear (regression guard for
+// the #4077 default so it does not weaken the #2079 gate).
+func TestPoolUtilizationAlarmExplicitClearStillValidated(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security nat source pool-utilization-alarm raise-threshold 90 clear-threshold 0",
+	})
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("explicit clear-threshold 0 must still be rejected")
+	}
+}
+
 func TestPoolUtilizationAlarmRejectsInverted(t *testing.T) {
 	// clear >= raise is invalid (hysteresis meaningless).
 	tree := buildTree(t, []string{


### PR DESCRIPTION
Closes #4077

## Problem

The NAT source pool-utilization-alarm rejected a **raise-only** config. Committing

```
set security nat source pool-utilization-alarm raise-threshold 90
```

failed with:

```
pool-utilization-alarm: clear-threshold must be in 1..raise-threshold-1 (0 < clear < raise), got clear=0 raise=90
```

With no `clear-threshold` the compiled `ClearThreshold` stayed `0`, and the #2079 gate (`validatePoolUtilizationAlarm`) hard-rejects `clear<=0`. Even if it were accepted, the runtime monitor (`pkg/natpoolalarm`, `natpoolalarm.go:229-231`) treats `clear<=0` as *feature disabled*, so a raise-only alarm would never arm. Junos makes `clear-threshold` optional — an operator who just wants "alarm when the pool is >90% utilized" could not express it. **VERIFY-FIRST repro confirmed the rejection.**

## Fix

Default `clear-threshold` at **parse time** in `pkg/config/compiler_nat.go` when the operator supplies only `raise-threshold`:

- New helper `defaultPoolAlarmClearThreshold(raise) = max(1, raise-10)` — a 10-point hysteresis margin below raise, floored at 1 so it stays a valid percentage (raise 90 → clear 80, raise 50 → clear 40, raise 5 → clear 1). For every `raise >= 2` the result is strictly inside `0 < clear < raise`, so the raise-only config both commits and arms the runtime monitor.
- A `clearSet` presence flag distinguishes an **omitted** `clear-threshold` from an **explicit** one. The default applies only when the token is absent; an explicit `clear-threshold 0` (and inverted / equal / bare / out-of-range configs) is preserved verbatim and still rejected by the unchanged #2079 gate. The fix does not weaken commit validation.

## Tests (RED-on-revert)

`pkg/config/compiler_nat_pool_alarm_test.go` (ParseSetCommand + SetPath):
- `TestPoolUtilizationAlarmRaiseOnlyDefaultsClear` — raise 90 commits, clear defaults to 80.
- `TestPoolUtilizationAlarmRaiseOnlyLowRaiseFloorsClear` — raise 5 floors clear at 1.
- `TestPoolUtilizationAlarmExplicitClearStillValidated` — explicit `clear-threshold 0` still rejected.

Neutralizing the parse-time default makes the two raise-only tests fail with the original `clear=0 raise=90/5` rejection (RED-on-revert verified). All prior #2079 tests (bare / inverted / equal / out-of-range / zero-clear / lenient-load) still pass.

## Validation

- `go test ./pkg/config/... ./pkg/natpoolalarm/...` green
- `go build ./...` clean
- `gofmt` + `go vet` clean
- Docs: `docs/deterministic-nat-cgnat.md`, `docs/config-schema.md`