### PR TITLE
cli/grpc: resolve bondless reth on all show-interfaces text surfaces (#4328)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-06 — #4328 follow-up: non-reth Junos-name kernel resolution + comment/speed nits
+
+- **Timestamp**: 2026-07-06
+- **Action**: Copilot review of PR #4333 found a real RELATED bug at the same
+  lookup sites: for a NON-reth interface the summary/detail lookup used the raw
+  config `physName` (Junos-form "ge-0/0/2" or an alias), but
+  netlink.LinkByName / net.InterfaceByName need the Linux kernel ifname
+  ("ge-0-0-2") — so a VALID interface authored in Junos form rendered
+  "Physical interface: <name>, Not present". Verified the bug MANIFESTS
+  (zone/interface refs are stored verbatim slash-form; nothing normalized
+  upstream). Fixed both physical-lookup sites to resolve via
+  `cfg.ResolveKernelIfName(physName)` — the same helper Server.GetInterfaces
+  uses (#3460) — before the netlink lookup, keeping the reth branch's
+  member resolution: pkg/cli/cli_show_interfaces.go showInterfaces (summary),
+  pkg/grpcapi/server_show_interfaces.go ShowInterfacesDetail. Also (#4341)
+  the CLI summary's readLinkSpeed/readLinkDuplex now read from the resolved
+  kernel name (a reth has no /sys/class/net/reth0, and a Junos-form physName
+  has no sysfs entry either) — the gRPC summary already read speed/duplex
+  from kernelLookup. Fixed the rethMemberLinkState doc comment to match the
+  impl (absent device → admin stays "up", only link "down"; the comment said
+  both "down"). Added portable RED-on-revert tests (pkg/cli + pkg/grpcapi)
+  that discover a real dash-named host interface, reference it via its
+  Junos-slash form, and assert the summary / RPC do NOT render "Not present"
+  (skip when no dash-named netdev exists); reverting the resolution to raw
+  physName reproduces "Not present". go build ./... clean; gofmt clean;
+  go test ./pkg/config/... ./pkg/cli/... ./pkg/grpcapi/... green. Merged
+  origin/master (#4331/#4334 etc.) cleanly into the branch first.
+- **File(s)**: pkg/cli/cli_show_interfaces.go,
+  pkg/grpcapi/server_show_interfaces.go,
+  pkg/cli/cli_show_interfaces_reth_4328_test.go,
+  pkg/grpcapi/server_show_interfaces_reth_4328_test.go
+
 ## 2026-07-06 — #4328: teach all `show interfaces` text surfaces to resolve a bondless reth
 
 - **Timestamp**: 2026-07-06

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,39 @@
+## 2026-07-06 — #4328: teach all `show interfaces` text surfaces to resolve a bondless reth
+
+- **Timestamp**: 2026-07-06
+- **Action**: Fixed operator-visibility bug where every operational
+  `show interfaces` variant EXCEPT `terse` failed to find a bondless reth
+  (no kernel netdev is named `reth0`). Root cause: `cfg.RethToPhysical()` /
+  the physical<->reth reverse map was built in EXACTLY ONE place — the terse
+  handler; every other path did a raw kernel-netdev lookup that could not
+  resolve a reth, so `show interfaces reth0` → "Not present",
+  `reth0 detail` → empty, `reth0 extensive` → "not found". Extracted the
+  terse map-building into a shared resolver `config.RethShowMaps` +
+  `LookupReth`/`LookupMember`/`RethShowUnits` (new `pkg/config/reth_show.go`,
+  dual-keyed Junos + kernel ifname). Taught the four text surfaces to
+  synthesize the reth aggregate over its local physical member (link
+  state/MAC from the member netdev, addresses/units from config) and to
+  annotate a physical member with its `aenet --> reth<N>.<unit>` aggregation:
+  CLI summary/detail/extensive (`pkg/cli/cli_show_interfaces.go`), the gRPC
+  `ShowInterfacesDetail` RPC + its ShowText detail/extensive twins
+  (`pkg/grpcapi/server_show_interfaces.go`,
+  `server_show_interfaces_text.go`). Refactored both terse handlers (CLI +
+  gRPC) to consume the same shared maps so they cannot drift again. Rendering
+  works when the member kernel device is absent (peer-owned member or a unit
+  test host) — mirrors terse's config-sourced addresses. Did NOT touch the
+  structured `GetInterfaces` RPC (#3460 fixed that surface separately). Added
+  RED-on-revert unit tests in pkg/cli + pkg/grpcapi (a 2-unit reth over member
+  ge-0/0/2); neutralizing `RethShowMaps` reproduces the exact issue symptoms
+  ("Not present"/"not found"/empty). Normal non-reth interface show verified
+  unchanged. `go build ./...` clean; gofmt clean;
+  `go test ./pkg/config/... ./pkg/cli/... ./pkg/grpcapi/...` green.
+- **File(s)**: pkg/config/reth_show.go (new),
+  pkg/cli/cli_show_interfaces.go, pkg/grpcapi/server_show_interfaces.go,
+  pkg/grpcapi/server_show_interfaces_text.go,
+  pkg/cli/cli_show_interfaces_reth_4328_test.go (new),
+  pkg/grpcapi/server_show_interfaces_reth_4328_test.go (new),
+  docs/junos-cli-reference.md
+
 ## 2026-07-06 — #4282 part (a): lock CoS-submit owner TX accounting (tx_packets/tx_bytes)
 
 - **Timestamp**: 2026-07-06

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -1511,6 +1511,16 @@ Physical interface: reth0, Enabled, Physical link is Up
   - Each counter: 6-space indent, name padded, colon, right-aligned number.
 - **Protocol blocks:** `Protocol inet, MTU: 1500` and `Protocol inet6, MTU: 1500`.
   - Address entries under each protocol.
+- **Bondless reth resolution (#4328):** a reth (`reth0`) has no kernel netdev
+  of its own, so `show interfaces reth0`, `show interfaces reth0 detail`, and
+  `... extensive` render the aggregate over its local physical member — link
+  state / MAC / counters from the member, addresses/units from config — with a
+  `Redundant-ethernet: aggregate over member <ge-...>` line naming the member.
+  A physical reth member queried by name shows its `aenet --> reth<N>.<unit>`
+  aggregation. Previously only `show interfaces terse` was reth-aware; the
+  other variants reported `Not present` / empty / `not found`. All four
+  surfaces (summary, detail, extensive, terse) now build the same reth maps via
+  `config.RethShowMaps` (CLI + gRPC) so they cannot drift again.
 
 ---
 

--- a/pkg/cli/cli_show_interfaces.go
+++ b/pkg/cli/cli_show_interfaces.go
@@ -194,7 +194,12 @@ func (c *CLI) showInterfaces(args []string) error {
 		group := physGroups[physName]
 
 		_, rethMember, isReth := rethMaps.LookupReth(physName)
-		kernelLookup := physName
+		// A config/zone-ref name is Junos-form ("ge-0/0/2") or an alias, while
+		// the kernel netdev is "ge-0-0-2" — resolve to the kernel ifname before
+		// the lookup so a valid non-reth interface does not render "Not present"
+		// (mirrors Server.GetInterfaces, #3460 / #4328 Copilot follow-up). A
+		// reth is resolved to its local physical member instead.
+		kernelLookup := cfg.ResolveKernelIfName(physName)
 		if isReth {
 			kernelLookup = config.LinuxIfName(rethMember)
 		}
@@ -251,10 +256,13 @@ func (c *CLI) showInterfaces(args []string) error {
 
 		linkType := "Ethernet"
 		var linkDetails []string
-		if speed := readLinkSpeed(physName); speed > 0 {
+		// Read speed/duplex from the resolved kernel device (#4341): the reth
+		// aggregate has no /sys/class/net/reth0, and a Junos-form physName has
+		// no sysfs entry either — kernelLookup is the real netdev.
+		if speed := readLinkSpeed(kernelLookup); speed > 0 {
 			linkDetails = append(linkDetails, "Speed: "+formatSpeed(speed))
 		}
-		if duplex := readLinkDuplex(physName); duplex != "" {
+		if duplex := readLinkDuplex(kernelLookup); duplex != "" {
 			linkDetails = append(linkDetails, "Link-mode: "+formatDuplex(duplex))
 		}
 		extra := ""
@@ -460,8 +468,8 @@ func (c *CLI) showInterfaces(args []string) error {
 
 // rethMemberLinkState returns the admin/link ("up"/"down") state for a reth's
 // physical member, best-effort from the kernel. When the device is absent (a
-// peer-owned member, or a test host with no such netdev) both are reported
-// "down"/absent — matching the terse handler (#4328).
+// peer-owned member, or a test host with no such netdev) admin stays "up" and
+// only link is reported "down" — matching the terse handler (#4328).
 func rethMemberLinkState(member string) (admin, link string) {
 	admin, link = "up", "up"
 	kernelIf := config.LinuxIfName(member)

--- a/pkg/cli/cli_show_interfaces.go
+++ b/pkg/cli/cli_show_interfaces.go
@@ -162,7 +162,20 @@ func (c *CLI) showInterfaces(args []string) error {
 		})
 	}
 
+	// #4328: a bondless reth has no kernel netdev of its own — resolve it to
+	// its local physical member so link state / MAC / counters come from the
+	// member while the logical name stays reth<N>. The addresses come from
+	// config (they live on the member's VLAN sub-interfaces, not on "reth0").
+	rethMaps := cfg.RethShowMaps()
+
+	// A physical reth member is not zoned, so it never appears in the
+	// zone-driven collection above. When the operator asks for one by name,
+	// render its aggregation membership (aenet --> reth<N>.<unit>) directly.
 	if len(logicals) == 0 && filterName != "" {
+		if rethName, ok := rethMaps.LookupMember(filterName); ok {
+			c.showInterfacesRethMemberSummary(cfg, filterName, rethName)
+			return nil
+		}
 		return fmt.Errorf("interface %s not found in configuration", filterName)
 	}
 
@@ -180,12 +193,18 @@ func (c *CLI) showInterfaces(args []string) error {
 	for _, physName := range physOrder {
 		group := physGroups[physName]
 
+		_, rethMember, isReth := rethMaps.LookupReth(physName)
+		kernelLookup := physName
+		if isReth {
+			kernelLookup = config.LinuxIfName(rethMember)
+		}
+
 		// Get netlink link for richer info
-		link, nlErr := netlink.LinkByName(physName)
+		link, nlErr := netlink.LinkByName(kernelLookup)
 
 		// Fallback to net.InterfaceByName if netlink fails
-		iface, stdErr := net.InterfaceByName(physName)
-		if stdErr != nil && nlErr != nil {
+		iface, stdErr := net.InterfaceByName(kernelLookup)
+		if stdErr != nil && nlErr != nil && !isReth {
 			fmt.Printf("Physical interface: %s, Not present\n\n", physName)
 			continue
 		}
@@ -211,6 +230,11 @@ func (c *CLI) showInterfaces(args []string) error {
 			physName, enabled, linkUp)
 		if ifCfg, ok := cfg.Interfaces.Interfaces[physName]; ok && ifCfg.Description != "" {
 			fmt.Printf("  Description: %s\n", ifCfg.Description)
+		}
+		if isReth {
+			// Name the local physical member backing this bondless reth so the
+			// operator can see which link carries the aggregate (#4328).
+			fmt.Printf("  Redundant-ethernet: aggregate over member %s\n", rethMember)
 		}
 
 		// Link-level details
@@ -367,45 +391,63 @@ func (c *CLI) showInterfaces(args []string) error {
 				}
 			}
 
-			// Addresses grouped by protocol
-			liface, err := net.InterfaceByName(lookupName)
-			if err != nil && iface != nil {
-				liface = iface
-			}
-			if liface != nil {
-				addrs, err := liface.Addrs()
-				if err == nil && len(addrs) > 0 {
-					var v4Addrs, v6Addrs []string
-					for _, addr := range addrs {
-						ipNet, ok := addr.(*net.IPNet)
-						if !ok {
+			// Addresses grouped by protocol. For a reth aggregate the addresses
+			// are configured on reth<N>.<unit> but the kernel carries them on the
+			// physical member's VLAN sub-interface, so read them from config
+			// (#4328). Normal interfaces read live addresses from the kernel.
+			var v4Addrs, v6Addrs []string
+			if isReth {
+				if unit != nil {
+					for _, addr := range unit.Addresses {
+						ip, _, perr := net.ParseCIDR(addr)
+						if perr != nil {
 							continue
 						}
-						ones, _ := ipNet.Mask.Size()
-						if ipNet.IP.To4() != nil {
-							v4Addrs = append(v4Addrs, fmt.Sprintf("%s/%d", ipNet.IP, ones))
+						if ip.To4() != nil {
+							v4Addrs = append(v4Addrs, addr)
 						} else {
-							v6Addrs = append(v6Addrs, fmt.Sprintf("%s/%d", ipNet.IP, ones))
+							v6Addrs = append(v6Addrs, addr)
 						}
 					}
-					if len(v4Addrs) > 0 {
-						fmt.Printf("    Protocol inet, MTU: %d\n", mtu)
-						for _, a := range v4Addrs {
-							fmt.Printf("      Addresses, Flags: Is-Preferred Is-Primary\n")
-							fmt.Printf("        Local: %s\n", a)
-						}
-					}
-					if len(v6Addrs) > 0 {
-						fmt.Printf("    Protocol inet6, MTU: %d\n", mtu)
-						for _, a := range v6Addrs {
-							flags := "Is-Preferred Is-Primary"
-							if strings.HasPrefix(a, "fe80:") {
-								flags = "Is-Preferred"
+				}
+			} else {
+				liface, err := net.InterfaceByName(lookupName)
+				if err != nil && iface != nil {
+					liface = iface
+				}
+				if liface != nil {
+					if addrs, err := liface.Addrs(); err == nil {
+						for _, addr := range addrs {
+							ipNet, ok := addr.(*net.IPNet)
+							if !ok {
+								continue
 							}
-							fmt.Printf("      Addresses, Flags: %s\n", flags)
-							fmt.Printf("        Local: %s\n", a)
+							ones, _ := ipNet.Mask.Size()
+							if ipNet.IP.To4() != nil {
+								v4Addrs = append(v4Addrs, fmt.Sprintf("%s/%d", ipNet.IP, ones))
+							} else {
+								v6Addrs = append(v6Addrs, fmt.Sprintf("%s/%d", ipNet.IP, ones))
+							}
 						}
 					}
+				}
+			}
+			if len(v4Addrs) > 0 {
+				fmt.Printf("    Protocol inet, MTU: %d\n", mtu)
+				for _, a := range v4Addrs {
+					fmt.Printf("      Addresses, Flags: Is-Preferred Is-Primary\n")
+					fmt.Printf("        Local: %s\n", a)
+				}
+			}
+			if len(v6Addrs) > 0 {
+				fmt.Printf("    Protocol inet6, MTU: %d\n", mtu)
+				for _, a := range v6Addrs {
+					flags := "Is-Preferred Is-Primary"
+					if strings.HasPrefix(a, "fe80:") {
+						flags = "Is-Preferred"
+					}
+					fmt.Printf("      Addresses, Flags: %s\n", flags)
+					fmt.Printf("        Local: %s\n", a)
 				}
 			}
 		}
@@ -414,6 +456,58 @@ func (c *CLI) showInterfaces(args []string) error {
 	}
 
 	return nil
+}
+
+// rethMemberLinkState returns the admin/link ("up"/"down") state for a reth's
+// physical member, best-effort from the kernel. When the device is absent (a
+// peer-owned member, or a test host with no such netdev) both are reported
+// "down"/absent — matching the terse handler (#4328).
+func rethMemberLinkState(member string) (admin, link string) {
+	admin, link = "up", "up"
+	kernelIf := config.LinuxIfName(member)
+	iface, err := net.InterfaceByName(kernelIf)
+	if err != nil {
+		return "up", "down"
+	}
+	if iface.Flags&net.FlagUp == 0 {
+		admin = "down"
+	}
+	if data, err := os.ReadFile("/sys/class/net/" + kernelIf + "/operstate"); err == nil {
+		if strings.TrimSpace(string(data)) != "up" {
+			link = "down"
+		}
+	}
+	return admin, link
+}
+
+// showInterfacesRethMemberSummary renders `show interfaces <member>` for a
+// physical reth member (which is not zoned and so never surfaces through the
+// zone-driven summary walk). It names the reth parent and lists the aggregated
+// logical units (aenet --> reth<N>.<unit>), mirroring the terse handler (#4328).
+func (c *CLI) showInterfacesRethMemberSummary(cfg *config.Config, member, reth string) {
+	admin, link := rethMemberLinkState(member)
+	enabled := "Enabled"
+	if admin == "down" {
+		enabled = "Disabled"
+	}
+	linkUp := "Up"
+	if link == "down" {
+		linkUp = "Down"
+	}
+	fmt.Printf("Physical interface: %s, %s, Physical link is %s\n", member, enabled, linkUp)
+	if ifCfg, ok := cfg.Interfaces.Interfaces[member]; ok && ifCfg.Description != "" {
+		fmt.Printf("  Description: %s\n", ifCfg.Description)
+	}
+	fmt.Printf("  Redundant-ethernet: member of %s\n", reth)
+	for _, ru := range cfg.RethShowUnits(reth) {
+		fmt.Printf("  Logical interface %s.%d", member, ru.Unit)
+		if ru.VlanID > 0 {
+			fmt.Printf(" VLAN-Tag [ 0x8100.%d ]", ru.VlanID)
+		}
+		fmt.Println()
+		fmt.Printf("    aenet --> %s.%d\n", reth, ru.Unit)
+	}
+	fmt.Println()
 }
 
 // dhcpLease returns the DHCP lease for an interface/family, or nil.
@@ -431,8 +525,15 @@ func (c *CLI) showInterfacesDetail(filterName string) error {
 	// Build zone + description lookup from active config
 	ifZoneMap := make(map[string]string)
 	ifDescMap := make(map[string]string)
-	if activeCfg := c.store.ActiveConfig(); activeCfg != nil {
-		for _, z := range activeCfg.Security.Zones {
+	cfg := c.store.ActiveConfig()
+	// #4328: reth resolution — a bondless reth has no kernel netdev, so the
+	// netlink walk below never emits it. Build the shared maps so a reth
+	// aggregate is synthesized from config and its physical members are
+	// annotated with their aenet aggregation.
+	var rethMaps config.RethShowMaps
+	if cfg != nil {
+		rethMaps = cfg.RethShowMaps()
+		for _, z := range cfg.Security.Zones {
 			if z == nil { // #3493: tolerant/HA-sync path may carry a nil zone value
 				continue
 			}
@@ -440,7 +541,7 @@ func (c *CLI) showInterfacesDetail(filterName string) error {
 				ifZoneMap[ifName] = z.Name
 			}
 		}
-		for _, ifc := range activeCfg.Interfaces.Interfaces {
+		for _, ifc := range cfg.Interfaces.Interfaces {
 			if ifc.Description != "" {
 				ifDescMap[ifc.Name] = ifc.Description
 			}
@@ -515,6 +616,16 @@ func (c *CLI) showInterfacesDetail(filterName string) error {
 			fmt.Printf("    Flags: %s\n", strings.Join(flags, " "))
 		}
 
+		// #4328: a physical reth member carries the reth's logical units as
+		// aenet aggregation — surface that membership here (terse already does).
+		if rethName, ok := rethMaps.LookupMember(attrs.Name); ok && cfg != nil {
+			fmt.Printf("    Redundant-ethernet: member of %s\n", rethName)
+			for _, ru := range cfg.RethShowUnits(rethName) {
+				fmt.Printf("    Logical interface %s.%d --> aenet %s.%d\n",
+					attrs.Name, ru.Unit, rethName, ru.Unit)
+			}
+		}
+
 		addrs, _ := netlink.AddrList(link, netlink.FAMILY_ALL)
 		if len(addrs) > 0 {
 			fmt.Println("    Addresses:")
@@ -535,10 +646,143 @@ func (c *CLI) showInterfacesDetail(filterName string) error {
 		}
 		fmt.Println()
 	}
+
+	// #4328: render bondless reth aggregates (no kernel netdev) and, when the
+	// filter names a reth member whose kernel device is absent, a synthetic
+	// member block. This runs after the netlink walk so an unfiltered
+	// `show interfaces detail` lists reths alongside the physical members.
+	if cfg != nil {
+		if c.showInterfacesRethDetail(cfg, rethMaps, filterName, found) {
+			found = true
+		}
+	}
+
 	if filterName != "" && !found {
 		fmt.Printf("Interface %s not found\n", filterName)
 	}
 	return nil
+}
+
+// baseIfName strips a dotted unit suffix ("reth0.50" -> "reth0").
+func baseIfName(name string) string {
+	if i := strings.IndexByte(name, '.'); i >= 0 {
+		return name[:i]
+	}
+	return name
+}
+
+// rethMemberAttrs returns the netlink attributes of a reth's physical member,
+// best-effort. ok is false when the member device is absent (peer-owned or a
+// test host) so callers render from config alone (#4328).
+func rethMemberAttrs(member string) (attrs *netlink.LinkAttrs, ok bool) {
+	link, err := netlink.LinkByName(config.LinuxIfName(member))
+	if err != nil {
+		return nil, false
+	}
+	return link.Attrs(), true
+}
+
+// showInterfacesRethDetail renders the `show interfaces ... detail` view for
+// bondless reth aggregates (which have no kernel netdev) and, when the filter
+// names a reth member whose kernel device is absent, a synthetic member block.
+// alreadyFound reports whether the netlink walk already rendered the filtered
+// interface (a real member device). Returns true when anything was rendered.
+func (c *CLI) showInterfacesRethDetail(cfg *config.Config, maps config.RethShowMaps, filterName string, alreadyFound bool) bool {
+	// Zone lookup keyed by logical ref (reth0.50 -> zone).
+	ifZone := make(map[string]string)
+	for _, z := range cfg.Security.Zones {
+		if z == nil {
+			continue
+		}
+		for _, ifName := range z.Interfaces {
+			ifZone[ifName] = z.Name
+		}
+	}
+
+	rendered := false
+	reths := make([]string, 0, len(maps.RethToPhys))
+	for reth := range maps.RethToPhys {
+		reths = append(reths, reth)
+	}
+	sort.Strings(reths)
+	for _, reth := range reths {
+		if filterName != "" && baseIfName(filterName) != reth {
+			continue
+		}
+		member := maps.RethToPhys[reth]
+		attrs, haveDev := rethMemberAttrs(member)
+		adminStr, linkStr := "Disabled", "Down"
+		mtu := 0
+		var hwAddr net.HardwareAddr
+		if haveDev {
+			if attrs.Flags&net.FlagUp != 0 {
+				adminStr = "Enabled"
+			}
+			if attrs.OperState == netlink.OperUp {
+				linkStr = "Up"
+			}
+			mtu = attrs.MTU
+			hwAddr = attrs.HardwareAddr
+		}
+		fmt.Printf("Physical interface: %s, %s, Physical link is %s\n", reth, adminStr, linkStr)
+		if ifc, ok := cfg.Interfaces.Interfaces[reth]; ok && ifc.Description != "" {
+			fmt.Printf("  Description: %s\n", ifc.Description)
+		}
+		fmt.Printf("  Redundant-ethernet: aggregate over member %s\n", member)
+		fmt.Printf("  Link-level type: Ethernet, MTU: %d\n", mtu)
+		if len(hwAddr) > 0 {
+			fmt.Printf("  Current address: %s\n", hwAddr)
+		}
+		for _, ru := range cfg.RethShowUnits(reth) {
+			fmt.Printf("  Logical interface %s.%d", reth, ru.Unit)
+			if ru.VlanID > 0 {
+				fmt.Printf(" VLAN-Tag [ 0x8100.%d ]", ru.VlanID)
+			}
+			fmt.Println()
+			if zone, ok := ifZone[fmt.Sprintf("%s.%d", reth, ru.Unit)]; ok {
+				fmt.Printf("    Security zone: %s\n", zone)
+			}
+			if len(ru.V4Addrs) > 0 || len(ru.V6Addrs) > 0 {
+				fmt.Println("    Addresses:")
+				for _, a := range ru.V4Addrs {
+					fmt.Printf("      %s\n", a)
+				}
+				for _, a := range ru.V6Addrs {
+					fmt.Printf("      %s\n", a)
+				}
+			}
+		}
+		fmt.Println()
+		rendered = true
+	}
+
+	// A reth member whose kernel device is absent never surfaces through the
+	// netlink walk; render its aenet membership synthetically so the filtered
+	// lookup is not empty.
+	if !alreadyFound && !rendered && filterName != "" {
+		if reth, ok := maps.LookupMember(filterName); ok {
+			member := baseIfName(filterName)
+			admin, link := rethMemberLinkState(member)
+			adminStr, linkStr := "Enabled", "Up"
+			if admin == "down" {
+				adminStr = "Disabled"
+			}
+			if link == "down" {
+				linkStr = "Down"
+			}
+			fmt.Printf("Physical interface: %s, %s, Physical link is %s\n", member, adminStr, linkStr)
+			if ifc, ok := cfg.Interfaces.Interfaces[member]; ok && ifc.Description != "" {
+				fmt.Printf("  Description: %s\n", ifc.Description)
+			}
+			fmt.Printf("  Redundant-ethernet: member of %s\n", reth)
+			for _, ru := range cfg.RethShowUnits(reth) {
+				fmt.Printf("  Logical interface %s.%d --> aenet %s.%d\n", member, ru.Unit, reth, ru.Unit)
+			}
+			fmt.Println()
+			rendered = true
+		}
+	}
+	return rendered
 }
 
 func (c *CLI) showInterfacesTerse() error {
@@ -548,14 +792,11 @@ func (c *CLI) showInterfacesTerse() error {
 		return nil
 	}
 
-	// Build RETH mappings
-	physToReth := make(map[string]string) // physical member → reth parent
-	rethToPhys := cfg.RethToPhysical()    // reth → physical member
-	for _, ifCfg := range cfg.Interfaces.Interfaces {
-		if ifCfg.RedundantParent != "" {
-			physToReth[ifCfg.Name] = ifCfg.RedundantParent
-		}
-	}
+	// Build RETH mappings (shared resolver, #4328 — the same maps back the
+	// summary/detail/extensive paths so they can never drift from terse again).
+	rethMaps := cfg.RethShowMaps()
+	physToReth := rethMaps.PhysToReth // physical member → reth parent
+	rethToPhys := rethMaps.RethToPhys // reth → physical member
 
 	type ifUnit struct {
 		physName string
@@ -870,8 +1111,13 @@ func (c *CLI) showInterfacesExtensiveFiltered(filterName string) error {
 	ifZoneMap := make(map[string]string)
 	ifDescMap := make(map[string]string)
 	ifCfgMap := make(map[string]*config.InterfaceConfig)
-	if activeCfg := c.store.ActiveConfig(); activeCfg != nil {
-		for _, z := range activeCfg.Security.Zones {
+	cfg := c.store.ActiveConfig()
+	// #4328: reth resolution — synthesize bondless reth aggregates (no kernel
+	// netdev) and annotate physical members with their aenet aggregation.
+	var rethMaps config.RethShowMaps
+	if cfg != nil {
+		rethMaps = cfg.RethShowMaps()
+		for _, z := range cfg.Security.Zones {
 			if z == nil { // #3493: tolerant/HA-sync path may carry a nil zone value
 				continue
 			}
@@ -879,7 +1125,7 @@ func (c *CLI) showInterfacesExtensiveFiltered(filterName string) error {
 				ifZoneMap[ifName] = z.Name
 			}
 		}
-		for _, ifc := range activeCfg.Interfaces.Interfaces {
+		for _, ifc := range cfg.Interfaces.Interfaces {
 			ifCfgMap[ifc.Name] = ifc
 			if ifc.Description != "" {
 				ifDescMap[ifc.Name] = ifc.Description
@@ -887,6 +1133,7 @@ func (c *CLI) showInterfacesExtensiveFiltered(filterName string) error {
 		}
 	}
 
+	found := false
 	for _, link := range links {
 		attrs := link.Attrs()
 		if attrs.Name == "lo" {
@@ -895,6 +1142,7 @@ func (c *CLI) showInterfacesExtensiveFiltered(filterName string) error {
 		if filterName != "" && attrs.Name != filterName {
 			continue
 		}
+		found = true
 
 		// State
 		adminUp := attrs.Flags&net.FlagUp != 0
@@ -913,6 +1161,14 @@ func (c *CLI) showInterfacesExtensiveFiltered(filterName string) error {
 		}
 		if zone, ok := ifZoneMap[attrs.Name]; ok {
 			fmt.Printf("  Security zone: %s\n", zone)
+		}
+		// #4328: annotate a physical reth member with its aenet aggregation.
+		if rethName, ok := rethMaps.LookupMember(attrs.Name); ok && cfg != nil {
+			fmt.Printf("  Redundant-ethernet: member of %s\n", rethName)
+			for _, ru := range cfg.RethShowUnits(rethName) {
+				fmt.Printf("  Logical interface %s.%d --> aenet %s.%d\n",
+					attrs.Name, ru.Unit, rethName, ru.Unit)
+			}
 		}
 		if ifCfg, ok := ifCfgMap[attrs.Name]; ok {
 			if ifCfg.Speed != "" {
@@ -1020,6 +1276,12 @@ func (c *CLI) showInterfacesExtensiveFiltered(filterName string) error {
 			}
 		}
 		fmt.Println()
+	}
+
+	// #4328: bondless reth aggregates + absent-device members (see the detail
+	// path). The extensive view reuses the same synthesized block.
+	if cfg != nil {
+		c.showInterfacesRethDetail(cfg, rethMaps, filterName, found)
 	}
 	return nil
 }

--- a/pkg/cli/cli_show_interfaces_reth_4328_test.go
+++ b/pkg/cli/cli_show_interfaces_reth_4328_test.go
@@ -1,0 +1,200 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #4328: every operational `show interfaces` variant EXCEPT `terse` failed to
+// resolve a bondless reth — the reth has no kernel netdev of its own (no link
+// is named "reth0"), and only the terse handler built the physical<->reth maps
+// from cfg.RethToPhysical(). `show interfaces reth0` printed
+// "Physical interface: reth0, Not present"; `... detail` was empty;
+// `... extensive` said "not found". These golden tests assert the summary,
+// detail, and extensive paths now render the aggregate over its physical
+// member, and that a member surfaces its aenet aggregation.
+//
+// RED-on-revert: routing any of these back through the raw kernel-netdev
+// lookup (no RethShowMaps resolution) drops the reth block entirely — the
+// member name and the config addresses vanish, failing the assertions.
+
+func rethShowCLI(t *testing.T) *CLI {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+interfaces {
+    ge-0/0/2 {
+        gigether-options { redundant-parent reth0; }
+    }
+    reth0 {
+        vlan-tagging;
+        unit 50 {
+            vlan-id 50;
+            family inet { address 172.16.50.8/24; }
+            family inet6 { address 2001:559:8585:50::8/64; }
+        }
+        unit 80 {
+            vlan-id 80;
+            family inet { address 172.16.80.8/24; }
+        }
+    }
+    ge-0/0/9 {
+        unit 0 { family inet { address 10.20.30.40/24; } }
+    }
+}
+security {
+    zones {
+        security-zone wan {
+            interfaces { reth0.50; reth0.80; }
+        }
+        security-zone trust {
+            interfaces { ge-0/0/9.0; }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return &CLI{store: store} // dp nil: exercise the display walk only
+}
+
+func TestShowInterfacesRethSummary4328(t *testing.T) {
+	c := rethShowCLI(t)
+	out := captureStdout(t, func() {
+		if err := c.showInterfaces([]string{"reth0"}); err != nil {
+			t.Fatalf("showInterfaces(reth0): %v", err)
+		}
+	})
+	if strings.Contains(out, "Not present") {
+		t.Errorf("reth0 summary still reports Not present:\n%s", out)
+	}
+	for _, want := range []string{
+		"Physical interface: reth0",
+		"ge-0/0/2",       // names the resolved physical member (RED on revert)
+		"172.16.50.8/24", // reth0.50 config address
+		"172.16.80.8/24", // reth0.80 config address
+		"2001:559:8585:50::8/64",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("reth0 summary missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestShowInterfacesRethSummaryUnit4328(t *testing.T) {
+	c := rethShowCLI(t)
+	out := captureStdout(t, func() {
+		if err := c.showInterfaces([]string{"reth0.50"}); err != nil {
+			t.Fatalf("showInterfaces(reth0.50): %v", err)
+		}
+	})
+	if strings.TrimSpace(out) == "" || strings.Contains(out, "Not present") {
+		t.Fatalf("reth0.50 summary empty / Not present:\n%s", out)
+	}
+	for _, want := range []string{"reth0.50", "ge-0/0/2", "172.16.50.8/24"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("reth0.50 summary missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestShowInterfacesRethDetail4328(t *testing.T) {
+	c := rethShowCLI(t)
+	out := captureStdout(t, func() {
+		if err := c.showInterfacesDetail("reth0"); err != nil {
+			t.Fatalf("showInterfacesDetail(reth0): %v", err)
+		}
+	})
+	if strings.TrimSpace(out) == "" || strings.Contains(out, "not found") {
+		t.Fatalf("reth0 detail empty / not found:\n%s", out)
+	}
+	for _, want := range []string{
+		"Physical interface: reth0",
+		"aggregate over member ge-0/0/2",
+		"172.16.50.8/24",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("reth0 detail missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestShowInterfacesRethExtensive4328(t *testing.T) {
+	c := rethShowCLI(t)
+	out := captureStdout(t, func() {
+		if err := c.showInterfacesExtensiveFiltered("reth0"); err != nil {
+			t.Fatalf("showInterfacesExtensiveFiltered(reth0): %v", err)
+		}
+	})
+	if strings.TrimSpace(out) == "" {
+		t.Fatalf("reth0 extensive empty:\n%s", out)
+	}
+	for _, want := range []string{"Physical interface: reth0", "ge-0/0/2", "172.16.50.8/24"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("reth0 extensive missing %q\n%s", want, out)
+		}
+	}
+}
+
+// A physical reth member surfaces its aenet aggregation on the detail path.
+func TestShowInterfacesRethMemberDetail4328(t *testing.T) {
+	c := rethShowCLI(t)
+	out := captureStdout(t, func() {
+		if err := c.showInterfacesDetail("ge-0-0-2"); err != nil {
+			t.Fatalf("showInterfacesDetail(ge-0-0-2): %v", err)
+		}
+	})
+	if strings.Contains(out, "not found") || strings.TrimSpace(out) == "" {
+		t.Fatalf("member detail empty / not found:\n%s", out)
+	}
+	for _, want := range []string{
+		"member of reth0",
+		"aenet reth0.50",
+		"aenet reth0.80",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("member detail missing %q\n%s", want, out)
+		}
+	}
+}
+
+// The summary path names the reth parent for a physical member queried by name.
+func TestShowInterfacesRethMemberSummary4328(t *testing.T) {
+	c := rethShowCLI(t)
+	out := captureStdout(t, func() {
+		if err := c.showInterfaces([]string{"ge-0/0/2"}); err != nil {
+			t.Fatalf("showInterfaces(ge-0/0/2): %v", err)
+		}
+	})
+	for _, want := range []string{"member of reth0", "aenet --> reth0.50"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("member summary missing %q\n%s", want, out)
+		}
+	}
+}
+
+// A normal (non-reth) interface must render exactly as before — no reth
+// annotations, and the absent-device path still reports "Not present" (this
+// test host has no ge-0-0-9). Guards against the reth branch leaking into the
+// normal path.
+func TestShowInterfacesNormalUnchanged4328(t *testing.T) {
+	c := rethShowCLI(t)
+	out := captureStdout(t, func() {
+		if err := c.showInterfaces([]string{"ge-0/0/9"}); err != nil {
+			t.Fatalf("showInterfaces(ge-0/0/9): %v", err)
+		}
+	})
+	if !strings.Contains(out, "ge-0/0/9") {
+		t.Errorf("normal interface missing its own name:\n%s", out)
+	}
+	if strings.Contains(out, "Redundant-ethernet") || strings.Contains(out, "aenet") {
+		t.Errorf("normal interface leaked reth annotations:\n%s", out)
+	}
+}

--- a/pkg/cli/cli_show_interfaces_reth_4328_test.go
+++ b/pkg/cli/cli_show_interfaces_reth_4328_test.go
@@ -1,10 +1,35 @@
 package cli
 
 import (
+	"net"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
 )
+
+// dashNamedKernelIface finds a real host interface whose kernel name contains a
+// '-' and round-trips through LinuxIfName from its slash form, so a config name
+// authored in Junos form ("bpfrx/wan") resolves to a real netdev
+// ("bpfrx-wan"). Returns (junosName, kernelName, true) or skips.
+func dashNamedKernelIface(t *testing.T) (junos, kernel string, ok bool) {
+	t.Helper()
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", "", false
+	}
+	for _, in := range ifaces {
+		if in.Name == "lo" || !strings.Contains(in.Name, "-") || strings.Contains(in.Name, "/") {
+			continue
+		}
+		j := strings.ReplaceAll(in.Name, "-", "/")
+		if config.LinuxIfName(j) == in.Name {
+			return j, in.Name, true
+		}
+	}
+	return "", "", false
+}
 
 // #4328: every operational `show interfaces` variant EXCEPT `terse` failed to
 // resolve a bondless reth — the reth has no kernel netdev of its own (no link
@@ -177,6 +202,47 @@ func TestShowInterfacesRethMemberSummary4328(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("member summary missing %q\n%s", want, out)
 		}
+	}
+}
+
+// A NON-reth interface authored in Junos slash form ("bpfrx/wan") must resolve
+// to its kernel netdev ("bpfrx-wan") — the raw config-name lookup returned
+// "Not present" for a valid interface (#4328 Copilot follow-up; the same class
+// of name-resolution gap #3460 fixed for the structured GetInterfaces RPC).
+//
+// RED-on-revert: routing the summary lookup back through the raw `physName`
+// (LinkByName("bpfrx/wan") — no such kernel device) prints "Not present".
+func TestShowInterfacesNonRethKernelName4328(t *testing.T) {
+	junos, kernel, ok := dashNamedKernelIface(t)
+	if !ok {
+		t.Skip("no dash-named host interface available to exercise slash->kernel resolution")
+	}
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+interfaces {
+    ` + junos + ` { unit 0 { family inet { address 10.9.9.9/24; } } }
+}
+security { zones { security-zone z { interfaces { ` + junos + `.0; } } } }
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	c := &CLI{store: store}
+	out := captureStdout(t, func() {
+		if err := c.showInterfaces([]string{junos}); err != nil {
+			t.Fatalf("showInterfaces(%s): %v", junos, err)
+		}
+	})
+	if strings.Contains(out, "Not present") {
+		t.Errorf("valid interface %s (kernel %s) rendered Not present:\n%s", junos, kernel, out)
+	}
+	if !strings.Contains(out, junos) {
+		t.Errorf("summary missing interface name %s:\n%s", junos, out)
 	}
 }
 

--- a/pkg/config/reth_show.go
+++ b/pkg/config/reth_show.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"net"
+	"sort"
+	"strings"
+)
+
+// Shared RETH resolution for the `show interfaces` text surfaces (#4328).
+//
+// A bondless reth (VRRP on the physical member interfaces, no kernel bond
+// device) has NO kernel netdev of its own — nothing is named "reth0". Only the
+// `terse` handler resolved this, by building the physical<->reth maps from
+// cfg.RethToPhysical(); every other operational path (`show interfaces reth0`,
+// `... detail`, `... extensive`) did a raw kernel-netdev lookup that could not
+// succeed for a reth and rendered "Not present" / empty / "not found". This
+// file folds the map-building out of the terse handler so terse, summary,
+// detail, and extensive all classify a reth identically and can never drift
+// again.
+
+// RethShowMaps bundles the two reth lookup directions the `show interfaces`
+// text surfaces need.
+type RethShowMaps struct {
+	// PhysToReth maps a physical redundant-ether member to its reth parent.
+	// Keyed by BOTH the Junos config name ("ge-0/0/2") and the Linux/kernel
+	// name ("ge-0-0-2") so a caller that starts from a kernel ifname (the
+	// detail / extensive netlink.LinkList walk) resolves as readily as one
+	// that starts from a config name (the terse / summary walk).
+	PhysToReth map[string]string
+	// RethToPhys maps a reth aggregate to its LOCAL physical member, in Junos
+	// name form (as RethToPhysical returns). reth names carry no slash, so no
+	// dual-keying is required.
+	RethToPhys map[string]string
+}
+
+// RethShowMaps builds the reth lookup maps for a `show interfaces` surface.
+// The returned maps are freshly allocated, so a caller may add peer-node
+// members to PhysToReth (the terse cluster path does this) without mutating
+// shared state.
+func (c *Config) RethShowMaps() RethShowMaps {
+	physToReth := make(map[string]string)
+	for _, ifc := range c.Interfaces.Interfaces {
+		if ifc == nil || ifc.RedundantParent == "" {
+			continue
+		}
+		physToReth[ifc.Name] = ifc.RedundantParent
+		if ln := LinuxIfName(ifc.Name); ln != ifc.Name {
+			physToReth[ln] = ifc.RedundantParent
+		}
+	}
+	return RethShowMaps{PhysToReth: physToReth, RethToPhys: c.RethToPhysical()}
+}
+
+// rethShowBase strips a dotted unit suffix ("reth0.50" -> "reth0").
+func rethShowBase(name string) string {
+	if i := strings.IndexByte(name, '.'); i >= 0 {
+		return name[:i]
+	}
+	return name
+}
+
+// LookupReth reports whether name (or its base before ".") is a reth aggregate
+// and, if so, returns the reth parent name and its local physical member
+// (Junos name form — LinuxIfName it before a kernel lookup).
+func (m RethShowMaps) LookupReth(name string) (reth, physMember string, ok bool) {
+	base := rethShowBase(name)
+	if phys, found := m.RethToPhys[base]; found {
+		return base, phys, true
+	}
+	return "", "", false
+}
+
+// LookupMember reports whether name (or its base, in Junos or kernel form) is a
+// physical reth member and, if so, returns its reth parent name.
+func (m RethShowMaps) LookupMember(name string) (reth string, ok bool) {
+	base := rethShowBase(name)
+	reth, ok = m.PhysToReth[base]
+	return reth, ok
+}
+
+// RethShowUnit is one logical unit of a reth aggregate resolved for display:
+// its unit number, VLAN tag, and configured addresses split by family. The
+// addresses come from config because the reth has no kernel netdev — the
+// kernel addresses live on the physical member's VLAN sub-interfaces.
+type RethShowUnit struct {
+	Unit    int
+	VlanID  int
+	V4Addrs []string
+	V6Addrs []string
+}
+
+// RethShowUnits returns reth's logical units sorted by unit number, with the
+// configured addresses split into v4/v6, for a `show interfaces` surface.
+// Returns nil when reth is not a configured aggregate. Shared so every surface
+// orders units and splits addresses identically.
+func (c *Config) RethShowUnits(reth string) []RethShowUnit {
+	ifc, ok := c.Interfaces.Interfaces[reth]
+	if !ok || ifc == nil {
+		return nil
+	}
+	out := make([]RethShowUnit, 0, len(ifc.Units))
+	for num, unit := range ifc.Units {
+		if unit == nil {
+			continue
+		}
+		ru := RethShowUnit{Unit: num, VlanID: unit.VlanID}
+		for _, addr := range unit.Addresses {
+			ip, _, err := net.ParseCIDR(addr)
+			if err != nil {
+				continue
+			}
+			if ip.To4() != nil {
+				ru.V4Addrs = append(ru.V4Addrs, addr)
+			} else {
+				ru.V6Addrs = append(ru.V6Addrs, addr)
+			}
+		}
+		out = append(out, ru)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Unit < out[j].Unit })
+	return out
+}

--- a/pkg/grpcapi/server_show_interfaces.go
+++ b/pkg/grpcapi/server_show_interfaces.go
@@ -157,7 +157,12 @@ func (s *Server) ShowInterfacesDetail(_ context.Context, req *pb.ShowInterfacesD
 		group := physGroups[physName]
 
 		_, rethMember, isReth := rethMaps.LookupReth(physName)
-		kernelLookup := physName
+		// A config/zone-ref name is Junos-form ("ge-0/0/2") or an alias, while
+		// the kernel netdev is "ge-0-0-2" — resolve to the kernel ifname before
+		// the lookup so a valid non-reth interface does not render "Not present"
+		// (mirrors GetInterfaces, #3460 / #4328 Copilot follow-up). A reth is
+		// resolved to its local physical member instead.
+		kernelLookup := cfg.ResolveKernelIfName(physName)
 		if isReth {
 			kernelLookup = config.LinuxIfName(rethMember)
 		}

--- a/pkg/grpcapi/server_show_interfaces.go
+++ b/pkg/grpcapi/server_show_interfaces.go
@@ -126,7 +126,18 @@ func (s *Server) ShowInterfacesDetail(_ context.Context, req *pb.ShowInterfacesD
 		})
 	}
 
+	// #4328: a bondless reth has no kernel netdev of its own — resolve it to
+	// its local physical member for link state / MAC / counters, while the
+	// logical name stays reth<N> and its addresses come from config. A reth
+	// member is not zoned, so it never surfaces through the zone walk above —
+	// render its aenet aggregation directly when asked for by name.
+	rethMaps := cfg.RethShowMaps()
 	if len(logicals) == 0 && filterName != "" {
+		if rethName, ok := rethMaps.LookupMember(filterName); ok {
+			var mb strings.Builder
+			writeRethMemberSummary(&mb, cfg, baseIfName(filterName), rethName)
+			return &pb.ShowInterfacesDetailResponse{Output: mb.String()}, nil
+		}
 		return &pb.ShowInterfacesDetailResponse{Output: fmt.Sprintf("interface %s not found in configuration\n", filterName)}, nil
 	}
 
@@ -145,23 +156,31 @@ func (s *Server) ShowInterfacesDetail(_ context.Context, req *pb.ShowInterfacesD
 	for _, physName := range physOrder {
 		group := physGroups[physName]
 
-		iface, ifErr := net.InterfaceByName(physName)
-		if ifErr != nil {
+		_, rethMember, isReth := rethMaps.LookupReth(physName)
+		kernelLookup := physName
+		if isReth {
+			kernelLookup = config.LinuxIfName(rethMember)
+		}
+
+		iface, ifErr := net.InterfaceByName(kernelLookup)
+		if ifErr != nil && !isReth {
 			fmt.Fprintf(&buf, "Physical interface: %s, Not present\n\n", physName)
 			continue
 		}
 
-		// Determine link state
+		// Determine link state (best-effort from the resolved kernel device).
 		linkUp := "Down"
 		enabled := "Enabled"
-		if iface.Flags&net.FlagUp != 0 {
-			linkUp = "Up"
-		}
-		if iface.Flags&net.FlagUp == 0 {
-			enabled = "Disabled"
+		if iface != nil {
+			if iface.Flags&net.FlagUp != 0 {
+				linkUp = "Up"
+			}
+			if iface.Flags&net.FlagUp == 0 {
+				enabled = "Disabled"
+			}
 		}
 		// Try /sys/class/net for operstate
-		if data, err := os.ReadFile("/sys/class/net/" + physName + "/operstate"); err == nil {
+		if data, err := os.ReadFile("/sys/class/net/" + kernelLookup + "/operstate"); err == nil {
 			state := strings.TrimSpace(string(data))
 			if state == "up" {
 				linkUp = "Up"
@@ -171,6 +190,9 @@ func (s *Server) ShowInterfacesDetail(_ context.Context, req *pb.ShowInterfacesD
 		}
 
 		fmt.Fprintf(&buf, "Physical interface: %s, %s, Physical link is %s\n", physName, enabled, linkUp)
+		if isReth {
+			fmt.Fprintf(&buf, "  Redundant-ethernet: aggregate over member %s\n", rethMember)
+		}
 
 		// Show interface description and configured speed/duplex from config
 		if ifCfg, ok := cfg.Interfaces.Interfaces[physName]; ok {
@@ -186,10 +208,13 @@ func (s *Server) ShowInterfacesDetail(_ context.Context, req *pb.ShowInterfacesD
 		}
 
 		// Link-level details
-		mtu := iface.MTU
+		mtu := 0
+		if iface != nil {
+			mtu = iface.MTU
+		}
 		linkType := "Ethernet"
 		var linkExtras []string
-		if raw, err := os.ReadFile("/sys/class/net/" + physName + "/speed"); err == nil {
+		if raw, err := os.ReadFile("/sys/class/net/" + kernelLookup + "/speed"); err == nil {
 			var mbps int
 			if _, err := fmt.Sscanf(strings.TrimSpace(string(raw)), "%d", &mbps); err == nil && mbps > 0 {
 				if mbps >= 1000 {
@@ -199,7 +224,7 @@ func (s *Server) ShowInterfacesDetail(_ context.Context, req *pb.ShowInterfacesD
 				}
 			}
 		}
-		if raw, err := os.ReadFile("/sys/class/net/" + physName + "/duplex"); err == nil {
+		if raw, err := os.ReadFile("/sys/class/net/" + kernelLookup + "/duplex"); err == nil {
 			d := strings.TrimSpace(string(raw))
 			if d == "full" {
 				linkExtras = append(linkExtras, "Link-mode: Full-duplex")
@@ -213,7 +238,7 @@ func (s *Server) ShowInterfacesDetail(_ context.Context, req *pb.ShowInterfacesD
 		}
 		fmt.Fprintf(&buf, "  Link-level type: %s, MTU: %d%s\n", linkType, mtu, speedStr)
 
-		if len(iface.HardwareAddr) > 0 {
+		if iface != nil && len(iface.HardwareAddr) > 0 {
 			fmt.Fprintf(&buf, "  Current address: %s, Hardware address: %s\n", iface.HardwareAddr, iface.HardwareAddr)
 		}
 
@@ -234,10 +259,10 @@ func (s *Server) ShowInterfacesDetail(_ context.Context, req *pb.ShowInterfacesD
 		}
 
 		// Kernel link statistics via /sys/class/net
-		s.writeKernelStats(&buf, physName)
+		s.writeKernelStats(&buf, kernelLookup)
 
 		// BPF traffic counters
-		if s.dp != nil && s.dp.IsLoaded() {
+		if s.dp != nil && s.dp.IsLoaded() && iface != nil {
 			if ctrs, err := s.dp.ReadInterfaceCounters(iface.Index); err == nil && (ctrs.RxPackets > 0 || ctrs.TxPackets > 0) {
 				fmt.Fprintln(&buf, "  BPF statistics:")
 				fmt.Fprintf(&buf, "    Input:  %d packets, %d bytes\n", ctrs.RxPackets, ctrs.RxBytes)
@@ -317,45 +342,63 @@ func (s *Server) ShowInterfacesDetail(_ context.Context, req *pb.ShowInterfacesD
 				}
 			}
 
-			// Addresses grouped by protocol
-			liface, _ := net.InterfaceByName(lookupName)
-			if liface == nil {
-				liface = iface
-			}
-			if liface != nil {
-				addrs, err := liface.Addrs()
-				if err == nil && len(addrs) > 0 {
-					var v4Addrs, v6Addrs []string
-					for _, addr := range addrs {
-						a := addr.String()
-						ip, _, err := net.ParseCIDR(a)
-						if err != nil {
+			// Addresses grouped by protocol. For a reth aggregate the addresses
+			// live on the physical member's VLAN sub-interface, not on "reth0",
+			// so read them from config (#4328). Normal interfaces read live
+			// addresses from the kernel.
+			var v4Addrs, v6Addrs []string
+			if isReth {
+				if unit != nil {
+					for _, addr := range unit.Addresses {
+						ip, _, perr := net.ParseCIDR(addr)
+						if perr != nil {
 							continue
 						}
 						if ip.To4() != nil {
-							v4Addrs = append(v4Addrs, a)
+							v4Addrs = append(v4Addrs, addr)
 						} else {
-							v6Addrs = append(v6Addrs, a)
+							v6Addrs = append(v6Addrs, addr)
 						}
 					}
-					if len(v4Addrs) > 0 {
-						fmt.Fprintf(&buf, "    Protocol inet, MTU: %d\n", mtu)
-						for _, a := range v4Addrs {
-							fmt.Fprintln(&buf, "      Addresses, Flags: Is-Preferred Is-Primary")
-							fmt.Fprintf(&buf, "        Local: %s\n", a)
-						}
-					}
-					if len(v6Addrs) > 0 {
-						fmt.Fprintf(&buf, "    Protocol inet6, MTU: %d\n", mtu)
-						for _, a := range v6Addrs {
-							fl := "Is-Preferred Is-Primary"
-							if strings.HasPrefix(a, "fe80:") {
-								fl = "Is-Preferred"
+				}
+			} else {
+				liface, _ := net.InterfaceByName(lookupName)
+				if liface == nil {
+					liface = iface
+				}
+				if liface != nil {
+					if addrs, err := liface.Addrs(); err == nil {
+						for _, addr := range addrs {
+							a := addr.String()
+							ip, _, err := net.ParseCIDR(a)
+							if err != nil {
+								continue
 							}
-							fmt.Fprintf(&buf, "      Addresses, Flags: %s\n", fl)
-							fmt.Fprintf(&buf, "        Local: %s\n", a)
+							if ip.To4() != nil {
+								v4Addrs = append(v4Addrs, a)
+							} else {
+								v6Addrs = append(v6Addrs, a)
+							}
 						}
 					}
+				}
+			}
+			if len(v4Addrs) > 0 {
+				fmt.Fprintf(&buf, "    Protocol inet, MTU: %d\n", mtu)
+				for _, a := range v4Addrs {
+					fmt.Fprintln(&buf, "      Addresses, Flags: Is-Preferred Is-Primary")
+					fmt.Fprintf(&buf, "        Local: %s\n", a)
+				}
+			}
+			if len(v6Addrs) > 0 {
+				fmt.Fprintf(&buf, "    Protocol inet6, MTU: %d\n", mtu)
+				for _, a := range v6Addrs {
+					fl := "Is-Preferred Is-Primary"
+					if strings.HasPrefix(a, "fe80:") {
+						fl = "Is-Preferred"
+					}
+					fmt.Fprintf(&buf, "      Addresses, Flags: %s\n", fl)
+					fmt.Fprintf(&buf, "        Local: %s\n", a)
 				}
 			}
 		}
@@ -378,14 +421,11 @@ func (s *Server) showInterfacesTerse(cfg *config.Config, filterName string) (*pb
 		}
 	}
 
-	// Build RETH mappings
-	physToReth := make(map[string]string) // physical member → reth parent
-	rethToPhys := cfg.RethToPhysical()    // reth → physical member
-	for _, ifCfg := range cfg.Interfaces.Interfaces {
-		if ifCfg.RedundantParent != "" {
-			physToReth[ifCfg.Name] = ifCfg.RedundantParent
-		}
-	}
+	// Build RETH mappings (shared resolver, #4328 — the same maps back the
+	// summary/detail/extensive paths so they can never drift from terse again).
+	rethMaps := cfg.RethShowMaps()
+	physToReth := rethMaps.PhysToReth // physical member → reth parent
+	rethToPhys := rethMaps.RethToPhys // reth → physical member
 
 	// Collect all configured interfaces with units
 	type ifUnit struct {
@@ -754,4 +794,137 @@ func (s *Server) writeKernelStats(buf *strings.Builder, ifaceName string) {
 	if rxDrop > 0 || txDrop > 0 {
 		fmt.Fprintf(buf, "  Drops          : %d input, %d output\n", rxDrop, txDrop)
 	}
+}
+
+// --- #4328: shared reth rendering helpers for the gRPC text surfaces ---
+
+// baseIfName strips a dotted unit suffix ("reth0.50" -> "reth0").
+func baseIfName(name string) string {
+	if i := strings.IndexByte(name, '.'); i >= 0 {
+		return name[:i]
+	}
+	return name
+}
+
+// rethMemberKernelState returns admin/link ("up"/"down") for a reth's physical
+// member, best-effort from the kernel (down when the device is absent — a
+// peer-owned member or a test host), mirroring the terse handler (#4328).
+func rethMemberKernelState(member string) (admin, link string) {
+	admin, link = "up", "up"
+	kernelIf := config.LinuxIfName(member)
+	iface, err := net.InterfaceByName(kernelIf)
+	if err != nil {
+		return "up", "down"
+	}
+	if iface.Flags&net.FlagUp == 0 {
+		admin = "down"
+	}
+	if data, err := os.ReadFile("/sys/class/net/" + kernelIf + "/operstate"); err == nil {
+		if strings.TrimSpace(string(data)) != "up" {
+			link = "down"
+		}
+	}
+	return admin, link
+}
+
+// writeRethMemberSummary renders `show interfaces <member>` for a physical reth
+// member (not zoned, so absent from the zone-driven walk): it names the reth
+// parent and lists the aggregated logical units (aenet --> reth<N>.<unit>) (#4328).
+func writeRethMemberSummary(buf *strings.Builder, cfg *config.Config, member, reth string) {
+	admin, link := rethMemberKernelState(member)
+	enabled := "Enabled"
+	if admin == "down" {
+		enabled = "Disabled"
+	}
+	linkUp := "Up"
+	if link == "down" {
+		linkUp = "Down"
+	}
+	fmt.Fprintf(buf, "Physical interface: %s, %s, Physical link is %s\n", member, enabled, linkUp)
+	if ifc, ok := cfg.Interfaces.Interfaces[member]; ok && ifc.Description != "" {
+		fmt.Fprintf(buf, "  Description: %s\n", ifc.Description)
+	}
+	fmt.Fprintf(buf, "  Redundant-ethernet: member of %s\n", reth)
+	for _, ru := range cfg.RethShowUnits(reth) {
+		fmt.Fprintf(buf, "  Logical interface %s.%d", member, ru.Unit)
+		if ru.VlanID > 0 {
+			fmt.Fprintf(buf, " VLAN-Tag [ 0x8100.%d ]", ru.VlanID)
+		}
+		fmt.Fprintln(buf)
+		fmt.Fprintf(buf, "    aenet --> %s.%d\n", reth, ru.Unit)
+	}
+	fmt.Fprintln(buf)
+}
+
+// writeRethDetail renders `show interfaces ... detail` for bondless reth
+// aggregates (no kernel netdev) and, when the filter names a reth member whose
+// kernel device is absent, a synthetic member block. alreadyFound reports
+// whether the netlink walk already emitted the filtered interface. Returns true
+// when anything was rendered (#4328).
+func writeRethDetail(buf *strings.Builder, cfg *config.Config, maps config.RethShowMaps, filterName string, alreadyFound bool) bool {
+	ifZone := make(map[string]string)
+	for _, z := range cfg.Security.Zones {
+		if z == nil {
+			continue
+		}
+		for _, ifName := range z.Interfaces {
+			ifZone[ifName] = z.Name
+		}
+	}
+
+	rendered := false
+	reths := make([]string, 0, len(maps.RethToPhys))
+	for reth := range maps.RethToPhys {
+		reths = append(reths, reth)
+	}
+	sort.Strings(reths)
+	for _, reth := range reths {
+		if filterName != "" && baseIfName(filterName) != reth {
+			continue
+		}
+		member := maps.RethToPhys[reth]
+		admin, link := rethMemberKernelState(member)
+		adminStr := "Enabled"
+		if admin == "down" {
+			adminStr = "Disabled"
+		}
+		linkStr := "Up"
+		if link == "down" {
+			linkStr = "Down"
+		}
+		fmt.Fprintf(buf, "Physical interface: %s, %s, Physical link is %s\n", reth, adminStr, linkStr)
+		if ifc, ok := cfg.Interfaces.Interfaces[reth]; ok && ifc.Description != "" {
+			fmt.Fprintf(buf, "  Description: %s\n", ifc.Description)
+		}
+		fmt.Fprintf(buf, "  Redundant-ethernet: aggregate over member %s\n", member)
+		for _, ru := range cfg.RethShowUnits(reth) {
+			fmt.Fprintf(buf, "  Logical interface %s.%d", reth, ru.Unit)
+			if ru.VlanID > 0 {
+				fmt.Fprintf(buf, " VLAN-Tag [ 0x8100.%d ]", ru.VlanID)
+			}
+			fmt.Fprintln(buf)
+			if zone, ok := ifZone[fmt.Sprintf("%s.%d", reth, ru.Unit)]; ok {
+				fmt.Fprintf(buf, "    Security zone: %s\n", zone)
+			}
+			if len(ru.V4Addrs) > 0 || len(ru.V6Addrs) > 0 {
+				fmt.Fprintln(buf, "    Addresses:")
+				for _, a := range ru.V4Addrs {
+					fmt.Fprintf(buf, "      %s\n", a)
+				}
+				for _, a := range ru.V6Addrs {
+					fmt.Fprintf(buf, "      %s\n", a)
+				}
+			}
+		}
+		fmt.Fprintln(buf)
+		rendered = true
+	}
+
+	if !alreadyFound && !rendered && filterName != "" {
+		if reth, ok := maps.LookupMember(filterName); ok {
+			writeRethMemberSummary(buf, cfg, baseIfName(filterName), reth)
+			rendered = true
+		}
+	}
+	return rendered
 }

--- a/pkg/grpcapi/server_show_interfaces_reth_4328_test.go
+++ b/pkg/grpcapi/server_show_interfaces_reth_4328_test.go
@@ -1,0 +1,137 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #4328: the gRPC text `show interfaces` twins mirror the CLI bug — only the
+// terse handler resolved a bondless reth. `ShowInterfacesDetail` (the bare
+// `show interfaces reth0` RPC) printed "Not present" (:150), and the ShowText
+// `interfaces-detail` / `interfaces-extensive` branches walked netlink and
+// never saw a reth. These tests assert the RPC + the text detail path now
+// render the aggregate over its physical member.
+//
+// RED-on-revert: without the RethShowMaps resolution the reth block is dropped
+// (raw netdev lookup) and the member name + config addresses vanish.
+
+func rethShowGRPCStore(t *testing.T) *Server {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+interfaces {
+    ge-0/0/2 {
+        gigether-options { redundant-parent reth0; }
+    }
+    reth0 {
+        vlan-tagging;
+        unit 50 {
+            vlan-id 50;
+            family inet { address 172.16.50.8/24; }
+            family inet6 { address 2001:559:8585:50::8/64; }
+        }
+        unit 80 {
+            vlan-id 80;
+            family inet { address 172.16.80.8/24; }
+        }
+    }
+}
+security {
+    zones {
+        security-zone wan {
+            interfaces { reth0.50; reth0.80; }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return &Server{store: store}
+}
+
+func TestShowInterfacesDetailRPCReth4328(t *testing.T) {
+	s := rethShowGRPCStore(t)
+	resp, err := s.ShowInterfacesDetail(context.Background(), &pb.ShowInterfacesDetailRequest{Filter: "reth0"})
+	if err != nil {
+		t.Fatalf("ShowInterfacesDetail(reth0): %v", err)
+	}
+	out := resp.GetOutput()
+	if strings.Contains(out, "Not present") {
+		t.Errorf("reth0 RPC still reports Not present:\n%s", out)
+	}
+	for _, want := range []string{
+		"Physical interface: reth0",
+		"aggregate over member ge-0/0/2",
+		"172.16.50.8/24",
+		"172.16.80.8/24",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("reth0 RPC missing %q\n%s", want, out)
+		}
+	}
+}
+
+// The bare `show interfaces <member>` RPC surfaces the member's aenet
+// aggregation (the member is not zoned, so this exercises the synthetic path).
+func TestShowInterfacesDetailRPCRethMember4328(t *testing.T) {
+	s := rethShowGRPCStore(t)
+	resp, err := s.ShowInterfacesDetail(context.Background(), &pb.ShowInterfacesDetailRequest{Filter: "ge-0-0-2"})
+	if err != nil {
+		t.Fatalf("ShowInterfacesDetail(ge-0-0-2): %v", err)
+	}
+	out := resp.GetOutput()
+	if strings.Contains(out, "not found") {
+		t.Fatalf("member RPC reports not found:\n%s", out)
+	}
+	for _, want := range []string{"member of reth0", "aenet --> reth0.50"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("member RPC missing %q\n%s", want, out)
+		}
+	}
+}
+
+// The ShowText `interfaces-detail` twin (used by the remote CLI's
+// `show interfaces reth0 detail`) renders the reth aggregate.
+func TestShowInterfacesTextDetailReth4328(t *testing.T) {
+	s := rethShowGRPCStore(t)
+	cfg := s.store.ActiveConfig()
+	var buf strings.Builder
+	if err := s.showInterfacesDetail(cfg, "reth0", &buf); err != nil {
+		t.Fatalf("showInterfacesDetail(reth0): %v", err)
+	}
+	out := buf.String()
+	if strings.TrimSpace(out) == "" {
+		t.Fatalf("reth0 text detail empty:\n%s", out)
+	}
+	for _, want := range []string{"Physical interface: reth0", "ge-0/0/2", "172.16.50.8/24"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("reth0 text detail missing %q\n%s", want, out)
+		}
+	}
+}
+
+// The ShowText `interfaces-extensive` twin lists the reth aggregate too.
+func TestShowInterfacesTextExtensiveReth4328(t *testing.T) {
+	s := rethShowGRPCStore(t)
+	cfg := s.store.ActiveConfig()
+	var buf strings.Builder
+	if err := s.showInterfacesExtensive(cfg, &buf); err != nil {
+		t.Fatalf("showInterfacesExtensive: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"Physical interface: reth0", "ge-0/0/2", "172.16.50.8/24"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("reth extensive missing %q\n%s", want, out)
+		}
+	}
+}

--- a/pkg/grpcapi/server_show_interfaces_reth_4328_test.go
+++ b/pkg/grpcapi/server_show_interfaces_reth_4328_test.go
@@ -2,12 +2,35 @@ package grpcapi
 
 import (
 	"context"
+	"net"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/psaab/xpf/pkg/config"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 )
+
+// dashNamedKernelIface finds a real host interface whose kernel name contains a
+// '-' and round-trips through LinuxIfName from its slash form, so a Junos-form
+// config name resolves to a real netdev. Returns (junos, kernel, true) or skips.
+func dashNamedKernelIface(t *testing.T) (junos, kernel string, ok bool) {
+	t.Helper()
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", "", false
+	}
+	for _, in := range ifaces {
+		if in.Name == "lo" || !strings.Contains(in.Name, "-") || strings.Contains(in.Name, "/") {
+			continue
+		}
+		j := strings.ReplaceAll(in.Name, "-", "/")
+		if config.LinuxIfName(j) == in.Name {
+			return j, in.Name, true
+		}
+	}
+	return "", "", false
+}
 
 // #4328: the gRPC text `show interfaces` twins mirror the CLI bug — only the
 // terse handler resolved a bondless reth. `ShowInterfacesDetail` (the bare
@@ -117,6 +140,43 @@ func TestShowInterfacesTextDetailReth4328(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("reth0 text detail missing %q\n%s", want, out)
 		}
+	}
+}
+
+// A NON-reth interface authored in Junos slash form must resolve to its kernel
+// netdev on the ShowInterfacesDetail RPC (#4328 Copilot follow-up). RED-on
+// -revert: the raw config-name lookup prints "Not present".
+func TestShowInterfacesDetailRPCNonRethKernelName4328(t *testing.T) {
+	junos, kernel, ok := dashNamedKernelIface(t)
+	if !ok {
+		t.Skip("no dash-named host interface available to exercise slash->kernel resolution")
+	}
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+interfaces {
+    ` + junos + ` { unit 0 { family inet { address 10.9.9.9/24; } } }
+}
+security { zones { security-zone z { interfaces { ` + junos + `.0; } } } }
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	s := &Server{store: store}
+	resp, err := s.ShowInterfacesDetail(context.Background(), &pb.ShowInterfacesDetailRequest{Filter: junos})
+	if err != nil {
+		t.Fatalf("ShowInterfacesDetail(%s): %v", junos, err)
+	}
+	out := resp.GetOutput()
+	if strings.Contains(out, "Not present") {
+		t.Errorf("valid interface %s (kernel %s) rendered Not present:\n%s", junos, kernel, out)
+	}
+	if !strings.Contains(out, junos) {
+		t.Errorf("RPC output missing interface name %s:\n%s", junos, out)
 	}
 }
 

--- a/pkg/grpcapi/server_show_interfaces_text.go
+++ b/pkg/grpcapi/server_show_interfaces_text.go
@@ -44,7 +44,11 @@ func (s *Server) showInterfacesExtensive(cfg *config.Config, buf *strings.Builde
 	// Build config lookup for description/speed/duplex/zone
 	ifCfgMap := make(map[string]*config.InterfaceConfig)
 	ifZoneMap := make(map[string]string)
+	// #4328: reth resolution — synthesize bondless reth aggregates (no kernel
+	// netdev) and annotate physical members with their aenet aggregation.
+	var rethMaps config.RethShowMaps
 	if cfg != nil {
+		rethMaps = cfg.RethShowMaps()
 		for _, ifc := range cfg.Interfaces.Interfaces {
 			ifCfgMap[ifc.Name] = ifc
 		}
@@ -86,6 +90,14 @@ func (s *Server) showInterfacesExtensive(cfg *config.Config, buf *strings.Builde
 		}
 		if zone, ok := ifZoneMap[attrs.Name]; ok {
 			fmt.Fprintf(buf, "  Security zone: %s\n", zone)
+		}
+		// #4328: annotate a physical reth member with its aenet aggregation.
+		if rethName, ok := rethMaps.LookupMember(attrs.Name); ok && cfg != nil {
+			fmt.Fprintf(buf, "  Redundant-ethernet: member of %s\n", rethName)
+			for _, ru := range cfg.RethShowUnits(rethName) {
+				fmt.Fprintf(buf, "  Logical interface %s.%d --> aenet %s.%d\n",
+					attrs.Name, ru.Unit, rethName, ru.Unit)
+			}
 		}
 		// Speed/duplex from sysfs
 		var linkExtras []string
@@ -136,6 +148,11 @@ func (s *Server) showInterfacesExtensive(cfg *config.Config, buf *strings.Builde
 		}
 		fmt.Fprintln(buf)
 	}
+
+	// #4328: bondless reth aggregates have no kernel netdev — append them.
+	if cfg != nil {
+		writeRethDetail(buf, cfg, rethMaps, "", false)
+	}
 	return nil
 }
 
@@ -151,7 +168,13 @@ func (s *Server) showInterfacesDetail(cfg *config.Config, filter string, buf *st
 	})
 	ifZoneMap := make(map[string]string)
 	ifDescMap := make(map[string]string)
+	// #4328: reth resolution — a bondless reth has no kernel netdev, so the
+	// netlink walk never emits it. Build the shared maps to synthesize the
+	// aggregate from config and annotate physical members with their aenet
+	// aggregation.
+	var rethMaps config.RethShowMaps
 	if cfg != nil {
+		rethMaps = cfg.RethShowMaps()
 		for _, z := range cfg.Security.Zones {
 			if z == nil { // #3493: tolerant/HA-sync path may carry a nil zone value
 				continue
@@ -166,6 +189,7 @@ func (s *Server) showInterfacesDetail(cfg *config.Config, filter string, buf *st
 			}
 		}
 	}
+	found := false
 	for _, link := range linksList {
 		attrs := link.Attrs()
 		if attrs.Name == "lo" {
@@ -174,6 +198,7 @@ func (s *Server) showInterfacesDetail(cfg *config.Config, filter string, buf *st
 		if filter != "" && attrs.Name != filter {
 			continue
 		}
+		found = true
 		adminUp := attrs.Flags&net.FlagUp != 0
 		operUp := attrs.OperState == netlink.OperUp
 		adminStr := "Disabled"
@@ -222,6 +247,14 @@ func (s *Server) showInterfacesDetail(cfg *config.Config, filter string, buf *st
 			fmt.Fprintf(buf, "  Security zone: %s\n", zone)
 		}
 		fmt.Fprintf(buf, "  Logical interface %s.0\n", attrs.Name)
+		// #4328: annotate a physical reth member with its aenet aggregation.
+		if rethName, ok := rethMaps.LookupMember(attrs.Name); ok && cfg != nil {
+			fmt.Fprintf(buf, "    Redundant-ethernet: member of %s\n", rethName)
+			for _, ru := range cfg.RethShowUnits(rethName) {
+				fmt.Fprintf(buf, "    Logical interface %s.%d --> aenet %s.%d\n",
+					attrs.Name, ru.Unit, rethName, ru.Unit)
+			}
+		}
 		addrs, _ := netlink.AddrList(link, netlink.FAMILY_ALL)
 		if len(addrs) > 0 {
 			fmt.Fprintf(buf, "    Addresses:\n")
@@ -239,6 +272,11 @@ func (s *Server) showInterfacesDetail(cfg *config.Config, filter string, buf *st
 			fmt.Fprintf(buf, "    Output errors:              %12d\n", st.TxErrors)
 		}
 		fmt.Fprintln(buf)
+	}
+
+	// #4328: bondless reth aggregates + absent-device members.
+	if cfg != nil {
+		writeRethDetail(buf, cfg, rethMaps, filter, found)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Every operational `show interfaces` variant EXCEPT `terse` failed to find a bondless reth. A bondless reth (VRRP on the physical member interfaces, no kernel bond device) has NO kernel netdev of its own — nothing is named `reth0`. Only the terse handler resolved this via `cfg.RethToPhysical()`; every other path did a raw kernel-netdev lookup that could not succeed for a reth:

| Command | Before | After |
|---|---|---|
| `show interfaces reth0` | `Physical interface: reth0, Not present` | aggregate over member, names `ge-0/0/2` |
| `show interfaces reth0.50` | `reth0, Not present` | unit aggregate, config addresses |
| `show interfaces reth0 detail` | empty | synthesized aggregate |
| `show interfaces reth0 extensive` | `interface extensive not found` | synthesized aggregate |
| `show interfaces <member> detail` | no reth membership | `aenet --> reth0.<unit>` lines |

The reth CONFIG and FORWARDING are correct — only the operator INSPECTION command was broken.

## Fix

Extracted the terse handler's reth map-building into a single shared resolver so terse, summary, detail, and extensive classify a reth identically and cannot drift again:

- **`pkg/config/reth_show.go` (new)** — `RethShowMaps` (`PhysToReth` dual-keyed by Junos `ge-0/0/2` AND kernel `ge-0-0-2` ifname, `RethToPhys`) + `LookupReth` / `LookupMember` / `RethShowUnits`.

Four text surfaces now render the reth as a logical aggregate over its local physical member (link state/MAC/counters from the member netdev, addresses/units from `cfg.Interfaces[reth].Units`), and annotate a physical member with its `aenet --> reth<N>.<unit>` aggregation:

- **CLI** — `showInterfaces` (summary), `showInterfacesDetail`, `showInterfacesExtensiveFiltered` (`pkg/cli/cli_show_interfaces.go`).
- **gRPC** — the `ShowInterfacesDetail` RPC (bare `show interfaces reth0`) plus its ShowText `interfaces-detail` / `interfaces-extensive` twins (remote `show interfaces reth0 detail` / `extensive`).

Both terse handlers (CLI + gRPC) were refactored to consume the same shared maps. Rendering is config-sourced, so it works when the member kernel device is absent (peer-owned member or a unit-test host) — mirroring terse.

The structured `GetInterfaces` RPC is untouched — #3460 already resolved kernel ifnames on that surface. This is the TEXT show paths only.

## Tests

RED-on-revert regression tests in `pkg/cli` + `pkg/grpcapi` on a 2-unit reth (`reth0.50` / `reth0.80`) over physical member `ge-0/0/2`. They assert the summary / detail / extensive outputs are non-empty and name the physical member, and that a member surfaces its aenet lines. Neutralizing `RethShowMaps` reproduces the exact issue symptoms (Not present / not found / empty). A normal non-reth interface show is verified unchanged.

`go build ./...` clean; gofmt clean; `go test ./pkg/config/... ./pkg/cli/... ./pkg/grpcapi/...` green.

Closes #4328

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi