### PR TITLE
cos: key DSCP rewrite-rule on (forwarding-class, loss-priority) (#3995)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -37038,3 +37038,32 @@ top.
   pkg/config/compiler_validate_warn.go,
   pkg/config/parser_class_of_service_test.go,
   docs/cos-traffic-shaping.md, _Log.md
+
+- **Timestamp**: 2026-07-06
+  **Action**: #3995 review follow-up (PR #4366 Copilot findings). FIX 1
+  (real): an unrecognized CoS loss-priority value (operator typo like
+  `medum-low`) was threaded raw to the dataplane and silently mapped to
+  the SAFE default (LOW for the classifier, wildcard for the rewrite) —
+  wrong QoS, silently. Added a commit-time validator
+  `validateClassOfServiceLossPriorityStrict` (pkg/config/
+  compiler_validate_strict.go) covering all three loss-priority read
+  sites (dscp classifier, ieee-802.1 classifier, dscp rewrite-rule),
+  sorted-deterministic, rejecting a non-empty value not in
+  {low, medium-low, medium-high, high} and naming the rule/class + bad
+  value + valid set. Wired lenient-gated at the strict phase
+  (compiler.go) via a new `lenientCoSLossPriority` option (reject on
+  commit/commit-check; warn on tolerant load / peer-sync so an already-
+  persisted or peer-synced config still boots, #1960 no-brick). Empty
+  loss-priority is skipped (the legitimate wildcard/default placeholder).
+  Test `TestCoSLossPriorityTypoRejectedStrict` (rewrite-rule + dscp-
+  classifier subcases): strict rejects `medum-low` naming the valid set,
+  lenient warns + still compiles, `medium-low` accepted on both paths.
+  FIX 2 (doc): corrected the `CoSState::lp_rewrite` doc comment — it is
+  present for every interface passing the useful-CoS gate (empty tables
+  when no classifier/rewrite-rule), not absent. Merged origin/master
+  (#4313/#3627 etc). go test ./pkg/config/... green; cargo build
+  --release clean (doc-only Rust touch). gofmt clean.
+  **File(s)**: pkg/config/compiler.go,
+  pkg/config/compiler_validate_strict.go,
+  pkg/config/parser_class_of_service_test.go,
+  userspace-dp/src/afxdp/types/cos.rs, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -36950,3 +36950,34 @@ top.
   pkg/policymatch/host_inbound_token_3627_test.go,
   pkg/cli/cli_show_security.go, pkg/daemon/README.md,
   pkg/policymatch/README.md, docs/host-inbound-service-matrix.md, _Log.md
+
+- **Timestamp**: 2026-07-06
+  **Action**: #3995 — CoS DSCP/802.1p rewrite-rule now keys on
+  (forwarding-class, loss-priority) instead of forwarding-class only.
+  The Go config layer already carried loss-priority end-to-end
+  (classifier + rewrite snapshots); the Rust dataplane dropped it at
+  ingest and collapsed differentiated rewrites via `.or_insert`. Re-keyed
+  `CoSDSCPRewriteRuleConfig` to `dscp_by_fc_lp: FastMap<(String,u8),u8>`,
+  added `lp_by_dscp`/`lp_by_pcp` to the classifier configs and a new
+  per-interface `CoSLossPriorityRewrite` (flattened DSCP/PCP -> LP tables
+  + `(queue_id, loss_priority)` -> code-point matrix) on `CoSState`. At
+  CoS TX classification the flow's loss-priority is resolved from its
+  ingress code-point (default LOW) and the (queue, LP) rewrite is folded
+  into `CoSTxSelection.dscp_rewrite` (filter rewrite keeps precedence),
+  cached per-flow. The per-queue drain fallback keeps only the
+  loss-priority-UNIFORM rewrite so it never misapplies. A rewrite entry
+  with no explicit loss-priority is a wildcard applying to all LPs
+  (backward-compat). Go: removed the now-stale "rewrite-rule loss-priority
+  not enforced" commit warning (enforced now) and refined the classifier
+  loss-priority warning (drives rewrite; drop-precedence/WRED still a gap).
+  RED-on-revert Rust test asserts voice/low->21, voice/high->31 (differ)
+  and a wildcard data rewrite->40 for both LPs. FULL cargo test SERIAL:
+  3704 passed / 0 failed (cos:: 563 passed). Go ./pkg/config/... green.
+  **File(s)**: userspace-dp/src/afxdp/types/cos.rs,
+  userspace-dp/src/afxdp/forwarding_build/cos.rs,
+  userspace-dp/src/afxdp/forwarding_build/tests.rs,
+  userspace-dp/src/afxdp/tx/cos_classify.rs,
+  userspace-dp/src/afxdp/tx/cos_classify_tests.rs,
+  pkg/config/compiler_validate_warn.go,
+  pkg/config/parser_class_of_service_test.go,
+  docs/cos-traffic-shaping.md, _Log.md

--- a/docs/cos-traffic-shaping.md
+++ b/docs/cos-traffic-shaping.md
@@ -1084,7 +1084,9 @@ Notes for this specific test:
 - DSCP rewrite-rules can also be attached under
   `class-of-service interfaces ... unit ... rewrite-rules dscp <name>` on
   shaped userspace egress interfaces; they apply after queue selection and act
-  as a fallback behind any explicit firewall-filter DSCP rewrite action
+  as a fallback behind any explicit firewall-filter DSCP rewrite action. The
+  rewrite is keyed on `(forwarding-class, loss-priority)` (#3995) — see the
+  loss-priority note below
 - 802.1p BA classifiers are also available as a fallback queue selector on
   userspace interfaces; they use the ingress VLAN PCP preserved from tagged
   XDP traffic, including priority-tagged frames with VLAN ID 0
@@ -1166,10 +1168,26 @@ Notes for this specific test:
   missed — and the measurement-only
   `xpf_fairness_equal_flow_unsampled_active_workers` estimator gauge
   (#1304) is unrelated to the removed cap.
-- `loss-priority` on CoS DSCP / 802.1p classifiers is accepted for syntax
-  compatibility but is not enforced yet
-- `loss-priority` on CoS DSCP rewrite-rules is accepted for syntax
-  compatibility but is not enforced yet
+- `loss-priority` on CoS DSCP rewrite-rules is **enforced** (#3995): the
+  userspace dataplane keys the egress DSCP rewrite on
+  `(forwarding-class, loss-priority)`, so a rule that rewrites
+  `<fc> low` and `<fc> high` to different code-points produces the
+  LOW code-point for a low-loss-priority flow and the HIGH code-point
+  for a high-loss-priority flow of that class. A rewrite entry with no
+  explicit `loss-priority` is a wildcard that applies to every
+  loss-priority (backward-compat). The loss-priority is taken from the
+  egress interface's DSCP / 802.1p classifier assignment for the flow's
+  ingress code-point (Junos default LOW when unclassified); it is
+  resolved once per flow and cached, exactly like the firewall-filter
+  DSCP rewrite. A single, loss-priority-uniform rewrite (or a wildcard)
+  is additionally baked into the per-queue drain fallback; differentiated
+  rules resolve per flow at classification time.
+- `loss-priority` on CoS DSCP / 802.1p classifiers now drives the egress
+  rewrite-rule selection above, but is still **not** enforced for
+  drop-precedence / WRED buffer management (a commit warning names the
+  remaining gap). Note the loss-priority is resolved per flow from the
+  seed packet's ingress code-point; a flow that changes its marking
+  mid-stream keeps the seed loss-priority for its cached rewrite.
 
 Suggested verification commands:
 

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -265,6 +265,21 @@ type compileOpts struct {
 	// lenientIPsecPolicyProposalRef.
 	lenientSchedulerMapRef bool
 
+	// lenientCoSLossPriority (#3995) downgrades the class-of-service
+	// classifier / rewrite-rule loss-priority value check
+	// (validateClassOfServiceLossPriorityStrict) from a hard error to a
+	// warning on the tolerant load / peer-sync paths. An unrecognized
+	// loss-priority (an operator typo like `medum-low`) is rejected at
+	// commit / commit-check so it is LOUD rather than silently applied as
+	// the default LOW / a wildcard by the dataplane, but a config
+	// persisted by an older binary — or synced from a peer — must still
+	// boot through it (warn) rather than fail-closed-on-load (#1960
+	// class). The dataplane's parse (cos_loss_priority_index in
+	// userspace-dp forwarding_build/cos.rs) maps an unrecognized value to
+	// the SAFE default, preserving the fail-SAFE posture on that boot.
+	// Same doctrine as lenientSchedulerMapRef.
+	lenientCoSLossPriority bool
+
 	// lenientIPsecGatewayRefs (#2074) downgrades the IPsec VPN -> IKE
 	// gateway cross-reference check from a hard error to a warning on the
 	// tolerant load / peer-sync paths (CompileConfigLenient /
@@ -1496,6 +1511,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientEventAttributesMatch:            true,
 		lenientIPsecPolicyProposalRef:          true,
 		lenientSchedulerMapRef:                 true,
+		lenientCoSLossPriority:                 true,
 		lenientIPsecGatewayRefs:                true,
 		lenientIKEPolicyChainRef:               true,
 		lenientIPsecTrafficSelectors:           true,
@@ -1739,6 +1755,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientEventAttributesMatch:            true,
 		lenientIPsecPolicyProposalRef:          true,
 		lenientSchedulerMapRef:                 true,
+		lenientCoSLossPriority:                 true,
 		lenientIPsecGatewayRefs:                true,
 		lenientIKEPolicyChainRef:               true,
 		lenientIPsecTrafficSelectors:           true,
@@ -2628,6 +2645,22 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientSchedulerMapRef {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("class-of-service scheduler-map reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #3995 class-of-service loss-priority value gate. Strict on commit /
+	// commit-check (hard-reject an unrecognized loss-priority such as an
+	// operator typo `medum-low`, which the dataplane would otherwise apply
+	// as the SAFE default LOW / wildcard — silently wrong QoS). Lenient on
+	// load / peer-sync (warn so an already-persisted or peer-synced config
+	// still boots — #1960 no-brick; the dataplane applies the SAFE default
+	// on that boot).
+	if err := validateClassOfServiceLossPriorityStrict(cfg.ClassOfService); err != nil {
+		if opts.lenientCoSLossPriority {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("class-of-service loss-priority (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -238,6 +238,115 @@ func validateClassOfServiceSchedulerMapRefsStrict(cos *ClassOfServiceConfig) err
 	return nil
 }
 
+// cosLossPriorityValues is the set of loss-priority values Junos accepts on a
+// class-of-service DSCP / 802.1p classifier or DSCP rewrite-rule. It mirrors
+// cos_loss_priority_index in userspace-dp forwarding_build/cos.rs.
+var cosLossPriorityValues = map[string]struct{}{
+	"low":         {},
+	"medium-low":  {},
+	"medium-high": {},
+	"high":        {},
+}
+
+// validateClassOfServiceLossPriorityStrict hard-rejects a class-of-service
+// classifier or DSCP rewrite-rule entry whose `loss-priority` value is not one
+// of the four Junos levels (low, medium-low, medium-high, high) — an operator
+// typo like `medum-low` (#3995). Junos rejects an unknown loss-priority at
+// commit; before this gate the raw string was threaded through to the
+// dataplane, where `cos_loss_priority_index` maps an unrecognized value to the
+// SAFE default (LOW for the classifier, a wildcard-over-all-loss-priorities for
+// the rewrite-rule). That default is correct for fail-safe boot but WRONG for a
+// fresh operator edit: the typo silently applies the wrong QoS class instead of
+// surfacing the mistake. Reject it loudly at commit / commit-check.
+//
+// An EMPTY loss-priority is skipped: it is the legitimate "no explicit
+// loss-priority" case (the rewrite-rule wildcard / classifier default), the
+// same placeholder the other CoS validators skip.
+//
+// On the tolerant load / peer-sync paths the call site downgrades this to a
+// warning (opts.lenientCoSLossPriority) so a config persisted by an older
+// binary — or synced from a peer — still boots (#1960 no-brick); the dataplane
+// applies the SAFE default on that boot. Entries are visited in sorted order so
+// commit-check surfaces a STABLE first-error message.
+func validateClassOfServiceLossPriorityStrict(cos *ClassOfServiceConfig) error {
+	if cos == nil {
+		return nil
+	}
+	checkEntry := func(kind, ruleName, className, lossPriority string) error {
+		if lossPriority == "" {
+			return nil
+		}
+		if _, ok := cosLossPriorityValues[lossPriority]; ok {
+			return nil
+		}
+		return fmt.Errorf(
+			"class-of-service %s %q forwarding-class %q has unrecognized loss-priority %q "+
+				"(must be one of: low, medium-low, medium-high, high)",
+			kind, ruleName, className, lossPriority)
+	}
+
+	dscpNames := make([]string, 0, len(cos.DSCPClassifiers))
+	for name := range cos.DSCPClassifiers {
+		dscpNames = append(dscpNames, name)
+	}
+	sort.Strings(dscpNames)
+	for _, name := range dscpNames {
+		classifier := cos.DSCPClassifiers[name]
+		if classifier == nil {
+			continue
+		}
+		for _, entry := range classifier.Entries {
+			if entry == nil {
+				continue
+			}
+			if err := checkEntry("classifiers dscp", classifier.Name, entry.ForwardingClass, entry.LossPriority); err != nil {
+				return err
+			}
+		}
+	}
+
+	ieeeNames := make([]string, 0, len(cos.IEEE8021Classifiers))
+	for name := range cos.IEEE8021Classifiers {
+		ieeeNames = append(ieeeNames, name)
+	}
+	sort.Strings(ieeeNames)
+	for _, name := range ieeeNames {
+		classifier := cos.IEEE8021Classifiers[name]
+		if classifier == nil {
+			continue
+		}
+		for _, entry := range classifier.Entries {
+			if entry == nil {
+				continue
+			}
+			if err := checkEntry("classifiers ieee-802.1", classifier.Name, entry.ForwardingClass, entry.LossPriority); err != nil {
+				return err
+			}
+		}
+	}
+
+	rewriteNames := make([]string, 0, len(cos.DSCPRewriteRules))
+	for name := range cos.DSCPRewriteRules {
+		rewriteNames = append(rewriteNames, name)
+	}
+	sort.Strings(rewriteNames)
+	for _, name := range rewriteNames {
+		rewriteRule := cos.DSCPRewriteRules[name]
+		if rewriteRule == nil {
+			continue
+		}
+		for _, entry := range rewriteRule.Entries {
+			if entry == nil {
+				continue
+			}
+			if err := checkEntry("rewrite-rules dscp", rewriteRule.Name, entry.ForwardingClass, entry.LossPriority); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // validateIPsecPolicyProposalReferencesStrict hard-rejects an IPsec
 // (Phase 2) policy whose `proposals` reference does not resolve to a
 // defined IPsec proposal (#2073). resolveESPSettings (pkg/ipsec/ike.go)

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -912,7 +912,6 @@ func ValidateConfig(cfg *Config) []string {
 
 	if cos := cfg.ClassOfService; cos != nil {
 		warnedClassifierLossPriority := false
-		warnedRewriteLossPriority := false
 		warnedPriorityLowMinShare := false
 		// #4315 (fable-167 F-2): a traffic-control-profile's guaranteed-rate
 		// and delay-buffer-rate are typed + stored so garbage is rejected at
@@ -1070,7 +1069,7 @@ func ValidateConfig(cfg *Config) []string {
 						classifier.Name, entry.ForwardingClass))
 				}
 				if entry.LossPriority != "" && !warnedClassifierLossPriority {
-					warnings = append(warnings, "class-of-service dscp/802.1p classifier loss-priority is accepted for compatibility but not yet enforced by the userspace dataplane")
+					warnings = append(warnings, "class-of-service dscp/802.1p classifier loss-priority now drives egress dscp rewrite-rule selection (#3995) but is not yet enforced for drop-precedence / WRED buffer management")
 					warnedClassifierLossPriority = true
 				}
 			}
@@ -1089,7 +1088,7 @@ func ValidateConfig(cfg *Config) []string {
 						classifier.Name, entry.ForwardingClass))
 				}
 				if entry.LossPriority != "" && !warnedClassifierLossPriority {
-					warnings = append(warnings, "class-of-service dscp/802.1p classifier loss-priority is accepted for compatibility but not yet enforced by the userspace dataplane")
+					warnings = append(warnings, "class-of-service dscp/802.1p classifier loss-priority now drives egress dscp rewrite-rule selection (#3995) but is not yet enforced for drop-precedence / WRED buffer management")
 					warnedClassifierLossPriority = true
 				}
 			}
@@ -1107,10 +1106,9 @@ func ValidateConfig(cfg *Config) []string {
 						"class-of-service dscp rewrite-rule %q references undefined forwarding-class %q",
 						rewriteRule.Name, entry.ForwardingClass))
 				}
-				if entry.LossPriority != "" && !warnedRewriteLossPriority {
-					warnings = append(warnings, "class-of-service dscp rewrite-rule loss-priority is accepted for compatibility but not yet enforced by the userspace dataplane")
-					warnedRewriteLossPriority = true
-				}
+				// #3995: the userspace dataplane now keys the egress DSCP
+				// rewrite on (forwarding-class, loss-priority), so a
+				// rewrite-rule loss-priority is ENFORCED — no warning.
 			}
 		}
 		// #4220 / #4219: priority-low-min-share (#1614 A2) is typed and

--- a/pkg/config/parser_class_of_service_test.go
+++ b/pkg/config/parser_class_of_service_test.go
@@ -1175,6 +1175,106 @@ func TestSchedulerMapDanglingSchedulerRejectedStrict(t *testing.T) {
 	}
 }
 
+// #3995: an operator typo in a class-of-service loss-priority value (e.g.
+// `medum-low` for `medium-low`) must be REJECTED at commit / commit-check, not
+// silently threaded to the dataplane and applied as the SAFE default LOW /
+// wildcard (wrong QoS, silently). The tolerant load / peer-sync path downgrades
+// it to a warning so an already-persisted config still boots (#1960 no-brick).
+//
+// FAIL-ON-REVERT: without validateClassOfServiceLossPriorityStrict the strict
+// CompileConfig would ACCEPT `medum-low` (it was never validated), and the
+// dataplane's cos_loss_priority_index would silently map it to LOW.
+func TestCoSLossPriorityTypoRejectedStrict(t *testing.T) {
+	compile := func(t *testing.T, input string) *ConfigTree {
+		t.Helper()
+		tree, errs := NewParser(input).Parse()
+		if len(errs) > 0 {
+			t.Fatalf("parse errors: %v", errs)
+		}
+		return tree
+	}
+
+	cases := []struct {
+		name    string
+		block   string
+		errFrag string
+	}{
+		{
+			name: "rewrite-rule",
+			block: `    rewrite-rules {
+        dscp rw {
+            forwarding-class voice {
+                loss-priority medum-low {
+                    code-point ef;
+                }
+            }
+        }
+    }`,
+			errFrag: `rewrite-rules dscp "rw" forwarding-class "voice" has unrecognized loss-priority "medum-low"`,
+		},
+		{
+			name: "dscp-classifier",
+			block: `    classifiers {
+        dscp ba {
+            forwarding-class voice {
+                loss-priority medum-low code-points ef;
+            }
+        }
+    }`,
+			errFrag: `classifiers dscp "ba" forwarding-class "voice" has unrecognized loss-priority "medum-low"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := "class-of-service {\n" +
+				"    forwarding-classes {\n" +
+				"        queue 0 best-effort;\n" +
+				"        queue 5 voice;\n" +
+				"    }\n" +
+				tc.block + "\n}\n"
+
+			// Strict commit path rejects the typo, naming the bad value and the
+			// valid set.
+			_, err := CompileConfig(compile(t, input))
+			if err == nil {
+				t.Fatal("CompileConfig accepted an unrecognized loss-priority; want rejection")
+			}
+			if !strings.Contains(err.Error(), tc.errFrag) {
+				t.Fatalf("strict error missing the typo substring: %q", err.Error())
+			}
+			if !strings.Contains(err.Error(), "must be one of: low, medium-low, medium-high, high") {
+				t.Fatalf("strict error missing the valid-value set: %q", err.Error())
+			}
+
+			// Tolerant load path downgrades to a warning and still compiles
+			// (#1960 no-brick).
+			cfg, err := CompileConfigLenient(compile(t, input))
+			if err != nil {
+				t.Fatalf("CompileConfigLenient rejected a persistable config with a bad loss-priority (#1960 brick): %v", err)
+			}
+			warnings := strings.Join(cfg.Warnings, "\n")
+			if !strings.Contains(warnings, "loss-priority (downgraded to warning on tolerant path)") ||
+				!strings.Contains(warnings, "unrecognized loss-priority") {
+				t.Fatalf("lenient path missing the downgraded loss-priority warning, got: %s", warnings)
+			}
+
+			// A valid loss-priority is unchanged on BOTH paths.
+			validInput := strings.Replace(input, "medum-low", "medium-low", 1)
+			if _, err := CompileConfig(compile(t, validInput)); err != nil {
+				t.Fatalf("CompileConfig rejected a VALID loss-priority medium-low: %v", err)
+			}
+			validCfg, err := CompileConfigLenient(compile(t, validInput))
+			if err != nil {
+				t.Fatalf("CompileConfigLenient rejected a valid loss-priority: %v", err)
+			}
+			if strings.Contains(strings.Join(validCfg.Warnings, "\n"), "unrecognized loss-priority") {
+				t.Fatalf("unexpected unrecognized-loss-priority warning for a valid value: %v", validCfg.Warnings)
+			}
+		})
+	}
+}
+
 func TestCompileClassOfServiceHierarchicalDSCPClassifier(t *testing.T) {
 	input := `class-of-service {
     forwarding-classes {

--- a/pkg/config/parser_class_of_service_test.go
+++ b/pkg/config/parser_class_of_service_test.go
@@ -1078,11 +1078,15 @@ func TestValidateClassOfServiceWarnings(t *testing.T) {
 	if !strings.Contains(warnings, `dscp rewrite-rule "edge-rewrite" references undefined forwarding-class "missing-class"`) {
 		t.Fatalf("expected undefined dscp rewrite-rule forwarding-class warning, got: %s", warnings)
 	}
-	if !strings.Contains(warnings, "dscp/802.1p classifier loss-priority is accepted for compatibility but not yet enforced") {
+	// #3995: classifier loss-priority now drives egress rewrite selection but
+	// still warns about the remaining drop-precedence / WRED gap.
+	if !strings.Contains(warnings, "classifier loss-priority now drives egress dscp rewrite-rule selection") {
 		t.Fatalf("expected classifier loss-priority warning, got: %s", warnings)
 	}
-	if !strings.Contains(warnings, "dscp rewrite-rule loss-priority is accepted for compatibility but not yet enforced") {
-		t.Fatalf("expected rewrite-rule loss-priority warning, got: %s", warnings)
+	// #3995: rewrite-rule loss-priority is now ENFORCED, so its old
+	// accepted-but-inert warning must NOT appear.
+	if strings.Contains(warnings, "dscp rewrite-rule loss-priority is accepted for compatibility but not yet enforced") {
+		t.Fatalf("did not expect the stale rewrite-rule loss-priority warning, got: %s", warnings)
 	}
 	if strings.Contains(warnings, "class-of-service shaping, classifier attachment, and dscp rewrite-rule attachment are only implemented in the userspace dataplane") {
 		t.Fatalf("unexpected dataplane warning for default userspace path: %s", warnings)

--- a/userspace-dp/src/afxdp/forwarding_build/cos.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/cos.rs
@@ -120,6 +120,125 @@ fn build_cos_ieee8021_queue_table(
     Ok(table)
 }
 
+/// #3995: map a Junos loss-priority string to an internal index
+/// (low=0, medium-low=1, medium-high=2, high=3). Returns `None` for an empty
+/// or unrecognized value; callers treat that as the default LOW (classifier)
+/// or a wildcard applying to every loss-priority (rewrite-rule).
+pub(super) fn cos_loss_priority_index(value: &str) -> Option<u8> {
+    match value {
+        "low" => Some(0),
+        "medium-low" => Some(1),
+        "medium-high" => Some(2),
+        "high" => Some(3),
+        _ => None,
+    }
+}
+
+/// #3995: flatten a DSCP classifier's `lp_by_dscp` into a fixed 64-entry table
+/// (index = DSCP code-point). `u8::MAX` marks an unclassified code-point
+/// (resolves to the default LOW loss-priority at classification time). Fails
+/// the snapshot CLOSED on an out-of-range code-point, mirroring
+/// `build_cos_dscp_queue_table` (#2447).
+fn build_cos_dscp_lp_table(
+    classifier_name: &str,
+    classifiers: &FastMap<String, CoSDSCPClassifierConfig>,
+) -> Result<[u8; 64], crate::policy::SnapshotIntegrityError> {
+    let mut table = [u8::MAX; 64];
+    if classifier_name.is_empty() {
+        return Ok(table);
+    }
+    if let Some(classifier) = classifiers.get(classifier_name) {
+        for (&dscp, &lp) in &classifier.lp_by_dscp {
+            let Some(slot) = table.get_mut(usize::from(dscp)) else {
+                return Err(
+                    crate::policy::SnapshotIntegrityError::CosDscpCodePointOutOfRange {
+                        classifier: classifier_name.to_string(),
+                        dscp,
+                    },
+                );
+            };
+            *slot = lp;
+        }
+    }
+    Ok(table)
+}
+
+/// #3995: flatten an 802.1p classifier's `lp_by_pcp` into a fixed 8-entry
+/// table. `u8::MAX` marks an unclassified code-point.
+fn build_cos_ieee8021_lp_table(
+    classifier_name: &str,
+    classifiers: &FastMap<String, CoSIEEE8021ClassifierConfig>,
+) -> Result<[u8; 8], crate::policy::SnapshotIntegrityError> {
+    let mut table = [u8::MAX; 8];
+    if classifier_name.is_empty() {
+        return Ok(table);
+    }
+    if let Some(classifier) = classifiers.get(classifier_name) {
+        for (&pcp, &lp) in &classifier.lp_by_pcp {
+            let Some(slot) = table.get_mut(usize::from(pcp)) else {
+                return Err(
+                    crate::policy::SnapshotIntegrityError::CosIeee8021CodePointOutOfRange {
+                        classifier: classifier_name.to_string(),
+                        pcp,
+                    },
+                );
+            };
+            *slot = lp;
+        }
+    }
+    Ok(table)
+}
+
+/// #3995: the loss-priority-INDEPENDENT rewrite for a forwarding-class, or
+/// `None`. `Some(v)` only when EVERY loss-priority maps to the same code-point
+/// `v` (a single-value / wildcard rule), so the per-queue drain fallback can
+/// apply it regardless of a packet's loss-priority without misapplying it.
+/// Loss-priority-differentiated (or partial) rules return `None` and are
+/// resolved per-flow at classification time.
+fn uniform_fc_rewrite(rule: &CoSDSCPRewriteRuleConfig, forwarding_class: &str) -> Option<u8> {
+    let first = rule
+        .dscp_by_fc_lp
+        .get(&(forwarding_class.to_string(), 0))
+        .copied()?;
+    (1..COS_LOSS_PRIORITY_LEVELS)
+        .all(|lp| {
+            rule.dscp_by_fc_lp
+                .get(&(forwarding_class.to_string(), lp))
+                .copied()
+                == Some(first)
+        })
+        .then_some(first)
+}
+
+/// #3995: build the per-egress-interface loss-priority classification + rewrite
+/// tables. Flattens the interface's classifiers into DSCP/PCP → loss-priority
+/// tables and builds the `(queue_id, loss_priority)` → code-point matrix from
+/// the interface's rewrite-rule over its materialized queues.
+fn build_cos_lp_rewrite(
+    iface: &InterfaceSnapshot,
+    cfg: &CoSInterfaceConfig,
+    tables: &ClassifierTables<'_>,
+) -> Result<CoSLossPriorityRewrite, crate::policy::SnapshotIntegrityError> {
+    let dscp_lp_by_dscp = build_cos_dscp_lp_table(&cfg.dscp_classifier, &tables.dscp_classifiers)?;
+    let ieee8021_lp_by_pcp =
+        build_cos_ieee8021_lp_table(&cfg.ieee8021_classifier, &tables.ieee8021_classifiers)?;
+    let mut dscp_rewrite_by_queue_lp: FastMap<(u8, u8), u8> = FastMap::default();
+    if let Some(rule) = tables.dscp_rewrite_rules.get(&iface.cos_dscp_rewrite_rule) {
+        for queue in &cfg.queues {
+            for lp in 0..COS_LOSS_PRIORITY_LEVELS {
+                if let Some(&dscp) = rule.dscp_by_fc_lp.get(&(queue.forwarding_class.clone(), lp)) {
+                    dscp_rewrite_by_queue_lp.insert((queue.queue_id, lp), dscp);
+                }
+            }
+        }
+    }
+    Ok(CoSLossPriorityRewrite {
+        dscp_lp_by_dscp,
+        ieee8021_lp_by_pcp,
+        dscp_rewrite_by_queue_lp,
+    })
+}
+
 /// Default burst size when interface or scheduler did not specify
 /// one. 1% of the rate floored at 64×1500 (~96 KB).
 ///
@@ -220,6 +339,7 @@ pub(super) fn build_cos_classifier_tables(
         .filter(|classifier| !classifier.name.is_empty())
         .map(|classifier| {
             let mut queue_by_dscp = FastMap::default();
+            let mut lp_by_dscp = FastMap::default();
             for entry in &classifier.entries {
                 if entry.forwarding_class.is_empty() {
                     continue;
@@ -227,13 +347,20 @@ pub(super) fn build_cos_classifier_tables(
                 let Some(queue_id) = class_to_queue.get(&entry.forwarding_class).copied() else {
                     continue;
                 };
+                // #3995: a classifier entry with no explicit loss-priority
+                // defaults to LOW (the Junos default drop-precedence).
+                let lp = cos_loss_priority_index(&entry.loss_priority).unwrap_or(0);
                 for dscp in &entry.dscp_values {
                     queue_by_dscp.insert(*dscp, queue_id);
+                    lp_by_dscp.insert(*dscp, lp);
                 }
             }
             (
                 classifier.name.clone(),
-                CoSDSCPClassifierConfig { queue_by_dscp },
+                CoSDSCPClassifierConfig {
+                    queue_by_dscp,
+                    lp_by_dscp,
+                },
             )
         })
         .collect::<FastMap<_, _>>();
@@ -243,6 +370,7 @@ pub(super) fn build_cos_classifier_tables(
         .filter(|classifier| !classifier.name.is_empty())
         .map(|classifier| {
             let mut queue_by_pcp = FastMap::default();
+            let mut lp_by_pcp = FastMap::default();
             for entry in &classifier.entries {
                 if entry.forwarding_class.is_empty() {
                     continue;
@@ -250,13 +378,18 @@ pub(super) fn build_cos_classifier_tables(
                 let Some(queue_id) = class_to_queue.get(&entry.forwarding_class).copied() else {
                     continue;
                 };
+                let lp = cos_loss_priority_index(&entry.loss_priority).unwrap_or(0);
                 for pcp in &entry.code_points {
                     queue_by_pcp.insert(*pcp, queue_id);
+                    lp_by_pcp.insert(*pcp, lp);
                 }
             }
             (
                 classifier.name.clone(),
-                CoSIEEE8021ClassifierConfig { queue_by_pcp },
+                CoSIEEE8021ClassifierConfig {
+                    queue_by_pcp,
+                    lp_by_pcp,
+                },
             )
         })
         .collect::<FastMap<_, _>>();
@@ -265,20 +398,40 @@ pub(super) fn build_cos_classifier_tables(
         .iter()
         .filter(|rewrite_rule| !rewrite_rule.name.is_empty())
         .map(|rewrite_rule| {
-            let mut dscp_by_forwarding_class = FastMap::default();
+            // #3995: key the rewrite on (forwarding-class, loss-priority). Two
+            // passes so a specific loss-priority entry always wins over a
+            // wildcard (no explicit loss-priority) one regardless of config
+            // order.
+            let mut dscp_by_fc_lp: FastMap<(String, u8), u8> = FastMap::default();
+            // Pass 1: entries WITH an explicit loss-priority.
             for entry in &rewrite_rule.entries {
                 if entry.forwarding_class.is_empty() {
                     continue;
                 }
-                dscp_by_forwarding_class
-                    .entry(entry.forwarding_class.clone())
-                    .or_insert(entry.dscp_value);
+                if let Some(lp) = cos_loss_priority_index(&entry.loss_priority) {
+                    dscp_by_fc_lp
+                        .entry((entry.forwarding_class.clone(), lp))
+                        .or_insert(entry.dscp_value);
+                }
+            }
+            // Pass 2: an entry with NO explicit loss-priority is a wildcard that
+            // applies to ALL loss-priorities (backward-compat) — filling only
+            // the slots a specific entry did not already claim.
+            for entry in &rewrite_rule.entries {
+                if entry.forwarding_class.is_empty() {
+                    continue;
+                }
+                if cos_loss_priority_index(&entry.loss_priority).is_none() {
+                    for lp in 0..COS_LOSS_PRIORITY_LEVELS {
+                        dscp_by_fc_lp
+                            .entry((entry.forwarding_class.clone(), lp))
+                            .or_insert(entry.dscp_value);
+                    }
+                }
             }
             (
                 rewrite_rule.name.clone(),
-                CoSDSCPRewriteRuleConfig {
-                    dscp_by_forwarding_class,
-                },
+                CoSDSCPRewriteRuleConfig { dscp_by_fc_lp },
             )
         })
         .collect::<FastMap<_, _>>();
@@ -445,12 +598,11 @@ pub(super) fn build_cos_iface_config(
                     burst_bytes,
                     transmit_rate_bytes,
                 ),
-                dscp_rewrite: dscp_rewrite_rule.and_then(|rewrite_rule| {
-                    rewrite_rule
-                        .dscp_by_forwarding_class
-                        .get(&entry.forwarding_class)
-                        .copied()
-                }),
+                // #3995: only the loss-priority-UNIFORM rewrite is baked into
+                // the per-queue drain fallback; differentiated rewrites are
+                // resolved per-flow at classification (see `uniform_fc_rewrite`).
+                dscp_rewrite: dscp_rewrite_rule
+                    .and_then(|rewrite_rule| uniform_fc_rewrite(rewrite_rule, &entry.forwarding_class)),
                 // #1614 A3: per-queue CoDel target from scheduler. 0
                 // disables CoDel for the queue (current default).
                 codel_target_ns: scheduler
@@ -502,9 +654,9 @@ pub(super) fn build_cos_iface_config(
         .unwrap_or(false);
     let dscp_rewrite_targets_iface_class = dscp_rewrite_rule
         .map(|r| {
-            r.dscp_by_forwarding_class
+            r.dscp_by_fc_lp
                 .keys()
-                .any(|fc| iface_classes.contains(&fc.as_str()))
+                .any(|(fc, _lp)| iface_classes.contains(&fc.as_str()))
         })
         .unwrap_or(false);
 
@@ -534,11 +686,9 @@ pub(super) fn build_cos_iface_config(
             equal_flow_target_policy: EqualFlowTargetPolicy::default(),
             surplus_weight: 1,
             buffer_bytes: burst_bytes,
+            // #3995: uniform-only fallback (see the scheduler-map queue above).
             dscp_rewrite: dscp_rewrite_rule
-                .and_then(|rewrite_rule| {
-                    rewrite_rule.dscp_by_forwarding_class.get("best-effort")
-                })
-                .copied(),
+                .and_then(|rewrite_rule| uniform_fc_rewrite(rewrite_rule, "best-effort")),
             // #1614 A3: synthetic best-effort queue has no scheduler;
             // CoDel disabled by default (0 = off).
             codel_target_ns: 0,
@@ -644,6 +794,11 @@ pub(super) fn build_cos_state(
             continue;
         }
         if let Some(cfg) = build_cos_iface_config(iface, &tables)? {
+            // #3995: build the per-interface loss-priority classification +
+            // rewrite tables alongside the interface config so the DSCP rewrite
+            // resolves on (forwarding-class, loss-priority) at TX time.
+            let lp_rewrite = build_cos_lp_rewrite(iface, &cfg, &tables)?;
+            state.lp_rewrite.insert(iface.ifindex, lp_rewrite);
             state.interfaces.insert(iface.ifindex, cfg);
         }
     }

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -1030,15 +1030,28 @@ fn build_cos_state_binds_dscp_classifier_to_usable_interface_queue_ids() {
     let iface = state.interfaces.get(&42).expect("missing CoS interface");
     assert_eq!(iface.dscp_classifier, "wan-classifier");
     assert_eq!(iface.ieee8021_classifier, "wan-pcp");
+    // #3995: a single (voice, low) rewrite is loss-priority-DIFFERENTIATED
+    // (only LOW is set), so it is NOT baked into the per-queue drain fallback
+    // (which is uniform-only); it resolves per-flow via `lp_rewrite` instead.
     assert_eq!(
         iface
             .queues
             .iter()
             .find(|queue| queue.queue_id == 5)
             .and_then(|queue| queue.dscp_rewrite),
-        Some(46)
+        None
     );
     assert!(iface.queues.iter().any(|queue| queue.queue_id == 5));
+    // #3995: voice (queue 5) is classified LOW (index 0) for DSCP 46, and the
+    // rewrite-rule maps (voice, low) -> 46, so the loss-priority matrix carries
+    // (queue 5, low) -> 46.
+    let lp_rewrite = state
+        .lp_rewrite
+        .get(&42)
+        .expect("missing lp_rewrite for CoS interface");
+    assert_eq!(lp_rewrite.dscp_rewrite_by_queue_lp.get(&(5, 0)), Some(&46));
+    assert_eq!(lp_rewrite.dscp_lp_by_dscp[46], 0);
+    assert_eq!(lp_rewrite.dscp_lp_by_dscp[0], 0);
     let classifier = state
         .dscp_classifiers
         .get("wan-classifier")

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -112,19 +112,32 @@ pub(in crate::afxdp) fn resolve_cached_cos_tx_selection(
         // an EF fragment lands in its BA queue instead of straddling the
         // default queue. Filter forwarding-class / rewrite needs the flow
         // key, so those stay unset (as before).
+        let queue_id = iface.map(|iface| {
+            resolve_cos_dscp_classifier_queue_id(iface, meta.dscp)
+                .or_else(|| {
+                    resolve_cos_ieee8021_classifier_queue_id(
+                        iface,
+                        meta.ingress_pcp,
+                        meta.ingress_vlan_present != 0,
+                    )
+                })
+                .unwrap_or(iface.default_queue)
+        });
+        // #3995: flowless packets still resolve the loss-priority-aware CoS
+        // rewrite from their own DSCP/PCP (default LOW when unclassified).
+        let dscp_rewrite = queue_id.and_then(|queue_id| {
+            resolve_cos_queue_lp_rewrite(
+                forwarding,
+                egress_ifindex,
+                queue_id,
+                meta.dscp,
+                meta.ingress_pcp,
+                meta.ingress_vlan_present != 0,
+            )
+        });
         return CachedTxSelectionDescriptor {
-            queue_id: iface.map(|iface| {
-                resolve_cos_dscp_classifier_queue_id(iface, meta.dscp)
-                    .or_else(|| {
-                        resolve_cos_ieee8021_classifier_queue_id(
-                            iface,
-                            meta.ingress_pcp,
-                            meta.ingress_vlan_present != 0,
-                        )
-                    })
-                    .unwrap_or(iface.default_queue)
-            }),
-            dscp_rewrite: None,
+            queue_id,
+            dscp_rewrite,
             drop: false,
             reject: false,
             filter_counters: crate::filter::CachedFilterCounters::default(),
@@ -281,9 +294,27 @@ pub(in crate::afxdp) fn resolve_cached_cos_tx_selection(
             !iface.dscp_classifier.is_empty() || !iface.ieee8021_classifier.is_empty()
         });
 
+    // #3995: fold the loss-priority-aware CoS rewrite-rule DSCP for the chosen
+    // queue (filter DSCP rewrite keeps precedence). The loss-priority derives
+    // from the seed packet's ingress DSCP/PCP; for a BA-reclassify flow the
+    // frozen queue may shift per packet, so the resolved rewrite reflects the
+    // seed packet's queue/loss-priority (correct for the common stable-marking
+    // flow; a mixed-marking flow keeps the seed rewrite rather than tracking
+    // every packet's loss-priority).
+    let cos_rewrite = queue_id.and_then(|queue_id| {
+        resolve_cos_queue_lp_rewrite(
+            forwarding,
+            egress_ifindex,
+            queue_id,
+            meta.dscp,
+            meta.ingress_pcp,
+            meta.ingress_vlan_present != 0,
+        )
+    });
+
     CachedTxSelectionDescriptor {
         queue_id,
-        dscp_rewrite: effective_dscp_rewrite,
+        dscp_rewrite: effective_dscp_rewrite.or(cos_rewrite),
         drop: output_result.action != crate::filter::FilterAction::Accept,
         // #3608: the cached-descriptor `drop` above is the OUTPUT filter's
         // terminal action only (the three-color policer runs separately at
@@ -405,19 +436,32 @@ fn resolve_cos_tx_selection_internal(
         // 5-tuple-independent behavior-aggregate (DSCP / 802.1p) lookup from
         // `meta` so a marked fragment lands in its BA queue rather than the
         // default queue. Mirrors the cached-path None branch.
+        let queue_id = iface.map(|iface| {
+            resolve_cos_dscp_classifier_queue_id(iface, meta.dscp)
+                .or_else(|| {
+                    resolve_cos_ieee8021_classifier_queue_id(
+                        iface,
+                        meta.ingress_pcp,
+                        meta.ingress_vlan_present != 0,
+                    )
+                })
+                .unwrap_or(iface.default_queue)
+        });
+        // #3995: flowless packets still resolve the loss-priority-aware CoS
+        // rewrite from their own DSCP/PCP (default LOW when unclassified).
+        let dscp_rewrite = queue_id.and_then(|queue_id| {
+            resolve_cos_queue_lp_rewrite(
+                forwarding,
+                egress_ifindex,
+                queue_id,
+                meta.dscp,
+                meta.ingress_pcp,
+                meta.ingress_vlan_present != 0,
+            )
+        });
         return CoSTxSelection {
-            queue_id: iface.map(|iface| {
-                resolve_cos_dscp_classifier_queue_id(iface, meta.dscp)
-                    .or_else(|| {
-                        resolve_cos_ieee8021_classifier_queue_id(
-                            iface,
-                            meta.ingress_pcp,
-                            meta.ingress_vlan_present != 0,
-                        )
-                    })
-                    .unwrap_or(iface.default_queue)
-            }),
-            dscp_rewrite: None,
+            queue_id,
+            dscp_rewrite,
             drop: false,
             reject: false,
             filter_log: None,
@@ -603,57 +647,89 @@ fn resolve_cos_tx_selection_internal(
             filter_log,
         };
     };
-    if let Some(forwarding_class) = output_result.forwarding_class {
-        if let Some(queue_id) = iface.queue_by_forwarding_class.get(forwarding_class) {
-            return CoSTxSelection {
-                queue_id: Some(*queue_id),
-                dscp_rewrite: effective_dscp_rewrite,
-                drop,
-                reject,
-                filter_log,
-            };
-        }
-    }
-    if let Some(forwarding_class) = ingress_forwarding_class {
-        if let Some(queue_id) = iface.queue_by_forwarding_class.get(forwarding_class) {
-            return CoSTxSelection {
-                queue_id: Some(*queue_id),
-                dscp_rewrite: effective_dscp_rewrite,
-                drop,
-                reject,
-                filter_log,
-            };
-        }
-    }
-    if let Some(queue_id) = resolve_cos_dscp_classifier_queue_id(iface, meta.dscp) {
-        return CoSTxSelection {
-            queue_id: Some(queue_id),
-            dscp_rewrite: effective_dscp_rewrite,
-            drop,
-            reject,
-            filter_log,
-        };
-    }
-    if let Some(queue_id) = resolve_cos_ieee8021_classifier_queue_id(
-        iface,
+    // Queue selection precedence: the output-filter forwarding-class, then the
+    // ingress input-filter forwarding-class, then the DSCP behavior-aggregate
+    // classifier, then the 802.1p classifier, then the interface default queue.
+    let queue_id = output_result
+        .forwarding_class
+        .and_then(|forwarding_class| iface.queue_by_forwarding_class.get(forwarding_class).copied())
+        .or_else(|| {
+            ingress_forwarding_class.and_then(|forwarding_class| {
+                iface.queue_by_forwarding_class.get(forwarding_class).copied()
+            })
+        })
+        .or_else(|| resolve_cos_dscp_classifier_queue_id(iface, meta.dscp))
+        .or_else(|| {
+            resolve_cos_ieee8021_classifier_queue_id(
+                iface,
+                meta.ingress_pcp,
+                meta.ingress_vlan_present != 0,
+            )
+        })
+        .unwrap_or(iface.default_queue);
+    // #3995: fold the loss-priority-aware CoS rewrite-rule DSCP for the chosen
+    // queue. A filter DSCP rewrite (`effective_dscp_rewrite`) still takes
+    // precedence; the CoS rewrite-rule only fills the gap, matching the drain
+    // ordering `req.dscp_rewrite.or(queue_dscp_rewrite)` this replaces.
+    let cos_rewrite = resolve_cos_queue_lp_rewrite(
+        forwarding,
+        egress_ifindex,
+        queue_id,
+        meta.dscp,
         meta.ingress_pcp,
         meta.ingress_vlan_present != 0,
-    ) {
-        return CoSTxSelection {
-            queue_id: Some(queue_id),
-            dscp_rewrite: effective_dscp_rewrite,
-            drop,
-            reject,
-            filter_log,
-        };
-    }
+    );
     CoSTxSelection {
-        queue_id: Some(iface.default_queue),
-        dscp_rewrite: effective_dscp_rewrite,
+        queue_id: Some(queue_id),
+        dscp_rewrite: effective_dscp_rewrite.or(cos_rewrite),
         drop,
         reject,
         filter_log,
     }
+}
+
+/// #3995: resolve THIS packet's classifier-assigned loss-priority on the egress
+/// interface (index 0=low .. 3=high). Mirrors the BA queue-selection order —
+/// the DSCP classifier first, then 802.1p (when the frame carries a VLAN tag),
+/// then the Junos default LOW for an unclassified code-point.
+fn resolve_cos_loss_priority(
+    lp: &CoSLossPriorityRewrite,
+    dscp: u8,
+    ingress_pcp: u8,
+    vlan_present: bool,
+) -> u8 {
+    let dscp_lp = lp.dscp_lp_by_dscp[usize::from(dscp & 0x3f)];
+    if dscp_lp != u8::MAX {
+        return dscp_lp;
+    }
+    if vlan_present {
+        if let Some(&pcp_lp) = lp.ieee8021_lp_by_pcp.get(usize::from(ingress_pcp)) {
+            if pcp_lp != u8::MAX {
+                return pcp_lp;
+            }
+        }
+    }
+    0
+}
+
+/// #3995: resolve the egress DSCP rewrite for (this packet's egress queue, this
+/// packet's classifier loss-priority). Returns `None` when the interface has no
+/// loss-priority rewrite tables, or the (queue, loss-priority) pair has no
+/// configured code-point — so the caller keeps any filter DSCP rewrite / no
+/// rewrite. This is deterministic per flow (the loss-priority derives from the
+/// flow's ingress code-point) and is therefore cached per-flow exactly like the
+/// pre-existing filter DSCP rewrite.
+fn resolve_cos_queue_lp_rewrite(
+    forwarding: &ForwardingState,
+    egress_ifindex: i32,
+    queue_id: u8,
+    dscp: u8,
+    ingress_pcp: u8,
+    vlan_present: bool,
+) -> Option<u8> {
+    let lp = forwarding.cos.lp_rewrite.get(&egress_ifindex)?;
+    let plp = resolve_cos_loss_priority(lp, dscp, ingress_pcp, vlan_present);
+    lp.dscp_rewrite_by_queue_lp.get(&(queue_id, plp)).copied()
 }
 
 fn resolve_cos_dscp_classifier_queue_id(iface: &CoSInterfaceConfig, dscp: u8) -> Option<u8> {

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -9,9 +9,10 @@ use crate::afxdp::types::SharedCoSExactBacklog;
 use crate::filter::TermMatchExtra;
 use crate::{
     ClassOfServiceSnapshot, CoSDSCPClassifierEntrySnapshot, CoSDSCPClassifierSnapshot,
-    CoSForwardingClassSnapshot, CoSIEEE8021ClassifierEntrySnapshot, CoSIEEE8021ClassifierSnapshot,
-    CoSSchedulerMapEntrySnapshot, CoSSchedulerMapSnapshot, CoSSchedulerSnapshot,
-    FirewallFilterSnapshot, FirewallTermSnapshot, ThreeColorPolicerSnapshot,
+    CoSDSCPRewriteRuleEntrySnapshot, CoSDSCPRewriteRuleSnapshot, CoSForwardingClassSnapshot,
+    CoSIEEE8021ClassifierEntrySnapshot, CoSIEEE8021ClassifierSnapshot, CoSSchedulerMapEntrySnapshot,
+    CoSSchedulerMapSnapshot, CoSSchedulerSnapshot, FirewallFilterSnapshot, FirewallTermSnapshot,
+    ThreeColorPolicerSnapshot,
 };
 
 // #hb166 T-4: an explicit request for a queue this interface does NOT
@@ -2613,6 +2614,223 @@ fn resolve_cos_tx_selection_preserves_output_filter_dscp_rewrite_without_forward
 
     assert_eq!(selection.queue_id, Some(7));
     assert_eq!(selection.dscp_rewrite, Some(46));
+}
+
+// #3995: a CoS DSCP rewrite-rule keys on (forwarding-class, loss-priority).
+// A rule that rewrites `voice low` and `voice high` to DIFFERENT code-points
+// must produce the LOW code-point for a low-loss-priority flow and the HIGH
+// code-point for a high-loss-priority flow of the same forwarding-class. A
+// rewrite entry with NO explicit loss-priority is a wildcard that applies to
+// every loss-priority (backward-compat).
+//
+// FAIL-ON-REVERT: the pre-fix code keyed the rewrite on forwarding-class only
+// (`dscp_by_forwarding_class` + `.or_insert`), collapsing (voice, low) and
+// (voice, high) to whichever appeared first — so BOTH flows would resolve to
+// the SAME code-point and the `21 != 31` distinction (asserted below) would
+// vanish. Reverting also drops the rewrite out of `CoSTxSelection.dscp_rewrite`
+// entirely (it was applied at drain), flipping the `Some(..)` assertions to
+// `None`.
+#[test]
+fn cos_dscp_rewrite_keys_on_forwarding_class_and_loss_priority() {
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: 202,
+            hardware_addr: "02:bf:72:00:80:08".into(),
+            cos_shaping_rate_bytes_per_sec: 10_000_000,
+            cos_shaping_burst_bytes: 256_000,
+            cos_scheduler_map: "wan-map".into(),
+            cos_dscp_classifier: "ba".into(),
+            cos_dscp_rewrite_rule: "rw".into(),
+            ..Default::default()
+        }],
+        class_of_service: Some(ClassOfServiceSnapshot {
+            forwarding_classes: vec![
+                CoSForwardingClassSnapshot {
+                    name: "best-effort".into(),
+                    queue: 0,
+                },
+                CoSForwardingClassSnapshot {
+                    name: "voice".into(),
+                    queue: 1,
+                },
+                CoSForwardingClassSnapshot {
+                    name: "data".into(),
+                    queue: 2,
+                },
+            ],
+            // The egress DSCP classifier assigns BOTH the queue (via
+            // forwarding-class) AND the loss-priority per code-point.
+            dscp_classifiers: vec![CoSDSCPClassifierSnapshot {
+                name: "ba".into(),
+                entries: vec![
+                    CoSDSCPClassifierEntrySnapshot {
+                        forwarding_class: "voice".into(),
+                        loss_priority: "low".into(),
+                        dscp_values: vec![10],
+                    },
+                    CoSDSCPClassifierEntrySnapshot {
+                        forwarding_class: "voice".into(),
+                        loss_priority: "high".into(),
+                        dscp_values: vec![46],
+                    },
+                    CoSDSCPClassifierEntrySnapshot {
+                        forwarding_class: "data".into(),
+                        loss_priority: "low".into(),
+                        dscp_values: vec![18],
+                    },
+                    CoSDSCPClassifierEntrySnapshot {
+                        forwarding_class: "data".into(),
+                        loss_priority: "high".into(),
+                        dscp_values: vec![20],
+                    },
+                ],
+            }],
+            ieee8021_classifiers: vec![],
+            dscp_rewrite_rules: vec![CoSDSCPRewriteRuleSnapshot {
+                name: "rw".into(),
+                entries: vec![
+                    // voice: loss-priority-DIFFERENTIATED.
+                    CoSDSCPRewriteRuleEntrySnapshot {
+                        forwarding_class: "voice".into(),
+                        loss_priority: "low".into(),
+                        dscp_value: 21,
+                    },
+                    CoSDSCPRewriteRuleEntrySnapshot {
+                        forwarding_class: "voice".into(),
+                        loss_priority: "high".into(),
+                        dscp_value: 31,
+                    },
+                    // data: NO explicit loss-priority → wildcard (all LPs).
+                    CoSDSCPRewriteRuleEntrySnapshot {
+                        forwarding_class: "data".into(),
+                        loss_priority: String::new(),
+                        dscp_value: 40,
+                    },
+                ],
+            }],
+            schedulers: vec![
+                CoSSchedulerSnapshot {
+                    name: "be-sched".into(),
+                    transmit_rate_bytes: 2_000_000,
+                    transmit_rate_exact: false,
+                    priority: "low".into(),
+                    buffer_size_bytes: 64_000,
+                    buffer_size_percent: 0.0,
+                    surplus_sharing: false,
+                    equal_flow_enforcement: false,
+                    equal_flow_target_policy: String::new(),
+                    codel_target_ns: 0,
+                },
+                CoSSchedulerSnapshot {
+                    name: "voice-sched".into(),
+                    transmit_rate_bytes: 4_000_000,
+                    transmit_rate_exact: false,
+                    priority: "strict-high".into(),
+                    buffer_size_bytes: 64_000,
+                    buffer_size_percent: 0.0,
+                    surplus_sharing: false,
+                    equal_flow_enforcement: false,
+                    equal_flow_target_policy: String::new(),
+                    codel_target_ns: 0,
+                },
+                CoSSchedulerSnapshot {
+                    name: "data-sched".into(),
+                    transmit_rate_bytes: 4_000_000,
+                    transmit_rate_exact: false,
+                    priority: "medium-high".into(),
+                    buffer_size_bytes: 64_000,
+                    buffer_size_percent: 0.0,
+                    surplus_sharing: false,
+                    equal_flow_enforcement: false,
+                    equal_flow_target_policy: String::new(),
+                    codel_target_ns: 0,
+                },
+            ],
+            scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                name: "wan-map".into(),
+                entries: vec![
+                    CoSSchedulerMapEntrySnapshot {
+                        forwarding_class: "best-effort".into(),
+                        scheduler: "be-sched".into(),
+                    },
+                    CoSSchedulerMapEntrySnapshot {
+                        forwarding_class: "voice".into(),
+                        scheduler: "voice-sched".into(),
+                    },
+                    CoSSchedulerMapEntrySnapshot {
+                        forwarding_class: "data".into(),
+                        scheduler: "data-sched".into(),
+                    },
+                ],
+            }],
+        }),
+        ..Default::default()
+    };
+    let forwarding = build_forwarding_state(&snapshot);
+
+    // Resolve the egress DSCP rewrite for a flow whose ingress DSCP is `dscp`.
+    let rewrite_for = |dscp: u8| -> Option<u8> {
+        let meta = UserspaceDpMeta {
+            ingress_ifindex: 5,
+            addr_family: libc::AF_INET as u8,
+            dscp,
+            ..Default::default()
+        };
+        let key = SessionKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+            src_port: 12345,
+            dst_port: 443,
+        };
+        let selection =
+            resolve_cos_tx_selection(&forwarding, 202, meta, Some(&key), TermMatchExtra::default());
+        // The cached-descriptor path must resolve identically.
+        let cached = resolve_cached_cos_tx_selection(&forwarding, 202, meta, Some(&key));
+        assert_eq!(
+            selection.dscp_rewrite, cached.dscp_rewrite,
+            "runtime and cached CoS rewrite must agree for DSCP {dscp}",
+        );
+        selection.dscp_rewrite
+    };
+
+    // voice/low (DSCP 10) → 21, voice/high (DSCP 46) → 31. The two MUST differ
+    // — the whole point of loss-priority keying.
+    let voice_low = rewrite_for(10);
+    let voice_high = rewrite_for(46);
+    assert_eq!(voice_low, Some(21), "voice low-loss-priority rewrite");
+    assert_eq!(voice_high, Some(31), "voice high-loss-priority rewrite");
+    assert_ne!(
+        voice_low, voice_high,
+        "#3995: loss-priority must NOT collapse (fc, low) and (fc, high)",
+    );
+
+    // data has a wildcard (no loss-priority) rewrite → the SAME code-point for
+    // low and high loss-priority (backward-compat).
+    assert_eq!(rewrite_for(18), Some(40), "data low → wildcard rewrite");
+    assert_eq!(rewrite_for(20), Some(40), "data high → wildcard rewrite");
+
+    // The uniform-only per-queue drain fallback must be None for the
+    // differentiated voice class and Some(40) for the wildcard data class.
+    let iface = forwarding
+        .cos
+        .interfaces
+        .get(&202)
+        .expect("missing CoS interface");
+    let voice_queue = iface
+        .queues
+        .iter()
+        .find(|q| q.forwarding_class == "voice")
+        .expect("missing voice queue");
+    assert_eq!(voice_queue.dscp_rewrite, None);
+    let data_queue = iface
+        .queues
+        .iter()
+        .find(|q| q.forwarding_class == "data")
+        .expect("missing data queue");
+    assert_eq!(data_queue.dscp_rewrite, Some(40));
 }
 
 // #1829 Phase 1: `enqueue_cos_item` is the single CoS admission choke

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -20,9 +20,13 @@ pub(in crate::afxdp) struct CoSState {
     pub(in crate::afxdp) ieee8021_classifiers: FastMap<String, CoSIEEE8021ClassifierConfig>,
     pub(in crate::afxdp) dscp_rewrite_rules: FastMap<String, CoSDSCPRewriteRuleConfig>,
     /// #3995: per-egress-interface loss-priority classification + rewrite
-    /// tables, keyed by ifindex. Absent for interfaces with no CoS classifier /
-    /// rewrite-rule. Resolved at TX classification to key the DSCP rewrite on
-    /// `(forwarding-class, loss-priority)` instead of forwarding-class alone.
+    /// tables, keyed by ifindex. `build_cos_state` inserts one entry for every
+    /// interface that passes the useful-CoS gate (`build_cos_iface_config`), so
+    /// it is present for the SAME interface set as `interfaces`; the tables are
+    /// empty (no loss-priority classification, no rewrite entries) when the
+    /// interface has no classifier / rewrite-rule. Resolved at TX
+    /// classification to key the DSCP rewrite on `(forwarding-class,
+    /// loss-priority)` instead of forwarding-class alone.
     pub(in crate::afxdp) lp_rewrite: FastMap<i32, CoSLossPriorityRewrite>,
 }
 

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -19,6 +19,11 @@ pub(in crate::afxdp) struct CoSState {
     pub(in crate::afxdp) dscp_classifiers: FastMap<String, CoSDSCPClassifierConfig>,
     pub(in crate::afxdp) ieee8021_classifiers: FastMap<String, CoSIEEE8021ClassifierConfig>,
     pub(in crate::afxdp) dscp_rewrite_rules: FastMap<String, CoSDSCPRewriteRuleConfig>,
+    /// #3995: per-egress-interface loss-priority classification + rewrite
+    /// tables, keyed by ifindex. Absent for interfaces with no CoS classifier /
+    /// rewrite-rule. Resolved at TX classification to key the DSCP rewrite on
+    /// `(forwarding-class, loss-priority)` instead of forwarding-class alone.
+    pub(in crate::afxdp) lp_rewrite: FastMap<i32, CoSLossPriorityRewrite>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -58,19 +63,60 @@ pub(in crate::afxdp) struct CoSInterfaceConfig {
     pub(in crate::afxdp) priority_low_min_share_bytes: u64,
 }
 
+/// Number of Junos loss-priority levels: low, medium-low, medium-high, high.
+/// Indexed 0..=3 by `cos_loss_priority_index` in `forwarding_build/cos.rs`
+/// (low=0 .. high=3). The classifier assigns one per code-point; the rewrite
+/// rule keys on (forwarding-class, loss-priority).
+pub(in crate::afxdp) const COS_LOSS_PRIORITY_LEVELS: u8 = 4;
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(in crate::afxdp) struct CoSDSCPClassifierConfig {
     pub(in crate::afxdp) queue_by_dscp: FastMap<u8, u8>,
+    /// #3995: behavior-aggregate loss-priority assigned per DSCP code-point
+    /// (index 0=low .. 3=high). Parallel to `queue_by_dscp` — the same
+    /// classifier entry that maps a DSCP to a forwarding-class (→ queue) also
+    /// maps it to a loss-priority, which the egress rewrite-rule keys on.
+    pub(in crate::afxdp) lp_by_dscp: FastMap<u8, u8>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(in crate::afxdp) struct CoSIEEE8021ClassifierConfig {
     pub(in crate::afxdp) queue_by_pcp: FastMap<u8, u8>,
+    /// #3995: loss-priority assigned per 802.1p code-point (index 0=low ..
+    /// 3=high). Parallel to `queue_by_pcp`.
+    pub(in crate::afxdp) lp_by_pcp: FastMap<u8, u8>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(in crate::afxdp) struct CoSDSCPRewriteRuleConfig {
-    pub(in crate::afxdp) dscp_by_forwarding_class: FastMap<String, u8>,
+    /// #3995: egress DSCP rewrite keyed on `(forwarding_class, loss_priority)`.
+    /// Junos rewrite-rules match a (forwarding-class, loss-priority) pair to a
+    /// code-point, so a rule that rewrites `voice low` and `voice high` to
+    /// different DSCPs must NOT collapse to forwarding-class only (the pre-fix
+    /// `.or_insert` on a `FastMap<String, u8>` silently dropped every entry but
+    /// the first). A rule with no explicit loss-priority is a wildcard: it
+    /// fills all four loss-priority slots (backward-compat).
+    pub(in crate::afxdp) dscp_by_fc_lp: FastMap<(String, u8), u8>,
+}
+
+/// #3995: per-egress-interface loss-priority classification + rewrite tables,
+/// stored on `CoSState::lp_rewrite` keyed by ifindex. Resolved at CoS TX
+/// classification time (`tx/cos_classify.rs`) to select the correct
+/// `(forwarding-class, loss-priority)` rewrite for THIS flow, then cached
+/// per-flow exactly like the pre-existing filter DSCP rewrite.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::afxdp) struct CoSLossPriorityRewrite {
+    /// Flattened DSCP → loss-priority (0..3) for the egress interface's DSCP
+    /// classifier. `u8::MAX` = the code-point is unclassified (resolves to the
+    /// Junos default loss-priority LOW).
+    pub(in crate::afxdp) dscp_lp_by_dscp: [u8; 64],
+    /// Flattened 802.1p PCP → loss-priority (0..3). `u8::MAX` = unclassified.
+    pub(in crate::afxdp) ieee8021_lp_by_pcp: [u8; 8],
+    /// `(queue_id, loss_priority)` → egress DSCP code-point. Populated for the
+    /// interface's materialized queues from the interface's rewrite-rule. The
+    /// full loss-priority matrix (not just LOW) so a differentiated rule is
+    /// applied per-flow.
+    pub(in crate::afxdp) dscp_rewrite_by_queue_lp: FastMap<(u8, u8), u8>,
 }
 
 /// #1746: operator-selectable equal-flow target policy. Decides the
@@ -227,6 +273,15 @@ pub(in crate::afxdp) struct CoSQueueConfig {
     pub(in crate::afxdp) equal_flow_target_policy: EqualFlowTargetPolicy,
     pub(in crate::afxdp) surplus_weight: u32,
     pub(in crate::afxdp) buffer_bytes: u64,
+    /// #3995: loss-priority-INDEPENDENT egress DSCP rewrite applied at drain as
+    /// a fallback. `Some` ONLY when the forwarding-class rewrites EVERY
+    /// loss-priority to the SAME code-point (a single-value / wildcard rule),
+    /// so applying it regardless of a packet's loss-priority is always correct.
+    /// Loss-priority-DIFFERENTIATED rewrites resolve per-flow at CoS TX
+    /// classification via `CoSLossPriorityRewrite.dscp_rewrite_by_queue_lp` and
+    /// are cached in the flow's `dscp_rewrite`; this stays `None` for them so
+    /// the drain fallback never misapplies one loss-priority's code-point to a
+    /// packet of another (the #3995 collapse bug).
     pub(in crate::afxdp) dscp_rewrite: Option<u8>,
     /// #1614 A3: per-queue CoDel target in nanoseconds. WIRE
     /// SURFACE ONLY in PR #1618 — dequeue-time sojourn check


### PR DESCRIPTION
## Summary

Closes #3995.

A Junos CoS DSCP/802.1p rewrite-rule matches on **(forwarding-class, loss-priority)**, but the userspace dataplane keyed the egress DSCP rewrite on forwarding-class alone. A rule that rewrites `voice low` and `voice high` to different code-points was silently collapsed — the Rust ingest dropped the loss-priority and `.or_insert` kept only the first entry per class, so every packet of that class got one code-point.

The Go config layer already carried loss-priority end-to-end on both the classifier and rewrite-rule snapshots (`CoSDSCPClassifierEntrySnapshot.LossPriority`, `CoSDSCPRewriteRuleEntrySnapshot.LossPriority`); it was dropped only at the Rust dataplane ingest. This threads it through — no #2507 per-packet policer-color path needed, because the classifier loss-priority is deterministic per flow and cacheable exactly like the existing rewrite.

## What changed

**Rust (`userspace-dp`)**
- `CoSDSCPRewriteRuleConfig.dscp_by_forwarding_class` → `dscp_by_fc_lp: FastMap<(String, u8), u8>`; added `lp_by_dscp` / `lp_by_pcp` to the classifier configs; new per-egress-interface `CoSLossPriorityRewrite` on `CoSState` (flattened DSCP/PCP → loss-priority tables + `(queue_id, loss_priority)` → code-point matrix).
- Build (`forwarding_build/cos.rs`): read `entry.loss_priority` into the classifier LP tables; two-pass rewrite build so a specific loss-priority entry always wins over a wildcard (no-LP) one.
- Apply (`tx/cos_classify.rs`): resolve the flow's loss-priority from its ingress code-point (DSCP classifier → 802.1p → default LOW), look up `(queue, loss_priority)`, and fold into `CoSTxSelection.dscp_rewrite` (filter rewrite keeps precedence). Cached per flow like the filter rewrite; also resolved on the flowless/fragment path.
- Per-queue drain fallback (`CoSQueueConfig.dscp_rewrite`) now carries only the loss-priority-**uniform** rewrite, so it never misapplies one loss-priority's code-point to a packet of another.

**Backward-compat**: a rewrite entry with no explicit loss-priority is a wildcard applying to all four loss-priorities.

**Go (`pkg/config`)**: the rewrite-rule loss-priority is now enforced → dropped its stale "accepted but not yet enforced" commit warning; refined the classifier loss-priority warning to note it now drives the egress rewrite selection but is still not enforced for drop-precedence / WRED.

## Scope note
The loss-priority is resolved from the **seed** packet's ingress code-point and cached per flow. A flow that changes its DSCP mid-stream keeps the seed loss-priority for its cached rewrite — correct for the common stable-marking case; matching #2507's deferred per-packet policer-color scope.

## Validation
- New RED-on-revert Rust test (`cos_dscp_rewrite_keys_on_forwarding_class_and_loss_priority`): `voice/low → 21`, `voice/high → 31` (asserted to differ), wildcard `data → 40` for both loss-priorities, across the runtime AND cached classify paths.
- FULL `cargo test --release -- --test-threads=1`: **3704 passed / 0 failed** (`cos::` 563 passed).
- Go `./pkg/config/...` green. rustfmt/gofmt clean on changed lines.

⚠️ Dataplane CoS change → a **cluster CoS-smoke (per-loss-priority rewrite)** is warranted before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi