### PR TITLE
security follow-ups: family-any match gate, SNMP secret-log scrub, web-management auth (#4296 #4302 #4047)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -35784,3 +35784,29 @@ top.
   go test ./pkg/snmp/ green; go build ./pkg/snmp/ clean.
 - **File(s)**: pkg/snmp/agent.go, pkg/snmp/agent_secret_log_4302_test.go,
   _Log.md
+
+- **Timestamp**: 2026-07-06
+- **Action**: #4296 (fable-167 F-1 residual) firewall family-any specific-match
+  gate. #4287 dual-compiles a `family any` filter into BOTH FiltersInet and
+  FiltersInet6; a family-specific match under `family any` (a v4/v6
+  source/destination-address literal or a per-family icmp-type/icmp-code) was
+  dual-compiled VERBATIM, so the copy in the wrong pool never matches — the
+  v6 term falls through to the implicit ACCEPT (imperfect v6 under-block).
+  Added validateFirewallFilterFamilyAnyMatchesAST in compiler_firewall.go
+  (mirrors validateFirewallFilterFamilyCollisionsAST's strict-reject /
+  lenient-warn #1960/#3261 split), invoked in compiler.go right after the
+  collision gate; new lenientFirewallFilterFamilyAnyMatches flag set on both
+  lenient paths. Flagged leaves: source-address, destination-address,
+  icmp-type, icmp-code (next-header + prefix-lists deliberately excluded).
+  Gate fires BEFORE validateFilterAddressLiteralsStrict (#3433) so the address
+  case gets the clearer family-any message; icmp-type/icmp-code is the genuine
+  new coverage (#3433 does not check icmp).
+- **Validation**: compiler_firewall_family_any_match_4296_test.go — strict
+  reject of v4 source-address + symbolic icmp-type, lenient warn, family-
+  agnostic protocol under family any commits into both pools, single-family
+  address literals not flagged. Proven RED under gate-neuter: icmp-type went
+  nil (no other gate catches it); source-address error text reverted to the
+  #3433 message. go test ./pkg/config/... green; go build ./... clean.
+- **File(s)**: pkg/config/compiler_firewall.go, pkg/config/compiler.go,
+  pkg/config/compiler_firewall_family_any_match_4296_test.go,
+  docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -35810,3 +35810,30 @@ top.
 - **File(s)**: pkg/config/compiler_firewall.go, pkg/config/compiler.go,
   pkg/config/compiler_firewall_family_any_match_4296_test.go,
   docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-06
+- **Action**: #4047 (fable-161 F-155) web-management REST-auth gate. The
+  REST/config API (pkg/api) serves the mutating config endpoints with NO
+  auth middleware unless `system services web-management api-auth` is set;
+  binding it off-loopback (`web-management http|https interface <mgmt-if>`)
+  without api-auth exposes set/commit/rollback/system-action to the network.
+  Part A (pkg/config): validateWebManagementAuthStrict in compiler.go
+  (alongside validateDeviceMapStrict) hard-rejects an off-loopback bind
+  (HTTPInterface/HTTPSInterface non-empty) without api-auth at strict commit;
+  new lenientWebManagementAuth flag downgrades to a warning on load/peer-sync
+  (#1960 no-brick). Part B (pkg/daemon): daemon_run.go runtime clamp — when
+  the resolved bind is non-loopback AND apiCfg.Auth == nil, clamp to
+  127.0.0.1 + WARN (hostIsLoopback helper in daemon_cluster_bind.go), so a
+  leniently-loaded vulnerable config boots on loopback instead of exposed.
+  Updated two existing parse fixtures (TestSystemConfigWebManagementEnhanced,
+  TestSystemConfigSetSyntax) to carry api-auth (they bound interfaces without
+  auth). Part C (/metrics) was already done via #4162.
+- **Validation**: web_management_auth_4047_test.go — strict reject of HTTP +
+  HTTPS off-loopback no-auth, off-loopback+user / +api-key commits, loopback
+  no-auth commits, absent commits, lenient warn. Proven RED under gate-neuter
+  (accepted / no warning). go test ./pkg/config/... ./pkg/daemon/...
+  ./pkg/api/... green; go build ./... clean; gofmt + vet clean.
+- **File(s)**: pkg/config/compiler.go,
+  pkg/config/web_management_auth_4047_test.go,
+  pkg/config/parser_system_test.go, pkg/daemon/daemon_run.go,
+  pkg/daemon/daemon_cluster_bind.go, docs/architecture.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -35867,3 +35867,27 @@ top.
   pkg/config/web_management_auth_4047_test.go,
   pkg/config/parser_system_test.go, pkg/daemon/daemon_run.go,
   pkg/daemon/daemon_cluster_bind.go, docs/architecture.md, _Log.md
+
+- **Timestamp**: 2026-07-06
+- **Action**: #4047 review fold (PR #4319 MERGE-READY, 2 non-blocking items).
+  (1) IPv6 bind fix: daemon_run.go built the REST bind by string-concat
+  (`bindIP + ":8080"` / `httpsBindIP + ":8443"`), broken for an IPv6
+  interface address (no brackets -> net.SplitHostPort + net.Listen fail ->
+  the part-B clamp no-ops and the listener blackholes for an IPv6-only mgmt
+  interface). Changed both to net.JoinHostPort. (2) Part-B clamp refactored
+  into a pure testable helper clampBindToLoopback(addr, hasAuth) ->
+  (effectiveAddr, clamped) in daemon_cluster_bind.go, called from BOTH the
+  HTTP and HTTPS bind sites; clamps a non-loopback + no-auth bind to a
+  SAME-FAMILY loopback (::1 for IPv6, 127.0.0.1 for IPv4, port preserved).
+  Added web_management_clamp_4047_test.go: hostIsLoopback table (v4/v6
+  loopback + 127/8 + routable + wildcard + empty/unparseable-as-safe) and
+  clampBindToLoopback decision table (off-loopback+no-auth clamps same-family
+  incl [2001:db8::1]:8080 -> [::1]:8080; off-loopback+auth NOT clamped;
+  loopback untouched; wildcard 0.0.0.0 clamps; unparseable untouched).
+  Updated architecture.md part-B note (same-family loopback + JoinHostPort).
+  Merged origin/master (#4318 docs; _Log.md auto-merged, no conflict).
+- **Validation**: go test ./pkg/config/... ./pkg/snmp/... ./pkg/daemon/...
+  green (incl new clamp/hostIsLoopback tests); go build ./... clean; gofmt +
+  vet clean.
+- **File(s)**: pkg/daemon/daemon_run.go, pkg/daemon/daemon_cluster_bind.go,
+  pkg/daemon/web_management_clamp_4047_test.go, docs/architecture.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -35765,3 +35765,22 @@ top.
   gofmt + vet clean.
 - **File(s)**: pkg/cli/cli_request_policies_check.go,
   pkg/cli/cli_request_policies_check_test.go, _Log.md
+
+- **Timestamp**: 2026-07-06
+- **Action**: #4302 (follow-up to #4289 S-3) SNMP v2c community secret-leak
+  scrub. Two pre-existing debug log lines in pkg/snmp/agent.go echoed the
+  v2c community string (the shared secret): the invalid-community drop in
+  handleV2cPacket (`slog.Debug("SNMP: invalid community", "community",
+  string(community))`) and the read-only SET denial in handleSet. Scrubbed
+  both to log the request SOURCE instead of the secret, matching the #4289
+  source-denied log. handleSet now takes srcIP (threaded from
+  handleV2cPacket) so the denial is correlatable by source; the invalid-
+  community line logs `known_community=false`. The community value is only
+  used to echo back in the response varbind (buildResponse), never logged.
+- **Validation**: new agent_secret_log_4302_test.go captures Debug-level
+  slog output and asserts the community secret is ABSENT and the source IP
+  present for both paths; proven RED under revert (old lines leaked
+  s3cr3t-unknown-community / s3cr3t-readonly-community into the record).
+  go test ./pkg/snmp/ green; go build ./pkg/snmp/ clean.
+- **File(s)**: pkg/snmp/agent.go, pkg/snmp/agent_secret_log_4302_test.go,
+  _Log.md

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,10 +160,13 @@ editing cmdtree.
     new config that binds off-loopback without api-auth (downgraded to a
     warning on the tolerant load / peer-sync path so an already-persisted
     config still boots — #1960); and (B) a **runtime fail-safe clamp**
-    (`pkg/daemon/daemon_run.go`) that, when the resolved bind is non-loopback
-    and `apiCfg.Auth == nil`, pulls the bind back to `127.0.0.1` and WARNs —
-    so a leniently-loaded vulnerable config comes up on loopback (console/SSH
-    remain the lifeline) instead of exposed. Adding api-auth and recommitting
+    (`clampBindToLoopback` in `pkg/daemon`, applied in `daemon_run.go`) that,
+    when the resolved bind is non-loopback and `apiCfg.Auth == nil`, pulls the
+    bind back to a same-family loopback (`127.0.0.1` for IPv4, `::1` for IPv6,
+    port preserved) and WARNs — so a leniently-loaded vulnerable config comes up
+    on loopback (console/SSH remain the lifeline) instead of exposed. The bind
+    address is built with `net.JoinHostPort` so an IPv6 mgmt address is bracketed
+    and both the clamp and `net.Listen` parse it. Adding api-auth and recommitting
     restores the off-loopback bind. HTTPS is covered by the same rule
     (transport encryption without authentication still lets any reachable
     client mutate config).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,6 +146,27 @@ editing cmdtree.
   the deferred half of #4107.)
 - **HTTP REST** on `127.0.0.1:8080` — health, Prometheus `/metrics`,
   config endpoints, full gRPC parity.
+  - **Off-loopback bind requires api-auth (#4047).** The REST/config API
+    serves the mutating endpoints (`config set/delete/commit/commit-confirmed/
+    rollback/load/activate`, `system/action`) with **no** auth middleware
+    unless `system services web-management api-auth {user … | api-key …}`
+    is configured (`pkg/api/server.go` wires the middleware only when
+    `cfg.Auth != nil`). The default loopback bind is safe; a
+    `web-management http|https interface <mgmt-if>` stanza rebinds the API
+    to a routable address, so binding off-loopback **without** api-auth would
+    expose every mutating config RPC to the network. This is now closed at
+    two layers: (A) a **commit-time hard-reject**
+    (`validateWebManagementAuthStrict`, `pkg/config/compiler.go`) refuses a
+    new config that binds off-loopback without api-auth (downgraded to a
+    warning on the tolerant load / peer-sync path so an already-persisted
+    config still boots — #1960); and (B) a **runtime fail-safe clamp**
+    (`pkg/daemon/daemon_run.go`) that, when the resolved bind is non-loopback
+    and `apiCfg.Auth == nil`, pulls the bind back to `127.0.0.1` and WARNs —
+    so a leniently-loaded vulnerable config comes up on loopback (console/SSH
+    remain the lifeline) instead of exposed. Adding api-auth and recommitting
+    restores the off-loopback bind. HTTPS is covered by the same rule
+    (transport encryption without authentication still lets any reachable
+    client mutate config).
   - **`/metrics` posture (#4162).** The Prometheus endpoint is
     unauthenticated on the loopback default bind — the standard Prometheus
     posture. When `system services web-management http interface <if>`

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -954,6 +954,39 @@ Fail-on-revert: `pkg/config/compiler_firewall_family_any_4287_test.go` (both
 pools populated for a `family any` discard; strict reject + lenient warn for
 the any+inet6 collision; lone `family any` no-false-reject).
 
+### Family-specific matches under `family any` are rejected (#4296)
+
+The #4287 dual-compile has a residual: a `family any` term whose `from` block
+carries a **family-specific** match is dual-compiled **verbatim** into both
+pools, so the copy in the "wrong" pool can never match. A v4/v6
+`source-address`/`destination-address` literal or a per-family
+`icmp-type`/`icmp-code` (`echo-request` resolves to ICMPv4 type 8 for
+`af=="any"`, which never matches an IPv6 ICMP packet whose echo-request is
+type 128) leaves the inet6 (or inet) arm with a never-matching predicate — the
+term falls through to the implicit ACCEPT for that family, an imperfect v6
+UNDER-block (it degrades to the pre-#4287 state for that term; never an
+over-block, so no legitimate v6 traffic is broken). These configs are also
+non-Junos (Junos disallows family-specific matches under `family any`).
+
+`validateFirewallFilterFamilyAnyMatchesAST` (`compiler_firewall.go`, invoked in
+`compiler.go` right after the collision gate) **rejects** such a term at strict
+commit / commit-check with a message pointing the operator at `family inet` /
+`family inet6`, and **warns** on the tolerant load / peer-sync path
+(`lenientFirewallFilterFamilyAnyMatches`, same #1960 no-brick doctrine). The
+flagged leaves are exactly `source-address`, `destination-address`,
+`icmp-type`, `icmp-code`. `next-header` (the inet6 spelling of `protocol`,
+matching family-agnostic L4 protocol numbers) and `source-prefix-list` /
+`destination-prefix-list` (named prefix-lists may legitimately mix v4+v6) are
+deliberately NOT flagged. The gate fires **before**
+`validateFilterAddressLiteralsStrict` (#3433), which also rejects a wrong-family
+address literal but with a less specific message; for the address case the
+#4296 gate wins the first-error slot with the clearer diagnostic, and for the
+`icmp-type`/`icmp-code` case it is the ONLY gate that catches the residual.
+Fail-on-revert: `pkg/config/compiler_firewall_family_any_match_4296_test.go`
+(strict reject of a v4 source-address and a symbolic icmp-type; lenient warn;
+family-agnostic `protocol` under `family any` still commits into both pools;
+single-family filters with address literals not flagged).
+
 ## Repeated same-type sibling matches (NOT bracketed multi-value)
 
 The dual-AST contract above covers a single leaf carrying a bracketed list

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -495,6 +495,21 @@ type compileOpts struct {
 	// last-write-wins map compileFirewall always produced. Same doctrine as
 	// lenientApplicationNameCollisions.
 	lenientFirewallFilterFamilyCollisions bool
+
+	// lenientFirewallFilterFamilyAnyMatches (#4296, fable-review-167 F-1
+	// residual) downgrades the firewall-filter family-any specific-match gate
+	// (validateFirewallFilterFamilyAnyMatchesAST) from a hard compile error to a
+	// cfg.Warnings entry. #4287 dual-compiles a `family any` filter into BOTH the
+	// inet and inet6 pools; a family-specific match under `family any` (a v4/v6
+	// source/destination-address literal or a per-family icmp-type/icmp-code) is
+	// then dual-compiled verbatim and can never match the other family — an
+	// imperfect v6 under-block. The strict commit / commit-check path hard-rejects
+	// it (pointing the operator at family inet/inet6); the tolerant load / peer-
+	// sync paths downgrade to a warning so an already-persisted or peer-synced
+	// config an older binary silently accepted still BOOTS (#1960 no-brick),
+	// keeping the existing dual-compile behavior. Same doctrine as
+	// lenientFirewallFilterFamilyCollisions.
+	lenientFirewallFilterFamilyAnyMatches bool
 	// lenientFilterProtocols (#2175 review) downgrades the firewall-filter
 	// `from protocol <token>` gate (validateFilterProtocolsStrict) from a
 	// hard compile error to a cfg.Warnings entry. The strict commit /
@@ -1471,6 +1486,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientApplicationSpecs:                true,
 		lenientApplicationNameCollisions:       true,
 		lenientFirewallFilterFamilyCollisions:  true,
+		lenientFirewallFilterFamilyAnyMatches:  true,
 		lenientFilterProtocols:                 true,
 		lenientFilterCrossField:                true,
 		lenientFilterActions:                   true,
@@ -1656,6 +1672,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientApplicationSpecs:                true,
 		lenientApplicationNameCollisions:       true,
 		lenientFirewallFilterFamilyCollisions:  true,
+		lenientFirewallFilterFamilyAnyMatches:  true,
 		lenientFilterProtocols:                 true,
 		lenientFilterCrossField:                true,
 		lenientFilterActions:                   true,
@@ -1966,6 +1983,22 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		return nil, err
 	}
 
+	// #4296 firewall-filter family-any specific-match gate. #4287 dual-compiles a
+	// `family any` filter into BOTH the inet and inet6 pools; a family-specific
+	// match under `family any` (a v4/v6 source/destination-address literal or a
+	// per-family icmp-type/icmp-code) is then dual-compiled verbatim and can never
+	// match the other family — an imperfect v6 under-block. Strict (commit /
+	// commit-check): the first such match hard-rejects, pointing at family
+	// inet/inet6. Lenient (load / peer-sync): warn so an already-persisted or
+	// peer-synced config an older binary silently accepted still BOOTS (#1960).
+	// Runs on the group-expanded, inactive-pruned AST for the same reason as the
+	// collision gate above — only the raw AST still carries the family-any match.
+	fwFilterFamilyAnyWarnings, err := validateFirewallFilterFamilyAnyMatchesAST(
+		tree.Children, opts.lenientFirewallFilterFamilyAnyMatches)
+	if err != nil {
+		return nil, err
+	}
+
 	// #3096: the #3079 interim NAT rule-set scope reject is LIFTED. A
 	// `security nat {source|destination|static}` rule-set whose `from`/`to`
 	// clause scopes traffic by `interface` or `routing-instance` is now
@@ -2180,6 +2213,7 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	cfg.Warnings = append(cfg.Warnings, unsupportedIfaceWarnings...)
 	cfg.Warnings = append(cfg.Warnings, appCollisionWarnings...)
 	cfg.Warnings = append(cfg.Warnings, fwFilterFamilyWarnings...)
+	cfg.Warnings = append(cfg.Warnings, fwFilterFamilyAnyWarnings...)
 	cfg.Warnings = append(cfg.Warnings, bindIfaceWarnings...)
 	cfg.Warnings = append(cfg.Warnings, ipsecTSWarnings...)
 	cfg.Warnings = append(cfg.Warnings, policyMatchWarnings...)

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -882,6 +882,20 @@ type compileOpts struct {
 	// warning so an already-persisted or peer-synced config an older binary
 	// accepted still BOOTS (#1960 no-brick). Same doctrine as lenientPolicyZoneRefs.
 	lenientZoneCount bool
+	// lenientWebManagementAuth (#4047, fable-161 F-155) downgrades the
+	// web-management REST-auth gate (validateWebManagementAuthStrict) from a hard
+	// compile error to a cfg.Warnings entry. The REST/config API is unauthenticated
+	// unless `system services web-management api-auth` is configured; binding it to
+	// a non-loopback address (`web-management http|https interface <mgmt-if>`)
+	// without api-auth exposes the mutating config endpoints (set / commit /
+	// rollback / system action) to the network. The strict commit / commit-check
+	// path hard-rejects such a config; the tolerant load / peer-sync paths downgrade
+	// to a warning so an already-persisted or peer-synced config an older binary
+	// accepted still BOOTS (#1960 no-brick). The daemon's runtime bind path
+	// independently clamps a non-loopback + no-auth bind back to loopback (part B,
+	// daemon_run.go), so a leniently-loaded vulnerable config is not left exposed.
+	// Same doctrine as lenientZoneCount.
+	lenientWebManagementAuth bool
 	// lenientZoneIDCollision (#3075) downgrades the stable-zone-id collision
 	// gate (validateZoneIDCollisionAST) from a hard compile error to a
 	// cfg.Warnings entry. The strict commit / commit-check path hard-rejects a
@@ -1512,6 +1526,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientWireguardPeers:                  true,
 		lenientPolicyZoneRefs:                  true,
 		lenientZoneCount:                       true,
+		lenientWebManagementAuth:               true,
 		lenientZoneIDCollision:                 true,
 		lenientRoutingInstanceTableIDCollision: true,
 		lenientAddressBookNames:                true,
@@ -1547,6 +1562,62 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientDNATToScope:                     true,
 		lenientEventWithinTrigger:              true,
 	})
+}
+
+// validateWebManagementAuthStrict hard-rejects a `system services
+// web-management` config that binds the REST / config API to a NON-LOOPBACK
+// address without any REST authentication configured (#4047, fable-161 F-155).
+//
+// The REST server (pkg/api) serves the mutating config endpoints — POST
+// /api/v1/config/{set,delete,commit,commit-confirmed,rollback,load,activate}
+// and /api/v1/system/action — with NO auth middleware unless api-auth is set:
+// pkg/api/server.go wires the auth middleware only when cfg.Auth != nil, and
+// the daemon (daemon_run.go) sets apiCfg.Auth only when web-management api-auth
+// carries at least one user or api-key. The default bind is loopback
+// 127.0.0.1:8080 (safe); a `web-management http|https interface <mgmt-if>`
+// stanza resolves to the interface's routable address (daemon_run.go ->
+// resolveInterfaceAddr), so binding off-loopback WITHOUT api-auth exposes every
+// mutating config RPC to any host that can reach the management address — a
+// network attacker can reconfigure the firewall unauthenticated.
+//
+// A non-loopback bind is signalled by a non-empty HTTPInterface or
+// HTTPSInterface (the only way web-management moves the REST server off
+// loopback). "Authenticated" means APIAuth carries at least one user OR
+// api-key — the same predicate daemon_run.go uses to actually wire the auth
+// middleware, so this gate rejects exactly the configs that would bind
+// unauthenticated. HTTPS is covered too: transport encryption without
+// authentication still lets any reachable client mutate config.
+//
+// Strict on the commit / commit-check path (hard-reject). Downgraded to a
+// cfg.Warnings entry on the tolerant load / peer-sync paths
+// (lenientWebManagementAuth) so an already-persisted or peer-synced config that
+// an older binary accepted still BOOTS (#1960 fail-closed-on-load). The daemon's
+// runtime bind path independently CLAMPS a non-loopback + no-auth bind back to
+// loopback (part B, daemon_run.go), so the leniently-loaded config is preserved
+// but not left exposed — the operator adds api-auth and recommits to restore the
+// non-loopback bind.
+func validateWebManagementAuthStrict(cfg *Config) error {
+	if cfg == nil || cfg.System.Services == nil || cfg.System.Services.WebManagement == nil {
+		return nil
+	}
+	wm := cfg.System.Services.WebManagement
+	var binds []string
+	if wm.HTTPInterface != "" {
+		binds = append(binds, fmt.Sprintf("http interface %q", wm.HTTPInterface))
+	}
+	if wm.HTTPSInterface != "" {
+		binds = append(binds, fmt.Sprintf("https interface %q", wm.HTTPSInterface))
+	}
+	if len(binds) == 0 {
+		return nil // loopback bind (default) — safe without auth
+	}
+	authed := wm.APIAuth != nil && (len(wm.APIAuth.Users) > 0 || len(wm.APIAuth.APIKeys) > 0)
+	if authed {
+		return nil
+	}
+	return fmt.Errorf(
+		"system services web-management binds the REST/config API off-loopback (%s) without api-auth — the REST API is UNAUTHENTICATED, so an off-loopback bind exposes the mutating config endpoints (set / commit / rollback / system action) to the network; configure `set system services web-management api-auth {user <name> password <pw> | api-key <key>}` or remove the interface binding to keep the API on loopback (#4047)",
+		strings.Join(binds, ", "))
 }
 
 func compileConfigWithOpts(tree *ConfigTree, opts compileOpts) (*Config, error) {
@@ -1698,6 +1769,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientWireguardPeers:                  true,
 		lenientPolicyZoneRefs:                  true,
 		lenientZoneCount:                       true,
+		lenientWebManagementAuth:               true,
 		lenientZoneIDCollision:                 true,
 		lenientRoutingInstanceTableIDCollision: true,
 		lenientAddressBookNames:                true,
@@ -2507,6 +2579,22 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientDeviceMap {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("device-map (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #4047 web-management REST-auth gate. Strict on commit / commit-check
+	// (hard-reject a web-management config that binds the unauthenticated REST /
+	// config API off-loopback without api-auth — exposing the mutating config
+	// endpoints to the network); lenient on load / peer-sync (warn so an
+	// already-persisted or peer-synced config still boots — #1960; the daemon's
+	// runtime bind path clamps such a bind back to loopback, so the leniently-
+	// loaded config is preserved but not left exposed).
+	if err := validateWebManagementAuthStrict(cfg); err != nil {
+		if opts.lenientWebManagementAuth {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("web-management auth (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_firewall.go
+++ b/pkg/config/compiler_firewall.go
@@ -425,6 +425,116 @@ func validateFirewallFilterFamilyCollisionsAST(nodes []*Node, lenient bool) ([]s
 	return warnings, nil
 }
 
+// familyAnySpecificMatches is the set of firewall-filter `from` match leaves
+// that only make sense for ONE address family and must not appear under a
+// `family any` filter (#4296):
+//
+//   - source-address / destination-address: a firewall-filter address match is
+//     always an IP prefix LITERAL (v4 or v6), which binds to exactly one family.
+//   - icmp-type / icmp-code: ICMPv4 and ICMPv6 use DIFFERENT numeric type/code
+//     tables (echo-request is 8 for v4, 128 for v6); compileFilterFrom resolves
+//     the symbolic name via the ICMPv4 table for af=="any" (filter_match_resolve.go),
+//     so the resulting numeric is correct for at most one family.
+//
+// (next-header is the inet6 spelling of `protocol` and matches family-agnostic
+// L4 protocol NUMBERS, so it is NOT family-specific and is deliberately absent.
+// source-prefix-list / destination-prefix-list reference NAMED prefix-lists that
+// may legitimately mix v4 and v6 prefixes, so they are also not flagged here.)
+var familyAnySpecificMatches = map[string]bool{
+	"source-address":      true,
+	"destination-address": true,
+	"icmp-type":           true,
+	"icmp-code":           true,
+}
+
+// validateFirewallFilterFamilyAnyMatchesAST walks every top-level `firewall`
+// node and rejects a `family any` filter term whose `from` block carries a
+// FAMILY-SPECIFIC match leaf (#4296, fable-review-167 F-1 residual).
+//
+// #4287 fixed the original fail-open (a `family any` deny compiled into the
+// IPv4 pool only, silently letting IPv6 through) by dual-compiling a `family
+// any` filter into BOTH FiltersInet and FiltersInet6. But a family-specific
+// match under `family any` is dual-compiled VERBATIM: a v4 `source-address` (or
+// a symbolic icmp-type that resolves via the ICMPv4 table for af=="any") lands
+// in the FiltersInet6 pool as a predicate that can NEVER match a v6 packet, so
+// the v6 term falls through to the implicit ACCEPT — an imperfect v6 UNDER-block
+// (it degrades to the pre-#4287 state for that term; never an over-block, so no
+// legitimate v6 traffic is broken). These configs are also non-Junos (Junos
+// disallows family-specific matches under `family any`) and only reachable via a
+// hierarchical config-file / peer-synced AST, since the flat `set` schema does
+// not model `family any`.
+//
+// Rather than silently dual-compile a match that cannot work for one family,
+// this gate REJECTS it at commit with a message pointing the operator at
+// `family inet` / `family inet6`. Strict path (commit / commit-check,
+// lenient=false): the first offending match is a hard compile error. Lenient
+// path (load / peer-sync, lenient=true): every offending match is returned as a
+// warning and compilation continues with the existing dual-compile behavior, so
+// an already-persisted or peer-synced config that an older binary silently
+// accepted still BOOTS (#1960 / #3261 fail-closed-on-load doctrine).
+//
+// The traversal mirrors compileFirewall's family/filter/term/from walk exactly
+// (BOTH AST shapes) and aggregates across every top-level `firewall {}` block.
+func validateFirewallFilterFamilyAnyMatchesAST(nodes []*Node, lenient bool) ([]string, error) {
+	var warnings []string
+	for _, fwNode := range nodes {
+		if fwNode.Name() != "firewall" {
+			continue
+		}
+		for _, familyNode := range fwNode.FindChildren("family") {
+			var afNodes []*Node
+			var afName string
+			if len(familyNode.Keys) >= 2 {
+				// Hierarchical: family any { ... }
+				afName = familyNode.Keys[1]
+				afNodes = []*Node{familyNode}
+			} else {
+				// Set-command shape: family { any { ... } }
+				afNodes = append(afNodes, familyNode.Children...)
+			}
+			for _, afNode := range afNodes {
+				af := afName
+				if af == "" {
+					af = afNode.Keys[0]
+					if len(afNode.Keys) >= 2 {
+						af = afNode.Keys[1]
+					}
+				}
+				if af != "any" {
+					continue
+				}
+				for _, filterInst := range namedInstances(afNode.FindChildren("filter")) {
+					if filterInst.name == "" {
+						continue
+					}
+					for _, termInst := range namedInstances(filterInst.node.FindChildren("term")) {
+						for _, fromNode := range termInst.node.FindChildren("from") {
+							for _, child := range fromNode.Children {
+								mname := child.Name()
+								if !familyAnySpecificMatches[mname] {
+									continue
+								}
+								detail := mname
+								if vals := firewallMatchValues(child); len(vals) > 0 {
+									detail = mname + " " + vals[0]
+								}
+								msg := fmt.Sprintf(
+									"firewall filter %q term %q: `from %s` is a family-specific match not allowed under `family any` — a family any filter compiles into BOTH the inet (v4) and inet6 (v6) pools (#4287), and a single-family match (a v4/v6 address literal or a per-family icmp type/code) can never match the other family, silently under-blocking it; use `family inet` or `family inet6` (#4296)",
+									filterInst.name, termInst.name, detail)
+								if !lenient {
+									return nil, fmt.Errorf("%s", msg)
+								}
+								warnings = append(warnings, msg)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return warnings, nil
+}
+
 // firewallMatchValues extracts every value carried by a `from` match-criterion
 // node, across BOTH parser AST shapes (#2545):
 //

--- a/pkg/config/compiler_firewall_family_any_match_4296_test.go
+++ b/pkg/config/compiler_firewall_family_any_match_4296_test.go
@@ -1,0 +1,205 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4296 (fable-review-167 F-1 residual): #4287 dual-compiles a `family any`
+// firewall filter into BOTH the inet (v4) and inet6 (v6) pools. A
+// family-specific match under `family any` (a v4/v6 source/destination-address
+// literal, or a per-family icmp-type/icmp-code) is then dual-compiled VERBATIM
+// and can never match the other family — an imperfect v6 under-block (the term
+// falls through to the implicit ACCEPT for v6, degrading to the pre-#4287
+// state). validateFirewallFilterFamilyAnyMatchesAST rejects such a term at
+// strict commit (pointing the operator at family inet/inet6) and warns on the
+// tolerant load / peer-sync path.
+//
+// These configs are non-Junos and reach compileFirewall's structured path only
+// via a HIERARCHICAL config-file / peer-synced AST (the flat `set` schema does
+// not model `family any`), so the fixtures use parseHier.
+
+// RED-on-revert: a `family any` filter carrying a v4 source-address literal must
+// be REJECTED at strict commit. On revert of the #4296 gate this goes RED — the
+// term is silently dual-compiled into the v6 pool where the v4 literal never
+// matches (fail-open v6 under-block).
+func TestFirewallFilterFamilyAnySourceAddressRejected(t *testing.T) {
+	tree := parseHier(t, `
+firewall {
+    family any {
+        filter blockNet {
+            term t {
+                from {
+                    source-address {
+                        10.0.0.0/8;
+                    }
+                }
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+`)
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of a family-specific source-address under family any, got nil")
+	}
+	if !strings.Contains(err.Error(), "blockNet") || !strings.Contains(err.Error(), "family any") ||
+		!strings.Contains(err.Error(), "#4296") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// A symbolic icmp-type under `family any` resolves via the ICMPv4 table
+// (af=="any" is not inet6) and is therefore family-specific — rejected.
+func TestFirewallFilterFamilyAnyICMPTypeRejected(t *testing.T) {
+	tree := parseHier(t, `
+firewall {
+    family any {
+        filter noPing {
+            term t {
+                from {
+                    icmp-type echo-request;
+                }
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+`)
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of a per-family icmp-type under family any, got nil")
+	}
+	if !strings.Contains(err.Error(), "noPing") || !strings.Contains(err.Error(), "#4296") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// Lenient (load / peer-sync): the family-any specific-match downgrades to a
+// warning so an already-persisted or peer-synced config still boots — the
+// dual-compile behavior is preserved (the v6 arm merely never matches).
+func TestFirewallFilterFamilyAnySpecificMatchLenientWarns(t *testing.T) {
+	tree := parseHier(t, `
+firewall {
+    family any {
+        filter blockNet {
+            term t {
+                from {
+                    source-address {
+                        10.0.0.0/8;
+                    }
+                }
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+`)
+
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient: family-any specific match must downgrade to a warning, got error: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "blockNet") && strings.Contains(w, "#4296") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a #4296 family-any specific-match warning on the lenient path, got: %v", cfg.Warnings)
+	}
+}
+
+// A `family any` filter using only family-AGNOSTIC matches (protocol, which
+// maps to a family-independent L4 protocol number) commits cleanly — the gate
+// must not over-reject the legitimate #4287 dual-family case.
+func TestFirewallFilterFamilyAnyAgnosticMatchCommits(t *testing.T) {
+	tree := parseHier(t, `
+firewall {
+    family any {
+        filter dropTCP {
+            term t {
+                from {
+                    protocol tcp;
+                }
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+`)
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: family any with a family-agnostic protocol match must commit, got error: %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#4296") {
+			t.Fatalf("unexpected #4296 warning on a valid family-agnostic family any config: %q", w)
+		}
+	}
+	if cfg.Firewall.FiltersInet["dropTCP"] == nil || cfg.Firewall.FiltersInet6["dropTCP"] == nil {
+		t.Fatal("family any dropTCP must land in both pools (#4287)")
+	}
+}
+
+// A family-specific match under a normal single-family filter (family inet with
+// a v4 source-address, family inet6 with a v6 source-address) is legitimate and
+// must NOT be flagged — the gate is scoped to `family any` only.
+func TestFirewallFilterSingleFamilyAddressNotFlagged(t *testing.T) {
+	tree := parseHier(t, `
+firewall {
+    family inet {
+        filter v4 {
+            term t {
+                from {
+                    source-address {
+                        10.0.0.0/8;
+                    }
+                }
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+    family inet6 {
+        filter v6 {
+            term t {
+                from {
+                    source-address {
+                        2001:db8::/32;
+                    }
+                }
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+`)
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: single-family filters with address literals must commit, got error: %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#4296") {
+			t.Fatalf("unexpected #4296 warning on a valid single-family config: %q", w)
+		}
+	}
+}

--- a/pkg/config/parser_system_test.go
+++ b/pkg/config/parser_system_test.go
@@ -542,6 +542,11 @@ system {
                 system-generated-certificate;
                 interface fxp0.0;
             }
+            api-auth {
+                user admin {
+                    password s3cret;
+                }
+            }
         }
     }
 }
@@ -724,7 +729,7 @@ system {
 }
 
 func TestSystemConfigSetSyntax(t *testing.T) {
-	cmds := []string{"set system root-authentication encrypted-password \"$6$abcsalt$hashhash\"", "set system root-authentication ssh-ed25519 \"ssh-ed25519 AAAA\"", "set system master-password pseudorandom-function juniper-prf1", "set system license autoupdate url https://example.com/keys", "set system processes utmd disable", "set system services web-management https system-generated-certificate", "set system services web-management https interface fxp0.0", "set system syslog user * any emergency", "set system syslog host 10.0.0.1 any any", "set system syslog host 10.0.0.1 daemon info"}
+	cmds := []string{"set system root-authentication encrypted-password \"$6$abcsalt$hashhash\"", "set system root-authentication ssh-ed25519 \"ssh-ed25519 AAAA\"", "set system master-password pseudorandom-function juniper-prf1", "set system license autoupdate url https://example.com/keys", "set system processes utmd disable", "set system services web-management https system-generated-certificate", "set system services web-management https interface fxp0.0", "set system services web-management api-auth api-key tok-abc-123", "set system syslog user * any emergency", "set system syslog host 10.0.0.1 any any", "set system syslog host 10.0.0.1 daemon info"}
 	tree := &ConfigTree{}
 	for _, cmd := range cmds {
 		path, err := ParseSetCommand(cmd)

--- a/pkg/config/web_management_auth_4047_test.go
+++ b/pkg/config/web_management_auth_4047_test.go
@@ -1,0 +1,136 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4047 (fable-161 F-155): the REST / config API (pkg/api) serves the mutating
+// config endpoints (set / commit / rollback / system action) with NO auth
+// middleware unless `system services web-management api-auth` is configured. The
+// default bind is loopback (safe), but a `web-management http|https interface
+// <mgmt-if>` stanza binds the API to a routable address — off-loopback WITHOUT
+// api-auth exposes every mutating RPC to the network. validateWebManagementAuthStrict
+// hard-rejects such a config at strict commit and warns on the tolerant load path.
+
+// buildTreeFromSets applies flat `set` commands (the CLAUDE.md-mandated way to
+// test set syntax — NewParser merges newline-separated set lines).
+func buildTreeFromSets(t *testing.T, cmds ...string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		if err := tree.SetPath(strings.Fields(cmd)[1:]); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// RED-on-revert: an HTTP web-management bind to a non-loopback interface with no
+// api-auth must be REJECTED at strict commit. On revert of the #4047 gate this
+// goes RED — the config commits and the daemon binds the unauthenticated REST
+// API off-loopback.
+func TestWebManagementHTTPOffLoopbackNoAuthRejected(t *testing.T) {
+	tree := buildTreeFromSets(t, "set system services web-management http interface fxp0.0")
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of an off-loopback HTTP bind with no api-auth, got nil")
+	}
+	if !strings.Contains(err.Error(), "web-management") || !strings.Contains(err.Error(), "api-auth") ||
+		!strings.Contains(err.Error(), "#4047") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// HTTPS is covered too — transport encryption without authentication still lets
+// any reachable client mutate config.
+func TestWebManagementHTTPSOffLoopbackNoAuthRejected(t *testing.T) {
+	tree := buildTreeFromSets(t,
+		"set system services web-management https interface fxp0.0",
+		"set system services web-management https system-generated-certificate")
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of an off-loopback HTTPS bind with no api-auth, got nil")
+	}
+	if !strings.Contains(err.Error(), "https interface") || !strings.Contains(err.Error(), "#4047") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// An off-loopback bind WITH a basic-auth user configured commits cleanly — the
+// gate must not over-reject an authenticated off-loopback config.
+func TestWebManagementOffLoopbackWithUserAuthCommits(t *testing.T) {
+	tree := buildTreeFromSets(t,
+		"set system services web-management http interface fxp0.0",
+		"set system services web-management api-auth user admin password s3cret")
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: off-loopback + user auth must commit, got error: %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#4047") {
+			t.Fatalf("unexpected #4047 warning on an authenticated off-loopback config: %q", w)
+		}
+	}
+}
+
+// An off-loopback bind WITH an api-key configured commits cleanly.
+func TestWebManagementOffLoopbackWithAPIKeyCommits(t *testing.T) {
+	tree := buildTreeFromSets(t,
+		"set system services web-management http interface fxp0.0",
+		"set system services web-management api-auth api-key tok-abc-123")
+
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig: off-loopback + api-key must commit, got error: %v", err)
+	}
+}
+
+// A loopback bind (web-management http with NO interface) is safe without auth
+// and must commit cleanly — the gate keys on an interface binding, not the mere
+// presence of web-management.
+func TestWebManagementLoopbackNoAuthCommits(t *testing.T) {
+	tree := buildTreeFromSets(t, "set system services web-management http")
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: loopback web-management with no auth must commit, got error: %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#4047") {
+			t.Fatalf("unexpected #4047 warning on a loopback config: %q", w)
+		}
+	}
+}
+
+// No web-management stanza at all: no gate fires.
+func TestWebManagementAbsentCommits(t *testing.T) {
+	tree := buildTreeFromSets(t, "set system host-name fw0")
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig: a config with no web-management must commit, got error: %v", err)
+	}
+}
+
+// Lenient (load / peer-sync): the off-loopback no-auth config downgrades to a
+// warning so an already-persisted or peer-synced config still boots (#1960); the
+// daemon's part-B runtime clamp pulls the bind back to loopback.
+func TestWebManagementOffLoopbackNoAuthLenientWarns(t *testing.T) {
+	tree := buildTreeFromSets(t, "set system services web-management http interface fxp0.0")
+
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient: off-loopback no-auth must downgrade to a warning, got error: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "web-management auth") && strings.Contains(w, "#4047") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a #4047 web-management-auth warning on the lenient path, got: %v", cfg.Warnings)
+	}
+}

--- a/pkg/daemon/daemon_cluster_bind.go
+++ b/pkg/daemon/daemon_cluster_bind.go
@@ -68,6 +68,34 @@ func hostIsLoopback(host string) bool {
 	return ip.IsLoopback()
 }
 
+// clampBindToLoopback is the pure decision for the #4047 part-B runtime
+// fail-safe clamp. Given a resolved REST bind ("host:port", IPv6 host bracketed)
+// and whether api-auth is configured, it returns the effective bind address and
+// whether it was clamped. A bind is clamped ONLY when it is BOTH off-loopback
+// AND unauthenticated — that is the exact case where the unauthenticated
+// mutating config endpoints would otherwise be reachable from the network. The
+// clamp targets a loopback of the SAME address family (::1 for an IPv6 bind,
+// 127.0.0.1 for IPv4) and preserves the port. An authenticated bind, a loopback
+// bind, or an unparseable address is returned unchanged (do not clamp on
+// uncertainty and break a legitimate bind — resolveInterfaceAddr yields a
+// literal IP, so an unparseable host is not expected in practice).
+func clampBindToLoopback(addr string, hasAuth bool) (string, bool) {
+	if hasAuth {
+		return addr, false
+	}
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil || hostIsLoopback(host) {
+		return addr, false
+	}
+	loopback := "127.0.0.1"
+	if ip := net.ParseIP(host); ip != nil && ip.To4() == nil {
+		// An IPv6 (non-v4-mapped) address clamps to the IPv6 loopback so the
+		// bind stays same-family (a v6 daemon is reachable on ::1, not 127.0.0.1).
+		loopback = "::1"
+	}
+	return net.JoinHostPort(loopback, port), true
+}
+
 func parseLiteralIP(addr string) net.IP {
 	if addr == "" {
 		return nil

--- a/pkg/daemon/daemon_cluster_bind.go
+++ b/pkg/daemon/daemon_cluster_bind.go
@@ -50,6 +50,24 @@ func resolveInterfaceAddr(ifname, fallback string) string {
 	return fallback
 }
 
+// hostIsLoopback reports whether a bind host string is a loopback address. An
+// empty or unparseable host is treated as loopback (safe — do NOT clamp on
+// uncertainty and break a legitimate bind); resolveInterfaceAddr always returns
+// a literal IP (or the loopback fallback), so in practice host is a parseable
+// IP. Used by the #4047 part-B runtime clamp (daemon_run.go) to decide whether a
+// no-auth web-management bind is network-reachable and must be pulled back to
+// loopback.
+func hostIsLoopback(host string) bool {
+	if host == "" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return true
+	}
+	return ip.IsLoopback()
+}
+
 func parseLiteralIP(addr string) net.IP {
 	if addr == "" {
 		return nil

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1340,7 +1340,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 			// Bind HTTP to configured interface
 			if wm.HTTPInterface != "" {
 				bindIP := resolveInterfaceAddr(wm.HTTPInterface, "127.0.0.1")
-				apiCfg.Addr = bindIP + ":8080"
+				// net.JoinHostPort (not string-concat) so an IPv6 interface
+				// address is bracketed ("[2001:db8::1]:8080") — a bare
+				// "2001:db8::1:8080" is unparseable by net.SplitHostPort (the
+				// clamp below) and net.Listen, blackholing an IPv6-only mgmt bind.
+				apiCfg.Addr = net.JoinHostPort(bindIP, "8080")
 				slog.Info("HTTP API bound to interface", "interface", wm.HTTPInterface, "addr", apiCfg.Addr)
 			}
 			// Enable HTTPS if configured
@@ -1348,10 +1352,10 @@ func (d *Daemon) Run(ctx context.Context) error {
 				httpsBindIP := "127.0.0.1"
 				if wm.HTTPSInterface != "" {
 					httpsBindIP = resolveInterfaceAddr(wm.HTTPSInterface, "127.0.0.1")
-					slog.Info("HTTPS API bound to interface", "interface", wm.HTTPSInterface, "addr", httpsBindIP+":8443")
+					slog.Info("HTTPS API bound to interface", "interface", wm.HTTPSInterface, "addr", net.JoinHostPort(httpsBindIP, "8443"))
 				}
 				apiCfg.TLS = true
-				apiCfg.HTTPSAddr = httpsBindIP + ":8443"
+				apiCfg.HTTPSAddr = net.JoinHostPort(httpsBindIP, "8443")
 			}
 			// API authentication
 			if wm.APIAuth != nil && (len(wm.APIAuth.Users) > 0 || len(wm.APIAuth.APIKeys) > 0) {
@@ -1375,23 +1379,22 @@ func (d *Daemon) Run(ctx context.Context) error {
 			// is lenient-loaded (warn, no brick — #1960) and would still bind
 			// non-loopback UNAUTHENTICATED after upgrade, exposing the mutating
 			// config endpoints (set / commit / rollback / system action) to the
-			// network. When the resolved bind is non-loopback AND no api-auth is
-			// configured (apiCfg.Auth == nil), clamp it back to loopback and WARN:
-			// the daemon still boots, the web API stays reachable on 127.0.0.1, and
-			// the console/SSH remain the lifeline (device-map §9.6 posture) until
-			// the operator adds api-auth (which restores the non-loopback bind).
-			if apiCfg.Auth == nil {
-				if host, port, err := net.SplitHostPort(apiCfg.Addr); err == nil && !hostIsLoopback(host) {
-					slog.Warn("web-management HTTP bind is non-loopback without api-auth; clamping to loopback (add `set system services web-management api-auth` to bind off-loopback) — #4047",
-						"requested", apiCfg.Addr)
-					apiCfg.Addr = net.JoinHostPort("127.0.0.1", port)
-				}
-				if apiCfg.TLS {
-					if host, port, err := net.SplitHostPort(apiCfg.HTTPSAddr); err == nil && !hostIsLoopback(host) {
-						slog.Warn("web-management HTTPS bind is non-loopback without api-auth; clamping to loopback — #4047",
-							"requested", apiCfg.HTTPSAddr)
-						apiCfg.HTTPSAddr = net.JoinHostPort("127.0.0.1", port)
-					}
+			// network. clampBindToLoopback pulls a non-loopback + no-auth bind back
+			// to a loopback of the same family and WARNs: the daemon still boots,
+			// the web API stays reachable on loopback, and the console/SSH remain
+			// the lifeline (device-map §9.6 posture) until the operator adds
+			// api-auth (which restores the non-loopback bind).
+			hasAuth := apiCfg.Auth != nil
+			if clamped, ok := clampBindToLoopback(apiCfg.Addr, hasAuth); ok {
+				slog.Warn("web-management HTTP bind is non-loopback without api-auth; clamping to loopback (add `set system services web-management api-auth` to bind off-loopback) — #4047",
+					"requested", apiCfg.Addr, "clamped", clamped)
+				apiCfg.Addr = clamped
+			}
+			if apiCfg.TLS {
+				if clamped, ok := clampBindToLoopback(apiCfg.HTTPSAddr, hasAuth); ok {
+					slog.Warn("web-management HTTPS bind is non-loopback without api-auth; clamping to loopback — #4047",
+						"requested", apiCfg.HTTPSAddr, "clamped", clamped)
+					apiCfg.HTTPSAddr = clamped
 				}
 			}
 		}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1368,6 +1368,32 @@ func (d *Daemon) Run(ctx context.Context) error {
 				apiCfg.Auth = authCfg
 				slog.Info("HTTP API authentication enabled", "users", len(wm.APIAuth.Users), "api_keys", len(wm.APIAuth.APIKeys))
 			}
+			// #4047 part B: runtime fail-safe clamp. The commit gate
+			// (validateWebManagementAuthStrict, pkg/config) rejects a NEW
+			// web-management config that binds the unauthenticated REST/config API
+			// off-loopback without api-auth, but an ALREADY-PERSISTED such config
+			// is lenient-loaded (warn, no brick — #1960) and would still bind
+			// non-loopback UNAUTHENTICATED after upgrade, exposing the mutating
+			// config endpoints (set / commit / rollback / system action) to the
+			// network. When the resolved bind is non-loopback AND no api-auth is
+			// configured (apiCfg.Auth == nil), clamp it back to loopback and WARN:
+			// the daemon still boots, the web API stays reachable on 127.0.0.1, and
+			// the console/SSH remain the lifeline (device-map §9.6 posture) until
+			// the operator adds api-auth (which restores the non-loopback bind).
+			if apiCfg.Auth == nil {
+				if host, port, err := net.SplitHostPort(apiCfg.Addr); err == nil && !hostIsLoopback(host) {
+					slog.Warn("web-management HTTP bind is non-loopback without api-auth; clamping to loopback (add `set system services web-management api-auth` to bind off-loopback) — #4047",
+						"requested", apiCfg.Addr)
+					apiCfg.Addr = net.JoinHostPort("127.0.0.1", port)
+				}
+				if apiCfg.TLS {
+					if host, port, err := net.SplitHostPort(apiCfg.HTTPSAddr); err == nil && !hostIsLoopback(host) {
+						slog.Warn("web-management HTTPS bind is non-loopback without api-auth; clamping to loopback — #4047",
+							"requested", apiCfg.HTTPSAddr)
+						apiCfg.HTTPSAddr = net.JoinHostPort("127.0.0.1", port)
+					}
+				}
+			}
 		}
 		srv := api.NewServer(apiCfg)
 		wg.Add(1)

--- a/pkg/daemon/web_management_clamp_4047_test.go
+++ b/pkg/daemon/web_management_clamp_4047_test.go
@@ -1,0 +1,67 @@
+package daemon
+
+import "testing"
+
+// #4047 part B: the runtime fail-safe clamp that pulls an off-loopback +
+// unauthenticated web-management REST bind back to loopback so an
+// already-persisted (leniently-loaded) vulnerable config does not expose the
+// mutating config endpoints to the network after upgrade. hostIsLoopback and
+// clampBindToLoopback are the pure decision helpers; daemon_run.go applies the
+// result to apiCfg.Addr / apiCfg.HTTPSAddr and logs the clamp.
+
+func TestHostIsLoopback(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"127.0.0.1", true},    // canonical IPv4 loopback
+		{"127.0.0.5", true},    // anywhere in 127.0.0.0/8 is loopback
+		{"::1", true},          // IPv6 loopback
+		{"10.0.0.5", false},    // routable IPv4 (RFC1918, but network-reachable)
+		{"192.168.1.1", false}, // routable IPv4
+		{"2001:db8::1", false}, // routable IPv6
+		{"0.0.0.0", false},     // wildcard bind — reachable on every interface
+		{"", true},             // empty host: treated as safe (do not clamp)
+		{"not-an-ip", true},    // unparseable: treated as safe (do not clamp)
+	}
+	for _, c := range cases {
+		if got := hostIsLoopback(c.host); got != c.want {
+			t.Errorf("hostIsLoopback(%q) = %v, want %v", c.host, got, c.want)
+		}
+	}
+}
+
+func TestClampBindToLoopback(t *testing.T) {
+	cases := []struct {
+		name        string
+		addr        string
+		hasAuth     bool
+		wantAddr    string
+		wantClamped bool
+	}{
+		// Off-loopback + no auth => clamped to the same-family loopback, port kept.
+		{"v4 off-loopback no-auth clamps", "10.0.0.5:8080", false, "127.0.0.1:8080", true},
+		{"v4 off-loopback no-auth https port kept", "192.168.1.1:8443", false, "127.0.0.1:8443", true},
+		{"v6 off-loopback no-auth clamps to v6 loopback", "[2001:db8::1]:8080", false, "[::1]:8080", true},
+		// Off-loopback WITH auth => bind as configured (authenticated is allowed).
+		{"v4 off-loopback with auth not clamped", "10.0.0.5:8080", true, "10.0.0.5:8080", false},
+		{"v6 off-loopback with auth not clamped", "[2001:db8::1]:8080", true, "[2001:db8::1]:8080", false},
+		// Loopback binds are left untouched regardless of auth.
+		{"v4 loopback untouched", "127.0.0.1:8080", false, "127.0.0.1:8080", false},
+		{"v4 loopback-range untouched", "127.0.0.5:8080", false, "127.0.0.5:8080", false},
+		{"v6 loopback untouched", "[::1]:8080", false, "[::1]:8080", false},
+		// Wildcard bind is off-loopback => clamped.
+		{"v4 wildcard no-auth clamps", "0.0.0.0:8080", false, "127.0.0.1:8080", true},
+		// Unparseable / no-port => left unchanged (do not clamp on uncertainty).
+		{"unparseable no-port untouched", "not-an-addr", false, "not-an-addr", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotAddr, gotClamped := clampBindToLoopback(c.addr, c.hasAuth)
+			if gotAddr != c.wantAddr || gotClamped != c.wantClamped {
+				t.Errorf("clampBindToLoopback(%q, hasAuth=%v) = (%q, %v), want (%q, %v)",
+					c.addr, c.hasAuth, gotAddr, gotClamped, c.wantAddr, c.wantClamped)
+			}
+		})
+	}
+}

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -572,7 +572,12 @@ func (a *Agent) handleV2cPacket(rest []byte, srcIP net.IP) []byte {
 	// Verify community string and resolve its authorization level.
 	comm := a.getCommunity(string(community))
 	if comm == nil {
-		slog.Debug("SNMP: invalid community", "community", string(community))
+		// SECURITY (#4302): do NOT log the community string — it is the v2c
+		// shared secret (SNMPCommunity.Name, redacted everywhere else). Log
+		// only the source; known_community=false marks the unknown-community
+		// drop, symmetric with the source-denied known_community=true log
+		// below (#4289).
+		slog.Debug("SNMP: invalid community", "src", srcIP, "known_community", false)
 		return nil
 	}
 
@@ -607,7 +612,7 @@ func (a *Agent) handleV2cPacket(rest []byte, srcIP net.IP) []byte {
 	case pduGetBulkRequest:
 		return a.handleGetBulk(community, pduBody)
 	case pduSetRequest:
-		return a.handleSet(community, comm, pduBody)
+		return a.handleSet(community, comm, srcIP, pduBody)
 	default:
 		slog.Debug("SNMP: unsupported PDU type", "type", pduTag)
 		return nil
@@ -650,7 +655,7 @@ func (a *Agent) SETAuthorized(community string) bool {
 // itself is refused per-varbind with notWritable. No served object is
 // mutable, so a successful SET is never produced here — but the read-only vs
 // read-write distinction is enforced and observable in the error-status.
-func (a *Agent) handleSet(community []byte, comm *config.SNMPCommunity, pduBody []byte) []byte {
+func (a *Agent) handleSet(community []byte, comm *config.SNMPCommunity, srcIP net.IP, pduBody []byte) []byte {
 	requestID, _, _, oids, err := decodePDUFields(pduBody)
 	if err != nil {
 		slog.Debug("SNMP: failed to decode SET PDU", "err", err)
@@ -666,8 +671,12 @@ func (a *Agent) handleSet(community []byte, comm *config.SNMPCommunity, pduBody 
 
 	if !communityCanWrite(comm) {
 		// Read-only (or unspecified) community: deny write access.
+		// SECURITY (#4302): do NOT log the community string — it is the v2c
+		// shared secret. Log the source and the (non-secret) authorization
+		// level so the denial is correlatable without exposing the secret,
+		// matching the #4289 pattern.
 		slog.Debug("SNMP: SET denied, community not authorized read-write",
-			"community", string(community), "authorization", comm.Authorization)
+			"src", srcIP, "authorization", comm.Authorization)
 		errIdx := 0
 		if len(oids) > 0 {
 			errIdx = 1

--- a/pkg/snmp/agent_secret_log_4302_test.go
+++ b/pkg/snmp/agent_secret_log_4302_test.go
@@ -1,0 +1,94 @@
+package snmp
+
+import (
+	"bytes"
+	"log/slog"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #4302 (follow-up to #4289 S-3): two pre-existing debug log lines in agent.go
+// echoed the SNMP v2c community string — the shared secret. Even at debug
+// level, logging the secret increases accidental exposure (journald, log
+// shipping). The scrub logs the request SOURCE (and a non-secret authorization
+// level / known-community boolean) instead of the community value, matching the
+// #4289 source-denied log.
+//
+// RED-on-revert: with the pre-#4302 code, the community value is written to the
+// log record and these assertions fail (the secret leaks).
+
+// captureDebugLog installs a Debug-level text handler as the default slog
+// logger for the duration of fn and returns everything it emitted.
+func captureDebugLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+	fn()
+	return buf.String()
+}
+
+// The invalid-community (unknown community) drop must NOT log the community
+// value; it must log the source and known_community=false.
+func TestV2cInvalidCommunityLogDoesNotLeakSecret(t *testing.T) {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"public": {Name: "public", Authorization: "read-only"},
+		},
+	})
+
+	const secret = "s3cr3t-unknown-community"
+	pkt := buildV2cGetRequest(secret, 1, oidSysDescr)
+	src := net.ParseIP("198.51.100.7")
+
+	out := captureDebugLog(t, func() {
+		if resp := a.handlePacketFrom(pkt, src); resp != nil {
+			t.Fatal("GET with an unknown community must be dropped (nil response)")
+		}
+	})
+
+	if !strings.Contains(out, "SNMP: invalid community") {
+		t.Fatalf("expected the invalid-community debug line to fire; got: %q", out)
+	}
+	if strings.Contains(out, secret) {
+		t.Fatalf("invalid-community log LEAKED the community secret %q: %q", secret, out)
+	}
+	if !strings.Contains(out, "198.51.100.7") {
+		t.Fatalf("invalid-community log should record the source IP; got: %q", out)
+	}
+}
+
+// The SET-denied (read-only community, not authorized for write) log must NOT
+// log the community value; it logs the source and the non-secret authorization.
+func TestV2cSetDeniedLogDoesNotLeakSecret(t *testing.T) {
+	const secret = "s3cr3t-readonly-community"
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			secret: {Name: secret, Authorization: "read-only"},
+		},
+	})
+
+	pkt := buildV2cSetRequest(secret, 7, oidSysContact)
+	src := net.ParseIP("198.51.100.9")
+
+	out := captureDebugLog(t, func() {
+		// A read-only community is denied write (noAccess), a non-nil response.
+		if resp := a.handlePacketFrom(pkt, src); resp == nil {
+			t.Fatal("SET from a read-only community should return a denial response, not nil")
+		}
+	})
+
+	if !strings.Contains(out, "SET denied") {
+		t.Fatalf("expected the SET-denied debug line to fire; got: %q", out)
+	}
+	if strings.Contains(out, secret) {
+		t.Fatalf("SET-denied log LEAKED the community secret %q: %q", secret, out)
+	}
+	if !strings.Contains(out, "198.51.100.9") {
+		t.Fatalf("SET-denied log should record the source IP; got: %q", out)
+	}
+}


### PR DESCRIPTION
Three OPEN security follow-up issues, one PR. Each is a strict-commit
reject with a lenient-warn-on-load downgrade (#1960/#3261 no-brick), except
#4302 which is a pure log-line scrub. RED-on-revert proven for each.

## #4302 — SNMP v2c community secret-leak scrub (pkg/snmp)
Two pre-existing debug log lines in `pkg/snmp/agent.go` echoed the v2c
community string (the shared secret): the invalid-community drop in
`handleV2cPacket` and the read-only SET denial in `handleSet`. Scrubbed
both to log the request SOURCE (and non-secret authorization / known-
community boolean) instead of the secret, matching the #4289 pattern.
`handleSet` now takes `srcIP`. The community bytes are still used to echo
the community back in the response varbind — only the log args changed.

## #4296 — family-specific matches under `family any` (pkg/config)
#4287 dual-compiles a `family any` filter into BOTH the inet and inet6
pools; a family-specific match under `family any` (a v4/v6 source/
destination-address literal or a per-family icmp-type/icmp-code) was
dual-compiled VERBATIM, so the copy in the wrong pool never matches — the
v6 term falls through to the implicit ACCEPT (imperfect v6 under-block).
`validateFirewallFilterFamilyAnyMatchesAST` rejects such a term at strict
commit (pointing at `family inet`/`family inet6`), mirroring the existing
`validateFirewallFilterFamilyCollisionsAST` strict/lenient split. The gate
fires before `validateFilterAddressLiteralsStrict` (#3433) so the address
case gets the clearer message; icmp-type/icmp-code is the ONLY gate that
catches that residual.

## #4047 — off-loopback web-management REST bind requires api-auth (pkg/config + pkg/daemon)
The REST/config API serves the mutating endpoints (set/commit/rollback/
system-action) with no auth middleware unless api-auth is configured.
Binding it off-loopback (`web-management http|https interface <mgmt-if>`)
without api-auth exposes those RPCs to the network.
- **Part A (pkg/config):** `validateWebManagementAuthStrict` hard-rejects an
  off-loopback bind without api-auth at strict commit; lenient-warn on load.
- **Part B (pkg/daemon):** runtime fail-safe clamp — a non-loopback bind with
  `apiCfg.Auth == nil` is pulled back to `127.0.0.1` + WARN, so a leniently-
  loaded vulnerable config boots on loopback instead of exposed.
- Part C (/metrics) was already done in #4162.

## Validation
- `go test ./pkg/config/... ./pkg/snmp/... ./pkg/daemon/... ./pkg/api/...` green
- `go build ./...` clean; gofmt + vet clean on all touched files
- RED-on-revert proven for all three (SNMP: secret leaked into the record;
  #4296: icmp-type went nil / no other gate; #4047: config accepted / no warning)
- No legit config false-rejects (normal SNMP community; single-family filter;
  loopback-or-authed web-management). Two existing web-management parse
  fixtures updated to carry api-auth. No deploy config uses web-management.

Closes #4296
Closes #4302
Closes #4047

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi