### PR TITLE
config: warn on overlapping L3 across routing-instances (#2387 A.1)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -36085,3 +36085,31 @@ top.
   gofmt, vet, and `go build ./...` all clean.
 - **File(s)**: pkg/config/ast_groups.go,
   pkg/config/apply_groups_leaflist_test.go
+
+- **Timestamp**: 2026-07-06
+- **Action**: #2387 Track A.1 + A.3 (PR-A) — add a commit-time WARNING when two
+  DISTINCT routing-instances carry overlapping L3 address space, and document
+  the not-session-isolated limitation. The userspace-dp session/flow identity is
+  the bare 5-tuple (userspace-dp/src/session/key.rs) with no VRF discriminator,
+  so overlapping-address flows in different routing-instances collide in the
+  conntrack map — LIVE under PBR `then routing-instance` (the established-session
+  fast path runs before the PBR table override, so a second colliding flow
+  inherits the first's cached egress / NAT / policy). New validator
+  validateVRFOverlap mirrors validateScreenScanSweepThresholds: deterministic
+  []string, sorted RI names / filter names / prefixes. Builds RI -> prefix set
+  from BOTH native RI membership (ri.Interfaces -> unit Addresses) AND PBR
+  `then routing-instance` filter terms (source/dest match prefixes), then
+  compares every distinct RI pair for net/netip Prefix.Overlaps. WARNING, never a
+  reject — overlapping-subnet multi-tenant PBR VRF is a legitimate working
+  design. Wired into the compiler.go warnings aggregation next to
+  validateScreenScanSweepThresholds. A.3: forwarding/README.md records the
+  single-forwarding-domain / not-session-isolated limitation + the #3096
+  NAT-scope-vs-session-cache coherence contract. The VRF-aware session key
+  (Track B — SessionKey widening + FlowCacheLookup + reverse-key transforms + HA
+  wire bump) is the deferred real fix; #2387 stays open for it. RED-on-revert
+  proven (removing the validateVRFOverlap call -> 0 warnings -> positive tests
+  FAIL; restored -> GREEN). Full pkg/config suite, gofmt, vet, go build ./... all
+  clean.
+- **File(s)**: pkg/config/compiler_validate_vrf_overlap.go,
+  pkg/config/compiler_validate_vrf_overlap_2387_test.go, pkg/config/compiler.go,
+  userspace-dp/src/afxdp/forwarding/README.md, _Log.md

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -4132,6 +4132,19 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	// using these leaves commits and the operator is told what is/ isn't honoured.
 	cfg.Warnings = append(cfg.Warnings, validateScreenSynFloodSubThresholds(cfg)...)
 
+	// #2387 (Track A.1): warn when two DISTINCT routing-instances carry
+	// overlapping L3 address space. The userspace-dp session/flow identity is the
+	// bare 5-tuple with no VRF discriminator, so overlapping-address flows in
+	// different routing-instances collide in the conntrack map — LIVE under PBR
+	// `then routing-instance` (the established-session fast path runs before the
+	// PBR table override, so a second colliding flow inherits the first's cached
+	// egress / NAT / policy). A WARNING, never a reject: overlapping-subnet
+	// multi-tenant VRF via PBR is a legitimate working design; the config still
+	// commits, the operator is told it is not session-isolated. The VRF-aware
+	// session key is the deferred real fix (Track B — SessionKey widening + HA
+	// wire bump).
+	cfg.Warnings = append(cfg.Warnings, validateVRFOverlap(cfg)...)
+
 	// #2173: static-NAT / NAT64 host-mask gate. #2132 made the Rust
 	// dataplane tolerate the canonical /32-/128 host mask and PR #2167 then
 	// hardened it to REJECT a non-host mask — so a misconfigured non-host

--- a/pkg/config/compiler_validate_vrf_overlap.go
+++ b/pkg/config/compiler_validate_vrf_overlap.go
@@ -1,0 +1,194 @@
+package config
+
+import (
+	"fmt"
+	"net/netip"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// vrfOverlapPrefix records one L3 prefix carried by a routing-instance together
+// with a human-readable origin (the interface or the PBR filter/term that put
+// it there) so the overlap warning can name where each side comes from.
+type vrfOverlapPrefix struct {
+	prefix netip.Prefix // masked network prefix
+	origin string       // e.g. `interface "ge-0/0/1.0"` or `filter "fbf" term "t1"`
+}
+
+// validateVRFOverlap emits a commit WARNING (never a hard reject) when two
+// DISTINCT routing-instances carry overlapping L3 address space. This is the
+// #2387 interim mitigation (Track A.1): the userspace-dp session/flow identity
+// is the bare 5-tuple (userspace-dp/src/session/key.rs) with no
+// routing-instance/VRF discriminator, so two flows in different
+// routing-instances that share a 5-tuple collide in the conntrack map. The
+// collision is LIVE under PBR `then routing-instance` (the established-session
+// fast path runs before the PBR table override, so a second flow with the same
+// 5-tuple inherits the first flow's cached egress / NAT / policy decision —
+// wrong-VRF forwarding). See docs/research/2387-vrf-flow-identity/plan.md and
+// userspace-dp/src/afxdp/forwarding/README.md.
+//
+// A WARNING, not a reject: overlapping-subnet multi-tenant VRF via PBR is a
+// legitimate, working forwarding design, so hard-rejecting it would break a
+// valid deployment to work around a fast-path bug. The operator is told the
+// topology is not session-isolated; the config still commits. The hard-reject
+// variant (for a "no overlapping subnets at all" product posture) is a future
+// maintainer-gated follow-up, not this pass. The VRF-aware session key itself
+// (a symmetric routing-domain id in SessionKey + the HA wire bump) is the
+// deferred real fix (Track B).
+//
+// Detection builds routing-instance -> set-of-prefixes from two sources:
+//  1. native RI membership — each member interface unit's configured addresses
+//     (the connected L3 space that lives in that VRF), joined via
+//     ri.Interfaces -> cfg.Interfaces.Interfaces[base].Units[unit].Addresses;
+//  2. PBR filter terms — a `then routing-instance <name>` term's source/dest
+//     match prefixes (the L3 space steered INTO that VRF, the reachable-via-PBR
+//     trigger).
+//
+// then compares the prefix sets of every unordered pair of distinct
+// routing-instances for overlap (net/netip Prefix.Overlaps — contains-or-equal).
+// Deterministic ordering (sorted RI names, sorted filter names, sorted
+// prefixes) so the warning set is stable across commits.
+func validateVRFOverlap(cfg *Config) []string {
+	if cfg == nil {
+		return nil
+	}
+
+	// riPrefixes[riName] = de-duplicated, origin-tagged prefix set.
+	riPrefixes := map[string][]vrfOverlapPrefix{}
+	// seen[riName][maskedPrefixString] dedupes a prefix that appears from more
+	// than one origin (e.g. a native interface AND a PBR term). The first origin
+	// encountered wins; native interfaces are processed before PBR terms and both
+	// in deterministic order, so the retained origin is stable.
+	seen := map[string]map[string]bool{}
+	addPrefix := func(riName, cidr, origin string) {
+		if riName == "" || cidr == "" {
+			return
+		}
+		p, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			return
+		}
+		p = p.Masked()
+		key := p.String()
+		if seen[riName] == nil {
+			seen[riName] = map[string]bool{}
+		}
+		if seen[riName][key] {
+			return
+		}
+		seen[riName][key] = true
+		riPrefixes[riName] = append(riPrefixes[riName], vrfOverlapPrefix{prefix: p, origin: origin})
+	}
+
+	// Source 1: native routing-instance membership -> member interface unit
+	// addresses. cfg.RoutingInstances is a slice (deterministic order); each
+	// ri.Interfaces entry is a Junos interface name, optionally `.unit`.
+	for _, ri := range cfg.RoutingInstances {
+		if ri == nil || ri.Name == "" {
+			continue
+		}
+		for _, member := range ri.Interfaces {
+			base, unitTok, hasUnit := strings.Cut(member, ".")
+			unitNum := 0
+			if hasUnit {
+				n, err := strconv.Atoi(unitTok)
+				if err != nil {
+					continue
+				}
+				unitNum = n
+			}
+			ifc := cfg.Interfaces.Interfaces[base]
+			if ifc == nil {
+				continue
+			}
+			unit := ifc.Units[unitNum]
+			if unit == nil {
+				continue
+			}
+			origin := fmt.Sprintf("interface %q", member)
+			for _, addr := range unit.Addresses {
+				addPrefix(ri.Name, addr, origin)
+			}
+		}
+	}
+
+	// Source 2: PBR `then routing-instance <name>` filter terms. A family-agnostic
+	// filter is duplicated into both FiltersInet and FiltersInet6; process both
+	// maps in sorted-name order and let the per-RI prefix de-dup collapse the
+	// repeat.
+	addFilterTerms := func(filterName string, filter *FirewallFilter) {
+		if filter == nil {
+			return
+		}
+		for _, term := range filter.Terms {
+			if term == nil || term.RoutingInstance == "" {
+				continue
+			}
+			origin := fmt.Sprintf("filter %q term %q", filterName, term.Name)
+			for _, addr := range term.SourceAddresses {
+				addPrefix(term.RoutingInstance, addr, origin)
+			}
+			for _, addr := range term.DestAddresses {
+				addPrefix(term.RoutingInstance, addr, origin)
+			}
+		}
+	}
+	for _, filters := range []map[string]*FirewallFilter{cfg.Firewall.FiltersInet, cfg.Firewall.FiltersInet6} {
+		names := make([]string, 0, len(filters))
+		for name := range filters {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			addFilterTerms(name, filters[name])
+		}
+	}
+
+	// Compare every unordered pair of distinct routing-instances. Sort RI names
+	// and each RI's prefixes so the pairwise scan is deterministic.
+	riNames := make([]string, 0, len(riPrefixes))
+	for name := range riPrefixes {
+		riNames = append(riNames, name)
+	}
+	sort.Strings(riNames)
+	for _, name := range riNames {
+		set := riPrefixes[name]
+		sort.Slice(set, func(i, j int) bool {
+			return set[i].prefix.String() < set[j].prefix.String()
+		})
+		riPrefixes[name] = set
+	}
+
+	var warnings []string
+	for i := 0; i < len(riNames); i++ {
+		for j := i + 1; j < len(riNames); j++ {
+			riA, riB := riNames[i], riNames[j]
+			for _, a := range riPrefixes[riA] {
+				for _, b := range riPrefixes[riB] {
+					if !a.prefix.Overlaps(b.prefix) {
+						continue
+					}
+					if a.prefix == b.prefix {
+						warnings = append(warnings, fmt.Sprintf(
+							"routing-instance %q (%s) and %q (%s) both carry %s: "+
+								"overlapping L3 across routing-instances is forwarded via "+
+								"PBR but is NOT session-isolated (#2387) — colliding "+
+								"5-tuples may cross-forward until the session identity is "+
+								"VRF-aware",
+							riA, a.origin, riB, b.origin, a.prefix))
+					} else {
+						warnings = append(warnings, fmt.Sprintf(
+							"routing-instance %q (%s, %s) and %q (%s, %s) carry "+
+								"overlapping L3: overlapping L3 across routing-instances is "+
+								"forwarded via PBR but is NOT session-isolated (#2387) — "+
+								"colliding 5-tuples may cross-forward until the session "+
+								"identity is VRF-aware",
+							riA, a.origin, a.prefix, riB, b.origin, b.prefix))
+					}
+				}
+			}
+		}
+	}
+	return warnings
+}

--- a/pkg/config/compiler_validate_vrf_overlap_2387_test.go
+++ b/pkg/config/compiler_validate_vrf_overlap_2387_test.go
@@ -1,0 +1,136 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2387 (Track A.1): the userspace-dp session/flow identity is the bare 5-tuple
+// with no routing-instance/VRF discriminator (userspace-dp/src/session/key.rs),
+// so two flows in different routing-instances that share a 5-tuple collide in
+// the conntrack map. The collision is LIVE under PBR `then routing-instance`.
+// validateVRFOverlap emits a commit WARNING (never a reject) when two DISTINCT
+// routing-instances carry overlapping L3 address space.
+//
+// These tests pin: (1) two RIs with overlapping addresses on their member
+// interface units WARN, naming both RIs + the prefix; (2) non-overlapping RIs
+// do NOT warn (no false positive); (3) a single RI / no RI does NOT warn;
+// (4) the PBR-term source (`then routing-instance`) also feeds the overlap set.
+//
+// fail-on-revert: removing the validateVRFOverlap call (or its detection body)
+// drops the warning, so TestVRFOverlapWarnsOnOverlappingRIs goes RED.
+
+// vrf2387Warnings returns the compile warnings that mention #2387.
+func vrf2387Warnings(t *testing.T, cmds []string) []string {
+	t.Helper()
+	tree := buildTree(t, cmds)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	var out []string
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#2387") {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+func TestVRFOverlapWarnsOnOverlappingRIs(t *testing.T) {
+	warns := vrf2387Warnings(t, []string{
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/2 unit 0 family inet address 10.0.0.2/24",
+		"set routing-instances RI-A instance-type virtual-router",
+		"set routing-instances RI-A interface ge-0/0/1.0",
+		"set routing-instances RI-B instance-type virtual-router",
+		"set routing-instances RI-B interface ge-0/0/2.0",
+	})
+	if len(warns) != 1 {
+		t.Fatalf("expected exactly one #2387 overlap warning, got %d: %v", len(warns), warns)
+	}
+	w := warns[0]
+	for _, want := range []string{`"RI-A"`, `"RI-B"`, "10.0.0.0/24", "NOT session-isolated"} {
+		if !strings.Contains(w, want) {
+			t.Errorf("warning missing %q: %s", want, w)
+		}
+	}
+}
+
+func TestVRFOverlapNoWarnNonOverlapping(t *testing.T) {
+	// Distinct address space per VRF — the common multi-VRF deployment. No warn.
+	warns := vrf2387Warnings(t, []string{
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/2 unit 0 family inet address 10.0.1.1/24",
+		"set routing-instances RI-A instance-type virtual-router",
+		"set routing-instances RI-A interface ge-0/0/1.0",
+		"set routing-instances RI-B instance-type virtual-router",
+		"set routing-instances RI-B interface ge-0/0/2.0",
+	})
+	if len(warns) != 0 {
+		t.Fatalf("non-overlapping RIs should not warn, got: %v", warns)
+	}
+}
+
+func TestVRFOverlapNoWarnSingleRI(t *testing.T) {
+	// A single RI cannot overlap another RI. No warn even with two interfaces
+	// carrying the same subnet inside the SAME instance.
+	warns := vrf2387Warnings(t, []string{
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/2 unit 0 family inet address 10.0.0.2/24",
+		"set routing-instances RI-A instance-type virtual-router",
+		"set routing-instances RI-A interface ge-0/0/1.0",
+		"set routing-instances RI-A interface ge-0/0/2.0",
+	})
+	if len(warns) != 0 {
+		t.Fatalf("single RI should not warn, got: %v", warns)
+	}
+}
+
+func TestVRFOverlapNoWarnNoRI(t *testing.T) {
+	// No routing-instances at all — plain master-table config. No warn.
+	warns := vrf2387Warnings(t, []string{
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/2 unit 0 family inet address 10.0.0.2/24",
+	})
+	if len(warns) != 0 {
+		t.Fatalf("no-RI config should not warn, got: %v", warns)
+	}
+}
+
+func TestVRFOverlapWarnsViaPBRTerms(t *testing.T) {
+	// The same destination prefix steered into two different routing-instances
+	// by two PBR `then routing-instance` terms is the exact reachable-via-PBR
+	// trigger — overlap detected from the filter-term source.
+	warns := vrf2387Warnings(t, []string{
+		"set routing-instances RI-A instance-type virtual-router",
+		"set routing-instances RI-B instance-type virtual-router",
+		"set firewall family inet filter fbf term to-a from destination-address 172.16.9.0/24",
+		"set firewall family inet filter fbf term to-a then routing-instance RI-A",
+		"set firewall family inet filter fbf term to-b from destination-address 172.16.9.0/24",
+		"set firewall family inet filter fbf term to-b then routing-instance RI-B",
+	})
+	if len(warns) != 1 {
+		t.Fatalf("expected one #2387 overlap warning from PBR terms, got %d: %v", len(warns), warns)
+	}
+	for _, want := range []string{`"RI-A"`, `"RI-B"`, "172.16.9.0/24"} {
+		if !strings.Contains(warns[0], want) {
+			t.Errorf("PBR warning missing %q: %s", want, warns[0])
+		}
+	}
+}
+
+func TestVRFOverlapV6NoCrossFamilyFalsePositive(t *testing.T) {
+	// A v4 subnet in one RI and a v6 subnet in another never overlap. No warn.
+	warns := vrf2387Warnings(t, []string{
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/2 unit 0 family inet6 address 2001:db8::1/64",
+		"set routing-instances RI-A instance-type virtual-router",
+		"set routing-instances RI-A interface ge-0/0/1.0",
+		"set routing-instances RI-B instance-type virtual-router",
+		"set routing-instances RI-B interface ge-0/0/2.0",
+	})
+	if len(warns) != 0 {
+		t.Fatalf("cross-family (v4 vs v6) must not warn, got: %v", warns)
+	}
+}

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -183,6 +183,56 @@ next-hops, preference 0). The wire specimen lives in
       skipped-with-visibility, NOT fail-closed-whole-snapshot. See
       `docs/fabric-cross-chassis-fwd.md`.
 
+## Session identity is NOT VRF-aware — single forwarding domain (#2387)
+
+The FIB route model above is table-scoped for route + local-delivery
+*selection*, but the session/flow *identity* is not. This is a known
+limitation, tracked by #2387.
+
+- **`SessionKey` is the bare 5-tuple** (`session/key.rs`) — no
+  routing-instance / VRF / zone / ingress-ifindex discriminator. The
+  conntrack table and the shared synced / NAT / forward-wire session maps
+  (`afxdp/coordinator/session_manager.rs`) are all keyed by it alone, so
+  two flows with identical 5-tuples on any two interfaces share one
+  conntrack entry.
+- **PBR `then routing-instance` is the ONLY per-VRF forwarding path.** An
+  interface's native `routing_instance` selects only the connected-route
+  table NAME (#2388 above) — it does NOT scope a transit packet's
+  destination-FIB lookup. Only a PBR interface filter's
+  `ingress_route_table_override` (`forwarding/mod.rs`, sole caller in
+  `poll_descriptor/mod.rs`) actually steers a transit packet to a per-VRF
+  table. In default (non-PBR) mode the destination FIB is the global
+  `inet.0`/`inet6.0` and local-delivery uses the global `local_v[46]` sets,
+  so overlapping-address multi-VRF does not forward correctly there at all.
+- **PBR per-VRF forwarding is NOT session-isolated.** Because the identity
+  is the bare 5-tuple, the established-session fast path
+  (`resolve_flow_session_decision`) runs BEFORE the PBR table override, so
+  a second flow with the same 5-tuple in a different routing-instance hits
+  the first flow's conntrack session and inherits its cached egress / NAT /
+  policy decision — wrong-VRF forwarding. This is reachable only with
+  overlapping L3 address space + PBR + simultaneous identical 5-tuples (a
+  niche multi-tenant config), but it is real, not purely latent.
+- **#3096 NAT-scope-vs-session-cache coherence contract.** #3096 made NAT
+  rule *selection* routing-instance-aware at session CREATE
+  (`ifindex_to_routing_instance` + `NatScopeCtx`). But the established fast
+  path returns the cached hit's decision by the bare 5-tuple WITHOUT
+  re-running the scope gate, so a colliding second flow reuses the first
+  flow's NAT/policy/forwarding decision — defeating #3096's scoping for that
+  flow. The invariant the real fix must restore: **a cached fast-path
+  decision is only reused for a flow in the same scope it was admitted
+  under.**
+- **Interim mitigation + deferred real fix.** The Go compiler emits a
+  commit WARNING (`validateVRFOverlap`, `pkg/config`) when two distinct
+  routing-instances carry overlapping L3 address space, so the operator is
+  told the topology is not session-isolated (the config still commits — an
+  overlapping-subnet PBR VRF is a legitimate working design). The real fix
+  (Track B) adds a **symmetric routing-domain id** to `SessionKey` +
+  `FlowCacheLookup` + the reverse-key transforms, plus the HA session-sync
+  wire bump — the discriminator MUST be the routing-domain id (symmetric
+  across forward/reply), NOT zone or ingress-ifindex (asymmetric → breaks
+  conntrack reverse matching). See
+  `docs/research/2387-vrf-flow-identity/plan.md`.
+
 ## Where it sits
 
 - Reads the live snapshot Arcs (FIB, NAT, neighbor table) supplied


### PR DESCRIPTION
## Summary

PR-A of #2387: the userspace-dp session/flow identity is the bare 5-tuple
(`userspace-dp/src/session/key.rs`) with **no** routing-instance / VRF
discriminator, so two flows in different routing-instances that share a 5-tuple
collide in the conntrack map. The collision is **LIVE under PBR `then
routing-instance`** — the established-session fast path
(`resolve_flow_session_decision`) runs *before* the PBR table override, so a
second flow with the same 5-tuple in another routing-instance hits the first
flow's conntrack session and inherits its cached egress / NAT / policy decision
(wrong-VRF forwarding). It stays latent in default (non-PBR) mode.

This ships the interim mitigation from the converged `/research` plan
(`docs/research/2387-vrf-flow-identity/plan.md`, **Track A.1 + A.3**). It is a
**GO-only** change (`pkg/config` + a Rust doc) — no wire / HA / dataplane
behavior is touched.

## A.1 — commit-time WARNING (never a hard reject)

New validator `validateVRFOverlap` (`pkg/config/compiler_validate_vrf_overlap.go`)
mirrors `validateScreenScanSweepThresholds`: deterministic `[]string`, sorted
routing-instance names / filter names / prefixes. It builds a
routing-instance -> prefix set from BOTH sources named in the plan:

1. **native RI membership** — each member interface unit's configured addresses
   (`ri.Interfaces` -> `cfg.Interfaces.Interfaces[base].Units[unit].Addresses`);
2. **PBR filter terms** — a `then routing-instance <name>` term's source /
   destination match prefixes (the reachable-via-PBR trigger).

It then compares every unordered pair of DISTINCT routing-instances with
`net/netip` `Prefix.Overlaps` (contains-or-equal, family-safe) and emits a
warning naming both instances, their origins, and the overlapping prefix. A
**WARNING, not a reject** — overlapping-subnet multi-tenant VRF via PBR is a
legitimate working design; the config still commits and the operator is told it
is not session-isolated. Wired into the `compiler.go` warnings aggregation next
to `validateScreenScanSweepThresholds`.

## A.3 — docs

`userspace-dp/src/afxdp/forwarding/README.md` records the
single-forwarding-domain / not-session-isolated limitation: PBR is the only
per-VRF forwarding path and it is NOT session-isolated (bare-5-tuple conntrack),
plus the #3096 NAT-scope-vs-session-cache coherence contract.

## Validation

- New RED-on-revert tests (`compiler_validate_vrf_overlap_2387_test.go`): two
  routing-instances with overlapping `10.0.0.0/24` on their member units commit
  successfully with **one** warning naming both instances + the prefix (RED:
  removing the `validateVRFOverlap` call drops the warning); non-overlapping
  instances, a single RI, a no-RI config, and a v4-vs-v6 cross-family pair all
  produce **no** warning (no false positives); overlapping PBR `then
  routing-instance` terms also warn.
- RED-on-revert proven by temporarily disabling the wiring (0 warnings ->
  positive tests FAIL) then restoring.
- Full `pkg/config` suite, `gofmt`, `go vet`, and `go build ./...` all clean.

## Deferred (keeps #2387 open)

The VRF-aware session key itself — **Track B**: a symmetric routing-domain `u32`
added to `SessionKey` + `FlowCacheLookup` + the reverse-key transforms, plus the
HA session-sync wire bump (`CurrentHAProtocolVersion` + the #1930 mixed-base
ISSU gate). The discriminator MUST be the routing-domain id (symmetric across
forward/reply), NOT zone or ingress-ifindex (asymmetric -> breaks conntrack
reverse matching). That is Rust + Go + HA-wire and is the deferred half; #2387
stays open for it.

Refs #2387

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
