### PR TITLE
cos: fable-166 R-8 LOW fixes + R-9 false-sharing/alloc perf

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,45 @@
+## 2026-07-05 — cos: fable-166 R-8 LOW fixes + R-9 false-sharing/alloc perf (#4269, #4270)
+
+- **Timestamp**: 2026-07-05
+  - **Action**: Filed #4269 (R-8, grouped LOW dataplane) and #4270 (R-9,
+    perf). R-8 READY sub-items fixed: (b) `PaddedVtimeSlot::publish` clamps
+    a live vtime to `NOT_PARTICIPATING-1` so a saturated cumulative
+    `queue_vtime` can never collide with the `u64::MAX` sentinel; (c)
+    `cos_queue_flow_share_limit` no longer panics when `buffer_limit <
+    24_000` (legal `buffer-size 16k`) — new `clamp_flow_share_to_buffer`
+    helper lowers the floor to `min(floor, buffer_limit)`; (h)
+    `mark_ecn_ce_ipv4`/`_ipv6` reject a header whose version nibble is not
+    4/6 (defensive, ethertype was the only guard). R-8 DEFERRED with
+    rationale in #4269: (a) drain work-conservation [core hot path], (d)
+    non-optional shared_recycles param [cascades through 12 Option
+    signatures, several genuine None], (e) zero-length latent [no repro],
+    (f) empty-snapshot tripwire [needs caller-threaded flag; mismatch
+    tripwire already exists], (g) tag-mismatched grant bump [deliberate
+    existing behavior], (i) over-horizon park [already analyzed/deferred by
+    #1782 — snap covers idle case, parked residual is the reviewed
+    not-worth-the-risk option (b)], (j) budget-miss gate memo [perf memo >
+    LOW]. R-9 (a): `worker_active_flow_buckets` was the only
+    per-worker-per-acquire array left unpadded (raw `Box<[AtomicU32]>`, 16
+    workers/cache line, genuine false sharing — single-writer-per-slot
+    confirmed). Wrapped in new `PaddedAtomicU32` (`#[repr(align(64))]`,
+    mirrors `PaddedAtomicU64`); accessor still hands out `&AtomicU32` so the
+    four mutation sites are unchanged; compile-time `align_of`/`size_of`
+    const-asserts pin the padding (proven RED-on-revert: E0080). R-9 (b):
+    timer-wheel `cascade_cos_timer_wheel_level1` /
+    `wake_due_cos_timer_slot` eliminated the per-slot `mem::take`
+    capacity-destruction + `Vec::with_capacity` temporaries — new
+    `CoSTimerWheelScratch` (persistent drain/rearm/wake vectors, swapped
+    with the slot to preserve slot capacity). Validation: FULL cargo test
+    --release green (3638 tests, 0 failed); 5 new RED-on-revert tests.
+  - **File(s)**: userspace-dp/src/afxdp/types/shared_cos_lease/{vtime.rs,
+    epoch.rs,lease.rs,mod.rs,rotate_epoch_v8.rs,
+    publish_equal_flow_epoch_v8.rs,shared_cos_lease_tests.rs},
+    userspace-dp/src/afxdp/cos/{admission.rs,admission_tests.rs,ecn.rs,
+    ecn_tests.rs,tx_completion.rs}, userspace-dp/src/afxdp/types/cos.rs,
+    userspace-dp/src/afxdp/cos/builders.rs,
+    userspace-dp/src/afxdp/worker/cos/tests.rs,
+    docs/cos-traffic-shaping.md, _Log.md
+
 ## 2026-07-05 — cos: meter non-exact guaranteed classes class-wide (#4265, R-2)
 
 - **Timestamp**: 2026-07-05

--- a/docs/cos-traffic-shaping.md
+++ b/docs/cos-traffic-shaping.md
@@ -707,6 +707,18 @@ All shared buckets should be padded and isolated per cache line.
 
 Without that, coherence traffic will dominate the hot path on many-core boxes.
 
+Every per-worker, per-acquire-written array on the v8 shared lease is
+therefore `#[repr(align(64))]`: `PackedEpochGrant` (worker grants,
+starvation/demand events, equal-flow samples) and `PaddedAtomicU64`
+(cumulative requested/granted bytes). `worker_active_flow_buckets` was
+the one exception — a raw `Box<[AtomicU32]>` that packed 16 workers onto
+a single cache line and false-shared on every per-flow-churn write.
+#4270 (fable-166 R-9) wraps it in `PaddedAtomicU32` so it conforms to the
+same isolation rule; compile-time `align_of`/`size_of` asserts pin the
+padding. The interface timer wheel additionally reuses persistent
+drain/rearm/wake scratch vectors (`CoSTimerWheelScratch`) so the per-tick
+catch-up loop performs no allocator work.
+
 ## Failure Modes
 
 ### Queue Overflow

--- a/userspace-dp/src/afxdp/cos/admission.rs
+++ b/userspace-dp/src/afxdp/cos/admission.rs
@@ -138,6 +138,22 @@ pub(in crate::afxdp) fn bdp_floor_bytes(transmit_rate_bytes: u64, active_flows: 
     per_flow_rate.saturating_mul(RTT_TARGET_NS) / 1_000_000_000
 }
 
+/// #4269 (R-8c): panic-free equivalent of
+/// `value.clamp(COS_FLOW_FAIR_MIN_SHARE_BYTES, buffer_limit)`.
+///
+/// `u64::clamp(min, max)` PANICS when `min > max`. That fires when
+/// `buffer_limit < COS_FLOW_FAIR_MIN_SHARE_BYTES` (24 KB), which is a
+/// LEGAL operator configuration (`set class-of-service ... buffer-size
+/// 16k`). When the aggregate queue buffer is smaller than the per-flow
+/// min-share floor, the aggregate ceiling is the binding constraint, so
+/// the per-flow cap is `buffer_limit` itself. Lowering the floor to
+/// `min(floor, buffer_limit)` keeps `lo <= hi` for every input.
+#[inline]
+fn clamp_flow_share_to_buffer(value: u64, buffer_limit: u64) -> u64 {
+    let floor = COS_FLOW_FAIR_MIN_SHARE_BYTES.min(buffer_limit);
+    value.clamp(floor, buffer_limit)
+}
+
 #[inline]
 pub(in crate::afxdp) fn cos_queue_flow_share_limit(
     queue: &CoSQueueRuntime,
@@ -187,15 +203,15 @@ pub(in crate::afxdp) fn cos_queue_flow_share_limit(
         // div_ceil for that reason; shared_exact should follow.
         let fair_share = buffer_limit.div_ceil(prospective.max(1));
         let bdp = bdp_floor_bytes(queue.transmit_rate_bytes(), prospective);
-        return fair_share
-            .saturating_mul(SHARED_EXACT_BURST_HEADROOM)
-            .max(bdp)
-            .clamp(COS_FLOW_FAIR_MIN_SHARE_BYTES, buffer_limit);
+        return clamp_flow_share_to_buffer(
+            fair_share
+                .saturating_mul(SHARED_EXACT_BURST_HEADROOM)
+                .max(bdp),
+            buffer_limit,
+        );
     }
     let prospective_active = cos_queue_prospective_active_flows(queue, flow_bucket);
-    buffer_limit
-        .div_ceil(prospective_active)
-        .clamp(COS_FLOW_FAIR_MIN_SHARE_BYTES, buffer_limit)
+    clamp_flow_share_to_buffer(buffer_limit.div_ceil(prospective_active), buffer_limit)
 }
 
 /// Effective buffer cap for the admission check. Grows with the

--- a/userspace-dp/src/afxdp/cos/admission_tests.rs
+++ b/userspace-dp/src/afxdp/cos/admission_tests.rs
@@ -1564,3 +1564,42 @@ fn cos_flow_aware_buffer_limit_delay_cap_scales_linearly_with_rate() {
          (1 Gbps → {cap_1g}, 10 Gbps → {cap_10g})"
     );
 }
+
+#[test]
+fn clamp_flow_share_to_buffer_never_panics_below_min_share() {
+    // #4269 (R-8c): buffer_limit below the 24 KB min-share floor is legal
+    // config (`buffer-size 16k`). The old `clamp(MIN, buffer_limit)` form
+    // panicked (min > max); the panic-free form caps at buffer_limit.
+    let buffer_limit = 16 * 1024; // 16k, below COS_FLOW_FAIR_MIN_SHARE_BYTES (24000)
+    assert!(buffer_limit < COS_FLOW_FAIR_MIN_SHARE_BYTES);
+    // Any value clamps into [min(floor, buffer_limit), buffer_limit] without
+    // panicking; a value above the aggregate caps at the aggregate.
+    assert_eq!(
+        clamp_flow_share_to_buffer(1_000_000, buffer_limit),
+        buffer_limit
+    );
+    assert_eq!(clamp_flow_share_to_buffer(0, buffer_limit), buffer_limit);
+    assert_eq!(clamp_flow_share_to_buffer(4096, buffer_limit), buffer_limit);
+}
+
+#[test]
+fn clamp_flow_share_to_buffer_matches_clamp_when_buffer_above_floor() {
+    // Above the floor the helper is exactly clamp(MIN, buffer_limit).
+    let buffer_limit = 200 * 1024;
+    assert!(buffer_limit >= COS_FLOW_FAIR_MIN_SHARE_BYTES);
+    assert_eq!(
+        clamp_flow_share_to_buffer(1_000, buffer_limit),
+        COS_FLOW_FAIR_MIN_SHARE_BYTES,
+        "below-floor value clamps up to the min-share floor"
+    );
+    assert_eq!(
+        clamp_flow_share_to_buffer(1_000_000, buffer_limit),
+        buffer_limit,
+        "above-aggregate value clamps down to buffer_limit"
+    );
+    assert_eq!(
+        clamp_flow_share_to_buffer(100 * 1024, buffer_limit),
+        100 * 1024,
+        "in-range value passes through"
+    );
+}

--- a/userspace-dp/src/afxdp/cos/builders.rs
+++ b/userspace-dp/src/afxdp/cos/builders.rs
@@ -249,6 +249,7 @@ pub(in crate::afxdp) fn build_cos_interface_runtime(
             current_tick: cos_tick_for_ns(now_ns),
             level0: std::array::from_fn(|_| Vec::new()),
             level1: std::array::from_fn(|_| Vec::new()),
+            scratch: Default::default(),
         },
     }
 }

--- a/userspace-dp/src/afxdp/cos/ecn.rs
+++ b/userspace-dp/src/afxdp/cos/ecn.rs
@@ -104,6 +104,15 @@ pub(in crate::afxdp) fn mark_ecn_ce_ipv4(bytes: &mut [u8], l3_offset: usize) -> 
     if bytes.len() < end {
         return false;
     }
+    // #4269 (R-8h): the ethertype-based dispatch is the primary guard, but
+    // verify the IP version nibble too. A frame whose ethertype was
+    // trusted but whose L3 header is not actually IPv4 (mislabeled tag,
+    // NAT64/tunnel rewrite drift, injected frame) would otherwise have its
+    // TOS byte flipped and its "IPv4 checksum" recomputed over a non-IPv4
+    // header. Reject anything but version 4.
+    if (bytes[l3_offset] >> 4) != 4 {
+        return false;
+    }
     let tos_idx = l3_offset + 1;
     let old_tos = bytes[tos_idx];
     let ecn = old_tos & ECN_MASK;
@@ -154,6 +163,12 @@ pub(in crate::afxdp) fn mark_ecn_ce_ipv6(bytes: &mut [u8], l3_offset: usize) -> 
     // nibble of byte[l3_offset+1]. We need both bytes in range.
     let end = l3_offset.saturating_add(2);
     if bytes.len() < end {
+        return false;
+    }
+    // #4269 (R-8h): defensive version-nibble check (mirror of the IPv4
+    // marker). The ethertype dispatch is primary, but verify the header is
+    // actually IPv6 before rewriting its traffic-class ECN bits.
+    if (bytes[l3_offset] >> 4) != 6 {
         return false;
     }
     // Version/tclass-high byte: [vvvv tttt]. ECN bits are the low 2

--- a/userspace-dp/src/afxdp/cos/ecn_tests.rs
+++ b/userspace-dp/src/afxdp/cos/ecn_tests.rs
@@ -91,6 +91,37 @@ fn mark_ecn_ce_ipv4_rejects_short_buffer() {
 }
 
 #[test]
+fn mark_ecn_ce_ipv4_rejects_wrong_version_nibble() {
+    // #4269 (R-8h): a full-length ECT(0) frame whose L3 version nibble is
+    // NOT 4 (e.g. a mislabeled / rewritten header) must be refused so its
+    // "IPv4 checksum" is never recomputed over a non-IPv4 header.
+    let tos = (0x28u8 << 2) | ECN_ECT_0;
+    let mut pkt = build_ipv4_test_packet(tos);
+    pkt[14] = 0x65; // version = 6, IHL = 5 — wrong version, ECT still set
+    let before = pkt.clone();
+    assert!(
+        !mark_ecn_ce_ipv4(&mut pkt, 14),
+        "non-v4 version nibble must be rejected even with ECT bits set"
+    );
+    assert_eq!(pkt, before, "rejected frame must be byte-identical");
+}
+
+#[test]
+fn mark_ecn_ce_ipv6_rejects_wrong_version_nibble() {
+    // #4269 (R-8h): mirror guard for the IPv6 marker — reject a header
+    // whose version nibble is not 6.
+    let tclass = (0x2eu8 << 2) | ECN_ECT_0;
+    let mut pkt = build_ipv6_test_packet(tclass);
+    pkt[14] = 0x40 | (pkt[14] & 0x0f); // version = 4, keep tclass-high bits
+    let before = pkt.clone();
+    assert!(
+        !mark_ecn_ce_ipv6(&mut pkt, 14),
+        "non-v6 version nibble must be rejected even with ECT bits set"
+    );
+    assert_eq!(pkt, before, "rejected frame must be byte-identical");
+}
+
+#[test]
 fn mark_ecn_ce_ipv6_converts_ect0_to_ce() {
     // DSCP 46 (EF) + ECT(0) → full tclass 0xba.
     let tclass = (0x2eu8 << 2) | ECN_ECT_0;

--- a/userspace-dp/src/afxdp/cos/tx_completion.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion.rs
@@ -331,9 +331,17 @@ fn snap_cos_timer_wheel_over_horizon(root: &mut CoSInterfaceRuntime, now_tick: u
 fn cascade_cos_timer_wheel_level1(root: &mut CoSInterfaceRuntime) {
     let slot = ((root.timer_wheel.current_tick / COS_TIMER_WHEEL_L0_SLOTS as u64)
         % COS_TIMER_WHEEL_L1_SLOTS as u64) as usize;
-    let queued = core::mem::take(&mut root.timer_wheel.level1[slot]);
-    let mut rearm = Vec::with_capacity(queued.len());
-    for queue_idx in queued {
+    // #4270 (R-9): take the persistent scratch out of `root` so the
+    // `&mut root` rearm calls below borrow cleanly; restored before return.
+    let mut drain = core::mem::take(&mut root.timer_wheel.scratch.drain);
+    let mut rearm = core::mem::take(&mut root.timer_wheel.scratch.rearm);
+    drain.clear();
+    rearm.clear();
+    // Swap the slot's queued indices into `drain` WITHOUT freeing the
+    // slot's capacity: the slot receives `drain`'s emptied buffer, so the
+    // next park into it reuses that capacity instead of reallocating.
+    core::mem::swap(&mut drain, &mut root.timer_wheel.level1[slot]);
+    for queue_idx in drain.iter().copied() {
         let Some(queue) = root.queues.get(queue_idx) else {
             continue;
         };
@@ -342,17 +350,28 @@ fn cascade_cos_timer_wheel_level1(root: &mut CoSInterfaceRuntime) {
         }
         rearm.push((queue_idx, queue.hot.next_wakeup_tick));
     }
-    for (queue_idx, wake_tick) in rearm {
+    for (queue_idx, wake_tick) in rearm.iter().copied() {
         rearm_cos_queue(root, queue_idx, wake_tick);
     }
+    drain.clear();
+    rearm.clear();
+    root.timer_wheel.scratch.drain = drain;
+    root.timer_wheel.scratch.rearm = rearm;
 }
 
 fn wake_due_cos_timer_slot(root: &mut CoSInterfaceRuntime) {
     let slot = (root.timer_wheel.current_tick % COS_TIMER_WHEEL_L0_SLOTS as u64) as usize;
-    let queued = core::mem::take(&mut root.timer_wheel.level0[slot]);
-    let mut rearm = Vec::with_capacity(queued.len());
-    let mut wake = Vec::with_capacity(queued.len());
-    for queue_idx in queued {
+    // #4270 (R-9): reuse the persistent scratch (drain/rearm/wake) — no
+    // per-slot allocation on the per-tick catch-up loop.
+    let mut drain = core::mem::take(&mut root.timer_wheel.scratch.drain);
+    let mut rearm = core::mem::take(&mut root.timer_wheel.scratch.rearm);
+    let mut wake = core::mem::take(&mut root.timer_wheel.scratch.wake);
+    drain.clear();
+    rearm.clear();
+    wake.clear();
+    // Swap out the slot (capacity-preserving, see cascade above).
+    core::mem::swap(&mut drain, &mut root.timer_wheel.level0[slot]);
+    for queue_idx in drain.iter().copied() {
         let Some(queue) = root.queues.get(queue_idx) else {
             continue;
         };
@@ -365,12 +384,18 @@ fn wake_due_cos_timer_slot(root: &mut CoSInterfaceRuntime) {
             rearm.push((queue_idx, queue.hot.next_wakeup_tick));
         }
     }
-    for queue_idx in wake {
+    for queue_idx in wake.iter().copied() {
         wake_cos_queue(root, queue_idx);
     }
-    for (queue_idx, wake_tick) in rearm {
+    for (queue_idx, wake_tick) in rearm.iter().copied() {
         rearm_cos_queue(root, queue_idx, wake_tick);
     }
+    drain.clear();
+    rearm.clear();
+    wake.clear();
+    root.timer_wheel.scratch.drain = drain;
+    root.timer_wheel.scratch.rearm = rearm;
+    root.timer_wheel.scratch.wake = wake;
 }
 
 /// Conservative pre-prime gate for `drain_shaped_tx`.

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -1500,6 +1500,29 @@ pub(in crate::afxdp) struct CoSTimerWheelRuntime {
     pub(in crate::afxdp) current_tick: u64,
     pub(in crate::afxdp) level0: [Vec<usize>; COS_TIMER_WHEEL_L0_SLOTS],
     pub(in crate::afxdp) level1: [Vec<usize>; COS_TIMER_WHEEL_L1_SLOTS],
+    /// #4270 (R-9): persistent per-drain scratch buffers reused across
+    /// every `cascade_cos_timer_wheel_level1` / `wake_due_cos_timer_slot`
+    /// call so the per-tick catch-up loop performs no allocator ops. The
+    /// slot being processed is *swapped* with `drain` (preserving the
+    /// slot's own capacity for the next park), and the rearm/wake decision
+    /// lists reuse the persistent vectors instead of `Vec::with_capacity`
+    /// temporaries. See the two functions in cos/tx_completion.rs.
+    pub(in crate::afxdp) scratch: CoSTimerWheelScratch,
+}
+
+/// #4270 (R-9): reusable scratch for the timer-wheel drain path. All
+/// three vectors retain capacity across calls; the two consumers
+/// (`cascade_cos_timer_wheel_level1`, `wake_due_cos_timer_slot`) run
+/// sequentially on the owner thread and never nest, so sharing is safe.
+#[derive(Default)]
+pub(in crate::afxdp) struct CoSTimerWheelScratch {
+    /// Swapped with the slot Vec being processed so the slot keeps a
+    /// capacity-retaining buffer (never a fresh 0-capacity Vec).
+    pub(in crate::afxdp) drain: Vec<usize>,
+    /// Reused list of `(queue_idx, wake_tick)` to re-park after the scan.
+    pub(in crate::afxdp) rearm: Vec<(usize, u64)>,
+    /// Reused list of queue indices to wake after the scan.
+    pub(in crate::afxdp) wake: Vec<usize>,
 }
 
 /// #751: per-queue owner-side drain telemetry. Written by the owner

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/epoch.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/epoch.rs
@@ -127,6 +127,26 @@ pub(super) struct PackedEpochGrant(pub(super) AtomicU64);
 #[repr(align(64))]
 pub(super) struct PaddedAtomicU64(pub(super) AtomicU64);
 
+/// #4270 (R-9): cache-line-aligned per-worker `AtomicU32` slot. Same
+/// 64-byte isolation contract as `PackedEpochGrant` / `PaddedAtomicU64`,
+/// for `worker_active_flow_buckets` — the per-worker active-flow counter
+/// written per flow-bucket activation/teardown by each worker on its OWN
+/// slot (single-writer-per-slot) and read on every `acquire_v8` /
+/// `equal_flow_cap_v8`. Before this padding, 16 raw `AtomicU32`s packed
+/// onto one cache line and false-shared on every per-flow-churn write —
+/// the one per-acquire-written per-worker array the isolation rule had
+/// missed.
+// pub(super): named (as the `V8State::worker_active_flow_buckets` element
+// type) + `.0`-accessed by `lease.rs` / `rotate_epoch_v8.rs` /
+// `publish_equal_flow_epoch_v8.rs`.
+#[repr(align(64))]
+pub(super) struct PaddedAtomicU32(pub(super) AtomicU32);
+
+// #4270 (R-9): pin the padding at compile time — RED if the
+// `#[repr(align(64))]` is dropped or the atomic grows past a line.
+const _: () = assert!(core::mem::align_of::<PaddedAtomicU32>() == 64);
+const _: () = assert!(core::mem::size_of::<PaddedAtomicU32>() == 64);
+
 impl PackedEpochGrant {
     // pub(super): pack/unpack/new called from `lease.rs` and
     // `rotate_epoch_v8.rs`. `store_for_new_epoch` retained at its
@@ -254,7 +274,7 @@ pub(super) struct V8State {
     /// Per-worker active flow bucket count. Length = max_worker_id + 1.
     /// Single-writer-per-slot: only worker `id` writes its own slot
     /// (deltas via active_buckets.rs helpers, install via rehydrate).
-    pub(super) worker_active_flow_buckets: Box<[AtomicU32]>,
+    pub(super) worker_active_flow_buckets: Box<[PaddedAtomicU32]>,
     /// Per-worker fair share (bytes/epoch) snapshot, recomputed at
     /// rotation. Length = max_worker_id + 1.
     pub(super) worker_fair_share: Box<[AtomicU64]>,

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/lease.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/lease.rs
@@ -404,7 +404,7 @@ impl SharedCoSQueueLease {
             .collect::<Vec<_>>()
             .into_boxed_slice();
         let worker_active_flow_buckets = (0..len)
-            .map(|_| AtomicU32::new(0))
+            .map(|_| PaddedAtomicU32(AtomicU32::new(0)))
             .collect::<Vec<_>>()
             .into_boxed_slice();
         let worker_fair_share = (0..len)
@@ -593,7 +593,7 @@ impl SharedCoSQueueLease {
         let active_flows = v8
             .worker_active_flow_buckets
             .get(worker_id)
-            .map(|a| a.load(Ordering::Relaxed))
+            .map(|a| a.0.load(Ordering::Relaxed))
             .unwrap_or(0);
         let active = active_flows > 0;
         if active {
@@ -850,7 +850,14 @@ impl SharedCoSQueueLease {
         &self,
         worker_id: usize,
     ) -> Option<&AtomicU32> {
-        self.v8.as_ref()?.worker_active_flow_buckets.get(worker_id)
+        // #4270 (R-9): slots are cache-line-padded (`PaddedAtomicU32`);
+        // hand callers the inner `&AtomicU32` so the four mutation sites
+        // stay unchanged.
+        self.v8
+            .as_ref()?
+            .worker_active_flow_buckets
+            .get(worker_id)
+            .map(|s| &s.0)
     }
 
     /// #1229 Phase 6 v8: worker-side rehydration at lease install.
@@ -881,7 +888,7 @@ impl SharedCoSQueueLease {
             return;
         }
         if let Some(slot) = v8.worker_active_flow_buckets.get(worker_id) {
-            slot.fetch_add(count, Ordering::Relaxed);
+            slot.0.fetch_add(count, Ordering::Relaxed);
         }
     }
 
@@ -1229,7 +1236,7 @@ impl SharedCoSQueueLease {
         let active_flows = v8
             .worker_active_flow_buckets
             .get(worker_id)
-            .map(|a| a.load(Ordering::Relaxed) as u64)
+            .map(|a| a.0.load(Ordering::Relaxed) as u64)
             .unwrap_or(0);
         if active_flows == 0 {
             return Some(0);

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
@@ -70,7 +70,7 @@ pub(in crate::afxdp) use epoch::{AcquireV8ShortfallCause, V8EqualFlowFailOpenRea
 use epoch::{
     CARRY_DRAIN_MAX_EPOCHS, CARRY_MAX_EPOCHS, EPOCH_DURATION_NS, EQUAL_FLOW_MIN_WORKER_UTIL_DEN,
     EQUAL_FLOW_MIN_WORKER_UTIL_NUM, EQUAL_FLOW_VALID_STREAK_REQUIRED, MAX_ROLLBACK_RETRIES,
-    MAX_ROTATION_LAG_EPOCHS, MAX_SEQ_SPINS, PackedEpochGrant, PaddedAtomicU64,
+    MAX_ROTATION_LAG_EPOCHS, MAX_SEQ_SPINS, PackedEpochGrant, PaddedAtomicU32, PaddedAtomicU64,
     STALL_THRESHOLD_EPOCHS, SharedCoSEpochState, V8EqualFlowSuppressState, V8RotationScratch,
     V8State,
 };

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/publish_equal_flow_epoch_v8.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/publish_equal_flow_epoch_v8.rs
@@ -177,7 +177,7 @@ pub(super) fn publish_equal_flow_epoch_v8(
             let total_flows: u64 = v8
                 .worker_active_flow_buckets
                 .iter()
-                .map(|c| c.load(Ordering::Relaxed) as u64)
+                .map(|c| c.0.load(Ordering::Relaxed) as u64)
                 .sum::<u64>()
                 .max(1);
             nominal_epoch_bytes / total_flows

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs
@@ -146,7 +146,7 @@ impl SharedCoSQueueLease {
             let active = v8
                 .worker_active_flow_buckets
                 .get(id)
-                .map(|c| c.load(Ordering::Relaxed))
+                .map(|c| c.0.load(Ordering::Relaxed))
                 .unwrap_or(0);
             active_by_worker[id] = active > 0;
             demanded_by_worker[id] = old_demand_count > 0;
@@ -416,7 +416,7 @@ impl SharedCoSQueueLease {
         let total_flows: u64 = v8
             .worker_active_flow_buckets
             .iter()
-            .map(|c| c.load(Ordering::Relaxed) as u64)
+            .map(|c| c.0.load(Ordering::Relaxed) as u64)
             .sum::<u64>()
             .max(1);
         // #1643: payload store downgraded to Relaxed — the single Release
@@ -430,7 +430,7 @@ impl SharedCoSQueueLease {
             .epoch_grace_expires_ns
             .store(grace_ns, Ordering::Relaxed);
         for (id, count_atom) in v8.worker_active_flow_buckets.iter().enumerate() {
-            let my_count = count_atom.load(Ordering::Relaxed) as u64;
+            let my_count = count_atom.0.load(Ordering::Relaxed) as u64;
             let my_share = ((new_cap as u128) * (my_count as u128) / (total_flows as u128)) as u64;
             if let Some(share_atom) = v8.worker_fair_share.get(id) {
                 share_atom.store(my_share, Ordering::Relaxed);

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs
@@ -63,6 +63,25 @@ fn shared_cos_lease_state_is_cacheline_aligned() {
 }
 
 #[test]
+fn vtime_publish_clamps_below_not_participating_sentinel() {
+    // #4269 (R-8b): a saturated live vtime must NEVER be published as the
+    // NOT_PARTICIPATING sentinel (u64::MAX), or peers would skip a
+    // participating worker in the V_min reduction. publish() clamps to
+    // MAX-1, so the slot reads back as participating.
+    let slot = PaddedVtimeSlot::not_participating();
+    slot.publish(u64::MAX);
+    assert_eq!(
+        slot.read(),
+        Some(NOT_PARTICIPATING - 1),
+        "u64::MAX vtime must clamp to the participating value MAX-1, not the sentinel"
+    );
+    // A below-boundary value passes through unchanged.
+    let slot2 = PaddedVtimeSlot::not_participating();
+    slot2.publish(4242);
+    assert_eq!(slot2.read(), Some(4242));
+}
+
+#[test]
 fn shared_cos_lease_config_clamps_burst_to_packed_range() {
     let lease = SharedCoSRootLease::new(10_000_000, u64::MAX, 1);
     assert_eq!(lease.config.burst_bytes, u32::MAX as u64);

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/vtime.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/vtime.rs
@@ -80,6 +80,15 @@ impl PaddedVtimeSlot {
     /// The test `vmin_no_first_enqueue_publish` enforces this
     /// invariant.
     pub(in crate::afxdp) fn publish(&self, vtime: u64) {
+        // #4269 (R-8b): clamp a live vtime strictly below the
+        // NOT_PARTICIPATING sentinel. `queue_vtime` is a saturating
+        // cumulative served-bytes counter; if it ever reached u64::MAX it
+        // would be indistinguishable from the sentinel, and peers would
+        // skip a genuinely-participating worker in the V_min reduction.
+        // Unreachable in practice (~46 yr at 100G) but the clamp is a
+        // one-instruction defense that keeps the sentinel domain disjoint
+        // from the live domain in release builds too.
+        let vtime = vtime.min(NOT_PARTICIPATING - 1);
         debug_assert_ne!(
             vtime, NOT_PARTICIPATING,
             "live vtime must not equal sentinel"

--- a/userspace-dp/src/afxdp/worker/cos/tests.rs
+++ b/userspace-dp/src/afxdp/worker/cos/tests.rs
@@ -261,6 +261,7 @@ fn build_worker_cos_statuses_aggregates_runtime_by_interface_and_queue() {
                 current_tick: 0,
                 level0: std::array::from_fn(|idx| if idx == 3 { vec![0] } else { Vec::new() }),
                 level1: std::array::from_fn(|idx| if idx == 1 { vec![0] } else { Vec::new() }),
+                scratch: Default::default(),
             },
         };
 
@@ -441,6 +442,7 @@ fn build_worker_cos_statuses_sums_owner_profile_without_breaking_hist_invariant(
             current_tick: 0,
             level0: std::array::from_fn(|_| Vec::new()),
             level1: std::array::from_fn(|_| Vec::new()),
+            scratch: Default::default(),
         },
     };
 
@@ -788,6 +790,7 @@ fn build_worker_cos_statuses_owner_profile_only_surfaces_on_unambiguous_owner_lo
             current_tick: 0,
             level0: std::array::from_fn(|_| Vec::new()),
             level1: std::array::from_fn(|_| Vec::new()),
+            scratch: Default::default(),
         },
     };
 
@@ -1042,6 +1045,7 @@ fn build_worker_cos_statuses_owner_profile_stays_zero_for_ambiguous_multi_exact_
             current_tick: 0,
             level0: std::array::from_fn(|_| Vec::new()),
             level1: std::array::from_fn(|_| Vec::new()),
+            scratch: Default::default(),
         },
     };
 
@@ -1204,6 +1208,7 @@ fn build_worker_cos_statuses_owner_profile_stays_zero_for_ambiguous_multi_interf
             current_tick: 0,
             level0: std::array::from_fn(|_| Vec::new()),
             level1: std::array::from_fn(|_| Vec::new()),
+            scratch: Default::default(),
         },
     };
 
@@ -1468,6 +1473,7 @@ fn build_worker_cos_statuses_surfaces_distinct_per_queue_drain_telemetry() {
             current_tick: 0,
             level0: std::array::from_fn(|_| Vec::new()),
             level1: std::array::from_fn(|_| Vec::new()),
+            scratch: Default::default(),
         },
     };
 
@@ -2519,6 +2525,7 @@ fn active_flow_buckets_peak_is_max_not_sum_across_workers() {
                 current_tick: 0,
                 level0: std::array::from_fn(|_| Vec::new()),
                 level1: std::array::from_fn(|_| Vec::new()),
+                scratch: Default::default(),
             },
         }
     };


### PR DESCRIPTION
Closes #4269 Closes #4270

fable-review-166 R-8 (grouped LOW dataplane) + R-9 (perf). Verified each
finding against origin/master ~02f8c8080.

## R-8 (#4269) — READY sub-items fixed

- **(b) vtime sentinel collision** — `PaddedVtimeSlot::publish` clamps a
  live vtime below `NOT_PARTICIPATING = u64::MAX` so a saturated
  `queue_vtime` can never be misread as "not participating" and skip an
  active worker in the cross-worker V_min reduction.
- **(c) admission clamp panic** — `cos_queue_flow_share_limit` panicked
  when `buffer_limit < 24_000` (`clamp(min>max)`), a crash on the legal
  operator config `buffer-size 16k`. New `clamp_flow_share_to_buffer`
  lowers the floor to `min(floor, buffer_limit)` — panic-free for every
  input.
- **(h) ECN version nibble** — `mark_ecn_ce_ipv4`/`_ipv6` now reject a
  header whose IP version nibble is not 4/6 before rewriting ECN bits
  (the ethertype dispatch was the only guard).

Each ships a RED-on-revert test.

### R-8 deferred (rationale in #4269)
(a) drain work-conservation [core hot path], (d) non-optional
`shared_recycles` [cascades through 12 `Option<&mut Vec>` signatures,
several genuine `None`], (e) zero-length [latent, no repro], (f)
empty-snapshot tripwire [needs a caller-threaded flag; the bucket-mismatch
tripwire already exists], (g) tag-mismatched grant bump [deliberate
existing behavior], (i) over-horizon park [already analyzed — #1782 snap
covers the idle case; the parked residual is the reviewed
not-worth-the-risk option (b)], (j) budget-miss gate memo [perf memo > LOW].

## R-9 (#4270) — perf

- **(a) false sharing** — `worker_active_flow_buckets` was the only
  per-worker per-acquire array left unpadded (raw `Box<[AtomicU32]>`, 16
  workers per cache line). Verified genuine false sharing:
  single-writer-per-slot, written on every flow-bucket activation/teardown,
  read on every `acquire_v8`/`equal_flow_cap_v8` — NOT a shared gate.
  Wrapped in new `PaddedAtomicU32` (`#[repr(align(64))]`, mirroring
  `PaddedAtomicU64`); accessor still hands out `&AtomicU32` so mutation
  sites are unchanged. Compile-time `align_of`/`size_of` const-asserts pin
  the padding (proven RED-on-revert: E0080).
- **(b) timer-wheel allocations** — `cascade_cos_timer_wheel_level1` /
  `wake_due_cos_timer_slot` destroyed slot capacity via `mem::take` and
  allocated `Vec::with_capacity` temporaries per processed slot on the
  per-tick drain loop. New `CoSTimerWheelScratch` (persistent
  drain/rearm/wake vectors, swapped with the slot to preserve slot
  capacity) makes the loop allocation-free. Behavior identical.

## Validation
FULL `cargo test --release` green (3638 tests, 0 failed across all 5 test
binaries). 5 new RED-on-revert tests; R-9(a) padding proven load-bearing
by removing the repr and observing E0080.