### PR TITLE
api: harden /metrics — TTL/singleflight session-walk cache + non-loopback auth gate (#4162)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,51 @@
+## 2026-07-04 — #4162 (fable-review-164 L-5): /metrics session-walk TTL cache + auth posture
+
+- **Timestamp**: 2026-07-04
+  - **Action**: Closed an unauthenticated-DoS / hot-path-contention
+    vector on the Prometheus `/metrics` endpoint. The seven
+    `xpf_sessions_*` aggregate gauges walked the shared v4+v6 conntrack
+    BPF hash maps (up to ~10M entries, ~20M syscalls each taking a bucket
+    lock) on EVERY scrape, with no cache/throttle and no scrape
+    timeout/concurrency limit — a tight-loop or (when web-management
+    binds a routable interface) unauthenticated remote scraper could
+    amplify that O(sessions) scan against the live forwarding path.
+  - **Fix (B, primary — the DoS)**: added a short-TTL
+    (`sessionGaugeTTL` = 3s), singleflight-coalesced cache around the
+    session-gauge walk (`sessionGaugeSnapshotCached` +
+    `walkSessionGauges` in `pkg/api/metrics_sessions.go`; cache fields on
+    `xpfCollector` in `pkg/api/metrics.go`). A scrape inside the TTL
+    serves the cached seven aggregates (O(1)); the first scrape after it
+    does exactly one refresh walk; `singleflight` collapses concurrent
+    stale scrapes onto ONE in-flight walk. 3s is below the conventional
+    15-60s scrape interval so normal scraping always sees fresh counts
+    while a tight loop is capped at ≤1 walk/3s. The `#2469` fail-loud
+    contract is preserved (walk error → `scrape_ok=0`, gauges omitted,
+    cache NOT poisoned). Also set
+    `promhttp.HandlerOpts{Timeout: 10s, MaxRequestsInFlight: 3}` at the
+    `/metrics` registration (`pkg/api/server.go`).
+  - **Fix (A, secondary — auth posture)**: `/metrics` stays
+    unauthenticated on the loopback default (standard Prometheus
+    posture), but when the HTTP API is rebound to a NON-loopback
+    interface AND auth is configured, `/metrics` now requires credentials
+    like every other endpoint. `authMiddleware` gained a
+    `metricsRequireAuth bool`; `isLoopbackBindAddr(cfg.Addr)` (new, in
+    `pkg/api/auth.go`) drives it — wildcard / hostname / unparseable
+    binds are treated as non-loopback (fail safe: gate rather than
+    expose). `/health` remains always-exempt.
+  - **Tests** (`pkg/api/metrics_sessions_cache_test.go`): walk-once-per-TTL
+    over 25 rapid scrapes (RED on revert — walks == scrapes without the
+    cache), singleflight coalescing of 16 concurrent scrapes onto one walk
+    (RED on revert), refresh-after-TTL-expiry, cached aggregates ==
+    fresh cache-bypassing walk (reverse entries excluded),
+    `isLoopbackBindAddr` classification table, and the non-loopback
+    `/metrics` auth gate (401 without key / 200 with basic or API key /
+    `/health` still open; RED on revert of the unconditional bypass).
+    Existing `authMiddleware` callers updated for the new signature.
+  - **Files**: `pkg/api/metrics_sessions.go`, `pkg/api/metrics.go`,
+    `pkg/api/server.go`, `pkg/api/auth.go`, `pkg/api/auth_test.go`,
+    `pkg/api/auth_consttime_4157_test.go`,
+    `pkg/api/metrics_sessions_cache_test.go`, `docs/architecture.md`.
+
 ## 2026-07-04 — #4157 (fable-review-164 L-6): constant-time API-key/Bearer/username auth
 
 - **Timestamp**: 2026-07-04

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,6 +146,24 @@ editing cmdtree.
   the deferred half of #4107.)
 - **HTTP REST** on `127.0.0.1:8080` — health, Prometheus `/metrics`,
   config endpoints, full gRPC parity.
+  - **`/metrics` posture (#4162).** The Prometheus endpoint is
+    unauthenticated on the loopback default bind — the standard Prometheus
+    posture. When `system services web-management http interface <if>`
+    rebinds the HTTP API to a routable management address AND auth is
+    configured, `/metrics` requires the same credentials as every other
+    endpoint (`isLoopbackBindAddr` → `authMiddleware` gate); a
+    routable-interface Prometheus scraper must then present the configured
+    API key / basic-auth. `/health` stays exempt (no sensitive data, no
+    table walk).
+  - The seven `xpf_sessions_*` aggregate gauges are backed by a full walk
+    of the shared v4+v6 conntrack tables (up to ~10M entries). That walk is
+    served from a short-TTL (`sessionGaugeTTL`, 3s), singleflight-coalesced
+    cache, so the walk rate is capped at ≤1 per TTL regardless of scrape
+    frequency or concurrency — a tight-loop or unauthenticated scraper
+    cannot amplify the O(sessions) scan. Normal scrape intervals (15-60s)
+    always land outside the window and see fresh counts. `/metrics` is also
+    registered with `promhttp.HandlerOpts{Timeout, MaxRequestsInFlight}` to
+    bound slow/concurrent scrapes.
 - **CLI** — interactive Junos-style with tab completion, `?` help, pipe
   filters (`| match`, `| count`, `| except`).
 - **Remote CLI** — the `cli` binary connects via gRPC with full tab/`?`

--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -3,6 +3,7 @@ package api
 import (
 	"crypto/subtle"
 	"encoding/base64"
+	"net"
 	"net/http"
 	"strings"
 )
@@ -13,12 +14,19 @@ type AuthConfig struct {
 	APIKeys map[string]bool   // valid API key tokens
 }
 
-// authMiddleware wraps an http.Handler with Basic Auth / Bearer / X-API-Key checks.
-// Requests to /health and /metrics bypass authentication.
-func authMiddleware(cfg AuthConfig, next http.Handler) http.Handler {
+// authMiddleware wraps an http.Handler with Basic Auth / Bearer / X-API-Key
+// checks. /health always bypasses authentication (it exposes no sensitive data
+// and is a liveness probe). /metrics bypasses authentication only when
+// metricsRequireAuth is false — the loopback-bind default, the standard
+// Prometheus posture. When the HTTP API is rebound to a routable management
+// interface (metricsRequireAuth true), /metrics requires credentials like every
+// other endpoint so the aggregate session/counter surface is not exposed
+// unauthenticated on a routable interface (#4162).
+func authMiddleware(cfg AuthConfig, metricsRequireAuth bool, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Skip auth for health and metrics endpoints
-		if r.URL.Path == "/health" || r.URL.Path == "/metrics" {
+		// /health is always exempt; /metrics is exempt unless the bind is
+		// non-loopback and auth-gating was requested.
+		if r.URL.Path == "/health" || (r.URL.Path == "/metrics" && !metricsRequireAuth) {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -102,4 +110,28 @@ func constantTimeAPIKeyMatch(cfg AuthConfig, presented string) bool {
 		match |= subtle.ConstantTimeCompare(presentedBytes, []byte(key))
 	}
 	return match == 1
+}
+
+// isLoopbackBindAddr reports whether the API listen address binds only the
+// loopback interface (#4162). It parses host:port and returns true only for a
+// literal loopback IP (127.0.0.0/8 or ::1). Anything else — a routable IP, the
+// wildcard bind (":8080" / "0.0.0.0" / "::"), an empty/unparseable host, or a
+// hostname — is treated as NON-loopback (returns false), the conservative
+// default: when in doubt, gate /metrics behind auth rather than expose it.
+func isLoopbackBindAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// Not host:port (e.g. a bare host). Try the whole string as an IP.
+		host = addr
+	}
+	if host == "" {
+		// Wildcard bind (":8080") — listens on all interfaces.
+		return false
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// A hostname or malformed address — cannot prove it is loopback.
+		return false
+	}
+	return ip.IsLoopback()
 }

--- a/pkg/api/auth_consttime_4157_test.go
+++ b/pkg/api/auth_consttime_4157_test.go
@@ -175,7 +175,7 @@ func TestAuthMiddlewareConstantTimeIntegration(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	handler := authMiddleware(cfg, next)
+	handler := authMiddleware(cfg, false, next)
 
 	cases := []struct {
 		name   string

--- a/pkg/api/auth_test.go
+++ b/pkg/api/auth_test.go
@@ -24,7 +24,9 @@ func TestAuthMiddleware(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := authMiddleware(cfg, ok)
+	// metricsRequireAuth=false: the loopback-bind default, under which /metrics
+	// stays exempt (the "metrics bypass" case below asserts 200).
+	handler := authMiddleware(cfg, false, ok)
 
 	tests := []struct {
 		name   string

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
@@ -16,6 +17,30 @@ import (
 type xpfCollector struct {
 	srv *Server
 	mu  sync.Mutex
+
+	// #4162: short-TTL, singleflight-coalesced cache for the seven scalar
+	// session-aggregate gauges (active/established/ipv4/ipv6/snat/dnat +
+	// scrape_ok). collectSessionGauges walks the shared v4+v6 conntrack BPF
+	// hash maps (up to ~10M forward+reverse entries, 2 syscalls/entry each
+	// taking a bucket lock) concurrently with the helper's conntrack-publish
+	// path. Without this cache every /metrics scrape re-ran that O(sessions)
+	// walk, so an unauthenticated (non-loopback web-management bind) or
+	// tight-loop scraper could amplify the scan without bound. The export is
+	// only seven scalar aggregates (no per-session cardinality), so the O(N)
+	// walk yields O(1) output and is fully cacheable without losing a label.
+	// A scrape inside sessionGaugeTTL serves the cached snapshot (O(1)); the
+	// first scrape after it does exactly one refresh walk; sessionGaugeSF
+	// coalesces concurrent stale-scrapes onto a single in-flight walk so N
+	// parallel scrapes never fan out to N walks. The zero value is usable, so
+	// literal-constructed test collectors get the default TTL and a working
+	// cache. sessionGaugeTTLOverride is 0 in production (=> the default const);
+	// tests set it to drive TTL boundaries deterministically.
+	sessionGaugeMu          sync.Mutex
+	sessionGaugeSF          singleflight.Group
+	sessionGaugeSnap        sessionGaugeSnapshot
+	sessionGaugeComputedAt  time.Time
+	sessionGaugeValid       bool
+	sessionGaugeTTLOverride time.Duration
 
 	// Global counters
 	packetsTotal         *prometheus.Desc

--- a/pkg/api/metrics_auth_gate_4162_test.go
+++ b/pkg/api/metrics_auth_gate_4162_test.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestIsLoopbackBindAddr covers the bind classification that decides whether
+// /metrics is auth-gated (#4162).
+func TestIsLoopbackBindAddr(t *testing.T) {
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"127.0.0.1:8080", true},
+		{"127.0.0.1", true},
+		{"[::1]:8080", true},
+		{"::1", true},
+		{"192.168.1.5:8080", false},
+		{"10.0.0.1:8080", false},
+		{":8080", false},        // wildcard
+		{"0.0.0.0:8080", false}, // all v4
+		{"[::]:8080", false},    // all v6
+		{"example.com:8080", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isLoopbackBindAddr(tc.addr); got != tc.want {
+			t.Errorf("isLoopbackBindAddr(%q) = %v, want %v", tc.addr, got, tc.want)
+		}
+	}
+}
+
+// TestMetricsAuthGateNonLoopback asserts the #4162 auth posture: on a
+// non-loopback bind (metricsRequireAuth=true) /metrics demands credentials,
+// while /health stays exempt; on loopback (false) /metrics stays open.
+//
+// FAIL-ON-REVERT: restoring the unconditional `path == "/metrics"` bypass makes
+// the no-credential non-loopback case return 200 instead of 401.
+func TestMetricsAuthGateNonLoopback(t *testing.T) {
+	cfg := AuthConfig{
+		Users:   map[string]string{"admin": "secret123"},
+		APIKeys: map[string]bool{"tok-abc-123": true},
+	}
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	basic := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:secret123"))
+
+	cases := []struct {
+		name        string
+		requireAuth bool
+		path        string
+		header      map[string]string
+		want        int
+	}{
+		{"loopback metrics open", false, "/metrics", nil, http.StatusOK},
+		{"non-loopback metrics no-key blocked", true, "/metrics", nil, http.StatusUnauthorized},
+		{"non-loopback metrics with basic ok", true, "/metrics", map[string]string{"Authorization": basic}, http.StatusOK},
+		{"non-loopback metrics with api key ok", true, "/metrics", map[string]string{"X-API-Key": "tok-abc-123"}, http.StatusOK},
+		{"non-loopback health still open", true, "/health", nil, http.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := authMiddleware(cfg, tc.requireAuth, next)
+			req := httptest.NewRequest("GET", tc.path, nil)
+			for k, v := range tc.header {
+				req.Header.Set(k, v)
+			}
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			if w.Code != tc.want {
+				t.Fatalf("%s: status = %d, want %d", tc.name, w.Code, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/api/metrics_sessions.go
+++ b/pkg/api/metrics_sessions.go
@@ -1,16 +1,48 @@
 package api
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/psaab/xpf/pkg/dataplane"
 )
 
+// sessionGaugeTTL is the freshness window for the cached session-aggregate
+// snapshot (#4162). A scrape within this window of the last successful walk
+// serves the cached snapshot instead of re-walking the conntrack table, so the
+// walk rate is capped at <=1 per TTL regardless of scrape frequency.
+//
+// 3s is chosen deliberately: a Prometheus scrape interval is conventionally
+// 15-60s, so at normal cadence every scrape lands well outside a 3s window and
+// therefore always triggers a fresh walk — the cache is transparent to normal
+// operation and introduces no session-gauge staleness an operator would see. It
+// only engages when scrapes arrive faster than every 3s (a misconfigured tight
+// scrape loop or a deliberate amplification attempt), which is exactly the
+// #4162 DoS vector: there the cache collapses an unbounded scrape rate onto at
+// most one O(sessions) walk per 3s. 3s stays under the finest reasonable scrape
+// interval while still meaningfully rate-limiting the walk under abuse.
+const sessionGaugeTTL = 3 * time.Second
+
+// sessionGaugeSnapshot is the set of scalar aggregates produced by one full
+// walk of the v4+v6 conntrack tables. It carries no per-session cardinality —
+// the O(sessions) walk collapses to these seven O(1) counters — which is what
+// makes the walk result cacheable without dropping any Prometheus label.
+type sessionGaugeSnapshot struct {
+	active      int
+	established int
+	ipv4        int
+	ipv6        int
+	snat        int
+	dnat        int
+}
+
 func (c *xpfCollector) collectSessionGauges(ch chan<- prometheus.Metric, dp apiRuntimeDataPlane) {
 	// xpf_gc_sweep_duration_seconds reflects the last BPF GC sweep timing.
 	// On the userspace dataplane (the only live forwarding path) the BPF GC
 	// sweep is skipped (#333), so this is 0 — expected, and orthogonal to the
-	// session counts derived below.
+	// session counts derived below. It is not part of the cached snapshot: it
+	// is a single field read, not a table walk.
 	if c.srv.gc != nil {
 		ch <- prometheus.MustNewConstMetric(c.gcSweepDuration, prometheus.GaugeValue,
 			c.srv.gc.Stats().LastSweepDuration.Seconds())
@@ -21,55 +53,142 @@ func (c *xpfCollector) collectSessionGauges(ch chan<- prometheus.Metric, dp apiR
 	// session` reads. Previously xpf_sessions_active/xpf_sessions_established
 	// were sourced from GC sweep stats (gc.Stats().TotalEntries /
 	// EstablishedSessions), which are permanently 0 on the userspace dataplane
-	// because the BPF GC sweep is skipped (#333). Counting inside the single
-	// iteration that already backs the type breakdown keeps the scrape cost
-	// unchanged (no new periodic scan; the #333 optimization stands).
+	// because the BPF GC sweep is skipped (#333).
 	//
-	// active   = forward session entries (IsReverse == 0) — the live count.
-	// established = forward entries whose State is ESTABLISHED (a distinct
-	//              session state). Half-open / opening sessions are counted in
-	//              active but not established.
+	// #4162: the walk is behind a short-TTL, singleflight-coalesced cache
+	// (sessionGaugeSnapshotCached) so the scrape rate is decoupled from the
+	// walk rate — at most one full v4+v6 table walk per sessionGaugeTTL,
+	// regardless of how fast (or from how many concurrent clients) /metrics is
+	// scraped. This defeats the unauthenticated / tight-loop amplification of
+	// the O(sessions) scan over the box's largest hot structure.
 	//
 	// A backend iterator error (e.g. a helper restart mid-scrape) truncates the
 	// scan; publishing the partial counts would report a wrong-but-confident
 	// picture (#2469), so on error we EXPOSE xpf_sessions_breakdown_scrape_ok=0
 	// and OMIT every session gauge, letting an alert on scrape_ok fire rather
-	// than a graph silently dropping toward zero.
-	var active, established, ipv4, ipv6, snat, dnat int
-	countForward := func(state uint8, flags uint8, ipCounter *int) {
-		active++
-		*ipCounter++
-		if state == dataplane.SessStateEstablished {
-			established++
-		}
-		if flags&dataplane.SessFlagSNAT != 0 {
-			snat++
-		}
-		if flags&dataplane.SessFlagDNAT != 0 {
-			dnat++
-		}
-	}
-	errV4 := dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
-		if val.IsReverse == 0 {
-			countForward(val.State, val.Flags, &ipv4)
-		}
-		return true
-	})
-	errV6 := dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
-		if val.IsReverse == 0 {
-			countForward(val.State, val.Flags, &ipv6)
-		}
-		return true
-	})
-	if errV4 != nil || errV6 != nil {
+	// than a graph silently dropping toward zero. The cache is NOT poisoned on
+	// error — a failed walk leaves the previous good snapshot in place (and its
+	// TTL unchanged), so the next scrape retries the walk.
+	snap, ok := c.sessionGaugeSnapshotCached(dp)
+	if !ok {
 		ch <- prometheus.MustNewConstMetric(c.sessionScrapeOK, prometheus.GaugeValue, 0)
 		return
 	}
 	ch <- prometheus.MustNewConstMetric(c.sessionScrapeOK, prometheus.GaugeValue, 1)
-	ch <- prometheus.MustNewConstMetric(c.sessionsActive, prometheus.GaugeValue, float64(active))
-	ch <- prometheus.MustNewConstMetric(c.sessionsEstablished, prometheus.GaugeValue, float64(established))
-	ch <- prometheus.MustNewConstMetric(c.sessionsIPv4, prometheus.GaugeValue, float64(ipv4))
-	ch <- prometheus.MustNewConstMetric(c.sessionsIPv6, prometheus.GaugeValue, float64(ipv6))
-	ch <- prometheus.MustNewConstMetric(c.sessionsSNAT, prometheus.GaugeValue, float64(snat))
-	ch <- prometheus.MustNewConstMetric(c.sessionsDNAT, prometheus.GaugeValue, float64(dnat))
+	ch <- prometheus.MustNewConstMetric(c.sessionsActive, prometheus.GaugeValue, float64(snap.active))
+	ch <- prometheus.MustNewConstMetric(c.sessionsEstablished, prometheus.GaugeValue, float64(snap.established))
+	ch <- prometheus.MustNewConstMetric(c.sessionsIPv4, prometheus.GaugeValue, float64(snap.ipv4))
+	ch <- prometheus.MustNewConstMetric(c.sessionsIPv6, prometheus.GaugeValue, float64(snap.ipv6))
+	ch <- prometheus.MustNewConstMetric(c.sessionsSNAT, prometheus.GaugeValue, float64(snap.snat))
+	ch <- prometheus.MustNewConstMetric(c.sessionsDNAT, prometheus.GaugeValue, float64(snap.dnat))
+}
+
+// sessionGaugeTTLEffective returns the cache freshness window. Production uses
+// the sessionGaugeTTL const; tests set sessionGaugeTTLOverride to drive TTL
+// boundaries deterministically without a real sleep.
+func (c *xpfCollector) sessionGaugeTTLEffective() time.Duration {
+	if c.sessionGaugeTTLOverride > 0 {
+		return c.sessionGaugeTTLOverride
+	}
+	return sessionGaugeTTL
+}
+
+// sessionGaugeSnapshotCached returns the seven session aggregates, serving a
+// cached snapshot when it is younger than the effective TTL and otherwise
+// performing exactly one refresh walk. The second return is false when the
+// backing walk failed AND no prior good snapshot is available to serve, in
+// which case the caller emits scrape_ok=0 and omits the gauges (#2469).
+//
+// Concurrency: the fast-path freshness check takes sessionGaugeMu only briefly.
+// On a miss the refresh runs under singleflight keyed on a constant, so N
+// concurrent stale scrapes coalesce onto ONE walk and all observe its result —
+// they never fan out to N parallel walks over the shared conntrack maps.
+func (c *xpfCollector) sessionGaugeSnapshotCached(dp apiRuntimeDataPlane) (sessionGaugeSnapshot, bool) {
+	ttl := c.sessionGaugeTTLEffective()
+
+	// Fast path: a fresh snapshot serves without a walk or singleflight entry.
+	c.sessionGaugeMu.Lock()
+	if c.sessionGaugeValid && time.Since(c.sessionGaugeComputedAt) < ttl {
+		snap := c.sessionGaugeSnap
+		c.sessionGaugeMu.Unlock()
+		return snap, true
+	}
+	c.sessionGaugeMu.Unlock()
+
+	// Slow path: coalesce concurrent refreshes onto a single in-flight walk.
+	v, err, _ := c.sessionGaugeSF.Do("session-gauges", func() (interface{}, error) {
+		// Re-check under the lock: a sibling scrape may have refreshed the
+		// snapshot between our fast-path miss and acquiring the singleflight
+		// slot (singleflight only dedups callers that overlap the SAME in-flight
+		// call; a caller arriving just after a refresh completed would otherwise
+		// walk again immediately).
+		c.sessionGaugeMu.Lock()
+		if c.sessionGaugeValid && time.Since(c.sessionGaugeComputedAt) < ttl {
+			snap := c.sessionGaugeSnap
+			c.sessionGaugeMu.Unlock()
+			return snap, nil
+		}
+		c.sessionGaugeMu.Unlock()
+
+		snap, werr := walkSessionGauges(dp)
+		if werr != nil {
+			return sessionGaugeSnapshot{}, werr
+		}
+		c.sessionGaugeMu.Lock()
+		c.sessionGaugeSnap = snap
+		c.sessionGaugeComputedAt = time.Now()
+		c.sessionGaugeValid = true
+		c.sessionGaugeMu.Unlock()
+		return snap, nil
+	})
+	if err != nil {
+		// Walk failed. Do NOT poison the cache (leave any prior good snapshot
+		// and its TTL untouched so the next scrape retries). Signal scrape_ok=0.
+		return sessionGaugeSnapshot{}, false
+	}
+	return v.(sessionGaugeSnapshot), true
+}
+
+// walkSessionGauges performs one full walk of the v4 and v6 conntrack tables
+// and tallies the seven scalar aggregates. It returns an error if either
+// iterator fails; the caller discards a partial result rather than reporting a
+// truncated-but-confident count (#2469).
+//
+// active   = forward session entries (IsReverse == 0) — the live count.
+// established = forward entries whose State is ESTABLISHED (a distinct session
+//
+//	state). Half-open / opening sessions are counted in active but
+//	not established.
+func walkSessionGauges(dp apiRuntimeDataPlane) (sessionGaugeSnapshot, error) {
+	var s sessionGaugeSnapshot
+	countForward := func(state uint8, flags uint8, ipCounter *int) {
+		s.active++
+		*ipCounter++
+		if state == dataplane.SessStateEstablished {
+			s.established++
+		}
+		if flags&dataplane.SessFlagSNAT != 0 {
+			s.snat++
+		}
+		if flags&dataplane.SessFlagDNAT != 0 {
+			s.dnat++
+		}
+	}
+	if err := dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
+		if val.IsReverse == 0 {
+			countForward(val.State, val.Flags, &s.ipv4)
+		}
+		return true
+	}); err != nil {
+		return sessionGaugeSnapshot{}, err
+	}
+	if err := dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+		if val.IsReverse == 0 {
+			countForward(val.State, val.Flags, &s.ipv6)
+		}
+		return true
+	}); err != nil {
+		return sessionGaugeSnapshot{}, err
+	}
+	return s, nil
 }

--- a/pkg/api/metrics_sessions_cache_test.go
+++ b/pkg/api/metrics_sessions_cache_test.go
@@ -1,0 +1,216 @@
+package api
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// countingSessionDP is an apiRuntimeDataPlane whose session iterators emit a
+// fixed set of forward entries and count how many times the v4 iterator ran —
+// one v4 iteration == one full conntrack walk from collectSessionGauges. It
+// backs the #4162 cache tests: they assert the walk count against the scrape
+// count to prove the walk rate is decoupled from the scrape rate.
+//
+// When gate is non-nil the v4 iterator blocks receiving from it before
+// enumerating, so a test can hold one walk in flight while other goroutines
+// pile up — proving singleflight coalescing (they attach to the in-flight walk
+// rather than each starting their own).
+type countingSessionDP struct {
+	*dataplane.Manager
+	walks   atomic.Int64
+	entered chan struct{} // signalled once when a v4 walk begins (optional)
+	gate    chan struct{} // v4 walk blocks until closed/received (optional)
+	v4      []dataplane.SessionValue
+	v6      []dataplane.SessionValueV6
+}
+
+func (d *countingSessionDP) IsLoaded() bool { return true }
+
+func (d *countingSessionDP) IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	d.walks.Add(1)
+	if d.entered != nil {
+		select {
+		case d.entered <- struct{}{}:
+		default:
+		}
+	}
+	if d.gate != nil {
+		<-d.gate
+	}
+	for _, v := range d.v4 {
+		if !fn(dataplane.SessionKey{}, v) {
+			break
+		}
+	}
+	return nil
+}
+
+func (d *countingSessionDP) IterateSessionsV6(fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	for _, v := range d.v6 {
+		if !fn(dataplane.SessionKeyV6{}, v) {
+			break
+		}
+	}
+	return nil
+}
+
+// drainCollect runs collectSessionGauges and discards the emitted metrics.
+func drainCollect(c *xpfCollector, dp apiRuntimeDataPlane) {
+	ch := make(chan prometheus.Metric, 32)
+	go func() {
+		c.collectSessionGauges(ch, dp)
+		close(ch)
+	}()
+	for range ch { //nolint:revive // draining
+	}
+}
+
+// TestSessionGaugeCacheWalksOncePerTTL asserts the #4162 primary fix: rapid
+// repeated scrapes within one TTL window trigger exactly ONE conntrack walk,
+// not one per scrape.
+//
+// FAIL-ON-REVERT: removing the TTL cache (walking on every Collect) makes the
+// walk count equal the scrape count (numScrapes), flipping the == 1 assertion.
+func TestSessionGaugeCacheWalksOncePerTTL(t *testing.T) {
+	c := newSessionGaugeCollector()
+	c.sessionGaugeTTLOverride = time.Hour // never expires during the test
+	dp := &countingSessionDP{
+		Manager: dataplane.New(),
+		v4:      []dataplane.SessionValue{{IsReverse: 0}},
+	}
+
+	const numScrapes = 25
+	for i := 0; i < numScrapes; i++ {
+		drainCollect(c, dp)
+	}
+
+	if got := dp.walks.Load(); got != 1 {
+		t.Fatalf("conntrack walks = %d over %d scrapes within one TTL; want 1 (cache not decoupling walk rate from scrape rate)", got, numScrapes)
+	}
+}
+
+// TestSessionGaugeCacheRefreshesAfterTTL asserts the cache is a freshness
+// window, not a permanent latch: once the snapshot ages past the TTL, the next
+// scrape performs a fresh walk.
+func TestSessionGaugeCacheRefreshesAfterTTL(t *testing.T) {
+	c := newSessionGaugeCollector()
+	c.sessionGaugeTTLOverride = time.Hour
+	dp := &countingSessionDP{
+		Manager: dataplane.New(),
+		v4:      []dataplane.SessionValue{{IsReverse: 0}},
+	}
+
+	drainCollect(c, dp) // walk 1, snapshot cached
+	if got := dp.walks.Load(); got != 1 {
+		t.Fatalf("after first scrape walks = %d, want 1", got)
+	}
+	drainCollect(c, dp) // served from cache
+	if got := dp.walks.Load(); got != 1 {
+		t.Fatalf("second scrape within TTL walked again: walks = %d, want 1", got)
+	}
+
+	// Force the snapshot past its TTL without sleeping (in-package access).
+	c.sessionGaugeMu.Lock()
+	c.sessionGaugeComputedAt = time.Now().Add(-2 * time.Hour)
+	c.sessionGaugeMu.Unlock()
+
+	drainCollect(c, dp) // stale => refresh walk
+	if got := dp.walks.Load(); got != 2 {
+		t.Fatalf("scrape after TTL expiry did not refresh: walks = %d, want 2", got)
+	}
+}
+
+// TestSessionGaugeCacheCoalescesConcurrentScrapes asserts singleflight
+// coalescing: many concurrent scrapes that all miss the cache collapse onto a
+// SINGLE in-flight walk rather than each launching their own.
+//
+// FAIL-ON-REVERT: removing the singleflight (or the cache) lets each concurrent
+// scrape walk independently, so walks jumps toward numGoroutines.
+func TestSessionGaugeCacheCoalescesConcurrentScrapes(t *testing.T) {
+	c := newSessionGaugeCollector()
+	c.sessionGaugeTTLOverride = time.Hour
+	dp := &countingSessionDP{
+		Manager: dataplane.New(),
+		entered: make(chan struct{}, 1),
+		gate:    make(chan struct{}),
+		v4:      []dataplane.SessionValue{{IsReverse: 0}},
+	}
+
+	const numGoroutines = 16
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start // release all at once
+			drainCollect(c, dp)
+		}()
+	}
+	close(start)
+
+	// Wait until the single elected walker is in flight and blocked on the
+	// gate, then give stragglers a moment to reach singleflight.Do and attach
+	// to the in-flight call before releasing the walk.
+	<-dp.entered
+	time.Sleep(30 * time.Millisecond)
+	close(dp.gate)
+	wg.Wait()
+
+	if got := dp.walks.Load(); got != 1 {
+		t.Fatalf("concurrent scrapes fanned out to %d walks; want 1 (singleflight not coalescing)", got)
+	}
+}
+
+// TestSessionGaugeCacheValuesCorrect asserts the cached aggregates equal a
+// fresh, cache-bypassing walk of the same table — the cache must not distort
+// the seven counts (active/established/ipv4/ipv6/snat/dnat), and reverse
+// entries (IsReverse==1) must be excluded exactly as the uncached walk excludes
+// them.
+func TestSessionGaugeCacheValuesCorrect(t *testing.T) {
+	dp := &countingSessionDP{
+		Manager: dataplane.New(),
+		v4: []dataplane.SessionValue{
+			{IsReverse: 0, State: dataplane.SessStateEstablished},
+			{IsReverse: 0, State: dataplane.SessStateEstablished, Flags: dataplane.SessFlagSNAT},
+			{IsReverse: 0, Flags: dataplane.SessFlagDNAT},
+			{IsReverse: 1, State: dataplane.SessStateEstablished}, // reverse: ignored
+		},
+		v6: []dataplane.SessionValueV6{
+			{IsReverse: 0, State: dataplane.SessStateEstablished, Flags: dataplane.SessFlagSNAT | dataplane.SessFlagDNAT},
+			{IsReverse: 1}, // reverse: ignored
+		},
+	}
+
+	// Independent expectation.
+	// v4 forward: 3 (2 established, 1 snat, 1 dnat). v6 forward: 1 (established,
+	// snat, dnat). Totals: active=4, established=3, ipv4=3, ipv6=1, snat=2,
+	// dnat=2.
+	want := sessionGaugeSnapshot{active: 4, established: 3, ipv4: 3, ipv6: 1, snat: 2, dnat: 2}
+
+	// Fresh, cache-bypassing walk.
+	fresh, err := walkSessionGauges(dp)
+	if err != nil {
+		t.Fatalf("walkSessionGauges: %v", err)
+	}
+	if fresh != want {
+		t.Fatalf("fresh walk = %+v, want %+v", fresh, want)
+	}
+
+	// Cached path must match the fresh walk.
+	c := newSessionGaugeCollector()
+	c.sessionGaugeTTLOverride = time.Hour
+	got, ok := c.sessionGaugeSnapshotCached(dp)
+	if !ok {
+		t.Fatal("sessionGaugeSnapshotCached returned ok=false on a healthy walk")
+	}
+	if got != want {
+		t.Fatalf("cached snapshot = %+v, want %+v (== fresh walk)", got, want)
+	}
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -303,6 +303,19 @@ const (
 	// apiMaxHeaderBytes bounds total request header size so an attacker cannot
 	// buffer unbounded header data before the timeouts fire.
 	apiMaxHeaderBytes = 1 << 20 // 1 MiB
+
+	// metricsScrapeTimeout bounds a single /metrics scrape (#4162). promhttp
+	// aborts the handler and returns 503 if a scrape runs longer than this,
+	// so a scrape that stalls inside a slow dataplane read cannot pin a
+	// goroutine indefinitely. Generous relative to a healthy scrape (the
+	// session walk is now cached) but a hard ceiling on a wedged one.
+	metricsScrapeTimeout = 10 * time.Second
+	// metricsMaxInFlight bounds concurrent /metrics scrapes (#4162). promhttp
+	// returns 503 to scrapes beyond this many in flight, so a burst of parallel
+	// scrapers cannot each spin up a collector pass at once. The session walk
+	// is coalesced by the TTL cache, but this is the belt-and-suspenders limit
+	// on the rest of the collector's per-scrape work.
+	metricsMaxInFlight = 3
 )
 
 // NewServer creates a new API server.
@@ -350,7 +363,13 @@ func NewServer(cfg Config) *Server {
 	// Prometheus metrics with isolated registry
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(newCollector(s))
-	mux.Handle("GET /metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	mux.Handle("GET /metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{
+		// #4162: bound slow / concurrent scrapes. Empty opts left both zero
+		// (no timeout, unlimited concurrency), so a stalled or bursty scraper
+		// could pile up collector passes over the dataplane.
+		Timeout:             metricsScrapeTimeout,
+		MaxRequestsInFlight: metricsMaxInFlight,
+	}))
 
 	// REST API v1
 	mux.HandleFunc("GET /api/v1/status", s.statusHandler)
@@ -446,7 +465,18 @@ func NewServer(cfg Config) *Server {
 
 	var handler http.Handler = mux
 	if cfg.Auth != nil {
-		handler = authMiddleware(*cfg.Auth, mux)
+		// #4162 (auth posture): /metrics is unauthenticated by default, which
+		// is the standard Prometheus posture and safe on the loopback default
+		// bind (127.0.0.1). But when web-management rebinds the HTTP API to a
+		// routable management interface (daemon_run.go resolveInterfaceAddr),
+		// an unauthenticated /metrics becomes remotely reachable. When auth is
+		// configured AND the bind is non-loopback, require credentials for
+		// /metrics too. A routable-interface Prometheus scraper must then
+		// present the configured API key / basic-auth, same as every other
+		// endpoint (documented in docs/architecture.md). /health stays exempt
+		// (it exposes no table walk and no sensitive data).
+		metricsRequireAuth := !isLoopbackBindAddr(cfg.Addr)
+		handler = authMiddleware(*cfg.Auth, metricsRequireAuth, mux)
 	}
 
 	s.httpServer = &http.Server{


### PR DESCRIPTION
Closes #4162

fable-review-164 finding **L-5** (Low severity, High confidence). The Prometheus `/metrics` endpoint (1) bypassed auth and (2) walked the entire v4+v6 conntrack table on every scrape with no cache, timeout, or concurrency bound — an unauthenticated (non-loopback web-management bind) or tight-loop scraper could amplify an O(sessions) scan (up to ~10M entries / ~20M syscalls) over the box's largest hot structure, contending with the helper's conntrack-publish path.

Go-only, `pkg/api`. No dataplane / Rust / wire-format change.

## (B) Primary — the DoS: short-TTL singleflight cache
`collectSessionGauges` now serves the seven scalar `xpf_sessions_*` aggregates from a cache (`sessionGaugeSnapshotCached` + `walkSessionGauges`, `pkg/api/metrics_sessions.go`; cache state on `xpfCollector`, `pkg/api/metrics.go`):

- A scrape within **`sessionGaugeTTL` = 3s** of the last successful walk serves the cached aggregates (O(1)); the first scrape after it does exactly one refresh walk. 3s is below the conventional 15-60s Prometheus scrape interval, so normal scraping always sees fresh counts, while a faster-than-3s loop is capped at ≤1 walk/3s.
- `golang.org/x/sync/singleflight` (already a dep) coalesces concurrent stale scrapes onto a single in-flight walk (with an under-lock double-check), so N parallel scrapes never fan out to N walks.
- The #2469 fail-loud contract is preserved: a walk error → `scrape_ok=0`, gauges omitted, and the cache is **not** poisoned (prior snapshot + TTL untouched; next scrape retries).
- `/metrics` registration now sets `promhttp.HandlerOpts{Timeout: 10s, MaxRequestsInFlight: 3}` (`pkg/api/server.go`) to bound slow/concurrent scrapes.

The export is only seven scalar aggregates (no per-session cardinality), so the O(N) walk → O(1) output is fully cacheable without dropping any label. Per the research, the GC sweep cannot be piggybacked (skipped on userspace, #333) and the helper status poll carries only error counters — hence a self-contained TTL cache.

## (A) Secondary — auth posture
`/metrics` stays unauthenticated on the **loopback default** (standard Prometheus posture). `authMiddleware` gained `metricsRequireAuth`; `NewServer` sets it from `!isLoopbackBindAddr(cfg.Addr)`, so when auth is configured **and** the API is rebound to a routable `web-management http interface`, `/metrics` requires the same credentials as every other endpoint. `isLoopbackBindAddr` treats wildcard/hostname/unparseable binds as non-loopback (fail safe). `/health` stays always-exempt. A routable-interface Prometheus scraper must present the configured API key — documented in `docs/architecture.md`.

## Tests (RED-on-revert verified)
- **walk-once-per-TTL**: 25 rapid scrapes within one TTL → exactly 1 walk (RED without cache: walks == scrapes).
- **coalesce**: 16 concurrent scrapes → 1 walk via singleflight (RED without cache/singleflight).
- refresh-after-TTL-expiry; cached aggregates == fresh cache-bypassing walk (reverse entries excluded).
- **auth gate**: non-loopback `/metrics` → 401 without key / 200 with basic or API key, `/health` still open (RED on revert of the unconditional bypass); `isLoopbackBindAddr` classification table.

`go test ./pkg/api/...` green; `go build ./...`, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
