### PR TITLE
vrrp: address owner (priority 255) always preempts (#4116)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-07-04 — #4116: VRRP address owner (priority 255) always preempts (fable-163 F22)
+
+- **Timestamp**: 2026-07-04
+  - **Action**: VERIFY-FIRST confirmed the defect at HEAD (890b69ea3):
+    `getPreempt()` (pkg/vrrp/instance.go) returned `cfg.Preempt` verbatim,
+    so the `handleBackupRx` master-down-reset gate
+    (`if !getPreempt() || pkt.Priority >= pri`) reset the timer on EVERY
+    advert for a no-preempt owner → an address owner (priority 255,
+    no-preempt) that returned after a lower-priority peer took over stayed
+    BACKUP indefinitely though it OWNS the VIP (RFC 5798 §6.1 requires the
+    owner to preempt irrespective of the flag). The existing owner-255
+    exemption covered only track-down demotion (`getPriority`, track.go),
+    NOT the preempt case — F22 is the preempt case. FIX: force effective
+    preempt=true for the address owner at the two runtime preempt-decision
+    sites, keyed on the CONFIGURED priority (255): `getPreempt()` returns
+    `cfg.Preempt || cfg.Priority == 255`; `shouldPreemptObservedMaster()`
+    early-return becomes `if !preempt && priority != 255`. Added named const
+    `addressOwnerPriority = 255`. Composes with the track-exempt demotion
+    (owner is never demoted, so configured 255 is authoritative); no-op for
+    every non-owner (priorities < 255) so cluster RETH failover, the #2082
+    sync-hold gate, and ~60ms timing are unaffected. Tests
+    (instance_owner_preempt_test.go): getPreempt truth table + sync-hold
+    suppression, shouldPreemptObservedMaster owner-vs-nonowner, preemptNowCh
+    wiring, end-to-end reclaim via the master-down timer, non-owner
+    no-regression twin, owner-preempt-enabled unchanged. RED-on-revert
+    verified (5 owner tests FAIL on pre-fix instance.go: getPreempt=false,
+    state=BACKUP, timer reset). go test -race ./pkg/vrrp/ green; go build
+    ./..., vet, gofmt clean. Docs: critical-patterns.md,
+    feature-coverage.md.
+  - **File(s)**: pkg/vrrp/instance.go,
+    pkg/vrrp/instance_owner_preempt_test.go, docs/critical-patterns.md,
+    docs/feature-coverage.md, _Log.md
+
 ## 2026-07-04 — #4100: VRRPv3 IPv4 advert checksum RFC 5798 §5.2.8 pseudo-header (fable-163 F10)
 
 - **Timestamp**: 2026-07-04

--- a/docs/critical-patterns.md
+++ b/docs/critical-patterns.md
@@ -129,6 +129,16 @@ See the deploy backing table in
 - **Sync hold**: VRRP starts with `preempt=false`, released after bulk
   session sync (or 10s timeout); `preemptNowCh` triggers instant
   preemption.
+- **Address owner always preempts (#4116)**: an instance whose *configured*
+  priority is 255 (the IP address owner) preempts a lower-priority master
+  irrespective of the `no-preempt` flag or sync-hold suppression (RFC 5798
+  §6.1). `getPreempt()` and `shouldPreemptObservedMaster()` OR-in
+  `cfg.Priority == 255`, so an owner hearing a lower advert does NOT reset
+  its master-down timer (`handleBackupRx`) — the timer expires and the owner
+  reclaims MASTER. Keyed on the configured priority, this composes with the
+  owner-255 track-demotion exemption (`getPriority`, which never demotes 255)
+  and is a no-op for every non-owner (weight-based RETH priorities < 255), so
+  the #2082 sync-hold gate and ~60ms failover timing are unchanged.
 - **Heartbeat**: 200ms interval, threshold 5 (1s detection).
 
 ## Shutdown

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -113,7 +113,9 @@ the userspace dataplane admission boundary is in
   runtime kernel rename: the link watcher keys rename detection on the stable
   ifindex, so when the tracked name is renamed away (a single `RTM_NEWLINK`
   with the same ifindex but a new name, no `RTM_DELLINK`) the instance demotes
-  rather than holding stale "up" state (#2944).
+  rather than holding stale "up" state (#2944). The IP address owner (priority
+  255) always preempts a lower-priority master irrespective of the `no-preempt`
+  flag (RFC 5798 §6.1, #4116) and is exempt from track-down demotion.
 - **Bondless RETH**: VRRP on physical member interfaces, per-node virtual
   MAC (`02:bf:72:CC:RR:NN`), no Linux bonding required.
 - **Session sync**: incremental 1s sweep + ring buffer + GC delete

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -29,6 +29,14 @@ const (
 	StateMaster
 )
 
+// addressOwnerPriority is the VRRP priority reserved for the IP address owner
+// (RFC 5798 §5.2.4). An instance configured with this priority owns the virtual
+// address and, per RFC 5798 §6.1, MUST preempt a lower-priority master
+// "irrespective of the setting of" the preempt flag — the owner always reclaims
+// mastership. See getPreempt / shouldPreemptObservedMaster (owner-preempt), and
+// getPriority (track.go — the owner is also exempt from track-down demotion).
+const addressOwnerPriority = 255
+
 func (s VRRPState) String() string {
 	switch s {
 	case StateInitialize:
@@ -504,10 +512,25 @@ func (vi *vrrpInstance) triggerResign() {
 	}
 }
 
+// getPreempt reports the EFFECTIVE preempt mode. It is the configured
+// cfg.Preempt OR-ed with the address-owner override: an instance whose
+// configured priority is 255 (the IP address owner) always preempts,
+// irrespective of the no-preempt flag or a sync-hold suppression of
+// cfg.Preempt (RFC 5798 §6.1: "a Backup MUST preempt when it is the IP address
+// owner ... irrespective of the setting of this flag"). Without this override
+// an owner configured with `no-preempt` that returns after a peer took over
+// would reset its master-down timer on every lower-priority advert
+// (handleBackupRx) and stay BACKUP forever, though it OWNS the VIP (#4116).
+//
+// The override keys on cfg.Priority (the configured value), not the effective
+// tracked priority: an owner is track-exempt (getPriority never demotes 255),
+// so the configured 255 is authoritative here. It is a no-op for every
+// non-owner instance, so cluster RETH failover (weight-based priorities < 255)
+// is unaffected.
 func (vi *vrrpInstance) getPreempt() bool {
 	vi.mu.RLock()
 	defer vi.mu.RUnlock()
-	return vi.cfg.Preempt
+	return vi.cfg.Preempt || vi.cfg.Priority == addressOwnerPriority
 }
 
 // shouldPreemptObservedMaster decides whether the non-force sync-hold preempt
@@ -516,8 +539,10 @@ func (vi *vrrpInstance) getPreempt() bool {
 // only on a STRICTLY higher priority than the currently-observed master. It
 // returns true iff:
 //
-//   - preempt is configured (a non-preempting node never preempts on the
-//     shortcut), AND
+//   - preempt is effective — either configured, OR this instance is the IP
+//     address owner (priority 255), which always preempts irrespective of the
+//     no-preempt flag (RFC 5798 §6.1, #4116). A non-owner non-preempting node
+//     never preempts on the shortcut, AND
 //   - either no live master has been observed recently (lastMasterSeen is zero
 //     or older than masterDownInterval — the cold-start / peer-down /
 //     silent-master-death rescue, where becoming MASTER is correct), OR a
@@ -549,7 +574,11 @@ func (vi *vrrpInstance) shouldPreemptObservedMaster() bool {
 	lastMasterSeen := vi.lastMasterSeen
 	vi.mu.RUnlock()
 
-	if !preempt {
+	// The IP address owner (priority 255) always preempts, irrespective of the
+	// no-preempt flag or a sync-hold suppression of cfg.Preempt (RFC 5798 §6.1,
+	// #4116) — mirrors getPreempt(). This is a no-op for every non-owner
+	// instance, so the cluster RETH sync-hold gate (#2082) is unchanged.
+	if !preempt && priority != addressOwnerPriority {
 		return false
 	}
 
@@ -1514,6 +1543,10 @@ func (vi *vrrpInstance) handleBackupRx(pkt *VRRPPacket, masterDownTimer, preempt
 	// If we don't preempt, or the incoming priority is >= ours, accept it:
 	// reset the master-down timer and abort any pending preempt hold-time —
 	// a worthy master is present, so there is nothing to preempt (#2850).
+	// getPreempt() returns true for the IP address owner (priority 255)
+	// irrespective of the no-preempt flag, so an owner hearing a LOWER-priority
+	// advert does NOT reset the timer here — the timer expires and the owner
+	// reclaims MASTER (RFC 5798 §6.1, #4116).
 	// Also clear the one-shot resign bypass: it was armed by a prior
 	// priority-0 resign to make the imminent 1ms masterDownTimer expiry
 	// promote immediately, but a worthy master returning before that fire

--- a/pkg/vrrp/instance_owner_preempt_test.go
+++ b/pkg/vrrp/instance_owner_preempt_test.go
@@ -1,0 +1,202 @@
+package vrrp
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// Tests for the address-owner preempt override (#4116). RFC 5798 §6.1 requires
+// the IP address owner (priority 255) to preempt a lower-priority master
+// "irrespective of the setting of" the preempt flag. Before the fix an owner
+// configured with `no-preempt` that returned after a peer took over reset its
+// master-down timer on every lower-priority advert (handleBackupRx) and stayed
+// BACKUP forever, though it OWNS the VIP.
+//
+// These drive the same seams as instance_preempt_gate_test.go (getPreempt,
+// shouldPreemptObservedMaster, handleBackupRx, stepBackup) — no run() (its
+// preamble spawns a receiver that nil-derefs vi.conn).
+
+// TestGetPreempt_OwnerAlwaysPreempts: getPreempt() returns true for the address
+// owner (priority 255) regardless of the configured preempt flag, and honors
+// the configured flag for every non-owner. RED on the pre-fix code, where an
+// owner with no-preempt returned false.
+func TestGetPreempt_OwnerAlwaysPreempts(t *testing.T) {
+	cases := []struct {
+		name     string
+		priority int
+		preempt  bool
+		want     bool
+	}{
+		{"owner-no-preempt", 255, false, true}, // #4116: owner always preempts
+		{"owner-preempt", 255, true, true},     // owner, preempt configured
+		{"non-owner-no-preempt", 200, false, false},
+		{"non-owner-preempt", 200, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vi := newGateTestInstance(t, tc.priority, tc.preempt)
+			if got := vi.getPreempt(); got != tc.want {
+				t.Errorf("getPreempt() = %v, want %v (priority=%d preempt=%v)",
+					got, tc.want, tc.priority, tc.preempt)
+			}
+		})
+	}
+}
+
+// TestGetPreempt_OwnerPreemptsDespiteSyncHoldSuppression: sync hold suppresses
+// cfg.Preempt (suppressPreempt sets it false) while preserving desiredPreempt.
+// The owner override keys on cfg.Priority, so getPreempt() still returns true
+// under sync-hold suppression — the owner is not held BACKUP by sync hold.
+func TestGetPreempt_OwnerPreemptsDespiteSyncHoldSuppression(t *testing.T) {
+	vi := newGateTestInstance(t, 255, true)
+	vi.suppressPreempt() // sync hold: cfg.Preempt = false
+	if !vi.getPreempt() {
+		t.Error("getPreempt() = false for owner-255 under sync-hold suppression; want true (#4116)")
+	}
+	// A non-owner under suppression correctly reports no preempt.
+	non := newGateTestInstance(t, 200, true)
+	non.suppressPreempt()
+	if non.getPreempt() {
+		t.Error("getPreempt() = true for non-owner under sync-hold suppression; want false")
+	}
+}
+
+// TestShouldPreempt_OwnerNoPreemptStillPreempts: the sync-hold-release /
+// preempt-hold re-validation gate (shouldPreemptObservedMaster) lets the owner
+// through even with preempt disabled. RED on the pre-fix `if !preempt` gate.
+func TestShouldPreempt_OwnerNoPreemptStillPreempts(t *testing.T) {
+	vi := newGateTestInstance(t, 255, false) // owner, no-preempt
+	vi.mu.Lock()
+	vi.lastMasterPriority = 200 // a live lower-priority master
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+	if !vi.shouldPreemptObservedMaster() {
+		t.Error("want true (owner-255 preempts irrespective of the no-preempt flag, RFC 5798 §6.1, #4116)")
+	}
+}
+
+// TestShouldPreempt_NonOwnerNoPreemptStillDenied: the owner override must NOT
+// leak to non-owners — a priority-200 no-preempt node facing a lower master
+// still does not preempt on the shortcut (no-preempt honored).
+func TestShouldPreempt_NonOwnerNoPreemptStillDenied(t *testing.T) {
+	vi := newGateTestInstance(t, 200, false)
+	vi.mu.Lock()
+	vi.lastMasterPriority = 100
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+	if vi.shouldPreemptObservedMaster() {
+		t.Error("want false (non-owner no-preempt must still honor the no-preempt flag)")
+	}
+}
+
+// TestOwnerPreempt_NoPreemptBecomesMasterOnKick: wiring-level. An owner (255,
+// no-preempt) that has heard a live LOWER-priority (100) master becomes MASTER
+// on the non-force sync-hold preempt kick. RED on the pre-fix code (the gate
+// denied a no-preempt node → the owner stayed BACKUP).
+func TestOwnerPreempt_NoPreemptBecomesMasterOnKick(t *testing.T) {
+	vi := newGateTestInstance(t, 255, false)
+	vi.mu.Lock()
+	vi.lastMasterPriority = 100
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+
+	masterDown, advert, preemptHold := longTimers(t)
+	vi.triggerPreemptNow()
+	if stop := vi.stepBackup(masterDown, advert, preemptHold); stop {
+		t.Fatal("stepBackup returned stop=true unexpectedly")
+	}
+	if vi.getState() != StateMaster {
+		t.Errorf("state = %s, want MASTER (owner-255 must preempt even with preempt disabled)", vi.getState())
+	}
+}
+
+// TestOwnerPreempt_ReclaimsFromLowerMaster is the PRIMARY end-to-end guard for
+// the reported defect (the handleBackupRx master-down-reset gate, instance.go).
+// An owner (255, no-preempt) in BACKUP that hears a live LOWER-priority master
+// must NOT reset its master-down timer, so the timer expires and the next
+// stepBackup promotes it to MASTER.
+//
+// RED on revert: the pre-fix getPreempt() returns false for the owner, so the
+// gate `!getPreempt() || pkt.Priority >= pri` is true and resets the timer to
+// masterDownInterval() (~3s at the default 1s advert interval) — the short
+// deadline never fires within the wait and the owner never reclaims.
+func TestOwnerPreempt_ReclaimsFromLowerMaster(t *testing.T) {
+	vi := newGateTestInstance(t, 255, false)
+
+	// Master-down timer armed short, mimicking a BACKUP tenure about to end.
+	// The default advert interval makes masterDownInterval() ~3s, so a RESET
+	// (the pre-fix bug) pushes the fire far past this deadline; the fix leaves
+	// it intact so it still fires ~40ms out.
+	mdt := time.NewTimer(40 * time.Millisecond)
+	defer mdt.Stop()
+	hold := time.NewTimer(time.Hour)
+	defer hold.Stop()
+
+	// Owner hears the peer's LOWER-priority (100) advert.
+	vi.handleBackupRx(&VRRPPacket{Priority: 100, SrcIP: net.IPv4(10, 0, 0, 2)}, mdt, hold)
+
+	// The gate must NOT have reset the timer for the owner.
+	select {
+	case <-mdt.C:
+		// fired promptly → timer was not reset → correct
+	case <-time.After(1500 * time.Millisecond):
+		t.Fatal("owner-255 master-down timer was reset by a lower-priority advert; " +
+			"the owner would never reclaim MASTER (RFC 5798 §6.1, #4116)")
+	}
+
+	// The fired master-down timer now drives the BACKUP select → becomeMaster.
+	// Re-arm an already-expired timer so the select deterministically promotes.
+	mdt.Reset(0)
+	advert := time.NewTimer(time.Hour)
+	defer advert.Stop()
+	if stop := vi.stepBackup(mdt, advert, hold); stop {
+		t.Fatal("stepBackup returned stop=true unexpectedly")
+	}
+	if vi.getState() != StateMaster {
+		t.Errorf("state = %s, want MASTER (owner reclaims after master-down expiry)", vi.getState())
+	}
+}
+
+// TestNonOwnerNoPreempt_LowerAdvertResetsMasterDownTimer is the no-regression
+// twin of the reclaim test: a NON-owner (200, no-preempt) hearing a lower
+// advert DOES reset its master-down timer (no-preempt honored), so a short
+// deadline is pushed out and does not fire. Passes both pre- and post-fix —
+// it guards against the owner override leaking to non-owners.
+func TestNonOwnerNoPreempt_LowerAdvertResetsMasterDownTimer(t *testing.T) {
+	vi := newGateTestInstance(t, 200, false)
+
+	mdt := time.NewTimer(40 * time.Millisecond)
+	defer mdt.Stop()
+	hold := time.NewTimer(time.Hour)
+	defer hold.Stop()
+
+	vi.handleBackupRx(&VRRPPacket{Priority: 100, SrcIP: net.IPv4(10, 0, 0, 2)}, mdt, hold)
+
+	// The gate reset the timer to masterDownInterval() (~3s), so the original
+	// 40ms deadline is gone — it must NOT fire within a generous window.
+	select {
+	case <-mdt.C:
+		t.Fatal("non-owner no-preempt master-down timer fired; a lower advert must reset it (no-preempt honored)")
+	case <-time.After(300 * time.Millisecond):
+		// did not fire → correctly reset far out → no-preempt honored
+	}
+}
+
+// TestOwnerPreempt_PreemptEnabledUnchanged: an owner with preempt ENABLED is
+// unaffected by the override (it already preempted). Sanity that the override
+// composes rather than changing enabled-preempt behavior.
+func TestOwnerPreempt_PreemptEnabledUnchanged(t *testing.T) {
+	vi := newGateTestInstance(t, 255, true)
+	vi.mu.Lock()
+	vi.lastMasterPriority = 100
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+
+	masterDown, advert, preemptHold := longTimers(t)
+	vi.triggerPreemptNow()
+	vi.stepBackup(masterDown, advert, preemptHold)
+	if vi.getState() != StateMaster {
+		t.Errorf("state = %s, want MASTER (owner-255 preempt-enabled unchanged)", vi.getState())
+	}
+}


### PR DESCRIPTION
Closes #4116

## Problem

RFC 5798 §6.1 requires the IP address owner (priority 255) to preempt a
lower-priority master "irrespective of the setting of" the preempt flag — the
owner always reclaims mastership because it owns the virtual address.

Before this change an owner configured with `no-preempt` never reclaimed. After
the owner rebooted, a lower-priority peer became MASTER and held the VIP; when
the owner returned it entered BACKUP, heard the peer's LOWER advert, and
`handleBackupRx` (`pkg/vrrp/instance.go`) reset the master-down timer on every
advert (`!getPreempt()` was true), so the timer never expired and the owner
stayed BACKUP indefinitely though it OWNS the VIP.

## Fix

Force effective preempt=true for the address owner at the two runtime
preempt-decision sites, keyed on the **configured** priority (255):

- `getPreempt()` returns `cfg.Preempt || cfg.Priority == 255`. The
  `handleBackupRx` master-down-reset gate no longer resets the timer when the
  owner hears a lower advert → the timer expires → `becomeMaster`. The `run()`
  initial-timer branch (`if !getPreempt()`) also stops applying the 3s
  no-preempt safety timer to the owner, so it reclaims promptly.
- `shouldPreemptObservedMaster()` early-return becomes
  `if !preempt && priority != 255` so the sync-hold-release `preemptNowCh`
  shortcut and the preempt-hold-time re-validation both promote the owner.

A named const `addressOwnerPriority = 255` documents the invariant.

### How it composes

The override keys on `cfg.Priority`, not the effective tracked priority: the
owner is already track-exempt (`getPriority` never demotes 255, `track.go`), so
the configured 255 is authoritative and composes with — does not disturb — the
existing owner-255-exempt demotion logic. Both changes are a **no-op for every
non-owner** instance (priorities < 255), so cluster RETH weight-based failover,
the #2082 sync-hold peer-priority gate, and ~60ms failover timing are
unaffected.

## Tests (`pkg/vrrp/instance_owner_preempt_test.go`)

- `getPreempt()` truth table + sync-hold-suppression case.
- `shouldPreemptObservedMaster()` owner-passes vs non-owner-denied.
- `preemptNowCh` wiring: owner (255, no-preempt) becomes MASTER on the kick.
- End-to-end: owner hearing a lower advert does NOT reset its master-down timer
  → timer expires → `stepBackup` promotes to MASTER (the reported defect).
- Non-owner no-regression twin (lower advert DOES reset) + owner-preempt-enabled
  unchanged.

**RED-on-revert verified**: reverting `instance.go` to the pre-fix
`getPreempt` / `shouldPreemptObservedMaster` fails all five owner assertions
(getPreempt returns false, state stays BACKUP, master-down timer is reset).

`go test -race ./pkg/vrrp/` green; `go build ./...`, `go vet`, `gofmt` clean.

Docs: `critical-patterns.md` (HA section) and `feature-coverage.md`.

> test-failover WARRANTED (VRRP failover behavior) — flagged for batch validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi