### PR TITLE
api: management HTTP server slowloris timeouts + REST body-size cap (M-6 + M-7)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,4 +1,43 @@
 
+## 2026-07-04 — #4150 (M-6 + M-7): management HTTP server DoS hardening
+
+- **Timestamp**: 2026-07-04
+  - **Action**: VERIFY-FIRST at HEAD (origin/master ~d70851156, worktree
+    4a784dd1b) then FIX. fable-review-164 M-6 + M-7, both pre-auth (or
+    low-priv) mgmt-plane DoS on the `pkg/api` HTTP/HTTPS server.
+    M-6: both `http.Server` literals in `NewServer`
+    (`pkg/api/server.go`) set only `Addr`/`Handler`(/`TLSConfig`) — every
+    timeout field zero (no limit). Header read precedes `authMiddleware`, so a
+    pre-auth slowloris (dribbled headers/body) pins a goroutine/socket per
+    conn indefinitely once web-management binds a non-loopback interface. FIX:
+    set `ReadHeaderTimeout` 10s (slowloris-header defense), `ReadTimeout` 30s
+    (slow-body), `IdleTimeout` 120s, `MaxHeaderBytes` 1 MiB on BOTH literals
+    via a package const block. WriteTimeout deliberately left 0 (unlimited) —
+    the SSE event/log streams + large metrics/session-table scrapes are legit
+    slow responses a WriteTimeout would sever; the read-side timeouts are the
+    slowloris-critical ones and the response side is bounded by per-handler
+    ctx deadlines.
+    M-7: every mutating handler did `json.NewDecoder(r.Body).Decode(&req)`
+    with no `http.MaxBytesReader` (config load/merge/override buffers the whole
+    `Content` then parses it a second time → OOM-kill). FIX: new shared
+    `decodeJSONBody(w, r, dst)` helper (`pkg/api/api.go`) wraps r.Body in
+    `MaxBytesReader(maxRequestBodyBytes=16 MiB)` and returns HTTP 413 on
+    overflow, 400 on other decode errors. Converted all 12 mutation decode
+    sites (config.go ×8 incl. annotate, system.go ×3 ping/traceroute/action,
+    dhcp.go ×1 clear) to the helper; dropped the now-unused `encoding/json`
+    import from those three files. 16 MiB is orders of magnitude above any
+    legit config body; independent transport-layer guard (pairs with H-2's
+    parser-layer ceiling). Read-only GETs untouched.
+  - **Files**: `pkg/api/server.go`, `pkg/api/api.go`, `pkg/api/config.go`,
+    `pkg/api/system.go`, `pkg/api/dhcp.go`,
+    `pkg/api/http_dos_hardening_4150_test.go` (new), `pkg/api/README.md`,
+    `_Log.md`.
+  - **Validation**: `go test ./pkg/api/...` green; `go build ./...` green;
+    gofmt clean; `go vet ./pkg/api/...` clean. RED-on-revert proven: removing
+    the timeout fields → `TestManagementServerTimeoutsSetM6` fails (all fields
+    0); removing the MaxBytesReader wrap → `TestConfigMutationBodyCappedM7`
+    returns 200 not 413. Normal-size body still 200, malformed body still 400.
+
 ## 2026-07-04 — #4147 (M-8): unterminated /* */ block comment silently truncates config
 
 - **Timestamp**: 2026-07-04

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -226,6 +226,26 @@ under the daemon's errgroup. Nothing else imports this package.
 
 ## Gotchas
 
+- **Management-plane DoS hardening (#4150).** Both `http.Server` literals in
+  `NewServer` carry read-side timeouts and a header cap — `ReadHeaderTimeout`
+  (`apiReadHeaderTimeout`, 10s), `ReadTimeout` (`apiReadTimeout`, 30s),
+  `IdleTimeout` (`apiIdleTimeout`, 120s), and `MaxHeaderBytes`
+  (`apiMaxHeaderBytes`, 1 MiB). Header reads happen BEFORE `authMiddleware`, so
+  without these a pre-auth slowloris (dribbled headers/body) could pin a
+  goroutine/socket per connection once web-management binds a non-loopback
+  interface. `WriteTimeout` is deliberately left UNSET (0/unlimited): the SSE
+  event/log streams (`/api/v1/events/stream`, `/api/v1/logs/stream`) are
+  long-lived and a full metrics/session-table scrape is a large slow response —
+  a `WriteTimeout` would sever them; the response side is bounded by per-handler
+  context deadlines instead. Separately, every REST MUTATION handler decodes its
+  body through `decodeJSONBody`, which wraps `r.Body` in
+  `http.MaxBytesReader(maxRequestBodyBytes)` (16 MiB) and returns **HTTP 413** on
+  overflow instead of buffering a multi-gigabyte POST to an OOM-kill (config
+  `set`/`delete`/`activate`/`deactivate`/`load`/`rollback`/`commit-confirmed`/
+  `annotate`, `system/action`, `ping`/`traceroute`, `dhcp/identifiers/clear`).
+  Read-only GET handlers do not read a body and are out of scope. Add a new
+  mutation handler via `decodeJSONBody`, not a bare `json.NewDecoder(r.Body)`,
+  so the cap and 413 are inherited. Pinned by `http_dos_hardening_4150_test.go`.
 - The status-poll path (1 Hz) shares the userspace dataplane control socket
   with HA sync, session installs, snapshot sync, and forwarding sync.
   Adding a new caller at >1 Hz here will starve session installs during

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -55,6 +56,39 @@ func writeOK(w http.ResponseWriter, data any) {
 
 func writeError(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, Response{Success: false, Error: msg})
+}
+
+// maxRequestBodyBytes bounds every REST mutation request body (M-7). Without
+// it, a mutating handler `json.Decode`s r.Body with no ceiling: a crafted or
+// accidental multi-gigabyte POST — e.g. `POST /api/v1/config/load` with a huge
+// `Content` string — is buffered whole by the decoder and then parsed a second
+// time by the configstore, spiking daemon RSS to an OOM-kill (gosec
+// resource-exhaustion; the gRPC side is already bounded by grpc-go's 4 MiB
+// default recv cap, so this is REST-specific). 16 MiB is orders of magnitude
+// above any legitimate payload — the largest real body is a full candidate
+// config, well under a megabyte — while keeping even thousands of concurrent
+// maxed-out requests bounded. This is the transport-layer guard; it is
+// independent of any parser-layer config-size ceiling (which bounds the parsed
+// string, not the wire body).
+const maxRequestBodyBytes = 16 << 20 // 16 MiB
+
+// decodeJSONBody caps r.Body at maxRequestBodyBytes, then decodes JSON into
+// dst. It returns true on success. On an oversized body it writes HTTP 413; on
+// any other decode failure it writes HTTP 400. In BOTH failure cases it has
+// already written the error response, so a false return means the caller must
+// return from the handler immediately without writing anything else.
+func decodeJSONBody(w http.ResponseWriter, r *http.Request, dst any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return false
+		}
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return false
+	}
+	return true
 }
 
 func (s *Server) applyResult() *dataplane.ApplyResult {

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -44,8 +43,7 @@ func (s *Server) configStatusHandler(w http.ResponseWriter, _ *http.Request) {
 
 func (s *Server) configSetHandler(w http.ResponseWriter, r *http.Request) {
 	var req ConfigSetRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if !decodeJSONBody(w, r, &req) {
 		return
 	}
 	if req.Input == "" {
@@ -61,8 +59,7 @@ func (s *Server) configSetHandler(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) configDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	var req ConfigSetRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if !decodeJSONBody(w, r, &req) {
 		return
 	}
 	if req.Input == "" {
@@ -83,8 +80,7 @@ func (s *Server) configDeleteHandler(w http.ResponseWriter, r *http.Request) {
 // applyEditLine switch and the path is never mangled into a junk "set" node.
 func (s *Server) configDeactivateHandler(w http.ResponseWriter, r *http.Request) {
 	var req ConfigSetRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if !decodeJSONBody(w, r, &req) {
 		return
 	}
 	if req.Input == "" {
@@ -102,8 +98,7 @@ func (s *Server) configDeactivateHandler(w http.ResponseWriter, r *http.Request)
 // (#2051), the REST equivalent of the interactive `activate <path>` verb.
 func (s *Server) configActivateHandler(w http.ResponseWriter, r *http.Request) {
 	var req ConfigSetRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if !decodeJSONBody(w, r, &req) {
 		return
 	}
 	if req.Input == "" {
@@ -160,8 +155,7 @@ func (s *Server) configCommitCheckHandler(w http.ResponseWriter, _ *http.Request
 
 func (s *Server) configRollbackHandler(w http.ResponseWriter, r *http.Request) {
 	var req ConfigRollbackRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if !decodeJSONBody(w, r, &req) {
 		return
 	}
 	if err := s.store.Rollback(req.N); err != nil {
@@ -276,8 +270,7 @@ func (s *Server) configSearchHandler(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) configLoadHandler(w http.ResponseWriter, r *http.Request) {
 	var req ConfigLoadRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if !decodeJSONBody(w, r, &req) {
 		return
 	}
 	if req.Content == "" {
@@ -316,8 +309,7 @@ func (s *Server) configLoadHandler(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) configCommitConfirmedHandler(w http.ResponseWriter, r *http.Request) {
 	var req CommitConfirmedRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if !decodeJSONBody(w, r, &req) {
 		return
 	}
 	if s.commitConfirmedFn == nil {
@@ -372,8 +364,7 @@ func (s *Server) configShowRollbackHandler(w http.ResponseWriter, r *http.Reques
 
 func (s *Server) configAnnotateHandler(w http.ResponseWriter, r *http.Request) {
 	var req AnnotateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, Response{Error: err.Error()})
+	if !decodeJSONBody(w, r, &req) {
 		return
 	}
 	if req.Path == "" || req.Comment == "" {

--- a/pkg/api/dhcp.go
+++ b/pkg/api/dhcp.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -68,8 +67,7 @@ func (s *Server) clearDHCPIdentifiersHandler(w http.ResponseWriter, r *http.Requ
 
 	var req ClearDHCPIdentifierRequest
 	if r.ContentLength > 0 {
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON body")
+		if !decodeJSONBody(w, r, &req) {
 			return
 		}
 	}

--- a/pkg/api/http_dos_hardening_4150_test.go
+++ b/pkg/api/http_dos_hardening_4150_test.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #4150 M-6: the management HTTP/HTTPS servers must carry read/header/idle
+// timeouts so a pre-auth slowloris (dribbled headers or body) cannot pin a
+// goroutine/socket indefinitely. This asserts the constructed server fields
+// directly — the RED-on-revert signal is that the original literals set only
+// Addr/Handler(/TLSConfig), leaving every timeout field at its zero (no-limit)
+// value.
+func TestManagementServerTimeoutsSetM6(t *testing.T) {
+	s := NewServer(Config{Addr: "127.0.0.1:0"})
+	if s.httpServer == nil {
+		t.Fatal("httpServer was not constructed")
+	}
+	assertTimeouts(t, "http", s.httpServer.ReadHeaderTimeout, s.httpServer.ReadTimeout,
+		s.httpServer.IdleTimeout, s.httpServer.MaxHeaderBytes, s.httpServer.WriteTimeout)
+
+	// HTTPS server path: TLS on with an HTTPS listen address builds the second
+	// literal, which must carry the SAME hardening.
+	st := NewServer(Config{Addr: "127.0.0.1:0", TLS: true, HTTPSAddr: "127.0.0.1:0"})
+	if st.httpsServer == nil {
+		t.Fatal("httpsServer was not constructed with TLS + HTTPSAddr set")
+	}
+	assertTimeouts(t, "https", st.httpsServer.ReadHeaderTimeout, st.httpsServer.ReadTimeout,
+		st.httpsServer.IdleTimeout, st.httpsServer.MaxHeaderBytes, st.httpsServer.WriteTimeout)
+}
+
+func assertTimeouts(t *testing.T, which string, readHeader, read, idle time.Duration, maxHeaderBytes int, write time.Duration) {
+	t.Helper()
+	if readHeader != apiReadHeaderTimeout {
+		t.Errorf("%s ReadHeaderTimeout = %v, want %v (slowloris-header defense)", which, readHeader, apiReadHeaderTimeout)
+	}
+	if read != apiReadTimeout {
+		t.Errorf("%s ReadTimeout = %v, want %v (slow-body defense)", which, read, apiReadTimeout)
+	}
+	if idle != apiIdleTimeout {
+		t.Errorf("%s IdleTimeout = %v, want %v", which, idle, apiIdleTimeout)
+	}
+	if maxHeaderBytes != apiMaxHeaderBytes {
+		t.Errorf("%s MaxHeaderBytes = %d, want %d", which, maxHeaderBytes, apiMaxHeaderBytes)
+	}
+	// WriteTimeout MUST stay unlimited (0) so SSE event/log streams and large
+	// metrics/session-table scrapes are not severed mid-response. A non-zero
+	// WriteTimeout here would be a regression.
+	if write != 0 {
+		t.Errorf("%s WriteTimeout = %v, want 0 (unlimited — SSE streams + large scrapes must not be cut off)", which, write)
+	}
+}
+
+// repeatReader streams `remaining` copies of byte b without materializing a
+// giant buffer — used to build an over-cap request body cheaply.
+type repeatReader struct {
+	b         byte
+	remaining int64
+}
+
+func (r *repeatReader) Read(p []byte) (int, error) {
+	if r.remaining <= 0 {
+		return 0, io.EOF
+	}
+	n := int64(len(p))
+	if n > r.remaining {
+		n = r.remaining
+	}
+	for i := int64(0); i < n; i++ {
+		p[i] = r.b
+	}
+	r.remaining -= n
+	return int(n), nil
+}
+
+// #4150 M-7: a mutation-handler request body larger than maxRequestBodyBytes
+// must be rejected with HTTP 413 rather than buffered whole (OOM). The body is
+// valid JSON (`{"input":"AAAA..."}`) so on revert (no MaxBytesReader) the
+// decoder reads the entire >16 MiB payload and returns 200/400 — never 413 —
+// making the 413 assertion the RED-on-revert signal.
+func TestConfigMutationBodyCappedM7(t *testing.T) {
+	store := newAPIConfigStore(t)
+	s := &Server{store: store}
+
+	// prefix + (maxRequestBodyBytes + slack) filler bytes + suffix => the cap
+	// fires inside the string value.
+	body := io.MultiReader(
+		strings.NewReader(`{"input":"`),
+		&repeatReader{b: 'A', remaining: int64(maxRequestBodyBytes) + 4096},
+		strings.NewReader(`"}`),
+	)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/config/set", body)
+	s.configSetHandler(rr, req)
+
+	if rr.Code != 413 {
+		t.Fatalf("oversized body status = %d, want 413 (request body too large); body: %s",
+			rr.Code, rr.Body.String())
+	}
+}
+
+// A normal-size mutation body must still succeed — the cap defends against
+// abuse without breaking legitimate requests.
+func TestConfigMutationNormalBodySucceedsM7(t *testing.T) {
+	store := newAPIConfigStore(t)
+	s := &Server{store: store}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/config/set",
+		strings.NewReader(`{"input":"system host-name capped-ok"}`))
+	s.configSetHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("normal body status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// A small malformed JSON body keeps returning HTTP 400 (not 413, not 500) — the
+// cap must not change the error class for ordinary bad input.
+func TestConfigMutationMalformedBodyStill400M7(t *testing.T) {
+	store := newAPIConfigStore(t)
+	s := &Server{store: store}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/config/set",
+		strings.NewReader(`{not valid json`))
+	s.configSetHandler(rr, req)
+
+	if rr.Code != 400 {
+		t.Fatalf("malformed body status = %d, want 400; body: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -273,6 +273,38 @@ type Server struct {
 	startTime                        time.Time
 }
 
+// Management HTTP/HTTPS server timeouts (M-6). Both http.Server literals used
+// to set only Addr/Handler(/TLSConfig), leaving every timeout field zero (no
+// limit). Header reads happen BEFORE authMiddleware, so a pre-auth slowloris —
+// N connections dribbling request headers or a request body one byte at a time
+// — could pin a goroutine/socket per connection indefinitely and wedge the
+// control-plane API once web-management binds a non-loopback interface (gosec
+// G112/G114). The read-side timeouts below are the slowloris-critical defense.
+//
+// WriteTimeout is deliberately left UNSET (0 = unlimited): the SSE event/log
+// streams (GET /api/v1/events/stream, /api/v1/logs/stream) are long-lived, and
+// a full metrics or session-table scrape is a large, legitimately slow
+// response. A WriteTimeout would sever those. The response side is bounded by
+// per-handler context deadlines instead, so leaving it unlimited does not
+// reopen a slow-read DoS on the request side.
+const (
+	// apiReadHeaderTimeout bounds the time to read the request headers — the
+	// slow-header slowloris defense, and the pre-auth guard since header read
+	// precedes authMiddleware.
+	apiReadHeaderTimeout = 10 * time.Second
+	// apiReadTimeout bounds the time to read the ENTIRE request (headers +
+	// body) — the slow-body slowloris defense. 30s is generous for any
+	// legitimate mutation body (bodies are small; capped by
+	// maxRequestBodyBytes) while cutting off a dribbled body.
+	apiReadTimeout = 30 * time.Second
+	// apiIdleTimeout caps how long an idle keep-alive connection is held open
+	// awaiting the next request.
+	apiIdleTimeout = 120 * time.Second
+	// apiMaxHeaderBytes bounds total request header size so an attacker cannot
+	// buffer unbounded header data before the timeouts fire.
+	apiMaxHeaderBytes = 1 << 20 // 1 MiB
+)
+
 // NewServer creates a new API server.
 func NewServer(cfg Config) *Server {
 	s := &Server{
@@ -418,8 +450,14 @@ func NewServer(cfg Config) *Server {
 	}
 
 	s.httpServer = &http.Server{
-		Addr:    cfg.Addr,
-		Handler: handler,
+		Addr:              cfg.Addr,
+		Handler:           handler,
+		ReadHeaderTimeout: apiReadHeaderTimeout,
+		ReadTimeout:       apiReadTimeout,
+		IdleTimeout:       apiIdleTimeout,
+		MaxHeaderBytes:    apiMaxHeaderBytes,
+		// WriteTimeout intentionally unset — see the const block above (SSE
+		// streams + large scrapes must not be severed).
 	}
 
 	// Set up HTTPS server with auto-generated self-signed certificate
@@ -429,8 +467,13 @@ func NewServer(cfg Config) *Server {
 			slog.Warn("failed to generate self-signed certificate", "err", err)
 		} else {
 			s.httpsServer = &http.Server{
-				Addr:    cfg.HTTPSAddr,
-				Handler: handler,
+				Addr:              cfg.HTTPSAddr,
+				Handler:           handler,
+				ReadHeaderTimeout: apiReadHeaderTimeout,
+				ReadTimeout:       apiReadTimeout,
+				IdleTimeout:       apiIdleTimeout,
+				MaxHeaderBytes:    apiMaxHeaderBytes,
+				// WriteTimeout intentionally unset — see the const block above.
 				TLSConfig: &tls.Config{
 					Certificates: []tls.Certificate{tlsCert},
 					MinVersion:   tls.VersionTLS12,

--- a/pkg/api/system.go
+++ b/pkg/api/system.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -93,8 +92,7 @@ func (s *Server) systemInfoHandler(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) pingHandler(w http.ResponseWriter, r *http.Request) {
 	var req PingRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if !decodeJSONBody(w, r, &req) {
 		return
 	}
 	if req.Target == "" {
@@ -130,8 +128,7 @@ func (s *Server) pingHandler(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) tracerouteHandler(w http.ResponseWriter, r *http.Request) {
 	var req TracerouteRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if !decodeJSONBody(w, r, &req) {
 		return
 	}
 	if req.Target == "" {
@@ -261,8 +258,7 @@ func (s *Server) systemBuffersHandler(w http.ResponseWriter, _ *http.Request) {
 
 func (s *Server) systemActionHandler(w http.ResponseWriter, r *http.Request) {
 	var req SystemActionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if !decodeJSONBody(w, r, &req) {
 		return
 	}
 


### PR DESCRIPTION
Closes #4150.

Two management-plane DoS hardening fixes in `pkg/api`, from fable-review-164 M-6 and M-7. Both harden the HTTP/HTTPS server on 127.0.0.1:8080, which becomes remotely reachable pre-auth once `system services web-management {http|https} interface <if>` binds a non-loopback address (a supported config; `api-auth` is opt-in).

## M-6 — slowloris timeouts

Both `http.Server` literals in `NewServer` (`pkg/api/server.go`) set only `Addr`/`Handler`(/`TLSConfig`), leaving every timeout field zero (no limit). Header reads happen BEFORE `authMiddleware`, so a pre-auth slowloris (dribbled headers/body) could pin a goroutine/socket per connection indefinitely and wedge the control plane.

Fix: set `ReadHeaderTimeout` 10s, `ReadTimeout` 30s, `IdleTimeout` 120s, `MaxHeaderBytes` 1 MiB on BOTH servers.

**WriteTimeout is deliberately left unset (0 = unlimited).** The SSE event/log streams (`/api/v1/events/stream`, `/api/v1/logs/stream`) are long-lived and a full metrics/session-table scrape is a large slow response — a `WriteTimeout` would sever those. The read-side timeouts are the slowloris-critical ones; the response side is bounded by per-handler context deadlines instead.

## M-7 — request-body size cap

Every mutating handler did `json.NewDecoder(r.Body).Decode(&req)` with no `http.MaxBytesReader`. A `POST /api/v1/config/load` with a ~1 GB body was buffered whole and then parsed a second time by the configstore → OOM-kill.

Fix: new shared `decodeJSONBody(w, r, dst)` helper wraps `r.Body` in `http.MaxBytesReader(maxRequestBodyBytes = 16 MiB)` and returns **HTTP 413** on overflow (400 for other decode errors). Applied to all 12 mutation decode sites (config set/delete/deactivate/activate/load/rollback/commit-confirmed/annotate, system ping/traceroute/action, dhcp identifiers/clear). Read-only GETs untouched. 16 MiB is far above any legit config body; it is the transport-layer guard, independent of any parser-layer config-size ceiling.

## Tests (each RED on revert)

`pkg/api/http_dos_hardening_4150_test.go`:
- `TestManagementServerTimeoutsSetM6` — asserts both servers' timeout fields + WriteTimeout==0. Reverting the field assignments → all 0 → RED (verified).
- `TestConfigMutationBodyCappedM7` — streams a >16 MiB valid-JSON body → 413. Reverting the MaxBytesReader wrap → 200 → RED (verified).
- `TestConfigMutationNormalBodySucceedsM7` / `...MalformedBodyStill400M7` — normal body still 200, bad JSON still 400.

## Validation

`go test ./pkg/api/...` green; `go build ./...` green; gofmt clean; `go vet ./pkg/api/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi