### PR TITLE
config: per-subtree closed-world validation mechanism (PR-A, #4313)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -36113,3 +36113,39 @@ top.
 - **File(s)**: pkg/config/compiler_validate_vrf_overlap.go,
   pkg/config/compiler_validate_vrf_overlap_2387_test.go, pkg/config/compiler.go,
   userspace-dp/src/afxdp/forwarding/README.md, _Log.md
+
+- **Timestamp**: 2026-07-06
+- **Action**: #4313 PR-A — land the per-subtree closed-world validation
+  MECHANISM in the schema walker (mechanism only; no production subtree
+  flipped). The config schema is opt-in at the KEYWORD level: when
+  walkSchemaNode resolves a keyword to a nil schema child it returns nil
+  and the unmodeled leaf commits clean, then is silently dropped (the
+  compiler has no case for it either). A BLANKET closed-world flip is
+  infeasible — it breaks the deliberately-lenient accept-with-advisory
+  paths (#1960/#3307/#3318, #2078/#4231) and false-rejects
+  valid-but-not-yet-modeled Junos (#4191 strand-preflight class). PR-A
+  adds an additive `closedWorld bool` to schemaNode (schema.go): default
+  false = byte-identical legacy behaviour; true rejects an unmodeled child
+  keyword under that subtree at strict commit. The walker now threads a
+  `closed` param down walkSchemaChildren / walkSchemaNode /
+  walkInstanceChildren; the top-level call passes closed=false, and each
+  container descent folds in the node's flag
+  (childClosed := closed || childSchema.closedWorld), so the flag inherits
+  to every descendant level. The ONE behavioural branch is at the
+  keyword-resolution gate (childSchema == nil): closed=true → typedLeafErrorf
+  reject mirroring the modifier-level unknown-keyword rejects; closed=false
+  (every production subtree today) → return nil, unchanged. NO production
+  schemaNode sets closedWorld — the mechanism is dormant, so every existing
+  config validates identically (zero false-reject risk). The per-subtree
+  production flips (security ipsec / security nat then / snmp community /
+  protocols {ospf,bgp} interface / interfaces family) are deferred PR-B..N,
+  each gated on a Junos-leaf completeness audit for that subtree; #4313
+  stays open for them. White-box tested with a SYNTHETIC closedWorld
+  subtree (schema_walk_internal_test.go, TestClosedWorld_*): unmodeled →
+  rejected under closed / silently accepted under open (RED-on-revert
+  discriminator proven by disabling the gate: the two rejection tests fail,
+  the open/modeled tests stay green); modeled → accepted; closed-world
+  inherits to descendants. Full pkg/config suite (-count=1), gofmt, vet,
+  go build ./... all clean.
+- **File(s)**: pkg/config/schema.go, pkg/config/schema_walk.go,
+  pkg/config/schema_walk_internal_test.go, docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -616,6 +616,65 @@ not read it, so the value is currently unsupported and discarded — an arity
 gate there would assert validation on a no-op feature (tag it only if/when
 `AddressSet.Description` is wired).
 
+## Per-subtree closed-world keyword validation (#4313)
+
+The scalar-arity gate (#3332, above) is a token-level fix: it catches an
+extra token trailing a MODELED leaf. It does not touch the deeper default of
+the whole schema — **the config schema is OPT-IN at the KEYWORD level**. When
+the generic walker (`walkSchemaNode`, `schema_walk.go`) resolves a keyword and
+finds no schema child (`resolveSchemaChild` returns nil, no exact child and no
+wildcard), it returns nil and moves on — an unmodeled keyword is not the gate's
+concern, reporting is left to the compiler. But the compiler has no schema case
+for a keyword the schema does not model either, so such a leaf commits clean
+and is then silently DROPPED. The parity campaigns have repeatedly closed one
+of these per subtree (each "silently dropped … added a schema child + compiler
+case" entry in the changelog below), but the *default* remained silent-accept.
+
+A **blanket** flip of that default is infeasible: several subtrees are
+deliberately lenient — they accept-with-advisory rather than reject, so that a
+not-yet-modeled or peer-only Junos knob survives a load / sync instead of
+failing the whole snapshot (#1960/#3307/#3318 lenient-warn; the #2078/#4231
+accept-with-advisory knobs). Rejecting every unmodeled keyword tree-wide would
+break those on purpose-lenient paths and false-reject valid-but-not-yet-modeled
+Junos configs (the #4191 strand-preflight false-reject class).
+
+The remedy is therefore a **per-subtree closed-world flag**, landed as a
+dormant MECHANISM in PR-A:
+
+- `schemaNode.closedWorld bool` (`schema.go`). Default false = today's opt-in,
+  silent-accept behaviour. When true on a container node, an unmodeled child
+  keyword anywhere under that subtree is REJECTED at strict commit instead of
+  silently dropped.
+- The walker threads a `closed` parameter (`walkSchemaChildren` /
+  `walkSchemaNode` / `walkInstanceChildren`). The top-level call passes
+  `closed=false`; descending into a resolved container folds in that node's
+  flag (`childClosed := closed || childSchema.closedWorld`), so once a subtree
+  opts in, every level below it inherits closed-world enforcement.
+- The single behavioural branch is at the keyword-resolution gate: when
+  `closed` is true AND the keyword is unmodeled (`childSchema == nil`), the
+  walker returns a `typedLeafErrorf` reject ("unknown configuration keyword
+  … under closed-world subtree"), mirroring the existing modifier-level
+  unknown-keyword rejects. When `closed` is false — the state for EVERY
+  production subtree today — behaviour is byte-identical to pre-#4313
+  (return nil, silent-accept).
+
+**No production subtree sets `closedWorld` in PR-A.** The mechanism is dormant:
+every existing config validates identically, so PR-A carries zero false-reject
+risk. It is white-box tested with a SYNTHETIC subtree
+(`schema_walk_internal_test.go`, `TestClosedWorld_*`): an unmodeled keyword
+under a `closedWorld:true` node is rejected; the same shape under a default
+(open-world) node is still silently accepted; a modeled keyword under the
+closed node passes; and closed-world inherits into modeled descendant
+containers.
+
+**Deferred, per-subtree flips (PR-B..N).** Turning `closedWorld` on for a real
+subtree (candidates: `security ipsec`, `security nat … then`, `snmp community`,
+`protocols {ospf,bgp} interface`, `interfaces … family`) is only safe once that
+subtree is LEAF-COMPLETE — every valid Junos keyword under it is modeled —
+otherwise the flip false-rejects a valid config. Each flip is its own follow-up
+gated on a Junos-leaf completeness audit for that subtree, tracked on #4313. Do
+NOT set `closedWorld` on a subtree without that audit.
+
 ### `firewall ... from tcp-flags` — semantic validation, not just a list (#3076)
 
 `from tcp-flags` is a `multi: true` leaf, so the dual-AST contract above

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -54,6 +54,22 @@ type schemaNode struct {
 	midKeywordAt int       // 1-based arg position where midKeyword appears (e.g., 2 for "from-zone X to-zone Y")
 	compoundKey  bool      // children form compound key (e.g., "family inet6" → Keys=["family","inet6"])
 
+	// closedWorld opts this subtree in to closed-world validation: when
+	// true, an unmodeled child keyword under this subtree is REJECTED at
+	// strict commit instead of silently dropped (opt-in per subtree,
+	// #4313). The default (false) preserves the legacy opt-in behaviour —
+	// SchemaValidate leaves unmodeled keywords to the compiler and never
+	// rejects them, so a leaf the schema does not model commits clean and
+	// is silently discarded. Flipping this on a subtree is only safe once
+	// that subtree is LEAF-COMPLETE (every valid Junos keyword under it is
+	// modeled), otherwise it false-rejects a valid-but-not-yet-modeled
+	// config. The flag is threaded down the walker (walkSchemaNode's
+	// `closed` param): once a subtree sets it, every descendant level
+	// inherits closed-world enforcement. No production subtree sets this
+	// yet — the per-subtree flips are follow-ups gated on a leaf-
+	// completeness audit (see docs/config-schema.md).
+	closedWorld bool
+
 	// Typed-leaf metadata (#1319). The zero value (valueType==ValueAny,
 	// validator==nil) is the legacy behaviour: any string accepted, no
 	// schema-time validation, no value-slot examples in `?` completion.

--- a/pkg/config/schema_walk.go
+++ b/pkg/config/schema_walk.go
@@ -102,7 +102,10 @@ func SchemaValidateWithDefinitions(tree, defsSource *ConfigTree, cfg *Config) er
 		}
 	}
 	vc := &walkContext{cfg: cfg, refs: refs}
-	return walkSchemaChildren(tree.Children, setSchema, nil, vc)
+	// closed=false: the top-level walk is open-world. The per-subtree
+	// closed-world flag (#4313) is inherited from schemaNode.closedWorld as
+	// the walker descends; no production subtree sets it today.
+	return walkSchemaChildren(tree.Children, setSchema, nil, vc, false)
 }
 
 // walkContext carries the per-walk validation inputs: the (always-nil in
@@ -263,7 +266,7 @@ func collectSchemaRefs(tree *ConfigTree) *schemaRefs {
 // modifier-only sibling (e.g. flat-set `transmit-rate exact` next to
 // `transmit-rate 1g`) can be recognized as valid only when a sibling
 // supplies the value.
-func walkSchemaChildren(nodes []*Node, parent *schemaNode, path []string, vc *walkContext) error {
+func walkSchemaChildren(nodes []*Node, parent *schemaNode, path []string, vc *walkContext, closed bool) error {
 	if parent == nil {
 		return nil
 	}
@@ -271,7 +274,7 @@ func walkSchemaChildren(nodes []*Node, parent *schemaNode, path []string, vc *wa
 		if node == nil || len(node.Keys) == 0 {
 			continue
 		}
-		if err := walkSchemaNode(node, parent, path, vc, nodes); err != nil {
+		if err := walkSchemaNode(node, parent, path, vc, nodes, closed); err != nil {
 			return err
 		}
 	}
@@ -289,14 +292,28 @@ func walkSchemaChildren(nodes []*Node, parent *schemaNode, path []string, vc *wa
 //   - path:     consumed keyword path for error context.
 //   - siblings: the AST nodes at this level (for cross-sibling
 //     modifier-only recognition).
-func walkSchemaNode(node *Node, parent *schemaNode, path []string, vc *walkContext, siblings []*Node) error {
+//   - closed:   closed-world enforcement flag (#4313). When true, an
+//     unmodeled child keyword is REJECTED instead of silently accepted.
+//     Inherited from any ancestor subtree whose schemaNode.closedWorld is
+//     set; false (open-world) everywhere in production today.
+func walkSchemaNode(node *Node, parent *schemaNode, path []string, vc *walkContext, siblings []*Node, closed bool) error {
 	keyword := node.Keys[0]
 
 	// Resolve the schema child for this keyword. Exact match first, then
-	// wildcard (instance-name slot). Unknown keywords are not our concern —
-	// the gate is opt-in; leave reporting to the compiler.
+	// wildcard (instance-name slot).
 	childSchema := resolveSchemaChild(parent, keyword)
 	if childSchema == nil {
+		// Closed-world subtree (#4313): an unmodeled keyword here is operator
+		// garbage that would commit clean and be silently dropped. Reject it,
+		// mirroring the modifier-level unknown-keyword rejects below. Only a
+		// subtree that opted in (schemaNode.closedWorld, inherited via closed)
+		// reaches this branch; no production subtree does so today.
+		if closed {
+			return typedLeafErrorf(path, "unknown configuration keyword %q under closed-world subtree", keyword)
+		}
+		// Open-world (the default for every production subtree): unknown
+		// keywords are not our concern — the gate is opt-in; leave reporting
+		// to the compiler. Behaviour here is byte-identical to pre-#4313.
 		return nil
 	}
 
@@ -400,17 +417,22 @@ func walkSchemaNode(node *Node, parent *schemaNode, path []string, vc *walkConte
 	// declares, the missing instance-name args are supplied by nested AST
 	// children: peel those name levels (the compiler's namedInstances does
 	// the same) and validate each instance's children at the child schema.
+	// Inherit closed-world enforcement into this container's descent (#4313):
+	// a subtree that opts in (childSchema.closedWorld) closes every level
+	// below it, and an already-closed ancestor keeps it closed.
+	childClosed := closed || childSchema.closedWorld
+
 	missingArgs := declaredKeyTokens - consumed
 	if missingArgs > 0 && !childSchema.compoundKey {
 		for _, c := range node.Children {
-			if err := walkInstanceChildren(c, childSchema, missingArgs, newPath, vc); err != nil {
+			if err := walkInstanceChildren(c, childSchema, missingArgs, newPath, vc, childClosed); err != nil {
 				return err
 			}
 		}
 		return nil
 	}
 
-	return walkSchemaChildren(node.Children, descendSchema, newPath, vc)
+	return walkSchemaChildren(node.Children, descendSchema, newPath, vc, childClosed)
 }
 
 // walkInstanceChildren peels the missing instance-name level(s) off a
@@ -420,7 +442,7 @@ func walkSchemaNode(node *Node, parent *schemaNode, path []string, vc *walkConte
 // Keys; the leaves are the node's CHILDREN. Any extra tokens packed into the
 // instance node's Keys beyond the name are ignored (the compiler does not
 // compile them; see walkSchemaNode's container comment, Codex r7).
-func walkInstanceChildren(node *Node, containerSchema *schemaNode, remaining int, path []string, vc *walkContext) error {
+func walkInstanceChildren(node *Node, containerSchema *schemaNode, remaining int, path []string, vc *walkContext, closed bool) error {
 	if node == nil || len(node.Keys) == 0 {
 		return nil
 	}
@@ -440,9 +462,11 @@ func walkInstanceChildren(node *Node, containerSchema *schemaNode, remaining int
 	}
 	newPath := append(append([]string(nil), path...), node.Keys[:consume]...)
 	if stillMissing := remaining - consume; stillMissing > 0 {
-		// This node supplied only part of the name; keep peeling.
+		// This node supplied only part of the name; keep peeling. closed is
+		// inherited unchanged: containerSchema.closedWorld was already folded
+		// into it by the caller in walkSchemaNode (#4313).
 		for _, c := range node.Children {
-			if err := walkInstanceChildren(c, containerSchema, stillMissing, newPath, vc); err != nil {
+			if err := walkInstanceChildren(c, containerSchema, stillMissing, newPath, vc, closed); err != nil {
 				return err
 			}
 		}
@@ -450,7 +474,7 @@ func walkInstanceChildren(node *Node, containerSchema *schemaNode, remaining int
 	}
 	// Name fully consumed. The instance's leaves are its block children;
 	// any leftover Keys past the name are not compiled and are ignored.
-	return walkSchemaChildren(node.Children, containerSchema, newPath, vc)
+	return walkSchemaChildren(node.Children, containerSchema, newPath, vc, closed)
 }
 
 // validateModifierChild validates one AST child of a typed leaf (e.g.

--- a/pkg/config/schema_walk_internal_test.go
+++ b/pkg/config/schema_walk_internal_test.go
@@ -28,7 +28,7 @@ func runMultiValueTail(t *testing.T, leafKeys []string) error {
 		"destination-port": leafSchema,
 	}}
 	node := &Node{Keys: leafKeys, IsLeaf: true}
-	return walkSchemaNode(node, parent, nil, nil, []*Node{node})
+	return walkSchemaNode(node, parent, nil, nil, []*Node{node}, false)
 }
 
 func TestWalker_MultiValueTail_AcceptsRange(t *testing.T) {
@@ -92,5 +92,90 @@ func TestWalker_MultiValueTail_RejectsDanglingSeparator(t *testing.T) {
 		if !strings.Contains(err.Error(), "missing value") {
 			t.Fatalf("error should describe missing value for %v: %v", keys, err)
 		}
+	}
+}
+
+// --- #4313 closed-world mechanism white-box tests ---
+//
+// PR-A lands the per-subtree closed-world MECHANISM only; no production
+// schemaNode sets closedWorld yet, so these synthetic subtrees are the
+// sole coverage. Build an OPEN-WORLD root with two container children —
+// one flagged closedWorld, one left default — each modeling a single
+// child keyword, and drive the generic walker from the top-level open
+// entry (closed=false) exactly as SchemaValidate does. This exercises the
+// closed-world inheritance fold (walkSchemaNode's childClosed) end to end.
+
+func runClosedWorldWalk(t *testing.T, top *Node) error {
+	t.Helper()
+	root := &schemaNode{children: map[string]*schemaNode{
+		// closedsub opts in: unmodeled children are rejected. Its modeled
+		// child container `sub` does NOT set the flag — it relies on
+		// inheritance to stay closed.
+		"closedsub": {
+			closedWorld: true,
+			children: map[string]*schemaNode{
+				"known": {},
+				"sub":   {children: map[string]*schemaNode{"deep": {}}},
+			},
+		},
+		// opensub keeps the default (open-world): unmodeled children are
+		// silently accepted, matching every production subtree in PR-A.
+		"opensub": {
+			children: map[string]*schemaNode{"known": {}},
+		},
+	}}
+	return walkSchemaChildren([]*Node{top}, root, nil, nil, false)
+}
+
+func TestClosedWorld_RejectsUnmodeledUnderClosedSubtree(t *testing.T) {
+	// The ONE behavioural change: an unmodeled keyword under a closedWorld
+	// subtree is rejected instead of silently dropped. RED on revert of the
+	// gate (returns nil, silent-accept).
+	top := &Node{Keys: []string{"closedsub"}, Children: []*Node{{Keys: []string{"bogus"}}}}
+	err := runClosedWorldWalk(t, top)
+	if err == nil {
+		t.Fatal("expected rejection of unmodeled keyword under closed-world subtree")
+	}
+	if !strings.Contains(err.Error(), "bogus") || !strings.Contains(err.Error(), "closed-world") {
+		t.Fatalf("error should name the keyword and closed-world: %v", err)
+	}
+}
+
+func TestClosedWorld_AcceptsModeledUnderClosedSubtree(t *testing.T) {
+	// Only UNMODELED keywords are rejected — a modeled leaf under the same
+	// closed-world subtree still validates.
+	top := &Node{Keys: []string{"closedsub"}, Children: []*Node{{Keys: []string{"known"}}}}
+	if err := runClosedWorldWalk(t, top); err != nil {
+		t.Fatalf("modeled keyword under closed-world subtree must be accepted: %v", err)
+	}
+}
+
+func TestClosedWorld_SilentlyAcceptsUnmodeledUnderOpenSubtree(t *testing.T) {
+	// The default (closedWorld=false) subtree keeps pre-#4313 behaviour: an
+	// unmodeled keyword is silently accepted (returns nil). Same input shape
+	// as the closed subtree above, opposite disposition, decided solely by
+	// the closedWorld flag — this is the RED-on-revert discriminator and the
+	// proof that no open-world (i.e. every production) subtree is affected.
+	top := &Node{Keys: []string{"opensub"}, Children: []*Node{{Keys: []string{"bogus"}}}}
+	if err := runClosedWorldWalk(t, top); err != nil {
+		t.Fatalf("unmodeled keyword under open-world subtree must be silently accepted: %v", err)
+	}
+}
+
+func TestClosedWorld_InheritsToDescendants(t *testing.T) {
+	// closedWorld is set on `closedsub`; its modeled child container `sub`
+	// does NOT set it. Closed-world is inherited down every level, so an
+	// unmodeled grandchild is still rejected while the modeled one passes.
+	reject := &Node{Keys: []string{"closedsub"}, Children: []*Node{
+		{Keys: []string{"sub"}, Children: []*Node{{Keys: []string{"nope"}}}},
+	}}
+	if err := runClosedWorldWalk(t, reject); err == nil {
+		t.Fatal("closed-world must inherit into modeled descendant containers")
+	}
+	accept := &Node{Keys: []string{"closedsub"}, Children: []*Node{
+		{Keys: []string{"sub"}, Children: []*Node{{Keys: []string{"deep"}}}},
+	}}
+	if err := runClosedWorldWalk(t, accept); err != nil {
+		t.Fatalf("modeled grandchild under inherited closed-world must pass: %v", err)
 	}
 }


### PR DESCRIPTION
## What

PR-A of #4313: land the **per-subtree closed-world validation MECHANISM**
in the schema walker. Mechanism only — **no production subtree is flipped**,
so the change is dormant and carries **zero false-reject risk**.

## Why

The config schema is opt-in at the KEYWORD level. When the generic walker
(`walkSchemaNode`, `schema_walk.go`) resolves a keyword to a nil schema child
(`resolveSchemaChild` returns nil — no exact child, no wildcard), it returns
nil. The compiler has no case for an unmodeled keyword either, so such a leaf
commits clean and is then **silently dropped**.

A blanket flip of that default is infeasible: several subtrees are
deliberately lenient (accept-with-advisory so a not-yet-modeled or peer-only
Junos knob survives a load/sync — #1960/#3307/#3318, #2078/#4231), and
rejecting every unmodeled keyword tree-wide would false-reject
valid-but-not-yet-modeled configs (the #4191 strand-preflight class). The
remedy is a **per-subtree** flag.

## The mechanism

- `schemaNode.closedWorld bool` (`schema.go`) — default false = today's
  opt-in, byte-identical silent-accept. When true on a container, an
  unmodeled child keyword under that subtree is rejected at strict commit.
- The walker threads a `closed` param (`walkSchemaChildren` /
  `walkSchemaNode` / `walkInstanceChildren`). Top-level call passes
  `closed=false`; each container descent folds in the node's flag
  (`childClosed := closed || childSchema.closedWorld`), so the flag inherits
  to every descendant level.
- The ONE behavioural branch is the keyword-resolution gate: `closed==true`
  AND `childSchema==nil` → `typedLeafErrorf` reject ("unknown configuration
  keyword ... under closed-world subtree"), mirroring the existing
  modifier-level unknown-keyword rejects. `closed==false` (every production
  subtree today) → return nil, unchanged.

## Zero-risk

No production `schemaNode` sets `closedWorld` in this PR. Every existing
config validates identically — the full `pkg/config` suite passes with no
new rejections.

## Tests

White-box (`schema_walk_internal_test.go`, `TestClosedWorld_*`) with a
SYNTHETIC subtree:

- unmodeled keyword under `closedWorld:true` → **rejected**
- same shape under default (open-world) node → **still silently accepted**
  (the RED-on-revert discriminator)
- modeled keyword under the closed node → accepted
- closed-world inherits into modeled descendant containers

RED-on-revert proven: disabling the gate makes the two rejection tests fail
while the open/modeled tests stay green.

`go test -count=1 ./pkg/config/...`, `gofmt`, `go vet ./pkg/config/...`,
`go build ./...` all clean.

## Deferred (keeps #4313 open)

The per-subtree production flips — `security ipsec`, `security nat … then`,
`snmp community`, `protocols {ospf,bgp} interface`, `interfaces … family` —
are PR-B..N, each gated on a **Junos-leaf completeness audit** for that
subtree (flipping a not-yet-leaf-complete subtree would false-reject valid
config). Documented in `docs/config-schema.md`. **Refs #4313** — this PR does
not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
