### PR TITLE
CI/self-test coverage: validate.py legs, self-test runner, xpf-deploy HA gate tests (fable-165 H-9/H-19/H-24)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,11 @@ make test            # Run BOTH the Go suite AND the Rust userspace-dp
                      # cargo suite (#4006) — a Rust dataplane regression
                      # fails `make test`. `make test-go` / `make test-rust`
                      # run one leg. The Rust leg needs cargo (~minutes).
+make selftest        # Run ALL day-0/image/dist/deploy self-tests
+                     # (scripts/run-selftests.sh) in one fast hermetic pass —
+                     # grow-root, bake sign-order, dist roundtrip, validate.py
+                     # helpers, xpf-deploy mixed-base HA gate. Tool-gated legs
+                     # SKIP. Run before touching image/day-0/dist/deploy tooling.
 ```
 
 ## Test Environment (Incus VM)

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,24 @@ audit-check:
 docs-check:
 	bash scripts/docs/check-upgrade-docs.sh
 
+# Single entry point for the day-0/image/dist/deploy self-tests (#4210 H-19).
+# Before this, scripts/image/test-grow-root.sh, test_bake_sign_ordering.py,
+# scripts/dist/selftest.sh, and scripts/deploy/test_xpf_deploy_*.py all passed
+# but were reachable from NO target — a regression re-introducing
+# sign-before-validate (#4017) or breaking the grow-root stamp discipline
+# (#2047) merged green because nothing ran them. `make selftest` discovers and
+# runs them all in one fast (<a few seconds), hermetic pass (no root, no incus,
+# no cluster, no network); a leg whose external tool is missing SKIPs rather
+# than fails. Standalone by design — same posture as audit-check / docs-check /
+# test-deploy-lib (this repo has no CI; every gate is developer-invoked). It is
+# the one command to run before touching image/day-0/dist/deploy tooling, and
+# the single hook a future CI would call. The incus/QEMU image boot matrix
+# (scripts/image/validate.py) and the loss-cluster smokes are NOT included —
+# they need a hypervisor and have their own entry points.
+.PHONY: selftest
+selftest:
+	sh scripts/run-selftests.sh
+
 # Bake the distributable appliance image (#1879 Path C): one
 # offline-built bootable root disk (LATEST Ubuntu server cloudimg base
 # discovered at bake time — XPF_BASE_RELEASE pins; linux-generic

--- a/_Log.md
+++ b/_Log.md
@@ -34193,3 +34193,33 @@ top.
 - **File(s)**: scripts/dist/build-apt-repo.sh, debian/rules,
   scripts/dist/publish.py, scripts/dist/selftest.sh, docs/distribution.md,
   docs/in-place-upgrade.md, _Log.md
+
+- **Timestamp**: 2026-07-04
+- **Action**: Fixed fable-review-165 H-9/H-19/H-24 (issues #4209/#4210/#4211) —
+  CI/self-test coverage gaps.
+  - H-9 (#4209): validate.py exercised first boot only under incus. Added
+    scenario `q` (libvirt/plain-QEMU bootability: an always-on qcow2 probe —
+    qemu-img info format==qcow2 + virtual-size >= 8 GiB bake floor + qemu-img
+    check — plus a gated direct-QEMU boot with the day-0 config on a cdrom,
+    SKIP without qemu-system/KVM/OVMF); scenario `e` (cluster node-id=1 drive
+    → /etc/xpf/node-id persisted + em0/ge-7/0/N cluster naming); and extended
+    scenario `c` with the reject→fix→reboot→applied retry leg (pairs with the
+    H-1 active.json guard). Scenario map is now a single registry
+    (SCENARIO_ORDER/SCENARIO_METHODS). New hermetic test
+    test_validate_scenarios.py (12 tests) covers _qemu_img_verdict, OVMF
+    discovery order, the registry, and the node-id drive round-trip.
+  - H-19 (#4210): the day-0/image/dist/deploy self-tests were wired into no
+    target. Added scripts/run-selftests.sh + `make selftest`: discovers and
+    runs all hermetic self-tests (shell parse-check + shellcheck, grow-root,
+    bake sign-order, validate helpers, dist roundtrip, all deploy tests) in
+    one pass; tool-gated legs SKIP. 27 legs green.
+  - H-24 (#4211): the xpf-deploy mixed-base HA safety gate (_gate_mixed_base,
+    Python mirror of upgrade.GateMixedBaseSwap) + core pure funcs were
+    untested. New test_xpf_deploy_gate.py (28 tests): gate parity vectors
+    SHARED with pkg/upgrade/imageversions_test.go, _u16, manifest round-trip,
+    peer-probe parse, expected_name, memory_mb, --nic parser. RED-on-revert
+    confirmed (dropping the session-sync exact-match flips the mismatch test).
+- **File(s)**: scripts/image/validate.py,
+  scripts/image/test_validate_scenarios.py,
+  scripts/deploy/test_xpf_deploy_gate.py, scripts/run-selftests.sh, Makefile,
+  docs/install-images.md, CLAUDE.md, _Log.md

--- a/docs/install-images.md
+++ b/docs/install-images.md
@@ -163,6 +163,27 @@ python3 scripts/image/validate.py --qcow2 dist/xpf-<ver>.qcow2 \
     --metadata dist/xpf-<ver>.incus-metadata.tar.gz all
 ```
 
+Scenarios (`a|b|c|d|e|q|all`, default `all`):
+
+| key | proves |
+|-----|--------|
+| `a` | factory bootstrap (no drive): xpfd active, fxp0 DHCP, sshd, in-guest `verify-dataplane` |
+| `b` | valid day-0 drive: validated + installed + committed; reboot does NOT re-apply |
+| `c` | invalid drive: commit-check REJECT, nothing installed, boot survives; **then** a fixed drive + reboot DOES apply (the fix→reboot→applied retry contract, pairs with the day-0 `active.json` guard) |
+| `d` | resized disk: first-boot root auto-grow, idempotent on reboot, ESP intact |
+| `e` | cluster node-id drive: `node-id=1` persisted to `/etc/xpf/node-id`, cluster naming (`em0` + node-1 `ge-7/0/N`) |
+| `q` | libvirt/plain-QEMU bootability: the qcow2 is a valid, non-corrupt qcow2 ≥ the 8 GiB bake floor (always), and — gated on `qemu-system-x86_64` + `/dev/kvm` + OVMF — actually boots under direct QEMU with the day-0 config on a cdrom |
+
+Scenarios `a`–`e` need local incus; `q`'s boot leg needs qemu + KVM +
+OVMF and SKIPs (its config-level qcow2 probe still runs) when they are
+absent, like the root-required skips.
+
+Hermetic self-tests (no hypervisor, run in the `make selftest` runner —
+see below): `scripts/image/test_validate_scenarios.py` covers the pure
+pieces the incus/QEMU scenarios hinge on (the qcow2 bootability verdict,
+OVMF discovery order, the scenario registry, and the node-id drive
+round-trip).
+
 > **Deploying at scale?** `docs/deploy-quickstart.md` +
 > `examples/deploy/README.md` are the operator runbook: the positional
 > naming contract, the Python deployer (`scripts/deploy/xpf-deploy.py`
@@ -378,6 +399,37 @@ single ≥6.18 kernel, in-guest `verify-dataplane`, day-0 valid/invalid),
 Tier 2 (standalone forwarding + SNAT, manual), and Tier 3 (HA pair
 forwarding + failover, manual). Tier 1 gates the bake; Tiers 2–3 push
 real traffic and prove the image actually routes.
+
+### Self-tests — `make selftest`
+
+The day-0/image/dist/deploy tooling has a suite of hermetic self-tests
+(no root, no incus, no cluster, no network). `make selftest`
+(`scripts/run-selftests.sh`) is the single entry point that discovers and
+runs them all in one fast pass — before this they were reachable from no
+target and a regression re-introducing sign-before-validate (#4017) or
+breaking the grow-root stamp discipline (#2047) merged green. A leg whose
+external tool is missing SKIPs rather than fails, so the runner is green
+on a minimal host and only goes RED on a genuine regression. It covers:
+
+- shell parse-check (`sh`/`bash -n`) + `shellcheck` over the image/dist
+  shell scripts (`xpf-day0-config`, `xpf-grow-root`, `selftest.sh`, …);
+- `scripts/image/test-grow-root.sh` — grow-root device resolution + stamp
+  discipline (#1925);
+- `scripts/image/test_bake_sign_ordering.py` — VALIDATE-before-SIGN
+  ordering (#4017) + frr-pythontools presence;
+- `scripts/image/test_validate_scenarios.py` — the `validate.py` scenario
+  pure helpers (#4209 H-9);
+- `scripts/dist/selftest.sh` — the signed-distribution roundtrip
+  (sign → verify → tamper-fails → apt repo → `install.sh --dry-run`,
+  throwaway key; SKIPs without minisign/gpg/apt-ftparchive);
+- `scripts/deploy/test_xpf_deploy_*.py` — the deployer's pure functions,
+  NIC ordering, per-VM disks, and the **mixed-base HA safety gate**
+  (`_gate_mixed_base`, the Python mirror of `upgrade.GateMixedBaseSwap`)
+  with the same parity vectors as the Go test (#4211 H-24).
+
+The incus/QEMU image boot matrix (`validate.py`) and the loss-cluster
+smokes need a hypervisor and are NOT part of `make selftest` — they have
+their own entry points (above, and `make test-failover` / `docs/…`).
 
 ## What the image does NOT solve
 

--- a/scripts/deploy/test_xpf_deploy_gate.py
+++ b/scripts/deploy/test_xpf_deploy_gate.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Unit tests for the xpf-deploy.py mixed-base HA safety gate and the core
+pure functions the deployer relies on (fable-review-165 H-24).
+
+The deployer is 1348 lines imported/executed by nothing. The single most
+load-bearing piece is `_gate_mixed_base` — the Python "EXACT mirror of
+upgrade.GateMixedBaseSwap". That gate decides whether a LANE-2 HA image roll
+can preserve sessions across the failover; its docstring leans on the Go
+side's tests, and nothing here stops the mirror from drifting from the Go
+gate (pkg/upgrade/imageversions.go:139, pkg/upgrade/imageversions_test.go).
+
+These vectors are the SAME ones the Go test pins (imageversions_test.go):
+peer HA 1 or 2 in window [1,2] + sync 3 -> survive; peer HA 0 / below floor /
+above ceiling / sync-mismatch / sync-0 / negative -> fail closed. RED on any
+fix-forward that relaxes a leg (drops the session-sync exact-match, treats an
+unknown peer as compatible, or widens the HA window).
+
+Also covers the surrounding pure surface H-24 lists as untested:
+`_u16`, `_read_image_manifest_versions` (the manifest key round-trip that
+feeds the gate), `_node_protocol_versions` (the peer probe parse),
+`expected_name` (the positional naming contract), `memory_mb`, and the
+`--nic` spec parser in `cmd_launch`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "xpf_deploy", Path(__file__).with_name("xpf-deploy.py")
+)
+xpf_deploy = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(xpf_deploy)
+
+
+# The Go parity fixture (imageversions_test.go sampleManifest): a bake
+# .manifest speaking HA 2, floor 1, session-sync 3.
+_SAMPLE_MANIFEST = """version: 1.2.3
+git_commit: abcdef
+base_release: 26.04
+ha_protocol_version: 2
+ha_protocol_min_compat: 1
+session_sync_protocol_version: 3
+configdb_envelope_version: 1
+configdb_min_reader_version: 1
+"""
+
+# The Go parity fixture (imageversions_test.go sampleProtoVersions): the
+# hyphen/equals namespace `xpfd protocol-versions` emits on a running peer.
+_SAMPLE_PROTO = """xpf-version=1.2.3
+ha-protocol-version=2
+ha-protocol-min-compat=1
+session-sync-protocol-version=3
+configdb-envelope-version=1
+configdb-min-reader-version=1
+"""
+
+
+def _manifest_dict(text=_SAMPLE_MANIFEST):
+    """Parse a manifest string through the REAL round-trip helper (writes a
+    temp file so `_read_image_manifest_versions` opens it exactly as the
+    deployer does)."""
+    with tempfile.NamedTemporaryFile("w", suffix=".manifest",
+                                     delete=False) as f:
+        f.write(text)
+        path = f.name
+    try:
+        return xpf_deploy._read_image_manifest_versions(path)
+    finally:
+        os.unlink(path)
+
+
+def _peer(ha, sync):
+    """A peer protocol-versions dict as `_node_protocol_versions` would
+    return it (string values, hyphenated keys)."""
+    return {"ha-protocol-version": str(ha),
+            "session-sync-protocol-version": str(sync)}
+
+
+# ── H-24 primary: the mixed-base HA safety gate (Go-parity vectors) ───────
+class MixedBaseGateTests(unittest.TestCase):
+    def setUp(self):
+        self.img = _manifest_dict()  # HA 2, floor 1, sync 3
+
+    # --- survive legs (must match GateMixedBaseSwap true cases) ---
+    def test_peer_in_window_and_sync_match_survives(self):
+        survive, reason = xpf_deploy._gate_mixed_base(self.img, _peer(1, 3))
+        self.assertTrue(survive, reason)
+
+    def test_same_version_peer_survives(self):
+        survive, reason = xpf_deploy._gate_mixed_base(self.img, _peer(2, 3))
+        self.assertTrue(survive, reason)
+
+    # --- fail-closed legs (RED on any relaxation) ---
+    def test_unknown_peer_ha_fails_closed(self):
+        # peer HA 0 (not advertising) -> drop.
+        survive, _ = xpf_deploy._gate_mixed_base(self.img, _peer(0, 3))
+        self.assertFalse(survive)
+
+    def test_peer_below_compat_floor_fails_closed(self):
+        # New image floor raised to 2, peer still on 1 -> below floor.
+        img = _manifest_dict(_SAMPLE_MANIFEST.replace(
+            "ha_protocol_min_compat: 1", "ha_protocol_min_compat: 2"))
+        survive, _ = xpf_deploy._gate_mixed_base(img, _peer(1, 3))
+        self.assertFalse(survive)
+
+    def test_peer_newer_than_image_fails_closed(self):
+        # peer HA 3 > new image's 2 (a downgrade is not gated safe) -> drop.
+        survive, _ = xpf_deploy._gate_mixed_base(self.img, _peer(3, 3))
+        self.assertFalse(survive)
+
+    def test_session_sync_mismatch_fails_closed(self):
+        # THE mixed-base hazard: peer HA fine (1) but session-sync differs
+        # (peer 4, image 3). A fix-forward that drops this exact-match check
+        # (e.g. "just compare HA") would let a mismatched-base HA pair roll
+        # and silently corrupt synced sessions at the failover. RED here.
+        survive, reason = xpf_deploy._gate_mixed_base(self.img, _peer(1, 4))
+        self.assertFalse(survive, reason)
+        self.assertIn("session-sync", reason)
+
+    def test_unknown_peer_session_sync_fails_closed(self):
+        # peer session-sync 0 (unknown) must NOT be skipped as compatible.
+        survive, _ = xpf_deploy._gate_mixed_base(self.img, _peer(1, 0))
+        self.assertFalse(survive)
+
+    def test_negative_peer_session_sync_fails_closed(self):
+        # A signed value out of uint16 range -> _u16 None -> unparsable peer.
+        survive, _ = xpf_deploy._gate_mixed_base(self.img, _peer(1, -1))
+        self.assertFalse(survive)
+
+    def test_missing_required_key_fails_closed(self):
+        img = dict(self.img)
+        del img["session-sync-protocol-version"]
+        survive, reason = xpf_deploy._gate_mixed_base(img, _peer(1, 3))
+        self.assertFalse(survive)
+        self.assertIn("session-sync-protocol-version", reason)
+
+    def test_out_of_range_image_version_fails_closed(self):
+        # New image manifest itself carries an out-of-uint16 session-sync.
+        img = _manifest_dict(_SAMPLE_MANIFEST.replace(
+            "session_sync_protocol_version: 3",
+            "session_sync_protocol_version: 70000"))
+        survive, _ = xpf_deploy._gate_mixed_base(img, _peer(1, 3))
+        self.assertFalse(survive)
+
+
+# ── manifest key round-trip: _read_image_manifest_versions feeds the gate ──
+class ManifestRoundTripTests(unittest.TestCase):
+    def test_underscores_become_hyphens(self):
+        d = _manifest_dict()
+        # The gate reads hyphenated keys; the manifest ships underscores.
+        self.assertEqual(d["ha-protocol-version"], "2")
+        self.assertEqual(d["ha-protocol-min-compat"], "1")
+        self.assertEqual(d["session-sync-protocol-version"], "3")
+
+    def test_comments_and_blank_lines_skipped(self):
+        d = _manifest_dict("# a comment\n\nha_protocol_version: 2\n"
+                            "ha_protocol_min_compat: 1\n"
+                            "session_sync_protocol_version: 3\n")
+        self.assertEqual(set(d.keys()),
+                         {"ha-protocol-version", "ha-protocol-min-compat",
+                          "session-sync-protocol-version"})
+
+    def test_round_trip_output_gates_true(self):
+        # End to end: a real manifest file parsed and fed to the gate against
+        # a compatible peer must survive — proves the two helpers agree on
+        # the key namespace.
+        survive, reason = xpf_deploy._gate_mixed_base(_manifest_dict(),
+                                                      _peer(1, 3))
+        self.assertTrue(survive, reason)
+
+
+# ── _u16: uint16 bounds mirroring strconv.ParseUint(.,10,16) ──────────────
+class U16Tests(unittest.TestCase):
+    def test_valid_range(self):
+        self.assertEqual(xpf_deploy._u16("0"), 0)
+        self.assertEqual(xpf_deploy._u16("65535"), 0xFFFF)
+        self.assertEqual(xpf_deploy._u16("2"), 2)
+
+    def test_negative_rejected(self):
+        self.assertIsNone(xpf_deploy._u16("-1"))
+
+    def test_over_range_rejected(self):
+        self.assertIsNone(xpf_deploy._u16("70000"))
+        self.assertIsNone(xpf_deploy._u16("65536"))
+
+    def test_non_numeric_rejected(self):
+        self.assertIsNone(xpf_deploy._u16("x"))
+        self.assertIsNone(xpf_deploy._u16(""))
+        self.assertIsNone(xpf_deploy._u16(None))
+
+
+# ── _node_protocol_versions: parse the peer probe (key=value) ─────────────
+class NodeProtocolVersionsTests(unittest.TestCase):
+    def setUp(self):
+        self._orig = xpf_deploy._node_exec
+
+    def tearDown(self):
+        xpf_deploy._node_exec = self._orig
+
+    def test_parses_key_equals_value(self):
+        xpf_deploy._node_exec = lambda *a, **k: _SAMPLE_PROTO
+        d = xpf_deploy._node_protocol_versions(None, "incus", "fw0")
+        self.assertEqual(d["ha-protocol-version"], "2")
+        self.assertEqual(d["session-sync-protocol-version"], "3")
+        # And it feeds the gate directly (peer probe -> gate parity).
+        survive, reason = xpf_deploy._gate_mixed_base(_manifest_dict(), d)
+        self.assertTrue(survive, reason)
+
+    def test_ignores_non_kv_lines(self):
+        xpf_deploy._node_exec = lambda *a, **k: (
+            "banner line\nha-protocol-version=2\n\n")
+        d = xpf_deploy._node_protocol_versions(None, "incus", "fw0")
+        self.assertEqual(d, {"ha-protocol-version": "2"})
+
+
+# ── expected_name: the positional naming contract ─────────────────────────
+class ExpectedNameTests(unittest.TestCase):
+    def test_position_one_is_fxp0(self):
+        self.assertEqual(xpf_deploy.expected_name(0, "standalone", None), "fxp0")
+        self.assertEqual(xpf_deploy.expected_name(0, "cluster", 1), "fxp0")
+
+    def test_standalone_ge_naming(self):
+        self.assertEqual(xpf_deploy.expected_name(1, "standalone", None), "ge-0/0/0")
+        self.assertEqual(xpf_deploy.expected_name(3, "standalone", None), "ge-0/0/2")
+
+    def test_cluster_em0_then_fpc(self):
+        self.assertEqual(xpf_deploy.expected_name(1, "cluster", 0), "em0")
+        # node 0 uses FPC 0, node 1 uses FPC 7.
+        self.assertEqual(xpf_deploy.expected_name(2, "cluster", 0), "ge-0/0/0")
+        self.assertEqual(xpf_deploy.expected_name(2, "cluster", 1), "ge-7/0/0")
+        self.assertEqual(xpf_deploy.expected_name(3, "cluster", 1), "ge-7/0/1")
+
+
+# ── memory_mb ─────────────────────────────────────────────────────────────
+class MemoryMbTests(unittest.TestCase):
+    def test_gigabytes(self):
+        self.assertEqual(xpf_deploy.memory_mb("4G"), 4096)
+        self.assertEqual(xpf_deploy.memory_mb("2GiB"), 2048)
+
+    def test_megabytes_default(self):
+        self.assertEqual(xpf_deploy.memory_mb("512"), 512)
+        self.assertEqual(xpf_deploy.memory_mb("512M"), 512)
+
+    def test_unparseable_dies(self):
+        with self.assertRaises(SystemExit):
+            xpf_deploy.memory_mb("lots")
+
+
+# ── --nic spec parser (cmd_launch) ────────────────────────────────────────
+class NicSpecParserTests(unittest.TestCase):
+    class _Args:
+        pass
+
+    def _launch_interfaces(self, nics):
+        """Drive cmd_launch far enough to capture the parsed interface list
+        via a validate_appliance stub, without deploying."""
+        captured = {}
+        orig_validate = xpf_deploy.validate_appliance
+        orig_deploy = xpf_deploy.deploy
+        xpf_deploy.validate_appliance = lambda ap, where: captured.update(ap)
+        xpf_deploy.deploy = lambda ap, args: None
+        try:
+            a = self._Args()
+            a.nic = nics
+            a.name = "fw"
+            a.mode = "standalone"
+            a.node_id = None
+            a.image = "xpf-appliance"
+            a.cpu = 2
+            a.mem = "4G"
+            a.config = None
+            xpf_deploy.cmd_launch(a)
+        finally:
+            xpf_deploy.validate_appliance = orig_validate
+            xpf_deploy.deploy = orig_deploy
+        return captured["interfaces"]
+
+    def test_backing_prefix_split(self):
+        ifs = self._launch_interfaces(
+            ["bridge:br-mgmt", "sriov:enp8s0", "pci:0000:09:00.0"])
+        self.assertEqual(ifs[0], {"backing": "bridge", "source": "br-mgmt"})
+        self.assertEqual(ifs[1], {"backing": "sriov", "source": "enp8s0"})
+        # The pci: source keeps its full BDF (only the FIRST ':' splits kind).
+        self.assertEqual(ifs[2],
+                         {"backing": "pci", "source": "0000:09:00.0"})
+
+    def test_bare_spec_defaults_to_net(self):
+        ifs = self._launch_interfaces(["mgmtnet"])
+        self.assertEqual(ifs[0], {"backing": "net", "source": "mgmtnet"})
+
+    def test_mac_suffix_extracted(self):
+        ifs = self._launch_interfaces(["bridge:br0,mac=02:00:00:00:00:01"])
+        self.assertEqual(ifs[0]["mac"], "02:00:00:00:00:01")
+        self.assertEqual(ifs[0]["source"], "br0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/image/test_validate_scenarios.py
+++ b/scripts/image/test_validate_scenarios.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Hermetic unit tests for the validate.py scenario additions (fable-165 H-9).
+
+validate.py's incus/QEMU scenarios cannot run without a hypervisor and a real
+baked qcow2, but the pieces they hinge on ARE unit-testable without one:
+
+  - `_qemu_img_verdict` — the pure config-level qcow2 bootability check the
+    libvirt/plain-QEMU leg (scenario q) runs whenever qemu-img exists.
+  - the OVMF firmware discovery ORDER (non-secboot preferred).
+  - the scenario registry wiring (that e/q exist and dispatch).
+  - the node-id day-0 drive the cluster scenario (e) depends on actually
+    carrying a `node-id` file (make_config_drive round-trip).
+
+RED on revert: dropping the qcow2 format/size verdict, removing scenario e/q,
+or breaking the node-id drive all flip an assertion here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_ROOT = _HERE.parent.parent
+# validate.py's own top-level imports (make_config_drive, sign) resolve via the
+# sys.path inserts it performs at import time.
+_SPEC = importlib.util.spec_from_file_location("validate", _HERE / "validate.py")
+validate = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(validate)
+
+_SPEC_MCD = importlib.util.spec_from_file_location(
+    "make_config_drive", _HERE / "make_config_drive.py")
+make_config_drive = importlib.util.module_from_spec(_SPEC_MCD)
+assert _SPEC_MCD.loader is not None
+_SPEC_MCD.loader.exec_module(make_config_drive)
+
+
+# ── _qemu_img_verdict: qcow2 libvirt-bootability (scenario q config leg) ───
+class QemuImgVerdictTests(unittest.TestCase):
+    FLOOR = validate.BAKE_MIN_BYTES
+
+    def test_valid_qcow2_at_floor_passes(self):
+        ok, _ = validate._qemu_img_verdict(
+            {"format": "qcow2", "virtual-size": self.FLOOR}, self.FLOOR)
+        self.assertTrue(ok)
+
+    def test_larger_qcow2_passes(self):
+        ok, reason = validate._qemu_img_verdict(
+            {"format": "qcow2", "virtual-size": 20 * 1024 ** 3}, self.FLOOR)
+        self.assertTrue(ok, reason)
+
+    def test_wrong_format_fails(self):
+        # A raw export is what libvirt/plain-QEMU would refuse as the qcow2.
+        ok, reason = validate._qemu_img_verdict(
+            {"format": "raw", "virtual-size": self.FLOOR}, self.FLOOR)
+        self.assertFalse(ok)
+        self.assertIn("qcow2", reason)
+
+    def test_below_floor_fails(self):
+        # A truncated / incomplete image.
+        ok, reason = validate._qemu_img_verdict(
+            {"format": "qcow2", "virtual-size": 1024}, self.FLOOR)
+        self.assertFalse(ok)
+        self.assertIn("floor", reason)
+
+    def test_missing_or_nonint_size_fails(self):
+        self.assertFalse(validate._qemu_img_verdict(
+            {"format": "qcow2"}, self.FLOOR)[0])
+        self.assertFalse(validate._qemu_img_verdict(
+            {"format": "qcow2", "virtual-size": "8G"}, self.FLOOR)[0])
+
+
+# ── OVMF discovery: non-secboot preferred, first-existing wins ────────────
+class OvmfDiscoveryTests(unittest.TestCase):
+    def test_non_secboot_code_preferred_over_secboot(self):
+        cands = validate._OVMF_CODE_CANDIDATES
+        first_plain = next(i for i, p in enumerate(cands) if "secboot" not in p)
+        first_sb = next((i for i, p in enumerate(cands) if "secboot" in p),
+                        len(cands))
+        self.assertLess(first_plain, first_sb,
+                        "a non-secboot OVMF_CODE must be tried before any secboot one")
+
+    def test_find_first_returns_first_existing(self):
+        orig = os.path.isfile
+        present = {"/b", "/c"}
+        validate.os.path.isfile = lambda p: p in present
+        try:
+            self.assertEqual(validate._find_first(["/a", "/b", "/c"]), "/b")
+            self.assertIsNone(validate._find_first(["/x", "/y"]))
+        finally:
+            validate.os.path.isfile = orig
+
+
+# ── scenario registry wiring (single source of truth for CLI + dispatch) ──
+class ScenarioRegistryTests(unittest.TestCase):
+    def test_order_includes_h9_additions(self):
+        self.assertEqual(validate.SCENARIO_ORDER, ["a", "b", "c", "d", "e", "q"])
+
+    def test_every_key_maps_to_a_real_harness_method(self):
+        for k in validate.SCENARIO_ORDER:
+            self.assertIn(k, validate.SCENARIO_METHODS)
+            meth = validate.SCENARIO_METHODS[k]
+            self.assertTrue(hasattr(validate.Harness, meth),
+                            f"scenario {k!r} -> missing Harness.{meth}")
+
+    def test_h9_scenarios_present(self):
+        self.assertEqual(validate.SCENARIO_METHODS["e"], "scenario_e")
+        self.assertEqual(validate.SCENARIO_METHODS["q"], "scenario_qemu")
+
+
+# ── node-id day-0 drive (scenario e depends on this) ──────────────────────
+class NodeIdDriveTests(unittest.TestCase):
+    def test_node_id_out_of_range_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            conf = os.path.join(tmp, "x.conf")
+            with open(conf, "w") as f:
+                f.write("system { host-name x; }\n")
+            with self.assertRaises(SystemExit):
+                make_config_drive.build_config_drive(
+                    conf, os.path.join(tmp, "x.iso"), node_id=2, validate=False)
+
+    def test_node_id_1_drive_carries_node_id_file(self):
+        if not shutil.which("xorriso"):
+            self.skipTest("xorriso not installed — cannot build/extract the ISO")
+        with tempfile.TemporaryDirectory() as tmp:
+            conf = os.path.join(tmp, "n.conf")
+            with open(conf, "w") as f:
+                f.write("system { host-name xpf-node1; }\n")
+            iso = make_config_drive.build_config_drive(
+                conf, os.path.join(tmp, "n.iso"), node_id=1, validate=False)
+            out = os.path.join(tmp, "extract")
+            subprocess.run(
+                ["xorriso", "-osirrox", "on", "-indev", iso,
+                 "-extract", "/", out],
+                check=True, capture_output=True)
+            nid = os.path.join(out, "node-id")
+            self.assertTrue(os.path.isfile(nid), "day-0 drive has no node-id file")
+            with open(nid) as f:
+                self.assertEqual(f.read().strip(), "1")
+            self.assertTrue(os.path.isfile(os.path.join(out, "xpf.conf")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/image/validate.py
+++ b/scripts/image/validate.py
@@ -10,19 +10,31 @@ never the shared loss cluster) and proves the first-boot contract:
   b  valid day-0 drive -> config validated + installed + committed at first
      boot (hostname applied); a reboot does NOT re-apply (stamp).
   c  invalid day-0 drive -> commit-check REJECT logged, nothing installed,
-     boot survives, factory bootstrap still reachable.
+     boot survives, factory bootstrap still reachable; THEN the operator
+     swaps in a VALID drive and reboots and the config now applies (the
+     fix->reboot->applied retry contract, #4209 H-9 / pairs with H-1).
   d  resized disk (#1925) -> first-boot root auto-grow fills a LARGER root
      disk (partition + ext4), stamps, is idempotent on reboot, and leaves the
      ESP/boot substrate intact; a control boot at the bake size is a clean
      no-op.
+  e  cluster node-id drive (#4209 H-9) -> a node-id=1 day-0 drive persists
+     /etc/xpf/node-id=1, boots into cluster mode, and (with >=3 NICs) the
+     daemon assigns the node-1 vSRX names em0 + ge-7/0/N (FPC 7).
+  q  libvirt/plain-QEMU bootability (#4209 H-9) -> the SAME qcow2 the docs
+     sell for "libvirt/KVM, plain QEMU" is a valid, non-corrupt qcow2 of at
+     least the bake floor (always), and — gated on qemu-system-x86_64 +
+     /dev/kvm + OVMF — actually boots under direct QEMU with the day-0 config
+     on a cdrom (the cdrom day-0 attach path incus never exercises).
 
 Usage:
-  validate.py --qcow2 <img> --metadata <tar.gz> [a|b|c|d|all]
+  validate.py --qcow2 <img> --metadata <tar.gz> [a|b|c|d|e|q|all]
 """
 
 import argparse
+import json
 import os
 import shlex
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -36,6 +48,62 @@ import make_config_drive  # noqa: E402
 import sign  # noqa: E402  (#1924 signed-distribution helper)
 
 ALIAS = "xpf-image-validate"
+
+# The bake provisions an 8 GiB root disk (see scripts/image/bake.py); a qcow2
+# whose virtual size is below this floor is truncated / an incomplete artifact
+# that no hypervisor could boot correctly.
+BAKE_MIN_BYTES = 8 * 1024 ** 3
+
+# Scenario registry — the single source of truth for the CLI choices AND the
+# dispatch map, so a new scenario is wired in one place and is introspectable
+# by the hermetic unit test (test_validate_scenarios.py). "q" (QEMU) and "e"
+# (node-id) are the #4209 H-9 additions.
+SCENARIO_METHODS = {
+    "a": "scenario_a", "b": "scenario_b", "c": "scenario_c",
+    "d": "scenario_d", "e": "scenario_e", "q": "scenario_qemu",
+}
+SCENARIO_ORDER = ["a", "b", "c", "d", "e", "q"]
+
+# Preference order: a NON-secboot OVMF_CODE first so shim->grub->kernel boots
+# without needing MOK enrollment in the firmware var store (the shipped image
+# is Secure-Boot-signed, but plain-QEMU bootability is proven fine with SB off).
+_OVMF_CODE_CANDIDATES = (
+    "/usr/share/OVMF/OVMF_CODE_4M.fd",
+    "/usr/share/OVMF/OVMF_CODE.fd",
+    "/usr/share/edk2/x64/OVMF_CODE.4m.fd",
+    "/usr/share/qemu/OVMF_CODE.fd",
+    "/usr/share/OVMF/OVMF_CODE_4M.secboot.fd",
+    "/usr/share/OVMF/OVMF_CODE.secboot.fd",
+)
+_OVMF_VARS_CANDIDATES = (
+    "/usr/share/OVMF/OVMF_VARS_4M.fd",
+    "/usr/share/OVMF/OVMF_VARS.fd",
+    "/usr/share/edk2/x64/OVMF_VARS.4m.fd",
+    "/usr/share/qemu/OVMF_VARS.fd",
+)
+
+
+def _qemu_img_verdict(imginfo, min_bytes):
+    """Pure verdict over `qemu-img info --output=json` output: is this a
+    bootable qcow2 of at least `min_bytes` virtual size? Returns (ok, reason).
+    Split out so the config-level bootability check is unit-testable without a
+    real image (#4209 H-9)."""
+    fmt = imginfo.get("format")
+    if fmt != "qcow2":
+        return False, (f"image format is {fmt!r}, not qcow2 — libvirt/plain-QEMU "
+                       "consume the qcow2 export")
+    vsize = imginfo.get("virtual-size")
+    if not isinstance(vsize, int) or vsize < min_bytes:
+        return False, (f"virtual-size {vsize} below the {min_bytes}-byte bake floor "
+                       "— truncated / incomplete image")
+    return True, f"qcow2, virtual-size {vsize / (1024 ** 3):.1f}GiB"
+
+
+def _find_first(candidates):
+    for p in candidates:
+        if os.path.isfile(p):
+            return p
+    return None
 
 
 def info(m):
@@ -128,7 +196,7 @@ class Harness:
         info(f"importing image into local incus as {ALIAS}")
         incus("image", "import", self.metadata, self.qcow2, "--alias", ALIAS)
 
-    def launch(self, name, iso=None, root_size=None):
+    def launch(self, name, iso=None, root_size=None, extra_nics=0):
         incus("delete", "-f", name, check=False, capture=True)
         incus("init", ALIAS, name, "--vm", "--network", self.net,
               "-c", "limits.cpu=2", "-c", "limits.memory=2GiB", capture=True)
@@ -139,6 +207,12 @@ class Harness:
             # before the VM ever boots — the operator-resized-disk case.
             incus("config", "device", "override", name, "root",
                   f"size={root_size}", capture=True)
+        # Additional NICs beyond the default fxp0 slot, so the daemon's
+        # positional namer has em0 (idx 1) + ge-*/0/* (idx >= 2) to assign —
+        # required to prove the cluster node-id naming (#4209 H-9 scenario e).
+        for i in range(extra_nics):
+            incus("config", "device", "add", name, f"extranic{i}", "nic",
+                  f"network={self.net}", capture=True)
         if iso:
             incus("config", "device", "add", name, "day0", "disk",
                   f"source={os.path.realpath(iso)}", capture=True)
@@ -293,7 +367,42 @@ class Harness:
         self.wait_fxp0_dhcp("xpf-image-c")
         if not guest_sh("xpf-image-c", '[ "$(hostname)" != xpf-day0-c ]'):
             fail("invalid config changed the hostname")
-        info("Scenario C PASS (fallback reachable, boot survived)")
+        info("Scenario C reject leg PASS (fallback reachable, boot survived)")
+
+        # ── Retry leg (#4209 H-9, pairs with H-1): the REJECT wrote no stamp
+        # and left no committed active.json, so the box is still factory-
+        # default. Swap the bad drive for a VALID one and reboot — the day-0
+        # loader must re-probe and apply it. A regression that guarded on the
+        # bare .configdb directory (H-1) would have declared "already
+        # configured" here and never retried. ──
+        info("C retry: swapping in a VALID drive and rebooting...")
+        good = os.path.join(self.work, "day0-c-fixed.conf")
+        with open(good, "w") as f:
+            f.write("system {\n    host-name xpf-day0-c-fixed;\n}\n"
+                    "interfaces {\n    fxp0 {\n        unit 0 {\n"
+                    "            family inet {\n                dhcp;\n"
+                    "            }\n        }\n    }\n}\n")
+        good_iso = make_config_drive.build_config_drive(
+            good, os.path.join(self.work, "day0-c-fixed.iso"), validate=False)
+        # Replace the day0 medium in place, then reboot.
+        incus("config", "device", "remove", "xpf-image-c", "day0", capture=True)
+        incus("config", "device", "add", "xpf-image-c", "day0", "disk",
+              f"source={os.path.realpath(good_iso)}", capture=True)
+        incus("restart", "xpf-image-c")
+        self.wait_agent("xpf-image-c")
+        self.wait_xpfd("xpf-image-c")
+        if guest("xpf-image-c", "test", "-e", "/etc/xpf/.day0-config-applied",
+                 check=False).returncode != 0:
+            fail("retry: day-0 stamp missing after fix+reboot — the retry "
+                 "contract is broken (a rejected first boot could never be fixed)")
+        if not guest_sh("xpf-image-c",
+                        'journalctl -u xpf-day0-config -b --no-pager | grep -q '
+                        '"day-0 config installed"'):
+            fail("retry: day-0 loader did not install the fixed config on reboot")
+        self._wait("xpf-image-c",
+                   lambda: guest_sh("xpf-image-c", '[ "$(hostname)" = xpf-day0-c-fixed ]'),
+                   20, 3, "retry: fixed hostname xpf-day0-c-fixed not applied")
+        info("Scenario C PASS (reject survived, fix+reboot applied — retry contract)")
         self.drop("xpf-image-c")
 
     def _root_fs_gib(self, name):
@@ -388,6 +497,132 @@ class Harness:
         self.drop("xpf-image-d2")
         info("Scenario D PASS")
 
+    def scenario_e(self):
+        info("── Scenario E: cluster node-id day-0 drive (#4209 H-9) ──")
+        conf = os.path.join(self.work, "day0-node1.conf")
+        with open(conf, "w") as f:
+            f.write("system {\n    host-name xpf-node1;\n}\n"
+                    "interfaces {\n    fxp0 {\n        unit 0 {\n"
+                    "            family inet {\n                dhcp;\n"
+                    "            }\n        }\n    }\n}\n")
+        # node_id=1 writes a `node-id` file (contents "1") alongside xpf.conf on
+        # the drive; the loader persists it to /etc/xpf/node-id and the daemon
+        # reads it BEFORE positional naming (fpc=7 for node 1).
+        iso = make_config_drive.build_config_drive(
+            conf, os.path.join(self.work, "day0-node1.iso"), node_id=1,
+            validate=False)
+        # Two extra NICs so the namer has em0 (idx 1) and ge-7/0/0 (idx 2).
+        self.launch("xpf-image-e", iso, extra_nics=2)
+        self.wait_xpfd("xpf-image-e")
+        if guest("xpf-image-e", "test", "-e", "/etc/xpf/.day0-config-applied",
+                 check=False).returncode != 0:
+            fail("node-id drive: day-0 stamp missing")
+        # node-id persisted verbatim.
+        nid = guest("xpf-image-e", "sh", "-c",
+                    "cat /etc/xpf/node-id 2>/dev/null",
+                    capture=True).stdout.strip()
+        if nid != "1":
+            fail(f"/etc/xpf/node-id is '{nid}', expected '1' — node-id not "
+                 "persisted from the day-0 drive")
+        # Cluster-mode naming: node 1 uses FPC 7. em0 is assigned only in
+        # cluster mode (position 2); ge-7/0/0 proves the node-1 FPC branch.
+        if not guest_sh("xpf-image-e", 'ip link show em0 >/dev/null 2>&1'):
+            fail("em0 not present — daemon did not enter cluster naming mode "
+                 "for a node-id-present image")
+        if not guest_sh("xpf-image-e", 'ip link show ge-7/0/0 >/dev/null 2>&1'):
+            fail("ge-7/0/0 not present — node-1 FPC-7 positional naming did not "
+                 "run (a node-0 image would name it ge-0/0/0)")
+        info("Scenario E PASS (node-id=1 persisted, cluster em0 + ge-7/0/N naming)")
+        self.drop("xpf-image-e")
+
+    def scenario_qemu(self):
+        info("── Scenario Q: libvirt/plain-QEMU bootability (#4209 H-9) ──")
+        # ── Config-level probe (always runs when qemu-img is present): the
+        # qcow2 the docs sell for libvirt/KVM + plain QEMU must be a valid,
+        # non-corrupt qcow2 of at least the bake floor. Catches a truncated /
+        # wrong-format / corrupt export that incus import might still accept
+        # but a raw qcow2 consumer (libvirt) would refuse. ──
+        if not shutil.which("qemu-img"):
+            info("SKIP: qemu-img not installed (qemu-utils) — cannot probe the "
+                 "qcow2's libvirt bootability")
+            return
+        raw = subprocess.run(["qemu-img", "info", "--output=json", self.qcow2],
+                             capture_output=True, text=True)
+        if raw.returncode != 0:
+            fail(f"qemu-img info failed on {self.qcow2}: {raw.stderr.strip()}")
+        ok, reason = _qemu_img_verdict(json.loads(raw.stdout), BAKE_MIN_BYTES)
+        if not ok:
+            fail(f"qcow2 is not libvirt-bootable: {reason}")
+        info(f"qcow2 structural probe OK: {reason}")
+        chk = subprocess.run(["qemu-img", "check", "-q", self.qcow2],
+                             capture_output=True, text=True)
+        # qemu-img check exits 0 clean, 2/3 on leaked/corrupt clusters.
+        if chk.returncode not in (0,):
+            fail("qemu-img check reported qcow2 corruption:\n"
+                 f"{chk.stdout}{chk.stderr}")
+        info("qcow2 consistency check OK (no corruption)")
+
+        # ── Boot leg (gated): actually boot the SAME qcow2 under direct QEMU
+        # with a valid day-0 config on a cdrom, and confirm via the serial
+        # console that the appliance booted its userland and the day-0 loader
+        # applied the config off the cdrom — the plain-QEMU + cdrom-day-0 path
+        # incus never exercises. Needs qemu-system + KVM + OVMF; SKIP (probe
+        # stands) when any is absent, mirroring the root-required skips. ──
+        qsys = shutil.which("qemu-system-x86_64")
+        ovmf = _find_first(_OVMF_CODE_CANDIDATES)
+        ovmf_vars = _find_first(_OVMF_VARS_CANDIDATES)
+        if not qsys or not os.path.exists("/dev/kvm") or not ovmf or not ovmf_vars:
+            info("SKIP boot leg: need qemu-system-x86_64 + /dev/kvm + OVMF "
+                 f"(qemu={bool(qsys)} kvm={os.path.exists('/dev/kvm')} "
+                 f"ovmf_code={bool(ovmf)} ovmf_vars={bool(ovmf_vars)}) — "
+                 "the structural probe above stands")
+            return
+        conf = os.path.join(self.work, "day0-qemu.conf")
+        with open(conf, "w") as f:
+            f.write("system {\n    host-name xpf-qemu;\n}\n")
+        iso = make_config_drive.build_config_drive(
+            conf, os.path.join(self.work, "day0-qemu.iso"), validate=False)
+        vars_copy = os.path.join(self.work, "OVMF_VARS.fd")
+        shutil.copyfile(ovmf_vars, vars_copy)
+        serial = os.path.join(self.work, "qemu-serial.log")
+        argv = [qsys, "-machine", "q35,accel=kvm", "-cpu", "host",
+                "-m", "2048", "-smp", "2", "-nographic",
+                "-drive", f"if=pflash,format=raw,readonly=on,file={ovmf}",
+                "-drive", f"if=pflash,format=raw,file={vars_copy}",
+                # snapshot=on: never mutate the artifact under test.
+                "-drive", f"file={self.qcow2},if=virtio,format=qcow2,snapshot=on",
+                "-drive", f"file={os.path.realpath(iso)},media=cdrom",
+                "-serial", f"file:{serial}", "-nic", "none"]
+        info("booting the qcow2 under direct QEMU (serial-captured, snapshot)...")
+        proc = subprocess.Popen(argv, stdin=subprocess.DEVNULL,
+                                stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+        try:
+            deadline = time.time() + 360
+            txt = ""
+            while time.time() < deadline:
+                if proc.poll() is not None:
+                    _, err = proc.communicate()
+                    fail(f"QEMU exited early (rc={proc.returncode}): "
+                         f"{(err or b'').decode(errors='replace')[-400:]}")
+                if os.path.isfile(serial):
+                    txt = open(serial, errors="replace").read()
+                    if "day-0 config installed" in txt:
+                        info("QEMU boot: day-0 config installed off the cdrom")
+                        break
+                    if "REJECTED by commit-check" in txt:
+                        fail("QEMU boot: day-0 loader REJECTED a valid config")
+                time.sleep(3)
+            else:
+                fail("QEMU boot: no 'day-0 config installed' on the serial "
+                     f"console within 360s (serial tail:\n{txt[-600:]})")
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        info("Scenario Q PASS (qcow2 valid + boots under plain QEMU with cdrom day-0)")
+
 
 def _kver_ge(ver, floor):
     try:
@@ -427,7 +662,7 @@ def main():
                    const=False, help="skip image signature verification (dev)")
     p.set_defaults(verify_sig=True)  # default: verify if a .minisig is present
     p.add_argument("scenario", nargs="?", default="all",
-                   choices=["a", "b", "c", "d", "all"])
+                   choices=SCENARIO_ORDER + ["all"])
     a = p.parse_args()
     if not os.path.isfile(a.qcow2):
         fail(f"--qcow2 not found: {a.qcow2}")
@@ -438,12 +673,9 @@ def main():
     try:
         h.ensure_network()
         h.import_image()
-        scenarios = {"a": [h.scenario_a], "b": [h.scenario_b], "c": [h.scenario_c],
-                     "d": [h.scenario_d],
-                     "all": [h.scenario_a, h.scenario_b, h.scenario_c,
-                             h.scenario_d]}[a.scenario]
-        for s in scenarios:
-            s()
+        keys = SCENARIO_ORDER if a.scenario == "all" else [a.scenario]
+        for k in keys:
+            getattr(h, SCENARIO_METHODS[k])()
         info("Validation complete.")
         return 0
     finally:

--- a/scripts/run-selftests.sh
+++ b/scripts/run-selftests.sh
@@ -1,0 +1,155 @@
+#!/bin/sh
+# Single entry point for the day-0 / image / dist / deploy self-tests
+# (fable-165 H-19).
+#
+# These self-tests (grow-root stamp discipline, bake sign-ordering, the
+# signed-distribution roundtrip, and the xpf-deploy pure-function + mixed-base
+# HA gate coverage) all pass but were wired into NOTHING: `make test` runs only
+# the Go + Rust suites (#4006), there is no CI, and each self-test could only be
+# run by hand. A regression re-introducing sign-before-validate (#4017) or
+# breaking the grow-root stamp discipline (#2047) merged green.
+#
+# This runner DISCOVERS and runs every hermetic self-test with one command
+# (`make selftest`). It is fast (<a few seconds) and needs no root, no incus, no
+# cluster, no network. A leg whose external tool is missing SKIPs (exit 77 from
+# a shell leg, or unittest skips) instead of failing, so the runner is green on
+# a minimal host and only goes RED on a genuine regression.
+#
+# Scope: the pure/hermetic self-tests only. The incus/QEMU image boot matrix
+# (scripts/image/validate.py) and the loss-cluster smoke targets need a
+# hypervisor and are NOT run here — they have their own entry points.
+set -u
+
+# shellcheck disable=SC1007  # `CDPATH= cd` clears CDPATH for this command only
+HERE=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+# shellcheck disable=SC1007
+ROOT=$(CDPATH= cd -- "$HERE/.." && pwd)
+cd "$ROOT" || { echo "FATAL: cannot cd to repo root $ROOT" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+SKIP=0
+FAILED_LEGS=""
+
+hdr()  { printf '\n\033[1m== %s ==\033[0m\n' "$*"; }
+passl() { echo "  PASS: $*"; PASS=$((PASS + 1)); }
+skipl() { echo "  SKIP: $*"; SKIP=$((SKIP + 1)); }
+faill() { echo "  FAIL: $*" >&2; FAIL=$((FAIL + 1)); FAILED_LEGS="$FAILED_LEGS $1"; }
+
+# run_shell <script> [args...] — run a shell self-test. Exit 0 = PASS,
+# exit 77 = SKIP (a leg self-reported a missing tool), anything else = FAIL.
+run_shell() {
+	script=$1
+	shift
+	if [ ! -f "$script" ]; then
+		skipl "$script (not present)"
+		return
+	fi
+	out=$(sh "$script" "$@" 2>&1)
+	rc=$?
+	if [ "$rc" -eq 0 ]; then
+		passl "$script"
+	elif [ "$rc" -eq 77 ]; then
+		skipl "$script ($(echo "$out" | grep -m1 -i skip || echo 'tool unavailable'))"
+	else
+		faill "$script"
+		echo "$out" | sed 's/^/      /'
+	fi
+}
+
+# run_py <test_file.py> — run a python unittest file directly (each has a
+# `unittest.main()` __main__ and resolves its target import relative to its own
+# path, so cwd is irrelevant). Skips are reported by unittest itself (exit 0).
+run_py() {
+	script=$1
+	if [ ! -f "$script" ]; then
+		skipl "$script (not present)"
+		return
+	fi
+	out=$(python3 "$script" 2>&1)
+	rc=$?
+	if [ "$rc" -eq 0 ]; then
+		# Surface any unittest-level skips in the summary line.
+		nskip=$(echo "$out" | grep -c 'skipped=' 2>/dev/null || true)
+		if [ "$nskip" -gt 0 ] 2>/dev/null; then
+			passl "$script ($(echo "$out" | grep -o 'skipped=[0-9]*' | head -1))"
+		else
+			passl "$script"
+		fi
+	else
+		faill "$script"
+		echo "$out" | sed 's/^/      /'
+	fi
+}
+
+# ── 1. shell-syntax lint (<interp> -n) over the image/dist/day-0 scripts ──
+# The interpreter is chosen from each script's shebang: xpf-day0-config is
+# bash (uses arrays), the rest are POSIX sh — linting a bash script with dash
+# would false-fail on array syntax.
+hdr "shell syntax (parse check)"
+SH_SCRIPTS="
+scripts/image/xpf-day0-config
+scripts/image/xpf-grow-root
+scripts/image/xpf-uefi-slots
+scripts/image/incus-agent-setup
+scripts/image/test-grow-root.sh
+scripts/dist/selftest.sh
+scripts/dist/install.sh
+scripts/dist/build-apt-repo.sh
+scripts/run-selftests.sh
+"
+for s in $SH_SCRIPTS; do
+	[ -f "$s" ] || continue
+	case $(head -1 "$s") in
+	*bash*) interp="bash" ;;
+	*) interp="sh" ;;
+	esac
+	if ! command -v "$interp" >/dev/null 2>&1; then
+		skipl "$interp -n $s ($interp not installed)"
+		continue
+	fi
+	if "$interp" -n "$s" 2>/tmp/xpf-selftest-shn.$$; then
+		passl "$interp -n $s"
+	else
+		faill "$interp -n $s"
+		sed 's/^/      /' /tmp/xpf-selftest-shn.$$
+	fi
+done
+rm -f /tmp/xpf-selftest-shn.$$
+
+# ── 2. optional shellcheck lint (SKIP if not installed) ──
+hdr "shellcheck (optional)"
+if command -v shellcheck >/dev/null 2>&1; then
+	for s in $SH_SCRIPTS; do
+		[ -f "$s" ] || continue
+		if out=$(shellcheck -S warning "$s" 2>&1); then
+			passl "shellcheck $s"
+		else
+			faill "shellcheck $s"
+			echo "$out" | sed 's/^/      /'
+		fi
+	done
+else
+	skipl "shellcheck not installed (apt-get install shellcheck)"
+fi
+
+# ── 3. python unittest self-tests (image / deploy / scripts root) ──
+hdr "python self-tests"
+for t in scripts/image/test_*.py scripts/deploy/test_*.py scripts/test_*.py; do
+	[ -f "$t" ] || continue
+	run_py "$t"
+done
+
+# ── 4. shell self-tests ──
+hdr "shell self-tests"
+run_shell scripts/image/test-grow-root.sh
+run_shell scripts/dist/selftest.sh
+
+# ── summary ──
+printf '\n\033[1m== selftest summary ==\033[0m\n'
+echo "  passed=$PASS  skipped=$SKIP  failed=$FAIL"
+if [ "$FAIL" -ne 0 ]; then
+	echo "  FAILED legs:$FAILED_LEGS" >&2
+	exit 1
+fi
+echo "  OK — all self-tests passed (or SKIP-gated on missing tools)"


### PR DESCRIPTION
Closes #4209 Closes #4210 Closes #4211

Fills the three fable-review-165 CI/self-test coverage gaps.

## H-9 (#4209) — `validate.py` first-boot legs
`validate.py` proved first boot only under incus. Added:
- **scenario `q`** — libvirt/plain-QEMU bootability. Always-on config-level
  qcow2 probe (`qemu-img info` format==qcow2 + virtual-size ≥ 8 GiB bake floor
  + `qemu-img check`), then a gated direct-QEMU boot with the day-0 config on a
  **cdrom** (the plain-QEMU + cdrom-day-0 path incus never runs), asserted via
  the serial console. SKIPs (probe stands) without `qemu-system-x86_64` /
  `/dev/kvm` / OVMF.
- **scenario `e`** — cluster node-id drive. A `node-id=1` day-0 drive persists
  `/etc/xpf/node-id=1`, boots into cluster mode, and (with two extra NICs) the
  daemon assigns the node-1 vSRX names `em0` + `ge-7/0/0` (FPC 7).
- **scenario `c` extension** — reject → **fix → reboot → applied** retry
  contract (pairs with the H-1 `active.json` guard).

Scenario map is now a single registry (`SCENARIO_ORDER`/`SCENARIO_METHODS`).
New hermetic `scripts/image/test_validate_scenarios.py` (12 tests) covers the
pure pieces the incus/QEMU scenarios hinge on (the qcow2 verdict, OVMF
discovery order, the registry, the node-id drive round-trip).

## H-19 (#4210) — self-test runner
The day-0/image/dist/deploy self-tests passed but were wired into no target
(no CI; `make test` = Go + Rust only). Added `scripts/run-selftests.sh` +
**`make selftest`**: one command that discovers and runs every hermetic
self-test (shell parse-check + shellcheck, grow-root, bake sign-order, validate
helpers, dist roundtrip, all deploy tests). Tool-gated legs SKIP; **27 legs
green** here. Standalone by design (same posture as audit-check / docs-check /
test-deploy-lib) and the single hook a future CI would call.

## H-24 (#4211) — xpf-deploy mixed-base HA gate tests
`xpf-deploy.py` was imported/executed by nothing. Recent PRs
(#4174/#4181/#4193) covered disks/NIC-order/correctness, but the piece the
review names — `_gate_mixed_base`, the Python mirror of
`upgrade.GateMixedBaseSwap` that decides whether a LANE-2 HA image roll can
preserve sessions — stayed untested. New `scripts/deploy/test_xpf_deploy_gate.py`
(28 tests): gate parity vectors **shared with** `pkg/upgrade/imageversions_test.go`,
`_u16`, the manifest key round-trip, the peer-probe parse, `expected_name`,
`memory_mb`, and the `--nic` parser.

## Verification
- `make selftest` → 27 legs, 0 failed.
- **RED-on-revert** confirmed: dropping the session-sync exact-match in
  `_gate_mixed_base` flips the mismatch test to FAIL; the qcow2 format/size
  verdicts fail a wrong-format/truncated image.
- `py_compile` on all touched Python; `shellcheck -S warning` clean on the
  runner; `validate.py --help` exposes `{a,b,c,d,e,q,all}`.
- Docs: `docs/install-images.md` gains a "Self-tests" section + the expanded
  scenario table; CLAUDE.md Quick Start lists `make selftest`.

No cargo/Go source touched (test/CI/tooling only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi