### PR TITLE
dhcp: honor RFC 3442 classless static routes (option 121 / legacy 249)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -32611,3 +32611,32 @@ top.
     vet, gofmt clean.
   - **File(s)**: pkg/grpcapi/server.go,
     pkg/grpcapi/server_fabric_allowlist_4122_test.go, _Log.md
+
+- **Timestamp**: 2026-07-04
+  - **Action**: #4118 — honor RFC 3442 classless static routes (DHCPv4
+    option 121 / legacy 249) in the DHCP client. Verified at HEAD:
+    `leaseFromACKv4` extracted only `ack.Router()` (option 3); grep of
+    pkg/dhcp for 121/249/classless returned nothing. The insomniacslk/dhcp
+    library exposes a `ClasslessStaticRoute()` accessor (option 121) but no
+    legacy-249 helper. Fix: parse option 121 (accessor) with a raw
+    `GenericOptionCode(249)` + `Routes.FromBytes` fallback (identical RFC
+    3442 encoding) in new `classlessStaticRoutes` helper; store on new
+    `Lease.ClasslessRoutes []LeaseRoute`. RFC 3442 precedence enforced —
+    when option 121/249 present the option-3 Router is IGNORED; the
+    0.0.0.0/0 entry supplies `lease.Gateway`, more-specific routes go on
+    ClasslessRoutes. Programmed via the same paths as the default route:
+    `collectDHCPRoutes` emits a `frr.DHCPRoute{Destination}` per classless
+    route (DHCPRoute grew a `Destination` field, "" = default), 
+    `renderDHCPDefaults` writes `ip route <dest> <gw> [<iface>] 200` with
+    static-default suppression scoped to ONLY the default route, and
+    `applyMgmtVRFRoutes` installs them into mgmt VRF table 999 via netlink.
+    `leaseContentChanged` diffs ClasslessRoutes so they withdraw/re-install
+    with the lease. RED-on-revert: reverting the parse to option-3-only
+    fails TestLeaseFromACKv4ClasslessRoutesSupersedeOption3 /
+    ClasslessOnlySpecificNoDefault / LegacyOption249 (gateway falls back to
+    the option-3 gw 198.51.100.99, ClasslessRoutes empty). go test -count=1
+    ./pkg/dhcp/... ./pkg/frr/... green; go build ./..., vet, gofmt clean.
+  - **File(s)**: pkg/dhcp/dhcp.go, pkg/dhcp/commit.go,
+    pkg/dhcp/classless_routes_test.go, pkg/frr/manager.go,
+    pkg/frr/config_render.go, pkg/frr/frr_test.go,
+    pkg/daemon/daemon_flow.go, pkg/dhcp/README.md, _Log.md

--- a/pkg/daemon/daemon_flow.go
+++ b/pkg/daemon/daemon_flow.go
@@ -30,18 +30,28 @@ func (d *Daemon) collectDHCPRoutes() []frr.DHCPRoute {
 	}
 	var routes []frr.DHCPRoute
 	for _, lease := range d.dhcp.Leases() {
-		if !lease.Gateway.IsValid() {
-			continue
-		}
 		if d.mgmtVRFInterfaces[lease.Interface] {
 			continue
 		}
-		dr := frr.DHCPRoute{
-			Gateway:   lease.Gateway.String(),
-			Interface: lease.Interface,
-			IsIPv6:    lease.Family == dhcp.AFInet6,
+		isIPv6 := lease.Family == dhcp.AFInet6
+		// Default route (option-3 gateway, or option-121 0.0.0.0/0 entry).
+		if lease.Gateway.IsValid() {
+			routes = append(routes, frr.DHCPRoute{
+				Gateway:   lease.Gateway.String(),
+				Interface: lease.Interface,
+				IsIPv6:    isIPv6,
+			})
 		}
-		routes = append(routes, dr)
+		// RFC 3442 classless static routes (option 121 / legacy 249). A
+		// lease may carry these with or without a default gateway.
+		for _, cr := range lease.ClasslessRoutes {
+			routes = append(routes, frr.DHCPRoute{
+				Destination: cr.Destination.String(),
+				Gateway:     cr.Gateway.String(),
+				Interface:   lease.Interface,
+				IsIPv6:      isIPv6,
+			})
+		}
 	}
 	return routes
 }
@@ -62,7 +72,13 @@ func (d *Daemon) applyMgmtVRFRoutes() {
 	defer nlh.Close()
 
 	for _, lease := range d.dhcp.Leases() {
-		if !lease.Gateway.IsValid() || !d.mgmtVRFInterfaces[lease.Interface] {
+		if !d.mgmtVRFInterfaces[lease.Interface] {
+			continue
+		}
+		// A lease may carry a default gateway (option 3 or the option-121
+		// 0.0.0.0/0 entry) and/or RFC 3442 classless static routes (option
+		// 121 / legacy 249). Program each into the management VRF table.
+		if !lease.Gateway.IsValid() && len(lease.ClasslessRoutes) == 0 {
 			continue
 		}
 		link, err := nlh.LinkByName(lease.Interface)
@@ -71,25 +87,52 @@ func (d *Daemon) applyMgmtVRFRoutes() {
 				"interface", lease.Interface, "err", err)
 			continue
 		}
-		var dst *net.IPNet
-		if lease.Family == dhcp.AFInet6 {
-			dst = &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)}
-		} else {
-			dst = &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)}
+		linkIndex := link.Attrs().Index
+
+		if lease.Gateway.IsValid() {
+			var dst *net.IPNet
+			if lease.Family == dhcp.AFInet6 {
+				dst = &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)}
+			} else {
+				dst = &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)}
+			}
+			gwSlice := lease.Gateway.AsSlice()
+			route := &netlink.Route{
+				LinkIndex: linkIndex,
+				Dst:       dst,
+				Gw:        net.IP(gwSlice),
+				Table:     mgmtTableID,
+			}
+			if err := nlh.RouteReplace(route); err != nil {
+				slog.Warn("mgmt VRF route: failed to add default route",
+					"interface", lease.Interface, "gw", lease.Gateway, "table", mgmtTableID, "err", err)
+			} else {
+				slog.Info("mgmt VRF default route installed",
+					"interface", lease.Interface, "gw", lease.Gateway, "table", mgmtTableID)
+			}
 		}
-		gwSlice := lease.Gateway.AsSlice()
-		route := &netlink.Route{
-			LinkIndex: link.Attrs().Index,
-			Dst:       dst,
-			Gw:        net.IP(gwSlice),
-			Table:     mgmtTableID,
-		}
-		if err := nlh.RouteReplace(route); err != nil {
-			slog.Warn("mgmt VRF route: failed to add default route",
-				"interface", lease.Interface, "gw", lease.Gateway, "table", mgmtTableID, "err", err)
-		} else {
-			slog.Info("mgmt VRF default route installed",
-				"interface", lease.Interface, "gw", lease.Gateway, "table", mgmtTableID)
+
+		// RFC 3442 classless static routes.
+		for _, cr := range lease.ClasslessRoutes {
+			dst := &net.IPNet{
+				IP:   net.IP(cr.Destination.Addr().AsSlice()),
+				Mask: net.CIDRMask(cr.Destination.Bits(), cr.Destination.Addr().BitLen()),
+			}
+			route := &netlink.Route{
+				LinkIndex: linkIndex,
+				Dst:       dst,
+				Gw:        net.IP(cr.Gateway.AsSlice()),
+				Table:     mgmtTableID,
+			}
+			if err := nlh.RouteReplace(route); err != nil {
+				slog.Warn("mgmt VRF route: failed to add classless route",
+					"interface", lease.Interface, "dst", cr.Destination, "gw", cr.Gateway,
+					"table", mgmtTableID, "err", err)
+			} else {
+				slog.Info("mgmt VRF classless route installed",
+					"interface", lease.Interface, "dst", cr.Destination, "gw", cr.Gateway,
+					"table", mgmtTableID)
+			}
 		}
 	}
 }

--- a/pkg/dhcp/README.md
+++ b/pkg/dhcp/README.md
@@ -164,6 +164,27 @@ External only: `github.com/insomniacslk/dhcp`, `github.com/vishvananda/netlink`.
   address reconciliation on DHCP-marked interfaces.
 - DHCP-learned default routes go into FRR with admin distance 200 — lower
   priority than static routes, so a configured static default wins.
+- **RFC 3442 classless static routes (option 121 / legacy 249, #4118).**
+  `leaseFromACKv4` parses option 121 (the standard `ClasslessStaticRoute`
+  accessor) and falls back to the legacy Microsoft option 249 (raw
+  `GenericOptionCode(249)` decoded with the identical
+  `{mask-length, significant-prefix-octets, gateway}` encoding). Per RFC
+  3442 **precedence, option 121/249 SUPERSEDES option 3**: when it is
+  present the client MUST ignore the option-3 Router default entirely.
+  The `0.0.0.0/0` entry (if any) in the option supplies `lease.Gateway`
+  (so every existing gateway consumer — FRR default route, neighbor
+  resolution, ip-monitoring next-hop — is unchanged); every more-specific
+  route lands on `lease.ClasslessRoutes`. When option 121/249 is absent
+  the client falls back to option 3 exactly as before. The classless
+  routes are programmed through the same paths as the default route:
+  `collectDHCPRoutes` emits one `frr.DHCPRoute` per route (with a
+  non-empty `Destination`), `renderDHCPDefaults` writes
+  `ip route <dest> <gw> [<iface>] 200` — and the static-default
+  suppression applies ONLY to the default route, never to the
+  more-specific classless routes — and `applyMgmtVRFRoutes` installs them
+  into the management VRF table (999) via netlink. `leaseContentChanged`
+  diffs `ClasslessRoutes`, so the routes are withdrawn/re-installed in
+  lock-step with the lease on renew/expiry, like the default route.
 - **Lease records are NOT expired by the wall clock.** During a
   *timeout-driven* failed re-acquisition (T2 rebind timed out, fresh
   DORA in progress) the lease record and the kernel address

--- a/pkg/dhcp/classless_routes_test.go
+++ b/pkg/dhcp/classless_routes_test.go
@@ -1,0 +1,191 @@
+package dhcp
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/insomniacslk/dhcp/dhcpv4"
+)
+
+// classlessACK builds a DHCPv4 ACK carrying yourIP 192.0.2.50/24 plus the
+// supplied options (option 3 Router, option 121 Classless Static Route, or a
+// raw legacy option 249). It reuses the leaseFromACKv4 acquire path.
+func classlessACK(t *testing.T, opts ...dhcpv4.Option) *dhcpv4.DHCPv4 {
+	t.Helper()
+	mods := []dhcpv4.Modifier{
+		dhcpv4.WithMessageType(dhcpv4.MessageTypeAck),
+		dhcpv4.WithYourIP(net.ParseIP("192.0.2.50")),
+		dhcpv4.WithNetmask(net.IPMask{255, 255, 255, 0}),
+	}
+	for _, o := range opts {
+		mods = append(mods, dhcpv4.WithOption(o))
+	}
+	ack, err := dhcpv4.New(mods...)
+	if err != nil {
+		t.Fatalf("build DHCPv4 ACK: %v", err)
+	}
+	return ack
+}
+
+func mustCIDR(t *testing.T, s string) *net.IPNet {
+	t.Helper()
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		t.Fatalf("parse CIDR %q: %v", s, err)
+	}
+	return n
+}
+
+// TestLeaseFromACKv4ClasslessRoutesSupersedeOption3 locks in the #4118 fix:
+// when a DHCPv4 ACK carries RFC 3442 option 121 (Classless Static Route), the
+// client MUST install those routes and IGNORE the option-3 Router default. The
+// 0.0.0.0/0 entry in option 121 supplies the default gateway; more-specific
+// routes land on lease.ClasslessRoutes.
+//
+// RED-on-revert: without option-121 parsing the lease keeps the option-3
+// gateway (198.51.100.99) and lease.ClasslessRoutes is empty — both assertions
+// below fail.
+func TestLeaseFromACKv4ClasslessRoutesSupersedeOption3(t *testing.T) {
+	classless := dhcpv4.OptClasslessStaticRoute(
+		// Default route via 192.0.2.1 (option-121 way to express option 3).
+		&dhcpv4.Route{Dest: mustCIDR(t, "0.0.0.0/0"), Router: net.ParseIP("192.0.2.1")},
+		// More-specific classless route: 10.20.0.0/16 via 192.0.2.9.
+		&dhcpv4.Route{Dest: mustCIDR(t, "10.20.0.0/16"), Router: net.ParseIP("192.0.2.9")},
+	)
+	// A DIFFERENT option-3 gateway — must be ignored per RFC 3442.
+	router := dhcpv4.OptRouter(net.ParseIP("198.51.100.99"))
+
+	ack := classlessACK(t, router, classless)
+	lease, err := leaseFromACKv4("wan0", ack)
+	if err != nil {
+		t.Fatalf("leaseFromACKv4: %v", err)
+	}
+
+	// Option 121 supersedes option 3: gateway is the 0.0.0.0/0 entry.
+	wantGW := netip.MustParseAddr("192.0.2.1")
+	if lease.Gateway != wantGW {
+		t.Errorf("lease.Gateway = %v, want %v (option-121 default, NOT the option-3 gateway 198.51.100.99)",
+			lease.Gateway, wantGW)
+	}
+	if lease.Gateway == netip.MustParseAddr("198.51.100.99") {
+		t.Errorf("lease.Gateway is the option-3 gateway; option 3 must be ignored when option 121 present")
+	}
+
+	// The more-specific route is installed (not the 0.0.0.0/0 entry, which
+	// became the gateway).
+	want := []LeaseRoute{
+		{Destination: netip.MustParsePrefix("10.20.0.0/16"), Gateway: netip.MustParseAddr("192.0.2.9")},
+	}
+	if len(lease.ClasslessRoutes) != len(want) {
+		t.Fatalf("lease.ClasslessRoutes = %v, want %v", lease.ClasslessRoutes, want)
+	}
+	if lease.ClasslessRoutes[0] != want[0] {
+		t.Errorf("classless route = %+v, want %+v", lease.ClasslessRoutes[0], want[0])
+	}
+}
+
+// TestLeaseFromACKv4ClasslessOnlySpecificNoDefault verifies that option 121
+// with only a more-specific route (no 0.0.0.0/0 entry) still suppresses option
+// 3 per RFC 3442: the server chose not to provide a default, so no default is
+// installed even though option 3 is present.
+func TestLeaseFromACKv4ClasslessOnlySpecificNoDefault(t *testing.T) {
+	classless := dhcpv4.OptClasslessStaticRoute(
+		&dhcpv4.Route{Dest: mustCIDR(t, "172.16.0.0/12"), Router: net.ParseIP("192.0.2.7")},
+	)
+	router := dhcpv4.OptRouter(net.ParseIP("198.51.100.99"))
+
+	ack := classlessACK(t, router, classless)
+	lease, err := leaseFromACKv4("wan0", ack)
+	if err != nil {
+		t.Fatalf("leaseFromACKv4: %v", err)
+	}
+	if lease.Gateway.IsValid() {
+		t.Errorf("lease.Gateway = %v, want invalid (option 3 ignored, no option-121 default entry)", lease.Gateway)
+	}
+	want := LeaseRoute{Destination: netip.MustParsePrefix("172.16.0.0/12"), Gateway: netip.MustParseAddr("192.0.2.7")}
+	if len(lease.ClasslessRoutes) != 1 || lease.ClasslessRoutes[0] != want {
+		t.Errorf("lease.ClasslessRoutes = %v, want [%+v]", lease.ClasslessRoutes, want)
+	}
+}
+
+// TestLeaseFromACKv4Option3OnlyUnchanged verifies the fallback path is
+// unchanged: with no option 121/249, the option-3 Router default is honored
+// and no classless routes are recorded.
+func TestLeaseFromACKv4Option3OnlyUnchanged(t *testing.T) {
+	router := dhcpv4.OptRouter(net.ParseIP("192.0.2.1"))
+	ack := classlessACK(t, router)
+	lease, err := leaseFromACKv4("wan0", ack)
+	if err != nil {
+		t.Fatalf("leaseFromACKv4: %v", err)
+	}
+	if lease.Gateway != netip.MustParseAddr("192.0.2.1") {
+		t.Errorf("lease.Gateway = %v, want 192.0.2.1 (option 3)", lease.Gateway)
+	}
+	if len(lease.ClasslessRoutes) != 0 {
+		t.Errorf("lease.ClasslessRoutes = %v, want empty (no option 121/249)", lease.ClasslessRoutes)
+	}
+}
+
+// TestLeaseFromACKv4LegacyOption249 verifies the legacy Microsoft option 249
+// is decoded with the identical RFC 3442 encoding when option 121 is absent.
+func TestLeaseFromACKv4LegacyOption249(t *testing.T) {
+	// Encode the same routes into the raw option-249 value using the shared
+	// RFC 3442 encoder.
+	raw := dhcpv4.Routes{
+		{Dest: mustCIDR(t, "0.0.0.0/0"), Router: net.ParseIP("192.0.2.1")},
+		{Dest: mustCIDR(t, "10.0.0.0/8"), Router: net.ParseIP("192.0.2.5")},
+	}.ToBytes()
+	opt249 := dhcpv4.OptGeneric(dhcpv4.GenericOptionCode(249), raw)
+	router := dhcpv4.OptRouter(net.ParseIP("198.51.100.99"))
+
+	ack := classlessACK(t, router, opt249)
+	lease, err := leaseFromACKv4("wan0", ack)
+	if err != nil {
+		t.Fatalf("leaseFromACKv4: %v", err)
+	}
+	if lease.Gateway != netip.MustParseAddr("192.0.2.1") {
+		t.Errorf("lease.Gateway = %v, want 192.0.2.1 (option-249 default, option 3 ignored)", lease.Gateway)
+	}
+	want := LeaseRoute{Destination: netip.MustParsePrefix("10.0.0.0/8"), Gateway: netip.MustParseAddr("192.0.2.5")}
+	if len(lease.ClasslessRoutes) != 1 || lease.ClasslessRoutes[0] != want {
+		t.Errorf("lease.ClasslessRoutes = %v, want [%+v]", lease.ClasslessRoutes, want)
+	}
+}
+
+// TestClasslessStaticRoutesEncoding pins the RFC 3442
+// {mask-length, significant-prefix-octets, gateway} decode for a /24, /0, and
+// /32 — the mask determines how many prefix octets are on the wire (3, 0, 4).
+func TestClasslessStaticRoutesEncoding(t *testing.T) {
+	classless := dhcpv4.OptClasslessStaticRoute(
+		&dhcpv4.Route{Dest: mustCIDR(t, "10.20.30.0/24"), Router: net.ParseIP("192.0.2.2")},  // 3 prefix octets
+		&dhcpv4.Route{Dest: mustCIDR(t, "0.0.0.0/0"), Router: net.ParseIP("192.0.2.1")},      // 0 prefix octets (default)
+		&dhcpv4.Route{Dest: mustCIDR(t, "203.0.113.7/32"), Router: net.ParseIP("192.0.2.3")}, // 4 prefix octets (host)
+	)
+	ack := classlessACK(t, classless)
+
+	routes, defGW, present := classlessStaticRoutes(ack)
+	if !present {
+		t.Fatal("classlessStaticRoutes reported not present")
+	}
+	if defGW != netip.MustParseAddr("192.0.2.1") {
+		t.Errorf("default gateway = %v, want 192.0.2.1", defGW)
+	}
+	want := map[netip.Prefix]netip.Addr{
+		netip.MustParsePrefix("10.20.30.0/24"):  netip.MustParseAddr("192.0.2.2"),
+		netip.MustParsePrefix("203.0.113.7/32"): netip.MustParseAddr("192.0.2.3"),
+	}
+	if len(routes) != len(want) {
+		t.Fatalf("routes = %v, want %d entries", routes, len(want))
+	}
+	for _, r := range routes {
+		gw, ok := want[r.Destination]
+		if !ok {
+			t.Errorf("unexpected route destination %v", r.Destination)
+			continue
+		}
+		if r.Gateway != gw {
+			t.Errorf("route %v gateway = %v, want %v", r.Destination, r.Gateway, gw)
+		}
+	}
+}

--- a/pkg/dhcp/commit.go
+++ b/pkg/dhcp/commit.go
@@ -57,14 +57,16 @@ func renewalTimers(leaseTime time.Duration) (t1, t2Remaining time.Duration) {
 }
 
 // leaseContentChanged reports whether two leases differ in any field a
-// downstream consumer reads (address, gateway, DNS — what reconcileDNS,
-// FRR route generation, and the compiled config consume). Obtained and
-// LeaseTime are excluded: they change on every successful renewal and
-// feed only the run loop's own T1/T2 timers, never compiled state.
+// downstream consumer reads (address, gateway, DNS, and the RFC 3442
+// classless static routes — what reconcileDNS, FRR route generation, and
+// the compiled config consume). Obtained and LeaseTime are excluded: they
+// change on every successful renewal and feed only the run loop's own
+// T1/T2 timers, never compiled state.
 func leaseContentChanged(prev, next *Lease) bool {
 	return prev.Address != next.Address ||
 		prev.Gateway != next.Gateway ||
-		!slices.Equal(prev.DNS, next.DNS)
+		!slices.Equal(prev.DNS, next.DNS) ||
+		!slices.Equal(prev.ClasslessRoutes, next.ClasslessRoutes)
 }
 
 // delegatedPrefixesChanged reports whether the delegated-prefix set

--- a/pkg/dhcp/dhcp.go
+++ b/pkg/dhcp/dhcp.go
@@ -43,6 +43,17 @@ type Lease struct {
 	LeaseTime time.Duration
 	Obtained  time.Time
 
+	// ClasslessRoutes holds the RFC 3442 classless static routes learned
+	// from DHCPv4 option 121 (or the legacy Microsoft option 249) in the
+	// ACK. Per RFC 3442, when the server sends option 121 the client MUST
+	// ignore the option-3 Router default: the 0.0.0.0/0 entry (if any) in
+	// this set populates Gateway instead, and every more-specific route is
+	// held here so it is programmed alongside the lease and withdrawn on
+	// lease change/expiry, exactly like the default route. Nil for DHCPv6
+	// or when the server sends no option 121/249. IPv4 only — RFC 3442 is
+	// a DHCPv4 option.
+	ClasslessRoutes []LeaseRoute
+
 	// serverID is the DHCPv4 server-identifier (option 54) from the ACK
 	// that granted this lease. It is the unicast destination for the
 	// RFC 2131 §4.3.6 RENEWING DHCPREQUEST at T1. Unexported: internal
@@ -54,6 +65,15 @@ type Lease struct {
 	// that granted this lease, echoed in the RFC 8415 §18.2.4 RENEW so
 	// the original server matches the binding. Unexported (#2994).
 	v6ServerDUID dhcpv6.DUID
+}
+
+// LeaseRoute is one RFC 3442 classless static route (destination prefix
+// plus gateway) learned from DHCPv4 option 121 / legacy option 249. It is
+// comparable (netip.Prefix and netip.Addr are comparable), so a slice of
+// LeaseRoute is diffable with slices.Equal for leaseContentChanged.
+type LeaseRoute struct {
+	Destination netip.Prefix
+	Gateway     netip.Addr
 }
 
 // dhcpExchangeMode selects which RFC exchange a renewal cycle step runs.
@@ -962,11 +982,28 @@ func leaseFromACKv4(ifaceName string, ack *dhcpv4.DHCPv4) (*Lease, error) {
 		}
 	}
 
-	// Gateway
-	routers := ack.Router()
-	if len(routers) > 0 {
-		if gw, ok := netip.AddrFromSlice(routers[0].To4()); ok {
-			lease.Gateway = gw
+	// RFC 3442 classless static routes (option 121, or the legacy
+	// Microsoft option 249). When either is present it SUPERSEDES the
+	// option-3 Router option: RFC 3442 requires the client to ignore
+	// option 3 entirely and install the option-121 routes instead. The
+	// 0.0.0.0/0 entry (if any) is the option-121 way to express the
+	// default gateway and populates lease.Gateway (so every existing
+	// gateway consumer — FRR default route, neighbor resolution,
+	// ip-monitoring next-hop — keeps working); more-specific routes are
+	// held on the lease and programmed/withdrawn alongside it. Only when
+	// option 121/249 is absent do we fall back to option 3.
+	if classless, defGW, present := classlessStaticRoutes(ack); present {
+		lease.ClasslessRoutes = classless
+		if defGW.IsValid() {
+			lease.Gateway = defGW
+		}
+	} else {
+		// Gateway (option 3) — honored only when option 121/249 is absent.
+		routers := ack.Router()
+		if len(routers) > 0 {
+			if gw, ok := netip.AddrFromSlice(routers[0].To4()); ok {
+				lease.Gateway = gw
+			}
 		}
 	}
 
@@ -983,6 +1020,67 @@ func leaseFromACKv4(ifaceName string, ack *dhcpv4.DHCPv4) (*Lease, error) {
 	lease.LeaseTime = lt
 
 	return lease, nil
+}
+
+// classlessStaticRoutes parses RFC 3442 classless static routes from a
+// DHCPv4 ACK. It prefers option 121 (the standard code) and falls back to
+// the legacy Microsoft option 249 — both share the identical
+// {mask-length, significant-prefix-octets, gateway} wire encoding, so the
+// same dhcpv4.Routes decoder handles either.
+//
+// It returns the non-default routes separately from the default-route
+// gateway (the 0.0.0.0/0 entry, if the server included one). present is
+// true whenever either option was found — per RFC 3442 the caller MUST
+// then IGNORE the option-3 Router option, even if the option carried no
+// 0.0.0.0/0 entry (in which case defaultGW is the zero Addr and no default
+// route is installed — the server's explicit choice). A malformed entry
+// (bad mask, short buffer) is skipped rather than failing the whole lease.
+func classlessStaticRoutes(ack *dhcpv4.DHCPv4) (routes []LeaseRoute, defaultGW netip.Addr, present bool) {
+	libRoutes := ack.ClasslessStaticRoute() // option 121
+	if len(libRoutes) == 0 {
+		// Legacy option 249 (Microsoft), identical RFC 3442 encoding.
+		if raw := ack.Options.Get(dhcpv4.GenericOptionCode(249)); len(raw) > 0 {
+			var r dhcpv4.Routes
+			if err := r.FromBytes(raw); err == nil {
+				libRoutes = r
+			}
+		}
+	}
+	if len(libRoutes) == 0 {
+		return nil, netip.Addr{}, false
+	}
+	present = true
+	for _, lr := range libRoutes {
+		if lr == nil || lr.Dest == nil {
+			continue
+		}
+		ones, bits := lr.Dest.Mask.Size()
+		if bits != 32 {
+			continue // not an IPv4 mask; RFC 3442 is IPv4-only
+		}
+		gw, ok := netip.AddrFromSlice(lr.Router.To4())
+		if !ok {
+			continue
+		}
+		dst, ok := netip.AddrFromSlice(lr.Dest.IP.To4())
+		if !ok {
+			continue
+		}
+		if ones == 0 {
+			// Default-route entry — supplies lease.Gateway (RFC 3442's way
+			// to express the default gateway). First one wins, matching the
+			// single-gateway model of the option-3 path (routers[0]).
+			if !defaultGW.IsValid() {
+				defaultGW = gw
+			}
+			continue
+		}
+		routes = append(routes, LeaseRoute{
+			Destination: netip.PrefixFrom(dst, ones).Masked(),
+			Gateway:     gw,
+		})
+	}
+	return routes, defaultGW, present
 }
 
 // runDHCPv6 runs the DHCPv6 solicit/request cycle with retries and

--- a/pkg/frr/config_render.go
+++ b/pkg/frr/config_render.go
@@ -207,13 +207,17 @@ func renderGenerateRoutes(b *strings.Builder, fc *FullConfig) {
 	b.WriteString("!\n")
 }
 
-// renderDHCPDefaults emits DHCP-learned default routes at admin distance 200.
-// Suppressed when an explicit static default route exists for the same
+// renderDHCPDefaults emits DHCP-learned routes at admin distance 200: the
+// default route (option-3 gateway or the option-121 0.0.0.0/0 entry) plus
+// any RFC 3442 classless static routes (option 121 / legacy 249), each
+// carried on its DHCPRoute with a non-empty Destination. The default route
+// is suppressed when an explicit static default route exists for the same
 // address family so the management interface's DHCP gateway doesn't compete
-// with configured routes. Both families bind the route to the originating
-// interface when the lease records one (dr.Interface != ""), so that in
-// multi-WAN / shared-gateway-IP deployments the kernel can pick the correct
-// egress instead of leaving an ambiguous gateway-only default.
+// with configured routes; classless static routes are more-specific and are
+// never suppressed by a static default. Both families bind the route to the
+// originating interface when the lease records one (dr.Interface != ""), so
+// that in multi-WAN / shared-gateway-IP deployments the kernel can pick the
+// correct egress instead of leaving an ambiguous gateway-only default.
 func renderDHCPDefaults(b *strings.Builder, fc *FullConfig) {
 	if len(fc.DHCPRoutes) == 0 {
 		return
@@ -234,23 +238,38 @@ func renderDHCPDefaults(b *strings.Builder, fc *FullConfig) {
 	}
 	wrote := false
 	for _, dr := range fc.DHCPRoutes {
-		if dr.IsIPv6 && hasV6Default {
-			continue
-		}
-		if !dr.IsIPv6 && hasV4Default {
-			continue
+		// Destination: empty means the default route; a non-empty value is
+		// an RFC 3442 classless static route (option 121 / legacy 249).
+		dest := dr.Destination
+		isDefault := dest == "" || dest == "0.0.0.0/0" || dest == "::/0"
+		if isDefault {
+			// A configured static default of the same family suppresses the
+			// DHCP-learned default (a static default wins). This suppression
+			// applies ONLY to the default route — classless static routes are
+			// more-specific and must not be dropped by a static default.
+			if dr.IsIPv6 {
+				dest = "::/0"
+				if hasV6Default {
+					continue
+				}
+			} else {
+				dest = "0.0.0.0/0"
+				if hasV4Default {
+					continue
+				}
+			}
 		}
 		if dr.IsIPv6 {
 			if dr.Interface != "" {
-				fmt.Fprintf(b, "ipv6 route ::/0 %s %s 200\n", dr.Gateway, dr.Interface)
+				fmt.Fprintf(b, "ipv6 route %s %s %s 200\n", dest, dr.Gateway, dr.Interface)
 			} else {
-				fmt.Fprintf(b, "ipv6 route ::/0 %s 200\n", dr.Gateway)
+				fmt.Fprintf(b, "ipv6 route %s %s 200\n", dest, dr.Gateway)
 			}
 		} else {
 			if dr.Interface != "" {
-				fmt.Fprintf(b, "ip route 0.0.0.0/0 %s %s 200\n", dr.Gateway, dr.Interface)
+				fmt.Fprintf(b, "ip route %s %s %s 200\n", dest, dr.Gateway, dr.Interface)
 			} else {
-				fmt.Fprintf(b, "ip route 0.0.0.0/0 %s 200\n", dr.Gateway)
+				fmt.Fprintf(b, "ip route %s %s 200\n", dest, dr.Gateway)
 			}
 		}
 		wrote = true

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -4922,6 +4922,43 @@ func TestDHCPRoutesIPv4NoInterfaceUnbound(t *testing.T) {
 	}
 }
 
+// TestDHCPClasslessRoutesNotSuppressedByStaticDefault locks in the #4118 fix:
+// an RFC 3442 classless static route (option 121, carried on a DHCPRoute with a
+// non-empty Destination) is MORE-SPECIFIC and must be emitted even when a
+// configured static default exists — only the DHCP default route is suppressed
+// by a static default. RED-on-revert: without the Destination field the
+// classless route would be rendered as (or suppressed like) the default route.
+func TestDHCPClasslessRoutesNotSuppressedByStaticDefault(t *testing.T) {
+	m := New()
+	m.frrConf = filepath.Join(t.TempDir(), "frr.conf")
+	os.WriteFile(m.frrConf, []byte(""), 0644)
+
+	fc := &FullConfig{
+		StaticRoutes: []*config.StaticRoute{
+			{Destination: "0.0.0.0/0", NextHops: []config.NextHopEntry{{Address: "172.16.50.1"}}},
+		},
+		DHCPRoutes: []DHCPRoute{
+			// DHCP default — suppressed by the static default.
+			{Gateway: "192.0.2.1", Interface: "ge-0-0-3"},
+			// Classless static route — must survive.
+			{Destination: "10.20.0.0/16", Gateway: "192.0.2.9", Interface: "ge-0-0-3"},
+		},
+	}
+	_ = m.ApplyFull(fc)
+	data, _ := os.ReadFile(m.frrConf)
+	got := string(data)
+
+	if !strings.Contains(got, "ip route 10.20.0.0/16 192.0.2.9 ge-0-0-3 200\n") {
+		t.Errorf("classless static route missing (must not be suppressed by static default), got:\n%s", got)
+	}
+	if strings.Contains(got, "ip route 0.0.0.0/0 192.0.2.1") {
+		t.Errorf("DHCP default should be suppressed by the static default, got:\n%s", got)
+	}
+	if !strings.Contains(got, "ip route 0.0.0.0/0 172.16.50.1") {
+		t.Errorf("static default route missing, got:\n%s", got)
+	}
+}
+
 func TestPerInstanceInet6StaticRoutes(t *testing.T) {
 	m := New()
 	m.frrConf = t.TempDir() + "/frr.conf"

--- a/pkg/frr/manager.go
+++ b/pkg/frr/manager.go
@@ -232,11 +232,16 @@ type InstanceConfig struct {
 	Inet6StaticRoutes []*config.StaticRoute
 }
 
-// DHCPRoute represents a default route learned via DHCP.
+// DHCPRoute represents a route learned via DHCP. An empty Destination
+// means the default route (0.0.0.0/0 or ::/0) — the option-3 gateway or
+// the option-121 0.0.0.0/0 entry. A non-empty Destination (e.g.
+// "10.0.0.0/8") is an RFC 3442 classless static route from option 121 /
+// legacy option 249.
 type DHCPRoute struct {
-	Gateway   string // "10.0.2.1" or "fe80::1"
-	Interface string // needed for IPv6 link-local gateways
-	IsIPv6    bool
+	Destination string // "" = default route; else a classless-route prefix
+	Gateway     string // "10.0.2.1" or "fe80::1"
+	Interface   string // needed for IPv6 link-local gateways
+	IsIPv6      bool
 }
 
 // FullConfig holds the complete routing config for a single FRR apply.


### PR DESCRIPTION
Closes #4118

## Problem

The DHCPv4 client extracted only the option-3 Router default gateway from
an ACK (`leaseFromACKv4`); a grep of `pkg/dhcp` for 121/249/classless
returned nothing. RFC 3442 option 121 (Classless Static Route) and the
legacy Microsoft option 249 (identical encoding) were silently dropped, so
a DHCP uplink in a provider network that hands out classless routes ended
up with missing or wrong routing. vSRX honors classless-static-routes.

## Fix

- **Parse** option 121 via the `insomniacslk/dhcp` `ClasslessStaticRoute()`
  accessor, falling back to a raw `GenericOptionCode(249)` +
  `Routes.FromBytes` decode for the legacy option (both share the RFC 3442
  `{mask-length, significant-prefix-octets, gateway}` encoding) — new
  `classlessStaticRoutes` helper in `pkg/dhcp/dhcp.go`.
- **RFC 3442 precedence**: when option 121/249 is present the client MUST
  ignore option 3 entirely. The `0.0.0.0/0` entry (if any) supplies
  `lease.Gateway` so every existing gateway consumer (FRR default route,
  neighbor resolution, ip-monitoring next-hop) keeps working; more-specific
  routes land on the new `Lease.ClasslessRoutes` field. Only when option
  121/249 is absent does the client fall back to option 3, as before.
- **Program** the classless routes through the same paths as the default
  route:
  - `collectDHCPRoutes` emits one `frr.DHCPRoute` per route (`DHCPRoute`
    grew a `Destination` field; `""` = default route, preserving all
    existing callers).
  - `renderDHCPDefaults` writes `ip route <dest> <gw> [<iface>] 200`; the
    static-default suppression now applies **only** to the default route —
    more-specific classless routes are never suppressed by a static default.
  - `applyMgmtVRFRoutes` installs classless routes into the management VRF
    table (999) via netlink alongside the default route.
- `leaseContentChanged` diffs `ClasslessRoutes`, so a change in the learned
  set on renew triggers a recompile and the routes are withdrawn /
  re-installed in lock-step with the lease.

## Tests (RED-on-revert)

Reverting the `leaseFromACKv4` parse to option-3-only fails
`TestLeaseFromACKv4ClasslessRoutesSupersedeOption3` /
`ClasslessOnlySpecificNoDefault` / `LegacyOption249` (gateway falls back to
the option-3 gateway `198.51.100.99`, `ClasslessRoutes` empty). Also
`TestClasslessStaticRoutesEncoding` pins the /24, /0, /32 decode, and
`TestDHCPClasslessRoutesNotSuppressedByStaticDefault` (frr) confirms a
classless route survives a configured static default.

`go test ./pkg/dhcp/... ./pkg/frr/... ./pkg/daemon/...` green; `go build
./...`, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
