### PR TITLE
config lexer: reject unterminated /* */ block comments

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+
+## 2026-07-04 — #4147 (M-8): unterminated /* */ block comment silently truncates config
+
+- **Timestamp**: 2026-07-04
+  - **Action**: VERIFY-FIRST at HEAD (origin/master d70851156) then FIX.
+    fable-review-164 M-8. Confirmed empirically: the block-comment scanner
+    in `skipWhitespaceAndComments` (`pkg/config/lexer.go`) consumed input to
+    EOF when a `/*` had no closing `*/`, `continue`d, and returned no error —
+    so everything after the unclosed `/*` was swallowed as comment text,
+    `Parse()` returned 0 errors, and `commit` applied a config with dropped
+    stanzas (a scratch repro dropped an entire trailing `security { policies
+    { default-policy { deny-all; } } }` stanza — 0 errors, 1 top-level node).
+    A fail-open config-integrity path, in contrast to `readString` which
+    returns `TokenError{"unterminated string"}`. FIX: the block-comment loop
+    now tracks a `terminated` flag and the opening `/*` line/column; on EOF
+    with no `*/` it stashes a `TokenError{"unterminated block comment"}` in a
+    new `Lexer.pending` field, drained at the top of `Next` (since
+    `skipWhitespaceAndComments` cannot return a token). `parseStatements`
+    already surfaces a `TokenError` Peek as a `ParseError`, so the load /
+    commit paths now reject the truncated config (#1960-correct strict
+    reject). `Peek` also saves/restores `pending` to stay a pure no-op.
+    Single-line `/* x */`, `#`, and `//` comments are unaffected — only the
+    unterminated multi-line block is rejected. Added
+    `TestUnterminatedBlockComment` (RED on revert: without the fix it fails
+    "expected a parse error, got none (config silently truncated to 1
+    top-level node)"; terminated-comment case asserts the post-comment
+    `system` stanza SURVIVES). go test ./pkg/config/... green; go build
+    ./... green; gofmt + go vet clean. Documented in pkg/config/README.md
+    Gotchas.
+  - **File(s)**: pkg/config/lexer.go, pkg/config/parser_ast_test.go,
+    pkg/config/README.md, _Log.md
 ## 2026-07-04 — #4088: pool SNAT — id==0 ICMP echo is a valid keyable query
 
 - **Timestamp**: 2026-07-04

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -156,6 +156,21 @@ parser treats newlines as whitespace and merges multiple set lines into
 one giant node. This trap has bitten the project repeatedly — see
 CLAUDE.md.
 
+**Comments (`# ...`, `// ...`, `/* ... */`) and unterminated blocks
+(M-8):** the lexer (`skipWhitespaceAndComments`) skips `#`/`//` line
+comments to end-of-line and `/* */` block comments to their closing
+`*/`. An **unterminated** `/*` — one that reaches EOF with no closing
+`*/` — used to be swallowed silently to end-of-input, dropping every
+stanza after it while `Parse()` reported zero errors: one typo'd comment
+could delete an arbitrary tail of the config (e.g. security policies) and
+still `commit` successfully — a fail-open config-integrity path. The
+lexer now stashes a `TokenError{"unterminated block comment"}` (keyed to
+the opening `/*` line/column, mirroring `readString`'s "unterminated
+string"), surfaced via `Lexer.pending` at the top of `Next`, so
+`parseStatements` records a `ParseError` and the load/commit paths reject
+the truncated config. Single-line `/* x */` and `#`/`//` comments are
+unaffected — only the unterminated multi-line block is rejected.
+
 **Security-policy terminal action is fail-closed (#3043):** `PolicyAction`'s
 zero value is `PolicyPermit`, so a policy whose `then` stanza names no
 terminal action (log-only/count-only or a typo'd `then`) historically

--- a/pkg/config/lexer.go
+++ b/pkg/config/lexer.go
@@ -65,6 +65,11 @@ type Lexer struct {
 	pos    int
 	line   int
 	column int
+	// pending holds a TokenError produced while skipping whitespace and
+	// comments (an unterminated block comment) that must be surfaced by the
+	// next call to Next. skipWhitespaceAndComments cannot return a token, so
+	// the error is stashed here and drained at the top of Next.
+	pending *Token
 }
 
 // NewLexer creates a new Lexer for the given input string.
@@ -79,6 +84,16 @@ func NewLexer(input string) *Lexer {
 // Next returns the next token, advancing the position.
 func (l *Lexer) Next() Token {
 	l.skipWhitespaceAndComments()
+
+	// An unterminated block comment detected during skipping surfaces as a
+	// TokenError here so parseStatements records a ParseError and the load /
+	// commit paths reject the config instead of silently accepting a
+	// truncated one (matching the unterminated-string behavior).
+	if l.pending != nil {
+		tok := *l.pending
+		l.pending = nil
+		return tok
+	}
 
 	if l.pos >= len(l.input) {
 		return Token{Type: TokenEOF, Line: l.line, Column: l.column}
@@ -128,10 +143,12 @@ func (l *Lexer) Peek() Token {
 	savedPos := l.pos
 	savedLine := l.line
 	savedCol := l.column
+	savedPending := l.pending
 	tok := l.Next()
 	l.pos = savedPos
 	l.line = savedLine
 	l.column = savedCol
+	l.pending = savedPending
 	return tok
 }
 
@@ -167,15 +184,33 @@ func (l *Lexer) skipWhitespaceAndComments() {
 
 		// Block comment: /* ... */
 		if ch == '/' && l.pos+1 < len(l.input) && l.input[l.pos+1] == '*' {
+			startLine, startCol := l.line, l.column
 			l.advance() // /
 			l.advance() // *
+			terminated := false
 			for l.pos+1 < len(l.input) {
 				if l.input[l.pos] == '*' && l.input[l.pos+1] == '/' {
 					l.advance() // *
 					l.advance() // /
+					terminated = true
 					break
 				}
 				l.advance()
+			}
+			if !terminated {
+				// Reached EOF without a closing */. Consume the final byte the
+				// pos+1 loop bound left behind and stash an error keyed to the
+				// opening /* so the truncation is reported, not swallowed.
+				for l.pos < len(l.input) {
+					l.advance()
+				}
+				l.pending = &Token{
+					Type:   TokenError,
+					Value:  "unterminated block comment",
+					Line:   startLine,
+					Column: startCol,
+				}
+				return
 			}
 			continue
 		}

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -50,6 +50,90 @@ security {
 	}
 }
 
+// TestUnterminatedBlockComment guards the fable-review-164 M-8 fix: an
+// unterminated /* */ block comment must produce a lexer/parse error rather
+// than silently swallowing the remainder of the config to EOF. Before the
+// fix the block-comment scanner consumed to EOF and returned no error, so a
+// single accidental unterminated comment dropped an arbitrary tail of the
+// config (e.g. security policies) while Parse() reported success — a
+// fail-open config-integrity path (contrast readString's "unterminated
+// string" TokenError). This test goes RED on revert:
+//   - unterminated  -> Parse() must report an "unterminated block comment"
+//     error (RED on revert: 0 errors + dropped stanza).
+//   - terminated    -> parses clean AND the post-comment stanza survives.
+//   - single-line   -> /* x */ on one line is unchanged (no error).
+//   - line comments -> # and // are unchanged (no error).
+func TestUnterminatedBlockComment(t *testing.T) {
+	// The trailing `security { policies { ... } }` stanza sits AFTER the
+	// unclosed /* and would be silently eaten before the fix.
+	unterminated := `security {
+    zones {
+        security-zone trust;
+    }
+} /* oops I never closed this comment
+security {
+    policies {
+        default-policy {
+            deny-all;
+        }
+    }
+}`
+	tree, errs := NewParser(unterminated).Parse()
+	if len(errs) == 0 {
+		t.Fatalf("unterminated block comment: expected a parse error, got none "+
+			"(config silently truncated to %d top-level node(s))", len(tree.Children))
+	}
+	foundUnterm := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "unterminated block comment") {
+			foundUnterm = true
+		}
+	}
+	if !foundUnterm {
+		t.Fatalf("expected an 'unterminated block comment' error, got: %v", errs)
+	}
+
+	// A properly terminated block comment must parse clean AND preserve the
+	// stanza that follows it — the fix must not reject well-formed comments.
+	terminated := `security {
+    zones {
+        security-zone trust;
+    }
+} /* this comment is properly closed */
+system {
+    host-name after-comment;
+}`
+	tree, errs = NewParser(terminated).Parse()
+	if len(errs) != 0 {
+		t.Fatalf("terminated block comment: unexpected parse errors: %v", errs)
+	}
+	var haveSystem bool
+	for _, n := range tree.Children {
+		if len(n.Keys) > 0 && n.Keys[0] == "system" {
+			haveSystem = true
+		}
+	}
+	if !haveSystem {
+		t.Fatalf("terminated block comment: post-comment `system` stanza was "+
+			"dropped; top-level nodes: %d", len(tree.Children))
+	}
+
+	// A single-line /* x */ comment must remain valid (no error).
+	if _, errs := NewParser("system { /* inline */ host-name h; }").Parse(); len(errs) != 0 {
+		t.Fatalf("single-line block comment: unexpected parse errors: %v", errs)
+	}
+
+	// Line comments (# and //) are untouched by the fix.
+	lineComments := `# hash comment
+system {
+    // slash comment
+    host-name h;
+}`
+	if _, errs := NewParser(lineComments).Parse(); len(errs) != 0 {
+		t.Fatalf("line comments: unexpected parse errors: %v", errs)
+	}
+}
+
 func TestBracketList(t *testing.T) {
 	// server1/2/3 are declared as address-book entries so the policy
 	// match-address strict validator (#2008) accepts the bracket-list


### PR DESCRIPTION
## Summary

Closes #4147 (fable-review-164 finding M-8).

An unterminated `/* */` block comment silently truncated the config with **zero parse errors**. The block-comment scanner in `skipWhitespaceAndComments` (`pkg/config/lexer.go`) consumed input up to a closing `*/`, but on EOF with no terminator it fell through the loop, `continue`d, and returned no error — so everything after an unclosed `/*` was swallowed as comment text. `Parse()` then returned `errs=0`, `LoadOverride` accepted, and `commit` applied a config missing every stanza after the typo'd comment.

This is a fail-open config-integrity path: one accidental unterminated comment deletes an arbitrary tail of the config (potentially default-deny / security policies) with no operator signal. It contrasts with `readString`, which already returns `TokenError{"unterminated string"}` for the analogous case, and with vSRX, which rejects unterminated comments at parse time.

**Reproduced** (before fix): a config ending with `} /* oops never closed\nsecurity { policies { default-policy { deny-all; } } }` parses to **0 errors and 1 top-level node** — the entire second `security`/`policies` subtree is gone.

## Fix

The block-comment loop now tracks a `terminated` flag plus the opening `/*` line/column. On EOF with no `*/` seen it stashes a `TokenError{"unterminated block comment"}` in a new `Lexer.pending` field, drained at the top of `Next` (`skipWhitespaceAndComments` cannot itself return a token). `parseStatements` already surfaces a `TokenError` `Peek` as a `ParseError`, so the load and commit paths now strict-reject the truncated config (#1960-correct) instead of silently accepting it. `Peek` saves/restores `pending` to remain a pure no-op on lexer state.

Single-line `/* x */` block comments and `#` / `//` line comments are unaffected — only the unterminated multi-line block is rejected.

## Test (RED on revert)

`TestUnterminatedBlockComment` (`pkg/config/parser_ast_test.go`):
- **unterminated** `/*` → `Parse()` must report an "unterminated block comment" error. RED on revert: fails "expected a parse error, got none (config silently truncated to 1 top-level node)".
- **terminated** `/* ... */` → parses clean AND the post-comment `system` stanza survives.
- **single-line** `/* x */` → still valid, no error.
- **line comments** (`#`, `//`) → still valid, no error.

## Validation

- `go test ./pkg/config/...` green
- `go build ./...` green
- `gofmt` + `go vet ./pkg/config/` clean
- Documented in `pkg/config/README.md` Gotchas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi