### PR TITLE
cli: redact secrets in show configuration for non-super-user login classes (#4099)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -34,6 +34,30 @@
     pkg/cli/cli_show_config_redaction_4099_test.go,
     docs/system-login.md, docs/junos-config-display-reference.md
 
+- **Timestamp**: 2026-07-04 (follow-up)
+  - **Action**: #4099 Copilot follow-up (fold-before-merge, no merge).
+    `LoadRescueConfigRedacted` returned `fmt.Errorf("...: %v",
+    perrs[0])` on a malformed rescue.conf. `config.ParseError.Error()`
+    (parser.go:12) renders `line %d, column %d: %s` where `.Message` is
+    populated from the tampered file content (verified: the lexer emits
+    `unexpected character: %c` carrying the offending byte; the parser's
+    only `%s`-on-full-Token error sites never receive an identifier in
+    the hierarchical path, so a FULL token value does not leak, but the
+    raw parser detail + offending character DO). Forwarding that to the
+    VIEW-only CLI caller defeats the fail-closed "never leak" contract.
+    FIX: return a GENERIC, position-only error — "rescue configuration
+    is malformed and cannot be safely displayed (parse failed at line N,
+    column M)" — using only `perrs[0].Line`/`.Column` (ints, cannot hold
+    a token), never the ParseError, its `.Message`, or `.Error()`. Added
+    a store-level RED-on-revert test
+    (`rescue_redaction_leak_4099_test.go`): a tampered rescue.conf whose
+    parse fails on `@` inside a secret-looking token → the returned
+    error must not contain the raw parser detail, the offending-char
+    message, or the secret token body. Confirmed RED on revert (old `%v
+    perrs[0]` re-forwards `unexpected character: @`).
+  - **File(s)**: pkg/configstore/store_persist.go,
+    pkg/configstore/rescue_redaction_leak_4099_test.go
+
 ## 2026-07-04 — #4092: WireGuard responder handshake TAI64N anti-replay — enforce the per-peer greatest-timestamp gate
 
 - **Timestamp**: 2026-07-04

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,39 @@
+## 2026-07-04 — #4099: on-box CLI `show configuration` secret redaction by login class
+
+- **Timestamp**: 2026-07-04
+  - **Action**: Fixed fable-163 F3 (HIGH security, secret disclosure to a
+    VIEW-only login class). VERIFY-FIRST: the on-box interactive CLI
+    config-render show paths called the NON-redacted `Show*` store
+    methods, so a `read-only` / `config-viewer` / `operator` (all
+    PermView) login could `show configuration` and harvest cleartext IKE
+    PSKs, SNMP communities, BGP auth-keys, WireGuard private keys and the
+    encrypted root password — the CLI residual of #4051/F-020, which had
+    wired only the REST + gRPC ShowConfig paths through the `*Redacted`
+    `RedactedClone` renderers. DECISION: redact for every login class
+    EXCEPT `super-user` (and the unset/no-RBAC class = privileged); this
+    closes the reported VIEW-only leak while preserving the deliberate
+    #4057 super-user/root cleartext allowance (root has direct DB
+    filesystem access). Unknown class fails closed. Matches Junos (never
+    cleartext in show config) and the always-redacted REST/gRPC path.
+    FIX: new predicate `CLI.showConfigRedacted()` + helper
+    `showActiveConfigPath()` (`pkg/cli/permissions.go`) route
+    `cli_show.go` (case "configuration", all formats + path variants),
+    `cli_show_system.go` (`show system rollback [N|compare]`, `show
+    system login`/`internet-options`/`root-authentication`, `show system
+    configuration rescue`), and `cli_config.go handleConfigShow`
+    (config-mode candidate show / `| compare [rollback N]`,
+    defense-in-depth under PermConfig) through the existing `*Redacted`
+    store methods. Added `Store.LoadRescueConfigRedacted()`
+    (`pkg/configstore/store_persist.go`) — reparse + `RedactedClone` +
+    re-render, fail-closed on parse error — for the raw `rescue.conf`
+    text (#4056). RED-on-revert unit test proven (forcing `redact=false`
+    re-leaks every sentinel + drops the placeholder).
+  - **File(s)**: pkg/cli/permissions.go, pkg/cli/cli_show.go,
+    pkg/cli/cli_show_system.go, pkg/cli/cli_config.go,
+    pkg/configstore/store_persist.go,
+    pkg/cli/cli_show_config_redaction_4099_test.go,
+    docs/system-login.md, docs/junos-config-display-reference.md
+
 ## 2026-07-04 — #4092: WireGuard responder handshake TAI64N anti-replay — enforce the per-peer greatest-timestamp gate
 
 - **Timestamp**: 2026-07-04

--- a/docs/junos-config-display-reference.md
+++ b/docs/junos-config-display-reference.md
@@ -2,6 +2,14 @@
 
 Reference captured from a live Juniper vSRX cluster (JUNOS 24.4R1-S2.9) on 2026-02-15.
 
+> **Secret redaction (#4099).** For every login class except `super-user`, all
+> `show configuration` output — hierarchical, `| display set/json/xml/
+> inheritance`, path-scoped, and the `show system rollback` / `rescue` /
+> `root-authentication` variants — masks secret leaves with `##SECRET-DATA##`,
+> matching Junos and the REST/gRPC `ShowConfig` path (#4051). A VIEW-only
+> `read-only` / `config-viewer` / `operator` class never sees a cleartext IKE
+> PSK, SNMP community or auth-key. See `docs/system-login.md`.
+
 ---
 
 ## 1. `show configuration` Sub-Path Completions

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -82,6 +82,38 @@ matcher the dispatcher uses, so an abbreviated `monitor tr` is gated
 identically to the fully-spelled form and cannot bypass the gate. Other
 `monitor` subcommands and read-only `show` commands are unaffected.
 
+**Secret redaction in `show configuration` (#4099).** The on-box interactive
+CLI config-render show paths — `show configuration` (hierarchical / `| display
+set` / `| display json` / `| display xml` / `| display inheritance`, including
+path-scoped subtrees), `show system rollback <N> [| display set | compare]`,
+`show system login` / `internet-options` / `root-authentication`, `show system
+configuration rescue`, and the config-mode `show` / `show | compare` — mask
+secret leaves (IKE pre-shared-keys, SNMP communities, BGP/OSPF
+authentication-keys, WireGuard private keys, encrypted passwords, DDNS
+tokens/keys) with `##SECRET-DATA##` for **every login class except
+`super-user`**. This mirrors Junos (which never renders a cleartext secret in
+`show configuration` for any class) and the always-redacted REST/gRPC
+`ShowConfig` path (#4051): a VIEW-only `read-only`, `config-viewer`, or
+`operator` login can no longer harvest cleartext firewall secrets through the
+console. The redaction predicate is `CLI.showConfigRedacted()`
+(`pkg/cli/permissions.go`): it routes rendering through the `*Redacted`
+configstore methods (the same `RedactedClone` renderers REST/gRPC use) for any
+class **without** `PermAll`.
+
+`super-user` still reads cleartext — it is the console root that already has
+direct config-DB filesystem access, so masking it would only obstruct the
+operator copying a secret while providing no protection (the deliberate #4057
+allowance). An **unset/empty** class (no `system login` configured — the legacy
+no-RBAC allow-everything mode) is likewise treated as privileged and reads
+cleartext, so a deployment with no login classes is bit-identical to before the
+change. An **unknown** class fails **closed** (redacted). Config mode requires
+`PermConfig` (super-user only today), so the config-mode candidate show paths
+render cleartext in practice; they are wired through the same gate as
+defense-in-depth should a lower class ever gain config-view access. The raw
+`rescue.conf` text (a full cleartext-secret config dump, #4056) is reparsed +
+redacted before display and fails **closed** — a parse error returns an error
+rather than the cleartext bytes.
+
 ### Generating a hash
 
 ```

--- a/pkg/cli/cli_config.go
+++ b/pkg/cli/cli_config.go
@@ -344,6 +344,16 @@ func (c *CLI) handleConfigShow(args []string) error {
 	// Check for pipe commands
 	line := strings.Join(args, " ")
 
+	// Secret redaction (#4099): route the config-mode config display through
+	// the #4051 *Redacted store methods for a login class that
+	// showConfigRedacted() flags. Config mode requires PermConfig (super-user
+	// today), so this is defense-in-depth — cleartext for the current
+	// reachable class, and automatically masked should a non-super-user ever
+	// gain config-view access. The redacted candidate variants take the path
+	// directly (nil/empty == whole tree) and mirror the cleartext siblings'
+	// nil-source defaults.
+	redact := c.showConfigRedacted()
+
 	if strings.Contains(line, "| compare") {
 		// Check for "| compare rollback N"
 		if idx := strings.Index(line, "| compare rollback"); idx >= 0 {
@@ -352,18 +362,27 @@ func (c *CLI) handleConfigShow(args []string) error {
 			if err != nil || n < 1 {
 				return fmt.Errorf("usage: show | compare rollback <N>")
 			}
-			diff, err := c.store.ShowCompareRollback(n)
+			var diff string
+			if redact {
+				diff, err = c.store.ShowCompareRollbackRedacted(n)
+			} else {
+				diff, err = c.store.ShowCompareRollback(n)
+			}
 			if err != nil {
 				return err
 			}
 			fmt.Print(diff)
 			return nil
 		}
-		fmt.Print(c.store.ShowCompare())
+		if redact {
+			fmt.Print(c.store.ShowCompareRedacted())
+		} else {
+			fmt.Print(c.store.ShowCompare())
+		}
 		return nil
 	}
 
-	// Build path from editPath + args before the pipe (used by all display formats).
+	// Build path from editPath + args before the pipe (used by all formats).
 	var displayPath []string
 	{
 		editPath := c.store.GetEditPath()
@@ -376,64 +395,47 @@ func (c *CLI) handleConfigShow(args []string) error {
 		}
 	}
 
-	if strings.Contains(line, "| display json") {
-		if len(displayPath) > 0 {
-			output := c.store.ShowCandidatePathJSON(displayPath)
-			if output == "" {
-				fmt.Printf("configuration path not found: %s\n", strings.Join(displayPath, " "))
-			} else {
-				fmt.Print(output)
-			}
-		} else {
-			fmt.Print(c.store.ShowCandidateJSON())
+	var output string
+	switch {
+	case strings.Contains(line, "| display json"):
+		switch {
+		case redact:
+			output = c.store.ShowCandidateJSONRedacted(displayPath)
+		case len(displayPath) > 0:
+			output = c.store.ShowCandidatePathJSON(displayPath)
+		default:
+			output = c.store.ShowCandidateJSON()
 		}
-		return nil
-	}
-
-	if strings.Contains(line, "| display set") {
-		if len(displayPath) > 0 {
-			output := c.store.ShowCandidatePathSet(displayPath)
-			if output == "" {
-				fmt.Printf("configuration path not found: %s\n", strings.Join(displayPath, " "))
-			} else {
-				fmt.Print(output)
-			}
-		} else {
-			fmt.Print(c.store.ShowCandidateSet())
+	case strings.Contains(line, "| display set"):
+		switch {
+		case redact:
+			output = c.store.ShowCandidateSetRedacted(displayPath)
+		case len(displayPath) > 0:
+			output = c.store.ShowCandidatePathSet(displayPath)
+		default:
+			output = c.store.ShowCandidateSet()
 		}
-		return nil
-	}
-
-	if strings.Contains(line, "| display xml") {
-		if len(displayPath) > 0 {
-			output := c.store.ShowCandidatePathXML(displayPath)
-			if output == "" {
-				fmt.Printf("configuration path not found: %s\n", strings.Join(displayPath, " "))
-			} else {
-				fmt.Print(output)
-			}
-		} else {
-			fmt.Print(c.store.ShowCandidateXML())
+	case strings.Contains(line, "| display xml"):
+		switch {
+		case redact:
+			output = c.store.ShowCandidateXMLRedacted(displayPath)
+		case len(displayPath) > 0:
+			output = c.store.ShowCandidatePathXML(displayPath)
+		default:
+			output = c.store.ShowCandidateXML()
 		}
-		return nil
-	}
-
-	if strings.Contains(line, "| display inheritance") {
-		if len(displayPath) > 0 {
-			output := c.store.ShowCandidatePathInheritance(displayPath)
-			if output == "" {
-				fmt.Printf("configuration path not found: %s\n", strings.Join(displayPath, " "))
-			} else {
-				fmt.Print(output)
-			}
-		} else {
-			fmt.Print(c.store.ShowCandidateInheritance())
+	case strings.Contains(line, "| display inheritance"):
+		switch {
+		case redact:
+			output = c.store.ShowCandidateInheritanceRedacted(displayPath)
+		case len(displayPath) > 0:
+			output = c.store.ShowCandidatePathInheritance(displayPath)
+		default:
+			output = c.store.ShowCandidateInheritance()
 		}
-		return nil
-	}
-
-	// Unknown pipe command
-	if idx := strings.Index(line, "| "); idx >= 0 {
+	case strings.Index(line, "| ") >= 0:
+		// Unknown pipe command
+		idx := strings.Index(line, "| ")
 		pipeParts := strings.Fields(strings.TrimSpace(line[idx+2:]))
 		if len(pipeParts) >= 2 && pipeParts[0] == "display" {
 			fmt.Printf("syntax error: unknown display option '%s'\n", pipeParts[1])
@@ -441,25 +443,21 @@ func (c *CLI) handleConfigShow(args []string) error {
 			fmt.Printf("syntax error: unknown pipe command '%s'\n", pipeParts[0])
 		}
 		return nil
-	}
-
-	// Show scoped to path (editPath + args)
-	fullPath := append([]string{}, c.store.GetEditPath()...)
-	for _, a := range args {
-		if a == "|" {
-			break
+	default:
+		// Show scoped to path (editPath + args), or the whole candidate.
+		switch {
+		case redact:
+			output = c.store.ShowCandidateRedacted(displayPath)
+		case len(displayPath) > 0:
+			output = c.store.ShowCandidatePath(displayPath)
+		default:
+			output = c.store.ShowCandidate()
 		}
-		fullPath = append(fullPath, a)
 	}
-	if len(fullPath) > 0 {
-		output := c.store.ShowCandidatePath(fullPath)
-		if output == "" {
-			fmt.Printf("configuration path not found: %s\n", strings.Join(fullPath, " "))
-		} else {
-			fmt.Print(output)
-		}
+	if len(displayPath) > 0 && output == "" {
+		fmt.Printf("configuration path not found: %s\n", strings.Join(displayPath, " "))
 	} else {
-		fmt.Print(c.store.ShowCandidate())
+		fmt.Print(output)
 	}
 	return nil
 }

--- a/pkg/cli/cli_show.go
+++ b/pkg/cli/cli_show.go
@@ -42,66 +42,76 @@ func (c *CLI) handleShow(args []string) error {
 			}
 			cfgPath = append(cfgPath, a)
 		}
-		if strings.Contains(rest, "| display json") {
-			if len(cfgPath) > 0 {
-				output := c.store.ShowActivePathJSON(cfgPath)
-				if output == "" {
-					fmt.Printf("configuration path not found: %s\n", strings.Join(cfgPath, " "))
-				} else {
-					fmt.Print(output)
-				}
-			} else {
-				fmt.Print(c.store.ShowActiveJSON())
+		// Secret redaction (#4099): a VIEW-only read-only / config-viewer (and
+		// operator) login class must see ##SECRET-DATA## in place of IKE PSKs,
+		// SNMP communities and authentication-keys — matching Junos and the
+		// always-redacted REST/gRPC ShowConfig (#4051). super-user (and the
+		// no-RBAC empty class) still reads cleartext. The *Redacted store
+		// methods take the path directly (nil/empty == whole tree), mirroring
+		// the gRPC/REST usage; the cleartext siblings back the whole-tree /
+		// subtree split for the privileged path.
+		redact := c.showConfigRedacted()
+		var output string
+		switch {
+		case strings.Contains(rest, "| display json"):
+			switch {
+			case redact:
+				output = c.store.ShowActiveJSONRedacted(cfgPath)
+			case len(cfgPath) > 0:
+				output = c.store.ShowActivePathJSON(cfgPath)
+			default:
+				output = c.store.ShowActiveJSON()
 			}
-		} else if strings.Contains(rest, "| display set") {
-			if len(cfgPath) > 0 {
-				output := c.store.ShowActivePathSet(cfgPath)
-				if output == "" {
-					fmt.Printf("configuration path not found: %s\n", strings.Join(cfgPath, " "))
-				} else {
-					fmt.Print(output)
-				}
-			} else {
-				fmt.Print(c.store.ShowActiveSet())
+		case strings.Contains(rest, "| display set"):
+			switch {
+			case redact:
+				output = c.store.ShowActiveSetRedacted(cfgPath)
+			case len(cfgPath) > 0:
+				output = c.store.ShowActivePathSet(cfgPath)
+			default:
+				output = c.store.ShowActiveSet()
 			}
-		} else if strings.Contains(rest, "| display xml") {
-			if len(cfgPath) > 0 {
-				output := c.store.ShowActivePathXML(cfgPath)
-				if output == "" {
-					fmt.Printf("configuration path not found: %s\n", strings.Join(cfgPath, " "))
-				} else {
-					fmt.Print(output)
-				}
-			} else {
-				fmt.Print(c.store.ShowActiveXML())
+		case strings.Contains(rest, "| display xml"):
+			switch {
+			case redact:
+				output = c.store.ShowActiveXMLRedacted(cfgPath)
+			case len(cfgPath) > 0:
+				output = c.store.ShowActivePathXML(cfgPath)
+			default:
+				output = c.store.ShowActiveXML()
 			}
-		} else if strings.Contains(rest, "| display inheritance") {
-			if len(cfgPath) > 0 {
-				output := c.store.ShowActivePathInheritance(cfgPath)
-				if output == "" {
-					fmt.Printf("configuration path not found: %s\n", strings.Join(cfgPath, " "))
-				} else {
-					fmt.Print(output)
-				}
-			} else {
-				fmt.Print(c.store.ShowActiveInheritance())
+		case strings.Contains(rest, "| display inheritance"):
+			switch {
+			case redact:
+				output = c.store.ShowActiveInheritanceRedacted(cfgPath)
+			case len(cfgPath) > 0:
+				output = c.store.ShowActivePathInheritance(cfgPath)
+			default:
+				output = c.store.ShowActiveInheritance()
 			}
-		} else if idx := strings.Index(rest, "| "); idx >= 0 {
+		case strings.Index(rest, "| ") >= 0:
+			idx := strings.Index(rest, "| ")
 			pipeParts := strings.Fields(strings.TrimSpace(rest[idx+2:]))
 			if len(pipeParts) >= 2 && pipeParts[0] == "display" {
 				fmt.Printf("syntax error: unknown display option '%s'\n", pipeParts[1])
 			} else if len(pipeParts) > 0 {
 				fmt.Printf("syntax error: unknown pipe command '%s'\n", pipeParts[0])
 			}
-		} else if len(cfgPath) > 0 {
-			output := c.store.ShowActivePath(cfgPath)
-			if output == "" {
-				fmt.Printf("configuration path not found: %s\n", strings.Join(cfgPath, " "))
-			} else {
-				fmt.Print(output)
+			return nil
+		default:
+			switch {
+			case redact:
+				output = c.store.ShowActiveRedacted(cfgPath)
+			case len(cfgPath) > 0:
+				output = c.store.ShowActivePath(cfgPath)
+			default:
+				output = c.store.ShowActive()
 			}
+		}
+		if len(cfgPath) > 0 && output == "" {
+			fmt.Printf("configuration path not found: %s\n", strings.Join(cfgPath, " "))
 		} else {
-			fmt.Print(c.store.ShowActive())
+			fmt.Print(output)
 		}
 		return nil
 

--- a/pkg/cli/cli_show_config_redaction_4099_test.go
+++ b/pkg/cli/cli_show_config_redaction_4099_test.go
@@ -1,0 +1,265 @@
+// RED-on-revert tests for #4099: the on-box interactive CLI config-render show
+// paths (`show configuration` in every display format, `show system rollback`,
+// `show system root-authentication`, and `show system configuration rescue`)
+// must mask secret leaves for a VIEW-only login class (read-only /
+// config-viewer / operator) exactly as the always-redacted REST/gRPC
+// ShowConfig does (#4051). Before the fix these called the cleartext Show*
+// store methods, leaking IKE PSKs, SNMP communities, BGP auth-keys, WireGuard
+// private keys and the encrypted root password to a class that can only VIEW.
+//
+// Reverting the wiring makes the read-only / config-viewer / operator subtests
+// go RED (cleartext sentinel reappears). super-user keeps cleartext (the #4057
+// operator-reads-own-secret allowance; root has direct DB access), so the
+// super-user subtest asserts the cleartext IS present — a revert that redacts
+// everyone would also be caught.
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// cliSecretSet stages the secrets #4099/#4051 name explicitly (IKE PSK + SNMP
+// community) plus representative others and the encrypted root password, each
+// with a distinctive cleartext sentinel so a leak is identifiable. A non-secret
+// host-name sentinel rides along to prove redaction is surgical.
+var cliSecretSet = []string{
+	"set system host-name XPF-NONSECRET-HOST",
+	`set system root-authentication encrypted-password "$6$CLILEAK$ROOTPWHASH000000"`,
+	"set security ike policy pol1 pre-shared-key ascii-text CLI-LEAK-IKE-PSK",
+	"set snmp community CLI-LEAK-SNMP-COMMUNITY authorization read-only",
+	"set protocols bgp group ext authentication-key CLI-LEAK-BGP-AUTHPW",
+	"set interfaces wg0 tunnel wireguard private-key CLI-LEAK-WG-PRIVKEY",
+}
+
+var cliSecretSentinels = []string{
+	"ROOTPWHASH", "CLI-LEAK-IKE-PSK", "CLI-LEAK-SNMP-COMMUNITY",
+	"CLI-LEAK-BGP-AUTHPW", "CLI-LEAK-WG-PRIVKEY",
+}
+
+func newCLISecretStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure(): %v", err)
+	}
+	if _, err := store.LoadSet(strings.Join(cliSecretSet, "\n")); err != nil {
+		t.Fatalf("LoadSet(): %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit(): %v", err)
+	}
+	return store
+}
+
+// classWantsRedaction is the per-class expectation table shared by the show
+// path tests: redact everyone EXCEPT super-user and the unset (no-RBAC) class.
+var classWantsRedaction = []struct {
+	class  string
+	redact bool
+}{
+	{"super-user", false},
+	{"", false}, // unset — legacy no-RBAC allow-everything, cleartext
+	{"operator", true},
+	{"read-only", true},
+	{"config-viewer", true},
+	{"unauthorized", true}, // fail-closed
+}
+
+// TestCLIShowConfigurationRedactsPerClass is the primary #4099 RED-on-revert
+// net: `show configuration` across hierarchical / set / json / xml / display
+// inheritance formats masks every secret for a VIEW-only class, preserves the
+// non-secret host-name, and still shows cleartext for super-user.
+func TestCLIShowConfigurationRedactsPerClass(t *testing.T) {
+	store := newCLISecretStore(t)
+
+	formatArgs := map[string][]string{
+		"hierarchical": {"configuration"},
+		"set":          {"configuration", "|", "display", "set"},
+		"json":         {"configuration", "|", "display", "json"},
+		"xml":          {"configuration", "|", "display", "xml"},
+		"inheritance":  {"configuration", "|", "display", "inheritance"},
+	}
+
+	for _, tc := range classWantsRedaction {
+		for fname, args := range formatArgs {
+			t.Run(tc.class+"/"+fname, func(t *testing.T) {
+				c := &CLI{store: store, userClass: tc.class}
+				// handleShow mutates args[0] via resolveCommand; hand it a copy.
+				a := append([]string(nil), args...)
+				out := captureStdout(t, func() {
+					if err := c.handleShow(a); err != nil {
+						t.Fatalf("handleShow(%v): %v", args, err)
+					}
+				})
+
+				// Non-secret leaf survives in every case.
+				if !strings.Contains(out, "XPF-NONSECRET-HOST") {
+					t.Errorf("class=%q fmt=%s dropped non-secret host-name:\n%s", tc.class, fname, out)
+				}
+
+				if tc.redact {
+					for _, leak := range cliSecretSentinels {
+						if strings.Contains(out, leak) {
+							t.Errorf("class=%q fmt=%s LEAKED cleartext secret %q:\n%s", tc.class, fname, leak, out)
+						}
+					}
+					if !strings.Contains(out, config.SecretDataPlaceholder) {
+						t.Errorf("class=%q fmt=%s missing redaction placeholder %q:\n%s",
+							tc.class, fname, config.SecretDataPlaceholder, out)
+					}
+				} else {
+					// Privileged class must still see cleartext (the #4057
+					// allowance) — assert the IKE PSK survives.
+					if !strings.Contains(out, "CLI-LEAK-IKE-PSK") {
+						t.Errorf("class=%q fmt=%s unexpectedly redacted the IKE PSK for a privileged class:\n%s",
+							tc.class, fname, out)
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestCLIShowConfigurationPathRedacts confirms a path-scoped `show
+// configuration security` subtree render also redacts for a VIEW-only class.
+func TestCLIShowConfigurationPathRedacts(t *testing.T) {
+	store := newCLISecretStore(t)
+	c := &CLI{store: store, userClass: "read-only"}
+	out := captureStdout(t, func() {
+		if err := c.handleShow([]string{"configuration", "security", "|", "display", "set"}); err != nil {
+			t.Fatalf("handleShow: %v", err)
+		}
+	})
+	if strings.Contains(out, "CLI-LEAK-IKE-PSK") {
+		t.Errorf("path-scoped show configuration leaked IKE PSK:\n%s", out)
+	}
+	if !strings.Contains(out, config.SecretDataPlaceholder) {
+		t.Errorf("path-scoped show configuration missing placeholder:\n%s", out)
+	}
+}
+
+// TestCLIShowSystemRollbackRedactsPerClass pins the rollback render path: a
+// historical config slot carries the same secrets and must be masked for a
+// VIEW-only class in both hierarchical and `| display set` forms.
+func TestCLIShowSystemRollbackRedactsPerClass(t *testing.T) {
+	store := newCLISecretStore(t)
+	// A second commit pushes the secret-bearing config into rollback slot 1.
+	// The store is still in configure mode after the first commit (candidate
+	// is retained as a clone of active), so re-entering would deadlock the
+	// lock — LoadSet directly onto the live candidate.
+	if _, err := store.LoadSet("set system domain-name example.net"); err != nil {
+		t.Fatalf("LoadSet(): %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit(): %v", err)
+	}
+
+	for _, tc := range classWantsRedaction {
+		for _, args := range [][]string{
+			{"rollback", "1"},
+			{"rollback", "1", "|", "display", "set"},
+		} {
+			t.Run(tc.class+"/"+strings.Join(args, "_"), func(t *testing.T) {
+				c := &CLI{store: store, userClass: tc.class}
+				a := append([]string(nil), args...)
+				out := captureStdout(t, func() {
+					if err := c.handleShowSystem(a); err != nil {
+						t.Fatalf("handleShowSystem(%v): %v", args, err)
+					}
+				})
+				if tc.redact {
+					for _, leak := range cliSecretSentinels {
+						if strings.Contains(out, leak) {
+							t.Errorf("class=%q rollback LEAKED cleartext secret %q:\n%s", tc.class, leak, out)
+						}
+					}
+					if !strings.Contains(out, config.SecretDataPlaceholder) {
+						t.Errorf("class=%q rollback missing placeholder:\n%s", tc.class, out)
+					}
+				} else if !strings.Contains(out, "CLI-LEAK-IKE-PSK") {
+					t.Errorf("class=%q rollback unexpectedly redacted for privileged class:\n%s", tc.class, out)
+				}
+			})
+		}
+	}
+}
+
+// TestCLIShowSystemRootAuthRedacts pins `show system root-authentication`: the
+// encrypted root password is masked for a VIEW-only class, cleartext for
+// super-user.
+func TestCLIShowSystemRootAuthRedacts(t *testing.T) {
+	store := newCLISecretStore(t)
+	for _, tc := range classWantsRedaction {
+		t.Run(tc.class, func(t *testing.T) {
+			c := &CLI{store: store, userClass: tc.class}
+			out := captureStdout(t, func() {
+				if err := c.handleShowSystem([]string{"root-authentication"}); err != nil {
+					t.Fatalf("handleShowSystem(root-authentication): %v", err)
+				}
+			})
+			if tc.redact {
+				if strings.Contains(out, "ROOTPWHASH") {
+					t.Errorf("class=%q root-authentication LEAKED root password:\n%s", tc.class, out)
+				}
+				if !strings.Contains(out, config.SecretDataPlaceholder) {
+					t.Errorf("class=%q root-authentication missing placeholder:\n%s", tc.class, out)
+				}
+			} else if !strings.Contains(out, "ROOTPWHASH") {
+				t.Errorf("class=%q root-authentication unexpectedly redacted for privileged class:\n%s", tc.class, out)
+			}
+		})
+	}
+}
+
+// TestCLIShowSystemRescueRedacts pins `show system configuration rescue`: the
+// raw rescue.conf text (full active config with cleartext secrets, #4056) is
+// reparsed and masked for a VIEW-only class via LoadRescueConfigRedacted.
+func TestCLIShowSystemRescueRedacts(t *testing.T) {
+	store := newCLISecretStore(t)
+	if err := store.SaveRescueConfig(); err != nil {
+		t.Fatalf("SaveRescueConfig(): %v", err)
+	}
+	for _, tc := range classWantsRedaction {
+		t.Run(tc.class, func(t *testing.T) {
+			c := &CLI{store: store, userClass: tc.class}
+			out := captureStdout(t, func() {
+				if err := c.handleShowSystem([]string{"configuration", "rescue"}); err != nil {
+					t.Fatalf("handleShowSystem(configuration rescue): %v", err)
+				}
+			})
+			if tc.redact {
+				for _, leak := range cliSecretSentinels {
+					if strings.Contains(out, leak) {
+						t.Errorf("class=%q rescue LEAKED cleartext secret %q:\n%s", tc.class, leak, out)
+					}
+				}
+				if !strings.Contains(out, config.SecretDataPlaceholder) {
+					t.Errorf("class=%q rescue missing placeholder:\n%s", tc.class, out)
+				}
+			} else if !strings.Contains(out, "CLI-LEAK-IKE-PSK") {
+				t.Errorf("class=%q rescue unexpectedly redacted for privileged class:\n%s", tc.class, out)
+			}
+		})
+	}
+}
+
+// TestShowConfigRedactedHelper unit-tests the redact predicate directly so the
+// per-class policy is pinned independently of the render plumbing.
+func TestShowConfigRedactedHelper(t *testing.T) {
+	for _, tc := range classWantsRedaction {
+		c := &CLI{userClass: tc.class}
+		if got := c.showConfigRedacted(); got != tc.redact {
+			t.Errorf("showConfigRedacted(class=%q) = %v, want %v", tc.class, got, tc.redact)
+		}
+	}
+	// An unknown (never-configured) class fails closed.
+	c := &CLI{userClass: "bogus-class"}
+	if !c.showConfigRedacted() {
+		t.Errorf("showConfigRedacted(unknown class) = false, want true (fail-closed)")
+	}
+}

--- a/pkg/cli/cli_show_system.go
+++ b/pkg/cli/cli_show_system.go
@@ -828,6 +828,13 @@ func (c *CLI) handleShowSystem(args []string) error {
 		return nil
 
 	case "rollback":
+		// Secret redaction (#4099): rollback slots render a historical config
+		// AST that carries the same cleartext secret leaves as `show
+		// configuration`. Route a VIEW-only login class through the #4051
+		// *Redacted store methods so `show system rollback N [| display set]`
+		// cannot harvest IKE PSKs / SNMP communities / auth-keys; super-user
+		// (and the no-RBAC empty class) still sees cleartext.
+		redact := c.showConfigRedacted()
 		if len(args) >= 2 {
 			// "show system rollback compare N" — diff rollback N against active
 			if args[1] == "compare" {
@@ -838,7 +845,12 @@ func (c *CLI) handleShowSystem(args []string) error {
 				if err != nil || n < 1 {
 					return fmt.Errorf("usage: show system rollback compare <N>")
 				}
-				diff, err := c.store.ShowCompareRollback(n)
+				var diff string
+				if redact {
+					diff, err = c.store.ShowCompareRollbackRedacted(n)
+				} else {
+					diff, err = c.store.ShowCompareRollback(n)
+				}
 				if err != nil {
 					return err
 				}
@@ -857,13 +869,23 @@ func (c *CLI) handleShowSystem(args []string) error {
 			}
 			rest := strings.Join(args[2:], " ")
 			if strings.Contains(rest, "| display set") {
-				content, err := c.store.ShowRollbackSet(n)
+				var content string
+				if redact {
+					content, err = c.store.ShowRollbackSetRedacted(n)
+				} else {
+					content, err = c.store.ShowRollbackSet(n)
+				}
 				if err != nil {
 					return err
 				}
 				fmt.Print(content)
 			} else if strings.Contains(rest, "compare") {
-				diff, err := c.store.ShowCompareRollback(n)
+				var diff string
+				if redact {
+					diff, err = c.store.ShowCompareRollbackRedacted(n)
+				} else {
+					diff, err = c.store.ShowCompareRollback(n)
+				}
 				if err != nil {
 					return err
 				}
@@ -873,7 +895,12 @@ func (c *CLI) handleShowSystem(args []string) error {
 					fmt.Print(diff)
 				}
 			} else {
-				content, err := c.store.ShowRollback(n)
+				var content string
+				if redact {
+					content, err = c.store.ShowRollbackRedacted(n)
+				} else {
+					content, err = c.store.ShowRollback(n)
+				}
 				if err != nil {
 					return err
 				}
@@ -962,7 +989,9 @@ func (c *CLI) handleShowSystem(args []string) error {
 		if cfg == nil {
 			return fmt.Errorf("no active configuration")
 		}
-		fmt.Print(c.store.ShowActivePath([]string{"system", "login"}))
+		// #4099: system login carries encrypted-password hashes — mask them
+		// for a VIEW-only login class via the #4051 redacted renderer.
+		fmt.Print(c.showActiveConfigPath([]string{"system", "login"}))
 		return nil
 
 	case "internet-options":
@@ -970,7 +999,7 @@ func (c *CLI) handleShowSystem(args []string) error {
 		if cfg == nil {
 			return fmt.Errorf("no active configuration")
 		}
-		fmt.Print(c.store.ShowActivePath([]string{"system", "internet-options"}))
+		fmt.Print(c.showActiveConfigPath([]string{"system", "internet-options"}))
 		return nil
 
 	case "root-authentication":
@@ -978,12 +1007,23 @@ func (c *CLI) handleShowSystem(args []string) error {
 		if cfg == nil {
 			return fmt.Errorf("no active configuration")
 		}
-		fmt.Print(c.store.ShowActivePath([]string{"system", "root-authentication"}))
+		// #4099: root-authentication is the encrypted root password — mask it
+		// for a VIEW-only login class.
+		fmt.Print(c.showActiveConfigPath([]string{"system", "root-authentication"}))
 		return nil
 
 	case "configuration":
 		if len(args) >= 2 && args[1] == "rescue" {
-			content, err := c.store.LoadRescueConfig()
+			// #4099: rescue.conf is the full active config TEXT with cleartext
+			// secret leaves (#4056). Mask them for a VIEW-only login class via
+			// the reparse+RedactedClone path (fail-closed on parse error).
+			var content string
+			var err error
+			if c.showConfigRedacted() {
+				content, err = c.store.LoadRescueConfigRedacted()
+			} else {
+				content, err = c.store.LoadRescueConfig()
+			}
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/permissions.go
+++ b/pkg/cli/permissions.go
@@ -41,6 +41,60 @@ func (c *CLI) checkPermission(parts []string) error {
 	return fmt.Errorf("permission denied: %q requires a higher login class", strings.Join(parts, " "))
 }
 
+// showConfigRedacted reports whether the config-render CLI show paths — `show
+// configuration` (all formats), `show system rollback`, `show system
+// login|internet-options|root-authentication`, `show system configuration
+// rescue`, and the config-mode `show`/`show | compare` — must mask secret
+// leaves for the current login class (#4099).
+//
+// Junos never renders cleartext secrets in `show configuration` (it shows the
+// $9$/##SECRET-DATA form to every class), and xpf already redacts the REST and
+// gRPC ShowConfig raw-AST render paths unconditionally (#4051/F-020). The
+// on-box CLI, however, historically printed cleartext for every class (the
+// deliberate #4057 scope note: "operator reads own secret, root has DB
+// access"). That rationale holds for the privileged super-user / root operator
+// working at the console, but NOT for a VIEW-only read-only or config-viewer
+// login class — both PermView (types_system.go) — which could run `show
+// configuration | display set` and harvest every IKE PSK, SNMP community and
+// authentication-key in cleartext.
+//
+// We therefore redact for every login class EXCEPT super-user (the only class
+// carrying PermAll). super-user == the console root that #4057 protected and
+// that already has direct DB filesystem access, so it still reads cleartext to
+// copy a secret; read-only, config-viewer and operator see ##SECRET-DATA##. An
+// UNSET login class (CLI spawned without RBAC configured — the legacy
+// allow-everything mode, mirroring checkPermission's empty-class shortcut) is
+// treated as privileged and reads cleartext, so a deployment with no `system
+// login` classes is bit-identical to before this change. An UNKNOWN class
+// fails closed (redacted).
+func (c *CLI) showConfigRedacted() bool {
+	if c.userClass == "" {
+		return false
+	}
+	perms, ok := config.LoginClassPermissions[c.userClass]
+	if !ok {
+		return true
+	}
+	for _, p := range perms {
+		if p == config.PermAll {
+			return false
+		}
+	}
+	return true
+}
+
+// showActiveConfigPath renders an active-config subtree as hierarchical text,
+// masking secret leaves when showConfigRedacted() flags the current login
+// class (#4099). It is the redaction-aware replacement for direct
+// store.ShowActivePath calls on secret-bearing subtrees (`show system login`,
+// `show system root-authentication`).
+func (c *CLI) showActiveConfigPath(path []string) string {
+	if c.showConfigRedacted() {
+		return c.store.ShowActiveRedacted(path)
+	}
+	return c.store.ShowActivePath(path)
+}
+
 // requiredPermission returns the login-class permission a resolved operational
 // command needs. Gating is on the top-level word (parts[0]) for almost every
 // command, with one important exception: `monitor traffic` spawns a root

--- a/pkg/configstore/rescue_redaction_leak_4099_test.go
+++ b/pkg/configstore/rescue_redaction_leak_4099_test.go
@@ -1,0 +1,83 @@
+package configstore
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestLoadRescueConfigRedactedFailClosedOnParseError pins the #4099 Copilot
+// follow-up: a malformed rescue.conf must fail CLOSED with a GENERIC,
+// position-only error. It must NOT forward the raw config.ParseError text —
+// ParseError.Error() embeds ParseError.Message, which the lexer/parser
+// populates from the tampered file content (e.g. the offending character), and
+// the whole point of the redacted rescue path is that a VIEW-only CLI caller
+// never sees file-derived content it is not allowed to read.
+//
+// Before the fix the method returned fmt.Errorf("...: %v", perrs[0]), which
+// rendered ParseError.Error() verbatim into the returned error. Reverting to
+// that makes this test go RED (the raw parser detail — including the offending
+// character from the file — reappears in the error).
+func TestLoadRescueConfigRedactedFailClosedOnParseError(t *testing.T) {
+	dir := t.TempDir()
+	s, err := New(filepath.Join(dir, "xpf.conf"))
+	if err != nil {
+		t.Fatalf("New(): %v", err)
+	}
+
+	// A tampered/corrupt rescue.conf whose parse fails on an unexpected
+	// character ('@', not a Junos identifier character) sitting immediately
+	// after a secret-looking token. rescue.conf is written 0600 by the daemon
+	// (#4056) and is normally always well-formed (SaveRescueConfig renders the
+	// active tree); this simulates on-disk corruption / manual tampering.
+	const secretSentinel = "PRESHAREDLEAKSENTINEL"
+	malformed := "security {\n" +
+		"    ike {\n" +
+		"        policy p {\n" +
+		"            pre-shared-key " + secretSentinel + "@ ;\n" +
+		"        }\n" +
+		"    }\n" +
+		"}\n"
+	rescuePath := filepath.Join(dir, "rescue.conf")
+	if err := os.WriteFile(rescuePath, []byte(malformed), 0600); err != nil {
+		t.Fatalf("write rescue.conf: %v", err)
+	}
+
+	// Independently derive the raw parser error the OLD code forwarded, so the
+	// RED-on-revert assertion is exact and parser-agnostic.
+	_, perrs := config.NewParser(malformed).Parse()
+	if len(perrs) == 0 {
+		t.Fatalf("test setup: malformed rescue.conf parsed cleanly; adjust the fixture")
+	}
+	rawDetail := perrs[0].Error()
+
+	out, err := s.LoadRescueConfigRedacted()
+	if err == nil {
+		t.Fatalf("LoadRescueConfigRedacted() returned nil error on malformed rescue.conf; out=%q", out)
+	}
+	if out != "" {
+		t.Errorf("LoadRescueConfigRedacted() returned non-empty output on parse failure: %q", out)
+	}
+	got := err.Error()
+
+	// RED-on-revert: the raw parser detail (and the offending character it
+	// carries) must not reach the VIEW-only CLI caller.
+	if strings.Contains(got, rawDetail) {
+		t.Errorf("error forwarded raw parser detail %q to the CLI caller:\n%s", rawDetail, got)
+	}
+	if strings.Contains(got, "unexpected character") {
+		t.Errorf("error echoed the lexer's offending-character message:\n%s", got)
+	}
+	// The secret token body from the tampered file must never appear (guards
+	// against a future parser message that embeds the offending token value).
+	if strings.Contains(got, secretSentinel) {
+		t.Errorf("error leaked secret token %q from the rescue file:\n%s", secretSentinel, got)
+	}
+	// Positive: the fix returns the generic, position-only fail-closed message.
+	if !strings.Contains(got, "malformed") {
+		t.Errorf("error is not the generic fail-closed message:\n%s", got)
+	}
+}

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -432,3 +432,30 @@ func (s *Store) LoadRescueConfig() (string, error) {
 	}
 	return string(data), nil
 }
+
+// LoadRescueConfigRedacted returns the rescue configuration text with secret
+// leaves masked by config.SecretDataPlaceholder, for the on-box CLI display
+// path (#4099). rescue.conf is the full active config TEXT with cleartext
+// secret leaves (#4056), so `show system configuration rescue` — a PermView
+// command — would otherwise leak IKE PSKs, SNMP communities and auth-keys to a
+// read-only / config-viewer login class exactly as the raw-AST `show
+// configuration` renderers did before they were routed through the #4051
+// RedactedClone path. This reparses the saved text into an AST, redacts a
+// clone, and re-renders it as hierarchical text. It fails CLOSED: an empty
+// file returns "" (no rescue config), and a parse failure returns an error
+// rather than falling back to the cleartext bytes, so a malformed rescue file
+// can never leak a secret.
+func (s *Store) LoadRescueConfigRedacted() (string, error) {
+	text, err := s.LoadRescueConfig()
+	if err != nil {
+		return "", err
+	}
+	if text == "" {
+		return "", nil
+	}
+	tree, perrs := config.NewParser(text).Parse()
+	if len(perrs) > 0 {
+		return "", fmt.Errorf("parse rescue config for redaction: %v", perrs[0])
+	}
+	return tree.RedactedClone().Format(), nil
+}

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -445,6 +445,14 @@ func (s *Store) LoadRescueConfig() (string, error) {
 // file returns "" (no rescue config), and a parse failure returns an error
 // rather than falling back to the cleartext bytes, so a malformed rescue file
 // can never leak a secret.
+//
+// The parse-failure error is deliberately GENERIC: config.ParseError.Error()
+// embeds ParseError.Message, which the lexer/parser can populate with the
+// OFFENDING TOKEN VALUE (e.g. an unterminated `pre-shared-key "SECRET…`). If
+// that token were echoed back to the VIEW-only CLI caller it would defeat the
+// whole "never leak a secret" guarantee, so the returned error carries only
+// the position (Line/Column are ints and cannot hold a token) — never the
+// ParseError itself, its .Message, or any token text (#4099 Copilot follow-up).
 func (s *Store) LoadRescueConfigRedacted() (string, error) {
 	text, err := s.LoadRescueConfig()
 	if err != nil {
@@ -455,7 +463,9 @@ func (s *Store) LoadRescueConfigRedacted() (string, error) {
 	}
 	tree, perrs := config.NewParser(text).Parse()
 	if len(perrs) > 0 {
-		return "", fmt.Errorf("parse rescue config for redaction: %v", perrs[0])
+		return "", fmt.Errorf("rescue configuration is malformed and cannot be "+
+			"safely displayed (parse failed at line %d, column %d)",
+			perrs[0].Line, perrs[0].Column)
 	}
 	return tree.RedactedClone().Format(), nil
 }


### PR DESCRIPTION
## Summary

Fixes #4099 (fable-163 F3, HIGH security — secret disclosure to a VIEW-only login class).

The on-box interactive CLI config-render show paths called the **non-redacted** `Show*` store methods, so a `read-only` / `config-viewer` / `operator` login (all `PermView`) could run `show configuration` and print every IKE pre-shared-key, SNMP community, BGP/OSPF authentication-key, WireGuard private key and the encrypted root password **in cleartext**. This is the CLI residual of #4051/F-020, which wired only the REST + gRPC `ShowConfig` paths through the `*Redacted` `RedactedClone` renderers — the local CLI was never routed to them.

## Redaction-scope decision

Redact for **every login class except `super-user`** (and the unset/no-RBAC class, which is treated as privileged):

- Junos never renders a cleartext secret in `show configuration` for any class, and xpf already redacts the REST/gRPC path unconditionally — this brings the on-box CLI in line for the classes that can only VIEW.
- `super-user` keeps cleartext: it is the console root that #4057 deliberately left cleartext (root already has direct config-DB filesystem access, so masking it only obstructs copying a secret without protecting anything).
- An **unset/empty** class (no `system login` configured — the legacy no-RBAC allow-everything mode) is privileged → cleartext, so a deployment with no login classes is bit-identical to before.
- An **unknown** class fails **closed** (redacted).

## Changes

- `CLI.showConfigRedacted()` + `showActiveConfigPath()` (`pkg/cli/permissions.go`) — the per-class predicate (redact for any class without `PermAll`) and the redaction-aware active-subtree wrapper.
- `cli_show.go` case `"configuration"` — every format (hierarchical, `| display set/json/xml/inheritance`) and its path-scoped variants route through the `*Redacted` store methods when masking is required.
- `cli_show_system.go` — `show system rollback <N> [| display set | compare]`, `show system login`/`internet-options`/`root-authentication`, and `show system configuration rescue` routed the same way.
- `cli_config.go handleConfigShow` — config-mode candidate show + `| compare [rollback N]` routed through the redacted methods too (defense-in-depth: config mode is `PermConfig`/super-user-only today, but auto-masks should a lower class ever gain config-view access).
- `Store.LoadRescueConfigRedacted()` (`pkg/configstore/store_persist.go`) — reparse + `RedactedClone` + re-render for the raw `rescue.conf` text (#4056); **fails closed** on parse error.

## Validation

- New RED-on-revert unit test `pkg/cli/cli_show_config_redaction_4099_test.go`: commits a config with the named secrets, drives `handleShow` / `handleShowSystem` per login class across all display formats + the rollback / root-authentication / rescue paths — asserts `##SECRET-DATA##` (no cleartext) for read-only/config-viewer/operator/unauthorized, cleartext preserved for super-user and the unset class, and a non-secret `host-name` leaf unaffected. Forcing `redact=false` re-leaks every sentinel and drops the placeholder (confirmed RED on revert).
- `go test ./pkg/cli/... ./pkg/configstore/...` green; `go build ./...` clean; `gofmt`/`go vet` clean for all touched files.

## Docs

- `docs/system-login.md` gains a "Secret redaction in `show configuration`" subsection (per-class decision + fail-closed behavior).
- `docs/junos-config-display-reference.md` gets a redaction callout.

Closes #4099

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
