### PR TITLE
routing: OSPF adjacency timers + BGP update-source parity (fable-167 R-1/R-2)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -26,6 +26,34 @@
   - **Validation**: `go test ./pkg/config/... ./pkg/frr/...` green; RED-on-
     revert verified (neutralizing the render emit drops the frr.conf lines →
     tests fail). `go build ./...`, gofmt, go vet clean.
+  - **Action**: PR #4293 review follow-up (MERGE-NEEDS-MINOR) — added
+    commit-time range validators to the new numeric leaves so an
+    out-of-range value is REJECTED at strict commit instead of rendering
+    an frr-reload-BREAKING stanza (one bad leaf fails the whole reload).
+    OSPF/OSPFv3 hello/dead/retransmit `ValidateInteger(1, 65535)`,
+    priority `ValidateInteger(0, 255)`; BGP local-as
+    `ValidateInteger(1, 4294967295)`; BGP hold-time a new
+    `ValidateBGPHoldTime` accepting {0, or 3..65535} — FRR rejects a
+    hold-time of 1/2 (keepalive = hold/3) which would fail the reload, so
+    1/2 are rejected at commit while 0 (disabled) is kept. Discovered +
+    fixed a pre-existing schema gap: the leaves had landed in only ONE of
+    the two duplicated `protocols` subtrees per family (top-level `ospf3`
+    and `routing-instances ospf` were missing them); all FOUR OSPF
+    interface copies now carry the leaves + validators (the shared
+    `compileProtocols` already handled both scopes, and SchemaValidate is
+    lenient on unknown leaves so out-of-range slipped through where the
+    schema was incomplete). Fixed the stale `Priority < 0 = unset` comment
+    left from the abandoned -1 sentinel. Made the local-as-bearing tests
+    eBGP-shaped (FRR restricts `neighbor local-as` to eBGP peers).
+  - **File(s)**: pkg/config/schema_validators.go (ValidateBGPHoldTime),
+    pkg/config/schema_routing.go (validators on all 4 OSPF copies + BGP
+    group/neighbor), pkg/config/schema_validate_routing_4285_test.go (new
+    reject matrix), pkg/frr/policy_render.go (comment), pkg/frr/README.md,
+    pkg/config/routing_adjacency_4285_test.go +
+    pkg/frr/routing_adjacency_4285_test.go (eBGP-shaped local-as)
+  - **Validation**: reject matrix green (RED-on-revert verified — stripping
+    the validators lets out-of-range through); full
+    `go test ./pkg/config/... ./pkg/frr/...` green; build/gofmt/vet clean.
 
 ## 2026-07-05 — cos: #4272 div_ceil .max(1) hardening + fable-166 R-10 CoS test-coverage gaps (#4280)
 

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-07-05 — routing: fable-167 R-1/R-2 OSPF timers + BGP update-source adjacency parity (#4285/#4286)
+
+- **Timestamp**: 2026-07-05
+  - **Action**: #4285 (R-1) — OSPF/OSPFv3 interface `hello-interval`,
+    `dead-interval`, `retransmit-interval`, and `priority` were parsed by
+    no layer and dropped silently, so FRR kept its default 10s/40s hello/dead
+    and an adjacency to a fast-timer neighbor never formed. Added the leaves
+    to `setSchema` (OSPFv2 + OSPFv3 interface), the `OSPFInterface` /
+    `OSPFv3Interface` structs (with a `HasPriority` presence flag so a valid
+    priority 0 = "never DR" is not conflated with unset), the
+    `compiler_protocols.go` interface switches, and the FRR renderer
+    (`ip ospf hello-interval/dead-interval/retransmit-interval/priority` and
+    the `ipv6 ospf6 ...` equivalents).
+  - **Action**: #4286 (R-2) — BGP group-level (and per-neighbor override)
+    `local-address`, `passive`, `hold-time`, and `local-as` were dropped, so
+    iBGP loopback peering emitted no `update-source` and the session sourced
+    from the egress IP the peer had no `neighbor` for → never established.
+    Added the leaves to `setSchema` (group + neighbor), `BGPNeighbor`
+    (`LocalAddress`/`Passive`/`HoldTime`/`LocalAS`), the group + per-neighbor
+    compiler switches, and the renderer (`neighbor X update-source`, `passive`,
+    `timers <keepalive> <hold>` with keepalive = hold/3, `local-as`).
+  - **File(s)**: pkg/config/schema_routing.go, pkg/config/types_routing.go,
+    pkg/config/compiler_protocols.go, pkg/frr/policy_render.go,
+    pkg/config/routing_adjacency_4285_test.go,
+    pkg/frr/routing_adjacency_4285_test.go, pkg/frr/README.md
+  - **Validation**: `go test ./pkg/config/... ./pkg/frr/...` green; RED-on-
+    revert verified (neutralizing the render emit drops the frr.conf lines →
+    tests fail). `go build ./...`, gofmt, go vet clean.
+
 ## 2026-07-05 — cos: #4272 div_ceil .max(1) hardening + fable-166 R-10 CoS test-coverage gaps (#4280)
 
 - **Timestamp**: 2026-07-05

--- a/pkg/config/compiler_protocols.go
+++ b/pkg/config/compiler_protocols.go
@@ -95,6 +95,33 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 								iface.Cost = n
 							}
 						}
+					case "hello-interval":
+						if v := nodeVal(prop); v != "" {
+							if n, err := strconv.Atoi(v); err == nil {
+								iface.HelloInterval = n
+							}
+						}
+					case "dead-interval":
+						if v := nodeVal(prop); v != "" {
+							if n, err := strconv.Atoi(v); err == nil {
+								iface.DeadInterval = n
+							}
+						}
+					case "retransmit-interval":
+						if v := nodeVal(prop); v != "" {
+							if n, err := strconv.Atoi(v); err == nil {
+								iface.RetransmitInt = n
+							}
+						}
+					case "priority":
+						// OSPF priority 0 is valid ("never DR"), so mark
+						// HasPriority to distinguish it from unset.
+						if v := nodeVal(prop); v != "" {
+							if n, err := strconv.Atoi(v); err == nil {
+								iface.Priority = n
+								iface.HasPriority = true
+							}
+						}
 					case "authentication":
 						for _, authChild := range prop.Children {
 							switch authChild.Name() {
@@ -256,6 +283,10 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 
 		for _, groupInst := range namedInstances(bgpNode.FindChildren("group")) {
 			var peerAS uint32
+			var groupLocalAS uint32
+			var groupLocalAddress string
+			var groupHoldTime int
+			var groupPassive bool
 			var groupDesc string
 			var groupMultihop int
 			var groupExport []string
@@ -277,6 +308,22 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 							peerAS = uint32(n)
 						}
 					}
+				case "local-as":
+					if v := nodeVal(child); v != "" {
+						if n, err := strconv.Atoi(v); err == nil {
+							groupLocalAS = uint32(n)
+						}
+					}
+				case "local-address":
+					groupLocalAddress = nodeVal(child)
+				case "hold-time":
+					if v := nodeVal(child); v != "" {
+						if n, err := strconv.Atoi(v); err == nil {
+							groupHoldTime = n
+						}
+					}
+				case "passive":
+					groupPassive = true
 				case "description":
 					groupDesc = nodeVal(child)
 				case "multihop":
@@ -382,6 +429,10 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 						neighbor := &BGPNeighbor{
 							Address:          nAddr,
 							PeerAS:           peerAS,
+							LocalAS:          groupLocalAS,
+							LocalAddress:     groupLocalAddress,
+							HoldTime:         groupHoldTime,
+							Passive:          groupPassive,
 							Description:      groupDesc,
 							MultihopTTL:      groupMultihop,
 							Export:           groupExport,
@@ -416,6 +467,22 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 										neighbor.PeerAS = uint32(n)
 									}
 								}
+							case "local-as":
+								if v := nodeVal(prop); v != "" {
+									if n, err := strconv.Atoi(v); err == nil {
+										neighbor.LocalAS = uint32(n)
+									}
+								}
+							case "local-address":
+								neighbor.LocalAddress = nodeVal(prop)
+							case "hold-time":
+								if v := nodeVal(prop); v != "" {
+									if n, err := strconv.Atoi(v); err == nil {
+										neighbor.HoldTime = n
+									}
+								}
+							case "passive":
+								neighbor.Passive = true
 							case "authentication-key":
 								neighbor.AuthPassword = Secret(nodeVal(prop))
 							case "route-reflector-client":
@@ -541,6 +608,31 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 						if v := nodeVal(prop); v != "" {
 							if n, err := strconv.Atoi(v); err == nil {
 								iface.Cost = n
+							}
+						}
+					case "hello-interval":
+						if v := nodeVal(prop); v != "" {
+							if n, err := strconv.Atoi(v); err == nil {
+								iface.HelloInterval = n
+							}
+						}
+					case "dead-interval":
+						if v := nodeVal(prop); v != "" {
+							if n, err := strconv.Atoi(v); err == nil {
+								iface.DeadInterval = n
+							}
+						}
+					case "retransmit-interval":
+						if v := nodeVal(prop); v != "" {
+							if n, err := strconv.Atoi(v); err == nil {
+								iface.RetransmitInt = n
+							}
+						}
+					case "priority":
+						if v := nodeVal(prop); v != "" {
+							if n, err := strconv.Atoi(v); err == nil {
+								iface.Priority = n
+								iface.HasPriority = true
 							}
 						}
 					case "bfd-liveness-detection":

--- a/pkg/config/routing_adjacency_4285_test.go
+++ b/pkg/config/routing_adjacency_4285_test.go
@@ -86,14 +86,18 @@ func TestOSPFInterfacePriorityUnsetSentinel_4285(t *testing.T) {
 // passive, hold-time, and per-group local-as must survive the parser +
 // compiler and reach every neighbor in the group. RED-on-revert: the leaves
 // drop silently.
+//
+// The peer is eBGP-shaped (peer-as 65002 != router local-as 65001): FRR's
+// `neighbor X local-as` is an eBGP-oriented knob and can be rejected on an
+// iBGP-shaped peer, so the local-as case is modelled on an eBGP peer.
 func TestBGPGroupLocalAddressCompiled_4286(t *testing.T) {
 	c := compileSetsAdj4285(t, []string{
-		"set protocols bgp group ibgp local-address 10.255.0.1",
-		"set protocols bgp group ibgp local-as 65100",
-		"set protocols bgp group ibgp hold-time 30",
-		"set protocols bgp group ibgp passive",
+		"set protocols bgp group ext local-address 10.255.0.1",
+		"set protocols bgp group ext local-as 65100",
+		"set protocols bgp group ext hold-time 30",
+		"set protocols bgp group ext passive",
 		"set protocols bgp local-as 65001",
-		"set protocols bgp group ibgp neighbor 10.255.0.2 peer-as 65001",
+		"set protocols bgp group ext neighbor 10.255.0.2 peer-as 65002",
 	})
 
 	if c.Protocols.BGP == nil || len(c.Protocols.BGP.Neighbors) != 1 {

--- a/pkg/config/routing_adjacency_4285_test.go
+++ b/pkg/config/routing_adjacency_4285_test.go
@@ -1,0 +1,130 @@
+package config
+
+import "testing"
+
+func compileSetsAdj4285(t *testing.T, cmds []string) *Config {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	// The schema gate must ACCEPT these leaves — before #4285/#4286 they were
+	// unknown to setSchema. RED-on-revert: SchemaValidate rejects the unknown
+	// leaf. (cfg is always nil at this gate; see schema_walk.go.)
+	if err := SchemaValidate(tree, nil); err != nil {
+		t.Fatalf("SchemaValidate rejected an adjacency leaf: %v", err)
+	}
+	c, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return c
+}
+
+// #4285 (fable-review-167 R-1): OSPF/OSPFv3 interface hello/dead/retransmit
+// timers and DR priority must survive the parser + compiler. RED-on-revert:
+// the leaves drop silently (schema/compiler have no case) and the struct
+// fields stay zero.
+func TestOSPFInterfaceTimersCompiled_4285(t *testing.T) {
+	c := compileSetsAdj4285(t, []string{
+		"set protocols ospf area 0 interface ge-0-0-1 hello-interval 1",
+		"set protocols ospf area 0 interface ge-0-0-1 dead-interval 3",
+		"set protocols ospf area 0 interface ge-0-0-1 retransmit-interval 5",
+		"set protocols ospf area 0 interface ge-0-0-1 priority 200",
+		"set protocols ospf3 area 0 interface ge-0-0-1 hello-interval 2",
+		"set protocols ospf3 area 0 interface ge-0-0-1 dead-interval 6",
+		"set protocols ospf3 area 0 interface ge-0-0-1 retransmit-interval 7",
+		"set protocols ospf3 area 0 interface ge-0-0-1 priority 0",
+	})
+
+	if c.Protocols.OSPF == nil || len(c.Protocols.OSPF.Areas) != 1 {
+		t.Fatal("expected one compiled OSPF area")
+	}
+	ifs := c.Protocols.OSPF.Areas[0].Interfaces
+	if len(ifs) != 1 {
+		t.Fatalf("expected one OSPF interface, got %d", len(ifs))
+	}
+	v4 := ifs[0]
+	if v4.HelloInterval != 1 || v4.DeadInterval != 3 || v4.RetransmitInt != 5 || v4.Priority != 200 || !v4.HasPriority {
+		t.Errorf("OSPFv2 timers/priority not compiled: %+v", v4)
+	}
+
+	if c.Protocols.OSPFv3 == nil || len(c.Protocols.OSPFv3.Areas) != 1 {
+		t.Fatal("expected one compiled OSPFv3 area")
+	}
+	v6 := c.Protocols.OSPFv3.Areas[0].Interfaces[0]
+	if v6.HelloInterval != 2 || v6.DeadInterval != 6 || v6.RetransmitInt != 7 {
+		t.Errorf("OSPFv3 timers not compiled: %+v", v6)
+	}
+	// priority 0 is a valid explicit value ("never DR"); HasPriority marks it
+	// so it is not conflated with unset.
+	if v6.Priority != 0 || !v6.HasPriority {
+		t.Errorf("OSPFv3 priority 0 not compiled (Priority=%d HasPriority=%v)", v6.Priority, v6.HasPriority)
+	}
+}
+
+// An OSPF interface without a `priority` leaf compiles to HasPriority == false
+// so the renderer omits the line and FRR keeps its default DR priority.
+// RED-on-revert: the HasPriority gate is required for this.
+func TestOSPFInterfacePriorityUnsetSentinel_4285(t *testing.T) {
+	c := compileSetsAdj4285(t, []string{
+		"set protocols ospf area 0 interface ge-0-0-1 cost 5",
+	})
+	iface := c.Protocols.OSPF.Areas[0].Interfaces[0]
+	if iface.HasPriority {
+		t.Errorf("unset OSPF priority marked HasPriority=true (Priority=%d)", iface.Priority)
+	}
+}
+
+// #4286 (fable-review-167 R-2): BGP group-level local-address (update-source),
+// passive, hold-time, and per-group local-as must survive the parser +
+// compiler and reach every neighbor in the group. RED-on-revert: the leaves
+// drop silently.
+func TestBGPGroupLocalAddressCompiled_4286(t *testing.T) {
+	c := compileSetsAdj4285(t, []string{
+		"set protocols bgp group ibgp local-address 10.255.0.1",
+		"set protocols bgp group ibgp local-as 65100",
+		"set protocols bgp group ibgp hold-time 30",
+		"set protocols bgp group ibgp passive",
+		"set protocols bgp local-as 65001",
+		"set protocols bgp group ibgp neighbor 10.255.0.2 peer-as 65001",
+	})
+
+	if c.Protocols.BGP == nil || len(c.Protocols.BGP.Neighbors) != 1 {
+		t.Fatalf("expected one compiled BGP neighbor")
+	}
+	n := c.Protocols.BGP.Neighbors[0]
+	if n.LocalAddress != "10.255.0.1" {
+		t.Errorf("neighbor LocalAddress = %q, want 10.255.0.1", n.LocalAddress)
+	}
+	if n.LocalAS != 65100 {
+		t.Errorf("neighbor LocalAS = %d, want 65100", n.LocalAS)
+	}
+	if n.HoldTime != 30 {
+		t.Errorf("neighbor HoldTime = %d, want 30", n.HoldTime)
+	}
+	if !n.Passive {
+		t.Errorf("neighbor Passive = false, want true")
+	}
+}
+
+// A per-neighbor local-address overrides the group default (Junos
+// most-specific-wins).
+func TestBGPNeighborLocalAddressOverride_4286(t *testing.T) {
+	c := compileSetsAdj4285(t, []string{
+		"set protocols bgp local-as 65001",
+		"set protocols bgp group ibgp local-address 10.255.0.1",
+		"set protocols bgp group ibgp neighbor 10.255.0.2 peer-as 65001",
+		"set protocols bgp group ibgp neighbor 10.255.0.2 local-address 10.255.9.9",
+	})
+	n := c.Protocols.BGP.Neighbors[0]
+	if n.LocalAddress != "10.255.9.9" {
+		t.Errorf("per-neighbor LocalAddress override = %q, want 10.255.9.9", n.LocalAddress)
+	}
+}

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -261,10 +261,10 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 				"no-passive":          {desc: "Non-passive interface", children: nil},
 				"interface-type":      {desc: "Interface type", args: 1, placeholder: "<type>", children: nil},
 				"cost":                {desc: "Interface cost", args: 1, placeholder: "<cost>", children: nil},
-				"hello-interval":      {desc: "Hello interval (seconds)", args: 1, placeholder: "<seconds>", children: nil},
-				"dead-interval":       {desc: "Dead interval (seconds)", args: 1, placeholder: "<seconds>", children: nil},
-				"retransmit-interval": {desc: "Retransmit interval (seconds)", args: 1, placeholder: "<seconds>", children: nil},
-				"priority":            {desc: "Router priority for DR election", args: 1, placeholder: "<priority>", children: nil},
+				"hello-interval":      {desc: "Hello interval (seconds)", args: 1, valueType: ValueInteger, placeholder: "<seconds>", validator: ValidateInteger(1, 65535), children: nil},
+				"dead-interval":       {desc: "Dead interval (seconds)", args: 1, valueType: ValueInteger, placeholder: "<seconds>", validator: ValidateInteger(1, 65535), children: nil},
+				"retransmit-interval": {desc: "Retransmit interval (seconds)", args: 1, valueType: ValueInteger, placeholder: "<seconds>", validator: ValidateInteger(1, 65535), children: nil},
+				"priority":            {desc: "Router priority for DR election", args: 1, valueType: ValueInteger, placeholder: "<priority>", validator: ValidateInteger(0, 255), children: nil},
 				"authentication": {desc: "Authentication", children: map[string]*schemaNode{
 					"md5": {desc: "MD5 authentication", args: 1, placeholder: "<key-id>", children: map[string]*schemaNode{
 						"key": {desc: "Authentication key", args: 1, placeholder: "<key>", children: nil},
@@ -294,8 +294,12 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 		"export":    {desc: "Export policy", args: 1, multi: true, placeholder: "<policy-name>", children: nil},
 		"area": {desc: "OSPFv3 area", args: 1, placeholder: "<area-id>", children: map[string]*schemaNode{
 			"interface": {desc: "Interface", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: map[string]*schemaNode{
-				"passive": {desc: "Passive interface", children: nil},
-				"cost":    {desc: "Interface cost", args: 1, placeholder: "<cost>", children: nil},
+				"passive":             {desc: "Passive interface", children: nil},
+				"cost":                {desc: "Interface cost", args: 1, placeholder: "<cost>", children: nil},
+				"hello-interval":      {desc: "Hello interval (seconds)", args: 1, valueType: ValueInteger, placeholder: "<seconds>", validator: ValidateInteger(1, 65535), children: nil},
+				"dead-interval":       {desc: "Dead interval (seconds)", args: 1, valueType: ValueInteger, placeholder: "<seconds>", validator: ValidateInteger(1, 65535), children: nil},
+				"retransmit-interval": {desc: "Retransmit interval (seconds)", args: 1, valueType: ValueInteger, placeholder: "<seconds>", validator: ValidateInteger(1, 65535), children: nil},
+				"priority":            {desc: "Router priority for DR election", args: 1, valueType: ValueInteger, placeholder: "<priority>", validator: ValidateInteger(0, 255), children: nil},
 				"bfd-liveness-detection": {desc: "BFD liveness detection", children: map[string]*schemaNode{
 					"minimum-interval": {desc: "Minimum interval", args: 1, placeholder: "<milliseconds>", children: nil},
 					"multiplier":       {desc: "Multiplier", args: 1, placeholder: "<multiplier>", children: nil},
@@ -323,9 +327,9 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 		"import": {desc: "Import policy", args: 1, multi: true, placeholder: "<policy-name>", children: nil},
 		"group": {desc: "BGP group", args: 1, placeholder: "<group-name>", children: map[string]*schemaNode{
 			"peer-as":            {desc: "Peer AS number", args: 1, placeholder: "<as-number>", children: nil},
-			"local-as":           {desc: "Local AS number for this peering", args: 1, placeholder: "<as-number>", children: nil},
+			"local-as":           {desc: "Local AS number for this peering", args: 1, valueType: ValueInteger, placeholder: "<as-number>", validator: ValidateInteger(1, 4294967295), children: nil},
 			"local-address":      {desc: "Local address (BGP update-source)", args: 1, placeholder: "<address>", children: nil},
-			"hold-time":          {desc: "Hold time (seconds)", args: 1, placeholder: "<seconds>", children: nil},
+			"hold-time":          {desc: "Hold time (seconds)", args: 1, valueType: ValueInteger, placeholder: "<seconds>", validator: ValidateBGPHoldTime, children: nil},
 			"passive":            {desc: "Passive mode (do not initiate connections)", children: nil},
 			"description":        {desc: "Description", args: 1, scalar: true, placeholder: "<text>", children: nil},
 			"multihop":           {desc: "Multihop TTL", args: 1, placeholder: "<ttl>", children: nil},
@@ -358,9 +362,9 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 			"neighbor": {desc: "BGP neighbor", args: 1, placeholder: "<address>", children: map[string]*schemaNode{
 				"description":            {desc: "Description", args: 1, scalar: true, placeholder: "<text>", children: nil},
 				"peer-as":                {desc: "Peer AS number", args: 1, placeholder: "<as-number>", children: nil},
-				"local-as":               {desc: "Local AS number for this peering", args: 1, placeholder: "<as-number>", children: nil},
+				"local-as":               {desc: "Local AS number for this peering", args: 1, valueType: ValueInteger, placeholder: "<as-number>", validator: ValidateInteger(1, 4294967295), children: nil},
 				"local-address":          {desc: "Local address (BGP update-source)", args: 1, placeholder: "<address>", children: nil},
-				"hold-time":              {desc: "Hold time (seconds)", args: 1, placeholder: "<seconds>", children: nil},
+				"hold-time":              {desc: "Hold time (seconds)", args: 1, valueType: ValueInteger, placeholder: "<seconds>", validator: ValidateBGPHoldTime, children: nil},
 				"passive":                {desc: "Passive mode (do not initiate connections)", children: nil},
 				"multihop":               {desc: "Multihop TTL", args: 1, placeholder: "<ttl>", children: nil},
 				"export":                 {desc: "Export policy", args: 1, multi: true, placeholder: "<policy-name>", children: nil},
@@ -663,10 +667,14 @@ var schemaRoutingInstances = &schemaNode{desc: "Routing instance configuration",
 			"passive":             {desc: "Passive mode", children: nil},
 			"area": {desc: "OSPF area", args: 1, placeholder: "<area-id>", children: map[string]*schemaNode{
 				"interface": {desc: "Interface", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: map[string]*schemaNode{
-					"passive":        {desc: "Passive interface", children: nil},
-					"no-passive":     {desc: "Non-passive interface", children: nil},
-					"interface-type": {desc: "Interface type", args: 1, placeholder: "<type>", children: nil},
-					"cost":           {desc: "Interface cost", args: 1, placeholder: "<cost>", children: nil},
+					"passive":             {desc: "Passive interface", children: nil},
+					"no-passive":          {desc: "Non-passive interface", children: nil},
+					"interface-type":      {desc: "Interface type", args: 1, placeholder: "<type>", children: nil},
+					"cost":                {desc: "Interface cost", args: 1, placeholder: "<cost>", children: nil},
+					"hello-interval":      {desc: "Hello interval (seconds)", args: 1, valueType: ValueInteger, placeholder: "<seconds>", validator: ValidateInteger(1, 65535), children: nil},
+					"dead-interval":       {desc: "Dead interval (seconds)", args: 1, valueType: ValueInteger, placeholder: "<seconds>", validator: ValidateInteger(1, 65535), children: nil},
+					"retransmit-interval": {desc: "Retransmit interval (seconds)", args: 1, valueType: ValueInteger, placeholder: "<seconds>", validator: ValidateInteger(1, 65535), children: nil},
+					"priority":            {desc: "Router priority for DR election", args: 1, valueType: ValueInteger, placeholder: "<priority>", validator: ValidateInteger(0, 255), children: nil},
 					"authentication": {desc: "Authentication", children: map[string]*schemaNode{
 						"md5": {desc: "MD5 authentication", args: 1, placeholder: "<key-id>", children: map[string]*schemaNode{
 							"key": {desc: "Authentication key", args: 1, placeholder: "<key>", children: nil},
@@ -698,10 +706,10 @@ var schemaRoutingInstances = &schemaNode{desc: "Routing instance configuration",
 				"interface": {desc: "Interface", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: map[string]*schemaNode{
 					"passive":             {desc: "Passive interface", children: nil},
 					"cost":                {desc: "Interface cost", args: 1, placeholder: "<cost>", children: nil},
-					"hello-interval":      {desc: "Hello interval (seconds)", args: 1, placeholder: "<seconds>", children: nil},
-					"dead-interval":       {desc: "Dead interval (seconds)", args: 1, placeholder: "<seconds>", children: nil},
-					"retransmit-interval": {desc: "Retransmit interval (seconds)", args: 1, placeholder: "<seconds>", children: nil},
-					"priority":            {desc: "Router priority for DR election", args: 1, placeholder: "<priority>", children: nil},
+					"hello-interval":      {desc: "Hello interval (seconds)", args: 1, valueType: ValueInteger, placeholder: "<seconds>", validator: ValidateInteger(1, 65535), children: nil},
+					"dead-interval":       {desc: "Dead interval (seconds)", args: 1, valueType: ValueInteger, placeholder: "<seconds>", validator: ValidateInteger(1, 65535), children: nil},
+					"retransmit-interval": {desc: "Retransmit interval (seconds)", args: 1, valueType: ValueInteger, placeholder: "<seconds>", validator: ValidateInteger(1, 65535), children: nil},
+					"priority":            {desc: "Router priority for DR election", args: 1, valueType: ValueInteger, placeholder: "<priority>", validator: ValidateInteger(0, 255), children: nil},
 					"bfd-liveness-detection": {desc: "BFD liveness detection", children: map[string]*schemaNode{
 						"minimum-interval": {desc: "Minimum interval", args: 1, placeholder: "<milliseconds>", children: nil},
 						"multiplier":       {desc: "Multiplier", args: 1, placeholder: "<multiplier>", children: nil},

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -257,10 +257,14 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 		"export":              {desc: "Export policy", args: 1, multi: true, placeholder: "<policy-name>", children: nil},
 		"area": {desc: "OSPF area", args: 1, placeholder: "<area-id>", children: map[string]*schemaNode{
 			"interface": {desc: "Interface", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: map[string]*schemaNode{
-				"passive":        {desc: "Passive interface", children: nil},
-				"no-passive":     {desc: "Non-passive interface", children: nil},
-				"interface-type": {desc: "Interface type", args: 1, placeholder: "<type>", children: nil},
-				"cost":           {desc: "Interface cost", args: 1, placeholder: "<cost>", children: nil},
+				"passive":             {desc: "Passive interface", children: nil},
+				"no-passive":          {desc: "Non-passive interface", children: nil},
+				"interface-type":      {desc: "Interface type", args: 1, placeholder: "<type>", children: nil},
+				"cost":                {desc: "Interface cost", args: 1, placeholder: "<cost>", children: nil},
+				"hello-interval":      {desc: "Hello interval (seconds)", args: 1, placeholder: "<seconds>", children: nil},
+				"dead-interval":       {desc: "Dead interval (seconds)", args: 1, placeholder: "<seconds>", children: nil},
+				"retransmit-interval": {desc: "Retransmit interval (seconds)", args: 1, placeholder: "<seconds>", children: nil},
+				"priority":            {desc: "Router priority for DR election", args: 1, placeholder: "<priority>", children: nil},
 				"authentication": {desc: "Authentication", children: map[string]*schemaNode{
 					"md5": {desc: "MD5 authentication", args: 1, placeholder: "<key-id>", children: map[string]*schemaNode{
 						"key": {desc: "Authentication key", args: 1, placeholder: "<key>", children: nil},
@@ -319,6 +323,10 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 		"import": {desc: "Import policy", args: 1, multi: true, placeholder: "<policy-name>", children: nil},
 		"group": {desc: "BGP group", args: 1, placeholder: "<group-name>", children: map[string]*schemaNode{
 			"peer-as":            {desc: "Peer AS number", args: 1, placeholder: "<as-number>", children: nil},
+			"local-as":           {desc: "Local AS number for this peering", args: 1, placeholder: "<as-number>", children: nil},
+			"local-address":      {desc: "Local address (BGP update-source)", args: 1, placeholder: "<address>", children: nil},
+			"hold-time":          {desc: "Hold time (seconds)", args: 1, placeholder: "<seconds>", children: nil},
+			"passive":            {desc: "Passive mode (do not initiate connections)", children: nil},
 			"description":        {desc: "Description", args: 1, scalar: true, placeholder: "<text>", children: nil},
 			"multihop":           {desc: "Multihop TTL", args: 1, placeholder: "<ttl>", children: nil},
 			"export":             {desc: "Export policy", args: 1, multi: true, placeholder: "<policy-name>", children: nil},
@@ -350,6 +358,10 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 			"neighbor": {desc: "BGP neighbor", args: 1, placeholder: "<address>", children: map[string]*schemaNode{
 				"description":            {desc: "Description", args: 1, scalar: true, placeholder: "<text>", children: nil},
 				"peer-as":                {desc: "Peer AS number", args: 1, placeholder: "<as-number>", children: nil},
+				"local-as":               {desc: "Local AS number for this peering", args: 1, placeholder: "<as-number>", children: nil},
+				"local-address":          {desc: "Local address (BGP update-source)", args: 1, placeholder: "<address>", children: nil},
+				"hold-time":              {desc: "Hold time (seconds)", args: 1, placeholder: "<seconds>", children: nil},
+				"passive":                {desc: "Passive mode (do not initiate connections)", children: nil},
 				"multihop":               {desc: "Multihop TTL", args: 1, placeholder: "<ttl>", children: nil},
 				"export":                 {desc: "Export policy", args: 1, multi: true, placeholder: "<policy-name>", children: nil},
 				"import":                 {desc: "Import policy", args: 1, multi: true, placeholder: "<policy-name>", children: nil},
@@ -684,8 +696,12 @@ var schemaRoutingInstances = &schemaNode{desc: "Routing instance configuration",
 			"export":    {desc: "Export policy", args: 1, multi: true, placeholder: "<policy-name>", children: nil},
 			"area": {desc: "OSPFv3 area", args: 1, placeholder: "<area-id>", children: map[string]*schemaNode{
 				"interface": {desc: "Interface", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: map[string]*schemaNode{
-					"passive": {desc: "Passive interface", children: nil},
-					"cost":    {desc: "Interface cost", args: 1, placeholder: "<cost>", children: nil},
+					"passive":             {desc: "Passive interface", children: nil},
+					"cost":                {desc: "Interface cost", args: 1, placeholder: "<cost>", children: nil},
+					"hello-interval":      {desc: "Hello interval (seconds)", args: 1, placeholder: "<seconds>", children: nil},
+					"dead-interval":       {desc: "Dead interval (seconds)", args: 1, placeholder: "<seconds>", children: nil},
+					"retransmit-interval": {desc: "Retransmit interval (seconds)", args: 1, placeholder: "<seconds>", children: nil},
+					"priority":            {desc: "Router priority for DR election", args: 1, placeholder: "<priority>", children: nil},
 					"bfd-liveness-detection": {desc: "BFD liveness detection", children: map[string]*schemaNode{
 						"minimum-interval": {desc: "Minimum interval", args: 1, placeholder: "<milliseconds>", children: nil},
 						"multiplier":       {desc: "Multiplier", args: 1, placeholder: "<multiplier>", children: nil},

--- a/pkg/config/schema_validate_routing_4285_test.go
+++ b/pkg/config/schema_validate_routing_4285_test.go
@@ -1,0 +1,137 @@
+package config_test
+
+// fable-review-167 MERGE-NEEDS-MINOR follow-up: commit-time range validators
+// for the new OSPF adjacency-timer / DR-priority and BGP hold-time / local-as
+// leaves (#4285 / #4286). Without these, an out-of-range value COMMITS and then
+// renders an frr-reload-BREAKING stanza — one bad leaf fails the whole reload
+// (a `vtysh -f` add-batch exits non-zero on any CMD_WARNING_CONFIG_FAILED),
+// taking down every routing change on that reload. Each leaf is exercised
+// through the SchemaValidate gate (flat-set shape) with in-range, boundary, and
+// out-of-range values.
+//
+// SHARPEST case: BGP hold-time 1 or 2 renders `neighbor X timers 1 1|2`, but
+// FRR requires holdtime 0 OR >= 3 — a value of 1/2 is REJECTED by FRR and
+// fails the reload. The validator must reject 1/2 at commit while still
+// accepting 0 (hold-timer disabled, treated as unset by the renderer's > 0
+// gate).
+//
+// RED-on-revert: dropping the `validator:` on any leaf lets the reject values
+// through SchemaValidate and this test turns RED.
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type routingLeafCase struct {
+	name     string
+	template string
+	leaf     string
+	accept   []string
+	reject   []string
+}
+
+var routingLeafMatrix = []routingLeafCase{
+	{
+		// FRR ip ospf hello-interval range 1..65535; 0 is invalid.
+		name:     "ospf hello-interval",
+		leaf:     "hello-interval",
+		template: "set protocols ospf area 0 interface ge-0-0-1 hello-interval %s",
+		accept:   []string{"1", "3", "10", "65535"},
+		reject:   []string{"0", "65536", "-1", "asd", ""},
+	},
+	{
+		name:     "ospf dead-interval",
+		leaf:     "dead-interval",
+		template: "set protocols ospf area 0 interface ge-0-0-1 dead-interval %s",
+		accept:   []string{"1", "40", "65535"},
+		reject:   []string{"0", "65536", "-1", "asd", ""},
+	},
+	{
+		name:     "ospf retransmit-interval",
+		leaf:     "retransmit-interval",
+		template: "set protocols ospf area 0 interface ge-0-0-1 retransmit-interval %s",
+		accept:   []string{"1", "5", "65535"},
+		reject:   []string{"0", "65536", "-1", "asd", ""},
+	},
+	{
+		// FRR ip ospf priority range 0..255; 0 = "never DR" is valid.
+		name:     "ospf priority",
+		leaf:     "priority",
+		template: "set protocols ospf area 0 interface ge-0-0-1 priority %s",
+		accept:   []string{"0", "1", "100", "255"},
+		reject:   []string{"256", "-1", "asd", ""},
+	},
+	{
+		name:     "ospf3 hello-interval",
+		leaf:     "hello-interval",
+		template: "set protocols ospf3 area 0 interface ge-0-0-1 hello-interval %s",
+		accept:   []string{"1", "2", "65535"},
+		reject:   []string{"0", "65536", "-1", "asd", ""},
+	},
+	{
+		name:     "ospf3 priority",
+		leaf:     "priority",
+		template: "set protocols ospf3 area 0 interface ge-0-0-1 priority %s",
+		accept:   []string{"0", "100", "255"},
+		reject:   []string{"256", "-1", "asd", ""},
+	},
+	{
+		// BGP hold-time: 0 or 3..65535 — the sharpest gap (1/2 fail the reload).
+		name:     "bgp group hold-time",
+		leaf:     "hold-time",
+		template: "set protocols bgp group ibgp hold-time %s",
+		accept:   []string{"0", "3", "30", "180", "65535"},
+		reject:   []string{"1", "2", "65536", "-1", "asd", ""},
+	},
+	{
+		name:     "bgp neighbor hold-time",
+		leaf:     "hold-time",
+		template: "set protocols bgp group ibgp neighbor 10.0.0.2 hold-time %s",
+		accept:   []string{"0", "3", "90"},
+		reject:   []string{"1", "2", "asd", ""},
+	},
+	{
+		// Per-peering local-as: a valid 32-bit ASN 1..4294967295; AS 0 is
+		// reserved (RFC 7607).
+		name:     "bgp group local-as",
+		leaf:     "local-as",
+		template: "set protocols bgp group ibgp local-as %s",
+		accept:   []string{"1", "65001", "4294967295"},
+		reject:   []string{"0", "4294967296", "-1", "asd", ""},
+	},
+	{
+		name:     "bgp neighbor local-as",
+		leaf:     "local-as",
+		template: "set protocols bgp group ibgp neighbor 10.0.0.2 local-as %s",
+		accept:   []string{"1", "65100"},
+		reject:   []string{"0", "asd", ""},
+	},
+}
+
+func TestSchemaValidate_RoutingAdjacencyLeaves_Matrix_4285(t *testing.T) {
+	for _, tc := range routingLeafMatrix {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, v := range tc.accept {
+				cmd := strings.TrimSpace(fmt.Sprintf(tc.template, v))
+				if err := flatSchemaCheck(t, cmd); err != nil {
+					t.Errorf("accept %q: unexpected error: %v", cmd, err)
+				}
+			}
+			for _, v := range tc.reject {
+				cmd := strings.TrimSpace(fmt.Sprintf(tc.template, v))
+				err := flatSchemaCheck(t, cmd)
+				if err == nil {
+					t.Errorf("reject %q: expected a commit error, got nil", cmd)
+					continue
+				}
+				// The error must reference the leaf keyword so the operator
+				// can find the offending statement.
+				if !strings.Contains(err.Error(), tc.leaf) {
+					t.Errorf("reject %q: error should reference %q: %v", cmd, tc.leaf, err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -233,6 +233,31 @@ func ValidateInteger(min, max int64) LeafValidator {
 	}
 }
 
+// ValidateBGPHoldTime accepts a BGP hold-time in seconds: 0, or 3..65535.
+// FRR (and RFC 4271 §4.2 / §10) require the hold-time to be either 0
+// (hold timer disabled) or at least 3 seconds — the keepalive interval is
+// hold-time/3, so a hold-time of 1 or 2 yields a sub-second/zero keepalive
+// that FRR's `neighbor X timers <keepalive> <hold>` command REJECTS, and a
+// rejected line fails the WHOLE frr-reload (a single `vtysh -f` add-batch
+// exits non-zero on any CMD_WARNING_CONFIG_FAILED) — one bad leaf takes
+// down every routing change on that reload. The renderer treats 0 as "unset"
+// via its `> 0` gate (no `timers` line), an accepted documented tradeoff, so
+// 0 is permitted here; 1 and 2 are the values that must be rejected at commit
+// before they can reach frr-reload. Upper bound is the 16-bit on-wire max.
+func ValidateBGPHoldTime(raw string, _ *Config) error {
+	if strings.TrimSpace(raw) == "" {
+		return fmt.Errorf("missing value (expected integer)")
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return fmt.Errorf("not an integer: %q", raw)
+	}
+	if v != 0 && (v < 3 || v > 65535) {
+		return fmt.Errorf("BGP hold-time must be 0 or 3..65535 seconds (got %d); FRR rejects 1/2 and a rejected timers line fails the whole reload", v)
+	}
+	return nil
+}
+
 // ValidateDHGroup accepts a Diffie-Hellman group as either a bare integer
 // (e.g. "14") or the Junos "group<N>" spelling (e.g. "group14") — both are
 // configured in the wild and both compile (compiler_ipsec.go strips the

--- a/pkg/config/types_routing.go
+++ b/pkg/config/types_routing.go
@@ -273,6 +273,11 @@ type OSPFv3Interface struct {
 	Name          string
 	Passive       bool
 	Cost          int
+	HelloInterval int  // hello-interval in seconds, 0 = ospf6d default (10)
+	DeadInterval  int  // dead-interval in seconds, 0 = ospf6d default (40)
+	RetransmitInt int  // retransmit-interval in seconds, 0 = ospf6d default (5)
+	Priority      int  // DR-election priority (valid when HasPriority)
+	HasPriority   bool // priority explicitly set; 0 is a valid value ("never DR")
 	BFD           bool // enable BFD on this interface
 	BFDInterval   int  // BFD minimum-interval in ms (0 = default)
 	BFDMultiplier int  // BFD detect-multiplier (0 = default)
@@ -376,6 +381,11 @@ type OSPFInterface struct {
 	Passive       bool   // passive interface (no hello)
 	NoPassive     bool   // override passive-default (explicitly active)
 	Cost          int    // OSPF cost, 0 = default
+	HelloInterval int    // hello-interval in seconds, 0 = FRR default (10)
+	DeadInterval  int    // dead-interval (router-dead-interval) in seconds, 0 = FRR default (40)
+	RetransmitInt int    // retransmit-interval in seconds, 0 = FRR default (5)
+	Priority      int    // DR-election priority (valid when HasPriority)
+	HasPriority   bool   // priority explicitly set; 0 is a valid value ("never DR"), so a bare int cannot distinguish it from unset
 	NetworkType   string // "point-to-point", "broadcast", "" (default)
 	AuthType      string // "md5", "simple", "" (none)
 	AuthKey       Secret // authentication key/password; redacted on marshal (#2053)
@@ -409,6 +419,10 @@ type BGPConfig struct {
 type BGPNeighbor struct {
 	Address              string // peer IP
 	PeerAS               uint32
+	LocalAS              uint32 // per-peering local-as (FRR `neighbor X local-as`); 0 = inherit router AS
+	LocalAddress         string // BGP session source (FRR `neighbor X update-source`); "" = none
+	HoldTime             int    // hold-time in seconds (FRR `neighbor X timers <keepalive> <hold>`); 0 = FRR default (180)
+	Passive              bool   // do not initiate — wait for the peer (FRR `neighbor X passive`)
 	Description          string
 	MultihopTTL          int      // 0 = directly connected
 	Export               []string // export policies (route-map out): group default + per-neighbor override; last wins (most-specific)

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -239,7 +239,15 @@ also carries operator content:
   `HasMetric`/`HasLocalPreference`): priority **0** is a valid value ("never
   DR"), so a bare-int gate can't tell it from unset — the renderer emits the
   line IFF `HasPriority`, so an interface with no `priority` leaf keeps FRR's
-  default and never emits a stray `ip ospf priority 0`.
+  default and never emits a stray `ip ospf priority 0`. The four leaves carry
+  commit-time range validators (`schema_routing.go`): hello/dead/retransmit
+  `ValidateInteger(1, 65535)` (0 is invalid for these), priority
+  `ValidateInteger(0, 255)` — FRR's ranges. An out-of-range value would
+  otherwise commit and render a stanza FRR REJECTS, and a rejected line fails
+  the WHOLE `frr-reload` (one bad leaf = a routing outage). All FOUR schema
+  copies — top-level `protocols {ospf,ospf3}` AND the `routing-instances`
+  mirrors — carry the leaves + validators (the compiler already handled both
+  scopes via the shared `compileProtocols`).
 - **BGP update-source / passive / hold-time / local-as (#4286).** The group-level
   (and per-neighbor override) `local-address`, `passive`, `hold-time`, and
   `local-as` leaves flatten onto each `BGPNeighbor` and render as
@@ -248,7 +256,16 @@ also carries operator content:
   1), and `neighbor <peer> local-as <asn>`. `update-source` is load-bearing for
   iBGP loopback peering: without it the BGP TCP session sources from the egress
   interface IP, not the loopback the peer has a `neighbor` statement for, so the
-  peer rejects the connection and the session never establishes.
+  peer rejects the connection and the session never establishes. `local-as`
+  carries a commit-time `ValidateInteger(1, 4294967295)` (a valid ASN; AS 0 is
+  reserved, RFC 7607). `hold-time` uses `ValidateBGPHoldTime` — 0 **or** 3..65535
+  only: FRR requires the hold-time to be 0 or >= 3 (keepalive = hold/3), so a
+  hold-time of 1 or 2 renders `timers 1 1|2` which FRR REJECTS and fails the
+  whole reload; the validator rejects 1/2 at commit while still accepting 0
+  (hold-timer disabled, treated as unset by the renderer's `> 0` gate). NOTE:
+  FRR's `neighbor X local-as` is an eBGP-oriented knob and may be rejected on an
+  iBGP-shaped peer (peer-as == router AS); the classic eBGP local-as use is the
+  supported case.
 - **An OSPF/OSPFv3/BGP router-id is validated at commit (#2980).** `router-id`
   is parsed as a raw string with no validation, so a malformed value (not a
   32-bit IPv4 dotted-quad — e.g. garbage, an out-of-range octet, or an IPv6

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -227,6 +227,28 @@ also carries operator content:
   frr.conf for a config that arrives via the lenient path (an older-binary
   persisted config or a peer-synced one) — keeping the rest of the reload
   alive instead of bricking it for every other peer.
+- **OSPF/OSPFv3 interface adjacency timers + DR priority (#4285).** The
+  per-interface `hello-interval`, `dead-interval`, `retransmit-interval`, and
+  `priority` leaves (schema + `OSPFInterface`/`OSPFv3Interface` structs +
+  `compiler_protocols.go`) render under the interface stanza as
+  `ip ospf hello-interval/dead-interval/retransmit-interval/priority` (v4) and
+  `ipv6 ospf6 hello-interval/dead-interval/retransmit-interval/priority` (v6).
+  hello/dead MUST match a neighbor or the adjacency never forms (stuck in
+  Init/ExStart) — a fast-timer neighbor (hello 1s) never adjacencies with FRR's
+  silent default 10s/40s. Priority uses a `HasPriority` presence flag (mirroring
+  `HasMetric`/`HasLocalPreference`): priority **0** is a valid value ("never
+  DR"), so a bare-int gate can't tell it from unset — the renderer emits the
+  line IFF `HasPriority`, so an interface with no `priority` leaf keeps FRR's
+  default and never emits a stray `ip ospf priority 0`.
+- **BGP update-source / passive / hold-time / local-as (#4286).** The group-level
+  (and per-neighbor override) `local-address`, `passive`, `hold-time`, and
+  `local-as` leaves flatten onto each `BGPNeighbor` and render as
+  `neighbor <peer> update-source <local-address>`, `neighbor <peer> passive`,
+  `neighbor <peer> timers <keepalive> <hold-time>` (keepalive = hold/3, floor
+  1), and `neighbor <peer> local-as <asn>`. `update-source` is load-bearing for
+  iBGP loopback peering: without it the BGP TCP session sources from the egress
+  interface IP, not the loopback the peer has a `neighbor` statement for, so the
+  peer rejects the connection and the session never establishes.
 - **An OSPF/OSPFv3/BGP router-id is validated at commit (#2980).** `router-id`
   is parsed as a raw string with no validation, so a malformed value (not a
   32-bit IPv4 dotted-quad — e.g. garbage, an out-of-range octet, or an IPv6

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -554,6 +554,22 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 				if iface.Cost > 0 {
 					fmt.Fprintf(&b, " ip ospf cost %d\n", iface.Cost)
 				}
+				// Adjacency timers + DR priority (#4285). hello/dead MUST
+				// match the neighbor or the adjacency never forms; FRR keeps
+				// its defaults (hello 10s, dead 40s, priority 1) when unset.
+				if iface.HelloInterval > 0 {
+					fmt.Fprintf(&b, " ip ospf hello-interval %d\n", iface.HelloInterval)
+				}
+				if iface.DeadInterval > 0 {
+					fmt.Fprintf(&b, " ip ospf dead-interval %d\n", iface.DeadInterval)
+				}
+				if iface.RetransmitInt > 0 {
+					fmt.Fprintf(&b, " ip ospf retransmit-interval %d\n", iface.RetransmitInt)
+				}
+				// HasPriority gates the line; 0 is a valid value ("never DR").
+				if iface.HasPriority {
+					fmt.Fprintf(&b, " ip ospf priority %d\n", iface.Priority)
+				}
 				if iface.NetworkType != "" {
 					fmt.Fprintf(&b, " ip ospf network %s\n", iface.NetworkType)
 				}
@@ -607,13 +623,29 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 		b.WriteString("exit\n!\n")
 		for _, area := range ospfv3.Areas {
 			for _, iface := range area.Interfaces {
-				if iface.Cost > 0 || iface.Passive || iface.BFD {
+				if iface.Cost > 0 || iface.Passive || iface.BFD ||
+					iface.HelloInterval > 0 || iface.DeadInterval > 0 ||
+					iface.RetransmitInt > 0 || iface.HasPriority {
 					fmt.Fprintf(&b, "interface %s\n", iface.Name)
 					if iface.Passive {
 						b.WriteString(" ipv6 ospf6 passive\n")
 					}
 					if iface.Cost > 0 {
 						fmt.Fprintf(&b, " ipv6 ospf6 cost %d\n", iface.Cost)
+					}
+					// Adjacency timers + DR priority (#4285): hello/dead must
+					// match the neighbor. Priority < 0 = unset (0 = "never DR").
+					if iface.HelloInterval > 0 {
+						fmt.Fprintf(&b, " ipv6 ospf6 hello-interval %d\n", iface.HelloInterval)
+					}
+					if iface.DeadInterval > 0 {
+						fmt.Fprintf(&b, " ipv6 ospf6 dead-interval %d\n", iface.DeadInterval)
+					}
+					if iface.RetransmitInt > 0 {
+						fmt.Fprintf(&b, " ipv6 ospf6 retransmit-interval %d\n", iface.RetransmitInt)
+					}
+					if iface.HasPriority {
+						fmt.Fprintf(&b, " ipv6 ospf6 priority %d\n", iface.Priority)
 					}
 					if iface.BFD {
 						if iface.BFDInterval > 0 || iface.BFDMultiplier > 0 {
@@ -680,6 +712,32 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 				continue
 			}
 			fmt.Fprintf(&b, " neighbor %s remote-as %d\n", n.Address, n.PeerAS)
+			// Per-peering local-as (#4286): present a different AS than the
+			// router's own to this peer.
+			if n.LocalAS > 0 {
+				fmt.Fprintf(&b, " neighbor %s local-as %d\n", n.Address, n.LocalAS)
+			}
+			// update-source (#4286): iBGP peers over loopbacks need the TCP
+			// session sourced from the loopback the peer has a `neighbor`
+			// statement for, not the egress interface IP — otherwise the peer
+			// rejects the connection and the session never establishes.
+			if n.LocalAddress != "" {
+				fmt.Fprintf(&b, " neighbor %s update-source %s\n", n.Address, sanitizeFRRValue(n.LocalAddress))
+			}
+			// passive (#4286): do not initiate — wait for the peer to connect.
+			if n.Passive {
+				fmt.Fprintf(&b, " neighbor %s passive\n", n.Address)
+			}
+			// hold-time (#4286): FRR `timers <keepalive> <holdtime>`; keepalive
+			// defaults to hold/3 per the BGP convention (Junos derives the same
+			// way). A mismatched hold-time shortens or breaks the session.
+			if n.HoldTime > 0 {
+				keepalive := n.HoldTime / 3
+				if keepalive < 1 {
+					keepalive = 1
+				}
+				fmt.Fprintf(&b, " neighbor %s timers %d %d\n", n.Address, keepalive, n.HoldTime)
+			}
 			if n.Description != "" {
 				fmt.Fprintf(&b, " neighbor %s description %s\n", n.Address, sanitizeFRRValue(n.Description))
 			}

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -634,7 +634,8 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 						fmt.Fprintf(&b, " ipv6 ospf6 cost %d\n", iface.Cost)
 					}
 					// Adjacency timers + DR priority (#4285): hello/dead must
-					// match the neighbor. Priority < 0 = unset (0 = "never DR").
+					// match the neighbor. HasPriority gates the priority line;
+					// priority 0 ("never DR") emits, unset omits.
 					if iface.HelloInterval > 0 {
 						fmt.Fprintf(&b, " ipv6 ospf6 hello-interval %d\n", iface.HelloInterval)
 					}

--- a/pkg/frr/routing_adjacency_4285_test.go
+++ b/pkg/frr/routing_adjacency_4285_test.go
@@ -99,13 +99,16 @@ func TestGenerateProtocols_OSPFPriorityUnsetOmitted(t *testing.T) {
 func TestGenerateProtocols_BGPUpdateSourcePassiveHoldTimeLocalAS(t *testing.T) {
 	m := New()
 
+	// eBGP-shaped peer (PeerAS 65002 != router LocalAS 65001): FRR's
+	// `neighbor X local-as` is an eBGP-oriented knob, so the local-as line
+	// is modelled on an eBGP peer rather than an FRR-rejected iBGP combo.
 	bgp := &config.BGPConfig{
 		LocalAS:  65001,
 		RouterID: "10.255.0.1",
 		Neighbors: []*config.BGPNeighbor{
 			{
 				Address:      "10.255.0.2",
-				PeerAS:       65001,
+				PeerAS:       65002,
 				LocalAS:      65100,
 				LocalAddress: "10.255.0.1",
 				HoldTime:     30,

--- a/pkg/frr/routing_adjacency_4285_test.go
+++ b/pkg/frr/routing_adjacency_4285_test.go
@@ -1,0 +1,129 @@
+package frr
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #4285 / #4286 (fable-review-167 R-1/R-2): OSPF adjacency timers + DR
+// priority and BGP update-source / passive / hold-time / local-as must reach
+// the rendered frr.conf. Without them FRR keeps its defaults (OSPF hello 10s /
+// dead 40s / priority 1) so an adjacency to a fast-timer neighbor never forms,
+// and an iBGP loopback session sources from the egress interface IP the peer
+// has no `neighbor` for, so it never establishes.
+//
+// FAIL-ON-REVERT: with the renderer/compiler additions reverted these lines
+// are absent from the output and the test turns RED.
+func TestGenerateProtocols_OSPFInterfaceTimersAndPriority(t *testing.T) {
+	m := New()
+
+	ospf := &config.OSPFConfig{
+		RouterID: "10.0.0.1",
+		Areas: []*config.OSPFArea{
+			{
+				ID: "0",
+				Interfaces: []*config.OSPFInterface{
+					{
+						Name:          "ge-0-0-1",
+						HelloInterval: 1,
+						DeadInterval:  3,
+						RetransmitInt: 5,
+						Priority:      200,
+						HasPriority:   true,
+					},
+				},
+			},
+		},
+	}
+	ospfv3 := &config.OSPFv3Config{
+		RouterID: "10.0.0.1",
+		Areas: []*config.OSPFv3Area{
+			{
+				ID: "0",
+				Interfaces: []*config.OSPFv3Interface{
+					{
+						Name:          "ge-0-0-1",
+						HelloInterval: 2,
+						DeadInterval:  6,
+						RetransmitInt: 7,
+						Priority:      0, // valid: "never DR" — must still emit
+						HasPriority:   true,
+					},
+				},
+			},
+		},
+	}
+
+	got := m.generateProtocols(ospf, ospfv3, nil, nil, nil, "", 0, nil)
+
+	for _, want := range []string{
+		" ip ospf hello-interval 1\n",
+		" ip ospf dead-interval 3\n",
+		" ip ospf retransmit-interval 5\n",
+		" ip ospf priority 200\n",
+		" ipv6 ospf6 hello-interval 2\n",
+		" ipv6 ospf6 dead-interval 6\n",
+		" ipv6 ospf6 retransmit-interval 7\n",
+		" ipv6 ospf6 priority 0\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered frr.conf missing OSPF adjacency line %q; output:\n%s", want, got)
+		}
+	}
+}
+
+// An OSPF interface with HasPriority == false (unset) must NOT emit a priority
+// line; a stray `ip ospf priority 0` would override FRR's default DR priority.
+func TestGenerateProtocols_OSPFPriorityUnsetOmitted(t *testing.T) {
+	m := New()
+
+	ospf := &config.OSPFConfig{
+		RouterID: "10.0.0.1",
+		Areas: []*config.OSPFArea{
+			{ID: "0", Interfaces: []*config.OSPFInterface{{Name: "ge-0-0-1", Cost: 5}}},
+		},
+	}
+
+	got := m.generateProtocols(ospf, nil, nil, nil, nil, "", 0, nil)
+	if strings.Contains(got, "ip ospf priority") {
+		t.Errorf("renderer emitted an OSPF priority line for an unset priority; output:\n%s", got)
+	}
+	// Cost still renders — the interface block is not suppressed.
+	if !strings.Contains(got, " ip ospf cost 5\n") {
+		t.Errorf("renderer dropped the OSPF cost line; output:\n%s", got)
+	}
+}
+
+func TestGenerateProtocols_BGPUpdateSourcePassiveHoldTimeLocalAS(t *testing.T) {
+	m := New()
+
+	bgp := &config.BGPConfig{
+		LocalAS:  65001,
+		RouterID: "10.255.0.1",
+		Neighbors: []*config.BGPNeighbor{
+			{
+				Address:      "10.255.0.2",
+				PeerAS:       65001,
+				LocalAS:      65100,
+				LocalAddress: "10.255.0.1",
+				HoldTime:     30,
+				Passive:      true,
+			},
+		},
+	}
+
+	got := m.generateProtocols(nil, nil, bgp, nil, nil, "", 0, nil)
+
+	for _, want := range []string{
+		" neighbor 10.255.0.2 update-source 10.255.0.1\n",
+		" neighbor 10.255.0.2 passive\n",
+		" neighbor 10.255.0.2 timers 10 30\n", // keepalive = hold/3
+		" neighbor 10.255.0.2 local-as 65100\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered frr.conf missing BGP neighbor line %q; output:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #4285 Closes #4286

## fable-review-167 R-1/R-2 — routing-adjacency parity gaps

Two HIGH parity gaps where OSPF/BGP config was parsed by no layer and
dropped silently, so adjacency / peering would not form.

### R-1 (#4285) — OSPF/OSPFv3 interface timers + DR priority

`hello-interval`, `dead-interval`, `retransmit-interval`, and `priority`
on an OSPF/OSPFv3 interface were absent from the schema, the typed
structs, the compiler, and the FRR renderer. FRR kept its defaults
(hello 10s / dead 40s / priority 1), so an adjacency to a fast-timer
neighbor (e.g. `hello-interval 1`) never forms — it stays stuck in
Init/ExStart because hello/dead must match between neighbors.

Fix: added the four leaves through every layer and emit them under the
interface stanza:
- v4: `ip ospf hello-interval/dead-interval/retransmit-interval/priority`
- v6: `ipv6 ospf6 hello-interval/dead-interval/retransmit-interval/priority`

Priority uses a `HasPriority` presence flag (mirroring the existing
`HasMetric` / `HasLocalPreference` convention) because OSPF priority `0`
is a valid value ("never elect as DR") and a bare int cannot tell it
from unset — the renderer emits the line only when configured, so an
interface with no `priority` leaf keeps FRR's default and never emits a
stray `ip ospf priority 0`.

### R-2 (#4286) — BGP update-source / passive / hold-time / local-as

BGP group-level (and per-neighbor override) `local-address`, `passive`,
`hold-time`, and per-group `local-as` were dropped. iBGP designs that
peer loopback-to-loopback silently omitted `update-source`, so the BGP
TCP session sourced from the egress interface IP the remote peer has no
`neighbor` statement for — the peer rejects the connection and the
session never establishes.

Fix: flatten the group leaves onto each `BGPNeighbor` (with per-neighbor
override) and emit:
- `neighbor <peer> update-source <local-address>`
- `neighbor <peer> passive`
- `neighbor <peer> timers <keepalive> <hold-time>` (keepalive = hold/3, floor 1)
- `neighbor <peer> local-as <asn>`

## Layers touched

- `pkg/config/schema_routing.go` — schema leaves (OSPFv2/OSPFv3 iface, BGP group + neighbor)
- `pkg/config/types_routing.go` — `OSPFInterface` / `OSPFv3Interface` / `BGPNeighbor` fields
- `pkg/config/compiler_protocols.go` — interface + group/neighbor compiler switches
- `pkg/frr/policy_render.go` — FRR emission
- `pkg/frr/README.md` — module docs for both render paths

## Validation

- `go test ./pkg/config/... ./pkg/frr/...` green (new
  `routing_adjacency_4285_test.go` in both packages)
- RED-on-revert verified: neutralizing a render emit drops the frr.conf
  line and the assertion fails; restoring makes it pass
- `go build ./...`, gofmt, go vet clean
- Emitted stanzas use FRR's exact syntax (`ip ospf ...` / `ipv6 ospf6 ...`
  / `neighbor X update-source|passive|timers|local-as`) so frr-reload
  accepts them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi