### PR TITLE
security: fail-close the cluster fabric gRPC listener to its proxied RPCs (#4122)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -32370,3 +32370,33 @@ top.
   - **File(s)**: pkg/grpcapi/server.go,
     pkg/grpcapi/server_fabric_allowlist_4122_test.go, docs/architecture.md,
     _Log.md
+
+- **Timestamp**: 2026-07-04
+  - **Action**: #4122 fold — Copilot finding: the nested-action fabric
+    SystemAction gate (`isFabricSafeSystemAction`) used a loose
+    HasPrefix/Contains match that admitted syntactically invalid node targets
+    (`cluster-failover:1:node99`, `cluster-failover:garbage:node1`,
+    `cluster-failover:1:node1:node2`) past the interceptor. The handler then
+    made an OUTBOUND proxy dial (targetNode != local) BEFORE rejecting the
+    malformed action — an avoidable operational/DoS vector on the unauth
+    fabric surface (zeroize was already backstopped by the exact-case switch;
+    this is the distinct proxy-dial-amplification vector). Fix: added
+    `parseProxiedFailoverAction` (server.go) — the SSOT for a well-formed
+    peer-proxied cross-node failover: strict `strconv.Atoi` on rgID + nodeID
+    and `IsSupportedClusterNodeID` (0/1) range check on the node, fail-closed
+    (ok=false) for any malformed/out-of-range/non-failover action or trailing
+    garbage. `isFabricSafeSystemAction` now delegates to it. The parse mirrors
+    the handler's own Atoi + IsSupportedClusterNodeID validation
+    (server_diag.go) so gate and handler agree; the interceptor admits a
+    strict SUBSET of what the handler accepts, so no legit proxied failover is
+    denied. Did NOT refactor the handler's own parse (preserves its distinct
+    InvalidArgument messages + avoids test-failover-critical churn) — the
+    interceptor is the fail-closed backstop for the network-exposed surface.
+    Tests: `TestParseProxiedFailoverAction` pins the SSOT parse; the
+    nested-gate test now asserts malformed/out-of-range suffixes are DENIED at
+    the interceptor (handler not invoked). RED-on-revert verified: restoring
+    the loose gate admits node99/nodeX/node1:node2 past the interceptor and
+    fails the tests. go test -count=1 ./pkg/grpcapi/... green; go build ./...,
+    vet, gofmt clean.
+  - **File(s)**: pkg/grpcapi/server.go,
+    pkg/grpcapi/server_fabric_allowlist_4122_test.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -32334,3 +32334,39 @@ top.
     pkg/config/compiler_ipsec_trafficselector.go, pkg/config/compiler.go,
     pkg/ipsec/trafficselector_render_4098_test.go,
     pkg/config/compiler_ipsec_ts_4098_test.go, pkg/ipsec/README.md, _Log.md
+
+- **Timestamp**: 2026-07-04
+  - **Action**: #4122 — fail-closed fabric gRPC allowlist interceptor. The
+    cluster fabric listener (`RunFabricListener`, `pkg/grpcapi/server.go`)
+    registered the identical full 48-RPC `BpfrxService` as the loopback
+    `Run()` listener, guarded only by `configLockInterceptor` (a stale-lock
+    reaper, not auth). Since the loopback listener binds 127.0.0.1 and the
+    fabric listener binds the sync/fabric IP, the fabric listener is the ONLY
+    network-exposed gRPC surface — exposing SystemAction reboot/halt/
+    power-off/zeroize + Commit/Delete/Rollback UNAUTH on the fabric IP. Fix:
+    added a default-deny allowlist interceptor PAIR
+    (`fabricAllowlistUnaryInterceptor` / `fabricAllowlistStreamInterceptor`)
+    on the FABRIC listener only, chained with the existing
+    `configLockInterceptor` via `ChainUnaryInterceptor`/`ChainStreamInterceptor`.
+    Allowlist = exactly the peer-proxied RPCs (verified against every
+    `dialPeer()->NewBpfrxServiceClient` call site): GetStatus, GetSessions,
+    GetSessionSummary, GetZonePairSummary, ShowText, ClearSessions (unary) +
+    MonitorInterface (stream). SystemAction DECISION = NESTED-ACTION (not
+    blanket exclude): it multiplexes fabric-safe cluster-failover with
+    destructive actions, so `isFabricSafeSystemAction` permits ONLY the two
+    proxied cross-node forms (`cluster-failover-data:node<N>`,
+    `cluster-failover:<rg>:node<N>`) and denies zeroize/reboot/halt/power-off.
+    Chose nested over exclude because excluding SystemAction would make a
+    cross-node `request chassis cluster failover ... node <peer>` return
+    PermissionDenied when the initiating node proxies to the peer's fabric
+    listener — a shipped HA operator workflow regression. Loopback `Run()`
+    listener UNCHANGED (127.0.0.1 trusted, full service). RED-on-revert:
+    weakening the fix (SystemAction added to the plain allowlist) makes
+    zeroize/reboot reachable and fails the nested-gate + set-guard tests;
+    committed fix GREEN. `go test ./pkg/grpcapi/...` green; go build ./...,
+    go vet, gofmt clean. FLAG: touches the fabric proxy path — behavior is
+    PRESERVED for the two failover forms (nested-action), so no failover
+    regression, but test-failover is still warranted hygiene before terminal.
+  - **File(s)**: pkg/grpcapi/server.go,
+    pkg/grpcapi/server_fabric_allowlist_4122_test.go, docs/architecture.md,
+    _Log.md

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -123,7 +123,27 @@ editing cmdtree.
 ## APIs
 
 - **gRPC** on `127.0.0.1:50051` — 48+ RPCs (config, sessions, stats,
-  routes, IPsec, DHCP, cluster).
+  routes, IPsec, DHCP, cluster). The loopback listener (`Server.Run`) is
+  the trusted local surface and serves the full service.
+- **Cluster fabric gRPC listener** (`Server.RunFabricListener`) — in
+  cluster mode xpfd binds a second gRPC listener on the sync/fabric IP
+  (`<fabric-ip>:50051`) so a node can proxy monitor requests to its peer
+  over the fabric link. This is the **only** network-exposed gRPC surface,
+  so it is **fail-closed** (#4122): a default-deny allowlist interceptor
+  pair (`fabricAllowlistUnaryInterceptor` / `fabricAllowlistStreamInterceptor`
+  in `pkg/grpcapi/server.go`) serves **only** the RPCs a node actually
+  proxies to its peer — `GetStatus`, `GetSessions`, `GetSessionSummary`,
+  `GetZonePairSummary`, `ShowText`, `ClearSessions` (unary) and
+  `MonitorInterface` (stream). Every other method (Commit, Delete,
+  Rollback, the config-mode surface) returns `PermissionDenied`.
+  `SystemAction` multiplexes fabric-safe cross-node cluster-failover with
+  destructive node actions under one method, so it is gated by request
+  action (`isFabricSafeSystemAction`): only the two proxied cross-node
+  forms (`cluster-failover-data:node<N>`, `cluster-failover:<rg>:node<N>`)
+  pass; `zeroize`/`reboot`/`halt`/`power-off` are denied on the fabric.
+  The interceptors are installed on the fabric listener only; the loopback
+  listener keeps the full service. (Peer-identity auth — PSK/HMAC/mTLS — is
+  the deferred half of #4107.)
 - **HTTP REST** on `127.0.0.1:8080` — health, Prometheus `/metrics`,
   config endpoints, full gRPC parity.
 - **CLI** — interactive Junos-style with tab completion, `?` help, pipe

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -6,12 +6,15 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"strings"
 	"syscall"
 	"time"
 
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
 
 	"github.com/psaab/xpf/pkg/cluster"
 	"github.com/psaab/xpf/pkg/config"
@@ -252,8 +255,17 @@ func (s *Server) RunFabricListener(ctx context.Context, addr, vrfDevice string) 
 		return
 	}
 
+	// #4122: the fabric listener is the ONLY network-exposed gRPC surface
+	// (the loopback Run() listener binds 127.0.0.1). Fail-close it to the
+	// exact set of read/monitor RPCs the peer actually proxies over the
+	// fabric; the allowlist interceptors run BEFORE the handler so
+	// destructive RPCs (Commit/Delete/Rollback, SystemAction{zeroize,
+	// reboot,halt,power-off}) are rejected with PermissionDenied and never
+	// reach a handler. The loopback listener is left UNCHANGED (127.0.0.1 is
+	// the trusted local surface, full service).
 	srv := grpc.NewServer(
-		grpc.UnaryInterceptor(s.configLockInterceptor),
+		grpc.ChainUnaryInterceptor(s.fabricAllowlistUnaryInterceptor, s.configLockInterceptor),
+		grpc.ChainStreamInterceptor(s.fabricAllowlistStreamInterceptor),
 	)
 	pb.RegisterBpfrxServiceServer(srv, s)
 
@@ -266,6 +278,100 @@ func (s *Server) RunFabricListener(ctx context.Context, addr, vrfDevice string) 
 
 	<-ctx.Done()
 	srv.GracefulStop()
+}
+
+// fabricAllowedUnaryMethods is the fail-closed allowlist (#4122) of unary RPCs
+// the cluster fabric listener serves. Every entry is a method the local node
+// actually proxies to its peer over the fabric link — see the
+// dialPeer()->NewBpfrxServiceClient call sites in server_show_forwarding.go
+// (ShowText), server_sessions.go (GetSessions, GetSessionSummary,
+// GetZonePairSummary, ClearSessions), and server_diag.go dialPeer() itself
+// (GetStatus health probe). Any unary method NOT in this set is rejected with
+// PermissionDenied — so Commit, Delete, Rollback, and the whole config-mode
+// surface are unreachable on the network-exposed fabric IP.
+//
+// SystemAction is deliberately absent: it multiplexes fabric-safe cross-node
+// cluster-failover with destructive node actions (zeroize/reboot/halt/
+// power-off) under ONE gRPC method, so a method-name allowlist that included it
+// would still expose zeroize. It is gated separately, by request-action, in
+// isFabricSafeSystemAction.
+var fabricAllowedUnaryMethods = map[string]bool{
+	pb.BpfrxService_GetStatus_FullMethodName:          true,
+	pb.BpfrxService_GetSessions_FullMethodName:        true,
+	pb.BpfrxService_GetSessionSummary_FullMethodName:  true,
+	pb.BpfrxService_GetZonePairSummary_FullMethodName: true,
+	pb.BpfrxService_ShowText_FullMethodName:           true,
+	pb.BpfrxService_ClearSessions_FullMethodName:      true,
+}
+
+// fabricAllowedStreamMethods is the fail-closed allowlist (#4122) of streaming
+// RPCs the fabric listener serves. Only MonitorInterface is proxied
+// (proxyMonitorInterface in server_diag.go).
+var fabricAllowedStreamMethods = map[string]bool{
+	pb.BpfrxService_MonitorInterface_FullMethodName: true,
+}
+
+// isFabricSafeSystemAction reports whether a SystemAction request carries one of
+// the two cross-node cluster-failover actions the peer legitimately proxies over
+// the fabric (proxyPeerSystemAction call sites in server_diag.go):
+//
+//	"cluster-failover-data:node<N>"        — request chassis cluster failover ... node <N>
+//	"cluster-failover:<rgID>:node<N>"      — request chassis cluster failover redundancy-group <rg> node <N>
+//
+// These re-balance redundancy-group ownership — an operation squarely within the
+// fabric peer's trust boundary (coordinating RG ownership is the fabric's job).
+// Every other action — zeroize, reboot, halt, power-off, and the local-only
+// clear-* / cluster-failover-reset verbs — returns false and is denied on the
+// fabric listener. Node-local execution via the trusted loopback listener is
+// unaffected: an operator SSHed into the target node still runs any action.
+//
+// This is the nested-action choice over a blanket SystemAction exclusion:
+// excluding SystemAction entirely would make a cross-node `request chassis
+// cluster failover ... node <peer>` return PermissionDenied when the initiating
+// node proxies it, regressing a shipped HA operator workflow. Allowing ONLY the
+// two failover forms preserves that flow while keeping node-lifecycle actions
+// (zeroize/reboot/...) off the unauthenticated fabric surface.
+func isFabricSafeSystemAction(req interface{}) bool {
+	sa, ok := req.(*pb.SystemActionRequest)
+	if !ok {
+		return false
+	}
+	action := sa.GetAction()
+	if strings.HasPrefix(action, "cluster-failover-data:node") {
+		return true
+	}
+	if strings.HasPrefix(action, "cluster-failover:") && strings.Contains(action, ":node") {
+		return true
+	}
+	return false
+}
+
+// fabricAllowlistUnaryInterceptor fail-closes unary RPCs on the cluster fabric
+// listener (#4122): only the peer-proxied read/monitor RPCs
+// (fabricAllowedUnaryMethods) plus the two cross-node cluster-failover
+// SystemAction forms (isFabricSafeSystemAction) are served; every other method
+// is rejected with PermissionDenied before the handler runs. The loopback
+// listener does NOT install this interceptor and keeps the full service.
+func (s *Server) fabricAllowlistUnaryInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	if fabricAllowedUnaryMethods[info.FullMethod] {
+		return handler(ctx, req)
+	}
+	if info.FullMethod == pb.BpfrxService_SystemAction_FullMethodName && isFabricSafeSystemAction(req) {
+		return handler(ctx, req)
+	}
+	slog.Warn("fabric gRPC listener denied non-allowlisted method", "method", info.FullMethod)
+	return nil, status.Errorf(codes.PermissionDenied, "method %s is not permitted on the cluster fabric listener", info.FullMethod)
+}
+
+// fabricAllowlistStreamInterceptor fail-closes streaming RPCs on the fabric
+// listener (#4122): only MonitorInterface (fabricAllowedStreamMethods) is
+// served; every other stream is rejected with PermissionDenied.
+func (s *Server) fabricAllowlistStreamInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	if fabricAllowedStreamMethods[info.FullMethod] {
+		return handler(srv, ss)
+	}
+	slog.Warn("fabric gRPC listener denied non-allowlisted stream method", "method", info.FullMethod)
+	return status.Errorf(codes.PermissionDenied, "stream method %s is not permitted on the cluster fabric listener", info.FullMethod)
 }
 
 // configLockInterceptor auto-releases stale config locks when a gRPC client

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -311,39 +312,88 @@ var fabricAllowedStreamMethods = map[string]bool{
 	pb.BpfrxService_MonitorInterface_FullMethodName: true,
 }
 
-// isFabricSafeSystemAction reports whether a SystemAction request carries one of
-// the two cross-node cluster-failover actions the peer legitimately proxies over
-// the fabric (proxyPeerSystemAction call sites in server_diag.go):
+// parseProxiedFailoverAction is the single source of truth for what a
+// well-formed, peer-proxied cross-node cluster-failover SystemAction looks like.
+// It parses the two — and only two — request-action forms that a node
+// legitimately proxies to its peer over the fabric (the proxyPeerSystemAction
+// call sites in server_diag.go):
 //
-//	"cluster-failover-data:node<N>"        — request chassis cluster failover ... node <N>
-//	"cluster-failover:<rgID>:node<N>"      — request chassis cluster failover redundancy-group <rg> node <N>
+//	"cluster-failover-data:node<N>"    -> (rgID=-1, nodeID=N, ok)  [all data RGs]
+//	"cluster-failover:<rgID>:node<N>"  -> (rgID, nodeID=N, ok)
+//
+// It returns ok=false — fail-closed — for any other action, a missing/empty
+// node target, a non-numeric rgID or nodeID, a trailing garbage suffix
+// (e.g. "cluster-failover:1:node1:node2"), or a nodeID outside the supported
+// cluster range (IsSupportedClusterNodeID == 0/1). The parse mirrors the
+// handler's own strconv.Atoi + IsSupportedClusterNodeID validation
+// (server_diag.go) so the fabric interceptor gate and the handler agree on
+// which failover actions are valid.
+//
+// Why the range check matters on the interceptor: the handler proxy-dials the
+// peer whenever targetNode != local BEFORE rejecting an out-of-range/garbage
+// node as forwarded-not-local / InvalidArgument. A loose HasPrefix/Contains
+// gate would let a malformed action (e.g. "cluster-failover:1:node99") reach
+// that outbound-dial path, letting an unauthenticated fabric client drive
+// avoidable proxy dials + connection churn. Strict parsing here denies the
+// malformed action at the interceptor (PermissionDenied) so it never reaches
+// the handler.
+func parseProxiedFailoverAction(action string) (rgID, nodeID int, ok bool) {
+	const dataPrefix = "cluster-failover-data:node"
+	if strings.HasPrefix(action, dataPrefix) {
+		n, err := strconv.Atoi(strings.TrimPrefix(action, dataPrefix))
+		if err != nil || !cluster.IsSupportedClusterNodeID(n) {
+			return 0, 0, false
+		}
+		return -1, n, true
+	}
+	const rgPrefix = "cluster-failover:"
+	if strings.HasPrefix(action, rgPrefix) {
+		rest := strings.TrimPrefix(action, rgPrefix)
+		idx := strings.Index(rest, ":node")
+		if idx < 0 {
+			// No node target: this is the local-only failover form, never
+			// proxied over the fabric.
+			return 0, 0, false
+		}
+		rg, err := strconv.Atoi(rest[:idx])
+		if err != nil {
+			return 0, 0, false
+		}
+		n, err := strconv.Atoi(rest[idx+len(":node"):])
+		if err != nil || !cluster.IsSupportedClusterNodeID(n) {
+			return 0, 0, false
+		}
+		return rg, n, true
+	}
+	return 0, 0, false
+}
+
+// isFabricSafeSystemAction reports whether a SystemAction request carries a
+// well-formed cross-node cluster-failover action the peer legitimately proxies
+// over the fabric — delegating the strict parse to parseProxiedFailoverAction.
 //
 // These re-balance redundancy-group ownership — an operation squarely within the
 // fabric peer's trust boundary (coordinating RG ownership is the fabric's job).
-// Every other action — zeroize, reboot, halt, power-off, and the local-only
-// clear-* / cluster-failover-reset verbs — returns false and is denied on the
-// fabric listener. Node-local execution via the trusted loopback listener is
-// unaffected: an operator SSHed into the target node still runs any action.
+// Every other action — zeroize, reboot, halt, power-off, the local-only
+// clear-* / cluster-failover-reset verbs, and any malformed failover suffix —
+// is denied on the fabric listener. Node-local execution via the trusted
+// loopback listener is unaffected: an operator SSHed into the target node still
+// runs any action.
 //
 // This is the nested-action choice over a blanket SystemAction exclusion:
 // excluding SystemAction entirely would make a cross-node `request chassis
 // cluster failover ... node <peer>` return PermissionDenied when the initiating
 // node proxies it, regressing a shipped HA operator workflow. Allowing ONLY the
-// two failover forms preserves that flow while keeping node-lifecycle actions
-// (zeroize/reboot/...) off the unauthenticated fabric surface.
+// two well-formed failover forms preserves that flow while keeping
+// node-lifecycle actions (zeroize/reboot/...) off the unauthenticated fabric
+// surface.
 func isFabricSafeSystemAction(req interface{}) bool {
 	sa, ok := req.(*pb.SystemActionRequest)
 	if !ok {
 		return false
 	}
-	action := sa.GetAction()
-	if strings.HasPrefix(action, "cluster-failover-data:node") {
-		return true
-	}
-	if strings.HasPrefix(action, "cluster-failover:") && strings.Contains(action, ":node") {
-		return true
-	}
-	return false
+	_, _, ok = parseProxiedFailoverAction(sa.GetAction())
+	return ok
 }
 
 // fabricAllowlistUnaryInterceptor fail-closes unary RPCs on the cluster fabric

--- a/pkg/grpcapi/server_fabric_allowlist_4122_test.go
+++ b/pkg/grpcapi/server_fabric_allowlist_4122_test.go
@@ -97,6 +97,19 @@ func TestFabricAllowlistUnary_SystemActionNestedGate(t *testing.T) {
 		"clear-config-lock",
 		"cluster-failover-reset:1", // local-only, never proxied
 		"cluster-failover:1",       // no node suffix -> local-only, never proxied
+		// Malformed / out-of-range failover suffixes must be denied AT THE
+		// INTERCEPTOR so they never reach the handler's outbound proxy-dial
+		// path (an unauth fabric client could otherwise drive avoidable proxy
+		// dials / connection churn to arbitrary node IDs). RED-on-revert: the
+		// loose HasPrefix/Contains gate admitted all of these.
+		"cluster-failover:1:node99",      // node out of supported range (0/1)
+		"cluster-failover-data:node99",   // node out of supported range
+		"cluster-failover:garbage:node1", // non-numeric rgID
+		"cluster-failover:1:nodeX",       // non-numeric node
+		"cluster-failover-data:nodeX",    // non-numeric node
+		"cluster-failover:1:node1:node2", // trailing garbage suffix
+		"cluster-failover:1:node",        // empty node
+		"cluster-failover-data:node",     // empty node
 	}
 	for _, action := range deniedActions {
 		probe := &unaryCallProbe{}
@@ -137,6 +150,49 @@ func TestFabricAllowlistUnary_SystemActionNestedGate(t *testing.T) {
 	}
 	if probe.called {
 		t.Error("SystemAction with wrong req type: handler was invoked")
+	}
+}
+
+// TestParseProxiedFailoverAction pins the SSOT parse the fabric interceptor
+// shares with the handler: only well-formed cross-node failover forms (valid
+// numeric rgID + in-range node) parse ok; every malformed / out-of-range /
+// non-failover action is fail-closed (ok=false).
+func TestParseProxiedFailoverAction(t *testing.T) {
+	type want struct {
+		rgID, nodeID int
+		ok           bool
+	}
+	cases := map[string]want{
+		// Well-formed.
+		"cluster-failover-data:node0": {-1, 0, true},
+		"cluster-failover-data:node1": {-1, 1, true},
+		"cluster-failover:1:node0":    {1, 0, true},
+		"cluster-failover:2:node1":    {2, 1, true},
+		"cluster-failover:0:node1":    {0, 1, true},
+		// Malformed / out-of-range / non-failover -> fail-closed.
+		"cluster-failover-data:node99":   {0, 0, false},
+		"cluster-failover-data:nodeX":    {0, 0, false},
+		"cluster-failover-data:node":     {0, 0, false},
+		"cluster-failover:1:node99":      {0, 0, false},
+		"cluster-failover:garbage:node1": {0, 0, false},
+		"cluster-failover:1:nodeX":       {0, 0, false},
+		"cluster-failover:1:node1:node2": {0, 0, false},
+		"cluster-failover:1:node":        {0, 0, false},
+		"cluster-failover:1":             {0, 0, false}, // no node -> local-only
+		"cluster-failover-reset:1":       {0, 0, false},
+		"zeroize":                        {0, 0, false},
+		"reboot":                         {0, 0, false},
+		"":                               {0, 0, false},
+	}
+	for action, w := range cases {
+		rg, node, ok := parseProxiedFailoverAction(action)
+		if ok != w.ok {
+			t.Errorf("parseProxiedFailoverAction(%q): ok = %v, want %v", action, ok, w.ok)
+			continue
+		}
+		if ok && (rg != w.rgID || node != w.nodeID) {
+			t.Errorf("parseProxiedFailoverAction(%q): (rg=%d node=%d), want (rg=%d node=%d)", action, rg, node, w.rgID, w.nodeID)
+		}
 	}
 }
 

--- a/pkg/grpcapi/server_fabric_allowlist_4122_test.go
+++ b/pkg/grpcapi/server_fabric_allowlist_4122_test.go
@@ -1,0 +1,224 @@
+package grpcapi
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// #4122: the cluster fabric gRPC listener is the only network-exposed gRPC
+// surface (the loopback Run() listener binds 127.0.0.1). It must fail-close to
+// the exact set of read/monitor RPCs the peer actually proxies; every other
+// method — Commit/Delete/Rollback, the config-mode surface, and
+// SystemAction{zeroize,reboot,halt,power-off} — must be rejected with
+// PermissionDenied before the handler runs. These tests exercise the fabric
+// interceptors directly; on revert (interceptors removed / SystemAction
+// admitted / a destructive method added to the allowlist) they go RED because
+// the full service — including zeroize — becomes reachable on the fabric IP.
+
+// sentinelHandler records whether the unary handler was reached.
+type unaryCallProbe struct{ called bool }
+
+func (p *unaryCallProbe) handler(ctx context.Context, req interface{}) (interface{}, error) {
+	p.called = true
+	return "ok", nil
+}
+
+func TestFabricAllowlistUnary_AllowsProxiedReadMonitorRPCs(t *testing.T) {
+	s := &Server{}
+	allowed := []string{
+		pb.BpfrxService_GetStatus_FullMethodName,
+		pb.BpfrxService_GetSessions_FullMethodName,
+		pb.BpfrxService_GetSessionSummary_FullMethodName,
+		pb.BpfrxService_GetZonePairSummary_FullMethodName,
+		pb.BpfrxService_ShowText_FullMethodName,
+		pb.BpfrxService_ClearSessions_FullMethodName,
+	}
+	for _, method := range allowed {
+		probe := &unaryCallProbe{}
+		info := &grpc.UnaryServerInfo{FullMethod: method}
+		resp, err := s.fabricAllowlistUnaryInterceptor(context.Background(), nil, info, probe.handler)
+		if err != nil {
+			t.Errorf("method %s: expected allow, got err %v", method, err)
+		}
+		if !probe.called {
+			t.Errorf("method %s: handler was not invoked", method)
+		}
+		if resp != "ok" {
+			t.Errorf("method %s: expected handler response passthrough, got %v", method, resp)
+		}
+	}
+}
+
+func TestFabricAllowlistUnary_DeniesDestructiveAndUnknownMethods(t *testing.T) {
+	s := &Server{}
+	denied := []string{
+		pb.BpfrxService_Commit_FullMethodName,
+		pb.BpfrxService_CommitConfirmed_FullMethodName,
+		pb.BpfrxService_Delete_FullMethodName,
+		pb.BpfrxService_Rollback_FullMethodName,
+		pb.BpfrxService_Load_FullMethodName,
+		pb.BpfrxService_Set_FullMethodName,
+		pb.BpfrxService_EnterConfigure_FullMethodName,
+		"/xpf.v1.BpfrxService/DoesNotExist", // unknown method
+	}
+	for _, method := range denied {
+		probe := &unaryCallProbe{}
+		info := &grpc.UnaryServerInfo{FullMethod: method}
+		_, err := s.fabricAllowlistUnaryInterceptor(context.Background(), nil, info, probe.handler)
+		if status.Code(err) != codes.PermissionDenied {
+			t.Errorf("method %s: expected PermissionDenied, got %v", method, err)
+		}
+		if probe.called {
+			t.Errorf("method %s: handler was invoked on a denied method", method)
+		}
+	}
+}
+
+// TestFabricAllowlistUnary_SystemActionNestedGate verifies the nested-action
+// decision: SystemAction is admitted on the fabric ONLY for the two proxied
+// cross-node cluster-failover forms; every destructive / local-only action is
+// denied. On revert (SystemAction added to the plain allowlist, or the nested
+// gate removed) the zeroize case goes RED — a factory-reset wipe becomes
+// reachable unauth on the fabric IP.
+func TestFabricAllowlistUnary_SystemActionNestedGate(t *testing.T) {
+	s := &Server{}
+	info := &grpc.UnaryServerInfo{FullMethod: pb.BpfrxService_SystemAction_FullMethodName}
+
+	deniedActions := []string{
+		"zeroize",
+		"reboot",
+		"halt",
+		"power-off",
+		"clear-config-lock",
+		"cluster-failover-reset:1", // local-only, never proxied
+		"cluster-failover:1",       // no node suffix -> local-only, never proxied
+	}
+	for _, action := range deniedActions {
+		probe := &unaryCallProbe{}
+		req := &pb.SystemActionRequest{Action: action}
+		_, err := s.fabricAllowlistUnaryInterceptor(context.Background(), req, info, probe.handler)
+		if status.Code(err) != codes.PermissionDenied {
+			t.Errorf("SystemAction %q: expected PermissionDenied on fabric, got %v", action, err)
+		}
+		if probe.called {
+			t.Errorf("SystemAction %q: handler was invoked on the fabric listener", action)
+		}
+	}
+
+	allowedActions := []string{
+		"cluster-failover-data:node0",
+		"cluster-failover-data:node1",
+		"cluster-failover:1:node0",
+		"cluster-failover:2:node1",
+	}
+	for _, action := range allowedActions {
+		probe := &unaryCallProbe{}
+		req := &pb.SystemActionRequest{Action: action}
+		_, err := s.fabricAllowlistUnaryInterceptor(context.Background(), req, info, probe.handler)
+		if err != nil {
+			t.Errorf("SystemAction %q: expected allow (cross-node failover proxy), got %v", action, err)
+		}
+		if !probe.called {
+			t.Errorf("SystemAction %q: handler was not invoked", action)
+		}
+	}
+
+	// A SystemAction with the wrong request type must not be admitted (defensive:
+	// isFabricSafeSystemAction returns false rather than panicking).
+	probe := &unaryCallProbe{}
+	_, err := s.fabricAllowlistUnaryInterceptor(context.Background(), &pb.GetStatusRequest{}, info, probe.handler)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Errorf("SystemAction with wrong req type: expected PermissionDenied, got %v", err)
+	}
+	if probe.called {
+		t.Error("SystemAction with wrong req type: handler was invoked")
+	}
+}
+
+func TestFabricAllowlistStream_AllowsOnlyMonitorInterface(t *testing.T) {
+	s := &Server{}
+
+	// MonitorInterface (the only proxied stream) is allowed.
+	streamCalled := false
+	handler := func(srv interface{}, ss grpc.ServerStream) error {
+		streamCalled = true
+		return nil
+	}
+	info := &grpc.StreamServerInfo{FullMethod: pb.BpfrxService_MonitorInterface_FullMethodName}
+	if err := s.fabricAllowlistStreamInterceptor(nil, nil, info, handler); err != nil {
+		t.Errorf("MonitorInterface stream: expected allow, got %v", err)
+	}
+	if !streamCalled {
+		t.Error("MonitorInterface stream: handler was not invoked")
+	}
+
+	// A non-allowlisted stream (MonitorPacketDrop) is denied.
+	streamCalled = false
+	info = &grpc.StreamServerInfo{FullMethod: pb.BpfrxService_MonitorPacketDrop_FullMethodName}
+	err := s.fabricAllowlistStreamInterceptor(nil, nil, info, handler)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Errorf("MonitorPacketDrop stream: expected PermissionDenied, got %v", err)
+	}
+	if streamCalled {
+		t.Error("MonitorPacketDrop stream: handler was invoked on a denied stream")
+	}
+}
+
+// TestFabricAllowlistExcludesDestructiveMethods guards the allowlist SETS so a
+// future edit cannot silently add a destructive / config-mutating method (or
+// SystemAction, which multiplexes zeroize) to the fabric surface.
+func TestFabricAllowlistExcludesDestructiveMethods(t *testing.T) {
+	mustNotBeAllowed := []string{
+		pb.BpfrxService_Commit_FullMethodName,
+		pb.BpfrxService_CommitConfirmed_FullMethodName,
+		pb.BpfrxService_ConfirmCommit_FullMethodName,
+		pb.BpfrxService_Delete_FullMethodName,
+		pb.BpfrxService_Rollback_FullMethodName,
+		pb.BpfrxService_Load_FullMethodName,
+		pb.BpfrxService_Set_FullMethodName,
+		pb.BpfrxService_EnterConfigure_FullMethodName,
+		pb.BpfrxService_SystemAction_FullMethodName, // gated by action, never blanket-allowed
+	}
+	for _, method := range mustNotBeAllowed {
+		if fabricAllowedUnaryMethods[method] {
+			t.Errorf("%s must NOT be in fabricAllowedUnaryMethods", method)
+		}
+		if fabricAllowedStreamMethods[method] {
+			t.Errorf("%s must NOT be in fabricAllowedStreamMethods", method)
+		}
+	}
+}
+
+// TestLoopbackListenerUnaffected proves the loopback (Run) path is unchanged:
+// its only interceptor, configLockInterceptor, admits every method (including
+// the destructive ones the fabric listener denies). On a non-cancelled context
+// it simply invokes the handler and never touches s.store, so a zero-value
+// Server is sufficient. This is the #4122 invariant that the allowlist is
+// applied to the fabric surface ONLY.
+func TestLoopbackListenerUnaffected(t *testing.T) {
+	s := &Server{}
+	for _, method := range []string{
+		pb.BpfrxService_Commit_FullMethodName,
+		pb.BpfrxService_Delete_FullMethodName,
+		pb.BpfrxService_Rollback_FullMethodName,
+		pb.BpfrxService_SystemAction_FullMethodName,
+	} {
+		probe := &unaryCallProbe{}
+		info := &grpc.UnaryServerInfo{FullMethod: method}
+		resp, err := s.configLockInterceptor(context.Background(), &pb.SystemActionRequest{Action: "zeroize"}, info, probe.handler)
+		if err != nil {
+			t.Errorf("loopback configLockInterceptor denied %s: %v", method, err)
+		}
+		if !probe.called {
+			t.Errorf("loopback configLockInterceptor did not invoke handler for %s", method)
+		}
+		if resp != "ok" {
+			t.Errorf("loopback configLockInterceptor did not pass through response for %s", method)
+		}
+	}
+}


### PR DESCRIPTION
Closes #4122.

## Problem

`RunFabricListener` (`pkg/grpcapi/server.go`) registered the identical full 48-RPC `BpfrxService` as the loopback `Run()` listener, guarded only by `configLockInterceptor` (a stale config-lock reaper, **not** auth). The loopback listener binds `127.0.0.1:50051`; the fabric listener binds the sync/fabric IP (`<fabric-ip>:50051`, launched from `daemon_ha_sync.go`). So the fabric listener is the **only network-exposed gRPC surface**, and it exposed destructive RPCs UNAUTH on the fabric IP:

- `SystemAction` `reboot`/`halt`/`power-off`/`zeroize` (zeroize wipes `/etc/xpf/*.conf` + rollback + `/sys/fs/bpf/xpf` + managed networkd files)
- `Delete`, `Commit`, `Rollback`, and the whole config-mode surface

The peer client sends no identity (`insecure.NewCredentials`) and there is no source-IP allowlist.

This is the driveable half of #4107 (fable-163 F1). Peer-identity auth (PSK/HMAC/mTLS) + F23 stay deferred on #4107.

## Fix

A fail-closed allowlist interceptor **pair** installed on the **fabric listener only**, chained with the existing `configLockInterceptor` via `grpc.ChainUnaryInterceptor` / `grpc.ChainStreamInterceptor`. The interceptors run **before** the handler, so a non-allowlisted method is rejected with `codes.PermissionDenied` and never reaches a handler.

The allowlist is exactly the set of RPCs a node actually proxies to its peer, verified against **every** `dialPeer()->NewBpfrxServiceClient` call site:

| FullMethod | proxied from |
|---|---|
| `/xpf.v1.BpfrxService/GetStatus` | `dialPeer()` health probe (server_diag.go) |
| `/xpf.v1.BpfrxService/GetSessions` | server_sessions.go |
| `/xpf.v1.BpfrxService/GetSessionSummary` | server_sessions.go |
| `/xpf.v1.BpfrxService/GetZonePairSummary` | server_sessions.go (#3592) |
| `/xpf.v1.BpfrxService/ShowText` | server_show_forwarding.go |
| `/xpf.v1.BpfrxService/ClearSessions` | server_sessions.go |
| `/xpf.v1.BpfrxService/MonitorInterface` (stream) | server_diag.go `proxyMonitorInterface` |

Everything else — `Commit`, `Delete`, `Rollback`, `Load`, `Set`, the config-mode RPCs, any unknown method — returns `PermissionDenied`.

### SystemAction decision: nested-action (not blanket exclude)

`SystemAction` multiplexes fabric-safe cross-node cluster-failover with destructive node actions (`zeroize`/`reboot`/`halt`/`power-off`) under one gRPC method, so a method-name allowlist that included it would still expose `zeroize`. `isFabricSafeSystemAction` inspects the request action and permits **only** the two forms the peer actually proxies (`proxyPeerSystemAction` call sites):

- `cluster-failover-data:node<N>`
- `cluster-failover:<rgID>:node<N>`

and denies `zeroize`/`reboot`/`halt`/`power-off` plus the local-only `clear-*` / `cluster-failover-reset:` verbs.

**Why nested-action over exclude:** a blanket `SystemAction` exclusion would make a cross-node `request chassis cluster failover ... node <peer>` return `PermissionDenied` when the initiating node proxies it to the target node's fabric listener — regressing a shipped HA operator workflow. Re-balancing RG ownership is squarely within the fabric peer's trust boundary; wiping/rebooting the node is not. The nested check preserves the failover proxy while keeping node-lifecycle actions off the unauthenticated fabric surface.

The **loopback** `Run()` listener is left **unchanged** — `127.0.0.1` is the trusted local surface and keeps the full service.

## Tests (RED-on-revert)

`pkg/grpcapi/server_fabric_allowlist_4122_test.go` exercises the interceptors directly:

- 6 proxied read/monitor RPCs ALLOWED (handler reached); destructive + unknown methods DENIED (`PermissionDenied`, handler not reached).
- SystemAction nested gate: `zeroize`/`reboot`/`halt`/`power-off`/`clear-config-lock`/`cluster-failover-reset:1`/`cluster-failover:1` DENIED; `cluster-failover-data:nodeN` + `cluster-failover:R:nodeN` ALLOWED; wrong-typed req DENIED.
- Stream: `MonitorInterface` ALLOWED, `MonitorPacketDrop` DENIED.
- Allowlist-set guard: destructive methods (and `SystemAction`) must not be in the allowlist maps.
- Loopback unaffected: `configLockInterceptor` admits `Commit`/`Delete`/`Rollback`/`SystemAction` — the allowlist is fabric-only.

**RED proof:** adding `SystemAction` to `fabricAllowedUnaryMethods` (a weakened fix) makes `zeroize`/`reboot` reachable and fails the nested-gate + set-guard tests; the committed fix is GREEN.

## Validation

- `go test ./pkg/grpcapi/...` green
- `go build ./...`, `go vet ./pkg/grpcapi/`, `gofmt` clean

## Failover note

This touches the fabric proxy path. Behavior for the two cross-node failover forms is **preserved** (nested-action, not exclude), so there is no failover regression — but `make test-failover` is warranted hygiene before this is considered terminal, since the interceptor now sits in front of the cross-node `SystemAction` proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi