### PR TITLE
routing: consume interface modifier in fully-inline static route

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-07-04 — #3881: hierarchical inline-keys static route drops `interface` modifier
+
+- **Timestamp**: 2026-07-04
+  - **Action**: VERIFY-FIRST confirmed the defect at HEAD (9cd280f1e). The
+    hierarchical INLINE-keys route form (`route 2001:db8::/32 next-hop fe80::1
+    interface reth0.50;` on one line, no braces) collapses the whole route onto
+    ONE leaf node `Keys=[route <dst> next-hop fe80::1 interface reth0.50]` with
+    NO children → `compileStaticRoutes` takes the inline-keys switch. The
+    `next-hop` case absorbed the gateway run (stopping at the `interface` route
+    keyword via `isRouteInlineKeyword`) but had NO logic to consume the trailing
+    `interface <if>` modifier → the egress interface was silently DROPPED. A
+    scratch repro compiled `nexthops=[{Address:fe80::1 Interface:""}]`. For an
+    IPv6 link-local next-hop the egress interface is REQUIRED (unresolvable
+    without it). FIX (`pkg/config/compiler_routing.go`): the inline-keys
+    `next-hop` case now collects the gateways into a slice, then consumes a
+    trailing `interface <if>` and applies it to the gateway(s), mirroring the
+    working child/brace form. Both the inline-keys case and the child/brace
+    read now treat `interface` as the modifier keyword ONLY after ≥1 gateway is
+    parsed (Copilot defect 2, negligible edge), so a next-hop value literally
+    named `interface` as the FIRST token stays a gateway value.
+  - **File(s)**: pkg/config/compiler_routing.go,
+    pkg/config/compiler_static_route_inline_iface_3881_test.go,
+    docs/config-schema.md, _Log.md
+  - **Validation**: 5 new tests (inline-keys / brace / flat-set interface
+    modifier + inline ECMP + literal-`interface`-first-value). RED-on-revert
+    proven: reverting the two edits fails `TestStaticRouteInlineKeysInterface
+    Modifier_3881` (Interface="") and `TestStaticRouteNextHopLiteralInterface
+    FirstValue_3881` (0 next-hops); brace + flat-set stay green.
+    `go test ./pkg/config/...` green, `go build ./...` clean, gofmt + go vet
+    clean.
+
 ## 2026-07-04 — #4120: drop leftover test-env `is_trust_flow` debug-log bypass (fable-163 F27)
 
 - **Timestamp**: 2026-07-04

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -184,6 +184,25 @@ floating-backup leaf carrying its own per-next-hop preference (#3871): a plain
 `next-hop` list is equal-cost ECMP, a `qualified-next-hop` is a distance-N
 backup.
 
+**Fully-inline route-keys form drops the `interface` modifier (#3881).** The
+above covers the flat-set and hierarchical-brace shapes, where `next-hop` is
+its own leaf/child node. A THIRD shape exists: the hierarchical route written
+on ONE line with no braces (`route 2001:db8::/32 next-hop fe80::1 interface
+reth0.50;`) collapses the WHOLE route onto one leaf with NO children —
+`Keys=[route <dst> next-hop fe80::1 interface reth0.50]`. `compileStaticRoutes`
+(`compiler_routing.go`) reads this via the inline-keys switch, walking the route
+node's `Keys[2:]` clause by clause; `isRouteInlineKeyword` (which includes
+`interface`) bounds the multi-value gateway run so it stops before the modifier.
+Before #3881 the switch had a `next-hop` case but NO logic to consume the
+trailing `interface <if>` after the gateway run, so the egress interface was
+silently dropped — fatal for an IPv6 link-local next-hop (`fe80::/10`), whose
+gateway is unresolvable without a bound egress interface. The inline-keys
+`next-hop` case now consumes a trailing `interface <if>` and applies it to the
+gateway(s), mirroring the child/brace form. Both the inline-keys case and the
+child/brace read treat `interface` as the modifier keyword ONLY after ≥1
+gateway is parsed, so a next-hop value literally named `interface` as the FIRST
+token stays a gateway value rather than being misparsed as the modifier.
+
 **Delete-side contract: `delete` a member, not the whole list (#3846).**
 The read-side accumulate rule above has a mirror on the edit side. A
 `delete ... from protocol tcp` on a bracket-list leaf must remove ONLY the

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -174,9 +174,28 @@ func compileStaticRoutes(staticNode *Node, existing []*StaticRoute) []*StaticRou
 					// fully-inline form: consume consecutive gateway tokens
 					// until the next route keyword, installing each as an
 					// equal-cost next-hop (#3872).
+					var addrs []string
 					for i+1 < len(routeInst.node.Keys) && !isRouteInlineKeyword(routeInst.node.Keys[i+1]) {
 						i++
-						route.NextHops = append(route.NextHops, NextHopEntry{Address: routeInst.node.Keys[i]})
+						addrs = append(addrs, routeInst.node.Keys[i])
+					}
+					// A single-gateway next-hop may carry a trailing `interface
+					// <if>` egress modifier (#3881). In the fully-inline route-keys
+					// form (`route <dst> next-hop fe80::1 interface reth0.50` — no
+					// braces) `interface` is a route keyword, so the gateway run
+					// above stops before it; without this the modifier is dropped.
+					// For an IPv6 link-local next-hop the egress interface is
+					// REQUIRED (a link-local gateway is unresolvable without it).
+					// Consume the modifier ONLY after ≥1 gateway is parsed, so a
+					// bare-first `interface` token stays a gateway value, not the
+					// modifier.
+					iface := ""
+					if len(addrs) > 0 && i+2 < len(routeInst.node.Keys) && routeInst.node.Keys[i+1] == "interface" {
+						iface = routeInst.node.Keys[i+2]
+						i += 2
+					}
+					for _, a := range addrs {
+						route.NextHops = append(route.NextHops, NextHopEntry{Address: a, Interface: iface})
 					}
 				case "next-table":
 					if i+1 < len(routeInst.node.Keys) {
@@ -247,7 +266,11 @@ func compileStaticRoutes(staticNode *Node, existing []*StaticRoute) []*StaticRou
 				var addrs []string
 				iface := ""
 				for j := 1; j < len(prop.Keys); j++ {
-					if prop.Keys[j] == "interface" {
+					// Treat `interface` as the egress modifier only after ≥1
+					// gateway has been parsed (#3881). A next-hop value literally
+					// named "interface" as the FIRST token is a gateway, not the
+					// modifier keyword.
+					if prop.Keys[j] == "interface" && len(addrs) > 0 {
 						if j+1 < len(prop.Keys) {
 							iface = prop.Keys[j+1]
 							j++

--- a/pkg/config/compiler_static_route_inline_iface_3881_test.go
+++ b/pkg/config/compiler_static_route_inline_iface_3881_test.go
@@ -1,0 +1,110 @@
+package config
+
+import "testing"
+
+// compileHier3881 parses a hierarchical (brace / inline-keys) config source and
+// compiles it, so tests can exercise the NON-flat-set AST shapes.
+func compileHier3881(t *testing.T, src string) *Config {
+	t.Helper()
+	p := NewParser(src)
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse %q: %v", src, perrs)
+	}
+	c, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile %q: %v", src, err)
+	}
+	return c
+}
+
+// The hierarchical INLINE-keys route form collapses the whole route onto one
+// leaf node's Keys with NO children:
+//
+//	route 2001:db8::/32 next-hop fe80::1 interface reth0.50;   (one line, no braces)
+//
+// The trailing `interface <if>` is the egress modifier of the preceding
+// gateway. For an IPv6 LINK-LOCAL next-hop (fe80::/10) the egress interface is
+// REQUIRED — the gateway is ambiguous/unresolvable without it. Before #3881 the
+// inline-keys switch had no logic to consume `interface <if>` after the gateway
+// run, so the interface was silently DROPPED and the route misinstalled.
+//
+// RED-on-revert: nh.Interface is "" (interface dropped) on revert.
+func TestStaticRouteInlineKeysInterfaceModifier_3881(t *testing.T) {
+	c := compileHier3881(t,
+		`routing-options { static { route 2001:db8::/32 next-hop fe80::1 interface reth0.50; } }`)
+	r := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "2001:db8::/32")
+	if len(r.NextHops) != 1 {
+		t.Fatalf("NextHops = %d, want 1: %+v", len(r.NextHops), r.NextHops)
+	}
+	nh := r.NextHops[0]
+	if nh.Address != "fe80::1" || nh.Interface != "reth0.50" {
+		t.Fatalf("inline-keys next-hop = {Address:%q Interface:%q}, want {fe80::1 reth0.50}",
+			nh.Address, nh.Interface)
+	}
+}
+
+// The hierarchical BRACE form (route node WITH children) already carried the
+// interface modifier — this pins it so the #3881 fix does not regress the shape
+// that worked.
+func TestStaticRouteBraceInterfaceModifier_3881(t *testing.T) {
+	c := compileHier3881(t,
+		`routing-options { static { route 2001:db8::/32 { next-hop fe80::1 interface reth0.50; } } }`)
+	r := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "2001:db8::/32")
+	if len(r.NextHops) != 1 {
+		t.Fatalf("NextHops = %d, want 1: %+v", len(r.NextHops), r.NextHops)
+	}
+	nh := r.NextHops[0]
+	if nh.Address != "fe80::1" || nh.Interface != "reth0.50" {
+		t.Fatalf("brace next-hop = {Address:%q Interface:%q}, want {fe80::1 reth0.50}",
+			nh.Address, nh.Interface)
+	}
+}
+
+// The flat-set form (ParseSetCommand + SetPath) already carried the interface
+// modifier (#3872) — pin it alongside the two hierarchical shapes so all three
+// entry paths agree.
+func TestStaticRouteFlatSetInterfaceModifier_3881(t *testing.T) {
+	c := compileSets3870(t, []string{
+		"set routing-options static route 2001:db8::/32 next-hop fe80::1 interface reth0.50",
+	})
+	r := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "2001:db8::/32")
+	if len(r.NextHops) != 1 {
+		t.Fatalf("NextHops = %d, want 1: %+v", len(r.NextHops), r.NextHops)
+	}
+	nh := r.NextHops[0]
+	if nh.Address != "fe80::1" || nh.Interface != "reth0.50" {
+		t.Fatalf("flat-set next-hop = {Address:%q Interface:%q}, want {fe80::1 reth0.50}",
+			nh.Address, nh.Interface)
+	}
+}
+
+// An inline-keys ECMP list keeps every gateway AND applies a trailing interface
+// modifier to the gateways (single-egress link-local ECMP). Guards that the
+// #3881 interface consume did not break the #3872 multi-gateway absorb.
+func TestStaticRouteInlineKeysECMPStillWorks_3881(t *testing.T) {
+	c := compileHier3881(t,
+		`routing-options { static { route 10.1.0.0/16 next-hop 10.0.0.1 10.0.0.2; } }`)
+	r := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "10.1.0.0/16")
+	got := nhAddrs3872(r.NextHops)
+	if len(got) != 2 || got[0] != "10.0.0.1" || got[1] != "10.0.0.2" {
+		t.Fatalf("inline ECMP next-hops = %v, want [10.0.0.1 10.0.0.2]", got)
+	}
+}
+
+// Defect 2 (negligible edge): a next-hop value literally named "interface" as
+// the FIRST token must be treated as a gateway, not the modifier keyword. The
+// interface-modifier detection fires only after ≥1 gateway is parsed.
+func TestStaticRouteNextHopLiteralInterfaceFirstValue_3881(t *testing.T) {
+	c := compileHier3881(t,
+		`routing-options { static { route 10.9.0.0/16 { next-hop interface; } } }`)
+	r := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "10.9.0.0/16")
+	if len(r.NextHops) != 1 {
+		t.Fatalf("NextHops = %d, want 1: %+v", len(r.NextHops), r.NextHops)
+	}
+	nh := r.NextHops[0]
+	if nh.Address != "interface" || nh.Interface != "" {
+		t.Fatalf("bare-first literal next-hop = {Address:%q Interface:%q}, want gateway {interface \"\"}",
+			nh.Address, nh.Interface)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3881: the hierarchical INLINE-keys static route form (a route written on one line with no braces, e.g. `route 2001:db8::/32 next-hop fe80::1 interface reth0.50;`) silently DROPPED the `interface` egress modifier. For an IPv6 link-local next-hop (`fe80::/10`) the egress interface is REQUIRED — the gateway is unresolvable without it — so the route was misinstalled.

## Root cause

This route shape collapses the whole route onto ONE leaf node with NO children — `Keys=[route <dst> next-hop fe80::1 interface reth0.50]`. `compileStaticRoutes` (`pkg/config/compiler_routing.go`) reads it via the inline-keys switch. The `next-hop` case absorbed the multi-value gateway run and correctly stopped before the `interface` route keyword (bounded by `isRouteInlineKeyword`), but the switch had no logic to consume the trailing `interface <if>` as the modifier of the preceding gateway. The flat-set and hierarchical-brace shapes already carried the modifier (#3872); only the fully-inline shape lost it.

## Fix

- The inline-keys `next-hop` case now collects the gateways into a slice and, after the run, consumes a trailing `interface <if>` and applies it to the gateway(s), mirroring the working child/brace form.
- Restrict the `interface`-as-modifier detection (both the inline case and the child/brace next-hop read) to fire ONLY after >=1 gateway is parsed, so a next-hop value literally named `interface` as the FIRST token stays a gateway value rather than being misparsed as the modifier keyword (Copilot inline defect 2 on #3879, negligible edge).

## Testing

Five new tests in `compiler_static_route_inline_iface_3881_test.go`: inline-keys / brace / flat-set interface-modifier shapes, inline-keys ECMP, and the literal-`interface`-first-value edge.

RED-on-revert proven: reverting the two edits fails `TestStaticRouteInlineKeysInterfaceModifier_3881` (Interface dropped) and `TestStaticRouteNextHopLiteralInterfaceFirstValue_3881` (route lost); the brace and flat-set tests stay green.

- `go test ./pkg/config/...` green
- `go build ./...` clean
- gofmt + go vet clean
- `docs/config-schema.md` documents the third (fully-inline) shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi