### PR TITLE
NAT parity: resolve then static-nat prefix-name + advisories for port-overloading / translation-target routing-instance (#4290 #4291 #4292)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -35282,3 +35282,46 @@ top.
   userspace-dp/src/afxdp/poll_descriptor/mod.rs,
   userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs,
   userspace-dp/src/filter/README.md, _Log.md
+
+## 2026-07-05 — fable-review-167 NAT parity N-1/N-2/N-3 (#4290/#4291/#4292)
+
+- **Timestamp**: 2026-07-05
+- **Action**: Three NAT compiler parity fixes (Go-only, pkg/config).
+  - **N-1 (#4290, real fix)**: `then static-nat prefix-name <addr>` used to
+    fall through the compiler's then-target switch, leaving `rule.Then == ""`
+    — a static NAT that committed clean and installed with an EMPTY
+    translation target. Added a `prefix-name` case (records
+    `StaticNATRule.ThenPrefixName`), a post-address-book-fold resolver
+    (`resolveStaticNATThenPrefixNames`, compiler.go — resolves the named
+    global address-book entry to its literal prefix into `rule.Then`), and a
+    defensive empty-target guard (`validateStaticNATThenTargetStrict`) that
+    hard-rejects at strict commit ANY non-NPTv6 static rule whose then-target
+    is empty (unresolvable prefix-name OR unhandled/typo'd keyword). Lenient
+    load / peer-sync warns (#1960); dataplane fails closed.
+  - **N-2 (#4291, typed leaf + advisory)**: `nat source interface
+    port-overloading off` + pool `port-overloading-factor <n>` were unmodeled
+    and silently dropped (`off` hardened nothing). Added typed setSchema
+    leaves (`interface { port-overloading (off) }`, pool
+    `port-overloading-factor` int 1..32), typed fields
+    (`NATConfig.SourceInterfacePortOverloadingOff`,
+    `NATPool.PortOverloadingFactor`), and an accepted-only advisory. Full
+    SNAT-allocator enforcement = userspace-dp follow-up (noted).
+  - **N-3 (#4292, typed leaf + advisory)**: the NAT translation-TARGET
+    routing-instance (`then static-nat {inet|prefix} routing-instance <ri>`,
+    source/destination pool `routing-instance <ri>`) was silently dropped
+    (distinct from the enforced #3096 from/to SCOPE RI). Added parsing (static
+    then + both pool loops), typed fields (`StaticNATRule.ThenRoutingInstance`,
+    `NATPool.RoutingInstance`), source-pool `routing-instance` schema leaf, and
+    an accepted-only advisory. Cross-VRF-NAT enforcement = userspace-dp
+    follow-up (noted).
+  - **Validation**: 11 new RED-on-revert tests
+    (compiler_nat_target_parity_hb167_test.go) — proven RED by neutering just
+    the behavioral logic (types/schema kept) and observing all 11 fail, then
+    green after restore. `go test ./pkg/config/...` green; `go build ./...`
+    clean; gofmt + vet clean; `go test ./pkg/dataplane/userspace/...` green
+    (additive type fields, snapshot builder unchanged).
+- **File(s)**: pkg/config/types_security.go, pkg/config/compiler_nat.go,
+  pkg/config/compiler.go, pkg/config/schema_security.go,
+  pkg/config/compiler_validate_warn.go,
+  pkg/config/compiler_nat_target_parity_hb167_test.go,
+  docs/feature-gaps.md, docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -35382,3 +35382,27 @@ top.
   pkg/config/compiler_validate_warn.go,
   pkg/config/compiler_nat_target_parity_hb167_test.go,
   docs/feature-gaps.md, docs/config-schema.md, _Log.md
+
+## 2026-07-05 — fable-167 NAT PR #4294 Copilot fold: trailing-RI last-occurrence (#4292)
+
+- **Timestamp**: 2026-07-05
+- **Action**: Folded a Copilot correctness edge on PR #4294.
+  `staticNATRoutingInstanceFromKeys` (compiler_nat.go) scanned the collapsed
+  static-nat then-leaf Keys forward and returned the FIRST "routing-instance"
+  occurrence. The Junos grammar is TRAILING (`then static-nat <target>
+  routing-instance <ri>` — the target RI is at the tail), so an earlier
+  "routing-instance" token in the key list (e.g. a `prefix-name` whose
+  address-book entry is pathologically NAMED "routing-instance") made
+  first-match return the wrong token → ThenRoutingInstance + the advisory
+  referenced the wrong RI. Changed the scan to iterate BACKWARD and return the
+  LAST occurrence. The sibling N-3 key captures (pool `routing-instance` via
+  `nodeVal`, the `t.FindChild("routing-instance")` single-leaf path) do NOT use
+  a trailing key-scan, so no other site needed the fix.
+- **Validation**: 2 new tests (last-occurrence pathological entry-named-
+  "routing-instance" → MYVRF; normal `prefix-name FOO routing-instance MYVRF`
+  → MYVRF), proven RED under the first-match revert (recorded "routing-instance"
+  instead of MYVRF), green after. Full `go test ./pkg/config/...` green;
+  `go build ./...` clean; gofmt + vet clean. Rebased origin/master (#4293
+  routing merge, clean auto-merge of _Log.md).
+- **File(s)**: pkg/config/compiler_nat.go,
+  pkg/config/compiler_nat_target_parity_hb167_test.go, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1543,8 +1543,10 @@ reserved for whole-dataplane selection where a rewrite shim
     port-mapped static-NAT rule matches on. The companion
     `then static-nat prefix <ip> mapped-port <port>` carries the internal
     (post-translation) port. `static-nat` deliberately stays a
-    `children: nil` free-form leaf (so `prefix <ip> mapped-port <port>`
-    collapses onto ONE leaf node and SetPath grouping is preserved); the
+    `children: nil` free-form leaf (so `prefix <ip> mapped-port <port>`,
+    `prefix-name <addr>` (#4290), and a trailing
+    `... routing-instance <ri>` (#4292) all collapse onto ONE leaf node and
+    SetPath grouping is preserved); the
     `mapped-port` token therefore bypasses the schema value validator and
     is range-checked in the compiler (`validateNATHostMaskStrict`,
     `compiler_nat.go`), which ALSO rejects a `mapped-port` with no
@@ -1609,6 +1611,40 @@ reserved for whole-dataplane selection where a rewrite shim
     combinations (the #3303 snapshot tests call the builder directly and
     bypass the strict validator, which is how the over-reject survived for
     the three combinations the #3425 SNAT-source test did not cover).
+  - `security nat static rule-set rule then static-nat prefix-name <addr>`
+    (#4290) — the NAMED form of `then static-nat prefix <ip>`. `prefix-name`
+    references a global `security address-book` entry whose literal prefix
+    is the 1:1 translation target. The compiler records the raw name
+    (`StaticNATRule.ThenPrefixName`) and `resolveStaticNATThenPrefixNames`
+    (compiler.go, run AFTER `resolveZoneLocalAddressBooks` folds the
+    zone-local books into the global book — `compileNAT` can run before
+    `compileAddressBook` within a `security {}` root, so resolution cannot
+    happen inline in the then switch) resolves it to the single prefix and
+    writes `rule.Then`. A single `address <name> <prefix>` resolves to its
+    prefix; a one-member `address-set` resolves to that member's prefix;
+    anything else (undefined / prefix-less / multi-member / dangling) leaves
+    `Then == ""`. Before #4290 the target keyword fell through the then
+    switch and the rule installed with an EMPTY translation target (silent
+    broken static NAT). A defensive **empty-target guard**
+    (`validateStaticNATThenTargetStrict`) now rejects at strict commit ANY
+    non-NPTv6 `then static-nat` that produced `Then == ""` — the unresolvable
+    `prefix-name` AND any unhandled/misspelled target keyword — reusing the
+    `lenientFirewallRefs` downgrade (warn on load / peer-sync, #1960; the
+    dataplane fails closed since the empty prefix does not parse as an IP).
+  - **Accepted-only NAT knobs (typed + advisory, not enforced).** Three
+    knobs are now schema-typed so they complete and commit, but the
+    userspace dataplane does not enforce them — commit emits an accepted-only
+    advisory (`ValidateConfig`, mirroring the #2078/#4231 doctrine) instead
+    of the prior silent drop: `security nat source interface port-overloading`
+    (enum `{off}`) and pool `port-overloading-factor <n>` (`ValueInteger`
+    1..32) (#4291 — the SNAT allocator always overloads source ports, so
+    `off` hardens nothing); and the NAT translation-TARGET routing-instance —
+    the source/destination pool `routing-instance <ri>` leaf and the free-form
+    `then static-nat {inet|prefix <ip>} routing-instance <ri>` trailing token
+    (#4292 — the dataplane routes the post-translation packet against the
+    ingress / default instance; DISTINCT from the enforced #3096 from/to SCOPE
+    routing-instance). Full enforcement of all three is a userspace-dp
+    follow-up.
   - `protocols router-advertisement interface` — typed the
     second-denominated leaves (`max/min-advertisement-interval`,
     `default-lifetime`, `link-mtu`; the latter was tightened from

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -184,7 +184,7 @@ User-based policy enforcement integrating with directory services. Not implement
 
 ## 8. NAT Enhancements
 
-xpf has SNAT (interface + pool, address-persistent, source-nat off bypass), DNAT (with pools, hit counters, source-address-name match, destination-address-name match (#3229), protocol-only match, port rewriting, multi-port matching, destination-nat off exemption (#3844)), static 1:1 (host AND block-to-block subnet mappings, #3031), NAT64, and exemption rules. These are additional NAT features from the vSRX.
+xpf has SNAT (interface + pool, address-persistent, source-nat off bypass), DNAT (with pools, hit counters, source-address-name match, destination-address-name match (#3229), protocol-only match, port rewriting, multi-port matching, destination-nat off exemption (#3844)), static 1:1 (host AND block-to-block subnet mappings, #3031; named translation target `then static-nat prefix-name <addr>`, #4290), NAT64, and exemption rules. These are additional NAT features from the vSRX.
 
 > **DNAT `match destination-address` now honors a multi-host prefix
 > (#3164 — supersedes the #3029 exact-host limitation).** The userspace
@@ -222,6 +222,42 @@ xpf has SNAT (interface + pool, address-persistent, source-nat off bypass), DNAT
 > The commit gate REJECTS a block pair that also specifies a port, and the
 > dataplane lenient-load path drops it rather than mis-installing an
 > all-port block (#3202).
+>
+> **Named static-NAT target `then static-nat prefix-name <addr>` (#4290,
+> fable-167 N-1).** The named form of `then static-nat prefix <ip>`:
+> `prefix-name` references a global address-book entry whose literal prefix
+> is the 1:1 translation target. Before #4290 the target keyword fell
+> through the compiler's `then` switch (which recognized only
+> `nptv6-prefix` / `prefix` / `inet`), leaving `rule.Then == ""` — the rule
+> committed clean and installed with an **empty translation target** (a
+> silent broken static NAT). The compiler now resolves the referenced
+> address-book entry to its prefix (`resolveStaticNATThenPrefixNames`, run
+> after the zone-local books are folded into the global book). A defensive
+> **empty-target guard** (`validateStaticNATThenTargetStrict`) now REJECTS
+> at strict commit ANY `then static-nat` that produced an empty target —
+> an unresolvable `prefix-name` OR an unhandled/misspelled target keyword —
+> so no static-NAT rule can commit with no translation. Lenient load /
+> peer-sync downgrades to a warning (#1960) and the dataplane fails closed
+> (the empty prefix does not parse as an IP).
+
+> **Accepted-only NAT knobs (advisory, not enforced).** Three NAT knobs are
+> now schema-typed and committed but the userspace AF_XDP dataplane does not
+> enforce them; each emits a commit-time accepted-only advisory (mirroring
+> the #2078 / #4231 doctrine) instead of the prior silent drop:
+> - `security nat source interface port-overloading off` and pool
+>   `port-overloading-factor <n>` (#4291, fable-167 N-2) — the SNAT allocator
+>   always overloads source ports, so `off` hardened NOTHING; the advisory
+>   makes the false hardening operator-visible. Unique-src-port-per-mapping
+>   and factor-scaled port budgeting are a userspace-dp SNAT-allocator
+>   follow-up.
+> - the NAT translation-**target** routing-instance — `then static-nat
+>   {inet|prefix <ip>} routing-instance <ri>` and a source / destination
+>   pool `routing-instance <ri>` (#4292, fable-167 N-3) — the dataplane
+>   routes the post-translation packet against the ingress / default routing
+>   instance, so the target RI was silently dropped. This is DISTINCT from
+>   the #3096 from/to **scope** routing-instance, which IS enforced. Placing
+>   the translated packet in a non-ingress table (cross-VRF NAT) is a
+>   userspace-dp follow-up.
 
 > **NAT64 inbound policy now matches the real internal IPv4 host (#2358,
 > resolved).** For inbound NAT64 flows the security policy is evaluated

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -2326,6 +2326,14 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	// tokens and synthetic global entries.
 	resolveZoneLocalAddressBooks(&cfg.Security)
 
+	// #4290 — resolve `then static-nat prefix-name <name>` translation targets
+	// into their literal prefix now that the global address book is fully
+	// folded (compileNAT can run before compileAddressBook within a `security {}`
+	// root, so this cannot happen inline in the then switch). An unresolvable
+	// reference leaves Then=="" and is rejected below by
+	// validateStaticNATThenTargetStrict (warn on the tolerant path).
+	resolveStaticNATThenPrefixNames(&cfg.Security)
+
 	// #1538 — accumulate independent strict-validator families so
 	// `commit check` surfaces one error per family in a single
 	// response. This saves operator round-trips on first-touch
@@ -3505,6 +3513,23 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientFirewallRefs {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("NAT address-name reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #4290: reject a static-NAT rule that would install with an EMPTY
+	// translation target — an unresolvable `then static-nat prefix-name` or a
+	// misspelled / unhandled target keyword the free-form static-nat leaf
+	// accepted. Both silently installed a 1:1 NAT with no translation. Strict on
+	// commit / commit-check (hard reject so the broken target is operator-
+	// visible); lenient on load / peer-sync (warn — #1960; the dataplane then
+	// fails closed on the empty prefix). Reuses lenientFirewallRefs, the same
+	// opt the NAT address-name gate above uses.
+	if err := validateStaticNATThenTargetStrict(cfg); err != nil {
+		if opts.lenientFirewallRefs {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("static NAT translation target (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -1292,6 +1292,28 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 		sec.NAT.AddressPersistent = true
 	}
 
+	// #4291: `nat source interface port-overloading off` disables source-port
+	// reuse across destinations (a src-port-uniqueness hardening posture).
+	// Accepted + recorded for the advisory (ValidateConfig); NOT enforced —
+	// source-port overloading is always on in the SNAT allocator, so `off`
+	// hardens nothing. Handle both the flat-set collapse
+	// (["interface","port-overloading","off"]) and the hierarchical
+	// `interface { port-overloading off; }` shape.
+	if ifNode := node.FindChild("interface"); ifNode != nil {
+		poOff := false
+		for i := 0; i+1 < len(ifNode.Keys); i++ {
+			if ifNode.Keys[i] == "port-overloading" && ifNode.Keys[i+1] == "off" {
+				poOff = true
+			}
+		}
+		if po := ifNode.FindChild("port-overloading"); po != nil && nodeVal(po) == "off" {
+			poOff = true
+		}
+		if poOff {
+			sec.NAT.SourceInterfacePortOverloadingOff = true
+		}
+	}
+
 	// Parse source NAT pools
 	for _, inst := range namedInstances(node.FindChildren("pool")) {
 		pool := &NATPool{Name: inst.name}
@@ -1463,6 +1485,25 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 					}
 				}
 				pool.PersistentNAT = pnat
+			case "port-overloading-factor":
+				// #4291: source-pool port-overloading-factor <n>. Accepted +
+				// recorded for the advisory (ValidateConfig); not enforced —
+				// the SNAT allocator has no factor-scaled port budget. Flat-set
+				// collapses ["port-overloading-factor","<n>"] onto Keys; the
+				// hierarchical shape carries the value as nodeVal.
+				if v := nodeVal(prop); v != "" {
+					if n, err := strconv.Atoi(v); err == nil {
+						pool.PortOverloadingFactor = n
+					}
+				}
+			case "routing-instance":
+				// #4292: source-pool translation-target routing-instance.
+				// Accepted + recorded for the advisory; not enforced (the
+				// dataplane does not route the post-translation packet against
+				// a non-ingress table).
+				if v := nodeVal(prop); v != "" {
+					pool.RoutingInstance = v
+				}
 			}
 		}
 		if pool.PortLow == 0 {
@@ -1811,6 +1852,14 @@ func compileNATDestination(node *Node, sec *SecurityConfig) error {
 						pool.Port = n
 					}
 				}
+			case "routing-instance":
+				// #4292: destination-pool translation-target routing-instance.
+				// Accepted + recorded for the advisory (ValidateConfig); not
+				// enforced (the dataplane does not route the post-translation
+				// packet against a non-ingress table).
+				if v := nodeVal(prop); v != "" {
+					pool.RoutingInstance = v
+				}
 			}
 		}
 
@@ -2115,6 +2164,124 @@ func staticNATMappedPortFromKeys(keys []string) int {
 	return 0
 }
 
+// staticNATRoutingInstanceFromKeys scans a collapsed static-nat `then` leaf's
+// Keys for a trailing `routing-instance <ri>` translation target (#4292) and
+// returns the instance name (or "" when absent). Mirrors
+// staticNATMappedPortFromKeys — the free-form static-nat leaf absorbs the whole
+// `then static-nat <target> routing-instance <ri>` line onto one node's Keys in
+// the flat-set shape.
+func staticNATRoutingInstanceFromKeys(keys []string) string {
+	for i := 0; i+1 < len(keys); i++ {
+		if keys[i] == "routing-instance" {
+			return keys[i+1]
+		}
+	}
+	return ""
+}
+
+// resolveStaticNATThenPrefixName resolves a `then static-nat prefix-name <name>`
+// reference (#4290) to the single literal prefix that names the 1:1 translation
+// target. Junos `prefix-name` references a single global address-book entry: an
+// `address <name> <prefix>` resolves to its prefix; an `address-set` that
+// expands to exactly one address resolves to that address's prefix; anything
+// else (undefined, an address with no prefix, an empty / multi-member set,
+// dangling) is not a valid scalar 1:1 target and returns ok=false so the caller
+// leaves Then=="" and the strict guard rejects it.
+func resolveStaticNATThenPrefixName(ab *AddressBook, name string) (string, bool) {
+	if ab == nil || name == "" {
+		return "", false
+	}
+	if a, ok := ab.Addresses[name]; ok && a != nil && a.Value != "" {
+		return a.Value, true
+	}
+	if _, ok := ab.AddressSets[name]; ok {
+		members, err := ExpandAddressSet(name, ab)
+		if err != nil || len(members) != 1 {
+			return "", false
+		}
+		if a, ok := ab.Addresses[members[0]]; ok && a != nil && a.Value != "" {
+			return a.Value, true
+		}
+	}
+	return "", false
+}
+
+// resolveStaticNATThenPrefixNames resolves every `then static-nat prefix-name`
+// reference recorded during compileNATStatic into the rule's literal Then
+// target (#4290). It runs AFTER the zone-local address books are folded into the
+// global book (compiler.go), so the fully-resolved global book is available
+// (compileNAT can run before compileAddressBook within a single `security {}`
+// root, so resolution cannot happen inline in the then switch). An unresolvable
+// reference leaves Then=="" — validateStaticNATThenTargetStrict then rejects it
+// at strict commit (warns on the lenient load / peer-sync path, #1960).
+func resolveStaticNATThenPrefixNames(sec *SecurityConfig) {
+	ab := sec.AddressBook
+	for _, rs := range sec.NAT.Static {
+		if rs == nil {
+			continue
+		}
+		for _, rule := range rs.Rules {
+			if rule == nil || rule.ThenPrefixName == "" || rule.Then != "" {
+				continue
+			}
+			if prefix, ok := resolveStaticNATThenPrefixName(ab, rule.ThenPrefixName); ok {
+				rule.Then = prefix
+			}
+		}
+	}
+}
+
+// validateStaticNATThenTargetStrict rejects a static-NAT rule that would install
+// with an EMPTY translation target (#4290). Two causes both leave Then=="":
+//
+//   - an unresolvable `then static-nat prefix-name <name>` (undefined /
+//     multi-member / prefix-less address-book entry — resolveStaticNATThen-
+//     PrefixNames could not fill Then); and
+//   - a bare / misspelled `then static-nat` target keyword (a typo the free-form
+//     static-nat leaf accepted — the then switch matched no case).
+//
+// Both previously committed cleanly and installed a static NAT with no
+// translation (silent broken 1:1). NPTv6 rules are skipped (their Then holds the
+// nptv6 prefix and buildStaticNATSnapshots handles them on a separate path).
+// Strict on commit / commit-check (hard reject); the call site downgrades to a
+// warning on the tolerant load / peer-sync path (#1960) where the dataplane then
+// fails closed (the empty prefix does not parse as an IP → no translation).
+// Rule-sets are walked in slice order for a deterministic first error.
+func validateStaticNATThenTargetStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	for _, rs := range cfg.Security.NAT.Static {
+		if rs == nil {
+			continue
+		}
+		for _, rule := range rs.Rules {
+			if rule == nil || rule.IsNPTv6 || rule.Then != "" {
+				continue
+			}
+			if rule.ThenPrefixName != "" {
+				return fmt.Errorf(
+					"static NAT rule-set %q rule %q references `then static-nat "+
+						"prefix-name %q`, which does not resolve to a single "+
+						"address-book prefix (define `security address-book "+
+						"global address %s <prefix>`, or fix the name — the "+
+						"translation target would otherwise be silently empty "+
+						"and the 1:1 NAT would install with no target) (#4290)",
+					rs.Name, rule.Name, rule.ThenPrefixName, rule.ThenPrefixName)
+			}
+			return fmt.Errorf(
+				"static NAT rule-set %q rule %q has an empty `then static-nat` "+
+					"translation target (an unhandled or misspelled target "+
+					"keyword — expected prefix | prefix-name | nptv6-prefix | "+
+					"inet) — the rule would otherwise install with no "+
+					"translation and silently forward the packet untranslated "+
+					"(#4290)",
+				rs.Name, rule.Name)
+		}
+	}
+	return nil
+}
+
 func compileNATStatic(node *Node, sec *SecurityConfig) error {
 	for _, rsInst := range namedInstances(node.FindChildren("rule-set")) {
 		// #3096: capture from scope across zone | interface |
@@ -2185,6 +2352,11 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 				rule.Then = ""
 				rule.IsNPTv6 = false
 				rule.MappedPort = 0
+				// #4290 / #4292: reset the named-target reference and the
+				// translation-target routing-instance alongside the other
+				// then-set fields so only the LAST then-block's spec survives.
+				rule.ThenPrefixName = ""
+				rule.ThenRoutingInstance = ""
 				for _, t := range thenNode.Children {
 					if t.Name() == "static-nat" {
 						if len(t.Keys) >= 3 && t.Keys[1] == "nptv6-prefix" {
@@ -2195,6 +2367,20 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 							// static-nat { nptv6-prefix { PREFIX; } }
 							rule.Then = nodeVal(np)
 							rule.IsNPTv6 = true
+						} else if len(t.Keys) >= 3 && t.Keys[1] == "prefix-name" {
+							// #4290: set ... then static-nat prefix-name NAME.
+							// The named form of `prefix <ip>`: NAME references a
+							// global address-book entry whose literal prefix is
+							// the 1:1 translation target. Recorded raw here and
+							// resolved into rule.Then post-address-book-fold by
+							// resolveStaticNATThenPrefixNames (the book may not
+							// be compiled yet at this point). Before #4290 this
+							// keyword fell through, leaving Then=="" (empty
+							// translation target, silent broken static NAT).
+							rule.ThenPrefixName = t.Keys[2]
+						} else if pn := t.FindChild("prefix-name"); pn != nil {
+							// static-nat { prefix-name NAME; }
+							rule.ThenPrefixName = nodeVal(pn)
 						} else if len(t.Keys) >= 3 && t.Keys[1] == "prefix" {
 							rule.Then = t.Keys[2]
 							// #2491: optional trailing `mapped-port <port>`.
@@ -2224,6 +2410,30 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 						} else if t.FindChild("inet") != nil || (len(t.Keys) >= 2 && t.Keys[1] == "inet") {
 							// static-nat { inet; } — NAT64 translation
 							rule.Then = "inet"
+						}
+						// #4292: a translation-target `routing-instance <ri>`
+						// may trail ANY of the targets above (Junos allows it on
+						// inet and prefix). It rides on the free-form static-nat
+						// leaf in one of three AST shapes: collapsed onto t.Keys
+						// (["static-nat","prefix","<ip>","routing-instance",
+						// "<ri>"]); on the TARGET child leaf's Keys (the common
+						// flat-set shape — static-nat has a `prefix`/`inet` child
+						// whose Keys carry the trailing routing-instance pair); or
+						// as a distinct sibling `routing-instance` child. Captured
+						// for the accepted-but-unenforced advisory; the dataplane
+						// does not route the post-translation packet against a
+						// non-ingress table.
+						if ri := staticNATRoutingInstanceFromKeys(t.Keys); ri != "" {
+							rule.ThenRoutingInstance = ri
+						} else if riNode := t.FindChild("routing-instance"); riNode != nil {
+							rule.ThenRoutingInstance = nodeVal(riNode)
+						} else {
+							for _, c := range t.Children {
+								if ri := staticNATRoutingInstanceFromKeys(c.Keys); ri != "" {
+									rule.ThenRoutingInstance = ri
+									break
+								}
+							}
 						}
 					}
 				}

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -2165,13 +2165,21 @@ func staticNATMappedPortFromKeys(keys []string) int {
 }
 
 // staticNATRoutingInstanceFromKeys scans a collapsed static-nat `then` leaf's
-// Keys for a trailing `routing-instance <ri>` translation target (#4292) and
-// returns the instance name (or "" when absent). Mirrors
-// staticNATMappedPortFromKeys — the free-form static-nat leaf absorbs the whole
-// `then static-nat <target> routing-instance <ri>` line onto one node's Keys in
-// the flat-set shape.
+// Keys for the trailing `routing-instance <ri>` translation target (#4292) and
+// returns the instance name (or "" when absent). The free-form static-nat leaf
+// absorbs the whole `then static-nat <target> routing-instance <ri>` line onto
+// one node's Keys in the flat-set shape.
+//
+// It scans from the END and returns the LAST occurrence, because the Junos
+// grammar places the target routing-instance at the TAIL of the line. Scanning
+// forward (first match) would return the wrong token if an earlier
+// "routing-instance" appeared in the key list — e.g. `then static-nat
+// prefix-name routing-instance routing-instance MYVRF`, where the address-book
+// entry is pathologically NAMED "routing-instance": first-match would return
+// that entry name instead of the trailing "MYVRF". Last-match is strictly more
+// correct for the trailing-routing-instance grammar.
 func staticNATRoutingInstanceFromKeys(keys []string) string {
-	for i := 0; i+1 < len(keys); i++ {
+	for i := len(keys) - 2; i >= 0; i-- {
 		if keys[i] == "routing-instance" {
 			return keys[i+1]
 		}

--- a/pkg/config/compiler_nat_target_parity_hb167_test.go
+++ b/pkg/config/compiler_nat_target_parity_hb167_test.go
@@ -1,0 +1,272 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// fable-review-167 NAT parity findings:
+//
+//   N-1 (#4290): `then static-nat prefix-name <name>` must resolve the named
+//     global address-book entry to its literal prefix (rule.Then); an
+//     unresolvable prefix-name OR any unhandled/misspelled target that leaves an
+//     EMPTY translation target is rejected at strict commit (warn on lenient).
+//   N-2 (#4291): `nat source interface port-overloading off` and pool
+//     `port-overloading-factor <n>` are typed + accepted-with-advisory (not
+//     enforced), so `off` no longer implies silent false hardening.
+//   N-3 (#4292): the NAT translation-TARGET routing-instance (then static-nat
+//     ... routing-instance, source/destination pool routing-instance) is typed +
+//     accepted-with-advisory (not enforced), so it is no longer silently dropped.
+//
+// All tests drive the production ParseSetCommand + SetPath path (buildTree),
+// never NewParser (the flat-set gotcha in CLAUDE.md).
+
+func natWarnContains(cfg *Config, substr string) bool {
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- N-1: then static-nat prefix-name ---------------------------------------
+
+func staticPrefixNameSet(bookPrefix, thenName string) []string {
+	cmds := []string{
+		"set security nat static rule-set S rule R1 match destination-address 203.0.113.5/32",
+		"set security nat static rule-set S rule R1 then static-nat prefix-name " + thenName,
+	}
+	if bookPrefix != "" {
+		cmds = append([]string{
+			"set security address-book global address INSIDEHOST " + bookPrefix,
+		}, cmds...)
+	}
+	return cmds
+}
+
+// RED on revert: without the prefix-name case + resolver, rule.Then stays ""
+// (the target keyword falls through) and the rule installs with an empty
+// translation target.
+func TestStaticNATThenPrefixNameResolvesToBookPrefix(t *testing.T) {
+	tree := buildTree(t, staticPrefixNameSet("10.0.0.5/32", "INSIDEHOST"))
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("static NAT with a resolvable then prefix-name must compile, got: %v", err)
+	}
+	if len(cfg.Security.NAT.Static) == 0 || len(cfg.Security.NAT.Static[0].Rules) == 0 {
+		t.Fatal("static NAT rule-set missing after compile")
+	}
+	rule := cfg.Security.NAT.Static[0].Rules[0]
+	if rule.ThenPrefixName != "INSIDEHOST" {
+		t.Fatalf("ThenPrefixName = %q, want INSIDEHOST (parse dropped the named target)", rule.ThenPrefixName)
+	}
+	if rule.Then != "10.0.0.5/32" {
+		t.Fatalf("Then = %q, want 10.0.0.5/32 (prefix-name did not resolve to the address-book prefix — empty/broken static NAT)", rule.Then)
+	}
+}
+
+// RED on revert: without the empty-target guard, an unresolvable prefix-name
+// commits cleanly with rule.Then == "".
+func TestStaticNATThenPrefixNameUnresolvableRejected(t *testing.T) {
+	// Reference a name that is NOT defined under security address-book.
+	tree := buildTree(t, staticPrefixNameSet("", "NOSUCH"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("a then static-nat prefix-name referencing an undefined address-book entry must be rejected at commit")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "prefix-name") || !strings.Contains(msg, "R1") || !strings.Contains(msg, "NOSUCH") {
+		t.Fatalf("error must name the rule + the unresolvable prefix-name, got: %v", err)
+	}
+}
+
+// An address-set with two members cannot be a scalar 1:1 target -> unresolvable.
+func TestStaticNATThenPrefixNameMultiMemberSetRejected(t *testing.T) {
+	cmds := []string{
+		"set security address-book global address a1 10.0.0.5/32",
+		"set security address-book global address a2 10.0.0.6/32",
+		"set security address-book global address-set grp address a1",
+		"set security address-book global address-set grp address a2",
+		"set security nat static rule-set S rule R1 match destination-address 203.0.113.5/32",
+		"set security nat static rule-set S rule R1 then static-nat prefix-name grp",
+	}
+	_, err := CompileConfig(buildTree(t, cmds))
+	if err == nil {
+		t.Fatal("a then static-nat prefix-name resolving to a multi-member address-set must be rejected (no single 1:1 target)")
+	}
+	if !strings.Contains(err.Error(), "prefix-name") {
+		t.Fatalf("error must reference prefix-name, got: %v", err)
+	}
+}
+
+// RED on revert: without the empty-target guard, a misspelled/unhandled target
+// keyword commits cleanly with rule.Then == "".
+func TestStaticNATThenEmptyTargetRejected(t *testing.T) {
+	cmds := []string{
+		"set security nat static rule-set S rule R1 match destination-address 203.0.113.5/32",
+		// "prefix-nam" is a typo for "prefix" / "prefix-name" — the free-form
+		// static-nat leaf accepts it, and the then switch matches no case.
+		"set security nat static rule-set S rule R1 then static-nat prefix-nam 10.0.0.5/32",
+	}
+	_, err := CompileConfig(buildTree(t, cmds))
+	if err == nil {
+		t.Fatal("a then static-nat with an unhandled/misspelled target (empty translation target) must be rejected at commit")
+	}
+	if !strings.Contains(err.Error(), "empty") || !strings.Contains(err.Error(), "R1") {
+		t.Fatalf("error must flag the empty translation target for the rule, got: %v", err)
+	}
+}
+
+// RED on revert: the lenient (load / peer-sync) path must WARN, not brick, and
+// on revert there is neither warning nor error (silent).
+func TestStaticNATThenPrefixNameUnresolvableLenientWarns(t *testing.T) {
+	tree := buildTree(t, staticPrefixNameSet("", "NOSUCH"))
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile of an unresolvable prefix-name must not brick, got: %v", err)
+	}
+	if !natWarnContains(cfg, "static NAT translation target") {
+		t.Fatalf("lenient path must emit a downgraded warning for the unresolvable prefix-name; warnings=%v", cfg.Warnings)
+	}
+}
+
+// A well-formed prefix/inet/nptv6 target must NOT trip the empty-target guard.
+func TestStaticNATThenLiteralPrefixStillCompiles(t *testing.T) {
+	cmds := []string{
+		"set security nat static rule-set S rule R1 match destination-address 203.0.113.5/32",
+		"set security nat static rule-set S rule R1 then static-nat prefix 10.0.0.5/32",
+	}
+	cfg, err := CompileConfig(buildTree(t, cmds))
+	if err != nil {
+		t.Fatalf("a literal then static-nat prefix must still compile, got: %v", err)
+	}
+	if cfg.Security.NAT.Static[0].Rules[0].Then != "10.0.0.5/32" {
+		t.Fatalf("literal prefix target regressed: Then=%q", cfg.Security.NAT.Static[0].Rules[0].Then)
+	}
+}
+
+// --- N-2: port-overloading knobs -------------------------------------------
+
+// RED on revert: `interface port-overloading off` is silently dropped (no field,
+// no advisory) so `off` falsely implies hardening.
+func TestNATSourceInterfacePortOverloadingOffAdvisory(t *testing.T) {
+	cmds := []string{
+		"set security nat source interface port-overloading off",
+	}
+	cfg, err := CompileConfig(buildTree(t, cmds))
+	if err != nil {
+		t.Fatalf("nat source interface port-overloading off must compile, got: %v", err)
+	}
+	if !cfg.Security.NAT.SourceInterfacePortOverloadingOff {
+		t.Fatal("SourceInterfacePortOverloadingOff not recorded (knob silently dropped)")
+	}
+	if !natWarnContains(cfg, "#4291") || !natWarnContains(cfg, "port-overloading off") {
+		t.Fatalf("port-overloading off must emit an accepted-only advisory; warnings=%v", cfg.Warnings)
+	}
+}
+
+// RED on revert: pool port-overloading-factor is silently dropped.
+func TestNATSourcePoolPortOverloadingFactorAdvisory(t *testing.T) {
+	cmds := []string{
+		"set security nat source pool P1 address 203.0.113.10/32",
+		"set security nat source pool P1 port-overloading-factor 4",
+	}
+	cfg, err := CompileConfig(buildTree(t, cmds))
+	if err != nil {
+		t.Fatalf("nat source pool port-overloading-factor must compile, got: %v", err)
+	}
+	p := cfg.Security.NAT.SourcePools["P1"]
+	if p == nil || p.PortOverloadingFactor != 4 {
+		t.Fatalf("PortOverloadingFactor not recorded (got %+v)", p)
+	}
+	if !natWarnContains(cfg, "#4291") || !natWarnContains(cfg, "port-overloading-factor") {
+		t.Fatalf("port-overloading-factor must emit an accepted-only advisory; warnings=%v", cfg.Warnings)
+	}
+}
+
+// --- N-3: translation-target routing-instance -------------------------------
+
+// RED on revert: the trailing routing-instance on a static-nat then target is
+// silently dropped.
+func TestStaticNATThenRoutingInstanceAdvisory(t *testing.T) {
+	cmds := []string{
+		"set security nat static rule-set S rule R1 match destination-address 203.0.113.5/32",
+		"set security nat static rule-set S rule R1 then static-nat prefix 10.0.0.5/32 routing-instance vr-blue",
+	}
+	cfg, err := CompileConfig(buildTree(t, cmds))
+	if err != nil {
+		t.Fatalf("then static-nat prefix ... routing-instance must compile, got: %v", err)
+	}
+	rule := cfg.Security.NAT.Static[0].Rules[0]
+	if rule.Then != "10.0.0.5/32" {
+		t.Fatalf("literal prefix regressed alongside routing-instance: Then=%q", rule.Then)
+	}
+	if rule.ThenRoutingInstance != "vr-blue" {
+		t.Fatalf("ThenRoutingInstance = %q, want vr-blue (target RI silently dropped)", rule.ThenRoutingInstance)
+	}
+	if !natWarnContains(cfg, "#4292") || !natWarnContains(cfg, "vr-blue") {
+		t.Fatalf("translation-target routing-instance must emit an accepted-only advisory; warnings=%v", cfg.Warnings)
+	}
+}
+
+// The inet (NAT64) target must also keep its trailing routing-instance and NOT
+// trip the empty-target guard.
+func TestStaticNATThenInetRoutingInstanceAdvisory(t *testing.T) {
+	cmds := []string{
+		"set security nat static rule-set S rule R1 match destination-address 203.0.113.5/32",
+		"set security nat static rule-set S rule R1 then static-nat inet routing-instance vr-green",
+	}
+	cfg, err := CompileConfig(buildTree(t, cmds))
+	if err != nil {
+		t.Fatalf("then static-nat inet routing-instance must compile, got: %v", err)
+	}
+	rule := cfg.Security.NAT.Static[0].Rules[0]
+	if rule.Then != "inet" {
+		t.Fatalf("inet target regressed alongside routing-instance: Then=%q", rule.Then)
+	}
+	if rule.ThenRoutingInstance != "vr-green" {
+		t.Fatalf("ThenRoutingInstance = %q, want vr-green", rule.ThenRoutingInstance)
+	}
+}
+
+// RED on revert: the DNAT pool routing-instance is silently dropped.
+func TestDNATPoolRoutingInstanceAdvisory(t *testing.T) {
+	cmds := []string{
+		"set security nat destination pool DP address 10.0.0.5/32",
+		"set security nat destination pool DP routing-instance vr-red",
+	}
+	cfg, err := CompileConfig(buildTree(t, cmds))
+	if err != nil {
+		t.Fatalf("nat destination pool routing-instance must compile, got: %v", err)
+	}
+	if cfg.Security.NAT.Destination == nil {
+		t.Fatal("destination NAT config missing")
+	}
+	p := cfg.Security.NAT.Destination.Pools["DP"]
+	if p == nil || p.RoutingInstance != "vr-red" {
+		t.Fatalf("DNAT pool RoutingInstance not recorded (got %+v)", p)
+	}
+	if !natWarnContains(cfg, "#4292") || !natWarnContains(cfg, "vr-red") {
+		t.Fatalf("DNAT pool routing-instance must emit an accepted-only advisory; warnings=%v", cfg.Warnings)
+	}
+}
+
+// RED on revert: the source NAT pool routing-instance is silently dropped.
+func TestSourceNATPoolRoutingInstanceAdvisory(t *testing.T) {
+	cmds := []string{
+		"set security nat source pool SP address 203.0.113.10/32",
+		"set security nat source pool SP routing-instance vr-orange",
+	}
+	cfg, err := CompileConfig(buildTree(t, cmds))
+	if err != nil {
+		t.Fatalf("nat source pool routing-instance must compile, got: %v", err)
+	}
+	p := cfg.Security.NAT.SourcePools["SP"]
+	if p == nil || p.RoutingInstance != "vr-orange" {
+		t.Fatalf("source pool RoutingInstance not recorded (got %+v)", p)
+	}
+	if !natWarnContains(cfg, "#4292") || !natWarnContains(cfg, "vr-orange") {
+		t.Fatalf("source pool routing-instance must emit an accepted-only advisory; warnings=%v", cfg.Warnings)
+	}
+}

--- a/pkg/config/compiler_nat_target_parity_hb167_test.go
+++ b/pkg/config/compiler_nat_target_parity_hb167_test.go
@@ -230,6 +230,61 @@ func TestStaticNATThenInetRoutingInstanceAdvisory(t *testing.T) {
 	}
 }
 
+// Copilot edge (#4292): the trailing-routing-instance grammar. The RI scan must
+// return the LAST "routing-instance" occurrence, not the first — otherwise an
+// earlier "routing-instance" token in the collapsed key list wins. The
+// pathological case: the address-book entry referenced by prefix-name is itself
+// literally NAMED "routing-instance", and the target RI trails at the tail.
+//
+// RED on revert (first-match scan): ThenRoutingInstance is recorded as the entry
+// name "routing-instance" instead of the trailing "MYVRF".
+func TestStaticNATThenRoutingInstanceLastOccurrence(t *testing.T) {
+	cmds := []string{
+		// An address-book entry pathologically NAMED "routing-instance".
+		"set security address-book global address routing-instance 10.0.0.9/32",
+		"set security nat static rule-set S rule R1 match destination-address 203.0.113.5/32",
+		// then static-nat prefix-name <entry=routing-instance> routing-instance MYVRF
+		"set security nat static rule-set S rule R1 then static-nat prefix-name routing-instance routing-instance MYVRF",
+	}
+	cfg, err := CompileConfig(buildTree(t, cmds))
+	if err != nil {
+		t.Fatalf("prefix-name entry named routing-instance + trailing routing-instance must compile, got: %v", err)
+	}
+	rule := cfg.Security.NAT.Static[0].Rules[0]
+	if rule.ThenPrefixName != "routing-instance" {
+		t.Fatalf("ThenPrefixName = %q, want routing-instance (the pathological entry name)", rule.ThenPrefixName)
+	}
+	if rule.Then != "10.0.0.9/32" {
+		t.Fatalf("Then = %q, want 10.0.0.9/32 (prefix-name must resolve the entry named routing-instance)", rule.Then)
+	}
+	if rule.ThenRoutingInstance != "MYVRF" {
+		t.Fatalf("ThenRoutingInstance = %q, want MYVRF (trailing RI; a first-match scan wrongly returns the entry name %q)", rule.ThenRoutingInstance, "routing-instance")
+	}
+	if !natWarnContains(cfg, "#4292") || !natWarnContains(cfg, "MYVRF") {
+		t.Fatalf("advisory must reference the TRAILING RI MYVRF, not the entry name; warnings=%v", cfg.Warnings)
+	}
+}
+
+// The normal prefix-name + trailing routing-instance case stays correct.
+func TestStaticNATThenPrefixNameRoutingInstanceNormal(t *testing.T) {
+	cmds := []string{
+		"set security address-book global address FOO 10.0.0.7/32",
+		"set security nat static rule-set S rule R1 match destination-address 203.0.113.5/32",
+		"set security nat static rule-set S rule R1 then static-nat prefix-name FOO routing-instance MYVRF",
+	}
+	cfg, err := CompileConfig(buildTree(t, cmds))
+	if err != nil {
+		t.Fatalf("prefix-name FOO routing-instance MYVRF must compile, got: %v", err)
+	}
+	rule := cfg.Security.NAT.Static[0].Rules[0]
+	if rule.Then != "10.0.0.7/32" {
+		t.Fatalf("Then = %q, want 10.0.0.7/32", rule.Then)
+	}
+	if rule.ThenRoutingInstance != "MYVRF" {
+		t.Fatalf("ThenRoutingInstance = %q, want MYVRF", rule.ThenRoutingInstance)
+	}
+}
+
 // RED on revert: the DNAT pool routing-instance is silently dropped.
 func TestDNATPoolRoutingInstanceAdvisory(t *testing.T) {
 	cmds := []string{

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -9,6 +9,22 @@ import (
 	"strings"
 )
 
+// sortedPoolNames returns the keys of a NAT pool map in deterministic sorted
+// order, so advisory / warning messages that enumerate pools are stable across
+// compiles (Go map iteration order is randomized). Used by the #4291/#4292
+// accepted-only NAT advisories.
+func sortedPoolNames(pools map[string]*NATPool) []string {
+	if len(pools) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(pools))
+	for name := range pools {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 // ValidateConfig performs non-fatal validation on a compiled config.
 // Returns warnings for unresolved references and operator-visible
 // compatibility/deprecation conditions.
@@ -608,6 +624,93 @@ func ValidateConfig(cfg *Config) []string {
 		if flow.SyncICMPSession {
 			warnings = append(warnings,
 				"security flow sync-icmp-session configured but has no effect — xpf syncs ICMP sessions to the HA peer UNCONDITIONALLY (the session-sync path is protocol-agnostic), so this Junos opt-in knob is a no-op: ICMP session sync is already always on and cannot be turned off (config-only parity, #4231)")
+		}
+	}
+
+	// #4291 (fable-167 N-2): the NAT `port-overloading` knobs are now typed +
+	// committed (schema leaves + compileNAT) but the userspace AF_XDP SNAT
+	// allocator enforces neither. `security nat source interface port-overloading
+	// off` disables source-port reuse across destinations (a src-port-uniqueness
+	// hardening posture) — xpf's allocator always overloads source ports, so
+	// `off` hardens NOTHING. `port-overloading-factor <n>` scales the concurrent
+	// translations per pool address — xpf has no factor-scaled port budget.
+	// Mirror the #2078/#4231 accepted-only doctrine: warn so an operator is not
+	// silently misled into believing `off` is a real control. Full enforcement is
+	// a userspace-dp SNAT-allocator follow-up.
+	{
+		var poParts []string
+		if cfg.Security.NAT.SourceInterfacePortOverloadingOff {
+			poParts = append(poParts, "interface port-overloading off")
+		}
+		var poFactorPools []string
+		for _, name := range sortedPoolNames(cfg.Security.NAT.SourcePools) {
+			if p := cfg.Security.NAT.SourcePools[name]; p != nil && p.PortOverloadingFactor > 0 {
+				poFactorPools = append(poFactorPools, name)
+			}
+		}
+		if len(poFactorPools) > 0 {
+			poParts = append(poParts, fmt.Sprintf("pool %s port-overloading-factor", strings.Join(poFactorPools, ", ")))
+		}
+		if len(poParts) > 0 {
+			warnings = append(warnings, fmt.Sprintf(
+				"security nat source %s configured but accepted-only — the "+
+					"userspace dataplane always overloads source ports, so "+
+					"port-overloading off hardens nothing and "+
+					"port-overloading-factor has no effect (config-only parity, "+
+					"#4291)",
+				strings.Join(poParts, " / ")))
+		}
+	}
+
+	// #4292 (fable-167 N-3): NAT translation-TARGET routing-instance is now typed
+	// + recorded (compileNAT) but not enforced. `then static-nat {inet|prefix
+	// <ip>} routing-instance <ri>` and a source / destination NAT pool
+	// `routing-instance <ri>` would place the TRANSLATED packet in a different
+	// routing table (cross-VRF NAT) — distinct from the #3096 from/to SCOPE
+	// routing-instance, which IS enforced. The dataplane does not route the
+	// post-translation packet against a non-ingress table, so the target RI is
+	// dropped. Mirror the #2078/#4231 accepted-only doctrine: warn so the dropped
+	// target is operator-visible. Full enforcement is a cross-VRF-NAT userspace-dp
+	// follow-up.
+	{
+		targetRISeen := make(map[string]bool)
+		var targetRIParts []string
+		addRI := func(part string) {
+			if !targetRISeen[part] {
+				targetRISeen[part] = true
+				targetRIParts = append(targetRIParts, part)
+			}
+		}
+		for _, rs := range cfg.Security.NAT.Static {
+			if rs == nil {
+				continue
+			}
+			for _, rule := range rs.Rules {
+				if rule != nil && rule.ThenRoutingInstance != "" {
+					addRI(fmt.Sprintf("static rule-set %q rule %q then static-nat routing-instance %q", rs.Name, rule.Name, rule.ThenRoutingInstance))
+				}
+			}
+		}
+		for _, name := range sortedPoolNames(cfg.Security.NAT.SourcePools) {
+			if p := cfg.Security.NAT.SourcePools[name]; p != nil && p.RoutingInstance != "" {
+				addRI(fmt.Sprintf("source pool %q routing-instance %q", name, p.RoutingInstance))
+			}
+		}
+		if cfg.Security.NAT.Destination != nil {
+			for _, name := range sortedPoolNames(cfg.Security.NAT.Destination.Pools) {
+				if p := cfg.Security.NAT.Destination.Pools[name]; p != nil && p.RoutingInstance != "" {
+					addRI(fmt.Sprintf("destination pool %q routing-instance %q", name, p.RoutingInstance))
+				}
+			}
+		}
+		if len(targetRIParts) > 0 {
+			warnings = append(warnings, fmt.Sprintf(
+				"security nat translation-target routing-instance configured but "+
+					"accepted-only — the userspace dataplane routes the "+
+					"post-translation packet against the ingress / default "+
+					"routing instance, so the target routing-instance is not "+
+					"applied (%s) (config-only parity, #4292)",
+				strings.Join(targetRIParts, "; ")))
 		}
 	}
 

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -377,6 +377,40 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 						children:      nil,
 					},
 				}},
+				// #4291: per-pool port-overloading-factor. Typed so the knob
+				// completes and commits; accepted-but-unenforced (advisory in
+				// ValidateConfig) — the SNAT allocator has no factor-scaled port
+				// budget.
+				"port-overloading-factor": {
+					desc:          "Concurrent translations per pool address (accepted, not enforced)",
+					args:          1,
+					valueType:     ValueInteger,
+					valueDesc:     "Overloading factor",
+					valueExamples: []string{"1", "2", "4"},
+					validator:     ValidateInteger(1, 32),
+					children:      nil,
+				},
+				// #4292: per-pool translation-target routing-instance. Typed so
+				// it completes and commits; accepted-but-unenforced (advisory in
+				// ValidateConfig) — the dataplane does not route the post-
+				// translation packet against a non-ingress table.
+				"routing-instance": {desc: "Translation-target routing instance (accepted, not enforced)", args: 1, placeholder: "<routing-instance>", children: nil},
+			}},
+			// #4291: `nat source interface port-overloading off` disables
+			// source-port reuse across destinations. Typed so it completes and
+			// commits; accepted-but-unenforced (advisory in ValidateConfig) —
+			// source-port overloading is always on in the SNAT allocator, so
+			// `off` hardens nothing.
+			"interface": {desc: "Source NAT interface-address translation options", children: map[string]*schemaNode{
+				"port-overloading": {
+					desc:          "Source-port overloading control (off = unique src port per mapping; accepted, not enforced)",
+					args:          1,
+					valueType:     ValueEnumOf,
+					valueDesc:     "port-overloading mode",
+					valueExamples: []string{"off"},
+					validator:     ValidateEnum([]string{"off"}),
+					children:      nil,
+				},
 			}},
 			"address-persistent": {desc: "Always map a source IP to the same pool address", children: nil},
 			"rule-set": {desc: "Source NAT rule-set name", args: 1, placeholder: "<rule-set-name>", children: map[string]*schemaNode{
@@ -492,7 +526,7 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 					// nil is the replace-vs-container signal). The mapped-port
 					// range is validated in the compiler (compileNATStatic).
 					"then": {desc: "Static NAT action", children: map[string]*schemaNode{
-						"static-nat": {desc: "Static NAT translation (prefix [mapped-port <port>]|nptv6-prefix|inet)", children: nil},
+						"static-nat": {desc: "Static NAT translation (prefix [mapped-port <port>]|prefix-name <name>|nptv6-prefix|inet [routing-instance <ri>])", children: nil},
 					}},
 				}},
 			}},

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -504,6 +504,14 @@ type NATConfig struct {
 	NATv6v4              *NATv6v4Config // natv6v4 options
 	PoolUtilizationAlarm *PoolUtilizationAlarmConfig
 	ProxyARP             []*ProxyARPEntry
+	// SourceInterfacePortOverloadingOff records `security nat source interface
+	// port-overloading off` (#4291). Junos `off` disables source-port reuse
+	// across destinations (a src-port-uniqueness hardening posture). xpf accepts
+	// and records it but does NOT enforce it — source-port overloading is always
+	// on in the SNAT allocator — so `off` hardens nothing. An accept-with-
+	// advisory (ValidateConfig) surfaces the false-hardening. Enforcement is a
+	// userspace-dp SNAT-allocator follow-up.
+	SourceInterfacePortOverloadingOff bool
 }
 
 // ProxyARPEntry configures proxy ARP responses for NAT addresses.
@@ -703,8 +711,21 @@ type NATPool struct {
 	// in this mode. Before #3906 the token was silently dropped and the pool
 	// PAT-translated the port anyway.
 	PortNoTranslation bool
-	PersistentNAT     *PersistentNATConfig
-	Deterministic     *DeterministicNATConfig
+	// PortOverloadingFactor records the source-pool `port-overloading-factor
+	// <n>` knob (#4291). Junos scales the number of concurrent translations a
+	// single pool address may serve. xpf accepts and records it but does NOT
+	// enforce it — the SNAT allocator has no factor-scaled port budget — so an
+	// accept-with-advisory (ValidateConfig) surfaces the accepted-but-inert
+	// state. 0 = not configured. Enforcement is a userspace-dp SNAT-allocator
+	// follow-up.
+	PortOverloadingFactor int
+	// RoutingInstance records the source / destination NAT pool `routing-
+	// instance <ri>` translation-TARGET routing instance (#4292). Accepted +
+	// recorded for the advisory; not enforced (the dataplane does not route the
+	// post-translation packet against a non-ingress table). "" = unset.
+	RoutingInstance string
+	PersistentNAT   *PersistentNATConfig
+	Deterministic   *DeterministicNATConfig
 }
 
 // PersistentNATPermit selects the remote-endpoint scope of a persistent
@@ -766,7 +787,28 @@ type StaticNATRule struct {
 	// mirrored into SourceAddress for back-compat. Empty = match any source.
 	SourceAddresses []string
 	Then            string // static-nat prefix (internal/private IP), or "inet" for NAT64
-	IsNPTv6         bool   // true if this is an nptv6-prefix rule (RFC 6296)
+	// ThenPrefixName is the raw `then static-nat prefix-name <name>` reference
+	// (#4290). Junos static NAT `prefix-name` names a global address-book entry
+	// whose literal prefix is the 1:1 translation target — the named twin of
+	// `then static-nat prefix <ip>`. The compiler records the raw name here and
+	// resolveStaticNATThenPrefixNames (run post-address-book-fold) resolves it
+	// into Then. Before #4290 the target keyword fell through the then switch,
+	// leaving Then=="" — the rule committed with an EMPTY translation target
+	// (silent broken static NAT). An unresolvable reference is rejected at
+	// strict commit (validateStaticNATThenTargetStrict); lenient load / peer-
+	// sync downgrades to a warning (#1960) and the dataplane fails closed (the
+	// empty prefix does not parse as an IP → no translation installed).
+	ThenPrefixName string
+	// ThenRoutingInstance is the raw `then static-nat {inet|prefix <ip>}
+	// routing-instance <ri>` translation-TARGET routing instance (#4292). It is
+	// distinct from the rule-set `from` SCOPE routing-instance (#3096): the
+	// scope selects which ingress traffic the rule matches, the target RI would
+	// place the TRANSLATED packet in a different routing table (cross-VRF NAT).
+	// Recorded so the accepted-but-unenforced advisory (ValidateConfig) can
+	// surface it; the dataplane does not yet route the post-translation packet
+	// against a non-ingress table, so the token is otherwise silently dropped.
+	ThenRoutingInstance string
+	IsNPTv6             bool // true if this is an nptv6-prefix rule (RFC 6296)
 	// MatchDestinationPort is the external (pre-translation) destination
 	// port the inbound packet must carry for this rule to apply (Junos
 	// `match destination-port`). 0 = match any port (whole-address 1:1,


### PR DESCRIPTION
Closes #4290
Closes #4291
Closes #4292

Three fable-review-167 NAT compiler parity findings, Go-only in `pkg/config`
(no dataplane / cargo change).

## N-1 (#4290) — real fix: `then static-nat prefix-name <addr>` empty target
The static-nat `then`-target switch recognized only `nptv6-prefix` / `prefix`
/ `inet`, so the named form fell through, leaving `rule.Then == ""` — the rule
committed clean and installed a static NAT with **no translation** (silent
broken 1:1).

- `compileNATStatic` records the raw name in `StaticNATRule.ThenPrefixName`
  (`pkg/config/compiler_nat.go`).
- `resolveStaticNATThenPrefixNames` (`pkg/config/compiler.go`, run after
  `resolveZoneLocalAddressBooks` folds the zone-local books into the global
  book — `compileNAT` can run before `compileAddressBook` within a `security {}`
  root, so resolution cannot happen inline in the then switch) resolves the
  referenced global address-book entry to its single literal prefix and writes
  `rule.Then`.
- `validateStaticNATThenTargetStrict` — a defensive **empty-target guard** —
  hard-rejects at strict commit ANY non-NPTv6 static rule whose then-target is
  empty (unresolvable `prefix-name` OR an unhandled / misspelled target keyword
  the free-form leaf accepted). Lenient load / peer-sync downgrades to a
  warning (`lenientFirewallRefs`, #1960); the dataplane fails closed (the empty
  prefix does not parse as an IP).

## N-2 (#4291) — typed leaf + advisory: port-overloading knobs
`nat source interface port-overloading off` and pool
`port-overloading-factor <n>` were unmodeled and silently dropped, so `off`
implied a src-port-uniqueness hardening it never applied. Added typed setSchema
leaves (an `interface` container with a `port-overloading` enum `{off}`, and a
`port-overloading-factor` integer 1..32 under the source pool), typed fields,
and a commit-time **accepted-only advisory** so `off` no longer implies false
hardening. Full unique-src-port / factor-scaled enforcement is a userspace-dp
SNAT-allocator follow-up.

## N-3 (#4292) — typed leaf + advisory: translation-target routing-instance
The NAT translation-**target** routing-instance (`then static-nat {inet|prefix
<ip>} routing-instance <ri>`, source / destination pool `routing-instance
<ri>`) was silently dropped — distinct from the enforced #3096 from/to **scope**
routing-instance. Added parsing (static then-target + both pool loops), typed
fields, a source-pool `routing-instance` schema leaf, and an **accepted-only
advisory**. Placing the post-translation packet in a non-ingress table
(cross-VRF NAT) is a userspace-dp follow-up.

## Validation
- 11 RED-on-revert tests (`compiler_nat_target_parity_hb167_test.go`), proven
  RED by neutering only the behavioral logic (types/schema kept so it still
  compiles) and observing all 11 fail, then green after restore.
- `go test ./pkg/config/...` green; `go build ./...` clean; `gofmt` + `go vet`
  clean; `go test ./pkg/dataplane/userspace/...` green (the new type fields are
  additive; the snapshot builder is unchanged).

## Follow-ups (needs-design, dataplane)
- #4291: enforce unique-src-port-per-mapping / factor-scaled port budgeting in
  the userspace-dp SNAT allocator.
- #4292: route the post-translation packet against the target routing-instance
  (cross-VRF NAT) in userspace-dp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
