### PR TITLE
config: flip three leaf-complete IPsec subtrees to closed-world (#4313 PR-C)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-07-06 — #4313 PR-C: three more closed-world IPsec subtree flips
+
+- **Timestamp**: 2026-07-06
+- **Action**: Flipped three more leaf-complete `security` subtrees to
+  `closedWorld:true` on top of PR-B's destination-NAT then. Each was audited
+  Junos-leaf-complete (modeled child set == full Junos grammar == the exact
+  keyword set `compiler_ipsec.go` reads), so closing carries no false-reject
+  (#4191) risk: (1) `security ipsec vpn <v> traffic-selector <ts>` — only
+  `local-ip` / `remote-ip`; (2) `security ipsec vpn <v> vpn-monitor` — only
+  `source-interface` / `destination-ip` / `optimized`; (3) `security
+  {ike,ipsec} gateway <gw> dead-peer-detection` (both identical copies) —
+  only `always-send` / `optimized` / `probe-idle-tunnel` / `interval` /
+  `threshold`. All value leaves carry the value on the same statement line
+  (no nested Junos block), so closed-world never descends into an AST child
+  of a value leaf in either parser shape. An unknown/typo'd keyword under any
+  of these now REJECTS at strict commit instead of committing clean +
+  silently dropping; the tolerant Load/SyncApply path downgrades to a warning
+  (#1960). SKIPPED as incomplete/unsafe (documented in config-schema.md):
+  snmp community (missing `view`/`client-list-name`), ike/ipsec proposal
+  (missing `description`), static-NAT then (free-form leaf, hierarchical
+  `static-nat { prefix { … } }` would false-reject), screen ids-option
+  (deliberately open-world). Verified RED-on-revert (removed the 4 flags →
+  all 6 rejection tests fail silent-accept, AcceptsValid still pass), restored.
+- **File(s)**: pkg/config/schema_security.go,
+  pkg/config/schema_closedworld_ipsec_4313_test.go (new),
+  docs/config-schema.md, _Log.md
+
 ## 2026-07-06 — #4090: survivor-fabric cold-start bulk sync re-drive
 
 - **Timestamp**: 2026-07-06

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -697,14 +697,50 @@ false-reject that valid Junos config (the #4191 class). It is a follow-up:
 model the rule-level persistent-nat leaves (or make an accept-with-advisory
 decision) FIRST, then flip.
 
+**More production flips — IPsec leaf-complete option containers (PR-C, #4313).**
+Three additional `security` subtrees now set `closedWorld:true`
+(`schema_security.go`), each after the same leaf-completeness audit — the
+modeled child set equals the full Junos grammar AND equals the exact keyword
+set the compiler (`compiler_ipsec.go`) reads, so closing carries no
+false-reject risk:
+
+- `security ipsec vpn <v> traffic-selector <ts>` — the entire Junos grammar is
+  `local-ip <prefix>` and `remote-ip <prefix>` (both modeled); the compiler
+  traffic-selector loop reads only those two. A typo (`local-op`) would
+  silently drop the selector prefix and negotiate the wrong crypto proxy-id;
+  it is now rejected at commit.
+- `security ipsec vpn <v> vpn-monitor` — the full grammar is `source-interface`,
+  `destination-ip`, and `optimized` (all modeled); the compiler `vpn-monitor`
+  arm reads only those three. (The feature itself is accepted-but-not-enforced
+  advisory, but the flip still catches typos.)
+- `security {ike,ipsec} gateway <gw> dead-peer-detection` (both identical copies
+  of the block are flipped) — the full grammar is `always-send`, `optimized`,
+  `probe-idle-tunnel`, `interval <seconds>`, and `threshold <count>` (all
+  modeled); `parseDeadPeerDetectionNode` reads only those five. A typo
+  (`intervl`) would silently keep the Junos default; it is now rejected.
+
+Every value leaf in these subtrees (`local-ip`/`remote-ip`,
+`source-interface`/`destination-ip`, `interval`/`threshold`) carries its value
+on the same statement line — there is no nested value block in Junos — so
+closed-world never descends into an AST child of a value leaf in EITHER parser
+shape, and cannot false-reject a valid config. As with PR-B, the reject fires
+only on the strict commit path; `compileTreeLenient` downgrades it to a warning
+on `Store.Load` / `SyncApply`. Production tests:
+`schema_closedworld_ipsec_4313_test.go` (RED on revert of each flag).
+
 **Remaining per-subtree flips (future PRs, tracked on #4313).** Turning
-`closedWorld` on for the other umbrella candidates (`security ipsec`, `snmp
-community`, `protocols {ospf,bgp} interface`, `interfaces … family`, and the
-deferred source-NAT then above) is only safe once that subtree is LEAF-COMPLETE
-— every valid Junos keyword under it is modeled — otherwise the flip
-false-rejects a valid config. Each flip is its own follow-up gated on a
-Junos-leaf completeness audit for that subtree. Do NOT set `closedWorld` on a
-subtree without that audit.
+`closedWorld` on for the other umbrella candidates (`snmp community` — INCOMPLETE:
+Junos allows `view` / `client-list-name` / `routing-instance`, unmodeled;
+`security ipsec proposal` / `security ike proposal` — INCOMPLETE: Junos allows a
+`description` leaf, unmodeled; `security nat static … then static-nat` —
+UNSAFE: `static-nat` is a free-form leaf and the Junos hierarchical form
+`static-nat { prefix { … } }` would false-reject under closed-world; `security
+screen ids-option` — INCOMPLETE, deliberately open-world; `protocols {ospf,bgp}
+interface`, `interfaces … family`, and the deferred source-NAT then above) is
+only safe once that subtree is LEAF-COMPLETE — every valid Junos keyword under
+it is modeled — otherwise the flip false-rejects a valid config. Each flip is
+its own follow-up gated on a Junos-leaf completeness audit for that subtree. Do
+NOT set `closedWorld` on a subtree without that audit.
 
 ### `firewall ... from tcp-flags` — semantic validation, not just a list (#3076)
 

--- a/pkg/config/schema_closedworld_ipsec_4313_test.go
+++ b/pkg/config/schema_closedworld_ipsec_4313_test.go
@@ -1,0 +1,189 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4313 PR-C — three more PRODUCTION closed-world subtree flips, on top of
+// PR-B's destination-NAT then (schema_closedworld_nat_then_4313_test.go).
+//
+// Each flipped subtree is LEAF-COMPLETE (schema_security.go): every valid
+// Junos keyword under it is modeled AND the compiler (compiler_ipsec.go) reads
+// exactly that keyword set, so closing the subtree cannot false-reject a valid
+// config (the #4191 class the umbrella warns about). An unmodeled keyword (a
+// typo, or garbage) under a flipped subtree is now REJECTED at strict commit
+// (SchemaValidate) instead of committing clean and being silently dropped by
+// the compiler — the #4313 silent-inert bug.
+//
+//	- security ipsec vpn <v> traffic-selector <ts>: local-ip | remote-ip
+//	- security ipsec vpn <v> vpn-monitor:            source-interface |
+//	                                                 destination-ip | optimized
+//	- security {ike,ipsec} gateway <gw> dead-peer-detection:
+//	     always-send | optimized | probe-idle-tunnel | interval | threshold
+//
+// These tests use the production ParseSetCommand + SetPath + SchemaValidate
+// path. Each rejection test is RED on revert of the closedWorld flag: without
+// it, SchemaValidate returns nil (open-world silent-accept) and the test fails.
+
+// --- traffic-selector -------------------------------------------------------
+
+// tsSet builds a minimal IPsec VPN traffic-selector whose body is the supplied
+// set lines (e.g. "local-ip 10.0.0.0/24", "bogus 1.2.3.4").
+func tsSet(bodyLines ...string) []string {
+	out := []string{"set security ipsec vpn v1 bind-interface st0.0"}
+	for _, l := range bodyLines {
+		out = append(out, "set security ipsec vpn v1 traffic-selector ts1 "+l)
+	}
+	return out
+}
+
+// TestClosedWorldTrafficSelector_RejectsUnknownKeyword is the RED-on-revert
+// discriminator: an unmodeled keyword under the closed-world traffic-selector
+// is rejected at strict commit. On revert of closedWorld the same input is
+// silently accepted (SchemaValidate returns nil) and this test fails.
+func TestClosedWorldTrafficSelector_RejectsUnknownKeyword(t *testing.T) {
+	tree := buildTree(t, tsSet("bogus 10.0.0.0/24"))
+	err := SchemaValidate(tree, nil)
+	if err == nil {
+		t.Fatal("an unmodeled keyword under the closed-world traffic-selector must be rejected at commit (RED on revert: silently accepted + dropped)")
+	}
+	if !strings.Contains(err.Error(), "bogus") || !strings.Contains(err.Error(), "closed-world") {
+		t.Fatalf("error must name the keyword and the closed-world subtree, got: %v", err)
+	}
+}
+
+// TestClosedWorldTrafficSelector_RejectsTypo is the VALUE of the fix: a
+// fat-fingered `local-op` for `local-ip` is caught at commit rather than
+// silently ignored — the operator learns the selector prefix would be dropped
+// and the wrong crypto proxy-id negotiated.
+func TestClosedWorldTrafficSelector_RejectsTypo(t *testing.T) {
+	tree := buildTree(t, tsSet("local-op 10.0.0.0/24"))
+	err := SchemaValidate(tree, nil)
+	if err == nil {
+		t.Fatal("a typo'd traffic-selector leaf (local-op) must be rejected at commit, not silently dropped")
+	}
+	if !strings.Contains(err.Error(), "local-op") || !strings.Contains(err.Error(), "closed-world") {
+		t.Fatalf("error must name the typo and the closed-world subtree, got: %v", err)
+	}
+}
+
+// TestClosedWorldTrafficSelector_AcceptsValid proves no false-reject: every
+// valid Junos traffic-selector leaf still commits clean under closed-world,
+// both as separate set lines and combined.
+func TestClosedWorldTrafficSelector_AcceptsValid(t *testing.T) {
+	// each leaf on its own
+	for _, leaf := range []string{"local-ip 10.0.0.0/24", "remote-ip 0.0.0.0/0"} {
+		tree := buildTree(t, tsSet(leaf))
+		if err := SchemaValidate(tree, nil); err != nil {
+			t.Fatalf("valid traffic-selector leaf %q must commit clean under closed-world, got: %v", leaf, err)
+		}
+	}
+	// both together (the real-world shape)
+	tree := buildTree(t, tsSet("local-ip 10.0.0.0/24", "remote-ip 0.0.0.0/0"))
+	if err := SchemaValidate(tree, nil); err != nil {
+		t.Fatalf("a full traffic-selector (local-ip + remote-ip) must commit clean under closed-world, got: %v", err)
+	}
+}
+
+// --- vpn-monitor ------------------------------------------------------------
+
+func vpnMonitorSet(bodyLines ...string) []string {
+	out := []string{"set security ipsec vpn v1 bind-interface st0.0"}
+	for _, l := range bodyLines {
+		out = append(out, "set security ipsec vpn v1 vpn-monitor "+l)
+	}
+	return out
+}
+
+func TestClosedWorldVPNMonitor_RejectsUnknownKeyword(t *testing.T) {
+	tree := buildTree(t, vpnMonitorSet("bogus 1.2.3.4"))
+	err := SchemaValidate(tree, nil)
+	if err == nil {
+		t.Fatal("an unmodeled keyword under the closed-world vpn-monitor must be rejected at commit (RED on revert)")
+	}
+	if !strings.Contains(err.Error(), "bogus") || !strings.Contains(err.Error(), "closed-world") {
+		t.Fatalf("error must name the keyword and the closed-world subtree, got: %v", err)
+	}
+}
+
+func TestClosedWorldVPNMonitor_RejectsTypo(t *testing.T) {
+	tree := buildTree(t, vpnMonitorSet("destintion-ip 1.2.3.4"))
+	err := SchemaValidate(tree, nil)
+	if err == nil {
+		t.Fatal("a typo'd vpn-monitor leaf (destintion-ip) must be rejected at commit, not silently dropped")
+	}
+	if !strings.Contains(err.Error(), "destintion-ip") || !strings.Contains(err.Error(), "closed-world") {
+		t.Fatalf("error must name the typo and the closed-world subtree, got: %v", err)
+	}
+}
+
+func TestClosedWorldVPNMonitor_AcceptsValid(t *testing.T) {
+	for _, leaf := range []string{"source-interface ge-0-0-0", "destination-ip 1.2.3.4", "optimized"} {
+		tree := buildTree(t, vpnMonitorSet(leaf))
+		if err := SchemaValidate(tree, nil); err != nil {
+			t.Fatalf("valid vpn-monitor leaf %q must commit clean under closed-world, got: %v", leaf, err)
+		}
+	}
+	tree := buildTree(t, vpnMonitorSet("source-interface ge-0-0-0", "destination-ip 1.2.3.4", "optimized"))
+	if err := SchemaValidate(tree, nil); err != nil {
+		t.Fatalf("a full vpn-monitor stanza must commit clean under closed-world, got: %v", err)
+	}
+}
+
+// --- dead-peer-detection (both the ike-gateway and ipsec-gateway copies) -----
+
+// dpdSet builds a minimal gateway carrying a dead-peer-detection body. scope is
+// "ike" or "ipsec" — both gateway blocks model the identical DPD subtree and
+// both are flipped closed-world.
+func dpdSet(scope string, bodyLines ...string) []string {
+	base := "set security " + scope + " gateway gw1 "
+	out := []string{base + "address 198.51.100.1"}
+	for _, l := range bodyLines {
+		out = append(out, base+"dead-peer-detection "+l)
+	}
+	return out
+}
+
+func TestClosedWorldDeadPeerDetection_RejectsUnknownKeyword(t *testing.T) {
+	for _, scope := range []string{"ike", "ipsec"} {
+		tree := buildTree(t, dpdSet(scope, "bogus 10"))
+		err := SchemaValidate(tree, nil)
+		if err == nil {
+			t.Fatalf("[%s gateway] an unmodeled keyword under the closed-world dead-peer-detection must be rejected at commit (RED on revert)", scope)
+		}
+		if !strings.Contains(err.Error(), "bogus") || !strings.Contains(err.Error(), "closed-world") {
+			t.Fatalf("[%s gateway] error must name the keyword and the closed-world subtree, got: %v", scope, err)
+		}
+	}
+}
+
+func TestClosedWorldDeadPeerDetection_RejectsTypo(t *testing.T) {
+	for _, scope := range []string{"ike", "ipsec"} {
+		tree := buildTree(t, dpdSet(scope, "intervl 10"))
+		err := SchemaValidate(tree, nil)
+		if err == nil {
+			t.Fatalf("[%s gateway] a typo'd DPD leaf (intervl) must be rejected at commit, not silently dropped", scope)
+		}
+		if !strings.Contains(err.Error(), "intervl") || !strings.Contains(err.Error(), "closed-world") {
+			t.Fatalf("[%s gateway] error must name the typo and the closed-world subtree, got: %v", scope, err)
+		}
+	}
+}
+
+func TestClosedWorldDeadPeerDetection_AcceptsValid(t *testing.T) {
+	for _, scope := range []string{"ike", "ipsec"} {
+		// each keyword on its own
+		for _, leaf := range []string{"always-send", "optimized", "probe-idle-tunnel", "interval 10", "threshold 5"} {
+			tree := buildTree(t, dpdSet(scope, leaf))
+			if err := SchemaValidate(tree, nil); err != nil {
+				t.Fatalf("[%s gateway] valid DPD leaf %q must commit clean under closed-world, got: %v", scope, leaf, err)
+			}
+		}
+		// a real-world tuned stanza
+		tree := buildTree(t, dpdSet(scope, "always-send", "interval 10", "threshold 5"))
+		if err := SchemaValidate(tree, nil); err != nil {
+			t.Fatalf("[%s gateway] a tuned dead-peer-detection stanza must commit clean under closed-world, got: %v", scope, err)
+		}
+	}
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -883,7 +883,22 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 				valueType: ValueEnumOf, valueDesc: "NAT traversal (UDP encapsulation) mode",
 				valueExamples: []string{"enable", "disable", "force"},
 				validator:     ValidateEnum([]string{"enable", "disable", "force"}), children: nil},
-			"dead-peer-detection": {desc: "Dead peer detection", children: map[string]*schemaNode{
+			// #4313 PR-C — closed-world flip (both the `security ike gateway`
+			// and `security ipsec gateway` copies of this identical block). The
+			// Junos `dead-peer-detection` grammar is LEAF-COMPLETE: exactly
+			// `always-send`, `optimized`, `probe-idle-tunnel`, `interval
+			// <seconds>`, and `threshold <count>` (all modeled), and the
+			// compiler (compiler_ipsec.go parseDeadPeerDetectionNode) reads ONLY
+			// these five keywords. always-send/optimized/probe-idle-tunnel are
+			// bare flags; interval/threshold carry their value on the same
+			// statement line (no nested block), so closed-world never descends
+			// into an AST child — it cannot false-reject a valid config (#4191
+			// class). A typo (`intervl`) or garbage keyword under DPD is now
+			// REJECTED at strict commit instead of silently dropped (the #4313
+			// bug — a fat-fingered interval/threshold would silently keep the
+			// Junos default); the tolerant Load/SyncApply path downgrades to a
+			// warning (#1960).
+			"dead-peer-detection": {desc: "Dead peer detection", closedWorld: true, children: map[string]*schemaNode{
 				"always-send":       {desc: "Send DPD probes regardless of traffic", children: nil},
 				"optimized":         {desc: "Optimized DPD probing", children: nil},
 				"probe-idle-tunnel": {desc: "Probe idle tunnels", children: nil},
@@ -961,7 +976,22 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 				valueType: ValueEnumOf, valueDesc: "NAT traversal (UDP encapsulation) mode",
 				valueExamples: []string{"enable", "disable", "force"},
 				validator:     ValidateEnum([]string{"enable", "disable", "force"}), children: nil},
-			"dead-peer-detection": {desc: "Dead peer detection", children: map[string]*schemaNode{
+			// #4313 PR-C — closed-world flip (both the `security ike gateway`
+			// and `security ipsec gateway` copies of this identical block). The
+			// Junos `dead-peer-detection` grammar is LEAF-COMPLETE: exactly
+			// `always-send`, `optimized`, `probe-idle-tunnel`, `interval
+			// <seconds>`, and `threshold <count>` (all modeled), and the
+			// compiler (compiler_ipsec.go parseDeadPeerDetectionNode) reads ONLY
+			// these five keywords. always-send/optimized/probe-idle-tunnel are
+			// bare flags; interval/threshold carry their value on the same
+			// statement line (no nested block), so closed-world never descends
+			// into an AST child — it cannot false-reject a valid config (#4191
+			// class). A typo (`intervl`) or garbage keyword under DPD is now
+			// REJECTED at strict commit instead of silently dropped (the #4313
+			// bug — a fat-fingered interval/threshold would silently keep the
+			// Junos default); the tolerant Load/SyncApply path downgrades to a
+			// warning (#1960).
+			"dead-peer-detection": {desc: "Dead peer detection", closedWorld: true, children: map[string]*schemaNode{
 				"always-send":       {desc: "Send DPD probes regardless of traffic", children: nil},
 				"optimized":         {desc: "Optimized DPD probing", children: nil},
 				"probe-idle-tunnel": {desc: "Probe idle tunnels", children: nil},
@@ -1000,7 +1030,19 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 			// #4299 (V-3): vpn-monitor. Accepted-but-not-enforced — captured so
 			// ValidateConfig emits an advisory; xpf has no ICMP-probe liveness /
 			// st0 interface-state coupling yet.
-			"vpn-monitor": {desc: "Tunnel liveness monitoring (accepted-but-not-enforced advisory)", children: map[string]*schemaNode{
+			//
+			// #4313 PR-C — closed-world flip. The Junos `vpn-monitor` block is
+			// LEAF-COMPLETE: its entire grammar is exactly `source-interface`,
+			// `destination-ip`, and `optimized` (all modeled), and the compiler
+			// (compiler_ipsec.go vpn-monitor arm ~line 478) reads ONLY these
+			// three keywords. source-interface/destination-ip are value leaves
+			// whose value rides on the same statement line and optimized is a
+			// bare flag, so closed-world never descends into an AST child — it
+			// cannot false-reject a valid config (#4191 class). A typo under
+			// vpn-monitor is now REJECTED at strict commit instead of silently
+			// dropped (the #4313 bug); the tolerant Load/SyncApply path
+			// downgrades to a warning (#1960).
+			"vpn-monitor": {desc: "Tunnel liveness monitoring (accepted-but-not-enforced advisory)", closedWorld: true, children: map[string]*schemaNode{
 				"source-interface": {desc: "Probe source interface", args: 1, placeholder: "<interface-name>", children: nil},
 				"destination-ip":   {desc: "Probe destination IP", args: 1, placeholder: "<address>", children: nil},
 				"optimized":        {desc: "Send probes only when there is no outbound traffic", children: nil},
@@ -1009,7 +1051,25 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 			"remote-identity": {desc: "Remote identity (default remote traffic selector)", args: 1, placeholder: "<identity>", children: nil},
 			"pre-shared-key":  {desc: "Pre-shared key for this VPN", args: 1, placeholder: "<key>", children: nil},
 			"local-address":   {desc: "Local tunnel endpoint address", args: 1, placeholder: "<address>", children: nil},
-			"traffic-selector": {desc: "Traffic selector name", args: 1, placeholder: "<selector-name>", children: map[string]*schemaNode{
+			// #4313 PR-C — closed-world flip. The Junos IPsec
+			// `traffic-selector <name>` block is LEAF-COMPLETE: its entire
+			// grammar is exactly `local-ip <prefix>` and `remote-ip <prefix>`
+			// (both modeled), and the compiler (compiler_ipsec.go, the
+			// traffic-selector loop ~line 495) reads ONLY these two keywords.
+			// Each is a value leaf whose prefix rides on the same statement
+			// line (no nested block in Junos), so closed-world never descends
+			// into an AST child of local-ip/remote-ip in either parser shape —
+			// it cannot false-reject a valid config (the #4191 class the
+			// umbrella warns about). closedWorld is inherited down every
+			// descendant level by walkSchemaNode's childClosed fold, so a typo
+			// (`local-op`) or garbage keyword under the selector is REJECTED at
+			// strict operator commit (SchemaValidate) instead of committing
+			// clean and being silently dropped — the #4313 silent-inert bug
+			// (a malformed selector would apply the wrong crypto proxy-id). The
+			// tolerant Load/SyncApply path downgrades the reject to a warning
+			// (#1960, configstore compileTreeLenient), so a stored or
+			// peer-synced config is never bricked.
+			"traffic-selector": {desc: "Traffic selector name", args: 1, placeholder: "<selector-name>", closedWorld: true, children: map[string]*schemaNode{
 				"local-ip":  {desc: "Local traffic selector prefix", args: 1, placeholder: "<prefix>", children: nil},
 				"remote-ip": {desc: "Remote traffic selector prefix", args: 1, placeholder: "<prefix>", children: nil},
 			}},


### PR DESCRIPTION
## Summary

Refs #4313. This is **PR-C**: three more production closed-world subtree flips on top of PR-B (#4356, destination-NAT then) and the PR-A (#4334) dormant mechanism (`schemaNode.closedWorld` + the `walkSchemaNode` gate).

An unmodeled keyword under a flipped subtree is now REJECTED at strict commit instead of committing clean and being silently dropped by the compiler — the #4313 silent-inert bug.

## Leaf-completeness audit (the #4191-class gate the umbrella warns about)

For each flip, the modeled child set equals the **full Junos grammar** AND equals the **exact keyword set the compiler (`compiler_ipsec.go`) reads**, so closing cannot false-reject a valid config:

| Subtree | Full Junos grammar (all modeled) | Compiler reads |
|---|---|---|
| `security ipsec vpn <v> traffic-selector <ts>` | `local-ip`, `remote-ip` | traffic-selector loop (~L495): only those two |
| `security ipsec vpn <v> vpn-monitor` | `source-interface`, `destination-ip`, `optimized` | `vpn-monitor` arm (~L478): only those three |
| `security {ike,ipsec} gateway <gw> dead-peer-detection` (both identical copies flipped) | `always-send`, `optimized`, `probe-idle-tunnel`, `interval`, `threshold` | `parseDeadPeerDetectionNode`: only those five |

Every value leaf in these subtrees (`local-ip`/`remote-ip`, `source-interface`/`destination-ip`, `interval`/`threshold`) carries its value on the **same statement line** — there is no nested value block in Junos — so closed-world never descends into an AST child of a value leaf in **either** parser shape and cannot false-reject a valid config. `closedWorld` inherits down every descendant level via `walkSchemaNode`'s `childClosed` fold.

The reject fires only on the **strict operator commit** path (`SchemaValidate`); the tolerant `Store.Load` / `SyncApply` path downgrades it to a warning (`compileTreeLenient`, #1960), so a stored or peer-synced config is never bricked.

## Value

- `traffic-selector`: a typo (`local-op`) silently dropped the selector prefix and negotiated the wrong crypto proxy-id — now rejected.
- `dead-peer-detection`: a typo (`intervl 10`) silently kept the Junos default interval — now rejected.
- `vpn-monitor`: catches typos (the feature itself is accepted-but-not-enforced advisory).

## Deliberately NOT flipped (documented in `docs/config-schema.md`)

- **snmp community** — INCOMPLETE: Junos allows `view` / `client-list-name` / `routing-instance`, unmodeled → would false-reject.
- **ike/ipsec proposal** — INCOMPLETE: Junos allows a `description` leaf, unmodeled.
- **static-NAT then** — UNSAFE: `static-nat` is a free-form leaf; the Junos hierarchical `static-nat { prefix { … } }` shape would false-reject under closed-world.
- **screen ids-option** — deliberately open-world (many unmodeled leaves).

## Tests

New `pkg/config/schema_closedworld_ipsec_4313_test.go` drives the production `ParseSetCommand` + `SetPath` + `SchemaValidate` path. For each subtree: an unknown keyword and a typo are **rejected**; every valid keyword still **commits clean** (no false-reject). Verified **RED on revert** — removing the four flags makes all six rejection tests fail (silent-accept) while the AcceptsValid tests still pass either way.

`go test ./pkg/config/...` and `./pkg/configstore/...` green; `go build ./...`, `gofmt`, `go vet ./pkg/config/` clean. `docs/config-schema.md` #4313 section and `_Log.md` updated.

## Remaining subtrees (keep #4313 open)

Future per-subtree flips, each gated on its own leaf-completeness audit: source-NAT then (persistent-nat), the incomplete/unsafe ones listed above once their missing leaves are modeled, `protocols {ospf,bgp} interface`, `interfaces … family`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi