### PR TITLE
config: bound lexer/parser recursion + payload size (fable-review-164 H-2)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,42 @@
+## 2026-07-04 — #4148 (fable-review-164 H-2): bound config lexer/parser recursion + payload size
+
+- **Timestamp**: 2026-07-04
+  - **Action**: Fixed an unrecoverable stack-overflow DoS in the Junos
+    config parse path. The lexer stripped bracket-list delimiters with
+    `l.advance(); return l.Next()` (one goroutine-stack frame per `[`/`]`)
+    and the recursive-descent parser (`parseStatement` <->
+    `parseStatements`) had no nesting-depth guard, so a single sub-4 MiB
+    payload of consecutive `[` or a deeply nested `a{a{…}` brace payload
+    grew the stack past Go's 1 GiB `maxstacksize` and aborted xpfd with
+    `fatal error: stack overflow` (a runtime throw, not a recoverable
+    panic). Reachable unauthenticated from the localhost gRPC/REST
+    config-load API AND the HA peer config-sync ingress
+    (`configstore.Store.SyncApply`), so one hostile/corrupt peer config
+    could crash a cluster standby.
+  - **Fix**: (a) lexer strips brackets iteratively in the leading
+    whitespace/comment loop of `Next()` (O(1) stack); (b) `parseStatements`
+    caps nesting at `maxParseDepth` (256), recording one `ParseError` and
+    draining the over-deep block via the non-recursive `skipToBlockClose`;
+    (c) `configstore.MaxConfigSize` (16 MiB) rejects an over-large payload
+    before `NewParser` in LoadOverride/LoadMerge/LoadSet/SyncApply, backed
+    by `grpc.MaxRecvMsgSize` (16 MiB, both NewServer sites) and
+    `http.MaxBytesReader` (32 MiB, REST config-load body -> clean 413).
+  - **Validation**: RED-on-revert proven — reverting the iterative lexer
+    (6M-bracket flood) and neutering the depth cap (2M-deep braces) both
+    reproduce `fatal error: stack overflow`; a moderate 356-deep nest fails
+    without the cap. Size ceilings reject oversized input at all four store
+    paths + REST 413 + gRPC ResourceExhausted (bufconn). `[ a b c ]` still
+    collapses (#2419). `go test ./pkg/config/... ./pkg/configstore/...
+    ./pkg/api/... ./pkg/grpcapi/...` green; `go build ./...`, gofmt, vet
+    clean.
+  - **File(s)**: `pkg/config/lexer.go`, `pkg/config/parser.go`,
+    `pkg/config/parser_recursion_dos_hb164_test.go`,
+    `pkg/configstore/store.go`, `pkg/configstore/store_command.go`,
+    `pkg/configstore/config_size_ceiling_hb164_test.go`,
+    `pkg/grpcapi/server.go`, `pkg/grpcapi/server_recvsize_hb164_test.go`,
+    `pkg/api/config.go`, `pkg/api/config_load_bodycap_hb164_test.go`,
+    `pkg/config/README.md`, `pkg/configstore/README.md`.
+
 ## 2026-07-04 — #4088: pool SNAT — id==0 ICMP echo is a valid keyable query
 
 - **Timestamp**: 2026-07-04

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -12,6 +12,14 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 )
 
+// maxConfigBodyBytes caps the REST config-load POST body (fable-review-164
+// H-2). Without it the body is buffered unbounded and fed to the parser, which
+// a sub-4 MiB pathological payload can crash. It is 2x
+// configstore.MaxConfigSize (16 MiB) to leave headroom for JSON string
+// escaping of the config content; the post-decode configstore size ceiling is
+// the authoritative limit on the config itself.
+const maxConfigBodyBytes = 2 * (16 << 20) // 32 MiB
+
 func (s *Server) configHandler(w http.ResponseWriter, _ *http.Request) {
 	cfg := s.store.ActiveConfig()
 	if cfg == nil {
@@ -275,8 +283,18 @@ func (s *Server) configSearchHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) configLoadHandler(w http.ResponseWriter, r *http.Request) {
+	// Bound the request body so an oversized config-load payload is rejected
+	// before it reaches the parser (H-2). configstore.LoadOverride/LoadMerge/
+	// LoadSet re-check the decoded content against MaxConfigSize.
+	r.Body = http.MaxBytesReader(w, r.Body, maxConfigBodyBytes)
 	var req ConfigLoadRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeError(w, http.StatusRequestEntityTooLarge,
+				fmt.Sprintf("config body exceeds %d bytes", maxConfigBodyBytes))
+			return
+		}
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}

--- a/pkg/api/config_load_bodycap_hb164_test.go
+++ b/pkg/api/config_load_bodycap_hb164_test.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fable-review-164 H-2: the REST config-load handler must bound its request
+// body so an oversized payload is rejected before it reaches the parser. This
+// posts a body past maxConfigBodyBytes and asserts a clean 413, not an
+// unbounded read into the parser.
+func TestConfigLoadHandlerRejectsOversizedBody(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	s := &Server{store: store}
+
+	// A body comfortably over the cap; the content need not be valid config —
+	// the MaxBytesReader trips during decode, before the store sees it.
+	huge := strings.Repeat("a", maxConfigBodyBytes+(1<<20))
+	body := `{"mode":"override","content":"` + huge + `"}`
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/config/load", strings.NewReader(body))
+	s.configLoadHandler(rr, req)
+
+	if rr.Code != 413 {
+		t.Fatalf("status = %d, want 413 (request entity too large); body: %s",
+			rr.Code, rr.Body.String())
+	}
+}
+
+// TestConfigLoadHandlerAcceptsNormalBody confirms the body cap does not disturb
+// an ordinary config-load request.
+func TestConfigLoadHandlerAcceptsNormalBody(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	s := &Server{store: store}
+
+	body := `{"mode":"set","content":"set system host-name fw"}`
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/config/load", strings.NewReader(body))
+	s.configLoadHandler(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -10,8 +10,32 @@ nothing internal.
 
 ## Entry points
 
-- `Lexer` — `lexer.go`.
-- `Parser` — `parser.go`. **Hierarchical** input.
+- `Lexer` — `lexer.go`. Bracket-list delimiters (`[ a b c ]`) are stripped
+  **iteratively** in the leading whitespace/comment loop of `Next()`, not via
+  self-recursion — see the recursion-bound note below.
+- `Parser` — `parser.go`. **Hierarchical** input. Block nesting is capped at
+  `maxParseDepth` (256) — see the recursion-bound note below.
+
+**Recursion and size bounds are load-bearing security guards (H-2).** The
+lexer and recursive-descent parser are reachable, unauthenticated, from the
+localhost gRPC/REST config-load API AND the HA peer config-sync ingress
+(`configstore.Store.SyncApply`). A single sub-4 MiB payload of consecutive
+`[` (the lexer once recursed one goroutine-stack frame per bracket) or a
+deeply nested `a{a{…}` brace payload (the parser had no depth guard) grew the
+goroutine stack past Go's 1 GiB `maxstacksize` and aborted xpfd with
+`fatal error: stack overflow` — an unrecoverable runtime throw, not a
+recoverable panic. Three layers now bound this: (1) the lexer strips brackets
+iteratively (O(1) stack); (2) `parseStatements` caps nesting at
+`maxParseDepth` (256, far above any real Junos hierarchy), recording one
+`ParseError` and draining the over-deep block via the non-recursive
+`skipToBlockClose` past the cap; (3) `configstore.MaxConfigSize` (16 MiB)
+rejects an over-large payload before `NewParser`, backed by
+`grpc.MaxRecvMsgSize` and `http.MaxBytesReader` at the two transports. Do NOT
+reintroduce `return l.Next()` bracket recursion or remove the depth cap.
+Regression coverage: `pkg/config/parser_recursion_dos_hb164_test.go`,
+`pkg/configstore/config_size_ceiling_hb164_test.go`,
+`pkg/api/config_load_bodycap_hb164_test.go`,
+`pkg/grpcapi/server_recvsize_hb164_test.go`.
 - `ParseSetCommand(input string) ([]string, error)` — `parser.go`.
   Parses one flat-set line into the path components. The caller then
   applies that path with `tree.SetPath()` to build the AST.

--- a/pkg/config/lexer.go
+++ b/pkg/config/lexer.go
@@ -78,10 +78,25 @@ func NewLexer(input string) *Lexer {
 
 // Next returns the next token, advancing the position.
 func (l *Lexer) Next() Token {
-	l.skipWhitespaceAndComments()
-
-	if l.pos >= len(l.input) {
-		return Token{Type: TokenEOF, Line: l.line, Column: l.column}
+	// Skip leading whitespace, comments, and bracket-list delimiters. The
+	// bracket characters of a Junos list (`[ a b c ]`) are structural sugar:
+	// the lexer strips them and yields the enclosed words as ordinary tokens
+	// (#2419). Consuming them in this loop — rather than the old
+	// `l.advance(); return l.Next()` self-recursion — keeps bracket handling
+	// O(1) stack. Otherwise a payload of N consecutive '[' recurses one
+	// goroutine-stack frame per bracket and a sub-4 MiB config overflows Go's
+	// 1 GiB maxstacksize with an unrecoverable `fatal error: stack overflow`
+	// (fable-review-164 H-2).
+	for {
+		l.skipWhitespaceAndComments()
+		if l.pos >= len(l.input) {
+			return Token{Type: TokenEOF, Line: l.line, Column: l.column}
+		}
+		if c := l.input[l.pos]; c == '[' || c == ']' {
+			l.advance()
+			continue
+		}
+		break
 	}
 
 	ch := l.input[l.pos]
@@ -100,13 +115,6 @@ func (l *Lexer) Next() Token {
 	case '|':
 		l.advance()
 		return Token{Type: TokenPipe, Value: "|", Line: line, Column: col}
-	case '[':
-		// Bracket list: [ a b c ] — skip brackets, treat contents as regular tokens
-		l.advance()
-		return l.Next()
-	case ']':
-		l.advance()
-		return l.Next()
 	case '"':
 		return l.readString(line, col)
 	default:

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -13,10 +13,20 @@ func (e ParseError) Error() string {
 	return fmt.Sprintf("line %d, column %d: %s", e.Line, e.Column, e.Message)
 }
 
+// maxParseDepth caps recursive-descent block nesting. parseStatement recurses
+// into parseStatements for every `{ ... }` block, so a payload of deeply nested
+// braces (`a{a{a{…}`) would otherwise grow the goroutine stack past Go's 1 GiB
+// maxstacksize and abort xpfd with an unrecoverable `fatal error: stack
+// overflow` (fable-review-164 H-2). 256 levels is far above any real Junos
+// configuration; past it the parser records a ParseError and stops descending
+// rather than recursing.
+const maxParseDepth = 256
+
 // Parser implements a recursive descent parser for Junos configuration syntax.
 type Parser struct {
 	lexer  *Lexer
 	errors []ParseError
+	depth  int // current block-nesting depth (bounded by maxParseDepth)
 }
 
 // NewParser creates a new Parser for the given configuration text.
@@ -107,6 +117,28 @@ func ParseSetVerb(input string) (verb string, path []string, err error) {
 
 // parseStatements parses zero or more statements until EOF or '}'.
 func (p *Parser) parseStatements() []*Node {
+	// Bound block-nesting recursion (H-2). parseStatement recurses back into
+	// parseStatements for every `{` block; without this guard a deeply nested
+	// brace payload overflows the goroutine stack (an unrecoverable throw, not
+	// a panic). Past the cap we record a ParseError at the current position and
+	// stop descending. The caller's error-recovery path then drains the
+	// remaining tokens linearly (parseKeys yields nothing on `{`/`}`, so each
+	// parseStatement consumes one token), so parsing terminates cleanly with an
+	// error instead of crashing.
+	p.depth++
+	defer func() { p.depth-- }()
+	if p.depth > maxParseDepth {
+		tok := p.lexer.Peek()
+		p.addError(tok.Line, tok.Column,
+			fmt.Sprintf("configuration nesting exceeds maximum depth of %d", maxParseDepth))
+		// Drain the remainder of this over-deep block iteratively (no
+		// recursion) so a pathological payload records exactly one error and
+		// leaves the caller's matching '}' in place, rather than spamming one
+		// error per leftover token and holding O(N) ParseError structs.
+		p.skipToBlockClose()
+		return nil
+	}
+
 	var nodes []*Node
 	for {
 		tok := p.lexer.Peek()
@@ -124,6 +156,34 @@ func (p *Parser) parseStatements() []*Node {
 		}
 	}
 	return nodes
+}
+
+// skipToBlockClose consumes tokens until the '}' that closes the block whose
+// opening '{' the caller already consumed (or EOF), tracking brace balance
+// iteratively so it never recurses. The closing '}' at balance 0 is left in
+// place for the caller to consume. It is used only on the depth-cap path so a
+// maliciously deep payload is drained in O(remaining) with no additional
+// goroutine-stack growth (H-2).
+func (p *Parser) skipToBlockClose() {
+	balance := 0
+	for {
+		tok := p.lexer.Peek()
+		switch tok.Type {
+		case TokenEOF:
+			return
+		case TokenLBrace:
+			balance++
+			p.lexer.Next()
+		case TokenRBrace:
+			if balance == 0 {
+				return // closes the caller's block; leave it for the caller
+			}
+			balance--
+			p.lexer.Next()
+		default:
+			p.lexer.Next()
+		}
+	}
 }
 
 // inactiveMarker is the Junos `inactive:` statement prefix (#2008 H1).

--- a/pkg/config/parser_recursion_dos_hb164_test.go
+++ b/pkg/config/parser_recursion_dos_hb164_test.go
@@ -1,0 +1,150 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// fable-review-164 H-2: the lexer stripped bracket-list delimiters with
+// `l.advance(); return l.Next()` (one goroutine-stack frame per '[') and the
+// recursive-descent parser had no nesting-depth guard. A sub-4 MiB payload of
+// consecutive '[' — or a deeply nested `a{a{…}` brace payload — grew the stack
+// past Go's 1 GiB maxstacksize and aborted xpfd with an unrecoverable
+// `fatal error: stack overflow` (a runtime throw, not a recoverable panic).
+//
+// These tests exercise inputs an order of magnitude past the pre-fix crash
+// threshold. With the fixes (iterative bracket skip in the lexer + the
+// maxParseDepth cap in parseStatements) they complete without crashing and
+// return clean errors/tokens. On revert of either fix the test binary crashes
+// with a stack overflow (RED-on-revert).
+
+// TestLexerBracketFloodNoStackOverflow feeds millions of consecutive '['
+// characters through the lexer. Brackets are structural sugar (#2419) and are
+// stripped, so the only token is EOF. Pre-fix this recursed one frame per
+// bracket and overflowed the stack; the iterative skip makes it O(1) stack.
+func TestLexerBracketFloodNoStackOverflow(t *testing.T) {
+	const n = 6_000_000 // well past the reviewer's confirmed ~4M crash point
+	input := strings.Repeat("[", n)
+
+	l := NewLexer(input)
+	tok := l.Next()
+	if tok.Type != TokenEOF {
+		t.Fatalf("bracket flood: first token = %v, want EOF (brackets are stripped)", tok.Type)
+	}
+
+	// The same input must survive the full parser path too (empty tree, no
+	// crash). A bracketed run with no real tokens yields an empty config.
+	tree, errs := NewParser(input).Parse()
+	if tree == nil {
+		t.Fatal("bracket flood: Parse returned nil tree")
+	}
+	if len(tree.Children) != 0 {
+		t.Fatalf("bracket flood: expected empty tree, got %d children", len(tree.Children))
+	}
+	_ = errs // brackets-only input produces no statements; errors, if any, are fine
+}
+
+// TestLexerBracketListStillCollapses guards the #2419 behavior the iterative
+// rewrite must preserve: `[ a b c ]` still yields the enclosed words as
+// ordinary tokens with the brackets removed.
+func TestLexerBracketListStillCollapses(t *testing.T) {
+	l := NewLexer("from protocol [ tcp udp icmp ] ;")
+	var got []string
+	for {
+		tok := l.Next()
+		if tok.Type == TokenEOF {
+			break
+		}
+		if tok.Type == TokenIdentifier {
+			got = append(got, tok.Value)
+		}
+	}
+	want := []string{"from", "protocol", "tcp", "udp", "icmp"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("bracket list tokens = %v, want %v (brackets must be stripped, #2419)", got, want)
+	}
+
+	// Full flat-set path still collapses the list onto one leaf (#2419 pin
+	// preserved by the iterative lexer).
+	tree := flatSetTree(t, []string{
+		"set firewall family inet filter F term T from protocol [ tcp udp icmp ]",
+	})
+	keys := fromCriterionKeys(t, tree, "protocol")
+	if strings.Join(keys, ",") != "protocol,tcp,udp,icmp" {
+		t.Fatalf("flat-set bracket list Keys=%v, want [protocol tcp udp icmp]", keys)
+	}
+}
+
+// TestParserModerateNestReturnsDepthError proves the depth cap FIRES: a nesting
+// well above maxParseDepth (but far below any stack-overflow threshold) returns
+// a ParseError, not a silently-accepted tree. On revert of the depth cap this
+// nesting parses cleanly with zero errors, so the assertion fails (RED).
+func TestParserModerateNestReturnsDepthError(t *testing.T) {
+	const n = maxParseDepth + 100 // 356 — above the cap, nowhere near a crash
+	src := strings.Repeat("a{", n) + strings.Repeat("}", n)
+
+	_, errs := NewParser(src).Parse()
+	if len(errs) == 0 {
+		t.Fatal("deep nesting parsed with no error — depth cap did not fire")
+	}
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "nesting exceeds maximum depth") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a nesting-depth ParseError, got %v", errs)
+	}
+}
+
+// TestParserDeepNestNoStackOverflow drives a nesting depth an order of
+// magnitude past the pre-fix crash threshold. The maxParseDepth cap plus the
+// iterative skipToBlockClose drain make it terminate with a bounded number of
+// errors and no crash. On revert of the cap the mutual recursion overflows the
+// stack and the test binary dies (RED-on-revert).
+func TestParserDeepNestNoStackOverflow(t *testing.T) {
+	const n = 2_000_000
+	src := strings.Repeat("a{", n) + strings.Repeat("}", n)
+
+	tree, errs := NewParser(src).Parse()
+	if tree == nil {
+		t.Fatal("deep nest: Parse returned nil tree")
+	}
+	if len(errs) == 0 {
+		t.Fatal("deep nest: expected a depth-limit error")
+	}
+	// The drain keeps the error count bounded (~one), not O(n).
+	if len(errs) > maxParseDepth+2 {
+		t.Fatalf("deep nest: error count %d not bounded by the depth cap", len(errs))
+	}
+}
+
+// TestParserNormalConfigUnaffected confirms the depth cap does not perturb an
+// ordinary configuration's parse (a realistic hierarchy is only a handful of
+// levels deep).
+func TestParserNormalConfigUnaffected(t *testing.T) {
+	src := `security {
+    zones {
+        security-zone trust {
+            interfaces {
+                ge-0-0-0 {
+                    host-inbound-traffic {
+                        system-services {
+                            ping;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}`
+	tree, errs := NewParser(src).Parse()
+	if len(errs) != 0 {
+		t.Fatalf("normal config parse errors: %v", errs)
+	}
+	if tree.FindChild("security") == nil {
+		t.Fatal("normal config: security stanza missing")
+	}
+}

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -57,6 +57,16 @@ the 0600 perms fix only.
   `EnterConfigureExclusive`, `ExitConfigure`, `SyncApply`. (See
   `store.go` for the full surface — there's no shorthand
   `Candidate()` or `History()`; use the `Show*` / `List*` forms.)
+- `MaxConfigSize` (16 MiB) + `checkConfigSize` — `store.go`. The
+  transport-independent input-size ceiling checked at the head of every
+  parse entry point: `LoadOverride`, `LoadMerge`, `LoadSet`, and the HA
+  `SyncApply` ingress. It rejects an over-large or corrupt payload with a
+  clean `config too large` error before `config.NewParser`, so a
+  pathological input cannot exhaust memory or (with the pkg/config
+  lexer/depth guards) crash xpfd with a stack overflow (H-2). It backstops
+  the `grpc.MaxRecvMsgSize` / `http.MaxBytesReader` transport caps for the
+  HA peer-sync path and any non-transport caller. Real configs are well
+  under 1 MiB, so the ceiling never rejects a legitimate config.
 - `DB` — `db.go`. Low-level durable file I/O (via `pkg/fsatomic`).
   `NewDB` sweeps crash-leaked `.*.tmp-*` temps from `.configdb`.
 - `History` — `history.go`. Bounded ring of recent commits.

--- a/pkg/configstore/config_size_ceiling_hb164_test.go
+++ b/pkg/configstore/config_size_ceiling_hb164_test.go
@@ -1,0 +1,86 @@
+package configstore
+
+import (
+	"strings"
+	"testing"
+)
+
+// fable-review-164 H-2: every parse entry point must reject an over-large
+// payload with a clean error before it reaches config.NewParser, so a
+// pathological input cannot exhaust memory or the goroutine stack. These tests
+// pin the MaxConfigSize ceiling on LoadOverride, LoadMerge, LoadSet, and the HA
+// SyncApply ingress, and confirm a normal-size config still loads.
+
+func oversizedPayload() string {
+	// Just over the ceiling; the content need not be valid config — the size
+	// gate runs before the parser.
+	return strings.Repeat("[", MaxConfigSize+1)
+}
+
+func TestLoadOverrideRejectsOversized(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	err := s.LoadOverride(oversizedPayload())
+	if err == nil {
+		t.Fatal("LoadOverride accepted an oversized payload")
+	}
+	if !strings.Contains(err.Error(), "config too large") {
+		t.Fatalf("LoadOverride error = %q, want a size-ceiling rejection", err)
+	}
+}
+
+func TestLoadMergeRejectsOversized(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	err := s.LoadMerge(oversizedPayload())
+	if err == nil {
+		t.Fatal("LoadMerge accepted an oversized payload")
+	}
+	if !strings.Contains(err.Error(), "config too large") {
+		t.Fatalf("LoadMerge error = %q, want a size-ceiling rejection", err)
+	}
+}
+
+func TestLoadSetRejectsOversized(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	_, err := s.LoadSet(oversizedPayload())
+	if err == nil {
+		t.Fatal("LoadSet accepted an oversized payload")
+	}
+	if !strings.Contains(err.Error(), "config too large") {
+		t.Fatalf("LoadSet error = %q, want a size-ceiling rejection", err)
+	}
+}
+
+func TestSyncApplyRejectsOversized(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.SyncApply(oversizedPayload(), nil)
+	if err == nil {
+		t.Fatal("SyncApply accepted an oversized peer config")
+	}
+	if !strings.Contains(err.Error(), "config too large") {
+		t.Fatalf("SyncApply error = %q, want a size-ceiling rejection", err)
+	}
+}
+
+// TestLoadOverrideAcceptsNormalConfig confirms the ceiling never rejects a
+// legitimate (well-under-1-MiB) configuration.
+func TestLoadOverrideAcceptsNormalConfig(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	src := `system {
+    host-name fw;
+}`
+	if err := s.LoadOverride(src); err != nil {
+		t.Fatalf("LoadOverride rejected a normal config: %v", err)
+	}
+}

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -35,6 +35,27 @@ import (
 // full trees live in the rollback slots; see journal.Entry).
 type JournalEntry = journal.Entry
 
+// MaxConfigSize bounds a single configuration payload accepted by any parse
+// entry point: LoadOverride, LoadMerge, LoadSet, and the HA SyncApply ingress.
+// Real configurations are well under 1 MiB; this generous 16 MiB ceiling
+// rejects a hostile or corrupt payload with a clean error before the parser
+// runs, so a pathological input cannot exhaust memory or (together with the
+// pkg/config lexer/depth guards) the goroutine stack. It is the
+// transport-independent backstop for the grpc.MaxRecvMsgSize / http
+// .MaxBytesReader caps, covering any caller — a future one, or an HA peer —
+// that reaches these methods without passing through the gRPC/REST limits
+// (fable-review-164 H-2).
+const MaxConfigSize = 16 << 20 // 16 MiB
+
+// checkConfigSize rejects an over-large payload before it reaches the parser.
+func checkConfigSize(content string) error {
+	if len(content) > MaxConfigSize {
+		return fmt.Errorf("config too large: %d bytes exceeds maximum %d bytes",
+			len(content), MaxConfigSize)
+	}
+	return nil
+}
+
 // Store manages the candidate and active configuration.
 type Store struct {
 	mu        sync.RWMutex
@@ -354,6 +375,13 @@ func schemaValidateExpandedTreeForNode(tree *config.ConfigTree, nodeID int) erro
 // lets the caller patch the parsed tree before compiling (e.g. to preserve
 // local chassis cluster settings).
 func (s *Store) SyncApply(content string, chassisPreserve func(*config.ConfigTree)) (*config.Config, error) {
+	// H-2: the HA peer config-sync ingress is a network-reachable parse entry
+	// point (a hostile/corrupt peer config over the fabric). Reject an
+	// over-large payload before parsing so one bad peer cannot crash the
+	// standby.
+	if err := checkConfigSize(content); err != nil {
+		return nil, err
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/pkg/configstore/store_command.go
+++ b/pkg/configstore/store_command.go
@@ -219,6 +219,9 @@ func (s *Store) Annotate(path []string, comment string) error {
 // LoadOverride replaces the entire candidate config with the parsed input.
 // The input can be hierarchical Junos config or flat "set" commands.
 func (s *Store) LoadOverride(content string) error {
+	if err := checkConfigSize(content); err != nil {
+		return err
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -243,6 +246,9 @@ func (s *Store) LoadOverride(content string) error {
 // For flat "set" commands, each line is applied individually.
 // For hierarchical input, it's converted to set commands and merged.
 func (s *Store) LoadMerge(content string) error {
+	if err := checkConfigSize(content); err != nil {
+		return err
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -381,6 +387,9 @@ func applyEditLine(tree *config.ConfigTree, line string) error {
 // round-trippable: previously a `deactivate <path>` line was skipped here,
 // so an inactive node reloaded ACTIVE.
 func (s *Store) LoadSet(content string) (int, error) {
+	if err := checkConfigSize(content); err != nil {
+		return 0, err
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if err := s.ensureWritableLocked(); err != nil {

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -41,6 +41,14 @@ import (
 	"github.com/psaab/xpf/pkg/vrrp"
 )
 
+// maxRecvMsgSize caps an inbound gRPC message (fable-review-164 H-2). grpc-go
+// defaults to 4 MiB, which is already enough to crash the pre-fix config
+// parser; this explicit 16 MiB cap matches configstore.MaxConfigSize (the
+// transport-independent parse ceiling) so an oversized Load/config-sync body
+// is rejected at the transport with ResourceExhausted rather than buffered and
+// fed to the parser.
+const maxRecvMsgSize = 16 << 20 // 16 MiB
+
 // Config configures the gRPC server.
 type Config struct {
 	Store         *configstore.Store
@@ -210,6 +218,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	srv := grpc.NewServer(
+		grpc.MaxRecvMsgSize(maxRecvMsgSize),
 		grpc.UnaryInterceptor(s.configLockInterceptor),
 	)
 	pb.RegisterBpfrxServiceServer(srv, s)
@@ -265,6 +274,7 @@ func (s *Server) RunFabricListener(ctx context.Context, addr, vrfDevice string) 
 	// reach a handler. The loopback listener is left UNCHANGED (127.0.0.1 is
 	// the trusted local surface, full service).
 	srv := grpc.NewServer(
+		grpc.MaxRecvMsgSize(maxRecvMsgSize),
 		grpc.ChainUnaryInterceptor(s.fabricAllowlistUnaryInterceptor, s.configLockInterceptor),
 		grpc.ChainStreamInterceptor(s.fabricAllowlistStreamInterceptor),
 	)

--- a/pkg/grpcapi/server_recvsize_hb164_test.go
+++ b/pkg/grpcapi/server_recvsize_hb164_test.go
@@ -1,0 +1,70 @@
+package grpcapi
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// fable-review-164 H-2: the gRPC server must cap inbound message size so an
+// oversized Load / config-sync payload is rejected at the transport with
+// ResourceExhausted, never buffered and fed to the parser. This stands up the
+// real service over bufconn with the production grpc.MaxRecvMsgSize option and
+// confirms an over-cap Load is rejected while a normal Load succeeds.
+func TestGRPCLoadRejectsOversizedMessage(t *testing.T) {
+	store, err := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err != nil {
+		t.Fatalf("configstore.New: %v", err)
+	}
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+
+	lis := bufconn.Listen(1 << 20)
+	srv := grpc.NewServer(grpc.MaxRecvMsgSize(maxRecvMsgSize))
+	pb.RegisterBpfrxServiceServer(srv, &Server{store: store})
+	go srv.Serve(lis)
+	defer srv.Stop()
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	defer conn.Close()
+	client := pb.NewBpfrxServiceClient(conn)
+
+	// Over the server's receive cap -> ResourceExhausted before the handler.
+	oversized := strings.Repeat("a", maxRecvMsgSize+(1<<20))
+	_, err = client.Load(context.Background(), &pb.LoadRequest{Mode: "override", Content: oversized})
+	if err == nil {
+		t.Fatal("gRPC Load accepted an oversized message")
+	}
+	if got := status.Code(err); got != codes.ResourceExhausted {
+		t.Fatalf("gRPC Load oversized status = %v, want ResourceExhausted (%v)", got, err)
+	}
+
+	// A normal message still round-trips through the same capped server.
+	_, err = client.Load(context.Background(), &pb.LoadRequest{
+		Mode:    "set",
+		Content: "set system host-name fw",
+	})
+	if err != nil {
+		t.Fatalf("gRPC Load rejected a normal message: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #4148

## Problem (fable-review-164 H-2)

The Junos config lexer and recursive-descent parser had no recursion or
size bounds. The lexer stripped bracket-list delimiters with
`l.advance(); return l.Next()` (one goroutine-stack frame per `[`/`]`),
and `parseStatement` <-> `parseStatements` recursed per `{` block with no
depth guard. A single **sub-4 MiB** payload of consecutive `[` (~3.81 MiB,
under grpc-go's 4 MiB default) or a deeply nested `a{a{...}` brace payload
grows the goroutine stack past Go's 1 GiB `maxstacksize` and aborts xpfd
with `fatal error: stack overflow` — an unrecoverable `runtime.throw`, not
a `panic` (no `recover()` in pkg/config/pkg/configstore).

Reachable unauthenticated from the localhost gRPC/REST config-load API and,
critically, from the **HA peer config-sync ingress** (`Store.SyncApply`),
so one hostile/corrupt peer config over the fabric can take down a cluster
standby.

## Fix

- **Lexer (`pkg/config/lexer.go`)** — bracket delimiters are stripped
  iteratively in the leading whitespace/comment loop of `Next()` (O(1)
  stack). #2419 semantics unchanged: `[ a b c ]` still collapses to the
  enclosed words with brackets removed.
- **Parser (`pkg/config/parser.go`)** — `parseStatements` caps nesting at
  `maxParseDepth` (256, far above any real Junos hierarchy). Past the cap
  it records one `ParseError` and drains the over-deep block via the
  non-recursive `skipToBlockClose` (brace-balance walk) — bounded errors,
  bounded memory, no crash.
- **Size ceiling (`pkg/configstore`)** — `MaxConfigSize` (16 MiB) checked
  at the head of `LoadOverride`, `LoadMerge`, `LoadSet`, and `SyncApply`;
  the transport-independent backstop for the HA path and any future caller.
- **Transport caps** — `grpc.MaxRecvMsgSize` (16 MiB) on both
  `grpc.NewServer` sites (loopback + fabric) and `http.MaxBytesReader`
  (32 MiB, REST config-load body -> clean 413).

## Tests (RED-on-revert)

- `pkg/config/parser_recursion_dos_hb164_test.go` — a 6M-`[` flood
  tokenizes to EOF and a 2M-deep brace payload returns a bounded depth
  error, both without crashing; a 356-deep nest asserts the depth
  `ParseError` fires; `[ a b c ]` still collapses; a normal config parses
  unchanged. **Reverting the iterative lexer or neutering the depth cap
  reproduces `fatal error: stack overflow` (verified).**
- `pkg/configstore/config_size_ceiling_hb164_test.go` — all four store
  paths reject an over-ceiling payload and accept a normal config.
- `pkg/api/config_load_bodycap_hb164_test.go` — REST load returns 413 for
  an over-cap body, 200 for a normal one.
- `pkg/grpcapi/server_recvsize_hb164_test.go` — a bufconn server built with
  the production `MaxRecvMsgSize` rejects an oversized `Load` with
  `ResourceExhausted` and accepts a normal one.

`go test ./pkg/config/... ./pkg/configstore/... ./pkg/api/... ./pkg/grpcapi/...`
green; `go build ./...`, gofmt, vet clean. Docs updated in
`pkg/config/README.md` + `pkg/configstore/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi