### PR TITLE
#3627 B1a: structured host-inbound token SSOT + match-policies admitting-token report

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -36612,3 +36612,40 @@ top.
   pkg/config/firewall_address_except_mutex_3359_test.go,
   pkg/dataplane/userspace/filters_address_matchany_except_4338_test.go,
   docs/feature-coverage.md, _Log.md
+
+- **Timestamp**: 2026-07-06
+- **Action**: #3627 B1a — structured host-inbound token→tuple SSOT +
+  match-policies admitting-token report. Extracted the single structured
+  SSOT `config.HostInboundServiceMatch` / `HostInboundProtocolMatch`
+  (`[]config.L4Match{Proto, Ports []PortRange, ICMPType *uint8, Reject}`,
+  family-scoped, `all` expansion, ident-reset Reject marker, gre→proto
+  47) in `pkg/config/host_inbound_tokens.go`. Refactored the pkg/daemon
+  nft builder (`hostInboundServiceMatches` / `hostInboundProtocolMatches`
+  / `hostInboundAllowsAll`) to RENDER (`renderHostInboundMatches`) from
+  the SSOT instead of a parallel hard-coded switch — proven
+  BYTE-IDENTICAL to the pre-#3627 output for every token × family by
+  `TestHostInboundNftRenderGoldenByteIdentical` (frozen golden). Added
+  the host-inbound classifier `dataplane/userspace.ClassifyHostInbound`
+  (reads the SAME SSOT + mirrors the #3171 global ICMP/ND/ESP-AH
+  accepts) returning a presence-safe `HostInboundAdmission{Status,
+  Token, Kind}` (token-admit / global-accept / denied / indeterminate /
+  not-computed). Wired it into `policymatch.Match` (host path only) as
+  `Result.HostInbound` and surfaced the admitting token on the local CLI
+  `show security match-policies` host-inbound branch. RED-on-revert
+  verified (ssh 22→2222 turned the daemon golden, the config tuple test,
+  and the policymatch token test all RED). REST/gRPC structured
+  `host_inbound` fields (+ proto message) and a per-tuple Rust parity
+  test are deferred follow-ups (this PR is Go-only, no codegen/cargo);
+  the existing set-level parity guards still hold. `go test`
+  pkg/config + pkg/daemon + pkg/dataplane/userspace + pkg/policymatch +
+  pkg/cli green; gofmt, go build ./... clean.
+- **File(s)**: pkg/config/host_inbound_tokens.go,
+  pkg/config/host_inbound_match_3627_test.go,
+  pkg/daemon/daemon_nft.go,
+  pkg/daemon/host_inbound_ssot_render_3627_test.go,
+  pkg/dataplane/userspace/host_inbound_classify.go,
+  pkg/dataplane/userspace/host_inbound_classify_3627_test.go,
+  pkg/policymatch/policymatch.go,
+  pkg/policymatch/host_inbound_token_3627_test.go,
+  pkg/cli/cli_show_security.go, pkg/daemon/README.md,
+  pkg/policymatch/README.md, docs/host-inbound-service-matrix.md, _Log.md

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -12,25 +12,38 @@ issue #3619).
 Host-inbound admission is enforced (and validated) in three independent places
 that MUST agree on the token set:
 
-1. **Go SSOT — recognized-token allowlist + address family.** The set of
-   meaningful tokens and their address-family scoping. Commit-time validation
-   hard-rejects any token outside it (#3200).
+1. **Go SSOT — recognized-token allowlist + address family + structured
+   token→tuple table.** The set of meaningful tokens, their address-family
+   scoping, and (since #3627 B1a) their structured `(proto, ports, icmp-type)`
+   tuples. Commit-time validation hard-rejects any token outside it (#3200).
    - `config.KnownHostInboundSystemServices` — `pkg/config/host_inbound_tokens.go`
    - `config.KnownHostInboundProtocols` — same file
    - `config.HostInboundServiceFamily` / `config.HostInboundProtocolFamily` —
      family scoping (`ip` = IPv4-only, `ip6` = IPv6-only, absent = dual)
    - `config.HostInboundL2Protocols` / `config.HostInboundAllExpansionProtocols()`
      — `protocols all` expansion minus L2/non-IP tokens
-   - The Go SSOT declares the token allowlist and family, **not** the port
-     numbers. The port sets live on the two enforcement surfaces below, which are
-     hand-mirrors of each other.
+   - `config.HostInboundServiceMatch` / `config.HostInboundProtocolMatch`
+     (`[]config.L4Match{Proto, Ports, ICMPType, Reject}`) — the STRUCTURED
+     token→tuple SSOT added in #3627 B1a. The nft kernel mirror (surface 2) now
+     RENDERS its match fragments from this table rather than carrying a parallel
+     hard-coded copy, and the `request security match-policies` host-inbound
+     classifier (surface 4) MATCHES queries against it. Before #3627 the Go SSOT
+     declared only the token allowlist and family, and the port sets lived only
+     on surfaces 2 and 3 as hand-mirrors; now surface 2 is a render of this
+     table, and surface 3 (Rust) remains a hand-mirror pending the deferred
+     per-tuple parity test.
 
 2. **nft kernel mirror — PRIMARY enforcement.** Host-bound traffic to a
    firewall interface IP / VRRP VIP is shunted to the kernel by the XDP shim
    before it reaches userspace-dp, so the nftables `inet xpf_hostinbound` chain
-   carries ~100% of real host-inbound traffic.
-   - `hostInboundServiceMatches` — `pkg/daemon/daemon_nft.go` (services)
-   - `hostInboundProtocolMatches` — same file (protocols)
+   carries ~100% of real host-inbound traffic. Since #3627 B1a the per-token
+   match fragments are RENDERED from the surface-1 structured SSOT
+   (`renderHostInboundMatches`), byte-identical to the pre-#3627 strings
+   (`TestHostInboundNftRenderGoldenByteIdentical`).
+   - `hostInboundServiceMatches` — `pkg/daemon/daemon_nft.go` (services; renders
+     `config.HostInboundServiceMatch`)
+   - `hostInboundProtocolMatches` — same file (protocols; renders
+     `config.HostInboundProtocolMatch`)
    - `hostInboundServiceAction` — same file (ident-reset reject verdict)
    - global always-accepts — `buildHostInboundFilterPayload`, same file
 
@@ -42,6 +55,15 @@ that MUST agree on the token set:
      `userspace-dp/src/afxdp/forwarding/host_inbound.rs`
    - `is_icmp_host_inbound_global_accept` — same file (global ICMP/ND accepts)
 
+4. **match-policies host-inbound classifier — DIAGNOSTIC (not enforcement).**
+   The `request security match-policies` simulator names WHICH host-inbound token
+   admits a queried host-bound tuple (#3627 B1a). It does not enforce; it reads
+   the surface-1 structured SSOT and mirrors the surface-2 global accepts so its
+   report cannot drift from what the kernel opens.
+   - `ClassifyHostInbound` / `hostInboundGlobalAccept` —
+     `pkg/dataplane/userspace/host_inbound_classify.go`
+   - wired into `pkg/policymatch` as `Result.HostInbound`
+
 **Drift guards.** The token *sets* are pinned in lockstep by
 `config.TestHostInboundRustClassifierMatchesGoSSOT` (`pkg/config/host_inbound_rust_parity_test.go`,
 #3486 — parses the Rust source and asserts its match arms equal the Go SSOT) and
@@ -49,7 +71,15 @@ that MUST agree on the token set:
 #3200 — asserts the nft matcher's domain equals the SSOT). The *port sets* for
 deliberately-narrow tokens (sip, tftp, traceroute, bfd, the #3341 routing
 protocols) are additionally pinned by fail-on-revert assertions in
-`pkg/daemon/host_inbound_parity_test.go` so an accidental widen turns RED.
+`pkg/daemon/host_inbound_parity_test.go` so an accidental widen turns RED. Since
+#3627 B1a the nft match fragments are RENDERED from surface 1 and pinned
+byte-identical by `TestHostInboundNftRenderGoldenByteIdentical`
+(`pkg/daemon/host_inbound_ssot_render_3627_test.go`); the structured tuples
+themselves are pinned by `config.TestHostInboundServiceMatchTuples` /
+`TestHostInboundProtocolMatchTuples`. A per-tuple parity test between the Rust
+classifier (surface 3) and the structured SSOT (surface 1) is a deferred
+follow-up; until it lands, surface 3 stays a hand-mirror held by the set-level
+`TestHostInboundRustClassifierMatchesGoSSOT`.
 
 ## system-services matrix
 

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -430,6 +430,15 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 		// #3285: host-bound traffic — no transit global/default fallback.
 		fmt.Printf("No matching to-zone junos-host policy for %s -> junos-host\n", fromZone)
 		fmt.Printf("  %s\n", policymatch.HostInboundShowLine)
+		// #3627 B1a: name the admitting host-inbound-traffic token (or report
+		// deny / global-accept / indeterminate) so the operator sees WHICH
+		// system-service/protocol governs local delivery for this tuple, not just
+		// that host-inbound-traffic governs it.
+		if res.HostInbound != nil {
+			if line := res.HostInbound.Describe(); line != "" {
+				fmt.Printf("  host-inbound-traffic (zone %s): %s\n", fromZone, line)
+			}
+		}
 		return nil
 	}
 	if !res.Matched {

--- a/pkg/config/host_inbound_match_3627_test.go
+++ b/pkg/config/host_inbound_match_3627_test.go
@@ -1,0 +1,187 @@
+package config
+
+import (
+	"strconv"
+	"testing"
+)
+
+// TestHostInboundServiceMatchTuples pins the structured token->tuple SSOT
+// (#3627 B1a) for representative system-services: the proto/port/icmp truth the
+// nft builder renders from and the match-policies host-inbound classifier
+// matches against. Fail-on-revert: change a port here (or drop a tuple) and both
+// the render golden and the classifier tests move with it — this test names the
+// canonical value so a reviewer sees the intended tuple, not just a diff.
+func TestHostInboundServiceMatchTuples(t *testing.T) {
+	u8 := func(v uint8) *uint8 { return &v }
+	single := func(p uint16) []PortRange { return []PortRange{{Lo: p, Hi: p}} }
+
+	cases := []struct {
+		token  string
+		family string
+		want   []L4Match
+	}{
+		{"ssh", "ip", []L4Match{{Proto: HostInboundProtoTCP, Ports: single(22)}}},
+		{"ssh", "ip6", []L4Match{{Proto: HostInboundProtoTCP, Ports: single(22)}}},
+		{"https", "ip", []L4Match{{Proto: HostInboundProtoTCP, Ports: single(443)}}},
+		{"dns", "ip", []L4Match{
+			{Proto: HostInboundProtoUDP, Ports: single(53)},
+			{Proto: HostInboundProtoTCP, Ports: single(53)},
+		}},
+		// ping: echo-request only, family-specific ICMP type (v4 8 / v6 128).
+		{"ping", "ip", []L4Match{{Proto: HostInboundProtoICMP, ICMPType: u8(8)}}},
+		{"ping", "ip6", []L4Match{{Proto: HostInboundProtoICMPv6, ICMPType: u8(128)}}},
+		// dhcp is IPv4-only (family gate).
+		{"dhcp", "ip", []L4Match{{Proto: HostInboundProtoUDP, Ports: []PortRange{{67, 67}, {68, 68}}}}},
+		{"dhcp", "ip6", nil},
+		{"dhcpv6", "ip", nil},
+		{"dhcpv6", "ip6", []L4Match{{Proto: HostInboundProtoUDP, Ports: []PortRange{{546, 546}, {547, 547}}}}},
+		// traceroute is a contiguous UDP range.
+		{"traceroute", "ip", []L4Match{{Proto: HostInboundProtoUDP, Ports: []PortRange{{33434, 33523}}}}},
+		// gre is a bare IP protocol number.
+		{"gre", "ip", []L4Match{{Proto: 47}}},
+		// ident-reset carries the Reject marker (resets, does NOT admit).
+		{"ident-reset", "ip", []L4Match{{Proto: HostInboundProtoTCP, Ports: single(113), Reject: true}}},
+		// full-admit and unknown tokens are not per-tuple matches.
+		{"all", "ip", nil},
+		{"any-service", "ip", nil},
+		{"sssh", "ip", nil},
+	}
+	for _, c := range cases {
+		got := HostInboundServiceMatch(c.token, c.family)
+		if !equalL4(got, c.want) {
+			t.Errorf("HostInboundServiceMatch(%q,%q) = %s, want %s", c.token, c.family, showL4(got), showL4(c.want))
+		}
+	}
+
+	if !HostInboundFullAdmitService("all") || !HostInboundFullAdmitService("any-service") {
+		t.Errorf("all/any-service must be full-admit services")
+	}
+	if HostInboundFullAdmitService("ssh") {
+		t.Errorf("ssh must NOT be a full-admit service")
+	}
+}
+
+// TestHostInboundProtocolMatchTuples pins representative protocol tuples,
+// including the family gating (ospf v4 / ospf3 v6, igmp/dvmrp v4-only), the L2
+// no-op (isis), and the router-discovery two-ICMP-type v4 match. It also asserts
+// `protocols all` expands to the routing set and admits a real IP protocol (bgp)
+// while EXCLUDING the L2 protocol (isis) and every full system-service (ssh).
+func TestHostInboundProtocolMatchTuples(t *testing.T) {
+	u8 := func(v uint8) *uint8 { return &v }
+	single := func(p uint16) []PortRange { return []PortRange{{Lo: p, Hi: p}} }
+
+	cases := []struct {
+		token  string
+		family string
+		want   []L4Match
+	}{
+		{"bgp", "ip", []L4Match{{Proto: HostInboundProtoTCP, Ports: single(179)}}},
+		{"ospf", "ip", []L4Match{{Proto: 89}}},
+		{"ospf", "ip6", nil},
+		{"ospf3", "ip", nil},
+		{"ospf3", "ip6", []L4Match{{Proto: 89}}},
+		{"igmp", "ip", []L4Match{{Proto: 2}}},
+		{"igmp", "ip6", nil},
+		{"dvmrp", "ip", []L4Match{{Proto: 2}}},
+		{"dvmrp", "ip6", nil},
+		{"bfd", "ip", []L4Match{{Proto: HostInboundProtoUDP, Ports: []PortRange{{3784, 3784}, {3785, 3785}, {4784, 4784}}}}},
+		{"isis", "ip", nil},
+		{"isis", "ip6", nil},
+		{"router-discovery", "ip", []L4Match{
+			{Proto: HostInboundProtoICMP, ICMPType: u8(9)},
+			{Proto: HostInboundProtoICMP, ICMPType: u8(10)},
+		}},
+		{"router-discovery", "ip6", nil},
+	}
+	for _, c := range cases {
+		got := HostInboundProtocolMatch(c.token, c.family)
+		if !equalL4(got, c.want) {
+			t.Errorf("HostInboundProtocolMatch(%q,%q) = %s, want %s", c.token, c.family, showL4(got), showL4(c.want))
+		}
+	}
+
+	// `protocols all` includes bgp (tcp/179) and excludes isis (L2). It must
+	// never open a system-service like ssh.
+	all := HostInboundProtocolMatch("all", "ip")
+	if !containsL4(all, L4Match{Proto: HostInboundProtoTCP, Ports: single(179)}) {
+		t.Errorf("protocols all (ip) must expand to include bgp tcp/179; got %s", showL4(all))
+	}
+	if containsL4(all, L4Match{Proto: HostInboundProtoTCP, Ports: single(22)}) {
+		t.Errorf("protocols all must NOT open ssh tcp/22 (routing protocols only, #3199)")
+	}
+}
+
+func equalL4(a, b []L4Match) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !l4Equal(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func l4Equal(a, b L4Match) bool {
+	if a.Proto != b.Proto || a.Reject != b.Reject {
+		return false
+	}
+	if len(a.Ports) != len(b.Ports) {
+		return false
+	}
+	for i := range a.Ports {
+		if a.Ports[i] != b.Ports[i] {
+			return false
+		}
+	}
+	switch {
+	case a.ICMPType == nil && b.ICMPType == nil:
+		return true
+	case a.ICMPType == nil || b.ICMPType == nil:
+		return false
+	default:
+		return *a.ICMPType == *b.ICMPType
+	}
+}
+
+func containsL4(set []L4Match, want L4Match) bool {
+	for _, m := range set {
+		if l4Equal(m, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func showL4(ms []L4Match) string {
+	if ms == nil {
+		return "nil"
+	}
+	out := "["
+	for i, m := range ms {
+		if i > 0 {
+			out += " "
+		}
+		out += l4String(m)
+	}
+	return out + "]"
+}
+
+func l4String(m L4Match) string {
+	s := "proto=" + strconv.Itoa(int(m.Proto))
+	for _, p := range m.Ports {
+		if p.Lo == p.Hi {
+			s += "/" + strconv.Itoa(int(p.Lo))
+		} else {
+			s += "/" + strconv.Itoa(int(p.Lo)) + "-" + strconv.Itoa(int(p.Hi))
+		}
+	}
+	if m.ICMPType != nil {
+		s += "/icmp" + strconv.Itoa(int(*m.ICMPType))
+	}
+	if m.Reject {
+		s += "/reject"
+	}
+	return s
+}

--- a/pkg/config/host_inbound_tokens.go
+++ b/pkg/config/host_inbound_tokens.go
@@ -231,3 +231,254 @@ var HostInboundProtocolFamily = map[string]string{
 	// path. rsvp/pgm/sap are dual-family (absent here).
 	"dvmrp": "ip",
 }
+
+// ---------------------------------------------------------------------------
+// Structured token->tuple SSOT (#3627 B1a)
+//
+// Before #3627 the token->(proto, ports, icmp-type) mapping existed only as
+// nft match STRINGS (pkg/daemon hostInboundServiceMatches / hostInboundProtocol
+// Matches) and as the Rust classifier's per-CPU admit sets
+// (userspace-dp/.../forwarding/host_inbound.rs). A THIRD consumer — the
+// `request security match-policies` host-inbound simulator, which must report
+// WHICH host-inbound-traffic token admits a queried host-bound tuple — needs the
+// mapping in STRUCTURED form, not as nft syntax. Hand-writing a third table
+// would let it drift from the nft/Rust truth (a token could claim it admits
+// tcp/22 while a future edit moves the nft port). #3627 B1a extracts the single
+// structured SSOT below: the pkg/daemon nft builder RENDERS its match fragments
+// from this table (see renderHostInboundMatches) and the dataplane/userspace
+// host-inbound classifier MATCHES a query tuple against it, so both read ONE
+// table. The recognized-token allowlist (KnownHostInbound*), the family maps
+// (HostInbound*Family), and the L2/full-admit predicates above remain the
+// domain SSOT; this adds the per-token PORT/PROTO/ICMP truth.
+//
+// A per-tuple Rust parity test (host_inbound.rs admit-set == this table) is a
+// deferred follow-up; the existing domain-parity tests
+// (TestHostInboundNftMatchesKnownTokens, TestHostInboundRustClassifierMatchesGo
+// SSOT) still guard the token SETS.
+
+// IP protocol numbers the host-inbound token->tuple SSOT emits. Exported so the
+// pkg/daemon nft renderer and the dataplane/userspace classifier can key on a
+// match's L4 kind without re-deriving the numbers.
+const (
+	HostInboundProtoICMP   uint8 = 1
+	HostInboundProtoTCP    uint8 = 6
+	HostInboundProtoUDP    uint8 = 17
+	HostInboundProtoICMPv6 uint8 = 58
+)
+
+// PortRange is an inclusive TCP/UDP destination-port range in a host-inbound
+// L4Match. Lo == Hi is a single port (ssh -> {22,22}); Lo < Hi is a contiguous
+// range (traceroute -> {33434,33523}). All ports are host byte order.
+type PortRange struct {
+	Lo, Hi uint16
+}
+
+// L4Match is one structured host-inbound admission tuple for a Junos
+// host-inbound-traffic token in a given address family (#3627 B1a). Exactly one
+// L4 shape is populated per match:
+//
+//   - TCP/UDP (Proto == HostInboundProtoTCP/UDP): Ports carries the destination
+//     ports (single, set, or range). A zero-length Ports with a TCP/UDP proto is
+//     not emitted by this SSOT.
+//   - ICMP/ICMPv6 (Proto == HostInboundProtoICMP/ICMPv6): ICMPType carries the
+//     single admitted type (ping -> echo-request; router-discovery -> 9 then
+//     10 as two matches). nil ICMPType is not emitted for an ICMP proto.
+//   - a bare IP protocol (gre=47, ospf=89, pim=103, ...): neither Ports nor
+//     ICMPType is set; the protocol number alone is the match.
+//
+// Reject marks the lone non-admitting token `system-services ident-reset`
+// (#3310): its match fragment IS tcp/113 (the nft chain emits it to attach a
+// `reject with tcp reset` verdict), but it RESETS rather than admits, so the
+// host-inbound classifier must NOT report ident-reset as admitting a tcp/113
+// query. Every other token's matches admit (Reject == false).
+type L4Match struct {
+	Proto    uint8
+	Ports    []PortRange
+	ICMPType *uint8
+	Reject   bool
+}
+
+func hiTCP(ports ...uint16) L4Match {
+	return L4Match{Proto: HostInboundProtoTCP, Ports: hiPorts(ports)}
+}
+func hiUDP(ports ...uint16) L4Match {
+	return L4Match{Proto: HostInboundProtoUDP, Ports: hiPorts(ports)}
+}
+func hiIPProto(n uint8) L4Match { return L4Match{Proto: n} }
+func hiUDPRange(lo, hi uint16) L4Match {
+	return L4Match{Proto: HostInboundProtoUDP, Ports: []PortRange{{Lo: lo, Hi: hi}}}
+}
+
+func hiPorts(ports []uint16) []PortRange {
+	out := make([]PortRange, len(ports))
+	for i, p := range ports {
+		out[i] = PortRange{Lo: p, Hi: p}
+	}
+	return out
+}
+
+func hiICMP(proto, typ uint8) L4Match {
+	t := typ
+	return L4Match{Proto: proto, ICMPType: &t}
+}
+
+// HostInboundServiceMatch returns the structured admission tuples for a Junos
+// `system-services` token in the given address family ("ip" / "ip6"), the
+// STRUCTURED half of the #3627 B1a SSOT. It mirrors the pkg/daemon
+// hostInboundServiceMatches switch and the Rust classify_system_service admit
+// set exactly (docs/host-inbound-service-matrix.md), and applies the same family
+// gate: a family-specific token (HostInboundServiceFamily) returns nil for the
+// wrong family. Full-admit tokens (all / any-service, see
+// HostInboundFullAdmitService) and unrecognised tokens return nil — they are not
+// per-tuple matches. The nft builder renders these tuples back to byte-identical
+// match fragments (renderHostInboundMatches); the host-inbound classifier tests
+// each tuple against a queried packet tuple.
+func HostInboundServiceMatch(token, family string) []L4Match {
+	if fam, ok := HostInboundServiceFamily[token]; ok && fam != family {
+		return nil
+	}
+	switch token {
+	case "ssh":
+		return []L4Match{hiTCP(22)}
+	case "telnet":
+		return []L4Match{hiTCP(23)}
+	case "ftp":
+		return []L4Match{hiTCP(21)}
+	case "http", "webapi-clear-text":
+		return []L4Match{hiTCP(80)}
+	case "https", "webapi-ssl":
+		return []L4Match{hiTCP(443)}
+	case "ping":
+		// #3201/#3240: echo-request only — v4 type 8, v6 type 128. Error/PMTUD +
+		// ND subtypes are admitted globally, not per-token.
+		if family == "ip6" {
+			return []L4Match{hiICMP(HostInboundProtoICMPv6, 128)}
+		}
+		return []L4Match{hiICMP(HostInboundProtoICMP, 8)}
+	case "dns":
+		return []L4Match{hiUDP(53), hiTCP(53)}
+	case "dhcp", "bootp":
+		return []L4Match{hiUDP(67, 68)}
+	case "dhcpv6":
+		return []L4Match{hiUDP(546, 547)}
+	case "ntp":
+		return []L4Match{hiUDP(123)}
+	case "snmp":
+		return []L4Match{hiUDP(161)}
+	case "snmp-trap":
+		return []L4Match{hiUDP(162)}
+	case "ike", "ipsec":
+		// `ipsec` opens IKE (udp 500 / NAT-T 4500); the raw ESP/AH data plane is
+		// accepted globally, so `ipsec` is a superset of `ike` — one case.
+		return []L4Match{hiUDP(500, 4500)}
+	case "tftp":
+		return []L4Match{hiUDP(69)}
+	case "netconf":
+		return []L4Match{hiTCP(830)}
+	case "ssh-netconf", "netconf-ssh":
+		return []L4Match{hiTCP(22, 830)}
+	case "finger":
+		return []L4Match{hiTCP(79)}
+	case "ident-reset":
+		// #3310: matches tcp/113 (so the nft chain can attach `reject with tcp
+		// reset`) but RESETS — Reject marks it as non-admitting for the classifier.
+		m := hiTCP(113)
+		m.Reject = true
+		return []L4Match{m}
+	case "lsping":
+		return []L4Match{hiUDP(3503)}
+	case "sip":
+		return []L4Match{hiUDP(5060), hiTCP(5060)}
+	case "r-login", "rlogin":
+		return []L4Match{hiTCP(513)}
+	case "r-sh", "rsh":
+		return []L4Match{hiTCP(514)}
+	case "r-exec", "rexec":
+		return []L4Match{hiTCP(512)}
+	case "xnm-clear-text":
+		return []L4Match{hiTCP(3221)}
+	case "xnm-ssl":
+		return []L4Match{hiTCP(3220)}
+	case "traceroute":
+		return []L4Match{hiUDPRange(33434, 33523)}
+	case "gre":
+		return []L4Match{hiIPProto(47)}
+	default:
+		return nil
+	}
+}
+
+// HostInboundProtocolMatch returns the structured admission tuples for a Junos
+// `protocols` (routing-protocol) token in the given family, the protocol half of
+// the #3627 B1a SSOT. `all` expands to every routing protocol via
+// HostInboundAllExpansionProtocols (#3199/#3311 — L2/non-IP protocols excluded),
+// each family-gated, exactly like the pkg/daemon nft `all` case and the Rust
+// routing_protocol_all_expansion. Family-specific tokens (HostInboundProtocol
+// Family) return nil for the wrong family; L2 tokens (isis) and unrecognised
+// tokens return nil (no IP match).
+func HostInboundProtocolMatch(token, family string) []L4Match {
+	if fam, ok := HostInboundProtocolFamily[token]; ok && fam != family {
+		return nil
+	}
+	switch token {
+	case "all":
+		var out []L4Match
+		for _, p := range HostInboundAllExpansionProtocols() {
+			out = append(out, HostInboundProtocolMatch(p, family)...)
+		}
+		return out
+	case "ospf", "ospf3":
+		// Both ride IP protocol 89; the family gate above scopes each.
+		return []L4Match{hiIPProto(89)}
+	case "bgp":
+		return []L4Match{hiTCP(179)}
+	case "rip":
+		return []L4Match{hiUDP(520)}
+	case "ripng":
+		return []L4Match{hiUDP(521)}
+	case "igmp":
+		return []L4Match{hiIPProto(2)}
+	case "pim":
+		return []L4Match{hiIPProto(103)}
+	case "vrrp":
+		return []L4Match{hiIPProto(112)}
+	case "bfd":
+		// #3299: single-hop control (3784) + echo (3785) + multi-hop control (4784).
+		return []L4Match{hiUDP(3784, 3785, 4784)}
+	case "ldp":
+		return []L4Match{hiTCP(646), hiUDP(646)}
+	case "msdp":
+		return []L4Match{hiTCP(639)}
+	case "nhrp":
+		return []L4Match{hiIPProto(54)}
+	case "rsvp":
+		return []L4Match{hiIPProto(46)}
+	case "pgm":
+		return []L4Match{hiIPProto(113)}
+	case "sap":
+		return []L4Match{hiUDP(9875)}
+	case "dvmrp":
+		return []L4Match{hiIPProto(2)}
+	case "isis":
+		// #3311: rides L2 (OSI/CLNP), no IP match — handled by FRR over LLC.
+		return nil
+	case "router-discovery":
+		if family == "ip6" {
+			// v6 RS/RA are part of the always-accepted ND set (global accept).
+			return nil
+		}
+		return []L4Match{hiICMP(HostInboundProtoICMP, 9), hiICMP(HostInboundProtoICMP, 10)}
+	default:
+		return nil
+	}
+}
+
+// HostInboundFullAdmitService reports whether a `system-services` token opens
+// the zone to EVERY host-bound service (Junos `all` / `any-service`). Such a
+// token is not a per-tuple L4Match (HostInboundServiceMatch returns nil for it);
+// the nft builder emits a bare `accept` and the classifier reports admission
+// regardless of the tuple. `protocols all` is deliberately NOT a full admit
+// (#3199) — it expands to the routing-protocol set via HostInboundProtocolMatch.
+func HostInboundFullAdmitService(token string) bool {
+	return token == "all" || token == "any-service"
+}

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -527,7 +527,17 @@ never lock an operator out of a remote box it manages.
   are accepted before any deny; a configured zone that resolves to zero
   recognized matches fails OPEN (no deny) rather than locking the zone out.
   Token→nft mapping (`hostInboundServiceMatches`/`hostInboundProtocolMatches`)
-  mirrors the Rust classifier and must stay in sync. The authoritative
+  mirrors the Rust classifier and must stay in sync. **Structured SSOT (#3627
+  B1a):** since #3627 these two functions no longer carry their own hard-coded
+  nft strings — they RENDER (`renderHostInboundMatches`) the single structured
+  token→tuple SSOT `config.HostInboundServiceMatch` / `HostInboundProtocolMatch`
+  (`[]config.L4Match{Proto, Ports, ICMPType, Reject}`). The same table backs the
+  `request security match-policies` host-inbound classifier
+  (`dataplane/userspace.ClassifyHostInbound`), so the reported admitting token
+  cannot drift from the port the kernel opens. The render is byte-identical to
+  the pre-#3627 strings, proven by
+  `TestHostInboundNftRenderGoldenByteIdentical`; a per-tuple Rust parity test is
+  a deferred follow-up (the domain-parity guards still hold). The authoritative
   operator-facing token→port matrix across all three surfaces (Go SSOT allowlist,
   this nft mirror, the Rust AF_XDP classifier), including the deliberate
   narrowings and the ident-reset divergence, is

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -609,7 +609,7 @@ func emitHostInboundZone(rules *[]string, v dpuserspace.ZoneHostInboundView, fam
 // it never opens SSH/HTTPS/SNMP/NETCONF on the box.
 func hostInboundAllowsAll(v dpuserspace.ZoneHostInboundView) bool {
 	for _, s := range v.SystemServices {
-		if s == "all" || s == "any-service" {
+		if config.HostInboundFullAdmitService(s) {
 			return true
 		}
 	}
@@ -709,178 +709,113 @@ func hostInboundMatchSet(v dpuserspace.ZoneHostInboundView, family string) []hos
 // hostInboundServiceMatches maps a Junos `system-services` token to nft match
 // fragments for the given family. Returns nil for `all` / `any-service`
 // (handled by hostInboundAllowsAll) and for unrecognised tokens (fail-closed).
+//
+// #3627 B1a: the token->tuple truth now lives in the structured SSOT
+// config.HostInboundServiceMatch (shared with the match-policies host-inbound
+// classifier); this function RENDERS those tuples to nft match fragments. The
+// render is byte-identical to the pre-#3627 hand-written switch — proven by
+// TestHostInboundNftRenderGoldenByteIdentical — so the nft kernel mirror is
+// unchanged. The family gate (dhcp=v4, dhcpv6=v6, ...) is applied inside
+// HostInboundServiceMatch via config.HostInboundServiceFamily.
 func hostInboundServiceMatches(token, family string) []string {
-	// #3225: family-specific services (dhcp=v4, dhcpv6=v6) emit ONLY on their
-	// own family. emitHostInboundZone calls this once per family with the same
-	// token set, so a family-mismatched token must contribute no match (it would
-	// otherwise be emitted under the wrong `ip`/`ip6 daddr`). The family map is
-	// the SSOT shared with the Rust classifier (config.HostInboundServiceFamily).
-	if fam, ok := config.HostInboundServiceFamily[token]; ok && fam != family {
-		return nil
-	}
-	icmp := "icmp"
-	if family == "ip6" {
-		icmp = "icmpv6"
-	}
-	switch token {
-	case "ssh":
-		return []string{"tcp dport 22"}
-	case "telnet":
-		return []string{"tcp dport 23"}
-	case "ftp":
-		return []string{"tcp dport 21"}
-	case "http", "webapi-clear-text":
-		return []string{"tcp dport 80"}
-	case "https", "webapi-ssl":
-		return []string{"tcp dport 443"}
-	case "ping":
-		return []string{icmp + " type echo-request"}
-	case "dns":
-		return []string{"udp dport 53", "tcp dport 53"}
-	case "dhcp", "bootp":
-		return []string{"udp dport { 67, 68 }"}
-	case "dhcpv6":
-		return []string{"udp dport { 546, 547 }"}
-	case "ntp":
-		return []string{"udp dport 123"}
-	case "snmp":
-		return []string{"udp dport 161"}
-	case "snmp-trap":
-		return []string{"udp dport 162"}
-	case "ike", "ipsec":
-		// `ipsec` is the Junos system-service that permits host-terminated
-		// IPsec: IKE negotiation (udp 500 / NAT-T 4500) plus the ESP/AH data
-		// plane. The raw ESP (50) / AH (51) data plane is already accepted
-		// globally in buildHostInboundFilterPayload (so the kernel XFRM stack
-		// can decrypt), so the per-zone match only needs to open IKE — making
-		// `ipsec` a superset of `ike`. Treating them as one case keeps the nft
-		// mirror in parity with the Rust classifier.
-		return []string{"udp dport { 500, 4500 }"}
-	case "tftp":
-		return []string{"udp dport 69"}
-	case "netconf":
-		return []string{"tcp dport 830"}
-	case "ssh-netconf", "netconf-ssh":
-		return []string{"tcp dport { 22, 830 }"}
-	case "finger":
-		return []string{"tcp dport 79"}
-	case "ident-reset":
-		return []string{"tcp dport 113"}
-	case "lsping":
-		return []string{"udp dport 3503"}
-	case "sip":
-		return []string{"udp dport 5060", "tcp dport 5060"}
-	case "r-login", "rlogin":
-		return []string{"tcp dport 513"}
-	case "r-sh", "rsh":
-		return []string{"tcp dport 514"}
-	case "r-exec", "rexec":
-		return []string{"tcp dport 512"}
-	case "xnm-clear-text":
-		return []string{"tcp dport 3221"}
-	case "xnm-ssl":
-		return []string{"tcp dport 3220"}
-	case "traceroute":
-		return []string{"udp dport 33434-33523"}
-	case "gre":
-		return []string{"meta l4proto 47"}
-	default:
-		return nil
-	}
+	return renderHostInboundMatches(config.HostInboundServiceMatch(token, family), family)
 }
 
 // hostInboundProtocolMatches maps a Junos `protocols` (routing-protocol) token
 // to nft match fragments. `all` expands to the full routing-protocol set
 // (#3199) — NOT a blanket accept (that would open every system-service). Returns
 // nil for unrecognised tokens (fail-closed).
+//
+// #3627 B1a: renders the structured SSOT config.HostInboundProtocolMatch (which
+// owns the `all` expansion, the #3225 family gating, and the #3311 L2 no-op) to
+// byte-identical nft fragments.
 func hostInboundProtocolMatches(token, family string) []string {
-	// #3225: family-specific routing protocols (ospf=v4 / ospf3=v6, rip=v4 /
-	// ripng=v6, igmp=v4) emit ONLY on their own family — the SSOT is
-	// config.HostInboundProtocolFamily, shared with the Rust classifier. `all`
-	// is dual-family (absent from the map) and recurses into the per-token set,
-	// each of which family-gates itself here.
-	if fam, ok := config.HostInboundProtocolFamily[token]; ok && fam != family {
-		return nil
-	}
-	switch token {
-	case "all":
-		// `protocols all` = every recognized routing protocol, scoped to
-		// protocol traffic (#3199) — NOT a blanket accept. The expansion set is
-		// the SSOT-derived config.HostInboundAllExpansionProtocols()
-		// (KnownHostInboundProtocols minus `all` minus the L2/non-IP set
-		// config.HostInboundL2Protocols), so an L2 protocol like IS-IS is
-		// AUTOMATICALLY excluded from the IP expansion — adding one to the SSOT
-		// requires no edit here (#3311). ospf+ospf3 both appear (#3225): both
-		// ride IP protocol 89 but on different families; hostInboundProtocolMatches
-		// family-gates each, so proto 89 emits once per family. The Rust `all`
-		// arm mirrors this exclusion via routing_protocol_all_expansion().
-		var out []string
-		for _, p := range config.HostInboundAllExpansionProtocols() {
-			out = append(out, hostInboundProtocolMatches(p, family)...)
+	return renderHostInboundMatches(config.HostInboundProtocolMatch(token, family), family)
+}
+
+// renderHostInboundMatches renders a slice of structured host-inbound L4 match
+// tuples (config.L4Match, the #3627 B1a SSOT) into nft match fragments,
+// preserving the authored per-token order. The render is byte-identical to the
+// pre-#3627 hand-written strings (guarded by
+// TestHostInboundNftRenderGoldenByteIdentical):
+//
+//   - TCP/UDP -> "tcp dport <spec>" / "udp dport <spec>" (renderHostInboundPortSpec)
+//   - ICMP/ICMPv6 -> "icmp type <spec>" / "icmpv6 type <spec>", coalescing
+//     consecutive same-proto ICMP tuples into ONE type set so router-discovery
+//     stays `icmp type { 9, 10 }` (one rule) rather than two
+//   - a bare IP protocol -> "meta l4proto <n>"
+//
+// The Reject marker (ident-reset) does not affect the match fragment — the nft
+// VERDICT is applied separately by hostInboundServiceAction — so this render is
+// verdict-agnostic.
+func renderHostInboundMatches(ms []config.L4Match, family string) []string {
+	var out []string
+	for i := 0; i < len(ms); {
+		m := ms[i]
+		switch m.Proto {
+		case config.HostInboundProtoICMP, config.HostInboundProtoICMPv6:
+			kw := "icmp"
+			if m.Proto == config.HostInboundProtoICMPv6 {
+				kw = "icmpv6"
+			}
+			var types []uint8
+			for i < len(ms) && ms[i].Proto == m.Proto && ms[i].ICMPType != nil {
+				types = append(types, *ms[i].ICMPType)
+				i++
+			}
+			out = append(out, kw+" type "+renderHostInboundICMPSpec(types, m.Proto))
+		case config.HostInboundProtoTCP:
+			out = append(out, "tcp dport "+renderHostInboundPortSpec(m.Ports))
+			i++
+		case config.HostInboundProtoUDP:
+			out = append(out, "udp dport "+renderHostInboundPortSpec(m.Ports))
+			i++
+		default:
+			out = append(out, "meta l4proto "+strconv.Itoa(int(m.Proto)))
+			i++
 		}
-		return out
-	case "ospf", "ospf3":
-		// OSPFv2 (ospf, IPv4) and OSPFv3 (ospf3, IPv6) both ride IP protocol 89;
-		// the family gate above scopes each to its own family.
-		return []string{"meta l4proto 89"}
-	case "bgp":
-		return []string{"tcp dport 179"}
-	case "rip":
-		return []string{"udp dport 520"}
-	case "ripng":
-		return []string{"udp dport 521"}
-	case "igmp":
-		// v6 multicast group membership is MLD (icmpv6), reached via the ND
-		// accept; the family gate restricts igmp to IPv4.
-		return []string{"meta l4proto 2"}
-	case "pim":
-		return []string{"meta l4proto 103"}
-	case "vrrp":
-		return []string{"meta l4proto 112"}
-	case "bfd":
-		// #3299: single-hop control (3784) + echo (3785) AND multi-hop
-		// control (4784, RFC 5883). Keep this set in lockstep with the
-		// AF_XDP host_inbound classifier (host_inbound.rs "bfd" arm).
-		return []string{"udp dport { 3784, 3785, 4784 }"}
-	case "ldp":
-		return []string{"tcp dport 646", "udp dport 646"}
-	case "msdp":
-		return []string{"tcp dport 639"}
-	case "nhrp":
-		return []string{"meta l4proto 54"}
-	case "rsvp":
-		// #3341: RSVP rides directly over IP, protocol 46 (dual-family).
-		return []string{"meta l4proto 46"}
-	case "pgm":
-		// #3341: PGM (Pragmatic General Multicast) rides over IP, protocol 113
-		// (dual-family).
-		return []string{"meta l4proto 113"}
-	case "sap":
-		// #3341: SAP (Session Announcement Protocol) is UDP/9875 (dual-family).
-		return []string{"udp dport 9875"}
-	case "dvmrp":
-		// #3341: DVMRP is carried inside IGMP (IP protocol 2) and is IPv4-only;
-		// the family gate above (config.HostInboundProtocolFamily["dvmrp"]="ip")
-		// restricts it to IPv4, matching igmp.
-		return []string{"meta l4proto 2"}
-	case "isis":
-		// #3311: IS-IS rides OSI/CLNP directly over L2 (LLC-encapsulated, NOT
-		// IP), so it cannot be expressed as an ip/ip6 host-inbound match. It is
-		// a recognized-but-no-op token (config.HostInboundL2Protocols): the
-		// kernel delivers IS-IS PDUs to FRR's isisd via an LLC packet socket,
-		// outside this IP host-inbound filter. Returning nil keeps this surface
-		// consistent with the Rust classifier's isis no-op arm. The nft parity
-		// test skips L2 protocols and asserts they produce no IP match.
-		return nil
-	case "router-discovery":
-		if family == "ip6" {
-			// v6 RS/RA are part of the always-accepted ND set above.
-			return nil
-		}
-		return []string{"icmp type { 9, 10 }"}
-	default:
-		return nil
 	}
+	return out
+}
+
+// renderHostInboundPortSpec renders a TCP/UDP destination-port spec: a single
+// port ("22"), a contiguous range ("33434-33523"), or an nft anonymous set of
+// multiple ports ("{ 67, 68 }").
+func renderHostInboundPortSpec(ports []config.PortRange) string {
+	if len(ports) == 1 {
+		return renderHostInboundPort(ports[0])
+	}
+	parts := make([]string, len(ports))
+	for i, p := range ports {
+		parts[i] = renderHostInboundPort(p)
+	}
+	return "{ " + strings.Join(parts, ", ") + " }"
+}
+
+func renderHostInboundPort(p config.PortRange) string {
+	if p.Lo == p.Hi {
+		return strconv.Itoa(int(p.Lo))
+	}
+	return strconv.Itoa(int(p.Lo)) + "-" + strconv.Itoa(int(p.Hi))
+}
+
+// renderHostInboundICMPSpec renders an ICMP/ICMPv6 type spec. A single
+// echo-request type (v4 8 / v6 128) renders as the nft named type
+// "echo-request" — the only named ICMP type the per-token host-inbound rules
+// use; every other type renders numerically ("{ 9, 10 }" for router-discovery).
+func renderHostInboundICMPSpec(types []uint8, proto uint8) string {
+	if len(types) == 1 {
+		if (proto == config.HostInboundProtoICMP && types[0] == 8) ||
+			(proto == config.HostInboundProtoICMPv6 && types[0] == 128) {
+			return "echo-request"
+		}
+		return strconv.Itoa(int(types[0]))
+	}
+	parts := make([]string, len(types))
+	for i, t := range types {
+		parts[i] = strconv.Itoa(int(t))
+	}
+	return "{ " + strings.Join(parts, ", ") + " }"
 }
 
 // nftAddrSet renders a single address as a bare token or multiple as an nft

--- a/pkg/daemon/host_inbound_ssot_render_3627_test.go
+++ b/pkg/daemon/host_inbound_ssot_render_3627_test.go
@@ -1,0 +1,163 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestHostInboundNftRenderGoldenByteIdentical is the #3627 B1a byte-identity
+// proof for the SSOT nft-render refactor. hostInboundServiceMatches /
+// hostInboundProtocolMatches now RENDER the structured token->tuple SSOT
+// (config.HostInboundServiceMatch / config.HostInboundProtocolMatch) instead of
+// carrying their own hand-written nft strings. This golden freezes the EXACT
+// pre-#3627 nft fragments (captured from the hand-written switch before the
+// refactor) for every known token in both families, so any drift in the SSOT or
+// the renderer — a moved port, a lost `{ 9, 10 }` coalesce, a numeric
+// echo-request, a wrong `all` expansion order — turns this RED. It is the
+// "no behavior change, only a shared SSOT" guarantee the refactor rests on.
+//
+// The golden values are the authoritative nft match fragments; the parallel
+// domain-parity guards (TestHostInboundNftMatchesKnownTokens,
+// TestHostInboundSipTftpNarrowPortSet, ...) still assert the token SETS agree
+// with the recognized-token SSOT and the Rust classifier.
+func TestHostInboundNftRenderGoldenByteIdentical(t *testing.T) {
+	svc := map[string][2][]string{
+		"all":               {nil, nil},
+		"any-service":       {nil, nil},
+		"bootp":             {{"udp dport { 67, 68 }"}, nil},
+		"dhcp":              {{"udp dport { 67, 68 }"}, nil},
+		"dhcpv6":            {nil, {"udp dport { 546, 547 }"}},
+		"dns":               {{"udp dport 53", "tcp dport 53"}, {"udp dport 53", "tcp dport 53"}},
+		"finger":            {{"tcp dport 79"}, {"tcp dport 79"}},
+		"ftp":               {{"tcp dport 21"}, {"tcp dport 21"}},
+		"gre":               {{"meta l4proto 47"}, {"meta l4proto 47"}},
+		"http":              {{"tcp dport 80"}, {"tcp dport 80"}},
+		"https":             {{"tcp dport 443"}, {"tcp dport 443"}},
+		"ident-reset":       {{"tcp dport 113"}, {"tcp dport 113"}},
+		"ike":               {{"udp dport { 500, 4500 }"}, {"udp dport { 500, 4500 }"}},
+		"ipsec":             {{"udp dport { 500, 4500 }"}, {"udp dport { 500, 4500 }"}},
+		"lsping":            {{"udp dport 3503"}, {"udp dport 3503"}},
+		"netconf":           {{"tcp dport 830"}, {"tcp dport 830"}},
+		"netconf-ssh":       {{"tcp dport { 22, 830 }"}, {"tcp dport { 22, 830 }"}},
+		"ntp":               {{"udp dport 123"}, {"udp dport 123"}},
+		"ping":              {{"icmp type echo-request"}, {"icmpv6 type echo-request"}},
+		"r-exec":            {{"tcp dport 512"}, {"tcp dport 512"}},
+		"r-login":           {{"tcp dport 513"}, {"tcp dport 513"}},
+		"r-sh":              {{"tcp dport 514"}, {"tcp dport 514"}},
+		"rexec":             {{"tcp dport 512"}, {"tcp dport 512"}},
+		"rlogin":            {{"tcp dport 513"}, {"tcp dport 513"}},
+		"rsh":               {{"tcp dport 514"}, {"tcp dport 514"}},
+		"sip":               {{"udp dport 5060", "tcp dport 5060"}, {"udp dport 5060", "tcp dport 5060"}},
+		"snmp":              {{"udp dport 161"}, {"udp dport 161"}},
+		"snmp-trap":         {{"udp dport 162"}, {"udp dport 162"}},
+		"ssh":               {{"tcp dport 22"}, {"tcp dport 22"}},
+		"ssh-netconf":       {{"tcp dport { 22, 830 }"}, {"tcp dport { 22, 830 }"}},
+		"telnet":            {{"tcp dport 23"}, {"tcp dport 23"}},
+		"tftp":              {{"udp dport 69"}, {"udp dport 69"}},
+		"traceroute":        {{"udp dport 33434-33523"}, {"udp dport 33434-33523"}},
+		"webapi-clear-text": {{"tcp dport 80"}, {"tcp dport 80"}},
+		"webapi-ssl":        {{"tcp dport 443"}, {"tcp dport 443"}},
+		"xnm-clear-text":    {{"tcp dport 3221"}, {"tcp dport 3221"}},
+		"xnm-ssl":           {{"tcp dport 3220"}, {"tcp dport 3220"}},
+	}
+	proto := map[string][2][]string{
+		"all": {
+			{"udp dport { 3784, 3785, 4784 }", "tcp dport 179", "meta l4proto 2", "meta l4proto 2", "tcp dport 646", "udp dport 646", "tcp dport 639", "meta l4proto 54", "meta l4proto 89", "meta l4proto 113", "meta l4proto 103", "udp dport 520", "icmp type { 9, 10 }", "meta l4proto 46", "udp dport 9875", "meta l4proto 112"},
+			{"udp dport { 3784, 3785, 4784 }", "tcp dport 179", "tcp dport 646", "udp dport 646", "tcp dport 639", "meta l4proto 54", "meta l4proto 89", "meta l4proto 113", "meta l4proto 103", "udp dport 521", "meta l4proto 46", "udp dport 9875", "meta l4proto 112"},
+		},
+		"bfd":              {{"udp dport { 3784, 3785, 4784 }"}, {"udp dport { 3784, 3785, 4784 }"}},
+		"bgp":              {{"tcp dport 179"}, {"tcp dport 179"}},
+		"dvmrp":            {{"meta l4proto 2"}, nil},
+		"igmp":             {{"meta l4proto 2"}, nil},
+		"isis":             {nil, nil},
+		"ldp":              {{"tcp dport 646", "udp dport 646"}, {"tcp dport 646", "udp dport 646"}},
+		"msdp":             {{"tcp dport 639"}, {"tcp dport 639"}},
+		"nhrp":             {{"meta l4proto 54"}, {"meta l4proto 54"}},
+		"ospf":             {{"meta l4proto 89"}, nil},
+		"ospf3":            {nil, {"meta l4proto 89"}},
+		"pgm":              {{"meta l4proto 113"}, {"meta l4proto 113"}},
+		"pim":              {{"meta l4proto 103"}, {"meta l4proto 103"}},
+		"rip":              {{"udp dport 520"}, nil},
+		"ripng":            {nil, {"udp dport 521"}},
+		"router-discovery": {{"icmp type { 9, 10 }"}, nil},
+		"rsvp":             {{"meta l4proto 46"}, {"meta l4proto 46"}},
+		"sap":              {{"udp dport 9875"}, {"udp dport 9875"}},
+		"vrrp":             {{"meta l4proto 112"}, {"meta l4proto 112"}},
+	}
+
+	families := [2]string{"ip", "ip6"}
+
+	// Every golden key must be a recognized token, and every recognized token
+	// must have a golden entry — so a token added to the SSOT without a golden
+	// (or vice versa) is caught, not silently unverified.
+	for tok := range config.KnownHostInboundSystemServices {
+		if _, ok := svc[tok]; !ok {
+			t.Errorf("service token %q recognized by the SSOT but missing a byte-identity golden entry", tok)
+		}
+	}
+	for tok := range svc {
+		if !config.KnownHostInboundSystemServices[tok] {
+			t.Errorf("golden lists service token %q that is not in the recognized-token SSOT", tok)
+		}
+		for fi, fam := range families {
+			got := hostInboundServiceMatches(tok, fam)
+			if !equalStrings(got, svc[tok][fi]) {
+				t.Errorf("service %q (%s): render drift\n got  %#v\n want %#v", tok, fam, got, svc[tok][fi])
+			}
+		}
+	}
+	for tok := range config.KnownHostInboundProtocols {
+		if _, ok := proto[tok]; !ok {
+			t.Errorf("protocol token %q recognized by the SSOT but missing a byte-identity golden entry", tok)
+		}
+	}
+	for tok := range proto {
+		if !config.KnownHostInboundProtocols[tok] {
+			t.Errorf("golden lists protocol token %q that is not in the recognized-token SSOT", tok)
+		}
+		for fi, fam := range families {
+			got := hostInboundProtocolMatches(tok, fam)
+			if !equalStrings(got, proto[tok][fi]) {
+				t.Errorf("protocol %q (%s): render drift\n got  %#v\n want %#v", tok, fam, got, proto[tok][fi])
+			}
+		}
+	}
+}
+
+// TestHostInboundIdentResetRejectMarkerMatchesNftVerdict ties the #3627 SSOT
+// Reject marker to the pre-existing nft verdict SSOT (hostInboundServiceAction):
+// a service token whose SSOT tuple carries Reject == true is EXACTLY the token
+// the nft chain rejects (ident-reset), and every non-Reject token is a plain
+// accept. This guards against the marker and the nft verdict drifting apart —
+// e.g. adding a Reject tuple without teaching hostInboundServiceAction, which
+// would make the classifier report "not admitted" while the nft chain still
+// admits (or vice versa).
+func TestHostInboundIdentResetRejectMarkerMatchesNftVerdict(t *testing.T) {
+	for tok := range config.KnownHostInboundSystemServices {
+		reject := false
+		for _, fam := range []string{"ip", "ip6"} {
+			for _, m := range config.HostInboundServiceMatch(tok, fam) {
+				if m.Reject {
+					reject = true
+				}
+			}
+		}
+		wantReject := hostInboundServiceAction(tok) == hostInboundReject
+		if reject != wantReject {
+			t.Errorf("service %q: SSOT Reject marker = %v but nft verdict reject = %v — the marker and the nft verdict must agree", tok, reject, wantReject)
+		}
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/dataplane/userspace/host_inbound_classify.go
+++ b/pkg/dataplane/userspace/host_inbound_classify.go
@@ -1,0 +1,262 @@
+package userspace
+
+import (
+	"fmt"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// host_inbound_classify.go is the #3627 B1a host-inbound admission CLASSIFIER:
+// given a host-bound (to-zone junos-host) query tuple and the ingress zone, it
+// reports WHICH host-inbound-traffic system-service / protocol token admits the
+// packet — or that the box denies it, admits it globally (ICMP error/ND, ESP/AH),
+// or cannot classify it. It is consumed by the operator-plane match-policies
+// simulator (pkg/policymatch) so the host-inbound verdict names the admitting
+// token instead of the fixed "local delivery subject to host-inbound-traffic"
+// string.
+//
+// It is a DIAGNOSTIC, not the enforcement path: the kernel-nft chain
+// (pkg/daemon/daemon_nft.go) and the Rust AF_XDP classifier
+// (userspace-dp/.../forwarding/host_inbound.rs) enforce. To avoid a THIRD
+// token->port truth drifting from those two, the classifier reads the SAME
+// structured SSOT the nft builder renders from (config.HostInboundServiceMatch /
+// config.HostInboundProtocolMatch, #3627 B1a) and mirrors the global pre-accepts
+// the nft chain applies at the top of `chain input`
+// (buildHostInboundFilterPayload) and the Rust is_icmp_host_inbound_global_accept
+// (#3171): ESP/AH raw data plane, ICMP error/PMTUD, and the IPv6 ND set.
+//
+// Faithful to the enforcement paths (plan §5): a zone can carry MULTIPLE
+// per-interface effective views (#3362) — the query has no ingress interface, so
+// admission is reported if ANY view for the ingress zone admits the tuple.
+// Post-#3405 a configured zone with no host-inbound-traffic stanza default-DENIES
+// (its view carries empty token sets), so "unmatched host policy" does NOT imply
+// delivery. Lifeline interfaces (fxp0/em0/fab*) are excluded from the views and
+// so are never classified here (their host traffic is served unconditionally).
+
+// HostInboundStatus classifies how the ingress zone's host-inbound-traffic
+// admission gate treats a host-bound query tuple (#3627 B1a). It is presence-safe
+// so the four states are distinguishable — a bare token string could not tell
+// "denied" from "not computed" from "admitted by a global accept".
+type HostInboundStatus int
+
+const (
+	// HostInboundNotComputed is the zero value: the admission was not computed
+	// (not a host-bound query, or no config). Rendered as absence.
+	HostInboundNotComputed HostInboundStatus = iota
+	// HostInboundIndeterminate: the query omits the protocol, or omits the
+	// destination-port / icmp-type a port/ICMP token needs, so the admitting
+	// token cannot be identified. Never reported as a false admit.
+	HostInboundIndeterminate
+	// HostInboundGlobalAccept: admitted by a GLOBAL pre-accept independent of the
+	// zone's host-inbound-traffic set (ICMP error/PMTUD, IPv6 ND, or the raw
+	// ESP/AH data plane), matching the top-of-chain nft accepts (#3171).
+	HostInboundGlobalAccept
+	// HostInboundTokenAdmit: admitted by a named host-inbound-traffic token
+	// (Token/Kind identify it).
+	HostInboundTokenAdmit
+	// HostInboundDenied: the ingress zone's host-inbound-traffic admits nothing
+	// matching this tuple — the box drops the packet (Junos default-deny).
+	HostInboundDenied
+)
+
+func (s HostInboundStatus) String() string {
+	switch s {
+	case HostInboundIndeterminate:
+		return "indeterminate"
+	case HostInboundGlobalAccept:
+		return "global-accept"
+	case HostInboundTokenAdmit:
+		return "token-admit"
+	case HostInboundDenied:
+		return "denied"
+	default:
+		return "not-computed"
+	}
+}
+
+// HostInboundAdmission is the classifier verdict for a host-bound query tuple
+// (#3627 B1a). Token/Kind are meaningful only when Status == HostInboundTokenAdmit.
+type HostInboundAdmission struct {
+	Status HostInboundStatus
+	// Token is the admitting host-inbound-traffic token (e.g. "ssh", "bgp",
+	// "all"); set only for HostInboundTokenAdmit.
+	Token string
+	// Kind is the stanza the token belongs to: "system-services" or "protocols".
+	// Set only for HostInboundTokenAdmit.
+	Kind string
+}
+
+// Describe renders the operator-facing one-line explanation of the admission,
+// appended to the host-inbound match-policies verdict. Empty for
+// HostInboundNotComputed (nothing to say).
+func (a HostInboundAdmission) Describe() string {
+	switch a.Status {
+	case HostInboundTokenAdmit:
+		if a.Token == "all" || a.Token == "any-service" {
+			return fmt.Sprintf("admitted by host-inbound-traffic system-services %s (all host services open)", a.Token)
+		}
+		return fmt.Sprintf("admitted by host-inbound-traffic %s %s", a.Kind, a.Token)
+	case HostInboundGlobalAccept:
+		return "admitted by a global accept (ICMP error/PMTUD, IPv6 ND, or ESP/AH) independent of this zone's host-inbound-traffic set"
+	case HostInboundDenied:
+		return "DENIED by host-inbound-traffic — no system-service/protocol admits this tuple, so the box drops it"
+	case HostInboundIndeterminate:
+		return "indeterminate — specify protocol (and destination-port or icmp-type) to identify the admitting host-inbound-traffic token"
+	default:
+		return ""
+	}
+}
+
+// ClassifyHostInbound reports how the ingress zone's host-inbound-traffic gate
+// treats a host-bound query tuple (#3627 B1a). proto/hasProto carry the resolved
+// IP protocol number (hasProto false = the query omitted the protocol); dstPort
+// is the destination port (<= 0 = unspecified); icmpType is the ICMP/ICMPv6 type
+// (nil = unspecified); family is "ip" / "ip6" from the query's destination
+// address, or "" when the query gives no IP (both families are then tried and
+// admission is reported if either admits).
+func ClassifyHostInbound(cfg *config.Config, fromZone string, proto uint8, hasProto bool, dstPort int, icmpType *uint8, family string) HostInboundAdmission {
+	if cfg == nil || fromZone == "" {
+		return HostInboundAdmission{Status: HostInboundNotComputed}
+	}
+
+	views := viewsForZone(cfg, fromZone)
+
+	// Full-admit (`system-services all` / `any-service`) admits everything,
+	// independent of the tuple — report it even when the tuple is otherwise
+	// indeterminate.
+	for _, v := range views {
+		for _, s := range v.SystemServices {
+			if config.HostInboundFullAdmitService(s) {
+				return HostInboundAdmission{Status: HostInboundTokenAdmit, Token: s, Kind: "system-services"}
+			}
+		}
+	}
+
+	// Global pre-accepts (ICMP error/PMTUD, IPv6 ND, ESP/AH), mirroring the
+	// top-of-chain nft accepts (#3171). Needs the protocol.
+	if hasProto && hostInboundGlobalAccept(proto, icmpType) {
+		return HostInboundAdmission{Status: HostInboundGlobalAccept}
+	}
+
+	if !hasProto {
+		return HostInboundAdmission{Status: HostInboundIndeterminate}
+	}
+	// A port/ICMP token cannot be identified without the port / icmp-type.
+	if (proto == config.HostInboundProtoTCP || proto == config.HostInboundProtoUDP) && dstPort <= 0 {
+		return HostInboundAdmission{Status: HostInboundIndeterminate}
+	}
+	if (proto == config.HostInboundProtoICMP || proto == config.HostInboundProtoICMPv6) && icmpType == nil {
+		return HostInboundAdmission{Status: HostInboundIndeterminate}
+	}
+
+	fams := []string{family}
+	if family == "" {
+		fams = []string{"ip", "ip6"}
+	}
+	for _, v := range views {
+		for _, fam := range fams {
+			if tok, kind, ok := hostInboundViewAdmit(v, proto, dstPort, icmpType, fam); ok {
+				return HostInboundAdmission{Status: HostInboundTokenAdmit, Token: tok, Kind: kind}
+			}
+		}
+	}
+	// The zone is configured (post-#3405 every configured zone enforces) and
+	// nothing admits — default-deny.
+	return HostInboundAdmission{Status: HostInboundDenied}
+}
+
+// viewsForZone returns the host-inbound effective views for the given ingress
+// zone (there may be several, #3362).
+func viewsForZone(cfg *config.Config, zone string) []ZoneHostInboundView {
+	var out []ZoneHostInboundView
+	for _, v := range BuildZoneHostInboundViews(cfg) {
+		if v.Zone == zone {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// hostInboundViewAdmit reports the first token in the view that admits the tuple
+// (system-services before protocols), skipping the non-admitting ident-reset
+// (Reject). Family-scoped via the SSOT.
+func hostInboundViewAdmit(v ZoneHostInboundView, proto uint8, dstPort int, icmpType *uint8, family string) (token, kind string, admitted bool) {
+	for _, s := range v.SystemServices {
+		for _, m := range config.HostInboundServiceMatch(s, family) {
+			if !m.Reject && l4MatchAdmits(m, proto, dstPort, icmpType) {
+				return s, "system-services", true
+			}
+		}
+	}
+	for _, p := range v.Protocols {
+		for _, m := range config.HostInboundProtocolMatch(p, family) {
+			if l4MatchAdmits(m, proto, dstPort, icmpType) {
+				return p, "protocols", true
+			}
+		}
+	}
+	return "", "", false
+}
+
+// l4MatchAdmits reports whether a structured host-inbound match admits the query
+// tuple (proto, dstPort, icmpType). It mirrors the Rust ZoneHostInbound::admits
+// per-tuple semantics against the SSOT L4Match shape.
+func l4MatchAdmits(m config.L4Match, proto uint8, dstPort int, icmpType *uint8) bool {
+	if m.Proto != proto {
+		return false
+	}
+	switch m.Proto {
+	case config.HostInboundProtoTCP, config.HostInboundProtoUDP:
+		if len(m.Ports) == 0 {
+			return true
+		}
+		if dstPort <= 0 || dstPort > 65535 {
+			return false
+		}
+		dp := uint16(dstPort)
+		for _, pr := range m.Ports {
+			if dp >= pr.Lo && dp <= pr.Hi {
+				return true
+			}
+		}
+		return false
+	case config.HostInboundProtoICMP, config.HostInboundProtoICMPv6:
+		if m.ICMPType == nil {
+			return true
+		}
+		if icmpType == nil {
+			return false
+		}
+		return *icmpType == *m.ICMPType
+	default:
+		// Bare IP protocol (gre/ospf/pim/...): the protocol match is sufficient.
+		return true
+	}
+}
+
+// hostInboundGlobalAccept mirrors the top-of-chain nft global accepts
+// (buildHostInboundFilterPayload) and the Rust is_icmp_host_inbound_global_accept
+// (#3171): the raw ESP (50) / AH (51) data plane, and the ICMP error/PMTUD +
+// IPv6 ND subtypes, are admitted regardless of the zone's host-inbound-traffic
+// set. Echo-request (v4 8 / v6 128) and IPv4 router-advert/solicit (9/10) are
+// NOT global — they stay gated on the `ping` / `router-discovery` tokens.
+func hostInboundGlobalAccept(proto uint8, icmpType *uint8) bool {
+	// Raw ESP / AH data plane (nft `meta l4proto { 50, 51 } accept`).
+	if proto == 50 || proto == 51 {
+		return true
+	}
+	if icmpType == nil {
+		return false
+	}
+	t := *icmpType
+	switch proto {
+	case config.HostInboundProtoICMP: // ICMPv4 errors: dest-unreach(3), time-exceeded(11), param-problem(12)
+		return t == 3 || t == 11 || t == 12
+	case config.HostInboundProtoICMPv6: // ICMPv6 errors 1-4 + ND 133-137
+		switch t {
+		case 1, 2, 3, 4, 133, 134, 135, 136, 137:
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/dataplane/userspace/host_inbound_classify_3627_test.go
+++ b/pkg/dataplane/userspace/host_inbound_classify_3627_test.go
@@ -1,0 +1,116 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func u8ptr(v uint8) *uint8 { return &v }
+
+func cfgWithHostInbound(zone string, svc, proto []string) *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		zone: {
+			Name:               zone,
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: svc, Protocols: proto},
+		},
+	}
+	return cfg
+}
+
+// TestClassifyHostInboundReportsAdmittingToken is the #3627 B1a classifier
+// guard: given the ingress zone's host-inbound-traffic set and a host-bound
+// query tuple, ClassifyHostInbound reports the admitting system-service /
+// protocol token (or deny / global-accept / indeterminate). It reads the SAME
+// structured SSOT the nft builder renders from, so a reported token cannot claim
+// a port the kernel does not open.
+func TestClassifyHostInboundReportsAdmittingToken(t *testing.T) {
+	const TCP, UDP = uint8(6), uint8(17)
+	const ICMP, ICMPv6 = uint8(1), uint8(58)
+	const ESP = uint8(50)
+
+	// Zone admits ssh + ping (system-services) and bgp (protocols).
+	cfg := cfgWithHostInbound("edge", []string{"ssh", "ping"}, []string{"bgp"})
+
+	cases := []struct {
+		name     string
+		proto    uint8
+		hasProto bool
+		dstPort  int
+		icmpType *uint8
+		family   string
+		want     HostInboundStatus
+		wantTok  string
+		wantKind string
+	}{
+		{"ssh tcp/22 admits", TCP, true, 22, nil, "ip", HostInboundTokenAdmit, "ssh", "system-services"},
+		{"ssh v6 admits (dual)", TCP, true, 22, nil, "ip6", HostInboundTokenAdmit, "ssh", "system-services"},
+		{"telnet tcp/23 denied", TCP, true, 23, nil, "ip", HostInboundDenied, "", ""},
+		{"bgp tcp/179 admits (protocols)", TCP, true, 179, nil, "ip", HostInboundTokenAdmit, "bgp", "protocols"},
+		{"ping v4 echo admits", ICMP, true, 0, u8ptr(8), "ip", HostInboundTokenAdmit, "ping", "system-services"},
+		{"ping v6 echo admits", ICMPv6, true, 0, u8ptr(128), "ip6", HostInboundTokenAdmit, "ping", "system-services"},
+		{"icmp error global-accept", ICMP, true, 0, u8ptr(3), "ip", HostInboundGlobalAccept, "", ""},
+		{"v6 ND global-accept", ICMPv6, true, 0, u8ptr(135), "ip6", HostInboundGlobalAccept, "", ""},
+		{"esp global-accept", ESP, true, 0, nil, "ip", HostInboundGlobalAccept, "", ""},
+		{"tcp no port -> indeterminate", TCP, true, 0, nil, "ip", HostInboundIndeterminate, "", ""},
+		{"no protocol -> indeterminate", 0, false, 0, nil, "ip", HostInboundIndeterminate, "", ""},
+		{"udp/53 denied (dns not admitted)", UDP, true, 53, nil, "ip", HostInboundDenied, "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ClassifyHostInbound(cfg, "edge", c.proto, c.hasProto, c.dstPort, c.icmpType, c.family)
+			if got.Status != c.want {
+				t.Fatalf("status = %v, want %v (%+v)", got.Status, c.want, got)
+			}
+			if got.Token != c.wantTok || got.Kind != c.wantKind {
+				t.Fatalf("token/kind = %q/%q, want %q/%q", got.Token, got.Kind, c.wantTok, c.wantKind)
+			}
+		})
+	}
+}
+
+// TestClassifyHostInboundFullAdmit: `system-services all` admits every tuple,
+// even one that is otherwise indeterminate (no port).
+func TestClassifyHostInboundFullAdmit(t *testing.T) {
+	cfg := cfgWithHostInbound("edge", []string{"all"}, nil)
+	got := ClassifyHostInbound(cfg, "edge", 6, true, 0, nil, "ip")
+	if got.Status != HostInboundTokenAdmit || got.Token != "all" {
+		t.Fatalf("full-admit: got %+v, want token-admit all", got)
+	}
+}
+
+// TestClassifyHostInboundIdentResetDenies: a zone whose only service is
+// ident-reset does NOT admit tcp/113 — the Reject marker keeps the classifier
+// from reporting ident-reset as admitting (Junos resets, does not permit).
+func TestClassifyHostInboundIdentResetDenies(t *testing.T) {
+	cfg := cfgWithHostInbound("edge", []string{"ident-reset"}, nil)
+	got := ClassifyHostInbound(cfg, "edge", 6, true, 113, nil, "ip")
+	if got.Status != HostInboundDenied {
+		t.Fatalf("ident-reset tcp/113: got %+v, want denied (ident-reset resets, does not admit)", got)
+	}
+}
+
+// TestClassifyHostInboundNoStanzaDenies: a configured zone with no
+// host-inbound-traffic stanza default-denies every service (post-#3405), so a
+// host-bound ssh query is DENIED, not admitted.
+func TestClassifyHostInboundNoStanzaDenies(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{"edge": {Name: "edge"}}
+	got := ClassifyHostInbound(cfg, "edge", 6, true, 22, nil, "ip")
+	if got.Status != HostInboundDenied {
+		t.Fatalf("no-stanza zone ssh: got %+v, want denied (#3405 default-deny)", got)
+	}
+}
+
+// TestClassifyHostInboundFamilyGate: dhcp is IPv4-only; a v6 dhcp query is not
+// admitted by an dhcp-only zone.
+func TestClassifyHostInboundFamilyGate(t *testing.T) {
+	cfg := cfgWithHostInbound("edge", []string{"dhcp"}, nil)
+	if got := ClassifyHostInbound(cfg, "edge", 17, true, 67, nil, "ip"); got.Status != HostInboundTokenAdmit || got.Token != "dhcp" {
+		t.Fatalf("dhcp v4 udp/67: got %+v, want token-admit dhcp", got)
+	}
+	if got := ClassifyHostInbound(cfg, "edge", 17, true, 67, nil, "ip6"); got.Status != HostInboundDenied {
+		t.Fatalf("dhcp v6 udp/67: got %+v, want denied (dhcp is IPv4-only)", got)
+	}
+}

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -303,6 +303,25 @@ shared SSOT `Result.DisplayAction()` (#3375), which returns
 transit/global/default policy NOT applied)". Routing both transports through one
 method keeps them from diverging and prevents a blank verdict on the host path.
 
+**Admitting host-inbound token (#3627 B1a).** For a `to-zone junos-host` query,
+`Match` additionally classifies the ingress zone's `host-inbound-traffic`
+admission for the query tuple and attaches it as `Result.HostInbound`
+(`*dataplane/userspace.HostInboundAdmission`; `nil` off the host path). It
+reports WHICH system-service/protocol token admits the packet (`token-admit` +
+`Token`/`Kind`), a `global-accept` (ICMP error/PMTUD, IPv6 ND, or ESP/AH — the
+top-of-chain nft accepts, #3171), a `denied` (post-#3405 default-deny — the box
+drops it), or `indeterminate` (the query omits the protocol, or the
+destination-port / icmp-type a port/ICMP token needs). The classifier
+(`ClassifyHostInbound`) reads the SAME structured token→tuple SSOT the kernel-nft
+builder renders from (`config.HostInboundServiceMatch` /
+`HostInboundProtocolMatch`), so the reported token cannot claim a port the kernel
+does not open. `ident-reset` is reported as NOT admitting (it resets, #3310).
+This is ADDITIONAL context, not a verdict tier — it never changes `Matched` /
+`HostInboundUnmatched` (the host gate has no transit fallback, #3285). The local
+CLI `show security match-policies` prints it after `HostInboundShowLine`;
+surfacing it on the REST/gRPC responses (a presence-safe `host_inbound` object /
+proto message) and a per-tuple Rust parity test are deferred follow-ups.
+
 Address matching honors literal CIDRs, address
 books (recursive set expansion), `any`/`any-ipv4`/`any-ipv6`, source/destination
 exclusion (the #2008 empty-excluded fail-closed rule, hardened in #3356 to run

--- a/pkg/policymatch/host_inbound_token_3627_test.go
+++ b/pkg/policymatch/host_inbound_token_3627_test.go
@@ -1,0 +1,103 @@
+package policymatch
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// hostZone builds a zone map with one zone carrying a host-inbound-traffic set,
+// for the #3627 B1a host-inbound token-report tests.
+func hostZone(name string, svc, proto []string) map[string]*config.ZoneConfig {
+	return map[string]*config.ZoneConfig{
+		name: {
+			Name:               name,
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: svc, Protocols: proto},
+		},
+	}
+}
+
+// TestMatchReportsHostInboundAdmittingToken is the #3627 B1a RED-on-revert guard
+// at the simulator level: a `to-zone junos-host` query with no matching
+// host-bound policy returns HostInboundUnmatched AND carries a HostInbound
+// admission naming the host-inbound-traffic token that admits the tuple (or
+// deny / global-accept / indeterminate). Before B1a the host-inbound response
+// omitted the admitting token entirely (res.HostInbound == nil).
+func TestMatchReportsHostInboundAdmittingToken(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyDeny,
+		Zones:         hostZone("edge", []string{"ssh", "ping"}, []string{"bgp"}),
+	}, config.ApplicationsConfig{})
+
+	cases := []struct {
+		name     string
+		q        Query
+		wantStat dpuserspace.HostInboundStatus
+		wantTok  string
+		wantKind string
+	}{
+		{
+			name:     "ssh admits -> names the ssh system-service",
+			q:        Query{FromZone: "edge", ToZone: "junos-host", Protocol: "tcp", DstPort: 22, DstIP: net.ParseIP("192.0.2.1")},
+			wantStat: dpuserspace.HostInboundTokenAdmit, wantTok: "ssh", wantKind: "system-services",
+		},
+		{
+			name:     "bgp admits -> names the bgp protocol",
+			q:        Query{FromZone: "edge", ToZone: "junos-host", Protocol: "tcp", DstPort: 179, DstIP: net.ParseIP("192.0.2.1")},
+			wantStat: dpuserspace.HostInboundTokenAdmit, wantTok: "bgp", wantKind: "protocols",
+		},
+		{
+			name:     "telnet denied -> host-inbound default-deny",
+			q:        Query{FromZone: "edge", ToZone: "junos-host", Protocol: "tcp", DstPort: 23, DstIP: net.ParseIP("192.0.2.1")},
+			wantStat: dpuserspace.HostInboundDenied,
+		},
+		{
+			name:     "icmp error -> global accept",
+			q:        Query{FromZone: "edge", ToZone: "junos-host", Protocol: "icmp", ICMPType: u8(3), DstIP: net.ParseIP("192.0.2.1")},
+			wantStat: dpuserspace.HostInboundGlobalAccept,
+		},
+		{
+			name:     "no protocol -> indeterminate",
+			q:        Query{FromZone: "edge", ToZone: "junos-host", DstIP: net.ParseIP("192.0.2.1")},
+			wantStat: dpuserspace.HostInboundIndeterminate,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res := Match(cfg, c.q)
+			if !res.HostInboundUnmatched {
+				t.Fatalf("HostInboundUnmatched = false, want true")
+			}
+			if res.HostInbound == nil {
+				t.Fatalf("res.HostInbound == nil — host-inbound admitting token omitted (#3627 B1a regression)")
+			}
+			if res.HostInbound.Status != c.wantStat {
+				t.Fatalf("status = %v, want %v (%+v)", res.HostInbound.Status, c.wantStat, *res.HostInbound)
+			}
+			if res.HostInbound.Token != c.wantTok || res.HostInbound.Kind != c.wantKind {
+				t.Fatalf("token/kind = %q/%q, want %q/%q", res.HostInbound.Token, res.HostInbound.Kind, c.wantTok, c.wantKind)
+			}
+			if c.wantStat == dpuserspace.HostInboundTokenAdmit && res.HostInbound.Describe() == "" {
+				t.Errorf("token-admit must render a non-empty Describe() line")
+			}
+		})
+	}
+}
+
+// TestMatchHostInboundOnlyOnHostPath: the HostInbound field is set only on the
+// host path — a transit query never carries it.
+func TestMatchHostInboundOnlyOnHostPath(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyPermit,
+		Zones:         hostZone("edge", []string{"ssh"}, nil),
+	}, config.ApplicationsConfig{})
+	// Add a second zone so a transit pair exists.
+	cfg.Security.Zones["core"] = &config.ZoneConfig{Name: "core"}
+
+	res := Match(cfg, Query{FromZone: "edge", ToZone: "core", Protocol: "tcp", DstPort: 22})
+	if res.HostInbound != nil {
+		t.Errorf("transit query carried a HostInbound admission (%+v); it must be host-path only", *res.HostInbound)
+	}
+}

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -612,6 +612,19 @@ type Result struct {
 	SourceAddressExcluded      bool
 	DestinationAddressExcluded bool
 	Applications               []string
+
+	// HostInbound reports how the ingress zone's host-inbound-traffic admission
+	// gate treats a host-bound (to-zone junos-host) query tuple (#3627 B1a): the
+	// admitting system-service / protocol token, a global accept (ICMP error/ND,
+	// ESP/AH), a default-deny, or indeterminate. It is set ONLY on the host path
+	// (ToZone == junos-host); nil for every transit / default / content-rejected
+	// verdict. It is ADDITIONAL context, not a verdict tier — the host gate has
+	// no transit fallback (#3285), and this does not change Matched /
+	// HostInboundUnmatched. The classifier reads the SAME structured host-inbound
+	// SSOT the kernel-nft builder renders from (config.HostInboundServiceMatch /
+	// HostInboundProtocolMatch), so the reported token cannot drift from the port
+	// the kernel actually opens.
+	HostInbound *dpuserspace.HostInboundAdmission
 }
 
 // HostInboundActionString is the operator-facing verdict rendered for a
@@ -836,6 +849,19 @@ func Match(cfg *config.Config, q Query) Result {
 // path, matching the runtime gate — only a global explicitly scoped to
 // `to-zone junos-host` is consulted.
 func matchJunosHost(cfg *config.Config, q Query, ids map[[2]uint32]uint32) Result {
+	// #3627 B1a: classify the ingress zone's host-inbound-traffic admission for
+	// this tuple ONCE and attach it to every Result this host path returns, so a
+	// host-inbound verdict names the admitting service/protocol token (or reports
+	// deny / global-accept / indeterminate) rather than the fixed
+	// "subject to host-inbound-traffic" string. This is additional context, not a
+	// verdict tier — it never changes the match outcome (#3285 host gate has no
+	// transit fallback).
+	hi := hostInboundAdmission(cfg, q)
+	withHI := func(r Result) Result {
+		r.HostInbound = hi
+		return r
+	}
+
 	// #3355: evaluate_junos_host_policy returns None for from_id == 0 (the
 	// unknown/undefined ingress zone), mirroring the #3110 unzoned guard. An
 	// undefined query from-zone therefore matches no host-bound rule; local
@@ -843,7 +869,7 @@ func matchJunosHost(cfg *config.Config, q Query, ids map[[2]uint32]uint32) Resul
 	// HostInboundUnmatched rather than running the host tiers against an
 	// unresolved ingress zone.
 	if !zoneKnown(cfg, q.FromZone) {
-		return Result{HostInboundUnmatched: true}
+		return withHI(Result{HostInboundUnmatched: true})
 	}
 	// Exact ingress -> junos-host.
 	for setIdx, zpp := range cfg.Security.Policies {
@@ -852,7 +878,7 @@ func matchJunosHost(cfg *config.Config, q Query, ids map[[2]uint32]uint32) Resul
 		}
 		for sliceIdx, pol := range zpp.Policies {
 			if pol != nil && ruleMatches(cfg, q, pol) {
-				return matchedResult(ids, pol, false, zpp.FromZone, zpp.ToZone, setIdx, sliceIdx)
+				return withHI(matchedResult(ids, pol, false, zpp.FromZone, zpp.ToZone, setIdx, sliceIdx))
 			}
 		}
 	}
@@ -863,7 +889,7 @@ func matchJunosHost(cfg *config.Config, q Query, ids map[[2]uint32]uint32) Resul
 		}
 		for sliceIdx, pol := range zpp.Policies {
 			if pol != nil && ruleMatches(cfg, q, pol) {
-				return matchedResult(ids, pol, false, zpp.FromZone, zpp.ToZone, setIdx, sliceIdx)
+				return withHI(matchedResult(ids, pol, false, zpp.FromZone, zpp.ToZone, setIdx, sliceIdx))
 			}
 		}
 	}
@@ -888,12 +914,42 @@ func matchJunosHost(cfg *config.Config, q Query, ids map[[2]uint32]uint32) Resul
 			continue
 		}
 		if ruleMatches(cfg, q, pol) {
-			return matchedResult(ids, pol, true, pol.Match.FromZone, pol.Match.ToZone, globalSetIdx, sliceIdx)
+			return withHI(matchedResult(ids, pol, true, pol.Match.FromZone, pol.Match.ToZone, globalSetIdx, sliceIdx))
 		}
 	}
 	// No host-bound rule matched: local delivery proceeds. Do NOT fall through
 	// to the transit default — the dataplane host gate returns None here.
-	return Result{HostInboundUnmatched: true}
+	return withHI(Result{HostInboundUnmatched: true})
+}
+
+// hostInboundAdmission classifies the ingress zone's host-inbound-traffic
+// admission for a host-bound query tuple (#3627 B1a). It resolves the query's
+// protocol via appid.ProtocolNumber (empty = unspecified) and the address family
+// from the destination (then source) IP, and delegates to the SSOT-backed
+// dataplane/userspace classifier. Returns nil for a nil config.
+func hostInboundAdmission(cfg *config.Config, q Query) *dpuserspace.HostInboundAdmission {
+	if cfg == nil {
+		return nil
+	}
+	proto, hasProto := appid.ProtocolNumber(q.Protocol)
+	family := ""
+	switch {
+	case q.DstIP != nil:
+		family = ipFamily(q.DstIP)
+	case q.SrcIP != nil:
+		family = ipFamily(q.SrcIP)
+	}
+	adm := dpuserspace.ClassifyHostInbound(cfg, q.FromZone, proto, hasProto, q.DstPort, q.ICMPType, family)
+	return &adm
+}
+
+// ipFamily returns the nft-style family token ("ip" / "ip6") for an IP, matching
+// the family spelling the host-inbound SSOT and views use.
+func ipFamily(ip net.IP) string {
+	if ip.To4() != nil {
+		return "ip"
+	}
+	return "ip6"
 }
 
 // GlobalPolicyAppliesToZonePair reports whether a global policy (#3148) with the


### PR DESCRIPTION
## #3627 part-B (B1a) — driveable half

Drives the driveable B1a half of the #3627 part-B research plan (`docs/research/3627-explain-dimension/plan.md`). B2 (per-dimension miss explanation) is PLAN-KILLED and not built; the "cheapest extract" host-inbound verdict-string fix already shipped. This PR is Go-only (no protoc/cargo).

### What

**1. Structured token→tuple SSOT (`pkg/config`).** Before this, the host-inbound token→`(proto, ports, icmp-type)` truth existed only as nft match *strings* (`pkg/daemon`) and the Rust classifier's admit sets. The match-policies host-inbound simulator needs it *structured*. Added the single SSOT:

```go
type PortRange struct{ Lo, Hi uint16 }
type L4Match struct{ Proto uint8; Ports []PortRange; ICMPType *uint8; Reject bool }
func HostInboundServiceMatch(token, family string) []L4Match
func HostInboundProtocolMatch(token, family string) []L4Match
```

It owns the family gate, the `protocols all` expansion (#3199/#3311), the ident-reset `Reject` marker (#3310), and gre→proto 47.

**2. nft builder RENDERS from the SSOT (`pkg/daemon`).** `hostInboundServiceMatches` / `hostInboundProtocolMatches` / `hostInboundAllowsAll` no longer carry a parallel hard-coded table — they render (`renderHostInboundMatches`) the SSOT. **Byte-identical** to the pre-#3627 output for every token × family (a set/range/`echo-request`/coalesced-`{ 9, 10 }` render), proven by `TestHostInboundNftRenderGoldenByteIdentical` (frozen golden). No behavior change — it's a refactor to a shared SSOT.

**3. match-policies reports the admitting token.** New classifier `dataplane/userspace.ClassifyHostInbound` reads the **same** SSOT + mirrors the #3171 global accepts (ICMP error/PMTUD, IPv6 ND, ESP/AH), returning a presence-safe `HostInboundAdmission{Status, Token, Kind}` (token-admit / global-accept / denied / indeterminate / not-computed). Wired into `policymatch.Match` on the host path only as `Result.HostInbound` (nil off-host; additional context, never changes `Matched`/`HostInboundUnmatched`, #3285). Surfaced on the local CLI `show security match-policies` host-inbound branch. Because the classifier reads the same SSOT the kernel renders, a reported token cannot claim a port the box does not open.

### Tests (RED-on-revert verified)

- `TestHostInboundNftRenderGoldenByteIdentical` — nft render byte-identical to pre-#3627 (RED on any drift)
- `TestHostInboundServiceMatchTuples` / `TestHostInboundProtocolMatchTuples` — structured tuples pinned
- `TestClassifyHostInbound*` — classifier admits/denies/global-accepts/indeterminate + family gate + ident-reset-denies + no-stanza-denies
- `TestMatchReportsHostInboundAdmittingToken` — simulator reports the token (RED: omitted on revert)
- Reverting a port (ssh 22→2222) turns the golden, the tuple test, and the simulator token test all RED

`go test` for config, daemon, dataplane/userspace, policymatch, cli, api, grpcapi green; gofmt, go vet, `go build ./...` clean.

### Deferred follow-ups (why this is `Refs`, not `Closes`)

- REST/gRPC structured `host_inbound` field + proto message (presence-safe, kept in lockstep via `DisplayAction`, #3375) — needs protoc codegen, kept out to stay Go-only.
- Per-tuple Rust parity test (`host_inbound.rs` admit set == the structured SSOT) — needs cargo; the set-level `TestHostInboundRustClassifierMatchesGoSSOT` still holds.

#3627 stays open for these.

Refs #3627

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
