### PR TITLE
config: add predefined Junos application-set bundles (#4102)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,47 @@
+## 2026-07-04 — #4102: predefined Junos application-SET table (fable-163 F14)
+
+- **Timestamp**: 2026-07-04
+  - **Action**: VERIFY-FIRST then fix the MEDIUM vsrx-parity defect.
+    Confirmed at HEAD (`origin/master` e82b7d49c): `pkg/config/predefined.go`
+    shipped 89 individual predefined apps but NO predefined application-SET
+    table — the RPC bundles existed only as protocol-split members
+    (`junos-ms-rpc-tcp/-udp`, `junos-sun-rpc-tcp/-udp`), while
+    `junos-ms-rpc` / `junos-sun-rpc` / `junos-cifs` / `junos-routing-inbound`
+    were nowhere. `ResolveApplicationSet` consulted ONLY user-defined sets
+    (contrast `ResolveApplication`, which checks the predefined table). So a
+    stock vSRX policy `match application junos-ms-rpc` hard-failed at commit
+    (`validatePolicyMatchApplicationsStrict` → `appRefError`) and, on the
+    tolerant/HA-sync path, at runtime (`resolveUserspaceApplicationNames` →
+    `__unsupported__` → Rust `SnapshotIntegrityError`). Fail-closed but a
+    canonical vSRX config could not commit.
+  - **Fix**: added a `PredefinedApplicationSets` table seeded with the four
+    standard Junos bundles (members verified against a real `show
+    configuration groups junos-defaults` SRX dump), and routed both
+    `ResolveApplicationSet` and the `ExpandApplicationSet` member walk through
+    a new `lookupApplicationSet` helper that falls back to the predefined
+    table AFTER user-defined sets (user-then-predefined order, mirroring
+    `ResolveApplication`). `memberIsNestedSet` preserves the pre-#4102 member
+    classification (user-set → application → error) and only recurses a
+    predefined set when the member is not an application — zero regression for
+    existing configs. Both the commit gate and the runtime resolver route
+    through those two functions, so one table fixes every surface (commit,
+    runtime, NAT match, appid). Members:
+    `junos-ms-rpc`={ms-rpc-tcp,ms-rpc-udp}, `junos-sun-rpc`={sun-rpc-tcp,
+    sun-rpc-udp}, `junos-cifs`={netbios-session,smb-session},
+    `junos-routing-inbound`={bgp,rip,ldp-tcp,ldp-udp}. All members already in
+    the predefined app table — no member-app added, no partial-set gap.
+  - **File(s)**: `pkg/config/predefined.go`,
+    `pkg/config/predefined_app_sets_4102_test.go` (new),
+    `docs/config-schema.md`, `_Log.md`.
+  - **Validation**: `predefined_app_sets_4102_test.go` proves each set
+    resolves + expands to its canonical members (RED on revert:
+    `ResolveApplicationSet` miss / `ExpandApplicationSet` not-found /
+    `CompileConfig` appRefError when the table is emptied — verified), a
+    user-defined set still resolves and shadows a same-named bundle, and an
+    unknown set still hard-fails (no false-accept). `go test
+    ./pkg/config/... ./pkg/appid/... ./pkg/policymatch/...
+    ./pkg/dataplane/userspace/...` green; `go build ./...` + `go vet` clean.
+
 ## 2026-07-04 — #4101: DHCPv4 client rejects a degenerate subnet mask (fable-163 F6)
 
 - **Timestamp**: 2026-07-04

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3613,6 +3613,27 @@ strict-vs-lenient gates:
   (a `description` is accepted as metadata); it runs EARLIER than Finding B, so a
   typo'd keyword is reported as "unknown member statement" rather than a dangling
   reference. Same strict-reject / lenient-warn discipline (`lenientApplicationSpecs`).
+  **Predefined application-set bundles (#4102, fable-review-163 F14):**
+  `ResolveApplicationSet` / `ExpandApplicationSet` (`pkg/config/predefined.go`)
+  fall back to a `PredefinedApplicationSets` table AFTER user-defined sets —
+  mirroring `ResolveApplication`'s user-then-predefined order — so the standard
+  Junos `junos-defaults` bundles resolve without an operator having to redefine
+  them. Seeded from a real `show configuration groups junos-defaults` dump:
+  `junos-ms-rpc` = {`junos-ms-rpc-tcp`, `junos-ms-rpc-udp`}, `junos-sun-rpc` =
+  {`junos-sun-rpc-tcp`, `junos-sun-rpc-udp`}, `junos-cifs` =
+  {`junos-netbios-session`, `junos-smb-session`}, `junos-routing-inbound` =
+  {`junos-bgp`, `junos-rip`, `junos-ldp-tcp`, `junos-ldp-udp`}. Every member is
+  in the `PredefinedApplications` table, so each set expands to >= 1 member and
+  clears the empty-set fail-open gate (#3146). Before #4102 only the
+  protocol-split members shipped and the bundle names were nowhere, so a stock
+  vSRX policy `match application junos-ms-rpc` hard-failed at commit
+  (`validatePolicyMatchApplicationsStrict`) and, on the tolerant path, at runtime
+  (`resolveUserspaceApplicationNames` → `__unsupported__` →
+  `SnapshotIntegrityError`). Both the commit gate and the runtime resolver route
+  through these two functions, so the one table fixes every surface. A
+  user-defined set of the same name still shadows the predefined bundle (user
+  wins), and an unknown set name still hard-fails. Coverage:
+  `predefined_app_sets_4102_test.go`.
 - **Finding C — `then routing-instance <name>` (FBF) →
   `validateFirewallRoutingInstanceReferencesStrict`.** A firewall-filter term
   whose filter-based-forwarding steer names a routing-instance not defined under

--- a/pkg/config/predefined.go
+++ b/pkg/config/predefined.go
@@ -146,6 +146,45 @@ var PredefinedApplications = map[string]*Application{
 	"junos-udp-any": {Name: "junos-udp-any", Protocol: "udp"},
 }
 
+// PredefinedApplicationSets contains the built-in Junos application-SET bundles
+// (the `junos-defaults` application-sets shipped on an SRX/vSRX). A canonical
+// vSRX policy references these by name — e.g.
+// `set security policies ... match application junos-ms-rpc` — so without this
+// table a migrated config hard-fails: the commit gate
+// (validatePolicyMatchApplicationsStrict) rejects the token and the runtime
+// resolver (resolveUserspaceApplicationNames) returns __unsupported__, because
+// ResolveApplicationSet used to consult ONLY user-defined sets (#4102).
+//
+// Members are verified against a real `show configuration groups
+// junos-defaults` dump (SRX 15.1X49). Every member resolves through the
+// PredefinedApplications table above, so each set expands to >= 1 member and
+// clears the empty-set fail-open gate (#3146). ResolveApplicationSet and
+// ExpandApplicationSet fall back to this table AFTER user-defined sets, so an
+// operator can still shadow or extend a bundle name (user-then-predefined
+// precedence, mirroring ResolveApplication).
+var PredefinedApplicationSets = map[string]*ApplicationSet{
+	// Microsoft RPC endpoint mapper (TCP + UDP 135).
+	"junos-ms-rpc": {
+		Name:         "junos-ms-rpc",
+		Applications: []string{"junos-ms-rpc-tcp", "junos-ms-rpc-udp"},
+	},
+	// ONC / Sun RPC portmapper (TCP + UDP 111).
+	"junos-sun-rpc": {
+		Name:         "junos-sun-rpc",
+		Applications: []string{"junos-sun-rpc-tcp", "junos-sun-rpc-udp"},
+	},
+	// CIFS / Windows file sharing over NetBIOS session (139) + SMB (445).
+	"junos-cifs": {
+		Name:         "junos-cifs",
+		Applications: []string{"junos-netbios-session", "junos-smb-session"},
+	},
+	// Inbound routing protocols: BGP (179/tcp), RIP (520/udp), LDP (646/tcp+udp).
+	"junos-routing-inbound": {
+		Name:         "junos-routing-inbound",
+		Applications: []string{"junos-bgp", "junos-rip", "junos-ldp-tcp", "junos-ldp-udp"},
+	},
+}
+
 // ResolveApplication looks up an application by name, checking user-defined
 // applications first, then predefined.
 func ResolveApplication(name string, userApps map[string]*Application) (*Application, bool) {
@@ -160,12 +199,26 @@ func ResolveApplication(name string, userApps map[string]*Application) (*Applica
 	return nil, false
 }
 
-// ResolveApplicationSet looks up an application-set by name.
+// ResolveApplicationSet looks up an application-set by name, checking
+// user-defined sets first, then the built-in PredefinedApplicationSets table
+// (#4102). Mirrors ResolveApplication's user-then-predefined precedence so the
+// commit gate and the runtime resolver both recognize the standard Junos
+// bundles (junos-ms-rpc, junos-sun-rpc, junos-cifs, junos-routing-inbound).
 func ResolveApplicationSet(name string, appSets map[string]*ApplicationSet) (*ApplicationSet, bool) {
+	return lookupApplicationSet(name, appSets)
+}
+
+// lookupApplicationSet returns the application-set definition for name,
+// checking user-defined sets first (so an operator can shadow or extend a
+// predefined bundle name) then the built-in predefined Junos set table.
+func lookupApplicationSet(name string, appSets map[string]*ApplicationSet) (*ApplicationSet, bool) {
 	if appSets != nil {
 		if as, ok := appSets[name]; ok {
 			return as, true
 		}
+	}
+	if as, ok := PredefinedApplicationSets[name]; ok {
+		return as, true
 	}
 	return nil, false
 }
@@ -181,7 +234,7 @@ func expandAppSet(name string, apps *ApplicationsConfig, depth int) ([]string, e
 		return nil, fmt.Errorf("application-set nesting too deep (max 3): %s", name)
 	}
 
-	as, ok := apps.ApplicationSets[name]
+	as, ok := lookupApplicationSet(name, apps.ApplicationSets)
 	if !ok {
 		return nil, fmt.Errorf("application-set %q not found", name)
 	}
@@ -190,8 +243,11 @@ func expandAppSet(name string, apps *ApplicationsConfig, depth int) ([]string, e
 	seen := make(map[string]bool)
 
 	for _, memberName := range as.Applications {
-		// Check if it's another application-set (recurse)
-		if _, isSet := apps.ApplicationSets[memberName]; isSet {
+		// Check if it's another application-set (recurse). A member may name a
+		// user-defined OR a predefined set (#4102); memberIsNestedSet preserves
+		// the historical classification (user-set → application → error) and
+		// only recurses a predefined set when the member is not an application.
+		if memberIsNestedSet(memberName, apps) {
 			expanded, err := expandAppSet(memberName, apps, depth+1)
 			if err != nil {
 				return nil, err
@@ -216,6 +272,26 @@ func expandAppSet(name string, apps *ApplicationsConfig, depth int) ([]string, e
 	}
 
 	return result, nil
+}
+
+// memberIsNestedSet reports whether an application-set member should be expanded
+// as a nested set rather than resolved as a leaf application. A user-defined set
+// always wins first (an operator may shadow a predefined bundle name); a
+// predefined set is consulted only when the member does not resolve as an
+// application, so a user application that shadows a predefined-set name keeps
+// application semantics — preserving the pre-#4102 member classification for
+// every existing config while enabling nested references to predefined bundles.
+func memberIsNestedSet(memberName string, apps *ApplicationsConfig) bool {
+	if apps.ApplicationSets != nil {
+		if _, ok := apps.ApplicationSets[memberName]; ok {
+			return true
+		}
+	}
+	if _, isApp := ResolveApplication(memberName, apps.Applications); isApp {
+		return false
+	}
+	_, isPredefSet := PredefinedApplicationSets[memberName]
+	return isPredefSet
 }
 
 // ExpandAddressSet recursively expands an address-set to individual

--- a/pkg/config/predefined_app_sets_4102_test.go
+++ b/pkg/config/predefined_app_sets_4102_test.go
@@ -1,0 +1,153 @@
+package config
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Tests for #4102: the standard Junos predefined application-SETS
+// (junos-ms-rpc, junos-sun-rpc, junos-cifs, junos-routing-inbound) were absent.
+// Only the protocol-split members (junos-ms-rpc-tcp/-udp, junos-sun-rpc-tcp/-udp)
+// shipped as individual apps, and ResolveApplicationSet consulted ONLY
+// user-defined sets — so a canonical vSRX policy `match application junos-ms-rpc`
+// hard-failed at commit (validatePolicyMatchApplicationsStrict → appRefError:
+// not an app, not a set) and, on the tolerant path, at runtime
+// (resolveUserspaceApplicationNames → __unsupported__ → SnapshotIntegrityError).
+//
+// The fix adds PredefinedApplicationSets and has ResolveApplicationSet /
+// ExpandApplicationSet fall back to it (user-then-predefined order).
+//
+// fail-on-revert: deleting the PredefinedApplicationSets entries (or dropping
+// the predefined fallback in lookupApplicationSet) turns
+// TestPredefinedApplicationSetsResolve RED (ExpandApplicationSet errors /
+// ResolveApplicationSet misses) and TestPredefinedApplicationSetPolicyCommits
+// RED (CompileConfig hard-rejects the reference).
+
+// TestPredefinedApplicationSetsResolve pins the canonical Junos membership of
+// each predefined application-set and proves it resolves with NO user config —
+// the predefined table alone must satisfy both ResolveApplicationSet and the
+// ExpandApplicationSet member walk. Member lists and order are verified against
+// a real `show configuration groups junos-defaults` dump (SRX 15.1X49).
+func TestPredefinedApplicationSetsResolve(t *testing.T) {
+	cases := []struct {
+		set  string
+		want []string
+	}{
+		{"junos-ms-rpc", []string{"junos-ms-rpc-tcp", "junos-ms-rpc-udp"}},
+		{"junos-sun-rpc", []string{"junos-sun-rpc-tcp", "junos-sun-rpc-udp"}},
+		{"junos-cifs", []string{"junos-netbios-session", "junos-smb-session"}},
+		{"junos-routing-inbound", []string{"junos-bgp", "junos-rip", "junos-ldp-tcp", "junos-ldp-udp"}},
+	}
+	// Empty ApplicationsConfig: no user apps, no user sets — resolution must
+	// come entirely from the predefined tables.
+	empty := &ApplicationsConfig{}
+	for _, tc := range cases {
+		t.Run(tc.set, func(t *testing.T) {
+			if _, ok := ResolveApplicationSet(tc.set, nil); !ok {
+				t.Fatalf("ResolveApplicationSet(%q, nil) = false, want true (predefined set)", tc.set)
+			}
+			got, err := ExpandApplicationSet(tc.set, empty)
+			if err != nil {
+				t.Fatalf("ExpandApplicationSet(%q): %v", tc.set, err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("ExpandApplicationSet(%q) = %v, want %v (config order)", tc.set, got, tc.want)
+			}
+			// Every expanded member must itself resolve as a predefined app —
+			// otherwise the set would trip the empty/dangling-member gates.
+			for _, m := range got {
+				if _, ok := ResolveApplication(m, nil); !ok {
+					t.Fatalf("predefined set %q member %q does not resolve as an application", tc.set, m)
+				}
+			}
+		})
+	}
+}
+
+// TestPredefinedApplicationSetPolicyCommits proves a stock vSRX policy that
+// references each predefined application-set commits cleanly under the STRICT
+// path (the exact surface that hard-failed before #4102). This is the primary
+// fail-on-revert signal: removing the predefined set table makes appRefError
+// reject the reference and CompileConfig returns an error, failing this test.
+func TestPredefinedApplicationSetPolicyCommits(t *testing.T) {
+	for _, set := range []string{"junos-ms-rpc", "junos-sun-rpc", "junos-cifs", "junos-routing-inbound"} {
+		t.Run(set, func(t *testing.T) {
+			cmds := append(append([]string{}, zoneBoilerplate...),
+				"set security policies from-zone trust to-zone untrust policy p match source-address any",
+				"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy p match application "+set,
+				"set security policies from-zone trust to-zone untrust policy p then permit",
+			)
+			tree := buildAppMatchTree(t, cmds...)
+			if _, err := CompileConfig(tree); err != nil {
+				t.Fatalf("CompileConfig: predefined application-set %q should commit clean, got %v", set, err)
+			}
+		})
+	}
+}
+
+// TestUserDefinedApplicationSetShadowsPredefined proves the user-then-predefined
+// precedence: a user-defined application-set whose name collides with a
+// predefined bundle wins, and a plain user-defined set still resolves (the
+// pre-#4102 behavior is preserved, not clobbered by the new fallback).
+func TestUserDefinedApplicationSetShadowsPredefined(t *testing.T) {
+	apps := &ApplicationsConfig{
+		Applications: map[string]*Application{
+			"MYAPP": {Name: "MYAPP", Protocol: "tcp", DestinationPort: "8080"},
+		},
+		ApplicationSets: map[string]*ApplicationSet{
+			// Shadow the predefined junos-ms-rpc with a single custom member.
+			"junos-ms-rpc": {Name: "junos-ms-rpc", Applications: []string{"MYAPP"}},
+			// A plain user set (no predefined collision).
+			"MYSET": {Name: "MYSET", Applications: []string{"MYAPP", "junos-http"}},
+		},
+	}
+
+	// User definition wins over the predefined bundle (user-first order).
+	got, err := ExpandApplicationSet("junos-ms-rpc", apps)
+	if err != nil {
+		t.Fatalf("ExpandApplicationSet(shadowed junos-ms-rpc): %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"MYAPP"}) {
+		t.Fatalf("shadowed junos-ms-rpc expanded to %v, want [MYAPP] (user def must win)", got)
+	}
+
+	// A plain user set still resolves.
+	got, err = ExpandApplicationSet("MYSET", apps)
+	if err != nil {
+		t.Fatalf("ExpandApplicationSet(MYSET): %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"MYAPP", "junos-http"}) {
+		t.Fatalf("MYSET expanded to %v, want [MYAPP junos-http]", got)
+	}
+
+	// A predefined set NOT shadowed still resolves from the predefined table.
+	got, err = ExpandApplicationSet("junos-sun-rpc", apps)
+	if err != nil {
+		t.Fatalf("ExpandApplicationSet(junos-sun-rpc): %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"junos-sun-rpc-tcp", "junos-sun-rpc-udp"}) {
+		t.Fatalf("junos-sun-rpc expanded to %v, want the predefined members", got)
+	}
+}
+
+// TestUnknownApplicationSetStillRejected proves the predefined fallback did NOT
+// weaken the definedness gate: an unknown application-set / application name
+// still hard-fails at commit (no false-accept).
+func TestUnknownApplicationSetStillRejected(t *testing.T) {
+	cmds := append(append([]string{}, zoneBoilerplate...),
+		"set security policies from-zone trust to-zone untrust policy p match source-address any",
+		"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy p match application junos-no-such-set",
+		"set security policies from-zone trust to-zone untrust policy p then permit",
+	)
+	tree := buildAppMatchTree(t, cmds...)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("CompileConfig: expected reject for unknown application-set, got nil")
+	}
+	if !strings.Contains(err.Error(), `application "junos-no-such-set" is not defined`) {
+		t.Fatalf("CompileConfig error = %q, want undefined-application reject", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

Closes #4102 (fable-review-163 F14, MEDIUM vsrx-parity).

`pkg/config/predefined.go` shipped the 89 individual `junos-*` predefined applications but **no predefined application-SET table**. The RPC bundles existed only as protocol-split members (`junos-ms-rpc-tcp/-udp`, `junos-sun-rpc-tcp/-udp`), while `junos-ms-rpc`, `junos-sun-rpc`, `junos-cifs`, and `junos-routing-inbound` were absent. `ResolveApplicationSet` consulted **only** user-defined sets (contrast `ResolveApplication`, which checks the predefined table).

A stock vSRX policy `match application junos-ms-rpc` therefore hard-failed:
- **Strict commit path** — `validatePolicyMatchApplicationsStrict` → `appRefError` (not an app, not a set) rejected the token.
- **Tolerant / HA-sync path** — the strict gate warned, but `resolveUserspaceApplicationNames` hit the same miss → `__unsupported__` sentinel → Rust `SnapshotIntegrityError` rejected the whole snapshot.

Fail-closed, but a firewall cloning vSRX could not commit a canonical vSRX config.

## Fix

- New `PredefinedApplicationSets` table in `predefined.go`, seeded with the four standard Junos `junos-defaults` bundles.
- New `lookupApplicationSet` helper (user-then-predefined order, mirroring `ResolveApplication`); `ResolveApplicationSet` and the `ExpandApplicationSet` member walk both route through it.
- `memberIsNestedSet` preserves the exact pre-#4102 member classification (user-set → application → error) and only recurses a predefined set when the member resolves as nothing else — zero regression for existing configs.

Both the commit gate and the runtime resolver route through these two functions, so **one table fixes every surface**: commit gate, runtime capability gate, NAT match-application, and appid.

## Members (verified against a real `show configuration groups junos-defaults` SRX dump — not guessed)

| Set | Members |
|-----|---------|
| `junos-ms-rpc` | `junos-ms-rpc-tcp`, `junos-ms-rpc-udp` |
| `junos-sun-rpc` | `junos-sun-rpc-tcp`, `junos-sun-rpc-udp` |
| `junos-cifs` | `junos-netbios-session`, `junos-smb-session` |
| `junos-routing-inbound` | `junos-bgp`, `junos-rip`, `junos-ldp-tcp`, `junos-ldp-udp` |

Every member already exists in the `PredefinedApplications` table, so each set expands to >= 1 member and clears the empty-set fail-open gate (#3146). No member application had to be added; no partial-set gap.

## Tests

`predefined_app_sets_4102_test.go`:
- each bundle resolves (`ResolveApplicationSet`) and expands (`ExpandApplicationSet`) to its canonical members in config order;
- a stock vSRX policy matching each bundle commits clean under the strict path;
- a user-defined set of the same name shadows the predefined bundle (user wins) and a plain user-defined set still resolves;
- an unknown set name still hard-fails (no false-accept).

**RED-on-revert (verified):** emptying `PredefinedApplicationSets` turns the resolve + commit tests RED (`ResolveApplicationSet` miss / `ExpandApplicationSet` not-found / `appRefError` reject).

`go test ./pkg/config/... ./pkg/appid/... ./pkg/policymatch/... ./pkg/dataplane/userspace/...` green; `go build ./...` and `go vet` clean. `docs/config-schema.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi