### PR TITLE
cos: meter non-exact guaranteed classes class-wide (#4265, R-2)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,44 @@
+## 2026-07-05 — cos: meter non-exact guaranteed classes class-wide (#4265, R-2)
+
+- **Timestamp**: 2026-07-05
+  - **Action**: Fixed fable-review-166 finding R-2 — a non-exact
+    guaranteed class served by N workers on a shared (sharded) egress was
+    admitted at up to N_workers × its configured guaranteed rate because
+    each worker refilled a PRIVATE token bucket at the full rate in
+    `select_nonexact_cos_guarantee_batch` with no class-wide metering (a
+    shared lease was attached only to `exact` queues). Fix per the #4245
+    converged plan, option 1 (shared legacy lease): the coordinator
+    (`build_shared_cos_queue_leases_reusing_existing`) now builds a shared
+    LEGACY `SharedCoSQueueLease::new` (v8=None greedy-aggregate token
+    bucket) for non-exact guarantee_enabled queues whose rate trips
+    `COS_SHARED_EXACT_MIN_RATE_BYTES` (the sharded ones), Arc-reused via
+    `matches_config` (worker join/leave rebuilds on `active_shards`
+    change). The worker attaches whatever lease exists (dropped the
+    `queue.exact` gate). `select_nonexact_cos_guarantee_batch` now takes
+    the fast-path slice and refills through `maybe_top_up_cos_queue_lease`
+    (its pre-existing but unreachable non-exact-with-lease branch) instead
+    of `refill_cos_tokens`, so all N workers draw from ONE metered pool —
+    aggregate admission == configured rate, still work-conserving.
+    `apply_cos_send_result` / `apply_cos_prepared_result` now debit the
+    serviced queue's lease in the Guarantee phase regardless of `exact`
+    (renamed `exact_queue_idx` → `lease_consume_queue_idx`); the
+    queue-empty give-back in `refresh_cos_interface_activity` now fires for
+    any leased queue (gated on `has_lease`, not `exact`), routing through
+    `release_unused_v8` which reduces to legacy `release_unused` for a
+    v8=None lease. Single-owner low-rate non-exact queues are unchanged
+    (no lease → same per-worker refill). Legacy lease sidesteps the #4246
+    T-1 / R-5(a) v8-ledger hole. Added two tests
+    (`nonexact_guarantee_shared_lease_bounds_aggregate_admission_across_workers`,
+    `nonexact_guarantee_refill_is_gated_by_shared_lease_pool`), both RED on
+    revert. Docs: fairness-regimes.md (new R-2 subsection). Flagged: needs
+    a cluster CoS smoke with a non-exact guaranteed class on a shared
+    multi-worker egress (standard fixtures use exact classes).
+  - **File(s)**: userspace-dp/src/afxdp/coordinator/cos_leases.rs,
+    userspace-dp/src/afxdp/worker/cos/mod.rs,
+    userspace-dp/src/afxdp/cos/queue_service/mod.rs,
+    userspace-dp/src/afxdp/cos/queue_service/tests.rs,
+    userspace-dp/src/afxdp/cos/tx_completion.rs, docs/fairness-regimes.md
+
 ## 2026-07-05 — cos: surface waterfill phase1_selected_no_progress (#4262)
 
 - **Timestamp**: 2026-07-05

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -1536,6 +1536,65 @@ alternative** to (or co-factor of) the transport-physics floor.
   it eliminates a genuine over-charge that parked mid-rate classes early.
   Needs a cluster CoS mid-rate multi-class smoke to measure the recovery.
 
+### Non-exact guaranteed classes are metered class-wide (#4265, R-2)
+
+A **non-exact** guaranteed class whose transmit-rate trips
+`COS_SHARED_EXACT_MIN_RATE_BYTES` (2.5 Gbps) runs the sharded
+`shared_exact` execution policy — it drains locally on EVERY worker
+rather than being funnelled to one owner (#1598 admitted non-exact
+high-rate queues to sharded service to lift the single-worker AF_XDP
+UMEM ceiling). But its GUARANTEE-phase service goes through
+`select_nonexact_cos_guarantee_batch` (not the exact waterfill), which
+until #4265 refilled a **private per-worker** token bucket at the FULL
+configured rate. With N workers each independently refilling at the full
+rate, the class was admitted at up to **N × its configured guaranteed
+rate** at guarantee priority — e.g. a 1g non-exact guarantee could take
+~6 Gb/s on the 6-worker loss cluster. The excess bypassed both the
+surplus-phase DWRR and the `SharedCoSExactBacklog` residual bound (the
+whole cross-worker constraint machinery constrains only the surplus
+leg). Same CLASS of over-admission as the closed #4002 / #2955 (split
+per-worker state), different still-open site.
+
+- **The mechanism.** `worker/cos/mod.rs` attached a `shared_queue_lease`
+  to the queue fast-path only when `queue.exact`; the coordinator
+  (`build_shared_cos_queue_leases_reusing_existing`) only ever built a
+  `SharedCoSQueueLease` for exact queues. So the class-wide metered
+  refill path in `maybe_top_up_cos_queue_lease` was unreachable for
+  non-exact queues, and the selector fell to the unmetered per-worker
+  `refill_cos_tokens`.
+- **The fix.** The coordinator now builds a **shared LEGACY lease**
+  (`SharedCoSQueueLease::new` — v8=None, a greedy-aggregate shared token
+  bucket all workers draw from) for non-exact guaranteed queues whose
+  rate qualifies for sharded service, keyed and Arc-reuse-disciplined the
+  same way as the exact v8 leases (a worker join/leave changes
+  `active_shards` and rebuilds the lease via `matches_config`). The
+  worker attaches it unconditionally; `select_nonexact_cos_guarantee_batch`
+  refills through `maybe_top_up_cos_queue_lease` (its pre-existing but
+  previously-unreachable non-exact-with-lease branch); the guarantee-phase
+  send debits the lease via `maybe_consume_exact_queue_lease` (no longer
+  gated on `exact`); and the queue-empty give-back returns unspent credit
+  through `release_unused_v8`, which reduces to the legacy `release_unused`
+  for a v8=None lease. Aggregate guarantee admission is therefore metered
+  to the configured rate while staying work-conserving — a single busy
+  worker can drain the whole shared pool when its peers are idle
+  (rate-division would instead cap that worker at rate/N; the shared lease
+  avoids that starvation/waste tradeoff). Because the legacy lease has no
+  v8 epoch ledger, it is not subject to the #4246 T-1 / R-5(a) hole.
+- **Single-owner queues are unchanged.** A non-exact queue below the
+  sharded-service rate threshold stays single-owner (one worker services
+  it; no over-admission) and gets no lease; the selector still refills its
+  private bucket exactly as before.
+- **Test.** `nonexact_guarantee_shared_lease_bounds_aggregate_admission_across_workers`
+  (queue_service tests) drives N=6 worker replicas sharing one lease over
+  a 20 ms window and asserts the summed admission stays near the
+  configured rate (RED — ~N× — on revert to the per-worker refill);
+  `nonexact_guarantee_refill_is_gated_by_shared_lease_pool` pins that an
+  empty shared pool starves the selector rather than leaking a private
+  full-rate refill. Needs a cluster CoS smoke with a non-exact guaranteed
+  class on a shared multi-worker egress to confirm the aggregate cap on
+  real traffic (the standard fixtures use exact classes, so this does not
+  fire on the canonical smoke matrix).
+
 ### Simul-load harness
 
 `test/incus/cos-simul-load-smoke.sh [push|reverse]` runs all 11

--- a/userspace-dp/src/afxdp/coordinator/cos_leases.rs
+++ b/userspace-dp/src/afxdp/coordinator/cos_leases.rs
@@ -638,11 +638,53 @@ pub(super) fn build_shared_cos_queue_leases_reusing_existing(
             .unwrap_or(1)
             .max(1);
         for queue in &iface.queues {
-            if !queue.exact || queue.transmit_rate_bytes == 0 {
+            if queue.transmit_rate_bytes == 0 {
                 continue;
             }
             let burst_bytes = queue.buffer_bytes.max(64 * 1500);
             let key = (ifindex, queue.queue_id);
+            if !queue.exact {
+                // #4265 (R-2): a non-exact GUARANTEED queue that runs the
+                // sharded `shared_exact` execution policy (its rate trips
+                // `COS_SHARED_EXACT_MIN_RATE_BYTES`, so it drains locally on
+                // EVERY worker rather than being funnelled to one owner) is
+                // serviced through `select_nonexact_cos_guarantee_batch`,
+                // which refilled a PRIVATE per-worker token bucket at the
+                // FULL configured rate — admitting the guarantee at up to
+                // N_workers x its rate. Attach a SHARED LEGACY lease
+                // (`SharedCoSQueueLease::new`, v8=None: one greedy-aggregate
+                // token bucket all workers draw from) so the class-wide
+                // guarantee admission is metered to the configured rate
+                // while staying work-conserving (a single busy worker can
+                // drain the whole shared pool). Low-rate non-exact queues
+                // stay single-owner (one worker services them; no
+                // over-admission) and get no lease. The legacy lease has no
+                // v8 epoch ledger, so it sidesteps the #4246 T-1 / R-5(a)
+                // accounting hole. `active_shards` sizing means a worker
+                // join/leave rebuilds the lease via `matches_config`, the
+                // same discipline the exact v8 lease uses.
+                if !queue.guarantee_enabled
+                    || queue.transmit_rate_bytes
+                        < crate::afxdp::worker::COS_SHARED_EXACT_MIN_RATE_BYTES
+                {
+                    continue;
+                }
+                if let Some(lease) = existing.get(&key).filter(|lease| {
+                    lease.matches_config(queue.transmit_rate_bytes, burst_bytes, active_shards)
+                }) {
+                    out.insert(key, lease.clone());
+                    continue;
+                }
+                out.insert(
+                    key,
+                    Arc::new(SharedCoSQueueLease::new(
+                        queue.transmit_rate_bytes,
+                        burst_bytes,
+                        active_shards,
+                    )),
+                );
+                continue;
+            }
             let rate_mode = if queue.equal_flow_enforcement {
                 V8RateMode::EqualFlowSuppress
             } else {

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -273,9 +273,21 @@ fn build_nonexact_cos_batch(
         .as_ref()
         .map(|backlog| backlog.peer_exact_demand_queue_mask(binding.slot))
         .unwrap_or(0);
+    // #4265 (R-2): the non-exact guarantee refill now routes through the
+    // shared queue lease (when the coordinator built one for a sharded
+    // non-exact guaranteed queue) so admission is metered class-wide
+    // instead of per-worker. The fast-path slice reads the disjoint
+    // `cos_fast_interfaces` field, so it coexists with the `cos_interfaces`
+    // mutable borrow below (same borrow-split the exact direct path uses).
+    let queue_fast_path = binding
+        .cos
+        .cos_fast_interfaces
+        .get(&root_ifindex)
+        .map(|iface_fast| iface_fast.queue_fast_path.as_slice())
+        .unwrap_or(&[]);
     let selected = {
         let root = binding.cos.cos_interfaces.get_mut(&root_ifindex)?;
-        select_nonexact_cos_guarantee_batch(root, now_ns).or_else(|| {
+        select_nonexact_cos_guarantee_batch(root, queue_fast_path, now_ns).or_else(|| {
             // Strict priority applies to surplus service only. Non-exact
             // queues with explicit transmit-rate guarantees keep their
             // guarantee pass. Residual/best-effort surplus remains
@@ -1341,6 +1353,7 @@ fn select_exact_cos_guarantee_queue_waterfill(
 #[inline]
 pub(in crate::afxdp) fn select_nonexact_cos_guarantee_batch(
     root: &mut CoSInterfaceRuntime,
+    queue_fast_path: &[WorkerCoSQueueFastPath],
     now_ns: u64,
 ) -> Option<CoSBatch> {
     let queue_count = root.queues.len();
@@ -1358,12 +1371,20 @@ pub(in crate::afxdp) fn select_nonexact_cos_guarantee_batch(
         {
             continue;
         }
-        let transmit_rate_bytes = queue.transmit_rate_bytes();
-        refill_cos_tokens(
-            &mut queue.hot.tokens,
-            transmit_rate_bytes,
-            queue.config.buffer_bytes.max(COS_MIN_BURST_BYTES),
-            &mut queue.hot.last_refill_ns,
+        // #4265 (R-2): meter the guarantee refill through the shared queue
+        // lease when the coordinator attached one (a sharded non-exact
+        // guaranteed queue, rate >= COS_SHARED_EXACT_MIN_RATE_BYTES). All
+        // workers draw from the one legacy lease -> aggregate admission ==
+        // configured rate. When no lease is attached (single-owner low-rate
+        // non-exact queue), `maybe_top_up_cos_queue_lease` falls through to
+        // the same per-worker `refill_cos_tokens` used before this change,
+        // so single-owner behaviour is unchanged. The legacy lease returns
+        // default (no-v8) telemetry, so nothing is dropped by ignoring it.
+        let _ = maybe_top_up_cos_queue_lease(
+            queue,
+            queue_fast_path
+                .get(queue_idx)
+                .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref()),
             now_ns,
         );
         let Some(head) = cos_queue_front(queue) else {

--- a/userspace-dp/src/afxdp/cos/queue_service/tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests.rs
@@ -73,7 +73,7 @@ fn nonexact_guarantee_skips_residual_only_scheduler_map_queue() {
     root.runnable_queues = 1;
 
     assert!(
-        select_nonexact_cos_guarantee_batch(&mut root, 1).is_none(),
+        select_nonexact_cos_guarantee_batch(&mut root, &[], 1).is_none(),
         "residual-only queue must not consume non-exact guarantee service"
     );
     assert!(matches!(
@@ -340,7 +340,7 @@ fn nonexact_guarantee_selects_explicit_transmit_rate_queue() {
     root.runnable_queues = 1;
 
     assert!(matches!(
-        select_nonexact_cos_guarantee_batch(&mut root, 1),
+        select_nonexact_cos_guarantee_batch(&mut root, &[], 1),
         Some(CoSBatch::Local {
             phase: CoSServicePhase::Guarantee,
             ..
@@ -377,7 +377,7 @@ fn fallback_root_shaped_default_queue_has_guarantee_service() {
     root.runnable_queues = 1;
 
     assert!(matches!(
-        select_nonexact_cos_guarantee_batch(&mut root, 1),
+        select_nonexact_cos_guarantee_batch(&mut root, &[], 1),
         Some(CoSBatch::Local {
             phase: CoSServicePhase::Guarantee,
             ..
@@ -883,7 +883,7 @@ fn exact_and_nonexact_guarantee_rr_cursors_advance_independently() {
     );
 
     // Serving a non-exact queue must not disturb the exact cursor.
-    let batch = select_nonexact_cos_guarantee_batch(&mut root, 1).expect("nonexact queue batch");
+    let batch = select_nonexact_cos_guarantee_batch(&mut root, &[], 1).expect("nonexact queue batch");
     match batch {
         CoSBatch::Local { queue_idx, .. } => assert_eq!(queue_idx, 1),
         CoSBatch::Prepared { .. } => panic!("expected local batch"),
@@ -930,7 +930,7 @@ fn exact_guarantee_rr_walks_exact_queues_in_order_independent_of_nonexact() {
         exact_order.push(selection.queue_idx);
         // Service a non-exact queue to simulate concurrent class activity;
         // ignore the result.
-        let _ = select_nonexact_cos_guarantee_batch(&mut root, 1);
+        let _ = select_nonexact_cos_guarantee_batch(&mut root, &[], 1);
     }
     assert_eq!(exact_order, vec![0, 2, 0, 2]);
 }
@@ -945,7 +945,7 @@ fn nonexact_guarantee_rr_walks_nonexact_queues_in_order_independent_of_exact() {
 
     let mut nonexact_order = Vec::new();
     for _ in 0..4 {
-        let batch = select_nonexact_cos_guarantee_batch(&mut root, 1).expect("nonexact batch");
+        let batch = select_nonexact_cos_guarantee_batch(&mut root, &[], 1).expect("nonexact batch");
         let queue_idx = match batch {
             CoSBatch::Local { queue_idx, .. } => queue_idx,
             CoSBatch::Prepared { queue_idx, .. } => queue_idx,
@@ -2435,7 +2435,7 @@ fn waterfill_guarantee_rate_skips_non_exact_queues() {
         let _ = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel);
     }
     // After draining exacts, non-exact selector still works.
-    let batch = select_nonexact_cos_guarantee_batch(&mut root, 1);
+    let batch = select_nonexact_cos_guarantee_batch(&mut root, &[], 1);
     assert!(batch.is_some(), "non-exact RR must remain reachable");
 }
 
@@ -3757,5 +3757,166 @@ fn service_exact_guarantee_zero_tx_refunds_phase1_honor() {
     assert_eq!(
         counters.phase1_selected_no_progress, 1,
         "the refunded no-progress visit is recorded"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #4265 (R-2): non-exact guaranteed classes must be metered class-wide, not
+// admitted at N_workers x their configured rate on a shared (sharded) egress.
+// ---------------------------------------------------------------------------
+
+/// A single non-exact GUARANTEED queue config with an explicit high
+/// transmit-rate — the shape that runs the sharded `shared_exact`
+/// execution policy (rate >= COS_SHARED_EXACT_MIN_RATE_BYTES) yet is
+/// serviced through `select_nonexact_cos_guarantee_batch` because it is
+/// not `exact`.
+fn nonexact_guarantee_queue(rate_bytes: u64) -> CoSQueueConfig {
+    CoSQueueConfig {
+        queue_id: 4,
+        forwarding_class: "iperf-be".into(),
+        priority: 5,
+        transmit_rate_bytes: rate_bytes,
+        guarantee_enabled: true,
+        exact: false,
+        surplus_sharing: false,
+        equal_flow_enforcement: false,
+        equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+        surplus_weight: 1,
+        buffer_bytes: 512 * 1024,
+        dscp_rewrite: None,
+        codel_target_ns: 0,
+    }
+}
+
+#[test]
+fn nonexact_guarantee_refill_is_gated_by_shared_lease_pool() {
+    // #4265 (R-2): the non-exact guarantee selector must meter its refill
+    // through the attached shared lease, NOT refill a private per-worker
+    // bucket at the full configured rate. Attach a lease whose shared pool
+    // is fully drained and cannot replenish within the call (no elapsed
+    // time), and confirm the selector grants ZERO tokens -> the queue stays
+    // token-starved and returns no batch, with `hot.tokens` left at 0.
+    //
+    // RED on revert: the pre-fix selector called `refill_cos_tokens`, which
+    // ignores the lease and refills `hot.tokens` to the buffer cap on the
+    // first refill -> a batch is returned and `hot.tokens > 0`.
+    let rate = 3_000_000_000u64 / 8; // 3 Gbps, >= COS_SHARED_EXACT_MIN_RATE_BYTES
+    let lease = Arc::new(SharedCoSQueueLease::new(rate, 256 * 1024, 6));
+
+    let t0 = 8 * TEST_EPOCH_DURATION_NS;
+    // Drain the shared pool to empty at t0 (a fresh lease starts with a
+    // burst of credit).
+    let drained = lease.acquire(t0, u64::MAX);
+    assert!(
+        drained > 0,
+        "a fresh legacy lease starts with a burst to drain"
+    );
+
+    let mut root = test_cos_runtime_with_queues(rate, vec![nonexact_guarantee_queue(rate)]);
+    root.tokens = u64::MAX / 2; // root shaper never caps
+    root.queues[0].hot.tokens = 0;
+    root.queues[0].hot.runnable = true;
+    root.queues[0].v_min.worker_id = 0;
+    for _ in 0..8 {
+        cos_queue_push_back(&mut root.queues[0], test_flow_cos_item(10_000, 1500));
+    }
+    let fp = vec![test_queue_fast_path(true, 0, None, Some(lease.clone()))];
+
+    // Same timestamp as the drain: no elapsed time, so the pool refills
+    // nothing and the queue must be starved of guarantee credit.
+    let batch = select_nonexact_cos_guarantee_batch(&mut root, &fp, t0);
+    assert!(
+        batch.is_none(),
+        "an empty shared lease must starve the non-exact guarantee; a batch here \
+         means the per-worker full-rate refill leaked through (the R-2 bug)"
+    );
+    assert_eq!(
+        root.queues[0].hot.tokens, 0,
+        "the selector must not refill a private per-worker bucket past the shared lease"
+    );
+}
+
+#[test]
+fn nonexact_guarantee_shared_lease_bounds_aggregate_admission_across_workers() {
+    // #4265 (R-2): a non-exact guaranteed class sharded across N workers
+    // must admit at AGGREGATE == its configured rate, not N x it. Before
+    // the fix each worker's `select_nonexact_cos_guarantee_batch` refilled a
+    // PRIVATE token bucket at the FULL rate, so N backlogged workers each
+    // admitted a full rate -> ~N x over-admit at guarantee priority. With
+    // the shared legacy lease attached, all N workers draw from ONE metered
+    // pool, so the class-wide admission is bounded near the configured rate.
+    //
+    // Model: N per-worker replicas of the same queue, each backlogged, all
+    // sharing one lease. Each tick every worker tops up through the selector
+    // then "sends" all the credit it acquired (draining `hot.tokens` and
+    // debiting the shared lease). The summed sends are the class-wide
+    // admission over the window.
+    //
+    // RED on revert: without the lease routing the per-worker refill makes
+    // the aggregate ~N x the configured rate.
+    const N: usize = 6;
+    let rate = 3_000_000_000u64 / 8; // 3 Gbps, >= COS_SHARED_EXACT_MIN_RATE_BYTES
+    let burst = 256 * 1024u64;
+    let lease = Arc::new(SharedCoSQueueLease::new(rate, burst, N));
+
+    let mut roots: Vec<CoSInterfaceRuntime> = Vec::with_capacity(N);
+    let mut fps: Vec<Vec<WorkerCoSQueueFastPath>> = Vec::with_capacity(N);
+    for w in 0..N {
+        let mut root = test_cos_runtime_with_queues(rate, vec![nonexact_guarantee_queue(rate)]);
+        root.queues[0].hot.runnable = true;
+        root.queues[0].v_min.worker_id = w as u32;
+        roots.push(root);
+        fps.push(vec![test_queue_fast_path(
+            true,
+            w as u32,
+            None,
+            Some(lease.clone()),
+        )]);
+    }
+
+    let start = 8 * TEST_EPOCH_DURATION_NS;
+    let step = TEST_EPOCH_DURATION_NS; // 200 us == one lease window
+    let ticks = 100u64; // 20 ms observation window
+    let mut aggregate_admitted = 0u64;
+
+    let mut now = start;
+    for _ in 0..ticks {
+        now += step;
+        for w in 0..N {
+            let root = &mut roots[w];
+            // Keep the queue backlogged and the root shaper uncapped so the
+            // per-queue shared lease is the only admission gate under test.
+            root.tokens = u64::MAX / 2;
+            while root.queues[0].hot.items.len() < 96 {
+                cos_queue_push_back(
+                    &mut root.queues[0],
+                    test_flow_cos_item(10_000 + w as u16, 500),
+                );
+            }
+            root.queues[0].hot.runnable = true;
+
+            let _ = select_nonexact_cos_guarantee_batch(root, &fps[w], now);
+
+            // A fully-backlogged worker sends everything it was granted this
+            // tick; debit the shared lease for those bytes.
+            let admitted = root.queues[0].hot.tokens;
+            aggregate_admitted = aggregate_admitted.saturating_add(admitted);
+            lease.consume(admitted);
+            root.queues[0].hot.tokens = 0;
+        }
+    }
+
+    let window_ns = ticks * step;
+    let expected = ((rate as u128) * (window_ns as u128) / 1_000_000_000u128) as u64;
+    assert!(
+        aggregate_admitted < 3 * expected,
+        "aggregate non-exact guarantee admission {aggregate_admitted} B over {window_ns} ns must \
+         stay bounded near the configured rate (expected ~{expected} B, N={N}); an aggregate \
+         approaching N x expected means each worker refilled a private full-rate bucket (the R-2 bug)"
+    );
+    assert!(
+        aggregate_admitted > expected / 2,
+        "aggregate admission {aggregate_admitted} B collapsed well below the configured rate \
+         (expected ~{expected} B) — the shared lease is over-throttling the class"
     );
 }

--- a/userspace-dp/src/afxdp/cos/tx_completion.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion.rs
@@ -720,7 +720,15 @@ pub(in crate::afxdp) fn refresh_cos_interface_activity(
     if let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) {
         for (queue_idx, queue) in root.queues.iter_mut().enumerate() {
             normalize_cos_queue_state(queue);
-            if cos_queue_is_empty(queue) && queue.config.exact && queue.hot.tokens > 0 {
+            // #4265 (R-2): give back an empty queue's banked burst whenever a
+            // shared lease is attached — this now includes the non-exact
+            // guaranteed sharded queue's legacy lease, not just exact
+            // queues. The `has_lease` probe is still the actual gate for the
+            // `mem::take` (R-5(a)): a no-lease queue (single-owner exact OR
+            // single-owner non-exact) keeps its banked burst intact, since
+            // there is nowhere to give it back. `release_unused_v8` reduces
+            // to the legacy `release_unused` for a legacy (v8=None) lease.
+            if cos_queue_is_empty(queue) && queue.hot.tokens > 0 {
                 let has_lease = iface_fast
                     .and_then(|iface_fast| iface_fast.queue_fast_path.get(queue_idx))
                     .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())
@@ -779,7 +787,15 @@ pub(in crate::afxdp) fn apply_cos_send_result(
     sent_bytes: u64,
     retry: VecDeque<TxRequest>,
 ) {
-    let mut exact_queue_idx = None;
+    // #4265 (R-2): the serviced queue's shared lease is debited in the
+    // Guarantee phase regardless of `exact` — a non-exact guaranteed
+    // sharded queue now carries a legacy lease that meters its class-wide
+    // admission, so its guarantee-phase sends must debit that lease too.
+    // `maybe_consume_exact_queue_lease` still gates on phase == Guarantee
+    // and lease-presence, so a non-leased queue or a surplus-phase send is
+    // a no-op (surplus draws from root tokens, not the per-queue lease —
+    // the #915 rationale).
+    let mut lease_consume_queue_idx = None;
     let binding_slot = binding.slot;
     let shared_exact_backlog = binding
         .cos
@@ -808,7 +824,7 @@ pub(in crate::afxdp) fn apply_cos_send_result(
             && interface_has_backlogged_exact_queue(root, peer_exact_backlogged);
         let mut debit_nonexact_surplus_budget = false;
         if let Some(queue) = root.queues.get_mut(queue_idx) {
-            exact_queue_idx = queue.config.exact.then_some(queue_idx);
+            lease_consume_queue_idx = Some(queue_idx);
             debit_nonexact_surplus_budget = sent_bytes > 0
                 && !queue.config.exact
                 && matches!(phase, CoSServicePhase::Surplus)
@@ -863,7 +879,7 @@ pub(in crate::afxdp) fn apply_cos_send_result(
     // #915: phase-gate `shared_queue_lease` consumption to the
     // Guarantee phase only. See `maybe_consume_exact_queue_lease`
     // for rationale.
-    if let Some(queue_idx) = exact_queue_idx {
+    if let Some(queue_idx) = lease_consume_queue_idx {
         let shared_queue_lease = binding
             .cos
             .cos_fast_interfaces
@@ -885,7 +901,15 @@ pub(in crate::afxdp) fn apply_cos_prepared_result(
     sent_bytes: u64,
     retry: VecDeque<PreparedTxRequest>,
 ) {
-    let mut exact_queue_idx = None;
+    // #4265 (R-2): the serviced queue's shared lease is debited in the
+    // Guarantee phase regardless of `exact` — a non-exact guaranteed
+    // sharded queue now carries a legacy lease that meters its class-wide
+    // admission, so its guarantee-phase sends must debit that lease too.
+    // `maybe_consume_exact_queue_lease` still gates on phase == Guarantee
+    // and lease-presence, so a non-leased queue or a surplus-phase send is
+    // a no-op (surplus draws from root tokens, not the per-queue lease —
+    // the #915 rationale).
+    let mut lease_consume_queue_idx = None;
     let binding_slot = binding.slot;
     let shared_exact_backlog = binding
         .cos
@@ -914,7 +938,7 @@ pub(in crate::afxdp) fn apply_cos_prepared_result(
             && interface_has_backlogged_exact_queue(root, peer_exact_backlogged);
         let mut debit_nonexact_surplus_budget = false;
         if let Some(queue) = root.queues.get_mut(queue_idx) {
-            exact_queue_idx = queue.config.exact.then_some(queue_idx);
+            lease_consume_queue_idx = Some(queue_idx);
             debit_nonexact_surplus_budget = sent_bytes > 0
                 && !queue.config.exact
                 && matches!(phase, CoSServicePhase::Surplus)
@@ -971,7 +995,7 @@ pub(in crate::afxdp) fn apply_cos_prepared_result(
     // #915: phase-gate `shared_queue_lease` consumption to the
     // Guarantee phase only. See `maybe_consume_exact_queue_lease`
     // for rationale.
-    if let Some(queue_idx) = exact_queue_idx {
+    if let Some(queue_idx) = lease_consume_queue_idx {
         let shared_queue_lease = binding
             .cos
             .cos_fast_interfaces

--- a/userspace-dp/src/afxdp/worker/cos/mod.rs
+++ b/userspace-dp/src/afxdp/worker/cos/mod.rs
@@ -195,10 +195,17 @@ pub(super) fn build_worker_cos_fast_interfaces(
                     .copied()
                     .unwrap_or(current_worker_id),
                 owner_live: owner_live_by_queue.get(&queue_key).cloned(),
-                shared_queue_lease: queue
-                    .exact
-                    .then(|| shared_queue_leases.get(&queue_key).cloned())
-                    .flatten(),
+                // #4265 (R-2): attach whatever lease the coordinator built
+                // for this queue. Previously gated on `queue.exact`, which
+                // starved the non-exact guaranteed sharded queue of any
+                // class-wide metering (each worker refilled a private
+                // full-rate bucket -> N x over-admit). The coordinator
+                // (`build_shared_cos_queue_leases_reusing_existing`) now
+                // emits a shared LEGACY lease for those queues too, so the
+                // map entry only exists for queues that should be metered
+                // (exact -> v8 lease; non-exact high-rate guaranteed ->
+                // legacy lease); attach unconditionally.
+                shared_queue_lease: shared_queue_leases.get(&queue_key).cloned(),
                 // #917 Phase 2b: V_min coordination Arc, allocated
                 // once per shared_exact CoS queue by the coordinator
                 // (per `build_shared_cos_queue_vtime_floors_reusing_existing`

--- a/userspace-dp/src/afxdp/worker/cos/mod.rs
+++ b/userspace-dp/src/afxdp/worker/cos/mod.rs
@@ -108,13 +108,24 @@ where
 ///   throughput collapse from PR #680.
 ///
 /// The exact/non-exact distinction does NOT live here — it lives in
-/// the lease/V_min allocation gates at `coordinator/mod.rs:1058`
-/// (`SharedCoSQueueLease`) and `coordinator/mod.rs:1145`
-/// (`SharedCoSQueueVtimeFloor`), both of which remain exact-only.
-/// Non-exact high-rate queues admitted here run via the
-/// `shared_exact` execution policy in `cross_binding.rs` (Step1 bail)
-/// and drain locally per worker, but they do NOT get a per-queue rate
-/// lease or V_min coordination — those are exact-queue-only concepts.
+/// the lease/V_min allocation gates in `coordinator/cos_leases.rs`
+/// (`build_shared_cos_queue_leases_reusing_existing` for
+/// `SharedCoSQueueLease`,
+/// `build_shared_cos_queue_vtime_floors_reusing_existing` for
+/// `SharedCoSQueueVtimeFloor`). The V_min flow-fair coordination
+/// (`SharedCoSQueueVtimeFloor`) and the v8 per-worker epoch-ledger
+/// lease remain exact-only. The per-queue RATE lease is NO LONGER
+/// exact-only: #4265 (R-2) attaches a legacy (v8=None)
+/// `SharedCoSQueueLease` to a GUARANTEED non-exact queue at or above
+/// this threshold so its guarantee-phase admission is metered as an
+/// aggregate across the sharded workers (each worker otherwise refilled
+/// a private full-rate bucket → up to N_workers × over-admit). So a
+/// non-exact high-rate queue admitted here runs via the `shared_exact`
+/// execution policy in `cross_binding.rs` (Step1 bail) and drains
+/// locally per worker; if it is ALSO guaranteed its guarantee refill
+/// draws from that shared legacy rate lease, but it still gets no V_min
+/// coordination and no v8 epoch ledger — those stay exact-queue-only
+/// concepts.
 ///
 /// Before PR #697 the threshold was `max(iface_rate / 4, MIN)`. That
 /// scaled with iface rate, which is the wrong direction: the


### PR DESCRIPTION
## Summary

Fixes fable-review-166 finding **R-2** per the #4245 converged plan
(option 1, shared legacy lease). A **non-exact** guaranteed CoS class
served by N workers on a shared (sharded) egress was admitted at up to
**N_workers x its configured guaranteed rate** at guarantee priority —
each worker refilled a PRIVATE token bucket at the FULL configured rate
in `select_nonexact_cos_guarantee_batch` with no class-wide metering (a
shared queue lease was attached only to `exact` queues, and the
coordinator only ever built a `SharedCoSQueueLease` for exact queues).
A 1g non-exact guarantee could take ~6 Gb/s on the 6-worker loss
cluster; the excess bypassed both the surplus-phase DWRR and the
`SharedCoSExactBacklog` residual bound. Same class as the closed
#4002 / #2955, a different still-open site.

## Fix

- **`coordinator/cos_leases.rs`** — `build_shared_cos_queue_leases_reusing_existing`
  now also builds a shared **LEGACY** `SharedCoSQueueLease::new` (v8=None,
  a greedy-aggregate shared token bucket) for non-exact `guarantee_enabled`
  queues whose rate trips `COS_SHARED_EXACT_MIN_RATE_BYTES` (the sharded
  ones that over-admit). Arc-reused via `matches_config`, so a worker
  join/leave changes `active_shards` and rebuilds the lease — the same
  discipline the exact v8 leases use.
- **`worker/cos/mod.rs`** — attaches whatever lease the coordinator built
  (dropped the `queue.exact` gate on the fast-path `shared_queue_lease`).
- **`queue_service/mod.rs`** — `select_nonexact_cos_guarantee_batch` takes
  the fast-path slice and refills through `maybe_top_up_cos_queue_lease`
  (its pre-existing but previously-unreachable non-exact-with-lease branch)
  instead of `refill_cos_tokens`. All N workers draw from ONE metered pool
  → aggregate admission == configured rate, still work-conserving (a single
  busy worker can drain the whole shared pool when peers are idle;
  rate-division would instead cap that worker at rate/N — the shared lease
  avoids that starvation tradeoff).
- **`tx_completion.rs`** — the guarantee-phase send debits the lease via
  `maybe_consume_exact_queue_lease` regardless of `exact` (`exact_queue_idx`
  → `lease_consume_queue_idx`), and the queue-empty give-back in
  `refresh_cos_interface_activity` now fires for any leased queue (gated on
  `has_lease`, not `exact`) through `release_unused_v8`, which reduces to
  the legacy `release_unused` for a v8=None lease.

The legacy lease has no v8 epoch ledger, so it is not subject to the
#4246 T-1 / R-5(a) accounting hole. Single-owner low-rate non-exact
queues are unchanged (no lease → same per-worker refill).

## Tests (both RED on revert, verified)

- `nonexact_guarantee_shared_lease_bounds_aggregate_admission_across_workers`
  — N=6 worker replicas sharing one lease over a 20 ms window; asserts the
  summed admission stays near the configured rate (revert → ~N x → fails).
- `nonexact_guarantee_refill_is_gated_by_shared_lease_pool` — an empty
  shared pool starves the selector rather than leaking a private full-rate
  refill (revert → a batch + non-zero tokens → fails).

FULL `cargo test --release` green (3551 lib + 46 + 8 + 16 + 1, zero
failures). Docs: `fairness-regimes.md` gains an R-2 subsection.

## Follow-up

Needs a **cluster CoS smoke** with a non-exact guaranteed class on a
shared multi-worker egress to confirm the aggregate cap on real traffic —
the standard fixtures use exact classes, so this does not fire on the
canonical smoke matrix.

Closes #4265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi