### PR TITLE
config: permit "/" in address-object names (vSRX prefix-in-name drop-in)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-06 — #4340 allow "/" in address-object names (vSRX prefix-in-name drop-in blocker)
+
+- **Timestamp**: 2026-07-06
+- **Action**: Real vSRX configs name address objects after their prefix
+  (`net_10.0.0.0/8`, `net4_sfmix_72.52.96.201/32`,
+  `net_2001:559:8585:200::/64`) — the near-universal convention. xpf
+  HARD-REJECTED every such name ("address-book entry name … must not
+  contain '/'"), so a mechanical drop-in was impossible (194 objects +
+  every policy reference would need lockstep renaming). DIAGNOSIS: `/`
+  was reserved by `validateAddressBookEntryNamesStrict` (#3061,
+  `compiler_validate_strict.go`) purely to keep the zone-local fold's
+  synthetic `zone-local/<zone>/<name>` internal key collision-proof —
+  NOT because any consumer treats the object NAME as a path. Every
+  resolver (policyMatchNamedAddressRefs, resolveUserspaceAddressBookEntry,
+  classifyPolicyAddresses, the wire snapshot) keys objects by the FULL
+  name via direct map lookups, so a `/`-bearing name resolves end to end
+  unchanged. FIX: narrow the reservation from "any `/`" to the two
+  invariants the synthetic key actually needs — (1) an operator
+  address-book entry name may not BEGIN with the reserved `zone-local/`
+  prefix (collision guard), (2) a security-zone NAME may not contain `/`
+  (it is the `/`-free first segment `ZoneLocalUnqualify` splits on). `/`
+  is now permitted freely elsewhere in an entry name. ZoneLocalUnqualify
+  already splits on the FIRST `/` only, so a `/`-bearing zone-local name
+  round-trips (`zone-local/trust/net_10.0.0.0/8` → zone trust, name
+  net_10.0.0.0/8). RED-on-revert proven: with the old any-`/` reject,
+  `TestAddressBookSlashNameCommits` /
+  `TestAddressBookSlashNameZoneLocalFoldRoundTrips` fail with the exact
+  "must not contain '/'" error; the userspace resolution test passes on
+  both revisions (confirming no consumer depended on the ban). Full
+  pkg/config + pkg/dataplane/userspace + policymatch + grpcapi + api +
+  cli suites, gofmt, vet, go build ./... clean.
+- **File(s)**: pkg/config/compiler_validate_strict.go,
+  pkg/config/compiler_security_addressbook.go, pkg/config/compiler.go,
+  pkg/config/addressbook_name_slash_3061_test.go,
+  pkg/config/addressbook_name_slash_4340_test.go,
+  pkg/dataplane/userspace/addressbook_slash_name_4340_test.go,
+  docs/config-schema.md, _Log.md
+
 ## 2026-07-06 — #4328 follow-up: non-reth Junos-name kernel resolution + comment/speed nits
 
 - **Timestamp**: 2026-07-06

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3314,18 +3314,37 @@ zone-locally to that qualified name. A token NOT defined in the policy's zone
 book is left unchanged so it resolves against the global book; when a name
 exists in BOTH, the zone-local value WINS.
 
-**Collision-proof synthetic namespace:** the lexer permits `/` in an identifier
-token (it is needed for IP-literal VALUES like `10.0.0.0/24`), so without a
-guard an operator could name a global address `zone-local/trust/web-server` and
-have it silently clobbered by the fold. `validateAddressBookEntryNamesStrict`
-(run BEFORE the fold, on the pristine global book) hard-rejects `/` in any
-address-book entry NAME (global or zone-local `address`/`address-set`) and any
-security-zone NAME at commit — matching Junos object-naming rules — so no
-operator name can contain `/` and none can equal a synthetic `zone-local/...`
-name. Only the NAME is checked, never the address VALUE/prefix. Strict on
-commit / commit-check; the tolerant load / peer-sync path (`lenientAddressBookNames`)
-downgrades to a warning (#1960 no-brick), backstopped by the fold's
-no-clobber guard (it skips a global-book key that already exists).
+**Collision-proof synthetic namespace (#3061, narrowed in #4340):** real vSRX
+configs almost universally name an address object after its prefix —
+`net_10.0.0.0/8`, `net4_sfmix_72.52.96.201/32`, `net_2001:559:8585:200::/64` —
+so the NAME legitimately contains `/` (the lexer already permits `/` in an
+identifier, needed for the CIDR VALUE too). `/` in a name is a display
+identifier, never a structural token: the whole downstream resolution path
+(`policyMatchNamedAddressRefs`, `resolveUserspaceAddressBookEntry`,
+`classifyPolicyAddresses`, the wire snapshot) keys objects by the FULL name via
+direct map lookups, so a `/`-bearing name resolves correctly end to end.
+`validateAddressBookEntryNamesStrict` (run BEFORE the fold, on the pristine
+global book) therefore enforces only the two invariants the synthetic
+`zone-local/<zone>/<name>` key actually needs:
+
+1. **No operator entry name may begin with the reserved `zone-local/` prefix**
+   (global or zone-local `address`/`address-set`). Otherwise a global address
+   named `zone-local/trust/web-server` would collide with the synthetic name
+   the fold mints for a zone-local `web-server` in zone `trust`, and the fold's
+   no-clobber guard would silently drop the zone-local entry. Reserving only
+   the PREFIX — not every `/` — keeps `/` free elsewhere in a name.
+2. **No security-zone NAME may contain `/`.** The zone is the `/`-free first
+   segment after the prefix; `ZoneLocalUnqualify` splits zone from name on the
+   FIRST `/`, so a `/`-free zone keeps the split unambiguous even when the
+   address name that follows contains `/` (`zone-local/trust/net_10.0.0.0/8`
+   → zone `trust`, name `net_10.0.0.0/8`). Zones never carry a prefix-in-name
+   convention, so this costs nothing real.
+
+Only the NAME is checked, never the address VALUE/prefix. Strict on commit /
+commit-check; the tolerant load / peer-sync path (`lenientAddressBookNames`)
+downgrades the reserved-prefix / zone-slash reject to a warning (#1960
+no-brick), backstopped by the fold's no-clobber guard (it skips a global-book
+key that already exists).
 
 After this pass the whole downstream resolution path
 (wire snapshot, `nameToID`, `classifyPolicyAddresses`, the strict/warn
@@ -3342,11 +3361,17 @@ scoped to security-policy match addresses. Regression coverage:
 (`TestZoneLocalAddressBookResolves` — fail-on-revert resolution guard,
 `TestZoneLocalAddressBookScoping` — precedence + cross-zone isolation) and
 `pkg/config/addressbook_name_slash_3061_test.go`
-(`TestAddressBookGlobalNameSlashRejected`,
-`TestAddressBookZoneLocalNameSlashRejected`,
+(`TestAddressBookReservedPrefixNameRejected`,
+`TestAddressBookZoneLocalReservedPrefixRejected`,
 `TestSecurityZoneNameSlashRejected` — collision-safety fail-on-revert guards,
 `TestAddressBookNameSlashNormalConfigUnaffected` — prefix-value anti-over-reject,
-`TestAddressBookNameSlashLenientDowngrades` — tolerant-path warning).
+`TestAddressBookReservedPrefixLenientDowngrades` — tolerant-path warning) and
+`pkg/config/addressbook_name_slash_4340_test.go`
+(`TestAddressBookSlashNameCommits` — prefix-named objects commit + resolve,
+`TestAddressBookSlashNameZoneLocalFoldRoundTrips` — fold + unqualify round-trip
+of a `/`-bearing zone-local name) plus
+`pkg/dataplane/userspace/addressbook_slash_name_4340_test.go`
+(`TestPolicySlashNameResolvesToPrefix` — end-to-end dataplane resolution).
 
 **Operator display (#3358).** The synthetic `zone-local/<zone>/<name>` key is an
 INTERNAL identity, never an operator-facing string. The display surfaces that

--- a/pkg/config/addressbook_name_slash_3061_test.go
+++ b/pkg/config/addressbook_name_slash_3061_test.go
@@ -5,46 +5,50 @@ import (
 	"testing"
 )
 
-// TestAddressBookGlobalNameSlashRejected is the #3061 collision-safety guard.
-// A `/` in an address-book entry NAME is hard-rejected at strict commit so the
+// TestAddressBookReservedPrefixNameRejected is the #3061 collision-safety
+// guard, narrowed by #4340. A `/` is now permitted in an address-book entry
+// name (see TestAddressBookSlashNameCommits), but a name that BEGINS WITH the
+// reserved "zone-local/" prefix is still hard-rejected at strict commit so the
 // synthetic zone-local/<zone>/<name> namespace minted by the zone-local fold
-// (resolveZoneLocalAddressBooks) is collision-proof. The lexer permits `/` in
-// an identifier (needed for IP-literal VALUES), so without this gate an
+// (resolveZoneLocalAddressBooks) stays collision-proof: without this gate an
 // operator could name a global address `zone-local/trust/web-server` and have
-// it silently clobbered by the fold.
+// it silently clobber the synthetic name the fold mints for a zone-local
+// `web-server` in zone trust.
 //
-// Remove validateAddressBookEntryNamesStrict (or its dispatch in compiler.go)
-// and this test goes RED (CompileConfig accepts the `/` name).
-func TestAddressBookGlobalNameSlashRejected(t *testing.T) {
+// Relax validateAddressBookEntryNamesStrict (or its dispatch in compiler.go)
+// and this test goes RED (CompileConfig accepts the reserved-prefix name).
+func TestAddressBookReservedPrefixNameRejected(t *testing.T) {
 	tree := buildTree(t, []string{
 		"set security address-book global address zone-local/trust/web-server 10.0.0.0/24",
 	})
 	_, err := CompileConfig(tree)
 	if err == nil {
-		t.Fatalf("expected commit to reject a `/` in a global address-book entry name")
+		t.Fatalf("expected commit to reject a reserved zone-local/ prefix in a global address-book entry name")
 	}
-	if !strings.Contains(err.Error(), "must not contain '/'") {
-		t.Fatalf("error %q does not explain the `/` restriction", err.Error())
+	if !strings.Contains(err.Error(), "reserved") || !strings.Contains(err.Error(), "zone-local/") {
+		t.Fatalf("error %q does not explain the reserved-prefix restriction", err.Error())
 	}
 }
 
-// TestAddressBookZoneLocalNameSlashRejected covers the zone-local book NAME.
-func TestAddressBookZoneLocalNameSlashRejected(t *testing.T) {
+// TestAddressBookZoneLocalReservedPrefixRejected covers the zone-local book
+// NAME: the reserved-prefix guard applies to zone-local entries too.
+func TestAddressBookZoneLocalReservedPrefixRejected(t *testing.T) {
 	tree := buildTree(t, []string{
 		"set security zones security-zone trust interfaces eth0",
-		"set security zones security-zone trust address-book address a/b 10.0.0.0/24",
+		"set security zones security-zone trust address-book address zone-local/x/y 10.0.0.0/24",
 	})
 	_, err := CompileConfig(tree)
 	if err == nil {
-		t.Fatalf("expected commit to reject a `/` in a zone-local address-book entry name")
+		t.Fatalf("expected commit to reject a reserved zone-local/ prefix in a zone-local address-book entry name")
 	}
-	if !strings.Contains(err.Error(), "must not contain '/'") {
-		t.Fatalf("error %q does not explain the `/` restriction", err.Error())
+	if !strings.Contains(err.Error(), "reserved") {
+		t.Fatalf("error %q does not explain the reserved-prefix restriction", err.Error())
 	}
 }
 
-// TestSecurityZoneNameSlashRejected covers the security-zone NAME, the other
-// component of the synthetic name.
+// TestSecurityZoneNameSlashRejected covers the security-zone NAME, which keeps
+// the full `/` ban (the zone is the unambiguous first segment of the synthetic
+// zone-local/<zone>/<name> key, so it must stay `/`-free).
 func TestSecurityZoneNameSlashRejected(t *testing.T) {
 	tree := buildTree(t, []string{
 		"set security zones security-zone a/b interfaces eth0",
@@ -73,25 +77,25 @@ func TestAddressBookNameSlashNormalConfigUnaffected(t *testing.T) {
 	}
 }
 
-// TestAddressBookNameSlashLenientDowngrades asserts the tolerant load / peer-
-// sync path downgrades the `/`-name rejection to a warning (#1960 no-brick) so
-// an already-persisted config an older binary accepted still boots.
-func TestAddressBookNameSlashLenientDowngrades(t *testing.T) {
+// TestAddressBookReservedPrefixLenientDowngrades asserts the tolerant load /
+// peer-sync path downgrades the reserved-prefix rejection to a warning (#1960
+// no-brick) so an already-persisted config an older binary accepted still boots.
+func TestAddressBookReservedPrefixLenientDowngrades(t *testing.T) {
 	tree := buildTree(t, []string{
-		"set security address-book global address weird/name 10.0.0.0/24",
+		"set security address-book global address zone-local/weird/name 10.0.0.0/24",
 	})
 	cfg, err := CompileConfigLenient(tree)
 	if err != nil {
-		t.Fatalf("lenient compile must not brick on a `/` name: %v", err)
+		t.Fatalf("lenient compile must not brick on a reserved-prefix name: %v", err)
 	}
 	found := false
 	for _, w := range cfg.Warnings {
-		if strings.Contains(w, "must not contain '/'") {
+		if strings.Contains(w, "reserved") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("lenient compile must record a warning for the `/` name; warnings = %v", cfg.Warnings)
+		t.Fatalf("lenient compile must record a warning for the reserved-prefix name; warnings = %v", cfg.Warnings)
 	}
 }

--- a/pkg/config/addressbook_name_slash_4340_test.go
+++ b/pkg/config/addressbook_name_slash_4340_test.go
@@ -1,0 +1,153 @@
+package config
+
+import "testing"
+
+// TestAddressBookSlashNameCommits is the #4340 acceptance proof. Real vSRX
+// configs name an address object after its prefix — the near-universal operator
+// convention: net_10.0.0.0/8, net4_sfmix_72.52.96.201/32,
+// net_2001:559:8585:200::/64. The `/` in such a NAME is a display identifier,
+// not a structural token, so it must commit and its policy reference must
+// resolve.
+//
+// RED-on-revert: before #4340 validateAddressBookEntryNamesStrict rejected any
+// `/` in an address-book entry name ("must not contain '/'"), so both the
+// definition AND the policy reference failed at commit.
+func TestAddressBookSlashNameCommits(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security zones security-zone trust interfaces ge-0-0-0",
+		"set security zones security-zone untrust interfaces ge-0-0-1",
+		// v4 and v6 objects named after their prefix (a CIDR value + a `/`
+		// in the NAME).
+		"set security address-book global address net_10.0.0.0/8 10.0.0.0/8",
+		"set security address-book global address net4_sfmix_72.52.96.201/32 72.52.96.201/32",
+		"set security address-book global address net_2001:559:8585:200::/64 2001:559:8585:200::/64",
+		// An address-set that references the slash-named members.
+		"set security address-book global address-set feeds address net_10.0.0.0/8",
+		"set security address-book global address-set feeds address net_2001:559:8585:200::/64",
+		// A policy that references the slash-named objects by name.
+		"set security policies from-zone trust to-zone untrust policy p1 match source-address net_10.0.0.0/8",
+		"set security policies from-zone trust to-zone untrust policy p1 match source-address net4_sfmix_72.52.96.201/32",
+		"set security policies from-zone trust to-zone untrust policy p1 match destination-address feeds",
+		"set security policies from-zone trust to-zone untrust policy p1 match application any",
+		"set security policies from-zone trust to-zone untrust policy p1 then permit",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("strict commit rejected a prefix-named address object (the #4340 blocker): %v", err)
+	}
+
+	// The address objects are keyed by the FULL slash-bearing name and carry
+	// the CIDR VALUE (name and value are distinct — the value legitimately
+	// contains a `/` too).
+	ab := cfg.Security.AddressBook
+	if ab == nil {
+		t.Fatal("compiled config has no global address book")
+	}
+	for name, wantValue := range map[string]string{
+		"net_10.0.0.0/8":             "10.0.0.0/8",
+		"net4_sfmix_72.52.96.201/32": "72.52.96.201/32",
+		"net_2001:559:8585:200::/64": "2001:559:8585:200::/64",
+	} {
+		addr := ab.Addresses[name]
+		if addr == nil {
+			t.Fatalf("address %q not found in the compiled book (keys: %v)", name, addressNames(ab))
+		}
+		if addr.Value != wantValue {
+			t.Fatalf("address %q: value = %q, want %q (name must not be confused with the CIDR value)", name, addr.Value, wantValue)
+		}
+	}
+
+	// The address-set resolved its slash-named members (strict commit runs
+	// validatePolicyMatchAddressSetMembersStrict, so a dangling member would
+	// have failed above — assert the members are the slash names verbatim).
+	set := ab.AddressSets["feeds"]
+	if set == nil {
+		t.Fatal("address-set feeds not found")
+	}
+	if len(set.Addresses) != 2 {
+		t.Fatalf("address-set feeds members = %v, want the two slash-named entries", set.Addresses)
+	}
+
+	// The policy's source-address tokens are the slash names verbatim (global
+	// book — not rewritten by the zone-local fold), so they resolve directly
+	// against the book. A successful STRICT compile already proves
+	// validatePolicyMatchAddressesStrict recognized them; assert the tokens
+	// survived unmangled for good measure.
+	pol := findPolicy(t, cfg, "trust", "untrust", "p1")
+	assertContains(t, "source-address", pol.Match.SourceAddresses, "net_10.0.0.0/8")
+	assertContains(t, "source-address", pol.Match.SourceAddresses, "net4_sfmix_72.52.96.201/32")
+	assertContains(t, "destination-address", pol.Match.DestinationAddresses, "feeds")
+}
+
+// TestAddressBookSlashNameZoneLocalFoldRoundTrips proves the zone-local fold
+// (resolveZoneLocalAddressBooks) mints a collision-proof synthetic name for a
+// `/`-bearing zone-local object and rewrites the policy reference to it — and
+// that ZoneLocalUnqualify reverses it back to the authored `/`-bearing name.
+// This is the case that made #3061 reserve `/` in the first place; #4340 keeps
+// it correct while permitting the `/`.
+func TestAddressBookSlashNameZoneLocalFoldRoundTrips(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security zones security-zone trust interfaces ge-0-0-0",
+		"set security zones security-zone untrust interfaces ge-0-0-1",
+		"set security zones security-zone trust address-book address net_172.16.0.0/12 172.16.0.0/12",
+		"set security policies from-zone trust to-zone untrust policy p1 match source-address net_172.16.0.0/12",
+		"set security policies from-zone trust to-zone untrust policy p1 match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy p1 match application any",
+		"set security policies from-zone trust to-zone untrust policy p1 then permit",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("strict commit rejected a `/`-named zone-local object: %v", err)
+	}
+
+	// The fold injected the qualified synthetic name into the global book.
+	const qualified = "zone-local/trust/net_172.16.0.0/12"
+	addr := cfg.Security.AddressBook.Addresses[qualified]
+	if addr == nil {
+		t.Fatalf("zone-local fold did not mint %q (keys: %v)", qualified, addressNames(cfg.Security.AddressBook))
+	}
+	if addr.Value != "172.16.0.0/12" {
+		t.Fatalf("qualified entry value = %q, want 172.16.0.0/12", addr.Value)
+	}
+
+	// The policy source token was rewritten to the qualified name so it
+	// resolves zone-locally.
+	pol := findPolicy(t, cfg, "trust", "untrust", "p1")
+	assertContains(t, "source-address", pol.Match.SourceAddresses, qualified)
+
+	// ZoneLocalUnqualify reverses it: the `/`-free zone is the first segment,
+	// the `/`-bearing object name follows, split on the FIRST `/` only.
+	zone, name, ok := ZoneLocalUnqualify(qualified)
+	if !ok || zone != "trust" || name != "net_172.16.0.0/12" {
+		t.Fatalf("ZoneLocalUnqualify(%q) = (%q, %q, %v), want (trust, net_172.16.0.0/12, true)", qualified, zone, name, ok)
+	}
+	// DisplayAddressName shows the authored `/`-bearing name to the operator.
+	if got := DisplayAddressName(qualified); got != "net_172.16.0.0/12" {
+		t.Fatalf("DisplayAddressName(%q) = %q, want net_172.16.0.0/12", qualified, got)
+	}
+	// A non-synthetic `/`-bearing operator name is returned unchanged.
+	if got := DisplayAddressName("net_10.0.0.0/8"); got != "net_10.0.0.0/8" {
+		t.Fatalf("DisplayAddressName should not touch a non-synthetic slash name; got %q", got)
+	}
+}
+
+func addressNames(ab *AddressBook) []string {
+	if ab == nil {
+		return nil
+	}
+	out := make([]string, 0, len(ab.Addresses))
+	for n := range ab.Addresses {
+		out = append(out, n)
+	}
+	return out
+}
+
+func assertContains(t *testing.T, field string, tokens []string, want string) {
+	t.Helper()
+	for _, tok := range tokens {
+		if tok == want {
+			return
+		}
+	}
+	t.Fatalf("%s %v does not contain %q", field, tokens, want)
+}

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -920,18 +920,19 @@ type compileOpts struct {
 	// later-sorting instance so the two never actually share a table. Same
 	// doctrine as lenientZoneIDCollision; mirrors the #3075 / #1873 id gates.
 	lenientRoutingInstanceTableIDCollision bool
-	// lenientAddressBookNames (#3061) downgrades the address-book / zone name
-	// `/`-character gate (validateAddressBookEntryNamesStrict) from a hard
-	// compile error to a cfg.Warnings entry. The strict commit / commit-check
-	// path hard-rejects a `/` in any address-book entry name (global or
-	// zone-local address / address-set) or any security-zone name — matching
-	// Junos object-naming rules and making the synthetic `zone-local/<zone>/
-	// <name>` internal name (resolveZoneLocalAddressBooks) collision-proof. The
-	// tolerant load / peer-sync paths downgrade to a warning so an already-
-	// persisted config an older binary accepted (before this gate existed) still
-	// BOOTS (#1960 no-brick); the fold's no-clobber guard keeps such a config
-	// from silently overwriting an operator entry. Same doctrine as
-	// lenientZoneCount.
+	// lenientAddressBookNames (#3061, narrowed in #4340) downgrades the
+	// address-book / zone name gate (validateAddressBookEntryNamesStrict) from a
+	// hard compile error to a cfg.Warnings entry. The strict commit /
+	// commit-check path hard-rejects only an address-book entry name that begins
+	// with the reserved `zone-local/` prefix (global or zone-local address /
+	// address-set) or a security-zone name that contains `/` — the two invariants
+	// that keep the synthetic `zone-local/<zone>/<name>` internal name
+	// (resolveZoneLocalAddressBooks) collision-proof. A `/` elsewhere in an entry
+	// name (net_10.0.0.0/8, the #4340 prefix-in-name convention) is accepted. The
+	// tolerant load / peer-sync paths downgrade the reject to a warning so an
+	// already-persisted config an older binary accepted still BOOTS (#1960
+	// no-brick); the fold's no-clobber guard keeps such a config from silently
+	// overwriting an operator entry. Same doctrine as lenientZoneCount.
 	lenientAddressBookNames bool
 	// lenientZoneInterfaceMembership (#3072) downgrades the zone-interface
 	// membership gate (validateZoneInterfaceMembershipStrict) from a hard
@@ -2535,17 +2536,18 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		return nil, err
 	}
 
-	// #3061 — reject `/` in operator-typed address-book entry names and
-	// security-zone names BEFORE folding zone-local books, so the synthetic
-	// zone-local/<zone>/<name> internal names minted by
-	// resolveZoneLocalAddressBooks are collision-proof (an operator name can no
-	// longer contain `/` and so can never equal a synthetic name). This MUST
-	// run on the pristine global book — i.e. before the fold injects the
-	// `/`-bearing synthetic names — so it is placed here rather than in the
-	// post-fold accumulator. Strict on commit / commit-check (hard-reject);
-	// tolerant load / peer-sync downgrade to a warning (#1960 no-brick — a `/`
-	// name was unusual but accepted before this gate existed; the fold's
-	// no-clobber guard keeps it from silently overwriting an operator entry).
+	// #3061 (narrowed in #4340) — enforce the two naming invariants that keep
+	// the synthetic zone-local/<zone>/<name> internal names minted by
+	// resolveZoneLocalAddressBooks collision-proof, BEFORE folding zone-local
+	// books: an operator address-book entry name may not begin with the reserved
+	// `zone-local/` prefix, and a security-zone name may not contain `/`. A `/`
+	// elsewhere in an entry name (net_10.0.0.0/8) is permitted — the
+	// prefix-in-name convention real vSRX configs use (#4340). This MUST run on
+	// the pristine global book — i.e. before the fold injects the `/`-bearing
+	// synthetic names — so it is placed here rather than in the post-fold
+	// accumulator. Strict on commit / commit-check (hard-reject); tolerant load /
+	// peer-sync downgrade to a warning (#1960 no-brick; the fold's no-clobber
+	// guard keeps it from silently overwriting an operator entry).
 	if err := validateAddressBookEntryNamesStrict(cfg); err != nil {
 		if opts.lenientAddressBookNames {
 			cfg.Warnings = append(cfg.Warnings,

--- a/pkg/config/compiler_security_addressbook.go
+++ b/pkg/config/compiler_security_addressbook.go
@@ -6,15 +6,17 @@ import (
 )
 
 // zoneLocalNamePrefix marks a zone-qualified internal address-book name
-// minted by resolveZoneLocalAddressBooks (#3061). The `/` separators make
-// the synthetic name collision-proof against operator-typed names: the lexer
-// permits `/` in an identifier (needed for IP literals like 10.0.0.0/24), but
-// validateAddressBookEntryNamesStrict hard-rejects `/` in any address-book
-// entry name and any security-zone name at commit, so no operator name can
-// contain `/` and therefore none can equal a synthetic `zone-local/...` name.
-// The fold also skips a key already present in the global book as a
-// defence-in-depth no-clobber for the tolerant load path (a persisted
-// pre-validator config that an older binary accepted).
+// minted by resolveZoneLocalAddressBooks (#3061). The synthetic name is kept
+// collision-proof against operator-typed names by two narrow gates in
+// validateAddressBookEntryNamesStrict (relaxed in #4340): an operator
+// address-book entry name may NOT begin with this "zone-local/" prefix, and a
+// security-zone name may NOT contain `/`. A `/` is otherwise permitted inside
+// an entry NAME so real vSRX configs can name an object after its prefix
+// (net_10.0.0.0/8) — the zone is the `/`-free first segment after the prefix,
+// so ZoneLocalUnqualify still splits zone from a `/`-bearing name on the first
+// `/` unambiguously. The fold also skips a key already present in the global
+// book as a defence-in-depth no-clobber for the tolerant load path (a
+// persisted pre-validator config that an older binary accepted).
 const zoneLocalNamePrefix = "zone-local/"
 
 // zoneLocalQualify mints the global-book key for a zone-local address-book
@@ -27,9 +29,13 @@ func zoneLocalQualify(zone, name string) string {
 // ZoneLocalUnqualify reverses zoneLocalQualify. If qualified is a synthetic
 // zone-local key minted by the #3061 fold ("zone-local/<zone>/<name>"), it
 // returns the authored zone and address-book name with ok=true; any other
-// token returns ok=false. validateAddressBookEntryNamesStrict forbids `/` in
-// every operator-typed zone and address-book name, so the single `/` after the
-// prefix always splits zone from name unambiguously.
+// token returns ok=false. The zone component is the `/`-free first segment
+// after the prefix (validateAddressBookEntryNamesStrict forbids `/` in a
+// security-zone name), so strings.Cut on the first `/` splits zone from name
+// unambiguously even when <name> itself contains `/` (net_10.0.0.0/8) — the
+// #4340 prefix-in-name convention. Only the reserved "zone-local/" prefix is
+// withheld from operator entry names, so a non-synthetic `/`-bearing operator
+// name (net_10.0.0.0/8) never matches the prefix and returns ok=false.
 func ZoneLocalUnqualify(qualified string) (zone, name string, ok bool) {
 	rest, found := strings.CutPrefix(qualified, zoneLocalNamePrefix)
 	if !found {

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -6775,25 +6775,44 @@ func validateHostInboundStanzaStrict(zone, ifName string, hib *HostInboundTraffi
 	return nil
 }
 
-// validateAddressBookEntryNamesStrict (#3061) hard-rejects a `/` character in
-// any address-book entry NAME — a global `address`/`address-set` name, a
-// zone-local `address`/`address-set` name — or any security-zone NAME. Junos
-// object-naming rules disallow `/` in such identifiers, but the xpf lexer
-// permits `/` in an identifier token (it is needed for IP-literal values like
-// 10.0.0.0/24), and no other validator rejected it.
+// validateAddressBookEntryNamesStrict (#3061, relaxed in #4340) enforces the
+// two naming invariants the zone-local address-book fold
+// (resolveZoneLocalAddressBooks) depends on, while otherwise PERMITTING the
+// prefix-in-name convention every real vSRX config uses: an address object is
+// almost universally named after its prefix — net_10.0.0.0/8,
+// net4_sfmix_72.52.96.201/32, net_2001:559:8585:200::/64. The `/` in such a
+// name is only a display identifier, never a structural token; the whole
+// downstream resolution path (policyMatchNamedAddressRefs,
+// resolveUserspaceAddressBookEntry, the wire snapshot) keys address objects by
+// the FULL name string via direct map lookups, so a `/` in the name resolves
+// correctly end to end.
 //
-// This is load-bearing for the zone-local address-book fold
-// (resolveZoneLocalAddressBooks): the fold mints synthetic global names of the
-// form zone-local/<zone>/<name>. If an operator could type a name containing
-// `/` (e.g. a global address literally named zone-local/trust/web-server),
-// that name could collide with a synthetic name and be silently clobbered by
-// the fold — wrong policy address resolution with no commit error. Rejecting
-// `/` in every operator-typed name makes the synthetic `zone-local/...`
-// namespace collision-proof.
+// The fold mints synthetic global names of the form zone-local/<zone>/<name>.
+// Only two invariants keep that namespace collision-proof and unambiguously
+// reversible (ZoneLocalUnqualify) — and neither needs a blanket `/` ban:
+//
+//  1. No operator-typed address-book ENTRY name (global or zone-local
+//     address / address-set) may begin with the reserved "zone-local/"
+//     prefix. If it could, a global address literally named
+//     zone-local/trust/web-server would collide with the synthetic name the
+//     fold mints for a zone-local `web-server` in zone trust, and the fold's
+//     no-clobber guard would silently drop the zone-local entry (wrong
+//     address resolution, no commit error — the #3061 hazard). Reserving only
+//     this PREFIX, not every `/`, lets `/` appear freely elsewhere in a name.
+//
+//  2. No security-zone NAME may contain `/`. The zone is the FIRST segment
+//     after the reserved prefix, and ZoneLocalUnqualify splits zone from name
+//     on the first `/`; a `/`-free zone keeps that split unambiguous even
+//     when the address NAME that follows contains `/`
+//     (zone-local/trust/net_10.0.0.0/8 unqualifies to zone=trust,
+//     name=net_10.0.0.0/8 because strings.Cut stops at the first `/`). Zones
+//     never carry a prefix-in-name convention, so this costs nothing real.
 //
 // IMPORTANT: only the NAME token is checked, never an address VALUE/prefix —
-// `address web-server 10.0.0.0/24` is fine (the name is web-server; the
-// 10.0.0.0/24 prefix is the value, not validated here).
+// `address web-server 10.0.0.0/24` has always been fine (the name is
+// web-server; the 10.0.0.0/24 prefix is the value). After #4340
+// `address net_10.0.0.0/8 10.0.0.0/8` is ALSO fine: the `/` in the NAME is
+// permitted, matching the prefix-in-name convention.
 //
 // MUST run on the PRISTINE global book, i.e. BEFORE resolveZoneLocalAddressBooks
 // injects the `/`-bearing synthetic names; the caller enforces that ordering.
@@ -6801,12 +6820,26 @@ func validateAddressBookEntryNamesStrict(cfg *Config) error {
 	if cfg == nil {
 		return nil
 	}
-	checkName := func(kind, name string) error {
+	// checkEntryName reserves ONLY the synthetic zone-local/ prefix on an
+	// operator-typed address-book entry name (#4340); any other `/` is allowed.
+	checkEntryName := func(kind, name string) error {
+		if strings.HasPrefix(name, zoneLocalNamePrefix) {
+			return fmt.Errorf(
+				"%s name %q must not begin with the reserved %q prefix; that "+
+					"namespace is reserved for the internal zone-local "+
+					"address book — rename the object", kind, name, zoneLocalNamePrefix)
+		}
+		return nil
+	}
+	// checkZoneName keeps the full `/` ban on a security-zone name: the zone is
+	// the unambiguous first segment of the synthetic zone-local/<zone>/<name>
+	// key, so it must stay `/`-free.
+	checkZoneName := func(name string) error {
 		if strings.Contains(name, "/") {
 			return fmt.Errorf(
-				"%s name %q must not contain '/'; '/' is reserved for "+
-					"address prefixes and for the internal zone-local "+
-					"address-book namespace — rename the object", kind, name)
+				"security-zone name %q must not contain '/'; '/' is reserved "+
+					"for the internal zone-local address-book namespace — "+
+					"rename the zone", name)
 		}
 		return nil
 	}
@@ -6823,7 +6856,7 @@ func validateAddressBookEntryNamesStrict(cfg *Config) error {
 		}
 		sort.Strings(names)
 		for _, n := range names {
-			if err := checkName(kind, n); err != nil {
+			if err := checkEntryName(kind, n); err != nil {
 				return err
 			}
 		}
@@ -6840,7 +6873,7 @@ func validateAddressBookEntryNamesStrict(cfg *Config) error {
 	}
 	sort.Strings(zoneNames)
 	for _, z := range zoneNames {
-		if err := checkName("security-zone", z); err != nil {
+		if err := checkZoneName(z); err != nil {
 			return err
 		}
 		zone := cfg.Security.Zones[z]

--- a/pkg/dataplane/userspace/addressbook_slash_name_4340_test.go
+++ b/pkg/dataplane/userspace/addressbook_slash_name_4340_test.go
@@ -1,0 +1,76 @@
+package userspace
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestPolicySlashNameResolvesToPrefix is the #4340 end-to-end dataplane proof:
+// a security policy that references a prefix-named address object
+// (net_10.0.0.0/8) must resolve to that object's PREFIX through the userspace
+// snapshot builder, exactly as a non-slash name does. The resolution path keys
+// the object by its FULL name via direct map lookups
+// (resolveUserspaceAddressBookEntry / classifyPolicyAddresses), so the `/` in
+// the name is inert.
+func TestPolicySlashNameResolvesToPrefix(t *testing.T) {
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			AddressBook: &config.AddressBook{
+				Addresses: map[string]*config.Address{
+					"net_10.0.0.0/8":             {Name: "net_10.0.0.0/8", Value: "10.0.0.0/8"},
+					"net_2001:559:8585:200::/64": {Name: "net_2001:559:8585:200::/64", Value: "2001:559:8585:200::/64"},
+				},
+				AddressSets: map[string]*config.AddressSet{
+					"feeds": {Name: "feeds", Addresses: []string{"net_10.0.0.0/8", "net_2001:559:8585:200::/64"}},
+				},
+			},
+			Policies: []*config.ZonePairPolicies{
+				{
+					FromZone: "trust",
+					ToZone:   "untrust",
+					Policies: []*config.Policy{
+						{
+							Name: "p1",
+							Match: config.PolicyMatch{
+								SourceAddresses:      []string{"net_10.0.0.0/8"},
+								DestinationAddresses: []string{"feeds"},
+							},
+							Action: config.PolicyPermit,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	snaps, err := buildPolicySnapshots(cfg)
+	if err != nil {
+		t.Fatalf("buildPolicySnapshots: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(snaps))
+	}
+	s := snaps[0]
+
+	// The single slash-named source object resolved to a book ID (not dropped
+	// to a free-form literal), and its full-expansion prefix is 10.0.0.0/8.
+	if len(s.SourceBookIDs) != 1 {
+		t.Fatalf("source slash-named object did not resolve to a book id: bookIDs=%v literals=%v", s.SourceBookIDs, s.SourceLiterals)
+	}
+	if !slices.Contains(s.SourceAddresses, "10.0.0.0/8") {
+		t.Fatalf("source did not expand to the object prefix 10.0.0.0/8: %v", s.SourceAddresses)
+	}
+
+	// The destination address-set expands both slash-named members to their
+	// prefixes.
+	if len(s.DestinationBookIDs) != 1 {
+		t.Fatalf("destination address-set did not resolve to a book id: %v", s.DestinationBookIDs)
+	}
+	for _, want := range []string{"10.0.0.0/8", "2001:559:8585:200::/64"} {
+		if !slices.Contains(s.DestinationAddresses, want) {
+			t.Fatalf("destination did not expand to %q: %v", want, s.DestinationAddresses)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #4340 — the single biggest vSRX drop-in blocker.

Real vSRX configs almost universally name an address object after its prefix — `net_10.0.0.0/8`, `net4_sfmix_72.52.96.201/32`, `net_2001:559:8585:200::/64`. xpf hard-rejected every such name at commit (`address-book entry name ... must not contain '/'`), so a mechanical drop-in was impossible: a reviewed config had 194 prefix-named objects, and every policy/address-set reference would have to be renamed in lockstep.

## Diagnosis

The `/` ban came from `validateAddressBookEntryNamesStrict` (#3061), added **solely** to keep the zone-local address-book fold's synthetic internal key `zone-local/<zone>/<name>` collision-proof — **not** because any consumer treats the object NAME as a path. Every resolver (`policyMatchNamedAddressRefs`, `resolveUserspaceAddressBookEntry`, `classifyPolicyAddresses`, the wire snapshot) keys address objects by the **full** name string via direct map lookups, so a `/`-bearing name resolves end to end unchanged. The `/` in a name is a display identifier, not a structural token.

## Fix

Narrow the reservation from "any `/`" to the two invariants the synthetic key actually needs:

1. **No operator entry name may begin with the reserved `zone-local/` prefix** (global or zone-local `address`/`address-set`). Otherwise a global address literally named `zone-local/trust/web-server` would collide with the synthetic name minted for a zone-local `web-server` in zone `trust`, and the fold's no-clobber guard would silently drop the zone-local entry. Reserving only the *prefix* — not every `/` — leaves `/` free elsewhere in a name.
2. **No security-zone NAME may contain `/`.** The zone is the `/`-free first segment; `ZoneLocalUnqualify` splits zone from name on the FIRST `/`, so a `/`-free zone keeps the split unambiguous even when the address name that follows contains `/` (`zone-local/trust/net_10.0.0.0/8` → zone `trust`, name `net_10.0.0.0/8`). Zones never carry a prefix-in-name convention.

Only the NAME is checked, never the address VALUE/prefix. The tolerant load / peer-sync path keeps downgrading the reject to a warning (#1960 no-brick).

## Validation

- **RED-on-revert proven**: with the old any-`/` reject, `TestAddressBookSlashNameCommits` and `TestAddressBookSlashNameZoneLocalFoldRoundTrips` fail with the exact `must not contain '/'` error, while the userspace resolution test passes on both revisions (confirming no consumer depended on the ban).
- `TestPolicySlashNameResolvesToPrefix` proves a policy referencing a prefix-named object resolves to that object's prefix through the dataplane snapshot builder (`buildPolicySnapshots`).
- Full `pkg/config`, `pkg/dataplane/userspace`, `policymatch`, `grpcapi`, `api`, `cli` suites pass; `gofmt`, `go vet`, `go build ./...` clean.
- Updated the #3061 collision-safety tests to the narrowed contract and documented the change in `docs/config-schema.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi