### PR TITLE
config: application vSRX drop-in parity — 0-N port floor + unknown per-app alg

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-06 — #4336 + #4337: application vSRX drop-in parity (0-N port floor, unknown per-app alg)
+
+- **Timestamp**: 2026-07-06
+- **Action**: Fixed two OPEN vSRX drop-in blockers in application
+  definitions (fable-review-170 B-6/B-7).
+  - **#4336** — a `source-port`/`destination-port` `0-N` range was
+    hard-rejected (`invalid port 0: must be 1-65535`). Junos accepts 0 as
+    the range FLOOR (multi-term app defs split port space `0-N` /
+    `N+1-65535`, e.g. FaceTime `source-port 0-41640`). Fixed in
+    `resolveAppPort` (the single canonicalization chokepoint for BOTH
+    direct-match and inline-term ports): normalize a floor of 0 to 1. Port
+    0 never appears on the wire so `0-N` ≡ `1-N`; normalizing at this one
+    point keeps `validatePortSpec`, the `userspacePortSpecRepresentable`
+    #2124 gate, and Rust `parse_port_spec` all in agreement (the latter two
+    reject a raw 0 floor, so merely relaxing the validator would have
+    created a commit-succeeds / apply-fails split). A bare single port 0
+    stays invalid.
+  - **#4337** — an unknown per-application `alg <name>` (outside
+    dns/ftp/sip/tftp) was HARD-rejected at commit though the
+    per-application ALG is not carried to the dataplane at all (only the
+    global `alg_disable_flags` bitfield is on the wire), so xpf rejected an
+    ALG it does not even enforce. Relaxed the #3353 strict reject to an
+    accepted-but-inert advisory in `ValidateConfig`
+    (`application <a>: alg "<name>" accepted but not enforced …`, mirroring
+    the global #4232 advisory). Known names still commit silently;
+    enforcement deferred to the per-application ALG slice of #2008.
+  - RED-on-revert proven for both (Edit-revert, not git): #4336 → the exact
+    issue error `invalid port 0: must be 1-65535`; #4337 → re-instating the
+    strict reject fails the accept-with-advisory assertions. Full
+    `go test ./pkg/config/...` green, `go vet`, `go build ./...`, gofmt all
+    clean. No Rust/cargo change.
+- **File(s)**: pkg/config/compiler_applications.go,
+  pkg/config/compiler_validate_strict.go,
+  pkg/config/compiler_validate_warn.go,
+  pkg/config/compiler_application_port_range_zero_4336_test.go,
+  pkg/config/compiler_application_term_alg_3352_3353_test.go,
+  pkg/config/parser_ast_test.go, docs/config-schema.md, _Log.md
+
 ## 2026-07-06 — #4282 part (a): lock CoS-submit owner TX accounting (tx_packets/tx_bytes)
 
 - **Timestamp**: 2026-07-06

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -4373,55 +4373,82 @@ gaps lived under that opacity:
   commit. A custom application term accepts only `protocol` / `source-port` /
   `destination-port` / `inactivity-timeout` / `timeout` / `icmp-type` /
   `icmp-code` / `alg`.
-- **#3353 — unsupported per-application `alg`.** The `alg` leaf was a raw
-  `args:1` string with no validator, so a typo (`alg ftpp`) committed cleanly
-  and the operator believed an ALG was pinned when none existed (a silent no-op
-  on a security knob). `validateApplicationSpecsStrict` now validates the name
-  against `supportedApplicationALGs` (`compiler_applications.go`) — the SSOT
-  set `dns`/`ftp`/`sip`/`tftp`, MIRRORING the global `security alg <proto>`
-  control (`algDisableFlags`, `pkg/dataplane/userspace/flow.go`). The same gate
-  covers the top-level `app.ALG` and the inline-term `alg` (the term app carries
-  it). The match is case-insensitive.
+- **#3353 → #4337 — per-application `alg` accept-with-advisory (relaxed from a
+  hard reject).** The `alg` leaf was a raw `args:1` string with no validator, so
+  a typo (`alg ftpp`) committed cleanly and the operator believed an ALG was
+  pinned when none existed. #3353 first made an unsupported name (outside the
+  SSOT set `dns`/`ftp`/`sip`/`tftp`) a hard commit error. **#4337 relaxes that
+  to an accepted-but-inert advisory**: a per-application ALG is NOT carried into
+  the userspace dataplane snapshot at all (the only ALG signal on the wire is
+  the *global* `alg_disable_flags` bitfield, `userspace-dp` `snapshot.rs`), so
+  even a KNOWN name is informational today — hard-rejecting an UNKNOWN one
+  blocked real vSRX drop-in configs that tag applications with ALGs xpf does not
+  implement (e.g. `alg ssh`) for a knob with no functional effect. The unknown
+  name now commits, and `ValidateConfig` (`compiler_validate_warn.go`) emits an
+  advisory naming the unenforced alg — `application <a>: alg "<name>" accepted
+  but not enforced …` — mirroring the global `security alg` accepted-but-inert
+  advisory (#4232). A KNOWN name (case-insensitive, via
+  `supportedApplicationALGs` in `compiler_applications.go`) commits silently and
+  keeps its (informational) behavior. This covers both the top-level `app.ALG`
+  and the inline-term `alg` (the term app carries it).
 
-  **#3353 is VALIDATION only — enforcement is deferred.** A per-application ALG
-  is recorded on `Application.ALG` but is NOT carried into the userspace
-  dataplane snapshot: the only ALG signal on the wire is the *global*
-  `alg_disable_flags` bitfield (`userspace-dp` `snapshot.rs`), with no
-  per-application ALG / custom-port pin. Wiring per-application ALG (e.g. `alg
-  ftp destination-port 2121`) through to enforcement needs a new snapshot field
-  plus Rust session-metadata handling — a genuine dataplane fork that is the
+  **Enforcement remains deferred.** Wiring per-application ALG (e.g. `alg ftp
+  destination-port 2121`) through to enforcement needs a new snapshot field plus
+  Rust session-metadata handling — a genuine dataplane fork that is the
   per-application slice of the broader ALG parity tracked under **#2008**, and
-  is deliberately not built here. Until then this gate makes an unsupported
-  name an operator-visible commit error instead of a silent no-op.
+  is deliberately not built here.
 
-**Scope — ALL user-defined applications, referenced or not.** These two checks
-live in a SEPARATE pass, `validateApplicationSyntaxStrict`, that iterates every
-entry in `cfg.Applications.Applications`, NOT the reference-scoped
+**Scope — ALL user-defined applications, referenced or not.** The unknown
+term-leaf hard reject (#3352) lives in a SEPARATE pass,
+`validateApplicationSyntaxStrict`, that iterates every entry in
+`cfg.Applications.Applications`, NOT the reference-scoped
 `applicationsToValidateStrict` subset that `validateApplicationSpecsStrict` uses
 for its port / protocol / icmp / timeout checks. The reference scope is correct
 for those SEMANTIC checks (an unreferenced malformed-port app cannot break a
 live policy decision, so it stays a warning so an operator iterating on a
 not-yet-wired application library is not blocked). But an unknown term statement
-and an unsupported `alg` are SYNTACTIC / enum violations — the config names a
-statement or an ALG that does not exist — which Junos rejects at commit
-regardless of policy wiring; deferring them until reference would let a typo'd
-term-leaf silently widen a term, or a bogus `alg` silently no-op, from the
-moment the app is defined. `cfg.Applications.Applications` holds ONLY
-user-defined applications (and the per-term apps they generate); PREDEFINED
-junos-* apps (`junos-rtsp`, `junos-h323`, ...) live in the separate
-`PredefinedApplications` table and are never in this map, so the `alg` check
-never false-rejects a predefined app that legitimately carries an
-out-of-supported-set ALG.
+is a SYNTACTIC violation — the config names a statement that does not exist —
+which Junos rejects at commit regardless of policy wiring; deferring it until
+reference would let a typo'd term-leaf silently widen a term from the moment the
+app is defined. The per-application `alg` advisory (#4337) likewise applies to
+every entry (`ValidateConfig` iterates all user apps). `cfg.Applications.
+Applications` holds ONLY user-defined applications (and the per-term apps they
+generate); PREDEFINED junos-* apps (`junos-rtsp`, `junos-h323`, ...) live in the
+separate `PredefinedApplications` table and are never in this map, so neither
+the term-leaf gate nor the `alg` advisory ever touches a predefined app that
+legitimately carries an out-of-supported-set ALG.
 
-Both checks are STRICT on the commit / commit-check path and downgrade to a
-`cfg.Warnings` entry on the tolerant load / HA peer-sync path
+The #3352 term-leaf gate is STRICT on the commit / commit-check path and
+downgrades to a `cfg.Warnings` entry on the tolerant load / HA peer-sync path
 (`lenientApplicationSpecs`, #1960 no-brick), the same discipline as the #3320 /
-#3348 application gates. Regression coverage:
+#3348 application gates; the #4337 alg check is always an advisory (never a
+commit error). Regression coverage:
 `pkg/config/compiler_application_term_alg_3352_3353_test.go` (unknown term leaf
 rejected referenced AND unreferenced, well-formed term keeps its port
-constraint, unknown alg rejected top-level + inline-term + unreferenced,
-supported alg names accepted on both paths, predefined-app reference not
-rejected).
+constraint, unknown alg accepted-with-advisory top-level + inline-term +
+unreferenced, supported alg names accepted on both paths, predefined-app
+reference not rejected).
+
+### #4336 — application `source-port` / `destination-port` `0-N` range floor
+
+Junos accepts `0` as the FLOOR of an application port range. Real vSRX
+multi-term application defs routinely split a port space as `0-N` /
+`N+1-65535` (e.g. FaceTime `term 0_41640 { source-port 0-41640; }`). xpf
+hard-rejected the low half with `source-port: invalid port 0: must be
+1-65535` — a pure drop-in blocker. `resolveAppPort` (`compiler_applications.go`,
+the single canonicalization chokepoint for BOTH direct-match and inline-term
+ports) now normalizes a range floor of `0` to `1`. Port 0 never appears on the
+wire, so `0-N` matches identically to `1-N`; normalizing at this one point keeps
+the config, `validatePortSpec`, the `userspacePortSpecRepresentable` #2124
+capability gate, and the Rust `parse_port_spec` all in agreement (the latter two
+both reject a raw `0` floor, so accepting `0-N` WITHOUT normalizing would create
+a commit-succeeds / apply-fails split). A bare single port `0` (no hyphen) stays
+invalid, matching Junos, and an out-of-range / non-numeric endpoint still
+hard-rejects on the referenced (strict) path. Regression coverage:
+`pkg/config/compiler_application_port_range_zero_4336_test.go` (source-port,
+destination-port, and inline-term `0-N` normalized to `1-N`; normal `1-N`
+unchanged; garbage still rejected) plus the `FaceTime-0_41640` assertion in
+`TestMultiTermApplication`.
 
 ### #3366 — application EITHER direct OR term-based; conflicting duplicate term leaf
 

--- a/pkg/config/compiler_application_port_range_zero_4336_test.go
+++ b/pkg/config/compiler_application_port_range_zero_4336_test.go
@@ -1,0 +1,89 @@
+package config
+
+import "testing"
+
+// #4336: Junos accepts 0 as the FLOOR of an application source-port /
+// destination-port range. Real vSRX multi-term application defs split a port
+// space as `0-N` / `N+1-65535` (e.g. FaceTime `source-port 0-41640`). xpf
+// hard-rejected the range ("invalid port 0: must be 1-65535"). resolveAppPort
+// now normalizes the floor to 1 — port 0 never appears on the wire, so `0-N`
+// matches identically to `1-N`, and the normalized spec both passes
+// validatePortSpec AND is representable by the userspace dataplane (the Rust
+// parse_port_spec and the Go #2124 userspacePortSpecRepresentable gate both
+// reject a raw 0 floor).
+//
+// These use a REFERENCED application (refApp wires a permit policy to it) so the
+// reference-scoped validateApplicationSpecsStrict port gate actually runs — an
+// UNREFERENCED app skips that gate, which is why the pre-existing
+// TestMultiTermApplication (unreferenced FaceTime) never tripped the reject.
+
+// Core fail-on-revert: `source-port 0-41640` on a referenced app commits, and
+// the stored spec is normalized to `1-41640`. Revert the resolveAppPort floor
+// clamp and validatePortSpec hard-rejects "invalid port 0" → RED.
+func TestApplicationPortRange_ZeroFloor_SourcePort_Accepted(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("facetime",
+		"protocol udp", "source-port 0-41640", "destination-port 3478-3497")...)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected commit to ACCEPT source-port 0-41640 (#4336), got: %v", err)
+	}
+	app := cfg.Applications.Applications["facetime"]
+	if app == nil {
+		t.Fatalf("application facetime missing; have %v", appNames(cfg))
+	}
+	if app.SourcePort != "1-41640" {
+		t.Fatalf("source-port 0-41640 must normalize to 1-41640, got %q", app.SourcePort)
+	}
+}
+
+// destination-port 0-N is normalized the same way.
+func TestApplicationPortRange_ZeroFloor_DestinationPort_Accepted(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("app0", "protocol tcp", "destination-port 0-1024")...)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected commit to ACCEPT destination-port 0-1024 (#4336), got: %v", err)
+	}
+	app := cfg.Applications.Applications["app0"]
+	if app == nil || app.DestinationPort != "1-1024" {
+		t.Fatalf("destination-port 0-1024 must normalize to 1-1024, got %+v", app)
+	}
+}
+
+// The zero floor also works inside an inline term (the generated term app
+// carries the normalized port).
+func TestApplicationPortRange_ZeroFloor_InlineTerm_Accepted(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("ft",
+		"term t0 protocol udp source-port 0-41640 destination-port 3478-3497")...)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected commit to ACCEPT inline-term source-port 0-41640 (#4336), got: %v", err)
+	}
+	app := cfg.Applications.Applications["ft-t0"]
+	if app == nil || app.SourcePort != "1-41640" {
+		t.Fatalf("inline-term source-port 0-41640 must normalize to 1-41640, got %+v", app)
+	}
+}
+
+// Guard against over-acceptance: a normal 1-N range is byte-identical (no
+// clamp), and genuine garbage is still hard-rejected on the referenced (strict)
+// path — a bare single port 0 stays invalid (matching Junos), and an
+// out-of-range / non-numeric endpoint still fails.
+func TestApplicationPortRange_ZeroFloor_GuardsIntact(t *testing.T) {
+	cfg, err := CompileConfig(flatTreeFromSets(t,
+		refApp("ok", "protocol tcp", "source-port 1024-2048")...))
+	if err != nil {
+		t.Fatalf("normal range 1024-2048 must still commit: %v", err)
+	}
+	if app := cfg.Applications.Applications["ok"]; app == nil || app.SourcePort != "1024-2048" {
+		t.Fatalf("normal range must be unchanged, got %+v", app)
+	}
+	for _, bad := range []string{"70000", "0-70000", "abc", "0"} {
+		t.Run("reject_"+bad, func(t *testing.T) {
+			_, err := CompileConfig(flatTreeFromSets(t,
+				refApp("bad", "protocol tcp", "source-port "+bad)...))
+			if err == nil {
+				t.Fatalf("expected commit to REJECT garbage source-port %q", bad)
+			}
+		})
+	}
+}

--- a/pkg/config/compiler_application_term_alg_3352_3353_test.go
+++ b/pkg/config/compiler_application_term_alg_3352_3353_test.go
@@ -66,30 +66,37 @@ func TestApplicationTerm_ValidLeaves_Accepted(t *testing.T) {
 	}
 }
 
-// #3353 core fail-on-revert: an unknown per-application `alg` name (top-level)
-// must be rejected at commit. Revert the strict-gate ALG check and `alg ftpp`
-// commits cleanly, so this assertion goes RED.
-func TestApplicationALG_UnknownName_TopLevel_Rejected(t *testing.T) {
+// #4337 core fail-on-revert: an unknown per-application `alg` name (top-level)
+// is NO LONGER hard-rejected — it commits with an accepted-but-not-enforced
+// advisory naming the alg (the per-application ALG is not carried to the
+// dataplane, so rejecting a name for a knob with no effect blocked real vSRX
+// drop-in configs). Restore the #3353 strict reject and CompileConfig errors,
+// so both the no-error and the advisory assertions go RED.
+func TestApplicationALG_UnknownName_TopLevel_AcceptedWithAdvisory(t *testing.T) {
 	for _, bad := range []string{"ftpp", "ssh", "h323", "bogus"} {
 		t.Run(bad, func(t *testing.T) {
 			tree := flatTreeFromSets(t, refApp("bad", "protocol tcp", "alg "+bad)...)
-			if _, err := CompileConfig(tree); err == nil {
-				t.Fatalf("expected commit to REJECT unknown alg %q", bad)
-			} else if !strings.Contains(err.Error(), "unknown alg") {
-				t.Fatalf("error should mention the unknown alg, got: %v", err)
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("expected commit to ACCEPT unknown alg %q (accept-with-advisory, #4337), got: %v", bad, err)
+			}
+			if !hasWarningContaining(cfg.Warnings, `alg "`+bad+`" accepted but not enforced`) {
+				t.Fatalf("expected an accepted-but-not-enforced advisory naming alg %q, got warnings: %v", bad, cfg.Warnings)
 			}
 		})
 	}
 }
 
-// #3353: an unknown `alg` inside an inline term must also be rejected — the term
-// app carries the ALG and the strict gate validates it the same way.
-func TestApplicationALG_UnknownName_InlineTerm_Rejected(t *testing.T) {
+// #4337: an unknown `alg` inside an inline term is likewise accepted with the
+// advisory — the term app carries the ALG and the warn pass names it.
+func TestApplicationALG_UnknownName_InlineTerm_AcceptedWithAdvisory(t *testing.T) {
 	tree := flatTreeFromSets(t, refApp("badterm", "term t protocol tcp alg ftpp")...)
-	if _, err := CompileConfig(tree); err == nil {
-		t.Fatalf("expected commit to REJECT unknown inline-term alg")
-	} else if !strings.Contains(err.Error(), "unknown alg") {
-		t.Fatalf("error should mention the unknown alg, got: %v", err)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected commit to ACCEPT unknown inline-term alg (accept-with-advisory, #4337), got: %v", err)
+	}
+	if !hasWarningContaining(cfg.Warnings, `alg "ftpp" accepted but not enforced`) {
+		t.Fatalf("expected an accepted-but-not-enforced advisory naming alg ftpp, got warnings: %v", cfg.Warnings)
 	}
 }
 
@@ -154,20 +161,24 @@ func TestApplicationTerm_UnknownLeaf_Unreferenced_Rejected(t *testing.T) {
 	}
 }
 
-// #3353 scope fail-on-revert: an UNREFERENCED user application with an
-// unsupported `alg` must be rejected at commit (top-level and inline-term).
-func TestApplicationALG_UnknownName_Unreferenced_Rejected(t *testing.T) {
+// #4337 scope: an UNREFERENCED user application with an unsupported `alg`
+// commits with the advisory too (top-level and inline-term). The advisory
+// (ValidateConfig) iterates every user app, referenced or not.
+func TestApplicationALG_UnknownName_Unreferenced_AcceptedWithAdvisory(t *testing.T) {
 	cases := [][]string{
 		{"protocol tcp", "alg ftpp"},
 		{"term t protocol tcp alg h323"},
 	}
+	wantAlg := []string{"ftpp", "h323"}
 	for i, props := range cases {
 		t.Run(strings.Join(props, "_"), func(t *testing.T) {
 			tree := flatTreeFromSets(t, unrefAppOnly("lonely", props...)...)
-			if _, err := CompileConfig(tree); err == nil {
-				t.Fatalf("case %d: expected commit to REJECT unknown alg on an UNREFERENCED app", i)
-			} else if !strings.Contains(err.Error(), "unknown alg") {
-				t.Fatalf("case %d: error should mention the unknown alg, got: %v", i, err)
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("case %d: expected commit to ACCEPT unknown alg on an UNREFERENCED app (#4337), got: %v", i, err)
+			}
+			if !hasWarningContaining(cfg.Warnings, `alg "`+wantAlg[i]+`" accepted but not enforced`) {
+				t.Fatalf("case %d: expected advisory naming alg %q, got warnings: %v", i, wantAlg[i], cfg.Warnings)
 			}
 		})
 	}

--- a/pkg/config/compiler_applications.go
+++ b/pkg/config/compiler_applications.go
@@ -532,6 +532,24 @@ func resolveAppPort(spec string) string {
 	if lo, hi, found := strings.Cut(trimmed, "-"); found {
 		l, ok1 := resolveSinglePort(lo)
 		h, ok2 := resolveSinglePort(hi)
+		// #4336: Junos accepts 0 as the FLOOR of a port range. Real vSRX
+		// multi-term application defs routinely split a port space as
+		// `0-N` / `N+1-65535` (e.g. FaceTime `source-port 0-41640`).
+		// resolveSinglePort rejects the literal "0" (it clamps to [1,65535]),
+		// which left the raw `0-N` spec to be hard-rejected by validatePortSpec
+		// ("invalid port 0: must be 1-65535") — a pure drop-in blocker. Port 0
+		// never appears on the wire, so `0-N` matches identically to `1-N`;
+		// normalize the floor to 1 here, at the SINGLE canonicalization
+		// chokepoint for both direct-match and inline-term ports, so the
+		// resulting spec passes validatePortSpec AND is representable by the
+		// userspace dataplane (the Rust parse_port_spec and the Go #2124
+		// userspacePortSpecRepresentable gate both reject a 0 floor). A bare
+		// single port 0 (no hyphen) stays invalid, matching Junos.
+		if !ok1 {
+			if n, err := parseCanonicalPort(strings.TrimSpace(lo)); err == nil && n == 0 {
+				l, ok1 = 1, true
+			}
+		}
 		if ok1 && ok2 && l <= h {
 			return fmt.Sprintf("%d-%d", l, h)
 		}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -4040,26 +4040,20 @@ func validateApplicationSyntaxStrict(cfg *Config) error {
 					"with its value, widening the term to match more than intended)",
 				name, app.UnknownTermLeaves[0])
 		}
-		// #3353: a per-application `alg` name that is not one xpf supports. The
-		// `alg` leaf is a raw string with no schema validator, so a typo
-		// (`alg ftpp`) committed cleanly and the operator believed an ALG was
-		// pinned when none existed (a silent no-op on a security knob). Validate
-		// it against supportedApplicationALGs — the same DNS/FTP/SIP/TFTP set the
-		// global `security alg` control exposes. This is VALIDATION only: the
-		// per-application ALG is still not carried to the userspace dataplane
-		// (the wire has only the global alg_disable_flags bitfield), so a valid
-		// `alg` name remains informational until the enforcement half lands. That
-		// dataplane half is a genuine fork (new snapshot field + Rust) tracked as
-		// the per-application slice of #2008.
-		if app.ALG != "" && !validApplicationALG(app.ALG) {
-			return fmt.Errorf(
-				"application %q: unknown alg %q; supported application ALGs are "+
-					"dns/ftp/sip/tftp (the same set the global `security alg` control "+
-					"exposes). NOTE: a per-application alg is validated at commit but "+
-					"is not yet enforced by the userspace dataplane — enforcement is "+
-					"deferred to the per-application ALG slice of #2008",
-				name, app.ALG)
-		}
+		// #4337: a per-application `alg <name>` outside the four xpf implements
+		// (dns/ftp/sip/tftp) is NO LONGER hard-rejected here. The #3353 commit
+		// reject is deliberately relaxed to an accepted-but-inert advisory
+		// (ValidateConfig, compiler_validate_warn.go). Rationale: the
+		// per-application ALG is NOT carried into the userspace dataplane
+		// snapshot (the only ALG signal on the wire is the GLOBAL
+		// alg_disable_flags bitfield), so even a KNOWN name is informational
+		// today — rejecting an UNKNOWN one blocked real vSRX drop-in configs
+		// that tag applications with ALGs xpf does not implement (e.g.
+		// `alg ssh`) for a knob with no functional effect. The unknown name now
+		// commits with an advisory naming the unenforced alg so a typo is still
+		// surfaced; a KNOWN name commits silently, keeping its (informational)
+		// behavior. Enforcement of the per-application ALG is deferred to the
+		// per-application slice of #2008.
 	}
 	// #3890: an unrecognized member statement inside an opaque application-set
 	// body. The schema declares `application-set` as an args:1 leaf

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -144,6 +144,24 @@ func ValidateConfig(cfg *Config) []string {
 				warnings = append(warnings, fmt.Sprintf("application %s: %v", name, err))
 			}
 		}
+		// #4337: a per-application `alg <name>` outside the four the dataplane
+		// implements (dns/ftp/sip/tftp) is accepted-but-inert, not hard-rejected
+		// (relaxed from the #3353 commit reject — real vSRX app defs tag apps
+		// with ALGs xpf does not implement, e.g. `alg ssh`, a pure drop-in
+		// blocker). The per-application ALG is not carried into the userspace
+		// snapshot (the wire has only the global alg_disable_flags bitfield), so
+		// even a KNOWN name is informational; warn only for an UNKNOWN one so a
+		// typo is still surfaced. Mirrors the global `security alg`
+		// accepted-but-inert advisory (#4232). Enforcement deferred to the
+		// per-application ALG slice of #2008.
+		if app.ALG != "" && !validApplicationALG(app.ALG) {
+			warnings = append(warnings, fmt.Sprintf(
+				"application %s: alg %q accepted but not enforced — xpf implements "+
+					"per-application ALG control only for dns/ftp/sip/tftp; an "+
+					"unrecognized alg name commits but has no effect (enforcement "+
+					"deferred to the per-application ALG slice of #2008)",
+				name, app.ALG))
+		}
 	}
 
 	// Validate policies. Exempt the reserved special-zone tokens (`any`,

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -1905,6 +1905,15 @@ func TestMultiTermApplication(t *testing.T) {
 	if ft.DestinationPort != "3478-3497" {
 		t.Errorf("FaceTime dest-port: got %q, want 3478-3497", ft.DestinationPort)
 	}
+	// #4336: the `0-41640` low-half term is accepted (Junos allows 0 as a range
+	// floor) and its floor is normalized to 1 so it is dataplane-representable.
+	ft0 := cfg.Applications.Applications["FaceTime-0_41640"]
+	if ft0 == nil {
+		t.Fatal("missing term app FaceTime-0_41640")
+	}
+	if ft0.SourcePort != "1-41640" {
+		t.Errorf("FaceTime-0_41640 source-port: got %q, want 1-41640 (0 floor normalized)", ft0.SourcePort)
+	}
 	if _, isSet := cfg.Applications.ApplicationSets["simple-app"]; isSet {
 		t.Error("simple-app should NOT be an application-set")
 	}


### PR DESCRIPTION
Fix two OPEN vSRX drop-in blockers in application definitions found compiling a real vSRX config (fable-review-170 B-6/B-7). Both are `pkg/config` application-validation changes; no dataplane/cargo change.

## #4336 — source-port/destination-port `0-N` range floor
A multi-term application `term X { source-port 0-41640; }` was hard-rejected with `source-port: invalid port 0: must be 1-65535`. Junos accepts 0 as the FLOOR of a port range (multi-term defs split a port space as `0-N` / `N+1-65535`, e.g. FaceTime `source-port 0-41640`).

Fixed in `resolveAppPort` (`compiler_applications.go`) — the single canonicalization chokepoint for BOTH direct-match and inline-term ports: normalize a range floor of `0` to `1`. Port 0 never appears on the wire so `0-N` ≡ `1-N`. Normalizing at this one point keeps `validatePortSpec`, the `userspacePortSpecRepresentable` #2124 capability gate, and the Rust `parse_port_spec` all in agreement (the latter two reject a raw 0 floor, so merely relaxing the validator would have created a commit-succeeds / apply-fails split). A bare single port `0` stays invalid; out-of-range / non-numeric endpoints still hard-reject.

## #4337 — unknown per-application `alg` accept-with-advisory
`application ssh-long { term 22 alg ssh; }` was hard-rejected at commit though a per-application ALG is validated only — it is NOT carried into the userspace dataplane snapshot (the only ALG signal on the wire is the GLOBAL `alg_disable_flags` bitfield). So xpf rejected an ALG it does not even enforce, blocking real vSRX configs.

Relaxed the #3353 strict reject to an accepted-but-inert advisory in `ValidateConfig` (`compiler_validate_warn.go`): `application <a>: alg "<name>" accepted but not enforced …`, mirroring the global `security alg` #4232 advisory. Known names (dns/ftp/sip/tftp) still commit silently; an unknown name commits with the advisory so a typo is still surfaced. Enforcement deferred to the per-application ALG slice of #2008.

## Validation
- **RED-on-revert proven** for both (Edit-revert, not git): #4336 reproduces the exact `invalid port 0: must be 1-65535`; #4337 re-instating the strict reject fails the accept-with-advisory assertions.
- New test `pkg/config/compiler_application_port_range_zero_4336_test.go`; updated `compiler_application_term_alg_3352_3353_test.go` (reject → accepted-with-advisory) + a `FaceTime-0_41640` normalization assertion in `TestMultiTermApplication`.
- `go test ./pkg/config/...` green, `go vet`, `go build ./...`, gofmt all clean.
- `docs/config-schema.md` updated (#3352/#3353→#4337 section + new #4336 section).

Closes #4336
Closes #4337

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi