### PR TITLE
class-of-service: reject a dangling scheduler-map -> scheduler reference at strict commit; fail SAFE in the dataplane

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -34324,3 +34324,43 @@ top.
   scripts/image/test_validate_scenarios.py,
   scripts/deploy/test_xpf_deploy_gate.py, scripts/run-selftests.sh, Makefile,
   docs/install-images.md, CLAUDE.md, _Log.md
+
+## 2026-07-04 — CoS scheduler-map dangling scheduler ref: strict-reject + dataplane safe default (fable-166 G-2)
+
+- **Timestamp**: 2026-07-04
+- **Action**: Fixed a CoS fail-open: a `scheduler-map <m> forwarding-class
+  <fc> scheduler <name>` entry naming an UNDEFINED scheduler was warn-only
+  at commit (`ValidateConfig`) and then FAIL-OPEN in the helper — the
+  per-queue builder resolved the dangling name to `None`, left
+  `guarantee_enabled` false, set the queue rate to the WHOLE interface
+  shaping rate, and derived the MAXIMUM surplus weight (16). A premium
+  class (e.g. `ef`) whose scheduler name was a typo did not merely lose its
+  guarantee, it silently won the LARGEST best-effort surplus share
+  (`cos_surplus_quantum_bytes = COS_SURPLUS_ROUND_QUANTUM_BYTES *
+  surplus_weight`). Applied the #1960 doctrine: (a) Go
+  `validateClassOfServiceSchedulerMapRefsStrict` HARD-REJECTS the dangling
+  reference at strict commit / commit-check (lenient downgrade to a
+  `cfg.Warnings` entry on the tolerant load / peer-sync path via
+  `lenientSchedulerMapRef`, so an older-binary / peer-synced config still
+  boots); (b) the Rust helper now fails SAFE — an unresolved scheduler
+  (`scheduler.is_none()`) pins the queue to the minimal best-effort surplus
+  weight (1) instead of the whole-interface-rate maximum, while KEEPING the
+  queue materialized (dropping it — the undefined-forwarding-class
+  treatment — would blackhole classified traffic). `guarantee_enabled`
+  stays false and priority stays `low`; a DEFINED scheduler that merely
+  omits `transmit-rate` is unchanged (`surplus_weight = 16`). Removed the
+  redundant `ValidateConfig` scheduler warn (single SSOT, consistent with
+  every other cross-ref gate) and kept the undefined-forwarding-class warn.
+  Added a daemon-journal breadcrumb in the Go emitter
+  (`pkg/dataplane/userspace/cos.go`). RED-on-revert proven for BOTH tests
+  (Go strict-reject; Rust surplus_weight==1). Full Go build + `go test
+  ./pkg/config/... ./pkg/dataplane/...` green; full cargo suite green except
+  the pre-existing, unrelated
+  `event_stream::tests::test_paused_telemetry_eviction_does_not_poison_drain_2875`
+  (confirmed FAILING on clean origin/master without this change).
+- **File(s)**: pkg/config/compiler.go, pkg/config/compiler_validate_strict.go,
+  pkg/config/compiler_validate_warn.go, pkg/config/parser_class_of_service_test.go,
+  pkg/dataplane/userspace/cos.go,
+  userspace-dp/src/afxdp/forwarding_build/cos.rs,
+  userspace-dp/src/afxdp/forwarding_build/tests.rs,
+  docs/config-schema.md, docs/cos-traffic-shaping.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1364,6 +1364,41 @@ reserved for whole-dataplane selection where a rewrite shim
   live CoS state). The Go commit-time gate above stays the PRIMARY
   defense; this is the helper-boundary backstop against version /
   snapshot drift, consistent with the #2447 CoS fail-closed family.
+- **scheduler-map dangling `scheduler` reference (strict commit +
+  Rust safe default):** a `scheduler-map <m> forwarding-class <fc>
+  scheduler <name>` entry naming a scheduler that is NOT defined under
+  `class-of-service schedulers` was previously WARN-only at commit
+  (`ValidateConfig`) and then FAIL-OPEN in the helper: the per-queue
+  builder (`userspace-dp forwarding_build/cos.rs`) resolved the dangling
+  name to `None`, left `guarantee_enabled` false, set the queue's
+  transmit rate to the WHOLE interface shaping rate, and derived the
+  MAXIMUM surplus weight (16). So a premium class (e.g. `ef`) whose
+  scheduler name was a typo did not merely lose its guarantee — it
+  silently won the LARGEST best-effort surplus share, invisible outside
+  the runtime queue rows. `validateClassOfServiceSchedulerMapRefsStrict`
+  (`compiler_validate_strict.go`) now HARD-REJECTS the dangling
+  reference at strict commit / commit-check, mirroring
+  `validatePolicySchedulerReferencesStrict` (the policy → scheduler
+  sibling) and Junos, which rejects an unresolved scheduler reference.
+  The call site downgrades it to a `cfg.Warnings` entry on the tolerant
+  load / peer-sync paths (`lenientSchedulerMapRef`, #1960 no-brick) so a
+  config persisted by an older binary — which only warned — still boots.
+  The helper-side backstop keeps that leniently-loaded reference
+  fail-SAFE rather than fail-OPEN: an UNRESOLVED scheduler pins the
+  queue to the minimal best-effort surplus weight (1) instead of the
+  whole-interface-rate maximum, while KEEPING the queue materialized
+  under its real queue id / forwarding-class (dropping the entry — the
+  undefined-forwarding-class treatment — would blackhole any traffic a
+  classifier steers to the class's queue). `guarantee_enabled` stays
+  false and priority stays `low`, so no guarantee or priority is
+  fabricated. A DEFINED scheduler that merely omits `transmit-rate` is
+  unchanged (it keeps `surplus_weight = 16`). The redundant
+  `ValidateConfig` scheduler warn was removed (single SSOT), consistent
+  with every other cross-reference gate. Coverage:
+  `TestSchedulerMapDanglingSchedulerRejectedStrict` (strict reject +
+  lenient downgrade + valid-scheduler control, `pkg/config`) and
+  `build_cos_state_dangling_scheduler_reference_uses_safe_best_effort_default`
+  (`userspace-dp forwarding_build/tests.rs`).
 - **#1956 (chassis device-map):** added the bare-metal stable-identity
   managed allowlist under `chassis device-map` (a SIBLING of `cluster`, so
   per-node apply-groups compose). New value types `ValuePCIAddr` /

--- a/docs/cos-traffic-shaping.md
+++ b/docs/cos-traffic-shaping.md
@@ -870,6 +870,21 @@ Important current behavior:
   when an admitted CoS interface has no real scheduler-map queues remains the
   sole root-shaped guarantee queue; admission can come from shaping or from a
   classifier/rewrite rule that targets that default queue/class.
+- a scheduler-map entry naming a scheduler that is NOT defined (a
+  dangling reference) is hard-rejected at strict commit
+  (`validateClassOfServiceSchedulerMapRefsStrict`), so an operator can
+  never create one. If a config persisted by an older binary — or synced
+  from a peer — still carries one, it is downgraded to a warning on load
+  (`lenientSchedulerMapRef`, #1960) and the helper applies a SAFE
+  best-effort default: the queue stays materialized under its real queue
+  id / forwarding-class (so classified traffic still forwards) but is
+  pinned to the MINIMAL surplus weight (1), not the whole-interface-rate
+  MAXIMUM (16) the effective-rate derivation used before. This distinguishes
+  a dangling reference (no scheduler; minimal share) from a defined
+  scheduler that merely omits `transmit-rate` (residual-only above; full
+  surplus weight). Before the fix a scheduler typo silently handed the
+  class the LARGEST best-effort surplus share instead of its intended
+  guarantee — a fail-open now closed.
 - `transmit-rate exact` prevents that queue from borrowing surplus by default
 - adding `surplus-sharing` on the scheduler (#915) opts an `exact` queue
   into surplus participation while keeping the per-queue rate as a

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -235,6 +235,24 @@ type compileOpts struct {
 	// boot). Same doctrine as lenientPolicyMatchAddress.
 	lenientIPsecPolicyProposalRef bool
 
+	// lenientSchedulerMapRef downgrades the class-of-service
+	// scheduler-map -> scheduler cross-reference check
+	// (validateClassOfServiceSchedulerMapRefsStrict) from a hard error to
+	// a warning on the tolerant load / peer-sync paths. A scheduler-map
+	// entry naming an undefined scheduler was warn-only at commit before
+	// this gate, so a config persisted by an older binary — or synced
+	// from a peer — may carry the dangling reference; an upgrading /
+	// receiving node must still boot through it (warn) rather than
+	// fail-closed-on-load (#1960 class). Commit / commit-check stay strict
+	// — a new operator edit that would silently strip a class's
+	// scheduling guarantee and (pre-fix) hand it the MAXIMUM best-effort
+	// surplus share in the dataplane is rejected. The render-path safety
+	// net (the scheduler-unresolved SAFE default in
+	// userspace-dp forwarding_build/cos.rs, surplus_weight pinned to 1)
+	// preserves the fail-SAFE posture on that boot. Same doctrine as
+	// lenientIPsecPolicyProposalRef.
+	lenientSchedulerMapRef bool
+
 	// lenientIPsecGatewayRefs (#2074) downgrades the IPsec VPN -> IKE
 	// gateway cross-reference check from a hard error to a warning on the
 	// tolerant load / peer-sync paths (CompileConfigLenient /
@@ -1401,6 +1419,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientLogEventModeFormat:              true,
 		lenientEventAttributesMatch:            true,
 		lenientIPsecPolicyProposalRef:          true,
+		lenientSchedulerMapRef:                 true,
 		lenientIPsecGatewayRefs:                true,
 		lenientIKEPolicyChainRef:               true,
 		lenientIPsecTrafficSelectors:           true,
@@ -1582,6 +1601,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientLogEventModeFormat:              true,
 		lenientEventAttributesMatch:            true,
 		lenientIPsecPolicyProposalRef:          true,
+		lenientSchedulerMapRef:                 true,
 		lenientIPsecGatewayRefs:                true,
 		lenientIKEPolicyChainRef:               true,
 		lenientIPsecTrafficSelectors:           true,
@@ -2344,6 +2364,27 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	// commit-time rejection has nothing left to guard.
 	if err := errors.Join(strictErrs...); err != nil {
 		return nil, err
+	}
+
+	// class-of-service scheduler-map -> scheduler cross-reference gate.
+	// Strict on commit / commit-check (hard-reject a scheduler-map entry
+	// naming an undefined scheduler — such a reference was only warned,
+	// then compiled and KEPT, and the userspace dataplane resolved the
+	// dangling name to no scheduler: the class silently lost its
+	// guarantee and, pre-fix, won the MAXIMUM best-effort surplus share).
+	// Lenient on load / peer-sync (warn so an already-persisted or
+	// peer-synced config with a stale scheduler reference still boots —
+	// #1960 no-brick; the dataplane applies the scheduler-unresolved SAFE
+	// default on that boot). Runs AFTER the strict accumulator +
+	// device-map so a structural CoS/policer/device-map error still wins
+	// the first-error slot.
+	if err := validateClassOfServiceSchedulerMapRefsStrict(cfg.ClassOfService); err != nil {
+		if opts.lenientSchedulerMapRef {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("class-of-service scheduler-map reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
 	}
 
 	// #1956 device-map cross-entry validation. Strict on commit /

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -169,6 +169,74 @@ func validatePolicySchedulerReferencesStrict(cfg *Config) error {
 	return nil
 }
 
+// validateClassOfServiceSchedulerMapRefsStrict hard-rejects a
+// class-of-service scheduler-map entry whose `scheduler <name>`
+// reference does not resolve to a defined `class-of-service schedulers`
+// entry — a commit-time typo. Junos hard-rejects an unresolved
+// scheduler reference at commit; this restores that behavior.
+//
+// Before this gate the reference was warn-only at commit
+// (ValidateConfig, compiler_validate_warn.go) and then FAILED OPEN in
+// the dataplane: the userspace helper's per-queue builder
+// (userspace-dp forwarding_build/cos.rs) resolves the dangling name to
+// `None`, leaves `guarantee_enabled` false, sets the queue's transmit
+// rate to the WHOLE interface shaping rate, and derives the MAXIMUM
+// surplus weight (16). So a premium class (e.g. `ef`) whose scheduler
+// name is a typo did not merely lose its guarantee — it silently won
+// the LARGEST best-effort surplus share, invisible outside the runtime
+// queue rows.
+//
+// On the tolerant load / peer-sync paths the call site downgrades this
+// to a warning (opts.lenientSchedulerMapRef) so a config persisted by
+// an older binary (which only warned) or synced from a peer still boots
+// (#1960 no-brick). The dataplane's render-path safety net (the
+// scheduler-unresolved SAFE default in forwarding_build/cos.rs, which
+// pins surplus_weight to 1) keeps a leniently-loaded dangling reference
+// from fail-opening to the maximum best-effort share on that boot.
+// Mirrors validatePolicySchedulerReferencesStrict, which rejects an
+// undefined scheduler reference from a security policy.
+//
+// An EMPTY scheduler string is skipped: the grammar requires a name, so
+// an empty value arises only in constructed configs and is the same
+// "no scheduler assigned" placeholder the warn / strict buffer
+// validators skip.
+func validateClassOfServiceSchedulerMapRefsStrict(cos *ClassOfServiceConfig) error {
+	if cos == nil {
+		return nil
+	}
+	// Iterate scheduler-maps and their entries in sorted order so
+	// commit-check surfaces a STABLE first-error message (Go map
+	// iteration order is randomized).
+	mapNames := make([]string, 0, len(cos.SchedulerMaps))
+	for name := range cos.SchedulerMaps {
+		mapNames = append(mapNames, name)
+	}
+	sort.Strings(mapNames)
+	for _, mapName := range mapNames {
+		schedMap := cos.SchedulerMaps[mapName]
+		if schedMap == nil {
+			continue
+		}
+		classNames := make([]string, 0, len(schedMap.Entries))
+		for className := range schedMap.Entries {
+			classNames = append(classNames, className)
+		}
+		sort.Strings(classNames)
+		for _, className := range classNames {
+			entry := schedMap.Entries[className]
+			if entry == nil || entry.Scheduler == "" {
+				continue
+			}
+			if _, ok := cos.Schedulers[entry.Scheduler]; !ok {
+				return fmt.Errorf(
+					"class-of-service scheduler-map %q forwarding-class %q references undefined scheduler %q",
+					schedMap.Name, className, entry.Scheduler)
+			}
+		}
+	}
+	return nil
+}
+
 // validateIPsecPolicyProposalReferencesStrict hard-rejects an IPsec
 // (Phase 2) policy whose `proposals` reference does not resolve to a
 // defined IPsec proposal (#2073). resolveESPSettings (pkg/ipsec/ike.go)

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -696,20 +696,21 @@ func ValidateConfig(cfg *Config) []string {
 			if schedMap == nil {
 				continue
 			}
-			for className, entry := range schedMap.Entries {
+			for className := range schedMap.Entries {
 				if _, ok := cos.ForwardingClasses[className]; !ok {
 					warnings = append(warnings, fmt.Sprintf(
 						"class-of-service scheduler-map %q references undefined forwarding-class %q",
 						schedMap.Name, className))
 				}
-				if entry == nil || entry.Scheduler == "" {
-					continue
-				}
-				if _, ok := cos.Schedulers[entry.Scheduler]; !ok {
-					warnings = append(warnings, fmt.Sprintf(
-						"class-of-service scheduler-map %q references undefined scheduler %q",
-						schedMap.Name, entry.Scheduler))
-				}
+				// A scheduler-map entry naming an undefined scheduler is no
+				// longer warn-only: validateClassOfServiceSchedulerMapRefsStrict
+				// hard-rejects it at strict commit / commit-check and downgrades
+				// it to a cfg.Warnings entry on the tolerant load / peer-sync
+				// paths (#1960). Leaving a parallel warning here would
+				// double-report it on the lenient path and duplicates a rule
+				// that now lives in one place, consistent with every other
+				// cross-reference gate (IPsec proposal, policy zone/scheduler,
+				// log-stream, feed-name), none of which warn from ValidateConfig.
 			}
 		}
 		for _, classifier := range cos.DSCPClassifiers {

--- a/pkg/config/parser_class_of_service_test.go
+++ b/pkg/config/parser_class_of_service_test.go
@@ -1002,10 +1002,15 @@ func TestValidateClassOfServiceWarnings(t *testing.T) {
             }
         }
     }
+    schedulers {
+        be-sched {
+            transmit-rate percent 10;
+        }
+    }
     scheduler-maps {
         edge-map {
             forwarding-class best-effort {
-                scheduler missing-sched;
+                scheduler be-sched;
             }
         }
     }
@@ -1045,8 +1050,15 @@ func TestValidateClassOfServiceWarnings(t *testing.T) {
 		t.Fatalf("compile error: %v", err)
 	}
 	warnings := strings.Join(cfg.Warnings, "\n")
-	if !strings.Contains(warnings, `scheduler-map "edge-map" references undefined scheduler "missing-sched"`) {
-		t.Fatalf("expected undefined scheduler warning, got: %s", warnings)
+	// A dangling scheduler reference in a scheduler-map is no longer
+	// warn-only: it is hard-rejected at strict commit
+	// (validateClassOfServiceSchedulerMapRefsStrict), covered by
+	// TestSchedulerMapDanglingSchedulerRejectedStrict. The scheduler-map
+	// above references the DEFINED scheduler "be-sched" so this
+	// warn-collection test still exercises the surviving warn-only refs
+	// (undefined forwarding-class + undefined classifier / rewrite refs).
+	if strings.Contains(warnings, `references undefined scheduler`) {
+		t.Fatalf("did not expect an undefined-scheduler warning for a defined scheduler, got: %s", warnings)
 	}
 	if !strings.Contains(warnings, `dscp classifier "edge-classifier" references undefined forwarding-class "missing-class"`) {
 		t.Fatalf("expected undefined forwarding-class warning, got: %s", warnings)
@@ -1074,6 +1086,88 @@ func TestValidateClassOfServiceWarnings(t *testing.T) {
 	}
 	if strings.Contains(warnings, "class-of-service shaping, classifier attachment, and dscp rewrite-rule attachment are only implemented in the userspace dataplane") {
 		t.Fatalf("unexpected dataplane warning for default userspace path: %s", warnings)
+	}
+}
+
+// TestSchedulerMapDanglingSchedulerRejectedStrict pins the #1960
+// strict-on-commit / lenient-on-load contract for a scheduler-map entry
+// that references an undefined scheduler. Before the gate the reference
+// was warn-only at commit and then fail-open in the dataplane (the class
+// silently lost its guarantee and won the maximum best-effort surplus
+// share). The strict commit path must now REJECT it; the tolerant load /
+// peer-sync path must DOWNGRADE it to a warning so an already-persisted
+// or peer-synced config still boots.
+func TestSchedulerMapDanglingSchedulerRejectedStrict(t *testing.T) {
+	const danglingRef = `class-of-service {
+    forwarding-classes {
+        queue 0 best-effort;
+        queue 1 ef;
+    }
+    schedulers {
+        ef-sched {
+            transmit-rate percent 30;
+            priority strict-high;
+        }
+    }
+    scheduler-maps {
+        edge-map {
+            forwarding-class ef {
+                scheduler ef-typo;
+            }
+        }
+    }
+    interfaces {
+        ge-0/0/1 {
+            unit 0 {
+                shaping-rate 10g;
+                scheduler-map edge-map;
+            }
+        }
+    }
+}
+`
+	compile := func(t *testing.T, input string) *ConfigTree {
+		t.Helper()
+		tree, errs := NewParser(input).Parse()
+		if len(errs) > 0 {
+			t.Fatalf("parse errors: %v", errs)
+		}
+		return tree
+	}
+
+	// Strict commit path rejects the dangling reference.
+	strictTree := compile(t, danglingRef)
+	_, err := CompileConfig(strictTree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a scheduler-map with a dangling scheduler reference; want rejection")
+	}
+	if !strings.Contains(err.Error(), `references undefined scheduler "ef-typo"`) {
+		t.Fatalf("strict error missing the dangling-scheduler substring: %q", err.Error())
+	}
+
+	// Tolerant load path downgrades to a warning and still compiles.
+	lenientTree := compile(t, danglingRef)
+	cfg, err := CompileConfigLenient(lenientTree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient rejected a persistable config with a dangling scheduler reference (#1960 brick): %v", err)
+	}
+	warnings := strings.Join(cfg.Warnings, "\n")
+	if !strings.Contains(warnings, "scheduler-map reference (downgraded to warning on tolerant path)") ||
+		!strings.Contains(warnings, `references undefined scheduler "ef-typo"`) {
+		t.Fatalf("lenient path missing the downgraded scheduler-map warning, got: %s", warnings)
+	}
+
+	// A valid scheduler reference is unchanged on BOTH paths.
+	validInput := strings.Replace(danglingRef, "scheduler ef-typo;", "scheduler ef-sched;", 1)
+	if _, err := CompileConfig(compile(t, validInput)); err != nil {
+		t.Fatalf("CompileConfig rejected a scheduler-map with a DEFINED scheduler: %v", err)
+	}
+	validCfg, err := CompileConfigLenient(compile(t, validInput))
+	if err != nil {
+		t.Fatalf("CompileConfigLenient rejected a valid scheduler-map: %v", err)
+	}
+	if strings.Contains(strings.Join(validCfg.Warnings, "\n"), "references undefined scheduler") {
+		t.Fatalf("unexpected undefined-scheduler warning for a defined scheduler: %v", validCfg.Warnings)
 	}
 }
 

--- a/pkg/dataplane/userspace/cos.go
+++ b/pkg/dataplane/userspace/cos.go
@@ -224,6 +224,27 @@ func buildClassOfServiceSnapshot(cfg *config.Config) *ClassOfServiceSnapshot {
 					)
 					continue
 				}
+				// A scheduler-map entry naming an undefined scheduler is
+				// hard-rejected at strict commit
+				// (validateClassOfServiceSchedulerMapRefsStrict) but a
+				// leniently-loaded / peer-synced config can still carry it
+				// (#1960). Unlike the undefined-forwarding-class case above we
+				// KEEP the entry on the wire so the class's queue stays
+				// materialized — dropping it would blackhole any traffic a
+				// classifier steers to the class's queue. The Rust helper
+				// applies the scheduler-unresolved SAFE default (minimal
+				// best-effort surplus weight, no guarantee), NOT the fail-open
+				// maximum share. Log a breadcrumb so the degraded shaping is
+				// visible in the daemon journal.
+				if entry.Scheduler != "" {
+					if _, ok := cos.Schedulers[entry.Scheduler]; !ok {
+						slog.Warn("cos scheduler-map references undefined scheduler; dataplane applies safe best-effort default (degraded shaping)",
+							"scheduler_map", schedMap.Name,
+							"forwarding_class", entry.ForwardingClass,
+							"scheduler", entry.Scheduler,
+						)
+					}
+				}
 				mapSnap.Entries = append(mapSnap.Entries, CoSSchedulerMapEntrySnapshot{
 					ForwardingClass: entry.ForwardingClass,
 					Scheduler:       entry.Scheduler,

--- a/userspace-dp/src/afxdp/forwarding_build/cos.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/cos.rs
@@ -304,6 +304,30 @@ pub(super) fn build_cos_iface_config(
                 });
             };
             let scheduler = tables.schedulers.get(&entry.scheduler).copied();
+            // A scheduler-map entry naming a scheduler that is NOT defined
+            // in `class-of-service schedulers` resolves to `None` here. The
+            // strict commit validator
+            // (validateClassOfServiceSchedulerMapRefsStrict, pkg/config)
+            // now hard-rejects such a reference, but a config persisted by
+            // an older binary — or peer-synced — can still carry it on the
+            // lenient load path (#1960 no-brick), so the dataplane must fail
+            // SAFE, not OPEN. Before this fix `None` fell through to
+            // `transmit_rate_bytes = iface.cos_shaping_rate_bytes_per_sec`
+            // (the WHOLE interface shaping rate), which drove
+            // `surplus_weight` to the MAX (16, cos_surplus_weight at the
+            // root rate): the class did not merely lose its guarantee, it
+            // silently won the LARGEST best-effort surplus share. Pin the
+            // queue to the minimal best-effort surplus weight (1) for an
+            // unresolved reference instead. The queue stays materialized
+            // under its real queue_id / forwarding_class so a classifier
+            // steering traffic to it still forwards (dropping the entry
+            // would blackhole that traffic) — it just never gets MORE than
+            // a plain best-effort class. `guarantee_enabled` stays false and
+            // priority stays "low" below, so no guarantee or priority is
+            // fabricated. A DEFINED scheduler that merely omits a
+            // transmit-rate keeps its `surplus_weight = 16` (scheduler is
+            // Some), unchanged.
+            let scheduler_unresolved = scheduler.is_none();
             let explicit_transmit_rate_bytes = scheduler.and_then(|sched| {
                 (sched.transmit_rate_bytes > 0).then_some(sched.transmit_rate_bytes)
             });
@@ -360,10 +384,17 @@ pub(super) fn build_cos_iface_config(
                 // equal_flow_enforcement; parsed above so an unknown
                 // non-empty value fails the snapshot closed.
                 equal_flow_target_policy,
-                surplus_weight: cos_surplus_weight(
-                    transmit_rate_bytes.max(1),
-                    iface.cos_shaping_rate_bytes_per_sec,
-                ),
+                surplus_weight: if scheduler_unresolved {
+                    // SAFE default for a dangling scheduler reference:
+                    // minimal best-effort surplus share, never the fail-open
+                    // maximum the whole-interface effective rate would derive.
+                    1
+                } else {
+                    cos_surplus_weight(
+                        transmit_rate_bytes.max(1),
+                        iface.cos_shaping_rate_bytes_per_sec,
+                    )
+                },
                 buffer_bytes: cos_scheduler_buffer_bytes(
                     scheduler,
                     burst_bytes,

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -808,6 +808,66 @@ fn build_cos_state_marks_no_rate_scheduler_map_queue_residual_only() {
 }
 
 #[test]
+fn build_cos_state_dangling_scheduler_reference_uses_safe_best_effort_default() {
+    // A scheduler-map entry naming a scheduler that is NOT defined (a
+    // commit-time typo, hard-rejected on the strict path but downgraded
+    // to a warning on the lenient load / peer-sync path, so it can still
+    // reach the dataplane) must fail SAFE, not OPEN. Before the fix the
+    // unresolved reference fell through to `transmit_rate_bytes = the
+    // whole interface shaping rate`, deriving `surplus_weight = 16` (the
+    // maximum) — the class did not merely lose its guarantee, it won the
+    // LARGEST best-effort surplus share. The queue must stay materialized
+    // (so a classifier steering traffic to its queue still forwards) but
+    // be pinned to the minimal best-effort surplus weight, with no
+    // guarantee and no fabricated priority.
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            ifindex: 9,
+            cos_shaping_rate_bytes_per_sec: 1_000_000,
+            cos_scheduler_map: "test-map".into(),
+            ..Default::default()
+        }],
+        class_of_service: Some(ClassOfServiceSnapshot {
+            forwarding_classes: vec![CoSForwardingClassSnapshot {
+                name: "ef".into(),
+                queue: 1,
+            }],
+            dscp_classifiers: vec![],
+            ieee8021_classifiers: vec![],
+            dscp_rewrite_rules: vec![],
+            // The referenced scheduler "ef-typo" is intentionally absent.
+            schedulers: vec![],
+            scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                name: "test-map".into(),
+                entries: vec![CoSSchedulerMapEntrySnapshot {
+                    forwarding_class: "ef".into(),
+                    scheduler: "ef-typo".into(),
+                }],
+            }],
+        }),
+        ..Default::default()
+    };
+
+    let state = build_cos_state(&snapshot);
+    let iface = state.interfaces.get(&9).expect("missing CoS interface");
+    // Queue stays materialized under its real queue id / class.
+    assert_eq!(iface.queues.len(), 1);
+    assert_eq!(iface.queues[0].queue_id, 1);
+    assert_eq!(iface.queues[0].forwarding_class, "ef");
+    // SAFE default: minimal best-effort surplus share, NOT the fail-open
+    // maximum (16) the whole-interface effective rate would have derived.
+    assert_eq!(
+        iface.queues[0].surplus_weight, 1,
+        "dangling scheduler reference must fail SAFE to the minimal best-effort surplus weight, not fail OPEN to the max"
+    );
+    // No guarantee, no exact, priority stays "low" (rank 5) — nothing is
+    // fabricated for the unresolved reference.
+    assert!(!iface.queues[0].guarantee_enabled);
+    assert!(!iface.queues[0].exact);
+    assert_eq!(iface.queues[0].priority, 5, "low priority rank");
+}
+
+#[test]
 fn build_cos_state_binds_dscp_classifier_to_usable_interface_queue_ids() {
     let snapshot = ConfigSnapshot {
         interfaces: vec![InterfaceSnapshot {


### PR DESCRIPTION
## Problem

A `class-of-service scheduler-maps <m> forwarding-class <fc> scheduler <name>`
entry that references a scheduler **not defined** under
`class-of-service schedulers` was only **warn-only at commit** and then
**failed OPEN in the Rust dataplane**. The class silently lost its scheduling
guarantee AND was handed the *largest* best-effort surplus share. Junos
hard-rejects an unresolved scheduler reference at commit.

Found by fable-review-166 (G-2); verified at origin/master `cb993896e`.

### Fail-open chain

1. `ValidateConfig` (`compiler_validate_warn.go`) only *warned*;
   `validateClassOfServiceStrict` did NOT reject (its scheduler-map loop only
   checks buffer-percent overcommit and `continue`s past an undefined
   scheduler). Commit succeeded.
2. The Go emitter (`pkg/dataplane/userspace/cos.go`) forwarded `entry.Scheduler`
   unconditionally.
3. The Rust builder (`forwarding_build/cos.rs`) resolved the dangling name to
   `None`, leaving `guarantee_enabled = false`, `transmit_rate_bytes = the whole
   interface shaping rate`, and `surplus_weight = 16` (the max —
   `cos_surplus_quantum_bytes` scales with it). The typo'd class won the
   *largest* best-effort share.

Contrast: a missing forwarding-**class** already hard-errors
`SchedulerMapUnknownClass` (fail-closed). Only the missing **scheduler**
silently defaulted.

## Fix (#1960 strict-on-commit / lenient-but-SAFE-on-load)

- **Go commit** — `validateClassOfServiceSchedulerMapRefsStrict` hard-rejects
  the dangling reference at strict commit / commit-check (mirrors
  `validatePolicySchedulerReferencesStrict`). Downgraded to a `cfg.Warnings`
  entry on the tolerant load / peer-sync paths (`lenientSchedulerMapRef`) so an
  older-binary / peer-synced config still boots. The redundant `ValidateConfig`
  scheduler warn is removed (single SSOT); the undefined-forwarding-class warn
  stays.
- **Rust dataplane** — an unresolved scheduler now pins the queue to the
  **minimal** best-effort surplus weight (1), not the whole-interface-rate
  maximum, while KEEPING the queue materialized under its real queue id /
  forwarding-class (dropping it — the undefined-forwarding-class treatment —
  would blackhole any traffic a classifier steers to the class's queue).
  `guarantee_enabled` stays false and priority stays `low`; nothing is
  fabricated. A defined scheduler that merely omits `transmit-rate` is unchanged
  (`surplus_weight = 16`).
- **Emitter** — a journal breadcrumb (`slog.Warn`) so degraded shaping of a
  leniently-loaded config is visible.

## Tests (RED-on-revert proven)

- `TestSchedulerMapDanglingSchedulerRejectedStrict` (`pkg/config`) — strict
  reject + lenient downgrade + valid-scheduler control. RED when the validator
  is neutered.
- `build_cos_state_dangling_scheduler_reference_uses_safe_best_effort_default`
  (`userspace-dp`) — queue materialized with `surplus_weight == 1`, no
  guarantee, low priority. RED when the whole-interface-rate derivation is
  restored (yields 16).

## Validation

- `go build ./...`, `go vet`, `gofmt` clean; `go test ./pkg/config/...
  ./pkg/dataplane/...` green.
- Full cargo suite green **except** the pre-existing, unrelated
  `event_stream::tests::test_paused_telemetry_eviction_does_not_poison_drain_2875`
  (confirmed failing on clean origin/master without this change; my diff is
  disjoint from `event_stream`).
- Docs updated: `docs/config-schema.md`, `docs/cos-traffic-shaping.md`.

Closes #4226

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi