### PR TITLE
fable-167 parity SECURITY: family any v6 fail-open, VRRP auth false-security, SNMP community clients (#4287 #4288 #4289)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12,6 +12,18 @@
   - **File(s)**: pkg/config/compiler_firewall.go,
     pkg/config/compiler_firewall_family_any_4287_test.go,
     docs/config-schema.md, _Log.md
+  - **Action**: I-1 (#4288) — VRRP authentication-type/authentication-key
+    are parsed + stored + copied into the VRRP instance but never enforced
+    (the dataplane is RFC 5798 VRRPv3, which removed auth). Silently
+    accepting them is a false-security posture (rogue host can hijack
+    mastership). Added `validateVRRPAuthenticationAST` +
+    `lenientVRRPAuthentication` opt: strict commit hard-rejects, lenient
+    load/peer-sync warns (#1960 no-brick). Test
+    `vrrp_authentication_4288_test.go`.
+  - **File(s)**: pkg/config/compiler.go,
+    pkg/config/compiler_interfaces.go,
+    pkg/config/vrrp_authentication_4288_test.go,
+    docs/feature-coverage.md, _Log.md
 
 ## 2026-07-05 — cos: #4272 div_ceil .max(1) hardening + fable-166 R-10 CoS test-coverage gaps (#4280)
 

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,23 @@
+## 2026-07-05 — fable-167 PR #4295 Copilot fold: scrub two secret-leak-to-logs paths (VRRP auth-key + SNMP community)
+
+- **Timestamp**: 2026-07-05
+  - **Action**: Copilot review of PR #4295 found the security PR's OWN
+    error/log paths echoed the secrets they protect.
+    (1) I-1 VRRP reject built nodePath from the full vrrp-group Keys run;
+    in the Keys-packed spelling (`vrrp-group 1 authentication-key <sec>;`)
+    that run carries the auth-key VALUE, so the strict error / lenient
+    warning leaked the secret into logs + CLI. Fixed with `vrrpGroupIDKeys`
+    (identity-only `vrrp-group <id>`); message now value-free in BOTH AST
+    shapes. New RED-on-revert tests
+    `TestVRRPAuthenticationRejectDoesNotLeakSecret_{KeysPacked,FlatSet}` +
+    `...WarnDoesNotLeakSecret_KeysPacked`.
+    (2) S-3 SNMP source-denied path logged the v2c community string (the
+    shared secret). Scrubbed to log only `src` + `known_community=true`.
+    Pre-existing `"SNMP: invalid community"` leak (commit c10fc9a1f) left
+    as-is (out of scope).
+  - **File(s)**: pkg/config/compiler_interfaces.go,
+    pkg/config/vrrp_authentication_4288_test.go, pkg/snmp/agent.go, _Log.md
+
 ## 2026-07-05 — fable-review-167 parity SECURITY: family any v6 fail-open (#4287), VRRP auth false-security (#4288), SNMP community clients (#4289)
 
 - **Timestamp**: 2026-07-05

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,18 @@
+## 2026-07-05 — fable-review-167 parity SECURITY: family any v6 fail-open (#4287), VRRP auth false-security (#4288), SNMP community clients (#4289)
+
+- **Timestamp**: 2026-07-05
+  - **Action**: F-1 (#4287) — `compileFirewall` folded a `family any`
+    firewall filter into the IPv4 pool only, losing its IPv6 arm (a
+    `family any` discard/deny failed OPEN for v6). Fixed to compile a
+    `family any` filter into BOTH `FiltersInet` and `FiltersInet6`;
+    extended `validateFirewallFilterFamilyCollisionsAST` with an
+    `any`+`inet6` same-name collision cross-check (strict reject / lenient
+    warn) since `any` now folds into the inet6 pool too. Test
+    `compiler_firewall_family_any_4287_test.go`.
+  - **File(s)**: pkg/config/compiler_firewall.go,
+    pkg/config/compiler_firewall_family_any_4287_test.go,
+    docs/config-schema.md, _Log.md
+
 ## 2026-07-05 — cos: #4272 div_ceil .max(1) hardening + fable-166 R-10 CoS test-coverage gaps (#4280)
 
 - **Timestamp**: 2026-07-05

--- a/_Log.md
+++ b/_Log.md
@@ -24,6 +24,23 @@
     pkg/config/compiler_interfaces.go,
     pkg/config/vrrp_authentication_4288_test.go,
     docs/feature-coverage.md, _Log.md
+  - **Action**: S-3 (#4289) — SNMP `community <c> clients <ip>` source-IP
+    restriction was silently ignored (agent answered every source). Added
+    `SNMPClient`/`Clients` to `SNMPCommunity`, `parseSNMPClients` +
+    `AllowsSource` (longest-prefix match, `restrict` deny, default-deny
+    when clients set, allow-all when absent), `clients` schema leaf, and
+    threaded the UDP source IP into the agent v2c path
+    (`handlePacket`→`handlePacketFrom`→`handleV2cPacket`) to drop a query
+    from a non-permitted source. Tests `snmp_clients_4289_test.go` (config)
+    + `agent_clients_4289_test.go` (agent enforcement). Removed the VRRP
+    auth key from the pkg/api strict-commit redaction fixture (now rejected
+    by #4288); its redaction stays covered by the Secret type + AST leaf.
+  - **File(s)**: pkg/config/types_system.go, pkg/config/snmp_clients.go,
+    pkg/config/compiler_system.go, pkg/config/schema_system.go,
+    pkg/config/snmp_clients_4289_test.go, pkg/snmp/agent.go,
+    pkg/snmp/agent_clients_4289_test.go,
+    pkg/api/config_secret_redaction_test.go, docs/feature-coverage.md,
+    _Log.md
 
 ## 2026-07-05 — cos: #4272 div_ceil .max(1) hardening + fable-166 R-10 CoS test-coverage gaps (#4280)
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -878,12 +878,13 @@ and break the symmetry in the other direction. Pinned by
 
 Junos namespaces firewall filters **per family**, so `family inet filter blockX`
 and `family mpls filter blockX` are two distinct filters. xpf cannot: `compileFirewall`
-(`compiler_firewall.go`) selects the destination map with `dest := fw.FiltersInet`
-and only switches to `fw.FiltersInet6` when the family is literally `inet6`, so
-EVERY other family (`inet`, `any`, `mpls`, `ccc`, `vpls`, `bridge`, and any
-not-yet-modelled token — `SchemaValidate` does not reject an unknown family
-keyword) folds into the single `fw.FiltersInet` pool, then writes
-`dest[filter.Name] = filter` **unconditionally**. Two same-name filters authored
+(`compiler_firewall.go`) selects the destination pool(s) — `fw.FiltersInet` for
+most families, `fw.FiltersInet6` for `inet6`, and BOTH for `any` (#4287, see
+below) — so EVERY family except `inet6` and `any` (`inet`, `mpls`, `ccc`,
+`vpls`, `bridge`, and any not-yet-modelled token — `SchemaValidate` does not
+reject an unknown family keyword) folds into the single `fw.FiltersInet` pool,
+then writes `dest[filter.Name] = filter` **unconditionally**. Two same-name
+filters authored
 under two different non-inet6 families therefore silently collapse — the later
 definition last-write-wins over the earlier with no commit error. If the `family
 inet` filter was a `discard`/deny and the colliding-family filter is accept-all,
@@ -924,6 +925,34 @@ peer-synced config an older binary silently accepted still BOOTS. Fail-on-revert
 `CompileConfig`, warn-not-brick on `CompileConfigLenient` with the surviving
 accept asserted, plus the inet/inet6 dual-stack and single-family no-false-reject
 cases).
+
+## Firewall-filter `family any` applies to BOTH v4 and v6 (#4287)
+
+Junos `family any` firewall filters are **protocol-independent** — they match
+BOTH IPv4 and IPv6. Before #4287, `compileFirewall` folded every non-inet6
+family (including `any`) into the single `fw.FiltersInet` (IPv4) pool, so a
+uniquely-named `family any` discard/deny filter was enforced on IPv4 **only**
+and silently let IPv6 through — a security **fail-open** (an operator writes a
+`family any` deny expecting it to block both families; the v6 arm is lost).
+This is distinct from the #3884 same-name cross-family overwrite above: here a
+*uniquely-named* filter loses its v6 arm.
+
+`compileFirewall` now compiles a `family any` filter into **both**
+`fw.FiltersInet` and `fw.FiltersInet6` (the `dests` slice in
+`compiler_firewall.go`), so the deny applies to both address families. Because
+`family any` now folds into the inet6 pool as well,
+`validateFirewallFilterFamilyCollisionsAST` was extended with an `any`+`inet6`
+cross-check: a `family any` filter name shared with a distinct `family inet6`
+filter would silently overwrite in `FiltersInet6`, so it is rejected at strict
+commit / warned on the lenient load path (same #1960 no-brick doctrine).
+
+Reachability is the same as #3884: the schema-driven flat `set` grammar does
+not model `family any`, so a flat `set firewall family any ...` collapses and
+never mints a structured filter; the fail-open is reachable only via a
+hierarchical config-file parse or a directly-constructed / peer-synced AST.
+Fail-on-revert: `pkg/config/compiler_firewall_family_any_4287_test.go` (both
+pools populated for a `family any` discard; strict reject + lenient warn for
+the any+inet6 collision; lone `family any` no-false-reject).
 
 ## Repeated same-type sibling matches (NOT bracketed multi-value)
 

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -121,6 +121,14 @@ the userspace dataplane admission boundary is in
   rather than holding stale "up" state (#2944). The IP address owner (priority
   255) always preempts a lower-priority master irrespective of the `no-preempt`
   flag (RFC 5798 §6.1, #4116) and is exempt from track-down demotion.
+  **VRRP `authentication-type` / `authentication-key` are REJECTED at commit**
+  (#4288): RFC 5798 VRRPv3 removed authentication (VRRPv2 had it), so the
+  native dataplane cannot authenticate adverts. Accepting the auth config
+  silently would be a false-security posture — an operator would believe
+  mastership is protected when a rogue host can still hijack it. The compiler
+  hard-rejects the statement on operator commit and warns (does not brick) on
+  the tolerant load / peer-sync path (`validateVRRPAuthenticationAST`,
+  `pkg/config/compiler_interfaces.go`).
 - **Redundancy-group IP monitoring** (`chassis cluster redundancy-group N
   ip-monitoring`): each configured target is ICMP-echo probed every poll and
   its `weight` is subtracted from the RG priority while the target is

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -198,7 +198,12 @@ the userspace dataplane admission boundary is in
   collector, source}` labelset and Prometheus either rejects the duplicate
   (scrape error) or silently collapses the failing group.
 - **Prometheus metrics** (`/metrics` endpoint).
-- **SNMP**: system + ifTable MIB.
+- **SNMP**: system + ifTable MIB. Community `clients` source-IP restriction
+  ENFORCED (#4289): `snmp community <c> clients { <prefix> [restrict]; }`
+  scopes a community to the listed source prefixes — a v2c query from a source
+  outside the allowlist is dropped (longest-prefix match, `restrict` denies; a
+  community without `clients` is allow-all). Enforced in the agent v2c path
+  (`pkg/snmp/agent.go` `handleV2cPacket` → `SNMPCommunity.AllowsSource`).
 - **RPM probes**, dynamic address feeds.
 - **Dataplane buffer utilization** (`show system buffers`): AF_XDP
   UMEM/TX-ring capacity, CoS queued-byte capacity, helper-published

--- a/pkg/api/config_secret_redaction_test.go
+++ b/pkg/api/config_secret_redaction_test.go
@@ -23,7 +23,6 @@ var secretSentinels = []string{
 	"LEAK-ISIS-AREA-AUTHKEY",  // ISISConfig.AuthKey
 	"LEAK-ISIS-IFACE-AUTHKEY", // ISISInterface.AuthKey
 	"LEAK-BGP-AUTHPW",         // BGPNeighbor.AuthPassword (group-level)
-	"LEAK-VRRP-AUTHKEY",       // VRRPGroup.AuthKey
 	"LEAK-API-USER-PW",        // APIAuthUser.Password
 	"LEAK-API-KEY-TOKEN",      // APIAuthConfig.APIKeys
 	"LEAK-SNMPV3-AUTHPW",      // SNMPv3User.AuthPassword
@@ -80,10 +79,16 @@ var secretSetCommands = []string{
 	"set protocols bgp group external peer-as 65002",
 	"set protocols bgp group external authentication-key LEAK-BGP-AUTHPW",
 	"set protocols bgp group external neighbor 10.0.2.1",
-	// VRRP auth key.
+	// VRRP group (no authentication: VRRP authentication-type/-key are
+	// hard-rejected at strict commit since #4288 — the dataplane is RFC 5798
+	// VRRPv3, which has no authentication, so an operator commit carrying it
+	// is refused rather than silently accepted as a false-security posture).
+	// VRRPGroup.AuthKey is a config.Secret, so its JSON/YAML redaction is
+	// covered by the dozen other Secret sentinels here; the AST-level
+	// `authentication-key` leaf redaction is covered by the RIP/ISIS/BGP lines
+	// above (same leaf name) and by pkg/config/ast_redact_test.go, which stage
+	// a VRRP auth key through the AST RedactedClone path (no strict commit).
 	"set interfaces ge-0-0-3 unit 0 family inet address 10.0.3.1/24 vrrp-group 1 virtual-address 10.0.3.254/24",
-	"set interfaces ge-0-0-3 unit 0 family inet address 10.0.3.1/24 vrrp-group 1 authentication-type md5",
-	"set interfaces ge-0-0-3 unit 0 family inet address 10.0.3.1/24 vrrp-group 1 authentication-key LEAK-VRRP-AUTHKEY",
 	// REST API basic-auth password + API key.
 	"set system services web-management http",
 	"set system services web-management api-auth user admin password LEAK-API-USER-PW",

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -79,6 +79,18 @@ type compileOpts struct {
 	// #1319 PR 2 SchemaValidate violations only warn on tolerant paths).
 	lenientVRRPTrackDuplicates bool
 
+	// lenientVRRPAuthentication (#4288) downgrades the VRRP authentication
+	// reject (a vrrp-group carrying authentication-type / authentication-key)
+	// from a hard compile error to a cfg.Warnings entry. The native dataplane
+	// is RFC 5798 VRRPv3, which REMOVED authentication — the auth config is
+	// parsed but never enforced, so silently accepting it lets an operator
+	// believe adverts are authenticated when they are not (a rogue host can
+	// hijack mastership). Strict (commit / commit-check): hard-reject so the
+	// operator is not misled into a false-security posture. Set ONLY on the
+	// tolerant load / peer-sync paths so an already-persisted or peer-synced
+	// config an older binary silently accepted still boots (#1960).
+	lenientVRRPAuthentication bool
+
 	// lenientDeviceMap (#1956 V-1) downgrades the cross-entry device-map
 	// validator (validateDeviceMapStrict) from a hard compile error to a
 	// cfg.Warnings entry. Set ONLY on the tolerant load / peer-sync paths
@@ -1408,6 +1420,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 	return compileConfigWithOpts(tree, compileOpts{
 		sanitizeFreeTextControlChars:           true,
 		lenientVRRPTrackDuplicates:             true,
+		lenientVRRPAuthentication:              true,
 		lenientDeviceMap:                       true,
 		lenientPolicyMatchAddress:              true,
 		lenientTCPMSSRange:                     true,
@@ -1590,6 +1603,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 	return compileConfigForNodeWithOpts(tree, nodeID, compileOpts{
 		sanitizeFreeTextControlChars:           true,
 		lenientVRRPTrackDuplicates:             true,
+		lenientVRRPAuthentication:              true,
 		lenientDeviceMap:                       true,
 		lenientPolicyMatchAddress:              true,
 		lenientTCPMSSRange:                     true,
@@ -1758,6 +1772,25 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	// from here too — the typed config cannot distinguish them
 	// post-compile.
 	trackWarnings, err := validateVRRPTrackInterfaceAST(tree.Children, "", opts.lenientVRRPTrackDuplicates)
+	if err != nil {
+		return nil, err
+	}
+
+	// #4288 VRRP authentication reject. The native dataplane is RFC 5798
+	// VRRPv3, which REMOVED authentication (VRRPv2 had it; v3 does not). xpf
+	// parses authentication-type / authentication-key
+	// (compiler_interfaces.go), stores them on the VRRPGroup, and copies them
+	// into the VRRP instance (pkg/vrrp/vrrp.go) — but the packet build/receive
+	// path NEVER references them, so the config is inert. Silently accepting it
+	// lets an operator believe adverts are authenticated when they are not: a
+	// rogue host on the segment can send higher-priority adverts and hijack
+	// mastership. Runs on the group-expanded, inactive-pruned tree so an
+	// apply-groups-inherited auth statement is covered. Strict (commit /
+	// commit-check): hard-reject so the operator is not misled into a
+	// false-security posture. Lenient (load / peer-sync): warn so an
+	// already-persisted or peer-synced config an older binary silently
+	// accepted still boots (#1960).
+	vrrpAuthWarnings, err := validateVRRPAuthenticationAST(tree.Children, "", opts.lenientVRRPAuthentication)
 	if err != nil {
 		return nil, err
 	}
@@ -2110,6 +2143,7 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	}
 	cfg.Warnings = append(cfg.Warnings, ctrlCharWarnings...)
 	cfg.Warnings = append(cfg.Warnings, trackWarnings...)
+	cfg.Warnings = append(cfg.Warnings, vrrpAuthWarnings...)
 	cfg.Warnings = append(cfg.Warnings, mssWarnings...)
 	cfg.Warnings = append(cfg.Warnings, logStreamPortWarnings...)
 	cfg.Warnings = append(cfg.Warnings, logTLSProfileWarnings...)

--- a/pkg/config/compiler_firewall.go
+++ b/pkg/config/compiler_firewall.go
@@ -180,9 +180,23 @@ func compileFirewall(node *Node, fw *FirewallConfig) error {
 				}
 			}
 
-			dest := fw.FiltersInet
-			if af == "inet6" {
-				dest = fw.FiltersInet6
+			// #4287: a Junos `family any` filter is protocol-independent —
+			// it matches BOTH IPv4 and IPv6. Folding it into FiltersInet
+			// only (the pre-#4287 behavior for every non-inet6 family) lost
+			// its IPv6 arm: a `family any` discard/deny filter enforced on
+			// v4 only silently let v6 through (a security fail-open). Compile
+			// it into BOTH pools so the deny applies to both families. The
+			// #3884 cross-family same-name collision gate
+			// (validateFirewallFilterFamilyCollisionsAST) now also treats an
+			// `any`+`inet6` same-name reuse as a collision, since `any` folds
+			// into FiltersInet6 too — a name shared with a distinct inet6
+			// filter would otherwise silently overwrite in FiltersInet6.
+			dests := []map[string]*FirewallFilter{fw.FiltersInet}
+			switch af {
+			case "inet6":
+				dests = []map[string]*FirewallFilter{fw.FiltersInet6}
+			case "any":
+				dests = []map[string]*FirewallFilter{fw.FiltersInet, fw.FiltersInet6}
 			}
 
 			for _, filterInst := range namedInstances(afNode.FindChildren("filter")) {
@@ -232,7 +246,9 @@ func compileFirewall(node *Node, fw *FirewallConfig) error {
 					filter.Terms = append(filter.Terms, term)
 				}
 
-				dest[filter.Name] = filter
+				for _, dest := range dests {
+					dest[filter.Name] = filter
+				}
 			}
 		}
 	}
@@ -288,6 +304,11 @@ func validateFirewallFilterFamilyCollisionsAST(nodes []*Node, lenient bool) ([]s
 	filterFamilies := map[string][]string{}
 	// order preserves first-seen filter-name order for a deterministic error.
 	order := []string{}
+	// inet6Names records filter names defined under `family inet6` (their own
+	// FiltersInet6 pool). #4287 compiles a `family any` filter into BOTH pools,
+	// so an `any` name that ALSO names a distinct inet6 filter now collides in
+	// FiltersInet6 — tracked here and flagged below.
+	inet6Names := map[string]bool{}
 
 	record := func(name, fam string) {
 		for _, f := range filterFamilies[name] {
@@ -325,7 +346,15 @@ func validateFirewallFilterFamilyCollisionsAST(nodes []*Node, lenient bool) ([]s
 					}
 				}
 				if af == "inet6" {
-					// Its own dest map (FiltersInet6) — cannot collide with the pool.
+					// Its own dest map (FiltersInet6). It cannot collide with
+					// the FiltersInet pool, but #4287 dual-applies `family any`
+					// into FiltersInet6 too, so record inet6 names for the
+					// any+inet6 cross-check below.
+					for _, filterInst := range namedInstances(afNode.FindChildren("filter")) {
+						if filterInst.name != "" {
+							inet6Names[filterInst.name] = true
+						}
+					}
 					continue
 				}
 				for _, filterInst := range namedInstances(afNode.FindChildren("filter")) {
@@ -351,6 +380,37 @@ func validateFirewallFilterFamilyCollisionsAST(nodes []*Node, lenient bool) ([]s
 				"earlier (a discard filter can become accept-all — fail-open); "+
 				"Junos namespaces filters per family, so rename one of them (#3884)",
 			name, strings.Join(fams, ", "))
+		if !lenient {
+			return nil, fmt.Errorf("%s", msg)
+		}
+		warnings = append(warnings, msg)
+	}
+	// #4287 any+inet6 cross-check: a `family any` filter now folds into the
+	// FiltersInet6 pool as well, so a name shared with a distinct `family inet6`
+	// filter silently overwrites in FiltersInet6 (the same fail-open the pool
+	// gate above defends against, but on the v6 side). `any` names are recorded
+	// in filterFamilies (and thus `order`), so iterating order catches them.
+	for _, name := range order {
+		if !inet6Names[name] {
+			continue
+		}
+		hasAny := false
+		for _, f := range filterFamilies[name] {
+			if f == "any" {
+				hasAny = true
+				break
+			}
+		}
+		if !hasAny {
+			continue
+		}
+		msg := fmt.Sprintf(
+			"firewall filter %q is defined under both family any and family "+
+				"inet6 — xpf compiles a family any filter into BOTH the inet and "+
+				"inet6 pools (#4287), so the any definition and the inet6 "+
+				"definition collide in the inet6 pool and one silently overwrites "+
+				"the other (fail-open); rename one of them",
+			name)
 		if !lenient {
 			return nil, fmt.Errorf("%s", msg)
 		}

--- a/pkg/config/compiler_firewall_family_any_4287_test.go
+++ b/pkg/config/compiler_firewall_family_any_4287_test.go
@@ -1,0 +1,172 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4287 (fable-review-167 F-1): a Junos `family any` firewall filter is
+// protocol-independent — it matches BOTH IPv4 and IPv6. Before #4287
+// compileFirewall folded every non-inet6 family (including `any`) into the
+// single FiltersInet (IPv4) pool, so a `family any` discard/deny filter was
+// enforced on IPv4 ONLY and silently let IPv6 through — a security fail-open.
+// The fix compiles a `family any` filter into BOTH FiltersInet and
+// FiltersInet6 so the deny applies to both address families.
+//
+// Reachability note: the schema-driven flat `set` parser does not model
+// `family any` (schema_cos.go firewall family has only inet/inet6), so a flat
+// `set firewall family any ...` collapses and never mints a structured filter.
+// A `family any` filter reaches compileFirewall's structured path only via a
+// HIERARCHICAL config-file parse or a directly-built / peer-synced AST — the
+// same paths #3884 documents — so the fixtures use parseHier.
+
+// RED-on-revert: a `family any` discard filter must land in BOTH the IPv4 and
+// IPv6 pools. On revert of the #4287 fix this goes RED — the filter compiles
+// into FiltersInet only and the IPv6 forwarding path (FilterInputV6 →
+// FiltersInet6) never sees it, so v6 passes (fail-open).
+func TestFirewallFilterFamilyAnyAppliesToBothPools(t *testing.T) {
+	tree := parseHier(t, `
+firewall {
+    family any {
+        filter drop6 {
+            term t {
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+`)
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: family any filter must commit cleanly, got error: %v", err)
+	}
+	v4, ok4 := cfg.Firewall.FiltersInet["drop6"]
+	if !ok4 {
+		t.Fatal("family any filter drop6 must land in FiltersInet (IPv4)")
+	}
+	v6, ok6 := cfg.Firewall.FiltersInet6["drop6"]
+	if !ok6 {
+		t.Fatal("family any filter drop6 must land in FiltersInet6 (IPv6) — losing the v6 arm is the fail-open")
+	}
+	// Both must carry the discard action (the deny must apply to both families).
+	for fam, f := range map[string]*FirewallFilter{"inet": v4, "inet6": v6} {
+		if len(f.Terms) != 1 || f.Terms[0].Action != "discard" {
+			t.Fatalf("family any drop6 (%s pool): expected one discard term, got %+v", fam, f.Terms)
+		}
+	}
+}
+
+// A `family any` filter that shares a NAME with a distinct `family inet6`
+// filter now collides in the FiltersInet6 pool (any folds there too), so it is
+// hard-rejected at strict commit — otherwise one silently overwrites the other
+// (fail-open on the v6 side). On revert this goes RED (no error, silent
+// overwrite).
+func TestFirewallFilterFamilyAnyInet6NameCollisionRejected(t *testing.T) {
+	tree := parseHier(t, `
+firewall {
+    family inet6 {
+        filter blockV6 {
+            term t1 {
+                then {
+                    accept;
+                }
+            }
+        }
+    }
+    family any {
+        filter blockV6 {
+            term t1 {
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+`)
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of family any + family inet6 same-name collision, got nil")
+	}
+	if !strings.Contains(err.Error(), "blockV6") || !strings.Contains(err.Error(), "#4287") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// Lenient (load / peer-sync): the any+inet6 collision downgrades to a warning
+// so an already-persisted or peer-synced config still boots.
+func TestFirewallFilterFamilyAnyInet6NameCollisionLenientWarns(t *testing.T) {
+	tree := parseHier(t, `
+firewall {
+    family inet6 {
+        filter blockV6 {
+            term t1 {
+                then {
+                    accept;
+                }
+            }
+        }
+    }
+    family any {
+        filter blockV6 {
+            term t1 {
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+`)
+
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient: any+inet6 collision must downgrade to a warning, got error: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "blockV6") && strings.Contains(w, "#4287") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a #4287 any+inet6 collision warning on the lenient path, got: %v", cfg.Warnings)
+	}
+}
+
+// A `family any` filter whose name does NOT collide with any inet/inet6 filter
+// commits cleanly with no collision error/warning — the gate must not
+// over-reject the legitimate dual-family case.
+func TestFirewallFilterFamilyAnyNoCollisionCommits(t *testing.T) {
+	tree := parseHier(t, `
+firewall {
+    family any {
+        filter dropBoth {
+            term t {
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+`)
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: lone family any filter must commit cleanly, got error: %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#4287") || strings.Contains(w, "#3884") {
+			t.Fatalf("unexpected collision warning on a valid lone family any config: %q", w)
+		}
+	}
+	if cfg.Firewall.FiltersInet["dropBoth"] == nil || cfg.Firewall.FiltersInet6["dropBoth"] == nil {
+		t.Fatal("lone family any dropBoth must land in both pools")
+	}
+}

--- a/pkg/config/compiler_interfaces.go
+++ b/pkg/config/compiler_interfaces.go
@@ -911,11 +911,21 @@ func validateVRRPAuthenticationAST(nodes []*Node, prefix string, lenient bool) (
 		nodePath := joinNodePath(prefix, n.Keys)
 		if n.Name() == "vrrp-group" {
 			if leaf := vrrpAuthLeaf(n); leaf != "" {
+				// SECURITY: build the message path from the group IDENTITY
+				// ONLY (`vrrp-group <id>`), never n.Keys — in the Keys-packed
+				// spelling (`vrrp-group 1 authentication-key <secret>;`) the
+				// node's Keys run carries the authentication-key VALUE, so
+				// joinNodePath(prefix, n.Keys) would ECHO the secret into the
+				// commit error / lenient warning (logs + CLI). vrrpGroupIDKeys
+				// truncates to the value-free identity; `prefix` is composed of
+				// ancestor container keys (interface/unit/family/address) which
+				// carry no secret leaf value.
+				idPath := joinNodePath(prefix, vrrpGroupIDKeys(n))
 				msg := fmt.Sprintf("%s: VRRP %s is configured but NOT enforced — "+
 					"the dataplane is RFC 5798 VRRPv3, which removed authentication; "+
 					"adverts are unauthenticated regardless, so a rogue host can hijack "+
 					"mastership. Remove the authentication statement (#4288)",
-					nodePath, leaf)
+					idPath, leaf)
 				if !lenient {
 					return nil, fmt.Errorf("%s", msg)
 				}
@@ -929,6 +939,19 @@ func validateVRRPAuthenticationAST(nodes []*Node, prefix string, lenient bool) (
 		}
 	}
 	return warnings, nil
+}
+
+// vrrpGroupIDKeys returns the value-free identity keys of a vrrp-group node —
+// `["vrrp-group", "<id>"]` — dropping any trailing tokens that the Keys-packed
+// spelling (`vrrp-group 1 authentication-key <secret>;`) folds onto the same
+// Keys run. Used to build a diagnostic path that never echoes a leaf VALUE (the
+// authentication-key is a secret; see validateVRRPAuthenticationAST). vrrp-group
+// is `args: 1`, so the identity is exactly the first two keys.
+func vrrpGroupIDKeys(n *Node) []string {
+	if len(n.Keys) >= 2 {
+		return n.Keys[:2]
+	}
+	return n.Keys
 }
 
 // vrrpAuthLeaf returns the first authentication leaf name

--- a/pkg/config/compiler_interfaces.go
+++ b/pkg/config/compiler_interfaces.go
@@ -893,6 +893,64 @@ func validateVRRPTrackInterfaceAST(nodes []*Node, prefix string, lenient bool) (
 	return warnings, nil
 }
 
+// validateVRRPAuthenticationAST walks every vrrp-group node and rejects
+// (strict) or warns (lenient) a configured authentication-type /
+// authentication-key. #4288: the native dataplane is RFC 5798 VRRPv3, which
+// REMOVED authentication (VRRPv2 had it; v3 does not). The compiler parses the
+// auth statements (nodeVal above), stores them on the VRRPGroup, and copies
+// them into the VRRP instance (pkg/vrrp/vrrp.go), but the packet build/receive
+// path never references them — the config is inert. Silently accepting it lets
+// an operator believe adverts are authenticated when they are not: a rogue host
+// on the segment can send higher-priority adverts and hijack mastership. The
+// honest posture is to REJECT the dead-security config at strict commit so the
+// operator is not misled, and warn (not brick) on the tolerant load / peer-sync
+// path. Mirrors validateVRRPTrackInterfaceAST's recursive vrrp-group walk.
+func validateVRRPAuthenticationAST(nodes []*Node, prefix string, lenient bool) ([]string, error) {
+	var warnings []string
+	for _, n := range nodes {
+		nodePath := joinNodePath(prefix, n.Keys)
+		if n.Name() == "vrrp-group" {
+			if leaf := vrrpAuthLeaf(n); leaf != "" {
+				msg := fmt.Sprintf("%s: VRRP %s is configured but NOT enforced — "+
+					"the dataplane is RFC 5798 VRRPv3, which removed authentication; "+
+					"adverts are unauthenticated regardless, so a rogue host can hijack "+
+					"mastership. Remove the authentication statement (#4288)",
+					nodePath, leaf)
+				if !lenient {
+					return nil, fmt.Errorf("%s", msg)
+				}
+				warnings = append(warnings, msg)
+			}
+		}
+		w, err := validateVRRPAuthenticationAST(n.Children, nodePath, lenient)
+		warnings = append(warnings, w...)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return warnings, nil
+}
+
+// vrrpAuthLeaf returns the first authentication leaf name
+// ("authentication-type" or "authentication-key") present on a vrrp-group node,
+// across BOTH the Keys-packed flat-set spelling (the token appears in the
+// group node's Keys run) and the child-node / hierarchical spelling (a child
+// node named authentication-type / authentication-key). Returns "" when no
+// authentication statement is present.
+func vrrpAuthLeaf(vg *Node) string {
+	for _, k := range vg.Keys {
+		if k == "authentication-type" || k == "authentication-key" {
+			return k
+		}
+	}
+	for _, c := range vg.Children {
+		if name := c.Name(); name == "authentication-type" || name == "authentication-key" {
+			return name
+		}
+	}
+	return ""
+}
+
 // parseTrackCost parses a priority-cost value, returning 0 (tracking
 // has no effect) for anything outside the schema's 1..254 range — a
 // negative cost would RAISE priority on link-down (Codex review on PR

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -880,8 +880,16 @@ func compileSNMP(node *Node, sys *SystemConfig, cfg *Config, lenient bool) error
 					commChildren = child.Children[0].Children
 				}
 				for _, prop := range commChildren {
-					if prop.Name() == "authorization" {
+					switch prop.Name() {
+					case "authorization":
 						comm.Authorization = nodeVal(prop)
+					case "clients":
+						// #4289: Junos `clients` source-IP allowlist.
+						// parseSNMPClients handles both AST shapes and the
+						// per-entry `restrict` modifier. Accumulate so a
+						// clients block split across load-merge / flat-set
+						// replays is not dropped.
+						comm.Clients = append(comm.Clients, parseSNMPClients(prop)...)
 					}
 				}
 				// Flat form: community public authorization read-only

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -859,6 +859,11 @@ var schemaSNMP = &schemaNode{desc: "SNMP configuration", children: map[string]*s
 			validator:     ValidateEnum([]string{"read-only", "read-write"}),
 			children:      nil,
 		},
+		// #4289: source-IP allowlist. `clients <prefix> [restrict]` — multi so a
+		// bracketed list / repeated set lines collapse onto the leaf; the
+		// trailing optional `restrict` deny modifier rides on the same run and
+		// is paired to its prefix by parseSNMPClients.
+		"clients": {desc: "Source-IP allowlist for this community (<prefix> [restrict])", args: 1, multi: true, placeholder: "<prefix>", children: nil},
 	}},
 	"trap-group": {desc: "Trap group", args: 1, placeholder: "<group-name>", children: map[string]*schemaNode{
 		"targets": {

--- a/pkg/config/snmp_clients.go
+++ b/pkg/config/snmp_clients.go
@@ -1,0 +1,108 @@
+package config
+
+import "net"
+
+// SNMP community `clients` source-IP restriction (#4289).
+//
+// Junos `snmp community <c> clients { <prefix> [restrict]; ... }` scopes a
+// community so it is answered only from the listed source prefixes. xpf parsed
+// only `authorization` and served every source, so a community scoped to a
+// management subnet was queryable from anywhere — the restriction was silently
+// ignored (a security fail-open). The compiler now captures the allowlist
+// (parseSNMPClients) and the SNMP agent enforces it before serving a v2c
+// request (AllowsSource).
+
+// AllowsSource reports whether a v2c query from srcIP may be served under this
+// community. Semantics (Junos):
+//
+//   - No `clients` configured (empty allowlist): allow all (the default).
+//   - Otherwise longest-prefix match wins: the most-specific entry containing
+//     srcIP decides — `restrict` denies, a plain entry allows.
+//   - `clients` configured but srcIP matches no entry: deny (an allowlist that
+//     lists some sources implicitly excludes the rest).
+//
+// A nil srcIP (e.g. a non-IP transport / test path with no address) is allowed
+// so enforcement never blocks a request whose source cannot be determined; the
+// real serving path always supplies the UDP source address.
+func (c *SNMPCommunity) AllowsSource(srcIP net.IP) bool {
+	if c == nil {
+		return false
+	}
+	if len(c.Clients) == 0 {
+		return true // no restriction — allow-all (Junos default)
+	}
+	if srcIP == nil {
+		return true
+	}
+	bestBits := -1
+	bestAllow := false
+	for _, cl := range c.Clients {
+		_, ipnet, err := parseClientPrefix(cl.Prefix)
+		if err != nil || ipnet == nil {
+			continue // an unparseable prefix is inert, never a silent allow-all
+		}
+		if !ipnet.Contains(srcIP) {
+			continue
+		}
+		ones, _ := ipnet.Mask.Size()
+		if ones > bestBits {
+			bestBits = ones
+			bestAllow = !cl.Restrict
+		}
+	}
+	if bestBits < 0 {
+		return false // clients configured, no match: default-deny
+	}
+	return bestAllow
+}
+
+// parseClientPrefix parses a `clients` entry as either a CIDR prefix
+// (10.0.0.0/24, 2001:db8::/32) or a bare address (192.168.1.5, ::1), the bare
+// form treated as a host route (/32 or /128).
+func parseClientPrefix(s string) (net.IP, *net.IPNet, error) {
+	if ip, ipnet, err := net.ParseCIDR(s); err == nil {
+		return ip, ipnet, nil
+	}
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return nil, nil, &net.ParseError{Type: "SNMP client prefix", Text: s}
+	}
+	bits := 32
+	if ip.To4() == nil {
+		bits = 128
+	}
+	return ip, &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)}, nil
+}
+
+// parseSNMPClients extracts the `clients` allowlist from a community's `clients`
+// node, across both parser AST shapes (the #2419 dual-shape class). Each entry
+// is a `<prefix> [restrict]` group: a token equal to "restrict" attaches to the
+// prefix immediately preceding it (modeled on firewallPrefixListRefs's
+// `<name> [except]` handling).
+//
+//   - hierarchical block   `clients { 10.0.0.0/24; 0.0.0.0/0 restrict; }`
+//     → one child node per entry (child.Keys=["10.0.0.0/24"] / ["0.0.0.0/0","restrict"])
+//   - flat set / bracket   `clients 10.0.0.0/24` / `clients [ a b ]`
+//     → tokens on node.Keys[1:]
+func parseSNMPClients(node *Node) []SNMPClient {
+	var out []SNMPClient
+	appendTokens := func(tokens []string) {
+		for _, t := range tokens {
+			if t == "" {
+				continue
+			}
+			if t == "restrict" {
+				if len(out) > 0 {
+					out[len(out)-1].Restrict = true
+				}
+				continue
+			}
+			out = append(out, SNMPClient{Prefix: t})
+		}
+	}
+	appendTokens(node.Keys[1:])
+	for _, ch := range node.Children {
+		appendTokens(ch.Keys)
+	}
+	return out
+}

--- a/pkg/config/snmp_clients_4289_test.go
+++ b/pkg/config/snmp_clients_4289_test.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"net"
+	"testing"
+)
+
+// #4289 (fable-review-167 S-3): the SNMP community `clients` source-IP
+// restriction was silently ignored (parsed nothing, served every source). The
+// compiler now captures the allowlist and SNMPCommunity.AllowsSource enforces
+// it. These tests pin the parse (both AST shapes + the `restrict` modifier) and
+// the longest-prefix-match / default-deny / allow-all semantics.
+
+func communityFrom(t *testing.T, tree *ConfigTree, name string) *SNMPCommunity {
+	t.Helper()
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if cfg.System.SNMP == nil {
+		t.Fatal("no SNMP config compiled")
+	}
+	c := cfg.System.SNMP.Communities[name]
+	if c == nil {
+		t.Fatalf("community %q not compiled", name)
+	}
+	return c
+}
+
+// Flat-set parse of `clients` (with a trailing `restrict`) plus the AllowsSource
+// semantics. RED-on-revert: without the compileSNMP clients parse, Clients is
+// empty → AllowsSource returns allow-all → the 8.8.8.8 assertion (deny) flips.
+func TestSNMPClientsFlatSetParseAndEnforce(t *testing.T) {
+	c := communityFrom(t, buildTreeFromSet(t, []string{
+		"set snmp community public authorization read-only",
+		"set snmp community public clients 10.0.0.0/24",
+		"set snmp community public clients 192.168.1.5",
+		"set snmp community public clients 0.0.0.0/0 restrict",
+	}), "public")
+
+	if len(c.Clients) != 3 {
+		t.Fatalf("expected 3 client entries, got %+v", c.Clients)
+	}
+	cases := map[string]bool{
+		"10.0.0.5":    true,  // in 10.0.0.0/24
+		"192.168.1.5": true,  // /32 host
+		"8.8.8.8":     false, // only 0.0.0.0/0 restrict matches → deny
+	}
+	for src, want := range cases {
+		if got := c.AllowsSource(net.ParseIP(src)); got != want {
+			t.Errorf("AllowsSource(%s) = %v, want %v", src, got, want)
+		}
+	}
+}
+
+// Hierarchical parse with longest-prefix-match: a /24 restrict inside a /16
+// allow denies the /24 while the rest of the /16 is allowed. A source matching
+// no entry is denied (clients configured = default-deny for the unlisted).
+func TestSNMPClientsHierLongestPrefix(t *testing.T) {
+	c := communityFrom(t, parseHier(t, `
+snmp {
+    community mgmt {
+        authorization read-only;
+        clients {
+            10.1.0.0/16;
+            10.1.2.0/24 restrict;
+        }
+    }
+}
+`), "mgmt")
+
+	cases := map[string]bool{
+		"10.1.5.1":  true,  // allowed by /16
+		"10.1.2.9":  false, // denied by /24 restrict (longest match)
+		"192.0.2.1": false, // no match → default-deny
+	}
+	for src, want := range cases {
+		if got := c.AllowsSource(net.ParseIP(src)); got != want {
+			t.Errorf("AllowsSource(%s) = %v, want %v", src, got, want)
+		}
+	}
+}
+
+// A community without `clients` is allow-all (Junos default) — the enforcement
+// must not change the common unscoped case.
+func TestSNMPClientsAbsentIsAllowAll(t *testing.T) {
+	c := communityFrom(t, parseHier(t, `snmp { community open { authorization read-only; } }`), "open")
+	if len(c.Clients) != 0 {
+		t.Fatalf("expected no clients, got %+v", c.Clients)
+	}
+	for _, src := range []string{"10.0.0.1", "8.8.8.8", "2001:db8::1"} {
+		if !c.AllowsSource(net.ParseIP(src)) {
+			t.Errorf("AllowsSource(%s) = false on an unscoped community, want allow-all", src)
+		}
+	}
+}
+
+// IPv6 prefixes are honored too.
+func TestSNMPClientsIPv6(t *testing.T) {
+	c := communityFrom(t, parseHier(t, `
+snmp {
+    community v6 {
+        authorization read-only;
+        clients {
+            2001:db8::/32;
+        }
+    }
+}
+`), "v6")
+	if got := c.AllowsSource(net.ParseIP("2001:db8::1")); !got {
+		t.Error("AllowsSource(2001:db8::1) = false, want true (in 2001:db8::/32)")
+	}
+	if got := c.AllowsSource(net.ParseIP("2001:dead::1")); got {
+		t.Error("AllowsSource(2001:dead::1) = true, want false (outside 2001:db8::/32)")
+	}
+}

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -492,17 +492,34 @@ func (s SNMPConfig) MarshalYAML() (any, error) {
 type SNMPCommunity struct {
 	Name          string
 	Authorization string // "read-only" or "read-write"
+	// Clients is the Junos `clients` source-IP allowlist (#4289). When
+	// non-empty, only a query whose source IP matches the allowlist (by
+	// longest-prefix match, honoring the per-entry `restrict` deny modifier)
+	// is served — a query from any other source is dropped. An empty Clients
+	// is allow-all (the Junos default). Enforced by the SNMP agent via
+	// AllowsSource (snmp_clients.go).
+	Clients []SNMPClient
+}
+
+// SNMPClient is one entry of an SNMP community `clients` source-IP allowlist:
+// an address prefix and an optional Junos `restrict` (deny) modifier. See
+// SNMPCommunity.AllowsSource (snmp_clients.go).
+type SNMPClient struct {
+	Prefix   string // CIDR (10.0.0.0/24) or bare address (192.168.1.5 == /32 or /128)
+	Restrict bool   // true = deny this prefix (Junos `restrict`)
 }
 
 // MarshalJSON redacts the community string (the secret) on the JSON
-// surface, e.g. GET /api/v1/config, while leaving Authorization in the
-// clear. See the type doc for why Name stays a plain string (#2053).
+// surface, e.g. GET /api/v1/config, while leaving Authorization and the
+// (non-secret) clients allowlist in the clear. See the type doc for why
+// Name stays a plain string (#2053).
 func (c SNMPCommunity) MarshalJSON() ([]byte, error) {
 	type alias struct {
 		Name          Secret
 		Authorization string
+		Clients       []SNMPClient `json:",omitempty"`
 	}
-	return json.Marshal(alias{Name: Secret(c.Name), Authorization: c.Authorization})
+	return json.Marshal(alias{Name: Secret(c.Name), Authorization: c.Authorization, Clients: c.Clients})
 }
 
 // MarshalYAML mirrors MarshalJSON for the gopkg.in/yaml.v3 marshaller
@@ -511,7 +528,8 @@ func (c SNMPCommunity) MarshalYAML() (any, error) {
 	return struct {
 		Name          Secret
 		Authorization string
-	}{Name: Secret(c.Name), Authorization: c.Authorization}, nil
+		Clients       []SNMPClient `yaml:",omitempty"`
+	}{Name: Secret(c.Name), Authorization: c.Authorization, Clients: c.Clients}, nil
 }
 
 // SNMPTrapGroup defines an SNMP trap destination group.

--- a/pkg/config/vrrp_authentication_4288_test.go
+++ b/pkg/config/vrrp_authentication_4288_test.go
@@ -122,3 +122,86 @@ func TestVRRPNoAuthenticationCommits(t *testing.T) {
 		t.Fatal("expected the vrrp-group to compile")
 	}
 }
+
+// SECURITY (Copilot fable-167 review): the reject error / lenient warning must
+// NOT echo the authentication-key VALUE (it is a secret). In the Keys-packed
+// hierarchical leaf spelling `vrrp-group 1 authentication-key <secret>;` the
+// value rides on the vrrp-group node's Keys run, so a message built from the
+// full Keys would leak it into logs + CLI. The message must carry only the
+// group IDENTITY (`vrrp-group 1`). RED-on-revert: building the path from n.Keys
+// puts the secret into the error string.
+const vrrpAuthSecret = "SUPERSECRETVRRPKEY"
+
+func TestVRRPAuthenticationRejectDoesNotLeakSecret_KeysPacked(t *testing.T) {
+	// Hierarchical leaf form packs the value onto the vrrp-group node's Keys.
+	tree := parseHier(t, `interfaces {
+    reth0 {
+        unit 0 {
+            family inet {
+                address 10.0.61.10/24 {
+                    vrrp-group 1 authentication-key `+vrrpAuthSecret+`;
+                }
+            }
+        }
+    }
+}`)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected rejection of Keys-packed VRRP authentication-key, got nil")
+	}
+	if strings.Contains(err.Error(), vrrpAuthSecret) {
+		t.Fatalf("reject error LEAKED the authentication-key secret: %v", err)
+	}
+	// It must still identify the offending group without any leaf value.
+	if !strings.Contains(err.Error(), "vrrp-group 1") || !strings.Contains(err.Error(), "#4288") {
+		t.Fatalf("reject error must name the group identity + #4288, got: %v", err)
+	}
+}
+
+func TestVRRPAuthenticationRejectDoesNotLeakSecret_FlatSet(t *testing.T) {
+	tree := replaySetLines(t, []string{
+		"set interfaces reth0 unit 0 family inet address 10.0.61.10/24 vrrp-group 1 virtual-address 10.0.61.1/24",
+		"set interfaces reth0 unit 0 family inet address 10.0.61.10/24 vrrp-group 1 authentication-key " + vrrpAuthSecret,
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected rejection of flat-set VRRP authentication-key, got nil")
+	}
+	if strings.Contains(err.Error(), vrrpAuthSecret) {
+		t.Fatalf("reject error LEAKED the authentication-key secret: %v", err)
+	}
+	if !strings.Contains(err.Error(), "vrrp-group 1") || !strings.Contains(err.Error(), "#4288") {
+		t.Fatalf("reject error must name the group identity + #4288, got: %v", err)
+	}
+}
+
+// The lenient warning must also be value-free.
+func TestVRRPAuthenticationWarnDoesNotLeakSecret_KeysPacked(t *testing.T) {
+	tree := parseHier(t, `interfaces {
+    reth0 {
+        unit 0 {
+            family inet {
+                address 10.0.61.10/24 {
+                    vrrp-group 1 authentication-key `+vrrpAuthSecret+`;
+                }
+            }
+        }
+    }
+}`)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient: %v", err)
+	}
+	sawWarn := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#4288") {
+			sawWarn = true
+			if strings.Contains(w, vrrpAuthSecret) {
+				t.Fatalf("lenient warning LEAKED the authentication-key secret: %q", w)
+			}
+		}
+	}
+	if !sawWarn {
+		t.Fatalf("expected a #4288 lenient warning, got: %v", cfg.Warnings)
+	}
+}

--- a/pkg/config/vrrp_authentication_4288_test.go
+++ b/pkg/config/vrrp_authentication_4288_test.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4288 (fable-review-167 I-1): VRRP authentication-type / authentication-key
+// are parsed, stored on the VRRPGroup, and copied into the VRRP instance
+// (pkg/vrrp/vrrp.go), but the packet build/receive path never enforces them —
+// the native dataplane is RFC 5798 VRRPv3, which REMOVED authentication.
+// Silently accepting the config lets an operator believe adverts are
+// authenticated when they are not (a rogue host can hijack mastership). The
+// honest posture is to REJECT the dead-security statement at strict commit and
+// WARN (not brick) on the tolerant load / peer-sync path.
+
+// Strict commit rejects authentication-type (flat-set shape). RED-on-revert:
+// dropping the #4288 gate makes CompileConfig return nil (the inert auth config
+// is silently accepted — the false-security posture).
+func TestVRRPAuthenticationTypeRejectedFlatSet(t *testing.T) {
+	tree := replaySetLines(t, []string{
+		"set interfaces reth0 unit 0 family inet address 10.0.61.10/24 vrrp-group 1 virtual-address 10.0.61.1/24",
+		"set interfaces reth0 unit 0 family inet address 10.0.61.10/24 vrrp-group 1 authentication-type md5",
+		"set interfaces reth0 unit 0 family inet address 10.0.61.10/24 vrrp-group 1 authentication-key secret123",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of VRRP authentication, got nil")
+	}
+	if !strings.Contains(err.Error(), "authentication") || !strings.Contains(err.Error(), "#4288") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+const vrrpAuthHier = `interfaces {
+    reth0 {
+        unit 0 {
+            family inet {
+                address 10.0.61.10/24 {
+                    vrrp-group 1 {
+                        virtual-address 10.0.61.1/24;
+                        priority 200;
+                        authentication-type md5;
+                        authentication-key secret123;
+                    }
+                }
+            }
+        }
+    }
+}`
+
+// Strict commit rejects authentication in the hierarchical (braced) shape too.
+func TestVRRPAuthenticationRejectedHierarchical(t *testing.T) {
+	_, err := CompileConfig(parseHier(t, vrrpAuthHier))
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of VRRP authentication (hier), got nil")
+	}
+	if !strings.Contains(err.Error(), "authentication") || !strings.Contains(err.Error(), "#4288") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// Lenient (load / peer-sync): the reject downgrades to a warning so an
+// already-persisted or peer-synced config an older binary silently accepted
+// still boots. RED-on-revert: without the gate there is no warning.
+func TestVRRPAuthenticationLenientWarns(t *testing.T) {
+	cfg, err := CompileConfigLenient(parseHier(t, vrrpAuthHier))
+	if err != nil {
+		t.Fatalf("CompileConfigLenient: VRRP auth must downgrade to a warning, got error: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "authentication") && strings.Contains(w, "#4288") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a #4288 VRRP authentication warning on the lenient path, got: %v", cfg.Warnings)
+	}
+	// The config still boots — the vrrp-group is compiled (auth is simply inert).
+	vg := firstVRRPGroupWithVIP(t, cfg, "10.0.61.1/24")
+	if vg == nil {
+		t.Fatal("lenient path: vrrp-group must still compile (boot, do not brick)")
+	}
+}
+
+// authentication-key WITHOUT authentication-type is also rejected — either
+// statement is the misleading dead-security config.
+func TestVRRPAuthenticationKeyOnlyRejected(t *testing.T) {
+	tree := replaySetLines(t, []string{
+		"set interfaces reth0 unit 0 family inet address 10.0.61.10/24 vrrp-group 1 virtual-address 10.0.61.1/24",
+		"set interfaces reth0 unit 0 family inet address 10.0.61.10/24 vrrp-group 1 authentication-key onlykey",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of VRRP authentication-key, got nil")
+	}
+	if !strings.Contains(err.Error(), "authentication-key") || !strings.Contains(err.Error(), "#4288") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// A normal vrrp-group WITHOUT authentication commits cleanly — the gate must
+// not over-reject legitimate VRRP configs.
+func TestVRRPNoAuthenticationCommits(t *testing.T) {
+	tree := replaySetLines(t, []string{
+		"set interfaces reth0 unit 0 family inet address 10.0.61.10/24 vrrp-group 1 virtual-address 10.0.61.1/24",
+		"set interfaces reth0 unit 0 family inet address 10.0.61.10/24 vrrp-group 1 priority 200",
+		"set interfaces reth0 unit 0 family inet address 10.0.61.10/24 vrrp-group 1 preempt",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: a vrrp-group without authentication must commit cleanly, got: %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#4288") {
+			t.Fatalf("unexpected #4288 warning on a vrrp-group without authentication: %q", w)
+		}
+	}
+	if vg := firstVRRPGroupWithVIP(t, cfg, "10.0.61.1/24"); vg == nil {
+		t.Fatal("expected the vrrp-group to compile")
+	}
+}

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -487,7 +487,11 @@ func (a *Agent) Start(ctx context.Context) error {
 			continue
 		}
 
-		resp := a.handlePacket(buf[:n])
+		var srcIP net.IP
+		if remoteAddr != nil {
+			srcIP = remoteAddr.IP
+		}
+		resp := a.handlePacketFrom(buf[:n], srcIP)
 		if resp != nil {
 			if _, err := conn.WriteToUDP(resp, remoteAddr); err != nil {
 				slog.Error("SNMP write error", "err", err, "remote", remoteAddr)
@@ -508,8 +512,19 @@ func (a *Agent) Stop() {
 	slog.Info("SNMP agent stopped")
 }
 
-// handlePacket decodes an SNMP v2c or v3 request and produces a response.
+// handlePacket decodes an SNMP v2c or v3 request and produces a response. It is
+// the source-agnostic entry point (tests / non-IP transports); the real serving
+// path in Start() calls handlePacketFrom with the UDP source so the #4289
+// community `clients` source-IP restriction is enforced.
 func (a *Agent) handlePacket(data []byte) []byte {
+	return a.handlePacketFrom(data, nil)
+}
+
+// handlePacketFrom decodes an SNMP v2c or v3 request and produces a response,
+// carrying the request source IP so the v2c community `clients` allowlist
+// (#4289) can be enforced. A nil srcIP disables the source check (see
+// SNMPCommunity.AllowsSource).
+func (a *Agent) handlePacketFrom(data []byte, srcIP net.IP) []byte {
 	// Save raw packet for v3 auth verification.
 	a.lastPacket = make([]byte, len(data))
 	copy(a.lastPacket, data)
@@ -530,7 +545,7 @@ func (a *Agent) handlePacket(data []byte) []byte {
 
 	switch version {
 	case snmpVersion2c:
-		return a.handleV2cPacket(rest)
+		return a.handleV2cPacket(rest, srcIP)
 	case snmpVersion3:
 		if !a.hasV3Users() {
 			slog.Debug("SNMP: v3 not configured")
@@ -544,7 +559,9 @@ func (a *Agent) handlePacket(data []byte) []byte {
 }
 
 // handleV2cPacket processes an SNMP v2c message (version already decoded).
-func (a *Agent) handleV2cPacket(rest []byte) []byte {
+// srcIP is the request source (nil disables the source check); it enforces the
+// community `clients` source-IP allowlist (#4289).
+func (a *Agent) handleV2cPacket(rest []byte, srcIP net.IP) []byte {
 	// Decode community string.
 	community, rest, err := berDecodeOctetString(rest)
 	if err != nil {
@@ -556,6 +573,16 @@ func (a *Agent) handleV2cPacket(rest []byte) []byte {
 	comm := a.getCommunity(string(community))
 	if comm == nil {
 		slog.Debug("SNMP: invalid community", "community", string(community))
+		return nil
+	}
+
+	// #4289: enforce the community `clients` source-IP restriction. A community
+	// scoped to specific prefixes must be answered ONLY from those sources; a
+	// query from a non-permitted source is silently dropped (no response, as
+	// with an unknown community). A community without `clients` is allow-all.
+	if !comm.AllowsSource(srcIP) {
+		slog.Debug("SNMP: community source not permitted",
+			"community", string(community), "src", srcIP)
 		return nil
 	}
 

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -581,8 +581,14 @@ func (a *Agent) handleV2cPacket(rest []byte, srcIP net.IP) []byte {
 	// query from a non-permitted source is silently dropped (no response, as
 	// with an unknown community). A community without `clients` is allow-all.
 	if !comm.AllowsSource(srcIP) {
-		slog.Debug("SNMP: community source not permitted",
-			"community", string(community), "src", srcIP)
+		// SECURITY: do NOT log the community string — it is the v2c shared
+		// secret (SNMPCommunity.Name, redacted everywhere else). Log only the
+		// source; known_community=true distinguishes this source-denied KNOWN
+		// community from the unknown-community drop above (which also logs no
+		// secret value here) so a source-restriction denial can be correlated
+		// without exposing the secret (#4289).
+		slog.Debug("SNMP: source not permitted for community",
+			"src", srcIP, "known_community", true)
 		return nil
 	}
 

--- a/pkg/snmp/agent_clients_4289_test.go
+++ b/pkg/snmp/agent_clients_4289_test.go
@@ -1,0 +1,87 @@
+package snmp
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #4289 (fable-review-167 S-3): an SNMP community scoped with `clients
+// <prefix>` must be answered ONLY from a permitted source. Before the fix the
+// agent served every source (the restriction was silently ignored — a security
+// fail-open). handleV2cPacket now enforces SNMPCommunity.AllowsSource against
+// the UDP source before serving.
+
+// A GET from a source inside the community's clients allowlist is served; a GET
+// from a source outside it is dropped (nil response, as with an unknown
+// community). RED-on-revert: without the source check, the outside-source GET
+// is answered — the enforcement is gone.
+func TestV2cCommunityClientsSourceEnforced(t *testing.T) {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"scoped": {
+				Name:          "scoped",
+				Authorization: "read-only",
+				Clients: []config.SNMPClient{
+					{Prefix: "10.0.0.0/24"},
+				},
+			},
+		},
+	})
+
+	pkt := buildV2cGetRequest("scoped", 1, oidSysDescr)
+
+	// Permitted source (inside 10.0.0.0/24): served.
+	if resp := a.handlePacketFrom(pkt, net.ParseIP("10.0.0.9")); resp == nil {
+		t.Fatal("GET from a permitted source (10.0.0.9 in 10.0.0.0/24) was dropped; want a response")
+	}
+
+	// Non-permitted source (outside the allowlist): dropped.
+	if resp := a.handlePacketFrom(pkt, net.ParseIP("192.0.2.5")); resp != nil {
+		t.Fatal("GET from a non-permitted source (192.0.2.5, not in 10.0.0.0/24) was answered; want no response (fail-open)")
+	}
+}
+
+// A community with NO clients is allow-all (Junos default) — any source is
+// served. The enforcement must not break the common unscoped community.
+func TestV2cCommunityNoClientsAllowAll(t *testing.T) {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"public": {Name: "public", Authorization: "read-only"},
+		},
+	})
+
+	pkt := buildV2cGetRequest("public", 2, oidSysDescr)
+	for _, src := range []string{"10.0.0.9", "192.0.2.5", "203.0.113.7"} {
+		if resp := a.handlePacketFrom(pkt, net.ParseIP(src)); resp == nil {
+			t.Fatalf("GET from %s to an unscoped (allow-all) community was dropped; want a response", src)
+		}
+	}
+}
+
+// The `restrict` deny modifier: a source matched by a restrict entry (longest
+// prefix) is denied even though a broader allow entry would otherwise permit it.
+func TestV2cCommunityClientsRestrictDenies(t *testing.T) {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"mgmt": {
+				Name:          "mgmt",
+				Authorization: "read-only",
+				Clients: []config.SNMPClient{
+					{Prefix: "10.1.0.0/16"},
+					{Prefix: "10.1.2.0/24", Restrict: true},
+				},
+			},
+		},
+	})
+
+	pkt := buildV2cGetRequest("mgmt", 3, oidSysDescr)
+
+	if resp := a.handlePacketFrom(pkt, net.ParseIP("10.1.5.1")); resp == nil {
+		t.Fatal("GET from 10.1.5.1 (allowed by 10.1.0.0/16) was dropped; want a response")
+	}
+	if resp := a.handlePacketFrom(pkt, net.ParseIP("10.1.2.9")); resp != nil {
+		t.Fatal("GET from 10.1.2.9 (restricted by 10.1.2.0/24) was answered; want no response")
+	}
+}


### PR DESCRIPTION
Three vSRX-parity SECURITY fixes from fable-review-167 — config knobs that
should provide security but silently did not. Each is fixed to the honest,
fail-safe posture (never leave a false-security state) with a RED-on-revert
test.

## F-1 (#4287) — `firewall family any` filter lost the IPv6 arm (fail-open)

`compileFirewall` folded a `family any` filter into the IPv4 pool
(`FiltersInet`) only, so a `family any` discard/deny filter was enforced on
IPv4 and silently let IPv6 through — an operator's protocol-independent deny
failed open for v6.

Fix: compile a `family any` filter into BOTH `FiltersInet` and `FiltersInet6`.
Because `any` now folds into the inet6 pool too, the #3884 cross-family
collision gate is extended with an `any`+`inet6` same-name check (strict reject
/ lenient warn).

- `pkg/config/compiler_firewall.go`
- RED-on-revert: `compiler_firewall_family_any_4287_test.go`
  (`TestFirewallFilterFamilyAnyAppliesToBothPools` — FiltersInet6 lacks the
  filter on revert).

## I-1 (#4288) — VRRP authentication parsed but never enforced (false security)

`authentication-type` / `authentication-key` were parsed, stored, and copied
into the VRRP instance, but the native dataplane is RFC 5798 VRRPv3, which
REMOVED authentication — the config is inert. Silently accepting it let an
operator believe adverts were authenticated when a rogue host could still
hijack mastership.

Fix (honest posture): REJECT the auth statement at strict commit
(`validateVRRPAuthenticationAST`) and warn (not brick) on the lenient load /
peer-sync path (#1960 doctrine) — the operator is told VRRPv3 cannot
authenticate rather than being misled.

- `pkg/config/compiler.go`, `pkg/config/compiler_interfaces.go`
- RED-on-revert: `vrrp_authentication_4288_test.go` (strict reject both AST
  shapes, lenient warn; no-auth vrrp-group unaffected).

## S-3 (#4289) — SNMP community `clients` source-IP restriction ignored (allow-all)

The SNMP agent answered every source; the `clients` source-IP allowlist was
never parsed or enforced, so a community scoped to a management subnet was
queryable from anywhere.

Fix: parse `clients` (with the `restrict` deny modifier), and enforce
`SNMPCommunity.AllowsSource` (longest-prefix match; default-deny for an
unlisted source when clients are configured; allow-all when absent) in the
agent v2c path — a query from a non-permitted source is dropped.

- `pkg/config/types_system.go`, `pkg/config/snmp_clients.go`,
  `pkg/config/compiler_system.go`, `pkg/config/schema_system.go`,
  `pkg/snmp/agent.go`
- RED-on-revert: `snmp_clients_4289_test.go` (config) +
  `agent_clients_4289_test.go` (agent: served from a permitted source, dropped
  from a non-permitted source).

## Notes

- The pkg/api strict-commit secret-redaction fixture carried a VRRP
  authentication-key, which #4288 now rejects; that line + its sentinel were
  removed. VRRP AuthKey redaction stays covered by the `config.Secret` type
  (a dozen other sentinels) and by the AST `authentication-key` leaf redaction
  (RIP/ISIS/BGP lines + `pkg/config/ast_redact_test.go`).

## Validation

- `go test ./pkg/config/... ./pkg/vrrp/... ./pkg/api/... ./pkg/snmp/...` green
- `go build ./...`, `gofmt`, `go vet` clean
- Each fix has a RED-on-revert proof (verified by temporarily reverting the
  fix and observing the test fail).
- Docs: `docs/config-schema.md`, `docs/feature-coverage.md`, `_Log.md`.

Closes #4287
Closes #4288
Closes #4289

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
