### PR TITLE
userspace-dp: emit active reject on output-filter then reject (#3608)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -32917,3 +32917,37 @@ top.
   - **File(s)**: pkg/dataplane/loader_userspace_shim.go,
     pkg/dataplane/userspace_shim_loader_test.go,
     userspace-dp/src/afxdp/bpf_map/pin.rs, docs/in-place-upgrade.md, _Log.md
+
+- **Timestamp**: 2026-07-04
+  - **Action**: #3608 — OUTPUT firewall-filter `then reject` now emits an
+    active reject reply (TCP RST / ICMP admin-prohibited) on the transit
+    forward / TX-CoS path instead of the historical silent drop, mirroring
+    the input/lo0 reject (#2521). Added a `reject` bit to `CoSTxSelection`
+    and `CachedTxSelectionDescriptor` that isolates the `then reject` subset
+    of the collapsed `drop` bit (discard / red-policer stay silent). The
+    transit forward-request builder (`build_live_forward_request_from_frame`)
+    and the flow-cache-hit fast path now call the shared
+    `enqueue_filter_reject_reply` BEFORE dropping, reflecting the original
+    inbound frame back to the source via the ingress interface, and emit the
+    output filter-log with the truthful REJECT/DENY outcome (#3615). Reject
+    synthesis is passed the ingress TX pipeline via a new `ForwardRejectReply`
+    context. Widened `poll_descriptor`/`reject_reply` module + fn visibility
+    to `pub(in crate::afxdp)` so `forward_request` can reach the synthesis.
+    RED-on-revert tests: classification `reject` flag (cos_classify_tests)
+    and an end-to-end build-path test asserting the RST is enqueued +
+    `filter_reject_sent`/RT_FLOW REJECT (tests.rs). Full cargo suite green
+    (only the pre-existing unrelated `test_paused_telemetry_eviction_*`
+    fails, also red on clean master). go build + pkg/config green. Docs:
+    filter/README.md + docs/feature-gaps.md.
+  - **File(s)**: userspace-dp/src/afxdp/tx/cos_classify.rs,
+    userspace-dp/src/afxdp/flow_cache.rs,
+    userspace-dp/src/afxdp/forward_request.rs,
+    userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+    userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs,
+    userspace-dp/src/afxdp/poll_descriptor/filter.rs,
+    userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs,
+    userspace-dp/src/afxdp/mod.rs, userspace-dp/src/afxdp/tests.rs,
+    userspace-dp/src/afxdp/tx/cos_classify_tests.rs,
+    userspace-dp/src/afxdp/umem/tests.rs,
+    userspace-dp/src/afxdp/frame/tests.rs,
+    userspace-dp/src/filter/README.md, docs/feature-gaps.md

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -432,16 +432,22 @@ xpf has a broad chassis cluster implementation with redundancy groups, RETH (VRR
 
 xpf has firewall filters with source/dest addresses, prefix-lists (with except), DSCP, protocol, dest/source ports, ICMP type/code, TCP flags, fragment match, actions (accept/reject/discard), routing-instance, log, count, forwarding-class, loss-priority (parse-only/inert — see below), DSCP rewrite, and IPv6 traffic-class matching.
 
-Filter `then reject` is now an **active** reject on the input and lo0
-(host-bound) paths (#2521): it synthesizes a TCP RST (TCP) or ICMP/ICMPv6
-admin-prohibited unreachable (otherwise) using the SAME machinery as policy
-reject (`poll_descriptor/reject_reply.rs`), runs the generated reply through
-#2238 output-filter/CoS/DSCP classification, and counts it on
-`filter_reject_sent`. `then discard` stays a silent drop. Previously filter
-reject collapsed to a silent drop (fail-closed parity gap). REMAINING GAP:
-output-firewall-filter `then reject` realized on the TX/CoS path still
-collapses to a silent drop (the TX site lacks the descriptor context for
-reply synthesis) — tracked as a #2521 follow-up.
+Filter `then reject` is now an **active** reject on the input, lo0
+(host-bound) AND output (transit forward / TX/CoS) paths (#2521 + #3608): it
+synthesizes a TCP RST (TCP) or ICMP/ICMPv6 admin-prohibited unreachable
+(otherwise) using the SAME machinery as policy reject
+(`poll_descriptor/reject_reply.rs`), runs the generated reply through #2238
+output-filter/CoS/DSCP classification, and counts it on `filter_reject_sent`.
+`then discard` stays a silent drop. Previously filter reject collapsed to a
+silent drop (fail-closed parity gap). The output-firewall-filter case was
+closed in #3608: the TX/CoS classifier carries a `reject` bit alongside the
+collapsed `drop` bit, and the transit forward-request builder
+(`build_live_forward_request_from_frame`) + the flow-cache-hit fast path
+enqueue the reflected reply (original inbound frame → source via the ingress
+interface) before dropping, emitting the output filter-log with the truthful
+REJECT/DENY outcome (#3615). The only site that still collapses reject→drop is
+the deferred-CoS dispatch path, which is unreachable in production (all
+`PendingForwardRequest`s resolve CoS inline).
 
 `from protocol <name>` resolution is centralized (#2175) on the same
 `appid.ProtocolNumber` source of truth used by security-policy applications

--- a/userspace-dp/src/afxdp/flow_cache.rs
+++ b/userspace-dp/src/afxdp/flow_cache.rs
@@ -52,6 +52,12 @@ pub(super) struct CachedTxSelectionDescriptor {
     pub(super) queue_id: Option<u8>,
     pub(super) dscp_rewrite: Option<u8>,
     pub(super) drop: bool,
+    // #3608: `drop` collapses `then discard` and `then reject` (both
+    // non-`Accept` terminal actions) into one bit. `reject` isolates the
+    // `then reject` subset so the flow-cache-hit consumer can synthesize the
+    // active reject reply (TCP RST / ICMP admin-prohibited) rather than the
+    // silent drop `then discard` produces. Only ever true when `drop` is true.
+    pub(super) reject: bool,
     // #2573: all matched `then count` term counters for this flow, not just the
     // last — the cached replay must increment every fall-through count term.
     pub(super) filter_counters: crate::filter::CachedFilterCounters,

--- a/userspace-dp/src/afxdp/forward_request.rs
+++ b/userspace-dp/src/afxdp/forward_request.rs
@@ -12,6 +12,21 @@
 // afxdp.rs into scope.
 
 use super::*;
+use super::worker::WorkerTxPipeline;
+
+/// #3608: the tx-pipeline + counters an output-filter `then reject` needs to
+/// synthesize its active reply (TCP RST / ICMP admin-prohibited) on the transit
+/// forward path. `build_live_forward_request_from_frame` resolves the output
+/// filter inline and, on a `then reject` drop, must emit the same active reply
+/// the input/lo0 path already does (#2521) instead of the historical silent
+/// drop (#3608). Passed by the poll-loop callers that own the ingress binding's
+/// TX pipeline; `None` on the test-only `build_live_forward_request` wrapper and
+/// any caller that cannot (or need not) emit a reply, in which case a reject
+/// degrades to the prior silent drop and the filter-log truthfully reports DENY.
+pub(super) struct ForwardRejectReply<'a> {
+    pub(super) tx_pipeline: &'a mut WorkerTxPipeline,
+    pub(super) counters: &'a mut BatchCounters,
+}
 
 pub(super) fn should_install_local_reverse_session(
     decision: SessionDecision,
@@ -55,6 +70,7 @@ pub(super) fn build_live_forward_request(
         None,
         None,
         None,
+        None,
     )
 }
 
@@ -74,6 +90,7 @@ pub(super) fn build_live_forward_request_from_frame(
     event_stream: Option<&crate::event_stream::EventStreamWorkerHandle>,
     hints: Option<PendingForwardHints>,
     precomputed_tx_selection: Option<&CachedTxSelectionDescriptor>,
+    reject_reply: Option<ForwardRejectReply<'_>>,
 ) -> Option<PendingForwardRequest> {
     let hints = hints.unwrap_or_default();
     let target_ifindex = if decision.resolution.tx_ifindex > 0 {
@@ -180,6 +197,10 @@ pub(super) fn build_live_forward_request_from_frame(
             queue_id: selection.queue_id,
             dscp_rewrite: selection.dscp_rewrite,
             drop: selection.drop,
+            // #3608: preserve the `then reject` subset so the active reject
+            // reply is synthesized on the precomputed (flow-cache fallback) path
+            // too, not just the freshly resolved path.
+            reject: selection.reject,
             filter_log: selection.filter_log,
         })
         .unwrap_or_else(|| {
@@ -197,6 +218,36 @@ pub(super) fn build_live_forward_request_from_frame(
                 now_ns,
             )
         });
+    // #3608: an output firewall-filter `then reject` on the transit forward path
+    // now emits the SAME active reply as the input/lo0 path (#2521) — a TCP RST
+    // for TCP, an ICMP/ICMPv6 admin-prohibited unreachable otherwise — instead
+    // of the historical silent drop. The reply reflects the ORIGINAL inbound
+    // frame back toward the source via the ingress interface (the source is
+    // reachable on the reverse path), reusing the shared reject-synthesis +
+    // #2238 output-classification + #2472 rate-limit + fail-closed budget gate.
+    // `then discard` and three-color-policer drops stay silent (`cos.reject`
+    // isolates the reject subset of `cos.drop`). Enqueue the reply FIRST so the
+    // filter-log below reports the TRUTHFUL action (#3615): a reject whose reply
+    // fail-closes (budget/rate/parse/output-filter, or a missing tx-pipeline
+    // context) logs DENY, not REJECT.
+    let reject_reply_enqueued = if cos.drop && cos.reject {
+        match (reject_reply, tx_selection_flow) {
+            (Some(reply), Some(flow)) => {
+                crate::afxdp::poll_descriptor::reject_reply::enqueue_filter_reject_reply(
+                    reply.tx_pipeline,
+                    forwarding,
+                    ingress_ident.ifindex,
+                    frame,
+                    meta,
+                    flow,
+                    reply.counters,
+                )
+            }
+            _ => false,
+        }
+    } else {
+        false
+    };
     if let (Some(filter_log), Some(flow)) = (cos.filter_log, tx_selection_flow) {
         let ingress_zone_id = fabric_ingress_zone
             .filter(|id| forwarding.zone_id_to_name.contains_key(id))
@@ -224,10 +275,10 @@ pub(super) fn build_live_forward_request_from_frame(
             FilterLogSource::Output,
             // #2520: AppID via the hot-path app_catalog.lookup.
             resolve_flow_app_id(&forwarding.app_catalog, flow),
-            // #3615: the TX/forward OUTPUT-filter path synthesizes no reject
-            // reply (that silent drop is #3608's deferred domain), so a `then
-            // reject` output term logs the truthful DENY rather than REJECT.
-            false,
+            // #3608/#3615: reports whether the `then reject` reply above actually
+            // went out; a `then accept`/`then discard` term, or a reject that
+            // fail-closed, keeps this false so the log is truthful.
+            reject_reply_enqueued,
             now_ns,
         );
     }

--- a/userspace-dp/src/afxdp/frame/tests.rs
+++ b/userspace-dp/src/afxdp/frame/tests.rs
@@ -3204,6 +3204,7 @@ fn build_live_forward_request_emits_output_filter_log_event() {
         Some(&event_handle),
         None,
         None,
+        None,
     )
     .expect("output filter log should not block forwarding");
 

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -820,7 +820,7 @@ impl BatchCounters {
     }
 }
 
-mod poll_descriptor;
+pub(in crate::afxdp) mod poll_descriptor;
 use poll_descriptor::poll_binding_process_descriptor;
 
 // #946 Phase 1: per-packet pipeline stages extracted from the
@@ -884,7 +884,7 @@ use disposition::update_last_resolution;
 // afxdp/forward_request.rs.
 mod forward_request;
 use forward_request::{
-    build_live_forward_request_from_frame, should_install_local_reverse_session,
+    ForwardRejectReply, build_live_forward_request_from_frame, should_install_local_reverse_session,
 };
 // `build_live_forward_request` is only referenced by tests in
 // afxdp/frame/tests.rs; gate its import behind cfg(test).

--- a/userspace-dp/src/afxdp/poll_descriptor/filter.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/filter.rs
@@ -440,6 +440,10 @@ pub(super) fn emit_cached_output_filter_log(
     cached_decision: SessionDecision,
     cached_descriptor: &RewriteDescriptor,
     cached_metadata: &SessionMetadata,
+    // #3608: whether the cached `then reject` reply actually went out; threaded
+    // into the RT_FLOW action so a reject that fail-closed logs the truthful DENY
+    // (#3615). `false` for a `then accept`/`then discard`/policer log.
+    reject_reply_enqueued: bool,
     now_ns: u64,
 ) {
     let Some(log_match) = cached_descriptor.tx_selection.filter_log else {
@@ -453,6 +457,7 @@ pub(super) fn emit_cached_output_filter_log(
         cached_decision,
         cached_metadata,
         log_match,
+        reject_reply_enqueued,
         now_ns,
     );
 }
@@ -468,6 +473,7 @@ fn emit_cached_output_filter_log_tail(
     cached_decision: SessionDecision,
     cached_metadata: &SessionMetadata,
     log_match: crate::filter::FilterLogMatch,
+    reject_reply_enqueued: bool,
     now_ns: u64,
 ) {
     emit_filter_log_event(
@@ -482,11 +488,11 @@ fn emit_cached_output_filter_log_tail(
         FilterLogSource::CachedOutput,
         // #2520: AppID via the hot-path app_catalog.lookup.
         resolve_flow_app_id(&forwarding.app_catalog, flow),
-        // #3615: the TX/forward output-filter path does NOT synthesize a reject
-        // reply (that is #3608's silent-drop domain, deferred). No reply is
-        // enqueued here, so a `then reject` output-filter drop logs the truthful
-        // DENY rather than claiming an active reject was sent.
-        false,
+        // #3608/#3615: the cached output-filter `then reject` now DOES synthesize
+        // the active reply on the flow-cache-hit path. `reject_reply_enqueued`
+        // reports whether it actually went out, so a reject that fail-closed logs
+        // the truthful DENY rather than claiming an active reject was sent.
+        reject_reply_enqueued,
         now_ns,
     );
 }

--- a/userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs
@@ -226,6 +226,26 @@ pub(super) fn stage_flow_cache_hit(
             cached_descriptor,
             now_ns,
         );
+        // #3608: an output firewall-filter `then reject` cached on this flow now
+        // emits the same active reply (TCP RST / ICMP admin-prohibited) the
+        // input/lo0 path already produces (#2521) rather than the historical
+        // silent drop. Only the `then reject` subset synthesizes; `then discard`
+        // and a red three-color policer stay silent. Enqueue the reply FIRST so
+        // the cached output filter-log below reports the TRUTHFUL action (#3615)
+        // — a reject whose reply fail-closes logs DENY, not REJECT.
+        let output_reject_reply_enqueued = if cached_descriptor.tx_selection.reject {
+            super::reject_reply::enqueue_filter_reject_reply(
+                tx_pipeline,
+                worker_ctx.forwarding,
+                worker_ctx.ident.ifindex,
+                packet_frame,
+                meta,
+                flow,
+                telemetry.counters,
+            )
+        } else {
+            false
+        };
         emit_cached_output_filter_log(
             worker_ctx.forwarding,
             worker_ctx.event_stream,
@@ -234,6 +254,7 @@ pub(super) fn stage_flow_cache_hit(
             cached_decision,
             cached_descriptor,
             cached_metadata,
+            output_reject_reply_enqueued,
             now_ns,
         );
         if cached_descriptor.tx_selection.drop || policer_action.drop {
@@ -474,6 +495,11 @@ pub(super) fn stage_flow_cache_hit(
                         target_binding_index: target_bi,
                     }),
                     Some(&cached_precomputed_tx_selection),
+                    // #3608: no reject reply here — this fallback runs only for a
+                    // NON-dropped cached flow (the `then reject`/`then discard`
+                    // drop already returned above at the cached-drop check), so
+                    // the precomputed selection is never a reject.
+                    None,
                 ) {
                     request.frame = owned_packet_frame
                         .take()

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -19,7 +19,7 @@ mod cookie_reply;
 mod filter;
 mod flow_cache_hit;
 mod nat_exception;
-mod reject_reply;
+pub(in crate::afxdp) mod reject_reply;
 mod rx_telemetry;
 
 use flow_cache_hit::{FlowCacheOutcome, stage_flow_cache_hit};
@@ -1302,6 +1302,13 @@ pub(super) fn poll_binding_process_descriptor(
                                 worker_ctx.event_stream,
                                 None,
                                 None,
+                                // #3608: output-filter `then reject` on the
+                                // fabric-return forward emits the active reply
+                                // rather than silently dropping.
+                                Some(ForwardRejectReply {
+                                    tx_pipeline: &mut binding.tx_pipeline,
+                                    counters: telemetry.counters,
+                                }),
                             ) {
                                 request.frame = owned_packet_frame
                                     .take()
@@ -3780,6 +3787,13 @@ pub(super) fn poll_binding_process_descriptor(
                         worker_ctx.event_stream,
                         None,
                         None,
+                        // #3608: give the transit forward path the ingress TX
+                        // pipeline so an output-filter `then reject` emits the
+                        // active reply instead of a silent drop.
+                        Some(ForwardRejectReply {
+                            tx_pipeline: &mut binding.tx_pipeline,
+                            counters: telemetry.counters,
+                        }),
                     ) {
                         // #2362: capture the per-packet L4 match inputs from the
                         // frame BEFORE `owned_packet_frame.take()` below moves the

--- a/userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs
@@ -71,7 +71,7 @@ pub(super) fn enqueue_policy_reject_reply(
 /// behavior (the caller still drops the packet on a `false` return).
 #[cold]
 #[inline(never)]
-pub(super) fn enqueue_filter_reject_reply(
+pub(in crate::afxdp) fn enqueue_filter_reject_reply(
     tx_pipeline: &mut WorkerTxPipeline,
     forwarding: &ForwardingState,
     ingress_ifindex: i32,

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -386,6 +386,21 @@ fn build_live_forward_request_from_frame_drops_logged_output_filter_discard() {
 /// flips. `then discard` (the sibling test above) is unaffected.
 #[test]
 fn build_live_forward_request_from_frame_output_filter_reject_sends_rst_3608() {
+    // #2472/#2955: the reject reply is gated by the PROCESS-GLOBAL Reject GCRA
+    // token bucket, whose TAT advances monotonically across the whole test
+    // binary. Hold the shared global-bucket test lock for the entire
+    // reset→drive→assert window and reset the Reject bucket to full, exactly as
+    // the reject_reply.rs success-path siblings do (e.g.
+    // `reject_tcp_with_egress_enqueues_rst`). Without this a parallel test can
+    // drain the bucket out from under us (this assertion would flake to
+    // `filter_reject_sent == 0`) AND the resulting rate-limit denial would bump
+    // the global rate_limited_count and break a concurrent lock-test's
+    // before==after invariant.
+    let _bucket_guard = crate::afxdp::icmp_ratelimit::global_bucket_test_lock();
+    crate::afxdp::icmp_ratelimit::reset_bucket_for_test(
+        crate::afxdp::icmp_ratelimit::GeneratedErrorReason::Reject,
+        0,
+    );
     let lookup = WorkerBindingLookup::default();
     let ingress_ident = BindingIdentity {
         slot: 7,

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -1,4 +1,5 @@
 use super::test_fixtures::*;
+use super::worker::WorkerTxPipeline;
 use super::*;
 use crate::test_zone_ids::*;
 use crate::xsk_ffi::IfInfo;
@@ -250,6 +251,7 @@ fn build_live_forward_request_from_frame_uses_precomputed_hints() {
         None,
         Some(hints),
         None,
+        None,
     )
     .expect("request");
 
@@ -354,6 +356,7 @@ fn build_live_forward_request_from_frame_drops_logged_output_filter_discard() {
         Some(&event_handle),
         None,
         None,
+        None,
     );
 
     assert!(req.is_none(), "terminal output filter must not forward");
@@ -371,6 +374,186 @@ fn build_live_forward_request_from_frame_drops_logged_output_filter_discard() {
         event.reason,
         FilterLogSource::Output.wire_reason(),
         "live output filter source must not be mislabeled",
+    );
+}
+
+/// #3608 RED-on-revert: an OUTPUT firewall-filter `then reject` on the transit
+/// forward path must synthesize an ACTIVE reject reply (a TCP RST here), NOT the
+/// historical silent drop. On revert (the `CoSTxSelection.reject` flag or the
+/// `build_live_forward_request_from_frame` synthesis wiring removed) the reject
+/// collapses back to a silent discard: no RST is enqueued, `filter_reject_sent`
+/// stays 0, and the filter-log downgrades REJECT->DENY — every assertion below
+/// flips. `then discard` (the sibling test above) is unaffected.
+#[test]
+fn build_live_forward_request_from_frame_output_filter_reject_sends_rst_3608() {
+    let lookup = WorkerBindingLookup::default();
+    let ingress_ident = BindingIdentity {
+        slot: 7,
+        queue_id: 3,
+        worker_id: 0,
+        interface: Arc::<str>::from("ge-0-0-1"),
+        ifindex: 10,
+    };
+    let src_ip = Ipv4Addr::new(10, 0, 61, 100);
+    let dst_ip = Ipv4Addr::new(172, 16, 80, 200);
+    let src_port = 12345u16;
+    let dst_port = 443u16;
+    // A minimal, valid Ethernet/IPv4/TCP SYN so the RST builder + the generated-
+    // reply re-classify have real bytes to reflect. Unicast L2 addresses (a
+    // group/broadcast source would be suppressed by build_reject_rst_frame).
+    let mut frame = Vec::new();
+    frame.extend_from_slice(&[
+        0x02, 0xbf, 0x72, 0x00, 0x80, 0x08, // dst MAC (unicast)
+        0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, // src MAC
+        0x08, 0x00, // ethertype IPv4
+    ]);
+    frame.extend_from_slice(&[
+        0x45, 0x00, 0x00, 0x28, 0x12, 0x34, 0x40, 0x00, 64, PROTO_TCP, 0x00, 0x00,
+    ]);
+    frame.extend_from_slice(&src_ip.octets());
+    frame.extend_from_slice(&dst_ip.octets());
+    frame.extend_from_slice(&src_port.to_be_bytes());
+    frame.extend_from_slice(&dst_port.to_be_bytes());
+    frame.extend_from_slice(&[
+        0x00, 0x00, 0x00, 0x01, // seq
+        0x00, 0x00, 0x00, 0x00, // ack
+        0x50, 0x02, 0xfa, 0xf0, // data offset / SYN / window
+        0x00, 0x00, 0x00, 0x00, // checksum + urgent
+    ]);
+    let meta = UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+        ingress_ifindex: 10,
+        l3_offset: 14,
+        l4_offset: 34,
+        payload_offset: 54,
+        pkt_len: (frame.len() - 14) as u16,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        tcp_flags: 0x02,
+        ..UserspaceDpMeta::default()
+    };
+    let decision = SessionDecision {
+        resolution: ForwardingResolution {
+            disposition: ForwardingDisposition::ForwardCandidate,
+            local_ifindex: 0,
+            egress_ifindex: 12,
+            tx_ifindex: 11,
+            tunnel_endpoint_id: 0,
+            next_hop: Some(IpAddr::V4(dst_ip)),
+            neighbor_mac: Some([0xba, 0x86, 0xe9, 0xf6, 0x4b, 0xd5]),
+            src_mac: Some([0x02, 0xbf, 0x72, 0x00, 0x80, 0x08]),
+            tx_vlan_id: 80,
+        },
+        nat: NatDecision::default(),
+    };
+    let flow = SessionFlow {
+        src_ip: IpAddr::V4(src_ip),
+        dst_ip: IpAddr::V4(dst_ip),
+        forward_key: SessionKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            src_ip: IpAddr::V4(src_ip),
+            dst_ip: IpAddr::V4(dst_ip),
+            src_port,
+            dst_port,
+        },
+    };
+    let forwarding = build_forwarding_state(&ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: 12,
+            hardware_addr: "02:bf:72:00:80:08".into(),
+            filter_output_v4: "wan-reject".into(),
+            ..Default::default()
+        }],
+        filters: vec![FirewallFilterSnapshot {
+            name: "wan-reject".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "reject-web".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                action: "reject".into(),
+                log: true,
+                ..Default::default()
+            }],
+        }],
+        ..Default::default()
+    });
+    let (event_handle, event_rx) = crate::event_stream::test_worker_handle(
+        8,
+        crate::event_stream::DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+    // Size the pipeline above the SYN-cookie-shared TX-frame reserve so the
+    // reject reply's budget gate admits it (the reject path reuses that gate).
+    let mut tx_pipeline = WorkerTxPipeline {
+        free_tx_frames: (0..256u64).collect(),
+        pending_tx_prepared: std::collections::VecDeque::new(),
+        pending_tx_local: std::collections::VecDeque::new(),
+        max_pending_tx: 256,
+        outstanding_tx: 0,
+        pending_fill_frames: std::collections::VecDeque::new(),
+        in_flight_prepared_recycles: FastMap::default(),
+        tx_submit_ns: Vec::new().into_boxed_slice(),
+    };
+    let mut counters = BatchCounters::default();
+
+    let req = build_live_forward_request_from_frame(
+        &lookup,
+        2,
+        &ingress_ident,
+        XdpDesc {
+            addr: 0,
+            len: frame.len() as u32,
+            options: 0,
+        },
+        &frame,
+        meta,
+        &decision,
+        &forwarding,
+        Some(&flow),
+        None,
+        false,
+        123,
+        Some(&event_handle),
+        None,
+        None,
+        Some(ForwardRejectReply {
+            tx_pipeline: &mut tx_pipeline,
+            counters: &mut counters,
+        }),
+    );
+
+    assert!(
+        req.is_none(),
+        "a `then reject` output term must NOT forward the original packet"
+    );
+    assert_eq!(
+        counters.filter_reject_sent, 1,
+        "#3608: output-filter `then reject` must enqueue exactly one active reply (RED on revert: silent drop leaves this 0)"
+    );
+    assert_eq!(
+        tx_pipeline.pending_tx_local.len(),
+        1,
+        "the reflected TCP RST must be queued on the ingress TX pipeline"
+    );
+    let event = event_rx
+        .try_recv()
+        .expect("output filter-log frame")
+        .decode_dataplane_event()
+        .expect("filter-log payload");
+    assert_eq!(
+        event.kind,
+        crate::event_stream::codec::DataplaneEventKind::FilterLog
+    );
+    assert_eq!(
+        event.action, 2,
+        "#3608/#3615: an output `then reject` whose reply WAS sent must log RT_FLOW REJECT (2), not DENY (0)"
     );
 }
 
@@ -488,6 +671,7 @@ fn output_filter_matches_post_snat_source_forward_leg_3642() {
         false,
         123,
         Some(&event_handle),
+        None,
         None,
         None,
     );
@@ -615,6 +799,7 @@ fn output_filter_matches_post_snat_dest_reverse_leg_3642() {
         Some(&event_handle),
         None,
         None,
+        None,
     );
     assert!(
         req.is_none(),
@@ -733,6 +918,7 @@ fn output_filter_matches_post_dnat_dest_3642() {
         false,
         123,
         Some(&event_handle),
+        None,
         None,
         None,
     );
@@ -12380,6 +12566,7 @@ fn non_first_fragment_v4_not_dropped_by_port_matching_output_filter() {
         Some(&event_handle),
         None,
         None,
+        None,
     );
 
     let req = req.expect(
@@ -12476,6 +12663,7 @@ fn control_icmp_v4_installs_no_synthesized_tx_flow_key() {
         Some(&event_handle),
         None,
         None,
+        None,
     )
     .expect("control ICMP must still forward (TCP-only output filter does not match)");
 
@@ -12523,6 +12711,7 @@ fn flowless_non_fragmented_tcp_still_hits_port_matching_output_filter() {
         false,
         123,
         Some(&event_handle),
+        None,
         None,
         None,
     );
@@ -13114,6 +13303,7 @@ fn non_first_fragment_v6_not_dropped_by_port_matching_output_filter() {
         false,
         123,
         Some(&event_handle),
+        None,
         None,
         None,
     );

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -11,6 +11,14 @@ pub(in crate::afxdp) struct CoSTxSelection {
     pub(in crate::afxdp) queue_id: Option<u8>,
     pub(in crate::afxdp) dscp_rewrite: Option<u8>,
     pub(in crate::afxdp) drop: bool,
+    // #3608: `drop` folds every non-`Accept` output-filter action plus any
+    // three-color-policer drop into one bit. `reject` isolates the subset that
+    // was an explicit output-filter `then reject` (`FilterAction::Reject`), so
+    // the TX/CoS consumer can synthesize the active reject reply (TCP RST /
+    // ICMP admin-prohibited) instead of the silent drop a `then discard` or a
+    // red policer produces. `reject` is only ever true when `drop` is true; a
+    // policer drop or a `then discard` keeps `reject == false`.
+    pub(in crate::afxdp) reject: bool,
     pub(in crate::afxdp) filter_log: Option<crate::filter::FilterLogMatch>,
 }
 
@@ -102,6 +110,7 @@ pub(in crate::afxdp) fn resolve_cached_cos_tx_selection(
             queue_id: iface.map(|iface| iface.default_queue),
             dscp_rewrite: None,
             drop: false,
+            reject: false,
             filter_counters: crate::filter::CachedFilterCounters::default(),
             three_color_policers: crate::filter::CachedThreeColorPolicers::default(),
             filter_log: None,
@@ -250,6 +259,12 @@ pub(in crate::afxdp) fn resolve_cached_cos_tx_selection(
         queue_id,
         dscp_rewrite: effective_dscp_rewrite,
         drop: output_result.action != crate::filter::FilterAction::Accept,
+        // #3608: the cached-descriptor `drop` above is the OUTPUT filter's
+        // terminal action only (the three-color policer runs separately at
+        // replay via `apply_cached_three_color_policers`), so a `drop == true`
+        // here is exactly `then discard` or `then reject`. Carry the reject
+        // subset so the flow-cache-hit consumer can send an active reply.
+        reject: output_result.action == crate::filter::FilterAction::Reject,
         filter_counters,
         three_color_policers,
         filter_log,
@@ -364,6 +379,7 @@ fn resolve_cos_tx_selection_internal(
             queue_id: iface.map(|iface| iface.default_queue),
             dscp_rewrite: None,
             drop: false,
+            reject: false,
             filter_log: None,
         };
     };
@@ -386,6 +402,7 @@ fn resolve_cos_tx_selection_internal(
             queue_id: None,
             dscp_rewrite: None,
             drop: false,
+            reject: false,
             filter_log: None,
         };
     }
@@ -475,6 +492,12 @@ fn resolve_cos_tx_selection_internal(
     let mut effective_dscp_rewrite = output_result.dscp_rewrite;
     let mut drop =
         output_result.policer_drop || output_result.action != crate::filter::FilterAction::Accept;
+    // #3608: isolate the `then reject` subset of the collapsed `drop` bit so the
+    // TX/CoS consumer can synthesize an active reject reply. Only the OUTPUT
+    // filter's terminal action produces a reject; a three-color-policer drop
+    // (`policer_drop`, above or the ingress meter below) is always a silent
+    // discard.
+    let reject = output_result.action == crate::filter::FilterAction::Reject;
     let mut ingress_forwarding_class = None;
     let filter_log = output_result.log_match;
     if let Some(ingress_filter) = ingress_filter.filter(|filter| {
@@ -526,6 +549,7 @@ fn resolve_cos_tx_selection_internal(
             queue_id: None,
             dscp_rewrite: effective_dscp_rewrite,
             drop,
+            reject,
             filter_log,
         };
     };
@@ -535,6 +559,7 @@ fn resolve_cos_tx_selection_internal(
                 queue_id: Some(*queue_id),
                 dscp_rewrite: effective_dscp_rewrite,
                 drop,
+                reject,
                 filter_log,
             };
         }
@@ -545,6 +570,7 @@ fn resolve_cos_tx_selection_internal(
                 queue_id: Some(*queue_id),
                 dscp_rewrite: effective_dscp_rewrite,
                 drop,
+                reject,
                 filter_log,
             };
         }
@@ -554,6 +580,7 @@ fn resolve_cos_tx_selection_internal(
             queue_id: Some(queue_id),
             dscp_rewrite: effective_dscp_rewrite,
             drop,
+            reject,
             filter_log,
         };
     }
@@ -566,6 +593,7 @@ fn resolve_cos_tx_selection_internal(
             queue_id: Some(queue_id),
             dscp_rewrite: effective_dscp_rewrite,
             drop,
+            reject,
             filter_log,
         };
     }
@@ -573,6 +601,7 @@ fn resolve_cos_tx_selection_internal(
         queue_id: Some(iface.default_queue),
         dscp_rewrite: effective_dscp_rewrite,
         drop,
+        reject,
         filter_log,
     }
 }

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -1469,6 +1469,9 @@ fn resolve_cos_tx_selection_drops_terminal_output_filter_without_log() {
     );
 
     assert!(selection.drop);
+    // #3608: `then discard` is a SILENT drop — it must NOT be flagged as a
+    // reject, so no active reply is synthesized for it.
+    assert!(!selection.reject, "then discard must not be a reject");
     assert_eq!(selection.queue_id, None);
     assert_eq!(selection.filter_log, None);
 }
@@ -1522,6 +1525,10 @@ fn resolve_cos_tx_selection_drops_reject_output_filter_without_log() {
     );
 
     assert!(selection.drop);
+    // #3608 RED-on-revert: `then reject` must be flagged as a reject (distinct
+    // from `then discard`) so the TX/CoS consumer synthesizes the active reply
+    // instead of a silent drop.
+    assert!(selection.reject, "then reject must set the reject flag");
     assert_eq!(selection.queue_id, None);
     assert_eq!(selection.filter_log, None);
 }

--- a/userspace-dp/src/afxdp/umem/tests.rs
+++ b/userspace-dp/src/afxdp/umem/tests.rs
@@ -1573,6 +1573,7 @@ fn active_flow_debug_test_entry(
                 queue_id: Some(2),
                 dscp_rewrite: Some(46),
                 drop: false,
+                reject: false,
                 filter_counters: crate::filter::CachedFilterCounters::default(),
                 three_color_policers: crate::filter::CachedThreeColorPolicers::default(),
                 filter_log: None,

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -796,6 +796,24 @@ paths. `apply_lo0_filter_action` returns the matched `FilterAction`
 (not a bare drop `bool`) so the caller can tell `Reject` from
 `Discard`.
 
+The OUTPUT-firewall-filter (interface `filter output`) `then reject` on
+the transit forward / TX/CoS path is wired the same way (#3608). The
+TX/CoS classifier (`resolve_cos_tx_selection*` / `resolve_cached_cos_tx_selection`)
+collapses every non-`Accept` terminal action plus any three-color-policer
+drop into a single `drop` bit, so it now also carries a `reject` bit
+(`CoSTxSelection.reject` / `CachedTxSelectionDescriptor.reject`) that
+isolates exactly the `then reject` subset (`FilterAction::Reject`) — a
+`then discard` or a red policer keeps `reject == false`. The transit
+forward-request builder (`build_live_forward_request_from_frame`) and the
+flow-cache-hit fast path (`poll_descriptor/flow_cache_hit.rs`) consume
+that bit: on a reject drop they call `enqueue_filter_reject_reply` (the
+same shared synthesis) BEFORE returning `None` / recycling, reflecting the
+ORIGINAL inbound frame back toward the source via the ingress interface.
+The output filter-log is emitted AFTER the enqueue with the truthful
+outcome, so a reject whose reply fail-closes logs DENY, not REJECT
+(#3615). The builder gets the ingress TX pipeline + counters via the
+`ForwardRejectReply` context passed by its poll-loop callers.
+
 Zone-level Junos `tcp-rst` (#3071) reuses the same `enqueue_policy_reject_reply`
 machinery through the unified `enqueue_deny_reply` decision helper. Both
 policy-deny call sites in `poll_descriptor/mod.rs` now call
@@ -821,8 +839,11 @@ packet when synthesis returns `false`). The RT_FLOW filter-log action
 maps `Reject → reject` (matching policy reject and Junos), `Discard →
 deny`.
 
-**Scope:** output-firewall-filter `then reject` realized on the
-TX/CoS path (`tx/cos_classify.rs`) still collapses `Reject` to a
-silent drop. That site lacks the descriptor/packet context the
-reflected-reply synthesis needs, so wiring it would be a divergent
-path — tracked as a follow-up, not part of #2521.
+**Scope (resolved #3608):** output-firewall-filter `then reject` on the
+TX/CoS path is now an active reject too — see the OUTPUT-filter paragraph
+above. The remaining collapse-to-drop site is the deferred-CoS dispatch
+path (`tx/dispatch/mod.rs`, `resolve_pending_forward_cos_tx_selection`),
+which is unreachable in production today (every `PendingForwardRequest` is
+built with `cos_tx_selection_resolved: true`, so the deferred re-resolve
+never runs); the `reject` bit is available there for a future wiring if a
+deferred-CoS request path is ever introduced.


### PR DESCRIPTION
## Summary

Closes #3608.

An OUTPUT firewall-filter terminal `then reject` was realized as a **silent drop** on the transit forward / TX-CoS path. Input and lo0 `then reject` became active rejects (TCP RST / ICMP admin-prohibited) in #2521, but the TX/CoS cached-selection path collapsed every non-`Accept` action to a single `drop` bit with no reject-reply synthesis — so on the egress path the remote endpoint saw a timeout instead of the RST/unreachable that `reject` promises. Silent, incomplete parity for an operator-visible security action.

## What changed

- **Carry the reject intent through the TX/CoS classifier.** A `reject` bit is added to `CoSTxSelection` and `CachedTxSelectionDescriptor` that isolates the `then reject` subset (`FilterAction::Reject`) of the collapsed `drop` bit. `then discard` and a red three-color policer keep `reject == false` (still silent). Set in `resolve_cos_tx_selection_internal` and `resolve_cached_cos_tx_selection`.
- **Emit the reply, mirroring the input path.** The transit forward-request builder (`build_live_forward_request_from_frame`) and the flow-cache-hit fast path consume the bit and call the shared `enqueue_filter_reject_reply` (same synthesis + #2238 output-classification + #2472 rate-limit + fail-closed budget gate the input/lo0 path uses) BEFORE dropping, reflecting the ORIGINAL inbound frame back toward the source via the ingress interface.
- **Truthful logging (#3615).** The output filter-log is emitted AFTER the enqueue with the real outcome, so a reject whose reply fail-closes logs DENY rather than claiming an active reject. `emit_cached_output_filter_log` gains a `reject_reply_enqueued` param.
- The builder gets the ingress TX pipeline via a new `ForwardRejectReply` context passed by its poll-loop callers; `poll_descriptor`/`reject_reply` module + `enqueue_filter_reject_reply` visibility widened to `pub(in crate::afxdp)`.

The only remaining collapse-to-drop site is the deferred-CoS dispatch path, unreachable in production (every `PendingForwardRequest` resolves CoS inline with `cos_tx_selection_resolved: true`); the `reject` bit is available there for a future wiring.

## Not a DoS amplifier / no reflection loop

The output path reuses the *same* `enqueue_reject_reply` as the input/policy path, so it inherits every existing guard: the global #2472 Reject token bucket, the SYN-cookie TX-frame budget, and the #3656 feasibility gate (inbound RSTs / ICMP-errors / non-first-fragments / L2-group frames are never answered). On any exhaustion it fails closed to the silent drop and logs DENY. The reply goes to `pending_tx_local` straight to TX (no re-ingress loop). The accept path is byte-identical.

## Tests (RED on revert)

- Classification: `then reject` sets `reject`, `then discard` does not (`cos_classify_tests.rs`).
- End-to-end build path: a `then reject` output term enqueues the reflected TCP RST, bumps `filter_reject_sent`, and the RT_FLOW filter-log encodes **REJECT (2)** not **DENY (0)** (`tests.rs`). Verified RED-on-revert (silent drop leaves the counter 0). The existing `then discard` test is unchanged. The e2e test holds `global_bucket_test_lock()` + resets the Reject bucket (mirroring the reject_reply.rs siblings) so it is deterministic under parallel `--test-threads`.

## Validation

- Full `cargo test` green across three consecutive parallel-scheduled runs (3513 pass). The only failures are two pre-existing, unrelated event_stream flakes — `test_paused_telemetry_eviction_does_not_poison_drain_2875` and `stalled_consumer_does_not_grow_backlog_unbounded_end_to_end` — both red on clean `master` and touching no file in this diff (at most one fires per run).
- `go build ./...` and `go test ./pkg/config/...` green (no Go change — the compiler already carries `reject` regardless of direction).
- Docs updated: `userspace-dp/src/filter/README.md`, `docs/feature-gaps.md`.

Rebased onto latest `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi