### PR TITLE
deploy: fix physical --hostdev, watermark ordering, fetch->libvirt path (H-23/H-25/H-30)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,38 @@
+## 2026-07-04 — #4188 / #4189 / #4190 (fable-review-165 H-23 / H-25 / H-30): xpf-deploy correctness
+
+- **Timestamp**: 2026-07-04
+  - **Action**: Fixed three `scripts/deploy/xpf-deploy.py` correctness
+    bugs. H-23 (#4188): the libvirt `physical` backing passed the raw
+    netdev NAME (e.g. `enp8s0`) to `virt-install --hostdev`, which needs
+    a PCI/USB address — the domain fails to define / mis-attaches. Now
+    the netdev is resolved to its PCI BDF via the existing `pci_of()`
+    helper (a raw PCI address under `physical:` is accepted too, and an
+    unresolvable name dies with a clear message); incus is unchanged
+    (`nictype=physical parent=<dev>` correctly takes the netdev name).
+    H-25 (#4189): the fetch anti-rollback watermark compared git-describe
+    suffixes as whole strings, so `1.2.3-10-gabc` ranked OLDER than
+    `1.2.3-9-gdef` and `rc10` below `rc9` — false "possible rollback"
+    refusals. `_ver_key` is now module-level and numeric-splits the
+    suffix (`_suffix_key`, int/text-tagged so no mixed compare raises)
+    while keeping the rc < release < post-release category rank. H-30
+    (#4190): `fetch` left the verified qcow2 at `<out>/xpf-<ver>.qcow2`
+    but `deploy --hypervisor libvirt` reads the golden at
+    `/var/lib/libvirt/images/<image>.qcow2` — nothing bridged the gap.
+    Added `libvirt_golden_path()` as the shared SSOT used by BOTH
+    `libvirt_disk` (deploy) and a new `fetch --install-libvirt` (which
+    installs the verified qcow2 there via `_install_libvirt_golden`,
+    falling back to `sudo install` for the root-owned images dir); the
+    `--qcow2-only` hint now prints the exact install command.
+  - **File(s)**: `scripts/deploy/xpf-deploy.py`,
+    `scripts/deploy/test_xpf_deploy_correctness.py` (new — 12 RED-on-revert
+    tests), `examples/deploy/README.md`, `docs/distribution.md`,
+    `docs/install-images.md`, `_Log.md`.
+  - **Validation**: `python3 -m py_compile`; full `scripts/deploy`
+    unittest suite 27/27 (12 new + 15 existing); RED-on-revert proven for
+    each finding (H-23 physical→PCI resolution fails when the netdev name
+    is passed; H-25 rc10/count-10 ordering inverts on whole-string
+    compare; H-30 shared golden helper removed → agreement test fails).
+
 ## 2026-07-04 — #4178 / #4179 (fable-review-165 H-7 / H-10): interface-naming daemon bugs
 
 - **Timestamp**: 2026-07-04

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -149,9 +149,22 @@ sh install.sh
 # downloads + verifies the EXACT bytes against the signed manifest, then
 # imports to a local incus alias
 xpf-deploy.py fetch --version <ver> --image-url https://dl.example.com/xpf
-# libvirt/KVM (qcow2 only):
+
+# libvirt/KVM: verify the qcow2 AND install it to the golden path that
+# `deploy --hypervisor libvirt` reads (/var/lib/libvirt/images/<image>.qcow2,
+# basename from --alias, default xpf-appliance) so fetch and deploy connect:
+xpf-deploy.py fetch --version <ver> --image-url ... --qcow2-only --install-libvirt
+xpf-deploy.py --hypervisor libvirt deploy <appliance.yaml>
+
+# Verify only (no install): fetch prints the exact `install` command that
+# copies the verified qcow2 into the golden path.
 xpf-deploy.py fetch --version <ver> --image-url ... --qcow2-only
 ```
+
+`deploy --hypervisor libvirt` never boots the golden directly — it creates a
+per-VM copy-on-write overlay backed read-only by the golden. `--install-libvirt`
+is the one step that moves the *verified* qcow2 to the shared golden path; both
+sides derive that path from the same helper so they cannot drift.
 
 ### CAUTION — interface takeover (#1879)
 

--- a/docs/install-images.md
+++ b/docs/install-images.md
@@ -204,6 +204,12 @@ virt-install --name xpf1 --memory 4096 --vcpus 4 \
 Plain QEMU works the same way (`-drive file=xpf-<ver>.qcow2`
 `-cdrom day0.iso`); the image boots UEFI or BIOS.
 
+The tool-driven path is `xpf-deploy.py --hypervisor libvirt deploy`, which
+reads the golden qcow2 from `/var/lib/libvirt/images/<image>.qcow2` and gives
+each VM its own copy-on-write overlay. Put the verified image there with
+`xpf-deploy.py fetch --version <ver> --qcow2-only --install-libvirt` (see
+`docs/distribution.md`) so fetch and deploy use the same path.
+
 ## First-boot contract (vSRX parity)
 
 | vSRX | xpf image |

--- a/examples/deploy/README.md
+++ b/examples/deploy/README.md
@@ -69,7 +69,7 @@ That is the switch — the tool never guesses:
 | `macvlan` | host dev | `nic nictype=macvlan` | `--network type=direct` | virtio (vhost) |
 | `sriov` | **PF name** | `nic nictype=sriov` (incus carves a VF, pins MAC) | `<PF>-vfpool` network | mlx5 native / iavf generic |
 | `pci` | **PCI address** | `pci address=` (VFIO) | `--hostdev` / hostdev-network | native (real driver) |
-| `physical` | host dev | `nic nictype=physical` | `--hostdev` | native (real driver) |
+| `physical` | host dev name | `nic nictype=physical` | `--hostdev` (the netdev name is resolved to its PCI address) | native (real driver) |
 
 - **`sriov:<PF>`** = "give me a VF off this PF" — incus allocates a free
   VF and pins its MAC. incus convenience.
@@ -78,6 +78,12 @@ That is the switch — the tool never guesses:
   tool pins it on the parent PF). **`pci:<vf-addr>,mac=` deploys
   identically on incus and libvirt** — use it when one definition must
   serve both.
+- **`physical:<dev>`** = "pass through the whole card behind this
+  interface name". incus takes the netdev name directly
+  (`nictype=physical parent=<dev>`); on libvirt the tool resolves the
+  netdev to its PCI address for `--hostdev` (which requires a PCI/USB
+  address, not an interface name). A raw `physical:<pci-addr>` is accepted
+  too. Prefer `pci:` when you already have the PCI BDF.
 
 `xpf-deploy.py inventory` prints PF names, per-PF VFs, and PCI addresses
 ready to drop into `source`.

--- a/scripts/deploy/test_xpf_deploy_correctness.py
+++ b/scripts/deploy/test_xpf_deploy_correctness.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Unit tests for three xpf-deploy correctness fixes (fable-review-165).
+
+H-23  libvirt `physical` backing resolves the netdev NAME to a PCI address
+      before handing it to `virt-install --hostdev` (which requires a PCI /
+      USB address, not an interface name). On revert (the raw netdev name is
+      passed to --hostdev) the resolution assertion goes RED.
+
+H-25  the fetch anti-rollback watermark orders git-describe commit counts and
+      rc numbers NUMERICALLY, not lexically, so `1.2.3-10-gabc` outranks
+      `1.2.3-9-gdef` and `rc10` outranks `rc9`. On revert (whole-string
+      suffix compare) both orderings invert and the assertions go RED.
+
+H-30  `fetch --install-libvirt` installs the verified qcow2 to the SAME
+      libvirt golden path `deploy --hypervisor libvirt` reads, via one shared
+      helper (`libvirt_golden_path`). On revert (no shared constant; fetch
+      never lands the image at the deploy path) the agreement test goes RED.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "xpf_deploy", Path(__file__).with_name("xpf-deploy.py")
+)
+xpf_deploy = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(xpf_deploy)
+
+
+class RecordingRunner:
+    """Runner that records every argv instead of executing it (dry=True so
+    libvirt_disk() skips the host-state golden-exists check)."""
+
+    def __init__(self):
+        self.dry = True
+        self.calls = []
+
+    def run(self, argv):
+        self.calls.append(list(argv))
+        return ""
+
+
+def _find_call(calls, prog):
+    for c in calls:
+        if c and c[0] == prog:
+            return c
+    return None
+
+
+# ── H-23: physical backing on libvirt resolves netdev -> PCI address ──────
+class PhysicalHostdevTests(unittest.TestCase):
+    def setUp(self):
+        # Real hosts vary; drive resolution with a deterministic stub so the
+        # test does not depend on a physical NIC being present.
+        self._orig_pci_of = xpf_deploy.pci_of
+        xpf_deploy.pci_of = lambda dev: (
+            "0000:08:00.0" if dev == "enp8s0" else "?")
+
+    def tearDown(self):
+        xpf_deploy.pci_of = self._orig_pci_of
+
+    def _deploy(self, iface):
+        ap = {
+            "name": "fw", "mode": "standalone", "node_id": None,
+            "image": "xpf-appliance", "cpu": 2, "memory": "4G",
+            "interfaces": [
+                {"_name": "fxp0", "backing": "bridge", "source": "br-mgmt"},
+                iface,
+            ],
+        }
+        r = RecordingRunner()
+        xpf_deploy.deploy_libvirt(ap, r, start=False)
+        virt = _find_call(r.calls, "virt-install")
+        self.assertIsNotNone(virt, "virt-install was not invoked")
+        return virt
+
+    def test_physical_netdev_is_resolved_to_pci_for_hostdev(self):
+        # The H-23 hazard: `--hostdev enp8s0` is an invalid hostdev spec.
+        # The deployer must translate the netdev name to its PCI BDF.
+        virt = self._deploy(
+            {"_name": "ge-0/0/0", "backing": "physical", "source": "enp8s0"})
+        self.assertIn("--hostdev", virt)
+        addr = virt[virt.index("--hostdev") + 1]
+        # RED on revert: the raw netdev name "enp8s0" would appear here.
+        self.assertEqual(addr, "0000:08:00.0")
+        self.assertTrue(xpf_deploy.is_pci_addr(addr),
+                        f"--hostdev arg {addr!r} is not a PCI address")
+        self.assertNotIn("enp8s0", virt,
+                         "a netdev name must never reach virt-install --hostdev")
+
+    def test_physical_accepts_a_raw_pci_source_unchanged(self):
+        # A PCI address given directly under `physical:` passes through.
+        virt = self._deploy(
+            {"_name": "ge-0/0/0", "backing": "physical",
+             "source": "0000:09:00.0"})
+        addr = virt[virt.index("--hostdev") + 1]
+        self.assertEqual(addr, "0000:09:00.0")
+
+    def test_is_pci_addr_distinguishes_addr_from_netdev(self):
+        self.assertTrue(xpf_deploy.is_pci_addr("0000:08:00.0"))
+        self.assertTrue(xpf_deploy.is_pci_addr("0000:3b:00.1"))
+        self.assertFalse(xpf_deploy.is_pci_addr("enp8s0"))
+        self.assertFalse(xpf_deploy.is_pci_addr("ge-0/0/0"))
+
+
+# ── H-25: watermark version ordering is numeric, not lexical ──────────────
+class VersionKeyOrderingTests(unittest.TestCase):
+    def setUp(self):
+        self.k = xpf_deploy._ver_key
+
+    def test_describe_commit_count_orders_numerically(self):
+        # RED on revert: "10-gabc" < "9-gdef" lexically -> 10 ranked OLDER.
+        self.assertGreater(self.k("1.2.3-10-gabc"), self.k("1.2.3-9-gdef"))
+        self.assertGreater(self.k("1.2.3-100-gabc"), self.k("1.2.3-99-gdef"))
+
+    def test_rc_numbers_order_numerically(self):
+        # RED on revert: "rc10" < "rc9" lexically -> rc10 ranked below rc9.
+        self.assertGreater(self.k("1.2.3-rc10"), self.k("1.2.3-rc9"))
+        self.assertGreater(self.k("1.2.3-rc2"), self.k("1.2.3-rc1"))
+
+    def test_prerelease_sorts_before_its_base_release(self):
+        # rc/alpha/beta are BEFORE the final release (rc -> final is upgrade).
+        self.assertLess(self.k("1.2.3-rc1"), self.k("1.2.3"))
+        self.assertLess(self.k("1.2.3-rc10"), self.k("1.2.3"))
+
+    def test_postrelease_commits_sort_after_base(self):
+        # git-describe commits ahead of the tag rank AFTER the base release.
+        self.assertGreater(self.k("1.2.3-1-gabc"), self.k("1.2.3"))
+        self.assertGreater(self.k("1.2.3-1-gabc"), self.k("1.2.3-rc9"))
+
+    def test_release_component_still_orders_numerically(self):
+        self.assertGreater(self.k("1.10.0"), self.k("1.9.0"))
+        self.assertGreater(self.k("2.0.0"), self.k("1.99.99"))
+
+    def test_no_mixed_type_comparison_raises(self):
+        # A digit run and a text run must never be compared directly (which
+        # would raise TypeError in Python 3); the tagging prevents that.
+        pairs = [
+            ("1.2.3-rc9", "1.2.3-9-gabc"),   # text-suffix vs digit-suffix
+            ("1.2.3-rc1", "1.2.3"),          # suffix vs no-suffix
+            ("1.2.3-alpha", "1.2.3-rc1"),    # two text suffixes
+        ]
+        for a, b in pairs:
+            with self.subTest(a=a, b=b):
+                _ = self.k(a) < self.k(b)   # must not raise
+
+
+# ── H-30: fetch install path == deploy golden path (shared SSOT) ──────────
+class LibvirtGoldenPathAgreementTests(unittest.TestCase):
+    def test_golden_helper_matches_deploy_backing(self):
+        # The overlay the deploy side backs read-only MUST be exactly
+        # libvirt_golden_path(image) — proves deploy consumes the SSOT.
+        r = RecordingRunner()
+        ap = {
+            "name": "fw-solo", "mode": "standalone", "node_id": None,
+            "image": "xpf-appliance", "cpu": 2, "memory": "4G",
+            "interfaces": [
+                {"_name": "fxp0", "backing": "bridge", "source": "br-mgmt"}],
+        }
+        xpf_deploy.deploy_libvirt(ap, r, start=False)
+        qemu = _find_call(r.calls, "qemu-img")
+        self.assertIsNotNone(qemu, "qemu-img create was not invoked")
+        deploy_backing = qemu[qemu.index("-b") + 1]
+        # RED on revert: libvirt_golden_path removed -> AttributeError.
+        self.assertEqual(deploy_backing,
+                         xpf_deploy.libvirt_golden_path("xpf-appliance"))
+
+    def test_fetch_install_lands_at_deploy_golden(self):
+        # fetch --install-libvirt must write the verified qcow2 to the SAME
+        # path deploy reads. Redirect LIBVIRT_IMAGES to a tmpdir so both the
+        # fetch install and the deploy golden compute under it.
+        orig = xpf_deploy.LIBVIRT_IMAGES
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                xpf_deploy.LIBVIRT_IMAGES = os.path.join(tmp, "images")
+                src = os.path.join(tmp, "xpf-1.2.3.qcow2")
+                with open(src, "w") as f:
+                    f.write("QCOW-BYTES")
+
+                dest = xpf_deploy._install_libvirt_golden(src, "xpf-appliance")
+                deploy_golden = xpf_deploy.libvirt_golden_path("xpf-appliance")
+
+                # (a) fetch and deploy AGREE on the golden path.
+                self.assertEqual(dest, deploy_golden)
+                # (b) the verified image actually landed there.
+                self.assertTrue(os.path.isfile(dest))
+                with open(dest) as f:
+                    self.assertEqual(f.read(), "QCOW-BYTES")
+        finally:
+            xpf_deploy.LIBVIRT_IMAGES = orig
+
+    def test_fetch_defines_install_libvirt_flag(self):
+        # The bridging flag must exist on the fetch subparser (RED on revert
+        # if the whole feature is removed).
+        self.assertTrue(hasattr(xpf_deploy, "libvirt_golden_path"))
+        self.assertTrue(hasattr(xpf_deploy, "_install_libvirt_golden"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/deploy/xpf-deploy.py
+++ b/scripts/deploy/xpf-deploy.py
@@ -317,6 +317,14 @@ def memory_mb(val):
     return int(m.group(1)) * 1024 if (m.group(2) or "M").upper().startswith("G") else int(m.group(1))
 
 
+def is_pci_addr(s):
+    """True if s is a PCI BDF address (DDDD:BB:DD.F), not a netdev name.
+    Used to tell a libvirt --hostdev PCI address from an interface name
+    (fable-165 H-23)."""
+    return bool(re.fullmatch(
+        r"[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]", str(s)))
+
+
 def pci_parts(addr):
     m = re.fullmatch(r"([0-9a-fA-F]{4}):([0-9a-fA-F]{2}):([0-9a-fA-F]{2})\.([0-7])", addr)
     if not m:
@@ -405,6 +413,30 @@ def deploy_incus(ap, runner, start):
 LIBVIRT_IMAGES = "/var/lib/libvirt/images"
 
 
+def libvirt_golden_path(image):
+    """The libvirt golden qcow2 path — the SINGLE source of truth shared by
+    `deploy --hypervisor libvirt` (reads it as the read-only overlay backing)
+    AND `fetch --install-libvirt` (writes the verified image here). One helper
+    so the two halves can't drift (fable-165 H-30)."""
+    return os.path.join(LIBVIRT_IMAGES, f"{image}.qcow2")
+
+
+def _install_libvirt_golden(srcq, image):
+    """Install a verified qcow2 to the libvirt golden path deploy reads
+    (fable-165 H-30). Falls back to `sudo install` when the images dir is
+    root-owned (the common case). Returns the destination path."""
+    golden = libvirt_golden_path(image)
+    print(f"==> installing verified qcow2 -> {golden} (libvirt golden)")
+    try:
+        os.makedirs(os.path.dirname(golden), exist_ok=True)
+        shutil.copyfile(srcq, golden)
+    except OSError:
+        # /var/lib/libvirt/images is normally root-owned; -D creates the dir.
+        subprocess.run(["sudo", "install", "-m", "0644", "-D", srcq, golden],
+                       check=True)
+    return golden
+
+
 def libvirt_disk(ap, runner):
     """Return a per-VM writable qcow2 backed READ-ONLY by the golden image.
 
@@ -424,7 +456,7 @@ def libvirt_disk(ap, runner):
     redefine a live domain, so a running VM's overlay is not clobbered
     out from under it.
     """
-    golden = os.path.join(LIBVIRT_IMAGES, f"{ap['image']}.qcow2")
+    golden = libvirt_golden_path(ap['image'])
     overlay = os.path.join(LIBVIRT_IMAGES, f"{ap['name']}.qcow2")
     if os.path.abspath(overlay) == os.path.abspath(golden):
         die(f"VM name '{ap['name']}' collides with the golden image basename "
@@ -461,7 +493,23 @@ def deploy_libvirt(ap, runner, start):
             net = f"type=direct,source={src},source_mode=bridge,model=virtio"
             argv += ["--network", net + (f",mac.address={mac}" if mac else "")]
         elif b == "physical":
-            argv += ["--hostdev", src]
+            # libvirt --hostdev takes a PCI (or USB) address, NOT a netdev
+            # name — a bare `--hostdev enp8s0` is an invalid hostdev spec, so
+            # the domain fails to define / mis-attaches (fable-165 H-23). The
+            # incus backend's `nictype=physical parent=<dev>` DOES take the
+            # netdev name (incus resolves it), so translate here for libvirt.
+            # Accept a raw PCI address too (physical:0000:08:00.0).
+            addr = src if is_pci_addr(src) else pci_of(src)
+            if not is_pci_addr(addr):
+                if runner.dry:
+                    addr = f"pci-of:{src}"   # host may lack the NIC at plan time
+                else:
+                    die(f"physical:{src}: cannot resolve netdev '{src}' to a "
+                        f"PCI address on this host (is it a physical NIC?). "
+                        f"libvirt --hostdev requires a PCI address, not an "
+                        f"interface name — pass the PCI addr via `pci:` or fix "
+                        f"the source.")
+            argv += ["--hostdev", addr]
         elif b == "pci":
             if mac:
                 p = pci_parts(src)
@@ -529,6 +577,44 @@ def cmd_launch(args):
     return 0
 
 
+def _suffix_key(suffix):
+    """Split a pre-release / git-describe suffix into a comparable tuple of
+    alternating text/number runs, coercing the number runs to int so `rc10`
+    sorts ABOVE `rc9` and describe-count `10` above `9` (fable-165 H-25 — the
+    prior whole-string compare inverted BOTH). Each element is tagged
+    (0=number, 1=text) so a number run never string-compares against a text
+    run (which would raise TypeError in Python 3)."""
+    key = []
+    for part in re.split(r"(\d+)", suffix):
+        if not part:
+            continue
+        key.append((0, int(part)) if part.isdigit() else (1, part))
+    return tuple(key)
+
+
+def _ver_key(v):
+    """Order key for the fetch anti-rollback watermark. Compare on the
+    dotted-numeric RELEASE, then a pre-release rank so a pre-release sorts
+    BEFORE its base release (AGY: 1.2.3-rc1 < 1.2.3, so upgrading rc -> final
+    is NOT a rollback). git-describe tails like "-N-gHASH[-dirty]" are commits
+    AHEAD of the tag -> rank them AFTER the base. WITHIN each rank the suffix is
+    numeric-split (`_suffix_key`) so counts / rc numbers compare numerically,
+    not lexically (fable-165 H-25). Split on the FIRST '-': left = release,
+    right = suffix."""
+    s = str(v)
+    rel, _, suffix = s.partition("-")
+    rel_key = []
+    for tok in rel.split("."):
+        rel_key.append((0, int(tok)) if tok.isdigit() else (1, tok))
+    if not suffix:
+        pre_rank = (1,)                          # base release: after pre-release
+    elif suffix[:1].isdigit():
+        pre_rank = (2,) + _suffix_key(suffix)    # git-describe "N-gHASH": post-release
+    else:
+        pre_rank = (0,) + _suffix_key(suffix)    # rc/alpha/beta/...: before the base
+    return (rel_key, pre_rank)
+
+
 def cmd_fetch(args):
     """Download an appliance image from XPF_IMAGE_BASE_URL, VERIFY the exact
     downloaded bytes against the signed per-version manifest (#1924 §5.2),
@@ -558,25 +644,8 @@ def cmd_fetch(args):
         "~/.local/state")
     wm_path = os.path.join(state_home, "xpf", "image-watermark.json")
 
-    def _ver_key(v):
-        # Compare on the dotted-numeric RELEASE, then a pre-release rank so a
-        # pre-release sorts BEFORE its base release (AGY: 1.2.3-rc1 < 1.2.3, so
-        # upgrading rc -> final is NOT a rollback). git-describe tails like
-        # "-N-gHASH-dirty" are post-release commits ahead of the tag → rank
-        # them AFTER the base. Split on the FIRST '-': left = release, right =
-        # suffix.
-        s = str(v)
-        rel, _, suffix = s.partition("-")
-        rel_key = []
-        for tok in rel.split("."):
-            rel_key.append((0, int(tok)) if tok.isdigit() else (1, tok))
-        if not suffix:
-            pre_rank = (1,)           # base release: after any pre-release
-        elif suffix[:1].isdigit():
-            pre_rank = (2, suffix)    # git-describe "N-gHASH": post-release
-        else:
-            pre_rank = (0, suffix)    # rc/alpha/beta/...: before the base
-        return (rel_key, pre_rank)
+    # Version ordering for the watermark lives at module scope (`_ver_key`,
+    # unit-tested) — numeric-split so rc10 > rc9 and describe-count 10 > 9.
 
     def read_watermark():
         try:
@@ -652,13 +721,32 @@ def cmd_fetch(args):
         except OSError:
             pass  # best-effort; never block a verified fetch on watermark I/O
 
-    if args.no_import or args.qcow2_only:
-        print(f"==> verified into {out} (not imported — use the qcow2 with "
-              "virt-install --import, or re-run without --qcow2-only/--no-import "
-              "for an incus image import).")
+    # libvirt golden basename = deploy's `image:` default, so the incus alias
+    # and the libvirt golden name AGREE (fable-165 H-30).
+    img_name = args.alias or "xpf-appliance"
+    qcow2_src = os.path.join(out, names["qcow2"])
+
+    # H-30: bridge the fetch -> libvirt gap. `deploy --hypervisor libvirt`
+    # reads the golden at libvirt_golden_path(image); --install-libvirt puts
+    # the verified qcow2 there (shared path helper — the two can't drift).
+    if args.install_libvirt:
+        _install_libvirt_golden(qcow2_src, img_name)
+        print(f"==> done. Deploy with: xpf-deploy.py --hypervisor libvirt "
+              f"deploy <appliance.yaml>  (image: {img_name})")
         return 0
 
-    alias = args.alias or "xpf-appliance"
+    if args.no_import or args.qcow2_only:
+        golden = libvirt_golden_path(img_name)
+        print(f"==> verified into {out} (not imported). For libvirt/KVM, install "
+              f"it to the golden path deploy reads:\n"
+              f"      sudo install -m 0644 -D {qcow2_src} {golden}\n"
+              f"   (or re-run fetch with --install-libvirt), then: "
+              f"xpf-deploy.py --hypervisor libvirt deploy <appliance.yaml> "
+              f"(image: {img_name}). For incus, re-run without "
+              f"--qcow2-only/--no-import.")
+        return 0
+
+    alias = img_name
     subprocess.run(["incus", "image", "delete", alias],
                    capture_output=True, text=True)
     print(f"==> importing verified image as incus alias '{alias}'")
@@ -1339,6 +1427,13 @@ def main():
                               "recorded watermark (deliberate downgrade)")
         sub.add_argument("--qcow2-only", action="store_true",
                          help="fetch+verify only the qcow2 (libvirt/KVM path)")
+        sub.add_argument("--install-libvirt", action="store_true",
+                         dest="install_libvirt",
+                         help="after verifying, install the qcow2 to the "
+                              "libvirt golden path "
+                              "(/var/lib/libvirt/images/<image>.qcow2; basename "
+                              "from --alias, default xpf-appliance) that "
+                              "`deploy --hypervisor libvirt` reads")
         sub.add_argument("--no-import", action="store_true",
                          help="verify only; do not incus image import")
         args = sub.parse_args(cmd_argv)


### PR DESCRIPTION
Closes #4188 Closes #4189 Closes #4190

Three `scripts/deploy/xpf-deploy.py` correctness bugs from
fable-review-165 (H-23, H-25, H-30). Python-only; no Go/cargo change.

## H-23 (#4188) — libvirt `physical` passes a netdev name to --hostdev
`deploy --hypervisor libvirt` with a `physical` backing passed the raw
netdev name (e.g. `enp8s0`) to `virt-install --hostdev`, which requires a
PCI/USB address — the domain fails to define / mis-attaches (and per H-21
the error is swallowed). `deploy_libvirt` now resolves the netdev to its
PCI BDF via the existing `pci_of()` helper (accepts a raw PCI address
under `physical:` too; dies with a clear message when unresolvable).
incus is unchanged — `nictype=physical parent=<dev>` correctly takes the
netdev name.
`scripts/deploy/xpf-deploy.py` — `deploy_libvirt` physical branch + new
`is_pci_addr()`.

## H-25 (#4189) — watermark mis-orders describe counts and rc numbers
The fetch anti-rollback watermark compared git-describe / pre-release
suffixes as whole strings, so `1.2.3-10-gabc` ranked OLDER than
`1.2.3-9-gdef` and `rc10` below `rc9` — false "possible rollback"
refusals train operators to pass `--allow-rollback` (which then lets a
real downgrade through). Reproduced by execution. `_ver_key` is hoisted
to module scope and numeric-splits the suffix (`_suffix_key`,
int/text-tagged so no mixed compare raises) while keeping the
rc < release < post-release category rank.
`scripts/deploy/xpf-deploy.py` — new module-level `_ver_key`/`_suffix_key`.

## H-30 (#4190) — fetch qcow2 never reaches the libvirt golden path
`fetch` left the verified qcow2 at `<out>/xpf-<ver>.qcow2` but
`deploy --hypervisor libvirt` reads the golden at
`/var/lib/libvirt/images/<image>.qcow2` — different dir and basename, no
bridge. Added `libvirt_golden_path()` as the shared SSOT used by BOTH
`libvirt_disk` (deploy) and a new `fetch --install-libvirt`
(`_install_libvirt_golden`, `sudo install` fallback for the root-owned
images dir); the `--qcow2-only` hint prints the exact install command.
`scripts/deploy/xpf-deploy.py` — `libvirt_golden_path`,
`_install_libvirt_golden`, `cmd_fetch` tail, `--install-libvirt` flag.

## Tests (RED-on-revert)
`scripts/deploy/test_xpf_deploy_correctness.py` — 12 new tests mirroring
the H-20/H-22 pattern. Each goes RED when its fix is reverted (verified
locally): H-23 the netdev name reaches --hostdev; H-25 rc10/count-10
ordering inverts under whole-string compare; H-30 the shared golden
helper is gone so fetch never lands the image where deploy reads it.
Full `scripts/deploy` suite: 27/27 (12 new + 15 existing).

## Docs
`examples/deploy/README.md` (physical->PCI note), `docs/distribution.md`
+ `docs/install-images.md` (`fetch --install-libvirt`). H-25 is internal
best-effort CLI state — no operator-facing doc surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi