### PR TITLE
cos: three hb166 CoS correctness fixes (inert-binding warn, name-keyed rss-expectation, unit burst inheritance)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -34291,3 +34291,25 @@ top.
   scripts/image/test_validate_scenarios.py,
   scripts/deploy/test_xpf_deploy_gate.py, scripts/run-selftests.sh, Makefile,
   docs/install-images.md, CLAUDE.md, _Log.md
+
+- **Timestamp**: 2026-07-04
+- **Action**: hb166 CoS correctness — G-6 (warn on inert CoS binding to
+  unconfigured interface/unit), G-9 (name-key `fairness rss-expectation`,
+  resolve name->ifindex at evaluate time from the live snapshot so it
+  survives NIC re-enumeration; Prometheus label stays ifindex-keyed with
+  the resolved id), G-10 (a unit `shaping-rate` override no longer
+  inherits the interface-level `burst-size` — burst inheritance moved
+  inside the rate-inheritance block; override units fall back to the
+  dataplane `COS_MIN_BURST_BYTES` floor). Issues #4221/#4222/#4223.
+  Go-only, no Rust/cargo, no wire change. RED-on-revert proven for all
+  three (G-6 no warning; G-9 stale-ifindex judges wrong interface; G-10
+  inherits mismatched 200000 burst).
+- **File(s)**: pkg/config/compiler_validate_warn.go,
+  pkg/config/compiler_class_of_service.go, pkg/config/types_cos.go,
+  pkg/config/schema_cos.go, pkg/config/parser_class_of_service_test.go,
+  pkg/dataplane/userspace/fairness.go,
+  pkg/dataplane/userspace/fairness_test.go,
+  pkg/dataplane/userspace/format/status.go,
+  pkg/dataplane/userspace/format/status_test.go,
+  pkg/api/metrics_test.go, test/incus/sqm-cookbook-config.set,
+  docs/per-5-tuple/state.md, docs/cos-traffic-shaping.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -34385,3 +34385,23 @@ top.
   pkg/dataplane/userspace/format/status_test.go,
   pkg/api/metrics_test.go, test/incus/sqm-cookbook-config.set,
   docs/per-5-tuple/state.md, docs/cos-traffic-shaping.md, _Log.md
+
+- **Timestamp**: 2026-07-04
+- **Action**: hb166 F2 fold — the G-9 ifindex->name re-key introduced a
+  duplicate-Prometheus-label regression: an UNRESOLVED rss-expectation
+  emitted its gauge with ifindex=0, so two distinct unresolved interface
+  names on the same queue+kind (both valid config under the new
+  interface/queue dedup key) collapsed to identical (ifindex=0,queue,kind)
+  labels -> Gather() duplicate error -> HTTP 500 across the WHOLE /metrics
+  endpoint. Fix: add `Resolved bool` to FairnessRSSExpectationResult (true
+  only when the name mapped to a live ifindex) and skip unresolved rows in
+  emitFairnessRSSExpectationGauges. The `show ... fairness` text path keeps
+  reporting the unresolved reason (no uniqueness constraint). New api test
+  Gathers a real registry with two distinct unresolved names on the same
+  queue+kind and asserts no duplicate/500 (RED on revert). Also rebased on
+  origin/master (#4224 CoS schema typing): reconciled schema_cos.go (rss
+  interface node + #4224 shaping-rate typing both kept) and
+  compiler_validate_warn.go (G-6 warns + #4224 priority-low-min-share warns
+  both kept), unioned _Log.md + cos-traffic-shaping.md.
+- **File(s)**: pkg/dataplane/userspace/fairness.go,
+  pkg/api/metrics_userspace.go, pkg/api/metrics_test.go, _Log.md

--- a/docs/cos-traffic-shaping.md
+++ b/docs/cos-traffic-shaping.md
@@ -822,6 +822,28 @@ Before #4021 an interface-level binding compiled and committed cleanly but
 was silently dropped (only `unit N` children were read), so the shaping /
 classification / marking never applied.
 
+`shaping-rate` and its `burst-size` are a coupled pair (`burst-size` is
+grammatically a child of `shaping-rate`). A unit that **overrides**
+`shaping-rate` therefore defines its own shaper and does **not** inherit
+the interface-level `burst-size` (#hb166 G-10): pairing a level burst
+sized for the level rate with a different unit rate would mismatch them
+(e.g. a level `shaping-rate 100m burst-size 200000` with a unit override
+`shaping-rate 1g` would otherwise carry a 200000-byte burst computed for
+100m — 10x of intent). When such an override leaves `burst-size` unset it
+stays 0 and the dataplane applies its rate-independent
+`COS_MIN_BURST_BYTES` floor, exactly as for a fresh unit that sets
+`shaping-rate` alone. A unit that inherits the rate (sets no
+`shaping-rate`) still inherits both the level rate and the level burst as
+a pair.
+
+A `class-of-service interfaces <name>` binding whose interface — or a
+bound `unit N` — is **not configured under `[interfaces]`** is a silent
+no-op: the dataplane applier only visits CoS bindings that resolve
+against `cfg.Interfaces`, so a typo'd interface name or an unconfigured
+unit shapes nothing. The commit now emits a WARNING (not a reject — the
+interface may be added later) so the operator knows the binding is
+currently inert (#hb166 G-6).
+
 Scheduler `buffer-size` may be configured as an explicit byte size
 (`4m`, `256k`, `1g`) or as a Junos percent value (`10%`). Percent values
 are carried over the userspace protocol as `buffer_size_percent`, not as

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -389,14 +389,22 @@ the full helper-reported snapshot, or
 cap.
 
 The runtime expectation slice adds opt-in production evaluation via
-`class-of-service fairness rss-expectation ifindex <n> queue <q>
+`class-of-service fairness rss-expectation interface <name> queue <q>
 <expectation>`, where `<expectation>` uses the same vocabulary as
 `fairness-eval` in Junos-style set syntax (`balanced`,
 `at-least-active-workers <N>`, `max-worker-flow-share <X>`, or
 `cstruct-max <X>`; threshold values use fractions such as `0.5` in
-set syntax). The key is intentionally ifindex-only: the userspace
-status snapshot and Prometheus labels are keyed by kernel ifindex, and
-interface names can be renamed or absent during dataplane restarts.
+set syntax). The key is the STABLE xpf interface name (e.g. `ge-0-0-2`),
+not the kernel ifindex (#hb166 G-9): xpf renames every interface to a
+fixed vSRX name, while the kernel ifindex is transient across
+reboot/hotplug/re-enumeration. The name is resolved to the current
+kernel ifindex at evaluate time from the live status snapshot (which
+re-reports the ifindex<->name mapping every poll), so an expectation
+always tracks the named interface even after re-enumeration; a name that
+is absent from the current snapshot is reported as
+"interface … not present in dataplane status" rather than silently
+judging ifindex 0. The Prometheus labels remain ifindex-keyed, now
+populated with the freshly-resolved ifindex.
 Configured expectations are rendered under
 `show chassis cluster data-plane fairness` and exported as:
 

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -2017,6 +2017,9 @@ func TestEmitFairnessRSSExpectationGauges(t *testing.T) {
 	}
 	status := dpuserspace.ProcessStatus{
 		Workers: 4,
+		Bindings: []dpuserspace.BindingStatus{
+			{Interface: "reth0", Ifindex: 80},
+		},
 		CoSActiveFlowCounts: []dpuserspace.CoSActiveFlowCountStatus{
 			{Ifindex: 80, QueueID: 4, WorkerID: 0, ActiveFlowCount: 3},
 			{Ifindex: 80, QueueID: 4, WorkerID: 1, ActiveFlowCount: 1},
@@ -2032,9 +2035,9 @@ func TestEmitFairnessRSSExpectationGauges(t *testing.T) {
 	ch := make(chan prometheus.Metric)
 	go func() {
 		c.emitFairnessRSSExpectationGauges(ch, status, []dpuserspace.FairnessRSSExpectation{
-			{Ifindex: 80, QueueID: 4, RSSExpectation: "balanced"},
-			{Ifindex: 80, QueueID: 5, RSSExpectation: "balanced"},
-			{Ifindex: 80, QueueID: 6, RSSExpectation: "cstruct-max:0.25"},
+			{Interface: "reth0", QueueID: 4, RSSExpectation: "balanced"},
+			{Interface: "reth0", QueueID: 5, RSSExpectation: "balanced"},
+			{Interface: "reth0", QueueID: 6, RSSExpectation: "cstruct-max:0.25"},
 		})
 		close(ch)
 	}()

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -2062,6 +2062,74 @@ func TestEmitFairnessRSSExpectationGauges(t *testing.T) {
 	assertGaugeClose(t, got, c.fairnessRSSSkewViolation, labelsQ6, 1)
 }
 
+// fairnessExpectationCollector adapts emitFairnessRSSExpectationGauges to
+// the prometheus.Collector interface so a real registry Gather() runs the
+// same duplicate-label detection the live /metrics scrape does.
+type fairnessExpectationCollector struct {
+	c            *xpfCollector
+	status       dpuserspace.ProcessStatus
+	expectations []dpuserspace.FairnessRSSExpectation
+}
+
+func (fc fairnessExpectationCollector) Describe(chan<- *prometheus.Desc) {}
+
+func (fc fairnessExpectationCollector) Collect(ch chan<- prometheus.Metric) {
+	fc.c.emitFairnessRSSExpectationGauges(ch, fc.status, fc.expectations)
+}
+
+// #hb166 F2: two rss-expectations for two DISTINCT interface names on the
+// same queue+kind are both valid config (the dedup key is
+// interface/queue). When BOTH are unresolved (their names are absent from
+// the dataplane status snapshot) they resolve to ifindex 0, so emitting
+// the Prometheus gauge for both would produce two identical
+// (ifindex="0", queue_id, kind) label sets — a duplicate-metric error
+// that Gather() turns into an HTTP 500 for the ENTIRE /metrics endpoint.
+// The fix skips unresolved rows. RED on revert: without the skip both
+// rows emit ifindex=0 and Gather() fails.
+func TestEmitFairnessRSSExpectationGaugesUnresolvedNoDuplicateLabels(t *testing.T) {
+	c := &xpfCollector{
+		fairnessRSSExpectation: prometheus.NewDesc(
+			"xpf_fairness_rss_expectation_configured",
+			"test desc",
+			[]string{"ifindex", "queue_id", "kind"},
+			nil,
+		),
+		fairnessRSSExpectationValue: prometheus.NewDesc(
+			"xpf_fairness_rss_expectation_value",
+			"test desc",
+			[]string{"ifindex", "queue_id", "kind"},
+			nil,
+		),
+		fairnessRSSSkewViolation: prometheus.NewDesc(
+			"xpf_fairness_rss_skew_violation",
+			"test desc",
+			[]string{"ifindex", "queue_id", "kind"},
+			nil,
+		),
+	}
+	// No Bindings / CoSInterfaces: both interface names are unresolved.
+	status := dpuserspace.ProcessStatus{Workers: 4}
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(fairnessExpectationCollector{
+		c:      c,
+		status: status,
+		expectations: []dpuserspace.FairnessRSSExpectation{
+			{Interface: "ge-0-0-2", QueueID: 4, RSSExpectation: "balanced"},
+			{Interface: "ge-0-0-9", QueueID: 4, RSSExpectation: "balanced"},
+		},
+	})
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather failed — unresolved rss-expectations collide on ifindex=0 and 500 the whole /metrics scrape: %v", err)
+	}
+	for _, fam := range families {
+		if len(fam.GetMetric()) != 0 {
+			t.Fatalf("unresolved rss-expectations must emit no Prometheus gauge, got %d metric(s) for %s",
+				len(fam.GetMetric()), fam.GetName())
+		}
+	}
+}
+
 func TestEmitFairnessEqualFlowEstimateGauges(t *testing.T) {
 	c := newCollector(nil)
 	row := dpuserspace.FairnessThroughputSummary{

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -868,6 +868,17 @@ func (c *xpfCollector) emitFairnessRSSExpectationGauges(
 	expectations []dpuserspace.FairnessRSSExpectation,
 ) {
 	for _, result := range dpuserspace.EvaluateFairnessRSSExpectations(status, expectations) {
+		// #hb166 F2: skip expectations whose interface name did not resolve
+		// to a live kernel ifindex. Their Ifindex is 0, so two distinct
+		// unresolved names on the same queue+kind would emit identical
+		// (ifindex=0, queue_id, kind) label sets — a duplicate-metric error
+		// that Gather() turns into an HTTP 500 for the ENTIRE /metrics
+		// scrape. Operator visibility of the unresolved expectation is
+		// retained on the `show ... fairness` text path (no uniqueness
+		// constraint there); only the Prometheus gauge is suppressed.
+		if !result.Resolved {
+			continue
+		}
 		ifindexLabel := strconv.Itoa(result.Ifindex)
 		queueLabel := strconv.FormatUint(uint64(result.QueueID), 10)
 		ch <- prometheus.MustNewConstMetric(

--- a/pkg/config/compiler_class_of_service.go
+++ b/pkg/config/compiler_class_of_service.go
@@ -340,41 +340,46 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 	if fairnessNode := node.FindChild("fairness"); fairnessNode != nil {
 		if rssNode := fairnessNode.FindChild("rss-expectation"); rssNode != nil {
 			seen := make(map[string]string)
-			for _, ifindexNode := range rssNode.FindChildren("ifindex") {
-				if len(ifindexNode.Keys) < 2 {
+			// #hb166 G-9: rss-expectation is keyed by the STABLE xpf
+			// interface name (e.g. ge-0-0-2), not the transient kernel
+			// ifindex. The name is resolved to the current ifindex at
+			// evaluate time from the live status snapshot, so the
+			// expectation survives NIC re-enumeration.
+			for _, ifaceNode := range rssNode.FindChildren("interface") {
+				if len(ifaceNode.Keys) < 2 {
 					continue
 				}
-				ifindex, err := strconv.Atoi(ifindexNode.Keys[1])
-				if err != nil || ifindex <= 0 {
-					return fmt.Errorf("class-of-service fairness rss-expectation ifindex %q: expected positive integer", ifindexNode.Keys[1])
+				ifaceName := ifaceNode.Keys[1]
+				if ifaceName == "" {
+					return fmt.Errorf("class-of-service fairness rss-expectation interface: expected non-empty interface name")
 				}
-				for _, queueNode := range ifindexNode.FindChildren("queue") {
+				for _, queueNode := range ifaceNode.FindChildren("queue") {
 					if len(queueNode.Keys) < 2 {
 						continue
 					}
 					queue, err := strconv.Atoi(queueNode.Keys[1])
 					if err != nil || queue < 0 || queue > 255 {
-						return fmt.Errorf("class-of-service fairness rss-expectation ifindex %d queue %q: expected queue 0..255", ifindex, queueNode.Keys[1])
+						return fmt.Errorf("class-of-service fairness rss-expectation interface %s queue %q: expected queue 0..255", ifaceName, queueNode.Keys[1])
 					}
 					expr, err := collectCoSFairnessRSSExpectation(queueNode)
 					if err != nil {
-						return fmt.Errorf("class-of-service fairness rss-expectation ifindex %d queue %d: %w", ifindex, queue, err)
+						return fmt.Errorf("class-of-service fairness rss-expectation interface %s queue %d: %w", ifaceName, queue, err)
 					}
 					parsed, err := fairnesscontract.ParseRSSExpectation(expr)
 					if err != nil {
-						return fmt.Errorf("class-of-service fairness rss-expectation ifindex %d queue %d: %w", ifindex, queue, err)
+						return fmt.Errorf("class-of-service fairness rss-expectation interface %s queue %d: %w", ifaceName, queue, err)
 					}
-					key := fmt.Sprintf("%d/%d", ifindex, queue)
+					key := fmt.Sprintf("%s/%d", ifaceName, queue)
 					canonical := parsed.Canonical()
 					if existing, ok := seen[key]; ok {
 						if existing == canonical {
 							continue
 						}
-						return fmt.Errorf("class-of-service fairness rss-expectation ifindex %d queue %d: duplicate expectation %q conflicts with %q", ifindex, queue, canonical, existing)
+						return fmt.Errorf("class-of-service fairness rss-expectation interface %s queue %d: duplicate expectation %q conflicts with %q", ifaceName, queue, canonical, existing)
 					}
 					seen[key] = canonical
 					cos.FairnessExpectations = append(cos.FairnessExpectations, &CoSFairnessExpectation{
-						Ifindex:        ifindex,
+						Interface:      ifaceName,
 						QueueID:        uint8(queue),
 						RSSExpectation: canonical,
 					})
@@ -540,9 +545,20 @@ func mergeCoSInterfaceLevelInto(unit, level *CoSInterfaceUnit) {
 	}
 	if unit.ShapingRateBytes == 0 {
 		unit.ShapingRateBytes = level.ShapingRateBytes
-	}
-	if unit.BurstSizeBytes == 0 {
-		unit.BurstSizeBytes = level.BurstSizeBytes
+		// #hb166 G-10: burst-size is grammatically a child of
+		// shaping-rate (see parseCoSInterfaceUnitBody), so a shaper is a
+		// coupled (rate, burst) pair. Inherit the level burst-size ONLY
+		// when the unit is also inheriting the level's rate. A unit that
+		// overrides shaping-rate defines its own shaper; pairing the
+		// level burst with the unit rate would mismatch them (a level
+		// burst sized for a level rate applied to a different unit rate).
+		// When the override unit leaves burst unset it stays 0 and the
+		// dataplane applies its rate-independent COS_MIN_BURST_BYTES
+		// floor, consistent with a fresh unit that sets shaping-rate
+		// alone.
+		if unit.BurstSizeBytes == 0 {
+			unit.BurstSizeBytes = level.BurstSizeBytes
+		}
 	}
 	if unit.SchedulerMap == "" {
 		unit.SchedulerMap = level.SchedulerMap

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -773,9 +773,29 @@ func ValidateConfig(cfg *Config) []string {
 			if iface == nil {
 				continue
 			}
+			// #hb166 G-6: a class-of-service binding whose interface (or
+			// logical unit) is not configured under [interfaces] commits
+			// cleanly but shapes nothing — the dataplane applier only
+			// visits CoS bindings inside the cfg.Interfaces iteration, so
+			// a typo'd interface name or an unconfigured unit is a silent
+			// no-op. Warn (not reject: the interface could be added
+			// later) so the operator knows the binding is currently inert.
+			ifCfg := cfg.Interfaces.Interfaces[iface.Name]
+			if ifCfg == nil {
+				warnings = append(warnings, fmt.Sprintf(
+					"class-of-service interface %s is bound but not configured under [interfaces]; its shaping/classifiers are inert until the interface is configured",
+					iface.Name))
+			}
 			for _, unit := range iface.Units {
 				if unit == nil {
 					continue
+				}
+				if ifCfg != nil {
+					if _, ok := ifCfg.Units[unit.Unit]; !ok {
+						warnings = append(warnings, fmt.Sprintf(
+							"class-of-service interface %s unit %d is bound but unit %d is not configured under [interfaces %s]; its shaping/classifiers are inert",
+							iface.Name, unit.Unit, unit.Unit, iface.Name))
+					}
 				}
 				if unit.SchedulerMap != "" {
 					if _, ok := cos.SchedulerMaps[unit.SchedulerMap]; !ok {

--- a/pkg/config/parser_class_of_service_test.go
+++ b/pkg/config/parser_class_of_service_test.go
@@ -446,9 +446,9 @@ func TestCompileClassOfServiceBothBufferFieldsRejected(t *testing.T) {
 
 func TestCompileClassOfServiceFairnessRSSExpectations(t *testing.T) {
 	lines := []string{
-		"set class-of-service fairness rss-expectation ifindex 5 queue 4 balanced",
-		"set class-of-service fairness rss-expectation ifindex 5 queue 5 max-worker-flow-share 0.5",
-		"set class-of-service fairness rss-expectation ifindex 6 queue 7 cstruct-max 0.25",
+		"set class-of-service fairness rss-expectation interface ge-0/0/2 queue 4 balanced",
+		"set class-of-service fairness rss-expectation interface ge-0/0/2 queue 5 max-worker-flow-share 0.5",
+		"set class-of-service fairness rss-expectation interface ge-0/0/3 queue 7 cstruct-max 0.25",
 		"set system dataplane-type userspace",
 	}
 	tree := &ConfigTree{}
@@ -471,19 +471,19 @@ func TestCompileClassOfServiceFairnessRSSExpectations(t *testing.T) {
 	}
 	tests := []struct {
 		idx     int
-		ifindex int
+		iface   string
 		queueID uint8
 		expect  string
 	}{
-		{idx: 0, ifindex: 5, queueID: 4, expect: "balanced"},
-		{idx: 1, ifindex: 5, queueID: 5, expect: "max-worker-flow-share:0.5"},
-		{idx: 2, ifindex: 6, queueID: 7, expect: "cstruct-max:0.25"},
+		{idx: 0, iface: "ge-0/0/2", queueID: 4, expect: "balanced"},
+		{idx: 1, iface: "ge-0/0/2", queueID: 5, expect: "max-worker-flow-share:0.5"},
+		{idx: 2, iface: "ge-0/0/3", queueID: 7, expect: "cstruct-max:0.25"},
 	}
 	for _, tt := range tests {
 		row := got[tt.idx]
-		if row.Ifindex != tt.ifindex || row.QueueID != tt.queueID || row.RSSExpectation != tt.expect {
-			t.Fatalf("expectation[%d] = ifindex=%d queue=%d expectation=%q, want ifindex=%d queue=%d expectation=%q",
-				tt.idx, row.Ifindex, row.QueueID, row.RSSExpectation, tt.ifindex, tt.queueID, tt.expect)
+		if row.Interface != tt.iface || row.QueueID != tt.queueID || row.RSSExpectation != tt.expect {
+			t.Fatalf("expectation[%d] = interface=%s queue=%d expectation=%q, want interface=%s queue=%d expectation=%q",
+				tt.idx, row.Interface, row.QueueID, row.RSSExpectation, tt.iface, tt.queueID, tt.expect)
 		}
 	}
 }
@@ -491,8 +491,8 @@ func TestCompileClassOfServiceFairnessRSSExpectations(t *testing.T) {
 func TestCompileClassOfServiceFairnessRSSExpectationRejectsDuplicateConflict(t *testing.T) {
 	tree := &ConfigTree{}
 	for _, line := range []string{
-		"set class-of-service fairness rss-expectation ifindex 5 queue 4 balanced",
-		"set class-of-service fairness rss-expectation ifindex 5 queue 4 cstruct-max 0.25",
+		"set class-of-service fairness rss-expectation interface ge-0/0/2 queue 4 balanced",
+		"set class-of-service fairness rss-expectation interface ge-0/0/2 queue 4 cstruct-max 0.25",
 	} {
 		path, err := ParseSetCommand(line)
 		if err != nil {
@@ -514,8 +514,8 @@ func TestCompileClassOfServiceFairnessRSSExpectationRejectsDuplicateConflict(t *
 func TestCompileClassOfServiceFairnessRSSExpectationSetDuplicateSameValueDedupes(t *testing.T) {
 	tree := &ConfigTree{}
 	for _, line := range []string{
-		"set class-of-service fairness rss-expectation ifindex 5 queue 4 balanced",
-		"set class-of-service fairness rss-expectation ifindex 5 queue 4 balanced",
+		"set class-of-service fairness rss-expectation interface ge-0/0/2 queue 4 balanced",
+		"set class-of-service fairness rss-expectation interface ge-0/0/2 queue 4 balanced",
 	} {
 		path, err := ParseSetCommand(line)
 		if err != nil {
@@ -539,7 +539,7 @@ func TestCompileClassOfServiceFairnessRSSExpectationRejectsHierarchicalDuplicate
 class-of-service {
     fairness {
         rss-expectation {
-            ifindex 5 {
+            interface ge-0/0/2 {
                 queue 4 {
                     balanced;
                     balanced;
@@ -1740,5 +1740,148 @@ func TestCompileClassOfServicePerUnitStillWorks4021(t *testing.T) {
 	}
 	if ci.Units[0] == nil || ci.Units[0].SchedulerMap != "edge-map" {
 		t.Fatalf("per-unit scheduler-map = %#v, want edge-map", ci.Units[0])
+	}
+}
+
+// cosWarnings returns the compile warnings that mention class-of-service.
+func cosWarnings(cfg *Config) []string {
+	var out []string
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "class-of-service") {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+// #hb166 G-6: a CoS binding on an interface that is NOT configured under
+// [interfaces] is a silent no-op (the dataplane applier only visits CoS
+// bindings that resolve against cfg.Interfaces). Commit must warn.
+// RED on revert: the warn validator never checks interface existence, so
+// no warning is emitted and the operator believes CoS is applied.
+func TestCompileClassOfServiceBindingNonexistentInterfaceWarnsHB166G6(t *testing.T) {
+	lines := []string{
+		// reth0 is shaped but never configured under [interfaces].
+		"set class-of-service interfaces reth0 unit 80 shaping-rate 3g",
+		"set system dataplane-type userspace",
+	}
+	tree := buildCoSTree4021(t, lines)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	var found bool
+	for _, w := range cosWarnings(cfg) {
+		if strings.Contains(w, "interface reth0 is bound but not configured under [interfaces]") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an inert-CoS-binding warning for reth0; got %v", cosWarnings(cfg))
+	}
+}
+
+// #hb166 G-6: the interface exists but the bound logical unit does not.
+func TestCompileClassOfServiceBindingUnconfiguredUnitWarnsHB166G6(t *testing.T) {
+	lines := []string{
+		// ge-0/0/2 is configured with unit 0 only; the CoS binding targets
+		// unit 5 which is never configured.
+		"set interfaces ge-0/0/2 unit 0 family inet address 10.0.0.1/24",
+		"set class-of-service interfaces ge-0/0/2 unit 5 shaping-rate 3g",
+		"set system dataplane-type userspace",
+	}
+	tree := buildCoSTree4021(t, lines)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	var found bool
+	for _, w := range cosWarnings(cfg) {
+		if strings.Contains(w, "unit 5 is bound but unit 5 is not configured") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an inert-CoS-unit warning for ge-0/0/2 unit 5; got %v", cosWarnings(cfg))
+	}
+}
+
+// #hb166 G-6: a fully-configured interface + unit must NOT warn.
+func TestCompileClassOfServiceBindingConfiguredInterfaceNoWarnHB166G6(t *testing.T) {
+	lines := []string{
+		"set interfaces ge-0/0/2 unit 0 family inet address 10.0.0.1/24",
+		"set class-of-service interfaces ge-0/0/2 unit 0 shaping-rate 3g",
+		"set system dataplane-type userspace",
+	}
+	tree := buildCoSTree4021(t, lines)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	for _, w := range cosWarnings(cfg) {
+		if strings.Contains(w, "bound but not configured") || strings.Contains(w, "is bound but unit") {
+			t.Fatalf("configured interface/unit must not warn inert; got %q", w)
+		}
+	}
+}
+
+// #hb166 G-10: a unit that overrides shaping-rate but sets no burst-size
+// must NOT inherit the interface-level burst-size (a shaper is a coupled
+// (rate, burst) pair). RED on revert: mergeCoSInterfaceLevelInto inherits
+// level.BurstSizeBytes unconditionally, pairing a level burst with a unit
+// rate.
+func TestCompileClassOfServiceUnitRateOverrideDropsLevelBurstHB166G10(t *testing.T) {
+	lines := []string{
+		"set interfaces ge-0/0/2 unit 0 family inet address 10.0.0.1/24",
+		// Interface-level shaper: 100m with an explicit 200000-byte burst.
+		"set class-of-service interfaces ge-0/0/2 shaping-rate 100m burst-size 200000",
+		// Unit overrides the rate to 1g and sets NO burst.
+		"set class-of-service interfaces ge-0/0/2 unit 0 shaping-rate 1g",
+		"set system dataplane-type userspace",
+	}
+	tree := buildCoSTree4021(t, lines)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	u := cfg.ClassOfService.Interfaces["ge-0/0/2"].Units[0]
+	if u == nil {
+		t.Fatal("expected ge-0/0/2 unit 0")
+	}
+	if u.ShapingRateBytes != parseBandwidthLimit("1g") {
+		t.Fatalf("unit shaping-rate override lost: got %d, want %d", u.ShapingRateBytes, parseBandwidthLimit("1g"))
+	}
+	if u.BurstSizeBytes != 0 {
+		t.Fatalf("unit rate override must not inherit the level burst-size: got %d, want 0 (dataplane applies its rate-independent floor)", u.BurstSizeBytes)
+	}
+}
+
+// #hb166 G-10: a unit that inherits the rate (sets no shaping-rate) still
+// inherits BOTH the level rate and the level burst-size as a pair.
+func TestCompileClassOfServiceUnitInheritsLevelRateAndBurstHB166G10(t *testing.T) {
+	lines := []string{
+		"set interfaces ge-0/0/2 unit 0 family inet address 10.0.0.1/24",
+		"set class-of-service interfaces ge-0/0/2 shaping-rate 100m burst-size 200000",
+		// Unit overrides only the scheduler-map; shaper inherits fully.
+		"set class-of-service forwarding-classes queue 0 best-effort",
+		"set class-of-service schedulers be-sched transmit-rate 5g",
+		"set class-of-service scheduler-maps m forwarding-class best-effort scheduler be-sched",
+		"set class-of-service interfaces ge-0/0/2 unit 0 scheduler-map m",
+		"set system dataplane-type userspace",
+	}
+	tree := buildCoSTree4021(t, lines)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	u := cfg.ClassOfService.Interfaces["ge-0/0/2"].Units[0]
+	if u == nil {
+		t.Fatal("expected ge-0/0/2 unit 0")
+	}
+	if u.ShapingRateBytes != parseBandwidthLimit("100m") {
+		t.Fatalf("unit must inherit level rate: got %d, want %d", u.ShapingRateBytes, parseBandwidthLimit("100m"))
+	}
+	if u.BurstSizeBytes != parseBurstSizeLimit("200000") {
+		t.Fatalf("unit inheriting the rate must also inherit the level burst: got %d, want %d", u.BurstSizeBytes, parseBurstSizeLimit("200000"))
 	}
 }

--- a/pkg/config/schema_cos.go
+++ b/pkg/config/schema_cos.go
@@ -132,7 +132,7 @@ var schemaClassOfService = &schemaNode{desc: "Class of service configuration", c
 	}},
 	"fairness": {desc: "Dataplane fairness observability configuration", children: map[string]*schemaNode{
 		"rss-expectation": {desc: "Declarative RSS flow-distribution expectations evaluated against live dataplane status (shown in fairness output and exported as Prometheus gauges)", children: map[string]*schemaNode{
-			"ifindex": {desc: "Kernel interface index to evaluate (positive integer)", args: 1, multi: true, placeholder: "<ifindex>", children: map[string]*schemaNode{
+			"interface": {desc: "Stable interface name to evaluate (resolved to the current kernel ifindex at evaluate time)", args: 1, multi: true, placeholder: "<interface-name>", children: map[string]*schemaNode{
 				"queue": {desc: "CoS queue ID to evaluate (0..255; exactly one expectation per queue)", args: 1, multi: true, placeholder: "<queue-id>", children: map[string]*schemaNode{
 					"any":                     {desc: "No expectation; always passes", children: nil},
 					"balanced":                {desc: "Expect flows spread across min(flows, workers) workers with per-worker flow counts within 1", children: nil},

--- a/pkg/config/types_cos.go
+++ b/pkg/config/types_cos.go
@@ -164,10 +164,12 @@ type CoSInterfaceUnit struct {
 }
 
 // CoSFairnessExpectation declares an opt-in RSS/workload expectation for
-// one egress CoS queue. Ifindex is used intentionally because the
-// userspace status snapshot reports the same kernel identity.
+// one egress CoS queue. Interface is the STABLE xpf interface name (e.g.
+// ge-0-0-2); the kernel ifindex it maps to is transient across
+// re-enumeration, so the name is resolved to the current ifindex at
+// evaluate time from the live status snapshot (#hb166 G-9).
 type CoSFairnessExpectation struct {
-	Ifindex        int
+	Interface      string
 	QueueID        uint8
 	RSSExpectation string
 }

--- a/pkg/dataplane/userspace/fairness.go
+++ b/pkg/dataplane/userspace/fairness.go
@@ -31,7 +31,14 @@ type FairnessRSSExpectation struct {
 }
 
 type FairnessRSSExpectationResult struct {
-	Interface           string
+	Interface string
+	// Resolved reports whether Interface mapped to a live kernel ifindex
+	// in the evaluated status snapshot. When false, Ifindex is the zero
+	// value and callers that key on ifindex (e.g. Prometheus gauges) MUST
+	// skip the row — two distinct unresolved interface names on the same
+	// queue+kind would otherwise collapse to identical ifindex=0 labels
+	// and 500 the whole /metrics scrape (#hb166 F2).
+	Resolved            bool
 	Ifindex             int
 	QueueID             uint8
 	Expectation         string
@@ -290,6 +297,7 @@ func EvaluateFairnessRSSExpectations(
 		}
 		out = append(out, FairnessRSSExpectationResult{
 			Interface:           expectation.Interface,
+			Resolved:            resolved,
 			Ifindex:             ifindex,
 			QueueID:             expectation.QueueID,
 			Expectation:         canonical,

--- a/pkg/dataplane/userspace/fairness.go
+++ b/pkg/dataplane/userspace/fairness.go
@@ -1,6 +1,7 @@
 package userspace
 
 import (
+	"fmt"
 	"math"
 	"sort"
 
@@ -24,12 +25,13 @@ type CoSFairnessRSSSummary struct {
 }
 
 type FairnessRSSExpectation struct {
-	Ifindex        int
+	Interface      string
 	QueueID        uint8
 	RSSExpectation string
 }
 
 type FairnessRSSExpectationResult struct {
+	Interface           string
 	Ifindex             int
 	QueueID             uint8
 	Expectation         string
@@ -195,12 +197,36 @@ func FairnessRSSExpectationsFromConfig(cfg *config.Config) []FairnessRSSExpectat
 			continue
 		}
 		out = append(out, FairnessRSSExpectation{
-			Ifindex:        row.Ifindex,
+			Interface:      row.Interface,
 			QueueID:        row.QueueID,
 			RSSExpectation: row.RSSExpectation,
 		})
 	}
 	return out
+}
+
+// fairnessInterfaceIfindexMap resolves stable interface names to the
+// current kernel ifindex from the live status snapshot. The mapping is
+// re-read every evaluation, so a name-keyed rss-expectation always tracks
+// the named interface across NIC re-enumeration (#hb166 G-9). Both the
+// CoS-interface list and the binding list are consulted so an interface
+// with active egress CoS queues resolves even if it carries no explicit
+// CoS shaping binding.
+func fairnessInterfaceIfindexMap(status ProcessStatus) map[string]int {
+	m := make(map[string]int)
+	for _, ci := range status.CoSInterfaces {
+		if ci.InterfaceName != "" && ci.Ifindex > 0 {
+			m[ci.InterfaceName] = ci.Ifindex
+		}
+	}
+	for _, b := range status.Bindings {
+		if b.Interface != "" && b.Ifindex > 0 {
+			if _, ok := m[b.Interface]; !ok {
+				m[b.Interface] = b.Ifindex
+			}
+		}
+	}
+	return m
 }
 
 func EvaluateFairnessRSSExpectations(
@@ -215,12 +241,19 @@ func EvaluateFairnessRSSExpectations(
 	for _, summary := range summaries {
 		byQueue[cosFairnessRSSKey{ifindex: summary.Ifindex, queueID: summary.QueueID}] = summary
 	}
+	// #hb166 G-9: resolve each expectation's stable interface name to its
+	// current kernel ifindex from THIS snapshot, so the queue lookup
+	// tracks the named interface even after NIC re-enumeration.
+	nameToIfindex := fairnessInterfaceIfindexMap(status)
 	out := make([]FairnessRSSExpectationResult, 0, len(expectations))
 	for _, expectation := range expectations {
 		parsed, err := fairnesscontract.ParseRSSExpectation(expectation.RSSExpectation)
-		key := cosFairnessRSSKey{ifindex: expectation.Ifindex, queueID: expectation.QueueID}
-		summary, ok := byQueue[key]
-		if !ok {
+		ifindex, resolved := nameToIfindex[expectation.Interface]
+		key := cosFairnessRSSKey{ifindex: ifindex, queueID: expectation.QueueID}
+		var summary CoSFairnessRSSSummary
+		if s, ok := byQueue[key]; ok && resolved {
+			summary = s
+		} else {
 			summary = summarizeCoSFairnessRSSDistribution(
 				key,
 				make([]uint32, boundedFairnessRSSWorkerSlots(status.Workers, 0)),
@@ -232,7 +265,19 @@ func EvaluateFairnessRSSExpectations(
 		kind := "invalid"
 		var value float64
 		hasValue := false
-		if err == nil {
+		if err != nil {
+			// parse error already captured in result.Reason
+		} else if !resolved {
+			// Named interface is not present in the current dataplane
+			// snapshot; report it rather than silently judging ifindex 0.
+			canonical = parsed.Canonical()
+			kind = parsed.MetricKind()
+			value, hasValue = parsed.MetricValue()
+			result = fairnesscontract.RSSExpectationResult{
+				Pass:   false,
+				Reason: fmt.Sprintf("interface %q not present in dataplane status", expectation.Interface),
+			}
+		} else {
 			canonical = parsed.Canonical()
 			kind = parsed.MetricKind()
 			value, hasValue = parsed.MetricValue()
@@ -244,7 +289,8 @@ func EvaluateFairnessRSSExpectations(
 			)
 		}
 		out = append(out, FairnessRSSExpectationResult{
-			Ifindex:             expectation.Ifindex,
+			Interface:           expectation.Interface,
+			Ifindex:             ifindex,
 			QueueID:             expectation.QueueID,
 			Expectation:         canonical,
 			ExpectationKind:     kind,
@@ -258,8 +304,8 @@ func EvaluateFairnessRSSExpectations(
 		})
 	}
 	sort.Slice(out, func(i, j int) bool {
-		if out[i].Ifindex != out[j].Ifindex {
-			return out[i].Ifindex < out[j].Ifindex
+		if out[i].Interface != out[j].Interface {
+			return out[i].Interface < out[j].Interface
 		}
 		if out[i].QueueID != out[j].QueueID {
 			return out[i].QueueID < out[j].QueueID

--- a/pkg/dataplane/userspace/fairness_test.go
+++ b/pkg/dataplane/userspace/fairness_test.go
@@ -80,8 +80,14 @@ func TestBoundedFairnessRSSWorkerSlots(t *testing.T) {
 }
 
 func TestEvaluateFairnessRSSExpectationsFailsMissingQueue(t *testing.T) {
-	results := EvaluateFairnessRSSExpectations(ProcessStatus{Workers: 4}, []FairnessRSSExpectation{
-		{Ifindex: 80, QueueID: 4, RSSExpectation: "max-worker-flow-share:0.5"},
+	// The interface resolves (present in the snapshot) but has no active
+	// flows on the queue → "no active flows observed".
+	status := ProcessStatus{
+		Workers:  4,
+		Bindings: []BindingStatus{{Interface: "ge-0-0-2", Ifindex: 80}},
+	}
+	results := EvaluateFairnessRSSExpectations(status, []FairnessRSSExpectation{
+		{Interface: "ge-0-0-2", QueueID: 4, RSSExpectation: "max-worker-flow-share:0.5"},
 	})
 	if len(results) != 1 {
 		t.Fatalf("EvaluateFairnessRSSExpectations returned %d rows, want 1", len(results))
@@ -89,7 +95,69 @@ func TestEvaluateFairnessRSSExpectationsFailsMissingQueue(t *testing.T) {
 	if results[0].Pass {
 		t.Fatalf("missing queue expectation passed: %+v", results[0])
 	}
+	if results[0].Ifindex != 80 {
+		t.Fatalf("resolved ifindex = %d, want 80", results[0].Ifindex)
+	}
 	if !strings.Contains(results[0].Reason, "no active flows observed") {
 		t.Fatalf("missing queue reason = %q, want no active flows observed", results[0].Reason)
+	}
+}
+
+// #hb166 G-9: an rss-expectation keyed by a STABLE interface name must
+// track the named interface across NIC re-enumeration. When the kernel
+// ifindex of "ge-0-0-2" changes from 80 to 91 between snapshots, the
+// expectation must resolve to the CURRENT ifindex (91) and evaluate the
+// distribution reported under 91 — not the stale 80. RED on revert: the
+// pre-fix ifindex-keyed config baked in the ifindex and would judge
+// whichever interface now holds 80 (here, none), or the wrong port.
+func TestEvaluateFairnessRSSExpectationsNameKeyedSurvivesReenumeration(t *testing.T) {
+	// After re-enumeration ge-0-0-2 is ifindex 91 and carries a balanced
+	// 2-worker distribution; ifindex 80 now belongs to a different port
+	// (ge-0-0-1) with a single-worker (skewed) distribution.
+	status := ProcessStatus{
+		Workers: 2,
+		Bindings: []BindingStatus{
+			{Interface: "ge-0-0-2", Ifindex: 91},
+			{Interface: "ge-0-0-1", Ifindex: 80},
+		},
+		CoSActiveFlowCounts: []CoSActiveFlowCountStatus{
+			// ge-0-0-2 (ifindex 91): balanced across two workers, 10 flows.
+			{Ifindex: 91, QueueID: 4, WorkerID: 0, ActiveFlowCount: 5},
+			{Ifindex: 91, QueueID: 4, WorkerID: 1, ActiveFlowCount: 5},
+			// ge-0-0-1 (ifindex 80): all 7 flows on one worker (skewed).
+			{Ifindex: 80, QueueID: 4, WorkerID: 0, ActiveFlowCount: 7},
+		},
+	}
+	results := EvaluateFairnessRSSExpectations(status, []FairnessRSSExpectation{
+		{Interface: "ge-0-0-2", QueueID: 4, RSSExpectation: "balanced"},
+	})
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1: %+v", len(results), results)
+	}
+	if results[0].Ifindex != 91 {
+		t.Fatalf("resolved ifindex = %d, want 91 (re-enumerated ge-0-0-2)", results[0].Ifindex)
+	}
+	if !results[0].Pass {
+		t.Fatalf("balanced expectation on ge-0-0-2 (ifindex 91) failed: %+v", results[0])
+	}
+	if results[0].ActiveFlows != 10 {
+		t.Fatalf("evaluated the wrong interface: active flows = %d, want 10 (ge-0-0-2)", results[0].ActiveFlows)
+	}
+}
+
+// #hb166 G-9: a name that is not present in the current dataplane
+// snapshot is reported explicitly instead of silently judging ifindex 0.
+func TestEvaluateFairnessRSSExpectationsUnresolvedInterface(t *testing.T) {
+	results := EvaluateFairnessRSSExpectations(ProcessStatus{Workers: 4}, []FairnessRSSExpectation{
+		{Interface: "ge-9-9-9", QueueID: 4, RSSExpectation: "balanced"},
+	})
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(results))
+	}
+	if results[0].Pass {
+		t.Fatalf("unresolved interface passed: %+v", results[0])
+	}
+	if !strings.Contains(results[0].Reason, "not present in dataplane status") {
+		t.Fatalf("unresolved reason = %q, want not present in dataplane status", results[0].Reason)
 	}
 }

--- a/pkg/dataplane/userspace/format/status.go
+++ b/pkg/dataplane/userspace/format/status.go
@@ -731,11 +731,11 @@ func FormatFairnessRSS(status userspace.ProcessStatus, expectations []userspace.
 	if results := userspace.EvaluateFairnessRSSExpectations(status, expectations); len(results) > 0 {
 		fmt.Fprintln(&b)
 		fmt.Fprintln(&b, "RSS expectations:")
-		fmt.Fprintf(&b, "  %-8s %-7s %-28s %-6s %-11s %-13s %-10s %s\n",
-			"Ifindex", "Queue", "Expectation", "Pass", "ActiveFlows", "ActiveWorkers", "Cstruct", "Reason")
+		fmt.Fprintf(&b, "  %-12s %-7s %-28s %-6s %-11s %-13s %-10s %s\n",
+			"Interface", "Queue", "Expectation", "Pass", "ActiveFlows", "ActiveWorkers", "Cstruct", "Reason")
 		for _, result := range results {
-			fmt.Fprintf(&b, "  %-8d %-7d %-28s %-6t %-11d %-13d %-10.6f %s\n",
-				result.Ifindex,
+			fmt.Fprintf(&b, "  %-12s %-7d %-28s %-6t %-11d %-13d %-10.6f %s\n",
+				result.Interface,
 				result.QueueID,
 				result.Expectation,
 				result.Pass,

--- a/pkg/dataplane/userspace/format/status_test.go
+++ b/pkg/dataplane/userspace/format/status_test.go
@@ -554,6 +554,9 @@ func TestFormatStatusSummarySaturatesCoSAdmissionAttribution(t *testing.T) {
 func TestFormatFairnessRSS(t *testing.T) {
 	status := userspace.ProcessStatus{
 		CoSActiveFlowCountsTruncated: true,
+		Bindings: []userspace.BindingStatus{
+			{Interface: "reth0", Ifindex: 80},
+		},
 		CoSActiveFlowCounts: []userspace.CoSActiveFlowCountStatus{
 			{Ifindex: 80, QueueID: 4, WorkerID: 0, ActiveFlowCount: 1},
 			{Ifindex: 80, QueueID: 4, WorkerID: 1, ActiveFlowCount: 3},
@@ -564,8 +567,8 @@ func TestFormatFairnessRSS(t *testing.T) {
 	}
 
 	out := FormatFairnessRSS(status, []userspace.FairnessRSSExpectation{
-		{Ifindex: 80, QueueID: 4, RSSExpectation: "balanced"},
-		{Ifindex: 80, QueueID: 5, RSSExpectation: "max-worker-flow-share:50%"},
+		{Interface: "reth0", QueueID: 4, RSSExpectation: "balanced"},
+		{Interface: "reth0", QueueID: 5, RSSExpectation: "max-worker-flow-share:50%"},
 	})
 	for _, want := range []string{
 		"Userspace fairness RSS structure:",
@@ -577,9 +580,11 @@ func TestFormatFairnessRSS(t *testing.T) {
 		"80       4       4           2             0.577350   75.00%",
 		"80       5       4           2             0.000000   50.00%",
 		"RSS expectations:",
-		"80       4       balanced                     false",
+		"Interface",
+		"reth0",
+		"balanced                     false",
 		"balanced: active_workers=2 expected",
-		"80       5       max-worker-flow-share:0.5    true",
+		"max-worker-flow-share:0.5    true",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("fairness output missing %q:\n%s", want, out)
@@ -588,14 +593,19 @@ func TestFormatFairnessRSS(t *testing.T) {
 }
 
 func TestFormatFairnessRSSShowsExpectationsWithoutRows(t *testing.T) {
-	out := FormatFairnessRSS(userspace.ProcessStatus{Workers: 4}, []userspace.FairnessRSSExpectation{
-		{Ifindex: 80, QueueID: 4, RSSExpectation: "cstruct-max:0.25"},
+	status := userspace.ProcessStatus{
+		Workers:  4,
+		Bindings: []userspace.BindingStatus{{Interface: "reth0", Ifindex: 80}},
+	}
+	out := FormatFairnessRSS(status, []userspace.FairnessRSSExpectation{
+		{Interface: "reth0", QueueID: 4, RSSExpectation: "cstruct-max:0.25"},
 	})
 	for _, want := range []string{
 		"Userspace fairness RSS structure:",
 		"  none",
 		"RSS expectations:",
-		"80       4       cstruct-max:0.25",
+		"reth0",
+		"cstruct-max:0.25",
 		"false",
 		"cstruct-max: no active flows observed",
 	} {

--- a/test/incus/sqm-cookbook-config.set
+++ b/test/incus/sqm-cookbook-config.set
@@ -36,4 +36,13 @@
 # that inject their own delete list strip non-`set` lines).
 delete class-of-service
 
+# reth0 unit 80 must be a configured logical interface, otherwise the CoS
+# binding below is a silent no-op (the dataplane applier only visits CoS
+# bindings that resolve against [interfaces]; hb166 G-6 now warns on the
+# inert case). This mirrors the loss-userspace-cluster WAN unit
+# (reth0.80 / 172.16.80.0/24) that the recipe shapes.
+set interfaces reth0 vlan-tagging
+set interfaces reth0 unit 80 vlan-id 80
+set interfaces reth0 unit 80 family inet address 172.16.80.8/24
+
 set class-of-service interfaces reth0 unit 80 shaping-rate 3g


### PR DESCRIPTION
Fixes three CoS correctness findings from fable-review-166 (G-6, G-9,
G-10). Go-only — no Rust/cargo, no dataplane wire change.

## G-6 — inert CoS binding is a silent no-op (#4221)

A `class-of-service interfaces <name> ...` binding whose interface or
logical unit is not configured under `[interfaces]` committed cleanly
and shaped nothing (the dataplane applier only visits CoS bindings that
resolve against `cfg.Interfaces`). Now the commit emits a WARNING (not a
reject — the interface may be added later) so the operator knows the
binding is currently inert. `compiler_validate_warn.go`.

## G-9 — rss-expectation keyed by transient kernel ifindex (#4222)

`class-of-service fairness rss-expectation` was keyed by the kernel
ifindex, which changes across re-enumeration — silently evaluating the
wrong interface afterward. Re-keyed by the STABLE xpf interface name
(`rss-expectation interface <name> queue <q> ...`), resolved to the
current ifindex at evaluate time from the live status snapshot
(re-resolved every poll). Prometheus labels stay ifindex-keyed with the
resolved id, so the metric contract is unchanged. An absent name is
reported explicitly instead of judging ifindex 0.

## G-10 — unit shaping-rate override inherits the level burst-size (#4223)

`mergeCoSInterfaceLevelInto` inherited the interface-level `burst-size`
even when a unit overrode `shaping-rate`, pairing a level burst with a
unit rate (10x-of-intent mismatch). `burst-size` is grammatically a
child of `shaping-rate`, so a shaper is a coupled `(rate, burst)` pair;
the burst is now inherited ONLY when the unit also inherits the rate. An
override unit that leaves burst unset falls back to the dataplane's
rate-independent `COS_MIN_BURST_BYTES` floor.

## Testing

- `go test ./pkg/config/... ./pkg/dataplane/userspace/... ./pkg/api/...`
  green; `go build ./...` clean; gofmt + vet clean on touched files.
- RED-on-revert proven for all three: G-6 emits no warning; G-9 stale
  ifindex judges the wrong interface after re-enumeration (resolved
  ifindex 80 vs current 91); G-10 inherits the mismatched 200000-byte
  burst.
- Docs updated: `docs/per-5-tuple/state.md` (G-9 grammar + resolution),
  `docs/cos-traffic-shaping.md` (G-6 inert-binding + G-10 burst pairing).

Closes #4221 Closes #4222 Closes #4223

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi