### PR TITLE
cos: surface waterfill phase1_selected_no_progress via Prometheus + show formatter

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-07-05 — cos: surface waterfill phase1_selected_no_progress (#4262)
+
+- **Timestamp**: 2026-07-05
+  - **Action**: Surfaced the hb166 T-2 `waterfill_phase1_selected_no_progress`
+    counter (added in #4256/#4258) via Prometheus + the `show
+    class-of-service` formatter, mirroring its sibling
+    `waterfill_phase1_admissions`. Added the per-`{ifindex, queue_id}`
+    gauge `cosWaterfillPhase1SelectedNoProgress`
+    (`xpf_userspace_cos_waterfill_phase1_selected_no_progress_total`): the
+    Desc struct field + Describe emit in metrics.go, the NewDesc in
+    metrics_descriptors.go, and the CounterValue emit in the per-queue loop
+    of `emitCoSWaterfillTelemetry` (metrics_userspace.go). Added
+    `phase1_no_progress=%d` to the per-queue Waterfill row in
+    format/cos.go, with the view field, the copy-through in
+    buildCoSQueueViews, and the `hasWaterfillTelemetry` gate. Also folded a
+    comment-accuracy fix in protocol.go (~1979): a missing JSON field
+    decodes to 0 regardless of omitempty; omitempty only suppresses
+    emitting 0 on the wire. Extended the Prometheus test
+    (TestEmitCoSWaterfillTelemetry_EmitsQueueAndInterfaceMetrics) and added
+    a formatter test (TestFormatCoSInterfaceSummaryRendersWaterfillNoProgress).
+    Docs: cos-validation-notes.md (show example + per-queue bullet +
+    Prometheus list) and fairness-regimes.md (observability pointer).
+  - **File(s)**: pkg/api/metrics.go, pkg/api/metrics_descriptors.go,
+    pkg/api/metrics_userspace.go, pkg/api/metrics_test.go,
+    pkg/dataplane/userspace/format/cos.go,
+    pkg/dataplane/userspace/format/cos_test.go,
+    pkg/dataplane/userspace/protocol.go, docs/cos-validation-notes.md,
+    docs/fairness-regimes.md
+
 ## 2026-07-04 — fable-review-166 T-1: v8 lease give-back re-credits the epoch ledger (#4246, folds R-5(a))
 
 - **Timestamp**: 2026-07-04

--- a/docs/cos-validation-notes.md
+++ b/docs/cos-validation-notes.md
@@ -509,7 +509,7 @@ show class-of-service interface reth0.80
   ...
   Waterfill:                epochs=412 phase1_budget_breaks=9 min_epochs_per_worker=3
     Queue 5 ...
-           Waterfill:    phase1_admit=0  phase2_admit=512  eligible_visits=540
+           Waterfill:    phase1_admit=0  phase2_admit=512  eligible_visits=540  phase1_no_progress=44
 ```
 
 Per-queue (a queue has ONE owner worker, so the row reflects that
@@ -519,6 +519,13 @@ worker):
   (small-first honored) vs Phase-2 (descending residual) walk.
 - `eligible_visits` — times the selector reached this queue eligible and
   evaluated it (both phases, BEFORE the token gate).
+- `phase1_no_progress` (hb166 T-2) — times Phase 1 HONORED this queue but
+  it made ZERO TX progress, so the budget debit and the honored bit were
+  refunded. Climbing here while `phase1_admit` stays flat on a backlogged
+  small class = TX-ring pressure eating the guarantee pass (the
+  #1630/#4256 mid-rate-residual signal). It is the direct counterpart to
+  `phase1_admit`: `phase1_admit` counts Phase-1 visits that made TX
+  progress, `phase1_no_progress` counts the ones that did not.
 
 Per-interface (summed across workers, except the MIN):
 
@@ -555,8 +562,9 @@ queue is `!runnable` and skipped at the eligibility gate, so it shows LOW
 idle).
 
 Prometheus: `xpf_userspace_cos_waterfill_phase1_admissions_total`,
-`..._phase2_admissions_total`, `..._eligible_visits_total` (per
-`{ifindex, queue_id}`); `xpf_userspace_cos_waterfill_epochs_total`,
+`..._phase2_admissions_total`, `..._eligible_visits_total`,
+`..._phase1_selected_no_progress_total` (per `{ifindex, queue_id}`);
+`xpf_userspace_cos_waterfill_epochs_total`,
 `..._phase1_budget_breaks_total`, and the gauge
 `xpf_userspace_cos_waterfill_min_epochs_per_worker` (per `{ifindex}`).
 

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -1264,7 +1264,12 @@ unit policy:
   counts the refunded no-progress visits (climbing there with flat
   `phase1_admissions` on a backlogged small class = TX-ring pressure
   eating the guarantee pass). A queue that DID transmit keeps its honor
-  consumed — no double-consume, no honor leak.
+  consumed — no double-consume, no honor leak. Both counters are
+  surfaced (#4262): `show class-of-service interface` renders
+  `phase1_no_progress` in the per-queue Waterfill row next to
+  `phase1_admit`, and Prometheus exports
+  `xpf_userspace_cos_waterfill_phase1_selected_no_progress_total` per
+  `{ifindex, queue_id}` (see docs/cos-validation-notes.md).
 
   **Claim-side work conservation (#1863, Path A-ii):** the per-class
   v8 lease that fuels the selector's token banks publishes a per-epoch

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -257,13 +257,15 @@ type xpfCollector struct {
 	cosDrainParkRootTokens       *prometheus.Desc
 	cosDrainParkQueueTokens      *prometheus.Desc
 	// #1628: per-class waterfill-selector trace counters. Per-queue
-	// (admissions/visits) plus per-interface (epochs/breaks/min-epochs).
-	cosWaterfillPhase1Admissions   *prometheus.Desc
-	cosWaterfillPhase2Admissions   *prometheus.Desc
-	cosWaterfillEligibleVisits     *prometheus.Desc
-	cosWaterfillEpochs             *prometheus.Desc
-	cosWaterfillPhase1BudgetBreaks *prometheus.Desc
-	cosWaterfillMinEpochsPerWorker *prometheus.Desc
+	// (admissions/visits/no-progress) plus per-interface
+	// (epochs/breaks/min-epochs).
+	cosWaterfillPhase1Admissions         *prometheus.Desc
+	cosWaterfillPhase2Admissions         *prometheus.Desc
+	cosWaterfillEligibleVisits           *prometheus.Desc
+	cosWaterfillPhase1SelectedNoProgress *prometheus.Desc
+	cosWaterfillEpochs                   *prometheus.Desc
+	cosWaterfillPhase1BudgetBreaks       *prometheus.Desc
+	cosWaterfillMinEpochsPerWorker       *prometheus.Desc
 	// #1863 Step-0: per-(queue, worker) v8 lease claim-flow counters
 	// (requested vs granted bytes) + per-queue admission-path drop
 	// counters. The claim-flow pair attributes the honored-realization
@@ -666,6 +668,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.cosWaterfillPhase1Admissions
 	ch <- c.cosWaterfillPhase2Admissions
 	ch <- c.cosWaterfillEligibleVisits
+	ch <- c.cosWaterfillPhase1SelectedNoProgress
 	ch <- c.cosWaterfillEpochs
 	ch <- c.cosWaterfillPhase1BudgetBreaks
 	ch <- c.cosWaterfillMinEpochsPerWorker

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -753,6 +753,11 @@ func newCollector(srv *Server) *xpfCollector {
 			"Times the guarantee-rate waterfill selector reached this CoS queue eligible (nonempty/runnable/guarantee/exact) and evaluated it (both phases, before the token gate). Low value + high *_starvation_parks = backlogged-but-parked; low + low parks + zero queued = idle on this owner (#1628).",
 			[]string{"ifindex", "queue_id"}, nil,
 		),
+		cosWaterfillPhase1SelectedNoProgress: prometheus.NewDesc(
+			"xpf_userspace_cos_waterfill_phase1_selected_no_progress_total",
+			"Times this CoS queue was honored by the guarantee-rate waterfill Phase-1 walk but made ZERO TX progress, so its budget debit and honored bit were refunded (hb166 T-2). Climbing here while waterfill_phase1_admissions stays flat = TX-ring pressure eating a small class's guarantee pass (the #1630/#4256 mid-rate-residual signal).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
 		cosWaterfillEpochs: prometheus.NewDesc(
 			"xpf_userspace_cos_waterfill_epochs_total",
 			"Completed guarantee-rate waterfill epochs (Phase-1 budget refills) on this CoS interface, summed across workers (#1628).",

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -1509,6 +1509,9 @@ func TestEmitCoSWaterfillTelemetry_EmitsQueueAndInterfaceMetrics(t *testing.T) {
 		cosWaterfillEligibleVisits: prometheus.NewDesc(
 			"xpf_userspace_cos_waterfill_eligible_visits_total", "t",
 			[]string{"ifindex", "queue_id"}, nil),
+		cosWaterfillPhase1SelectedNoProgress: prometheus.NewDesc(
+			"xpf_userspace_cos_waterfill_phase1_selected_no_progress_total", "t",
+			[]string{"ifindex", "queue_id"}, nil),
 		cosWaterfillEpochs: prometheus.NewDesc(
 			"xpf_userspace_cos_waterfill_epochs_total", "t",
 			[]string{"ifindex"}, nil),
@@ -1526,10 +1529,11 @@ func TestEmitCoSWaterfillTelemetry_EmitsQueueAndInterfaceMetrics(t *testing.T) {
 			WaterfillPhase1BudgetBreaks: 7,
 			WaterfillMinEpochsPerWorker: 3,
 			Queues: []dpuserspace.CoSQueueStatus{{
-				QueueID:                   5,
-				WaterfillPhase1Admissions: 12,
-				WaterfillPhase2Admissions: 34,
-				WaterfillEligibleVisits:   56,
+				QueueID:                           5,
+				WaterfillPhase1Admissions:         12,
+				WaterfillPhase2Admissions:         34,
+				WaterfillEligibleVisits:           56,
+				WaterfillPhase1SelectedNoProgress: 78,
 			}},
 		}},
 	}
@@ -1563,11 +1567,12 @@ func TestEmitCoSWaterfillTelemetry_EmitsQueueAndInterfaceMetrics(t *testing.T) {
 	}
 
 	want := map[*prometheus.Desc]float64{
-		c.cosWaterfillPhase1Admissions:   12,
-		c.cosWaterfillPhase2Admissions:   34,
-		c.cosWaterfillEligibleVisits:     56,
-		c.cosWaterfillEpochs:             1000,
-		c.cosWaterfillPhase1BudgetBreaks: 7,
+		c.cosWaterfillPhase1Admissions:         12,
+		c.cosWaterfillPhase2Admissions:         34,
+		c.cosWaterfillEligibleVisits:           56,
+		c.cosWaterfillPhase1SelectedNoProgress: 78,
+		c.cosWaterfillEpochs:                   1000,
+		c.cosWaterfillPhase1BudgetBreaks:       7,
 	}
 	if !reflect.DeepEqual(counters, want) {
 		t.Fatalf("waterfill counter values: got %+v, want %+v", counters, want)

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -1599,6 +1599,16 @@ func (c *xpfCollector) emitCoSWaterfillTelemetry(ch chan<- prometheus.Metric, st
 				float64(queue.WaterfillEligibleVisits),
 				ifindexLabel, queueLabel,
 			)
+			// hb166 T-2: Phase-1 honored selections that made zero TX
+			// progress (budget + honored bit refunded). Climbing here
+			// with flat phase1_admissions = TX-ring pressure eating a
+			// small class's guarantee pass (#1630/#4256).
+			ch <- prometheus.MustNewConstMetric(
+				c.cosWaterfillPhase1SelectedNoProgress,
+				prometheus.CounterValue,
+				float64(queue.WaterfillPhase1SelectedNoProgress),
+				ifindexLabel, queueLabel,
+			)
 		}
 	}
 }

--- a/pkg/dataplane/userspace/format/cos.go
+++ b/pkg/dataplane/userspace/format/cos.go
@@ -79,6 +79,11 @@ type cosQueueView struct {
 	waterfillPhase1Admissions uint64
 	waterfillPhase2Admissions uint64
 	waterfillEligibleVisits   uint64
+	// hb166 T-2: Phase-1 honored selections that made zero TX progress
+	// (budget + honored bit refunded). Climbing here with flat
+	// waterfillPhase1Admissions = TX-ring pressure eating a small class's
+	// guarantee pass (#1630/#4256).
+	waterfillPhase1SelectedNoProgress uint64
 	// #1829 Phase 1: dequeue-time sojourn telemetry (queue-scoped,
 	// MAX-merged across workers). Rendered only once the queue has
 	// recorded at least one sample (peak > 0) so idle queues stay
@@ -334,10 +339,11 @@ func FormatCoSInterfaceSummary(cfg *config.Config, status *userspace.ProcessStat
 				// above-cutoff class, or idle: no backlog/parks).
 				fmt.Fprintf(
 					&b,
-					"           Waterfill:    phase1_admit=%d  phase2_admit=%d  eligible_visits=%d\n",
+					"           Waterfill:    phase1_admit=%d  phase2_admit=%d  eligible_visits=%d  phase1_no_progress=%d\n",
 					queue.waterfillPhase1Admissions,
 					queue.waterfillPhase2Admissions,
 					queue.waterfillEligibleVisits,
+					queue.waterfillPhase1SelectedNoProgress,
 				)
 			}
 		}
@@ -360,7 +366,8 @@ func (q cosQueueView) hasDrainShapeTelemetry() bool {
 func (q cosQueueView) hasWaterfillTelemetry() bool {
 	return q.waterfillPhase1Admissions != 0 ||
 		q.waterfillPhase2Admissions != 0 ||
-		q.waterfillEligibleVisits != 0
+		q.waterfillEligibleVisits != 0 ||
+		q.waterfillPhase1SelectedNoProgress != 0
 }
 
 // #709: render a histogram percentile as microseconds. The Rust side
@@ -717,6 +724,7 @@ func buildCoSQueueViews(cfg *config.Config, view cosInterfaceView) []cosQueueVie
 			qv.waterfillPhase1Admissions = runtimeQueue.WaterfillPhase1Admissions
 			qv.waterfillPhase2Admissions = runtimeQueue.WaterfillPhase2Admissions
 			qv.waterfillEligibleVisits = runtimeQueue.WaterfillEligibleVisits
+			qv.waterfillPhase1SelectedNoProgress = runtimeQueue.WaterfillPhase1SelectedNoProgress
 			queueViews[qv.queueID] = qv
 		}
 	}

--- a/pkg/dataplane/userspace/format/cos_test.go
+++ b/pkg/dataplane/userspace/format/cos_test.go
@@ -1104,6 +1104,64 @@ func TestFormatCoSInterfaceSummaryRendersSojournLine(t *testing.T) {
 	}
 }
 
+// #4262 (hb166 T-2): the per-queue Waterfill row must render the
+// phase1_no_progress counter alongside its phase1/phase2/eligible
+// siblings, and the row's gate must fire when only no_progress is
+// non-zero (climbing no_progress with flat phase1_admit is the
+// TX-ring-pressure signal an operator needs to see).
+func TestFormatCoSInterfaceSummaryRendersWaterfillNoProgress(t *testing.T) {
+	owner := uint32(1)
+	status := &userspace.ProcessStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
+			{
+				InterfaceName:   "reth0.80",
+				OwnerWorkerID:   &owner,
+				WorkerInstances: 1,
+				Queues: []userspace.CoSQueueStatus{
+					{
+						QueueID:                           4,
+						OwnerWorkerID:                     &owner,
+						ForwardingClass:                   "bandwidth-10mb",
+						Priority:                          5,
+						Exact:                             true,
+						TransmitRateBytes:                 1_250_000,
+						BufferBytes:                       32 * 1024,
+						WaterfillPhase1Admissions:         12,
+						WaterfillPhase2Admissions:         34,
+						WaterfillEligibleVisits:           56,
+						WaterfillPhase1SelectedNoProgress: 78,
+					},
+				},
+			},
+		},
+	}
+	out := FormatCoSInterfaceSummary(testCoSConfig(), status, "reth0.80")
+	want := "Waterfill:    phase1_admit=12  phase2_admit=34  eligible_visits=56  phase1_no_progress=78"
+	if !strings.Contains(out, want) {
+		t.Fatalf("missing %q in output:\n%s", want, out)
+	}
+
+	// The gate must fire when ONLY no_progress is non-zero — a queue that
+	// was honored but never made TX progress still needs the row.
+	q := &status.CoSInterfaces[0].Queues[0]
+	q.WaterfillPhase1Admissions = 0
+	q.WaterfillPhase2Admissions = 0
+	q.WaterfillEligibleVisits = 0
+	out = FormatCoSInterfaceSummary(testCoSConfig(), status, "reth0.80")
+	if !strings.Contains(out, "phase1_no_progress=78") {
+		t.Fatalf("no_progress-only queue must still render the Waterfill row:\n%s", out)
+	}
+
+	// An all-zero waterfill queue must stay silent. Match the per-queue
+	// row marker (phase1_admit) rather than the bare "Waterfill:" prefix,
+	// which the interface-scoped epochs/breaks line also carries.
+	q.WaterfillPhase1SelectedNoProgress = 0
+	out = FormatCoSInterfaceSummary(testCoSConfig(), status, "reth0.80")
+	if strings.Contains(out, "phase1_admit") {
+		t.Fatalf("idle queue must not render a per-queue Waterfill row:\n%s", out)
+	}
+}
+
 // #1829: formatSojournNS unit pin — ns/µs/ms scaling boundaries.
 func TestFormatSojournNS(t *testing.T) {
 	cases := []struct {

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -1974,8 +1974,10 @@ type CoSQueueStatus struct {
 	// hb166 T-2: Phase-1 honored selections that made ZERO TX progress and
 	// had their budget debit + honored bit refunded. Climbing here with
 	// flat WaterfillPhase1Admissions = TX-ring pressure eating a small
-	// class's guarantee pass. omitempty keeps a pre-hb166 daemon's absent
-	// field at 0 (rolling-upgrade safe).
+	// class's guarantee pass. Additive field: a pre-hb166 daemon that omits
+	// it decodes to 0 here regardless of omitempty (a missing JSON field
+	// unmarshals to the zero value), so this is rolling-upgrade safe;
+	// omitempty only suppresses emitting it on the wire when 0.
 	WaterfillPhase1SelectedNoProgress uint64 `json:"waterfill_phase1_selected_no_progress,omitempty"`
 	// #1829 Phase 1: dequeue-time sojourn telemetry. JSON tags MUST
 	// match the Rust serde rename(...) in protocol/cos.rs exactly.


### PR DESCRIPTION
Closes #4262

## Summary

The hb166 T-2 `waterfill_phase1_selected_no_progress` counter (added in
#4256/#4258) reached the Go protocol mirror (`protocol.go`) but was not
exported via Prometheus (`metrics_userspace.go`) nor rendered by the
`show class-of-service` formatter (`format/cos.go`), unlike its sibling
`waterfill_phase1_admissions`. This surfaces it through both, mirroring
the sibling's shape exactly, plus a small comment-accuracy fix.

Its diagnostic purpose: a climbing `phase1_selected_no_progress` with a
**flat** `phase1_admissions` on a backlogged small class means Phase-1
honored it but it made zero TX progress and had its budget debit +
honored bit refunded — TX-ring pressure eating the guarantee pass (the
#1630/#4256 mid-rate-residual signal, directly useful for validating the
T-1 #4253 fix).

## Changes

**Prometheus** (per `{ifindex, queue_id}`, mirrors `phase1_admissions`):
- `pkg/api/metrics.go` — `cosWaterfillPhase1SelectedNoProgress` Desc field + Describe emit
- `pkg/api/metrics_descriptors.go` — `NewDesc` `xpf_userspace_cos_waterfill_phase1_selected_no_progress_total`
- `pkg/api/metrics_userspace.go` — per-queue `CounterValue` emit in `emitCoSWaterfillTelemetry`

**Show formatter:**
- `pkg/dataplane/userspace/format/cos.go` — `phase1_no_progress=%d` appended to the per-queue `Waterfill:` row; view field + copy-through + folded into the `hasWaterfillTelemetry` gate (so a no-progress-only queue still renders the row)

**Comment-accuracy fix:**
- `pkg/dataplane/userspace/protocol.go` (~1979) — reword: a missing JSON field decodes to 0 on unmarshal regardless of `omitempty`; `omitempty` only suppresses emitting it on the wire when 0. Additive/rolling-upgrade safe; behavior unchanged.

**Tests:**
- `metrics_test.go` — extend `TestEmitCoSWaterfillTelemetry_EmitsQueueAndInterfaceMetrics` to assert the new counter (value 78)
- `cos_test.go` — new `TestFormatCoSInterfaceSummaryRendersWaterfillNoProgress`: row renders the counter, gate fires on a no_progress-only queue, all-zero queue stays silent

**Docs:** `docs/cos-validation-notes.md` (show example + per-queue bullet + Prometheus list), `docs/fairness-regimes.md` (observability pointer).

## Validation

- `go test ./pkg/api/... ./pkg/dataplane/userspace/...` — green
- `go build ./...`, `go vet ./pkg/api/... ./pkg/dataplane/userspace/...`, `gofmt` — clean
- Additive/diagnostic only; the scheduler reads none of these counters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi