### PR TITLE
cluster: authenticate the heartbeat/election channel with a PSK HMAC (Refs #4107, PR-A)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -36061,3 +36061,33 @@ top.
   userspace-dp/src/afxdp/forwarding/README.md,
   docs/userspace-dataplane-architecture.md,
   docs/research/3616-ipsec-host-inbound/*.md (materialized + status stamp).
+
+- **Timestamp**: 2026-07-06
+- **Action**: #4107 PR-A — first authenticated cluster control channel + config
+  foundation for the PSK/HMAC program (F1-stronger + F23). Config: added the
+  `set chassis cluster authentication-key <key>` leaf (schema_chassis.go),
+  `ClusterConfig.ControlLinkAuthKey config.Secret` (types_chassis.go), and the
+  Secret compile (compiler_system.go). Redaction is inherited free — the
+  `authentication-key` keyword is already in ast_redact.go's secret set
+  (##SECRET-DATA## in raw-AST renders) and the Secret type redacts JSON/YAML/
+  String(). Heartbeat/election channel authed: MarshalHeartbeatAuth appends a
+  52-byte trailer (magic XPFA + session + monotonic counter + HMAC-SHA256 over
+  the whole frame) after the version trailer (additive, legacy-parseable). The
+  receiver rejects a forged/tampered/replayed heartbeat BEFORE lastSeen refresh
+  or handlePeerHeartbeat. Dual-accept (heartbeatAuthDecision) mirrors the #4126
+  VRRP-checksum migration: no key → accept all; key + present → enforce HMAC +
+  anti-replay; key + absent + peer-never-authed → accept; key + absent +
+  peerAuthSeen (sticky, set only by a verified frame) → reject (downgrade).
+  Anti-replay (heartbeatAuthReplay) is strict within a session and re-anchors on
+  a new random session id, so a reboot/restart (test-failover) is never a false
+  replay. Key plumbed via Manager.UpdateConfig → controlLinkAuthKey(); raw
+  bytes, never logged; fetched fresh each send/recv so a commit takes effect
+  without a heartbeat restart. RED-on-revert proven: neutering
+  heartbeatAuthDecision to always-accept turns bad-hmac / replay / downgrade /
+  forged-frame assertions RED. go test ./pkg/config/... ./pkg/cluster/... green
+  (incl. -race); go build ./..., gofmt, go vet clean. Follow-up channels
+  (session-sync frames, fabric gRPC) reuse the same ControlLinkAuthKey.
+- **File(s)**: pkg/config/schema_chassis.go, pkg/config/types_chassis.go,
+  pkg/config/compiler_system.go, pkg/config/compiler_cluster_authkey_4107_test.go,
+  pkg/cluster/heartbeat.go, pkg/cluster/manager.go, pkg/cluster/group_state.go,
+  pkg/cluster/heartbeat_auth_test.go, pkg/cluster/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -36115,3 +36115,26 @@ top.
   gofmt, vet, and `go build ./...` all clean.
 - **File(s)**: pkg/config/ast_groups.go,
   pkg/config/apply_groups_leaflist_test.go
+
+- **Timestamp**: 2026-07-06
+- **Action**: #4107 PR-A hardening fold (hostile-review) — close the
+  silent-downgrade-to-unsigned edge. MarshalHeartbeatAuth previously fell back
+  to emitting an UNSIGNED frame when body+52 > maxHeartbeatSize (an extreme
+  ~monitor-heavy config), which an ENFORCING peer would reject → dual-primary.
+  Fix: extracted marshalHeartbeatBody(pkt, tailReserve) from MarshalHeartbeat
+  (MarshalHeartbeat is now a tailReserve=0 wrapper, byte-identical); when a key
+  is configured MarshalHeartbeatAuth reserves heartbeatAuthTrailerSize up front
+  so the best-effort monitor section is truncated to make room while the
+  election-critical header/RG groups are always kept — the signed frame ALWAYS
+  fits its HMAC. Invariant: once a key is configured a heartbeat is NEVER
+  emitted unsigned. The residual overflow guard is unreachable at the
+  uint8-bounded RG count and fails LOUD (slog.Error) instead of emitting
+  cleartext. Added TestMarshalHeartbeatAuth_NeverUnsignedWhenKeyed (300 long-name
+  monitors overflow the cap → frame still SIGNED + verifies, groups survive,
+  monitors truncated). RED-on-revert proven: dropping the reserve re-introduces
+  the unsigned-fallback → test fails "emitted UNSIGNED under frame overflow".
+  go test ./pkg/config/... ./pkg/cluster/... green (incl. -race); go build,
+  gofmt, vet clean. Also merged origin/master (#4070/#4325 advanced); _Log.md
+  union.
+- **File(s)**: pkg/cluster/heartbeat.go, pkg/cluster/heartbeat_auth_test.go,
+  pkg/cluster/README.md, _Log.md

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -22,7 +22,11 @@ locating any symbol below is now a matter of opening the named file.
   `handlePeerNeverSeen`, `HeartbeatStats`,
   `vrfListenConfig` — `heartbeat_manager.go`.
 - `HeartbeatPacket`, `MarshalHeartbeat`,
-  `UnmarshalHeartbeat`, sender/receiver goroutine types — `heartbeat.go`.
+  `UnmarshalHeartbeat`, the #4107 control-channel auth
+  (`MarshalHeartbeatAuth`, `heartbeatAuthTrailer`,
+  `verifyHeartbeatMAC`, `heartbeatAuthReplay`,
+  `heartbeatAuthDecision`), sender/receiver goroutine types —
+  `heartbeat.go`. See "Control-channel authentication" below.
 - Single-RG manual failover and transfer-commit protocol
   (`ManualFailover`, `ForceSecondary`, `ResetFailover`,
   `RequestPeerFailover`, `commitRequestedPeerFailover`,
@@ -104,6 +108,67 @@ The primary consumer of the `Manager.Events()` channel is
 `pkg/daemon/daemon_ha.go`, which fans events out (HA sync, status
 publish, etc.). `pkg/cluster/reth.go::HandleStateChange` is a
 state-handler method, not the event-channel consumer.
+
+## Control-channel authentication (#4107, PR-A)
+
+The cluster heartbeat drives election: `handlePeerHeartbeat` rebuilds
+peer redundancy-group state directly from the packet and runs
+`runElection()`, so a forged cleartext heartbeat can force the local
+node PRIMARY or demote the peer (Weight=0 → local claims PRIMARY;
+higher priority → local forced SECONDARY). The heartbeat is UDP on the
+shared control VLAN, so any host that can reach the peer's control IP
+could inject one.
+
+**Fix (first authed channel).** When a shared PSK is configured
+(`set chassis cluster authentication-key <key>` → `config.Secret`
+`ClusterConfig.ControlLinkAuthKey`, plumbed into the `Manager` by
+`UpdateConfig` and read via `controlLinkAuthKey()`), the sender appends
+an HMAC-SHA256 auth trailer to the heartbeat frame and the receiver
+rejects a forged/tampered/replayed heartbeat **before** it can refresh
+peer liveness (`lastSeen`) or drive election.
+
+- **Wire.** `MarshalHeartbeatAuth` appends a fixed 52-byte trailer
+  AFTER the optional version trailer: `magic "XPFA"(4) + session(8) +
+  counter(8) + HMAC-SHA256(32)`. The HMAC covers the whole frame plus
+  the magic/session/counter (everything but the digest). Because
+  `UnmarshalHeartbeat` already ignores bytes past the version section,
+  a signed frame stays wire-parseable by a legacy / not-yet-keyed peer
+  — the same additive-trailer discipline as the version trailer.
+- **Anti-replay.** `session` is a random per-sender-process id and
+  `counter` a monotonic per-session counter. `heartbeatAuthReplay.admit`
+  accepts a strictly increasing counter within a session and RE-ANCHORS
+  on a new session id, so a sender restart/reboot (a routine HA event —
+  `make test-failover` reboots a node) is never mistaken for a replay.
+  Intra-session replays are rejected. Cross-session stale replay is a
+  bounded residual (a captured old frame carries stale state that the
+  next genuine heartbeat overwrites within one interval); tightening it
+  belongs to the follow-up channels.
+- **Dual-accept (rolling upgrade), `heartbeatAuthDecision`.** Mirrors
+  the #4126 VRRP-checksum dual-accept migration:
+  - No local key → accept everything (this node cannot verify; may be
+    the not-yet-keyed side of an upgrade). No regression.
+  - Local key + auth trailer → enforce: reject a bad HMAC or a replayed
+    nonce.
+  - Local key + no trailer + peer has NOT yet authenticated → accept
+    (the peer has not started signing; key not yet synced).
+  - Local key + no trailer + peer HAS authenticated (sticky
+    `peerAuthSeen`, set only by a verified frame) → reject: a downgrade
+    to cleartext once both nodes are keyed is an attack.
+
+  Enforcement therefore engages only once BOTH nodes carry the key and
+  are observed signing — a mixed-version / mid-key-rollout cluster never
+  splits.
+- **Secret hygiene.** The key is `config.Secret`, redacted on every
+  JSON/YAML/`String()` path and masked as `##SECRET-DATA##` in raw-AST
+  renders (`authentication-key` is already in `ast_redact.go`'s secret
+  set). It is stored as raw bytes on the `Manager`, never logged; the
+  auth-reject log line carries only a reason string and the peer node id.
+
+**Scope.** PR-A authenticates the heartbeat/election channel only — the
+most acute F23 vector. The session-sync frames (`sync_conn.go`) and the
+fabric gRPC listener (`pkg/grpcapi`) remain follow-up channels of the
+same PSK program (#4107); the config foundation and the shared
+`ControlLinkAuthKey` land here so those channels reuse it.
 
 ## DHCP-server lease sync (#2239)
 

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -134,6 +134,15 @@ peer liveness (`lastSeen`) or drive election.
   `UnmarshalHeartbeat` already ignores bytes past the version section,
   a signed frame stays wire-parseable by a legacy / not-yet-keyed peer
   — the same additive-trailer discipline as the version trailer.
+  **Never-unsigned-when-keyed invariant:** `MarshalHeartbeatAuth`
+  reserves the 52-byte trailer up front via
+  `marshalHeartbeatBody(pkt, heartbeatAuthTrailerSize)`, which truncates
+  the best-effort monitor section (never the election-critical header /
+  RG groups) to make room. So once a key is configured a heartbeat is
+  ALWAYS signed — never silently downgraded to unsigned, which an
+  enforcing peer would reject and split the cluster (dual-primary). The
+  overflow guard is unreachable at the uint8-bounded RG count and fails
+  LOUD (`slog.Error`) rather than emitting cleartext.
 - **Anti-replay.** `session` is a random per-sender-process id and
   `counter` a monotonic per-session counter. `heartbeatAuthReplay.admit`
   accepts a strictly increasing counter within a session and RE-ANCHORS

--- a/pkg/cluster/group_state.go
+++ b/pkg/cluster/group_state.go
@@ -62,6 +62,16 @@ func (m *Manager) UpdateConfig(cfg *config.ClusterConfig) {
 		m.controlInterface = cfg.ControlInterface
 	}
 
+	// #4107: plumb the control-channel PSK. Reveal() reads the cleartext
+	// secret; it is stored as raw bytes and NEVER logged. Empty clears it
+	// (reverts to legacy dual-accept). The slice is replaced, not mutated, so
+	// the RLock read in controlLinkAuthKey() stays race-free.
+	if k := cfg.ControlLinkAuthKey.Reveal(); k != "" {
+		m.controlAuthKey = []byte(k)
+	} else {
+		m.controlAuthKey = nil
+	}
+
 	// Update peer fencing config.
 	m.peerFencing = cfg.PeerFencing
 

--- a/pkg/cluster/heartbeat.go
+++ b/pkg/cluster/heartbeat.go
@@ -152,6 +152,20 @@ func normalizeHAProtocolVersion(version uint16) uint16 {
 // metadata. If monitors would cause the packet to exceed the limit, the monitor
 // section is truncated and the version field is preserved.
 func MarshalHeartbeat(pkt *HeartbeatPacket) []byte {
+	return marshalHeartbeatBody(pkt, 0)
+}
+
+// marshalHeartbeatBody encodes the heartbeat wire body, keeping tailReserve
+// bytes free at the tail of the frame for a trailer the caller appends (the
+// #4107 auth trailer). tailReserve==0 is the plain legacy encoding, byte-for-
+// byte what MarshalHeartbeat always produced. The election-critical header +
+// RG groups are always written and the SOFTWARE version is reserved next; only
+// the best-effort monitor section is truncated to fit within
+// maxHeartbeatSize-tailReserve. Because the reserve is honored WHILE building
+// the body, a keyed frame ALWAYS has room for its HMAC — a heartbeat is never
+// silently downgraded to unsigned (the #4107 invariant; see
+// MarshalHeartbeatAuth).
+func marshalHeartbeatBody(pkt *HeartbeatPacket, tailReserve int) []byte {
 	buf := make([]byte, maxHeartbeatSize)
 	copy(buf[0:4], heartbeatMagic)
 	buf[4] = heartbeatVersion
@@ -176,7 +190,7 @@ func MarshalHeartbeat(pkt *HeartbeatPacket) []byte {
 		if len(version) > maxHeartbeatSoftwareVersionSize {
 			version = version[:maxHeartbeatSoftwareVersionSize]
 		}
-		if off+heartbeatVersionTrailerSize+len(version) <= maxHeartbeatSize {
+		if off+heartbeatVersionTrailerSize+len(version) <= maxHeartbeatSize-tailReserve {
 			versionReserve = heartbeatVersionTrailerSize + len(version)
 		} else {
 			version = nil
@@ -191,7 +205,7 @@ func MarshalHeartbeat(pkt *HeartbeatPacket) []byte {
 	for _, mon := range pkt.Monitors {
 		nameBytes := []byte(mon.Interface)
 		entrySize := 4 + len(nameBytes) // RGID + Flags + Weight + NameLen + name
-		if off+entrySize > maxHeartbeatSize-versionReserve {
+		if off+entrySize > maxHeartbeatSize-versionReserve-tailReserve {
 			break
 		}
 		buf[off] = mon.RGID
@@ -208,7 +222,7 @@ func MarshalHeartbeat(pkt *HeartbeatPacket) []byte {
 		numMon++
 	}
 	buf[monCountOff] = uint8(numMon)
-	if off+versionReserve <= maxHeartbeatSize {
+	if off+versionReserve+tailReserve <= maxHeartbeatSize {
 		buf[off] = uint8(len(version))
 		off++
 		if len(version) > 0 {
@@ -334,16 +348,28 @@ func UnmarshalHeartbeat(data []byte) (*HeartbeatPacket, error) {
 // strictly increasing counter rejects intra-session replays). When authKey is
 // empty the output is byte-identical to MarshalHeartbeat — a node without a key
 // emits legacy frames (dual-accept). The key is never logged.
+//
+// INVARIANT: once a key is configured, the returned frame is ALWAYS signed. The
+// trailer space is reserved WHILE building the body (marshalHeartbeatBody drops
+// best-effort monitor entries to make room), so a heartbeat is never silently
+// downgraded to unsigned — a silent downgrade would make an ENFORCING peer
+// reject every frame and split the cluster (dual-primary). At realistic RG +
+// monitor counts the reserve never even bites; the belt-and-suspenders guard
+// below is unreachable and fails LOUD rather than emitting cleartext.
 func MarshalHeartbeatAuth(pkt *HeartbeatPacket, authKey []byte, session, counter uint64) []byte {
-	body := MarshalHeartbeat(pkt)
 	if len(authKey) == 0 {
-		return body
+		return marshalHeartbeatBody(pkt, 0)
 	}
+	// Reserve the trailer up front so the signed frame is guaranteed to fit.
+	body := marshalHeartbeatBody(pkt, heartbeatAuthTrailerSize)
 	if len(body)+heartbeatAuthTrailerSize > maxHeartbeatSize {
-		// No room for the trailer within the UDP frame cap. Emit the legacy
-		// frame rather than a corrupt one; at real heartbeat sizes (a handful
-		// of RGs + monitors) this branch is never taken.
-		return body
+		// Unreachable: the RG group count is uint8-bounded and monitors were
+		// already truncated to leave the reserve. Guard so a future change can
+		// never SILENTLY downgrade a keyed heartbeat to unsigned (which an
+		// enforcing peer rejects → split-brain). Fail loud and still sign
+		// rather than emit an unsigned frame.
+		slog.Error("cluster: keyed heartbeat exceeds frame cap after monitor truncation; signing anyway to preserve the auth invariant",
+			"body_bytes", len(body), "cap", maxHeartbeatSize)
 	}
 	trailer := make([]byte, heartbeatAuthTrailerSize)
 	copy(trailer[0:4], heartbeatAuthMagic)

--- a/pkg/cluster/heartbeat.go
+++ b/pkg/cluster/heartbeat.go
@@ -1,6 +1,10 @@
 package cluster
 
 import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"log/slog"
@@ -50,6 +54,22 @@ const (
 
 	// DefaultHeartbeatThreshold is the default missed heartbeat count before peer is lost.
 	DefaultHeartbeatThreshold = 5
+
+	// heartbeatAuthMagic marks the optional #4107 PSK/HMAC auth trailer.
+	// Distinct from heartbeatMagic ("BPFX") so a reader can unambiguously
+	// detect a trailer at the tail of a frame. The trailer is appended AFTER
+	// the optional version trailer; UnmarshalHeartbeat ignores any bytes past
+	// the version section, so a signed frame is wire-compatible with a legacy
+	// or not-yet-keyed peer (dual-accept during a rolling upgrade).
+	heartbeatAuthMagic = "XPFA"
+
+	// heartbeatAuthMACSize is the HMAC-SHA256 digest length.
+	heartbeatAuthMACSize = 32
+
+	// heartbeatAuthTrailerSize = magic(4) + session(8) + counter(8) + HMAC(32).
+	// session+counter are the anti-replay nonce: a random per-sender-process
+	// session id plus a monotonic per-session counter.
+	heartbeatAuthTrailerSize = 4 + 8 + 8 + heartbeatAuthMACSize
 )
 
 // HeartbeatPacket is the wire format for cluster heartbeats.
@@ -289,6 +309,170 @@ func UnmarshalHeartbeat(data []byte) (*HeartbeatPacket, error) {
 	return pkt, nil
 }
 
+// --- #4107 control-channel authentication (heartbeat/election) -------------
+//
+// The cluster heartbeat drives election: handlePeerHeartbeat rebuilds peer RG
+// state directly from the packet and runs runElection(), so a forged cleartext
+// heartbeat can force the local node PRIMARY or demote the peer. When a shared
+// PSK (chassis cluster authentication-key) is configured, the sender appends an
+// HMAC-SHA256 trailer over the whole frame plus an anti-replay nonce, and the
+// receiver rejects a heartbeat that fails (or, once both nodes are keyed, lacks)
+// authentication BEFORE it can refresh peer liveness or drive election.
+//
+// Dual-accept (rolling upgrade): a node without a key emits and accepts legacy
+// frames; a keyed node accepts an unauthenticated frame until it has observed
+// the peer authenticate (proving both nodes hold the key), after which an
+// unauthenticated frame is a downgrade attack and is rejected. This mirrors the
+// #4126 VRRP-checksum dual-accept migration: accept both wire forms during the
+// upgrade window, enforce once both sides speak the new form.
+
+// MarshalHeartbeatAuth encodes a heartbeat and, when authKey is non-empty,
+// appends the PSK/HMAC auth trailer so the receiver can reject a forged or
+// tampered heartbeat. session is a per-sender-process random value and counter
+// is a per-session monotonic send counter; together they are the anti-replay
+// nonce (a new session re-anchors the receiver after a restart/reboot; a
+// strictly increasing counter rejects intra-session replays). When authKey is
+// empty the output is byte-identical to MarshalHeartbeat — a node without a key
+// emits legacy frames (dual-accept). The key is never logged.
+func MarshalHeartbeatAuth(pkt *HeartbeatPacket, authKey []byte, session, counter uint64) []byte {
+	body := MarshalHeartbeat(pkt)
+	if len(authKey) == 0 {
+		return body
+	}
+	if len(body)+heartbeatAuthTrailerSize > maxHeartbeatSize {
+		// No room for the trailer within the UDP frame cap. Emit the legacy
+		// frame rather than a corrupt one; at real heartbeat sizes (a handful
+		// of RGs + monitors) this branch is never taken.
+		return body
+	}
+	trailer := make([]byte, heartbeatAuthTrailerSize)
+	copy(trailer[0:4], heartbeatAuthMagic)
+	binary.LittleEndian.PutUint64(trailer[4:12], session)
+	binary.LittleEndian.PutUint64(trailer[12:20], counter)
+	// Sign the body PLUS magic+session+counter (everything but the digest), so
+	// the nonce and the whole packet are bound by the MAC.
+	mac := hmac.New(sha256.New, authKey)
+	mac.Write(body)
+	mac.Write(trailer[:20])
+	copy(trailer[20:], mac.Sum(nil))
+
+	out := make([]byte, 0, len(body)+heartbeatAuthTrailerSize)
+	out = append(out, body...)
+	out = append(out, trailer...)
+	return out
+}
+
+// heartbeatAuthTrailer locates the auth trailer at the tail of a raw heartbeat
+// frame and returns its nonce. present is false when the frame carries no
+// trailer (a legacy / not-yet-keyed peer).
+func heartbeatAuthTrailer(data []byte) (session, counter uint64, present bool) {
+	if len(data) < heartbeatAuthTrailerSize {
+		return 0, 0, false
+	}
+	start := len(data) - heartbeatAuthTrailerSize
+	if !bytes.Equal(data[start:start+4], []byte(heartbeatAuthMagic)) {
+		return 0, 0, false
+	}
+	session = binary.LittleEndian.Uint64(data[start+4 : start+12])
+	counter = binary.LittleEndian.Uint64(data[start+12 : start+20])
+	return session, counter, true
+}
+
+// verifyHeartbeatMAC recomputes the HMAC over the signed span (everything but
+// the trailing 32-byte digest) and compares it in constant time. It presumes a
+// trailer is present (heartbeatAuthTrailer returned present) and authKey is
+// non-empty; it returns false otherwise.
+func verifyHeartbeatMAC(data, authKey []byte) bool {
+	if len(authKey) == 0 || len(data) < heartbeatAuthTrailerSize {
+		return false
+	}
+	signed := data[:len(data)-heartbeatAuthMACSize]
+	got := data[len(data)-heartbeatAuthMACSize:]
+	mac := hmac.New(sha256.New, authKey)
+	mac.Write(signed)
+	return hmac.Equal(got, mac.Sum(nil))
+}
+
+// heartbeatAuthReplay tracks per-peer anti-replay state for authenticated
+// heartbeats. A sender advertises a random per-process session id and a
+// monotonic per-session counter (MarshalHeartbeatAuth). The receiver accepts a
+// strictly increasing counter within a session and RE-ANCHORS on a new session
+// id — a sender restart/reboot picks a fresh random session, so a genuine
+// reboot (a routine HA event) is never mistaken for a replay and failover is
+// never wedged. Touched only from the single readLoop goroutine.
+type heartbeatAuthReplay struct {
+	session uint64
+	counter uint64
+	seen    bool
+}
+
+// admit reports whether (session, counter) is fresh (not a replay) and, when
+// fresh, advances the watermark. Callers must invoke admit only after the MAC
+// has verified — an unauthenticated caller must never mutate replay state.
+func (a *heartbeatAuthReplay) admit(session, counter uint64) bool {
+	if !a.seen || session != a.session {
+		a.session = session
+		a.counter = counter
+		a.seen = true
+		return true
+	}
+	if counter > a.counter {
+		a.counter = counter
+		return true
+	}
+	return false
+}
+
+// heartbeatAuthDecision applies the #4107 dual-accept policy for one received
+// heartbeat and returns whether to accept it (and, when rejected, a short
+// reason for logging — never the key or packet bytes).
+//
+//	keyConfigured — the local ControlLinkAuthKey is set (we can verify).
+//	present       — the frame carried an auth trailer.
+//	macOK         — the trailer's HMAC verified (only meaningful when present).
+//	nonceFresh    — the nonce passed anti-replay (only meaningful when macOK).
+//	peerAuthSeen  — we have previously accepted an authenticated heartbeat from
+//	                the peer (sticky: proves the peer holds the key, so both
+//	                nodes are keyed and an unauthenticated frame is now forged).
+//
+// Policy:
+//   - No local key: dual-accept everything — this node cannot verify and may be
+//     the not-yet-upgraded / not-yet-keyed side of a rolling upgrade.
+//   - Local key + auth trailer: enforce — reject a bad HMAC or a replayed nonce.
+//   - Local key + no trailer + peer never authenticated: dual-accept — the peer
+//     has not started signing yet (rolling upgrade / key not yet synced).
+//   - Local key + no trailer + peer HAS authenticated: reject — a downgrade to
+//     cleartext once both nodes are keyed is an attack.
+func heartbeatAuthDecision(keyConfigured, present, macOK, nonceFresh, peerAuthSeen bool) (bool, string) {
+	if !keyConfigured {
+		return true, ""
+	}
+	if present {
+		if !macOK {
+			return false, "hmac verification failed"
+		}
+		if !nonceFresh {
+			return false, "stale nonce (replay)"
+		}
+		return true, ""
+	}
+	if peerAuthSeen {
+		return false, "missing auth trailer (enforced: peer previously authenticated)"
+	}
+	return true, ""
+}
+
+// randomSessionID returns a random 64-bit anti-replay session id. On the
+// (practically impossible) crypto/rand failure it falls back to the monotonic
+// clock, which is still process-unique for the receiver's re-anchor logic.
+func randomSessionID() uint64 {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return uint64(MonotonicNanos())
+	}
+	return binary.LittleEndian.Uint64(b[:])
+}
+
 // PeerGroupState holds the last-known state of a peer's redundancy group.
 type PeerGroupState struct {
 	GroupID  int
@@ -307,6 +491,12 @@ type heartbeatSender struct {
 	wg         sync.WaitGroup
 	sent       atomic.Uint64
 	sendErrors atomic.Uint64
+
+	// #4107 anti-replay: a random per-process session id plus a monotonic
+	// per-session counter. A new sender (StartHeartbeat/RestartHeartbeat)
+	// re-seeds authSession so the receiver re-anchors after a restart/reboot.
+	authSession uint64
+	authCounter atomic.Uint64
 }
 
 // heartbeatReceiver listens for peer heartbeat packets.
@@ -321,15 +511,20 @@ type heartbeatReceiver struct {
 	received   atomic.Uint64
 	recvErrors atomic.Uint64
 	startedAt  time.Time // when receiver started (for initial peer-lost detection)
+
+	// #4107 control-channel auth state. Touched only from readLoop.
+	authReplay   heartbeatAuthReplay // per-peer anti-replay watermark
+	peerAuthSeen bool                // sticky: peer has sent a valid authed HB
 }
 
 func newHeartbeatSender(mgr *Manager, conn *net.UDPConn, peerAddr *net.UDPAddr, interval time.Duration) *heartbeatSender {
 	return &heartbeatSender{
-		mgr:      mgr,
-		conn:     conn,
-		peerAddr: peerAddr,
-		interval: interval,
-		stopCh:   make(chan struct{}),
+		mgr:         mgr,
+		conn:        conn,
+		peerAddr:    peerAddr,
+		interval:    interval,
+		stopCh:      make(chan struct{}),
+		authSession: randomSessionID(),
 	}
 }
 
@@ -355,7 +550,15 @@ func (s *heartbeatSender) run() {
 
 func (s *heartbeatSender) send() {
 	pkt := s.mgr.buildHeartbeat()
-	data := MarshalHeartbeat(pkt)
+	// #4107: sign the frame when a control-channel PSK is configured. The key
+	// is fetched fresh each tick so a commit that sets/clears it takes effect
+	// without a heartbeat restart. Never logged.
+	var data []byte
+	if key := s.mgr.controlLinkAuthKey(); len(key) > 0 {
+		data = MarshalHeartbeatAuth(pkt, key, s.authSession, s.authCounter.Add(1))
+	} else {
+		data = MarshalHeartbeat(pkt)
+	}
 	if _, err := s.conn.WriteToUDP(data, s.peerAddr); err != nil {
 		s.sendErrors.Add(1)
 		slog.Debug("cluster: heartbeat send failed", "err", err)
@@ -436,6 +639,29 @@ func (r *heartbeatReceiver) readLoop() {
 		// Ignore our own heartbeats (shouldn't happen with unicast, but be safe).
 		if int(pkt.NodeID) == r.mgr.NodeID() {
 			continue
+		}
+
+		// #4107 control-channel authentication. When a PSK is configured the
+		// heartbeat/election channel is HMAC-authenticated; a forged or
+		// replayed heartbeat is rejected HERE, before it can refresh peer
+		// liveness (lastSeen) or drive election (handlePeerHeartbeat).
+		// Dual-accept keeps a mixed-version / not-yet-keyed cluster from
+		// splitting — see heartbeatAuthDecision. The key is never logged.
+		key := r.mgr.controlLinkAuthKey()
+		session, counter, present := heartbeatAuthTrailer(buf[:n])
+		macOK := present && len(key) > 0 && verifyHeartbeatMAC(buf[:n], key)
+		nonceFresh := macOK && r.authReplay.admit(session, counter)
+		accept, reason := heartbeatAuthDecision(len(key) > 0, present, macOK, nonceFresh, r.peerAuthSeen)
+		if !accept {
+			r.recvErrors.Add(1)
+			slog.Warn("cluster: heartbeat auth rejected",
+				"reason", reason, "peer_node", pkt.NodeID)
+			continue
+		}
+		if macOK {
+			// The peer proved it holds the key — from now on an
+			// unauthenticated frame from it is a downgrade attack.
+			r.peerAuthSeen = true
 		}
 
 		r.received.Add(1)

--- a/pkg/cluster/heartbeat_auth_test.go
+++ b/pkg/cluster/heartbeat_auth_test.go
@@ -1,0 +1,199 @@
+package cluster
+
+import (
+	"testing"
+)
+
+// samplePkt is a representative heartbeat with a couple of RGs and a monitor,
+// used across the auth tests.
+func samplePkt() *HeartbeatPacket {
+	return &HeartbeatPacket{
+		NodeID:            1,
+		ClusterID:         42,
+		SoftwareVersion:   "xpf-test-1",
+		HAProtocolVersion: CurrentHAProtocolVersion,
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+			{GroupID: 1, Priority: 150, Weight: 100, State: uint8(StateSecondary)},
+		},
+		Monitors: []HeartbeatMonitor{
+			{RGID: 0, Weight: 10, Up: true, Interface: "ge-0-0-1"},
+		},
+	}
+}
+
+// TestMarshalHeartbeatAuth_RoundTrip verifies a signed frame carries a
+// detectable, verifiable auth trailer while the body still parses.
+func TestMarshalHeartbeatAuth_RoundTrip(t *testing.T) {
+	key := []byte("cluster-shared-secret")
+	pkt := samplePkt()
+	data := MarshalHeartbeatAuth(pkt, key, 0xdeadbeef, 7)
+
+	// The body still decodes (RG/monitor/version) with the trailer appended.
+	got, err := UnmarshalHeartbeat(data)
+	if err != nil {
+		t.Fatalf("unmarshal authed frame: %v", err)
+	}
+	if len(got.Groups) != 2 || got.Groups[0].Priority != 200 {
+		t.Errorf("body parse wrong: %+v", got.Groups)
+	}
+	if got.SoftwareVersion != "xpf-test-1" {
+		t.Errorf("software version lost under auth trailer: %q", got.SoftwareVersion)
+	}
+
+	session, counter, present := heartbeatAuthTrailer(data)
+	if !present {
+		t.Fatal("auth trailer not detected on signed frame")
+	}
+	if session != 0xdeadbeef || counter != 7 {
+		t.Errorf("nonce = (%d,%d), want (%d,7)", session, counter, uint64(0xdeadbeef))
+	}
+	if !verifyHeartbeatMAC(data, key) {
+		t.Error("valid HMAC rejected")
+	}
+}
+
+// TestMarshalHeartbeatAuth_NoKeyIsLegacy verifies that an empty key yields a
+// byte-identical legacy frame with no trailer (dual-accept: a node without a
+// key emits legacy).
+func TestMarshalHeartbeatAuth_NoKeyIsLegacy(t *testing.T) {
+	pkt := samplePkt()
+	legacy := MarshalHeartbeat(pkt)
+	authed := MarshalHeartbeatAuth(pkt, nil, 1, 1)
+	if len(authed) != len(legacy) || string(authed) != string(legacy) {
+		t.Fatalf("empty key must produce legacy frame: authed=%d legacy=%d", len(authed), len(legacy))
+	}
+	if _, _, present := heartbeatAuthTrailer(authed); present {
+		t.Error("legacy frame must not carry an auth trailer")
+	}
+}
+
+// TestVerifyHeartbeatMAC_TamperAndWrongKey verifies the MAC rejects a modified
+// frame and a wrong key — the core anti-forgery property.
+func TestVerifyHeartbeatMAC_TamperAndWrongKey(t *testing.T) {
+	key := []byte("cluster-shared-secret")
+	data := MarshalHeartbeatAuth(samplePkt(), key, 5, 1)
+
+	if !verifyHeartbeatMAC(data, key) {
+		t.Fatal("baseline valid MAC rejected")
+	}
+
+	// Wrong key.
+	if verifyHeartbeatMAC(data, []byte("attacker-guess")) {
+		t.Error("MAC accepted under wrong key")
+	}
+
+	// Tamper a body byte (flip the priority of group 0). heartbeatHeaderSize is
+	// the start of the group section.
+	tampered := append([]byte(nil), data...)
+	tampered[heartbeatHeaderSize+1] ^= 0xFF
+	if verifyHeartbeatMAC(tampered, key) {
+		t.Error("MAC accepted a tampered body")
+	}
+
+	// Tamper the MAC itself.
+	tampered2 := append([]byte(nil), data...)
+	tampered2[len(tampered2)-1] ^= 0xFF
+	if verifyHeartbeatMAC(tampered2, key) {
+		t.Error("MAC accepted a tampered digest")
+	}
+}
+
+// TestHeartbeatAuthReplay verifies intra-session monotonic acceptance and
+// session-change re-anchor (reboot tolerance).
+func TestHeartbeatAuthReplay(t *testing.T) {
+	var r heartbeatAuthReplay
+
+	if !r.admit(100, 1) {
+		t.Fatal("first heartbeat must be admitted")
+	}
+	if !r.admit(100, 2) {
+		t.Error("strictly increasing counter must be admitted")
+	}
+	if r.admit(100, 2) {
+		t.Error("replay of the same counter must be rejected")
+	}
+	if r.admit(100, 1) {
+		t.Error("lower counter within a session must be rejected")
+	}
+	// New sender session (restart/reboot) re-anchors even with a lower counter.
+	if !r.admit(200, 1) {
+		t.Error("new session must re-anchor and be admitted (reboot tolerance)")
+	}
+	if !r.admit(200, 2) {
+		t.Error("post-reanchor increasing counter must be admitted")
+	}
+	if r.admit(200, 2) {
+		t.Error("replay after re-anchor must be rejected")
+	}
+}
+
+// TestHeartbeatAuthDecision is the RED-on-revert core: it pins the accept/reject
+// truth table of the dual-accept policy. Reverting the enforcement (e.g. always
+// returning accept, or dropping the macOK/peerAuthSeen checks) turns one of
+// these REJECT cases GREEN — i.e. a forged/unauthenticated heartbeat would
+// drive election.
+func TestHeartbeatAuthDecision(t *testing.T) {
+	cases := []struct {
+		name                                                string
+		keyConfigured, present, macOK, nonceFresh, peerSeen bool
+		wantAccept                                          bool
+	}{
+		// No local key -> dual-accept everything (cannot verify; may be the
+		// not-yet-keyed side of a rolling upgrade). No regression.
+		{"no-key/legacy", false, false, false, false, false, true},
+		{"no-key/authed-frame", false, true, false, false, false, true},
+
+		// Local key + authed frame -> enforce.
+		{"key/good-hmac-fresh", true, true, true, true, false, true},
+		{"key/bad-hmac", true, true, false, false, false, false},       // forged/tampered -> REJECT
+		{"key/good-hmac-replay", true, true, true, false, true, false}, // replayed nonce -> REJECT
+
+		// Local key + no trailer.
+		{"key/legacy-peer-not-yet-authed", true, false, false, false, false, true}, // rolling upgrade dual-accept
+		{"key/legacy-after-peer-authed", true, false, false, false, true, false},   // downgrade -> REJECT
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason := heartbeatAuthDecision(tc.keyConfigured, tc.present, tc.macOK, tc.nonceFresh, tc.peerSeen)
+			if got != tc.wantAccept {
+				t.Fatalf("accept = %v (reason %q), want %v", got, reason, tc.wantAccept)
+			}
+			if !got && reason == "" {
+				t.Error("a rejection must carry a non-empty reason")
+			}
+		})
+	}
+}
+
+// TestHeartbeatAuthDecision_ForgedFrameRejected is the end-to-end anti-forgery
+// assertion tying the wire path to the decision: a frame signed with the WRONG
+// key (an attacker who does not hold the PSK) is rejected when a key is
+// configured and the peer has authenticated. RED on revert: if the receiver
+// stops enforcing, macOK would be ignored and this forged frame would be
+// accepted -> forced election.
+func TestHeartbeatAuthDecision_ForgedFrameRejected(t *testing.T) {
+	realKey := []byte("real-cluster-psk")
+	forged := MarshalHeartbeatAuth(samplePkt(), []byte("attacker-psk"), 9, 1)
+
+	_, _, present := heartbeatAuthTrailer(forged)
+	macOK := present && verifyHeartbeatMAC(forged, realKey)
+	if macOK {
+		t.Fatal("forged frame verified under the real key — HMAC broken")
+	}
+	// peerAuthSeen=true (both nodes keyed, peer previously authed).
+	accept, reason := heartbeatAuthDecision(true, present, macOK, false, true)
+	if accept {
+		t.Fatalf("forged heartbeat accepted (reason %q) — forged frame drives election", reason)
+	}
+
+	// A correctly-signed frame from the genuine peer is accepted.
+	good := MarshalHeartbeatAuth(samplePkt(), realKey, 9, 2)
+	var replay heartbeatAuthReplay
+	s, c, gp := heartbeatAuthTrailer(good)
+	goodMAC := gp && verifyHeartbeatMAC(good, realKey)
+	fresh := goodMAC && replay.admit(s, c)
+	if accept2, _ := heartbeatAuthDecision(true, gp, goodMAC, fresh, true); !accept2 {
+		t.Error("correctly-signed heartbeat rejected")
+	}
+}

--- a/pkg/cluster/heartbeat_auth_test.go
+++ b/pkg/cluster/heartbeat_auth_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -65,6 +66,62 @@ func TestMarshalHeartbeatAuth_NoKeyIsLegacy(t *testing.T) {
 	}
 	if _, _, present := heartbeatAuthTrailer(authed); present {
 		t.Error("legacy frame must not carry an auth trailer")
+	}
+}
+
+// TestMarshalHeartbeatAuth_NeverUnsignedWhenKeyed is the #4107 invariant: a
+// config large enough to overflow the frame (many interface monitors) STILL
+// yields a SIGNED frame when a key is configured — the best-effort monitor
+// section is truncated to make room, but the HMAC is always present and
+// verifies, and the election-critical RG groups survive. RED on revert:
+// dropping the trailer reserve (marshalHeartbeatBody tailReserve) lets the body
+// fill to the cap so MarshalHeartbeatAuth would emit an UNSIGNED frame
+// (present==false) that an enforcing peer rejects -> dual-primary split.
+func TestMarshalHeartbeatAuth_NeverUnsignedWhenKeyed(t *testing.T) {
+	key := []byte("cluster-shared-secret")
+	pkt := &HeartbeatPacket{
+		NodeID:            1,
+		ClusterID:         42,
+		SoftwareVersion:   "xpf-overflow-version-string",
+		HAProtocolVersion: CurrentHAProtocolVersion,
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+			{GroupID: 1, Priority: 150, Weight: 100, State: uint8(StateSecondary)},
+		},
+	}
+	// Enough monitors with long names to blow well past the 1472-byte cap so
+	// the monitor section MUST be truncated to fit the trailer.
+	for i := 0; i < 300; i++ {
+		pkt.Monitors = append(pkt.Monitors, HeartbeatMonitor{
+			RGID:      uint8(i % 2),
+			Weight:    10,
+			Up:        true,
+			Interface: fmt.Sprintf("monitor-interface-name-%04d", i),
+		})
+	}
+
+	data := MarshalHeartbeatAuth(pkt, key, 0xabc, 1)
+
+	if len(data) > maxHeartbeatSize {
+		t.Fatalf("signed frame exceeds cap: %d > %d", len(data), maxHeartbeatSize)
+	}
+	if _, _, present := heartbeatAuthTrailer(data); !present {
+		t.Fatal("keyed heartbeat emitted UNSIGNED under frame overflow — an enforcing peer would reject every frame (dual-primary)")
+	}
+	if !verifyHeartbeatMAC(data, key) {
+		t.Error("overflow-truncated signed frame failed HMAC verification")
+	}
+	got, err := UnmarshalHeartbeat(data)
+	if err != nil {
+		t.Fatalf("unmarshal truncated signed frame: %v", err)
+	}
+	if len(got.Groups) != 2 {
+		t.Errorf("election-critical groups dropped under truncation: got %d, want 2", len(got.Groups))
+	}
+	// Monitors WERE truncated — that is how room for the HMAC was made.
+	if len(got.Monitors) >= len(pkt.Monitors) {
+		t.Errorf("expected monitor truncation to make room for the trailer, got %d of %d",
+			len(got.Monitors), len(pkt.Monitors))
 	}
 }
 

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -160,11 +160,17 @@ type Manager struct {
 
 	// Heartbeat config.
 	controlInterface string
-	hbInterval       time.Duration
-	hbThreshold      int
-	hbLocalAddr      string // last StartHeartbeat localAddr (for restart)
-	hbPeerAddr       string // last StartHeartbeat peerAddr (for restart)
-	hbVRFDevice      string // last StartHeartbeat vrfDevice (for restart)
+	// controlAuthKey is the #4107 shared PSK authenticating cluster
+	// control-channel messages (chassis cluster authentication-key). Empty =
+	// no auth (legacy dual-accept). Raw key bytes; NEVER logged. Replaced (not
+	// mutated in place) under m.mu on config apply; read via
+	// controlLinkAuthKey().
+	controlAuthKey []byte
+	hbInterval     time.Duration
+	hbThreshold    int
+	hbLocalAddr    string // last StartHeartbeat localAddr (for restart)
+	hbPeerAddr     string // last StartHeartbeat peerAddr (for restart)
+	hbVRFDevice    string // last StartHeartbeat vrfDevice (for restart)
 
 	// Sync stats provider (set by daemon after sessionSync creation).
 	syncStats SyncStatsProvider
@@ -299,6 +305,16 @@ func (m *Manager) NodeID() int { return m.nodeID }
 
 // ClusterID returns the cluster ID.
 func (m *Manager) ClusterID() int { return m.clusterID }
+
+// controlLinkAuthKey returns the configured cluster control-channel PSK (raw
+// bytes), or nil when no key is configured. The value is a secret and must
+// never be logged. The slice is only ever replaced (never mutated in place),
+// so returning the header under RLock is race-free for the read-only HMAC use.
+func (m *Manager) controlLinkAuthKey() []byte {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.controlAuthKey
+}
 
 // Events returns the event channel for state change notifications.
 func (m *Manager) Events() <-chan ClusterEvent { return m.eventCh }

--- a/pkg/config/compiler_cluster_authkey_4107_test.go
+++ b/pkg/config/compiler_cluster_authkey_4107_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4107 PR-A: the chassis cluster control-channel PSK (authentication-key)
+// compiles into a Secret and is redacted on every render path.
+
+func TestClusterAuthKeyCompilesToSecret(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster node 0",
+		"set chassis cluster authentication-key SUPER-SECRET-PSK-4107",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if cfg.Chassis.Cluster == nil {
+		t.Fatal("chassis cluster not compiled")
+	}
+	if got := cfg.Chassis.Cluster.ControlLinkAuthKey.Reveal(); got != "SUPER-SECRET-PSK-4107" {
+		t.Fatalf("ControlLinkAuthKey = %q, want cleartext PSK via Reveal()", got)
+	}
+	// The Secret String() must redact, so %v/%s/slog never leak it.
+	if s := cfg.Chassis.Cluster.ControlLinkAuthKey.String(); strings.Contains(s, "SUPER-SECRET-PSK-4107") {
+		t.Fatalf("Secret.String() leaked the PSK: %q", s)
+	}
+}
+
+func TestClusterAuthKeyAbsentIsEmpty(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster node 0",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if got := cfg.Chassis.Cluster.ControlLinkAuthKey.Reveal(); got != "" {
+		t.Fatalf("absent authentication-key must compile empty, got %q", got)
+	}
+}
+
+// TestClusterAuthKeyRedactedInASTRender proves the value token is masked as
+// ##SECRET-DATA## in the raw-AST display paths (the leaf keyword is
+// authentication-key, already in secretIndices). RED on revert if the
+// authentication-key redaction ever regresses for the cluster path.
+func TestClusterAuthKeyRedactedInASTRender(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set chassis cluster authentication-key LEAK-CLUSTER-PSK-4107",
+	})
+	red := tree.RedactedClone()
+	renders := map[string]string{
+		"Format":    red.Format(),
+		"FormatSet": red.FormatSet(),
+		"FormatXML": red.FormatXML(),
+	}
+	for name, out := range renders {
+		if strings.Contains(out, "LEAK-CLUSTER-PSK-4107") {
+			t.Errorf("%s leaked the cluster PSK cleartext:\n%s", name, out)
+		}
+		if !strings.Contains(out, SecretDataPlaceholder) {
+			t.Errorf("%s did not mask the cluster PSK with %s:\n%s", name, SecretDataPlaceholder, out)
+		}
+	}
+	// The live tree must still carry cleartext (config-sync / persistence SSOT).
+	if !strings.Contains(tree.FormatSet(), "LEAK-CLUSTER-PSK-4107") {
+		t.Error("RedactedClone mutated the source tree — config-sync would lose the PSK")
+	}
+}

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -1594,6 +1594,15 @@ func compileChassis(node *Node, ch *ChassisConfig) error {
 	if clusterNode.FindChild("control-link-recovery") != nil {
 		ch.Cluster.ControlLinkRecovery = true
 	}
+	// #4107: compile the cluster control-channel PSK into a Secret so it is
+	// redacted on every render/log path (mirrors the IKE/interface/routing
+	// Secret compile sites). nodeVal reads the raw leaf value; it is never
+	// logged here.
+	if n := clusterNode.FindChild("authentication-key"); n != nil {
+		if v := nodeVal(n); v != "" {
+			ch.Cluster.ControlLinkAuthKey = Secret(v)
+		}
+	}
 	if n := clusterNode.FindChild("control-interface"); n != nil {
 		if v := nodeVal(n); v != "" {
 			ch.Cluster.ControlInterface = v

--- a/pkg/config/schema_chassis.go
+++ b/pkg/config/schema_chassis.go
@@ -97,6 +97,18 @@ var schemaChassis = &schemaNode{desc: "Chassis configuration", children: map[str
 			children:      nil,
 		},
 		"control-link-recovery": {desc: "Control link recovery (accepted for Junos compatibility; no runtime effect)", children: nil},
+		// #4107: shared PSK authenticating the cluster control channel.
+		// When set on BOTH nodes, cluster heartbeat/election messages are
+		// signed with HMAC-SHA256 and a forged/unauthenticated heartbeat
+		// is rejected (dual-accept during a rolling upgrade so a
+		// mixed-version cluster does not split). The SAME key on both
+		// nodes — ${node}-agnostic, synced by config-sync. Secret-typed
+		// (compiler_system.go) so it is redacted in every show/log/JSON
+		// path; the value token is masked as ##SECRET-DATA## in raw-AST
+		// renders because the leaf keyword is `authentication-key`
+		// (ast_redact.go). Untyped value slot, mirroring the OSPF/IS-IS/
+		// RIP/interface authentication-key leaves.
+		"authentication-key": {desc: "Shared PSK authenticating cluster control messages (HMAC-SHA256; same key on both nodes)", args: 1, placeholder: "<key>", children: nil},
 		// control-ports fpc/port: NOT typed — compileChassis never
 		// reads control-ports (compiled-leaf-only invariant).
 		"control-ports": {desc: "Control port assignments (accepted for Junos compatibility; ignored)", children: map[string]*schemaNode{

--- a/pkg/config/types_chassis.go
+++ b/pkg/config/types_chassis.go
@@ -100,18 +100,27 @@ type ClusterConfig struct {
 	// cluster stanza but no explicit `node` leaf must NOT be treated as
 	// "node 0" when reconciling against the /etc/xpf/node-id file, or an
 	// absent leaf on a node-1 box would false-reject as a mismatch.
-	NodeIDSet             bool
-	RethCount             int
-	HeartbeatInterval     int    // milliseconds, 0=default(1000)
-	HeartbeatThreshold    int    // missed heartbeats before lost, 0=default(3)
-	ControlInterface      string // interface for heartbeat traffic (e.g. "hb0")
-	PeerAddress           string // peer node's control link IP (e.g. "10.99.0.2")
-	FabricInterface       string // interface for session/config sync (e.g. "fab0")
-	FabricPeerAddress     string // peer's fabric link IP (e.g. "10.99.1.2")
-	Fabric1Interface      string // secondary fabric interface (e.g. "fab1")
-	Fabric1PeerAddress    string // peer's secondary fabric IP
-	ConfigSync            bool   // enable config synchronization to peer on commit
-	ControlLinkRecovery   bool   // enable control-link-recovery
+	NodeIDSet           bool
+	RethCount           int
+	HeartbeatInterval   int    // milliseconds, 0=default(1000)
+	HeartbeatThreshold  int    // missed heartbeats before lost, 0=default(3)
+	ControlInterface    string // interface for heartbeat traffic (e.g. "hb0")
+	PeerAddress         string // peer node's control link IP (e.g. "10.99.0.2")
+	FabricInterface     string // interface for session/config sync (e.g. "fab0")
+	FabricPeerAddress   string // peer's fabric link IP (e.g. "10.99.1.2")
+	Fabric1Interface    string // secondary fabric interface (e.g. "fab1")
+	Fabric1PeerAddress  string // peer's secondary fabric IP
+	ConfigSync          bool   // enable config synchronization to peer on commit
+	ControlLinkRecovery bool   // enable control-link-recovery
+	// ControlLinkAuthKey is the #4107 shared PSK that authenticates cluster
+	// control-channel messages. When set, the heartbeat/election channel is
+	// signed with HMAC-SHA256; a forged or unauthenticated heartbeat is
+	// rejected once BOTH nodes carry the key (dual-accept during a rolling
+	// upgrade so a mixed-version cluster does not split-brain). ${node}-
+	// agnostic: the SAME key on both nodes, synced by config-sync. Secret-
+	// typed so it is redacted on every show/log/JSON/YAML path and never
+	// echoed into an error string.
+	ControlLinkAuthKey    Secret
 	NATStateSync          bool   // enable NAT state synchronization (session sync with NAT fields)
 	IPsecSASync           bool   // enable IPsec SA synchronization (connection name sync for failover re-initiation)
 	DHCPLeaseSync         bool   // enable DHCP-server lease synchronization (#2239 PATH C: lease state held on standby, seeded into Kea on takeover)


### PR DESCRIPTION
## Refs #4107 — PR-A: config foundation + first authenticated cluster control channel

The converged PSK/HMAC plan (F1-stronger + F23) for the cluster control
plane. This PR lands the **shared config foundation** and the **first
authenticated channel** — the heartbeat/election path, the most acute
F23 vector. Session-sync frames and the fabric gRPC listener remain
follow-up channels that reuse the same key; **#4107 stays open** for
them.

### The bug
`handlePeerHeartbeat` rebuilds peer redundancy-group state directly from
the packet and calls `runElection()`, and the heartbeat is
unauthenticated UDP on the shared control VLAN. A forged cleartext
heartbeat drives election — `Weight=0` makes the local node claim
PRIMARY; a higher priority forces it SECONDARY. Any host that can reach
the peer's control IP can inject one.

### Config foundation
- `set chassis cluster authentication-key <key>` — new schema leaf,
  mirroring the existing untyped OSPF/IS-IS/RIP/interface
  `authentication-key` leaves.
- `ClusterConfig.ControlLinkAuthKey` is `config.Secret` → redacted on
  JSON/YAML/`String()` and never echoed into an error/log. Raw-AST
  renders mask it as `##SECRET-DATA##` for free (`authentication-key` is
  already in `ast_redact.go`'s secret set).
- `${node}`-agnostic: the SAME key on both nodes, synced by the existing
  config-sync (the AST leaf rides the tree).

### Authenticated heartbeat channel
- **Wire** (`MarshalHeartbeatAuth`): a fixed 52-byte trailer appended
  AFTER the version trailer — `magic "XPFA"(4) + session(8) +
  counter(8) + HMAC-SHA256(32)` over the whole frame plus the nonce.
  `UnmarshalHeartbeat` already ignores bytes past the version section,
  so a signed frame is parseable by a legacy / not-yet-keyed peer
  (additive-trailer discipline, like the version trailer).
- **Anti-replay** (`heartbeatAuthReplay`): random per-process `session`
  + monotonic `counter`. Strictly increasing within a session; RE-ANCHOR
  on a new session id, so a reboot/restart (what `test-failover`
  exercises) is never a false replay. Cross-session stale replay is a
  bounded residual (overwritten by the next genuine heartbeat) left to
  the follow-up channels.
- **Dual-accept** (`heartbeatAuthDecision`), mirroring the #4126
  VRRP-checksum migration so a mixed-version / mid-rollout cluster never
  splits:

  | local key | frame | peer authed before | result |
  |---|---|---|---|
  | no | any | — | accept (cannot verify) |
  | yes | authed, good HMAC + fresh nonce | — | accept |
  | yes | authed, bad HMAC / replayed | — | **reject** |
  | yes | no trailer | no | accept (rolling upgrade) |
  | yes | no trailer | yes (sticky) | **reject** (downgrade) |

  Enforcement engages only once BOTH nodes are keyed and observed
  signing. `peerAuthSeen` is set only by a verified frame.
- The key is plumbed via `Manager.UpdateConfig` → `controlLinkAuthKey()`,
  stored as raw bytes, never logged, fetched fresh each send/recv so a
  commit that sets/clears it takes effect without a heartbeat restart.
  The auth-reject log carries only a reason string + peer node id.

### Failover safety
The dual-accept and the session-id re-anchor are designed so a
mixed-version failover and a node reboot are never wedged: a peer that is
not yet keyed (or a rebooted peer with a reset counter) is accepted, and
enforcement only kicks in once both sides sign. No `~60ms` failover-path
change. The parent runs `make test-failover` before merge.

### Validation
- New unit tests pin the accept/reject truth table, HMAC tamper/wrong-key
  rejection, round-trip, legacy-frame-when-no-key, and anti-replay
  (intra-session reject + session-change re-anchor).
- **RED-on-revert proven**: neutering `heartbeatAuthDecision` to
  always-accept turns the bad-hmac, replayed-nonce, downgrade, and
  end-to-end forged-frame assertions RED.
- `go test ./pkg/config/... ./pkg/cluster/...` green (incl. `-race`);
  `go build ./...`, `gofmt`, `go vet` clean.

### Follow-up (keeps #4107 open)
- Session-sync frames (`sync_conn.go`) — HMAC the `writeMsg`/`readMsg`
  frames with the same `ControlLinkAuthKey`.
- Fabric gRPC listener (`pkg/grpcapi`) — PSK-derived bearer/interceptor;
  converges with F-155/#4047 into one management-plane auth posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
