### PR TITLE
publish: default-deny orphan sweep + gate every channel's latest.json (HB165 H-5, H-13)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ test/xsk-repro/xdp-tools*
 
 # Appliance image bake artifacts (#1879)
 /dist/
+# .deb build-staging dir — a sibling of the publish root dist/ (HB165 H-5)
+/dist-deb/

--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,8 @@ loss-cluster-restart:
 
 # Build the xpf Debian package (#1917 increment A). Produces ../xpf_*.deb
 # and ../xpf-appliance_*.deb relative to the source tree (dpkg's default
-# parent-dir output), then copies them into dist/deb/.
+# parent-dir output), then copies them into dist-deb/ (a staging dir OUTSIDE
+# the image publish root dist/ — see DEB_OUT below).
 #
 # The package build delegates to `make build build-ctl build-userspace-dp`
 # (see debian/rules), so it picks up the embedded #1864 shim and the
@@ -411,7 +412,12 @@ DEB_GIT_COUNT ?= $(shell git rev-list --count HEAD 2>/dev/null || echo 0)
 DEB_GIT_SHA   ?= $(shell git rev-parse --short=12 HEAD 2>/dev/null || echo unknown)
 DEB_GIT_DIRTY ?= $(shell git diff --quiet 2>/dev/null || echo .dirty)
 DEB_VERSION ?= 0.0.$(DEB_GIT_COUNT)+g$(DEB_GIT_SHA)$(DEB_GIT_DIRTY)
-DEB_OUT ?= $(CURDIR)/dist/deb
+# DEB_OUT is a build-STAGING dir and MUST live OUTSIDE the image publish root
+# `dist/` (HB165 H-5): `make image` runs `make deb` and `make dist-publish`
+# uploads the WHOLE `dist/` tree to the image URL, so a deb staged under
+# `dist/` would ship unsigned. publish.py's default-deny sweep now REFUSES any
+# stray file under `dist/`, so debs stage in the `dist-deb/` sibling instead.
+DEB_OUT ?= $(CURDIR)/dist-deb
 
 .PHONY: deb
 deb:
@@ -425,7 +431,7 @@ deb:
 	@# only the top changelog line's version token is rewritten so the rest
 	@# of the entry/trailer stays dpkg-parseable. dpkg-buildpackage writes
 	@# the .deb/.changes/.buildinfo to the PARENT dir (not configurable);
-	@# we keep the canonical copies in dist/deb/ and scrub the parent so it
+	@# we keep the canonical copies in dist-deb/ and scrub the parent so it
 	@# never litters the tree above the source dir (a git worktree parent).
 	@# Signal traps re-raise the caught signal after cleanup (trap - SIG;
 	@# kill -SIG $$) so an interrupted build returns the SIGNAL exit status,

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Install xpf onto an existing Debian/Ubuntu host. **Requires kernel ≥
 ```bash
 # On the build host (Go + cargo toolchain):
 make deb                       # builds xpfd + xpf-userspace-dp + cli,
-                               # packages them into dist/deb/xpf_<ver>_amd64.deb
+                               # packages them into dist-deb/xpf_<ver>_amd64.deb
                                # (+ the xpf-appliance metapackage)
 
-# Copy dist/deb/xpf_<ver>_amd64.deb to the target host, then there:
+# Copy dist-deb/xpf_<ver>_amd64.deb to the target host, then there:
 sudo apt install ./xpf_<ver>_amd64.deb     # ${shlibs:Depends} pulled in by apt
 ```
 

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-07-04 — #4214 / #4215 (fable-review-165 H-5 / H-13): publish default-deny sweep + per-channel latest.json gate
+
+- **Timestamp**: 2026-07-04
+  - **Action**: Closed two publish-gate escapes in `scripts/dist/publish.py`.
+    H-5 (#4214): the image orphan sweep was suffix-shaped — it only inspected
+    `.qcow2` / `.incus-metadata.tar.gz` and skipped every other file, so an
+    unsigned `dist/deb/*.deb` (staged there by `make deb`, which `make image`
+    invokes) rode the whole-tree upload to `XPF_IMAGE_BASE_URL` unsigned.
+    Rewrote the sweep as DEFAULT-DENY via `_is_allowed_publish_file`: every
+    file under the publish root (outside `apt/`) must be a manifest-covered
+    image artifact OR an expected sidecar (`*.SHA256SUMS`, `*.minisig`,
+    top-level `install.sh` / `xpf-image.pub` / `xpf-<ver>.manifest`, per-channel
+    `latest.json`); anything else blocks the publish. Also moved `DEB_OUT` out
+    of the publish root to a `dist-deb/` sibling so the mainline
+    `make image && make dist-publish` does not trip the stricter gate
+    (Makefile, bake.py, build-apt-repo.sh, cluster-setup.sh, README,
+    .gitignore).
+    H-13 (#4215): `gate_latest` verified only `--channel`'s `latest.json`;
+    other channels' pointers rode the tree unverified. Split out
+    `_gate_one_latest` and made `gate_latest` enumerate every
+    `dist/*/latest.json` — target channel keeps the version-present contract,
+    every other channel's pointer must carry a verifying signature (mirrors
+    `gate_apt`'s per-suite InRelease posture).
+  - selftest.sh: new §8g (default-deny sweep — clean set passes, stray `.deb`
+    refused) and §8h (every channel's latest.json signature-gated — unsigned
+    edge refused, signed edge passes); test debs stage in `dist-deb/`. All 39
+    checks pass. RED-on-revert confirmed independently: reverting the sweep
+    fails §8g H-5 only; reverting the loop fails §8h H-13 only. py_compile
+    publish.py + bake.py OK; shellcheck touched shell files rc=0.
+- **File(s)**: scripts/dist/publish.py, scripts/dist/selftest.sh,
+  scripts/image/bake.py, scripts/dist/build-apt-repo.sh, Makefile,
+  test/incus/cluster-setup.sh, README.md, .gitignore, _Log.md
+
 ## 2026-07-04 — #4197 / #4198 / #4199 (fable-review-165 H-2 / H-14 / H-16): install.sh + publish tooling
 
 - **Timestamp**: 2026-07-04

--- a/scripts/dist/build-apt-repo.sh
+++ b/scripts/dist/build-apt-repo.sh
@@ -55,8 +55,8 @@ case "$SUITE" in stable|edge) ;; *) die "suite must be stable|edge (got $SUITE)"
 
 # Default deb set: the freshly built binary + appliance packages.
 if [ -z "$DEBS" ]; then
-    DEBS=$(ls "$ROOT"/dist/deb/xpf_*.deb "$ROOT"/dist/deb/xpf-appliance_*.deb 2>/dev/null || true)
-    [ -n "$DEBS" ] || die "no debs in dist/deb (run 'make deb' first, or pass --debs)"
+    DEBS=$(ls "$ROOT"/dist-deb/xpf_*.deb "$ROOT"/dist-deb/xpf-appliance_*.deb 2>/dev/null || true)
+    [ -n "$DEBS" ] || die "no debs in dist-deb (run 'make deb' first, or pass --debs)"
 fi
 
 APT="$OUT/apt"

--- a/scripts/dist/publish.py
+++ b/scripts/dist/publish.py
@@ -13,8 +13,11 @@ artifact in the publish set is properly signed:
       404s without it; opt out with --no-installer), carries NO placeholder
       key and NO unsubstituted %%…%% marker (it must be stamped first), and
       has a verifying install.sh.minisig;
-  (d) the per-channel latest.json verifies against the image pubkey AND names
-      a version present in the image set.
+  (d) the TARGET channel's latest.json verifies against the image pubkey AND
+      names a version present in the image set, AND every OTHER channel's
+      latest.json present in the tree also carries a verifying signature — the
+      whole dist tree is uploaded, so a stale/unsigned pointer for a non-target
+      channel must not ship unverified (HB165 H-13).
 
 The bake may be fail-OPEN (a dev bake without a key still produces artifacts),
 but PUBLISH is fail-CLOSED — an unsigned dev bake can never reach the channel.
@@ -81,6 +84,31 @@ def image_pubkey():
 # `dist` that is NOT covered by a verified manifest blocks the publish, because
 # the whole dist tree is uploaded.
 IMAGE_ARTIFACT_SUFFIXES = (".qcow2", ".incus-metadata.tar.gz")
+
+
+def _is_allowed_publish_file(name, at_top):
+    """Default-deny allowlist for NON-image files in the image publish tree
+    (HB165 H-5). The whole dist tree is uploaded RECURSIVELY, so a file that is
+    neither a verified image artifact nor an expected sidecar must NOT ride
+    along — an unsigned `dist/deb/*.deb` (or any stray file) is the motivating
+    case: `make image` stages debs under the publish root and the suffix-shaped
+    orphan sweep skipped every non-`.qcow2`/`.incus-metadata.tar.gz` file.
+
+    Allowed (everything else is refused):
+      - `*.minisig` / `*.SHA256SUMS` — inert signature + checksum material,
+        anywhere in the tree;
+      - top-level bake outputs: `install.sh` (its minisign signature is
+        verified in gate_images), `xpf-image.pub` (the pinned pubkey convenience
+        copy), and `xpf-<ver>.manifest` (build metadata read by
+        `xpf-deploy image-roll`);
+      - a per-channel `latest.json` in a channel subdir — gate_latest verifies
+        its signature.
+    """
+    if name.endswith((".minisig", ".SHA256SUMS")):
+        return True
+    if at_top:
+        return name in ("install.sh", "xpf-image.pub") or name.endswith(".manifest")
+    return name == "latest.json"
 
 
 def archive_pubkey():
@@ -387,11 +415,13 @@ def gate_images(dist, require_installer=True):
                 die(f"image artifact {base} failed verify: {e}")
             covered.add(base)
         info(f"image set {ver}: signature + {len(checks)} file hashes OK")
-    # Orphan sweep (Codex-r2-1 / r3): the WHOLE dist tree is uploaded
-    # RECURSIVELY (rsync -a / aws s3 sync), so walk the tree — not just the top
-    # level — and refuse any image artifact NOT covered by a verified manifest,
-    # wherever it sits (e.g. a nested dist/stable/xpf-evil.qcow2). The apt pool
-    # is gated separately (gate_apt) so skip apt/.
+    # Default-deny sweep (Codex-r2-1 / r3 + HB165 H-5): the WHOLE dist tree is
+    # uploaded RECURSIVELY (rsync -a / aws s3 sync), so walk the tree — not just
+    # the top level — and refuse EVERY file that is neither a verified image
+    # artifact nor an expected sidecar (see _is_allowed_publish_file). A
+    # suffix-shaped allowlist let unsigned non-image files (a dist/deb/*.deb)
+    # ride to the image URL; default-deny closes that. The apt pool is gated
+    # separately (gate_apt) so skip apt/.
     apt_dir = os.path.join(dist, "apt")
     for root, dirs, files in os.walk(dist):
         if root == apt_dir or root.startswith(apt_dir + os.sep):
@@ -407,28 +437,45 @@ def gate_images(dist, require_installer=True):
                 die(f"symlinked directory in the image publish set: {rel} — "
                     "refusing (a dereferencing backend could upload "
                     "unverified bytes).")
+        at_top = os.path.abspath(root) == os.path.abspath(dist)
         for name in sorted(files):
             full = os.path.join(root, name)
             if os.path.islink(full):
                 rel = os.path.relpath(full, dist)
                 die(f"symlink in the image publish set: {rel} — refusing "
                     "(a dereferencing backend could upload unverified bytes).")
-            if not name.endswith(IMAGE_ARTIFACT_SUFFIXES):
+            rel = os.path.relpath(full, dist)
+            if name.endswith(IMAGE_ARTIFACT_SUFFIXES):
+                # Image artifacts live ONLY at the top level (the bake writes
+                # dist/xpf-<ver>.*). A nested one (e.g. dist/stable/xpf-evil.qcow2)
+                # can never be a verified artifact — a manifest binds BASENAMES,
+                # so a nested duplicate basename would also escape a basename-only
+                # `covered` check. Refuse any image artifact below the top level.
+                if not at_top:
+                    die(f"image artifact outside the top-level dist dir: {rel} — "
+                        "images belong at dist/xpf-<ver>.*; refusing to publish "
+                        "unverified nested bytes.")
+                if name not in covered:
+                    die(f"orphan image artifact in the publish set: {rel} is not "
+                        "listed in any verified manifest — refusing to publish "
+                        "unverified bytes. Remove it or sign a manifest covering "
+                        "it.")
                 continue
-            rel = os.path.relpath(os.path.join(root, name), dist)
-            # Image artifacts live ONLY at the top level (the bake writes
-            # dist/xpf-<ver>.*). A nested one (e.g. dist/stable/xpf-evil.qcow2)
-            # can never be a verified artifact — a manifest binds BASENAMES, so
-            # a nested duplicate basename would also escape a basename-only
-            # `covered` check. Refuse any image artifact below the top level.
-            if os.path.abspath(root) != os.path.abspath(dist):
-                die(f"image artifact outside the top-level dist dir: {rel} — "
-                    "images belong at dist/xpf-<ver>.*; refusing to publish "
-                    "unverified nested bytes.")
-            if name not in covered:
-                die(f"orphan image artifact in the publish set: {rel} is not "
-                    "listed in any verified manifest — refusing to publish "
-                    "unverified bytes. Remove it or sign a manifest covering it.")
+            # Default-deny (HB165 H-5): the whole dist tree is uploaded, so a
+            # file that is neither a verified image artifact nor an expected
+            # signed/metadata sidecar must NOT ride along. The motivating case
+            # is an unsigned dist/deb/*.deb — the suffix-shaped sweep skipped
+            # every non-image file, so a deb staged under the publish root
+            # shipped to the image URL with no signature. Refuse anything
+            # unrecognised.
+            if not _is_allowed_publish_file(name, at_top):
+                die(f"unexpected file in the image publish set: {rel} — the "
+                    "whole dist tree is uploaded, so every file must be a "
+                    "verified image artifact or an expected sidecar "
+                    "(*.SHA256SUMS, *.minisig, install.sh, latest.json, "
+                    "xpf-image.pub, xpf-<ver>.manifest). Refusing to publish "
+                    "unverified bytes — build .deb packages OUTSIDE dist/ (see "
+                    "DEB_OUT) and remove any stray file.")
     # (c) install.sh — PRESENT (mandatory unless --no-installer), stamped
     # (no placeholder key, no unsubstituted marker), AND signed. Presence is
     # mandatory by default because a missing installer makes the Tier-A
@@ -479,8 +526,12 @@ def gate_images(dist, require_installer=True):
     return versions, pub
 
 
-def gate_latest(dist, channel, versions, pub):
-    """(d): latest.json verifies and names a present version."""
+def _gate_one_latest(dist, channel, pub, require_present):
+    """Verify one channel's signed latest.json. `require_present`, when not
+    None, is the set of versions the pointer's `version` MUST name (the target
+    channel's freshness contract); pass None to enforce only the signature (a
+    non-target channel may legitimately point at a version outside THIS
+    publish's dist set)."""
     latest = os.path.join(dist, channel, "latest.json")
     if not os.path.isfile(latest):
         die(f"{channel}/latest.json missing — run "
@@ -494,14 +545,33 @@ def gate_latest(dist, channel, versions, pub):
     try:
         data = json.loads(sign.verify_and_read(latest, sig, pub).decode())
     except sign.SignError as e:
-        die(f"latest.json signature failed verify: {e}")
+        die(f"{channel}/latest.json signature failed verify: {e}")
     except (ValueError, UnicodeDecodeError) as e:
-        die(f"latest.json is not valid JSON after verify: {e}")
+        die(f"{channel}/latest.json is not valid JSON after verify: {e}")
     ver = data.get("version")
-    if ver not in versions:
-        die(f"latest.json names version {ver!r} which is NOT in the publish set "
-            f"{sorted(versions)} — refusing to advertise a missing version.")
+    if require_present is not None and ver not in require_present:
+        die(f"{channel}/latest.json names version {ver!r} which is NOT in the "
+            f"publish set {sorted(require_present)} — refusing to advertise a "
+            "missing version.")
     info(f"latest.json OK (channel {channel} -> {ver})")
+
+
+def gate_latest(dist, channel, versions, pub):
+    """(d): the TARGET channel's latest.json verifies and names a present
+    version, AND every OTHER dist/<chan>/latest.json in the tree also carries a
+    verifying signature (HB165 H-13). The whole dist tree is uploaded, so a
+    stale/tampered/unsigned pointer for a non-target channel would otherwise
+    ship unverified — mirror gate_apt's per-suite InRelease posture and gate
+    EVERY channel's freshness pointer, not just `--channel`'s."""
+    # Target channel: mandatory + must name a version present in this publish.
+    _gate_one_latest(dist, channel, pub, require_present=versions)
+    # Every other channel pointer present in the tree: signature only.
+    for entry in sorted(os.listdir(dist)):
+        cdir = os.path.join(dist, entry)
+        if entry == channel or not os.path.isdir(cdir):
+            continue
+        if os.path.isfile(os.path.join(cdir, "latest.json")):
+            _gate_one_latest(dist, entry, pub, require_present=None)
 
 
 def gate_apt(dist, channel):

--- a/scripts/dist/selftest.sh
+++ b/scripts/dist/selftest.sh
@@ -151,8 +151,8 @@ Architecture: amd64
 Maintainer: selftest <selftest@xpf.invalid>
 Description: xpf selftest fake package
 EOF
-mkdir -p "$ROOT/dist/deb"
-FAKEDEB="$ROOT/dist/deb/xpf-appliance_${VER}_amd64.selftest.deb"
+mkdir -p "$ROOT/dist-deb"
+FAKEDEB="$ROOT/dist-deb/xpf-appliance_${VER}_amd64.selftest.deb"
 dpkg-deb --build "$DEBDIR" "$FAKEDEB" >/dev/null 2>&1
 cleanup_deb() { rm -f "$FAKEDEB"; }
 trap 'cleanup; cleanup_deb' EXIT INT TERM
@@ -222,7 +222,7 @@ fi
 
 # ── 5c. apt channel isolation (#4201, HB165 H-4) ──────────────────────────
 info "5c. apt channel isolation: a stable rebuild after edge must not list edge"
-EDGEDEB="$ROOT/dist/deb/xpf-appliance_0.0.0-edge.selftest.deb"
+EDGEDEB="$ROOT/dist-deb/xpf-appliance_0.0.0-edge.selftest.deb"
 EDGEDIR="$WORK/pkg-edge"; mkdir -p "$EDGEDIR/DEBIAN"
 cat > "$EDGEDIR/DEBIAN/control" <<EOF
 Package: xpf-appliance
@@ -446,6 +446,60 @@ if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/publish.py" \
     ok "publish --no-installer opts out of the install.sh requirement"
 else
     bad "publish --no-installer MUST pass without install.sh but FAILED"
+fi
+
+# ── 8g. HB165 H-5: default-deny sweep refuses a stray non-image file ────────
+info "8g. publish default-deny sweep refuses a stray file under dist/ (HB165 H-5)"
+GOOD="$WORK/hb165"; mkdir -p "$GOOD"
+cp "$QCOW" "$META" "$MANIFEST" "$MANIFEST.minisig" "$GOOD/"
+XPF_SIGN_SECKEY="$WORK/img.sec" $PY "$DIST/publish.py" make-latest \
+    --channel stable --version "$VER" --dist "$GOOD" >/dev/null 2>&1
+$PY "$DIST/publish.py" stamp-installer --out "$GOOD/install.sh" \
+    --archive-key "$AKEY" --apt-base-url "https://dl.selftest.invalid/apt" \
+    --channel stable >/dev/null 2>&1
+minisign -S -W -s "$WORK/img.sec" -m "$GOOD/install.sh" \
+    -x "$GOOD/install.sh.minisig" >/dev/null 2>&1
+# Baseline: the clean signed set (image + manifest + install.sh + latest.json)
+# passes the default-deny sweep.
+if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/publish.py" \
+     --dist "$GOOD" --channel stable --no-apt >/dev/null 2>&1; then
+    ok "clean signed image set passes the default-deny sweep"
+else
+    bad "clean signed image set MUST pass the default-deny sweep but FAILED"
+fi
+# H-5: an unsigned .deb staged under the publish root must be REFUSED — the
+# whole dist/ tree is uploaded to the image URL, and the old suffix-shaped
+# sweep skipped every non-image file.
+mkdir -p "$GOOD/deb"
+printf 'not-a-real-signed-package\n' > "$GOOD/deb/xpf_0.0.0_amd64.deb"
+if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/publish.py" \
+     --dist "$GOOD" --channel stable --no-apt >/dev/null 2>&1; then
+    bad "publish MUST refuse an unsigned .deb under dist/ but PASSED (H-5)"
+else
+    ok "publish refuses an unsigned .deb under the image publish root (H-5)"
+fi
+rm -rf "$GOOD/deb"
+
+# ── 8h. HB165 H-13: every channel's latest.json is signature-gated ──────────
+info "8h. publish signature-gates every channel's latest.json (HB165 H-13)"
+# An UNSIGNED edge pointer beside the signed stable pointer must be refused,
+# even when publishing --channel stable (the whole tree is uploaded).
+mkdir -p "$GOOD/edge"
+printf '{"channel":"edge","version":"%s"}\n' "$VER" > "$GOOD/edge/latest.json"
+if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/publish.py" \
+     --dist "$GOOD" --channel stable --no-apt >/dev/null 2>&1; then
+    bad "publish MUST refuse an unsigned edge latest.json but PASSED (H-13)"
+else
+    ok "publish refuses an unsigned non-target channel latest.json (H-13)"
+fi
+# A properly SIGNED edge pointer passes the whole gate.
+XPF_SIGN_SECKEY="$WORK/img.sec" $PY "$DIST/publish.py" make-latest \
+    --channel edge --version "$VER" --dist "$GOOD" >/dev/null 2>&1
+if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/publish.py" \
+     --dist "$GOOD" --channel stable --no-apt >/dev/null 2>&1; then
+    ok "publish passes when the edge latest.json is properly signed (H-13)"
+else
+    bad "publish MUST pass a signed edge latest.json but FAILED (H-13)"
 fi
 
 # ── 9. install.sh H-16: validate-before-mutate + cleanup-on-failure ─────────

--- a/scripts/image/bake.py
+++ b/scripts/image/bake.py
@@ -569,14 +569,18 @@ def main():
         #    it picks up the embedded #1864 shim and the pinned cargo helper,
         #    then packages the freshly-built binaries. The image consumes the
         #    .deb instead of raw --copy-in binaries.
-        deb_dir = os.path.join(ROOT, "dist", "deb")
+        # Staging dir for the built .deb — a `dist-deb/` SIBLING of the image
+        # publish root `dist/`, NOT under it (HB165 H-5): `make dist-publish`
+        # uploads the whole `dist/` tree and publish.py's default-deny sweep
+        # refuses any stray file there, so the deb must stage outside `dist/`.
+        deb_dir = os.path.join(ROOT, "dist-deb")
         if not a.skip_build:
             info("building xpf .deb (xpfd, cli, xpf-userspace-dp -> staged)...")
             run(["make", "-C", ROOT, "deb"])
         # The git-derived version is computed by the Makefile; glob for the
         # binary package (NOT the xpf-appliance metapackage) and pick the
         # NEWEST by mtime so a stale deb from an earlier (e.g. dirty-tree)
-        # build in dist/deb/ is never selected over the one just built.
+        # build in dist-deb/ is never selected over the one just built.
         debs = sorted((g for g in glob.glob(os.path.join(deb_dir, "xpf_*.deb"))
                        if "xpf-appliance" not in os.path.basename(g)),
                       key=os.path.getmtime)

--- a/test/incus/cluster-setup.sh
+++ b/test/incus/cluster-setup.sh
@@ -679,9 +679,9 @@ deploy_vm_deb() {
 		die "Instance $vm does not exist. Run '$0 create' first."
 	fi
 	# Locate the freshly-built .deb (Makefile deb: target output dir is
-	# dist/deb/; install the runtime xpf_*.deb, NOT the xpf-appliance meta).
-	deb=$(ls -t "$PROJECT_ROOT"/dist/deb/xpf_*.deb 2>/dev/null | head -1 || true)
-	[[ -n "$deb" ]] || die "no xpf_*.deb found in dist/deb/ — run 'make deb' first (XPF_DEPLOY_DEB build)"
+	# dist-deb/; install the runtime xpf_*.deb, NOT the xpf-appliance meta).
+	deb=$(ls -t "$PROJECT_ROOT"/dist-deb/xpf_*.deb 2>/dev/null | head -1 || true)
+	[[ -n "$deb" ]] || die "no xpf_*.deb found in dist-deb/ — run 'make deb' first (XPF_DEPLOY_DEB build)"
 
 	info "Pushing $(basename "$deb") to $vm..."
 	incus file push "$deb" "${rinst}/tmp/$(basename "$deb")"


### PR DESCRIPTION
Closes #4214
Closes #4215

Two fable-review-165 escapes in the signed-distribution publish gate
(`scripts/dist/publish.py`), where unverified bytes rode the whole-tree image
upload to `XPF_IMAGE_BASE_URL`. Both reproduced at HEAD (`70b3c88c5`).

## H-5 (#4214) — suffix-shaped orphan sweep let unsigned files ride

`gate_images`' orphan sweep only inspected files ending in `.qcow2` /
`.incus-metadata.tar.gz`; every other file was skipped. `make image` runs
`make deb`, which staged an unsigned `dist/deb/*.deb` under the publish root, so
it (and any stray file) shipped to the image URL with no signature — defeating
the module's fail-closed contract. This is the *normal* release workflow, not a
corner case.

- Rewrote the sweep as **default-deny** (`_is_allowed_publish_file`): every file
  under the publish root (outside `apt/`, handled by `gate_apt`) must be a
  manifest-covered image artifact OR an expected sidecar — `*.SHA256SUMS` /
  `*.minisig` anywhere, top-level `install.sh` / `xpf-image.pub` /
  `xpf-<ver>.manifest`, or a per-channel `latest.json`. Anything else blocks the
  publish.
- Moved `DEB_OUT` out of the publish root to a `dist-deb/` sibling so the
  mainline `make image && make dist-publish` does not trip the stricter gate
  (Makefile, `bake.py`, `build-apt-repo.sh`, `cluster-setup.sh`, README,
  `.gitignore`). The apt repo build still copies these debs into
  `dist/apt/pool` (gated by `gate_apt`), so the signed apt channel is
  unaffected — only the raw staging location moves.

## H-13 (#4215) — only the target channel's latest.json was gated

`gate_latest` verified only `--channel`'s `latest.json`; other channels'
freshness pointers rode the tree unverified (`latest.json` is not an image
suffix, so the sweep skipped it too). Split out `_gate_one_latest` and made
`gate_latest` enumerate **every** `dist/*/latest.json` — the target channel
keeps the version-present contract, and every other channel's pointer must carry
a verifying signature, mirroring `gate_apt`'s per-suite InRelease posture.

## Validation

- `scripts/dist/selftest.sh` gains §8g (clean signed set passes; a stray
  `dist/deb/*.deb` is refused) and §8h (unsigned non-target-channel
  `latest.json` refused; signed one passes). **39/0**, deterministic across 3
  runs.
- **RED-on-revert confirmed independently**: reverting the sweep fails only §8g
  (H-5); reverting the per-channel loop fails only §8h (H-13).
- `py_compile` publish.py + bake.py OK; `shellcheck` touched shell files rc=0
  (only pre-existing info notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi