### PR TITLE
config: fix mixed-shape apply-groups leaf-list duplicate (#4070 PR-A)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -36061,3 +36061,27 @@ top.
   userspace-dp/src/afxdp/forwarding/README.md,
   docs/userspace-dataplane-architecture.md,
   docs/research/3616-ipsec-host-inbound/*.md (materialized + status stamp).
+
+- **Timestamp**: 2026-07-06
+- **Action**: #4070 PR-A — fix the mixed-shape apply-groups leaf-list
+  DUPLICATE-NODE bug (CASE-D). A leaf-list can be expressed as a COLLAPSED
+  leaf (`name-server 1.1.1.1 2.2.2.2`, Keys[0]=="name-server") or a BLOCK
+  container (`name-server { 1.1.1.1; 2.2.2.2; }`, Keys==["name-server"]).
+  Before the fix, `mergeNodes` only cross-recognized the SAME shape
+  (leaf-vs-leaf override, container-vs-container union); a MIXED shape for
+  the same key emitted BOTH a leaf AND a container — a duplicate that is
+  never correct. Made the group-inheritance merge shape-agnostic on Keys[0]:
+  broadened `hasMatchingLeaf` to also match a single-key CONTAINER sharing
+  Keys[0] (a block-shaped leaf-list), and added a symmetric guard in the
+  container branch so a group block container is suppressed when the stanza
+  already holds the same leaf-list as a collapsed leaf. Multi-key containers
+  (e.g. `["family","inet"]`) are never cross-suppressed (len==1 gate). Only
+  the DUPLICATE-NODE bug is fixed; the union-vs-override VALUE decision for
+  SAME-shape leaf-lists (CASE-B override / CASE-C union preserved unchanged)
+  remains the deferred half of #4070. Added dual-shape RED-on-revert tests
+  (both mixed orderings collapse to ONE node; same-shape override/union
+  unchanged; multi-key sibling containers both survive). Verified RED on
+  Edit-revert (2 nodes) and GREEN with the fix; full pkg/config suite,
+  gofmt, vet, and `go build ./...` all clean.
+- **File(s)**: pkg/config/ast_groups.go,
+  pkg/config/apply_groups_leaflist_test.go

--- a/pkg/config/apply_groups_leaflist_test.go
+++ b/pkg/config/apply_groups_leaflist_test.go
@@ -27,8 +27,8 @@ import "testing"
 // single well-formed hierarchical string, the same pattern as
 // TestApplyGroupsMergeDoesNotOverride / TestApplyGroupsHierarchical.
 
-// countNameServers returns the number of distinct "name-server" nodes under
-// the top-level "system" node after group expansion, plus a shape summary.
+// systemNameServerNodes returns the distinct "name-server" nodes under the
+// top-level "system" node after group expansion.
 func systemNameServerNodes(t *testing.T, tree *ConfigTree) []*Node {
 	t.Helper()
 	sys := tree.FindChild("system")
@@ -255,7 +255,15 @@ interfaces {
 	if err := tree.ExpandGroups(); err != nil {
 		t.Fatalf("ExpandGroups: %v", err)
 	}
-	unit := tree.FindChild("interfaces").FindChild("eth0").FindChild("unit")
+	ifaces := tree.FindChild("interfaces")
+	if ifaces == nil {
+		t.Fatal("no interfaces node after expansion")
+	}
+	eth0 := ifaces.FindChild("eth0")
+	if eth0 == nil {
+		t.Fatal("no interfaces eth0 node after expansion")
+	}
+	unit := eth0.FindChild("unit")
 	if unit == nil {
 		t.Fatal("no interfaces eth0 unit 0 after expansion")
 	}

--- a/pkg/config/apply_groups_leaflist_test.go
+++ b/pkg/config/apply_groups_leaflist_test.go
@@ -1,0 +1,283 @@
+package config
+
+import "testing"
+
+// #4070 PR-A: a leaf-list can be expressed either as a COLLAPSED leaf
+// ("name-server 1.1.1.1 2.2.2.2", one Node with Keys[0]=="name-server" and
+// the values in Keys[1:]) or as a BLOCK container
+// ("name-server { 1.1.1.1; 2.2.2.2; }", one Node with Keys==["name-server"]
+// and the values as child leaves). Before the fix, apply-groups inheritance
+// only cross-recognized the SAME shape: a collapsed group leaf overrode a
+// collapsed stanza leaf (leaf-vs-leaf), and a block group container merged
+// into a block stanza container (container-vs-container). When the two
+// shapes were MIXED for the same key, mergeNodes recognized neither branch
+// and emitted BOTH a leaf AND a container for the same key — a duplicate
+// node that is never correct.
+//
+// These tests assert the KEY invariant of PR-A: after group expansion a
+// given Keys[0] leaf-list appears as EXACTLY ONE node, never a leaf AND a
+// container. They intentionally do NOT pin the union-vs-override VALUE
+// decision for same-shape leaf-lists (that is the deferred half of #4070) —
+// they only lock the same-shape behavior as UNCHANGED and require the mixed
+// shape to stop producing a duplicate.
+//
+// Block-shape leaf-lists require hierarchical syntax (flat `set` cannot
+// produce a block container — repeated `set name-server X` yields separate
+// single-value leaves, not a block), so these tests use NewParser on a
+// single well-formed hierarchical string, the same pattern as
+// TestApplyGroupsMergeDoesNotOverride / TestApplyGroupsHierarchical.
+
+// countNameServers returns the number of distinct "name-server" nodes under
+// the top-level "system" node after group expansion, plus a shape summary.
+func systemNameServerNodes(t *testing.T, tree *ConfigTree) []*Node {
+	t.Helper()
+	sys := tree.FindChild("system")
+	if sys == nil {
+		t.Fatal("no system node after expansion")
+	}
+	return sys.FindChildren("name-server")
+}
+
+// TestApplyGroupsMixedShapeBlockGroupCollapsedStanza is CASE-D: the group
+// defines the leaf-list as a BLOCK container and the inheriting stanza as a
+// COLLAPSED leaf. Before the fix this produced TWO name-server nodes (a leaf
+// AND a container). After the fix exactly one node survives.
+func TestApplyGroupsMixedShapeBlockGroupCollapsedStanza(t *testing.T) {
+	input := `
+groups {
+    g {
+        system {
+            name-server {
+                1.1.1.1;
+                2.2.2.2;
+            }
+        }
+    }
+}
+apply-groups g;
+system {
+    name-server 9.9.9.9;
+}
+`
+	p := NewParser(input)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	if err := tree.ExpandGroups(); err != nil {
+		t.Fatalf("ExpandGroups: %v", err)
+	}
+	ns := systemNameServerNodes(t, tree)
+	if len(ns) != 1 {
+		t.Fatalf("mixed-shape (block group + collapsed stanza) must yield "+
+			"exactly ONE name-server node, got %d: %s",
+			len(ns), describeNodes(ns))
+	}
+	// The explicit stanza value wins (same precedence rule the code already
+	// applies for a collapsed leaf that shadows a group value).
+	if got := ns[0]; !got.IsLeaf || len(got.Keys) < 2 || got.Keys[1] != "9.9.9.9" {
+		t.Fatalf("surviving node should be the explicit stanza leaf "+
+			"name-server 9.9.9.9, got %s", describeNodes(ns))
+	}
+}
+
+// TestApplyGroupsMixedShapeCollapsedGroupBlockStanza is CASE-D reversed: the
+// group defines the leaf-list as a COLLAPSED leaf and the inheriting stanza
+// as a BLOCK container. Before the fix this also produced TWO name-server
+// nodes. After the fix exactly one node survives.
+func TestApplyGroupsMixedShapeCollapsedGroupBlockStanza(t *testing.T) {
+	input := `
+groups {
+    g {
+        system {
+            name-server 9.9.9.9;
+        }
+    }
+}
+apply-groups g;
+system {
+    name-server {
+        1.1.1.1;
+        2.2.2.2;
+    }
+}
+`
+	p := NewParser(input)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	if err := tree.ExpandGroups(); err != nil {
+		t.Fatalf("ExpandGroups: %v", err)
+	}
+	ns := systemNameServerNodes(t, tree)
+	if len(ns) != 1 {
+		t.Fatalf("mixed-shape (collapsed group + block stanza) must yield "+
+			"exactly ONE name-server node, got %d: %s",
+			len(ns), describeNodes(ns))
+	}
+	// The explicit stanza (block container) wins; the group's collapsed value
+	// is suppressed, so the survivor is the container holding 1.1.1.1/2.2.2.2.
+	if got := ns[0]; got.IsLeaf {
+		t.Fatalf("surviving node should be the explicit stanza block "+
+			"container, got %s", describeNodes(ns))
+	}
+}
+
+// TestApplyGroupsSameShapeBlockUnionUnchanged is CASE-C: both group and
+// stanza express the leaf-list as a BLOCK container. The existing behavior
+// (union: all values present under one container) MUST be unchanged by the
+// fix — the deferred union-vs-override VALUE decision is not touched here.
+func TestApplyGroupsSameShapeBlockUnionUnchanged(t *testing.T) {
+	input := `
+groups {
+    g {
+        system {
+            name-server {
+                1.1.1.1;
+                2.2.2.2;
+            }
+        }
+    }
+}
+apply-groups g;
+system {
+    name-server {
+        9.9.9.9;
+    }
+}
+`
+	p := NewParser(input)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	if err := tree.ExpandGroups(); err != nil {
+		t.Fatalf("ExpandGroups: %v", err)
+	}
+	ns := systemNameServerNodes(t, tree)
+	if len(ns) != 1 {
+		t.Fatalf("same-shape block+block must yield ONE name-server node, "+
+			"got %d: %s", len(ns), describeNodes(ns))
+	}
+	if ns[0].IsLeaf {
+		t.Fatalf("same-shape block+block survivor must be a container, got %s",
+			describeNodes(ns))
+	}
+	// Union preserved: stanza's own value plus both group values.
+	got := map[string]bool{}
+	for _, c := range ns[0].Children {
+		got[c.Keys[0]] = true
+	}
+	for _, want := range []string{"9.9.9.9", "1.1.1.1", "2.2.2.2"} {
+		if !got[want] {
+			t.Errorf("same-shape block+block union missing %q; children=%v",
+				want, got)
+		}
+	}
+}
+
+// TestApplyGroupsSameShapeCollapsedOverrideUnchanged is CASE-B: both group
+// and stanza express the leaf-list as a COLLAPSED leaf. The existing
+// behavior (override: the explicit stanza value wins, group suppressed) MUST
+// be unchanged by the fix.
+func TestApplyGroupsSameShapeCollapsedOverrideUnchanged(t *testing.T) {
+	input := `
+groups {
+    g {
+        system {
+            name-server [ 1.1.1.1 2.2.2.2 ];
+        }
+    }
+}
+apply-groups g;
+system {
+    name-server 9.9.9.9;
+}
+`
+	p := NewParser(input)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	if err := tree.ExpandGroups(); err != nil {
+		t.Fatalf("ExpandGroups: %v", err)
+	}
+	ns := systemNameServerNodes(t, tree)
+	if len(ns) != 1 {
+		t.Fatalf("same-shape collapsed+collapsed must yield ONE name-server "+
+			"node, got %d: %s", len(ns), describeNodes(ns))
+	}
+	got := ns[0]
+	if !got.IsLeaf || len(got.Keys) != 2 || got.Keys[1] != "9.9.9.9" {
+		t.Fatalf("same-shape collapsed+collapsed must keep only the explicit "+
+			"stanza value name-server 9.9.9.9, got %s", describeNodes(ns))
+	}
+}
+
+// TestApplyGroupsMultiKeyContainerSiblingsNotSuppressed guards the fix's
+// cross-shape match against over-reach: a group's multi-key container
+// (family inet6 { ... }, Keys==["family","inet6"]) must NOT be suppressed by
+// a stanza's sibling multi-key container (family inet { ... }) that only
+// shares Keys[0]=="family". Multi-key containers are real hierarchical nodes,
+// never leaf-lists, so both must survive as distinct nodes.
+func TestApplyGroupsMultiKeyContainerSiblingsNotSuppressed(t *testing.T) {
+	input := `
+groups {
+    g {
+        interfaces {
+            eth0 {
+                unit 0 {
+                    family inet6 {
+                        address fc00::1/64;
+                    }
+                }
+            }
+        }
+    }
+}
+apply-groups g;
+interfaces {
+    eth0 {
+        unit 0 {
+            family inet {
+                address 10.0.0.1/24;
+            }
+        }
+    }
+}
+`
+	p := NewParser(input)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	if err := tree.ExpandGroups(); err != nil {
+		t.Fatalf("ExpandGroups: %v", err)
+	}
+	unit := tree.FindChild("interfaces").FindChild("eth0").FindChild("unit")
+	if unit == nil {
+		t.Fatal("no interfaces eth0 unit 0 after expansion")
+	}
+	fams := unit.FindChildren("family")
+	if len(fams) != 2 {
+		t.Fatalf("multi-key sibling containers family inet + family inet6 "+
+			"must both survive, got %d: %s", len(fams), describeNodes(fams))
+	}
+}
+
+// describeNodes renders a compact shape/keys summary for assertion messages.
+func describeNodes(nodes []*Node) string {
+	out := ""
+	for i, n := range nodes {
+		if i > 0 {
+			out += "; "
+		}
+		shape := "container"
+		if n.IsLeaf {
+			shape = "leaf"
+		}
+		out += shape + " " + n.KeyPath()
+	}
+	return out
+}

--- a/pkg/config/ast_groups.go
+++ b/pkg/config/ast_groups.go
@@ -255,6 +255,19 @@ func mergeNodes(dst *[]*Node, src []*Node) {
 			}
 		}
 		if !found {
+			// Cross-shape guard (#4070): a single-key group container is a
+			// leaf-list expressed in BLOCK shape (Keys == ["name-server"]).
+			// If the destination already holds the same leaf-list as a
+			// COLLAPSED leaf sharing Keys[0] (e.g. "name-server 9.9.9.9"),
+			// the two express the SAME statement in different shapes. The
+			// explicit stanza value wins (same precedence rule as
+			// hasMatchingLeaf), so skip the group container instead of
+			// appending a duplicate second node for the same key. Multi-key
+			// containers (e.g. ["family","inet"]) are real hierarchical
+			// nodes, never leaf-lists, so they are never cross-suppressed.
+			if len(s.Keys) == 1 && hasMatchingLeaf(*dst, s.Keys) {
+				continue
+			}
 			*dst = append(*dst, s)
 		}
 	}
@@ -287,12 +300,29 @@ func keysMatchWildcard(dst, src []string) bool {
 // hasMatchingLeaf returns true if nodes contains a leaf whose first key
 // matches. This prevents group values from overriding explicit config
 // (e.g., if "host-name explicit" already exists, "host-name group" is skipped).
+//
+// It ALSO matches a single-key CONTAINER whose Keys[0] equals keys[0]
+// (#4070). A leaf-list can be expressed either as a collapsed leaf
+// ("name-server 1.1.1.1 2.2.2.2", Keys[0]=="name-server") or as a block
+// container ("name-server { 1.1.1.1; 2.2.2.2; }", Keys==["name-server"]).
+// Recognizing the block container here lets a collapsed group leaf and an
+// existing block stanza (or vice versa) be treated as the SAME leaf-list
+// instead of emitting both a leaf AND a container for one key. Only
+// single-key containers cross-match: multi-key containers (e.g.
+// ["family","inet"]) are real hierarchical nodes, never leaf-lists, and a
+// leaf sharing only Keys[0] must not be confused with them.
 func hasMatchingLeaf(nodes []*Node, keys []string) bool {
 	if len(keys) == 0 {
 		return false
 	}
 	for _, n := range nodes {
-		if n.IsLeaf && len(n.Keys) > 0 && n.Keys[0] == keys[0] {
+		if len(n.Keys) == 0 || n.Keys[0] != keys[0] {
+			continue
+		}
+		if n.IsLeaf {
+			return true
+		}
+		if len(n.Keys) == 1 {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

PR-A of #4070: fixes the standalone **mixed-shape apply-groups leaf-list
duplicate** bug (CASE-D in the issue's converged plan), independent of the
deferred union-vs-override VALUE decision.

A leaf-list under `apply-groups` can be expressed in two AST shapes:

- **Collapsed leaf** — `name-server 1.1.1.1 2.2.2.2` (one `Node`, values in `Keys[1:]`)
- **Block container** — `name-server { 1.1.1.1; 2.2.2.2; }` (one `Node`, `Keys==["name-server"]`, values as child leaves)

Before this change, `mergeNodes` only cross-recognized the **same** shape
(leaf-vs-leaf override, container-vs-container union). When a group and the
inheriting stanza expressed the **same key in different shapes**, neither
branch matched and the merge emitted **both** a leaf **and** a container for
one key — a duplicate node that is never correct.

## Fix (`pkg/config/ast_groups.go`, GO — not cargo)

Make the group-inheritance merge shape-agnostic on `Keys[0]` so a given
leaf-list yields **exactly one** node:

1. **Leaf branch / `hasMatchingLeaf`** — now also matches a single-key
   CONTAINER sharing `Keys[0]` (a block-shaped leaf-list), so a collapsed
   group leaf inheriting into an existing block stanza is recognized as the
   same leaf-list and skipped, not appended as a duplicate.
2. **Container branch** — symmetric guard: when no matching container exists
   but a collapsed leaf with the same `Keys[0]` does, the group block
   container is suppressed rather than appended.

The cross-shape match is confined to single-key nodes (`len(Keys)==1`):
multi-key containers like `["family","inet"]` are real hierarchical nodes,
never leaf-lists, so a leaf sharing only `Keys[0]` can never suppress a
sibling such as `["family","inet6"]`.

## Scope / what remains

This fixes **only** the DUPLICATE-NODE bug (the same key must not produce two
nodes). The **union-vs-override VALUE decision** for same-shape leaf-lists is
intentionally untouched and remains the **deferred half of #4070**:
`collapsed+collapsed` still overrides (explicit stanza wins) and
`block+block` still unions — both pinned unchanged by tests. That direction
needs the real-Junos per-statement-class matrix (policy chains union; some
scalars-as-lists override) before it can be driven.

## Tests (`pkg/config/apply_groups_leaflist_test.go`, RED on revert)

- `TestApplyGroupsMixedShapeBlockGroupCollapsedStanza` — CASE-D, block group + collapsed stanza -> ONE node (RED on revert: leaf + container).
- `TestApplyGroupsMixedShapeCollapsedGroupBlockStanza` — reverse mixed shape -> ONE node (RED on revert).
- `TestApplyGroupsSameShapeBlockUnionUnchanged` — CASE-C union preserved.
- `TestApplyGroupsSameShapeCollapsedOverrideUnchanged` — CASE-B override preserved.
- `TestApplyGroupsMultiKeyContainerSiblingsNotSuppressed` — `family inet` + `family inet6` both survive (over-reach guard).

Verified RED on Edit-revert (2 nodes) and GREEN with the fix. Full
`go test ./pkg/config/... ./pkg/configstore/... ./pkg/cluster/...`, `gofmt`,
`go vet`, and `go build ./...` all clean. Block-shape leaf-lists require
hierarchical syntax, so the tests use `NewParser` on a single well-formed
string (flat `set` cannot produce a block container).

Refs #4070

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi