### PR TITLE
config: flip destination-NAT then to closed-world (first production #4313 flip)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-07-06 — #4313 PR-B: first production closed-world subtree flip (destination-NAT then)
+
+- **Timestamp**: 2026-07-06
+- **Action**: Flipped `closedWorld: true` on the destination-NAT rule
+  then-action container (`security nat destination rule-set <rs> rule <r>
+  then`), the FIRST production subtree to opt in to the #4334 (#4313 PR-A)
+  closed-world mechanism. Leaf-completeness verified first: the Junos DNAT
+  then-action is exactly `destination-nat { off | pool <name> }` — every
+  keyword at every level below `then` is modeled and the compiler
+  (`compileNATDestination`) reads only these, so closing carries no
+  false-reject risk. An unmodeled keyword (typo like `poool`, or garbage)
+  is now REJECTED at strict commit (`SchemaValidate`) instead of committing
+  clean and being silently dropped; the tolerant Load/SyncApply path
+  downgrades to a warning (#1960), so stored/peer-synced configs are not
+  bricked. The sibling SOURCE-NAT then was deliberately NOT flipped: Junos
+  permits `then source-nat pool <name> persistent-nat { … }` at the rule
+  level (xpf models persistent-nat per-pool), so closing it would
+  false-reject a valid Junos config (#4191 class) — deferred as a follow-up.
+- **File(s)**: `pkg/config/schema_security.go` (flip + deferral comment on
+  source-NAT then), `pkg/config/schema_closedworld_nat_then_4313_test.go`
+  (new — RED-on-revert reject tests + valid-keyword + source-NAT-still-open
+  guard), `docs/config-schema.md` (#4313 section: first production flip +
+  remaining subtrees).
+- **Validation**: `go test ./pkg/config/...` and `./pkg/configstore/...`
+  green; RED-on-revert confirmed (reject tests FAIL without the flag);
+  `go build ./...`, `gofmt -l`, `go vet ./pkg/config/` clean.
+
 ## 2026-07-06 — #2354: QinQ inner-vlan-id honest-posture gate
 
 - **Timestamp**: 2026-07-06

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -658,22 +658,53 @@ dormant MECHANISM in PR-A:
   production subtree today — behaviour is byte-identical to pre-#4313
   (return nil, silent-accept).
 
-**No production subtree sets `closedWorld` in PR-A.** The mechanism is dormant:
-every existing config validates identically, so PR-A carries zero false-reject
-risk. It is white-box tested with a SYNTHETIC subtree
+PR-A landed the mechanism DORMANT (no production subtree set `closedWorld`,
+zero false-reject risk). It is white-box tested with a SYNTHETIC subtree
 (`schema_walk_internal_test.go`, `TestClosedWorld_*`): an unmodeled keyword
 under a `closedWorld:true` node is rejected; the same shape under a default
 (open-world) node is still silently accepted; a modeled keyword under the
 closed node passes; and closed-world inherits into modeled descendant
 containers.
 
-**Deferred, per-subtree flips (PR-B..N).** Turning `closedWorld` on for a real
-subtree (candidates: `security ipsec`, `security nat … then`, `snmp community`,
-`protocols {ospf,bgp} interface`, `interfaces … family`) is only safe once that
-subtree is LEAF-COMPLETE — every valid Junos keyword under it is modeled —
-otherwise the flip false-rejects a valid config. Each flip is its own follow-up
-gated on a Junos-leaf completeness audit for that subtree, tracked on #4313. Do
-NOT set `closedWorld` on a subtree without that audit.
+**First production flip — destination-NAT rule then-action (PR-B, #4313).**
+`security nat destination rule-set <rs> rule <r> then` now sets
+`closedWorld:true` (`schema_security.go`). It is the first production subtree
+to opt in. The completeness audit that gates the flip:
+
+- The Junos DNAT rule then-action is exactly `destination-nat { off | pool
+  <pool-name> }`. Directly under `then` the only valid keyword is
+  `destination-nat`; directly under `destination-nat` the only valid keywords
+  are `off` and `pool`; `off` is a value-less leaf and `pool <name>` is a
+  terminal pool reference with no sub-block (there is no rule-level
+  persistent-nat for destination NAT — that is a source-NAT feature). Every
+  keyword at every level below `then` is modeled, and the compiler
+  (`compileNATDestination`) reads only these same keywords, so closing carries
+  no false-reject risk.
+- The reject fires on the STRICT operator commit path (`SchemaValidate`); the
+  tolerant `Store.Load` / `SyncApply` path downgrades it to a warning
+  (`compileTreeLenient`, #1960), so a stored or peer-synced config is never
+  bricked. A typo (`then destination-nat poool dp`) or garbage keyword now
+  fails the commit with a "closed-world subtree" error instead of committing
+  clean and being silently dropped. Production tests:
+  `schema_closedworld_nat_then_4313_test.go` (RED on revert of the flag).
+
+**NOT flipped — source-NAT rule then-action.** The sibling `security nat source
+… rule … then` is deliberately left open-world. Junos permits `then source-nat
+pool <name> persistent-nat { … }` at the RULE level, which xpf instead models
+per-pool (`security nat source pool <name> persistent-nat`). Flipping the
+source-NAT then would inherit closed-world down to its `pool` leaf and
+false-reject that valid Junos config (the #4191 class). It is a follow-up:
+model the rule-level persistent-nat leaves (or make an accept-with-advisory
+decision) FIRST, then flip.
+
+**Remaining per-subtree flips (future PRs, tracked on #4313).** Turning
+`closedWorld` on for the other umbrella candidates (`security ipsec`, `snmp
+community`, `protocols {ospf,bgp} interface`, `interfaces … family`, and the
+deferred source-NAT then above) is only safe once that subtree is LEAF-COMPLETE
+— every valid Junos keyword under it is modeled — otherwise the flip
+false-rejects a valid config. Each flip is its own follow-up gated on a
+Junos-leaf completeness audit for that subtree. Do NOT set `closedWorld` on a
+subtree without that audit.
 
 ### `firewall ... from tcp-flags` — semantic validation, not just a list (#3076)
 

--- a/pkg/config/schema_closedworld_nat_then_4313_test.go
+++ b/pkg/config/schema_closedworld_nat_then_4313_test.go
@@ -1,0 +1,127 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4313 PR-B — first PRODUCTION closed-world subtree flip.
+//
+// The destination-NAT rule then-action container
+// (security nat destination rule-set <rs> rule <r> then) now sets
+// schemaNode.closedWorld (schema_security.go). Its subtree is leaf-complete:
+// the only valid Junos DNAT then-action is `destination-nat { off | pool
+// <name> }`, all modeled, so closing it carries no false-reject risk. An
+// unmodeled keyword (a typo, or garbage trailing a valid action) is now
+// REJECTED at strict commit (SchemaValidate) instead of committing clean and
+// being silently dropped by the compiler — the #4313 silent-inert bug.
+//
+// These tests use the production ParseSetCommand + SetPath + SchemaValidate
+// path. Each rejection test is RED on revert of the closedWorld flag: without
+// it, SchemaValidate returns nil (open-world silent-accept) and the test fails.
+
+// dnatThenSet builds a minimal destination-NAT rule-set whose then-action is
+// the supplied token stream (e.g. "pool dp", "off", "bogus", "poool dp").
+func dnatThenSet(thenAction string) []string {
+	return []string{
+		"set security zones security-zone untrust",
+		"set security nat destination pool dp address 10.0.0.5",
+		"set security nat destination rule-set rs1 from zone untrust",
+		"set security nat destination rule-set rs1 rule r1 match destination-address 203.0.113.10",
+		"set security nat destination rule-set rs1 rule r1 then destination-nat " + thenAction,
+	}
+}
+
+// TestClosedWorldDNATThen_RejectsUnknownActionKeyword is the core RED-on-revert
+// discriminator: an unmodeled keyword under the closed-world DNAT then subtree
+// is rejected at strict commit. On revert of closedWorld the same input is
+// silently accepted (SchemaValidate returns nil) and this test fails — proving
+// the flip closes the #4313 silent-inert gap.
+func TestClosedWorldDNATThen_RejectsUnknownActionKeyword(t *testing.T) {
+	tree := buildTree(t, dnatThenSet("bogus"))
+	err := SchemaValidate(tree, nil)
+	if err == nil {
+		t.Fatal("an unmodeled keyword under the closed-world destination-NAT then must be rejected at commit (RED on revert: silently accepted + dropped)")
+	}
+	if !strings.Contains(err.Error(), "bogus") || !strings.Contains(err.Error(), "closed-world") {
+		t.Fatalf("error must name the keyword and the closed-world subtree, got: %v", err)
+	}
+}
+
+// TestClosedWorldDNATThen_RejectsTypo is the VALUE of the fix: a fat-fingered
+// Junos action (`poool` for `pool`) is caught at commit rather than silently
+// ignored — the operator learns the DNAT translation would never apply.
+func TestClosedWorldDNATThen_RejectsTypo(t *testing.T) {
+	tree := buildTree(t, dnatThenSet("poool dp"))
+	err := SchemaValidate(tree, nil)
+	if err == nil {
+		t.Fatal("a typo'd DNAT then-action (poool) must be rejected at commit, not silently dropped")
+	}
+	if !strings.Contains(err.Error(), "poool") || !strings.Contains(err.Error(), "closed-world") {
+		t.Fatalf("error must name the typo and the closed-world subtree, got: %v", err)
+	}
+}
+
+// TestClosedWorldDNATThen_AcceptsValidActions proves no false-reject: every
+// valid Junos DNAT then-action keyword still commits clean under closed-world.
+func TestClosedWorldDNATThen_AcceptsValidActions(t *testing.T) {
+	for _, action := range []string{"off", "pool dp"} {
+		tree := buildTree(t, dnatThenSet(action))
+		if err := SchemaValidate(tree, nil); err != nil {
+			t.Fatalf("valid destination-NAT then-action %q must commit clean under closed-world, got: %v", action, err)
+		}
+	}
+}
+
+// TestClosedWorldDNATThen_RejectsUnknownDirectlyUnderThen closes the top level
+// too: an action keyword directly under `then` that is not `destination-nat`
+// (the only valid one for a DNAT rule) is rejected.
+func TestClosedWorldDNATThen_RejectsUnknownDirectlyUnderThen(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security zones security-zone untrust",
+		"set security nat destination rule-set rs1 from zone untrust",
+		"set security nat destination rule-set rs1 rule r1 match destination-address 203.0.113.10",
+		"set security nat destination rule-set rs1 rule r1 then bogus-action",
+	})
+	err := SchemaValidate(tree, nil)
+	if err == nil {
+		t.Fatal("an unknown action directly under a DNAT rule then must be rejected under closed-world")
+	}
+	if !strings.Contains(err.Error(), "bogus-action") || !strings.Contains(err.Error(), "closed-world") {
+		t.Fatalf("error must name the keyword and the closed-world subtree, got: %v", err)
+	}
+}
+
+// TestSourceNATThen_StillOpenWorld documents the deliberate asymmetry (#4313):
+// the source-NAT rule then-action is NOT yet closed, because Junos permits
+// `then source-nat pool <name> persistent-nat { ... }` at the rule level, which
+// xpf models per-pool rather than under the rule-then pool. Closing it would
+// false-reject that valid Junos config (#4191 class). This test guards against
+// an accidental future flip landing without first modeling the rule-level
+// persistent-nat leaves: it asserts the persistent-nat form still commits
+// (open-world) AND that a bogus source-NAT action is still silently accepted.
+func TestSourceNATThen_StillOpenWorld(t *testing.T) {
+	// A valid-Junos rule-level persistent-nat must NOT be rejected today.
+	persistent := buildTree(t, []string{
+		"set security zones security-zone untrust",
+		"set security nat source pool p1 address 192.0.2.10",
+		"set security nat source rule-set rs1 from zone untrust",
+		"set security nat source rule-set rs1 rule r1 match source-address 10.0.0.0/24",
+		"set security nat source rule-set rs1 rule r1 then source-nat pool p1 persistent-nat permit any-remote-host",
+	})
+	if err := SchemaValidate(persistent, nil); err != nil {
+		t.Fatalf("rule-level `then source-nat pool <name> persistent-nat ...` is valid Junos and must NOT be rejected while source-NAT then is open-world (deferred #4313 subtree), got: %v", err)
+	}
+
+	// And an outright bogus source-NAT action is still silently accepted
+	// (open-world) — the source-NAT then flip is a documented follow-up.
+	bogus := buildTree(t, []string{
+		"set security zones security-zone untrust",
+		"set security nat source rule-set rs1 from zone untrust",
+		"set security nat source rule-set rs1 rule r1 match source-address 10.0.0.0/24",
+		"set security nat source rule-set rs1 rule r1 then source-nat bogus",
+	})
+	if err := SchemaValidate(bogus, nil); err != nil {
+		t.Fatalf("source-NAT then is still open-world (deferred #4313 subtree); a bogus action must be silently accepted today, got: %v", err)
+	}
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -436,6 +436,14 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 						"destination-port":         {desc: "Destination port to match", args: 1, multi: true, placeholder: "<port>", children: nil},
 						"application":              {desc: "Application to match", args: 1, multi: true, placeholder: "<application>", children: nil},
 					}},
+					// #4313: NOT closed-world (unlike the destination-NAT then
+					// below). Junos permits `then source-nat pool <name>
+					// persistent-nat { ... }` at the rule level, which xpf models
+					// per-pool (`security nat source pool <name> persistent-nat`,
+					// ~line 360) rather than under the rule-then pool. Flipping
+					// closedWorld here would inherit down to the `pool` leaf and
+					// false-reject that valid Junos config (#4191 class). Deferred
+					// until the rule-level persistent-nat leaves are modeled.
 					"then": {desc: "Source NAT action", children: map[string]*schemaNode{
 						"source-nat": {desc: "Source NAT translation", children: map[string]*schemaNode{
 							"interface": {desc: "Translate to the egress interface address", children: nil},
@@ -473,7 +481,37 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 						"protocol":                 {desc: "IP protocol to match", args: 1, multi: true, placeholder: "<protocol>", children: nil},
 						"application":              {desc: "Application to match", args: 1, multi: true, placeholder: "<application>", children: nil},
 					}},
-					"then": {desc: "Destination NAT action", children: map[string]*schemaNode{
+					// #4313 PR-B — FIRST production closed-world subtree flip.
+					// The destination-NAT rule then-action is LEAF-COMPLETE: the
+					// Junos grammar under a DNAT rule `then` is exactly
+					// `destination-nat { off | pool <pool-name> }` — there is no
+					// persistent-nat (a source-NAT-only feature), no other action
+					// keyword, and the pool reference is a terminal name with no
+					// sub-block. Every valid keyword at every level below `then`
+					// is modeled here (then→destination-nat; destination-nat→
+					// off|pool; off/pool→leaf), and the compiler
+					// (compileNATDestination, compiler_nat.go) reads only these
+					// same keywords — so closing this subtree cannot false-reject
+					// any valid config (the #4191 class the umbrella warns about).
+					// closedWorld is inherited down every descendant level by
+					// walkSchemaNode's childClosed fold, so an unmodeled keyword
+					// anywhere under `then` (a typo like `poool`, or garbage
+					// trailing a valid action) is REJECTED at strict operator
+					// commit instead of committing clean and being silently
+					// dropped by the compiler (the #4313 silent-inert bug). The
+					// tolerant Load/SyncApply path downgrades the reject to a
+					// warning (#1960, configstore compileTreeLenient), so a
+					// stored or peer-synced config is not bricked.
+					//
+					// NOT flipped (yet): the SOURCE-NAT rule then-action above is
+					// deliberately left open-world because Junos permits
+					// `then source-nat pool <name> persistent-nat { ... }` at the
+					// rule level, which xpf instead models per-pool (`security nat
+					// source pool <name> persistent-nat`, ~line 360). Closing the
+					// source-NAT then would false-reject that valid Junos config;
+					// it is a follow-up once the rule-level persistent-nat leaves
+					// are modeled (or an accept-with-advisory decision is made).
+					"then": {desc: "Destination NAT action", closedWorld: true, children: map[string]*schemaNode{
 						"destination-nat": {desc: "Destination NAT translation", children: map[string]*schemaNode{
 							"off":  {desc: "Disable destination NAT for matching traffic (no-translate exemption)", children: nil},
 							"pool": {desc: "Translate using a destination NAT pool", args: 1, valueHint: ValueHintPoolName, placeholder: "<pool-name>", children: nil},


### PR DESCRIPTION
## Summary

Refs #4313. This is **PR-B**: the FIRST production closed-world subtree flip on top of the #4334 (#4313 PR-A) dormant mechanism (`schemaNode.closedWorld` + the `walkSchemaNode` gate).

It sets `closedWorld: true` on the **destination-NAT rule then-action** container (`security nat destination rule-set <rs> rule <r> then`). An unmodeled keyword under it is now REJECTED at strict commit instead of committing clean and being silently dropped by the compiler — the #4313 silent-inert bug.

## Leaf-completeness audit (the #4191-class gate the umbrella warns about)

The Junos DNAT rule then-action is **exactly** `destination-nat { off | pool <pool-name> }`:
- directly under `then` → only `destination-nat` is valid (modeled);
- under `destination-nat` → only `off` and `pool` (both modeled);
- `off` is a value-less leaf; `pool <name>` is a terminal pool reference with no sub-block (there is **no** rule-level persistent-nat for destination NAT — that is a source-NAT feature).

Every keyword at every level below `then` is modeled, and the compiler (`compileNATDestination`) reads only these same keywords, so closing the subtree **cannot false-reject a valid config**. `closedWorld` inherits down every descendant level (`walkSchemaNode`'s `childClosed` fold).

The reject fires only on the **strict operator commit** path (`SchemaValidate`); the tolerant `Store.Load` / `SyncApply` path downgrades it to a warning (`compileTreeLenient`, #1960), so a stored or peer-synced config is never bricked.

## Deliberately NOT flipped — source-NAT then (deferred)

The sibling **source-NAT** rule then-action stays open-world. Junos permits `then source-nat pool <name> persistent-nat { ... }` at the RULE level, which xpf instead models **per-pool** (`security nat source pool <name> persistent-nat`). Flipping the source-NAT then would inherit closed-world down to its `pool` leaf and **false-reject that valid Junos config** (#4191 class). Follow-up: model the rule-level persistent-nat leaves (or make an accept-with-advisory decision) first, then flip.

## Tests

New `pkg/config/schema_closedworld_nat_then_4313_test.go` drives the production `ParseSetCommand` + `SetPath` + `SchemaValidate` path:
- unknown action keyword, a typo (`then destination-nat poool dp`), and an unknown keyword directly under `then` are all **rejected** — **RED on revert** of the flag (verified: without `closedWorld` they are silently accepted and the tests fail);
- valid `off` / `pool <name>` actions still commit clean (no false-reject);
- a guard test asserts the source-NAT then remains open-world (rule-level `persistent-nat` still commits; a bogus source-NAT action is still silently accepted), so an accidental future flip cannot land without first modeling those leaves.

`go test ./pkg/config/...` and `./pkg/configstore/...` green; `go build ./...`, `gofmt`, `go vet ./pkg/config/` clean. `docs/config-schema.md` #4313 section updated.

## Remaining subtrees (keep #4313 open)

Future per-subtree flips, each gated on its own leaf-completeness audit: source-NAT then (persistent-nat), `security ipsec`, `snmp community`, `protocols {ospf,bgp} interface`, `interfaces … family`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi