### PR TITLE
cos: #4272 div_ceil .max(1) hardening + fable-166 R-10 CoS test-coverage gaps

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,37 @@
+## 2026-07-05 — cos: #4272 div_ceil .max(1) hardening + fable-166 R-10 CoS test-coverage gaps (#4280)
+
+- **Timestamp**: 2026-07-05
+  - **Action**: #4272 — extracted `flow_share_div_ceil(buffer_limit,
+    prospective_active)` helper that guards the divisor with `.max(1)` and
+    routed BOTH flow-share div_ceil sites through it (the shared_exact
+    rate-aware cap already inlined `.max(1)`; the owner-local legacy cap
+    divided by the raw count — a latent divide-by-zero if a future caller
+    reached it with 0; `cos_queue_prospective_active_flows` already clamps
+    to >=1 so it is unreachable today). Added
+    `flow_share_div_ceil_zero_divisor_is_panic_free` (admission_tests.rs) —
+    RED-on-revert: dropping `.max(1)` panics "attempt to divide by zero"
+    (verified).
+  - **Action**: fable-166 R-10 (#4280) — enumerated the consolidated CoS
+    test-coverage gaps, verified which the merged fable-166 wave already
+    covers (R-1/R-2/R-3/R-4-refill/R-5b/R-7/bucket-reuse-EWMA/FlowRrRing-
+    wrap/timer-cascade/demotion) and added tests for the 3 still-open
+    paths: (1) `apply_cos_send_result` / `apply_cos_prepared_result` with a
+    NON-empty retry deque (batch-vs-retry queued_bytes reconciliation —
+    every prior test passed an empty deque); (2) the `flow_fair &&
+    shared_exact` ECN aggregate arm (#785 Phase 3, previously only the
+    owner-local per-flow arm was tested); (3) `cos_refill_ns_until` direct
+    unit test (all 3 branches + div_ceil rounding). Deferred the two R-10
+    owner cross-checks (binding.live.tx bump; dehydrate counterpart) as
+    behavior/design work, out of scope for a test-only PR.
+  - **File(s)**: userspace-dp/src/afxdp/cos/admission.rs,
+    userspace-dp/src/afxdp/cos/admission_tests.rs,
+    userspace-dp/src/afxdp/cos/token_bucket_tests.rs,
+    userspace-dp/src/afxdp/cos/tx_completion_tests.rs, _Log.md
+  - **Validation**: FULL `cargo test --release --bins --tests
+    -- --test-threads=1` green (main bin 3572 passed / 0 failed / 2
+    ignored; all other bins pass). 5 new tests pass; #4272 fix verified
+    RED-on-revert.
+
 ## 2026-07-05 — cos: fable-166 R-8 LOW fixes + R-9 false-sharing/alloc perf (#4269, #4270)
 
 - **Timestamp**: 2026-07-05

--- a/userspace-dp/src/afxdp/cos/admission.rs
+++ b/userspace-dp/src/afxdp/cos/admission.rs
@@ -154,6 +154,24 @@ fn clamp_flow_share_to_buffer(value: u64, buffer_limit: u64) -> u64 {
     value.clamp(floor, buffer_limit)
 }
 
+/// #4272: per-flow fair share = `buffer_limit.div_ceil(prospective_active)`
+/// with a defensive `.max(1)` on the divisor.
+///
+/// `cos_queue_prospective_active_flows` already clamps its result to
+/// `>= 1` (`flow_hash.rs`), so `prospective_active` is `>= 1` on every
+/// real call path and the `.max(1)` here is currently unreachable
+/// headroom. But `u64::div_ceil(0)` panics, so both flow-share div_ceil
+/// sites — the shared_exact rate-aware cap AND the owner-local legacy
+/// cap — must funnel through one guarded helper. Previously only the
+/// shared_exact site inlined `prospective.max(1)`; the owner-local site
+/// divided by the raw count, an asymmetry that would panic if a future
+/// caller ever reached it with 0. Centralizing removes that latent
+/// hazard and keeps the two paths bit-identical.
+#[inline]
+fn flow_share_div_ceil(buffer_limit: u64, prospective_active: u64) -> u64 {
+    buffer_limit.div_ceil(prospective_active.max(1))
+}
+
 #[inline]
 pub(in crate::afxdp) fn cos_queue_flow_share_limit(
     queue: &CoSQueueRuntime,
@@ -201,7 +219,7 @@ pub(in crate::afxdp) fn cos_queue_flow_share_limit(
         // `buffer_limit` is not divisible by `prospective`, increasing
         // boundary-condition tail-drops. The legacy path picked
         // div_ceil for that reason; shared_exact should follow.
-        let fair_share = buffer_limit.div_ceil(prospective.max(1));
+        let fair_share = flow_share_div_ceil(buffer_limit, prospective);
         let bdp = bdp_floor_bytes(queue.transmit_rate_bytes(), prospective);
         return clamp_flow_share_to_buffer(
             fair_share
@@ -211,7 +229,10 @@ pub(in crate::afxdp) fn cos_queue_flow_share_limit(
         );
     }
     let prospective_active = cos_queue_prospective_active_flows(queue, flow_bucket);
-    clamp_flow_share_to_buffer(buffer_limit.div_ceil(prospective_active), buffer_limit)
+    clamp_flow_share_to_buffer(
+        flow_share_div_ceil(buffer_limit, prospective_active),
+        buffer_limit,
+    )
 }
 
 /// Effective buffer cap for the admission check. Grows with the

--- a/userspace-dp/src/afxdp/cos/admission_tests.rs
+++ b/userspace-dp/src/afxdp/cos/admission_tests.rs
@@ -62,6 +62,36 @@ fn flow_share_limit_shared_exact_scales_with_rate() {
     );
 }
 
+/// #4272: both flow-share `div_ceil` paths (the shared_exact
+/// rate-aware cap and the owner-local legacy cap) route through
+/// `flow_share_div_ceil`, which guards the divisor with `.max(1)`.
+/// `cos_queue_prospective_active_flows` already clamps its result to
+/// `>= 1`, so a 0 divisor is unreachable on every real call path — but
+/// `u64::div_ceil(0)` panics, so the guard lives at the arithmetic
+/// itself, not only at the caller. Before this change the owner-local
+/// path divided by the raw count while shared_exact inlined `.max(1)`,
+/// an asymmetry that would panic if a future caller reached the
+/// owner-local site with 0.
+///
+/// RED-on-revert: drop the `.max(1)` inside `flow_share_div_ceil` and
+/// the first assertion panics with "attempt to divide by zero".
+#[test]
+fn flow_share_div_ceil_zero_divisor_is_panic_free() {
+    // A 0 divisor degenerates to div_ceil-by-1 == buffer_limit, never a
+    // panic. This is the defensive branch the .max(1) exists for.
+    assert_eq!(flow_share_div_ceil(96_000, 0), 96_000);
+    assert_eq!(flow_share_div_ceil(0, 0), 0);
+    // Non-zero divisors are unaffected by the guard — the .max(1) is a
+    // no-op once the count is already >= 1, so the helper equals a plain
+    // div_ceil.
+    assert_eq!(flow_share_div_ceil(96_000, 6), 96_000u64.div_ceil(6));
+    assert_eq!(flow_share_div_ceil(100_001, 7), 100_001u64.div_ceil(7));
+    // Rounding is UP, matching the legacy owner-local path's original
+    // choice (a divisor that does not evenly divide rounds up, never
+    // down — the #4272 consistency goal for the two unified sites).
+    assert_eq!(flow_share_div_ceil(10, 3), 4);
+}
+
 /// #914: at low N, `bdp_floor` exceeds `buffer_limit`; the formula
 /// must clamp to buffer_limit and degenerate to today's behavior
 /// rather than capping below per-flow BDP (which would collapse

--- a/userspace-dp/src/afxdp/cos/admission_tests.rs
+++ b/userspace-dp/src/afxdp/cos/admission_tests.rs
@@ -569,6 +569,74 @@ fn admission_ecn_does_not_mark_when_both_thresholds_below() {
     }
 }
 
+/// hb166 R-10: the `flow_fair && shared_exact` ECN branch (#785 Phase 3)
+/// was untested — both existing ECN policy tests exercise only the
+/// owner-local `flow_fair && !shared_exact` per-flow arm. A shared_exact
+/// queue uses the AGGREGATE arm: per-flow fairness is enforced by MQFQ
+/// virtual-finish-time ordering in the dequeue path, so per-flow ECN on
+/// top would double-signal a throttled flow. This test drives the exact
+/// state the owner-local sibling
+/// (`admission_ecn_does_not_mark_when_only_aggregate_above_threshold`)
+/// asserts must NOT mark — aggregate strictly above, per-flow strictly
+/// below — and asserts the shared_exact queue DOES mark. That contrast
+/// pins the branch: if the `should_mark` selector ever routes
+/// shared_exact through the per-flow arm, this flips to `!marked`.
+#[test]
+fn admission_ecn_shared_exact_marks_on_aggregate_arm() {
+    let mut root = test_flow_fair_exact_queue_16_flows();
+    let queue = &mut root.queues[0];
+    // Flip to the #785 Phase 3 branch (flow_fair stays on via the
+    // fixture's flow_fair_state; shared_exact is a config-read accessor).
+    queue.config.shared_exact = true;
+    assert!(
+        queue.flow_fair() && queue.shared_exact(),
+        "fixture must be on the flow_fair && shared_exact branch",
+    );
+    let target = 0usize;
+
+    // Per-flow bucket well BELOW its threshold, aggregate strictly ABOVE
+    // — the ONE state where the owner-local per-flow arm stays silent, so
+    // a mark here can only come from the aggregate arm.
+    let target_bucket_bytes = 500;
+    let _ = seed_sixteen_flow_buckets(queue, target, target_bucket_bytes);
+    let buffer_limit = cos_flow_aware_buffer_limit(queue, target);
+    let share_cap = cos_queue_flow_share_limit(queue, buffer_limit, target);
+    let aggregate_ecn_threshold =
+        buffer_limit.saturating_mul(COS_ECN_MARK_THRESHOLD_NUM) / COS_ECN_MARK_THRESHOLD_DEN;
+    let flow_ecn_threshold =
+        share_cap.saturating_mul(COS_ECN_MARK_THRESHOLD_NUM) / COS_ECN_MARK_THRESHOLD_DEN;
+    queue.hot.queued_bytes = aggregate_ecn_threshold + 1; // strictly above
+    assert!(queue.hot.queued_bytes > aggregate_ecn_threshold);
+    assert!(
+        test_flow_fair_state(queue).flow_bucket_bytes[target] <= flow_ecn_threshold,
+        "per-flow bucket must be below its threshold so only the aggregate arm can fire",
+    );
+
+    let before = snapshot_counters(queue);
+    let mut item = test_local_ipv4_item(ECN_ECT_0);
+    let umem = test_admission_umem();
+    let marked =
+        apply_cos_admission_ecn_policy(queue, buffer_limit, target, false, false, &mut item, &umem);
+
+    assert!(
+        marked,
+        "#785 Phase 3: a shared_exact queue MUST mark on the aggregate arm \
+         even when the per-flow bucket is below threshold (the owner-local \
+         queue would NOT mark on this exact state)",
+    );
+    let after = snapshot_counters(queue);
+    assert_eq!(
+        after.admission_ecn_marked,
+        before.admission_ecn_marked + 1,
+        "ECN counter must advance by exactly 1",
+    );
+    if let CoSPendingTxItem::Local(req) = &item {
+        assert_eq!(req.bytes[15] & ECN_MASK, ECN_CE, "CE bit must be set");
+    } else {
+        panic!("item must stay Local variant");
+    }
+}
+
 #[test]
 fn admission_ecn_does_not_mark_when_flow_share_already_exceeded() {
     // Per-flow above threshold BUT the caller has also decided the

--- a/userspace-dp/src/afxdp/cos/token_bucket_tests.rs
+++ b/userspace-dp/src/afxdp/cos/token_bucket_tests.rs
@@ -587,3 +587,32 @@ fn refill_cos_tokens_carries_fractional_dust_for_low_rate_class() {
         1_000_000_000 / RATE_BYTES_PER_SEC,
     );
 }
+
+/// hb166 R-10 / R-4: `cos_refill_ns_until` had no direct unit test — it
+/// was exercised only transitively through the wakeup-tick estimator.
+/// Pin all three branches plus the div_ceil rounding: the wait math
+/// must round UP so the caller never wakes one tick early with the
+/// bucket still short of `need`.
+#[test]
+fn cos_refill_ns_until_covers_all_branches() {
+    // Branch 1 — already have `need` tokens: zero wait, regardless of rate.
+    assert_eq!(cos_refill_ns_until(1_500, 1_500, 1_000_000), Some(0));
+    assert_eq!(cos_refill_ns_until(3_000, 1_500, 1_000_000), Some(0));
+    // The token-sufficiency check precedes the rate check, so a rate of 0
+    // with enough tokens is still Some(0), NOT None.
+    assert_eq!(cos_refill_ns_until(10, 10, 0), Some(0));
+
+    // Branch 2 — unshaped (rate 0) and short: never refills.
+    assert_eq!(cos_refill_ns_until(0, 1_500, 0), None);
+    assert_eq!(cos_refill_ns_until(500, 1_500, 0), None);
+
+    // Branch 3 — wait = ceil(deficit * 1e9 / rate).
+    // Exact division: deficit 1000 B at 1_000_000 B/s = 1_000_000 ns.
+    assert_eq!(cos_refill_ns_until(500, 1_500, 1_000_000), Some(1_000_000));
+    // Non-divisible: deficit 1 B at 3 B/s = 1e9 / 3 = 333_333_333.33 ns.
+    // RED-on-revert if div_ceil is swapped for truncating division
+    // (which yields 333_333_333, waking a tick early with the bucket
+    // still one byte short).
+    assert_eq!(cos_refill_ns_until(0, 1, 3), Some(333_333_334));
+    assert_eq!(cos_refill_ns_until(0, 2, 3), Some(666_666_667));
+}

--- a/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
@@ -4,6 +4,7 @@
 // `#[path = "tx_completion_tests.rs"]` from tx_completion.rs.
 
 use super::*;
+use crate::afxdp::PROTO_TCP;
 use crate::afxdp::TX_BATCH_SIZE;
 use crate::afxdp::cos::queue_service::{
     select_cos_guarantee_batch, select_exact_cos_guarantee_queue_with_fast_path,
@@ -12,7 +13,7 @@ use crate::afxdp::cos::token_bucket::COS_MIN_BURST_BYTES;
 use crate::afxdp::tx::test_support::*;
 use crate::afxdp::types::{
     COS_FLOW_FAIR_BUCKETS, CoSQueueDropCounters, CoSQueueOwnerProfile, CoSQueueWaterfillCounters,
-    FlowRrRing, SharedCoSExactBacklog, SharedCoSQueueLease,
+    FlowRrRing, PreparedTxRecycle, SharedCoSExactBacklog, SharedCoSQueueLease,
 };
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -507,6 +508,162 @@ fn apply_cos_prepared_result_debits_shared_residual_surplus_budget() {
         after,
         before - 1500,
         "non-exact surplus prepared send must debit the shared residual budget, not a per-worker bucket"
+    );
+}
+
+/// hb166 R-10: every prior `apply_cos_send_result` test passed an EMPTY
+/// retry deque, so the batch-vs-retry `queued_bytes` reconciliation —
+/// `queued_bytes.saturating_sub(batch_bytes).saturating_add(retry_bytes)`
+/// — was never exercised for a non-zero `retry_bytes`. A partial-commit
+/// retry pushes the unsent tail back onto the queue; those bytes must be
+/// re-added or the queue undercounts its backlog and can settle to a
+/// false-empty demotion. This drives a real non-empty retry and pins
+/// the add-back.
+///
+/// RED-on-revert: drop the `.saturating_add(retry_bytes)` and the
+/// queued_bytes assertion fails (9000 instead of 10500), and the
+/// items-restored assertion fails.
+#[test]
+fn apply_cos_send_result_nonempty_retry_readds_restored_bytes() {
+    let root = test_mixed_class_root_with_primed_queues();
+    // Queue 1 is non-exact, primed with 8 × 1500 = 12000 queued bytes.
+    let queue_idx = 1;
+    let initial_queued = 8 * 1500u64;
+    assert_eq!(root.queues[queue_idx].hot.queued_bytes, initial_queued);
+
+    let fast_interfaces = test_cos_fast_interfaces(
+        42,
+        42,
+        0,
+        vec![
+            (0, test_queue_fast_path(false, 0, None, None)),
+            (1, test_queue_fast_path(false, 0, None, None)),
+            (2, test_queue_fast_path(false, 0, None, None)),
+            (3, test_queue_fast_path(false, 0, None, None)),
+        ],
+        None,
+        None,
+    );
+    let fast_path = fast_interfaces.get(&42).expect("test fast path").clone();
+    let mut binding = BindingWorker::new_for_cos_drain_test(0, 0, 42, root, fast_path);
+
+    let items_before = binding.cos.cos_interfaces.get(&42).unwrap().queues[queue_idx]
+        .hot
+        .items
+        .len();
+
+    // Drain a 3000-byte batch, then retry one 1500-byte item back.
+    let batch_bytes = 3000u64;
+    let retry = std::collections::VecDeque::from([TxRequest {
+        bytes: vec![0u8; 1500],
+        expected_ports: None,
+        expected_addr_family: libc::AF_INET as u8,
+        expected_protocol: PROTO_TCP,
+        flow_key: None,
+        egress_ifindex: 80,
+        cos_queue_id: Some(1),
+        dscp_rewrite: None,
+        mirror_clone: false,
+        enqueue_ns: 0,
+    }]);
+    apply_cos_send_result(
+        &mut binding,
+        42,
+        queue_idx,
+        CoSServicePhase::Surplus,
+        batch_bytes,
+        1500,
+        retry,
+    );
+
+    let queue = &binding.cos.cos_interfaces.get(&42).unwrap().queues[queue_idx];
+    // 12000 − 3000 (batch drained) + 1500 (retry restored) = 10500.
+    assert_eq!(
+        queue.hot.queued_bytes,
+        initial_queued - batch_bytes + 1500,
+        "queued_bytes must subtract the drained batch AND re-add the retried bytes",
+    );
+    assert_ne!(
+        queue.hot.queued_bytes,
+        initial_queued - batch_bytes,
+        "if the retry_bytes add-back were dropped, queued_bytes would be 9000",
+    );
+    assert_eq!(
+        queue.hot.items.len(),
+        items_before + 1,
+        "the retried item must be restored onto the queue",
+    );
+}
+
+/// hb166 R-10: the prepared (zero-copy UMEM) sibling of
+/// `apply_cos_send_result_nonempty_retry_readds_restored_bytes`. Same
+/// batch-vs-retry `queued_bytes` reconciliation, same empty-deque gap in
+/// the prior tests. `restore_cos_prepared_items_inner` sums `len` for
+/// the retry byte count, so a single 1500-byte prepared request adds
+/// 1500 back.
+#[test]
+fn apply_cos_prepared_result_nonempty_retry_readds_restored_bytes() {
+    let root = test_mixed_class_root_with_primed_queues();
+    let queue_idx = 1;
+    let initial_queued = 8 * 1500u64;
+    assert_eq!(root.queues[queue_idx].hot.queued_bytes, initial_queued);
+
+    let fast_interfaces = test_cos_fast_interfaces(
+        42,
+        42,
+        0,
+        vec![
+            (0, test_queue_fast_path(false, 0, None, None)),
+            (1, test_queue_fast_path(false, 0, None, None)),
+            (2, test_queue_fast_path(false, 0, None, None)),
+            (3, test_queue_fast_path(false, 0, None, None)),
+        ],
+        None,
+        None,
+    );
+    let fast_path = fast_interfaces.get(&42).expect("test fast path").clone();
+    let mut binding = BindingWorker::new_for_cos_drain_test(0, 0, 42, root, fast_path);
+
+    let items_before = binding.cos.cos_interfaces.get(&42).unwrap().queues[queue_idx]
+        .hot
+        .items
+        .len();
+
+    let batch_bytes = 3000u64;
+    let retry = std::collections::VecDeque::from([PreparedTxRequest {
+        offset: 64,
+        len: 1500,
+        recycle: PreparedTxRecycle::FreeTxFrame,
+        expected_ports: None,
+        expected_addr_family: libc::AF_INET as u8,
+        expected_protocol: PROTO_TCP,
+        flow_key: None,
+        egress_ifindex: 80,
+        cos_queue_id: Some(1),
+        dscp_rewrite: None,
+        mirror_clone: false,
+        enqueue_ns: 0,
+    }]);
+    apply_cos_prepared_result(
+        &mut binding,
+        42,
+        queue_idx,
+        CoSServicePhase::Surplus,
+        batch_bytes,
+        1500,
+        retry,
+    );
+
+    let queue = &binding.cos.cos_interfaces.get(&42).unwrap().queues[queue_idx];
+    assert_eq!(
+        queue.hot.queued_bytes,
+        initial_queued - batch_bytes + 1500,
+        "prepared path must subtract the drained batch AND re-add the retried bytes",
+    );
+    assert_eq!(
+        queue.hot.items.len(),
+        items_before + 1,
+        "the retried prepared item must be restored onto the queue",
     );
 }
 


### PR DESCRIPTION
Two small, low-risk CoS changes in one PR: a 1-line defensive hardening
and a set of test-coverage additions. No behavior change on any live
call path.

## #4272 — non-shared_exact flow-share div_ceil `.max(1)`

`cos_queue_flow_share_limit` had two per-flow `div_ceil` sites: the
shared_exact rate-aware cap guarded its divisor with `.max(1)`, the
owner-local legacy cap divided by the raw count. `cos_queue_prospective_
active_flows` already clamps to `>= 1`, so the 0 case is unreachable
today — but `u64::div_ceil(0)` panics, so the asymmetry is a latent
hazard. Extracted `flow_share_div_ceil(buffer_limit, prospective_active)`
that applies the guard and routed both sites through it (bit-identical
for every divisor `>= 1`).

- `admission.rs`: new `flow_share_div_ceil` helper; both call sites use it.
- Test `flow_share_div_ceil_zero_divisor_is_panic_free` — RED-on-revert:
  removing `.max(1)` panics "attempt to divide by zero" (verified).

## fable-166 R-10 — CoS-core test-coverage gaps

Enumerated the consolidated R-10 gaps and verified which the merged
fable-166 wave already covers (R-1/R-2/R-3/R-4-refill/R-5b/R-7/
bucket-reuse-EWMA/FlowRrRing-wrap/timer-cascade/demotion). Added tests
for the 3 still-open paths R-10 names:

1. `apply_cos_send_result` / `apply_cos_prepared_result` with a NON-empty
   retry deque — the batch-vs-retry `queued_bytes` reconciliation was
   never exercised (every prior test passed an empty deque).
2. The `flow_fair && shared_exact` ECN aggregate arm (#785 Phase 3) —
   previously only the owner-local per-flow arm was tested.
3. `cos_refill_ns_until` direct unit test — all 3 branches + div_ceil
   rounding.

The two R-10 owner cross-checks (`binding.live.tx_packets/tx_bytes` bump;
`dehydrate` counterpart) are behavior/design questions, tracked in #4280
for separate follow-up — out of scope for this test-only change.

## Validation

FULL `cargo test --release --bins --tests -- --test-threads=1` green:
main bin **3572 passed / 0 failed / 2 ignored**, all other bins pass.
5 new tests pass; #4272 fix verified RED-on-revert. rustfmt: touched
lines match the file's hand-formatted style (crate baseline is not
fmt-clean; no whole-crate `cargo fmt`).

Closes #4272
Closes #4280

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi