### PR TITLE
config: warn at commit when a scheduler defines no window

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-07-04 — #3860: warn at commit when a scheduler defines no window
+
+- **Timestamp**: 2026-07-04
+  - **Action**: VERIFY-FIRST at HEAD (113a1a0aa). Confirmed a degenerate
+    scheduler with no effective window (empty `scheduler x {}` or a bare
+    `daily;` — no start/stop time, no `all-day`, no per-day arm, no
+    start/stop date) compiles (`compileSchedulers`,
+    `pkg/config/compiler_system.go:1084`) to a `SchedulerConfig` with every
+    window field zero and NO commit warning. Post-#3849/#3858 the runtime
+    (`pkg/scheduler.isWithinWindow:278`) fail-closes such a scheduler to
+    INACTIVE (the security half of #3849; helpers `schedulerHasTimeWindow`
+    / `schedulerHasDateRange`). Only half-windows and unparseable
+    times/dates log today — the fully-degenerate always-on→INACTIVE flip
+    was silent. FIX: added a commit-time WARNING in `ValidateConfig`
+    (`pkg/config/compiler_validate_warn.go`) that iterates schedulers by
+    sorted name and, when `schedulerHasEffectiveWindow` is false, appends
+    `scheduler "X" defines no time window; policies bound to it will be
+    INACTIVE (use `+"`daily all-day`"+` for always-on)`. Warning, not
+    hard-reject (#1960-safe: degenerate scheduler is legal Junos; an
+    upgrade must not refuse an existing candidate). A scheduler with any
+    daily/weekday arm, `all-day`, or start/stop date does NOT warn.
+  - **File(s)**: pkg/config/compiler_validate_warn.go,
+    pkg/config/compiler_validate_scheduler_no_window_3860_test.go,
+    pkg/scheduler/README.md, _Log.md
+  - **Validation**: RED-on-revert proven (neutralizing the warn loop makes
+    the 3 no-window cases fire zero warnings → FAIL; has-window cases stay
+    green). `go test ./pkg/config/...` green, `go build ./...` clean,
+    gofmt clean, `go vet ./pkg/config/` clean.
+
 ## 2026-07-04 — #3881: hierarchical inline-keys static route drops `interface` modifier
 
 - **Timestamp**: 2026-07-04

--- a/pkg/config/compiler_validate_scheduler_no_window_3860_test.go
+++ b/pkg/config/compiler_validate_scheduler_no_window_3860_test.go
@@ -1,0 +1,111 @@
+package config_test
+
+// #3860: a scheduler that defines NO effective window (empty `scheduler x {}`
+// or a bare `daily;` — no start/stop time, no all-day, no per-day arm, no
+// start/stop calendar date) resolves to fail-closed INACTIVE at runtime after
+// the #3849/#3858 flip away from the old always-on bug. That direction is
+// safe, but an operator migrating a config that relied on the always-on bug
+// loses enforcement silently, so ValidateConfig must emit a commit-time
+// WARNING naming the scheduler. A scheduler carrying ANY window (daily/weekday
+// time-of-day arm, all-day, or a start/stop date range) must NOT warn.
+//
+// RED-on-revert: dropping the warning loop in ValidateConfig makes the
+// no-window cases below fire zero warnings and TestSchedulerNoWindowWarns goes
+// RED (want-warning assertions fail).
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// schedulerNoWindowWarnings returns the subset of ValidateConfig warnings that
+// concern a scheduler with no effective window.
+func schedulerNoWindowWarnings(cfg *config.Config) []string {
+	var got []string
+	for _, w := range config.ValidateConfig(cfg) {
+		if strings.HasPrefix(w, "scheduler ") && strings.Contains(w, "defines no time window") {
+			got = append(got, w)
+		}
+	}
+	return got
+}
+
+func TestSchedulerNoWindowWarns(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       *config.Config
+		wantWarn  bool
+		wantNamed string // scheduler name expected in the warning text
+	}{
+		{
+			name:      "empty scheduler body",
+			cfg:       compileHier(t, "schedulers {\n    scheduler idle {\n    }\n}"),
+			wantWarn:  true,
+			wantNamed: "idle",
+		},
+		{
+			name:      "bare daily flag, no window",
+			cfg:       compileHier(t, "schedulers {\n    scheduler dailyflag {\n        daily;\n    }\n}"),
+			wantWarn:  true,
+			wantNamed: "dailyflag",
+		},
+		{
+			name:      "empty scheduler via flat set",
+			cfg:       compileFlat(t, "set schedulers scheduler flatidle"),
+			wantWarn:  true,
+			wantNamed: "flatidle",
+		},
+		{
+			name: "daily time window does not warn",
+			cfg: compileHier(t, "schedulers {\n    scheduler biz {\n        daily {\n"+
+				"            start-time 09:00:00;\n            stop-time 17:00:00;\n        }\n    }\n}"),
+			wantWarn: false,
+		},
+		{
+			name:     "daily all-day does not warn",
+			cfg:      compileHier(t, "schedulers {\n    scheduler always {\n        daily all-day;\n    }\n}"),
+			wantWarn: false,
+		},
+		{
+			name: "weekday arm does not warn",
+			cfg: compileHier(t, "schedulers {\n    scheduler wd {\n        monday {\n"+
+				"            start-time 08:00:00;\n            stop-time 12:00:00;\n        }\n    }\n}"),
+			wantWarn: false,
+		},
+		{
+			name: "date range only does not warn",
+			cfg: compileHier(t, "schedulers {\n    scheduler dated {\n"+
+				"        start-date 2026-03-01;\n        stop-date 2026-03-31;\n    }\n}"),
+			wantWarn: false,
+		},
+		{
+			name: "legacy start/stop-time does not warn",
+			cfg: compileFlat(t,
+				"set schedulers scheduler legacy start-time 09:00:00",
+				"set schedulers scheduler legacy stop-time 17:00:00"),
+			wantWarn: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := schedulerNoWindowWarnings(tc.cfg)
+			if tc.wantWarn {
+				if len(got) == 0 {
+					t.Fatalf("expected a no-window warning, got none")
+				}
+				joined := strings.Join(got, "\n")
+				if !strings.Contains(joined, "\""+tc.wantNamed+"\"") {
+					t.Errorf("warning does not name scheduler %q: %q", tc.wantNamed, joined)
+				}
+				if !strings.Contains(joined, "INACTIVE") {
+					t.Errorf("warning does not state INACTIVE behavior: %q", joined)
+				}
+			} else if len(got) != 0 {
+				t.Errorf("unexpected no-window warning(s): %q", got)
+			}
+		})
+	}
+}

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -382,6 +382,34 @@ func ValidateConfig(cfg *Config) []string {
 		}
 	}
 
+	// #3860: warn when a scheduler defines no effective window. Post-#3849/
+	// #3858 the runtime evaluator (pkg/scheduler.isWithinWindow) fail-closes
+	// such a scheduler to INACTIVE — an absent window is never treated as
+	// always-on. That direction is safe (the config is degenerate), but an
+	// operator migrating a config that relied on the old always-on bug loses
+	// enforcement silently. Surface the flip at commit. A scheduler carrying
+	// any time-of-day window (daily/weekday arm or all-day) or a start/stop
+	// calendar range is well-formed and does NOT warn. Iterate by sorted name
+	// so warnings are deterministic across commits (map iteration is
+	// randomized).
+	schedNames := make([]string, 0, len(cfg.Schedulers))
+	for name := range cfg.Schedulers {
+		schedNames = append(schedNames, name)
+	}
+	sort.Strings(schedNames)
+	for _, name := range schedNames {
+		sched := cfg.Schedulers[name]
+		if sched == nil {
+			continue
+		}
+		if schedulerHasEffectiveWindow(sched) {
+			continue
+		}
+		warnings = append(warnings, fmt.Sprintf(
+			"scheduler %q defines no time window; policies bound to it will "+
+				"be INACTIVE (use `daily all-day` for always-on)", name))
+	}
+
 	// Validate routing-instance interface references
 	for _, ri := range cfg.RoutingInstances {
 		if ri == nil { // #3494: tolerant/HA-sync path may carry a nil routing-instance
@@ -1188,6 +1216,27 @@ func validateFilterNoCatchAllWarnings(cfg *Config) []string {
 		}
 	}
 	return warnings
+}
+
+// schedulerHasEffectiveWindow reports whether a compiled scheduler carries any
+// window the runtime evaluator (pkg/scheduler.isWithinWindow) can act on: a
+// daily/weekday time-of-day arm, an all-day flag, or a start/stop calendar
+// range. A scheduler with none of these resolves to fail-closed INACTIVE at
+// runtime (#3849/#3858) — ValidateConfig warns on it (#3860). The predicate
+// mirrors pkg/scheduler.schedulerHasTimeWindow || schedulerHasDateRange; a
+// bare `daily;` or an empty `scheduler x {}` leaves every field zero and
+// therefore has no effective window.
+func schedulerHasEffectiveWindow(s *SchedulerConfig) bool {
+	if s == nil {
+		return false
+	}
+	if s.AllDay || s.StartTime != "" || s.StopTime != "" || len(s.Days) > 0 {
+		return true
+	}
+	if s.StartDate != "" || s.StopDate != "" {
+		return true
+	}
+	return false
 }
 
 // firewallFilterHasCatchAllTerminator reports whether the filter contains a

--- a/pkg/scheduler/README.md
+++ b/pkg/scheduler/README.md
@@ -76,6 +76,34 @@ window that fails to compile now DENIES, matching the firewall's
 fail-closed posture. To express "always active", omit `scheduler-name`
 from the policy or use `daily all-day`.
 
+**No-window commit warning (#3860).** The fail-closed flip (#3849/#3858)
+is safe but silent: a *degenerate* scheduler that defines no window at all
+— an empty `scheduler x {}`, or a bare `daily;` with no start/stop time,
+no `all-day`, no per-day arm, and no start/stop date — now resolves to
+INACTIVE where the old always-on bug forwarded 24/7. An operator migrating
+a config that leaned on that bug would lose enforcement with no signal.
+`ValidateConfig` (`pkg/config/compiler_validate_warn.go`,
+`schedulerHasEffectiveWindow`) therefore emits a commit-time WARNING naming
+each such scheduler: *"scheduler X defines no time window; policies bound
+to it will be INACTIVE (use `daily all-day` for always-on)."* A scheduler
+carrying any window — a daily/weekday time-of-day arm, `all-day`, or a
+start/stop calendar range — does NOT warn. The predicate mirrors the
+runtime `schedulerHasTimeWindow || schedulerHasDateRange` split, so the
+warning fires exactly when `isWithinWindow` would fail closed for every
+instant. It is a warning, not a hard reject, because a degenerate scheduler
+is legal Junos and an upgrade must not refuse an existing candidate.
+
+**Overnight windows with per-day overrides.** An overnight window
+(e.g. `22:00:00`-`06:00:00`) wraps past midnight, but `effectiveDayWindow`
+resolves the applicable window by the *current* weekday. The post-midnight
+tail (00:00-06:00 the next calendar day) is therefore evaluated against
+that next day's window — a per-day override on the next day (or its absence)
+governs the tail, not the prior day's overnight window. This matches (and
+does not regress) the single-daily behavior: a uniform `daily 22:00-06:00`
+carries across every night because every day resolves to the same window.
+Mixing an overnight daily window with divergent per-day arms is the case to
+reason about carefully.
+
 ## Republish self-heal (#3780)
 
 `updateFn` returns an `error`. A window transition republishes


### PR DESCRIPTION
## Summary

Closes #3860.

A degenerate scheduler that defines **no effective window** — an empty
`scheduler x {}`, or a bare `daily;` with no start/stop time, no `all-day`,
no per-day arm, and no start/stop date — compiled cleanly and produced **no
commit warning**. Post-#3849/#3858 the runtime evaluator (`pkg/scheduler.isWithinWindow`)
fail-closes such a scheduler to **INACTIVE** (an absent window is never treated
as always-on). That direction is safe, but an operator migrating a config that
leaned on the old always-on bug loses policy enforcement **silently** — only
half-windows and unparseable times/dates log today, so the fully-degenerate
always-on → INACTIVE flip was invisible.

## Fix

`ValidateConfig` (`pkg/config/compiler_validate_warn.go`) now iterates
schedulers by sorted name and, when the new `schedulerHasEffectiveWindow`
predicate is false, emits a commit-time WARNING:

> scheduler "X" defines no time window; policies bound to it will be INACTIVE (use `daily all-day` for always-on)

The predicate mirrors the runtime `schedulerHasTimeWindow || schedulerHasDateRange`
split, so the warning fires exactly when `isWithinWindow` would fail closed for
every instant. A scheduler carrying any window — a daily/weekday time-of-day
arm, `all-day`, or a start/stop calendar range — does **not** warn.

This is a **WARNING, not a hard reject**: a degenerate scheduler is legal Junos,
and a hard-reject could refuse an existing candidate on upgrade (the #1960-safe
choice).

## Test (RED-on-revert)

`compiler_validate_scheduler_no_window_3860_test.go`: neutralizing the warn
loop makes the empty-body, bare `daily;`, and flat-set no-window cases fire
zero warnings and **fail**, while the daily-window, all-day, weekday-arm,
date-range, and legacy start/stop-time cases stay green. The warning text is
asserted to name the scheduler and to state the INACTIVE behavior.

## Docs

`pkg/scheduler/README.md` gains a "No-window commit warning" subsection under
the fail-closed invariant, plus an overnight-window / per-day-override doc note
(the #3858 review's DOC-only minor observation 2).

## Validation

- `go test ./pkg/config/...` green; RED-on-revert confirmed
- `go test ./pkg/scheduler/... ./pkg/grpcapi/... ./pkg/cli/...` green
- `go build ./...` clean, `gofmt` clean on changed files, `go vet ./pkg/config/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi