### PR TITLE
filter: stop double-counting a `then count` term via the CoS TX-selection ingress leg (#4085)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -31951,3 +31951,38 @@ top.
   - **File(s)**: pkg/config/compiler_nat.go,
     pkg/config/compiler_nat_pool_alarm_test.go,
     docs/deterministic-nat-cgnat.md, docs/config-schema.md, _Log.md
+- **Timestamp**: 2026-07-04
+  - **Action**: #4085 — firewall-filter `then count` double-count fix (Rust
+    dataplane). VERIFIED against origin/master: an interface INPUT filter term
+    with BOTH `then count` and a tx-selection modifier (`then forwarding-class`
+    / `then dscp`) OR a three-color policer was counted TWICE per packet. The
+    input-filter ACTION evaluation (`evaluate_non_pbr_input_filter` ->
+    `evaluate_interface_filter_non_routing_counted`) records the count once —
+    the one legitimate count. But when the egress interface has no output
+    filter and the input filter affects tx-selection / has a policer, the CoS
+    classifier (`afxdp/tx/cos_classify.rs` `resolve_cos_tx_selection[_at]`)
+    RE-WALKS the same ingress filter (to recover the fc queue / dscp-rewrite
+    and to meter the ingress policer) using the *counted* eval variant, reading
+    the SAME `term.counter` Arc a second time. Cacheable flows double-counted
+    the seed packet (+1/flow); non-cacheable (DSCP-sensitive / NAT64 / NPTv6)
+    double-counted EVERY packet. Fix: added counter-suppressed eval variants
+    `evaluate_filter_ref_tx_selection_{,runtime_}uncounted` (thread a
+    `count_terms: bool`; when false, skip `record_filter_counter` but KEEP the
+    policer meter + fc/dscp/log accumulation), and switched the INGRESS
+    tx-selection leg (cos_classify.rs) to them. The OUTPUT-filter leg KEEPS
+    counting (an output filter is action-evaluated nowhere else). Cache-hit
+    exactly-once is preserved unchanged: the cached path already captures the
+    ingress count via the non-counting `evaluate_filter_ref_tx_selection_cached`
+    into `tx_selection.filter_counters`, deduped against `input_filter_counters`
+    (#3777, flow_cache.rs `retain_absent_from`), replayed once per hit. So miss
+    (action-eval) + hits (cached replay) = exactly one per packet.
+    RED-on-revert (6 tests fail on revert, the plain-count no-regression guard
+    stays green): miss v4/v6, None-now_ns branch, count+policer (also asserts
+    the policer STILL meters -> drop), non-cacheable 3-packet, and cache-hit
+    seed+2hits=3. FULL cargo test --release green; go build ./... green.
+    Docs: userspace-dp/src/filter/README.md.
+  - **File(s)**: userspace-dp/src/filter/engine/tx_selection.rs,
+    userspace-dp/src/filter/engine/mod.rs,
+    userspace-dp/src/afxdp/tx/cos_classify.rs,
+    userspace-dp/src/afxdp/tx/cos_classify_tests.rs,
+    userspace-dp/src/filter/README.md, _Log.md

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -480,8 +480,17 @@ fn resolve_cos_tx_selection_internal(
     if let Some(ingress_filter) = ingress_filter.filter(|filter| {
         (!has_output_filter && filter.affects_tx_selection) || filter.has_three_color_policer_terms
     }) {
+        // #4085: the INGRESS input filter's `then count` terms are already
+        // recorded exactly once by the input-filter ACTION evaluation
+        // (`evaluate_non_pbr_input_filter` on the session-miss / DSCP-sensitive
+        // session-hit path) and, for a cacheable flow, replayed on hits from the
+        // cached filter_counter set. This tx-selection re-walk exists ONLY to
+        // extract forwarding-class / dscp-rewrite for queue selection and to
+        // METER the ingress three-color policer, so it MUST NOT re-record the
+        // count — use the counter-suppressed variant (the policer meter still
+        // runs via the threaded now_ns).
         let ingress_result = if let Some(now_ns) = now_ns {
-            crate::filter::evaluate_filter_ref_tx_selection_runtime_counted(
+            crate::filter::evaluate_filter_ref_tx_selection_runtime_uncounted(
                 ingress_filter,
                 flow_key.src_ip,
                 flow_key.dst_ip,
@@ -494,7 +503,7 @@ fn resolve_cos_tx_selection_internal(
                 now_ns,
             )
         } else {
-            crate::filter::evaluate_filter_ref_tx_selection_counted(
+            crate::filter::evaluate_filter_ref_tx_selection_uncounted(
                 ingress_filter,
                 flow_key.src_ip,
                 flow_key.dst_ip,

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -3377,3 +3377,537 @@ fn pbr_recovers_classify_modifiers_on_cached_tx_selection() {
         "#2621: cached dscp rewrite must survive the PBR term"
     );
 }
+
+// ============================================================================
+// #4085: an interface INPUT filter term carrying BOTH `then count` and a
+// tx-selection modifier (`then forwarding-class` / `then dscp`) OR a three-color
+// policer must be counted EXACTLY ONCE per packet.
+//
+// The `then count` hit-counter is owned by the input-filter ACTION evaluation
+// (`evaluate_non_pbr_input_filter` -> `evaluate_interface_filter_non_routing_counted`,
+// on the session-miss / DSCP-sensitive session-hit path). The CoS TX-selection
+// re-walk (`resolve_cos_tx_selection[_at]`) re-reads the SAME `term.counter` Arc
+// only to extract forwarding-class / dscp-rewrite for queue selection and to
+// METER the ingress three-color policer. Before the fix that re-walk used the
+// *counted* eval variant, so it recorded the count a SECOND time — doubling the
+// hit counter on every packet of a non-cacheable flow (DSCP-sensitive / NAT64 /
+// NPTv6) and on the seed packet of a cacheable flow.
+//
+// The fix makes the ingress TX-selection leg counter-suppressed
+// (`evaluate_filter_ref_tx_selection_{,runtime_}uncounted`); the OUTPUT leg
+// stays counted (an output filter is action-evaluated nowhere else), the policer
+// still meters, and the cache-hit replay (deduped `filter_counters` +
+// `input_filter_counters`) still records exactly once per hit.
+//
+// Each test replays the session-miss two-leg sequence (action-eval count, then
+// TX-selection walk) and asserts the term counter lands on 1, not 2 — RED (2) on
+// revert.
+// ============================================================================
+
+fn count_fc_two_class_service() -> ClassOfServiceSnapshot {
+    ClassOfServiceSnapshot {
+        forwarding_classes: vec![
+            CoSForwardingClassSnapshot {
+                name: "best-effort".into(),
+                queue: 0,
+            },
+            CoSForwardingClassSnapshot {
+                name: "expedited-forwarding".into(),
+                queue: 1,
+            },
+        ],
+        dscp_classifiers: vec![],
+        ieee8021_classifiers: vec![],
+        dscp_rewrite_rules: vec![],
+        schedulers: vec![
+            CoSSchedulerSnapshot {
+                name: "be-sched".into(),
+                transmit_rate_bytes: 4_000_000,
+                transmit_rate_exact: false,
+                priority: "low".into(),
+                buffer_size_bytes: 128_000,
+                buffer_size_percent: 0.0,
+                surplus_sharing: false,
+                equal_flow_enforcement: false,
+                equal_flow_target_policy: String::new(),
+                codel_target_ns: 0,
+            },
+            CoSSchedulerSnapshot {
+                name: "ef-sched".into(),
+                transmit_rate_bytes: 6_000_000,
+                transmit_rate_exact: false,
+                priority: "strict-high".into(),
+                buffer_size_bytes: 64_000,
+                buffer_size_percent: 0.0,
+                surplus_sharing: false,
+                equal_flow_enforcement: false,
+                equal_flow_target_policy: String::new(),
+                codel_target_ns: 0,
+            },
+        ],
+        scheduler_maps: vec![CoSSchedulerMapSnapshot {
+            name: "wan-map".into(),
+            entries: vec![
+                CoSSchedulerMapEntrySnapshot {
+                    forwarding_class: "best-effort".into(),
+                    scheduler: "be-sched".into(),
+                },
+                CoSSchedulerMapEntrySnapshot {
+                    forwarding_class: "expedited-forwarding".into(),
+                    scheduler: "ef-sched".into(),
+                },
+            ],
+        }],
+    }
+}
+
+/// Ingress reth1.0 (ifindex 101, parent 5) carries an input filter with a single
+/// `accept; count; forwarding-class expedited-forwarding;` term; egress reth0.0
+/// (ifindex 202) is a CoS interface with NO output filter — so the CoS
+/// TX-selection re-walks the ingress input filter for its forwarding-class.
+fn input_count_fc_snapshot(is_v6: bool) -> ConfigSnapshot {
+    let family = if is_v6 { "inet6" } else { "inet" };
+    let mut ingress = InterfaceSnapshot {
+        name: "reth1.0".into(),
+        ifindex: 101,
+        parent_ifindex: 5,
+        vlan_id: 0,
+        hardware_addr: "02:bf:72:00:61:01".into(),
+        ..Default::default()
+    };
+    if is_v6 {
+        ingress.filter_input_v6 = "in-count-fc".into();
+    } else {
+        ingress.filter_input_v4 = "in-count-fc".into();
+    }
+    ConfigSnapshot {
+        interfaces: vec![
+            ingress,
+            InterfaceSnapshot {
+                name: "reth0.0".into(),
+                ifindex: 202,
+                hardware_addr: "02:bf:72:00:80:08".into(),
+                cos_shaping_rate_bytes_per_sec: 10_000_000,
+                cos_shaping_burst_bytes: 256_000,
+                cos_scheduler_map: "wan-map".into(),
+                ..Default::default()
+            },
+        ],
+        filters: vec![FirewallFilterSnapshot {
+            name: "in-count-fc".into(),
+            family: family.into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "voice".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                action: "accept".into(),
+                count: "lan-hits".into(),
+                forwarding_class: "expedited-forwarding".into(),
+                ..Default::default()
+            }],
+        }],
+        class_of_service: Some(count_fc_two_class_service()),
+        ..Default::default()
+    }
+}
+
+/// Ingress input filter term with `then count` AND a three-color policer (tiny
+/// committed burst -> RED drop) but NO forwarding-class. The `has_three_color_
+/// policer_terms` gate (not `affects_tx_selection`) drives the TX-selection
+/// re-walk here; the policer must still METER (drop) while the count is
+/// suppressed.
+fn input_count_policer_snapshot() -> ConfigSnapshot {
+    ConfigSnapshot {
+        interfaces: vec![
+            InterfaceSnapshot {
+                name: "reth1.0".into(),
+                ifindex: 101,
+                parent_ifindex: 5,
+                vlan_id: 0,
+                hardware_addr: "02:bf:72:00:61:01".into(),
+                filter_input_v4: "in-count-pol".into(),
+                ..Default::default()
+            },
+            InterfaceSnapshot {
+                name: "reth0.0".into(),
+                ifindex: 202,
+                hardware_addr: "02:bf:72:00:80:08".into(),
+                cos_shaping_rate_bytes_per_sec: 10_000_000,
+                cos_shaping_burst_bytes: 256_000,
+                cos_scheduler_map: "wan-map".into(),
+                ..Default::default()
+            },
+        ],
+        filters: vec![FirewallFilterSnapshot {
+            name: "in-count-pol".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "metered".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                action: "accept".into(),
+                count: "lan-hits".into(),
+                policer: "trickle".into(),
+                ..Default::default()
+            }],
+        }],
+        three_color_policers: vec![ThreeColorPolicerSnapshot {
+            name: "trickle".into(),
+            mode: "single-rate".into(),
+            color_blind: true,
+            committed_rate_bytes_per_sec: 1,
+            committed_burst_bytes: 1,
+            peak_or_excess_rate_bytes_per_sec: 0,
+            peak_or_excess_burst_bytes: 1,
+            then_action: "discard".into(),
+        }],
+        class_of_service: Some(count_fc_two_class_service()),
+        ..Default::default()
+    }
+}
+
+/// A plain `accept; count;` input filter with NO tx-selection modifier and NO
+/// policer: the CoS TX-selection ingress branch never fires for it, so the
+/// counter must be untouched by the re-walk (a no-regression guard, GREEN both
+/// before and after the fix).
+fn input_count_only_snapshot() -> ConfigSnapshot {
+    ConfigSnapshot {
+        interfaces: vec![
+            InterfaceSnapshot {
+                name: "reth1.0".into(),
+                ifindex: 101,
+                parent_ifindex: 5,
+                vlan_id: 0,
+                hardware_addr: "02:bf:72:00:61:01".into(),
+                filter_input_v4: "in-count-only".into(),
+                ..Default::default()
+            },
+            InterfaceSnapshot {
+                name: "reth0.0".into(),
+                ifindex: 202,
+                hardware_addr: "02:bf:72:00:80:08".into(),
+                cos_shaping_rate_bytes_per_sec: 10_000_000,
+                cos_shaping_burst_bytes: 256_000,
+                cos_scheduler_map: "wan-map".into(),
+                ..Default::default()
+            },
+        ],
+        filters: vec![FirewallFilterSnapshot {
+            name: "in-count-only".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "count".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                action: "accept".into(),
+                count: "lan-hits".into(),
+                ..Default::default()
+            }],
+        }],
+        class_of_service: Some(count_fc_two_class_service()),
+        ..Default::default()
+    }
+}
+
+fn count4085_v4_key() -> SessionKey {
+    SessionKey {
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+        src_port: 12345,
+        dst_port: 443,
+    }
+}
+
+fn count4085_v6_key() -> SessionKey {
+    SessionKey {
+        addr_family: libc::AF_INET6 as u8,
+        protocol: PROTO_TCP,
+        src_ip: IpAddr::V6(Ipv6Addr::new(0x2001, 0x559, 0x8585, 0x61, 0, 0, 0, 100)),
+        dst_ip: IpAddr::V6(Ipv6Addr::new(0x2001, 0x559, 0x8585, 0x80, 0, 0, 0, 200)),
+        src_port: 12345,
+        dst_port: 443,
+    }
+}
+
+fn count4085_meta(is_v6: bool) -> UserspaceDpMeta {
+    UserspaceDpMeta {
+        ingress_ifindex: 5,
+        ingress_vlan_id: 0,
+        addr_family: if is_v6 {
+            libc::AF_INET6 as u8
+        } else {
+            libc::AF_INET as u8
+        },
+        protocol: PROTO_TCP,
+        dscp: 0,
+        pkt_len: 1500,
+        ..Default::default()
+    }
+}
+
+/// Read the `Arc<FilterTermCounter>` for the sole `then count` term of the
+/// ingress input filter attached at `ifindex`.
+fn ingress_count_term_counter(
+    forwarding: &ForwardingState,
+    ifindex: i32,
+    is_v6: bool,
+) -> Arc<crate::filter::FilterTermCounter> {
+    let filters = if is_v6 {
+        &forwarding.filter_state.iface_filter_v6_fast
+    } else {
+        &forwarding.filter_state.iface_filter_v4_fast
+    };
+    filters
+        .get(&ifindex)
+        .expect("ingress input filter present")
+        .terms
+        .iter()
+        .find(|term| term.has_count)
+        .expect("input filter carries a `then count` term")
+        .counter
+        .clone()
+}
+
+/// Leg 1 of the session-miss path: the input-filter ACTION evaluation records
+/// the `then count` hit-counter exactly once (the ONE legitimate count).
+fn count4085_action_eval(forwarding: &ForwardingState, is_v6: bool, key: &SessionKey, pkt_len: u64) {
+    crate::filter::evaluate_interface_filter_non_routing_counted(
+        &forwarding.filter_state,
+        101,
+        is_v6,
+        key.src_ip,
+        key.dst_ip,
+        key.protocol,
+        key.src_port,
+        key.dst_port,
+        0,
+        TermMatchExtra::default(),
+        pkt_len,
+        crate::filter::NonRoutingCountPolicy::Always,
+    );
+}
+
+fn count4085_counts_once_per_miss(is_v6: bool) {
+    let forwarding = build_forwarding_state(&input_count_fc_snapshot(is_v6));
+    let counter = ingress_count_term_counter(&forwarding, 101, is_v6);
+    let key = if is_v6 {
+        count4085_v6_key()
+    } else {
+        count4085_v4_key()
+    };
+    let meta = count4085_meta(is_v6);
+
+    // Leg 1: action-eval counts once. Assert it landed on the RIGHT counter so a
+    // wrong-ifindex zero here can't let a pre-fix leg-2 double masquerade as 1.
+    count4085_action_eval(&forwarding, is_v6, &key, meta.pkt_len as u64);
+    assert_eq!(
+        counter.packets.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "input-filter action-eval records the `then count` exactly once"
+    );
+
+    // Leg 2 (runtime, now_ns present): the CoS TX-selection walk recovers the
+    // forwarding-class queue but MUST NOT re-record the count.
+    let sel = resolve_cos_tx_selection_at(
+        &forwarding,
+        202,
+        meta,
+        Some(&key),
+        TermMatchExtra::default(),
+        1_000_000_000,
+    );
+    assert_eq!(
+        sel.queue_id,
+        Some(1),
+        "forwarding-class -> EF queue must still be selected"
+    );
+    assert_eq!(
+        counter.packets.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "#4085: the TX-selection ingress leg must NOT re-record the input-filter \
+         count (RED == 2 on revert)"
+    );
+}
+
+#[test]
+fn input_filter_count_plus_fc_counts_once_per_miss_v4() {
+    count4085_counts_once_per_miss(false);
+}
+
+#[test]
+fn input_filter_count_plus_fc_counts_once_per_miss_v6() {
+    count4085_counts_once_per_miss(true);
+}
+
+#[test]
+fn input_filter_count_plus_fc_counts_once_none_now_ns_branch_v4() {
+    // Exercise the `now_ns == None` entry point (`resolve_cos_tx_selection` ->
+    // `evaluate_filter_ref_tx_selection_uncounted`), the sibling of the runtime
+    // branch above.
+    let forwarding = build_forwarding_state(&input_count_fc_snapshot(false));
+    let counter = ingress_count_term_counter(&forwarding, 101, false);
+    let key = count4085_v4_key();
+    let meta = count4085_meta(false);
+
+    count4085_action_eval(&forwarding, false, &key, meta.pkt_len as u64);
+    assert_eq!(counter.packets.load(std::sync::atomic::Ordering::Relaxed), 1);
+
+    let sel = resolve_cos_tx_selection(&forwarding, 202, meta, Some(&key), TermMatchExtra::default());
+    assert_eq!(sel.queue_id, Some(1));
+    assert_eq!(
+        counter.packets.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "#4085: the None-now_ns TX-selection ingress leg must NOT re-count \
+         (RED == 2 on revert)"
+    );
+}
+
+#[test]
+fn input_filter_count_plus_policer_counts_once_and_still_meters_v4() {
+    // The `has_three_color_policer_terms` gate drives the re-walk. The count must
+    // be suppressed BUT the policer must still meter (RED -> drop) — the policer
+    // is metered nowhere else.
+    let forwarding = build_forwarding_state(&input_count_policer_snapshot());
+    let counter = ingress_count_term_counter(&forwarding, 101, false);
+    let key = count4085_v4_key();
+    let meta = count4085_meta(false);
+
+    count4085_action_eval(&forwarding, false, &key, meta.pkt_len as u64);
+    assert_eq!(counter.packets.load(std::sync::atomic::Ordering::Relaxed), 1);
+
+    let sel = resolve_cos_tx_selection_at(
+        &forwarding,
+        202,
+        meta,
+        Some(&key),
+        TermMatchExtra::default(),
+        1_000_000_000,
+    );
+    assert!(
+        sel.drop,
+        "#4085: the ingress three-color policer must still meter (RED -> drop) \
+         even though the count is suppressed"
+    );
+    assert_eq!(
+        counter.packets.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "#4085: count+policer input term must count once, not twice \
+         (RED == 2 on revert)"
+    );
+}
+
+#[test]
+fn plain_count_only_input_filter_unchanged_v4() {
+    // No fc / dscp / policer -> the TX-selection ingress branch never fires, so
+    // the re-walk leaves the counter untouched (no-regression guard).
+    let forwarding = build_forwarding_state(&input_count_only_snapshot());
+    let counter = ingress_count_term_counter(&forwarding, 101, false);
+    let key = count4085_v4_key();
+    let meta = count4085_meta(false);
+
+    count4085_action_eval(&forwarding, false, &key, meta.pkt_len as u64);
+    let _ = resolve_cos_tx_selection_at(
+        &forwarding,
+        202,
+        meta,
+        Some(&key),
+        TermMatchExtra::default(),
+        1_000_000_000,
+    );
+    assert_eq!(
+        counter.packets.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "a plain count-only input filter is counted once and untouched by \
+         TX-selection"
+    );
+}
+
+#[test]
+fn non_cacheable_flow_counts_once_per_packet_v4() {
+    // A non-cacheable (DSCP-sensitive / NAT64 / NPTv6) flow takes the session-miss
+    // path on EVERY packet, so the double-count is per-packet, not per-flow.
+    // Replay the two-leg miss sequence 3x and require exactly 3 counts (RED == 6
+    // on revert).
+    let forwarding = build_forwarding_state(&input_count_fc_snapshot(false));
+    let counter = ingress_count_term_counter(&forwarding, 101, false);
+    let key = count4085_v4_key();
+    let meta = count4085_meta(false);
+
+    for _ in 0..3 {
+        count4085_action_eval(&forwarding, false, &key, meta.pkt_len as u64);
+        let _ = resolve_cos_tx_selection_at(
+            &forwarding,
+            202,
+            meta,
+            Some(&key),
+            TermMatchExtra::default(),
+            1_000_000_000,
+        );
+    }
+    assert_eq!(
+        counter.packets.load(std::sync::atomic::Ordering::Relaxed),
+        3,
+        "#4085: a non-cacheable flow counts once per packet (RED == 6 on revert)"
+    );
+}
+
+#[test]
+fn cache_hit_replays_input_count_exactly_once_v4() {
+    // End-to-end exactly-once across a cacheable flow: the seed (miss) packet is
+    // counted by the action-eval (leg 1) with the TX-selection re-walk suppressed
+    // (leg 2), and each subsequent flow-cache HIT replays the deduped cached
+    // counter sets exactly once. seed(1) + 2 hits(1 each) == 3.
+    let forwarding = build_forwarding_state(&input_count_fc_snapshot(false));
+    let counter = ingress_count_term_counter(&forwarding, 101, false);
+    let key = count4085_v4_key();
+    let meta = count4085_meta(false);
+
+    // --- seed / miss packet.
+    count4085_action_eval(&forwarding, false, &key, meta.pkt_len as u64);
+    let _ = resolve_cos_tx_selection_at(
+        &forwarding,
+        202,
+        meta,
+        Some(&key),
+        TermMatchExtra::default(),
+        1_000_000_000,
+    );
+    assert_eq!(
+        counter.packets.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "seed packet counts once"
+    );
+
+    // --- build the cached counter sets exactly as flow-cache install does: the
+    // cos rebuild folds the input filter's count into `tx_selection.filter_counters`
+    // (no output filter present) and the dedicated input replay set is deduped
+    // against it (`retain_absent_from`) so the count lives in exactly ONE set.
+    let tx = resolve_cached_cos_tx_selection(&forwarding, 202, meta, Some(&key));
+    let mut input_counters = crate::filter::evaluate_interface_input_filter_counters_cached(
+        &forwarding.filter_state,
+        101,
+        false,
+        key.src_ip,
+        key.dst_ip,
+        key.protocol,
+        key.src_port,
+        key.dst_port,
+        meta.dscp,
+    );
+    input_counters.retain_absent_from(&tx.filter_counters);
+
+    // --- two flow-cache HITs: replay both sets once per hit (flow_cache_hit.rs).
+    for _ in 0..2 {
+        tx.filter_counters
+            .for_each(|c| crate::filter::record_filter_counter(c, meta.pkt_len as u64));
+        input_counters.for_each(|c| crate::filter::record_filter_counter(c, meta.pkt_len as u64));
+    }
+    assert_eq!(
+        counter.packets.load(std::sync::atomic::Ordering::Relaxed),
+        3,
+        "#4085: seed (1) + 2 cache hits (1 each) == 3 — hits must count once, \
+         not zero or two"
+    );
+}

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -221,6 +221,28 @@ Mirrors the BPF firewall-filter pipeline in userspace.
   exits. (The earlier coarse fix gated the precheck solely on
   `affects_route_lookup`; that under-counted to zero on the discard/reject
   and session-hit exits, where the routing evaluator is never the counter.)
+
+  **The CoS TX-selection INGRESS leg is counter-suppressed (#4085).** An
+  interface INPUT filter is action-evaluated for its `then count` exactly
+  once (the #2620 precheck above / the DSCP-sensitive session-hit re-eval).
+  But when the resolved egress interface has NO output filter and the input
+  filter `affects_tx_selection` (a `then forwarding-class` / `then dscp`
+  term) OR carries a three-color policer, the CoS classifier
+  (`afxdp/tx/cos_classify.rs` `resolve_cos_tx_selection[_at]`) RE-WALKS the
+  same ingress filter to recover the forwarding-class queue / dscp-rewrite
+  and to METER the ingress three-color policer. That re-walk reads the SAME
+  `term.counter` Arc, so counting it there double-counts every packet of a
+  non-cacheable flow (DSCP-sensitive / NAT64 / NPTv6) and the seed packet of
+  a cacheable one. The ingress leg therefore uses the counter-suppressed
+  eval variant (`evaluate_filter_ref_tx_selection_{,runtime_}uncounted`,
+  `count_terms == false`): fc/dscp/log accumulate and the policer STILL
+  meters, but `record_filter_counter` is NOT called. The OUTPUT-filter leg
+  KEEPS counting: an output filter is action-evaluated nowhere else, so its
+  single `then count` belongs to the TX-selection walk. On the flow-cache
+  HIT path the ingress count is replayed exactly once from the cached
+  `tx_selection.filter_counters` (deduped against the dedicated
+  `input_filter_counters` set at seed, #3777), so miss (action-eval) + hits
+  (cached replay) still total exactly one per packet.
 - `policer.rs` — token-bucket implementation plus the #1375 RFC
   2697/2698 three-color meter core. Token math is integer-only:
   the legacy token bucket keeps its bits/sec constructor contract, and

--- a/userspace-dp/src/filter/engine/mod.rs
+++ b/userspace-dp/src/filter/engine/mod.rs
@@ -30,6 +30,7 @@ pub(crate) use policer::{
 };
 pub(crate) use tx_selection::{
     evaluate_filter_ref_tx_selection_counted, evaluate_filter_ref_tx_selection_runtime_counted,
+    evaluate_filter_ref_tx_selection_runtime_uncounted, evaluate_filter_ref_tx_selection_uncounted,
     evaluate_interface_filter_tx_selection_counted,
     evaluate_interface_output_filter_tx_selection_counted, filter_state_has_input_tx_selection,
     filter_state_has_output_tx_selection, interface_filter_affects_tx_selection,

--- a/userspace-dp/src/filter/engine/tx_selection.rs
+++ b/userspace-dp/src/filter/engine/tx_selection.rs
@@ -41,6 +41,43 @@ pub(crate) fn evaluate_filter_ref_tx_selection_counted<'a>(
         extra,
         packet_bytes,
         None,
+        true,
+    )
+}
+
+/// #4085: TX-selection walk that extracts forwarding-class / dscp-rewrite /
+/// three-color-policer modifiers but does NOT record `then count` term
+/// counters. Used for the INGRESS input filter's tx-selection leg
+/// ([`resolve_cos_tx_selection_internal`]) — that filter's `then count`
+/// counters are already recorded once by the input-filter ACTION evaluation
+/// (`evaluate_non_pbr_input_filter`, `poll_descriptor`), so a second increment
+/// here double-counted every packet of a non-cacheable flow (and the seed
+/// packet of a cacheable one). The three-color policer METER still runs (it is
+/// metered nowhere else); only the counter increment is suppressed.
+#[inline]
+pub(crate) fn evaluate_filter_ref_tx_selection_uncounted<'a>(
+    filter: &'a Filter,
+    src_ip: IpAddr,
+    dst_ip: IpAddr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+    extra: TermMatchExtra<'_>,
+    packet_bytes: u64,
+) -> TxSelectionFilterResult<'a> {
+    evaluate_filter_ref_tx_selection_runtime(
+        filter,
+        src_ip,
+        dst_ip,
+        protocol,
+        src_port,
+        dst_port,
+        dscp,
+        extra,
+        packet_bytes,
+        None,
+        false,
     )
 }
 
@@ -67,10 +104,44 @@ pub(crate) fn evaluate_filter_ref_tx_selection_runtime_counted<'a>(
         extra,
         packet_bytes,
         Some(now_ns),
+        true,
+    )
+}
+
+/// #4085: three-color-policer-metered but counter-suppressed sibling of
+/// [`evaluate_filter_ref_tx_selection_runtime_counted`]. See
+/// [`evaluate_filter_ref_tx_selection_uncounted`] for why the ingress leg must
+/// not re-record `then count` — this variant threads `now_ns` so the ingress
+/// three-color policer still meters, while suppressing the double count.
+pub(crate) fn evaluate_filter_ref_tx_selection_runtime_uncounted<'a>(
+    filter: &'a Filter,
+    src_ip: IpAddr,
+    dst_ip: IpAddr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+    extra: TermMatchExtra<'_>,
+    packet_bytes: u64,
+    now_ns: u64,
+) -> TxSelectionFilterResult<'a> {
+    evaluate_filter_ref_tx_selection_runtime(
+        filter,
+        src_ip,
+        dst_ip,
+        protocol,
+        src_port,
+        dst_port,
+        dscp,
+        extra,
+        packet_bytes,
+        Some(now_ns),
+        false,
     )
 }
 
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn evaluate_filter_ref_tx_selection_runtime<'a>(
     filter: &'a Filter,
     src_ip: IpAddr,
@@ -82,6 +153,11 @@ fn evaluate_filter_ref_tx_selection_runtime<'a>(
     extra: TermMatchExtra<'_>,
     packet_bytes: u64,
     now_ns: Option<u64>,
+    // #4085: when false, matched `then count` terms are NOT recorded (the
+    // policer meter + fc/dscp/log modifiers still apply). The ingress
+    // tx-selection leg passes false — the input-filter action-eval owns that
+    // count.
+    count_terms: bool,
 ) -> TxSelectionFilterResult<'a> {
     match (src_ip, dst_ip) {
         (IpAddr::V4(src), IpAddr::V4(dst)) => evaluate_filter_ref_tx_selection_counted_v4(
@@ -95,6 +171,7 @@ fn evaluate_filter_ref_tx_selection_runtime<'a>(
             extra,
             packet_bytes,
             now_ns,
+            count_terms,
         ),
         (IpAddr::V6(src), IpAddr::V6(dst)) => evaluate_filter_ref_tx_selection_counted_v6(
             filter,
@@ -107,12 +184,14 @@ fn evaluate_filter_ref_tx_selection_runtime<'a>(
             extra,
             packet_bytes,
             now_ns,
+            count_terms,
         ),
         _ => TxSelectionFilterResult::default(),
     }
 }
 
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn evaluate_filter_ref_tx_selection_counted_v4<'a>(
     filter: &'a Filter,
     src_ip: Ipv4Addr,
@@ -124,6 +203,7 @@ fn evaluate_filter_ref_tx_selection_counted_v4<'a>(
     extra: TermMatchExtra<'_>,
     packet_bytes: u64,
     now_ns: Option<u64>,
+    count_terms: bool,
 ) -> TxSelectionFilterResult<'a> {
     // #2544: accumulate modifiers across fall-through terms (forwarding-class,
     // dscp-rewrite, policer metering + drop, log). A matched fall-through term
@@ -137,7 +217,9 @@ fn evaluate_filter_ref_tx_selection_counted_v4<'a>(
         ) {
             continue;
         }
-        if term.has_count {
+        // #4085: skip the counter on the ingress tx-selection leg (count_terms
+        // == false) — the input-filter action-eval already recorded it once.
+        if count_terms && term.has_count {
             record_filter_counter(&term.counter, packet_bytes);
         }
         merge_matched_tx_modifiers(&mut acc, filter, term, now_ns, packet_bytes);
@@ -180,6 +262,7 @@ fn merge_matched_tx_modifiers<'a>(
 }
 
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn evaluate_filter_ref_tx_selection_counted_v6<'a>(
     filter: &'a Filter,
     src_ip: Ipv6Addr,
@@ -191,6 +274,7 @@ fn evaluate_filter_ref_tx_selection_counted_v6<'a>(
     extra: TermMatchExtra<'_>,
     packet_bytes: u64,
     now_ns: Option<u64>,
+    count_terms: bool,
 ) -> TxSelectionFilterResult<'a> {
     // #2544: see evaluate_filter_ref_tx_selection_counted_v4.
     let mut acc = TxSelectionFilterResult::default();
@@ -200,7 +284,9 @@ fn evaluate_filter_ref_tx_selection_counted_v6<'a>(
         ) {
             continue;
         }
-        if term.has_count {
+        // #4085: skip the counter on the ingress tx-selection leg (count_terms
+        // == false) — the input-filter action-eval already recorded it once.
+        if count_terms && term.has_count {
             record_filter_counter(&term.counter, packet_bytes);
         }
         merge_matched_tx_modifiers(&mut acc, filter, term, now_ns, packet_bytes);

--- a/userspace-dp/src/filter/engine/tx_selection.rs
+++ b/userspace-dp/src/filter/engine/tx_selection.rs
@@ -48,7 +48,7 @@ pub(crate) fn evaluate_filter_ref_tx_selection_counted<'a>(
 /// #4085: TX-selection walk that extracts forwarding-class / dscp-rewrite /
 /// three-color-policer modifiers but does NOT record `then count` term
 /// counters. Used for the INGRESS input filter's tx-selection leg
-/// ([`resolve_cos_tx_selection_internal`]) — that filter's `then count`
+/// (`resolve_cos_tx_selection_internal`) — that filter's `then count`
 /// counters are already recorded once by the input-filter ACTION evaluation
 /// (`evaluate_non_pbr_input_filter`, `poll_descriptor`), so a second increment
 /// here double-counted every packet of a non-cacheable flow (and the seed


### PR DESCRIPTION
## Summary

Closes #4085.

An interface INPUT firewall filter term carrying BOTH `then count` and a
TX-selection modifier (`then forwarding-class` / `then dscp`) OR a three-color
policer was counted **twice** per packet, so `show firewall` hit-counters
overreported.

### Root cause (Rust dataplane)

The `then count` hit-counter is legitimately owned by the input-filter **action**
evaluation (`evaluate_non_pbr_input_filter` →
`evaluate_interface_filter_non_routing_counted`), which records it exactly once on
the session-miss / DSCP-sensitive session-hit path.

But when the resolved egress interface has **no output filter** and the input
filter `affects_tx_selection` (or carries a three-color policer), the CoS
classifier (`afxdp/tx/cos_classify.rs` `resolve_cos_tx_selection[_at]`) **re-walks
the same ingress filter** to recover the forwarding-class queue / dscp-rewrite and
to meter the ingress policer. That re-walk used the *counted* TX-selection eval
variant, reading the **same** `term.counter` Arc a second time:

- **Cacheable flows** double-counted only the seed packet (+1 per flow).
- **Non-cacheable flows** (DSCP-sensitive / NAT64 / NPTv6, which miss on every
  packet) double-counted **every** packet.

### Fix

Add counter-suppressed eval variants
`evaluate_filter_ref_tx_selection_{,runtime_}uncounted` (thread a `count_terms`
flag through the shared runtime walk; when `false`, skip `record_filter_counter`
but keep the three-color policer **meter** and the fc/dscp/log accumulation). The
ingress TX-selection leg now calls the uncounted variants. The **output-filter**
leg keeps counting — an output filter is action-evaluated nowhere else, so its
single `then count` belongs there.

Cache-hit exactly-once is preserved unchanged: the cached path already captures
the ingress count with the non-counting `evaluate_filter_ref_tx_selection_cached`
into `tx_selection.filter_counters`, deduped against the dedicated
`input_filter_counters` set (#3777, `retain_absent_from`) and replayed once per
hit. Miss (action-eval) + hits (cached replay) = exactly one per packet.

### Tests (RED-on-revert)

New `cos_classify_tests.rs` tests replay the session-miss two-leg sequence and
assert the counter lands on 1, not 2:

- count + forwarding-class, runtime + `None`-now_ns branches, **v4 and v6**
- count + three-color policer — counter once **and** policer still meters (drop)
- plain count-only — no-regression guard (green before and after)
- non-cacheable 3-packet — exactly 3 counts (RED 6 on revert)
- cache-hit — seed + 2 hits = exactly 3 (exactly-once across the cache boundary)

Reverting the ingress leg to the counted variant fails the six double-count tests
while the plain-count guard stays green. Full `cargo test --release`
(3477 unit tests) and `go build ./...` are green.

Docs: `userspace-dp/src/filter/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
