### PR TITLE
config: warn on to-zone junos-host policy the kernel host-inbound gate can't enforce (Refs #4146)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -33657,3 +33657,30 @@ top.
   issue #4156. Doc: docs/feature-coverage.md HA section.
 - **File(s)**: pkg/cluster/monitor.go, pkg/cluster/monitor_test.go,
   docs/feature-coverage.md, _Log.md
+
+- **Timestamp**: 2026-07-04
+- **Action**: #4146 (H-1 slice c) — commit-time WARNING for the `to-zone
+  junos-host` enforcement gap on the direct host-bound path. Ordinary traffic
+  to a firewall interface IP is delivered by the kernel (XDP shim shunts
+  local-destined packets on a session miss via `is_local_destination` ->
+  `cpumap_or_pass`); the nft `xpf_hostinbound` chain is permit-by-service only
+  (admits configured system-services from ANY source, no per-source/per-app
+  deny), and the fine `junos_host_local_policy` runs only on the userspace XSK
+  `LocalDelivery` path — which a direct-to-interface packet never reaches. So a
+  configured `to-zone junos-host` deny (or source-scoped permit) is silently
+  unenforced there. Added `validateJunosHostDirectDeliveryWarnings` +
+  `junosHostPolicyStricterThanCoarseGate` + `junosHostPolicySourceScoped` to
+  `ValidateConfig`: WARN-only, per `to-zone junos-host` policy (zone-pair or
+  global) that is stricter than the coarse gate — a deny/reject, or a
+  source-restricted permit. Conservative trigger: plain permit-any mirrors the
+  coarse gate and does NOT warn; application-only scope is not a standalone
+  trigger. Never a hard reject (legal Junos; reject would brick a committed
+  config). The actual enforcement (directions a/b) stays PLAN-DEFERRED on #4146
+  (availability-vs-security). New unit tests: warn on deny/reject/source-permit/
+  global-deny, no-warn on permit-any / no-junos-host, nil-safety. Fail-on-revert:
+  removing the ValidateConfig call drops the warning and TestJunosHostDirect
+  DeliveryWarns goes RED. `go test ./pkg/config/...` green; `go build ./...`,
+  gofmt, vet clean. PR: Refs #4146 (keep #4146 open for the deferred enforcement).
+- **File(s)**: pkg/config/compiler_validate_warn.go,
+  pkg/config/compiler_junos_host_direct_warn_4146_test.go,
+  docs/host-inbound-service-matrix.md, _Log.md

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -391,6 +391,75 @@ path ingress-scoped. Two follow-ons are tracked on #3718:
   distinct host-inbound policies (which Option B rejects). A larger architectural
   fork; deferred until there is demand.
 
+## `to-zone junos-host` policy and the direct host-bound path (#4146)
+
+vSRX layers management-plane admission in two places: the coarse
+`host-inbound-traffic system-services <svc>` port gate above, PLUS a fine
+`security policies from-zone <z> to-zone junos-host` (or a global
+`match to-zone junos-host`) policy that can restrict the source or application
+and can `then deny`. On xpf the fine junos-host policy is **not enforced on the
+primary (direct) host-bound path**, so a stricter-than-coarse junos-host policy
+gives a false sense of security.
+
+### The gap
+
+Ordinary traffic to a firewall interface IP is delivered by the **Linux kernel**,
+not the userspace dataplane. On a session miss the XDP shim's `is_local_destination`
+(`userspace-xdp/src/lib.rs`) returns true for any address in the local set and
+shunts the packet to the kernel (`cpumap_or_pass`). The nft `xpf_hostinbound`
+chain — the PRIMARY enforcement surface documented above — is **permit-by-service
+only**: it admits configured `system-services`/`protocols` to a firewall-local
+address from **any** source, with **no per-source and no per-application deny**.
+The fine `to-zone junos-host` policy runs **only** on the userspace AF_XDP
+`LocalDelivery` path (`junos_host_local_policy`), which is reached only by the
+subset of host-bound traffic that arrives on the XSK fast path (e.g. DNAT /
+static-NAT to a firewall-local address) — never by a direct-to-interface-IP
+packet, which was already shunted to the kernel. Net: a
+`from-zone X to-zone junos-host { match source-address ...; then deny; }` (or a
+source-scoped permit) on a plain interface IP is silently unenforced for the
+direct path; hit counters stay zero. This is distinct from #3019 (which wired the
+deny into the XSK `LocalDelivery` arm) and #3292 (the flowless arm): those are the
+XSK paths that DO enforce it.
+
+### Commit-time warning (direction c — shipped)
+
+`config.validateJunosHostDirectDeliveryWarnings` (`pkg/config/compiler_validate_warn.go`,
+run inside `ValidateConfig`) emits a WARN-only commit message for each `to-zone
+junos-host` policy — zone-pair or global — that is **stricter than the coarse
+gate**: a `then deny`/`then reject` (the coarse gate cannot deny a service it
+permits), or a `then permit` with a source-address restriction (the coarse gate
+admits any source). The trigger is deliberately conservative — a plain
+`permit`-from-any to junos-host only mirrors the coarse permit-by-service gate and
+does **not** warn, and an application-only scope is not a standalone trigger
+because the coarse gate already filters by service/dport. It is **never a hard
+reject**: the config is legal Junos, and a reject would brick a previously
+committed config. The warning names the policy and points here.
+
+### Enforcement (directions a/b — deferred on #4146)
+
+Actually enforcing the fine junos-host restriction on the direct path is a
+security-vs-availability decision, not a mechanical fix, so it stays open on #4146:
+
+- **(a) Withhold junos-host-policy'd interface IPs from the local set**
+  (`buildLocalAddressEntries` / `buildDesiredLocalAddressSets`,
+  `pkg/dataplane/userspace/maps_sync.go`). `is_local_destination` then returns
+  false, the packet falls through to the XSK redirect, and the existing
+  `LocalDelivery` junos-host gate enforces the deny. **Cost:** the XSK
+  redirect-error arm is fail-CLOSED (`drop_degraded_transit` → `XDP_DROP`,
+  `lib.rs`), so a withheld IP is **dropped** while the dataplane helper is down —
+  turning "management always reachable" into "reachable only while the helper is
+  healthy", the exact moment an operator needs to log in. Rejected as specified.
+- **(a′) Route LOCAL destinations to the kernel on the redirect-error arm** plus
+  (a)'s withholding — steady-state enforces the deny, helper-down falls open to
+  kernel delivery. A moderate shim change with a bounded (crash-window-only)
+  fail-open on the deny.
+- **(b) Mirror source/application-scoped junos-host policy into the kernel nft
+  `xpf_hostinbound`/`xpf_lo0` chains** — preserves availability, but nft can
+  express only daddr-set + service/dport, not full application/ALG/feed semantics,
+  so it would be a partial mirror that itself introduces a new (coarser) parity
+  gap, and it doubles the enforcement SSOT. The right long-term parity answer, but
+  needs an nft-representability spec.
+
 ## Adding a new host-inbound service
 
 Adding or changing a token is a coordinated edit across all three surfaces so the

--- a/pkg/config/compiler_junos_host_direct_warn_4146_test.go
+++ b/pkg/config/compiler_junos_host_direct_warn_4146_test.go
@@ -1,0 +1,201 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// buildJunosHostWarnTree parses flat set commands via the ParseSetCommand +
+// SetPath loop (NewParser must not be used for set syntax — see CLAUDE.md
+// "Testing flat set syntax").
+func buildJunosHostWarnTree(t *testing.T, cmds []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// junosHostWarnings returns the ValidateConfig warnings that mention the #4146
+// junos-host direct-host-bound parity limitation.
+func junosHostWarnings(t *testing.T, cmds []string) []string {
+	t.Helper()
+	cfg, err := CompileConfig(buildJunosHostWarnTree(t, cmds))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	var got []string
+	for _, w := range ValidateConfig(cfg) {
+		if strings.Contains(w, "to-zone junos-host") && strings.Contains(w, "#4146") {
+			got = append(got, w)
+		}
+	}
+	return got
+}
+
+// baseZones is the minimal zone/address-book scaffolding the junos-host policy
+// cases reference.
+var junosHostBaseZones = []string{
+	"set security zones security-zone untrust interfaces ge-0/0/1.0",
+	"set security zones security-zone untrust host-inbound-traffic system-services ssh",
+	"set security zones security-zone trust interfaces ge-0/0/0.0",
+	"set security address-book global address bad-host 10.0.0.5/32",
+	"set security address-book global address mgmt-net 10.10.0.0/24",
+}
+
+// TestJunosHostDirectDeliveryWarns is the #4146 (H-1 slice c) fail-on-revert
+// guard: a `to-zone junos-host` policy that is STRICTER than the coarse kernel
+// host-inbound gate — a deny/reject, or a source-restricted permit — emits the
+// commit-time parity warning. Reverting the validateJunosHostDirectDelivery
+// Warnings call (or the trigger) drops the warning and this test goes RED.
+func TestJunosHostDirectDeliveryWarns(t *testing.T) {
+	cases := []struct {
+		name       string
+		policyName string
+		reason     string // substring the warning must carry
+		cmds       []string
+	}{
+		{
+			name:       "zone-pair deny with source scope",
+			policyName: `"block-bad"`,
+			reason:     "a deny to-zone junos-host",
+			cmds: append(append([]string{}, junosHostBaseZones...),
+				"set security policies from-zone untrust to-zone junos-host policy block-bad match source-address bad-host",
+				"set security policies from-zone untrust to-zone junos-host policy block-bad match destination-address any",
+				"set security policies from-zone untrust to-zone junos-host policy block-bad match application any",
+				"set security policies from-zone untrust to-zone junos-host policy block-bad then deny",
+			),
+		},
+		{
+			name:       "zone-pair deny with source any (blanket deny is still stricter than a permit-by-service gate)",
+			policyName: `"block-all"`,
+			reason:     "a deny to-zone junos-host",
+			cmds: append(append([]string{}, junosHostBaseZones...),
+				"set security policies from-zone untrust to-zone junos-host policy block-all match source-address any",
+				"set security policies from-zone untrust to-zone junos-host policy block-all match destination-address any",
+				"set security policies from-zone untrust to-zone junos-host policy block-all match application any",
+				"set security policies from-zone untrust to-zone junos-host policy block-all then deny",
+			),
+		},
+		{
+			name:       "zone-pair reject",
+			policyName: `"reject-bad"`,
+			reason:     "a reject to-zone junos-host",
+			cmds: append(append([]string{}, junosHostBaseZones...),
+				"set security policies from-zone untrust to-zone junos-host policy reject-bad match source-address bad-host",
+				"set security policies from-zone untrust to-zone junos-host policy reject-bad match destination-address any",
+				"set security policies from-zone untrust to-zone junos-host policy reject-bad match application any",
+				"set security policies from-zone untrust to-zone junos-host policy reject-bad then reject",
+			),
+		},
+		{
+			name:       "zone-pair source-restricted permit (the standard vSRX layered-management model)",
+			policyName: `"mgmt-only"`,
+			reason:     "a source-restricted permit to-zone junos-host",
+			cmds: append(append([]string{}, junosHostBaseZones...),
+				"set security policies from-zone untrust to-zone junos-host policy mgmt-only match source-address mgmt-net",
+				"set security policies from-zone untrust to-zone junos-host policy mgmt-only match destination-address any",
+				"set security policies from-zone untrust to-zone junos-host policy mgmt-only match application junos-ssh",
+				"set security policies from-zone untrust to-zone junos-host policy mgmt-only then permit",
+			),
+		},
+		{
+			name:       "global policy deny to-zone junos-host",
+			policyName: `global "g-block"`,
+			reason:     "a deny to-zone junos-host",
+			cmds: append(append([]string{}, junosHostBaseZones...),
+				"set security policies global policy g-block match source-address bad-host",
+				"set security policies global policy g-block match destination-address any",
+				"set security policies global policy g-block match application any",
+				"set security policies global policy g-block match to-zone junos-host",
+				"set security policies global policy g-block then deny",
+			),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := junosHostWarnings(t, tc.cmds)
+			if len(got) != 1 {
+				t.Fatalf("expected exactly 1 junos-host parity warning, got %d: %v", len(got), got)
+			}
+			w := got[0]
+			for _, want := range []string{tc.policyName, tc.reason, "direct host-bound path", "docs/host-inbound-service-matrix.md"} {
+				if !strings.Contains(w, want) {
+					t.Errorf("warning missing substring %q:\n  %s", want, w)
+				}
+			}
+		})
+	}
+}
+
+// TestJunosHostDirectDeliveryNoWarn confirms the trigger is conservative: a
+// `to-zone junos-host` policy that only mirrors the coarse permit-by-service
+// gate (a plain permit from any source), and a config with no junos-host
+// policy at all, emit NO parity warning.
+func TestJunosHostDirectDeliveryNoWarn(t *testing.T) {
+	cases := []struct {
+		name string
+		cmds []string
+	}{
+		{
+			name: "plain permit-any to junos-host mirrors the coarse gate",
+			cmds: append(append([]string{}, junosHostBaseZones...),
+				"set security policies from-zone untrust to-zone junos-host policy allow-mgmt match source-address any",
+				"set security policies from-zone untrust to-zone junos-host policy allow-mgmt match destination-address any",
+				"set security policies from-zone untrust to-zone junos-host policy allow-mgmt match application any",
+				"set security policies from-zone untrust to-zone junos-host policy allow-mgmt then permit",
+			),
+		},
+		{
+			name: "no junos-host policy at all",
+			cmds: append(append([]string{}, junosHostBaseZones...),
+				"set security policies from-zone trust to-zone untrust policy any-any match source-address any",
+				"set security policies from-zone trust to-zone untrust policy any-any match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy any-any match application any",
+				"set security policies from-zone trust to-zone untrust policy any-any then permit",
+			),
+		},
+		{
+			name: "global permit-any to junos-host mirrors the coarse gate",
+			cmds: append(append([]string{}, junosHostBaseZones...),
+				"set security policies global policy g-allow match source-address any",
+				"set security policies global policy g-allow match destination-address any",
+				"set security policies global policy g-allow match application any",
+				"set security policies global policy g-allow match to-zone junos-host",
+				"set security policies global policy g-allow then permit",
+			),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := junosHostWarnings(t, tc.cmds); len(got) != 0 {
+				t.Fatalf("expected no junos-host parity warning, got: %v", got)
+			}
+		})
+	}
+}
+
+// TestJunosHostDirectDeliveryWarningsNilSafe mirrors the #3494 nil-tolerance of
+// the surrounding warn pass: the sub-validator must not panic on a nil config
+// or on the tolerant/HA-sync path's nil zone-pair / nil policy entries.
+func TestJunosHostDirectDeliveryWarningsNilSafe(t *testing.T) {
+	if got := validateJunosHostDirectDeliveryWarnings(nil); got != nil {
+		t.Errorf("nil cfg: want nil, got %v", got)
+	}
+	cfg := &Config{}
+	cfg.Security.Policies = []*ZonePairPolicies{
+		nil,
+		{FromZone: "untrust", ToZone: "junos-host", Policies: []*Policy{nil}},
+	}
+	cfg.Security.GlobalPolicies = []*Policy{nil}
+	if got := validateJunosHostDirectDeliveryWarnings(cfg); got != nil {
+		t.Errorf("nil entries: want nil, got %v", got)
+	}
+}

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -914,6 +914,23 @@ func ValidateConfig(cfg *Config) []string {
 	// must not brick a previously-committed config).
 	warnings = append(warnings, validateDefaultPolicyLogWarnings(cfg)...)
 
+	// #4146 (H-1 slice c): warn when a `to-zone junos-host` policy expresses a
+	// constraint STRICTER than the coarse kernel host-inbound gate can enforce
+	// on the DIRECT host-bound path. Ordinary traffic to a firewall interface
+	// IP is delivered by the Linux kernel — the XDP shim shunts local-destined
+	// packets to the kernel on a session miss (userspace-xdp/src/lib.rs
+	// is_local_destination) — and the nft xpf_hostinbound chain admits
+	// configured system-services from ANY source with no per-source /
+	// per-application deny. The fine junos-host restriction is enforced only on
+	// the userspace AF_XDP LocalDelivery path (e.g. DNAT/static-NAT to a
+	// firewall-local address), which the direct host-bound packet never
+	// reaches, so a configured deny (or source-scoped permit) is silently
+	// unenforced there — a false sense of security. WARN-only: the config is
+	// legal Junos and the enforcement decision (a/b) is PLAN-DEFERRED
+	// (availability-vs-security tradeoff). See docs/host-inbound-service-
+	// matrix.md "to-zone junos-host and the direct host-bound path".
+	warnings = append(warnings, validateJunosHostDirectDeliveryWarnings(cfg)...)
+
 	return warnings
 }
 
@@ -955,6 +972,133 @@ func validateDefaultPolicyLogWarnings(cfg *Config) []string {
 			"is already logged via the policy-deny RT_FLOW record). These flags "+
 			"take effect only with `default-policy permit-all`",
 		strings.Join(modes, "/"), action)}
+}
+
+// junosHostPolicySourceScoped reports whether a policy match carries a genuine
+// source-address restriction — i.e. it is narrower than "any source". A match
+// with only the reserved wildcards (`any`/`any-ipv4`/`any-ipv6`/the empty
+// token) is NOT scoped; a match naming a concrete address-book entry, literal
+// prefix, or feed binding IS. `source-address-excluded` is inherently a
+// restriction (permit/deny all EXCEPT the named sources) and so counts as
+// scoped regardless of the token. Mirrors the wildcard set recognized by
+// policyMatchAddressTokenRecognized (#3958) so the two agree on "any".
+func junosHostPolicySourceScoped(m PolicyMatch) bool {
+	if m.SourceAddressExcluded {
+		return true
+	}
+	for _, a := range m.SourceAddresses {
+		switch a {
+		case "", "any", "any-ipv4", "any-ipv6":
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// junosHostPolicyStricterThanCoarseGate reports whether a `to-zone junos-host`
+// policy expresses a constraint the coarse kernel host-inbound gate cannot
+// enforce on the direct host-bound path, and if so a short human label for the
+// reason. The nft `xpf_hostinbound` chain (the PRIMARY enforcement for
+// host-bound traffic the XDP shim shunts to the kernel) is permit-by-service
+// only: it admits configured `system-services`/`protocols` to a firewall-local
+// address from ANY source, with no per-source or per-application DENY. So a
+// junos-host policy is stricter — and therefore silently unenforced on the
+// direct path — when it:
+//   - denies/rejects: the coarse gate cannot deny a service it permits, OR
+//   - permits but restricts the source: the coarse gate admits any source.
+//
+// A plain `then permit` from any source only mirrors (or loosens) the coarse
+// permit-by-service gate and adds no restriction the coarse gate lacks, so it
+// does NOT warn — the conservative trigger the #4146 plan calls for (warn only
+// on a genuinely stricter-than-coarse-gate junos-host policy, not every one).
+// An application-only scope is deliberately not a standalone trigger: the
+// coarse gate already filters by service/dport, so a narrow single-port
+// application largely overlaps it; only the deny and the source restriction are
+// dimensions the coarse gate has no expression for at all.
+func junosHostPolicyStricterThanCoarseGate(action PolicyAction, m PolicyMatch) (bool, string) {
+	switch action {
+	case PolicyDeny:
+		return true, "deny"
+	case PolicyReject:
+		return true, "reject"
+	}
+	if junosHostPolicySourceScoped(m) {
+		return true, "source-restricted permit"
+	}
+	return false, ""
+}
+
+// validateJunosHostDirectDeliveryWarnings emits a WARN-only commit-time message
+// for each `to-zone junos-host` security policy — zone-pair or global — that is
+// stricter than the coarse kernel host-inbound gate can enforce on the DIRECT
+// host-bound path (#4146 H-1 slice c).
+//
+// The gap: ordinary traffic to a firewall interface IP is delivered by the
+// Linux kernel (the XDP shim shunts local-destined packets to the kernel on a
+// session miss — userspace-xdp/src/lib.rs is_local_destination →
+// cpumap_or_pass), whose nft `xpf_hostinbound` chain has no junos-host
+// awareness: it admits configured system-services from any source with no
+// per-source / per-application deny. The fine `to-zone junos-host` restriction
+// runs only on the userspace AF_XDP LocalDelivery path
+// (junos_host_local_policy), which a direct host-bound packet never reaches.
+// So a configured deny (or source-scoped permit) to junos-host is silently
+// unenforced on the primary host-bound path — a false sense of security this
+// warning surfaces at commit.
+//
+// It is never an error: the config is legal Junos, and the actual enforcement
+// fix (withhold the IP from the local set / mirror the policy into nft) is a
+// PLAN-DEFERRED availability-vs-security decision (#4146 directions a/b) — a
+// hard reject would also brick a previously-committed config. Iteration is over
+// the ordered policy slices (deterministic by config order), so the warnings
+// are stable across commits.
+func validateJunosHostDirectDeliveryWarnings(cfg *Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	var warnings []string
+	msg := func(who, reason string) string {
+		return fmt.Sprintf(
+			"security policy %s expresses a %s to-zone junos-host that the kernel "+
+				"host-inbound gate cannot enforce on the direct host-bound path: "+
+				"traffic to a firewall interface IP is delivered by the kernel (the "+
+				"XDP shim shunts local-destined packets to it on a session miss) and "+
+				"nft xpf_hostinbound admits configured system-services from ANY "+
+				"source with no per-source/per-application deny. The junos-host "+
+				"restriction is enforced only on the userspace AF_XDP local-delivery "+
+				"path (e.g. DNAT/static-NAT to a firewall-local address), so this "+
+				"management-plane restriction may not fully apply to the direct path "+
+				"(#4146, known vSRX-parity limitation — see "+
+				"docs/host-inbound-service-matrix.md)",
+			who, reason)
+	}
+	// Zone-pair policies: `from-zone X to-zone junos-host { policy ... }`.
+	for _, zpp := range cfg.Security.Policies {
+		if zpp == nil || zpp.ToZone != "junos-host" {
+			continue
+		}
+		for _, p := range zpp.Policies {
+			if p == nil {
+				continue
+			}
+			if stricter, reason := junosHostPolicyStricterThanCoarseGate(p.Action, p.Match); stricter {
+				warnings = append(warnings, msg(fmt.Sprintf(
+					"%q (from-zone %q)", p.Name, zpp.FromZone), reason))
+			}
+		}
+	}
+	// Global policies with a `match to-zone junos-host` context (#3639). A
+	// `match from-zone junos-host` global is already hard-rejected at commit
+	// (validatePolicyZoneReferencesStrict), so it never reaches here.
+	for _, p := range cfg.Security.GlobalPolicies {
+		if p == nil || p.Match.ToZone != "junos-host" {
+			continue
+		}
+		if stricter, reason := junosHostPolicyStricterThanCoarseGate(p.Action, p.Match); stricter {
+			warnings = append(warnings, msg(fmt.Sprintf("global %q", p.Name), reason))
+		}
+	}
+	return warnings
 }
 
 // validatePreIDDefaultPolicyLogWarnings emits a WARN-only commit-time message


### PR DESCRIPTION
## Summary

Driveable slice (c) of #4146 (fable-164 H-1): a commit-time **WARNING** for
the `to-zone junos-host` enforcement gap on the **direct host-bound path**.
The actual enforcement stays **PLAN-DEFERRED** on #4146 (an
availability-vs-security decision) — this PR ships the honesty warning + doc
so an operator is not given a false sense of security. **Refs #4146** (issue
stays open for the deferred enforcement).

## The gap

Ordinary traffic to a firewall interface IP is delivered by the **Linux
kernel**, not the userspace dataplane: on a session miss the XDP shim's
`is_local_destination` (`userspace-xdp/src/lib.rs`) shunts local-destined
packets to the kernel (`cpumap_or_pass`). The nft `xpf_hostinbound` chain —
the PRIMARY host-inbound enforcement surface — is **permit-by-service only**:
it admits configured `system-services` from **any** source with **no**
per-source / per-application deny. The fine `to-zone junos-host` policy runs
only on the userspace AF_XDP `LocalDelivery` path (`junos_host_local_policy`),
which a direct-to-interface-IP packet never reaches. So a
`from-zone X to-zone junos-host { match source-address ...; then deny; }` (or a
source-scoped permit) on a plain interface IP is silently unenforced there —
a management-plane deny that reaches the RE unfiltered. Distinct from #3019
(wired the deny into the XSK `LocalDelivery` arm) and #3292 (flowless arm).

## The change

`config.validateJunosHostDirectDeliveryWarnings` (in `ValidateConfig`,
`pkg/config/compiler_validate_warn.go`) emits a **WARN-only** commit message
for each `to-zone junos-host` policy — zone-pair or global — that is
**stricter than the coarse gate**:

- `then deny` / `then reject` — the coarse gate cannot deny a service it
  permits, or
- `then permit` with a **source-address restriction** — the coarse gate admits
  any source (this is the standard vSRX layered-management model: coarse
  `host-inbound-traffic system-services ssh` + a fine source-scoped
  `to-zone junos-host` permit).

The trigger is deliberately **conservative**: a plain `permit`-from-any to
junos-host only mirrors the coarse permit-by-service gate and does **not**
warn; an application-only scope is not a standalone trigger (the coarse gate
already filters by service/dport). **Never a hard reject** — the config is
legal Junos and a reject would brick a previously-committed config.

## Deferred (stays on #4146)

Actual enforcement is a security-vs-availability decision, not a mechanical
fix. (a) Withholding the IP from the local set drops all host-bound traffic to
it while the dataplane helper is down (the XSK redirect-error arm is
fail-CLOSED) — turning "management always reachable" into "reachable only while
the helper is healthy". (a′)/(b) each carry real cost (crash-window fail-open,
or a partial nft mirror that introduces its own coarser parity gap). Choosing
among them needs operator/product input, so #4146 stays open.

## Validation

- New unit tests (`pkg/config/compiler_junos_host_direct_warn_4146_test.go`):
  warn on deny / reject / source-restricted-permit / global-deny; **no** warn
  on permit-any / no-junos-host; nil-safety on the tolerant-load path.
- **Fail-on-revert**: removing the `ValidateConfig` call drops the warning and
  `TestJunosHostDirectDeliveryWarns` goes RED (verified); the no-warn cases stay
  green.
- `go test ./pkg/config/...` green; `go build ./...`, `gofmt`, `go vet` clean.
- Doc: `docs/host-inbound-service-matrix.md` gains a
  "`to-zone junos-host` policy and the direct host-bound path (#4146)" section
  recording the gap, the shipped warning, and the deferred enforcement options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
