### PR TITLE
nat: source-NAT rule-set precedence most-specific-scope-wins (#4161 + L-9)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,44 @@
+## 2026-07-04 — #4161 (fable-review-164 M-3) + L-9: source-NAT most-specific-scope-wins
+
+- **Timestamp**: 2026-07-04
+  - **Action**: Source-NAT rule-set precedence was config-order
+    first-match, scope-BLIND to specificity — a broader-scope rule-set
+    defined earlier in the config won over a more-specific rule-set
+    defined later, so a vSRX-correct config could pick the wrong
+    translation (or bypass a more-specific `then source-nat off`
+    exemption) purely from text ordering.
+  - **Fix**: STABLE-sort the emitted `SourceNATRuleSnapshot` slice by
+    Junos context tier in `buildSourceNATSnapshotsWithFeeds`
+    (`pkg/dataplane/userspace/nat.go`) — interface=0, zone=1,
+    routing-instance=2, unscoped=3, `tier = MIN(from-tier, to-tier)`
+    when a rule-set carries both a `from` and a `to` context. Same-tier
+    ties keep config order (stable sort → within-rule-set order + no
+    interleaving). Tier is a pure function of the six scope fields
+    already stamped since #3096; no new wire plumbing. The Rust matcher
+    (`nat/source.rs match_source_nat_result_for_tuple`) is left as a
+    first-match loop — a tier-sorted Vec makes first-match ==
+    most-specific-match. Comments added at both the Go sort site and the
+    Rust loop record that precedence now lives in the snapshot ORDER.
+    New helpers `sourceNATScopeTier` / `scopeContextTier` + tier consts.
+  - **L-9 test-gap (paired)**: `nat_scope_precedence_4161_test.go` —
+    tier-value table (incl. from-vs-to MIN), interface-defined-LAST
+    still wins (the finding's own trace), full
+    interface>zone>routing-instance>unscoped ordering declared in
+    reverse, same-tier config-order + rule contiguity, from-vs-to MIN
+    wins, and single-scope identity (existing configs unaffected).
+    Verified RED-on-revert: removing the sort turns the ordering tests
+    RED (`[rs-zone rs-if]`, `[rs-unscoped rs-ri rs-zone rs-if]`); the
+    tier-value + identity tests stay green. `go test ./pkg/dataplane/...`
+    green; `go build ./...`, gofmt, vet clean.
+  - **Scope note**: SNAT only. DNAT (`destination.rs match_entries`) and
+    static (`static_nat.rs pick_scoped`) tier only zone-scoped-vs-zone-
+    wildcard — the same latent interface-vs-zone gap — a SEPARATE
+    out-of-scope follow-up.
+  - **File(s)**: pkg/dataplane/userspace/nat.go,
+    pkg/dataplane/userspace/nat_scope_precedence_4161_test.go,
+    userspace-dp/src/nat/source.rs,
+    docs/userspace-dataplane-architecture.md, _Log.md
+
 ## 2026-07-04 — #4157 (fable-review-164 L-6): constant-time API-key/Bearer/username auth
 
 - **Timestamp**: 2026-07-04

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -652,6 +652,25 @@ the NAT module applies it:
   helper restart does not. #1449 closes HA behavior as an explicit userspace
   capability gate: HA configs using persistent source-NAT pools are not
   admitted because persistent leases are not synchronized.
+- **Rule-set precedence — most-specific-scope-wins (#4161).** When several
+  source-NAT rule-sets overlap on a flow, selection follows Junos: the rule-set
+  whose match CONTEXT is most specific wins — **interface > zone >
+  routing-instance > unscoped** — and only THEN does within-rule-set rule order
+  apply. This is NOT config-order first-match. The Rust matcher
+  (`match_source_nat_result_for_tuple`, `nat/source.rs`) is a first-match loop
+  over the published slice; precedence is achieved entirely on the Go side by
+  **stable-sorting** the emitted `SourceNATRuleSnapshot` slice by context tier
+  in `buildSourceNATSnapshotsWithFeeds` (`pkg/dataplane/userspace/nat.go`)
+  before publishing, so "first match" == "most-specific match". The tier is a
+  pure function of the six scope fields already carried since #3096
+  (From/To Zone/Interface/RoutingInstance); a rule-set carrying both a `from`
+  and a `to` context of different kinds is ranked by the MORE-specific of the
+  two (`tier = MIN(from-tier, to-tier)`, the vSRX default). Same-tier ties keep
+  config order (stable sort), and each rule-set's rules stay contiguous, so
+  rule-sets never interleave. This aligns SNAT with the DNAT/static
+  most-specific-wins DIRECTION, though those two tables currently rank only
+  zone-scoped-vs-zone-wildcard (a narrower axis that does not yet rank interface
+  above zone) — extending the full hierarchy to them is a tracked follow-up.
 - **Checksum update:** Incremental RFC 1624 checksum adjustment for
   IP header + TCP/UDP pseudo-header. Avoids full recomputation.
 

--- a/pkg/dataplane/userspace/nat.go
+++ b/pkg/dataplane/userspace/nat.go
@@ -272,7 +272,73 @@ func buildSourceNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map[stri
 			})
 		}
 	}
+	// #4161: Junos source-NAT rule-set precedence is MOST-SPECIFIC-SCOPE-WINS,
+	// not config-order first-match. Among overlapping rule-sets whose scopes
+	// all match a flow, Junos selects by the specificity of the match context
+	// — interface > zone > routing-instance (interface most specific) — and
+	// only then applies within-set rule order. The Rust matcher
+	// (userspace-dp/src/nat/source.rs match_source_nat_result_for_tuple) is
+	// first-match on slice order, so we make "first match" == "most-specific
+	// match" by STABLE-sorting the emitted snapshot by context tier here. A
+	// stable sort keeps config order WITHIN a tier (Junos within-rule-set order
+	// plus equal-specificity rule-set-definition order) and keeps each
+	// rule-set's rules contiguous, so rule-sets never interleave. The tier is a
+	// pure function of the six scope fields already stamped above — no new wire
+	// plumbing (they were carried since #3096). This is why the Rust first-match
+	// loop is deliberately left unchanged: it reads a pre-tiered Vec.
+	//
+	// Scope note: DNAT (destination.rs match_entries) and static
+	// (static_nat.rs pick_scoped) tier only zone-SCOPED vs zone-WILDCARD — a
+	// narrower axis that does NOT rank interface above zone. Extending this full
+	// interface>zone>routing-instance hierarchy to them is a separate,
+	// out-of-scope follow-up.
+	sort.SliceStable(out, func(i, j int) bool {
+		return sourceNATScopeTier(out[i]) < sourceNATScopeTier(out[j])
+	})
 	return out
+}
+
+// Source-NAT context-specificity tiers (#4161). LOWER = more specific = higher
+// precedence, matching Junos rule-set selection (interface most specific).
+const (
+	snatTierInterface       = 0
+	snatTierZone            = 1
+	snatTierRoutingInstance = 2
+	snatTierUnscoped        = 3
+)
+
+// sourceNATScopeTier returns the Junos context-specificity tier of a
+// source-NAT rule-set snapshot (#4161). A rule-set may carry both a `from` and
+// a `to` context, and they may be of different kinds; either context narrows
+// the match, so the MORE-SPECIFIC of the two governs the rule-set's
+// precedence: tier = MIN(from-tier, to-tier). This MIN default is the
+// vSRX-pinned semantic (confirmed by the L-9 overlap tests).
+func sourceNATScopeTier(s SourceNATRuleSnapshot) int {
+	from := scopeContextTier(s.FromInterface, s.FromZone, s.FromRoutingInstance)
+	to := scopeContextTier(s.ToInterface, s.ToZone, s.ToRoutingInstance)
+	if to < from {
+		return to
+	}
+	return from
+}
+
+// scopeContextTier maps a single from/to context to its specificity tier
+// (#4161): interface=0, zone=1, routing-instance=2, none/wildcard=3. A Junos
+// from/to clause names exactly one kind of context; a hostile config that sets
+// more than one is ranked by its most-specific present field (the Rust
+// scope_matches AND-filters every set field regardless, so this only affects
+// precedence, never eligibility).
+func scopeContextTier(iface, zone, routingInstance string) int {
+	switch {
+	case iface != "":
+		return snatTierInterface
+	case zone != "":
+		return snatTierZone
+	case routingInstance != "":
+		return snatTierRoutingInstance
+	default:
+		return snatTierUnscoped
+	}
 }
 
 // natProtoAny is the source-NAT match-term protocol wildcard, mirroring the

--- a/pkg/dataplane/userspace/nat.go
+++ b/pkg/dataplane/userspace/nat.go
@@ -323,11 +323,28 @@ func sourceNATScopeTier(s SourceNATRuleSnapshot) int {
 }
 
 // scopeContextTier maps a single from/to context to its specificity tier
-// (#4161): interface=0, zone=1, routing-instance=2, none/wildcard=3. A Junos
-// from/to clause names exactly one kind of context; a hostile config that sets
-// more than one is ranked by its most-specific present field (the Rust
-// scope_matches AND-filters every set field regardless, so this only affects
-// precedence, never eligibility).
+// (#4161): interface=0, zone=1, routing-instance=2.
+//
+// The wildcard / match-any context is the EMPTY string on every axis (all
+// three args ""), which falls through to snatTierUnscoped (3). That empty
+// value is exactly what the compiler emits for an absent `from`/`to` clause:
+// collectNATScopes (pkg/config/compiler_nat.go:1083-1088) defaults a missing
+// side to {kind:"zone", value:""} → FromZone/ToZone "" — the legacy
+// global/match-any scope. So "wildcard" here means empty, NOT a zone named
+// "any": a NON-EMPTY zone (tier 1) is always a SPECIFIC zone, and a literal
+// `from zone any` is FromZone="any", a specific zone literally named "any", not
+// a wildcard. This is CONSISTENT with the Rust eligibility check
+// (source.rs scope_matches: `!from_zone.is_empty() && from_zone != ingress`),
+// which only special-cases the empty string and matches "any" literally. NAT
+// rule-set from/to-contexts do NOT treat "any" as a wildcard (unlike security
+// policies' from-zone/to-zone). A future maintainer must not special-case
+// "any" as tier-unscoped — that would diverge from the matcher and mis-tier a
+// legitimately-named zone.
+//
+// A Junos from/to clause names exactly one kind of context; a hostile config
+// that sets more than one is ranked by its most-specific present field (the
+// Rust scope_matches AND-filters every set field regardless, so this only
+// affects precedence, never eligibility).
 func scopeContextTier(iface, zone, routingInstance string) int {
 	switch {
 	case iface != "":

--- a/pkg/dataplane/userspace/nat_scope_precedence_4161_test.go
+++ b/pkg/dataplane/userspace/nat_scope_precedence_4161_test.go
@@ -73,6 +73,19 @@ func TestSourceNATScopeTierValue(t *testing.T) {
 		{"ri-from", SourceNATRuleSnapshot{FromRoutingInstance: "VR1"}, snatTierRoutingInstance},
 		{"ri-to", SourceNATRuleSnapshot{ToRoutingInstance: "VR1"}, snatTierRoutingInstance},
 		{"unscoped", SourceNATRuleSnapshot{}, snatTierUnscoped},
+		// Wildcard / match-any is the EMPTY zone string (what the compiler
+		// emits for an absent from/to clause, compiler_nat.go collectNATScopes
+		// {kind:"zone", value:""}) — tiers UNSCOPED, so a match-any rule-set
+		// loses to any specifically-scoped one. This is the same shape as the
+		// bare `unscoped` case above but named to pin the wildcard==empty
+		// contract explicitly.
+		{"empty-zone-wildcard-is-unscoped", SourceNATRuleSnapshot{FromZone: "", ToZone: ""}, snatTierUnscoped},
+		// A literal zone NAMED "any" is a SPECIFIC zone, NOT a wildcard: it
+		// tiers as ZONE (1), consistent with the Rust scope_matches treating a
+		// non-empty from_zone literally. Guards against a future change that
+		// wrongly special-cases "any" as a wildcard (which would make it
+		// tier-unscoped and diverge from the matcher).
+		{"literal-zone-any-is-zone", SourceNATRuleSnapshot{FromZone: "any"}, snatTierZone},
 		// from-vs-to = MIN: from zone (1) + to interface (0) => 0.
 		{"from-zone-to-interface-min0", SourceNATRuleSnapshot{FromZone: "trust", ToInterface: "ge-0/0/2.0"}, snatTierInterface},
 		// from routing-instance (2) + to zone (1) => 1.

--- a/pkg/dataplane/userspace/nat_scope_precedence_4161_test.go
+++ b/pkg/dataplane/userspace/nat_scope_precedence_4161_test.go
@@ -1,0 +1,199 @@
+// #4161 (fable-review-164 M-3, paired L-9 test-gap): source-NAT rule-set
+// precedence is Junos MOST-SPECIFIC-SCOPE-WINS, not config-order first-match.
+// These tests pin the tier ordering (interface > zone > routing-instance >
+// unscoped), the same-tier config-order tie-break, the from-vs-to MIN(tier)
+// combination edge, and the single-scope identity case. The Rust matcher
+// (userspace-dp/src/nat/source.rs) is first-match on slice order, so the Go
+// snapshot builder STABLE-sorts the emitted snapshot by context tier and the
+// FIRST matching rule becomes the most-specific one — meaning these
+// emission-order assertions ARE the precedence assertions.
+//
+// RED-on-revert: reverting the sort.SliceStable in
+// buildSourceNATSnapshotsWithFeeds turns
+// TestSourceNATInterfaceScopedRuleDefinedAfterZoneStillWins and
+// TestSourceNATScopeTierOrdering RED (config order would place the broader-
+// scope rule-set first).
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// snatRuleSet builds a source-NAT rule-set carrying the given scope with a
+// single interface-mode rule. The Match is left match-any: these tests assert
+// the emitted SNAPSHOT ORDER (the precedence contract the Rust first-match loop
+// reads), not the per-flow match, so the match terms are irrelevant.
+func snatRuleSet(name, fromZone, toZone, fromIf, toIf, fromRI, toRI string) *config.NATRuleSet {
+	return &config.NATRuleSet{
+		Name:                name,
+		FromZone:            fromZone,
+		ToZone:              toZone,
+		FromInterface:       fromIf,
+		ToInterface:         toIf,
+		FromRoutingInstance: fromRI,
+		ToRoutingInstance:   toRI,
+		Rules: []*config.NATRule{{
+			// Snapshot.Name carries the RULE name; name the sole rule after its
+			// rule-set so the emitted-order assertions read cleanly.
+			Name: name,
+			Then: config.NATThen{Type: config.NATSource, Interface: true},
+		}},
+	}
+}
+
+func snatOrder(t *testing.T, sets ...*config.NATRuleSet) []string {
+	t.Helper()
+	cfg := &config.Config{}
+	cfg.Security.NAT.Source = sets
+	snaps := buildSourceNATSnapshots(cfg, nil)
+	if len(snaps) != len(sets) {
+		t.Fatalf("len(snaps) = %d, want %d", len(snaps), len(sets))
+	}
+	names := make([]string, len(snaps))
+	for i, s := range snaps {
+		names[i] = s.Name
+	}
+	return names
+}
+
+// TestSourceNATScopeTierValue pins the pure tier function: interface=0, zone=1,
+// routing-instance=2, unscoped=3, and MIN(from,to) when both contexts are set.
+func TestSourceNATScopeTierValue(t *testing.T) {
+	cases := []struct {
+		name string
+		snap SourceNATRuleSnapshot
+		want int
+	}{
+		{"interface-from", SourceNATRuleSnapshot{FromInterface: "ge-0/0/1.0"}, snatTierInterface},
+		{"interface-to", SourceNATRuleSnapshot{ToInterface: "ge-0/0/2.0"}, snatTierInterface},
+		{"zone-from", SourceNATRuleSnapshot{FromZone: "trust"}, snatTierZone},
+		{"zone-to", SourceNATRuleSnapshot{ToZone: "untrust"}, snatTierZone},
+		{"ri-from", SourceNATRuleSnapshot{FromRoutingInstance: "VR1"}, snatTierRoutingInstance},
+		{"ri-to", SourceNATRuleSnapshot{ToRoutingInstance: "VR1"}, snatTierRoutingInstance},
+		{"unscoped", SourceNATRuleSnapshot{}, snatTierUnscoped},
+		// from-vs-to = MIN: from zone (1) + to interface (0) => 0.
+		{"from-zone-to-interface-min0", SourceNATRuleSnapshot{FromZone: "trust", ToInterface: "ge-0/0/2.0"}, snatTierInterface},
+		// from routing-instance (2) + to zone (1) => 1.
+		{"from-ri-to-zone-min1", SourceNATRuleSnapshot{FromRoutingInstance: "VR1", ToZone: "untrust"}, snatTierZone},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := sourceNATScopeTier(c.snap); got != c.want {
+				t.Fatalf("sourceNATScopeTier(%+v) = %d, want %d", c.snap, got, c.want)
+			}
+		})
+	}
+}
+
+// TestSourceNATInterfaceScopedRuleDefinedAfterZoneStillWins is the finding's
+// own trace and the RED-on-revert guard: an interface-scoped rule-set defined
+// textually AFTER a zone-scoped one still wins (emitted first) because
+// interface is the more specific context. On revert of the tier-sort the
+// zone-scoped set — first in config order — would be emitted first and win,
+// bypassing the more-specific `source-nat off` exemption. This is the L-9 gap.
+func TestSourceNATInterfaceScopedRuleDefinedAfterZoneStillWins(t *testing.T) {
+	// RS-ZONE first, RS-IF second (config order) — both match ge-0/0/1 in zone
+	// trust. Junos picks RS-IF (interface most specific).
+	order := snatOrder(t,
+		snatRuleSet("rs-zone", "trust", "", "", "", "", ""),
+		snatRuleSet("rs-if", "", "", "ge-0/0/1.0", "", "", ""),
+	)
+	if order[0] != "rs-if" {
+		t.Fatalf("interface-scoped rule must win over an earlier zone-scoped rule; emission order = %v, want rs-if first", order)
+	}
+}
+
+// TestSourceNATScopeTierOrdering pins the full hierarchy
+// interface > zone > routing-instance > unscoped. Rule-sets are declared in
+// REVERSE specificity order (least specific first) to prove the sort — not
+// config order — governs.
+func TestSourceNATScopeTierOrdering(t *testing.T) {
+	order := snatOrder(t,
+		snatRuleSet("rs-unscoped", "", "", "", "", "", ""),
+		snatRuleSet("rs-ri", "", "", "", "", "VR1", ""),
+		snatRuleSet("rs-zone", "trust", "", "", "", "", ""),
+		snatRuleSet("rs-if", "", "", "ge-0/0/1.0", "", "", ""),
+	)
+	want := []string{"rs-if", "rs-zone", "rs-ri", "rs-unscoped"}
+	for i, w := range want {
+		if order[i] != w {
+			t.Fatalf("tier ordering = %v, want %v", order, want)
+		}
+	}
+}
+
+// TestSourceNATScopeSameTierKeepsConfigOrder proves the stable-sort tie-break:
+// two equally-specific (both zone-scoped) rule-sets keep their config order,
+// and their rules stay contiguous (no interleaving).
+func TestSourceNATScopeSameTierKeepsConfigOrder(t *testing.T) {
+	order := snatOrder(t,
+		snatRuleSet("rs-a", "trust", "untrust-a", "", "", "", ""),
+		snatRuleSet("rs-b", "trust", "untrust-b", "", "", "", ""),
+	)
+	if order[0] != "rs-a" || order[1] != "rs-b" {
+		t.Fatalf("same-tier rule-sets must keep config order; got %v, want [rs-a rs-b]", order)
+	}
+}
+
+// TestSourceNATScopeSameTierMultiRuleStaysContiguous proves a rule-set's own
+// rules keep their within-set order and stay grouped after the sort, even when
+// a more-specific rule-set is spliced ahead of it.
+func TestSourceNATScopeSameTierMultiRuleStaysContiguous(t *testing.T) {
+	zoneSet := &config.NATRuleSet{
+		Name:     "rs-zone",
+		FromZone: "trust",
+		Rules: []*config.NATRule{
+			{Name: "z-r1", Then: config.NATThen{Type: config.NATSource, Interface: true}},
+			{Name: "z-r2", Then: config.NATThen{Type: config.NATSource, Interface: true}},
+		},
+	}
+	ifSet := snatRuleSet("rs-if", "", "", "ge-0/0/1.0", "", "", "")
+	cfg := &config.Config{}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{zoneSet, ifSet}
+	snaps := buildSourceNATSnapshots(cfg, nil)
+	got := make([]string, len(snaps))
+	for i, s := range snaps {
+		got[i] = s.Name
+	}
+	// interface rule-set (tier 0) first, then the zone rule-set's rules in
+	// their original within-set order (tier 1).
+	want := []string{"rs-if", "z-r1", "z-r2"}
+	for i, w := range want {
+		if got[i] != w {
+			t.Fatalf("rule ordering = %v, want %v (within-set order + contiguity)", got, want)
+		}
+	}
+}
+
+// TestSourceNATScopeFromVsToMinTierWins pins the from-vs-to combination edge:
+// a rule-set scoped `from zone trust` AND `to interface ge-0/0/2` is ranked by
+// the MORE-specific of the two contexts (interface, tier 0), so it wins over a
+// pure zone-scoped rule (tier 1) even when declared later.
+func TestSourceNATScopeFromVsToMinTierWins(t *testing.T) {
+	order := snatOrder(t,
+		snatRuleSet("rs-zone-only", "trust", "", "", "", "", ""),
+		snatRuleSet("rs-zone-and-egress-if", "trust", "", "", "ge-0/0/2.0", "", ""),
+	)
+	if order[0] != "rs-zone-and-egress-if" {
+		t.Fatalf("from-vs-to MIN(tier): a to-interface context must rank a rule above a pure-zone rule; got %v, want rs-zone-and-egress-if first", order)
+	}
+}
+
+// TestSourceNATScopeSingleScopeUnchanged proves the sort is an identity for a
+// config whose rule-sets are all the same specificity (the common case): order
+// is preserved bit-for-bit, so existing single-scope configs are unaffected.
+func TestSourceNATScopeSingleScopeUnchanged(t *testing.T) {
+	order := snatOrder(t,
+		snatRuleSet("rs-1", "trust", "untrust", "", "", "", ""),
+		snatRuleSet("rs-2", "dmz", "untrust", "", "", "", ""),
+		snatRuleSet("rs-3", "trust", "dmz", "", "", "", ""),
+	)
+	want := []string{"rs-1", "rs-2", "rs-3"}
+	for i, w := range want {
+		if order[i] != w {
+			t.Fatalf("single-tier config must be unchanged; got %v, want %v", order, want)
+		}
+	}
+}

--- a/userspace-dp/src/nat/source.rs
+++ b/userspace-dp/src/nat/source.rs
@@ -825,6 +825,14 @@ pub(crate) fn match_source_nat_result_for_tuple(
         src_port,
         dst_port,
     };
+    // #4161: this is first-match on slice order, and that is INTENTIONALLY
+    // most-specific-scope-wins. The Go snapshot builder
+    // (pkg/dataplane/userspace/nat.go buildSourceNATSnapshotsWithFeeds) STABLE-
+    // sorts the rule-sets by Junos context specificity (interface > zone >
+    // routing-instance > unscoped) before publishing, with config order as the
+    // tie-break, so the first rule that matches here is the most-specific one.
+    // Precedence therefore lives in the snapshot ORDER, not in this loop — do
+    // not re-sort or assume raw config order.
     for rule in rules {
         if !rule.matches(
             scope, from_zone, to_zone, src_ip, dst_ip, protocol, src_port, dst_port,


### PR DESCRIPTION
## Summary

Closes #4161 (fable-review-164 M-3) and closes the paired **L-9**
test-gap in the same PR.

Source-NAT rule-set precedence in xpf was **config-order first-match**,
scope-BLIND to specificity. Junos selects among overlapping source-NAT
rule-sets by the specificity of the match CONTEXT —
**interface > zone > routing-instance** (interface most specific) — and
only then applies within-set rule order. A broader-scope rule-set
defined earlier in the config won over a more-specific rule-set defined
later, so a vSRX-correct config could produce a different SNAT decision
here purely from text ordering, including bypass of a more-specific
`then source-nat off` exemption.

## Fix (Go-only, no hot-path / cargo change)

`buildSourceNATSnapshotsWithFeeds` (`pkg/dataplane/userspace/nat.go`) now
**stable-sorts** the emitted `SourceNATRuleSnapshot` slice by Junos
context tier before publishing:

- **Tier** = pure function of the six scope fields already stamped on
  every snapshot since #3096 (From/To Zone/Interface/RoutingInstance):
  `interface=0, zone=1, routing-instance=2, unscoped=3` (lower = more
  specific = wins). Helpers `sourceNATScopeTier` / `scopeContextTier`.
- **from-vs-to combination edge:** a rule-set carrying both a `from` and
  a `to` context of different kinds is ranked by the MORE-specific of
  the two — `tier = MIN(from-tier, to-tier)` — since either context
  narrows the match (the vSRX default the L-9 test pins).
- **Same-tier ties → config order** (stable sort preserves within-
  rule-set order and keeps each rule-set's rules contiguous, so
  rule-sets never interleave).

The Rust matcher (`match_source_nat_result_for_tuple`,
`userspace-dp/src/nat/source.rs`) is a first-match loop and is left
**unchanged**: a tier-sorted Vec makes "first match" == "most-specific
match". A comment at both the Go sort site and the Rust loop records
that precedence now lives in the snapshot ORDER.

The plan's option-1 (Go stable-sort) was chosen for minimal blast
radius — no hot-path change, no cargo.

## L-9 test-gap (paired)

`nat_scope_precedence_4161_test.go`:

- tier-value table incl. from-vs-to MIN,
- **interface-scoped rule defined LAST still wins** (the finding's own
  trace) — the RED-on-revert guard,
- full `interface > zone > routing-instance > unscoped` ordering
  declared in REVERSE specificity order,
- same-tier config-order + rule contiguity,
- from-vs-to MIN(tier) wins,
- single-scope identity (existing configs unaffected).

**RED-on-revert verified:** removing the `sort.SliceStable` turns the
four ordering tests RED (emission falls back to pure config order —
`[rs-zone rs-if]`, `[rs-unscoped rs-ri rs-zone rs-if]`); the tier-value
and identity tests stay green.

## Scope note (follow-up)

SNAT only. DNAT (`destination.rs match_entries`) and static
(`static_nat.rs pick_scoped`) tier only **zone-scoped vs zone-wildcard**
— a narrower axis that does NOT rank interface above zone, so they share
the same latent interface-vs-zone gap. A literal "mirror DNAT/static"
would NOT have fixed this finding's interface-vs-zone trace. Extending
the full `interface > zone > routing-instance` hierarchy to DNAT/static
is a **separate, out-of-scope follow-up**.

## Validation

- `go test ./pkg/dataplane/...` green (incl. the new L-9 tests and the
  existing `nat_per_uplink` same-tier ordering test).
- `go build ./...`, `gofmt -l`, `go vet` clean.
- RED-on-revert proven for the sort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
