### PR TITLE
routing: bump linkGen on anchor transient-lookup + device-vanished recreate (#4076)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-07-04 — #4076: bump linkGen on anchor transient-lookup + device-vanished recreate
+
+- **Timestamp**: 2026-07-04
+  - **Action**: VERIFY-FIRST at HEAD (f1c54a5a4). Confirmed the #4075
+    follow-up gap in `applyAnchorLocked` (`pkg/routing/tunnel.go`): its
+    up-front `willRecreate` switch (`tunnel.go:515`) has only
+    `lookupErr == nil` and `isLinkNotFound` cases — NO `default: return`
+    (unlike the legacy `applyKernelTunnelLocked`, `tunnel.go:777`, which
+    aborts a transient non-not-found lookup error). So a TRANSIENT
+    (non-not-found) `LinkByName` error leaves `willRecreate=false` (no
+    up-front `stopKeepaliveLocked`/`bumpLinkGenLocked`), yet if the device
+    had simultaneously VANISHED the fall-through `LinkAdd` SUCCEEDS
+    (`created=true`, `tunnel.go:570`) against a genuinely NEW device with
+    a STALE `linkGen`. A stale keepalive runner still holding the previous
+    generation would then pass the lock-free gen guard
+    (`keepaliveTick`, `tunnel.go:1601`) and `LinkSet*` the fresh device in
+    the µs window before `startKeepalive` drains it. FIX: added a
+    `if created && !willRecreate { t.bumpLinkGenLocked(tc.Name) }` block
+    after the `LinkAdd`/`link==nil` reconcile (`tunnel.go` ~:584) — every
+    genuinely new device gets a fresh generation. Guarded on
+    `!willRecreate` so the classified-recreate path (already bumped +
+    drained up-front) is not double-bumped, and gated on `created` so a
+    plain reuse/adopt reconcile never needlessly bumps (no per-apply
+    re-resolve of a stable keepalive). Chose the issue's preferred
+    non-aborting one-line hardening over mirroring the legacy
+    `default: return`. TESTS:
+    `TestAnchorKeepaliveTransientLookupVanishedBumpsGen`
+    (byNameHardErr + addExisting=false → LinkAdd created → gen MUST bump;
+    RED on revert: 0->0) +
+    `TestAnchorKeepaliveReuseDoesNotBumpGen` (repeated reuse applies →
+    gen unchanged, no needless re-resolve). RED-on-revert verified. Full
+    `go test ./pkg/routing/...` green; `go build ./...`, `go vet`, gofmt
+    clean. Updated `pkg/routing/README.md` Recreate-safety bullet.
+  - **File(s)**: pkg/routing/tunnel.go,
+    pkg/routing/tunnel_anchor_keepalive_test.go, pkg/routing/README.md,
+    _Log.md
+
 ## 2026-07-04 — #3860: warn at commit when a scheduler defines no window
 
 - **Timestamp**: 2026-07-04

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -373,7 +373,15 @@ peer behind a valid route read up forever and the fail-safe
   a live runner is retained rather than drained. A per-tunnel `linkGen`
   (`*atomic.Uint64`, read LOCK-FREE by the runner — it never takes
   `t.mu`) is the defense-in-depth backstop; the runner drops any
-  transition whose captured generation no longer matches.
+  transition whose captured generation no longer matches. The anchor
+  branch also bumps `linkGen` whenever the `LinkAdd` ends `created` (#4076):
+  its up-front `willRecreate` switch has no `default: return` (unlike the
+  legacy branch), so a transient (non-not-found) lookup error that masks a
+  device that had actually VANISHED — `LinkAdd` then SUCCEEDS — would
+  otherwise leave the new device on a stale generation. The `created &&
+  !willRecreate` bump gives every genuinely new device a fresh generation
+  without double-bumping the already-drained classified-recreate path and
+  without touching a plain reuse/adopt reconcile.
 
 `Clear()`/`ClearTunnels` keep delete-everything semantics and reset the
 reconcile state. Restart residuals (documented): anchors/addresses/RI

--- a/pkg/routing/tunnel.go
+++ b/pkg/routing/tunnel.go
@@ -581,6 +581,24 @@ func (t *tunnelManager) applyAnchorLocked(tc *config.TunnelConfig, adopting bool
 			slog.Info("tunnel anchor created", "name", tc.Name, "mode", "tun")
 		}
 	}
+	// #4076: a genuine (re)create ALWAYS gets a fresh generation. The
+	// up-front willRecreate block bumps for the CLASSIFIED recreate
+	// (reusable-mismatch / not-found). But a TRANSIENT (non-not-found)
+	// lookup error masks the recreate there — willRecreate stays false
+	// because the switch has no `default` (unlike the legacy branch's
+	// `default: return`) — while the device had actually VANISHED, so the
+	// LinkAdd above SUCCEEDED and `created` is now true against a NEW
+	// device. Bump the generation here so a keepalive runner still holding
+	// the previous generation drops its netlink op (the lock-free gen
+	// guard in keepaliveTick) before it can LinkSet* the fresh device in
+	// the µs window before startKeepalive drains it. Guarded on
+	// !willRecreate so the classified-recreate path (already bumped
+	// up-front) is not double-bumped, and gated on `created` so a plain
+	// reuse/adopt reconcile never needlessly bumps (no per-apply
+	// re-resolve of a stable keepalive). fable-161 F-063 follow-up.
+	if created && !willRecreate {
+		t.bumpLinkGenLocked(tc.Name)
+	}
 	if !created {
 		t.reconcileAnchorMTULocked(tc, link, adopting)
 	}

--- a/pkg/routing/tunnel_anchor_keepalive_test.go
+++ b/pkg/routing/tunnel_anchor_keepalive_test.go
@@ -259,3 +259,92 @@ func TestAnchorKeepaliveTransientLookupKeepsRunner(t *testing.T) {
 		t.Fatalf("transient lookup error must NOT bump the generation: %d -> %d", startGen, gen.Load())
 	}
 }
+
+// --- #4076: a TRANSIENT (non-not-found) lookup error whose device has
+// SIMULTANEOUSLY VANISHED — so LinkAdd SUCCEEDS (created=true) — is a
+// genuine (re)create. The up-front willRecreate classification cannot see
+// the vanish THROUGH the transient error (the anchor switch has no
+// `default: return`, unlike the legacy branch), so willRecreate stays
+// false and the up-front bump is skipped. The created=true bump MUST then
+// advance the generation so a stale keepalive runner still holding the
+// previous generation drops any in-flight LinkSet* against the fresh
+// device (the lock-free gen guard in keepaliveTick). RED-on-revert:
+// dropping the created=true bump leaves the generation unbumped here. ---
+func TestAnchorKeepaliveTransientLookupVanishedBumpsGen(t *testing.T) {
+	ops := newFakeLinkOps()
+	// Transient (non-not-found) lookup error → willRecreate stays false.
+	ops.byNameHardErr["gr-0-0-0"] = errors.New("transient netlink transport error")
+	// Device vanished: addExisting stays false → LinkAdd SUCCEEDS → created=true.
+	tm, _ := newReconcileManager(ops)
+	// Alive prober + 60s interval so the runner startKeepalive spawns does
+	// no real I/O and never ticks during the test.
+	tm.prober = &fakeProber{results: []probeOutcome{{result: ProbeAlive, kind: UnsupportedNone}}}
+
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	tm.ensureReconcileStateLocked()
+
+	// Seed a STALE runner holding the PREVIOUS generation (pre-closed done
+	// so any drain is instant). This is the runner the bump must invalidate.
+	gen := tm.linkGenForLocked("gr-0-0-0")
+	startGen := gen.Load()
+	state := &KeepaliveState{
+		Up: true, RemoteAddr: "203.0.113.1", SourceAddr: "198.51.100.1",
+		Interval: 60, MaxRetries: 3,
+	}
+	seededDone := make(chan struct{})
+	close(seededDone)
+	tm.keepalives["gr-0-0-0"] = &keepaliveRunner{
+		cancel: func() {}, state: state, done: seededDone,
+		remote: "203.0.113.1", source: "198.51.100.1", interval: 60, maxRetries: 3,
+		linkGen: gen, startGen: startGen,
+	}
+
+	tm.applyAnchorLocked(anchorKATC("gr-0-0-0", 60, 3), false)
+
+	// The device genuinely vanished + was recreated (LinkAdd succeeded) →
+	// the generation MUST have advanced so the stale runner's gen guard
+	// drops any in-flight LinkSet* against the new device.
+	if gen.Load() <= startGen {
+		t.Fatalf("transient-lookup + device-vanished (LinkAdd created) must BUMP the generation: %d -> %d", startGen, gen.Load())
+	}
+
+	// Drain the fresh runner startKeepalive spawned (restartKA fired on created).
+	tm.stopKeepaliveLocked("gr-0-0-0")
+}
+
+// --- #4076 (companion, no-needless-re-resolve): a REUSED (matching)
+// anchor TUN across repeated applies must NOT bump the generation. The
+// created=true bump fires only on a genuine (re)create, never on a plain
+// reconcile, so a stable keepalive is never forced to re-resolve its
+// anchor each commit. ---
+func TestAnchorKeepaliveReuseDoesNotBumpGen(t *testing.T) {
+	ops := newFakeLinkOps()
+	seedAnchor(ops, "gr-0-0-0", 10, 1500) // reusable TUN → reuse-in-place (no recreate)
+	tm, _ := newReconcileManager(ops)
+	tm.prober = &fakeProber{results: []probeOutcome{{result: ProbeAlive, kind: UnsupportedNone}}}
+
+	tc := anchorKATC("gr-0-0-0", 60, 3)
+	if err := tm.Apply([]*config.TunnelConfig{tc}); err != nil {
+		t.Fatalf("Apply 1: %v", err)
+	}
+	tm.mu.Lock()
+	gen := tm.linkGenForLocked("gr-0-0-0")
+	afterFirst := gen.Load()
+	tm.mu.Unlock()
+
+	// Repeated identical applies (steady state, device reused each time)
+	// must leave the generation untouched — no needless re-resolve.
+	for i := 0; i < 3; i++ {
+		if err := tm.Apply([]*config.TunnelConfig{tc}); err != nil {
+			t.Fatalf("Apply %d: %v", i+2, err)
+		}
+	}
+
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	if got := gen.Load(); got != afterFirst {
+		t.Fatalf("steady-state reuse must NOT bump the generation: %d -> %d", afterFirst, got)
+	}
+	tm.stopKeepaliveLocked("gr-0-0-0")
+}


### PR DESCRIPTION
Closes #4076. Follow-up to #4075 (GRE keepalive on the userspace-dp anchor path).

## The gap (fable-161 F-063 follow-up)

`applyAnchorLocked`'s up-front `willRecreate` switch (`pkg/routing/tunnel.go:515`) has only the `lookupErr == nil` and `isLinkNotFound` cases — unlike the legacy `applyKernelTunnelLocked` branch (`tunnel.go:777`) it has **no** `default: return`. So a TRANSIENT (non-not-found) `LinkByName` error leaves `willRecreate=false`, skipping the up-front `stopKeepaliveLocked` + `bumpLinkGenLocked`.

- Common sub-case: the device still exists → `LinkAdd` EEXIST → adopt-in-place → runner retained (correct; covered by the existing `TestAnchorKeepaliveTransientLookupKeepsRunner`).
- Effectively-unreachable sub-case (the bug): the device simultaneously VANISHED → the fall-through `LinkAdd` SUCCEEDS (`created=true`, `tunnel.go:570`) against a genuinely NEW device while `linkGen` is **not** bumped. A stale keepalive runner still holding the previous generation would then pass the lock-free gen guard in `keepaliveTick` (`tunnel.go:1601`) and `LinkSet*` the fresh device in the µs window before `startKeepalive` drains it.

## The fix

One-line hardening — bump `linkGen` whenever the `LinkAdd` ends `created`:

```go
if created && !willRecreate {
    t.bumpLinkGenLocked(tc.Name)
}
```

- Guarded on `!willRecreate` so the classified-recreate path (already drained + bumped up-front) is **not** double-bumped.
- Gated on `created` so a plain reuse/adopt reconcile never needlessly bumps — no per-apply re-resolve of a stable keepalive.

This is the issue's **preferred** option (non-aborting) over mirroring the legacy `default: return`. Every genuinely new device gets a fresh generation.

## Tests (RED-on-revert verified)

- `TestAnchorKeepaliveTransientLookupVanishedBumpsGen` — `byNameHardErr` (transient) + `addExisting=false` so `LinkAdd` creates; asserts the generation advances. **RED on revert: `0 -> 0`.**
- `TestAnchorKeepaliveReuseDoesNotBumpGen` — repeated steady-state reuse applies leave the generation untouched (no needless re-resolve).

Full `go test ./pkg/routing/...` green; `go build ./...`, `go vet`, gofmt clean. `pkg/routing/README.md` Recreate-safety bullet updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi