### PR TITLE
fable-167 C-1/F-2/F-3: CLI drill-downs + CoS traffic-control-profiles + filter/CoS schema parity

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -35535,3 +35535,48 @@ top.
 - **File(s)**: pkg/config/compiler_ipsec_proposalset.go,
   pkg/config/compiler_ipsec_hb167_parity_test.go, pkg/ipsec/README.md,
   _Log.md
+
+- **Timestamp**: 2026-07-05
+- **Action**: fable-167 findings C-1, F-2, F-3 (issues #4314/#4315/#4316).
+  **C-1 (CLI drill-downs):** added `show security ike/ipsec
+  security-associations detail`, `show security nat static rule [detail]`,
+  and `request security policies check` to the operational tree (cmdtree
+  SSOT) + handlers. IKE SA `detail` now renders TS/SPI/lifetime; static NAT
+  `rule detail` surfaces source restriction / mapped-port / prefix-name /
+  routing-instance (RenderStaticRule in pkg/natshow/static.go); `policies
+  check` is a conservative shadow/redundancy lint over zone-pair policies
+  (analyzePolicyShadowing, cli_request_policies_check.go). **F-2
+  (make-or-break):** modeled Junos hierarchical shaping —
+  `traffic-control-profiles <n> { shaping-rate; guaranteed-rate;
+  scheduler-map; delay-buffer-rate; }` + `output-traffic-control-profile`
+  at unit + interface level (schema_cos.go), captured on
+  ClassOfServiceConfig.TrafficControlProfiles + CoSInterfaceUnit.
+  OutputTrafficControlProfile (types_cos.go), and WIRED the bounded knobs:
+  resolveCoSTrafficControlProfiles folds shaping-rate + scheduler-map into
+  the per-unit shaper so shaping ACTUALLY applies (direct unit knob wins).
+  guaranteed-rate / delay-buffer-rate accepted-but-inert + dangling-ref =
+  commit advisories. This closes the silent zero-shaping: pre-fix the
+  binding committed clean and shaped nothing. **F-3 (schema gaps):**
+  `firewall filter interface-specific` (accepted-but-inert, single shared
+  counter advisory) + CoS `classifiers inet-precedence` and `rewrite-rules
+  inet-precedence`/`exp` (accepted-but-inert advisories).
+- **Validation**: go test ./pkg/config/ ./pkg/cli/ ./pkg/cmdtree/
+  ./pkg/natshow/ green; go build ./... clean; gofmt + vet clean on all
+  touched files (pre-existing cli.go:503 vet + 4 unrelated gofmt files
+  untouched). RED-on-revert proven for F-2 (unit shaping-rate = 0 without
+  resolveCoSTrafficControlProfiles) and via focused C-1/F-3 tests.
+  No cargo leg — F-2 wires into the existing per-unit shaper snapshot
+  (interfaces.go reads ShapingRateBytes/SchedulerMap), no userspace-dp
+  change; guaranteed-rate/delay-buffer-rate hierarchical enforcement is a
+  noted dataplane follow-up.
+- **File(s)**: pkg/cmdtree/tree.go, pkg/cmdtree/tree_hb167_test.go,
+  pkg/cli/cli_show_security_ipsec.go, pkg/cli/cli_show_nat.go,
+  pkg/cli/cli_show_nat_shared_test.go, pkg/cli/cli_request.go,
+  pkg/cli/cli_request_policies_check.go,
+  pkg/cli/cli_request_policies_check_test.go, pkg/natshow/static.go,
+  pkg/config/schema_cos.go, pkg/config/types_cos.go,
+  pkg/config/compiler_class_of_service.go, pkg/config/compiler.go,
+  pkg/config/compiler_validate_warn.go, pkg/config/types_system.go,
+  pkg/config/compiler_firewall.go, pkg/config/compiler_cos_tcp_hb167_test.go,
+  pkg/config/compiler_f3_hb167_test.go, docs/cos-traffic-shaping.md,
+  docs/config-schema.md, docs/junos-cli-reference.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -35745,3 +35745,23 @@ top.
   pkg/config/compiler_firewall.go, pkg/config/compiler_cos_tcp_hb167_test.go,
   pkg/config/compiler_f3_hb167_test.go, docs/cos-traffic-shaping.md,
   docs/config-schema.md, docs/junos-cli-reference.md, _Log.md
+
+- **Timestamp**: 2026-07-05
+- **Action**: fable-167 C-1c review MINOR fold on PR #4317. The `request
+  security policies check` lint (policyMatchIsSuperset) disqualified only
+  the EARLIER policy's excluded match sense, ignoring
+  source/destination-address-excluded on the LATER candidate-shadowed
+  policy — so earlier `permit source-address [A]` vs later `deny
+  source-address [A] source-address-excluded` (DISJOINT match sets, fully
+  reachable) was falsely reported SHADOWED/UNREACHABLE. Added a b-excluded
+  guard (both src + dst) in cli_request_policies_check.go so an inverted
+  sense on EITHER side returns not-a-superset (no-false-positive contract).
+  Also merged origin/master (10 commits incl. #4311 System / #4303 syslog);
+  unioned _Log.md + docs/config-schema.md (both additive).
+- **Validation**: new no-FP test green + proven RED under the guard revert
+  (both src+dst-excluded later policies falsely SHADOWED); genuine-shadow
+  case still reported. go test ./pkg/config/... ./pkg/cli/...
+  ./pkg/cmdtree/... ./pkg/natshow/... green; go build ./... clean;
+  gofmt + vet clean.
+- **File(s)**: pkg/cli/cli_request_policies_check.go,
+  pkg/cli/cli_request_policies_check_test.go, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -4673,3 +4673,42 @@ packed the whole line onto one leaf node and the compiler dropped it.
   per-day evaluation: `pkg/scheduler/scheduler_3849_test.go` and the
   updated `pkg/scheduler/scheduler_test.go`
   (`TestIsWithinWindow_NoWindowFailsClosed`).
+
+## fable-167 F-2 / F-3: CoS traffic-control-profiles + filter/CoS schema gaps
+
+**F-2 — hierarchical traffic-control-profiles (#4315).** The Junos
+hierarchical shaping binding is now modeled in `schemaClassOfService`
+(`schema_cos.go`) and **wired**:
+
+- `traffic-control-profiles <name>` — typed leaves `shaping-rate`,
+  `guaranteed-rate`, `delay-buffer-rate` (all `ValueRate` + `ValidateRate`)
+  and `scheduler-map`.
+- `output-traffic-control-profile <name>` — a binding leaf at BOTH the
+  interface-unit level and the interface level (mirroring `scheduler-map`).
+
+`resolveCoSTrafficControlProfiles` (`compiler_class_of_service.go`, called
+from `compiler.go` after `applyCoSInterfaceLevelBindings`) folds a bound
+profile's `shaping-rate` + `scheduler-map` into the referencing
+`CoSInterfaceUnit.ShapingRateBytes` / `SchedulerMap` — so the existing
+per-unit shaper enforces it. A **direct unit-level knob wins** over the
+profile. Before #4315 the whole binding was silently dropped (SchemaValidate
+ignores unknown keywords, no compiler read it) → a clean commit with **zero
+shaping**. `guaranteed-rate` / `delay-buffer-rate` are typed + captured but
+**accepted-but-inert** (no per-unit absolute reservation in the shaper); a
+commit advisory (`compiler_validate_warn.go`) surfaces the inertness, and a
+dangling `output-traffic-control-profile` reference also warns.
+
+**F-3a — firewall `interface-specific` (#4316).** Added as a presence flag
+under `firewall family {inet,inet6} filter <name>`; captured on
+`FirewallFilter.InterfaceSpecific`. It is **accepted-but-inert** — xpf keeps
+a single shared counter rather than a per-interface instance — with a commit
+advisory (`validateFirewallInterfaceSpecificWarnings`).
+
+**F-3b — CoS `inet-precedence` + `exp` (#4316).** Added
+`classifiers inet-precedence`, `rewrite-rules inet-precedence`, and
+`rewrite-rules exp` to `schemaClassOfService` (completion + `?` help). They
+are **accepted-but-inert** — the userspace dataplane classifies / rewrites on
+`dscp` / `ieee-802.1` only. Their names are recorded on
+`ClassOfServiceConfig` (`INetPrecedenceClassifiers` /
+`INetPrecedenceRewriteRules` / `EXPRewriteRules`) solely to drive a commit
+advisory; no runtime structure is built.

--- a/docs/cos-traffic-shaping.md
+++ b/docs/cos-traffic-shaping.md
@@ -847,6 +847,40 @@ stays 0 and the dataplane applies its rate-independent
 `shaping-rate`) still inherits both the level rate and the level burst as
 a pair.
 
+### Hierarchical traffic-control-profiles (#4315, fable-167 F-2)
+
+The Junos hierarchical shaping binding is modeled and **wired** to the
+per-unit shaper:
+
+```
+set class-of-service traffic-control-profiles wan-tcp shaping-rate 9g
+set class-of-service traffic-control-profiles wan-tcp scheduler-map edge-map
+set class-of-service interfaces ge-0-0-2 unit 80 output-traffic-control-profile wan-tcp
+```
+
+A `traffic-control-profiles <name>` profile carries `shaping-rate`,
+`scheduler-map`, `guaranteed-rate`, and `delay-buffer-rate`. Binding it to a
+logical unit's egress with `output-traffic-control-profile <name>` folds the
+profile's **shaping-rate** and **scheduler-map** into that unit's existing
+per-unit shaper (`resolveCoSTrafficControlProfiles` in
+`pkg/config/compiler.go`, run after the interface-level fold), so the shaper
+materializes exactly as if the operator had set `shaping-rate` /
+`scheduler-map` directly on the unit. A **direct unit-level knob wins** over
+the profile (Junos precedence), and an interface-level
+`output-traffic-control-profile` applies to every configured logical unit.
+
+Before #4315 both `traffic-control-profiles` and
+`output-traffic-control-profile` were unmodeled: the binding committed
+cleanly and was **silently dropped** — the shaper never materialized (ZERO
+shaping while the operator believed shaping was applied). `guaranteed-rate`
+and `delay-buffer-rate` are typed (garbage rejected at commit) and captured
+for `show configuration` fidelity, but are **accepted-but-inert** — the
+userspace shaper has no per-unit absolute guaranteed-rate reservation or
+delay-buffer sizing (the #1614 A1 `guarantee-rate` is a proportional
+*fraction*, a distinct mechanism); a commit advisory surfaces the inertness.
+A dangling `output-traffic-control-profile` reference (no such profile) also
+warns (the unit is not shaped).
+
 A `class-of-service interfaces <name>` binding whose interface — or a
 bound `unit N` — is **not configured under `[interfaces]`** is a silent
 no-op: the dataplane applier only visits CoS bindings that resolve

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -1326,6 +1326,27 @@ Index   State  Initiator cookie  Responder cookie  Mode           Remote Address
 - **Mode:** `IKEv2` or `Main` (for IKEv1), ~15 chars.
 - **Remote Address:** IP address.
 
+### Drill-downs (fable-167 C-1, #4314)
+
+The operational tree (`pkg/cmdtree`) now advertises these grouped
+drill-downs (tab-completion + `?` help):
+
+- `show security ike security-associations detail` — per-SA local/remote
+  traffic selectors, SPI in/out, and lifetime (was: bare list only).
+- `show security ipsec security-associations detail` — already rendered by
+  the handler; now surfaced in completion/help.
+- `show security nat static rule [detail]` — per-rule drill-down mirroring
+  source/destination NAT; `detail` adds the source-address restriction,
+  destination-port / mapped-port translation, `prefix-name`, and the
+  translation-target routing-instance.
+- `request security policies check` — a config lint that reports **shadowed**
+  (an earlier terminal policy matches a superset with a *different* action →
+  the later rule is unreachable) and **redundant** (same action) policies. It
+  is a conservative name-set containment pass over the configured zone-pair
+  policies; it never resolves address-book names to prefixes (no false
+  positives) and never treats an inverted-match or schedule-gated policy as a
+  shadower. It does not mutate config.
+
 ---
 
 ## Security: Log

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -1136,9 +1136,40 @@ func (c *CLI) handleRequestSecurity(args []string) error {
 		return nil
 	case "wireguard":
 		return c.handleRequestSecurityWireguard(args[1:])
+	case "policies":
+		return c.handleRequestSecurityPolicies(args[1:])
 	default:
 		return fmt.Errorf("unknown request security target: %s", args[0])
 	}
+}
+
+// handleRequestSecurityPolicies implements `request security policies check`
+// (fable-167 C-1c, #4314): a static analysis of the configured policy set
+// that reports shadowed / redundant rules. Junos `request security policies
+// check` validates the compiled policy DB; xpf runs a conservative
+// name-set-containment pass over config.ZonePairPolicies (no dataplane call —
+// this is a config lint). It never mutates config.
+func (c *CLI) handleRequestSecurityPolicies(args []string) error {
+	if len(args) == 0 || args[0] != "check" {
+		fmt.Println("request security policies:")
+		writeCompletionHelp(os.Stdout, treeHelpCandidates(operationalTree["request"].Children["security"].Children["policies"].Children))
+		return nil
+	}
+	cfg := c.store.ActiveConfig()
+	if cfg == nil {
+		fmt.Println("no active configuration")
+		return nil
+	}
+	findings := analyzePolicyShadowing(cfg)
+	if len(findings) == 0 {
+		fmt.Println("Policy check complete: no shadowed or redundant policies detected.")
+		return nil
+	}
+	fmt.Printf("Policy check complete: %d issue(s) detected.\n\n", len(findings))
+	for _, f := range findings {
+		fmt.Println(f)
+	}
+	return nil
 }
 
 // handleRequestSecurityWireguard implements `request security wireguard

--- a/pkg/cli/cli_request_policies_check.go
+++ b/pkg/cli/cli_request_policies_check.go
@@ -1,0 +1,150 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// analyzePolicyShadowing runs a conservative shadow / redundancy pass over the
+// configured zone-pair policies (fable-167 C-1c, #4314), mirroring Junos
+// `request security policies check`. Within each ordered zone-pair list, an
+// earlier policy shadows a later one when it matches a SUPERSET of the later
+// policy's traffic — because policies are terminal (permit/deny/reject) and
+// evaluated first-match, the later policy is then unreachable.
+//
+// The superset test is a NAME-SET containment on the match fields
+// (source-address, destination-address, application), with "any" treated as
+// the universal set. It deliberately does NOT resolve address-book names to
+// prefixes — that would need the address-book expansion and risks false
+// positives — so it is conservative: it reports only high-confidence
+// wildcard-or-containment shadows, never a partial-overlap guess. Policies
+// that invert a match sense (source/destination-address-excluded) or that are
+// schedule-gated (scheduler-name — not always active) are never treated as
+// shadowers, since their coverage is not a plain superset.
+//
+// A finding distinguishes a pure REDUNDANT rule (same action as its shadower —
+// harmless but dead) from a SHADOWED rule whose distinct action never applies
+// (the operationally dangerous case).
+func analyzePolicyShadowing(cfg *config.Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	var findings []string
+	// Deterministic order: sort zone pairs by from/to zone.
+	pairs := append([]*config.ZonePairPolicies(nil), cfg.Security.Policies...)
+	sort.SliceStable(pairs, func(i, j int) bool {
+		if pairs[i] == nil || pairs[j] == nil {
+			return pairs[j] == nil
+		}
+		if pairs[i].FromZone != pairs[j].FromZone {
+			return pairs[i].FromZone < pairs[j].FromZone
+		}
+		return pairs[i].ToZone < pairs[j].ToZone
+	})
+	for _, zpp := range pairs {
+		if zpp == nil {
+			continue
+		}
+		for j := 1; j < len(zpp.Policies); j++ {
+			later := zpp.Policies[j]
+			if later == nil {
+				continue
+			}
+			for i := 0; i < j; i++ {
+				earlier := zpp.Policies[i]
+				if earlier == nil {
+					continue
+				}
+				if !policyMatchIsSuperset(earlier, later) {
+					continue
+				}
+				scope := fmt.Sprintf("from-zone %s to-zone %s", zpp.FromZone, zpp.ToZone)
+				if earlier.Action == later.Action &&
+					policyMatchIsSuperset(later, earlier) {
+					findings = append(findings, fmt.Sprintf(
+						"  [%s] policy %q is REDUNDANT: identical match and action to earlier policy %q",
+						scope, later.Name, earlier.Name))
+				} else if earlier.Action == later.Action {
+					findings = append(findings, fmt.Sprintf(
+						"  [%s] policy %q is REDUNDANT: earlier policy %q already matches a superset with the same action (%s)",
+						scope, later.Name, earlier.Name, policyActionName(earlier.Action)))
+				} else {
+					findings = append(findings, fmt.Sprintf(
+						"  [%s] policy %q is SHADOWED and UNREACHABLE: earlier policy %q matches a superset with a different action (%s vs %s)",
+						scope, later.Name, earlier.Name,
+						policyActionName(earlier.Action), policyActionName(later.Action)))
+				}
+				break // report the first shadower only
+			}
+		}
+	}
+	return findings
+}
+
+// policyMatchIsSuperset reports whether policy a matches a superset of the
+// traffic policy b matches, using conservative name-set containment. a is
+// disqualified as a shadower if it inverts a match sense or is schedule-gated.
+func policyMatchIsSuperset(a, b *config.Policy) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	// An inverted or schedule-gated policy does not cover a plain superset.
+	if a.Match.SourceAddressExcluded || a.Match.DestinationAddressExcluded {
+		return false
+	}
+	if a.SchedulerName != "" {
+		return false
+	}
+	return nameSetSuperset(a.Match.SourceAddresses, b.Match.SourceAddresses) &&
+		nameSetSuperset(a.Match.DestinationAddresses, b.Match.DestinationAddresses) &&
+		nameSetSuperset(a.Match.Applications, b.Match.Applications)
+}
+
+// nameSetSuperset reports whether super is a superset of sub as Junos match
+// name sets: "any" in super is the universal set; otherwise every element of
+// sub must appear in super. An "any" in sub that super lacks is NOT covered.
+// An empty sub is treated as unconstrained (== "any") for safety, so it is
+// covered only when super is also "any".
+func nameSetSuperset(super, sub []string) bool {
+	if containsAny(super) {
+		return true
+	}
+	if len(sub) == 0 || containsAny(sub) {
+		// sub is universal but super is not.
+		return false
+	}
+	set := make(map[string]struct{}, len(super))
+	for _, s := range super {
+		set[s] = struct{}{}
+	}
+	for _, s := range sub {
+		if _, ok := set[s]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func containsAny(names []string) bool {
+	for _, n := range names {
+		if n == "any" {
+			return true
+		}
+	}
+	return false
+}
+
+func policyActionName(a config.PolicyAction) string {
+	switch a {
+	case config.PolicyPermit:
+		return "permit"
+	case config.PolicyDeny:
+		return "deny"
+	case config.PolicyReject:
+		return "reject"
+	default:
+		return "unknown"
+	}
+}

--- a/pkg/cli/cli_request_policies_check.go
+++ b/pkg/cli/cli_request_policies_check.go
@@ -84,14 +84,31 @@ func analyzePolicyShadowing(cfg *config.Config) []string {
 }
 
 // policyMatchIsSuperset reports whether policy a matches a superset of the
-// traffic policy b matches, using conservative name-set containment. a is
-// disqualified as a shadower if it inverts a match sense or is schedule-gated.
+// traffic policy b matches, using conservative name-set containment. It is
+// disqualified (returns false, the safe no-shadow answer) whenever EITHER
+// policy inverts a match sense, or a is schedule-gated.
+//
+// An excluded (`source-address-excluded` / `destination-address-excluded`)
+// sense makes the match set the COMPLEMENT of the named set, so a plain
+// name-set containment no longer proves coverage. It must disqualify on BOTH
+// sides, not just a: if b (the later, candidate-shadowed policy) is excluded,
+// the two match sets can be disjoint even when the named sets are identical —
+// e.g. earlier `permit source-address [A]` vs later `deny source-address [A]
+// source-address-excluded` matches src∈{A} vs src∉{A}, which is FULLY
+// reachable, not shadowed. Ignoring b's excluded flags produced that false
+// positive (fable-167 C-1c review MINOR); a lint that cries wolf on an
+// advisory erodes trust, so the no-false-positive contract wins over
+// completeness here.
 func policyMatchIsSuperset(a, b *config.Policy) bool {
 	if a == nil || b == nil {
 		return false
 	}
-	// An inverted or schedule-gated policy does not cover a plain superset.
+	// An inverted match sense on EITHER policy breaks plain name-set
+	// containment; a schedule-gated shadower is not always active.
 	if a.Match.SourceAddressExcluded || a.Match.DestinationAddressExcluded {
+		return false
+	}
+	if b.Match.SourceAddressExcluded || b.Match.DestinationAddressExcluded {
 		return false
 	}
 	if a.SchedulerName != "" {

--- a/pkg/cli/cli_request_policies_check_test.go
+++ b/pkg/cli/cli_request_policies_check_test.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestAnalyzePolicyShadowing pins the fable-167 C-1c shadow/redundancy pass.
+func TestAnalyzePolicyShadowing(t *testing.T) {
+	pol := func(name string, action config.PolicyAction, src, dst, apps []string) *config.Policy {
+		return &config.Policy{
+			Name:   name,
+			Action: action,
+			Match: config.PolicyMatch{
+				SourceAddresses:      src,
+				DestinationAddresses: dst,
+				Applications:         apps,
+			},
+		}
+	}
+	cfg := &config.Config{}
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		{
+			FromZone: "trust", ToZone: "untrust",
+			Policies: []*config.Policy{
+				// permit-any shadows every later rule in this pair.
+				pol("permit-all", config.PolicyPermit, []string{"any"}, []string{"any"}, []string{"any"}),
+				// SHADOWED with a different action (dangerous).
+				pol("block-web", config.PolicyDeny, []string{"any"}, []string{"web-srv"}, []string{"http"}),
+			},
+		},
+		{
+			FromZone: "trust", ToZone: "dmz",
+			Policies: []*config.Policy{
+				pol("allow-http", config.PolicyPermit, []string{"any"}, []string{"any"}, []string{"http"}),
+				// REDUNDANT: identical match+action to allow-http.
+				pol("allow-http-dup", config.PolicyPermit, []string{"any"}, []string{"any"}, []string{"http"}),
+				// NOT shadowed: distinct application not covered by allow-http.
+				pol("allow-dns", config.PolicyPermit, []string{"any"}, []string{"any"}, []string{"dns"}),
+			},
+		},
+	}
+
+	findings := analyzePolicyShadowing(cfg)
+	joined := strings.Join(findings, "\n")
+
+	if !strings.Contains(joined, "block-web") || !strings.Contains(joined, "SHADOWED") {
+		t.Fatalf("expected block-web reported SHADOWED, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "allow-http-dup") || !strings.Contains(joined, "REDUNDANT") {
+		t.Fatalf("expected allow-http-dup reported REDUNDANT, got:\n%s", joined)
+	}
+	if strings.Contains(joined, "allow-dns") {
+		t.Fatalf("allow-dns is not shadowed (distinct application) but was reported:\n%s", joined)
+	}
+}
+
+// TestAnalyzePolicyShadowingScheduledEarlierIsNotShadower pins that a
+// schedule-gated earlier policy (not always active) is NOT treated as a
+// shadower — avoids false positives.
+func TestAnalyzePolicyShadowingScheduledEarlierIsNotShadower(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		{
+			FromZone: "trust", ToZone: "untrust",
+			Policies: []*config.Policy{
+				{
+					Name:          "business-hours",
+					Action:        config.PolicyPermit,
+					SchedulerName: "work-week",
+					Match: config.PolicyMatch{
+						SourceAddresses: []string{"any"}, DestinationAddresses: []string{"any"}, Applications: []string{"any"},
+					},
+				},
+				{
+					Name:   "after-hours-block",
+					Action: config.PolicyDeny,
+					Match: config.PolicyMatch{
+						SourceAddresses: []string{"any"}, DestinationAddresses: []string{"any"}, Applications: []string{"any"},
+					},
+				},
+			},
+		},
+	}
+	if findings := analyzePolicyShadowing(cfg); len(findings) != 0 {
+		t.Fatalf("scheduled earlier policy must not shadow, got: %v", findings)
+	}
+}

--- a/pkg/cli/cli_request_policies_check_test.go
+++ b/pkg/cli/cli_request_policies_check_test.go
@@ -57,6 +57,86 @@ func TestAnalyzePolicyShadowing(t *testing.T) {
 	}
 }
 
+// TestAnalyzePolicyShadowingExcludedLaterIsNotShadowed pins the fable-167 C-1c
+// review MINOR fix: a later policy whose match sense is INVERTED
+// (source/destination-address-excluded) is NOT reported as shadowed even when
+// the named sets are identical — the two match sets are disjoint (in-set vs
+// complement), so the later rule is fully reachable. RED on revert: without
+// the b-excluded guard the lint reports it SHADOWED/UNREACHABLE (false
+// positive).
+func TestAnalyzePolicyShadowingExcludedLaterIsNotShadowed(t *testing.T) {
+	src := func(name string, action config.PolicyAction, srcExcluded bool) *config.Policy {
+		return &config.Policy{
+			Name:   name,
+			Action: action,
+			Match: config.PolicyMatch{
+				SourceAddresses:       []string{"A"},
+				DestinationAddresses:  []string{"any"},
+				Applications:          []string{"any"},
+				SourceAddressExcluded: srcExcluded,
+			},
+		}
+	}
+	dst := func(name string, action config.PolicyAction, dstExcluded bool) *config.Policy {
+		return &config.Policy{
+			Name:   name,
+			Action: action,
+			Match: config.PolicyMatch{
+				SourceAddresses:            []string{"any"},
+				DestinationAddresses:       []string{"B"},
+				Applications:               []string{"any"},
+				DestinationAddressExcluded: dstExcluded,
+			},
+		}
+	}
+	cfg := &config.Config{}
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		{
+			FromZone: "trust", ToZone: "untrust",
+			Policies: []*config.Policy{
+				// earlier permit src∈{A}; later deny src∉{A} — DISJOINT.
+				src("permit-A", config.PolicyPermit, false),
+				src("deny-not-A", config.PolicyDeny, true),
+			},
+		},
+		{
+			FromZone: "trust", ToZone: "dmz",
+			Policies: []*config.Policy{
+				// earlier permit dst∈{B}; later deny dst∉{B} — DISJOINT.
+				dst("permit-B", config.PolicyPermit, false),
+				dst("deny-not-B", config.PolicyDeny, true),
+			},
+		},
+	}
+	if findings := analyzePolicyShadowing(cfg); len(findings) != 0 {
+		t.Fatalf("an excluded-sense later policy is reachable, must not shadow, got: %v", findings)
+	}
+}
+
+// TestAnalyzePolicyShadowingGenuineStillReported guards that the b-excluded
+// fix did not suppress a genuine shadow: earlier permit-any shadows a later
+// deny [A] (both plain, no exclusion).
+func TestAnalyzePolicyShadowingGenuineStillReported(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		{
+			FromZone: "trust", ToZone: "untrust",
+			Policies: []*config.Policy{
+				{Name: "permit-any", Action: config.PolicyPermit, Match: config.PolicyMatch{
+					SourceAddresses: []string{"any"}, DestinationAddresses: []string{"any"}, Applications: []string{"any"},
+				}},
+				{Name: "deny-A", Action: config.PolicyDeny, Match: config.PolicyMatch{
+					SourceAddresses: []string{"A"}, DestinationAddresses: []string{"any"}, Applications: []string{"any"},
+				}},
+			},
+		},
+	}
+	findings := analyzePolicyShadowing(cfg)
+	if len(findings) != 1 || !strings.Contains(findings[0], "deny-A") || !strings.Contains(findings[0], "SHADOWED") {
+		t.Fatalf("expected genuine shadow of deny-A still reported, got: %v", findings)
+	}
+}
+
 // TestAnalyzePolicyShadowingScheduledEarlierIsNotShadower pins that a
 // schedule-gated earlier policy (not always active) is NOT treated as a
 // shadower — avoids false positives.

--- a/pkg/cli/cli_show_nat.go
+++ b/pkg/cli/cli_show_nat.go
@@ -49,7 +49,7 @@ func (c *CLI) handleShowNAT(args []string) error {
 	case "destination":
 		return c.showNATDestination(cfg, args[1:])
 	case "static":
-		return c.showNATStatic(cfg)
+		return c.showNATStatic(cfg, args[1:])
 	case "nat64":
 		return c.showNAT64(cfg)
 	case "nptv6":
@@ -844,8 +844,14 @@ func (c *CLI) showNATDestinationRuleDetail(cfg *config.Config) error {
 	return nil
 }
 
-func (c *CLI) showNATStatic(cfg *config.Config) error {
+func (c *CLI) showNATStatic(cfg *config.Config, args []string) error {
 	// #1687: shared with the gRPC ShowText path via pkg/natshow.
+	// C-1b (#4314): `rule [detail]` drill-down mirrors source/destination NAT.
+	if len(args) > 0 && args[0] == "rule" {
+		detail := len(args) >= 2 && args[1] == "detail"
+		natshow.RenderStaticRule(os.Stdout, cfg, detail)
+		return nil
+	}
 	natshow.RenderStatic(os.Stdout, cfg)
 	return nil
 }

--- a/pkg/cli/cli_show_nat_shared_test.go
+++ b/pkg/cli/cli_show_nat_shared_test.go
@@ -84,8 +84,13 @@ func TestCLINATWrappersMatchSharedRenderers(t *testing.T) {
 		},
 		{
 			"static",
-			func() error { return c.showNATStatic(cfg) },
+			func() error { return c.showNATStatic(cfg, nil) },
 			func(b *strings.Builder) { natshow.RenderStatic(b, cfg) },
+		},
+		{
+			"static-rule-detail",
+			func() error { return c.showNATStatic(cfg, []string{"rule", "detail"}) },
+			func(b *strings.Builder) { natshow.RenderStaticRule(b, cfg, true) },
 		},
 		{
 			"nptv6",

--- a/pkg/cli/cli_show_security_ipsec.go
+++ b/pkg/cli/cli_show_security_ipsec.go
@@ -174,6 +174,7 @@ func (c *CLI) showIKE(args []string) error {
 	}
 
 	if len(args) > 0 && args[0] == "security-associations" {
+		detail := len(args) >= 2 && args[1] == "detail"
 		// Show IKE SA status from strongSwan
 		if c.ipsec != nil {
 			sas, err := c.ipsec.GetSAStatus()
@@ -191,6 +192,20 @@ func (c *CLI) showIKE(args []string) error {
 				}
 				if sa.RemoteAddr != "" {
 					fmt.Printf("  Remote: %s\n", sa.RemoteAddr)
+				}
+				if detail {
+					if sa.LocalTS != "" {
+						fmt.Printf("  Local TS:  %s\n", sa.LocalTS)
+					}
+					if sa.RemoteTS != "" {
+						fmt.Printf("  Remote TS: %s\n", sa.RemoteTS)
+					}
+					if sa.SPIIn != "" || sa.SPIOut != "" {
+						fmt.Printf("  SPI In/Out: %s/%s\n", sa.SPIIn, sa.SPIOut)
+					}
+					if sa.Rekey != "" {
+						fmt.Printf("  Lifetime:   %s\n", sa.Rekey)
+					}
 				}
 				fmt.Println()
 			}

--- a/pkg/cmdtree/tree.go
+++ b/pkg/cmdtree/tree.go
@@ -449,9 +449,13 @@ var OperationalTree = map[string]*Node{
 					}},
 					"rule-set": {Desc: "Show destination NAT rule sets"},
 				}},
-				"static": {Desc: "Show static NAT"},
-				"nptv6":  {Desc: "Show NPTv6 prefix translation rules"},
-				"nat64":  {Desc: "Show NAT64 rules"},
+				"static": {Desc: "Show static NAT", Children: map[string]*Node{
+					"rule": {Desc: "Show static NAT rules", Children: map[string]*Node{
+						"detail": {Desc: "Show detailed static NAT rules (source restriction, mapped-port, prefix-name, routing-instance)"},
+					}},
+				}},
+				"nptv6": {Desc: "Show NPTv6 prefix translation rules"},
+				"nat64": {Desc: "Show NAT64 rules"},
 			}},
 			"address-book": {Desc: "Show address book entries"},
 			"applications": {Desc: "Show application definitions"},
@@ -473,11 +477,15 @@ var OperationalTree = map[string]*Node{
 				"detail": {Desc: "Show detailed statistics with screen and session breakdown"},
 			}},
 			"ike": {Desc: "Show Internet Key Exchange information", Children: map[string]*Node{
-				"security-associations": {Desc: "Show IKE SAs"},
+				"security-associations": {Desc: "Show IKE SAs", Children: map[string]*Node{
+					"detail": {Desc: "Show detailed IKE SA information"},
+				}},
 			}},
 			"ipsec": {Desc: "Show IP Security information", Children: map[string]*Node{
-				"security-associations": {Desc: "Show IPsec SAs"},
-				"statistics":            {Desc: "Show IPsec statistics"},
+				"security-associations": {Desc: "Show IPsec SAs", Children: map[string]*Node{
+					"detail": {Desc: "Show detailed IPsec SA information (bytes, packets, SPI, lifetime)"},
+				}},
+				"statistics": {Desc: "Show IPsec statistics"},
 			}},
 			"vrrp": {Desc: "Show VRRP high availability status"},
 			"wireguard": {Desc: "Show WireGuard tunnel status", Children: map[string]*Node{
@@ -932,6 +940,9 @@ var OperationalTree = map[string]*Node{
 				"sa": {Desc: "IPsec SA operations", Children: map[string]*Node{
 					"clear": {Desc: "Clear all IPsec SAs"},
 				}},
+			}},
+			"policies": {Desc: "Security policy operations", Children: map[string]*Node{
+				"check": {Desc: "Check the configured policy set for shadowed / redundant rules"},
 			}},
 			"wireguard": {Desc: "WireGuard operations", Children: map[string]*Node{
 				"generate-private-key": {Desc: "Generate a fresh WireGuard private key and its public key"},

--- a/pkg/cmdtree/tree_hb167_test.go
+++ b/pkg/cmdtree/tree_hb167_test.go
@@ -1,0 +1,34 @@
+package cmdtree
+
+import "testing"
+
+// TestHB167DrillDownsPresent pins the fable-167 C-1 operational-tree
+// drill-downs (SSOT for tab-completion + ? help). RED on revert: each node is
+// absent before the fix, so completion/help never surface it.
+func TestHB167DrillDownsPresent(t *testing.T) {
+	child := func(root map[string]*Node, path ...string) *Node {
+		t.Helper()
+		var cur *Node
+		children := root
+		for i, p := range path {
+			n, ok := children[p]
+			if !ok || n == nil {
+				t.Fatalf("missing node at path %v (stuck at %q)", path[:i+1], p)
+			}
+			cur = n
+			children = n.Children
+		}
+		return cur
+	}
+
+	show := OperationalTree["show"].Children["security"].Children
+	// C-1a: show security ike/ipsec security-associations detail.
+	child(show, "ike", "security-associations", "detail")
+	child(show, "ipsec", "security-associations", "detail")
+	// C-1b: show security nat static rule [detail].
+	child(show, "nat", "static", "rule", "detail")
+
+	// C-1c: request security policies check.
+	req := OperationalTree["request"].Children["security"].Children
+	child(req, "policies", "check")
+}

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -2285,6 +2285,14 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	// the interface-level one per knob (Junos precedence).
 	applyCoSInterfaceLevelBindings(cfg)
 
+	// #4315 (fable-167 F-2): resolve output-traffic-control-profile bindings
+	// into each unit's per-unit shaper (shaping-rate + scheduler-map). Runs
+	// AFTER the interface-level fold so an interface-level profile binding is
+	// already present on each unit. Before modeling, the hierarchical
+	// traffic-control-profile binding was silently dropped — a clean commit
+	// with ZERO shaping; now the shaper actually materializes.
+	resolveCoSTrafficControlProfiles(cfg)
+
 	// Post-compilation fixup: resolve vSRX-style fabric member-interfaces.
 	// For fab0/fab1 with fabric-options member-interfaces, resolve which member
 	// belongs to the local node using FPC slot → node-id mapping (slot 0 → node0,

--- a/pkg/config/compiler_class_of_service.go
+++ b/pkg/config/compiler_class_of_service.go
@@ -33,6 +33,9 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 	if cos.Interfaces == nil {
 		cos.Interfaces = make(map[string]*CoSInterface)
 	}
+	if cos.TrafficControlProfiles == nil {
+		cos.TrafficControlProfiles = make(map[string]*CoSTrafficControlProfile)
+	}
 	if fcNode := node.FindChild("forwarding-classes"); fcNode != nil {
 		// Enforce the FC ↔ queue bijection. Junos semantics give
 		// each queue ID one forwarding class, and each FC one
@@ -192,9 +195,22 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 				cos.IEEE8021Classifiers[classifier.Name] = classifier
 			}
 		}
+		// #4316 (fable-167 F-3b): inet-precedence classifiers are accepted
+		// but inert; record their names for the commit advisory.
+		for _, inst := range namedInstances(classifiersNode.FindChildren("inet-precedence")) {
+			cos.INetPrecedenceClassifiers = append(cos.INetPrecedenceClassifiers, inst.name)
+		}
 	}
 
 	if rewriteRulesNode := node.FindChild("rewrite-rules"); rewriteRulesNode != nil {
+		// #4316 (fable-167 F-3b): inet-precedence and exp rewrite-rules are
+		// accepted but inert; record their names for the commit advisory.
+		for _, inst := range namedInstances(rewriteRulesNode.FindChildren("inet-precedence")) {
+			cos.INetPrecedenceRewriteRules = append(cos.INetPrecedenceRewriteRules, inst.name)
+		}
+		for _, inst := range namedInstances(rewriteRulesNode.FindChildren("exp")) {
+			cos.EXPRewriteRules = append(cos.EXPRewriteRules, inst.name)
+		}
 		for _, inst := range namedInstances(rewriteRulesNode.FindChildren("dscp")) {
 			rewriteRule := &CoSDSCPRewriteRule{Name: inst.name}
 			for _, fcNode := range inst.node.FindChildren("forwarding-class") {
@@ -275,6 +291,34 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 			}
 		}
 		cos.Schedulers[sched.Name] = sched
+	}
+
+	// #4315 (fable-167 F-2): traffic-control-profiles. Each profile carries
+	// the Junos hierarchical shaping knobs. The bounded ones (shaping-rate,
+	// scheduler-map) are folded into the referencing interface unit by
+	// resolveCoSTrafficControlProfiles; guaranteed-rate / delay-buffer-rate
+	// are captured but currently inert (see CoSTrafficControlProfile).
+	for _, inst := range namedInstances(node.FindChildren("traffic-control-profiles")) {
+		tcp := &CoSTrafficControlProfile{Name: inst.name}
+		if shapingNode := inst.node.FindChild("shaping-rate"); shapingNode != nil {
+			if v := nodeVal(shapingNode); v != "" {
+				tcp.ShapingRateBytes = parseBandwidthLimit(v)
+			}
+		}
+		if grNode := inst.node.FindChild("guaranteed-rate"); grNode != nil {
+			if v := nodeVal(grNode); v != "" {
+				tcp.GuaranteedRateBytes = parseBandwidthLimit(v)
+			}
+		}
+		if dbNode := inst.node.FindChild("delay-buffer-rate"); dbNode != nil {
+			if v := nodeVal(dbNode); v != "" {
+				tcp.DelayBufferRateBytes = parseBandwidthLimit(v)
+			}
+		}
+		if smNode := inst.node.FindChild("scheduler-map"); smNode != nil {
+			tcp.SchedulerMap = nodeVal(smNode)
+		}
+		cos.TrafficControlProfiles[tcp.Name] = tcp
 	}
 
 	for _, inst := range namedInstances(node.FindChildren("scheduler-maps")) {
@@ -412,6 +456,9 @@ func parseCoSInterfaceUnitBody(node *Node, unit *CoSInterfaceUnit) {
 	if schedMapNode := node.FindChild("scheduler-map"); schedMapNode != nil {
 		unit.SchedulerMap = nodeVal(schedMapNode)
 	}
+	if tcpNode := node.FindChild("output-traffic-control-profile"); tcpNode != nil {
+		unit.OutputTrafficControlProfile = nodeVal(tcpNode)
+	}
 	if classifiersNode := node.FindChild("classifiers"); classifiersNode != nil {
 		if dscpNode := classifiersNode.FindChild("dscp"); dscpNode != nil {
 			unit.DSCPClassifier = nodeVal(dscpNode)
@@ -493,7 +540,7 @@ func coSInterfaceUnitHasBinding(unit *CoSInterfaceUnit) bool {
 	return unit.ShapingRateBytes > 0 || unit.BurstSizeBytes > 0 || unit.SchedulerMap != "" ||
 		unit.DSCPClassifier != "" || unit.IEEE8021Classifier != "" ||
 		unit.DSCPRewriteRule != "" || unit.OversubscriptionPolicy != "" ||
-		unit.PriorityLowMinShareBytes > 0
+		unit.PriorityLowMinShareBytes > 0 || unit.OutputTrafficControlProfile != ""
 }
 
 // applyCoSInterfaceLevelBindings folds each interface-level CoS binding
@@ -563,6 +610,9 @@ func mergeCoSInterfaceLevelInto(unit, level *CoSInterfaceUnit) {
 	if unit.SchedulerMap == "" {
 		unit.SchedulerMap = level.SchedulerMap
 	}
+	if unit.OutputTrafficControlProfile == "" {
+		unit.OutputTrafficControlProfile = level.OutputTrafficControlProfile
+	}
 	if unit.DSCPClassifier == "" {
 		unit.DSCPClassifier = level.DSCPClassifier
 	}
@@ -578,6 +628,57 @@ func mergeCoSInterfaceLevelInto(unit, level *CoSInterfaceUnit) {
 	}
 	if unit.PriorityLowMinShareBytes == 0 {
 		unit.PriorityLowMinShareBytes = level.PriorityLowMinShareBytes
+	}
+}
+
+// resolveCoSTrafficControlProfiles folds each interface unit's
+// output-traffic-control-profile binding (fable-167 F-2, #4315) into the
+// unit's existing per-unit shaper. For every CoSInterfaceUnit that names a
+// profile, the referenced profile's shaping-rate and scheduler-map fill the
+// unit's ShapingRateBytes / SchedulerMap when those are not already set
+// directly on the unit — a DIRECT unit-level knob wins (Junos gives an
+// explicit unit binding precedence over a profile). After this pass the
+// dataplane snapshot and `show class-of-service`, which iterate Units and
+// read ShapingRateBytes / SchedulerMap, enforce the profile's shaping with no
+// awareness of traffic-control-profiles. This is what stops the silent
+// zero-shaping: before modeling, output-traffic-control-profile was dropped
+// and the shaper never materialized.
+//
+// A dangling reference (no such profile) leaves the unit's shaper knobs
+// unset; ValidateConfig warns so the operator sees the inert binding.
+// guaranteed-rate / delay-buffer-rate are NOT folded — the userspace shaper
+// has no per-unit consumer for them (accepted-but-inert; warned separately).
+//
+// Runs AFTER applyCoSInterfaceLevelBindings so an interface-level
+// output-traffic-control-profile has already been copied into each unit.
+func resolveCoSTrafficControlProfiles(cfg *Config) {
+	if cfg == nil || cfg.ClassOfService == nil {
+		return
+	}
+	cos := cfg.ClassOfService
+	resolve := func(unit *CoSInterfaceUnit) {
+		if unit == nil || unit.OutputTrafficControlProfile == "" {
+			return
+		}
+		tcp := cos.TrafficControlProfiles[unit.OutputTrafficControlProfile]
+		if tcp == nil {
+			return
+		}
+		if unit.ShapingRateBytes == 0 {
+			unit.ShapingRateBytes = tcp.ShapingRateBytes
+		}
+		if unit.SchedulerMap == "" {
+			unit.SchedulerMap = tcp.SchedulerMap
+		}
+	}
+	for _, iface := range cos.Interfaces {
+		if iface == nil {
+			continue
+		}
+		resolve(iface.Level)
+		for _, unit := range iface.Units {
+			resolve(unit)
+		}
 	}
 }
 

--- a/pkg/config/compiler_cos_tcp_hb167_test.go
+++ b/pkg/config/compiler_cos_tcp_hb167_test.go
@@ -1,0 +1,160 @@
+package config
+
+import (
+	"testing"
+)
+
+// compileHB167 is a small helper: parse flat `set` lines with ParseSetCommand
+// + SetPath (NEVER NewParser — it merges newlines) and compile.
+func compileHB167(t *testing.T, lines []string) *Config {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	return cfg
+}
+
+// TestCompileCoSTrafficControlProfileShapesUnit is the fable-167 F-2
+// make-or-break: a traffic-control-profile bound to a unit via
+// output-traffic-control-profile must ACTUALLY shape — its shaping-rate and
+// scheduler-map fold into the per-unit shaper. RED on revert: before modeling,
+// output-traffic-control-profile was silently dropped (SchemaValidate ignores
+// unknown keywords, no compiler read it) → ShapingRateBytes==0, no shaping.
+func TestCompileCoSTrafficControlProfileShapesUnit(t *testing.T) {
+	cfg := compileHB167(t, []string{
+		"set class-of-service forwarding-classes queue 0 best-effort",
+		"set class-of-service schedulers be-sched transmit-rate 5g",
+		"set class-of-service scheduler-maps edge-map forwarding-class best-effort scheduler be-sched",
+		"set class-of-service traffic-control-profiles wan-tcp shaping-rate 9g",
+		"set class-of-service traffic-control-profiles wan-tcp scheduler-map edge-map",
+		"set class-of-service traffic-control-profiles wan-tcp guaranteed-rate 2g",
+		"set class-of-service traffic-control-profiles wan-tcp delay-buffer-rate 1g",
+		"set class-of-service interfaces ge-0/0/2 unit 80 output-traffic-control-profile wan-tcp",
+		"set system dataplane-type userspace",
+	})
+
+	tcp := cfg.ClassOfService.TrafficControlProfiles["wan-tcp"]
+	if tcp == nil {
+		t.Fatal("expected traffic-control-profile wan-tcp to be modeled")
+	}
+	if got, want := tcp.ShapingRateBytes, parseBandwidthLimit("9g"); got != want {
+		t.Fatalf("tcp shaping-rate = %d, want %d", got, want)
+	}
+	if got, want := tcp.GuaranteedRateBytes, parseBandwidthLimit("2g"); got != want {
+		t.Fatalf("tcp guaranteed-rate = %d, want %d", got, want)
+	}
+	if got, want := tcp.DelayBufferRateBytes, parseBandwidthLimit("1g"); got != want {
+		t.Fatalf("tcp delay-buffer-rate = %d, want %d", got, want)
+	}
+	if got := tcp.SchedulerMap; got != "edge-map" {
+		t.Fatalf("tcp scheduler-map = %q, want edge-map", got)
+	}
+
+	iface := cfg.ClassOfService.Interfaces["ge-0/0/2"]
+	if iface == nil {
+		t.Fatal("expected ge-0/0/2 CoS interface (output-traffic-control-profile is a binding)")
+	}
+	unit := iface.Units[80]
+	if unit == nil {
+		t.Fatal("expected ge-0/0/2 unit 80 CoS binding")
+	}
+	// The make-or-break: the profile's shaping-rate materialized on the unit
+	// shaper. RED on revert = 0 (silent zero-shaping).
+	if got, want := unit.ShapingRateBytes, parseBandwidthLimit("9g"); got != want {
+		t.Fatalf("unit shaping-rate after TCP resolution = %d, want %d (zero-shaping regression)", got, want)
+	}
+	if got := unit.SchedulerMap; got != "edge-map" {
+		t.Fatalf("unit scheduler-map after TCP resolution = %q, want edge-map", got)
+	}
+	if got := unit.OutputTrafficControlProfile; got != "wan-tcp" {
+		t.Fatalf("unit output-traffic-control-profile = %q, want wan-tcp", got)
+	}
+}
+
+// TestCompileCoSTrafficControlProfileDirectUnitKnobWins pins the precedence: a
+// direct unit-level shaping-rate / scheduler-map overrides the profile's
+// (Junos gives an explicit unit binding precedence over the profile).
+func TestCompileCoSTrafficControlProfileDirectUnitKnobWins(t *testing.T) {
+	cfg := compileHB167(t, []string{
+		"set class-of-service forwarding-classes queue 0 best-effort",
+		"set class-of-service scheduler-maps edge-map forwarding-class best-effort scheduler be-sched",
+		"set class-of-service scheduler-maps other-map forwarding-class best-effort scheduler be-sched",
+		"set class-of-service schedulers be-sched transmit-rate 5g",
+		"set class-of-service traffic-control-profiles wan-tcp shaping-rate 9g",
+		"set class-of-service traffic-control-profiles wan-tcp scheduler-map edge-map",
+		"set class-of-service interfaces ge-0/0/2 unit 80 output-traffic-control-profile wan-tcp",
+		"set class-of-service interfaces ge-0/0/2 unit 80 shaping-rate 3g",
+		"set class-of-service interfaces ge-0/0/2 unit 80 scheduler-map other-map",
+		"set system dataplane-type userspace",
+	})
+	unit := cfg.ClassOfService.Interfaces["ge-0/0/2"].Units[80]
+	if got, want := unit.ShapingRateBytes, parseBandwidthLimit("3g"); got != want {
+		t.Fatalf("unit shaping-rate = %d, want %d (direct knob must win)", got, want)
+	}
+	if got := unit.SchedulerMap; got != "other-map" {
+		t.Fatalf("unit scheduler-map = %q, want other-map (direct knob must win)", got)
+	}
+}
+
+// TestCompileCoSTrafficControlProfileInterfaceLevel pins that an
+// interface-level output-traffic-control-profile applies to every configured
+// logical unit on the port (folded through applyCoSInterfaceLevelBindings then
+// resolved).
+func TestCompileCoSTrafficControlProfileInterfaceLevel(t *testing.T) {
+	cfg := compileHB167(t, []string{
+		"set interfaces ge-0/0/2 unit 50 family inet address 172.16.50.8/24",
+		"set interfaces ge-0/0/2 unit 80 family inet address 172.16.80.8/24",
+		"set class-of-service traffic-control-profiles wan-tcp shaping-rate 9g",
+		"set class-of-service interfaces ge-0/0/2 output-traffic-control-profile wan-tcp",
+		"set system dataplane-type userspace",
+	})
+	iface := cfg.ClassOfService.Interfaces["ge-0/0/2"]
+	if iface == nil {
+		t.Fatal("expected ge-0/0/2 CoS interface")
+	}
+	for _, u := range []int{50, 80} {
+		unit := iface.Units[u]
+		if unit == nil {
+			t.Fatalf("expected unit %d to inherit interface-level TCP binding", u)
+		}
+		if got, want := unit.ShapingRateBytes, parseBandwidthLimit("9g"); got != want {
+			t.Fatalf("unit %d shaping-rate = %d, want %d", u, got, want)
+		}
+	}
+}
+
+// TestValidateCoSTrafficControlProfileAdvisories pins the two advisories:
+// guaranteed-rate/delay-buffer-rate accepted-but-inert, and a dangling
+// output-traffic-control-profile reference (inert / not shaped).
+func TestValidateCoSTrafficControlProfileAdvisories(t *testing.T) {
+	// guaranteed-rate / delay-buffer-rate inert advisory.
+	cfg := compileHB167(t, []string{
+		"set class-of-service traffic-control-profiles wan-tcp shaping-rate 9g",
+		"set class-of-service traffic-control-profiles wan-tcp guaranteed-rate 2g",
+		"set class-of-service interfaces ge-0/0/2 unit 80 output-traffic-control-profile wan-tcp",
+		"set system dataplane-type userspace",
+	})
+	if !hasWarningContaining(ValidateConfig(cfg), "guaranteed-rate / delay-buffer-rate are accepted") {
+		t.Fatalf("expected guaranteed-rate inert advisory, got %v", ValidateConfig(cfg))
+	}
+
+	// Dangling reference advisory.
+	cfg2 := compileHB167(t, []string{
+		"set class-of-service interfaces ge-0/0/2 unit 80 output-traffic-control-profile missing-tcp",
+		"set system dataplane-type userspace",
+	})
+	if !hasWarningContaining(ValidateConfig(cfg2), "undefined output-traffic-control-profile") {
+		t.Fatalf("expected dangling TCP-reference advisory, got %v", ValidateConfig(cfg2))
+	}
+}

--- a/pkg/config/compiler_f3_hb167_test.go
+++ b/pkg/config/compiler_f3_hb167_test.go
@@ -1,0 +1,52 @@
+package config
+
+import "testing"
+
+// TestFirewallInterfaceSpecificAdvisory pins fable-167 F-3a: interface-specific
+// is captured and warned as accepted-but-inert. RED on revert: the token is
+// dropped (unknown-keyword ignored) → no field, no advisory.
+func TestFirewallInterfaceSpecificAdvisory(t *testing.T) {
+	cfg := compileHB167(t, []string{
+		"set firewall family inet filter guard interface-specific",
+		"set firewall family inet filter guard term t1 then accept",
+	})
+	filter := cfg.Firewall.FiltersInet["guard"]
+	if filter == nil || !filter.InterfaceSpecific {
+		t.Fatalf("expected filter guard InterfaceSpecific=true, got %#v", filter)
+	}
+	if !hasWarningContaining(ValidateConfig(cfg), "interface-specific is accepted for compatibility") {
+		t.Fatalf("expected interface-specific advisory, got %v", ValidateConfig(cfg))
+	}
+}
+
+// TestCoSInetPrecedenceExpAdvisory pins fable-167 F-3b: inet-precedence
+// classifiers/rewrite and exp rewrite are captured and warned as inert.
+func TestCoSInetPrecedenceExpAdvisory(t *testing.T) {
+	cfg := compileHB167(t, []string{
+		"set class-of-service forwarding-classes queue 0 best-effort",
+		"set class-of-service classifiers inet-precedence prec-cl forwarding-class best-effort loss-priority low code-points 0",
+		"set class-of-service rewrite-rules inet-precedence prec-rw forwarding-class best-effort loss-priority low code-point 0",
+		"set class-of-service rewrite-rules exp exp-rw forwarding-class best-effort loss-priority low code-point 0",
+		"set system dataplane-type userspace",
+	})
+	cos := cfg.ClassOfService
+	if len(cos.INetPrecedenceClassifiers) == 0 {
+		t.Fatal("expected inet-precedence classifier name recorded")
+	}
+	if len(cos.INetPrecedenceRewriteRules) == 0 {
+		t.Fatal("expected inet-precedence rewrite-rule name recorded")
+	}
+	if len(cos.EXPRewriteRules) == 0 {
+		t.Fatal("expected exp rewrite-rule name recorded")
+	}
+	warnings := ValidateConfig(cfg)
+	for _, want := range []string{
+		"classifiers inet-precedence is accepted for compatibility but inert",
+		"rewrite-rules inet-precedence is accepted for compatibility but inert",
+		"rewrite-rules exp is accepted for compatibility but inert",
+	} {
+		if !hasWarningContaining(warnings, want) {
+			t.Fatalf("missing advisory %q in %v", want, warnings)
+		}
+	}
+}

--- a/pkg/config/compiler_firewall.go
+++ b/pkg/config/compiler_firewall.go
@@ -202,6 +202,12 @@ func compileFirewall(node *Node, fw *FirewallConfig) error {
 			for _, filterInst := range namedInstances(afNode.FindChildren("filter")) {
 				filter := &FirewallFilter{Name: filterInst.name}
 
+				// #4316 (fable-167 F-3a): record interface-specific so the
+				// commit advisory can flag the single-shared-counter divergence.
+				if filterInst.node.FindChild("interface-specific") != nil {
+					filter.InterfaceSpecific = true
+				}
+
 				for _, termInst := range namedInstances(filterInst.node.FindChildren("term")) {
 					term := &FirewallFilterTerm{
 						Name: termInst.name,

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -898,6 +898,43 @@ func ValidateConfig(cfg *Config) []string {
 		warnedClassifierLossPriority := false
 		warnedRewriteLossPriority := false
 		warnedPriorityLowMinShare := false
+		// #4315 (fable-167 F-2): a traffic-control-profile's guaranteed-rate
+		// and delay-buffer-rate are typed + stored so garbage is rejected at
+		// commit, but the userspace shaper has no per-unit consumer for them
+		// (there is no absolute per-unit guaranteed-rate reservation — the
+		// #1614 A1 guarantee-rate is a proportional fraction, a distinct
+		// mechanism). shaping-rate + scheduler-map ARE enforced (folded into
+		// the bound unit). Warn once so an operator who sets guaranteed-rate /
+		// delay-buffer-rate is not misled into believing they bound the
+		// minimum rate or buffer. Mirrors the #4218/#4220 accepted-but-inert
+		// doctrine.
+		warnedTCPInert := false
+		for _, tcp := range cos.TrafficControlProfiles {
+			if tcp == nil {
+				continue
+			}
+			if (tcp.GuaranteedRateBytes > 0 || tcp.DelayBufferRateBytes > 0) && !warnedTCPInert {
+				warnings = append(warnings,
+					"class-of-service traffic-control-profiles guaranteed-rate / delay-buffer-rate are accepted for compatibility but inert: the userspace dataplane enforces only the profile's shaping-rate and scheduler-map on the bound unit (#4315), so those values have no runtime effect")
+				warnedTCPInert = true
+			}
+		}
+		// #4316 (fable-167 F-3b): inet-precedence classifiers/rewrite and exp
+		// rewrite are accepted for Junos compatibility but INERT — the
+		// userspace dataplane classifies/rewrites on dscp / ieee-802.1 only.
+		// Warn once per category so the operator is not misled.
+		if len(cos.INetPrecedenceClassifiers) > 0 {
+			warnings = append(warnings,
+				"class-of-service classifiers inet-precedence is accepted for compatibility but inert: the userspace dataplane classifies on dscp / ieee-802.1 only, so IP-precedence classification has no runtime effect")
+		}
+		if len(cos.INetPrecedenceRewriteRules) > 0 {
+			warnings = append(warnings,
+				"class-of-service rewrite-rules inet-precedence is accepted for compatibility but inert: the userspace dataplane rewrites dscp on egress only, so IP-precedence rewrite has no runtime effect")
+		}
+		if len(cos.EXPRewriteRules) > 0 {
+			warnings = append(warnings,
+				"class-of-service rewrite-rules exp is accepted for compatibility but inert: the userspace dataplane rewrites dscp on egress only, so MPLS EXP rewrite has no runtime effect")
+		}
 		for _, class := range cos.ForwardingClasses {
 			if class == nil {
 				continue
@@ -1088,6 +1125,17 @@ func ValidateConfig(cfg *Config) []string {
 							iface.Name, unit.Unit, unit.SchedulerMap))
 					}
 				}
+				// #4315 (fable-167 F-2): a dangling output-traffic-control-profile
+				// reference resolves to no shaper — the binding shapes nothing.
+				// Warn so the operator sees the inert binding rather than a silent
+				// zero-shaping commit.
+				if unit.OutputTrafficControlProfile != "" {
+					if _, ok := cos.TrafficControlProfiles[unit.OutputTrafficControlProfile]; !ok {
+						warnings = append(warnings, fmt.Sprintf(
+							"class-of-service interface %s unit %d references undefined output-traffic-control-profile %q; the unit is not shaped",
+							iface.Name, unit.Unit, unit.OutputTrafficControlProfile))
+					}
+				}
 				if unit.DSCPClassifier != "" {
 					if _, ok := cos.DSCPClassifiers[unit.DSCPClassifier]; !ok {
 						warnings = append(warnings, fmt.Sprintf(
@@ -1186,6 +1234,11 @@ func ValidateConfig(cfg *Config) []string {
 	// the QoS action is inert. Same principle as #2486 (ipsec-vpn): never
 	// silently accept config the dataplane cannot enforce.
 	warnings = append(warnings, validateFilterLossPriorityWarnings(cfg)...)
+
+	// #4316 (fable-167 F-3a): `firewall filter <n> interface-specific` is
+	// accepted but xpf keeps a single shared counter (not per-interface
+	// instances). WARN so the operator knows `show firewall` aggregates.
+	warnings = append(warnings, validateFirewallInterfaceSpecificWarnings(cfg)...)
 
 	// #3445: an lo0 INPUT filter is mirrored onto a kernel nftables chain
 	// (the PRIMARY enforcement for host-bound traffic the XDP shim shunts to the
@@ -1484,6 +1537,50 @@ func validateFilterLossPriorityWarnings(cfg *Config) []string {
 						"dataplane (no per-packet loss-priority action is enforced)",
 					family, name, term.Name, term.LossPriority))
 			}
+		}
+	}
+	emit("inet", cfg.Firewall.FiltersInet)
+	emit("inet6", cfg.Firewall.FiltersInet6)
+	return warnings
+}
+
+// validateFirewallInterfaceSpecificWarnings emits a WARN-only commit-time
+// message for each firewall filter carrying `interface-specific` (fable-167
+// F-3a, #4316). Junos instantiates a distinct counter/policer instance per
+// interface the filter is attached to; xpf keeps a single shared counter, so
+// `show firewall` aggregates across interfaces. The flag is accepted (never a
+// hard reject — it is valid Junos) but its per-interface-instance semantics
+// are not honored. WARN once per filter, naming it.
+func validateFirewallInterfaceSpecificWarnings(cfg *Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	var warnings []string
+	seen := make(map[string]struct{})
+	emit := func(family string, filters map[string]*FirewallFilter) {
+		names := make([]string, 0, len(filters))
+		for name := range filters {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			filter := filters[name]
+			if filter == nil || !filter.InterfaceSpecific {
+				continue
+			}
+			// A `family any` filter is folded into both pools; dedup by name
+			// so it is not double-reported.
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			warnings = append(warnings, fmt.Sprintf(
+				"firewall filter %q interface-specific is accepted for compatibility "+
+					"but inert: xpf keeps a single shared counter/policer instance "+
+					"(not a distinct per-interface instance), so `show firewall` "+
+					"aggregates counts across every interface the filter is attached to",
+				name))
+			_ = family
 		}
 	}
 	emit("inet", cfg.Firewall.FiltersInet)

--- a/pkg/config/schema_cos.go
+++ b/pkg/config/schema_cos.go
@@ -25,6 +25,17 @@ var schemaClassOfService = &schemaNode{desc: "Class of service configuration", c
 				}},
 			}},
 		}},
+		// #4316 (fable-167 F-3b): IP-precedence classifier. Accepted for
+		// Junos compatibility (completion + ? help) but INERT — the userspace
+		// dataplane classifies only on dscp / ieee-802.1. A commit advisory
+		// surfaces the inertness.
+		"inet-precedence": {desc: "IP-precedence classifier (accepted for Junos compatibility; NOT enforced — the dataplane classifies on dscp / ieee-802.1 only)", args: 1, multi: true, placeholder: "<classifier-name>", children: map[string]*schemaNode{
+			"forwarding-class": {desc: "Forwarding class to assign to matching code points", args: 1, multi: true, placeholder: "<class-name>", children: map[string]*schemaNode{
+				"loss-priority": {desc: "Loss priority (accepted for Junos compatibility; not enforced by the userspace dataplane)", args: 1, multi: true, placeholder: "<level>", children: map[string]*schemaNode{
+					"code-points": {desc: "IP-precedence code points to match (0..7)", args: 1, multi: true, placeholder: "<code-points>", children: nil},
+				}},
+			}},
+		}},
 	}},
 	"rewrite-rules": {desc: "Egress rewrite rules mapping forwarding classes to code points", children: map[string]*schemaNode{
 		"dscp": {desc: "DSCP rewrite rule", args: 1, multi: true, placeholder: "<rewrite-rule-name>", children: map[string]*schemaNode{
@@ -32,6 +43,25 @@ var schemaClassOfService = &schemaNode{desc: "Class of service configuration", c
 				"loss-priority": {desc: "Loss priority (accepted for Junos compatibility; not enforced by the userspace dataplane)", args: 1, multi: true, placeholder: "<level>", children: map[string]*schemaNode{
 					"code-point":  {desc: "DSCP code point to write (alias such as ef, af11, cs6, or numeric 0..63)", args: 1, placeholder: "<code-point>", children: nil},
 					"code-points": {desc: "DSCP code point to write (alias of code-point; first value is used)", args: 1, multi: true, placeholder: "<code-points>", children: nil},
+				}},
+			}},
+		}},
+		// #4316 (fable-167 F-3b): IP-precedence and MPLS EXP egress rewrite.
+		// Accepted for Junos compatibility (completion + ? help) but INERT —
+		// the userspace dataplane rewrites only dscp on egress. Commit advisory.
+		"inet-precedence": {desc: "IP-precedence rewrite rule (accepted for Junos compatibility; NOT enforced — the dataplane rewrites dscp only)", args: 1, multi: true, placeholder: "<rewrite-rule-name>", children: map[string]*schemaNode{
+			"forwarding-class": {desc: "Forwarding class whose packets get the rewritten code point", args: 1, multi: true, placeholder: "<class-name>", children: map[string]*schemaNode{
+				"loss-priority": {desc: "Loss priority (accepted for Junos compatibility; not enforced by the userspace dataplane)", args: 1, multi: true, placeholder: "<level>", children: map[string]*schemaNode{
+					"code-point":  {desc: "IP-precedence code point to write (0..7)", args: 1, placeholder: "<code-point>", children: nil},
+					"code-points": {desc: "IP-precedence code point to write (alias of code-point; first value is used)", args: 1, multi: true, placeholder: "<code-points>", children: nil},
+				}},
+			}},
+		}},
+		"exp": {desc: "MPLS EXP rewrite rule (accepted for Junos compatibility; NOT enforced — the dataplane rewrites dscp only)", args: 1, multi: true, placeholder: "<rewrite-rule-name>", children: map[string]*schemaNode{
+			"forwarding-class": {desc: "Forwarding class whose packets get the rewritten code point", args: 1, multi: true, placeholder: "<class-name>", children: map[string]*schemaNode{
+				"loss-priority": {desc: "Loss priority (accepted for Junos compatibility; not enforced by the userspace dataplane)", args: 1, multi: true, placeholder: "<level>", children: map[string]*schemaNode{
+					"code-point":  {desc: "MPLS EXP code point to write (0..7)", args: 1, placeholder: "<code-point>", children: nil},
+					"code-points": {desc: "MPLS EXP code point to write (alias of code-point; first value is used)", args: 1, multi: true, placeholder: "<code-points>", children: nil},
 				}},
 			}},
 		}},
@@ -115,6 +145,49 @@ var schemaClassOfService = &schemaNode{desc: "Class of service configuration", c
 			"scheduler": {desc: "Scheduler to apply to this forwarding class", args: 1, placeholder: "<scheduler-name>", children: nil},
 		}},
 	}},
+	// #4315 (fable-167 F-2): the Junos hierarchical shaping profile. A
+	// profile is bound to a logical interface's egress via
+	// `interfaces <if> unit N output-traffic-control-profile <name>`;
+	// resolveCoSTrafficControlProfiles folds shaping-rate + scheduler-map
+	// into the referencing unit's existing per-unit shaper. shaping-rate is
+	// a plain typed rate leaf here (no burst-size child, unlike the
+	// interface-level cosShapingRateSchema — Junos sizes the buffer via
+	// delay-buffer-rate, not burst-size). guaranteed-rate / delay-buffer-rate
+	// are typed (garbage rejected at commit) but currently INERT — no
+	// per-unit dataplane consumer — and carry a commit advisory.
+	"traffic-control-profiles": {desc: "Hierarchical traffic-shaping profiles bound to an interface via output-traffic-control-profile", args: 1, multi: true, placeholder: "<profile-name>", children: map[string]*schemaNode{
+		"shaping-rate": {
+			desc:          "Peak shaping rate in bits per second (k/m/g suffix) — enforced as the root shaper on the bound unit",
+			args:          1,
+			placeholder:   "<rate>",
+			valueType:     ValueRate,
+			valueDesc:     "Bandwidth (e.g. 100k, 10m, 1g) or bps integer; >= 8 bps",
+			valueExamples: []string{"10m", "1g", "10g"},
+			validator:     ValidateRate,
+			children:      nil,
+		},
+		"guaranteed-rate": {
+			desc:          "Guaranteed minimum rate in bits per second (accepted for Junos compatibility; NOT yet enforced per-unit by the userspace dataplane)",
+			args:          1,
+			placeholder:   "<rate>",
+			valueType:     ValueRate,
+			valueDesc:     "Bandwidth (e.g. 100k, 10m, 1g) or bps integer; >= 8 bps (accepted but currently inert)",
+			valueExamples: []string{"5m", "500m"},
+			validator:     ValidateRate,
+			children:      nil,
+		},
+		"delay-buffer-rate": {
+			desc:          "Delay-buffer sizing rate in bits per second (accepted for Junos compatibility; NOT yet enforced by the userspace dataplane)",
+			args:          1,
+			placeholder:   "<rate>",
+			valueType:     ValueRate,
+			valueDesc:     "Bandwidth (e.g. 100k, 10m, 1g) or bps integer; >= 8 bps (accepted but currently inert)",
+			valueExamples: []string{"10m", "1g"},
+			validator:     ValidateRate,
+			children:      nil,
+		},
+		"scheduler-map": {desc: "Scheduler map applied to the unit bound to this profile", args: 1, placeholder: "<map-name>", children: nil},
+	}},
 	"interfaces": {desc: "Apply CoS to an interface", args: 1, multi: true, placeholder: "<interface-name>", children: map[string]*schemaNode{
 		"unit": {desc: "Logical unit number", args: 1, multi: true, placeholder: "<unit-number>", children: map[string]*schemaNode{
 			"classifiers": {desc: "Classifiers applied to traffic arriving on this unit", children: map[string]*schemaNode{
@@ -124,10 +197,11 @@ var schemaClassOfService = &schemaNode{desc: "Class of service configuration", c
 			"rewrite-rules": {desc: "Rewrite rules applied to traffic leaving this unit", children: map[string]*schemaNode{
 				"dscp": {desc: "DSCP rewrite rule to apply", args: 1, placeholder: "<rewrite-rule-name>", children: nil},
 			}},
-			"shaping-rate":            cosShapingRateSchema("Shaping rate for this unit in bits per second (k/m/g suffixes)"),
-			"scheduler-map":           {desc: "Scheduler map to apply to this unit", args: 1, placeholder: "<map-name>", children: nil},
-			"oversubscription-policy": cosOversubscriptionPolicySchema(),
-			"priority-low-min-share":  cosPriorityLowMinShareSchema(),
+			"shaping-rate":                   cosShapingRateSchema("Shaping rate for this unit in bits per second (k/m/g suffixes)"),
+			"scheduler-map":                  {desc: "Scheduler map to apply to this unit", args: 1, placeholder: "<map-name>", children: nil},
+			"output-traffic-control-profile": {desc: "Bind a traffic-control-profile to this unit's egress (applies its shaping-rate + scheduler-map)", args: 1, placeholder: "<profile-name>", children: nil},
+			"oversubscription-policy":        cosOversubscriptionPolicySchema(),
+			"priority-low-min-share":         cosPriorityLowMinShareSchema(),
 		}},
 		// #4021: interface-level (physical, no unit) bindings. In Junos these
 		// apply to every logical unit on the port; a unit-level binding
@@ -141,10 +215,11 @@ var schemaClassOfService = &schemaNode{desc: "Class of service configuration", c
 		"rewrite-rules": {desc: "Rewrite rules applied at the interface level (all units)", children: map[string]*schemaNode{
 			"dscp": {desc: "DSCP rewrite rule to apply", args: 1, placeholder: "<rewrite-rule-name>", children: nil},
 		}},
-		"shaping-rate":            cosShapingRateSchema("Shaping rate applied at the interface level in bits per second (k/m/g suffixes)"),
-		"scheduler-map":           {desc: "Scheduler map to apply at the interface level (all units)", args: 1, placeholder: "<map-name>", children: nil},
-		"oversubscription-policy": cosOversubscriptionPolicySchema(),
-		"priority-low-min-share":  cosPriorityLowMinShareSchema(),
+		"shaping-rate":                   cosShapingRateSchema("Shaping rate applied at the interface level in bits per second (k/m/g suffixes)"),
+		"scheduler-map":                  {desc: "Scheduler map to apply at the interface level (all units)", args: 1, placeholder: "<map-name>", children: nil},
+		"output-traffic-control-profile": {desc: "Bind a traffic-control-profile at the interface level (all units)", args: 1, placeholder: "<profile-name>", children: nil},
+		"oversubscription-policy":        cosOversubscriptionPolicySchema(),
+		"priority-low-min-share":         cosPriorityLowMinShareSchema(),
 	}},
 	"fairness": {desc: "Dataplane fairness observability configuration", children: map[string]*schemaNode{
 		"rss-expectation": {desc: "Declarative RSS flow-distribution expectations evaluated against live dataplane status (shown in fairness output and exported as Prometheus gauges)", children: map[string]*schemaNode{
@@ -276,6 +351,12 @@ var schemaFirewall = &schemaNode{desc: "Firewall filters and policers", children
 	"family": {desc: "Protocol family for firewall filters", compoundKey: true, children: map[string]*schemaNode{
 		"inet": {desc: "IPv4 firewall filters", children: map[string]*schemaNode{
 			"filter": {desc: "Firewall filter", args: 1, placeholder: "<filter-name>", children: map[string]*schemaNode{
+				// #4316 (fable-167 F-3a): interface-specific instantiates a
+				// per-interface counter/policer instance in Junos. xpf accepts
+				// it (completion + ? help) but keeps a single shared counter;
+				// a commit advisory (compiler_validate_warn.go) surfaces the
+				// divergence.
+				"interface-specific": {desc: "Instantiate per-interface counter/policer instances (accepted; xpf keeps a single shared counter — advisory at commit)", children: nil},
 				"term": {desc: "Filter term", args: 1, placeholder: "<term-name>", children: map[string]*schemaNode{
 					"from": {desc: "Match conditions", children: map[string]*schemaNode{
 						"source-address":          {desc: "Match source address", args: 1, multi: true, placeholder: "<address>", children: nil},
@@ -336,6 +417,12 @@ var schemaFirewall = &schemaNode{desc: "Firewall filters and policers", children
 		}},
 		"inet6": {desc: "IPv6 firewall filters", children: map[string]*schemaNode{
 			"filter": {desc: "Firewall filter", args: 1, placeholder: "<filter-name>", children: map[string]*schemaNode{
+				// #4316 (fable-167 F-3a): interface-specific instantiates a
+				// per-interface counter/policer instance in Junos. xpf accepts
+				// it (completion + ? help) but keeps a single shared counter;
+				// a commit advisory (compiler_validate_warn.go) surfaces the
+				// divergence.
+				"interface-specific": {desc: "Instantiate per-interface counter/policer instances (accepted; xpf keeps a single shared counter — advisory at commit)", children: nil},
 				"term": {desc: "Filter term", args: 1, placeholder: "<term-name>", children: map[string]*schemaNode{
 					"from": {desc: "Match conditions", children: map[string]*schemaNode{
 						"source-address":          {desc: "Match source address", args: 1, multi: true, placeholder: "<address>", children: nil},

--- a/pkg/config/types_cos.go
+++ b/pkg/config/types_cos.go
@@ -15,6 +15,45 @@ type ClassOfServiceConfig struct {
 	SchedulerMaps        map[string]*CoSSchedulerMap
 	Interfaces           map[string]*CoSInterface
 	FairnessExpectations []*CoSFairnessExpectation
+	// INetPrecedenceClassifiers / INetPrecedenceRewriteRules / EXPRewriteRules
+	// record the NAMES of `inet-precedence` classifiers, `inet-precedence`
+	// rewrite-rules, and `exp` rewrite-rules configured (fable-167 F-3b,
+	// #4316). These behavior-aggregate maps are accepted for Junos
+	// compatibility but INERT — the userspace dataplane classifies and
+	// rewrites on dscp / ieee-802.1 only. Names are recorded solely to drive
+	// the accepted-but-inert commit advisory; no runtime structure is built.
+	INetPrecedenceClassifiers  []string
+	INetPrecedenceRewriteRules []string
+	EXPRewriteRules            []string
+	// TrafficControlProfiles holds the Junos hierarchical shaping profiles
+	// (`class-of-service traffic-control-profiles <name>`). A profile is
+	// bound to a logical interface's egress by
+	// `interfaces <if> unit N output-traffic-control-profile <name>`;
+	// resolveCoSTrafficControlProfiles folds the bounded knobs
+	// (shaping-rate, scheduler-map) into the referencing CoSInterfaceUnit so
+	// the existing per-unit shaper enforces them. Before this modeling the
+	// whole binding was silently dropped — a clean commit with ZERO shaping
+	// (fable-167 F-2, #4315).
+	TrafficControlProfiles map[string]*CoSTrafficControlProfile
+}
+
+// CoSTrafficControlProfile models one Junos traffic-control-profile
+// (`class-of-service traffic-control-profiles <name>`). The BOUNDED knobs
+// map onto xpf's existing per-unit shaper: ShapingRateBytes becomes the
+// unit root shaper and SchedulerMap the unit scheduler-map when the profile
+// is bound via output-traffic-control-profile
+// (resolveCoSTrafficControlProfiles). GuaranteedRateBytes and
+// DelayBufferRateBytes are captured for `show configuration` fidelity and a
+// commit advisory but have NO per-unit dataplane consumer yet
+// (accepted-but-not-enforced) — there is no absolute per-unit guaranteed-rate
+// or delay-buffer reservation in the userspace shaper (the #1614 A1
+// guarantee-rate is a proportional FRACTION, a distinct mechanism).
+type CoSTrafficControlProfile struct {
+	Name                 string
+	ShapingRateBytes     uint64 // bytes/sec; 0 = unset
+	GuaranteedRateBytes  uint64 // bytes/sec; 0 = unset (accepted-but-inert)
+	DelayBufferRateBytes uint64 // bytes/sec; 0 = unset (accepted-but-inert)
+	SchedulerMap         string
 }
 
 // CoSForwardingClass maps a forwarding-class name to a queue number.
@@ -144,6 +183,15 @@ type CoSInterfaceUnit struct {
 	DSCPClassifier     string
 	IEEE8021Classifier string
 	DSCPRewriteRule    string
+	// OutputTrafficControlProfile is the raw
+	// `output-traffic-control-profile <name>` reference bound to this unit's
+	// egress (fable-167 F-2, #4315). resolveCoSTrafficControlProfiles (run
+	// after applyCoSInterfaceLevelBindings) looks up the named profile and
+	// folds its shaping-rate + scheduler-map into ShapingRateBytes /
+	// SchedulerMap when those are not already set directly on the unit
+	// (a direct unit-level knob wins). Retained on the unit for
+	// `show configuration` fidelity and the undefined-reference advisory.
+	OutputTrafficControlProfile string
 	// OversubscriptionPolicy (#1614 A1) is the operator-selectable
 	// behaviour when sum of exact-class transmit-rates exceeds the
 	// interface's shaping-rate. Empty or "proportional" (default)

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -1016,6 +1016,14 @@ type ThreeColorPolicerConfig struct {
 type FirewallFilter struct {
 	Name  string
 	Terms []*FirewallFilterTerm
+	// InterfaceSpecific records the Junos `interface-specific` flag
+	// (fable-167 F-3a, #4316). In Junos it instantiates a distinct
+	// counter/policer instance per interface the filter is attached to; xpf
+	// keeps a single shared counter, so the flag is accepted but inert. It
+	// is recorded here only to drive the commit advisory
+	// (validateFirewallInterfaceSpecificWarnings); the dataplane never reads
+	// it.
+	InterfaceSpecific bool
 }
 
 // FirewallFilterTerm is a single match/action term within a filter.

--- a/pkg/natshow/static.go
+++ b/pkg/natshow/static.go
@@ -3,6 +3,7 @@ package natshow
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/psaab/xpf/pkg/config"
 )
@@ -24,6 +25,60 @@ func RenderStatic(w io.Writer, cfg *config.Config) {
 				fmt.Fprintf(w, "    Then nptv6-prefix:         %s\n", rule.Then)
 			} else {
 				fmt.Fprintf(w, "    Then static-nat prefix:    %s\n", rule.Then)
+			}
+		}
+		io.WriteString(w, "\n")
+	}
+}
+
+// RenderStaticRule renders `show security nat static rule [detail]` — the
+// per-rule drill-down that mirrors source/destination NAT's `rule [detail]`
+// (fable-167 C-1b, #4314). Without detail it lists each rule's match/then
+// prefixes; with detail it also surfaces the source-address restriction,
+// destination-port / mapped-port translation, prefix-name reference, and the
+// translation-target routing-instance — fields already carried on
+// config.StaticNATRule that the plain `static` view omits.
+func RenderStaticRule(w io.Writer, cfg *config.Config, detail bool) {
+	if cfg == nil || len(cfg.Security.NAT.Static) == 0 {
+		io.WriteString(w, "No static NAT rules configured.\n")
+		return
+	}
+	for _, rs := range cfg.Security.NAT.Static {
+		fmt.Fprintf(w, "Static NAT rule-set: %s\n", rs.Name)
+		if rs.FromZone != "" {
+			fmt.Fprintf(w, "  From zone: %s\n", rs.FromZone)
+		}
+		if detail && rs.FromInterface != "" {
+			fmt.Fprintf(w, "  From interface: %s\n", rs.FromInterface)
+		}
+		if detail && rs.FromRoutingInstance != "" {
+			fmt.Fprintf(w, "  From routing-instance: %s\n", rs.FromRoutingInstance)
+		}
+		for _, rule := range rs.Rules {
+			fmt.Fprintf(w, "  Rule: %s\n", rule.Name)
+			fmt.Fprintf(w, "    Match destination-address: %s\n", rule.Match)
+			if rule.IsNPTv6 {
+				fmt.Fprintf(w, "    Then nptv6-prefix:         %s\n", rule.Then)
+			} else {
+				fmt.Fprintf(w, "    Then static-nat prefix:    %s\n", rule.Then)
+			}
+			if !detail {
+				continue
+			}
+			if len(rule.SourceAddresses) > 0 {
+				fmt.Fprintf(w, "    Match source-address:      %s\n", strings.Join(rule.SourceAddresses, ", "))
+			}
+			if rule.MatchDestinationPort > 0 {
+				fmt.Fprintf(w, "    Match destination-port:    %d\n", rule.MatchDestinationPort)
+			}
+			if rule.MappedPort > 0 {
+				fmt.Fprintf(w, "    Then mapped-port:          %d\n", rule.MappedPort)
+			}
+			if rule.ThenPrefixName != "" {
+				fmt.Fprintf(w, "    Then prefix-name:          %s\n", rule.ThenPrefixName)
+			}
+			if rule.ThenRoutingInstance != "" {
+				fmt.Fprintf(w, "    Then routing-instance:     %s (accepted; cross-VRF post-translation routing not enforced)\n", rule.ThenRoutingInstance)
 			}
 		}
 		io.WriteString(w, "\n")


### PR DESCRIPTION
Closes #4314 Closes #4315 Closes #4316

fable-review-167 findings C-1 (CLI drill-downs), F-2 (CoS hierarchical
shaping), and F-3 (filter/CoS schema gaps). GO-only change (pkg/cmdtree +
pkg/cli + pkg/config); no cargo leg.

## C-1 (#4314) — grouped show/request drill-downs
The operational tree (pkg/cmdtree SSOT) was missing three drill-downs whose
data already exists:
- `show security ike/ipsec security-associations detail` — IKE detail was
  absent; IPsec detail was rendered by the handler but never advertised.
- `show security nat static rule [detail]` — source/destination NAT had it,
  static did not (RenderStaticRule surfaces source restriction, mapped-port,
  prefix-name, routing-instance from config.StaticNATRule).
- `request security policies check` — conservative shadow/redundancy lint
  over zone-pair policies (name-set containment; no address-book prefix
  resolution → no false positives; inverted-match / schedule-gated policies
  are never shadowers; never mutates config).

## F-2 (#4315) — CoS traffic-control-profiles (make-or-break)
`traffic-control-profiles <n> { shaping-rate; guaranteed-rate;
scheduler-map; delay-buffer-rate; }` bound via
`output-traffic-control-profile <n>` was unmodeled — it committed cleanly
and was **silently dropped**, so a profile-based shaping config applied ZERO
shaping while the operator believed shaping was on.

Modeled the profile + binding (unit + interface level) and **wired** the
bounded knobs: `resolveCoSTrafficControlProfiles` folds the profile's
shaping-rate + scheduler-map into the referencing unit's existing per-unit
shaper, so shaping actually materializes (a direct unit knob wins).
`guaranteed-rate` / `delay-buffer-rate` are typed + captured but
accepted-but-inert (no per-unit absolute reservation in the shaper — the
#1614 A1 guarantee-rate is a proportional *fraction*, distinct); a commit
advisory surfaces the inertness and a dangling reference warns. The
hierarchical guaranteed-rate / delay-buffer enforcement is a noted
userspace-dp follow-up.

RED-on-revert: the unit's shaping-rate resolves to 0 (silent zero-shaping)
without the resolution pass.

## F-3 (#4316) — filter/CoS schema gaps (accept-with-advisory)
- `firewall filter <n> interface-specific` — accepted + inert advisory (xpf
  keeps a single shared counter, not per-interface instances).
- CoS `classifiers inet-precedence` and `rewrite-rules inet-precedence`/`exp`
  — added to schema (completion) + accepted-but-inert advisories (the
  dataplane classifies/rewrites on dscp / ieee-802.1 only).
- cite-only: `from packet-length`/`ttl`/`ip-options`/`precedence` remain
  reject-at-commit (#3307); no change.

## Validation
`go test ./pkg/config/ ./pkg/cli/ ./pkg/cmdtree/ ./pkg/natshow/` green;
`go build ./...` clean; gofmt + vet clean on all touched files. New tests:
compiler_cos_tcp_hb167_test.go, compiler_f3_hb167_test.go,
tree_hb167_test.go, cli_request_policies_check_test.go. Docs updated:
cos-traffic-shaping.md, config-schema.md, junos-cli-reference.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi