### PR TITLE
screen: warn on flowless path for a missing screen profile (#3908)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -32917,3 +32917,27 @@ top.
   - **File(s)**: pkg/dataplane/loader_userspace_shim.go,
     pkg/dataplane/userspace_shim_loader_test.go,
     userspace-dp/src/afxdp/bpf_map/pin.rs, docs/in-place-upgrade.md, _Log.md
+
+- **Timestamp**: 2026-07-04
+  - **Action**: #3908 — flowless screen path missing-profile WARN parity.
+    check_flowless_screens returned ScreenVerdict::Pass SILENTLY on the None
+    branch (no resolved profile for the zone), whereas the flow-present
+    check_packet_with_zone_id None branch calls maybe_warn_missing_profile
+    (#3082 observability). A flowless packet (non-first fragment / non-query
+    ICMP) to a zone that REFERENCES an undefined screen profile therefore
+    produced no diagnostic. FIX: on the check_flowless_screens None branch call
+    self.maybe_warn_missing_profile(zone, now_secs) before returning Pass,
+    mirroring the flow path. Watch-log-only, no drop-behavior change — the
+    helper already distinguishes "zone references a MISSING profile" (rate-
+    limited WARN) from "zone has no screen configured" (silent Pass), so a zone
+    with no screen still passes without warning. O(1) (one hashmap lookup + a
+    rate-limited increment); no unwrap/panic on the hot flowless path. TESTS
+    (RED-on-revert, all three cases): a missing-profile zone WARNs-once-but-
+    Passes and is rate-limited on the flowless path; a no-screen zone Passes
+    flowless without WARN; a resolved-profile zone runs the real flowless checks
+    and never takes the missing-profile WARN path. Docs: screen/mod.rs #3082
+    module note + check_flowless_screens rustdoc + docs/syn-cookie-flood-
+    protection.md now state both paths share maybe_warn_missing_profile.
+  - **File(s)**: userspace-dp/src/screen/mod.rs,
+    userspace-dp/src/screen/tests.rs, docs/syn-cookie-flood-protection.md,
+    _Log.md

--- a/docs/syn-cookie-flood-protection.md
+++ b/docs/syn-cookie-flood-protection.md
@@ -106,6 +106,14 @@ evade the per-destination cap. A flowless non-first fragment carries no L4 port,
 so the UDP cap degrades to per-destination-IP there (the best available for a
 fragment).
 
+The two paths also agree on the missing-screen-profile signal (#3082/#3908):
+each None branch calls `maybe_warn_missing_profile`, so a zone that references a
+screen profile undefined at snapshot-build time emits the same rate-limited
+runtime WARN whether the packet is flow-bearing or flowless, while a zone with
+no screen configured passes silently on both. The verdict stays `Pass` in both
+cases (watch-log-only; the fail-closed-vs-pass posture is the deferred #3082
+design decision).
+
 ### SYN-flood sub-thresholds: source / destination / alarm / timeout (#3315)
 
 The Go compiler parses the full Junos `tcp syn-flood` shape (alarm/attack/

--- a/userspace-dp/src/screen/mod.rs
+++ b/userspace-dp/src/screen/mod.rs
@@ -37,11 +37,15 @@
 //! (older-binary `active.json` on upgrade, or an HA sync from an un-upgraded
 //! primary). The Go control plane now threads the set of zones that reference a
 //! missing profile (`ConfigSnapshot.screen_missing_profile_zones`) so the
-//! `check_packet` None branch can distinguish "zone has no screen configured"
-//! (legit Pass, silent) from "zone references a MISSING screen". For the latter
-//! it emits a runtime WARN, rate-limited to one per zone per second (sustained
-//! traffic produces essentially one WARN until it subsides) so a packet flood
-//! to a misconfigured zone cannot spam the log. The verdict STILL stays
+//! None branch can distinguish "zone has no screen configured" (legit Pass,
+//! silent) from "zone references a MISSING screen". For the latter it emits a
+//! runtime WARN, rate-limited to one per zone per second (sustained traffic
+//! produces essentially one WARN until it subsides) so a packet flood to a
+//! misconfigured zone cannot spam the log. BOTH the flow-present
+//! (`check_packet_with_zone_id`) and the flowless (`check_flowless_screens`,
+//! #3908) None branches call `maybe_warn_missing_profile`, so a flowless packet
+//! (non-first fragment / non-query ICMP) to a broken-profile zone is as
+//! observable as a flow-bearing one. The verdict STILL stays
 //! `ScreenVerdict::Pass` — a runtime fail-CLOSED posture would itself be an
 //! availability brick (the #1960 no-brick rationale), so the fail-closed-vs-pass
 //! posture is a deferred design decision (the /research half of #3082). This
@@ -948,6 +952,13 @@ impl ScreenState {
     /// run here matches that method's relative order exactly (LAND →
     /// ping-of-death → teardrop → icmp-fragment → source-route → icmp-flood
     /// → udp-flood).
+    ///
+    /// When the zone has no resolved profile this mirrors the flow-present
+    /// path's None branch (#3908): a zone that REFERENCES a screen profile
+    /// undefined at snapshot-build time gets a rate-limited runtime WARN via
+    /// `maybe_warn_missing_profile`, while a zone with no screen configured
+    /// passes silently. The verdict is `Pass` in both cases (watch-log-only,
+    /// no drop-behavior change — see the #3082 module note).
     pub(crate) fn check_flowless_screens(
         &mut self,
         zone: &str,
@@ -956,6 +967,17 @@ impl ScreenState {
         now_secs: u64,
     ) -> ScreenVerdict {
         let Some(profile) = self.profiles.get(zone) else {
+            // #3908: mirror the flow-present `check_packet_with_zone_id` None
+            // branch so the flowless path is as observable as the flow path.
+            // A zone that REFERENCES a screen profile undefined at
+            // snapshot-build time (lenient/HA-sync fail-open) gets a
+            // rate-limited runtime WARN; a zone with no screen configured
+            // passes silently (the helper distinguishes the two). Verdict is
+            // still Pass in BOTH cases — watch-log-only, no drop-behavior
+            // change (the fail-closed-vs-pass posture is the deferred #3082
+            // design decision). O(1): one hashmap lookup + a rate-limited
+            // increment; no unwrap/panic on the hot flowless path.
+            self.maybe_warn_missing_profile(zone, now_secs);
             return ScreenVerdict::Pass;
         };
         // --- Stateless, source-independent checks (side-effect-free) ---

--- a/userspace-dp/src/screen/tests.rs
+++ b/userspace-dp/src/screen/tests.rs
@@ -4344,6 +4344,116 @@ fn empty_missing_set_passes_without_warn() {
 }
 
 // ================================================================
+// #3908 — missing-screen-profile signal on the FLOWLESS path
+// ================================================================
+//
+// The flow-present `check_packet_with_zone_id` None branch calls
+// `maybe_warn_missing_profile` (#3082), but before #3908 the flowless
+// `check_flowless_screens` None branch returned Pass SILENTLY — a flowless
+// packet (non-first fragment / non-query ICMP) to a broken-profile zone
+// produced no diagnostic. These tests assert the flowless path now mirrors the
+// flow path: WARN-but-Pass for a referenced-missing profile, silent Pass for a
+// zone with no screen, and no missing-warn for a resolved profile.
+
+// A zone that REFERENCES a screen profile undefined at snapshot-build time
+// must take the WARN path on the flowless None branch — yet still return Pass
+// (watch-log-only, no verdict change). FAIL-ON-REVERT: drop the
+// `maybe_warn_missing_profile` call from `check_flowless_screens` and
+// `missing_profile_warn_count()` stays 0 → this test goes RED.
+#[test]
+fn missing_profile_reference_warns_on_flowless_path_but_passes() {
+    let mut state = ScreenState::new();
+    let mut missing = FxHashMap::default();
+    missing.insert("trust".to_string(), "ghost".to_string());
+    state.update_missing_profiles(missing);
+
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 2));
+    let pkt = flowless_icmp_pkt(src, dst);
+
+    // First flowless packet in second 1: WARN emitted, verdict Pass.
+    assert_eq!(
+        state.check_flowless_screens("trust", &pkt, true, 1),
+        ScreenVerdict::Pass
+    );
+    assert_eq!(
+        state.missing_profile_warn_count(),
+        1,
+        "first flowless packet to a missing-profile zone must emit exactly one WARN"
+    );
+
+    // Flood within the same second: rate-limited to the single WARN, all Pass.
+    for _ in 0..200 {
+        assert_eq!(
+            state.check_flowless_screens("trust", &pkt, true, 1),
+            ScreenVerdict::Pass
+        );
+    }
+    assert_eq!(
+        state.missing_profile_warn_count(),
+        1,
+        "a flowless per-packet flood within one second must be rate-limited to 1 WARN"
+    );
+
+    // After a multi-second quiet gap a new flowless packet re-emits one WARN.
+    assert_eq!(
+        state.check_flowless_screens("trust", &pkt, true, 10),
+        ScreenVerdict::Pass
+    );
+    assert_eq!(
+        state.missing_profile_warn_count(),
+        2,
+        "a flowless packet after a quiet gap must re-WARN"
+    );
+}
+
+// A zone with NO screen configured (absent from BOTH `profiles` and the
+// references-missing set) is the legit Pass case on the flowless path: it must
+// NOT warn. FAIL-SAFE: an over-broad flowless fix that warns on every None
+// would make this go RED.
+#[test]
+fn no_screen_configured_zone_passes_flowless_without_warn() {
+    let mut state = ScreenState::new();
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 2));
+    let pkt = flowless_icmp_pkt(src, dst);
+    for s in 1..6 {
+        assert_eq!(
+            state.check_flowless_screens("nozone", &pkt, true, s),
+            ScreenVerdict::Pass
+        );
+    }
+    assert_eq!(
+        state.missing_profile_warn_count(),
+        0,
+        "a zone with no screen configured must never WARN on the flowless path"
+    );
+}
+
+// A zone with a RESOLVED screen profile runs the real flowless checks and never
+// takes the missing-profile WARN path.
+#[test]
+fn resolved_profile_zone_flowless_never_warns_missing() {
+    // icmp_flood_threshold high enough that a single ICMP packet passes; the
+    // point is that the resolved-profile branch is taken (never the None WARN).
+    let mut profile = default_profile();
+    profile.icmp_flood_threshold = 1000;
+    let mut state = make_state("trust", profile);
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 2));
+    let pkt = flowless_icmp_pkt(src, dst);
+    assert_eq!(
+        state.check_flowless_screens("trust", &pkt, true, 1),
+        ScreenVerdict::Pass
+    );
+    assert_eq!(
+        state.missing_profile_warn_count(),
+        0,
+        "a resolved-profile zone must not take the missing-profile WARN path on the flowless path"
+    );
+}
+
+// ================================================================
 // #3902: source-independent screens on the FLOWLESS path
 // ================================================================
 //


### PR DESCRIPTION
## Summary

Closes #3908.

The flow-present `check_packet_with_zone_id` None branch calls
`maybe_warn_missing_profile` (#3082 observability) so a zone that references a
screen profile undefined at snapshot-build time (lenient/HA-sync fail-open)
emits a rate-limited runtime WARN. The flowless `check_flowless_screens` None
branch instead returned `ScreenVerdict::Pass` **silently**, so a flowless packet
— a non-first IP fragment or a non-query ICMP/ICMPv6 control message, which
never derive an L4 tuple — to a broken-profile zone produced **no diagnostic**.
The two paths disagreed on observability.

## Fix

`userspace-dp/src/screen/mod.rs` — on the `check_flowless_screens` None branch,
call `self.maybe_warn_missing_profile(zone, now_secs)` before returning `Pass`,
mirroring the flow-present path. This is **watch-log-only, no drop-behavior
change** — the verdict stays `Pass` in both cases (the fail-closed-vs-pass
posture is the deferred #3082 design decision).

The helper already distinguishes a zone that **references a missing profile**
(rate-limited WARN) from a zone with **no screen configured** (silent Pass), so
a no-screen zone still passes without warning — the fix does not over-block. The
call is O(1) (one hashmap lookup + a rate-limited increment) with no
unwrap/panic on the hot flowless path.

## Tests (RED-on-revert, all three cases)

`userspace-dp/src/screen/tests.rs`:

- `missing_profile_reference_warns_on_flowless_path_but_passes` — a
  missing-profile zone warns-once-but-passes and is rate-limited on the flowless
  path. **RED on revert**: with the fix line removed, `left: 0, right: 1`
  (asserts the WARN count).
- `no_screen_configured_zone_passes_flowless_without_warn` — a no-screen zone
  passes flowless without a warn (invariant guard; stays green on revert →
  proves no over-block).
- `resolved_profile_zone_flowless_never_warns_missing` — a resolved-profile zone
  runs the real flowless checks and never takes the missing-profile warn path
  (invariant guard; stays green on revert).

## Validation

- FULL `cargo test --release` (single-threaded): **3510 + 46 + 8 + 16 + 1
  passed, 0 failed** across all test binaries.
- `go build ./...` green.
- RED-on-revert proven: removing only the flowless warn line fails the
  missing-profile test while the two invariant guards stay green.
- Docs updated: the screen module #3082 note, the `check_flowless_screens`
  rustdoc, and `docs/syn-cookie-flood-protection.md` now state both paths share
  `maybe_warn_missing_profile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi