### PR TITLE
cluster: re-drive stranded cold-start bulk over survivor fabric (#4090)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,37 @@
+## 2026-07-06 — #4090: survivor-fabric cold-start bulk sync re-drive
+
+- **Timestamp**: 2026-07-06
+- **Action**: Fixed the #4090 dual-fabric cold-start gap. The full session
+  BulkSync streams over a SINGLE fabric connection (`BulkSync` /
+  `sendBulkMarkers` pin `getActiveConn()` once, no per-message failover). If
+  that connection dropped mid-cold-start while the OTHER fabric stayed up, the
+  bulk was stranded — the per-message send loop only fails over the
+  steady-state delta stream, and `handleNewConnection`'s `wasDisconnected` gate
+  needs BOTH conns nil to re-fire, so the standby cold-started with an
+  incomplete session table. `handleDisconnect` now, after clearing the dropped
+  conn and computing `connected`, schedules a re-drive of `doBulkSync()` over
+  the survivor when `connected && !bulkEverCompleted`. The re-drive runs on a
+  `wg`-tracked GOROUTINE (not inline: `handleDisconnect` holds `s.mu` and
+  `doBulkSync → getActiveConn` re-locks it — inline would self-deadlock),
+  guarded by a `bulkRedriveInFlight` atomic.Bool CAS (one re-drive at a time,
+  reset when done, so a survivor that ALSO flaps cannot cause a re-drive
+  storm), and resets `pendingBulkAckEpoch=0` before the re-run so its fresh
+  epoch supersedes the stranded one (#3912). Receiver needs no change — a fresh
+  `BulkStart` resets `bulkInProgress`/`bulkRecvV4`/`bulkRecvV6` and `BulkEnd`
+  runs `reconcileStaleSessions`, so the re-driven bulk cleanly re-primes.
+- **File(s)**: `pkg/cluster/sync.go` (new `bulkRedriveInFlight` field),
+  `pkg/cluster/sync_conn.go` (`handleDisconnect` survivor re-drive branch),
+  `pkg/cluster/sync_test.go` (new `readSyncFrame` helper +
+  `TestBulkSyncRedriveOnSurvivorFabric` RED-on-revert + no-deadlock,
+  `TestBulkSyncNoRedriveWhenAlreadyCompleted`,
+  `TestBulkSyncRedriveInFlightGuard`), `docs/sync-protocol.md` (new
+  "Survivor-fabric cold-start bulk re-drive (#4090)" subsection).
+- **Validation**: `go test ./pkg/cluster/ -race` green; RED-on-revert
+  confirmed (neutralizing the CAS branch fails the re-drive + guard tests);
+  `go build ./...`, `go vet ./pkg/cluster/...`, `gofmt -l` clean. HA
+  session-sync change — parent runs `test-failover` before merge (a mid-bulk
+  fabric flap during failover is the target scenario).
+
 ## 2026-07-06 — #4313 PR-B: first production closed-world subtree flip (destination-NAT then)
 
 - **Timestamp**: 2026-07-06

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -400,6 +400,47 @@ ordering".
 
 Both forward and reverse entries are sent during bulk sync. The receiver calls `SetSessionV4/V6` to install each session directly into the BPF map.
 
+#### Survivor-fabric cold-start bulk re-drive (#4090)
+
+The cold-start bulk streams over a **single** fabric connection: `BulkSync`
+(and the event-stream override's `sendBulkMarkers`) capture
+`getActiveConn()` once and pin every session + `BulkStart`/`BulkEnd` marker to
+that connection with no per-message failover. On a dual-fabric cluster both
+`conn0` and `conn1` are established concurrently, and the cold-start bulk is
+triggered exactly once — gated on `wasDisconnected` (BOTH conns nil) AND
+`!bulkEverCompleted` in `handleNewConnection`. If the pinned fabric dropped
+mid-bulk while the *other* fabric stayed up, the bulk was stranded: the
+per-message send loop only fails over the steady-state delta stream, not the
+one-shot bulk, and `handleNewConnection`'s `wasDisconnected` gate cannot
+re-fire while a survivor is up. The standby cold-started with an incomplete
+session table until BOTH fabrics happened to drop together.
+
+`handleDisconnect` now closes that gap. After clearing the dropped conn and
+computing `connected := conn0 != nil || conn1 != nil`, when a survivor is still
+up AND `!bulkEverCompleted.Load()` (the cold-start bulk never completed), it
+schedules a single re-drive of `doBulkSync()` over the survivor:
+
+- **Goroutine, not inline.** `handleDisconnect` holds `s.mu`, and
+  `doBulkSync → BulkSync/sendBulkMarkers → getActiveConn` re-locks `s.mu`; an
+  inline call would self-deadlock. The re-drive runs on a `wg`-tracked
+  goroutine that takes no lock across the `handleDisconnect` boundary.
+- **CAS in-flight guard.** `bulkRedriveInFlight` (an `atomic.Bool`,
+  compare-and-swap `false→true`) bounds re-drives to one at a time and is reset
+  when the goroutine returns, so a survivor that *also* flaps (its own write
+  failure re-entering `handleDisconnect`) cannot start a storm of re-drives.
+- **Stranded epoch reset.** The goroutine stores `pendingBulkAckEpoch = 0`
+  before the re-run so the fresh bulk's epoch supersedes the stranded one (a
+  latched phantom pending epoch would block manual failover, #3912).
+- **Receiver unchanged.** A fresh `BulkStart` resets the receiver's
+  `bulkInProgress`/`bulkRecvV4`/`bulkRecvV6` (and `resetRecvGen`, #2198 F2), and
+  `BulkEnd` runs `reconcileStaleSessions`, so the re-driven bulk cleanly
+  re-primes the standby.
+
+Once any bulk exchange completes (`bulkEverCompleted` set on a received
+`BulkEnd`/`BulkAck`), the gate closes: steady-state incremental sync already
+fails over via the send loop, so no re-drive is needed and a normal
+post-cold-start single-fabric drop does not re-bulk.
+
 ### 2. Periodic Sync Sweep (1s interval, new sessions)
 
 `StartSyncSweep()` launches a goroutine with a 1-second ticker:

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -303,29 +303,39 @@ type SessionSync struct {
 	// IsPrimaryFn reports whether the local node is primary for the default sync scope.
 	IsPrimaryFn func() bool
 	// IsPrimaryForRGFn reports whether the local node is primary for a given RG.
-	IsPrimaryForRGFn           func(rgID int) bool
-	lastSweepTime              uint64
-	syncBackfillNeeded         atomic.Bool
-	lastNewCounter             uint64
-	lastClosedCounter          uint64
-	lastSweepEmpty             bool
-	vrfDevice                  string
-	peerClockOffset            atomic.Int64
-	clockSynced                atomic.Bool
-	zoneRGMu                   sync.RWMutex
-	zoneRGMap                  map[uint16]int
-	deleteJournalMu            sync.Mutex
-	deleteJournal              [][]byte
-	deleteJournalCap           int
-	lastPeerRxMono             atomic.Int64 // CLOCK_MONOTONIC nanos of last inbound sync msg (#1792)
-	peerHeartbeatAckEver       atomic.Bool
-	readDeadline               time.Duration
-	peerSilenceLimit           time.Duration
-	bulkSendMu                 sync.Mutex
-	bulkSendNext               atomic.Uint64
-	pendingBulkAckEpoch        atomic.Uint64
-	pendingBulkAckSince        atomic.Int64
-	bulkEverCompleted          atomic.Bool
+	IsPrimaryForRGFn     func(rgID int) bool
+	lastSweepTime        uint64
+	syncBackfillNeeded   atomic.Bool
+	lastNewCounter       uint64
+	lastClosedCounter    uint64
+	lastSweepEmpty       bool
+	vrfDevice            string
+	peerClockOffset      atomic.Int64
+	clockSynced          atomic.Bool
+	zoneRGMu             sync.RWMutex
+	zoneRGMap            map[uint16]int
+	deleteJournalMu      sync.Mutex
+	deleteJournal        [][]byte
+	deleteJournalCap     int
+	lastPeerRxMono       atomic.Int64 // CLOCK_MONOTONIC nanos of last inbound sync msg (#1792)
+	peerHeartbeatAckEver atomic.Bool
+	readDeadline         time.Duration
+	peerSilenceLimit     time.Duration
+	bulkSendMu           sync.Mutex
+	bulkSendNext         atomic.Uint64
+	pendingBulkAckEpoch  atomic.Uint64
+	pendingBulkAckSince  atomic.Int64
+	bulkEverCompleted    atomic.Bool
+	// bulkRedriveInFlight guards the survivor-fabric cold-start bulk
+	// re-drive (#4090). A single fabric dropping mid-cold-start-bulk while
+	// the other fabric is up leaves the bulk stranded — pinned to the dead
+	// conn, never retried, and not re-triggered on the survivor (the
+	// wasDisconnected/bulkEverCompleted gate in handleNewConnection needs
+	// BOTH fabrics to have dropped). handleDisconnect schedules ONE
+	// debounced goroutine to re-run doBulkSync over the survivor; this CAS
+	// flag bounds it to a single in-flight re-drive so a survivor that ALSO
+	// flaps cannot cause a re-drive storm.
+	bulkRedriveInFlight        atomic.Bool
 	bulkMu                     sync.Mutex
 	bulkInProgress             bool
 	bulkRecvEpoch              uint64

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -1742,5 +1742,42 @@ func (s *SessionSync) handleDisconnect(conn net.Conn) {
 		if s.OnPeerDisconnected != nil {
 			go s.OnPeerDisconnected()
 		}
+	} else if !s.bulkEverCompleted.Load() {
+		// #4090: a survivor fabric is still up but the cold-start bulk
+		// never completed. The bulk streams over a SINGLE connection
+		// (BulkSync/sendBulkMarkers pin s.getActiveConn once); if that
+		// connection dropped mid-stream the bulk is stranded — it is not
+		// retried on the survivor and handleNewConnection will not
+		// re-trigger it (its wasDisconnected gate needs BOTH fabrics to
+		// have dropped). Re-drive doBulkSync over the survivor.
+		//
+		// This MUST be a goroutine, not inline: handleDisconnect holds
+		// s.mu, and doBulkSync -> BulkSync/sendBulkMarkers -> getActiveConn
+		// re-locks s.mu (self-deadlock if run inline). The CAS guard bounds
+		// re-drives to one in-flight at a time so a survivor that also flaps
+		// (its own write failure re-entering handleDisconnect) cannot spawn a
+		// storm; the flag is reset when the re-drive goroutine returns.
+		if s.bulkRedriveInFlight.CompareAndSwap(false, true) {
+			slog.Info("cluster sync: scheduling cold-start bulk re-drive on survivor fabric",
+				"had_conn0", s.conn0 != nil, "had_conn1", s.conn1 != nil)
+			s.wg.Add(1)
+			go func() {
+				defer s.wg.Done()
+				defer s.bulkRedriveInFlight.Store(false)
+				// A concurrent reconnect (both-fabric drop then reconnect)
+				// may have already re-primed via handleNewConnection.
+				if s.bulkEverCompleted.Load() {
+					return
+				}
+				// Reset the stranded pending-ack epoch so the re-run's fresh
+				// epoch supersedes it (a latched phantom pending epoch would
+				// block manual failover, #3912).
+				s.pendingBulkAckEpoch.Store(0)
+				s.pendingBulkAckSince.Store(0)
+				if err := s.doBulkSync(); err != nil {
+					slog.Warn("cluster sync: cold-start bulk re-drive failed", "err", err)
+				}
+			}()
+		}
 	}
 }

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -4345,3 +4345,247 @@ func TestReceiveLoopKeepsConnectionAliveWithHeartbeatAck(t *testing.T) {
 		t.Fatalf("server loop failed: %v", err)
 	}
 }
+
+// readSyncFrame reads one framed sync message (header + payload) from conn and
+// returns its message type and payload. Used by the #4090 survivor re-drive
+// tests to observe what a peer fabric actually receives on the wire.
+func readSyncFrame(conn net.Conn) (msgType uint8, payload []byte, err error) {
+	hdr := make([]byte, syncHeaderSize)
+	if _, err = io.ReadFull(conn, hdr); err != nil {
+		return 0, nil, err
+	}
+	if string(hdr[0:4]) != "BPSY" {
+		return 0, nil, fmt.Errorf("bad magic: %x", hdr[0:4])
+	}
+	msgType = hdr[4]
+	pLen := binary.LittleEndian.Uint32(hdr[8:12])
+	if pLen > 1<<20 {
+		return 0, nil, fmt.Errorf("unreasonable payload length: %d", pLen)
+	}
+	if pLen > 0 {
+		payload = make([]byte, pLen)
+		if _, err = io.ReadFull(conn, payload); err != nil {
+			return 0, nil, err
+		}
+	}
+	return msgType, payload, nil
+}
+
+// TestBulkSyncRedriveOnSurvivorFabric is the #4090 RED-on-revert test: a
+// cold-start bulk streams over fabric 0, fabric 0 drops mid-bulk while fabric 1
+// is up, and the bulk must be re-driven over the survivor so the standby ends
+// with the COMPLETE session table. On revert (no re-drive path) the survivor
+// receives nothing and this test times out.
+//
+// It also proves the no-deadlock property: the re-drive is scheduled on a
+// goroutine, NOT inline. handleDisconnect holds s.mu and doBulkSync ->
+// getActiveConn re-locks s.mu, so an inline re-drive self-deadlocks inside the
+// first BulkSync — which this test detects as a hung first BulkSync.
+func TestBulkSyncRedriveOnSurvivorFabric(t *testing.T) {
+	dp := &mockSweepDP{
+		v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{
+			{SrcIP: [4]byte{10, 0, 1, 1}, DstIP: [4]byte{10, 0, 2, 1}, Protocol: 6, SrcPort: 1001, DstPort: 80}: {IsReverse: 0, IngressZone: 1},
+			{SrcIP: [4]byte{10, 0, 1, 2}, DstIP: [4]byte{10, 0, 2, 2}, Protocol: 6, SrcPort: 1002, DstPort: 80}: {IsReverse: 0, IngressZone: 1},
+			{SrcIP: [4]byte{10, 0, 1, 3}, DstIP: [4]byte{10, 0, 2, 3}, Protocol: 6, SrcPort: 1003, DstPort: 80}: {IsReverse: 0, IngressZone: 1},
+		},
+	}
+	const wantSessions = 3
+
+	c0local, c0peer := net.Pipe()
+	c1local, c1peer := net.Pipe()
+
+	ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
+	ss.IsPrimaryFn = func() bool { return true }
+	ss.mu.Lock()
+	ss.conn0 = c0local
+	ss.conn1 = c1local
+	ss.stats.Connected.Store(true)
+	ss.mu.Unlock()
+
+	// Fabric 0 peer: read exactly two frames (BulkStart + one session) then
+	// close, forcing the bulk write to fail mid-stream on fabric 0.
+	go func() {
+		_, _, _ = readSyncFrame(c0peer)
+		_, _, _ = readSyncFrame(c0peer)
+		c0peer.Close()
+	}()
+
+	// Fabric 1 peer (the survivor): drain the re-driven bulk and report the
+	// session count once BulkEnd arrives.
+	type recvResult struct {
+		sessions int
+		bulkEnd  bool
+	}
+	done := make(chan recvResult, 1)
+	go func() {
+		var res recvResult
+		for {
+			msgType, _, err := readSyncFrame(c1peer)
+			if err != nil {
+				done <- res
+				return
+			}
+			switch msgType {
+			case syncMsgSessionV4:
+				res.sessions++
+			case syncMsgBulkEnd:
+				res.bulkEnd = true
+				done <- res
+				return
+			}
+		}
+	}()
+
+	// First bulk fails on fabric 0; it must return (not deadlock) and schedule
+	// the survivor re-drive.
+	bulkDone := make(chan error, 1)
+	go func() { bulkDone <- ss.BulkSync() }()
+	select {
+	case err := <-bulkDone:
+		if err == nil {
+			t.Fatal("first BulkSync over the dropped fabric 0 should have returned an error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("first BulkSync hung — an inline re-drive would deadlock on s.mu (#4090 no-deadlock regression)")
+	}
+
+	select {
+	case res := <-done:
+		if !res.bulkEnd {
+			t.Fatal("survivor fabric never received BulkEnd — re-drive incomplete (#4090)")
+		}
+		if res.sessions != wantSessions {
+			t.Fatalf("survivor received %d sessions, want %d — cold-start bulk not fully re-driven (#4090)", res.sessions, wantSessions)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("cold-start bulk was not re-driven over the survivor fabric (#4090 RED-on-revert)")
+	}
+
+	ss.Stop()
+	c1peer.Close()
+}
+
+// TestBulkSyncNoRedriveWhenAlreadyCompleted verifies that a single-fabric drop
+// AFTER the cold-start bulk already completed does NOT re-drive (#4090). Once
+// bulkEverCompleted is set, the steady-state incremental stream already fails
+// over via the send loop, so a re-bulk would be redundant.
+func TestBulkSyncNoRedriveWhenAlreadyCompleted(t *testing.T) {
+	c0local, c0peer := net.Pipe()
+	defer c0peer.Close()
+	c1local, c1peer := net.Pipe()
+	defer c1peer.Close()
+
+	ss := NewSessionSync(":0", "10.0.0.2:4785", &mockSweepDP{})
+	ss.IsPrimaryFn = func() bool { return true }
+	var mu sync.Mutex
+	redrives := 0
+	ss.BulkSyncOverride = func() error {
+		mu.Lock()
+		redrives++
+		mu.Unlock()
+		return nil
+	}
+	ss.bulkEverCompleted.Store(true)
+	ss.mu.Lock()
+	ss.conn0 = c0local
+	ss.conn1 = c1local
+	ss.stats.Connected.Store(true)
+	ss.mu.Unlock()
+
+	ss.handleDisconnect(c0local)
+
+	if ss.bulkRedriveInFlight.Load() {
+		t.Fatal("re-drive was scheduled after the bulk already completed (#4090)")
+	}
+	// Give any (erroneously spawned) goroutine a moment to run.
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	got := redrives
+	mu.Unlock()
+	if got != 0 {
+		t.Fatalf("doBulkSync ran %d times after completion, want 0 (#4090)", got)
+	}
+	if !ss.IsConnected() {
+		t.Fatal("survivor fabric 1 should keep the sync connected")
+	}
+}
+
+// TestBulkSyncRedriveInFlightGuard verifies the CAS in-flight guard: while one
+// survivor re-drive is running, a second fabric flap does NOT spawn a second
+// re-drive (#4090 storm prevention).
+func TestBulkSyncRedriveInFlightGuard(t *testing.T) {
+	c0localA, c0peerA := net.Pipe()
+	c0localB, c0peerB := net.Pipe()
+	c1local, c1peer := net.Pipe()
+
+	ss := NewSessionSync(":0", "10.0.0.2:4785", &mockSweepDP{})
+	ss.IsPrimaryFn = func() bool { return true }
+
+	entered := make(chan struct{}, 4)
+	release := make(chan struct{})
+	ss.BulkSyncOverride = func() error {
+		entered <- struct{}{}
+		<-release
+		return nil
+	}
+
+	// Survivor drainer so the post-release sendBulkMarkers write completes.
+	go func() {
+		for {
+			if _, _, err := readSyncFrame(c1peer); err != nil {
+				return
+			}
+		}
+	}()
+
+	ss.mu.Lock()
+	ss.conn0 = c0localA
+	ss.conn1 = c1local
+	ss.stats.Connected.Store(true)
+	ss.mu.Unlock()
+
+	// First flap: fabric 0 (conn A) drops with fabric 1 up -> schedules the
+	// re-drive, which sets bulkRedriveInFlight synchronously and then blocks in
+	// the override.
+	ss.handleDisconnect(c0localA)
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first survivor re-drive never started (#4090)")
+	}
+	if !ss.bulkRedriveInFlight.Load() {
+		t.Fatal("re-drive in-flight flag should be set while a re-drive is running")
+	}
+
+	// Reconnect fabric 0 (conn B) so two fabrics are up again, then flap it
+	// while the first re-drive is still in flight. The CAS guard must refuse a
+	// second re-drive.
+	ss.mu.Lock()
+	ss.conn0 = c0localB
+	ss.mu.Unlock()
+	ss.handleDisconnect(c0localB)
+
+	select {
+	case <-entered:
+		t.Fatal("a second re-drive was spawned while one was in-flight (#4090 storm)")
+	case <-time.After(200 * time.Millisecond):
+		// good — no second re-drive
+	}
+
+	// Let the in-flight re-drive finish and confirm the flag resets.
+	close(release)
+	deadline := time.After(5 * time.Second)
+	for ss.bulkRedriveInFlight.Load() {
+		select {
+		case <-deadline:
+			t.Fatal("in-flight flag never reset after re-drive completed (#4090)")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	ss.Stop()
+	c0peerA.Close()
+	c0peerB.Close()
+	c1peer.Close()
+}


### PR DESCRIPTION
## Summary

Closes #4090.

The full session `BulkSync` streams over a **single** fabric connection
(`BulkSync` / the event-stream override's `sendBulkMarkers` capture
`getActiveConn()` once and pin every session + `BulkStart`/`BulkEnd` marker to
it, no per-message failover). On a dual-fabric cluster the cold-start bulk is
triggered exactly once, gated on `wasDisconnected` (BOTH conns nil) AND
`!bulkEverCompleted`. If the pinned fabric dropped mid-cold-start while the
other fabric stayed up, the bulk was stranded — not retried on the survivor and
not re-triggered by `handleNewConnection` — so the standby cold-started with an
**incomplete session table** until BOTH fabrics happened to drop together.

## Fix

`handleDisconnect`, after clearing the dropped conn and computing
`connected := conn0 != nil || conn1 != nil`, now re-drives `doBulkSync()` over
the survivor when `connected && !bulkEverCompleted.Load()`:

- **Goroutine, not inline** — `handleDisconnect` holds `s.mu` and
  `doBulkSync → getActiveConn` re-locks `s.mu` (inline would self-deadlock).
  Runs on a `wg`-tracked goroutine.
- **CAS in-flight guard** — `bulkRedriveInFlight` (`atomic.Bool`, CAS
  `false→true`, reset when done) bounds re-drives to one at a time so a
  survivor that also flaps cannot cause a re-drive storm.
- **Stranded epoch reset** — `pendingBulkAckEpoch=0` before the re-run so the
  fresh epoch supersedes the stranded one (a phantom pending epoch would block
  manual failover, #3912).
- **Receiver unchanged** — a fresh `BulkStart` resets `bulkInProgress`/
  `bulkRecvV4`/`bulkRecvV6` and `BulkEnd` runs `reconcileStaleSessions`, so the
  re-driven bulk cleanly re-primes.

Once any bulk exchange completes, the gate closes — steady-state incremental
sync already fails over via the send loop, so a normal post-cold-start
single-fabric drop does not re-bulk.

## Tests (dual `net.Pipe` harness)

- `TestBulkSyncRedriveOnSurvivorFabric` — drop fabric 0 mid-bulk with fabric 1
  up, assert the survivor receives the COMPLETE re-driven bulk (RED-on-revert).
  Also proves no deadlock: an inline re-drive hangs the first `BulkSync`, which
  the test detects via timeout.
- `TestBulkSyncRedriveInFlightGuard` — a second flap while a re-drive is
  in-flight does not spawn a second (CAS storm guard).
- `TestBulkSyncNoRedriveWhenAlreadyCompleted` — `bulkEverCompleted` already set
  means a single-fabric drop does NOT re-bulk.

## Validation

- `go test ./pkg/cluster/ -race` green; RED-on-revert confirmed (neutralizing
  the CAS branch fails the re-drive + guard tests).
- `go build ./...`, `go vet ./pkg/cluster/...`, `gofmt -l` clean.
- **HA session-sync change** — a mid-bulk fabric flap during failover is the
  target scenario, so `make test-failover` should run before merge.

Docs: new "Survivor-fabric cold-start bulk re-drive (#4090)" subsection in
`docs/sync-protocol.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
