### PR TITLE
ipsec: fail closed on a dangling ESP-proposal reference (#4117)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-07-04 — #4117: ESP proposals fail closed on a dangling reference (fable-163 F24)
+
+- **Timestamp**: 2026-07-04
+  - **Action**: LOW, security/ipsec/vsrx-parity. VERIFY-FIRST confirmed the
+    bug at HEAD: `resolveESPSettings` (`pkg/ipsec/ike.go`) only preserved
+    crypto intent for a dangling ESP-proposal reference when `pfsGroup > 0`
+    (the #2073 `aes256-sha256-modp<bits>` fallback); at `pfsGroup == 0` it
+    fell through to `return "default"`, and `policy.go:193` emits
+    `esp_proposals = %s` unconditionally — so a tolerant/peer-sync boot of a
+    config whose ipsec-policy references an UNDEFINED proposal with no PFS
+    silently negotiated strongSwan's built-in ESP suite instead of the
+    operator's cipher/integrity. Asymmetric vs the IKE path (#2270 SKIPs the
+    VPN). Fix: restructured `resolveESPSettings` to an ABSENT-vs-DANGLING
+    contract — `vpn.IPsecPolicy == ""` still returns `default` (legitimate,
+    the ONLY default path); ANY named-but-unresolved reference (dangling
+    proposal ref OR dangling policy ref) now emits a conservative FIXED suite
+    (`aes256-sha256`, plus `-modp<bits>` when PFS is set), never `default`.
+    Chose the fixed-suite fallback over the IKE-style whole-VPN skip for
+    parity with #2073 (which already emits the fallback for pfsGroup>0 rather
+    than skipping) — skipping only the no-PFS case would drop a no-PFS tunnel
+    while an identical with-PFS tunnel keeps a working fallback (availability
+    asymmetry). Also closed the sibling dangling-POLICY-reference hole (VPN
+    names an undefined ipsec-policy) which had the same silent-default
+    downgrade and no commit-time validator. RED-on-revert proven (3 tests go
+    RED when the fallback is restored to `default`). `go test ./pkg/ipsec/...
+    ./pkg/config/...` green, `go build ./...` clean, gofmt+vet clean.
+  - **File(s)**: pkg/ipsec/ike.go, pkg/ipsec/ipsec_test.go,
+    pkg/ipsec/README.md, _Log.md
+
 ## 2026-07-04 — #4100: VRRPv3 IPv4 advert checksum RFC 5798 §5.2.8 pseudo-header (fable-163 F10)
 
 - **Timestamp**: 2026-07-04

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -140,15 +140,34 @@ all files stay in `package ipsec`, so the public API is unchanged.
   carries no required modp term), so PFS was silently disabled. On the
   tolerant load / peer-sync paths the commit check is downgraded to a
   warning (an already-persisted or peer-synced config still boots), and
-  `resolveESPSettings` has a render-side safety net: when the policy
-  resolves with a PFS group but the proposal ref dangles, it carries the
-  configured PFS group on a conservative valid fallback proposal
-  (`aes256-sha256-modp<bits>`, built with swanctl's canonical keyword
-  spellings) instead of falling through to `default`,
-  and logs a warning. Note: strongSwan ≥ 6.0.2 changed its `default` ESP
-  set to make PFS *optional* rather than absent, so the silent weakening is
-  a downgrade-to-negotiable-PFS there rather than no-PFS — the fix is the
-  same.
+  `resolveESPSettings` has a render-side safety net that emits a
+  conservative **fixed** ESP suite instead of falling through to
+  `default`, and logs a warning. Note: strongSwan ≥ 6.0.2 changed its
+  `default` ESP set to make PFS *optional* rather than absent, so the
+  silent weakening is a downgrade-to-negotiable-PFS there rather than
+  no-PFS — the fix is the same.
+  - **Absent vs dangling (#4117).** The safety net distinguishes two
+    cases. A VPN that names **no** `ipsec-policy` at all
+    (`vpn.IPsecPolicy == ""`) legitimately gets `esp_proposals = default`
+    — the operator made no crypto choice, so strongSwan's built-in suite
+    is their explicit choice. This is the ONLY path that emits `default`.
+    A **named-but-unresolved (dangling)** reference — the policy is
+    undefined, or the policy resolves but its proposal ref dangles — never
+    falls through to `default`. It renders a conservative fixed suite:
+    `aes256-sha256-modp<bits>` when a PFS group is configured (the #2073
+    case), or `aes256-sha256` (no modp term) when no PFS is configured.
+    Before #4117 the no-PFS dangling case still fell through to `default`,
+    silently substituting the operator's whole cipher/integrity choice
+    with strongSwan's built-in suite (the reasoning was "no PFS = nothing
+    to preserve", which overlooked that the cipher/integrity intent is
+    also lost). #4117 chose the conservative **fixed suite** over the
+    IKE-style whole-VPN **skip** (#2270) for parity with the #2073 PFS
+    case, which already emits the fallback rather than skipping: skipping
+    only the no-PFS case would drop a no-PFS tunnel entirely while an
+    otherwise-identical with-PFS tunnel keeps a working fallback — a
+    surprising availability asymmetry driven solely by whether PFS
+    happened to be configured. IKE (Phase 1) fails closed by skipping
+    instead because it has no equivalent strong fixed suite to offer.
 - **DH-group keyword rendering (#2392).** Every IKE/ESP proposal builder
   (`buildIKEProposalFromIKE`, `buildIKEProposal`, `buildESPProposal`, and
   the #2073 PFS fallback above) renders the Diffie-Hellman group suffix

--- a/pkg/ipsec/ike.go
+++ b/pkg/ipsec/ike.go
@@ -98,75 +98,100 @@ func resolveIKESettings(cfg *config.IPsecConfig, gw *config.IPsecGateway) (authM
 // resolveESPSettings resolves the ESP (Phase 2) proposal string and lifetime
 // from the VPN's IPsec policy chain.
 func resolveESPSettings(cfg *config.IPsecConfig, vpn *config.IPsecVPN) (string, int) {
-	espProposals := "default"
-	pfsGroup := 0
-	if vpn.IPsecPolicy != "" {
-		if ipsecPol, ok := cfg.Policies[vpn.IPsecPolicy]; ok {
-			pfsGroup = ipsecPol.PFSGroup
-			// #3904: `proposals [ p1 p2 ]` offers every listed ESP proposal.
-			// Build each resolvable reference (the policy-level PFS group
-			// applies to all) and comma-join. An empty list falls back to a
-			// proposal named after the policy, as before.
-			propRefs := ipsecPol.Proposals
-			if len(propRefs) == 0 {
-				propRefs = []string{vpn.IPsecPolicy}
-			}
-			var built []string
-			var firstLifetime int
-			for _, propRef := range propRefs {
-				if prop, ok := cfg.Proposals[propRef]; ok {
-					if len(built) == 0 {
-						firstLifetime = prop.LifetimeSeconds
-					}
-					built = append(built, buildESPProposal(prop, pfsGroup))
-				}
-			}
-			if len(built) > 0 {
-				return strings.Join(built, ","), firstLifetime
-			}
-			// #2073: the IPsec policy resolves but its proposal reference
-			// does not. The commit-time strict validator
-			// (validateIPsecPolicyProposalReferencesStrict) hard-rejects
-			// this for new operator edits, so this branch is only reached
-			// on a tolerant-path boot of an already-persisted or
-			// peer-synced config (where the validator downgraded to a
-			// warning so the node still boots). Do NOT silently drop a
-			// configured perfect-forward-secrecy group by falling through
-			// to bare "default" (which has no modp term): carry the
-			// configured PFS group on a conservative fallback proposal so
-			// PFS is still negotiated. A non-AEAD (CBC) ESP transform
-			// requires an integrity algorithm, so the fallback includes
-			// both a cipher and integrity in addition to the modp term. The
-			// string is built directly with swanctl's canonical keyword
-			// spellings (aes256 / sha256 / modp<bits>). This is now the
-			// same integrity keyword buildESPProposal produces —
-			// normalizeAuthAlg maps hmac-sha-256-128 to the strongSwan base
-			// keyword "sha256" (#3851), not the invalid dash-stripped
-			// "sha256128" that strongSwan's proposal parser rejects (its
-			// keyword table has only "sha256"/"sha2_256" for
-			// AUTH_HMAC_SHA2_256_128). This fallback keeps the direct
-			// spelling because the proposal reference dangles (there is no
-			// proposal object to hand to buildESPProposal), not because the
-			// builder is unsafe.
-			//
-			// formatDHGroup renders the PFS group with its canonical
-			// swanctl keyword: modp<bits> for the MODP groups
-			// (1/2/5/14/15/16/...) and the ECP/curve spellings for the
-			// elliptic-curve groups (19->ecp256, 20->ecp384, ...). This
-			// fallback uses the same renderer as the normal-path builders,
-			// so the #2392 ECP fix applies here too — group 19/20 no longer
-			// emits the strongSwan-invalid modp256/modp384 token.
-			if pfsGroup > 0 {
-				slog.Warn("ipsec policy references undefined proposal; "+
-					"preserving configured PFS group on fallback proposal",
-					"policy", vpn.IPsecPolicy, "proposal", strings.Join(propRefs, ","),
-					"pfs_group", pfsGroup)
-				return fmt.Sprintf("aes256-sha256-%s", formatDHGroup(pfsGroup)), 0
-			}
-		} else if prop, ok := cfg.Proposals[vpn.IPsecPolicy]; ok {
-			return buildESPProposal(prop, 0), prop.LifetimeSeconds
-		}
+	// ABSENT vs DANGLING (#4117). A VPN that names NO ipsec-policy at all
+	// legitimately wants strongSwan's compiled-in "default" ESP suite — the
+	// operator made no crypto choice, so the built-in default is their
+	// explicit choice and nothing dangles. This is the ONLY path that emits
+	// esp_proposals = default. A NAMED-but-unresolved (dangling) reference
+	// must NEVER fall through to it (see the fail-closed fallback below).
+	if vpn.IPsecPolicy == "" {
+		return "default", 0
 	}
+
+	pfsGroup := 0
+	if ipsecPol, ok := cfg.Policies[vpn.IPsecPolicy]; ok {
+		pfsGroup = ipsecPol.PFSGroup
+		// #3904: `proposals [ p1 p2 ]` offers every listed ESP proposal.
+		// Build each resolvable reference (the policy-level PFS group
+		// applies to all) and comma-join. An empty list falls back to a
+		// proposal named after the policy, as before.
+		propRefs := ipsecPol.Proposals
+		if len(propRefs) == 0 {
+			propRefs = []string{vpn.IPsecPolicy}
+		}
+		var built []string
+		var firstLifetime int
+		for _, propRef := range propRefs {
+			if prop, ok := cfg.Proposals[propRef]; ok {
+				if len(built) == 0 {
+					firstLifetime = prop.LifetimeSeconds
+				}
+				built = append(built, buildESPProposal(prop, pfsGroup))
+			}
+		}
+		if len(built) > 0 {
+			return strings.Join(built, ","), firstLifetime
+		}
+		// Dangling proposal reference: the policy resolves but none of its
+		// proposal references do. Fall through to the conservative fixed
+		// fallback below — never bare "default".
+	} else if prop, ok := cfg.Proposals[vpn.IPsecPolicy]; ok {
+		// Legacy form: the ipsec-policy value is itself the NAME of a
+		// defined ESP proposal (no policy object). Render it directly.
+		return buildESPProposal(prop, 0), prop.LifetimeSeconds
+	}
+	// else: dangling POLICY reference — vpn.IPsecPolicy names neither a
+	// defined ipsec-policy nor a defined ESP proposal. Fail closed below.
+
+	// #4117 / #2073: a NAMED ipsec-policy reference did not resolve — either
+	// the policy is undefined, or the policy resolves but its proposal
+	// reference dangles. The commit-time strict validators
+	// (validateIPsecPolicyProposalReferencesStrict) hard-reject this for new
+	// operator edits, so this branch is only reached on a tolerant-path boot
+	// of an already-persisted or peer-synced config (where the validator
+	// downgraded to a warning so the node still boots).
+	//
+	// Do NOT fall through to bare "default" (strongSwan's compiled-in ESP
+	// suite): a NAMED reference carries operator crypto intent, and
+	// substituting the built-in default silently WEAKENS ESP — the same
+	// silent-downgrade class the IKE (Phase-1) path fails closed on (#2270).
+	// Emit a conservative FIXED suite instead: aes256-sha256, a strong known
+	// cipher+integrity pair, carrying the configured perfect-forward-secrecy
+	// group when one is set. A non-AEAD (CBC) ESP transform requires an
+	// integrity algorithm, so the fallback always pairs a cipher with an
+	// integrity alg (and a modp term when PFS is configured). The string is
+	// built directly with swanctl's canonical keyword spellings (aes256 /
+	// sha256 / modp<bits>): "sha256" is the strongSwan base keyword
+	// normalizeAuthAlg maps hmac-sha-256-128 to (#3851), not the invalid
+	// dash-stripped "sha256128" its proposal parser rejects. formatDHGroup
+	// renders the PFS group with its canonical swanctl keyword — modp<bits>
+	// for the MODP groups and the ECP/curve spellings for the elliptic-curve
+	// groups (19->ecp256, 20->ecp384, ...) — so the #2392 ECP fix applies
+	// here too. Direct spelling is used because the reference dangles (there
+	// is no proposal object to hand to buildESPProposal), not because the
+	// builder is unsafe.
+	//
+	// #4117 chose the conservative fixed fallback over the IKE-style
+	// whole-VPN SKIP for ESP parity with #2073, which already emits this
+	// fallback for the pfsGroup > 0 dangling case (with tests asserting the
+	// suite is EMITTED, not skipped). Skipping only when pfsGroup == 0 would
+	// fracture that: a no-PFS dangling config would lose its tunnel entirely
+	// while an otherwise-identical with-PFS config keeps a working fallback
+	// tunnel — a surprising availability asymmetry driven solely by whether
+	// PFS happened to be configured. The tolerant/peer-sync boot path's
+	// intent is to keep an already-persisted tunnel alive with strong,
+	// known crypto rather than drop it; this fallback honours that intent
+	// uniformly. IKE fails closed instead because it has no equivalent
+	// strong fixed suite to offer.
+	espProposals := "aes256-sha256"
+	if pfsGroup > 0 {
+		espProposals = fmt.Sprintf("aes256-sha256-%s", formatDHGroup(pfsGroup))
+	}
+	slog.Warn("ipsec policy reference does not resolve; emitting a "+
+		"conservative fixed ESP suite instead of the strongSwan default "+
+		"(a dangling reference must not silently weaken ESP crypto)",
+		"policy", vpn.IPsecPolicy, "esp_proposals", espProposals,
+		"pfs_group", pfsGroup)
 	return espProposals, 0
 }
 

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -233,11 +233,15 @@ func TestResolveESPSettings_DanglingProposalPreservesPFS(t *testing.T) {
 	}
 }
 
-// TestResolveESPSettings_DanglingProposalNoPFSStaysDefault verifies that a
-// dangling proposal reference with NO configured PFS still falls to
-// "default" — there is no security control to preserve, so the render
-// behavior is unchanged from before #2073.
-func TestResolveESPSettings_DanglingProposalNoPFSStaysDefault(t *testing.T) {
+// TestResolveESPSettings_DanglingProposalNoPFSFailsClosed is the #4117
+// regression. A dangling proposal reference with NO configured PFS must NOT
+// silently fall through to "default" (strongSwan's compiled-in ESP suite):
+// the NAMED proposal reference carries the operator's cipher/integrity
+// intent, and substituting the built-in default silently weakens ESP. The
+// renderer emits the conservative fixed fallback aes256-sha256 — parity with
+// the pfsGroup > 0 case (#2073), which already emits aes256-sha256-modp
+// rather than skipping. On revert this returns "default" and goes RED.
+func TestResolveESPSettings_DanglingProposalNoPFSFailsClosed(t *testing.T) {
 	cfg := &config.IPsecConfig{
 		Policies: map[string]*config.IPsecPolicyDef{
 			"ipsec-pol": {
@@ -246,12 +250,71 @@ func TestResolveESPSettings_DanglingProposalNoPFSStaysDefault(t *testing.T) {
 				Proposals: []string{"does-not-exist"},
 			},
 		},
+		// Proposals deliberately omits "does-not-exist" — dangling ref.
+	}
+	vpn := &config.IPsecVPN{IPsecPolicy: "ipsec-pol"}
+
+	got, lifetime := resolveESPSettings(cfg, vpn)
+	if got == "default" {
+		t.Fatalf("dangling ESP proposal ref silently downgraded to the "+
+			"strongSwan default suite: got %q", got)
+	}
+	if got != "aes256-sha256" {
+		t.Fatalf("resolveESPSettings = %q, want conservative fixed fallback "+
+			"aes256-sha256 (dangling ref, no PFS)", got)
+	}
+	if lifetime != 0 {
+		t.Errorf("lifetime = %d, want 0 (no resolvable proposal to take a lifetime from)", lifetime)
+	}
+}
+
+// TestResolveESPSettings_DanglingPolicyRefFailsClosed covers the sibling
+// dangling case (#4117): the VPN names an ipsec-policy that is not defined at
+// all (neither a policy object nor a legacy proposal of that name). This too
+// must fail closed to the conservative fixed suite rather than silently emit
+// esp_proposals = default. No policy resolves, so no PFS group is available
+// and the fallback carries no modp term.
+func TestResolveESPSettings_DanglingPolicyRefFailsClosed(t *testing.T) {
+	cfg := &config.IPsecConfig{
+		// Neither Policies nor Proposals defines "ipsec-pol".
 	}
 	vpn := &config.IPsecVPN{IPsecPolicy: "ipsec-pol"}
 
 	got, _ := resolveESPSettings(cfg, vpn)
-	if got != "default" {
-		t.Errorf("resolveESPSettings = %q, want default (no PFS configured)", got)
+	if got == "default" {
+		t.Fatalf("dangling ESP policy ref silently downgraded to the "+
+			"strongSwan default suite: got %q", got)
+	}
+	if got != "aes256-sha256" {
+		t.Fatalf("resolveESPSettings = %q, want conservative fixed fallback "+
+			"aes256-sha256 (dangling policy ref)", got)
+	}
+}
+
+// TestGenerateConfig_DanglingProposalNoPFSFailsClosed is the #4117 full-render
+// regression: a dangling ESP proposal reference with no PFS must render
+// esp_proposals = aes256-sha256, never esp_proposals = default.
+func TestGenerateConfig_DanglingProposalNoPFSFailsClosed(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		VPNs: map[string]*config.IPsecVPN{
+			"tun1": {
+				Gateway:     "172.16.0.1",
+				IPsecPolicy: "ipsec-pol",
+				LocalID:     "10.0.1.0/24",
+				RemoteID:    "10.0.2.0/24",
+			},
+		},
+		Policies: map[string]*config.IPsecPolicyDef{
+			"ipsec-pol": {Name: "ipsec-pol", PFSGroup: 0, Proposals: []string{"does-not-exist"}},
+		},
+	}
+	got := m.generateConfig(cfg)
+	if strings.Contains(got, "esp_proposals = default") {
+		t.Errorf("dangling ESP ref silently downgraded to esp_proposals = default:\n%s", got)
+	}
+	if !strings.Contains(got, "esp_proposals = aes256-sha256\n") {
+		t.Errorf("expected conservative fixed esp_proposals = aes256-sha256, got:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
Closes #4117

## Problem

`resolveESPSettings` (`pkg/ipsec/ike.go`) only preserved the operator's
crypto intent for a dangling ESP-proposal reference when a PFS group was
configured (the #2073 `aes256-sha256-modp<bits>` fallback). At
`pfsGroup == 0` it fell through to `return "default"`, and
`policy.go:193` emits `esp_proposals = %s` **unconditionally** (no
`!= ""` guard, unlike the IKE `proposals` line).

On the tolerant / peer-sync boot path — where the strict validator
`validateIPsecPolicyProposalReferencesStrict` is downgraded to a warning
so an already-persisted or peer-synced config still boots — an
ipsec-policy referencing an **undefined** proposal with no PFS group
built 0 proposals and rendered `esp_proposals = default`. strongSwan
then negotiates its compiled-in ESP suite instead of the operator's
intended cipher/integrity. This is **asymmetric** with the IKE
(Phase-1) path, which fails closed by SKIPping the VPN (#2270): ESP
quietly **downgraded**.

## Fix

Restructured `resolveESPSettings` around an explicit **absent-vs-dangling**
contract:

- **Absent** (`vpn.IPsecPolicy == ""`): no ipsec-policy is named, so
  strongSwan's built-in `default` ESP suite is the operator's explicit
  choice. This is now the **only** path that emits `default`.
- **Dangling** (`vpn.IPsecPolicy != ""` but unresolved — the policy is
  undefined, or the policy resolves but its proposal reference dangles):
  now renders a conservative **fixed** suite (`aes256-sha256`, plus
  `-modp<bits>` when a PFS group is configured), never bare `default`.

This also closes the sibling **dangling-policy-reference** hole (a VPN
that names an ipsec-policy that is not defined at all), which had the
same silent-default downgrade and, unlike the proposal reference, no
commit-time validator gating it.

### Skip vs fixed-suite decision

Chose the conservative fixed-suite fallback over the IKE-style whole-VPN
**skip** for parity with #2073, which already emits the fallback for the
`pfsGroup > 0` dangling case (with tests asserting the suite is emitted,
not skipped). Skipping only when `pfsGroup == 0` would fracture that: a
no-PFS dangling config would lose its tunnel entirely while an
otherwise-identical with-PFS config keeps a working fallback tunnel — a
surprising availability asymmetry driven solely by whether PFS happened
to be configured. IKE fails closed instead because it has no equivalent
strong fixed suite to offer.

## RED-on-revert proof

Temporarily restoring the fallback to `"default"` turns all three new
tests RED (verified):

```
--- FAIL: TestResolveESPSettings_DanglingProposalNoPFSFailsClosed
--- FAIL: TestResolveESPSettings_DanglingPolicyRefFailsClosed
--- FAIL: TestGenerateConfig_DanglingProposalNoPFSFailsClosed
```

The existing `pfsGroup > 0` (`aes256-sha256-modp2048`) and absent-policy
(`-> default`) tests are unchanged and still pass, pinning the
absent-vs-dangling distinction.

## Validation

- `go test ./pkg/ipsec/... ./pkg/config/...` green
- `go build ./...` clean
- `gofmt` + `go vet ./pkg/ipsec/...` clean

Docs: `pkg/ipsec/README.md` #2073 section updated with the #4117
absent-vs-dangling sub-bullet and the skip-vs-fixed-suite rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi