### PR TITLE
cos: type shaping-rate/burst-size/codel-target/oversubscription schema leaves (fable-review-166 G-3/G-4/G-5/G-1)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,43 @@
+## 2026-07-04 — #4217 / #4218 / #4219 / #4220 (fable-review-166 G-4 / G-3 / G-5 / G-1): CoS config-schema typing
+
+- **Timestamp**: 2026-07-04
+  - **Action**: Typed four class-of-service config-schema leaves that
+    were untyped/missing/inert so garbage HARD-REJECTS at commit instead
+    of compiling to a silent 0, and added accepted-but-inert commit
+    warnings for the two knobs the dataplane does not enforce. G-4
+    (#4217): `shaping-rate` typed via the container `keyValidator`
+    (ValueRate — it carries the burst-size child, so `valueType` would
+    mis-treat burst-size as a modifier) + `burst-size` ValueByteSize, at
+    both unit and #4021 interface level; before this `shaping-rate 10gg`
+    committed as 0 and the root shaper vanished (unshaped ~25G). G-3
+    (#4218): typed `codel-target` (ValueInteger/ValidateIntegerMin(0)) +
+    a commit warning when CodelTargetNS>0 (CoDel AQM never shipped,
+    #1829 Phase 2 PLAN-KILLED). G-5 (#4219): added
+    `oversubscription-policy` (container `{ guarantee-rate <frac 0..1> |
+    proportional }`, fraction validated ValidatePercent(0,1) so 1.7 is
+    rejected not clamped) + `priority-low-min-share` (ValueRate) at unit
+    + interface level. G-1 (#4220): priority-low-min-share is INERT
+    (wire-surface only; no cap_eff reservation) — added a commit
+    warning, corrected the misleading `queue_service/mod.rs` comment
+    that cited a nonexistent cap_eff subtraction, and marked
+    fairness-regimes.md gate 2 DEFERRED/NOT-IMPLEMENTED. Enforcement
+    (cap_eff) is separate deferred research, out of scope.
+  - **File(s)**: pkg/config/schema_cos.go (typed leaves + 3 shared
+    constructors), pkg/config/compiler_validate_warn.go (codel-target +
+    priority-low-min-share inert warnings),
+    pkg/config/schema_cos_hb166_test.go (new RED-on-revert tests),
+    pkg/config/schema_validate_test.go (repointed the "untyped leaf
+    ignored" test off now-typed shaping-rate/burst-size onto the
+    still-untyped classifiers dscp reference),
+    userspace-dp/src/afxdp/cos/queue_service/mod.rs (comment fix),
+    docs/config-schema.md, docs/cos-traffic-shaping.md (+ fixed a buggy
+    two-line shaping-rate/burst-size example), docs/cos-wan-sqm.md,
+    docs/fairness-regimes.md.
+  - **Validation**: `go test ./pkg/config/...` green; `go build ./...`;
+    gofmt + `go vet ./pkg/config/...` clean. RED-on-revert proven: with
+    the validators removed the shaping-rate/burst-size/codel-target
+    garbage values commit clean again.
+
 ## 2026-07-04 — #4197 / #4198 / #4199 (fable-review-165 H-2 / H-14 / H-16): install.sh + publish tooling
 
 - **Timestamp**: 2026-07-04

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2302,6 +2302,58 @@ reserved for whole-dataplane selection where a rewrite shim
   `reservations` render, **dotted/uppercase MAC canonicalization**,
   no-binding omits the key).
 
+### #4217/#4218/#4219/#4220 — CoS interface-binding + scheduler typed leaves (fable-review-166 G-3/G-4/G-5/G-1)
+
+Four class-of-service config-schema gaps where a leaf was untyped,
+missing, or inert. All four are typed in `schema_cos.go` (shared
+constructors `cosShapingRateSchema` / `cosOversubscriptionPolicySchema` /
+`cosPriorityLowMinShareSchema` keep the unit level and the #4021
+interface level identical), so garbage HARD-REJECTS at commit instead of
+compiling to a silent 0.
+
+- **#4217 (G-4) `shaping-rate` / `burst-size`.** Both untyped, so `set
+  class-of-service interfaces reth0 unit 80 shaping-rate 10gg` committed:
+  `parseBandwidthLimit("10gg")` returns 0, the compiler reads 0 as
+  "unset", and the root shaper silently disappeared (unshaped ~25G
+  egress). `shaping-rate` is a CONTAINER (it carries the `burst-size`
+  child), so it uses the typed-KEY-slot feature (`keyValueType:
+  ValueRate`, `keyValidator: ValidateRate`) — NOT `valueType`, which
+  would flip the walker into the typed-LEAF branch and mis-treat
+  `burst-size` as a presence-only modifier. `burst-size` is a plain typed
+  value leaf (`ValueByteSize` / `ValidateByteSize`); bare-integer
+  burst-size is now rejected as ambiguous (same tightening `buffer-size`
+  got in #1319).
+- **#4218 (G-3) `codel-target`.** Absent from `setSchema`, so no
+  completion and `codel-target banana` was silently dropped by the
+  compiler's `err == nil` parse guard. Now a typed `ValueInteger` /
+  `ValidateIntegerMin(0)` leaf under `schedulers`. The CoDel AQM is still
+  NOT enforced (#1829 Phase 2 PLAN-KILLED), so a commit warning fires
+  when `CodelTargetNS > 0` (`compiler_validate_warn.go` scheduler loop).
+- **#4219 (G-5) `oversubscription-policy` / `priority-low-min-share`.**
+  Both absent from `setSchema` — no completion, no validation, unknown
+  policy strings committing. `oversubscription-policy` is now a container
+  `{ guarantee-rate <fraction 0..1> | proportional }` (adding it to the
+  schema changes SetPath grouping flat→hierarchical; the compiler already
+  handled both shapes). The guarantee-rate fraction is validated
+  `ValidatePercent(0,1)`, so `1.7` is rejected at commit instead of
+  silently clamping to 1.0. `priority-low-min-share` is `ValueRate` /
+  `ValidateRate`.
+- **#4220 (G-1) `priority-low-min-share` truth-in-labeling.** The knob is
+  INERT — it is wire-surface-only and no scheduler code consults it (the
+  `cap_eff` per-pass reservation does not exist). The typed leaf + commit
+  warning (`compiler_validate_warn.go` interface loop) surface the
+  inertness; a misleading `queue_service/mod.rs` comment that cited a
+  nonexistent `cap_eff` subtraction is corrected, and
+  `docs/fairness-regimes.md` gate 2 is marked DEFERRED/NOT-IMPLEMENTED.
+  The ENFORCEMENT (cap_eff reservation) is a separate deferred-research
+  item, out of scope here.
+
+Regression coverage: `pkg/config/schema_cos_hb166_test.go` (flat-set
+schema reject-on-garbage for all four, valid-value accept, the two inert
+warnings, and completion presence of the new leaves at unit + interface
+level). FAIL-ON-REVERT: dropping the validators / warnings makes the
+garbage values commit clean again and the inert knobs go silent.
+
 ### #3043 — Security-policy missing/conflicting terminal action (commit fail-closed)
 
 `PolicyAction`'s zero value is `PolicyPermit` (`types_security.go`:

--- a/docs/cos-traffic-shaping.md
+++ b/docs/cos-traffic-shaping.md
@@ -792,8 +792,7 @@ set class-of-service schedulers be-sched buffer-size 16m
 set class-of-service scheduler-maps my-map forwarding-class best-effort scheduler be-sched
 set class-of-service scheduler-maps my-map forwarding-class expedited-forwarding scheduler ef-sched
 
-set class-of-service interfaces ge-0-0-1 unit 0 shaping-rate 10g
-set class-of-service interfaces ge-0-0-1 unit 0 shaping-rate burst-size 125m
+set class-of-service interfaces ge-0-0-1 unit 0 shaping-rate 10g burst-size 125m
 set class-of-service interfaces ge-0-0-1 unit 0 scheduler-map my-map
 ```
 
@@ -821,6 +820,25 @@ keeps that map while still inheriting the interface-level `shaping-rate`.
 Before #4021 an interface-level binding compiled and committed cleanly but
 was silently dropped (only `unit N` children were read), so the shaping /
 classification / marking never applied.
+
+**Commit-time validation of the interface-binding leaves (fable-review-166).**
+The `shaping-rate`, `burst-size`, `oversubscription-policy` (its
+`guarantee-rate` fraction), and `priority-low-min-share` leaves are typed
+in `setSchema`, at BOTH the unit level and the interface level. A garbage
+value now HARD-REJECTS at `commit` / `commit check` instead of silently
+compiling to 0 and removing the shaper: before this, `shaping-rate 10gg`
+parsed to 0 (`parseBandwidthLimit` silent-zero), the compiler read 0 as
+"unset", and egress ran **unshaped** (#4217). `oversubscription-policy
+guarantee-rate 1.7` is rejected rather than silently clamped to 1.0
+(#4219). `priority-low-min-share` is typed + validated and completes, but
+the dataplane does not yet enforce it (wire-surface only; a commit warning
+surfaces the inertness — #4220). `bare-integer` burst-size is now rejected
+as ambiguous — use an explicit `k`/`m`/`g` suffix (e.g. `125m`). Put the
+rate and its `burst-size` on the SAME `set` line (`shaping-rate 10g
+burst-size 125m`): a separate `set ... shaping-rate burst-size 125m`
+line creates a second sibling `shaping-rate` node whose value is the
+literal `burst-size` — which the commit gate now rejects (before this it
+silently dropped the burst-size).
 
 Scheduler `buffer-size` may be configured as an explicit byte size
 (`4m`, `256k`, `1g`) or as a Junos percent value (`10%`). Percent values

--- a/docs/cos-wan-sqm.md
+++ b/docs/cos-wan-sqm.md
@@ -218,10 +218,20 @@ in one line, keep the rates versioned in one place.
   Phase 1 sojourn telemetry. A per-scheduler `codel-target` knob exists
   in the compiler today but is **inert** (write-only in the engine),
   and the bare-shaping synthetic queue hardcodes `codel_target_ns: 0`
-  (`forwarding_build/cos.rs`). When/if Phase 2 ships, the planned
-  `smart-queueing` unit leaf (#1828 Option B, gated rider) becomes the
-  way to arm CoDel on a bare-shaped unit without rewriting into
-  scheduler-maps. Do not set `codel-target` expecting AQM today.
+  (`forwarding_build/cos.rs`). As of #4218 the leaf is typed (so
+  `codel-target banana` is rejected at commit and `set ... codel-target
+  ?` completes) and a **commit warning** fires when it is set, stating
+  the value is accepted but has no runtime effect. When/if Phase 2
+  ships, the planned `smart-queueing` unit leaf (#1828 Option B, gated
+  rider) becomes the way to arm CoDel on a bare-shaped unit without
+  rewriting into scheduler-maps. Do not set `codel-target` expecting AQM
+  today.
+- **`priority-low-min-share` (#1614 A2)** — typed + validated at commit
+  (#4219) and completes, but the dataplane does **not** enforce it: it
+  is wire-surface only (no `cap_eff` reservation exists — #4220). A
+  commit warning surfaces the inertness; enforcement is deferred
+  research. `docs/fairness-regimes.md` acceptance gate 2 is marked
+  DEFERRED/NOT-IMPLEMENTED accordingly.
 - **Per-packet overhead compensation** (CAKE `overhead`/`atm`) —
   [#1849](https://github.com/psaab/xpf/issues/1849); until then use
   the 85-95% headroom guidance above.

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -1308,9 +1308,17 @@ guarantee-rate runs assert:
    The ≥95% guarantee for 3g/6g under multi-class contention is a
    CONFIRMED-but-mechanism-UNRESOLVED defect tracked in **#1692**; it
    is not asserted here until that issue resolves.
-2. **Priority-low minimum share**: when configured, the
-   priority-low queue receives ≥ 95% of its configured
-   `priority-low-min-share`.
+2. **Priority-low minimum share**: **DEFERRED / NOT IMPLEMENTED.**
+   The intended gate — when configured, the priority-low queue
+   receives ≥ 95% of its configured `priority-low-min-share` — is
+   NOT satisfied by any engine path. `priority-low-min-share`
+   (#1614 A2) is wire-surface only: it is typed, validated at
+   commit, and stored, but no scheduler code consults it (the
+   `cap_eff` per-pass reservation that would enforce it does not
+   exist; see `afxdp/types/cos.rs` "Currently UNUSED" and the note
+   in `afxdp/cos/queue_service/mod.rs`). A commit warning surfaces
+   the inertness. Enforcement is deferred research (#4220); until it
+   ships this gate must not be asserted.
 3. **Retransmit floor**: per class ≤ 100 retransmits per 30 s
    under all-class simul load (gate 3 of plan.md §7). Achieved by
    the A3 CoDel-style sojourn-time AQM (default disabled; opt-in

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -646,6 +646,7 @@ func ValidateConfig(cfg *Config) []string {
 	if cos := cfg.ClassOfService; cos != nil {
 		warnedClassifierLossPriority := false
 		warnedRewriteLossPriority := false
+		warnedPriorityLowMinShare := false
 		for _, class := range cos.ForwardingClasses {
 			if class == nil {
 				continue
@@ -690,6 +691,17 @@ func ValidateConfig(cfg *Config) []string {
 						"class-of-service scheduler %q equal-flow-target-policy %s is non-work-conserving: it clips fast flows and reduces aggregate class throughput; it cannot lift slow flows",
 						sched.Name, sched.EqualFlowTargetPolicy))
 				}
+			}
+			// #4218: codel-target (#1614 A3 CoDel AQM) is typed and stored
+			// (CodelTargetNS) so a garbage value is rejected at commit, but
+			// the AQM itself is NOT enforced — #1829 Phase 2 was PLAN-KILLED.
+			// Warn so an operator who sets it is not misled into believing it
+			// bounds queue latency. Mirrors the accepted-but-inert doctrine
+			// used for loss-priority and the #2078/#3440 knobs.
+			if sched.CodelTargetNS > 0 {
+				warnings = append(warnings, fmt.Sprintf(
+					"class-of-service scheduler %q codel-target is accepted for compatibility but inert: the userspace dataplane has no CoDel AQM (#1829 Phase 2 not shipped), so the configured target has no runtime effect",
+					sched.Name))
 			}
 		}
 		for _, schedMap := range cos.SchedulerMaps {
@@ -769,14 +781,34 @@ func ValidateConfig(cfg *Config) []string {
 				}
 			}
 		}
+		// #4220 / #4219: priority-low-min-share (#1614 A2) is typed and
+		// stored (PriorityLowMinShareBytes) so garbage is rejected at
+		// commit, but the knob is INERT — it is wire-surface-only and no
+		// scheduler code consults it (the cap_eff per-pass reservation that
+		// would enforce it is deferred research). Warn ONCE (map iteration
+		// is randomized; a generic message stays deterministic) so an
+		// operator is not misled into believing the priority-low queue has
+		// a protected minimum. The enforcement itself is a separate
+		// deferred item.
+		warnPriorityLowMinShareInert := func(bytes uint64) {
+			if bytes > 0 && !warnedPriorityLowMinShare {
+				warnings = append(warnings,
+					"class-of-service priority-low-min-share is accepted for compatibility but inert: the userspace dataplane does not yet enforce a priority-low minimum share (#1614 A2; the cap_eff reservation is deferred), so the configured value has no runtime effect")
+				warnedPriorityLowMinShare = true
+			}
+		}
 		for _, iface := range cos.Interfaces {
 			if iface == nil {
 				continue
+			}
+			if iface.Level != nil {
+				warnPriorityLowMinShareInert(iface.Level.PriorityLowMinShareBytes)
 			}
 			for _, unit := range iface.Units {
 				if unit == nil {
 					continue
 				}
+				warnPriorityLowMinShareInert(unit.PriorityLowMinShareBytes)
 				if unit.SchedulerMap != "" {
 					if _, ok := cos.SchedulerMaps[unit.SchedulerMap]; !ok {
 						warnings = append(warnings, fmt.Sprintf(

--- a/pkg/config/schema_cos.go
+++ b/pkg/config/schema_cos.go
@@ -93,6 +93,22 @@ var schemaClassOfService = &schemaNode{desc: "Class of service configuration", c
 			}),
 			children: nil,
 		},
+		// #1614 A3 CoDel AQM target queue delay in milliseconds. The
+		// value is typed so `codel-target banana` is REJECTED at commit
+		// (the compiler otherwise swallows the parse error and drops the
+		// value silently), but the AQM itself is NOT enforced — #1829
+		// Phase 2 was PLAN-KILLED. A commit warning
+		// (compiler_validate_warn.go CoS scheduler loop) surfaces the
+		// inertness when CodelTargetNS>0 (#4218).
+		"codel-target": {
+			desc:          "CoDel AQM target queue delay in milliseconds (accepted for Junos compatibility; AQM not yet enforced by the userspace dataplane)",
+			args:          1,
+			valueType:     ValueInteger,
+			valueDesc:     "CoDel target queue delay in milliseconds (non-negative integer; AQM not yet enforced)",
+			valueExamples: []string{"5", "10"},
+			validator:     ValidateIntegerMin(0),
+			children:      nil,
+		},
 	}},
 	"scheduler-maps": {desc: "Scheduler map assigning schedulers to forwarding classes", args: 1, multi: true, placeholder: "<map-name>", children: map[string]*schemaNode{
 		"forwarding-class": {desc: "Forwarding class entry in this map", args: 1, multi: true, placeholder: "<class-name>", children: map[string]*schemaNode{
@@ -108,10 +124,10 @@ var schemaClassOfService = &schemaNode{desc: "Class of service configuration", c
 			"rewrite-rules": {desc: "Rewrite rules applied to traffic leaving this unit", children: map[string]*schemaNode{
 				"dscp": {desc: "DSCP rewrite rule to apply", args: 1, placeholder: "<rewrite-rule-name>", children: nil},
 			}},
-			"shaping-rate": {desc: "Shaping rate for this unit in bits per second (k/m/g suffixes)", args: 1, placeholder: "<rate>", children: map[string]*schemaNode{
-				"burst-size": {desc: "Shaping burst size in bytes (k/m/g suffixes)", args: 1, placeholder: "<bytes>", children: nil},
-			}},
-			"scheduler-map": {desc: "Scheduler map to apply to this unit", args: 1, placeholder: "<map-name>", children: nil},
+			"shaping-rate":            cosShapingRateSchema("Shaping rate for this unit in bits per second (k/m/g suffixes)"),
+			"scheduler-map":           {desc: "Scheduler map to apply to this unit", args: 1, placeholder: "<map-name>", children: nil},
+			"oversubscription-policy": cosOversubscriptionPolicySchema(),
+			"priority-low-min-share":  cosPriorityLowMinShareSchema(),
 		}},
 		// #4021: interface-level (physical, no unit) bindings. In Junos these
 		// apply to every logical unit on the port; a unit-level binding
@@ -125,10 +141,10 @@ var schemaClassOfService = &schemaNode{desc: "Class of service configuration", c
 		"rewrite-rules": {desc: "Rewrite rules applied at the interface level (all units)", children: map[string]*schemaNode{
 			"dscp": {desc: "DSCP rewrite rule to apply", args: 1, placeholder: "<rewrite-rule-name>", children: nil},
 		}},
-		"shaping-rate": {desc: "Shaping rate applied at the interface level in bits per second (k/m/g suffixes)", args: 1, placeholder: "<rate>", children: map[string]*schemaNode{
-			"burst-size": {desc: "Shaping burst size in bytes (k/m/g suffixes)", args: 1, placeholder: "<bytes>", children: nil},
-		}},
-		"scheduler-map": {desc: "Scheduler map to apply at the interface level (all units)", args: 1, placeholder: "<map-name>", children: nil},
+		"shaping-rate":            cosShapingRateSchema("Shaping rate applied at the interface level in bits per second (k/m/g suffixes)"),
+		"scheduler-map":           {desc: "Scheduler map to apply at the interface level (all units)", args: 1, placeholder: "<map-name>", children: nil},
+		"oversubscription-policy": cosOversubscriptionPolicySchema(),
+		"priority-low-min-share":  cosPriorityLowMinShareSchema(),
 	}},
 	"fairness": {desc: "Dataplane fairness observability configuration", children: map[string]*schemaNode{
 		"rss-expectation": {desc: "Declarative RSS flow-distribution expectations evaluated against live dataplane status (shown in fairness output and exported as Prometheus gauges)", children: map[string]*schemaNode{
@@ -146,6 +162,83 @@ var schemaClassOfService = &schemaNode{desc: "Class of service configuration", c
 		}},
 	}},
 }}
+
+// cosShapingRateSchema builds the `shaping-rate` CoS binding leaf shared by
+// the unit level and the #4021 interface level. shaping-rate is a CONTAINER
+// (it carries the burst-size child), so its rate value is typed via the
+// container `keyValidator` (ValidateRate) — NOT `valueType`, which would flip
+// the walker into the typed-LEAF branch and mis-treat burst-size as a
+// presence-only modifier. Before #4217 both leaves were untyped, so
+// `shaping-rate 10gg` committed as 0 (parseBandwidthLimit's silent
+// zero-on-garbage), which the compiler reads as "unset" — the root shaper
+// silently disappeared and egress ran unshaped.
+func cosShapingRateSchema(desc string) *schemaNode {
+	return &schemaNode{
+		desc:             desc,
+		args:             1,
+		placeholder:      "<rate>",
+		keyValueType:     ValueRate,
+		keyValueDesc:     "Shaping rate (e.g. 100k, 10m, 1g) or bps integer; >= 8 bps",
+		keyValueExamples: []string{"10m", "1g", "10g"},
+		keyValidator:     ValidateRate,
+		children: map[string]*schemaNode{
+			"burst-size": {
+				desc:          "Shaping burst size in bytes (explicit k/m/g suffix)",
+				args:          1,
+				placeholder:   "<bytes>",
+				valueType:     ValueByteSize,
+				valueDesc:     "Byte-size with an explicit k/m/g suffix (e.g. 15k, 1m)",
+				valueExamples: []string{"15k", "1m"},
+				validator:     ValidateByteSize,
+			},
+		},
+	}
+}
+
+// cosOversubscriptionPolicySchema builds the #1614 A1 `oversubscription-policy`
+// binding leaf shared by the unit level and the interface level. It is a
+// container `{ guarantee-rate <fraction 0..1> | proportional }`; the compiler
+// (parseCoSInterfaceUnitBody) reads guarantee-rate's fraction and clamps to
+// [0,1], so the schema rejects an out-of-range fraction at commit rather than
+// silently clamping (#4219). Before #4219 the whole leaf was absent from the
+// schema — no completion, no validation, unknown policy strings committing.
+func cosOversubscriptionPolicySchema() *schemaNode {
+	return &schemaNode{
+		desc: "Oversubscription allocation policy when exact-class transmit-rates exceed the shaping-rate (#1614)",
+		children: map[string]*schemaNode{
+			"guarantee-rate": {
+				desc:          "Fraction of the shaping-rate guaranteed to each exact class before proportional sharing (0..1)",
+				args:          1,
+				placeholder:   "<fraction>",
+				valueType:     ValuePercent,
+				valueDesc:     "Guaranteed fraction of the shaping-rate in the range 0..1 (e.g. 0.7)",
+				valueExamples: []string{"0.5", "0.7", "1"},
+				validator:     ValidatePercent(0, 1),
+			},
+			"proportional": {desc: "Share the shaping-rate proportionally to configured rates (default)", children: nil},
+		},
+	}
+}
+
+// cosPriorityLowMinShareSchema builds the #1614 A2 `priority-low-min-share`
+// binding leaf shared by the unit level and the interface level. The value is
+// typed + validated at commit (so garbage is rejected, not silently zeroed by
+// parseBandwidthLimit) and offers `?` completion, but the knob is currently
+// INERT in the dataplane: it is WIRE-SURFACE-ONLY (the cap_eff reservation
+// that would enforce it is deferred research). A commit warning
+// (compiler_validate_warn.go CoS interface loop) surfaces the inertness
+// (#4220 / #4219).
+func cosPriorityLowMinShareSchema() *schemaNode {
+	return &schemaNode{
+		desc:          "Minimum guaranteed share for the priority-low queue in bits/sec (#1614 A2; accepted but NOT yet enforced by the dataplane)",
+		args:          1,
+		placeholder:   "<rate>",
+		valueType:     ValueRate,
+		valueDesc:     "Bandwidth (e.g. 100k, 10m, 1g) or bps integer; >= 8 bps (accepted but currently inert)",
+		valueExamples: []string{"100m", "1g"},
+		validator:     ValidateRate,
+	}
+}
 
 var schemaFirewall = &schemaNode{desc: "Firewall filters and policers", children: map[string]*schemaNode{
 	"policer": {desc: "Traffic policer", args: 1, multi: true, placeholder: "<name>", children: map[string]*schemaNode{

--- a/pkg/config/schema_cos_hb166_test.go
+++ b/pkg/config/schema_cos_hb166_test.go
@@ -1,0 +1,234 @@
+package config
+
+// Regression tests for the fable-review-166 CoS config-schema gaps
+// (#4217 G-4, #4218 G-3, #4219 G-5, #4220 G-1). Each of the four
+// scheduler/interface leaves below was untyped, missing, or inert; the
+// fix types them so garbage HARD-REJECTS at commit and adds
+// accepted-but-inert commit warnings for the two knobs the dataplane
+// does not enforce (codel-target AQM, priority-low-min-share).
+//
+// FAIL-ON-REVERT: dropping the typed-leaf metadata from schema_cos.go
+// (or the warnings from compiler_validate_warn.go) makes the "rejects"
+// / "warns" assertions go RED — the garbage values commit clean again
+// and the inert knobs go silent, exactly the pre-fix behavior.
+
+import (
+	"strings"
+	"testing"
+)
+
+func hb166SchemaCheck(t *testing.T, cmds ...string) error {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return SchemaValidate(tree, nil)
+}
+
+func hb166Compile(t *testing.T, cmds ...string) *Config {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return cfg
+}
+
+func hb166HasWarning(cfg *Config, substr string) bool {
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- G-4: shaping-rate / burst-size typed (unit level + interface level) ---
+
+func TestHB166_G4_ShapingRate_RejectsGarbage(t *testing.T) {
+	// Unit level and #4021 interface level. Before #4217 both committed
+	// as 0 (parseBandwidthLimit silent-zero) and the shaper vanished.
+	bad := []string{
+		"set class-of-service interfaces reth0 unit 80 shaping-rate 10gg",
+		"set class-of-service interfaces reth0 shaping-rate 10gg",
+	}
+	for _, cmd := range bad {
+		err := hb166SchemaCheck(t, cmd)
+		if err == nil {
+			t.Fatalf("%q: expected rejection, got nil", cmd)
+		}
+		if !strings.Contains(err.Error(), "shaping-rate") {
+			t.Fatalf("%q: error should reference shaping-rate: %v", cmd, err)
+		}
+	}
+}
+
+func TestHB166_G4_ShapingRate_AcceptsValid(t *testing.T) {
+	good := []string{
+		"set class-of-service interfaces reth0 unit 80 shaping-rate 25g",
+		"set class-of-service interfaces reth0 shaping-rate 1g",
+	}
+	for _, cmd := range good {
+		if err := hb166SchemaCheck(t, cmd); err != nil {
+			t.Fatalf("%q: expected accept, got %v", cmd, err)
+		}
+	}
+}
+
+func TestHB166_G4_BurstSize_RejectsGarbage(t *testing.T) {
+	bad := []string{
+		"set class-of-service interfaces reth0 unit 80 shaping-rate 10m burst-size garbage",
+		"set class-of-service interfaces reth0 shaping-rate 10m burst-size garbage",
+	}
+	for _, cmd := range bad {
+		err := hb166SchemaCheck(t, cmd)
+		if err == nil {
+			t.Fatalf("%q: expected rejection, got nil", cmd)
+		}
+		if !strings.Contains(err.Error(), "burst-size") {
+			t.Fatalf("%q: error should reference burst-size: %v", cmd, err)
+		}
+	}
+}
+
+func TestHB166_G4_BurstSize_AcceptsValid(t *testing.T) {
+	if err := hb166SchemaCheck(t,
+		"set class-of-service interfaces reth0 unit 80 shaping-rate 10m burst-size 15k"); err != nil {
+		t.Fatalf("expected accept, got %v", err)
+	}
+}
+
+// --- G-3: codel-target typed + inert warning ---
+
+func TestHB166_G3_CodelTarget_RejectsGarbage(t *testing.T) {
+	err := hb166SchemaCheck(t,
+		"set class-of-service schedulers be codel-target banana")
+	if err == nil {
+		t.Fatal("expected rejection for codel-target banana, got nil")
+	}
+	if !strings.Contains(err.Error(), "codel-target") {
+		t.Fatalf("error should reference codel-target: %v", err)
+	}
+}
+
+func TestHB166_G3_CodelTarget_AcceptsValidAndWarnsInert(t *testing.T) {
+	if err := hb166SchemaCheck(t,
+		"set class-of-service schedulers be codel-target 5"); err != nil {
+		t.Fatalf("expected codel-target 5 to pass schema, got %v", err)
+	}
+	cfg := hb166Compile(t,
+		"set class-of-service schedulers be codel-target 5")
+	if !hb166HasWarning(cfg, "codel-target is accepted for compatibility but inert") {
+		t.Fatalf("expected inert codel-target warning; got: %v", cfg.Warnings)
+	}
+}
+
+// --- G-5: oversubscription-policy + priority-low-min-share typed ---
+
+func TestHB166_G5_GuaranteeRateFraction_RejectsOutOfRange(t *testing.T) {
+	// The compiler silently clamps 1.7 -> 1.0 today; the schema now
+	// rejects the out-of-range fraction at commit.
+	err := hb166SchemaCheck(t,
+		"set class-of-service interfaces reth0 unit 80 oversubscription-policy guarantee-rate 1.7")
+	if err == nil {
+		t.Fatal("expected rejection for guarantee-rate 1.7, got nil")
+	}
+	if !strings.Contains(err.Error(), "guarantee-rate") {
+		t.Fatalf("error should reference guarantee-rate: %v", err)
+	}
+}
+
+func TestHB166_G5_GuaranteeRateFraction_AcceptsValid(t *testing.T) {
+	good := []string{
+		"set class-of-service interfaces reth0 unit 80 oversubscription-policy guarantee-rate 0.7",
+		"set class-of-service interfaces reth0 unit 80 oversubscription-policy proportional",
+		"set class-of-service interfaces reth0 oversubscription-policy guarantee-rate 0.5",
+	}
+	for _, cmd := range good {
+		if err := hb166SchemaCheck(t, cmd); err != nil {
+			t.Fatalf("%q: expected accept, got %v", cmd, err)
+		}
+	}
+}
+
+func TestHB166_G5_PriorityLowMinShare_RejectsGarbage(t *testing.T) {
+	bad := []string{
+		"set class-of-service interfaces reth0 unit 80 priority-low-min-share 10gg",
+		"set class-of-service interfaces reth0 priority-low-min-share 10gg",
+	}
+	for _, cmd := range bad {
+		err := hb166SchemaCheck(t, cmd)
+		if err == nil {
+			t.Fatalf("%q: expected rejection, got nil", cmd)
+		}
+		if !strings.Contains(err.Error(), "priority-low-min-share") {
+			t.Fatalf("%q: error should reference priority-low-min-share: %v", cmd, err)
+		}
+	}
+}
+
+// --- G-1: priority-low-min-share accepted but inert warning ---
+
+func TestHB166_G1_PriorityLowMinShare_AcceptsValidAndWarnsInert(t *testing.T) {
+	if err := hb166SchemaCheck(t,
+		"set class-of-service interfaces reth0 unit 80 priority-low-min-share 100m"); err != nil {
+		t.Fatalf("expected priority-low-min-share 100m to pass schema, got %v", err)
+	}
+	cfg := hb166Compile(t,
+		"set class-of-service interfaces reth0 unit 80 priority-low-min-share 100m")
+	if !hb166HasWarning(cfg, "priority-low-min-share is accepted for compatibility but inert") {
+		t.Fatalf("expected inert priority-low-min-share warning; got: %v", cfg.Warnings)
+	}
+}
+
+// --- completion: the new leaves are reachable via `set ... ?` ---
+
+func TestHB166_Completion_NewLeavesPresent(t *testing.T) {
+	// codel-target under schedulers.
+	sched := CompleteSetPathWithValues(
+		[]string{"class-of-service", "schedulers", "be"}, nil)
+	if !containsCompletionName(sched, "codel-target") {
+		t.Fatalf("expected codel-target in schedulers completions; got %v", completionNames(sched))
+	}
+	// oversubscription-policy + priority-low-min-share under interfaces>unit.
+	unit := CompleteSetPathWithValues(
+		[]string{"class-of-service", "interfaces", "reth0", "unit", "80"}, nil)
+	for _, want := range []string{"oversubscription-policy", "priority-low-min-share", "shaping-rate"} {
+		if !containsCompletionName(unit, want) {
+			t.Fatalf("expected %q in unit completions; got %v", want, completionNames(unit))
+		}
+	}
+	// oversubscription-policy children.
+	oversub := CompleteSetPathWithValues(
+		[]string{"class-of-service", "interfaces", "reth0", "unit", "80", "oversubscription-policy"}, nil)
+	for _, want := range []string{"guarantee-rate", "proportional"} {
+		if !containsCompletionName(oversub, want) {
+			t.Fatalf("expected %q in oversubscription-policy completions; got %v", want, completionNames(oversub))
+		}
+	}
+	// Interface-level (#4021) leaves too.
+	iface := CompleteSetPathWithValues(
+		[]string{"class-of-service", "interfaces", "reth0"}, nil)
+	for _, want := range []string{"oversubscription-policy", "priority-low-min-share", "shaping-rate"} {
+		if !containsCompletionName(iface, want) {
+			t.Fatalf("expected %q in interface-level completions; got %v", want, completionNames(iface))
+		}
+	}
+}

--- a/pkg/config/schema_validate_test.go
+++ b/pkg/config/schema_validate_test.go
@@ -423,14 +423,17 @@ func TestSchemaValidate_AcceptsLegacyDPDKSubStanza(t *testing.T) {
 // validated even though the walker now descends all subtrees. This guards
 // the "opt-in per leaf" scope contract.
 func TestSchemaValidate_OutsideSchedulersIgnored(t *testing.T) {
-	// `buffer-size purple` under a different parent should not error
-	// at SchemaValidate (no typed-leaf metadata for it elsewhere).
+	// A still-untyped CoS reference leaf (the dscp classifier NAME bound
+	// to an interface unit is resolved at compile-warn, not schema-typed)
+	// should not error at SchemaValidate. shaping-rate/burst-size — the
+	// prior example here — are now typed by #4217, so they no longer
+	// illustrate an untyped leaf.
 	if err := schemaCheck(t, `class-of-service {
     interfaces {
         ge-0/0/1 {
             unit 0 {
-                shaping-rate 10g {
-                    burst-size purple-not-validated;
+                classifiers {
+                    dscp purple-not-validated;
                 }
                 scheduler-map edge-map;
             }

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -604,11 +604,17 @@ fn select_exact_cos_guarantee_queue_with_lease_telemetry(
 ) -> Option<ExactCoSQueueSelection> {
     // #1614 A1: in GuaranteeRate mode (operator opt-in), dispatch to
     // the small-first waterfill selector. The default Proportional
-    // mode falls through to the legacy round-robin selector below,
-    // bit-for-bit unchanged when priority_low_min_share_bytes == 0
-    // (see service_exact_guarantee_queue_direct_with_info for the
-    // cap_eff subtraction that handles priority-low orthogonality
-    // per AGY r3 finding B).
+    // mode falls through to the legacy round-robin selector below.
+    //
+    // NOTE (#4220): priority_low_min_share_bytes is WIRE-SURFACE ONLY
+    // and is NOT enforced by this or any other selector — no cap_eff
+    // subtraction exists anywhere in the tree (matching the honest
+    // field note at afxdp/types/cos.rs, "Currently UNUSED"). The
+    // intended per-pass reservation of the priority-low min-share
+    // before the A1 selector is deferred research. Because no code
+    // consults the field, the Proportional fall-through is bit-for-bit
+    // unchanged for ANY value of priority_low_min_share_bytes, not just
+    // 0.
     if matches!(
         root.oversubscription_policy,
         CoSOversubscriptionPolicy::GuaranteeRate


### PR DESCRIPTION
Closes #4218 Closes #4217 Closes #4219 Closes #4220

## Summary

Four class-of-service config-schema gaps from fable-review-166 where a
leaf was untyped, missing from `setSchema`, or inert — garbage committed
silently and inert knobs gave no operator signal. All four leaves are now
typed (garbage HARD-REJECTS at commit) and the two dataplane-unenforced
knobs get accepted-but-inert commit warnings.

Shared constructors in `schema_cos.go` (`cosShapingRateSchema`,
`cosOversubscriptionPolicySchema`, `cosPriorityLowMinShareSchema`) keep
the unit level and the #4021 interface level bit-identical.

### G-4 (#4217) — shaping-rate / burst-size untyped
`set class-of-service interfaces reth0 unit 80 shaping-rate 10gg`
committed: `parseBandwidthLimit("10gg")` returns 0, the compiler reads 0
as "unset", and the root shaper silently disappeared (unshaped ~25G).
`shaping-rate` is a CONTAINER (it carries `burst-size`), so its rate is
typed via the container `keyValidator` (ValidateRate) — NOT `valueType`,
which would flip the walker into the typed-LEAF branch and mis-treat
`burst-size` as a presence-only modifier. `burst-size` is a plain typed
value leaf (ValueByteSize/ValidateByteSize).

### G-3 (#4218) — codel-target no schema leaf / no warning / silent garbage
Absent from `setSchema`, so no completion and `codel-target banana` was
silently dropped by the compiler's `err==nil` guard. Now typed
(ValueInteger/ValidateIntegerMin(0)) with a commit warning when set
(CoDel AQM never shipped — #1829 Phase 2 PLAN-KILLED).

### G-5 (#4219) — oversubscription-policy / priority-low-min-share missing
Both absent from `setSchema`. Added `oversubscription-policy` as a
container `{ guarantee-rate <fraction 0..1> | proportional }` (the
fraction validated `ValidatePercent(0,1)`, so `1.7` is rejected at commit
instead of silently clamping to 1.0) and `priority-low-min-share` as
ValueRate/ValidateRate, at both the unit and interface level.

### G-1 (#4220, driveable part) — priority-low-min-share inert truth-in-labeling
The knob is INERT — wire-surface only; no `cap_eff` reservation exists.
Corrected the misleading `queue_service/mod.rs` comment that cited a
nonexistent cap_eff subtraction, marked `docs/fairness-regimes.md` gate 2
DEFERRED/NOT-IMPLEMENTED, and added the typed leaf + commit warning.
**The ENFORCEMENT (cap_eff per-pass reservation) is a separate
DEFERRED-research item and is NOT implemented here.**

## Doc fix
`docs/cos-traffic-shaping.md` had a buggy two-line example
(`shaping-rate 10g` then a separate `shaping-rate burst-size 125m`) that
created a second sibling `shaping-rate` node and silently dropped the
burst-size; the commit gate now rejects it. Corrected to the single-line
form `shaping-rate 10g burst-size 125m`.

## Tests
`pkg/config/schema_cos_hb166_test.go`: reject-on-garbage for all four
leaves, valid-value accept, the two inert warnings, completion presence
(unit + interface level). **RED-on-revert proven**: removing the
validators makes the garbage values commit clean again (the exact pre-fix
bug). `go test ./pkg/config/...` green; `go build ./...`; gofmt + vet
clean. The Rust change is comment-only.