### PR TITLE
fairness-eval reducer: six accuracy fixes (hb166 V-3..V-9)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,50 @@
+## 2026-07-05 — fairness-eval reducer: six accuracy fixes (hb166 V-3..V-9)
+
+- **Timestamp**: 2026-07-05
+  - **Action**: Fixed six fable-review-166 fairness_eval REDUCER accuracy
+    bugs (the Rust SSOT that computes the CoS fairness verdict).
+    - **V-6 (#4276)**: the per-worker scrape aggregation anchored its
+      steady-state window to the scrape-file min/max timestamp, letting
+      stale pre-run/cooldown scrapes leak in. Now anchored to the iperf
+      run epoch (`start.timestamp.timesecs` + warmup/final-burst);
+      falls back to min/max only when timesecs is absent. New
+      `steady_window_bounds` helper; `Iperf3Timestamp.timesecs` added.
+    - **V-5 (#4275)**: CoS-source `{aᵢ}` medians ignored absent (zero)
+      samples, so a worker whose flows died mid-window stayed "active".
+      New `median_per_worker_zero_filled` zero-fills each worker across
+      the in-window scrape-timestamp universe before the median (a
+      no-op for the already-zero-filling binding source).
+    - **V-7 (#4277)**: the ≥60 s steady-state minimum checked the
+      DECLARED iperf duration, not observed samples. Now rejects on the
+      observed non-omitted 1-second bucket count (60 − 5 slack) and
+      filters iperf `-O` omitted intervals. `Iperf3IntervalSum.omitted`
+      added.
+    - **V-4 (#4274)**: the a_i overcount trim removes from the LARGEST
+      bucket, which can RAISE Cstruct and LOOSEN Gate 2. Verdict now
+      gates on `min(Cstruct_raw, Cstruct_trimmed)` (fail-closed): the
+      trim may only tighten the ceiling. Legit #1281 stale-overcount
+      cases (trim LOWERS Cstruct) still normalize.
+    - **V-3 (#4273)**: Gate 3 (aggregate throughput) was vacuous — the
+      `saturated` label and the gate used the same `is_saturated`
+      predicate, so no run could FAIL on aggregate. New
+      `--expect-saturation` operator declaration breaks the circularity:
+      when set, the observed aggregate MUST reach ≥95% of the Nₐ/Nᵥ-scaled
+      cap, else Gate 3 fails. The label stays report-only. The non-shaped
+      ±5%-of-baseline clause still needs a baseline-artifact input
+      (deferred; noted in the doc + issue).
+    - **V-9 (#4278)**: the verdict omitted doc-mandated required metrics.
+      Report now emits `per_flow_throughput_mbps` (item 1 quantiles),
+      `steady_state_window` (item 12 timestamps), and `saturation_series`
+      (item 6 per-bucket series + cap + fraction), plus
+      `aggregate_throughput_gate_enforced`.
+  - **File(s)**: userspace-dp/src/fairness_eval/{inputs,per_worker,
+    windowing,verdict,args,report,mod}.rs,
+    userspace-dp/tests/fairness_eval_blackbox.rs,
+    docs/fairness-regimes.md
+  - **Validation**: FULL `cargo test --release` green; per-fix
+    RED-on-revert unit + black-box tests. Reducer/harness-only — no
+    dataplane change, no cluster smoke needed.
+
 ## 2026-07-05 — cos: meter non-exact guaranteed classes class-wide (#4265, R-2)
 
 - **Timestamp**: 2026-07-05

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -295,7 +295,11 @@ A measurement run **PASSES** iff ALL of:
    independent input observed data cannot launder: it asserts the run
    *ought* to reach the cap, so the observed aggregate is then required
    to actually hit ≥ 95% of the `Nₐ/Nᵥ`-scaled cap for ≥ 80% of buckets.
-   `--expect-saturation` requires `--shaper-rate-bps` and `--n-workers`.
+   `--expect-saturation` requires `--shaper-rate-bps` and `--n-workers`;
+   passing it with a missing/zero `--shaper-rate-bps` or `--n-workers` is
+   an operator CLI mistake and fails fast with an arg-validation error
+   (exit 2), not a Gate-3 FAIL (exit 1), so automation does not
+   misclassify a config error as a fairness regression.
    The non-shaped "±5% of measured baseline" clause still needs a
    baseline-artifact input and is not yet implemented; the
    `--expect-saturation` shaped leg is the enforceable part today.
@@ -451,7 +455,10 @@ Any fairness measurement run MUST report:
 
 The `fairness-eval` verdict always includes the doc-mandated required
 metrics (hb166 V-9): `per_flow_throughput_mbps` (item 1: `stream_count`
-plus `min/p25/median/p75/max_mbps`), `steady_state_window` (item 12:
+plus `min/p25/median/p75/max_mbps`, computed over the FULL iperf stream
+set — a starved / zero-throughput stream is counted as 0 Mb/s, not
+dropped, so a failing run's per-flow distribution surfaces the starved
+flow instead of undercounting it), `steady_state_window` (item 12:
 `iperf_epoch_start/end`, `relative_start/end_sec`), and
 `saturation_series` (item 6: the per-bucket `aggregate_buckets_bps`
 series, the `structural_cap_bps` it is judged against, and

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -277,24 +277,41 @@ A measurement run **PASSES** iff ALL of:
    `Cstruct` is computed from the per-worker active-flow
    distribution measured during the steady-state window.
 
-3. **Aggregate throughput** (saturated regime only):
-   For runs labeled saturated (per "Saturation detection" below): the
-   structural-throughput gate
+3. **Aggregate throughput** (declared-saturating runs only):
+   The structural-throughput gate
    `observed_aggregate ≥ (Nₐ / Nᵥ) × shaper_rate × 0.95` applies
-   for shaped queues. For non-shaped (best-effort) saturated
+   for shaped queues **when the operator declares the offered load is
+   expected to saturate the structural cap** (`fairness-eval
+   --expect-saturation`). For non-shaped (best-effort) saturated
    runs: ±5% of the cluster's measured baseline for the same
    `{aᵢ}` distribution from a known-good prior run.
 
-   For runs labeled **non-saturated**: aggregate throughput is
-   NOT gated. The contract assumes non-saturated runs are
-   cwnd-bound or application-bound; the test simply records
-   `observed_aggregate` for diagnostic context but does not
-   apply a fail/pass on it. Per-flow fairness (Gate 2),
-   starved-flow (Gate 1), and mouse p99 (Gate 4) remain
-   active for non-saturated runs.
+   **This gate is driven by the operator declaration, NOT by the
+   observed `saturated` label (hb166 V-3).** Enforcing it off the
+   `saturated` label alone is vacuous by construction: the label is
+   `is_saturated()` over the observed aggregate, so a run that fails to
+   reach the cap is simply labeled non-saturated and thereby exempted —
+   no run could ever FAIL on aggregate throughput. The declaration is an
+   independent input observed data cannot launder: it asserts the run
+   *ought* to reach the cap, so the observed aggregate is then required
+   to actually hit ≥ 95% of the `Nₐ/Nᵥ`-scaled cap for ≥ 80% of buckets.
+   `--expect-saturation` requires `--shaper-rate-bps` and `--n-workers`.
+   The non-shaped "±5% of measured baseline" clause still needs a
+   baseline-artifact input and is not yet implemented; the
+   `--expect-saturation` shaped leg is the enforceable part today.
 
-   Rationale: non-saturated runs by definition do not push
-   enough load to fill the structural cap; failing them on a
+   When `--expect-saturation` is **not** passed: aggregate throughput is
+   NOT gated (the run is treated as diagnostic on this leg regardless of
+   the `saturated` label). The contract assumes such runs are cwnd-bound
+   or application-bound; the test records `observed_aggregate`, the
+   per-bucket `saturation_series`, and the `saturated` label for
+   diagnostic context but does not apply a fail/pass on aggregate. The
+   verdict field `aggregate_throughput_gate_enforced` reports whether the
+   gate was active. Per-flow fairness (Gate 2), starved-flow (Gate 1),
+   and mouse p99 (Gate 4) remain active for all runs.
+
+   Rationale: a run that does not declare saturating offered load may not
+   push enough load to fill the structural cap; failing it on a
    throughput floor would be a category error.
 
 4. **Mouse p99** (only when mouse probes are present): mouse
@@ -328,9 +345,10 @@ the active workers can deliver".
 
 Gates 1, 2, and 4 apply to **all** runs (saturated and
 non-saturated). Gate 3 (aggregate throughput) applies to
-**saturated runs only** (see Gate 3 above). The two regimes
-differ only in *expected observed_CoV*, not in the CoV gate
-formula:
+**runs the operator declares saturating** (`--expect-saturation`,
+see Gate 3 above) — NOT to the observed `saturated` label, which is
+report-only. The two regimes differ only in *expected observed_CoV*,
+not in the CoV gate formula:
 
 - **Saturated**: `observed_CoV` will approach `Cstruct` from
   below as the per-worker scheduler does its job. Pass iff the
@@ -343,10 +361,17 @@ formula:
   trivially because `observed_CoV << Cstruct`, leaving a
   large negative gap.
 
-The gate formula does NOT change between regimes. Saturation
-labeling is for diagnostic context (operators can see "we're
-in saturated regime and CoV is at the structural floor") but
-does not change pass/fail.
+The CoV gate formula (Gate 2) does NOT change between regimes.
+Saturation **labeling** (`is_saturated()` over the observed
+aggregate) is for diagnostic context (operators can see "we're in
+saturated regime and CoV is at the structural floor") and never by
+itself changes pass/fail. Gate 3 enforcement is a separate mechanism
+driven by the operator's `--expect-saturation` declaration (hb166
+V-3): with that flag the observed aggregate must reach the scaled cap;
+without it the aggregate leg is diagnostic. This resolves the earlier
+apparent contradiction between "Gate 3 applies for saturated runs" and
+"labeling does not change pass/fail" — the *label* never gates, the
+*declaration* does.
 
 ## Required metrics — exported from the harness
 
@@ -377,6 +402,24 @@ Any fairness measurement run MUST report:
    window (e.g. heavily shaped streams) legitimately drop out of
    `{a_i}` between packets. Consumers (#1746) get a trustworthy
    "recently-seen flows" gauge, not a session count.
+
+   **Reducer aggregation semantics (`fairness-eval`, hb166 V-5/V-6).**
+   The per-worker `{aᵢ}` is the **median** of the per-`(timestamp,
+   worker)` summed active-flow count over the steady-state window. Two
+   correctness rules apply. (V-6) The window is anchored to the **iperf
+   run epoch** (`start.timestamp.timesecs` + warmup/final-burst), NOT to
+   the scrape file's min/max timestamp — the binding/CoS TSV timestamps
+   share the same epoch-seconds clock, so stale pre-run / cooldown-era
+   scrapes that sit inside the file but outside the run are excluded.
+   (V-5) The median **zero-fills** each worker's absent samples across
+   the full in-window scrape-timestamp universe: a worker whose flows
+   die partway through the window is correctly seen as inactive
+   (median 0), not left "active" on the median of its live head samples.
+   The CoS active-flow exporter emits rows only for live flows, so the
+   reducer enforces the zero-fill; the binding exporter already zero-fills
+   every worker every scrape, so for that source it is a no-op. A whole
+   missing scrape (no worker on the source emitted) is not fabricated
+   into spurious zeros.
 5. **Computed `Cstruct`**: the structural CoV ceiling for the
    observed `{aᵢ}`.
 6. **Saturation determination**: which regime the run is in (per
@@ -397,10 +440,23 @@ Any fairness measurement run MUST report:
 11. **Mouse p99 latency** (when mouse probes are present).
 12. **Steady-state window**: explicit start/end timestamps,
     excluding the first 5 seconds (warmup) and any final
-    sender-shutdown bursts.
+    sender-shutdown bursts. `fairness-eval` emits these as
+    `steady_state_window` (iperf-epoch and run-relative start/end) and
+    (hb166 V-7) rejects a run whose OBSERVED non-omitted 1-second bucket
+    count falls below the 60 s minimum — the check is on measured
+    samples, not the self-reported iperf duration, so a truncated JSON
+    that merely *declares* a long run is rejected with an explicit error
+    rather than producing a CoV from a handful of buckets. iperf `-O`
+    omitted intervals are filtered out of the steady-state window.
 
-The `fairness-eval` verdict always includes `iperf_retransmits` and
-`iperf_reverse`. When iperf3 exports `end.cpu_utilization_percent`, the
+The `fairness-eval` verdict always includes the doc-mandated required
+metrics (hb166 V-9): `per_flow_throughput_mbps` (item 1: `stream_count`
+plus `min/p25/median/p75/max_mbps`), `steady_state_window` (item 12:
+`iperf_epoch_start/end`, `relative_start/end_sec`), and
+`saturation_series` (item 6: the per-bucket `aggregate_buckets_bps`
+series, the `structural_cap_bps` it is judged against, and
+`saturated_bucket_fraction`). It also always includes `iperf_retransmits`
+and `iperf_reverse`. When iperf3 exports `end.cpu_utilization_percent`, the
 verdict also includes `iperf_cpu_host_total_percent`,
 `iperf_cpu_host_user_percent`, `iperf_cpu_host_system_percent`,
 `iperf_cpu_remote_total_percent`, `iperf_cpu_remote_user_percent`,
@@ -1157,7 +1213,12 @@ Every measurement run requires:
 A run shorter than 60 seconds steady-state cannot pass the per-flow
 fairness gate (insufficient samples for stable CoV). The harness
 must reject such runs with an explicit error, not pass them
-trivially.
+trivially. `fairness-eval` enforces this on the **observed** in-window
+1-second bucket count (with a small boundary slack), not on the
+self-reported iperf `duration` (hb166 V-7): a truncated JSON that
+declares a 120 s run but carries only a handful of intervals is
+rejected, and iperf `-O` omitted intervals are filtered out before the
+count.
 
 ## Regression bounds
 

--- a/userspace-dp/src/fairness_eval/args.rs
+++ b/userspace-dp/src/fairness_eval/args.rs
@@ -15,6 +15,13 @@ pub(crate) struct Args {
     pub(crate) n_workers: u32,
     pub(crate) shaper_rate_bps: u64,
     pub(crate) rss_expectation: String,
+    /// Operator declaration that the offered load is expected to
+    /// saturate the Nₐ/Nᵥ-scaled structural cap. When set, Gate 3
+    /// (aggregate throughput) is enforced: the observed aggregate must
+    /// reach >=95% of the scaled cap, else the run FAILs. Without it the
+    /// aggregate leg stays diagnostic-only (the doc's non-saturated
+    /// exemption).
+    pub(crate) expect_saturation: bool,
 }
 
 pub(crate) fn parse_args() -> Args {
@@ -29,6 +36,7 @@ pub(crate) fn parse_args() -> Args {
     let mut n_workers: u32 = 6;
     let mut shaper_rate_bps: u64 = 0;
     let mut rss_expectation: String = "any".to_string();
+    let mut expect_saturation: bool = false;
     let mut args = std::env::args().skip(1).peekable();
     while let Some(arg) = args.next() {
         match arg.as_str() {
@@ -68,9 +76,12 @@ pub(crate) fn parse_args() -> Args {
             "--rss-expectation" => {
                 rss_expectation = parse_required_string_arg("--rss-expectation", args.next());
             }
+            "--expect-saturation" => {
+                expect_saturation = true;
+            }
             "-h" | "--help" => {
                 eprintln!(
-                    "Usage: fairness-eval --iperf-json PATH --binding-flows PATH \\\n  [--cos-flows PATH --cos-ifindex N --cos-queue-id N] \\\n  [--iface NAME] [--warmup-secs N] [--final-burst-secs N] \\\n  [--n-workers N] [--shaper-rate-bps N] [--rss-expectation EXPR]\n\n--iface NAME: filter binding-flows rows to this interface (recommended for legacy per-binding mode).\n--cos-flows: class-specific CoS active-flow TSV; when present, Cstruct uses the selected CoS queue.\n--rss-expectation: any, balanced, at-least-active-workers:N, max-worker-flow-share:X, or cstruct-max:X."
+                    "Usage: fairness-eval --iperf-json PATH --binding-flows PATH \\\n  [--cos-flows PATH --cos-ifindex N --cos-queue-id N] \\\n  [--iface NAME] [--warmup-secs N] [--final-burst-secs N] \\\n  [--n-workers N] [--shaper-rate-bps N] [--rss-expectation EXPR] \\\n  [--expect-saturation]\n\n--iface NAME: filter binding-flows rows to this interface (recommended for legacy per-binding mode).\n--cos-flows: class-specific CoS active-flow TSV; when present, Cstruct uses the selected CoS queue.\n--rss-expectation: any, balanced, at-least-active-workers:N, max-worker-flow-share:X, or cstruct-max:X.\n--expect-saturation: declare the offered load >= structural cap; enforces Gate 3 (aggregate >= 95% of the Na/Nv-scaled cap)."
                 );
                 std::process::exit(0);
             }
@@ -106,6 +117,7 @@ pub(crate) fn parse_args() -> Args {
         n_workers,
         shaper_rate_bps,
         rss_expectation,
+        expect_saturation,
     }
 }
 

--- a/userspace-dp/src/fairness_eval/args.rs
+++ b/userspace-dp/src/fairness_eval/args.rs
@@ -105,6 +105,22 @@ pub(crate) fn parse_args() -> Args {
             std::process::exit(2);
         }
     };
+    // --expect-saturation requires the Nₐ/Nᵥ-scaled cap inputs. A missing
+    // --shaper-rate-bps or a zero --n-workers is an operator CLI mistake,
+    // not a fairness regression, so fail fast with an arg-validation error
+    // (exit 2) instead of letting it surface as a Gate-3 FAIL (exit 1) —
+    // otherwise automation would misclassify a config error as a
+    // fairness failure (Copilot #2).
+    if expect_saturation && shaper_rate_bps == 0 {
+        eprintln!(
+            "fairness-eval: --expect-saturation requires --shaper-rate-bps > 0 to compute the Na/Nv-scaled structural cap"
+        );
+        std::process::exit(2);
+    }
+    if expect_saturation && n_workers == 0 {
+        eprintln!("fairness-eval: --expect-saturation requires --n-workers > 0");
+        std::process::exit(2);
+    }
     Args {
         iperf_json,
         binding_flows,

--- a/userspace-dp/src/fairness_eval/inputs.rs
+++ b/userspace-dp/src/fairness_eval/inputs.rs
@@ -17,7 +17,21 @@ pub(crate) struct Iperf3Output {
 pub(crate) struct Iperf3Start {
     #[serde(default)]
     pub(crate) connected: Vec<Iperf3Connected>,
+    /// Wall-clock start of the iperf run. `timesecs` is UNIX epoch
+    /// seconds; the binding/CoS scrape TSV timestamps share the same
+    /// clock, so this anchors the steady-state window to the actual run
+    /// interval rather than the scrape-file extent (V-6). Absent in
+    /// synthetic/legacy JSON, in which case the aggregation falls back
+    /// to the min/max scrape heuristic.
+    #[serde(default)]
+    pub(crate) timestamp: Iperf3Timestamp,
     pub(crate) test_start: Iperf3TestStart,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct Iperf3Timestamp {
+    #[serde(default)]
+    pub(crate) timesecs: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -41,6 +55,18 @@ pub(crate) struct Iperf3TestStart {
 #[derive(Debug, Deserialize)]
 pub(crate) struct Iperf3Interval {
     pub(crate) streams: Vec<Iperf3StreamInterval>,
+    /// Interval-summary flags. iperf3 marks warmup/omitted intervals
+    /// (`-O`) with `sum.omitted=true`; those must not count as
+    /// steady-state data (V-7). Absent in synthetic JSON → defaults
+    /// to a non-omitted summary.
+    #[serde(default)]
+    pub(crate) sum: Iperf3IntervalSum,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct Iperf3IntervalSum {
+    #[serde(default)]
+    pub(crate) omitted: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/userspace-dp/src/fairness_eval/mod.rs
+++ b/userspace-dp/src/fairness_eval/mod.rs
@@ -11,7 +11,7 @@ use crate::fairness::{compute_observed_cov, starved_flow_count};
 use self::args::Args;
 use self::inputs::Inputs;
 use self::per_worker::{aggregate_cos_per_worker, aggregate_per_worker};
-use self::report::Report;
+use self::report::{per_flow_quantiles_mbps, Report, SaturationSeries, SteadyStateWindow};
 use self::rss::parse_rss_expectation;
 use self::verdict::{evaluate, VerdictInput, EPSILON};
 use self::windowing::extract_window;
@@ -19,6 +19,15 @@ use self::windowing::extract_window;
 pub(crate) fn run_evaluation(args: &Args, inputs: Inputs) -> Result<Report, String> {
     let window = extract_window(&inputs.iperf, args.warmup_secs, args.final_burst_secs)?;
     let n_total_workers = args.n_workers;
+
+    // Anchor the per-worker scrape aggregation to the actual iperf run
+    // interval (V-6): the binding/CoS TSV timestamps share the same
+    // epoch-seconds clock as start.timestamp.timesecs, so stale pre-run /
+    // cooldown scrapes that sit inside the scrape file but outside the run
+    // are excluded. When timesecs is absent the aggregation falls back to
+    // the scrape-file extent.
+    let iperf_epoch = inputs.iperf.start.timestamp.timesecs;
+    let iperf_total_dur = inputs.iperf.start.test_start.duration;
 
     let observed_cov = compute_observed_cov(&window.per_flow_throughputs);
 
@@ -48,6 +57,8 @@ pub(crate) fn run_evaluation(args: &Args, inputs: Inputs) -> Result<Report, Stri
         n_total_workers,
         args.warmup_secs,
         args.final_burst_secs,
+        iperf_epoch,
+        iperf_total_dur,
     )?;
     let binding_distribution_a_i = agg.distribution_a_i;
     let mut iface_filter_active = agg.iface_filter_active;
@@ -70,6 +81,8 @@ pub(crate) fn run_evaluation(args: &Args, inputs: Inputs) -> Result<Report, Stri
             n_total_workers,
             args.warmup_secs,
             args.final_burst_secs,
+            iperf_epoch,
+            iperf_total_dur,
         )?;
         iface_filter_active = true;
         cstruct_source = "cos_queue";
@@ -163,7 +176,36 @@ pub(crate) fn run_evaluation(args: &Args, inputs: Inputs) -> Result<Report, Stri
         n_total_workers,
         iface_filter_active,
         rss_expectation: &rss_expectation,
+        expect_saturation: args.expect_saturation,
     });
+
+    // Required metrics (docs/fairness-regimes.md): per-flow throughput
+    // quantiles (item 1), the steady-state window timestamps (item 12),
+    // and the saturation determination time-series (item 6). A routine
+    // verdict must carry these to satisfy the MUST list without a
+    // separate artifact dump (V-9).
+    let per_flow_throughput_mbps = per_flow_quantiles_mbps(&window.per_flow_throughputs);
+    let steady_state_window = SteadyStateWindow {
+        iperf_epoch_start: if iperf_epoch > 0 {
+            iperf_epoch.saturating_add(args.warmup_secs)
+        } else {
+            0
+        },
+        iperf_epoch_end: if iperf_epoch > 0 {
+            iperf_epoch
+                .saturating_add(iperf_total_dur)
+                .saturating_sub(args.final_burst_secs)
+        } else {
+            0
+        },
+        relative_start_sec: args.warmup_secs as f64,
+        relative_end_sec: iperf_total_dur.saturating_sub(args.final_burst_secs) as f64,
+    };
+    let saturation_series = SaturationSeries {
+        structural_cap_bps: decision.structural_cap_bps,
+        saturated_bucket_fraction: decision.saturated_bucket_fraction,
+        aggregate_buckets_bps: window.aggregate_buckets_bps.clone(),
+    };
 
     Ok(Report {
         cstruct_source,
@@ -185,6 +227,10 @@ pub(crate) fn run_evaluation(args: &Args, inputs: Inputs) -> Result<Report, Stri
         gap: decision.gap,
         epsilon: EPSILON,
         saturated: decision.saturated,
+        aggregate_throughput_gate_enforced: decision.aggregate_throughput_gate_enforced,
+        per_flow_throughput_mbps,
+        steady_state_window,
+        saturation_series,
         aggregate_mbps,
         iperf_retransmits,
         iperf_reverse,

--- a/userspace-dp/src/fairness_eval/mod.rs
+++ b/userspace-dp/src/fairness_eval/mod.rs
@@ -183,8 +183,13 @@ pub(crate) fn run_evaluation(args: &Args, inputs: Inputs) -> Result<Report, Stri
     // quantiles (item 1), the steady-state window timestamps (item 12),
     // and the saturation determination time-series (item 6). A routine
     // verdict must carry these to satisfy the MUST list without a
-    // separate artifact dump (V-9).
-    let per_flow_throughput_mbps = per_flow_quantiles_mbps(&window.per_flow_throughputs);
+    // separate artifact dump (V-9). The per-flow quantiles use the FULL
+    // stream set (starved streams counted as 0), NOT the active-only
+    // per_flow_throughputs that feeds observed_cov — otherwise a
+    // starved-at-0 flow (the fairness violation a failing run must
+    // surface) would be silently dropped and stream_count would
+    // undercount (Copilot #1).
+    let per_flow_throughput_mbps = per_flow_quantiles_mbps(&window.per_flow_throughputs_all);
     let steady_state_window = SteadyStateWindow {
         iperf_epoch_start: if iperf_epoch > 0 {
             iperf_epoch.saturating_add(args.warmup_secs)

--- a/userspace-dp/src/fairness_eval/per_worker.rs
+++ b/userspace-dp/src/fairness_eval/per_worker.rs
@@ -33,6 +33,8 @@ pub(crate) fn aggregate_per_worker(
     n_total_workers: u32,
     warmup_secs: u64,
     final_burst_secs: u64,
+    iperf_epoch: u64,
+    iperf_total_dur: u64,
 ) -> Result<AggregateResult, String> {
     let any_iface_label_present = binding_flows.iter().any(|r| !r.iface.is_empty());
     if !iface_arg.is_empty() && !any_iface_label_present && !binding_flows.is_empty() {
@@ -43,18 +45,13 @@ pub(crate) fn aggregate_per_worker(
     }
     let iface_filter_active = !iface_arg.is_empty() && any_iface_label_present;
 
-    let ss_start_ts = binding_flows
-        .iter()
-        .map(|r| r.timestamp)
-        .min()
-        .unwrap_or(0)
-        .saturating_add(warmup_secs);
-    let ss_end_ts = binding_flows
-        .iter()
-        .map(|r| r.timestamp)
-        .max()
-        .unwrap_or(0)
-        .saturating_sub(final_burst_secs);
+    let (ss_start_ts, ss_end_ts) = steady_window_bounds(
+        binding_flows.iter().map(|r| r.timestamp),
+        warmup_secs,
+        final_burst_secs,
+        iperf_epoch,
+        iperf_total_dur,
+    );
 
     let mut per_ts_worker: BTreeMap<(u64, u32), u32> = BTreeMap::new();
     for row in binding_flows {
@@ -78,22 +75,7 @@ pub(crate) fn aggregate_per_worker(
             .or_insert(0) += row.count;
     }
 
-    let mut per_worker_samples: BTreeMap<u32, Vec<u32>> = BTreeMap::new();
-    for ((_ts, w), c) in per_ts_worker {
-        per_worker_samples.entry(w).or_default().push(c);
-    }
-    let distribution_a_i: Vec<u32> = (0..n_total_workers)
-        .map(|w| {
-            per_worker_samples
-                .get(&w)
-                .map(|samples| {
-                    let mut s = samples.clone();
-                    s.sort_unstable();
-                    s[s.len() / 2]
-                })
-                .unwrap_or(0)
-        })
-        .collect();
+    let distribution_a_i = median_per_worker_zero_filled(&per_ts_worker, n_total_workers);
 
     Ok(AggregateResult {
         distribution_a_i,
@@ -108,19 +90,16 @@ pub(crate) fn aggregate_cos_per_worker(
     n_total_workers: u32,
     warmup_secs: u64,
     final_burst_secs: u64,
+    iperf_epoch: u64,
+    iperf_total_dur: u64,
 ) -> Result<Vec<u32>, String> {
-    let ss_start_ts = cos_flows
-        .iter()
-        .map(|r| r.timestamp)
-        .min()
-        .unwrap_or(0)
-        .saturating_add(warmup_secs);
-    let ss_end_ts = cos_flows
-        .iter()
-        .map(|r| r.timestamp)
-        .max()
-        .unwrap_or(0)
-        .saturating_sub(final_burst_secs);
+    let (ss_start_ts, ss_end_ts) = steady_window_bounds(
+        cos_flows.iter().map(|r| r.timestamp),
+        warmup_secs,
+        final_burst_secs,
+        iperf_epoch,
+        iperf_total_dur,
+    );
 
     let mut per_ts_worker: BTreeMap<(u64, u32), u32> = BTreeMap::new();
     for row in cos_flows {
@@ -142,22 +121,91 @@ pub(crate) fn aggregate_cos_per_worker(
             .or_insert(0) += row.count;
     }
 
-    let mut per_worker_samples: BTreeMap<u32, Vec<u32>> = BTreeMap::new();
-    for ((_ts, w), c) in per_ts_worker {
-        per_worker_samples.entry(w).or_default().push(c);
-    }
-    Ok((0..n_total_workers)
+    Ok(median_per_worker_zero_filled(&per_ts_worker, n_total_workers))
+}
+
+/// Per-worker median of the summed active-flow count, zero-filling
+/// absent worker samples across the full in-window scrape-timestamp
+/// universe (V-5).
+///
+/// The universe is the set of timestamps present in `per_ts_worker`
+/// (the in-window, source-matched rows). A worker with no entry at a
+/// timestamp where the source WAS scraped genuinely had 0 active flows
+/// there. Median-over-present-samples-only kept a worker whose flows
+/// died mid-window "active" (it retained the median of its live head
+/// samples), inflating Nₐ and distorting Cstruct. The CoS exporter emits
+/// rows only for live flows, so it is the vulnerable source; the binding
+/// exporter zero-fills every worker every scrape, so for that source the
+/// universe already contains every (ts, worker) and this is a no-op.
+///
+/// Missing whole scrapes (a Prometheus scrape gap where NO worker on the
+/// source emitted) do not appear in the universe, so a scrape gap is not
+/// fabricated into spurious zeros.
+fn median_per_worker_zero_filled(
+    per_ts_worker: &BTreeMap<(u64, u32), u32>,
+    n_total_workers: u32,
+) -> Vec<u32> {
+    let timestamps: std::collections::BTreeSet<u64> =
+        per_ts_worker.keys().map(|(ts, _)| *ts).collect();
+    (0..n_total_workers)
         .map(|w| {
-            per_worker_samples
-                .get(&w)
-                .map(|samples| {
-                    let mut s = samples.clone();
-                    s.sort_unstable();
-                    s[s.len() / 2]
-                })
-                .unwrap_or(0)
+            if timestamps.is_empty() {
+                return 0;
+            }
+            let mut samples: Vec<u32> = timestamps
+                .iter()
+                .map(|ts| per_ts_worker.get(&(*ts, w)).copied().unwrap_or(0))
+                .collect();
+            samples.sort_unstable();
+            samples[samples.len() / 2]
         })
-        .collect())
+        .collect()
+}
+
+/// Steady-state window bounds (inclusive, epoch seconds) for the scrape
+/// aggregation.
+///
+/// When the iperf JSON carries a run epoch (`start.timestamp.timesecs`)
+/// and a usable duration, the window is anchored to the ACTUAL run
+/// interval `[epoch + warmup, epoch + duration - final_burst]`. This
+/// excludes stale pre-run / cooldown-era scrapes that sit inside the
+/// scrape file but outside the run (V-6). The scrape TSV timestamps and
+/// `timesecs` share the same epoch-seconds clock.
+///
+/// Fallback (no `timesecs`, e.g. synthetic or legacy hand-built input):
+/// the scrape-file extent `[min + warmup, max - final_burst]`. This is
+/// the pre-V-6 heuristic and can admit stale head samples, but the
+/// production harness always emits `timesecs`, so the fallback is only
+/// reached by artifacts that never had a run epoch to anchor to.
+pub(crate) fn steady_window_bounds(
+    timestamps: impl Iterator<Item = u64>,
+    warmup_secs: u64,
+    final_burst_secs: u64,
+    iperf_epoch: u64,
+    iperf_total_dur: u64,
+) -> (u64, u64) {
+    if iperf_epoch > 0 && iperf_total_dur > warmup_secs + final_burst_secs {
+        let start = iperf_epoch.saturating_add(warmup_secs);
+        let end = iperf_epoch
+            .saturating_add(iperf_total_dur)
+            .saturating_sub(final_burst_secs);
+        return (start, end);
+    }
+    let mut min_ts = u64::MAX;
+    let mut max_ts = 0u64;
+    for ts in timestamps {
+        min_ts = min_ts.min(ts);
+        max_ts = max_ts.max(ts);
+    }
+    if min_ts == u64::MAX {
+        // No rows: degenerate empty window (start > end filters nothing
+        // in, matching the pre-V-6 unwrap_or(0) behavior for empty input).
+        return (warmup_secs, 0u64.saturating_sub(final_burst_secs));
+    }
+    (
+        min_ts.saturating_add(warmup_secs),
+        max_ts.saturating_sub(final_burst_secs),
+    )
 }
 
 pub(crate) fn max_worker_flow_share(distribution_a_i: &[u32]) -> f64 {
@@ -248,7 +296,7 @@ mod tests {
                 rows.push(row(ts, 100 + w, 0, w, "ge-0-0-3", 999));
             }
         }
-        let r = aggregate_per_worker(&rows, "ge-0-0-2", 6, 0, 0).unwrap();
+        let r = aggregate_per_worker(&rows, "ge-0-0-2", 6, 0, 0, 0, 0).unwrap();
         assert!(r.iface_filter_active);
         assert_eq!(r.distribution_a_i, vec![1, 2, 3, 4, 5, 6]);
     }
@@ -267,7 +315,7 @@ mod tests {
                 rows.push(row(ts, w + 1, 0, w, "ge-0-0-2", 1));
             }
         }
-        let r = aggregate_per_worker(&rows, "ge-0-0-2", 6, 0, 0).unwrap();
+        let r = aggregate_per_worker(&rows, "ge-0-0-2", 6, 0, 0, 0, 0).unwrap();
         assert_eq!(r.distribution_a_i, vec![5, 1, 1, 1, 1, 1]);
     }
 
@@ -279,7 +327,7 @@ mod tests {
         let rows: Vec<_> = (0u32..6)
             .flat_map(|w| (1000u64..1003).map(move |ts| row(ts, w, 0, w, "", 7)))
             .collect();
-        let r = aggregate_per_worker(&rows, "ge-0-0-2", 6, 0, 0).unwrap();
+        let r = aggregate_per_worker(&rows, "ge-0-0-2", 6, 0, 0, 0, 0).unwrap();
         assert!(!r.iface_filter_active, "legacy 3-col must collapse filter");
         // Each worker still appears at its slot/wid index with count 7.
         assert_eq!(r.distribution_a_i, vec![7, 7, 7, 7, 7, 7]);
@@ -296,7 +344,7 @@ mod tests {
                     .map(move |&w| row(ts, w, 0, w, "ge-0-0-2", 4))
             })
             .collect();
-        let r = aggregate_per_worker(&rows, "ge-0-0-2", 6, 0, 0).unwrap();
+        let r = aggregate_per_worker(&rows, "ge-0-0-2", 6, 0, 0, 0, 0).unwrap();
         assert_eq!(r.distribution_a_i, vec![4, 0, 4, 0, 4, 0]);
     }
 
@@ -313,7 +361,7 @@ mod tests {
             row(1001, 1, 0, 1, "ge-0-0-2", 1),
             row(1002, 1, 0, 1, "ge-0-0-2", 1),
         ];
-        let r = aggregate_per_worker(&rows, "ge-0-0-2", 2, 0, 0).unwrap();
+        let r = aggregate_per_worker(&rows, "ge-0-0-2", 2, 0, 0, 0, 0).unwrap();
         assert_eq!(r.distribution_a_i, vec![5, 1]);
     }
 
@@ -326,12 +374,37 @@ mod tests {
             row(1000, 0, 0, 0, "ge-0-0-2", 3),
             row(1000, 1, 0, 6, "ge-0-0-2", 5), // worker_id=6 out of range for n=6
         ];
-        let result = aggregate_per_worker(&rows, "ge-0-0-2", 6, 0, 0);
+        let result = aggregate_per_worker(&rows, "ge-0-0-2", 6, 0, 0, 0, 0);
         assert!(result.is_err(), "out-of-range worker_id should return Err");
         let msg = result.unwrap_err();
         assert!(
             msg.contains("worker_id=6"),
             "error should mention the bad worker_id: {msg}"
+        );
+    }
+
+    #[test]
+    fn aggregate_per_worker_anchors_window_to_iperf_epoch_not_scrape_extent() {
+        // V-6: the scrape file spans ts 900..1060, but the iperf run is
+        // epoch=1000, duration=60 → run interval [1000, 1060]. Stale
+        // pre-run samples (worker 0 pile-up at ts 900..999) must be
+        // excluded by epoch anchoring. On the min/max scrape-extent
+        // fallback (the bug) they would enter the window and inflate
+        // worker 0's median.
+        let mut rows = Vec::new();
+        for ts in 900u64..1000 {
+            rows.push(row(ts, 0, 0, 0, "ge-0-0-2", 99));
+        }
+        for ts in 1000u64..1061 {
+            for w in 0u32..6 {
+                rows.push(row(ts, w, 0, w, "ge-0-0-2", 1));
+            }
+        }
+        let r = aggregate_per_worker(&rows, "ge-0-0-2", 6, 0, 0, 1000, 60).unwrap();
+        assert_eq!(
+            r.distribution_a_i,
+            vec![1, 1, 1, 1, 1, 1],
+            "stale pre-run worker-0 pile-up must be excluded by iperf-epoch anchoring"
         );
     }
 
@@ -344,8 +417,32 @@ mod tests {
             rows.push(cos_row(ts, 80, 5, 0, 99));
             rows.push(cos_row(ts, 81, 4, 1, 99));
         }
-        let r = aggregate_cos_per_worker(&rows, 80, 4, 3, 0, 0).unwrap();
+        let r = aggregate_cos_per_worker(&rows, 80, 4, 3, 0, 0, 0, 0).unwrap();
         assert_eq!(r, vec![3, 5, 0]);
+    }
+
+    #[test]
+    fn aggregate_cos_per_worker_zero_fills_dead_worker_across_window() {
+        // V-5: worker 0's flows die after the first 10 of 100 scrapes;
+        // workers 1-5 stay live on the same queue for the whole window.
+        // Median over PRESENT samples (the bug) keeps worker 0 at 2;
+        // zero-filling across the full scrape universe correctly reports
+        // it inactive (median 0).
+        let mut rows = Vec::new();
+        for ts in 1000u64..1100 {
+            if ts < 1010 {
+                rows.push(cos_row(ts, 80, 4, 0, 2));
+            }
+            for w in 1u32..6 {
+                rows.push(cos_row(ts, 80, 4, w, 2));
+            }
+        }
+        let r = aggregate_cos_per_worker(&rows, 80, 4, 6, 0, 0, 0, 0).unwrap();
+        assert_eq!(
+            r[0], 0,
+            "dead worker must be seen as inactive (median 0), not its stale live value"
+        );
+        assert_eq!(&r[1..], &[2, 2, 2, 2, 2]);
     }
 
     #[test]

--- a/userspace-dp/src/fairness_eval/report.rs
+++ b/userspace-dp/src/fairness_eval/report.rs
@@ -2,6 +2,76 @@ use serde::Serialize;
 
 use super::args::Args;
 
+/// Per-flow throughput quantiles (docs/fairness-regimes.md required
+/// metric item 1): min, p25, median, p75, max in Mb/s, plus the stream
+/// count N of the per-flow set.
+#[derive(Debug, Serialize)]
+pub(crate) struct PerFlowThroughputQuantiles {
+    pub(crate) stream_count: u32,
+    pub(crate) min_mbps: f64,
+    pub(crate) p25_mbps: f64,
+    pub(crate) median_mbps: f64,
+    pub(crate) p75_mbps: f64,
+    pub(crate) max_mbps: f64,
+}
+
+/// Steady-state window explicit timestamps (required metric item 12).
+/// `iperf_epoch_*` are wall-clock UNIX seconds (0 when the iperf JSON
+/// carried no `timesecs`); `relative_*` are seconds since the run start.
+#[derive(Debug, Serialize)]
+pub(crate) struct SteadyStateWindow {
+    pub(crate) iperf_epoch_start: u64,
+    pub(crate) iperf_epoch_end: u64,
+    pub(crate) relative_start_sec: f64,
+    pub(crate) relative_end_sec: f64,
+}
+
+/// Saturation determination supporting time-series (required metric item
+/// 6): the per-bucket aggregate throughput series, the Nₐ/Nᵥ-scaled
+/// structural cap it is judged against, and the fraction of buckets at
+/// or above 95% of that cap.
+#[derive(Debug, Serialize)]
+pub(crate) struct SaturationSeries {
+    pub(crate) structural_cap_bps: u64,
+    pub(crate) saturated_bucket_fraction: f64,
+    pub(crate) aggregate_buckets_bps: Vec<u64>,
+}
+
+/// Compute per-flow throughput quantiles (Mb/s) from the steady-state
+/// per-flow mean throughputs (bytes/sec). Nearest-rank percentiles.
+pub(crate) fn per_flow_quantiles_mbps(per_flow_bytes_per_sec: &[u64]) -> PerFlowThroughputQuantiles {
+    if per_flow_bytes_per_sec.is_empty() {
+        return PerFlowThroughputQuantiles {
+            stream_count: 0,
+            min_mbps: 0.0,
+            p25_mbps: 0.0,
+            median_mbps: 0.0,
+            p75_mbps: 0.0,
+            max_mbps: 0.0,
+        };
+    }
+    let mut mbps: Vec<f64> = per_flow_bytes_per_sec
+        .iter()
+        .map(|&b| b as f64 * 8.0 / 1_000_000.0)
+        .collect();
+    mbps.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let n = mbps.len();
+    let pick = |frac: f64| -> f64 {
+        let idx = ((frac * n as f64).ceil() as usize)
+            .saturating_sub(1)
+            .min(n - 1);
+        mbps[idx]
+    };
+    PerFlowThroughputQuantiles {
+        stream_count: n as u32,
+        min_mbps: mbps[0],
+        p25_mbps: pick(0.25),
+        median_mbps: pick(0.5),
+        p75_mbps: pick(0.75),
+        max_mbps: mbps[n - 1],
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub(crate) struct Report {
     pub(crate) cstruct_source: &'static str,
@@ -25,6 +95,16 @@ pub(crate) struct Report {
     pub(crate) gap: f64,
     pub(crate) epsilon: f64,
     pub(crate) saturated: bool,
+    /// True when Gate 3 (aggregate throughput) was ENFORCED for this run
+    /// (operator passed --expect-saturation). False = aggregate leg is
+    /// diagnostic-only for this run (V-3).
+    pub(crate) aggregate_throughput_gate_enforced: bool,
+    /// Required metric item 1 (per-flow throughput quantiles).
+    pub(crate) per_flow_throughput_mbps: PerFlowThroughputQuantiles,
+    /// Required metric item 12 (steady-state window timestamps).
+    pub(crate) steady_state_window: SteadyStateWindow,
+    /// Required metric item 6 (saturation determination time-series).
+    pub(crate) saturation_series: SaturationSeries,
     pub(crate) aggregate_mbps: f64,
     pub(crate) iperf_retransmits: u64,
     pub(crate) iperf_reverse: bool,

--- a/userspace-dp/src/fairness_eval/verdict.rs
+++ b/userspace-dp/src/fairness_eval/verdict.rs
@@ -34,6 +34,13 @@ pub(crate) struct VerdictInput<'a> {
     pub(crate) n_total_workers: u32,
     pub(crate) iface_filter_active: bool,
     pub(crate) rss_expectation: &'a RssExpectation,
+    /// Operator declaration that the offered load is >= the structural
+    /// cap, so the observed aggregate is REQUIRED to reach it (Gate 3).
+    /// This is the independent input that breaks the V-3 circularity:
+    /// the `saturated` label is descriptive, but enforcement is driven
+    /// by this declaration, not by re-reading the same is_saturated
+    /// predicate.
+    pub(crate) expect_saturation: bool,
 }
 
 pub(crate) struct VerdictDecision {
@@ -46,6 +53,9 @@ pub(crate) struct VerdictDecision {
     pub(crate) cstruct: f64,
     pub(crate) gap: f64,
     pub(crate) saturated: bool,
+    pub(crate) structural_cap_bps: u64,
+    pub(crate) saturated_bucket_fraction: f64,
+    pub(crate) aggregate_throughput_gate_enforced: bool,
     pub(crate) a_i_sum_check_ok: bool,
     pub(crate) a_i_sum: u32,
     pub(crate) iperf_non_starved_streams: u32,
@@ -88,33 +98,65 @@ pub(crate) fn evaluate(input: VerdictInput<'_>) -> VerdictDecision {
     };
     let a_i_sum_check_ok = a_i_abs_delta <= tolerance;
 
-    let cstruct_distribution_a_i = if a_i_delta > 0 && a_i_sum_check_ok {
+    // Candidate normalized distribution: trim an accepted overcount down
+    // to the expected sum. `trim_distribution_to_sum` removes from the
+    // LARGEST bucket, which for an evenly-loaded overcount MANUFACTURES
+    // skew and RAISES Cstruct — loosening the Gate-2 tolerance
+    // (observed_CoV ≤ Cstruct + 0.05). That is fail-open in exactly the
+    // wrong direction (V-4). Gate on the TIGHTER of raw vs trimmed
+    // Cstruct (fail-closed): the overcount normalization may only tighten
+    // the ceiling, never loosen it. The legitimate #1281 stale-overcount
+    // cases (e.g. {4,4,4,3,0,0} → {3,3,3,3,0,0}) trim to a LOWER Cstruct,
+    // so they still normalize; only a trim that would raise Cstruct falls
+    // back to the raw ceiling.
+    let trimmed_distribution_a_i = if a_i_delta > 0 && a_i_sum_check_ok {
         trim_distribution_to_sum(input.distribution_a_i, expected_sum)
     } else {
         input.distribution_a_i.to_vec()
     };
+    let cstruct_raw = compute_cstruct(input.distribution_a_i);
+    let cstruct_trimmed = compute_cstruct(&trimmed_distribution_a_i);
+    let (cstruct_distribution_a_i, cstruct) = if cstruct_trimmed < cstruct_raw {
+        (trimmed_distribution_a_i, cstruct_trimmed)
+    } else {
+        (input.distribution_a_i.to_vec(), cstruct_raw)
+    };
     let cstruct_adjusted_for_a_i_overcount = cstruct_distribution_a_i != input.distribution_a_i;
 
-    let cstruct = compute_cstruct(&cstruct_distribution_a_i);
     let n_active: u32 = input.distribution_a_i.iter().filter(|&&a| a > 0).count() as u32;
     let max_worker_flow_share = max_worker_flow_share(input.distribution_a_i);
     let (rss_expectation_pass, rss_expectation_reason) = evaluate_rss_expectation(
         input.rss_expectation,
         input.distribution_a_i,
-        compute_cstruct(input.distribution_a_i),
+        cstruct_raw,
         input.n_total_workers,
     );
     let gap = input.observed_cov - cstruct;
 
     // Saturation: structural cap = (n_active / n_total_workers) × shaper_rate.
-    // shaper_rate provided via --shaper-rate-bps; if zero, skip the saturated check.
-    let saturated = if input.shaper_rate_bps > 0 && input.n_total_workers > 0 {
-        let structural_cap_bps = (input.shaper_rate_bps as u128 * n_active as u128
-            / input.n_total_workers as u128) as u64;
-        is_saturated(input.aggregate_buckets_bps, structural_cap_bps)
+    // shaper_rate provided via --shaper-rate-bps; if zero, the cap is
+    // unknown (0) and saturation cannot be determined.
+    let structural_cap_bps = if input.shaper_rate_bps > 0 && input.n_total_workers > 0 {
+        (input.shaper_rate_bps as u128 * n_active as u128 / input.n_total_workers as u128) as u64
     } else {
-        false
+        0
     };
+    // `saturated` stays a report-only descriptive LABEL (is_saturated
+    // over the observed aggregate). It does NOT drive Gate 3 — enforcing
+    // the aggregate gate off this same label is vacuous (V-3).
+    let saturated = is_saturated(input.aggregate_buckets_bps, structural_cap_bps);
+    let saturated_bucket_fraction =
+        if structural_cap_bps > 0 && !input.aggregate_buckets_bps.is_empty() {
+            let threshold = (structural_cap_bps as f64 * 0.95) as u64;
+            let above = input
+                .aggregate_buckets_bps
+                .iter()
+                .filter(|&&b| b >= threshold)
+                .count();
+            above as f64 / input.aggregate_buckets_bps.len() as f64
+        } else {
+            0.0
+        };
 
     let mut failure_reasons: Vec<String> = Vec::new();
     if input.starved > 0 {
@@ -146,6 +188,31 @@ pub(crate) fn evaluate(input: VerdictInput<'_>) -> VerdictDecision {
         ));
     }
 
+    // Gate 3 (aggregate throughput). Enforced only when the operator
+    // declares the offered load is expected to saturate the structural
+    // cap (--expect-saturation). This breaks the V-3 circularity: the
+    // `saturated` LABEL above is is_saturated over observed data, so
+    // gating off it can never FAIL (a run that misses the cap is simply
+    // labeled non-saturated and exempted). The operator declaration is an
+    // INDEPENDENT input observed data cannot launder — the run OUGHT to
+    // reach the cap, so the observed aggregate is required to actually
+    // hit >=95% of the Nₐ/Nᵥ-scaled cap for >=80% of buckets.
+    if input.expect_saturation {
+        if structural_cap_bps == 0 {
+            failure_reasons.push(
+                "Gate 3 (aggregate throughput): --expect-saturation requires --shaper-rate-bps and --n-workers>0 to compute the Nₐ/Nᵥ-scaled structural cap".to_string(),
+            );
+        } else if !saturated {
+            failure_reasons.push(format!(
+                "Gate 3 (aggregate throughput): offered load declared saturating (--expect-saturation) but observed aggregate stayed below 95% of the Nₐ/Nᵥ-scaled cap ({:.1} Mb/s, Nₐ={}/Nᵥ={}) for >20% of steady-state buckets (saturated_bucket_fraction={:.2})",
+                structural_cap_bps as f64 / 1_000_000.0,
+                n_active,
+                input.n_total_workers,
+                saturated_bucket_fraction,
+            ));
+        }
+    }
+
     let verdict = if failure_reasons.is_empty() {
         "PASS"
     } else {
@@ -162,6 +229,9 @@ pub(crate) fn evaluate(input: VerdictInput<'_>) -> VerdictDecision {
         cstruct,
         gap,
         saturated,
+        structural_cap_bps,
+        saturated_bucket_fraction,
+        aggregate_throughput_gate_enforced: input.expect_saturation,
         a_i_sum_check_ok,
         a_i_sum,
         iperf_non_starved_streams: n_non_starved,
@@ -170,5 +240,127 @@ pub(crate) fn evaluate(input: VerdictInput<'_>) -> VerdictDecision {
         a_i_sum_tolerance: tolerance,
         verdict,
         failure_reasons,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_input<'a>(
+        distribution_a_i: &'a [u32],
+        rss: &'a RssExpectation,
+        observed_cov: f64,
+        n_iperf_streams: u32,
+        n_total_workers: u32,
+    ) -> VerdictInput<'a> {
+        VerdictInput {
+            observed_cov,
+            aggregate_buckets_bps: &[],
+            shaper_rate_bps: 0,
+            distribution_a_i,
+            binding_distribution_a_i: distribution_a_i,
+            cstruct_source: "binding",
+            starved: 0,
+            n_iperf_streams,
+            n_total_workers,
+            iface_filter_active: true,
+            rss_expectation: rss,
+            expect_saturation: false,
+        }
+    }
+
+    #[test]
+    fn overcount_trim_never_loosens_gate2() {
+        // V-4: {3,3} observed with an accepted overcount whose expected
+        // sum is 5 trims to {2,3}: raw Cstruct 0.00, trimmed Cstruct
+        // ~0.204. The gate must use the TIGHTER raw ceiling (fail-closed)
+        // so observed_cov=0.10 exceeds Cstruct+epsilon and Gate 2 FAILS.
+        // The buggy trim would raise Cstruct to ~0.204, making the gap
+        // negative and PASSing an unfair run.
+        let dist = [3u32, 3];
+        let rss = RssExpectation::Any;
+        // n_iperf_streams=5, iface filter active → dir_mult=1 →
+        // expected_sum=5; a_i_sum=6 → +1 overcount inside tolerance → the
+        // trim path is exercised.
+        let d = evaluate(base_input(&dist, &rss, 0.10, 5, 2));
+        assert!(
+            d.cstruct <= 1e-9,
+            "Cstruct must use the tighter raw ceiling (0.0), got {}",
+            d.cstruct
+        );
+        assert_eq!(d.cstruct_distribution_a_i, vec![3, 3]);
+        assert!(!d.cstruct_adjusted_for_a_i_overcount);
+        assert_eq!(d.verdict, "FAIL");
+        assert!(
+            d.failure_reasons.iter().any(|r| r.contains("Gate 2")),
+            "must fail Gate 2: {:?}",
+            d.failure_reasons
+        );
+    }
+
+    #[test]
+    fn overcount_trim_still_normalizes_when_it_tightens() {
+        // The legitimate #1281 case: {4,4,4,3,0,0} with expected_sum=12
+        // trims to {3,3,3,3,0,0}. Raw Cstruct ~0.125, trimmed 0.0 → the
+        // trim LOWERS the ceiling, so it is applied (fail-closed keeps
+        // the min).
+        let dist = [4u32, 4, 4, 3, 0, 0];
+        let rss = RssExpectation::Any;
+        let d = evaluate(base_input(&dist, &rss, 0.0, 12, 6));
+        assert_eq!(d.cstruct_distribution_a_i, vec![3, 3, 3, 3, 0, 0]);
+        assert!(d.cstruct_adjusted_for_a_i_overcount);
+        assert!(d.cstruct <= 1e-9, "trimmed Cstruct is 0.0, got {}", d.cstruct);
+    }
+
+    #[test]
+    fn expect_saturation_below_cap_fails_gate3() {
+        // V-3: aggregate ~6 Gbps against a 20 Gbps scaled cap is NOT
+        // saturated. Without --expect-saturation the aggregate leg is
+        // diagnostic and the run PASSes; with it, Gate 3 FAILS.
+        let dist = [1u32, 1, 1, 1, 1, 1];
+        let rss = RssExpectation::Any;
+        let buckets = vec![6_000_000_000u64; 60];
+        let mut input = base_input(&dist, &rss, 0.0, 6, 6);
+        input.aggregate_buckets_bps = &buckets;
+        input.shaper_rate_bps = 20_000_000_000;
+        // Diagnostic-only default: no gate.
+        let diag = evaluate(input);
+        assert_eq!(diag.verdict, "PASS");
+        assert!(!diag.saturated);
+        assert!(!diag.aggregate_throughput_gate_enforced);
+
+        let mut input = base_input(&dist, &rss, 0.0, 6, 6);
+        input.aggregate_buckets_bps = &buckets;
+        input.shaper_rate_bps = 20_000_000_000;
+        input.expect_saturation = true;
+        let enforced = evaluate(input);
+        assert_eq!(enforced.verdict, "FAIL");
+        assert!(enforced.aggregate_throughput_gate_enforced);
+        assert!(
+            enforced
+                .failure_reasons
+                .iter()
+                .any(|r| r.contains("Gate 3")),
+            "must fail Gate 3: {:?}",
+            enforced.failure_reasons
+        );
+    }
+
+    #[test]
+    fn expect_saturation_at_cap_passes_gate3() {
+        // Aggregate at the scaled cap (>=95%) with --expect-saturation
+        // must PASS — the gate is enforceable, not always-firing.
+        let dist = [1u32, 1, 1, 1, 1, 1];
+        let rss = RssExpectation::Any;
+        let buckets = vec![6_000_000_000u64; 60];
+        let mut input = base_input(&dist, &rss, 0.0, 6, 6);
+        input.aggregate_buckets_bps = &buckets;
+        input.shaper_rate_bps = 6_000_000_000;
+        input.expect_saturation = true;
+        let d = evaluate(input);
+        assert!(d.saturated);
+        assert_eq!(d.verdict, "PASS");
+        assert!(d.aggregate_throughput_gate_enforced);
     }
 }

--- a/userspace-dp/src/fairness_eval/windowing.rs
+++ b/userspace-dp/src/fairness_eval/windowing.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use super::inputs::Iperf3Output;
 
+#[cfg_attr(test, derive(Debug))]
 pub(crate) struct Window {
     pub(crate) per_stream_buckets: BTreeMap<u64, Vec<u64>>,
     pub(crate) aggregate_buckets_bps: Vec<u64>,
@@ -26,6 +27,11 @@ pub(crate) fn extract_window(
     // produce a statistically meaningful CoV measurement. Shorter
     // runs would give a verdict on too few per-second buckets.
     const MIN_STEADY_STATE_SECS: u64 = 60;
+    // Boundary/jitter slack for the OBSERVED-sample check below: a run
+    // whose declared window is exactly the minimum can lose a bucket or
+    // two to mid-point boundary exclusion and sub-second interval
+    // alignment.
+    const STEADY_STATE_SAMPLE_SLACK_SECS: u64 = 5;
     if ss_dur < MIN_STEADY_STATE_SECS {
         return Err(format!(
             "steady-state window {ss_dur}s < {MIN_STEADY_STATE_SECS}s minimum; use a longer -t or reduce --warmup-secs/--final-burst-secs"
@@ -48,6 +54,13 @@ pub(crate) fn extract_window(
     let mut aggregate_buckets_bps: Vec<u64> = Vec::new();
 
     for interval in &iperf.intervals {
+        // Skip iperf3 `-O` omitted (warmup) intervals; they are not
+        // steady-state data (V-7). The harness does not pass -O today,
+        // but fairness-eval is a general CLI and must not fold omitted
+        // buckets into the CoV window.
+        if interval.sum.omitted {
+            continue;
+        }
         let mut iv_start = f64::INFINITY;
         let mut iv_end = f64::NEG_INFINITY;
         let mut iv_total_bps = 0.0_f64;
@@ -67,6 +80,21 @@ pub(crate) fn extract_window(
         aggregate_buckets_bps.push(iv_total_bps as u64);
     }
 
+    // Reject on OBSERVED sample coverage, not the self-reported duration
+    // (V-7). A truncated JSON that DECLARES a long run but carries only a
+    // handful of non-omitted intervals would otherwise pass the
+    // declared-duration gate above and produce a CoV from a few buckets.
+    // The contract requires such runs be rejected with an explicit error.
+    let observed_buckets = aggregate_buckets_bps.len() as u64;
+    if observed_buckets + STEADY_STATE_SAMPLE_SLACK_SECS < MIN_STEADY_STATE_SECS {
+        return Err(format!(
+            "observed {observed_buckets} in-window 1s buckets < {MIN_STEADY_STATE_SECS}s minimum \
+             (declared duration {total_dur}s, but the iperf JSON carries too few non-omitted \
+             intervals — truncated or heavily-omitted run); a meaningful CoV needs a full \
+             steady-state window"
+        ));
+    }
+
     // Per-stream window-mean throughput for the per-flow CoV input.
     let per_flow_throughputs: Vec<u64> = per_stream_buckets
         .values()
@@ -82,4 +110,77 @@ pub(crate) fn extract_window(
         aggregate_buckets_bps,
         per_flow_throughputs,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::inputs::{
+        Iperf3Interval, Iperf3IntervalSum, Iperf3Output, Iperf3Start, Iperf3StreamInterval,
+        Iperf3TestStart, Iperf3Timestamp,
+    };
+    use super::extract_window;
+
+    fn interval(socket: u64, start: f64, bps: f64, omitted: bool) -> Iperf3Interval {
+        Iperf3Interval {
+            streams: vec![Iperf3StreamInterval {
+                socket,
+                start,
+                end: start + 1.0,
+                bits_per_second: bps,
+            }],
+            sum: Iperf3IntervalSum { omitted },
+        }
+    }
+
+    fn output(duration: u64, intervals: Vec<Iperf3Interval>) -> Iperf3Output {
+        Iperf3Output {
+            start: Iperf3Start {
+                connected: vec![],
+                timestamp: Iperf3Timestamp { timesecs: 0 },
+                test_start: Iperf3TestStart {
+                    duration,
+                    num_streams: 1,
+                    reverse: 0,
+                },
+            },
+            intervals,
+            end: None,
+        }
+    }
+
+    #[test]
+    fn extract_window_skips_omitted_intervals() {
+        // V-7: 65 one-second intervals, first 5 flagged omitted. With
+        // warmup 0 / final-burst 0 all 65 mid-points fall in [0, 65), but
+        // the 5 omitted intervals must not contribute buckets — leaving
+        // exactly 60 steady-state buckets.
+        let mut intervals = Vec::new();
+        for i in 0..65u64 {
+            intervals.push(interval(5, i as f64, 1.0e9, i < 5));
+        }
+        let iperf = output(65, intervals);
+        let w = extract_window(&iperf, 0, 0).expect("window");
+        assert_eq!(
+            w.aggregate_buckets_bps.len(),
+            60,
+            "omitted intervals must be filtered from the steady-state window"
+        );
+    }
+
+    #[test]
+    fn extract_window_rejects_truncated_interval_set() {
+        // V-7: declared 120s clears the ss_dur>=60 declared gate, but
+        // only 10 non-omitted intervals are present → observed buckets
+        // far below the 60s minimum → explicit reject.
+        let mut intervals = Vec::new();
+        for i in 0..10u64 {
+            intervals.push(interval(5, i as f64, 1.0e9, false));
+        }
+        let iperf = output(120, intervals);
+        let err = extract_window(&iperf, 0, 0).expect_err("truncated run must be rejected");
+        assert!(
+            err.contains("buckets"),
+            "error must cite the observed bucket count: {err}"
+        );
+    }
 }

--- a/userspace-dp/src/fairness_eval/windowing.rs
+++ b/userspace-dp/src/fairness_eval/windowing.rs
@@ -6,7 +6,20 @@ use super::inputs::Iperf3Output;
 pub(crate) struct Window {
     pub(crate) per_stream_buckets: BTreeMap<u64, Vec<u64>>,
     pub(crate) aggregate_buckets_bps: Vec<u64>,
+    /// Per-stream window-mean throughput (bytes/sec) over the ACTIVE flow
+    /// set only — streams that produced no steady-state samples are
+    /// dropped. This feeds the observed-CoV / Gate-2 input, whose
+    /// contract is defined over the active flow set (a starved flow is
+    /// caught by Gate 1, not folded into the CoV).
     pub(crate) per_flow_throughputs: Vec<u64>,
+    /// Per-stream window-mean throughput (bytes/sec) over EVERY seeded
+    /// stream, mapping a stream absent from the steady window to 0. This
+    /// is the FULL iperf stream set (seeded from `start.connected[]`),
+    /// so the V-9 required per-flow quantiles + stream_count include
+    /// starved-at-0 flows rather than silently undercounting them — a
+    /// starved flow at 0 Mb/s is exactly the fairness violation a failing
+    /// run's per-flow distribution must surface.
+    pub(crate) per_flow_throughputs_all: Vec<u64>,
 }
 
 pub(crate) fn extract_window(
@@ -105,10 +118,27 @@ pub(crate) fn extract_window(
         })
         .collect();
 
+    // Full-stream-set variant for the V-9 required metric: every seeded
+    // stream contributes, with an empty (absent-from-window) stream
+    // counted as 0 rather than dropped. Mirrors the V-5 "absent == 0,
+    // don't drop" principle so the per-flow quantiles + stream_count
+    // reflect the true iperf stream set including starved flows.
+    let per_flow_throughputs_all: Vec<u64> = per_stream_buckets
+        .values()
+        .map(|v| {
+            if v.is_empty() {
+                0
+            } else {
+                v.iter().sum::<u64>() / v.len() as u64
+            }
+        })
+        .collect();
+
     Ok(Window {
         per_stream_buckets,
         aggregate_buckets_bps,
         per_flow_throughputs,
+        per_flow_throughputs_all,
     })
 }
 

--- a/userspace-dp/tests/fairness_eval_blackbox.rs
+++ b/userspace-dp/tests/fairness_eval_blackbox.rs
@@ -1062,6 +1062,147 @@ fn exit2_out_of_range_worker_id() {
     );
 }
 
+#[test]
+fn gate3_expect_saturation_below_cap_fails() {
+    let tmp = TempGuard::new("gate3_below");
+    // 6 balanced ~1 Gbps streams → aggregate ~6 Gbps. Structural cap =
+    // shaper_rate(20g) × Nₐ(6)/Nᵥ(6) = 20 Gbps → NOT saturated. Without
+    // --expect-saturation the aggregate leg is diagnostic and the run
+    // PASSes (V-3: previously unenforceable); with it, Gate 3 FAILs.
+    let (_sockets, json_str) = make_balanced_pass_inputs(6, 60);
+    let tsv_str = make_balanced_tsv(6, &timestamps_for(60), "ge-0-0-2");
+
+    // Diagnostic-only (no flag): PASS even below the cap.
+    let (diag_out, diag_v) = run_with_inputs(&tmp, &json_str, &tsv_str, &[
+        "--iface", "ge-0-0-2", "--n-workers", "6",
+        "--warmup-secs", "0", "--final-burst-secs", "0",
+        "--shaper-rate-bps", "20000000000",
+    ]);
+    assert_eq!(diag_out.status.code(), Some(0), "no flag → aggregate is diagnostic, run PASSes; stderr={}", String::from_utf8_lossy(&diag_out.stderr));
+    let diag = diag_v.expect("verdict JSON");
+    assert_eq!(diag["saturated"], false);
+    assert_eq!(diag["aggregate_throughput_gate_enforced"], false);
+
+    // Enforced: FAIL below the cap.
+    let (output, verdict) = run_with_inputs(&tmp, &json_str, &tsv_str, &[
+        "--iface", "ge-0-0-2", "--n-workers", "6",
+        "--warmup-secs", "0", "--final-burst-secs", "0",
+        "--shaper-rate-bps", "20000000000",
+        "--expect-saturation",
+    ]);
+    assert_eq!(output.status.code(), Some(1),
+        "expect-saturation below cap must FAIL Gate 3; stderr={}",
+        String::from_utf8_lossy(&output.stderr));
+    let v = verdict.expect("verdict JSON");
+    assert_eq!(v["verdict"], "FAIL");
+    assert_eq!(v["saturated"], false);
+    assert_eq!(v["aggregate_throughput_gate_enforced"], true);
+    let reasons = v["failure_reasons"].as_array().expect("failure_reasons array");
+    assert!(
+        reasons.iter().any(|r| r.as_str().unwrap_or("").contains("Gate 3")),
+        "must contain a Gate 3 aggregate-throughput reason; got: {reasons:?}"
+    );
+}
+
+#[test]
+fn gate3_expect_saturation_at_cap_passes() {
+    let tmp = TempGuard::new("gate3_at");
+    // Aggregate ~6 Gbps against a 6 Gbps scaled cap (>=95%) → saturated
+    // → Gate 3 PASSes even with --expect-saturation (not always-firing).
+    let (_sockets, json_str) = make_balanced_pass_inputs(6, 60);
+    let tsv_str = make_balanced_tsv(6, &timestamps_for(60), "ge-0-0-2");
+    let (output, verdict) = run_with_inputs(&tmp, &json_str, &tsv_str, &[
+        "--iface", "ge-0-0-2", "--n-workers", "6",
+        "--warmup-secs", "0", "--final-burst-secs", "0",
+        "--shaper-rate-bps", "6000000000",
+        "--expect-saturation",
+    ]);
+    assert_eq!(output.status.code(), Some(0),
+        "expect-saturation at cap must PASS; stderr={}",
+        String::from_utf8_lossy(&output.stderr));
+    let v = verdict.expect("verdict JSON");
+    assert_eq!(v["verdict"], "PASS");
+    assert_eq!(v["saturated"], true);
+    assert_eq!(v["aggregate_throughput_gate_enforced"], true);
+}
+
+#[test]
+fn truncated_intervals_below_min_window_rejected() {
+    let tmp = TempGuard::new("truncated_window");
+    // V-7: declared duration 120s clears the ss_dur>=60 declared gate,
+    // but only 10 one-second intervals are present. The reducer must
+    // reject on OBSERVED sample count (exit 2, explicit error), not
+    // produce a verdict from a handful of buckets.
+    let sockets: Vec<u64> = (5..11).collect();
+    let mut intervals = Vec::new();
+    for i in 0..10u64 {
+        let mut iv = Vec::new();
+        for &sock in &sockets {
+            iv.push(StreamSample { socket: sock, start: i as f64, end: i as f64 + 1.0, bits_per_second: 1.0e9 });
+        }
+        intervals.push(iv);
+    }
+    let json_str = synth_iperf3_json(120, &sockets, intervals);
+    let tsv_str = make_balanced_tsv(6, &timestamps_for(10), "ge-0-0-2");
+    let (output, _verdict) = run_with_inputs(&tmp, &json_str, &tsv_str, &[
+        "--iface", "ge-0-0-2", "--n-workers", "6",
+        "--warmup-secs", "0", "--final-burst-secs", "0",
+    ]);
+    assert_eq!(output.status.code(), Some(2),
+        "truncated interval set must be rejected with exit 2; stderr={}",
+        String::from_utf8_lossy(&output.stderr));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("buckets"),
+        "error must cite the observed bucket count: {stderr}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains('{'), "rejected run must not emit a verdict: {stdout}");
+}
+
+#[test]
+fn verdict_emits_doc_mandated_required_metrics() {
+    let tmp = TempGuard::new("required_metrics");
+    // V-9: per-flow quantiles (item 1), steady-state window timestamps
+    // (item 12), and the saturation time-series (item 6) must be in the
+    // routine verdict JSON.
+    let (_sockets, json_str) = make_balanced_pass_inputs(6, 60);
+    let tsv_str = make_balanced_tsv(6, &timestamps_for(60), "ge-0-0-2");
+    let (output, verdict) = run_with_inputs(&tmp, &json_str, &tsv_str, &[
+        "--iface", "ge-0-0-2", "--n-workers", "6",
+        "--warmup-secs", "0", "--final-burst-secs", "0",
+        "--shaper-rate-bps", "6000000000",
+    ]);
+    assert!(output.status.success(),
+        "required-metrics fixture must PASS; stderr={}",
+        String::from_utf8_lossy(&output.stderr));
+    let v = verdict.expect("verdict JSON");
+
+    // item 1: per-flow throughput quantiles + stream count.
+    let q = &v["per_flow_throughput_mbps"];
+    for k in ["stream_count", "min_mbps", "p25_mbps", "median_mbps", "p75_mbps", "max_mbps"] {
+        assert!(q.get(k).is_some(), "per_flow_throughput_mbps.{k} missing: {v}");
+    }
+    assert_eq!(q["stream_count"], 6);
+    assert!(q["median_mbps"].as_f64().unwrap() > 0.0, "median must be >0: {v}");
+    assert!(q["max_mbps"].as_f64().unwrap() >= q["min_mbps"].as_f64().unwrap());
+
+    // item 12: steady-state window timestamps.
+    let w = &v["steady_state_window"];
+    for k in ["iperf_epoch_start", "iperf_epoch_end", "relative_start_sec", "relative_end_sec"] {
+        assert!(w.get(k).is_some(), "steady_state_window.{k} missing: {v}");
+    }
+    assert_eq!(w["relative_start_sec"].as_f64(), Some(0.0));
+    assert_eq!(w["relative_end_sec"].as_f64(), Some(60.0));
+
+    // item 6: saturation determination time-series.
+    let ss = &v["saturation_series"];
+    assert!(ss["aggregate_buckets_bps"].is_array(), "aggregate_buckets_bps must be array: {v}");
+    assert_eq!(ss["aggregate_buckets_bps"].as_array().unwrap().len(), 60,
+        "one bucket per steady-state second");
+    assert!(ss.get("structural_cap_bps").is_some());
+    assert!(ss.get("saturated_bucket_fraction").is_some());
+    assert_eq!(v["aggregate_throughput_gate_enforced"], false);
+}
+
 // ---------------------------------------------------------------------------
 // Shared input builders.
 // ---------------------------------------------------------------------------

--- a/userspace-dp/tests/fairness_eval_blackbox.rs
+++ b/userspace-dp/tests/fairness_eval_blackbox.rs
@@ -1203,6 +1203,87 @@ fn verdict_emits_doc_mandated_required_metrics() {
     assert_eq!(v["aggregate_throughput_gate_enforced"], false);
 }
 
+#[test]
+fn per_flow_metric_includes_starved_zero_streams() {
+    let tmp = TempGuard::new("starved_metric");
+    // Copilot #1 (V-9 accuracy): 6 connected streams, but socket 10
+    // never appears in any interval → it produced no steady-state
+    // throughput (starved). The per_flow_throughput_mbps metric must
+    // count all 6 streams with the starved one at 0 Mb/s, NOT drop it.
+    let sockets = [5u64, 6, 7, 8, 9, 10];
+    let mut intervals: Vec<Vec<StreamSample>> = Vec::new();
+    for i in 0..60u64 {
+        let mut iv = Vec::new();
+        // Only the first 5 sockets send; socket 10 is absent from every
+        // interval → empty bucket vec → starved.
+        for &sock in &sockets[..5] {
+            iv.push(StreamSample {
+                socket: sock,
+                start: i as f64,
+                end: i as f64 + 1.0,
+                bits_per_second: 1.0e9,
+            });
+        }
+        intervals.push(iv);
+    }
+    let json_str = synth_iperf3_json(60, &sockets, intervals);
+    let tsv_str = make_balanced_tsv(6, &timestamps_for(60), "ge-0-0-2");
+    let (_output, verdict) = run_with_inputs(&tmp, &json_str, &tsv_str, &[
+        "--iface", "ge-0-0-2", "--n-workers", "6",
+        "--warmup-secs", "0", "--final-burst-secs", "0",
+    ]);
+    // Gate 1 fails on the starved stream, but the verdict JSON is still
+    // emitted on exit 1.
+    let v = verdict.expect("verdict JSON");
+    assert_eq!(v["starved_flow_count"], 1, "socket 10 must be starved: {v}");
+    let q = &v["per_flow_throughput_mbps"];
+    assert_eq!(
+        q["stream_count"], 6,
+        "starved stream must be counted, not dropped: {v}"
+    );
+    assert_eq!(
+        q["min_mbps"].as_f64(),
+        Some(0.0),
+        "starved stream contributes 0 Mb/s to the quantiles: {v}"
+    );
+    assert!(
+        q["max_mbps"].as_f64().unwrap() > 0.0,
+        "live streams still contribute >0: {v}"
+    );
+}
+
+#[test]
+fn expect_saturation_without_shaper_rate_is_arg_error() {
+    let tmp = TempGuard::new("expect_sat_no_shaper");
+    // Copilot #2: --expect-saturation without --shaper-rate-bps is an
+    // operator CLI mistake → arg-validation error (exit 2), NOT a Gate-3
+    // FAIL (exit 1) that automation would misread as a fairness
+    // regression.
+    let (_sockets, json_str) = make_balanced_pass_inputs(6, 60);
+    let tsv_str = make_balanced_tsv(6, &timestamps_for(60), "ge-0-0-2");
+    let (output, _verdict) = run_with_inputs(&tmp, &json_str, &tsv_str, &[
+        "--iface", "ge-0-0-2", "--n-workers", "6",
+        "--warmup-secs", "0", "--final-burst-secs", "0",
+        "--expect-saturation",
+    ]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "expect-saturation without --shaper-rate-bps must be an arg error (exit 2); stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("shaper-rate"),
+        "stderr must explain the missing --shaper-rate-bps: {stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains('{'),
+        "arg error must not emit a verdict: {stdout}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Shared input builders.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4273 Closes #4274 Closes #4275 Closes #4276 Closes #4277 Closes #4278

Six fable-review-166 accuracy bugs in the `fairness_eval` REDUCER — the
Rust SSOT (`userspace-dp/src/fairness_eval/`) that computes the CoS
fairness contract verdict. A reducer bug means the contract is
mis-evaluated, so each is a correctness fix, not cosmetics. Reducer /
harness only — no dataplane path is touched, so no cluster smoke is
needed (this changes how the verdict is COMPUTED, not how packets are
forwarded).

## Fixes

- **V-3 (#4273) — Gate 3 was vacuous.** The saturation LABEL and the
  aggregate-throughput gate used the same `is_saturated()` predicate, and
  `saturated` was report-only, never referenced in a failure reason — so
  a run below the cap was labeled non-saturated and exempted, and no run
  could FAIL on aggregate. New operator declaration `--expect-saturation`
  breaks the circularity: it asserts offered load >= the structural cap
  (an input observed data cannot launder), so the observed aggregate is
  then REQUIRED to reach >=95% of the Na/Nv-scaled cap for >=80% of
  buckets, else Gate 3 fails. The label stays report-only; the verdict
  reports `aggregate_throughput_gate_enforced`. **Design note:** the
  non-shaped "±5% of measured baseline" clause needs a baseline-artifact
  input and is deferred (noted in the doc + issue); the shaped
  `--expect-saturation` leg is the enforceable part shipped here.
- **V-4 (#4274) — overcount trim could LOOSEN Gate 2.** The a_i trim
  removes flows from the LARGEST bucket, which for an evenly-loaded
  overcount RAISES Cstruct and widens the allowed CoV (fail-open). The
  verdict now gates on `min(Cstruct_raw, Cstruct_trimmed)` (fail-closed).
  Legit #1281 stale-overcount cases (trim LOWERS Cstruct) still
  normalize. Careful not to interact with V-3: `n_active` (hence the
  Gate-3 cap) is computed from the raw distribution, untouched by the
  trim.
- **V-5 (#4275) — CoS medians ignored absent (zero) samples.** The CoS
  exporter emits rows only for live flows; the reducer medianed over
  present samples, so a worker whose flows died mid-window stayed
  "active". Now zero-fills each worker across the in-window scrape
  universe before the median (a no-op for the already-zero-filling
  binding source; a whole missing scrape is not fabricated into zeros).
- **V-6 (#4276) — window anchored to scrape-file extent.** The per-worker
  aggregation used the scrape file's min/max timestamp, letting stale
  pre-run/cooldown scrapes leak in. Now anchored to the iperf run epoch
  (`start.timestamp.timesecs` + warmup/-final_burst); falls back to
  min/max only when `timesecs` is absent.
- **V-7 (#4277) — 60s minimum checked declared duration.** The
  steady-state minimum gated on the self-reported iperf `duration`, so a
  truncated JSON declaring a long run passed. Now rejects on the observed
  non-omitted 1-second bucket count with an explicit error, and filters
  iperf `-O` omitted intervals.
- **V-9 (#4278) — verdict omitted required metrics.** Report now emits
  `per_flow_throughput_mbps` (item 1), `steady_state_window` (item 12),
  and `saturation_series` (item 6), so a routine verdict satisfies the
  MUST list without a separate artifact dump.

## Validation

- FULL `cargo test --release` green: fairness-eval bin 54, lib 3562,
  black-box 20, other targets 8/1 — 0 failed.
- RED-on-revert demonstrated for every fix: neutralizing each fix's core
  logic turns exactly its unit/black-box test(s) red (9 tests total)
  while all pre-existing tests stay green.
- `docs/fairness-regimes.md` updated for the corrected gate/window/median
  semantics (Gate 3 enforcement decoupled from the label; epoch-anchored
  window; zero-fill median; observed-sample minimum; emitted required
  metrics). `_Log.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
