### PR TITLE
config: route compilePolicy match reads through firewallMatchValues (Refs #4121)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-07-04 — #4121: compilePolicy match reads share the firewallMatchValues SSOT (fable-163 F28)
+
+- **Timestamp**: 2026-07-04
+  - **Action**: VERIFY-FIRST on the claimed #2419 fail-open. Built a scratch
+    matrix (flat bracket / flat repeated / flat bracket+single / hier bracket /
+    hier block / hier repeated) and compiled each — the CURRENT either/or read
+    (`compiler_security.go` compilePolicy, `if len(m.Keys) >= 2 { Keys[1:] }
+    else { Children }`) read ALL values in EVERY realistic shape. The bracketed
+    `[ a b c ]` collapses onto `Keys` and the Keys[1:] arm reads it in full — the
+    issue's premise (drops all-but-first) is REFUTED. The ONLY shape where
+    either/or diverges from `firewallMatchValues` (read-both) is a node carrying
+    members in BOTH slots (`source-address a1 { a2; }`), which no canonical Junos
+    / display-set round-trip emits. VERDICT: already-reads-both-equivalent
+    (cosmetic divergence), NOT a genuine fail-open. Did the trivial SSOT
+    consolidation the issue requests: routed the three policy-match `multi`
+    arms (source-address / destination-address / application) through
+    `firewallMatchValues` — the SAME reader the strict gates use, and the same
+    pattern the `then log` / `default-policy-log` arms in this file already use
+    — so compiler + gates share ONE reader (future dual-AST drift = shared-test
+    failure). Address arms keep the `normalizePolicyAddrTokens` any-ipv4/6
+    normalization. RED-on-revert proven: reverting to either/or turns the
+    both-slots subtest RED (src=[a1], a2 dropped) while all four realistic
+    shapes stay GREEN. Part B (2357-line file-split + trafficSelectorValues
+    fold) DEFERRED (low-value/high-churn) — issue kept open via Refs.
+  - **File(s)**: pkg/config/compiler_security.go,
+    pkg/config/compiler_policy_match_ssot_4121_test.go (new),
+    docs/config-schema.md
+  - **Validation**: `go test ./pkg/config/...` green; `go build ./...` OK;
+    gofmt + go vet clean.
+
 ## 2026-07-04 — #4116: VRRP address owner (priority 255) always preempts (fable-163 F22)
 
 - **Timestamp**: 2026-07-04

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -439,6 +439,31 @@ both AST shapes):
   isolation break. Coverage: `compiler_routing_instance_interface_3904_test.go`
   (both AST shapes + single-value back-compat).
 
+**Policy match source-/destination-address/application share the reader
+(#4121, divergence-elimination, NOT a fail-open).** `compilePolicy`
+(`compiler_security.go`) previously read the three `multi: true` policy-match
+value leaves with a per-arm either/or (`if len(m.Keys) >= 2 { Keys[1:] } else {
+Children }`) while the strict match gates read them via `firewallMatchValues`
+(Keys[1:] AND Children). VERIFY-FIRST established the either/or was NOT lossy for
+any shape the parser actually emits: a bracket / inline list collapses onto
+`Keys` (read by the Keys[1:] arm), a hierarchical block `source-address { a; b; }`
+yields `Keys=["source-address"]` + child nodes (read by the Children arm), and
+repeated statements yield sibling leaves (each read on its own pass) — the three
+shapes are mutually exclusive, so either/or picked the correct slot every time
+and the #2419 bracketed-list class was already read in full. The ONE shape where
+either/or diverged from read-both — a node carrying members in BOTH slots
+(`source-address a1 { a2; }`, not emitted by any canonical Junos or display-set
+round-trip) — dropped the child members. The three arms now route through
+`firewallMatchValues` (address arms keep the `any-ipv4`/`any-ipv6` →
+`0.0.0.0/0`/`::/0` normalization via `normalizePolicyAddrTokens`) so the compiler
+and the strict gates share ONE match-value reader: a future dual-AST divergence
+becomes a shared-test change rather than a silent drift. Coverage:
+`compiler_policy_match_ssot_4121_test.go` (flat/hier bracket, flat/hier repeated,
+hier block all read every value; the both-slots node is the fail-on-revert case).
+The optional `compiler_security.go` file-split (2357 lines) and folding
+`trafficSelectorValues` (`compiler_ipsec_trafficselector.go`) onto the shared
+reader are deferred (issue #4121 part B, low-value/high-churn).
+
 ## Duplicate host-local-address fail-closed gate (#3718, Option B)
 
 Beyond the per-leaf token allowlist above, host-inbound admission has a

--- a/pkg/config/compiler_policy_match_ssot_4121_test.go
+++ b/pkg/config/compiler_policy_match_ssot_4121_test.go
@@ -1,0 +1,201 @@
+package config
+
+import (
+	"sort"
+	"testing"
+)
+
+// #4121: compilePolicy's source-address / destination-address / application
+// match reads route through the firewallMatchValues SSOT — the SAME read-both
+// reader the strict match gates use — instead of a per-arm either/or
+// (`if len(Keys)>=2 { Keys[1:] } else { Children }`). The either/or read was
+// correct for every shape the parser actually emits (bracket/inline collapse
+// onto Keys, a hierarchical block yields Children, repeated statements yield
+// sibling nodes — all mutually exclusive), so this is a divergence-elimination
+// / hardening change, not a fail-open fix: the #2419 bracketed-list class
+// (`source-address [ a b c ]`) was already read in full. The ONE shape where
+// either/or diverged from read-both — a node carrying members in BOTH slots
+// (`source-address a1 { a2; }`) — dropped the child members; the last subtest
+// pins that as the genuine fail-on-revert case.
+//
+// fail-on-revert: reverting the three arms to the either/or read leaves the
+// realistic-shape subtests GREEN (they always were) but turns
+// TestPolicyMatchSSOT_4121/both_slots RED (a2 is dropped).
+
+// compiledPolicyMatch returns the compiled source-address, destination-address
+// and application match value sets for the named policy (searching both
+// zone-pair and global policies).
+func compiledPolicyMatch(t *testing.T, tree *ConfigTree, name string) (src, dst, apps []string) {
+	t.Helper()
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	collect := func(p *Policy) {
+		if p.Name != name {
+			return
+		}
+		src = append([]string(nil), p.Match.SourceAddresses...)
+		dst = append([]string(nil), p.Match.DestinationAddresses...)
+		apps = append([]string(nil), p.Match.Applications...)
+	}
+	for _, pr := range cfg.Security.Policies {
+		for _, p := range pr.Policies {
+			collect(p)
+		}
+	}
+	for _, p := range cfg.Security.GlobalPolicies {
+		collect(p)
+	}
+	sort.Strings(src)
+	sort.Strings(dst)
+	sort.Strings(apps)
+	return src, dst, apps
+}
+
+func eqStrs4121(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestPolicyMatchSSOT_4121(t *testing.T) {
+	scaffold := []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security address-book global address a1 10.0.1.0/24",
+		"set security address-book global address a2 10.0.2.0/24",
+		"set security address-book global address a3 10.0.3.0/24",
+		"set security address-book global address d1 10.0.10.0/24",
+		"set security address-book global address d2 10.0.11.0/24",
+	}
+	wantSrc := []string{"a1", "a2", "a3"}
+	wantDst := []string{"d1", "d2"}
+	wantApps := []string{"junos-http", "junos-https", "junos-ssh"}
+
+	// Flat-set bracket lists collapse onto one leaf's Keys (#2419) — the
+	// either/or read already handled this via the Keys[1:] arm; this guards it.
+	t.Run("flat_bracket", func(t *testing.T) {
+		tree := buildTree3846(t, append(append([]string(nil), scaffold...),
+			"set security policies from-zone trust to-zone untrust policy p1 match source-address [ a1 a2 a3 ]",
+			"set security policies from-zone trust to-zone untrust policy p1 match destination-address [ d1 d2 ]",
+			"set security policies from-zone trust to-zone untrust policy p1 match application [ junos-http junos-https junos-ssh ]",
+			"set security policies from-zone trust to-zone untrust policy p1 then permit",
+		)...)
+		src, dst, apps := compiledPolicyMatch(t, tree, "p1")
+		if !eqStrs4121(src, wantSrc) || !eqStrs4121(dst, wantDst) || !eqStrs4121(apps, wantApps) {
+			t.Fatalf("flat_bracket: src=%v dst=%v apps=%v; want %v %v %v", src, dst, apps, wantSrc, wantDst, wantApps)
+		}
+	})
+
+	// Repeated flat-set lines yield one sibling leaf per value.
+	t.Run("flat_repeated", func(t *testing.T) {
+		tree := buildTree3846(t, append(append([]string(nil), scaffold...),
+			"set security policies from-zone trust to-zone untrust policy p1 match source-address a1",
+			"set security policies from-zone trust to-zone untrust policy p1 match source-address a2",
+			"set security policies from-zone trust to-zone untrust policy p1 match source-address a3",
+			"set security policies from-zone trust to-zone untrust policy p1 match destination-address d1",
+			"set security policies from-zone trust to-zone untrust policy p1 match destination-address d2",
+			"set security policies from-zone trust to-zone untrust policy p1 match application junos-http",
+			"set security policies from-zone trust to-zone untrust policy p1 match application junos-https",
+			"set security policies from-zone trust to-zone untrust policy p1 match application junos-ssh",
+			"set security policies from-zone trust to-zone untrust policy p1 then permit",
+		)...)
+		src, dst, apps := compiledPolicyMatch(t, tree, "p1")
+		if !eqStrs4121(src, wantSrc) || !eqStrs4121(dst, wantDst) || !eqStrs4121(apps, wantApps) {
+			t.Fatalf("flat_repeated: src=%v dst=%v apps=%v; want %v %v %v", src, dst, apps, wantSrc, wantDst, wantApps)
+		}
+	})
+
+	// Hierarchical bracket list — parser collapses onto Keys (Keys[1:] arm).
+	t.Run("hier_bracket", func(t *testing.T) {
+		tree := mustParse(t, `security {
+    zones { security-zone trust; security-zone untrust; }
+    address-book { global {
+        address a1 10.0.1.0/24; address a2 10.0.2.0/24; address a3 10.0.3.0/24;
+        address d1 10.0.10.0/24; address d2 10.0.11.0/24;
+    } }
+    policies {
+        from-zone trust to-zone untrust {
+            policy p1 {
+                match {
+                    source-address [ a1 a2 a3 ];
+                    destination-address [ d1 d2 ];
+                    application [ junos-http junos-https junos-ssh ];
+                }
+                then { permit; }
+            }
+        }
+    }
+}`)
+		src, dst, apps := compiledPolicyMatch(t, tree, "p1")
+		if !eqStrs4121(src, wantSrc) || !eqStrs4121(dst, wantDst) || !eqStrs4121(apps, wantApps) {
+			t.Fatalf("hier_bracket: src=%v dst=%v apps=%v; want %v %v %v", src, dst, apps, wantSrc, wantDst, wantApps)
+		}
+	})
+
+	// Hierarchical block shape `source-address { a1; a2; a3; }` — a child node
+	// per member (Keys=["source-address"], len 1 → the old Children arm).
+	t.Run("hier_block", func(t *testing.T) {
+		tree := mustParse(t, `security {
+    zones { security-zone trust; security-zone untrust; }
+    address-book { global {
+        address a1 10.0.1.0/24; address a2 10.0.2.0/24; address a3 10.0.3.0/24;
+        address d1 10.0.10.0/24; address d2 10.0.11.0/24;
+    } }
+    policies {
+        from-zone trust to-zone untrust {
+            policy p1 {
+                match {
+                    source-address { a1; a2; a3; }
+                    destination-address { d1; d2; }
+                    application { junos-http; junos-https; junos-ssh; }
+                }
+                then { permit; }
+            }
+        }
+    }
+}`)
+		src, dst, apps := compiledPolicyMatch(t, tree, "p1")
+		if !eqStrs4121(src, wantSrc) || !eqStrs4121(dst, wantDst) || !eqStrs4121(apps, wantApps) {
+			t.Fatalf("hier_block: src=%v dst=%v apps=%v; want %v %v %v", src, dst, apps, wantSrc, wantDst, wantApps)
+		}
+	})
+
+	// The genuine fail-on-revert case: a node with members in BOTH slots
+	// (`source-address a1 { a2; }`). The either/or read reads only Keys[1:]
+	// (["a1"]) and drops the child a2 — read-both (firewallMatchValues) keeps
+	// both. No canonical Junos emits this, but the tolerant load / group-merge
+	// paths must not silently narrow a policy when it appears.
+	t.Run("both_slots", func(t *testing.T) {
+		tree := mustParse(t, `security {
+    zones { security-zone trust; security-zone untrust; }
+    address-book { global {
+        address a1 10.0.1.0/24; address a2 10.0.2.0/24;
+    } }
+    policies {
+        from-zone trust to-zone untrust {
+            policy p1 {
+                match {
+                    source-address a1 { a2; }
+                    destination-address any;
+                    application any;
+                }
+                then { permit; }
+            }
+        }
+    }
+}`)
+		src, _, _ := compiledPolicyMatch(t, tree, "p1")
+		want := []string{"a1", "a2"}
+		if !eqStrs4121(src, want) {
+			t.Fatalf("both_slots: src=%v; want %v (either/or drops the child member)", src, want)
+		}
+	})
+}

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -710,21 +710,22 @@ func compilePolicy(polInst struct {
 		for _, m := range matchChildren {
 			switch m.Name() {
 			case "source-address":
-				if len(m.Keys) >= 2 {
-					pol.Match.SourceAddresses = append(pol.Match.SourceAddresses, normalizePolicyAddrTokens(m.Keys[1:])...)
-				} else {
-					for _, c := range m.Children {
-						pol.Match.SourceAddresses = append(pol.Match.SourceAddresses, normalizePolicyAddrToken(c.Name()))
-					}
-				}
+				// #4121: read BOTH Keys[1:] AND Children via the
+				// firewallMatchValues SSOT — the SAME reader the strict match
+				// gates (validatePolicyMatchLeavesStrict) use — so the compiler
+				// and gates can never diverge on a dual-AST shape (the #2419
+				// bracketed-list class). The prior either/or read
+				// (`if len(Keys)>=2 { Keys[1:] } else { Children }`) was correct
+				// for every shape the parser actually produces (bracket/inline →
+				// Keys, block → Children, repeated → sibling nodes, all mutually
+				// exclusive), but a `source-address a1 { a2; }` node carrying
+				// members in BOTH slots dropped the child members. Reading both
+				// removes that divergence and shares one reader with the gates.
+				pol.Match.SourceAddresses = append(pol.Match.SourceAddresses, normalizePolicyAddrTokens(firewallMatchValues(m))...)
 			case "destination-address":
-				if len(m.Keys) >= 2 {
-					pol.Match.DestinationAddresses = append(pol.Match.DestinationAddresses, normalizePolicyAddrTokens(m.Keys[1:])...)
-				} else {
-					for _, c := range m.Children {
-						pol.Match.DestinationAddresses = append(pol.Match.DestinationAddresses, normalizePolicyAddrToken(c.Name()))
-					}
-				}
+				// #4121: read BOTH slots via the firewallMatchValues SSOT (see
+				// the source-address arm).
+				pol.Match.DestinationAddresses = append(pol.Match.DestinationAddresses, normalizePolicyAddrTokens(firewallMatchValues(m))...)
 			case "source-address-excluded":
 				pol.Match.SourceAddressExcluded = true
 			case "destination-address-excluded":
@@ -748,13 +749,9 @@ func compilePolicy(polInst struct {
 					pol.Match.ToZone = m.Children[0].Name()
 				}
 			case "application":
-				if len(m.Keys) >= 2 {
-					pol.Match.Applications = append(pol.Match.Applications, m.Keys[1:]...)
-				} else {
-					for _, c := range m.Children {
-						pol.Match.Applications = append(pol.Match.Applications, c.Name())
-					}
-				}
+				// #4121: read BOTH slots via the firewallMatchValues SSOT (see
+				// the source-address arm).
+				pol.Match.Applications = append(pol.Match.Applications, firewallMatchValues(m)...)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

VERIFY-FIRST result for #4121: **the fail-open the issue posits does NOT reproduce.** This PR does the trivial SSOT consolidation the issue asks for (the actionable part), framed honestly as **divergence-elimination / hardening**, not a bug fix. It leaves the optional 2357-line file-split for a follow-up, so the issue stays open (`Refs`, not `Closes`).

## What was verified

`compilePolicy` (`pkg/config/compiler_security.go`) read the three `multi: true` policy-match value leaves — `source-address` / `destination-address` / `application` — with a per-arm either/or:

```go
if len(m.Keys) >= 2 { read Keys[1:] } else { read Children }
```

while the strict match gates read them via `firewallMatchValues` (Keys[1:] **AND** Children). A scratch matrix over every AST shape the parser actually emits was compiled and inspected:

| shape | node | either/or reads |
|---|---|---|
| flat bracket `[ a1 a2 a3 ]` | `Keys=[source-address a1 a2 a3]` | **all 3** (Keys[1:]) |
| flat repeated (3 lines) | 3 sibling leaves | **all 3** (per-pass) |
| flat bracket + single | 2 sibling leaves | **all 3** |
| hier bracket | `Keys=[source-address a1 a2 a3]` | **all 3** (Keys[1:]) |
| hier block `{ a1; a2; a3; }` | `Keys=[source-address]` + 3 children | **all 3** (Children) |
| hier repeated | 3 sibling leaves | **all 3** |

The bracketed `[ a b c ]` list collapses onto `Keys` and the `Keys[1:]` arm reads it **in full** — the issue's premise (the #2419 class drops all-but-first here) is **refuted**. The three shapes are mutually exclusive, so either/or picked the correct slot every time.

The **only** shape where either/or diverges from read-both is a node carrying members in **both** slots — `source-address a1 { a2; }` — which no canonical Junos, `display-set` round-trip, or flat-set path emits. There the child member `a2` was dropped.

## Change

Route the three arms through `firewallMatchValues` — the SAME read-both reader the strict gates use, and the same pattern the `then log` / `default-policy-log` arms in this file already use. The address arms keep the `any-ipv4`/`any-ipv6` → `0.0.0.0/0`/`::/0` normalization via `normalizePolicyAddrTokens`. Compiler + strict gates now share ONE match-value reader, so a future dual-AST divergence becomes a shared-test failure rather than a silent drift.

## RED-on-revert

`compiler_policy_match_ssot_4121_test.go` — reverting the three arms to either/or leaves the four realistic-shape subtests **GREEN** (they always were) and turns the `both_slots` subtest **RED** (`src=[a1]`, `a2` dropped). Confirmed:

```
--- PASS: .../flat_bracket
--- PASS: .../flat_repeated
--- PASS: .../hier_bracket
--- PASS: .../hier_block
--- FAIL: .../both_slots   both_slots: src=[a1]; want [a1 a2]
```

## Deferred (part B, low-value / high-churn)

- The 2357-line `compiler_security.go` file-split.
- Folding `trafficSelectorValues` (`compiler_ipsec_trafficselector.go`, the #4104 Copilot DRY note) onto the shared reader.

Issue kept open for these.

## Validation

- `go test ./pkg/config/...` green
- `go build ./...` OK
- `gofmt` + `go vet` clean

Refs #4121

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
