### PR TITLE
nat: translate ICMP query-id in pool SNAT (RFC 5508 §3.1, #4074)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -31951,3 +31951,37 @@ top.
   - **File(s)**: pkg/config/compiler_nat.go,
     pkg/config/compiler_nat_pool_alarm_test.go,
     docs/deterministic-nat-cgnat.md, docs/config-schema.md, _Log.md
+- **Timestamp**: 2026-07-04
+  - **Action**: #4074 (RFC 5508 §3.1 "ICMP Query Mappings") — pool-mode source
+    NAT now translates the ICMP/ICMPv6 Query Identifier. The flow parser lifts
+    an echo/query Identifier into the tuple `src_port` (dst_port 0), so it is
+    the ICMP demux key exactly like a TCP/UDP port. Before this, pool SNAT took
+    the port-less address-only path for ICMP (`rewrite_src_port` unset), so two
+    internal hosts pinging the same target with the same id, both hidden behind
+    one pool address, collided on the reverse tuple `(pool_addr, id)` → replies
+    mis-associated. Fix, three coordinated parts: (1) nat/source.rs — an
+    identifier-bearing ICMP flow (`src_port != 0`) now takes the PAT
+    `allocate_translation` path, drawing a unique translated id from the pool
+    id space (mirrors the TCP/UDP port allocation; `no_translation` and
+    flowless/non-identifier ICMP stay address-only). (2) session/key.rs — the
+    ICMP arm of forward_wire_key / reverse_wire_key / translated_session_key /
+    reverse_session_key folds the translated id into `src_port` (symmetric
+    field, dst_port stays 0), so the reverse index + companion session demux on
+    the translated id. No-op when `rewrite_src_port` is None (interface-mode,
+    static, DNAT, no-NAT unchanged). (3) afxdp/frame/mod.rs —
+    `apply_nat_icmp_identifier_rewrite` rewrites the Identifier at l4+4 and
+    repairs the ICMP checksum incrementally, both directions (forward
+    orig→translated via `rewrite_src_port`, reverse translated→orig via the
+    `rewrite_dst_port` produced by `NatDecision::reverse`); gated on an
+    identifier-bearing ICMP type so error/control messages are untouched; the
+    ICMPv6 pseudo-header address delta is already folded by the IP-rewrite
+    section, ICMPv4 has no pseudo-header. ICMP is never flow-cached, so the
+    TCP/UDP descriptor fast path is unaffected. RED-on-revert: distinct
+    translated ids per host + distinct reverse keys (nat + session tests);
+    on-wire identifier + checksum forward/reverse (frame v4 + v6 tests).
+    Validated: FULL `cargo test --release`, `go build ./...`, rustfmt.
+  - **File(s)**: userspace-dp/src/nat/source.rs,
+    userspace-dp/src/nat/tests.rs, userspace-dp/src/session/key.rs,
+    userspace-dp/src/session/tests.rs, userspace-dp/src/afxdp/frame/mod.rs,
+    userspace-dp/src/afxdp/frame/tests.rs,
+    docs/userspace-dataplane-architecture.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -31985,3 +31985,35 @@ top.
     userspace-dp/src/session/tests.rs, userspace-dp/src/afxdp/frame/mod.rs,
     userspace-dp/src/afxdp/frame/tests.rs,
     docs/userspace-dataplane-architecture.md, _Log.md
+- **Timestamp**: 2026-07-04
+  - **Action**: #4074 review fold (PR #4086, MERGE-NEEDS-MINOR) — fix a
+    reachable DNAT regression introduced by the ICMP query-id rewriter. The new
+    `apply_nat_icmp_identifier_rewrite` fires on `rewrite_src_port.or(rewrite_
+    dst_port)`. A forward DNAT to a POOLED PORT that is UNSCOPED by protocol/
+    destination-port (`validateDNATPoolStrict` does NOT require a
+    `match destination-port`, unlike static NAT) produces, for an ICMP echo, a
+    NatDecision `{rewrite_dst_port=Some(pool_port)}` → the `.or()` fired the
+    identifier rewrite for the DNAT case too → ICMP ping through that rule got
+    its Query Identifier corrupted to the pool port (pre-PR it was address-
+    only). Fix in the DECISION layer, NOT the frame fn (the LEGITIMATE reverse
+    pool-SNAT reply is also ICMP-with-rewrite_dst_port, from
+    `NatDecision::reverse`, and MUST still fire): gate `rewrite_dst_port` on
+    `has_l4_ports(protocol)` in the DNAT lookup
+    (`DnatTable::lookup_with_counter_scoped`, destination.rs — capture the
+    predicate before `protocol` is widened to the u16 key space). A port-less
+    protocol (ICMP/ICMPv6/GRE) now keeps `rewrite_dst_port = None` (address-only
+    DNAT). Static NAT needs no gate — it is ICMP-safe by construction (the build
+    maps `match_destination_port == 0` to `(None, None)`, so a port-mapped entry
+    is always keyed `(ip, Some(nonzero))` which dst_port-0 ICMP can never match,
+    and the whole-address `(ip, None)` bucket only holds `mapped_port = None`);
+    documented at the static DNAT decision site. NAT64 already sets
+    `rewrite_dst_port: None`. RED-on-revert: `dnat_pooled_port_does_not_
+    translate_icmp_identifier` (decision-layer: ICMP DNAT → rewrite_dst_port
+    None, TCP control still Some(8080)) +
+    `rewrite_forwarded_frame_in_place_dnat_preserves_icmpv4_identifier` (wire-
+    level: identifier preserved, checksum valid). Existing pool-SNAT id tests +
+    the reverse pool-SNAT reply still pass. Validated: FULL `cargo test
+    --release`, `go build ./...`, rustfmt.
+  - **File(s)**: userspace-dp/src/nat/destination.rs,
+    userspace-dp/src/nat/static_nat.rs, userspace-dp/src/nat/tests.rs,
+    userspace-dp/src/afxdp/frame/tests.rs, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -32017,3 +32017,38 @@ top.
   - **File(s)**: userspace-dp/src/nat/destination.rs,
     userspace-dp/src/nat/static_nat.rs, userspace-dp/src/nat/tests.rs,
     userspace-dp/src/afxdp/frame/tests.rs, _Log.md
+- **Timestamp**: 2026-07-04
+  - **Action**: #4074 Copilot fold (PR #4086) — fix a PR-introduced ICMP
+    reply-accounting regression (Finding 1). `account_packet` (session/mod.rs)
+    folds a REVERSE ICMP packet's volume onto the canonical FORWARD entry by
+    calling `reverse_session_key(reverse_entry_key, reverse_decision)` to
+    recover the forward key. Pool-SNAT translated the ICMP id X->Y, so the
+    reverse entry is keyed on Y and `NatDecision::reverse` stored the ORIGINAL
+    id X in `rewrite_dst_port`. The PR's `reverse_session_key` ICMP arm read
+    only `rewrite_src_port` (None on the reverse decision) -> yielded Y ->
+    MISSED the forward entry {..,X,..} -> the reply volume was mis-accounted
+    onto the reverse entry, so the forward-only conntrack mirror / SESSION_CLOSE
+    / NetFlow / IPFIX under-counted reply-direction volume for translated ICMP.
+    Fix: the ICMP arm now reads `rewrite_src_port.or(rewrite_dst_port)` — the id
+    is a symmetric field and at most one of the two is set (SNAT sets only
+    src_port forward; its `.reverse()` sets only dst_port; ICMP DNAT is gated to
+    no L4 port), so `.or()` recovers Y forward->reverse and X reverse->forward.
+    Forward->reverse callers (session_delta/ha/bpf_map/publish_conntrack/
+    session_glue/coordinator/types) are UNCHANGED (rewrite_dst_port is None
+    there). `reverse_wire_key` (the demux, forward->reverse only) is correct and
+    untouched. RED-on-revert: account_packet_reverse_folds_onto_forward_
+    translated_icmp (v4 + v6) — a reverse ICMP packet bumps the FORWARD entry's
+    rev_* (reverting the arm to src_port-only misses the forward entry -> RED).
+    Finding 2 (id==0 edge): the `icmp_query = ... && src_port != 0` gate
+    misclassifies an identifier-bearing ICMP query with id==0 as flowless (both
+    Some((0,0)) and None flatten to src_port 0), so an id==0 echo is not
+    translated and two id==0 flows collide on (pool_addr, 0). REPORTED for a
+    follow-up rather than folded: the clean signal (parse_flow_ports Some vs
+    None) would thread a new bool through SessionFlow (83 construction literals,
+    a hot per-packet struct) or `match_source_nat_result_for_tuple` (28 call
+    sites) — a moderate-to-large refactor for a rare edge (standard ping uses a
+    nonzero PID as the id; id==0 is uncommon on-wire) that is strictly better
+    than pre-PR either way (pre-PR ALL ids collided; now only id==0). Validated:
+    FULL `cargo test --release`, `go build ./...`, rustfmt.
+  - **File(s)**: userspace-dp/src/session/key.rs,
+    userspace-dp/src/session/tests.rs, _Log.md

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -601,7 +601,20 @@ the NAT module applies it:
 - **SNAT (interface mode):** Rewrite source IP to egress interface address.
   Source port preserved.
 - **SNAT (pool mode):** Rewrite source IP to a configured source pool address
-  and allocate a source port from the pool range. By default, pool address
+  and allocate a source port from the pool range. For an ICMP/ICMPv6 echo or
+  query message the 16-bit **Query Identifier** plays the role of the L4 port
+  (RFC 5508 §3.1 "ICMP Query Mappings"): the flow parser lifts it into the
+  tuple `src_port` slot, so pool mode allocates a unique translated identifier
+  from the same pool id space, rewrites the ICMP Identifier field, and repairs
+  the ICMP checksum incrementally (`apply_nat_icmp_identifier_rewrite`,
+  #4074). This lets many internal hosts pinging one target with the same id
+  share a single pool address without colliding on the reverse tuple
+  `(pool_addr, id)`; the reverse companion session and the reply un-NAT are
+  keyed on the translated id. A non-identifier ICMP control/error message
+  parses flowless (`src_port == 0`) and, like a genuinely port-less protocol
+  (GRE/ESP/AH/OSPF), takes the address-only path — its L4 bytes are never
+  rewritten. `port no-translation` preserves the id just as it preserves a
+  TCP/UDP source port. By default, pool address
   selection is round-robin within the packet address family. With global source
   NAT `address-persistent`, the userspace dataplane hashes a domain-tag seed,
   address family, and canonical source IP bytes with a seeded non-cryptographic

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -95,6 +95,9 @@ pub(in crate::afxdp) use tcp::{
     frame_has_tcp_rst,
 };
 pub(super) use tcp::{extract_tcp_flags_and_window, extract_tcp_window, tcp_flags_str};
+// #4074: the ICMP identifier-bearing query-type gate, reused by the NAT
+// identifier rewriter (`apply_nat_icmp_identifier_rewrite`).
+use inspect::icmp_identifier_bearing;
 // #1352: clamp_tcp_mss_frame is now imported directly by the per-family
 // helpers in frame/build/{ipv4,ipv6}.rs.
 
@@ -862,6 +865,9 @@ pub(super) fn apply_nat_ipv4(
     // #1852: skip on a non-first fragment — the port bytes are payload.
     if !non_first_fragment {
         apply_nat_port_rewrite(packet, ihl, protocol, ChecksumFamily::V4, nat)?;
+        // #4074: translate the ICMP Query Identifier (RFC 5508 §3.1). No-op
+        // for TCP/UDP and for any ICMP decision without a translated id.
+        apply_nat_icmp_identifier_rewrite(packet, ihl, protocol, ChecksumFamily::V4, nat)?;
     }
 
     Some(())
@@ -987,6 +993,10 @@ pub(super) fn apply_nat_ipv6(
     // #1852: skip on a non-first fragment — the port bytes are payload.
     if !non_first_fragment {
         apply_nat_port_rewrite(packet, rel_l4, protocol, ChecksumFamily::V6, nat)?;
+        // #4074: translate the ICMPv6 Query Identifier (RFC 5508 §3.1). The
+        // pseudo-header address delta is already folded above; this adds only
+        // the identifier delta.
+        apply_nat_icmp_identifier_rewrite(packet, rel_l4, protocol, ChecksumFamily::V6, nat)?;
     }
 
     Some(())
@@ -1066,6 +1076,80 @@ pub(in crate::afxdp::frame) fn apply_nat_port_rewrite(
         }
     }
 
+    Some(())
+}
+
+/// #4074 (RFC 5508 §3.1 "ICMP Query Mappings"): rewrite the ICMP / ICMPv6
+/// Query Identifier and repair the ICMP checksum incrementally.
+///
+/// The identifier is a single 16-bit field at `l4_offset + 4` — the same
+/// offset in BOTH families and BOTH directions (`type[0] code[1]
+/// checksum[2..4] identifier[4..6] sequence[6..8]`) — and it is the ICMP
+/// demux key that pool-mode SNAT translates so two internal hosts pinging the
+/// same target with the same id, both hidden behind one pool address, do not
+/// collide on the reverse tuple `(pool_addr, id)`. Because the field is
+/// symmetric, the forward NAT decision carries the translated id in
+/// `rewrite_src_port` while the reverse (reply) decision — produced by
+/// `NatDecision::reverse` — carries the ORIGINAL id in `rewrite_dst_port`. At
+/// most one of the two is set for an ICMP flow, so the new identifier is
+/// `rewrite_src_port.or(rewrite_dst_port)`.
+///
+/// Gated on the ICMP type being an identifier-bearing query (echo / timestamp
+/// / information for ICMPv4, echo for ICMPv6): an error or control message's
+/// `l4+4` bytes are a gateway address / next-hop MTU / pointer / reserved
+/// field, NOT an identifier, and must never be touched — the same query-type
+/// gate `parse_flow_ports` applies when it lifts the id into the session tuple.
+///
+/// For ICMPv6 the pseudo-header address change is already folded into the
+/// checksum by the caller's IP-rewrite section (`adjust_l4_checksum_ipv6_*`,
+/// which handles `PROTO_ICMPV6`); here only the identifier delta is applied.
+/// ICMPv4 has no pseudo-header, so the SNAT address change never affects the
+/// ICMPv4 checksum and only the identifier delta matters.
+// #[inline(always)]: `family` and the protocol match are constants at both
+// call sites, so the whole body folds out of the TCP/UDP NAT path.
+#[inline(always)]
+pub(in crate::afxdp::frame) fn apply_nat_icmp_identifier_rewrite(
+    packet: &mut [u8],
+    l4_offset: usize,
+    protocol: u8,
+    family: ChecksumFamily,
+    nat: NatDecision,
+) -> Option<()> {
+    if !matches!(protocol, PROTO_ICMP | PROTO_ICMPV6) {
+        return Some(());
+    }
+    let Some(new_ident) = nat.rewrite_src_port.or(nat.rewrite_dst_port) else {
+        return Some(());
+    };
+    // Need type[0], checksum[2..4], and identifier[4..6].
+    if packet.len() < l4_offset + 6 {
+        return Some(());
+    }
+    // The l4+4 bytes are an identifier ONLY for query types (echo / timestamp /
+    // information). Anything else keeps its bytes untouched (fail closed).
+    if !icmp_identifier_bearing(protocol, packet[l4_offset]) {
+        return Some(());
+    }
+    let old_ident = u16::from_be_bytes([packet[l4_offset + 4], packet[l4_offset + 5]]);
+    if old_ident == new_ident {
+        return Some(());
+    }
+    packet
+        .get_mut(l4_offset + 4..l4_offset + 6)?
+        .copy_from_slice(&new_ident.to_be_bytes());
+    // ICMP checksum field is at l4+2 in both families.
+    let csum_off = l4_offset + 2;
+    let current = u16::from_be_bytes([*packet.get(csum_off)?, *packet.get(csum_off + 1)?]);
+    let mut updated = checksum16_adjust(current, &[old_ident], &[new_ident]);
+    // ICMPv6 forbids a transmitted 0x0000 checksum (RFC 8200 §8.1); a v4 ICMP
+    // 0x0000 is a legal checksum value. `adjust_zero_checksum_illegal` is the
+    // shared SSOT for this rule (ICMPv6 canonicalizes, ICMPv4 does not).
+    if adjust_zero_checksum_illegal(protocol, family) && updated == 0 {
+        updated = 0xffff;
+    }
+    packet
+        .get_mut(csum_off..csum_off + 2)?
+        .copy_from_slice(&updated.to_be_bytes());
     Some(())
 }
 

--- a/userspace-dp/src/afxdp/frame/tests.rs
+++ b/userspace-dp/src/afxdp/frame/tests.rs
@@ -1932,6 +1932,295 @@ fn rewrite_forwarded_frame_in_place_keeps_icmpv6_echo_identifier_and_sequence() 
     assert!(icmpv6_checksum_ok(packet));
 }
 
+fn build_icmp_frame_v4(src: Ipv4Addr, dst: Ipv4Addr, ttl: u8, icmp_type: u8, id: u16) -> Vec<u8> {
+    let mut frame = Vec::new();
+    write_eth_header(
+        &mut frame,
+        [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff],
+        [0x00, 0x25, 0x90, 0x12, 0x34, 0x56],
+        0,
+        0x0800,
+    );
+    frame.extend_from_slice(&[
+        0x45, 0x00, 0x00, 0x1c, 0x00, 0x01, 0x00, 0x00, ttl, PROTO_ICMP, 0x00, 0x00,
+    ]);
+    frame.extend_from_slice(&src.octets());
+    frame.extend_from_slice(&dst.octets());
+    let ip_csum = checksum16(&frame[14..34]);
+    frame[24..26].copy_from_slice(&ip_csum.to_be_bytes());
+    let icmp_start = frame.len();
+    frame.extend_from_slice(&[
+        icmp_type,
+        0,
+        0x00,
+        0x00,
+        (id >> 8) as u8,
+        id as u8,
+        0x00,
+        0x01,
+    ]);
+    let icmp_csum = checksum16(&frame[icmp_start..]);
+    frame[icmp_start + 2..icmp_start + 4].copy_from_slice(&icmp_csum.to_be_bytes());
+    frame
+}
+
+fn build_icmpv6_echo_frame(
+    src: Ipv6Addr,
+    dst: Ipv6Addr,
+    hop: u8,
+    icmp_type: u8,
+    id: u16,
+) -> Vec<u8> {
+    let mut frame = Vec::new();
+    write_eth_header(
+        &mut frame,
+        [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff],
+        [0x00, 0x25, 0x90, 0x12, 0x34, 0x56],
+        0,
+        0x86dd,
+    );
+    frame.extend_from_slice(&[0x60, 0x00, 0x00, 0x00, 0x00, 0x08, PROTO_ICMPV6, hop]);
+    frame.extend_from_slice(&src.octets());
+    frame.extend_from_slice(&dst.octets());
+    frame.extend_from_slice(&[
+        icmp_type,
+        0,
+        0x00,
+        0x00,
+        (id >> 8) as u8,
+        id as u8,
+        0x00,
+        0x01,
+    ]);
+    let sum = checksum16_ipv6(src, dst, PROTO_ICMPV6, &frame[54..]);
+    frame[56] = (sum >> 8) as u8;
+    frame[57] = sum as u8;
+    frame
+}
+
+fn icmp_test_decision(nat: NatDecision) -> SessionDecision {
+    SessionDecision {
+        resolution: ForwardingResolution {
+            disposition: ForwardingDisposition::ForwardCandidate,
+            local_ifindex: 0,
+            egress_ifindex: 12,
+            tx_ifindex: 11,
+            tunnel_endpoint_id: 0,
+            next_hop: None,
+            neighbor_mac: Some([0xba, 0x86, 0xe9, 0xf6, 0x4b, 0xd5]),
+            src_mac: Some([0x02, 0xbf, 0x72, 0x00, 0x80, 0x08]),
+            tx_vlan_id: 0,
+        },
+        nat,
+    }
+}
+
+// #4074 FAIL-ON-REVERT (RFC 5508 §3.1): pool SNAT translates the ICMP Query
+// Identifier on the wire and repairs the ICMP checksum — forward (orig ->
+// translated) on egress and reverse (translated -> orig) on the reply.
+// Reverting `apply_nat_icmp_identifier_rewrite` leaves the identifier AND the
+// checksum untouched, turning the translated-id and checksum assertions RED.
+#[test]
+fn rewrite_forwarded_frame_in_place_translates_icmpv4_echo_identifier() {
+    let host = Ipv4Addr::new(10, 0, 1, 100);
+    let target = Ipv4Addr::new(8, 8, 8, 8);
+    let pool = Ipv4Addr::new(203, 0, 113, 1);
+    let orig_id: u16 = 0x1234;
+    let translated_id: u16 = 40001;
+    // `flow_src_port` carries the packet's on-wire ICMP identifier (the parser
+    // fills it); `restore_l4_tuple_from_meta` uses it, so it must match the
+    // frame — orig id on the request, translated id on the reply.
+    let meta_for = |flow_src_port: u16| UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+        l3_offset: 14,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_ICMP,
+        flow_src_port,
+        ..UserspaceDpMeta::default()
+    };
+    let meta = meta_for(orig_id);
+
+    // Forward: host -> target, echo request. SNAT src to pool + translate id.
+    let frame = build_icmp_frame_v4(host, target, 64, 8, orig_id);
+    let mut area = MmapArea::new(4096).expect("mmap");
+    area.slice_mut(0, frame.len())
+        .unwrap()
+        .copy_from_slice(&frame);
+    let fwd_nat = NatDecision {
+        rewrite_src: Some(IpAddr::V4(pool)),
+        rewrite_src_port: Some(translated_id),
+        ..NatDecision::default()
+    };
+    let res = rewrite_forwarded_frame_in_place(
+        &area,
+        XdpDesc {
+            addr: 0,
+            len: frame.len() as u32,
+            options: 0,
+        },
+        meta,
+        &icmp_test_decision(fwd_nat),
+        false,
+        None,
+    )
+    .expect("fwd rewrite");
+    let out = area
+        .slice(res.offset as usize, res.len as usize)
+        .expect("fwd out");
+    // eth 14 + ip 20 => icmp at 34; type@34, identifier@38..40.
+    assert_eq!(out[34], 8, "still an echo request");
+    assert_eq!(&out[26..30], &pool.octets(), "src translated to pool");
+    assert_eq!(
+        u16::from_be_bytes([out[38], out[39]]),
+        translated_id,
+        "identifier translated on the wire",
+    );
+    assert_eq!(
+        checksum16(&out[34..]),
+        0,
+        "ICMPv4 checksum valid after id rewrite",
+    );
+
+    // Reverse: reply target -> pool carries the translated id; un-NAT restores
+    // the original id and dst. Use the real NatDecision::reverse inversion.
+    let reply = build_icmp_frame_v4(target, pool, 64, 0, translated_id);
+    let mut rarea = MmapArea::new(4096).expect("mmap");
+    rarea
+        .slice_mut(0, reply.len())
+        .unwrap()
+        .copy_from_slice(&reply);
+    let rev_nat = fwd_nat.reverse(IpAddr::V4(host), IpAddr::V4(target), orig_id, 0);
+    let rres = rewrite_forwarded_frame_in_place(
+        &rarea,
+        XdpDesc {
+            addr: 0,
+            len: reply.len() as u32,
+            options: 0,
+        },
+        meta_for(translated_id),
+        &icmp_test_decision(rev_nat),
+        false,
+        None,
+    )
+    .expect("rev rewrite");
+    let rout = rarea
+        .slice(rres.offset as usize, rres.len as usize)
+        .expect("rev out");
+    assert_eq!(rout[34], 0, "still an echo reply");
+    assert_eq!(&rout[30..34], &host.octets(), "dst un-NAT'd to the host");
+    assert_eq!(
+        u16::from_be_bytes([rout[38], rout[39]]),
+        orig_id,
+        "identifier restored to the original on the reply",
+    );
+    assert_eq!(
+        checksum16(&rout[34..]),
+        0,
+        "ICMPv4 checksum valid after reverse id rewrite",
+    );
+}
+
+#[test]
+fn rewrite_forwarded_frame_in_place_translates_icmpv6_echo_identifier() {
+    let host = "2001:559:8585:ef00::100".parse::<Ipv6Addr>().unwrap();
+    let target = "2001:4860:4860::8888".parse::<Ipv6Addr>().unwrap();
+    let pool = "2001:559:8585:80::8".parse::<Ipv6Addr>().unwrap();
+    let orig_id: u16 = 0x3e0f;
+    let translated_id: u16 = 40002;
+    // `flow_src_port` mirrors the packet's on-wire ICMPv6 identifier so
+    // `restore_l4_tuple_from_meta` is a no-op and MY incremental checksum
+    // adjustment (not a full recompute) is what the test validates.
+    let meta_for = |flow_src_port: u16| UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+        l3_offset: 14,
+        addr_family: libc::AF_INET6 as u8,
+        protocol: PROTO_ICMPV6,
+        flow_src_port,
+        ..UserspaceDpMeta::default()
+    };
+    let meta = meta_for(orig_id);
+
+    // Forward: host -> target, echo request (128). SNAT src + translate id.
+    let frame = build_icmpv6_echo_frame(host, target, 64, 128, orig_id);
+    let mut area = MmapArea::new(4096).expect("mmap");
+    area.slice_mut(0, frame.len())
+        .unwrap()
+        .copy_from_slice(&frame);
+    let fwd_nat = NatDecision {
+        rewrite_src: Some(IpAddr::V6(pool)),
+        rewrite_src_port: Some(translated_id),
+        ..NatDecision::default()
+    };
+    let res = rewrite_forwarded_frame_in_place(
+        &area,
+        XdpDesc {
+            addr: 0,
+            len: frame.len() as u32,
+            options: 0,
+        },
+        meta,
+        &icmp_test_decision(fwd_nat),
+        false,
+        None,
+    )
+    .expect("fwd v6 rewrite");
+    let out = area
+        .slice(res.offset as usize, res.len as usize)
+        .expect("fwd v6 out");
+    // eth 14 + ipv6 40 => icmp at 54; type@54, identifier@58..60.
+    assert_eq!(out[54], 128, "still an echo request");
+    assert_eq!(&out[22..38], &pool.octets(), "src translated to pool");
+    assert_eq!(
+        u16::from_be_bytes([out[58], out[59]]),
+        translated_id,
+        "identifier translated on the wire",
+    );
+    assert!(
+        icmpv6_checksum_ok(&out[14..]),
+        "ICMPv6 checksum valid after id rewrite",
+    );
+
+    // Reverse: reply target -> pool with the translated id; un-NAT restores it.
+    let reply = build_icmpv6_echo_frame(target, pool, 64, 129, translated_id);
+    let mut rarea = MmapArea::new(4096).expect("mmap");
+    rarea
+        .slice_mut(0, reply.len())
+        .unwrap()
+        .copy_from_slice(&reply);
+    let rev_nat = fwd_nat.reverse(IpAddr::V6(host), IpAddr::V6(target), orig_id, 0);
+    let rres = rewrite_forwarded_frame_in_place(
+        &rarea,
+        XdpDesc {
+            addr: 0,
+            len: reply.len() as u32,
+            options: 0,
+        },
+        meta_for(translated_id),
+        &icmp_test_decision(rev_nat),
+        false,
+        None,
+    )
+    .expect("rev v6 rewrite");
+    let rout = rarea
+        .slice(rres.offset as usize, rres.len as usize)
+        .expect("rev v6 out");
+    assert_eq!(rout[54], 129, "still an echo reply");
+    assert_eq!(&rout[38..54], &host.octets(), "dst un-NAT'd to the host");
+    assert_eq!(
+        u16::from_be_bytes([rout[58], rout[59]]),
+        orig_id,
+        "identifier restored to the original on the reply",
+    );
+    assert!(
+        icmpv6_checksum_ok(&rout[14..]),
+        "ICMPv6 checksum valid after reverse id rewrite",
+    );
+}
+
 fn tcp_ports_ipv6(packet: &[u8]) -> (u16, u16) {
     (
         u16::from_be_bytes([packet[40], packet[41]]),

--- a/userspace-dp/src/afxdp/frame/tests.rs
+++ b/userspace-dp/src/afxdp/frame/tests.rs
@@ -2221,6 +2221,68 @@ fn rewrite_forwarded_frame_in_place_translates_icmpv6_echo_identifier() {
     );
 }
 
+// #4074: end-to-end — a DNAT'd ICMP echo (address-only, `rewrite_dst` set,
+// `rewrite_dst_port` None, which is what the gated DNAT lookup now produces for
+// a port-less protocol) must PRESERVE the ICMP Query Identifier and leave the
+// checksum valid. This is the wire-level counterpart to the decision-layer test
+// `dnat_pooled_port_does_not_translate_icmp_identifier`: the gate keeps
+// `rewrite_dst_port` None, so `apply_nat_icmp_identifier_rewrite` no-ops here.
+#[test]
+fn rewrite_forwarded_frame_in_place_dnat_preserves_icmpv4_identifier() {
+    let client = Ipv4Addr::new(198, 51, 100, 1);
+    let public = Ipv4Addr::new(203, 0, 113, 10);
+    let internal = Ipv4Addr::new(10, 0, 0, 5);
+    let orig_id: u16 = 0x1234;
+    let meta = UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+        l3_offset: 14,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_ICMP,
+        flow_src_port: orig_id,
+        ..UserspaceDpMeta::default()
+    };
+    let frame = build_icmp_frame_v4(client, public, 64, 8, orig_id);
+    let mut area = MmapArea::new(4096).expect("mmap");
+    area.slice_mut(0, frame.len())
+        .unwrap()
+        .copy_from_slice(&frame);
+    // Address-only DNAT decision (the gated lookup's output for ICMP).
+    let dnat = NatDecision {
+        rewrite_dst: Some(IpAddr::V4(internal)),
+        rewrite_dst_port: None,
+        ..NatDecision::default()
+    };
+    let res = rewrite_forwarded_frame_in_place(
+        &area,
+        XdpDesc {
+            addr: 0,
+            len: frame.len() as u32,
+            options: 0,
+        },
+        meta,
+        &icmp_test_decision(dnat),
+        false,
+        None,
+    )
+    .expect("dnat rewrite");
+    let out = area
+        .slice(res.offset as usize, res.len as usize)
+        .expect("dnat out");
+    assert_eq!(&out[30..34], &internal.octets(), "dst translated by DNAT");
+    assert_eq!(
+        u16::from_be_bytes([out[38], out[39]]),
+        orig_id,
+        "ICMP identifier PRESERVED through address-only DNAT",
+    );
+    assert_eq!(
+        checksum16(&out[34..]),
+        0,
+        "ICMPv4 checksum valid (identifier untouched)",
+    );
+}
+
 fn tcp_ports_ipv6(packet: &[u8]) -> (u16, u16) {
     (
         u16::from_be_bytes([packet[40], packet[41]]),

--- a/userspace-dp/src/nat/destination.rs
+++ b/userspace-dp/src/nat/destination.rs
@@ -574,6 +574,17 @@ impl DnatTable {
         ingress_routing_instance: &str,
         packet_icmp: Option<(u8, u8)>,
     ) -> Option<(NatDecision, Option<Arc<NatRuleCounter>>)> {
+        // #4074: whether the inbound protocol carries a rewritable 16-bit L4
+        // port (TCP/UDP). A port-less protocol (ICMP/ICMPv6/GRE/...) has no L4
+        // port, so a DNAT rule must NEVER attach a translated destination port
+        // to it — captured here before `protocol` is widened to the u16 key
+        // space below. Without this, an UNSCOPED pool DNAT rule (no `match
+        // destination-port`) whose pool carries a `port` would set
+        // `rewrite_dst_port = Some(pool_port)` for an ICMP echo, and the SNAT
+        // ICMP-identifier rewriter (`apply_nat_icmp_identifier_rewrite`) would
+        // then corrupt the ICMP Query Identifier to the pool port. ICMP DNAT
+        // must stay address-only (the pre-#4074 behaviour).
+        let protocol_has_l4_ports = crate::ip_proto::has_l4_ports(protocol);
         // The inbound packet protocol is a real IANA byte; widen it to the
         // u16 key space. The wildcard sentinel (PROTO_ANY = 256) is OUTSIDE
         // this range, so a real packet — even one carrying protocol 0 (HOPOPT)
@@ -664,11 +675,18 @@ impl DnatTable {
             Some(DnatOutcome::Translate(v, c)) => (v, c),
             Some(DnatOutcome::Exempt) | None => return None,
         };
-        let rewrite_dst_port = if value.new_dst_port != 0 && value.new_dst_port != dst_port {
-            Some(value.new_dst_port)
-        } else {
-            None
-        };
+        // #4074: gate the destination-port translation on the protocol actually
+        // carrying an L4 port. A port-less protocol (ICMP/ICMPv6/GRE/...) keeps
+        // `rewrite_dst_port = None` — address-only DNAT — so a pooled-port DNAT
+        // rule can never smuggle a spurious L4 port onto an ICMP flow (which
+        // would otherwise drive the ICMP-identifier rewriter to corrupt the
+        // Query Identifier).
+        let rewrite_dst_port =
+            if protocol_has_l4_ports && value.new_dst_port != 0 && value.new_dst_port != dst_port {
+                Some(value.new_dst_port)
+            } else {
+                None
+            };
         Some((
             NatDecision {
                 rewrite_src: None,

--- a/userspace-dp/src/nat/source.rs
+++ b/userspace-dp/src/nat/source.rs
@@ -21,6 +21,7 @@ use super::allocator::{
 };
 use super::{NatCounterStore, NatDecision, NatRuleCounter, NatScopeCtx};
 use crate::SourceNATRuleSnapshot;
+use crate::ip_proto::{PROTO_ICMP, PROTO_ICMPV6};
 use crate::prefix::{PrefixV4, PrefixV6};
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use rustc_hash::FxHashMap;
@@ -877,7 +878,21 @@ pub(crate) fn match_source_nat_result_for_tuple(
         // via `try_next_port` with no flow-keyed mapping — because the
         // packet rewriters gate every L4 write on `has_l4_ports`, so the
         // port it returns can never be written to a frame.
-        let port_less = protocol != 0 && !crate::ip_proto::has_l4_ports(protocol);
+        // #4074 (RFC 5508 §3.1 "ICMP Query Mappings"): an ICMP/ICMPv6 echo or
+        // query message carries a 16-bit Query Identifier that the flow parser
+        // (`parse_flow_ports`) lifts into `src_port` (with `dst_port == 0`).
+        // That identifier is the ICMP demux key — exactly the role a TCP/UDP
+        // port plays — so pool-mode SNAT must translate it, or two internal
+        // hosts pinging the same target with the same id, both hidden behind
+        // one pool address, collide on the reverse tuple (pool_addr, id) and
+        // their replies are mis-associated. A non-identifier ICMP control/error
+        // message parses flowless (`src_port == 0`) and keeps the address-only
+        // path — there is no id to translate. `no_translation` (port
+        // no-translation) still preserves the id via the `address_only` gate
+        // below. The translated id comes from the same pool port/id space as
+        // the TCP/UDP PAT allocation (`allocate_translation`).
+        let icmp_query = matches!(protocol, PROTO_ICMP | PROTO_ICMPV6) && src_port != 0;
+        let port_less = protocol != 0 && !crate::ip_proto::has_l4_ports(protocol) && !icmp_query;
         let tuple_unknown = protocol == 0;
         // #3906: `port no-translation` translates the ADDRESS only and PRESERVES
         // the original source port. It takes the same address-only path as a

--- a/userspace-dp/src/nat/static_nat.rs
+++ b/userspace-dp/src/nat/static_nat.rs
@@ -554,6 +554,15 @@ impl StaticNatTable {
         if let Some(entry) = pick_scoped(self.dnat.get(&(dst_ip, Some(dst_port))), &zone_ok)
             .or_else(|| pick_scoped(self.dnat.get(&(dst_ip, None)), &zone_ok))
         {
+            // #4074: this cannot attach a spurious L4 port to an ICMP flow (the
+            // regression the DNAT-pool path had). A port-mapped entry always
+            // carries `mapped_port = Some(_)` together with `match_dst_port =
+            // Some(nonzero)` (the build maps `match_destination_port == 0` to
+            // `(None, None)`), so it is keyed under `(ip, Some(nonzero))` and an
+            // ICMP packet (dst_port 0) can never match it; the whole-address
+            // `(ip, None)` bucket only ever holds `mapped_port = None`. So
+            // `rewrite_dst_port` is structurally `None` for ICMP here — no
+            // protocol gate needed.
             return Some((
                 NatDecision {
                     rewrite_src: None,

--- a/userspace-dp/src/nat/tests.rs
+++ b/userspace-dp/src/nat/tests.rs
@@ -1685,6 +1685,71 @@ fn dnat_basic_lookup_tcp() {
     );
 }
 
+// #4074 FAIL-ON-REVERT: an UNSCOPED pool DNAT rule (no `match destination-port`)
+// whose pool carries a `port` must NOT attach that port to a port-less ICMP
+// flow. `validateDNATPoolStrict` does not require a destination-port, so such a
+// rule commits; the snapshot builder emits protocol="" (ANY) + destination_port
+// 0 (wildcard) + pool_port=8080, and the ICMP DNAT lookup runs with dst_port 0.
+// Pre-gate, `rewrite_dst_port` became `Some(8080)` and the SNAT ICMP-identifier
+// rewriter (`apply_nat_icmp_identifier_rewrite`) then corrupted the ICMP Query
+// Identifier to 8080, breaking ping through the DNAT rule. The `has_l4_ports`
+// gate keeps ICMP DNAT address-only (pre-#4074 behaviour).
+//
+// Reverting the gate in destination.rs makes `rewrite_dst_port` `Some(8080)` for
+// the ICMP lookup, turning the `None` assertion RED. The TCP control (which DOES
+// carry an L4 port) still receives the port translation.
+#[test]
+fn dnat_pooled_port_does_not_translate_icmp_identifier() {
+    let table = DnatTable::from_snapshots(
+        &[DestinationNATRuleSnapshot {
+            counter_id: 0,
+            name: "web".to_string(),
+            destination_address: "203.0.113.10".to_string(),
+            destination_port: 0,     // unscoped by destination-port
+            protocol: String::new(), // any protocol (matches ICMP)
+            pool_address: "10.0.0.5".to_string(),
+            pool_port: 8080,
+            ..DestinationNATRuleSnapshot::default()
+        }],
+        &crate::nat::NatCounterStore::default(),
+    );
+    // ICMP echo (dst_port 0): the destination address is translated, but the
+    // pool port must NOT be attached — ICMP has no L4 port.
+    let icmp = table.lookup(
+        PROTO_ICMP,
+        "198.51.100.1".parse().unwrap(),
+        "203.0.113.10".parse().unwrap(),
+        0,
+        "",
+    );
+    assert_eq!(
+        icmp,
+        Some(NatDecision {
+            rewrite_dst: Some("10.0.0.5".parse().unwrap()),
+            rewrite_dst_port: None,
+            ..NatDecision::default()
+        }),
+        "ICMP DNAT must be address-only — no pooled L4 port on a port-less flow",
+    );
+    // TCP control: a port-carrying protocol still gets the pool port.
+    let tcp = table.lookup(
+        PROTO_TCP,
+        "198.51.100.1".parse().unwrap(),
+        "203.0.113.10".parse().unwrap(),
+        80,
+        "",
+    );
+    assert_eq!(
+        tcp,
+        Some(NatDecision {
+            rewrite_dst: Some("10.0.0.5".parse().unwrap()),
+            rewrite_dst_port: Some(8080),
+            ..NatDecision::default()
+        }),
+        "TCP DNAT still translates the destination port",
+    );
+}
+
 // #3844: `then destination-nat off` is a no-translate EXEMPTION. An off entry
 // that matches must return NO DNAT decision AND short-circuit later DNAT rules
 // for the same destination — a translate rule keyed identically must NOT

--- a/userspace-dp/src/nat/tests.rs
+++ b/userspace-dp/src/nat/tests.rs
@@ -3328,6 +3328,167 @@ fn pool_snat_portless_protocols_translate_ip_only_no_port() {
     }
 }
 
+// #4074 FAIL-ON-REVERT (RFC 5508 §3.1): pool-mode source-NAT applied to an
+// ICMP echo/query flow must translate the ICMP Query Identifier — the flow
+// parser lifts that id into `src_port` (with `dst_port == 0`), and it is the
+// ICMP demux key exactly like a TCP/UDP port. Two internal hosts pinging the
+// same target with the SAME id, both hidden behind ONE pool address, must get
+// DISTINCT translated ids so their return replies demux (the reverse tuple
+// `(pool_addr, id)` no longer collides).
+//
+// Reverting the source.rs `icmp_query` gate makes ICMP fall through to the
+// port-less address-only path (`rewrite_src_port: None`), so BOTH decisions
+// carry the untranslated id, the two `is_some()`/distinctness assertions go
+// RED, and (in production) the reverse keys collide.
+#[test]
+fn pool_snat_translates_icmp_query_id_distinct_per_host() {
+    for proto in [PROTO_ICMP, PROTO_ICMPV6] {
+        let (src_a, src_b, dst): (IpAddr, IpAddr, IpAddr) = if proto == PROTO_ICMP {
+            (
+                "10.0.1.100".parse().unwrap(),
+                "10.0.1.101".parse().unwrap(),
+                "8.8.8.8".parse().unwrap(),
+            )
+        } else {
+            (
+                "2001:db8::100".parse().unwrap(),
+                "2001:db8::101".parse().unwrap(),
+                "2001:4860:4860::8888".parse().unwrap(),
+            )
+        };
+        let pool_addr = if proto == PROTO_ICMP {
+            "203.0.113.1/32".to_string()
+        } else {
+            "2001:db8:cafe::1/128".to_string()
+        };
+        let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+            name: "pool-snat".to_string(),
+            from_zone: "lan".to_string(),
+            to_zone: "wan".to_string(),
+            source_addresses: vec![if proto == PROTO_ICMP {
+                "0.0.0.0/0".to_string()
+            } else {
+                "::/0".to_string()
+            }],
+            pool_name: "my-pool".to_string(),
+            pool_addresses: vec![pool_addr],
+            port_low: 1024,
+            port_high: 65535,
+            ..SourceNATRuleSnapshot::default()
+        }]);
+        // Both hosts use the SAME ICMP query-id 0x1234 to the SAME target.
+        let query_id = 0x1234u16;
+        let mut counter = None;
+        let da = expect_snat_decision(match_source_nat_result_for_tuple(
+            &rules,
+            &NatScopeCtx::default(),
+            "lan",
+            "wan",
+            src_a,
+            dst,
+            proto,
+            query_id,
+            0,
+            None,
+            None,
+            0,
+            false,
+            &mut counter,
+        ));
+        let db = expect_snat_decision(match_source_nat_result_for_tuple(
+            &rules,
+            &NatScopeCtx::default(),
+            "lan",
+            "wan",
+            src_b,
+            dst,
+            proto,
+            query_id,
+            0,
+            None,
+            None,
+            0,
+            false,
+            &mut counter,
+        ));
+        // Both hosts land on the single pool address (overload) ...
+        let expected_pool: IpAddr = if proto == PROTO_ICMP {
+            "203.0.113.1".parse().unwrap()
+        } else {
+            "2001:db8:cafe::1".parse().unwrap()
+        };
+        assert_eq!(da.rewrite_src, Some(expected_pool), "proto {proto}");
+        assert_eq!(db.rewrite_src, Some(expected_pool), "proto {proto}");
+        // ... and each MUST get a translated query-id from the pool id space.
+        let id_a = da
+            .rewrite_src_port
+            .unwrap_or_else(|| panic!("proto {proto}: host A must get a translated ICMP id"));
+        let id_b = db
+            .rewrite_src_port
+            .unwrap_or_else(|| panic!("proto {proto}: host B must get a translated ICMP id"));
+        assert!(id_a >= 1024, "proto {proto}: id {id_a} out of pool range");
+        assert!(id_b >= 1024, "proto {proto}: id {id_b} out of pool range");
+        // The demux invariant: same pool address + same original id => the
+        // translated ids MUST differ (RFC 5508 §3.1 uniqueness).
+        assert_ne!(
+            id_a, id_b,
+            "proto {proto}: two hosts sharing a pool address + query-id must get DISTINCT translated ids",
+        );
+        assert_eq!(da.rewrite_dst, None, "proto {proto}");
+        assert_eq!(da.rewrite_dst_port, None, "proto {proto}");
+
+        // Two pool ids consumed, one per flow.
+        let status = source_nat_pool_statuses(&rules);
+        assert_eq!(
+            status[0].used_ports, 2,
+            "proto {proto}: one pool id per ICMP query flow",
+        );
+    }
+}
+
+// #4074: a NON-identifier ICMP message (an error / control type, or any flow
+// the parser could not lift an id from — `src_port == 0`) keeps the
+// address-only path: the source IP is translated but NO id is allocated. This
+// pins that the `icmp_query` gate is `src_port != 0`, not "all ICMP".
+#[test]
+fn pool_snat_icmp_without_query_id_is_address_only() {
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "pool-snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "my-pool".to_string(),
+        pool_addresses: vec!["203.0.113.1/32".to_string()],
+        port_low: 1024,
+        port_high: 65535,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    let mut counter = None;
+    let d = expect_snat_decision(match_source_nat_result_for_tuple(
+        &rules,
+        &NatScopeCtx::default(),
+        "lan",
+        "wan",
+        "10.0.1.100".parse().unwrap(),
+        "8.8.8.8".parse().unwrap(),
+        PROTO_ICMP,
+        0, // flowless / non-identifier ICMP
+        0,
+        None,
+        None,
+        0,
+        false,
+        &mut counter,
+    ));
+    assert_eq!(d.rewrite_src, Some("203.0.113.1".parse().unwrap()));
+    assert_eq!(
+        d.rewrite_src_port, None,
+        "a flowless / non-identifier ICMP must NOT allocate a pool id",
+    );
+    let status = source_nat_pool_statuses(&rules);
+    assert_eq!(status[0].used_ports, 0, "no pool id for a flowless ICMP");
+}
+
 // #3906 FAIL-ON-REVERT: pool-mode source-NAT with `port no-translation` must
 // translate the source ADDRESS but PRESERVE the original source port — for a
 // port-carrying protocol (TCP/UDP) it takes the address-only path (pick a pool

--- a/userspace-dp/src/session/key.rs
+++ b/userspace-dp/src/session/key.rs
@@ -27,7 +27,15 @@ pub(crate) fn reply_matches_forward_session(
 
 pub(crate) fn forward_wire_key(forward_key: &SessionKey, nat: NatDecision) -> SessionKey {
     let (src_port, dst_port) = if matches!(forward_key.protocol, PROTO_ICMP | PROTO_ICMPV6) {
-        (forward_key.src_port, forward_key.dst_port)
+        // #4074: the ICMP Query Identifier lives in `src_port` (`dst_port` is
+        // always 0) and is a single symmetric field carried at the same offset
+        // in both directions. Pool SNAT translates it (RFC 5508 §3.1), so the
+        // forward wire key carries the translated id when the decision set one;
+        // absent a translation this is `forward_key.src_port` — unchanged.
+        (
+            nat.rewrite_src_port.unwrap_or(forward_key.src_port),
+            forward_key.dst_port,
+        )
     } else {
         (
             nat.rewrite_src_port.unwrap_or(forward_key.src_port),
@@ -64,7 +72,9 @@ pub(crate) fn forward_wire_key(forward_key: &SessionKey, nat: NatDecision) -> Se
 
 pub(crate) fn translated_session_key(key: &SessionKey, nat: NatDecision) -> SessionKey {
     let (src_port, dst_port) = if matches!(key.protocol, PROTO_ICMP | PROTO_ICMPV6) {
-        (key.src_port, key.dst_port)
+        // #4074: translate the ICMP Query Identifier (in `src_port`) like a
+        // port; `dst_port` stays 0. No translation => `key.src_port` unchanged.
+        (nat.rewrite_src_port.unwrap_or(key.src_port), key.dst_port)
     } else {
         (
             nat.rewrite_src_port.unwrap_or(key.src_port),
@@ -83,7 +93,16 @@ pub(crate) fn translated_session_key(key: &SessionKey, nat: NatDecision) -> Sess
 
 pub(super) fn reverse_wire_key(forward_key: &SessionKey, nat: NatDecision) -> SessionKey {
     let (src_port, dst_port) = if matches!(forward_key.protocol, PROTO_ICMP | PROTO_ICMPV6) {
-        (forward_key.src_port, forward_key.dst_port)
+        // #4074: the reply carries the SAME (translated) ICMP identifier at the
+        // same offset, which the parser lifts into the reply's `src_port`. So
+        // the reverse wire key's `src_port` is the translated id (not swapped
+        // with `dst_port` the way a TCP/UDP port pair is), and `dst_port` stays
+        // 0. This is what makes two hosts sharing a pool address + original id
+        // demux — their translated ids differ, so their reverse keys differ.
+        (
+            nat.rewrite_src_port.unwrap_or(forward_key.src_port),
+            forward_key.dst_port,
+        )
     } else {
         (
             nat.rewrite_dst_port.unwrap_or(forward_key.dst_port),
@@ -153,7 +172,11 @@ pub(crate) fn reverse_canonical_key(forward_key: &SessionKey, _nat: NatDecision)
 
 pub(crate) fn reverse_session_key(key: &SessionKey, nat: NatDecision) -> SessionKey {
     let (src_port, dst_port) = if matches!(key.protocol, PROTO_ICMP | PROTO_ICMPV6) {
-        (key.src_port, key.dst_port)
+        // #4074: the reverse (reply) companion is keyed on the translated ICMP
+        // identifier so the reply demuxes to the right forward flow. Symmetric
+        // field: `src_port` = translated id, `dst_port` = 0 (see
+        // `reverse_wire_key`). No translation => `key.src_port` unchanged.
+        (nat.rewrite_src_port.unwrap_or(key.src_port), key.dst_port)
     } else {
         (
             nat.rewrite_dst_port.unwrap_or(key.dst_port),

--- a/userspace-dp/src/session/key.rs
+++ b/userspace-dp/src/session/key.rs
@@ -172,11 +172,31 @@ pub(crate) fn reverse_canonical_key(forward_key: &SessionKey, _nat: NatDecision)
 
 pub(crate) fn reverse_session_key(key: &SessionKey, nat: NatDecision) -> SessionKey {
     let (src_port, dst_port) = if matches!(key.protocol, PROTO_ICMP | PROTO_ICMPV6) {
-        // #4074: the reverse (reply) companion is keyed on the translated ICMP
-        // identifier so the reply demuxes to the right forward flow. Symmetric
-        // field: `src_port` = translated id, `dst_port` = 0 (see
-        // `reverse_wire_key`). No translation => `key.src_port` unchanged.
-        (nat.rewrite_src_port.unwrap_or(key.src_port), key.dst_port)
+        // #4074: the ICMP Query Identifier is a symmetric field, and this
+        // function is called in BOTH directions:
+        //   - forward→reverse (build the reverse companion key from the FORWARD
+        //     entry + its FORWARD decision): the translated id lives in
+        //     `rewrite_src_port` (= Y), so the companion is keyed on Y and the
+        //     reply (which carries Y) demuxes to it.
+        //   - reverse→forward (`account_packet` recovers the FORWARD entry key
+        //     from the REVERSE entry + its REVERSE decision, session/mod.rs):
+        //     `NatDecision::reverse` moved the ORIGINAL id into
+        //     `rewrite_dst_port` (= X) and left `rewrite_src_port` None, so we
+        //     must read `rewrite_dst_port` to recover X and hit the forward
+        //     entry — reading only `rewrite_src_port` (=None → falls back to the
+        //     reverse key's Y) misses it and mis-accounts the reply volume onto
+        //     the reverse entry.
+        // At most one of the two port fields is ever set for an ICMP flow (SNAT
+        // sets only `rewrite_src_port` forward; its `.reverse()` sets only
+        // `rewrite_dst_port`; ICMP DNAT is gated to no L4 port), so `.or()`
+        // picks the right id in each direction. No translation => `key.src_port`
+        // unchanged; `dst_port` stays 0.
+        (
+            nat.rewrite_src_port
+                .or(nat.rewrite_dst_port)
+                .unwrap_or(key.src_port),
+            key.dst_port,
+        )
     } else {
         (
             nat.rewrite_dst_port.unwrap_or(key.dst_port),

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -2224,6 +2224,94 @@ fn icmp_port_handling_unchanged_with_dnat_ports() {
     ));
 }
 
+// #4074 FAIL-ON-REVERT (RFC 5508 §3.1): with pool SNAT translating the ICMP
+// Query Identifier, two internal hosts pinging the SAME target with the SAME
+// original id, both hidden behind ONE pool address, must produce DISTINCT
+// reverse wire keys — otherwise the return replies collide on
+// `(pool_addr, id)` and are mis-associated.
+//
+// The forward SNAT decision carries the translated id in `rewrite_src_port`.
+// `reverse_wire_key` must fold it into the reverse key's `src_port` (the ICMP
+// identifier is symmetric — the reply carries the same translated id at the
+// same offset). Reverting the key.rs ICMP arm (ignore `rewrite_src_port`, keep
+// the original id) collapses both reverse keys to `{T, P, 0x1234, 0}`, turning
+// the `assert_ne!` RED.
+#[test]
+fn icmp_query_id_translation_demuxes_reverse_wire_key() {
+    let target = IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8));
+    let pool = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1));
+    let query_id = 0x1234u16;
+
+    let mk_forward = |host: Ipv4Addr| SessionKey {
+        addr_family: 2,
+        protocol: PROTO_ICMP,
+        src_ip: IpAddr::V4(host),
+        dst_ip: target,
+        src_port: query_id,
+        dst_port: 0,
+    };
+    // Distinct translated ids allocated by pool SNAT for the two hosts.
+    let mk_nat = |translated_id: u16| NatDecision {
+        rewrite_src: Some(pool),
+        rewrite_src_port: Some(translated_id),
+        ..NatDecision::default()
+    };
+
+    let fwd_a = mk_forward(Ipv4Addr::new(10, 0, 0, 1));
+    let fwd_b = mk_forward(Ipv4Addr::new(10, 0, 0, 2));
+    let nat_a = mk_nat(40001);
+    let nat_b = mk_nat(40002);
+
+    // The reverse (reply) wire keys carry the translated id in src_port, so
+    // they differ — the replies demux back to the right host.
+    let rev_a = reverse_wire_key(&fwd_a, nat_a);
+    let rev_b = reverse_wire_key(&fwd_b, nat_b);
+    assert_eq!(rev_a.src_ip, target, "reply source is the pinged target");
+    assert_eq!(rev_a.dst_ip, pool, "reply destination is the pool address");
+    assert_eq!(
+        rev_a.src_port, 40001,
+        "reverse key carries the translated id"
+    );
+    assert_eq!(rev_a.dst_port, 0, "ICMP dst_port stays 0");
+    assert_ne!(
+        rev_a, rev_b,
+        "distinct translated ids MUST give distinct reverse keys (no collision)",
+    );
+
+    // The reply that carries host A's translated id (40001) matches forward A
+    // but NOT forward B (whose reverse key expects 40002).
+    let reply_a = SessionKey {
+        addr_family: 2,
+        protocol: PROTO_ICMP,
+        src_ip: target,
+        dst_ip: pool,
+        src_port: 40001,
+        dst_port: 0,
+    };
+    assert!(reply_matches_forward_session(&fwd_a, nat_a, &reply_a));
+    assert!(!reply_matches_forward_session(&fwd_b, nat_b, &reply_a));
+
+    // The reverse companion session key is keyed on the translated id too, so
+    // both hosts' companions have distinct primary keys.
+    assert_ne!(
+        reverse_session_key(&fwd_a, nat_a),
+        reverse_session_key(&fwd_b, nat_b),
+        "reverse companion keys must differ per translated id",
+    );
+
+    // Sanity: with NO translated id (rewrite_src_port None), ICMP keeps the
+    // original id — the pre-#4074 behavior, and the collision case.
+    let no_id_nat = NatDecision {
+        rewrite_src: Some(pool),
+        ..NatDecision::default()
+    };
+    assert_eq!(
+        reverse_wire_key(&fwd_a, no_id_nat),
+        reverse_wire_key(&fwd_b, no_id_nat),
+        "without id translation the two reverse keys collide (documents the gap)",
+    );
+}
+
 #[test]
 fn find_forward_nat_match_with_dnat_port_rewrite() {
     let mut table = SessionTable::new();

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -5604,6 +5604,101 @@ fn account_packet_miss_is_noop() {
     assert!(table.session_counters(&key_v4()).is_none());
 }
 
+// #4074 FAIL-ON-REVERT: for a TRANSLATED pool-SNAT ICMP flow, a reverse (reply)
+// packet's volume must fold onto the canonical FORWARD entry's `rev` counter —
+// exactly like TCP/UDP — so the forward-only conntrack mirror / SESSION_CLOSE
+// harvest sees the reply-direction bytes. `account_packet` does this by calling
+// `reverse_session_key(reverse_entry_key, reverse_decision)` to recover the
+// forward entry's key. Because SNAT translated the ICMP id X->Y, the reverse
+// entry is keyed on Y; `NatDecision::reverse` stored the ORIGINAL id X in
+// `rewrite_dst_port`. So `reverse_session_key` MUST read `rewrite_dst_port` to
+// recover X and hit the forward entry {..,X,..}.
+//
+// Reverting the `reverse_session_key` ICMP arm to read only `rewrite_src_port`
+// yields Y (not X) -> the forward entry is MISSED -> `account_packet` falls back
+// to the reverse entry, so the FORWARD entry's `rev_*` stays 0 and the reply
+// volume is lost by the forward-only harvest. This asserts the forward entry's
+// `rev_*` is bumped, going RED on revert. Covers v4 + v6.
+#[test]
+fn account_packet_reverse_folds_onto_forward_translated_icmp() {
+    for v6 in [false, true] {
+        let mut table = SessionTable::new();
+        let now = 1_000_000_000u64;
+        let (proto, af, host, target, pool): (u8, u8, IpAddr, IpAddr, IpAddr) = if v6 {
+            (
+                PROTO_ICMPV6,
+                10,
+                IpAddr::V6("2001:db8::1".parse().unwrap()),
+                IpAddr::V6("2606:4700:4700::1111".parse().unwrap()),
+                IpAddr::V6("2001:db8:cafe::8".parse().unwrap()),
+            )
+        } else {
+            (
+                PROTO_ICMP,
+                2,
+                IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+                IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1)),
+            )
+        };
+        let orig_id: u16 = 0x1234; // X (original identifier)
+        let translated_id: u16 = 40001; // Y (pool-allocated identifier)
+
+        // Forward ICMP entry {host, target, X, 0}, pool-SNAT'd to {pool, .., Y}.
+        let fwd = SessionKey {
+            addr_family: af,
+            protocol: proto,
+            src_ip: host,
+            dst_ip: target,
+            src_port: orig_id,
+            dst_port: 0,
+        };
+        let fwd_nat = NatDecision {
+            rewrite_src: Some(pool),
+            rewrite_src_port: Some(translated_id),
+            ..NatDecision::default()
+        };
+        let fwd_decision = SessionDecision {
+            resolution: resolution(),
+            nat: fwd_nat,
+        };
+        // Reverse companion, keyed on the translated id (the reply carries Y).
+        let rev = reverse_session_key(&fwd, fwd_nat);
+        assert_eq!(rev.src_port, translated_id, "v6={v6}: companion keyed on Y");
+        // The reverse entry's decision is the inverted forward decision — this
+        // is exactly what build_reverse_session_from_forward_match installs.
+        let rev_nat = fwd_nat.reverse(host, target, orig_id, 0);
+        let rev_decision = SessionDecision {
+            resolution: resolution(),
+            nat: rev_nat,
+        };
+
+        assert!(table.install_with_protocol(fwd.clone(), fwd_decision, metadata(), now, proto, 0));
+        assert!(table.install_with_protocol(
+            rev.clone(),
+            rev_decision,
+            metadata_reverse(),
+            now,
+            proto,
+            0,
+        ));
+
+        // A reverse (reply) packet keyed by the reverse-entry tuple.
+        table.account_packet(&rev, 100, 0, 0);
+
+        let c = table.session_counters(&fwd).expect("forward entry exists");
+        assert_eq!(
+            c.rev_packets, 1,
+            "v6={v6}: reverse ICMP volume must fold onto the FORWARD entry",
+        );
+        assert_eq!(
+            c.rev_bytes, 100,
+            "v6={v6}: reverse bytes on the forward entry"
+        );
+        assert_eq!(c.fwd_packets, 0, "v6={v6}: no forward packet was accounted");
+    }
+}
+
 #[test]
 fn close_delta_carries_harvested_counters() {
     let mut table = SessionTable::new();


### PR DESCRIPTION
Closes #4074

## Problem (RFC 5508 §3.1, verified genuine)

Pool-mode source NAT applied to an ICMP/ICMPv6 **echo or query** message left
the ICMP **Query Identifier** untranslated. The flow parser (`parse_flow_ports`)
lifts that 16-bit Identifier into the session tuple's `src_port` slot
(`dst_port` stays 0), so it is the ICMP demux key exactly like a TCP/UDP port.
Because pool SNAT took the port-less **address-only** path for ICMP
(`rewrite_src_port` unset), two internal hosts pinging the same target with the
same id, both hidden behind one pool address, produced the **same** reverse
tuple `(pool_addr, id)` — their return replies collided and were
mis-associated. (The session table already carries a `nat_reverse_key_collisions`
counter for exactly this 1:N reverse-key collision, #1758.)

RFC 5508 §3.1 ("ICMP Query Mappings") requires a NAT to translate the query id
so `(translated-source, translated-id)` is unique.

## Fix — three coordinated parts

1. **`nat/source.rs`** — an identifier-bearing ICMP flow (`src_port != 0`) now
   takes the PAT `allocate_translation` path, drawing a unique translated id
   from the pool id space (the same allocator the TCP/UDP port PAT uses). A
   flowless / non-identifier ICMP control-or-error message (`src_port == 0`)
   and `port no-translation` keep the address-only path (no id to translate).

2. **`session/key.rs`** — the ICMP arm of `forward_wire_key` /
   `reverse_wire_key` / `translated_session_key` / `reverse_session_key` folds
   the translated id into `src_port` (a symmetric field carried at the same
   offset in both directions; `dst_port` stays 0, and it is **not** swapped the
   way a TCP/UDP port pair is). This keys the reverse index and the reverse
   companion session on the translated id so the reply demuxes. It is a no-op
   when `rewrite_src_port` is `None`, so interface-mode SNAT, static NAT, DNAT,
   NAT64 (which sets `rewrite_src_port: None`), and un-NAT'd ICMP are
   byte-identical.

3. **`afxdp/frame/mod.rs`** — `apply_nat_icmp_identifier_rewrite` rewrites the
   Identifier field at `l4+4` and repairs the ICMP checksum incrementally in
   **both** directions — forward (orig → translated via `rewrite_src_port`) and
   reverse (translated → orig via the `rewrite_dst_port` that
   `NatDecision::reverse` produces). Gated on an identifier-bearing ICMP type,
   so error/control messages keep their `l4+4` bytes untouched. For ICMPv6 the
   pseudo-header address delta is already folded by the IP-rewrite section;
   ICMPv4 has no pseudo-header, so only the identifier delta matters. ICMP is
   never flow-cached (`packet_eligible` = TCP-ACK/UDP only), so the TCP/UDP
   descriptor fast path is unaffected.

Scope note: **interface-mode** SNAT remains address-only (it preserves the
source port / ICMP id for every protocol) — out of scope for #4074, which is
specifically pool SNAT.

## Tests (RED-on-revert)

- `nat/tests.rs`: `pool_snat_translates_icmp_query_id_distinct_per_host`
  (v4 + v6) — two hosts sharing one pool address + the same original id get
  **distinct** translated ids and consume two pool ids;
  `pool_snat_icmp_without_query_id_is_address_only` pins the flowless case.
- `session/tests.rs`: `icmp_query_id_translation_demuxes_reverse_wire_key` —
  distinct translated ids give distinct reverse wire/companion keys; a reply
  carrying host A's id matches forward A but not forward B; documents the
  collision without translation.
- `afxdp/frame/tests.rs`: `..._translates_icmpv4_echo_identifier` + the icmpv6
  sibling — on-wire identifier rewrite + valid ICMP checksum, forward and
  reverse (via the real `NatDecision::reverse` inversion).

## Validation

- FULL `cargo test --release` (`--test-threads=1`) green.
- `go build ./...` green.
- rustfmt clean on changed lines.
- Docs: `docs/userspace-dataplane-architecture.md` source-NAT pool-mode section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
