### PR TITLE
screen: skip rate-based flood counters for fabric-redirected traffic (#4155)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -33351,3 +33351,39 @@ top.
     already covered by the doc's "empty/malformed/non-/96 prefix" wording).
   - **File(s)**: userspace-dp/src/nat64.rs, userspace-dp/src/nat64_tests.rs,
     _Log.md
+
+- **Timestamp**: 2026-07-04
+  - **Action**: #4155 (fable-review-164 M-4) — rate-based flood screens re-run
+    on the RG owner for fabric-redirected (already-screened) traffic,
+    double-counting against the per-zone / per-destination flood thresholds. In
+    a chassis cluster a packet ingressing the non-owner node is screened there,
+    fabric-redirected to the owner, and the owner re-ran `stage_screen_check` →
+    the SAME packet ticked the icmp/udp/syn-flood counters a second time, so a
+    legit high-pps synced session could false-trip a flood Drop and defeat
+    fabric cross-chassis forwarding (vSRX does not re-screen fabric traffic).
+    Fix: stage 9 already sets `FABRIC_INGRESS_FLAG` on `meta.meta_flags`;
+    `stage_screen_check` now derives
+    `skip_rate_flood = (meta.meta_flags & FABRIC_INGRESS_FLAG) != 0` and threads
+    it into new `ScreenState::check_packet_with_zone_id_opts` /
+    `check_flowless_screens_opts` entry points (the old signatures are thin
+    wrappers passing `false`, so ~55 existing callers/tests are untouched). When
+    set, the stateless per-packet screens (land, ping-of-death, teardrop,
+    icmp-fragment, source-route) still run — idempotent — and the method returns
+    Pass BEFORE the rate flood counters, so the owner does not re-count. The
+    per-`(zone,src)` scan/sweep new-flow counter is skipped the same way
+    (`packet_fabric_ingress`) at the session-miss decision in
+    `poll_descriptor/mod.rs`; the per-IP session-limit check there still runs
+    (it guards the owner's own SessionTable). The #4132 per-destination flood
+    sketches are untouched — the fix skips the re-count, not the screen.
+    RED-on-revert: 7 screen-runtime unit tests + 1 poll_stages integration test
+    driving the LIVE `stage_screen_check` (fabric UDP fragment never drops; a
+    direct-ingress stream drops at the correct threshold+1). Verified by
+    neutering both gates — the 6 rate-flood tests go RED, the 2 stateless-scope
+    guards stay green (proving the skip is rate-only). FULL cargo test --release
+    green; go build ./... green. Docs: docs/fabric-cross-chassis-fwd.md +
+    userspace-dp/src/afxdp/README.md screen bullet.
+  - **File(s)**: userspace-dp/src/screen/mod.rs,
+    userspace-dp/src/afxdp/poll_stages.rs,
+    userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+    userspace-dp/src/screen/tests.rs, docs/fabric-cross-chassis-fwd.md,
+    userspace-dp/src/afxdp/README.md, _Log.md

--- a/docs/fabric-cross-chassis-fwd.md
+++ b/docs/fabric-cross-chassis-fwd.md
@@ -346,7 +346,7 @@ re-resolves and re-syncs the fabric MACs within seconds. The persisted
 fabric set is therefore the **observability snapshot** (so `show` reflects
 the resolved truth), not the restore source.
 
-## Screens are not re-run on fabric-redirected traffic (#4155)
+## Rate-based flood screens are not re-counted on fabric-redirected traffic (#4155)
 
 A packet that ingresses the **non-owner** node for a session the RG **owner**
 owns is screened on the ingress node and then fabric-redirected to the owner

--- a/docs/fabric-cross-chassis-fwd.md
+++ b/docs/fabric-cross-chassis-fwd.md
@@ -345,3 +345,42 @@ restart the daemon re-applies the full snapshot and re-runs
 re-resolves and re-syncs the fabric MACs within seconds. The persisted
 fabric set is therefore the **observability snapshot** (so `show` reflects
 the resolved truth), not the restore source.
+
+## Screens are not re-run on fabric-redirected traffic (#4155)
+
+A packet that ingresses the **non-owner** node for a session the RG **owner**
+owns is screened on the ingress node and then fabric-redirected to the owner
+(the Fix 1 path above). Before #4155 the owner **re-ran** the full screen stage
+on that redirected packet, so the **rate-based flood counters** (`icmp-flood`,
+`udp-flood`, `syn-flood`) counted the **same packet twice** against the
+per-zone / per-destination flood thresholds. A legitimate high-pps synced
+session could then false-trip a flood `Drop` on the owner — dropping exactly the
+traffic fabric forwarding exists to keep alive during failback /
+asymmetric-routing windows. This also diverges from vSRX, which does not
+re-apply screens to fabric-forwarded traffic.
+
+**Fix.** Stage 9 (`stage_classify_fabric_ingress`, `afxdp/poll_stages.rs`)
+already sets `FABRIC_INGRESS_FLAG` on `meta.meta_flags` for a fabric-redirected
+packet. Stage 10 (`stage_screen_check`) now derives
+`skip_rate_flood = (meta.meta_flags & FABRIC_INGRESS_FLAG) != 0` and threads it
+into `ScreenState::check_packet_with_zone_id_opts` /
+`check_flowless_screens_opts` (`screen/mod.rs`). When set, the screen runtime
+runs the **stateless** per-packet screens (land, ping-of-death, teardrop,
+icmp-fragment, source-route — idempotent, so re-running them on the owner is
+correct) and then returns before the **rate-based** flood counters, so the
+owner never re-counts the packet. The per-destination flood sketches (#4132) are
+left intact — the fix skips the re-count, it does not disable the screen. The
+per-`(zone, src)` **scan/sweep** new-flow counter is skipped the same way at the
+session-miss decision in `poll_descriptor/mod.rs` (gated on
+`packet_fabric_ingress`), for the sync-race window in which a fabric-redirected
+packet arrives before its synced session installs; the per-IP session-limit
+check there still runs because it guards the owner's own `SessionTable`, which
+the ingress node did not populate.
+
+The flood screen therefore fires **once**, on the true cluster-ingress node.
+RED-on-revert coverage: `screen/tests.rs`
+(`fabric_skip_does_not_count_{icmp,udp,syn}_flood_4155`,
+`fabric_skip_leaves_direct_ingress_counting_intact_4155`, plus the stateless
+scope guards) and `afxdp/poll_stages.rs`
+(`fabric_ingress_skips_rate_flood_direct_still_counts_4155`, driving the live
+`stage_screen_check`).

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -246,6 +246,23 @@ sync.
     on the flow-present `check_packet_with_zone_id` path — unchanged, with no
     screen double-run on the flow path. A truncated/unparseable header fails
     CLOSED (drop), matching the flow path (`#2146`).
+  - **#4155 — no screen rate double-count on fabric-redirected traffic:**
+    a packet that ingressed the non-owner node was already screened there
+    before being fabric-redirected to the RG owner (`docs/fabric-cross-chassis-fwd.md`).
+    Stage 9 sets `FABRIC_INGRESS_FLAG` on `meta.meta_flags`; `stage_screen_check`
+    now derives `skip_rate_flood` from it and threads it into
+    `check_packet_with_zone_id_opts` / `check_flowless_screens_opts`. When set,
+    the stateless per-packet screens (land, ping-of-death, teardrop,
+    icmp-fragment, source-route) still run on the owner — they are idempotent —
+    but the RATE-based flood counters (icmp/udp/syn-flood + SYN-cookie) are
+    skipped so the same packet is not counted twice against the per-zone /
+    per-destination thresholds (which would false-trip a flood Drop on a legit
+    synced session). The per-`(zone, src)` scan/sweep new-flow counter is
+    skipped the same way (`packet_fabric_ingress`) at the session-miss decision
+    in `poll_descriptor.rs`; the per-IP session-limit check there still runs.
+    The per-destination flood sketches (#4132) are untouched — the fix skips the
+    re-count, it does not disable the screen. vSRX parity: screens fire once, on
+    the true cluster-ingress node.
   - **#3291 — zone policy / input filter / PBR on the flowless TRANSIT
     arm:** #3064 restored only the *screen* engine on the flowless path;
     zone security policy, the interface input filter, and firewall-filter

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -259,7 +259,7 @@ sync.
     per-destination thresholds (which would false-trip a flood Drop on a legit
     synced session). The per-`(zone, src)` scan/sweep new-flow counter is
     skipped the same way (`packet_fabric_ingress`) at the session-miss decision
-    in `poll_descriptor.rs`; the per-IP session-limit check there still runs.
+    in `poll_descriptor/mod.rs`; the per-IP session-limit check there still runs.
     The per-destination flood sketches (#4132) are untouched — the fix skips the
     re-count, it does not disable the screen. vSRX parity: screens fire once, on
     the true cluster-ingress node.

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -1780,14 +1780,28 @@ pub(super) fn poll_binding_process_descriptor(
                             l3_off,
                         )
                         .unwrap_or_else(|_| screen_parse_error_info(&meta, flow));
-                        let new_flow_screen_reason = screen
-                            .scan_sweep_drop_on_new_flow(
+                        let new_flow_screen_reason = (if packet_fabric_ingress {
+                            // #4155: a fabric-redirected packet was already
+                            // scan/sweep-screened on the peer ingress node
+                            // before it crossed the fabric link. In the
+                            // session-sync race window it can arrive here as a
+                            // session MISS; re-running the per-(zone,src)
+                            // scan/sweep counter on the RG owner would
+                            // double-count the same new flow. The ingress node
+                            // owns scan/sweep for this packet — skip it here.
+                            // (Session-limit enforcement below still runs: it
+                            // guards the owner's own SessionTable, which the
+                            // ingress node did not populate.)
+                            None
+                        } else {
+                            screen.scan_sweep_drop_on_new_flow(
                                 from_zone,
                                 from_zone_id,
                                 &screen_pkt,
                                 now_secs,
                             )
-                            // #2134: per-IP session-limit enforcement at the
+                        })
+                        // #2134: per-IP session-limit enforcement at the
                             // new-flow decision. This dominates BOTH counted
                             // install sites below (LocalMiss host-inbound and
                             // ForwardFlow transit), fires exactly once per new

--- a/userspace-dp/src/afxdp/poll_stages.rs
+++ b/userspace-dp/src/afxdp/poll_stages.rs
@@ -376,6 +376,15 @@ pub(super) fn stage_screen_check(
     if !screen.has_profiles() {
         return StageOutcome::Continue(ScreenCheckOutcome::Pass);
     }
+    // #4155: a fabric-redirected packet (stage 9 set FABRIC_INGRESS_FLAG on
+    // `meta.meta_flags`) was already rate-screened on the peer ingress node
+    // before it crossed the fabric link. Skip the rate-based flood counters
+    // (icmp/udp/syn-flood) on the RG owner so the same packet is not counted
+    // twice against the per-zone / per-destination flood thresholds — a legit
+    // high-pps synced session would otherwise false-trip a flood Drop and
+    // defeat fabric cross-chassis forwarding. The stateless per-packet screens
+    // still run (idempotent). See docs/fabric-cross-chassis-fwd.md.
+    let skip_rate_flood = (meta.meta_flags & FABRIC_INGRESS_FLAG) != 0;
     // Zone resolution is flow-INDEPENDENT: it is keyed on the packet's
     // ingress context (logical ifindex / VLAN / fabric override), not on the
     // transport flow. Resolving it BEFORE branching on `flow` lets the
@@ -486,7 +495,13 @@ pub(super) fn stage_screen_check(
                 return StageOutcome::RecycleAndContinue;
             }
         };
-        return match screen.check_flowless_screens(zone_name, &screen_pkt, addrs_known, now_secs) {
+        return match screen.check_flowless_screens_opts(
+            zone_name,
+            &screen_pkt,
+            addrs_known,
+            now_secs,
+            skip_rate_flood,
+        ) {
             ScreenVerdict::Drop(reason) => {
                 emit_screen_drop_event(
                     worker_ctx.event_stream,
@@ -539,7 +554,8 @@ pub(super) fn stage_screen_check(
             return StageOutcome::RecycleAndContinue;
         }
     };
-    let verdict = screen.check_packet_with_zone_id(zone_name, zone_id, &screen_pkt, now_secs);
+    let verdict = screen
+        .check_packet_with_zone_id_opts(zone_name, zone_id, &screen_pkt, now_secs, skip_rate_flood);
     // #3315: drain a pending SYN-flood alarm (alarm-threshold crossed below
     // attack-threshold). Like scan-table-pressure this is a log-only PERMIT
     // alarm — it does NOT drop and is rate-limited to ≤1/sec/zone in the screen
@@ -2541,6 +2557,79 @@ mod tests {
             !dropped && drops == 0,
             "regression: a benign non-fragmented packet still passes the \
              flow path with no false positive"
+        );
+    }
+
+    /// Zone `lan` screen arming ONLY the UDP flood counter (per-zone /
+    /// per-destination), threshold `n`. Used to prove the #4155 fabric skip:
+    /// a fabric-redirected packet must NOT tick this counter on the owner.
+    fn udp_flood_screen(n: u32) -> ScreenState {
+        let mut profiles = FxHashMap::default();
+        profiles.insert(
+            "lan".to_string(),
+            ScreenProfile {
+                udp_flood_threshold: n,
+                ..ScreenProfile::default()
+            },
+        );
+        let mut screen = ScreenState::new();
+        screen.update_profiles(profiles);
+        screen
+    }
+
+    /// #4155 fail-on-revert (integration, flood double-count): drive the LIVE
+    /// `stage_screen_check` with a benign flowless non-first UDP fragment on
+    /// zone `lan` well past a UDP flood threshold of 2, once with a
+    /// FABRIC-INGRESS meta (`meta_flags = FABRIC_INGRESS_FLAG`, as stage 9
+    /// sets for a fabric-redirected packet) and once with a DIRECT-ingress
+    /// meta. The fabric packet must NEVER drop (the ingress node already
+    /// counted it; the owner must not re-count), while the direct packet
+    /// crosses the threshold and drops. Reverting the
+    /// `skip_rate_flood`/`FABRIC_INGRESS_FLAG` gate re-counts the fabric
+    /// packet and turns the fabric-Pass assertion RED.
+    #[test]
+    fn fabric_ingress_skips_rate_flood_direct_still_counts_4155() {
+        // frag_off field 185 (offset 1480 bytes, MF=0) → benign non-first
+        // tail fragment: flowless (#2344) and trips no L3 fragment screen
+        // (payload 100 ≥ 8; 1480 + 120 < 65535). Only the source-independent
+        // UDP flood counter can act on it.
+        const FRAG_PROTO_UDP: u8 = 17;
+        let frame = ipv4_fragment_frame(0x00B9, FRAG_PROTO_UDP, 100);
+        let direct_meta = ipv4_fragment_meta(&frame, FRAG_PROTO_UDP);
+        assert!(
+            parse_session_flow_from_bytes(&frame, direct_meta).is_none(),
+            "benign non-first fragment must be flowless so the flowless \
+             screen path (with the rate flood counter) runs"
+        );
+        let mut fabric_meta = direct_meta;
+        fabric_meta.meta_flags |= FABRIC_INGRESS_FLAG;
+
+        // Fabric-redirected: the owner must NOT tick the UDP flood counter,
+        // so the packet passes on every iteration regardless of rate.
+        let mut fab_screen = udp_flood_screen(2);
+        for i in 0..8 {
+            let (dropped, drops) = run_stage_screen(&mut fab_screen, &frame, fabric_meta, None);
+            assert!(
+                !dropped && drops == 0,
+                "iteration {i}: a FABRIC-redirected packet was already \
+                 flood-screened on the ingress node; the owner must not \
+                 re-count it (double-count would false-trip udp-flood)"
+            );
+        }
+
+        // Direct ingress on the SAME zone: the counter runs and the third
+        // packet (threshold 2) drops — proving the skip is scoped to fabric
+        // traffic and the flood screen still protects direct ingress at the
+        // CORRECT count (not halved by a phantom fabric double-count).
+        let mut direct_screen = udp_flood_screen(2);
+        let (d1, c1) = run_stage_screen(&mut direct_screen, &frame, direct_meta, None);
+        let (d2, c2) = run_stage_screen(&mut direct_screen, &frame, direct_meta, None);
+        let (d3, c3) = run_stage_screen(&mut direct_screen, &frame, direct_meta, None);
+        assert!(!d1 && c1 == 0, "1st direct packet under threshold passes");
+        assert!(!d2 && c2 == 0, "2nd direct packet at threshold passes");
+        assert!(
+            d3 && c3 == 1,
+            "3rd direct packet crosses udp-flood threshold 2 and DROPS"
         );
     }
 }

--- a/userspace-dp/src/screen/mod.rs
+++ b/userspace-dp/src/screen/mod.rs
@@ -659,6 +659,29 @@ impl ScreenState {
         pkt: &ScreenPacketInfo,
         now_secs: u64,
     ) -> ScreenVerdict {
+        self.check_packet_with_zone_id_opts(zone, zone_id, pkt, now_secs, false)
+    }
+
+    /// As `check_packet_with_zone_id`, but `skip_rate_flood` suppresses the
+    /// rate-based flood counters (icmp/udp/syn-flood + SYN-cookie) while still
+    /// running the stateless per-packet screens.
+    ///
+    /// #4155: fabric-redirected traffic in a chassis cluster was already
+    /// rate-screened on the ingress node before it crossed the fabric link.
+    /// The RG owner must NOT re-run the rate counters on that same packet —
+    /// re-counting double-counts it against the per-zone / per-destination
+    /// flood thresholds, so a legit high-pps synced session can false-trip a
+    /// flood Drop and defeat fabric cross-chassis forwarding
+    /// (`docs/fabric-cross-chassis-fwd.md`). The caller passes
+    /// `skip_rate_flood = (meta.meta_flags & FABRIC_INGRESS_FLAG) != 0`.
+    pub fn check_packet_with_zone_id_opts(
+        &mut self,
+        zone: &str,
+        zone_id: u16,
+        pkt: &ScreenPacketInfo,
+        now_secs: u64,
+        skip_rate_flood: bool,
+    ) -> ScreenVerdict {
         // #2209 perf: borrow the profile instead of cloning it. The
         // stateless/rate checks below read `self.profiles` immutably while
         // mutating disjoint per-zone counter fields (`icmp_counters`,
@@ -699,6 +722,25 @@ impl ScreenState {
         }
         if let Some(reason) = stateless::check_source_route(profile, pkt) {
             return ScreenVerdict::Drop(reason);
+        }
+
+        // #4155: fabric-redirected traffic was already rate-screened on the
+        // ingress node before it crossed the fabric link. Skip the rate-based
+        // flood counters (icmp/udp/syn-flood + SYN-cookie) so the same packet
+        // is not counted a SECOND time against the per-zone / per-destination
+        // flood thresholds on the RG owner. Re-counting would let a legit
+        // high-pps synced session false-trip a flood Drop, dropping exactly
+        // the traffic fabric cross-chassis forwarding exists to protect during
+        // failback / asymmetric-routing windows (vSRX does not re-screen
+        // fabric-forwarded traffic). The stateless per-packet screens above
+        // already ran and are idempotent; only the RATE counters must fire
+        // once, on the true ingress node. The per-destination flood sketches
+        // (#4132) are left intact — this skips the re-count, it does not
+        // disable the screen. A `SynCookieBypass` verdict is likewise
+        // suppressed: a fabric-redirected SYN belongs to a session the peer
+        // already admitted, so the owner mints no cookie challenge/bypass.
+        if skip_rate_flood {
+            return ScreenVerdict::Pass;
         }
 
         // --- Rate-based flood checks ---
@@ -966,6 +1008,24 @@ impl ScreenState {
         addrs_known: bool,
         now_secs: u64,
     ) -> ScreenVerdict {
+        self.check_flowless_screens_opts(zone, pkt, addrs_known, now_secs, false)
+    }
+
+    /// As `check_flowless_screens`, but `skip_rate_flood` suppresses the
+    /// source-independent rate-based flood counters (icmp/udp-flood) while
+    /// still running the stateless source-independent screens.
+    ///
+    /// #4155: a fabric-redirected non-first fragment / non-query ICMP control
+    /// message was already rate-screened on the ingress node; the RG owner
+    /// must not re-count it. See `check_packet_with_zone_id_opts`.
+    pub(crate) fn check_flowless_screens_opts(
+        &mut self,
+        zone: &str,
+        pkt: &ScreenPacketInfo,
+        addrs_known: bool,
+        now_secs: u64,
+        skip_rate_flood: bool,
+    ) -> ScreenVerdict {
         let Some(profile) = self.profiles.get(zone) else {
             // #3908: mirror the flow-present `check_packet_with_zone_id` None
             // branch so the flowless path is as observable as the flow path.
@@ -997,6 +1057,13 @@ impl ScreenState {
         }
         if let Some(reason) = stateless::check_source_route(profile, pkt) {
             return ScreenVerdict::Drop(reason);
+        }
+        // #4155: fabric-redirected flowless traffic was already rate-screened
+        // on the ingress node — skip the re-count (see
+        // `check_packet_with_zone_id_opts`). Stateless source-independent
+        // screens above already ran and are idempotent.
+        if skip_rate_flood {
+            return ScreenVerdict::Pass;
         }
         // --- Rate-based flood checks (source-independent, per-zone) ---
         // Copy the scalar thresholds out so the immutable `self.profiles`

--- a/userspace-dp/src/screen/tests.rs
+++ b/userspace-dp/src/screen/tests.rs
@@ -4685,3 +4685,156 @@ fn flowless_clean_non_first_fragment_passes() {
         ScreenVerdict::Pass
     );
 }
+
+// ================================================================
+// #4155: fabric-redirected traffic must NOT re-run the rate-based
+// flood counters on the RG owner (already screened on ingress).
+// The `_opts(..., skip_rate_flood = true)` entry points model the
+// FABRIC_INGRESS_FLAG path; the stateless screens still run.
+// ================================================================
+
+#[test]
+fn fabric_skip_does_not_count_icmp_flood_4155() {
+    // RED-on-revert: with skip_rate_flood=true the per-zone/per-dst ICMP
+    // flood counter must NOT tick, so an ICMP stream well past threshold 2
+    // keeps passing. Reverting the skip lets the counter run and the 3rd
+    // packet Drops → this Pass assertion goes RED.
+    let mut profile = ScreenProfile::default();
+    profile.icmp_flood_threshold = 2;
+    let mut state = make_state("trust", profile);
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+    for i in 0..8 {
+        assert_eq!(
+            state.check_packet_with_zone_id_opts("trust", 3, &icmp_pkt(src, dst, 84), 100, true),
+            ScreenVerdict::Pass,
+            "fabric-redirected ICMP #{i} must not be re-counted on the owner"
+        );
+    }
+}
+
+#[test]
+fn fabric_skip_does_not_count_udp_flood_4155() {
+    let mut profile = ScreenProfile::default();
+    profile.udp_flood_threshold = 2;
+    let mut state = make_state("trust", profile);
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+    for i in 0..8 {
+        let mut pkt = udp_pkt(src, dst);
+        pkt.dst_ip = dst;
+        assert_eq!(
+            state.check_packet_with_zone_id_opts("trust", 3, &pkt, 100, true),
+            ScreenVerdict::Pass,
+            "fabric-redirected UDP #{i} must not be re-counted on the owner"
+        );
+    }
+}
+
+#[test]
+fn fabric_skip_does_not_count_syn_flood_4155() {
+    // A fabric-redirected SYN belongs to a session the peer already admitted:
+    // the owner must neither count it toward syn-flood nor mint a cookie.
+    let mut profile = ScreenProfile::default();
+    profile.syn_flood_threshold = 2;
+    let mut state = make_state("trust", profile);
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+    for i in 0..8 {
+        let pkt = tcp_pkt(src, dst, 1234 + i, 80, TCP_SYN);
+        assert_eq!(
+            state.check_packet_with_zone_id_opts("trust", 3, &pkt, 100, true),
+            ScreenVerdict::Pass,
+            "fabric-redirected SYN #{i} must not be re-counted (no syn-flood, no cookie)"
+        );
+    }
+}
+
+#[test]
+fn fabric_skip_still_runs_stateless_land_4155() {
+    // Scope guard: the skip is RATE-only. A stateless LAND attack must still
+    // Drop on a fabric-redirected packet (idempotent per-packet check).
+    let mut state = make_state("trust", default_profile());
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let pkt = tcp_pkt(src, src, 80, 80, TCP_SYN);
+    assert_eq!(
+        state.check_packet_with_zone_id_opts("trust", 3, &pkt, 1, true),
+        ScreenVerdict::Drop("land-attack"),
+        "stateless LAND must still fire on fabric traffic"
+    );
+}
+
+#[test]
+fn fabric_skip_flowless_does_not_count_icmp_flood_4155() {
+    let mut profile = ScreenProfile::default();
+    profile.icmp_flood_threshold = 2;
+    let mut state = make_state("trust", profile);
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+    for i in 0..8 {
+        assert_eq!(
+            state.check_flowless_screens_opts("trust", &flowless_icmp_pkt(src, dst), true, 100, true),
+            ScreenVerdict::Pass,
+            "fabric-redirected flowless ICMP #{i} must not be re-counted"
+        );
+    }
+}
+
+#[test]
+fn fabric_skip_flowless_still_runs_teardrop_4155() {
+    // Scope guard on the flowless path: stateless fragment screens still run.
+    let mut profile = ScreenProfile::default();
+    profile.teardrop = true;
+    let mut state = make_state("trust", profile);
+    let mut pkt = flowless_nonfirst_fragment(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+        PROTO_UDP,
+    );
+    pkt.ip_frag_off = 0x0001; // offset 1 unit (non-first)
+    pkt.ip_total_len = 24; // 20-byte header + 4-byte payload (< 8) → teardrop
+    assert_eq!(
+        state.check_flowless_screens_opts("trust", &pkt, true, 1, true),
+        ScreenVerdict::Drop("teardrop"),
+        "stateless teardrop must still fire on fabric flowless traffic"
+    );
+}
+
+#[test]
+fn fabric_skip_leaves_direct_ingress_counting_intact_4155() {
+    // The skip is scoped to fabric traffic: a burst of fabric-redirected ICMP
+    // must NOT advance the counter, so a subsequent DIRECT-ingress stream
+    // reaches the flood threshold at the CORRECT count (threshold + 1), not
+    // halved by a phantom fabric double-count.
+    let mut profile = ScreenProfile::default();
+    profile.icmp_flood_threshold = 3;
+    let mut state = make_state("trust", profile);
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+    // 5 fabric packets — none may count.
+    for _ in 0..5 {
+        assert_eq!(
+            state.check_packet_with_zone_id_opts("trust", 3, &icmp_pkt(src, dst, 84), 100, true),
+            ScreenVerdict::Pass
+        );
+    }
+    // Direct ingress: 3 pass (threshold 3), 4th drops. If fabric packets had
+    // polluted the counter the drop would come EARLY (RED-on-revert of scope).
+    assert_eq!(
+        state.check_packet_with_zone_id_opts("trust", 3, &icmp_pkt(src, dst, 84), 100, false),
+        ScreenVerdict::Pass
+    );
+    assert_eq!(
+        state.check_packet_with_zone_id_opts("trust", 3, &icmp_pkt(src, dst, 84), 100, false),
+        ScreenVerdict::Pass
+    );
+    assert_eq!(
+        state.check_packet_with_zone_id_opts("trust", 3, &icmp_pkt(src, dst, 84), 100, false),
+        ScreenVerdict::Pass
+    );
+    assert_eq!(
+        state.check_packet_with_zone_id_opts("trust", 3, &icmp_pkt(src, dst, 84), 100, false),
+        ScreenVerdict::Drop("icmp-flood"),
+        "direct ingress reaches the flood threshold at the correct count"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #4155 (fable-review-164 M-4).

In a chassis cluster, a packet that ingresses the **non-owner** node is screened
there and then fabric-redirected to the RG **owner** (the fabric cross-chassis
forwarding path, `docs/fabric-cross-chassis-fwd.md`). The owner re-ran
`stage_screen_check` on that redirected packet, so the **rate-based flood
counters** (`icmp-flood`, `udp-flood`, `syn-flood`) counted the **same packet a
second time** against the per-zone / per-destination flood thresholds. A
legitimate high-pps synced session could then false-trip a flood `Drop` on the
owner — dropping exactly the traffic fabric forwarding exists to protect during
failback / asymmetric-routing windows. vSRX does not re-apply screens to
fabric-forwarded traffic.

## Fix

Stage 9 (`stage_classify_fabric_ingress`) already sets `FABRIC_INGRESS_FLAG` on
`meta.meta_flags` for a fabric-redirected packet. Stage 10
(`stage_screen_check`) now derives
`skip_rate_flood = (meta.meta_flags & FABRIC_INGRESS_FLAG) != 0` and threads it
into two new `ScreenState` entry points, `check_packet_with_zone_id_opts` and
`check_flowless_screens_opts` (the existing signatures become thin wrappers
passing `false`, so the ~55 existing callers/tests are untouched).

When `skip_rate_flood` is set, the runtime:
- **still runs** the stateless per-packet screens (land, ping-of-death,
  teardrop, icmp-fragment, source-route) — they are idempotent, so re-running
  them on the owner is correct;
- **returns `Pass` before** the rate-based flood counters (icmp/udp/syn-flood +
  SYN-cookie), so the owner never re-counts the packet.

The per-`(zone, src)` **scan/sweep** new-flow counter is skipped the same way
(gated on `packet_fabric_ingress`) at the session-miss decision in
`poll_descriptor`, for the sync-race window in which a fabric-redirected packet
arrives before its synced session installs; the per-IP session-limit check there
still runs because it guards the owner's own `SessionTable`, which the ingress
node did not populate.

Scoped to the **rate-based** counters only — the per-destination flood sketches
(#4132) are untouched. The fix skips the re-count, it does not disable the
screen. The flood screen fires **once**, on the true cluster-ingress node.

## Files

- `userspace-dp/src/screen/mod.rs` — `check_packet_with_zone_id_opts` /
  `check_flowless_screens_opts` with the `skip_rate_flood` gate after the
  stateless block.
- `userspace-dp/src/afxdp/poll_stages.rs` — `stage_screen_check` derives
  `skip_rate_flood` from `FABRIC_INGRESS_FLAG` and threads it through.
- `userspace-dp/src/afxdp/poll_descriptor/mod.rs` — scan/sweep skip on
  `packet_fabric_ingress`.
- Tests + docs (`docs/fabric-cross-chassis-fwd.md`, afxdp README, `_Log.md`).

## Tests (RED-on-revert)

7 screen-runtime unit tests + 1 poll_stages integration test driving the live
`stage_screen_check`:
- fabric-redirected icmp/udp/syn floods above threshold never drop on the owner;
- flowless path covered;
- **scope guards** — a stateless LAND and a flowless teardrop still `Drop` on
  fabric traffic (skip is rate-only);
- a burst of fabric packets does not pollute the counter, so a subsequent
  direct-ingress stream reaches the flood threshold at the **correct** count
  (threshold + 1), not halved.

Verified RED-on-revert by neutering both gates: the six rate-flood tests go RED
(double-count → false Drop) while the two stateless-scope guards stay green.

## Validation

- FULL `cargo test --release` (single-threaded): **3523 passed / 0 failed** in
  the main binary (+ all integration binaries green).
- `go build ./...` clean.

## test-failover note

This change touches the HA fabric-redirect ingress path + screens. A
`make test-failover` on the loss userspace cluster is warranted before merge to
confirm no failover regression (the reviewer/merger may batch it with other HA
fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi