### PR TITLE
docs: secrets-at-rest threat model (#4056) + VRRP accept-data no-op (#4080)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-07-06 — docs: drive-to-zero doc slices #4056 (config-store secrets-at-rest threat model) + #4080 (VRRP accept-data no-op)
+
+- **Timestamp**: 2026-07-06
+- **Action**: Drove two converged PLAN-READY doc-only slices to fixes.
+  (#4056) Replaced the "Follow-up (design, not shipped here)" pointer note
+  in pkg/configstore/README.md with an explicit secrets-at-rest threat
+  model: 0600 file + 0700 dir defend non-root local users + casual
+  leakage but NOT root compromise or physical disk theft; at-rest
+  encryption of the text copies is intentionally not done because the
+  unattended-boot appliance must keep the decryption key on-box next to
+  the ciphertext (master.key is a plain random 0600 file, no TPM/HSM
+  substrate) — theater vs the root/disk threat, so a real feature needs
+  a TPM/HSM-sealed key (deferred, #4056). Also documented that
+  transfer-on-commit scp's cleartext secrets off-box (the honest residual
+  to control). (#4080) Added a Gotchas note to pkg/vrrp/README.md that
+  accept-data is accepted for Junos compatibility but is a no-op under
+  xpf's VIP-as-real-address model: addVIPs installs each VIP as a real
+  kernel address via netlink.AddrAdd, so the master always accepts VIP
+  traffic (RFC 5798 Accept_Mode=on); accept-data=off is a deferred
+  dataplane+control-plane redesign. accept-data is ALREADY accepted at
+  commit (schema_interfaces.go / compiler_interfaces.go, covered by
+  existing tests) — no schema-accept needed, doc-only.
+- **Validation**: verified every claim against HEAD (3bc0d54ba) — perms
+  code (store_commit/store_persist/db/crypto 0600, dirs 0700), master.key
+  = io.ReadFull(rand.Reader) no TPM, transfer-on-commit scpArchiveTransfer
+  StrictHostKeyChecking=no, addVIPs netlink.AddrAdd, AcceptData compiled
+  but never read outside tests. go test ./pkg/config/... ./pkg/vrrp/...
+  green; go build ./... clean; gofmt + vet clean.
+- **File(s)**: pkg/configstore/README.md, pkg/vrrp/README.md, _Log.md
+
 ## 2026-07-05 — system: fable-167 PR #4311 review fixes (S-2 priv-esc + deny-commands advisory + S-4 sshd -t gate)
 
 - **Timestamp**: 2026-07-05

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -41,12 +41,45 @@ unaffected. The v2 audit journal (`.config.journal`) stays 0644 by
 design — it is compact metadata only (timestamp/action/detail), never
 config content or secret values (#1896).
 
-**Follow-up (design, not shipped here):** when master-password is set,
-the text rollback/archive/rescue copies still hold **cleartext** secrets
-(only the JSON DB body is encrypted). Encrypting or redacting secrets in
-those persisted text copies — with a decrypt-on-restore round-trip —
-needs a design decision (see the #4056 issue comment). This change ships
-the 0600 perms fix only.
+### Threat model — what 0600 + 0700 defends, and what it does not (#4056)
+
+The `0600` file perms plus `0700` directory perms defend against
+**non-root local users** (a compromised low-privilege process or an
+interactive account without root) reading the secret leaves, and against
+**casual leakage** of an individual file. That is the exposure #4058
+closed — the world-readable 0644 copies previously handed every firewall
+secret to any local user.
+
+They do **not** defend against **root compromise** or **physical disk
+theft** (a stolen disk, backup, or VM snapshot). At-rest encryption of
+the config store is intentionally **not** applied to the persisted text
+copies, and encrypting them with the on-box `master.key` would add **no
+real defense** against those two threats: this is an **unattended-boot
+appliance**, so the decryption key must live on the box (`rollback N` /
+`loadRollbackHistory` and a future rescue-load must restore secrets with
+no operator present). `master.key` is a plain random 0600 file
+(`crypto.go readOrCreateMasterKey`) in the same 0700 `.configdb`
+directory as the ciphertext, with **no TPM/HSM substrate** in the tree
+to seal it. An attacker who can read `xpf.conf.N` can equally read
+`master.key` one directory over and decrypt — so on-box encryption is
+theater against the root/disk-theft threat, not defense. A genuine
+at-rest feature therefore requires a **TPM/HSM-sealed key** (a separate,
+maintainer-gated work item — deferred, see #4056), not symmetric
+encryption with an on-box key.
+
+The JSON DB body is the one copy that IS AES-GCM encrypted when
+`system master-password` is set; the text rollback slots, archives, and
+`rescue.conf` stay cleartext-at-rest (0600) by the reasoning above.
+
+**Off-box copy — `transfer-on-commit`:** the honest place to control the
+residual is the off-box transfer, not on-box encryption. When
+`system archival configuration transfer-on-commit` is set, the daemon
+`scp`s the raw config file (cleartext secret leaves included) to the
+operator-configured archive sites on every commit
+(`daemon_flow.go scpArchiveTransfer`, `StrictHostKeyChecking=no`). This
+is the one genuine off-box copy of the secrets; the operator must secure
+the destination host and transport (extends the #651 warning about
+inline archive-site passwords).
 
 ## Entry points
 

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -471,6 +471,25 @@ dataplane reuses this Go walker, and do NOT try to consolidate them.
 
 - Use the **non-VIP** primary IP as source on advertisements. Sourcing
   from the VIP would self-filter peer adverts.
+- **`accept-data` is accepted for Junos config compatibility but is a
+  no-op (#4080).** The leaf parses and compiles into `AcceptData`
+  (`schema_interfaces.go`, `compiler_interfaces.go`), but no non-test
+  code reads it to gate behavior. xpf uses a **VIP-as-real-address**
+  model: on MASTER, `addVIPs()` installs each VIP as a genuine local
+  kernel address via `netlink.AddrAdd` (`instance.go`), so the Linux
+  stack itself answers ARP/ND and replies to ICMP echo / accepts
+  host-inbound traffic addressed to the VIP — regardless of the flag.
+  That is exactly RFC 5798 §6.1 `Accept_Mode=on` (a pingable VIP, the
+  common operator default), so `accept-data` on/off cannot change
+  today's behavior. `accept-data=off` (the RFC default,
+  don't-respond-unless-owner) is a **deferred non-default**: it would
+  require NOT installing the VIP as a real kernel address — which
+  directly conflicts with the `bpf_fib_lookup` dependency in
+  `becomeMaster` and the VIP install/reconcile machinery
+  (`ReconcileVIPs`, `KeepConfiguration=static`, GARP epoch/dampener) —
+  plus the dataplane taking over ARP/ND and dropping VIP-addressed
+  host-inbound traffic. That is a dataplane + control-plane redesign,
+  not a wired gate; see #4080.
 - RETH virtual MAC per node: `02:bf:72:CC:RR:NN`. Programmed via link
   DOWN → set MAC → link UP. This bounces all kernel addresses; VIPs are
   re-added by `ReconcileVIPs()` immediately afterwards, and the advert


### PR DESCRIPTION
Two converged PLAN-READY doc-only slices from the drive-to-zero backlog. No code behavior change — README + operator documentation only.

## #4056 — config-store secrets at rest (threat model)

The 0600 perms fix shipped in #4058. This replaces the pointer note in `pkg/configstore/README.md` with an **explicit threat model** (per the issue's converged plan):

- **0600 file + 0700 dir defend** non-root local users + casual file leakage (the #4058 exposure).
- They do **NOT defend** root compromise or physical disk theft.
- At-rest encryption of the persisted text copies (rollback slots, archives, `rescue.conf`) is intentionally **not applied**: an unattended-boot appliance must keep the decryption key on-box for `rollback N` / `loadRollbackHistory` / rescue restore. `master.key` is a plain random 0600 file (`crypto.go readOrCreateMasterKey`, `io.ReadFull(rand.Reader)`) in the same 0700 `.configdb` dir as the ciphertext, **no TPM/HSM substrate** — so on-box encryption is theater against the root/disk threat. A real feature needs a TPM/HSM-sealed key (deferred).
- Documents `transfer-on-commit` scp'ing cleartext secret leaves off-box (`daemon_flow.go scpArchiveTransfer`, `StrictHostKeyChecking=no`) — the honest residual to control, extending the #651 warning.

## #4080 — VRRP accept-data (no-op)

Adds a Gotchas note to `pkg/vrrp/README.md`: `accept-data` is accepted for Junos config compatibility but is a **no-op** under xpf's VIP-as-real-address model. On MASTER, `addVIPs()` installs each VIP as a real kernel address via `netlink.AddrAdd` (`instance.go`), so the stack always answers ARP/ND and accepts VIP-addressed host-inbound traffic — exactly RFC 5798 `Accept_Mode=on`. `accept-data=off` (RFC default) is a deferred dataplane + control-plane redesign (conflicts with the `bpf_fib_lookup` VIP dependency + reconcile machinery).

`accept-data` is **already accepted at commit** (`schema_interfaces.go` / `compiler_interfaces.go`, covered by existing config tests: `schema_validate_interfaces_test.go`, `vrrp_v6_test.go`, `dual_ast_differential_test.go`) — so this is doc-only, **no schema change needed**.

## Validation

- Verified every claim against HEAD (perms code, master.key no-TPM, transfer-on-commit scp, addVIPs AddrAdd, AcceptData compiled-but-never-read).
- `go test ./pkg/config/... ./pkg/vrrp/...` green
- `go build ./...` clean, `go vet` clean

Closes #4056
Closes #4080

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi