### PR TITLE
cos: fix TX-path queue-service fairness bugs (hb166 T-2, T-5)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -34874,3 +34874,37 @@ top.
   userspace-dp/src/afxdp/tx/test_support.rs,
   userspace-dp/src/afxdp/cos/queue_ops/v_min_tests.rs,
   docs/fairness-regimes.md, _Log.md
+
+- **Timestamp**: 2026-07-04
+- **Action**: Fix two TX-path CoS queue-service bugs (fable-review-166
+  T-2 HIGH + T-5 Medium). T-2 (#4256): the guarantee-rate waterfill
+  selector debited the Phase-1 budget and set the honored-epoch bit at
+  SELECTION; a zero-byte TX (ring full / no free frame / build Drop)
+  did not refund, burning the small class's 200 µs epoch guarantee
+  while Phase-2 classes stayed re-selectable. Fix: carry the committed
+  honor (debit bytes + ordinal) out of the selector on the returned
+  selection and REFUND it in the service wrapper on progress == false
+  (add debit back, clear bit); phase1_admissions now counts progressing
+  services and a new phase1_selected_no_progress counter records the
+  refunded no-progress visits (surfaced Rust runtime -> snapshot ->
+  protocol -> Go mirror, additive + omitempty). Interface-wide TX
+  pressure means refund+retry does not differentially starve peers. T-5
+  (#4257): cos_flow_aware_buffer_limit's #717 delay_cap = rate × 5 ms
+  computed 0 for an unshaped (rate == 0) flow-fair queue, pinning the
+  aggregate cap at base and dropping a new flow's first packet (rate-0
+  twin of #704/#707). Fix: anchor the delay rate to a 10 Gb/s physical
+  link-rate floor (COS_FLOW_FAIR_UNSHAPED_DRAIN_RATE_BYTES) when
+  unshaped; shaped path bit-identical. RED-on-revert tests added for
+  both (waterfill_phase1_honor_refund_* + service_exact_guarantee_zero_
+  tx_refunds_phase1_honor; cos_flow_aware_buffer_limit_expands_for_
+  unshaped_rate0_queue). Needs a cluster CoS smoke (TX-path fairness).
+- **File(s)**: userspace-dp/src/afxdp/cos/queue_service/mod.rs,
+  userspace-dp/src/afxdp/cos/queue_service/tests.rs,
+  userspace-dp/src/afxdp/cos/admission.rs,
+  userspace-dp/src/afxdp/cos/admission_tests.rs,
+  userspace-dp/src/afxdp/types/cos.rs,
+  userspace-dp/src/afxdp/worker/cos/queue_row.rs,
+  userspace-dp/src/afxdp/coordinator/cos_leases.rs,
+  userspace-dp/src/protocol/cos.rs,
+  pkg/dataplane/userspace/protocol.go,
+  docs/fairness-regimes.md, _Log.md

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -505,7 +505,16 @@ exact classes deeper buffers than the implicit admission/buffer cap:
 `max(transmit_rate_bytes/100, 96_000)` (10 ms of bytes with a 96 KB
 floor), then admission applies the flow-aware
 `prospective_active * 24 KB` expansion plus the #717 5 ms envelope clamp
-(`.min(delay_cap.max(base))`). #1312 showed that those implicit caps
+(`.min(delay_cap.max(base))`). For an UNSHAPED flow-fair queue
+(`transmit_rate_bytes == 0`, i.e. no per-queue shaper) the delay cap is
+anchored to a physical link-rate floor
+(`COS_FLOW_FAIR_UNSHAPED_DRAIN_RATE_BYTES`, 10 Gb/s) rather than the
+literal 0 rate — an unshaped queue drains at line rate, not zero. Before
+hb166 T-5 the rate-0 `delay_cap` computed 0, so `.min(delay_cap.max(base))`
+pinned the aggregate cap at `base` regardless of flow count: the
+flow-aware expansion collapsed and a new flow's first packet was dropped
+at the aggregate cap (the rate-0 twin of the #704/#707 regression). #1312
+showed that those implicit caps
 reproduce reverse-mode tail-drop under `-P 12` even when equal-flow
 suppression is disabled: the 100M class hit aggregate admission drops,
 and the 1G class hit per-flow share drops. The fixture overrides
@@ -1241,6 +1250,21 @@ unit policy:
   proportionally across the queues NOT fully honoured in Phase 1
   (with the partial-honour queue carrying its REMAINING quantum,
   not its full quantum, so total alloc per queue ≤ Q_i).
+
+  **Zero-TX honor refund (hb166 T-2):** the selector debits the
+  Phase-1 budget and sets the honored-epoch bit at SELECTION, but the
+  service wrapper REFUNDS both (adds the debit back, clears the bit) if
+  the selected queue transmits zero bytes — a transient TX failure (TX
+  ring full, no free UMEM frame, frame-build Drop) must not burn the
+  small class's 200 µs epoch guarantee. The failure is interface-wide
+  (all CoS queues share one TX ring / UMEM pool), so a refund + retry
+  does not differentially starve other queues; the worker reaps
+  completions between drain passes. `phase1_admissions` therefore counts
+  only visits that made TX progress; `phase1_selected_no_progress`
+  counts the refunded no-progress visits (climbing there with flat
+  `phase1_admissions` on a backlogged small class = TX-ring pressure
+  eating the guarantee pass). A queue that DID transmit keeps its honor
+  consumed — no double-consume, no honor leak.
 
   **Claim-side work conservation (#1863, Path A-ii):** the per-class
   v8 lease that fuels the selector's token banks publishes a per-epoch

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -1971,6 +1971,12 @@ type CoSQueueStatus struct {
 	WaterfillPhase1Admissions uint64 `json:"waterfill_phase1_admissions,omitempty"`
 	WaterfillPhase2Admissions uint64 `json:"waterfill_phase2_admissions,omitempty"`
 	WaterfillEligibleVisits   uint64 `json:"waterfill_eligible_visits,omitempty"`
+	// hb166 T-2: Phase-1 honored selections that made ZERO TX progress and
+	// had their budget debit + honored bit refunded. Climbing here with
+	// flat WaterfillPhase1Admissions = TX-ring pressure eating a small
+	// class's guarantee pass. omitempty keeps a pre-hb166 daemon's absent
+	// field at 0 (rolling-upgrade safe).
+	WaterfillPhase1SelectedNoProgress uint64 `json:"waterfill_phase1_selected_no_progress,omitempty"`
 	// #1829 Phase 1: dequeue-time sojourn telemetry. JSON tags MUST
 	// match the Rust serde rename(...) in protocol/cos.rs exactly.
 	// All three are MAX-merged across worker instances and across

--- a/userspace-dp/src/afxdp/coordinator/cos_leases.rs
+++ b/userspace-dp/src/afxdp/coordinator/cos_leases.rs
@@ -317,6 +317,10 @@ pub(super) fn aggregate_cos_statuses_across_workers(
                 q.waterfill_eligible_visits = q
                     .waterfill_eligible_visits
                     .saturating_add(queue.waterfill_eligible_visits);
+                // hb166 T-2: refunded zero-TX Phase-1 honored selections.
+                q.waterfill_phase1_selected_no_progress = q
+                    .waterfill_phase1_selected_no_progress
+                    .saturating_add(queue.waterfill_phase1_selected_no_progress);
                 // #1829 Phase 1: sojourn telemetry MAX-merges across
                 // workers (worst instance), matching the worker-side
                 // MAX in queue_row.rs — see the AGGREGATION contract

--- a/userspace-dp/src/afxdp/cos/admission.rs
+++ b/userspace-dp/src/afxdp/cos/admission.rs
@@ -47,6 +47,24 @@ pub(in crate::afxdp) const COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS: u64 = 5_000_000;
 // no room to grow cwnd past a handful of packets.
 const _: () = assert!(COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS >= 1_000_000);
 
+/// #717 hb166 T-5: assumed drain rate for the delay cap on an UNSHAPED
+/// (transparent) flow-fair queue. `transmit_rate_bytes == 0` means
+/// "no shaper / full bucket", NOT "zero drain rate" — an unshaped queue
+/// drains at the physical link rate. Anchoring the #717 delay cap to
+/// this floor (instead of the literal 0 rate) keeps the flow-aware
+/// aggregate buffer expanding for a new flow on an unshaped queue, so a
+/// mouse's first packet is not dropped at the aggregate cap while
+/// resident elephant bytes stay — the #704/#707 regression that a
+/// rate-0 `delay_cap == 0` resurrected. 10 Gb/s (1.25 GB/s) matches the
+/// cluster VF line rate and yields a 6.25 MB delay cap, consistent with
+/// a 10 G SHAPED queue rather than the ~98 MB an uncapped rate-0 queue
+/// would otherwise reach.
+pub(in crate::afxdp) const COS_FLOW_FAIR_UNSHAPED_DRAIN_RATE_BYTES: u64 = 1_250_000_000;
+
+// Compile-time sanity: a positive floor is the whole point — a zero
+// floor would re-collapse the delay cap to 0 for unshaped queues.
+const _: () = assert!(COS_FLOW_FAIR_UNSHAPED_DRAIN_RATE_BYTES > 0);
+
 /// ECN CE-marking threshold as a fraction of the relevant cap.
 /// Applied to both the aggregate `buffer_limit` and the per-flow
 /// `share_cap` in `apply_cos_admission_ecn_policy`.
@@ -214,6 +232,14 @@ pub(in crate::afxdp) fn cos_queue_flow_share_limit(
 /// explicit `buffer-size`, so an operator who asked for a deeper
 /// buffer still gets it. Adds one u128 multiply + divide per admission
 /// decision, not per packet.
+///
+/// hb166 T-5: for an UNSHAPED (`transmit_rate_bytes == 0`) flow-fair
+/// queue the delay rate is anchored to
+/// `COS_FLOW_FAIR_UNSHAPED_DRAIN_RATE_BYTES` (physical link rate),
+/// NOT the literal 0. A 0 rate collapses `delay_cap` to 0, which pins
+/// the aggregate cap at `base` and drops a new flow's first packet
+/// (the rate-0 twin of the #704/#707 regression this expansion exists
+/// to prevent).
 #[inline]
 pub(in crate::afxdp) fn cos_flow_aware_buffer_limit(
     queue: &CoSQueueRuntime,
@@ -224,10 +250,21 @@ pub(in crate::afxdp) fn cos_flow_aware_buffer_limit(
         return base;
     }
     let prospective_active = cos_queue_prospective_active_flows(queue, flow_bucket);
+    // #717 hb166 T-5: rate 0 means "unshaped", not "zero drain rate". A
+    // literal 0 rate collapses `delay_cap` to 0, so `.min(delay_cap.max(
+    // base))` pins the aggregate cap at `base` regardless of flow count —
+    // the flow-aware expansion never fires and a new flow's first packet is
+    // dropped at the aggregate cap (the #704/#707 regression, rate-0 twin).
+    // An unshaped queue drains at the physical link rate, so anchor the
+    // delay cap to the link-rate floor when unshaped; the shaped (rate > 0)
+    // path is bit-identical.
+    let delay_rate = match queue.transmit_rate_bytes() {
+        0 => COS_FLOW_FAIR_UNSHAPED_DRAIN_RATE_BYTES,
+        rate => rate,
+    };
     // u128 to keep the intermediate product safe at 10 Gbps × 5 ms
     // (plus any plausible operator-configured rate inflation).
-    let delay_cap = ((queue.transmit_rate_bytes() as u128)
-        * (COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS as u128)
+    let delay_cap = ((delay_rate as u128) * (COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS as u128)
         / 1_000_000_000u128) as u64;
     base.max(prospective_active.saturating_mul(COS_FLOW_FAIR_MIN_SHARE_BYTES))
         .min(delay_cap.max(base))

--- a/userspace-dp/src/afxdp/cos/admission_tests.rs
+++ b/userspace-dp/src/afxdp/cos/admission_tests.rs
@@ -1032,6 +1032,88 @@ fn cos_flow_aware_buffer_limit_scales_with_prospective_active_flow_count() {
     );
 }
 
+/// hb166 T-5: the rate-0 twin of
+/// `cos_flow_aware_buffer_limit_scales_with_prospective_active_flow_count`.
+/// An UNSHAPED (`transmit_rate_bytes == 0`) flow-fair queue must STILL
+/// expand its aggregate cap with the prospective flow count. Before the
+/// fix the #717 `delay_cap = rate × 5 ms` computed 0 at rate 0, so
+/// `.min(delay_cap.max(base))` pinned the cap at `base` regardless of
+/// flow count — the flow-aware expansion collapsed and a new flow's
+/// first packet was dropped at the aggregate cap (the rate-0 twin of the
+/// #704/#707 regression). The fix anchors the delay rate to the physical
+/// link-rate floor when unshaped, so the cap expands exactly as a shaped
+/// queue at that rate would.
+#[test]
+fn cos_flow_aware_buffer_limit_expands_for_unshaped_rate0_queue() {
+    // transmit_rate_bytes == 0 → "unshaped / full bucket". base = 125 KB
+    // (< 16 × 24 KB) so the flow-aware expansion is observable.
+    let mut root = test_cos_runtime_with_queues(
+        // Root is transparent too (shaping_rate_bytes irrelevant to this
+        // per-queue admission cap; the queue's own rate is what collapsed).
+        0,
+        vec![CoSQueueConfig {
+            queue_id: 4,
+            forwarding_class: "unshaped-a".into(),
+            priority: 5,
+            transmit_rate_bytes: 0,
+            guarantee_enabled: true,
+            exact: true,
+            surplus_sharing: false,
+            equal_flow_enforcement: false,
+            equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+            surplus_weight: 1,
+            buffer_bytes: 125_000,
+            dscp_rewrite: None,
+            codel_target_ns: 0,
+        }],
+    );
+    let queue = &mut root.queues[0];
+    enable_test_flow_fair(queue);
+    assert_eq!(
+        queue.transmit_rate_bytes(),
+        0,
+        "precondition: this exercises the unshaped rate-0 regime"
+    );
+
+    // Low flow count: base still wins (prospective × MIN_SHARE < base).
+    test_flow_fair_state_mut(queue).active_flow_buckets = 2;
+    assert_eq!(
+        cos_flow_aware_buffer_limit(queue, 0),
+        queue.config.buffer_bytes.max(COS_MIN_BURST_BYTES),
+        "3 prospective × 24 KB = 72 KB < 125 KB base, so base wins even unshaped"
+    );
+
+    // High flow count: the aggregate cap MUST expand to
+    // prospective × MIN_SHARE. Pre-fix this collapsed back to `base`
+    // because delay_cap was 0 — the RED-on-revert assertion.
+    test_flow_fair_state_mut(queue).active_flow_buckets = 16;
+    for bucket in 0..16 {
+        test_flow_fair_state_mut(queue).flow_bucket_bytes[bucket] = 1_000;
+    }
+    assert_eq!(
+        cos_flow_aware_buffer_limit(queue, 0),
+        16 * COS_FLOW_FAIR_MIN_SHARE_BYTES,
+        "unshaped rate-0 queue must still expand to 16 × 24 KB = 384 KB, \
+         not collapse to the 125 KB base (T-5: delay_cap must not be 0)"
+    );
+
+    // New-flow first-packet protection (#704/#707): with 15 resident
+    // flows and the target bucket EMPTY, prospective = 16, so the
+    // aggregate cap reserves room for the arriving 16th flow rather than
+    // pinning at base and dropping its first packet.
+    test_flow_fair_state_mut(queue).active_flow_buckets = 15;
+    for bucket in 0..15 {
+        test_flow_fair_state_mut(queue).flow_bucket_bytes[bucket] = 1_000;
+    }
+    let new_flow_bucket = 15;
+    test_flow_fair_state_mut(queue).flow_bucket_bytes[new_flow_bucket] = 0;
+    assert_eq!(
+        cos_flow_aware_buffer_limit(queue, new_flow_bucket),
+        16 * COS_FLOW_FAIR_MIN_SHARE_BYTES,
+        "unshaped queue must reserve aggregate room for a new flow's first packet"
+    );
+}
+
 #[test]
 fn cos_flow_aware_buffer_limit_matches_share_limit_at_new_flow_boundary() {
     // #716 review: the aggregate cap and the per-flow clamp must

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -524,9 +524,21 @@ fn refund_phase1_waterfill_honor(
     queue_idx: usize,
     refund: Phase1HonorRefund,
 ) {
-    let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) else {
-        return;
-    };
+    if let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) {
+        apply_phase1_waterfill_honor_refund(root, queue_idx, refund);
+    }
+}
+
+/// Root-scoped body of the Phase-1 honor refund (see
+/// `refund_phase1_waterfill_honor`), split out so it is exercisable
+/// without a full `BindingWorker`. Restores the debited budget, clears
+/// the honored-epoch bit, and corrects the telemetry.
+#[inline]
+fn apply_phase1_waterfill_honor_refund(
+    root: &mut CoSInterfaceRuntime,
+    queue_idx: usize,
+    refund: Phase1HonorRefund,
+) {
     root.waterfill_pass1_remaining_bytes = root
         .waterfill_pass1_remaining_bytes
         .saturating_add(refund.cost_bytes);

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -103,6 +103,30 @@ pub(in crate::afxdp) struct ExactCoSQueueSelection {
     pub(in crate::afxdp) queue_idx: usize,
     pub(in crate::afxdp) secondary_budget: u64,
     kind: ExactCoSQueueKind,
+    /// hb166 T-2: `Some` only for a Phase-1 HONORED waterfill selection,
+    /// carrying the epoch honor that must be UNDONE if the service call
+    /// makes zero TX progress. The waterfill selector debits the Phase-1
+    /// budget and sets the honored-epoch bit at selection time; a
+    /// zero-byte TX (ring full / no free frame / build Drop) must not
+    /// burn the small class's 200 us epoch guarantee, so the service
+    /// wrapper refunds the debit + clears the bit on `progress == false`.
+    /// `None` for fast-path, Phase-2, and legacy-RR selections (which set
+    /// no honor bit and debit no budget), so they refund nothing.
+    phase1_honor: Option<Phase1HonorRefund>,
+}
+
+/// hb166 T-2: the Phase-1 waterfill honor to refund on a zero-byte-TX
+/// service failure. Captured at selection so the service wrapper can undo
+/// exactly what the selector committed, without re-deriving it.
+#[derive(Clone, Copy)]
+struct Phase1HonorRefund {
+    /// Bytes debited from `waterfill_pass1_remaining_bytes` at selection
+    /// (the queue's stable `phase1_cost`), to add back on no-progress.
+    cost_bytes: u64,
+    /// Ascending-vec ordinal `i` whose bit was set in
+    /// `waterfill_honored_epoch_bits`. `>= 64` means the ordinal was out
+    /// of the u64 bitset range and no bit was set (nothing to clear).
+    bit_ordinal: u32,
 }
 
 pub(in crate::afxdp) enum ExactCoSScratchBuild {
@@ -452,6 +476,12 @@ fn service_exact_guarantee_queue_direct_with_info(
         ),
     };
 
+    if !progress {
+        if let Some(refund) = selection.phase1_honor {
+            refund_phase1_waterfill_honor(binding, root_ifindex, selection.queue_idx, refund);
+        }
+    }
+
     Some(if progress {
         queue_id.map(|queue_id| DrainedQueueRef {
             root_ifindex,
@@ -461,6 +491,54 @@ fn service_exact_guarantee_queue_direct_with_info(
     } else {
         None
     })
+}
+
+/// hb166 T-2: undo the Phase-1 waterfill honor for a queue that was
+/// SELECTED via the Phase-1 honored walk but transmitted zero bytes (TX
+/// ring full / no free UMEM frame / frame-build Drop → service returned
+/// `progress == false`).
+///
+/// The waterfill selector commits the honor at SELECTION: it debits
+/// `waterfill_pass1_remaining_bytes` by the queue's stable `phase1_cost`
+/// and sets the queue's ascending-ordinal bit in
+/// `waterfill_honored_epoch_bits`, marking it "already took its guarantee
+/// this epoch" so BOTH phases skip it until the epoch refills (~200 us).
+/// A zero-byte TX must NOT burn that guarantee — the small class should
+/// keep its honor and retry once the interface-wide TX-ring / free-frame
+/// pressure clears. This refund restores the debit and clears the bit so
+/// the queue is re-selectable this same epoch.
+///
+/// Correctness: the debit is undone by the exact `cost_bytes` captured at
+/// selection, and nothing else mutates `waterfill_pass1_remaining_bytes`
+/// between selection and this refund on the single-threaded owner (so the
+/// `saturating_add` cannot exceed the pre-selection budget → no honor
+/// leak). A queue that DID transmit keeps its honor consumed (this runs
+/// only on `progress == false` → no double-consume). Telemetry:
+/// `phase1_admissions` was bumped at selection, so decrement it (it must
+/// count only progressing services) and record the no-progress in
+/// `phase1_selected_no_progress`.
+#[inline]
+fn refund_phase1_waterfill_honor(
+    binding: &mut BindingWorker,
+    root_ifindex: i32,
+    queue_idx: usize,
+    refund: Phase1HonorRefund,
+) {
+    let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) else {
+        return;
+    };
+    root.waterfill_pass1_remaining_bytes = root
+        .waterfill_pass1_remaining_bytes
+        .saturating_add(refund.cost_bytes);
+    if refund.bit_ordinal < 64 {
+        root.waterfill_honored_epoch_bits &= !(1u64 << refund.bit_ordinal);
+    }
+    if let Some(queue) = root.queues.get_mut(queue_idx) {
+        let counters = &mut queue.telemetry.waterfill_counters;
+        counters.phase1_admissions = counters.phase1_admissions.saturating_sub(1);
+        counters.phase1_selected_no_progress =
+            counters.phase1_selected_no_progress.wrapping_add(1);
+    }
 }
 
 #[cfg(test)]
@@ -757,6 +835,9 @@ fn select_exact_cos_guarantee_queue_with_lease_telemetry(
             queue_idx,
             secondary_budget,
             kind,
+            // Legacy Proportional RR selector: no Phase-1 waterfill honor
+            // to refund (it debits no budget and sets no honored bit).
+            phase1_honor: None,
         });
     }
     None
@@ -1098,6 +1179,15 @@ fn select_exact_cos_guarantee_queue_waterfill(
             queue_idx,
             secondary_budget: send_budget,
             kind,
+            // hb166 T-2: carry the epoch honor just committed above
+            // (budget debit at `:1104`, honored bit at `:1112`) so the
+            // service wrapper can REFUND it if this queue transmits zero
+            // bytes. `cost_bytes` is always debited; the bit was set only
+            // when `i < 64`, so the refund clears it under the same guard.
+            phase1_honor: Some(Phase1HonorRefund {
+                cost_bytes: phase1_cost,
+                bit_ordinal: i as u32,
+            }),
         });
     }
     // Phase 2: descending-rate walk over queues NOT honored in Phase 1
@@ -1214,6 +1304,9 @@ fn select_exact_cos_guarantee_queue_waterfill(
             queue_idx,
             secondary_budget: candidate_budget,
             kind,
+            // Phase 2 debits no Phase-1 budget and sets no honored bit, so
+            // a zero-byte TX here loses nothing — nothing to refund.
+            phase1_honor: None,
         });
     }
     // Genuine Phase-2 WRAP: a full descending cycle serviced nothing, so the

--- a/userspace-dp/src/afxdp/cos/queue_service/tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests.rs
@@ -3639,3 +3639,123 @@ fn build_cos_batch_clears_pop_snapshot_stack_across_batches() {
         "#3968: stack must not realloc past TX_BATCH_SIZE",
     );
 }
+
+// hb166 T-2: a Phase-1 honored waterfill selection whose service makes
+// ZERO TX progress must have its epoch honor REFUNDED, not burned.
+
+/// Unit-level: the refund helper restores the debited Phase-1 budget,
+/// clears the honored-epoch bit, and corrects the telemetry
+/// (phase1_admissions back to 0, phase1_selected_no_progress = 1).
+#[test]
+fn waterfill_phase1_honor_refund_restores_budget_clears_bit_and_counts() {
+    let mut root = waterfill_guarantee_rate_root(1.0);
+    let mut tel = CoSQueueLeaseAcquireTelemetry::default();
+    let s = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel)
+        .expect("phase-1 selection");
+
+    // The smallest exact queue is ascending ordinal 0.
+    let refund = s
+        .phase1_honor
+        .expect("a Phase-1 honored selection must carry refund info");
+    assert!(refund.cost_bytes > 0, "a Phase-1 honor debits real bytes");
+    assert_eq!(refund.bit_ordinal, 0, "smallest exact queue is ordinal 0");
+
+    let budget_debited = root.waterfill_pass1_remaining_bytes;
+    assert_ne!(
+        root.waterfill_honored_epoch_bits & 0b1,
+        0,
+        "selection set the ordinal-0 honored bit"
+    );
+    assert_eq!(
+        root.queues[s.queue_idx]
+            .telemetry
+            .waterfill_counters
+            .phase1_admissions,
+        1,
+        "selection bumped phase1_admissions"
+    );
+
+    // Zero-byte TX: refund the honor.
+    apply_phase1_waterfill_honor_refund(&mut root, s.queue_idx, refund);
+
+    assert_eq!(
+        root.waterfill_pass1_remaining_bytes,
+        budget_debited + refund.cost_bytes,
+        "refund adds the debited cost back to the Phase-1 budget"
+    );
+    assert_eq!(
+        root.waterfill_honored_epoch_bits & 0b1,
+        0,
+        "refund clears the honored bit so the class is re-selectable this epoch"
+    );
+    let counters = root.queues[s.queue_idx].telemetry.waterfill_counters;
+    assert_eq!(
+        counters.phase1_admissions, 0,
+        "refund undoes the over-counted admission (counts services, not selections)"
+    );
+    assert_eq!(
+        counters.phase1_selected_no_progress, 1,
+        "refund records the no-progress visit"
+    );
+}
+
+/// End-to-end wiring: with the TX free-frame pool exhausted, the
+/// service wrapper's Phase-1 honored selection makes zero progress and
+/// the honor is refunded via the production
+/// `service_exact_guarantee_queue_direct_with_info` path. RED-on-revert:
+/// without the refund the honored bit stays set (`0b1`) and the class is
+/// skipped for the rest of the epoch.
+#[test]
+fn service_exact_guarantee_zero_tx_refunds_phase1_honor() {
+    let root = waterfill_guarantee_rate_root(1.0);
+    let root_lease = Arc::new(SharedCoSRootLease::new(
+        root.shaping_rate_bytes,
+        root.burst_bytes,
+        1,
+    ));
+    let fast_interfaces = test_cos_fast_interfaces(
+        42,
+        42,
+        0,
+        vec![
+            (0, test_queue_fast_path(false, 0, None, None)),
+            (1, test_queue_fast_path(false, 0, None, None)),
+            (2, test_queue_fast_path(false, 0, None, None)),
+            (3, test_queue_fast_path(false, 0, None, None)),
+        ],
+        None,
+        Some(root_lease),
+    );
+    let fast_path = fast_interfaces.get(&42).expect("test fast path").clone();
+    let mut binding = BindingWorker::new_for_cos_drain_test(0, 0, 42, root, fast_path);
+
+    // Force every service call to make zero TX progress: no free UMEM
+    // frames and nothing to reap. This is the interface-wide TX-pressure
+    // condition that the pre-fix code let burn the small class's epoch.
+    binding.tx_pipeline.free_tx_frames.clear();
+
+    let mut shared_recycles = Vec::new();
+    let mut tel = CoSQueueLeaseAcquireTelemetry::default();
+    let out =
+        service_exact_guarantee_queue_direct_with_info(&mut binding, 42, 1, &mut shared_recycles, &mut tel);
+    assert!(
+        matches!(out, Some(None)),
+        "exact selection fired but service made no TX progress"
+    );
+
+    let root = binding.cos.cos_interfaces.get(&42).expect("cos root");
+    assert_eq!(
+        root.waterfill_honored_epoch_bits & 0b1,
+        0,
+        "zero-TX Phase-1 selection must REFUND the honored bit (T-2), not burn the epoch"
+    );
+    let counters = root.queues[0].telemetry.waterfill_counters;
+    assert_eq!(
+        counters.phase1_admissions, 0,
+        "a no-progress selection must not count as an admission"
+    );
+    assert_eq!(
+        counters.phase1_selected_no_progress, 1,
+        "the refunded no-progress visit is recorded"
+    );
+}

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -1465,6 +1465,18 @@ pub(in crate::afxdp) struct CoSQueueWaterfillCounters {
     /// (low visits + high parks) from "genuinely idle on this owner"
     /// (low visits + low parks + zero queued_bytes).
     pub(in crate::afxdp) eligible_visits: u64,
+    /// hb166 T-2: times this queue was selected via the Phase-1 honored
+    /// walk but the subsequent service call transmitted zero bytes (TX
+    /// ring full / no free UMEM frame / frame-build Drop). On such a
+    /// no-progress visit the Phase-1 budget debit and honored-epoch bit
+    /// are REFUNDED (the class keeps its guarantee for a retry), so
+    /// `phase1_admissions` counts only visits that actually made TX
+    /// progress. A climbing `phase1_selected_no_progress` with flat
+    /// `phase1_admissions` on a backlogged small class is the fingerprint
+    /// of sustained TX-ring / completion-reap pressure eating the
+    /// guarantee pass (previously invisible: the pre-hb166 code counted
+    /// the failed selection as an admission and burned the epoch).
+    pub(in crate::afxdp) phase1_selected_no_progress: u64,
 }
 
 pub(in crate::afxdp) struct CoSTimerWheelRuntime {

--- a/userspace-dp/src/afxdp/worker/cos/queue_row.rs
+++ b/userspace-dp/src/afxdp/worker/cos/queue_row.rs
@@ -273,6 +273,15 @@ pub(super) fn accumulate_queue_row(
     status.waterfill_eligible_visits = status
         .waterfill_eligible_visits
         .saturating_add(queue.telemetry.waterfill_counters.eligible_visits);
+    // hb166 T-2: refunded zero-TX Phase-1 honored selections.
+    status.waterfill_phase1_selected_no_progress = status
+        .waterfill_phase1_selected_no_progress
+        .saturating_add(
+            queue
+                .telemetry
+                .waterfill_counters
+                .phase1_selected_no_progress,
+        );
     // #1829 Phase 1: sojourn telemetry, MAX-merged across worker
     // instances (NOT summed — each instance measures its own queue
     // runtime's delay; the row reports the worst instance, matching

--- a/userspace-dp/src/protocol/cos.rs
+++ b/userspace-dp/src/protocol/cos.rs
@@ -399,6 +399,14 @@ pub(crate) struct CoSQueueStatus {
     pub waterfill_phase2_admissions: u64,
     #[serde(rename = "waterfill_eligible_visits", default)]
     pub waterfill_eligible_visits: u64,
+    // hb166 T-2: times a Phase-1 honored selection made ZERO TX progress
+    // (ring full / no free frame / build Drop) and had its budget debit +
+    // honored bit REFUNDED. Climbing here with flat waterfill_phase1_
+    // admissions on a backlogged small class = TX-ring pressure eating the
+    // guarantee pass. `default` keeps a pre-hb166 daemon's absent field at
+    // 0 (rolling-upgrade safe).
+    #[serde(rename = "waterfill_phase1_selected_no_progress", default)]
+    pub waterfill_phase1_selected_no_progress: u64,
     // #1829 Phase 1: dequeue-time sojourn telemetry, sampled as
     // `now_ns - item.enqueue_ns` at the COMMITTED-PREFIX settle points
     // (after the TX insert accepts the item — Codex review on PR

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -428,6 +428,7 @@
     "tx_ring_full_submit_stalls": 0,
     "waterfill_eligible_visits": 0,
     "waterfill_phase1_admissions": 0,
+    "waterfill_phase1_selected_no_progress": 0,
     "waterfill_phase2_admissions": 0,
     "worker_instances": 0
   },


### PR DESCRIPTION
Closes #4256
Closes #4257

Two TX-path CoS queue-service fairness bugs in the AF_XDP userspace
dataplane, from fable-review-166. Disjoint files, both TX-path fairness,
one PR.

## T-2 (HIGH, #4256) — waterfill Phase-1 honor consumed at selection, not service

The guarantee-rate waterfill selector debited the Phase-1 budget
(`waterfill_pass1_remaining_bytes`) and set the honored-epoch bit at
SELECTION time, before the queue was serviced. When the subsequent
service call transmitted zero bytes (TX ring full / no free UMEM frame /
frame-build Drop -> `progress == false`), the honor was never refunded:
the honored small class was then skipped by BOTH phases for the rest of
the 200 us epoch while larger Phase-2 classes stayed re-selectable
(Phase 2 sets no honor bit and debits no budget). At ~5% ring-full
incidence a 100 Mb/s Phase-1 class lost ~5% of its guarantee, inverting
the #1732/#1743 small-first intent precisely under load.

**Fix** (`queue_service/mod.rs`): the selection now carries the
committed honor (debited bytes + honored ordinal) out of the selector,
and the service wrapper `service_exact_guarantee_queue_direct_with_info`
REFUNDS it (adds the debit back, clears the honored bit) via
`refund_phase1_waterfill_honor` when the queue makes zero TX progress. A
queue that DID transmit keeps its honor consumed -> no double-consume,
no honor leak. The refund runs only for Phase-1 honored selections
(`phase1_honor: Some`); fast-path / Phase-2 / legacy-RR selections carry
`None` and refund nothing.

Why refund + retry does not starve peers: a full TX ring / empty
free-frame pool is interface-wide (all CoS queues on the interface share
one xsk TX ring + UMEM pool), so re-selecting the same queue next drain
pass causes no differential starvation -- every queue fails on the same
ring -- and the worker reaps completions between passes, at which point
the retry succeeds and the honor sticks.

Telemetry: `phase1_admissions` now counts only progressing services (the
refund decrements the selection-time bump). New
`phase1_selected_no_progress` counter records the refunded no-progress
visits, surfaced end-to-end (Rust runtime -> snapshot -> protocol serde
-> Go mirror, additive + omitempty, rolling-upgrade safe). Regenerated
the `protocol_wire_v1.json` golden fixture for the one additive field.

## T-5 (Medium/High, #4257) — unshaped flow-fair queue delay-cap collapses to 0

`cos_flow_aware_buffer_limit` bounds the flow-aware aggregate buffer
expansion by the #717 latency clamp
`delay_cap = transmit_rate_bytes * MAX_QUEUE_DELAY_NS / 1e9`. For an
UNSHAPED flow-fair queue `transmit_rate_bytes == 0` (rate 0 means
"unshaped / full bucket", not "zero drain rate"), so `delay_cap`
collapsed to 0 and `.min(delay_cap.max(base))` pinned the aggregate cap
at `base` regardless of flow count. The flow-aware expansion never fired
and a new flow's first packet was dropped at the aggregate cap while
resident elephant bytes stayed -- the rate-0 twin of the #704/#707
regression the expansion exists to prevent. Post-#1735 every CoS queue
is flow-fair-eligible, so unshaped queues hit this path.

**Fix** (`admission.rs`): anchor the delay rate to a physical
link-rate floor (`COS_FLOW_FAIR_UNSHAPED_DRAIN_RATE_BYTES` = 10 Gb/s)
when the queue is unshaped, so the delay cap no longer collapses and the
aggregate buffer expands for a new flow. This gives an unshaped queue a
delay cap consistent with a shaped queue at the same physical rate
(6.25 MB), rather than collapsing to base (today's bug) or expanding
unbounded to ~98 MB. The shaped (rate > 0) path is bit-identical.

## Tests (RED-on-revert verified)

- `waterfill_phase1_honor_refund_restores_budget_clears_bit_and_counts`
  (unit: refund arithmetic + telemetry).
- `service_exact_guarantee_zero_tx_refunds_phase1_honor` (end-to-end
  through the production wrapper with the TX free-frame pool exhausted;
  RED on revert of the wrapper refund call -> honored bit stays set).
- `cos_flow_aware_buffer_limit_expands_for_unshaped_rate0_queue` (RED on
  revert -> cap collapses to the 125 KB base instead of 384 KB).

Both RED-on-revert proofs were run: reverting each fix fails exactly the
matching assertion. FULL `cargo test --release` green (3549 + sibling
binaries, 0 failed). `go build ./pkg/dataplane/userspace/ ./pkg/api/` OK.

Docs: `docs/fairness-regimes.md` updated for both the unshaped delay-cap
floor and the zero-TX honor refund.

Needs a cluster CoS smoke (TX-path fairness) before merge -- not run in
this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi