### PR TITLE
cos: TX-path MEDIUM cluster fixes (fable-166 T-6, READY sub-items)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -34995,3 +34995,64 @@ top.
   userspace-dp/src/protocol/cos.rs,
   pkg/dataplane/userspace/protocol.go,
   docs/fairness-regimes.md, _Log.md
+
+- **Timestamp**: 2026-07-05
+- **Action**: hb166 T-6 (#4267) — TX-path MEDIUM cluster: drove 6 of the 7
+  READY sub-items (a, b, d, e, g, m) to fixes; deferred (k) + the original
+  6 (c/f/h/i/j/l) with recorded reasons. Verified each reproduces at HEAD
+  (origin/master 81e8f381f); none already-fixed by R-7/#4255, T-1/#4253,
+  T-2+T-5/#4258, R-1/R-3/R-4/#4264. (g) admission drop no longer
+  double-reports as tx_errors nor allocates a per-drop set_error(format!)
+  String (~1M allocs/sec hot-path violation) — kept the dedicated
+  admission_*_drops + dbg_cos_queue_overflow counters; same per-drop
+  format! removed from bound_pending_tx_* overflow loops. (d)
+  transmit_batch oversized-frame Drop-unwind now drains in reverse
+  (.drain(..).rev()) so same-flow TCP segments keep order. (m)
+  fragments/flowless (flow_key None) now get BA (DSCP→802.1p→default)
+  classification in both resolve_cos_tx_selection_internal and
+  resolve_cached_cos_tx_selection instead of default-queue. (e)
+  submit_local/submit_prepared now call publish_committed_queue_vtime on
+  the 5th V_min settle boundary (surplus-phase shared_exact was advancing
+  vtime unpublished). (a) added v_min_suspended_batches counter (full
+  scratch→atomic→snapshot→wire + Go VMinSuspendedBatches) + a decaying
+  re-arm (halve the suspension window per consecutive hard-cap toward
+  V_MIN_SUSPENSION_MIN_BATCHES=64, reset on a clean check). (b) gated BOTH
+  the local root_exact_demand_queue_mask and the published
+  exact_backlog_queue_mask on a shared cos_exact_queue_serviceable
+  predicate so a v8-starved exact class releases its BE-surplus reservation
+  (work conservation); serviceable_exact_backlog_bytes refactored to share
+  it. RED-on-revert unit tests added for all six (d/g/b spot-verified: the
+  named tests FAIL against reverted code). FULL cargo test --release green
+  (3631 tests, 0 failed); regenerated tests/fixtures/protocol_wire_v1.json
+  for the additive v_min_suspended_batches wire key; Go userspace parity
+  tests green. (a) telemetry + (b) reservation contract change need a
+  cluster CoS smoke before merge.
+- **File(s)**: userspace-dp/src/afxdp/tx/cos_classify.rs,
+  userspace-dp/src/afxdp/tx/cos_classify_tests.rs,
+  userspace-dp/src/afxdp/tx/drain/mod.rs,
+  userspace-dp/src/afxdp/tx/transmit/mod.rs,
+  userspace-dp/src/afxdp/tx/transmit_tests.rs,
+  userspace-dp/src/afxdp/cos/queue_service/mod.rs,
+  userspace-dp/src/afxdp/cos/queue_service/submit_local.rs,
+  userspace-dp/src/afxdp/cos/queue_service/submit_prepared.rs,
+  userspace-dp/src/afxdp/cos/queue_service/tests.rs,
+  userspace-dp/src/afxdp/cos/tx_completion.rs,
+  userspace-dp/src/afxdp/cos/queue_ops/mod.rs,
+  userspace-dp/src/afxdp/cos/queue_ops/v_min.rs,
+  userspace-dp/src/afxdp/cos/queue_ops/v_min_tests.rs,
+  userspace-dp/src/afxdp/cos/builders.rs,
+  userspace-dp/src/afxdp/cos/mod.rs,
+  userspace-dp/src/afxdp/types/cos.rs,
+  userspace-dp/src/afxdp/umem/mod.rs,
+  userspace-dp/src/afxdp/umem/debug_state.rs,
+  userspace-dp/src/afxdp/umem/snapshot.rs,
+  userspace-dp/src/afxdp/umem/tests.rs,
+  userspace-dp/src/afxdp/worker/mod.rs,
+  userspace-dp/src/afxdp/worker/cos/tests.rs,
+  userspace-dp/src/afxdp/cos/tx_completion_tests.rs,
+  userspace-dp/src/afxdp/coordinator/refresh_bindings.rs,
+  userspace-dp/src/protocol/binding.rs,
+  userspace-dp/src/main_tests.rs,
+  userspace-dp/tests/fixtures/protocol_wire_v1.json,
+  pkg/dataplane/userspace/protocol.go,
+  docs/fairness-regimes.md, _Log.md

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -1603,6 +1603,89 @@ per-class SOLO/simul-load harness for R-1/R-4, and — because R-3 cannot
 be reproduced on x86-TSO — a functional CoS smoke to confirm the added
 writer fence is behavior-neutral on the deploy targets.
 
+#### TX-path MEDIUM cluster fixes (hb166 T-6, #4267)
+
+The fable-review-166 T-6 grouped TX-path cluster enumerated 13 CoS
+correctness/robustness sub-items (a–m). #4245 classified them 7 READY /
+6 DEFER; #4267 drives the six that are cleanly bounded at current master
+(after R-7/#4255, T-1/#4253, T-2+T-5/#4258, R-1/R-3/R-4/#4264 merged).
+Each carries a RED-on-revert unit test.
+
+- **T-6(a) — V_min suspended-batch telemetry + decaying re-arm.** The
+  V_min hard-cap arms `V_MIN_SUSPENSION_BATCHES` (1000) suspended drains
+  (`queue_ops/v_min.rs`), but `cos_queue_v_min_consume_suspension` counted
+  none of them — only the activation (`v_min_hard_cap_overrides`) — so
+  telemetry read "brake idle" while it was actually suppressed ~99% of the
+  time under persistent skew. Fix: a `v_min_suspended_batches` counter
+  (full scratch→atomic→snapshot→wire plumbing, mirrors `v_min_throttles`,
+  Go `VMinSuspendedBatches`) plus a decaying re-arm — each consecutive
+  hard-cap (no intervening passing V_min check) halves the suspension
+  window toward `V_MIN_SUSPENSION_MIN_BATCHES` (64), and a clean check
+  restores the full window — so a persistently-skewed queue re-engages the
+  brake progressively sooner. R-7/#4255 fixed the *root cause* of the trap
+  (rejoiner reseed); this is the telemetry + re-arm half of the same pair.
+
+- **T-6(b) — work-conserving exact-demand surplus reservation.** The
+  best-effort surplus reservation counted an exact guarantee class as full
+  demand (reserving its whole rate from the BE residual) merely for being
+  non-empty (`root_exact_demand_queue_mask`, `queue_service/mod.rs`;
+  `exact_backlog_queue_mask`, `tx_completion.rs`) — even when the class was
+  v8-starved / token-parked and shipping zero bytes, starving BE while the
+  link idled. Fix: a shared `cos_exact_queue_serviceable` predicate
+  (`queue_ops/mod.rs`) — runnable ∧ non-empty ∧ root/queue tokens cover the
+  head — gates BOTH the local demand mask AND the published peer-demand
+  mask, aligning them with the serviceability signal
+  `serviceable_exact_backlog_bytes` already publishes. A non-serviceable
+  class now releases its residual to best-effort. This touches the
+  #1368/#1371 BE-vs-exact contention contract — **needs a cluster CoS smoke
+  before merge** (confirm BE reclaims idle bandwidth without under-serving
+  a briefly-parked exact class). The "budget-0 queues never park / no wake
+  source" half of (b) is a separate wake-source design and stays deferred.
+
+- **T-6(e) — V_min publish on the CoSBatch settle path.** The CoSBatch
+  submit path (`submit_local`/`submit_prepared`) was the 5th of 5 V_min
+  settle boundaries but never called `publish_committed_queue_vtime`; the
+  four direct-service sites in `service.rs` do. Surplus-phase shared_exact
+  service advanced `queue_vtime` during batch build but never broadcast it,
+  so peers read a stale-low V_min slot and self-throttled exactly when
+  surplus works hardest. Fix: add the post-settle publish (no-op for
+  non-flow-fair / non-shared queues).
+
+- **T-6(g) — admission drops stop double-reporting as tx_errors + stop
+  allocating.** A designed CoS admission drop (`flow_share`/`buffer`
+  exceeded, `tx/cos_classify.rs`) — already counted in the dedicated
+  `admission_flow_share_drops`/`admission_buffer_drops` counters — ALSO
+  bumped the aggregate `tx_errors` (an operator reads a saturated shaper as
+  a fault) and allocated a per-drop `set_error(format!())` String, ~1M
+  allocs/sec under a shaping-drop storm (a hot-path-allocation-rule
+  violation). Fix: drop both; keep the non-allocating `dbg_cos_queue_overflow`
+  disambiguation counter. The per-drop `format!` in the `bound_pending_tx_*`
+  overflow loops (`tx/drain/mod.rs`) is removed for the same reason.
+
+- **T-6(d) — transmit_batch Drop-unwind order.** The oversized-frame
+  error unwind in `transmit_batch` (`tx/transmit/mod.rs`) drained the
+  staged prefix forward and `push_front`-ed each item, REVERSING same-flow
+  (in-order TCP) segments back onto `pending`. Fix: `.drain(..).rev()`
+  (the idiom already used in `tcp_segmentation.rs`).
+
+- **T-6(m) — BA classification for fragments / flowless packets.**
+  `resolve_cos_tx_selection` / `resolve_cached_cos_tx_selection` returned
+  the default queue whenever `flow_key == None` (fragments, flowless),
+  bypassing DSCP / 802.1p behavior-aggregate classification despite the
+  DSCP being present — so EF fragments straddled queues. BA classification
+  is 5-tuple-independent; the fix runs the DSCP→802.1p→default lookup from
+  `meta` in both None branches.
+
+**Deferred T-6 sub-items (recorded in #4267):** (k) coordinator-side
+scrub on binding unregister — overlaps R-7's reseed + the existing
+worker-side `vacate_all_shared_exact_slots_for_binding`; a safe scrub that
+distinguishes membership-change from legit Arc-reuse (without clobbering
+the deliberate additive `rehydrate_worker_active_count` or scrubbing live
+vtime slots) needs its own analysis + failover smoke. (c) ECN aggregate
+arm, (f) sidecar desync, (h) inbox-overflow fallbacks, (i)
+`max_total_leased` bank floor, (j) equal-flow divisor, (l) truncating-zip
+/ FIFO-settle sojourn — each needs its own design decision or repro.
+
 ### Simul-load harness
 
 `test/incus/cos-simul-load-smoke.sh [push|reverse]` runs all 11

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -2345,15 +2345,20 @@ type BindingStatus struct {
 	// rescued throughput". Ratio is the LAG_THRESHOLD diagnostic.
 	VMinThrottleHardCapOverrides uint64 `json:"v_min_throttle_hard_cap_overrides,omitempty"`
 	VMinThrottles                uint64 `json:"v_min_throttles,omitempty"`
-	SessionHits                  uint64 `json:"session_hits,omitempty"`
-	SessionMisses                uint64 `json:"session_misses,omitempty"`
-	SessionCreates               uint64 `json:"session_creates,omitempty"`
-	SessionExpires               uint64 `json:"session_expires,omitempty"`
-	SessionDeltaPending          uint64 `json:"session_delta_pending,omitempty"`
-	SessionDeltaGenerated        uint64 `json:"session_delta_generated,omitempty"`
-	SessionDeltaDropped          uint64 `json:"session_delta_dropped,omitempty"`
-	SessionDeltaDrained          uint64 `json:"session_delta_drained,omitempty"`
-	PolicyDeniedPackets          uint64 `json:"policy_denied_packets,omitempty"`
+	// #hb166 T-6(a): count of V_min suspended drain batches — batches
+	// where the fairness brake was OFF because a prior hard-cap armed
+	// suspension. VMinSuspendedBatches / VMinThrottleHardCapOverrides is
+	// the effective suspension-window-length diagnostic.
+	VMinSuspendedBatches  uint64 `json:"v_min_suspended_batches,omitempty"`
+	SessionHits           uint64 `json:"session_hits,omitempty"`
+	SessionMisses         uint64 `json:"session_misses,omitempty"`
+	SessionCreates        uint64 `json:"session_creates,omitempty"`
+	SessionExpires        uint64 `json:"session_expires,omitempty"`
+	SessionDeltaPending   uint64 `json:"session_delta_pending,omitempty"`
+	SessionDeltaGenerated uint64 `json:"session_delta_generated,omitempty"`
+	SessionDeltaDropped   uint64 `json:"session_delta_dropped,omitempty"`
+	SessionDeltaDrained   uint64 `json:"session_delta_drained,omitempty"`
+	PolicyDeniedPackets   uint64 `json:"policy_denied_packets,omitempty"`
 	// #3326: host-bound packets dropped by the zone host-inbound admission
 	// gate. Mirrored into dataplane.GlobalCtrHostInboundDeny by
 	// syncBPFCountersLocked so REST (host_inbound_denies), Prometheus
@@ -2637,6 +2642,8 @@ type BindingCountersSnapshot struct {
 	// projects zeros even when the atomics flushed real values.
 	VMinThrottleHardCapOverrides uint64 `json:"v_min_throttle_hard_cap_overrides,omitempty"`
 	VMinThrottles                uint64 `json:"v_min_throttles,omitempty"`
+	// #hb166 T-6(a): V_min suspended-batch count (per_binding lean view).
+	VMinSuspendedBatches uint64 `json:"v_min_suspended_batches,omitempty"`
 }
 
 type ExceptionStatus struct {

--- a/userspace-dp/src/afxdp/coordinator/refresh_bindings.rs
+++ b/userspace-dp/src/afxdp/coordinator/refresh_bindings.rs
@@ -96,6 +96,7 @@ fn copy_live_snapshot(binding: &mut BindingStatus, snap: BindingLiveSnapshot) {
     // wire surface (BindingCountersSnapshot) sees them.
     binding.v_min_throttle_hard_cap_overrides = snap.v_min_throttle_hard_cap_overrides;
     binding.v_min_throttles = snap.v_min_throttles;
+    binding.v_min_suspended_batches = snap.v_min_suspended_batches;
     binding.session_hits = snap.session_hits;
     binding.session_misses = snap.session_misses;
     binding.session_creates = snap.session_creates;
@@ -292,6 +293,7 @@ fn zero_unbound_slot(binding: &mut BindingStatus) {
     binding.flow_cache_capacity = 0;
     binding.v_min_throttle_hard_cap_overrides = 0;
     binding.v_min_throttles = 0;
+    binding.v_min_suspended_batches = 0;
     binding.session_hits = 0;
     binding.session_misses = 0;
     binding.session_creates = 0;

--- a/userspace-dp/src/afxdp/cos/builders.rs
+++ b/userspace-dp/src/afxdp/cos/builders.rs
@@ -230,6 +230,8 @@ pub(in crate::afxdp) fn build_cos_interface_runtime(
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_suspended_batches_scratch: 0,
+                    v_min_suspension_window: super::queue_ops::V_MIN_SUSPENSION_BATCHES,
                     v_min_pop_count: 0,
                 },
                 telemetry: CoSQueueTelemetry {

--- a/userspace-dp/src/afxdp/cos/mod.rs
+++ b/userspace-dp/src/afxdp/cos/mod.rs
@@ -19,11 +19,11 @@ pub(super) use cross_binding::{
 };
 pub(super) use flow_hash::{cos_flow_bucket_index, cos_item_flow_key};
 pub(super) use queue_ops::{
-    cos_item_len, cos_queue_clear_orphan_snapshot_after_drop, cos_queue_drain_all, cos_queue_front,
-    cos_queue_front_with_cap, cos_queue_is_empty, cos_queue_len, cos_queue_peek_min_bucket,
-    cos_queue_pop_front_no_snapshot, cos_queue_pop_known_bucket, cos_queue_push_back,
-    cos_queue_push_front, cos_queue_restore_front, cos_queue_v_min_consume_suspension,
-    cos_queue_v_min_continue, publish_committed_queue_vtime,
+    cos_exact_queue_serviceable, cos_item_len, cos_queue_clear_orphan_snapshot_after_drop,
+    cos_queue_drain_all, cos_queue_front, cos_queue_front_with_cap, cos_queue_is_empty,
+    cos_queue_len, cos_queue_peek_min_bucket, cos_queue_pop_front_no_snapshot,
+    cos_queue_pop_known_bucket, cos_queue_push_back, cos_queue_push_front, cos_queue_restore_front,
+    cos_queue_v_min_consume_suspension, cos_queue_v_min_continue, publish_committed_queue_vtime,
 };
 // #1763: reference single-pop API retained for tests (fused out of the
 // production drain paths). Still present in non-test builds;

--- a/userspace-dp/src/afxdp/cos/queue_ops/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/mod.rs
@@ -269,6 +269,16 @@ pub(in crate::afxdp) const V_MIN_CONSECUTIVE_SKIP_HARD_CAP: u32 = 8;
 /// short enough that mouse-latency budgets (#905) are unaffected.
 pub(in crate::afxdp) const V_MIN_SUSPENSION_BATCHES: u32 = 1000;
 
+/// #hb166 T-6(a) — floor for the decaying re-arm of the V_min
+/// suspension window. Each consecutive hard-cap activation (no
+/// intervening passing V_min check) halves the suspension window from
+/// `V_MIN_SUSPENSION_BATCHES` toward this floor, so a PERSISTENTLY
+/// skewed shared_exact queue re-engages the fairness brake far sooner
+/// than the fixed 1000-batch (~200 ms) window would — instead of the
+/// brake staying off ~99% of the time. A clean V_min check resets the
+/// window back to `V_MIN_SUSPENSION_BATCHES`.
+pub(in crate::afxdp) const V_MIN_SUSPENSION_MIN_BATCHES: u32 = 64;
+
 /// #1735: consecutive quiescent batch settles required before a
 /// lazily-promoted non-exact flow-fair queue is demoted back to FIFO
 /// (dropping its ~232 KB `FlowFairState`). Hysteresis so a queue
@@ -338,6 +348,34 @@ pub(in crate::afxdp) fn cos_item_len(item: &CoSPendingTxItem) -> u64 {
         CoSPendingTxItem::Local(req) => req.bytes.len() as u64,
         CoSPendingTxItem::Prepared(req) => req.len as u64,
     }
+}
+
+/// #hb166 T-6(b): a guaranteed exact queue counts as REAL (serviceable)
+/// demand for the surplus-reservation masks only when it can actually ship
+/// its head packet right now — runnable, non-empty, and both the root and
+/// per-queue token buckets cover the head length. A v8-starved /
+/// token-parked exact class that ships zero bytes is NOT serviceable, so it
+/// must release its reserved rate to best-effort (work conservation)
+/// instead of zeroing the BE residual while the link idles.
+///
+/// This is exactly the per-queue predicate the shared_exact backlog already
+/// publishes as `serviceable_exact_backlog_bytes`; gating the demand MASKS
+/// on it makes the reservation consistent with the published serviceability
+/// signal. Callers still apply the `exact && guarantee_enabled` config
+/// gate separately.
+#[inline]
+pub(in crate::afxdp) fn cos_exact_queue_serviceable(
+    root_tokens: u64,
+    queue: &CoSQueueRuntime,
+) -> bool {
+    if !queue.hot.runnable {
+        return false;
+    }
+    let Some(head) = cos_queue_front(queue) else {
+        return false;
+    };
+    let head_len = cos_item_len(head);
+    root_tokens >= head_len && queue.hot.tokens >= head_len
 }
 
 #[cfg(test)]

--- a/userspace-dp/src/afxdp/cos/queue_ops/v_min.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/v_min.rs
@@ -116,6 +116,12 @@ fn compute_v_min_lag_threshold(queue_rate_bytes: u64, participating: u32) -> u64
 pub(in crate::afxdp) fn cos_queue_v_min_consume_suspension(queue: &mut CoSQueueRuntime) -> bool {
     if queue.v_min.v_min_suspended_remaining > 0 {
         queue.v_min.v_min_suspended_remaining -= 1;
+        // #hb166 T-6(a): count every batch the fairness brake is OFF
+        // because a prior hard-cap armed suspension. Pre-fix these were
+        // uncounted, so telemetry read "brake idle" while it was actually
+        // suppressed ~99% of the time under persistent skew.
+        queue.v_min.v_min_suspended_batches_scratch =
+            queue.v_min.v_min_suspended_batches_scratch.saturating_add(1);
         return true;
     }
     false
@@ -185,6 +191,10 @@ pub(in crate::afxdp) fn cos_queue_v_min_continue(
     // and gating decision are byte-identical to before.
     if transmit_rate_bytes == 0 {
         queue.v_min.consecutive_v_min_skips = 0;
+        // #hb166 T-6(a): not throttled -> reset the decaying suspension
+        // window (see the hard-cap arm below). Invariant: the window is
+        // full whenever the consecutive-skip counter is 0.
+        queue.v_min.v_min_suspension_window = V_MIN_SUSPENSION_BATCHES;
         return true;
     }
     // Invariant: shared_exact queues are also flow_fair (set together
@@ -210,6 +220,8 @@ pub(in crate::afxdp) fn cos_queue_v_min_continue(
     let Some(v_min) = v_min else {
         // No peers — reset hard-cap counter and continue.
         queue.v_min.consecutive_v_min_skips = 0;
+        // #hb166 T-6(a): not throttled -> reset the decaying window.
+        queue.v_min.v_min_suspension_window = V_MIN_SUSPENSION_BATCHES;
         return true;
     };
     let lag = compute_v_min_lag_threshold(transmit_rate_bytes, participating + 1);
@@ -219,6 +231,9 @@ pub(in crate::afxdp) fn cos_queue_v_min_continue(
         // single throttled batch followed by 7 ok ones doesn't
         // accumulate.
         queue.v_min.consecutive_v_min_skips = 0;
+        // #hb166 T-6(a): the skew cleared -> restore the full decaying
+        // suspension window (see the hard-cap arm below).
+        queue.v_min.v_min_suspension_window = V_MIN_SUSPENSION_BATCHES;
         return true;
     }
     // #941 Work item D: hard-cap accounting. After
@@ -231,7 +246,15 @@ pub(in crate::afxdp) fn cos_queue_v_min_continue(
     queue.v_min.consecutive_v_min_skips = queue.v_min.consecutive_v_min_skips.saturating_add(1);
     if queue.v_min.consecutive_v_min_skips >= V_MIN_CONSECUTIVE_SKIP_HARD_CAP {
         queue.v_min.consecutive_v_min_skips = 0;
-        queue.v_min.v_min_suspended_remaining = V_MIN_SUSPENSION_BATCHES;
+        // #hb166 T-6(a): decaying re-arm. Suspend for the CURRENT window,
+        // then halve it toward V_MIN_SUSPENSION_MIN_BATCHES so a queue
+        // that keeps tripping the hard-cap (no intervening passing V_min
+        // check to reset the window) re-engages the brake progressively
+        // sooner, instead of the fixed 1000-batch window keeping the
+        // brake off ~99% of the time under persistent skew.
+        queue.v_min.v_min_suspended_remaining = queue.v_min.v_min_suspension_window;
+        queue.v_min.v_min_suspension_window =
+            (queue.v_min.v_min_suspension_window / 2).max(V_MIN_SUSPENSION_MIN_BATCHES);
         queue.v_min.v_min_hard_cap_overrides_scratch = queue
             .v_min
             .v_min_hard_cap_overrides_scratch

--- a/userspace-dp/src/afxdp/cos/queue_ops/v_min.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/v_min.rs
@@ -191,9 +191,14 @@ pub(in crate::afxdp) fn cos_queue_v_min_continue(
     // and gating decision are byte-identical to before.
     if transmit_rate_bytes == 0 {
         queue.v_min.consecutive_v_min_skips = 0;
-        // #hb166 T-6(a): not throttled -> reset the decaying suspension
-        // window (see the hard-cap arm below). Invariant: the window is
-        // full whenever the consecutive-skip counter is 0.
+        // #hb166 T-6(a): the decaying suspension window (see the hard-cap
+        // arm below) is RESTORED to full on the skew-clear / not-applicable
+        // paths — this unshaped path, the no-peer path, and a passing
+        // V_min check. The hard-cap path is the ONLY place that resets the
+        // skip counter WITHOUT restoring the window (it deliberately keeps
+        // the halved value, the decaying re-arm), so this is not a global
+        // "window==full iff skips==0" invariant — it is a reset on the
+        // three not-throttled outcomes.
         queue.v_min.v_min_suspension_window = V_MIN_SUSPENSION_BATCHES;
         return true;
     }

--- a/userspace-dp/src/afxdp/cos/queue_ops/v_min_tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/v_min_tests.rs
@@ -693,6 +693,123 @@ fn vmin_hard_cap_force_continue_activates_suspension() {
     );
 }
 
+// #hb166 T-6(a): consecutive hard-cap activations (no intervening
+// passing V_min check) must DECAY the suspension re-arm window — halving
+// it toward V_MIN_SUSPENSION_MIN_BATCHES — so a persistently-skewed queue
+// re-engages the fairness brake progressively sooner instead of parking
+// it off for the fixed 1000-batch window every time. A clean V_min check
+// resets the window to full.
+//
+// FAIL-ON-REVERT: restoring the fixed
+// `v_min_suspended_remaining = V_MIN_SUSPENSION_BATCHES` arm flips the
+// 2nd/3rd activation assertions from 500/250 back to 1000.
+#[test]
+fn vmin_hard_cap_rearm_decays_suspension_window() {
+    let mut root = test_cos_runtime_with_queues(
+        10_000_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 0,
+            forwarding_class: "iperf-c".into(),
+            priority: 5,
+            transmit_rate_bytes: 10_000_000_000 / 8,
+            guarantee_enabled: true,
+            exact: true,
+            surplus_sharing: false,
+            equal_flow_enforcement: false,
+            equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+            surplus_weight: 1,
+            buffer_bytes: COS_MIN_BURST_BYTES,
+            dscp_rewrite: None,
+            codel_target_ns: 0,
+        }],
+    );
+    let queue = &mut root.queues[0];
+    let floor = attach_test_vtime_floor(queue, 4, 1);
+    floor.slots[0].publish(0);
+    test_flow_fair_state_mut(queue).queue_vtime = 100 * 1024 * 1024;
+
+    // Drive one full hard-cap cycle: 7 throttles then the force-continue.
+    let fire_hard_cap = |queue: &mut CoSQueueRuntime| {
+        for _ in 1..V_MIN_CONSECUTIVE_SKIP_HARD_CAP {
+            assert!(!cos_queue_v_min_continue(queue, 1), "throttle expected");
+        }
+        assert!(cos_queue_v_min_continue(queue, 1), "hard-cap force-continue");
+    };
+
+    fire_hard_cap(queue);
+    assert_eq!(
+        queue.v_min.v_min_suspended_remaining, V_MIN_SUSPENSION_BATCHES,
+        "1st activation arms the full window",
+    );
+    fire_hard_cap(queue);
+    assert_eq!(
+        queue.v_min.v_min_suspended_remaining,
+        V_MIN_SUSPENSION_BATCHES / 2,
+        "2nd consecutive activation halves the window",
+    );
+    fire_hard_cap(queue);
+    assert_eq!(
+        queue.v_min.v_min_suspended_remaining,
+        V_MIN_SUSPENSION_BATCHES / 4,
+        "3rd consecutive activation halves again",
+    );
+
+    // A clean V_min check (queue within lag of the peer) resets the window.
+    test_flow_fair_state_mut(queue).queue_vtime = 0;
+    assert!(cos_queue_v_min_continue(queue, 1), "queue is now within lag");
+    assert_eq!(
+        queue.v_min.v_min_suspension_window, V_MIN_SUSPENSION_BATCHES,
+        "a passing V_min check restores the full window",
+    );
+    // ...and the next activation re-arms at the full window.
+    test_flow_fair_state_mut(queue).queue_vtime = 100 * 1024 * 1024;
+    fire_hard_cap(queue);
+    assert_eq!(
+        queue.v_min.v_min_suspended_remaining, V_MIN_SUSPENSION_BATCHES,
+        "after reset the window re-arms at full",
+    );
+}
+
+// #hb166 T-6(a): every consumed suspension slot must increment the
+// per-queue scratch counter so telemetry stops reading "brake idle" while
+// the brake is actually suppressed.
+//
+// FAIL-ON-REVERT: dropping the scratch increment in
+// `cos_queue_v_min_consume_suspension` leaves the counter at 0.
+#[test]
+fn vmin_consume_suspension_counts_suspended_batches() {
+    let mut root = test_cos_runtime_with_queues(
+        10_000_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 0,
+            forwarding_class: "iperf-c".into(),
+            priority: 5,
+            transmit_rate_bytes: 10_000_000_000 / 8,
+            guarantee_enabled: true,
+            exact: true,
+            surplus_sharing: false,
+            equal_flow_enforcement: false,
+            equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+            surplus_weight: 1,
+            buffer_bytes: COS_MIN_BURST_BYTES,
+            dscp_rewrite: None,
+            codel_target_ns: 0,
+        }],
+    );
+    let queue = &mut root.queues[0];
+    let _floor = attach_test_vtime_floor(queue, 4, 1);
+    queue.v_min.v_min_suspended_remaining = 5;
+    for _ in 0..5 {
+        assert!(cos_queue_v_min_consume_suspension(queue));
+    }
+    // Drained — no further count.
+    assert!(!cos_queue_v_min_consume_suspension(queue));
+    assert_eq!(
+        queue.v_min.v_min_suspended_batches_scratch, 5,
+        "each consumed suspension slot must be counted exactly once",
+    );
+}
+
 /// #941 Work item D: `cos_queue_v_min_consume_suspension` decrements
 /// the counter once per call and returns the suspension state.
 #[test]

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -29,7 +29,7 @@ use crate::afxdp::{FastMap, TX_BATCH_SIZE, tx_frame_capacity};
 use crate::xsk_ffi::xdp::XdpDesc;
 
 use super::{
-    COS_MIN_BURST_BYTES, CoSQueueLeaseAcquireTelemetry, cos_item_len,
+    COS_MIN_BURST_BYTES, CoSQueueLeaseAcquireTelemetry, cos_exact_queue_serviceable, cos_item_len,
     cos_queue_clear_orphan_snapshot_after_drop, cos_queue_front, cos_queue_front_with_cap,
     cos_queue_is_empty, cos_queue_peek_min_bucket, cos_queue_pop_known_bucket, cos_queue_push_front,
     cos_queue_v_min_consume_suspension, cos_queue_v_min_continue, cos_refill_ns_until,
@@ -301,11 +301,21 @@ fn build_nonexact_cos_batch(
 
 #[inline]
 fn root_exact_demand_queue_mask(root: &CoSInterfaceRuntime) -> u64 {
+    // #hb166 T-6(b): reserve residual best-effort surplus ONLY for exact
+    // guarantee queues that are actually SERVICEABLE (can ship their head
+    // right now). A v8-starved / token-parked exact class shipping zero
+    // bytes must NOT zero the BE residual while the link idles — gate on
+    // the same serviceability predicate the shared_exact backlog already
+    // publishes (`serviceable_exact_backlog_bytes`) instead of the loose
+    // `!cos_queue_is_empty`.
+    let root_tokens = root.tokens;
     root.queues
         .iter()
         .enumerate()
         .filter(|(_, queue)| {
-            queue.config.exact && queue.config.guarantee_enabled && !cos_queue_is_empty(queue)
+            queue.config.exact
+                && queue.config.guarantee_enabled
+                && cos_exact_queue_serviceable(root_tokens, queue)
         })
         .fold(0u64, |acc, (queue_idx, _)| {
             if queue_idx < u64::BITS as usize {

--- a/userspace-dp/src/afxdp/cos/queue_service/submit_local.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/submit_local.rs
@@ -128,6 +128,21 @@ pub(super) fn submit_local(
                     .drain_sent_bytes_shaped_unconditional
                     .fetch_add(bytes, Ordering::Relaxed);
             }
+            // #hb166 T-6(e): publish the committed queue_vtime on THIS
+            // CoSBatch settle boundary. The four direct-service settle
+            // sites in service.rs already publish; the CoSBatch submit path
+            // (surplus-phase shared_exact service) advanced queue_vtime
+            // during batch build but never broadcast it, so peers read a
+            // stale-low V_min slot and self-throttle exactly when surplus
+            // works hardest. No-op for non-flow-fair / non-shared queues
+            // (vtime_floor is None).
+            publish_committed_queue_vtime(
+                binding
+                    .cos
+                    .cos_interfaces
+                    .get(&root_ifindex)
+                    .and_then(|root| root.queues.get(queue_idx)),
+            );
             cos_batch_tx_made_progress(Ok((packets, bytes)))
         }
         Err(TxError::Retry(err)) => {

--- a/userspace-dp/src/afxdp/cos/queue_service/submit_prepared.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/submit_prepared.rs
@@ -108,6 +108,17 @@ pub(super) fn submit_prepared(
                     .drain_sent_bytes_shaped_unconditional
                     .fetch_add(bytes, Ordering::Relaxed);
             }
+            // #hb166 T-6(e): publish the committed queue_vtime on the
+            // Prepared CoSBatch settle boundary too — see the matching
+            // block + rationale in submit_local.rs. No-op for
+            // non-flow-fair / non-shared queues.
+            publish_committed_queue_vtime(
+                binding
+                    .cos
+                    .cos_interfaces
+                    .get(&root_ifindex)
+                    .and_then(|root| root.queues.get(queue_idx)),
+            );
             cos_batch_tx_made_progress(Ok((packets, bytes)))
         }
         Err(TxError::Retry(err)) => {

--- a/userspace-dp/src/afxdp/cos/queue_service/tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests.rs
@@ -85,6 +85,56 @@ fn nonexact_guarantee_skips_residual_only_scheduler_map_queue() {
     ));
 }
 
+// #hb166 T-6(b): the exact-demand mask that reserves best-effort surplus
+// must count only SERVICEABLE exact guarantee queues (can ship their head
+// right now), not merely non-empty ones. A v8-starved / token-parked exact
+// class that ships zero bytes must release its reserved rate to best-effort.
+//
+// FAIL-ON-REVERT: restoring the `!cos_queue_is_empty` predicate re-includes
+// the starved queue, flipping the `mask & 0b10 == 0` assertion.
+#[test]
+fn exact_demand_mask_excludes_starved_exact_queue() {
+    let queue = |queue_id: u8, fc: &str| CoSQueueConfig {
+        queue_id,
+        forwarding_class: fc.into(),
+        priority: 5,
+        transmit_rate_bytes: 1_000_000_000,
+        guarantee_enabled: true,
+        exact: true,
+        surplus_sharing: false,
+        equal_flow_enforcement: false,
+        equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+        surplus_weight: 1,
+        buffer_bytes: COS_MIN_BURST_BYTES,
+        dscp_rewrite: None,
+        codel_target_ns: 0,
+    };
+    let mut root = test_cos_runtime_with_queues(
+        25_000_000_000 / 8,
+        vec![queue(0, "iperf-a"), queue(1, "iperf-b")],
+    );
+    root.tokens = 100_000;
+    // Queue 0: serviceable — runnable, tokens cover the head, non-empty.
+    root.queues[0].hot.runnable = true;
+    root.queues[0].hot.tokens = 10_000;
+    root.queues[0].hot.items.push_back(test_cos_item(1500));
+    root.queues[0].hot.queued_bytes = 1500;
+    // Queue 1: v8-starved — runnable + non-empty, but NO per-queue tokens,
+    // so it cannot ship a byte this round.
+    root.queues[1].hot.runnable = true;
+    root.queues[1].hot.tokens = 0;
+    root.queues[1].hot.items.push_back(test_cos_item(1500));
+    root.queues[1].hot.queued_bytes = 1500;
+
+    let mask = root_exact_demand_queue_mask(&root);
+    assert_eq!(mask & 0b01, 0b01, "serviceable exact queue counts as demand");
+    assert_eq!(
+        mask & 0b10,
+        0,
+        "a token-starved (ships-zero) exact queue must NOT reserve BE surplus",
+    );
+}
+
 fn residual_and_exact_test_root(exact_surplus_sharing: bool) -> CoSInterfaceRuntime {
     let mut root = test_cos_runtime_with_queues(
         25_000_000_000 / 8,
@@ -2202,6 +2252,8 @@ fn restore_cos_local_items_marks_queue_runnable_after_retry() {
             v_min_suspended_remaining: 0,
             v_min_hard_cap_overrides_scratch: 0,
             v_min_throttles_scratch: 0,
+            v_min_suspended_batches_scratch: 0,
+            v_min_suspension_window: 0,
             v_min_pop_count: 0,
         },
         telemetry: crate::afxdp::types::CoSQueueTelemetry {
@@ -2273,6 +2325,8 @@ fn restore_cos_prepared_items_marks_queue_runnable_after_retry() {
             v_min_suspended_remaining: 0,
             v_min_hard_cap_overrides_scratch: 0,
             v_min_throttles_scratch: 0,
+            v_min_suspended_batches_scratch: 0,
+            v_min_suspension_window: 0,
             v_min_pop_count: 0,
         },
         telemetry: crate::afxdp::types::CoSQueueTelemetry {
@@ -3466,6 +3520,88 @@ fn sojourn_recorded_end_to_end_via_submit_local() {
     assert_eq!(
         queue.telemetry.sojourn, expected,
         "committed send through submit_local must sample exactly once",
+    );
+}
+
+// #hb166 T-6(e): the CoSBatch submit path (submit_local / submit_prepared)
+// is the 5th V_min settle boundary. Like the four direct-service settle
+// sites in service.rs, it must publish the committed queue_vtime so peers'
+// V_min reduction sees this worker's real progress. Without it a
+// surplus-phase shared_exact queue advances vtime unpublished and peers
+// self-throttle against a stale-low slot.
+//
+// FAIL-ON-REVERT: removing the `publish_committed_queue_vtime(...)` call
+// added to submit_local's Ok arm leaves the floor slot at None.
+#[test]
+fn submit_local_publishes_committed_vtime_on_settle() {
+    let now_ns = 1_000_000_000u64;
+    let mut root = test_cos_runtime_with_queues(
+        10_000_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 0,
+            forwarding_class: "iperf-c".into(),
+            priority: 5,
+            transmit_rate_bytes: 10_000_000_000 / 8,
+            guarantee_enabled: true,
+            exact: true,
+            surplus_sharing: true,
+            equal_flow_enforcement: false,
+            equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+            surplus_weight: 1,
+            buffer_bytes: COS_MIN_BURST_BYTES,
+            dscp_rewrite: None,
+            codel_target_ns: 0,
+        }],
+    );
+    root.tokens = 1500;
+    root.queues[0].hot.tokens = 1500;
+    // shared_exact flow-fair queue with a V_min floor for worker 0 of 2.
+    let floor = attach_test_vtime_floor(&mut root.queues[0], 2, 0);
+    // Pretend a drain has already advanced this queue's committed vtime.
+    test_flow_fair_state_mut(&mut root.queues[0]).queue_vtime = 54_321;
+
+    let fast_interfaces = test_cos_fast_interfaces(
+        42,
+        42,
+        0,
+        vec![(0, test_queue_fast_path(false, 0, None, None))],
+        None,
+        None,
+    );
+    let fast_path = fast_interfaces.get(&42).expect("test fast path").clone();
+    let mut binding = BindingWorker::new_for_cos_drain_test(0, 0, 42, root, fast_path);
+
+    assert_eq!(floor.slots[0].read(), None, "test premise: slot starts unpublished");
+
+    let items = VecDeque::from([TxRequest {
+        bytes: vec![0u8; 128],
+        expected_ports: None,
+        expected_addr_family: 0,
+        expected_protocol: 0,
+        flow_key: None,
+        egress_ifindex: 42,
+        cos_queue_id: Some(0),
+        dscp_rewrite: None,
+        mirror_clone: false,
+        enqueue_ns: now_ns,
+    }]);
+    let mut shared_recycles = Vec::new();
+
+    submit_local(
+        &mut binding,
+        42,
+        0,
+        CoSServicePhase::Surplus,
+        128,
+        items,
+        now_ns,
+        &mut shared_recycles,
+    );
+
+    assert_eq!(
+        floor.slots[0].read(),
+        Some(54_321),
+        "submit_local settle must publish the committed queue_vtime to the V_min floor slot",
     );
 }
 

--- a/userspace-dp/src/afxdp/cos/tx_completion.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion.rs
@@ -17,8 +17,8 @@ use crate::afxdp::types::{
 use crate::afxdp::worker::BindingWorker;
 
 use super::queue_ops::{
-    cos_item_len, cos_queue_front, cos_queue_is_empty, cos_queue_push_front,
-    maybe_demote_drained_best_effort,
+    cos_exact_queue_serviceable, cos_item_len, cos_queue_front, cos_queue_is_empty,
+    cos_queue_push_front, maybe_demote_drained_best_effort,
 };
 use super::token_bucket::{maybe_top_up_cos_root_lease, release_cos_root_lease};
 
@@ -490,25 +490,36 @@ fn exact_backlog_bytes(root: &CoSInterfaceRuntime) -> u64 {
 
 #[inline]
 fn serviceable_exact_backlog_bytes(root: &CoSInterfaceRuntime) -> u64 {
+    // #hb166 T-6(b): share the serviceability predicate with the demand
+    // masks (queue_ops::cos_exact_queue_serviceable) so the published
+    // serviceable-bytes signal and the demand mask agree byte-for-byte.
+    let root_tokens = root.tokens;
     root.queues
         .iter()
-        .filter(|queue| queue.config.exact && queue.config.guarantee_enabled && queue.hot.runnable)
-        .filter_map(|queue| {
-            let head = cos_queue_front(queue)?;
-            let head_len = cos_item_len(head);
-            (root.tokens >= head_len && queue.hot.tokens >= head_len)
-                .then_some(queue.hot.queued_bytes)
+        .filter(|queue| {
+            queue.config.exact
+                && queue.config.guarantee_enabled
+                && cos_exact_queue_serviceable(root_tokens, queue)
         })
-        .fold(0u64, |acc, bytes| acc.saturating_add(bytes))
+        .fold(0u64, |acc, queue| acc.saturating_add(queue.hot.queued_bytes))
 }
 
 #[inline]
 fn exact_backlog_queue_mask(root: &CoSInterfaceRuntime) -> u64 {
+    // #hb166 T-6(b): the published exact-demand MASK (read by peer workers
+    // as `peer_exact_demand_queue_mask` for their BE-surplus reservation)
+    // must also reflect serviceability, not just non-emptiness — otherwise
+    // a peer over-reserves for this node's starved/parked exact class and
+    // starves best-effort while the link idles. Same predicate as
+    // `serviceable_exact_backlog_bytes` / `root_exact_demand_queue_mask`.
+    let root_tokens = root.tokens;
     root.queues
         .iter()
         .enumerate()
         .filter(|(_, queue)| {
-            queue.config.exact && queue.config.guarantee_enabled && !cos_queue_is_empty(queue)
+            queue.config.exact
+                && queue.config.guarantee_enabled
+                && cos_exact_queue_serviceable(root_tokens, queue)
         })
         .fold(0u64, |acc, (queue_idx, _)| {
             if queue_idx < u64::BITS as usize {

--- a/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
@@ -550,6 +550,8 @@ fn normalize_cos_queue_state_repairs_nonempty_unparked_queue_to_runnable() {
             v_min_suspended_remaining: 0,
             v_min_hard_cap_overrides_scratch: 0,
             v_min_throttles_scratch: 0,
+            v_min_suspended_batches_scratch: 0,
+            v_min_suspension_window: 0,
             v_min_pop_count: 0,
         },
         telemetry: crate::afxdp::types::CoSQueueTelemetry {

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -106,15 +106,32 @@ pub(in crate::afxdp) fn resolve_cached_cos_tx_selection(
 ) -> CachedTxSelectionDescriptor {
     let iface = forwarding.cos.interfaces.get(&egress_ifindex);
     let Some(flow_key) = flow_key else {
+        // #hb166 T-6(m): fragments / flowless packets carry no 5-tuple but
+        // still carry a DSCP (and 802.1p PCP). Behavior-aggregate
+        // classification is 5-tuple-independent — resolve it from `meta` so
+        // an EF fragment lands in its BA queue instead of straddling the
+        // default queue. Filter forwarding-class / rewrite needs the flow
+        // key, so those stay unset (as before).
         return CachedTxSelectionDescriptor {
-            queue_id: iface.map(|iface| iface.default_queue),
+            queue_id: iface.map(|iface| {
+                resolve_cos_dscp_classifier_queue_id(iface, meta.dscp)
+                    .or_else(|| {
+                        resolve_cos_ieee8021_classifier_queue_id(
+                            iface,
+                            meta.ingress_pcp,
+                            meta.ingress_vlan_present != 0,
+                        )
+                    })
+                    .unwrap_or(iface.default_queue)
+            }),
             dscp_rewrite: None,
             drop: false,
             reject: false,
             filter_counters: crate::filter::CachedFilterCounters::default(),
             three_color_policers: crate::filter::CachedThreeColorPolicers::default(),
             filter_log: None,
-            // No flow key => default-queue only; nothing to re-classify.
+            // Flowless packets are re-resolved per packet (no cache entry),
+            // so there is nothing to mark for hit-path re-classification.
             ba_reclassify: false,
         };
     };
@@ -384,8 +401,22 @@ fn resolve_cos_tx_selection_internal(
     }
     let iface = forwarding.cos.interfaces.get(&egress_ifindex);
     let Some(flow_key) = flow_key else {
+        // #hb166 T-6(m): flowless / fragment classification — run the
+        // 5-tuple-independent behavior-aggregate (DSCP / 802.1p) lookup from
+        // `meta` so a marked fragment lands in its BA queue rather than the
+        // default queue. Mirrors the cached-path None branch.
         return CoSTxSelection {
-            queue_id: iface.map(|iface| iface.default_queue),
+            queue_id: iface.map(|iface| {
+                resolve_cos_dscp_classifier_queue_id(iface, meta.dscp)
+                    .or_else(|| {
+                        resolve_cos_ieee8021_classifier_queue_id(
+                            iface,
+                            meta.ingress_pcp,
+                            meta.ingress_vlan_present != 0,
+                        )
+                    })
+                    .unwrap_or(iface.default_queue)
+            }),
             dscp_rewrite: None,
             drop: false,
             reject: false,
@@ -1063,7 +1094,7 @@ fn enqueue_cos_item(
     }
     let mut root_became_nonempty = false;
     let mut accepted_exact = false;
-    let (accepted, queue_id, recycle) = {
+    let (accepted, _queue_id, recycle) = {
         // Split-borrow: `umem` sits alongside `cos_interfaces` on
         // `BindingWorker`, so we can take a shared borrow on the umem
         // field while holding `&mut binding.cos.cos_interfaces` for the
@@ -1204,11 +1235,15 @@ fn enqueue_cos_item(
     // separate counters so operators can disambiguate CoS shaping
     // pressure from bound-pending pressure.
     binding.telemetry.dbg_cos_queue_overflow += 1;
-    binding.live.tx_errors.fetch_add(1, Ordering::Relaxed);
-    binding.live.set_error(format!(
-        "class-of-service queue overflow on ifindex {} queue {}",
-        egress_ifindex, queue_id
-    ));
+    // #hb166 T-6(g): a CoS admission drop is DESIGNED shaping, not a TX
+    // error. It is already attributed above to the dedicated per-reason
+    // `admission_flow_share_drops` / `admission_buffer_drops` counters, so
+    // do NOT also inflate the aggregate `tx_errors` (an operator reads a
+    // saturated shaper as a fault) and do NOT allocate a per-drop
+    // `set_error(format!())` String: under a sustained shaping-drop storm
+    // this classify path runs once per excess packet (~1M allocs/sec), a
+    // hot-path-allocation-rule violation (CLAUDE.md). `dbg_cos_queue_overflow`
+    // (plain, non-allocating) keeps the #804 disambiguation signal.
     Ok(())
 }
 

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -110,6 +110,81 @@ fn enqueue_exact_queue_publishes_shared_backlog_slot() {
     );
 }
 
+// #hb166 T-6(g): a CoS admission drop (buffer / flow-share exceeded) is
+// DESIGNED shaping. It is attributed to the dedicated per-reason
+// `admission_buffer_drops` / `admission_flow_share_drops` counters and must
+// NOT also inflate the aggregate `tx_errors` (an operator reads a saturated
+// shaper as a fault) nor allocate a per-drop `set_error(format!())` String.
+//
+// FAIL-ON-REVERT: restoring the `tx_errors.fetch_add(1)` on the CoS
+// admission-overflow path flips the `tx_errors == 0` assertion.
+#[test]
+fn cos_admission_drop_counts_dedicated_counter_not_tx_errors() {
+    // FIFO (non-flow-fair) queue with a small buffer so accumulated
+    // queued bytes exceed the buffer limit without any drain.
+    let root = test_cos_runtime_with_queues(
+        10_000_000,
+        vec![CoSQueueConfig {
+            queue_id: 0,
+            forwarding_class: "best-effort".into(),
+            priority: 5,
+            transmit_rate_bytes: 10_000_000,
+            guarantee_enabled: false,
+            exact: false,
+            surplus_sharing: false,
+            equal_flow_enforcement: false,
+            equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+            surplus_weight: 1,
+            buffer_bytes: COS_MIN_BURST_BYTES,
+            dscp_rewrite: None,
+            codel_target_ns: 0,
+        }],
+    );
+    let fast_interfaces = test_cos_fast_interfaces(
+        42,
+        42,
+        0,
+        vec![(0, test_queue_fast_path(false, 0, None, None))],
+        None,
+        None,
+    );
+    let fast_path = fast_interfaces.get(&42).expect("test fast path").clone();
+    let mut binding = BindingWorker::new_for_cos_drain_test(0, 0, 42, root, fast_path);
+
+    // Push 1500-byte items without draining until the buffer limit trips.
+    // 400 * 1500 = 600 KB dwarfs any COS_MIN_BURST_BYTES-derived limit.
+    for _ in 0..400 {
+        let _ = enqueue_cos_item(
+            &mut binding,
+            42,
+            Some(0),
+            1500,
+            test_flow_cos_item(5201, 1500),
+            0,
+            None,
+        );
+    }
+
+    let buffer_drops = binding
+        .cos
+        .cos_interfaces
+        .get(&42)
+        .and_then(|root| root.queues.first())
+        .map(|q| q.telemetry.drop_counters.admission_buffer_drops)
+        .expect("queue present");
+    assert!(
+        buffer_drops > 0,
+        "test premise: the buffer cap must trip at least one admission drop",
+    );
+    assert_eq!(
+        binding.live.tx_errors.load(Ordering::Relaxed),
+        0,
+        "a designed CoS admission (shaping) drop must NOT inflate tx_errors",
+    );
+    // The #804 disambiguation debug counter still records the overflow.
+    assert!(binding.telemetry.dbg_cos_queue_overflow > 0);
+}
+
 #[test]
 fn clone_prepared_request_for_cos_returns_local_copy_with_metadata() {
     let mut area = MmapArea::new(4096).expect("mmap");
@@ -764,6 +839,125 @@ fn resolve_cos_queue_id_prefers_egress_output_filter_forwarding_class() {
     );
 
     assert_eq!(queue_id, Some(1));
+}
+
+// #hb166 T-6(m): fragments / flowless packets (flow_key == None) still carry
+// a DSCP. Behavior-aggregate (DSCP) classification is 5-tuple-independent, so
+// a marked fragment must land in its BA queue rather than the default queue.
+//
+// FAIL-ON-REVERT: restoring the `queue_id: iface.map(|i| i.default_queue)`
+// None-branch (in BOTH resolve_cos_tx_selection_internal and
+// resolve_cached_cos_tx_selection) flips the dscp==46 assertions from
+// Some(1) back to Some(0).
+#[test]
+fn flowless_packet_gets_ba_classification_from_dscp() {
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: 202,
+            hardware_addr: "02:bf:72:00:80:08".into(),
+            cos_shaping_rate_bytes_per_sec: 10_000_000,
+            cos_shaping_burst_bytes: 256_000,
+            cos_scheduler_map: "wan-map".into(),
+            cos_dscp_classifier: "ba".into(),
+            ..Default::default()
+        }],
+        class_of_service: Some(ClassOfServiceSnapshot {
+            forwarding_classes: vec![
+                CoSForwardingClassSnapshot {
+                    name: "best-effort".into(),
+                    queue: 0,
+                },
+                CoSForwardingClassSnapshot {
+                    name: "expedited-forwarding".into(),
+                    queue: 1,
+                },
+            ],
+            dscp_classifiers: vec![CoSDSCPClassifierSnapshot {
+                name: "ba".into(),
+                entries: vec![CoSDSCPClassifierEntrySnapshot {
+                    forwarding_class: "expedited-forwarding".into(),
+                    loss_priority: String::new(),
+                    dscp_values: vec![46],
+                }],
+            }],
+            ieee8021_classifiers: vec![],
+            dscp_rewrite_rules: vec![],
+            schedulers: vec![
+                CoSSchedulerSnapshot {
+                    name: "be-sched".into(),
+                    transmit_rate_bytes: 4_000_000,
+                    transmit_rate_exact: false,
+                    priority: "low".into(),
+                    buffer_size_bytes: 128_000,
+                    buffer_size_percent: 0.0,
+                    surplus_sharing: false,
+                    equal_flow_enforcement: false,
+                    equal_flow_target_policy: String::new(),
+                    codel_target_ns: 0,
+                },
+                CoSSchedulerSnapshot {
+                    name: "ef-sched".into(),
+                    transmit_rate_bytes: 6_000_000,
+                    transmit_rate_exact: false,
+                    priority: "strict-high".into(),
+                    buffer_size_bytes: 64_000,
+                    buffer_size_percent: 0.0,
+                    surplus_sharing: false,
+                    equal_flow_enforcement: false,
+                    equal_flow_target_policy: String::new(),
+                    codel_target_ns: 0,
+                },
+            ],
+            scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                name: "wan-map".into(),
+                entries: vec![
+                    CoSSchedulerMapEntrySnapshot {
+                        forwarding_class: "best-effort".into(),
+                        scheduler: "be-sched".into(),
+                    },
+                    CoSSchedulerMapEntrySnapshot {
+                        forwarding_class: "expedited-forwarding".into(),
+                        scheduler: "ef-sched".into(),
+                    },
+                ],
+            }],
+        }),
+        ..Default::default()
+    };
+    let forwarding = build_forwarding_state(&snapshot);
+
+    let ef_meta = UserspaceDpMeta {
+        ingress_ifindex: 5,
+        addr_family: libc::AF_INET as u8,
+        dscp: 46,
+        ..Default::default()
+    };
+    let be_meta = UserspaceDpMeta {
+        ingress_ifindex: 5,
+        addr_family: libc::AF_INET as u8,
+        dscp: 0,
+        ..Default::default()
+    };
+
+    // Non-cached path (resolve_cos_tx_selection_internal via resolve_cos_queue_id).
+    assert_eq!(
+        resolve_cos_queue_id(&forwarding, 202, ef_meta, None),
+        Some(1),
+        "EF-marked flowless packet must hit the BA (EF) queue, not the default",
+    );
+    assert_eq!(
+        resolve_cos_queue_id(&forwarding, 202, be_meta, None),
+        Some(0),
+        "an unmarked flowless packet falls back to the default queue",
+    );
+
+    // Cached-descriptor path.
+    assert_eq!(
+        resolve_cached_cos_tx_selection(&forwarding, 202, ef_meta, None).queue_id,
+        Some(1),
+        "cached flowless BA classification must also hit the EF queue",
+    );
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/tx/drain/mod.rs
+++ b/userspace-dp/src/afxdp/tx/drain/mod.rs
@@ -43,10 +43,12 @@ pub(in crate::afxdp) fn bound_pending_tx_local(binding: &mut BindingWorker) {
                 .live
                 .pending_tx_local_overflow_drops
                 .fetch_add(1, Ordering::Relaxed);
-            binding.live.set_error(format!(
-                "pending TX local overflow on slot {}",
-                binding.slot
-            ));
+            // #hb166 T-6(g): no per-drop `set_error(format!())` here — this
+            // is a `while overflow` loop, so the String alloc fired once per
+            // evicted packet under backpressure (hot-path-allocation-rule
+            // violation, CLAUDE.md). The dedicated
+            // `pending_tx_local_overflow_drops` counter above (a subset of
+            // `tx_errors`) already attributes the drop without allocating.
         }
     }
 }
@@ -74,10 +76,8 @@ pub(in crate::afxdp) fn bound_pending_tx_prepared(
                 .live
                 .pending_tx_local_overflow_drops
                 .fetch_add(1, Ordering::Relaxed);
-            binding.live.set_error(format!(
-                "pending TX prepared overflow on slot {}",
-                binding.slot
-            ));
+            // #hb166 T-6(g): no per-drop `set_error(format!())` — same
+            // hot-path String alloc removal as the local overflow loop above.
         }
     }
 }

--- a/userspace-dp/src/afxdp/tx/transmit/mod.rs
+++ b/userspace-dp/src/afxdp/tx/transmit/mod.rs
@@ -111,8 +111,13 @@ pub(in crate::afxdp) fn transmit_batch(
             let _ = apply_dscp_rewrite_to_frame(&mut req.bytes, dscp_rewrite);
         }
         if req.bytes.len() > tx_frame_capacity() {
-            // Unwind already-prepared entries before returning.
-            for (off, r) in binding.scratch.scratch_local_tx.drain(..) {
+            // #hb166 T-6(d): unwind already-prepared entries before
+            // returning. Drain in REVERSE so the successive push_front
+            // calls restore the ORIGINAL front-to-back order at the head of
+            // `pending`; a forward drain reverses the staged prefix and
+            // reorders same-flow (e.g. in-order TCP) segments on this error
+            // path. free_tx_frames are fungible, so their order is moot.
+            for (off, r) in binding.scratch.scratch_local_tx.drain(..).rev() {
                 binding.tx_pipeline.free_tx_frames.push_back(off);
                 pending.push_front(r);
             }
@@ -133,8 +138,10 @@ pub(in crate::afxdp) fn transmit_batch(
                 .slice_mut_unchecked(offset as usize, req.bytes.len())
         }) else {
             binding.tx_pipeline.free_tx_frames.push_front(offset);
-            // Unwind already-prepared entries before returning.
-            for (off, r) in binding.scratch.scratch_local_tx.drain(..) {
+            // #hb166 T-6(d): reverse-drain unwind (see the capacity-drop
+            // site above) so the staged prefix keeps its original order at
+            // the head of `pending`.
+            for (off, r) in binding.scratch.scratch_local_tx.drain(..).rev() {
                 binding.tx_pipeline.free_tx_frames.push_back(off);
                 pending.push_front(r);
             }

--- a/userspace-dp/src/afxdp/tx/transmit_tests.rs
+++ b/userspace-dp/src/afxdp/tx/transmit_tests.rs
@@ -122,3 +122,65 @@ fn cancelled_prepared_local_fill_stays_on_pending_fill() {
     assert_eq!(pending_fill_frames, VecDeque::from([42]));
     assert!(shared_recycles.is_empty());
 }
+
+// #hb166 T-6(d): when `transmit_batch` hits an oversized frame mid-batch it
+// unwinds the already-staged prefix back onto the head of `pending`. The
+// unwind MUST preserve the original front-to-back order so same-flow (in-
+// order TCP) segments are not reordered on the error path.
+//
+// FAIL-ON-REVERT: dropping the `.rev()` from the unwind drain reverses the
+// restored prefix, flipping the recovered enqueue_ns order from [1, 2, 4]
+// to [2, 1, 4].
+#[test]
+fn transmit_batch_oversized_unwind_preserves_pending_order() {
+    use crate::afxdp::tx::test_support::{
+        test_cos_fast_interfaces, test_cos_runtime_with_queues, test_queue_fast_path,
+    };
+    use crate::afxdp::types::TxRequest;
+
+    let mk = |len: usize, id: u64| TxRequest {
+        bytes: vec![0u8; len],
+        expected_ports: None,
+        expected_addr_family: 0,
+        expected_protocol: 0,
+        flow_key: None,
+        egress_ifindex: 42,
+        cos_queue_id: None,
+        dscp_rewrite: None,
+        mirror_clone: false,
+        // enqueue_ns doubles as an identity marker for order assertions.
+        enqueue_ns: id,
+    };
+
+    let root = test_cos_runtime_with_queues(10_000_000, vec![]);
+    let fast_interfaces = test_cos_fast_interfaces(
+        42,
+        42,
+        0,
+        vec![(0, test_queue_fast_path(false, 0, None, None))],
+        None,
+        None,
+    );
+    let fast_path = fast_interfaces.get(&42).expect("test fast path").clone();
+    let mut binding = BindingWorker::new_for_cos_drain_test(0, 0, 42, root, fast_path);
+
+    // A(128), B(128) stage; the oversized item (> tx_frame_capacity()) trips
+    // the Drop-unwind; D(128) is never reached (loop returns on the Err).
+    let mut pending = VecDeque::from([
+        mk(128, 1),
+        mk(128, 2),
+        mk(tx_frame_capacity() + 1, 3),
+        mk(128, 4),
+    ]);
+    let mut shared_recycles = Vec::new();
+
+    let result = transmit_batch(&mut binding, &mut pending, 0, &mut shared_recycles);
+    assert!(matches!(result, Err(TxError::Drop(_))));
+
+    let order: Vec<u64> = pending.iter().map(|r| r.enqueue_ns).collect();
+    assert_eq!(
+        order,
+        vec![1, 2, 4],
+        "oversized-unwind must keep the staged prefix in original order (A before B)",
+    );
+}

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -1195,6 +1195,23 @@ pub(in crate::afxdp) struct VMinQueueState {
     /// (working-as-designed fairness brake) and the hard-cap
     /// override path (escape hatch when the brake is too tight).
     pub(in crate::afxdp) v_min_throttles_scratch: u32,
+    /// #hb166 T-6(a): per-queue scratch counter for V_min *suspended*
+    /// drain batches — every batch where `cos_queue_v_min_consume_suspension`
+    /// burned a suspension slot (the fairness brake was OFF because a
+    /// prior hard-cap armed suspension). Pre-fix these were UNCOUNTED, so
+    /// telemetry read "brake idle" while it was suppressed. Flushed to
+    /// `BindingLiveState::v_min_suspended_batches` in
+    /// `update_binding_debug_state` alongside the throttle/hard-cap
+    /// counters. `v_min_suspended_batches / v_min_throttle_hard_cap_overrides`
+    /// is the "how long is the brake staying off per activation" diagnostic.
+    pub(in crate::afxdp) v_min_suspended_batches_scratch: u32,
+    /// #hb166 T-6(a): current decaying re-arm window for the V_min
+    /// suspension. Initialized to `V_MIN_SUSPENSION_BATCHES`; each
+    /// consecutive hard-cap activation (no intervening passing V_min
+    /// check) halves it toward `V_MIN_SUSPENSION_MIN_BATCHES`, and a
+    /// clean V_min check resets it to `V_MIN_SUSPENSION_BATCHES`. This
+    /// makes a persistently-skewed queue re-engage the brake sooner.
+    pub(in crate::afxdp) v_min_suspension_window: u32,
     /// #2624: persistent V_min cadence pop counter. The cross-worker
     /// V_min sync (`cos_queue_v_min_continue` → the expensive
     /// `participating_v_min_snapshot` Acquire-load scan of every peer

--- a/userspace-dp/src/afxdp/umem/debug_state.rs
+++ b/userspace-dp/src/afxdp/umem/debug_state.rs
@@ -271,13 +271,13 @@ fn publish_binding_debug_state(binding: &mut BindingWorker) {
             })
             .collect(),
     );
-    // #941 Work item D + #943: flush each queue's per-queue scratch
-    // counters (hard-cap overrides AND regular V_min throttles) into
-    // the binding-wide AtomicU64s. Mirrors the
-    // flow_cache_collision_evictions pattern. Single-writer (worker
-    // thread) on both ends, so no atomicity issue. The body is in
-    // `flush_v_min_scratches_into` so it's directly unit-testable
-    // without needing to construct a full `BindingWorker`.
+    // #941 Work item D + #943 + #hb166 T-6(a): flush each queue's
+    // per-queue scratch counters (hard-cap overrides, regular V_min
+    // throttles, AND suspended-batch count) into the binding-wide
+    // AtomicU64s. Mirrors the flow_cache_collision_evictions pattern.
+    // Single-writer (worker thread) on both ends, so no atomicity issue.
+    // The body is in `flush_v_min_scratches_into` so it's directly
+    // unit-testable without needing to construct a full `BindingWorker`.
     flush_v_min_scratches_into(
         binding.cos.cos_interfaces.values_mut(),
         &binding.live.v_min_throttle_hard_cap_overrides,
@@ -287,11 +287,12 @@ fn publish_binding_debug_state(binding: &mut BindingWorker) {
 }
 
 /// Flush each queue's per-queue V_min scratch counters
-/// (`v_min_hard_cap_overrides_scratch` + `v_min_throttles_scratch`)
-/// into the binding-wide `AtomicU64`s and zero the scratches. Single
-/// pass over `roots`, single-writer discipline. Extracted from
-/// `update_binding_debug_state` so the flush is testable without
-/// constructing a `BindingWorker` (which has ~40 fields).
+/// (`v_min_hard_cap_overrides_scratch` + `v_min_throttles_scratch` +
+/// `v_min_suspended_batches_scratch`) into the binding-wide `AtomicU64`s
+/// and zero the scratches. Single pass over `roots`, single-writer
+/// discipline. Extracted from `update_binding_debug_state` so the flush
+/// is testable without constructing a `BindingWorker` (which has ~40
+/// fields).
 pub(in crate::afxdp) fn flush_v_min_scratches_into<'a, I>(
     roots: I,
     hard_cap_target: &AtomicU64,

--- a/userspace-dp/src/afxdp/umem/debug_state.rs
+++ b/userspace-dp/src/afxdp/umem/debug_state.rs
@@ -282,6 +282,7 @@ fn publish_binding_debug_state(binding: &mut BindingWorker) {
         binding.cos.cos_interfaces.values_mut(),
         &binding.live.v_min_throttle_hard_cap_overrides,
         &binding.live.v_min_throttles,
+        &binding.live.v_min_suspended_batches,
     );
 }
 
@@ -295,11 +296,13 @@ pub(in crate::afxdp) fn flush_v_min_scratches_into<'a, I>(
     roots: I,
     hard_cap_target: &AtomicU64,
     throttles_target: &AtomicU64,
+    suspended_batches_target: &AtomicU64,
 ) where
     I: IntoIterator<Item = &'a mut crate::afxdp::types::CoSInterfaceRuntime>,
 {
     let mut hard_cap_overrides_total = 0u64;
     let mut throttles_total = 0u64;
+    let mut suspended_batches_total = 0u64;
     for root in roots {
         for queue in &mut root.queues {
             if queue.v_min.v_min_hard_cap_overrides_scratch != 0 {
@@ -312,6 +315,12 @@ pub(in crate::afxdp) fn flush_v_min_scratches_into<'a, I>(
                     throttles_total.saturating_add(u64::from(queue.v_min.v_min_throttles_scratch));
                 queue.v_min.v_min_throttles_scratch = 0;
             }
+            // #hb166 T-6(a): flush the suspended-batch scratch too.
+            if queue.v_min.v_min_suspended_batches_scratch != 0 {
+                suspended_batches_total = suspended_batches_total
+                    .saturating_add(u64::from(queue.v_min.v_min_suspended_batches_scratch));
+                queue.v_min.v_min_suspended_batches_scratch = 0;
+            }
         }
     }
     if hard_cap_overrides_total != 0 {
@@ -319,5 +328,8 @@ pub(in crate::afxdp) fn flush_v_min_scratches_into<'a, I>(
     }
     if throttles_total != 0 {
         throttles_target.fetch_add(throttles_total, Ordering::Relaxed);
+    }
+    if suspended_batches_total != 0 {
+        suspended_batches_target.fetch_add(suspended_batches_total, Ordering::Relaxed);
     }
 }

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -342,6 +342,14 @@ pub(in crate::afxdp) struct BindingLiveState {
     /// Flushed from each queue's `v_min_throttles_scratch` in
     /// `update_binding_debug_state` (mirrors flow_cache_collision_evictions).
     pub(super) v_min_throttles: AtomicU64,
+    /// #hb166 T-6(a): count of V_min *suspended* drain batches — batches
+    /// where the fairness brake was OFF because a prior hard-cap armed
+    /// suspension. Flushed from each queue's
+    /// `v_min_suspended_batches_scratch` in `update_binding_debug_state`.
+    /// `v_min_suspended_batches / v_min_throttle_hard_cap_overrides` is
+    /// the effective suspension-window-length diagnostic; a large ratio
+    /// means the brake spends most of its time suppressed.
+    pub(super) v_min_suspended_batches: AtomicU64,
     pub(super) session_hits: AtomicU64,
     pub(super) session_misses: AtomicU64,
     pub(super) session_creates: AtomicU64,
@@ -809,6 +817,7 @@ impl BindingLiveState {
             cos_active_flow_counts: ArcSwap::from_pointee(Vec::new()),
             v_min_throttle_hard_cap_overrides: AtomicU64::new(0),
             v_min_throttles: AtomicU64::new(0),
+            v_min_suspended_batches: AtomicU64::new(0),
             session_hits: AtomicU64::new(0),
             session_misses: AtomicU64::new(0),
             session_creates: AtomicU64::new(0),

--- a/userspace-dp/src/afxdp/umem/snapshot.rs
+++ b/userspace-dp/src/afxdp/umem/snapshot.rs
@@ -70,6 +70,7 @@ impl BindingLiveState {
                 .v_min_throttle_hard_cap_overrides
                 .load(Ordering::Relaxed),
             v_min_throttles: self.v_min_throttles.load(Ordering::Relaxed),
+            v_min_suspended_batches: self.v_min_suspended_batches.load(Ordering::Relaxed),
             session_hits: self.session_hits.load(Ordering::Relaxed),
             session_misses: self.session_misses.load(Ordering::Relaxed),
             session_creates: self.session_creates.load(Ordering::Relaxed),

--- a/userspace-dp/src/afxdp/umem/tests.rs
+++ b/userspace-dp/src/afxdp/umem/tests.rs
@@ -1389,15 +1389,24 @@ fn flush_v_min_scratches_sums_and_zeros_per_queue_counters() {
     // Manually populate scratches as if v_min check fired.
     runtime.queues[0].v_min.v_min_hard_cap_overrides_scratch = 3;
     runtime.queues[0].v_min.v_min_throttles_scratch = 17;
+    // #hb166 T-6(a): suspended-batch scratch flushes alongside.
+    runtime.queues[0].v_min.v_min_suspended_batches_scratch = 100;
     runtime.queues[1].v_min.v_min_hard_cap_overrides_scratch = 5;
     runtime.queues[1].v_min.v_min_throttles_scratch = 23;
+    runtime.queues[1].v_min.v_min_suspended_batches_scratch = 200;
 
     let hard_cap = std::sync::atomic::AtomicU64::new(0);
     let throttles = std::sync::atomic::AtomicU64::new(0);
+    let suspended = std::sync::atomic::AtomicU64::new(0);
     let mut interfaces = std::collections::BTreeMap::new();
     interfaces.insert(1, runtime);
 
-    crate::afxdp::umem::flush_v_min_scratches_into(interfaces.values_mut(), &hard_cap, &throttles);
+    crate::afxdp::umem::flush_v_min_scratches_into(
+        interfaces.values_mut(),
+        &hard_cap,
+        &throttles,
+        &suspended,
+    );
 
     // Atomics carry the sums.
     assert_eq!(
@@ -1410,13 +1419,22 @@ fn flush_v_min_scratches_sums_and_zeros_per_queue_counters() {
         17 + 23,
         "throttles atomic must equal sum across queues",
     );
+    // FAIL-ON-REVERT for T-6(a): the suspended-batch atomic must equal
+    // the sum of the per-queue scratches.
+    assert_eq!(
+        suspended.load(std::sync::atomic::Ordering::Relaxed),
+        100 + 200,
+        "suspended-batches atomic must equal sum across queues",
+    );
 
     // Per-queue scratches reset to 0.
     let r = interfaces.get(&1).unwrap();
     assert_eq!(r.queues[0].v_min.v_min_hard_cap_overrides_scratch, 0);
     assert_eq!(r.queues[0].v_min.v_min_throttles_scratch, 0);
+    assert_eq!(r.queues[0].v_min.v_min_suspended_batches_scratch, 0);
     assert_eq!(r.queues[1].v_min.v_min_hard_cap_overrides_scratch, 0);
     assert_eq!(r.queues[1].v_min.v_min_throttles_scratch, 0);
+    assert_eq!(r.queues[1].v_min.v_min_suspended_batches_scratch, 0);
 }
 
 /// #943: a second flush call with all scratches zero must NOT bump
@@ -1460,14 +1478,21 @@ fn flush_v_min_scratches_no_op_when_all_zero() {
     // doesn't accidentally store-zero.
     let hard_cap = std::sync::atomic::AtomicU64::new(42);
     let throttles = std::sync::atomic::AtomicU64::new(99);
+    let suspended = std::sync::atomic::AtomicU64::new(7);
     let mut interfaces = std::collections::BTreeMap::new();
     interfaces.insert(1, runtime);
 
-    crate::afxdp::umem::flush_v_min_scratches_into(interfaces.values_mut(), &hard_cap, &throttles);
+    crate::afxdp::umem::flush_v_min_scratches_into(
+        interfaces.values_mut(),
+        &hard_cap,
+        &throttles,
+        &suspended,
+    );
 
     // Atomics unchanged — the no-zero-scratch path skips the fetch_add.
     assert_eq!(hard_cap.load(std::sync::atomic::Ordering::Relaxed), 42);
     assert_eq!(throttles.load(std::sync::atomic::Ordering::Relaxed), 99);
+    assert_eq!(suspended.load(std::sync::atomic::Ordering::Relaxed), 7);
 }
 
 fn debug_state_test_timers() -> WorkerTimers {

--- a/userspace-dp/src/afxdp/worker/cos/tests.rs
+++ b/userspace-dp/src/afxdp/worker/cos/tests.rs
@@ -242,6 +242,8 @@ fn build_worker_cos_statuses_aggregates_runtime_by_interface_and_queue() {
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_suspended_batches_scratch: 0,
+                    v_min_suspension_window: 0,
                     v_min_pop_count: 0,
                 },
                 telemetry: crate::afxdp::types::CoSQueueTelemetry {
@@ -421,6 +423,8 @@ fn build_worker_cos_statuses_sums_owner_profile_without_breaking_hist_invariant(
                 v_min_suspended_remaining: 0,
                 v_min_hard_cap_overrides_scratch: 0,
                 v_min_throttles_scratch: 0,
+                v_min_suspended_batches_scratch: 0,
+                v_min_suspension_window: 0,
                 v_min_pop_count: 0,
             },
             telemetry: crate::afxdp::types::CoSQueueTelemetry {
@@ -665,6 +669,8 @@ fn build_worker_cos_statuses_owner_profile_only_surfaces_on_unambiguous_owner_lo
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_suspended_batches_scratch: 0,
+                    v_min_suspension_window: 0,
                     v_min_pop_count: 0,
                 },
                 telemetry: crate::afxdp::types::CoSQueueTelemetry {
@@ -713,6 +719,8 @@ fn build_worker_cos_statuses_owner_profile_only_surfaces_on_unambiguous_owner_lo
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_suspended_batches_scratch: 0,
+                    v_min_suspension_window: 0,
                     v_min_pop_count: 0,
                 },
                 telemetry: crate::afxdp::types::CoSQueueTelemetry {
@@ -761,6 +769,8 @@ fn build_worker_cos_statuses_owner_profile_only_surfaces_on_unambiguous_owner_lo
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_suspended_batches_scratch: 0,
+                    v_min_suspension_window: 0,
                     v_min_pop_count: 0,
                 },
                 telemetry: crate::afxdp::types::CoSQueueTelemetry {
@@ -963,6 +973,8 @@ fn build_worker_cos_statuses_owner_profile_stays_zero_for_ambiguous_multi_exact_
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_suspended_batches_scratch: 0,
+                    v_min_suspension_window: 0,
                     v_min_pop_count: 0,
                 },
                 telemetry: crate::afxdp::types::CoSQueueTelemetry {
@@ -1011,6 +1023,8 @@ fn build_worker_cos_statuses_owner_profile_stays_zero_for_ambiguous_multi_exact_
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_suspended_batches_scratch: 0,
+                    v_min_suspension_window: 0,
                     v_min_pop_count: 0,
                 },
                 telemetry: crate::afxdp::types::CoSQueueTelemetry {
@@ -1172,6 +1186,8 @@ fn build_worker_cos_statuses_owner_profile_stays_zero_for_ambiguous_multi_interf
                 v_min_suspended_remaining: 0,
                 v_min_hard_cap_overrides_scratch: 0,
                 v_min_throttles_scratch: 0,
+                v_min_suspended_batches_scratch: 0,
+                v_min_suspension_window: 0,
                 v_min_pop_count: 0,
             },
             telemetry: crate::afxdp::types::CoSQueueTelemetry {
@@ -1383,6 +1399,8 @@ fn build_worker_cos_statuses_surfaces_distinct_per_queue_drain_telemetry() {
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_suspended_batches_scratch: 0,
+                    v_min_suspension_window: 0,
                     v_min_pop_count: 0,
                 },
                 telemetry: crate::afxdp::types::CoSQueueTelemetry {
@@ -1431,6 +1449,8 @@ fn build_worker_cos_statuses_surfaces_distinct_per_queue_drain_telemetry() {
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_suspended_batches_scratch: 0,
+                    v_min_suspension_window: 0,
                     v_min_pop_count: 0,
                 },
                 telemetry: crate::afxdp::types::CoSQueueTelemetry {
@@ -2481,6 +2501,8 @@ fn active_flow_buckets_peak_is_max_not_sum_across_workers() {
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_suspended_batches_scratch: 0,
+                    v_min_suspension_window: 0,
                     v_min_pop_count: 0,
                 },
                 telemetry: crate::afxdp::types::CoSQueueTelemetry {

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -1338,6 +1338,8 @@ pub(crate) struct BindingLiveSnapshot {
     /// so operators can tell the fairness brake is engaged from the
     /// escape-hatch firing.
     pub(crate) v_min_throttles: u64,
+    /// #hb166 T-6(a): V_min suspended-batch count on this binding.
+    pub(crate) v_min_suspended_batches: u64,
     pub(crate) session_hits: u64,
     pub(crate) session_misses: u64,
     pub(crate) session_creates: u64,

--- a/userspace-dp/src/main_tests.rs
+++ b/userspace-dp/src/main_tests.rs
@@ -1643,6 +1643,7 @@ fn binding_counters_snapshot_serializes_with_expected_wire_keys() {
         flow_cache_capacity: 4096,
         v_min_throttle_hard_cap_overrides: 28,
         v_min_throttles: 29,
+        v_min_suspended_batches: 30,
     };
     let value: serde_json::Value =
         serde_json::to_value(&snap).expect("serialize snapshot to Value");
@@ -2288,6 +2289,7 @@ fn tx_latency_hist_serialization_roundtrip() {
         flow_cache_capacity: 0,
         v_min_throttle_hard_cap_overrides: 18,
         v_min_throttles: 19,
+        v_min_suspended_batches: 20,
     };
     let json = serde_json::to_string(&snap).expect("serialize snapshot");
     let back: BindingCountersSnapshot = serde_json::from_str(&json).expect("deserialize snapshot");

--- a/userspace-dp/src/protocol/binding.rs
+++ b/userspace-dp/src/protocol/binding.rs
@@ -393,6 +393,11 @@ pub(crate) struct BindingStatus {
     /// hatch rescued throughput". Ratio is the LAG_THRESHOLD diagnostic.
     #[serde(rename = "v_min_throttles", default)]
     pub v_min_throttles: u64,
+    /// #hb166 T-6(a): count of V_min suspended drain batches (fairness
+    /// brake OFF because a prior hard-cap armed suspension). Default keeps
+    /// pre-fix consumers parseable.
+    #[serde(rename = "v_min_suspended_batches", default)]
+    pub v_min_suspended_batches: u64,
     #[serde(rename = "session_hits", default)]
     pub session_hits: u64,
     #[serde(rename = "session_misses", default)]
@@ -914,6 +919,10 @@ pub(crate) struct BindingCountersSnapshot {
     /// pre-#943 consumers parseable.
     #[serde(rename = "v_min_throttles", default)]
     pub v_min_throttles: u64,
+    /// #hb166 T-6(a): V_min suspended-batch count. Default keeps
+    /// pre-fix consumers parseable.
+    #[serde(rename = "v_min_suspended_batches", default)]
+    pub v_min_suspended_batches: u64,
 }
 
 // #812 (plan §3.5a / §6.1 test #8): compile-time assertion that
@@ -1003,6 +1012,7 @@ impl From<&BindingStatus> for BindingCountersSnapshot {
             // BindingCountersSnapshot. By-value u64, no Send concerns.
             v_min_throttle_hard_cap_overrides: b.v_min_throttle_hard_cap_overrides,
             v_min_throttles: b.v_min_throttles,
+            v_min_suspended_batches: b.v_min_suspended_batches,
         }
     }
 }

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -48,6 +48,7 @@
     "tx_submit_latency_sum_ns": 0,
     "umem_inflight_frames": 0,
     "umem_total_frames": 0,
+    "v_min_suspended_batches": 0,
     "v_min_throttle_hard_cap_overrides": 0,
     "v_min_throttles": 0,
     "worker_id": 0
@@ -212,6 +213,7 @@
     "umem_inflight_frames": 0,
     "umem_total_frames": 0,
     "unsupported_packets": 0,
+    "v_min_suspended_batches": 0,
     "v_min_throttle_hard_cap_overrides": 0,
     "v_min_throttles": 0,
     "validated_bytes": 0,


### PR DESCRIPTION
Closes #4267. Refs #4245 (converged plan).

Drives 6 of the 7 READY sub-items from the fable-review-166 **T-6**
grouped TX-path MEDIUM cluster (a–m). Verified against origin/master
(81e8f381f) after the sibling fixes R-7/#4255, T-1/#4253, T-2+T-5/#4258,
R-1/R-3/R-4/#4264 merged — none of the driven sub-items was already
fixed by those. Each fix carries a RED-on-revert unit test.

## Fixed (6)

| item | what | file:line |
|------|------|-----------|
| **g** | designed CoS admission drop no longer double-reports as `tx_errors` nor allocates a per-drop `set_error(format!())` (~1M allocs/sec hot-path violation); kept the dedicated `admission_*_drops` + `dbg_cos_queue_overflow` counters; same per-drop `format!` removed from `bound_pending_tx_*` loops | `tx/cos_classify.rs:1206`, `tx/drain/mod.rs` |
| **d** | `transmit_batch` oversized-frame Drop-unwind now `.drain(..).rev()` so same-flow TCP segments keep order | `tx/transmit/mod.rs:115,137` |
| **m** | fragments / flowless (`flow_key==None`) now get BA (DSCP→802.1p→default) classification instead of default queue | `tx/cos_classify.rs:108,386` |
| **e** | `submit_local`/`submit_prepared` now `publish_committed_queue_vtime` on the 5th V_min settle boundary (surplus-phase shared_exact was advancing vtime unpublished) | `cos/queue_service/submit_{local,prepared}.rs` |
| **a** | added `v_min_suspended_batches` counter (full scratch→atomic→snapshot→wire + Go `VMinSuspendedBatches`) + decaying re-arm (halve the suspension window per consecutive hard-cap toward `V_MIN_SUSPENSION_MIN_BATCHES=64`, reset on a clean check) | `cos/queue_ops/v_min.rs` |
| **b** | gated BOTH the local `root_exact_demand_queue_mask` and the published `exact_backlog_queue_mask` on a shared `cos_exact_queue_serviceable` predicate so a v8-starved exact class releases its BE-surplus reservation (work conservation) | `cos/queue_service/mod.rs`, `cos/tx_completion.rs`, `cos/queue_ops/mod.rs` |

## Deferred (recorded in #4267)

- **k** — coordinator-side scrub on binding unregister. Overlaps the merged R-7 reseed + the existing worker-side `vacate_all_shared_exact_slots_for_binding`; a safe scrub that distinguishes membership-change from legit Arc-reuse (without clobbering the deliberate additive `rehydrate_worker_active_count` or scrubbing live vtime slots) needs its own analysis + failover smoke.
- **c** ECN aggregate arm, **f** sidecar desync, **h** inbox-overflow fallbacks, **i** `max_total_leased` bank floor, **j** equal-flow divisor, **l** truncating-zip / FIFO-settle sojourn — each needs its own design decision or repro.

## Validation

- FULL `cargo test --release ... --test-threads=1` — **3631 tests, 0 failed** (2 pre-existing ignored).
- RED-on-revert spot-verified for (d)/(g)/(b): the named tests FAIL against reverted code.
- `protocol_wire_v1.json` regenerated for the additive `v_min_suspended_batches` wire key (serde `default`, backward compatible); Go userspace parity tests green.

## ⚠️ Needs a cluster CoS smoke before merge

(a) is a V_min behavior change (decaying re-arm) and (b) changes the **#1368/#1371 BE-vs-exact contention contract** (does BE reclaim idle bandwidth without under-serving a briefly-token-parked exact class?). Both must pass the loss userspace cluster per-class CoS smoke before merge. Do **not** merge on green CI alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
