### PR TITLE
cos: TX-path LOW cluster + stats-that-lie counter fixes (fable-166 T-7)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -35257,3 +35257,28 @@ top.
   userspace-dp/src/afxdp/cos/queue_service/{mod,tests}.rs,
   userspace-dp/src/afxdp/tx/dispatch/{mod,cos,dispatch_tests}.rs,
   userspace-dp/src/afxdp/cos/README.md, _Log.md
+
+## 2026-07-05 — fable-166 T-7 hostile-review fold (M1 doc + M2 dead field)
+
+- **Timestamp**: 2026-07-05
+- **Action**: Folded the two non-blocking MINOR items from the PR #4284
+  hostile review (MERGE-NEEDS-MINOR).
+    - **M2**: removed `PendingForwardRequest.filter_match_extra` — the #8
+      dead-path deletion left it write-only (sole reader was the deleted
+      `resolve_pending_forward_cos_tx_selection`). Removed the field def,
+      all 4 population sites (forward_request.rs, icmp.rs,
+      poll_descriptor/mod.rs, dispatch_tests.rs), and the now-pointless
+      per-forwarded-packet `term_match_extra_from_frame(..).to_static()`
+      snapshot. Confirmed zero `.filter_match_extra` read access; the
+      poll_descriptor:3922 local of the same name is the unrelated
+      flow-cache-log arg to `evaluate_non_pbr_input_filter_log_only`.
+    - **M1**: corrected 2 stale refs in `src/filter/README.md` to the
+      deleted symbol/field, including the affirmatively-false "reject bit
+      available there for a future wiring" claim.
+- **Validation**: cargo build --release clean; FULL cargo test --release
+  (--test-threads=1) 0 failed (3578+54+8+22+1).
+- **File(s)**: userspace-dp/src/afxdp/types/tx.rs,
+  userspace-dp/src/afxdp/forward_request.rs, userspace-dp/src/afxdp/icmp.rs,
+  userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs,
+  userspace-dp/src/filter/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -35219,3 +35219,41 @@ top.
   userspace-dp/tests/fixtures/protocol_wire_v1.json,
   pkg/dataplane/userspace/protocol.go,
   docs/fairness-regimes.md, _Log.md
+
+## 2026-07-05 — fable-166 T-7 (TX-path LOW cluster + stats-that-lie) + R-6 re-verify
+
+- **Timestamp**: 2026-07-05
+- **Action**: Drove fable-166 T-7 grouped LOW cluster — fixed 8 READY
+  sub-items, deferred the design ones, plus re-verified R-6 (confirmed
+  NOT-MATERIAL). Branch `fix/hb166-t7-low-cluster`.
+- **Fixes (each with a RED-on-revert test)**:
+    - head-finish u64::MAX sentinel: `cos_queue_min_finish_bucket[_no_cap]`
+      gate on `is_none()` so a saturated head-finish bucket stays
+      selectable (distinct from R-8(b)/#4271 vtime sentinel).
+    - snapshot-push-before-fallible-pop: reorder pop before snapshot push
+      in `cos_queue_pop_known_bucket_inner` (avoid release-mode panic).
+    - keyless SFQ bucket: reserve a dedicated keyless lane; steer real
+      flows off it (`cos_flow_bucket_index`).
+    - pcp fail-closed: `resolve_cos_ieee8021_classifier_queue_id` returns
+      None for pcp>7 instead of `.min(7)` clamp (#2447 posture).
+    - unknown scheduler priority fail-closed: `cos_priority_rank` → Option,
+      new `SnapshotIntegrityError::CosUnknownSchedulerPriority` (#2458
+      mirror).
+    - buffer_bytes N× inflation: MAX not SUM across worker instances
+      (worker + coordinator folds).
+    - defensive None arms leak: 2 flow-fair local scratch None arms recycle
+      free_tx_frames offsets (queue_service).
+    - dead deferred-CoS dispatch path deletion (dispatch/mod.rs + cos.rs +
+      test), carrying 2 latent bugs.
+- **R-6**: confirmed NOT-MATERIAL — shared-consume bounds the long-run
+  rate; budget==0 gate hard-stops surplus; bounded transient burst only.
+- **File(s)**: userspace-dp/src/afxdp/cos/queue_ops/{mod,pop,fused_diff_tests}.rs,
+  userspace-dp/src/afxdp/cos/flow_hash{,_tests}.rs,
+  userspace-dp/src/afxdp/tx/cos_classify{,_tests}.rs,
+  userspace-dp/src/afxdp/worker/cos/{queue_row,tests}.rs,
+  userspace-dp/src/afxdp/coordinator/{cos_leases,tests}.rs,
+  userspace-dp/src/policy.rs,
+  userspace-dp/src/afxdp/forwarding_build/{cos,tests}.rs,
+  userspace-dp/src/afxdp/cos/queue_service/{mod,tests}.rs,
+  userspace-dp/src/afxdp/tx/dispatch/{mod,cos,dispatch_tests}.rs,
+  userspace-dp/src/afxdp/cos/README.md, _Log.md

--- a/userspace-dp/src/afxdp/coordinator/cos_leases.rs
+++ b/userspace-dp/src/afxdp/coordinator/cos_leases.rs
@@ -266,7 +266,11 @@ pub(super) fn aggregate_cos_statuses_across_workers(
                     .flow_fair_buckets_occupied
                     .saturating_add(queue.flow_fair_buckets_occupied);
                 q.transmit_rate_bytes = q.transmit_rate_bytes.max(queue.transmit_rate_bytes);
-                q.buffer_bytes = q.buffer_bytes.saturating_add(queue.buffer_bytes);
+                // #hb166 T-7: MAX, not SUM — `buffer_bytes` is a per-queue
+                // CONFIG value identical across workers; summing reported N×
+                // the configured buffer. Matches the worker-side fold in
+                // queue_row.rs and the `transmit_rate_bytes` MAX above.
+                q.buffer_bytes = q.buffer_bytes.max(queue.buffer_bytes);
                 q.worker_instances = q.worker_instances.saturating_add(queue.worker_instances);
                 q.queued_packets = q.queued_packets.saturating_add(queue.queued_packets);
                 q.queued_bytes = q.queued_bytes.saturating_add(queue.queued_bytes);

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -1239,7 +1239,10 @@ fn aggregate_cos_statuses_sums_drop_counters_across_worker_snapshots() {
     let q = &iface.queues[0];
     assert_eq!(q.queue_id, 4);
     assert_eq!(q.owner_worker_id, Some(3));
-    assert_eq!(q.buffer_bytes, 128 * 1024);
+    // #hb166 T-7: buffer_bytes is a per-queue CONFIG value identical across
+    // workers — aggregate by MAX, not SUM. Pre-fix summed 64 KB + 64 KB =
+    // 128 KB (an N× "stats-that-lie" inflation). RED-on-revert.
+    assert_eq!(q.buffer_bytes, 64 * 1024);
     assert_eq!(q.queued_bytes, 64 * 1024);
     // Each counter is non-coprime-prime on both sides to catch
     // accidental re-attribution between counters.

--- a/userspace-dp/src/afxdp/cos/README.md
+++ b/userspace-dp/src/afxdp/cos/README.md
@@ -88,6 +88,13 @@ mod.rs for further file-level breakdown.
   the residual/best-effort
   queue-level → flow-level item from the #1731 research plan (its
   finding #7; NOT GitHub issue #7, which is an unrelated SNAT bug).
+  Both scans (cap-aware and no-cap) gate their "chosen bucket" on
+  `Option::is_none()`, NOT a bare `finish < best` compare against a
+  `best = u64::MAX` seed (#hb166 T-7): a `flow_bucket_head_finish_bytes`
+  that ever SATURATES to `u64::MAX` would otherwise be indistinguishable
+  from the not-found sentinel and become a permanently unselectable
+  active bucket whose packets never drain. This mirrors the R-8(b)/#4271
+  vtime-sentinel clamp for the head-finish domain #4271 did not cover.
 - Single-writer per FlowFairState. The owner worker that polls a
   binding is the same worker that owns the queue's
   `FlowFairState`; therefore `observed_bps` updates and reads do not

--- a/userspace-dp/src/afxdp/cos/flow_hash.rs
+++ b/userspace-dp/src/afxdp/cos/flow_hash.rs
@@ -73,12 +73,40 @@ pub(in crate::afxdp) fn cos_item_flow_key(item: &CoSPendingTxItem) -> Option<&Se
     }
 }
 
+/// #hb166 T-7: dedicated SFQ lane for keyless / flowless traffic
+/// (non-TCP/UDP frames, pre-session packets — anything with no
+/// `SessionKey`). Reserving a fixed bucket keeps all such items in ONE
+/// lane (the anti-splay intent of #693, so they don't inflate
+/// `active_flow_buckets`) WITHOUT sharing that lane with a real 5-tuple
+/// flow that happens to hash to the same slot. The pre-fix code routed
+/// BOTH keyless AND any real flow whose salted hash masked onto bucket 0
+/// into bucket 0, so one unlucky victim flow contended for SFQ
+/// virtual-finish time against ALL keyless traffic.
+pub(in crate::afxdp) const COS_FLOW_FAIR_KEYLESS_BUCKET: usize = 0;
+
+/// Fallback lane for the rare real flow whose salted hash masks onto the
+/// reserved keyless bucket. Steering it to bucket 1 adds at most a
+/// 1-in-`COS_FLOW_FAIR_BUCKETS` skew to bucket 1's occupancy — negligible
+/// for SFQ — and is strictly better than diluting the victim flow's share
+/// with keyless traffic.
+const COS_FLOW_FAIR_KEYLESS_REAL_FALLBACK: usize = 1;
+
 #[inline(always)]
 pub(in crate::afxdp) fn cos_flow_bucket_index(
     queue_seed: u64,
     flow_key: Option<&SessionKey>,
 ) -> usize {
-    usize::from(exact_cos_flow_bucket(queue_seed, flow_key)) & COS_FLOW_FAIR_BUCKET_MASK
+    if flow_key.is_none() {
+        return COS_FLOW_FAIR_KEYLESS_BUCKET;
+    }
+    let idx = usize::from(exact_cos_flow_bucket(queue_seed, flow_key)) & COS_FLOW_FAIR_BUCKET_MASK;
+    // Reserve the keyless lane: a real flow that masks onto it is steered
+    // to a dedicated fallback bucket instead of colliding with keyless.
+    if idx == COS_FLOW_FAIR_KEYLESS_BUCKET {
+        COS_FLOW_FAIR_KEYLESS_REAL_FALLBACK
+    } else {
+        idx
+    }
 }
 
 /// Prospective distinct-flow count: current `active_flow_buckets` plus

--- a/userspace-dp/src/afxdp/cos/flow_hash_tests.rs
+++ b/userspace-dp/src/afxdp/cos/flow_hash_tests.rs
@@ -86,12 +86,41 @@ fn exact_cos_flow_bucket_preserves_legacy_behavior_at_zero_seed() {
 #[test]
 fn exact_cos_flow_bucket_handles_missing_flow_key() {
     // An item without a flow_key (e.g. a non-TCP/UDP frame, or a
-    // pre-session packet) must still produce a valid bucket. Pick
-    // bucket 0 deterministically so these items share one SFQ lane
-    // rather than splaying across the ring and inflating
-    // active_flow_buckets.
-    assert_eq!(cos_flow_bucket_index(0, None), 0);
-    assert_eq!(cos_flow_bucket_index(0x1234_5678_9abc_def0, None), 0);
+    // pre-session packet) must still produce a valid bucket. All keyless
+    // items share ONE dedicated SFQ lane rather than splaying across the
+    // ring and inflating active_flow_buckets — the reserved keyless
+    // bucket, independent of the queue seed.
+    assert_eq!(cos_flow_bucket_index(0, None), COS_FLOW_FAIR_KEYLESS_BUCKET);
+    assert_eq!(
+        cos_flow_bucket_index(0x1234_5678_9abc_def0, None),
+        COS_FLOW_FAIR_KEYLESS_BUCKET
+    );
+}
+
+#[test]
+fn keyless_lane_is_reserved_from_real_flows() {
+    // #hb166 T-7: no real 5-tuple flow may land on the reserved keyless
+    // SFQ lane, so keyless traffic never dilutes a real flow's fair
+    // share. Pre-fix, real flows masked into the keyless bucket with
+    // probability 1/COS_FLOW_FAIR_BUCKETS, so scanning this many
+    // (seed, flow) pairs is virtually certain to hit it on the un-fixed
+    // code (RED-on-revert); the fix steers every such flow off the
+    // reserved bucket onto the fallback lane.
+    let mut real_flows_on_reserved = 0usize;
+    for seed in 0u64..64 {
+        for port in 0u16..2048 {
+            let flow = test_session_key(10_000 + port, 5201);
+            if cos_flow_bucket_index(seed, Some(&flow)) == COS_FLOW_FAIR_KEYLESS_BUCKET {
+                real_flows_on_reserved += 1;
+            }
+        }
+    }
+    assert_eq!(
+        real_flows_on_reserved, 0,
+        "a real 5-tuple flow landed on the reserved keyless SFQ bucket {} \
+         ({} of 131072 scanned flows)",
+        COS_FLOW_FAIR_KEYLESS_BUCKET, real_flows_on_reserved
+    );
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/cos/queue_ops/fused_diff_tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/fused_diff_tests.rs
@@ -27,7 +27,8 @@ use crate::afxdp::cos::queue_ops::{
     cos_queue_pop_known_bucket, cos_queue_push_back, cos_queue_push_front,
 };
 use crate::afxdp::tx::test_support::{
-    enable_test_flow_fair, test_cos_runtime_with_queues, test_flow_fair_state, test_session_key,
+    enable_test_flow_fair, test_cos_runtime_with_queues, test_flow_fair_state,
+    test_flow_fair_state_mut, test_session_key,
 };
 use crate::afxdp::types::{CoSPendingTxItem, CoSQueueConfig, CoSQueueRuntime, TxRequest};
 use crate::afxdp::{PROTO_TCP, TX_BATCH_SIZE};
@@ -595,6 +596,75 @@ fn no_cap_fast_path_equals_two_pass_at_max() {
         // Also confirm the no_cap specialization directly matches.
         assert_eq!(cos_queue_min_finish_bucket_no_cap(ff), want);
     }
+}
+
+#[test]
+fn min_finish_bucket_selects_a_saturated_head_finish_bucket() {
+    // #hb166 T-7: a bucket whose head-finish has SATURATED to u64::MAX
+    // (the same value seeded as the "no bucket found" sentinel) must still
+    // be selectable — otherwise it becomes a permanently unselectable
+    // active bucket whose packets never drain. Pre-fix, the bare
+    // `finish < *_finish` compare skipped it (both scans returned None);
+    // the fix gates on `is_none()` so the first active bucket is always
+    // chosen. Mirrors the R-8(b)/#4271 vtime-sentinel guard for the
+    // head-finish domain #4271 did NOT cover.
+    let mut queue = make_flow_fair_queue();
+    let ff = test_flow_fair_state_mut(&mut queue);
+    let bucket: u16 = 7;
+    let bi = usize::from(bucket);
+    ff.flow_bucket_head_finish_bytes[bi] = u64::MAX;
+    ff.flow_bucket_tail_finish_bytes[bi] = u64::MAX;
+    ff.flow_bucket_observed_bps[bi] = 0;
+    ff.flow_rr_buckets.push_back(bucket);
+
+    assert_eq!(
+        cos_queue_min_finish_bucket_no_cap(ff),
+        Some(bucket),
+        "no-cap scan must select the sole active bucket even at u64::MAX head-finish"
+    );
+    assert_eq!(
+        cos_queue_min_finish_bucket(ff, u64::MAX),
+        Some(bucket),
+        "dispatch must select the sole active bucket even at u64::MAX head-finish"
+    );
+    // Cap-aware path (finite target, observed under cap) must also fall
+    // back to a saturated-finish bucket rather than returning None.
+    assert_eq!(
+        cos_queue_min_finish_bucket(ff, 1_000),
+        Some(bucket),
+        "cap-aware fallback must select a u64::MAX head-finish bucket"
+    );
+}
+
+#[test]
+fn pop_known_bucket_on_empty_selected_bucket_leaves_no_orphan_snapshot() {
+    // #hb166 T-7: a desync where the selected min-finish bucket is in the
+    // active ring but its item deque is empty must NOT leave an orphaned
+    // rollback snapshot on the per-queue LIFO stack — a later push_front
+    // would match against it and `assert!(false)`-panic the worker in
+    // release. Pre-fix, the snapshot was pushed BEFORE the fallible pop, so
+    // the `None` return orphaned it; the fix pops first and only pushes the
+    // snapshot on success. RED-on-revert: the pre-fix ordering grows the
+    // stack by 1.
+    let mut queue = make_flow_fair_queue();
+    let bucket: u16 = 3;
+    {
+        let ff = test_flow_fair_state_mut(&mut queue);
+        // Active bucket with the smallest finish so the min-finish scan
+        // selects it, but with an EMPTY item deque (the desync).
+        ff.flow_bucket_head_finish_bytes[usize::from(bucket)] = 1;
+        ff.flow_bucket_tail_finish_bytes[usize::from(bucket)] = 1;
+        ff.flow_rr_buckets.push_back(bucket);
+        assert!(ff.pop_snapshot_stack.is_empty());
+    }
+    let popped = cos_queue_pop_known_bucket(&mut queue, bucket, u64::MAX);
+    assert!(popped.is_none(), "empty selected bucket must yield None");
+    let ff = test_flow_fair_state_mut(&mut queue);
+    assert!(
+        ff.pop_snapshot_stack.is_empty(),
+        "a None pop must not leave an orphaned rollback snapshot ({} entries)",
+        ff.pop_snapshot_stack.len()
+    );
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/cos/queue_ops/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/mod.rs
@@ -127,12 +127,24 @@ fn cos_queue_min_finish_bucket(ff: &FlowFairState, target_bps: u64) -> Option<u1
     for bucket in ff.flow_rr_buckets.iter() {
         let b = usize::from(bucket);
         let finish = ff.flow_bucket_head_finish_bytes[b];
-        if finish < fallback_finish {
+        // #hb166 T-7: distinguish "no bucket chosen yet" from a real
+        // head-finish that has SATURATED to u64::MAX. `head_finish` is a
+        // saturating cumulative byte counter; if it ever reaches u64::MAX
+        // (the same value seeded into `*_finish` as the not-found
+        // sentinel), the bare `finish < *_finish` compare would skip that
+        // bucket forever — a permanently unselectable active bucket whose
+        // packets never drain. Gating on `is_none()` selects the FIRST
+        // active bucket regardless of its finish value, keeping the
+        // domains disjoint. Byte-identical to the pre-fix selection for
+        // every non-saturated input (strict `<` still gives first-wins on
+        // ties). Mirrors the R-8(b)/#4271 vtime-sentinel clamp for the
+        // head-finish domain (which #4271 did NOT cover).
+        if fallback.is_none() || finish < fallback_finish {
             fallback_finish = finish;
             fallback = Some(bucket);
         }
         let observed = ff.flow_bucket_observed_bps[b];
-        if observed <= target_bps && finish < eligible_finish {
+        if observed <= target_bps && (eligible.is_none() || finish < eligible_finish) {
             eligible_finish = finish;
             eligible = Some(bucket);
         }
@@ -152,7 +164,14 @@ fn cos_queue_min_finish_bucket_no_cap(ff: &FlowFairState) -> Option<u16> {
     let mut best_finish = u64::MAX;
     for bucket in ff.flow_rr_buckets.iter() {
         let finish = ff.flow_bucket_head_finish_bytes[usize::from(bucket)];
-        if finish < best_finish {
+        // #hb166 T-7: gate on `is_none()` so a head-finish that has
+        // SATURATED to u64::MAX (the same value seeded as the not-found
+        // sentinel) is still selectable — otherwise it becomes a
+        // permanently unselectable active bucket. Byte-identical to the
+        // pre-fix selection for every non-saturated input (strict `<`
+        // keeps first-wins on ties); stays in lockstep with the cap-aware
+        // `cos_queue_min_finish_bucket` scan above.
+        if best.is_none() || finish < best_finish {
             best_finish = finish;
             best = Some(bucket);
         }

--- a/userspace-dp/src/afxdp/cos/queue_ops/pop.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/pop.rs
@@ -175,6 +175,18 @@ fn cos_queue_pop_known_bucket_inner(
             .as_mut()
             .expect("cos_queue_pop_known_bucket_inner: flow_fair queue without flow_fair_state");
         let bucket = usize::from(bucket_u16);
+        // #913: capture served_finish (the popped packet's finish time)
+        // BEFORE pop_front + head-advance below mutate it.
+        let served_finish = ff.flow_bucket_head_finish_bytes[bucket];
+        // #hb166 T-7: perform the FALLIBLE pop BEFORE pushing the rollback
+        // snapshot. On an empty bucket `pop_front()` returns None and we
+        // exit WITHOUT leaving an orphaned wrong-bucket snapshot on the
+        // per-queue LIFO stack — the pre-fix push-then-`?` ordering left a
+        // stale snapshot that a later `push_front` matched against and
+        // `assert!(false)`-panicked the worker thread in release. `bucket`
+        // (from the fused peek that selected it) is normally non-empty, so
+        // this is a defensive-desync guard, not a hot-path change.
+        let item = ff.flow_bucket_items[bucket].pop_front()?;
         if push_snapshot {
             // #785 Phase 3 — Codex round-3 HIGH + NEW-1: snapshot
             // pre-pop bucket + vtime state BEFORE we mutate anything,
@@ -209,17 +221,16 @@ fn cos_queue_pop_known_bucket_inner(
                  cos_queue_pop_front_no_snapshot",
                 TX_BATCH_SIZE,
             );
+            // #hb166 T-7: `served_finish` holds the pre-pop head-finish;
+            // tail-finish and queue_vtime are still pre-pop here (the
+            // vtime/head advances below run AFTER this push).
             ff.pop_snapshot_stack.push(CoSQueuePopSnapshot {
                 bucket: bucket_u16,
-                pre_pop_head_finish: ff.flow_bucket_head_finish_bytes[bucket],
+                pre_pop_head_finish: served_finish,
                 pre_pop_tail_finish: ff.flow_bucket_tail_finish_bytes[bucket],
                 pre_pop_queue_vtime: ff.queue_vtime,
             });
         }
-        // #913: capture served_finish (the popped packet's finish
-        // time) BEFORE pop_front + head-advance below mutate it.
-        let served_finish = ff.flow_bucket_head_finish_bytes[bucket];
-        let item = ff.flow_bucket_items[bucket].pop_front()?;
         // #913: branched vtime advance.
         // - push_snapshot=true (hot path / `cos_queue_pop_front`):
         //   MQFQ served-finish semantics — `vtime = max(vtime,

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -1554,7 +1554,15 @@ fn restore_exact_local_scratch_to_queue_head_flow_fair(
     scratch_local_tx: &mut Vec<(u64, TxRequest)>,
 ) {
     let Some(queue) = queue else {
-        scratch_local_tx.clear();
+        // #hb166 T-7: the queue was torn down mid-drain, but each scratch
+        // entry still owns a `free_tx_frames` UMEM offset popped at
+        // scratch-build time. Recycle them before dropping — the pre-fix
+        // bare `.clear()` leaked every offset (an uncounted UMEM-frame
+        // leak), unlike the FIFO sibling `settle_exact_local_fifo_submission`
+        // (via `release_exact_local_scratch_frames`).
+        while let Some((offset, _req)) = scratch_local_tx.pop() {
+            free_tx_frames.push_front(offset);
+        }
         return;
     };
     while let Some((offset, req)) = scratch_local_tx.pop() {
@@ -1623,7 +1631,13 @@ pub(in crate::afxdp) fn settle_exact_local_scratch_submission_flow_fair(
     now_ns: u64,
 ) -> (u64, u64) {
     let Some(queue) = queue else {
-        scratch_local_tx.clear();
+        // #hb166 T-7: recycle the UMEM offsets before dropping the scratch
+        // (queue torn down mid-drain) — the pre-fix `.clear()` leaked them,
+        // uncounted. Mirrors the FIFO `settle_exact_local_fifo_submission`
+        // None arm and `restore_exact_local_scratch_to_queue_head_flow_fair`.
+        while let Some((offset, _req)) = scratch_local_tx.pop() {
+            free_tx_frames.push_front(offset);
+        }
         return (0, 0);
     };
     // #1229 v7: per-bucket TX rate accounting. Capture the

--- a/userspace-dp/src/afxdp/cos/queue_service/tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests.rs
@@ -4056,3 +4056,69 @@ fn nonexact_guarantee_shared_lease_bounds_aggregate_admission_across_workers() {
          (expected ~{expected} B) — the shared lease is over-throttling the class"
     );
 }
+
+// #hb166 T-7: the flow-fair local scratch None arms (queue torn down
+// mid-drain) must recycle the popped `free_tx_frames` UMEM offsets, not
+// leak them. Pre-fix they bare-`.clear()`ed the scratch, unlike the FIFO
+// sibling `settle_exact_local_fifo_submission`. RED-on-revert: the
+// recycled offsets stay absent from `free_tx_frames`.
+fn t7_local_scratch_entry(offset: u64, len: usize) -> (u64, TxRequest) {
+    (
+        offset,
+        TxRequest {
+            bytes: vec![0u8; len],
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: None,
+            egress_ifindex: 80,
+            cos_queue_id: Some(5),
+            dscp_rewrite: None,
+            mirror_clone: false,
+            enqueue_ns: 0,
+        },
+    )
+}
+
+#[test]
+fn settle_local_scratch_flow_fair_recycles_offsets_when_queue_gone() {
+    let mut free_tx_frames: VecDeque<u64> = VecDeque::new();
+    let mut scratch_local_tx: Vec<(u64, TxRequest)> =
+        vec![t7_local_scratch_entry(64, 4), t7_local_scratch_entry(128, 4)];
+    let (packets, bytes) = settle_exact_local_scratch_submission_flow_fair(
+        None,
+        &mut free_tx_frames,
+        &mut scratch_local_tx,
+        0,
+        0,
+    );
+    assert_eq!((packets, bytes), (0, 0));
+    assert!(scratch_local_tx.is_empty(), "scratch must be drained");
+    let mut recycled: Vec<u64> = free_tx_frames.into_iter().collect();
+    recycled.sort_unstable();
+    assert_eq!(
+        recycled,
+        vec![64, 128],
+        "both UMEM offsets must be recycled to free_tx_frames, not leaked"
+    );
+}
+
+#[test]
+fn restore_local_scratch_flow_fair_recycles_offsets_when_queue_gone() {
+    let mut free_tx_frames: VecDeque<u64> = VecDeque::new();
+    let mut scratch_local_tx: Vec<(u64, TxRequest)> =
+        vec![t7_local_scratch_entry(64, 4), t7_local_scratch_entry(128, 4)];
+    restore_exact_local_scratch_to_queue_head_flow_fair(
+        None,
+        &mut free_tx_frames,
+        &mut scratch_local_tx,
+    );
+    assert!(scratch_local_tx.is_empty(), "scratch must be drained");
+    let mut recycled: Vec<u64> = free_tx_frames.into_iter().collect();
+    recycled.sort_unstable();
+    assert_eq!(
+        recycled,
+        vec![64, 128],
+        "both UMEM offsets must be recycled to free_tx_frames, not leaked"
+    );
+}

--- a/userspace-dp/src/afxdp/forward_request.rs
+++ b/userspace-dp/src/afxdp/forward_request.rs
@@ -300,13 +300,11 @@ pub(super) fn build_live_forward_request_from_frame(
         cos_queue_id: cos.queue_id,
         dscp_rewrite: cos.dscp_rewrite,
         cos_tx_selection_resolved: true,
-        // #2362 fold B: snapshot the fragment-safe per-packet match inputs so a
-        // later deferred TX-selection recompute keeps the same verdict even
-        // after the UMEM frame is recycled.
-        // #3077: stored on the deferred CoS/TX-selection path — strip the
-        // borrowed frame slice (to_static) since the frame may be recycled
-        // before this is consumed. The flex byte-offset term fails closed here.
-        filter_match_extra: crate::afxdp::frame::term_match_extra_from_frame(frame, meta)
-            .to_static(),
+        // #hb166 T-7: the `filter_match_extra` snapshot was removed — CoS TX
+        // selection is resolved on the LIVE frame just above (via
+        // `resolve_cos_tx_selection_at`), and the deferred recompute path
+        // that consumed the snapshot is deleted. Dropping it also removes a
+        // per-forwarded-packet `term_match_extra_from_frame(..).to_static()`
+        // that produced write-only data.
     })
 }

--- a/userspace-dp/src/afxdp/forwarding_build/cos.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/cos.rs
@@ -175,14 +175,20 @@ fn cos_surplus_weight(rate_bytes: u64, root_rate_bytes: u64) -> u32 {
         .clamp(1, 16) as u32
 }
 
-fn cos_priority_rank(priority: &str) -> u8 {
+/// Map a Junos scheduler priority string to an internal strict-priority
+/// rank (0 = highest, 5 = lowest). Returns `None` for an unrecognized
+/// non-empty string so the caller can fail the snapshot CLOSED (#hb166
+/// T-7) — mirroring the #2458 equal-flow-policy parse on the same queue
+/// rather than silently ranking an unknown priority lowest ("low").
+fn cos_priority_rank(priority: &str) -> Option<u8> {
     match priority {
-        "strict-high" => 0,
-        "high" => 1,
-        "medium-high" => 2,
-        "medium" => 3,
-        "medium-low" => 4,
-        _ => 5,
+        "strict-high" => Some(0),
+        "high" => Some(1),
+        "medium-high" => Some(2),
+        "medium" => Some(3),
+        "medium-low" => Some(4),
+        "low" => Some(5),
+        _ => None,
     }
 }
 
@@ -389,11 +395,19 @@ pub(super) fn build_cos_iface_config(
             queues.push(CoSQueueConfig {
                 queue_id,
                 forwarding_class: entry.forwarding_class.clone(),
-                priority: cos_priority_rank(
-                    scheduler
-                        .map(|sched| sched.priority.as_str())
-                        .unwrap_or("low"),
-                ),
+                // #hb166 T-7: fail-closed on an unknown non-empty priority
+                // (mirrors the #2458 equal-flow-policy parse above). A
+                // missing scheduler, or one with an empty (unset) priority
+                // string, keeps the byte-unchanged legacy "low" default.
+                priority: match scheduler.map(|sched| sched.priority.as_str()) {
+                    Some(p) if !p.is_empty() => cos_priority_rank(p).ok_or_else(|| {
+                        crate::policy::SnapshotIntegrityError::CosUnknownSchedulerPriority {
+                            forwarding_class: entry.forwarding_class.clone(),
+                            priority: p.to_string(),
+                        }
+                    })?,
+                    _ => 5,
+                },
                 transmit_rate_bytes,
                 guarantee_enabled,
                 exact: scheduler
@@ -511,7 +525,7 @@ pub(super) fn build_cos_iface_config(
         queues.push(CoSQueueConfig {
             queue_id: 0,
             forwarding_class: "best-effort".to_string(),
-            priority: cos_priority_rank("low"),
+            priority: cos_priority_rank("low").expect("\"low\" is a known scheduler priority"),
             transmit_rate_bytes: iface.cos_shaping_rate_bytes_per_sec,
             guarantee_enabled: true,
             exact: false,

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -612,6 +612,67 @@ fn build_cos_state_fails_closed_on_unknown_equal_flow_target_policy() {
 }
 
 #[test]
+fn build_cos_state_fails_closed_on_unknown_scheduler_priority() {
+    // #hb166 T-7: a scheduler carrying a NON-EMPTY `priority` string that
+    // is not a known Junos scheduler priority fails the snapshot CLOSED
+    // (the helper-boundary backstop for a typo / version-drifted snapshot)
+    // rather than silently ranking it lowest ("low") — mirroring the #2458
+    // equal-flow-policy backstop a few fields over. RED-on-revert: the
+    // pre-fix `_ => 5` catch-all returned `Ok` with the class demoted to
+    // rank 5.
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            ifindex: 42,
+            cos_shaping_rate_bytes_per_sec: 10_000_000,
+            cos_shaping_burst_bytes: 256_000,
+            cos_scheduler_map: "wan-map".into(),
+            ..Default::default()
+        }],
+        class_of_service: Some(ClassOfServiceSnapshot {
+            forwarding_classes: vec![CoSForwardingClassSnapshot {
+                name: "fc-bad".into(),
+                queue: 4,
+            }],
+            schedulers: vec![CoSSchedulerSnapshot {
+                name: "s-bad".into(),
+                transmit_rate_bytes: 1_000_000_000 / 8,
+                transmit_rate_exact: true,
+                priority: "hgh".into(),
+                buffer_size_bytes: 128 * 1024,
+                buffer_size_percent: 0.0,
+                surplus_sharing: false,
+                equal_flow_enforcement: false,
+                equal_flow_target_policy: String::new(),
+                codel_target_ns: 0,
+            }],
+            scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                name: "wan-map".into(),
+                entries: vec![CoSSchedulerMapEntrySnapshot {
+                    forwarding_class: "fc-bad".into(),
+                    scheduler: "s-bad".into(),
+                }],
+            }],
+            dscp_classifiers: vec![],
+            ieee8021_classifiers: vec![],
+            dscp_rewrite_rules: vec![],
+        }),
+        ..Default::default()
+    };
+
+    match super::cos::build_cos_state(&snapshot) {
+        Err(crate::policy::SnapshotIntegrityError::CosUnknownSchedulerPriority {
+            forwarding_class,
+            priority,
+        }) => {
+            assert_eq!(forwarding_class, "fc-bad");
+            assert_eq!(priority, "hgh");
+        }
+        Err(other) => panic!("wrong integrity error: {other}"),
+        Ok(_) => panic!("unknown scheduler priority must fail the snapshot closed"),
+    }
+}
+
+#[test]
 fn build_cos_state_falls_back_to_default_best_effort_queue() {
     let snapshot = ConfigSnapshot {
         interfaces: vec![InterfaceSnapshot {

--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -266,12 +266,9 @@ pub(super) fn build_local_time_exceeded_request(
         cos_queue_id: verdict.cos_queue_id,
         dscp_rewrite: verdict.dscp_rewrite,
         cos_tx_selection_resolved: true,
-        // #2362 fold B: TX-selection already resolved above via
-        // classify_generated_reply (which read the prebuilt frame), so the
-        // deferred recompute path is never taken for this request — Default is
-        // unused. The prebuilt frame was moved into `frame`, so it cannot be
-        // re-read here regardless.
-        filter_match_extra: crate::filter::TermMatchExtra::default(),
+        // #hb166 T-7: `filter_match_extra` removed (was write-only; the
+        // deferred recompute that consumed it is deleted). TX selection is
+        // already resolved above via `classify_generated_reply`.
     })
 }
 

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -2346,11 +2346,11 @@ pub(super) fn poll_binding_process_descriptor(
                                                     cos_queue_id: cos.queue_id,
                                                     dscp_rewrite: cos.dscp_rewrite,
                                                     cos_tx_selection_resolved: true,
-                                                    // #2362 fold B: resolved
-                                                    // above; deferred recompute
-                                                    // not taken.
-                                                    filter_match_extra:
-                                                        crate::filter::TermMatchExtra::default(),
+                                                    // #hb166 T-7:
+                                                    // filter_match_extra
+                                                    // removed (write-only;
+                                                    // deferred recompute
+                                                    // deleted).
                                                 },
                                             );
                                             recycle_now = false;

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -669,7 +669,14 @@ fn resolve_cos_ieee8021_classifier_queue_id(
     if !vlan_present {
         return None;
     }
-    let queue_id = iface.ieee8021_queue_by_pcp[usize::from(pcp.min(7))];
+    // #hb166 T-7: fail-closed on an out-of-range PCP instead of the
+    // pre-fix `pcp.min(7)` clamp, which silently misclassified any value
+    // >7 as the PCP-7 traffic class — the exact fail-OPEN the #2447
+    // build-side gate refuses (see forwarding_build/cos.rs). The wire PCP
+    // field is structurally 3-bit, so this guards only a malformed shim
+    // meta / version drift: a bad value falls through to the default
+    // queue (None) rather than being routed to the wrong class.
+    let queue_id = *iface.ieee8021_queue_by_pcp.get(usize::from(pcp))?;
     (queue_id != u8::MAX).then_some(queue_id)
 }
 

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -4311,3 +4311,49 @@ fn resolve_cached_cos_tx_selection_preserves_input_fc_under_counter_only_output_
     // input filter's class survives — output-overrides-when-set semantics.
     assert!(!cached.filter_counters.is_empty());
 }
+
+#[test]
+fn ieee8021_classifier_fails_closed_on_out_of_range_pcp() {
+    // #hb166 T-7: a PCP outside the 3-bit 0..=7 domain must NOT be clamped
+    // into a valid index. Pre-fix `pcp.min(7)` routed pcp 8 to the PCP-7
+    // class (here queue 3); the fix returns None so the frame falls
+    // through to the default queue, matching the #2447 build-side
+    // fail-closed posture. RED-on-revert: restoring `.min(7)` flips the
+    // pcp-8/255 assertions from None back to Some(3).
+    let mut pcp_table = [u8::MAX; 8];
+    pcp_table[7] = 3;
+    let iface = CoSInterfaceConfig {
+        shaping_rate_bytes: 1_000_000,
+        burst_bytes: COS_MIN_BURST_BYTES,
+        default_queue: 0,
+        dscp_classifier: String::new(),
+        ieee8021_classifier: "wan-pcp".into(),
+        dscp_queue_by_dscp: [u8::MAX; 64],
+        ieee8021_queue_by_pcp: pcp_table,
+        queue_by_forwarding_class: FastMap::default(),
+        queues: vec![],
+        oversubscription_policy: crate::afxdp::types::CoSOversubscriptionPolicy::Proportional,
+        oversubscription_guarantee_fraction: 0.0,
+        priority_low_min_share_bytes: 0,
+    };
+    // Valid PCP 7 resolves to its configured queue.
+    assert_eq!(
+        resolve_cos_ieee8021_classifier_queue_id(&iface, 7, true),
+        Some(3)
+    );
+    // Out-of-range PCP fails closed to None (default queue), NOT clamped to
+    // the PCP-7 queue.
+    assert_eq!(
+        resolve_cos_ieee8021_classifier_queue_id(&iface, 8, true),
+        None
+    );
+    assert_eq!(
+        resolve_cos_ieee8021_classifier_queue_id(&iface, 255, true),
+        None
+    );
+    // Untagged frames never classify.
+    assert_eq!(
+        resolve_cos_ieee8021_classifier_queue_id(&iface, 7, false),
+        None
+    );
+}

--- a/userspace-dp/src/afxdp/tx/dispatch/cos.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/cos.rs
@@ -132,43 +132,10 @@ pub(super) fn enqueue_local_request_to_target_or_owner(
     Ok(())
 }
 
-#[inline]
-pub(super) fn resolve_pending_forward_cos_tx_selection(
-    forwarding: &ForwardingState,
-    request: &PendingForwardRequest,
-    now_ns: u64,
-) -> CoSTxSelection {
-    // #2362 fold B: the deferred forward request runs after the UMEM frame may
-    // have been recycled, so it consumes the per-packet match inputs snapshotted
-    // at build time from the live frame rather than re-reading the frame.
-    // #3642: the egress output filter matches the POST-NAT on-wire tuple. The
-    // stored `flow_key` is the PRE-NAT key (kept for CoS flow-bucket hashing),
-    // so derive the egress wire key here from that key + the request's NAT
-    // decision (apply-to-this-packet form, correct for both directions).
-    let tx_selection_wire_key = request
-        .flow_key
-        .as_ref()
-        .map(|key| crate::session::forward_wire_key(key, request.decision.nat));
-    resolve_cos_tx_selection_at(
-        forwarding,
-        request.decision.resolution.egress_ifindex,
-        request.meta,
-        tx_selection_wire_key.as_ref(),
-        request.filter_match_extra,
-        now_ns,
-    )
-}
-
-#[inline]
-pub(super) fn pending_forward_needs_cos_tx_selection(
-    request: &PendingForwardRequest,
-    tx_selection_enabled_v4: bool,
-    tx_selection_enabled_v6: bool,
-) -> bool {
-    let tx_selection_enabled = if request.meta.addr_family as i32 == libc::AF_INET6 {
-        tx_selection_enabled_v6
-    } else {
-        tx_selection_enabled_v4
-    };
-    tx_selection_enabled && !request.cos_tx_selection_resolved
-}
+// #hb166 T-7: the deferred forward-request CoS-TX-selection helpers
+// (`resolve_pending_forward_cos_tx_selection` +
+// `pending_forward_needs_cos_tx_selection`) were removed as dead code.
+// Every PendingForwardRequest is built with `cos_tx_selection_resolved =
+// true`, so the dispatch loop never deferred CoS selection to them. The
+// live resolution path uses `resolve_cos_tx_selection_at` directly at
+// build time (forward_request.rs / icmp.rs / poll_descriptor).

--- a/userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs
@@ -63,36 +63,6 @@ fn test_forwarding_decision_to_bound_ifindex(tx_ifindex: i32) -> SessionDecision
     }
 }
 
-fn test_pending_forward_request(
-    addr_family: u8,
-    cos_tx_selection_resolved: bool,
-) -> PendingForwardRequest {
-    PendingForwardRequest {
-        target_ifindex: 11,
-        target_binding_index: None,
-        ingress_queue_id: 0,
-        desc: XdpDesc {
-            addr: 0,
-            len: 64,
-            options: 0,
-        },
-        frame: PendingForwardFrame::Live,
-        meta: ForwardPacketMeta {
-            addr_family,
-            ..ForwardPacketMeta::default()
-        },
-        decision: test_decision(),
-        apply_nat_on_fabric: false,
-        expected_ports: None,
-        flow_key: None,
-        nat64_reverse: None,
-        cos_queue_id: None,
-        dscp_rewrite: None,
-        cos_tx_selection_resolved,
-        filter_match_extra: crate::filter::TermMatchExtra::default(),
-    }
-}
-
 fn test_live_forward_request_for_frame(
     frame_len: usize,
     decision: SessionDecision,
@@ -181,29 +151,6 @@ fn test_cos_fast_interfaces_decoupled(
         },
     );
     interfaces
-}
-
-#[test]
-fn pending_forward_cos_resolution_uses_resolved_bit_not_empty_outputs() {
-    let resolved = test_pending_forward_request(libc::AF_INET as u8, true);
-    assert!(
-        !pending_forward_needs_cos_tx_selection(&resolved, true, false),
-        "a resolved None/None selection must not be metered again"
-    );
-
-    let unresolved_v4 = test_pending_forward_request(libc::AF_INET as u8, false);
-    assert!(pending_forward_needs_cos_tx_selection(
-        &unresolved_v4,
-        true,
-        false
-    ));
-
-    let unresolved_v6 = test_pending_forward_request(libc::AF_INET6 as u8, false);
-    assert!(pending_forward_needs_cos_tx_selection(
-        &unresolved_v6,
-        false,
-        true
-    ));
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs
@@ -94,7 +94,6 @@ fn test_live_forward_request_for_frame(
         cos_queue_id: None,
         dscp_rewrite: None,
         cos_tx_selection_resolved: true,
-        filter_match_extra: crate::filter::TermMatchExtra::default(),
     }
 }
 

--- a/userspace-dp/src/afxdp/tx/dispatch/mod.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/mod.rs
@@ -38,8 +38,7 @@ mod slow_path;
 
 use cos::{
     cos_owner_live_for_request, enqueue_local_request_to_target_or_owner,
-    pending_forward_needs_cos_tx_selection, request_runs_under_shared_exact_policy,
-    resolve_pending_forward_cos_tx_selection,
+    request_runs_under_shared_exact_policy,
 };
 pub(in crate::afxdp) use shared_recycle::{
     apply_shared_recycles, apply_shared_recycles_to_bindings, resolve_tx_binding_ifindex,
@@ -148,8 +147,6 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
         return;
     }
     let ingress_area = ingress_binding.umem.area() as *const MmapArea;
-    let tx_selection_enabled_v4 = forwarding.tx_selection_enabled_v4;
-    let tx_selection_enabled_v6 = forwarding.tx_selection_enabled_v6;
     post_recycles.clear();
     // Walk the scratch vector in place. Moving large PendingForwardRequest
     // values through the iterator path was still forcing per-request memcpy
@@ -157,20 +154,19 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
     for request in pending_forwards.iter_mut() {
         let source_offset = request.desc.addr;
         let ingress_slot = ingress_binding.slot;
-        if pending_forward_needs_cos_tx_selection(
-            request,
-            tx_selection_enabled_v4,
-            tx_selection_enabled_v6,
-        ) {
-            let cos = resolve_pending_forward_cos_tx_selection(forwarding, &request, now_ns);
-            if cos.drop {
-                recycle_ingress_frame(ingress_binding, source_offset, now_ns);
-                continue;
-            }
-            request.cos_queue_id = cos.queue_id;
-            request.dscp_rewrite = cos.dscp_rewrite;
-            request.cos_tx_selection_resolved = true;
-        }
+        // #hb166 T-7: the deferred CoS-TX-selection resolution that used to
+        // live here was DEAD. Every PendingForwardRequest is constructed
+        // with `cos_tx_selection_resolved = true` (forward_request.rs,
+        // icmp.rs, poll_descriptor/mod.rs), so CoS TX selection is always
+        // resolved upstream and never deferred to this dispatch loop. The
+        // removed block also carried two latent bugs that only mattered if
+        // it ever went live: an UNCONDITIONAL `recycle_ingress_frame` that
+        // mis-/double-recycled Prebuilt/Owned frames (whose `source_offset`
+        // is not a live ingress frame), and a fully UNCOUNTED drop (no
+        // tx_errors / CoS drop / fabric_redirect_unsendable_drops). Deleting
+        // the dead path drops both. The `cos_tx_selection_resolved` field is
+        // retained as the load-bearing invariant marker (asserted by the
+        // constructor tests).
         let target_binding_index = request.target_binding_index.or_else(|| {
             binding_lookup.target_index(
                 ingress_index,

--- a/userspace-dp/src/afxdp/types/tx.rs
+++ b/userspace-dp/src/afxdp/types/tx.rs
@@ -85,22 +85,15 @@ pub(in crate::afxdp) struct PendingForwardRequest {
     pub(in crate::afxdp) cos_queue_id: Option<u8>,
     pub(in crate::afxdp) dscp_rewrite: Option<u8>,
     pub(in crate::afxdp) cos_tx_selection_resolved: bool,
-    /// #2362 fold B: the per-packet L4 firewall-filter match inputs (tcp-flags
-    /// / is-fragment / icmp-type / icmp-code), captured from the live frame at
-    /// request-build time. The deferred TX-selection / CoS path
-    /// (resolve_pending_forward_cos_tx_selection) runs after the UMEM frame may
-    /// have been recycled, so it cannot re-read the frame — it consumes this
-    /// snapshot. Built fragment-safe (a non-first fragment zeroes the
-    /// L4-derived fields). Default for non-frame-derived requests.
-    ///
-    /// #3077: this is a `'static` snapshot — it carries NO borrowed frame slice.
-    /// The deferred CoS/TX-selection path runs after the UMEM frame may be
-    /// recycled, so the flexible-match-range byte-offset condition cannot be
-    /// re-evaluated and fails closed here (under-matches → default
-    /// forwarding-class). Use `TermMatchExtra::to_static()` to build this from a
-    /// frame-derived value. The security ACCEPT/DISCARD decision is taken on the
-    /// immediate filter-eval path, which retains the live slice.
-    pub(in crate::afxdp) filter_match_extra: crate::filter::TermMatchExtra<'static>,
+    // #hb166 T-7: the `filter_match_extra` snapshot field was removed. Its
+    // sole reader was the deferred TX-selection / CoS dispatch path
+    // (`resolve_pending_forward_cos_tx_selection`), which was deleted as
+    // dead code — every request is built with `cos_tx_selection_resolved =
+    // true`, so CoS TX selection is always resolved upstream at build time
+    // (via `resolve_cos_tx_selection_at`, which reads the LIVE frame). With
+    // no reader, the field was write-only and its per-request
+    // `term_match_extra_from_frame(..).to_static()` snapshot was wasted
+    // work on every forwarded packet.
 }
 
 pub(in crate::afxdp) struct PreparedTxRequest {

--- a/userspace-dp/src/afxdp/worker/cos/queue_row.rs
+++ b/userspace-dp/src/afxdp/worker/cos/queue_row.rs
@@ -75,9 +75,12 @@ pub(super) fn accumulate_queue_row(
     status.exact = queue.config.exact;
     status.guarantee_enabled = queue.config.guarantee_enabled;
     status.transmit_rate_bytes = status.transmit_rate_bytes.max(queue.transmit_rate_bytes());
-    status.buffer_bytes = status
-        .buffer_bytes
-        .saturating_add(queue.config.buffer_bytes);
+    // #hb166 T-7: `buffer_bytes` is a per-queue CONFIG value, identical on
+    // every worker-instance of the queue. Aggregate by MAX (like
+    // `transmit_rate_bytes` above), NOT saturating_add — summing reported
+    // N× the configured buffer for an N-worker queue (a "stats-that-lie"
+    // inflation). The coordinator-side fold uses MAX to match.
+    status.buffer_bytes = status.buffer_bytes.max(queue.config.buffer_bytes);
     status.worker_instances = status.worker_instances.saturating_add(1);
     status.queued_packets = status
         .queued_packets

--- a/userspace-dp/src/afxdp/worker/cos/tests.rs
+++ b/userspace-dp/src/afxdp/worker/cos/tests.rs
@@ -305,7 +305,10 @@ fn build_worker_cos_statuses_aggregates_runtime_by_interface_and_queue() {
     let queue = &iface.queues[0];
     assert_eq!(queue.queue_id, 4);
     assert_eq!(queue.forwarding_class, "bandwidth-10mb");
-    assert_eq!(queue.buffer_bytes, 2 * 32 * 1024);
+    // #hb166 T-7: buffer_bytes is a per-queue CONFIG value, identical on
+    // every worker-instance — aggregate by MAX, not SUM. Pre-fix this
+    // summed to 2 × 32 KB (an N× "stats-that-lie" inflation). RED-on-revert.
+    assert_eq!(queue.buffer_bytes, 32 * 1024);
     assert_eq!(queue.queued_packets, 2);
     assert_eq!(queue.queued_bytes, 3072);
     assert_eq!(queue.runnable_instances, 1);

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -400,11 +400,14 @@ The L4 byte fields are also zeroed (defense-in-depth) but the gate is the flag.
 The L3-derived `is_fragment` bit is NOT gated by `l4_present` and stays true
 (a non-first fragment IS a fragment). This applies on the
 CoS / TX-selection leg too (`tx/cos_classify.rs`): the TX-selection evaluators
-thread the same `TermMatchExtra`, and the deferred path snapshots it on
-`PendingForwardRequest.filter_match_extra` because the UMEM frame may be
-recycled before the deferred recompute runs. The flow-cache decline (output and
-input legs) keeps the precomputed TX-selection descriptor from being built for a
-per-packet-L4 filter, so the live per-packet evaluator always runs.
+thread the same `TermMatchExtra`, built from the LIVE frame at
+request-build time. The flow-cache decline (output and input legs) keeps
+the precomputed TX-selection descriptor from being built for a
+per-packet-L4 filter, so the live per-packet evaluator always runs. (There
+is no deferred snapshot: the `PendingForwardRequest.filter_match_extra`
+field and the deferred-recompute path that consumed it were removed as
+dead code in #hb166 T-7 — CoS TX selection is always resolved upstream on
+the live frame.)
 
 #2449 also covers a NON-FRAGMENTED but TRUNCATED ICMP/ICMPv6 frame (shorter than
 `l4_offset + 2`, so the type/code bytes are absent): the frame builders force
@@ -841,9 +844,9 @@ deny`.
 
 **Scope (resolved #3608):** output-firewall-filter `then reject` on the
 TX/CoS path is now an active reject too — see the OUTPUT-filter paragraph
-above. The remaining collapse-to-drop site is the deferred-CoS dispatch
-path (`tx/dispatch/mod.rs`, `resolve_pending_forward_cos_tx_selection`),
-which is unreachable in production today (every `PendingForwardRequest` is
-built with `cos_tx_selection_resolved: true`, so the deferred re-resolve
-never runs); the `reject` bit is available there for a future wiring if a
-deferred-CoS request path is ever introduced.
+above. There is no remaining collapse-to-drop site: the deferred-CoS
+dispatch path (`resolve_pending_forward_cos_tx_selection` in
+`tx/dispatch/`) that used to be one was deleted as dead code in #hb166 T-7
+(every `PendingForwardRequest` is built with `cos_tx_selection_resolved:
+true`, so the deferred re-resolve never ran). CoS TX selection — including
+its `reject` bit — is resolved entirely on the live build-time path.

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -493,6 +493,24 @@ pub(crate) enum SnapshotIntegrityError {
         forwarding_class: String,
         target_policy: String,
     },
+    /// #hb166 T-7: a CoS scheduler snapshot carried a NON-EMPTY `priority`
+    /// wire string that is not one of the known Junos scheduler priorities
+    /// (`strict-high` / `high` / `medium-high` / `medium` / `medium-low` /
+    /// `low`). The pre-fix `cos_priority_rank` mapped any unrecognized
+    /// string to rank 5 (`low`, the strict-priority FLOOR) via a catch-all
+    /// match arm — so a typo or a mixed-version snapshot silently demoted a
+    /// class to lowest priority with no failure surfaced. Fail-closed here,
+    /// directly mirroring the #2458 `CosUnknownEqualFlowTargetPolicy` parse
+    /// on the SAME queue a few fields over. The Go commit-time gate is the
+    /// primary defense; this is the helper-boundary backstop for
+    /// version/snapshot drift, consistent with the #2447/#2458 CoS
+    /// fail-closed family. A MISSING scheduler, or a present scheduler with
+    /// an EMPTY priority string, is the legitimate legacy default (rank
+    /// `low`) and is NOT an error.
+    CosUnknownSchedulerPriority {
+        forwarding_class: String,
+        priority: String,
+    },
     /// #3365: a policy rule's `action` field, or the snapshot `default_policy`,
     /// carried a NON-EMPTY string that is not one of `permit` / `reject` /
     /// `deny`. The pre-fix `parse_action` mapped any unrecognized string to
@@ -825,6 +843,14 @@ impl std::fmt::Display for SnapshotIntegrityError {
                 f,
                 "cos forwarding-class {:?} has equal-flow-target-policy {:?} that is not one of slowest | mean | ideal-share — refusing to silently map it to the \"slowest\" default (which would change queue fairness with no failure surfaced)",
                 forwarding_class, target_policy
+            ),
+            Self::CosUnknownSchedulerPriority {
+                forwarding_class,
+                priority,
+            } => write!(
+                f,
+                "cos forwarding-class {:?} has scheduler priority {:?} that is not one of strict-high | high | medium-high | medium | medium-low | low — refusing to silently rank it lowest (\"low\"), which would demote the class with no failure surfaced",
+                forwarding_class, priority
             ),
             Self::UnknownPolicyAction { context, action } => write!(
                 f,


### PR DESCRIPTION
Drives the fable-166 **T-7** grouped LOW cluster: fixes 8 CLEAR + bounded
sub-items (each with a RED-on-revert test), defers the design/larger ones with
recorded reasons, and re-verifies **R-6** (confirmed NOT-MATERIAL). Verified
against master ~cb04457bc.

## Fixed (8 sub-items, 7 new tests + 2 repurposed regression pins)

| # | Sub-item | Fix |
|---|----------|-----|
| 1 | head-finish `u64::MAX` sentinel → permanently unselectable bucket | `cos_queue_min_finish_bucket[_no_cap]` gate on `Option::is_none()` (distinct from R-8(b)/#4271 vtime sentinel) |
| 2 | snapshot-push-before-fallible-pop → release panic | pop before snapshot push in `cos_queue_pop_known_bucket_inner` |
| 3 | keyless traffic shares SFQ bucket 0 with a victim flow | reserve a dedicated keyless lane; steer real flows off it |
| 4 | runtime `pcp.min(7)` clamp vs #2447 | bounds-check → `None` for pcp>7 (default queue) |
| 5 | unknown scheduler priority silently ranks lowest vs #2458 | `cos_priority_rank`→`Option`; new `CosUnknownSchedulerPriority` fail-closed |
| 6 | `buffer_bytes` summed N× across workers | MAX not SUM on both folds |
| 7 | defensive `None` arms drop retry batches (frame leak) | recycle `free_tx_frames` offsets before clearing |
| 8 | dead deferred-CoS dispatch path + 2 latent bugs | delete the block + helpers + test |

## Already-fixed / partial
- vtime `u64::MAX` NOT_PARTICIPATING sentinel — R-8(b)/#4271 (head-finish is a
  distinct domain, fixed here as #1).
- waterfill honored-bit for ordinals ≥64 — runtime journald warning already
  present (non-silent); a hard commit-reject belongs in the Go scheduler-map
  compiler and the trigger (>64 exact guarantee classes on one interface) is
  outside any realistic Junos config. Deferred (Go, unreachable).

## Deferred (design decision)
`worker_instances` (distinct-worker identity not threaded), `timer_level*_sleepers`
(counts wheel entries incl. stale re-parks — semantics decision),
`ShareExhausted` (policy vs capacity — new metric surface), cross-binding
submit-latency histogram (per-binding single-writer sidecar),
copy-TX attribution (per-origin vs per-transmit — no field swap found),
`active_flow_buckets_peak` (working-as-documented; live gauge is
`flow_fair_buckets_occupied`), plus the remaining rotation/lease/seqlock/
wake-tick/surplus-weight items.

## R-6 re-verdict: NOT MATERIAL
Shared residual-surplus budget read-then-consume. `consume_residual_surplus_budget`
drains the SHARED pool via CAS and `select_cos_surplus_batch_filtered` HARD-STOPS
non-exact surplus on a zero budget, so the long-run admitted rate is bounded by
the shared refill (residual_rate), NOT W× — the structural difference from the
MATERIAL R-2 (#4265) whose PER-WORKER refill had no shared drain. Worst case is a
bounded transient burst (~residual_rate/100) of BEST-EFFORT surplus,
self-correcting within one refill window; exact guarantees are serviced
strict-priority first. No fix.

## Validation
- FULL `cargo test --release` (`--test-threads=1`): **0 failed** (3578 + 54 + 8 +
  22 + 1 across binaries). All 7 new T-7 tests pass; the 2 repurposed
  `buffer_bytes` pins go RED on revert.
- LOW counter-correctness + defensive-edge fixes. #1/#2/#3/#7 touch the
  flow-fair CoS drain selection path but only on defensive/saturation/collision
  edges (normal-path selection byte-unchanged); a cluster CoS smoke is prudent
  before merge but no steady-state forwarding behavior changes.

Closes #4283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
