### PR TITLE
dhcp-relay: validate server reply source against the configured server set (#4163)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,47 @@
+## 2026-07-04 — #4163 (fable-review-164 L-12): DHCP-relay reply source validation
+
+- **Timestamp**: 2026-07-04
+  - **Action**: Closed a rogue-DHCP-reply injection hole in the DHCPv4
+    relay. `handleServerResponses` (`pkg/dhcprelay/relay.go`) forwarded
+    server replies (OFFER/ACK/NAK/FORCERENEW) to clients based on packet
+    contents alone (OpCode==BootReply + relayable MessageType); the
+    reply's source IP was read via `ReadFrom` but used only in a
+    `slog.Debug` line, never validated. The server-facing socket is
+    `ListenPacket("udp4", giaddr:67)` — bound, not `connect()`-ed — so it
+    accepts datagrams from ANY host that can route to `giaddr:67`. An
+    off-path attacker could inject a forged OFFER/ACK (hostile
+    gateway/DNS → MITM) or a forged NAK (client restart).
+  - **Fix**: threaded the already-resolved server set
+    (`servers []*net.UDPAddr`, from `computeDesired` via `runRelaySession`)
+    into `handleServerResponses` (signature + the one call site, ~line
+    1016). Built an IP allow-set once, and before `dhcpv4.FromBytes` drop
+    any reply whose source IP is not a configured server (compared with
+    `net.IP.Equal`; source port not load-bearing), incrementing a new
+    `repliesDroppedUnknownServer` counter (mirrored to
+    `RelayStats.RepliesDroppedUnknownServer`, populated in `Stats()`,
+    surfaced in `show ... dhcp-relay`). Enforced by DEFAULT (RFC 3046
+    relay practice). The drop is LOUD: first drop per session at `Warn`,
+    subsequent at `Debug` (counter is the durable signal — a forged-reply
+    flood cannot spam the log), so the one benign edge (a multi-homed
+    server unicasting from an unlisted source) is diagnosable, not a
+    silent black-hole. An extra-reply-source allow-list knob is a
+    deliberate follow-up, not shipped now. Helpers: `replySourceAllowed`,
+    `udpAddrIP` (handles *net.UDPAddr / *net.IPAddr / string fallback).
+    Existing OpCode/MessageType gates preserved (source check added
+    alongside). DHCPv4-only (no DHCPv6 relay exists).
+  - **Tests**: `pkg/dhcprelay/delivery_test.go` — added
+    configurable-source support to `fakeConn`; new tests: configured
+    source forwarded (counter stays 0); UNCONFIGURED source dropped +
+    counter==1 (RED on revert — under a neutered check the rogue OFFER
+    reaches the client, `repliesForwarded=1`, counter=0, proven);
+    multi-server group accepts from ANY member (2nd member forwarded);
+    configured-source-wrong-OpCode dropped by the OpCode gate WITHOUT
+    counting as an unknown-server drop. `go test ./pkg/dhcprelay/...
+    ./pkg/cli/...` green; `go build ./...`, gofmt, vet clean.
+  - **File(s)**: pkg/dhcprelay/relay.go, pkg/dhcprelay/delivery_test.go,
+    pkg/dhcprelay/relay_test.go, pkg/cli/cli_show_services.go,
+    pkg/dhcprelay/README.md, _Log.md
+
 ## 2026-07-04 — #4157 (fable-review-164 L-6): constant-time API-key/Bearer/username auth
 
 - **Timestamp**: 2026-07-04

--- a/pkg/cli/cli_show_services.go
+++ b/pkg/cli/cli_show_services.go
@@ -426,6 +426,15 @@ func (c *CLI) showDHCPRelay() error {
 					s.RepliesBroadcastNoTarget, s.RepliesBroadcastL2Fallback,
 					s.RepliesBroadcastNak)
 			}
+			// Reply source validation (#4163). A non-zero count means a reply
+			// arrived from a source IP that is NOT one of the configured DHCP
+			// servers and was dropped — a rogue-reply injection attempt, or a
+			// multi-homed server unicasting from an unlisted source IP.
+			fmt.Println("\nReply source validation (#4163):")
+			fmt.Printf("  %-16s %s\n", "Interface", "Dropped (unknown server)")
+			for _, s := range stats {
+				fmt.Printf("  %-16s %d\n", s.Interface, s.RepliesDroppedUnknownServer)
+			}
 		}
 	}
 	return nil

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -115,10 +115,49 @@ RFC 768).
 - **Counters.** `Stats()` exposes a per-reason breakdown
   (`RepliesL2Unicast`, `RepliesUnicastCiaddr`, `RepliesBroadcastFlag1`,
   `RepliesBroadcastForced`, `RepliesBroadcastNoTarget`,
-  `RepliesBroadcastL2Fallback`, `RepliesBroadcastNak`). **`RepliesBroadcastL2Fallback` is the one
+  `RepliesBroadcastL2Fallback`, `RepliesBroadcastNak`,
+  `RepliesDroppedUnknownServer`). **`RepliesBroadcastL2Fallback` is the one
   to alert on** — it means the raw-L2 path failed (CAP_NET_RAW, driver, or
-  MTU) and the relay degraded to broadcast. `show ... dhcp-relay` prints
-  this breakdown.
+  MTU) and the relay degraded to broadcast. **`RepliesDroppedUnknownServer`
+  (#4163)** counts replies dropped because their source IP was not a
+  configured server — a non-zero value is a rogue-reply injection attempt (or
+  a multi-homed server unicasting from an unlisted source IP); see "Reply
+  source validation" below. `show ... dhcp-relay` prints this breakdown.
+
+## Reply source validation (#4163)
+
+`handleServerResponses` validates every server reply's **source IP against the
+configured server set before parsing or forwarding it**. The server-facing
+socket is *bound* to `giaddr:67` (see the socket-lifecycle notes below), not
+`connect()`-ed, so the kernel delivers any datagram routed to `giaddr:67` —
+from **any** source — up to the relay. Without a source check an off-path
+attacker (or a compromised transit host) that can route a UDP datagram to
+`giaddr:67` could inject a forged `OFFER`/`ACK` (steering the client to a
+hostile gateway/DNS → MITM) or a forged `NAK` (forcing a client restart) and
+the relay would deliver it. RFC 3046 relay practice is to forward replies only
+from the relay's explicit, configured server list.
+
+- The resolved server set (`[]*net.UDPAddr`, IP + port 67, from the group's
+  active `server-group`) is threaded from `runRelaySession` into
+  `handleServerResponses`, which builds an IP allow-set once. Each reply's
+  source IP (from `ReadFrom`) is compared with `net.IP.Equal` (form-agnostic;
+  the source **port** is not part of the trust decision). A reply from an
+  unlisted source is **dropped before `dhcpv4.FromBytes`** and counted in
+  `RepliesDroppedUnknownServer`.
+- **Enforced by default** — there is no legitimate case for a relay forwarding
+  a reply from a source outside its configured set. The drop is made **loud**:
+  the first drop per session logs at `Warn` (subsequent ones at `Debug` so a
+  forged-reply flood cannot spam the log) and every drop bumps the counter, so
+  the one benign edge case — a strictly **multi-homed server** that unicasts
+  its reply from a source IP different from the one the operator listed — is
+  diagnosable from `RepliesDroppedUnknownServer` (and the `Warn`) rather than
+  presenting as a silent black-hole. If a real deployment needs that, a
+  follow-up can add an explicit extra-reply-source allow-list knob; it is not
+  needed to close the injection hole.
+- `giaddr`-echo and Option-82 correlation are strictly-stronger secondary
+  checks and are **out of scope** here (Option 82 is stripped on the reply, but
+  not echo-validated); source-set membership is the primary, highest-value
+  control. This is DHCPv4-only (there is no DHCPv6 relay — see below).
 
 ### `overrides always-broadcast` config
 

--- a/pkg/dhcprelay/delivery_test.go
+++ b/pkg/dhcprelay/delivery_test.go
@@ -85,7 +85,26 @@ var (
 	testYiaddr = net.IPv4(10, 0, 0, 50)
 	testCiaddr = net.IPv4(10, 0, 0, 60)
 	testChaddr = net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x99}
+	// testServerIP matches the default source IP fakeConn.ReadFrom reports for
+	// pending datagrams (10.0.0.1), so the #4163 source-validation check admits
+	// the existing reply-path tests. Drive a drop by pointing fakeConn.srcAddr
+	// at a different IP.
+	testServerIP = net.IPv4(10, 0, 0, 1)
 )
+
+// testServerSet returns the configured-server allow-set passed into
+// handleServerResponses. With no args it is the single default server
+// (testServerIP) that matches fakeConn's default reply source.
+func testServerSet(ips ...net.IP) []*net.UDPAddr {
+	if len(ips) == 0 {
+		ips = []net.IP{testServerIP}
+	}
+	set := make([]*net.UDPAddr, 0, len(ips))
+	for _, ip := range ips {
+		set = append(set, &net.UDPAddr{IP: ip, Port: relayPort})
+	}
+	return set
+}
 
 // TestDeliverReply_Matrix is the §7.1 decision-matrix oracle: every row of the
 // reply-destination table maps to exactly one delivery path and one counter.
@@ -462,7 +481,7 @@ func TestHandleServerResponses_NakForwarded(t *testing.T) {
 	defer cancel()
 	done := make(chan struct{})
 	go func() {
-		handleServerResponses(ctx, serverConn, clientConn, ir, fl2, testGiaddr)
+		handleServerResponses(ctx, serverConn, clientConn, ir, fl2, testGiaddr, testServerSet())
 		close(done)
 	}()
 
@@ -576,7 +595,7 @@ func TestHandleServerResponses_ForceRenewForwarded(t *testing.T) {
 	defer cancel()
 	done := make(chan struct{})
 	go func() {
-		handleServerResponses(ctx, serverConn, clientConn, ir, fl2, testGiaddr)
+		handleServerResponses(ctx, serverConn, clientConn, ir, fl2, testGiaddr, testServerSet())
 		close(done)
 	}()
 
@@ -638,7 +657,7 @@ func TestHandleServerResponses_L2SourceIsSavedGiaddr(t *testing.T) {
 	defer cancel()
 	done := make(chan struct{})
 	go func() {
-		handleServerResponses(ctx, serverConn, clientConn, ir, fl2, testGiaddr)
+		handleServerResponses(ctx, serverConn, clientConn, ir, fl2, testGiaddr, testServerSet())
 		close(done)
 	}()
 
@@ -655,6 +674,218 @@ func TestHandleServerResponses_L2SourceIsSavedGiaddr(t *testing.T) {
 	fl2.mu.Unlock()
 	if !c.srcIP.Equal(testGiaddr) {
 		t.Errorf("L2 srcIP = %v, want saved giaddr %v", c.srcIP, testGiaddr)
+	}
+
+	cancel()
+	serverConn.Close()
+	<-done
+}
+
+// waitClientWrite polls until the client conn has ≥1 write or the deadline, then
+// returns a snapshot of its writes.
+func waitClientWrite(clientConn *fakeConn) []fakeWrite {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		clientConn.mu.Lock()
+		n := len(clientConn.writes)
+		clientConn.mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	clientConn.mu.Lock()
+	defer clientConn.mu.Unlock()
+	return append([]fakeWrite(nil), clientConn.writes...)
+}
+
+// TestHandleServerResponses_ConfiguredSourceForwarded is the #4163 positive
+// gate: a reply whose source IP IS a configured server is forwarded to the
+// client and the drop counter stays zero. It pins the srcAddr explicitly (a
+// configured member other than the default) so the accept path is not an
+// accident of fakeConn's default source.
+func TestHandleServerResponses_ConfiguredSourceForwarded(t *testing.T) {
+	srv := net.IPv4(192, 0, 2, 10)
+	offer := newReply(t, true, testYiaddr, nil, testChaddr) // broadcast flag → client write
+	serverConn := newFakeConn()
+	serverConn.mu.Lock()
+	serverConn.pending = [][]byte{offer.ToBytes()}
+	serverConn.srcAddr = &net.UDPAddr{IP: srv, Port: relayPort}
+	serverConn.mu.Unlock()
+	clientConn := newFakeConn()
+	defer clientConn.Close()
+	fl2 := &fakeL2{}
+	ir := &interfaceRelay{ifaceName: "ge-0-0-0"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		handleServerResponses(ctx, serverConn, clientConn, ir, fl2, testGiaddr, testServerSet(srv))
+		close(done)
+	}()
+
+	writes := waitClientWrite(clientConn)
+	if len(writes) != 1 {
+		t.Fatalf("reply from configured server not forwarded: got %d writes, want 1", len(writes))
+	}
+	if ir.repliesForwarded.Load() != 1 {
+		t.Errorf("repliesForwarded = %d, want 1", ir.repliesForwarded.Load())
+	}
+	if got := ir.repliesDroppedUnknownServer.Load(); got != 0 {
+		t.Errorf("repliesDroppedUnknownServer = %d, want 0 (legit reply must not count as a drop)", got)
+	}
+
+	cancel()
+	serverConn.Close()
+	<-done
+}
+
+// TestHandleServerResponses_UnconfiguredSourceDropped is the #4163 fail-on-revert
+// gate: a syntactically valid OFFER whose SOURCE IP is not a configured server
+// MUST be dropped before it reaches the client (rogue-reply injection), and the
+// repliesDroppedUnknownServer counter MUST increment. Reverting the source
+// check makes this RED — the forged OFFER is forwarded (a client write appears)
+// and the counter stays 0.
+func TestHandleServerResponses_UnconfiguredSourceDropped(t *testing.T) {
+	rogue := net.IPv4(192, 0, 2, 66) // NOT in the configured set
+	offer := newReply(t, true, testYiaddr, nil, testChaddr)
+	offer.GatewayIPAddr = testGiaddr
+	serverConn := newFakeConn()
+	serverConn.mu.Lock()
+	serverConn.pending = [][]byte{offer.ToBytes()}
+	serverConn.srcAddr = &net.UDPAddr{IP: rogue, Port: relayPort}
+	serverConn.mu.Unlock()
+	clientConn := newFakeConn()
+	defer clientConn.Close()
+	fl2 := &fakeL2{}
+	ir := &interfaceRelay{ifaceName: "ge-0-0-0"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		// Configured server set is 10.0.0.1 only; the reply comes from 192.0.2.66.
+		handleServerResponses(ctx, serverConn, clientConn, ir, fl2, testGiaddr, testServerSet())
+		close(done)
+	}()
+
+	// Wait for the drop to register (bounded); the datagram is consumed but
+	// never forwarded, so poll the counter rather than a client write.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if ir.repliesDroppedUnknownServer.Load() > 0 {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	if got := ir.repliesDroppedUnknownServer.Load(); got != 1 {
+		t.Errorf("repliesDroppedUnknownServer = %d, want 1 (rogue reply must be dropped+counted)", got)
+	}
+	clientConn.mu.Lock()
+	nWrites := len(clientConn.writes)
+	clientConn.mu.Unlock()
+	if nWrites != 0 {
+		t.Errorf("rogue reply reached the client: got %d client writes, want 0", nWrites)
+	}
+	if ir.repliesForwarded.Load() != 0 {
+		t.Errorf("repliesForwarded = %d, want 0 (rogue reply must not be forwarded)", ir.repliesForwarded.Load())
+	}
+	if fl2.callCount() != 0 {
+		t.Errorf("rogue reply used raw-L2: got %d calls, want 0", fl2.callCount())
+	}
+
+	cancel()
+	serverConn.Close()
+	<-done
+}
+
+// TestHandleServerResponses_MultiServerGroupAnyMemberForwarded proves the check
+// is set-membership, not first-only: with a two-server group, a reply from the
+// SECOND configured member is forwarded (not just the first). Reverting to a
+// single-server or "==first" check would drop the legitimate reply.
+func TestHandleServerResponses_MultiServerGroupAnyMemberForwarded(t *testing.T) {
+	srvA := net.IPv4(10, 0, 0, 1)
+	srvB := net.IPv4(10, 0, 0, 2)
+	offer := newReply(t, true, testYiaddr, nil, testChaddr)
+	serverConn := newFakeConn()
+	serverConn.mu.Lock()
+	serverConn.pending = [][]byte{offer.ToBytes()}
+	serverConn.srcAddr = &net.UDPAddr{IP: srvB, Port: relayPort} // second member
+	serverConn.mu.Unlock()
+	clientConn := newFakeConn()
+	defer clientConn.Close()
+	fl2 := &fakeL2{}
+	ir := &interfaceRelay{ifaceName: "ge-0-0-0"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		handleServerResponses(ctx, serverConn, clientConn, ir, fl2, testGiaddr, testServerSet(srvA, srvB))
+		close(done)
+	}()
+
+	writes := waitClientWrite(clientConn)
+	if len(writes) != 1 {
+		t.Fatalf("reply from 2nd configured server not forwarded: got %d writes, want 1", len(writes))
+	}
+	if got := ir.repliesDroppedUnknownServer.Load(); got != 0 {
+		t.Errorf("repliesDroppedUnknownServer = %d, want 0", got)
+	}
+
+	cancel()
+	serverConn.Close()
+	<-done
+}
+
+// TestHandleServerResponses_ConfiguredSourceWrongOpCodeDropped confirms the
+// #4163 source check is added ALONGSIDE the existing OpCode gate, not in place
+// of it: a datagram from a CONFIGURED server that is a BOOTREQUEST (wrong
+// OpCode for the reply path) is still dropped — and because the source WAS
+// valid, it is NOT counted as an unknown-server drop.
+func TestHandleServerResponses_ConfiguredSourceWrongOpCodeDropped(t *testing.T) {
+	offer := newReply(t, true, testYiaddr, nil, testChaddr)
+	offer.OpCode = dhcpv4.OpcodeBootRequest // wrong direction for the reply path
+	serverConn := newFakeConn()
+	serverConn.mu.Lock()
+	serverConn.pending = [][]byte{offer.ToBytes()}
+	// default srcAddr (10.0.0.1) is a configured server
+	serverConn.mu.Unlock()
+	clientConn := newFakeConn()
+	defer clientConn.Close()
+	fl2 := &fakeL2{}
+	ir := &interfaceRelay{ifaceName: "ge-0-0-0"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		handleServerResponses(ctx, serverConn, clientConn, ir, fl2, testGiaddr, testServerSet())
+		close(done)
+	}()
+
+	// Let the datagram be consumed (two reads: the pending datagram, then block).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if serverConn.readCalls.Load() >= 2 {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	clientConn.mu.Lock()
+	nWrites := len(clientConn.writes)
+	clientConn.mu.Unlock()
+	if nWrites != 0 {
+		t.Errorf("BOOTREQUEST on the reply path was forwarded: got %d client writes, want 0", nWrites)
+	}
+	if got := ir.repliesDroppedUnknownServer.Load(); got != 0 {
+		t.Errorf("repliesDroppedUnknownServer = %d, want 0 (source WAS configured; OpCode gate dropped it)", got)
+	}
+	if ir.repliesForwarded.Load() != 0 {
+		t.Errorf("repliesForwarded = %d, want 0", ir.repliesForwarded.Load())
 	}
 
 	cancel()

--- a/pkg/dhcprelay/relay.go
+++ b/pkg/dhcprelay/relay.go
@@ -115,6 +115,16 @@ type RelayStats struct {
 	// BACKUP for the interface's redundancy group (#2456 HA relay gate).
 	RequestsDroppedBackup uint64
 
+	// RepliesDroppedUnknownServer counts server replies dropped because their
+	// source IP is NOT one of the configured DHCP servers (#4163). The
+	// server-facing socket is bound (not connected), so it accepts datagrams
+	// from any host that can route to giaddr:67; RFC 3046 relay practice
+	// forwards replies only from the configured server set. A non-zero value
+	// means a non-configured source tried to inject a reply (rogue-DHCP /
+	// lease-hijack attempt) or a legitimately multi-homed server unicast from
+	// an unlisted source IP — either way it MUST be visible, not silent.
+	RepliesDroppedUnknownServer uint64
+
 	// Reply-delivery breakdown (#2076). These distinguish WHY a reply was
 	// broadcast vs L2-unicast so an L2/CAP_NET_RAW/driver/MTU regression is
 	// observable in operations. RepliesBroadcastL2Fallback is the one to
@@ -178,6 +188,12 @@ type interfaceRelay struct {
 	// the observability signal that the HA relay gate is suppressing duplicate
 	// upstream relays on the standby node.
 	requestsDroppedBackup atomic.Uint64
+
+	// repliesDroppedUnknownServer counts server replies dropped by the reply
+	// path because their source IP is not one of the configured DHCP servers
+	// (#4163). It is the observability signal for a rogue-reply injection
+	// attempt (or a multi-homed server unicasting from an unlisted source IP).
+	repliesDroppedUnknownServer atomic.Uint64
 
 	// spec is the desired-config snapshot this relay was started with. Apply
 	// (#2348) compares it against the new desired spec to detect a changed
@@ -661,17 +677,18 @@ func (m *Manager) Stats() []RelayStats {
 	stats := make([]RelayStats, 0, len(m.relays))
 	for _, ir := range m.relays {
 		stats = append(stats, RelayStats{
-			Interface:                  ir.ifaceName,
-			RequestsRelayed:            ir.requestsRelayed.Load(),
-			RepliesForwarded:           ir.repliesForwarded.Load(),
-			RequestsDroppedBackup:      ir.requestsDroppedBackup.Load(),
-			RepliesL2Unicast:           ir.repliesL2Unicast.Load(),
-			RepliesUnicastCiaddr:       ir.repliesUnicastCiaddr.Load(),
-			RepliesBroadcastFlag1:      ir.repliesBroadcastFlag1.Load(),
-			RepliesBroadcastForced:     ir.repliesBroadcastForced.Load(),
-			RepliesBroadcastNoTarget:   ir.repliesBroadcastNoTarget.Load(),
-			RepliesBroadcastL2Fallback: ir.repliesBroadcastL2Fallback.Load(),
-			RepliesBroadcastNak:        ir.repliesBroadcastNak.Load(),
+			Interface:                   ir.ifaceName,
+			RequestsRelayed:             ir.requestsRelayed.Load(),
+			RepliesForwarded:            ir.repliesForwarded.Load(),
+			RequestsDroppedBackup:       ir.requestsDroppedBackup.Load(),
+			RepliesDroppedUnknownServer: ir.repliesDroppedUnknownServer.Load(),
+			RepliesL2Unicast:            ir.repliesL2Unicast.Load(),
+			RepliesUnicastCiaddr:        ir.repliesUnicastCiaddr.Load(),
+			RepliesBroadcastFlag1:       ir.repliesBroadcastFlag1.Load(),
+			RepliesBroadcastForced:      ir.repliesBroadcastForced.Load(),
+			RepliesBroadcastNoTarget:    ir.repliesBroadcastNoTarget.Load(),
+			RepliesBroadcastL2Fallback:  ir.repliesBroadcastL2Fallback.Load(),
+			RepliesBroadcastNak:         ir.repliesBroadcastNak.Load(),
 		})
 	}
 	return stats
@@ -1013,7 +1030,7 @@ func (m *Manager) runRelaySession(ctx context.Context,
 	go func() {
 		defer wg.Done()
 		defer cancel()
-		handleServerResponses(sctx, serverConn, conn, ir, l2, giaddr)
+		handleServerResponses(sctx, serverConn, conn, ir, l2, giaddr, servers)
 	}()
 
 	// Main read loop in its OWN func scope so its `defer cancel()` fires on
@@ -1168,9 +1185,35 @@ func (m *Manager) resolveGIAddrWithRetry(ctx context.Context, ifaceName string) 
 // srcIP is the saved interface giaddr (the IPv4 source the server saw in the
 // relayed request); it MUST come from the caller, not from pkt.GatewayIPAddr,
 // which is zeroed below before sending.
+//
+// Source validation (#4163): the server-facing socket is bound (not
+// connect()-ed) to giaddr:67, so it accepts datagrams from ANY host that can
+// route there. Before parsing or forwarding, each reply's source IP is checked
+// against the configured server set (RFC 3046 relay practice — a relay forwards
+// replies only from its explicit server list); a reply from an unlisted source
+// is DROPPED and counted (repliesDroppedUnknownServer) so an off-path
+// rogue-DHCP / lease-hijack injection cannot reach the client. The check is by
+// IP with net.IP.Equal (the source port is not load-bearing); an empty server
+// set admits nothing (fail-closed — a session is only started with a non-empty
+// set, so this cannot black-hole a legitimately-configured relay).
 func handleServerResponses(ctx context.Context, serverConn, clientConn net.PacketConn,
-	ir *interfaceRelay, l2 l2Replier, srcIP net.IP) {
+	ir *interfaceRelay, l2 l2Replier, srcIP net.IP, servers []*net.UDPAddr) {
 	ifaceName := ir.ifaceName
+	// Build the server-IP allow-set ONCE, outside the read loop. Keep the raw
+	// net.IP (compared with net.IP.Equal) rather than a string key so a 4-in-6
+	// vs 4-byte form never causes a false miss.
+	allow := make([]net.IP, 0, len(servers))
+	for _, s := range servers {
+		if s != nil && s.IP != nil {
+			allow = append(allow, s.IP)
+		}
+	}
+	// warnedUnknownSrc: log the FIRST rogue-source drop of this session at Warn
+	// (loud, so an operator sees the injection attempt / multi-homed
+	// misconfiguration) and subsequent ones at Debug — the counter is the
+	// durable signal, so a flood of forged replies cannot spam the log. Mirrors
+	// the resolveGIAddrWithRetry warn-once pattern.
+	warnedUnknownSrc := false
 	buf := make([]byte, readBufSize)
 	for {
 		n, srcAddr, err := serverConn.ReadFrom(buf)
@@ -1181,6 +1224,23 @@ func handleServerResponses(ctx context.Context, serverConn, clientConn net.Packe
 			}
 			slog.Warn("dhcp-relay: server read error",
 				"interface", ifaceName, "err", err)
+			continue
+		}
+
+		// #4163: drop any reply whose source IP is not a configured server,
+		// BEFORE parsing or forwarding. This closes the rogue-reply injection
+		// hole (a forged OFFER/ACK steering the client to a hostile
+		// gateway/DNS, or a forged NAK forcing a client restart).
+		if !replySourceAllowed(srcAddr, allow) {
+			ir.repliesDroppedUnknownServer.Add(1)
+			if !warnedUnknownSrc {
+				slog.Warn("dhcp-relay: dropping server reply from unconfigured source",
+					"interface", ifaceName, "src", srcAddr)
+				warnedUnknownSrc = true
+			} else {
+				slog.Debug("dhcp-relay: dropping server reply from unconfigured source",
+					"interface", ifaceName, "src", srcAddr)
+			}
 			continue
 		}
 
@@ -1231,6 +1291,49 @@ func handleServerResponses(ctx context.Context, serverConn, clientConn net.Packe
 		if deliverReply(ir, clientConn, l2, srcIP, pkt, replyData) {
 			ir.repliesForwarded.Add(1)
 		}
+	}
+}
+
+// replySourceAllowed reports whether a server reply's source address is one of
+// the configured DHCP servers (#4163). Comparison is by IP with net.IP.Equal so
+// a 4-in-6 vs 4-byte form never yields a false miss; the source port is NOT
+// checked (a strict-RFC server unicasts its reply from BOOTPS/67, but the port
+// is not load-bearing for the trust decision). An empty allow-set admits
+// nothing — a relay session is only started with a non-empty resolved server
+// set, so this fail-closed default never black-holes a legitimately-configured
+// relay.
+func replySourceAllowed(srcAddr net.Addr, allow []net.IP) bool {
+	src := udpAddrIP(srcAddr)
+	if src == nil {
+		return false
+	}
+	for _, ip := range allow {
+		if ip.Equal(src) {
+			return true
+		}
+	}
+	return false
+}
+
+// udpAddrIP extracts the source IP from a ReadFrom address. It handles the
+// *net.UDPAddr a UDP PacketConn returns (and *net.IPAddr for completeness), and
+// falls back to parsing the string form for any other net.Addr implementation.
+// Returns nil when no IP can be extracted (a nil addr or an unparseable form),
+// which replySourceAllowed treats as "not a configured server" (drop).
+func udpAddrIP(addr net.Addr) net.IP {
+	switch a := addr.(type) {
+	case nil:
+		return nil
+	case *net.UDPAddr:
+		return a.IP
+	case *net.IPAddr:
+		return a.IP
+	default:
+		host, _, err := net.SplitHostPort(addr.String())
+		if err != nil {
+			host = addr.String()
+		}
+		return net.ParseIP(host)
 	}
 }
 

--- a/pkg/dhcprelay/relay_test.go
+++ b/pkg/dhcprelay/relay_test.go
@@ -389,6 +389,11 @@ type fakeConn struct {
 	// readErr, if set, is returned by ReadFrom (instead of blocking) once
 	// pending is exhausted — used to simulate an early one-sided close.
 	readErr error
+	// srcAddr, when non-nil, is the source address ReadFrom reports for each
+	// pending datagram. nil falls back to the default 10.0.0.1:68 — this lets
+	// the #4163 source-validation tests drive a reply from a non-configured
+	// source without disturbing the existing reply-path tests.
+	srcAddr net.Addr
 }
 
 type fakeWrite struct {
@@ -406,9 +411,13 @@ func (f *fakeConn) ReadFrom(p []byte) (int, net.Addr, error) {
 	if len(f.pending) > 0 {
 		d := f.pending[0]
 		f.pending = f.pending[1:]
+		src := f.srcAddr
 		f.mu.Unlock()
 		n := copy(p, d)
-		return n, &net.UDPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 68}, nil
+		if src == nil {
+			src = &net.UDPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 68}
+		}
+		return n, src, nil
 	}
 	rerr := f.readErr
 	f.mu.Unlock()


### PR DESCRIPTION
## Summary

Closes #4163 (fable-review-164 L-12; security / DHCP relay hardening).

The DHCPv4 relay forwarded server replies (OFFER/ACK/NAK/FORCERENEW) to
clients based on packet contents alone (`OpCode==BootReply` + a relayable
`MessageType`). `handleServerResponses` read the reply's source address via
`ReadFrom` but used it only in a `slog.Debug` line — it was never validated.
The server-facing socket is `ListenPacket("udp4", giaddr:67)` — **bound, not
`connect()`-ed** — so it accepts datagrams from **any** host that can route to
`giaddr:67`. An off-path attacker (or a compromised transit host) could inject
a forged OFFER/ACK (steering the client to a hostile gateway/DNS → MITM) or a
forged NAK (forcing a client restart). RFC 3046 relay practice forwards replies
only from the relay's explicit, configured server list.

## Fix

- Thread the already-resolved server set (`servers []*net.UDPAddr`, from
  `computeDesired` via `runRelaySession`) into `handleServerResponses`
  (signature + the single call site) and build an IP allow-set once.
- Before `dhcpv4.FromBytes`, **drop any reply whose source IP is not a
  configured server** (compared with `net.IP.Equal`; source port not
  load-bearing) and increment a new `repliesDroppedUnknownServer` counter
  (mirrored to `RelayStats.RepliesDroppedUnknownServer`, populated in `Stats()`,
  surfaced in `show ... dhcp-relay`). Helpers: `replySourceAllowed`, `udpAddrIP`.
- **Enforced by default.** The drop is loud but flood-safe: first drop per
  session at `Warn`, subsequent at `Debug` (counter is the durable signal), so a
  multi-homed server unicasting from an unlisted source IP is diagnosable via
  `RepliesDroppedUnknownServer` rather than a silent black-hole. An explicit
  extra-reply-source allow-list knob is a deliberate follow-up.
- Existing OpCode/MessageType gates preserved (source check added alongside).
  DHCPv4-only (no DHCPv6 relay exists). An empty allow-set fails closed, but a
  session is only started with a non-empty resolved server set.

## Tests (RED-on-revert)

`pkg/dhcprelay/delivery_test.go`: `fakeConn` gains a configurable reply source.
New cases — configured source forwarded (drop counter stays 0); **non-configured
source dropped + `repliesDroppedUnknownServer`==1** (RED on revert: with the
check neutered the forged OFFER reaches the client, `repliesForwarded=1`,
counter=0 — verified); two-server group forwards from either member (set
membership, not first-only); a BOOTREQUEST from a configured server is still
dropped by the OpCode gate WITHOUT counting as an unknown-server drop.

`go test ./pkg/dhcprelay/... ./pkg/cli/...` green; `go build ./...`, `gofmt`,
`go vet` clean.

## Docs

`pkg/dhcprelay/README.md`: new "Reply source validation (#4163)" section +
the counter added to the reply-delivery counters list. `_Log.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
