### PR TITLE
docs+examples: fix fable-review-165 H-18/H-28/H-29 day-0 accuracy findings

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -34027,3 +34027,15 @@ top.
   failed); go build ./... green. No doc change: no doc documents the
   Rust policy-engine per-arm test coverage.
 - **File(s)**: userspace-dp/src/policy_tests.rs, _Log.md
+
+- **Timestamp**: 2026-07-04
+- **Action**: fable-review-165 H-18 (#4194) — fix docs/bare-metal-device-map.md
+  quick-start step 3, which told the operator `commit check` confirms a
+  `commit confirmed`. It does not: `CommitCheck`
+  (`pkg/configstore/store_commit.go:26-41`) only validates and never
+  touches the confirm timer, so following the doc lets the T+5m window
+  expire and auto-rollback the just-verified device-map. The confirming
+  command is a plain `commit` (`store_commit.go:106-120`:
+  `clearPendingConfirmLocked` cancels the timer). Rewrote step 3 to
+  confirm with `commit` and warn that `commit check` alone rolls back.
+- **File(s)**: docs/bare-metal-device-map.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -34039,3 +34039,15 @@ top.
   `clearPendingConfirmLocked` cancels the timer). Rewrote step 3 to
   confirm with `commit` and warn that `commit check` alone rolls back.
 - **File(s)**: docs/bare-metal-device-map.md, _Log.md
+
+- **Timestamp**: 2026-07-04
+- **Action**: fable-review-165 H-28 (#4195) — fix docs/deploy-quickstart.md
+  standalone quickstart. standalone.yaml (and the `launch` form) source
+  br-mgmt/br-lan/br-wan, but the only `incus network create` block lived
+  in the HA section, so a fresh-host standalone deploy failed on an
+  unknown source network; and a bare bridge has no DHCP, so fxp0 (mgmt)
+  and ge-0/0/1 (WAN) — both `dhcp` in standalone.conf — came up with no
+  address. Added a copy-pasteable bridge-create block to the standalone
+  section mirroring the HA form: br-mgmt + br-wan NAT/DHCP-bearing, br-lan
+  plain L2 (ge-0/0/0 is the static gateway running dhcp-local-server).
+- **File(s)**: docs/deploy-quickstart.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -34051,3 +34051,20 @@ top.
   section mirroring the HA form: br-mgmt + br-wan NAT/DHCP-bearing, br-lan
   plain L2 (ge-0/0/0 is the static gateway running dhcp-local-server).
 - **File(s)**: docs/deploy-quickstart.md, _Log.md
+
+- **Timestamp**: 2026-07-04
+- **Action**: fable-review-165 H-29 (#4196) — add root-authentication to the
+  example day-0 configs. standalone.conf and ha-pair.conf enabled ssh
+  host-inbound but shipped no credentials, so SSH was unusable and a real
+  vSRX would refuse to commit (Junos requires root-authentication; xpf
+  accepts one silently). The baked sshd is PermitRootLogin
+  prohibit-password (scripts/image/bake.py), so an ssh KEY — not a
+  password — is what enables `ssh root@fxp0`. Added an active
+  `system root-authentication { ssh-ed25519 "...REPLACE..."; }` stanza to
+  both confs with a loud REPLACE-ME comment: it parses + commits (schema
+  node pkg/config/schema_system.go:58-67; no format validator on the key)
+  and gives vSRX parity, but the placeholder authenticates no one so it
+  fails closed if deployed unmodified. Verified all three personalities
+  still pass `xpfd check-config` (standalone; ha-pair -node-id 0 and 1) —
+  strict parse + schema + compile.
+- **File(s)**: examples/deploy/standalone.conf, examples/deploy/ha-pair.conf, _Log.md

--- a/docs/bare-metal-device-map.md
+++ b/docs/bare-metal-device-map.md
@@ -60,8 +60,16 @@ the console is your lifeline.
    ```
    commit confirmed 5
    ... verify reachability + forwarding ...
-   commit check        # or just `commit` to confirm
+   commit              # confirms the pending commit-confirmed
    ```
+
+   Confirm with a plain **`commit`** (Junos semantics: any subsequent
+   explicit `commit` confirms a pending `commit confirmed` —
+   `pkg/configstore/store_commit.go:106-120`). Do **not** rely on `commit
+   check` — it only VALIDATES the candidate and never touches the confirm
+   timer (`CommitCheck`, `store_commit.go:26-41`), so the window still
+   expires and the daemon auto-rolls-back the just-verified device-map at
+   T+5m.
 
 4. Verify the resolved bindings:
 

--- a/docs/deploy-quickstart.md
+++ b/docs/deploy-quickstart.md
@@ -54,6 +54,19 @@ incus image import dist/xpf-<ver>.incus-metadata.tar.gz \
 
 ## Standalone in two commands
 
+`standalone.yaml` (and the `launch` form below) source three bridges —
+`br-mgmt`, `br-lan`, `br-wan`. Create them first so the deploy runs
+unedited. `br-mgmt` and `br-wan` are **NAT/DHCP-bearing** so `fxp0`
+(mgmt, DHCP) and `ge-0/0/1` (WAN, DHCP-from-upstream) get addresses and
+reach the internet; `br-lan` is a plain L2 segment — `ge-0/0/0` is the
+static LAN gateway that runs the DHCP server itself:
+
+```bash
+incus network create br-mgmt ipv4.address=10.167.0.1/24 ipv4.nat=true ipv6.address=none
+incus network create br-wan  ipv4.address=10.168.0.1/24 ipv4.nat=true ipv6.address=none
+incus network create br-lan  ipv4.address=none ipv6.address=none
+```
+
 ```bash
 scripts/deploy/xpf-deploy.py inventory                              # see your NICs/VFs/bridges
 scripts/deploy/xpf-deploy.py deploy examples/deploy/standalone.yaml # build drive + launch

--- a/examples/deploy/ha-pair.conf
+++ b/examples/deploy/ha-pair.conf
@@ -156,6 +156,24 @@ routing-options {
     }
 }
 system {
+    /* REPLACE THIS BEFORE ANY USE — day-0 root credential (applies to
+     * BOTH nodes; this shared `system` block is outside the node0/node1
+     * groups).
+     *
+     * The example ships a NON-FUNCTIONAL placeholder ssh key so the
+     * config commits AND matches vSRX, which REFUSES to commit a config
+     * with no root-authentication (xpf accepts one silently — this
+     * stanza closes that parity + usability gap). As shipped it
+     * authenticates NO ONE (fails closed): the baked image's sshd runs
+     * PermitRootLogin prohibit-password, so an ssh KEY — not a password
+     * — is what lets `ssh root@fxp0` in. Paste your real ed25519 public
+     * key below (from `ssh-keygen -t ed25519`). To allow console /
+     * password login instead, replace the ssh-ed25519 line with:
+     *     encrypted-password "..."   # hash from `openssl passwd -6`
+     */
+    root-authentication {
+        ssh-ed25519 "ssh-ed25519 REPLACE-WITH-YOUR-ED25519-PUBLIC-KEY xpf-day0";
+    }
     name-server {
         1.1.1.1;
         9.9.9.9;

--- a/examples/deploy/standalone.conf
+++ b/examples/deploy/standalone.conf
@@ -65,6 +65,22 @@ security {
 }
 system {
     host-name xpf-fw1;
+    /* REPLACE THIS BEFORE ANY USE — day-0 root credential.
+     *
+     * The example ships a NON-FUNCTIONAL placeholder ssh key so the
+     * config commits AND matches vSRX, which REFUSES to commit a config
+     * with no root-authentication (xpf accepts one silently — this
+     * stanza closes that parity + usability gap). As shipped it
+     * authenticates NO ONE (fails closed): the baked image's sshd runs
+     * PermitRootLogin prohibit-password, so an ssh KEY — not a password
+     * — is what lets `ssh root@fxp0` in. Paste your real ed25519 public
+     * key below (from `ssh-keygen -t ed25519`). To allow console /
+     * password login instead, replace the ssh-ed25519 line with:
+     *     encrypted-password "..."   # hash from `openssl passwd -6`
+     */
+    root-authentication {
+        ssh-ed25519 "ssh-ed25519 REPLACE-WITH-YOUR-ED25519-PUBLIC-KEY xpf-day0";
+    }
     name-server {
         1.1.1.1;
         9.9.9.9;


### PR DESCRIPTION
Three DOC-accuracy findings from fable-review-165. Docs/examples only —
no code, no cargo. Each example config verified with the real
`xpfd check-config` strict commit-check gate.

## Closes #4194 Closes #4195 Closes #4196

### H-18 (#4194) — `commit check` does not confirm a `commit confirmed`
`docs/bare-metal-device-map.md` step 3 told the operator that `commit
check` confirms a pending `commit confirmed`. It does not: `CommitCheck`
(`pkg/configstore/store_commit.go:26-41`) validates the candidate and
returns without touching the confirm timer, so following the doc lets
the T+5m window expire and auto-rolls-back the just-verified device-map.
The confirming command is a plain `commit`
(`store_commit.go:106-120` — `clearPendingConfirmLocked` cancels the
timer). Rewrote step 3 to confirm with `commit` and warn that `commit
check` alone rolls back.

### H-28 (#4195) — standalone quickstart missing its bridge prerequisites
`docs/deploy-quickstart.md`'s standalone "two commands" deploys
`standalone.yaml`, which sources `br-mgmt`/`br-lan`/`br-wan`, but the
only `incus network create` block was in the HA section — a fresh-host
standalone deploy failed on an unknown source network. And a bare bridge
has no DHCP, so `fxp0` (mgmt) and `ge-0/0/1` (WAN), both `dhcp` in
`standalone.conf`, came up with no address. Added a bridge-create block
to the standalone section mirroring the HA form: `br-mgmt`+`br-wan`
NAT/DHCP-bearing, `br-lan` plain L2 (`ge-0/0/0` is the static gateway
that runs the DHCP server). Also covers the `launch` variant.

### H-29 (#4196) — examples ship no root credential
`standalone.conf`/`ha-pair.conf` enabled `ssh` host-inbound but carried
no `root-authentication`, so SSH was unusable (the baked sshd is
`prohibit-password`, `scripts/image/bake.py`) and a real vSRX would
refuse to commit. Added an active `system root-authentication` stanza
with an `ssh-ed25519` **placeholder** key + a loud REPLACE-ME comment to
both confs. Under `prohibit-password`, an ssh key (not a password) is
what makes `ssh root@fxp0` work; the placeholder authenticates no one so
a verbatim deploy fails closed (no weak default), and it gives vSRX
commit parity.

## Validation
`xpfd check-config` PASS (strict parse + schema + compile):
- `examples/deploy/standalone.conf`
- `examples/deploy/ha-pair.conf` `-node-id 0` and `-node-id 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi