### PR TITLE
test/incus: make CoS smoke gates actually fail (hb166 V-1/V-2/V-11)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -34593,3 +34593,10 @@ top.
   ./pkg/config/... + gofmt + vet all green.
 - **File(s)**: pkg/config/compiler_validate_warn.go, docs/feature-gaps.md,
   docs/feature-coverage.md, CLAUDE.md, _Log.md
+- **Timestamp**: 2026-07-04
+- **Action**: hb166 V-1 — wire cos-simul-load-smoke.sh reducer to exit
+  nonzero on gate failure (was always exit 0 = false-green). Added a
+  heterogeneous-gate `_ok` extractor + `sys.exit`, an all-error length
+  guard on gate_1, a gate_0 generator-health check, and replaced the
+  `|| true` iperf launchers with per-port .rc capture. Closes #4239.
+- **File(s)**: test/incus/cos-simul-load-smoke.sh, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -34616,3 +34616,18 @@ top.
   new harness exit-code contract in docs/fairness-regimes.md. Closes #4241.
 - **File(s)**: test/incus/fairness-harness.sh, docs/fairness-regimes.md,
   _Log.md
+
+- **Timestamp**: 2026-07-04
+- **Action**: hb166 V-1 Copilot fold (PR #4242) — close the gate_0
+  row-readability hole. gate_0 previously checked only the per-port .rc
+  EXIT CODE, so an iperf3 run that exits 0 yet emits an {"error": ...} or
+  truncated JSON payload passed gate_0; if no throughput floor read that
+  class (a mid-class parse error), the whole harness still exited 0.
+  Extended the existing parse loop to tag each row with gen_error
+  (iperf-error / truncated — using bits_per_second key MEMBERSHIP so a
+  genuinely 0-Gbps but complete row is NOT flagged), and gate_0 now fails
+  on nonzero/missing rc OR unparseable/iperf-error/truncated row. Reused
+  the existing per-port parse (no duplicate parse logic). RED-on-revert:
+  the rc-only gate_0 passes both garbage inputs. Closes the Copilot gap.
+- **File(s)**: test/incus/cos-simul-load-smoke.sh, docs/fairness-regimes.md,
+  _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -34607,3 +34607,12 @@ top.
   all_pass else 1), per-port .rc generator-health capture, replaced
   `|| true` launchers. Closes #4240.
 - **File(s)**: test/incus/cos-gate1-small-four-alone.sh, _Log.md
+
+- **Timestamp**: 2026-07-04
+- **Action**: hb166 V-11 — fairness-harness.sh single mode now fails hard
+  (exit 2) on a port with no canonical shaper rate, mirroring the
+  mixed-cos branch, instead of silently defaulting SHAPER_RATE_BPS=25G
+  (which masked a misconfigured port as a 25G-cap pass). Documented the
+  new harness exit-code contract in docs/fairness-regimes.md. Closes #4241.
+- **File(s)**: test/incus/fairness-harness.sh, docs/fairness-regimes.md,
+  _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -34600,3 +34600,10 @@ top.
   guard on gate_1, a gate_0 generator-health check, and replaced the
   `|| true` iperf launchers with per-port .rc capture. Closes #4239.
 - **File(s)**: test/incus/cos-simul-load-smoke.sh, _Log.md
+
+- **Timestamp**: 2026-07-04
+- **Action**: hb166 V-2 — wire cos-gate1-small-four-alone.sh reducer to
+  exit nonzero on GATE1 FAIL (was always exit 0). Added sys.exit(0 if
+  all_pass else 1), per-port .rc generator-health capture, replaced
+  `|| true` launchers. Closes #4240.
+- **File(s)**: test/incus/cos-gate1-small-four-alone.sh, _Log.md

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -1411,6 +1411,16 @@ with per-class achievement, CoV, retransmits, and gate booleans.
 This is now part of the canonical smoke matrix for any PR that
 touches CoS scheduling.
 
+**Exit-code contract (#4239/#4240):** the reducer propagates the gate
+verdict as the process exit status — the script exits **0 only when
+every gate passes**, and **nonzero on any gate failure** (a starved
+class, a missing/errored generator, or a nonzero iperf3 rc). Both
+`cos-simul-load-smoke.sh` and the SOLO `cos-gate1-small-four-alone.sh`
+follow this contract, so `&&`-chained or CI invocation fails loudly
+instead of passing on a printed `FAIL`. The generators no longer swallow
+failures with `|| true`: each writes a per-port `.rc` sidecar and a
+nonzero (or missing) rc is a hard gate failure.
+
 ### Bit-for-bit preservation of proportional mode
 
 When `oversubscription-policy` is unset (or set to `proportional`)

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -1418,8 +1418,10 @@ class, a missing/errored generator, or a nonzero iperf3 rc). Both
 `cos-simul-load-smoke.sh` and the SOLO `cos-gate1-small-four-alone.sh`
 follow this contract, so `&&`-chained or CI invocation fails loudly
 instead of passing on a printed `FAIL`. The generators no longer swallow
-failures with `|| true`: each writes a per-port `.rc` sidecar and a
-nonzero (or missing) rc is a hard gate failure.
+failures with `|| true`: each writes a per-port `.rc` sidecar, and
+`gate_0` fails on a nonzero (or missing) rc **or** on a rc==0 run that
+emitted an unparseable, `{"error": ...}`, or truncated JSON payload —
+even for a class no throughput floor reads.
 
 ### Bit-for-bit preservation of proportional mode
 

--- a/test/incus/cos-gate1-small-four-alone.sh
+++ b/test/incus/cos-gate1-small-four-alone.sh
@@ -33,8 +33,10 @@ echo "#1630 Gate1 small-four-alone: dir=$DIRECTION af=$AF target=$TARGET dur=${D
 declare -a PIDS=()
 for port in "${PORTS[@]}"; do
   (
+    rc=0
     sg incus-admin -c "incus exec $HOST -- iperf3 -c $TARGET -P $STREAMS -t $DURATION -p $port $REV_FLAG --json" \
-      > "$ART/g1_${port}.json" 2>"$ART/g1_${port}.err" || true
+      > "$ART/g1_${port}.json" 2>"$ART/g1_${port}.err" || rc=$?
+    echo "$rc" > "$ART/g1_${port}.rc"
   ) &
   PIDS+=($!)
 done
@@ -49,6 +51,18 @@ shape = {5201: 0.1, 5202: 1.0, 5203: 3.0, 5204: 6.0}
 rows = []
 all_pass = True
 for p in ports:
+    # Generator health: a crashed or unlaunched iperf3 sender leaves a
+    # nonzero (or missing) .rc sidecar. Treat it as a hard failure — do
+    # not read a stale/partial JSON as a pass (#4240 V-2).
+    rcf = os.path.join(art, f"g1_{p}.rc")
+    try:
+        rc = int(open(rcf).read().strip())
+    except Exception:
+        rc = 1  # missing/unreadable .rc == generator never completed
+    if rc != 0:
+        rows.append((p, names[p], shape[p], None, None, f"ERR generator rc={rc}"))
+        all_pass = False
+        continue
     f = os.path.join(art, f"g1_{p}.json")
     try:
         d = json.load(open(f))
@@ -71,4 +85,10 @@ for p, n, sh, recv, pct, v in rows:
     else:
         print(f"{p:<6}{n:<14}{sh:>6.2f}G {recv:>7.2f}G {pct:>7.1f}%  {v}")
 print(f"\nGATE1 {'PASS' if all_pass else 'FAIL'} (all four >= 95% of shape)")
+# Propagate the verdict as the process exit status. Under `set -euo
+# pipefail` this heredoc is the last command, so a nonzero exit here
+# becomes the script's exit status. A JSON parse error or a nonzero
+# generator rc already flips all_pass, so malformed/missing output
+# correctly yields exit 1 (#4240 V-2).
+sys.exit(0 if all_pass else 1)
 PYEOF

--- a/test/incus/cos-simul-load-smoke.sh
+++ b/test/incus/cos-simul-load-smoke.sh
@@ -136,6 +136,19 @@ for port in ports:
     # is always zero for the retransmit field in iperf3 JSON).
     sum_received = d.get("end", {}).get("sum_received") or {}
     sum_sent = d.get("end", {}).get("sum_sent") or {}
+    # gate_0 readability: an iperf3 run can exit rc==0 yet emit a payload
+    # that is useless to the gates — a top-level {"error": ...} object, or
+    # a result truncated before the end/sum row was written. Flag it here,
+    # reusing this single parse, so gate_0 can fail on it even for a class
+    # no throughput floor reads. A legitimately starved-to-zero class still
+    # carries bits_per_second (value 0), so key MEMBERSHIP — not truthiness
+    # — distinguishes "0 Gbps" from "no result row" (#4239 V-1 Copilot
+    # row-readability follow-up).
+    gen_error = None
+    if d.get("error"):
+        gen_error = "iperf-error"
+    elif not (("bits_per_second" in sum_received) or ("bits_per_second" in sum_sent)):
+        gen_error = "truncated"
     recv_gbps = (sum_received.get("bits_per_second") or
                  sum_sent.get("bits_per_second") or 0) / 1e9
     retr = sum_sent.get("retransmits", 0) or 0
@@ -150,6 +163,7 @@ for port in ports:
         "cov_pct": round(cov, 1),
         "spread": round(spread, 2) if spread != float("inf") else None,
         "retransmits": retr,
+        "gen_error": gen_error,
     })
     total_recv += recv_gbps
     total_retr += retr
@@ -169,21 +183,35 @@ print(f"{'':<6} {'Sum':<16} {'':>7} {total_recv:>6.2f}G")
 # Gate verdict.
 verdict = {"direction": direction, "aggregate_gbps": round(total_recv, 3), "rows": rows}
 gates = {}
-# Gate 0 (both directions): every generator exited 0. A crashed or
-# unlaunched iperf3 sender leaves a nonzero (or missing) .rc sidecar; a
-# generator failure must be a hard fail, not a silent pass. Rows that
-# error on JSON parse are ALSO caught by the per-gate floors below, but
-# this makes a middle-class generator failure (a class no floor reads)
-# fail too (#4239 V-1).
+# Gate 0 (both directions): every generator both exited 0 AND produced a
+# parseable, error-free, complete JSON result. Two independent failure
+# modes must both trip:
+#   - a crashed/unlaunched sender leaves a nonzero (or missing) .rc; and
+#   - a sender that exits rc==0 can still emit an unparseable, {"error":
+#     ...}, or truncated payload (gen_error set during parse above).
+# Checking the rc alone would let a middle-class garbage payload — a class
+# no throughput floor reads — sail through, defeating the whole point of
+# this harness (#4239 V-1 + Copilot row-readability follow-up).
 gen_failures = []
+rows_by_port = {r["port"]: r for r in rows}
 for port in ports:
     rcf = os.path.join(art_dir, f"sim_{port}.rc")
     try:
         rc = int(open(rcf).read().strip())
     except Exception:
         rc = 1  # missing/unreadable .rc == generator never completed
+    reasons = []
     if rc != 0:
-        gen_failures.append({"port": port, "class": class_names[port], "rc": rc})
+        reasons.append(f"rc={rc}")
+    row = rows_by_port.get(port)
+    if row is None:
+        reasons.append("no-row")
+    elif "error" in row:
+        reasons.append("unparseable")  # json.load raised on this port
+    elif row.get("gen_error"):
+        reasons.append(row["gen_error"])  # rc==0 but iperf-error / truncated
+    if reasons:
+        gen_failures.append({"port": port, "class": class_names[port], "reasons": reasons})
 gates["gate_0_generators_healthy"] = {
     "failures": gen_failures,
     "pass": len(gen_failures) == 0,

--- a/test/incus/cos-simul-load-smoke.sh
+++ b/test/incus/cos-simul-load-smoke.sh
@@ -71,12 +71,17 @@ fi
 sg incus-admin -c "incus exec $HOST -- mpstat -P ALL 1 $DURATION" > "$ART/mpstat.txt" 2>&1 &
 MPSTAT_PID=$!
 
-# Launch the 11 iperf3 senders in parallel.
+# Launch the 11 iperf3 senders in parallel. Capture each generator's exit
+# code to a .rc sidecar (instead of swallowing it with `|| true`) so the
+# reducer can fail hard on a generator failure — a crashed or unlaunched
+# sender must not read as a silent pass (#4239 V-1).
 declare -a IPERF_PIDS=()
 for port in "${PORTS[@]}"; do
   (
+    rc=0
     sg incus-admin -c "incus exec $HOST -- iperf3 -c $TARGET_V4 -P $STREAMS -t $DURATION -p $port $REV_FLAG --json" \
-      > "$ART/sim_${port}.json" 2>"$ART/sim_${port}.err" || true
+      > "$ART/sim_${port}.json" 2>"$ART/sim_${port}.err" || rc=$?
+    echo "$rc" > "$ART/sim_${port}.rc"
   ) &
   IPERF_PIDS+=($!)
 done
@@ -164,6 +169,25 @@ print(f"{'':<6} {'Sum':<16} {'':>7} {total_recv:>6.2f}G")
 # Gate verdict.
 verdict = {"direction": direction, "aggregate_gbps": round(total_recv, 3), "rows": rows}
 gates = {}
+# Gate 0 (both directions): every generator exited 0. A crashed or
+# unlaunched iperf3 sender leaves a nonzero (or missing) .rc sidecar; a
+# generator failure must be a hard fail, not a silent pass. Rows that
+# error on JSON parse are ALSO caught by the per-gate floors below, but
+# this makes a middle-class generator failure (a class no floor reads)
+# fail too (#4239 V-1).
+gen_failures = []
+for port in ports:
+    rcf = os.path.join(art_dir, f"sim_{port}.rc")
+    try:
+        rc = int(open(rcf).read().strip())
+    except Exception:
+        rc = 1  # missing/unreadable .rc == generator never completed
+    if rc != 0:
+        gen_failures.append({"port": port, "class": class_names[port], "rc": rc})
+gates["gate_0_generators_healthy"] = {
+    "failures": gen_failures,
+    "pass": len(gen_failures) == 0,
+}
 if direction == "reverse":
     # Phase 0 / R8 gate 8: aggregate ≥ 22 G means firewall (not generator) is the bottleneck.
     gates["gate_8_reverse_simul_22g"] = total_recv >= 22.0
@@ -208,7 +232,11 @@ else:
                       "NOT the >=95% guarantee (SOLO-only via #1630 "
                       "cos-gate1-small-four-alone.sh; 3g/6g guarantee = #1692)"),
         "classes": gate1_classes,
-        "pass": all(c["pass"] for c in gate1_classes),
+        # `all([]) == True`: if EVERY small-class row errored, gate1_classes
+        # is empty and would vacuously pass. Require the full expected set
+        # (#4239 V-1 all-error guard).
+        "pass": (all(c["pass"] for c in gate1_classes)
+                 and len(gate1_classes) == len(SIMUL_FLOOR_PCT)),
     }
     # Gate 2: priority-low ≥ 5% of cluster ceiling.
     ceiling = 18.0
@@ -230,4 +258,21 @@ with open(verdict_path, "w") as f:
     json.dump(verdict, f, indent=2)
 print(f"\nVerdict written: {verdict_path}")
 print(json.dumps(gates, indent=2))
+
+# Propagate the verdict as the process exit status. Gates are
+# HETEROGENEOUS: dict gates carry a "pass" key; bare-bool gates are
+# themselves the verdict. A naive `all(gates.values())` is WRONG — a
+# failing DICT gate is still truthy as a raw dict. Under `set -euo
+# pipefail` this heredoc is the LAST command, so a nonzero exit here
+# becomes the script's exit status with no extra bash wiring (#4239 V-1).
+def _ok(v):
+    return v["pass"] if isinstance(v, dict) else bool(v)
+
+
+failed = [name for name, v in gates.items() if not _ok(v)]
+if failed:
+    print(f"\nFAIL: gates not satisfied: {', '.join(failed)}")
+    sys.exit(1)
+print("\nPASS: all gates satisfied")
+sys.exit(0)
 PYEOF

--- a/test/incus/fairness-harness.sh
+++ b/test/incus/fairness-harness.sh
@@ -224,8 +224,13 @@ if [[ "$MIXED_COS" -eq 1 ]]; then
     fi
 else
     if [[ -z "$SHAPER_RATE_BPS" ]]; then
+        # Mirror the mixed-cos branch: a port with no canonical shaper rate
+        # is a misconfiguration, NOT a 25G-capped class. Silently defaulting
+        # to 25G masked a bad PORT as a pass against the largest cap; fail
+        # hard instead and require an explicit rate (#4241 V-11).
         if ! SHAPER_RATE_BPS=$(canonical_shaper_rate_for_port "$PORT"); then
-            SHAPER_RATE_BPS=25000000000
+            echo "fairness-harness: cannot infer SHAPER_RATE_BPS for PORT=$PORT; set SHAPER_RATE_BPS explicitly" >&2
+            exit 2
         fi
     fi
 fi


### PR DESCRIPTION
## Summary

fable-review-166 flagged three CoS validation-harness integrity defects —
smoke gates that can **never fail**, so the fairness contract they claim to
enforce is a false-green. This PR wires the exit statuses so a real
regression fails loudly.

- **Closes #4239 (V-1)** — `cos-simul-load-smoke.sh` (the only harness
  asserting the #1614 divided-ceiling floors under full-11 simul) computed
  the gate booleans, wrote `verdict.json`, printed them, and ended at
  `PYEOF` with no `sys.exit`. Under `set -euo pipefail` it always exited 0,
  so a starve-to-zero collapse of the small classes printed FAIL yet passed.
- **Closes #4240 (V-2)** — `cos-gate1-small-four-alone.sh` (the only machine
  assertion of the #1630 SOLO >=95% small-class guarantee) had the identical
  defect: printed `GATE1 FAIL`, exited 0.
- **Closes #4241 (V-11)** — `fairness-harness.sh` single mode silently
  defaulted `SHAPER_RATE_BPS=25G` for unknown ports, masking a misconfigured
  port as a 25G-cap pass; the mixed-cos branch already `exit 2`s.

## Changes

- `cos-simul-load-smoke.sh`: heterogeneous-gate `_ok` extractor
  (dict gates carry `"pass"`; bare bools are the verdict — a naive
  `all(gates.values())` is wrong since a failing dict is truthy) +
  `sys.exit`; a `gate_1` all-error length guard (`all([]) == True`
  vacuous pass); a `gate_0` generator-health check; per-port `.rc`
  capture replacing the `|| true` launchers.
- `cos-gate1-small-four-alone.sh`: `sys.exit(0 if all_pass else 1)` +
  per-port `.rc` generator health + `|| true` hardening.
- `fairness-harness.sh`: single mode `exit 2` on unknown port, mirroring
  the mixed-cos branch.
- `docs/fairness-regimes.md`: documents the newly-enforced exit-code
  contract.

## Validation

Extracted each reducer and ran it standalone against synthetic art dirs:

- **V-1**: PASS input exits 0; starve-to-zero (`gate_1`), middle-class
  generator crash (`gate_0`), and all-small-class-JSON-missing (all-error
  guard) each exit 1. **RED-on-revert**: the `origin/master` reducer exits
  0 on the starve-to-zero input.
- **V-2**: all-at-shape exits 0; 50%-of-shape, generator crash, missing
  JSON each exit 1. **RED-on-revert**: original exits 0 on 50%-of-shape.
- **V-11**: unknown `PORT=9999` exits 2 with diagnostic; known `PORT=5203`
  exits 0 (rate unchanged). **RED-on-revert**: original exits 0 with a
  silent 25G default.

`bash -n` clean on all three scripts; `shellcheck` introduces no new
findings (two pre-existing SC2034 on `cos-simul-load-smoke.sh` unused
bash-side maps; identical shellcheck code-count on `fairness-harness.sh`
vs `origin/master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
