### PR TITLE
ipsec: sanitize traffic-selector local_ts/remote_ts + strict commit gate (Closes #4098)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -32134,3 +32134,35 @@ top.
     userspace-dp/src/afxdp/tx/cos_classify.rs,
     userspace-dp/src/afxdp/tx/cos_classify_tests.rs,
     userspace-dp/src/filter/README.md, _Log.md
+
+- **Timestamp**: 2026-07-04
+  - **Action**: #4098 — IPsec traffic-selector local_ts/remote_ts swanctl
+    injection (config-injection → root RCE via `updown`). VERIFY-FIRST at HEAD
+    confirmed policy.go rendered child.LocalTS/RemoteTS with a bare `%s`
+    (unlike the sibling child.Name, which uses `sanitizeSwanctlValue`), sourced
+    from `traffic-selector local-ip/remote-ip` (+ `local-identity`/
+    `remote-identity` fallback) via `effectiveTrafficSelectors`. lexer.go
+    materializes `\n` in a quoted value. FINDING: the general free-text
+    control-char gate (`validateNodesControlChars`, freetext.go) ALREADY
+    rejects an embedded newline in ANY value at strict commit and sanitizes it
+    on the lenient path — so the pure-newline RCE-via-commit was not reachable
+    at HEAD; the issue's "NO commit validation" premise held only for
+    `compiler_validate*strict*.go`, missing the freetext gate. Still fixed the
+    two genuine residual gaps: (a) render-side belt — run local_ts/remote_ts
+    through `sanitizeSwanctlValue` (parity with child.Name), the defense for
+    any path that reaches render with an unsanitized typed config (direct
+    IPsecConfig construction / peer-sync); (b) new AST commit gate
+    `validateIPsecTrafficSelectorsStrict` — rejects a local-ip/remote-ip value
+    carrying a control char OR whitespace, or that is not a CIDR/host/range
+    (whitespace + shape are what the general gate misses). Strict on commit,
+    lenient-downgraded (warn) on load/sync per #1960; walks every value token
+    (both parser shapes + bracketed list #2419). RED-on-revert verified for
+    BOTH: reverting the render belt fails the direct-construction render test
+    (injected `updown =` line reaches the children block); neutralizing the
+    validator fails the whitespace + non-CIDR strict tests. go test
+    ./pkg/ipsec/... ./pkg/config/... green; go build ./... , go vet, gofmt
+    clean.
+  - **File(s)**: pkg/ipsec/policy.go,
+    pkg/config/compiler_ipsec_trafficselector.go, pkg/config/compiler.go,
+    pkg/ipsec/trafficselector_render_4098_test.go,
+    pkg/config/compiler_ipsec_ts_4098_test.go, pkg/ipsec/README.md, _Log.md

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -264,6 +264,24 @@ type compileOpts struct {
 	// lenientIPsecPolicyProposalRef.
 	lenientIKEPolicyChainRef bool
 
+	// lenientIPsecTrafficSelectors (#4098) downgrades the IPsec
+	// `traffic-selector local-ip / remote-ip` value gate
+	// (validateIPsecTrafficSelectorsStrict) from a hard compile error to a
+	// cfg.Warnings entry on the tolerant load / peer-sync paths. A selector
+	// value containing a control character (a newline in particular) or
+	// whitespace, or one that is not a CIDR prefix / host address / IP range,
+	// would otherwise inject an arbitrary `key = value` line — e.g.
+	// `updown = <script>`, executed by the root charon daemon, or an
+	// `esp_proposals` override — into the rendered swanctl.conf children
+	// block (the swanctl-injection class already closed for the connection
+	// name / IKE identity / cert / PSK, #1798/#2126). Commit / commit-check
+	// stay strict so a new operator edit is rejected; an already-persisted or
+	// peer-synced config carrying such a value must still BOOT (warn) per the
+	// #1960 fail-closed-on-load doctrine — the render path now strips control
+	// chars (sanitizeSwanctlValue in pkg/ipsec/policy.go) so the malformed
+	// line stays inert. Same doctrine as lenientIKEPolicyChainRef.
+	lenientIPsecTrafficSelectors bool
+
 	// lenientLogProfileStreamRef (#2008 H7) downgrades the
 	// `security log profile <name> stream-name <stream>` cross-reference
 	// from a hard error to a warning on the tolerant load / peer-sync
@@ -1385,6 +1403,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientIPsecPolicyProposalRef:          true,
 		lenientIPsecGatewayRefs:                true,
 		lenientIKEPolicyChainRef:               true,
+		lenientIPsecTrafficSelectors:           true,
 		lenientLogProfileStreamRef:             true,
 		lenientDynamicAddressFeedRef:           true,
 		lenientNATPoolAlarmThreshold:           true,
@@ -1565,6 +1584,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientIPsecPolicyProposalRef:          true,
 		lenientIPsecGatewayRefs:                true,
 		lenientIKEPolicyChainRef:               true,
+		lenientIPsecTrafficSelectors:           true,
 		lenientLogProfileStreamRef:             true,
 		lenientDynamicAddressFeedRef:           true,
 		lenientNATPoolAlarmThreshold:           true,
@@ -1903,6 +1923,29 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		return nil, err
 	}
 
+	// #4098 IPsec traffic-selector injection gate. `security ipsec vpn
+	// <name> traffic-selector <ts> local-ip / remote-ip` are free-form 1-arg
+	// strings the IPsec renderer interpolates into the swanctl.conf
+	// children{} block as `local_ts = <value>` / `remote_ts = <value>`.
+	// Unlike the sibling child SA name they were emitted raw, so a value
+	// carrying a materialized `\n` (lexer.go) injected an arbitrary
+	// `key = value` line — `updown = <script>` runs as ROOT under charon, or
+	// an `esp_proposals` override silently rewrites the crypto posture — into
+	// the generated config. Runs on the group-expanded, inactive-pruned tree
+	// so an apply-groups-inherited selector is covered and an inactive VPN is
+	// ignored; it inspects EVERY value token (both parser shapes + a
+	// bracketed list, #2419) so a malicious token the typed compiler's
+	// nodeVal would drop is still caught. Strict (commit / commit-check):
+	// hard-reject naming the VPN, selector, leaf, and reason. Lenient (load /
+	// peer-sync): warn so an already-persisted or peer-synced config still
+	// boots (#1960) — the render belt (sanitizeSwanctlValue) keeps the value
+	// inert. Mirrors validateSecureTunnelBindInterfaceAST.
+	ipsecTSWarnings, err := validateIPsecTrafficSelectorsStrict(
+		tree.Children, opts.lenientIPsecTrafficSelectors)
+	if err != nil {
+		return nil, err
+	}
+
 	// #3113 security-policy unsupported-match-leaf gate. A policy whose
 	// `match` clause carries a leaf the compiler does not enforce (e.g.
 	// `dynamic-application`, `url-category`, `source-identity`) committed
@@ -2058,6 +2101,7 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	cfg.Warnings = append(cfg.Warnings, appCollisionWarnings...)
 	cfg.Warnings = append(cfg.Warnings, fwFilterFamilyWarnings...)
 	cfg.Warnings = append(cfg.Warnings, bindIfaceWarnings...)
+	cfg.Warnings = append(cfg.Warnings, ipsecTSWarnings...)
 	cfg.Warnings = append(cfg.Warnings, policyMatchWarnings...)
 	cfg.Warnings = append(cfg.Warnings, policyThenPermitWarnings...)
 	cfg.Warnings = append(cfg.Warnings, policyThenRejectWarnings...)

--- a/pkg/config/compiler_ipsec_trafficselector.go
+++ b/pkg/config/compiler_ipsec_trafficselector.go
@@ -1,0 +1,174 @@
+package config
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// compiler_ipsec_trafficselector.go carries the #4098 reject-at-commit gate
+// for IPsec `traffic-selector local-ip / remote-ip` values.
+//
+// The defect: `security ipsec vpn <name> traffic-selector <ts> local-ip` and
+// `remote-ip` are free-form 1-arg strings (schema_security.go). The IPsec
+// renderer (pkg/ipsec/policy.go effectiveTrafficSelectors → renderConfig)
+// interpolates them directly into the swanctl.conf children{} block as
+// `local_ts = <value>` / `remote_ts = <value>`. Unlike the sibling child SA
+// name (rendered through sanitizeSwanctlValue), these two values were emitted
+// raw. The Junos lexer materializes a `\n` escape inside a quoted value
+// (lexer.go), so a selector such as
+//
+//	set security ipsec vpn v1 traffic-selector ts1 local-ip \
+//	    "10.0.0.0/24\n        updown = /tmp/x.sh"
+//
+// injected a real newline plus an arbitrary `key = value` line into the
+// children{} block. charon runs as ROOT, so an injected `updown = <script>`
+// is a remote-config → root-RCE; an injected `esp_proposals` / `mode` /
+// `mark_*` silently rewrites the crypto posture. This is the traffic-selector
+// instance of the swanctl-injection class the module already closes for the
+// connection name / IKE identity / certificate / PSK (#1798/#2126).
+//
+// Two-layer fix (mirrors the FRR auth-value gate, #2889):
+//
+//   - Render belt: pkg/ipsec/policy.go now runs local_ts/remote_ts through
+//     sanitizeSwanctlValue (control chars → spaces), so even a value that
+//     reaches the renderer on the lenient load path cannot inject a line.
+//   - Commit gate (this file): a well-formed traffic selector is a CIDR
+//     prefix, a bare host address, or an IP range — never carries a control
+//     character or whitespace. Reject anything else at commit so the operator
+//     sees the malformed / malicious value instead of a silently mangled
+//     (sanitized-to-spaces) selector.
+//
+// This is an AST pre-walk (like validateSecureTunnelBindInterfaceAST) rather
+// than a typed-Config validator so it runs on the group-expanded,
+// inactive-pruned tree in compileExpanded: an apply-groups-inherited selector
+// is covered, an `inactive:` VPN is ignored, and — critically — it inspects
+// EVERY value token on the leaf (both parser shapes, plus a bracketed
+// `[ a b ]` list that the lexer collapses onto the leaf Keys, #2419), not just
+// the first token the typed compiler keeps (nodeVal reads only Keys[1], so a
+// malicious second token would otherwise be dropped from the typed config yet
+// escape validation).
+//
+// Strict path (commit / commit-check, lenient=false): the first offending
+// value is a hard compile error naming the VPN, the selector, the leaf, and
+// the reason.
+//
+// Lenient path (load / peer-sync, lenient=true): every offending value is
+// returned as a warning and compilation continues — an already-persisted or
+// peer-synced config that an older binary silently accepted still BOOTS (#1960
+// fail-closed-on-load class); the render belt keeps the value inert. Commit /
+// commit-check stay strict.
+func validateIPsecTrafficSelectorsStrict(nodes []*Node, lenient bool) ([]string, error) {
+	var warnings []string
+	emit := func(format string, args ...any) error {
+		msg := fmt.Sprintf(format, args...)
+		if !lenient {
+			return fmt.Errorf("%s", msg)
+		}
+		warnings = append(warnings, msg)
+		return nil
+	}
+
+	// Iterate EVERY top-level `security` node and EVERY `ipsec` sibling — the
+	// parser APPENDS a repeated top-level block rather than merging it, and
+	// compileExpanded compiles every one (mirrors #3562 in the bind-interface
+	// gate). A stable per-VPN, per-selector walk keeps error ordering
+	// deterministic.
+	walkErr := forEachChild(nodes, "security", func(security *Node) error {
+		return forEachChild(security.Children, "ipsec", func(ipsec *Node) error {
+			for _, vpnInst := range namedInstances(ipsec.FindChildren("vpn")) {
+				for _, tsInst := range namedInstances(vpnInst.node.FindChildren("traffic-selector")) {
+					for _, leaf := range tsInst.node.Children {
+						leafName := leaf.Name()
+						if leafName != "local-ip" && leafName != "remote-ip" {
+							continue
+						}
+						for _, val := range trafficSelectorValues(leaf) {
+							if reason := trafficSelectorValueReject(val); reason != "" {
+								if err := emit(
+									"security ipsec vpn %q traffic-selector %q %s %q %s "+
+										"(a traffic selector must be a CIDR prefix, a host "+
+										"address, or an IP range; a control character or "+
+										"whitespace would inject an arbitrary line — e.g. "+
+										"`updown = <script>`, run by charon as root, or an "+
+										"`esp_proposals` override — into the rendered "+
+										"swanctl.conf children block, #4098)",
+									vpnInst.name, tsInst.name, leafName, val, reason,
+								); err != nil {
+									return err
+								}
+							}
+						}
+					}
+				}
+			}
+			return nil
+		})
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return warnings, nil
+}
+
+// trafficSelectorValues returns every value token carried by a `local-ip` /
+// `remote-ip` leaf across BOTH parser AST shapes and a bracketed `[ a b ]`
+// list — mirrors firewallMatchValues (#2419). Reading Keys[1:] AND the child
+// names guarantees a malicious token in any list position is validated even
+// though the typed compiler's nodeVal keeps only Keys[1].
+func trafficSelectorValues(leaf *Node) []string {
+	var vals []string
+	for _, k := range leaf.Keys[1:] {
+		if k != "" {
+			vals = append(vals, k)
+		}
+	}
+	for _, vn := range leaf.Children {
+		if len(vn.Keys) >= 1 && vn.Keys[0] != "" {
+			vals = append(vals, vn.Keys[0])
+		}
+	}
+	return vals
+}
+
+// trafficSelectorValueReject returns a human-readable reason a traffic-selector
+// value is unacceptable, or "" if it is a well-formed CIDR prefix, host
+// address, or IP range. The control-character / whitespace check runs first so
+// the injection case gets an explicit reason; a value that clears it but is
+// not a routable selector shape is still rejected (operator hygiene).
+func trafficSelectorValueReject(v string) string {
+	for i := 0; i < len(v); i++ {
+		c := v[i]
+		if c < 0x20 || c == 0x7f {
+			return fmt.Sprintf("contains a control character (byte offset %d)", i)
+		}
+		if c == ' ' || c == '\t' {
+			return fmt.Sprintf("contains whitespace (byte offset %d)", i)
+		}
+	}
+	if !isTrafficSelectorShape(v) {
+		return "is not a valid CIDR prefix, host address, or IP range"
+	}
+	return ""
+}
+
+// isTrafficSelectorShape reports whether v is a CIDR prefix (v4/v6), a bare
+// host address (v4/v6), or an inclusive IP range `start-end` — the shapes a
+// swanctl local_ts / remote_ts value may take.
+func isTrafficSelectorShape(v string) bool {
+	if v == "" {
+		return false
+	}
+	// IP range: start-end (both endpoints bare addresses). Split on the FIRST
+	// '-' only; an IPv6 address never contains '-', and a v4 range uses a
+	// single separator.
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		start := v[:i]
+		end := v[i+1:]
+		return net.ParseIP(start) != nil && net.ParseIP(end) != nil
+	}
+	if _, _, err := net.ParseCIDR(v); err == nil {
+		return true
+	}
+	return net.ParseIP(v) != nil
+}

--- a/pkg/config/compiler_ipsec_ts_4098_test.go
+++ b/pkg/config/compiler_ipsec_ts_4098_test.go
@@ -1,0 +1,150 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for #4098: `security ipsec vpn <name> traffic-selector <ts>
+// local-ip / remote-ip` had no commit validation, and pkg/ipsec/policy.go
+// rendered the value raw into the swanctl.conf children{} block as
+// `local_ts = <value>`. The Junos lexer materializes a `\n` escape inside a
+// quoted value, so a selector value could inject an arbitrary swanctl line
+// (`updown = <script>`, run as root by charon -> RCE, or an esp_proposals
+// override). validateIPsecTrafficSelectorsStrict rejects such a value at
+// commit; the render belt (sanitizeSwanctlValue) neutralizes it on the lenient
+// load / peer-sync path.
+
+// buildTree4098 compiles a flat set-command list into a ConfigTree via the
+// ParseSetCommand + SetPath loop (NewParser merges newline-separated set lines
+// into one node and must not be used for set syntax — see CLAUDE.md "Testing
+// flat set syntax"). A quoted value carrying a `\n` is materialized into a real
+// newline by the lexer, exactly as the exploit input would be.
+func buildTree4098(t *testing.T, cmds []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// TestTrafficSelectorNewlineRejectedStrict guards the injection vector end to
+// end: a local-ip value with an embedded newline must be rejected at strict
+// commit. At HEAD the general free-text control-char gate
+// (validateNodesControlChars, freetext.go) fires FIRST and already rejects any
+// newline in any value — so this asserts rejection, not a specific gate. The
+// #4098-specific RED-on-revert lives in TestTrafficSelectorWhitespaceRejectedStrict
+// / TestTrafficSelectorNonCIDRRejectedStrict, which exercise cases the general
+// control-char gate does NOT catch (whitespace, malformed shape).
+func TestTrafficSelectorNewlineRejectedStrict(t *testing.T) {
+	tree := buildTree4098(t, []string{
+		`set security ipsec vpn v1 traffic-selector ts1 local-ip "10.0.0.0/24\n        updown = /tmp/pwn.sh"`,
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a traffic-selector local-ip with an embedded newline; want a strict reject (#4098)")
+	}
+	if !strings.Contains(err.Error(), "control character") {
+		t.Fatalf("reject error %q should reference the control character", err.Error())
+	}
+}
+
+// TestTrafficSelectorWhitespaceRejectedStrict is the primary #4098 RED-on-revert
+// guard. A value carrying only whitespace (no control character) clears the
+// general control-char gate, so ONLY validateIPsecTrafficSelectorsStrict rejects
+// it. Reverting the validator call in compiler.go makes CompileConfig accept the
+// value and this test goes RED. A space in local_ts still yields a malformed /
+// mis-scoped swanctl selector, so rejecting it is correct.
+func TestTrafficSelectorWhitespaceRejectedStrict(t *testing.T) {
+	tree := buildTree4098(t, []string{
+		`set security ipsec vpn v1 traffic-selector ts1 local-ip "10.0.0.0/24 updown=/tmp/pwn.sh"`,
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a traffic-selector local-ip with embedded whitespace; want a strict reject (#4098)")
+	}
+	if !strings.Contains(err.Error(), "#4098") ||
+		!strings.Contains(err.Error(), "traffic-selector") ||
+		!strings.Contains(err.Error(), "whitespace") {
+		t.Fatalf("reject error %q does not identify the #4098 traffic-selector gate", err.Error())
+	}
+}
+
+// TestTrafficSelectorNonCIDRRejectedStrict is a second #4098 RED-on-revert case:
+// a value that clears the control-char gate but is not a CIDR / host / range.
+func TestTrafficSelectorNonCIDRRejectedStrict(t *testing.T) {
+	tree := buildTree4098(t, []string{
+		`set security ipsec vpn v1 traffic-selector ts1 local-ip not.an.address`,
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a non-CIDR traffic-selector local-ip; want a strict reject (#4098)")
+	}
+	if !strings.Contains(err.Error(), "#4098") || !strings.Contains(err.Error(), "CIDR") {
+		t.Fatalf("reject error %q should identify the #4098 gate and the required CIDR/host/range shape", err.Error())
+	}
+}
+
+// TestTrafficSelectorLenientWarns proves the #1960 downgrade for MY gate: a
+// value STRICT rejects (whitespace, clean of control chars so the general gate
+// ignores it) must NOT fail the lenient load / peer-sync compile — an
+// already-persisted or peer-synced config still boots — but must surface as a
+// #4098 warning. The render belt keeps the value inert.
+func TestTrafficSelectorLenientWarns(t *testing.T) {
+	tree := buildTree4098(t, []string{
+		`set security ipsec vpn v1 traffic-selector ts1 local-ip "10.0.0.0/24 updown=/tmp/pwn.sh"`,
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must not fail on a persisted config (#1960): %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#4098") && strings.Contains(w, "traffic-selector") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient compile did not warn about the injected traffic-selector; warnings=%v", cfg.Warnings)
+	}
+}
+
+// TestTrafficSelectorValidCIDRAccepted is the over-reject negative control: a
+// well-formed selector (CIDR both sides) commits cleanly and warns on neither
+// path.
+func TestTrafficSelectorValidCIDRAccepted(t *testing.T) {
+	tree := buildTree4098(t, []string{
+		`set security ipsec vpn v1 traffic-selector ts1 local-ip 10.0.0.0/24`,
+		`set security ipsec vpn v1 traffic-selector ts1 remote-ip 2001:db8::/48`,
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig rejected a valid CIDR traffic selector: %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#4098") {
+			t.Fatalf("clean selector produced a #4098 warning: %q", w)
+		}
+	}
+}
+
+// TestTrafficSelectorRangeAndHostAccepted guards the host-address and range
+// shapes the validator must also accept (a false reject would break legitimate
+// configs).
+func TestTrafficSelectorRangeAndHostAccepted(t *testing.T) {
+	tree := buildTree4098(t, []string{
+		`set security ipsec vpn v1 traffic-selector ts1 local-ip 10.0.0.5`,
+		`set security ipsec vpn v1 traffic-selector ts1 remote-ip 10.0.1.10-10.0.1.20`,
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a host / range traffic selector: %v", err)
+	}
+}

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -410,3 +410,28 @@ all files stay in `package ipsec`, so the public API is unchanged.
   legacy any-peer behavior for that one tunnel. A cert/EAP VPN has no PSK,
   so it emits no secret block and is unaffected. The selector values reuse
   the `sanitizeSwanctlValue`/`escapeSwanctlQuoted` quoting (#1798/#2126).
+- **Traffic-selector `local_ts`/`remote_ts` sanitize + commit gate
+  (#4098).** The child SA `local_ts = <value>` / `remote_ts = <value>`
+  lines (from `security ipsec vpn <name> traffic-selector <ts>
+  local-ip/remote-ip`, or the `local-identity`/`remote-identity`
+  fallback) are now run through `sanitizeSwanctlValue` at render, parity
+  with the sibling child SA name. Before #4098 they were interpolated
+  raw: the Junos lexer materializes a `\n` escape inside a quoted value,
+  so a selector such as `local-ip "10.0.0.0/24\n        updown =
+  /tmp/x.sh"` injected a real newline plus an arbitrary `key = value`
+  line into the `children {}` block — and charon runs as **root**, so an
+  injected `updown = <script>` is a config-injection → root RCE (an
+  injected `esp_proposals`/`mode`/`mark_*` silently rewrites the crypto
+  posture). Two layers close it: the render belt above keeps any value
+  that reaches the renderer inert, and a commit-time gate
+  (`validateIPsecTrafficSelectorsStrict`, `pkg/config/compiler_ipsec_trafficselector.go`)
+  rejects a `local-ip`/`remote-ip` value that carries a control
+  character or whitespace, or that is not a CIDR prefix / host address /
+  IP range. The gate is strict on operator commit / commit-check and
+  lenient-downgraded (warn) on load / peer-sync per #1960, mirroring the
+  `sanitizeSwanctlValue` render belt on the other swanctl-injection
+  surfaces (#1798/#2126). Note: the general free-text control-char gate
+  (`validateNodesControlChars`, `pkg/config/freetext.go`) already
+  rejected an embedded newline in ANY value at commit — the #4098 gate
+  adds the traffic-selector-specific shape check (malformed / mis-scoped
+  selector) and the render-side belt.

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -173,11 +173,22 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 		fmt.Fprintf(&b, "    children {\n")
 		for _, child := range effectiveTrafficSelectors(name, vpn) {
 			fmt.Fprintf(&b, "      %s {\n", sanitizeSwanctlValue(child.Name))
+			// local_ts / remote_ts carry the traffic-selector prefixes
+			// (`traffic-selector local-ip/remote-ip`, or the
+			// local-identity/remote-identity fallback). Run them through
+			// sanitizeSwanctlValue for parity with child.Name above: an
+			// embedded control character — a newline in particular — would
+			// otherwise inject an arbitrary `key = value` line (e.g.
+			// `updown = /tmp/x.sh`, executed by charon as ROOT) or an extra
+			// swanctl section into the children{} block. The commit-time
+			// gate (validateIPsecTrafficSelectorsStrict, #4098) rejects such
+			// a value; this render-side belt keeps an already-persisted /
+			// peer-synced value inert on the lenient load path (#1798/#4098).
 			if child.LocalTS != "" {
-				fmt.Fprintf(&b, "        local_ts = %s\n", child.LocalTS)
+				fmt.Fprintf(&b, "        local_ts = %s\n", sanitizeSwanctlValue(child.LocalTS))
 			}
 			if child.RemoteTS != "" {
-				fmt.Fprintf(&b, "        remote_ts = %s\n", child.RemoteTS)
+				fmt.Fprintf(&b, "        remote_ts = %s\n", sanitizeSwanctlValue(child.RemoteTS))
 			}
 			fmt.Fprintf(&b, "        esp_proposals = %s\n", espProposals)
 			if espLifetime > 0 {

--- a/pkg/ipsec/trafficselector_render_4098_test.go
+++ b/pkg/ipsec/trafficselector_render_4098_test.go
@@ -1,0 +1,95 @@
+package ipsec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestRenderTrafficSelectorSanitizesInjection is the #4098 render RED-on-revert
+// guard. A `traffic-selector local-ip / remote-ip` whose value carries a
+// materialized newline (the Junos lexer turns a quoted `\n` into a real
+// newline) must NOT reach the swanctl.conf children{} block verbatim: the raw
+// renderer emitted `local_ts = <value>` unescaped, so the newline started a
+// fresh `updown = <script>` line inside the child block — a config-injection
+// executed by the root charon daemon (root RCE). renderConfig now runs
+// local_ts / remote_ts through sanitizeSwanctlValue (control chars -> spaces),
+// parity with the sibling child SA name, so the injected line collapses onto
+// the local_ts value and is inert.
+//
+// Reverting the sanitizeSwanctlValue wrap in policy.go makes the rendered
+// config contain a standalone `updown = ...` line and this test goes RED.
+func TestRenderTrafficSelectorSanitizesInjection(t *testing.T) {
+	const injectedLocal = "10.0.0.0/24\n        updown = /tmp/pwn.sh"
+	const injectedRemote = "10.0.1.0/24\n        esp_proposals = null-null"
+
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		VPNs: map[string]*config.IPsecVPN{
+			"tun1": {
+				Name:        "tun1",
+				Gateway:     "172.16.0.1",
+				IPsecPolicy: "ipsec-pol",
+				TrafficSelectors: map[string]*config.IPsecTrafficSelector{
+					"ts1": {Name: "ts1", LocalIP: injectedLocal, RemoteIP: injectedRemote},
+				},
+			},
+		},
+		Policies: map[string]*config.IPsecPolicyDef{
+			"ipsec-pol": {Name: "ipsec-pol", Proposals: []string{"prop1"}},
+		},
+	}
+
+	got := m.generateConfig(cfg)
+
+	// No rendered line may be a standalone injected swanctl setting. On the
+	// raw (pre-fix) renderer the materialized newline splits the local_ts /
+	// remote_ts value, so `updown = ...` and `esp_proposals = ...` appear on
+	// their own lines inside the children block.
+	for _, line := range strings.Split(got, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "updown") {
+			t.Fatalf("injected updown line reached swanctl children block:\n%s", got)
+		}
+		if strings.HasPrefix(trimmed, "esp_proposals = null-null") {
+			t.Fatalf("injected esp_proposals override reached swanctl children block:\n%s", got)
+		}
+	}
+
+	// The sanitized value stays on the local_ts line (newline -> space), so
+	// the tunnel still carries the operator's selector prefix — the belt does
+	// not drop the whole value.
+	if !strings.Contains(got, "local_ts = 10.0.0.0/24") {
+		t.Fatalf("sanitized local_ts prefix missing from render:\n%s", got)
+	}
+}
+
+// TestRenderTrafficSelectorNormalUnchanged is the over-reject negative control:
+// a well-formed CIDR selector renders byte-for-byte as before (the sanitize
+// belt is a no-op on a clean value).
+func TestRenderTrafficSelectorNormalUnchanged(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		VPNs: map[string]*config.IPsecVPN{
+			"tun1": {
+				Name:        "tun1",
+				Gateway:     "172.16.0.1",
+				IPsecPolicy: "ipsec-pol",
+				TrafficSelectors: map[string]*config.IPsecTrafficSelector{
+					"ts1": {Name: "ts1", LocalIP: "10.0.0.0/24", RemoteIP: "10.0.1.0/24"},
+				},
+			},
+		},
+		Policies: map[string]*config.IPsecPolicyDef{
+			"ipsec-pol": {Name: "ipsec-pol", Proposals: []string{"prop1"}},
+		},
+	}
+	got := m.generateConfig(cfg)
+	if !strings.Contains(got, "local_ts = 10.0.0.0/24\n") {
+		t.Fatalf("clean local_ts selector not rendered verbatim:\n%s", got)
+	}
+	if !strings.Contains(got, "remote_ts = 10.0.1.0/24\n") {
+		t.Fatalf("clean remote_ts selector not rendered verbatim:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #4098. IPsec `traffic-selector local-ip/remote-ip` values were
rendered raw into the swanctl.conf `children {}` block as
`local_ts = <value>` / `remote_ts = <value>` — unlike the sibling child
SA name, which passes through `sanitizeSwanctlValue`. Because the Junos
lexer materializes a `\n` escape inside a quoted value, a selector like

    set security ipsec vpn v1 traffic-selector ts1 local-ip \
        "10.0.0.0/24\n        updown = /tmp/x.sh"

injected a real newline plus an arbitrary `key = value` line into the
generated config. charon runs as **root**, so an injected
`updown = <script>` is config-injection → root RCE; an injected
`esp_proposals`/`mode`/`mark_*` silently rewrites the crypto posture.
This is the traffic-selector instance of the swanctl-injection class
already closed for the connection name / IKE identity / cert / PSK
(#1798/#2126).

## VERIFY-FIRST finding

The issue's "NO commit validation" premise held only for
`compiler_validate*strict*.go`. A **general** free-text control-char gate
(`validateNodesControlChars`, `pkg/config/freetext.go`) already rejects
an embedded newline in ANY value at strict commit and sanitizes it on the
lenient path — so the pure-newline RCE-via-commit was **not reachable at
HEAD**. Two genuine residual gaps remained and are fixed here:

1. **Render omission** — `local_ts`/`remote_ts` rendered raw
   (policy.go:176-182), the defense for any path reaching render with an
   unsanitized typed config (direct `IPsecConfig` construction, peer-sync).
2. **No shape / whitespace validation** — the general gate ignores
   spaces and does not check that a selector is a routable prefix.

## Fix (two layers, mirroring the FRR auth-value gate #2889)

- **Render belt** (`pkg/ipsec/policy.go`): run `local_ts`/`remote_ts`
  through `sanitizeSwanctlValue` (control chars → spaces), parity with
  the child SA name.
- **Commit gate** (`pkg/config/compiler_ipsec_trafficselector.go`): new
  AST pre-walk `validateIPsecTrafficSelectorsStrict` rejects a
  `local-ip`/`remote-ip` value carrying a control character or
  whitespace, or that is not a CIDR prefix / host address / IP range.
  Strict on commit / commit-check; lenient-downgraded (warn) on
  load / peer-sync per #1960. Runs on the group-expanded, inactive-pruned
  tree and inspects every value token (both parser shapes + a bracketed
  list, #2419) so a malicious token `nodeVal` would drop is still caught.

## RED-on-revert (verified)

- Reverting the `sanitizeSwanctlValue` wrap in policy.go → the render
  test (direct `IPsecConfig`, bypasses the AST gate) fails: the injected
  `updown = ...` line reaches the children block.
- Neutralizing the validator call → the whitespace and non-CIDR strict
  tests fail (these clear the general control-char gate, so only the
  #4098 gate rejects them).

## Validation

- `go test ./pkg/ipsec/... ./pkg/config/...` green
- `go build ./...`, `go vet`, `gofmt` clean

Docs: `pkg/ipsec/README.md` #4098 gotcha; `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
