### PR TITLE
IPsec/VPN parity (fable-167 V-1..V-5): implement proposal-set, reject AH/manual, validate establish-tunnels, advise vpn-monitor

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -35406,3 +35406,47 @@ top.
   routing merge, clean auto-merge of _Log.md).
 - **File(s)**: pkg/config/compiler_nat.go,
   pkg/config/compiler_nat_target_parity_hb167_test.go, _Log.md
+
+## 2026-07-05 — fable-review-167 IPsec/VPN parity (V-1..V-5, #4297-4301)
+
+- **Timestamp**: 2026-07-05
+- **Action**: Filed issues #4297-#4301 and implemented the five fable-167
+  IPsec/VPN parity findings on branch `fix/hb167-ipsec-parity`.
+  - **V-1 (#4297) — proposal-set IMPLEMENTED.** `security ike|ipsec policy P
+    proposal-set <set>` was silently dropped, so the common vSRX shorthand
+    could not commit a working tunnel. Added `ProposalSet` to `IKEPolicy` /
+    `IPsecPolicyDef`, captured it in `compileIKE`/`compileIPsec`, and expand it
+    into concrete synthetic proposals via a new SSOT table
+    (`compiler_ipsec_proposalset.go`: `expandIKEProposalSets` /
+    `expandIPsecProposalSets`). standard/basic/compatible = Juniper legacy
+    tables (DH group 2, DES/3DES/SHA1/MD5); suiteb-gcm-128/256 = RFC 6379
+    Suite-B. Schema `proposal-set` enum rejects a typo. Downstream strict
+    cross-ref validators + the renderer work unchanged because the policy now
+    references real proposals.
+  - **V-2 (#4298, SECURITY) — protocol ah REJECTED (never silent-ESP).**
+    `protocol ah` used to render as ESP with a fabricated aes256 cipher.
+    Added `validateIPsecProposalProtocolStrict` (hard-reject at commit,
+    lenient warn) + a render belt `vpnUsesAHProposal` (ike.go) that SKIPS an
+    AH VPN in `renderConfig` on the tolerant-boot path. Schema types
+    `protocol` as esp|ah. AH support left as a follow-up; the invariant is
+    never to substitute ESP for AH.
+  - **V-3 (#4299) — vpn-monitor accept-with-advisory.** Typed + captured;
+    `ValidateConfig` emits an accepted-but-not-enforced advisory (mirrors
+    #2078/#4231), pointing at IKE-layer dead-peer-detection.
+  - **V-4 (#4300) — manual-key SA REJECTED.** `manual { ... }` was dropped
+    silently, leaving a dead tunnel; `validateIPsecManualKeyStrict` now
+    hard-rejects it (lenient warn).
+  - **V-5 (#4301) — establish-tunnels enum validated.**
+    `ValidateEnum([immediately, on-traffic, responder-only])`.
+- **Validation**: new RED-on-revert tests in
+  `pkg/config/compiler_ipsec_hb167_parity_test.go` (proposal-set expands /
+  compiles; ah reject; manual reject; vpn-monitor advisory; establish-tunnels
+  enum) and `pkg/ipsec/proposalset_ah_hb167_test.go` (proposal-set standard +
+  suiteb render tokens; AH-VPN render skip). `go test ./pkg/config/...
+  ./pkg/ipsec/...` green; `go build ./...` clean; gofmt + vet clean.
+- **File(s)**: pkg/config/types_security.go, pkg/config/compiler_ipsec.go,
+  pkg/config/compiler_ipsec_proposalset.go, pkg/config/schema_security.go,
+  pkg/config/compiler.go, pkg/config/compiler_validate_strict.go,
+  pkg/config/compiler_validate_warn.go, pkg/ipsec/ike.go, pkg/ipsec/policy.go,
+  pkg/ipsec/README.md, pkg/config/compiler_ipsec_hb167_parity_test.go,
+  pkg/ipsec/proposalset_ah_hb167_test.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -35513,3 +35513,25 @@ top.
   pkg/config/compiler_validate_warn.go, pkg/ipsec/ike.go, pkg/ipsec/policy.go,
   pkg/ipsec/README.md, pkg/config/compiler_ipsec_hb167_parity_test.go,
   pkg/ipsec/proposalset_ah_hb167_test.go, _Log.md
+
+## 2026-07-05 — fable-167 review fold: basic proposal-set DH group 2 -> 1 (#4297, V-1)
+
+- **Timestamp**: 2026-07-05
+- **Action**: Hostile-review fold on PR #4310. The `basic` IKE proposal-set
+  used DH group 2 in both member rows, but Junos documents `basic` = DH
+  group 1 (group2 belongs to `compatible`/`standard`). A real vSRX peer with
+  `proposal-set basic` offers group1/DES in Phase-1, so offering group2 would
+  mismatch the DH group and no common proposal would negotiate — an interop
+  failure in the make-or-break class. Fixed both IKE `basic` rows in
+  `expandIKEProposalSets` (compiler_ipsec_proposalset.go) from group 2 -> 1
+  (des/sha1/g1 + des/md5/g1). The ESP `basic` rows are unchanged and correct
+  (no PFS — DHGroup 0; Junos basic ESP is no-PFS). compatible/standard/suiteb
+  are verified exact and untouched. Updated the file + README doc comments
+  and added TestProposalSetBasicDHGroup1_4297 asserting group 1.
+- **Validation**: new test green; proven RED under the group-2 revert
+  (DHGroup:2 want g1). `go test ./pkg/config/... ./pkg/ipsec/...` green;
+  `go build ./...` clean; gofmt + vet clean. Merged origin/master
+  (dd5cdbcf, clean).
+- **File(s)**: pkg/config/compiler_ipsec_proposalset.go,
+  pkg/config/compiler_ipsec_hb167_parity_test.go, pkg/ipsec/README.md,
+  _Log.md

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -300,6 +300,28 @@ type compileOpts struct {
 	// line stays inert. Same doctrine as lenientIKEPolicyChainRef.
 	lenientIPsecTrafficSelectors bool
 
+	// lenientIPsecProposalProtocol (#4298, V-2) downgrades the IPsec
+	// proposal `protocol ah` reject (validateIPsecProposalProtocolStrict)
+	// from a hard error to a warning on the tolerant load / peer-sync paths.
+	// AH is integrity-only (no encryption) and xpf has no AH render path, so
+	// a `protocol ah` proposal used to render as ESP with a fabricated
+	// cipher — a crypto misrepresentation. Commit / commit-check hard-reject
+	// it; an already-persisted or peer-synced config carrying it must still
+	// BOOT (warn), and the render-path belt (vpnUsesAHProposal ->
+	// renderConfig skips the VPN) keeps the fabricated ESP tunnel out of the
+	// generated swanctl.conf. Same doctrine as lenientIKEPolicyChainRef.
+	lenientIPsecProposalProtocol bool
+
+	// lenientIPsecManualKey (#4300, V-4) downgrades the IPsec VPN
+	// manual-key SA reject (validateIPsecManualKeyStrict) from a hard error
+	// to a warning on the tolerant load / peer-sync paths. xpf has no
+	// manual-key path; the block was silently dropped, leaving a dead
+	// tunnel. Commit / commit-check hard-reject it so a new operator edit
+	// fails loudly; an already-persisted or peer-synced config still boots
+	// (warn) — the manual block was already inert, so the boot is fail-safe.
+	// Same doctrine as lenientIPsecGatewayRefs.
+	lenientIPsecManualKey bool
+
 	// lenientLogProfileStreamRef (#2008 H7) downgrades the
 	// `security log profile <name> stream-name <stream>` cross-reference
 	// from a hard error to a warning on the tolerant load / peer-sync
@@ -1423,6 +1445,8 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientIPsecGatewayRefs:                true,
 		lenientIKEPolicyChainRef:               true,
 		lenientIPsecTrafficSelectors:           true,
+		lenientIPsecProposalProtocol:           true,
+		lenientIPsecManualKey:                  true,
 		lenientLogProfileStreamRef:             true,
 		lenientDynamicAddressFeedRef:           true,
 		lenientNATPoolAlarmThreshold:           true,
@@ -1605,6 +1629,8 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientIPsecGatewayRefs:                true,
 		lenientIKEPolicyChainRef:               true,
 		lenientIPsecTrafficSelectors:           true,
+		lenientIPsecProposalProtocol:           true,
+		lenientIPsecManualKey:                  true,
 		lenientLogProfileStreamRef:             true,
 		lenientDynamicAddressFeedRef:           true,
 		lenientNATPoolAlarmThreshold:           true,
@@ -3252,6 +3278,37 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientIKEPolicyChainRef {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("ike-policy chain reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #4298 (V-2): reject an IPsec proposal with `protocol ah`. AH is
+	// integrity-only and xpf has no AH render path, so a `protocol ah`
+	// proposal used to render as ESP with a fabricated cipher — a crypto
+	// misrepresentation. Strict on commit / commit-check (hard reject);
+	// lenient on load / peer-sync (warn so an already-persisted or
+	// peer-synced config still boots — the render belt skips the VPN rather
+	// than emitting the fabricated ESP tunnel).
+	if err := validateIPsecProposalProtocolStrict(cfg); err != nil {
+		if opts.lenientIPsecProposalProtocol {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("ipsec proposal protocol (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #4300 (V-4): reject an IPsec VPN configuring a `manual { ... }`
+	// manual-key SA. xpf has no manual-key path; the block was silently
+	// dropped, leaving a dead tunnel that committed OK. Strict on commit /
+	// commit-check (hard reject with a clear "use an IKE-negotiated VPN"
+	// message); lenient on load / peer-sync (warn — the block was already
+	// inert, so the boot is fail-safe).
+	if err := validateIPsecManualKeyStrict(cfg); err != nil {
+		if opts.lenientIPsecManualKey {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("ipsec manual-key SA (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_ipsec.go
+++ b/pkg/config/compiler_ipsec.go
@@ -73,6 +73,13 @@ func compileIKE(node *Node, sec *SecurityConfig) error {
 			switch p.Name() {
 			case "mode":
 				pol.Mode = v
+			case "proposal-set":
+				// #4297 (V-1): predefined proposal-set shorthand. Captured
+				// here and expanded into concrete synthetic proposals after
+				// both the proposal and policy maps are built
+				// (expandIKEProposalSets), so the common vSRX idiom commits a
+				// working tunnel instead of being silently dropped.
+				pol.ProposalSet = v
 			case "proposals":
 				// Multi-value leaf (#3904): `proposals [ p1 p2 ]` collapses
 				// onto Keys[1:] (hierarchical / clean flat-set) and/or child
@@ -95,6 +102,10 @@ func compileIKE(node *Node, sec *SecurityConfig) error {
 		}
 		sec.IPsec.IKEPolicies[pol.Name] = pol
 	}
+
+	// #4297 (V-1): expand any predefined IKE proposal-set into concrete
+	// synthetic proposals now that both the proposal and policy maps exist.
+	expandIKEProposalSets(sec)
 
 	// IKE gateways
 	for _, inst := range namedInstances(node.FindChildren("gateway")) {
@@ -304,6 +315,10 @@ func compileIPsec(node *Node, sec *SecurityConfig) error {
 		pol := &IPsecPolicyDef{Name: inst.name}
 		for _, p := range inst.node.Children {
 			switch p.Name() {
+			case "proposal-set":
+				// #4297 (V-1): predefined ESP proposal-set shorthand;
+				// expanded after the maps are built (expandIPsecProposalSets).
+				pol.ProposalSet = nodeVal(p)
 			case "proposals":
 				// Multi-value leaf (#3904): read EVERY ESP proposal reference
 				// (Keys[1:] + child nodes) — mirror of the IKE policy loop.
@@ -320,6 +335,10 @@ func compileIPsec(node *Node, sec *SecurityConfig) error {
 		}
 		sec.IPsec.Policies[pol.Name] = pol
 	}
+
+	// #4297 (V-1): expand any predefined ESP proposal-set into concrete
+	// synthetic proposals now that both maps exist.
+	expandIPsecProposalSets(sec)
 
 	// Gateways (may appear under ipsec or ike)
 	if sec.IPsec.Gateways == nil {
@@ -450,6 +469,27 @@ func compileIPsec(node *Node, sec *SecurityConfig) error {
 				vpn.PSK = Secret(v)
 			case "local-address":
 				vpn.LocalAddr = v
+			case "manual":
+				// #4300 (V-4): manual-key SA block. Captured (not compiled
+				// into an SA — xpf has no manual-key path) so
+				// validateIPsecManualKeyStrict rejects it at commit rather
+				// than leaving a silent dead tunnel.
+				vpn.Manual = true
+			case "vpn-monitor":
+				// #4299 (V-3): accepted-but-not-enforced. Capture the stanza
+				// so ValidateConfig emits an advisory; xpf has no ICMP-probe
+				// liveness / st0 interface-state coupling yet.
+				vpn.VPNMonitor = true
+				for _, c := range p.Children {
+					switch c.Name() {
+					case "source-interface":
+						vpn.VPNMonitorSourceInterface = nodeVal(c)
+					case "destination-ip":
+						vpn.VPNMonitorDestinationIP = nodeVal(c)
+					case "optimized":
+						vpn.VPNMonitorOptimized = true
+					}
+				}
 			}
 		}
 		for _, tsInst := range namedInstances(inst.node.FindChildren("traffic-selector")) {

--- a/pkg/config/compiler_ipsec_hb167_parity_test.go
+++ b/pkg/config/compiler_ipsec_hb167_parity_test.go
@@ -121,6 +121,47 @@ func TestProposalSetSuiteB128Expands_4297(t *testing.T) {
 	}
 }
 
+// V-1: the `basic` set is DH group 1 in Phase-1 (Junos documents `basic` =
+// group1; `compatible`/`standard` are group2). A real vSRX peer with
+// `proposal-set basic` offers group1/DES in Phase-1, so offering group2 would
+// mismatch the DH group and no proposal would negotiate.
+//
+// FAIL-ON-REVERT: the old group-2 basic rows make the DHGroup assertions RED.
+// The ESP `basic` set carries NO PFS group (0) — Junos `basic` is no-PFS.
+func TestProposalSetBasicDHGroup1_4297(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security ike policy ike-b proposal-set basic",
+		"set security ipsec policy esp-b proposal-set basic",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("proposal-set basic must compile, got: %v", err)
+	}
+	ike := resolvedIKE(t, cfg, "ike-b")
+	if len(ike) != 2 {
+		t.Fatalf("IKE basic set = %d proposals, want 2", len(ike))
+	}
+	if ike[0].EncryptionAlg != "des-cbc" || ike[0].AuthAlg != "sha1" || ike[0].DHGroup != 1 {
+		t.Errorf("IKE basic[0] = %+v, want des-cbc/sha1/g1 (Junos basic is DH group 1)", ike[0])
+	}
+	if ike[1].EncryptionAlg != "des-cbc" || ike[1].AuthAlg != "md5" || ike[1].DHGroup != 1 {
+		t.Errorf("IKE basic[1] = %+v, want des-cbc/md5/g1", ike[1])
+	}
+	// ESP basic is no-PFS (DHGroup 0) with DES + SHA1/MD5.
+	esp := resolvedESP(t, cfg, "esp-b")
+	if len(esp) != 2 {
+		t.Fatalf("ESP basic set = %d proposals, want 2", len(esp))
+	}
+	for i, p := range esp {
+		if p.EncryptionAlg != "des-cbc" || p.DHGroup != 0 {
+			t.Errorf("ESP basic[%d] = %+v, want des-cbc + no PFS (DHGroup 0)", i, p)
+		}
+	}
+	if esp[0].AuthAlg != "hmac-sha1-96" || esp[1].AuthAlg != "hmac-md5-96" {
+		t.Errorf("ESP basic auth = %q/%q, want hmac-sha1-96/hmac-md5-96", esp[0].AuthAlg, esp[1].AuthAlg)
+	}
+}
+
 // V-1: an explicit proposals list wins over proposal-set (mutually exclusive
 // in Junos; the set only fills an empty list).
 func TestProposalSetYieldsToExplicitProposals_4297(t *testing.T) {

--- a/pkg/config/compiler_ipsec_hb167_parity_test.go
+++ b/pkg/config/compiler_ipsec_hb167_parity_test.go
@@ -1,0 +1,263 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// fable-review-167 IPsec/VPN parity fixes.
+//
+//	V-1 (#4297): predefined proposal-set expands to concrete proposals so
+//	             the common vSRX shorthand commits a working tunnel.
+//	V-2 (#4298): `proposal ... protocol ah` is rejected at commit, never
+//	             silently rendered as ESP with a fabricated cipher.
+//	V-3 (#4299): `vpn-monitor` is accepted with an advisory (not dropped).
+//	V-4 (#4300): `manual { ... }` manual-key SA is rejected (no dead tunnel).
+//	V-5 (#4301): `establish-tunnels` value is enum-validated.
+
+// resolvedIKE gathers the crypto of every synthetic/real proposal an IKE
+// policy references, in order.
+func resolvedIKE(t *testing.T, cfg *Config, policy string) []*IKEProposal {
+	t.Helper()
+	pol := cfg.Security.IPsec.IKEPolicies[policy]
+	if pol == nil {
+		t.Fatalf("ike policy %q missing after compile", policy)
+	}
+	var out []*IKEProposal
+	for _, ref := range pol.Proposals {
+		p := cfg.Security.IPsec.IKEProposals[ref]
+		if p == nil {
+			t.Fatalf("ike policy %q references unresolvable proposal %q", policy, ref)
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+func resolvedESP(t *testing.T, cfg *Config, policy string) []*IPsecProposal {
+	t.Helper()
+	pol := cfg.Security.IPsec.Policies[policy]
+	if pol == nil {
+		t.Fatalf("ipsec policy %q missing after compile", policy)
+	}
+	var out []*IPsecProposal
+	for _, ref := range pol.Proposals {
+		p := cfg.Security.IPsec.Proposals[ref]
+		if p == nil {
+			t.Fatalf("ipsec policy %q references unresolvable proposal %q", policy, ref)
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// V-1: `proposal-set standard` on both the IKE and IPsec policy must let a
+// full VPN commit AND expand to the Junos-documented concrete proposals.
+//
+// FAIL-ON-REVERT: without expandIKE/IPsecProposalSets the policies carry no
+// resolvable proposal — the gateway -> ike-policy chain fails closed and
+// CompileConfig returns an error, so the t.Fatalf below fires (RED). The
+// per-member crypto assertions additionally pin the expansion table.
+func TestProposalSetStandardExpands_4297(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security zones security-zone untrust",
+		"set security ike policy ike-pol proposal-set standard",
+		"set security ike policy ike-pol pre-shared-key ascii-text secret123",
+		"set security ike gateway gw1 address 172.16.0.1",
+		"set security ike gateway gw1 ike-policy ike-pol",
+		"set security ipsec policy esp-pol proposal-set standard",
+		"set security ipsec vpn tun1 ike gateway gw1",
+		"set security ipsec vpn tun1 ike ipsec-policy esp-pol",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("proposal-set standard must commit a working tunnel, got: %v", err)
+	}
+
+	ike := resolvedIKE(t, cfg, "ike-pol")
+	if len(ike) != 2 {
+		t.Fatalf("IKE standard set = %d proposals, want 2", len(ike))
+	}
+	if ike[0].EncryptionAlg != "3des-cbc" || ike[0].AuthAlg != "sha1" || ike[0].DHGroup != 2 ||
+		ike[0].AuthMethod != "pre-shared-keys" {
+		t.Errorf("IKE standard[0] = %+v, want 3des-cbc/sha1/g2/pre-shared-keys", ike[0])
+	}
+	if ike[1].EncryptionAlg != "aes-128-cbc" || ike[1].AuthAlg != "sha1" || ike[1].DHGroup != 2 {
+		t.Errorf("IKE standard[1] = %+v, want aes-128-cbc/sha1/g2", ike[1])
+	}
+
+	esp := resolvedESP(t, cfg, "esp-pol")
+	if len(esp) != 2 {
+		t.Fatalf("ESP standard set = %d proposals, want 2", len(esp))
+	}
+	if esp[0].Protocol != "esp" || esp[0].EncryptionAlg != "3des-cbc" || esp[0].AuthAlg != "hmac-sha1-96" {
+		t.Errorf("ESP standard[0] = %+v, want esp/3des-cbc/hmac-sha1-96", esp[0])
+	}
+	if esp[1].EncryptionAlg != "aes-128-cbc" || esp[1].AuthAlg != "hmac-sha1-96" {
+		t.Errorf("ESP standard[1] = %+v, want aes-128-cbc/hmac-sha1-96", esp[1])
+	}
+}
+
+// V-1: suiteb-gcm-128 expands to the RFC 6379 Suite-B members (AES-GCM +
+// ECDSA + ECP group 19). Compiled without a full VPN chain to avoid
+// pubkey/cert prerequisites — expansion is reference-independent.
+func TestProposalSetSuiteB128Expands_4297(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security ike policy ike-sb proposal-set suiteb-gcm-128",
+		"set security ipsec policy esp-sb proposal-set suiteb-gcm-128",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("proposal-set suiteb-gcm-128 must compile, got: %v", err)
+	}
+	ike := resolvedIKE(t, cfg, "ike-sb")
+	if len(ike) != 1 || ike[0].EncryptionAlg != "aes-128-gcm" || ike[0].DHGroup != 19 ||
+		ike[0].AuthMethod != "ecdsa-signatures" {
+		t.Errorf("IKE suiteb-gcm-128 = %+v, want [aes-128-gcm/g19/ecdsa-signatures]", ike)
+	}
+	esp := resolvedESP(t, cfg, "esp-sb")
+	if len(esp) != 1 || esp[0].EncryptionAlg != "aes-128-gcm" || esp[0].DHGroup != 19 {
+		t.Errorf("ESP suiteb-gcm-128 = %+v, want [aes-128-gcm/g19]", esp)
+	}
+}
+
+// V-1: an explicit proposals list wins over proposal-set (mutually exclusive
+// in Junos; the set only fills an empty list).
+func TestProposalSetYieldsToExplicitProposals_4297(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security ike proposal ike-x authentication-method pre-shared-keys",
+		"set security ike proposal ike-x encryption-algorithm aes-256-cbc",
+		"set security ike policy ike-pol proposal-set standard",
+		"set security ike policy ike-pol proposals ike-x",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	pol := cfg.Security.IPsec.IKEPolicies["ike-pol"]
+	if len(pol.Proposals) != 1 || pol.Proposals[0] != "ike-x" {
+		t.Errorf("explicit proposals must win over proposal-set, got %v", pol.Proposals)
+	}
+}
+
+// V-1: an unknown proposal-set keyword is rejected at commit by the schema
+// enum (SchemaValidate). FAIL-ON-REVERT: an untyped leaf stores the typo and
+// returns nil.
+func TestProposalSetUnknownRejected_4297(t *testing.T) {
+	tree := flatTreeFromSets(t, "set security ike policy ike-pol proposal-set standrd")
+	if err := SchemaValidate(tree, nil); err == nil ||
+		!strings.Contains(err.Error(), "standrd") {
+		t.Fatalf("unknown proposal-set must be rejected naming the typo, got: %v", err)
+	}
+	// every supported keyword still commits
+	for _, s := range ProposalSetNames() {
+		ok := flatTreeFromSets(t, "set security ipsec policy p proposal-set "+s)
+		if err := SchemaValidate(ok, nil); err != nil {
+			t.Errorf("proposal-set %q rejected: %v", s, err)
+		}
+	}
+}
+
+// V-2: `proposal ... protocol ah` must be REJECTED at commit — never
+// silently rendered as ESP with a fabricated cipher.
+//
+// FAIL-ON-REVERT: without validateIPsecProposalProtocolStrict the AH proposal
+// compiles clean (protocol captured, ignored) and CompileConfig returns nil,
+// so the expect-error below fires RED. The render belt is covered in pkg/ipsec.
+func TestProtocolAHRejected_4298(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security ipsec proposal AHPROP protocol ah",
+		"set security ipsec proposal AHPROP authentication-algorithm hmac-sha-256-128",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("protocol ah must be rejected at commit (never silent ESP substitution)")
+	}
+	if !strings.Contains(err.Error(), "AHPROP") || !strings.Contains(err.Error(), "ah") {
+		t.Errorf("reject error should name the AH proposal, got: %v", err)
+	}
+	// Tolerant path downgrades to a warning so a persisted/peer-synced config
+	// still boots (the render belt keeps the fabricated ESP tunnel out).
+	cfg, lerr := CompileConfigLenient(tree)
+	if lerr != nil {
+		t.Fatalf("lenient compile of protocol ah must warn, not error: %v", lerr)
+	}
+	if !warningsContain(cfg.Warnings, "protocol") {
+		t.Errorf("lenient path should warn about the AH proposal, warnings: %v", cfg.Warnings)
+	}
+}
+
+// V-3: `vpn-monitor` is accepted (committed) with an advisory, not dropped.
+func TestVPNMonitorAdvisory_4299(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security zones security-zone untrust",
+		"set security ike policy ike-pol proposal-set standard",
+		"set security ike policy ike-pol pre-shared-key ascii-text secret123",
+		"set security ike gateway gw1 address 172.16.0.1",
+		"set security ike gateway gw1 ike-policy ike-pol",
+		"set security ipsec policy esp-pol proposal-set standard",
+		"set security ipsec vpn tun1 ike gateway gw1",
+		"set security ipsec vpn tun1 ike ipsec-policy esp-pol",
+		"set security ipsec vpn tun1 vpn-monitor source-interface ge-0/0/0",
+		"set security ipsec vpn tun1 vpn-monitor destination-ip 172.16.0.1",
+		"set security ipsec vpn tun1 vpn-monitor optimized",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("vpn-monitor must be accepted, got: %v", err)
+	}
+	vpn := cfg.Security.IPsec.VPNs["tun1"]
+	if vpn == nil || !vpn.VPNMonitor || !vpn.VPNMonitorOptimized ||
+		vpn.VPNMonitorSourceInterface != "ge-0/0/0" || vpn.VPNMonitorDestinationIP != "172.16.0.1" {
+		t.Errorf("vpn-monitor fields not captured: %+v", vpn)
+	}
+	if !warningsContain(ValidateConfig(cfg), "vpn-monitor") {
+		t.Errorf("vpn-monitor should raise an accepted-but-not-enforced advisory, got: %v", ValidateConfig(cfg))
+	}
+}
+
+// V-4: a `manual { ... }` manual-key SA must be rejected at commit — no
+// silent dead tunnel.
+//
+// FAIL-ON-REVERT: without validateIPsecManualKeyStrict the manual block is
+// dropped silently and the VPN compiles to an empty shell (CompileConfig ==
+// nil error), so the expect-error below fires RED.
+func TestManualKeyRejected_4300(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security ipsec vpn tun1 manual protocol esp",
+		"set security ipsec vpn tun1 manual spi 256",
+		"set security ipsec vpn tun1 manual encryption-algorithm aes-256-cbc",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("manual-key SA must be rejected at commit (no silent dead tunnel)")
+	}
+	if !strings.Contains(err.Error(), "tun1") || !strings.Contains(err.Error(), "manual") {
+		t.Errorf("reject error should name the vpn + manual, got: %v", err)
+	}
+	cfg, lerr := CompileConfigLenient(tree)
+	if lerr != nil {
+		t.Fatalf("lenient compile of manual-key must warn, not error: %v", lerr)
+	}
+	if !warningsContain(cfg.Warnings, "manual") {
+		t.Errorf("lenient path should warn about the manual-key SA, warnings: %v", cfg.Warnings)
+	}
+}
+
+// V-5: `establish-tunnels` is enum-validated. A typo is rejected; every valid
+// mode commits.
+//
+// FAIL-ON-REVERT: the untyped leaf accepts any string and SchemaValidate
+// returns nil for the typo.
+func TestEstablishTunnelsEnum_4301(t *testing.T) {
+	bad := flatTreeFromSets(t, "set security ipsec vpn tun1 establish-tunnels on-tarffic")
+	if err := SchemaValidate(bad, nil); err == nil || !strings.Contains(err.Error(), "on-tarffic") {
+		t.Fatalf("establish-tunnels typo must be rejected naming the value, got: %v", err)
+	}
+	for _, m := range []string{"immediately", "on-traffic", "responder-only"} {
+		ok := flatTreeFromSets(t, "set security ipsec vpn tun1 establish-tunnels "+m)
+		if err := SchemaValidate(ok, nil); err != nil {
+			t.Errorf("establish-tunnels %q rejected: %v", m, err)
+		}
+	}
+}

--- a/pkg/config/compiler_ipsec_proposalset.go
+++ b/pkg/config/compiler_ipsec_proposalset.go
@@ -1,0 +1,182 @@
+package config
+
+import "fmt"
+
+// Predefined IKE/IPsec proposal-set expansion (fable-167 V-1, #4297).
+//
+// Junos `security ike policy P proposal-set <set>` and
+// `security ipsec policy P proposal-set <set>` are the standard shorthand
+// operators use to avoid hand-defining proposals. Each named set expands to
+// a fixed list of concrete proposals. Before this change the keyword was
+// silently dropped by the compiler switch (unknown keys are ignored), so the
+// policy resolved to NO proposal: the IPsec side hard-rejected with a
+// misleading "no resolvable ipsec proposal" message and the IKE side left the
+// chain unresolved (errIKEChainUnresolved) — either way the common vSRX idiom
+// could not commit a working tunnel.
+//
+// The tables below are the single source of truth. They use Junos algorithm
+// spellings; the pkg/ipsec renderer normalizes them to swanctl tokens
+// (buildIKEProposalFromIKE / buildESPProposal) so the expansion needs no
+// crypto knowledge here — it only names the members. Keeping the members in
+// one explicit, tested table (rather than a hidden default substitution) is
+// deliberate: the crypto is auditable and correctable, never fabricated.
+//
+// Members follow Juniper's published predefined-proposal tables:
+//   - basic / compatible / standard: legacy DES/3DES/SHA1/MD5 sets, DH
+//     group 2. These are weak by modern standards and a hardened strongSwan
+//     build may not have the `des` plugin loaded; the operator asked for the
+//     legacy set, so we expand it faithfully rather than silently upgrading.
+//   - suiteb-gcm-128 / suiteb-gcm-256: RFC 6379 Suite-B — AES-GCM AEAD with
+//     ECDSA authentication and an ECP (elliptic-curve) DH group. suiteb
+//     requires ECDSA certificates (authMethodToSwan maps ecdsa-signatures to
+//     pubkey); that is the operator's responsibility, exactly as on Junos.
+
+// ikeProposalSetSpec is one Phase-1 proposal member of a predefined set.
+type ikeProposalSetSpec struct {
+	authMethod string // Junos authentication-method (pre-shared-keys / ecdsa-signatures)
+	enc        string // Junos encryption-algorithm
+	auth       string // Junos authentication-algorithm (also the AEAD PRF hint)
+	dhGroup    int    // Diffie-Hellman group number
+}
+
+// espProposalSetSpec is one Phase-2 (ESP) proposal member of a predefined set.
+type espProposalSetSpec struct {
+	enc     string // Junos encryption-algorithm
+	auth    string // Junos authentication-algorithm ("" for AEAD/GCM)
+	dhGroup int    // PFS DH group carried on the proposal (0 = no PFS)
+}
+
+// ikeProposalSets maps a Junos IKE proposal-set keyword to its member
+// proposals, in negotiation-preference order.
+var ikeProposalSets = map[string][]ikeProposalSetSpec{
+	"basic": {
+		{"pre-shared-keys", "des-cbc", "sha1", 2},
+		{"pre-shared-keys", "des-cbc", "md5", 2},
+	},
+	"compatible": {
+		{"pre-shared-keys", "3des-cbc", "sha1", 2},
+		{"pre-shared-keys", "3des-cbc", "md5", 2},
+		{"pre-shared-keys", "des-cbc", "sha1", 2},
+		{"pre-shared-keys", "des-cbc", "md5", 2},
+	},
+	"standard": {
+		{"pre-shared-keys", "3des-cbc", "sha1", 2},
+		{"pre-shared-keys", "aes-128-cbc", "sha1", 2},
+	},
+	"suiteb-gcm-128": {
+		{"ecdsa-signatures", "aes-128-gcm", "sha-256", 19},
+	},
+	"suiteb-gcm-256": {
+		{"ecdsa-signatures", "aes-256-gcm", "sha-384", 20},
+	},
+}
+
+// espProposalSets maps a Junos IPsec proposal-set keyword to its member ESP
+// proposals. The legacy sets carry no PFS (group at policy level in Junos is
+// separate); the suiteb sets carry their Suite-B ECP group as the proposal's
+// PFS group so buildESPProposal renders the ecp<N> term.
+var espProposalSets = map[string][]espProposalSetSpec{
+	"basic": {
+		{"des-cbc", "hmac-sha1-96", 0},
+		{"des-cbc", "hmac-md5-96", 0},
+	},
+	"compatible": {
+		{"3des-cbc", "hmac-sha1-96", 0},
+		{"3des-cbc", "hmac-md5-96", 0},
+		{"des-cbc", "hmac-sha1-96", 0},
+		{"des-cbc", "hmac-md5-96", 0},
+	},
+	"standard": {
+		{"3des-cbc", "hmac-sha1-96", 0},
+		{"aes-128-cbc", "hmac-sha1-96", 0},
+	},
+	"suiteb-gcm-128": {
+		{"aes-128-gcm", "", 19},
+	},
+	"suiteb-gcm-256": {
+		{"aes-256-gcm", "", 20},
+	},
+}
+
+// ProposalSetNames returns the supported predefined proposal-set keywords
+// (sorted, stable) for schema enum validation and completion.
+func ProposalSetNames() []string {
+	return []string{"basic", "compatible", "standard", "suiteb-gcm-128", "suiteb-gcm-256"}
+}
+
+// syntheticProposalSetName builds a deterministic, collision-resistant name
+// for a proposal synthesized from a policy's proposal-set. The rendered
+// swanctl proposal is the crypto token string (buildIKEProposalFromIKE /
+// buildESPProposal), not this name, so the name is internal only; the "__"
+// prefix and slashes keep it clear of operator-authored proposal names.
+func syntheticProposalSetName(policy, set string, n int) string {
+	return fmt.Sprintf("__proposal-set/%s/%s/%d", policy, set, n)
+}
+
+// expandIKEProposalSets synthesizes concrete IKE (Phase 1) proposals for every
+// IKE policy that carries a `proposal-set`, appending them to the IKE proposal
+// map and pointing the policy's Proposals list at them. It runs after the IKE
+// proposal and policy loops so both maps exist. A policy that ALSO lists
+// explicit `proposals` keeps them (proposal-set is the no-explicit-proposals
+// shorthand and is mutually exclusive with `proposals` in Junos); the set only
+// fills an empty list. An unknown set keyword is left unexpanded — the schema
+// enum validator rejects it at commit.
+func expandIKEProposalSets(sec *SecurityConfig) {
+	if sec == nil || sec.IPsec.IKEPolicies == nil {
+		return
+	}
+	if sec.IPsec.IKEProposals == nil {
+		sec.IPsec.IKEProposals = make(map[string]*IKEProposal)
+	}
+	for _, pol := range sec.IPsec.IKEPolicies {
+		if pol == nil || pol.ProposalSet == "" || len(pol.Proposals) > 0 {
+			continue
+		}
+		specs, ok := ikeProposalSets[pol.ProposalSet]
+		if !ok {
+			continue
+		}
+		for i, s := range specs {
+			name := syntheticProposalSetName(pol.Name, pol.ProposalSet, i+1)
+			sec.IPsec.IKEProposals[name] = &IKEProposal{
+				Name:          name,
+				AuthMethod:    s.authMethod,
+				EncryptionAlg: s.enc,
+				AuthAlg:       s.auth,
+				DHGroup:       s.dhGroup,
+			}
+			pol.Proposals = append(pol.Proposals, name)
+		}
+	}
+}
+
+// expandIPsecProposalSets is the Phase-2 (ESP) mirror of
+// expandIKEProposalSets.
+func expandIPsecProposalSets(sec *SecurityConfig) {
+	if sec == nil || sec.IPsec.Policies == nil {
+		return
+	}
+	if sec.IPsec.Proposals == nil {
+		sec.IPsec.Proposals = make(map[string]*IPsecProposal)
+	}
+	for _, pol := range sec.IPsec.Policies {
+		if pol == nil || pol.ProposalSet == "" || len(pol.Proposals) > 0 {
+			continue
+		}
+		specs, ok := espProposalSets[pol.ProposalSet]
+		if !ok {
+			continue
+		}
+		for i, s := range specs {
+			name := syntheticProposalSetName(pol.Name, pol.ProposalSet, i+1)
+			sec.IPsec.Proposals[name] = &IPsecProposal{
+				Name:          name,
+				Protocol:      "esp",
+				EncryptionAlg: s.enc,
+				AuthAlg:       s.auth,
+				DHGroup:       s.dhGroup,
+			}
+			pol.Proposals = append(pol.Proposals, name)
+		}
+	}
+}

--- a/pkg/config/compiler_ipsec_proposalset.go
+++ b/pkg/config/compiler_ipsec_proposalset.go
@@ -22,8 +22,9 @@ import "fmt"
 // deliberate: the crypto is auditable and correctable, never fabricated.
 //
 // Members follow Juniper's published predefined-proposal tables:
-//   - basic / compatible / standard: legacy DES/3DES/SHA1/MD5 sets, DH
-//     group 2. These are weak by modern standards and a hardened strongSwan
+//   - basic / compatible / standard: legacy DES/3DES/SHA1/MD5 sets. `basic`
+//     is DH group 1 in Phase-1; `compatible` and `standard` are DH group 2.
+//     These are weak by modern standards and a hardened strongSwan
 //     build may not have the `des` plugin loaded; the operator asked for the
 //     legacy set, so we expand it faithfully rather than silently upgrading.
 //   - suiteb-gcm-128 / suiteb-gcm-256: RFC 6379 Suite-B — AES-GCM AEAD with
@@ -50,8 +51,12 @@ type espProposalSetSpec struct {
 // proposals, in negotiation-preference order.
 var ikeProposalSets = map[string][]ikeProposalSetSpec{
 	"basic": {
-		{"pre-shared-keys", "des-cbc", "sha1", 2},
-		{"pre-shared-keys", "des-cbc", "md5", 2},
+		// Junos `basic` IKE set is DH GROUP 1 (not group 2 — that is
+		// `compatible`/`standard`). A real vSRX peer with `proposal-set basic`
+		// offers group1/DES in Phase-1, so offering group2 here would mismatch
+		// the DH group and no common proposal would negotiate.
+		{"pre-shared-keys", "des-cbc", "sha1", 1},
+		{"pre-shared-keys", "des-cbc", "md5", 1},
 	},
 	"compatible": {
 		{"pre-shared-keys", "3des-cbc", "sha1", 2},

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -475,6 +475,97 @@ func validateIKEPolicyChainReferencesStrict(cfg *Config) error {
 	return nil
 }
 
+// validateIPsecProposalProtocolStrict hard-rejects an IPsec (Phase 2)
+// proposal whose `protocol` is `ah` (#4298, V-2). AH (Authentication
+// Header) is integrity-only with no encryption; swanctl expresses it via
+// `ah_proposals`, not `esp_proposals`. xpf has no AH render path:
+// buildESPProposal (pkg/ipsec) ignores the protocol and defaults empty
+// encryption to aes256, and renderConfig always emits `esp_proposals`, so a
+// `protocol ah` proposal used to render as ESP with a fabricated cipher —
+// the operator asked for AH (integrity only) and silently got ESP with a
+// made-up aes256 cipher. That is a crypto misrepresentation, so we reject it
+// at commit rather than silently substitute.
+//
+// Only proposals that are actually referenced by an ipsec-policy (directly,
+// via the policy-name fallback, or as a synthetic proposal-set member) reach
+// render, but an unreferenced AH proposal is still an operator error worth
+// surfacing, so every defined proposal is checked. Proposal names are sorted
+// for a deterministic first error.
+//
+// On the tolerant load / peer-sync paths the call site downgrades this to a
+// warning (opts.lenientIPsecProposalProtocol) so an already-persisted or
+// peer-synced config still boots; the render-path belt in pkg/ipsec
+// (vpnUsesAHProposal -> renderConfig skips the VPN) keeps the fabricated
+// ESP tunnel out of the generated swanctl.conf rather than emitting it.
+// Commit / commit-check stay strict. Mirrors
+// validateIPsecPolicyProposalReferencesStrict.
+func validateIPsecProposalProtocolStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	proposals := cfg.Security.IPsec.Proposals
+	names := make([]string, 0, len(proposals))
+	for name := range proposals {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		prop := proposals[name]
+		if prop == nil {
+			continue
+		}
+		if strings.EqualFold(prop.Protocol, "ah") {
+			return fmt.Errorf("ipsec proposal %q uses protocol ah "+
+				"(Authentication Header), which xpf does not support — xpf "+
+				"renders ESP only and will not silently substitute ESP with a "+
+				"fabricated cipher; use `protocol esp` (or remove the proposal)",
+				prop.Name)
+		}
+	}
+	return nil
+}
+
+// validateIPsecManualKeyStrict hard-rejects an IPsec VPN that carries a
+// `manual { ... }` manual-key SA block (#4300, V-4). xpf negotiates all SAs
+// via IKE (strongSwan); there is no manual-key path, so compileIPsec used to
+// drop the block silently and the VPN compiled to an empty shell that
+// committed OK — a silent dead tunnel (no gateway, no policy, no SA).
+// Rejecting it at commit gives the operator an immediate, clear diagnostic
+// instead of a tunnel that is configured but forwards nothing.
+//
+// VPN names are sorted so a multi-VPN config reports a deterministic first
+// failure. On the tolerant load / peer-sync paths the call site downgrades
+// this to a warning (opts.lenientIPsecManualKey) so an already-persisted or
+// peer-synced config still boots (#1960 fail-closed-on-load class) — the
+// manual block was already inert (never compiled to an SA), so the boot is
+// fail-safe. Commit / commit-check stay strict. Mirrors
+// validateIPsecGatewayReferencesStrict.
+func validateIPsecManualKeyStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	vpns := cfg.Security.IPsec.VPNs
+	names := make([]string, 0, len(vpns))
+	for name := range vpns {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		vpn := vpns[name]
+		if vpn == nil {
+			continue
+		}
+		if vpn.Manual {
+			return fmt.Errorf("ipsec vpn %q configures a manual-key SA "+
+				"(`manual { ... }`), which xpf does not support — a manual-key "+
+				"tunnel would commit but forward nothing (silent dead tunnel); "+
+				"use an IKE-negotiated VPN (ike { gateway ...; ipsec-policy ...; })",
+				vpn.Name)
+		}
+	}
+	return nil
+}
+
 // validateLogProfileStreamReferencesStrict hard-rejects a
 // `security log profile <name>` whose `stream-name` reference does not
 // resolve to a configured `security log stream` (#2008 H7). xpf routes

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -627,6 +627,33 @@ func ValidateConfig(cfg *Config) []string {
 		}
 	}
 
+	// #4299 (fable-167 V-3): `security ipsec vpn <v> vpn-monitor` is typed +
+	// captured (schema leaf + compileIPsec) but xpf does not implement its
+	// ICMP-probe tunnel-liveness monitoring or st0 interface-state coupling.
+	// Mirror the #2078/#4231 accepted-only doctrine: warn so an operator who
+	// configures it is not silently misled into believing the tunnel is being
+	// probed. IKE-layer DPD (dead-peer-detection, #3994) IS enforced and is a
+	// partial substitute for peer liveness, but not for vpn-monitor's
+	// interface-state coupling. Full enforcement is a monitoring follow-up.
+	{
+		var monVPNs []string
+		for name := range cfg.Security.IPsec.VPNs {
+			if vpn := cfg.Security.IPsec.VPNs[name]; vpn != nil && vpn.VPNMonitor {
+				monVPNs = append(monVPNs, name)
+			}
+		}
+		if len(monVPNs) > 0 {
+			sort.Strings(monVPNs)
+			warnings = append(warnings, fmt.Sprintf(
+				"security ipsec vpn %s vpn-monitor configured but accepted-only "+
+					"— xpf does not implement vpn-monitor ICMP-probe liveness or "+
+					"st0 interface-state coupling; configure ike gateway "+
+					"dead-peer-detection for IKE-layer peer liveness "+
+					"(config-only parity, #4299)",
+				strings.Join(monVPNs, ", ")))
+		}
+	}
+
 	// #4291 (fable-167 N-2): the NAT `port-overloading` knobs are now typed +
 	// committed (schema leaves + compileNAT) but the userspace AF_XDP SNAT
 	// allocator enforces neither. `security nat source interface port-overloading

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -818,7 +818,16 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 			// proposal for phase-1 negotiation. Without multi the flat-set
 			// path strands every reference past the first as a child node and
 			// the compiler dropped them (crypto-negotiation narrowing).
-			"proposals":      {desc: "IKE proposal reference(s)", args: 1, multi: true, placeholder: "<proposal-name>", children: nil},
+			"proposals": {desc: "IKE proposal reference(s)", args: 1, multi: true, placeholder: "<proposal-name>", children: nil},
+			// #4297 (V-1): predefined IKE proposal-set shorthand. Typed so a
+			// typo (`proposal-set standrd`) fails closed at commit; the
+			// compiler (expandIKEProposalSets) expands a valid keyword into
+			// concrete synthetic proposals so the common vSRX idiom commits a
+			// working tunnel instead of being silently dropped.
+			"proposal-set": {desc: "Predefined IKE proposal set", args: 1, placeholder: "<set>",
+				valueType: ValueEnumOf, valueDesc: "predefined IKE proposal set",
+				valueExamples: []string{"standard", "suiteb-gcm-128"},
+				validator:     ValidateEnum(ProposalSetNames()), children: nil},
 			"pre-shared-key": {desc: "Pre-shared key (ascii-text <key>)", children: nil},
 		}},
 		"gateway": {desc: "IKE gateway (VPN peer) name", args: 1, placeholder: "<gateway-name>", children: map[string]*schemaNode{
@@ -869,7 +878,15 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 		// gate deliberately rejected the prefixed spelling to stay
 		// compiler-faithful; the compiler fix lets both gates accept it.
 		"proposal": {desc: "IPsec (Phase 2) proposal name", args: 1, placeholder: "<proposal-name>", children: map[string]*schemaNode{
-			"protocol":                 {desc: "IPsec protocol (esp|ah)", args: 1, placeholder: "<protocol>", children: nil},
+			// #4298 (V-2): type the protocol so a typo fails closed. `ah`
+			// is an accepted value here (grammar-valid) but hard-rejected at
+			// commit by validateIPsecProposalProtocolStrict — xpf does not
+			// support AH and must NOT silently render it as ESP with a
+			// fabricated cipher.
+			"protocol": {desc: "IPsec protocol (esp|ah)", args: 1, placeholder: "<protocol>",
+				valueType: ValueEnumOf, valueDesc: "IPsec security protocol",
+				valueExamples: []string{"esp", "ah"},
+				validator:     ValidateEnum([]string{"esp", "ah"}), children: nil},
 			"encryption-algorithm":     {desc: "Encryption algorithm (e.g. aes-256-cbc, aes-256-gcm)", args: 1, placeholder: "<algorithm>", children: nil},
 			"authentication-algorithm": {desc: "Authentication/integrity algorithm (e.g. hmac-sha-256-128)", args: 1, placeholder: "<algorithm>", children: nil},
 			"dh-group": {desc: "Diffie-Hellman group for PFS (e.g. 14 or group14)", args: 1, placeholder: "<dh-group>",
@@ -884,6 +901,12 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 			// multi (#3904): mirror of the IKE proposals leaf — offer every
 			// listed ESP proposal for phase-2 negotiation.
 			"proposals": {desc: "IPsec proposal reference(s)", args: 1, multi: true, placeholder: "<proposal-name>", children: nil},
+			// #4297 (V-1): predefined IPsec (ESP) proposal-set shorthand;
+			// mirror of the IKE policy leaf (expandIPsecProposalSets).
+			"proposal-set": {desc: "Predefined IPsec proposal set", args: 1, placeholder: "<set>",
+				valueType: ValueEnumOf, valueDesc: "predefined IPsec proposal set",
+				valueExamples: []string{"standard", "suiteb-gcm-128"},
+				validator:     ValidateEnum(ProposalSetNames()), children: nil},
 		}},
 		"gateway": {desc: "IKE gateway (VPN peer) name", args: 1, placeholder: "<gateway-name>", children: map[string]*schemaNode{
 			"address":            {desc: "Remote gateway address", args: 1, placeholder: "<address>", children: nil},
@@ -914,13 +937,40 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 			}},
 		}},
 		"vpn": {desc: "IPsec VPN tunnel name", args: 1, placeholder: "<vpn-name>", children: map[string]*schemaNode{
-			"bind-interface":    {desc: "XFRM tunnel interface to bind", args: 1, placeholder: "<interface-name>", children: nil},
-			"df-bit":            {desc: "Outer-header DF bit handling (copy|set|clear)", args: 1, placeholder: "<mode>", children: nil},
-			"establish-tunnels": {desc: "Tunnel establishment (immediately = initiate at commit)", args: 1, placeholder: "<mode>", children: nil},
-			"local-identity":    {desc: "Local identity (default local traffic selector)", args: 1, placeholder: "<identity>", children: nil},
-			"remote-identity":   {desc: "Remote identity (default remote traffic selector)", args: 1, placeholder: "<identity>", children: nil},
-			"pre-shared-key":    {desc: "Pre-shared key for this VPN", args: 1, placeholder: "<key>", children: nil},
-			"local-address":     {desc: "Local tunnel endpoint address", args: 1, placeholder: "<address>", children: nil},
+			"bind-interface": {desc: "XFRM tunnel interface to bind", args: 1, placeholder: "<interface-name>", children: nil},
+			"df-bit":         {desc: "Outer-header DF bit handling (copy|set|clear)", args: 1, placeholder: "<mode>", children: nil},
+			// #4301 (V-5): type the enum so a typo (`on-tarffic`) fails closed
+			// at commit instead of storing verbatim and silently degrading to
+			// on-traffic. Only `immediately` is acted on (start_action =
+			// start); on-traffic / responder-only are the initiate-later modes.
+			"establish-tunnels": {desc: "Tunnel establishment (immediately|on-traffic|responder-only)", args: 1, placeholder: "<mode>",
+				valueType: ValueEnumOf, valueDesc: "tunnel establishment mode",
+				valueExamples: []string{"immediately", "on-traffic", "responder-only"},
+				validator:     ValidateEnum([]string{"immediately", "on-traffic", "responder-only"}), children: nil},
+			// #4300 (V-4): manual-key SA block. Grammar present for completion,
+			// but validateIPsecManualKeyStrict hard-rejects any VPN carrying it
+			// at commit — xpf has no manual-key path and must not leave a silent
+			// dead tunnel.
+			"manual": {desc: "Manual-key SA (NOT supported — rejected at commit; use an IKE-negotiated VPN)", children: map[string]*schemaNode{
+				"protocol":                 {desc: "Manual SA protocol (esp|ah)", args: 1, placeholder: "<protocol>", children: nil},
+				"spi":                      {desc: "Security parameter index", args: 1, placeholder: "<spi>", children: nil},
+				"encryption":               {desc: "Manual SA encryption (algorithm + key)", children: nil},
+				"authentication":           {desc: "Manual SA authentication (algorithm + key)", children: nil},
+				"encryption-algorithm":     {desc: "Manual SA encryption algorithm", args: 1, placeholder: "<algorithm>", children: nil},
+				"authentication-algorithm": {desc: "Manual SA authentication algorithm", args: 1, placeholder: "<algorithm>", children: nil},
+			}},
+			// #4299 (V-3): vpn-monitor. Accepted-but-not-enforced — captured so
+			// ValidateConfig emits an advisory; xpf has no ICMP-probe liveness /
+			// st0 interface-state coupling yet.
+			"vpn-monitor": {desc: "Tunnel liveness monitoring (accepted-but-not-enforced advisory)", children: map[string]*schemaNode{
+				"source-interface": {desc: "Probe source interface", args: 1, placeholder: "<interface-name>", children: nil},
+				"destination-ip":   {desc: "Probe destination IP", args: 1, placeholder: "<address>", children: nil},
+				"optimized":        {desc: "Send probes only when there is no outbound traffic", children: nil},
+			}},
+			"local-identity":  {desc: "Local identity (default local traffic selector)", args: 1, placeholder: "<identity>", children: nil},
+			"remote-identity": {desc: "Remote identity (default remote traffic selector)", args: 1, placeholder: "<identity>", children: nil},
+			"pre-shared-key":  {desc: "Pre-shared key for this VPN", args: 1, placeholder: "<key>", children: nil},
+			"local-address":   {desc: "Local tunnel endpoint address", args: 1, placeholder: "<address>", children: nil},
 			"traffic-selector": {desc: "Traffic selector name", args: 1, placeholder: "<selector-name>", children: map[string]*schemaNode{
 				"local-ip":  {desc: "Local traffic selector prefix", args: 1, placeholder: "<prefix>", children: nil},
 				"remote-ip": {desc: "Remote traffic selector prefix", args: 1, placeholder: "<prefix>", children: nil},

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -1077,6 +1077,13 @@ type IKEProposal struct {
 type IKEPolicy struct {
 	Name string
 	Mode string // "main" or "aggressive"
+	// ProposalSet is a Junos predefined IKE proposal-set keyword
+	// (standard, basic, compatible, suiteb-gcm-128, suiteb-gcm-256).
+	// When set and no explicit Proposals are given, the compiler expands
+	// it into concrete synthetic IKE proposals (expandIKEProposalSets,
+	// #4297) so the common vSRX shorthand commits a working tunnel instead
+	// of being silently dropped.
+	ProposalSet string
 	// Proposals is the ordered list of IKE proposal references. Junos
 	// `proposals [ p1 p2 ]` offers every listed proposal for phase-1
 	// negotiation; reading only the first (the pre-#3904 scalar) narrowed
@@ -1100,6 +1107,12 @@ type IPsecProposal struct {
 type IPsecPolicyDef struct {
 	Name     string
 	PFSGroup int // PFS DH group number (0 = disabled)
+	// ProposalSet is a Junos predefined IPsec proposal-set keyword
+	// (standard, basic, compatible, suiteb-gcm-128, suiteb-gcm-256).
+	// When set and no explicit Proposals are given, the compiler expands
+	// it into concrete synthetic ESP proposals (expandIPsecProposalSets,
+	// #4297). Mirror of IKEPolicy.ProposalSet.
+	ProposalSet string
 	// Proposals is the ordered list of IPsec (ESP) proposal references.
 	// Junos `proposals [ p1 p2 ]` offers every listed proposal; the
 	// pre-#3904 scalar truncated to the first, narrowing negotiation.
@@ -1161,6 +1174,21 @@ type IPsecVPN struct {
 	LocalAddr        string // local address
 	BindInterface    string // tunnel interface (e.g. "st0.0") — creates xfrmi with if_id
 	DFBit            string // "copy", "set", "clear"
-	EstablishTunnels string // "immediately", "on-traffic"
+	EstablishTunnels string // "immediately", "on-traffic", "responder-only"
 	TrafficSelectors map[string]*IPsecTrafficSelector
+	// Manual records a `manual { ... }` manual-key SA block (#4300, V-4).
+	// xpf does not support manual-key SAs; the block used to be silently
+	// dropped, leaving a dead tunnel that committed OK. It is now captured
+	// so validateIPsecManualKeyStrict can hard-reject it at commit with a
+	// clear "use an IKE-negotiated VPN" message (lenient warn on load).
+	Manual bool
+	// VPNMonitor records a `vpn-monitor { ... }` block (#4299, V-3). xpf
+	// does not implement vpn-monitor's ICMP-probe liveness / st0
+	// interface-state coupling; the stanza is accepted and captured so
+	// ValidateConfig can emit an accepted-but-not-enforced advisory
+	// (mirroring the #2078/#4231 doctrine) rather than silently dropping it.
+	VPNMonitor                bool
+	VPNMonitorSourceInterface string
+	VPNMonitorDestinationIP   string
+	VPNMonitorOptimized       bool
 }

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -356,6 +356,64 @@ all files stay in `package ipsec`, so the public API is unchanged.
     tunnel. A non-chain resolve error (e.g. an unknown auth-method token
     from `authMethodToSwan`) is a different class and still aborts the
     whole render.
+- **Predefined proposal-set expansion (#4297, fable-167 V-1).** Junos
+  `security ike policy P proposal-set <set>` and the `security ipsec policy`
+  equivalent are the standard vSRX shorthand for "use a Juniper-curated
+  proposal set instead of hand-defining proposals". The keyword used to be
+  silently dropped (unknown compiler-switch key), so the policy carried no
+  resolvable proposal and the tunnel could not be built (the IPsec side
+  hard-rejected with "no resolvable ipsec proposal"; the IKE side left the
+  chain unresolved). The compiler now expands each set into concrete
+  synthetic proposals — `expandIKEProposalSets` / `expandIPsecProposalSets`
+  in `pkg/config/compiler_ipsec_proposalset.go`, run after the proposal and
+  policy maps are built — and points the policy's `Proposals` list at them,
+  so the whole downstream (strict cross-ref validators + the renderer here)
+  works unchanged. The expansion table is the single source of truth and
+  uses Junos algorithm spellings that `buildIKEProposalFromIKE` /
+  `buildESPProposal` normalize. Members follow Juniper's published tables:
+  `basic` / `compatible` / `standard` are the legacy DES/3DES/SHA1/MD5 sets
+  (DH group 2 — weak by modern standards and possibly not loaded in a
+  hardened strongSwan, but expanded faithfully because the operator asked
+  for the legacy set); `suiteb-gcm-128` / `suiteb-gcm-256` are RFC 6379
+  Suite-B (AES-GCM + ECDSA + ECP group 19/20). An explicit `proposals` list
+  wins (proposal-set only fills an empty list); an unknown set keyword is
+  rejected by the schema enum at commit. The crypto is an explicit, tested
+  table, never a hidden default substitution.
+- **AH (`protocol ah`) is rejected, never faked as ESP (#4298, fable-167
+  V-2, SECURITY).** A `security ipsec proposal P protocol ah` selects
+  Authentication Header (integrity only, no encryption; swanctl expresses it
+  via `ah_proposals`). xpf has no AH render path — `buildESPProposal`
+  ignores the protocol and defaults empty encryption to `aes256`, and
+  `renderConfig` always emits `esp_proposals` — so a `protocol ah` proposal
+  used to render as ESP with a fabricated cipher (the operator asked for AH
+  and silently got ESP-with-made-up-crypto, a misrepresentation). The
+  commit-time gate `validateIPsecProposalProtocolStrict`
+  (`pkg/config/compiler_validate_strict.go`) hard-rejects `protocol ah` with
+  a clear "use `protocol esp`" message; the render belt `vpnUsesAHProposal`
+  (`ike.go`) makes `renderConfig` SKIP any VPN whose ipsec-policy resolves to
+  an AH proposal (tolerant-boot path) rather than emit the fabricated ESP
+  tunnel. Full AH support (`ah_proposals`) is a possible follow-up; the
+  invariant is: **never substitute ESP for AH silently.**
+- **`vpn-monitor` accepted-but-not-enforced (#4299, fable-167 V-3).**
+  `security ipsec vpn V vpn-monitor { source-interface; destination-ip;
+  optimized; }` drives ICMP-probe tunnel liveness + st0 interface-state
+  coupling. xpf implements neither; the stanza used to be silently dropped.
+  It is now typed + captured (`compileIPsec`) and `ValidateConfig` emits an
+  accepted-only advisory (mirroring the #2078/#4231 doctrine) pointing the
+  operator at IKE-layer `dead-peer-detection` for peer liveness. Full
+  probe-driven monitoring is a follow-up.
+- **Manual-key SA rejected (#4300, fable-167 V-4).** `security ipsec vpn V
+  manual { ... }` configures a manual-key SA (no IKE). xpf negotiates all
+  SAs via IKE; the block used to be dropped silently, leaving a VPN that
+  committed OK but forwarded nothing (a silent dead tunnel).
+  `validateIPsecManualKeyStrict` now hard-rejects it at commit with a "use
+  an IKE-negotiated VPN" message (lenient warn on load — the block was
+  already inert).
+- **`establish-tunnels` enum validated (#4301, fable-167 V-5).** The leaf
+  was untyped, so a typo (`on-tarffic`) or a newer value stored verbatim and
+  silently degraded to on-traffic. It is now
+  `ValidateEnum([immediately, on-traffic, responder-only])` in
+  `setSchema` — a typo fails closed at commit.
 - **AES-GCM IKE PRF + ICV-suffix canonicalization (#2125).** The
   load-bearing fix: a strongSwan IKEv2 AEAD (AES-GCM) proposal MUST
   name a PRF explicitly — an AEAD cipher carries no integrity algorithm

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -372,9 +372,10 @@ all files stay in `package ipsec`, so the public API is unchanged.
   uses Junos algorithm spellings that `buildIKEProposalFromIKE` /
   `buildESPProposal` normalize. Members follow Juniper's published tables:
   `basic` / `compatible` / `standard` are the legacy DES/3DES/SHA1/MD5 sets
-  (DH group 2 — weak by modern standards and possibly not loaded in a
-  hardened strongSwan, but expanded faithfully because the operator asked
-  for the legacy set); `suiteb-gcm-128` / `suiteb-gcm-256` are RFC 6379
+  (`basic` is DH group 1 in Phase-1, `compatible`/`standard` are DH group 2
+  — weak by modern standards and possibly not loaded in a hardened
+  strongSwan, but expanded faithfully because the operator asked for the
+  legacy set); `suiteb-gcm-128` / `suiteb-gcm-256` are RFC 6379
   Suite-B (AES-GCM + ECDSA + ECP group 19/20). An explicit `proposals` list
   wins (proposal-set only fills an empty list); an unknown set keyword is
   rejected by the schema enum at commit. The crypto is an explicit, tested

--- a/pkg/ipsec/ike.go
+++ b/pkg/ipsec/ike.go
@@ -95,6 +95,40 @@ func resolveIKESettings(cfg *config.IPsecConfig, gw *config.IPsecGateway) (authM
 	return "", "", 0, aggressive, fmt.Errorf("%w: ike-policy %q", errIKEChainUnresolved, gw.IKEPolicy)
 }
 
+// vpnUsesAHProposal reports whether the VPN's ipsec-policy resolves to any
+// proposal with `protocol ah`. AH (Authentication Header) is integrity-only
+// and has no ESP render path — buildESPProposal would fabricate an aes256
+// cipher and renderConfig would emit esp_proposals — so renderConfig skips
+// such a VPN (#4298, V-2) rather than misrepresent AH as ESP. It mirrors
+// resolveESPSettings' resolution order exactly: the policy's proposal list,
+// the policy-name fallback for a policy with no explicit proposals, and the
+// legacy form where the ipsec-policy value is itself a proposal name.
+func vpnUsesAHProposal(cfg *config.IPsecConfig, vpn *config.IPsecVPN) bool {
+	if cfg == nil || vpn == nil || vpn.IPsecPolicy == "" {
+		return false
+	}
+	isAH := func(name string) bool {
+		if p, ok := cfg.Proposals[name]; ok && p != nil {
+			return strings.EqualFold(p.Protocol, "ah")
+		}
+		return false
+	}
+	if pol, ok := cfg.Policies[vpn.IPsecPolicy]; ok && pol != nil {
+		refs := pol.Proposals
+		if len(refs) == 0 {
+			refs = []string{vpn.IPsecPolicy}
+		}
+		for _, r := range refs {
+			if isAH(r) {
+				return true
+			}
+		}
+		return false
+	}
+	// Legacy form: the ipsec-policy value is itself a defined proposal name.
+	return isAH(vpn.IPsecPolicy)
+}
+
 // resolveESPSettings resolves the ESP (Phase 2) proposal string and lifetime
 // from the VPN's IPsec policy chain.
 func resolveESPSettings(cfg *config.IPsecConfig, vpn *config.IPsecVPN) (string, int) {

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -86,6 +86,25 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 			return "", fmt.Errorf("vpn %s: %w", name, err)
 		}
 
+		// #4298 (V-2): a proposal with `protocol ah` (Authentication Header)
+		// has no ESP render path — buildESPProposal would default the empty
+		// encryption to aes256 and renderConfig would emit esp_proposals, so
+		// the operator would silently get ESP with a fabricated cipher instead
+		// of the AH (integrity-only) they asked for. The commit-time gate
+		// (validateIPsecProposalProtocolStrict) hard-rejects AH, so this belt
+		// only fires on the tolerant load / peer-sync path or a directly-
+		// constructed IPsecConfig: SKIP the VPN rather than emit a fabricated
+		// ESP tunnel, mirroring the errIKEChainUnresolved skip above.
+		if vpnUsesAHProposal(ipsecCfg, vpn) {
+			skipped[name] = true
+			slog.Warn("skipping IPsec VPN: ipsec proposal uses protocol ah "+
+				"(Authentication Header) which xpf does not support — use "+
+				"protocol esp (rendering ESP would fabricate a cipher the "+
+				"operator never specified)",
+				"vpn", name, "ipsec_policy", vpn.IPsecPolicy)
+			continue
+		}
+
 		fmt.Fprintf(&b, "  %s {\n", sanitizeSwanctlValue(name))
 		espProposals, espLifetime := resolveESPSettings(ipsecCfg, vpn)
 		dpd := deriveDPD(gw, vpn)

--- a/pkg/ipsec/proposalset_ah_hb167_test.go
+++ b/pkg/ipsec/proposalset_ah_hb167_test.go
@@ -1,0 +1,121 @@
+package ipsec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// fable-review-167 render-side coverage:
+//
+//	V-1 (#4297): a predefined proposal-set renders the Junos-documented
+//	             swanctl proposal tokens (end-to-end: compile -> render).
+//	V-2 (#4298): a `protocol ah` proposal makes renderConfig SKIP the VPN
+//	             rather than emit ESP with a fabricated cipher.
+
+func compileToIPsec(t *testing.T, lines []string) *config.IPsecConfig {
+	t.Helper()
+	tree := &config.ConfigTree{}
+	for _, l := range lines {
+		path, err := config.ParseSetCommand(l)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", l, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", l, err)
+		}
+	}
+	cfg, err := config.CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	return PrepareConfig(cfg)
+}
+
+// V-1: proposal-set standard renders the concrete swanctl proposals on both
+// the Phase-1 (proposals =) and Phase-2 (esp_proposals =) lines.
+//
+// FAIL-ON-REVERT: without the compiler expansion the policies carry no
+// resolvable proposal, so CompileConfig errors (compileToIPsec t.Fatalf) —
+// the shorthand cannot commit a working tunnel.
+func TestProposalSetStandardRenders_4297(t *testing.T) {
+	prepared := compileToIPsec(t, []string{
+		"set security zones security-zone untrust",
+		"set security ike policy ike-pol proposal-set standard",
+		"set security ike policy ike-pol pre-shared-key ascii-text secret123",
+		"set security ike gateway gw1 address 172.16.0.1",
+		"set security ike gateway gw1 ike-policy ike-pol",
+		"set security ipsec policy esp-pol proposal-set standard",
+		"set security ipsec vpn tun1 ike gateway gw1",
+		"set security ipsec vpn tun1 ike ipsec-policy esp-pol",
+	})
+	out := New().generateConfig(prepared)
+	if !strings.Contains(out, "tun1 {") {
+		t.Fatalf("proposal-set standard tunnel missing from render:\n%s", out)
+	}
+	// Phase-1: 3des-sha1-modp1024 (group2) and aes128-sha1-modp1024, comma-joined.
+	if !strings.Contains(out, "3des-sha1-modp1024") || !strings.Contains(out, "aes128-sha1-modp1024") {
+		t.Errorf("IKE proposals line missing the standard set members:\n%s", out)
+	}
+	// Phase-2: 3des-sha1 and aes128-sha1.
+	if !strings.Contains(out, "esp_proposals = ") ||
+		!strings.Contains(out, "3des-sha1") || !strings.Contains(out, "aes128-sha1") {
+		t.Errorf("esp_proposals line missing the standard ESP set members:\n%s", out)
+	}
+}
+
+// V-1: suiteb-gcm-128 renders the RFC 6379 AEAD tokens (aes128gcm16 + ecp256).
+func TestProposalSetSuiteB128Renders_4297(t *testing.T) {
+	prepared := compileToIPsec(t, []string{
+		"set security zones security-zone untrust",
+		"set security ike policy ike-sb proposal-set suiteb-gcm-128",
+		"set security ike gateway gw1 address 172.16.0.1",
+		"set security ike gateway gw1 ike-policy ike-sb",
+		"set security ike gateway gw1 local-certificate my-cert",
+		"set security ipsec policy esp-sb proposal-set suiteb-gcm-128",
+		"set security ipsec vpn tun1 ike gateway gw1",
+		"set security ipsec vpn tun1 ike ipsec-policy esp-sb",
+	})
+	out := New().generateConfig(prepared)
+	if !strings.Contains(out, "aes128gcm16-prfsha256-ecp256") {
+		t.Errorf("IKE suiteb-gcm-128 proposal token missing:\n%s", out)
+	}
+	if !strings.Contains(out, "aes128gcm16-ecp256") {
+		t.Errorf("ESP suiteb-gcm-128 proposal token missing:\n%s", out)
+	}
+}
+
+// V-2: a VPN whose ipsec-policy resolves to a `protocol ah` proposal is
+// SKIPPED at render — never emitted as ESP with a fabricated cipher — while a
+// healthy ESP VPN in the same config survives.
+//
+// FAIL-ON-REVERT: without the vpnUsesAHProposal belt, tun-ah renders an
+// esp_proposals line (aes256 default) and "tun-ah {" appears — RED.
+func TestRenderConfig_AHProposalSkipsVPN_4298(t *testing.T) {
+	cfg := &config.IPsecConfig{
+		Proposals: map[string]*config.IPsecProposal{
+			"ah-prop":  {Name: "ah-prop", Protocol: "ah", AuthAlg: "hmac-sha-256-128"},
+			"esp-prop": {Name: "esp-prop", Protocol: "esp", EncryptionAlg: "aes-256-cbc", AuthAlg: "hmac-sha-256-128"},
+		},
+		Policies: map[string]*config.IPsecPolicyDef{
+			"ah-pol":  {Name: "ah-pol", Proposals: []string{"ah-prop"}},
+			"esp-pol": {Name: "esp-pol", Proposals: []string{"esp-prop"}},
+		},
+		Gateways: map[string]*config.IPsecGateway{
+			"gw-ah":  {Name: "gw-ah", Address: "192.0.2.1"},
+			"gw-esp": {Name: "gw-esp", Address: "192.0.2.2"},
+		},
+		VPNs: map[string]*config.IPsecVPN{
+			"tun-ah":  {Name: "tun-ah", Gateway: "gw-ah", IPsecPolicy: "ah-pol"},
+			"tun-esp": {Name: "tun-esp", Gateway: "gw-esp", IPsecPolicy: "esp-pol"},
+		},
+	}
+	out := New().generateConfig(cfg)
+	if strings.Contains(out, "tun-ah {") {
+		t.Errorf("AH VPN tun-ah must be skipped (never fabricated ESP):\n%s", out)
+	}
+	if !strings.Contains(out, "tun-esp {") {
+		t.Errorf("healthy ESP VPN tun-esp missing from render:\n%s", out)
+	}
+}


### PR DESCRIPTION
Closes #4297 Closes #4298 Closes #4299 Closes #4300 Closes #4301

Five vSRX IPsec/VPN parity findings from fable-review-167. Each was a
silently-dropped or silently-mistranslated stanza; every fix either
implements the feature or fails closed with a clear commit-time
diagnostic instead of leaving a dead or misrepresented tunnel. No silent
crypto substitution.

## V-1 (#4297) proposal-set — IMPLEMENTED

`security ike|ipsec policy P proposal-set <set>` is the standard vSRX
shorthand for a Juniper-curated proposal set. The keyword was silently
dropped (unknown compiler-switch key), so the policy carried no
resolvable proposal and the tunnel could not commit (IPsec side
hard-rejected "no resolvable ipsec proposal"; IKE side left the chain
unresolved). Now expanded into concrete synthetic proposals:

- `pkg/config/compiler_ipsec_proposalset.go` — SSOT expansion tables
  (`expandIKEProposalSets` / `expandIPsecProposalSets`), run after the
  proposal+policy maps are built; the policy then references real
  proposals so the strict cross-ref validators and the renderer work
  unchanged.
- Members follow Juniper's published tables:
  `basic`/`compatible`/`standard` = legacy DES/3DES/SHA1/MD5, DH group 2;
  `suiteb-gcm-128`/`suiteb-gcm-256` = RFC 6379 Suite-B (AES-GCM + ECDSA +
  ECP 19/20). An explicit `proposals` list wins; an unknown set keyword
  is rejected by the schema enum. The crypto is an explicit, tested table
  — never a hidden default substitution.

## V-2 (#4298, SECURITY) protocol ah — REJECTED, never faked as ESP

`protocol ah` is integrity-only (swanctl `ah_proposals`). xpf has no AH
render path, so `buildESPProposal` defaulted empty encryption to `aes256`
and `renderConfig` always emitted `esp_proposals` — a `protocol ah`
proposal silently rendered as `esp_proposals = aes256-sha256`, a crypto
misrepresentation. Fix:

- `validateIPsecProposalProtocolStrict` hard-rejects `protocol ah` at
  commit (lenient warn on load).
- Render belt `vpnUsesAHProposal` (ike.go) makes `renderConfig` SKIP any
  VPN whose ipsec-policy resolves to an AH proposal, rather than emit the
  fabricated ESP tunnel.
- Schema types `protocol` as esp|ah.

Full `ah_proposals` support is a possible follow-up; the invariant is
never to substitute ESP for AH silently.

## V-3 (#4299) vpn-monitor — accept-with-advisory

Typed + captured; `ValidateConfig` emits an accepted-but-not-enforced
advisory (mirrors #2078/#4231) pointing at IKE-layer
dead-peer-detection. Full probe-driven monitoring is a follow-up.

## V-4 (#4300) manual-key SA — REJECTED

`manual { ... }` was dropped silently, leaving a VPN that committed OK
but forwarded nothing. `validateIPsecManualKeyStrict` hard-rejects it
with a "use an IKE-negotiated VPN" message (lenient warn on load).

## V-5 (#4301) establish-tunnels — enum validated

`ValidateEnum([immediately, on-traffic, responder-only])` so a typo
(`on-tarffic`) fails closed at commit instead of silently degrading to
on-traffic.

## Tests (RED-on-revert, proven)

- `pkg/config/compiler_ipsec_hb167_parity_test.go` — proposal-set
  standard/suiteb expand + compile (RED on revert: gateway chain fails
  closed → CompileConfig errors); protocol-ah reject; manual reject;
  vpn-monitor advisory; establish-tunnels enum.
- `pkg/ipsec/proposalset_ah_hb167_test.go` — proposal-set standard +
  suiteb render tokens; AH-VPN render skip (RED on revert: AH VPN renders
  a fabricated `esp_proposals`).

Reverting the expansion / strict validators / render belt was verified to
turn the corresponding assertions RED.

`go test ./pkg/config/... ./pkg/ipsec/...` green; `go build ./...` clean;
gofmt + vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi