### PR TITLE
system/logging/SNMP vSRX parity: syslog misparse + custom login class + SSH hardening + inert-knob advisories (hb167 S-1/S-2/S-4/S-5)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,24 @@
+## 2026-07-05 — system: fable-167 S-2 accept custom `system login class <name>` (#4304)
+
+- **Timestamp**: 2026-07-05
+  - **Action**: #4304 (S-2) — a custom `system login class <name>` RBAC
+    definition was hard-rejected at commit (the `user ... class` leaf was a
+    fixed enum over the built-ins), blocking the WHOLE config. Accept-with-
+    advisory: added the `login class` schema container, switched the
+    `user ... class` validator to the tree-aware `validateLoginClassRef`
+    (built-ins UNION custom names via `schemaRefs.loginClasses`), parsed the
+    class definitions into `LoginConfig.Classes` with `mapJunosPermissions`
+    folding Junos permission tokens onto xpf's coarse model (least-privilege
+    view floor for non-whole-box tokens), emitted a per-class advisory, and
+    wired the runtime RBAC (`resolveClassPerms` in pkg/cli/permissions.go) so
+    a custom-class user is enforced instead of locked out.
+  - **File(s)**: pkg/config/types_system.go, pkg/config/compiler_system.go,
+    pkg/config/schema_system.go, pkg/config/schema_walk.go,
+    pkg/config/schema_validators.go, pkg/config/compiler.go,
+    pkg/cli/permissions.go, pkg/config/login_custom_class_4304_test.go,
+    pkg/cli/permissions_custom_class_4304_test.go, docs/system-login.md,
+    docs/config-schema.md
+
 ## 2026-07-05 — system/logging/SNMP: fable-167 S-1 syslog host/file sub-statement misparse (#4303)
 
 - **Timestamp**: 2026-07-05

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,20 @@
+## 2026-07-05 — system: fable-167 S-4 implement SSH hardening knobs (#4305)
+
+- **Timestamp**: 2026-07-05
+  - **Action**: #4305 (S-4) — `system services ssh` ciphers/macs/
+    connection-limit/client-alive-interval/client-alive-count-max/
+    protocol-version were silently inert (the SSH compiler read only
+    root-login + key-exchange). Added the schema leaves, parsed them into
+    `SSHServiceConfig`, and rendered Ciphers/MACs/MaxStartups/
+    ClientAliveInterval/ClientAliveCountMax into the sshd drop-in
+    (`buildSSHDConfig`). protocol-version is accept-with-advisory (sshd is
+    SSH-2 only). client-alive-* use presence flags (0 is meaningful).
+  - **File(s)**: pkg/config/types_system.go, pkg/config/compiler_system.go,
+    pkg/config/schema_system.go, pkg/config/compiler.go,
+    pkg/daemon/daemon_system.go,
+    pkg/config/compiler_ssh_hardening_4305_test.go,
+    pkg/daemon/daemon_ssh_test.go, docs/config-schema.md
+
 ## 2026-07-05 — system: fable-167 S-2 accept custom `system login class <name>` (#4304)
 
 - **Timestamp**: 2026-07-05

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,19 @@
+## 2026-07-05 — system/SNMP: fable-167 S-5 accept-with-advisory for grouped inert knobs (#4306)
+
+- **Timestamp**: 2026-07-05
+  - **Action**: #4306 (S-5) — a cluster of system/SNMP knobs committed clean
+    but did nothing (several security-relevant). Added `snmpInertKnobWarnings`
+    (view / community view / trap-options source-address / health-monitor /
+    rmon) and `systemInertKnobWarnings` (login message/announcement/
+    retry-options, ntp boot-server/authentication-key/source-address,
+    internet-options extras, ssh rate-limit) emitting loud
+    accept-with-advisory `cfg.Warnings`. Messages are built from the node
+    IDENTITY only — the SNMP community string and NTP authentication-key value
+    are never echoed. Advisory-only (no schema reject) since the knobs already
+    commit clean.
+  - **File(s)**: pkg/config/compiler_system.go,
+    pkg/config/compiler_inert_knobs_4306_test.go, docs/config-schema.md
+
 ## 2026-07-05 — system: fable-167 S-4 implement SSH hardening knobs (#4305)
 
 - **Timestamp**: 2026-07-05

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-07-05 — system/logging/SNMP: fable-167 S-1 syslog host/file sub-statement misparse (#4303)
+
+- **Timestamp**: 2026-07-05
+  - **Action**: #4303 (S-1) — `system syslog host/file/user` bodies mixed
+    `<facility> <severity>` pairs with non-facility modifiers
+    (`source-address`, `port`, `match`, `structured-data`,
+    `explicit-priority`, `archive`). The compiler captured EVERY
+    non-`allow-duplicates` child as a facility/severity pair, so
+    `source-address 10.0.1.1` became `{Facility:source-address,
+    Severity:10.0.1.1}` and polluted `Facilities[0]`, which
+    `applySystemSyslog` reads for the forwarding client's facility. Strict
+    commit ALSO rejected the modifiers (their value is not a valid severity
+    under the wildcard leaf). Fixed the compiler to switch on the known
+    modifiers first (`syslogFacilitySeverity` helper), captured host
+    `source-address`/`port` into `SyslogHostConfig`, modelled the modifiers
+    in the schema (`syslogDestinationModifiers`), and wired source-address +
+    port into the daemon syslog client.
+  - **File(s)**: pkg/config/compiler_system.go, pkg/config/types_system.go,
+    pkg/config/schema_system.go, pkg/daemon/daemon_system.go,
+    pkg/config/compiler_syslog_hostmods_4303_test.go, docs/config-schema.md
+
+
 ## 2026-07-05 — fable-review-167 I-4 (#4309): DHCP relay overrides
 
 - **Timestamp**: 2026-07-05

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-07-05 — system: fable-167 PR #4311 review fixes (S-2 priv-esc + deny-commands advisory + S-4 sshd -t gate)
+
+- **Timestamp**: 2026-07-05
+  - **Action**: Hostile review of PR #4311 found a REAL privilege escalation
+    in the S-2 permission mapping + two hardenings.
+    (FIX 1, priv-esc) `mapJunosPermissions` (types_system.go) mapped Junos
+    `reset` → PermMaint and `rollback` → PermConfig — over-grants. `reset` is
+    daemon-restart (`restart <process>`), NOT the destructive box verbs
+    PermMaint gates (reboot/halt/power-off/zeroize + cluster failover), so a
+    class `permissions reset` could `request system zeroize`. Fixed: `reset`
+    → PermControl, `rollback` → PermView floor; only `maintenance` → PermMaint,
+    only `configure` → PermConfig.
+    (FIX 2, deny-commands advisory) `all` + `deny-commands X` means
+    "everything EXCEPT X"; xpf drops deny-commands so the class is MORE
+    PERMISSIVE than the source config. Reframed the advisory
+    (`loginClassAdvisoryWarnings`) to state deny-commands/deny-configuration
+    make the class MORE PERMISSIVE (denied verbs stay ALLOWED) as an explicit
+    WARNING, separated from the neutral allow-*/idle-timeout not-enforced note.
+    (FIX 3, sshd -t gate) `applySSHConfig` (daemon_system.go) rendered
+    Ciphers/MACs/KexAlgorithms verbatim and relied on the base-image
+    ExecReload=sshd -t. Added `sshdValidateCmd` (`sshd -t`) run after writing
+    the drop-in but BEFORE the reload; on failure the drop-in is reverted and
+    the reload is SKIPPED, so a cipher typo cannot SIGHUP sshd into an invalid
+    config and drop its listener. Self-contained lockout protection.
+  - **File(s)**: pkg/config/types_system.go, pkg/config/compiler_system.go,
+    pkg/daemon/daemon_system.go, pkg/daemon/daemon_ssh_test.go,
+    pkg/config/login_custom_class_4304_test.go,
+    pkg/cli/permissions_custom_class_4304_test.go, docs/system-login.md,
+    docs/config-schema.md
+
 ## 2026-07-05 — system/SNMP: fable-167 S-5 accept-with-advisory for grouped inert knobs (#4306)
 
 - **Timestamp**: 2026-07-05

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -4726,3 +4726,40 @@ packed the whole line onto one leaf node and the compiler dropped it.
   per-day evaluation: `pkg/scheduler/scheduler_3849_test.go` and the
   updated `pkg/scheduler/scheduler_test.go`
   (`TestIsWithinWindow_NoWindowFailsClosed`).
+
+## System syslog host/file sub-statements (#4303 S-1)
+
+A `system syslog host <h>` / `file <f>` / `user <u>` destination body is a
+mix of `<facility> <severity>` pairs (`any warning;`, `daemon info;`) and
+NON-facility modifiers (`source-address 10.0.1.1;`, `port 5514;`,
+`match "re";`, `structured-data;`, `explicit-priority;`, `archive size 1m
+files 5;`). The compiler previously treated EVERY non-`allow-duplicates`
+child as a `<facility> <severity>` pair via a `len(Keys) >= 2` fallback, so
+`source-address 10.0.1.1` was captured as
+`SyslogFacility{Facility:"source-address", Severity:"10.0.1.1"}`.
+`applySystemSyslog` reads `Facilities[0].Facility` for the remote client's
+facility, so a leading `source-address` set the whole forwarding client's
+facility to garbage. The strict commit-check ALSO rejected these lines: the
+schema `host`/`file`/`user` nodes carried only the `<facility> <severity>`
+wildcard, so `source-address 10.0.1.1` was validated against the severity
+enum and rejected (an IP is not a severity).
+
+- **compiler** — `compileSystem` syslog loop (`compiler_system.go`) now
+  switches on the known modifier keywords before the pair fallback. Host
+  `source-address`/`port` are captured into `SyslogHostConfig.SourceAddress`
+  / `.Port`; `match`/`structured-data`/`explicit-priority`/`log-prefix`/
+  `facility-override`/`archive` are recognized-and-skipped. The
+  `syslogFacilitySeverity` helper extracts the pair (flat `Keys[0]/Keys[1]`
+  or hierarchical `Keys[0]` + child) and returns ok=false for a valueless
+  leaf, so a bare/garbage keyword is dropped instead of appended as a
+  half-populated filter.
+- **schema** — `syslogDestinationModifiers` models the modifiers as named
+  children so they take precedence over the wildcard. `source-address` is
+  `ValueIPAddress`, `port` is `ValueInteger(1,65535)`; the rest are accepted
+  structurally. No valid syslog config is newly rejected.
+- **runtime** — `applySystemSyslog` (`pkg/daemon/daemon_system.go`) now binds
+  the outgoing socket to `host.SourceAddress` (via
+  `logging.NewSyslogClientWithSource`) and honors `host.Port` instead of the
+  hardcoded 514.
+- **tests** — `pkg/config/compiler_syslog_hostmods_4303_test.go` (facilities
+  not polluted, source-address/port captured, strict commit accepts).

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -4799,3 +4799,33 @@ blocking the whole config. This is accept-with-advisory now:
   mapping + advisory + undefined-still-rejected);
   `pkg/cli/permissions_custom_class_4304_test.go` (runtime enforcement +
   redaction).
+
+## SSH hardening knobs (#4305 S-4)
+
+The SSH compiler read only `root-login` + `key-exchange`, so the standard
+sshd-hardening knobs committed clean (unknown-key accepted-inert) and never
+reached the `sshd_config.d/xpf.conf` drop-in — the box kept base-image cipher/
+MAC defaults even when the operator configured hardened algorithms.
+
+- **schema** (`schema_system.go`) — `services ssh` gains `ciphers` (multi),
+  `macs` (multi), `connection-limit` (int 1-250), `rate-limit` (int 1-250),
+  `client-alive-interval` (int 0-65535), `client-alive-count-max` (int 0-255),
+  `protocol-version` (enum v1|v2). ciphers/macs are free-form (sshd validates
+  spellings at reload). OpenSSH `@`-suffixed algorithm names are configurable
+  via quoting (`ciphers "aes256-gcm@openssh.com"`).
+- **compiler** (`compiler_system.go`) — parses them into `SSHServiceConfig`.
+  ciphers/macs read every value via `firewallMatchValues` so a `[ a b ]`
+  bracketed list is not truncated. client-alive-* carry presence flags because
+  0 is a meaningful sshd value.
+- **runtime** (`daemon_system.go buildSSHDConfig`) — renders `Ciphers`, `MACs`,
+  `MaxStartups` (connection-limit's nearest sshd equivalent),
+  `ClientAliveInterval`, `ClientAliveCountMax`. A bad value fails the sshd
+  reload, which `applySSHConfig` reverts.
+- **advisory** — `protocol-version` is accept-with-advisory: modern sshd is
+  SSH-2 only, so `v2` is a silent no-op and any other value emits a
+  `cfg.Warnings` advisory (`sshHardeningAdvisoryWarnings`). `rate-limit` has no
+  clean sshd equivalent; it is accepted and covered by the S-5 inert-knob
+  advisory scan.
+- **tests** — `pkg/config/compiler_ssh_hardening_4305_test.go`,
+  `pkg/daemon/daemon_ssh_test.go` (`TestBuildSSHDConfigHardeningKnobs`,
+  `TestBuildSSHDConfigClientAlivePresence`).

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -4829,3 +4829,31 @@ MAC defaults even when the operator configured hardened algorithms.
 - **tests** — `pkg/config/compiler_ssh_hardening_4305_test.go`,
   `pkg/daemon/daemon_ssh_test.go` (`TestBuildSSHDConfigHardeningKnobs`,
   `TestBuildSSHDConfigClientAlivePresence`).
+
+## Grouped system/SNMP inert knobs — accept-with-advisory (#4306 S-5)
+
+A cluster of `system`/`snmp` knobs commit clean but do nothing, several
+security-relevant. Rather than silently dropping them, the compiler now emits
+a loud accept-with-advisory (`cfg.Warnings`) so the operator learns the knob is
+inert. Advisory messages are built from the node IDENTITY (keywords) only —
+never a leaf value — so an SNMP community string or an NTP authentication-key
+is never echoed into a warning.
+
+- **SNMP** (`snmpInertKnobWarnings`, `compiler_system.go`) — `view` /
+  community `view` (MIB view scoping is NOT enforced → full ifTable exposure),
+  `trap-options source-address` (traps use the default egress IP),
+  `health-monitor`, `rmon` (no-ops).
+- **system** (`systemInertKnobWarnings`) — `login message` / `announcement`
+  (banners not applied), `login retry-options` (lockout not enforced), `ntp
+  boot-server` / `authentication-key` / `source-address`, and
+  `internet-options` leaves beyond `no-ipv6-reject-zero-hop-limit`. Also the
+  S-4 `services ssh rate-limit` (no sshd equivalent).
+- These are advisory-only by design: the knobs already committed clean
+  (unknown keys under a known container are accepted-inert by the opt-in
+  typed-leaf gate), so no valid config is newly rejected. The security-relevant
+  ones (community view scoping, trap source-address) get an explicit
+  "accepted but NOT enforced" note rather than an implicit full-exposure
+  surprise. Note: SNMP community `clients` source-IP restriction is tracked
+  separately (S-3, not this change).
+- **tests** — `pkg/config/compiler_inert_knobs_4306_test.go` (advisories fire,
+  no secret echoed).

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -4786,10 +4786,18 @@ blocking the whole config. This is accept-with-advisory now:
   tokens onto the coarse xpf model via `mapJunosPermissions`
   (`LoginClass.MappedPermissions`). Only whole-box tokens map precisely;
   everything else folds DOWN to a PermView floor (never over-grants
-  config/control/maint from a narrow subsystem token).
+  config/control/maint from a narrow subsystem token). **No privilege
+  escalation** (#4311 review): `reset` = restart daemons → PermControl (NOT
+  PermMaint — the destructive reboot/halt/zeroize verbs); `rollback` = revert
+  to a prior commit → PermView floor (NOT PermConfig); only `maintenance` →
+  PermMaint and only `configure` → PermConfig.
 - **advisory** — `loginClassAdvisoryWarnings` emits one `cfg.Warnings` entry
-  per custom class naming the mapped permissions and the recognized-but-not-
-  enforced sub-statements (allow/deny-commands, idle-timeout).
+  per custom class naming the mapped permissions. `allow-commands` /
+  `allow-configuration` / `idle-timeout` are named as accepted-but-not-enforced
+  (neutral). `deny-commands` / `deny-configuration` get an explicit `WARNING`
+  that, because they are unenforced blacklists, the class is **more permissive
+  than the Junos config** (the denied verbs stay allowed) — a weaker posture,
+  not merely "unenforced". Full per-command deny enforcement is a follow-up.
 - **runtime** — `pkg/cli/permissions.go` `resolveClassPerms` consults the
   built-ins first, then `store.ActiveConfig().System.Login.Classes`, so a
   custom-class user is enforced against the mapped permissions instead of
@@ -4819,8 +4827,16 @@ MAC defaults even when the operator configured hardened algorithms.
   0 is a meaningful sshd value.
 - **runtime** (`daemon_system.go buildSSHDConfig`) — renders `Ciphers`, `MACs`,
   `MaxStartups` (connection-limit's nearest sshd equivalent),
-  `ClientAliveInterval`, `ClientAliveCountMax`. A bad value fails the sshd
-  reload, which `applySSHConfig` reverts.
+  `ClientAliveInterval`, `ClientAliveCountMax`.
+- **validation gate** (#4311 review) — `applySSHConfig` runs `sshd -t`
+  (`sshdValidateCmd`) on the merged config AFTER writing the drop-in but BEFORE
+  the reload. A bad `Ciphers`/`MACs`/`KexAlgorithms` spelling fails `sshd -t`,
+  the drop-in is reverted to its prior content (or removed when there was
+  none), and the reload (SIGHUP) is **skipped entirely** — so a cipher typo can
+  never make sshd re-exec into an invalid config and drop its listener (SSH
+  lockout on the appliance). This makes the lockout protection self-contained
+  rather than relying on the base-image `ExecReload=sshd -t`; the reload-failure
+  revert stays as a backstop.
 - **advisory** — `protocol-version` is accept-with-advisory: modern sshd is
   SSH-2 only, so `v2` is a silent no-op and any other value emits a
   `cfg.Warnings` advisory (`sshHardeningAdvisoryWarnings`). `rate-limit` has no
@@ -4828,7 +4844,9 @@ MAC defaults even when the operator configured hardened algorithms.
   advisory scan.
 - **tests** — `pkg/config/compiler_ssh_hardening_4305_test.go`,
   `pkg/daemon/daemon_ssh_test.go` (`TestBuildSSHDConfigHardeningKnobs`,
-  `TestBuildSSHDConfigClientAlivePresence`).
+  `TestBuildSSHDConfigClientAlivePresence`, and the validation-gate guards
+  `TestApplySSHConfig_ValidationGateBlocksReload` /
+  `...ValidationGateRemovesWhenNoPrior` / `...ValidationPassesThenReloads`).
 
 ## Grouped system/SNMP inert knobs — accept-with-advisory (#4306 S-5)
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -4763,3 +4763,39 @@ enum and rejected (an IP is not a severity).
   hardcoded 514.
 - **tests** — `pkg/config/compiler_syslog_hostmods_4303_test.go` (facilities
   not polluted, source-address/port captured, strict commit accepts).
+
+## Custom system login class (#4304 S-2)
+
+The `system login user <n> class <c>` leaf was a fixed enum over the
+system-defined built-ins (`ValidLoginClasses()`), so a config that defined
+its own RBAC class (`set system login class noc-admin permissions all` +
+`set system login user bob class noc-admin`) was HARD-REJECTED at commit —
+blocking the whole config. This is accept-with-advisory now:
+
+- **schema** — a new `system login class <name>` container
+  (`schema_system.go`) with children `permissions` (multi), `idle-timeout`
+  (int), `allow-commands`, `deny-commands`, `allow-configuration`,
+  `deny-configuration`, `login-alarms`, `login-tip`. The `user ... class`
+  leaf switched from `ValidateEnum(ValidLoginClasses())` to the tree-aware
+  `treeValidator: validateLoginClassRef`, which accepts the built-ins UNION
+  the custom class names collected from the tree (`schemaRefs.loginClasses`,
+  `collectSchemaRefs`, merged from `defsSource` too). An undefined class
+  still fails closed.
+- **compiler** — `compileSystem` login loop parses the `class` definitions
+  (before users) into `LoginConfig.Classes`, folding the Junos `permissions`
+  tokens onto the coarse xpf model via `mapJunosPermissions`
+  (`LoginClass.MappedPermissions`). Only whole-box tokens map precisely;
+  everything else folds DOWN to a PermView floor (never over-grants
+  config/control/maint from a narrow subsystem token).
+- **advisory** — `loginClassAdvisoryWarnings` emits one `cfg.Warnings` entry
+  per custom class naming the mapped permissions and the recognized-but-not-
+  enforced sub-statements (allow/deny-commands, idle-timeout).
+- **runtime** — `pkg/cli/permissions.go` `resolveClassPerms` consults the
+  built-ins first, then `store.ActiveConfig().System.Login.Classes`, so a
+  custom-class user is enforced against the mapped permissions instead of
+  being locked out as an "unknown login class". Both `checkPermission` and
+  `showConfigRedacted` route through it.
+- **tests** — `pkg/config/login_custom_class_4304_test.go` (commit accepts +
+  mapping + advisory + undefined-still-rejected);
+  `pkg/cli/permissions_custom_class_4304_test.go` (runtime enforcement +
+  redaction).

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -90,17 +90,30 @@ per-command allow/deny regexes. The mapping is therefore
 per-class advisory (`show system commit` / warnings) describing exactly what
 maps and what does not:
 
-- `all` / `super-user` → `super-user` (PermAll); `maintenance` / `reset` →
-  maintenance; `clear` → clear; `control` → control; `configure` / `rollback`
-  → configure; `view` / `view-configuration` → view.
+- `all` / `super-user` → `super-user` (PermAll); `maintenance` → maintenance;
+  `clear` → clear; `control` / `reset` → control; `configure` → configure;
+  `view` / `view-configuration` → view.
+- **No privilege escalation** — the mapping never grants more than the Junos
+  token permits. Two Junos tokens are deceptive and are folded conservatively:
+  `reset` permits restarting software *daemons* (`restart <process>`), **not**
+  rebooting/halting/zeroizing the box, so it maps to **control**, never
+  `maintenance` (the destructive box verbs). `rollback` permits reverting to a
+  prior commit only, not arbitrary `set`/`delete`, so it folds to the
+  **view-only floor**, never `configure`.
 - **Every other** recognized token (a subsystem read like `network` /
   `interface` / `routing` / `firewall`, a `*-control` write token, `shell`,
   `secret`, …) folds **down** to a **view-only floor**. Under-granting is
   deliberate: the coarse model must never silently grant config / control /
   maintenance from a narrow subsystem token.
-- `allow-commands` / `deny-commands` / `allow-configuration` /
-  `deny-configuration` / `idle-timeout` are **recognized but NOT enforced** by
-  the coarse gate; the advisory names them.
+- `allow-commands` / `allow-configuration` / `idle-timeout` are **recognized
+  but NOT enforced** by the coarse gate (dropping a whitelist extension or a
+  session-lifetime knob cannot make the class more permissive); the advisory
+  names them.
+- **`deny-commands` / `deny-configuration` are blacklists** — because xpf does
+  not enforce them, the denied verbs stay **allowed**, so the class is **more
+  permissive than the Junos config**, not merely "unenforced". The advisory
+  states this explicitly as a `WARNING` so the operator knows the security
+  posture is weaker. Full per-command deny enforcement is a follow-up.
 
 An undefined class (referenced by a user but never defined, and not a built-in)
 still **fails closed** at commit.

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -33,11 +33,13 @@ does not hash plaintext for you.
 set system login user <name> class <class>
 ```
 
-The `class` value is **enum-validated at commit** against the set of
-system-defined Junos login classes xpf supports. An unrecognized class
-(e.g. `superuser`, `admin`) is hard-rejected by the `#1319` typed-leaf
-gate, closing the previous commit-accepts-any-string hole. The accepted
-classes are:
+The `class` value is **validated at commit** against the set of
+system-defined Junos login classes xpf supports **UNION any custom
+`system login class <name>` defined in the same candidate tree** (#4304 S-2,
+see below). An unrecognized class that is neither built-in nor defined
+(e.g. `superuser`, `admin` with no matching `class` definition) is still
+hard-rejected by the `#1319` typed-leaf gate, closing the previous
+commit-accepts-any-string hole. The system-defined classes are:
 
 | Class | Permissions |
 |---|---|
@@ -60,6 +62,48 @@ enum is **derived from** `LoginClassPermissions`
 runtime RBAC table can never drift apart: adding a class in one place
 without the other is impossible. An empty/unset class keeps the legacy
 allow-everything behavior (no class configured = no RBAC restriction).
+
+### Custom login classes (accept-with-advisory, #4304 S-2)
+
+Real vSRX configs define their own RBAC classes:
+
+```
+set system login class noc-admin permissions all
+set system login class noc-admin idle-timeout 30
+set system login user bob class noc-admin
+```
+
+Before #4304 the `class` leaf was a **fixed enum** over the built-ins only, so
+`class noc-admin` was **hard-rejected at commit** — which blocked the WHOLE
+config from committing. xpf now **recognizes** the custom `login class <name>`
+definition (`permissions`, `idle-timeout`, `allow-commands`, `deny-commands`,
+`allow-configuration`, `deny-configuration`), feeds the defined names into the
+`class` validator (a tree-aware cross-reference, `validateLoginClassRef`), and
+maps the Junos `permissions` token set onto xpf's coarse permission model at
+compile (`LoginClass.MappedPermissions`, consulted at runtime by
+`resolveClassPerms`).
+
+Because xpf's runtime RBAC is **coarse** (view/clear/control/config/maintenance/
+all) it cannot faithfully represent every fine-grained Junos permission or the
+per-command allow/deny regexes. The mapping is therefore
+**accept-with-advisory** — the commit succeeds and the compiler emits a
+per-class advisory (`show system commit` / warnings) describing exactly what
+maps and what does not:
+
+- `all` / `super-user` → `super-user` (PermAll); `maintenance` / `reset` →
+  maintenance; `clear` → clear; `control` → control; `configure` / `rollback`
+  → configure; `view` / `view-configuration` → view.
+- **Every other** recognized token (a subsystem read like `network` /
+  `interface` / `routing` / `firewall`, a `*-control` write token, `shell`,
+  `secret`, …) folds **down** to a **view-only floor**. Under-granting is
+  deliberate: the coarse model must never silently grant config / control /
+  maintenance from a narrow subsystem token.
+- `allow-commands` / `deny-commands` / `allow-configuration` /
+  `deny-configuration` / `idle-timeout` are **recognized but NOT enforced** by
+  the coarse gate; the advisory names them.
+
+An undefined class (referenced by a user but never defined, and not a built-in)
+still **fails closed** at commit.
 
 ### Command-to-permission mapping
 

--- a/pkg/cli/permissions.go
+++ b/pkg/cli/permissions.go
@@ -17,6 +17,29 @@ import (
 // on the top-level word alone, but a few privileged subcommands need a finer
 // gate (see requiredPermission). If userClass is empty (not set), all actions
 // are allowed for backward compatibility.
+// resolveClassPerms returns the coarse permission set for a login class,
+// consulting the system-defined built-ins FIRST and then any custom `system
+// login class <name>` defined in the active config (#4304 S-2). A custom
+// class's Junos permissions were mapped to the coarse model at compile
+// (config.LoginClass.MappedPermissions); without this resolution a
+// custom-class user would be locked out of every command at runtime even
+// though the config committed cleanly.
+func (c *CLI) resolveClassPerms(class string) ([]config.LoginClassPermission, bool) {
+	if perms, ok := config.LoginClassPermissions[class]; ok {
+		return perms, true
+	}
+	if c.store != nil {
+		if cfg := c.store.ActiveConfig(); cfg != nil && cfg.System.Login != nil {
+			for _, lc := range cfg.System.Login.Classes {
+				if lc != nil && lc.Name == class {
+					return lc.MappedPermissions, true
+				}
+			}
+		}
+	}
+	return nil, false
+}
+
 func (c *CLI) checkPermission(parts []string) error {
 	if c.userClass == "" {
 		return nil
@@ -25,7 +48,7 @@ func (c *CLI) checkPermission(parts []string) error {
 		return nil
 	}
 
-	perms, ok := config.LoginClassPermissions[c.userClass]
+	perms, ok := c.resolveClassPerms(c.userClass)
 	if !ok {
 		return fmt.Errorf("permission denied: unknown login class %q", c.userClass)
 	}
@@ -71,7 +94,7 @@ func (c *CLI) showConfigRedacted() bool {
 	if c.userClass == "" {
 		return false
 	}
-	perms, ok := config.LoginClassPermissions[c.userClass]
+	perms, ok := c.resolveClassPerms(c.userClass)
 	if !ok {
 		return true
 	}

--- a/pkg/cli/permissions_custom_class_4304_test.go
+++ b/pkg/cli/permissions_custom_class_4304_test.go
@@ -66,3 +66,44 @@ func TestCustomLoginClassRuntimeRBAC(t *testing.T) {
 		t.Errorf("viewer-plus (view/clear only) SHOULD redact secrets")
 	}
 }
+
+// TestCustomLoginClassResetCannotZeroize is the runtime half of the #4311
+// priv-esc fix: a class with `permissions reset` (daemon restart) must be able
+// to run benign control verbs but must NOT be able to run the destructive
+// maintenance verbs (request system reboot/halt/power-off/zeroize + chassis
+// cluster failover). Pre-fix reset->PermMaint let those through.
+func TestCustomLoginClassResetCannotZeroize(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure(): %v", err)
+	}
+	sets := []string{
+		"set system login class daemon-op permissions reset",
+		"set system login user dan class daemon-op",
+	}
+	if _, err := store.LoadSet(strings.Join(sets, "\n")); err != nil {
+		t.Fatalf("LoadSet(): %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit(): %v", err)
+	}
+
+	c := &CLI{store: store, userClass: "daemon-op"}
+
+	// Destructive maintenance verbs MUST be denied (reset != maintenance).
+	for _, parts := range [][]string{
+		{"request", "system", "reboot"},
+		{"request", "system", "zeroize"},
+		{"request", "system", "halt"},
+		{"request", "chassis", "cluster", "failover", "redundancy-group", "1", "node", "0"},
+	} {
+		if err := c.checkPermission(parts); err == nil {
+			t.Errorf("PRIV-ESC: %q ALLOWED for `permissions reset` class (want denied — that is maintenance, not reset)",
+				strings.Join(parts, " "))
+		}
+	}
+	// A benign control verb IS allowed (reset -> PermControl).
+	if err := c.checkPermission([]string{"request", "session"}); err != nil {
+		t.Errorf("benign control verb denied for `permissions reset` class: %v", err)
+	}
+}

--- a/pkg/cli/permissions_custom_class_4304_test.go
+++ b/pkg/cli/permissions_custom_class_4304_test.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCustomLoginClassRuntimeRBAC is the runtime half of #4304 S-2: a user
+// assigned to a custom `system login class <name>` must be enforced against
+// the class's mapped permissions resolved from the active config — NOT locked
+// out as an "unknown login class". Reverting resolveClassPerms back to a bare
+// config.LoginClassPermissions lookup makes every subtest go RED (a custom
+// class is unknown -> all commands denied).
+func TestCustomLoginClassRuntimeRBAC(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure(): %v", err)
+	}
+	sets := []string{
+		// noc-admin: permissions all -> super-user (everything).
+		"set system login class noc-admin permissions all",
+		// viewer-plus: view + clear only.
+		"set system login class viewer-plus permissions [ view clear ]",
+		"set system login user alice class noc-admin",
+		"set system login user bob class viewer-plus",
+	}
+	if _, err := store.LoadSet(strings.Join(sets, "\n")); err != nil {
+		t.Fatalf("LoadSet(): %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit(): %v", err)
+	}
+
+	cases := []struct {
+		class string
+		parts []string
+		allow bool
+	}{
+		{"noc-admin", []string{"configure"}, true},           // all -> super-user
+		{"noc-admin", []string{"clear", "security"}, true},   //
+		{"viewer-plus", []string{"show", "version"}, true},   // view granted
+		{"viewer-plus", []string{"clear", "security"}, true}, // clear granted
+		{"viewer-plus", []string{"configure"}, false},        // no config perm
+		{"viewer-plus", []string{"request", "system", "reboot"}, false},
+	}
+	for _, tc := range cases {
+		c := &CLI{store: store, userClass: tc.class}
+		err := c.checkPermission(tc.parts)
+		cmd := strings.Join(tc.parts, " ")
+		if tc.allow && err != nil {
+			t.Errorf("%q for class %q denied: %v (want allowed)", cmd, tc.class, err)
+		}
+		if !tc.allow && err == nil {
+			t.Errorf("%q for class %q ALLOWED (want denied)", cmd, tc.class)
+		}
+	}
+
+	// showConfigRedacted: the all-permissions custom class carries PermAll, so
+	// it reads cleartext like super-user; the view-only custom class must be
+	// redacted.
+	if (&CLI{store: store, userClass: "noc-admin"}).showConfigRedacted() {
+		t.Errorf("noc-admin (permissions all) should NOT redact (has PermAll)")
+	}
+	if !(&CLI{store: store, userClass: "viewer-plus"}).showConfigRedacted() {
+		t.Errorf("viewer-plus (view/clear only) SHOULD redact secrets")
+	}
+}

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -4080,6 +4080,11 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	// model and which sub-statements are recognized-but-not-enforced.
 	cfg.Warnings = append(cfg.Warnings, loginClassAdvisoryWarnings(cfg)...)
 
+	// #4305 S-4: SSH hardening knobs are rendered into the sshd drop-in; the
+	// ones sshd cannot honor (protocol-version on an SSH-2-only daemon) get an
+	// advisory instead of silently doing nothing.
+	cfg.Warnings = append(cfg.Warnings, sshHardeningAdvisoryWarnings(cfg)...)
+
 	// #1539: the structural invariant `cfg.System.DPDKDataplane = nil`
 	// was added on master (PR #1553) as a runtime safeguard against
 	// AST leakage of retired DPDK sub-tree fields. After this PR

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -4074,6 +4074,12 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	// inert instead of silently dropping it.
 	cfg.Warnings = append(cfg.Warnings, userspaceRetiredKnobWarnings(cfg)...)
 
+	// #4304 S-2: custom `system login class <name>` definitions are
+	// accepted-with-advisory — recognized so a valid vSRX RBAC config commits,
+	// with a per-class note on which Junos permissions map to xpf's coarse
+	// model and which sub-statements are recognized-but-not-enforced.
+	cfg.Warnings = append(cfg.Warnings, loginClassAdvisoryWarnings(cfg)...)
+
 	// #1539: the structural invariant `cfg.System.DPDKDataplane = nil`
 	// was added on master (PR #1553) as a runtime safeguard against
 	// AST leakage of retired DPDK sub-tree fields. After this PR

--- a/pkg/config/compiler_inert_knobs_4306_test.go
+++ b/pkg/config/compiler_inert_knobs_4306_test.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSNMPInertKnobAdvisories is the RED-on-revert guard for #4306 S-5 (SNMP
+// half): the security-relevant SNMP knobs that commit clean but do nothing
+// must emit a loud accept-with-advisory, and the advisory must NOT echo the
+// community NAME (an SNMP community string is a secret).
+func TestSNMPInertKnobAdvisories(t *testing.T) {
+	tree := buildTree4303(t, []string{
+		"set snmp view myview oid 1.3.6.1.2.1 include",
+		"set snmp community SUPERSECRETCOMMUNITY view myview",
+		"set snmp community SUPERSECRETCOMMUNITY authorization read-only",
+		"set snmp trap-options source-address 10.0.0.1",
+		"set snmp health-monitor",
+		"set snmp rmon",
+	})
+	c, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if err := SchemaValidate(tree, c); err != nil {
+		t.Fatalf("SchemaValidate rejected an accepted-inert SNMP config: %v", err)
+	}
+	all := strings.Join(c.Warnings, "\n")
+	for _, want := range []string{
+		"snmp view",
+		"trap-options source-address",
+		"health-monitor",
+		"rmon",
+		"community view",
+	} {
+		if !strings.Contains(all, want) {
+			t.Errorf("missing advisory %q; warnings:\n%s", want, all)
+		}
+	}
+	// The community string must never appear in an advisory.
+	if strings.Contains(all, "SUPERSECRETCOMMUNITY") {
+		t.Errorf("advisory echoed the secret community string; warnings:\n%s", all)
+	}
+}
+
+// TestSystemInertKnobAdvisories is the RED-on-revert guard for #4306 S-5
+// (system half): login banner/retry, ntp boot-server/authentication-key/
+// source-address, internet-options extras, and ssh rate-limit each emit an
+// advisory, and the NTP authentication-key VALUE is never echoed.
+func TestSystemInertKnobAdvisories(t *testing.T) {
+	tree := buildTree4303(t, []string{
+		`set system login message "authorized use only"`,
+		`set system login announcement "maintenance saturday"`,
+		"set system login retry-options tries-before-disconnect 3",
+		"set system ntp boot-server 10.0.0.9",
+		"set system ntp authentication-key 1 type md5 value NTPSECRETKEY",
+		"set system ntp source-address 10.0.0.2",
+		"set system internet-options tcp-mss 1400",
+		"set system services ssh rate-limit 20",
+	})
+	c, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if err := SchemaValidate(tree, c); err != nil {
+		t.Fatalf("SchemaValidate rejected an accepted-inert system config: %v", err)
+	}
+	all := strings.Join(c.Warnings, "\n")
+	for _, want := range []string{
+		"login message",
+		"login announcement",
+		"login retry-options",
+		"ntp boot-server",
+		"ntp authentication-key",
+		"ntp source-address",
+		"internet-options",
+		"ssh rate-limit",
+	} {
+		if !strings.Contains(all, want) {
+			t.Errorf("missing advisory %q; warnings:\n%s", want, all)
+		}
+	}
+	if strings.Contains(all, "NTPSECRETKEY") {
+		t.Errorf("advisory echoed the NTP authentication-key value; warnings:\n%s", all)
+	}
+}

--- a/pkg/config/compiler_ssh_hardening_4305_test.go
+++ b/pkg/config/compiler_ssh_hardening_4305_test.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSSHHardeningKnobsCompiled is the RED-on-revert guard for #4305 S-4: the
+// SSH hardening knobs must reach SSHServiceConfig (the compiler previously read
+// only root-login + key-exchange, so these were silently inert), and the
+// config must commit clean.
+func TestSSHHardeningKnobsCompiled(t *testing.T) {
+	tree := buildTree4303(t, []string{
+		// Bracketed list (must not be truncated to the first element) plus a
+		// quoted OpenSSH `@`-suffixed name (the lexer accepts `@` when quoted).
+		"set system services ssh ciphers [ aes256-ctr aes192-ctr ]",
+		`set system services ssh macs "hmac-sha2-512-etm@openssh.com"`,
+		"set system services ssh connection-limit 10",
+		"set system services ssh client-alive-interval 120",
+		"set system services ssh client-alive-count-max 3",
+		"set system services ssh protocol-version v2",
+	})
+	c, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if err := SchemaValidate(tree, c); err != nil {
+		t.Fatalf("SchemaValidate rejected valid SSH hardening config: %v", err)
+	}
+	if c.System.Services == nil || c.System.Services.SSH == nil {
+		t.Fatalf("no SSH config compiled")
+	}
+	ssh := c.System.Services.SSH
+	if len(ssh.Ciphers) != 2 || ssh.Ciphers[0] != "aes256-ctr" || ssh.Ciphers[1] != "aes192-ctr" {
+		t.Fatalf("Ciphers = %v, want [aes256-ctr aes192-ctr] (bracketed list not truncated)", ssh.Ciphers)
+	}
+	if len(ssh.MACs) != 1 || ssh.MACs[0] != "hmac-sha2-512-etm@openssh.com" {
+		t.Fatalf("MACs = %v", ssh.MACs)
+	}
+	if ssh.ConnectionLimit != 10 {
+		t.Fatalf("ConnectionLimit = %d, want 10", ssh.ConnectionLimit)
+	}
+	if !ssh.ClientAliveIntervalSet || ssh.ClientAliveInterval != 120 {
+		t.Fatalf("ClientAliveInterval = %d set=%v, want 120/true", ssh.ClientAliveInterval, ssh.ClientAliveIntervalSet)
+	}
+	if !ssh.ClientAliveCountMaxSet || ssh.ClientAliveCountMax != 3 {
+		t.Fatalf("ClientAliveCountMax = %d set=%v, want 3/true", ssh.ClientAliveCountMax, ssh.ClientAliveCountMaxSet)
+	}
+}
+
+// TestSSHProtocolVersionAdvisory checks the accept-with-advisory path: a
+// non-v2 protocol-version commits (sshd is SSH-2 only) but emits an advisory;
+// v2 is a silent no-op.
+func TestSSHProtocolVersionAdvisory(t *testing.T) {
+	tree := buildTree4303(t, []string{
+		"set system services ssh protocol-version v1",
+	})
+	c, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if err := SchemaValidate(tree, c); err != nil {
+		t.Fatalf("protocol-version v1 should commit (accept-with-advisory): %v", err)
+	}
+	found := false
+	for _, w := range c.Warnings {
+		if strings.Contains(w, "protocol-version") && strings.Contains(w, "SSH-2") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an SSH-2-only advisory for protocol-version v1; warnings=%v", c.Warnings)
+	}
+}

--- a/pkg/config/compiler_syslog_hostmods_4303_test.go
+++ b/pkg/config/compiler_syslog_hostmods_4303_test.go
@@ -1,0 +1,89 @@
+package config
+
+import "testing"
+
+// buildTree4303 assembles a candidate tree the way the CLI does — via
+// ParseSetCommand + SetPath — so flat-set token grouping matches production
+// (NewParser would merge newline-separated set lines into one node).
+func buildTree4303(t *testing.T, cmds []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// TestSyslogHostSubstatementsNotMisparsed is the RED-on-revert guard for
+// #4303 S-1. A syslog host's `source-address`/`port` sub-statements must NOT
+// be captured as facility/severity pairs, and the real `any warning` pair
+// must survive intact. On the pre-fix code Facilities carried three entries
+// ({source-address 10.0.1.1}, {any warning}, {port 5514}) and the strict
+// commit-check rejected `source-address` because an IP is not a severity.
+func TestSyslogHostSubstatementsNotMisparsed(t *testing.T) {
+	tree := buildTree4303(t, []string{
+		"set system syslog host 10.0.0.5 source-address 10.0.1.1",
+		"set system syslog host 10.0.0.5 any warning",
+		"set system syslog host 10.0.0.5 port 5514",
+		"set system syslog host 10.0.0.5 explicit-priority",
+	})
+	c, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	// Strict commit-check must ACCEPT the config (source-address/port are now
+	// modelled and no longer validated against the severity enum).
+	if err := SchemaValidate(tree, c); err != nil {
+		t.Fatalf("SchemaValidate rejected a valid syslog host config: %v", err)
+	}
+	if c.System.Syslog == nil || len(c.System.Syslog.Hosts) != 1 {
+		t.Fatalf("expected exactly one syslog host, got %+v", c.System.Syslog)
+	}
+	h := c.System.Syslog.Hosts[0]
+	if len(h.Facilities) != 1 {
+		t.Fatalf("expected exactly 1 facility pair (the real `any warning`), got %d: %+v",
+			len(h.Facilities), h.Facilities)
+	}
+	if h.Facilities[0].Facility != "any" || h.Facilities[0].Severity != "warning" {
+		t.Fatalf("facility pair = %+v, want {any warning}", h.Facilities[0])
+	}
+	if h.SourceAddress != "10.0.1.1" {
+		t.Fatalf("SourceAddress = %q, want 10.0.1.1", h.SourceAddress)
+	}
+	if h.Port != 5514 {
+		t.Fatalf("Port = %d, want 5514", h.Port)
+	}
+}
+
+// TestSyslogFileArchiveNotMisparsed guards the file-destination side: an
+// `archive`/`match`/`structured-data` modifier must not overwrite the real
+// facility/severity pair, and the config must commit clean.
+func TestSyslogFileArchiveNotMisparsed(t *testing.T) {
+	tree := buildTree4303(t, []string{
+		"set system syslog file messages any info",
+		"set system syslog file messages match SOMEPATTERN",
+		"set system syslog file messages archive size 1m",
+		"set system syslog file messages structured-data",
+	})
+	c, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if err := SchemaValidate(tree, c); err != nil {
+		t.Fatalf("SchemaValidate rejected a valid syslog file config: %v", err)
+	}
+	if c.System.Syslog == nil || len(c.System.Syslog.Files) != 1 {
+		t.Fatalf("expected one syslog file, got %+v", c.System.Syslog)
+	}
+	f := c.System.Syslog.Files[0]
+	if f.Facility != "any" || f.Severity != "info" {
+		t.Fatalf("file facility/severity = %q/%q, want any/info (archive/match/structured-data leaked in)",
+			f.Facility, f.Severity)
+	}
+}

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -265,14 +265,38 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 			for _, slInst := range namedInstances(child.FindChildren("host")) {
 				host := &SyslogHostConfig{Address: slInst.name}
 				for _, prop := range slInst.node.Children {
+					// #4303 S-1: switch on the KNOWN host sub-statements
+					// before the facility/severity fallback. Without this
+					// every non-`allow-duplicates` child (source-address,
+					// port, match, structured-data, ...) was captured as a
+					// bogus SyslogFacility{Facility:Keys[0], Severity:Keys[1]}
+					// that polluted the facility filter — applySystemSyslog
+					// reads Facilities[0].Facility, so a leading
+					// `source-address` set the whole client's facility to
+					// garbage.
 					switch prop.Name() {
 					case "allow-duplicates":
 						host.AllowDuplicates = true
+					case "source-address":
+						host.SourceAddress = nodeVal(prop)
+					case "port":
+						if v := nodeVal(prop); v != "" {
+							if n, err := strconv.Atoi(v); err == nil {
+								host.Port = n
+							}
+						}
+					case "match", "match-strings", "structured-data",
+						"explicit-priority", "log-prefix", "facility-override",
+						"routing-instance", "exclude-hostname":
+						// Recognized Junos host modifiers that are NOT
+						// facility/severity pairs. Accepted so a valid
+						// config commits; not (yet) wired into the runtime
+						// syslog client — see the S-5 advisory path.
 					default:
-						if len(prop.Keys) >= 2 {
+						if fac, sev, ok := syslogFacilitySeverity(prop); ok {
 							host.Facilities = append(host.Facilities, SyslogFacility{
-								Facility: prop.Keys[0],
-								Severity: prop.Keys[1],
+								Facility: fac,
+								Severity: sev,
 							})
 						}
 					}
@@ -282,9 +306,16 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 			for _, fileInst := range namedInstances(child.FindChildren("file")) {
 				file := &SyslogFileConfig{Name: fileInst.name}
 				for _, prop := range fileInst.node.Children {
-					if len(prop.Keys) >= 2 {
-						file.Facility = prop.Keys[0]
-						file.Severity = prop.Keys[1]
+					switch prop.Name() {
+					case "archive", "match", "match-strings", "structured-data",
+						"explicit-priority", "allow-duplicates":
+						// #4303 S-1: recognized file modifiers, not a
+						// facility/severity pair — do not append as one.
+					default:
+						if fac, sev, ok := syslogFacilitySeverity(prop); ok {
+							file.Facility = fac
+							file.Severity = sev
+						}
 					}
 				}
 				sys.Syslog.Files = append(sys.Syslog.Files, file)
@@ -293,9 +324,15 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 			for _, userInst := range namedInstances(child.FindChildren("user")) {
 				user := &SyslogUserConfig{User: userInst.name}
 				for _, prop := range userInst.node.Children {
-					if len(prop.Keys) >= 2 {
-						user.Facility = prop.Keys[0]
-						user.Severity = prop.Keys[1]
+					switch prop.Name() {
+					case "match", "match-strings", "structured-data",
+						"explicit-priority", "allow-duplicates":
+						// #4303 S-1: recognized user modifiers, not a pair.
+					default:
+						if fac, sev, ok := syslogFacilitySeverity(prop); ok {
+							user.Facility = fac
+							user.Severity = sev
+						}
 					}
 				}
 				sys.Syslog.Users = append(sys.Syslog.Users, user)
@@ -709,6 +746,29 @@ func compileUserspaceDataplane(node *Node, cfg *UserspaceConfig) error {
 		}
 	}
 	return nil
+}
+
+// syslogFacilitySeverity extracts the `<facility> <severity>` pair from a
+// system-syslog destination child. The pair is normally flat
+// (`daemon warning;` → Keys=["daemon","warning"]) but tolerates the
+// hierarchical shape (`daemon { warning; }` → Keys=["daemon"], child
+// Keys=["warning"]). Returns ok=false when the node carries no severity
+// token, so a bare/garbage leaf is dropped rather than appended as a
+// half-populated filter entry (#4303 S-1). Callers must pre-filter the
+// known non-facility host/file/user modifiers by keyword.
+func syslogFacilitySeverity(prop *Node) (facility, severity string, ok bool) {
+	if prop == nil || len(prop.Keys) == 0 {
+		return "", "", false
+	}
+	if len(prop.Keys) >= 2 {
+		return prop.Keys[0], prop.Keys[1], true
+	}
+	for _, c := range prop.Children {
+		if len(c.Keys) > 0 && c.Keys[0] != "" {
+			return prop.Keys[0], c.Keys[0], true
+		}
+	}
+	return "", "", false
 }
 
 // userspaceRetiredKnobWarnings turns each retired DPDK-era `system

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -495,6 +495,13 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 		}
 	}
 
+	// #4306 S-5: make the grouped `system` inert knobs (login banner/retry,
+	// ntp boot-server/authentication-key/source-address, internet-options
+	// extras, ssh rate-limit) loud instead of a silent no-op.
+	if cfg != nil {
+		cfg.Warnings = append(cfg.Warnings, systemInertKnobWarnings(node)...)
+	}
+
 	return nil
 }
 
@@ -1176,7 +1183,129 @@ func compileSNMP(node *Node, sys *SystemConfig, cfg *Config, lenient bool) error
 	}
 
 	sys.SNMP = snmp
+	if cfg != nil {
+		cfg.Warnings = append(cfg.Warnings, snmpInertKnobWarnings(node)...)
+	}
 	return nil
+}
+
+// snmpInertKnobWarnings emits accept-with-advisory notes for the top-level
+// `snmp` knobs xpf recognizes but does not enforce (#4306 S-5). The
+// security-relevant ones are called out explicitly: a MIB `view` (on a
+// community or standalone) is NOT enforced, so a view-scoped community is
+// silently promoted to full ifTable exposure; `trap-options source-address`
+// is NOT bound, so traps leave from the default egress IP. Messages are built
+// from the node IDENTITY (keywords) only — never the community NAME (an SNMP
+// community string is a secret). Deterministic, deduplicated output.
+func snmpInertKnobWarnings(node *Node) []string {
+	if node == nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var warnings []string
+	add := func(msg string) {
+		if !seen[msg] {
+			seen[msg] = true
+			warnings = append(warnings, msg)
+		}
+	}
+	nodeHasSub := func(n *Node, keyword string) bool {
+		if n == nil {
+			return false
+		}
+		if n.FindChild(keyword) != nil {
+			return true
+		}
+		for _, k := range n.Keys[1:] {
+			if k == keyword {
+				return true
+			}
+		}
+		return false
+	}
+	for _, child := range node.Children {
+		switch child.Name() {
+		case "view":
+			add("snmp view: MIB view scoping is accepted but NOT enforced by the SNMP agent (the full ifTable MIB is exposed regardless)")
+		case "trap-options":
+			if nodeHasSub(child, "source-address") {
+				add("snmp trap-options source-address: accepted but NOT enforced (traps are sent from the default egress IP)")
+			}
+		case "health-monitor":
+			add("snmp health-monitor: accepted but NOT implemented (no-op)")
+		case "rmon":
+			add("snmp rmon: accepted but NOT implemented (no-op)")
+		case "community":
+			// The community NAME is a secret — never echo it. Name only the
+			// keyword. A view-scoped community answers the full ifTable.
+			if nodeHasSub(child, "view") {
+				add("snmp community view: per-community MIB view scoping is accepted but NOT enforced (the community answers the full ifTable)")
+			}
+		}
+	}
+	return warnings
+}
+
+// systemInertKnobWarnings emits accept-with-advisory notes for the grouped
+// `system` knobs that commit clean but do nothing (#4306 S-5): login banners /
+// retry-options, NTP boot-server / authentication-key / source-address, and
+// `internet-options` leaves beyond the one xpf models. Messages name the
+// keyword only — never a leaf value (the NTP authentication-key is a secret).
+func systemInertKnobWarnings(sysNode *Node) []string {
+	if sysNode == nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var warnings []string
+	add := func(msg string) {
+		if !seen[msg] {
+			seen[msg] = true
+			warnings = append(warnings, msg)
+		}
+	}
+	if login := sysNode.FindChild("login"); login != nil {
+		if login.FindChild("message") != nil {
+			add("system login message: pre-login banner accepted but NOT applied")
+		}
+		if login.FindChild("announcement") != nil {
+			add("system login announcement: post-login announcement accepted but NOT applied")
+		}
+		if login.FindChild("retry-options") != nil {
+			add("system login retry-options: login retry/lockout policy accepted but NOT enforced")
+		}
+	}
+	if ntp := sysNode.FindChild("ntp"); ntp != nil {
+		if ntp.FindChild("boot-server") != nil {
+			add("system ntp boot-server: accepted but NOT enforced (no one-shot boot-time sync)")
+		}
+		if ntp.FindChild("authentication-key") != nil {
+			// The key VALUE is a secret — name the keyword only.
+			add("system ntp authentication-key: NTP authentication accepted but NOT enforced")
+		}
+		if ntp.FindChild("source-address") != nil {
+			add("system ntp source-address: accepted but NOT bound (NTP uses the default source IP)")
+		}
+	}
+	if io := sysNode.FindChild("internet-options"); io != nil {
+		var extra []string
+		for _, c := range io.Children {
+			if c.Name() != "no-ipv6-reject-zero-hop-limit" {
+				extra = append(extra, c.Name())
+			}
+		}
+		if len(extra) > 0 {
+			sort.Strings(extra)
+			add(fmt.Sprintf("system internet-options [%s]: accepted but NOT implemented (xpf models only no-ipv6-reject-zero-hop-limit)", strings.Join(extra, " ")))
+		}
+	}
+	if svc := sysNode.FindChild("services"); svc != nil {
+		if ssh := svc.FindChild("ssh"); ssh != nil {
+			if ssh.FindChild("rate-limit") != nil {
+				add("system services ssh rate-limit: accepted but NOT enforced (sshd has no per-minute connection-rate limiter)")
+			}
+		}
+	}
+	return warnings
 }
 
 // compileSNMPv3 parses the v3 { usm { local-engine { user <name> { ... } } } } hierarchy.

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -885,18 +885,36 @@ func loginClassAdvisoryWarnings(cfg *Config) []string {
 			sort.Strings(folded)
 			msg += fmt.Sprintf("; fine-grained permissions [%s] folded to view-only (xpf has no finer bucket)", strings.Join(folded, " "))
 		}
+		// Neutral not-enforced knobs (allow-* is a whitelist EXTENSION and
+		// idle-timeout is a session-lifetime knob; dropping them cannot make
+		// the class more permissive than the source config).
 		var inert []string
-		if lc.AllowCommands != "" || lc.DenyCommands != "" {
-			inert = append(inert, "allow-commands/deny-commands")
+		if lc.AllowCommands != "" {
+			inert = append(inert, "allow-commands")
 		}
-		if lc.AllowConfiguration != "" || lc.DenyConfiguration != "" {
-			inert = append(inert, "allow-configuration/deny-configuration")
+		if lc.AllowConfiguration != "" {
+			inert = append(inert, "allow-configuration")
 		}
 		if lc.IdleTimeout > 0 {
 			inert = append(inert, "idle-timeout")
 		}
 		if len(inert) > 0 {
-			msg += fmt.Sprintf("; %s accepted but NOT enforced by xpf's coarse RBAC", strings.Join(inert, " + "))
+			msg += fmt.Sprintf("; %s accepted but NOT enforced by xpf's coarse RBAC", strings.Join(inert, "/"))
+		}
+		// SECURITY: deny-commands / deny-configuration are BLACKLISTS. Dropping
+		// them makes the class MORE PERMISSIVE than the Junos config — the
+		// denied verbs stay ALLOWED. State that explicitly so the operator
+		// knows the posture is WEAKER, not merely "not enforced" (per-command
+		// deny enforcement is a larger follow-up).
+		var deny []string
+		if lc.DenyCommands != "" {
+			deny = append(deny, "deny-commands")
+		}
+		if lc.DenyConfiguration != "" {
+			deny = append(deny, "deny-configuration")
+		}
+		if len(deny) > 0 {
+			msg += fmt.Sprintf("; WARNING: %s is NOT enforced, so this class is MORE PERMISSIVE than the Junos config (denied commands/configuration remain ALLOWED); per-command deny enforcement is a follow-up", strings.Join(deny, "/"))
 		}
 		warnings = append(warnings, msg)
 	}

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -398,6 +398,35 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 					sys.Services.SSH.KeyExchange = append(sys.Services.SSH.KeyExchange, v)
 				}
 			}
+			// #4305 S-4: SSH hardening knobs. ciphers/macs are repeatable
+			// (bracketed list or one-per-child); read every value via
+			// firewallMatchValues so a `[ a b c ]` list is not truncated.
+			for _, cn := range sshNode.FindChildren("ciphers") {
+				sys.Services.SSH.Ciphers = append(sys.Services.SSH.Ciphers, firewallMatchValues(cn)...)
+			}
+			for _, mn := range sshNode.FindChildren("macs") {
+				sys.Services.SSH.MACs = append(sys.Services.SSH.MACs, firewallMatchValues(mn)...)
+			}
+			if cl := sshNode.FindChild("connection-limit"); cl != nil {
+				if n, err := strconv.Atoi(nodeVal(cl)); err == nil {
+					sys.Services.SSH.ConnectionLimit = n
+				}
+			}
+			if ci := sshNode.FindChild("client-alive-interval"); ci != nil {
+				if n, err := strconv.Atoi(nodeVal(ci)); err == nil {
+					sys.Services.SSH.ClientAliveInterval = n
+					sys.Services.SSH.ClientAliveIntervalSet = true
+				}
+			}
+			if cc := sshNode.FindChild("client-alive-count-max"); cc != nil {
+				if n, err := strconv.Atoi(nodeVal(cc)); err == nil {
+					sys.Services.SSH.ClientAliveCountMax = n
+					sys.Services.SSH.ClientAliveCountMaxSet = true
+				}
+			}
+			if pv := sshNode.FindChild("protocol-version"); pv != nil {
+				sys.Services.SSH.ProtocolVersion = nodeVal(pv)
+			}
 		}
 		// DNS service
 		if dnsNode := svcNode.FindChild("dns"); dnsNode != nil {
@@ -863,6 +892,24 @@ func loginClassAdvisoryWarnings(cfg *Config) []string {
 			msg += fmt.Sprintf("; %s accepted but NOT enforced by xpf's coarse RBAC", strings.Join(inert, " + "))
 		}
 		warnings = append(warnings, msg)
+	}
+	return warnings
+}
+
+// sshHardeningAdvisoryWarnings notes the SSH knobs xpf recognizes but does not
+// (or cannot) render into the sshd drop-in (#4305 S-4). protocol-version is the
+// main one: modern sshd is SSH-2 only, so `v2` is a silent no-op and any other
+// value cannot be honored (SSH-1 is unsupported).
+func sshHardeningAdvisoryWarnings(cfg *Config) []string {
+	if cfg == nil || cfg.System.Services == nil || cfg.System.Services.SSH == nil {
+		return nil
+	}
+	ssh := cfg.System.Services.SSH
+	var warnings []string
+	if ssh.ProtocolVersion != "" && ssh.ProtocolVersion != "v2" {
+		warnings = append(warnings, fmt.Sprintf(
+			"system services ssh protocol-version %q: sshd is SSH-2 only; SSH-1 is not supported, so this is accepted but NOT enforced",
+			ssh.ProtocolVersion))
 	}
 	return warnings
 }

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -84,6 +84,36 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 			}
 		case "login":
 			sys.Login = &LoginConfig{}
+			// #4304 S-2: parse custom `login class <name>` RBAC definitions so
+			// a real vSRX config commits (the `user ... class` enum accepts
+			// the defined names) and maps its Junos permission set onto xpf's
+			// coarse permission model. Compiled BEFORE users so the class set
+			// is complete regardless of stanza order.
+			for _, classInst := range namedInstances(child.FindChildren("class")) {
+				lc := &LoginClass{Name: classInst.name}
+				for _, prop := range classInst.node.Children {
+					switch prop.Name() {
+					case "permissions":
+						lc.Permissions = append(lc.Permissions, firewallMatchValues(prop)...)
+					case "idle-timeout":
+						if v := nodeVal(prop); v != "" {
+							if n, err := strconv.Atoi(v); err == nil {
+								lc.IdleTimeout = n
+							}
+						}
+					case "allow-commands":
+						lc.AllowCommands = nodeVal(prop)
+					case "deny-commands":
+						lc.DenyCommands = nodeVal(prop)
+					case "allow-configuration":
+						lc.AllowConfiguration = nodeVal(prop)
+					case "deny-configuration":
+						lc.DenyConfiguration = nodeVal(prop)
+					}
+				}
+				lc.MappedPermissions, _ = mapJunosPermissions(lc.Permissions)
+				sys.Login.Classes = append(sys.Login.Classes, lc)
+			}
 			for _, userInst := range namedInstances(child.FindChildren("user")) {
 				user := &LoginUser{Name: userInst.name}
 				for _, prop := range userInst.node.Children {
@@ -769,6 +799,72 @@ func syslogFacilitySeverity(prop *Node) (facility, severity string, ok bool) {
 		}
 	}
 	return "", "", false
+}
+
+// loginClassPermName renders a coarse xpf permission for the advisory.
+func loginClassPermName(p LoginClassPermission) string {
+	switch p {
+	case PermView:
+		return "view"
+	case PermClear:
+		return "clear"
+	case PermControl:
+		return "control"
+	case PermConfig:
+		return "configure"
+	case PermMaint:
+		return "maintenance"
+	case PermAll:
+		return "super-user"
+	default:
+		return "unknown"
+	}
+}
+
+// loginClassAdvisoryWarnings emits one accept-with-advisory warning per custom
+// `system login class <name>` (#4304 S-2). The class is RECOGNIZED (a valid
+// vSRX RBAC config commits instead of being hard-rejected), but xpf's coarse
+// permission model cannot faithfully represent every Junos permission or the
+// per-command allow/deny regexes, so the advisory states exactly what maps and
+// what is recognized-but-not-enforced. Deterministic order for stable output.
+func loginClassAdvisoryWarnings(cfg *Config) []string {
+	if cfg == nil || cfg.System.Login == nil || len(cfg.System.Login.Classes) == 0 {
+		return nil
+	}
+	var warnings []string
+	for _, lc := range cfg.System.Login.Classes {
+		mapped, folded := mapJunosPermissions(lc.Permissions)
+		names := make([]string, 0, len(mapped))
+		for _, p := range mapped {
+			names = append(names, loginClassPermName(p))
+		}
+		mappedStr := "none"
+		if len(names) > 0 {
+			sort.Strings(names)
+			mappedStr = strings.Join(names, ",")
+		}
+		msg := fmt.Sprintf("system login class %q: recognized (custom RBAC); Junos permissions [%s] mapped to xpf coarse permissions {%s}",
+			lc.Name, strings.Join(lc.Permissions, " "), mappedStr)
+		if len(folded) > 0 {
+			sort.Strings(folded)
+			msg += fmt.Sprintf("; fine-grained permissions [%s] folded to view-only (xpf has no finer bucket)", strings.Join(folded, " "))
+		}
+		var inert []string
+		if lc.AllowCommands != "" || lc.DenyCommands != "" {
+			inert = append(inert, "allow-commands/deny-commands")
+		}
+		if lc.AllowConfiguration != "" || lc.DenyConfiguration != "" {
+			inert = append(inert, "allow-configuration/deny-configuration")
+		}
+		if lc.IdleTimeout > 0 {
+			inert = append(inert, "idle-timeout")
+		}
+		if len(inert) > 0 {
+			msg += fmt.Sprintf("; %s accepted but NOT enforced by xpf's coarse RBAC", strings.Join(inert, " + "))
+		}
+		warnings = append(warnings, msg)
+	}
+	return warnings
 }
 
 // userspaceRetiredKnobWarnings turns each retired DPDK-era `system

--- a/pkg/config/login_custom_class_4304_test.go
+++ b/pkg/config/login_custom_class_4304_test.go
@@ -97,3 +97,74 @@ func TestUndefinedLoginClassStillRejected(t *testing.T) {
 		t.Fatalf("SchemaValidate accepted an undefined login class (fail-open regression)")
 	}
 }
+
+// TestCustomLoginClassNoPrivEsc pins the #4311-review privilege-escalation fix:
+// the deceptive Junos tokens must NOT over-grant.
+//   - `reset` (restart daemons) maps to PermControl, NOT PermMaint (the
+//     destructive box verbs). RED on revert: reset->PermMaint lets a class
+//     scoped to daemon restarts run `request system zeroize`.
+//   - `rollback` (revert to a prior commit) maps to the PermView floor, NOT
+//     PermConfig (arbitrary set/delete).
+//   - only `maintenance` maps to PermMaint.
+func TestCustomLoginClassNoPrivEsc(t *testing.T) {
+	has := func(perms []LoginClassPermission, want LoginClassPermission) bool {
+		for _, p := range perms {
+			if p == want {
+				return true
+			}
+		}
+		return false
+	}
+
+	// `reset` -> PermControl, and crucially NOT PermMaint.
+	resetPerms, _ := mapJunosPermissions([]string{"reset"})
+	if !has(resetPerms, PermControl) {
+		t.Errorf("permissions reset should map to PermControl; got %v", resetPerms)
+	}
+	if has(resetPerms, PermMaint) {
+		t.Errorf("PRIV-ESC: permissions reset must NOT map to PermMaint (would grant reboot/zeroize); got %v", resetPerms)
+	}
+	if has(resetPerms, PermAll) {
+		t.Errorf("permissions reset must NOT map to PermAll; got %v", resetPerms)
+	}
+
+	// `rollback` -> PermView floor, NOT PermConfig.
+	rbPerms, _ := mapJunosPermissions([]string{"rollback"})
+	if has(rbPerms, PermConfig) {
+		t.Errorf("permissions rollback must NOT map to PermConfig; got %v", rbPerms)
+	}
+	if !has(rbPerms, PermView) {
+		t.Errorf("permissions rollback should map to the PermView floor; got %v", rbPerms)
+	}
+
+	// `maintenance` is the ONLY token that legitimately maps to PermMaint.
+	maintPerms, _ := mapJunosPermissions([]string{"maintenance"})
+	if !has(maintPerms, PermMaint) {
+		t.Errorf("permissions maintenance should map to PermMaint; got %v", maintPerms)
+	}
+}
+
+// TestCustomLoginClassDenyCommandsAdvisory pins FIX 2: a class with
+// deny-commands must get an advisory that explicitly states the class becomes
+// MORE PERMISSIVE than the Junos config (not merely "not enforced").
+func TestCustomLoginClassDenyCommandsAdvisory(t *testing.T) {
+	tree := buildTree4303(t, []string{
+		"set system login class limited permissions all",
+		`set system login class limited deny-commands "request system reboot"`,
+		"set system login user carol class limited",
+	})
+	c, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	found := false
+	for _, w := range c.Warnings {
+		if strings.Contains(w, "limited") && strings.Contains(w, "deny-commands") &&
+			strings.Contains(w, "MORE PERMISSIVE") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a MORE-PERMISSIVE deny-commands advisory for class limited; warnings=%v", c.Warnings)
+	}
+}

--- a/pkg/config/login_custom_class_4304_test.go
+++ b/pkg/config/login_custom_class_4304_test.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCustomLoginClassCommitsWithAdvisory is the RED-on-revert guard for
+// #4304 S-2. A real vSRX RBAC config that defines a custom `login class` and
+// assigns a user to it must COMMIT (SchemaValidate accepts) — the pre-fix
+// fixed enum hard-rejected `class noc-admin`, blocking the WHOLE config. The
+// class must compile with the Junos permission set mapped to the coarse xpf
+// model, and the compiler must emit the accept-with-advisory warning.
+func TestCustomLoginClassCommitsWithAdvisory(t *testing.T) {
+	tree := buildTree4303(t, []string{
+		"set system login class noc-admin permissions all",
+		"set system login class noc-admin idle-timeout 30",
+		"set system login user bob class noc-admin",
+		"set system login user bob uid 2001",
+	})
+	c, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	// RED-on-revert: the fixed enum rejected the custom class name here.
+	if err := SchemaValidate(tree, c); err != nil {
+		t.Fatalf("SchemaValidate hard-rejected a valid custom-RBAC config: %v", err)
+	}
+	if c.System.Login == nil || len(c.System.Login.Classes) != 1 {
+		t.Fatalf("expected one custom login class, got %+v", c.System.Login)
+	}
+	lc := c.System.Login.Classes[0]
+	if lc.Name != "noc-admin" {
+		t.Fatalf("class name = %q, want noc-admin", lc.Name)
+	}
+	if len(lc.MappedPermissions) != 1 || lc.MappedPermissions[0] != PermAll {
+		t.Fatalf("permissions all -> %v, want [PermAll]", lc.MappedPermissions)
+	}
+	if lc.IdleTimeout != 30 {
+		t.Fatalf("idle-timeout = %d, want 30", lc.IdleTimeout)
+	}
+	// Accept-with-advisory: an advisory naming the class must be present.
+	found := false
+	for _, w := range c.Warnings {
+		if strings.Contains(w, "noc-admin") && strings.Contains(w, "recognized") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an accept-with-advisory warning for noc-admin; warnings=%v", c.Warnings)
+	}
+}
+
+// TestCustomLoginClassPermissionMapping checks the least-privilege folding:
+// unambiguous whole-box tokens map precisely, and any other subsystem/-control
+// token folds DOWN to a view-only floor (never silently grants config/control
+// from a narrow token).
+func TestCustomLoginClassPermissionMapping(t *testing.T) {
+	tree := buildTree4303(t, []string{
+		"set system login class ops permissions [ view clear network interface-control ]",
+		"set system login user carol class ops",
+	})
+	c, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if err := SchemaValidate(tree, c); err != nil {
+		t.Fatalf("SchemaValidate rejected ops class: %v", err)
+	}
+	lc := c.System.Login.Classes[0]
+	perms := map[LoginClassPermission]bool{}
+	for _, p := range lc.MappedPermissions {
+		perms[p] = true
+	}
+	if !perms[PermView] || !perms[PermClear] {
+		t.Fatalf("expected view+clear in %v", lc.MappedPermissions)
+	}
+	// `network` and `interface-control` fold to view-only — they must NOT
+	// silently grant config/control/maint.
+	if perms[PermConfig] || perms[PermControl] || perms[PermMaint] || perms[PermAll] {
+		t.Fatalf("subsystem tokens over-granted: %v", lc.MappedPermissions)
+	}
+}
+
+// TestUndefinedLoginClassStillRejected proves the gate did not go fail-open:
+// a user referencing a class that is neither built-in nor defined must still
+// be rejected at commit.
+func TestUndefinedLoginClassStillRejected(t *testing.T) {
+	tree := buildTree4303(t, []string{
+		"set system login user dave class ghost-class",
+	})
+	c, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if err := SchemaValidate(tree, c); err == nil {
+		t.Fatalf("SchemaValidate accepted an undefined login class (fail-open regression)")
+	}
+}

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -185,17 +185,33 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 			})},
 	}},
 	"login": {desc: "Login configuration", children: map[string]*schemaNode{
+		// #4304 S-2: custom `login class <name>` RBAC definition. Recognized so
+		// a real vSRX config commits; the Junos permission set is mapped onto
+		// xpf's coarse permission model at compile (compiler_system.go). The
+		// fine-grained allow/deny-command regexes are accepted structurally but
+		// not enforced (see the compile advisory).
+		"class": {desc: "Login class definition", args: 1, placeholder: "<class-name>", children: map[string]*schemaNode{
+			"permissions":         {desc: "Permission bits granted to the class", args: 1, multi: true, placeholder: "<permission>", children: nil},
+			"idle-timeout":        {desc: "Idle timeout (minutes)", args: 1, placeholder: "<minutes>", valueType: ValueInteger, validator: ValidateInteger(0, 4294967295), children: nil},
+			"allow-commands":      {desc: "Regex of operational commands to allow", args: 1, placeholder: "<regex>", children: nil},
+			"deny-commands":       {desc: "Regex of operational commands to deny", args: 1, placeholder: "<regex>", children: nil},
+			"allow-configuration": {desc: "Regex of configuration to allow", args: 1, placeholder: "<regex>", children: nil},
+			"deny-configuration":  {desc: "Regex of configuration to deny", args: 1, placeholder: "<regex>", children: nil},
+			"login-alarms":        {desc: "Display system alarms on login", children: nil},
+			"login-tip":           {desc: "Display a tip on login", children: nil},
+		}},
 		"user": {desc: "User name", args: 1, placeholder: "<username>", children: map[string]*schemaNode{
 			"uid": {desc: "User ID", args: 1, placeholder: "<uid>", children: nil},
-			// #2008 H6: enum-validate the login class at commit (RBAC is
-			// already enforced in pkg/cli/permissions.go; this closes the
-			// commit-accepts-any-string hole). The allowed set is derived from
-			// LoginClassPermissions so the schema enum and the runtime RBAC
-			// table cannot drift. Mirrors the SNMP `authorization` enum leaf.
+			// #2008 H6 / #4304 S-2: the class is validated against the
+			// system-defined built-ins UNION any custom `login class <name>`
+			// defined in the SAME candidate tree. The tree-aware validator
+			// replaces the fixed enum so a valid custom-RBAC config is no
+			// longer hard-rejected at commit, while an undefined class still
+			// fails closed. RBAC enforcement is in pkg/cli/permissions.go.
 			"class": {desc: "Login class", args: 1, placeholder: "<class>",
-				valueType: ValueEnumOf, valueDesc: "System-defined login class (super-user | operator | read-only | config-viewer | unauthorized)",
+				valueType: ValueEnumOf, valueDesc: "System-defined class (super-user | operator | read-only | config-viewer | unauthorized) or a custom `login class <name>`",
 				valueExamples: []string{"super-user", "operator", "read-only"},
-				validator:     ValidateEnum(ValidLoginClasses()), children: nil},
+				treeValidator: validateLoginClassRef, children: nil},
 			// #1944: close the schema asymmetry the compiler already
 			// half-implemented — give `authentication` a value-bearing
 			// children map (encrypted-password typed leaf + ssh-* keys).

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -400,6 +400,23 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 				placeholder: "<key-exchange-method>",
 				children:    nil,
 			},
+			// #4305 S-4: sshd hardening knobs rendered into the xpf drop-in.
+			// ciphers/macs are free-form algorithm lists (sshd validates the
+			// spellings at reload, so no enum). The numeric knobs are bounded
+			// to the Junos ranges.
+			"ciphers": {desc: "SSH ciphers (sshd Ciphers)", args: 1, multi: true, placeholder: "<cipher>", children: nil},
+			"macs":    {desc: "SSH message-authentication codes (sshd MACs)", args: 1, multi: true, placeholder: "<mac>", children: nil},
+			"connection-limit": {desc: "Maximum concurrent SSH connections (sshd MaxStartups)", args: 1, placeholder: "<limit>",
+				valueType: ValueInteger, valueDesc: "1-250", validator: ValidateInteger(1, 250), children: nil},
+			"rate-limit": {desc: "SSH connection attempts per minute", args: 1, placeholder: "<limit>",
+				valueType: ValueInteger, valueDesc: "1-250", validator: ValidateInteger(1, 250), children: nil},
+			"client-alive-interval": {desc: "sshd ClientAliveInterval (seconds; 0 disables)", args: 1, placeholder: "<seconds>",
+				valueType: ValueInteger, valueDesc: "0-65535", validator: ValidateInteger(0, 65535), children: nil},
+			"client-alive-count-max": {desc: "sshd ClientAliveCountMax", args: 1, placeholder: "<count>",
+				valueType: ValueInteger, valueDesc: "0-255", validator: ValidateInteger(0, 255), children: nil},
+			"protocol-version": {desc: "SSH protocol version (sshd is SSH-2 only)", args: 1, placeholder: "<version>",
+				valueType: ValueEnumOf, valueDesc: "v1 | v2", valueExamples: []string{"v2"},
+				validator: ValidateEnum([]string{"v1", "v2"}), children: nil},
 		}},
 		"netconf": {desc: "NETCONF service", children: map[string]*schemaNode{
 			"ssh": {desc: "NETCONF over SSH", children: nil},

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -32,6 +32,30 @@ func syslogFacilitySeverityLeaf() *schemaNode {
 	}
 }
 
+// syslogDestinationModifiers builds the named (non-facility) sub-statements a
+// system-syslog host/file/user destination accepts. These MUST be modelled as
+// named children so they take precedence over the `<facility> <severity>`
+// wildcard: without an exact-match entry a `source-address 10.0.1.1` /
+// `port 5514` / `match "re"` hits the severity-enum wildcard and the strict
+// commit-check REJECTS it (the value is not a Junos severity). `extra` folds
+// in per-destination keywords (host: source-address/port; file: archive).
+// Fresh maps/nodes per call so destinations never alias (#4303 S-1).
+func syslogDestinationModifiers(extra map[string]*schemaNode) map[string]*schemaNode {
+	children := map[string]*schemaNode{
+		"allow-duplicates":  {desc: "Do not suppress duplicate messages", children: nil},
+		"match":             {desc: "Regular-expression message filter", args: 1, placeholder: "<regex>", children: nil},
+		"match-strings":     {desc: "Message string filter", args: 1, placeholder: "<string>", children: nil},
+		"explicit-priority": {desc: "Include priority in the logged message", children: nil},
+		"structured-data": {desc: "Log in RFC 5424 structured-data format", children: map[string]*schemaNode{
+			"brief": {desc: "Omit the English-language message text", children: nil},
+		}},
+	}
+	for k, v := range extra {
+		children[k] = v
+	}
+	return children
+}
+
 var schemaSystem = &schemaNode{desc: "System configuration", children: map[string]*schemaNode{
 	"host-name":     {desc: "System hostname", args: 1, scalar: true, placeholder: "<hostname>", children: nil},
 	"domain-name":   {desc: "Domain name", args: 1, placeholder: "<domain>", children: nil},
@@ -124,13 +148,41 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 		// `allow-duplicates` is an explicit presence-only flag so it is
 		// not mistaken for a facility with a missing severity.
 		"user": {desc: "Syslog user destination", args: 1, placeholder: "<user>",
-			wildcard: syslogFacilitySeverityLeaf()},
+			wildcard: syslogFacilitySeverityLeaf(),
+			children: syslogDestinationModifiers(nil)},
 		"host": {desc: "Syslog host destination", args: 1, placeholder: "<host>",
-			wildcard: syslogFacilitySeverityLeaf(), children: map[string]*schemaNode{
-				"allow-duplicates": {desc: "Do not suppress duplicate messages", children: nil},
-			}},
+			wildcard: syslogFacilitySeverityLeaf(),
+			// #4303 S-1: host-only modifiers wired into the runtime syslog
+			// client (source-address, port). log-prefix / facility-override /
+			// routing-instance / exclude-hostname are recognized so a valid
+			// vSRX config commits (not yet enforced — S-5 advisory territory).
+			children: syslogDestinationModifiers(map[string]*schemaNode{
+				"source-address": {desc: "Local source address for outgoing syslog", args: 1, placeholder: "<ip>",
+					valueType: ValueIPAddress, valueDesc: "IPv4 or IPv6 source address",
+					valueExamples: []string{"10.0.1.1", "2001:db8::1"},
+					validator:     ValidateIPAddress, children: nil},
+				"port": {desc: "Destination syslog port", args: 1, placeholder: "<port>",
+					valueType: ValueInteger, valueDesc: "syslog UDP destination port (1-65535)",
+					valueExamples: []string{"514", "5514"},
+					validator:     ValidateInteger(1, 65535), children: nil},
+				"log-prefix":        {desc: "Prefix prepended to each forwarded message", args: 1, placeholder: "<prefix>", children: nil},
+				"facility-override": {desc: "Override the facility of forwarded messages", args: 1, placeholder: "<facility>", children: nil},
+				"routing-instance":  {desc: "Routing instance used to reach the host", args: 1, placeholder: "<instance>", children: nil},
+				"exclude-hostname":  {desc: "Omit the local hostname field", children: nil},
+			})},
 		"file": {desc: "Syslog file destination", args: 1, placeholder: "<filename>",
-			wildcard: syslogFacilitySeverityLeaf()},
+			wildcard: syslogFacilitySeverityLeaf(),
+			children: syslogDestinationModifiers(map[string]*schemaNode{
+				"archive": {desc: "Archive-file rotation settings", children: map[string]*schemaNode{
+					"size":              {desc: "Maximum file size before rotation", args: 1, placeholder: "<size>", children: nil},
+					"files":             {desc: "Number of archive files to retain", args: 1, placeholder: "<count>", children: nil},
+					"world-readable":    {desc: "Archives readable by all users", children: nil},
+					"no-world-readable": {desc: "Archives readable only by root", children: nil},
+					"start-time":        {desc: "Scheduled archive start time", args: 1, placeholder: "<time>", children: nil},
+					"transfer-interval": {desc: "Periodic archive interval (minutes)", args: 1, placeholder: "<minutes>", children: nil},
+					"archive-sites":     {desc: "Off-box archive site URL", args: 1, multi: true, placeholder: "<url>", children: nil},
+				}},
+			})},
 	}},
 	"login": {desc: "Login configuration", children: map[string]*schemaNode{
 		"user": {desc: "User name", args: 1, placeholder: "<username>", children: map[string]*schemaNode{

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -644,6 +644,28 @@ func validateForwardingClassRef(raw string, refs *schemaRefs) error {
 	return fmt.Errorf("forwarding-class %q is not defined; add `set class-of-service forwarding-classes queue <queue-id> %s` in the same commit (xpf does not implicitly define the Junos default classes other than best-effort)", raw, raw)
 }
 
+// validateLoginClassRef accepts a `system login user <n> class <c>` value that
+// is EITHER a system-defined built-in class (super-user/operator/read-only/
+// config-viewer/unauthorized, from LoginClassPermissions) OR a custom `system
+// login class <c>` defined in the same candidate tree (#4304 S-2). It replaces
+// the fixed enum so a valid vSRX RBAC config that defines its own class is no
+// longer hard-rejected at commit, while an undefined class still fails closed.
+func validateLoginClassRef(raw string, refs *schemaRefs) error {
+	if strings.TrimSpace(raw) == "" {
+		return fmt.Errorf("missing value (expected a login class name)")
+	}
+	if _, ok := LoginClassPermissions[raw]; ok {
+		return nil
+	}
+	if refs != nil {
+		if _, ok := refs.loginClasses[raw]; ok {
+			return nil
+		}
+	}
+	return fmt.Errorf("login class %q is not defined; use a system-defined class (one of: %s) or add `set system login class %s permissions <...>` in the same commit",
+		raw, strings.Join(ValidLoginClasses(), ", "), raw)
+}
+
 // validatePercent returns a closure that accepts a real number in
 // [min, max] inclusive. The input must parse as a float.
 func ValidatePercent(min, max float64) LeafValidator {

--- a/pkg/config/schema_walk.go
+++ b/pkg/config/schema_walk.go
@@ -93,8 +93,12 @@ func SchemaValidateWithDefinitions(tree, defsSource *ConfigTree, cfg *Config) er
 	}
 	refs := collectSchemaRefs(tree)
 	if defsSource != nil {
-		for name := range collectSchemaRefs(defsSource).forwardingClasses {
+		defRefs := collectSchemaRefs(defsSource)
+		for name := range defRefs.forwardingClasses {
 			refs.forwardingClasses[name] = struct{}{}
+		}
+		for name := range defRefs.loginClasses {
+			refs.loginClasses[name] = struct{}{}
 		}
 	}
 	vc := &walkContext{cfg: cfg, refs: refs}
@@ -161,6 +165,12 @@ type schemaRefs struct {
 	// that group, and node0/node1-variable configs legitimately keep
 	// peer-node definitions un-applied locally).
 	forwardingClasses map[string]struct{}
+	// loginClasses are the custom names defined via `system login class
+	// <name>` anywhere in the tree (including group bodies, applied or
+	// not — same permissive rationale as forwardingClasses). The
+	// `system login user <n> class <c>` leaf validates against the
+	// built-in classes UNION this set (#4304 S-2).
+	loginClasses map[string]struct{}
 }
 
 // collectSchemaRefs walks the tree for cross-referenceable definitions.
@@ -170,7 +180,10 @@ type schemaRefs struct {
 // whose queue number does not parse are skipped, as the compiler skips
 // them.
 func collectSchemaRefs(tree *ConfigTree) *schemaRefs {
-	refs := &schemaRefs{forwardingClasses: map[string]struct{}{}}
+	refs := &schemaRefs{
+		forwardingClasses: map[string]struct{}{},
+		loginClasses:      map[string]struct{}{},
+	}
 	if tree == nil {
 		return refs
 	}
@@ -190,6 +203,28 @@ func collectSchemaRefs(tree *ConfigTree) *schemaRefs {
 			refs.forwardingClasses[queueNode.Keys[2]] = struct{}{}
 		}
 	}
+	// collectLoginClasses records custom `login class <name>` names under a
+	// `system` node (#4304 S-2). Mirrors the compiler's namedInstances over
+	// `system login class`: the class name is the leading Keys arg.
+	collectLoginClasses := func(sysNode *Node) {
+		loginNode := sysNode.FindChild("login")
+		if loginNode == nil {
+			return
+		}
+		for _, classNode := range loginNode.FindChildren("class") {
+			if len(classNode.Keys) >= 2 && classNode.Keys[1] != "" {
+				refs.loginClasses[classNode.Keys[1]] = struct{}{}
+				continue
+			}
+			// Hierarchical shape: `class { noc-admin { ... } }` — the name
+			// is a child of the bare `class` node.
+			for _, c := range classNode.Children {
+				if len(c.Keys) > 0 && c.Keys[0] != "" {
+					refs.loginClasses[c.Keys[0]] = struct{}{}
+				}
+			}
+		}
+	}
 	for _, top := range tree.Children {
 		if top == nil || len(top.Keys) == 0 {
 			continue
@@ -197,6 +232,8 @@ func collectSchemaRefs(tree *ConfigTree) *schemaRefs {
 		switch top.Name() {
 		case "class-of-service":
 			collectCoS(top)
+		case "system":
+			collectLoginClasses(top)
 		case "groups":
 			for _, group := range top.Children {
 				if group == nil {
@@ -204,6 +241,9 @@ func collectSchemaRefs(tree *ConfigTree) *schemaRefs {
 				}
 				if cos := group.FindChild("class-of-service"); cos != nil {
 					collectCoS(cos)
+				}
+				if sys := group.FindChild("system"); sys != nil {
+					collectLoginClasses(sys)
 				}
 			}
 		}

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -332,6 +332,21 @@ func (p *DDNSProvider) String() string {
 type SSHServiceConfig struct {
 	RootLogin   string   // "allow", "deny", "deny-password"
 	KeyExchange []string // sshd KexAlgorithms (key-exchange methods)
+	// #4305 S-4: sshd hardening knobs rendered into the xpf sshd drop-in.
+	Ciphers         []string // sshd Ciphers
+	MACs            []string // sshd MACs
+	ConnectionLimit int      // sshd MaxStartups (0 = unset)
+	// ClientAlive* use presence flags because 0 is a meaningful sshd value
+	// (interval 0 disables keepalives; count-max 0 drops on the first miss).
+	ClientAliveInterval    int
+	ClientAliveIntervalSet bool
+	ClientAliveCountMax    int
+	ClientAliveCountMaxSet bool
+	// ProtocolVersion is recognized but accept-with-advisory: sshd is
+	// SSH-2-only, so v2 is a no-op and any other value gets a compile
+	// advisory (no `Protocol` line is emitted — the directive is gone from
+	// modern sshd).
+	ProtocolVersion string
 }
 
 // WebManagementConfig holds web management settings.

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -372,8 +372,15 @@ type SyslogUserConfig struct {
 
 // SyslogHostConfig defines a syslog host destination.
 type SyslogHostConfig struct {
-	Address         string
-	Facilities      []SyslogFacility // multiple facility/severity pairs
+	Address    string
+	Facilities []SyslogFacility // multiple facility/severity pairs
+	// SourceAddress binds the outgoing syslog socket to a specific local
+	// source IP (`host <h> source-address <ip>`). Empty = OS-selected
+	// source. Wired into logging.SyslogClient's source-bind (#4303 S-1).
+	SourceAddress string
+	// Port overrides the destination UDP port (`host <h> port <n>`).
+	// 0 = the RFC 3164 default 514 (#4303 S-1).
+	Port            int
 	AllowDuplicates bool
 }
 

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -618,6 +618,77 @@ func ValidLoginClasses() []string {
 // LoginConfig holds user account definitions.
 type LoginConfig struct {
 	Users []*LoginUser
+	// Classes are custom `system login class <name>` RBAC definitions
+	// (#4304 S-2). xpf recognizes them so a real vSRX RBAC config commits,
+	// and maps their Junos permission set onto the coarse xpf permission
+	// model (LoginClass.MappedPermissions) consulted by pkg/cli/permissions.
+	Classes []*LoginClass
+}
+
+// LoginClass is a custom `system login class <name>` definition (#4304 S-2).
+//
+// Junos ships a large fine-grained permission vocabulary and per-command
+// allow/deny regexes; xpf's runtime RBAC is coarse
+// (view/clear/control/config/maint/all, types_system.go LoginClassPermission).
+// So xpf recognizes the class (a valid config commits instead of being
+// hard-rejected at the `user ... class` enum) and maps the whole-box Junos
+// permission tokens onto the nearest coarse bucket. Fine-grained
+// allow-commands / deny-commands / idle-timeout are recorded but NOT enforced
+// by the coarse gate; the compiler emits an advisory saying so.
+type LoginClass struct {
+	Name               string
+	Permissions        []string               // raw Junos permission tokens as written
+	MappedPermissions  []LoginClassPermission // coarse xpf perms derived from Permissions
+	IdleTimeout        int                    // minutes; recognized, not enforced
+	AllowCommands      string                 // regex; recognized, not enforced
+	DenyCommands       string                 // regex; recognized, not enforced
+	AllowConfiguration string                 // regex; recognized, not enforced
+	DenyConfiguration  string                 // regex; recognized, not enforced
+}
+
+// mapJunosPermissions folds a custom login class's Junos permission tokens onto
+// xpf's coarse permission model (#4304 S-2). Only the unambiguous whole-box
+// tokens map precisely; every other recognized subsystem/-control token folds
+// DOWN to a PermView floor (least-privilege — never silently grant config,
+// control, or maintenance from a narrow subsystem token) and is returned in
+// foldedToView so the compiler advisory can list what is coarsely mapped. The
+// PermView floor lets the class holder log in and view even when no token maps
+// precisely; `unauthorized` (empty token set) grants nothing.
+func mapJunosPermissions(tokens []string) (perms []LoginClassPermission, foldedToView []string) {
+	have := map[LoginClassPermission]bool{}
+	add := func(p LoginClassPermission) {
+		if !have[p] {
+			have[p] = true
+			perms = append(perms, p)
+		}
+	}
+	for _, tok := range tokens {
+		switch tok {
+		case "all", "super-user":
+			add(PermAll)
+		case "maintenance", "reset":
+			add(PermMaint)
+		case "clear":
+			add(PermClear)
+		case "control":
+			add(PermControl)
+		case "configure", "rollback":
+			add(PermConfig)
+		case "view", "view-configuration":
+			add(PermView)
+		default:
+			// Any other recognized Junos permission (a subsystem read like
+			// `network`/`interface`/`routing`/`firewall`, a `*-control`
+			// write token, `shell`, `secret`, ...) is coarsely folded to a
+			// view-only floor. Under-granting is the safe direction: xpf's
+			// coarse model cannot faithfully represent per-subsystem write
+			// scope, so it must not over-grant config/control from a narrow
+			// token.
+			add(PermView)
+			foldedToView = append(foldedToView, tok)
+		}
+	}
+	return perms, foldedToView
 }
 
 // LoginUser defines a system user account.

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -669,6 +669,20 @@ type LoginClass struct {
 // foldedToView so the compiler advisory can list what is coarsely mapped. The
 // PermView floor lets the class holder log in and view even when no token maps
 // precisely; `unauthorized` (empty token set) grants nothing.
+//
+// CRITICAL (no privilege escalation, review of #4311): the mapping must never
+// grant MORE than the Junos token permits. Two Junos tokens are deceptive:
+//   - `reset` permits restarting software DAEMONS (`restart <process>`), NOT
+//     rebooting/halting/zeroizing the box. It must map to PermControl, NOT
+//     PermMaint — PermMaint is exactly the destructive box verbs (request
+//     system reboot/halt/power-off/zeroize + chassis cluster failover), which
+//     `reset` does not authorize.
+//   - `rollback` permits reverting to a prior commit only, NOT arbitrary
+//     set/delete. It must map to the PermView floor, NOT PermConfig (which
+//     gates entering configure to make arbitrary changes).
+//
+// Only `maintenance` maps to PermMaint (the correct whole-box-destructive
+// grant), and only `configure` maps to PermConfig.
 func mapJunosPermissions(tokens []string) (perms []LoginClassPermission, foldedToView []string) {
 	have := map[LoginClassPermission]bool{}
 	add := func(p LoginClassPermission) {
@@ -681,14 +695,21 @@ func mapJunosPermissions(tokens []string) (perms []LoginClassPermission, foldedT
 		switch tok {
 		case "all", "super-user":
 			add(PermAll)
-		case "maintenance", "reset":
+		case "maintenance":
 			add(PermMaint)
 		case "clear":
 			add(PermClear)
-		case "control":
+		case "control", "reset":
+			// `reset` = restart daemons (restart <process>); NOT the
+			// box-destructive reboot/halt/zeroize verbs that PermMaint gates.
 			add(PermControl)
-		case "configure", "rollback":
+		case "configure":
 			add(PermConfig)
+		case "rollback":
+			// `rollback` reverts to a prior commit only, not arbitrary
+			// set/delete; fold to the least-privilege view floor rather than
+			// PermConfig.
+			add(PermView)
 		case "view", "view-configuration":
 			add(PermView)
 		default:

--- a/pkg/daemon/daemon_ssh_test.go
+++ b/pkg/daemon/daemon_ssh_test.go
@@ -115,6 +115,11 @@ type sshdSeamRecorder struct {
 	// writes succeed. failNthWrite<=0 means every write returns writeErr.
 	writeErr     error
 	failNthWrite int
+
+	// validateErr, when set, makes `sshd -t` validation fail (models a bad
+	// Ciphers/MACs/KexAlgorithms spelling). validates counts invocations.
+	validateErr error
+	validates   int
 }
 
 // installSSHDSeam swaps the package-level seam vars to route through the
@@ -128,6 +133,7 @@ func installSSHDSeam(t *testing.T, r *sshdSeamRecorder) {
 	origRemove := sshdRemoveFile
 	origMkdir := sshdMkdirAll
 	origReload := sshdReloadCmd
+	origValidate := sshdValidateCmd
 
 	sshdConfPath = "/test/sshd_config.d/xpf.conf"
 	sshdReadFile = func(string) ([]byte, error) {
@@ -161,6 +167,13 @@ func installSSHDSeam(t *testing.T, r *sshdSeamRecorder) {
 		return nil
 	}
 	sshdMkdirAll = func(string, os.FileMode) error { return nil }
+	sshdValidateCmd = func() ([]byte, error) {
+		r.validates++
+		if r.validateErr != nil {
+			return []byte("bad configuration"), r.validateErr
+		}
+		return nil, nil
+	}
 	sshdReloadCmd = func() ([]byte, error) {
 		r.reloads++
 		if r.reloadErr != nil && (r.failNthReload <= 0 || r.reloads == r.failNthReload) {
@@ -176,6 +189,7 @@ func installSSHDSeam(t *testing.T, r *sshdSeamRecorder) {
 		sshdRemoveFile = origRemove
 		sshdMkdirAll = origMkdir
 		sshdReloadCmd = origReload
+		sshdValidateCmd = origValidate
 	})
 }
 
@@ -448,5 +462,94 @@ func TestBuildSSHDConfigHardeningKnobs(t *testing.T) {
 func TestBuildSSHDConfigClientAlivePresence(t *testing.T) {
 	if got := buildSSHDConfig(&config.SSHServiceConfig{ClientAliveCountMax: 0}); strings.Contains(got, "ClientAliveCountMax") {
 		t.Errorf("unset ClientAliveCountMax should not render; got:\n%s", got)
+	}
+}
+
+// TestApplySSHConfig_ValidationGateBlocksReload is the RED-on-revert guard for
+// the #4311 review's sshd -t gate: a bad Ciphers/MACs/KexAlgorithms line must
+// be caught by `sshd -t` BEFORE the reload, so the drop-in is reverted to its
+// prior content and the reload (SIGHUP) is never issued — the running sshd is
+// never disturbed. Pre-gate, the bad content went straight to reload and could
+// drop sshd's listener → SSH lockout. Reverting the gate (dropping sshdValidateCmd)
+// makes this go RED: reload is called and the bad content is applied.
+func TestApplySSHConfig_ValidationGateBlocksReload(t *testing.T) {
+	priorContent := buildSSHDConfig(&config.SSHServiceConfig{RootLogin: "deny"})
+	r := &sshdSeamRecorder{
+		present:     []byte(priorContent),
+		validateErr: errors.New("sshd: unsupported cipher"),
+	}
+	installSSHDSeam(t, r)
+
+	d := &Daemon{}
+	// A bad cipher: write succeeds, sshd -t fails, reload must be skipped.
+	d.applySSHConfig(sshConfig(&config.SSHServiceConfig{
+		RootLogin: "deny",
+		Ciphers:   []string{"aes999-bogus"},
+	}))
+
+	if r.validates != 1 {
+		t.Errorf("sshd -t should be invoked exactly once, got %d", r.validates)
+	}
+	if r.reloads != 0 {
+		t.Errorf("reload MUST be skipped when validation fails, got %d reload(s)", r.reloads)
+	}
+	if r.present == nil {
+		t.Fatalf("drop-in removed on validation failure but a prior existed; want prior restored")
+	}
+	if string(r.present) != priorContent {
+		t.Fatalf("drop-in not reverted to prior after validation failure\n got: %q\nwant: %q", r.present, priorContent)
+	}
+	if strings.Contains(string(r.present), "aes999-bogus") {
+		t.Errorf("bad cipher left on disk after validation failure: %q", r.present)
+	}
+}
+
+// TestApplySSHConfig_ValidationGateRemovesWhenNoPrior verifies the no-prior
+// branch: when validation fails and there was no prior drop-in, the just-written
+// bad drop-in is REMOVED (not left on disk to break the next sshd restart).
+func TestApplySSHConfig_ValidationGateRemovesWhenNoPrior(t *testing.T) {
+	r := &sshdSeamRecorder{
+		present:     nil, // no drop-in on disk
+		validateErr: errors.New("sshd: unsupported MAC"),
+	}
+	installSSHDSeam(t, r)
+
+	d := &Daemon{}
+	d.applySSHConfig(sshConfig(&config.SSHServiceConfig{
+		RootLogin: "allow",
+		MACs:      []string{"hmac-bogus"},
+	}))
+
+	if r.reloads != 0 {
+		t.Errorf("reload MUST be skipped when validation fails, got %d", r.reloads)
+	}
+	if r.present != nil {
+		t.Fatalf("bad drop-in left on disk after validation failure with no prior; want removed: %q", r.present)
+	}
+	if r.removed != 1 {
+		t.Errorf("Remove should be called once to clear the bad drop-in, got %d", r.removed)
+	}
+}
+
+// TestApplySSHConfig_ValidationPassesThenReloads confirms the happy path is
+// unchanged: valid content passes sshd -t and IS reloaded.
+func TestApplySSHConfig_ValidationPassesThenReloads(t *testing.T) {
+	r := &sshdSeamRecorder{present: nil} // no prior; validateErr nil = passes
+	installSSHDSeam(t, r)
+
+	d := &Daemon{}
+	d.applySSHConfig(sshConfig(&config.SSHServiceConfig{
+		RootLogin: "deny",
+		Ciphers:   []string{"aes256-ctr"},
+	}))
+
+	if r.validates != 1 {
+		t.Errorf("sshd -t should be invoked once, got %d", r.validates)
+	}
+	if r.reloads != 1 {
+		t.Errorf("reload should run once after validation passes, got %d", r.reloads)
+	}
+	if r.present == nil || !strings.Contains(string(r.present), "Ciphers aes256-ctr") {
+		t.Fatalf("valid drop-in should be applied; got %q", r.present)
 	}
 }

--- a/pkg/daemon/daemon_ssh_test.go
+++ b/pkg/daemon/daemon_ssh_test.go
@@ -413,3 +413,40 @@ func TestApplySSHConfig_NoChange(t *testing.T) {
 		t.Errorf("unexpected reload on no-change: %d", r.reloads)
 	}
 }
+
+// TestBuildSSHDConfigHardeningKnobs is the RED-on-revert guard for #4305 S-4:
+// the ciphers/macs/connection-limit/client-alive-* hardening knobs must render
+// into the sshd drop-in. Before the fix buildSSHDConfig read only root-login +
+// key-exchange, so these committed clean and never reached sshd.
+func TestBuildSSHDConfigHardeningKnobs(t *testing.T) {
+	ssh := &config.SSHServiceConfig{
+		Ciphers:                []string{"aes256-gcm@openssh.com", "chacha20-poly1305@openssh.com"},
+		MACs:                   []string{"hmac-sha2-512-etm@openssh.com"},
+		ConnectionLimit:        10,
+		ClientAliveInterval:    120,
+		ClientAliveIntervalSet: true,
+		ClientAliveCountMax:    0,
+		ClientAliveCountMaxSet: true,
+	}
+	got := buildSSHDConfig(ssh)
+	for _, want := range []string{
+		"Ciphers aes256-gcm@openssh.com,chacha20-poly1305@openssh.com",
+		"MACs hmac-sha2-512-etm@openssh.com",
+		"MaxStartups 10",
+		"ClientAliveInterval 120",
+		"ClientAliveCountMax 0",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("buildSSHDConfig missing %q; got:\n%s", want, got)
+		}
+	}
+}
+
+// TestBuildSSHDConfigClientAlivePresence proves the presence flags: a config
+// with ClientAliveCountMaxSet=false must NOT emit a ClientAliveCountMax line,
+// so "unset" is distinguishable from an explicit 0.
+func TestBuildSSHDConfigClientAlivePresence(t *testing.T) {
+	if got := buildSSHDConfig(&config.SSHServiceConfig{ClientAliveCountMax: 0}); strings.Contains(got, "ClientAliveCountMax") {
+		t.Errorf("unset ClientAliveCountMax should not render; got:\n%s", got)
+	}
+}

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -1193,6 +1193,27 @@ func buildSSHDConfig(ssh *config.SSHServiceConfig) string {
 	if len(ssh.KeyExchange) > 0 {
 		lines = append(lines, "KexAlgorithms "+strings.Join(ssh.KeyExchange, ","))
 	}
+	// #4305 S-4: sshd hardening knobs. sshd validates the algorithm
+	// spellings and numeric ranges at reload, so xpf renders them verbatim
+	// (a bad value fails the reload, which applySSHConfig reverts).
+	if len(ssh.Ciphers) > 0 {
+		lines = append(lines, "Ciphers "+strings.Join(ssh.Ciphers, ","))
+	}
+	if len(ssh.MACs) > 0 {
+		lines = append(lines, "MACs "+strings.Join(ssh.MACs, ","))
+	}
+	if ssh.ConnectionLimit > 0 {
+		// Junos `connection-limit` bounds concurrent sessions; sshd's
+		// nearest knob is MaxStartups (concurrent unauthenticated
+		// connections). Not an exact equivalent, but the standard mapping.
+		lines = append(lines, fmt.Sprintf("MaxStartups %d", ssh.ConnectionLimit))
+	}
+	if ssh.ClientAliveIntervalSet {
+		lines = append(lines, fmt.Sprintf("ClientAliveInterval %d", ssh.ClientAliveInterval))
+	}
+	if ssh.ClientAliveCountMaxSet {
+		lines = append(lines, fmt.Sprintf("ClientAliveCountMax %d", ssh.ClientAliveCountMax))
+	}
 	if len(lines) == 0 {
 		return ""
 	}

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -1047,6 +1047,16 @@ var (
 	sshdReloadCmd  = func() ([]byte, error) {
 		return runCommandTimeout("systemctl", "reload", "sshd")
 	}
+	// sshdValidateCmd runs `sshd -t`, which parses the full merged sshd
+	// configuration (/etc/ssh/sshd_config plus the sshd_config.d drop-ins,
+	// including the xpf drop-in) and fails on a bad Ciphers/MACs/
+	// KexAlgorithms spelling or any other syntax error. applySSHConfig gates
+	// the reload on this passing so a cipher/MAC typo never reaches a SIGHUP
+	// that could drop sshd's listener (#4311 review). Overridden in
+	// daemon_ssh_test.go.
+	sshdValidateCmd = func() ([]byte, error) {
+		return runCommandTimeout("/usr/sbin/sshd", "-t")
+	}
 )
 
 // applySSHConfig configures sshd from system { services { ssh { ... } } }.
@@ -1126,31 +1136,51 @@ func (d *Daemon) applySSHConfig(cfg *config.Config) {
 		return
 	}
 
-	// Reload sshd to pick up changes. On failure the drop-in we just wrote is
-	// syntactically/semantically bad (e.g. an invalid key-exchange algorithm)
-	// and would break the next sshd RESTART, so revert it to the prior state:
-	// restore the previous content, or remove the file if there was none.
-	if out, err := sshdReloadCmd(); err != nil {
-		slog.Error("failed to reload sshd",
-			"err", err, "output", strings.TrimSpace(string(out)))
-		// Revert. Only restore the prior content when we actually read it
-		// (priorReadable); an unreadable-but-present prior is unknown, so
-		// fail safe by removing the drop-in instead of restoring garbage.
+	// revertDropIn restores the drop-in to its prior state after a validation
+	// or reload failure: restore the previously-read content, else remove the
+	// file. Only restore the prior content when we actually read it
+	// (priorReadable); an unreadable-but-present prior is unknown, so fail safe
+	// by removing the drop-in instead of restoring garbage. No drop-in is safer
+	// than the known-bad content we just wrote (which would break the next sshd
+	// restart).
+	revertDropIn := func(reason string) {
 		if priorReadable {
 			if rerr := sshdWriteFile(sshdConfPath, prior, 0644); rerr != nil {
-				// Restoring the prior content failed too. No drop-in is safer
-				// than the known-bad content we just wrote (which would break
-				// the next sshd restart), so fall back to removing the file.
-				slog.Warn("failed to restore prior sshd config after reload failure; removing drop-in", "err", rerr)
+				slog.Warn("failed to restore prior sshd config; removing drop-in",
+					"reason", reason, "err", rerr)
 				if rmErr := sshdRemoveFile(sshdConfPath); rmErr != nil && !os.IsNotExist(rmErr) {
 					slog.Warn("failed to remove bad sshd config after failed restore", "err", rmErr)
 				}
 			}
 		} else {
 			if rerr := sshdRemoveFile(sshdConfPath); rerr != nil && !os.IsNotExist(rerr) {
-				slog.Warn("failed to remove bad sshd config after reload failure", "err", rerr)
+				slog.Warn("failed to remove bad sshd config", "reason", reason, "err", rerr)
 			}
 		}
+	}
+
+	// Validate the merged sshd config BEFORE reloading (#4311 review). A bad
+	// Ciphers/MACs/KexAlgorithms line reaching a reload (SIGHUP) can make sshd
+	// re-exec into an invalid config and drop its listener → SSH lockout on the
+	// appliance. `sshd -t` catches the typo first. On failure revert the
+	// drop-in and SKIP the reload entirely: the running sshd is never disturbed
+	// and the next restart reads the good prior config. This makes the
+	// cipher-typo-lockout protection self-contained rather than relying on the
+	// base-image ExecReload=sshd -t.
+	if out, err := sshdValidateCmd(); err != nil {
+		slog.Error("sshd config validation failed; SSH drop-in not applied",
+			"err", err, "output", strings.TrimSpace(string(out)))
+		revertDropIn("validation-failed")
+		return
+	}
+
+	// Reload sshd to pick up changes. Validation passed, so this should
+	// succeed; the reload-failure revert stays as a backstop (e.g. a runtime
+	// reload error unrelated to config syntax).
+	if out, err := sshdReloadCmd(); err != nil {
+		slog.Error("failed to reload sshd",
+			"err", err, "output", strings.TrimSpace(string(out)))
+		revertDropIn("reload-failed")
 		// Best-effort reload of the restored content so the running sshd is
 		// not left referencing a drop-in we just rewrote/removed underneath
 		// it. The original reload already failed; a second failure here is

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -601,8 +601,15 @@ func (d *Daemon) applySystemSyslog(cfg *config.Config) {
 
 	var clients []*logging.SyslogClient
 	for _, host := range cfg.System.Syslog.Hosts {
+		// #4303 S-1: honor `host <h> port <n>` and `source-address <ip>`.
+		// Both were previously misparsed into bogus facility entries and
+		// never reached the client; the port stayed pinned at 514 and the
+		// source bind was ignored.
 		port := 514
-		c, err := logging.NewSyslogClient(host.Address, port)
+		if host.Port > 0 {
+			port = host.Port
+		}
+		c, err := logging.NewSyslogClientWithSource(host.Address, port, host.SourceAddress)
 		if err != nil {
 			slog.Warn("failed to create system syslog client",
 				"host", host.Address, "err", err)


### PR DESCRIPTION
Closes #4303 Closes #4304 Closes #4305 Closes #4306

Four fable-review-167 SYSTEM/SNMP/LOGGING parity findings.

## S-1 (#4303) — syslog host/file sub-statements misparsed (real parse bug)
`system syslog host/file/user` bodies mix `<facility> <severity>` pairs with
non-facility modifiers. The compiler captured EVERY non-`allow-duplicates`
child as a facility/severity pair, so `source-address 10.0.1.1` became
`SyslogFacility{Facility:"source-address", Severity:"10.0.1.1"}` and polluted
`Facilities[0]` — which `applySystemSyslog` reads for the forwarding client's
facility. The strict commit-check separately REJECTED the modifiers (an IP is
not a valid severity under the wildcard leaf).

Fix: switch on the known modifiers before the pair fallback
(`syslogFacilitySeverity` helper); capture host `source-address`/`port` into
`SyslogHostConfig` and wire them into the syslog client
(`NewSyslogClientWithSource`, honor `Port`); model the modifiers in the schema
(`syslogDestinationModifiers`) so a valid config commits.

## S-2 (#4304) — custom `login class <name>` hard-rejected at commit
Login classes were a fixed built-in enum, so a real vSRX RBAC config
(`set system login class noc-admin ...` + `class noc-admin` on a user) was
hard-rejected at commit — blocking the WHOLE config. Accept-with-advisory now:
a `login class` schema container, a tree-aware `class` validator
(`validateLoginClassRef`, built-ins UNION defined names), compile mapping of
Junos permissions onto xpf's coarse model (`mapJunosPermissions`,
least-privilege view floor for non-whole-box tokens), a per-class advisory,
and runtime RBAC resolution (`resolveClassPerms`) so a custom-class user is
enforced instead of locked out. An undefined class still fails closed.

## S-4 (#4305) — SSH hardening knobs silently inert
`services ssh` ciphers/macs/connection-limit/client-alive-*/protocol-version
committed clean and never reached the sshd drop-in. Implemented: parse them
into `SSHServiceConfig`, render `Ciphers`/`MACs`/`MaxStartups`/`ClientAlive*`
in `buildSSHDConfig`. `protocol-version` is accept-with-advisory (sshd is
SSH-2 only). client-alive-* use presence flags (0 is meaningful).

## S-5 (#4306) — grouped system/SNMP inert knobs
Accept-with-advisory for the security-relevant silent no-ops: SNMP `view` /
community `view` (MIB view scoping NOT enforced → full ifTable exposure),
`trap-options source-address`, `health-monitor`, `rmon`; system `login
message`/`announcement`/`retry-options`, `ntp boot-server`/
`authentication-key`/`source-address`, `internet-options` extras, `ssh
rate-limit`. Advisory messages are built from node IDENTITY only — the SNMP
community string and NTP authentication-key value are never echoed.

## Validation
- RED-on-revert tests per finding: `compiler_syslog_hostmods_4303_test.go`,
  `login_custom_class_4304_test.go` + `pkg/cli/permissions_custom_class_4304_test.go`,
  `compiler_ssh_hardening_4305_test.go` + daemon `TestBuildSSHDConfig*`,
  `compiler_inert_knobs_4306_test.go`.
- `go test ./pkg/config/... ./pkg/logging/... ./pkg/api/... ./pkg/daemon/... ./pkg/cli/...` green; `go build ./...`; gofmt + vet clean.
- Docs: `docs/config-schema.md`, `docs/system-login.md`, `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi