### PR TITLE
cos: hb166 R-1/R-3/R-4 fairness-accounting lifecycle fixes

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,24 @@
+## 2026-07-05 — PR #4264 review fold (Copilot doc/comment accuracy, R-1/R-3/R-4)
+
+- **Timestamp**: 2026-07-05
+  - **Action**: Folded two Copilot doc/comment-accuracy items on PR #4264
+    (hostile review = MERGE-READY; R-3 seqlock fence verified CORRECT).
+    NO code change — the fence is unchanged. (1)
+    `docs/fairness-regimes.md`: reworded "each carries a RED-on-revert unit
+    test" — R-1/R-4 carry RED-on-revert tests; R-3 carries a structural
+    cross-field-invariant ordering guard (its tear is only observable on a
+    weakly-ordered CPU [ARM/POWER] or under loom, NOT on the x86-TSO
+    CI/deploy host). (2) `rotate_epoch_v8.rs` fence comment: reworded to
+    state both framings — (a) writer-side store-store barrier intuition and
+    (b) the formal [atomics.fences]/2 fence-fence guarantee — and made it
+    precise that the reader's Relaxed LOAD (ordered by its Acquire fence),
+    not the fence itself, reads the post-Release-fence payload store that
+    establishes the synchronizes-with edge. Confirmed comment-only diff
+    (no non-comment line changed); `cargo build --release` exit 0; rustfmt
+    clean on the touched lines.
+  - **File(s)**: docs/fairness-regimes.md,
+    userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs, _Log.md
+
 ## 2026-07-04 — fable-review-166 R-1/R-3/R-4: CoS/MQFQ fairness-accounting lifecycle fixes (#4259/#4260/#4261)
 
 - **Timestamp**: 2026-07-04

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-04 — fable-review-166 R-1/R-3/R-4: CoS/MQFQ fairness-accounting lifecycle fixes (#4259/#4260/#4261)
+
+- **Timestamp**: 2026-07-04
+  - **Action**: Three state-lifecycle defects in shipped fairness
+    mechanisms. R-1 (#4259): the MQFQ bucket-idle reset in
+    `account_cos_queue_flow_dequeue` cleared only head/tail finish tags;
+    the per-bucket observed-rate EWMA survived flow death, so a newcomer
+    hashing into a recycled bucket was deferred by the cap-aware selector
+    as the departed elephant. Now also zero
+    `flow_bucket_observed_bps`/`last_tx_ns`/`pending_bytes` on the
+    nonzero→0 transition (monotonic `tx_bytes` preserved). Added the
+    missing selector-defers-at-finite-target test + a RED-on-revert
+    recycle test. R-3 (#4260): the v8 epoch seqlock writer
+    (`maybe_rotate_epoch_v8`) had no ordering after the EVEN→ODD claim CAS
+    — the Relaxed payload stores could publish before the ODD claim on a
+    weakly-ordered CPU (torn cross-epoch snapshot, #1619 class; #1643
+    fixed only the reader half). Added `fence(Ordering::Release)` right
+    after the successful claim CAS (Boehm seqlock recipe), pairing with
+    the reader's existing `fence(Acquire)`. Added a contention test
+    asserting `grace == tag*EPOCH + EPOCH/2` (a cross-field invariant a
+    torn read breaks) + a `#[cfg(test)]` snapshot accessor; x86-TSO cannot
+    reproduce the tear so it is a documented structural guard, not
+    RED-on-revert on the CI host. R-4 (#4261): `refill_cos_tokens` floored
+    the byte grant but advanced `last_refill_ns` to `now_ns`, discarding
+    <1 byte of credit per refill (37.5% under at 64 kbps / 200 µs). Now
+    carry the remainder in the timestamp (rewind by `remainder/rate`) so
+    cumulative granted == floor(elapsed×rate/1e9). Added a conservation
+    unit test. All three need a cluster CoS smoke (fairness-mechanism
+    change); R-3 especially needs careful memory-model review.
+  - **File(s)**: userspace-dp/src/afxdp/cos/queue_ops/accounting.rs,
+    userspace-dp/src/afxdp/cos/queue_ops/tests.rs,
+    userspace-dp/src/afxdp/cos/token_bucket.rs,
+    userspace-dp/src/afxdp/cos/token_bucket_tests.rs,
+    userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs,
+    userspace-dp/src/afxdp/types/shared_cos_lease/lease.rs,
+    userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs,
+    docs/fairness-regimes.md, _Log.md
+
 ## 2026-07-04 — fable-review-166 T-1: v8 lease give-back re-credits the epoch ledger (#4246, folds R-5(a))
 
 - **Timestamp**: 2026-07-04

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -1541,8 +1541,13 @@ alternative** to (or co-factor of) the transport-physics floor.
 Three further fable-review-166 findings are state-lifecycle defects in
 already-shipped fairness mechanisms — invisible to steady-state iperf
 smoke, real under flow churn / low-rate classes / weak-memory CPUs. All
-three are pure accounting corrections (no policy change) and each carries
-a RED-on-revert unit test.
+three are pure accounting corrections (no policy change). R-1 and R-4
+carry RED-on-revert unit tests (the fix reverted, the named assertion
+fails). R-3 is a memory-ordering fix whose failure is only observable on
+a weakly-ordered CPU (ARM/POWER) or under a loom model — it is NOT
+reproducible on the x86-TSO CI/deploy host — so it carries a structural
+ordering guard that asserts a cross-field snapshot invariant a torn read
+would break, not a RED-on-revert test.
 
 - **R-1 — recycled MQFQ bucket inherits a dead flow's rate (#4259).** The
   cap-aware per-flow selector (`cos_queue_min_finish_bucket`,

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -1507,6 +1507,68 @@ alternative** to (or co-factor of) the transport-physics floor.
   it eliminates a genuine over-charge that parked mid-rate classes early.
   Needs a cluster CoS mid-rate multi-class smoke to measure the recovery.
 
+#### Fairness-accounting lifecycle fixes (hb166 R-1/R-3/R-4)
+
+Three further fable-review-166 findings are state-lifecycle defects in
+already-shipped fairness mechanisms — invisible to steady-state iperf
+smoke, real under flow churn / low-rate classes / weak-memory CPUs. All
+three are pure accounting corrections (no policy change) and each carries
+a RED-on-revert unit test.
+
+- **R-1 — recycled MQFQ bucket inherits a dead flow's rate (#4259).** The
+  cap-aware per-flow selector (`cos_queue_min_finish_bucket`,
+  `queue_ops/mod.rs`) defers any bucket whose per-bucket observed-rate
+  EWMA (`account_flow_bucket_tx`, `cos/fairness.rs`) exceeds the fair-
+  share target. That EWMA decays only on TX commits (which need service)
+  and its skip-ramp re-arms only at 0, but the bucket-idle reset in
+  `account_cos_queue_flow_dequeue` (`queue_ops/accounting.rs`) cleared
+  only the head/tail finish tags — the observed rate survived flow death.
+  A newcomer hashing into a recycled bucket was throttled with the
+  departed elephant's rate (the mechanism built to protect cool flows
+  throttling the coolest). Fix: on the bucket nonzero→0 transition (the
+  bucket-identity boundary) also zero `flow_bucket_observed_bps` /
+  `flow_bucket_last_tx_ns` / `flow_bucket_pending_bytes`, mirroring the
+  existing finish-tag reset (a drain to 0 is treated as idle/recycled).
+  The monotonic lifetime counter `flow_bucket_tx_bytes` is preserved. The
+  positive action of the cap-aware selector (defer-at-finite-target) was
+  previously untested and is now pinned.
+
+- **R-3 — v8 epoch seqlock writer missing the Release fence (#4260).**
+  `maybe_rotate_epoch_v8` claims the rotation with an AcqRel EVEN→ODD CAS,
+  writes the payload with Relaxed stores, and publishes with the final
+  Release ODD→EVEN store (the #1643 reader-fence's partner). The AcqRel
+  claim's Release half orders only writes *before* the CAS; no reader
+  synchronizes-with it by reading the ODD value. So on a weakly-ordered
+  CPU a payload store could become visible before the ODD claim, and a
+  reader could read seq=EVEN(old) / new payload / seq=EVEN(old) and accept
+  a cross-epoch mix (the #1619 tearing class, of which #1643 fixed only
+  the reader half). Fix: `fence(Ordering::Release)` immediately after the
+  successful claim CAS (Boehm's seqlock recipe) — one fence per rotation
+  (~200 µs). Latent on the x86-TSO deploy targets; a real hazard on
+  ARM/POWER. The crate has no loom dependency, so the guard is a
+  contention test asserting the cross-field `grace == tag*EPOCH + EPOCH/2`
+  invariant a torn snapshot would break.
+
+- **R-4 — token-bucket refill drops fractional dust (#4261).**
+  `refill_cos_tokens` (`cos/token_bucket.rs`) floored the byte grant
+  (`added = elapsed×rate / 1e9`) but advanced `last_refill_ns` fully to
+  `now_ns`, discarding `< 1` byte of accrued credit every refill. At
+  64 kbps on the ~200 µs drain cadence that is 1.6→1 B/interval — a 37.5%
+  shortfall a kbps voice/control class never recovers (~2% at 1 Mbps,
+  negligible ≥100 Mbps). Same failure shape as #1630 cause-1, one decade
+  lower — the ns-integer-division dust layer under the epoch/visit-cap
+  layer #1630 fixed. Fix: carry the fractional remainder in the timestamp
+  — rewind `last_refill_ns` by the time-equivalent of the ungranted
+  fraction (`remainder / rate`) instead of advancing to `now_ns`, so
+  cumulative granted == `floor(total_elapsed × rate / 1e9)`. No new field
+  or signature change; the remainder lives in the timestamp, mirroring the
+  #1630 byte-carry precedent one decade up.
+
+All three need a cluster CoS smoke (a fairness-mechanism change): the
+per-class SOLO/simul-load harness for R-1/R-4, and — because R-3 cannot
+be reproduced on x86-TSO — a functional CoS smoke to confirm the added
+writer fence is behavior-neutral on the deploy targets.
+
 ### Simul-load harness
 
 `test/incus/cos-simul-load-smoke.sh [push|reverse]` runs all 11

--- a/userspace-dp/src/afxdp/cos/queue_ops/accounting.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/accounting.rs
@@ -127,6 +127,27 @@ pub(super) fn account_cos_queue_flow_dequeue(
         // enqueue re-anchors at the live `queue.vtime`.
         ff.flow_bucket_head_finish_bytes[bucket] = 0;
         ff.flow_bucket_tail_finish_bytes[bucket] = 0;
+        // #4259 (hb166 R-1) — bucket identity ends here. Also reset the
+        // per-bucket TX-rate EWMA state written by
+        // `account_flow_bucket_tx` (cos/fairness.rs). Without this, the
+        // observed-rate EWMA survives flow death: it decays only on TX
+        // commits (which require service), and its skip-ramp arms only at
+        // 0 — so a bucket driven high by a departed elephant keeps that
+        // rate indefinitely. A new flow that hashes into the recycled
+        // bucket is then deferred by the cap-aware MQFQ selector
+        // (queue_ops/mod.rs `observed_bps > target_bps`) as if it were the
+        // old elephant, inverting the mechanism's purpose (it throttles the
+        // coolest flow — a newcomer). Zeroing `observed_bps` re-arms the
+        // skip-ramp; zeroing `last_tx_ns` routes the next commit through
+        // the first-commit stamp path; zeroing `pending_bytes` drops the
+        // departed flow's un-rolled accumulation. This mirrors the
+        // head/tail reset above — a drain to 0 is treated as idle/recycled,
+        // consistent with the enqueue-side re-anchor. The monotonic
+        // lifetime counter `flow_bucket_tx_bytes` is left intact (its
+        // "never decremented" diagnostic contract).
+        ff.flow_bucket_observed_bps[bucket] = 0;
+        ff.flow_bucket_last_tx_ns[bucket] = 0;
+        ff.flow_bucket_pending_bytes[bucket] = 0;
         // #941 Work item A: bucket-empty vacate. When this worker's
         // last active bucket on a shared_exact queue empties, vacate
         // the V_min slot so peers don't see a phantom-participating

--- a/userspace-dp/src/afxdp/cos/queue_ops/tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/tests.rs
@@ -1574,3 +1574,176 @@ fn exact_queue_never_demotes() {
         "exact queue must never demote (stable flow_fair_state)"
     );
 }
+
+/// #4259 (hb166 R-1) — the positive action of the cap-aware MQFQ
+/// selector: with a FINITE `target_bps`, a bucket whose observed rate
+/// exceeds the target is deferred in favor of a less-served (under-cap)
+/// bucket, even though the over-cap bucket has the LOWER virtual-finish
+/// time. Before this test the cap-aware branch of
+/// `cos_queue_min_finish_bucket` had no direct coverage — only the
+/// `target_bps == u64::MAX` no-op fast path was exercised.
+#[test]
+fn cap_aware_selector_defers_over_cap_bucket() {
+    let mut root = test_cos_runtime_with_queues(
+        100_000_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 4,
+            forwarding_class: "iperf-c".into(),
+            priority: 5,
+            transmit_rate_bytes: 25_000_000_000 / 8,
+            guarantee_enabled: true,
+            exact: true,
+            surplus_sharing: false,
+            equal_flow_enforcement: false,
+            equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+            surplus_weight: 1,
+            buffer_bytes: 128 * 1024,
+            dscp_rewrite: None,
+            codel_target_ns: 0,
+        }],
+    );
+    let queue = &mut root.queues[0];
+    enable_test_flow_fair(queue);
+
+    // Two flows in DISTINCT buckets (seed 0 after enable_test_flow_fair).
+    let src_a: u16 = 9999;
+    let bucket_a = cos_flow_bucket_index(0, Some(&test_session_key(src_a, 5201)));
+    let mut src_b: u16 = 9000;
+    let bucket_b = loop {
+        let b = cos_flow_bucket_index(0, Some(&test_session_key(src_b, 5201)));
+        if b != bucket_a {
+            break b;
+        }
+        src_b += 1;
+    };
+
+    // Enqueue A small (500 B) then B large (1500 B). With queue_vtime at
+    // 0 the head-finish anchors at bytes, so head_a=500 < head_b=1500 —
+    // the over-cap bucket is the LOWER-finish one, which a naive
+    // min-finish selector would pick.
+    cos_queue_push_back(queue, test_flow_cos_item(src_a, 500));
+    cos_queue_push_back(queue, test_flow_cos_item(src_b, 1500));
+    assert_eq!(
+        test_flow_fair_state(queue).flow_bucket_head_finish_bytes[bucket_a],
+        500,
+    );
+    assert_eq!(
+        test_flow_fair_state(queue).flow_bucket_head_finish_bytes[bucket_b],
+        1500,
+    );
+
+    // A over cap (2 Gbps), B under cap (10 Mbps); target 100 Mbps.
+    {
+        let ff = test_flow_fair_state_mut(queue);
+        ff.flow_bucket_observed_bps[bucket_a] = 2_000_000_000;
+        ff.flow_bucket_observed_bps[bucket_b] = 10_000_000;
+    }
+
+    // No-cap selector: lowest finish wins → over-cap bucket A.
+    assert_eq!(
+        cos_queue_min_finish_bucket(test_flow_fair_state(queue), u64::MAX),
+        Some(bucket_a as u16),
+        "no-cap selection must pick the lowest-finish bucket",
+    );
+    // Cap-aware selector: defers over-cap A, picks under-cap B despite
+    // its higher finish — the positive cap action.
+    assert_eq!(
+        cos_queue_min_finish_bucket(test_flow_fair_state(queue), 100_000_000),
+        Some(bucket_b as u16),
+        "cap-aware selector must defer the over-cap bucket in favor of \
+         the under-cap one",
+    );
+
+    // All-over-cap: raise B over the target too. The selector is
+    // work-conserving — it falls back to the lowest-finish bucket (A)
+    // rather than stalling.
+    {
+        let ff = test_flow_fair_state_mut(queue);
+        ff.flow_bucket_observed_bps[bucket_b] = 3_000_000_000;
+    }
+    assert_eq!(
+        cos_queue_min_finish_bucket(test_flow_fair_state(queue), 100_000_000),
+        Some(bucket_a as u16),
+        "all-over-cap must fall back to the lowest-finish bucket \
+         (work-conserving, no stall)",
+    );
+}
+
+/// #4259 (hb166 R-1) — a recycled bucket must not inherit a departed
+/// flow's observed-rate EWMA. When a bucket drains to 0 (the flow ends),
+/// `account_cos_queue_flow_dequeue` now zeros the per-bucket EWMA state
+/// so the next flow that hashes into the bucket starts clean instead of
+/// being deferred by the cap-aware selector as if it were the old
+/// elephant.
+///
+/// RED-on-revert: without the reset the `observed_bps`/`last_tx_ns`/
+/// `pending_bytes` assertions below fail — the departed elephant's
+/// 2 Gbps survives flow death indefinitely.
+#[test]
+fn bucket_recycle_zeros_stale_observed_rate() {
+    let mut root = test_cos_runtime_with_queues(
+        100_000_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 4,
+            forwarding_class: "iperf-c".into(),
+            priority: 5,
+            transmit_rate_bytes: 25_000_000_000 / 8,
+            guarantee_enabled: true,
+            exact: true,
+            surplus_sharing: false,
+            equal_flow_enforcement: false,
+            equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+            surplus_weight: 1,
+            buffer_bytes: 128 * 1024,
+            dscp_rewrite: None,
+            codel_target_ns: 0,
+        }],
+    );
+    let queue = &mut root.queues[0];
+    enable_test_flow_fair(queue);
+
+    let src = 9999u16;
+    let bucket = cos_flow_bucket_index(0, Some(&test_session_key(src, 5201)));
+
+    // Elephant fills the bucket and drives its EWMA state high.
+    cos_queue_push_back(queue, test_flow_cos_item(src, 1500));
+    {
+        let ff = test_flow_fair_state_mut(queue);
+        ff.flow_bucket_observed_bps[bucket] = 2_000_000_000;
+        ff.flow_bucket_last_tx_ns[bucket] = 123_456;
+        ff.flow_bucket_pending_bytes[bucket] = 4096;
+        // Monotonic lifetime counter — must be preserved across recycle.
+        ff.flow_bucket_tx_bytes[bucket] = 9_000_000;
+    }
+
+    // Flow ends: drain the bucket to 0 through the real pop path (which
+    // calls account_cos_queue_flow_dequeue).
+    let popped = cos_queue_pop_front(queue);
+    assert!(popped.is_some(), "expected the queued item back");
+    assert_eq!(
+        test_flow_fair_state(queue).flow_bucket_bytes[bucket],
+        0,
+        "bucket must drain to 0 (nonzero→0 transition triggers reset)",
+    );
+
+    // Bucket identity ended — EWMA state zeroed so a newcomer is clean.
+    let ff = test_flow_fair_state(queue);
+    assert_eq!(
+        ff.flow_bucket_observed_bps[bucket], 0,
+        "recycled bucket must not carry the departed flow's observed rate",
+    );
+    assert_eq!(
+        ff.flow_bucket_last_tx_ns[bucket], 0,
+        "recycled bucket last_tx_ns must reset so the next commit takes \
+         the first-commit stamp path",
+    );
+    assert_eq!(
+        ff.flow_bucket_pending_bytes[bucket], 0,
+        "recycled bucket pending accumulation must be dropped",
+    );
+    // Lifetime diagnostic counter is monotonic — NOT reset on recycle.
+    assert_eq!(
+        ff.flow_bucket_tx_bytes[bucket], 9_000_000,
+        "monotonic lifetime tx_bytes must survive recycle",
+    );
+}

--- a/userspace-dp/src/afxdp/cos/token_bucket.rs
+++ b/userspace-dp/src/afxdp/cos/token_bucket.rs
@@ -320,12 +320,36 @@ pub(in crate::afxdp) fn refill_cos_tokens(
         return;
     }
     let elapsed_ns = now_ns - *last_refill_ns;
-    let added = ((elapsed_ns as u128) * (rate_bytes_per_sec as u128) / 1_000_000_000u128) as u64;
+    let scaled = (elapsed_ns as u128) * (rate_bytes_per_sec as u128);
+    let added = (scaled / 1_000_000_000u128) as u64;
     if added == 0 {
+        // No whole byte accrued this call. Leave `last_refill_ns`
+        // untouched so the sub-byte credit keeps accumulating against
+        // the original timestamp (advancing it here would discard it —
+        // the #4261 dust bug for low-rate classes).
         return;
     }
     *tokens = tokens.saturating_add(added).min(burst_bytes);
-    *last_refill_ns = now_ns;
+    // #4261 (hb166 R-4) — carry the fractional remainder across refills.
+    // `added` floors the byte grant; advancing `last_refill_ns` fully to
+    // `now_ns` would discard `scaled % 1e9` byte-nanoseconds of accrued-
+    // but-ungranted credit EVERY refill. At 64 kbps (8000 B/s) on the
+    // ~200 µs drain cadence that is added = 1.6 → 1 with 0.6 B dropped per
+    // interval — a 37.5% shortfall the low-rate class never recovers.
+    // Instead of advancing to `now_ns`, rewind by the time-equivalent of
+    // the ungranted fraction so it stays on the clock for the next refill.
+    // `remainder` is the leftover byte-nanoseconds (`< 1e9`); dividing by
+    // the rate converts it back to the elapsed time not yet turned into a
+    // whole byte. Conservation: cumulative granted == floor(total_elapsed ×
+    // rate / 1e9), matching the #1630 byte-carry precedent one decade up.
+    // Bounds: `leftover_ns = remainder / rate ≤ elapsed_ns` (remainder ≤
+    // elapsed×rate), so `now_ns - leftover_ns` stays in
+    // `[*last_refill_ns, now_ns]` — the timestamp never moves backward and
+    // never overshoots. `rate_bytes_per_sec != 0` is guaranteed by the
+    // early return above, so the division is safe.
+    let remainder = scaled - (added as u128) * 1_000_000_000u128;
+    let leftover_ns = (remainder / (rate_bytes_per_sec as u128)) as u64;
+    *last_refill_ns = now_ns - leftover_ns;
 }
 
 /// Time-until-refill helper. Returns `Some(ns)` for the wait-time

--- a/userspace-dp/src/afxdp/cos/token_bucket_tests.rs
+++ b/userspace-dp/src/afxdp/cos/token_bucket_tests.rs
@@ -500,3 +500,90 @@ fn transparent_root_preserves_per_queue_exact_cap() {
         root.queues[0].hot.tokens,
     );
 }
+
+/// #4261 (hb166 R-4) — refill dust conservation.
+///
+/// A 64 kbps class (8000 B/s) refilled at the ~200 µs drain cadence
+/// accrues 1.6 B/interval. The pre-fix `refill_cos_tokens` floored to 1
+/// B AND advanced `last_refill_ns` to `now_ns`, discarding the 0.6 B
+/// remainder every interval → 5000 B/s delivered (37.5% under the 8000
+/// B/s shape). The fix carries the fractional remainder in the
+/// timestamp so cumulative granted tracks `rate × elapsed`.
+///
+/// RED-on-revert: with the timestamp advanced fully to `now_ns`, the
+/// class delivers ~5000 B/s and this test's `>= 7900` floor fails.
+#[test]
+fn refill_cos_tokens_carries_fractional_dust_for_low_rate_class() {
+    // 64 kbps = 8000 bytes/sec.
+    const RATE_BYTES_PER_SEC: u64 = 8_000;
+    // ~200 µs drain cadence — deliberately NON-integral bytes/interval
+    // (8000 * 200_000 / 1e9 = 1.6 B).
+    const INTERVAL_NS: u64 = 200_000;
+    // 1 second of refills.
+    const INTERVALS: u64 = 5_000;
+    // Burst large enough that the bucket never saturates — we are
+    // measuring pure refill accounting, not the cap.
+    const BURST_BYTES: u64 = 1_000_000;
+
+    // Consume tokens each interval so the bucket never fills and we can
+    // sum the actual grants. Start "primed" (last_refill_ns != 0) so we
+    // exercise the rate path, not the first-refill fill-to-burst path.
+    let mut tokens: u64 = 0;
+    let mut last_refill_ns: u64 = 1_000_000_000;
+    let mut now = last_refill_ns;
+    let mut granted_total: u64 = 0;
+
+    for _ in 0..INTERVALS {
+        now += INTERVAL_NS;
+        let before = tokens;
+        refill_cos_tokens(
+            &mut tokens,
+            RATE_BYTES_PER_SEC,
+            BURST_BYTES,
+            &mut last_refill_ns,
+            now,
+        );
+        let added = tokens - before;
+        granted_total += added;
+        // Drain everything granted so the bucket cannot approach BURST.
+        tokens = 0;
+    }
+
+    let elapsed_ns = now - 1_000_000_000;
+    let ideal = (elapsed_ns as u128 * RATE_BYTES_PER_SEC as u128 / 1_000_000_000u128) as u64;
+    // ideal == 8000 B over 1 s.
+    assert_eq!(ideal, 8_000, "fixture sanity: 1 s at 8000 B/s = 8000 B");
+
+    // Conservation: cumulative granted must equal ideal within a
+    // small bounded error (sub-nanosecond flooring in the leftover
+    // rewind). The pre-fix behavior delivered ~5000 B (37.5% under)
+    // and fails this floor.
+    assert!(
+        granted_total >= 7_900,
+        "low-rate class under-ran: granted {} B over 1 s vs 8000 B ideal \
+         (dust discarded each refill — #4261 regression)",
+        granted_total,
+    );
+    assert!(
+        granted_total <= 8_000,
+        "low-rate class over-ran: granted {} B > 8000 B ideal (dust \
+         carry must not manufacture credit)",
+        granted_total,
+    );
+
+    // The carried remainder lives in the timestamp: after the last
+    // granting refill, `last_refill_ns` trails `now` by the ungranted
+    // fraction (< one byte's worth of time), never advancing past it.
+    assert!(
+        last_refill_ns <= now,
+        "last_refill_ns {} overshot now {}",
+        last_refill_ns,
+        now,
+    );
+    assert!(
+        now - last_refill_ns < (1_000_000_000 / RATE_BYTES_PER_SEC),
+        "carried leftover {} ns must be under one byte's time ({} ns)",
+        now - last_refill_ns,
+        1_000_000_000 / RATE_BYTES_PER_SEC,
+    );
+}

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/lease.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/lease.rs
@@ -1181,6 +1181,19 @@ impl SharedCoSQueueLease {
         }
     }
 
+    /// #4260 (hb166 R-3) test hook: expose the private seqlock snapshot so
+    /// the writer/reader ordering-correctness test can observe the raw
+    /// `(cap, share, grace, tag)` tuple and assert the cross-field
+    /// tag/grace invariant a torn read would violate. Test-only — never
+    /// compiled into the shipping helper.
+    #[cfg(test)]
+    pub(in crate::afxdp) fn test_snapshot_epoch_v8(
+        &self,
+        worker_id: usize,
+    ) -> Option<(u64, u64, u64, u32)> {
+        self.snapshot_epoch_v8(worker_id)
+    }
+
     // pub(super): called by the co-located `tests` module (equal-flow cap
     // unit tests). Inherent-private before the split.
     pub(super) fn equal_flow_cap_v8(

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs
@@ -56,25 +56,37 @@ impl SharedCoSQueueLease {
             return; // peer claimed first
         }
 
-        // #4260 (hb166 R-3) — seqlock writer half. The EVEN→ODD claim CAS
-        // above is AcqRel: its Release half orders only writes SEQUENCED-
-        // BEFORE the CAS, and no reader synchronizes-with it by reading the
-        // ODD value (readers spin on ODD, they never accept it). It does
-        // NOT order the Relaxed payload stores below relative to the ODD
-        // claim becoming visible. Without this fence, on a weakly-ordered
-        // CPU (ARM/POWER) a payload store can become globally visible
-        // before the ODD claim, so a reader can read seq=EVEN(old), read
-        // new-epoch payload (torn), re-read seq=EVEN(old), and pass the
-        // even-equal validation against a cross-epoch mix — the #1619
-        // tearing class, of which #1643 fixed only the reader half.
+        // #4260 (hb166 R-3) — seqlock writer half (Boehm's seqlock recipe).
+        // The EVEN→ODD claim CAS above is AcqRel, but its Release half
+        // orders only writes SEQUENCED-BEFORE the CAS, and no reader
+        // synchronizes-with it by reading the ODD value (readers spin on
+        // ODD, they never accept it). So the CAS does NOT order the Relaxed
+        // payload stores below relative to the ODD claim.
         //
-        // The Release fence pairs with the reader's `fence(Acquire)` in
-        // `snapshot_epoch_v8` (lease.rs): a reader whose Acquire fence
-        // observes any payload store issued after this fence synchronizes-
-        // with it, so the ODD claim (sequenced-before the fence) happens-
-        // before the reader's trailing `seq_after` load, which then reads
-        // ODD (or the later EVEN) and forces a retry. Boehm's seqlock
-        // recipe — one fence per rotation (~200 µs, EPOCH_DURATION_NS).
+        // (a) Writer-side intuition. This Release fence is a store-store
+        // ordering barrier: it prevents the Relaxed payload stores that
+        // follow it from becoming visible before the ODD claim that
+        // precedes it. Without it, on a weakly-ordered CPU (ARM/POWER) a
+        // payload store could publish before the ODD claim, so a reader
+        // could read seq=EVEN(old), read new-epoch payload (torn), re-read
+        // seq=EVEN(old), and pass the even-equal validation against a
+        // cross-epoch mix — the #1619 tearing class, of which #1643 fixed
+        // only the reader half.
+        //
+        // (b) Formal guarantee ([atomics.fences]/2, the fence-fence rule).
+        // The reader's payload reads in `snapshot_epoch_v8` (lease.rs) are
+        // Relaxed LOADS sealed by an Acquire FENCE before its trailing
+        // `seq_after` load. If the reader's Relaxed payload LOAD (not the
+        // fence — a fence performs no access) reads the value written by a
+        // Relaxed payload STORE that is sequenced-AFTER this Release fence,
+        // then this Release fence (FA) synchronizes-with the reader's
+        // Acquire fence (FB). Everything sequenced-before FA — the ODD
+        // claim CAS — therefore happens-before everything sequenced-after
+        // FB — the reader's `seq_after` load — so `seq_after` observes the
+        // ODD claim (or the later EVEN publish) and the reader retries. The
+        // fence orders the reader's LOAD; the LOAD is what reads the store.
+        // This is the write-side partner of the #1643 reader-fence half.
+        // One fence per rotation (~200 µs, EPOCH_DURATION_NS).
         std::sync::atomic::fence(Ordering::Release);
 
         // We are the rotation winner; seq is now ODD.

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs
@@ -56,6 +56,27 @@ impl SharedCoSQueueLease {
             return; // peer claimed first
         }
 
+        // #4260 (hb166 R-3) — seqlock writer half. The EVEN→ODD claim CAS
+        // above is AcqRel: its Release half orders only writes SEQUENCED-
+        // BEFORE the CAS, and no reader synchronizes-with it by reading the
+        // ODD value (readers spin on ODD, they never accept it). It does
+        // NOT order the Relaxed payload stores below relative to the ODD
+        // claim becoming visible. Without this fence, on a weakly-ordered
+        // CPU (ARM/POWER) a payload store can become globally visible
+        // before the ODD claim, so a reader can read seq=EVEN(old), read
+        // new-epoch payload (torn), re-read seq=EVEN(old), and pass the
+        // even-equal validation against a cross-epoch mix — the #1619
+        // tearing class, of which #1643 fixed only the reader half.
+        //
+        // The Release fence pairs with the reader's `fence(Acquire)` in
+        // `snapshot_epoch_v8` (lease.rs): a reader whose Acquire fence
+        // observes any payload store issued after this fence synchronizes-
+        // with it, so the ODD claim (sequenced-before the fence) happens-
+        // before the reader's trailing `seq_after` load, which then reads
+        // ODD (or the later EVEN) and forces a retry. Boehm's seqlock
+        // recipe — one fence per rotation (~200 µs, EPOCH_DURATION_NS).
+        std::sync::atomic::fence(Ordering::Release);
+
         // We are the rotation winner; seq is now ODD.
         let new_tag = ((seq >> 1) + 1) as u32;
         let new_packed_zero = PackedEpochGrant::pack(new_tag, 0);

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs
@@ -2383,3 +2383,110 @@ fn v8_release_unused_v8_concurrent_preserves_ledger_invariant() {
         "ledger invariant sum(worker_grants) == packed_granted after concurrent churn"
     );
 }
+
+/// #4260 (hb166 R-3) — v8 epoch seqlock writer/reader ordering.
+///
+/// The rotation winner (`maybe_rotate_epoch_v8`) now issues a
+/// `fence(Ordering::Release)` immediately after the EVEN→ODD claim CAS so
+/// the Relaxed payload stores are published AFTER the ODD claim becomes
+/// visible. That is the writer half of the #1643 reader `fence(Acquire)`;
+/// together they close the #1619 cross-epoch tearing window.
+///
+/// This test drives many concurrent snapshots against a single rotating
+/// writer and asserts a CROSS-FIELD invariant that a torn snapshot would
+/// violate. All rotations here happen at `now_ns = k*EPOCH`, which
+/// publishes `grace = now_ns + EPOCH/2` and `tag = k` from the SAME
+/// rotation, so any consistent snapshot MUST satisfy
+/// `grace == tag*EPOCH + EPOCH/2`. A reader that paired a fresh `tag`
+/// with a stale `grace` (or vice-versa — a torn cross-epoch read) breaks
+/// the equality.
+///
+/// NOTE: x86-TSO does not reorder plain stores, so on the CI host this
+/// test cannot deterministically REPRODUCE the tear — it passes with and
+/// without the writer fence there. It is a structural ordering-correctness
+/// guard plus executable documentation of the invariant: on a weakly-
+/// ordered CPU (ARM/POWER), or under a loom model, the missing-fence
+/// writer would let this equality fail. The crate carries no loom
+/// dependency, so this contention test is the available regression
+/// surface for the writer half.
+#[test]
+fn v8_epoch_seqlock_snapshot_never_tears_tag_grace() {
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering as AtomicOrdering};
+    use std::sync::Arc;
+
+    const MAX_WORKER_ID: usize = 3;
+    // rate_bytes / burst are irrelevant to the tag/grace invariant; any
+    // v8 lease rotates on the same schedule.
+    let lease = Arc::new(SharedCoSQueueLease::new_v8(
+        100_000_000,
+        64 * 1024,
+        MAX_WORKER_ID + 1,
+        MAX_WORKER_ID,
+    ));
+
+    const ROTATIONS: u64 = 4_000;
+    // The writer's last-rotated now_ns, published for the readers. 0 =
+    // "no rotation yet".
+    let clock = Arc::new(AtomicU64::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+
+    // Reader threads: pure snapshots (no rotation) racing the writer's
+    // payload publish. Each verifies the tag/grace invariant.
+    let mut readers = Vec::new();
+    for worker_id in 0..=MAX_WORKER_ID {
+        let lease = Arc::clone(&lease);
+        let clock = Arc::clone(&clock);
+        let stop = Arc::clone(&stop);
+        readers.push(std::thread::spawn(move || -> u64 {
+            let mut checked: u64 = 0;
+            while !stop.load(AtomicOrdering::Relaxed) {
+                if clock.load(AtomicOrdering::Relaxed) == 0 {
+                    std::hint::spin_loop();
+                    continue;
+                }
+                // Pure seqlock read — snapshot_epoch_v8 does NOT rotate.
+                if let Some((_cap, _share, grace, tag)) = lease.test_snapshot_epoch_v8(worker_id) {
+                    if tag >= 1 {
+                        let expected = tag as u64 * EPOCH_DURATION_NS + EPOCH_DURATION_NS / 2;
+                        assert_eq!(
+                            grace, expected,
+                            "torn seqlock snapshot: tag {} paired with grace \
+                             {} (expected {}) — writer publish ordering broken",
+                            tag, grace, expected,
+                        );
+                        checked += 1;
+                    }
+                }
+            }
+            checked
+        }));
+    }
+
+    // Single writer: the ONLY rotation driver, stepping the clock one
+    // epoch per iteration so rotation k lands at now_ns = k*EPOCH with
+    // tag == k and grace == k*EPOCH + EPOCH/2.
+    for k in 1..=ROTATIONS {
+        let now = k * EPOCH_DURATION_NS;
+        // acquire_v8 runs maybe_rotate_epoch_v8(now) then the snapshot.
+        let _ = lease.acquire_v8(0, now, 1);
+        clock.store(now, AtomicOrdering::Relaxed);
+    }
+    stop.store(true, AtomicOrdering::Relaxed);
+
+    let total_checked: u64 = readers.into_iter().map(|h| h.join().unwrap()).sum();
+    assert!(
+        total_checked > 0,
+        "readers must have validated at least one snapshot (test not vacuous)"
+    );
+
+    // Writer completed all rotations: final tag == ROTATIONS.
+    let (_c, _s, grace, tag) = lease
+        .test_snapshot_epoch_v8(0)
+        .expect("final snapshot must succeed with no concurrent writer");
+    assert_eq!(tag as u64, ROTATIONS, "writer must reach the final epoch");
+    assert_eq!(
+        grace,
+        ROTATIONS * EPOCH_DURATION_NS + EPOCH_DURATION_NS / 2,
+        "final grace must match the final epoch's tag",
+    );
+}


### PR DESCRIPTION
Closes #4259 Closes #4260 Closes #4261

Three fable-review-166 findings — state-lifecycle defects in already-shipped CoS/MQFQ fairness mechanisms. All are pure accounting corrections (no policy change), each verified against HEAD and carrying a RED-on-revert test. FULL `cargo test --release --test-threads=1` green (main binary 3550 passed / 0 failed; all integration binaries ok).

## R-1 — recycled MQFQ bucket inherits a dead flow's rate (#4259)
`cos/queue_ops/accounting.rs`, `queue_ops/tests.rs`

The cap-aware selector `cos_queue_min_finish_bucket` defers any bucket whose observed-rate EWMA exceeds the fair-share target. That EWMA decays only on TX commits (which need service) and its skip-ramp re-arms only at 0, but `account_cos_queue_flow_dequeue`'s bucket-idle reset cleared only the head/tail finish tags — the observed rate survived flow death, so a newcomer hashing into a recycled bucket was throttled with the departed elephant's rate. Fix: on the nonzero->0 transition also zero `flow_bucket_observed_bps` / `flow_bucket_last_tx_ns` / `flow_bucket_pending_bytes` (monotonic `flow_bucket_tx_bytes` preserved), mirroring the existing finish-tag reset.

- `bucket_recycle_zeros_stale_observed_rate` — RED on revert (stale 2 Gbps survives without the reset).
- `cap_aware_selector_defers_over_cap_bucket` — pins the previously untested positive cap action (+ work-conserving all-over-cap fallback).

## R-3 — v8 epoch seqlock writer missing Release fence (#4260) — MEMORY-MODEL, please review closely
`types/shared_cos_lease/rotate_epoch_v8.rs`, `lease.rs`, `shared_cos_lease_tests.rs`

`maybe_rotate_epoch_v8` claims the rotation with an AcqRel EVEN->ODD CAS, writes the payload Relaxed, and publishes with the final Release ODD->EVEN store (the #1643 reader-fence partner). The AcqRel claim's Release half orders only writes *before* the CAS, and no reader synchronizes-with the ODD value — so the Relaxed payload stores are unordered relative to the ODD claim becoming visible. On a weakly-ordered CPU a payload store can publish before the ODD claim; a reader then reads seq=EVEN(old) / new payload / seq=EVEN(old) and accepts a cross-epoch mix (#1619 tearing class; #1643 fixed only the reader half). Fix: `fence(Ordering::Release)` immediately after the successful claim CAS (Boehm's recipe), pairing with the reader's existing `fence(Acquire)`. One fence per rotation (~200 us).

Latent on x86-TSO deploy targets; real on ARM/POWER. No loom in the crate, so the test (`v8_epoch_seqlock_snapshot_never_tears_tag_grace`) is a contention guard asserting the cross-field `grace == tag*EPOCH + EPOCH/2` invariant a torn read would break; it is a structural/documentation guard, NOT RED-on-revert on the x86-TSO CI host.

## R-4 — token-bucket refill drops fractional dust (#4261)
`cos/token_bucket.rs`, `token_bucket_tests.rs`

`refill_cos_tokens` floored the byte grant but advanced `last_refill_ns` fully to `now_ns`, discarding <1 byte of credit per refill — 37.5% under at 64 kbps / 200 us (~2% at 1 Mbps, negligible >=100 Mbps). Same shape as #1630 cause-1, one decade lower. Fix: carry the remainder in the timestamp (rewind by `remainder/rate`) so cumulative granted == `floor(elapsed*rate/1e9)`; no new field/signature. `refill_cos_tokens_carries_fractional_dust_for_low_rate_class` — RED on revert (5000 B vs 8000 B ideal over 1 s).

## Validation
- FULL `cargo test --release --test-threads=1`: PASS (exit 0, 3550/0 in the main binary).
- RED-on-revert proven for R-1 and R-4 (reverted the fix, saw the named assertion fail: stale-rate carried; 5000 B delivered).
- Docs: `docs/fairness-regimes.md` gains a "Fairness-accounting lifecycle fixes (hb166 R-1/R-3/R-4)" subsection.

## Follow-up
All three need a cluster CoS smoke (fairness-mechanism change): the per-class SOLO / simul-load harness for R-1/R-4, and a functional CoS smoke to confirm R-3's added writer fence is behavior-neutral on the x86-TSO deploy targets (R-3 can't be reproduced there).

No file overlap with #4258 (T-2/T-5) — this PR touches `lease.rs`/`rotate_epoch_v8.rs`, not `queue_service/mod.rs`, `admission.rs`, or the wire protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi