### PR TITLE
image/packaging: install frr-pythontools so the appliance FRR reload isn't permanently degraded

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-07-04 — #4172 (fable-review-165 H-3): frr-pythontools missing from baked image + metapackage
+
+- **Timestamp**: 2026-07-04
+  - **Action**: The baked appliance never installed `frr-pythontools`,
+    so `/usr/lib/frr/frr-reload.py` (the daemon's primary FRR reload
+    path — `pkg/frr/vtysh.go` `frrReloadScript`, invoked from
+    `pkg/frr/manager.go:641/824`) was permanently absent. Every reload
+    silently fell back to the additive `vtysh -f` path and the
+    degraded-retry loop re-execed the missing script forever, so a
+    deleted route/BGP neighbor kept forwarding/advertising. The dev/test
+    cluster installs `frr-pythontools` (`cluster-setup.sh:452`), so the
+    real reload path was the one combination never exercised.
+  - **Fix**: (a) added `frr-pythontools` to `RUNTIME_PACKAGES`
+    (`scripts/image/bake.py`, right after `frr`) with a comment; (b)
+    added `frr-pythontools,` to the `xpf-appliance` `Depends`
+    (`debian/control`, right after `frr,`) — kept in sync per the
+    bake.py comment; (c) added a bake-time HARD-ASSERT
+    `test -x /usr/lib/frr/frr-reload.py` (mirrors the growpart assert)
+    so future frr package-name drift FAILS THE BAKE instead of silently
+    degrading; (d) added a `validate.py` scenario-A presence check
+    (mirrors the growpart presence check).
+  - **Test**: `test_bake_sign_ordering.py` new `RuntimePackageSyncTests`
+    asserts `frr-pythontools` membership in BOTH lists + a `frr`
+    baseline guard on the parse logic. RED-on-revert proven: removing
+    the additions makes 2 membership tests FAIL; baseline stays green.
+    `debian/control` re-parses cleanly (RFC822 paragraph parse). Doc:
+    `docs/install-images.md` bake-steps note.
+  - **File(s)**: scripts/image/bake.py, debian/control,
+    scripts/image/validate.py, scripts/image/test_bake_sign_ordering.py,
+    docs/install-images.md, _Log.md
+
 ## 2026-07-04 — #4161 (fable-review-164 M-3) + L-9: source-NAT most-specific-scope-wins
 
 - **Timestamp**: 2026-07-04

--- a/debian/control
+++ b/debian/control
@@ -39,6 +39,7 @@ Architecture: amd64
 Depends: ${misc:Depends},
  xpf (= ${binary:Version}),
  frr,
+ frr-pythontools,
  strongswan,
  strongswan-swanctl,
  kea-dhcp4-server,

--- a/docs/install-images.md
+++ b/docs/install-images.md
@@ -68,7 +68,16 @@ Pipeline (offline — the image is never booted to provision it):
    (a competing network manager), snapd, and the virtual-kernel
    metapackages, systemd-networkd + resolved enabled, FRR + chrony
    enabled (default NTP pools neutered; xpfd manages
-   `sources.d/xpf.sources`), sysctls, `init_on_alloc=0` (via an
+   `sources.d/xpf.sources`). FRR is installed WITH `frr-pythontools`
+   (`RUNTIME_PACKAGES` + the `xpf-appliance` `Depends`, kept in sync):
+   it provides `/usr/lib/frr/frr-reload.py`, the daemon's primary FRR
+   reload path (`pkg/frr`). It is NOT pulled in transitively by the
+   `frr` package, so it is listed explicitly and a bake-time
+   `test -x /usr/lib/frr/frr-reload.py` assert (plus a `validate.py`
+   presence check) fails the build if it is ever missing — without it
+   every reload silently degrades to the additive `vtysh -f` fallback
+   and stale-config removal (a deleted route/BGP neighbor) never
+   converges (#4172). Then sysctls, `init_on_alloc=0` (via an
    `/etc/default/grub.d` drop-in — Ubuntu cloud images override
    `GRUB_CMDLINE_LINUX_DEFAULT` there), and `apt-get install ./xpf.deb`.
    The package's `postinst` always stages the binary set into

--- a/scripts/image/bake.py
+++ b/scripts/image/bake.py
@@ -55,7 +55,17 @@ import sign  # noqa: E402
 # entry point (e.g. from a future hosted repo, #1924). Keep this list and
 # the metapackage Depends in debian/control in sync.
 RUNTIME_PACKAGES = [
-    "frr", "strongswan", "strongswan-swanctl",
+    # #4172: frr-pythontools provides /usr/lib/frr/frr-reload.py, the
+    # daemon's PRIMARY FRR reload path (pkg/frr/vtysh.go frrReloadScript,
+    # invoked from pkg/frr/manager.go). It is NOT pulled in transitively by
+    # the `frr` package, so it MUST be listed explicitly here (and in the
+    # xpf-appliance Depends, kept in sync per the comment above). Without it
+    # every reload silently falls back to the additive `vtysh -f` path and
+    # the degraded-retry loop never converges stale-config removal — a
+    # deleted route/BGP neighbor keeps forwarding/advertising. A bake-time
+    # hard-assert below (`test -x /usr/lib/frr/frr-reload.py`) fails the bake
+    # loudly if a future frr package-name drift drops the tool.
+    "frr", "frr-pythontools", "strongswan", "strongswan-swanctl",
     "kea-dhcp4-server", "kea-dhcp6-server", "chrony",
     "iproute2", "nftables", "ethtool", "tcpdump", "pciutils",
     "iputils-ping", "traceroute", "openssh-server", "openssh-client",
@@ -433,6 +443,18 @@ def virt_customize(work_qcow, xpf_deb):
         'command -v resize2fs >/dev/null || { echo "FATAL: resize2fs missing '
         '(#1925; e2fsprogs not installed)" >&2; exit 1; }; '
         'echo "#1925: growpart + resize2fs present ($(command -v growpart), $(command -v resize2fs))"',
+        # HARD-ASSERT the FRR reload tool survived the package install. It is
+        # provided by frr-pythontools (RUNTIME_PACKAGES above), NOT the base
+        # `frr` package. If a future frr package-name drift drops it, FAIL THE
+        # BAKE here rather than silently ship an image whose FRR reload is
+        # permanently degraded — the additive `vtysh -f` fallback never
+        # converges stale-config removal, so a deleted route/BGP neighbor
+        # keeps forwarding/advertising (#4172). Mirrors the growpart assert.
+        "--run-command",
+        'test -x /usr/lib/frr/frr-reload.py || { echo "FATAL: /usr/lib/frr/'
+        'frr-reload.py missing (#4172 FRR reload permanently degraded; '
+        'frr-pythontools not installed)" >&2; exit 1; }; '
+        'echo "#4172: frr-reload.py present (/usr/lib/frr/frr-reload.py)"',
         "--write", f"/etc/default/grub.d/99-xpf.cfg:{GRUB_DROPIN}",
         "--run-command", "update-grub",
         "--write", f"/etc/ssh/sshd_config.d/10-xpf-factory.conf:{SSHD_DROPIN}",

--- a/scripts/image/test_bake_sign_ordering.py
+++ b/scripts/image/test_bake_sign_ordering.py
@@ -132,5 +132,48 @@ class ValidationGateStepTests(unittest.TestCase):
         bake.validation_gate_step(True, "/nonexistent.qcow2", "/nonexistent.meta")
 
 
+class RuntimePackageSyncTests(unittest.TestCase):
+    """#4172: frr-pythontools (provider of /usr/lib/frr/frr-reload.py, the
+    daemon's primary FRR reload path) MUST appear in BOTH the bake's
+    RUNTIME_PACKAGES and the xpf-appliance metapackage Depends, kept in sync
+    per the bake.py comment. Missing it silently degrades every appliance's
+    FRR reload to the additive `vtysh -f` fallback (stale-config removal
+    never converges). RED on revert: dropping it from either list fails
+    here."""
+
+    @staticmethod
+    def _appliance_depends():
+        control = Path(__file__).resolve().parents[2] / "debian" / "control"
+        text = control.read_text()
+        stanza = text.split("Package: xpf-appliance", 1)[1]
+        # Depends runs until the next control field at column 0 (Description:).
+        depends = stanza.split("Depends:", 1)[1].split("\nDescription:", 1)[0]
+        pkgs = set()
+        for entry in depends.split(","):
+            tok = entry.strip()
+            if tok:
+                # Drop any version constraint / arch qualifier after the name.
+                pkgs.add(tok.split()[0])
+        return pkgs
+
+    def test_frr_pythontools_in_runtime_packages(self):
+        self.assertIn(
+            "frr-pythontools", bake.RUNTIME_PACKAGES,
+            "frr-pythontools missing from bake RUNTIME_PACKAGES "
+            "(#4172: /usr/lib/frr/frr-reload.py provider)")
+
+    def test_frr_pythontools_in_appliance_depends(self):
+        self.assertIn(
+            "frr-pythontools", self._appliance_depends(),
+            "frr-pythontools missing from xpf-appliance Depends in "
+            "debian/control (#4172; keep in sync with RUNTIME_PACKAGES)")
+
+    def test_frr_present_as_baseline(self):
+        # Guard the split/parse logic itself: `frr` must resolve in both
+        # lists, so a false-negative parse can't mask a real regression.
+        self.assertIn("frr", bake.RUNTIME_PACKAGES)
+        self.assertIn("frr", self._appliance_depends())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/image/validate.py
+++ b/scripts/image/validate.py
@@ -207,6 +207,16 @@ class Harness:
                  check=False).returncode != 0:
             fail("in-guest verify-dataplane REJECTED — image must not ship")
         self.wait_fxp0_dhcp("xpf-image-a")
+        # #4172: frr-pythontools (/usr/lib/frr/frr-reload.py) MUST be present
+        # or every FRR reload silently degrades to the additive `vtysh -f`
+        # fallback and stale-config removal never converges (a deleted route
+        # keeps forwarding). It is NOT pulled in transitively by `frr`, so
+        # assert presence here — package-name drift fails with a clear cause
+        # rather than as the downstream "deleted route still active" symptom.
+        if not guest_sh("xpf-image-a", 'test -x /usr/lib/frr/frr-reload.py'):
+            fail("frr-reload.py missing (/usr/lib/frr/frr-reload.py) — "
+                 "frr-pythontools not installed (#4172 FRR reload permanently "
+                 "degraded; stale-config removal never converges)")
         if not guest_sh("xpf-image-a", 'ss -tln | grep -q ":22 "'):
             fail("sshd not listening")
         if not guest_sh("xpf-image-a",


### PR DESCRIPTION
Closes #4172

## Problem

The daemon's PRIMARY FRR reload path shells out to
`/usr/lib/frr/frr-reload.py` (`pkg/frr/vtysh.go:44` `frrReloadScript`,
invoked from `pkg/frr/manager.go:641` and `manager.go:824`). That script
is provided by the Debian/Ubuntu **`frr-pythontools`** package.

Neither the baked image's `RUNTIME_PACKAGES` (`scripts/image/bake.py`)
nor the `xpf-appliance` metapackage `Depends` (`debian/control`)
installed it — despite the `bake.py` comment mandating the two lists stay
in sync. So **every appliance permanently ran the degraded FRR reload**:

1. First reload: `frr-reload.py` ENOENT -> warn-once -> additive
   `vtysh -f` fallback (`manager.go:650`); commit succeeds (degraded).
2. The degraded-retry loop meant to converge stale-config removal
   (`manager.go:824-825`) re-execs the same missing script forever.
3. Operator deletes a static route / BGP neighbor and commits: the
   additive load cannot remove it — the stale route keeps
   forwarding/advertising until FRR is restarted by hand.

On a router, "deleted route still active" is a correctness and security
defect, present on every image-based install from its first routing
commit. The dev/test cluster DOES install `frr-pythontools`
(`test/incus/cluster-setup.sh:452`), so the real (non-degraded) reload
path was the ONE combination never exercised.

## Fix

- Add `frr-pythontools` to `RUNTIME_PACKAGES` (`scripts/image/bake.py`,
  right after `frr`).
- Add `frr-pythontools,` to the `xpf-appliance` `Depends`
  (`debian/control`, right after `frr,`) — kept in sync per the bake.py
  comment.
- Bake-time HARD-ASSERT `test -x /usr/lib/frr/frr-reload.py` (mirrors the
  growpart assert) so future frr package-name drift FAILS THE BAKE loudly
  instead of silently shipping a degraded appliance.
- `validate.py` scenario-A presence check (mirrors the growpart check).

## Tests

- `scripts/image/test_bake_sign_ordering.py` — new `RuntimePackageSyncTests`
  asserts `frr-pythontools` membership in BOTH lists (parsing
  `debian/control` for the Depends) plus an `frr` baseline guard on the
  parse logic. All 9 tests pass.
- **RED on revert proven**: removing the additions makes the 2 membership
  tests FAIL (`FAILED (failures=2)`); the baseline `frr` test stays green,
  confirming the parse logic is sound.
- `debian/control` re-parses cleanly (RFC822 paragraph parse).

## Docs

- `docs/install-images.md` bake-steps: document FRR is installed WITH
  `frr-pythontools`, why it is explicit, and the bake-assert + validate
  check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi