### PR TITLE
config: gate the inactive: marker on TokenIdentifier not TokenString (#4348)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,24 @@
+## 2026-07-06 — #4348: gate the `inactive:` marker on TokenIdentifier not TokenString
+
+- **Timestamp**: 2026-07-06
+- **Action**: Follow-up to #4335/#4347. `parseKeys` flattened `TokenString`
+  and `TokenIdentifier` into one `[]string`, so a QUOTED value exactly equal
+  to `inactive:` (e.g. `description "inactive:";`) was indistinguishable from
+  a bare deactivation marker and got silently truncated — the value dropped
+  and the statement wrongly deactivated. This hit BOTH the leading (index 0)
+  and the inline (index > 0, added by #4347) marker handlers. Fix:
+  `parseKeys` now returns a parallel `[]TokenType` (token-kind) slice, and
+  both marker checks in `parseStatement` require
+  `kinds[i] == TokenIdentifier && keys[i] == inactiveMarker`. A quoted
+  `"inactive:"` (TokenString) is preserved verbatim as a literal value; a
+  bare identifier `inactive:` still deactivates (leading) or drops its
+  governed tokens (inline) exactly as before. RED-on-revert regression in
+  `quoted_inactive_4348_test.go` (leading + inline quoted-value preserved;
+  bare leading/inline unchanged; normal quoted value unaffected).
+- **File(s)**: `pkg/config/parser.go`,
+  `pkg/config/quoted_inactive_4348_test.go`, `docs/config-schema.md`,
+  `_Log.md`
+
 ## 2026-07-06 — #4342 / #4343: session-invalidation residuals (default-policy + scheduler)
 
 - **Timestamp**: 2026-07-06

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -4606,6 +4606,22 @@ the DNAT-pool compiler read the literal `inactive:` token as the pool
 address, hard-rejecting a valid drop-in vSRX config
 (`inline_inactive_4335_test.go`).
 
+**Quoted `"inactive:"` is a value, not a marker (#4348).** The marker
+detection is gated on the source TOKEN KIND, not just the token text. A
+bare `inactive:` lexes as a `TokenIdentifier`; a quoted `"inactive:"` (e.g.
+`description "inactive:";`) lexes as a `TokenString`. `parseKeys` returns a
+parallel token-kind slice alongside the key values, and BOTH the leading
+(index 0) and inline (index > 0) marker checks require
+`kinds[i] == TokenIdentifier && keys[i] == inactiveMarker`. Without the
+kind gate the flattened `[]string` made a quoted value equal to the marker
+text indistinguishable from a bare marker, so the value was silently
+truncated (leading: the whole statement wrongly deactivated and the value
+dropped; inline: the value and everything after it dropped from `Keys`). A
+quoted `"inactive:"` is now preserved verbatim as a literal value
+(`quoted_inactive_4348_test.go`). Real-world impact is near-zero — no Junos
+leaf's value is the bare token `inactive:` — but the parser no longer loses
+data for a value that merely equals the marker text.
+
 **Strip-before-validate / strip-before-compile contract.** A deactivated
 statement must be excluded from BOTH the typed-leaf gate and the compiler,
 and Junos accepts a deactivated leaf even when its value would be rejected

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -191,6 +191,12 @@ func (p *Parser) skipToBlockClose() {
 // tokenizes `inactive:` as a single identifier; the parser detects it as
 // the leading key of a statement and lifts it into Node.Inactive rather
 // than letting it mangle the node's identity (Keys[0]).
+//
+// The marker is recognized ONLY when the source token is a bare
+// TokenIdentifier. A QUOTED `"inactive:"` (TokenString) is a literal value
+// that merely equals the marker text (e.g. `description "inactive:";`) and
+// must be preserved, so parseStatement gates both the leading and inline
+// marker checks on the parallel token-kind slice from parseKeys (#4348).
 const inactiveMarker = "inactive:"
 
 // parseStatement parses one statement: keys followed by ; or { block }.
@@ -199,7 +205,7 @@ const inactiveMarker = "inactive:"
 // and key matching, schema walks, and group merge keep working unmodified.
 func (p *Parser) parseStatement() *Node {
 	statementStart := p.lexer.Peek()
-	keys := p.parseKeys()
+	keys, kinds := p.parseKeys()
 	if len(keys) == 0 {
 		// Recovery: skip unexpected token
 		tok := p.lexer.Next()
@@ -212,12 +218,16 @@ func (p *Parser) parseStatement() *Node {
 
 	// Detect a leading `inactive:` deactivation marker and lift it off the
 	// keys. A lone `inactive:` with no following statement is a parse error
-	// (Junos requires a statement to deactivate).
+	// (Junos requires a statement to deactivate). The marker is recognized
+	// ONLY as a bare identifier token — a QUOTED `"inactive:"` (TokenString)
+	// is a literal value (e.g. `description "inactive:";`) and must be
+	// preserved, never treated as a deactivation marker (#4348).
 	inactive := false
 	markerLine, markerCol := statementStart.Line, statementStart.Column
-	if keys[0] == inactiveMarker {
+	if kinds[0] == TokenIdentifier && keys[0] == inactiveMarker {
 		inactive = true
 		keys = keys[1:]
+		kinds = kinds[1:]
 		if len(keys) == 0 {
 			p.addError(markerLine, markerCol,
 				"inactive: marker must be followed by a statement")
@@ -244,8 +254,10 @@ func (p *Parser) parseStatement() *Node {
 	// as a deactivated leaf would be for compilation. A leading marker is
 	// already lifted above, so any remaining marker is strictly inline (index
 	// > 0) and leaves at least the statement's identity key intact.
+	// As with the leading marker, only a bare identifier `inactive:` counts;
+	// a quoted `"inactive:"` value (TokenString) is preserved (#4348).
 	for i, k := range keys {
-		if i > 0 && k == inactiveMarker {
+		if i > 0 && kinds[i] == TokenIdentifier && k == inactiveMarker {
 			keys = keys[:i]
 			// The governed tokens were only on the key line of a leaf; a
 			// trailing `{ ... }` cannot follow an inline marker in valid
@@ -319,18 +331,25 @@ func (p *Parser) skipStatementBody() {
 }
 
 // parseKeys reads one or more identifiers/strings until { or ; or } or EOF.
-func (p *Parser) parseKeys() []string {
+// It returns the token VALUES and a parallel slice of the source token KINDS
+// (TokenIdentifier vs TokenString). The kinds let the caller distinguish a
+// bare identifier `inactive:` (a deactivation marker) from a quoted
+// `"inactive:"` value that happens to equal the marker text (#4348) — the
+// []string alone flattens the two into an indistinguishable string.
+func (p *Parser) parseKeys() ([]string, []TokenType) {
 	var keys []string
+	var kinds []TokenType
 	for {
 		tok := p.lexer.Peek()
 		if tok.Type == TokenIdentifier || tok.Type == TokenString {
 			p.lexer.Next()
 			keys = append(keys, tok.Value)
+			kinds = append(kinds, tok.Type)
 		} else {
 			break
 		}
 	}
-	return keys
+	return keys, kinds
 }
 
 func (p *Parser) addError(line, col int, msg string) {

--- a/pkg/config/quoted_inactive_4348_test.go
+++ b/pkg/config/quoted_inactive_4348_test.go
@@ -1,0 +1,135 @@
+package config
+
+// Regression tests for #4348 — a QUOTED value exactly equal to the
+// `inactive:` marker text must be preserved, never treated as a Junos
+// deactivation marker.
+//
+// The lexer tokenizes a bare `inactive:` as a single TokenIdentifier (because
+// `:` is an identifier character) and a quoted `"inactive:"` as a TokenString.
+// parseKeys previously flattened both kinds into one []string, so a quoted
+// value equal to the marker text (e.g. `description "inactive:";`) was
+// indistinguishable from a bare deactivation marker and got silently
+// truncated — the value was dropped and the statement wrongly deactivated.
+//
+// The parser now carries a parallel token-kind slice and gates BOTH the
+// leading (index 0) and inline (index > 0) marker detection on
+// `kinds[i] == TokenIdentifier`, so only a bare identifier `inactive:` is a
+// marker; a quoted `"inactive:"` stays a literal value.
+//
+// RED-on-revert: reverting the token-kind gate in parseStatement truncates the
+// quoted value (LeadingQuotedValuePreserved -> Keys loses "inactive:" and the
+// node is wrongly Inactive; InlineQuotedValuePreserved -> the "inactive:" value
+// is dropped from Keys), failing the assertions below.
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestQuotedInactive_InlineQuotedValuePreserved is the core #4348 regression,
+// mirroring the issue's example `description "inactive:";`. The quoted value
+// sits at an INLINE position (index 1). It must be preserved as the leaf's
+// value; the statement must stay active.
+func TestQuotedInactive_InlineQuotedValuePreserved(t *testing.T) {
+	tree := mustParse(t, `interfaces {
+    ge-0/0/0 {
+        description "inactive:";
+    }
+}`)
+	desc := tree.FindChild("interfaces").FindChild("ge-0/0/0").FindChild("description")
+	if desc == nil {
+		t.Fatalf("description leaf not found; ge-0/0/0 children=%v",
+			tree.FindChild("interfaces").FindChild("ge-0/0/0").Children)
+	}
+	if desc.Inactive {
+		t.Fatal("a quoted \"inactive:\" value must NOT deactivate the statement")
+	}
+	want := []string{"description", inactiveMarker}
+	if !reflect.DeepEqual(desc.Keys, want) {
+		t.Fatalf("quoted inline \"inactive:\" truncated: got %v, want %v", desc.Keys, want)
+	}
+}
+
+// TestQuotedInactive_LeadingQuotedValuePreserved exercises the LEADING (index
+// 0) branch: a statement whose first token is the quoted string `"inactive:"`.
+// The pre-existing leading handler treated this as a marker and lifted it off,
+// losing the value and wrongly deactivating the statement. With the token-kind
+// gate the quoted value stays the statement's identity key.
+func TestQuotedInactive_LeadingQuotedValuePreserved(t *testing.T) {
+	tree := mustParse(t, `system {
+    "inactive:" host-name h;
+}`)
+	sys := tree.FindChild("system")
+	if len(sys.Children) != 1 {
+		t.Fatalf("expected 1 child under system, got %d: %+v", len(sys.Children), sys.Children)
+	}
+	n := sys.Children[0]
+	if n.Inactive {
+		t.Fatal("a quoted leading \"inactive:\" value must NOT deactivate the statement")
+	}
+	want := []string{inactiveMarker, "host-name", "h"}
+	if !reflect.DeepEqual(n.Keys, want) {
+		t.Fatalf("quoted leading \"inactive:\" truncated: got %v, want %v", n.Keys, want)
+	}
+}
+
+// TestQuotedInactive_BareLeadingMarkerStillDeactivates guards case (2): a bare
+// (identifier) leading `inactive:` still lifts into Node.Inactive and strips
+// off the keys — unchanged behavior.
+func TestQuotedInactive_BareLeadingMarkerStillDeactivates(t *testing.T) {
+	tree := mustParse(t, `system {
+    inactive: host-name h;
+}`)
+	hn := tree.FindChild("system").FindChild("host-name")
+	if hn == nil {
+		t.Fatalf("host-name not found; system children=%v", tree.FindChild("system").Children)
+	}
+	if !hn.Inactive {
+		t.Fatal("a bare leading inactive: must still deactivate the statement")
+	}
+	want := []string{"host-name", "h"}
+	if !reflect.DeepEqual(hn.Keys, want) {
+		t.Fatalf("bare leading inactive: leaked into Keys: got %v, want %v", hn.Keys, want)
+	}
+}
+
+// TestQuotedInactive_BareInlineMarkerStillDeactivates guards case (3): a bare
+// (identifier) inline `inactive:` still drops the marker and every token it
+// governs — the #4347 behavior is unchanged.
+func TestQuotedInactive_BareInlineMarkerStillDeactivates(t *testing.T) {
+	tree := mustParse(t, `system {
+    host-name keep inactive: extra;
+}`)
+	hn := tree.FindChild("system").FindChild("host-name")
+	if hn == nil {
+		t.Fatalf("host-name not found; system children=%v", tree.FindChild("system").Children)
+	}
+	if hn.Inactive {
+		t.Fatal("the host-name statement itself must stay active")
+	}
+	want := []string{"host-name", "keep"}
+	if !reflect.DeepEqual(hn.Keys, want) {
+		t.Fatalf("bare inline inactive: not pruned: got %v, want %v", hn.Keys, want)
+	}
+}
+
+// TestQuotedInactive_NormalQuotedValueUnaffected guards case (4): an ordinary
+// quoted value (not equal to the marker text) is preserved exactly.
+func TestQuotedInactive_NormalQuotedValueUnaffected(t *testing.T) {
+	tree := mustParse(t, `interfaces {
+    ge-0/0/0 {
+        description "up link";
+    }
+}`)
+	desc := tree.FindChild("interfaces").FindChild("ge-0/0/0").FindChild("description")
+	if desc == nil {
+		t.Fatal("description leaf not found")
+	}
+	if desc.Inactive {
+		t.Fatal("a normal quoted value must not deactivate the statement")
+	}
+	want := []string{"description", "up link"}
+	if !reflect.DeepEqual(desc.Keys, want) {
+		t.Fatalf("normal quoted value altered: got %v, want %v", desc.Keys, want)
+	}
+}


### PR DESCRIPTION
Closes #4348. Follow-up to #4335/#4347.

## Problem
`parseKeys` (pkg/config/parser.go) flattened `TokenString` and
`TokenIdentifier` into one `[]string`, so a QUOTED value exactly equal to the
marker text — e.g. `description "inactive:";` — was indistinguishable from a
bare `inactive:` deactivation marker and got **silently truncated**: the value
was dropped and the statement wrongly deactivated. This hit BOTH marker
handlers in `parseStatement`: the pre-existing leading (index 0) check and the
inline (index > 0) check added by #4347.

## Fix
Preserve the string-vs-identifier distinction at the marker-check site.
`parseKeys` now returns a parallel `[]TokenType` (token-kind) slice next to the
key values, and both marker checks require
`kinds[i] == TokenIdentifier && keys[i] == inactiveMarker`.

- A bare `inactive:` lexes as `TokenIdentifier` and still deactivates (leading)
  or drops its governed tokens (inline) exactly as before.
- A quoted `"inactive:"` lexes as `TokenString` and is now preserved verbatim
  as a literal value.

Real-world impact is near-zero (no Junos leaf's value is the bare token
`inactive:`), but the parser no longer loses data for a value that merely
equals the marker text.

## Validation
`pkg/config/quoted_inactive_4348_test.go` is **RED on revert** of either gate:
the leading quoted value is wrongly deactivated with its value dropped, and the
inline quoted value is truncated out of `Keys`. Green with the fix; bare
leading/inline markers (#4347 behavior) and normal quoted values are
unaffected.

- `go test ./pkg/config/...` — pass
- `go build ./...`, `gofmt`, `go vet` — clean
- `docs/config-schema.md` documents the token-kind gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi