### PR TITLE
deploy: give each libvirt VM its own qcow2 overlay off the golden (H-20)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -33717,3 +33717,36 @@ top.
 - **File(s)**: userspace-dp/src/screen/extract.rs,
   userspace-dp/src/screen/packet.rs, userspace-dp/src/screen/tests.rs,
   _Log.md
+
+- **Timestamp**: 2026-07-04
+- **Action**: fable-165 H-20 — libvirt deploy attached the shared golden
+  qcow2 to every VM as a WRITABLE `--disk`, so an HA pair booted two live
+  domains off ONE file (qcow2 is not a cluster filesystem → concurrent
+  metadata/refcount writes corrupt it), and even a single
+  `virt-install --import` mutated the golden master in place (day-0
+  stamp/host keys/configstore DB baked in; the next VM inherited the
+  prior identity and skipped its own config). Added `libvirt_disk()` in
+  `scripts/deploy/xpf-deploy.py`: each domain now gets its OWN
+  copy-on-write overlay `qemu-img create -f qcow2 -b <golden> -F qcow2
+  /var/lib/libvirt/images/<name>.qcow2`, and virt-install attaches that
+  overlay; the golden is an immutable read-only backing store shared by
+  all nodes and is never written. A re-deploy re-creates the overlay
+  (fresh boot from golden); `virt-install --name` still refuses to
+  redefine a live domain so a running VM's overlay is not clobbered. A
+  name==image collision (overlay would overwrite the golden) is
+  hard-rejected; a missing golden fails with a fetch/import hint before
+  qemu-img runs. This matches the incus backend, which already clones per
+  instance via `incus init`. Added
+  `scripts/deploy/test_xpf_deploy_disk.py` (unittest, importlib-loads the
+  hyphenated module): HA pair → two DISTINCT non-golden writable disks,
+  each overlay `-b` the golden read-only, virt-install attaches exactly
+  the created overlay, standalone gets its own overlay, name==image
+  rejected. RED-on-revert PROVEN: reverting to the shared-golden `--disk`
+  makes all 4 tests FAIL (no qemu-img overlay created; both VMs share the
+  golden). `python3 -m py_compile` clean; unittest 4/4 OK. Updated
+  `examples/deploy/README.md` "incus vs libvirt" (was "Both run the
+  *same* qcow2" — now documents per-VM overlay / per-instance clone +
+  a Root-disk table row). Refs fable-165 H-20 (issue #4171).
+- **File(s)**: scripts/deploy/xpf-deploy.py,
+  scripts/deploy/test_xpf_deploy_disk.py, examples/deploy/README.md,
+  _Log.md

--- a/examples/deploy/README.md
+++ b/examples/deploy/README.md
@@ -74,13 +74,20 @@ ready to drop into `source`.
 
 ## incus vs libvirt
 
-Both run the *same* qcow2 and *same* day-0 drive; only the VM/NIC
-declaration differs. Pick with `--hypervisor` (default `incus`):
+Both build from the *same* golden qcow2 and the *same* day-0 drive; only
+the VM/NIC declaration differs. Pick with `--hypervisor` (default
+`incus`). Neither backend attaches the golden image writable: incus
+clones a per-instance root disk via `incus init`, and libvirt creates a
+per-VM copy-on-write overlay (`qemu-img create -b <golden>`) so the
+golden stays a read-only backing store. An HA pair therefore gets two
+DISTINCT writable disks — attaching one shared writable qcow2 to two
+live VMs would corrupt it.
 
 | | incus | libvirt / KVM |
 |---|---|---|
 | **Best for** | quick, scriptable, VM fleets; the project's own test cluster | existing `virsh` shops; fine-grained guest PCI control |
 | **Tool action** | runs `incus init` + `device add…` + `start` end-to-end | emits a `virt-install` command you run |
+| **Root disk** | per-instance clone from the image store (`incus init`) | per-VM `qemu-img` overlay `<name>.qcow2` backed read-only by `<image>.qcow2` |
 | **NIC ordering** | device-name order (`dev00…`) → PCI slot → positional name | `--network`/`--hostdev` order → persisted `<address>` slots (pin in `virsh edit` for full control) |
 | **SR-IOV auto-VF** | `nictype=sriov parent=<PF>` | one-time `<forward mode='hostdev'>` VF pool (tool prints the XML) |
 | **SR-IOV specific VF** | `pci:<vf-addr>,mac=` | `pci:<vf-addr>,mac=` (same definition) |

--- a/scripts/deploy/test_xpf_deploy_disk.py
+++ b/scripts/deploy/test_xpf_deploy_disk.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Unit tests for the libvirt per-VM disk overlay (fable-165 H-20).
+
+The libvirt deploy path must NOT attach the shared golden qcow2 to a VM
+as a writable disk. qcow2 is not a cluster filesystem, so an HA pair
+booting two live domains off one file corrupts it, and even a single
+`virt-install --import` would mutate the golden master in place (day-0
+stamp, host keys, configstore DB baked in). Each domain must instead get
+its OWN copy-on-write overlay
+(`qemu-img create -f qcow2 -b <golden> -F qcow2 <overlay>`), leaving the
+golden an immutable read-only backing store.
+
+These tests drive deploy_libvirt() with a recording runner and assert:
+  - an HA pair (fw0, fw1) gets TWO DISTINCT per-VM disk paths;
+  - neither VM's writable --disk is the golden image;
+  - each VM's overlay is created with the golden as the read-only -b
+    backing store;
+  - the overlay handed to virt-install is exactly the one qemu-img just
+    created;
+  - the standalone case also gets its own overlay, never the golden.
+
+On revert (attach `path=.../{image}.qcow2` directly to both domains) the
+distinctness and non-golden assertions go RED: both VMs get the same
+path and it IS the golden.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "xpf_deploy", Path(__file__).with_name("xpf-deploy.py")
+)
+xpf_deploy = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(xpf_deploy)
+
+
+class RecordingRunner:
+    """Runner that records every argv instead of executing it.
+
+    dry=True so libvirt_disk() skips the host-state golden-exists check
+    (there is no real image in a unit test); the recording still captures
+    the qemu-img/virt-install argv the code would run.
+    """
+
+    def __init__(self):
+        self.dry = True
+        self.calls = []
+
+    def run(self, argv):
+        self.calls.append(list(argv))
+        return ""
+
+
+def _appliance(name, node_id=None):
+    ap = {
+        "name": name,
+        "mode": "cluster" if node_id is not None else "standalone",
+        "node_id": node_id,
+        "image": "xpf-appliance",
+        "cpu": 2,
+        "memory": "4G",
+        # no "config" -> build_config_drive returns None (no ISO build).
+        "interfaces": [
+            {"_name": "fxp0", "backing": "bridge", "source": "br-mgmt"},
+        ],
+    }
+    return ap
+
+
+def _find_call(calls, prog):
+    for c in calls:
+        if c and c[0] == prog:
+            return c
+    return None
+
+
+def _boot_disk_path(virt_install_argv):
+    """Return the writable boot --disk path (the one that is not a cdrom)."""
+    disks = [virt_install_argv[i + 1]
+             for i, a in enumerate(virt_install_argv) if a == "--disk"]
+    boot = [d for d in disks if "device=cdrom" not in d]
+    assert len(boot) == 1, f"expected exactly one boot disk, got {boot}"
+    val = boot[0]
+    assert val.startswith("path="), f"unexpected --disk form: {val}"
+    return val[len("path="):]
+
+
+def _qemu_backing_and_overlay(qemu_argv):
+    """Return (backing, overlay) from a `qemu-img create ... -b B ... OVERLAY`."""
+    backing = qemu_argv[qemu_argv.index("-b") + 1]
+    overlay = qemu_argv[-1]  # target is the final positional arg
+    return backing, overlay
+
+
+GOLDEN = f"{xpf_deploy.LIBVIRT_IMAGES}/xpf-appliance.qcow2"
+
+
+class LibvirtPerVmDiskTests(unittest.TestCase):
+    def _deploy(self, ap):
+        r = RecordingRunner()
+        xpf_deploy.deploy_libvirt(ap, r, start=False)
+        virt = _find_call(r.calls, "virt-install")
+        qemu = _find_call(r.calls, "qemu-img")
+        self.assertIsNotNone(virt, "virt-install was not invoked")
+        self.assertIsNotNone(qemu, "qemu-img create was not invoked")
+        return virt, qemu
+
+    def test_ha_pair_gets_two_distinct_non_golden_disks(self):
+        virt0, qemu0 = self._deploy(_appliance("ha-fw0", node_id=0))
+        virt1, qemu1 = self._deploy(_appliance("ha-fw1", node_id=1))
+
+        disk0 = _boot_disk_path(virt0)
+        disk1 = _boot_disk_path(virt1)
+
+        # (a) each VM gets a DISTINCT writable disk — the corruption fix.
+        self.assertNotEqual(
+            disk0, disk1,
+            "HA pair must not share one writable qcow2 (image corruption)")
+
+        # (b) neither writable disk is the golden image.
+        self.assertNotEqual(disk0, GOLDEN)
+        self.assertNotEqual(disk1, GOLDEN)
+
+        # (c) each overlay is backed READ-ONLY by the golden image.
+        back0, ov0 = _qemu_backing_and_overlay(qemu0)
+        back1, ov1 = _qemu_backing_and_overlay(qemu1)
+        self.assertEqual(back0, GOLDEN)
+        self.assertEqual(back1, GOLDEN)
+
+        # (d) virt-install attaches exactly the overlay qemu-img created.
+        self.assertEqual(disk0, ov0)
+        self.assertEqual(disk1, ov1)
+        self.assertNotEqual(ov0, ov1)
+
+        # (e) qemu-img creates qcow2 overlays with the qcow2 backing fmt.
+        for q in (qemu0, qemu1):
+            self.assertEqual(q[:3], ["qemu-img", "create", "-f"])
+            self.assertIn("-F", q)
+            self.assertEqual(q[q.index("-F") + 1], "qcow2")
+
+    def test_golden_is_never_attached_writable(self):
+        # Across BOTH nodes, no virt-install writable --disk is the golden.
+        for name, nid in (("ha-fw0", 0), ("ha-fw1", 1)):
+            virt, _ = self._deploy(_appliance(name, node_id=nid))
+            self.assertNotEqual(_boot_disk_path(virt), GOLDEN)
+
+    def test_standalone_gets_own_overlay(self):
+        virt, qemu = self._deploy(_appliance("fw-solo"))
+        disk = _boot_disk_path(virt)
+        back, overlay = _qemu_backing_and_overlay(qemu)
+        self.assertNotEqual(disk, GOLDEN)
+        self.assertEqual(back, GOLDEN)
+        self.assertEqual(disk, overlay)
+
+    def test_name_equal_image_is_rejected(self):
+        # If the VM name equals the golden basename the overlay path would
+        # collide with the golden and overwrite it — must hard-fail.
+        ap = _appliance("xpf-appliance")  # name == image
+        r = RecordingRunner()
+        with self.assertRaises(SystemExit):
+            xpf_deploy.deploy_libvirt(ap, r, start=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/deploy/xpf-deploy.py
+++ b/scripts/deploy/xpf-deploy.py
@@ -355,13 +355,53 @@ def deploy_incus(ap, runner, start):
         print(f"{name} created (not started): incus start {name}")
 
 
+# Directory libvirt/KVM keeps its qcow2 disks in (the default pool path).
+LIBVIRT_IMAGES = "/var/lib/libvirt/images"
+
+
+def libvirt_disk(ap, runner):
+    """Return a per-VM writable qcow2 backed READ-ONLY by the golden image.
+
+    The golden image ({image}.qcow2) must NEVER be attached writable:
+    qcow2 is not a cluster filesystem, so an HA pair booting two live
+    domains off one file corrupts it (concurrent metadata/refcount
+    writes), and even a single `virt-install --import` would mutate the
+    golden master in place — the day-0 stamp, host keys, and configstore
+    DB would get baked into it, and the NEXT VM launched "from the image"
+    would inherit the previous VM's identity and skip its own config.
+
+    Each domain gets its OWN copy-on-write overlay instead
+    (`qemu-img create -f qcow2 -b <golden> -F qcow2 <overlay>`), so the
+    golden stays an immutable shared backing store and each VM writes
+    only to its distinct {name}.qcow2. A re-deploy re-creates the overlay
+    (a fresh boot from golden); `virt-install --name` still refuses to
+    redefine a live domain, so a running VM's overlay is not clobbered
+    out from under it.
+    """
+    golden = os.path.join(LIBVIRT_IMAGES, f"{ap['image']}.qcow2")
+    overlay = os.path.join(LIBVIRT_IMAGES, f"{ap['name']}.qcow2")
+    if os.path.abspath(overlay) == os.path.abspath(golden):
+        die(f"VM name '{ap['name']}' collides with the golden image basename "
+            f"'{ap['image']}' — the per-VM overlay would overwrite the golden "
+            f"image. Rename the appliance (name:) or the image (image:).")
+    if not runner.dry and not os.path.isfile(golden):
+        die(f"golden image not found: {golden} — fetch/import it first "
+            f"(see `xpf-deploy.py fetch`) or set image: in the YAML.")
+    # Fresh overlay per deploy so the VM boots clean from golden; the
+    # golden is the read-only -b backing store and is never written.
+    runner.run(["qemu-img", "create", "-f", "qcow2",
+                "-b", golden, "-F", "qcow2", overlay])
+    return overlay
+
+
 def deploy_libvirt(ap, runner, start):
     name = ap["name"]
     print_map(ap)
     iso = build_config_drive(ap, runner)
+    disk = libvirt_disk(ap, runner)
     argv = ["virt-install", "--name", name, "--memory", str(memory_mb(ap["memory"])),
             "--vcpus", str(ap["cpu"]), "--import",
-            "--disk", f"path=/var/lib/libvirt/images/{ap['image']}.qcow2",
+            "--disk", f"path={disk}",
             "--osinfo", "ubuntu26.04", "--noautoconsole"]
     if iso:
         argv += ["--disk", f"path={iso},device=cdrom"]


### PR DESCRIPTION
Closes #4171

## Problem

`deploy_libvirt()` in `scripts/deploy/xpf-deploy.py` attached the shared
golden image `/var/lib/libvirt/images/<image>.qcow2` to every domain as a
WRITABLE `--disk` (line 364 at HEAD). Since every YAML defaults
`image: xpf-appliance`, `deploy --hypervisor libvirt ha-fw0.yaml ha-fw1.yaml`
points BOTH live VMs at the SAME file.

- **HA pair = image corruption.** qcow2 is not a cluster filesystem; two
  running VMs writing one qcow2 corrupt its metadata/refcount blocks.
- **Even a single deploy poisons the golden.** `virt-install --import`
  mutates the master in place — the day-0 stamp, host keys, and the
  configstore DB get baked in, so the NEXT VM "from the image" comes up
  with the previous VM's identity and silently skips its own config drive.

The incus backend was already correct: `incus init` clones a per-instance
root disk from the image store rather than booting the golden directly.

## Fix

Add `libvirt_disk()`: each domain gets its OWN copy-on-write overlay

    qemu-img create -f qcow2 -b <golden> -F qcow2 /var/lib/libvirt/images/<name>.qcow2

and virt-install attaches that overlay (`--disk path=<overlay>`). The
golden becomes an immutable read-only backing store shared by all nodes
and is never written. A re-deploy re-creates the overlay (a clean boot
from golden); `virt-install --name` still refuses to redefine a live
domain, so a running VM's overlay is not clobbered underneath it.

Guards: a `name == image` collision (the overlay path would equal the
golden and overwrite it) is hard-rejected; a missing golden fails with a
fetch/import hint before qemu-img runs.

## How each VM's disk is now distinct + golden read-only

- Overlay path is keyed on the per-VM `name` (`ha-fw0` / `ha-fw1` /
  standalone), which is unique per node → distinct writable disks.
- The golden appears ONLY as the `qemu-img -b` backing (read-only); it is
  never passed to `virt-install --disk`.

## Test

`scripts/deploy/test_xpf_deploy_disk.py` (unittest; importlib-loads the
hyphenated module) drives `deploy_libvirt()` with a recording runner and
asserts: an HA pair yields two DISTINCT non-golden writable disks, each
overlay is created with the golden as the read-only `-b` backing,
virt-install attaches exactly the overlay qemu-img created, the
standalone case gets its own overlay, and `name == image` is rejected.

**RED-on-revert (proven):** reverting to the shared-golden `--disk` makes
all 4 tests FAIL — no qemu-img overlay is created and both VMs share the
golden path.

```
Ran 4 tests in 0.001s
OK
```

`python3 -m py_compile` clean on both files.

## Docs

`examples/deploy/README.md` "incus vs libvirt" previously claimed "Both
run the *same* qcow2" (the bug). Updated to state neither backend
attaches the golden writable (incus per-instance clone / libvirt per-VM
overlay) + a Root-disk table row. `_Log.md` updated.

Found as fable-review-165 finding H-20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi