### PR TITLE
deploy: reject virtio-after-hardware NIC order that silently swaps firewall zones (H-22)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-04 — #4180 (fable-review-165 H-22): deploy role validation ignored the guest virtio-first PCI tiebreaker — virtio-after-hardware silently swaps zones
+
+- **Timestamp**: 2026-07-04
+  - **Action**: `scripts/deploy/xpf-deploy.py` `validate_appliance()`
+    checked each declared `role` against its raw LIST INDEX only
+    (`expected_name(i, ...)`), but the guest does not name NICs by attach
+    order. `enumeratePCINICs()` (`pkg/daemon/linksetup.go:189-204`) sorts
+    NICs with a virtio-first tiebreaker (`sk=0` for `virtio_net`, `sk=1`
+    for hardware) BEFORE `assignName()` assigns positional vSRX names. So
+    a YAML/`--nic` list that put a virtio-class NIC (`net`/`bridge`/
+    `macvlan`) AFTER a hardware-class NIC (`sriov`/`physical`/`pci`)
+    passed validation but booted with the firewall zones/policies/NAT on
+    SWAPPED ports (trust/untrust inverted) — a silent security miswiring.
+  - **Fix**: classify each backing virtio-class vs hardware-class
+    (`VIRTIO_BACKINGS`/`HARDWARE_BACKINGS` + `backing_sort_key()`,
+    mirroring the guest `sk=0`/`sk=1` rule) and FAIL CLOSED (`die()`) in
+    `validate_appliance` when a virtio-class interface appears after a
+    hardware-class one, naming both offending positions and telling the
+    operator to reorder. Chose reject over silent reorder because the
+    zone→vSRX-name binding lives in the operator's day-0 `.conf` (which
+    the tool does not rewrite); reordering could still land the intended
+    backing on a different vSRX name invisibly. Reject keeps the existing
+    "position is the contract" guarantee honest.
+  - **Test**: `scripts/deploy/test_xpf_deploy_nicorder.py` (11 tests,
+    mirrors the H-20 `test_xpf_deploy_disk.py` pattern) — asserts the
+    virtio-after-hardware layout is rejected (with/without roles,
+    standalone + cluster), the reordered set validates with correct
+    positional names, pure-virtio/pure-hardware pass, and all shipped
+    example YAMLs satisfy the guard. RED-on-revert verified: dropping the
+    guard un-raises the four rejection tests.
+  - **Docs**: `docs/deploy-quickstart.md` "60-second mental model" and
+    `examples/deploy/README.md` "naming contract is positional" — replaced
+    the "identical to pure position in every normal layout" hand-wave
+    with the explicit virtio-first rule + the new validate-time reject.
+  - **File(s)**: `scripts/deploy/xpf-deploy.py`,
+    `scripts/deploy/test_xpf_deploy_nicorder.py`,
+    `docs/deploy-quickstart.md`, `examples/deploy/README.md`, `_Log.md`
+
 ## 2026-07-04 — #4175 (fable-review-165 H-1): day-0 config-drive retry permanently dead — loader guarded on bare .configdb directory
 
 - **Timestamp**: 2026-07-04

--- a/docs/deploy-quickstart.md
+++ b/docs/deploy-quickstart.md
@@ -26,9 +26,21 @@ So a deployment is one ordered table: each interface gets a **role**
 YAML; the tool validates the role↔position match, builds the day-0
 config drive, and launches the VM with the NICs attached in order.
 
-(The guest applies a `virtio-first` tiebreaker so mgmt/control stay
-`fxp0`/`em0`; identical to pure position in every normal layout. Verify
-with `show interfaces terse`.)
+**The virtio-first tiebreaker (get the NIC order right).** The guest
+does not name NICs purely by the order the tool attaches them — before
+assigning positional names it sorts **virtio-class** backings
+(`net`/`bridge`/`macvlan`, which attach as `virtio_net`) *ahead of*
+**hardware-class** backings (`sriov`/`physical`/`pci`, which attach as
+the real passthrough driver). See `enumeratePCINICs()` in
+`pkg/daemon/linksetup.go`. So "position is the contract" holds only when
+your interface list already puts **every virtio-class NIC before every
+hardware-class NIC**. If you list a virtio-class NIC *after* a
+hardware-class one, the guest renames it to an earlier slot and the
+firewall zones/policies/NAT land on **swapped ports** (e.g. trust and
+untrust inverted). The deploy tool now rejects such a layout at validate
+time (`validate_appliance`) and tells you which two interfaces to
+reorder — so this is caught before launch, not discovered in production.
+Still verify the final map with `show interfaces terse` after boot.
 
 ## Prerequisites
 

--- a/examples/deploy/README.md
+++ b/examples/deploy/README.md
@@ -31,10 +31,20 @@ shown below, and the config layer translates):
 
 You write the `role` you expect at each position; the tool computes the
 real name and refuses to launch on a mismatch — a miswired definition
-fails on your laptop, not in production. (The guest applies a
-`virtio-first` tiebreaker so mgmt/control stay `fxp0`/`em0`; identical
-to pure position in every normal layout. Confirm with `show interfaces
-terse` after boot.)
+fails on your laptop, not in production.
+
+**Order virtio-class NICs before hardware-class NICs.** The guest does
+not name NICs purely by attach order: `enumeratePCINICs()`
+(`pkg/daemon/linksetup.go`) sorts **virtio-class** backings
+(`net`/`bridge`/`macvlan` → `virtio_net`) *ahead of* **hardware-class**
+backings (`sriov`/`physical`/`pci` → the passthrough driver) before it
+assigns the positional names above. So the position → name contract only
+holds when every virtio-class NIC precedes every hardware-class NIC in
+your list. If you list a virtio-class NIC *after* a hardware-class one,
+the guest renames it to an earlier slot and the zones/policies/NAT land
+on **swapped ports** (e.g. trust ↔ untrust). The tool rejects that
+layout at validate time and names the two interfaces to reorder. Always
+confirm the final map with `show interfaces terse` after boot.
 
 ## Files
 

--- a/scripts/deploy/test_xpf_deploy_nicorder.py
+++ b/scripts/deploy/test_xpf_deploy_nicorder.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Unit tests for the guest virtio-first NIC-order guard (fable-165 H-22).
+
+The guest does NOT name interfaces by the order the deploy tool attaches
+them. `enumeratePCINICs()` (pkg/daemon/linksetup.go) sorts NICs with a
+virtio-first tiebreaker — sk=0 for driver `virtio_net`, sk=1 for
+hardware — BEFORE `assignName()` hands out positional vSRX names. A
+virtio-backed NIC (net/bridge/macvlan) therefore always enumerates ahead
+of a passthrough NIC (sriov/physical/pci), no matter where the operator
+lists it.
+
+`validate_appliance()` used to check each declared role against its raw
+list index only, so a YAML that put a virtio-class NIC AFTER a
+hardware-class one passed validation but booted with the firewall zones
+on swapped ports (trust/untrust inverted) — a silent security miswiring.
+
+These tests drive validate_appliance() and assert:
+  - a virtio-class NIC listed after a hardware-class NIC is REJECTED
+    (die -> SystemExit), naming both offending positions;
+  - the same interface set reordered virtio-first is ACCEPTED and gets
+    the expected positional vSRX names;
+  - pure-virtio and pure-hardware layouts (and the shipped examples) are
+    unaffected;
+  - backing_sort_key mirrors the guest's sk=0/sk=1 classes.
+
+On revert (drop the virtio-first guard in validate_appliance) the
+rejection test goes RED: the mixed-order appliance validates without
+raising, exactly the latent zone-swap the guard exists to prevent.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "xpf_deploy", Path(__file__).with_name("xpf-deploy.py")
+)
+xpf_deploy = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(xpf_deploy)
+
+EXAMPLES = Path(__file__).resolve().parents[2] / "examples" / "deploy"
+
+
+def _iface(backing, source, role=None):
+    ic = {"backing": backing, "source": source}
+    if role is not None:
+        ic["role"] = role
+    return ic
+
+
+def _appliance(interfaces, mode="standalone", node_id=None):
+    return {
+        "name": "fw",
+        "mode": mode,
+        "node_id": node_id,
+        "interfaces": interfaces,
+    }
+
+
+class BackingSortKeyTests(unittest.TestCase):
+    def test_virtio_class_is_zero(self):
+        for b in ("net", "bridge", "macvlan"):
+            self.assertEqual(xpf_deploy.backing_sort_key(b), 0, b)
+
+    def test_hardware_class_is_one(self):
+        for b in ("sriov", "physical", "pci"):
+            self.assertEqual(xpf_deploy.backing_sort_key(b), 1, b)
+
+    def test_classes_partition_valid_backings(self):
+        # Every valid backing is classified exactly once, so the guard can
+        # never see an unclassified backing slip through.
+        self.assertEqual(
+            xpf_deploy.VIRTIO_BACKINGS | xpf_deploy.HARDWARE_BACKINGS,
+            xpf_deploy.VALID_BACKINGS,
+        )
+        self.assertEqual(
+            xpf_deploy.VIRTIO_BACKINGS & xpf_deploy.HARDWARE_BACKINGS, set()
+        )
+
+
+class VirtioFirstGuardTests(unittest.TestCase):
+    def test_virtio_after_hardware_is_rejected(self):
+        # The H-22 hazard: pos1 fxp0 (virtio bridge), pos2 ge-0/0/0 (pci
+        # VF, hardware), pos3 ge-0/0/1 (virtio bridge). Index-only
+        # validation passes, but the guest sorts both virtio NICs first, so
+        # the pos-3 bridge becomes ge-0/0/0 and the pos-2 VF becomes
+        # ge-0/0/1 — zones swap. Must be rejected.
+        ap = _appliance([
+            _iface("bridge", "br-mgmt"),
+            _iface("pci", "0000:09:00.0", role="ge-0/0/0"),
+            _iface("bridge", "br-lan", role="ge-0/0/1"),
+        ])
+        with self.assertRaises(SystemExit) as cm:
+            xpf_deploy.validate_appliance(ap, "test.yaml")
+        msg = str(cm.exception)
+        # Error names both offending positions and the virtio/hardware
+        # classes so the operator can act on it.
+        self.assertIn("interface 3", msg)
+        self.assertIn("interface 2", msg)
+        self.assertIn("virtio", msg)
+        self.assertIn("hardware", msg)
+
+    def test_virtio_after_hardware_rejected_without_roles(self):
+        # The guard is class-based, so it fires even for position-only
+        # configs that declare no roles at all.
+        ap = _appliance([
+            _iface("bridge", "br-mgmt"),
+            _iface("sriov", "enp8s0"),
+            _iface("net", "lan-net"),
+        ])
+        with self.assertRaises(SystemExit):
+            xpf_deploy.validate_appliance(ap, "test.yaml")
+
+    def test_virtio_after_hardware_rejected_in_cluster(self):
+        ap = _appliance(
+            [
+                _iface("bridge", "br-mgmt"),          # fxp0
+                _iface("bridge", "br-ha"),            # em0
+                _iface("pci", "0000:09:00.0"),        # ge-0/0/0 (hardware)
+                _iface("macvlan", "eno1"),            # virtio after hardware
+            ],
+            mode="cluster",
+            node_id=0,
+        )
+        with self.assertRaises(SystemExit):
+            xpf_deploy.validate_appliance(ap, "node0.yaml")
+
+    def test_all_virtio_first_is_accepted(self):
+        # Same physical set, reordered so the two virtio NICs precede the
+        # hardware VF: valid, and names map positionally.
+        ifaces = [
+            _iface("bridge", "br-mgmt", role="fxp0"),
+            _iface("bridge", "br-lan", role="ge-0/0/0"),
+            _iface("pci", "0000:09:00.0", role="ge-0/0/1"),
+        ]
+        ap = _appliance(ifaces)
+        xpf_deploy.validate_appliance(ap, "test.yaml")  # no raise
+        self.assertEqual([ic["_name"] for ic in ifaces],
+                         ["fxp0", "ge-0/0/0", "ge-0/0/1"])
+
+    def test_pure_virtio_is_accepted(self):
+        ap = _appliance([
+            _iface("bridge", "br-mgmt"),
+            _iface("bridge", "br-lan"),
+            _iface("net", "wan-net"),
+        ])
+        xpf_deploy.validate_appliance(ap, "test.yaml")  # no raise
+
+    def test_pure_hardware_is_accepted(self):
+        # No virtio at all -> no cross-class inversion possible.
+        ap = _appliance([
+            _iface("pci", "0000:08:00.0"),
+            _iface("sriov", "enp9s0"),
+            _iface("physical", "enp10s0"),
+        ])
+        xpf_deploy.validate_appliance(ap, "test.yaml")  # no raise
+
+    def test_hardware_then_virtio_boundary_only(self):
+        # A single hardware NIC followed by a single virtio NIC is the
+        # minimal inversion and must still be caught.
+        ap = _appliance([
+            _iface("bridge", "br-mgmt"),
+            _iface("sriov", "enp8s0"),
+            _iface("bridge", "br-lan"),
+        ])
+        with self.assertRaises(SystemExit):
+            xpf_deploy.validate_appliance(ap, "test.yaml")
+
+
+@unittest.skipUnless(xpf_deploy.yaml is not None, "PyYAML not installed")
+class ShippedExamplesTests(unittest.TestCase):
+    """Every shipped example YAML must satisfy the virtio-first guard."""
+
+    def test_shipped_examples_validate(self):
+        yamls = sorted(EXAMPLES.glob("*.yaml"))
+        self.assertTrue(yamls, f"no example YAMLs under {EXAMPLES}")
+        for path in yamls:
+            with self.subTest(example=path.name):
+                # load_yaml_appliance() calls validate_appliance() and
+                # would die() on a virtio-after-hardware layout.
+                xpf_deploy.load_yaml_appliance(str(path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/deploy/xpf-deploy.py
+++ b/scripts/deploy/xpf-deploy.py
@@ -59,7 +59,26 @@ except ImportError:
     yaml = None
 
 VALID_BACKINGS = {"net", "bridge", "macvlan", "sriov", "physical", "pci"}
+
+# Guest PCI enumeration classes. The guest names interfaces positionally
+# (assignName), but ONLY after enumeratePCINICs() sorts NICs with a
+# virtio-first tiebreaker: sk=0 for driver "virtio_net", sk=1 for
+# everything else, then by PCI bus address (pkg/daemon/linksetup.go). A
+# virtio-backed device (net/bridge/macvlan attach as `virtio_net`) always
+# sorts ahead of a passthrough device (sriov/physical/pci attach as the
+# real hardware driver), regardless of the order the tool attaches them.
+# So the config's list position only equals the guest's vSRX name when
+# every virtio-class NIC precedes every hardware-class NIC.
+VIRTIO_BACKINGS = {"net", "bridge", "macvlan"}
+HARDWARE_BACKINGS = {"sriov", "physical", "pci"}
 SYS_NET = "/sys/class/net"
+
+
+def backing_sort_key(backing):
+    """Guest enumeration sort key for a backing, mirroring the sk=0
+    (virtio) / sk=1 (hardware) tiebreaker in enumeratePCINICs()
+    (pkg/daemon/linksetup.go). Lower sorts earlier in the guest."""
+    return 0 if backing in VIRTIO_BACKINGS else 1
 
 
 def die(msg):
@@ -186,6 +205,33 @@ def validate_appliance(ap, where):
             die(f"{where}: interface {i + 1} declares role '{ic['role']}' but position {i + 1} "
                 f"is '{want}' — reorder or fix; position is the contract.")
         ic["_name"] = want
+
+    # Guest virtio-first tiebreaker (enumeratePCINICs, linksetup.go): the
+    # guest sorts virtio-class NICs ahead of hardware-class ones BEFORE it
+    # assigns positional vSRX names. "Position is the contract" therefore
+    # only holds when the list order already matches that sort — i.e. every
+    # virtio-class NIC precedes every hardware-class one. A virtio-class NIC
+    # listed AFTER a hardware-class NIC would be renamed to an earlier slot
+    # in the guest, silently swapping the zones/policies/NAT bound to those
+    # vSRX names (trust/untrust inversion). Fail closed — the deployer holds
+    # every backing's class, so it can and must catch this (fable-165 H-22).
+    first_hw = None
+    for i, ic in enumerate(ap["interfaces"]):
+        if backing_sort_key(ic["backing"]) == 1:
+            if first_hw is None:
+                first_hw = i
+        elif first_hw is not None:
+            hw = ap["interfaces"][first_hw]
+            die(f"{where}: interface {i + 1} ({ic['backing']}:{ic['source']}, "
+                f"declared '{ic['_name']}') is a virtio-class NIC listed after "
+                f"the hardware-class interface {first_hw + 1} "
+                f"({hw['backing']}:{hw['source']}, declared '{hw['_name']}'). "
+                f"The guest enumerates virtio before hardware "
+                f"(enumeratePCINICs, linksetup.go), so it renames this NIC to "
+                f"an earlier slot and SWAPS the zones on '{ic['_name']}' and "
+                f"'{hw['_name']}'. Reorder so every virtio-class NIC "
+                f"(net/bridge/macvlan) comes before every hardware-class NIC "
+                f"(sriov/physical/pci); position is the contract.")
 
 
 def load_yaml_appliance(path):


### PR DESCRIPTION
Closes #4180 (fable-review-165 H-22).

## Problem

`scripts/deploy/xpf-deploy.py` `validate_appliance()` checks each
interface's declared `role` against its **raw list index** only
(`expected_name(i, ...)`), but the guest does not name NICs by the
order the deploy tool attaches them. `enumeratePCINICs()`
(`pkg/daemon/linksetup.go:189-204`) sorts NICs with a **virtio-first
tiebreaker** — `sk=0` for driver `virtio_net`, `sk=1` for hardware —
BEFORE `assignName()` assigns positional vSRX names. A virtio-backed
device (`net`/`bridge`/`macvlan` → `virtio_net`) always enumerates
ahead of a passthrough device (`sriov`/`physical`/`pci`).

So a YAML or `--nic` list that placed a **virtio-class NIC after a
hardware-class NIC** passed validation but booted with the firewall
zones/policies/NAT on **swapped ports** (trust/untrust inverted) — a
silent security miswiring. All six shipped example YAMLs happen to list
virtio first, so the hazard was latent, not active, in the shipped
files.

### Trace

- pos1 `fxp0` bridge (virtio), pos2 `ge-0/0/0` `pci` VF (hardware),
  pos3 `ge-0/0/1` bridge (virtio) → validation passes.
- In the guest both virtio NICs sort first: the pos-3 bridge becomes
  `ge-0/0/0` (LAN/trust) and the pos-2 VF becomes `ge-0/0/1`
  (WAN/untrust). Zones land on swapped ports; nothing errors.

## Fix

Classify each backing virtio-class (`net`/`bridge`/`macvlan`) vs
hardware-class (`sriov`/`physical`/`pci`) with `backing_sort_key()`,
mirroring the guest's `sk=0`/`sk=1` rule, and **fail closed** (`die()`)
in `validate_appliance` when a virtio-class interface appears after a
hardware-class one — naming both offending positions and telling the
operator to reorder.

Reject rather than silent reorder: the zone→vSRX-name binding lives in
the operator's day-0 `.conf`, which the tool does not rewrite, so
reordering the NIC list could still land the intended backing on a
different vSRX name invisibly. Rejecting keeps the existing "position is
the contract" guarantee honest. The guard is a single chokepoint in
`validate_appliance`, so it covers both the YAML (`deploy`) and
imperative (`launch --nic`) paths.

## Test

`scripts/deploy/test_xpf_deploy_nicorder.py` (11 tests, mirrors the H-20
`test_xpf_deploy_disk.py` pattern):

- virtio-after-hardware is rejected (with/without roles, standalone +
  cluster, and the minimal single-boundary case);
- the reordered set validates with the expected positional names;
- pure-virtio and pure-hardware layouts pass;
- every shipped example YAML satisfies the guard.

RED-on-revert verified: dropping the guard un-raises the four rejection
tests. Full `scripts/deploy` suite (15 tests) green; `py_compile` clean.

## Docs

`docs/deploy-quickstart.md` and `examples/deploy/README.md` — replaced
the "identical to pure position in every normal layout" hand-wave with
the explicit virtio-first rule + the new validate-time reject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi