### PR TITLE
config: prune an inline inactive: token, not just a leading one

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-07-06 — #4335: parser prunes an INLINE `inactive:` token (drop-in blocker)
+
+- **Timestamp**: 2026-07-06
+- **Action**: Fixed the parser so an INLINE `inactive:` marker (mid-statement,
+  not just leading) is pruned. Junos collapses a deactivated sub-statement onto
+  its parent statement's line, e.g. a destination-NAT pool address with a
+  deactivated port: `address 2001:559:8585:80::7aef/128 inactive: port 32400;`.
+  The lexer tokenizes `inactive:` as one identifier, so an inline marker landed
+  mid-`Keys` (`[address, 2001:...::7aef/128, inactive:, port, 32400]`); the
+  DNAT-pool compiler (`parseDNATPoolAddress`) then overwrote `pool.Address` with
+  the literal `"inactive:"` token, hard-rejecting a valid drop-in vSRX config
+  with "destination-nat pool: address inactive: is not a single host address".
+  The leading-only pruning (keys[0]=="inactive:") already lifted the whole
+  statement into `Node.Inactive`; extended `parseStatement` to also detect an
+  inline marker (index > 0) and drop the marker plus every token it governs (the
+  remainder of the statement) from the active `Keys`. A leaf carries one
+  `Inactive` flag and cannot mark part of its identity inactive, so — per the
+  #2008 H1 "deactivated == absent" doctrine — the governed sub-statement (the
+  port) is dropped: the address stays active as the pool member, the port
+  collapses to preserve-destination-port. Semantics: inline `inactive:`
+  deactivates the FOLLOWING sub-statement/modifier, NOT the parent statement.
+- **File(s)**: pkg/config/parser.go (parseStatement inline-marker branch),
+  pkg/config/inline_inactive_4335_test.go (new, RED-on-revert),
+  docs/config-schema.md ("Inline `inactive:` (mid-statement, #4335)").
+- **Validation**: `go test ./pkg/config/...` green; RED-on-revert proven
+  (neutralizing the branch fails the DNAT-pool commit + generic-prune tests
+  while the active-port and leading-marker control tests stay green);
+  `go build ./...`, gofmt, `go vet ./pkg/config/` clean.
+
 ## 2026-07-06 — #4328 follow-up: non-reth Junos-name kernel resolution + comment/speed nits
 
 - **Timestamp**: 2026-07-06

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -4563,6 +4563,24 @@ modifier never appears in the node's identity, the `setSchema` walk, the
 flat-set token grouping, and the value-slot `?` completion are all
 unaffected — they continue to see the node's real keyword.
 
+**Inline `inactive:` (mid-statement, #4335).** Junos also collapses a
+deactivated *sub-statement* onto its parent statement's line, e.g. a
+destination-NAT pool address with a deactivated port:
+`address 2001:db8::7aef/128 inactive: port 32400;`. Here `inactive:`
+deactivates the `port 32400` modifier, not the address. Because `:` is an
+identifier character the lexer tokenizes `inactive:` as one identifier, so
+an inline marker lands mid-`Keys` rather than leading. A node carries a
+single `Inactive` flag for its whole identity and cannot mark only part of
+a flat leaf inactive, so `parseStatement` drops the inline marker and every
+token it governs (the remainder of that statement) from the active `Keys` —
+consistent with the doctrine that a deactivated statement behaves as if it
+were absent. The parent statement (the address) stays active; the governed
+sub-statement (the port) is simply absent for compilation, exactly as a
+deactivated leaf would be. Before this fix the marker leaked mid-`Keys` and
+the DNAT-pool compiler read the literal `inactive:` token as the pool
+address, hard-rejecting a valid drop-in vSRX config
+(`inline_inactive_4335_test.go`).
+
 **Strip-before-validate / strip-before-compile contract.** A deactivated
 statement must be excluded from BOTH the typed-leaf gate and the compiler,
 and Junos accepts a deactivated leaf even when its value would be rejected

--- a/pkg/config/inline_inactive_4335_test.go
+++ b/pkg/config/inline_inactive_4335_test.go
@@ -1,0 +1,177 @@
+package config
+
+// Regression tests for #4335 — an INLINE `inactive:` marker (mid-statement),
+// not just a LEADING one.
+//
+// Junos collapses a deactivated sub-statement onto its parent statement's
+// line, e.g. a destination-NAT pool address with a deactivated port:
+//
+//	address 2001:559:8585:80::7aef/128 inactive: port 32400;
+//
+// Here `inactive:` deactivates the `port 32400` modifier, leaving the address
+// active as the pool member. Because `:` is an identifier character the lexer
+// tokenizes `inactive:` as a single identifier, so before this fix it landed
+// mid-Keys (`address 2001:...::7aef/128 inactive: port 32400`) and the DNAT
+// pool compiler overwrote pool.Address with the literal "inactive:" token,
+// rejecting the config with "address \"inactive:\" is not a single host
+// address". The parser now drops the inline marker and every token it governs
+// (the deactivated sub-statement) from the active statement, consistent with
+// the #2008 H1 doctrine that a deactivated statement behaves as if absent.
+//
+// RED-on-revert: reverting the inline-marker branch in parseStatement makes
+// the DNAT-pool commit assertion RED — pool.Address becomes "inactive:" and
+// validateDNATPoolStrict rejects the config.
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestInlineInactive_DNATPoolPortDeactivated is the core #4335 regression: a
+// DNAT pool address with an inline `inactive: port <N>` commits, the address
+// stays active as the pool member, and the deactivated port is absent
+// (PortRaw == "" == preserve destination port).
+func TestInlineInactive_DNATPoolPortDeactivated(t *testing.T) {
+	tree := mustParse(t, `security {
+    nat {
+        destination {
+            pool p1 {
+                address 2001:559:8585:80::7aef/128 inactive: port 32400;
+            }
+        }
+    }
+}`)
+
+	// Parser: the inline marker and the token(s) it governs are dropped from
+	// the active leaf's identity — pool.Address must NOT read "inactive:".
+	addr := tree.FindChild("security").FindChild("nat").
+		FindChild("destination").FindChild("pool").FindChild("address")
+	if addr == nil {
+		t.Fatal("address leaf not found")
+	}
+	if addr.Inactive {
+		t.Fatal("the ADDRESS itself must stay active; only the port is deactivated")
+	}
+	wantKeys := []string{"address", "2001:559:8585:80::7aef/128"}
+	if !reflect.DeepEqual(addr.Keys, wantKeys) {
+		t.Fatalf("inline inactive: not pruned from Keys: got %v, want %v", addr.Keys, wantKeys)
+	}
+
+	// Compile: this is the drop-in blocker. Before the fix the compiler read
+	// the literal "inactive:" as the pool address and rejected the config.
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile rejected an inline-inactive DNAT pool (#4335): %v", err)
+	}
+	pool := cfg.Security.NAT.Destination.Pools["p1"]
+	if pool == nil {
+		t.Fatalf("pool p1 not compiled; pools=%v", cfg.Security.NAT.Destination.Pools)
+	}
+	if pool.Address != "2001:559:8585:80::7aef/128" {
+		t.Fatalf("pool.Address = %q, want the active host address", pool.Address)
+	}
+	// The deactivated port is absent -> preserve-destination-port (PortRaw "").
+	if pool.PortRaw != "" || pool.Port != 0 {
+		t.Fatalf("deactivated port must be absent: PortRaw=%q Port=%d, want \"\"/0",
+			pool.PortRaw, pool.Port)
+	}
+}
+
+// TestInlineInactive_EquivalentToPortAbsent proves the inline-inactive form
+// compiles to exactly the same DNAT pool as authoring the address with no port
+// leaf at all — the deactivated modifier truly behaves as if it were absent.
+func TestInlineInactive_EquivalentToPortAbsent(t *testing.T) {
+	withInline := mustParse(t, `security {
+    nat { destination { pool p1 {
+        address 192.0.2.7/32 inactive: port 32400;
+    } } }
+}`)
+	portAbsent := mustParse(t, `security {
+    nat { destination { pool p1 {
+        address 192.0.2.7/32;
+    } } }
+}`)
+	cfgA, err := CompileConfig(withInline)
+	if err != nil {
+		t.Fatalf("compile inline-inactive: %v", err)
+	}
+	cfgB, err := CompileConfig(portAbsent)
+	if err != nil {
+		t.Fatalf("compile port-absent: %v", err)
+	}
+	if !reflect.DeepEqual(cfgA.Security.NAT.Destination, cfgB.Security.NAT.Destination) {
+		t.Fatalf("inline-inactive DNAT pool != port-absent pool:\n  inline=%+v\n  absent=%+v",
+			cfgA.Security.NAT.Destination.Pools["p1"], cfgB.Security.NAT.Destination.Pools["p1"])
+	}
+}
+
+// TestInlineInactive_ActivePortStillCompiles guards the sibling case: with NO
+// inactive: marker the port modifier is honored (the fix must not swallow a
+// legitimate inline port).
+func TestInlineInactive_ActivePortStillCompiles(t *testing.T) {
+	tree := mustParse(t, `security {
+    nat { destination { pool p1 {
+        address 192.0.2.7/32 port 32400;
+    } } }
+}`)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile active port: %v", err)
+	}
+	pool := cfg.Security.NAT.Destination.Pools["p1"]
+	if pool == nil || pool.Address != "192.0.2.7/32" {
+		t.Fatalf("pool address wrong: %+v", pool)
+	}
+	if pool.Port != 32400 || pool.PortRaw != "32400" {
+		t.Fatalf("active inline port dropped: Port=%d PortRaw=%q, want 32400", pool.Port, pool.PortRaw)
+	}
+}
+
+// TestInlineInactive_LeadingMarkerStillLifted guards that the pre-existing
+// LEADING `inactive:` handling is unchanged — the whole statement is
+// deactivated and its real identity survives in Keys.
+func TestInlineInactive_LeadingMarkerStillLifted(t *testing.T) {
+	tree := mustParse(t, `interfaces {
+    ge-0/0/0 {
+        unit 0 {
+            family inet {
+                inactive: address 192.168.50.210/24;
+            }
+        }
+    }
+}`)
+	addr := tree.FindChild("interfaces").FindChild("ge-0/0/0").
+		FindChild("unit").FindChild("family").FindChild("address")
+	if addr == nil {
+		t.Fatal("address node not found")
+	}
+	if !addr.Inactive {
+		t.Fatal("leading inactive: must deactivate the whole statement")
+	}
+	if got := addr.KeyPath(); got != "address 192.168.50.210/24" {
+		t.Fatalf("leading inactive: leaked into Keys: %q", got)
+	}
+}
+
+// TestInlineInactive_ParserDropsMarkerGenerically checks the parser-level
+// behavior directly on a generic leaf (not DNAT-specific): the inline marker
+// and everything it governs are dropped, leaving the active identity intact.
+func TestInlineInactive_ParserDropsMarkerGenerically(t *testing.T) {
+	tree := mustParse(t, "system {\n    host-name keep inactive: extra token;\n}")
+	hn := tree.FindChild("system").FindChild("host-name")
+	if hn == nil {
+		t.Fatalf("host-name not found; children=%v", tree.FindChild("system").Children)
+	}
+	if hn.Inactive {
+		t.Fatal("the host-name statement itself must stay active")
+	}
+	want := []string{"host-name", "keep"}
+	if !reflect.DeepEqual(hn.Keys, want) {
+		t.Fatalf("inline marker not pruned generically: got %v, want %v", hn.Keys, want)
+	}
+	// No stray "inactive:" token survived anywhere in the identity.
+	if strings.Contains(strings.Join(hn.Keys, " "), inactiveMarker) {
+		t.Fatalf("inactive: marker leaked into Keys: %v", hn.Keys)
+	}
+}

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -229,6 +229,31 @@ func (p *Parser) parseStatement() *Node {
 		}
 	}
 
+	// Detect an INLINE `inactive:` marker (#4335). Junos also collapses a
+	// deactivated sub-statement onto its parent statement's line, e.g.
+	//   address 2001:db8::7aef/128 inactive: port 32400;
+	// where the `inactive:` deactivates the `port 32400` modifier, NOT the
+	// address. Because `:` is an identifier character the lexer tokenizes
+	// `inactive:` as one identifier, so it lands mid-keys instead of leading.
+	// A node carries a single Inactive flag for its whole identity and cannot
+	// mark only part of a flat leaf inactive; consistent with the #2008 H1
+	// doctrine that a deactivated statement behaves as if it were absent, drop
+	// the marker and every token it governs (the remainder of this statement)
+	// from the active keys. The parent statement (here the address) stays
+	// active; the governed sub-statement (the port) is simply absent, exactly
+	// as a deactivated leaf would be for compilation. A leading marker is
+	// already lifted above, so any remaining marker is strictly inline (index
+	// > 0) and leaves at least the statement's identity key intact.
+	for i, k := range keys {
+		if i > 0 && k == inactiveMarker {
+			keys = keys[:i]
+			// The governed tokens were only on the key line of a leaf; a
+			// trailing `{ ... }` cannot follow an inline marker in valid
+			// Junos, so nothing more to consume here.
+			break
+		}
+	}
+
 	line := p.lexer.Peek().Line
 	col := p.lexer.Peek().Column
 


### PR DESCRIPTION
## Summary

Closes #4335.

xpf pruned a LEADING `inactive:` token but not an INLINE one, blocking a
drop-in vSRX config. The offending source line is a destination-NAT pool
address with a deactivated port modifier:

```
address 2001:559:8585:80::7aef/128 inactive: port 32400;
```

Because `:` is an identifier character, the lexer tokenizes `inactive:` as
one identifier, so an inline marker landed mid-`Keys`
(`[address, 2001:...::7aef/128, inactive:, port, 32400]`). The DNAT-pool
compiler (`parseDNATPoolAddress`) then walked every token and overwrote
`pool.Address` with the literal `"inactive:"`, hard-rejecting the config:
`destination-nat pool "p1": address "inactive:" is not a single host address`.

## Fix

`parseStatement` (`pkg/config/parser.go`) already lifted a **leading**
`inactive:` (index 0) into `Node.Inactive`. This extends it to also detect
an **inline** marker (index > 0) and drop the marker plus every token it
governs (the remainder of the statement) from the active `Keys`.

### Deactivation semantics

An inline `inactive:` deactivates the **following** sub-statement/modifier,
NOT the parent statement. For `address X inactive: port 32400`:

- the **address stays active** as the pool member (`pool.Address = X`), and
- the **port is deactivated** — dropped from `Keys`, so `PortRaw == ""`,
  `Port == 0` = preserve-destination-port.

A node carries a single `Inactive` flag and cannot mark only part of a flat
leaf inactive, so — per the #2008 H1 doctrine that a deactivated statement
behaves as if absent — the governed sub-statement is dropped. The
inline-inactive pool compiles bit-identically to authoring the address with
no `port` leaf at all (`TestInlineInactive_EquivalentToPortAbsent`).

## Tests (`pkg/config/inline_inactive_4335_test.go`)

- `TestInlineInactive_DNATPoolPortDeactivated` — the #4335 case commits;
  address active, port absent. **RED-on-revert.**
- `TestInlineInactive_EquivalentToPortAbsent` — inline-inactive == port-absent.
- `TestInlineInactive_ActivePortStillCompiles` — control: an inline `port`
  with no marker is still honored (fix doesn't swallow legit modifiers).
- `TestInlineInactive_LeadingMarkerStillLifted` — control: leading `inactive:`
  still deactivates the whole statement into `Node.Inactive`.
- `TestInlineInactive_ParserDropsMarkerGenerically` — parser-level, non-DNAT.

RED-on-revert verified: neutralizing the inline branch fails the two
fix-dependent tests + the generic-prune test while both control tests stay
green.

## Validation

- `go test ./pkg/config/...` green
- `go build ./...`, `gofmt`, `go vet ./pkg/config/` clean
- Docs updated: `docs/config-schema.md` ("Inline `inactive:` (mid-statement, #4335)")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi