### PR TITLE
cluster: validate ICMP echo reply in redundancy-group IP monitoring

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -33381,3 +33381,33 @@ top.
     pkg/cluster/status.go, pkg/cluster/sync_config_gen_test.go,
     pkg/daemon/daemon_ha_sync.go, pkg/dataplane/userspace/manager.go,
     docs/sync-protocol.md, _Log.md
+
+- **Timestamp**: 2026-07-04
+- **Action**: Fix hb164 L-3 — cluster redundancy-group IP monitoring
+  (`chassis cluster redundancy-group N ip-monitoring`, `pkg/cluster/monitor.go`
+  `probeICMP`) accepted ANY ICMP echo reply as a successful probe: it read one
+  packet and returned on `parsed.Type == replyType`, never checking the
+  responder source, the ICMP identifier, or the sequence number. A stray or
+  off-path-spoofed echo reply landing in the 800 ms window reported a genuinely
+  down monitored target as reachable, suppressing the RG weight demotion and the
+  intended WAN failover. Fix: validate the reply against the request before
+  counting it — source IP must equal the probed target, identifier must match,
+  sequence must match — looping until a matching reply or the deadline so a
+  non-matching reply neither counts nor consumes the single read. Identifier
+  handling accounts for the Linux SOCK_DGRAM ICMP socket this code uses: the
+  kernel overwrites the marshalled identifier with the socket's local port and
+  demuxes replies by it (empirically confirmed: a request marshalled with
+  ID 0xbf comes back as the socket port), so the identifier matched against is
+  `LocalAddr().(*net.UDPAddr).Port` (per-probe unique — each probe opens a fresh
+  socket), not the 0xbf constant. Sequence is stamped per probe from an atomic
+  counter cycling 1..0xffff. Added `LocalAddr()` to the `icmpConn` interface;
+  rewrote `mockICMPConn` into a faithful datagram responder (echoes port as ID,
+  request seq, target as source) with adversarial overrides (badSource/badID/
+  badSeq) + one-reply-then-timeout. RED-on-revert: restoring the type-only
+  accept makes TestProbeICMP_ReplyValidation (wrong source / wrong id / stale
+  seq) and TestProbeICMP_StaleSequenceAcrossProbes fail (bad reply accepted →
+  false "path up"); correct-reply and genuinely-down cases stay green.
+  `go test ./pkg/cluster/` green; `go build ./...`, gofmt, vet clean. Filed
+  issue #4156. Doc: docs/feature-coverage.md HA section.
+- **File(s)**: pkg/cluster/monitor.go, pkg/cluster/monitor_test.go,
+  docs/feature-coverage.md, _Log.md

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -116,6 +116,19 @@ the userspace dataplane admission boundary is in
   rather than holding stale "up" state (#2944). The IP address owner (priority
   255) always preempts a lower-priority master irrespective of the `no-preempt`
   flag (RFC 5798 §6.1, #4116) and is exempt from track-down demotion.
+- **Redundancy-group IP monitoring** (`chassis cluster redundancy-group N
+  ip-monitoring`): each configured target is ICMP-echo probed every poll and
+  its `weight` is subtracted from the RG priority while the target is
+  unreachable, driving weight-based failover. The probe **validates the echo
+  reply against the request** before counting it as reachable — the responder
+  source must equal the probed target, the ICMP identifier must equal the
+  one the request used, and the sequence must match the value just sent. The
+  probe uses a Linux SOCK_DGRAM ICMP socket, where the kernel overwrites the
+  identifier with the socket's local port and demuxes replies by it, so the
+  matched identifier is that port (per-probe unique), not a fixed constant;
+  the sequence is stamped per probe. A reply failing any check is ignored, so
+  a stray or spoofed echo reply cannot mask a genuinely down path and
+  suppress the intended failover (#4156). `pkg/cluster/monitor.go`.
 - **Bondless RETH**: VRRP on physical member interfaces, per-node virtual
   MAC (`02:bf:72:CC:RR:NN`), no Linux bonding required.
 - **Session sync**: incremental 1s sweep + ring buffer + GC delete

--- a/pkg/cluster/monitor.go
+++ b/pkg/cluster/monitor.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -64,6 +65,11 @@ type Monitor struct {
 	// network is "udp4" or "udp6".
 	icmpDialer func(network string) (icmpConn, error)
 
+	// icmpSeq is a monotonically increasing per-probe ICMP echo sequence
+	// counter. Each probe stamps a fresh sequence into its request so a
+	// stale reply from an earlier poll cycle is rejected.
+	icmpSeq atomic.Uint32
+
 	// Dampening thresholds (0 means use default).
 	FailThreshold int
 	PassThreshold int
@@ -83,6 +89,12 @@ type icmpConn interface {
 	WriteTo(b []byte, dst net.Addr) (int, error)
 	ReadFrom(b []byte) (int, net.Addr, error)
 	SetReadDeadline(t time.Time) error
+	// LocalAddr reports the socket's bound address. For the Linux
+	// SOCK_DGRAM ICMP socket used by the probe, the port carried here is
+	// the value the kernel writes into the ICMP identifier field of every
+	// echo request (and demuxes inbound replies by), so it is the
+	// identifier a reply must carry to be considered a match.
+	LocalAddr() net.Addr
 	Close() error
 }
 
@@ -373,12 +385,34 @@ func (mon *Monitor) probeICMP(addr string) bool {
 	}
 	defer conn.Close()
 
+	// Identifier the reply must carry. This code uses a Linux SOCK_DGRAM
+	// ICMP socket ("udp4"/"udp6"); the kernel OVERWRITES the identifier we
+	// marshal with the socket's local port and demuxes inbound replies by
+	// that value, so the identifier to match against is the socket port,
+	// not the constant placed in the request. Each probe opens a fresh
+	// socket, so this identifier is per-probe unique. Fall back to the
+	// marshalled constant when a port is unavailable (e.g. a raw-socket or
+	// test connection that reports no port).
+	const probeID = 0xbf
+	wantID := probeID
+	if la := conn.LocalAddr(); la != nil {
+		if ua, ok := la.(*net.UDPAddr); ok && ua.Port != 0 {
+			wantID = ua.Port
+		}
+	}
+
+	// Per-probe sequence number, cycling 1..0xffff in the 16-bit ICMP
+	// sequence space (never 0). The kernel preserves the sequence field, so
+	// a matching reply must echo the exact value we sent; a stale reply from
+	// an earlier poll cycle carries a different value and is rejected.
+	wantSeq := int(mon.icmpSeq.Add(1)%0xffff) + 1
+
 	msg := icmp.Message{
 		Type: echoType,
 		Code: 0,
 		Body: &icmp.Echo{
-			ID:   0xbf,
-			Seq:  1,
+			ID:   probeID,
+			Seq:  wantSeq,
 			Data: []byte("xpf"),
 		},
 	}
@@ -392,18 +426,59 @@ func (mon *Monitor) probeICMP(addr string) bool {
 		return false
 	}
 
+	// Read replies until one matches the request or the deadline expires.
+	// A non-matching reply (wrong responder, identifier, or sequence) must
+	// NOT be counted as a successful probe, and must NOT consume the single
+	// read and cause a false timeout — so keep reading until the deadline.
+	// The deadline is absolute, so subsequent ReadFrom calls inherit it.
 	conn.SetReadDeadline(time.Now().Add(800 * time.Millisecond))
 	reply := make([]byte, 1500)
-	n, _, err := conn.ReadFrom(reply)
-	if err != nil {
-		return false
-	}
+	for {
+		n, peer, err := conn.ReadFrom(reply)
+		if err != nil {
+			return false
+		}
 
-	parsed, err := icmp.ParseMessage(proto, reply[:n])
-	if err != nil {
+		// The responder source address must equal the probed target.
+		if !icmpPeerMatchesTarget(peer, ip) {
+			continue
+		}
+
+		parsed, err := icmp.ParseMessage(proto, reply[:n])
+		if err != nil {
+			continue
+		}
+		if parsed.Type != replyType {
+			continue
+		}
+		echo, ok := parsed.Body.(*icmp.Echo)
+		if !ok {
+			continue
+		}
+		if echo.ID != wantID || echo.Seq != wantSeq {
+			continue
+		}
+		return true
+	}
+}
+
+// icmpPeerMatchesTarget reports whether the source address of a received
+// ICMP reply equals the probed target. Datagram ICMP sockets report the
+// peer as *net.UDPAddr; raw sockets report *net.IPAddr.
+func icmpPeerMatchesTarget(peer net.Addr, target net.IP) bool {
+	if peer == nil {
 		return false
 	}
-	return parsed.Type == replyType
+	var pip net.IP
+	switch a := peer.(type) {
+	case *net.UDPAddr:
+		pip = a.IP
+	case *net.IPAddr:
+		pip = a.IP
+	default:
+		return false
+	}
+	return pip != nil && pip.Equal(target)
 }
 
 func defaultICMPDialer(network string) (icmpConn, error) {

--- a/pkg/cluster/monitor_test.go
+++ b/pkg/cluster/monitor_test.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
 )
 
 // mockLink implements netlink.Link for testing.
@@ -627,13 +630,63 @@ func TestMonitor_InvalidAddress(t *testing.T) {
 	}
 }
 
-// mockICMPConn simulates ICMP for testing.
+// mockICMPConn simulates a Linux datagram ICMP socket. On WriteTo it records
+// the request's target and sequence; on ReadFrom it synthesizes a matching
+// echo reply — source == target, identifier == the simulated kernel-assigned
+// socket port, sequence == the request's sequence — modeling the real
+// SOCK_DGRAM behavior where the kernel overwrites the identifier with the
+// socket port and preserves the sequence. Adversarial overrides let a test
+// model a spoofed / stale reply (wrong source, identifier, or sequence).
 type mockICMPConn struct {
 	reachable bool
 	v6        bool // if true, return ICMPv6 echo reply
+
+	// localPort is the simulated kernel-assigned identifier reported by
+	// LocalAddr and echoed as the reply identifier. 0 means use 0xbf.
+	localPort int
+
+	// Adversarial overrides. When set, the reply deviates from a faithful
+	// echo of the request so validation can be exercised.
+	badSource net.IP // reply source instead of the probed target
+	badID     *int   // reply identifier instead of localPort
+	badSeq    *int   // reply sequence instead of the request's sequence
+
+	// Captured from the most recent WriteTo.
+	lastTarget net.IP
+	lastSeq    int
+
+	// readCount models a socket that delivers at most one reply before the
+	// read deadline expires, so the validation loop terminates.
+	readCount int
+}
+
+func (c *mockICMPConn) proto() int {
+	if c.v6 {
+		return 58
+	}
+	return 1
+}
+
+func (c *mockICMPConn) port() int {
+	if c.localPort != 0 {
+		return c.localPort
+	}
+	return 0xbf
+}
+
+func (c *mockICMPConn) LocalAddr() net.Addr {
+	return &net.UDPAddr{Port: c.port()}
 }
 
 func (c *mockICMPConn) WriteTo(b []byte, dst net.Addr) (int, error) {
+	if ua, ok := dst.(*net.UDPAddr); ok {
+		c.lastTarget = ua.IP
+	}
+	if m, err := icmp.ParseMessage(c.proto(), b); err == nil {
+		if e, ok := m.Body.(*icmp.Echo); ok {
+			c.lastSeq = e.Seq
+		}
+	}
 	return len(b), nil
 }
 
@@ -641,24 +694,142 @@ func (c *mockICMPConn) ReadFrom(b []byte) (int, net.Addr, error) {
 	if !c.reachable {
 		return 0, nil, net.UnknownNetworkError("timeout")
 	}
-	if c.v6 {
-		// ICMPv6 echo reply: Type=129, Code=0, Checksum, ID, Seq
-		reply := []byte{0x81, 0x00, 0x00, 0x00, 0x00, 0xbf, 0x00, 0x01}
-		// Checksum is validated by kernel for UDP-based ICMP, set to zero.
-		n := copy(b, reply)
-		return n, &net.UDPAddr{IP: net.ParseIP("2001:db8::1")}, nil
+	c.readCount++
+	if c.readCount > 1 {
+		// Model the read deadline expiring with no further replies, so a
+		// probe that rejected the first (non-matching) reply gives up.
+		return 0, nil, net.UnknownNetworkError("timeout")
 	}
-	// ICMPv4 echo reply: Type=0, Code=0, Checksum, ID, Seq
-	reply := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0xbf, 0x00, 0x01}
-	// Fix checksum
-	reply[2] = 0xff
-	reply[3] = 0x40
+
+	id := c.port()
+	if c.badID != nil {
+		id = *c.badID
+	}
+	seq := c.lastSeq
+	if c.badSeq != nil {
+		seq = *c.badSeq
+	}
+
+	var replyType icmp.Type
+	if c.v6 {
+		replyType = ipv6.ICMPTypeEchoReply
+	} else {
+		replyType = ipv4.ICMPTypeEchoReply
+	}
+	reply, err := (&icmp.Message{
+		Type: replyType,
+		Code: 0,
+		Body: &icmp.Echo{ID: id, Seq: seq, Data: []byte("xpf")},
+	}).Marshal(nil)
+	if err != nil {
+		return 0, nil, err
+	}
 	n := copy(b, reply)
-	return n, &net.UDPAddr{IP: net.ParseIP("10.0.1.1")}, nil
+
+	src := c.lastTarget
+	if c.badSource != nil {
+		src = c.badSource
+	}
+	return n, &net.UDPAddr{IP: src}, nil
 }
 
 func (c *mockICMPConn) SetReadDeadline(t time.Time) error { return nil }
 func (c *mockICMPConn) Close() error                      { return nil }
+
+// TestProbeICMP_ReplyValidation verifies that probeICMP only counts an echo
+// reply as a successful probe when the responder source address, the ICMP
+// identifier (the datagram socket's local port), and the sequence number all
+// match the request. A reply failing any check must be ignored — otherwise a
+// stray or spoofed reply falsely reports a down path as up and suppresses the
+// intended failover (the L-3 finding).
+func TestProbeICMP_ReplyValidation(t *testing.T) {
+	intp := func(v int) *int { return &v }
+
+	cases := []struct {
+		name   string
+		v6     bool
+		target string
+		mutate func(c *mockICMPConn)
+		want   bool
+	}{
+		{
+			name:   "v4 correct reply accepted",
+			target: "10.0.1.1",
+			want:   true,
+		},
+		{
+			name:   "v4 wrong source rejected",
+			target: "10.0.1.1",
+			mutate: func(c *mockICMPConn) { c.badSource = net.ParseIP("10.0.1.99") },
+			want:   false,
+		},
+		{
+			name:   "v4 wrong identifier rejected",
+			target: "10.0.1.1",
+			// 0xbf is the constant the request marshals; the kernel would
+			// have rewritten it to the socket port, so a reply still bearing
+			// 0xbf is a foreign/spoofed reply.
+			mutate: func(c *mockICMPConn) { c.badID = intp(0xbf) },
+			want:   false,
+		},
+		{
+			name:   "v4 stale sequence rejected",
+			target: "10.0.1.1",
+			mutate: func(c *mockICMPConn) { c.badSeq = intp(1) },
+			want:   false,
+		},
+		{
+			name:   "v6 correct reply accepted",
+			v6:     true,
+			target: "2001:db8::1",
+			want:   true,
+		},
+		{
+			name:   "v6 wrong source rejected",
+			v6:     true,
+			target: "2001:db8::1",
+			mutate: func(c *mockICMPConn) { c.badSource = net.ParseIP("2001:db8::99") },
+			want:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mc := &mockICMPConn{reachable: true, v6: tc.v6, localPort: 45502}
+			if tc.mutate != nil {
+				tc.mutate(mc)
+			}
+			mon := &Monitor{
+				icmpDialer: func(network string) (icmpConn, error) { return mc, nil },
+			}
+			if got := mon.probeICMP(tc.target); got != tc.want {
+				t.Errorf("probeICMP(%s) = %v, want %v", tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestProbeICMP_StaleSequenceAcrossProbes verifies that a reply carrying the
+// sequence from a PREVIOUS probe (a delayed/duplicated reply) is not accepted
+// by a later probe, since each probe stamps a fresh sequence.
+func TestProbeICMP_StaleSequenceAcrossProbes(t *testing.T) {
+	first := &mockICMPConn{reachable: true, localPort: 45502}
+	mon := &Monitor{
+		icmpDialer: func(network string) (icmpConn, error) { return first, nil },
+	}
+	if !mon.probeICMP("10.0.1.1") {
+		t.Fatal("first probe should succeed")
+	}
+
+	// Second probe: a reply that replays the FIRST probe's exact sequence
+	// (captured in first.lastSeq) must be rejected because the second probe
+	// stamped a fresh sequence.
+	replay := &mockICMPConn{reachable: true, localPort: 45502, badSeq: &first.lastSeq}
+	mon.icmpDialer = func(network string) (icmpConn, error) { return replay, nil }
+	if mon.probeICMP("10.0.1.1") {
+		t.Error("probe accepted a reply carrying the previous probe's sequence")
+	}
+}
 
 func TestMonitor_LocalStatusesConcurrent(t *testing.T) {
 	m := NewManager(0, 1)


### PR DESCRIPTION
Closes #4156

## Problem

The chassis-cluster redundancy-group IP monitor
(`chassis cluster redundancy-group N ip-monitoring`, `probeICMP` in
`pkg/cluster/monitor.go`) accepted **any** ICMP echo reply as a
successful probe. It did a single `ReadFrom` and returned on
`parsed.Type == replyType`, discarding the responder source address and
never comparing the parsed identifier or sequence to the request:

```go
parsed, err := icmp.ParseMessage(proto, reply[:n])
if err != nil {
    return false
}
return parsed.Type == replyType
```

A genuinely down monitored target could be reported reachable whenever
any host on the segment emitted an echo reply (misconfig, proxy, stray
reply, or an off-path spoofer inside the 800 ms window on the
unprivileged ping socket). A false "path up" **suppresses the RG weight
demotion and the intended WAN failover** — the event ip-monitoring
exists to trigger.

## Fix

Validate the reply against the request before counting it, looping until
a matching reply or the deadline (so a non-matching reply neither counts
as success nor consumes the single read and falsely times out):

- **Source** — the `ReadFrom` peer IP must equal the probed target.
- **Identifier** — must equal the identifier the probe used. This code
  opens a Linux SOCK_DGRAM ICMP socket (`udp4`/`udp6`); the kernel
  overwrites the marshalled identifier with the socket's local port and
  demuxes replies by it (empirically confirmed: a request marshalled
  with `ID 0xbf` returns bearing the socket port as its ID). The matched
  identifier is therefore `LocalAddr().(*net.UDPAddr).Port` — per-probe
  unique because each probe opens a fresh socket — **not** the `0xbf`
  constant, which would reject every legitimate reply.
- **Sequence** — must match the value stamped for that probe, from an
  atomic counter cycling `1..0xffff`, so a stale reply from an earlier
  poll is rejected.

`LocalAddr()` is added to the `icmpConn` interface (satisfied by
`*icmp.PacketConn`). `mockICMPConn` becomes a faithful datagram
responder (echoes port as ID, request seq, target as source) with
adversarial overrides and a one-reply-then-timeout model.

## Tests

- `TestProbeICMP_ReplyValidation` — accept on match; reject wrong
  source, wrong identifier, stale sequence (v4 + v6).
- `TestProbeICMP_StaleSequenceAcrossProbes` — a replayed prior-probe
  sequence is rejected.

**RED-on-revert:** restoring the type-only accept turns every reject
case red (bad reply accepted -> false "path up"); the correct-reply and
genuinely-down (no reply -> demotion) cases stay green.

`go test ./pkg/cluster/` green; `go build ./...`, gofmt, vet clean.

## Docs

`docs/feature-coverage.md` HA section documents the RG IP-monitoring
probe and its reply validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi