### PR TITLE
screen: fail closed on a too-short IPv4 L3 header (IPv4/IPv6 symmetry)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -33684,3 +33684,36 @@ top.
 - **File(s)**: pkg/config/compiler_validate_warn.go,
   pkg/config/compiler_junos_host_direct_warn_4146_test.go,
   docs/host-inbound-service-matrix.md, _Log.md
+
+- **Timestamp**: 2026-07-04
+- **Action**: screen: IPv4 L3-header extraction now FAILS CLOSED on a
+  too-short header, symmetric with the IPv6 #2146 contract (#4167,
+  fable-review-164 L-11). Before this, `extract_screen_info`'s IPv4 arm
+  was gated by `addr_family == AF_INET && l3_offset + 20 <= frame.len()`;
+  a too-short IPv4 header failed that gate, fell through neither branch,
+  and returned `Ok(defaults)` (`is_fragment=false`, `ip_ihl=5`,
+  `saw_ipv4_source_route=false`). Those defaults made
+  `check_ping_of_death` / `check_teardrop` / `check_icmp_fragment` /
+  `check_source_route` all early-return, so a malformed/truncated IPv4
+  frame passed UNSCREENED — a fail-open asymmetry vs the IPv6 arm, which
+  returns `Err(TruncatedIpv6ExtChain)` (drop) on `l3_offset + 40 >
+  frame.len()`. Fix: split the AF_INET check from the length check; a
+  base header shorter than 20 bytes, or an IHL claiming `l3_offset +
+  ihl*4 > frame.len()` (options region uncaptured → a source-route
+  option would be silently missed), now returns the new
+  `ScreenParseError::TruncatedIpv4Header` (mapped to the same
+  `ip-malformed` reason as IPv6), which the poll_stages caller already
+  treats as a screen-drop. A valid minimal 20-byte IPv4 header (IHL=5, no
+  options) is NOT over-dropped. RED-on-revert: reverting extract.rs to
+  the fail-open gate (variant kept) makes
+  `extract_screen_info_ipv4_truncated_base_header_fails_closed` and
+  `extract_screen_info_ipv4_ihl_claims_past_frame_fails_closed` FAIL
+  (expect_err panics — the malformed frame is admitted), while
+  `extract_screen_info_ipv4_minimal_header_not_overdropped` stays green.
+  Module docs updated in the extract.rs `extract_screen_info` doc comment
+  and the packet.rs `ScreenParseError` variant comment (no separate
+  markdown documents the screen extractor). FULL `cargo test --release`
+  green (3526 lib + integration suites, 0 failed); `go build ./...` clean.
+- **File(s)**: userspace-dp/src/screen/extract.rs,
+  userspace-dp/src/screen/packet.rs, userspace-dp/src/screen/tests.rs,
+  _Log.md

--- a/userspace-dp/src/screen/extract.rs
+++ b/userspace-dp/src/screen/extract.rs
@@ -18,6 +18,17 @@ use super::packet::{PROTO_TCP, ScreenPacketInfo, ScreenParseError};
 /// IDS-evasion the screen claims to defend against now that the BPF
 /// screen path (#1373/#1476) that masked it is gone.
 ///
+/// #4167 (fable-review-164 L-11): the IPv4 arm is now SYMMETRIC with the
+/// IPv6 fail-closed contract. A too-short IPv4 base header (fewer than
+/// the fixed 20 bytes captured at `l3_offset`) or an IHL that claims a
+/// header longer than the captured frame (`l3_offset + ihl*4 >
+/// frame.len()`) returns `Err(TruncatedIpv4Header)` instead of falling
+/// through to `Ok(defaults)`. The old fall-through left `is_fragment=
+/// false`/`ip_ihl=5`/`saw_ipv4_source_route=false`, so a malformed IPv4
+/// frame bypassed `check_ping_of_death`/`check_teardrop`/
+/// `check_icmp_fragment`/`check_source_route` — the IPv4 mirror of the
+/// IPv6 fail-open the #2146 hardening closed.
+///
 /// #3120: the IPv6 walk now CONTINUES past the Fragment header for a
 /// FIRST fragment (fragment offset == 0) instead of stopping at it, so a
 /// `Fragment → Destination-Options → TCP` chain (RFC 8200 permits an
@@ -65,7 +76,25 @@ pub(crate) fn extract_screen_info(
 
     let mut tcp_offset: Option<usize> = None;
 
-    if addr_family == libc::AF_INET as u8 && l3_offset + 20 <= frame.len() {
+    if addr_family == libc::AF_INET as u8 {
+        // FAIL-CLOSED (#4167 / fable-review-164 L-11): a too-short IPv4
+        // base header — fewer than the mandatory 20 bytes captured at
+        // `l3_offset` — cannot be parsed to evaluate the fragment /
+        // source-route / ICMP screens. Return an `Err` so the caller
+        // fail-closes (drop), MIRRORING the IPv6 `l3_offset + 40 >
+        // frame.len()` arm below. Before this, the too-short IPv4 case
+        // fell through to the terminal `Ok(info)` with defaults
+        // (`is_fragment=false`, `ip_ihl=5`, `saw_ipv4_source_route=
+        // false`), which made `check_ping_of_death` / `check_teardrop` /
+        // `check_icmp_fragment` / `check_source_route` all early-return
+        // and let a truncated frame pass UNSCREENED — a fail-open
+        // asymmetry vs the IPv6 #2146 fail-closed contract. A valid
+        // minimal 20-byte IPv4 header (IHL=5, no options) is NOT
+        // dropped; only a runt/malformed capture shorter than the base
+        // header its own layout requires.
+        if l3_offset + 20 > frame.len() {
+            return Err(ScreenParseError::TruncatedIpv4Header);
+        }
         // IPv4: extract IHL, total_len, frag_off from the fixed 20-byte
         // base header. frag_off is bytes 6-7, big-endian.
         let ip_hdr = &frame[l3_offset..];
@@ -77,6 +106,19 @@ pub(crate) fn extract_screen_info(
         info.is_fragment = (info.ip_frag_off & 0x3FFF) != 0;
         info.is_first_fragment =
             (info.ip_frag_off & 0x2000) != 0 && (info.ip_frag_off & 0x1FFF) == 0;
+        // FAIL-CLOSED (#4167): the header's own IHL claims a header
+        // (`ihl*4`) longer than the captured frame, so the options
+        // region — and thus any LSRR/SSRR source-route option — cannot
+        // be parsed. Drop rather than silently skip the scan below,
+        // which would leave `saw_ipv4_source_route=false` for a route
+        // the extractor was UNABLE to read (a fail-open on the
+        // `source-route` screen). Mirrors the IPv6 extension-header
+        // overshoot fail-closed check. A minimal IHL=5 header always
+        // survives — `l3_offset + 20 <= frame.len()` was just asserted.
+        let ihl_bytes = (info.ip_ihl as usize) * 4;
+        if l3_offset + ihl_bytes > frame.len() {
+            return Err(ScreenParseError::TruncatedIpv4Header);
+        }
         // #2973: scan the IPv4 options region (bytes 20..ihl*4) for an
         // actual source-route option. The `source-route` screen used to
         // drop on ANY IHL>5 (any options present), which also dropped
@@ -84,8 +126,9 @@ pub(crate) fn extract_screen_info(
         // Detect only LSRR (option type 131 = copied|control|9) and
         // SSRR (137 = copied|control|11). Bounded TLV walk; EOOL(0) ends,
         // NOP(1) is one byte, every other option is length-prefixed.
-        let ihl_bytes = (info.ip_ihl as usize) * 4;
-        if info.ip_ihl > 5 && l3_offset + ihl_bytes <= frame.len() {
+        // The options region is guaranteed captured by the fail-closed
+        // `l3_offset + ihl_bytes > frame.len()` check above.
+        if info.ip_ihl > 5 {
             const IPOPT_EOOL: u8 = 0;
             const IPOPT_NOP: u8 = 1;
             const IPOPT_LSRR: u8 = 131;

--- a/userspace-dp/src/screen/packet.rs
+++ b/userspace-dp/src/screen/packet.rs
@@ -135,6 +135,17 @@ pub(crate) enum ScreenParseError {
     /// otherwise leave `is_first_fragment=false` and silently bypass
     /// the `syn-frag` screen.
     TruncatedIpv6ExtChain,
+    /// The IPv4 L3 header was truncated: fewer than the fixed 20 base
+    /// bytes were captured at `l3_offset`, or the header's own IHL field
+    /// claims a header (`ihl*4`) longer than the captured frame. The
+    /// symmetric IPv4 counterpart to `TruncatedIpv6ExtChain` (#4167 /
+    /// fable-review-164 L-11): before this, a too-short IPv4 header fell
+    /// through to `Ok(defaults)` (`is_fragment=false`, `ip_ihl=5`, no
+    /// source-route), so `check_ping_of_death`/`check_teardrop`/
+    /// `check_icmp_fragment`/`check_source_route` all early-returned and
+    /// the malformed frame passed unscreened — a fail-open asymmetry vs
+    /// the IPv6 #2146 fail-closed contract.
+    TruncatedIpv4Header,
 }
 
 impl ScreenParseError {
@@ -148,6 +159,7 @@ impl ScreenParseError {
     pub(crate) fn screen_reason(self) -> &'static str {
         match self {
             ScreenParseError::TruncatedIpv6ExtChain => "ip-malformed",
+            ScreenParseError::TruncatedIpv4Header => "ip-malformed",
         }
     }
 }

--- a/userspace-dp/src/screen/tests.rs
+++ b/userspace-dp/src/screen/tests.rs
@@ -1357,6 +1357,93 @@ fn extract_screen_info_ipv6_truncated_base_header_fails_closed() {
 }
 
 #[test]
+fn extract_screen_info_ipv4_truncated_base_header_fails_closed() {
+    // #4167 (L-11): AF_INET metadata but the captured frame is shorter
+    // than the mandatory 20-byte IPv4 base header at l3_offset 14. Pre-
+    // fix, the `addr_family == AF_INET && l3_offset + 20 <= frame.len()`
+    // gate fell through to `Ok(defaults)` (is_fragment=false, ip_ihl=5,
+    // no source-route) and the frame passed UNSCREENED. Now it is FAIL-
+    // CLOSED, symmetric with the IPv6 base-header case above. Goes RED
+    // on revert (the Err becomes Ok → an unparseable frame is admitted).
+    let frame = vec![0u8; 14 + 15]; // 5 bytes short of the 20-byte header
+    let res = extract_screen_info(
+        &frame,
+        libc::AF_INET as u8,
+        6,
+        0x02,
+        29,
+        IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+        IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8)),
+        12345,
+        80,
+        14,
+    );
+    assert_eq!(
+        res.expect_err("short IPv4 base header must fail closed"),
+        ScreenParseError::TruncatedIpv4Header
+    );
+}
+
+#[test]
+fn extract_screen_info_ipv4_ihl_claims_past_frame_fails_closed() {
+    // #4167 (L-11): the 20-byte base header IS captured, but the IHL
+    // field claims 6 words = 24 bytes while only 20 are present. The
+    // options region (bytes 20..24) cannot be read, so a source-route
+    // option would be silently missed. FAIL-CLOSED rather than skip the
+    // scan (the pre-fix `l3_offset + ihl_bytes <= frame.len()` guard let
+    // this fall through with saw_ipv4_source_route=false). Goes RED on
+    // revert.
+    let mut frame = vec![0u8; 14 + 20]; // exactly 20 IPv4 bytes captured
+    let ip = 14;
+    frame[ip] = 0x46; // version=4, ihl=6 → claims 24 header bytes
+    frame[ip + 9] = 6; // protocol = TCP
+    let res = extract_screen_info(
+        &frame,
+        libc::AF_INET as u8,
+        6,
+        0x02,
+        34,
+        IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+        IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8)),
+        12345,
+        80,
+        14,
+    );
+    assert_eq!(
+        res.expect_err("IHL claiming more than captured must fail closed"),
+        ScreenParseError::TruncatedIpv4Header
+    );
+}
+
+#[test]
+fn extract_screen_info_ipv4_minimal_header_not_overdropped() {
+    // #4167 (L-11) over-drop guard: a VALID minimal 20-byte IPv4 header
+    // (IHL=5, no options) must still parse Ok — the fail-closed fix must
+    // NOT drop a legitimate runt-but-complete IPv4 packet. Frame carries
+    // exactly the 20-byte base header at l3_offset 14 and nothing more.
+    let mut frame = vec![0u8; 14 + 20];
+    let ip = 14;
+    frame[ip] = 0x45; // version=4, ihl=5 → 20-byte header, no options
+    frame[ip + 9] = 6; // protocol = TCP
+    let info = extract_screen_info(
+        &frame,
+        libc::AF_INET as u8,
+        6,
+        0x02,
+        34,
+        IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+        IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8)),
+        12345,
+        80,
+        14,
+    )
+    .expect("valid minimal 20-byte IPv4 header must NOT be over-dropped");
+    assert!(!info.is_fragment, "no MF/offset → not a fragment");
+    assert!(!info.saw_ipv4_source_route, "no options → no source route");
+    assert_eq!(info.ip_ihl, 5, "IHL=5 parsed from the minimal header");
+}
+
+#[test]
 fn extract_screen_info_ipv6_truncated_hopbyhop_fails_closed() {
     // NextHdr=HOP-BY-HOP (0) at the base header, but the chain is cut
     // off before the hop-by-hop header's own 2 length bytes — the walk


### PR DESCRIPTION
Closes #4167

## Problem

The screen field extractor `extract_screen_info` (`userspace-dp/src/screen/extract.rs`) was **asymmetric** between IPv4 and IPv6 when the captured L3 header is too short to parse:

- **IPv6 fails CLOSED**: returns `Err(ScreenParseError::TruncatedIpv6ExtChain)` on `l3_offset + 40 > frame.len()` (or any extension-header overshoot). The `afxdp/poll_stages.rs` caller treats every `Err` as a screen-drop (`err.screen_reason()` -> `ip-malformed`). This is the #2146/#2189/#2361 fail-closed contract.
- **IPv4 failed OPEN**: the arm was gated by `addr_family == AF_INET && l3_offset + 20 <= frame.len()`. A too-short IPv4 header failed the gate, entered neither branch, and fell through to the terminal `Ok(info)` with defaults (`is_fragment=false`, `ip_ihl=5`, `saw_ipv4_source_route=false`). With those defaults `check_ping_of_death` / `check_teardrop` / `check_icmp_fragment` / `check_source_route` all early-return, so a malformed/truncated IPv4 frame passed **unscreened**.

A second fail-open: when the IHL field claimed a header longer than the captured bytes (`l3_offset + ihl*4 > frame.len()`), the source-route option scan was skipped, so an LSRR/SSRR the extractor could not read left `saw_ipv4_source_route=false` and the `source-route` screen could not fire.

## Fix

Split the AF_INET family check from the length check and add two fail-closed guards mirroring the IPv6 arm exactly:

- `l3_offset + 20 > frame.len()` (base header truncated) -> `Err(TruncatedIpv4Header)`
- `l3_offset + ihl*4 > frame.len()` (IHL claims past the captured frame) -> `Err(TruncatedIpv4Header)`

The new `ScreenParseError::TruncatedIpv4Header` variant maps to the same `ip-malformed` reason string as the IPv6 variant, so the existing caller drop path is unchanged. A valid minimal 20-byte IPv4 header (IHL=5, no options) is **not** over-dropped.

## Tests (RED on revert)

- `extract_screen_info_ipv4_truncated_base_header_fails_closed` — 15-byte header -> `Err`. RED on revert (frame admitted).
- `extract_screen_info_ipv4_ihl_claims_past_frame_fails_closed` — IHL=6, 20 captured -> `Err`. RED on revert.
- `extract_screen_info_ipv4_minimal_header_not_overdropped` — valid 20-byte header -> `Ok` (over-drop guard, stays green on revert).

Verified: reverting `extract.rs` to the fail-open gate (variant retained) makes both `fails_closed` tests FAIL (`expect_err` panics) while `not_overdropped` stays green.

## Validation

- FULL `cargo test --release` (single-threaded) green — 3526 lib tests + integration suites, 0 failed.
- `go build ./...` clean.
- rustfmt clean on the changed lines (two pre-existing whole-crate drift hunks left untouched).

Module docs updated in the `extract_screen_info` and `ScreenParseError` doc comments (no separate markdown documents the screen extractor).

Source: fable-review-164 finding L-11.