### PR TITLE
config: stamp cluster NodeID from runtime node-id for flat vSRX reth

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -36113,3 +36113,43 @@ top.
 - **File(s)**: pkg/config/compiler_validate_vrf_overlap.go,
   pkg/config/compiler_validate_vrf_overlap_2387_test.go, pkg/config/compiler.go,
   userspace-dp/src/afxdp/forwarding/README.md, _Log.md
+
+## 2026-07-06 — #4329 flat vSRX reth mis-resolves node identity on secondary
+
+- **Timestamp**: 2026-07-06
+- **Action**: Fix #4329 — a canonical vSRX chassis-cluster config (both
+  `ge-0/0/0` and `ge-7/0/0` carrying `redundant-parent reth0`, NO groups, NO
+  `chassis cluster node` leaf) silently mis-bound EVERY reth to the node-0
+  physical member on node 1 (wrong VIP placement, wrong HA-group interfaces).
+  Root cause: `Config.RethToPhysical()` scores members by
+  `SlotToNodeID(name) == Cluster.NodeID`, but `Cluster.NodeID` is populated
+  ONLY from the config leaf `chassis cluster node <id>` (guarded NodeIDSet).
+  The leaf-less flat vSRX form left `Cluster.NodeID` at its `0` default on BOTH
+  nodes, and `CompileConfigForNode(tree, nodeID)` used `nodeID` only for the
+  `${node}` group-expansion var, never the compiled cluster identity — so on
+  node 1 both members scored by the node-0 fallback and the alphabetical
+  tiebreak picked `ge-0/0/0` on both nodes. Fix: in
+  `compileConfigForNodeWithOpts` (pkg/config/compiler.go), after
+  `compileExpanded`, STAMP `cfg.Chassis.Cluster.NodeID = nodeID` guarded by
+  `nodeID >= 0 && cfg.Chassis.Cluster != nil && !cfg.Chassis.Cluster.NodeIDSet`.
+  Guard rationale: (1) `nodeID >= 0` — standalone compile routes through
+  `CompileConfig` (nodeID -1) and never reaches this path, so single-node
+  resolution is unchanged; (2) `Cluster != nil` — never fabricate a cluster
+  stanza, so a config-less HA node (node-id present, empty config — the
+  EMPTY-config takeover in pkg/daemon/daemon.go) keeps `Cluster == nil` and the
+  daemon's `haMode` / ~30 `Cluster != nil` gates do not flip on an empty
+  config (a real reth config always carries a `chassis cluster` stanza, so this
+  never suppresses a genuine fix); (3) `!NodeIDSet` — an explicit `chassis
+  cluster node <id>` leaf is the operator SSOT and must win, so the GROUPS form
+  (loss cluster: `groups node0/node1` each carry an explicit `node` leaf) is
+  bit-identical and `test-failover` is unaffected. RethToPhysical's alphabetical
+  tiebreak is left as-is: with the stamp the local member scores strictly higher
+  (2 vs 0), so the tiebreak is never reached for the 2-member case and never
+  decides between two nodes' members. RED-on-revert proven: reverting the stamp
+  makes node-1 bind `ge-0/0/0` (the exact bug); the explicit-leaf / groups /
+  standalone tests correctly stay GREEN on revert (not falsely coupled). Full
+  `go test ./pkg/config/...` + `./pkg/configstore/...` green, gofmt, go vet,
+  `go build ./...` all clean.
+- **File(s)**: pkg/config/compiler.go,
+  pkg/config/compiler_flat_reth_nodeid_4329_test.go,
+  docs/ha-cluster-test-plan.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -36153,3 +36153,42 @@ top.
 - **File(s)**: pkg/config/compiler.go,
   pkg/config/compiler_flat_reth_nodeid_4329_test.go,
   docs/ha-cluster-test-plan.md, _Log.md
+
+## 2026-07-06 — #4329 fold: relocate NodeID stamp before fabric derivation
+
+- **Timestamp**: 2026-07-06
+- **Action**: Copilot review of PR #4331 found a REAL incompleteness in the
+  first stamp placement. The stamp ran in `compileConfigForNodeWithOpts` AFTER
+  `compileExpanded` returned, but `compileExpanded` ALREADY derives two
+  NodeID-dependent COMPILE-TIME fabric fields under the stale default NodeID=0
+  (compiler.go fabric fixup, `SlotToNodeID(member) == cc.NodeID`):
+  `InterfaceConfig.LocalFabricMember` (which fab member is local to this node)
+  and the auto-detected `Cluster.FabricInterface` / `Fabric1Interface`. So the
+  first fix corrected reth resolution (RethToPhysical reads NodeID at runtime,
+  after the stamp) but left the fabric fields WRONG on node 1 for a leaf-less
+  flat config — the same class of bug, still present for fabric. Fix: thread
+  the node identity into `compileExpanded` via two new `compileOpts` fields
+  (`nodeAware bool`, `stampNodeID int`), set only by the node-aware entry
+  `compileConfigForNodeWithOpts`, and MOVE the stamp INSIDE `compileExpanded`
+  to run immediately after the top-level child loop (Cluster + interfaces
+  populated) and BEFORE every NodeID-dependent derivation: the fabric fixup
+  AND `validateDeviceMapStrict` (compiler.go, called later, also reads
+  cc.NodeID). Same three guards preserved:
+  `opts.nodeAware && opts.stampNodeID >= 0 && Cluster != nil && !NodeIDSet`
+  (standalone `CompileConfig` leaves nodeAware false → unchanged; never
+  fabricate Cluster → daemon.go EMPTY-config haMode reasoning holds; explicit
+  `chassis cluster node` leaf wins → GROUPS form bit-identical). RethToPhysical
+  and its alphabetical tiebreak are still unchanged (stamp now sets NodeID
+  during compile, so the runtime read still sees the correct value). Added
+  fabric regression test (canonical vSRX fab0=FPC-0 member / fab1=FPC-7 member,
+  NO node leaf): node 0 → fab0.LocalFabricMember=ge-0/0/1 + FabricInterface
+  fab0; node 1 → fab1.LocalFabricMember=ge-7/0/1 + FabricInterface fab1. RED on
+  revert PROVEN for BOTH reth (node 1 → ge-0/0/0) and fabric (node 1 fab1
+  LocalFabricMember empty, FabricInterface picks fab0); the reth/fabric GROUPS
+  forms + explicit-leaf + standalone tests correctly stay GREEN on revert (not
+  falsely coupled). GROUPS form confirmed unaffected (loss cluster carries an
+  explicit `node` leaf per group → NodeIDSet true → stamp skipped → no
+  test-failover impact). Full `go test ./pkg/config/...` +
+  `./pkg/configstore/...` green, gofmt, go vet, `go build ./...` clean.
+- **File(s)**: pkg/config/compiler.go,
+  pkg/config/compiler_flat_reth_nodeid_4329_test.go, _Log.md

--- a/docs/ha-cluster-test-plan.md
+++ b/docs/ha-cluster-test-plan.md
@@ -30,6 +30,39 @@ per-node configuration from a single source file.
 Config sync "just works" — the primary sends the **unexpanded** config text (with groups
 intact) to the secondary. Each node compiles it with its own `${node}` expansion.
 
+### Flat vSRX config drop-in (no groups) — #4329
+
+The `groups` / `apply-groups "${node}"` pattern above is the xpf-native form. A
+**canonical vSRX chassis-cluster config also works as a drop-in with no changes** —
+the form where both members carry `redundant-parent reth0` at the top level (e.g.
+`ge-0/0/0` and `ge-7/0/0`), with **no `groups` and no `chassis cluster node` leaf**:
+
+```
+chassis { cluster { cluster-id 1; reth-count 2; ... } }
+interfaces {
+    ge-0/0/0 { gigether-options { redundant-parent reth0; } }   # node 0 member (FPC 0)
+    ge-7/0/0 { gigether-options { redundant-parent reth0; } }   # node 1 member (FPC 7)
+    reth0 { redundant-ether-options { redundancy-group 1; } }
+}
+```
+
+vSRX encodes node ownership in the **FPC slot** (`ge-0/0/N` → node 0, `ge-7/0/N` →
+node 1, via `SlotToNodeID`) and runs the identical flat config on both nodes. The
+node identity comes from the runtime SSOT (`/etc/xpf/node-id`, or `-node-id` on
+`xpfd check-config`), not from a config leaf. At compile time
+`CompileConfigForNode(tree, nodeID)` **stamps** `Cluster.NodeID` from that runtime
+node-id whenever the config carries a cluster stanza but no explicit `chassis
+cluster node` leaf, so `RethToPhysical` scores and binds each reth to the **local**
+FPC member on both nodes — `reth0` → `ge-0/0/0` on node 0 and `reth0` → `ge-7/0/0`
+on node 1.
+
+The stamp only fills a **leaf-less** config: an explicit `chassis cluster node <id>`
+leaf (as the `groups node0/node1` form carries) remains the operator's SSOT and is
+never overwritten — so the groups form above is bit-identical. Before #4329,
+`Cluster.NodeID` defaulted to `0` on both nodes for the leaf-less flat form, so the
+secondary silently mis-bound every reth to the node-0 member (wrong VIP placement,
+wrong HA-group interfaces).
+
 ### Interface Naming Convention
 
 xpf uses vSRX-style interface names:

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1448,6 +1448,17 @@ type compileOpts struct {
 	// threshold, so the mis-arrived 0 no longer over-fires. Same doctrine as
 	// lenientEventAttributesMatch (its attributes-match sibling).
 	lenientEventWithinTrigger bool
+
+	// nodeAware / stampNodeID (#4329) carry the runtime cluster node
+	// identity (from /etc/xpf/node-id, or `-node-id` on `xpfd
+	// check-config`) into compileExpanded so it can be stamped onto the
+	// compiled ClusterConfig.NodeID BEFORE any NodeID-dependent derivation
+	// runs. Only the node-aware entry (compileConfigForNodeWithOpts) sets
+	// nodeAware; the standalone CompileConfig path leaves it false so
+	// single-node compiles are unchanged. See the stamp in compileExpanded
+	// for the full rationale and guards.
+	nodeAware   bool
+	stampNodeID int
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -1848,43 +1859,17 @@ func compileConfigForNodeWithOpts(tree *ConfigTree, nodeID int, opts compileOpts
 		return nil, fmt.Errorf("apply-groups: %w", err)
 	}
 
+	// #4329: thread the runtime cluster node identity into compileExpanded so
+	// it can stamp ClusterConfig.NodeID for a leaf-less flat vSRX config
+	// BEFORE any NodeID-dependent derivation runs (reth member resolution AND
+	// the compile-time fabric-member / FabricInterface auto-detect). See the
+	// stamp block in compileExpanded for the full rationale and guards.
+	opts.nodeAware = true
+	opts.stampNodeID = nodeID
+
 	cfg, err := compileExpanded(tree, opts)
 	if err != nil {
 		return nil, err
-	}
-
-	// #4329: stamp the compiled cluster node identity from the runtime
-	// node-id (/etc/xpf/node-id, or the `-node-id` flag on `xpfd
-	// check-config`) when the config carries a chassis-cluster stanza but
-	// no explicit `chassis cluster node` leaf. A canonical vSRX
-	// chassis-cluster config encodes node ownership in the FPC slot
-	// (ge-0/0/N=node0, ge-7/0/N=node1) and runs the SAME flat config on both
-	// nodes with no `node` leaf. Without this stamp, Cluster.NodeID sits at
-	// its zero default on BOTH nodes, so RethToPhysical scores every reth
-	// member as node 0 and binds every reth to the node-0 physical member on
-	// node 1 — reth breaks on the secondary (wrong VIP placement, wrong
-	// HA-group interfaces). Stamping makes the compiled identity reflect the
-	// node the config is compiled FOR, so RethToPhysical scores the local
-	// member correctly on both nodes and the flat vSRX form is a drop-in.
-	//
-	// Guards (all three are load-bearing):
-	//   - nodeID >= 0: cluster mode only. A standalone compile passes
-	//     nodeID == -1 through CompileConfig and never reaches this path, so
-	//     single-node resolution is unchanged.
-	//   - Cluster != nil: never fabricate a cluster stanza. A config-less HA
-	//     node (node-id present but empty/no-cluster config — the
-	//     EMPTY-config takeover in pkg/daemon/daemon.go) must keep
-	//     Cluster == nil so the daemon's `haMode` / `Cluster != nil` gates do
-	//     not flip on a config that has no cluster. A real reth config always
-	//     carries a `chassis cluster` stanza (redundant-parent is only
-	//     meaningful under cluster), so this never suppresses a genuine fix.
-	//   - !NodeIDSet: an explicit `chassis cluster node <id>` leaf is the
-	//     operator's SSOT and must win — never clobber it. crossCheckNodeID
-	//     (pkg/configstore) already rejects a leaf that disagrees with the
-	//     runtime node-id, and the GROUPS form (groups node0/node1 each carry
-	//     an explicit `node` leaf) is left bit-identical.
-	if nodeID >= 0 && cfg.Chassis.Cluster != nil && !cfg.Chassis.Cluster.NodeIDSet {
-		cfg.Chassis.Cluster.NodeID = nodeID
 	}
 
 	cfg.Warnings = append(cfg.Warnings, tunnelIDWarnings...)
@@ -2402,6 +2387,48 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 				return nil, fmt.Errorf("bridge-domains: %w", err)
 			}
 		}
+	}
+
+	// #4329: stamp the compiled cluster node identity from the runtime
+	// node-id (/etc/xpf/node-id, or the `-node-id` flag on `xpfd
+	// check-config`) when the config carries a chassis-cluster stanza but no
+	// explicit `chassis cluster node` leaf. A canonical vSRX chassis-cluster
+	// config encodes node ownership in the FPC slot (ge-0/0/N=node0,
+	// ge-7/0/N=node1) and runs the SAME flat config on both nodes with no
+	// `node` leaf. Without this stamp, Cluster.NodeID sits at its zero default
+	// on BOTH nodes, so every NodeID-dependent derivation resolves to the
+	// node-0 member on node 1 — reth breaks on the secondary (RethToPhysical
+	// reads NodeID at runtime), AND the compile-time fabric-member /
+	// FabricInterface auto-detect below (SlotToNodeID(member) == cc.NodeID)
+	// binds fab0/fab1 to the node-0 member. Stamping makes the compiled
+	// identity reflect the node the config is compiled FOR, so BOTH reth and
+	// fabric resolve to the LOCAL member on each node and the flat vSRX form
+	// is a drop-in.
+	//
+	// This MUST run after the child loop (Cluster + interfaces are populated)
+	// and BEFORE every NodeID-dependent derivation that follows: the fabric
+	// fixup below and validateDeviceMapStrict later in this function both read
+	// cc.NodeID.
+	//
+	// Guards (all load-bearing):
+	//   - opts.nodeAware && stampNodeID >= 0: only the node-aware entry
+	//     (compileConfigForNodeWithOpts) sets these. The standalone
+	//     CompileConfig path leaves nodeAware false, so single-node compiles
+	//     are unchanged; a negative node-id (defensive) never stamps.
+	//   - Cluster != nil: never fabricate a cluster stanza. A config-less HA
+	//     node (node-id present but empty/no-cluster config — the EMPTY-config
+	//     takeover in pkg/daemon/daemon.go) must keep Cluster == nil so the
+	//     daemon's `haMode` / `Cluster != nil` gates do not flip on a config
+	//     that has no cluster. A real reth/fabric config always carries a
+	//     `chassis cluster` stanza, so this never suppresses a genuine fix.
+	//   - !NodeIDSet: an explicit `chassis cluster node <id>` leaf is the
+	//     operator's SSOT and must win — never clobber it. crossCheckNodeID
+	//     (pkg/configstore) already rejects a leaf that disagrees with the
+	//     runtime node-id, and the GROUPS form (groups node0/node1 each carry
+	//     an explicit `node` leaf) is left bit-identical.
+	if opts.nodeAware && opts.stampNodeID >= 0 &&
+		cfg.Chassis.Cluster != nil && !cfg.Chassis.Cluster.NodeIDSet {
+		cfg.Chassis.Cluster.NodeID = opts.stampNodeID
 	}
 
 	// #3870: resolve the BGP local-AS from `routing-options

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1852,6 +1852,41 @@ func compileConfigForNodeWithOpts(tree *ConfigTree, nodeID int, opts compileOpts
 	if err != nil {
 		return nil, err
 	}
+
+	// #4329: stamp the compiled cluster node identity from the runtime
+	// node-id (/etc/xpf/node-id, or the `-node-id` flag on `xpfd
+	// check-config`) when the config carries a chassis-cluster stanza but
+	// no explicit `chassis cluster node` leaf. A canonical vSRX
+	// chassis-cluster config encodes node ownership in the FPC slot
+	// (ge-0/0/N=node0, ge-7/0/N=node1) and runs the SAME flat config on both
+	// nodes with no `node` leaf. Without this stamp, Cluster.NodeID sits at
+	// its zero default on BOTH nodes, so RethToPhysical scores every reth
+	// member as node 0 and binds every reth to the node-0 physical member on
+	// node 1 — reth breaks on the secondary (wrong VIP placement, wrong
+	// HA-group interfaces). Stamping makes the compiled identity reflect the
+	// node the config is compiled FOR, so RethToPhysical scores the local
+	// member correctly on both nodes and the flat vSRX form is a drop-in.
+	//
+	// Guards (all three are load-bearing):
+	//   - nodeID >= 0: cluster mode only. A standalone compile passes
+	//     nodeID == -1 through CompileConfig and never reaches this path, so
+	//     single-node resolution is unchanged.
+	//   - Cluster != nil: never fabricate a cluster stanza. A config-less HA
+	//     node (node-id present but empty/no-cluster config — the
+	//     EMPTY-config takeover in pkg/daemon/daemon.go) must keep
+	//     Cluster == nil so the daemon's `haMode` / `Cluster != nil` gates do
+	//     not flip on a config that has no cluster. A real reth config always
+	//     carries a `chassis cluster` stanza (redundant-parent is only
+	//     meaningful under cluster), so this never suppresses a genuine fix.
+	//   - !NodeIDSet: an explicit `chassis cluster node <id>` leaf is the
+	//     operator's SSOT and must win — never clobber it. crossCheckNodeID
+	//     (pkg/configstore) already rejects a leaf that disagrees with the
+	//     runtime node-id, and the GROUPS form (groups node0/node1 each carry
+	//     an explicit `node` leaf) is left bit-identical.
+	if nodeID >= 0 && cfg.Chassis.Cluster != nil && !cfg.Chassis.Cluster.NodeIDSet {
+		cfg.Chassis.Cluster.NodeID = nodeID
+	}
+
 	cfg.Warnings = append(cfg.Warnings, tunnelIDWarnings...)
 	cfg.Warnings = append(cfg.Warnings, zoneIDWarnings...)
 	cfg.Warnings = append(cfg.Warnings, riTableIDWarnings...)

--- a/pkg/config/compiler_flat_reth_nodeid_4329_test.go
+++ b/pkg/config/compiler_flat_reth_nodeid_4329_test.go
@@ -137,6 +137,102 @@ func TestFlatRethGroupsFormUnaffected_4329(t *testing.T) {
 	}
 }
 
+// TestFlatFabricResolvesLocalMemberPerNode_4329 is the fabric sibling of the
+// reth regression: the same NodeID-default bug hits the COMPILE-TIME fabric
+// derivation (LocalFabricMember + FabricInterface auto-detect), which reads
+// cc.NodeID inside compileExpanded. The stamp is relocated to run BEFORE that
+// derivation, so a leaf-less flat config resolves fab0/fab1 to the LOCAL
+// node's member on each node. RED on revert: node 1 resolves fab0 →
+// ge-0/0/1 and FabricInterface "fab0" (the node-0 member), same class of bug.
+func TestFlatFabricResolvesLocalMemberPerNode_4329(t *testing.T) {
+	// Canonical vSRX fabric form: fab0 carries the node-0 member (FPC 0),
+	// fab1 carries the node-1 member (FPC 7); NO `chassis cluster node` leaf.
+	flatFabric := []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster reth-count 2",
+		"set interfaces fab0 fabric-options member-interfaces ge-0/0/1",
+		"set interfaces fab0 unit 0 family inet address 10.99.1.1/30",
+		"set interfaces fab1 fabric-options member-interfaces ge-7/0/1",
+		"set interfaces fab1 unit 0 family inet address 10.99.2.1/30",
+	}
+	tree := buildTree(t, flatFabric)
+
+	// Node 0: fab0's FPC-0 member is local; fab1's FPC-7 member is remote.
+	cfg0, err := CompileConfigForNode(tree, 0)
+	if err != nil {
+		t.Fatalf("CompileConfigForNode(node 0): %v", err)
+	}
+	if got := cfg0.Interfaces.Interfaces["fab0"].LocalFabricMember; got != "ge-0/0/1" {
+		t.Fatalf("node 0: fab0 LocalFabricMember = %q, want ge-0/0/1", got)
+	}
+	if got := cfg0.Interfaces.Interfaces["fab1"].LocalFabricMember; got != "" {
+		t.Fatalf("node 0: fab1 LocalFabricMember = %q, want empty (remote)", got)
+	}
+	if got := cfg0.Chassis.Cluster.FabricInterface; got != "fab0" {
+		t.Fatalf("node 0: FabricInterface = %q, want fab0", got)
+	}
+
+	// Node 1: fab1's FPC-7 member is local; fab0's FPC-0 member is remote.
+	// This is the load-bearing assertion — the compile-time fabric fields
+	// must follow the runtime node identity, not the NodeID=0 default.
+	cfg1, err := CompileConfigForNode(tree, 1)
+	if err != nil {
+		t.Fatalf("CompileConfigForNode(node 1): %v", err)
+	}
+	if got := cfg1.Interfaces.Interfaces["fab1"].LocalFabricMember; got != "ge-7/0/1" {
+		t.Fatalf("node 1: fab1 LocalFabricMember = %q, want ge-7/0/1 (RED-on-revert: pre-fix empty)", got)
+	}
+	if got := cfg1.Interfaces.Interfaces["fab0"].LocalFabricMember; got != "" {
+		t.Fatalf("node 1: fab0 LocalFabricMember = %q, want empty (RED-on-revert: pre-fix binds ge-0/0/1)", got)
+	}
+	if got := cfg1.Chassis.Cluster.FabricInterface; got != "fab1" {
+		t.Fatalf("node 1: FabricInterface = %q, want fab1 (RED-on-revert: pre-fix picks fab0)", got)
+	}
+
+	// ResolveFab (the runtime resolver) must follow the corrected map.
+	if got := cfg1.ResolveFab("fab1"); got != "ge-7/0/1" {
+		t.Fatalf("node 1: ResolveFab(fab1) = %q, want ge-7/0/1", got)
+	}
+}
+
+// TestFlatFabricGroupsFormUnaffected_4329 confirms the GROUPS fabric form (an
+// explicit `node` leaf per group) is bit-identical under the fix: NodeIDSet is
+// true so the stamp is skipped, and each node's expanded config still resolves
+// its own fabric member.
+func TestFlatFabricGroupsFormUnaffected_4329(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set groups node0 chassis cluster node 0",
+		"set groups node1 chassis cluster node 1",
+		`set apply-groups "${node}"`,
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster reth-count 2",
+		"set interfaces fab0 fabric-options member-interfaces ge-0/0/1",
+		"set interfaces fab1 fabric-options member-interfaces ge-7/0/1",
+	})
+
+	cfg0, err := CompileConfigForNode(tree, 0)
+	if err != nil {
+		t.Fatalf("CompileConfigForNode(node 0, groups): %v", err)
+	}
+	if !cfg0.Chassis.Cluster.NodeIDSet {
+		t.Error("node 0 groups: NodeIDSet must stay true (explicit leaf)")
+	}
+	if got := cfg0.Interfaces.Interfaces["fab0"].LocalFabricMember; got != "ge-0/0/1" {
+		t.Fatalf("node 0 groups: fab0 LocalFabricMember = %q, want ge-0/0/1", got)
+	}
+
+	cfg1, err := CompileConfigForNode(tree, 1)
+	if err != nil {
+		t.Fatalf("CompileConfigForNode(node 1, groups): %v", err)
+	}
+	if !cfg1.Chassis.Cluster.NodeIDSet {
+		t.Error("node 1 groups: NodeIDSet must stay true (explicit leaf)")
+	}
+	if got := cfg1.Interfaces.Interfaces["fab1"].LocalFabricMember; got != "ge-7/0/1" {
+		t.Fatalf("node 1 groups: fab1 LocalFabricMember = %q, want ge-7/0/1", got)
+	}
+}
+
 // TestFlatRethStandaloneCompileUnchanged_4329 pins that the standalone
 // (non-cluster) compile path is untouched: CompileConfig (nodeID == -1)
 // routes through compileConfigWithOpts, never the node-aware stamp, so a

--- a/pkg/config/compiler_flat_reth_nodeid_4329_test.go
+++ b/pkg/config/compiler_flat_reth_nodeid_4329_test.go
@@ -1,0 +1,160 @@
+package config
+
+import "testing"
+
+// #4329: a canonical vSRX chassis-cluster config encodes node ownership in
+// the FPC slot (ge-0/0/N=node0, ge-7/0/N=node1) and runs the SAME flat config
+// on both nodes with NO `chassis cluster node` leaf. Before the fix,
+// CompileConfigForNode never stamped Cluster.NodeID from the runtime node-id,
+// so Cluster.NodeID sat at its zero default on BOTH nodes and RethToPhysical
+// scored every reth member as node 0 — binding every reth to the node-0
+// physical member on node 1 (reth breaks on the secondary).
+
+// flatRethClusterConfig is the canonical leaf-less vSRX form: a chassis
+// cluster stanza (cluster-id + reth-count) with NO `node` leaf, and both
+// per-node physical members carrying `redundant-parent reth0`.
+func flatRethClusterConfig() []string {
+	return []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster reth-count 2",
+		"set interfaces ge-0/0/0 gigether-options redundant-parent reth0",
+		"set interfaces ge-7/0/0 gigether-options redundant-parent reth0",
+		"set interfaces reth0 redundant-ether-options redundancy-group 1",
+	}
+}
+
+// TestFlatRethResolvesLocalMemberPerNode_4329 is the RED-on-revert regression
+// guard: the flat two-member form (no `node` leaf) must resolve reth0 to the
+// LOCAL member on each node — ge-0/0/0 on node 0 AND ge-7/0/0 on node 1.
+// RED on revert: without the NodeID stamp both nodes resolve to ge-0/0/0
+// (Cluster.NodeID==0 default → node 0's member wins the score on both).
+func TestFlatRethResolvesLocalMemberPerNode_4329(t *testing.T) {
+	tree := buildTree(t, flatRethClusterConfig())
+
+	cfg0, err := CompileConfigForNode(tree, 0)
+	if err != nil {
+		t.Fatalf("CompileConfigForNode(node 0): %v", err)
+	}
+	if got := cfg0.RethToPhysical()["reth0"]; got != "ge-0/0/0" {
+		t.Fatalf("node 0: reth0 → %q, want ge-0/0/0", got)
+	}
+	if cfg0.Chassis.Cluster == nil || cfg0.Chassis.Cluster.NodeID != 0 {
+		t.Fatalf("node 0: stamped NodeID = %+v, want 0", cfg0.Chassis.Cluster)
+	}
+
+	cfg1, err := CompileConfigForNode(tree, 1)
+	if err != nil {
+		t.Fatalf("CompileConfigForNode(node 1): %v", err)
+	}
+	// The load-bearing assertion: the secondary must bind reth0 to its OWN
+	// FPC-7 member, not the node-0 member.
+	if got := cfg1.RethToPhysical()["reth0"]; got != "ge-7/0/0" {
+		t.Fatalf("node 1: reth0 → %q, want ge-7/0/0 (RED-on-revert: pre-fix binds ge-0/0/0)", got)
+	}
+	if cfg1.Chassis.Cluster == nil || cfg1.Chassis.Cluster.NodeID != 1 {
+		t.Fatalf("node 1: stamped NodeID = %+v, want 1", cfg1.Chassis.Cluster)
+	}
+	// The stamp must NOT fabricate the explicit-leaf flag: NodeIDSet stays
+	// false so crossCheckNodeID still treats this as a leaf-less config.
+	if cfg1.Chassis.Cluster.NodeIDSet {
+		t.Error("node 1: NodeIDSet must stay false — the stamp derives from the runtime node-id, not a `node` leaf")
+	}
+
+	// ResolveReth (the runtime resolver every reth consumer drives) must
+	// follow the corrected map on node 1.
+	if got := cfg1.ResolveReth("reth0.80"); got != "ge-7/0/0.80" {
+		t.Fatalf("node 1: ResolveReth(reth0.80) = %q, want ge-7/0/0.80", got)
+	}
+}
+
+// TestFlatRethExplicitNodeLeafNotClobbered_4329 pins the precedence rule: an
+// explicit `chassis cluster node <id>` leaf is the operator's SSOT and MUST
+// win over the runtime node-id — the stamp only fills a leaf-less config.
+// A config with `node 0` compiled FOR node 1 keeps NodeID==0 (and resolves
+// reth0 to node 0's member), exactly as before the fix.
+func TestFlatRethExplicitNodeLeafNotClobbered_4329(t *testing.T) {
+	lines := append(flatRethClusterConfig(), "set chassis cluster node 0")
+	tree := buildTree(t, lines)
+
+	cfg, err := CompileConfigForNode(tree, 1)
+	if err != nil {
+		t.Fatalf("CompileConfigForNode(node 1, explicit node 0 leaf): %v", err)
+	}
+	if cfg.Chassis.Cluster == nil {
+		t.Fatal("Cluster is nil")
+	}
+	if !cfg.Chassis.Cluster.NodeIDSet {
+		t.Error("NodeIDSet must stay true — an explicit `node` leaf was present")
+	}
+	if cfg.Chassis.Cluster.NodeID != 0 {
+		t.Fatalf("NodeID = %d, want 0 — the stamp must NOT clobber an explicit leaf", cfg.Chassis.Cluster.NodeID)
+	}
+	// With the explicit leaf naming node 0, reth0 stays bound to the node-0
+	// member even though we compiled for node 1 (crossCheckNodeID rejects
+	// this mismatch on the commit path; here we only assert precedence).
+	if got := cfg.RethToPhysical()["reth0"]; got != "ge-0/0/0" {
+		t.Fatalf("reth0 → %q, want ge-0/0/0 (explicit node 0 leaf must decide)", got)
+	}
+}
+
+// TestFlatRethGroupsFormUnaffected_4329 confirms the GROUPS form (the xpf loss
+// cluster shape: groups node0/node1 each carrying an explicit `node` leaf and
+// only ITS own member, applied via `apply-groups "${node}"`) is bit-identical
+// under the fix. Each node's expanded config carries an explicit `node` leaf
+// (NodeIDSet==true → stamp skipped) and a single candidate member.
+func TestFlatRethGroupsFormUnaffected_4329(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set groups node0 chassis cluster node 0",
+		"set groups node0 interfaces ge-0/0/0 gigether-options redundant-parent reth0",
+		"set groups node1 chassis cluster node 1",
+		"set groups node1 interfaces ge-7/0/0 gigether-options redundant-parent reth0",
+		`set apply-groups "${node}"`,
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster reth-count 2",
+		"set interfaces reth0 redundant-ether-options redundancy-group 1",
+	})
+
+	cfg0, err := CompileConfigForNode(tree, 0)
+	if err != nil {
+		t.Fatalf("CompileConfigForNode(node 0, groups): %v", err)
+	}
+	if !cfg0.Chassis.Cluster.NodeIDSet || cfg0.Chassis.Cluster.NodeID != 0 {
+		t.Fatalf("node 0 groups: Cluster = %+v, want explicit node 0", cfg0.Chassis.Cluster)
+	}
+	if got := cfg0.RethToPhysical()["reth0"]; got != "ge-0/0/0" {
+		t.Fatalf("node 0 groups: reth0 → %q, want ge-0/0/0", got)
+	}
+
+	cfg1, err := CompileConfigForNode(tree, 1)
+	if err != nil {
+		t.Fatalf("CompileConfigForNode(node 1, groups): %v", err)
+	}
+	if !cfg1.Chassis.Cluster.NodeIDSet || cfg1.Chassis.Cluster.NodeID != 1 {
+		t.Fatalf("node 1 groups: Cluster = %+v, want explicit node 1", cfg1.Chassis.Cluster)
+	}
+	if got := cfg1.RethToPhysical()["reth0"]; got != "ge-7/0/0" {
+		t.Fatalf("node 1 groups: reth0 → %q, want ge-7/0/0", got)
+	}
+}
+
+// TestFlatRethStandaloneCompileUnchanged_4329 pins that the standalone
+// (non-cluster) compile path is untouched: CompileConfig (nodeID == -1)
+// routes through compileConfigWithOpts, never the node-aware stamp, so a
+// leaf-less config keeps NodeIDSet==false and its zero-default NodeID.
+func TestFlatRethStandaloneCompileUnchanged_4329(t *testing.T) {
+	tree := buildTree(t, flatRethClusterConfig())
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig (standalone): %v", err)
+	}
+	if cfg.Chassis.Cluster == nil {
+		t.Fatal("Cluster is nil")
+	}
+	if cfg.Chassis.Cluster.NodeIDSet {
+		t.Error("standalone: NodeIDSet must stay false — CompileConfig must not stamp")
+	}
+	if cfg.Chassis.Cluster.NodeID != 0 {
+		t.Errorf("standalone: NodeID = %d, want 0 (zero default, unstamped)", cfg.Chassis.Cluster.NodeID)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #4329.

A canonical vSRX chassis-cluster config dropped into xpf as-is — both
`ge-0/0/0` and `ge-7/0/0` carrying `redundant-parent reth0`, **no `groups`,
no `chassis cluster node` leaf** — silently mis-bound **every reth to the
node-0 physical member on node 1**. reth breaks on the secondary: wrong VIP
placement, wrong HA-group interfaces. `xpfd check-config -node-id {0,1}`
passed the flat form on both nodes, so the mis-resolution was silent.

## Root cause

- `Config.RethToPhysical()` (`pkg/config/types.go:64`) scores each candidate
  member by `SlotToNodeID(name) == Cluster.NodeID` (local member wins).
- `Cluster.NodeID` is populated **only** from the config leaf `chassis cluster
  node <id>` (`compiler_system.go:1566`, guarded by `NodeIDSet`). vSRX encodes
  node ownership in the FPC slot (`ge-0/0/N`=node 0, `ge-7/0/N`=node 1) and runs
  the identical leaf-less flat config on both nodes → `Cluster.NodeID` sat at
  its `0` default on **both** nodes.
- `CompileConfigForNode(tree, nodeID)` used `nodeID` only for the `${node}`
  group-expansion var, never the compiled cluster identity → on node 1 both
  members scored by the node-0 fallback and the alphabetical tiebreak picked
  `ge-0/0/0` on both nodes.

## Fix

In `compileConfigForNodeWithOpts` (`pkg/config/compiler.go`), after
`compileExpanded`, stamp the runtime SSOT identity into the compiled config:

```go
if nodeID >= 0 && cfg.Chassis.Cluster != nil && !cfg.Chassis.Cluster.NodeIDSet {
    cfg.Chassis.Cluster.NodeID = nodeID
}
```

The three guards are load-bearing:

- **`nodeID >= 0`** — standalone compile routes through `CompileConfig`
  (nodeID -1) and never reaches this path; single-node resolution is unchanged.
- **`Cluster != nil`** — never fabricate a cluster stanza. A config-less HA
  node (node-id present, empty config — the EMPTY-config takeover in
  `pkg/daemon/daemon.go`) keeps `Cluster == nil` so the daemon's `haMode` and
  ~30 other `Cluster != nil` gates do not flip on an empty config. A real reth
  config always carries a `chassis cluster` stanza, so this never suppresses a
  genuine fix.
- **`!NodeIDSet`** — an explicit `chassis cluster node <id>` leaf is the
  operator SSOT and must win; never clobber it. The **GROUPS form** (the loss
  cluster: `groups node0/node1` each carry an explicit `node` leaf) is therefore
  **bit-identical**, so `test-failover` is unaffected.

`RethToPhysical`'s alphabetical tiebreak is left as-is: with the stamp the local
member scores strictly higher (2 vs 0), so the tiebreak is never reached for the
2-member case and never decides between two nodes' members.

## Validation

- **RED-on-revert regression test** (`compiler_flat_reth_nodeid_4329_test.go`):
  the flat two-member form resolves `reth0 → ge-0/0/0` on node 0 **and**
  `reth0 → ge-7/0/0` on node 1; reverting the stamp makes node 1 bind
  `ge-0/0/0` (the exact bug — verified).
- Explicit-leaf precedence: a config with `chassis cluster node 0` compiled for
  node 1 keeps `NodeID 0` (stamp does not clobber).
- GROUPS form unaffected; standalone `CompileConfig` never stamps.
- `go test ./pkg/config/...` and `./pkg/configstore/...` green; `gofmt`,
  `go vet`, `go build ./...` clean.

Docs: `docs/ha-cluster-test-plan.md` documents the flat vSRX drop-in.

> Touches reth resolution → HA (VIP / HA-group placement). The GROUPS-form
> resolution (loss cluster) is bit-identical by the `!NodeIDSet` guard, so
> `test-failover` should stay green — recommend running it before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi