### PR TITLE
api: constant-time API-key/Bearer/username auth — close timing side channel (#4157)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-07-04 — #4157 (fable-review-164 L-6): constant-time API-key/Bearer/username auth
+
+- **Timestamp**: 2026-07-04
+  - **Action**: Closed a timing side channel in the HTTP API auth
+    middleware. `authMiddleware` (X-API-Key) and `checkAuthorization`
+    (Bearer) validated tokens with a plain `cfg.APIKeys[token]` map
+    lookup — non-constant-time (latency varies with hash-bucket
+    collisions / key presence), so a network-timing attacker on an
+    interface-bound API could probe whether a submitted token/prefix was
+    valid. The Basic-auth username path also early-returned on
+    `!exists`, skipping the constant-time password compare entirely and
+    leaking username existence by timing. The password compare itself
+    already used `subtle.ConstantTimeCompare`.
+  - **Fix**: added `constantTimeAPIKeyMatch(cfg, presented)` — compares
+    the presented token against EVERY configured key with
+    `subtle.ConstantTimeCompare`, OR-ing results, never short-circuiting
+    on first match (so which key matched does not leak). Routed both the
+    X-API-Key and Bearer paths through it. Removed the username
+    early-return: always run `ConstantTimeCompare` against the looked-up
+    value, then AND with existence.
+  - **Tests**: `auth_consttime_4157_test.go` — functional (valid /
+    invalid / wrong-length / shared-prefix / false-valued key / empty
+    set), unknown-user rejection, HTTP integration, and an AST
+    regression guard (`TestAuthPathsUseConstantTimeCompare`) that fails
+    if any auth path reverts to a bare `cfg.APIKeys[...]` lookup.
+    Verified RED-on-revert: the guard fails on the reverted map-lookup
+    source, passes on the fix.
+  - **File(s)**: pkg/api/auth.go, pkg/api/auth_consttime_4157_test.go,
+    pkg/api/README.md, _Log.md
+
 ## 2026-07-04 — #4148 (fable-review-164 H-2): bound config lexer/parser recursion + payload size
 
 - **Timestamp**: 2026-07-04

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -246,6 +246,21 @@ under the daemon's errgroup. Nothing else imports this package.
   Read-only GET handlers do not read a body and are out of scope. Add a new
   mutation handler via `decodeJSONBody`, not a bare `json.NewDecoder(r.Body)`,
   so the cap and 413 are inherited. Pinned by `http_dos_hardening_4150_test.go`.
+- **Constant-time credential comparison (#4157).** `authMiddleware` /
+  `checkAuthorization` (`auth.go`) validate every credential in constant
+  time to avoid a network-timing side channel. API keys and Bearer tokens
+  go through `constantTimeAPIKeyMatch`, which compares the presented token
+  against EVERY configured key with `subtle.ConstantTimeCompare` and OR-s
+  the results — it never short-circuits on the first match (so *which* key
+  matched does not leak either) and never uses the old `cfg.APIKeys[token]`
+  map lookup (whose latency varied with hash-bucket collisions / presence).
+  Basic-auth passwords already used `ConstantTimeCompare`; the username path
+  no longer early-returns on `!exists` — it always runs the password compare
+  and AND-s with existence, so a known vs. unknown username is not
+  distinguishable by response timing. `ConstantTimeCompare` returns 0 on a
+  length mismatch (reveals length, not content — acceptable). Pinned by
+  `auth_consttime_4157_test.go`, including an AST regression guard that fails
+  if any auth path reverts to a bare `cfg.APIKeys[...]` lookup.
 - The status-poll path (1 Hz) shares the userspace dataplane control socket
   with HA sync, session installs, snapshot sync, and forwarding sync.
   Adding a new caller at >1 Hz here will starve session installs during

--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -33,7 +33,7 @@ func authMiddleware(cfg AuthConfig, next http.Handler) http.Handler {
 
 		// Check X-API-Key header
 		if key := r.Header.Get("X-API-Key"); key != "" {
-			if cfg.APIKeys[key] {
+			if constantTimeAPIKeyMatch(cfg, key) {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -52,7 +52,7 @@ func checkAuthorization(auth string, cfg AuthConfig) bool {
 	// Bearer token
 	if strings.HasPrefix(auth, "Bearer ") {
 		token := strings.TrimPrefix(auth, "Bearer ")
-		return cfg.APIKeys[token]
+		return constantTimeAPIKeyMatch(cfg, token)
 	}
 
 	// Basic auth
@@ -65,12 +65,41 @@ func checkAuthorization(auth string, cfg AuthConfig) bool {
 		if !ok {
 			return false
 		}
+		// Look up the expected password, but ALWAYS run the constant-time
+		// compare — even for an unknown user — so response timing does not
+		// reveal whether the username exists (#4157). Early-returning on
+		// !exists would skip the compare entirely, a large and measurable
+		// timing gap between a known and an unknown username.
 		expected, exists := cfg.Users[user]
-		if !exists {
-			return false
-		}
-		return subtle.ConstantTimeCompare([]byte(pass), []byte(expected)) == 1
+		passMatch := subtle.ConstantTimeCompare([]byte(pass), []byte(expected)) == 1
+		return exists && passMatch
 	}
 
 	return false
+}
+
+// constantTimeAPIKeyMatch reports whether presented equals any configured API
+// key. It compares presented against EVERY configured key with
+// crypto/subtle.ConstantTimeCompare and OR-s the per-key results, never
+// short-circuiting on the first match. This closes the timing side channel of
+// the previous plain map lookup (`cfg.APIKeys[presented]`), whose latency
+// varied with hash-bucket collisions and key presence and could leak whether a
+// submitted token/prefix was valid to a network-timing attacker on an
+// interface-bound API (#4157).
+//
+// ConstantTimeCompare returns 0 immediately when the two byte slices differ in
+// length; that reveals only length, not content, which is acceptable here. The
+// loop count is the number of configured keys — a deployment constant, not
+// attacker-controllable per request — so it does not leak the secret. Not
+// short-circuiting means WHICH key matched is not leaked by timing either.
+func constantTimeAPIKeyMatch(cfg AuthConfig, presented string) bool {
+	presentedBytes := []byte(presented)
+	match := 0
+	for key, valid := range cfg.APIKeys {
+		if !valid {
+			continue
+		}
+		match |= subtle.ConstantTimeCompare(presentedBytes, []byte(key))
+	}
+	return match == 1
 }

--- a/pkg/api/auth_consttime_4157_test.go
+++ b/pkg/api/auth_consttime_4157_test.go
@@ -1,0 +1,203 @@
+package api
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestConstantTimeAPIKeyMatch pins the functional contract of the constant-time
+// API-key / Bearer-token comparison introduced for #4157: a configured key is
+// accepted, anything else (including a same-prefix or wrong-length candidate)
+// is rejected, and matching is independent of which key in the set matched.
+func TestConstantTimeAPIKeyMatch(t *testing.T) {
+	cfg := AuthConfig{
+		APIKeys: map[string]bool{
+			"tok-abc-123":  true,
+			"tok-xyz-999":  true,
+			"disabled-key": false, // a false-valued key must NOT authenticate
+		},
+	}
+
+	tests := []struct {
+		name      string
+		presented string
+		want      bool
+	}{
+		{"first configured key", "tok-abc-123", true},
+		{"second configured key", "tok-xyz-999", true},
+		{"empty token", "", false},
+		{"unknown token", "not-a-key", false},
+		{"shared prefix, wrong tail", "tok-abc-124", false},
+		{"prefix of a valid key (wrong length)", "tok-abc-12", false},
+		{"valid key plus trailing byte", "tok-abc-1234", false},
+		{"false-valued key rejected", "disabled-key", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := constantTimeAPIKeyMatch(cfg, tt.presented); got != tt.want {
+				t.Errorf("constantTimeAPIKeyMatch(%q) = %v, want %v", tt.presented, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestConstantTimeAPIKeyMatchEmptySet ensures an empty key set never
+// authenticates — the OR of zero comparisons must be false.
+func TestConstantTimeAPIKeyMatchEmptySet(t *testing.T) {
+	cfg := AuthConfig{APIKeys: map[string]bool{}}
+	if constantTimeAPIKeyMatch(cfg, "anything") {
+		t.Fatal("empty key set authenticated a token")
+	}
+	if constantTimeAPIKeyMatch(cfg, "") {
+		t.Fatal("empty key set authenticated an empty token")
+	}
+}
+
+// TestBasicAuthUnknownUserRejected confirms the Basic-auth path still rejects
+// an unknown username. The #4157 fix removed the early `return false` on
+// !exists (which skipped the constant-time compare and leaked username
+// existence via timing) and instead always runs ConstantTimeCompare against
+// the looked-up value, then AND-s with existence — so an unknown user, a known
+// user with the wrong password, and a known user whose password happens to
+// equal the empty-string default must all be rejected.
+func TestBasicAuthUnknownUserRejected(t *testing.T) {
+	cfg := AuthConfig{
+		Users: map[string]string{"admin": "secret123"},
+	}
+
+	cases := []struct {
+		name string
+		user string
+		pass string
+		want bool
+	}{
+		{"known user, correct password", "admin", "secret123", true},
+		{"known user, wrong password", "admin", "nope", false},
+		{"unknown user, valid password", "nobody", "secret123", false},
+		{"unknown user, empty password", "nobody", "", false},
+		{"known user, empty password", "admin", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hdr := "Basic " + basicAuth64(tc.user, tc.pass)
+			if got := checkAuthorization(hdr, cfg); got != tc.want {
+				t.Errorf("checkAuthorization(%s:%s) = %v, want %v", tc.user, tc.pass, got, tc.want)
+			}
+		})
+	}
+}
+
+func basicAuth64(user, pass string) string {
+	// Mirror pkg/api/auth_test.go's basicAuth without the "Basic " prefix.
+	return strings.TrimPrefix(basicAuth(user, pass), "Basic ")
+}
+
+// TestAuthPathsUseConstantTimeCompare is a source-level regression guard.
+// Reverting to a plain map lookup (`cfg.APIKeys[token]`) or a `==` compare
+// keeps the functional tests above green while silently reintroducing the
+// timing side channel, so we assert the AST of the auth paths instead: the
+// Bearer / X-API-Key decision must route through constantTimeAPIKeyMatch, that
+// helper must call subtle.ConstantTimeCompare, and no auth-decision code may
+// index cfg.APIKeys as a boolean (`cfg.APIKeys[...]`).
+func TestAuthPathsUseConstantTimeCompare(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "auth.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse auth.go: %v", err)
+	}
+
+	var (
+		helperCallsConstantTimeCompare bool
+		bearerUsesHelper               bool
+		apiKeyIndexedAsBool            bool
+	)
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok {
+			return true
+		}
+		switch fn.Name.Name {
+		case "constantTimeAPIKeyMatch":
+			ast.Inspect(fn.Body, func(m ast.Node) bool {
+				if sel, ok := m.(*ast.SelectorExpr); ok {
+					if pkg, ok := sel.X.(*ast.Ident); ok &&
+						pkg.Name == "subtle" && sel.Sel.Name == "ConstantTimeCompare" {
+						helperCallsConstantTimeCompare = true
+					}
+				}
+				return true
+			})
+		case "checkAuthorization", "authMiddleware":
+			ast.Inspect(fn.Body, func(m ast.Node) bool {
+				switch e := m.(type) {
+				case *ast.CallExpr:
+					if id, ok := e.Fun.(*ast.Ident); ok && id.Name == "constantTimeAPIKeyMatch" {
+						bearerUsesHelper = true
+					}
+				case *ast.IndexExpr:
+					// cfg.APIKeys[...] used as a value — the old leaky pattern.
+					if sel, ok := e.X.(*ast.SelectorExpr); ok && sel.Sel.Name == "APIKeys" {
+						apiKeyIndexedAsBool = true
+					}
+				}
+				return true
+			})
+		}
+		return true
+	})
+
+	if !helperCallsConstantTimeCompare {
+		t.Error("constantTimeAPIKeyMatch must call subtle.ConstantTimeCompare (#4157)")
+	}
+	if !bearerUsesHelper {
+		t.Error("Bearer / X-API-Key auth paths must route through constantTimeAPIKeyMatch (#4157)")
+	}
+	if apiKeyIndexedAsBool {
+		t.Error("auth paths must not index cfg.APIKeys as a boolean map lookup — timing side channel (#4157)")
+	}
+}
+
+// TestAuthMiddlewareConstantTimeIntegration re-exercises the middleware end to
+// end after the #4157 change to confirm token acceptance/rejection through the
+// real HTTP path (complements the unit-level helper tests).
+func TestAuthMiddlewareConstantTimeIntegration(t *testing.T) {
+	cfg := AuthConfig{
+		Users:   map[string]string{"admin": "secret123"},
+		APIKeys: map[string]bool{"tok-abc-123": true},
+	}
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := authMiddleware(cfg, next)
+
+	cases := []struct {
+		name   string
+		header map[string]string
+		want   int
+	}{
+		{"bearer valid", map[string]string{"Authorization": "Bearer tok-abc-123"}, http.StatusOK},
+		{"bearer wrong-length", map[string]string{"Authorization": "Bearer tok-abc-12"}, http.StatusUnauthorized},
+		{"x-api-key valid", map[string]string{"X-API-Key": "tok-abc-123"}, http.StatusOK},
+		{"x-api-key shared-prefix", map[string]string{"X-API-Key": "tok-abc-124"}, http.StatusUnauthorized},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/api/v1/status", nil)
+			for k, v := range tc.header {
+				req.Header.Set(k, v)
+			}
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			if w.Code != tc.want {
+				t.Errorf("got %d, want %d", w.Code, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #4157

## Problem

The HTTP API auth middleware (`pkg/api/auth.go`) validated API keys and
Bearer tokens with a plain Go map lookup (`cfg.APIKeys[token]`) and
short-circuited the Basic-auth username check before the constant-time
password compare (`if !exists { return false }`). Map-lookup latency
varies with hash-bucket collisions and key presence, and the username
early-return skips the compare entirely — so a network-timing attacker
on an interface-bound web-management API could probe whether a submitted
token/prefix or username is valid. The Basic-auth PASSWORD path already
used `subtle.ConstantTimeCompare`, so these paths were inconsistent with
the deliberate constant-time posture already in the same file.

fable-review-164 finding L-6 (security / hardening).

## Fix

- **`constantTimeAPIKeyMatch(cfg, presented)`** — compares the presented
  token against EVERY configured key with `subtle.ConstantTimeCompare`,
  OR-ing the per-key results. It never short-circuits on the first match
  (so *which* key matched is not leaked by timing either) and never uses
  the leaky map lookup. `ConstantTimeCompare` returns 0 on a length
  mismatch (reveals length, not content — acceptable). The loop count is
  the number of configured keys — a deployment constant, not
  attacker-controllable per request. A false-valued key does not
  authenticate, preserving the old set semantics.
- Route both the **X-API-Key** (`authMiddleware`) and **Bearer**
  (`checkAuthorization`) paths through the helper.
- **Username path**: drop the `!exists` early return — always run
  `ConstantTimeCompare` against the looked-up password, then AND with
  existence, so a known vs. unknown username is not distinguishable by
  response timing.

## Tests

`pkg/api/auth_consttime_4157_test.go`:
- Functional: valid / invalid / wrong-length / shared-prefix /
  false-valued key / empty set; unknown-user rejection; HTTP end-to-end
  integration.
- **AST regression guard** (`TestAuthPathsUseConstantTimeCompare`):
  fails if any auth path reverts to a bare `cfg.APIKeys[...]` lookup or
  the helper stops calling `subtle.ConstantTimeCompare`.
- Verified **RED-on-revert**: the guard FAILS on the reverted
  map-lookup source and PASSES on the fix (functional tests stay green
  on a revert — that is exactly why the AST guard exists).

## Validation

- `go test ./pkg/api/...` — ok
- `go build ./...` — ok
- `gofmt -l pkg/api/` clean, `go vet ./pkg/api/...` clean

Docs: `pkg/api/README.md` Gotchas + `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi