### PR TITLE
cos: lock CoS-submit owner TX accounting (tx_packets/tx_bytes) (#4282 part a)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,22 @@
+## 2026-07-06 — #4282 part (a): lock CoS-submit owner TX accounting (tx_packets/tx_bytes)
+
+- **Timestamp**: 2026-07-06
+- **Action**: Verified at HEAD (origin/master f7d3b2367) that every CoS
+  packet-ship settle boundary bumps the owner binding's
+  `live.tx_packets` / `live.tx_bytes` — no genuine gap, so part (a) is a
+  regression LOCK, not a fix. The three code-level `fetch_add` sites are
+  `submit_local` (CoSBatch::Local non-exact batch), `submit_prepared`
+  (CoSBatch::Prepared non-exact batch), and `apply_direct_exact_send_result`
+  (the single funnel for the four exact direct-service settle sites in
+  `service.rs` — local|prepared × FIFO|flow-fair). Added three RED-on-revert
+  unit tests that call each site directly and assert the exact
+  (tx_packets, tx_bytes) pair, so a future refactor that drops the counter
+  fails on revert. Full `cargo test --release` = 3679 passed / 0 failed.
+  Part (b) (no dehydrate counterpart to `rehydrate_worker_active_count`)
+  recorded as a PLAN-DEFER-to-/research comment on #4282 — the issue stays
+  OPEN to track that deferred worker-lifecycle-accounting design pass.
+- **File(s)**: userspace-dp/src/afxdp/cos/queue_service/tests.rs
+
 ## 2026-07-05 — #3607: screen flood token bucket (Option B) — fix RateCounter sustained-at-threshold over-throttle
 
 - **Timestamp**: 2026-07-05

--- a/userspace-dp/src/afxdp/cos/queue_service/tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests.rs
@@ -4122,3 +4122,263 @@ fn restore_local_scratch_flow_fair_recycles_offsets_when_queue_gone() {
         "both UMEM offsets must be recycled to free_tx_frames, not leaked"
     );
 }
+
+// #4282 part (a): owner-lifecycle TX accounting lock on the CoS submit
+// paths. A CoS-forwarded packet MUST bump the owner binding's
+// `live.tx_packets` / `live.tx_bytes` exactly like the non-CoS backup
+// drain path (`tx/drain/phase_backup.rs`), or `show interfaces` and the
+// Prometheus TX gauges undercount every shaped byte.
+//
+// Verification at HEAD found the accounting already present on all CoS
+// ship paths — this is a regression LOCK, not a fix. Every CoS-submit
+// settle boundary funnels through exactly one of three `fetch_add`
+// sites:
+//   1. `submit_local`  — the non-exact CoSBatch::Local batched submit.
+//   2. `submit_prepared` — the non-exact CoSBatch::Prepared submit.
+//   3. `apply_direct_exact_send_result` — the single funnel for the
+//      four exact direct-service settle sites in `service.rs`
+//      (local|prepared × FIFO|flow-fair).
+// The three tests below pin the (tx_packets, tx_bytes) pair on each,
+// so a future refactor that drops the counter goes RED on revert.
+
+/// FAIL-ON-REVERT: neutering either `binding.live.tx_packets` /
+/// `tx_bytes` `fetch_add` in `submit_local`'s Ok arm leaves the counter
+/// at 0 and the matching assert fails.
+#[test]
+fn submit_local_bumps_owner_tx_packets_and_bytes() {
+    let now_ns = 1_000_000_000u64;
+    let mut root = test_cos_runtime_with_queues(
+        10_000_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 0,
+            forwarding_class: "iperf-c".into(),
+            priority: 5,
+            transmit_rate_bytes: 10_000_000_000 / 8,
+            guarantee_enabled: true,
+            exact: true,
+            surplus_sharing: true,
+            equal_flow_enforcement: false,
+            equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+            surplus_weight: 1,
+            buffer_bytes: COS_MIN_BURST_BYTES,
+            dscp_rewrite: None,
+            codel_target_ns: 0,
+        }],
+    );
+    root.tokens = 10_000;
+    root.queues[0].hot.tokens = 10_000;
+    root.queues[0].hot.queued_bytes = 300;
+
+    let fast_interfaces = test_cos_fast_interfaces(
+        42,
+        42,
+        0,
+        vec![(0, test_queue_fast_path(false, 0, None, None))],
+        None,
+        None,
+    );
+    let fast_path = fast_interfaces.get(&42).expect("test fast path").clone();
+    let mut binding = BindingWorker::new_for_cos_drain_test(0, 0, 42, root, fast_path);
+
+    // Three 100-byte items, all fully shipped through the test TX ring
+    // in a single transmit_batch call (TX_BATCH_SIZE == 64).
+    let items: VecDeque<TxRequest> = (0..3)
+        .map(|_| TxRequest {
+            bytes: vec![0u8; 100],
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: None,
+            egress_ifindex: 42,
+            cos_queue_id: Some(0),
+            dscp_rewrite: None,
+            mirror_clone: false,
+            enqueue_ns: now_ns,
+        })
+        .collect();
+    let mut shared_recycles = Vec::new();
+
+    let progress = submit_local(
+        &mut binding,
+        42,
+        0,
+        CoSServicePhase::Surplus,
+        300,
+        items,
+        now_ns,
+        &mut shared_recycles,
+    );
+    assert!(
+        progress,
+        "submit_local must report progress on a full commit"
+    );
+
+    assert_eq!(
+        binding
+            .live
+            .tx_packets
+            .load(std::sync::atomic::Ordering::Relaxed),
+        3,
+        "submit_local must bump owner tx_packets by the committed packet count",
+    );
+    assert_eq!(
+        binding
+            .live
+            .tx_bytes
+            .load(std::sync::atomic::Ordering::Relaxed),
+        300,
+        "submit_local must bump owner tx_bytes by the committed byte count",
+    );
+}
+
+/// FAIL-ON-REVERT: neutering either `binding.live.tx_packets` /
+/// `tx_bytes` `fetch_add` in `submit_prepared`'s Ok arm leaves the
+/// counter at 0 and the matching assert fails.
+#[test]
+fn submit_prepared_bumps_owner_tx_packets_and_bytes() {
+    let now_ns = 1_000_000_000u64;
+    let mut root = test_cos_runtime_with_queues(
+        10_000_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 0,
+            forwarding_class: "iperf-c".into(),
+            priority: 5,
+            transmit_rate_bytes: 10_000_000_000 / 8,
+            guarantee_enabled: true,
+            exact: true,
+            surplus_sharing: true,
+            equal_flow_enforcement: false,
+            equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+            surplus_weight: 1,
+            buffer_bytes: COS_MIN_BURST_BYTES,
+            dscp_rewrite: None,
+            codel_target_ns: 0,
+        }],
+    );
+    root.tokens = 10_000;
+    root.queues[0].hot.tokens = 10_000;
+    root.queues[0].hot.queued_bytes = 250;
+
+    let fast_interfaces = test_cos_fast_interfaces(
+        42,
+        42,
+        0,
+        vec![(0, test_queue_fast_path(false, 0, None, None))],
+        None,
+        None,
+    );
+    let fast_path = fast_interfaces.get(&42).expect("test fast path").clone();
+    let mut binding = BindingWorker::new_for_cos_drain_test(0, 0, 42, root, fast_path);
+
+    // Two prepared items whose frames live in the binding's own UMEM.
+    // Production allocates a prepared frame OUT of the free pool, so
+    // remove those two offsets from free_tx_frames to mirror that and
+    // avoid double-ownership of the frame.
+    let specs = [
+        (40u64 << UMEM_FRAME_SHIFT, 100u32),
+        (41u64 << UMEM_FRAME_SHIFT, 150u32),
+    ];
+    for (offset, len) in specs {
+        let frame = unsafe {
+            binding
+                .umem
+                .area()
+                .slice_mut_unchecked(offset as usize, len as usize)
+        }
+        .expect("umem frame slice");
+        frame.fill(0);
+    }
+    binding
+        .tx_pipeline
+        .free_tx_frames
+        .retain(|&off| off != specs[0].0 && off != specs[1].0);
+
+    let items: VecDeque<PreparedTxRequest> = specs
+        .iter()
+        .map(|&(offset, len)| PreparedTxRequest {
+            offset,
+            len,
+            recycle: PreparedTxRecycle::FreeTxFrame,
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: None,
+            egress_ifindex: 42,
+            cos_queue_id: Some(0),
+            dscp_rewrite: None,
+            mirror_clone: false,
+            enqueue_ns: now_ns,
+        })
+        .collect();
+    let mut shared_recycles = Vec::new();
+
+    let progress = submit_prepared(
+        &mut binding,
+        42,
+        0,
+        CoSServicePhase::Surplus,
+        250,
+        items,
+        now_ns,
+        &mut shared_recycles,
+    );
+    assert!(
+        progress,
+        "submit_prepared must report progress on a full commit"
+    );
+
+    assert_eq!(
+        binding
+            .live
+            .tx_packets
+            .load(std::sync::atomic::Ordering::Relaxed),
+        2,
+        "submit_prepared must bump owner tx_packets by the committed packet count",
+    );
+    assert_eq!(
+        binding
+            .live
+            .tx_bytes
+            .load(std::sync::atomic::Ordering::Relaxed),
+        250,
+        "submit_prepared must bump owner tx_bytes by the committed byte count",
+    );
+}
+
+/// FAIL-ON-REVERT: removing either `binding.live.tx_packets` /
+/// `tx_bytes` `fetch_add` in `apply_direct_exact_send_result` leaves the
+/// counter at 0. This is the single owner-TX accounting funnel for all
+/// four exact direct-service settle sites in `service.rs`.
+#[test]
+fn apply_direct_exact_send_result_bumps_owner_tx_packets_and_bytes() {
+    let root = test_cos_interface_runtime(0);
+    let fast_interfaces = test_cos_fast_interfaces(
+        42,
+        42,
+        0,
+        vec![(0, test_queue_fast_path(false, 0, None, None))],
+        None,
+        None,
+    );
+    let fast_path = fast_interfaces.get(&42).expect("test fast path").clone();
+    let mut binding = BindingWorker::new_for_cos_drain_test(0, 0, 42, root, fast_path);
+
+    crate::afxdp::cos::tx_completion::apply_direct_exact_send_result(&mut binding, 42, 0, 4, 6_000);
+
+    assert_eq!(
+        binding
+            .live
+            .tx_packets
+            .load(std::sync::atomic::Ordering::Relaxed),
+        4,
+        "direct-exact settle funnel must bump owner tx_packets",
+    );
+    assert_eq!(
+        binding
+            .live
+            .tx_bytes
+            .load(std::sync::atomic::Ordering::Relaxed),
+        6_000,
+        "direct-exact settle funnel must bump owner tx_bytes",
+    );
+}


### PR DESCRIPTION
## Summary

Part (a) of #4282. Verified at HEAD (`f7d3b2367`) that every CoS
packet-ship settle boundary already bumps the owner binding's
`live.tx_packets` / `live.tx_bytes` — same as the non-CoS backup drain
path (`tx/drain/phase_backup.rs`). No undercount exists, so this is a
**regression LOCK, not a fix**.

Every CoS-submit settle boundary funnels through one of three
`fetch_add` sites:

1. `submit_local` — non-exact `CoSBatch::Local` batched submit.
2. `submit_prepared` — non-exact `CoSBatch::Prepared` batched submit.
3. `apply_direct_exact_send_result` — the single owner-TX accounting
   funnel for the four exact direct-service settle sites in `service.rs`
   (local|prepared × FIFO|flow-fair).

The forwarding fast path (`tx/dispatch`) keeps a separate deferred
sub-counter family (`direct/copy/in_place_tx_packets`, flushed in
`umem/debug_state.rs`), so `tx_packets`/`tx_bytes` are exclusively the
CoS + backup-drain family — these three are the complete CoS set.

## Change

Three RED-on-revert unit tests, one per site, each asserting the exact
`(tx_packets, tx_bytes)` pair the committed batch should produce:

- `submit_local_bumps_owner_tx_packets_and_bytes`
- `submit_prepared_bumps_owner_tx_packets_and_bytes`
- `apply_direct_exact_send_result_bumps_owner_tx_packets_and_bytes`

`submit_local`/`submit_prepared` ship through the test TX ring
(`RingTx::new_for_test`); prepared frames are staged into the binding's
own UMEM. `apply_direct_exact_send_result` is called with a known
`(packets, bytes)` tuple. Neutering either `fetch_add` on any site drops
the matching counter to zero and fails the assert.

## Validation

- Full `cargo test --release` = **3679 passed, 0 failed**.
- rustfmt clean on the changed lines.

## Scope / follow-up

Refs #4282. This PR closes **part (a)** only. **Part (b)** (no dehydrate
counterpart to `rehydrate_worker_active_count` — a dropped worker
runtime with `active_flow_buckets > 0` can leave a stale per-worker
active-flow count in a surviving shared lease Arc) is a
worker-lifecycle-accounting design question interacting with the R-7
rejoin (additive rehydrate) and R-2 shared-lease machinery. It is
recorded as a PLAN-DEFER-to-/research comment on #4282, which stays
**open** to track it (suggest label `plan-deferred-research`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
