### PR TITLE
class-of-service: add vSRX CoS show commands (show interfaces queue, show class-of-service classifier/scheduler-map/forwarding-class) — #4228 Gap 7

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-07-04 — #4228 Gap 7: vSRX CoS show commands
+
+- **Timestamp**: 2026-07-04
+  - **Action**: Added the four missing Junos-style CoS operational show
+    commands whose backing data already existed but had no operational-
+    tree surface (#4228 Gap 7, fable-review-166 G-8). Pure presentation
+    over existing data — `cfg.ClassOfService` (compiled config) and
+    `CoSQueueStatus` (userspace status) — no dataplane change, no new
+    gRPC RPC (reuses `ShowText`). Commands: `show interfaces queue
+    [<interface>]` (per-queue Queued/Transmitted/Dropped from
+    CoSQueueStatus), `show class-of-service classifier [name <n>] [type
+    <dscp|ieee-802.1>]` (code point as 6-bit/3-bit binary), `show
+    class-of-service scheduler-map [<name>]` (FC->scheduler bindings
+    resolved to rate/priority/buffer/exact + queue), and `show
+    class-of-service forwarding-class` (FC->queue table). Wired through
+    cmdtree (tab-completion + `?` help + DynamicFn names), the local CLI
+    (`pkg/cli`), the remote CLI (`cmd/cli`), and the gRPC `ShowText`
+    topics (`interfaces-queue`, `cos-classifier`, `cos-scheduler-map`,
+    `cos-forwarding-class`). `clear class-of-service statistics` DEFERRED
+    — no CoS-queue stat-reset RPC exists; filed as a follow-up.
+  - **File(s)**: pkg/dataplane/userspace/format/cos_show.go (new, four
+    formatters), pkg/dataplane/userspace/format/cos_show_test.go (new),
+    pkg/cmdtree/tree.go (+cosClassifierNames helper, show subtree
+    entries), pkg/cmdtree/tree_test.go, pkg/cli/cli_show_services.go,
+    pkg/cli/cli_show_interfaces.go, cmd/cli/show.go,
+    pkg/grpcapi/server_show.go, pkg/grpcapi/server_show_interfaces_text.go
+    (four handler methods), pkg/grpcapi/server_show_cos_gap7_test.go
+    (new), docs/cos-validation-notes.md.
+
 ## 2026-07-04 — #4217 / #4218 / #4219 / #4220 (fable-review-166 G-4 / G-3 / G-5 / G-1): CoS config-schema typing
 
 - **Timestamp**: 2026-07-04

--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -122,12 +122,47 @@ func (c *ctl) handleShow(args []string) error {
 		return nil
 
 	case "class-of-service":
-		if len(args) >= 2 && args[1] == "interface" {
-			topic := "class-of-service"
-			if len(args) >= 3 {
-				topic += ":" + args[2]
+		if len(args) >= 2 {
+			switch args[1] {
+			case "interface":
+				topic := "class-of-service"
+				if len(args) >= 3 {
+					topic += ":" + args[2]
+				}
+				return c.showText(topic)
+			case "classifier":
+				// #4228 Gap 7: encode optional `name <n>` / `type <t>`
+				// filters into the topic params.
+				var params []string
+				rest := args[2:]
+				for i := 0; i < len(rest); i++ {
+					switch rest[i] {
+					case "name":
+						if i+1 < len(rest) {
+							params = append(params, "name="+rest[i+1])
+							i++
+						}
+					case "type":
+						if i+1 < len(rest) {
+							params = append(params, "type="+rest[i+1])
+							i++
+						}
+					}
+				}
+				topic := "cos-classifier"
+				if len(params) > 0 {
+					topic += ":" + strings.Join(params, ",")
+				}
+				return c.showText(topic)
+			case "scheduler-map":
+				topic := "cos-scheduler-map"
+				if len(args) >= 3 {
+					topic += ":" + args[2]
+				}
+				return c.showText(topic)
+			case "forwarding-class":
+				return c.showText("cos-forwarding-class")
 			}
-			return c.showText(topic)
 		}
 		printRemoteTreeHelp("show class-of-service:", "show", "class-of-service")
 		return nil
@@ -1627,6 +1662,14 @@ func (c *ctl) showIPsec(args []string) error {
 }
 
 func (c *ctl) showInterfaces(args []string) error {
+	if len(args) > 0 && args[0] == "queue" {
+		// #4228 Gap 7: per-queue CoS statistics, optional interface filter.
+		selector := ""
+		if len(args) > 1 {
+			selector = args[1]
+		}
+		return c.showTextFiltered("interfaces-queue", selector)
+	}
 	if len(args) > 0 && args[0] == "tunnel" {
 		return c.showText("tunnels")
 	}

--- a/docs/cos-validation-notes.md
+++ b/docs/cos-validation-notes.md
@@ -16,6 +16,39 @@ exact, then 5203..5210 / 6203..6210 step through 3G, 6G, 9G, 12G, 15G,
 interface root shaper. Older measurements below may cite the pre-grid
 class names (`iperf-a`/`iperf-b`/`iperf-c`) and queue IDs.
 
+## vSRX CoS show commands (#4228 Gap 7)
+
+In addition to `show class-of-service interface` (the detailed per-queue
+runtime dump described below), xpf renders the four Junos-style CoS
+operational commands whose backing data already existed but had no
+operational-tree surface. All are pure presentation over existing data —
+`cfg.ClassOfService` (the compiled config) and `CoSQueueStatus` (the
+userspace status) — with no dataplane change:
+
+- `show interfaces queue [<interface>]` — per-egress-queue Queued /
+  Transmitted / Dropped counters, sourced from `CoSQueueStatus`
+  (`QueuedPackets/Bytes`, `DrainSentBytes`, the admission-drop counters).
+  Optional interface filter; a physical-name selector (`ge-0-0-2`)
+  matches the unit-qualified runtime label (`ge-0-0-2.80`).
+- `show class-of-service classifier [name <n>] [type <dscp|ieee-802.1>]`
+  — the configured classifiers, rendering the code point as 6-bit binary
+  (DSCP) or 3-bit binary (802.1p PCP), with forwarding-class and loss
+  priority (defaulting to `low` when the config omits it).
+- `show class-of-service scheduler-map [<name>]` — each scheduler-map's
+  forwarding-class -> scheduler bindings, resolved to the scheduler's
+  transmit rate, priority, buffer, and exact flag plus the mapped queue.
+- `show class-of-service forwarding-class` — the forwarding-class to
+  queue table (ID == queue, per the FC<->queue bijection).
+
+`clear class-of-service statistics` is deferred (#4228 Gap 7 note): the
+userspace CoS queue counters have no stat-reset RPC — they reset only on
+config change — so a reset path is a separate follow-up.
+
+Renderers live in `pkg/dataplane/userspace/format/cos_show.go` (the
+shared SSOT used by both the local CLI in `pkg/cli` and the gRPC
+`ShowText` path in `pkg/grpcapi`); the operational-tree entries and
+tab-completion are in `pkg/cmdtree/tree.go`.
+
 ## How to read admission drop counters live
 
 Since #724, `show class-of-service interface` renders three per-queue

--- a/pkg/cli/cli_show_interfaces.go
+++ b/pkg/cli/cli_show_interfaces.go
@@ -60,6 +60,15 @@ func (c *CLI) showTunnelInterfaces() error {
 }
 
 func (c *CLI) showInterfaces(args []string) error {
+	// Handle "show interfaces queue [<interface>]" sub-command (#4228 Gap 7)
+	if len(args) > 0 && args[0] == "queue" {
+		selector := ""
+		if len(args) > 1 {
+			selector = args[1]
+		}
+		return c.showInterfacesQueue(selector)
+	}
+
 	// Handle "show interfaces tunnel" sub-command
 	if len(args) > 0 && args[0] == "tunnel" {
 		return c.showTunnelInterfaces()

--- a/pkg/cli/cli_show_services.go
+++ b/pkg/cli/cli_show_services.go
@@ -21,15 +21,55 @@ import (
 // handleShowClassOfService dispatches `show class-of-service ...`
 // to the appropriate presenter.
 func (c *CLI) handleShowClassOfService(args []string) error {
-	if len(args) == 0 || args[0] != "interface" {
+	if len(args) == 0 {
 		cmdtree.PrintTreeHelp("show class-of-service:", operationalTree, "show", "class-of-service")
 		return nil
 	}
-	selector := ""
-	if len(args) > 1 {
-		selector = args[1]
+	switch args[0] {
+	case "interface":
+		selector := ""
+		if len(args) > 1 {
+			selector = args[1]
+		}
+		return c.showClassOfServiceInterface(selector)
+	case "classifier":
+		nameFilter, typeFilter := parseCoSClassifierArgs(args[1:])
+		fmt.Print(dpformat.FormatCoSClassifiers(c.store.ActiveConfig(), nameFilter, typeFilter))
+		return nil
+	case "scheduler-map":
+		name := ""
+		if len(args) > 1 {
+			name = args[1]
+		}
+		fmt.Print(dpformat.FormatCoSSchedulerMaps(c.store.ActiveConfig(), name))
+		return nil
+	case "forwarding-class":
+		fmt.Print(dpformat.FormatCoSForwardingClasses(c.store.ActiveConfig()))
+		return nil
+	default:
+		cmdtree.PrintTreeHelp("show class-of-service:", operationalTree, "show", "class-of-service")
+		return nil
 	}
-	return c.showClassOfServiceInterface(selector)
+}
+
+// parseCoSClassifierArgs extracts optional `name <n>` and `type <t>` filters
+// from `show class-of-service classifier` arguments.
+func parseCoSClassifierArgs(args []string) (nameFilter, typeFilter string) {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "name":
+			if i+1 < len(args) {
+				nameFilter = args[i+1]
+				i++
+			}
+		case "type":
+			if i+1 < len(args) {
+				typeFilter = args[i+1]
+				i++
+			}
+		}
+	}
+	return nameFilter, typeFilter
 }
 
 // handleShowServices dispatches `show services ...` to the appropriate
@@ -264,6 +304,17 @@ func (c *CLI) showClassOfServiceInterface(selector string) error {
 		status = &userspaceStatus
 	}
 	fmt.Print(dpformat.FormatCoSInterfaceSummary(cfg, status, selector))
+	return nil
+}
+
+// showInterfacesQueue renders `show interfaces queue [<interface>]` (#4228
+// Gap 7) from the live userspace CoS runtime snapshot.
+func (c *CLI) showInterfacesQueue(selector string) error {
+	var status *dpuserspace.ProcessStatus
+	if userspaceStatus, err := c.userspaceDataplaneStatus(); err == nil {
+		status = &userspaceStatus
+	}
+	fmt.Print(dpformat.FormatInterfacesQueue(status, selector))
 	return nil
 }
 

--- a/pkg/cmdtree/tree.go
+++ b/pkg/cmdtree/tree.go
@@ -173,6 +173,28 @@ var OperationalTree = map[string]*Node{
 		}},
 		"class-of-service": {Desc: "Show class-of-service information", Children: map[string]*Node{
 			"interface": {Desc: "Show per-interface CoS configuration"},
+			"classifier": {Desc: "Show configured CoS classifiers", DynamicFn: func(cfg *config.Config) []string {
+				return cosClassifierNames(cfg)
+			}, Children: map[string]*Node{
+				"name": {Desc: "Filter by classifier name", DynamicFn: func(cfg *config.Config) []string {
+					return cosClassifierNames(cfg)
+				}},
+				"type": {Desc: "Filter by code-point type", Children: map[string]*Node{
+					"dscp":       {Desc: "DSCP classifiers"},
+					"ieee-802.1": {Desc: "IEEE 802.1p classifiers"},
+				}},
+			}},
+			"scheduler-map": {Desc: "Show configured CoS scheduler-maps", DynamicFn: func(cfg *config.Config) []string {
+				if cfg == nil || cfg.ClassOfService == nil {
+					return nil
+				}
+				names := make([]string, 0, len(cfg.ClassOfService.SchedulerMaps))
+				for name := range cfg.ClassOfService.SchedulerMaps {
+					names = append(names, name)
+				}
+				return names
+			}},
+			"forwarding-class": {Desc: "Show the forwarding-class to queue table"},
 		}},
 		"configuration": {Desc: "Show active configuration", Children: map[string]*Node{
 			"applications":       {Desc: "Application protocol definitions"},
@@ -493,6 +515,16 @@ var OperationalTree = map[string]*Node{
 			"extensive":  {Desc: "Display extensive output"},
 			"statistics": {Desc: "Display statistics and detailed output"},
 			"tunnel":     {Desc: "Show tunnel interfaces"},
+			"queue": {Desc: "Show per-queue CoS statistics", DynamicFn: func(cfg *config.Config) []string {
+				if cfg == nil || cfg.Interfaces.Interfaces == nil {
+					return nil
+				}
+				names := make([]string, 0, len(cfg.Interfaces.Interfaces))
+				for name := range cfg.Interfaces.Interfaces {
+					names = append(names, name)
+				}
+				return names
+			}},
 		}},
 		"protocols": {Desc: "Show protocol information", Children: map[string]*Node{
 			"ospf": {Desc: "Show OSPF information", Children: map[string]*Node{
@@ -1471,6 +1503,23 @@ func KeysOf(m map[string]*Node) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// cosClassifierNames returns the configured CoS classifier names (DSCP and
+// IEEE-802.1p) for tab-completion of `show class-of-service classifier`.
+func cosClassifierNames(cfg *config.Config) []string {
+	if cfg == nil || cfg.ClassOfService == nil {
+		return nil
+	}
+	names := make([]string, 0,
+		len(cfg.ClassOfService.DSCPClassifiers)+len(cfg.ClassOfService.IEEE8021Classifiers))
+	for name := range cfg.ClassOfService.DSCPClassifiers {
+		names = append(names, name)
+	}
+	for name := range cfg.ClassOfService.IEEE8021Classifiers {
+		names = append(names, name)
+	}
+	return names
 }
 
 // FilterPrefix returns only items that start with the given prefix.

--- a/pkg/cmdtree/tree_test.go
+++ b/pkg/cmdtree/tree_test.go
@@ -115,3 +115,57 @@ func TestCompleteFromTree_RequestSystemDynamicDNS(t *testing.T) {
 		t.Fatalf("expected update/check completions under request system dynamic-dns, got %v", cands)
 	}
 }
+
+// #4228 Gap 7: the vSRX CoS show commands are registered in the operational
+// tree with tab-completion + descriptions.
+func TestCompleteFromTree_ShowClassOfServiceGap7(t *testing.T) {
+	cands := CompleteFromTree(OperationalTree, []string{"show", "class-of-service"}, "", nil)
+	for _, want := range []string{"interface", "classifier", "scheduler-map", "forwarding-class"} {
+		if !contains(cands, want) {
+			t.Fatalf("expected %q under show class-of-service, got %v", want, cands)
+		}
+	}
+
+	// classifier type filter completes to the two supported code-point types.
+	cands = CompleteFromTree(OperationalTree, []string{"show", "class-of-service", "classifier", "type"}, "", nil)
+	if !contains(cands, "dscp") || !contains(cands, "ieee-802.1") {
+		t.Fatalf("expected dscp/ieee-802.1 under classifier type, got %v", cands)
+	}
+
+	// Descriptions are present for the new leaves.
+	if got := LookupDesc([]string{"show", "class-of-service"}, "forwarding-class", false); got == "" {
+		t.Fatalf("missing description for show class-of-service forwarding-class")
+	}
+}
+
+func TestCompleteFromTree_ShowInterfacesQueueGap7(t *testing.T) {
+	cands := CompleteFromTree(OperationalTree, []string{"show", "interfaces"}, "", nil)
+	if !contains(cands, "queue") {
+		t.Fatalf("expected 'queue' under show interfaces, got %v", cands)
+	}
+}
+
+// The classifier/scheduler-map DynamicFn surface the configured names.
+func TestCompleteFromTree_ShowClassOfServiceDynamicNames(t *testing.T) {
+	cfg := &config.Config{
+		ClassOfService: &config.ClassOfServiceConfig{
+			DSCPClassifiers: map[string]*config.CoSDSCPClassifier{
+				"wan-classifier": {Name: "wan-classifier"},
+			},
+			IEEE8021Classifiers: map[string]*config.CoSIEEE8021Classifier{
+				"wan-pcp": {Name: "wan-pcp"},
+			},
+			SchedulerMaps: map[string]*config.CoSSchedulerMap{
+				"bandwidth-limit": {Name: "bandwidth-limit"},
+			},
+		},
+	}
+	cands := CompleteFromTree(OperationalTree, []string{"show", "class-of-service", "classifier"}, "", cfg)
+	if !contains(cands, "wan-classifier") || !contains(cands, "wan-pcp") {
+		t.Fatalf("expected configured classifier names, got %v", cands)
+	}
+	cands = CompleteFromTree(OperationalTree, []string{"show", "class-of-service", "scheduler-map"}, "", cfg)
+	if !contains(cands, "bandwidth-limit") {
+		t.Fatalf("expected configured scheduler-map name, got %v", cands)
+	}
+}

--- a/pkg/dataplane/userspace/format/cos_show.go
+++ b/pkg/dataplane/userspace/format/cos_show.go
@@ -1,0 +1,348 @@
+package format
+
+// #4228 Gap 7: Junos-style CoS `show` command formatters. These render the
+// four vSRX class-of-service operational commands whose backing data already
+// exists but had no operational-tree surface:
+//
+//   - `show interfaces queue [<interface>]`      (from CoSQueueStatus)
+//   - `show class-of-service classifier ...`     (from cfg.ClassOfService)
+//   - `show class-of-service scheduler-map [n]`  (from cfg.ClassOfService)
+//   - `show class-of-service forwarding-class`   (from cfg.ClassOfService)
+//
+// The renderers reuse the shared helpers in cos.go (formatCoSRate,
+// formatCoSBytes, emptyDash, yesNo). No dataplane change — the four commands
+// are pure presentation over data the config compiler and userspace status
+// already carry.
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/psaab/xpf/pkg/config"
+	userspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// FormatInterfacesQueue renders `show interfaces queue [<interface>]` from the
+// live userspace CoS runtime snapshot. Junos reports per-egress-queue Queued /
+// Transmitted / Dropped counters; xpf sources the equivalent fields from
+// CoSQueueStatus (QueuedPackets/Bytes, DrainSentBytes, the admission-drop
+// counters aggregated across worker instances by the Rust coordinator). An
+// empty selector renders every CoS interface reported by the dataplane.
+func FormatInterfacesQueue(status *userspace.ProcessStatus, selector string) string {
+	selector = strings.TrimSpace(selector)
+	if status == nil || len(status.CoSInterfaces) == 0 {
+		if selector == "" {
+			return "No class-of-service queues active\n"
+		}
+		return fmt.Sprintf("No class-of-service queues active on %s\n", selector)
+	}
+
+	ifaces := make([]userspace.CoSInterfaceStatus, 0, len(status.CoSInterfaces))
+	for _, iface := range status.CoSInterfaces {
+		if selector != "" && !cosInterfaceMatchesSelector(iface.InterfaceName, selector) {
+			continue
+		}
+		ifaces = append(ifaces, iface)
+	}
+	if len(ifaces) == 0 {
+		return fmt.Sprintf("No class-of-service queues active on %s\n", selector)
+	}
+	sort.Slice(ifaces, func(i, j int) bool { return ifaces[i].InterfaceName < ifaces[j].InterfaceName })
+
+	var b strings.Builder
+	for idx, iface := range ifaces {
+		if idx > 0 {
+			b.WriteString("\n")
+		}
+		name := iface.InterfaceName
+		if name == "" {
+			name = "-"
+		}
+		fmt.Fprintf(&b, "Physical interface: %s\n", name)
+		queues := append([]userspace.CoSQueueStatus(nil), iface.Queues...)
+		sort.Slice(queues, func(i, j int) bool { return queues[i].QueueID < queues[j].QueueID })
+		// vSRX egress-queue space is 3-bit (queue IDs 0..7); report the
+		// in-use count against that supported ceiling.
+		fmt.Fprintf(&b, "  Egress queues: 8 supported, %d in use\n", len(queues))
+		if len(queues) == 0 {
+			b.WriteString("  No egress queues\n")
+			continue
+		}
+		for _, q := range queues {
+			fmt.Fprintf(&b, "  Queue: %d, Forwarding classes: %s\n", q.QueueID, emptyDash(q.ForwardingClass))
+			b.WriteString("    Queued:\n")
+			fmt.Fprintf(&b, "      Packets              : %20d\n", q.QueuedPackets)
+			fmt.Fprintf(&b, "      Bytes                : %20d\n", q.QueuedBytes)
+			b.WriteString("    Transmitted:\n")
+			fmt.Fprintf(&b, "      Bytes                : %20d\n", q.DrainSentBytes)
+			b.WriteString("    Dropped:\n")
+			fmt.Fprintf(&b, "      Buffer-drop packets  : %20d\n", q.AdmissionBufferDrops)
+			fmt.Fprintf(&b, "      Flow-share packets   : %20d\n", q.AdmissionFlowShareDrops)
+			fmt.Fprintf(&b, "      ECN-marked packets   : %20d\n", q.AdmissionEcnMarked)
+		}
+	}
+	return b.String()
+}
+
+// cosInterfaceMatchesSelector matches a runtime CoS interface name against an
+// operator-supplied selector, tolerant of the vSRX-style name, its Linux
+// kernel name, and a physical-name prefix of a unit-qualified runtime label
+// (e.g. selector "ge-0-0-2" matches runtime "ge-0-0-2.80").
+func cosInterfaceMatchesSelector(name, selector string) bool {
+	if name == "" {
+		return false
+	}
+	if name == selector || config.LinuxIfName(name) == selector {
+		return true
+	}
+	return strings.HasPrefix(name, selector+".") ||
+		strings.HasPrefix(config.LinuxIfName(name), selector+".")
+}
+
+// FormatCoSClassifiers renders `show class-of-service classifier [name <n>]
+// [type <dscp|ieee-802.1>]` from the compiled classifiers. DSCP code points
+// render as 6-bit binary and 802.1p PCP as 3-bit binary, matching the vSRX
+// "Code point" column. A queue's loss priority defaults to "low" (the Junos
+// classifier default) when the config omits it.
+func FormatCoSClassifiers(cfg *config.Config, nameFilter, typeFilter string) string {
+	if cfg == nil || cfg.ClassOfService == nil {
+		return "No class-of-service classifiers configured\n"
+	}
+	cos := cfg.ClassOfService
+	nameFilter = strings.TrimSpace(nameFilter)
+	typeFilter = strings.TrimSpace(strings.ToLower(typeFilter))
+
+	type cpRow struct {
+		value uint16
+		bits  int
+		fc    string
+		lp    string
+	}
+	type classifierBlock struct {
+		name   string
+		cpType string
+		rows   []cpRow
+	}
+	var blocks []classifierBlock
+
+	if typeFilter == "" || typeFilter == "dscp" {
+		for _, name := range sortedMapKeys(cos.DSCPClassifiers) {
+			if nameFilter != "" && name != nameFilter {
+				continue
+			}
+			c := cos.DSCPClassifiers[name]
+			blk := classifierBlock{name: name, cpType: "dscp"}
+			for _, e := range c.Entries {
+				for _, dscp := range e.DSCPValues {
+					blk.rows = append(blk.rows, cpRow{
+						value: uint16(dscp),
+						bits:  6,
+						fc:    e.ForwardingClass,
+						lp:    lossPriorityOrDefault(e.LossPriority),
+					})
+				}
+			}
+			blocks = append(blocks, blk)
+		}
+	}
+	if typeFilter == "" || typeFilter == "ieee-802.1" {
+		for _, name := range sortedMapKeys(cos.IEEE8021Classifiers) {
+			if nameFilter != "" && name != nameFilter {
+				continue
+			}
+			c := cos.IEEE8021Classifiers[name]
+			blk := classifierBlock{name: name, cpType: "ieee-802.1"}
+			for _, e := range c.Entries {
+				for _, cp := range e.CodePoints {
+					blk.rows = append(blk.rows, cpRow{
+						value: uint16(cp),
+						bits:  3,
+						fc:    e.ForwardingClass,
+						lp:    lossPriorityOrDefault(e.LossPriority),
+					})
+				}
+			}
+			blocks = append(blocks, blk)
+		}
+	}
+
+	if len(blocks) == 0 {
+		if nameFilter != "" || typeFilter != "" {
+			return "No class-of-service classifier matches the given filter\n"
+		}
+		return "No class-of-service classifiers configured\n"
+	}
+
+	var b strings.Builder
+	for idx, blk := range blocks {
+		if idx > 0 {
+			b.WriteString("\n")
+		}
+		fmt.Fprintf(&b, "Classifier: %s, Code point type: %s\n", blk.name, blk.cpType)
+		sort.SliceStable(blk.rows, func(i, j int) bool { return blk.rows[i].value < blk.rows[j].value })
+		tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  Code point\tForwarding class\tLoss priority")
+		for _, r := range blk.rows {
+			fmt.Fprintf(tw, "  %s\t%s\t%s\n",
+				codePointBinary(r.value, r.bits), emptyDash(r.fc), r.lp)
+		}
+		_ = tw.Flush()
+	}
+	return b.String()
+}
+
+// FormatCoSSchedulerMaps renders `show class-of-service scheduler-map [<name>]`
+// from the compiled scheduler-maps, resolving each forwarding-class binding to
+// its scheduler knobs (transmit rate, priority, buffer, exact) and the queue
+// the forwarding class maps to.
+func FormatCoSSchedulerMaps(cfg *config.Config, nameFilter string) string {
+	if cfg == nil || cfg.ClassOfService == nil || len(cfg.ClassOfService.SchedulerMaps) == 0 {
+		return "No class-of-service scheduler-maps configured\n"
+	}
+	cos := cfg.ClassOfService
+	nameFilter = strings.TrimSpace(nameFilter)
+
+	var b strings.Builder
+	rendered := 0
+	for _, name := range sortedMapKeys(cos.SchedulerMaps) {
+		if nameFilter != "" && name != nameFilter {
+			continue
+		}
+		sm := cos.SchedulerMaps[name]
+		if rendered > 0 {
+			b.WriteString("\n")
+		}
+		rendered++
+		fmt.Fprintf(&b, "Scheduler map: %s\n", name)
+
+		type mapRow struct {
+			fc    string
+			queue int
+			hasQ  bool
+		}
+		rows := make([]mapRow, 0, len(sm.Entries))
+		for fc := range sm.Entries {
+			row := mapRow{fc: fc}
+			if class := cos.ForwardingClasses[fc]; class != nil {
+				row.queue = class.Queue
+				row.hasQ = true
+			}
+			rows = append(rows, row)
+		}
+		sort.Slice(rows, func(i, j int) bool {
+			if rows[i].hasQ != rows[j].hasQ {
+				return rows[i].hasQ // configured-queue rows first
+			}
+			if rows[i].hasQ && rows[i].queue != rows[j].queue {
+				return rows[i].queue < rows[j].queue
+			}
+			return rows[i].fc < rows[j].fc
+		})
+
+		tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  Forwarding class\tScheduler\tQueue\tPriority\tTransmit rate\tBuffer\tExact")
+		for _, row := range rows {
+			entry := sm.Entries[row.fc]
+			queue := "-"
+			if row.hasQ {
+				queue = strconv.Itoa(row.queue)
+			}
+			schedName := "-"
+			priority := "-"
+			rate := "-"
+			buffer := "-"
+			exact := "no"
+			if entry != nil {
+				schedName = emptyDash(entry.Scheduler)
+				if sched := cos.Schedulers[entry.Scheduler]; sched != nil {
+					if sched.Priority != "" {
+						priority = sched.Priority
+					}
+					rate = formatCoSRate(sched.TransmitRateBytes)
+					buffer = formatSchedulerBuffer(sched)
+					exact = yesNo(sched.TransmitRateExact)
+				}
+			}
+			fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				emptyDash(row.fc), schedName, queue, priority, rate, buffer, exact)
+		}
+		_ = tw.Flush()
+	}
+	if rendered == 0 {
+		return fmt.Sprintf("No class-of-service scheduler-map matches %s\n", nameFilter)
+	}
+	return b.String()
+}
+
+// FormatCoSForwardingClasses renders `show class-of-service forwarding-class`
+// — the forwarding-class -> queue table. xpf's forwarding-class ID is its
+// queue number (the FC<->queue bijection enforced by the compiler), so ID and
+// Queue render identically.
+func FormatCoSForwardingClasses(cfg *config.Config) string {
+	if cfg == nil || cfg.ClassOfService == nil || len(cfg.ClassOfService.ForwardingClasses) == 0 {
+		return "No class-of-service forwarding-classes configured\n"
+	}
+	classes := make([]*config.CoSForwardingClass, 0, len(cfg.ClassOfService.ForwardingClasses))
+	for _, c := range cfg.ClassOfService.ForwardingClasses {
+		classes = append(classes, c)
+	}
+	sort.Slice(classes, func(i, j int) bool {
+		if classes[i].Queue != classes[j].Queue {
+			return classes[i].Queue < classes[j].Queue
+		}
+		return classes[i].Name < classes[j].Name
+	})
+
+	var b strings.Builder
+	tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "Forwarding class\tID\tQueue")
+	for _, c := range classes {
+		fmt.Fprintf(tw, "%s\t%d\t%d\n", emptyDash(c.Name), c.Queue, c.Queue)
+	}
+	_ = tw.Flush()
+	return b.String()
+}
+
+// formatSchedulerBuffer renders a scheduler's buffer sizing for display: an
+// explicit byte size, the Junos percent form, or "-" when unset.
+func formatSchedulerBuffer(sched *config.CoSScheduler) string {
+	if sched == nil {
+		return "-"
+	}
+	if sched.BufferSizeBytes > 0 {
+		return formatCoSBytes(sched.BufferSizeBytes)
+	}
+	if sched.BufferSizePercent > 0 {
+		return strconv.FormatFloat(sched.BufferSizePercent, 'f', -1, 64) + "%"
+	}
+	return "-"
+}
+
+// codePointBinary renders a classifier code point as a fixed-width binary
+// string (6 bits for DSCP, 3 bits for IP precedence / 802.1p), matching the
+// vSRX "Code point" column.
+func codePointBinary(value uint16, bits int) string {
+	return fmt.Sprintf("%0*b", bits, value)
+}
+
+// lossPriorityOrDefault returns the configured loss priority, defaulting to
+// "low" (the Junos classifier default) when the config omits it.
+func lossPriorityOrDefault(lp string) string {
+	if strings.TrimSpace(lp) == "" {
+		return "low"
+	}
+	return lp
+}
+
+// sortedMapKeys returns the keys of a string-keyed map in sorted order.
+func sortedMapKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/dataplane/userspace/format/cos_show_test.go
+++ b/pkg/dataplane/userspace/format/cos_show_test.go
@@ -1,0 +1,202 @@
+package format
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	userspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// testCoSShowConfig extends the shared CoS fixture with classifiers and
+// rewrite rules so the show-command formatters have data to render.
+func testCoSShowConfig() *config.Config {
+	cfg := testCoSConfig()
+	cfg.ClassOfService.DSCPClassifiers = map[string]*config.CoSDSCPClassifier{
+		"wan-classifier": {
+			Name: "wan-classifier",
+			Entries: []*config.CoSDSCPClassifierEntry{
+				// Expedited-forwarding: DSCP 46 = 101110b.
+				{ForwardingClass: "bandwidth-10mb", LossPriority: "low", DSCPValues: []uint8{46}},
+				// Best-effort: DSCP 0 = 000000b, no explicit loss-priority.
+				{ForwardingClass: "best-effort", DSCPValues: []uint8{0}},
+			},
+		},
+	}
+	cfg.ClassOfService.IEEE8021Classifiers = map[string]*config.CoSIEEE8021Classifier{
+		"wan-pcp": {
+			Name: "wan-pcp",
+			Entries: []*config.CoSIEEE8021ClassifierEntry{
+				{ForwardingClass: "bandwidth-10mb", LossPriority: "high", CodePoints: []uint8{5}},
+			},
+		},
+	}
+	return cfg
+}
+
+func TestFormatInterfacesQueue(t *testing.T) {
+	status := &userspace.ProcessStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
+			{
+				InterfaceName: "reth0.80",
+				Queues: []userspace.CoSQueueStatus{
+					{
+						QueueID:              4,
+						ForwardingClass:      "bandwidth-10mb",
+						QueuedPackets:        12,
+						QueuedBytes:          6000,
+						DrainSentBytes:       48000,
+						AdmissionBufferDrops: 3,
+						AdmissionEcnMarked:   1,
+					},
+					{
+						QueueID:         0,
+						ForwardingClass: "best-effort",
+						QueuedPackets:   1,
+					},
+				},
+			},
+		},
+	}
+
+	out := FormatInterfacesQueue(status, "")
+	for _, want := range []string{
+		"Physical interface: reth0.80",
+		"Egress queues: 8 supported, 2 in use",
+		"Queue: 0, Forwarding classes: best-effort",
+		"Queue: 4, Forwarding classes: bandwidth-10mb",
+		"Buffer-drop packets  :                    3",
+		"ECN-marked packets   :                    1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in output:\n%s", want, out)
+		}
+	}
+	// Queues must render in ascending queue-id order (0 before 4).
+	if strings.Index(out, "Queue: 0,") > strings.Index(out, "Queue: 4,") {
+		t.Fatalf("queues rendered out of order:\n%s", out)
+	}
+}
+
+func TestFormatInterfacesQueueSelectorFilter(t *testing.T) {
+	status := &userspace.ProcessStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
+			{InterfaceName: "reth0.80", Queues: []userspace.CoSQueueStatus{{QueueID: 0}}},
+			{InterfaceName: "reth1.0", Queues: []userspace.CoSQueueStatus{{QueueID: 0}}},
+		},
+	}
+	// Physical-name selector matches the unit-qualified runtime interface.
+	out := FormatInterfacesQueue(status, "reth0")
+	if !strings.Contains(out, "reth0.80") || strings.Contains(out, "reth1.0") {
+		t.Fatalf("selector reth0 did not filter correctly:\n%s", out)
+	}
+	// No matching interface reports a scoped no-data message.
+	out = FormatInterfacesQueue(status, "ge-9-9-9")
+	if !strings.Contains(out, "No class-of-service queues active on ge-9-9-9") {
+		t.Fatalf("unexpected no-match output:\n%s", out)
+	}
+}
+
+func TestFormatInterfacesQueueNoStatus(t *testing.T) {
+	if got := FormatInterfacesQueue(nil, ""); !strings.Contains(got, "No class-of-service queues active") {
+		t.Fatalf("nil status: %q", got)
+	}
+}
+
+func TestFormatCoSClassifiers(t *testing.T) {
+	out := FormatCoSClassifiers(testCoSShowConfig(), "", "")
+	for _, want := range []string{
+		"Classifier: wan-classifier, Code point type: dscp",
+		"Classifier: wan-pcp, Code point type: ieee-802.1",
+		"Code point", "Forwarding class", "Loss priority",
+		"101110", // DSCP 46 as 6-bit binary
+		"000000", // DSCP 0 as 6-bit binary
+		"101",    // PCP 5 as 3-bit binary
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in output:\n%s", want, out)
+		}
+	}
+	// DSCP rows must sort by code-point value (0 before 46).
+	if strings.Index(out, "000000") > strings.Index(out, "101110") {
+		t.Fatalf("DSCP code points rendered out of order:\n%s", out)
+	}
+	// Missing loss-priority defaults to "low".
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "000000") {
+			if !strings.Contains(line, "low") {
+				t.Fatalf("best-effort row missing default loss-priority low: %q", line)
+			}
+		}
+	}
+}
+
+func TestFormatCoSClassifiersFilters(t *testing.T) {
+	cfg := testCoSShowConfig()
+
+	// type dscp excludes the ieee-802.1 classifier.
+	out := FormatCoSClassifiers(cfg, "", "dscp")
+	if !strings.Contains(out, "wan-classifier") || strings.Contains(out, "wan-pcp") {
+		t.Fatalf("type=dscp filter wrong:\n%s", out)
+	}
+
+	// name filter selects a single classifier.
+	out = FormatCoSClassifiers(cfg, "wan-pcp", "")
+	if strings.Contains(out, "wan-classifier") || !strings.Contains(out, "wan-pcp") {
+		t.Fatalf("name=wan-pcp filter wrong:\n%s", out)
+	}
+
+	// No match reports the filter message.
+	out = FormatCoSClassifiers(cfg, "nope", "")
+	if !strings.Contains(out, "No class-of-service classifier matches") {
+		t.Fatalf("expected no-match message, got:\n%s", out)
+	}
+}
+
+func TestFormatCoSSchedulerMaps(t *testing.T) {
+	out := FormatCoSSchedulerMaps(testCoSShowConfig(), "")
+	for _, want := range []string{
+		"Scheduler map: bandwidth-limit",
+		"Forwarding class", "Scheduler", "Queue", "Transmit rate", "Exact",
+		"best-effort", "bandwidth-10mb",
+		"10.00 Mb/s", // exact scheduler transmit rate
+		"yes",        // exact column for the 10mb scheduler
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in output:\n%s", want, out)
+		}
+	}
+	// Entries sort by queue id: best-effort (queue 0) before bandwidth-10mb (queue 4).
+	if strings.Index(out, "best-effort") > strings.Index(out, "bandwidth-10mb") {
+		t.Fatalf("scheduler-map rows out of order:\n%s", out)
+	}
+}
+
+func TestFormatCoSSchedulerMapsNameFilter(t *testing.T) {
+	cfg := testCoSShowConfig()
+	if got := FormatCoSSchedulerMaps(cfg, "missing"); !strings.Contains(got, "No class-of-service scheduler-map matches missing") {
+		t.Fatalf("name filter miss: %q", got)
+	}
+	if got := FormatCoSSchedulerMaps(&config.Config{}, ""); !strings.Contains(got, "No class-of-service scheduler-maps configured") {
+		t.Fatalf("empty cfg: %q", got)
+	}
+}
+
+func TestFormatCoSForwardingClasses(t *testing.T) {
+	out := FormatCoSForwardingClasses(testCoSShowConfig())
+	for _, want := range []string{
+		"Forwarding class", "ID", "Queue",
+		"best-effort", "bandwidth-10mb",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in output:\n%s", want, out)
+		}
+	}
+	// Sorted by queue: best-effort (0) before bandwidth-10mb (4).
+	if strings.Index(out, "best-effort") > strings.Index(out, "bandwidth-10mb") {
+		t.Fatalf("forwarding-class rows out of order:\n%s", out)
+	}
+	if got := FormatCoSForwardingClasses(&config.Config{}); !strings.Contains(got, "No class-of-service forwarding-classes configured") {
+		t.Fatalf("empty cfg: %q", got)
+	}
+}

--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -38,6 +38,20 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 		return s.showClassOfService(req, cfg, &buf)
 	}
 
+	// #4228 Gap 7: vSRX CoS show commands over existing data.
+	if req.Topic == "interfaces-queue" || strings.HasPrefix(req.Topic, "interfaces-queue:") {
+		return s.showInterfacesQueue(req, &buf)
+	}
+	if req.Topic == "cos-classifier" || strings.HasPrefix(req.Topic, "cos-classifier:") {
+		return s.showCoSClassifier(req, cfg, &buf)
+	}
+	if req.Topic == "cos-scheduler-map" || strings.HasPrefix(req.Topic, "cos-scheduler-map:") {
+		return s.showCoSSchedulerMap(req, cfg, &buf)
+	}
+	if req.Topic == "cos-forwarding-class" {
+		return s.showCoSForwardingClass(cfg, &buf)
+	}
+
 	if strings.HasPrefix(req.Topic, "screen-ids-option:") {
 		return s.showScreenIDSOption(req, cfg, &buf)
 	}

--- a/pkg/grpcapi/server_show_cos_gap7_test.go
+++ b/pkg/grpcapi/server_show_cos_gap7_test.go
@@ -1,0 +1,159 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #4228 Gap 7: the four vSRX CoS show commands dispatch through ShowText over
+// the compiled config (classifier/scheduler-map/forwarding-class) and the live
+// userspace status (interfaces queue).
+func newCoSGap7Server(t *testing.T) *Server {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	for _, cmd := range []string{
+		"class-of-service forwarding-classes queue 0 best-effort",
+		"class-of-service forwarding-classes queue 1 premium",
+		"class-of-service schedulers scheduler-be transmit-rate 1m",
+		"class-of-service schedulers scheduler-prem transmit-rate 100m exact",
+		"class-of-service scheduler-maps bandwidth-limit forwarding-class best-effort scheduler scheduler-be",
+		"class-of-service scheduler-maps bandwidth-limit forwarding-class premium scheduler scheduler-prem",
+		"class-of-service classifiers dscp wan-classifier forwarding-class premium loss-priority low code-points ef",
+		"class-of-service classifiers dscp wan-classifier forwarding-class best-effort loss-priority low code-points be",
+		"class-of-service classifiers ieee-802.1 wan-pcp forwarding-class premium loss-priority high code-points 5",
+	} {
+		if err := store.SetFromInput(cmd); err != nil {
+			t.Fatalf("SetFromInput(%q) error = %v", cmd, err)
+		}
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return &Server{
+		store: store,
+		dp: &firewallFilterShowUserspaceDP{
+			Manager: dataplane.New(),
+			status: dpuserspace.ProcessStatus{
+				CoSInterfaces: []dpuserspace.CoSInterfaceStatus{
+					{
+						InterfaceName: "reth0.80",
+						Queues: []dpuserspace.CoSQueueStatus{
+							{QueueID: 1, ForwardingClass: "premium", QueuedPackets: 9, DrainSentBytes: 4096, AdmissionBufferDrops: 2},
+							{QueueID: 0, ForwardingClass: "best-effort", QueuedPackets: 3},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestShowTextCoSForwardingClassGap7(t *testing.T) {
+	s := newCoSGap7Server(t)
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "cos-forwarding-class"})
+	if err != nil {
+		t.Fatalf("ShowText() error = %v", err)
+	}
+	out := resp.GetOutput()
+	for _, want := range []string{"Forwarding class", "best-effort", "premium"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output = %q, want %q", out, want)
+		}
+	}
+}
+
+func TestShowTextCoSSchedulerMapGap7(t *testing.T) {
+	s := newCoSGap7Server(t)
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "cos-scheduler-map"})
+	if err != nil {
+		t.Fatalf("ShowText() error = %v", err)
+	}
+	out := resp.GetOutput()
+	for _, want := range []string{"Scheduler map: bandwidth-limit", "scheduler-be", "scheduler-prem", "100.00 Mb/s"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output = %q, want %q", out, want)
+		}
+	}
+	// Name filter.
+	resp, err = s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "cos-scheduler-map:missing"})
+	if err != nil {
+		t.Fatalf("ShowText() error = %v", err)
+	}
+	if !strings.Contains(resp.GetOutput(), "No class-of-service scheduler-map matches missing") {
+		t.Fatalf("name filter output = %q", resp.GetOutput())
+	}
+}
+
+func TestShowTextCoSClassifierGap7(t *testing.T) {
+	s := newCoSGap7Server(t)
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "cos-classifier"})
+	if err != nil {
+		t.Fatalf("ShowText() error = %v", err)
+	}
+	out := resp.GetOutput()
+	for _, want := range []string{
+		"Classifier: wan-classifier, Code point type: dscp",
+		"Classifier: wan-pcp, Code point type: ieee-802.1",
+		"101110", // ef = DSCP 46
+		"101",    // PCP 5
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output = %q, want %q", out, want)
+		}
+	}
+
+	// type filter excludes the 802.1 classifier.
+	resp, err = s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "cos-classifier:type=dscp"})
+	if err != nil {
+		t.Fatalf("ShowText() error = %v", err)
+	}
+	if out := resp.GetOutput(); !strings.Contains(out, "wan-classifier") || strings.Contains(out, "wan-pcp") {
+		t.Fatalf("type=dscp output = %q", out)
+	}
+
+	// name filter selects a single classifier.
+	resp, err = s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "cos-classifier:name=wan-pcp"})
+	if err != nil {
+		t.Fatalf("ShowText() error = %v", err)
+	}
+	if out := resp.GetOutput(); strings.Contains(out, "wan-classifier,") || !strings.Contains(out, "wan-pcp") {
+		t.Fatalf("name=wan-pcp output = %q", out)
+	}
+}
+
+func TestShowTextInterfacesQueueGap7(t *testing.T) {
+	s := newCoSGap7Server(t)
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "interfaces-queue"})
+	if err != nil {
+		t.Fatalf("ShowText() error = %v", err)
+	}
+	out := resp.GetOutput()
+	for _, want := range []string{
+		"Physical interface: reth0.80",
+		"Queue: 0, Forwarding classes: best-effort",
+		"Queue: 1, Forwarding classes: premium",
+		"Egress queues: 8 supported, 2 in use",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output = %q, want %q", out, want)
+		}
+	}
+
+	// Filter carries the selector.
+	resp, err = s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "interfaces-queue", Filter: "reth9"})
+	if err != nil {
+		t.Fatalf("ShowText() error = %v", err)
+	}
+	if !strings.Contains(resp.GetOutput(), "No class-of-service queues active on reth9") {
+		t.Fatalf("selector filter output = %q", resp.GetOutput())
+	}
+}

--- a/pkg/grpcapi/server_show_interfaces_text.go
+++ b/pkg/grpcapi/server_show_interfaces_text.go
@@ -288,6 +288,64 @@ func (s *Server) showClassOfService(req *pb.ShowTextRequest, cfg *config.Config,
 	return &pb.ShowTextResponse{Output: buf.String()}, nil
 }
 
+// showInterfacesQueue renders `show interfaces queue [<interface>]` (#4228
+// Gap 7) from the live userspace CoS runtime snapshot. Topic form is
+// "interfaces-queue" or "interfaces-queue:<selector>".
+func (s *Server) showInterfacesQueue(req *pb.ShowTextRequest, buf *strings.Builder) (*pb.ShowTextResponse, error) {
+	selector := strings.TrimPrefix(req.Topic, "interfaces-queue")
+	selector = strings.TrimPrefix(selector, ":")
+	if selector == "" {
+		selector = req.Filter
+	}
+	var status *dpuserspace.ProcessStatus
+	if userspaceStatus, err := s.userspaceDataplaneStatus(); err == nil {
+		status = &userspaceStatus
+	}
+	buf.WriteString(dpformat.FormatInterfacesQueue(status, selector))
+	return &pb.ShowTextResponse{Output: buf.String()}, nil
+}
+
+// showCoSClassifier renders `show class-of-service classifier [name <n>]
+// [type <dscp|ieee-802.1>]` (#4228 Gap 7). Topic form is "cos-classifier" or
+// "cos-classifier:name=<n>,type=<t>".
+func (s *Server) showCoSClassifier(req *pb.ShowTextRequest, cfg *config.Config, buf *strings.Builder) (*pb.ShowTextResponse, error) {
+	nameFilter, typeFilter := "", ""
+	params := strings.TrimPrefix(req.Topic, "cos-classifier")
+	params = strings.TrimPrefix(params, ":")
+	for _, kv := range strings.Split(params, ",") {
+		kv = strings.TrimSpace(kv)
+		if kv == "" {
+			continue
+		}
+		if k, v, ok := strings.Cut(kv, "="); ok {
+			switch k {
+			case "name":
+				nameFilter = v
+			case "type":
+				typeFilter = v
+			}
+		}
+	}
+	buf.WriteString(dpformat.FormatCoSClassifiers(cfg, nameFilter, typeFilter))
+	return &pb.ShowTextResponse{Output: buf.String()}, nil
+}
+
+// showCoSSchedulerMap renders `show class-of-service scheduler-map [<name>]`
+// (#4228 Gap 7). Topic form is "cos-scheduler-map" or "cos-scheduler-map:<name>".
+func (s *Server) showCoSSchedulerMap(req *pb.ShowTextRequest, cfg *config.Config, buf *strings.Builder) (*pb.ShowTextResponse, error) {
+	name := strings.TrimPrefix(req.Topic, "cos-scheduler-map")
+	name = strings.TrimPrefix(name, ":")
+	buf.WriteString(dpformat.FormatCoSSchedulerMaps(cfg, name))
+	return &pb.ShowTextResponse{Output: buf.String()}, nil
+}
+
+// showCoSForwardingClass renders `show class-of-service forwarding-class`
+// (#4228 Gap 7) — the forwarding-class to queue table.
+func (s *Server) showCoSForwardingClass(cfg *config.Config, buf *strings.Builder) (*pb.ShowTextResponse, error) {
+	buf.WriteString(dpformat.FormatCoSForwardingClasses(cfg))
+	return &pb.ShowTextResponse{Output: buf.String()}, nil
+}
+
 func (s *Server) showVLANs(cfg *config.Config, buf *strings.Builder) {
 	if cfg == nil || len(cfg.Interfaces.Interfaces) == 0 {
 		buf.WriteString("No VLANs configured\n")


### PR DESCRIPTION
Addresses #4228 (Gap 7).

Implements the PLAN-READY-driveable half of #4228 Gap 7 (fable-review-166
G-8): the four Junos-style class-of-service operational `show` commands
whose backing data already existed but had no operational-tree surface.
Pure presentation over existing data — `cfg.ClassOfService` (the compiled
config) and `CoSQueueStatus` (the userspace status) — with **no dataplane
change** and **no new gRPC RPC** (reuses `ShowText`).

## Commands added

- **`show interfaces queue [<interface>]`** — per-egress-queue Queued /
  Transmitted / Dropped counters from `CoSQueueStatus`
  (`QueuedPackets/Bytes`, `DrainSentBytes`, the admission-drop counters).
  Optional interface filter; a physical-name selector (`ge-0-0-2`)
  matches the unit-qualified runtime label (`ge-0-0-2.80`).
- **`show class-of-service classifier [name <n>] [type <dscp|ieee-802.1>]`**
  — the configured classifiers, code point rendered as 6-bit binary
  (DSCP) or 3-bit binary (802.1p PCP), with forwarding-class and loss
  priority (defaulting to `low` when omitted).
- **`show class-of-service scheduler-map [<name>]`** — each
  scheduler-map's forwarding-class → scheduler bindings, resolved to the
  scheduler's transmit rate, priority, buffer, exact flag, and the mapped
  queue.
- **`show class-of-service forwarding-class`** — the forwarding-class →
  queue table (ID == queue, per the compiler-enforced FC↔queue bijection).

## Data sources reused

- `cfg.ClassOfService` — `ForwardingClasses`, `DSCPClassifiers`,
  `IEEE8021Classifiers`, `SchedulerMaps`, `Schedulers`.
- `CoSQueueStatus` / `CoSInterfaceStatus` (userspace status snapshot).

No new RPC — the four commands ride the existing `ShowText` RPC via new
topics (`interfaces-queue`, `cos-classifier`, `cos-scheduler-map`,
`cos-forwarding-class`).

## Wiring (SSOT)

- Renderers: `pkg/dataplane/userspace/format/cos_show.go` (shared by the
  local CLI and the gRPC path).
- Operational tree + tab-completion + `?` help + DynamicFn name
  completion: `pkg/cmdtree/tree.go`.
- Local CLI: `pkg/cli/cli_show_services.go`,
  `pkg/cli/cli_show_interfaces.go`.
- Remote CLI: `cmd/cli/show.go`.
- gRPC: `pkg/grpcapi/server_show.go` +
  `pkg/grpcapi/server_show_interfaces_text.go`.

## Deferred

- **`clear class-of-service statistics`** — no CoS-queue stat-reset RPC
  exists (counters reset only on config change); a reset path is a
  separate follow-up, per the #4228 Gap 7 disposition.

## Tests

- `format/cos_show_test.go` — unit tests for the four formatters
  (content, sort order, binary code-point encoding, default loss
  priority, filters, empty/no-match messages).
- `cmdtree/tree_test.go` — new commands register with completion +
  descriptions, plus DynamicFn name completion.
- `grpcapi/server_show_cos_gap7_test.go` — end-to-end `ShowText` dispatch
  for all four topics over a compiled config + userspace status fixture.

`go build ./...`, `go test ./pkg/cmdtree/... ./pkg/cli/... ./pkg/grpcapi/...
./pkg/dataplane/userspace/format/...`, gofmt, and vet are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi