### PR TITLE
screen: per-destination ICMP/UDP flood + SYN per-dst before cookie mint (#4112)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -32611,3 +32611,41 @@ top.
     vet, gofmt clean.
   - **File(s)**: pkg/grpcapi/server.go,
     pkg/grpcapi/server_fabric_allowlist_4122_test.go, _Log.md
+
+- **Timestamp**: 2026-07-04
+  **Action**: #4112 — screen ICMP/UDP flood per-DESTINATION (F18) + SYN per-dst
+    ordering (F19), userspace-dp Rust. F18: `icmp flood`/`udp flood threshold`
+    were enforced per-ZONE AGGREGATE (`icmp_counters`/`udp_counters` keyed by
+    zone name), but Junos measures per DESTINATION IP (UDP also per dest PORT).
+    Two legit high-volume services in one zone summed into one counter →
+    false-drop; an attacker spreading a modest flood across destinations evaded
+    the operator's per-destination expectation. Fix: PRIMARY per-destination
+    count-min sketch reusing the #3315 `SynRateSketch` substrate — new
+    `icmp_dst_sketch` (keyed on dst_ip via `increment`) + `udp_dst_sketch` (keyed
+    on dst_ip+dst_port via new `increment_ip_port`), allocated per zone that
+    configures the threshold and freed when removed. The per-zone aggregate is
+    retained as a coarse SECONDARY zone-saturation ceiling at
+    `SECONDARY_FLOOD_CEILING_MULT (8) × threshold` (counts only
+    per-destination-admitted packets, so it bounds the admitted zone-wide rate —
+    an operator relying on the zone-wide cap still gets it). Shared
+    `icmp_flood_drop`/`udp_flood_drop` helpers used by BOTH the flow-present
+    (`check_packet_with_zone_id`) and flowless (`check_flowless_screens`,
+    non-first fragment / non-query ICMP) paths so a fragment flood cannot evade
+    the per-dest cap (flowless UDP has no port → degrades to per-dest-IP). F19:
+    the SYN per-DESTINATION sketch sat AFTER the aggregate `over_attack`
+    early-return, so a real-client flood over `attack-threshold` took the
+    cookie-mint branch on every SYN and the per-dest sketch was NEVER reached —
+    `destination-threshold` (shield a single victim even from validated clients)
+    was defeated in exactly the high-load regime it exists for. Fix: evaluate the
+    per-dst sketch BEFORE the over_attack early-return (aggregate still ALWAYS
+    counts first via `increment_and_classify`, so its cookie-activation
+    side-effect is never skipped). RED-on-revert PROVEN for both: F19 temp-revert
+    (gate per-dst on !over_attack) → 3rd SYN returns SynCookieChallenge not
+    Drop; F18 temp-revert (aggregate-only at threshold T) → distinct
+    destinations / dest-ports summed into a false Drop. FULL cargo test --release
+    green (3495 lib + 16 + 1 + 46 + 8, 0 failed); go build ./... green; rustfmt
+    clean on added lines (pre-existing whole-crate drift left untouched). Not an
+    HA/session-sync path (per-packet ingress screen) — no test-failover needed.
+  **File(s)**: userspace-dp/src/screen/mod.rs,
+    userspace-dp/src/screen/syn_rate.rs, userspace-dp/src/screen/tests.rs,
+    docs/syn-cookie-flood-protection.md, _Log.md

--- a/docs/syn-cookie-flood-protection.md
+++ b/docs/syn-cookie-flood-protection.md
@@ -67,6 +67,45 @@ microsecond time-window value. Feeding 5000 here would be read as a count and
 clamped to the dataplane cap (1023, `maxScanSweepThreshold`) — effectively never
 firing.
 
+### ICMP / UDP flood are measured PER DESTINATION (#4112)
+
+Junos `icmp flood threshold N` caps the ICMP rate to a single DESTINATION IP, and
+`udp flood threshold N` caps the UDP rate to a destination IP AND port; traffic to
+different destinations counts INDEPENDENTLY. Before #4112 the Rust engine keyed
+the ICMP/UDP flood counters by ZONE NAME only (`icmp_counters` / `udp_counters`,
+`screen/mod.rs`), a per-zone AGGREGATE. That both false-dropped legitimate traffic
+(two high-volume services in one zone — a DNS resolver + VoIP — SUM into one
+counter and cross the threshold though no single destination is flooded) and let
+an attacker spread a modest flood across many destinations while no single victim
+was rate-limited as the operator expected.
+
+#4112 gives ICMP/UDP flood the same per-destination substrate the SYN-flood path
+grew in #3315 — the no-eviction count-min `SynRateSketch` (`syn_rate.rs`), reused
+via `SynRateSketch::increment` (ICMP, keyed on `dst_ip`) and `increment_ip_port`
+(UDP, keyed on `dst_ip` + `dst_port`):
+
+- **PRIMARY per-destination cap** — the configured `threshold` is enforced per
+  destination (ICMP) / per destination IP+port (UDP). A single flooded
+  destination is still capped; distinct destinations no longer sum. The sketch is
+  allocated per zone that configures the threshold (`icmp_dst_sketch` /
+  `udp_dst_sketch`, `ROWS*DST_COLS*16 = 64 KiB` each, mirroring the #3315 per-dest
+  sizing) and freed when the threshold is removed.
+- **SECONDARY per-zone ceiling** — the existing `icmp_counters` / `udp_counters`
+  aggregate is retained as a coarse zone-saturation backstop at
+  `SECONDARY_FLOOD_CEILING_MULT × threshold` (currently 8×). It counts only
+  per-destination-ADMITTED packets (the per-destination check short-circuits
+  first), so it bounds the admitted zone-wide rate and still caps a flood spread
+  thin across many under-threshold destinations — an operator relying on the
+  zone-wide cap still gets it. There is no separate Junos knob for this ceiling,
+  so it is derived from the single configured per-destination threshold.
+
+Both the flow-present (`check_packet_with_zone_id`) and the flowless
+(`check_flowless_screens`, non-first fragment / non-query ICMP) paths share the
+`icmp_flood_drop` / `udp_flood_drop` helpers so a fragment-based flood cannot
+evade the per-destination cap. A flowless non-first fragment carries no L4 port,
+so the UDP cap degrades to per-destination-IP there (the best available for a
+fragment).
+
 ### SYN-flood sub-thresholds: source / destination / alarm / timeout (#3315)
 
 The Go compiler parses the full Junos `tcp syn-flood` shape (alarm/attack/
@@ -116,10 +155,20 @@ screen runtime:
 Enforcement order (`screen/mod.rs`, inside the initial-SYN gate, after the
 validated-cookie bypass): (1) the aggregate `attack-threshold` (+
 `alarm-threshold`) ALWAYS counts via a single `RateCounter::increment_and_classify`
-so its cookie-activation side-effect can never be skipped — `attack` keeps the
-existing cookie-mint / Drop behaviour; (2) per-destination cap; (3) per-source
-cap (gated). The aggregate is authoritative — a per-IP cap only ADDS drops for
-IPs under the aggregate radar. A per-IP trip hard-drops with the existing
+so its cookie-activation side-effect can never be skipped — it does NOT return
+here; (2) the per-destination cap is evaluated BEFORE the aggregate over-attack
+verdict (#4112 F19), so a per-destination trip HARD-DROPS the flooded victim even
+while the zone is over `attack-threshold` and minting cookies for validated
+clients; (3) the aggregate over-attack verdict then mints the SYN-cookie
+challenge (or Drops when cookies are disabled) for the case where the per-dest
+cap did not trip — `attack` keeps its existing cookie-mint / Drop behaviour;
+(4) per-source cap (gated, skipped while cookie-active). Before #4112 the
+per-destination sketch sat AFTER the over-attack early-return, so a real-client
+flood that pushed the zone over `attack-threshold` took the cookie-mint branch on
+every SYN and the per-destination sketch was NEVER reached — the
+`destination-threshold` that exists to shield a single victim even from validated
+clients was defeated in exactly the high-load regime it is configured for (a
+code-vs-comment contradiction). A per-IP trip hard-drops with the existing
 `syn-flood` reason id (no Go gRPC/CLI change); per-source vs per-destination is
 distinguished by separate per-worker counters.
 

--- a/userspace-dp/src/screen/mod.rs
+++ b/userspace-dp/src/screen/mod.rs
@@ -22,8 +22,11 @@
 //! - ICMP fragment
 //! - IP source route — IPv4 LSRR/SSRR options and IPv6 Routing Header
 //!   (source-route routing type), not every IHL>5 packet (#2973)
-//! - Rate limiting (ICMP, UDP flood)
-//! - SYN flood (per-zone rate)
+//! - Rate limiting (ICMP, UDP flood) — per-DESTINATION cap (Junos parity:
+//!   ICMP per destination IP, UDP per destination IP+port; #4112) with the
+//!   per-zone aggregate retained as a coarser secondary zone-saturation ceiling
+//! - SYN flood (per-zone aggregate + per-source/per-destination sub-caps, #3315;
+//!   per-destination evaluated before the aggregate cookie/Drop verdict, #4112)
 //!
 //! ## Missing-screen-profile signal (#3082)
 //!
@@ -61,6 +64,7 @@
 //! - `tests`         — relocated screen_tests.rs (loaded via #[path]).
 
 use rustc_hash::FxHashMap;
+use std::net::IpAddr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 mod extract;
@@ -153,10 +157,23 @@ use syncookie::SYN_COOKIE_STANDBY_ACK_VALIDATION_RATE_LIMIT_PER_SEC;
 /// Per-zone screen state with mutable rate counters and advanced trackers.
 pub(crate) struct ScreenState {
     profiles: FxHashMap<String, ScreenProfile>, // zone_name -> profile
-    // Per-zone rate counters
+    // Per-zone AGGREGATE rate counters. #4112: for ICMP/UDP these are now the
+    // SECONDARY zone-saturation ceiling (checked at `SECONDARY_FLOOD_CEILING_MULT
+    // × threshold`) above the PRIMARY per-destination sketches below; Junos
+    // measures the ICMP/UDP flood rate per destination, not per zone.
     icmp_counters: FxHashMap<String, RateCounter>,
     udp_counters: FxHashMap<String, RateCounter>,
     syn_counters: FxHashMap<String, RateCounter>,
+    /// #4112: per-zone per-DESTINATION-IP ICMP flood sketch (Junos `icmp flood
+    /// threshold` is per destination). Present (Some) only for zones whose
+    /// `icmp_flood_threshold > 0`; reuses the #3315 count-min `SynRateSketch`
+    /// substrate. PRIMARY cap — checked before the per-zone aggregate ceiling.
+    icmp_dst_sketch: FxHashMap<String, SynRateSketch>,
+    /// #4112: per-zone per-DESTINATION (IP + PORT) UDP flood sketch (Junos `udp
+    /// flood threshold` is per destination IP AND port). Present only for zones
+    /// whose `udp_flood_threshold > 0`; reuses the #3315 sketch via
+    /// `increment_ip_port`. PRIMARY cap — checked before the per-zone aggregate.
+    udp_dst_sketch: FxHashMap<String, SynRateSketch>,
     syn_cookie_active_until_secs: FxHashMap<String, u64>,
     syn_cookie_standby_ack_counters: FxHashMap<String, RateCounter>,
     syn_cookie_codec: Option<SynCookieCodec>,
@@ -241,6 +258,21 @@ pub(crate) struct ScreenState {
 /// #3082: at most one missing-screen-profile WARN per zone per second.
 const MISSING_PROFILE_WARN_RATE_LIMIT_PER_SEC: u32 = 1;
 
+/// #4112: multiplier for the per-zone ICMP/UDP flood aggregate SECONDARY
+/// ceiling. Junos measures the ICMP/UDP flood rate PER DESTINATION, so the
+/// per-destination sketch (threshold `T`) is the PRIMARY cap. The per-zone
+/// aggregate `RateCounter` is retained as a coarse zone-saturation backstop that
+/// fires at `SECONDARY_FLOOD_CEILING_MULT × T`: a zone with up to this many
+/// simultaneously-hot legitimate destinations (each under the per-destination
+/// cap) is NOT false-dropped (the #4112 F18 fix — two legit high-volume services
+/// no longer SUM into one counter), while a flood spread thin across many
+/// destinations is still bounded zone-wide (an operator relying on the zone-wide
+/// cap still gets it). The aggregate counts only per-destination-ADMITTED
+/// packets (the per-destination check short-circuits first), so it bounds the
+/// admitted zone-wide rate. There is no separate Junos knob for this ceiling, so
+/// it is derived from the single configured per-destination threshold.
+const SECONDARY_FLOOD_CEILING_MULT: u32 = 8;
+
 impl ScreenState {
     pub fn new() -> Self {
         Self {
@@ -248,6 +280,8 @@ impl ScreenState {
             icmp_counters: FxHashMap::default(),
             udp_counters: FxHashMap::default(),
             syn_counters: FxHashMap::default(),
+            icmp_dst_sketch: FxHashMap::default(),
+            udp_dst_sketch: FxHashMap::default(),
             syn_cookie_active_until_secs: FxHashMap::default(),
             syn_cookie_standby_ack_counters: FxHashMap::default(),
             syn_cookie_codec: None,
@@ -325,6 +359,13 @@ impl ScreenState {
         self.icmp_counters.retain(|k, _| profiles.contains_key(k));
         self.udp_counters.retain(|k, _| profiles.contains_key(k));
         self.syn_counters.retain(|k, _| profiles.contains_key(k));
+        // #4112: drop the per-destination ICMP/UDP flood sketches for zones that
+        // lost the corresponding threshold (memory tracks live config), mirroring
+        // the #3315 SYN sketches below.
+        self.icmp_dst_sketch
+            .retain(|k, _| profiles.get(k).is_some_and(|p| p.icmp_flood_threshold > 0));
+        self.udp_dst_sketch
+            .retain(|k, _| profiles.get(k).is_some_and(|p| p.udp_flood_threshold > 0));
         self.syn_cookie_active_until_secs
             .retain(|k, _| profiles.contains_key(k));
         self.syn_cookie_standby_ack_counters
@@ -340,6 +381,20 @@ impl ScreenState {
             self.icmp_counters.entry(zone.clone()).or_default();
             self.udp_counters.entry(zone.clone()).or_default();
             self.syn_counters.entry(zone.clone()).or_default();
+            // #4112: allocate the per-destination ICMP/UDP flood sketches ONCE
+            // per zone that configures the threshold (`or_insert_with` preserves
+            // in-flight counters across an unrelated profile edit; the
+            // per-increment threshold means a threshold change needs no realloc).
+            if profiles[zone].icmp_flood_threshold > 0 {
+                self.icmp_dst_sketch
+                    .entry(zone.clone())
+                    .or_insert_with(SynRateSketch::for_dst);
+            }
+            if profiles[zone].udp_flood_threshold > 0 {
+                self.udp_dst_sketch
+                    .entry(zone.clone())
+                    .or_insert_with(SynRateSketch::for_dst);
+            }
             self.syn_cookie_active_until_secs
                 .entry(zone.clone())
                 .or_insert(0);
@@ -511,6 +566,67 @@ impl ScreenState {
             .unwrap_or(true)
     }
 
+    /// #4112 F18: ICMP flood admission. Junos measures the ICMP flood rate PER
+    /// DESTINATION IP, not per zone. (1) the per-destination count-min sketch is
+    /// the PRIMARY cap at the configured `threshold`; (2) the per-zone aggregate
+    /// counter is a coarse SECONDARY zone-saturation ceiling at
+    /// `SECONDARY_FLOOD_CEILING_MULT × threshold`. The per-destination check
+    /// short-circuits, so the aggregate counts only per-destination-admitted
+    /// packets (it bounds the admitted zone-wide rate). Returns true when the
+    /// packet must be dropped as an ICMP flood. Shared by the flow-present and
+    /// flowless (`check_flowless_screens`) paths so both enforce identically.
+    fn icmp_flood_drop(
+        &mut self,
+        zone: &str,
+        dst_ip: &IpAddr,
+        threshold: u32,
+        now_secs: u64,
+    ) -> bool {
+        // (1) per-DESTINATION cap — PRIMARY (Junos parity).
+        if let Some(sketch) = self.icmp_dst_sketch.get_mut(zone)
+            && sketch.increment(dst_ip, now_secs, threshold)
+        {
+            return true;
+        }
+        // (2) per-zone aggregate — SECONDARY ceiling.
+        if let Some(counter) = self.icmp_counters.get_mut(zone) {
+            return counter.increment(
+                now_secs,
+                threshold.saturating_mul(SECONDARY_FLOOD_CEILING_MULT),
+            );
+        }
+        false
+    }
+
+    /// #4112 F18: UDP flood admission — like `icmp_flood_drop`, but the PRIMARY
+    /// per-destination cap keys on `(dst_ip, dst_port)` (Junos `udp flood
+    /// threshold` caps the rate to a destination IP AND port). On the flowless
+    /// path a non-first fragment carries no L4 port, so `dst_port` is 0 there and
+    /// the cap degrades to per-destination-IP (the best available for a fragment).
+    fn udp_flood_drop(
+        &mut self,
+        zone: &str,
+        dst_ip: &IpAddr,
+        dst_port: u16,
+        threshold: u32,
+        now_secs: u64,
+    ) -> bool {
+        // (1) per-DESTINATION (IP + PORT) cap — PRIMARY (Junos parity).
+        if let Some(sketch) = self.udp_dst_sketch.get_mut(zone)
+            && sketch.increment_ip_port(dst_ip, dst_port, now_secs, threshold)
+        {
+            return true;
+        }
+        // (2) per-zone aggregate — SECONDARY ceiling.
+        if let Some(counter) = self.udp_counters.get_mut(zone) {
+            return counter.increment(
+                now_secs,
+                threshold.saturating_mul(SECONDARY_FLOOD_CEILING_MULT),
+            );
+        }
+        false
+    }
+
     /// Returns true if any zone has a screen profile configured.
     pub fn has_profiles(&self) -> bool {
         !self.profiles.is_empty()
@@ -606,35 +722,47 @@ impl ScreenState {
 
         let mut syn_cookie_bypassed = false;
 
-        // ICMP flood
+        // ICMP flood — per-DESTINATION cap (PRIMARY) + per-zone aggregate ceiling
+        // (SECONDARY). Junos measures this rate per destination IP (#4112 F18).
         if icmp_flood_threshold > 0
             && (pkt.protocol == PROTO_ICMP || pkt.protocol == PROTO_ICMPV6)
+            && self.icmp_flood_drop(zone, &pkt.dst_ip, icmp_flood_threshold, now_secs)
         {
-            if let Some(counter) = self.icmp_counters.get_mut(zone) {
-                if counter.increment(now_secs, icmp_flood_threshold) {
-                    return ScreenVerdict::Drop("icmp-flood");
-                }
-            }
+            return ScreenVerdict::Drop("icmp-flood");
         }
 
-        // UDP flood
-        if udp_flood_threshold > 0 && pkt.protocol == PROTO_UDP {
-            if let Some(counter) = self.udp_counters.get_mut(zone) {
-                if counter.increment(now_secs, udp_flood_threshold) {
-                    return ScreenVerdict::Drop("udp-flood");
-                }
-            }
+        // UDP flood — per-DESTINATION (IP + PORT) cap (PRIMARY) + per-zone
+        // aggregate ceiling (SECONDARY). Junos caps per destination IP AND port
+        // (#4112 F18).
+        if udp_flood_threshold > 0
+            && pkt.protocol == PROTO_UDP
+            && self.udp_flood_drop(
+                zone,
+                &pkt.dst_ip,
+                pkt.dst_port,
+                udp_flood_threshold,
+                now_secs,
+            )
+        {
+            return ScreenVerdict::Drop("udp-flood");
         }
 
         // SYN flood: count TCP SYN (without ACK) per zone.
         //
-        // #3315 enforcement order (aggregate authoritative, per-IP additive):
-        //   1. aggregate `attack-threshold` (+ `alarm-threshold`) — UNCHANGED
-        //      cookie-mint / Drop behaviour; the aggregate ALWAYS counts so its
-        //      cookie-activation side-effect can never be skipped.
-        //   2. per-DESTINATION cap (primary, spoof-resistant) — runs even when
-        //      the zone is cookie-active.
-        //   3. per-SOURCE cap (secondary) — SKIPPED while the zone is cookie-
+        // #3315 + #4112 F19 enforcement order (aggregate counts first, per-dst
+        // authoritative over the aggregate cookie/Drop verdict, per-src additive):
+        //   1. aggregate `attack-threshold` (+ `alarm-threshold`) — ALWAYS counts
+        //      via a SINGLE window advance so its cookie-activation side-effect
+        //      can never be skipped. It does NOT return here.
+        //   2. per-DESTINATION cap (primary, spoof-resistant) — evaluated BEFORE
+        //      the aggregate over-attack early-return (#4112 F19), so a per-dst
+        //      trip HARD-DROPS the flooded victim even while the zone is over
+        //      attack-threshold and minting cookies for validated clients. Runs
+        //      even when cookie-active.
+        //   3. aggregate over-attack verdict — mint a SYN-cookie challenge (or
+        //      Drop when cookies are disabled); UNCHANGED for the case where the
+        //      per-dst cap did not trip.
+        //   4. per-SOURCE cap (secondary) — SKIPPED while the zone is cookie-
         //      active (the cookie governs the spoofed-flood regime; per-source is
         //      spoof-defeated there and the sketch would over-throttle).
         // A validated returning SYN-cookie client bypasses ALL of the above.
@@ -673,6 +801,26 @@ impl ScreenState {
                             )
                         })
                         .unwrap_or((false, false));
+                    // (2) per-DESTINATION cap — PRIMARY. Evaluated BEFORE the
+                    // aggregate over-attack early-return (#4112 F19) so a
+                    // per-destination trip HARD-DROPS the flooded victim even
+                    // while the zone is over attack-threshold and minting cookies
+                    // for validated clients. destination-threshold's purpose
+                    // (shield a single over-threshold backend even from
+                    // cookie-completing clients) was otherwise defeated in exactly
+                    // the high-load regime it is configured for: `if over_attack`
+                    // returned the cookie challenge before the per-dst sketch at
+                    // the old site (2) was ever reached. The aggregate counter
+                    // above ALWAYS counts first (its cookie-activation side-effect
+                    // is never skipped); a per-dst trip never flips zone cookie
+                    // state. Runs even when the zone is cookie-active.
+                    if syn_dst_threshold > 0
+                        && let Some(sketch) = self.syn_dst_sketch.get_mut(zone)
+                        && sketch.increment(&pkt.dst_ip, now_secs, syn_dst_threshold)
+                    {
+                        self.syn_flood_dst_drops = self.syn_flood_dst_drops.wrapping_add(1);
+                        return ScreenVerdict::Drop("syn-flood");
+                    }
                     if over_attack {
                         if syn_cookie {
                             if let Some(active_until) =
@@ -715,16 +863,6 @@ impl ScreenState {
                         *last = now_secs;
                         self.syn_alarm_pending = true;
                         self.syn_flood_alarm_events = self.syn_flood_alarm_events.wrapping_add(1);
-                    }
-                    // (2) per-DESTINATION cap — PRIMARY, always runs (even when
-                    // cookie-active). A trip HARD-DROPS and never flips zone
-                    // cookie state.
-                    if syn_dst_threshold > 0
-                        && let Some(sketch) = self.syn_dst_sketch.get_mut(zone)
-                        && sketch.increment(&pkt.dst_ip, now_secs, syn_dst_threshold)
-                    {
-                        self.syn_flood_dst_drops = self.syn_flood_dst_drops.wrapping_add(1);
-                        return ScreenVerdict::Drop("syn-flood");
                     }
                     // (3) per-SOURCE cap — SECONDARY, skipped while the zone is
                     // SYN-cookie active (D3). The cookie-active window is the
@@ -846,20 +984,28 @@ impl ScreenState {
         let udp_flood_threshold = profile.udp_flood_threshold;
         // `profile` borrow ends here (NLL): no further reads of `self.profiles`.
 
-        // ICMP flood
+        // ICMP flood — per-DESTINATION cap (PRIMARY) + per-zone aggregate ceiling
+        // (SECONDARY), same as the flow-present path (#4112 F18). Keeps a
+        // fragment-based flood from evading the per-destination cap.
         if icmp_flood_threshold > 0
             && (pkt.protocol == PROTO_ICMP || pkt.protocol == PROTO_ICMPV6)
-            && let Some(counter) = self.icmp_counters.get_mut(zone)
-            && counter.increment(now_secs, icmp_flood_threshold)
+            && self.icmp_flood_drop(zone, &pkt.dst_ip, icmp_flood_threshold, now_secs)
         {
             return ScreenVerdict::Drop("icmp-flood");
         }
 
-        // UDP flood
+        // UDP flood — per-DESTINATION cap (PRIMARY) + per-zone aggregate ceiling
+        // (SECONDARY). A flowless non-first fragment has no L4 port, so `dst_port`
+        // is 0 here and the cap degrades to per-destination-IP (#4112 F18).
         if udp_flood_threshold > 0
             && pkt.protocol == PROTO_UDP
-            && let Some(counter) = self.udp_counters.get_mut(zone)
-            && counter.increment(now_secs, udp_flood_threshold)
+            && self.udp_flood_drop(
+                zone,
+                &pkt.dst_ip,
+                pkt.dst_port,
+                udp_flood_threshold,
+                now_secs,
+            )
         {
             return ScreenVerdict::Drop("udp-flood");
         }

--- a/userspace-dp/src/screen/syn_rate.rs
+++ b/userspace-dp/src/screen/syn_rate.rs
@@ -1,4 +1,5 @@
-//! Per-zone SYN-flood per-source / per-destination rate limiter (#3315).
+//! Per-zone per-key flood rate limiter — a count-min sketch of `RateCounter`s
+//! (#3315 SYN-flood per-source/per-destination; #4112 ICMP/UDP per-destination).
 //!
 //! `source-threshold` and `destination-threshold` cap the SYN/s rate for a
 //! single source IP or destination IP, distinct from the aggregate per-zone
@@ -6,6 +7,13 @@
 //! destination (a victim, possibly flooded from spoofed sources) can be driven
 //! hard while the zone aggregate stays under budget, and `destination-threshold`
 //! exists precisely to cap that.
+//!
+//! The same substrate backs the per-destination ICMP/UDP flood caps (#4112):
+//! Junos measures `icmp flood` / `udp flood threshold` PER DESTINATION (UDP
+//! additionally per destination PORT), not per zone aggregate. `increment` keys
+//! on the destination IP (ICMP); `increment_ip_port` mixes the destination port
+//! in (UDP). The per-zone aggregate `RateCounter` is retained as a coarser
+//! SECONDARY ceiling above these per-destination caps.
 //!
 //! ## Substrate — count-min sketch of `RateCounter`s, NO eviction
 //!
@@ -165,6 +173,43 @@ impl SynRateSketch {
         let mut over_all = true;
         for row in 0..ROWS {
             let idx = self.cell_index(row, ip);
+            let over = self.rows[row][idx].increment(now_secs, threshold);
+            over_all &= over;
+        }
+        over_all
+    }
+
+    /// Cell index for `(ip, port)` in row `row`: the seeded per-row hash of the
+    /// address WITH the L4 destination port mixed in. Keys the per-DESTINATION
+    /// UDP flood sketch on `(dst_ip, dst_port)` — matching Junos `udp flood
+    /// threshold`, which caps the rate to a destination IP AND port (#4112).
+    #[inline]
+    fn cell_index_ip_port(&self, row: usize, ip: &IpAddr, port: u16) -> usize {
+        let mut h = FxHasher::default();
+        h.write_u64(ROW_SEEDS[row]);
+        match ip {
+            IpAddr::V4(a) => h.write(&a.octets()),
+            IpAddr::V6(a) => h.write(&a.octets()),
+        }
+        h.write_u16(port);
+        (h.finish() as usize) & self.mask
+    }
+
+    /// Count one packet for `(ip, port)` and report whether it is over
+    /// `threshold` in the trailing 1-second window. Mirrors `increment` but keys
+    /// on the L4 destination port too — the UDP per-destination-port flood cap
+    /// (#4112 F18). Every row cell is still incremented (non-short-circuiting
+    /// AND), so the count-min side effect happens in all rows.
+    pub(super) fn increment_ip_port(
+        &mut self,
+        ip: &IpAddr,
+        port: u16,
+        now_secs: u64,
+        threshold: u32,
+    ) -> bool {
+        let mut over_all = true;
+        for row in 0..ROWS {
+            let idx = self.cell_index_ip_port(row, ip, port);
             let over = self.rows[row][idx].increment(now_secs, threshold);
             over_all &= over;
         }

--- a/userspace-dp/src/screen/tests.rs
+++ b/userspace-dp/src/screen/tests.rs
@@ -1891,6 +1891,147 @@ fn udp_flood_triggers() {
     );
 }
 
+/// #4112 F18: Junos measures ICMP flood PER DESTINATION IP, not per zone.
+/// Traffic to two distinct destinations, each AT the per-destination threshold,
+/// counts INDEPENDENTLY and is NOT summed into one zone counter. RED on revert
+/// (single per-zone aggregate at `threshold`): the two destinations sum, so the
+/// 4th packet overall crosses the zone counter and is false-dropped even though
+/// no single destination is flooded.
+#[test]
+fn icmp_flood_per_destination_counts_independently() {
+    let mut profile = ScreenProfile::default();
+    profile.icmp_flood_threshold = 3;
+    let mut state = make_state("trust", profile);
+    let dst_a = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+    let dst_b = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 2));
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    // 3 to A and 3 to B: each destination is AT its per-destination cap (3), so
+    // none trip. The reverted single zone counter (threshold 3) would drop from
+    // the 4th packet on.
+    for _ in 0..3 {
+        assert_eq!(
+            state.check_packet("trust", &icmp_pkt(src, dst_a, 84), 100),
+            ScreenVerdict::Pass,
+            "destination A within its own per-destination cap"
+        );
+    }
+    for _ in 0..3 {
+        assert_eq!(
+            state.check_packet("trust", &icmp_pkt(src, dst_b, 84), 100),
+            ScreenVerdict::Pass,
+            "destination B counts independently of A (not summed)"
+        );
+    }
+    // A single-destination flood is STILL capped: the 4th packet to A trips the
+    // per-destination cap.
+    assert_eq!(
+        state.check_packet("trust", &icmp_pkt(src, dst_a, 84), 100),
+        ScreenVerdict::Drop("icmp-flood"),
+        "a single flooded destination is still capped per-destination"
+    );
+}
+
+/// #4112 F18: Junos measures UDP flood PER DESTINATION IP AND PORT. Two flows to
+/// the SAME destination IP but DIFFERENT destination ports count independently.
+/// RED on revert (single per-zone aggregate): the two ports sum and are
+/// false-dropped.
+#[test]
+fn udp_flood_per_destination_port_counts_independently() {
+    let mut profile = ScreenProfile::default();
+    profile.udp_flood_threshold = 2;
+    let mut state = make_state("trust", profile);
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+    let to_port = |port: u16| {
+        let mut p = udp_pkt(src, dst);
+        p.dst_port = port;
+        p
+    };
+    // 2 to (dst, 80) and 2 to (dst, 443): each destination-port is AT its cap.
+    for _ in 0..2 {
+        assert_eq!(
+            state.check_packet("trust", &to_port(80), 100),
+            ScreenVerdict::Pass
+        );
+    }
+    for _ in 0..2 {
+        assert_eq!(
+            state.check_packet("trust", &to_port(443), 100),
+            ScreenVerdict::Pass,
+            "a different destination port counts independently (not summed)"
+        );
+    }
+    // Same (dst, port) flood is STILL capped: the 3rd packet to (dst, 80) trips.
+    assert_eq!(
+        state.check_packet("trust", &to_port(80), 100),
+        ScreenVerdict::Drop("udp-flood"),
+        "a single flooded destination-port is still capped"
+    );
+}
+
+/// #4112 F18: the per-zone aggregate is retained as a coarse SECONDARY
+/// zone-saturation ceiling ABOVE the per-destination cap. A flood spread thin
+/// across many destinations (each under the per-destination cap) is still
+/// bounded zone-wide at `SECONDARY_FLOOD_CEILING_MULT × threshold` — an operator
+/// relying on the zone-wide cap still gets it. With threshold 2 and the 8×
+/// multiplier the ceiling is 16, so the 17th distinct-destination packet trips.
+#[test]
+fn icmp_flood_secondary_zone_ceiling_still_fires() {
+    let mut profile = ScreenProfile::default();
+    profile.icmp_flood_threshold = 2;
+    let mut state = make_state("trust", profile);
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    // 16 distinct destinations, one packet each — every per-destination cap is
+    // far below threshold, but the zone aggregate climbs to the 8×2 = 16 ceiling.
+    for i in 0..16u8 {
+        let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 2, i + 1));
+        assert_eq!(
+            state.check_packet("trust", &icmp_pkt(src, dst, 84), 100),
+            ScreenVerdict::Pass,
+            "under the zone-saturation ceiling"
+        );
+    }
+    // 17th distinct destination: still under its own per-destination cap, but the
+    // zone aggregate (17) crosses the 16 ceiling → secondary drop.
+    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 200));
+    assert_eq!(
+        state.check_packet("trust", &icmp_pkt(src, dst, 84), 100),
+        ScreenVerdict::Drop("icmp-flood"),
+        "zone-wide saturation ceiling fires above the per-destination cap"
+    );
+}
+
+/// #4112 F18: the per-destination cap also runs on the FLOWLESS path (non-first
+/// fragment / non-query ICMP), so a fragment-based flood cannot evade it. Two
+/// distinct destinations count independently there too.
+#[test]
+fn icmp_flood_flowless_per_destination_independent() {
+    let mut profile = ScreenProfile::default();
+    profile.icmp_flood_threshold = 2;
+    let mut state = make_state("trust", profile);
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let dst_a = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+    let dst_b = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 2));
+    for _ in 0..2 {
+        assert_eq!(
+            state.check_flowless_screens("trust", &flowless_icmp_pkt(src, dst_a), true, 100),
+            ScreenVerdict::Pass
+        );
+    }
+    for _ in 0..2 {
+        assert_eq!(
+            state.check_flowless_screens("trust", &flowless_icmp_pkt(src, dst_b), true, 100),
+            ScreenVerdict::Pass,
+            "flowless per-destination independence"
+        );
+    }
+    assert_eq!(
+        state.check_flowless_screens("trust", &flowless_icmp_pkt(src, dst_a), true, 100),
+        ScreenVerdict::Drop("icmp-flood"),
+        "flowless single-destination flood still capped"
+    );
+}
+
 // ================================================================
 // Rate limiting: SYN flood
 // ================================================================
@@ -2179,6 +2320,58 @@ fn syn_flood_dest_runs_when_cookie_active() {
         state.check_packet_with_zone_id("trust", 3, &pkt, 100),
         ScreenVerdict::Drop("syn-flood"),
         "per-dest must still enforce while the zone is cookie-active"
+    );
+    assert_eq!(state.syn_flood_dst_drops(), 1);
+}
+
+/// #4112 F19: the per-DESTINATION SYN cap is evaluated BEFORE the aggregate
+/// over-attack early-return, so a per-destination-over-threshold backend is
+/// HARD-DROPPED even while the zone aggregate is over attack-threshold and
+/// minting SYN cookies. A LOW `syn_flood_threshold` makes over_attack fire, and
+/// the per-dest cap is also low, so the same SYN trips BOTH. On revert (per-dst
+/// checked only AFTER the `if over_attack` return) the 3rd SYN is a
+/// SynCookieChallenge, not a Drop, and `syn_flood_dst_drops` stays 0 — the
+/// destination-threshold that exists to shield a single victim is defeated in
+/// exactly the high-load regime it is configured for.
+#[test]
+fn syn_flood_dest_hard_drops_over_attack_with_cookie() {
+    let mut profile = ScreenProfile::default();
+    profile.syn_flood_threshold = 2; // LOW aggregate → over_attack fires fast
+    profile.syn_cookie = true;
+    profile.syn_flood_dst_threshold = 2; // per-dest also low
+    let mut state = make_state("trust", profile);
+    state.update_syn_cookie_master_key(Some(syn_cookie_key()));
+    let victim = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 9));
+    // SYNs 1,2 to the victim: aggregate 1,2 (not over 2) AND per-dest 1,2 (not
+    // over 2) → Pass. These also feed both counters.
+    for i in 0..2u8 {
+        let pkt = tcp_pkt(
+            IpAddr::V4(Ipv4Addr::new(10, 0, 1, i + 1)),
+            victim,
+            1234,
+            80,
+            TCP_SYN,
+        );
+        assert_eq!(
+            state.check_packet_with_zone_id("trust", 3, &pkt, 100),
+            ScreenVerdict::Pass
+        );
+    }
+    // SYN 3: aggregate 3 > 2 → over_attack (WOULD mint a cookie), AND per-dest
+    // 3 > 2. The per-destination cap is evaluated first and HARD-DROPS. On revert
+    // this is a SynCookieChallenge (the flooded victim admits cookie-completing
+    // clients) — the F19 bug.
+    let pkt = tcp_pkt(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 50)),
+        victim,
+        1234,
+        80,
+        TCP_SYN,
+    );
+    assert_eq!(
+        state.check_packet_with_zone_id("trust", 3, &pkt, 100),
+        ScreenVerdict::Drop("syn-flood"),
+        "per-dst must hard-drop before the aggregate mints a cookie"
     );
     assert_eq!(state.syn_flood_dst_drops(), 1);
 }


### PR DESCRIPTION
## Summary

Closes #4112 (fable-163 F18 + F19). Two coupled screen findings on the
userspace-dp screen engine, one PR.

### F18 (MEDIUM, vsrx-parity) — ICMP/UDP flood is per-DESTINATION

`icmp flood threshold N` / `udp flood threshold N` were enforced against
a per-ZONE AGGREGATE counter (`icmp_counters` / `udp_counters` keyed by
zone name only, `screen/mod.rs`). Junos measures the ICMP flood rate PER
DESTINATION IP and the UDP flood rate per destination IP AND port;
traffic to different destinations counts independently. The aggregate
keying both (a) false-dropped legitimate traffic — two high-volume
services in one zone (DNS resolver + VoIP) SUM into one counter and cross
the threshold though no single destination is flooded — and (b) let an
attacker spread a modest flood across many destinations while no single
victim was rate-limited as the operator expected.

**Fix:** reuse the #3315 no-eviction count-min `SynRateSketch` substrate.

- **PRIMARY per-destination cap** at the configured threshold —
  `icmp_dst_sketch` (keyed on `dst_ip`) and `udp_dst_sketch` (keyed on
  `dst_ip` + `dst_port` via a new `increment_ip_port`). A single flooded
  destination is still capped; distinct destinations no longer sum.
- **SECONDARY per-zone ceiling** — the existing aggregate counter,
  retained at `SECONDARY_FLOOD_CEILING_MULT (8) × threshold`. It counts
  only per-destination-admitted packets, so it bounds the admitted
  zone-wide rate and still caps a flood spread thin across many
  under-threshold destinations (an operator relying on the zone-wide cap
  still gets it).
- Shared `icmp_flood_drop` / `udp_flood_drop` helpers back BOTH the
  flow-present (`check_packet_with_zone_id`) and flowless
  (`check_flowless_screens`) paths so a fragment-based flood cannot evade
  the per-destination cap (a flowless non-first fragment has no L4 port,
  so the UDP cap degrades to per-destination-IP there).

### F19 (LOW, correctness/defense-in-depth) — SYN per-dst before cookie mint

The per-DESTINATION SYN sketch was evaluated AFTER the aggregate
`over_attack` early-return, so a real-client flood that pushed a zone
over `attack-threshold` took the SYN-cookie-mint branch on every SYN and
the per-destination sketch was NEVER reached — `destination-threshold`
(shield a single over-threshold victim even from validated clients) was
defeated in exactly the high-load regime it is configured for (a
code-vs-comment contradiction; the sketch was documented as always-on).

**Fix:** evaluate the per-destination sketch BEFORE the aggregate
over-attack early-return so a per-destination trip HARD-DROPS even while
the zone mints cookies. The aggregate still ALWAYS counts first
(`increment_and_classify`), so its cookie-activation side-effect is never
skipped; the over-attack cookie-mint is unchanged when the per-dest cap
did not trip.

## Validation

- **RED-on-revert proven, both.** F19 temp-revert (gate per-dst on
  `!over_attack`) → the 3rd SYN returns `SynCookieChallenge` instead of
  `Drop("syn-flood")`. F18 temp-revert (per-zone aggregate only at
  threshold T) → distinct destinations / destination-ports get summed
  into a false `Drop`.
- **FULL `cargo test --release` green** (3495 lib + 16 + 1 + 46 + 8
  integration, 0 failed). `go build ./...` green. rustfmt clean on added
  lines (pre-existing whole-crate drift left untouched).
- Not an HA / session-sync path (per-packet ingress screen), so no
  `test-failover` run.

New tests: `icmp_flood_per_destination_counts_independently`,
`udp_flood_per_destination_port_counts_independently`,
`icmp_flood_secondary_zone_ceiling_still_fires`,
`icmp_flood_flowless_per_destination_independent`,
`syn_flood_dest_hard_drops_over_attack_with_cookie`.

Docs: `docs/syn-cookie-flood-protection.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
