### PR TITLE
wg: consume cookie-reply on the initiator side (#4094 PR-B)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,50 @@
+## 2026-07-06 — #4094 PR-B: WireGuard INITIATOR-side cookie-reply consume
+
+- **Timestamp**: 2026-07-06
+- **Action**: Completed #4094 (PR-A #4330 shipped the RESPONDER half). Taught
+  the INITIATOR to consume an inbound type-3 CookieReply and attach a real MAC2
+  to its retried handshake-init, so xpf-as-initiator now completes a handshake
+  against a peer that is itself under load. Added `cookie::InitiatorCookie` (the
+  wireguard-go `CookieGenerator` analog): per-peer state (last-sent MAC1 + last
+  decrypted cookie + receive time) held in `WgEngine::cookie_gen`
+  (`Mutex<FxHashMap<pubkey, InitiatorCookie>>`). `InitiatorCookie::add_macs`,
+  called from `create_initiation` AFTER `build_initiation` writes MAC1 + zeroes
+  MAC2, records the MAC1 (the AEAD AAD for a future reply) and — if we hold a
+  cookie younger than `COOKIE_ROTATION_TIME_NS` (120 s, reusing PR-A's constant)
+  — stamps `MAC2 = keyed-BLAKE2s-128(cookie, msg[0..132])`; an expired/absent
+  cookie leaves MAC2 zero. `WgEngine::consume_cookie_reply` (wired in
+  `dispatch_inbound`'s `WG_TYPE_COOKIE` arm, replacing the S7 drop stub) parses
+  the reply's `receiver_index`, looks it up in `pending` to attribute the reply
+  to a peer, decrypts via `CookieChecker::decrypt_cookie_reply` (promoted from a
+  `#[cfg(test)]` mirror to production) with the peer's pubkey-derived key + the
+  stored last-MAC1 as AAD, and stores the cookie. Fails CLOSED (no state change,
+  no panic) for an unattributable or undecryptable reply; a cookie-reply is not
+  authenticated for endpoint-learning. Counters: new `hs_rx_cookie_consumed` on
+  success (Prometheus `xpf_userspace_wg_cookie_replies_total{event=consumed}`),
+  and `hs_rx_cookie_unsupported` (its former S7-placeholder wire name) now a real
+  drop site. Counter bump lives inside `consume_cookie_reply` (mirroring
+  `classify_initiation`'s self-contained counter discipline) so the engine
+  method is self-testable. Tests (all RED-on-revert): 4 cookie.rs unit tests
+  (round-trip stamps-accepted MAC2 + source-binding, expired→zero MAC2,
+  undecryptable→fail-closed, reply-before-any-send ignored) + engine-wired
+  end-to-end `initiator_consume_completes_handshake_under_load`. Neutering the
+  MAC2 stamp fails the 3 stamping tests (verified). FULL cargo serial + Go
+  build/tests green.
+- **File(s)**: userspace-dp/src/afxdp/wg/cookie.rs (`InitiatorCookie` struct +
+  `add_macs`/`consume_reply`, `decrypt_cookie_reply` un-gated to production, 4
+  unit tests), userspace-dp/src/afxdp/wg/handshake_session.rs
+  (`add_initiator_macs`, `consume_cookie_reply` + `_inner`,
+  `peer_for_pending_index`, `create_initiation_inner` stamp call),
+  userspace-dp/src/afxdp/coordinator/wg_control.rs (`WG_TYPE_COOKIE` arm),
+  userspace-dp/src/afxdp/wg/engine.rs (`cookie_gen` field + init),
+  userspace-dp/src/afxdp/wg/engine_tests.rs (end-to-end interop test),
+  userspace-dp/src/afxdp/wg/counters.rs (`hs_rx_cookie_consumed` + docs),
+  userspace-dp/src/afxdp/coordinator/status.rs + userspace-dp/src/protocol/
+  control.rs + userspace-dp/src/protocol/tests.rs (wire field),
+  pkg/dataplane/userspace/protocol.go, pkg/api/metrics_userspace.go +
+  metrics_descriptors.go + metrics_wireguard_test.go (Prometheus `consumed`
+  event), docs/wireguard-interop.md.
+
 ## 2026-07-06 — #4332: WireGuard per-SOURCE cookie-reply token bucket
 
 - **Timestamp**: 2026-07-06

--- a/docs/wireguard-interop.md
+++ b/docs/wireguard-interop.md
@@ -18,7 +18,7 @@ therefore staged by capability, not by vendor.
 | #1434 | Multi-PEER per WG interface (N peers on one listen port) | **DONE (#1434 B1a+B1b)** — Go config `TunnelConfig.WgPeers []WgPeerConfig` (named-instance `peer <pubkey>` schema + dual-AST compiler + commit gate; the commit gate also validates the tunnel's LOCAL identity — `listen-port` in `[1,65535]` and a 64-hex `private-key` — so a value the Rust `hydrate_wg_identity` would drop the WHOLE row on can never commit clean into a silent dead tunnel, #3863), wire slice `wg_peers`, Rust engine fed N peers (RX/decap already multi-peer), egress generalized: encap LPM-selects the peer by inner-dst AllowedIPs (`frame/wg.rs` + `engine.peer_for_dest`), the WG control thread keeps per-peer effective-endpoint + per-peer handshake attempt + per-peer keepalive/rekey timers (`timer_pass_for_peer`), and per-peer status rows. The LIVE multi-peer handshake / Ubiquiti interop validation is #1703. KNOWN LIMITATION: the worker-driven NoSession/rekey REQUEST edges are still engine-wide (single edge), not per-peer — the per-peer T6/T7/T8 timers ARE per-peer; per-peer request edges ride #1703. |
 | S5 | Persistent-keepalive + REKEY/REJECT-AFTER timers + endpoint roaming + empty-record (keepalive/key-confirm) handling + TAI64N disk persistence | **timers + keepalives DONE (#1888/#1889)** — full whitepaper §6.1 timer machine (REKEY_AFTER_TIME 120s initiator-only, 165s receive horizon, REJECT_AFTER_TIME 180s per-use + expiry teardown, 5s/90s retry discipline, 10s passive + configured persistent keepalives, post-msg2 key-confirmation keepalive) on a blocking-poll(2) control loop; design of record `docs/research/1888-wg-timers/plan.md`. Authenticated-datagram endpoint LEARNING shipped in S2a/#1888 (keepalives now count); engine-level roam API + TAI64N disk persistence remain pending. #2961: the handshake attempt machine's GIVE-UP branch (`drive_attempt_machine`, after the 90s `REKEY_ATTEMPT_TIME` window) now advances the T8 pacing anchor (`note_t8_attempt(now)`), so a permanently-unreachable persistent-keepalive peer waits a full keepalive interval before the next `KeepaliveNoSession` initiation instead of re-firing a fresh 90s window every ~1s tick — the gap between failed-handshake windows is now ≥ keepalive_interval (matching wireguard-go, which stops re-initiating after `REKEY_ATTEMPT_TIME` until a new send/keepalive is due). A peer that comes back to life re-anchors T8 on fresh authenticated traffic (`anchor = max(last_send_any, last_recv_any, t8_last_attempt)`), so the cooldown is a floor, not a penalty on the live/successful path |
 | S6 | Junos config surface (grammar + compiler + snapshot population, base64↔hex keys) | pending |
-| S7 | Type-3 CookieReply + MAC2 generation/verification + IPv6 outer encap + DSCP/ECN | **DSCP/ECN encap DONE (#2303)** — inner DSCP+ECN copied onto the outer header (uniform DSCP + RFC 6040 ECN ingress copy). RFC 6040 §4.2 decap-side ECN *combine* shipped for GRE (#2315) AND WG (#2317) — WG captures the outer ECN via `recvmsg` + `IP_RECVTOS`/`IPV6_RECVTCLASS` cmsg and folds it into the decrypted inner via the shared `apply_decap_ecn_combine` (live ECN-propagation verification lab-deferred to #1703-class interop). **RESPONDER CookieReply + MAC2 under-load DoS mitigation DONE (#4094 PR-A)** — a per-tunnel rotating secret `Rm` (120 s, one-window previous-secret carry), an inbound-initiation fixed-window load gate, and MAC2 verification bind an initiation to the source that received the responder's type-3 CookieReply, so a valid-MAC1 flood (attacker knows our public key) no longer forces a Noise handshake per forged datagram. See "Responder cookie / MAC2 under-load DoS mitigation" below. The INITIATOR-side CookieReply *consume* (decrypt the cookie + re-initiate with a real MAC2 against a peer that is itself under load) is PR-B. IPv6 outer encap still pending |
+| S7 | Type-3 CookieReply + MAC2 generation/verification + IPv6 outer encap + DSCP/ECN | **DSCP/ECN encap DONE (#2303)** — inner DSCP+ECN copied onto the outer header (uniform DSCP + RFC 6040 ECN ingress copy). RFC 6040 §4.2 decap-side ECN *combine* shipped for GRE (#2315) AND WG (#2317) — WG captures the outer ECN via `recvmsg` + `IP_RECVTOS`/`IPV6_RECVTCLASS` cmsg and folds it into the decrypted inner via the shared `apply_decap_ecn_combine` (live ECN-propagation verification lab-deferred to #1703-class interop). **RESPONDER CookieReply + MAC2 under-load DoS mitigation DONE (#4094 PR-A)** — a per-tunnel rotating secret `Rm` (120 s, one-window previous-secret carry), an inbound-initiation fixed-window load gate, and MAC2 verification bind an initiation to the source that received the responder's type-3 CookieReply, so a valid-MAC1 flood (attacker knows our public key) no longer forces a Noise handshake per forged datagram. See "Responder cookie / MAC2 under-load DoS mitigation" below. **INITIATOR-side CookieReply *consume* DONE (#4094 PR-B)** — an inbound type-3 is decrypted (responder pubkey-derived key + our last-sent MAC1 as AAD), the cookie stored per-peer, and our NEXT initiation carries a real MAC2 (honoring the 120 s cookie TTL), so xpf-as-initiator now completes a handshake against a peer that is itself under load. IPv6 outer encap still pending |
 | S8 | HA RG WG-session migration | pending |
 
 ## Tunnel MTU + MSS + DSCP/ECN model (#2299 / #2300 / #2303 / #2329)
@@ -437,7 +437,10 @@ S1 makes xpf's WireGuard **handshake bytes** standards-compliant:
   type-1 MessageInitiation (148 bytes) and type-2 MessageResponse (92 bytes)
   on-wire framing — type byte, reserved, sender/receiver index, and
   `MAC1 = keyed-BLAKE2s-128(BLAKE2s-256("mac1----" || recipient_static_pub),
-  msg[0..offsetof(mac1)])`. MAC2 is emitted as zeros on build; on parse it is
+  msg[0..offsetof(mac1)])`. MAC2 is emitted as zeros on build UNLESS the
+  initiator holds a fresh cookie for the peer (#4094 PR-B — see below), in
+  which case `create_initiation` stamps
+  `MAC2 = keyed-BLAKE2s-128(cookie, msg[0..offsetof(mac2)])`; on parse it is
   skip-verified when NOT under load (spec-correct) and validated against the
   responder cookie when under load (#4094 PR-A — see below).
 
@@ -514,12 +517,51 @@ is exactly that layer.
   `xpf_userspace_wg_cookie_replies_total{event}` +
   `xpf_userspace_wg_handshake_rx_drops_total{reason=under_load_no_mac2|cookie_reply_budget}`).
 
-**Not in PR-A (→ PR-B):** the INITIATOR-side consume of an inbound type-3
-CookieReply (decrypt the cookie, store it per-peer, re-initiate with a real
-MAC2). Until PR-B, an inbound type-3 is still dropped (`hs_rx_cookie_unsupported`),
-so xpf-as-initiator cannot yet complete a handshake against a peer that is
-itself under load. The `#[cfg(test)] CookieChecker::decrypt_cookie_reply`
-mirror is the PR-B reference and proves the reply is well-formed.
+## Initiator cookie-reply consume (#4094 PR-B)
+
+PR-A gave the RESPONDER half; PR-B completes the interop by teaching the
+INITIATOR to answer a cookie challenge. Without it, an inbound type-3 was
+dropped and xpf-as-initiator could never complete a handshake against a peer
+that was itself under load (the responder keeps challenging; the initiator
+keeps sending zero-MAC2 initiations). The initiator half mirrors wireguard-go
+`CookieGenerator` and lives in `cookie::InitiatorCookie` (per-peer state held
+in `WgEngine::cookie_gen`, keyed by responder pubkey):
+
+- **On every outbound initiation** (`create_initiation` →
+  `WgEngine::add_initiator_macs` → `InitiatorCookie::add_macs`, run AFTER
+  `build_initiation` writes MAC1 and zeroes MAC2): record the message's MAC1 as
+  the AEAD AAD for a future cookie-reply, and — if we hold a cookie younger than
+  `COOKIE_ROTATION_TIME_NS` (the same 120 s TTL as the responder secret) — stamp
+  `MAC2 = keyed-BLAKE2s-128(cookie, msg[0..offsetof(mac2)])`. No cookie, or an
+  expired one, leaves MAC2 zero (spec-correct).
+- **On an inbound type-3 CookieReply** (`wg_control::dispatch_inbound` →
+  `WgEngine::consume_cookie_reply`): the reply's `receiver_index` echoes the
+  `sender_index` of the initiation that triggered it, which is the key of a
+  pending initiator handshake — look it up to attribute the reply to a peer,
+  decrypt the sealed cookie with that peer's (the responder's) public-key-derived
+  key and our stored last-sent MAC1 as the AAD
+  (`CookieChecker::decrypt_cookie_reply`, now production, not a test mirror), and
+  store the cookie + receive time. Fails CLOSED (no state change, no panic) for a
+  reply we cannot attribute (no matching in-flight initiation) or cannot decrypt
+  (wrong key / bad AAD / tampered ciphertext). A cookie-reply is XChaCha-sealed
+  under our own public-key-derived key and proves nothing about whether the
+  source holds the peer's keys, so it is NOT authenticated for endpoint-learning.
+- **Counters** — `hs_rx_cookie_consumed` (Prometheus:
+  `xpf_userspace_wg_cookie_replies_total{event=consumed}`) on a successful
+  decrypt+store; `hs_rx_cookie_unsupported` (its former S7-placeholder wire name,
+  now a real drop-by-reason site) on an unattributable / undecryptable reply.
+
+**RED-on-revert (PR-B):** `cookie.rs`
+`initiator_cookie_roundtrip_stamps_accepted_mac2` (a responder cookie-reply is
+consumed by the initiator and the retried MAC2 verifies against the responder's
+own `verify_initiation_mac2` — and is rejected from a different source),
+`initiator_expired_cookie_yields_zero_mac2` (a cookie past the 120 s TTL is not
+used), `initiator_drops_undecryptable_cookie_reply` (tampered/wrong-key reply is
+dropped fail-closed), `initiator_ignores_cookie_reply_before_any_initiation`; and
+the engine-wired end-to-end `initiator_consume_completes_handshake_under_load`
+(an initiator challenged by a responder under load consumes the cookie-reply and
+its retried `create_initiation` is admitted as `Process`). Neutering the MAC2
+stamp makes the stamping tests fail (retried MAC2 stays zero / re-challenged).
 
 **RED-on-revert:** `classify_initiation_under_load_requires_mac2` (drives a
 synthetic initiation flood past the threshold, then asserts a spoofed/unprimed

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -1756,7 +1756,7 @@ func newCollector(srv *Server) *xpfCollector {
 		),
 		wgCookieRepliesTotal: prometheus.NewDesc(
 			"xpf_userspace_wg_cookie_replies_total",
-			"WireGuard responder cookie mechanism (#4094 PR-A) by event: sent = type-3 CookieReply challenges emitted under load to valid-MAC1 initiations lacking a valid MAC2; mac2_ok = under-load initiations that carried a valid MAC2 (a primed peer) and were allowed through to the Noise handshake.",
+			"WireGuard cookie mechanism (#4094) by event: sent = type-3 CookieReply challenges the RESPONDER emitted under load to valid-MAC1 initiations lacking a valid MAC2; mac2_ok = under-load initiations that carried a valid MAC2 (a primed peer) and were allowed through to the Noise handshake; consumed = cookie-replies the INITIATOR decrypted and stored (PR-B) to arm a valid MAC2 on its next initiation.",
 			[]string{"tunnel", "event"}, nil,
 		),
 		wgHandshakeRequestsArmedTotal: prometheus.NewDesc(

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -181,9 +181,12 @@ func (c *xpfCollector) emitWireguardTelemetry(ch chan<- prometheus.Metric, statu
 		}
 
 		// #4094 PR-A responder cookie mechanism working signals: challenges
-		// issued and primed peers that completed under load.
+		// issued and primed peers that completed under load. #4094 PR-B adds
+		// the initiator half — cookie-replies we consumed to arm a valid
+		// MAC2 on our next initiation.
 		counter(c.wgCookieRepliesTotal, t.HsCookieRepliesSent, t.Tunnel, "sent")
 		counter(c.wgCookieRepliesTotal, t.HsRxUnderLoadMac2Ok, t.Tunnel, "mac2_ok")
+		counter(c.wgCookieRepliesTotal, t.HsRxCookieConsumed, t.Tunnel, "consumed")
 
 		counter(c.wgTransportPacketsTotal, t.EncapPackets, t.Tunnel, "encap")
 		counter(c.wgTransportPacketsTotal, t.DecapPackets, t.Tunnel, "decap")

--- a/pkg/api/metrics_wireguard_test.go
+++ b/pkg/api/metrics_wireguard_test.go
@@ -74,6 +74,8 @@ func TestEmitWireguardTelemetrySeriesSet(t *testing.T) {
 			HsRxDropsIndexExhausted:   10,
 			HsRxDropsReplayedInit:     45,
 			HsRxCookieUnsupported:     11,
+			// #4094 PR-B initiator cookie-replies consumed (50, off-ladder).
+			HsRxCookieConsumed:        50,
 			// #4094 PR-A responder cookie mechanism (46.. continuing).
 			HsCookieRepliesSent:       46,
 			HsRxUnderLoadNoMac2:       47,
@@ -165,6 +167,7 @@ func TestEmitWireguardTelemetrySeriesSet(t *testing.T) {
 		"xpf_userspace_wg_handshake_rx_drops_total,reason=cookie_reply_budget,tunnel=wg0":           49,
 		"xpf_userspace_wg_cookie_replies_total,event=sent,tunnel=wg0":                               46,
 		"xpf_userspace_wg_cookie_replies_total,event=mac2_ok,tunnel=wg0":                            48,
+		"xpf_userspace_wg_cookie_replies_total,event=consumed,tunnel=wg0":                           50,
 		"xpf_userspace_wg_handshake_rx_drops_total,reason=unknown_type,tunnel=wg0":                  12,
 		"xpf_userspace_wg_transport_packets_total,direction=encap,tunnel=wg0":                       26,
 		"xpf_userspace_wg_transport_packets_total,direction=decap,tunnel=wg0":                       15,
@@ -290,10 +293,10 @@ func TestEmitWireguardTelemetryNeverHandshakedGauge(t *testing.T) {
 	// 2x expired, #1888) + 4 send kinds + 1 confirmed (per-peer, #1434;
 	// one peer here) + 3 rekey reasons + 2 keepalive-sent kinds +
 	// 1 sessions-expired + 1 attempts-aborted; +2 hs reasons #4094
-	// (under_load_no_mac2 + cookie_reply_budget) + 2 cookie-reply events
-	// #4094 (sent + mac2_ok) = 50.
-	if count != 50 {
-		t.Errorf("emitted %d series for a zeroed tunnel, want 50 (zeros are real signals)", count)
+	// (under_load_no_mac2 + cookie_reply_budget) + 3 cookie-reply events
+	// #4094 (sent + mac2_ok [PR-A] + consumed [PR-B]) = 51.
+	if count != 51 {
+		t.Errorf("emitted %d series for a zeroed tunnel, want 51 (zeros are real signals)", count)
 	}
 }
 

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -1696,6 +1696,9 @@ type WgTunnelStatus struct {
 	// that peer. Distinct from the transport DecapDropsReplay window.
 	HsRxDropsReplayedInit uint64 `json:"hs_rx_drops_replayed_init,omitempty"`
 	HsRxCookieUnsupported uint64 `json:"hs_rx_cookie_unsupported,omitempty"`
+	// #4094 PR-B initiator-side cookie-replies successfully consumed
+	// (decrypted + stored, arming a valid MAC2 on the next initiation).
+	HsRxCookieConsumed uint64 `json:"hs_rx_cookie_consumed,omitempty"`
 	// #4094 PR-A responder cookie-reply / MAC2 under-load DoS mitigation:
 	// cookie replies emitted, under-load initiations dropped for a
 	// missing/bad MAC2 (challenged instead of handshaked), under-load

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -911,6 +911,7 @@ impl super::Coordinator {
                 hs_rx_drops_index_exhausted: c.hs_rx_drops_index_exhausted.load(Ordering::Relaxed),
                 hs_rx_drops_replayed_init: c.hs_rx_drops_replayed_init.load(Ordering::Relaxed),
                 hs_rx_cookie_unsupported: c.hs_rx_cookie_unsupported.load(Ordering::Relaxed),
+                hs_rx_cookie_consumed: c.hs_rx_cookie_consumed.load(Ordering::Relaxed),
                 hs_cookie_replies_sent: c.hs_cookie_replies_sent.load(Ordering::Relaxed),
                 hs_rx_under_load_no_mac2: c.hs_rx_under_load_no_mac2.load(Ordering::Relaxed),
                 hs_rx_under_load_mac2_ok: c.hs_rx_under_load_mac2_ok.load(Ordering::Relaxed),

--- a/userspace-dp/src/afxdp/coordinator/wg_control.rs
+++ b/userspace-dp/src/afxdp/coordinator/wg_control.rs
@@ -1389,10 +1389,22 @@ fn dispatch_inbound(
             }
         },
         crate::afxdp::wg::WG_TYPE_COOKIE => {
-            // Cookie/MAC2 reply handling is S7; drop for now. Not
-            // authenticated for endpoint-learning purposes.
-            WgCounters::bump(&engine.counters().hs_rx_cookie_unsupported);
-            debug_log!("WG[{}]: drop cookie (S7)", tunnel_name);
+            // #4094 PR-B: initiator-side cookie-reply consume. A responder
+            // under load answers our valid-MAC1 initiation with a type-3
+            // cookie-reply instead of a handshake response; decrypt it and
+            // store the cookie so our NEXT initiation to that peer carries a
+            // valid MAC2 (completing the handshake under load). NOT
+            // authenticated for endpoint-learning: a cookie-reply is
+            // XChaCha-sealed under our own public-key-derived key and proves
+            // nothing about whether the source holds the peer's keys.
+            // consume_cookie_reply counts internally (hs_rx_cookie_consumed
+            // on success, hs_rx_cookie_unsupported on a drop).
+            if !engine.consume_cookie_reply(datagram, engine.now_ns()) {
+                // Reply we could not attribute (no matching in-flight
+                // initiation) or could not decrypt (wrong key / bad AAD /
+                // tampered).
+                debug_log!("WG[{}]: drop cookie (unconsumable)", tunnel_name);
+            }
             InboundOutcome::Unauthenticated
         }
         crate::afxdp::wg::WG_TYPE_DATA => {

--- a/userspace-dp/src/afxdp/wg/cookie.rs
+++ b/userspace-dp/src/afxdp/wg/cookie.rs
@@ -630,23 +630,27 @@ impl CookieChecker {
         Ok(WG_MSG_COOKIE_LEN)
     }
 
-    // --- test-only mirrors of the PR-B initiator decrypt + secret peek ---
+    // --- initiator-side cookie-reply decrypt (#4094 PR-B) + test peek ---
 
-    /// Decrypt a type-3 CookieReply the way the xpf-as-initiator half
-    /// (PR-B) will: recover the 16-byte cookie with the responder's
-    /// public-key-derived AEAD key, the reply's nonce, and the AAD MAC1 of
-    /// the initiation that triggered it. `#[cfg(test)]` reference until
-    /// PR-B wires it into the initiator path.
-    #[cfg(test)]
+    /// Decrypt a type-3 CookieReply as the xpf-as-initiator half (#4094
+    /// PR-B): recover the 16-byte cookie with the RESPONDER's public-key-
+    /// derived AEAD key (`BLAKE2s-256("cookie--" || responder_static_pub)`),
+    /// the reply's carried nonce, and the AAD MAC1 of the initiation that
+    /// triggered it. From the initiator's view `responder_static_pub` is the
+    /// PEER's static public key (the responder we are handshaking toward);
+    /// the responder-side round-trip test passes its own public key, which
+    /// is the same value from its own perspective. Returns `None` on a
+    /// malformed reply or an AEAD authentication failure (wrong key / wrong
+    /// AAD / tampered ciphertext) — fail closed, no panic, cookie ignored.
     pub(crate) fn decrypt_cookie_reply(
         reply: &[u8],
-        our_static_pub: &[u8; WG_KEY_LEN],
+        responder_static_pub: &[u8; WG_KEY_LEN],
         aad_mac1: &[u8],
     ) -> Option<[u8; WG_COOKIE_LEN]> {
         if reply.len() != WG_MSG_COOKIE_LEN || reply[0] != WG_TYPE_COOKIE {
             return None;
         }
-        let key = cookie_encryption_key(our_static_pub);
+        let key = cookie_encryption_key(responder_static_pub);
         let nonce = &reply[M3_NONCE..M3_COOKIE];
         let mut buf = [0u8; WG_COOKIE_LEN];
         buf.copy_from_slice(&reply[M3_COOKIE..M3_COOKIE + WG_COOKIE_LEN]);
@@ -705,6 +709,124 @@ impl CookieChecker {
     #[cfg(test)]
     pub(crate) fn source_contains_for_test(&self, ip: IpAddr) -> bool {
         self.per_source.lock().unwrap().buckets.contains_key(&ip)
+    }
+}
+
+/// Initiator-side per-peer cookie state (#4094 PR-B) — the counterpart to
+/// the responder's [`CookieChecker`]. Mirrors wireguard-go
+/// `CookieGenerator`'s `mac2` sub-struct: the last cookie we decrypted from
+/// a responder's cookie-reply (used to stamp MAC2 on our RETRIED
+/// handshake-initiations until it ages past [`COOKIE_ROTATION_TIME_NS`])
+/// plus the MAC1 of our most recently sent initiation (the XChaCha20-
+/// Poly1305 AAD needed to decrypt an incoming cookie-reply).
+///
+/// One per peer, held in the [`super::WgEngine`] under a mutex and consulted
+/// only on the slow control-thread path (`create_initiation` on send,
+/// `consume_cookie_reply` on receive). SECRET-adjacent: the cookie authorizes
+/// our initiations under load, so it is never logged.
+pub(crate) struct InitiatorCookie {
+    /// MAC1 of the last initiation we sent to this peer — the AEAD
+    /// associated data for decrypting a cookie-reply. `None` until we have
+    /// sent at least one initiation (a cookie-reply arriving before we ever
+    /// sent an initiation cannot be attributed, so it is dropped).
+    last_mac1: Option<[u8; WG_MAC_LEN]>,
+    /// The last cookie decrypted from a cookie-reply and the monotonic-ns
+    /// time we stored it. `None` until a reply is consumed. Expiry is
+    /// evaluated lazily at stamp time (a cookie older than
+    /// [`COOKIE_ROTATION_TIME_NS`] yields a zero MAC2), not on a timer.
+    cookie: Option<([u8; WG_COOKIE_LEN], u64)>,
+}
+
+impl InitiatorCookie {
+    pub(crate) fn new() -> Self {
+        Self {
+            last_mac1: None,
+            cookie: None,
+        }
+    }
+
+    /// Called on EVERY outbound initiation we send to this peer, AFTER
+    /// [`super::handshake::build_initiation`] has written MAC1 and zeroed
+    /// MAC2. Two effects, mirroring wireguard-go `CookieGenerator::AddMacs`:
+    ///
+    /// 1. Record the message's MAC1 (`msg[116..132]`) as [`Self::last_mac1`]
+    ///    so a subsequent cookie-reply — whose AEAD AAD is exactly this
+    ///    MAC1 — can be decrypted.
+    /// 2. If we hold a cookie that has NOT aged past
+    ///    [`COOKIE_ROTATION_TIME_NS`], stamp
+    ///    `mac2 = keyed-BLAKE2s-128(cookie, msg[0..132])` into the MAC2 slot
+    ///    (`msg[132..148]`). Otherwise leave MAC2 zero — the spec-correct
+    ///    value when we have no valid cookie (a first, un-challenged
+    ///    initiation, or one whose cookie has expired).
+    ///
+    /// Returns `true` iff a non-zero MAC2 was stamped. A too-short `msg`
+    /// (never happens at the sole caller, which passes the 148-byte framed
+    /// message) is a no-op returning `false`.
+    pub(crate) fn add_macs(&mut self, msg: &mut [u8], now_ns: u64) -> bool {
+        if msg.len() < WG_MSG_INIT_LEN {
+            return false;
+        }
+        let mut mac1 = [0u8; WG_MAC_LEN];
+        mac1.copy_from_slice(&msg[M1_MAC1..M1_MAC2]);
+        self.last_mac1 = Some(mac1);
+
+        // A cookie is fresh iff strictly younger than one rotation window.
+        // `saturating_sub` makes a backwards monotonic clock read as
+        // zero-elapsed (still fresh) rather than a huge age — conservative,
+        // and the cookie is our own so this weakens nothing.
+        match self.cookie {
+            Some((cookie, set_ns)) if now_ns.saturating_sub(set_ns) < COOKIE_ROTATION_TIME_NS => {
+                let mac2 = keyed_blake2s_128(&cookie, &msg[..M1_MAC2]);
+                msg[M1_MAC2..WG_MSG_INIT_LEN].copy_from_slice(&mac2);
+                true
+            }
+            _ => {
+                // No cookie, or expired: keep MAC2 zero (build_initiation
+                // already zeroed it; re-zero defensively in case a stale
+                // MAC2 was left by a caller that reused the buffer).
+                msg[M1_MAC2..WG_MSG_INIT_LEN].fill(0);
+                false
+            }
+        }
+    }
+
+    /// Consume an inbound type-3 cookie-reply from this peer. Decrypts the
+    /// sealed cookie with the responder's public-key-derived key and OUR
+    /// stored [`Self::last_mac1`] as the AEAD AAD; on success stores the
+    /// cookie + `now_ns` so the next [`Self::add_macs`] stamps a valid MAC2.
+    ///
+    /// Fails closed (`false`, cookie state untouched) when we never sent an
+    /// initiation (`last_mac1` unset — nothing to attribute the reply to) or
+    /// when decryption fails (wrong key / wrong AAD / tampered ciphertext).
+    pub(crate) fn consume_reply(
+        &mut self,
+        reply: &[u8],
+        responder_static_pub: &[u8; WG_KEY_LEN],
+        now_ns: u64,
+    ) -> bool {
+        let Some(aad_mac1) = self.last_mac1 else {
+            return false;
+        };
+        match CookieChecker::decrypt_cookie_reply(reply, responder_static_pub, &aad_mac1) {
+            Some(cookie) => {
+                self.cookie = Some((cookie, now_ns));
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// #4094 PR-B test hook: whether a (non-expired-agnostic) cookie is
+    /// currently stored.
+    #[cfg(test)]
+    pub(crate) fn has_cookie_for_test(&self) -> bool {
+        self.cookie.is_some()
+    }
+}
+
+impl Default for InitiatorCookie {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -1170,5 +1292,144 @@ mod tests {
             !cc.source_reply_allowed(s, t_hi),
             "the forward jump after a backwards step is not replayed into an over-credit"
         );
+    }
+
+    // ===================================================================
+    // #4094 PR-B initiator-side cookie-reply consume + MAC2 stamping.
+    // ===================================================================
+
+    /// Full cookie handshake round-trip across BOTH halves: the responder
+    /// (PR-A [`CookieChecker`]) issues a cookie-reply; the initiator (PR-B
+    /// [`InitiatorCookie`]) consumes it and stamps a MAC2 on its RETRIED
+    /// initiation that the responder's [`CookieChecker::verify_initiation_mac2`]
+    /// accepts. RED on revert: without the consume+stamp the retried MAC2
+    /// stays zero and the responder rejects it (re-challenging forever — the
+    /// handshake never completes under load).
+    #[test]
+    fn initiator_cookie_roundtrip_stamps_accepted_mac2() {
+        let responder_pub = [0x91u8; 32];
+        let cc = CookieChecker::new(&responder_pub);
+        let now = 10_000_000_000u64;
+        let from = src(51820); // the initiator's source as the responder sees it
+
+        // 1. Initiator sends its FIRST initiation (MAC2 zero) and records its
+        //    MAC1 via add_macs.
+        let mut ic = InitiatorCookie::new();
+        let mut first = valid_mac1_init(&responder_pub, 0x1111);
+        assert!(
+            !ic.add_macs(&mut first, now),
+            "no cookie yet → MAC2 stays zero"
+        );
+        assert_eq!(&first[M1_MAC2..], &[0u8; 16]);
+
+        // 2. Responder issues a cookie-reply for that initiation from `from`.
+        let mut reply = [0u8; WG_MSG_COOKIE_LEN];
+        cc.build_cookie_reply(&first, from, now, &mut reply).unwrap();
+
+        // 3. Initiator consumes the reply → stores the cookie.
+        assert!(ic.consume_reply(&reply, &responder_pub, now));
+        assert!(ic.has_cookie_for_test());
+
+        // 4. Initiator retries — add_macs now stamps a NON-ZERO MAC2.
+        let mut retry = valid_mac1_init(&responder_pub, 0x2222);
+        assert!(ic.add_macs(&mut retry, now), "a fresh cookie stamps MAC2");
+        assert_ne!(&retry[M1_MAC2..], &[0u8; 16]);
+
+        // 5. The responder's MAC2 verifier accepts the retried initiation
+        //    from the SAME source (RED on revert: zero MAC2 is rejected).
+        assert!(
+            cc.verify_initiation_mac2(&retry, from, now),
+            "responder must accept the initiator's cookie-derived MAC2"
+        );
+        // A DIFFERENT source is still rejected — the cookie binds the source.
+        assert!(
+            !cc.verify_initiation_mac2(&retry, src(51821), now),
+            "a cookie-derived MAC2 must not verify from a different source"
+        );
+    }
+
+    /// A cookie-reply that fails AEAD authentication (tampered ciphertext or
+    /// wrong responder key) is DROPPED: no cookie is stored, no panic, and a
+    /// subsequent retry still carries a zero MAC2 (fail-closed).
+    #[test]
+    fn initiator_drops_undecryptable_cookie_reply() {
+        let responder_pub = [0x92u8; 32];
+        let cc = CookieChecker::new(&responder_pub);
+        let now = 10_000_000_000u64;
+        let from = src(51820);
+
+        let mut ic = InitiatorCookie::new();
+        let mut first = valid_mac1_init(&responder_pub, 7);
+        ic.add_macs(&mut first, now);
+        let mut reply = [0u8; WG_MSG_COOKIE_LEN];
+        cc.build_cookie_reply(&first, from, now, &mut reply).unwrap();
+
+        // (a) Tampered ciphertext → AEAD tag mismatch → not consumed.
+        let mut tampered = reply;
+        tampered[M3_COOKIE] ^= 0xFF;
+        assert!(!ic.consume_reply(&tampered, &responder_pub, now));
+        assert!(!ic.has_cookie_for_test());
+
+        // (b) Wrong responder key → wrong AEAD key → not consumed.
+        let wrong_pub = [0x93u8; 32];
+        assert!(!ic.consume_reply(&reply, &wrong_pub, now));
+        assert!(!ic.has_cookie_for_test());
+
+        // Sanity: the untampered reply with the RIGHT key DOES consume — the
+        // failures above were the tamper/key, not a broken reply. (`last_mac1`
+        // is still the first initiation's MAC1 — we have not sent another —
+        // so the AAD still matches.)
+        assert!(ic.consume_reply(&reply, &responder_pub, now));
+        assert!(ic.has_cookie_for_test());
+    }
+
+    /// An EXPIRED cookie (older than [`COOKIE_ROTATION_TIME_NS`], 120 s) is
+    /// NOT used: add_macs leaves MAC2 zero rather than stamping a stale
+    /// cookie. Just inside the window it is still stamped.
+    #[test]
+    fn initiator_expired_cookie_yields_zero_mac2() {
+        let responder_pub = [0x94u8; 32];
+        let cc = CookieChecker::new(&responder_pub);
+        let t0 = 10_000_000_000u64;
+        let from = src(51820);
+
+        let mut ic = InitiatorCookie::new();
+        let mut first = valid_mac1_init(&responder_pub, 1);
+        ic.add_macs(&mut first, t0);
+        let mut reply = [0u8; WG_MSG_COOKIE_LEN];
+        cc.build_cookie_reply(&first, from, t0, &mut reply).unwrap();
+        assert!(ic.consume_reply(&reply, &responder_pub, t0));
+
+        // Just within the TTL → MAC2 stamped.
+        let mut in_window = valid_mac1_init(&responder_pub, 2);
+        assert!(ic.add_macs(&mut in_window, t0 + COOKIE_ROTATION_TIME_NS - 1));
+        assert_ne!(&in_window[M1_MAC2..], &[0u8; 16]);
+
+        // Past the TTL (> 120 s) → MAC2 zero (a stale cookie is not used).
+        let mut expired = valid_mac1_init(&responder_pub, 3);
+        assert!(!ic.add_macs(&mut expired, t0 + COOKIE_ROTATION_TIME_NS + 1));
+        assert_eq!(&expired[M1_MAC2..], &[0u8; 16]);
+    }
+
+    /// A cookie-reply that arrives before the initiator ever sent an
+    /// initiation (no stored MAC1 to use as the AEAD AAD) is ignored — the
+    /// reply cannot be attributed, so it is dropped fail-closed.
+    #[test]
+    fn initiator_ignores_cookie_reply_before_any_initiation() {
+        let responder_pub = [0x95u8; 32];
+        let cc = CookieChecker::new(&responder_pub);
+        let now = 10_000_000_000u64;
+        let from = src(51820);
+
+        let first = valid_mac1_init(&responder_pub, 9);
+        let mut reply = [0u8; WG_MSG_COOKIE_LEN];
+        cc.build_cookie_reply(&first, from, now, &mut reply).unwrap();
+
+        let mut ic = InitiatorCookie::new();
+        assert!(
+            !ic.consume_reply(&reply, &responder_pub, now),
+            "a reply with no prior sent initiation cannot be attributed"
+        );
+        assert!(!ic.has_cookie_for_test());
     }
 }

--- a/userspace-dp/src/afxdp/wg/counters.rs
+++ b/userspace-dp/src/afxdp/wg/counters.rs
@@ -31,9 +31,11 @@
 //! that peer). The responder cookie-reply / MAC2 under-load path is now
 //! counted too (#4094 PR-A): `hs_cookie_replies_sent`,
 //! `hs_rx_under_load_no_mac2`, `hs_rx_under_load_mac2_ok`, and
-//! `hs_cookie_reply_budget_drops`. The remaining reserved-with-no-site
-//! counter is `hs_rx_cookie_unsupported` — an INBOUND type-3 drop, still
-//! deferred to the initiator-side cookie-reply consume (PR-B).
+//! `hs_cookie_reply_budget_drops`. The initiator-side cookie-reply CONSUME
+//! (#4094 PR-B) is now counted: `hs_rx_cookie_consumed` (a cookie-reply we
+//! decrypted and stored, arming a valid MAC2 on our next initiation) and
+//! `hs_rx_cookie_unsupported` (now a real site: a cookie-reply we could not
+//! attribute to an in-flight initiation or could not decrypt).
 
 use super::engine::{DecapError, EncapError};
 use super::handshake::FramingError;
@@ -70,12 +72,21 @@ pub(crate) struct WgCounters {
     /// the transport-record `decap_drops_replay` window; this is the
     /// HANDSHAKE anti-replay gate.
     pub(crate) hs_rx_drops_replayed_init: AtomicU64,
-    /// Inbound type-3 (cookie-reply) datagrams dropped. In PR-A the
-    /// RESPONDER cookie path is live, but the INITIATOR-side consume of an
-    /// inbound cookie-reply (parse + re-initiate with a real MAC2) is PR-B,
-    /// so a received type-3 is still dropped here. Renamed intent, same
-    /// wire name for compatibility.
+    /// Inbound type-3 (cookie-reply) datagrams DROPPED by the initiator
+    /// (#4094 PR-B): a reply we could not attribute to an in-flight
+    /// initiation (`receiver_index` matched no pending handshake) or could
+    /// not decrypt (wrong key / bad AAD / tampered). Successful consumes are
+    /// counted separately as `hs_rx_cookie_consumed`. Same wire name as the
+    /// former S7 placeholder for Go-side compatibility; the meaning is now a
+    /// real drop-by-reason rather than "unsupported".
     pub(crate) hs_rx_cookie_unsupported: AtomicU64,
+    /// #4094 PR-B: inbound type-3 cookie-replies successfully CONSUMED by the
+    /// initiator — decrypted with the responder's public-key-derived key and
+    /// our last-sent MAC1 as AAD, and stored so the NEXT initiation to that
+    /// peer carries a valid MAC2. The initiator half of the under-load DoS
+    /// mitigation working end-to-end (pairs with the responder's
+    /// `hs_cookie_replies_sent` / `hs_rx_under_load_mac2_ok`).
+    pub(crate) hs_rx_cookie_consumed: AtomicU64,
     /// #4094 PR-A: WG type-3 CookieReply messages the RESPONDER emitted —
     /// one per under-load, valid-MAC1, missing/bad-MAC2 initiation that was
     /// challenged instead of handshaked.

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -467,6 +467,17 @@ pub(crate) struct WgEngine {
     /// this engine's responder static public key. Consulted by
     /// `classify_initiation` before the expensive Noise responder path.
     pub(in crate::afxdp::wg) cookie: super::cookie::CookieChecker,
+    /// #4094 PR-B: initiator-side per-peer cookie state — the last
+    /// cookie-reply we decrypted from each responder (used to stamp MAC2 on
+    /// our retried initiations until it ages past
+    /// `cookie::COOKIE_ROTATION_TIME_NS`) plus the MAC1 of our last-sent
+    /// initiation to that peer (the AEAD AAD to decrypt an incoming
+    /// cookie-reply). Keyed by peer static public key. Slow-path only
+    /// (control thread: `create_initiation` on send, `consume_cookie_reply`
+    /// on receive); the `Mutex` provides `&self` interior mutability and is
+    /// effectively uncontended.
+    pub(in crate::afxdp::wg) cookie_gen:
+        std::sync::Mutex<FxHashMap<[u8; WG_KEY_LEN], super::cookie::InitiatorCookie>>,
     /// #1888 S5 test hook: when nonzero, `now_ns()` returns this value
     /// instead of CLOCK_MONOTONIC, making the timer semantics
     /// deterministically testable. Compiled out of release builds.
@@ -514,6 +525,7 @@ impl WgEngine {
             counters: WgCounters::default(),
             rekey_request_pending: std::sync::atomic::AtomicBool::new(false),
             cookie: super::cookie::CookieChecker::new(&local_public_key),
+            cookie_gen: std::sync::Mutex::new(FxHashMap::default()),
             #[cfg(test)]
             mock_now_ns: std::sync::atomic::AtomicU64::new(0),
         };

--- a/userspace-dp/src/afxdp/wg/engine_tests.rs
+++ b/userspace-dp/src/afxdp/wg/engine_tests.rs
@@ -1269,3 +1269,135 @@ fn classify_initiation_fails_closed_without_secure_randomness() {
         "the fail-closed drop is counted"
     );
 }
+
+/// #4094 PR-B end-to-end interop through the wired engine paths: an
+/// INITIATOR (this PR) whose first initiation is cookie-challenged by a
+/// RESPONDER under load (PR-A) consumes the cookie-reply and, on its RETRY
+/// via `create_initiation`, stamps a valid MAC2 that the responder's
+/// `classify_initiation` accepts (`Process`) — the two halves complete a
+/// full cookie handshake. RED on revert: without the PR-B consume+stamp the
+/// retry carries a zero MAC2 and the responder re-challenges it
+/// (`SendCookie`) forever.
+#[test]
+fn initiator_consume_completes_handshake_under_load() {
+    use crate::afxdp::wg::cookie::INITIATIONS_UNDER_LOAD_THRESHOLD;
+    use std::net::SocketAddr;
+    use std::str::FromStr;
+
+    let (init_priv, init_pub) = keypair();
+    let (resp_priv, resp_pub) = keypair();
+    let i_engine = WgEngine::new(WgEngineConfig {
+        local_private_key: init_priv.into(),
+        listen_port: 51820,
+        peers: vec![WgPeerConfig {
+            pubkey: resp_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            preshared_key: [0u8; 32].into(),
+        }],
+    });
+    let r_engine = WgEngine::new(WgEngineConfig {
+        local_private_key: resp_priv.into(),
+        listen_port: 51820,
+        peers: vec![WgPeerConfig {
+            pubkey: init_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            preshared_key: [0u8; 32].into(),
+        }],
+    });
+    let now = 10_000_000_000u64;
+    i_engine.set_mock_now_ns(now);
+    r_engine.set_mock_now_ns(now);
+    // The initiator's source as the responder observes it.
+    let from: SocketAddr = "203.0.113.9:51820".parse().unwrap();
+    let mut out = [0u8; 256];
+
+    // 1. Initiator builds its FIRST real initiation toward the responder.
+    //    No cookie held yet → MAC2 is zero.
+    let mut init_buf = [0u8; 256];
+    i_engine.create_initiation(&resp_pub, &mut init_buf).unwrap();
+    let init = init_buf[..crate::afxdp::wg::WG_MSG_INIT_LEN].to_vec();
+    assert_eq!(
+        &init[132..148],
+        &[0u8; 16],
+        "the first initiation carries a zero MAC2"
+    );
+
+    // 2. Drive the responder under load with filler valid-MAC1 initiations
+    //    from DISTINCT sources (so the per-source reply bucket is not the
+    //    limiter), then challenge the initiator's real initiation.
+    let noise = [0x3Cu8; crate::afxdp::wg::handshake::MSG_INIT_NOISE_LEN];
+    let mut filler = [0u8; crate::afxdp::wg::WG_MSG_INIT_LEN];
+    crate::afxdp::wg::handshake::build_initiation(&mut filler, 0x1234_5678, &noise, &resp_pub)
+        .unwrap();
+    for i in 0..(INITIATIONS_UNDER_LOAD_THRESHOLD + 4) {
+        let s: SocketAddr = format!("192.0.2.{}:51820", (i % 250) + 1).parse().unwrap();
+        r_engine.classify_initiation(&filler, s, &mut out, now);
+    }
+
+    // 3. The responder challenges the initiator's initiation → cookie-reply.
+    let action = r_engine.classify_initiation(&init, from, &mut out, now);
+    let len = match action {
+        InitiationAction::SendCookie(l) => l,
+        other => panic!("expected a cookie challenge, got {other:?}"),
+    };
+    let reply = out[..len].to_vec();
+    assert_eq!(reply[0], crate::afxdp::wg::WG_TYPE_COOKIE);
+
+    // 4. Initiator consumes the cookie-reply (wired path).
+    assert!(
+        i_engine.consume_cookie_reply(&reply, now),
+        "the initiator must consume the responder's cookie-reply"
+    );
+    assert_eq!(
+        i_engine
+            .counters()
+            .hs_rx_cookie_consumed
+            .load(Ordering::Relaxed),
+        1,
+        "a consumed cookie-reply is counted"
+    );
+
+    // 5. Initiator RETRIES — create_initiation now stamps a NON-ZERO MAC2.
+    let mut retry_buf = [0u8; 256];
+    i_engine
+        .create_initiation(&resp_pub, &mut retry_buf)
+        .unwrap();
+    let retry = retry_buf[..crate::afxdp::wg::WG_MSG_INIT_LEN].to_vec();
+    assert_ne!(
+        &retry[132..148],
+        &[0u8; 16],
+        "after consuming a cookie the retried initiation carries a MAC2"
+    );
+
+    // 6. The responder, still under load, ACCEPTS the retried initiation —
+    //    the cookie-derived MAC2 verifies against its own recomputation.
+    assert_eq!(
+        r_engine.classify_initiation(&retry, from, &mut out, now),
+        InitiationAction::Process,
+        "the responder must admit the initiator's cookie-derived MAC2 (full \
+         cookie handshake completes under load)"
+    );
+    assert!(
+        r_engine
+            .counters()
+            .hs_rx_under_load_mac2_ok
+            .load(Ordering::Relaxed)
+            >= 1,
+        "the primed retry counts as an under-load MAC2 pass on the responder"
+    );
+
+    // Control: the SAME retried MAC2 replayed from a DIFFERENT source is
+    // still challenged — the cookie binds to the source that received it.
+    let spoof: SocketAddr = "198.51.100.7:51820".parse().unwrap();
+    assert!(
+        matches!(
+            r_engine.classify_initiation(&retry, spoof, &mut out, now),
+            InitiationAction::SendCookie(_)
+        ),
+        "a cookie-derived MAC2 must not authorize a handshake from a different source"
+    );
+}

--- a/userspace-dp/src/afxdp/wg/handshake_session.rs
+++ b/userspace-dp/src/afxdp/wg/handshake_session.rs
@@ -312,6 +312,12 @@ impl WgEngine {
             self.release_pending(local_index);
             return Err(e.into());
         }
+        // #4094 PR-B: record this initiation's MAC1 (the AEAD AAD for a
+        // future cookie-reply) and, if we already hold a fresh cookie for
+        // this peer, stamp a valid MAC2 — so a retried initiation after a
+        // cookie challenge is admitted by a responder under load. build_
+        // initiation left MAC2 zero; this is the sole site that stamps it.
+        self.add_initiator_macs(peer_pubkey, out, self.now_ns());
         // Stash the real (post-write) snow state into the pending entry so
         // `consume_response` can resume it.
         {
@@ -325,6 +331,76 @@ impl WgEngine {
             }
         }
         Ok(local_index)
+    }
+
+    /// #4094 PR-B: record the just-built outbound initiation's MAC1 and
+    /// stamp MAC2 if we hold a fresh cookie for `peer_pubkey`. Delegates to
+    /// the per-peer [`super::cookie::InitiatorCookie`]. Called from
+    /// `create_initiation_inner` after `build_initiation` has written MAC1
+    /// and zeroed MAC2. Slow path (control thread only).
+    fn add_initiator_macs(&self, peer_pubkey: &[u8; WG_KEY_LEN], out: &mut [u8], now_ns: u64) {
+        let mut cg = self.cookie_gen.lock().unwrap();
+        let entry = cg
+            .entry(*peer_pubkey)
+            .or_insert_with(super::cookie::InitiatorCookie::new);
+        entry.add_macs(out, now_ns);
+    }
+
+    /// #4094 PR-B: consume an inbound WG type-3 cookie-reply. A responder
+    /// under load answers our valid-MAC1 initiation with a cookie-reply
+    /// instead of a handshake response; this decrypts it and stores the
+    /// cookie so our NEXT initiation to that peer carries a valid MAC2.
+    ///
+    /// The reply's `receiver_index` (bytes 4..8, LE) echoes the
+    /// `sender_index` of the initiation that triggered it — the key of a
+    /// pending initiator handshake — so we look it up to attribute the reply
+    /// to a peer, then decrypt with that peer's static public key (the
+    /// responder key that derives the cookie AEAD key) and OUR stored
+    /// last-sent MAC1 as the AEAD AAD. Returns `true` iff a cookie was
+    /// decrypted and stored. Fails closed (`false`) for a wrong-length
+    /// reply, a `receiver_index` with no matching in-flight initiation, or a
+    /// decryption/authentication failure.
+    ///
+    /// Counts internally (mirroring `classify_initiation`'s self-contained
+    /// counter discipline): `hs_rx_cookie_consumed` on success,
+    /// `hs_rx_cookie_unsupported` on any drop. Slow path (control thread
+    /// only).
+    pub(crate) fn consume_cookie_reply(&self, reply: &[u8], now_ns: u64) -> bool {
+        let ok = self.consume_cookie_reply_inner(reply, now_ns);
+        if ok {
+            super::counters::WgCounters::bump(&self.counters.hs_rx_cookie_consumed);
+        } else {
+            super::counters::WgCounters::bump(&self.counters.hs_rx_cookie_unsupported);
+        }
+        ok
+    }
+
+    fn consume_cookie_reply_inner(&self, reply: &[u8], now_ns: u64) -> bool {
+        if reply.len() != super::cookie::WG_MSG_COOKIE_LEN {
+            return false;
+        }
+        let recv_index = u32::from_le_bytes([reply[4], reply[5], reply[6], reply[7]]);
+        let Some(peer_pubkey) = self.peer_for_pending_index(recv_index) else {
+            return false;
+        };
+        let mut cg = self.cookie_gen.lock().unwrap();
+        let entry = cg
+            .entry(peer_pubkey)
+            .or_insert_with(super::cookie::InitiatorCookie::new);
+        entry.consume_reply(reply, &peer_pubkey, now_ns)
+    }
+
+    /// The peer a pending initiator handshake with local index `index` is
+    /// with, if any. Used by `consume_cookie_reply` to attribute an inbound
+    /// cookie-reply (whose `receiver_index` echoes our `sender_index`) to a
+    /// peer. Defined here because `PendingHandshake`'s fields are private to
+    /// this module.
+    fn peer_for_pending_index(&self, index: u32) -> Option<[u8; WG_KEY_LEN]> {
+        self.pending
+            .read()
+            .unwrap()
+            .get(&index)
+            .map(|ph| ph.peer_pubkey)
     }
 
     /// Consume a peer's framed WG type-2 response, complete the initiator

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -740,6 +740,10 @@ pub(crate) struct WgTunnelStatus {
     pub hs_rx_drops_replayed_init: u64,
     #[serde(rename = "hs_rx_cookie_unsupported", default)]
     pub hs_rx_cookie_unsupported: u64,
+    /// #4094 PR-B initiator-side cookie-replies successfully consumed
+    /// (decrypted + stored, arming a valid MAC2 on the next initiation).
+    #[serde(rename = "hs_rx_cookie_consumed", default)]
+    pub hs_rx_cookie_consumed: u64,
     /// #4094 PR-A responder cookie-reply / MAC2 under-load DoS-mitigation
     /// accounting: cookie replies emitted, under-load initiations dropped
     /// for a missing/bad MAC2 (challenged), under-load initiations that

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -1979,6 +1979,8 @@ fn process_status_wg_tunnels_roundtrip_and_compat() {
         // field must be nonzero for the wire-invariant populated pin).
         hs_rx_drops_replayed_init: 45,
         hs_rx_cookie_unsupported: 11,
+        // #4094 PR-B initiator cookie-replies consumed (50, off-ladder).
+        hs_rx_cookie_consumed: 50,
         // #4094 PR-A responder cookie / MAC2 under-load accounting
         // (46.. off-ladder, mirror of the Go-side series-set values).
         hs_cookie_replies_sent: 46,
@@ -2044,6 +2046,7 @@ fn process_status_wg_tunnels_roundtrip_and_compat() {
     assert_eq!(wire_row["rekeys_initiated_age"], 39);
     assert_eq!(wire_row["keepalives_tx_persistent"], 43);
     assert_eq!(wire_row["hs_cookie_replies_sent"], 46);
+    assert_eq!(wire_row["hs_rx_cookie_consumed"], 50);
     assert_eq!(wire_row["hs_rx_under_load_no_mac2"], 47);
     let back: ProcessStatus =
         serde_json::from_value(value).expect("deserialize ProcessStatus");


### PR DESCRIPTION
## Summary

Completes #4094. PR-A (#4330) shipped the RESPONDER half of the WireGuard §5.4.7 under-load cookie mechanism; the INITIATOR half was still a no-op (an inbound type-3 CookieReply was dropped), so xpf-as-initiator could never complete a handshake against a peer that was itself under load. This PR teaches the initiator to consume a cookie-reply and attach a real MAC2 to its retried handshake-init. No undecided design — the cookie TTL, XChaCha20-Poly1305 sealing, and AAD are all fixed by PR-A.

## Changes

- **`cookie::InitiatorCookie`** (the wireguard-go `CookieGenerator` analog), held per-peer in `WgEngine::cookie_gen`, holds the last decrypted cookie + receive time and the MAC1 of our most recent initiation.
- **Outbound** (`create_initiation` → `add_initiator_macs` → `InitiatorCookie::add_macs`, after `build_initiation`): records the MAC1 (AEAD AAD for a future reply) and, if we hold a cookie younger than `COOKIE_ROTATION_TIME_NS` (120 s, reusing PR-A's constant), stamps `mac2 = keyed-BLAKE2s-128(cookie, msg[0..132])`. Expired/absent cookie → MAC2 stays zero.
- **Inbound** (`dispatch_inbound` `WG_TYPE_COOKIE` arm → `consume_cookie_reply`): attributes the reply to a peer via its `receiver_index` (→ pending handshake), decrypts with the peer's public-key-derived key + our stored last-MAC1 as AAD (`decrypt_cookie_reply`, promoted from a `#[cfg(test)]` mirror to production), and stores the cookie. Fails closed for unattributable/undecryptable replies; not authenticated for endpoint-learning.
- **Counters**: new `hs_rx_cookie_consumed` (Prometheus `xpf_userspace_wg_cookie_replies_total{event=consumed}`) on success; `hs_rx_cookie_unsupported` keeps its wire name but becomes a real drop-by-reason site. Threaded through status/control → Go protocol.go → the Prometheus collector.
- Docs: `docs/wireguard-interop.md` (S7 row + new "Initiator cookie-reply consume" section).

## Tests (RED-on-revert, verified)

- `cookie.rs`: `initiator_cookie_roundtrip_stamps_accepted_mac2` (responder's `verify_initiation_mac2` accepts the initiator's cookie-derived MAC2 + source-binds it), `initiator_expired_cookie_yields_zero_mac2`, `initiator_drops_undecryptable_cookie_reply` (fail-closed, no panic), `initiator_ignores_cookie_reply_before_any_initiation`.
- `engine_tests.rs`: `initiator_consume_completes_handshake_under_load` — end-to-end through the wired paths (challenged initiator consumes the reply, its retried `create_initiation` is admitted as `Process`).

Neutering the MAC2 stamp fails the stamping-dependent tests (retried MAC2 stays zero / re-challenged).

## Validation

- Full `cargo test --release -- --test-threads=1`: **3703 passed / 0 failed / 2 ignored**; `wg::` all green.
- Go build + `pkg/api` + `pkg/dataplane/userspace` tests green.

Closes #4094

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi