### PR TITLE
cli/api/grpc: migrate remaining policy-counter surfaces to the bulk reader (#4344)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,45 @@
+## 2026-07-06 — #4344 migrate remaining policy-counter display surfaces to the bulk reader (H05/M02/M07)
+
+- **Timestamp**: 2026-07-06
+- **Action**: Some policy-counter DISPLAY surfaces still called
+  `dp.ReadPolicyCounters` per-policy in a loop despite the #3965 bulk
+  reader (`dpuserspace.NewPolicyCounterReader`) existing — O(policies)
+  latency, each read rebuilding the ruleID->counter index and rescanning
+  the config under the dataplane policy mutex. Migrated every remaining
+  surface onto the shared reader, mirroring the `pkg/api/security.go:161`
+  reference: build `readPolicy := dpuserspace.NewPolicyCounterReader(dp,
+  cfg, dp.ReadPolicyCounters)` ONCE per render (guarded by
+  `dp.IsLoaded()`), then replace each in-loop `dp.ReadPolicyCounters(h)`
+  with `readPolicy(h)`. Surfaces migrated: CLI `showPoliciesHitCount`
+  (zone-pair + global + default-policy sentinel rows) and the `policies
+  brief` view; gRPC `showPoliciesHitCount`, `showPoliciesDetail`, and
+  structured `GetPolicies` (zone-pair + global + default rows). M02: the
+  REST `GET /api/v1/security/policies` default-policy row had bypassed the
+  reader with a standalone `s.dp.ReadPolicyCounters(sentinel)` call even
+  though the configured rows used it — routed it through the same
+  `readPolicy`. The bulk snapshot already includes the sentinel handle
+  (`ReadAllPolicyCounters` puts `DefaultPolicySentinelID`), so values are
+  identical. NO interface change (reader falls back to the per-policy read
+  for dataplanes without the bulk snapshot — test fakes / retired eBPF —
+  so existing fakes exercise the unchanged path). Value identity is pinned
+  by the existing `TestReadAllPolicyCountersMatchesPerPolicy`. Added
+  per-surface canary tests: a fake dp implementing BOTH the bulk map (with
+  authoritative values) and a poisoned per-policy fallback proves each
+  surface renders the bulk value AND never invokes the fallback
+  (`perPolicyCalls == 0`). Added an L08 static canary per package that
+  fails if a display-surface source file makes a direct `.ReadPolicyCounters(`
+  call. Docs: pkg/api/README.md + pkg/grpcapi/README.md note the completed
+  migration. `go build ./...`, gofmt, vet, and the full pkg/cli + pkg/api +
+  pkg/grpcapi suites clean.
+- **File(s)**: pkg/cli/cli_show_security.go,
+  pkg/cli/cli_show_security_dispatch.go,
+  pkg/grpcapi/server_show_policies_text.go,
+  pkg/grpcapi/server_show_zones.go, pkg/api/security.go,
+  pkg/cli/cli_show_policies_bulk_reader_test.go,
+  pkg/grpcapi/policies_bulk_reader_test.go,
+  pkg/api/policies_bulk_reader_test.go, pkg/api/README.md,
+  pkg/grpcapi/README.md, _Log.md
+
 ## 2026-07-06 — #4340 allow "/" in address-object names (vSRX prefix-in-name drop-in blocker)
 
 - **Timestamp**: 2026-07-06

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -66,6 +66,17 @@ liveness/readiness. Prometheus metrics endpoint. SSE event streams.
     lock; a dataplane without the bulk snapshot (test fakes / retired eBPF)
     transparently falls back to the per-policy read, and the skip-and-bump
     (#3345/#3408) / HTTP-500 degraded-read contracts are unchanged.
+    #4344: the migration is now complete across EVERY policy-counter display
+    surface — this endpoint's default-policy row (which had bypassed the
+    reader with a standalone sentinel read, M02), the CLI `show security
+    policies hit-count` / `brief` tables, and the gRPC `show security
+    policies hit-count` / `detail` text renderers plus the structured
+    `GetPolicies` RPC all read through the same `NewPolicyCounterReader`
+    snapshot. The returned counter values are identical to the per-policy
+    read (`ReadAllPolicyCounters` is a batching layer, not a semantic
+    change — pinned by `TestReadAllPolicyCountersMatchesPerPolicy`); a
+    per-surface static canary forbids a new show surface from regressing to
+    a direct per-rule `ReadPolicyCounters` call.
     The first rule of the first zone-pair set legitimately has runtime id
     0 (`policySetID*MaxRulesPerPolicy + ruleIndex = 0`), and since #3057
     the implicit default policy uses a distinct sentinel (`0xFFFFFFFF`),

--- a/pkg/api/policies_bulk_reader_test.go
+++ b/pkg/api/policies_bulk_reader_test.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// TestNoDirectPerPolicyReadInSecurityHandler is the #4344 L08 static canary for
+// the REST policy inventory: security.go must NOT call dp.ReadPolicyCounters
+// directly (including for the M02 default-policy row) — every read goes through
+// the #3965 bulk reader (dpuserspace.NewPolicyCounterReader). The permitted
+// mention is the fallback method value passed to NewPolicyCounterReader
+// (`s.dp.ReadPolicyCounters`, no trailing `(`), so a direct `.ReadPolicyCounters(`
+// CALL fails the test.
+func TestNoDirectPerPolicyReadInSecurityHandler(t *testing.T) {
+	const f = "security.go"
+	src, err := os.ReadFile(f)
+	if err != nil {
+		t.Fatalf("read %s: %v", f, err)
+	}
+	if n := strings.Count(string(src), ".ReadPolicyCounters("); n != 0 {
+		t.Errorf("%s makes %d direct .ReadPolicyCounters( call(s); the policy inventory (incl. the default-policy row) must read via dpuserspace.NewPolicyCounterReader (#4344 M02)", f, n)
+	}
+}
+
+// #4344 (M02): the REST `GET /api/v1/security/policies` structured
+// default-policy row must read its hit counter through the SAME #3965 bulk
+// reader (dpuserspace.NewPolicyCounterReader -> ReadAllPolicyCounters) as the
+// configured rows, instead of a standalone per-policy s.dp.ReadPolicyCounters
+// call that took a second dataplane snapshot for the sentinel handle.
+//
+// bulkReaderAPIDP implements BOTH paths: the bulk map holds the authoritative
+// values (including the DefaultPolicySentinelID handle), and the per-policy
+// fallback returns a distinct poison value + records that it was called. With
+// the endpoint fully migrated, EVERY row (configured + default) reads from the
+// bulk snapshot, so the per-policy fallback is never invoked (perPolicyCalls ==
+// 0). Before the M02 fix the default-policy row alone bumped it.
+type bulkReaderAPIDP struct {
+	*dataplane.Manager
+	bulk           map[uint32]dataplane.CounterValue
+	perPolicyVal   dataplane.CounterValue
+	perPolicyCalls *int
+}
+
+func (d *bulkReaderAPIDP) IsLoaded() bool { return true }
+
+func (d *bulkReaderAPIDP) ReadPolicyCounters(uint32) (dataplane.CounterValue, error) {
+	*d.perPolicyCalls++
+	return d.perPolicyVal, nil
+}
+
+func (d *bulkReaderAPIDP) ReadAllPolicyCounters(*config.Config) (map[uint32]dataplane.CounterValue, error) {
+	return d.bulk, nil
+}
+
+func TestPoliciesHandlerDefaultRowUsesBulkReader(t *testing.T) {
+	store := newSchedulerCounterAPIStore(t)
+	enablePolicyStatsAPI(t, store)
+	scheduledID := scheduledCounterPolicyID(t, store)
+	calls := 0
+	s := &Server{
+		store: store,
+		dp: &bulkReaderAPIDP{
+			Manager: dataplane.New(),
+			bulk: map[uint32]dataplane.CounterValue{
+				// plain-allow occupies slot 0; both configured rows are read
+				// because policy-stats is enabled, so both handles must resolve
+				// from the bulk snapshot or the reader signals unpublished.
+				0:           {Packets: 11, Bytes: 1100},
+				scheduledID: {Packets: 23, Bytes: 2300},
+				// M02: the implicit default-policy catch-all sentinel handle.
+				dataplane.DefaultPolicySentinelID: {Packets: 55, Bytes: 5500},
+			},
+			perPolicyVal:   dataplane.CounterValue{Packets: 7, Bytes: 700},
+			perPolicyCalls: &calls,
+		},
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/policies", nil)
+	s.policiesHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Success bool         `json:"success"`
+		Data    []PolicyInfo `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	var sawDefault bool
+	for _, policy := range resp.Data {
+		for _, rule := range policy.Rules {
+			if rule.Name != dataplane.DefaultPolicyName {
+				continue
+			}
+			sawDefault = true
+			// The default row must show the BULK sentinel value, not the
+			// per-policy poison 7/700.
+			if rule.HitPackets != 55 || rule.HitBytes != 5500 {
+				t.Fatalf("default-policy row counters = %d/%d, want the bulk sentinel 55/5500",
+					rule.HitPackets, rule.HitBytes)
+			}
+		}
+	}
+	if !sawDefault {
+		t.Fatal("default-policy row not found in REST response")
+	}
+	if calls != 0 {
+		t.Fatalf("per-policy ReadPolicyCounters called %d times; want 0 (the default-policy row must read the shared bulk snapshot, not a standalone per-policy read)", calls)
+	}
+}

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -365,8 +365,15 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 			PolicyID:        dataplane.DefaultPolicySentinelID,
 			RuleID:          dataplane.DefaultPolicyName,
 		}
-		if statsEnabled && s.dp != nil && s.dp.IsLoaded() {
-			if ctrs, err := s.dp.ReadPolicyCounters(dataplane.DefaultPolicySentinelID); err == nil {
+		// #4344 (M02): the default-policy row now reads through the SAME #3965
+		// bulk reader as the configured rows above (readPolicy), instead of a
+		// standalone per-policy s.dp.ReadPolicyCounters call that took a second
+		// dataplane snapshot for a single sentinel handle. readPolicy != nil
+		// implies the dataplane is loaded (built above under that guard); the
+		// bulk snapshot already includes the DefaultPolicySentinelID handle
+		// (ReadAllPolicyCounters puts it), so the value is identical.
+		if statsEnabled && readPolicy != nil {
+			if ctrs, err := readPolicy(dataplane.DefaultPolicySentinelID); err == nil {
 				defRule.HitPackets = ctrs.Packets
 				defRule.HitBytes = ctrs.Bytes
 			} else if readErr == nil {

--- a/pkg/cli/cli_show_policies_bulk_reader_test.go
+++ b/pkg/cli/cli_show_policies_bulk_reader_test.go
@@ -1,0 +1,141 @@
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// TestNoDirectPerPolicyReadInShowSurfaces is the #4344 L08 static canary: the
+// local-CLI policy display surfaces must NOT call dp.ReadPolicyCounters
+// directly in a per-rule loop — every read goes through the #3965 bulk reader
+// (dpuserspace.NewPolicyCounterReader). The only permitted mention of
+// ReadPolicyCounters is the fallback method value passed to
+// NewPolicyCounterReader (`c.dp.ReadPolicyCounters`, no trailing `(`), so a
+// direct `.ReadPolicyCounters(` CALL in these files fails the test. This keeps a
+// future show surface from regressing to the O(policies) per-policy loop.
+func TestNoDirectPerPolicyReadInShowSurfaces(t *testing.T) {
+	for _, f := range []string{"cli_show_security.go", "cli_show_security_dispatch.go"} {
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		if n := strings.Count(string(src), ".ReadPolicyCounters("); n != 0 {
+			t.Errorf("%s makes %d direct .ReadPolicyCounters( call(s); policy display surfaces must read via dpuserspace.NewPolicyCounterReader (#4344)", f, n)
+		}
+	}
+}
+
+// #4344: the local-CLI policy-counter display surfaces (`show security policies
+// hit-count` and `show security policies brief`) must read the whole policy set
+// through the #3965 bulk reader (dpuserspace.NewPolicyCounterReader ->
+// ReadAllPolicyCounters), NOT a per-policy ReadPolicyCounters loop.
+//
+// bulkReaderCLIDP is a fake dataplane that implements BOTH paths. The bulk map
+// holds the AUTHORITATIVE per-policy values; the per-policy ReadPolicyCounters
+// fallback returns a DISTINCT poison value and records that it was called. A
+// correctly-migrated surface builds the reader once, reads every counter from
+// the bulk snapshot, and never touches the per-policy fallback — so it renders
+// the bulk value and leaves perPolicyCalls == 0. A surface still looping the
+// per-policy read would render the poison value and bump perPolicyCalls.
+type bulkReaderCLIDP struct {
+	*dataplane.Manager
+	bulk           map[uint32]dataplane.CounterValue
+	perPolicyVal   dataplane.CounterValue
+	perPolicyCalls *int
+}
+
+func (d *bulkReaderCLIDP) IsLoaded() bool { return true }
+
+func (d *bulkReaderCLIDP) ReadPolicyCounters(uint32) (dataplane.CounterValue, error) {
+	*d.perPolicyCalls++
+	return d.perPolicyVal, nil
+}
+
+func (d *bulkReaderCLIDP) ReadAllPolicyCounters(*config.Config) (map[uint32]dataplane.CounterValue, error) {
+	return d.bulk, nil
+}
+
+func rowContaining(out, needle string) string {
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, needle) {
+			return line
+		}
+	}
+	return ""
+}
+
+func TestCLIShowPoliciesHitCountUsesBulkReader(t *testing.T) {
+	store := newPolicyHitCountCLIStore(t, true)
+	cfg := store.ActiveConfig()
+	calls := 0
+	c := &CLI{
+		store: store,
+		dp: &bulkReaderCLIDP{
+			Manager: dataplane.New(),
+			bulk: map[uint32]dataplane.CounterValue{
+				// trust->untrust allow-web is the only policy set -> handle 0.
+				0: {Packets: 42, Bytes: 4242},
+				// implicit default-policy catch-all sentinel handle.
+				dataplane.DefaultPolicySentinelID: {Packets: 99, Bytes: 9900},
+			},
+			perPolicyVal:   dataplane.CounterValue{Packets: 7, Bytes: 700},
+			perPolicyCalls: &calls,
+		},
+	}
+
+	var callErr error
+	out := captureStdout(t, func() {
+		callErr = c.showPoliciesHitCount(cfg, "", "")
+	})
+	if callErr != nil {
+		t.Fatalf("showPoliciesHitCount() error = %v", callErr)
+	}
+
+	// The configured allow-web row must show the BULK value 42, not the
+	// per-policy poison 7 — proving the render read the bulk snapshot.
+	if row := rowContaining(out, "allow-web"); !strings.Contains(row, "42") {
+		t.Fatalf("allow-web row = %q, want the bulk count 42 (not the per-policy poison 7)\nfull:\n%s", row, out)
+	}
+	// M02-parity: the default-policy sentinel row also reads via the bulk map.
+	if row := rowContaining(out, dataplane.DefaultPolicyName); !strings.Contains(row, "99") {
+		t.Fatalf("default-policy row = %q, want the bulk sentinel count 99\nfull:\n%s", row, out)
+	}
+	if calls != 0 {
+		t.Fatalf("per-policy ReadPolicyCounters called %d times; want 0 (the render must read the bulk snapshot, not loop the per-policy read)", calls)
+	}
+}
+
+func TestCLIShowPoliciesBriefUsesBulkReader(t *testing.T) {
+	store := newPolicyHitCountCLIStore(t, true)
+	calls := 0
+	c := &CLI{
+		store: store,
+		dp: &bulkReaderCLIDP{
+			Manager: dataplane.New(),
+			bulk: map[uint32]dataplane.CounterValue{
+				0: {Packets: 42, Bytes: 4242},
+			},
+			perPolicyVal:   dataplane.CounterValue{Packets: 7, Bytes: 700},
+			perPolicyCalls: &calls,
+		},
+	}
+
+	var callErr error
+	out := captureStdout(t, func() {
+		callErr = c.handleShowSecurity([]string{"policies", "brief"})
+	})
+	if callErr != nil {
+		t.Fatalf("handleShowSecurity(policies brief) error = %v", callErr)
+	}
+
+	if row := rowContaining(out, "allow-web"); !strings.Contains(row, "42") {
+		t.Fatalf("brief allow-web row = %q, want the bulk hits 42 (not the per-policy poison 7)\nfull:\n%s", row, out)
+	}
+	if calls != 0 {
+		t.Fatalf("per-policy ReadPolicyCounters called %d times; want 0 (brief must read the bulk snapshot)", calls)
+	}
+}

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -29,6 +29,16 @@ func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) 
 		return nil
 	}
 
+	// #4344: read the whole policy set from ONE snapshot (O(P+C), one brief
+	// dataplane lock) via the #3965 bulk reader instead of a per-policy
+	// ReadPolicyCounters loop that rebuilt the ruleID->counter index and
+	// rescanned the config under the policy mutex on every rule. The reader
+	// falls back to the per-policy read for dataplanes without the bulk
+	// snapshot (test fakes / retired eBPF), so the displayed values are
+	// identical. cfg is the config walked below, so the snapshot's handles
+	// line up with the handles computed here.
+	readPolicy := dpuserspace.NewPolicyCounterReader(c.dp, cfg, c.dp.ReadPolicyCounters)
+
 	// Honor `set security policy-stats system-wide enable` (#2008 M4 /
 	// #2118): per-policy hit counters are maintained and displayed only
 	// when policy-stats is enabled system-wide (default off). The
@@ -78,7 +88,7 @@ func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) 
 			ruleID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
 			var count uint64
 			if statsEnabled || pol.Count {
-				if counters, err := c.dp.ReadPolicyCounters(ruleID); err == nil {
+				if counters, err := readPolicy(ruleID); err == nil {
 					count = counters.Packets
 				} else if readErr == nil {
 					readErr = err
@@ -116,7 +126,7 @@ func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) 
 			ruleID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
 			var count uint64
 			if statsEnabled || pol.Count {
-				if counters, err := c.dp.ReadPolicyCounters(ruleID); err == nil {
+				if counters, err := readPolicy(ruleID); err == nil {
 					count = counters.Packets
 				} else if readErr == nil {
 					readErr = err
@@ -154,7 +164,7 @@ func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) 
 		}
 		var defCount uint64
 		if statsEnabled {
-			if counters, err := c.dp.ReadPolicyCounters(dataplane.DefaultPolicySentinelID); err == nil {
+			if counters, err := readPolicy(dataplane.DefaultPolicySentinelID); err == nil {
 				defCount = counters.Packets
 			} else if readErr == nil {
 				readErr = err

--- a/pkg/cli/cli_show_security_dispatch.go
+++ b/pkg/cli/cli_show_security_dispatch.go
@@ -226,6 +226,16 @@ func (c *CLI) handleShowSecurity(args []string) error {
 			// #3408: surface a per-policy counter read failure as a warning
 			// AFTER all reads rather than rendering a clean "0" hits column.
 			var readErr error
+			// #4344: read the whole policy set from ONE snapshot (O(P+C), one
+			// brief dataplane lock) via the #3965 bulk reader instead of a
+			// per-policy ReadPolicyCounters loop. Built only when the dataplane
+			// is loaded; falls back to the per-policy read for dataplanes
+			// without the bulk snapshot (test fakes / retired eBPF), so the
+			// displayed hits are identical. cfg is the config walked below.
+			var readPolicy func(uint32) (dataplane.CounterValue, error)
+			if c.dp != nil && c.dp.IsLoaded() {
+				readPolicy = dpuserspace.NewPolicyCounterReader(c.dp, cfg, c.dp.ReadPolicyCounters)
+			}
 			// Brief tabular summary
 			fmt.Printf("%-12s %-12s %-20s %-8s %s\n",
 				"From", "To", "Name", "Action", "Hits")
@@ -263,8 +273,8 @@ func (c *CLI) handleShowSecurity(args []string) error {
 					// the counter is unavailable or the knob is off);
 					// overwrite only on a successful gated read.
 					hits := "0"
-					if (statsEnabled || pol.Count) && c.dp != nil && c.dp.IsLoaded() {
-						if counters, err := c.dp.ReadPolicyCounters(ruleID); err == nil {
+					if (statsEnabled || pol.Count) && readPolicy != nil {
+						if counters, err := readPolicy(ruleID); err == nil {
 							hits = fmt.Sprintf("%d", counters.Packets)
 						} else if readErr == nil {
 							readErr = err
@@ -299,8 +309,8 @@ func (c *CLI) handleShowSecurity(args []string) error {
 					// Default to "0" for the same cross-surface
 					// consistency reason as the zone-pair branch above.
 					hits := "0"
-					if (statsEnabled || pol.Count) && c.dp != nil && c.dp.IsLoaded() {
-						if counters, err := c.dp.ReadPolicyCounters(ruleID); err == nil {
+					if (statsEnabled || pol.Count) && readPolicy != nil {
+						if counters, err := readPolicy(ruleID); err == nil {
 							hits = fmt.Sprintf("%d", counters.Packets)
 						} else if readErr == nil {
 							readErr = err

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -215,7 +215,15 @@ contract.
   global (group still `*`), and structured `GetPolicies` populates the
   per-rule `match_from_zone`/`match_to_zone` proto fields (empty for an
   unscoped global). Showing the group `*`/`*` but dropping the per-rule
-  scope is the #3286 blind spot.
+  scope is the #3286 blind spot. #4344: `showPoliciesHitCount`,
+  `showPoliciesDetail`, and structured `GetPolicies` read every per-rule
+  counter (zone-pair, global, and the default-policy sentinel row) through
+  the shared `dpuserspace.NewPolicyCounterReader` bulk snapshot — one brief
+  dataplane lock for the whole set — instead of a per-policy
+  `ReadPolicyCounters` loop; the reader falls back to the per-policy read
+  for a dataplane without the bulk snapshot, so the rendered values are
+  identical. A static canary in the test package forbids a direct per-rule
+  `ReadPolicyCounters` call in these files.
 - `GetZones` enumerates security zones (`ZoneInfo`). The host-inbound
   admission set is surfaced distinctly (#3328): `host_inbound_configured`
   is the dataplane posture bit (mirrors `ZoneSnapshot.HostInboundConfigured`,

--- a/pkg/grpcapi/policies_bulk_reader_test.go
+++ b/pkg/grpcapi/policies_bulk_reader_test.go
@@ -1,0 +1,176 @@
+package grpcapi
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// TestNoDirectPerPolicyReadInShowSurfaces is the #4344 L08 static canary for the
+// gRPC policy display surfaces: they must NOT call dp.ReadPolicyCounters
+// directly in a per-rule loop — every read goes through the #3965 bulk reader
+// (dpuserspace.NewPolicyCounterReader). The permitted mention is the fallback
+// method value passed to NewPolicyCounterReader (`s.dp.ReadPolicyCounters`, no
+// trailing `(`), so a direct `.ReadPolicyCounters(` CALL fails the test.
+func TestNoDirectPerPolicyReadInShowSurfaces(t *testing.T) {
+	for _, f := range []string{"server_show_policies_text.go", "server_show_zones.go"} {
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		if n := strings.Count(string(src), ".ReadPolicyCounters("); n != 0 {
+			t.Errorf("%s makes %d direct .ReadPolicyCounters( call(s); policy display surfaces must read via dpuserspace.NewPolicyCounterReader (#4344)", f, n)
+		}
+	}
+}
+
+// #4344: the gRPC policy-counter display surfaces — structured GetPolicies, the
+// `show security policies hit-count` text renderer, and the `... detail` text
+// renderer — must read the whole policy set through the #3965 bulk reader
+// (dpuserspace.NewPolicyCounterReader -> ReadAllPolicyCounters), NOT a
+// per-policy ReadPolicyCounters loop.
+//
+// bulkReaderGRPCDP implements BOTH paths: the bulk map holds the authoritative
+// values, the per-policy fallback returns a distinct poison value and records
+// that it was called. A migrated surface renders the bulk value and leaves
+// perPolicyCalls == 0.
+type bulkReaderGRPCDP struct {
+	*dataplane.Manager
+	bulk           map[uint32]dataplane.CounterValue
+	perPolicyVal   dataplane.CounterValue
+	perPolicyCalls *int
+}
+
+func (d *bulkReaderGRPCDP) IsLoaded() bool { return true }
+
+func (d *bulkReaderGRPCDP) ReadPolicyCounters(uint32) (dataplane.CounterValue, error) {
+	*d.perPolicyCalls++
+	return d.perPolicyVal, nil
+}
+
+func (d *bulkReaderGRPCDP) ReadAllPolicyCounters(*config.Config) (map[uint32]dataplane.CounterValue, error) {
+	return d.bulk, nil
+}
+
+// fullPolicyBulk fills a bulk counter map for EVERY policy handle in cfg
+// (zone-pair rules, global rules, default-policy sentinel), computing each
+// handle the same way ReadAllPolicyCounters and the display surfaces do so no
+// read signals "unpublished" (GetPolicies fails closed on an unpublished
+// counter with policy-stats on). The scheduled-allow handle gets a distinctive
+// value the canary asserts.
+func fullPolicyBulk(cfg *config.Config, scheduledID uint32) map[uint32]dataplane.CounterValue {
+	bulk := map[uint32]dataplane.CounterValue{}
+	var setID uint32
+	for _, zpp := range cfg.Security.Policies {
+		if zpp == nil {
+			setID++
+			continue
+		}
+		for i, rule := range zpp.Policies {
+			if rule == nil {
+				continue
+			}
+			bulk[setID*dataplane.MaxRulesPerPolicy+uint32(i)] = dataplane.CounterValue{Packets: 1, Bytes: 10}
+		}
+		setID++
+	}
+	for i, rule := range cfg.Security.GlobalPolicies {
+		if rule == nil {
+			continue
+		}
+		bulk[setID*dataplane.MaxRulesPerPolicy+uint32(i)] = dataplane.CounterValue{Packets: 1, Bytes: 10}
+	}
+	bulk[dataplane.DefaultPolicySentinelID] = dataplane.CounterValue{Packets: 5, Bytes: 50}
+	bulk[scheduledID] = dataplane.CounterValue{Packets: 23, Bytes: 2300}
+	return bulk
+}
+
+func newBulkReaderGRPCServer(t *testing.T) (*Server, uint32, *int) {
+	t.Helper()
+	store := newSchedulerCounterGRPCStore(t)
+	policyID := scheduledCounterGRPCPolicyID(t, store)
+	calls := 0
+	s := &Server{
+		store: store,
+		dp: &bulkReaderGRPCDP{
+			Manager:        dataplane.New(),
+			bulk:           fullPolicyBulk(store.ActiveConfig(), policyID),
+			perPolicyVal:   dataplane.CounterValue{Packets: 7, Bytes: 700},
+			perPolicyCalls: &calls,
+		},
+	}
+	return s, policyID, &calls
+}
+
+func TestGetPoliciesUsesBulkReader(t *testing.T) {
+	s, _, calls := newBulkReaderGRPCServer(t)
+
+	resp, err := s.GetPolicies(context.Background(), &pb.GetPoliciesRequest{})
+	if err != nil {
+		t.Fatalf("GetPolicies() error = %v", err)
+	}
+	var found bool
+	for _, policy := range resp.GetPolicies() {
+		for _, rule := range policy.GetRules() {
+			if rule.GetName() != "scheduled-allow" {
+				continue
+			}
+			found = true
+			if rule.GetHitPackets() != 23 || rule.GetHitBytes() != 2300 {
+				t.Fatalf("scheduled-allow counters = %d/%d, want the bulk value 23/2300 (not the per-policy poison 7/700)",
+					rule.GetHitPackets(), rule.GetHitBytes())
+			}
+		}
+	}
+	if !found {
+		t.Fatal("scheduled-allow rule not found in GetPolicies response")
+	}
+	if *calls != 0 {
+		t.Fatalf("per-policy ReadPolicyCounters called %d times; want 0 (GetPolicies must read the bulk snapshot)", *calls)
+	}
+}
+
+func TestShowPoliciesHitCountTextUsesBulkReader(t *testing.T) {
+	s, _, calls := newBulkReaderGRPCServer(t)
+
+	var buf strings.Builder
+	s.showPoliciesHitCount("", &buf)
+	out := buf.String()
+
+	if row := rowContaining(out, "scheduled-allow"); !strings.Contains(row, "23") {
+		t.Fatalf("scheduled-allow hit-count row = %q, want the bulk value 23\nfull:\n%s", row, out)
+	}
+	if *calls != 0 {
+		t.Fatalf("per-policy ReadPolicyCounters called %d times; want 0 (text hit-count must read the bulk snapshot)", *calls)
+	}
+}
+
+func TestShowPoliciesDetailTextUsesBulkReader(t *testing.T) {
+	s, _, calls := newBulkReaderGRPCServer(t)
+
+	var buf strings.Builder
+	s.showPoliciesDetail("", &buf)
+	out := buf.String()
+
+	// The Session statistics block for scheduled-allow must show the bulk value.
+	if !strings.Contains(out, "23 packets, 2300 bytes") {
+		t.Fatalf("detail Session statistics missing the bulk value 23 packets, 2300 bytes\nfull:\n%s", out)
+	}
+	if *calls != 0 {
+		t.Fatalf("per-policy ReadPolicyCounters called %d times; want 0 (text detail must read the bulk snapshot)", *calls)
+	}
+}
+
+func rowContaining(out, needle string) string {
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, needle) {
+			return line
+		}
+	}
+	return ""
+}

--- a/pkg/grpcapi/server_show_policies_text.go
+++ b/pkg/grpcapi/server_show_policies_text.go
@@ -112,6 +112,16 @@ func (s *Server) showPoliciesHitCount(filter string, buf *strings.Builder) {
 	// #3408: surface a per-policy counter read failure as a warning AFTER all
 	// reads rather than printing clean-zero hit counts.
 	var readErr error
+	// #4344: read the whole policy set from ONE snapshot (O(P+C), one brief
+	// dataplane lock) via the #3965 bulk reader instead of a per-policy
+	// ReadPolicyCounters loop. Built only when the dataplane is loaded; falls
+	// back to the per-policy read for dataplanes without the bulk snapshot
+	// (test fakes / retired eBPF), so the displayed counts are identical. cfg
+	// is the config walked below, so the snapshot's handles line up.
+	var readPolicy func(uint32) (dataplane.CounterValue, error)
+	if s.dp != nil && s.dp.IsLoaded() {
+		readPolicy = dpuserspace.NewPolicyCounterReader(s.dp, cfg, s.dp.ReadPolicyCounters)
+	}
 	fmt.Fprintf(buf, "%-12s %-12s %-24s %-8s %12s %16s\n",
 		"From zone", "To zone", "Policy", "Action", "Packets", "Bytes")
 	fmt.Fprintln(buf, strings.Repeat("-", 88))
@@ -143,8 +153,8 @@ func (s *Server) showPoliciesHitCount(filter string, buf *strings.Builder) {
 			}
 			ruleID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
 			var pkts, bytes uint64
-			if (statsEnabled || pol.Count) && s.dp != nil && s.dp.IsLoaded() {
-				if counters, err := s.dp.ReadPolicyCounters(ruleID); err == nil {
+			if (statsEnabled || pol.Count) && readPolicy != nil {
+				if counters, err := readPolicy(ruleID); err == nil {
 					pkts = counters.Packets
 					bytes = counters.Bytes
 				} else if readErr == nil {
@@ -192,8 +202,8 @@ func (s *Server) showPoliciesHitCount(filter string, buf *strings.Builder) {
 			}
 			ruleID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
 			var pkts, bytes uint64
-			if (statsEnabled || pol.Count) && s.dp != nil && s.dp.IsLoaded() {
-				if counters, err := s.dp.ReadPolicyCounters(ruleID); err == nil {
+			if (statsEnabled || pol.Count) && readPolicy != nil {
+				if counters, err := readPolicy(ruleID); err == nil {
 					pkts = counters.Packets
 					bytes = counters.Bytes
 				} else if readErr == nil {
@@ -230,8 +240,8 @@ func (s *Server) showPoliciesHitCount(filter string, buf *strings.Builder) {
 			defAction = "reject"
 		}
 		var pkts, bytes uint64
-		if statsEnabled && s.dp != nil && s.dp.IsLoaded() {
-			if counters, err := s.dp.ReadPolicyCounters(dataplane.DefaultPolicySentinelID); err == nil {
+		if statsEnabled && readPolicy != nil {
+			if counters, err := readPolicy(dataplane.DefaultPolicySentinelID); err == nil {
 				pkts = counters.Packets
 				bytes = counters.Bytes
 			} else if readErr == nil {
@@ -277,6 +287,15 @@ func (s *Server) showPoliciesDetail(filter string, buf *strings.Builder) {
 	// the "Session statistics" block is per-policy hit-count display, so
 	// it must honor the knob for cross-surface consistency.
 	statsEnabled := cfg.Security.PolicyStatsEnabled
+	// #4344: same #3965 bulk-reader migration as showPoliciesHitCount — read the
+	// policy set from ONE snapshot instead of a per-policy ReadPolicyCounters
+	// loop for the "Session statistics" block. Built only when the dataplane is
+	// loaded; falls back to the per-policy read for non-bulk dataplanes, so the
+	// rendered values are identical. cfg is the config walked below.
+	var readPolicy func(uint32) (dataplane.CounterValue, error)
+	if s.dp != nil && s.dp.IsLoaded() {
+		readPolicy = dpuserspace.NewPolicyCounterReader(s.dp, cfg, s.dp.ReadPolicyCounters)
+	}
 	schedActive, haveSched := s.policySchedulerActiveState()
 	// #3667 (H05): the displayed Index must equal the runtime/RT_FLOW policy ID
 	// so a remote operator can map a policy-deny/RT_FLOW log line (which carries
@@ -366,8 +385,8 @@ func (s *Server) showPoliciesDetail(filter string, buf *strings.Builder) {
 			if pol.Count {
 				fmt.Fprintf(buf, "      count\n")
 			}
-			if (statsEnabled || pol.Count) && s.dp != nil && s.dp.IsLoaded() {
-				if counters, err := s.dp.ReadPolicyCounters(ruleID); err == nil {
+			if (statsEnabled || pol.Count) && readPolicy != nil {
+				if counters, err := readPolicy(ruleID); err == nil {
 					fmt.Fprintf(buf, "    Session statistics:\n")
 					fmt.Fprintf(buf, "      %d packets, %d bytes\n", counters.Packets, counters.Bytes)
 				} else if readErr == nil {
@@ -442,8 +461,8 @@ func (s *Server) showPoliciesDetail(filter string, buf *strings.Builder) {
 			if pol.Count {
 				fmt.Fprintf(buf, "      count\n")
 			}
-			if (statsEnabled || pol.Count) && s.dp != nil && s.dp.IsLoaded() {
-				if counters, err := s.dp.ReadPolicyCounters(ruleID); err == nil {
+			if (statsEnabled || pol.Count) && readPolicy != nil {
+				if counters, err := readPolicy(ruleID); err == nil {
 					fmt.Fprintf(buf, "    Session statistics:\n")
 					fmt.Fprintf(buf, "      %d packets, %d bytes\n", counters.Packets, counters.Bytes)
 				} else if readErr == nil {

--- a/pkg/grpcapi/server_show_zones.go
+++ b/pkg/grpcapi/server_show_zones.go
@@ -141,6 +141,18 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 	statsEnabled := cfg.Security.PolicyStatsEnabled
 	// #3408: surface a per-policy counter read failure as codes.Internal.
 	var readErr error
+	// #4344: read the whole policy set from ONE snapshot (O(P+C), one brief
+	// dataplane lock) via the #3965 bulk reader instead of a per-policy
+	// ReadPolicyCounters loop that rebuilt the ruleID->counter index and
+	// rescanned the config under the policy mutex on every rule. Built only
+	// when the dataplane is loaded; falls back to the per-policy read for
+	// dataplanes without the bulk snapshot (test fakes / retired eBPF), so the
+	// returned HitPackets/HitBytes are identical. cfg is the config walked
+	// below, so the snapshot's handles line up with the handles computed here.
+	var readPolicy func(uint32) (dataplane.CounterValue, error)
+	if s.dp != nil && s.dp.IsLoaded() {
+		readPolicy = dpuserspace.NewPolicyCounterReader(s.dp, cfg, s.dp.ReadPolicyCounters)
+	}
 	resp := &pb.GetPoliciesResponse{}
 	// #3336: span-accumulated runtime/RT_FLOW policy IDs, keyed
 	// [policySetID, sliceIndex] — the same identity the event path logs, so
@@ -213,9 +225,9 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 			if pr.Applications == nil {
 				pr.Applications = []string{}
 			}
-			if (statsEnabled || rule.Count) && s.dp != nil && s.dp.IsLoaded() {
+			if (statsEnabled || rule.Count) && readPolicy != nil {
 				policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
-				if ctrs, err := s.dp.ReadPolicyCounters(policyID); err == nil {
+				if ctrs, err := readPolicy(policyID); err == nil {
 					pr.HitPackets = ctrs.Packets
 					pr.HitBytes = ctrs.Bytes
 				} else if readErr == nil {
@@ -285,9 +297,9 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 			if pr.Applications == nil {
 				pr.Applications = []string{}
 			}
-			if (statsEnabled || rule.Count) && s.dp != nil && s.dp.IsLoaded() {
+			if (statsEnabled || rule.Count) && readPolicy != nil {
 				policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
-				if ctrs, err := s.dp.ReadPolicyCounters(policyID); err == nil {
+				if ctrs, err := readPolicy(policyID); err == nil {
 					pr.HitPackets = ctrs.Packets
 					pr.HitBytes = ctrs.Bytes
 				} else if readErr == nil {
@@ -330,8 +342,8 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 			PolicyId: proto.Uint32(dataplane.DefaultPolicySentinelID),
 			RuleId:   dataplane.DefaultPolicyName,
 		}
-		if statsEnabled && s.dp != nil && s.dp.IsLoaded() {
-			if ctrs, err := s.dp.ReadPolicyCounters(dataplane.DefaultPolicySentinelID); err == nil {
+		if statsEnabled && readPolicy != nil {
+			if ctrs, err := readPolicy(dataplane.DefaultPolicySentinelID); err == nil {
 				defRule.HitPackets = ctrs.Packets
 				defRule.HitBytes = ctrs.Bytes
 			} else if readErr == nil {


### PR DESCRIPTION
Closes #4344

## Summary

codex-164 H05 + M02 + M07. Some policy-counter DISPLAY surfaces still
called `dp.ReadPolicyCounters` once per policy in a loop despite the
#3965 bulk reader (`dpuserspace.NewPolicyCounterReader`) existing —
O(policies) latency, and each read rebuilt the ruleID->counter index and
rescanned the config under the dataplane policy mutex. This migrates the
remaining surfaces onto the shared reader, mirroring the existing
`pkg/api/security.go:161` reference (built ONCE per render under
`dp.IsLoaded()`, then O(1) map lookups per rule).

This is a perf/consistency migration, NOT a semantic change: the returned
counter values are identical to the per-policy read (`ReadAllPolicyCounters`
is a batching layer — pinned by the pre-existing
`TestReadAllPolicyCountersMatchesPerPolicy`). The retired-eBPF-shim-counter
divergence (M01) is deliberate and left untouched.

## Surfaces migrated

- **CLI** (`pkg/cli/cli_show_security.go`, `cli_show_security_dispatch.go`):
  `show security policies hit-count` (zone-pair + global + default-policy
  sentinel rows) and the `policies brief` "Hits" column.
- **gRPC** (`pkg/grpcapi/server_show_policies_text.go`,
  `server_show_zones.go`): `show security policies hit-count` /
  `... detail` text renderers and the structured `GetPolicies` RPC
  (zone-pair + global + default rows).
- **REST default-policy row (M02)** (`pkg/api/security.go`): the
  `GET /api/v1/security/policies` inventory already read its configured
  rows through the bulk reader, but the implicit default-policy row still
  took a second dataplane snapshot with a standalone
  `s.dp.ReadPolicyCounters(DefaultPolicySentinelID)` call. The bulk
  snapshot already includes the sentinel handle (`ReadAllPolicyCounters`
  puts `DefaultPolicySentinelID`), so it now routes through the same
  `readPolicy` closure.

No interface change — `NewPolicyCounterReader` already exists and falls
back to the per-policy read for a dataplane without the bulk snapshot
(test fakes / retired eBPF), so existing fakes exercise the unchanged
path bit-for-bit.

## Tests

- Per-surface **value-identity / bulk-usage canaries**: a fake dp
  implementing BOTH the bulk map (authoritative values) and a poisoned
  per-policy fallback proves each surface renders the bulk value AND
  never invokes the fallback (`perPolicyCalls == 0`). Covers CLI
  hit-count + brief + default row, gRPC GetPolicies + text hit-count +
  text detail, and the REST default-policy row (M02).
- **L08 static canary** per package: fails if a display-surface source
  file makes a direct `.ReadPolicyCounters(` call, so a future show
  surface cannot regress to the per-policy loop.

`go build ./...`, `gofmt`, `go vet`, and the full `pkg/cli` + `pkg/api` +
`pkg/grpcapi` suites are clean.

## Docs

`pkg/api/README.md` and `pkg/grpcapi/README.md` note the completed
migration across every policy-counter display surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
