### PR TITLE
ra: allow default-lifetime 0 — advertise 'not a default router' (RFC 4861 §6.2.1) (#4119)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -32640,3 +32640,30 @@ top.
     pkg/dhcp/classless_routes_test.go, pkg/frr/manager.go,
     pkg/frr/config_render.go, pkg/frr/frr_test.go,
     pkg/daemon/daemon_flow.go, pkg/dhcp/README.md, _Log.md
+- **Timestamp**: 2026-07-04
+  - **Action**: #4119 — allow `router-advertisement default-lifetime 0`
+    (RFC 4861 §6.2.1 "not a default router"). Verified at HEAD: schema
+    `ValidateInteger(1, 65535)` rejected 0 at commit; `types_routing.go`
+    `DefaultLifetime int` doc said "0 = default (1800)"; and buildRA /
+    Status / CLI show all coerced `lifetime <= 0` back to 1800 — so an
+    explicit 0 could never reach the wire and xpf always hijacked host
+    default-router selection on multi-router LANs. Fix: lower the schema
+    floor to `ValidateInteger(0, 65535)` (upper 16-bit #3895 bound kept);
+    add `RAInterfaceConfig.DefaultLifetimeSet` to separate an explicit
+    value (incl. 0) from an unset leaf; the compiler sets it only when
+    default-lifetime is configured; buildRA / Status / CLI show default to
+    1800 ONLY when the flag is false; configEqual compares the flag so an
+    unset→"0" edit restarts the sender. Dependent options (RDNSS, PREF64),
+    whose lifetime defaults to the router lifetime, use a separate
+    optLifetime that never drops below 1800 — a 0 Router Lifetime withdraws
+    only default-router duty, not the DNS server / NAT64 prefix; Prefix
+    Information options carry their own 30d/7d lifetimes so on-link SLAAC is
+    unaffected. RED-on-revert PROVEN: reverting the schema floor fails
+    TestSchema4119_DefaultLifetime_Accepts0; reverting the buildRA coercion
+    fails TestBuildRA_4119_ExplicitZero + _PrefixAndPref64StillAdvertised
+    (RouterLifetime springs back to 1800). go test ./pkg/config/...
+    ./pkg/ra/... ./pkg/cli/... green; go build ./..., vet, gofmt clean.
+  - **File(s)**: pkg/config/types_routing.go, pkg/config/schema_routing.go,
+    pkg/config/compiler_protocols.go, pkg/config/schema_validate_4119_test.go,
+    pkg/ra/sender.go, pkg/ra/ra.go, pkg/ra/sender_marshal_4119_test.go,
+    pkg/cli/cli_show_routing.go, docs/embedded-radvd.md, _Log.md

--- a/docs/embedded-radvd.md
+++ b/docs/embedded-radvd.md
@@ -32,7 +32,8 @@ type RAInterfaceConfig struct {
     ManagedConfig      bool        // M flag
     OtherStateful      bool        // O flag
     Preference         string      // "high", "medium", "low"
-    DefaultLifetime    int         // seconds (0 = default 1800)
+    DefaultLifetime    int         // RA Router Lifetime, seconds; meaningful only when DefaultLifetimeSet
+    DefaultLifetimeSet bool        // true when default-lifetime was explicitly configured (#4119)
     MaxAdvInterval     int         // seconds (0 = default 600)
     MinAdvInterval     int         // seconds (0 = default 200)
     Prefixes           []*RAPrefix
@@ -268,7 +269,7 @@ Map `RAInterfaceConfig` fields directly to `ndp.RouterAdvertisement`:
 | `ManagedConfig` | `ManagedConfiguration` |
 | `OtherStateful` | `OtherConfiguration` |
 | `Preference` | `RouterSelectionPreference` (map "high"→`ndp.High`, "low"→`ndp.Low`, default→`ndp.Medium`) |
-| `DefaultLifetime` | `RouterLifetime` (time.Duration) |
+| `DefaultLifetime` | `RouterLifetime` (time.Duration) — see the lifetime note below |
 | `Prefixes[].Prefix` | Option: `ndp.PrefixInformation{Prefix, PrefixLength}` |
 | `Prefixes[].OnLink` | `PrefixInformation.OnLink` |
 | `Prefixes[].Autonomous` | `PrefixInformation.AutonomousAddressConfiguration` |
@@ -280,6 +281,31 @@ Map `RAInterfaceConfig` fields directly to `ndp.RouterAdvertisement`:
 | (interface MAC) | Option: `ndp.LinkLayerAddress{Direction: ndp.Source, Addr: mac}` |
 
 Additionally, `CurrentHopLimit` should default to 64 (standard for Linux).
+
+**Router Lifetime and `default-lifetime 0` (#4119).** `RouterLifetime` comes
+from `DefaultLifetime`, but only when `DefaultLifetimeSet` is true. RFC 4861
+§6.2.1 defines a Router Lifetime of 0 as "this router is NOT a default router":
+a host removes it from its default-router list yet may still use the prefixes /
+PREF64 it advertises. An operator therefore needs to advertise prefixes / NAT64
+while declining default-router duty on a multi-router LAN. To support that:
+
+- The schema floor is 0 (`ValidateInteger(0, 65535)`), so `set protocols
+  router-advertisement interface <if> default-lifetime 0` commits.
+- The compiler sets `DefaultLifetimeSet=true` for any explicit value; an
+  absent leaf leaves it false.
+- `buildRA` marshals `RouterLifetime = DefaultLifetime` when the flag is set
+  (an explicit 0 stays 0) and defaults to 1800s only when it is unset. The old
+  `if lifetime <= 0 { lifetime = 1800 }` coercion conflated an explicit 0 with
+  "unset" and could never emit Router Lifetime 0.
+- The Prefix Information options carry their own valid / preferred lifetimes
+  (30d / 7d), so on-link prefixes and SLAAC keep working with a Router Lifetime
+  of 0. The RDNSS and PREF64 options — whose lifetimes DEFAULT to the router
+  lifetime — fall back to 1800s (never 0) when the router lifetime is an
+  explicit 0, so a 0 Router Lifetime withdraws only default-router duty, not the
+  DNS server or NAT64 prefix.
+- `configEqual` compares `DefaultLifetimeSet` so an unset → `default-lifetime 0`
+  edit (both have `DefaultLifetime == 0` but a different wire value) restarts
+  the sender.
 
 ### 3.6 Goodbye RA (Withdraw)
 

--- a/pkg/cli/cli_show_routing.go
+++ b/pkg/cli/cli_show_routing.go
@@ -675,9 +675,12 @@ func (c *CLI) showIPv6RouterAdvertisement() error {
 	for _, ra := range cfg.Protocols.RouterAdvertisement {
 		fmt.Printf("Interface: %s\n", ra.Interface)
 
-		lifetime := ra.DefaultLifetime
-		if lifetime <= 0 {
-			lifetime = 1800
+		// #4119: an explicit default-lifetime 0 ("not a default router", RFC
+		// 4861 §6.2.1) is shown as 0; only an unset leaf shows the 1800
+		// default.
+		lifetime := 1800
+		if ra.DefaultLifetimeSet {
+			lifetime = ra.DefaultLifetime
 		}
 		fmt.Printf("  Router lifetime:    %ds\n", lifetime)
 

--- a/pkg/config/compiler_protocols.go
+++ b/pkg/config/compiler_protocols.go
@@ -715,7 +715,13 @@ func compileRouterAdvertisement(node *Node, proto *ProtocolsConfig) error {
 			case "default-lifetime":
 				if v := nodeVal(prop); v != "" {
 					if n, err := strconv.Atoi(v); err == nil {
+						// #4119: record that default-lifetime was set
+						// explicitly so the sender preserves an explicit 0
+						// (RFC 4861 §6.2.1 "not a default router") instead of
+						// re-defaulting it to 1800. An absent leaf leaves
+						// DefaultLifetimeSet false → 1800 default.
 						ra.DefaultLifetime = n
+						ra.DefaultLifetimeSet = true
 					}
 				}
 			case "max-advertisement-interval":

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -439,9 +439,15 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 			// field maximum. A larger value silently wraps in the RA sender's
 			// ndp uint16(lifetime) (65536 -> 0 = "not a default router"), so
 			// hosts drop their default route.
-			"default-lifetime": {desc: "Router lifetime advertised to hosts (seconds)", args: 1, placeholder: "<seconds>",
-				valueType: ValueInteger, valueDesc: "router lifetime in seconds (RFC 4861 §4.2 16-bit)",
-				valueExamples: []string{"1800", "9000"}, validator: ValidateInteger(1, raRouterMaxLifetimeSeconds), children: nil},
+			// #4119: the floor is 0, not 1, because RFC 4861 §6.2.1 defines
+			// Router Lifetime 0 as "this router is NOT a default router" — a
+			// valid, deliberate advertisement (advertise prefixes/PREF64 but do
+			// not enter host default-router lists). The compiler records an
+			// explicit 0 via DefaultLifetimeSet so the sender does not coerce
+			// it back to 1800.
+			"default-lifetime": {desc: "Router lifetime advertised to hosts (seconds; 0 = not a default router)", args: 1, placeholder: "<seconds>",
+				valueType: ValueInteger, valueDesc: "router lifetime in seconds (RFC 4861 §4.2 16-bit; 0 = not a default router)",
+				valueExamples: []string{"0", "1800", "9000"}, validator: ValidateInteger(0, raRouterMaxLifetimeSeconds), children: nil},
 			// #2497: link-mtu is advertised verbatim via ndp.NewMTU. RFC 8200
 			// §5 sets the IPv6 minimum link MTU at 1280 bytes; a smaller value
 			// (1-1279) committed today reaches the wire and blackholes hosts

--- a/pkg/config/schema_validate_4119_test.go
+++ b/pkg/config/schema_validate_4119_test.go
@@ -1,0 +1,109 @@
+package config_test
+
+// Regression tests for #4119: `router-advertisement default-lifetime 0` was
+// commit-rejected (schema floor was 1) AND conflated with "unset" in the typed
+// config, so it could never reach the wire as RFC 4861 §6.2.1's Router
+// Lifetime 0 ("this router is NOT a default router"). The schema now accepts 0
+// and the compiler records DefaultLifetimeSet so an explicit value (including
+// 0) is distinguishable from an absent leaf.
+//
+// RED-on-revert: restore ValidateInteger(1, ...) and TestSchema4119_...Accepts0
+// fails at commit; drop DefaultLifetimeSet and the compiler cases below can no
+// longer tell an explicit 0 from unset.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// The RFC 4861 §6.2.1 "not a default router" value (0) must commit.
+func TestSchema4119_DefaultLifetime_Accepts0(t *testing.T) {
+	if err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            default-lifetime 0;
+        }
+    }
+}`); err != nil {
+		t.Fatalf("default-lifetime 0 must commit (RFC 4861 §6.2.1 not-a-default-router): %v", err)
+	}
+}
+
+// The #3895 upper 16-bit bound is unchanged: 65536 still rejected.
+func TestSchema4119_DefaultLifetime_StillRejectsOverlarge(t *testing.T) {
+	err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            default-lifetime 65536;
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("default-lifetime 65536 (> uint16 max) must still be rejected")
+	}
+	if !strings.Contains(err.Error(), "default-lifetime") {
+		t.Fatalf("error should reference default-lifetime: %v", err)
+	}
+}
+
+// compileRAFor builds a ConfigTree from flat set commands, compiles it, and
+// returns the RA config for ge-0-0-0.
+func compileRAFor(t *testing.T, cmds ...string) *config.RAInterfaceConfig {
+	t.Helper()
+	tree := &config.ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := config.ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := config.CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	for _, ra := range cfg.Protocols.RouterAdvertisement {
+		if ra.Interface == "ge-0-0-0" {
+			return ra
+		}
+	}
+	t.Fatal("no RA config compiled for ge-0-0-0")
+	return nil
+}
+
+// An explicit `default-lifetime 0` must compile to DefaultLifetime=0 with the
+// set-flag true — the crux of #4119 (0 is not "unset").
+func TestCompile4119_ExplicitZero(t *testing.T) {
+	ra := compileRAFor(t, "set protocols router-advertisement interface ge-0-0-0 default-lifetime 0")
+	if !ra.DefaultLifetimeSet {
+		t.Error("DefaultLifetimeSet must be true for an explicit default-lifetime 0")
+	}
+	if ra.DefaultLifetime != 0 {
+		t.Errorf("DefaultLifetime = %d, want 0", ra.DefaultLifetime)
+	}
+}
+
+// A non-zero explicit value is preserved with the flag set.
+func TestCompile4119_ExplicitValue(t *testing.T) {
+	ra := compileRAFor(t, "set protocols router-advertisement interface ge-0-0-0 default-lifetime 9000")
+	if !ra.DefaultLifetimeSet {
+		t.Error("DefaultLifetimeSet must be true for an explicit default-lifetime 9000")
+	}
+	if ra.DefaultLifetime != 9000 {
+		t.Errorf("DefaultLifetime = %d, want 9000", ra.DefaultLifetime)
+	}
+}
+
+// An absent default-lifetime leaves the flag false so readers apply the 1800
+// default. (A bare prefix keeps the RA interface present without setting the
+// lifetime.)
+func TestCompile4119_Unset(t *testing.T) {
+	ra := compileRAFor(t, "set protocols router-advertisement interface ge-0-0-0 prefix 2001:db8::/64")
+	if ra.DefaultLifetimeSet {
+		t.Error("DefaultLifetimeSet must be false when default-lifetime is absent")
+	}
+}

--- a/pkg/config/types_routing.go
+++ b/pkg/config/types_routing.go
@@ -314,19 +314,27 @@ type ISISInterface struct {
 
 // RAInterfaceConfig configures Router Advertisement on an interface.
 type RAInterfaceConfig struct {
-	Interface       string
-	ManagedConfig   bool   // managed-configuration (M flag)
-	OtherStateful   bool   // other-stateful-configuration (O flag)
-	Preference      string // "high", "medium", "low" (default: medium)
-	DefaultLifetime int    // seconds, 0 = default (1800)
-	MaxAdvInterval  int    // seconds, 0 = default (600)
-	MinAdvInterval  int    // seconds, 0 = default (200)
-	Prefixes        []*RAPrefix
-	DNSServers      []string // recursive DNS server addresses
-	NAT64Prefix     string   // PREF64 prefix (e.g. "64:ff9b::/96")
-	NAT64PrefixLife int      // PREF64 lifetime in seconds (0 = default)
-	LinkMTU         int      // advertised link MTU, 0 = omit
-	SourceLinkLocal string   // explicit link-local to use as RA source (overrides auto-selected)
+	Interface     string
+	ManagedConfig bool   // managed-configuration (M flag)
+	OtherStateful bool   // other-stateful-configuration (O flag)
+	Preference    string // "high", "medium", "low" (default: medium)
+	// DefaultLifetime is the RA header Router Lifetime in seconds (RFC 4861
+	// §4.2). It is meaningful ONLY when DefaultLifetimeSet is true; an
+	// EXPLICIT 0 means "not a default router" (RFC 4861 §6.2.1) and MUST be
+	// preserved through to the wire. When DefaultLifetimeSet is false the
+	// field is unset and readers default it to defaultRouterLifetime (1800).
+	// Do NOT treat 0 as "unset" — that conflation (#4119) made an explicit
+	// 0 indistinguishable from absent and coerced it back to 1800.
+	DefaultLifetime    int
+	DefaultLifetimeSet bool // true when default-lifetime was explicitly configured
+	MaxAdvInterval     int  // seconds, 0 = default (600)
+	MinAdvInterval     int  // seconds, 0 = default (200)
+	Prefixes           []*RAPrefix
+	DNSServers         []string // recursive DNS server addresses
+	NAT64Prefix        string   // PREF64 prefix (e.g. "64:ff9b::/96")
+	NAT64PrefixLife    int      // PREF64 lifetime in seconds (0 = default)
+	LinkMTU            int      // advertised link MTU, 0 = omit
+	SourceLinkLocal    string   // explicit link-local to use as RA source (overrides auto-selected)
 }
 
 // RAPrefix defines a prefix advertised via RA.

--- a/pkg/ra/ra.go
+++ b/pkg/ra/ra.go
@@ -739,10 +739,18 @@ func (m *Manager) Status() []SenderInfo {
 
 	var result []SenderInfo
 	for _, s := range m.senders {
+		// #4119: report the effective Router Lifetime. An explicit 0
+		// (DefaultLifetimeSet, "not a default router") is reported as 0, not
+		// coerced to 1800; only an unset default-lifetime shows the 1800
+		// default.
+		lifetime := defaultRouterLifetime
+		if s.cfg.DefaultLifetimeSet {
+			lifetime = s.cfg.DefaultLifetime
+		}
 		info := SenderInfo{
 			Interface:   s.cfg.Interface,
 			SrcAddr:     s.getSrcAddr().String(),
-			Lifetime:    s.cfg.DefaultLifetime,
+			Lifetime:    lifetime,
 			MaxInterval: s.cfg.MaxAdvInterval,
 			MinInterval: s.cfg.MinAdvInterval,
 			LinkMTU:     s.cfg.LinkMTU,
@@ -751,9 +759,6 @@ func (m *Manager) Status() []SenderInfo {
 			Preference:  s.cfg.Preference,
 			NAT64Prefix: s.cfg.NAT64Prefix,
 			State:       "active",
-		}
-		if info.Lifetime <= 0 {
-			info.Lifetime = defaultRouterLifetime
 		}
 		if info.MaxInterval <= 0 {
 			info.MaxInterval = defaultMaxAdvInterval
@@ -795,6 +800,11 @@ func configEqual(a, b *config.RAInterfaceConfig) bool {
 		a.OtherStateful != b.OtherStateful ||
 		a.Preference != b.Preference ||
 		a.DefaultLifetime != b.DefaultLifetime ||
+		// #4119: unset (→1800) and explicit-0 both have DefaultLifetime==0 but
+		// marshal a DIFFERENT Router Lifetime, so the set-flag is part of the
+		// identity — otherwise an unset→"default-lifetime 0" edit would not
+		// restart the sender and the wire would keep advertising 1800.
+		a.DefaultLifetimeSet != b.DefaultLifetimeSet ||
 		a.MaxAdvInterval != b.MaxAdvInterval ||
 		a.MinAdvInterval != b.MinAdvInterval ||
 		a.LinkMTU != b.LinkMTU ||

--- a/pkg/ra/sender.go
+++ b/pkg/ra/sender.go
@@ -668,9 +668,31 @@ func (s *sender) sendGoodbyeRA() bool {
 
 // buildRA constructs a Router Advertisement from the config.
 func (s *sender) buildRA() *ndp.RouterAdvertisement {
-	lifetime := s.cfg.DefaultLifetime
-	if lifetime <= 0 {
-		lifetime = defaultRouterLifetime
+	// #4119: an EXPLICIT default-lifetime (DefaultLifetimeSet) is honored
+	// verbatim, including 0 — RFC 4861 §6.2.1 Router Lifetime 0 means "this
+	// router is NOT a default router" (hosts drop it from their default-router
+	// list but may still use the prefixes/PREF64 it advertises). Only an UNSET
+	// default-lifetime falls back to defaultRouterLifetime (1800). The old
+	// `if lifetime <= 0` coercion made an explicit 0 indistinguishable from
+	// unset and forced it to 1800, so xpf could never advertise "not a default
+	// router" and hijacked host default-route selection on multi-router LANs.
+	lifetime := defaultRouterLifetime
+	if s.cfg.DefaultLifetimeSet {
+		lifetime = s.cfg.DefaultLifetime
+	}
+
+	// Dependent options (RDNSS, PREF64) that inherit a lifetime default MUST
+	// NOT collapse to 0 just because the ROUTER lifetime is an explicit 0:
+	// their independent lifetimes govern whether hosts keep using the DNS
+	// server / NAT64 prefix, and the whole point of Router Lifetime 0 is to
+	// keep advertising those while declining default-router duty. Fall back to
+	// the standard 1800s default for a dependent option whenever the resolved
+	// router lifetime is not positive (identical to the pre-#4119 value, which
+	// was always >= 1800). The Prefix Information options are unaffected — they
+	// carry their own valid/preferred lifetimes (30d/7d) already.
+	optLifetime := lifetime
+	if optLifetime <= 0 {
+		optLifetime = defaultRouterLifetime
 	}
 
 	ra := &ndp.RouterAdvertisement{
@@ -757,7 +779,7 @@ func (s *sender) buildRA() *ndp.RouterAdvertisement {
 		}
 		if len(servers) > 0 {
 			ra.Options = append(ra.Options, &ndp.RecursiveDNSServer{
-				Lifetime: time.Duration(lifetime) * time.Second,
+				Lifetime: time.Duration(optLifetime) * time.Second,
 				Servers:  servers,
 			})
 		}
@@ -769,7 +791,7 @@ func (s *sender) buildRA() *ndp.RouterAdvertisement {
 		if err == nil {
 			pref64Life := s.cfg.NAT64PrefixLife
 			if pref64Life <= 0 {
-				pref64Life = lifetime
+				pref64Life = optLifetime
 			}
 			ra.Options = append(ra.Options, &ndp.PREF64{
 				Lifetime: time.Duration(pref64Life) * time.Second,

--- a/pkg/ra/sender_marshal_4119_test.go
+++ b/pkg/ra/sender_marshal_4119_test.go
@@ -1,0 +1,107 @@
+package ra
+
+// Regression tests for #4119: an explicit `default-lifetime 0` must marshal as
+// RFC 4861 §6.2.1 Router Lifetime 0 ("this router is NOT a default router"),
+// while an UNSET default-lifetime still defaults to 1800 and a configured value
+// is passed through verbatim. Critically, a Router Lifetime of 0 withdraws only
+// default-router duty — the on-link prefixes and the PREF64 / RDNSS options
+// must still be advertised (with their own lifetimes), so a host can still use
+// xpf for SLAAC / NAT64 / DNS while picking another router as its default.
+//
+// RED-on-revert: restore buildRA's `if lifetime <= 0 { lifetime =
+// defaultRouterLifetime }` coercion and TestBuildRA_4119_ExplicitZero fails
+// (RouterLifetime springs back to 1800). Point the RDNSS/PREF64 default back at
+// the raw `lifetime` and TestBuildRA_4119_PrefixAndPref64StillAdvertised fails
+// (their lifetimes collapse to 0).
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mdlayher/ndp"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// An explicit default-lifetime 0 must reach the wire as RouterLifetime 0.
+func TestBuildRA_4119_ExplicitZero(t *testing.T) {
+	s := newTestSender3895(&config.RAInterfaceConfig{
+		Interface:          "trust0",
+		DefaultLifetime:    0,
+		DefaultLifetimeSet: true,
+	})
+	ra := s.buildRA()
+	if ra.RouterLifetime != 0 {
+		t.Fatalf("explicit default-lifetime 0 must marshal RouterLifetime 0; got %v", ra.RouterLifetime)
+	}
+}
+
+// An UNSET default-lifetime still defaults to 1800 (unchanged behavior).
+func TestBuildRA_4119_UnsetDefaults1800(t *testing.T) {
+	s := newTestSender3895(&config.RAInterfaceConfig{
+		Interface: "trust0",
+		// DefaultLifetimeSet omitted -> false (unset).
+	})
+	ra := s.buildRA()
+	if ra.RouterLifetime != 1800*time.Second {
+		t.Fatalf("unset default-lifetime must default to 1800s; got %v", ra.RouterLifetime)
+	}
+}
+
+// A configured non-zero value is passed through verbatim.
+func TestBuildRA_4119_ExplicitValue(t *testing.T) {
+	s := newTestSender3895(&config.RAInterfaceConfig{
+		Interface:          "trust0",
+		DefaultLifetime:    9000,
+		DefaultLifetimeSet: true,
+	})
+	ra := s.buildRA()
+	if ra.RouterLifetime != 9000*time.Second {
+		t.Fatalf("explicit default-lifetime 9000 must marshal 9000s; got %v", ra.RouterLifetime)
+	}
+}
+
+// With Router Lifetime 0 the prefix and PREF64 options must STILL be
+// advertised: the RA marshals, the on-link prefix and PREF64 options are
+// present, and the PREF64 lifetime does not collapse to 0 (it falls back to the
+// standard default so hosts keep the NAT64 prefix while xpf declines
+// default-router duty).
+func TestBuildRA_4119_PrefixAndPref64StillAdvertised(t *testing.T) {
+	s := newTestSender3895(&config.RAInterfaceConfig{
+		Interface:          "trust0",
+		DefaultLifetime:    0,
+		DefaultLifetimeSet: true,
+		NAT64Prefix:        "64:ff9b::/96",
+		Prefixes: []*config.RAPrefix{
+			{Prefix: "2001:db8::/64", OnLink: true, Autonomous: true},
+		},
+	})
+
+	ra := s.buildRA()
+	if ra.RouterLifetime != 0 {
+		t.Fatalf("RouterLifetime must be 0; got %v", ra.RouterLifetime)
+	}
+	if _, err := ndp.MarshalMessage(ra); err != nil {
+		t.Fatalf("RA with lifetime 0 must still marshal; got %v", err)
+	}
+
+	var foundPrefix bool
+	var pref64 *ndp.PREF64
+	for _, opt := range ra.Options {
+		switch o := opt.(type) {
+		case *ndp.PrefixInformation:
+			foundPrefix = true
+		case *ndp.PREF64:
+			pref64 = o
+		}
+	}
+	if !foundPrefix {
+		t.Error("on-link prefix must still be advertised when Router Lifetime is 0")
+	}
+	if pref64 == nil {
+		t.Fatal("PREF64 must still be advertised when Router Lifetime is 0")
+	}
+	if pref64.Lifetime == 0 {
+		t.Error("PREF64 lifetime must not collapse to 0 when the router lifetime is an explicit 0")
+	}
+}


### PR DESCRIPTION
Closes #4119

## Problem

`set protocols router-advertisement interface <if> default-lifetime 0` was
both commit-rejected and, even when it reached the sender, coerced back to
1800. An operator could therefore never advertise a Router Lifetime of 0 —
RFC 4861 §6.2.1's "this router is NOT a default router" — so xpf always
inserted itself into host default-router selection on a multi-router LAN even
when it was only meant to advertise on-link prefixes / PREF64. Junos accepts
`default-lifetime 0`.

Root cause was a three-way conflation of "unset" and "explicit 0":

- `pkg/config/schema_routing.go`: `ValidateInteger(1, 65535)` rejected 0 at
  commit.
- `pkg/config/types_routing.go`: `DefaultLifetime int` with "0 = default
  (1800)" — an explicit 0 was indistinguishable from absent.
- `pkg/ra/sender.go` buildRA / `pkg/ra/ra.go` Status /
  `pkg/cli/cli_show_routing.go`: every reader coerced `lifetime <= 0` to 1800.

## Fix

- Lower the schema floor to `ValidateInteger(0, 65535)`; 0 is a valid,
  deliberate advertisement. The upper 16-bit bound (#3895) is kept, so 65536
  is still rejected.
- Add `RAInterfaceConfig.DefaultLifetimeSet` to separate an explicit value
  (including 0) from an unset leaf. The compiler sets it only when
  `default-lifetime` is configured.
- buildRA / Status / the CLI `show` now default to 1800 ONLY when
  `DefaultLifetimeSet` is false; an explicit 0 marshals `RouterLifetime:0`.
- `configEqual` compares `DefaultLifetimeSet` so an unset → `default-lifetime
  0` edit (both have `DefaultLifetime == 0` but differ on the wire) restarts
  the sender.
- Dependent options that inherit a lifetime default (RDNSS, PREF64) use a
  separate `optLifetime` that never drops below 1800: a Router Lifetime of 0
  withdraws default-router duty, it must not silently withdraw the DNS server
  / NAT64 prefix. Prefix Information options are unaffected — they already
  carry their own 30d/7d lifetimes, so on-link prefixes remain advertised with
  a Router Lifetime of 0.

## Tests (RED-on-revert)

- `pkg/config/schema_validate_4119_test.go`: `default-lifetime 0` commits;
  65536 still rejected; the compiler records `DefaultLifetimeSet` true for an
  explicit 0 / value and false when absent.
- `pkg/ra/sender_marshal_4119_test.go`: explicit-0 → `RouterLifetime` 0;
  unset → 1800; value → value; and with lifetime 0 the on-link prefix and
  PREF64 options are still advertised (PREF64 lifetime does not collapse to 0).

RED-on-revert proven locally: restoring `ValidateInteger(1, ...)` fails
`TestSchema4119_DefaultLifetime_Accepts0`; restoring buildRA's
`if lifetime <= 0 { lifetime = 1800 }` coercion fails
`TestBuildRA_4119_ExplicitZero` and
`TestBuildRA_4119_PrefixAndPref64StillAdvertised`.

`go test ./pkg/config/... ./pkg/ra/... ./pkg/cli/...` green; `go build ./...`,
`go vet`, `gofmt` clean. Docs updated in `docs/embedded-radvd.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
