### PR TITLE
fable-review-167 I-2/I-3/I-4: interface/RA/DHCP-relay parity knobs

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-07-05 — fable-review-167 I-4 (#4309): DHCP relay overrides
+
+- **Timestamp**: 2026-07-05
+  - **Action**: Extend the dhcp-relay `overrides` block (previously
+    always-broadcast only). IMPLEMENTED maximum-hop-count: the relay's
+    hop limit was hardcoded 16, now the group's configured value
+    (default 16) — request at limit dropped, RequestsDroppedMaxHops
+    counts it, relaySpec.maxHopCount participates in the restart diff.
+    ACCEPTED-ONLY forward-only + relay-agent-option (typed + compiled,
+    commit-time advisory) — the relay already forwards statelessly and
+    always inserts Option 82, so each matches the default. Both AST
+    shapes (inline Keys + block children). CLI show surfaces the new
+    overrides + hop-drop stat. RED-on-revert: hop check pinned to 16
+    relays a hops=4 request.
+  - **File(s)**: pkg/config/schema_routing.go,
+    pkg/config/types_system.go, pkg/config/compiler_services.go,
+    pkg/config/compiler_validate_warn.go, pkg/dhcprelay/relay.go,
+    pkg/cli/cli_show_services.go,
+    pkg/config/compiler_dhcp_relay_overrides_test.go,
+    pkg/dhcprelay/relay_test.go, pkg/dhcprelay/README.md,
+    docs/config-schema.md, _Log.md
+
 ## 2026-07-05 — fable-review-167 I-3 (#4308): interface ARP/addressing parity knobs
 
 - **Timestamp**: 2026-07-05

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,23 @@
+## 2026-07-05 — fable-review-167 I-3 (#4308): interface ARP/addressing parity knobs
+
+- **Timestamp**: 2026-07-05
+  - **Action**: Type + compile five interface knobs that were silently
+    dropped (native-vlan-id, gratuitous-arp-reply,
+    no-gratuitous-arp-request at interface level; unnumbered-address,
+    targeted-broadcast under family inet). All accept-with-advisory
+    (#2078 doctrine): typed schema leaves, compiled into
+    InterfaceConfig/InterfaceUnit fields, and a per-interface
+    accepted-only advisory (validateInterfaceParityWarnings) at commit —
+    full enforcement is design/cluster work (native-vlan-id → QinQ
+    pipeline #2354; unnumbered-address → networkd borrow; ARP knobs →
+    sysctls; targeted-broadcast → dataplane). RED-on-revert: compile +
+    advisory tests go empty on revert.
+  - **File(s)**: pkg/config/schema_interfaces.go,
+    pkg/config/types_interfaces.go, pkg/config/compiler_interfaces.go,
+    pkg/config/compiler_validate_warn.go,
+    pkg/config/interface_parity_4308_test.go, docs/config-schema.md,
+    _Log.md
+
 ## 2026-07-05 — fable-review-167 I-2 (#4307): RA reachable-time / retransmit-timer
 
 - **Timestamp**: 2026-07-05

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,20 @@
+## 2026-07-05 — fable-review-167 I-2 (#4307): RA reachable-time / retransmit-timer
+
+- **Timestamp**: 2026-07-05
+  - **Action**: Implement the RFC 4861 §4.2 Reachable Time / Retrans
+    Timer RA header fields, which were silently dropped (no schema leaf,
+    no config field, sender never set them → both went on the wire as 0).
+    Added typed millisecond leaves `reachable-time` / `retransmit-timer`
+    (bounded at the 32-bit ms max so they cannot silently wrap in ndp),
+    `RAInterfaceConfig.ReachableTime` / `RetransTimer`, the compiler cases,
+    and set them on the ndp RA in `buildRA`. RED-on-revert tests: parser
+    compile + sender wire round-trip.
+  - **File(s)**: pkg/config/schema_routing.go,
+    pkg/config/types_routing.go, pkg/config/compiler_protocols.go,
+    pkg/ra/sender.go, pkg/config/parser_routing_test.go,
+    pkg/ra/sender_marshal_4307_test.go, docs/embedded-radvd.md,
+    docs/config-schema.md, _Log.md
+
 ## 2026-07-05 — fable-167 PR #4295 Copilot fold: scrub two secret-leak-to-logs paths (VRRP auth-key + SNMP community)
 
 - **Timestamp**: 2026-07-05

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1737,6 +1737,28 @@ reserved for whole-dataplane selection where a rewrite shim
   `pkg/ra/sender.go buildRA`. 0 keeps the pre-#4307 unspecified default.
   Coverage: `pkg/config/parser_routing_test.go` (compile) +
   `pkg/ra/sender_marshal_4307_test.go` (wire round-trip).
+- **#4308 (interface ARP/addressing parity knobs, fable-review-167
+  I-3):** five common Junos interface knobs were accepted by the
+  permissive parser but never modeled or compiled, so they silently
+  vanished at commit. They are now typed leaves + compiled fields +
+  carry an accepted-only advisory (the #2078 doctrine), because full
+  enforcement needs design/cluster work:
+  - `native-vlan-id <id>` (interface-level, `ValidateInteger(1, 4094)`)
+    — folds into the QinQ tagging pipeline (#2354).
+  - `gratuitous-arp-reply` / `no-gratuitous-arp-request`
+    (interface-level flags) — map to per-interface ARP sysctls the
+    interface apply path does not write yet.
+  - `family inet unnumbered-address <interface>` — needs a networkd
+    borrow-address implementation (resolve the donor unit's address).
+  - `family inet targeted-broadcast` — needs dataplane directed-
+    broadcast forwarding.
+  Compiled into `InterfaceConfig.{NativeVlanID,GratuitousARPReply,
+  NoGratuitousARPRequest}` and `InterfaceUnit.{UnnumberedInet,
+  TargetedBroadcast}`; `validateInterfaceParityWarnings`
+  (compiler_validate_warn.go) emits one deterministic per-interface
+  accepted-only warning at commit. Coverage:
+  `pkg/config/interface_parity_4308_test.go` (compile + advisory +
+  no-false-positive).
 - **#2008 H7 (security log profile):** declared the `security log
   profile <name>` stanza — `stream-name` (`ValueHintStreamName`
   completion), `default-profile` (presence flag), and

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1723,6 +1723,20 @@ reserved for whole-dataplane selection where a rewrite shim
   configs). New validators `ValidateIPv6Address` / `ValidatePREF64CIDR`
   live in `schema_validators.go`. Regression coverage:
   `pkg/config/schema_validate_2497_test.go`.
+- **#4307 (router-advertisement reachable-time / retransmit-timer,
+  fable-review-167 I-2):** the RFC 4861 §4.2 Reachable Time and Retrans
+  Timer RA header fields had no schema leaf, no `RAInterfaceConfig`
+  field, and the sender never set them, so both went on the wire as 0
+  ("unspecified") and hosts could not be tuned via RA. Added
+  `reachable-time` / `retransmit-timer` as typed millisecond leaves
+  (`ValidateInteger(0, raReachableRetransMaxMillis)` — the 32-bit ms
+  field maximum so an over-large value does not silently wrap in ndp's
+  `Duration/time.Millisecond -> uint32`), compiled into
+  `RAInterfaceConfig.ReachableTime` / `RetransTimer`, and set on
+  `ndp.RouterAdvertisement.ReachableTime` / `RetransmitTimer` in
+  `pkg/ra/sender.go buildRA`. 0 keeps the pre-#4307 unspecified default.
+  Coverage: `pkg/config/parser_routing_test.go` (compile) +
+  `pkg/ra/sender_marshal_4307_test.go` (wire round-trip).
 - **#2008 H7 (security log profile):** declared the `security log
   profile <name>` stanza — `stream-name` (`ValueHintStreamName`
   completion), `default-profile` (presence flag), and

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1759,6 +1759,23 @@ reserved for whole-dataplane selection where a rewrite shim
   accepted-only warning at commit. Coverage:
   `pkg/config/interface_parity_4308_test.go` (compile + advisory +
   no-false-positive).
+- **#4309 (DHCP relay overrides, fable-review-167 I-4):** the dhcp-relay
+  `overrides` block modeled only `always-broadcast`; three standard
+  relay knobs were silently dropped. Added under group `overrides`:
+  - `maximum-hop-count <1..16>` (`ValidateInteger(1, 16)`) — **enforced**.
+    The relay's hop limit was hardcoded at 16; it is now the group's
+    configured value (default 16), a request at the limit is dropped, and
+    `RelayStats.RequestsDroppedMaxHops` counts the drop. Compiled into
+    `DHCPRelayGroup.MaximumHopCount` and flows into `relaySpec.maxHopCount`.
+  - `forward-only` / `relay-agent-option` — **accepted-only**. The xpf
+    relay already forwards statelessly and always inserts Option 82, so
+    each matches the default; compiled into `DHCPRelayGroup.ForwardOnly`
+    / `RelayAgentOption` with a commit-time accepted-only advisory
+    (`validateDHCPRelayParityWarnings`). Both AST shapes handled (inline
+    flat-set Keys and block-form children). Coverage:
+    `pkg/config/compiler_dhcp_relay_overrides_test.go` (compile flat-set
+    + merged-Keys value + block form + advisory) and
+    `pkg/dhcprelay/relay_test.go` (`TestRunRelay_ConfiguredMaxHopCount`).
 - **#2008 H7 (security log profile):** declared the `security log
   profile <name>` stanza — `stream-name` (`ValueHintStreamName`
   completion), `default-profile` (presence flag), and

--- a/docs/embedded-radvd.md
+++ b/docs/embedded-radvd.md
@@ -278,6 +278,8 @@ Map `RAInterfaceConfig` fields directly to `ndp.RouterAdvertisement`:
 | `DNSServers` | Option: `ndp.RecursiveDNSServer{Servers, Lifetime}` |
 | `NAT64Prefix` | Option: `ndp.PREF64{Prefix, Lifetime}` |
 | `LinkMTU` | Option: `ndp.NewMTU(mtu)` |
+| `ReachableTime` | `ReachableTime` (time.Duration, ms; RFC 4861 §4.2 — #4307) |
+| `RetransTimer` | `RetransmitTimer` (time.Duration, ms; RFC 4861 §4.2 — #4307) |
 | (interface MAC) | Option: `ndp.LinkLayerAddress{Direction: ndp.Source, Addr: mac}` |
 
 Additionally, `CurrentHopLimit` should default to 64 (standard for Linux).

--- a/pkg/cli/cli_show_services.go
+++ b/pkg/cli/cli_show_services.go
@@ -448,8 +448,24 @@ func (c *CLI) showDHCPRelay() error {
 			fmt.Printf("  %s:\n", name)
 			fmt.Printf("    Interfaces: %s\n", strings.Join(g.Interfaces, ", "))
 			fmt.Printf("    Active server group: %s\n", g.ActiveServerGroup)
+			var overrides []string
 			if g.AlwaysBroadcast {
-				fmt.Printf("    Overrides: always-broadcast\n")
+				overrides = append(overrides, "always-broadcast")
+			}
+			// #4309: maximum-hop-count is enforced; forward-only /
+			// relay-agent-option are accepted-only (annotated so the operator
+			// sees they match the relay's existing default behavior).
+			if g.MaximumHopCount > 0 {
+				overrides = append(overrides, fmt.Sprintf("maximum-hop-count %d", g.MaximumHopCount))
+			}
+			if g.ForwardOnly {
+				overrides = append(overrides, "forward-only (accepted-only)")
+			}
+			if g.RelayAgentOption {
+				overrides = append(overrides, "relay-agent-option (accepted-only)")
+			}
+			if len(overrides) > 0 {
+				fmt.Printf("    Overrides: %s\n", strings.Join(overrides, ", "))
 			}
 		}
 	}
@@ -459,9 +475,9 @@ func (c *CLI) showDHCPRelay() error {
 		stats := c.dhcpRelay.Stats()
 		if len(stats) > 0 {
 			fmt.Println("\nRelay statistics:")
-			fmt.Printf("  %-16s %-20s %s\n", "Interface", "Requests relayed", "Replies forwarded")
+			fmt.Printf("  %-16s %-20s %-20s %s\n", "Interface", "Requests relayed", "Replies forwarded", "Dropped (max-hops)")
 			for _, s := range stats {
-				fmt.Printf("  %-16s %-20d %d\n", s.Interface, s.RequestsRelayed, s.RepliesForwarded)
+				fmt.Printf("  %-16s %-20d %-20d %d\n", s.Interface, s.RequestsRelayed, s.RepliesForwarded, s.RequestsDroppedMaxHops)
 			}
 			// Reply-delivery breakdown (#2076). L2-fallback is the one to
 			// alert on: it means the raw-L2 path failed (CAP_NET_RAW,

--- a/pkg/config/compiler_dhcp_relay_overrides_test.go
+++ b/pkg/config/compiler_dhcp_relay_overrides_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -240,5 +241,147 @@ func TestDHCPRelayOverrides_SchemaCompletion(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("overrides completion missing always-broadcast; got %v", comps)
+	}
+}
+
+// #4309 (fable-review-167 I-4): the additional relay overrides
+// (maximum-hop-count / forward-only / relay-agent-option) must compile from
+// the flat-set path. RED-on-revert: without the compiler cases each field
+// reads back its zero value (silent drop).
+func TestDHCPRelayOverrides_4309_FlatSet(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set forwarding-options dhcp-relay server-group sg 10.1.1.1",
+		"set forwarding-options dhcp-relay group lan active-server-group sg",
+		"set forwarding-options dhcp-relay group lan interface ge-0/0/0.0",
+		"set forwarding-options dhcp-relay group lan overrides maximum-hop-count 4",
+		"set forwarding-options dhcp-relay group lan overrides forward-only",
+		"set forwarding-options dhcp-relay group lan overrides relay-agent-option",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	g := relayGroup(t, cfg, "lan")
+	if g.MaximumHopCount != 4 {
+		t.Errorf("MaximumHopCount = %d, want 4", g.MaximumHopCount)
+	}
+	if !g.ForwardOnly {
+		t.Error("ForwardOnly = false, want true")
+	}
+	if !g.RelayAgentOption {
+		t.Error("RelayAgentOption = false, want true")
+	}
+	// The interface list must stay clean — the new override keywords/value
+	// must not be swallowed into it.
+	if len(g.Interfaces) != 1 || g.Interfaces[0] != "ge-0/0/0.0" {
+		t.Errorf("Interfaces = %v, want [ge-0/0/0.0]", g.Interfaces)
+	}
+}
+
+// Merged-Keys shape: `maximum-hop-count 4` packed inline with a value token in
+// one group node exercises the inline-Keys override loop's value consumption
+// (the loop must advance past the value, not treat "4" as an override keyword).
+func TestDHCPRelayOverrides_4309_MergedKeysHopCountValue(t *testing.T) {
+	relayNode := &Node{
+		Keys: []string{"dhcp-relay"},
+		Children: []*Node{
+			{Keys: []string{"server-group", "sg", "10.1.1.1"}, IsLeaf: true},
+			{
+				Keys: []string{
+					"group", "lan",
+					"overrides", "maximum-hop-count", "4",
+					"interface", "ge-0/0/0.0",
+				},
+				IsLeaf: true,
+			},
+		},
+	}
+	fo := &ForwardingOptionsConfig{}
+	if err := compileDHCPRelay(relayNode, fo); err != nil {
+		t.Fatalf("compileDHCPRelay: %v", err)
+	}
+	g := fo.DHCPRelay.Groups["lan"]
+	if g == nil {
+		t.Fatal("relay group lan not found")
+	}
+	if g.MaximumHopCount != 4 {
+		t.Errorf("MaximumHopCount = %d, want 4 (merged-Keys value)", g.MaximumHopCount)
+	}
+	if len(g.Interfaces) != 1 || g.Interfaces[0] != "ge-0/0/0.0" {
+		t.Errorf("Interfaces = %v, want [ge-0/0/0.0] (hop-count value swallowed?)", g.Interfaces)
+	}
+}
+
+// Block form: `overrides { maximum-hop-count 4; forward-only; }` as child
+// nodes exercises the children-based override loop.
+func TestDHCPRelayOverrides_4309_BlockForm(t *testing.T) {
+	relayNode := &Node{
+		Keys: []string{"dhcp-relay"},
+		Children: []*Node{
+			{Keys: []string{"server-group", "sg", "10.1.1.1"}, IsLeaf: true},
+			{
+				Keys: []string{"group", "lan"},
+				Children: []*Node{
+					{Keys: []string{"interface", "ge-0/0/0.0"}, IsLeaf: true},
+					{Keys: []string{"overrides"}, Children: []*Node{
+						{Keys: []string{"maximum-hop-count", "4"}, IsLeaf: true},
+						{Keys: []string{"forward-only"}, IsLeaf: true},
+						{Keys: []string{"relay-agent-option"}, IsLeaf: true},
+					}},
+				},
+			},
+		},
+	}
+	fo := &ForwardingOptionsConfig{}
+	if err := compileDHCPRelay(relayNode, fo); err != nil {
+		t.Fatalf("compileDHCPRelay: %v", err)
+	}
+	g := fo.DHCPRelay.Groups["lan"]
+	if g == nil {
+		t.Fatal("relay group lan not found")
+	}
+	if g.MaximumHopCount != 4 {
+		t.Errorf("MaximumHopCount = %d, want 4 (block form)", g.MaximumHopCount)
+	}
+	if !g.ForwardOnly {
+		t.Error("ForwardOnly = false, want true (block form)")
+	}
+	if !g.RelayAgentOption {
+		t.Error("RelayAgentOption = false, want true (block form)")
+	}
+}
+
+// forward-only / relay-agent-option must surface an accepted-only advisory;
+// maximum-hop-count is enforced and must NOT (it is a real behavior, not a
+// no-op).
+func TestDHCPRelayOverrides_4309_Advisory(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set forwarding-options dhcp-relay server-group sg 10.1.1.1",
+		"set forwarding-options dhcp-relay group lan active-server-group sg",
+		"set forwarding-options dhcp-relay group lan interface ge-0/0/0.0",
+		"set forwarding-options dhcp-relay group lan overrides forward-only",
+		"set forwarding-options dhcp-relay group lan overrides relay-agent-option",
+		"set forwarding-options dhcp-relay group lan overrides maximum-hop-count 4",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	var warn string
+	for _, w := range ValidateConfig(cfg) {
+		if strings.Contains(w, "#4309") && strings.Contains(w, "lan") {
+			warn = w
+		}
+	}
+	if warn == "" {
+		t.Fatalf("expected a #4309 accepted-only advisory for group lan, got: %v", ValidateConfig(cfg))
+	}
+	if !strings.Contains(warn, "forward-only") || !strings.Contains(warn, "relay-agent-option") {
+		t.Errorf("advisory missing an accepted-only knob: %s", warn)
+	}
+	// maximum-hop-count is enforced — it must not appear in the accepted-only
+	// advisory.
+	if strings.Contains(warn, "maximum-hop-count") {
+		t.Errorf("maximum-hop-count is enforced and must not be in the accepted-only advisory: %s", warn)
 	}
 }

--- a/pkg/config/compiler_interfaces.go
+++ b/pkg/config/compiler_interfaces.go
@@ -75,6 +75,24 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig) error {
 			ifc.FlexibleVlanTagging = true
 		}
 
+		// #4308 (fable-review-167 I-3): accepted-only interface-level parity
+		// knobs — typed + compiled so they stop silently vanishing, with a
+		// commit-time advisory (validateInterfaceParityWarnings) noting they
+		// are not enforced yet.
+		if nvNode := child.FindChild("native-vlan-id"); nvNode != nil {
+			if v := nodeVal(nvNode); v != "" {
+				if n, err := strconv.Atoi(v); err == nil {
+					ifc.NativeVlanID = n
+				}
+			}
+		}
+		if child.FindChild("gratuitous-arp-reply") != nil {
+			ifc.GratuitousARPReply = true
+		}
+		if child.FindChild("no-gratuitous-arp-request") != nil {
+			ifc.NoGratuitousARPRequest = true
+		}
+
 		// Check for encapsulation
 		if encapNode := child.FindChild("encapsulation"); encapNode != nil {
 			ifc.Encapsulation = nodeVal(encapNode)
@@ -387,6 +405,17 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig) error {
 							if outputNode := filterNode.FindChild("output"); outputNode != nil {
 								unit.FilterOutputV4 = nodeVal(outputNode)
 							}
+						}
+						// #4308 (fable-review-167 I-3): accepted-only family
+						// inet parity knobs — typed + compiled so they stop
+						// silently vanishing, with a commit-time advisory
+						// (validateInterfaceParityWarnings) noting they are not
+						// enforced yet.
+						if unNode := afNode.FindChild("unnumbered-address"); unNode != nil {
+							unit.UnnumberedInet = nodeVal(unNode)
+						}
+						if afNode.FindChild("targeted-broadcast") != nil {
+							unit.TargetedBroadcast = true
 						}
 						// Surface A router/interface-address DDNS (#2691 P2): the
 						// per-family `dynamic-dns` binding may appear as a child node

--- a/pkg/config/compiler_protocols.go
+++ b/pkg/config/compiler_protocols.go
@@ -834,6 +834,18 @@ func compileRouterAdvertisement(node *Node, proto *ProtocolsConfig) error {
 						ra.LinkMTU = n
 					}
 				}
+			case "reachable-time":
+				if v := nodeVal(prop); v != "" {
+					if n, err := strconv.Atoi(v); err == nil {
+						ra.ReachableTime = n
+					}
+				}
+			case "retransmit-timer":
+				if v := nodeVal(prop); v != "" {
+					if n, err := strconv.Atoi(v); err == nil {
+						ra.RetransTimer = n
+					}
+				}
 			case "dns-server-address":
 				if len(prop.Keys) >= 2 {
 					ra.DNSServers = append(ra.DNSServers, nodeVal(prop))

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -1596,12 +1596,26 @@ func compileDHCPRelay(node *Node, fo *ForwardingOptionsConfig) error {
 				// Inline flat-set spelling (#2076):
 				// `group g overrides always-broadcast`. Consume the
 				// override sub-keywords until the next group property.
+				// #4309: forward-only / relay-agent-option are flags;
+				// maximum-hop-count consumes a following value token.
 				for i+1 < len(keys) && keys[i+1] != "interface" &&
 					keys[i+1] != "active-server-group" &&
 					keys[i+1] != "overrides" {
 					i++
-					if keys[i] == "always-broadcast" {
+					switch keys[i] {
+					case "always-broadcast":
 						g.AlwaysBroadcast = true
+					case "forward-only":
+						g.ForwardOnly = true
+					case "relay-agent-option":
+						g.RelayAgentOption = true
+					case "maximum-hop-count":
+						if i+1 < len(keys) {
+							i++
+							if n, err := strconv.Atoi(keys[i]); err == nil {
+								g.MaximumHopCount = n
+							}
+						}
 					}
 				}
 			}
@@ -1627,14 +1641,41 @@ func compileDHCPRelay(node *Node, fo *ForwardingOptionsConfig) error {
 				g.ActiveServerGroup = nodeVal(prop)
 			case "overrides":
 				// Block form (#2076): `overrides { always-broadcast; }`.
-				// always-broadcast may also ride in Keys[1:] when the
-				// override block collapses to a single inline value.
-				if prop.FindChild("always-broadcast") != nil {
-					g.AlwaysBroadcast = true
-				}
-				for _, k := range prop.Keys[1:] {
-					if k == "always-broadcast" {
+				// #4309 adds forward-only / relay-agent-option (flags) and
+				// maximum-hop-count (value). Each may appear as a child node
+				// OR ride in Keys[1:] when the override block collapses to
+				// inline values.
+				for _, oc := range prop.Children {
+					switch oc.Name() {
+					case "always-broadcast":
 						g.AlwaysBroadcast = true
+					case "forward-only":
+						g.ForwardOnly = true
+					case "relay-agent-option":
+						g.RelayAgentOption = true
+					case "maximum-hop-count":
+						if v := nodeVal(oc); v != "" {
+							if n, err := strconv.Atoi(v); err == nil {
+								g.MaximumHopCount = n
+							}
+						}
+					}
+				}
+				for i := 1; i < len(prop.Keys); i++ {
+					switch prop.Keys[i] {
+					case "always-broadcast":
+						g.AlwaysBroadcast = true
+					case "forward-only":
+						g.ForwardOnly = true
+					case "relay-agent-option":
+						g.RelayAgentOption = true
+					case "maximum-hop-count":
+						if i+1 < len(prop.Keys) {
+							i++
+							if n, err := strconv.Atoi(prop.Keys[i]); err == nil {
+								g.MaximumHopCount = n
+							}
+						}
 					}
 				}
 			}

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -1223,6 +1223,74 @@ func ValidateConfig(cfg *Config) []string {
 	// matrix.md "to-zone junos-host and the direct host-bound path".
 	warnings = append(warnings, validateJunosHostDirectDeliveryWarnings(cfg)...)
 
+	// #4308 (fable-review-167 I-3): interface parity knobs that are typed +
+	// compiled so they stop silently vanishing, but are ACCEPTED-ONLY today.
+	warnings = append(warnings, validateInterfaceParityWarnings(cfg)...)
+
+	return warnings
+}
+
+// validateInterfaceParityWarnings emits WARN-only commit-time advisories for
+// the #4308 (fable-review-167 I-3) interface knobs. Each is typed in the
+// schema and compiled into the typed config so it no longer silently vanishes,
+// but the runtime does not enforce it yet: native-vlan-id needs the QinQ
+// tagging pipeline (#2354); unnumbered-address needs a networkd borrow-address
+// implementation; the gratuitous-ARP knobs map to per-interface sysctls the
+// apply path does not write; targeted-broadcast needs dataplane directed-
+// broadcast forwarding. The advisory mirrors the #2078 accepted-only doctrine
+// so an operator who sets one is not misled into believing it has effect.
+// Interfaces are reported in sorted order for a deterministic message.
+func validateInterfaceParityWarnings(cfg *Config) []string {
+	if cfg.Interfaces.Interfaces == nil {
+		return nil
+	}
+	names := make([]string, 0, len(cfg.Interfaces.Interfaces))
+	for name := range cfg.Interfaces.Interfaces {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var warnings []string
+	for _, name := range names {
+		ifc := cfg.Interfaces.Interfaces[name]
+		if ifc == nil {
+			continue
+		}
+		var knobs []string
+		if ifc.NativeVlanID != 0 {
+			knobs = append(knobs, "native-vlan-id")
+		}
+		if ifc.GratuitousARPReply {
+			knobs = append(knobs, "gratuitous-arp-reply")
+		}
+		if ifc.NoGratuitousARPRequest {
+			knobs = append(knobs, "no-gratuitous-arp-request")
+		}
+		// family inet knobs live per-unit; report them qualified so the
+		// operator can find the offending unit.
+		unitNums := make([]int, 0, len(ifc.Units))
+		for un := range ifc.Units {
+			unitNums = append(unitNums, un)
+		}
+		sort.Ints(unitNums)
+		for _, un := range unitNums {
+			unit := ifc.Units[un]
+			if unit == nil {
+				continue
+			}
+			if unit.UnnumberedInet != "" {
+				knobs = append(knobs, fmt.Sprintf("unit %d family inet unnumbered-address", un))
+			}
+			if unit.TargetedBroadcast {
+				knobs = append(knobs, fmt.Sprintf("unit %d family inet targeted-broadcast", un))
+			}
+		}
+		if len(knobs) > 0 {
+			warnings = append(warnings, fmt.Sprintf(
+				"interfaces %s: %s configured but accepted-only — typed and stored but not enforced by the runtime yet (parity, #4308)",
+				name, strings.Join(knobs, ", ")))
+		}
+	}
 	return warnings
 }
 

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -1227,6 +1227,50 @@ func ValidateConfig(cfg *Config) []string {
 	// compiled so they stop silently vanishing, but are ACCEPTED-ONLY today.
 	warnings = append(warnings, validateInterfaceParityWarnings(cfg)...)
 
+	// #4309 (fable-review-167 I-4): DHCP relay overrides accepted-only advisory.
+	warnings = append(warnings, validateDHCPRelayParityWarnings(cfg)...)
+
+	return warnings
+}
+
+// validateDHCPRelayParityWarnings emits WARN-only commit-time advisories for
+// the #4309 (fable-review-167 I-4) DHCP relay override knobs that are
+// accepted-only. maximum-hop-count is ENFORCED (the relay's hop limit) so it
+// gets no advisory; forward-only and relay-agent-option are typed + compiled
+// so they stop silently vanishing but the relay already behaves as they
+// request (it forwards statelessly and always inserts Option 82), so the
+// advisory tells the operator the knob is accepted and matches the default.
+// Groups are reported in sorted order for a deterministic message.
+func validateDHCPRelayParityWarnings(cfg *Config) []string {
+	relay := cfg.ForwardingOptions.DHCPRelay
+	if relay == nil || len(relay.Groups) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(relay.Groups))
+	for name := range relay.Groups {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var warnings []string
+	for _, name := range names {
+		g := relay.Groups[name]
+		if g == nil {
+			continue
+		}
+		var knobs []string
+		if g.ForwardOnly {
+			knobs = append(knobs, "forward-only (the relay already forwards statelessly)")
+		}
+		if g.RelayAgentOption {
+			knobs = append(knobs, "relay-agent-option (Option 82 circuit-id is always inserted)")
+		}
+		if len(knobs) > 0 {
+			warnings = append(warnings, fmt.Sprintf(
+				"forwarding-options dhcp-relay group %s: %s configured but accepted-only — accepted and matches the relay's default behavior (#4309)",
+				name, strings.Join(knobs, ", ")))
+		}
+	}
 	return warnings
 }
 

--- a/pkg/config/interface_parity_4308_test.go
+++ b/pkg/config/interface_parity_4308_test.go
@@ -1,0 +1,116 @@
+package config
+
+// Regression tests for #4308 (fable-review-167 I-3): five common Junos
+// interface knobs were accepted by the permissive parser but never modeled or
+// compiled, so they silently vanished at commit. They are now typed leaves,
+// compiled into the typed config, and surface a commit-time accepted-only
+// advisory (the #2078 doctrine) instead of being silently dropped.
+//
+// RED-on-revert: drop the compiler assignments and each field reads back its
+// zero value (the silent-drop); drop the validateInterfaceParityWarnings call
+// and the advisory disappears.
+
+import (
+	"strings"
+	"testing"
+)
+
+func compileTreeFromSet(t *testing.T, lines []string) *Config {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	// The knobs must also pass strict schema validation (typed leaves).
+	if err := SchemaValidate(tree, cfg); err != nil {
+		t.Fatalf("SchemaValidate rejected the interface parity knobs: %v", err)
+	}
+	return cfg
+}
+
+// The knobs must survive compile (not silently dropped) and validate.
+func TestInterfaceParityKnobsCompile_4308(t *testing.T) {
+	cfg := compileTreeFromSet(t, []string{
+		"set interfaces ge-0-0-0 native-vlan-id 100",
+		"set interfaces ge-0-0-0 gratuitous-arp-reply",
+		"set interfaces ge-0-0-0 no-gratuitous-arp-request",
+		"set interfaces ge-0-0-0 unit 0 family inet unnumbered-address lo0.0",
+		"set interfaces ge-0-0-0 unit 0 family inet targeted-broadcast",
+	})
+
+	ifc := cfg.Interfaces.Interfaces["ge-0-0-0"]
+	if ifc == nil {
+		t.Fatal("missing interface ge-0-0-0")
+	}
+	if ifc.NativeVlanID != 100 {
+		t.Errorf("native-vlan-id = %d, want 100", ifc.NativeVlanID)
+	}
+	if !ifc.GratuitousARPReply {
+		t.Error("gratuitous-arp-reply not compiled")
+	}
+	if !ifc.NoGratuitousARPRequest {
+		t.Error("no-gratuitous-arp-request not compiled")
+	}
+	unit := ifc.Units[0]
+	if unit == nil {
+		t.Fatal("missing unit 0")
+	}
+	if unit.UnnumberedInet != "lo0.0" {
+		t.Errorf("unnumbered-address = %q, want lo0.0", unit.UnnumberedInet)
+	}
+	if !unit.TargetedBroadcast {
+		t.Error("targeted-broadcast not compiled")
+	}
+}
+
+// Each configured knob must surface an accepted-only advisory at commit.
+func TestInterfaceParityKnobsAdvisory_4308(t *testing.T) {
+	cfg := compileTreeFromSet(t, []string{
+		"set interfaces ge-0-0-0 native-vlan-id 100",
+		"set interfaces ge-0-0-0 gratuitous-arp-reply",
+		"set interfaces ge-0-0-0 no-gratuitous-arp-request",
+		"set interfaces ge-0-0-0 unit 0 family inet unnumbered-address lo0.0",
+		"set interfaces ge-0-0-0 unit 0 family inet targeted-broadcast",
+	})
+
+	var warn string
+	for _, w := range ValidateConfig(cfg) {
+		if strings.Contains(w, "#4308") && strings.Contains(w, "ge-0-0-0") {
+			warn = w
+		}
+	}
+	if warn == "" {
+		t.Fatalf("expected a #4308 accepted-only advisory for ge-0-0-0, got: %v", ValidateConfig(cfg))
+	}
+	for _, knob := range []string{
+		"native-vlan-id", "gratuitous-arp-reply", "no-gratuitous-arp-request",
+		"unnumbered-address", "targeted-broadcast",
+	} {
+		if !strings.Contains(warn, knob) {
+			t.Errorf("advisory missing %q: %s", knob, warn)
+		}
+	}
+}
+
+// An interface with none of the knobs must NOT trigger the advisory (guards
+// against a false-positive warning firing on every interface).
+func TestInterfaceParityNoAdvisoryWhenUnset_4308(t *testing.T) {
+	cfg := compileTreeFromSet(t, []string{
+		"set interfaces ge-0-0-0 unit 0 family inet address 10.0.1.1/24",
+	})
+	for _, w := range ValidateConfig(cfg) {
+		if strings.Contains(w, "#4308") {
+			t.Fatalf("unexpected #4308 advisory for a plain interface: %s", w)
+		}
+	}
+}

--- a/pkg/config/parser_routing_test.go
+++ b/pkg/config/parser_routing_test.go
@@ -595,7 +595,7 @@ func TestForwardingInstanceType(t *testing.T) {
 
 func TestRouterAdvertisement(t *testing.T) {
 	tree := &ConfigTree{}
-	setCommands := []string{"set protocols router-advertisement interface vlan100 managed-configuration", "set protocols router-advertisement interface vlan100 other-stateful-configuration", "set protocols router-advertisement interface vlan100 default-lifetime 1800", "set protocols router-advertisement interface vlan100 max-advertisement-interval 600", "set protocols router-advertisement interface vlan100 link-mtu 1500", "set protocols router-advertisement interface vlan100 prefix 2001:db8:1::/64 on-link", "set protocols router-advertisement interface vlan100 prefix 2001:db8:1::/64 autonomous", "set protocols router-advertisement interface vlan100 dns-server-address 2001:db8::53", "set protocols router-advertisement interface vlan100 dns-server-address 2001:db8::54", "set protocols router-advertisement interface vlan100 nat64prefix 64:ff9b::/96", "set protocols router-advertisement interface vlan200 prefix 2001:db8:2::/64"}
+	setCommands := []string{"set protocols router-advertisement interface vlan100 managed-configuration", "set protocols router-advertisement interface vlan100 other-stateful-configuration", "set protocols router-advertisement interface vlan100 default-lifetime 1800", "set protocols router-advertisement interface vlan100 max-advertisement-interval 600", "set protocols router-advertisement interface vlan100 link-mtu 1500", "set protocols router-advertisement interface vlan100 reachable-time 30000", "set protocols router-advertisement interface vlan100 retransmit-timer 1000", "set protocols router-advertisement interface vlan100 prefix 2001:db8:1::/64 on-link", "set protocols router-advertisement interface vlan100 prefix 2001:db8:1::/64 autonomous", "set protocols router-advertisement interface vlan100 dns-server-address 2001:db8::53", "set protocols router-advertisement interface vlan100 dns-server-address 2001:db8::54", "set protocols router-advertisement interface vlan100 nat64prefix 64:ff9b::/96", "set protocols router-advertisement interface vlan200 prefix 2001:db8:2::/64"}
 	for _, cmd := range setCommands {
 		path, err := ParseSetCommand(cmd)
 		if err != nil {
@@ -633,6 +633,14 @@ func TestRouterAdvertisement(t *testing.T) {
 	}
 	if ra100.LinkMTU != 1500 {
 		t.Errorf("vlan100: link-mtu = %d", ra100.LinkMTU)
+	}
+	// #4307 (I-2): reachable-time / retransmit-timer must survive compile.
+	// Before the leaves existed both were silently dropped and stayed 0.
+	if ra100.ReachableTime != 30000 {
+		t.Errorf("vlan100: reachable-time = %d, want 30000", ra100.ReachableTime)
+	}
+	if ra100.RetransTimer != 1000 {
+		t.Errorf("vlan100: retransmit-timer = %d, want 1000", ra100.RetransTimer)
 	}
 	if len(ra100.Prefixes) != 1 || ra100.Prefixes[0].Prefix != "2001:db8:1::/64" {
 		t.Errorf("vlan100: prefixes = %+v", ra100.Prefixes)

--- a/pkg/config/schema_interfaces.go
+++ b/pkg/config/schema_interfaces.go
@@ -47,7 +47,17 @@ var schemaInterfaces = &schemaNode{desc: "Interface configuration", wildcard: &s
 	"disable":               {desc: "Disable this interface", children: nil},
 	"vlan-tagging":          {desc: "Enable 802.1Q VLAN tagging", children: nil},
 	"flexible-vlan-tagging": {desc: "Enable flexible 802.1Q VLAN tagging (QinQ)", children: nil},
-	"encapsulation":         {desc: "Physical link-layer encapsulation", args: 1, children: nil},
+	// #4308 (fable-review-167 I-3): typed + compiled so they stop silently
+	// vanishing, but ACCEPTED-ONLY today (a commit-time advisory warns each
+	// is not enforced). native-vlan-id folds into the QinQ tagging pipeline
+	// (#2354); the gratuitous-ARP knobs map to per-interface sysctls the
+	// apply path does not yet write. See validateInterfaceParityWarnings.
+	"native-vlan-id": {desc: "VLAN ID for untagged frames on a trunk (accepted-only, not yet enforced — #4308)", args: 1, placeholder: "<number>",
+		valueType: ValueInteger, valueDesc: "802.1Q native VLAN ID (1..4094)",
+		valueExamples: []string{"1", "100"}, validator: ValidateInteger(1, 4094), children: nil},
+	"gratuitous-arp-reply":      {desc: "Reply to gratuitous ARP requests (accepted-only, not yet enforced — #4308)", children: nil},
+	"no-gratuitous-arp-request": {desc: "Suppress sending gratuitous ARP requests (accepted-only, not yet enforced — #4308)", children: nil},
+	"encapsulation":             {desc: "Physical link-layer encapsulation", args: 1, children: nil},
 	"gigether-options": {desc: "Gigabit Ethernet interface options", children: map[string]*schemaNode{
 		"redundant-parent": {desc: "Parent of this redundant interface", args: 1, children: nil},
 		"802.3ad":          {desc: "Link aggregation group", args: 1, children: nil},
@@ -102,6 +112,15 @@ var schemaInterfaces = &schemaNode{desc: "Interface configuration", wildcard: &s
 		"tunnel": {desc: "Tunnel parameters", children: tunnelSchemaChildren()},
 		"family": {desc: "Protocol family", compoundKey: true, children: map[string]*schemaNode{
 			"inet": {desc: "IPv4 protocol", children: map[string]*schemaNode{
+				// #4308 (fable-review-167 I-3): typed + compiled so they stop
+				// silently vanishing, but ACCEPTED-ONLY today (commit-time
+				// advisory). unnumbered-address needs a networkd
+				// borrow-address implementation; targeted-broadcast needs
+				// dataplane directed-broadcast forwarding. See
+				// validateInterfaceParityWarnings.
+				"unnumbered-address": {desc: "Borrow another interface's address (accepted-only, not yet enforced — #4308)", args: 1, placeholder: "<interface>",
+					valueHint: ValueHintInterfaceName, children: nil},
+				"targeted-broadcast": {desc: "Forward directed broadcasts to the subnet (accepted-only, not yet enforced — #4308)", children: nil},
 				// Compiled verbatim (compiler_interfaces.go:539); same
 				// pass-through contract as the interface-level mtu.
 				"mtu": {

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -247,6 +247,13 @@ const (
 	// 32-bit seconds fields (0xffffffff = infinity). A larger value silently
 	// truncates in ndp's uint32(lifetime); bound at the 32-bit maximum.
 	raPrefixMaxLifetimeSeconds = 4294967295
+	// RFC 4861 §4.2: the RA header Reachable Time and Retrans Timer are
+	// 32-bit unsigned millisecond fields. The RA sender marshals them via
+	// ndp as time.Duration/time.Millisecond -> uint32, so a larger value
+	// silently wraps on the wire. Bound both at the 32-bit millisecond
+	// maximum; 0 is the RFC "unspecified" sentinel (host uses its own
+	// defaults) and is the pre-existing behavior.
+	raReachableRetransMaxMillis = 4294967295
 )
 
 var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map[string]*schemaNode{
@@ -471,6 +478,17 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 			"link-mtu": {desc: "Link MTU option advertised to hosts", args: 1, placeholder: "<mtu>",
 				valueType: ValueInteger, valueDesc: "advertised link MTU (RFC 8200 §5 minimum 1280)",
 				valueExamples: []string{"1280", "1500"}, validator: ValidateIntegerMin(1280), children: nil},
+			// #4307 (I-2): the RFC 4861 §4.2 Reachable Time / Retrans Timer
+			// header fields. Both are 32-bit millisecond values the sender
+			// emits verbatim on the RA; before this leaf existed they were
+			// silently dropped and went on the wire as 0 ("unspecified"), so
+			// hosts could not be tuned. 0 keeps the unspecified default.
+			"reachable-time": {desc: "Reachable Time advertised to hosts (milliseconds; 0 = unspecified)", args: 1, placeholder: "<milliseconds>",
+				valueType: ValueInteger, valueDesc: "RFC 4861 §4.2 Reachable Time in milliseconds (0 = unspecified)",
+				valueExamples: []string{"0", "30000"}, validator: ValidateInteger(0, raReachableRetransMaxMillis), children: nil},
+			"retransmit-timer": {desc: "Retrans Timer advertised to hosts (milliseconds; 0 = unspecified)", args: 1, placeholder: "<milliseconds>",
+				valueType: ValueInteger, valueDesc: "RFC 4861 §4.2 Retrans Timer in milliseconds (0 = unspecified)",
+				valueExamples: []string{"0", "1000"}, validator: ValidateInteger(0, raReachableRetransMaxMillis), children: nil},
 			// #2497: each address is appended to an RFC 8106 RecursiveDNSServer
 			// (RDNSS) option, which is IPv6-only. The runtime skips an
 			// unparseable string but does NOT family-gate, so a bare IPv4

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -649,6 +649,16 @@ var schemaForwardingOptions = &schemaNode{desc: "Packet forwarding options", chi
 			"interface":           {desc: "Interface to relay on", args: 1, multi: true, placeholder: "<interface>", children: nil},
 			"overrides": {desc: "Relay overrides", children: map[string]*schemaNode{
 				"always-broadcast": {desc: "Always broadcast replies to clients", children: nil},
+				// #4309 (fable-review-167 I-4): maximum-hop-count is enforced
+				// (the relay's RFC 1542 §4.1.1 loop-protection hop limit,
+				// previously hardcoded at 16). forward-only and
+				// relay-agent-option are accepted-only (a commit-time advisory
+				// notes each matches the relay's existing default behavior).
+				"maximum-hop-count": {desc: "Drop relayed requests whose hop count reaches this limit", args: 1, placeholder: "<count>",
+					valueType: ValueInteger, valueDesc: "relay hop limit (RFC 1542 §4.1.1; 1..16)",
+					valueExamples: []string{"4", "16"}, validator: ValidateInteger(1, 16), children: nil},
+				"forward-only":       {desc: "Forward without retaining relay state (accepted-only; matches default — #4309)", children: nil},
+				"relay-agent-option": {desc: "Insert Option 82 relay agent information (accepted-only; always inserted — #4309)", children: nil},
 			}},
 		}},
 	}},

--- a/pkg/config/types_interfaces.go
+++ b/pkg/config/types_interfaces.go
@@ -29,6 +29,15 @@ type InterfaceConfig struct {
 	AggregatedEtherOpts *AggregatedEtherOptions // ae interface options (LACP, etc.)
 	Units               map[int]*InterfaceUnit
 	Tunnel              *TunnelConfig // non-nil for tunnel interfaces (gre0, etc.)
+	// #4308 (fable-review-167 I-3): parity knobs that are typed + compiled
+	// so they stop silently vanishing, but are ACCEPTED-ONLY today (a
+	// commit-time advisory warns they are not enforced). native-vlan-id
+	// needs the QinQ tagging pipeline (#2354); the gratuitous-ARP knobs
+	// map to per-interface sysctls not yet written by the interface apply
+	// path. See validateInterfaceParityWarnings.
+	NativeVlanID           int  // native-vlan-id <id> (0 = unset) — accepted-only (#4308)
+	GratuitousARPReply     bool // gratuitous-arp-reply — accepted-only (#4308)
+	NoGratuitousARPRequest bool // no-gratuitous-arp-request — accepted-only (#4308)
 }
 
 // AggregatedEtherOptions defines LAG/ae interface parameters.
@@ -55,15 +64,22 @@ type InterfaceUnit struct {
 	DHCPOptions      *DHCPInetOptions // dhcp sub-options (lease-time, etc.)
 	DHCPv6           bool             // family inet6 { dhcpv6; }
 	DHCPv6Client     *DHCPv6ClientConfig
-	DADDisable       bool                  // family inet6 { dad-disable; }
-	SamplingInput    bool                  // family inet/inet6 { sampling { input; } }
-	SamplingOutput   bool                  // family inet/inet6 { sampling { output; } }
-	FilterInputV4    string                // family inet { filter { input NAME; } }
-	FilterOutputV4   string                // family inet { filter { output NAME; } }
-	FilterInputV6    string                // family inet6 { filter { input NAME; } }
-	FilterOutputV6   string                // family inet6 { filter { output NAME; } }
-	VRRPGroups       map[string]*VRRPGroup // keyed by address (CIDR), each address can have VRRP groups
-	Tunnel           *TunnelConfig         // per-unit tunnel config (for multi-unit GRE/IPIP)
+	DADDisable       bool // family inet6 { dad-disable; }
+	// #4308 (fable-review-167 I-3): family inet parity knobs, typed +
+	// compiled so they stop silently vanishing but ACCEPTED-ONLY today
+	// (commit-time advisory; see validateInterfaceParityWarnings).
+	// unnumbered-address needs a networkd borrow-address implementation;
+	// targeted-broadcast needs dataplane directed-broadcast forwarding.
+	UnnumberedInet    string                // family inet unnumbered-address <donor> — accepted-only (#4308)
+	TargetedBroadcast bool                  // family inet targeted-broadcast — accepted-only (#4308)
+	SamplingInput     bool                  // family inet/inet6 { sampling { input; } }
+	SamplingOutput    bool                  // family inet/inet6 { sampling { output; } }
+	FilterInputV4     string                // family inet { filter { input NAME; } }
+	FilterOutputV4    string                // family inet { filter { output NAME; } }
+	FilterInputV6     string                // family inet6 { filter { input NAME; } }
+	FilterOutputV6    string                // family inet6 { filter { output NAME; } }
+	VRRPGroups        map[string]*VRRPGroup // keyed by address (CIDR), each address can have VRRP groups
+	Tunnel            *TunnelConfig         // per-unit tunnel config (for multi-unit GRE/IPIP)
 	// DynamicDNSInet / DynamicDNSInet6 are the per-family Surface A
 	// router/interface-address DDNS bindings (#2691 P2, plan §5.9): publish
 	// THIS interface unit's learned v4 / v6 address as a configured FQDN through

--- a/pkg/config/types_routing.go
+++ b/pkg/config/types_routing.go
@@ -340,6 +340,11 @@ type RAInterfaceConfig struct {
 	NAT64PrefixLife    int      // PREF64 lifetime in seconds (0 = default)
 	LinkMTU            int      // advertised link MTU, 0 = omit
 	SourceLinkLocal    string   // explicit link-local to use as RA source (overrides auto-selected)
+	// ReachableTime / RetransTimer are the RFC 4861 §4.2 RA header fields,
+	// in milliseconds (#4307). 0 = "unspecified" (host uses its own
+	// default), which is the pre-#4307 wire behavior.
+	ReachableTime int // reachable-time (ms), 0 = unspecified
+	RetransTimer  int // retransmit-timer (ms), 0 = unspecified
 }
 
 // RAPrefix defines a prefix advertised via RA.

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -901,6 +901,18 @@ type DHCPRelayGroup struct {
 	// client's broadcast flag and raw-L2-unicasts flag-clear replies to
 	// chaddr+yiaddr (#2076).
 	AlwaysBroadcast bool
+	// #4309 (fable-review-167 I-4): additional relay overrides.
+	//
+	// MaximumHopCount is the RFC 1542 §4.1.1 loop-protection hop limit —
+	// the relay drops a client request whose hops field has reached this
+	// value. 0 = unset = the pre-#4309 hardcoded default (16). ENFORCED.
+	MaximumHopCount int
+	// ForwardOnly / RelayAgentOption are ACCEPTED-ONLY (a commit-time
+	// advisory notes each matches the relay's existing default behavior):
+	// the xpf relay already forwards statelessly (no persistent per-client
+	// binding), and it always inserts Option 82 (circuit-id).
+	ForwardOnly      bool
+	RelayAgentOption bool
 }
 
 // SamplingConfig holds sampling instance definitions.

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -174,6 +174,30 @@ inline-interface consumer treats `overrides` as a property boundary so it
 is not swallowed into the interface list (#2076 / dual-AST harness case
 `forwarding-options-dhcp-relay-overrides`).
 
+### Additional overrides (#4309)
+
+```
+set forwarding-options dhcp-relay group <g> overrides maximum-hop-count <1..16>
+set forwarding-options dhcp-relay group <g> overrides forward-only
+set forwarding-options dhcp-relay group <g> overrides relay-agent-option
+```
+
+- **`maximum-hop-count` — ENFORCED.** The relay drops a client request
+  whose BOOTP `hops` field has reached this value (RFC 1542 §4.1.1 loop
+  protection), and increments `RelayStats.RequestsDroppedMaxHops`.
+  Previously the limit was hardcoded at 16; that stays the default when
+  the override is unset (`resolveMaxHopCount`). Compiles to
+  `DHCPRelayGroup.MaximumHopCount` and flows into `relaySpec.maxHopCount`
+  (a change restarts the per-interface relay).
+- **`forward-only` — accepted-only.** The xpf relay already forwards
+  statelessly (no persistent per-client binding), so this matches the
+  default behavior. Typed + compiled so it stops silently vanishing; a
+  commit-time advisory (`validateDHCPRelayParityWarnings`) notes it is
+  accepted and inert.
+- **`relay-agent-option` — accepted-only.** The relay ALWAYS inserts
+  Option 82 (`circuit-id`); this knob is accepted and matches the
+  default, with the same accepted-only advisory.
+
 ### IPv6 / DHCPv6 parity
 
 There is **no DHCPv6 relay agent** in the codebase, and DHCPv6 (RFC 8415)

--- a/pkg/dhcprelay/relay.go
+++ b/pkg/dhcprelay/relay.go
@@ -28,6 +28,23 @@ const relayPort = 67
 // clientPort is the standard DHCP client port.
 const clientPort = 68
 
+// defaultMaxHopCount is the RFC 1542 §4.1.1 relay hop limit applied when a
+// group does not configure `overrides maximum-hop-count`. A client request
+// whose hops field has reached this value is dropped for loop protection.
+// This preserves the historical hardcoded limit (#4309).
+const defaultMaxHopCount uint8 = 16
+
+// resolveMaxHopCount maps a configured hop limit to the value the relay
+// enforces: 0 (unset) or out-of-range falls back to defaultMaxHopCount. The
+// schema bounds the leaf to 1..16 (`ValidateInteger(1, 16)`), so the clamp
+// only backstops a config that predates the bound (e.g. a loaded active.json).
+func resolveMaxHopCount(n int) uint8 {
+	if n <= 0 || n > int(defaultMaxHopCount) {
+		return defaultMaxHopCount
+	}
+	return uint8(n)
+}
+
 // readBufSize is the size of the per-loop read buffer for both the
 // client-facing and server-facing UDP sockets.
 //
@@ -115,6 +132,11 @@ type RelayStats struct {
 	// BACKUP for the interface's redundancy group (#2456 HA relay gate).
 	RequestsDroppedBackup uint64
 
+	// RequestsDroppedMaxHops counts client requests dropped because their hops
+	// field reached the group's `overrides maximum-hop-count` limit (default
+	// 16) — the RFC 1542 §4.1.1 loop-protection drop (#4309).
+	RequestsDroppedMaxHops uint64
+
 	// RepliesDroppedUnknownServer counts server replies dropped because their
 	// source IP is NOT one of the configured DHCP servers (#4163). The
 	// server-facing socket is bound (not connected), so it accepts datagrams
@@ -157,11 +179,19 @@ type l2Replier interface {
 type relaySpec struct {
 	servers         []string // server IPs in config order
 	alwaysBroadcast bool
+	// maxHopCount is the RFC 1542 §4.1.1 loop-protection hop limit (#4309):
+	// a client request whose hops field has reached this value is dropped.
+	// 0 = unset = the default (defaultMaxHopCount, 16). A change requires a
+	// fresh session, so it participates in equal().
+	maxHopCount int
 }
 
 // equal reports whether two specs would produce an identical relay session.
 func (s relaySpec) equal(o relaySpec) bool {
 	if s.alwaysBroadcast != o.alwaysBroadcast {
+		return false
+	}
+	if s.maxHopCount != o.maxHopCount {
 		return false
 	}
 	if len(s.servers) != len(o.servers) {
@@ -204,6 +234,17 @@ type interfaceRelay struct {
 	// alwaysBroadcast forces every reply to broadcast (overrides
 	// always-broadcast). Set once at start; read-only thereafter.
 	alwaysBroadcast bool
+
+	// maxHopCount is the resolved RFC 1542 §4.1.1 hop limit (#4309) — a
+	// client request whose hops field has reached it is dropped. Resolved
+	// from the group's overrides maximum-hop-count (default 16). Set once
+	// at start; read-only thereafter.
+	maxHopCount uint8
+
+	// requestsDroppedMaxHops counts client requests dropped because their
+	// hops field reached maxHopCount (#4309). Observability for a relay loop
+	// or a misconfigured downstream relay chain.
+	requestsDroppedMaxHops atomic.Uint64
 
 	// Reply-delivery counters (#2076).
 	repliesL2Unicast           atomic.Uint64
@@ -559,6 +600,7 @@ func computeDesired(cfg *config.DHCPRelayConfig) map[string]desiredRelay {
 				spec: relaySpec{
 					servers:         serverIPs,
 					alwaysBroadcast: group.AlwaysBroadcast,
+					maxHopCount:     group.MaximumHopCount,
 				},
 				servers: serverAddrs,
 			}
@@ -637,6 +679,7 @@ func (m *Manager) Apply(ctx context.Context, cfg *config.DHCPRelayConfig) {
 			done:            make(chan struct{}),
 			spec:            d.spec,
 			alwaysBroadcast: d.spec.alwaysBroadcast,
+			maxHopCount:     resolveMaxHopCount(d.spec.maxHopCount),
 		}
 		m.relays[name] = ir
 		toStart = append(toStart, struct {
@@ -681,6 +724,7 @@ func (m *Manager) Stats() []RelayStats {
 			RequestsRelayed:             ir.requestsRelayed.Load(),
 			RepliesForwarded:            ir.repliesForwarded.Load(),
 			RequestsDroppedBackup:       ir.requestsDroppedBackup.Load(),
+			RequestsDroppedMaxHops:      ir.requestsDroppedMaxHops.Load(),
 			RepliesDroppedUnknownServer: ir.repliesDroppedUnknownServer.Load(),
 			RepliesL2Unicast:            ir.repliesL2Unicast.Load(),
 			RepliesUnicastCiaddr:        ir.repliesUnicastCiaddr.Load(),
@@ -1099,12 +1143,14 @@ func (m *Manager) runRelaySession(ctx context.Context,
 
 			// Enforce the RFC 1542 §4.1.1 hop limit BEFORE incrementing.
 			// HopCount is uint8: checking after a ++ lets an incoming value
-			// of 255 wrap to 0 and slip past a post-increment "> 16" test,
-			// defeating loop protection. A request that already carries 16
-			// hops has reached the limit and must be dropped.
-			if pkt.HopCount >= 16 {
+			// of 255 wrap to 0 and slip past a post-increment ">= limit"
+			// test, defeating loop protection. A request that already carries
+			// the limit has reached it and must be dropped. The limit is the
+			// group's `overrides maximum-hop-count` (default 16) — #4309.
+			if pkt.HopCount >= ir.maxHopCount {
+				ir.requestsDroppedMaxHops.Add(1)
 				slog.Warn("dhcp-relay: hop count exceeded, dropping",
-					"interface", ifaceName, "hops", pkt.HopCount)
+					"interface", ifaceName, "hops", pkt.HopCount, "limit", ir.maxHopCount)
 				continue
 			}
 			pkt.HopCount++

--- a/pkg/dhcprelay/relay_test.go
+++ b/pkg/dhcprelay/relay_test.go
@@ -373,6 +373,69 @@ func TestRunRelay_HopCountLimit(t *testing.T) {
 	}
 }
 
+// TestRunRelay_ConfiguredMaxHopCount asserts the #4309 configurable hop limit:
+// `overrides maximum-hop-count <n>` lowers the drop threshold from the default
+// 16, a request AT the configured limit is dropped, one below it is relayed,
+// and the drop increments RequestsDroppedMaxHops. RED-on-revert: with the hop
+// check pinned to the hardcoded 16 (or ir.maxHopCount unwired), the hops=4
+// request would relay instead of drop.
+func TestRunRelay_ConfiguredMaxHopCount(t *testing.T) {
+	cfg := singleInterfaceConfig()
+	cfg.Groups["g"].MaximumHopCount = 4
+
+	cases := []struct {
+		name        string
+		hops        uint8
+		wantRelayed bool
+	}{
+		{"below_configured_limit", 3, true},
+		{"at_configured_limit", 4, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := dhcpv4.New()
+			if err != nil {
+				t.Fatalf("dhcpv4.New: %v", err)
+			}
+			req.OpCode = dhcpv4.OpcodeBootRequest
+			req.ClientHWAddr = net.HardwareAddr{0x02, 0, 0, 0, 0, 1}
+			req.HopCount = tc.hops
+			req.UpdateOption(dhcpv4.OptMessageType(dhcpv4.MessageTypeRequest))
+
+			client := newFakeConn()
+			client.pending = [][]byte{req.ToBytes()}
+			server := newFakeConn()
+			factory, _ := recordingFactory(client, server)
+			m := testManager(factory)
+			m.Apply(context.Background(), cfg)
+			defer m.Stop()
+
+			deadline := time.Now().Add(1 * time.Second)
+			for client.readCalls.Load() < 2 && time.Now().Before(deadline) {
+				time.Sleep(time.Millisecond)
+			}
+
+			got := server.writeCount()
+			if tc.wantRelayed && got == 0 {
+				t.Fatalf("hops=%d limit=4: expected relay, got none", tc.hops)
+			}
+			if !tc.wantRelayed {
+				if got != 0 {
+					t.Fatalf("hops=%d limit=4: expected drop, but %d datagram(s) relayed", tc.hops, got)
+				}
+				// The drop must be counted.
+				var dropped uint64
+				for _, s := range m.Stats() {
+					dropped += s.RequestsDroppedMaxHops
+				}
+				if dropped == 0 {
+					t.Errorf("hops=%d limit=4: dropped but RequestsDroppedMaxHops stayed 0", tc.hops)
+				}
+			}
+		})
+	}
+}
+
 // --- Lifecycle test scaffolding (#1915) ---
 
 // fakeConn is a fake net.PacketConn whose ReadFrom blocks until Close (unless

--- a/pkg/ra/sender.go
+++ b/pkg/ra/sender.go
@@ -700,6 +700,12 @@ func (s *sender) buildRA() *ndp.RouterAdvertisement {
 		ManagedConfiguration: s.cfg.ManagedConfig,
 		OtherConfiguration:   s.cfg.OtherStateful,
 		RouterLifetime:       time.Duration(lifetime) * time.Second,
+		// RFC 4861 §4.2 Reachable Time / Retrans Timer (#4307). ndp
+		// marshals these as ms (Duration/time.Millisecond -> uint32); a
+		// configured 0 keeps the "unspecified" default the RA carried
+		// before these leaves existed.
+		ReachableTime:   time.Duration(s.cfg.ReachableTime) * time.Millisecond,
+		RetransmitTimer: time.Duration(s.cfg.RetransTimer) * time.Millisecond,
 	}
 
 	// Router selection preference.

--- a/pkg/ra/sender_marshal_4307_test.go
+++ b/pkg/ra/sender_marshal_4307_test.go
@@ -1,0 +1,84 @@
+package ra
+
+// Regression test for #4307 (fable-review-167 I-2): the RFC 4861 §4.2
+// Reachable Time and Retrans Timer header fields were never modeled or set,
+// so every RA went on the wire with both = 0 ("unspecified") and hosts could
+// not be tuned via RA. The sender now copies the configured milliseconds onto
+// the ndp.RouterAdvertisement, which marshals them as ms (Duration /
+// time.Millisecond -> uint32).
+//
+// RED-on-revert: drop the ReachableTime/RetransmitTimer assignments in
+// buildRA (or the ReachableTime/RetransTimer config fields) and the round-trip
+// reads back 0 for both — the silent-drop this issue fixes.
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/mdlayher/ndp"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func TestBuildRA_4307_ReachableAndRetransOnWire(t *testing.T) {
+	s := &sender{
+		cfg: &config.RAInterfaceConfig{
+			Interface:     "trust0",
+			ReachableTime: 30000, // ms
+			RetransTimer:  1000,  // ms
+		},
+		iface: &net.Interface{
+			Name:         "trust0",
+			HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+		},
+	}
+
+	ra := s.buildRA()
+	if ra.ReachableTime != 30000*time.Millisecond {
+		t.Errorf("ReachableTime = %v, want 30000ms", ra.ReachableTime)
+	}
+	if ra.RetransmitTimer != 1000*time.Millisecond {
+		t.Errorf("RetransmitTimer = %v, want 1000ms", ra.RetransmitTimer)
+	}
+
+	// Marshal + re-parse to confirm the values survive the wire encoding
+	// (ndp encodes them as 32-bit millisecond fields).
+	raw, err := ndp.MarshalMessage(ra)
+	if err != nil {
+		t.Fatalf("MarshalMessage: %v", err)
+	}
+	msg, err := ndp.ParseMessage(raw)
+	if err != nil {
+		t.Fatalf("ParseMessage: %v", err)
+	}
+	got, ok := msg.(*ndp.RouterAdvertisement)
+	if !ok {
+		t.Fatalf("parsed message is %T, want *ndp.RouterAdvertisement", msg)
+	}
+	if got.ReachableTime != 30000*time.Millisecond {
+		t.Errorf("wire ReachableTime = %v, want 30000ms", got.ReachableTime)
+	}
+	if got.RetransmitTimer != 1000*time.Millisecond {
+		t.Errorf("wire RetransmitTimer = %v, want 1000ms", got.RetransmitTimer)
+	}
+}
+
+// A config that omits both leaves keeps the pre-#4307 "unspecified" (0) wire
+// behavior — the fix must not perturb the default.
+func TestBuildRA_4307_UnsetStaysZero(t *testing.T) {
+	s := &sender{
+		cfg: &config.RAInterfaceConfig{Interface: "trust0"},
+		iface: &net.Interface{
+			Name:         "trust0",
+			HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+		},
+	}
+	ra := s.buildRA()
+	if ra.ReachableTime != 0 {
+		t.Errorf("ReachableTime = %v, want 0 (unspecified)", ra.ReachableTime)
+	}
+	if ra.RetransmitTimer != 0 {
+		t.Errorf("RetransmitTimer = %v, want 0 (unspecified)", ra.RetransmitTimer)
+	}
+}


### PR DESCRIPTION
Fixes three fable-review-167 findings — Junos knobs the permissive parser
accepted but the compiler silently dropped. Each is now typed + compiled,
and either enforced or accepted-with-advisory (the #2078 doctrine) so it
stops silently vanishing.

## I-2 (#4307) — RA reachable-time / retransmit-timer — IMPLEMENTED

The RFC 4861 §4.2 Reachable Time / Retrans Timer RA header fields had no
schema leaf, no config field, and the sender never set them → both went
on the wire as 0 ("unspecified"). Added typed millisecond leaves (bounded
at the 32-bit ms max so they cannot silently wrap in ndp's
`Duration/time.Millisecond -> uint32`), compiled into
`RAInterfaceConfig.ReachableTime` / `RetransTimer`, and set on the ndp RA
in `pkg/ra/sender.go buildRA`. 0 keeps the unspecified default.

## I-3 (#4308) — interface ARP/addressing knobs — ADVISED

Five knobs (`native-vlan-id`, `gratuitous-arp-reply`,
`no-gratuitous-arp-request` at interface level; `unnumbered-address`,
`targeted-broadcast` under family inet) are now typed schema leaves +
compiled fields + carry a per-interface accepted-only advisory
(`validateInterfaceParityWarnings`). Full enforcement is design/cluster
work (native-vlan-id → QinQ pipeline #2354; unnumbered-address → networkd
borrow; ARP knobs → per-interface sysctls; targeted-broadcast →
dataplane), so they are accepted-with-advisory for now.

## I-4 (#4309) — DHCP relay overrides — MIXED

- `maximum-hop-count <1..16>` — **IMPLEMENTED (enforced)**. The relay's
  hop limit was hardcoded at 16; it is now the group's configured value
  (default 16), a request at the limit is dropped, and a new
  `RelayStats.RequestsDroppedMaxHops` counts the drop.
- `forward-only` / `relay-agent-option` — **accepted-only**. The relay
  already forwards statelessly and always inserts Option 82, so each
  matches the default; typed + compiled with an accepted-only advisory
  (`validateDHCPRelayParityWarnings`).

## Validation

- `go test ./pkg/config/... ./pkg/ra/... ./pkg/networkd/...
  ./pkg/dhcprelay/... ./pkg/cli/...` green; `go build ./...` green;
  gofmt clean.
- RED-on-revert proven for every finding (dropping the emit/enforce path
  makes the value read back 0 / the request relay instead of drop; each
  proof recorded in the commit messages and _Log.md).
- Docs updated: `docs/embedded-radvd.md`, `docs/config-schema.md`,
  `pkg/dhcprelay/README.md`.

Closes #4307
Closes #4308
Closes #4309

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi