### PR TITLE
userspace-dp NAT: treat an ICMP echo with identifier 0 as a real query (Closes #4088)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-04 — #4088: pool SNAT — id==0 ICMP echo is a valid keyable query
+
+- **Timestamp**: 2026-07-04
+  - **Action**: VERIFY-FIRST at HEAD (b9c2ee46c). Confirmed the #4086
+    residual: `nat/source.rs` computed `icmp_query = matches!(protocol,
+    PROTO_ICMP | PROTO_ICMPV6) && src_port != 0`, so an ICMP echo whose
+    Query Identifier is 0 (a valid on-wire value, 0..=65535) flattened to
+    the same `src_port == 0` sentinel a non-query ICMP uses, took the
+    address-only path, and two id==0 flows behind one pool address collided
+    on the reverse tuple `(pool_addr, 0)` — the #4074 bug, residual for
+    id==0. Root insight: the frame parser only builds a `SessionFlow` for an
+    ICMP protocol when `parse_flow_ports` matched an identifier-bearing
+    query type (`icmp_identifier_bearing`), so at the real call site a
+    SessionFlow existing for ICMP ⟺ it IS a query (id may be 0). FIX:
+    threaded an authoritative `icmp_identifier_present: bool` into
+    `match_source_nat_result_for_tuple` (last positional bool before
+    `matched_counter`) and changed the gate to `matches!(protocol, ICMP |
+    ICMPV6) && icmp_identifier_present` (dropping the `src_port != 0`
+    heuristic). The flow caller (`forwarding/mod.rs`
+    `match_source_nat_for_flow_result_at`) passes
+    `matches!(flow.forward_key.protocol, PROTO_ICMP | PROTO_ICMPV6)`; the
+    address-only wrapper (`match_source_nat_result`, `protocol == 0`) and the
+    status.rs test helper pass `false`. The reverse arms
+    (`session/key.rs`) already key on `nat.rewrite_src_port`, so id==0
+    recovers once the forward allocates. Frame rewriter
+    (`apply_nat_icmp_identifier_rewrite`) re-gates on the real ICMP type byte
+    (defense in depth). Updated all 23 `match_source_nat_result_for_tuple`
+    call sites (2 ICMP-query → true, the rest → false).
+  - **File(s)**: userspace-dp/src/nat/source.rs,
+    userspace-dp/src/afxdp/forwarding/mod.rs,
+    userspace-dp/src/afxdp/coordinator/status.rs,
+    userspace-dp/src/nat/tests.rs (new
+    `pool_snat_translates_icmp_query_id_zero_distinct_per_host` RED-on-revert
+    + updated call sites/comments),
+    userspace-dp/src/session/tests.rs (new
+    `icmp_query_id_zero_translation_demuxes_reverse_wire_key`),
+    docs/userspace-dataplane-architecture.md.
+
 ## 2026-07-04 — #3860: warn at commit when a scheduler defines no window
 
 - **Timestamp**: 2026-07-04

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -613,11 +613,18 @@ the NAT module applies it:
   #4074). This lets many internal hosts pinging one target with the same id
   share a single pool address without colliding on the reverse tuple
   `(pool_addr, id)`; the reverse companion session and the reply un-NAT are
-  keyed on the translated id. A non-identifier ICMP control/error message
-  parses flowless (`src_port == 0`) and, like a genuinely port-less protocol
-  (GRE/ESP/AH/OSPF), takes the address-only path — its L4 bytes are never
-  rewritten. `port no-translation` preserves the id just as it preserves a
-  TCP/UDP source port. By default, pool address
+  keyed on the translated id. Whether a tuple is an ICMP query is decided by an
+  authoritative "identifier present" signal threaded from the frame parser
+  (`match_source_nat_result_for_tuple`'s `icmp_identifier_present` arg), NOT by
+  `src_port != 0` — a SessionFlow is only built for an ICMP protocol when the
+  parser matched an identifier-bearing query type, so an ICMP Query Identifier
+  of **0** (a valid on-wire value, 0..=65535) is translated like any other id
+  rather than misread as flowless (#4088; the earlier `src_port != 0` gate left
+  id==0 colliding on `(pool_addr, 0)`). A non-identifier ICMP control/error
+  message parses flowless (no SessionFlow, `icmp_identifier_present` false) and,
+  like a genuinely port-less protocol (GRE/ESP/AH/OSPF), takes the address-only
+  path — its L4 bytes are never rewritten. `port no-translation` preserves the
+  id just as it preserves a TCP/UDP source port. By default, pool address
   selection is round-robin within the packet address family. With global source
   NAT `address-persistent`, the userspace dataplane hashes a domain-tag seed,
   address family, and canonical source IP bytes with a seeded non-cryptographic

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -500,6 +500,9 @@ impl super::Coordinator {
             egress_v6,
             now_ns,
             false,
+            // #4088: this helper is exercised only with TCP/UDP tuples; ICMP
+            // id==0 classification is covered by the nat/ unit tests.
+            false,
             &mut counter,
         )
     }

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -398,6 +398,16 @@ pub(super) fn match_source_nat_for_flow_result_at(
         egress.primary_v6,
         now_ns,
         non_first_fragment,
+        // #4088 (RFC 5508 §3.1): a `SessionFlow` is only built for an
+        // ICMP/ICMPv6 protocol when the frame parser matched an
+        // identifier-bearing query type (`icmp_identifier_bearing`), so its
+        // `src_port` holds a real Query Identifier — even when that id is 0.
+        // Signal that authoritatively so pool SNAT translates the id instead
+        // of dropping an id==0 query onto the address-only path.
+        matches!(
+            flow.forward_key.protocol,
+            crate::ip_proto::PROTO_ICMP | crate::ip_proto::PROTO_ICMPV6
+        ),
         matched_counter,
     )
 }

--- a/userspace-dp/src/nat/source.rs
+++ b/userspace-dp/src/nat/source.rs
@@ -771,6 +771,9 @@ pub(crate) fn match_source_nat_result(
         egress_v6,
         0,
         false,
+        // #4088: the address-only wrapper never carries an ICMP query id
+        // (`protocol == 0`), so there is no identifier to preserve.
+        false,
         &mut counter,
     )
 }
@@ -800,6 +803,19 @@ pub(crate) fn match_source_nat_result_for_tuple(
     // a non-first fragment has no L4 ports. Interface-mode (address-only)
     // and `off`/static rules are unaffected.
     non_first_fragment: bool,
+    // #4088 (RFC 5508 §3.1): for an ICMP/ICMPv6 tuple this is the
+    // authoritative "the tuple carries a real ICMP Query Identifier" signal,
+    // replacing the old `src_port != 0` heuristic. The frame parser
+    // (`parse_flow_ports`) only lifts an identifier into `src_port` for an
+    // identifier-bearing query type, and a `SessionFlow` is only built for an
+    // ICMP protocol when that gate matched — so the flow caller passes
+    // `matches!(protocol, PROTO_ICMP | PROTO_ICMPV6)`. An ICMP Query
+    // Identifier of 0 is a valid on-wire value (0..=65535); keying the query
+    // gate on `src_port != 0` misclassified an id==0 query as flowless and
+    // took the address-only path, colliding two id==0 flows behind one pool
+    // address on the reverse tuple (pool_addr, 0). The synthetic /
+    // address-only (`protocol == 0`) callers pass `false`.
+    icmp_identifier_present: bool,
     matched_counter: &mut Option<Arc<NatRuleCounter>>,
 ) -> SourceNatLookup {
     let flow = SourceNatFlowKey {
@@ -886,12 +902,17 @@ pub(crate) fn match_source_nat_result_for_tuple(
         // hosts pinging the same target with the same id, both hidden behind
         // one pool address, collide on the reverse tuple (pool_addr, id) and
         // their replies are mis-associated. A non-identifier ICMP control/error
-        // message parses flowless (`src_port == 0`) and keeps the address-only
-        // path — there is no id to translate. `no_translation` (port
-        // no-translation) still preserves the id via the `address_only` gate
-        // below. The translated id comes from the same pool port/id space as
-        // the TCP/UDP PAT allocation (`allocate_translation`).
-        let icmp_query = matches!(protocol, PROTO_ICMP | PROTO_ICMPV6) && src_port != 0;
+        // message parses flowless (no `SessionFlow`, `icmp_identifier_present`
+        // false) and keeps the address-only path — there is no id to translate.
+        // `no_translation` (port no-translation) still preserves the id via the
+        // `address_only` gate below. The translated id comes from the same pool
+        // port/id space as the TCP/UDP PAT allocation (`allocate_translation`).
+        //
+        // #4088 (RFC 5508 §3.1): classify by the identifier-present signal, NOT
+        // by `src_port != 0`. A valid ICMP echo whose Query Identifier is 0
+        // must be treated as a real, keyable query (allocate + rewrite +
+        // reverse-recover its id like any other), not misread as flowless.
+        let icmp_query = matches!(protocol, PROTO_ICMP | PROTO_ICMPV6) && icmp_identifier_present;
         let port_less = protocol != 0 && !crate::ip_proto::has_l4_ports(protocol) && !icmp_query;
         let tuple_unknown = protocol == 0;
         // #3906: `port no-translation` translates the ADDRESS only and PRESERVES

--- a/userspace-dp/src/nat/tests.rs
+++ b/userspace-dp/src/nat/tests.rs
@@ -3319,6 +3319,7 @@ fn pool_snat_single_address_rewrites_src_and_port() {
         None,
         0,
         false,
+        false,
         &mut counter,
     ));
     assert_eq!(d.rewrite_src, Some("203.0.113.1".parse().unwrap()));
@@ -3369,6 +3370,7 @@ fn pool_snat_portless_protocols_translate_ip_only_no_port() {
             None,
             None,
             0,
+            false,
             false,
             &mut counter,
         ));
@@ -3458,6 +3460,8 @@ fn pool_snat_translates_icmp_query_id_distinct_per_host() {
             None,
             0,
             false,
+            // #4088: an identifier-bearing ICMP echo query.
+            true,
             &mut counter,
         ));
         let db = expect_snat_decision(match_source_nat_result_for_tuple(
@@ -3474,6 +3478,8 @@ fn pool_snat_translates_icmp_query_id_distinct_per_host() {
             None,
             0,
             false,
+            // #4088: an identifier-bearing ICMP echo query.
+            true,
             &mut counter,
         ));
         // Both hosts land on the single pool address (overload) ...
@@ -3511,10 +3517,161 @@ fn pool_snat_translates_icmp_query_id_distinct_per_host() {
     }
 }
 
-// #4074: a NON-identifier ICMP message (an error / control type, or any flow
-// the parser could not lift an id from — `src_port == 0`) keeps the
-// address-only path: the source IP is translated but NO id is allocated. This
-// pins that the `icmp_query` gate is `src_port != 0`, not "all ICMP".
+// #4088 FAIL-ON-REVERT (RFC 5508 §3.1): an ICMP echo whose Query Identifier is
+// 0 is a valid, keyable query (the id space is 0..=65535). Pool-mode source-NAT
+// must translate it exactly like any other id — two hosts pinging the same
+// target with id==0 behind one pool address must get DISTINCT translated ids so
+// their replies demux on the reverse tuple (pool_addr, translated_id).
+//
+// Before #4088 the query gate was `src_port != 0`, so an id==0 query flattened
+// to the same `src_port == 0` sentinel a non-query ICMP uses, took the
+// address-only path, and both id==0 flows collided on the reverse tuple
+// (pool_addr, 0) — the #4074 bug, residual for id==0. Reverting the source.rs
+// gate to `src_port != 0` makes `icmp_query` false for id==0, both decisions
+// carry `rewrite_src_port: None`, and the `is_some()` / distinctness assertions
+// go RED.
+//
+// The authoritative signal is `icmp_identifier_present` (the last positional
+// bool arg), set true here because the frame parser only builds a SessionFlow
+// for an identifier-bearing ICMP query — so id==0 is a real id, not "no id".
+#[test]
+fn pool_snat_translates_icmp_query_id_zero_distinct_per_host() {
+    for proto in [PROTO_ICMP, PROTO_ICMPV6] {
+        let (src_a, src_b, dst): (IpAddr, IpAddr, IpAddr) = if proto == PROTO_ICMP {
+            (
+                "10.0.1.100".parse().unwrap(),
+                "10.0.1.101".parse().unwrap(),
+                "8.8.8.8".parse().unwrap(),
+            )
+        } else {
+            (
+                "2001:db8::100".parse().unwrap(),
+                "2001:db8::101".parse().unwrap(),
+                "2001:4860:4860::8888".parse().unwrap(),
+            )
+        };
+        let pool_addr = if proto == PROTO_ICMP {
+            "203.0.113.1/32".to_string()
+        } else {
+            "2001:db8:cafe::1/128".to_string()
+        };
+        let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+            name: "pool-snat".to_string(),
+            from_zone: "lan".to_string(),
+            to_zone: "wan".to_string(),
+            source_addresses: vec![if proto == PROTO_ICMP {
+                "0.0.0.0/0".to_string()
+            } else {
+                "::/0".to_string()
+            }],
+            pool_name: "my-pool".to_string(),
+            pool_addresses: vec![pool_addr],
+            port_low: 1024,
+            port_high: 65535,
+            ..SourceNATRuleSnapshot::default()
+        }]);
+        // Both hosts use the identifier 0 (a valid on-wire ICMP Query id).
+        let query_id = 0u16;
+        let mut counter = None;
+        let da = expect_snat_decision(match_source_nat_result_for_tuple(
+            &rules,
+            &NatScopeCtx::default(),
+            "lan",
+            "wan",
+            src_a,
+            dst,
+            proto,
+            query_id,
+            0,
+            None,
+            None,
+            0,
+            false,
+            // #4088: identifier-bearing echo query — even though id==0.
+            true,
+            &mut counter,
+        ));
+        let db = expect_snat_decision(match_source_nat_result_for_tuple(
+            &rules,
+            &NatScopeCtx::default(),
+            "lan",
+            "wan",
+            src_b,
+            dst,
+            proto,
+            query_id,
+            0,
+            None,
+            None,
+            0,
+            false,
+            true,
+            &mut counter,
+        ));
+        let expected_pool: IpAddr = if proto == PROTO_ICMP {
+            "203.0.113.1".parse().unwrap()
+        } else {
+            "2001:db8:cafe::1".parse().unwrap()
+        };
+        assert_eq!(da.rewrite_src, Some(expected_pool), "proto {proto}");
+        assert_eq!(db.rewrite_src, Some(expected_pool), "proto {proto}");
+        let id_a = da.rewrite_src_port.unwrap_or_else(|| {
+            panic!("proto {proto}: host A id==0 query must get a translated ICMP id")
+        });
+        let id_b = db.rewrite_src_port.unwrap_or_else(|| {
+            panic!("proto {proto}: host B id==0 query must get a translated ICMP id")
+        });
+        assert!(id_a >= 1024, "proto {proto}: id {id_a} out of pool range");
+        assert!(id_b >= 1024, "proto {proto}: id {id_b} out of pool range");
+        assert_ne!(
+            id_a, id_b,
+            "proto {proto}: two id==0 flows sharing a pool address must get DISTINCT translated ids",
+        );
+        let status = source_nat_pool_statuses(&rules);
+        assert_eq!(
+            status[0].used_ports, 2,
+            "proto {proto}: one pool id per id==0 ICMP query flow",
+        );
+
+        // Contrast: WITHOUT the identifier-present signal (a non-query ICMP that
+        // also flattens to src_port==0) the same id==0 tuple stays address-only.
+        // This pins that the gate is `icmp_identifier_present`, not the id value.
+        let mut counter2 = None;
+        let non_query = expect_snat_decision(match_source_nat_result_for_tuple(
+            &rules,
+            &NatScopeCtx::default(),
+            "lan",
+            "wan",
+            src_a,
+            dst,
+            proto,
+            query_id,
+            0,
+            None,
+            None,
+            0,
+            false,
+            false,
+            &mut counter2,
+        ));
+        assert_eq!(
+            non_query.rewrite_src,
+            Some(expected_pool),
+            "proto {proto}: address still translated",
+        );
+        assert_eq!(
+            non_query.rewrite_src_port, None,
+            "proto {proto}: no identifier present => address-only, no id allocated",
+        );
+    }
+}
+
+// #4074/#4088: a NON-identifier ICMP message (an error / control type, or any
+// flow the parser could not lift an id from — no `SessionFlow`, so
+// `icmp_identifier_present` is false) keeps the address-only path: the source
+// IP is translated but NO id is allocated. This pins that the `icmp_query`
+// gate is the identifier-present signal, not "all ICMP" (and, post-#4088, not
+// `src_port != 0` either).
 #[test]
 fn pool_snat_icmp_without_query_id_is_address_only() {
     let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
@@ -3542,6 +3699,8 @@ fn pool_snat_icmp_without_query_id_is_address_only() {
         None,
         None,
         0,
+        false,
+        // #4088: no identifier-bearing query → address-only.
         false,
         &mut counter,
     ));
@@ -3594,6 +3753,7 @@ fn pool_snat_no_translation_preserves_source_port() {
         None,
         None,
         0,
+        false,
         false,
         &mut counter,
     ));
@@ -3981,6 +4141,7 @@ fn tuple_snat_lookup_from_src(
         None,
         None,
         now_ns,
+        false,
         false,
         &mut counter,
     )
@@ -4542,6 +4703,7 @@ fn pool_snat_shared_pool_exhaustion_crosses_rules() {
         None,
         1,
         false,
+        false,
         &mut None,
     );
     assert!(matches!(first, SourceNatLookup::Matched(_)));
@@ -4559,6 +4721,7 @@ fn pool_snat_shared_pool_exhaustion_crosses_rules() {
         None,
         None,
         2,
+        false,
         false,
         &mut None,
     );
@@ -4621,6 +4784,7 @@ fn pool_snat_shared_pool_exhaustion_crosses_persistence_modes() {
         None,
         1,
         false,
+        false,
         &mut None,
     );
     assert!(matches!(first, SourceNatLookup::Matched(_)));
@@ -4638,6 +4802,7 @@ fn pool_snat_shared_pool_exhaustion_crosses_persistence_modes() {
         None,
         None,
         2,
+        false,
         false,
         &mut None,
     );
@@ -5680,6 +5845,7 @@ fn pool_snat_address_persistent_userspace_v2_selects_pool_addresses() {
             None,
             0,
             false,
+            false,
             &mut None,
         ));
 
@@ -6222,6 +6388,7 @@ fn pool_snat_non_first_fragment_refused_no_allocation() {
         None,
         1,
         true,
+        false,
         &mut None,
     );
     match frag {
@@ -6245,6 +6412,7 @@ fn pool_snat_non_first_fragment_refused_no_allocation() {
         None,
         None,
         1,
+        false,
         false,
         &mut None,
     );
@@ -7457,6 +7625,7 @@ fn source_nat_match_destination_port_constrains_flow_3429() {
         None,
         0,
         false,
+        false,
         &mut counter,
     );
     assert!(
@@ -7478,6 +7647,7 @@ fn source_nat_match_destination_port_constrains_flow_3429() {
         egress_v4,
         None,
         0,
+        false,
         false,
         &mut counter,
     );
@@ -7521,6 +7691,7 @@ fn source_nat_match_destination_port_constrains_off_exemption_3429() {
         None,
         0,
         false,
+        false,
         &mut counter,
     );
     assert!(
@@ -7542,6 +7713,7 @@ fn source_nat_match_destination_port_constrains_off_exemption_3429() {
         egress_v4,
         None,
         0,
+        false,
         false,
         &mut counter,
     );
@@ -7589,6 +7761,7 @@ fn source_nat_match_application_constrains_protocol_and_port_3429() {
             egress_v4,
             None,
             0,
+            false,
             false,
             &mut counter,
         )
@@ -7657,6 +7830,7 @@ fn source_nat_match_application_constrains_source_port_3491() {
             None,
             0,
             false,
+            false,
             &mut counter,
         )
     };
@@ -7707,6 +7881,7 @@ fn source_nat_app_source_port_never_match_sentinel_3491() {
         egress_v4,
         None,
         0,
+        false,
         false,
         &mut counter,
     );
@@ -7816,6 +7991,7 @@ fn source_nat_never_match_port_sentinel_matches_nothing_3429() {
             None,
             0,
             false,
+            false,
             &mut counter,
         );
         assert_eq!(
@@ -7853,6 +8029,7 @@ fn source_nat_app_protocol_never_vs_any_3429() {
             egress_v4,
             None,
             0,
+            false,
             false,
             &mut counter,
         )

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -2636,6 +2636,71 @@ fn icmp_query_id_translation_demuxes_reverse_wire_key() {
     );
 }
 
+// #4088: the reverse-recovery path must work for an ICMP Query Identifier of 0
+// (a valid on-wire id). Two hosts pinging the same target with id==0, both
+// behind one pool address, are given DISTINCT translated ids by pool SNAT
+// (source.rs, exercised in nat/tests.rs). Here we pin that the reverse keying
+// carries the TRANSLATED id — not the original 0 — so the id==0 replies demux
+// back to the right host and the original id (0) is recovered on the reverse.
+// If the reverse keys ignored `rewrite_src_port` and kept the original id, both
+// would collapse to `{T, P, 0, 0}` and the `assert_ne!` would go RED.
+#[test]
+fn icmp_query_id_zero_translation_demuxes_reverse_wire_key() {
+    let target = IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8));
+    let pool = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1));
+    // The valid-but-uncommon id==0 case.
+    let query_id = 0u16;
+
+    let mk_forward = |host: Ipv4Addr| SessionKey {
+        addr_family: 2,
+        protocol: PROTO_ICMP,
+        src_ip: IpAddr::V4(host),
+        dst_ip: target,
+        src_port: query_id,
+        dst_port: 0,
+    };
+    let mk_nat = |translated_id: u16| NatDecision {
+        rewrite_src: Some(pool),
+        rewrite_src_port: Some(translated_id),
+        ..NatDecision::default()
+    };
+
+    let fwd_a = mk_forward(Ipv4Addr::new(10, 0, 0, 1));
+    let fwd_b = mk_forward(Ipv4Addr::new(10, 0, 0, 2));
+    let nat_a = mk_nat(40001);
+    let nat_b = mk_nat(40002);
+
+    let rev_a = reverse_wire_key(&fwd_a, nat_a);
+    let rev_b = reverse_wire_key(&fwd_b, nat_b);
+    assert_eq!(
+        rev_a.src_port, 40001,
+        "reverse key carries the translated id, not the original 0",
+    );
+    assert_ne!(
+        rev_a, rev_b,
+        "distinct translated ids MUST give distinct reverse keys even when the original id is 0",
+    );
+
+    // The reply carrying host A's translated id (40001) matches forward A only.
+    let reply_a = SessionKey {
+        addr_family: 2,
+        protocol: PROTO_ICMP,
+        src_ip: target,
+        dst_ip: pool,
+        src_port: 40001,
+        dst_port: 0,
+    };
+    assert!(reply_matches_forward_session(&fwd_a, nat_a, &reply_a));
+    assert!(!reply_matches_forward_session(&fwd_b, nat_b, &reply_a));
+
+    // The reverse companion keys differ per translated id (no (pool, 0) collision).
+    assert_ne!(
+        reverse_session_key(&fwd_a, nat_a),
+        reverse_session_key(&fwd_b, nat_b),
+        "id==0 reverse companion keys must differ per translated id",
+    );
+}
+
 #[test]
 fn find_forward_nat_match_with_dnat_port_rewrite() {
     let mut table = SessionTable::new();


### PR DESCRIPTION
## Summary

Closes #4088 (fable-161 F-186 follow-up; Copilot finding 2 on #4086).

Pool-mode source-NAT classified an ICMP/ICMPv6 flow as an identifier-bearing query via `icmp_query = matches!(protocol, PROTO_ICMP | PROTO_ICMPV6) && src_port != 0` in `nat/source.rs`. An ICMP Query Identifier of **0** is a valid on-wire value (0..=65535), but it flattens to the same `src_port == 0` sentinel a non-query ICMP control/error message uses, so `src_port != 0` could not tell an id==0 query from a non-query. An id==0 echo therefore took the address-only path (no id translation), and two id==0 flows behind one pool address collided on the reverse tuple `(pool_addr, 0)` — the exact bug #4074/#4086 fixed, residual for id==0.

## Fix

Replace the `src_port != 0` heuristic with an authoritative `icmp_identifier_present` bool threaded into `match_source_nat_result_for_tuple`. The frame parser only lifts an identifier into `src_port` for an identifier-bearing query type (`icmp_identifier_bearing`), and a `SessionFlow` is only built for an ICMP protocol when that gate matched — so the flow caller (`match_source_nat_for_flow_result_at`) passes `matches!(protocol, PROTO_ICMP | PROTO_ICMPV6)`, which is true exactly when the tuple carries a real query id (**even 0**). The address-only wrapper (`protocol == 0`) and the status.rs test helper pass `false`. The gate becomes `matches!(...) && icmp_identifier_present`, so an id==0 query is allocated, rewritten, and reverse-recovered like any other id.

### Why this decouples id==0 from `src_port != 0`
- **`nat/source.rs:915`** — `let icmp_query = matches!(protocol, PROTO_ICMP | PROTO_ICMPV6) && icmp_identifier_present;` (was `&& src_port != 0`). The id value no longer gates the query classification.
- **`afxdp/forwarding/mod.rs`** (`match_source_nat_for_flow_result_at`) — the only real ICMP source-NAT call site; passes the protocol-derived signal. A non-query ICMP never reaches here (it is flowless, no `SessionFlow`), so the signal can't over-broaden.
- The reverse session/wire keys (`session/key.rs`) already key on `nat.rewrite_src_port`, so id==0 recovers once the forward allocates. The frame identifier rewriter (`apply_nat_icmp_identifier_rewrite`) re-gates on the real ICMP type byte (defense in depth). No production regression; couples cleanly with the #4086 rewrite/reverse arms.

## Tests (RED-on-revert)

- `pool_snat_translates_icmp_query_id_zero_distinct_per_host` (nat/tests.rs, v4+v6): two id==0 echoes behind one pool address get **DISTINCT** translated ids and consume two pool ids; the same tuple **without** the identifier-present signal stays address-only. Reverting the source.rs gate to `src_port != 0` makes both id==0 decisions address-only (`rewrite_src_port: None`) → the `is_some()`/distinctness asserts go RED (verified: `panicked ... host A id==0 query must get a translated ICMP id`).
- `icmp_query_id_zero_translation_demuxes_reverse_wire_key` (session/tests.rs): the reverse keys carry the **translated** id (not 0), so id==0 replies demux back to the right host.
- Updated all 23 `match_source_nat_result_for_tuple` call sites and the NAT/ICMP architecture doc.

## Validation
- FULL `cargo test --release` (single-threaded): **3512 lib + all integration binaries pass, 0 failed**.
- RED-on-revert proven then fix restored.
- `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi