### PR TITLE
CoS validation-harness fixes: give-back handback cross-checks, smoke CoV SSOT alignment, minor cleanups (hb166 V-8/V-10/V-12)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,27 @@
+## 2026-07-04 — hb166 V-8: surplus give-back handback series cross-checks
+
+- **Timestamp**: 2026-07-04
+- **Action**: hb166 V-8 — fairness_surplus_giveback_validate.py accepted the
+  first list-order sample matching the post-handback thresholds with no
+  monotonic-t_sec check, no pre-handback baseline, and no density
+  requirement, so a one-element artifact with a single settled snapshot
+  trivially passed the <=5s handback gate on a self-attested t_sec.
+  Hardened _handback_from_samples to require >=min_handback_samples
+  (default 2), strictly increasing t_sec, consecutive gaps within
+  max_handback_sample_gap_sec (default 5s), and a pre-handback baseline
+  before the first post-handback sample; the handback time is derived as
+  the first post-handback sample following a pre-handback one. Added CLI
+  flags --min-handback-samples / --max-handback-sample-gap-sec and 4 unit
+  tests (single-sample, non-monotonic, no-pre-baseline, too-sparse).
+  Documented that timestamps remain generator-supplied (the ordered-series
+  is the auditability bound in a reduced artifact) and that NO live runner
+  produces phases.json yet — the validator is a MANUAL gate until a live
+  reducer is built (deferred half of V-8). Updated docs/fairness-regimes.md
+  and the validator docstring. Closes #4248.
+- **File(s)**: test/incus/fairness_surplus_giveback_validate.py,
+  test/incus/fairness_surplus_giveback_validate_test.py,
+  docs/fairness-regimes.md, _Log.md
+
 ## 2026-07-04 — hb166 V-10: align smoke CoV to the Rust fairness SSOT
 
 - **Timestamp**: 2026-07-04

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,24 @@
+## 2026-07-04 — hb166 V-10: align smoke CoV to the Rust fairness SSOT
+
+- **Timestamp**: 2026-07-04
+- **Action**: hb166 V-10 — the simul-load smoke reducer computed CoV with
+  the SAMPLE stddev (statistics.stdev, N-1) AND filtered zero-bps streams,
+  so its printed CoV could not reproduce a fairness-eval verdict and a
+  fully starved class printed CoV 0 (the "perfectly fair" value). Extracted
+  the population-CoV estimator into test/incus/fairness_cov.py as the single
+  Python mirror of userspace-dp/src/fairness.rs::compute_observed_cov
+  (population stddev over the full vector including zeros, 0.0 for
+  empty/zero-mean). Imported it into cos-simul-load-smoke.sh, stopped
+  filtering zero-bps flows, relabelled the printed column wrCoV% (whole-run)
+  with a legend + verdict provenance field. Added fairness_cov_test.py
+  pinning population_cov to the exact fairness.rs unit-test values (0.5
+  skewed, 0.0 balanced/empty/zero-mean) plus a starved-flow-not-filtered
+  assertion (RED-on-revert: sample stddev gives 0.5774; zero-filter gives
+  0.0). Documented the CoV semantics in docs/fairness-regimes.md. Closes
+  #4247.
+- **File(s)**: test/incus/fairness_cov.py, test/incus/fairness_cov_test.py,
+  test/incus/cos-simul-load-smoke.sh, docs/fairness-regimes.md, _Log.md
+
 ## 2026-07-04 — #4228 Gap 7: vSRX CoS show commands
 
 - **Timestamp**: 2026-07-04

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,20 @@
+## 2026-07-04 — hb166 V-12: minor CoS harness cleanups
+
+- **Timestamp**: 2026-07-04
+- **Action**: hb166 V-12 grouped minor notes. (1) Deleted dead
+  _last_n_sum_bps from mouse_latency_orchestrate.py (no callers). (2)
+  Documented in iperf3_sum_parse.py that the non-end-anchored [SUM] regex
+  also matches warmup (omitted) rows — current callers safe (no -O), a
+  future -O consumer must filter them. (3) Added a comment at the
+  fairness_equal_flow_capture.py fail-closed raise explaining the
+  deliberate posture (one bad scrape fails the reduction; kept, not
+  loosened). (4) Documented the fairness-cos-class-sweep.sh scrape-cadence
+  drift (serial max-time-1 curl + sleep 1 → ~2s under load) and noted ts
+  is captured at scrape START so windowing stays correct. Closes #4249.
+- **File(s)**: test/incus/mouse_latency_orchestrate.py,
+  test/incus/iperf3_sum_parse.py, test/incus/fairness_equal_flow_capture.py,
+  test/incus/fairness-cos-class-sweep.sh, _Log.md
+
 ## 2026-07-04 — hb166 V-8: surplus give-back handback series cross-checks
 
 - **Timestamp**: 2026-07-04

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -1411,6 +1411,20 @@ with per-class achievement, CoV, retransmits, and gate booleans.
 This is now part of the canonical smoke matrix for any PR that
 touches CoS scheduling.
 
+**CoV column semantics (#4239 V-10):** the printed `wrCoV%` column is a
+**whole-run population CoV** computed by `test/incus/fairness_cov.py`,
+the single Python mirror of the Rust fairness SSOT
+(`userspace-dp/src/fairness.rs::compute_observed_cov`). It uses the
+population estimator (denominator N, not the sample N-1 that
+`statistics.stdev` returns) and counts starved (0 bps) flows rather than
+filtering them, so a fully starved class raises CoV instead of printing
+`0.0` (the "perfectly fair" value). It is labelled *whole-run* because it
+covers the entire run including warmup, whereas `fairness.rs` reduces the
+steady-state window — the estimator FORM matches; the window does not.
+The CoV column is decorative context, not a gate (per the #1614
+re-scope). `test/incus/fairness_cov_test.py` pins `population_cov` to the
+exact values asserted by the `fairness.rs` unit tests.
+
 **Exit-code contract (#4239/#4240):** the reducer propagates the gate
 verdict as the process exit status — the script exits **0 only when
 every gate passes**, and **nonzero on any gate failure** (a starved

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -719,7 +719,37 @@ phases: `borrow_alone`, `peer_demand`, `peer_steady`, and
 throughput samples in `handback_samples`. Scalar
 `handback_window_sec` values and self-attested handback labels are not
 accepted as substitutes because the validator must derive the handback
-point from auditable data. The default gates are:
+point from auditable data.
+
+**Handback series cross-checks (#4239 V-8).** A single already-settled
+snapshot cannot prove a give-back transition — its self-attested `t_sec`
+would be the only evidence, and a one-element artifact trivially clears
+the ≤5 s gate. The validator therefore requires the `handback_samples`
+series to demonstrate an OBSERVED transition:
+
+- at least `--min-handback-samples` samples (default 2);
+- strictly increasing `t_sec` (an ordered time series);
+- consecutive gaps within `--max-handback-sample-gap-sec` (default 5 s),
+  so the derived handback time is bounded rather than hidden inside a
+  wide blind gap;
+- a pre-handback baseline sample (peer guarantee not yet restored)
+  BEFORE the first post-handback sample.
+
+The derived handback time is the first post-handback sample that follows
+a pre-handback one, so the accepted `t_sec` is bracketed by the observed
+transition. The timestamps themselves are still generator-supplied; the
+ordered-series cross-check is the auditability bound available in a
+reduced artifact, and an independent wall-clock derivation belongs in the
+live reducer.
+
+**No live runner yet (#4239 V-8).** Nothing in the tree produces
+`phases.json`; the 100E100M give-back contract is exercised only by
+hand-built artifacts today, so this validator is a MANUAL gate. The
+structural cross-checks above are what keep a hand-built artifact honest
+until a live reducer (iperf interval JSON + Prometheus/dataplane status
+→ `phases.json` + `handback_samples` with wall-clock `t_sec`) is built.
+
+The default gates are:
 
 - borrower-alone throughput exceeds 105% of the borrower guarantee
 - peer-demand throughput is non-zero (at least 1% of the peer guarantee)

--- a/test/incus/cos-simul-load-smoke.sh
+++ b/test/incus/cos-simul-load-smoke.sh
@@ -22,6 +22,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 DIRECTION="${1:-push}"
 DURATION="${DURATION:-30}"
 STREAMS="${STREAMS:-12}"
@@ -30,7 +32,10 @@ HOST="${HOST:-loss:cluster-userspace-host}"
 ART="${ART:-/tmp/cos-simul-load-$(date +%s)}"
 
 # Port → class-name map (matches test/incus/cos-iperf-config.set).
+# CLASS_NAME / SHAPE_GBPS document the port mapping for a bash reader; the
+# Python reducer carries its own copies, so they are unused in the shell.
 declare -a PORTS=(5201 5202 5203 5204 5205 5206 5207 5208 5209 5210 5211)
+# shellcheck disable=SC2034  # documentation map; Python heredoc has its own
 declare -A CLASS_NAME=(
   [5201]=iperf-100m
   [5202]=iperf-1g
@@ -44,6 +49,7 @@ declare -A CLASS_NAME=(
   [5210]=iperf-24g
   [5211]=iperf-uncapped
 )
+# shellcheck disable=SC2034  # documentation map; Python heredoc has its own
 declare -A SHAPE_GBPS=(
   [5201]=0.1
   [5202]=1.0
@@ -93,11 +99,17 @@ done
 wait "$MPSTAT_PID" 2>/dev/null || true
 
 # Reduce verdict.
-python3 - <<'PYEOF' "$ART" "$DIRECTION"
-import json, os, statistics, sys
+python3 - <<'PYEOF' "$ART" "$DIRECTION" "$SCRIPT_DIR"
+import json, os, sys
 
 art_dir = sys.argv[1]
 direction = sys.argv[2]
+# Import the shared population-CoV mirror of the Rust fairness SSOT
+# (userspace-dp/src/fairness.rs::compute_observed_cov). This heredoc runs
+# on the operator host from an arbitrary cwd, so add the script's own
+# directory to the import path explicitly (#4239 V-10).
+sys.path.insert(0, sys.argv[3])
+from fairness_cov import population_cov
 ports = [5201, 5202, 5203, 5204, 5205, 5206, 5207, 5208, 5209, 5210, 5211]
 class_names = {
     5201: "iperf-100m", 5202: "iperf-1g", 5203: "iperf-3g",
@@ -124,12 +136,17 @@ for port in ports:
         rows.append({"port": port, "class": class_names[port], "error": str(e)})
         continue
     streams = d.get("end", {}).get("streams", [])
+    # Build the FULL per-flow rate vector including starved (0 bps)
+    # streams. The CoV must match the Rust SSOT
+    # (fairness.rs::compute_observed_cov), which never filters zeros: a
+    # starved flow is maximally unfair and must RAISE CoV, not vanish
+    # (#4239 V-10). Filtering zeros previously let a fully starved class
+    # print CoV 0 — the "perfectly fair" value — inverting the signal.
     rates = []
     for s in streams:
         ss = s.get("sender", {})
-        bps = ss.get("bits_per_second", 0)
-        if bps > 0:
-            rates.append(bps / 1e9)
+        bps = ss.get("bits_per_second", 0) or 0
+        rates.append(bps / 1e9)
     # Codex code-r1 #5 fix: read throughput from sum_received
     # (the actual landed bytes) but retransmits from sum_sent
     # (where the sender-side retransmit counter lives — sum_received
@@ -152,7 +169,13 @@ for port in ports:
     recv_gbps = (sum_received.get("bits_per_second") or
                  sum_sent.get("bits_per_second") or 0) / 1e9
     retr = sum_sent.get("retransmits", 0) or 0
-    cov = (statistics.stdev(rates) / statistics.mean(rates) * 100) if len(rates) > 1 and statistics.mean(rates) > 0 else 0
+    # Whole-run population CoV via the shared Rust-SSOT mirror. This is a
+    # whole-run figure (warmup included) — fairness.rs computes the same
+    # estimator over the steady-state window, so the number is comparable
+    # in FORM but is labelled "whole-run" to flag the window difference
+    # (#4239 V-10). CoV is decorative here (printed, not gated) per the
+    # #1614 re-scope; aligning the estimator prevents misdiagnosis.
+    cov = population_cov(rates) * 100
     spread = (max(rates) / min(rates)) if rates and min(rates) > 0 else float("inf")
     shape = shape_gbps[port]
     rows.append({
@@ -160,7 +183,7 @@ for port in ports:
         "class": class_names[port],
         "shape_gbps": shape,
         "recv_gbps": round(recv_gbps, 3),
-        "cov_pct": round(cov, 1),
+        "whole_run_cov_pct": round(cov, 1),
         "spread": round(spread, 2) if spread != float("inf") else None,
         "retransmits": retr,
         "gen_error": gen_error,
@@ -171,17 +194,24 @@ for port in ports:
         priority_low_gbps = recv_gbps
 
 print(f"\n#1614 simul-load smoke ({direction})")
-print(f"{'port':<6} {'class':<16} {'shape':>7} {'recv_G':>7} {'%shape':>7} {'CoV%':>6} {'retr':>6}")
+print(f"{'port':<6} {'class':<16} {'shape':>7} {'recv_G':>7} {'%shape':>7} {'wrCoV%':>6} {'retr':>6}")
 for r in rows:
     if "error" in r:
         print(f"{r['port']:<6} {r['class']:<16} ERROR: {r['error']}")
         continue
     pct = (r["recv_gbps"] / r["shape_gbps"] * 100) if r["shape_gbps"] > 0 else 0
-    print(f"{r['port']:<6} {r['class']:<16} {r['shape_gbps']:>6.2f}G {r['recv_gbps']:>6.2f}G {pct:>6.1f}% {r['cov_pct']:>5.1f}% {r['retransmits']:>6}")
+    print(f"{r['port']:<6} {r['class']:<16} {r['shape_gbps']:>6.2f}G {r['recv_gbps']:>6.2f}G {pct:>6.1f}% {r['whole_run_cov_pct']:>5.1f}% {r['retransmits']:>6}")
 print(f"{'':<6} {'Sum':<16} {'':>7} {total_recv:>6.2f}G")
+print("wrCoV% = whole-run population CoV (Rust SSOT fairness.rs estimator, "
+      "warmup included, zero-bps flows counted); decorative, not gated.")
 
 # Gate verdict.
-verdict = {"direction": direction, "aggregate_gbps": round(total_recv, 3), "rows": rows}
+verdict = {
+    "direction": direction,
+    "aggregate_gbps": round(total_recv, 3),
+    "cov_estimator": "whole_run_population",  # matches fairness.rs SSOT form
+    "rows": rows,
+}
 gates = {}
 # Gate 0 (both directions): every generator both exited 0 AND produced a
 # parseable, error-free, complete JSON result. Two independent failure

--- a/test/incus/fairness-cos-class-sweep.sh
+++ b/test/incus/fairness-cos-class-sweep.sh
@@ -174,6 +174,12 @@ scrape_equal_flow_metrics() {
 
     : > "$raw"
     : > "$stderr"
+    # Cadence is best-effort ~1s but can stretch toward ~2s under a slow
+    # endpoint (the --max-time 1 curl and the sleep 1 are serial; hb166
+    # V-12). That only thins the sample count — `ts` is captured at scrape
+    # START, before curl, so the steady-window filter in
+    # fairness_equal_flow_capture.py keys each scrape by its true start
+    # time and stays correct regardless of curl latency.
     while true; do
         local ts
         local metrics

--- a/test/incus/fairness_cov.py
+++ b/test/incus/fairness_cov.py
@@ -1,0 +1,50 @@
+"""Population coefficient-of-variation — the single Python mirror of the Rust
+fairness SSOT.
+
+`population_cov` computes the SAME estimator as `compute_observed_cov` in
+`userspace-dp/src/fairness.rs` (the authoritative fairness verdict):
+
+    CoV = population_stddev / mean
+
+over the FULL per-flow throughput vector. Two properties are load-bearing
+for parity with the Rust SSOT and MUST NOT drift:
+
+* **Population stddev (denominator N), not sample stddev (N-1).**
+  `statistics.stdev` is the *sample* estimator and diverges from the Rust
+  value — e.g. for {500,500,1500,1500} the population CoV is 0.5 while the
+  sample CoV is 0.5774. The smoke reducer previously used
+  `statistics.stdev`, so its printed CoV could not reproduce a
+  fairness-eval verdict on identical traffic (hb166 V-10).
+
+* **Zero-throughput (starved) flows are NOT filtered.** A fully starved
+  flow must RAISE the CoV (it is maximally unfair), not silently vanish.
+  The old reducer dropped `bits_per_second == 0` streams, so a class with
+  one starved flow printed CoV 0 — the "perfectly fair" value — exactly
+  inverting the signal. `compute_observed_cov` takes the whole vector
+  including zeros; this mirror does too.
+
+Returns 0.0 for an empty vector or a zero mean, matching the Rust
+reference exactly (see `fairness.rs` `observed_cov_empty` /
+`observed_cov_zero_mean`).
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+
+def population_cov(values: Sequence[float]) -> float:
+    """Return the population CoV (stddev/mean) over ``values``.
+
+    Mirrors ``userspace-dp/src/fairness.rs::compute_observed_cov``:
+    population stddev over the full vector, no zero filtering, 0.0 for an
+    empty vector or a zero mean.
+    """
+    n = len(values)
+    if n == 0:
+        return 0.0
+    mean = sum(values) / n
+    if mean == 0.0:
+        return 0.0
+    var = sum((float(v) - mean) ** 2 for v in values) / n
+    return (var ** 0.5) / mean

--- a/test/incus/fairness_cov_test.py
+++ b/test/incus/fairness_cov_test.py
@@ -1,0 +1,57 @@
+"""Cross-check the Python CoV mirror against the Rust fairness SSOT.
+
+The expected values are the SAME ones asserted by
+`userspace-dp/src/fairness.rs` unit tests (`observed_cov_balanced`,
+`observed_cov_skewed`, `observed_cov_empty`, `observed_cov_zero_mean`).
+If `population_cov` ever drifts from that estimator — e.g. reverts to a
+sample stddev or re-introduces zero-flow filtering — these tests go RED.
+"""
+
+import statistics
+import unittest
+
+from fairness_cov import population_cov
+
+
+class PopulationCovMatchesRustSSOT(unittest.TestCase):
+    def test_balanced_is_zero(self):
+        # fairness.rs observed_cov_balanced: {1000,1000,1000,1000} -> 0.0
+        self.assertAlmostEqual(population_cov([1000, 1000, 1000, 1000]), 0.0)
+
+    def test_skewed_is_half(self):
+        # fairness.rs observed_cov_skewed: {500,500,1500,1500}
+        # mean=1000, var=250000, stddev=500, CoV=0.5 (POPULATION).
+        self.assertAlmostEqual(population_cov([500, 500, 1500, 1500]), 0.5)
+
+    def test_empty_is_zero(self):
+        # fairness.rs observed_cov_empty
+        self.assertEqual(population_cov([]), 0.0)
+
+    def test_zero_mean_is_zero(self):
+        # fairness.rs observed_cov_zero_mean: {0,0,0} -> 0.0
+        self.assertEqual(population_cov([0, 0, 0]), 0.0)
+
+    def test_population_not_sample_stddev(self):
+        # The distinction that motivated hb166 V-10: the SSOT is the
+        # population estimator. The sample estimator (statistics.stdev,
+        # N-1) gives 0.5774 for the same input — a value the printed CoV
+        # must NOT report.
+        skewed = [500, 500, 1500, 1500]
+        sample_cov = statistics.stdev(skewed) / statistics.mean(skewed)
+        self.assertAlmostEqual(sample_cov, 0.5773502691896257)
+        self.assertNotAlmostEqual(population_cov(skewed), sample_cov, places=3)
+
+    def test_starved_flow_is_not_filtered(self):
+        # A starved (0 bps) flow must RAISE CoV, not vanish. The old
+        # reducer filtered zeros and printed CoV 0 (perfectly fair) for
+        # exactly this vector — the inverted signal V-10 flags.
+        with_starved = [0, 1000, 1000, 1000]
+        # mean=750, var=187500, stddev=433.0127, CoV=0.57735.
+        self.assertAlmostEqual(population_cov(with_starved), 0.5773502691896257)
+        # Filtering the zero (the old behaviour) would collapse to CoV 0.
+        filtered = [v for v in with_starved if v > 0]
+        self.assertAlmostEqual(population_cov(filtered), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/incus/fairness_equal_flow_capture.py
+++ b/test/incus/fairness_equal_flow_capture.py
@@ -467,6 +467,14 @@ def main(argv: list[str]) -> int:
     try:
         raw = args.raw.read_text(encoding="utf-8")
         scrapes, empty_timestamps, error_timestamps = split_scrapes(raw)
+        # Fail-closed on ANY empty or errored scrape (hb166 V-12): a single
+        # transient curl hiccup fails the whole reduction, which can burn a
+        # sweep run. This is a DELIBERATE posture — the equal-flow estimator
+        # is only meaningful over a clean, gap-free steady-state window, and
+        # silently dropping a bad scrape would let a partially-observed run
+        # read as a valid verdict. If a future run needs transient-error
+        # tolerance, add an explicit, bounded budget (e.g. an allowed error
+        # fraction) here rather than making the failure silent.
         if empty_timestamps:
             raise CaptureError(
                 "empty metrics scrape(s): " + ", ".join(empty_timestamps[:5])

--- a/test/incus/fairness_surplus_giveback_validate.py
+++ b/test/incus/fairness_surplus_giveback_validate.py
@@ -23,6 +23,27 @@ Input is a JSON artifact with four named phases:
 The script deliberately validates reduced artifacts only. It does not run
 traffic; shell harnesses can feed it summaries from iperf, dataplane status,
 or Prometheus as those live runners evolve.
+
+Handback auditability (hb166 V-8): the ``handback_samples`` series must
+PROVE a give-back transition, not merely assert a settled snapshot. The
+validator requires at least ``--min-handback-samples`` samples (default 2),
+strictly increasing ``t_sec``, consecutive gaps within
+``--max-handback-sample-gap-sec`` (default 5s), and a pre-handback baseline
+sample (peer guarantee not yet restored) BEFORE the first post-handback
+sample. The derived handback time is the first post-handback sample that
+follows a pre-handback one, so the accepted ``t_sec`` is bracketed by an
+observed transition rather than trusted on its own. Note the timestamps
+themselves remain generator-supplied; the ordered-series cross-check is the
+auditability bound available in a reduced artifact, and an independent
+wall-clock derivation belongs in the live reducer (see below).
+
+No live runner exists yet (hb166 V-8): NOTHING in the tree produces
+``phases.json`` — the 100E100M give-back contract is exercised only by
+hand-built artifacts today. Building the live reducer (iperf interval JSON
++ Prometheus/dataplane-status → ``phases.json`` + ``handback_samples`` with
+wall-clock ``t_sec``) is tracked separately; until then this validator is a
+MANUAL gate, run by hand against a reduced artifact, and the structural
+cross-checks above are what keep a hand-built artifact honest.
 """
 
 from __future__ import annotations
@@ -103,15 +124,32 @@ def _handback_from_samples(
     min_peer_guarantee_ratio: float,
     borrow_alone_bps: float,
     max_borrower_demand_ratio: float,
-) -> Tuple[Optional[float], Optional[str]]:
+    min_samples: int,
+    max_sample_gap_sec: float,
+) -> Tuple[Optional[float], str, list[str]]:
+    """Derive the handback time from the ordered sample series.
+
+    Returns ``(handback_sec, source, structural_issues)``. The handback
+    time is only accepted when the series proves a give-back TRANSITION:
+    at least ``min_samples`` samples, strictly increasing ``t_sec``,
+    consecutive gaps within ``max_sample_gap_sec``, and a pre-handback
+    sample (peer guarantee not yet restored) preceding the first
+    post-handback sample. Each violated invariant is returned as a
+    structural-issue string so the caller can fail the artifact. Without
+    these cross-checks a one-element artifact carrying a single already
+    settled snapshot trivially satisfies the handback gate — the sample's
+    self-attested ``t_sec`` is the only evidence (hb166 V-8).
+    """
     samples = artifact.get("handback_samples")
     if samples is None:
-        return None, "missing_handback_samples"
+        return None, "missing_handback_samples", []
     if not isinstance(samples, list) or not samples:
         raise ValueError("handback_samples must be a non-empty list when present")
 
     threshold_peer = peer_guarantee * min_peer_guarantee_ratio
     threshold_borrower = borrow_alone_bps * max_borrower_demand_ratio
+
+    parsed: list[Tuple[float, float, float]] = []  # (t_sec, borrower, peer)
     for index, sample in enumerate(samples):
         if not isinstance(sample, dict):
             raise ValueError(f"handback_samples[{index}] must be an object")
@@ -127,9 +165,59 @@ def _handback_from_samples(
             throughputs.get("peer"),
             f"handback_samples[{index}].throughput_mbps.peer",
         )
-        if peer >= threshold_peer and borrower <= threshold_borrower:
-            return t_sec, "handback_samples"
-    return None, "handback_samples_no_match"
+        parsed.append((t_sec, borrower, peer))
+
+    issues: list[str] = []
+    if len(parsed) < min_samples:
+        issues.append(
+            f"handback_samples has {len(parsed)} sample(s); at least {min_samples} "
+            "are required to prove a give-back transition (a single self-attested "
+            "snapshot is not auditable)"
+        )
+    for i in range(1, len(parsed)):
+        if parsed[i][0] <= parsed[i - 1][0]:
+            issues.append(
+                f"handback_samples t_sec not strictly increasing at index {i}: "
+                f"{parsed[i][0]:.3f} <= {parsed[i - 1][0]:.3f}"
+            )
+        gap = parsed[i][0] - parsed[i - 1][0]
+        if gap > max_sample_gap_sec:
+            issues.append(
+                f"handback_samples gap {gap:.3f}s between index {i - 1} and {i} "
+                f"exceeds max {max_sample_gap_sec:.3f}s (series too sparse to bound "
+                "the handback time)"
+            )
+
+    def _is_post(borrower: float, peer: float) -> bool:
+        return peer >= threshold_peer and borrower <= threshold_borrower
+
+    if parsed and _is_post(parsed[0][1], parsed[0][2]):
+        issues.append(
+            "first handback sample is already in the post-handback state (peer "
+            "guarantee restored while borrower gave back surplus); no pre-handback "
+            "baseline captured, so the handback point is not derived from an "
+            "observed transition"
+        )
+
+    handback_time: Optional[float] = None
+    seen_pre = False
+    saw_post = False
+    for t_sec, borrower, peer in parsed:
+        if _is_post(borrower, peer):
+            saw_post = True
+            if seen_pre and handback_time is None:
+                handback_time = t_sec
+        else:
+            seen_pre = True
+    if handback_time is not None:
+        return handback_time, "handback_samples", issues
+    if saw_post:
+        # A post-handback state exists but no pre-handback sample precedes
+        # it — the "already post / no pre-baseline" structural issue above
+        # is the precise reason; do not also claim the series never showed
+        # restoration.
+        return None, "handback_samples_no_pre_baseline", issues
+    return None, "handback_samples_no_match", issues
 
 
 def validate(
@@ -144,6 +232,8 @@ def validate(
     min_reclaim_alone_ratio: float,
     root_cap_tolerance_ratio: float,
     max_peer_steady_drops: float,
+    min_handback_samples: int = 2,
+    max_handback_sample_gap_sec: float = 5.0,
 ) -> dict[str, Any]:
     phases = _phase_map(artifact)
     root_cap = _nonnegative_number(artifact.get("root_cap_mbps"), "root_cap_mbps")
@@ -164,12 +254,14 @@ def validate(
     steady_peer = _throughput(peer_steady, "peer")
     reclaim_borrower = _throughput(reclaim, "borrower")
     steady_peer_drops = _drops(peer_steady, "peer")
-    handback, handback_source = _handback_from_samples(
+    handback, handback_source, handback_issues = _handback_from_samples(
         artifact,
         peer_guarantee=peer_guarantee,
         min_peer_guarantee_ratio=min_peer_guarantee_ratio,
         borrow_alone_bps=borrow_alone_bps,
         max_borrower_demand_ratio=max_borrower_demand_ratio,
+        min_samples=min_handback_samples,
+        max_sample_gap_sec=max_handback_sample_gap_sec,
     )
     if handback is None:
         handback = max_handback_sec + 1.0
@@ -207,6 +299,11 @@ def validate(
         failures.append(
             "handback_samples are required; scalar handback evidence is not auditable"
         )
+    # Structural cross-checks on the sample series (>=N samples, strictly
+    # increasing t_sec, bounded gap, pre-handback baseline) prove the
+    # handback is an OBSERVED transition rather than a single self-attested
+    # snapshot (hb166 V-8).
+    failures.extend(handback_issues)
     if steady_borrower > borrow_alone_bps * max_borrower_demand_ratio:
         failures.append(
             f"borrower did not give back surplus: steady {steady_borrower:.3f} Mbps "
@@ -252,6 +349,8 @@ def validate(
             "min_reclaim_alone_ratio": min_reclaim_alone_ratio,
             "root_cap_tolerance_ratio": root_cap_tolerance_ratio,
             "max_peer_steady_drops": max_peer_steady_drops,
+            "min_handback_samples": min_handback_samples,
+            "max_handback_sample_gap_sec": max_handback_sample_gap_sec,
         },
         "metrics": {
             "borrow_alone_borrower_mbps": borrow_alone_bps,
@@ -288,6 +387,24 @@ def main() -> int:
     parser.add_argument("--min-reclaim-alone-ratio", type=float, default=0.90)
     parser.add_argument("--root-cap-tolerance-ratio", type=float, default=0.02)
     parser.add_argument("--max-peer-steady-drops", type=float, default=0.0)
+    parser.add_argument(
+        "--min-handback-samples",
+        type=int,
+        default=2,
+        help=(
+            "minimum number of handback_samples required to prove a give-back "
+            "transition; a single self-attested snapshot is not auditable"
+        ),
+    )
+    parser.add_argument(
+        "--max-handback-sample-gap-sec",
+        type=float,
+        default=5.0,
+        help=(
+            "maximum allowed gap between consecutive handback_samples; a wider "
+            "gap leaves the derived handback time unbounded"
+        ),
+    )
     args = parser.parse_args()
 
     with open(args.input) as f:
@@ -303,6 +420,8 @@ def main() -> int:
         min_reclaim_alone_ratio=args.min_reclaim_alone_ratio,
         root_cap_tolerance_ratio=args.root_cap_tolerance_ratio,
         max_peer_steady_drops=args.max_peer_steady_drops,
+        min_handback_samples=args.min_handback_samples,
+        max_handback_sample_gap_sec=args.max_handback_sample_gap_sec,
     )
     with open(args.out, "w") as f:
         json.dump(verdict, f, indent=2, sort_keys=True)

--- a/test/incus/fairness_surplus_giveback_validate_test.py
+++ b/test/incus/fairness_surplus_giveback_validate_test.py
@@ -39,6 +39,8 @@ def _validate(artifact):
         min_reclaim_alone_ratio=0.90,
         root_cap_tolerance_ratio=0.02,
         max_peer_steady_drops=0,
+        min_handback_samples=2,
+        max_handback_sample_gap_sec=5.0,
     )
 
 
@@ -129,12 +131,66 @@ class SurplusGivebackValidateTests(unittest.TestCase):
         artifact["phases"][0]["throughput_mbps"]["borrower"] = 10600
         artifact["phases"][2]["throughput_mbps"]["borrower"] = 9000
         artifact["phases"][3]["throughput_mbps"]["borrower"] = 9700
+        # A valid pre->post series so the reclaim failure is isolated (the
+        # handback cross-checks are exercised by their own tests below).
         artifact["handback_samples"] = [
+            {"t_sec": 0.5, "throughput_mbps": {"borrower": 17000, "peer": 1000}},
             {"t_sec": 3.0, "throughput_mbps": {"borrower": 9000, "peer": 9800}},
         ]
         verdict = _validate(artifact)
         self.assertEqual(verdict["verdict"], "FAIL")
         self.assertTrue(any("did not reclaim surplus" in r for r in verdict["failure_reasons"]))
+
+    def test_fails_single_self_attested_handback_sample(self):
+        # hb166 V-8: a one-element artifact carrying a single already
+        # settled snapshot must NOT satisfy the handback gate.
+        artifact = _artifact()
+        artifact["handback_samples"] = [
+            {"t_sec": 0.1, "throughput_mbps": {"borrower": 9000, "peer": 9800}},
+        ]
+        verdict = _validate(artifact)
+        self.assertEqual(verdict["verdict"], "FAIL")
+        self.assertTrue(any("at least 2" in r for r in verdict["failure_reasons"]))
+        self.assertTrue(
+            any("no pre-handback baseline" in r for r in verdict["failure_reasons"])
+        )
+
+    def test_fails_non_monotonic_handback_samples(self):
+        artifact = _artifact()
+        artifact["handback_samples"] = [
+            {"t_sec": 3.0, "throughput_mbps": {"borrower": 17000, "peer": 1000}},
+            {"t_sec": 0.5, "throughput_mbps": {"borrower": 9000, "peer": 9800}},
+        ]
+        verdict = _validate(artifact)
+        self.assertEqual(verdict["verdict"], "FAIL")
+        self.assertTrue(
+            any("not strictly increasing" in r for r in verdict["failure_reasons"])
+        )
+
+    def test_fails_first_sample_already_post_handback(self):
+        # No pre-handback baseline: both samples already show the guarantee
+        # restored, so the handback point is not an observed transition.
+        artifact = _artifact()
+        artifact["handback_samples"] = [
+            {"t_sec": 0.5, "throughput_mbps": {"borrower": 9000, "peer": 9800}},
+            {"t_sec": 3.0, "throughput_mbps": {"borrower": 9000, "peer": 9800}},
+        ]
+        verdict = _validate(artifact)
+        self.assertEqual(verdict["verdict"], "FAIL")
+        self.assertTrue(
+            any("no pre-handback baseline" in r for r in verdict["failure_reasons"])
+        )
+
+    def test_fails_sparse_handback_samples(self):
+        # A wide blind gap leaves the derived handback time unbounded.
+        artifact = _artifact()
+        artifact["handback_samples"] = [
+            {"t_sec": 0.5, "throughput_mbps": {"borrower": 17000, "peer": 1000}},
+            {"t_sec": 100.0, "throughput_mbps": {"borrower": 9000, "peer": 9800}},
+        ]
+        verdict = _validate(artifact)
+        self.assertEqual(verdict["verdict"], "FAIL")
+        self.assertTrue(any("too sparse" in r for r in verdict["failure_reasons"]))
 
     def test_fails_when_reclaim_not_near_borrow_alone(self):
         artifact = _artifact()

--- a/test/incus/iperf3_sum_parse.py
+++ b/test/incus/iperf3_sum_parse.py
@@ -9,6 +9,15 @@ Final summary lines look like:
 
 Per-stream lines start with `[N]` where N is a digit; they must NOT
 match. Anchored regex on `[SUM]` only.
+
+CAUTION (hb166 V-12): the regex is NOT anchored at end-of-line, so BOTH
+the final-summary rows above AND warmup `(omitted)` rows —
+    [SUM]   0.00-1.00   sec  1.00 GBytes  8.59 Gbits/sec  ...  (omitted)
+— match `parse_sum_line`. Current callers pass runs without `-O`, so no
+omitted rows exist, and they explicitly drop the trailing final-summary
+rows. A future caller that scrapes a run started with `-O` (omit N
+warmup seconds) MUST filter the leading omitted rows itself; this parser
+returns them as ordinary per-second rows.
 """
 
 import re

--- a/test/incus/mouse_latency_orchestrate.py
+++ b/test/incus/mouse_latency_orchestrate.py
@@ -305,15 +305,6 @@ _BYTE_UNIT_MULTIPLIER = {
 }
 
 
-def _last_n_sum_bps(text: str, n: int) -> list:
-    out = []
-    for line in text.splitlines():
-        bps = parse_sum_bps(line)
-        if bps is not None:
-            out.append(bps)
-    return out[-n:]
-
-
 def _parse_iperf_interval_rows(text: str) -> list[dict]:
     """Parse iperf3 text interval rows, including stream-level TCP fields."""
     rows = []


### PR DESCRIPTION
Closes #4248 Closes #4247 Closes #4249

fable-review-166 findings V-8, V-10, V-12 — all in the CoS fairness
validation harness (test/incus/ Python reducers + shell). No cargo / no
dataplane change.

## V-8 (#4248) — surplus give-back handback derivation + no live runner
fairness_surplus_giveback_validate.py accepted the first list-order
handback sample matching the post-handback thresholds with no
monotonic-t_sec check, no pre-handback baseline, and no density
requirement, so a one-element artifact with a single already-settled
snapshot cleared the <=5s gate on a self-attested t_sec.

The handback_samples series must now prove an OBSERVED transition: at
least --min-handback-samples (default 2), strictly increasing t_sec,
consecutive gaps within --max-handback-sample-gap-sec (default 5s), and a
pre-handback baseline before the first post-handback sample. The handback
time is the first post-handback sample following a pre-handback one, so
the accepted t_sec is bracketed by the transition. Four new unit tests
(single-sample, non-monotonic, no-pre-baseline, too-sparse).

Deferred half (documented, not driveable here): NOTHING in the tree
produces phases.json — the give-back contract is exercised only by
hand-built artifacts, so the validator is a MANUAL gate. The docstring +
docs/fairness-regimes.md now state this; the structural cross-checks keep
a hand-built artifact honest until a live reducer (iperf interval JSON +
Prometheus/dataplane status -> phases.json with wall-clock t_sec) exists.

RED-on-revert: restoring the lax first-match derivation makes the
single-sample artifact PASS (verified) — test_fails_single_self_attested_
handback_sample goes red.

## V-10 (#4247) — smoke CoV diverged from the Rust fairness SSOT
cos-simul-load-smoke.sh computed CoV with statistics.stdev (SAMPLE
stddev, N-1) and filtered zero-bps streams, so its printed CoV could not
reproduce a fairness-eval verdict and a fully starved class printed CoV 0
(the "perfectly fair" value).

Extracted the estimator into test/incus/fairness_cov.py — the single
Python mirror of userspace-dp/src/fairness.rs::compute_observed_cov
(population stddev over the full vector including zeros, 0.0 for
empty/zero-mean). The smoke reducer imports it, stops filtering zeros,
relabels the column wrCoV% (whole-run) with a legend + verdict provenance
field. fairness_cov_test.py pins population_cov to the exact values the
fairness.rs unit tests assert.

RED-on-revert: swapping population_cov back to sample-stddev+zero-filter
fails 3 fairness_cov_test assertions (verified).

## V-12 (#4249) — grouped minor cleanups
- delete dead _last_n_sum_bps (no callers);
- document the iperf3_sum_parse.py non-anchored [SUM] regex also matches
  (omitted) warmup rows (current callers safe; future -O consumer must
  filter);
- document the deliberate fail-closed posture at the
  fairness_equal_flow_capture.py empty/error raise (kept, not loosened);
- document the fairness-cos-class-sweep.sh scrape-cadence drift (ts is
  captured at scrape start, so windowing stays correct).

## Validation
- (cd test/incus && python3 -m unittest fairness_cov_test
  fairness_surplus_giveback_validate_test iperf3_sum_parse_test
  mouse_latency_orchestrate_test) — 66 pass.
- py_compile all touched Python; bash -n + shellcheck rc=0 on
  cos-simul-load-smoke.sh; the fairness-cos-class-sweep.sh SC2016 items
  are pre-existing Markdown-backtick INFO false-positives, unchanged by
  the comment-only edit.
- End-to-end: ran the smoke reducer against synthetic artifacts (a
  starved-stream class now shows wrCoV 30.2%, was 0.0% under the old
  filter); ran the give-back validator CLI (valid artifact rc=0,
  single-sample artifact rc=1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi