### PR TITLE
cos: reseed rejoining shared_exact V_min worker to peer frontier (R-7, #4254)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -34732,3 +34732,30 @@ top.
   the rc-only gate_0 passes both garbage inputs. Closes the Copilot gap.
 - **File(s)**: test/incus/cos-simul-load-smoke.sh, docs/fairness-regimes.md,
   _Log.md
+
+- **Timestamp**: 2026-07-04
+- **Action**: hb166 R-7 fix (#4254) — cross-worker V_min gate compared
+  ABSOLUTE `queue_vtime` values, so a reset/rejoining shared_exact worker
+  that restarts at `queue_vtime = 0` broadcast a near-zero vtime and
+  trapped surviving peers (terabytes ahead) in the throttle → hard-cap →
+  1000-suspended-drain duty cycle forever. Root cause: `queue_vtime` is
+  cumulative served-bytes with no shared epoch; a fresh 0 is not
+  comparable to a survivor's absolute value. Fix: seed a rebuilt
+  shared_exact queue's fresh `FlowFairState.queue_vtime` to the current
+  cross-worker peer frontier (MAX participating peer slot) in
+  `promote_cos_queue_flow_fair` — the sole reconstruction site (exact
+  queues never demote). New `SharedCoSQueueVtimeFloor::peer_frontier_vtime`
+  helper. MAX (not the participating V_min) is the do-no-harm seed: a
+  rejoiner at the frontier never lowers an existing peer's V_min and
+  still defers to a GENUINE laggard (a live peer never reconstructed,
+  hence never reseeded — distinguishes "rejoining at 0" from
+  "legitimately behind"). Cold start / full reset → no peer → seed stays
+  0. Added 4 tests incl. the T-7 trap scenario (RED-on-revert proven: the
+  survivor-not-trapped + seed assertions both fail with the seed
+  disabled) and the genuine-laggard-still-deferred distinction. Needs a
+  cluster CoS fairness smoke (fairness-mechanism change).
+- **File(s)**: userspace-dp/src/afxdp/types/shared_cos_lease/vtime.rs,
+  userspace-dp/src/afxdp/cos/admission.rs,
+  userspace-dp/src/afxdp/tx/test_support.rs,
+  userspace-dp/src/afxdp/cos/queue_ops/v_min_tests.rs,
+  docs/fairness-regimes.md, _Log.md

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -1072,7 +1072,32 @@ the sweep exit `2`; they do not produce a false-green fairness verdict.
   drain force-continues and arms suspension (#941 work item D).
   Counted distinctly from (not a subset of) the throttle counter; the
   overrides/throttles ratio is the diagnostic for LAG_THRESHOLD tuned
-  too tight.
+  too tight. **Rejoin reseed (#4254, R-7):** `queue_vtime` is a
+  cumulative served-bytes counter with NO shared epoch, so an absolute
+  cross-worker comparison is only meaningful while every participant
+  shares a baseline. A worker whose per-interface CoS runtime is rebuilt
+  — config commit, XDP rebind, per-binding `reset_binding_cos_runtime` —
+  restarts its `FlowFairState` at `queue_vtime = 0`. Left uncorrected,
+  its first post-settle publish broadcasts a near-zero vtime; a
+  surviving peer terabytes ahead then fails the gate every batch and
+  rides the hard-cap → 1000-suspended-drain escape hatch continuously
+  (fairness brake effectively OFF, `hard_cap_overrides` the only counter
+  climbing). To prevent this, `promote_cos_queue_flow_fair`
+  (`cos/admission.rs`) SEEDS a rebuilt shared_exact queue's fresh
+  `queue_vtime` to the current cross-worker **peer frontier** — the MAX
+  participating peer slot, via
+  `SharedCoSQueueVtimeFloor::peer_frontier_vtime`. This is the sole
+  reconstruction site for a shared_exact `FlowFairState` (exact queues
+  never demote). The MAX (rather than the participating V_min) is the
+  do-no-harm seed: a rejoiner placed at the frontier can never become a
+  new V_min below an existing peer, so it does not perturb the
+  survivors' throttle decisions, yet it still defers to a GENUINE
+  laggard (a live peer at a real lower vtime, never reconstructed, hence
+  never reseeded — the reseed distinguishes "rejoining at 0" from
+  "legitimately behind"). Cold start / full simultaneous reset → no
+  participating peer → frontier `None` → seed stays 0 (unchanged). Only
+  shared_exact queues carry a `vtime_floor`, so owner-local exact queues
+  keep the plain 0 seed.
 - **`xpf_userspace_cos_sojourn_windowed_min_ns{ifindex=..., queue_id=...}`**
   gauge (#1829 Phase 1): minimum per-packet queue sojourn over the
   last 1-2 100 ms windows, MAX-merged across workers (worst

--- a/userspace-dp/src/afxdp/cos/admission.rs
+++ b/userspace-dp/src/afxdp/cos/admission.rs
@@ -526,7 +526,42 @@ fn promote_cos_queue_flow_fair(
         // #1755: new_boxed builds the ~352 KB FlowFairState directly into
         // the heap, so the giant struct never lands on this build-time
         // frame.
-        Some(FlowFairState::new_boxed(cos_flow_hash_seed_from_os()))
+        let mut ff = FlowFairState::new_boxed(cos_flow_hash_seed_from_os());
+        // #4254 (R-7): seed a (re)joining shared_exact worker's virtual
+        // clock to the current cross-worker peer frontier. This is the
+        // sole reconstruction site for a shared_exact FlowFairState
+        // (exact queues never demote — queue_ops/mod.rs
+        // `maybe_demote_drained_best_effort`), so it is reached on every
+        // runtime rebuild — config commit, XDP rebind, per-binding
+        // `reset_binding_cos_runtime` — via
+        // `ensure_cos_interface_runtime_cold`. Without this, the fresh
+        // queue_vtime starts at 0 and the worker's first post-settle
+        // publish broadcasts a near-zero vtime into the shared V_min
+        // floor. `queue_vtime` is cumulative served-bytes with no shared
+        // epoch, so a surviving peer terabytes ahead then fails the
+        // absolute-vtime gate (v_min.rs `cos_queue_v_min_continue`) every
+        // batch, burns the hard-cap, and arms 1000 suspended drains — the
+        // fairness brake pinned OFF ~99% of the rejoiner's re-warmup.
+        //
+        // Seeding to the MAX participating peer slot (the frontier) is
+        // the do-no-harm choice: the rejoiner can never become a NEW
+        // V_min below an existing peer (survivors' throttle decisions are
+        // unchanged at the join instant) yet still defers to a genuine
+        // laggard, whose real lower slot remains the V_min everyone
+        // obeys. A genuine laggard never reaches this construction site
+        // (its FlowFairState is not being rebuilt), so it is never
+        // reseeded — this distinguishes "rejoining at 0" (reseed) from
+        // "legitimately behind" (leave alone). Cold start / full
+        // simultaneous reset → no participating peer → frontier None →
+        // keep 0 (unchanged). `vtime_floor` is Some only on shared_exact
+        // queues (set from the fast path above), so non-shared exact
+        // queues keep the plain 0 seed.
+        if let Some(floor) = queue.v_min.vtime_floor.as_ref() {
+            if let Some(frontier) = floor.peer_frontier_vtime(worker_id) {
+                ff.queue_vtime = frontier;
+            }
+        }
+        Some(ff)
     } else {
         None
     };

--- a/userspace-dp/src/afxdp/cos/queue_ops/v_min_tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/v_min_tests.rs
@@ -8,8 +8,11 @@
 // (where they were originally placed before the V_min split
 // landed in #1036).
 use super::*;
+use crate::afxdp::cos::admission::apply_cos_queue_flow_fair_promotion;
 use crate::afxdp::types::EqualFlowTargetPolicy;
+use crate::afxdp::types::SharedCoSQueueVtimeFloor;
 use crate::afxdp::PROTO_TCP;
+use std::sync::Arc;
 use crate::afxdp::cos::queue_ops::{
     cos_queue_pop_front, cos_queue_push_back, cos_queue_push_front,
 };
@@ -1660,5 +1663,213 @@ fn vmin_shaped_threshold_is_byte_identical() {
         compute_v_min_lag_threshold(0, 4),
         V_MIN_MIN_LAG_BYTES,
         "compute_v_min_lag_threshold(0, _) is unchanged — clamps to the floor",
+    );
+}
+
+// ---- #4254 (R-7): rejoining-worker V_min reseed ----
+
+/// A 10 Gb/s shared_exact queue config used by the R-7 reseed tests.
+/// Above `COS_SHARED_EXACT_MIN_RATE_BYTES`; a nonzero rate so
+/// `cos_queue_v_min_continue` does not early-return on the #2981
+/// unshaped path.
+fn r7_exact_queue(queue_id: u8) -> CoSQueueConfig {
+    CoSQueueConfig {
+        queue_id,
+        forwarding_class: "iperf-c".into(),
+        priority: 5,
+        transmit_rate_bytes: 10_000_000_000 / 8,
+        guarantee_enabled: true,
+        exact: true,
+        surplus_sharing: false,
+        equal_flow_enforcement: false,
+        equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+        surplus_weight: 1,
+        buffer_bytes: 4 * 1024 * 1024,
+        dscp_rewrite: None,
+        codel_target_ns: 0,
+    }
+}
+
+/// #4254 (R-7): `peer_frontier_vtime` returns the MAX participating peer
+/// slot, excludes the caller's own slot, and returns `None` when no peer
+/// participates.
+#[test]
+fn vmin_peer_frontier_vtime_max_excludes_self_and_none_when_empty() {
+    let floor = SharedCoSQueueVtimeFloor::new(4);
+    // No peers participating yet -> None (cold-start / full reset).
+    assert_eq!(
+        floor.peer_frontier_vtime(1),
+        None,
+        "no participating peer -> None (seed stays 0)",
+    );
+    // Populate three peers; worker 1 is the caller (self-excluded).
+    floor.slots[0].publish(500);
+    floor.slots[1].publish(999_999); // caller's own slot — must be ignored
+    floor.slots[2].publish(4_000);
+    floor.slots[3].publish(1_500);
+    assert_eq!(
+        floor.peer_frontier_vtime(1),
+        Some(4_000),
+        "frontier must be the MAX participating peer slot, excluding self",
+    );
+    // Vacate the max peer; frontier falls back to the next-highest peer.
+    floor.slots[2].vacate();
+    assert_eq!(
+        floor.peer_frontier_vtime(1),
+        Some(1_500),
+        "vacated max peer drops out of the frontier reduction",
+    );
+}
+
+/// #4254 (R-7): a shared_exact worker rebuilt via the production
+/// `promote_cos_queue_flow_fair` path seeds its fresh `queue_vtime` to
+/// the current peer frontier instead of 0. Cold start (no peer) keeps 0.
+///
+/// RED-on-revert: dropping the reseed leaves `queue_vtime == 0`, so the
+/// first assertion (`== FRONTIER`) fails.
+#[test]
+fn vmin_r7_rejoiner_seeds_to_peer_frontier_not_zero() {
+    const FRONTIER: u64 = 100 * 1024 * 1024 * 1024; // ~100 GB cumulative
+
+    // Shared floor: 2 workers. Worker 0 (survivor) is terabytes ahead.
+    let floor = Arc::new(SharedCoSQueueVtimeFloor::new(2));
+    floor.slots[0].publish(FRONTIER);
+
+    // Worker 1 rebuilds its runtime through the production promotion
+    // path with the reused floor attached.
+    let mut rejoiner = test_cos_runtime_with_queues(10_000_000_000 / 8, vec![r7_exact_queue(0)]);
+    let fast = vec![test_queue_fast_path_for_promotion_with_floor(
+        true,
+        Some(Arc::clone(&floor)),
+    )];
+    apply_cos_queue_flow_fair_promotion(&mut rejoiner, &fast, 1);
+
+    assert!(
+        rejoiner.queues[0].shared_exact(),
+        "fixture must be shared_exact"
+    );
+    assert_eq!(
+        test_flow_fair_state(&rejoiner.queues[0]).queue_vtime,
+        FRONTIER,
+        "R-7: a rejoining shared_exact worker MUST seed queue_vtime to the \
+         peer frontier, not 0 (RED on revert)",
+    );
+
+    // Cold start: no participating peer -> seed stays 0.
+    let cold_floor = Arc::new(SharedCoSQueueVtimeFloor::new(2));
+    let mut cold = test_cos_runtime_with_queues(10_000_000_000 / 8, vec![r7_exact_queue(0)]);
+    let cold_fast = vec![test_queue_fast_path_for_promotion_with_floor(
+        true,
+        Some(Arc::clone(&cold_floor)),
+    )];
+    apply_cos_queue_flow_fair_promotion(&mut cold, &cold_fast, 1);
+    assert_eq!(
+        test_flow_fair_state(&cold.queues[0]).queue_vtime,
+        0,
+        "cold start (no participating peer) must keep queue_vtime == 0",
+    );
+}
+
+/// #4254 (R-7) — the T-7 trap scenario end-to-end. A surviving peer
+/// terabytes ahead must NOT be trapped in the throttle duty cycle after
+/// a peer worker resets and rejoins. With the reseed, the rejoiner's
+/// first publish lands on the frontier, so the survivor's V_min gate
+/// continues.
+///
+/// RED-on-revert: without the reseed the rejoiner publishes ~0, the
+/// survivor's V_min collapses to 0, and its gate throttles — the final
+/// `assert!(cont)` fails.
+#[test]
+fn vmin_r7_rejoiner_does_not_trap_surviving_peer() {
+    const FRONTIER: u64 = 100 * 1024 * 1024 * 1024;
+
+    let floor = Arc::new(SharedCoSQueueVtimeFloor::new(2));
+    // Survivor (worker 0) publishes its real, terabytes-ahead vtime.
+    floor.slots[0].publish(FRONTIER);
+
+    // Rejoiner (worker 1) rebuilds + seeds + performs its first publish.
+    let mut rejoiner = test_cos_runtime_with_queues(10_000_000_000 / 8, vec![r7_exact_queue(0)]);
+    let fast = vec![test_queue_fast_path_for_promotion_with_floor(
+        true,
+        Some(Arc::clone(&floor)),
+    )];
+    apply_cos_queue_flow_fair_promotion(&mut rejoiner, &fast, 1);
+    publish_committed_queue_vtime(Some(&rejoiner.queues[0]));
+    // Post-fix the rejoiner's slot reflects the frontier, not ~0.
+    assert_eq!(
+        floor.slots[1].read(),
+        Some(FRONTIER),
+        "rejoiner's first publish must broadcast the seeded frontier",
+    );
+
+    // Build the survivor's queue on worker 0 sharing the same floor.
+    let mut survivor = test_cos_runtime_with_queues(10_000_000_000 / 8, vec![r7_exact_queue(0)]);
+    {
+        let q = &mut survivor.queues[0];
+        enable_test_flow_fair(q);
+        q.v_min.vtime_floor = Some(Arc::clone(&floor));
+        q.v_min.worker_id = 0;
+        q.config.shared_exact = true;
+        test_flow_fair_state_mut(q).queue_vtime = FRONTIER;
+    }
+
+    // The survivor reads the rejoiner's slot (== FRONTIER) -> V_min at
+    // the frontier -> its own vtime is within LAG -> continue (no trap).
+    assert!(
+        cos_queue_v_min_continue(&mut survivor.queues[0], 1),
+        "R-7: a surviving peer MUST NOT be trapped by a reset/rejoining \
+         worker — the reseed keeps the rejoiner's published vtime on the \
+         frontier (RED on revert: rejoiner publishes ~0 -> throttle)",
+    );
+    assert_eq!(
+        survivor.queues[0].v_min.v_min_throttles_scratch, 0,
+        "no throttle should have been recorded for the survivor",
+    );
+}
+
+/// #4254 (R-7): the reseed distinguishes a rejoining-0 worker from a
+/// GENUINE laggard. A genuine laggard (a live peer with a real, lower
+/// published vtime — never reconstructed) must remain the cross-worker
+/// V_min that everyone defers to. Seeding the rejoiner to the MAX peer
+/// (frontier) — not the min — guarantees it never becomes a new
+/// artificial low, and the seeded rejoiner still defers to the genuine
+/// laggard.
+#[test]
+fn vmin_r7_seeded_rejoiner_still_defers_to_genuine_laggard() {
+    const FRONTIER: u64 = 100 * 1024 * 1024 * 1024;
+    // A genuine laggard: real, lower cumulative vtime, well below the
+    // frontier and below FRONTIER minus any plausible lag.
+    const LAGGARD: u64 = 40 * 1024 * 1024 * 1024;
+
+    // 3 workers: 0 = survivor-high, 2 = genuine laggard, 1 = rejoiner.
+    let floor = Arc::new(SharedCoSQueueVtimeFloor::new(3));
+    floor.slots[0].publish(FRONTIER);
+    floor.slots[2].publish(LAGGARD);
+
+    let mut rejoiner = test_cos_runtime_with_queues(10_000_000_000 / 8, vec![r7_exact_queue(0)]);
+    let fast = vec![test_queue_fast_path_for_promotion_with_floor(
+        true,
+        Some(Arc::clone(&floor)),
+    )];
+    apply_cos_queue_flow_fair_promotion(&mut rejoiner, &fast, 1);
+
+    // Seed is the MAX peer (frontier), NOT the laggard's low value and
+    // NOT 0.
+    assert_eq!(
+        test_flow_fair_state(&rejoiner.queues[0]).queue_vtime,
+        FRONTIER,
+        "rejoiner must seed to the frontier (max peer), not the genuine \
+         laggard's lower vtime and not 0",
+    );
+
+    // Evaluate the rejoiner's OWN gate: with peers {slot0=FRONTIER,
+    // slot2=LAGGARD}, V_min == LAGGARD. The rejoiner sits at FRONTIER,
+    // far past LAGGARD + lag, so it MUST throttle — i.e. it defers to the
+    // genuine laggard. The fix does not let a rejoiner ignore a
+    // legitimately-behind peer.
+    assert!(
+        !cos_queue_v_min_continue(&mut rejoiner.queues[0], 1),
+        "the seeded rejoiner MUST still throttle (defer) to a genuine \
+         laggard peer whose real vtime is the cross-worker V_min",
     );
 }

--- a/userspace-dp/src/afxdp/tx/test_support.rs
+++ b/userspace-dp/src/afxdp/tx/test_support.rs
@@ -535,6 +535,24 @@ pub(in crate::afxdp) fn test_queue_fast_path_for_promotion(
     }
 }
 
+/// #4254 (R-7): promotion fast-path carrying a real
+/// `SharedCoSQueueVtimeFloor` Arc so tests can drive the production
+/// `promote_cos_queue_flow_fair` reseed path with pre-populated peer
+/// slots. Mirrors `test_queue_fast_path_for_promotion` but attaches the
+/// shared floor the coordinator would clone onto a shared_exact queue.
+pub(in crate::afxdp) fn test_queue_fast_path_for_promotion_with_floor(
+    shared_exact: bool,
+    vtime_floor: Option<Arc<SharedCoSQueueVtimeFloor>>,
+) -> WorkerCoSQueueFastPath {
+    WorkerCoSQueueFastPath {
+        shared_exact,
+        owner_worker_id: 0,
+        owner_live: None,
+        shared_queue_lease: None,
+        vtime_floor,
+    }
+}
+
 /// Build a Prepared CoS item whose frame lives in `umem` at the
 /// given offset. Copies `packet_bytes` into the UMEM in place,
 /// then returns the `CoSPendingTxItem::Prepared` referencing

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/vtime.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/vtime.rs
@@ -191,4 +191,39 @@ impl SharedCoSQueueVtimeFloor {
             (participating, Some(v_min))
         }
     }
+
+    /// #4254 (R-7) — peer virtual-time **frontier** for seeding a
+    /// (re)joining worker's fresh `queue_vtime`. Returns the MAX
+    /// committed vtime across participating peers (excluding
+    /// `worker_id`'s own slot), or `None` if no peer participates.
+    ///
+    /// `queue_vtime` is cumulative served-bytes with no shared epoch, so
+    /// a worker whose runtime was just rebuilt (config commit / XDP
+    /// rebind / per-binding reset) restarts at 0 on a baseline that no
+    /// longer matches its surviving peers. Publishing that near-zero
+    /// value pins the cross-worker V_min to ~0 and traps every survivor
+    /// in the throttle → hard-cap → suspend duty cycle. Seeding the
+    /// rejoiner to this frontier re-anchors it on the survivors'
+    /// baseline before its first publish.
+    ///
+    /// Why MAX (not the participating V_min): the frontier is the
+    /// do-no-harm seed — a rejoiner placed at the max can never become a
+    /// NEW cross-worker V_min below any existing peer, so it does not
+    /// alter the survivors' throttle decisions at the join instant, and
+    /// it still defers to a genuine laggard (whose real, lower slot
+    /// remains the V_min everyone obeys). Same Acquire-load,
+    /// non-atomic-across-slots contract as `participating_v_min_snapshot`.
+    #[inline]
+    pub(in crate::afxdp) fn peer_frontier_vtime(&self, worker_id: u32) -> Option<u64> {
+        let mut frontier: Option<u64> = None;
+        for (idx, slot) in self.slots.iter().enumerate() {
+            if idx == worker_id as usize {
+                continue;
+            }
+            if let Some(peer) = slot.read() {
+                frontier = Some(frontier.map_or(peer, |f| f.max(peer)));
+            }
+        }
+        frontier
+    }
 }


### PR DESCRIPTION
## What

Fixes fable-review-166 finding **R-7** (converged plan #4245). The
cross-worker MQFQ V_min fairness brake compares **absolute** `queue_vtime`
values. `queue_vtime` is cumulative served-bytes with no shared epoch, so
the comparison is only meaningful while every participant shares a
baseline.

A worker whose per-interface CoS runtime is rebuilt — config commit, XDP
rebind, per-binding `reset_binding_cos_runtime` — restarts its
`FlowFairState` at `queue_vtime = 0`. Its first post-settle publish then
broadcasts a near-zero vtime into the shared V_min floor. A surviving
peer terabytes of cumulative vtime ahead fails the gate every batch
(`cos_queue_v_min_continue`: `ff.queue_vtime <= v_min + lag`), burns
`V_MIN_CONSECUTIVE_SKIP_HARD_CAP`, and arms `V_MIN_SUSPENSION_BATCHES`
(=1000) suspended drains — permanently. The fairness brake is effectively
OFF ~99% of the time for the rejoiner's entire re-warmup, with only
`v_min_hard_cap_overrides` climbing. The existing vacate path handles
only a departing worker's stale-HIGH slot, not a rejoiner's stale-LOW one.

## Fix

Seed a rebuilt shared_exact queue's fresh `queue_vtime` to the current
cross-worker **peer frontier** (the MAX participating peer slot) in
`promote_cos_queue_flow_fair` (`cos/admission.rs`). That is the sole
reconstruction site for a shared_exact `FlowFairState` — exact queues
never demote, so the best-effort re-promotion path is not involved —
reached on every runtime rebuild via `ensure_cos_interface_runtime_cold`.
New `SharedCoSQueueVtimeFloor::peer_frontier_vtime` provides the frontier
under the same Acquire-load, non-atomic-across-slots contract as
`participating_v_min_snapshot`.

**MAX, not the participating V_min**, is the do-no-harm seed: a rejoiner
placed at the frontier can never become a NEW cross-worker V_min below an
existing peer, so it does not perturb the survivors' throttle decisions,
yet it still defers to a GENUINE laggard. A genuine laggard is a live
peer at a real lower vtime that was never reconstructed — it never
reaches this construction site, so it is never reseeded. That is how the
fix distinguishes **"rejoining at 0"** (reseed) from **"legitimately
behind"** (leave alone; still deferred-to). Cold start / full
simultaneous reset → no participating peer → frontier `None` → seed stays
0 (byte-identical to before). Only shared_exact queues carry a
`vtime_floor`, so owner-local exact queues keep the plain 0 seed.

## Tests

`v_min_tests.rs`:
- `vmin_peer_frontier_vtime_max_excludes_self_and_none_when_empty` — the
  helper: MAX peer, self-exclusion, `None` when empty.
- `vmin_r7_rejoiner_seeds_to_peer_frontier_not_zero` — seed value pinned;
  cold-start keeps 0.
- `vmin_r7_rejoiner_does_not_trap_surviving_peer` — the T-7 trap scenario
  end-to-end: survivor's gate continues (no trap) after a rejoiner resets.
- `vmin_r7_seeded_rejoiner_still_defers_to_genuine_laggard` — the seeded
  rejoiner throttles to a real low peer (distinction preserved).

**RED-on-revert verified**: disabling the seed fails both the seed-value
and survivor-not-trapped assertions.

FULL `cargo test --release` green: **3540 passed, 0 failed** (+4 new).

## Validation flag

This changes a fairness mechanism on the shared_exact multi-worker path —
**needs a cluster CoS fairness smoke** on `loss:xpf-userspace-fw0/fw1`
before/with merge (not run here per the engineer-stop scope).

Closes #4254
Refs #4245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi