### PR TITLE
cli: mask SNMP community name in status commands (#4111)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -32817,3 +32817,26 @@ top.
     pkg/config/compiler_protocols.go, pkg/config/schema_validate_4119_test.go,
     pkg/ra/sender.go, pkg/ra/ra.go, pkg/ra/sender_marshal_4119_test.go,
     pkg/cli/cli_show_routing.go, docs/embedded-radvd.md, _Log.md
+
+- **Timestamp**: 2026-07-04
+  - **Action**: #4111 — mask the SNMP community name in the two operational
+    status commands (`show system services`, `show snmp`) for non-super-user
+    login classes. Follow-up to #4099/#4106 (config-render secret redaction):
+    the #4106 hostile review found these two STATUS commands format the typed
+    active config directly (`cfg.System.SNMP.Communities`), bypassing the
+    `RedactedClone` path #4106 wired into the config-render surfaces, so the
+    SNMP community credential printed cleartext to view-only classes
+    (read-only / config-viewer / operator — all PermView `show`). Fix reuses
+    the existing `CLI.showConfigRedacted()` predicate (redact for any class
+    without PermAll; cleartext for super-user + unset/legacy class): for a
+    redacting class the community NAME is masked to `config.SecretDataPlaceholder`
+    (`##SECRET-DATA##`) while the authorization MODE (read-only/read-write)
+    stays visible. Only the secret community name is masked. RED-on-revert
+    PROVEN both ways: reverting either mask makes the read-only/config-viewer/
+    operator/unauthorized subtests fail (cleartext CLI-LEAK-SNMP-COMMUNITY
+    reappears, placeholder missing); super-user still sees cleartext.
+    go test ./pkg/cli/... green; go build ./..., gofmt clean (vet warning at
+    cli.go:503 is pre-existing, untouched).
+  - **File(s)**: pkg/cli/cli_show_system.go, pkg/cli/cli_show_services.go,
+    pkg/cli/cli_show_snmp_community_redaction_4111_test.go,
+    docs/system-login.md, _Log.md

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -144,6 +144,23 @@ defense-in-depth should a lower class ever gain config-view access. The raw
 redacted before display and fails **closed** — a parse error returns an error
 rather than the cleartext bytes.
 
+**SNMP community masking in status commands (#4111).** The #4099 redaction
+above covers the config-render surfaces (they route through the `RedactedClone`
+renderers). Two **operational status** commands, however, format the typed
+active config directly and so bypassed that path: `show system services`
+(`showSystemServices`, `pkg/cli/cli_show_system.go`) printed `Community: <name>
+(<auth>)`, and `show snmp` (`showSNMP`, `pkg/cli/cli_show_services.go`) printed
+`  <name>: <auth>`. Both are PermView `show` commands reachable by
+`read-only` / `config-viewer` / `operator`, so the SNMP community string — a
+read/write credential — leaked in cleartext to view-only classes. They now
+reuse the same `CLI.showConfigRedacted()` predicate: for any class without
+`PermAll` the community **name** is masked to `##SECRET-DATA##` while the
+authorization **mode** (`read-only` / `read-write`) stays visible; `super-user`
+and the unset/legacy class still read the cleartext name (parity with the #4099
+config-render decision above). The TSIG key already showed `(secret redacted)`
+and SNMPv3 renders auth/priv protocol names only, so the community name was the
+last cleartext SNMP secret on these two surfaces.
+
 ### Generating a hash
 
 ```

--- a/pkg/cli/cli_show_services.go
+++ b/pkg/cli/cli_show_services.go
@@ -637,8 +637,17 @@ func (c *CLI) showSNMP() error {
 
 	if len(snmpCfg.Communities) > 0 {
 		fmt.Println("Communities:")
+		// #4111: mask the secret community name for any non-super-user login
+		// class (reuse the #4099/#4106 showConfigRedacted predicate). The
+		// authorization mode stays visible; only the community credential is
+		// masked. Super-user / unset class reads cleartext.
+		redactCommunity := c.showConfigRedacted()
 		for name, comm := range snmpCfg.Communities {
-			fmt.Printf("  %s: %s\n", name, comm.Authorization)
+			shown := name
+			if redactCommunity {
+				shown = config.SecretDataPlaceholder
+			}
+			fmt.Printf("  %s: %s\n", shown, comm.Authorization)
 		}
 	}
 

--- a/pkg/cli/cli_show_snmp_community_redaction_4111_test.go
+++ b/pkg/cli/cli_show_snmp_community_redaction_4111_test.go
@@ -1,0 +1,94 @@
+// RED-on-revert tests for #4111: the two OPERATIONAL STATUS commands that
+// render the SNMP configuration by reading the typed active config directly —
+// `show system services` (showSystemServices) and `show snmp` (showSNMP) — must
+// mask the secret SNMP community NAME for a VIEW-only login class (read-only /
+// config-viewer / operator), exactly as the #4099/#4106 config-render show
+// paths do. Both are PermView `show` commands reachable by every view-capable
+// class, and both bypassed the #4106 RedactedClone path because they format the
+// typed struct fields themselves. Before the fix they printed the community
+// credential (a read/write SNMP secret) in cleartext.
+//
+// Reverting the mask makes the read-only / config-viewer / operator subtests go
+// RED (the cleartext community sentinel reappears). super-user keeps cleartext
+// (the #4057/#4106 console-operator allowance), so its subtest asserts the
+// cleartext community IS present — a revert that redacts everyone would also be
+// caught. The authorization MODE (read-only) must stay visible in every case:
+// only the secret community name is masked.
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestShowSystemServicesSNMPCommunityRedactsPerClass pins `show system
+// services` → showSystemServices(): the community name is masked for a
+// VIEW-only class, cleartext for super-user, and the authorization mode
+// (read-only) is always shown.
+func TestShowSystemServicesSNMPCommunityRedactsPerClass(t *testing.T) {
+	store := newCLISecretStore(t)
+	for _, tc := range classWantsRedaction {
+		t.Run(tc.class, func(t *testing.T) {
+			c := &CLI{store: store, userClass: tc.class}
+			out := captureStdout(t, func() {
+				if err := c.showSystemServices(); err != nil {
+					t.Fatalf("showSystemServices(): %v", err)
+				}
+			})
+			// The authorization mode is not a secret — it must always show.
+			if !strings.Contains(out, "read-only") {
+				t.Errorf("class=%q dropped the SNMP authorization mode:\n%s", tc.class, out)
+			}
+			if tc.redact {
+				if strings.Contains(out, "CLI-LEAK-SNMP-COMMUNITY") {
+					t.Errorf("class=%q LEAKED cleartext SNMP community name:\n%s", tc.class, out)
+				}
+				if !strings.Contains(out, config.SecretDataPlaceholder) {
+					t.Errorf("class=%q missing redaction placeholder %q:\n%s",
+						tc.class, config.SecretDataPlaceholder, out)
+				}
+			} else {
+				// Privileged / unset class must still see the cleartext name.
+				if !strings.Contains(out, "CLI-LEAK-SNMP-COMMUNITY") {
+					t.Errorf("class=%q unexpectedly redacted the community for a privileged class:\n%s",
+						tc.class, out)
+				}
+			}
+		})
+	}
+}
+
+// TestShowSNMPCommunityRedactsPerClass pins `show snmp` → showSNMP(): same
+// per-class expectation as above for the standalone SNMP status render.
+func TestShowSNMPCommunityRedactsPerClass(t *testing.T) {
+	store := newCLISecretStore(t)
+	for _, tc := range classWantsRedaction {
+		t.Run(tc.class, func(t *testing.T) {
+			c := &CLI{store: store, userClass: tc.class}
+			out := captureStdout(t, func() {
+				if err := c.showSNMP(); err != nil {
+					t.Fatalf("showSNMP(): %v", err)
+				}
+			})
+			if !strings.Contains(out, "read-only") {
+				t.Errorf("class=%q dropped the SNMP authorization mode:\n%s", tc.class, out)
+			}
+			if tc.redact {
+				if strings.Contains(out, "CLI-LEAK-SNMP-COMMUNITY") {
+					t.Errorf("class=%q LEAKED cleartext SNMP community name:\n%s", tc.class, out)
+				}
+				if !strings.Contains(out, config.SecretDataPlaceholder) {
+					t.Errorf("class=%q missing redaction placeholder %q:\n%s",
+						tc.class, config.SecretDataPlaceholder, out)
+				}
+			} else {
+				if !strings.Contains(out, "CLI-LEAK-SNMP-COMMUNITY") {
+					t.Errorf("class=%q unexpectedly redacted the community for a privileged class:\n%s",
+						tc.class, out)
+				}
+			}
+		})
+	}
+}

--- a/pkg/cli/cli_show_system.go
+++ b/pkg/cli/cli_show_system.go
@@ -287,8 +287,19 @@ func (c *CLI) showSystemServices() error {
 		if cfg.System.SNMP.Location != "" {
 			fmt.Printf("    Location:     %s\n", cfg.System.SNMP.Location)
 		}
+		// #4111: the SNMP community name is a secret (it is the read/write
+		// credential). Mask it for any non-super-user login class, mirroring
+		// the #4099/#4106 config-render redaction decision (showConfigRedacted).
+		// The authorization mode (read-only/read-write) stays visible; only the
+		// secret community string is masked. Super-user / unset class reads
+		// cleartext (console operator parity with #4057/#4106).
+		redactCommunity := c.showConfigRedacted()
 		for name, comm := range cfg.System.SNMP.Communities {
-			fmt.Printf("    Community:    %s (%s)\n", name, comm.Authorization)
+			shown := name
+			if redactCommunity {
+				shown = config.SecretDataPlaceholder
+			}
+			fmt.Printf("    Community:    %s (%s)\n", shown, comm.Authorization)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to #4099/#4106 (CLI config-render secret redaction). The #4106
hostile review found a distinct-surface residual: the SNMP community string is
printed **cleartext** to view-only login classes by two **operational STATUS**
commands that format the typed active config directly, bypassing the
`RedactedClone` path #4099/#4106 wired into the config-render surfaces:

- `show system services` → `showSystemServices` (`pkg/cli/cli_show_system.go`) printed `Community: <name> (<auth>)`
- `show snmp` → `showSNMP` (`pkg/cli/cli_show_services.go`) printed `  <name>: <auth>`

Both are PermView `show` commands reachable by `read-only` / `config-viewer` /
`operator`. TSIG already showed `(secret redacted)` and SNMPv3 renders
protocol names only, so the community name was the last cleartext SNMP secret
on these surfaces.

## Fix

Reuse the existing `CLI.showConfigRedacted()` predicate (redact for any class
**without** `PermAll`; cleartext for `super-user` + the unset/legacy no-RBAC
class — parity with the #4099 config-render decision). For a redacting class
the community **name** is masked to `config.SecretDataPlaceholder`
(`##SECRET-DATA##`); the authorization **mode** (`read-only`/`read-write`)
stays visible, so only the secret is hidden.

## Validation

- New per-login-class RED-on-revert test
  (`pkg/cli/cli_show_snmp_community_redaction_4111_test.go`) drives both status
  renders and asserts: community name masked for view-only classes, cleartext
  for `super-user`, auth mode always shown.
- **RED-on-revert proven both ways**: reverting either mask makes the
  `read-only` / `config-viewer` / `operator` / `unauthorized` subtests fail
  (cleartext `CLI-LEAK-SNMP-COMMUNITY` reappears, placeholder missing).
- `go test ./pkg/cli/...` green; `go build ./...`, `gofmt` clean.
- Doc updated: `docs/system-login.md` (#4111 status-command masking paragraph).

Closes #4111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi