### PR TITLE
cluster: advance config-sync high-water only after a successful apply (M-2/#4151)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -33312,3 +33312,33 @@ top.
     already covered by the doc's "empty/malformed/non-/96 prefix" wording).
   - **File(s)**: userspace-dp/src/nat64.rs, userspace-dp/src/nat64_tests.rs,
     _Log.md
+
+- **Timestamp**: 2026-07-04
+  - **Action**: fable-review-164 M-2 / #4151 — HA config-sync receiver advanced
+    the generation high-water mark BEFORE applying the config, silently
+    stranding a diverged standby on apply failure. `admitConfigGen` stored the
+    incoming gen then `configApplyLoop` invoked `OnConfigReceived` with no error
+    path; `handleConfigSync` returns without applying on a transient
+    RG0-primary belief or a `syncAndApply` compile/promote failure. The mark
+    then read gen N while the active config was still N-1, and the primary's
+    re-push of gen N was dropped as "not strictly newer" → stranded. Fix =
+    apply-then-advance: split `admitConfigGen` into `shouldApplyConfigGen`
+    (pure admission gate, no advance) + `recordAppliedConfigGen` (advance);
+    `OnConfigReceived`/`handleConfigSync` now return an `error`, and the loop
+    advances the mark ONLY on a nil return. On failure it counts a new
+    `ConfigsApplyFailed` counter and leaves the high-water at the last-applied
+    gen so the peer's re-push is re-admitted and the standby re-converges. The
+    `activeText == incomingText` short-circuit returns nil (already converged →
+    advance). Preserves the #1960 lenient-load posture — whatever
+    `syncAndApply` reports gates the mark, so the high-water always reflects the
+    config actually in effect. Added `ConfigsApplyFailed` to SyncStats +
+    snapshot + `show ... status` display. RED-on-revert:
+    `TestConfigSyncApplyFailureRetainsHighWater` fails ("apply failure must NOT
+    advance the high-water mark, got 7 want 0") when the advance-before-apply
+    order is restored. `go test ./pkg/cluster/... ./pkg/daemon/...` green;
+    `go build ./...`, gofmt, vet clean. Docs: docs/sync-protocol.md
+    apply-then-advance section + message/stats tables.
+  - **File(s)**: pkg/cluster/sync.go, pkg/cluster/sync_conn.go,
+    pkg/cluster/status.go, pkg/cluster/sync_config_gen_test.go,
+    pkg/daemon/daemon_ha_sync.go, pkg/dataplane/userspace/manager.go,
+    docs/sync-protocol.md, _Log.md

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -325,11 +325,29 @@ older C1 with no alarm. The receiver now:
    queue (`configApplyLoop`) — the `receiveLoop` is single-threaded per
    connection, so this preserves receive order. The non-blocking enqueue never
    stalls session sync / heartbeats behind a slow config apply.
-3. Applies a config only when `admitConfigGen` accepts its generation
+3. Applies a config only when `shouldApplyConfigGen` accepts its generation
    (strictly newer than the last-applied high-water mark, or `gen=0`). An
    out-of-order older config is **dropped with an alarm** and counted in
    `ConfigsStaleIgnored`. The standby therefore always converges to the newest
    config the primary sent.
+
+**Apply-then-advance (M-2/#4151).** The high-water mark (`lastAppliedConfigGen`)
+advances ONLY AFTER the apply succeeds — `OnConfigReceived` now returns an
+`error`, and `configApplyLoop` calls `recordAppliedConfigGen` to advance the
+mark only on a `nil` return. If the apply does NOT take effect — a
+compile/promote failure (a mixed-build ISSU syntax error), a store rejection, or
+a transient RG0-primary rejection (`handleConfigSync` refuses the config while
+this node believes it is the RG0 config authority) — the loop counts
+`ConfigsApplyFailed` and leaves the high-water at the last-applied generation.
+The primary's re-push of the SAME generation is then re-admitted (not dropped as
+stale) and the standby re-converges. The pre-#4151 order advanced the mark on
+admission, BEFORE the apply, so an apply failure left the mark ahead of the
+actually-applied config: the re-push was silently dropped and the standby stayed
+stranded on the prior config (the failure class #4034 fixed on the *sender*,
+reintroduced on the *receiver* by the #3931 ordering guard). This preserves the
+#1960 lenient-load posture: whatever `syncAndApply` reports as its outcome
+(nil = store promoted + applied; error = not applied) is exactly what gates the
+mark, so the high-water always reflects the config actually in effect.
 
 The last-applied high-water mark is reset to 0 on a peer bulk re-prime
 (`resetRecvGen`, fired on `BulkStart`) so a **rebooted primary** — whose
@@ -349,7 +367,9 @@ and the config-sync apply fails — the old node retains its current config
 (fail-safe, no crash, no divergence worse than today).
 
 The secondary's `OnConfigReceived` callback invokes `load override` + commit to
-apply the accepted config.
+apply the accepted config, and returns an `error` so the ordered apply loop
+advances the high-water mark only on a successful apply (see Apply-then-advance
+above).
 
 ## IPsec SA Payload (Variable)
 
@@ -458,7 +478,7 @@ This is **additive** to the periodic sweep — it provides sub-millisecond sync 
 | DeleteV4/V6 | Lookup → delete reverse → delete dnat_table (SNAT) → delete forward |
 | BulkStart/End | Log markers; BulkEnd triggers `OnBulkSyncReceived` (releases VRRP sync hold) |
 | Heartbeat | No-op (resets read deadline) |
-| Config | Decode `(text, gen)` → enqueue on the single-consumer ordered apply queue (`configApplyLoop`); `admitConfigGen` drops out-of-order older gens, then `OnConfigReceived` applies (#3931) |
+| Config | Decode `(text, gen)` → enqueue on the single-consumer ordered apply queue (`configApplyLoop`); `shouldApplyConfigGen` drops out-of-order older gens, then `OnConfigReceived` applies and the high-water advances (`recordAppliedConfigGen`) ONLY on a successful apply — a failure counts `ConfigsApplyFailed` and re-admits the peer's re-push (#3931, M-2/#4151) |
 | IPsecSA | Store names, call `OnIPsecSAReceived` |
 
 ### Session Reconstruction on Receiver
@@ -513,6 +533,7 @@ All counters are `atomic.Uint64` / `atomic.Bool`, lock-free:
 | BulkSyncs | Completed bulk sync operations |
 | ConfigsSent/Received | Config sync messages |
 | ConfigsStaleIgnored | Config messages dropped by the #3931 ordering guard (incoming generation not strictly newer than last-applied) |
+| ConfigsApplyFailed | Config messages admitted by the ordering guard but whose apply did NOT take effect (compile/promote failure or a transient RG0-primary rejection). The high-water is left unadvanced so the peer's re-push re-converges the standby (M-2/#4151) |
 | IPsecSASent/Received | IPsec SA list messages |
 | Errors | Send failures, channel overflows, bad magic |
 | Connected | Peer TCP connection active |

--- a/pkg/cluster/status.go
+++ b/pkg/cluster/status.go
@@ -331,6 +331,9 @@ func (m *Manager) FormatInformation() string {
 		if syncStats.ConfigsStaleIgnored > 0 {
 			fmt.Fprintf(&b, "  Configs stale-dropped: %d\n", syncStats.ConfigsStaleIgnored)
 		}
+		if syncStats.ConfigsApplyFailed > 0 {
+			fmt.Fprintf(&b, "  Configs apply-failed:  %d\n", syncStats.ConfigsApplyFailed)
+		}
 	} else {
 		fmt.Fprintln(&b, "  Not configured")
 	}

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -107,8 +107,18 @@ type SyncStats struct {
 	// guard prevented a rapid-commit reorder (C1 applied after C2) from
 	// leaving the standby on the older config.
 	ConfigsStaleIgnored atomic.Uint64
-	IPsecSASent         atomic.Uint64
-	IPsecSAReceived     atomic.Uint64
+	// ConfigsApplyFailed counts config-sync messages that were admitted by the
+	// #3931 ordering guard but whose apply did NOT take effect on this node —
+	// a compile/promote failure (a mixed-build ISSU syntax error, a store
+	// rejection) or a transient RG0-primary rejection. On such a failure the
+	// config high-water mark (lastAppliedConfigGen) is deliberately NOT
+	// advanced, so the primary's re-push of the SAME generation is re-admitted
+	// and the standby re-converges instead of being silently stranded on the
+	// prior config (M-2/#4151). A persistently-nonzero value means a standby is
+	// repeatedly failing to apply the peer's config — investigate divergence.
+	ConfigsApplyFailed atomic.Uint64
+	IPsecSASent        atomic.Uint64
+	IPsecSAReceived    atomic.Uint64
 	// #2239 HA DHCP-server lease sync counters. Sent/Received count
 	// full-set lease push MESSAGES (one per family per push); Seeded counts
 	// leases written into a freshly-started Kea on takeover; errors fold
@@ -162,6 +172,7 @@ type SyncStatsSnapshot struct {
 	ConfigsSent          uint64
 	ConfigsReceived      uint64
 	ConfigsStaleIgnored  uint64
+	ConfigsApplyFailed   uint64
 	IPsecSASent          uint64
 	IPsecSAReceived      uint64
 	DHCPLeasesSent       uint64
@@ -242,8 +253,15 @@ type SessionSync struct {
 	// during ordered handoff operations.
 	incrementalPauseDepth atomic.Int32
 
-	// OnConfigReceived is called when a config sync message arrives from the peer.
-	OnConfigReceived func(configText string)
+	// OnConfigReceived is called when a config sync message arrives from the
+	// peer. It returns nil ONLY when the config was actually applied (or is
+	// already the active config); a non-nil error means the apply did not take
+	// effect (a compile/promote failure, or a transient RG0-primary rejection).
+	// The single-consumer configApplyLoop advances the config high-water mark
+	// (lastAppliedConfigGen) ONLY on a nil return, so an apply failure leaves
+	// the standby eligible for the primary's re-push instead of silently
+	// stranded on the prior config (M-2/#4151).
+	OnConfigReceived func(configText string) error
 	// OnIPsecSAReceived is called when an IPsec SA list arrives from the peer.
 	OnIPsecSAReceived func(connectionNames []string)
 	// OnDHCPLeasesReceived is called when a DHCP-server lease set arrives from
@@ -369,13 +387,19 @@ type SessionSync struct {
 	// Receiver side: the config-sync handler no longer spawns a racing
 	// goroutine per message (the pre-#3931 `go OnConfigReceived` hazard). It
 	// enqueues (gen, text) onto configApplyCh, and a single ordered consumer
-	// (configApplyLoop) drains it in receive order, applying a config only
+	// (configApplyLoop) drains it in receive order, attempting a config only
 	// when its generation is strictly newer than lastAppliedConfigGen
-	// (admitConfigGen). An out-of-order older config is dropped with an alarm
-	// (ConfigsStaleIgnored). lastAppliedConfigGen is reset to 0 on a peer
-	// bulk re-prime (resetRecvGen) so a rebooted primary — whose monotonic
-	// counter restarts lower — is accepted instead of refused as stale (the
-	// #2198 F2 inverse-of-stale-RETAIN reasoning, applied to config).
+	// (shouldApplyConfigGen). An out-of-order older config is dropped with an
+	// alarm (ConfigsStaleIgnored). lastAppliedConfigGen advances ONLY AFTER a
+	// successful apply (recordAppliedConfigGen, gated on OnConfigReceived
+	// returning nil) — an apply failure counts ConfigsApplyFailed and leaves
+	// the high-water at the last-applied generation so the primary's re-push of
+	// the same generation is re-admitted and the standby re-converges instead
+	// of being silently stranded on the prior config (M-2/#4151). The mark is
+	// reset to 0 on a peer bulk re-prime (resetRecvGen) so a rebooted primary —
+	// whose monotonic counter restarts lower — is accepted instead of refused
+	// as stale (the #2198 F2 inverse-of-stale-RETAIN reasoning, applied to
+	// config).
 	configGenCounter     atomic.Uint64
 	lastAppliedConfigGen atomic.Uint64
 	configApplyCh        chan configApplyItem
@@ -640,7 +664,7 @@ func (s *SessionSync) Stats() SyncStatsSnapshot {
 		activeFabric = -1
 	}
 	s.mu.Unlock()
-	return SyncStatsSnapshot{SessionsSent: s.stats.SessionsSent.Load(), SessionsReceived: s.stats.SessionsReceived.Load(), SessionsInstalled: s.stats.SessionsInstalled.Load(), DeletesSent: s.stats.DeletesSent.Load(), DeletesReceived: s.stats.DeletesReceived.Load(), BulkSyncs: s.stats.BulkSyncs.Load(), ConfigsSent: s.stats.ConfigsSent.Load(), ConfigsReceived: s.stats.ConfigsReceived.Load(), ConfigsStaleIgnored: s.stats.ConfigsStaleIgnored.Load(), IPsecSASent: s.stats.IPsecSASent.Load(), IPsecSAReceived: s.stats.IPsecSAReceived.Load(), DHCPLeasesSent: s.stats.DHCPLeasesSent.Load(), DHCPLeasesReceived: s.stats.DHCPLeasesReceived.Load(), DHCPLeasesSeeded: s.stats.DHCPLeasesSeeded.Load(), FencesSent: s.stats.FencesSent.Load(), FencesReceived: s.stats.FencesReceived.Load(), Errors: s.stats.Errors.Load(), DeletesDropped: s.stats.DeletesDropped.Load(), DeletesStaleIgnored: s.stats.DeletesStaleIgnored.Load(), InstallsStaleIgnored: s.stats.InstallsStaleIgnored.Load(), GenMapOverflow: s.stats.GenMapOverflow.Load(), Connected: s.stats.Connected.Load(), ActiveFabric: activeFabric, BulkSyncStartTime: s.stats.BulkSyncStartTime.Load(), BulkSyncEndTime: s.stats.BulkSyncEndTime.Load(), BulkSyncSessions: s.stats.BulkSyncSessions.Load(), LastConfigSyncTime: s.stats.LastConfigSyncTime.Load(), LastConfigSyncSize: s.stats.LastConfigSyncSize.Load(), LastFenceSeq: s.stats.LastFenceSeq.Load(), LastFenceAckAt: s.stats.LastFenceAckAt.Load()}
+	return SyncStatsSnapshot{SessionsSent: s.stats.SessionsSent.Load(), SessionsReceived: s.stats.SessionsReceived.Load(), SessionsInstalled: s.stats.SessionsInstalled.Load(), DeletesSent: s.stats.DeletesSent.Load(), DeletesReceived: s.stats.DeletesReceived.Load(), BulkSyncs: s.stats.BulkSyncs.Load(), ConfigsSent: s.stats.ConfigsSent.Load(), ConfigsReceived: s.stats.ConfigsReceived.Load(), ConfigsStaleIgnored: s.stats.ConfigsStaleIgnored.Load(), ConfigsApplyFailed: s.stats.ConfigsApplyFailed.Load(), IPsecSASent: s.stats.IPsecSASent.Load(), IPsecSAReceived: s.stats.IPsecSAReceived.Load(), DHCPLeasesSent: s.stats.DHCPLeasesSent.Load(), DHCPLeasesReceived: s.stats.DHCPLeasesReceived.Load(), DHCPLeasesSeeded: s.stats.DHCPLeasesSeeded.Load(), FencesSent: s.stats.FencesSent.Load(), FencesReceived: s.stats.FencesReceived.Load(), Errors: s.stats.Errors.Load(), DeletesDropped: s.stats.DeletesDropped.Load(), DeletesStaleIgnored: s.stats.DeletesStaleIgnored.Load(), InstallsStaleIgnored: s.stats.InstallsStaleIgnored.Load(), GenMapOverflow: s.stats.GenMapOverflow.Load(), Connected: s.stats.Connected.Load(), ActiveFabric: activeFabric, BulkSyncStartTime: s.stats.BulkSyncStartTime.Load(), BulkSyncEndTime: s.stats.BulkSyncEndTime.Load(), BulkSyncSessions: s.stats.BulkSyncSessions.Load(), LastConfigSyncTime: s.stats.LastConfigSyncTime.Load(), LastConfigSyncSize: s.stats.LastConfigSyncSize.Load(), LastFenceSeq: s.stats.LastFenceSeq.Load(), LastFenceAckAt: s.stats.LastFenceAckAt.Load()}
 }
 
 // IsConnected reports whether a peer sync connection is currently established.

--- a/pkg/cluster/sync_config_gen_test.go
+++ b/pkg/cluster/sync_config_gen_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -10,8 +11,9 @@ import (
 // #3931 — HA config-sync generation ordering guard tests.
 //
 // These exercise the config-sync wire codec (encodeConfigPayload /
-// decodeConfigPayload), the receiver-side ordering guard (admitConfigGen), and
-// the single-consumer ordered apply loop (configApplyLoop). Every test is
+// decodeConfigPayload), the receiver-side ordering guard (shouldApplyConfigGen
+// admission + recordAppliedConfigGen apply-then-advance, M-2/#4151), and the
+// single-consumer ordered apply loop (configApplyLoop). Every test is
 // written so it FAILS against the pre-#3931 behavior, where a config was
 // applied via a racing `go OnConfigReceived` with NO generation on the wire:
 // a rapid commit pair (C1 then C2) could apply out of order and leave the
@@ -64,22 +66,27 @@ func TestConfigPayloadEmptyText(t *testing.T) {
 
 // --- ordering guard --------------------------------------------------------
 
-func TestAdmitConfigGenMonotonic(t *testing.T) {
+// The admission gate (shouldApplyConfigGen) is strictly monotonic against the
+// last SUCCESSFULLY-applied generation (advanced only via recordAppliedConfigGen
+// after a confirmed apply, M-2/#4151).
+func TestShouldApplyConfigGenMonotonic(t *testing.T) {
 	s := &SessionSync{}
-	// First real config admits and sets the high-water mark.
-	if !s.admitConfigGen(5) {
+	// First real config admits; the caller records it on successful apply.
+	if !s.shouldApplyConfigGen(5) {
 		t.Fatal("gen 5 should admit (first config)")
 	}
+	s.recordAppliedConfigGen(5)
 	// A strictly-newer config admits.
-	if !s.admitConfigGen(6) {
+	if !s.shouldApplyConfigGen(6) {
 		t.Fatal("gen 6 should admit (newer than 5)")
 	}
+	s.recordAppliedConfigGen(6)
 	// An older config (the reordered C1) is refused.
-	if s.admitConfigGen(5) {
+	if s.shouldApplyConfigGen(5) {
 		t.Fatal("gen 5 must be refused after gen 6 applied (stale)")
 	}
 	// The same generation is refused (not strictly newer).
-	if s.admitConfigGen(6) {
+	if s.shouldApplyConfigGen(6) {
 		t.Fatal("gen 6 must be refused after gen 6 applied (not strictly newer)")
 	}
 	if got := s.lastAppliedConfigGen.Load(); got != 6 {
@@ -87,22 +94,50 @@ func TestAdmitConfigGenMonotonic(t *testing.T) {
 	}
 }
 
-// gen==0 (legacy sender) is always applied and does NOT advance the
-// high-water mark, so a subsequent real generation still orders correctly.
-func TestAdmitConfigGenLegacyUnconditional(t *testing.T) {
+// The gate does NOT advance the high-water mark on its own: admitting a
+// generation must not record it. Only a confirmed apply (recordAppliedConfigGen)
+// advances the mark — the M-2/#4151 apply-then-advance separation.
+func TestShouldApplyConfigGenDoesNotAdvance(t *testing.T) {
 	s := &SessionSync{}
-	if !s.admitConfigGen(0) {
+	if !s.shouldApplyConfigGen(9) {
+		t.Fatal("gen 9 should admit (first config)")
+	}
+	if got := s.lastAppliedConfigGen.Load(); got != 0 {
+		t.Fatalf("the admission gate must NOT advance the high-water mark, got %d (want 0)", got)
+	}
+	// Admitting it again (no apply recorded yet) must still succeed — the same
+	// generation stays eligible until an apply confirms it.
+	if !s.shouldApplyConfigGen(9) {
+		t.Fatal("gen 9 must stay admissible until a successful apply records it")
+	}
+	s.recordAppliedConfigGen(9)
+	if got := s.lastAppliedConfigGen.Load(); got != 9 {
+		t.Fatalf("recordAppliedConfigGen must advance the mark to 9, got %d", got)
+	}
+	if s.shouldApplyConfigGen(9) {
+		t.Fatal("gen 9 must be refused once recorded (not strictly newer)")
+	}
+}
+
+// gen==0 (legacy sender) is always admitted and never advances the high-water
+// mark, so a subsequent real generation still orders correctly.
+func TestShouldApplyConfigGenLegacyUnconditional(t *testing.T) {
+	s := &SessionSync{}
+	if !s.shouldApplyConfigGen(0) {
 		t.Fatal("legacy gen 0 must always admit")
 	}
+	s.recordAppliedConfigGen(0)
 	if got := s.lastAppliedConfigGen.Load(); got != 0 {
 		t.Fatalf("gen 0 must not advance high-water mark, got %d", got)
 	}
-	if !s.admitConfigGen(3) {
+	if !s.shouldApplyConfigGen(3) {
 		t.Fatal("real gen 3 should admit after a legacy gen 0")
 	}
-	if !s.admitConfigGen(0) {
+	s.recordAppliedConfigGen(3)
+	if !s.shouldApplyConfigGen(0) {
 		t.Fatal("legacy gen 0 must still admit after a real gen")
 	}
+	s.recordAppliedConfigGen(0)
 	if got := s.lastAppliedConfigGen.Load(); got != 3 {
 		t.Fatalf("high-water mark should remain 3, got %d", got)
 	}
@@ -115,32 +150,46 @@ func TestResetRecvGenResetsConfigGen(t *testing.T) {
 	s := &SessionSync{}
 	s.recvGenV4 = nil
 	s.recvGenV6 = nil
-	if !s.admitConfigGen(100) {
+	if !s.shouldApplyConfigGen(100) {
 		t.Fatal("gen 100 should admit")
 	}
+	s.recordAppliedConfigGen(100)
 	s.resetRecvGen()
 	if got := s.lastAppliedConfigGen.Load(); got != 0 {
 		t.Fatalf("resetRecvGen must zero the config gen, got %d", got)
 	}
 	// A lower generation (rebooted peer) now applies.
-	if !s.admitConfigGen(3) {
+	if !s.shouldApplyConfigGen(3) {
 		t.Fatal("gen 3 should admit after reset (rebooted peer)")
 	}
 }
 
 // --- end-to-end ordered apply (RED-on-revert) ------------------------------
 
-// configRecorder captures the sequence of applied config texts under a mutex
-// so the ordered-apply consumer can be observed deterministically.
+// configRecorder captures the sequence of SUCCESSFULLY applied config texts
+// under a mutex so the ordered-apply consumer can be observed deterministically.
+//
+// failN, if > 0, makes the next failN record() calls return an error WITHOUT
+// recording the text — simulating an apply that failed before promoting the
+// store (a compile/promote failure or a transient RG0-primary rejection). This
+// exercises the M-2/#4151 apply-then-advance contract.
 type configRecorder struct {
-	mu      sync.Mutex
-	applied []string
+	mu       sync.Mutex
+	applied  []string
+	failN    int
+	attempts int
 }
 
-func (r *configRecorder) record(text string) {
+func (r *configRecorder) record(text string) error {
 	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.attempts++
+	if r.failN > 0 {
+		r.failN--
+		return fmt.Errorf("simulated config apply failure for %q", text)
+	}
 	r.applied = append(r.applied, text)
-	r.mu.Unlock()
+	return nil
 }
 
 func (r *configRecorder) last() (string, int) {
@@ -247,6 +296,71 @@ func TestConfigSyncSinglePushApplies(t *testing.T) {
 	last, count := rec.last()
 	if last != "config-only" || count != 1 {
 		t.Fatalf("single push should apply once, got %q count=%d", last, count)
+	}
+}
+
+// TestConfigSyncApplyFailureRetainsHighWater is the M-2 (#4151) RED-on-revert
+// test. When the apply FAILS, the config high-water mark must NOT advance, so
+// the primary's re-push of the SAME generation is re-admitted and re-attempted
+// (the standby re-converges) instead of being silently dropped as stale.
+//
+// Under the pre-fix advance-before-apply order (admitConfigGen advanced the
+// high-water BEFORE OnConfigReceived and ignored its result), the high-water
+// jumped to the failed generation, the re-push was dropped as "not strictly
+// newer," and the standby stayed stranded on the prior config — so this test
+// fails on revert.
+func TestConfigSyncApplyFailureRetainsHighWater(t *testing.T) {
+	s := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", nil)
+	rec := &configRecorder{failN: 1} // fail the first apply, succeed after
+	s.OnConfigReceived = rec.record
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.configApplyLoop(ctx)
+
+	// (1) First delivery of gen 7 fails to apply.
+	s.configApplyCh <- configApplyItem{gen: 7, text: "config-C7"}
+	drainConfigApply(t, s)
+
+	if got := s.lastAppliedConfigGen.Load(); got != 0 {
+		t.Fatalf("apply failure must NOT advance the high-water mark, got %d (want 0)", got)
+	}
+	if got := s.stats.ConfigsApplyFailed.Load(); got != 1 {
+		t.Fatalf("a failed apply must be counted in ConfigsApplyFailed, got %d", got)
+	}
+	if got := s.stats.ConfigsStaleIgnored.Load(); got != 0 {
+		t.Fatalf("a failed apply must NOT be counted as stale-dropped, got %d", got)
+	}
+	if _, count := rec.last(); count != 0 {
+		t.Fatalf("no config should have been recorded after the failed apply, got %d", count)
+	}
+
+	// (2) Primary re-pushes the SAME generation 7; it must be re-admitted (not
+	// dropped as stale) and now applies successfully — the standby re-converges.
+	s.configApplyCh <- configApplyItem{gen: 7, text: "config-C7"}
+	drainConfigApply(t, s)
+
+	last, count := rec.last()
+	if last != "config-C7" || count != 1 {
+		t.Fatalf("re-push of gen 7 must re-apply after the earlier failure, got %q count=%d", last, count)
+	}
+	if got := s.stats.ConfigsStaleIgnored.Load(); got != 0 {
+		t.Fatalf("the re-push must NOT be dropped as stale, ConfigsStaleIgnored=%d", got)
+	}
+	if got := s.lastAppliedConfigGen.Load(); got != 7 {
+		t.Fatalf("high-water must advance to 7 only AFTER the successful apply, got %d", got)
+	}
+
+	// (3) A THIRD push of gen 7, now AFTER a successful apply, is correctly
+	// skipped as stale — proving the skip is legitimate only once the apply
+	// actually succeeded (distinguishes it from the fail case in step 1).
+	s.configApplyCh <- configApplyItem{gen: 7, text: "config-C7"}
+	drainConfigApply(t, s)
+	if _, count := rec.last(); count != 1 {
+		t.Fatalf("a same-gen push after a successful apply must be skipped, applies=%d", count)
+	}
+	if got := s.stats.ConfigsStaleIgnored.Load(); got != 1 {
+		t.Fatalf("the post-success same-gen push must be dropped as stale, ConfigsStaleIgnored=%d", got)
 	}
 }
 

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -1097,7 +1097,16 @@ func (s *SessionSync) configApplyLoop(ctx context.Context) {
 				// the standby eligible for the primary's re-push so it
 				// re-converges instead of being silently stranded (M-2/#4151).
 				s.stats.ConfigsApplyFailed.Add(1)
-				slog.Warn("cluster sync: config apply failed — retaining prior high-water so the peer re-push re-converges",
+				// Debug, not Warn: handleConfigSync (the callback) already logs
+				// the authoritative one-time reason WHY the apply failed
+				// (RG0-primary rejection at Warn, compile/promote failure at
+				// Error). This line is the per-retry diagnostic detail of the
+				// M-2/#4151 high-water retention, and the same generation may be
+				// re-pushed on every reconnect while the condition persists — a
+				// Warn here would spam (CLAUDE.md logging rule). The
+				// rate-independent observable is the ConfigsApplyFailed counter
+				// above (surfaced in cluster status), not this log.
+				slog.Debug("cluster sync: config apply failed — retaining prior high-water so the peer re-push re-converges",
 					"incoming_gen", item.gen, "last_applied_gen", s.lastAppliedConfigGen.Load(), "size", len(item.text), "err", err)
 				continue
 			}

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -1024,45 +1024,86 @@ func (s *SessionSync) QueueConfig(configText string) {
 	slog.Info("cluster sync: config sent to peer", "size", len(configText), "gen", gen)
 }
 
-// admitConfigGen implements the #3931 receiver-side config ordering guard. It
-// returns true if a config with generation gen should be applied — strictly
-// newer than the last-applied one, or gen==0 (a legacy sender / unknown, which
-// is applied unconditionally without advancing the high-water mark) — and
-// false if it is an out-of-order older config that must be dropped. On admit
-// of a non-zero gen it advances lastAppliedConfigGen. It is called ONLY from
-// the single-consumer configApplyLoop, so the load/store pair needs no CAS.
-func (s *SessionSync) admitConfigGen(gen uint64) bool {
-	last := s.lastAppliedConfigGen.Load()
-	if gen != 0 && last != 0 && gen <= last {
-		return false
+// shouldApplyConfigGen is the admission half of the #3931 receiver-side config
+// ordering guard. It returns true if a config with generation gen should be
+// ATTEMPTED — gen==0 (a legacy sender / unknown, applied unconditionally) or
+// strictly newer than the last SUCCESSFULLY-applied generation — and false if
+// it is an out-of-order older / duplicate config that must be dropped.
+//
+// It deliberately does NOT advance the high-water mark; the caller advances via
+// recordAppliedConfigGen ONLY after the apply succeeds (M-2/#4151). Advancing
+// on admission (the pre-#4151 behavior) meant an apply failure left the
+// high-water ahead of the actually-applied config, so the primary's re-push of
+// the same generation was dropped as stale and the standby stayed silently
+// stranded on the prior config. It is called ONLY from the single-consumer
+// configApplyLoop, so the load needs no CAS.
+func (s *SessionSync) shouldApplyConfigGen(gen uint64) bool {
+	if gen == 0 {
+		return true
 	}
-	if gen != 0 && gen > last {
+	last := s.lastAppliedConfigGen.Load()
+	return last == 0 || gen > last
+}
+
+// recordAppliedConfigGen advances the config high-water mark after a config of
+// generation gen has been SUCCESSFULLY applied. gen==0 (legacy / unconditional)
+// never advances the mark, mirroring the pre-#3931 behavior. It is called ONLY
+// from the single-consumer configApplyLoop after OnConfigReceived returns nil,
+// so the load/store pair needs no CAS.
+func (s *SessionSync) recordAppliedConfigGen(gen uint64) {
+	if gen == 0 {
+		return
+	}
+	if gen > s.lastAppliedConfigGen.Load() {
 		s.lastAppliedConfigGen.Store(gen)
 	}
-	return true
 }
 
 // configApplyLoop is the single ordered consumer of config-sync messages
-// (#3931). It drains configApplyCh in receive order and applies a config only
-// when admitConfigGen accepts its generation, so a reordered older config from
-// a rapid commit pair (C1 after C2) is dropped and the standby always
+// (#3931). It drains configApplyCh in receive order and attempts a config only
+// when shouldApplyConfigGen accepts its generation, so a reordered older config
+// from a rapid commit pair (C1 after C2) is dropped and the standby always
 // converges to the newest config. Replaces the pre-#3931 racing
 // `go OnConfigReceived` per message.
+//
+// The config high-water mark (lastAppliedConfigGen) advances ONLY after the
+// apply succeeds (recordAppliedConfigGen, gated on OnConfigReceived returning
+// nil). An apply failure counts ConfigsApplyFailed and leaves the high-water at
+// the last-applied generation, so the primary's re-push of the same generation
+// is re-admitted and the standby re-converges instead of being silently
+// stranded on the prior config (M-2/#4151).
 func (s *SessionSync) configApplyLoop(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case item := <-s.configApplyCh:
-			if !s.admitConfigGen(item.gen) {
+			if !s.shouldApplyConfigGen(item.gen) {
 				s.stats.ConfigsStaleIgnored.Add(1)
 				slog.Warn("cluster sync: dropping out-of-order config sync (stale generation) — standby retains newer config",
 					"incoming_gen", item.gen, "last_applied_gen", s.lastAppliedConfigGen.Load(), "size", len(item.text))
 				continue
 			}
-			if s.OnConfigReceived != nil {
-				s.OnConfigReceived(item.text)
+			if s.OnConfigReceived == nil {
+				// No apply handler wired — the config cannot be applied, so the
+				// high-water must NOT advance (M-2/#4151). A later wired handler
+				// re-applies on the primary's next push of this generation.
+				continue
 			}
+			if err := s.OnConfigReceived(item.text); err != nil {
+				// The apply did not take effect (compile/promote failure or a
+				// transient RG0-primary rejection). Do NOT advance the
+				// high-water: leaving it at the last-applied generation keeps
+				// the standby eligible for the primary's re-push so it
+				// re-converges instead of being silently stranded (M-2/#4151).
+				s.stats.ConfigsApplyFailed.Add(1)
+				slog.Warn("cluster sync: config apply failed — retaining prior high-water so the peer re-push re-converges",
+					"incoming_gen", item.gen, "last_applied_gen", s.lastAppliedConfigGen.Load(), "size", len(item.text), "err", err)
+				continue
+			}
+			// Apply confirmed — advance the high-water so a duplicate re-push of
+			// the same generation is correctly skipped as stale.
+			s.recordAppliedConfigGen(item.gen)
 		}
 	}
 }

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -340,14 +341,28 @@ func (d *Daemon) pushConfigToPeer() {
 	d.sessionSync.QueueConfig(configText)
 }
 
+// errConfigSyncRejectedPrimary is returned by handleConfigSync when this node
+// believes it is the RG0 primary (config authority) and therefore refuses the
+// peer's config. It is NOT an apply failure per se, but the config was not
+// applied, so the caller (configApplyLoop) must NOT advance the config
+// high-water mark — the transient dual-active window must heal via the peer's
+// re-push once this node settles into secondary (M-2/#4151).
+var errConfigSyncRejectedPrimary = errors.New("config sync rejected: this node is RG0 primary")
+
 // handleConfigSync processes a config received from the cluster peer.
 // Config sync is unidirectional: primary → secondary only. If this node
 // is the RG0 primary (config authority), incoming config is rejected to
 // prevent a reconnecting secondary from overwriting the authoritative config.
-func (d *Daemon) handleConfigSync(configText string) {
+//
+// It returns nil ONLY when the config was actually applied (or already matches
+// the active config); a non-nil error means the apply did not take effect. The
+// config high-water mark advances ONLY on a nil return (M-2/#4151), so a
+// rejection or a compile/promote failure leaves the standby eligible for the
+// primary's re-push instead of being silently stranded on the prior config.
+func (d *Daemon) handleConfigSync(configText string) error {
 	if d.cluster != nil && d.cluster.IsLocalPrimary(0) {
 		slog.Warn("cluster: rejecting config sync (this node is RG0 primary)")
-		return
+		return errConfigSyncRejectedPrimary
 	}
 	if d.store != nil {
 		activeText := strings.TrimSpace(d.store.ShowActive())
@@ -355,7 +370,9 @@ func (d *Daemon) handleConfigSync(configText string) {
 		if activeText == incomingText {
 			slog.Info("cluster: skipping config sync apply (config already matches active)",
 				"size", len(configText))
-			return
+			// Already converged to this config — a nil return lets the
+			// high-water advance so a duplicate re-push is correctly skipped.
+			return nil
 		}
 	}
 	slog.Info("cluster: accepting config sync from peer", "size", len(configText))
@@ -367,9 +384,10 @@ func (d *Daemon) handleConfigSync(configText string) {
 	// disagreeing.
 	if _, err := d.syncAndApply(context.Background(), configText, nil); err != nil {
 		slog.Error("cluster: config sync apply failed", "err", err)
-		return
+		return err
 	}
 	slog.Info("cluster: config sync applied successfully")
+	return nil
 }
 
 // watchClusterEvents monitors cluster state transitions and toggles
@@ -568,9 +586,9 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			d.cluster.SetSyncStats(d.sessionSync)
 
 			// Wire config sync callback: when secondary receives config from primary.
-			d.sessionSync.OnConfigReceived = func(configText string) {
+			d.sessionSync.OnConfigReceived = func(configText string) error {
 				d.cluster.RecordEvent(cluster.EventConfigSync, -1, fmt.Sprintf("Config received (%d bytes)", len(configText)))
-				d.handleConfigSync(configText)
+				return d.handleConfigSync(configText)
 			}
 
 			// Wire peer connected callback: push config to returning peer.

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -45,9 +45,13 @@ var ErrPersistentSourceNATProtocolIncompatible = errors.New("userspace persisten
 //     applyConfig wrapper, which logs slog.Warn and swallows the error —
 //     the node boots through (warn, not brick).
 //   - Peer config-sync goes through syncAndApply, which DOES propagate the
-//     error, but its caller (handleConfigSync) logs slog.Error and returns;
-//     the store is already promoted by SyncApply, so the node stays
-//     consistent with the peer (helper disarmed, not bricked).
+//     error; its caller (handleConfigSync) logs slog.Error and returns the
+//     error to configApplyLoop, which counts ConfigsApplyFailed and leaves the
+//     config high-water mark UNADVANCED so the primary's re-push re-converges
+//     the standby (M-2/#4151). When SyncApply already promoted the store, the
+//     re-push short-circuits on the "already matches active" check and heals
+//     the high-water; the node stays consistent with the peer (helper
+//     disarmed, not bricked).
 //
 // Only the operator-facing commit path (commitAndApply /
 // commitConfirmedAndApply) returns the abort to the committer.


### PR DESCRIPTION
Closes #4151

## Problem (HA correctness)

The HA config-sync receiver advanced its generation **high-water mark
BEFORE the config was actually applied**, silently stranding a diverged
standby on apply failure.

`admitConfigGen` (`pkg/cluster/sync_conn.go`) stored the incoming
generation, then `configApplyLoop` invoked `OnConfigReceived` with **no
error path**. `handleConfigSync` (`pkg/daemon/daemon_ha_sync.go`) returns
WITHOUT applying on a transient RG0-primary belief (this node believes it
is the RG0 config authority and refuses the peer's config), or on a
`syncAndApply` compile/promote failure (a mixed-build ISSU syntax error,
a store rejection).

Trace:
1. Primary commits C1 (gen N+1), pushes to standby.
2. Standby stores `lastAppliedConfigGen = N+1`, returns admit.
3. `OnConfigReceived(C1)` returns early WITHOUT applying -> store stays on C0.
4. Standby now records gen N+1 but its active config is C0 -- diverged.
5. Primary never re-sends N+1; the re-push of the SAME gen is dropped as
   "not strictly newer". On failover the standby serves stale C0.

This is the failure class #4034 fixed on the **sender**, reintroduced on
the **receiver** by the #3931 ordering guard.

## Fix: apply-then-advance

- Split `admitConfigGen` into `shouldApplyConfigGen` (pure admission gate,
  no advance) and `recordAppliedConfigGen` (the advance).
- `OnConfigReceived` / `handleConfigSync` now return an `error`.
- `configApplyLoop` advances the high-water via `recordAppliedConfigGen`
  ONLY when `OnConfigReceived` returns `nil`. On a non-nil return it counts
  a new `ConfigsApplyFailed` alarm and leaves the mark at the last-applied
  generation, so the primary's re-push of the same generation is
  re-admitted and the standby re-converges.
- The "already matches active" short-circuit returns `nil` (already
  converged -> advance), so a duplicate re-push is still correctly skipped.
- Preserves the #1960 lenient-load posture: whatever `syncAndApply` reports
  (nil = store promoted + applied; error = not applied) gates the mark, so
  the high-water always reflects the config actually in effect.
- Added `ConfigsApplyFailed` to `SyncStats`, the snapshot, and the cluster
  status display.

## Tests (RED on revert)

`TestConfigSyncApplyFailureRetainsHighWater`: a failed apply must NOT
advance the mark; the re-push of the same gen re-applies; a same-gen push
AFTER a successful apply IS skipped. Reverting to the advance-before-apply
order fails it:

```
--- FAIL: TestConfigSyncApplyFailureRetainsHighWater
    apply failure must NOT advance the high-water mark, got 7 (want 0)
```

The former `admitConfigGen` unit tests are rewritten against the new
gate/advance split (+ `TestShouldApplyConfigGenDoesNotAdvance`).

`go test ./pkg/cluster/... ./pkg/daemon/...` green; `go build ./...`,
gofmt, vet clean. Docs updated in `docs/sync-protocol.md`.

## Test-failover

This touches the HA config-sync path (receiver ordering). A
`make test-failover` on the loss userspace cluster is warranted before
merge to confirm no failover regression -- flagged for batching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi