### PR TITLE
frr: render-side sanitize belt for community members and as-path regexes (#4097)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,37 @@
+## 2026-07-04 — #4097: FRR community-list member / as-path regex render-side sanitize belt (fable-163 F2)
+
+- **Timestamp**: 2026-07-04
+  - **Action**: VERIFY-FIRST on the reported HIGH frr.conf config-injection.
+    Confirmed the two render sites DO emit verbatim: `policy_render.go`
+    `bgp community-list %s %s permit %s` (member) and `bgp as-path
+    access-list %s permit %s` (`ap.Regex`), while every auth/description
+    field routes through `sanitizeFRRValue`. BUT the newline-injection
+    vector is ALREADY closed at HEAD by the pre-existing #1798/#3900
+    AST-level control-char defense in `pkg/config/freetext.go`, which
+    runs at the top of `compileExpanded` for EVERY compile and covers
+    community members + as-path regexes because they are ordinary AST
+    node values: strict commit hard-rejects any control char
+    (`validateNodesControlChars`), lenient load/HA-sync/rollback scrubs
+    it in place (`sanitizeNodesControlChars`). Proven by probe: with a
+    would-be new gate removed, strict `CompileConfig` still rejects the
+    `\n` as-path/community value; lenient load scrubs it to a
+    newline-free regex. So the injection is NOT exploitable — the issue's
+    "bypasses ALL sanitization" premise misses the AST layers.
+  - **Decision**: The genuine gap is layer-3 of the documented #1798
+    three-layer model — the render-side belt these two sites lacked while
+    every other frr.conf free-text field has it. Shipped ONLY the render
+    belt (route `member` + `ap.Regex` through `sanitizeFRRValue`; a space
+    stays legit because FRR reads both as a rest-of-line token). Did NOT
+    add the commit-time strict gate the issue asked for — it is fully
+    redundant with `validateNodesControlChars` (fires first) and would be
+    dead code. F20 (Junos→FRR as-path regex syntax translation) is
+    non-trivial (different regex semantics) — left for a separate issue.
+  - **File(s)**: `pkg/frr/policy_render.go` (2 render sites +
+    `sanitizeFRRValue` doc), `pkg/frr/policy_injection_4097_test.go`
+    (render RED-on-revert), `pkg/config/compiler_frr_policy_inject_4097_test.go`
+    (guards #1798 coverage of the two fields end-to-end),
+    `pkg/frr/README.md` (security section bullet).
+
 ## 2026-07-04 — #4092: WireGuard responder handshake TAI64N anti-replay — enforce the per-peer greatest-timestamp gate
 
 - **Timestamp**: 2026-07-04

--- a/pkg/config/compiler_frr_policy_inject_4097_test.go
+++ b/pkg/config/compiler_frr_policy_inject_4097_test.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFRRPolicyValueControlCharsBlocked_4097 locks in that the #1798 free-text
+// control-character defense already covers a `policy-options as-path` regex and
+// a `policy-options community` member — the two frr.conf free-text values the
+// #4097 report flagged. Both are ordinary AST node values, so the AST walk that
+// runs at the top of every compile catches an embedded newline (which the lexer
+// materializes from a `\n` escape) BEFORE it can reach the pkg/frr renderer:
+//
+//   - the STRICT commit path (CompileConfig) hard-rejects it
+//     (validateNodesControlChars), so an injecting newline never commits;
+//   - the LENIENT load / peer-sync / rollback path (CompileConfigLenient)
+//     scrubs it in place (sanitizeNodesControlChars) and boots (#1960), so no
+//     newline survives into the typed config the renderer sees.
+//
+// The render-side belt added in pkg/frr for #4097 (sanitizeFRRValue on the two
+// permit lines) is the third, independent layer per the documented #1798 model
+// — proven RED-on-revert in pkg/frr. This test guards the first two layers so a
+// future refactor cannot silently drop these fields out of that coverage and
+// re-open the injection.
+func TestFRRPolicyValueControlCharsBlocked_4097(t *testing.T) {
+	t.Run("strict commit rejects a newline in an as-path regex", func(t *testing.T) {
+		tree := buildTreeFromSet(t, []string{`set policy-options as-path evil "^1$\n router bgp 65000\n neighbor 6.6.6.6 remote-as 65000"`})
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatal("expected strict commit to reject an as-path regex with an embedded newline")
+		}
+		if !strings.Contains(err.Error(), "as-path evil") || !strings.Contains(err.Error(), "control character") {
+			t.Fatalf("error should name the as-path and the control-character class; got: %v", err)
+		}
+	})
+
+	t.Run("strict commit rejects a newline in a community member", func(t *testing.T) {
+		tree := buildTreeFromSet(t, []string{`set policy-options community evilc members "65000:100\n router bgp 65000"`})
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatal("expected strict commit to reject a community member with an embedded newline")
+		}
+		if !strings.Contains(err.Error(), "community evilc") || !strings.Contains(err.Error(), "control character") {
+			t.Fatalf("error should name the community and the control-character class; got: %v", err)
+		}
+	})
+
+	t.Run("lenient load scrubs the newline and boots", func(t *testing.T) {
+		tree := buildTreeFromSet(t, []string{`set policy-options as-path evil "^1$\n router bgp 65000"`})
+		cfg, err := CompileConfigLenient(tree)
+		if err != nil {
+			t.Fatalf("lenient path must boot (#1960), got error: %v", err)
+		}
+		if cfg == nil {
+			t.Fatal("lenient path returned nil config")
+		}
+		// The newline must not survive into the typed regex the renderer reads.
+		if ap := cfg.PolicyOptions.ASPaths["evil"]; ap != nil {
+			if strings.ContainsAny(ap.Regex, "\n\r") {
+				t.Fatalf("a control character survived into the leniently-loaded regex: %q", ap.Regex)
+			}
+		}
+		flagged := false
+		for _, w := range cfg.Warnings {
+			if strings.Contains(w, "as-path evil") {
+				flagged = true
+				break
+			}
+		}
+		if !flagged {
+			t.Fatalf("expected the tolerant path to flag the scrubbed value; warnings: %v", cfg.Warnings)
+		}
+	})
+
+	t.Run("a normal as-path with a space and a normal community commit clean", func(t *testing.T) {
+		// A legitimate multi-AS regex contains a space; FRR reads it as a
+		// rest-of-line token, so it must commit unchanged — proving neither the
+		// #1798 gate nor the render belt over-rejects a benign value.
+		tree := buildTreeFromSet(t, []string{
+			`set policy-options as-path good "^65001 65002$"`,
+			"set policy-options community goodc members 65000:100",
+		})
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("strict commit must accept a normal as-path/community, got: %v", err)
+		}
+		if ap := cfg.PolicyOptions.ASPaths["good"]; ap == nil || ap.Regex != "^65001 65002$" {
+			t.Fatalf("normal as-path regex not preserved: %+v", cfg.PolicyOptions.ASPaths["good"])
+		}
+	})
+}

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -339,6 +339,30 @@ also carries operator content:
   is NOT covered by this gate** (it is cosmetic, not a security secret, and
   historically multi-word); it remains control-char-sanitized only — a
   follow-up if FRR's `description` token ever needs the same treatment.
+- **Community members and as-path regexes get the render-side sanitize belt
+  (#4097).** `generatePolicyOptions` renders a `policy-options community
+  <name> members <value>` member as `bgp community-list <kind> <name> permit
+  <value>` and a `policy-options as-path <name> <regex>` as `bgp as-path
+  access-list <name> permit <regex>`. Both were the last free-text frr.conf
+  interpolations still emitting the value with a bare `%s`; they now pass
+  through `sanitizeFRRValue` for parity with the auth/description fields —
+  the third of the documented #1798 defense layers ("the render-side belt …
+  at each free-text file interpolation"). The **newline-injection vector
+  itself is already closed by the first two #1798 layers**, which cover these
+  two values because they are ordinary AST node values: the strict commit path
+  hard-rejects any control character (`validateNodesControlChars`,
+  `pkg/config/freetext.go`) and the lenient load / HA-sync / rollback path
+  scrubs it in place (`sanitizeNodesControlChars`) — so a `\n` the lexer
+  materializes from a quoted escape never reaches the renderer on any current
+  path (guarded by `pkg/config` `TestFRRPolicyValueControlCharsBlocked_4097`).
+  The render belt is defense-in-depth for any future path that hands the
+  renderer a typed value the AST walk never saw. Unlike an auth secret a
+  **space is legitimate** here — FRR takes the community/as-path value as a
+  rest-of-line token — so `sanitizeFRRValue` (which strips only the C0/DEL set
+  and leaves `0x20`) is the right tool, and no whitespace-rejecting commit gate
+  is added. (NOTE: a Junos→FRR as-path regex *syntax* translation is still
+  absent — Junos regex operates on whole AS-number terms, FRR uses POSIX ERE
+  over the space-separated AS string — tracked separately, not part of #4097.)
 - **Group address-family flags are gated by neighbor address version
   (#2454).** When `compiler_protocols.go` copies a BGP group's `family inet`
   / `family inet6` flags down to each neighbor, it parses the neighbor's

--- a/pkg/frr/policy_injection_4097_test.go
+++ b/pkg/frr/policy_injection_4097_test.go
@@ -1,0 +1,74 @@
+package frr
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestGeneratePolicyOptions_InjectionSanitized_4097 is a FAIL-ON-REVERT guard
+// for the #4097 render-side belt. A `policy-options community` member or a
+// `policy-options as-path` regex is rendered into a rest-of-line frr.conf token
+// (bgp community-list / as-path access-list). Before the fix these two were the
+// ONLY free-text FRR fields the module rendered with a bare %s — bypassing
+// sanitizeFRRValue, the third of the documented #1798 defense layers ("the
+// render-side belt ... at each free-text file interpolation"), which every auth
+// / description field already uses.
+//
+// The embedded-newline injection itself is caught earlier by the #1798 AST
+// gate (validateNodesControlChars hard-rejects on commit; sanitizeNodesControl-
+// Chars scrubs on load) — see pkg/config TestFRRPolicyValueControlCharsBlocked_
+// 4097 — so this belt is defense-in-depth for any future path that hands the
+// renderer a typed value the AST walk never saw. sanitizeFRRValue collapses the
+// newline to a space so the whole value stays on the single rendered line; a
+// legitimate space inside an as-path regex (a multi-AS path) survives (FRR
+// reads the regex as a rest-of-line token). Reverting the render-site sanitize
+// turns this RED: a standalone `router bgp 65000` / `neighbor` line appears.
+func TestGeneratePolicyOptions_InjectionSanitized_4097(t *testing.T) {
+	m := &Manager{frrConf: "/dev/null"}
+	po := &config.PolicyOptionsConfig{
+		Communities: map[string]*config.CommunityDef{
+			// Newline-injecting member (sorts first: "evilc" < "okc").
+			"evilc": {Name: "evilc", Members: []string{"65000:100\n router bgp 65000"}},
+			// Normal member — must render unchanged.
+			"okc": {Name: "okc", Members: []string{"65000:100"}},
+		},
+		ASPaths: map[string]*config.ASPathDef{
+			// Newline-injecting regex ("evil" < "ok").
+			"evil": {Name: "evil", Regex: "^1$\n router bgp 65000\n neighbor 6.6.6.6 remote-as 65000"},
+			// Normal regex WITH a legitimate space — must survive verbatim.
+			"ok": {Name: "ok", Regex: "^65001 65002$"},
+		},
+	}
+
+	got := m.generatePolicyOptions(po)
+
+	// No injected top-level command line may appear: every rendered line must
+	// be an FRR policy-options directive (or a `!` separator), never a bare
+	// `router bgp` / `neighbor` that the injected newline would have created.
+	for _, line := range strings.Split(got, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "router bgp") || strings.HasPrefix(trimmed, "neighbor ") {
+			t.Fatalf("config injection: rendered a standalone %q line:\n%s", trimmed, got)
+		}
+	}
+
+	// The injected content survives, but collapsed onto the single permit line.
+	wantASPathEvil := "bgp as-path access-list evil permit ^1$  router bgp 65000  neighbor 6.6.6.6 remote-as 65000\n"
+	if !strings.Contains(got, wantASPathEvil) {
+		t.Errorf("as-path regex not sanitized onto one line; want %q in:\n%s", wantASPathEvil, got)
+	}
+	wantCommEvil := "bgp community-list standard evilc permit 65000:100  router bgp 65000\n"
+	if !strings.Contains(got, wantCommEvil) {
+		t.Errorf("community member not sanitized onto one line; want %q in:\n%s", wantCommEvil, got)
+	}
+
+	// The normal values render unchanged — a legitimate space is preserved.
+	if !strings.Contains(got, "bgp as-path access-list ok permit ^65001 65002$\n") {
+		t.Errorf("normal as-path regex altered:\n%s", got)
+	}
+	if !strings.Contains(got, "bgp community-list standard okc permit 65000:100\n") {
+		t.Errorf("normal community member altered:\n%s", got)
+	}
+}

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -30,11 +30,22 @@ import (
 // sanitizeFRRValue strips ASCII control characters — the C0 set
 // (0x00-0x1F, including newline) and DEL (0x7F), each replaced by a
 // space — from a free-text config value (description, auth key,
-// password) before it is interpolated into a generated frr.conf line.
-// Render-side belt for #1798: a BGP neighbor description or auth key
-// containing an embedded newline must not be able to inject extra
-// frr.conf commands even if the commit-time validation layer were
-// bypassed.
+// password, BGP community member, AS-path regex) before it is
+// interpolated into a generated frr.conf line. Render-side belt for
+// #1798 / #4097: a BGP neighbor description, auth key, community-list
+// member, or as-path-access-list regex containing an embedded newline
+// must not be able to inject extra frr.conf commands even if the
+// commit-time validation layer were bypassed (a leniently-loaded /
+// peer-synced / rolled-back stored value re-parses through the same
+// lexer, which materializes a `\n` escape into a real newline byte).
+// Collapsing the newline to a space keeps the whole value on the single
+// rendered line, so no injected `router bgp` / `neighbor` command
+// reaches the managed section. A single SPACE (0x20) is preserved: an
+// FRR `bgp as-path access-list ... permit LINE` and an expanded
+// `bgp community-list expanded ... permit LINE` take the regex as a
+// rest-of-line token, so a space inside the regex is legitimate (unlike
+// a whitespace-split auth secret, which frrTokenUnsafeIndex also rejects
+// at commit).
 func sanitizeFRRValue(s string) string {
 	clean := true
 	for i := 0; i < len(s); i++ {
@@ -1306,7 +1317,14 @@ func (m *Manager) generatePolicyOptions(po *config.PolicyOptionsConfig, bgpAccep
 			}
 		}
 		for _, member := range cd.Members {
-			fmt.Fprintf(&b, "bgp community-list %s %s permit %s\n", listKind, name, member)
+			// #4097: sanitize the member so an embedded newline (from a
+			// leniently-loaded / peer-synced / rolled-back stored value)
+			// cannot inject an extra frr.conf line — parity with the auth
+			// / description fields. The listKind decision above reads the
+			// RAW members (a `\n` is not a regex metacharacter, so it does
+			// not by itself flip standard→expanded; the exploit's `^`/`$`
+			// do). The strict #1798 commit control-char gate rejects it outright.
+			fmt.Fprintf(&b, "bgp community-list %s %s permit %s\n", listKind, name, sanitizeFRRValue(member))
 		}
 	}
 	if len(po.Communities) > 0 {
@@ -1322,7 +1340,13 @@ func (m *Manager) generatePolicyOptions(po *config.PolicyOptionsConfig, bgpAccep
 		sort.Strings(aspNames)
 		for _, name := range aspNames {
 			ap := po.ASPaths[name]
-			fmt.Fprintf(&b, "bgp as-path access-list %s permit %s\n", name, ap.Regex)
+			// #4097: sanitize the regex so an embedded newline cannot
+			// inject an extra frr.conf line — parity with the auth /
+			// description fields. FRR takes the regex as a rest-of-line
+			// token, so a legitimate space (multi-AS path) survives; only
+			// control chars (incl. the newline injection vector) collapse
+			// to a space. The strict #1798 commit control-char gate rejects it.
+			fmt.Fprintf(&b, "bgp as-path access-list %s permit %s\n", name, sanitizeFRRValue(ap.Regex))
 		}
 		b.WriteString("!\n")
 	}


### PR DESCRIPTION
Closes #4097

## Summary

`generatePolicyOptions` (`pkg/frr/policy_render.go`) rendered a
`policy-options community <name> members <value>` member and a
`policy-options as-path <name> <regex>` with a bare `%s`:

```
bgp community-list <kind> <name> permit <member>
bgp as-path access-list <name> permit <regex>
```

These were the last two free-text frr.conf interpolations still missing
`sanitizeFRRValue`, the render-side belt that every other free-text FRR
field (neighbor description/password, OSPF/RIP/IS-IS auth keys) already
uses — the third of the documented #1798 defense layers. This routes
both through `sanitizeFRRValue`.

## VERIFY-FIRST finding (important)

The newline-injection the report describes is **already closed at HEAD**
by the first two #1798/#3900 layers. A community member and an as-path
regex are ordinary AST node values, so the control-char walk at the top
of `compileExpanded` (which runs on **every** compile) covers them:

- **strict commit** (`CompileConfig`) hard-rejects any control character
  via `validateNodesControlChars` (`pkg/config/freetext.go`), so an
  injecting `\n` never commits;
- **lenient load / HA-sync / rollback** (`CompileConfigLenient`) scrubs
  it in place via `sanitizeNodesControlChars` and boots (#1960), so no
  newline survives into the typed config the renderer reads.

Proven by probe: with a would-be new gate removed, strict `CompileConfig`
still rejects the `\n` as-path/community value, and lenient load scrubs
it to a newline-free regex.

Consequently the render belt here is **defense-in-depth / parity**, not a
patch for a live exploitable hole. The **commit-time strict gate the
issue asks for is deliberately NOT added** — it would be fully redundant
with `validateNodesControlChars` (which fires first) and would be dead
code.

A **space is legitimate** for these two fields (FRR reads each as a
rest-of-line token, unlike a whitespace-split auth secret), so
`sanitizeFRRValue` — which strips only C0/DEL and leaves `0x20` — is the
right tool; no whitespace-rejecting gate is introduced.

## F20 (as-path regex Junos→FRR syntax translation)

Non-trivial (Junos regex operates on whole AS-number terms with `[]`/
`{}`/`.` semantics different from FRR's POSIX ERE over the space-separated
AS string — needs a real transpiler). Left for a separate issue; noted in
the FRR README. Not in scope for #4097.

## Tests

- `pkg/frr` `TestGeneratePolicyOptions_InjectionSanitized_4097` — RED on
  revert: reverting either sanitize call makes a standalone `router bgp` /
  `neighbor` line appear. A normal as-path regex with a space is preserved.
- `pkg/config` `TestFRRPolicyValueControlCharsBlocked_4097` — guards that
  the #1798 layers still reject (strict) / scrub (lenient) a newline in
  both fields end-to-end, and that a benign spaced regex commits clean.
- `go test ./pkg/frr/... ./pkg/config/...` green; `go build ./...`, gofmt,
  `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi