### PR TITLE
daemon: implement periodic config archival timer (transfer-interval)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-07-04 — #4078: `system archival configuration transfer-interval` periodic archive accepted-but-inert — add the runtime timer
+
+- **Timestamp**: 2026-07-04
+  - **Action**: Fixed fable-161 F-060 (MEDIUM, feature-gap). Junos
+    `transfer-interval <minutes>` archives the running config to
+    `archive-sites` every N minutes, independent of `transfer-on-commit`.
+    The leaf compiled into `config.ArchivalConfig.TransferInterval` (with
+    parser tests) but no runtime consumer read it — only `archiveConfig`
+    (gated on `TransferOnCommit`, called from `applyConfigLocked`) ran, so
+    the timed periodic archive never fired (accepted-but-inert). Fix
+    (Go-only): (1) extract the reusable archive-to-site transport
+    `archiveToSites(sites)` out of `archiveConfig` (`daemon_flow.go`) —
+    serialize `Store.ShowActive` to a 0600 temp file + scp to each site via
+    the `archiveTransfer` seam; `archiveConfig` now delegates to it, so
+    transfer-on-commit is unchanged. (2) Add `reconcileArchiveTimer` +
+    `runArchiveTimer` + `stopArchiveTimer` (`daemon_archive_timer.go`),
+    mirroring `reconcileRPM`: called from `applyConfigLocked` (new step
+    15c), hash-gated on `(interval, sites)` so an unrelated commit never
+    bounces a healthy timer; a change reschedules; removing the leaf (or
+    interval 0 / no sites) stops it; re-arms on restart via the boot apply;
+    the timer reuses `archiveToSites` (reads the LIVE active config on each
+    tick). (3) Added the `transfer-interval` typed `setSchema` leaf
+    (`ValueInteger`, `ValidateInteger(1,2880)`) for completion + commit-check.
+    (4) `stopArchiveTimer` added to the shutdown teardown. Tick source is
+    behind the `archiveNewTicker` seam so tests fire deterministically.
+  - **File(s)**: pkg/config/schema_system.go,
+    pkg/daemon/daemon_flow.go, pkg/daemon/daemon_archive_timer.go (new),
+    pkg/daemon/daemon.go, pkg/daemon/daemon_apply.go,
+    pkg/daemon/daemon_run.go, pkg/daemon/archive_timer_4078_test.go (new),
+    docs/config-schema.md
+  - **Validation**: `go build ./...`, `go vet`, `gofmt` clean;
+    `go test ./pkg/config/... ./pkg/daemon/... ./pkg/configstore/...`
+    green; archive tests green under `-race`. RED-on-revert proven:
+    neutering the `archiveToSites` call in `runArchiveTimer` makes
+    `TestArchiveTimerFiresPeriodicArchive` fail ("periodic archive never
+    fired — transfer-interval is inert").
+
 ## 2026-07-04 — #4071: GRE keepalive accepted-but-inert on the userspace-dp (anchor) path — re-wire the #1918 engine onto `applyAnchorLocked`
 
 - **Timestamp**: 2026-07-04

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -143,6 +143,25 @@ all N siblings) and the delete/deactivate-side #3846/#3975 (member-wise edit,
 which these leaves now inherit for free because `delete`/`deactivate` route a
 `multi: true, children: nil, args == 1` leaf through the member matcher).
 
+**`system archival configuration transfer-interval <minutes>` — periodic
+off-box archive (#4078).** Junos archives the running config to `archive-sites`
+every N minutes, independent of `transfer-on-commit` (a periodic backup for a
+config that rarely changes). The leaf compiled into
+`config.ArchivalConfig.TransferInterval` from the start, but no runtime consumer
+read it — so the timed archive never fired (accepted-but-inert). It is now a
+typed `setSchema` leaf (`ValueInteger`, `ValidateInteger(1, 2880)`) AND is wired
+to a runtime timer: `daemon.reconcileArchiveTimer` (called from
+`applyConfigLocked`, mirroring `reconcileRPM`) arms `runArchiveTimer`, which
+fires every N minutes and archives the CURRENT active config via the SAME
+`archiveToSites` transport `transfer-on-commit` uses (`daemon_flow.go`). The two
+compose — either, both, or neither. The timer is hash-gated on
+`(interval, sites)` so an unrelated commit never bounces a healthy timer; a
+change to the interval or the site set reschedules; removing the leaf (or
+dropping to interval 0 / no sites) stops it; and it re-arms on daemon restart
+because the boot apply runs the same reconcile against the active config.
+Periodic archival needs BOTH a positive interval AND at least one archive-site;
+a bare `transfer-on-commit` config never spins a periodic goroutine.
+
 **`valueList` — a bracketed value list on a multi leaf that ALSO has a
 modifier child (#3872).** The bracket-absorption above fires only for a
 `multi: true` leaf with `children: nil`. The static-route `next-hop` leaf is

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -68,6 +68,14 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 	"archival": {desc: "Configuration archival", children: map[string]*schemaNode{
 		"configuration": {desc: "Configuration archival", children: map[string]*schemaNode{
 			"transfer-on-commit": {desc: "Transfer on commit", children: nil},
+			// #4078: periodic off-box archive every N minutes, independent of
+			// transfer-on-commit. Parsed+compiled since the leaf was added, but
+			// the runtime periodic timer (reconcileArchiveTimer) that consumes
+			// it landed in #4078 — before that this leaf was accepted-but-inert.
+			"transfer-interval": {desc: "Periodic archive interval (minutes)", args: 1,
+				valueType: ValueInteger, valueDesc: "Minutes between periodic archives",
+				valueExamples: []string{"30", "60", "1440"},
+				validator:     ValidateInteger(1, 2880), placeholder: "<minutes>", children: nil},
 			// #3984: a repeated keyed-list leaf — an operator writes one
 			// `set ... archive-sites <url>` per site and the compiler reads
 			// every sibling via FindChildren (compiler_system.go). Without

--- a/pkg/daemon/archive_timer_4078_test.go
+++ b/pkg/daemon/archive_timer_4078_test.go
@@ -1,0 +1,200 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// storeWithHost builds a config store, commits a config carrying the given
+// host-name, and returns the store. ShowActive on the returned store therefore
+// contains host-name <host>, letting the archive tests assert the periodic
+// timer uploaded the CURRENT active config.
+func storeWithHost(t *testing.T, host string) (*Daemon, chan string, chan time.Time, *int32) {
+	t.Helper()
+	dir := t.TempDir()
+	store := newConfigStore(t, filepath.Join(dir, "config.db"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := store.SetFromInput("system host-name " + host); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	tickCh := make(chan time.Time, 1)
+	captured := make(chan string, 8)
+	var transfers int32
+	d := &Daemon{
+		store: store,
+		opts:  Options{ConfigFile: filepath.Join(dir, "xpf.conf")},
+		archiveNewTicker: func(time.Duration) (<-chan time.Time, func()) {
+			return tickCh, func() {}
+		},
+		archiveTransfer: func(_ context.Context, srcPath, _ string) error {
+			b, _ := os.ReadFile(srcPath)
+			atomic.AddInt32(&transfers, 1)
+			captured <- string(b)
+			return nil
+		},
+	}
+	return d, captured, tickCh, &transfers
+}
+
+// TestArchiveTimerFiresPeriodicArchive pins the #4078 fix: with
+// `transfer-interval N` + archive-sites configured, a periodic timer archives
+// the CURRENT active config to the sites — independent of transfer-on-commit.
+//
+// RED on revert: without the reconcileArchiveTimer/runArchiveTimer wiring the
+// leaf is accepted-but-inert (compiled into TransferInterval but never read at
+// runtime), so no goroutine consumes the tick and no transfer ever fires — the
+// `<-captured` receive below times out and the test FAILS.
+func TestArchiveTimerFiresPeriodicArchive(t *testing.T) {
+	d, captured, tickCh, transfers := storeWithHost(t, "periodic-host")
+
+	cfg := &config.Config{}
+	// NOTE: transfer-on-commit deliberately NOT set — periodic archival must
+	// fire on its own timer, not only on commit.
+	cfg.System.Archival = &config.ArchivalConfig{
+		TransferInterval: 30,
+		ArchiveSites:     []string{"scp://user@host:/archive/"},
+	}
+
+	d.reconcileArchiveTimer(cfg)
+	t.Cleanup(d.stopArchiveTimer)
+
+	d.archiveTimerMu.Lock()
+	armed := d.archiveTimerStop != nil
+	d.archiveTimerMu.Unlock()
+	if !armed {
+		t.Fatal("timer not armed for transfer-interval + sites")
+	}
+
+	// Fire one tick; the periodic archive must invoke the archive-to-site path.
+	tickCh <- time.Now()
+	select {
+	case got := <-captured:
+		if !strings.Contains(got, "periodic-host") {
+			t.Fatalf("periodic archive uploaded wrong config: %q", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("periodic archive never fired — transfer-interval is inert (RED on revert)")
+	}
+
+	// A second tick archives again (it is a repeating timer, not one-shot).
+	tickCh <- time.Now()
+	select {
+	case <-captured:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second periodic archive never fired")
+	}
+	if n := atomic.LoadInt32(transfers); n < 2 {
+		t.Fatalf("expected >= 2 periodic transfers, got %d", n)
+	}
+}
+
+// TestArchiveTimerReschedulesAndStops covers the timer lifecycle: unchanged
+// config does not bounce a healthy timer, an interval change reschedules
+// (old goroutine stopped, new one armed), and removing the leaf stops it.
+func TestArchiveTimerReschedulesAndStops(t *testing.T) {
+	d, _, _, _ := storeWithHost(t, "lifecycle-host")
+	t.Cleanup(d.stopArchiveTimer)
+
+	cfg1 := &config.Config{}
+	cfg1.System.Archival = &config.ArchivalConfig{
+		TransferInterval: 30,
+		ArchiveSites:     []string{"scp://user@host:/archive/"},
+	}
+	d.reconcileArchiveTimer(cfg1)
+
+	d.archiveTimerMu.Lock()
+	gen1 := d.archiveTimerStop
+	d.archiveTimerMu.Unlock()
+	if gen1 == nil {
+		t.Fatal("timer not armed by cfg1")
+	}
+
+	// Unchanged config → same generation, no bounce.
+	d.reconcileArchiveTimer(cfg1)
+	d.archiveTimerMu.Lock()
+	same := d.archiveTimerStop
+	d.archiveTimerMu.Unlock()
+	if same != gen1 {
+		t.Fatal("healthy timer bounced on an unchanged config (hash gate broken)")
+	}
+
+	// Change the interval → reschedule: old goroutine stopped, new one armed.
+	cfg2 := &config.Config{}
+	cfg2.System.Archival = &config.ArchivalConfig{
+		TransferInterval: 60,
+		ArchiveSites:     []string{"scp://user@host:/archive/"},
+	}
+	d.reconcileArchiveTimer(cfg2)
+	select {
+	case <-gen1:
+	default:
+		t.Fatal("old timer not stopped on reschedule")
+	}
+	d.archiveTimerMu.Lock()
+	gen2 := d.archiveTimerStop
+	d.archiveTimerMu.Unlock()
+	if gen2 == nil || gen2 == gen1 {
+		t.Fatal("no fresh timer armed after reschedule")
+	}
+
+	// Remove the archival stanza → stop.
+	d.reconcileArchiveTimer(&config.Config{})
+	select {
+	case <-gen2:
+	default:
+		t.Fatal("timer not stopped when transfer-interval removed")
+	}
+	d.archiveTimerMu.Lock()
+	after := d.archiveTimerStop
+	d.archiveTimerMu.Unlock()
+	if after != nil {
+		t.Fatal("timer still armed after removal")
+	}
+}
+
+// TestArchiveTimerRequiresSitesAndPositiveInterval verifies the timer is NOT
+// armed when there is nothing to archive to (no sites) or the interval is 0
+// (transfer-on-commit-only), so a bare `transfer-on-commit` config never spins
+// a pointless periodic goroutine.
+func TestArchiveTimerRequiresSitesAndPositiveInterval(t *testing.T) {
+	d, _, _, _ := storeWithHost(t, "gate-host")
+	t.Cleanup(d.stopArchiveTimer)
+
+	// interval set but no sites → not armed.
+	cfg := &config.Config{}
+	cfg.System.Archival = &config.ArchivalConfig{TransferInterval: 30}
+	d.reconcileArchiveTimer(cfg)
+	d.archiveTimerMu.Lock()
+	armed := d.archiveTimerStop != nil
+	d.archiveTimerMu.Unlock()
+	if armed {
+		t.Fatal("timer armed with no archive-sites")
+	}
+
+	// transfer-on-commit only (interval 0) with sites → not armed.
+	cfg2 := &config.Config{}
+	cfg2.System.Archival = &config.ArchivalConfig{
+		TransferOnCommit: true,
+		ArchiveSites:     []string{"scp://user@host:/archive/"},
+	}
+	d.reconcileArchiveTimer(cfg2)
+	d.archiveTimerMu.Lock()
+	armed2 := d.archiveTimerStop != nil
+	d.archiveTimerMu.Unlock()
+	if armed2 {
+		t.Fatal("timer armed for transfer-on-commit-only (interval 0)")
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -627,6 +627,22 @@ type Daemon struct {
 	// d.opts.ConfigFile (#3867).
 	archiveTransfer func(ctx context.Context, srcPath, dest string) error
 
+	// --- periodic configuration-archival timer (#4078) ---
+	// archiveTimerMu guards archiveTimerKey + archiveTimerStop.
+	archiveTimerMu sync.Mutex
+	// archiveTimerKey is the (interval|sites) hash the running periodic-archival
+	// timer was armed for; "" ⇒ no timer running. reconcileArchiveTimer compares
+	// against it so an unrelated commit never bounces a healthy timer.
+	archiveTimerKey string
+	// archiveTimerStop is closed to stop the running periodic-archival goroutine
+	// (reschedule on a transfer-interval/site change, or shutdown). nil ⇒ none.
+	archiveTimerStop chan struct{}
+	// archiveNewTicker builds the periodic-archival tick channel + a stop func.
+	// nil ⇒ realArchiveTicker (a wall-clock time.Ticker). Overridable so tests
+	// drive the periodic archive deterministically without a wall-clock wait
+	// and assert it reuses the archiveToSites transport (#4078).
+	archiveNewTicker func(d time.Duration) (<-chan time.Time, func())
+
 	// --- SNMP link-state monitor seams (#3950) ---
 	// linkStateSubscribe starts a netlink link-update subscription for the
 	// SNMP link-state monitor. It MUST stream updates to ch and close ch when

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1443,6 +1443,13 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 		d.store.SetArchiveConfig("", 0)
 	}
 
+	// 15c. Reconcile the periodic configuration-archival timer (#4078). Junos
+	// `transfer-interval N` archives the running config to the archive-sites
+	// every N minutes, independent of transfer-on-commit. Hash-gated so an
+	// unrelated commit never bounces a healthy timer; re-armed on daemon
+	// restart via this same boot apply; stopped when the leaf is removed.
+	d.reconcileArchiveTimer(cfg)
+
 	// 16. Update flow traceoptions (trace file + filters)
 	d.updateFlowTrace(cfg)
 

--- a/pkg/daemon/daemon_archive_timer.go
+++ b/pkg/daemon/daemon_archive_timer.go
@@ -1,0 +1,126 @@
+package daemon
+
+import (
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// realArchiveTicker is the default archiveNewTicker seam: a wall-clock
+// time.Ticker firing every d. Tests override d.archiveNewTicker to drive the
+// periodic archive deterministically without a wall-clock wait (#4078).
+func realArchiveTicker(d time.Duration) (<-chan time.Time, func()) {
+	t := time.NewTicker(d)
+	return t.C, t.Stop
+}
+
+// archiveTimerKey collapses (interval, sites) into a stable string so
+// reconcileArchiveTimer can hash-gate: an unrelated commit that leaves the
+// periodic-archival config untouched must NOT bounce a healthy timer. An empty
+// key means "no periodic archival" (interval <= 0 or no sites).
+func archiveTimerKey(interval int, sites []string) string {
+	if interval <= 0 || len(sites) == 0 {
+		return ""
+	}
+	return strconv.Itoa(interval) + "|" + strings.Join(sites, "\x00")
+}
+
+// reconcileArchiveTimer starts, reschedules, or stops the periodic
+// configuration-archival timer (#4078). Junos `system archival configuration
+// transfer-interval <minutes>` archives the running config to the configured
+// archive-sites every N minutes, independent of transfer-on-commit — a
+// periodic off-box backup for a config that rarely changes but should still be
+// backed up. Before this the leaf was parsed and compiled
+// (config.ArchivalConfig.TransferInterval) but no runtime consumer existed, so
+// the timed archive never fired.
+//
+// Lifecycle (mirrors reconcileRPM / reconcileFlowExporters): called from
+// applyConfigLocked on every commit/boot apply. Hash-gated on (interval, sites)
+// so an unrelated commit leaves a running timer alone; a change to the interval
+// or the site set stops the old goroutine and starts a fresh one; removing the
+// leaf (or dropping to 0 / no sites) stops it. Re-armed on daemon restart
+// because the boot apply runs this same reconcile against the active config.
+func (d *Daemon) reconcileArchiveTimer(cfg *config.Config) {
+	interval := 0
+	var sites []string
+	if cfg != nil && cfg.System.Archival != nil {
+		interval = cfg.System.Archival.TransferInterval
+		sites = cfg.System.Archival.ArchiveSites
+	}
+	// Periodic archival needs a positive interval AND at least one site;
+	// otherwise there is nothing to schedule.
+	if interval <= 0 || len(sites) == 0 {
+		interval, sites = 0, nil
+	}
+	key := archiveTimerKey(interval, sites)
+
+	d.archiveTimerMu.Lock()
+	defer d.archiveTimerMu.Unlock()
+	if key == d.archiveTimerKey {
+		return // unchanged — do not bounce a healthy timer
+	}
+	// Stop the currently-running timer (if any) before (re)scheduling.
+	if d.archiveTimerStop != nil {
+		close(d.archiveTimerStop)
+		d.archiveTimerStop = nil
+	}
+	d.archiveTimerKey = key
+	if interval <= 0 {
+		slog.Info("periodic config archival disabled")
+		return
+	}
+	stop := make(chan struct{})
+	d.archiveTimerStop = stop
+	sitesCopy := append([]string(nil), sites...)
+	go d.runArchiveTimer(interval, sitesCopy, stop)
+	slog.Info("periodic config archival scheduled",
+		"interval_minutes", interval, "sites", len(sitesCopy))
+}
+
+// runArchiveTimer fires every `interval` minutes and archives the CURRENT
+// active config to `sites` via the shared archiveToSites path (the same
+// transport transfer-on-commit uses — the periodic archive always reflects the
+// latest committed config, no daemon restart required). Exits when its
+// per-generation stop channel is closed (reschedule/removal via
+// reconcileArchiveTimer) or the daemon-stop context is cancelled. #4078.
+func (d *Daemon) runArchiveTimer(interval int, sites []string, stop <-chan struct{}) {
+	newTicker := d.archiveNewTicker
+	if newTicker == nil {
+		newTicker = realArchiveTicker
+	}
+	tickC, tickStop := newTicker(time.Duration(interval) * time.Minute)
+	defer tickStop()
+
+	// Secondary shutdown guard: the daemon-stop context (nil at early boot, in
+	// which case stopArchiveTimer in the teardown sequence is the authoritative
+	// stop). A nil channel blocks forever in select — harmless.
+	var ctxDone <-chan struct{}
+	if d.applyCancelContext != nil {
+		ctxDone = d.applyCancelContext.Done()
+	}
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ctxDone:
+			return
+		case <-tickC:
+			d.archiveToSites(sites)
+		}
+	}
+}
+
+// stopArchiveTimer stops the periodic archival timer at daemon shutdown. Safe
+// to call when no timer is running. #4078.
+func (d *Daemon) stopArchiveTimer() {
+	d.archiveTimerMu.Lock()
+	defer d.archiveTimerMu.Unlock()
+	if d.archiveTimerStop != nil {
+		close(d.archiveTimerStop)
+		d.archiveTimerStop = nil
+	}
+	d.archiveTimerKey = ""
+}

--- a/pkg/daemon/daemon_flow.go
+++ b/pkg/daemon/daemon_flow.go
@@ -235,6 +235,22 @@ func (d *Daemon) archiveConfig(cfg *config.Config) {
 	if len(cfg.System.Archival.ArchiveSites) == 0 {
 		return
 	}
+	d.archiveToSites(cfg.System.Archival.ArchiveSites)
+}
+
+// archiveToSites serializes the CURRENT active configuration (Store.ShowActive
+// — the same hierarchical text `show configuration` renders) to a transient
+// 0600 temp file and uploads it to every archive site via the archiveTransfer
+// seam (default scpArchiveTransfer). It is the shared archive-to-site path used
+// by BOTH transfer-on-commit (archiveConfig, invoked on each commit apply) and
+// the periodic transfer-interval timer (runArchiveTimer, #4078) — the periodic
+// path reuses this exact transport rather than reimplementing it. The uploaded
+// remote filename preserves the historical basename (the boot-file basename,
+// default xpf.conf).
+func (d *Daemon) archiveToSites(sites []string) {
+	if len(sites) == 0 {
+		return
+	}
 	if d.store == nil {
 		slog.Warn("config archival skipped: no configuration store")
 		return
@@ -277,7 +293,7 @@ func (d *Daemon) archiveConfig(cfg *config.Config) {
 	}
 
 	var wg sync.WaitGroup
-	for _, site := range cfg.System.Archival.ArchiveSites {
+	for _, site := range sites {
 		wg.Add(1)
 		go func(dest string) {
 			defer wg.Done()

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1647,6 +1647,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 		d.rpm.StopAll()
 	}
 
+	// Stop the periodic configuration-archival timer (#4078). Its goroutine
+	// binds to a per-generation stop channel (not the run WaitGroup), so this
+	// explicit stop is the authoritative shutdown for the boot-armed timer,
+	// whose captured daemon-stop context may predate applyCancelContext.
+	d.stopArchiveTimer()
+
 	// Stop the event-options action worker (after RPM so no events arrive
 	// during teardown). Close drains in-flight lock-retry backoffs (#2157).
 	if d.eventEngine != nil {


### PR DESCRIPTION
Closes #4078.

## Problem (fable-161 F-060, verified)

Junos `system archival configuration transfer-interval <minutes>`
archives the running config to the configured `archive-sites` every N
minutes, independent of `transfer-on-commit` — a periodic off-box backup
for a config that rarely changes but should still be backed up.

The leaf was parsed and compiled into
`config.ArchivalConfig.TransferInterval` (with parser tests in
`pkg/config/parser_system_test.go`) but **no runtime consumer read it**.
The only archive path was `archiveConfig`, gated on `TransferOnCommit`
and invoked from `applyConfigLocked` on each commit. `grep TransferInterval
pkg/daemon/` returned zero hits — accepted-but-inert. So configuring
`transfer-interval 60` produced no periodic archive.

## Fix (Go control-plane only, reuses the existing archive transport)

- **Extract `archiveToSites(sites)`** out of `archiveConfig`
  (`daemon_flow.go`): serialize `Store.ShowActive` to a 0600 temp file
  and scp it to each site via the `archiveTransfer` seam. `archiveConfig`
  keeps its transfer-on-commit gate and delegates — commit behavior is
  byte-identical (first commit is a pure refactor).
- **`reconcileArchiveTimer` / `runArchiveTimer` / `stopArchiveTimer`**
  (new `daemon_archive_timer.go`), mirroring `reconcileRPM`. Called from
  `applyConfigLocked` (new step 15c). Hash-gated on `(interval, sites)`
  so an unrelated commit never bounces a healthy timer; an interval/site
  change reschedules; removing the leaf (or interval ≤ 0 / no sites)
  stops it; re-arms on daemon restart via the boot apply.
- **`runArchiveTimer`** fires every N minutes and archives via the shared
  `archiveToSites` path — always the CURRENT active config
  (`Store.ShowActive` read per tick). Exits on its per-generation stop
  channel or the daemon-stop context; `stopArchiveTimer` in the shutdown
  teardown is the authoritative stop. Composes with transfer-on-commit.
- **`transfer-interval` typed `setSchema` leaf**
  (`ValueInteger`, `ValidateInteger(1, 2880)`) for completion + value
  help + commit-check. The schema was already lenient on the keyword, so
  this only adds validation/UX.
- Wall-clock ticker behind the `archiveNewTicker` seam so tests are
  deterministic.

## Tests (`pkg/daemon/archive_timer_4078_test.go`)

- `TestArchiveTimerFiresPeriodicArchive` — arms a timer, fires ticks,
  asserts the archive path uploads the current active config.
  **RED on revert:** neutering the `archiveToSites` call in
  `runArchiveTimer` makes this fail ("periodic archive never fired —
  transfer-interval is inert"). Confirmed.
- `TestArchiveTimerReschedulesAndStops` — unchanged config does not
  bounce the timer; interval change reschedules; removal stops it.
- `TestArchiveTimerRequiresSitesAndPositiveInterval` — no timer without
  a positive interval AND ≥1 site (a bare `transfer-on-commit` config
  never spins a periodic goroutine).

## Validation

`go build ./...`, `go vet`, `gofmt` clean; `go test ./pkg/config/...
./pkg/daemon/... ./pkg/configstore/...` green; archive tests green under
`-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
