### PR TITLE
dhcp: reject a degenerate DHCPv4 subnet mask (Closes #4101)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-07-04 — #4101: DHCPv4 client rejects a degenerate subnet mask (fable-163 F6)
+
+- **Timestamp**: 2026-07-04
+  - **Action**: VERIFY-FIRST then fix the MEDIUM security/untrusted-input
+    defect. Confirmed at HEAD (`origin/master` ee8de92ef): `leaseFromACKv4`
+    (`pkg/dhcp/dhcp.go`) guarded only `mask == nil` (fallback `/24`) and
+    then took `ones, _ := net.IPMask(mask).Size()`. For a zero mask
+    (`0.0.0.0`) `Size()` returns `ones=0, bits=32`; for a non-contiguous
+    mask (`255.255.0.255`) it returns `(0,0)` — either way
+    `netip.PrefixFrom(addr, 0)` yields `YourIP/0`, which the apply path
+    (`applyAddress` `AddrReplace`) installs as an on-link `0.0.0.0/0`
+    connected route, blackholing/hijacking ALL IPv4 forwarding. A single
+    crafted ACK from a rogue/broken server triggers it, no operator action.
+  - **Fix**: after `.Size()` (now `ones, bits`), reject when
+    `bits != 32 || ones == 0` with an error (no lease). The error
+    propagates through `v4Exchange` → `runDHCPv4`, which retries a fresh
+    DISCOVER on acquire (no `YourIP/0` ever committed) or falls through to
+    T2/expiry keeping the current valid lease on renew/rebind — the safest
+    behavior (refuse the ACK, never default a degenerate mask to `/24`
+    which would mask the attack). A *missing* option 1 still falls back to
+    `/24`; only a present-but-degenerate mask is refused. `/31` and `/32`
+    (point-to-point / host leases) are accepted (floor: reject only
+    `ones==0` + non-contiguous).
+  - **File(s)**: `pkg/dhcp/dhcp.go` (guard), `pkg/dhcp/renew_test.go`
+    (table test `TestLeaseFromACKv4RejectsDegenerateMask` + `mustV4ACK`
+    helper), `pkg/dhcp/README.md` (Gotchas bullet).
+  - **Validation**: RED-on-revert proven — with the guard removed both
+    `0.0.0.0` and `255.255.0.255` parse to `192.0.2.50/0`; the /24, /32,
+    /31 and absent-mask cases pass either way. `go test ./pkg/dhcp/...`
+    green, `go build ./...`, `gofmt`, `go vet` clean.
+
 ## 2026-07-04 — #4097: FRR community-list member / as-path regex render-side sanitize belt (fable-163 F2)
 
 - **Timestamp**: 2026-07-04

--- a/pkg/dhcp/README.md
+++ b/pkg/dhcp/README.md
@@ -178,3 +178,16 @@ External only: `github.com/insomniacslk/dhcp`, `github.com/vishvananda/netlink`.
   route through a path that fires `onGatewayChange` (`finishClient` and
   `abandonLeaseAfterNAK` both do), so the ip-monitoring overlay
   withdraws its resolved next-hop in lock-step with the address.
+- **Degenerate subnet mask is refused (#4101, untrusted input).**
+  `leaseFromACKv4` validates option 1 after `net.IPMask.Size()`: a zero
+  mask (`0.0.0.0` → `Size()` returns `ones=0`) or a non-contiguous mask
+  (`255.255.0.255` → `(0,0)`) is rejected with an error instead of
+  producing a `YourIP/0` lease. Without the guard the kernel would install
+  an on-link `0.0.0.0/0` connected route on the DHCP interface and
+  blackhole/hijack all IPv4 forwarding — a rogue or broken server could
+  force this with a single crafted ACK. The rejection propagates through
+  `v4Exchange` → `runDHCPv4`, which retries a fresh DISCOVER on acquire (no
+  address ever installed) or falls through to T2/expiry keeping the current
+  valid lease on renew/rebind. A missing option 1 still falls back to `/24`;
+  only a *present-but-degenerate* mask is refused. Valid prefixes including
+  `/31` and `/32` (point-to-point / host leases) are accepted.

--- a/pkg/dhcp/dhcp.go
+++ b/pkg/dhcp/dhcp.go
@@ -924,7 +924,24 @@ func leaseFromACKv4(ifaceName string, ack *dhcpv4.DHCPv4) (*Lease, error) {
 	if mask == nil {
 		mask = net.CIDRMask(24, 32) // fallback
 	}
-	ones, _ := net.IPMask(mask).Size()
+	ones, bits := net.IPMask(mask).Size()
+
+	// Reject a degenerate subnet mask (untrusted input). net.IPMask.Size()
+	// returns ones=0 for a zero mask (0.0.0.0 → /0) and (0,0) for a
+	// non-contiguous mask (e.g. 255.255.0.255). Either would make the lease
+	// YourIP/0 and cause the kernel to install an on-link 0.0.0.0/0 connected
+	// route on this interface — blackholing/hijacking ALL IPv4 forwarding
+	// until the lease is replaced. A rogue or broken server can force this
+	// with a single crafted ACK, so refuse the lease rather than commit it.
+	// leaseFromACKv4's error propagates through v4Exchange → runDHCPv4, which
+	// retries a fresh DISCOVER (acquire) or falls through to T2/expiry keeping
+	// the existing valid lease (renew/rebind) — no YourIP/0 is ever installed.
+	// RFC 2131 requires option 1 to carry a valid subnet mask.
+	if bits != 32 || ones == 0 {
+		return nil, fmt.Errorf(
+			"DHCP ACK has invalid subnet mask %v on %s — refusing lease (would blackhole IPv4)",
+			net.IP(mask), ifaceName)
+	}
 
 	addr, ok := netip.AddrFromSlice(yourIP.To4())
 	if !ok {

--- a/pkg/dhcp/renew_test.go
+++ b/pkg/dhcp/renew_test.go
@@ -437,3 +437,100 @@ func TestRunDHCPv4RebindingNAKRestartsDiscover(t *testing.T) {
 		t.Errorf("lease after REBINDING NAK = %v, want nil (deconfigured)", got)
 	}
 }
+
+// mustV4ACK builds a minimal DHCPv4 ACK carrying yourIP and, when non-nil,
+// the given subnet mask (option 1). A nil mask omits the option so the
+// leaseFromACKv4 fallback path is exercised.
+func mustV4ACK(t *testing.T, yourIP net.IP, mask net.IPMask) *dhcpv4.DHCPv4 {
+	t.Helper()
+	mods := []dhcpv4.Modifier{
+		dhcpv4.WithMessageType(dhcpv4.MessageTypeAck),
+		dhcpv4.WithYourIP(yourIP),
+	}
+	if mask != nil {
+		mods = append(mods, dhcpv4.WithNetmask(mask))
+	}
+	ack, err := dhcpv4.New(mods...)
+	if err != nil {
+		t.Fatalf("build DHCPv4 ACK: %v", err)
+	}
+	return ack
+}
+
+// TestLeaseFromACKv4RejectsDegenerateMask locks in the #4101 fix: a rogue or
+// broken server that ACKs with a zero (0.0.0.0 → /0) or non-contiguous subnet
+// mask must NOT yield a YourIP/0 lease — the kernel would install an on-link
+// 0.0.0.0/0 connected route and blackhole all IPv4 forwarding. leaseFromACKv4
+// must reject such an ACK (error, no lease). RED-on-revert: without the guard,
+// the zero/non-contiguous cases parse to a valid Lease at 192.0.2.50/0.
+func TestLeaseFromACKv4RejectsDegenerateMask(t *testing.T) {
+	yourIP := net.ParseIP("192.0.2.50")
+
+	tests := []struct {
+		name     string
+		mask     net.IPMask
+		wantErr  bool
+		wantOnes int // expected prefix bits when accepted
+	}{
+		{
+			name:    "zero mask 0.0.0.0 (/0) rejected",
+			mask:    net.IPMask{0, 0, 0, 0},
+			wantErr: true,
+		},
+		{
+			name:    "non-contiguous mask 255.255.0.255 rejected",
+			mask:    net.IPMask{255, 255, 0, 255},
+			wantErr: true,
+		},
+		{
+			name:     "normal /24 accepted",
+			mask:     net.IPMask{255, 255, 255, 0},
+			wantErr:  false,
+			wantOnes: 24,
+		},
+		{
+			name:     "host /32 accepted",
+			mask:     net.IPMask{255, 255, 255, 255},
+			wantErr:  false,
+			wantOnes: 32,
+		},
+		{
+			name:     "point-to-point /31 accepted",
+			mask:     net.IPMask{255, 255, 255, 254},
+			wantErr:  false,
+			wantOnes: 31,
+		},
+		{
+			name:     "absent mask falls back to /24",
+			mask:     nil,
+			wantErr:  false,
+			wantOnes: 24,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ack := mustV4ACK(t, yourIP, tc.mask)
+			lease, err := leaseFromACKv4("wan0", ack)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("leaseFromACKv4 accepted degenerate mask; got lease %v, want error (no YourIP/0)",
+						lease.Address)
+				}
+				if lease != nil {
+					t.Errorf("lease returned alongside error = %v, want nil", lease.Address)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("leaseFromACKv4 rejected a valid mask: %v", err)
+			}
+			if got := lease.Address.Bits(); got != tc.wantOnes {
+				t.Errorf("lease prefix = /%d, want /%d", got, tc.wantOnes)
+			}
+			if lease.Address.Bits() == 0 {
+				t.Errorf("lease installed YourIP/0 (%v) — would blackhole IPv4", lease.Address)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`leaseFromACKv4` (`pkg/dhcp/dhcp.go`) guarded only the `mask == nil` case (falling back to `/24`) and then took `ones, _ := net.IPMask(mask).Size()`. A **present-but-degenerate** subnet mask (option 1) was never validated:

- zero mask `0.0.0.0` → `Size()` returns `ones=0, bits=32`
- non-contiguous mask `255.255.0.255` → `Size()` returns `(0,0)`

Either way the lease became `netip.PrefixFrom(addr, 0)` == **`YourIP/0`**, and the apply path (`applyAddress` → `AddrReplace`) installed an on-link **`0.0.0.0/0` connected route** on the DHCP interface — blackholing/hijacking **all IPv4 forwarding** until the lease is replaced. xpf runs DHCPv4 on uplink/mgmt interfaces (the `fxp0` bootstrap default), so option 1 is untrusted input: a rogue or broken server forces this with a **single crafted ACK**, no operator action.

## Fix

`pkg/dhcp/dhcp.go` — after `.Size()` (now `ones, bits`), reject when `bits != 32 || ones == 0`:

```go
ones, bits := net.IPMask(mask).Size()
if bits != 32 || ones == 0 {
    return nil, fmt.Errorf(
        "DHCP ACK has invalid subnet mask %v on %s — refusing lease (would blackhole IPv4)",
        net.IP(mask), ifaceName)
}
```

The error propagates through `v4Exchange` → `runDHCPv4`, which **retries a fresh DISCOVER** on acquire (no `YourIP/0` is ever committed) or **falls through to T2/expiry keeping the current valid lease** on renew/rebind. Refusing the ACK is safer than silently defaulting a degenerate mask to `/24`, which would mask the attack.

### Decisions
- **Floor:** reject only `ones == 0` (zero mask) and non-contiguous masks. `/31` and `/32` (point-to-point / host leases) are **accepted** — a `/32` DHCP lease is legitimate.
- **Missing option 1** still falls back to `/24` (unchanged) — only a *present-but-degenerate* mask is refused.
- `bits != 32` also catches any malformed non-4-byte mask.

## Test — RED on revert

`TestLeaseFromACKv4RejectsDegenerateMask` (table test in `pkg/dhcp/renew_test.go`, with a `mustV4ACK` helper) covers `0.0.0.0`, `255.255.0.255`, `/24`, `/32`, `/31`, and the absent-mask fallback.

With the guard removed both degenerate cases parse to `192.0.2.50/0`:

```
--- FAIL: .../zero_mask_0.0.0.0_(/0)_rejected
    leaseFromACKv4 accepted degenerate mask; got lease 192.0.2.50/0, want error
--- FAIL: .../non-contiguous_mask_255.255.0.255_rejected
    leaseFromACKv4 accepted degenerate mask; got lease 192.0.2.50/0, want error
--- PASS: .../normal_/24_accepted
--- PASS: .../host_/32_accepted
--- PASS: .../point-to-point_/31_accepted
--- PASS: .../absent_mask_falls_back_to_/24
```

With the fix: `go test ./pkg/dhcp/...` green, `go build ./...`, `gofmt`, `go vet` clean.

## Docs
`pkg/dhcp/README.md` Gotchas bullet + `_Log.md` entry.

Closes #4101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi