### PR TITLE
config: merge duplicate match/then/from blocks in NAT rules + filter terms (#3850)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -32941,3 +32941,43 @@ top.
   - **File(s)**: userspace-dp/src/screen/mod.rs,
     userspace-dp/src/screen/tests.rs, docs/syn-cookie-flood-protection.md,
     _Log.md
+
+- **Timestamp**: 2026-07-04
+  - **Action**: #3850 — NAT-rule + firewall filter-term duplicate
+    `match`/`then`/`from` blocks read first-block-only (fail-open sibling of
+    #3842). #3842 fixed duplicate inner match/then blocks for SECURITY POLICIES
+    and #3915 for the `nat {}` SUB-blocks, but the same first-block-only class
+    survived in three sibling constructs. `compileNATSource`/`Destination`/
+    `Static` (compiler_nat.go) read `ruleInst.node.FindChild("match")` /
+    `FindChild("then")`; `compileFirewall` read `termInst.node.FindChild("from")`
+    / `FindChild("then")`; `compileSecurity` read the singleton
+    `pre-id-default-policy` `then` via FindChild. `parseStatements` APPENDS a
+    repeated hierarchical block as a sibling at EVERY level, so a
+    `load merge`/`load override` (or a hierarchical config authored twice) that
+    split a rule's/term's conditions across two `match`/`from` blocks had the
+    SECOND block SILENTLY DROPPED — the NAT rule / filter term matched a WIDER
+    set than configured (a fail-open widening), and a second `then` block's
+    action was lost. FIX: iterate EVERY sibling block with `FindChildren`
+    (two-nested-loop form preserving brace depth) so all match/from conditions
+    AND-combine and all then actions apply; a single translation / terminal
+    action resolves last-wins across duplicate then blocks (Junos merge, never a
+    silent drop). Flat-set is inherently safe — `SetPath` container-descent
+    (ast_edit.go) merges duplicate `match`/`from` containers onto one node, so
+    the fail-open is reachable ONLY via the hierarchical `NewParser` shape
+    (verified empirically). SECONDARY: `validatePolicyTerminalActionStrict`
+    (compiler_validate_strict.go) now DEDUPS `pol.terminalActions` by distinct
+    value before the #3043 count, so two IDENTICAL `then { permit; }` blocks
+    merge silently (Junos-faithful) instead of over-rejecting as "2 conflicting
+    terminal actions (permit, permit)"; permit+reject still rejected. TESTS
+    (RED-on-revert, 8 of 13 go RED on source revert): NAT source/destination/
+    static two-`match`-block merge, NAT source two-`then`-block last-wins,
+    filter term two-`from`/two-`then`-block merge, `pre-id-default-policy`
+    two-`then`-block; flat-set split-condition merge regression guards + single-
+    block bit-identical guards stay green; identical-permit merge + permit/reject
+    still-rejected for the dedup. `go test ./pkg/config/...` green; go build
+    ./..., go vet, gofmt clean. Docs: docs/config-schema.md #3850 entry
+    alongside #3842/#3915.
+  - **File(s)**: pkg/config/compiler_nat.go, pkg/config/compiler_firewall.go,
+    pkg/config/compiler_security.go, pkg/config/compiler_validate_strict.go,
+    pkg/config/compiler_dup_match_then_3850_test.go, docs/config-schema.md,
+    _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -33041,3 +33041,26 @@ top.
     pkg/config/compiler_security.go, pkg/config/compiler_validate_strict.go,
     pkg/config/compiler_dup_match_then_3850_test.go, docs/config-schema.md,
     _Log.md
+
+- **Timestamp**: 2026-07-04
+  - **Action**: #3850 fold (PR #4139 hostile-review MINOR) — reset the NAT
+    `then` translation spec per block for true last-wins. The #3850 NAT-then
+    merge iterated every `then {}` block but wrote fields by OVERWRITE, so a
+    duplicate then that switches translation TYPE (`then { source-nat
+    interface; }` then `then { source-nat pool poolB; }`) left BOTH
+    Interface=true AND PoolName=poolB on rule.Then → dataplane field-precedence
+    decided, latent stale field. Not a regression / not security-relevant, but
+    overstated "last-wins". FIX: `rule.Then = NATThen{}` at the top of each
+    then-block in compileNATSource (compiler_nat.go:1697) and
+    compileNATDestination (:1921); static NAT resets only the then-set fields
+    `rule.Then=""`/`IsNPTv6=false`/`MappedPort=0` (:2185-2187) so the match
+    fields set by the match loop persist. Reset runs BETWEEN blocks so
+    within-block `prefix X mapped-port P` coupling survives. compileFilterThen
+    (compiler_firewall.go:662) and pre-id-default-policy then are DELIBERATELY
+    NOT reset — they legitimately accumulate modifiers (count+accept /
+    LogSessionInit+Close). TEST: TestNATSourceDupThenTypeSwitchResetsStaleField
+    _3850 — interface→pool switch compiles pool-only (Interface=false); RED on
+    revert of the reset (verified: stale Interface=true). 14 #3850 tests green;
+    go build ./..., go vet, gofmt clean. Merged origin/master (auto-resolved).
+  - **File(s)**: pkg/config/compiler_nat.go,
+    pkg/config/compiler_dup_match_then_3850_test.go, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1844,6 +1844,51 @@ reserved for whole-dataplane selection where a rewrite shim
   RED-on-revert for source/destination/static/nat64/proxy-arp, pool merge,
   single-block bit-identical guard — built with `NewParser` for the
   `LoadOverride` dup-block shape, driving `compileNAT` directly).
+- **#3850 (the NAT-RULE and filter-TERM analogue of #3842 — duplicate
+  `match {}`/`then {}` / `from {}` blocks UNDER ONE rule or term):** #3842 fixed
+  the duplicate inner `match`/`then` blocks for SECURITY POLICIES and #3915 for
+  the `nat {}` SUB-blocks, but the SAME first-block-only fail-open survived in
+  three sibling constructs. The per-rule / per-term body read only the FIRST
+  inner block via `FindChild`:
+  - **NAT rules** — `compileNATSource` / `compileNATDestination` /
+    `compileNATStatic` (`compiler_nat.go`) read `ruleInst.node.FindChild("match")`
+    and `FindChild("then")`. A rule with a duplicate `match {}` block had the
+    second block's constraint (e.g. a `destination-address` split into a second
+    block by `load merge`) silently dropped → the NAT rule matched a WIDER set of
+    traffic than configured (a fail-open widening / mis-translation).
+  - **Firewall filter terms** — `compileFirewall` read `termInst.node.FindChild(
+    "from")` and `FindChild("then")`. A term with duplicate `from {}` blocks
+    likewise dropped the second block's match conditions (fail-open widening);
+    a duplicate `then {}` dropped the second block's action.
+  - **`pre-id-default-policy`** — `compileSecurity` read the singleton `then {}`
+    with `FindChild` (narrow surface, session-log modes only).
+
+  The fix iterates EVERY sibling block with `FindChildren` (a two-nested-loop
+  form that preserves brace depth): the NAT rule loops read `match {}` and
+  `then {}` blocks in full; the filter term calls `compileFilterFrom` /
+  `compileFilterThen` once per block (both ACCUMULATE into the term, and
+  `compileFilterThen` still handles the leaf form `then accept;` where the
+  action rides on `Keys`, not `Children`). All match/from conditions AND-combine;
+  a NAT rule's single translation action and a filter term's terminal action
+  (accept/discard/reject) resolve last-wins across duplicate `then` blocks (Junos
+  merges duplicate stanzas — the second is applied, never silently dropped). The
+  flat-set path is INHERENTLY SAFE: `SetPath` container-descent (`ast_edit.go`)
+  merges two `set … match X` / `set … match Y` lines onto ONE `match` node, so
+  this fail-open is reachable ONLY via the hierarchical `NewParser` /
+  `LoadMerge`/`LoadOverride` shape. SECONDARY (same review): the #3843/#3043
+  conflicting-terminal-action gate `validatePolicyTerminalActionStrict`
+  (`compiler_validate_strict.go`) now DEDUPS `pol.terminalActions` by distinct
+  value before the count, so two IDENTICAL `then { permit; }` blocks merge
+  silently (Junos-faithful) instead of over-rejecting as "2 conflicting terminal
+  actions (permit, permit)"; only DIFFERENT actions (permit + reject) still trip
+  the gate. Regression coverage:
+  `pkg/config/compiler_dup_match_then_3850_test.go` (RED-on-revert: NAT
+  source/destination/static two-`match`-block merge, NAT source two-`then`-block
+  last-wins, filter term two-`from`/two-`then`-block merge, `pre-id-default-policy`
+  two-`then`-block; flat-set split-condition merge regression guards; single-block
+  bit-identical guards; identical-permit merge + permit/reject-still-rejected for
+  the dedup — built with `NewParser` for the `LoadOverride` shape, driving
+  `compileNAT`/`compileFirewall`/`compileSecurity` directly).
 - **#3473 (duplicate security-policy names — strict commit gate):**
   `validateDuplicatePolicyNamesStrict` (`compiler_validate_strict.go`)
   hard-rejects two security policies that share a name within the same

--- a/pkg/config/compiler_dup_match_then_3850_test.go
+++ b/pkg/config/compiler_dup_match_then_3850_test.go
@@ -1,0 +1,578 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3850: a NAT rule or firewall filter term with DUPLICATE inner `match {}` /
+// `then {}` / `from {}` blocks was read FIRST-BLOCK-ONLY. The Junos parser
+// APPENDS a repeated hierarchical block as a SEPARATE sibling (parseStatements)
+// rather than merging it, and `load merge` / `load override` can produce two
+// such blocks under one rule/term. The old `FindChild("match"/"then"/"from")`
+// first-block-only read silently DROPPED the second block's conditions (a
+// fail-open widening of the match) or its action — the same class #3842 fixed
+// for security policies and #3915 fixed for the nat SUB-blocks (source/
+// destination/static). The fix iterates EVERY sibling block with FindChildren
+// so all conditions AND-combine and all actions apply (Junos merge semantics).
+//
+// The flat-set path is INHERENTLY SAFE: SetPath merges duplicate containers
+// into a single node (ast_edit.go container-descent), so two `set ... match X`
+// / `set ... match Y` lines collapse onto ONE `match` node. The flat-set tests
+// below therefore prove the merge reads all conditions (a regression guard),
+// while the hierarchical tests go RED on revert (the compiler reads only the
+// first sibling block).
+
+// containsStr3850 reports whether xs contains s.
+func containsStr3850(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+// --- NAT SOURCE ------------------------------------------------------------
+
+// TestNATSourceDupMatchBlocksMerge_3850 is the primary fail-open case: a source
+// NAT rule with two `match {}` blocks, source-address in the first and
+// destination-address in the second. Both constraints must compile. Reverting
+// compileNATSource's match read to FindChild-first drops the second block's
+// destination-address -> the rule matches a WIDER set of traffic than
+// configured (a fail-open NAT widening) and this goes RED.
+func TestNATSourceDupMatchBlocksMerge_3850(t *testing.T) {
+	cfgText := `
+security {
+    nat {
+        source {
+            rule-set RS1 {
+                from zone trust;
+                to zone untrust;
+                rule R1 {
+                    match {
+                        source-address 10.0.0.0/24;
+                    }
+                    match {
+                        destination-address 20.0.0.0/24;
+                    }
+                    then {
+                        source-nat interface;
+                    }
+                }
+            }
+        }
+    }
+}
+`
+	nat := natNodeFromText(t, cfgText)
+	rule := nat.FindChild("source").FindChild("rule-set").FindChild("rule")
+	if n := len(rule.FindChildren("match")); n != 2 {
+		t.Fatalf("precondition: expected 2 match blocks under the rule, got %d", n)
+	}
+	sec := &SecurityConfig{}
+	if err := compileNAT(nat, sec); err != nil {
+		t.Fatalf("compileNAT: %v", err)
+	}
+	r := sec.NAT.Source[0].Rules[0]
+	if !containsStr3850(r.Match.SourceAddresses, "10.0.0.0/24") {
+		t.Fatalf("first match block source-address dropped: %v", r.Match.SourceAddresses)
+	}
+	if !containsStr3850(r.Match.DestinationAddresses, "20.0.0.0/24") {
+		t.Fatalf("SECOND match block destination-address DROPPED (first-block-only fail-open); "+
+			"DestinationAddresses=%v", r.Match.DestinationAddresses)
+	}
+}
+
+// TestNATSourceDupThenBlocksApplied_3850: two `then {}` blocks each naming a
+// source-nat pool. A NAT rule has one translation action, so the second block
+// resolves last-wins (Junos merges duplicate stanzas). Reverting the then read
+// to FindChild-first keeps only the first pool -> RED.
+func TestNATSourceDupThenBlocksApplied_3850(t *testing.T) {
+	cfgText := `
+security {
+    nat {
+        source {
+            rule-set RS1 {
+                from zone trust;
+                to zone untrust;
+                rule R1 {
+                    match {
+                        source-address 10.0.0.0/24;
+                    }
+                    then {
+                        source-nat pool poolA;
+                    }
+                    then {
+                        source-nat pool poolB;
+                    }
+                }
+            }
+        }
+    }
+}
+`
+	nat := natNodeFromText(t, cfgText)
+	rule := nat.FindChild("source").FindChild("rule-set").FindChild("rule")
+	if n := len(rule.FindChildren("then")); n != 2 {
+		t.Fatalf("precondition: expected 2 then blocks, got %d", n)
+	}
+	sec := &SecurityConfig{}
+	if err := compileNAT(nat, sec); err != nil {
+		t.Fatalf("compileNAT: %v", err)
+	}
+	r := sec.NAT.Source[0].Rules[0]
+	if r.Then.PoolName != "poolB" {
+		t.Fatalf("SECOND then block source-nat pool DROPPED (first-block-only); "+
+			"PoolName=%q, want poolB (last-wins merge)", r.Then.PoolName)
+	}
+}
+
+// --- NAT DESTINATION -------------------------------------------------------
+
+// TestNATDestinationDupMatchBlocksMerge_3850: two `match {}` blocks under a
+// destination NAT rule (destination-address in one, source-address in the
+// other). Both must compile; revert drops the second -> RED.
+func TestNATDestinationDupMatchBlocksMerge_3850(t *testing.T) {
+	cfgText := `
+security {
+    nat {
+        destination {
+            pool P1 {
+                address 10.0.30.100;
+            }
+            rule-set RD1 {
+                from zone untrust;
+                rule R1 {
+                    match {
+                        destination-address 198.51.100.1/32;
+                    }
+                    match {
+                        source-address 203.0.113.0/24;
+                    }
+                    then {
+                        destination-nat pool P1;
+                    }
+                }
+            }
+        }
+    }
+}
+`
+	nat := natNodeFromText(t, cfgText)
+	sec := &SecurityConfig{}
+	if err := compileNAT(nat, sec); err != nil {
+		t.Fatalf("compileNAT: %v", err)
+	}
+	r := sec.NAT.Destination.RuleSets[0].Rules[0]
+	if !containsStr3850(r.Match.DestinationAddresses, "198.51.100.1/32") {
+		t.Fatalf("first match block destination-address dropped: %v", r.Match.DestinationAddresses)
+	}
+	if !containsStr3850(r.Match.SourceAddresses, "203.0.113.0/24") {
+		t.Fatalf("SECOND match block source-address DROPPED (first-block-only fail-open); "+
+			"SourceAddresses=%v", r.Match.SourceAddresses)
+	}
+}
+
+// --- NAT STATIC ------------------------------------------------------------
+
+// TestNATStaticDupMatchBlocksMerge_3850: two `match {}` blocks under a static
+// NAT rule (destination-address in one, source-address in the other). Both must
+// compile; revert drops the second -> RED.
+func TestNATStaticDupMatchBlocksMerge_3850(t *testing.T) {
+	cfgText := `
+security {
+    nat {
+        static {
+            rule-set ST1 {
+                from zone untrust;
+                rule R1 {
+                    match {
+                        destination-address 198.51.100.10/32;
+                    }
+                    match {
+                        source-address 203.0.113.0/24;
+                    }
+                    then {
+                        static-nat prefix 10.0.1.10/32;
+                    }
+                }
+            }
+        }
+    }
+}
+`
+	nat := natNodeFromText(t, cfgText)
+	sec := &SecurityConfig{}
+	if err := compileNAT(nat, sec); err != nil {
+		t.Fatalf("compileNAT: %v", err)
+	}
+	r := sec.NAT.Static[0].Rules[0]
+	if r.Match != "198.51.100.10/32" {
+		t.Fatalf("first match block destination-address dropped: Match=%q", r.Match)
+	}
+	if !containsStr3850(r.SourceAddresses, "203.0.113.0/24") {
+		t.Fatalf("SECOND match block source-address DROPPED (first-block-only fail-open); "+
+			"SourceAddresses=%v", r.SourceAddresses)
+	}
+}
+
+// --- FIREWALL FILTER TERM --------------------------------------------------
+
+// firewallFromText parses cfgText and compiles the first `firewall` node.
+func firewallFromText(t *testing.T, cfgText string) *FirewallConfig {
+	t.Helper()
+	p := NewParser(cfgText)
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("Parse: %v", perrs)
+	}
+	fwNode := tree.FindChild("firewall")
+	if fwNode == nil {
+		t.Fatalf("no firewall node parsed")
+	}
+	fw := &FirewallConfig{}
+	if err := compileFirewall(fwNode, fw); err != nil {
+		t.Fatalf("compileFirewall: %v", err)
+	}
+	return fw
+}
+
+// TestFilterTermDupFromBlocksMerge_3850 is the primary filter fail-open case: a
+// term with two `from {}` blocks (source-address in one, destination-address in
+// the other). Both must compile; revert to FindChild-first drops the second
+// block's destination-address -> the term matches a WIDER set (fail-open) -> RED.
+func TestFilterTermDupFromBlocksMerge_3850(t *testing.T) {
+	cfgText := `
+firewall {
+    family inet {
+        filter F1 {
+            term T1 {
+                from {
+                    source-address 10.0.0.0/24;
+                }
+                from {
+                    destination-address 20.0.0.0/24;
+                }
+                then {
+                    accept;
+                }
+            }
+        }
+    }
+}
+`
+	fw := firewallFromText(t, cfgText)
+	term := fw.FiltersInet["F1"].Terms[0]
+	if !containsStr3850(term.SourceAddresses, "10.0.0.0/24") {
+		t.Fatalf("first from block source-address dropped: %v", term.SourceAddresses)
+	}
+	if !containsStr3850(term.DestAddresses, "20.0.0.0/24") {
+		t.Fatalf("SECOND from block destination-address DROPPED (first-block-only fail-open); "+
+			"DestAddresses=%v", term.DestAddresses)
+	}
+}
+
+// TestFilterTermDupThenBlocksApplied_3850: two `then {}` blocks, a `count`
+// modifier in the first and the terminal `accept` in the second. Both must
+// apply; revert to FindChild-first keeps only the first (count, no terminal
+// action) -> Action == "" -> RED.
+func TestFilterTermDupThenBlocksApplied_3850(t *testing.T) {
+	cfgText := `
+firewall {
+    family inet {
+        filter F1 {
+            term T1 {
+                from {
+                    source-address 10.0.0.0/24;
+                }
+                then {
+                    count C1;
+                }
+                then {
+                    accept;
+                }
+            }
+        }
+    }
+}
+`
+	fw := firewallFromText(t, cfgText)
+	term := fw.FiltersInet["F1"].Terms[0]
+	if term.Count != "C1" {
+		t.Fatalf("first then block count dropped: Count=%q", term.Count)
+	}
+	if term.Action != "accept" {
+		t.Fatalf("SECOND then block terminal action DROPPED (first-block-only); "+
+			"Action=%q, want accept", term.Action)
+	}
+}
+
+// --- FLAT-SET (regression guard: SetPath merges duplicate containers) -------
+
+// setPathTree builds a ConfigTree from flat `set` lines (the #2419 testing
+// discipline: ParseSetCommand + SetPath, never NewParser for set syntax).
+func setPathTree3850(t *testing.T, lines []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, l := range lines {
+		toks, err := ParseSetCommand(l)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", l, err)
+		}
+		if err := tree.SetPath(toks); err != nil {
+			t.Fatalf("SetPath(%v): %v", toks, err)
+		}
+	}
+	return tree
+}
+
+// TestNATSourceFlatSetSplitMatchMerges_3850 proves the flat-set shape is safe:
+// two `set ... match ...` lines with different conditions MERGE onto one match
+// node (SetPath container-descent), and the compiler reads BOTH. Green before
+// and after the fix (documents that the fail-open is hierarchical-only).
+func TestNATSourceFlatSetSplitMatchMerges_3850(t *testing.T) {
+	tree := setPathTree3850(t, []string{
+		"set security nat source rule-set RS1 from zone trust",
+		"set security nat source rule-set RS1 to zone untrust",
+		"set security nat source rule-set RS1 rule R1 match source-address 10.0.0.0/24",
+		"set security nat source rule-set RS1 rule R1 match destination-address 20.0.0.0/24",
+		"set security nat source rule-set RS1 rule R1 then source-nat interface",
+	})
+	nat := tree.FindChild("security").FindChild("nat")
+	rule := nat.FindChild("source").FindChild("rule-set").FindChild("rule")
+	if n := len(rule.FindChildren("match")); n != 1 {
+		t.Fatalf("flat-set should MERGE duplicate match containers into 1 node, got %d", n)
+	}
+	sec := &SecurityConfig{}
+	if err := compileNAT(nat, sec); err != nil {
+		t.Fatalf("compileNAT: %v", err)
+	}
+	r := sec.NAT.Source[0].Rules[0]
+	if !containsStr3850(r.Match.SourceAddresses, "10.0.0.0/24") ||
+		!containsStr3850(r.Match.DestinationAddresses, "20.0.0.0/24") {
+		t.Fatalf("flat-set merged match lost a condition: src=%v dst=%v",
+			r.Match.SourceAddresses, r.Match.DestinationAddresses)
+	}
+}
+
+// TestFilterTermFlatSetSplitFromMerges_3850 is the firewall analogue.
+func TestFilterTermFlatSetSplitFromMerges_3850(t *testing.T) {
+	tree := setPathTree3850(t, []string{
+		"set firewall family inet filter F1 term T1 from source-address 10.0.0.0/24",
+		"set firewall family inet filter F1 term T1 from destination-address 20.0.0.0/24",
+		"set firewall family inet filter F1 term T1 then accept",
+	})
+	fwNode := tree.FindChild("firewall")
+	term := fwNode.FindChild("family").FindChild("filter").FindChild("term")
+	if n := len(term.FindChildren("from")); n != 1 {
+		t.Fatalf("flat-set should MERGE duplicate from containers into 1 node, got %d", n)
+	}
+	fw := &FirewallConfig{}
+	if err := compileFirewall(fwNode, fw); err != nil {
+		t.Fatalf("compileFirewall: %v", err)
+	}
+	tm := fw.FiltersInet["F1"].Terms[0]
+	if !containsStr3850(tm.SourceAddresses, "10.0.0.0/24") ||
+		!containsStr3850(tm.DestAddresses, "20.0.0.0/24") {
+		t.Fatalf("flat-set merged from lost a condition: src=%v dst=%v",
+			tm.SourceAddresses, tm.DestAddresses)
+	}
+}
+
+// --- SINGLE-BLOCK REGRESSION GUARDS ----------------------------------------
+
+// TestNATSingleMatchThenUnchanged_3850 pins bit-identical behaviour for the
+// common single-block NAT rule after the FindChildren conversion.
+func TestNATSingleMatchThenUnchanged_3850(t *testing.T) {
+	cfgText := `
+security {
+    nat {
+        source {
+            rule-set RS1 {
+                from zone trust;
+                to zone untrust;
+                rule R1 {
+                    match {
+                        source-address 10.0.0.0/24;
+                        destination-address 20.0.0.0/24;
+                    }
+                    then {
+                        source-nat pool poolA;
+                    }
+                }
+            }
+        }
+    }
+}
+`
+	nat := natNodeFromText(t, cfgText)
+	sec := &SecurityConfig{}
+	if err := compileNAT(nat, sec); err != nil {
+		t.Fatalf("compileNAT: %v", err)
+	}
+	r := sec.NAT.Source[0].Rules[0]
+	if !containsStr3850(r.Match.SourceAddresses, "10.0.0.0/24") ||
+		!containsStr3850(r.Match.DestinationAddresses, "20.0.0.0/24") ||
+		r.Then.PoolName != "poolA" {
+		t.Fatalf("single-block NAT rule regressed: src=%v dst=%v pool=%q",
+			r.Match.SourceAddresses, r.Match.DestinationAddresses, r.Then.PoolName)
+	}
+}
+
+// TestFilterSingleFromThenUnchanged_3850 pins the single-block filter term.
+func TestFilterSingleFromThenUnchanged_3850(t *testing.T) {
+	cfgText := `
+firewall {
+    family inet {
+        filter F1 {
+            term T1 {
+                from {
+                    source-address 10.0.0.0/24;
+                    destination-address 20.0.0.0/24;
+                }
+                then {
+                    count C1;
+                    accept;
+                }
+            }
+        }
+    }
+}
+`
+	fw := firewallFromText(t, cfgText)
+	term := fw.FiltersInet["F1"].Terms[0]
+	if !containsStr3850(term.SourceAddresses, "10.0.0.0/24") ||
+		!containsStr3850(term.DestAddresses, "20.0.0.0/24") ||
+		term.Count != "C1" || term.Action != "accept" {
+		t.Fatalf("single-block filter term regressed: src=%v dst=%v count=%q action=%q",
+			term.SourceAddresses, term.DestAddresses, term.Count, term.Action)
+	}
+}
+
+// --- pre-id-default-policy (minor, singleton then) -------------------------
+
+// TestPreIDDefaultPolicyDupThenBlocks_3850: two `then {}` blocks under
+// pre-id-default-policy, session-init in the first and session-close in the
+// second. Both flags must set; revert to FindChild-first drops the second -> RED.
+func TestPreIDDefaultPolicyDupThenBlocks_3850(t *testing.T) {
+	cfgText := `
+security {
+    pre-id-default-policy {
+        then {
+            log {
+                session-init;
+            }
+        }
+        then {
+            log {
+                session-close;
+            }
+        }
+    }
+}
+`
+	p := NewParser(cfgText)
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("Parse: %v", perrs)
+	}
+	secNode := tree.FindChild("security")
+	sec := &SecurityConfig{}
+	if err := compileSecurity(secNode, sec); err != nil {
+		t.Fatalf("compileSecurity: %v", err)
+	}
+	if sec.PreIDDefaultPolicy == nil {
+		t.Fatalf("PreIDDefaultPolicy not compiled")
+	}
+	if !sec.PreIDDefaultPolicy.LogSessionInit {
+		t.Fatalf("first then block session-init dropped")
+	}
+	if !sec.PreIDDefaultPolicy.LogSessionClose {
+		t.Fatalf("SECOND then block session-close DROPPED (first-block-only)")
+	}
+}
+
+// --- SECONDARY: identical terminal actions merge silently ------------------
+
+// TestPolicyIdenticalPermitBlocksMerge_3850: two IDENTICAL `then { permit; }`
+// blocks are NOT a conflict (Junos merges duplicate stanzas). The #3043
+// conflicting-terminal-action gate must dedup by distinct value before the
+// count, so this commits. Before the fix it over-rejected as "2 conflicting
+// terminal actions (permit, permit)" -> reverting the dedup makes CompileConfig
+// return that error and this goes RED.
+func TestPolicyIdenticalPermitBlocksMerge_3850(t *testing.T) {
+	cfg := `security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy p {
+                match {
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then {
+                    permit;
+                }
+                then {
+                    permit;
+                }
+            }
+        }
+    }
+}`
+	p := NewParser(cfg)
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected two IDENTICAL permit blocks (should merge "+
+			"silently, Junos-faithful): %v", err)
+	}
+}
+
+// TestPolicyConflictingTerminalStillRejected_3850 guards the secondary fix: a
+// genuine permit + reject conflict (DIFFERENT actions) must STILL be rejected
+// after the identical-action dedup.
+func TestPolicyConflictingTerminalStillRejected_3850(t *testing.T) {
+	cfg := `security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy p {
+                match {
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then {
+                    permit;
+                }
+                then {
+                    reject;
+                }
+            }
+        }
+    }
+}`
+	p := NewParser(cfg)
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted permit+reject conflict (should reject)")
+	}
+	if !strings.Contains(err.Error(), "conflicting terminal actions") {
+		t.Fatalf("error = %q, want conflicting-terminal-actions rejection", err.Error())
+	}
+}

--- a/pkg/config/compiler_dup_match_then_3850_test.go
+++ b/pkg/config/compiler_dup_match_then_3850_test.go
@@ -128,6 +128,53 @@ security {
 	}
 }
 
+// TestNATSourceDupThenTypeSwitchResetsStaleField_3850 proves the per-block
+// reset (#3850 review fold): a source NAT rule whose first `then` block sets
+// `source-nat interface` and whose second sets `source-nat pool poolB` compiles
+// to a POOL-ONLY spec (PoolName=poolB, Interface=false) — true last-wins across
+// a translation-TYPE switch. Reverting the `rule.Then = NATThen{}` per-block
+// reset leaves the first block's Interface=true set ALONGSIDE PoolName=poolB
+// (both fields set, so the dataplane's field precedence decides, not true
+// last-wins), so this goes RED.
+func TestNATSourceDupThenTypeSwitchResetsStaleField_3850(t *testing.T) {
+	cfgText := `
+security {
+    nat {
+        source {
+            rule-set RS1 {
+                from zone trust;
+                to zone untrust;
+                rule R1 {
+                    match {
+                        source-address 10.0.0.0/24;
+                    }
+                    then {
+                        source-nat interface;
+                    }
+                    then {
+                        source-nat pool poolB;
+                    }
+                }
+            }
+        }
+    }
+}
+`
+	nat := natNodeFromText(t, cfgText)
+	sec := &SecurityConfig{}
+	if err := compileNAT(nat, sec); err != nil {
+		t.Fatalf("compileNAT: %v", err)
+	}
+	r := sec.NAT.Source[0].Rules[0]
+	if r.Then.PoolName != "poolB" {
+		t.Fatalf("second then block pool not applied: PoolName=%q, want poolB", r.Then.PoolName)
+	}
+	if r.Then.Interface {
+		t.Fatalf("STALE Interface=true from the first then block survived the translation-" +
+			"type switch (per-block reset missing); want Interface=false (true last-wins)")
+	}
+}
+
 // --- NAT DESTINATION -------------------------------------------------------
 
 // TestNATDestinationDupMatchBlocksMerge_3850: two `match {}` blocks under a

--- a/pkg/config/compiler_firewall.go
+++ b/pkg/config/compiler_firewall.go
@@ -193,13 +193,25 @@ func compileFirewall(node *Node, fw *FirewallConfig) error {
 						Name: termInst.name,
 					}
 
-					fromNode := termInst.node.FindChild("from")
-					if fromNode != nil {
+					// #3850: apply EVERY `from {}` block, not just the first via
+					// FindChild — a duplicate block (a `load merge`/`load
+					// override` that splits its conditions, or a hierarchical
+					// config authored twice) must AND-combine every condition,
+					// never be dropped (a fail-open widening of the term match).
+					// compileFilterFrom accumulates into term. Flat-set is
+					// unaffected: SetPath merges duplicate containers into one
+					// node (ast_edit.go), so this only changes the hierarchical
+					// (parser / load merge) shape.
+					for _, fromNode := range termInst.node.FindChildren("from") {
 						compileFilterFrom(fromNode, term, af)
 					}
 
-					thenNode := termInst.node.FindChild("then")
-					if thenNode != nil {
+					// #3850: apply EVERY `then {}` block. compileFilterThen
+					// accumulates modifiers (count/log/forwarding-class/...); a
+					// terminal action (accept/discard/reject) resolves last-wins
+					// across blocks (Junos merges duplicate stanzas), so the
+					// second block's action is applied, never silently dropped.
+					for _, thenNode := range termInst.node.FindChildren("then") {
 						compileFilterThen(thenNode, term)
 					}
 

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -1684,8 +1684,17 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 			// #3850: iterate EVERY `then {}` block, not just the first. A NAT
 			// rule carries a single translation action, so a duplicate then
 			// block resolves last-wins (Junos merges duplicate stanzas) — the
-			// second block's action is applied, never silently dropped.
+			// second block's action is applied, never silently dropped. RESET
+			// the translation spec at the top of each block so only the LAST
+			// block's fields survive: a source-nat then-block is a COMPLETE,
+			// mutually-exclusive spec (interface | pool | off), so without the
+			// reset a first `interface` block would leave Interface=true stale
+			// under a second `pool` block (both fields set → the dataplane's
+			// field precedence, not true last-wins). NATThen carries only these
+			// translation-mode fields, so a whole-struct reset is safe (#3850
+			// review).
 			for _, thenNode := range ruleInst.node.FindChildren("then") {
+				rule.Then = NATThen{}
 				for _, t := range thenNode.Children {
 					if t.Name() == "source-nat" {
 						if len(t.Keys) >= 2 {
@@ -1902,8 +1911,14 @@ func compileNATDestination(node *Node, sec *SecurityConfig) error {
 			// #3850: iterate EVERY `then {}` block, not just the first. A NAT
 			// rule carries a single translation action, so a duplicate then
 			// block resolves last-wins (Junos merges duplicate stanzas) — the
-			// second block's action is applied, never silently dropped.
+			// second block's action is applied, never silently dropped. RESET
+			// the translation spec at the top of each block (see the source-NAT
+			// note) so a second `pool` block cannot inherit a first `off`
+			// block's stale field; a destination-nat then-block is a complete
+			// mutually-exclusive spec (pool | off) and NATThen carries only
+			// translation-mode fields (#3850 review).
 			for _, thenNode := range ruleInst.node.FindChildren("then") {
+				rule.Then = NATThen{}
 				for _, t := range thenNode.Children {
 					if t.Name() == "destination-nat" {
 						// #3844: `then destination-nat off` is a no-translate
@@ -2157,8 +2172,19 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 			// #3850: iterate EVERY `then {}` block, not just the first. A NAT
 			// rule carries a single translation action, so a duplicate then
 			// block resolves last-wins (Junos merges duplicate stanzas) — the
-			// second block's action is applied, never silently dropped.
+			// second block's action is applied, never silently dropped. RESET
+			// the static-nat target fields at the top of each block so only the
+			// LAST block's spec survives (no stale prefix/nptv6/mapped-port from
+			// an earlier block). The reset covers ONLY the then-set fields
+			// (Then/IsNPTv6/MappedPort) — the match fields (Match/SourceAddress
+			// (es)/MatchDestinationPort) are set by the match loop above and MUST
+			// persist. A single static-nat then-block is a complete spec, so
+			// `prefix X mapped-port P` within one block stays coupled: the reset
+			// runs BETWEEN blocks, then the whole block is read (#3850 review).
 			for _, thenNode := range ruleInst.node.FindChildren("then") {
+				rule.Then = ""
+				rule.IsNPTv6 = false
+				rule.MappedPort = 0
 				for _, t := range thenNode.Children {
 					if t.Name() == "static-nat" {
 						if len(t.Keys) >= 3 && t.Keys[1] == "nptv6-prefix" {

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -1599,8 +1599,14 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 		for _, ruleInst := range namedInstances(rsInst.node.FindChildren("rule")) {
 			rule := &NATRule{Name: ruleInst.name}
 
-			matchNode := ruleInst.node.FindChild("match")
-			if matchNode != nil {
+			// #3850: iterate EVERY `match {}` block, not just the first — a
+			// duplicate block (a `load merge`/`load override` that splits its
+			// conditions, or a hierarchical config authored twice) must
+			// AND-combine every condition, never be dropped by a FindChild-first
+			// read (a fail-open widening of the NAT match). Flat-set is
+			// unaffected: SetPath merges duplicate containers into one node
+			// (ast_edit.go), so this only changes the hierarchical/parser shape.
+			for _, matchNode := range ruleInst.node.FindChildren("match") {
 				for _, m := range matchNode.Children {
 					switch m.Name() {
 					case "source-address":
@@ -1675,8 +1681,11 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 				}
 			}
 
-			thenNode := ruleInst.node.FindChild("then")
-			if thenNode != nil {
+			// #3850: iterate EVERY `then {}` block, not just the first. A NAT
+			// rule carries a single translation action, so a duplicate then
+			// block resolves last-wins (Junos merges duplicate stanzas) — the
+			// second block's action is applied, never silently dropped.
+			for _, thenNode := range ruleInst.node.FindChildren("then") {
 				for _, t := range thenNode.Children {
 					if t.Name() == "source-nat" {
 						if len(t.Keys) >= 2 {
@@ -1815,8 +1824,14 @@ func compileNATDestination(node *Node, sec *SecurityConfig) error {
 		for _, ruleInst := range namedInstances(rsInst.node.FindChildren("rule")) {
 			rule := &NATRule{Name: ruleInst.name}
 
-			matchNode := ruleInst.node.FindChild("match")
-			if matchNode != nil {
+			// #3850: iterate EVERY `match {}` block, not just the first — a
+			// duplicate block (a `load merge`/`load override` that splits its
+			// conditions, or a hierarchical config authored twice) must
+			// AND-combine every condition, never be dropped by a FindChild-first
+			// read (a fail-open widening of the NAT match). Flat-set is
+			// unaffected: SetPath merges duplicate containers into one node
+			// (ast_edit.go), so this only changes the hierarchical/parser shape.
+			for _, matchNode := range ruleInst.node.FindChildren("match") {
 				for _, m := range matchNode.Children {
 					switch m.Name() {
 					case "destination-address":
@@ -1884,8 +1899,11 @@ func compileNATDestination(node *Node, sec *SecurityConfig) error {
 				}
 			}
 
-			thenNode := ruleInst.node.FindChild("then")
-			if thenNode != nil {
+			// #3850: iterate EVERY `then {}` block, not just the first. A NAT
+			// rule carries a single translation action, so a duplicate then
+			// block resolves last-wins (Junos merges duplicate stanzas) — the
+			// second block's action is applied, never silently dropped.
+			for _, thenNode := range ruleInst.node.FindChildren("then") {
 				for _, t := range thenNode.Children {
 					if t.Name() == "destination-nat" {
 						// #3844: `then destination-nat off` is a no-translate
@@ -2093,8 +2111,14 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 		for _, ruleInst := range namedInstances(rsInst.node.FindChildren("rule")) {
 			rule := &StaticNATRule{Name: ruleInst.name}
 
-			matchNode := ruleInst.node.FindChild("match")
-			if matchNode != nil {
+			// #3850: iterate EVERY `match {}` block, not just the first — a
+			// duplicate block (a `load merge`/`load override` that splits its
+			// conditions, or a hierarchical config authored twice) must
+			// AND-combine every condition, never be dropped by a FindChild-first
+			// read (a fail-open widening of the NAT match). Flat-set is
+			// unaffected: SetPath merges duplicate containers into one node
+			// (ast_edit.go), so this only changes the hierarchical/parser shape.
+			for _, matchNode := range ruleInst.node.FindChildren("match") {
 				for _, m := range matchNode.Children {
 					switch m.Name() {
 					case "destination-address":
@@ -2130,8 +2154,11 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 				}
 			}
 
-			thenNode := ruleInst.node.FindChild("then")
-			if thenNode != nil {
+			// #3850: iterate EVERY `then {}` block, not just the first. A NAT
+			// rule carries a single translation action, so a duplicate then
+			// block resolves last-wins (Junos merges duplicate stanzas) — the
+			// second block's action is applied, never silently dropped.
+			for _, thenNode := range ruleInst.node.FindChildren("then") {
 				for _, t := range thenNode.Children {
 					if t.Name() == "static-nat" {
 						if len(t.Keys) >= 3 && t.Keys[1] == "nptv6-prefix" {

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -217,7 +217,10 @@ func compileSecurity(node *Node, sec *SecurityConfig) error {
 			}
 		case "pre-id-default-policy":
 			sec.PreIDDefaultPolicy = &PreIDDefaultPolicy{}
-			if thenNode := child.FindChild("then"); thenNode != nil {
+			// #3850: read EVERY `then {}` block, not just the first via
+			// FindChild — a duplicate then block (load merge/override) would
+			// otherwise have its session-log modes silently dropped.
+			for _, thenNode := range child.FindChildren("then") {
 				// #3703: multi-value session-log list leaf. Read every mode via
 				// the firewallMatchValues SSOT (Keys[1:] AND/OR one-per-child)
 				// across EVERY `log` leaf so a bracket `then log [ session-init

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -3264,7 +3264,24 @@ func validatePolicyTerminalActionStrict(cfg *Config) error {
 		if pol == nil {
 			return nil
 		}
-		switch len(pol.terminalActions) {
+		// #3850: two IDENTICAL terminal-action blocks (e.g. a `load merge` that
+		// duplicates the SAME `then { permit; }`, now both accumulated by the
+		// #3842 policyThenChildren read) are NOT a conflict — Junos merges them
+		// silently. Dedup by distinct action VALUE before the count so an
+		// identical duplicate collapses to one (commit succeeds, Junos-faithful)
+		// and only DIFFERENT terminal actions (e.g. permit + reject) trip the
+		// conflict gate. Before this the #3043 gate over-rejected `permit,permit`
+		// as "2 conflicting terminal actions (permit, permit)" — fail-closed but
+		// imprecise.
+		seen := make(map[PolicyAction]bool, len(pol.terminalActions))
+		distinct := make([]PolicyAction, 0, len(pol.terminalActions))
+		for _, a := range pol.terminalActions {
+			if !seen[a] {
+				seen[a] = true
+				distinct = append(distinct, a)
+			}
+		}
+		switch len(distinct) {
 		case 1:
 			return nil
 		case 0:
@@ -3274,15 +3291,15 @@ func validatePolicyTerminalActionStrict(cfg *Config) error {
 					"count-only or typo'd policy silently PERMITTED all matching "+
 					"traffic; it now defaults to deny on load)")
 		default:
-			names := make([]string, 0, len(pol.terminalActions))
-			for _, a := range pol.terminalActions {
+			names := make([]string, 0, len(distinct))
+			for _, a := range distinct {
 				names = append(names, policyActionName(a))
 			}
 			return policyTerminalActionError(scope, pol.Name, fmt.Sprintf(
 				"%d conflicting terminal actions (%s); a policy must specify "+
 					"exactly one of permit/deny/reject (the enforced action would "+
 					"otherwise depend on parse order)",
-				len(pol.terminalActions), strings.Join(names, ", ")))
+				len(distinct), strings.Join(names, ", ")))
 		}
 	}
 	for _, zpp := range cfg.Security.Policies {


### PR DESCRIPTION
## Summary

Closes #3850. Fixes the first-block-only fail-open in **NAT rules** and
**firewall filter terms** — the sibling of #3842 (security policies) and
#3915 (nat sub-blocks) that the #3847 hostile review flagged.

`parseStatements` APPENDS a repeated hierarchical block as a sibling at
every level, so `load merge` / `load override` (or a config authored
twice) can split a rule's or term's conditions across two `match`/`from`
blocks. The per-rule / per-term body read only the FIRST block via
`FindChild`:

- `compileNATSource` / `compileNATDestination` / `compileNATStatic` —
  `ruleInst.node.FindChild("match")` / `FindChild("then")`
- `compileFirewall` — `termInst.node.FindChild("from")` / `FindChild("then")`
- `compileSecurity` — the singleton `pre-id-default-policy` `then`

A duplicate `match`/`from` block had its constraints **silently dropped**
→ the NAT rule / filter term matched a **wider** set of traffic than
configured (a fail-open widening), and a duplicate `then` block's action
was lost — all with a clean commit.

## Fix

Iterate **every** sibling block with `FindChildren` (a two-nested-loop
form that preserves brace depth). All `match`/`from` conditions
AND-combine; `compileFilterFrom`/`compileFilterThen` already accumulate
into the term (and `compileFilterThen` still handles the leaf form
`then accept;` where the action rides on `Keys`). A NAT rule's single
translation action and a filter term's terminal action resolve
**last-wins** across duplicate `then` blocks (Junos merges duplicate
stanzas — the second is applied, never silently dropped).

The **flat-set path is inherently safe**: `SetPath` container-descent
(`ast_edit.go`) merges two `set … match X` / `set … match Y` lines onto
one `match` node, so this fail-open is reachable only via the
hierarchical `NewParser` / `LoadMerge`/`LoadOverride` shape (verified
empirically).

**Secondary** (same review): `validatePolicyTerminalActionStrict` now
dedups `pol.terminalActions` by distinct value before the #3043
conflicting-terminal-action count, so two IDENTICAL `then { permit; }`
blocks merge silently (Junos-faithful) instead of over-rejecting as
`2 conflicting terminal actions (permit, permit)`. Only DIFFERENT
actions (permit + reject) still trip the gate.

## Tests

`pkg/config/compiler_dup_match_then_3850_test.go` — RED-on-revert
(8 of 13 fail when the compiler is reverted to `origin/master`):

- NAT source/destination/static two-`match`-block merge
- NAT source two-`then`-block last-wins
- filter term two-`from` / two-`then`-block merge
- `pre-id-default-policy` two-`then`-block
- flat-set split-condition merge regression guards (stay green)
- single-block bit-identical guards (stay green)
- identical-permit merge + permit/reject-still-rejected (the dedup)

`go test ./pkg/config/...` green; `go build ./...`, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
