### PR TITLE
RBAC maintenance gate for destructive request verbs + system_action audit journal (#4108 F21+F8)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,24 @@
+## 2026-07-04 — #4108: RBAC maintenance gate + system_action audit journal (fable-163 F21+F8)
+
+- **Timestamp**: 2026-07-04
+  - **Action**: F21 (MEDIUM, RBAC/vsrx-parity). VERIFY-FIRST confirmed the
+    bug: `operator` holds `PermControl` and `requiredPermission` mapped ALL
+    of `request`/`test` → `PermControl`, so `operator` passed the gate for
+    the destructive `request system {reboot,halt,power-off,zeroize}` and
+    `request chassis cluster failover` — verbs the predefined Junos
+    `operator` class LACKS (`maintenance`). Fix: added a super-user-only
+    `PermMaint` bit (`pkg/config/types_system.go`); super-user reaches it via
+    `PermAll` so no non-super class holds it. New `requiredPermission` branch
+    → `requestSubcommandIsMaintenance` returns `PermMaint` for the four
+    destructive `request system` verbs + `request chassis cluster failover`,
+    resolving the subcommand with the SAME prefix matcher the dispatcher uses
+    (abbrev `request system zero` / `request sys reboot` cannot bypass). Kept
+    benign `request` verbs at `PermControl` so `operator` retains them.
+    RED-on-revert proven (operator allowed all four + cluster failover +
+    abbreviations when the branch is neutralized).
+  - **File(s)**: pkg/config/types_system.go, pkg/cli/permissions.go,
+    pkg/cli/permissions_maintenance_4108_test.go, docs/system-login.md, _Log.md
+
 ## 2026-07-04 — #4099: on-box CLI `show configuration` secret redaction by login class
 
 - **Timestamp**: 2026-07-04

--- a/_Log.md
+++ b/_Log.md
@@ -19,6 +19,30 @@
   - **File(s)**: pkg/config/types_system.go, pkg/cli/permissions.go,
     pkg/cli/permissions_maintenance_4108_test.go, docs/system-login.md, _Log.md
 
+- **Timestamp**: 2026-07-04
+  - **Action**: F8 (LOW, audit/observability). VERIFY-FIRST confirmed the
+    gap: `grpcapi/server_diag.go` SystemAction only `slog.Warn`'d the
+    destructive verbs — no journal call — so a `zeroize` (wipes config) or
+    reboot left NO tamper-resistant audit record (the journald line does not
+    survive a zeroize). Fix: new public `Store.LogSystemAction(action)`
+    (`pkg/configstore/store_commit.go`) appends a fsynced `system_action`
+    journal entry (reuses `journalLog`); the SystemAction handler calls
+    `s.logSystemAction(<verb>)` BEFORE executing reboot/halt/power-off/
+    zeroize (`pkg/grpcapi/server_diag.go`), so the fsynced record is durable
+    before the box goes down / config is wiped. The journal file
+    `.config.journal` also survives zeroize (not in the .conf/rollback
+    removal set). Extracted the destructive execution behind package seams
+    (`schedulePowerAction`/`performZeroizeWipe`) so a unit test can drive the
+    full SystemAction dispatch without rebooting or wiping /etc/xpf.
+    `system_action` is excluded from `ListCommitHistory` (show system commit
+    = config commits only). RED-on-revert proven (no-op'ing LogSystemAction
+    → both configstore + grpcapi tests fail: no journal entry).
+  - **File(s)**: pkg/configstore/store_commit.go,
+    pkg/configstore/journal/journal.go, pkg/grpcapi/server_diag.go,
+    pkg/configstore/system_action_journal_4108_test.go,
+    pkg/grpcapi/system_action_journal_4108_test.go,
+    pkg/configstore/README.md, docs/system-login.md, _Log.md
+
 ## 2026-07-04 — #4099: on-box CLI `show configuration` secret redaction by login class
 
 - **Timestamp**: 2026-07-04

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -90,6 +90,13 @@ subcommand with the same prefix matcher the dispatcher uses, so an abbreviated
 fully-spelled form and cannot bypass the gate. `super-user` reaches these verbs
 through `PermAll`, so `PermMaint` need not appear in its permission list.
 
+**Audit trail (#4108 F8).** When one of these destructive verbs runs, the gRPC
+`SystemAction` handler writes a fsynced `system_action` entry (verb + timestamp)
+to the configstore audit journal (`.config.journal`) **before** executing, so a
+durable, attributable record survives even a `zeroize` (the `journald` line does
+not). See the configstore README "Audit journal" section for the record format
+and zeroize-survival details.
+
 **Privileged-subcommand exception — `monitor traffic` (#4067).** Almost
 every command is gated on the top-level word alone, but `monitor traffic`
 spawns a **root `tcpdump` live packet capture** on a data interface, so it

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -41,11 +41,17 @@ classes are:
 
 | Class | Permissions |
 |---|---|
-| `super-user` | everything |
-| `operator` | view, clear, control (request/test) |
+| `super-user` | everything (incl. destructive maintenance) |
+| `operator` | view, clear, control (request/test) — **not** maintenance |
 | `read-only` | view only |
 | `config-viewer` | view only (can display config; cannot enter `configure` to modify) |
 | `unauthorized` | nothing |
+
+`super-user` is the only class that holds the destructive **maintenance**
+permission (`PermMaint`), which it reaches through `PermAll`. `operator` has
+`control` (so it can run benign `request`/`test` commands) but **not**
+maintenance, mirroring Junos where the predefined `operator` class lacks the
+`maintenance` permission and therefore cannot reboot or zeroize the box (#4108).
 
 RBAC is enforced at runtime by `checkPermission` (`pkg/cli/permissions.go`),
 invoked by the dispatch layer before each top-level command. The accepted
@@ -64,8 +70,25 @@ Gating is on the resolved **top-level** command word:
 | `show`, `ping`, `traceroute`, `monitor` | view |
 | `clear` | clear |
 | `request`, `test` | control |
+| `request system {reboot,halt,power-off,zeroize}`, `request chassis cluster failover` | **maintenance** (super-user only) |
 | `configure` | config |
 | anything else | super-user (all) |
+
+**Privileged-subcommand exception — destructive maintenance (#4108 F21).**
+Most `request` verbs are `control`-level, but the four `request system` verbs
+that take the box down or wipe it — `reboot`, `halt`, `power-off`, `zeroize` —
+and `request chassis cluster failover` are gated at the super-user-only
+**maintenance** (`PermMaint`) level. On Junos the predefined `operator` class
+has no `maintenance` permission and so cannot reboot/zeroize; xpf matches that:
+`operator` (which holds `control`) is **denied** these verbs, while its benign
+`request` commands (`request security …`, `request system software`,
+`request system dynamic-dns`, rescue-config save, etc.) stay `control` and
+remain available. The exception lives in `requiredPermission` →
+`requestSubcommandIsMaintenance` (`pkg/cli/permissions.go`) and resolves the
+subcommand with the same prefix matcher the dispatcher uses, so an abbreviated
+`request system zero` or `request sys reboot` is gated identically to the
+fully-spelled form and cannot bypass the gate. `super-user` reaches these verbs
+through `PermAll`, so `PermMaint` need not appear in its permission list.
 
 **Privileged-subcommand exception — `monitor traffic` (#4067).** Almost
 every command is gated on the top-level word alone, but `monitor traffic`

--- a/pkg/cli/permissions.go
+++ b/pkg/cli/permissions.go
@@ -113,6 +113,18 @@ func requiredPermission(parts []string) config.LoginClassPermission {
 		return config.PermControl
 	}
 
+	// `request system {reboot,halt,power-off,zeroize}` and `request chassis
+	// cluster failover` are DESTRUCTIVE maintenance verbs. On Junos the
+	// predefined `operator` class lacks the `maintenance` permission and so
+	// cannot reboot/zeroize; xpf mirrors that by gating them at the
+	// super-user-only PermMaint level instead of the plain PermControl the
+	// rest of the `request` family (request session, request security, etc.)
+	// keeps, so `operator` retains benign request verbs but not the ones that
+	// take the box down or wipe it (#4108 F21).
+	if action == "request" && requestSubcommandIsMaintenance(parts[1:]) {
+		return config.PermMaint
+	}
+
 	switch action {
 	case "show", "ping", "traceroute", "monitor":
 		return config.PermView
@@ -125,6 +137,72 @@ func requiredPermission(parts []string) config.LoginClassPermission {
 	default:
 		return config.PermAll
 	}
+}
+
+// requestSubcommandIsMaintenance reports whether the `request` arguments
+// resolve to a destructive maintenance verb: `request system
+// {reboot,halt,power-off,zeroize}` or `request chassis cluster failover ...`.
+// It applies the same prefix resolution the CLI dispatcher uses (resolveCommand
+// over the cmdtree children), so an abbreviated `request system zero` or
+// `request sys reboot` is gated identically to the fully-spelled form and
+// cannot bypass the gate. Resolution errs toward the dispatcher: an
+// unresolvable/ambiguous token that would never actually run returns false
+// (plain control), while every token the dispatcher would execute as a
+// destructive verb resolves here and elevates to PermMaint (fail-closed).
+func requestSubcommandIsMaintenance(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	reqNode, ok := operationalTree["request"]
+	if !ok || reqNode == nil {
+		return false
+	}
+	target, err := resolveCommand(args[0], keysFromTree(reqNode.Children))
+	if err != nil {
+		return false
+	}
+	switch target {
+	case "system":
+		if len(args) < 2 {
+			return false
+		}
+		sysNode := reqNode.Children["system"]
+		if sysNode == nil {
+			return false
+		}
+		verb, err := resolveCommand(args[1], keysFromTree(sysNode.Children))
+		if err != nil {
+			return false
+		}
+		switch verb {
+		case "reboot", "halt", "power-off", "zeroize":
+			return true
+		}
+		return false
+	case "chassis":
+		// request chassis cluster failover ...
+		if len(args) < 3 {
+			return false
+		}
+		chNode := reqNode.Children["chassis"]
+		if chNode == nil {
+			return false
+		}
+		clusterTok, err := resolveCommand(args[1], keysFromTree(chNode.Children))
+		if err != nil || clusterTok != "cluster" {
+			return false
+		}
+		clNode := chNode.Children["cluster"]
+		if clNode == nil {
+			return false
+		}
+		failoverTok, err := resolveCommand(args[2], keysFromTree(clNode.Children))
+		if err != nil {
+			return false
+		}
+		return failoverTok == "failover"
+	}
+	return false
 }
 
 // monitorSubcommandIsTraffic reports whether the monitor arguments resolve to

--- a/pkg/cli/permissions_maintenance_4108_test.go
+++ b/pkg/cli/permissions_maintenance_4108_test.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCheckPermission_DestructiveMaintenanceRequiresMaint pins #4108 F21: the
+// destructive maintenance verbs — `request system {reboot,halt,power-off,
+// zeroize}` and `request chassis cluster failover` — are gated behind the
+// super-user-only PermMaint. `operator` (which holds PermControl) is DENIED,
+// matching Junos where the predefined operator class lacks `maintenance`; only
+// `super-user` is allowed. Reverting the gate (mapping these back to plain
+// PermControl) makes the operator subtests go RED (operator allowed to
+// zeroize/reboot the box).
+func TestCheckPermission_DestructiveMaintenanceRequiresMaint(t *testing.T) {
+	destructive := [][]string{
+		{"request", "system", "reboot"},
+		{"request", "system", "halt"},
+		{"request", "system", "power-off"},
+		{"request", "system", "zeroize"},
+		{"request", "chassis", "cluster", "failover", "redundancy-group", "1", "node", "0"},
+		{"request", "chassis", "cluster", "failover", "data", "node", "0"},
+	}
+
+	tests := []struct {
+		class string
+		allow bool // destructive maintenance allowed?
+	}{
+		{"super-user", true},
+		{"operator", false},
+		{"read-only", false},
+		{"config-viewer", false},
+		{"unauthorized", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.class, func(t *testing.T) {
+			c := &CLI{userClass: tc.class}
+			for _, parts := range destructive {
+				err := c.checkPermission(parts)
+				cmd := strings.Join(parts, " ")
+				if tc.allow && err != nil {
+					t.Errorf("%q denied for %q: %v (want allowed)", cmd, tc.class, err)
+				}
+				if !tc.allow && err == nil {
+					t.Errorf("%q ALLOWED for %q (want denied — destructive maintenance)", cmd, tc.class)
+				}
+			}
+		})
+	}
+}
+
+// TestCheckPermission_DestructiveMaintenanceAbbreviationCannotBypass asserts
+// the gate resolves prefixes the same way the dispatcher does, so an
+// abbreviated destructive verb (`request system zero`, `request sys reboot`)
+// is gated identically to the fully-spelled form and cannot slip past as plain
+// control. operator must stay DENIED on every abbreviation.
+func TestCheckPermission_DestructiveMaintenanceAbbreviationCannotBypass(t *testing.T) {
+	op := &CLI{userClass: "operator"}
+	abbrev := [][]string{
+		{"request", "system", "zero"}, // zeroize
+		{"request", "system", "reb"},  // reboot
+		{"request", "sys", "halt"},    // system halt
+		{"request", "sys", "power"},   // system power-off
+		{"request", "chassis", "cluster", "fail", "data", "node", "1"},
+	}
+	for _, parts := range abbrev {
+		if err := op.checkPermission(parts); err == nil {
+			t.Errorf("operator ALLOWED %q (abbreviation bypassed the maintenance gate)", strings.Join(parts, " "))
+		}
+	}
+	// super-user is allowed via the same abbreviations.
+	su := &CLI{userClass: "super-user"}
+	for _, parts := range abbrev {
+		if err := su.checkPermission(parts); err != nil {
+			t.Errorf("super-user denied %q: %v (want allowed)", strings.Join(parts, " "), err)
+		}
+	}
+}
+
+// TestCheckPermission_BenignRequestStaysControlForOperator asserts the gate is
+// surgical: operator keeps the BENIGN request verbs at PermControl — only the
+// four destructive `request system` verbs and cluster failover elevate, not
+// the whole `request` family and not the rest of the `request system` subtree
+// (software ISSU, rescue config, dynamic-dns). This guards against
+// over-gating operator out of its legitimate control commands.
+func TestCheckPermission_BenignRequestStaysControlForOperator(t *testing.T) {
+	op := &CLI{userClass: "operator"}
+	benign := [][]string{
+		{"request", "system", "software", "in-service-upgrade"}, // request system, but not destructive
+		{"request", "system", "configuration", "rescue", "save"},
+		{"request", "system", "dynamic-dns", "update"},
+		{"request", "security", "ipsec", "sa", "clear"},
+		{"request", "chassis", "cluster", "data-plane", "userspace", "forwarding", "arm"},
+		{"request", "protocols", "bgp", "clear"},
+	}
+	for _, parts := range benign {
+		if err := op.checkPermission(parts); err != nil {
+			t.Errorf("operator DENIED benign request %q: %v (want allowed — control-level)", strings.Join(parts, " "), err)
+		}
+	}
+}

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -544,7 +544,15 @@ const (
 	PermClear                               // clear commands
 	PermControl                             // restart/request commands
 	PermConfig                              // configure mode
-	PermAll                                 // super-user: everything
+	// PermMaint gates the destructive maintenance verbs — `request system
+	// {reboot,halt,power-off,zeroize}` and `request chassis cluster failover`
+	// — that on Junos require the `maintenance` permission the predefined
+	// `operator` class LACKS (#4108 F21). It is intentionally NOT held by any
+	// non-super class; super-user reaches these verbs through PermAll (which
+	// matches every required permission), so PermMaint need not appear in
+	// super-user's list to allow them.
+	PermMaint
+	PermAll // super-user: everything (subsumes every permission incl. PermMaint)
 )
 
 // LoginClassPermissions maps class names to their allowed permissions.
@@ -553,6 +561,11 @@ const (
 // classes xpf accepts; ValidLoginClasses (and the schema `class` enum, #2008
 // H6) is derived from it so the commit-time validator and the runtime RBAC
 // table can never drift apart.
+//
+// PermMaint (destructive maintenance) is deliberately absent from every
+// non-super class: only `super-user` (via PermAll) may reboot/halt/power-off/
+// zeroize the box or trigger a chassis-cluster failover, matching Junos where
+// the predefined `operator` class has no `maintenance` permission (#4108 F21).
 var LoginClassPermissions = map[string][]LoginClassPermission{
 	"super-user": {PermAll},
 	"operator":   {PermView, PermClear, PermControl},

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -354,6 +354,19 @@ owned by the `journal/` subpackage.
   commit and leaked config content (incl. secrets) into a 0644 file.
   Full trees live in the rollback files (above), which remain the
   canonical config history.
+- **`system_action` entries (#4108 F8)** — `Store.LogSystemAction(verb)`
+  appends a `{action: "system_action", detail: <verb>}` record for the
+  destructive maintenance verbs `reboot`/`halt`/`power-off`/`zeroize`
+  (written by `grpcapi.Server.SystemAction` BEFORE the action runs). The
+  append is fsynced, so the record is durable on disk before the box goes
+  down or the config is wiped — the `slog.Warn` line only reaches
+  journald, which does not survive a `zeroize`. The journal file itself
+  survives a `zeroize`: `.config.journal` neither ends in `.conf` nor
+  starts with `rollback`, so it is not in the wipe's removal set.
+  `system_action` is deliberately EXCLUDED from `ListCommitHistory`
+  (`show system commit` shows config commits only). The local gRPC
+  transport is unauthenticated, so no operator identity is attributed —
+  action + timestamp is the best-effort record.
 - **`config_hash`** — sha256 hex of the post-action active tree's
   `Format()` text, the same text `saveRollbackFiles` writes: while a
   slot is retained, `sha256sum <config>.N` correlates the rollback

--- a/pkg/configstore/journal/journal.go
+++ b/pkg/configstore/journal/journal.go
@@ -46,7 +46,8 @@ type Entry struct {
 	Schema    int       `json:"v,omitempty"`
 	Timestamp time.Time `json:"timestamp"`
 	// Action: "commit", "commit_confirmed", "auto_rollback",
-	// "config_sync", "persist_error", "persist_recovered".
+	// "config_sync", "persist_error", "persist_recovered",
+	// "system_action" (destructive maintenance verb, #4108 F8).
 	Action string `json:"action"`
 	// Detail is the human-readable description (commit comment or
 	// error text).

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -524,6 +524,32 @@ func (s *Store) ListCommitHistory(limit int) ([]*JournalEntry, error) {
 	return commits, nil
 }
 
+// LogSystemAction appends a `system_action` audit entry (action name +
+// timestamp) to the commit journal and fsyncs it (#4108 F8). It is the
+// tamper-evident record for the destructive maintenance verbs — reboot,
+// halt, power-off, zeroize — which otherwise leave NO durable trail: the
+// slog.Warn line goes to journald, which does not survive a zeroize, so
+// post-incident attribution had nothing to read.
+//
+// The caller MUST invoke this BEFORE running the action, because the append
+// is synchronous and fsynced (journal.Log), so the record is durable on disk
+// before the box goes down or the config is wiped. The journal file itself
+// (`.config.journal`) also survives a zeroize: it neither ends in `.conf` nor
+// starts with `rollback`, so it is not in the zeroize removal set — belt and
+// braces on top of the pre-execution fsync.
+//
+// Journaling must never block a confirmed power/wipe action, so an append
+// failure is warned (journalLog), not returned. Detail carries the action
+// name; the local gRPC transport is unauthenticated (127.0.0.1, trusted) so
+// no operator identity is available to attribute — action + timestamp is the
+// best-effort record.
+func (s *Store) LogSystemAction(action string) {
+	s.journalLog(&JournalEntry{
+		Action: "system_action",
+		Detail: action,
+	})
+}
+
 // CommitDiffSummary returns a human-readable summary of changes between
 // the active and candidate configs. Must be called while in config mode.
 func (s *Store) CommitDiffSummary() string {

--- a/pkg/configstore/system_action_journal_4108_test.go
+++ b/pkg/configstore/system_action_journal_4108_test.go
@@ -1,0 +1,59 @@
+package configstore
+
+import "testing"
+
+// TestLogSystemAction_WritesJournalEntry pins #4108 F8: a destructive
+// maintenance verb (reboot/halt/power-off/zeroize) writes a fsynced
+// `system_action` audit entry to the commit journal, so a durable,
+// attributable record survives even when the action wipes the config or takes
+// the box down. RED on revert: making Store.LogSystemAction a no-op (or
+// dropping the s.logSystemAction call in the SystemAction handler) leaves the
+// journal empty and this test fails.
+func TestLogSystemAction_WritesJournalEntry(t *testing.T) {
+	s := newTestStore(t)
+
+	for _, action := range []string{"reboot", "halt", "power-off", "zeroize"} {
+		s.LogSystemAction(action)
+	}
+
+	entries, err := s.journal.Tail(0)
+	if err != nil {
+		t.Fatalf("journal.Tail: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, e := range entries {
+		if e.Action != "system_action" {
+			continue
+		}
+		if e.Timestamp.IsZero() {
+			t.Errorf("system_action entry %q has zero timestamp (want stamped)", e.Detail)
+		}
+		got[e.Detail] = true
+	}
+
+	for _, action := range []string{"reboot", "halt", "power-off", "zeroize"} {
+		if !got[action] {
+			t.Errorf("no system_action journal entry for %q (want one)", action)
+		}
+	}
+}
+
+// TestLogSystemAction_ExcludedFromCommitHistory asserts the maintenance record
+// does NOT leak into `show system commit` (ListCommitHistory), which filters to
+// commit/commit_confirmed/auto_rollback — a reboot is not a config commit, so
+// journaling it must not pollute the commit history view.
+func TestLogSystemAction_ExcludedFromCommitHistory(t *testing.T) {
+	s := newTestStore(t)
+	s.LogSystemAction("zeroize")
+
+	commits, err := s.ListCommitHistory(0)
+	if err != nil {
+		t.Fatalf("ListCommitHistory: %v", err)
+	}
+	for _, e := range commits {
+		if e.Action == "system_action" {
+			t.Fatalf("system_action leaked into ListCommitHistory (%q)", e.Detail)
+		}
+	}
+}

--- a/pkg/grpcapi/server_diag.go
+++ b/pkg/grpcapi/server_diag.go
@@ -714,57 +714,88 @@ func (s *Server) proxyPeerSystemAction(ctx context.Context, req *pb.SystemAction
 	return pb.NewBpfrxServiceClient(conn).SystemAction(peerCtx, req)
 }
 
+// logSystemAction records a destructive maintenance action to the configstore
+// audit journal BEFORE it executes (#4108 F8). The store append is synchronous
+// and fsynced, so an attributable record is durable on disk even when the
+// action wipes the config (zeroize) or takes the box down (reboot/halt/
+// power-off) — the slog.Warn line only reaches journald, which does not
+// survive a zeroize. Best-effort: a journal write failure never blocks a
+// confirmed power/wipe action (the store layer warns rather than failing).
+func (s *Server) logSystemAction(action string) {
+	if s.store == nil {
+		return
+	}
+	s.store.LogSystemAction(action)
+}
+
+// schedulePowerAction runs `systemctl <arg>` after a 1s grace so the RPC
+// response reaches the client first. It is a package var so a test can drive
+// the reboot/halt/power-off SystemAction verbs (to assert the #4108 F8 journal
+// wiring) WITHOUT actually taking the host down.
+var schedulePowerAction = func(systemctlArg string) {
+	go func() {
+		time.Sleep(1 * time.Second)
+		// context.Background(): a confirmed power action must not be
+		// cancelled by client disconnect. Errors ignored as before.
+		runTimeout(context.Background(), "systemctl", systemctlArg)
+	}()
+}
+
+// performZeroizeWipe erases the on-disk config, BPF pins, and managed networkd
+// files (factory reset). It is a package var so a test can drive the `zeroize`
+// SystemAction verb (to assert the #4108 F8 journal wiring) WITHOUT wiping a
+// real /etc/xpf on the developer/appliance box.
+var performZeroizeWipe = func() {
+	// Remove configs
+	configDir := "/etc/xpf"
+	files, _ := os.ReadDir(configDir)
+	for _, f := range files {
+		if strings.HasSuffix(f.Name(), ".conf") || strings.HasPrefix(f.Name(), "rollback") {
+			os.Remove(configDir + "/" + f.Name())
+		}
+	}
+	// Remove BPF pins
+	os.RemoveAll("/sys/fs/bpf/xpf")
+	// Remove managed networkd files
+	ndFiles, _ := os.ReadDir("/etc/systemd/network")
+	for _, f := range ndFiles {
+		if strings.HasPrefix(f.Name(), "10-xpf-") {
+			os.Remove("/etc/systemd/network/" + f.Name())
+		}
+	}
+}
+
 func (s *Server) SystemAction(ctx context.Context, req *pb.SystemActionRequest) (*pb.SystemActionResponse, error) {
 	switch req.Action {
 	case "reboot":
 		slog.Warn("system reboot requested via gRPC")
-		go func() {
-			time.Sleep(1 * time.Second)
-			// context.Background(): a confirmed power action must not be
-			// cancelled by client disconnect. Errors ignored as before.
-			runTimeout(context.Background(), "systemctl", "reboot")
-		}()
+		// Journal BEFORE the box goes down: the fsynced record survives the
+		// reboot even though the slog.Warn journald line may not (#4108 F8).
+		s.logSystemAction("reboot")
+		schedulePowerAction("reboot")
 		return &pb.SystemActionResponse{Message: "System going down for reboot NOW!"}, nil
 
 	case "halt":
 		slog.Warn("system halt requested via gRPC")
-		go func() {
-			time.Sleep(1 * time.Second)
-			// context.Background(): a confirmed power action must not be
-			// cancelled by client disconnect. Errors ignored as before.
-			runTimeout(context.Background(), "systemctl", "halt")
-		}()
+		s.logSystemAction("halt")
+		schedulePowerAction("halt")
 		return &pb.SystemActionResponse{Message: "System halting NOW!"}, nil
 
 	case "power-off":
 		slog.Warn("system power-off requested via gRPC")
-		go func() {
-			time.Sleep(1 * time.Second)
-			// context.Background(): a confirmed power action must not be
-			// cancelled by client disconnect. Errors ignored as before.
-			runTimeout(context.Background(), "systemctl", "poweroff")
-		}()
+		s.logSystemAction("power-off")
+		schedulePowerAction("poweroff")
 		return &pb.SystemActionResponse{Message: "System powering off NOW!"}, nil
 
 	case "zeroize":
 		slog.Warn("system zeroize requested via gRPC")
-		// Remove configs
-		configDir := "/etc/xpf"
-		files, _ := os.ReadDir(configDir)
-		for _, f := range files {
-			if strings.HasSuffix(f.Name(), ".conf") || strings.HasPrefix(f.Name(), "rollback") {
-				os.Remove(configDir + "/" + f.Name())
-			}
-		}
-		// Remove BPF pins
-		os.RemoveAll("/sys/fs/bpf/xpf")
-		// Remove managed networkd files
-		ndFiles, _ := os.ReadDir("/etc/systemd/network")
-		for _, f := range ndFiles {
-			if strings.HasPrefix(f.Name(), "10-xpf-") {
-				os.Remove("/etc/systemd/network/" + f.Name())
-			}
-		}
+		// Journal BEFORE the wipe: the fsynced record is durable on disk
+		// before any config file is removed, so a factory reset still leaves
+		// an attributable audit trail (#4108 F8). The journal file itself
+		// (.config.journal) is not in the removal set below (it neither ends
+		// in .conf nor starts with rollback), so the record also survives.
+		s.logSystemAction("zeroize")
+		performZeroizeWipe()
 		return &pb.SystemActionResponse{Message: "System zeroized. Configuration erased. Reboot to complete factory reset."}, nil
 
 	case "clear-config-lock":

--- a/pkg/grpcapi/system_action_journal_4108_test.go
+++ b/pkg/grpcapi/system_action_journal_4108_test.go
@@ -1,0 +1,80 @@
+package grpcapi
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// TestSystemActionJournalsDestructiveVerbs pins #4108 F8 at the RPC boundary:
+// each destructive maintenance verb (reboot/halt/power-off/zeroize) writes a
+// `system_action` audit entry to the configstore journal BEFORE it executes.
+// The destructive side effects are stubbed to no-ops via the package seams
+// (schedulePowerAction / performZeroizeWipe), so the test drives the real
+// SystemAction dispatch WITHOUT taking the host down or wiping /etc/xpf.
+//
+// RED on revert: dropping the s.logSystemAction(...) call from a case leaves no
+// journal entry for that verb and the corresponding subtest fails.
+func TestSystemActionJournalsDestructiveVerbs(t *testing.T) {
+	// Neutralize the real destructive side effects for the whole test.
+	origPower := schedulePowerAction
+	origWipe := performZeroizeWipe
+	t.Cleanup(func() {
+		schedulePowerAction = origPower
+		performZeroizeWipe = origWipe
+	})
+	var poweredArg string
+	var wiped bool
+	schedulePowerAction = func(arg string) { poweredArg = arg }
+	performZeroizeWipe = func() { wiped = true }
+
+	cases := []struct {
+		action      string
+		wantPowered string // systemctl arg expected via schedulePowerAction ("" = none)
+		wantWipe    bool
+	}{
+		{"reboot", "reboot", false},
+		{"halt", "halt", false},
+		{"power-off", "poweroff", false},
+		{"zeroize", "", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.action, func(t *testing.T) {
+			poweredArg, wiped = "", false
+			dir := t.TempDir()
+			configPath := filepath.Join(dir, "xpf.conf")
+			store := newConfigStore(t, configPath)
+			s := &Server{store: store}
+
+			if _, err := s.SystemAction(context.Background(), &pb.SystemActionRequest{Action: tc.action}); err != nil {
+				t.Fatalf("SystemAction(%q): %v", tc.action, err)
+			}
+
+			// The destructive effect ran (via the stub), proving the case body
+			// executed and did not short-circuit before the journal write.
+			if tc.wantPowered != "" && poweredArg != tc.wantPowered {
+				t.Errorf("schedulePowerAction arg = %q, want %q", poweredArg, tc.wantPowered)
+			}
+			if tc.wantWipe != wiped {
+				t.Errorf("performZeroizeWipe called = %v, want %v", wiped, tc.wantWipe)
+			}
+
+			// The journal entry was persisted to .config.journal (next to the
+			// config file) BEFORE the action — a durable, on-disk record.
+			journalPath := filepath.Join(dir, ".config.journal")
+			data, err := os.ReadFile(journalPath)
+			if err != nil {
+				t.Fatalf("read journal %s: %v", journalPath, err)
+			}
+			if !bytes.Contains(data, []byte(`"action":"system_action"`)) ||
+				!bytes.Contains(data, []byte(`"detail":"`+tc.action+`"`)) {
+				t.Errorf("journal missing system_action/%q entry; got:\n%s", tc.action, data)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #4108

Two coupled RBAC/audit findings from fable-review-163 for the destructive
maintenance verbs, verified genuine at `origin/master` before fixing.

## F21 (MEDIUM, security/rbac/vsrx-parity) — over-grant

`pkg/cli/permissions.go` mapped ALL of `request`/`test` to `PermControl`, and
`operator` holds `PermControl` (`types_system.go`), so the `operator` login
class passed the gate for `request system {reboot,halt,power-off,zeroize}` and
`request chassis cluster failover`. On Junos the predefined `operator` class
lacks the `maintenance` permission and cannot reboot/zeroize — xpf was granting
a destructive maintenance verb to a non-super class.

**Fix:** new super-user-only `PermMaint` bit (`pkg/config/types_system.go`); no
non-super class holds it, and super-user reaches these verbs through `PermAll`.
`requiredPermission` returns `PermMaint` for the destructive verbs via a new
`requestSubcommandIsMaintenance` helper that resolves the subcommand with the
same prefix matcher the dispatcher uses (mirrors the #4067 monitor-traffic
gate), so an abbreviated `request system zero` / `request sys reboot` is gated
identically and cannot bypass. Benign `request` verbs stay at `PermControl` so
`operator` keeps them.

## F8 (LOW, audit/observability/security) — no tamper-resistant record

`grpcapi/server_diag.go` `SystemAction` only `slog.Warn`'d the destructive
verbs; the journald line does not survive a `zeroize`, so reboot/zeroize left no
audit record.

**Fix:** new public `Store.LogSystemAction(action)` appends a fsynced
`system_action` journal entry; `SystemAction` calls it BEFORE executing each of
reboot/halt/power-off/zeroize, so the record is durable before the box goes down
or the config is wiped. `.config.journal` also survives a zeroize (not in the
`.conf`/`rollback` removal set). Destructive execution is extracted behind two
package seams (`schedulePowerAction`/`performZeroizeWipe`) so the RPC dispatch is
testable without rebooting the host or wiping `/etc/xpf`. `system_action` is
excluded from `ListCommitHistory`.

## RED-on-revert (both proven locally)

- **F21:** neutralizing the maintenance branch → `operator` is ALLOWED to
  reboot/halt/power-off/zeroize and cluster-failover (incl. abbreviations);
  super-user allowed and operator's benign requests stay allowed.
- **F8:** no-op'ing `LogSystemAction` → both the configstore and grpcapi tests
  fail (no `system_action` journal entry).

## Tests / build

`go test ./pkg/cli/... ./pkg/config/... ./pkg/grpcapi/... ./pkg/configstore/...`
green; `go build ./...` clean; gofmt + vet clean (pre-existing
`cli.go:503 unreachable code` note is unrelated).

Docs: `docs/system-login.md` (permission tables + destructive-maintenance +
audit-trail note), `pkg/configstore/README.md` (system_action journal format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
