### PR TITLE
day-0 config-drive: guard on committed active.json, not bare .configdb dir (fix dead retry)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-04 — #4175 (fable-review-165 H-1): day-0 config-drive retry permanently dead — loader guarded on bare .configdb directory
+
+- **Timestamp**: 2026-07-04
+  - **Action**: The day-0 config-drive loader's "already configured,
+    skip the probe" guard tested bare directory existence
+    (`[ -e "$XPF_DIR/.configdb" ]`, `scripts/image/xpf-day0-config`).
+    But xpfd durably creates that directory on EVERY start
+    (`pkg/configstore/db.go` `NewDB` → `MkdirAllDurable`, via
+    `configstore.New` → `daemon.New`, before any commit). So after the
+    very first boot the empty `.configdb` dir exists → the loader logged
+    "system already configured" and NEVER re-probed the medium,
+    permanently defeating its own documented reject → fix → reboot retry
+    contract (`xpf-day0-config` Retriability note; `docs/install-images.md`
+    Recovery). The COMMITTED config is `active.json`, written only on
+    commit/sync/rollback; a rejected/absent drive enters factory
+    bootstrap without ever writing it.
+  - **Fix**: guard on the COMMITTED artifact, not the directory. Changed
+    the guard to `have_committed_config()` testing
+    `[ -e "$XPF_DIR/.configdb/active.json" ]`, and fixed the misleading
+    log line to "committed config present (…/active.json) — system
+    already configured". Chose the script-only active.json path (smallest,
+    version-skew-safe) over an `xpfd config-state`/EverCommitted
+    subcommand: reading the #1922 committed marker needs envelope-header
+    parsing + master-key handling, not trivial, and the subcommand adds a
+    version-skew surface the script-only fix avoids. Added a source-guard
+    (`XPF_DAY0_SOURCE_ONLY=1`) so the loader can be sourced for unit tests.
+    Updated the loader header comment and `docs/install-images.md`
+    (first-boot contract table + loader specifics).
+  - **Test**: new `test/image/day0-configdb-guard-test.sh` — 5 scenarios
+    (3 unit on `have_committed_config`, 2 integration driving `main()`
+    with stubbed probes). RED-on-revert proven: reverting the guard to
+    the bare `.configdb` dir makes scenarios A (empty dir must re-probe)
+    and D (main must reach the probe) FAIL with exit 1. shellcheck clean
+    on both the loader and the test.
+  - **File(s)**: scripts/image/xpf-day0-config,
+    test/image/day0-configdb-guard-test.sh, docs/install-images.md,
+    _Log.md
+
 ## 2026-07-04 — #4172 (fable-review-165 H-3): frr-pythontools missing from baked image + metapackage
 
 - **Timestamp**: 2026-07-04

--- a/docs/install-images.md
+++ b/docs/install-images.md
@@ -212,7 +212,7 @@ Plain QEMU works the same way (`-drive file=xpf-<ver>.qcow2`
 | Factory default: fxp0 DHCP, root console login, no password | Identical: fxp0 DHCP bootstrap; root login on the hypervisor console with empty password; sshd refuses empty/root-password auth |
 | Day-0 config: ISO with `juniper.conf` at the root, attached as CD-ROM | ISO (or any volume labeled `xpf-config`) with `xpf.conf` at the root — `juniper.conf` accepted as an alias; optional `node-id` file (`0`/`1`) for cluster members |
 | Bad day-0 config: boots factory-default | Identical, but stricter: the config is validated with the REAL commit-check gate (`xpfd check-config`) BEFORE install; a REJECT logs loudly and the system stays factory-default |
-| Day-0 applied once | Applied at most once: stamped after success; never clobbers an existing config (`.configdb` or preseeded `xpf.conf`). A REJECTED medium does not stamp — fix the config and reboot to retry while the system is still factory-default |
+| Day-0 applied once | Applied at most once: stamped after success; never clobbers an existing config (a COMMITTED `.configdb/active.json` or a preseeded `xpf.conf`). A REJECTED medium does not stamp — fix the config and reboot to retry while the system is still factory-default |
 
 Day-0 loader specifics (`scripts/image/xpf-day0-config`, oneshot unit
 `Before=xpfd.service`):
@@ -228,6 +228,14 @@ Day-0 loader specifics (`scripts/image/xpf-day0-config`, oneshot unit
 - Failures never block the boot: the unit is ordering-only (no
   `Requires=`), the script always exits 0, and `TimeoutStartSec`
   backstops a hung mount. Fallback is always the factory bootstrap.
+- The "already configured, skip the probe" guard tests
+  `/etc/xpf/.configdb/active.json` (a COMMITTED config), NOT the bare
+  `.configdb` directory. xpfd creates that directory on EVERY start
+  (`configstore.NewDB` → `MkdirAllDurable`, before any commit), so its
+  mere existence is not a "configured" signal — guarding on it would
+  make a box that booted once (empty `.configdb` present) permanently
+  skip the probe, killing the fix-and-reboot retry above. A box in
+  factory bootstrap has no `active.json`, so the loader re-probes.
 
 Build a config drive:
 

--- a/scripts/image/xpf-day0-config
+++ b/scripts/image/xpf-day0-config
@@ -6,9 +6,17 @@
 # applied at first boot while the system is factory-default. This is
 # the xpf analog, run as a oneshot systemd unit ordered Before=xpfd:
 #
-#   1. If the system has ever had a config (stamp file, configstore DB,
-#      or a preseeded /etc/xpf/xpf.conf), do nothing. A day-0 config is
+#   1. If the system has ever been configured (stamp file, a COMMITTED
+#      configstore DB — active.json, written only on commit/sync — or a
+#      preseeded /etc/xpf/xpf.conf), do nothing. A day-0 config is
 #      applied at most once; later boots never re-apply or clobber.
+#      The guard tests active.json, NOT the bare .configdb directory:
+#      xpfd creates that directory on EVERY start (NewDB ->
+#      MkdirAllDurable, before any commit), so its mere existence is not
+#      a "configured" signal. Guarding on the bare directory silently
+#      defeated the fix-and-reboot retry contract (see Retriability
+#      below): after the first boot the empty .configdb existed, so a
+#      rejected/absent drive could never be retried.
 #   2. Probe attached block devices for a config medium: any volume
 #      labeled `xpf-config` (any filesystem type), plus any ISO9660
 #      medium (the vSRX cdrom convention). The medium must carry
@@ -184,6 +192,20 @@ try_device() {
 	return 0
 }
 
+# have_committed_config — true (0) when the box already holds a COMMITTED
+# configstore DB, i.e. .configdb/active.json exists. active.json is written
+# only by a successful commit / HA sync / rollback (pkg/configstore/db.go
+# WriteActive*); the bare .configdb DIRECTORY is created on EVERY xpfd start
+# by NewDB -> MkdirAllDurable (before any commit), so its existence is NOT a
+# "configured" signal. Testing active.json — not the directory — is what
+# makes the fix-and-reboot retry contract work: a rejected/absent drive
+# leaves the box in factory bootstrap with no active.json, so the loader
+# re-probes on the next boot instead of falsely declaring "already
+# configured" forever.
+have_committed_config() {
+	[ -e "$XPF_DIR/.configdb/active.json" ]
+}
+
 main() {
 	regen_ssh_host_keys
 
@@ -191,8 +213,8 @@ main() {
 		log "day-0 config already applied ($STAMP) — skipping"
 		return 0
 	fi
-	if [ -e "$XPF_DIR/.configdb" ]; then
-		log "configstore DB exists — system already configured, skipping day-0 probe"
+	if have_committed_config; then
+		log "committed config present ($XPF_DIR/.configdb/active.json) — system already configured, skipping day-0 probe"
 		return 0
 	fi
 	if [ -e "$XPF_DIR/xpf.conf" ]; then
@@ -228,5 +250,11 @@ main() {
 	return 0
 }
 
-main "$@"
-exit 0
+# Run main unless the file is sourced for unit tests. A test sets
+# XPF_DAY0_SOURCE_ONLY=1 and sources this script to exercise the individual
+# helpers (e.g. have_committed_config, main with stubbed probes) without
+# actually running the day-0 loader.
+if [ "${XPF_DAY0_SOURCE_ONLY:-}" != "1" ]; then
+	main "$@"
+	exit 0
+fi

--- a/test/image/day0-configdb-guard-test.sh
+++ b/test/image/day0-configdb-guard-test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Regression test for the day-0 config-drive "already configured" guard
+# (fable-review-165 H-1, issue #4175).
+#
+# The loader (scripts/image/xpf-day0-config) must skip the day-0 probe only
+# when the box holds a COMMITTED configstore DB — i.e. .configdb/active.json
+# exists — NOT merely when the bare .configdb DIRECTORY exists. xpfd creates
+# .configdb on EVERY start (pkg/configstore NewDB -> MkdirAllDurable, before
+# any commit), so guarding on the directory permanently defeated the
+# fix-and-reboot retry contract: after the very first boot the empty
+# .configdb dir existed and a rejected/absent drive could never be retried.
+#
+# RED-on-revert: change have_committed_config back to `[ -e "$XPF_DIR/.configdb" ]`
+# and scenarios A and D fail (an empty .configdb dir wrongly reports
+# "already configured" / suppresses the re-probe).
+#
+#   bash test/image/day0-configdb-guard-test.sh
+#
+# shellcheck disable=SC1007  # `CDPATH= cd` is an env-prefix, not an assignment
+# shellcheck disable=SC1090  # the sourced loader path is a runtime argument
+# shellcheck disable=SC2034  # STAMP/XPFD are consumed by the sourced main()
+# shellcheck disable=SC2329  # probe/regen stubs are invoked indirectly by main()
+set -u
+
+HERE=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+SCRIPT="${1:-$HERE/../../scripts/image/xpf-day0-config}"
+[ -f "$SCRIPT" ] || { echo "loader not found: $SCRIPT" >&2; exit 1; }
+
+# Source the loader as a library (do not run main).
+XPF_DAY0_SOURCE_ONLY=1 . "$SCRIPT"
+set +u  # keep the harness relaxed; the sourced script re-enables -u
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# make_stub_xpfd <path> — an executable stand-in so main()'s `[ ! -x "$XPFD" ]`
+# gate passes and the probe path is reached.
+make_stub_xpfd() {
+	cat >"$1" <<'STUB'
+#!/bin/sh
+exit 0
+STUB
+	chmod +x "$1"
+}
+
+# ── unit: the have_committed_config predicate ─────────────────────────────
+
+# A: an empty .configdb directory (no active.json) must NOT count as
+# configured — this is the exact state xpfd leaves after every start, and the
+# state the retry contract depends on re-probing.
+scenario_empty_dir_reprobes() (
+	XPF_DIR=$(mktemp -d)
+	mkdir -p "$XPF_DIR/.configdb"
+	if have_committed_config; then
+		fail "A: empty .configdb dir wrongly reported as committed (retry would be dead)"
+	fi
+	rm -rf "$XPF_DIR"
+	echo "PASS A: empty .configdb dir -> re-probe (not configured)"
+)
+
+# B: a committed DB (active.json present) must count as configured.
+scenario_active_json_skips() (
+	XPF_DIR=$(mktemp -d)
+	mkdir -p "$XPF_DIR/.configdb"
+	: >"$XPF_DIR/.configdb/active.json"
+	if ! have_committed_config; then
+		fail "B: active.json present but not reported as committed (would clobber a real config)"
+	fi
+	rm -rf "$XPF_DIR"
+	echo "PASS B: .configdb/active.json present -> skip (configured)"
+)
+
+# C: no .configdb at all must NOT count as configured.
+scenario_no_configdb_reprobes() (
+	XPF_DIR=$(mktemp -d)
+	if have_committed_config; then
+		fail "C: absent .configdb reported as committed"
+	fi
+	rm -rf "$XPF_DIR"
+	echo "PASS C: no .configdb -> re-probe (not configured)"
+)
+
+# ── integration: main()'s skip/probe decision ────────────────────────────
+# Stub the side-effecting helpers so main() exercises only the guard chain.
+
+# D: empty .configdb + a valid xpfd + no media -> main must fall through the
+# guard chain and REACH the probe (logs the no-medium fallback), proving the
+# retry path is alive. It must NOT log "already configured".
+scenario_main_empty_dir_probes() (
+	XPF_DIR=$(mktemp -d)
+	STAMP="$XPF_DIR/.day0-config-applied"
+	XPFD="$XPF_DIR/xpfd"; make_stub_xpfd "$XPFD"
+	mkdir -p "$XPF_DIR/.configdb"          # empty dir as xpfd leaves it
+	regen_ssh_host_keys() { :; }           # no ssh-keygen
+	probe_devices() { :; }                 # no media -> empty
+	out=$(main 2>&1)
+	echo "$out" | grep -q "already configured" && \
+		fail "D: main logged 'already configured' on an empty .configdb dir (retry dead)"
+	echo "$out" | grep -q "no config medium found" || \
+		fail "D: main did not reach the probe path on an empty .configdb dir"
+	rm -rf "$XPF_DIR"
+	echo "PASS D: empty .configdb dir -> main re-probes the medium"
+)
+
+# E: a committed DB (active.json) -> main must short-circuit at the guard and
+# never reach the probe.
+scenario_main_active_json_skips() (
+	XPF_DIR=$(mktemp -d)
+	STAMP="$XPF_DIR/.day0-config-applied"
+	XPFD="$XPF_DIR/xpfd"; make_stub_xpfd "$XPFD"
+	mkdir -p "$XPF_DIR/.configdb"
+	: >"$XPF_DIR/.configdb/active.json"
+	regen_ssh_host_keys() { :; }
+	probe_devices() { fail "E: main probed media despite a committed active.json"; }
+	out=$(main 2>&1)
+	echo "$out" | grep -q "already configured" || \
+		fail "E: main did not skip on a committed active.json"
+	rm -rf "$XPF_DIR"
+	echo "PASS E: committed active.json -> main skips the day-0 probe"
+)
+
+# Each scenario runs in a subshell; `fail` exits that subshell non-zero, so
+# propagate it to the overall exit status (a swallowed subshell exit would
+# let CI see a green run despite FAIL lines).
+scenario_empty_dir_reprobes      || exit 1
+scenario_active_json_skips       || exit 1
+scenario_no_configdb_reprobes    || exit 1
+scenario_main_empty_dir_probes   || exit 1
+scenario_main_active_json_skips  || exit 1
+echo "ALL DAY-0 CONFIGDB GUARD SCENARIOS PASSED"


### PR DESCRIPTION
## Problem

The day-0 config-drive loader (`scripts/image/xpf-day0-config`) skipped
its probe whenever the `.configdb` **directory** existed:

    if [ -e "$XPF_DIR/.configdb" ]; then
        log "configstore DB exists — system already configured..."
        return 0

But xpfd creates that directory durably on **every** start, before any
commit: `configstore.NewDB` -> `fsatomic.MkdirAllDurable`
(`pkg/configstore/db.go:48`), reached via `configstore.New`
(`store.go:196`) -> `daemon.New` (`daemon.go:714`) unconditionally.

So after the very first boot the empty `.configdb` dir exists, the loader
logs "system already configured", and **never re-probes the medium
again** — permanently defeating its own documented reject -> fix ->
reboot retry contract (the Retriability note in the script, and the
Recovery section of `docs/install-images.md`). An operator who ships a
config drive with a typo gets a correct REJECT on the first boot, fixes
the ISO, reboots to retry, and the loader silently ignores the drive
forever with an actively misleading log line. The only escape was to
delete `.configdb` by hand. `validate.py` scenario C tests
reject-within-one-boot only, so the bake gate structurally could not
catch it.

## Fix

Guard on the **committed artifact**, not the directory:

    have_committed_config() {
        [ -e "$XPF_DIR/.configdb/active.json" ]
    }

`active.json` (`pkg/configstore/db.go:70-72`) is written only by a
successful commit / HA sync / rollback, so its presence is a true "the
box has a config" signal. A rejected/absent drive leaves the box in
factory bootstrap with **no** `active.json` (bootstrap does not run
`bootstrapFromFile` unless `/etc/xpf/xpf.conf` exists,
`daemon_apply.go:56-72`), so the loader correctly re-probes on the next
boot. The skip-log message now names `active.json` so an operator
debugging a dead retry is not misled.

**Why script-only active.json (not an `xpfd config-state` subcommand):**
the active.json path is the smallest, version-skew-safe fix. Reading the
#1922 `EverCommitted` marker precisely (for the narrow never-committed
edge where `active.json` is written with `committed=0` by the
first-commit rollback) needs envelope-header parsing plus master-key
handling and adds a version-skew surface — not trivial, and not needed to
fix the reported retry death.

A source-guard (`XPF_DAY0_SOURCE_ONLY=1`) lets the loader be sourced by a
unit test without running `main`.

## Test

New `test/image/day0-configdb-guard-test.sh` — hermetic bash, 5 scenarios
(3 unit on `have_committed_config`, 2 integration driving `main()` with
stubbed probes):

| | state | expected |
|---|---|---|
| A | empty `.configdb` dir, no active.json | not configured -> re-probe |
| B | `.configdb/active.json` present | configured -> skip |
| C | no `.configdb` | not configured -> re-probe |
| D | `main()` on empty `.configdb` dir | reaches probe, never logs "already configured" |
| E | `main()` on committed active.json | short-circuits, no probe |

Scenario A is the exact state xpfd leaves after every start.

**RED-on-revert proven:** reverting the guard to `[ -e "$XPF_DIR/.configdb" ]`
makes scenarios A and D FAIL and the harness exits non-zero (subshell
failures propagate). shellcheck clean on both the loader and the test.

A full VM `reject -> fix-ISO -> reboot -> assert applied` scenario belongs
in `validate.py` as a follow-up but is not runnable in this harness; the
unit test covers the guard logic runnably.

## Docs

`docs/install-images.md` first-boot contract table + loader-specifics list
updated to state the guard tests `active.json`, not the bare directory.
The Recovery section's retry promise is now accurate (it previously
documented a retry that was broken). `_Log.md` updated.

Closes #4175

Found in fable-review-165 (H-1).