### PR TITLE
userspace-dp: per-zone reject-reply rate-limit buckets (#3618)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -37067,3 +37067,37 @@ top.
   pkg/config/compiler_validate_strict.go,
   pkg/config/parser_class_of_service_test.go,
   userspace-dp/src/afxdp/types/cos.rs, _Log.md
+
+- **Timestamp**: 2026-07-06
+  **Action**: #3618 — per-zone `reject`-reply rate-limit buckets
+  (userspace-dp). Replaced the SINGLE process-global Reject `TokenBucket`
+  with ONE bucket per configured ingress (from) zone so a rejected-flow
+  flood in one zone can no longer drain a shared bucket and starve
+  legitimate reject-generation (TCP RST / ICMP-unreachable) in another
+  zone. New `ForwardingState::reject_buckets: FastMap<u16,
+  Arc<TokenBucket>>` built in `populate_zones` from the same validated
+  zone set as `zone_id_to_name` (config-bounded, not attacker-growable);
+  held behind `Arc` so the shared atomics survive
+  `ForwardingState::clone()` (fabric refresh re-stores a clone at runtime
+  cadence — a plain-value clone would reset the limiter). The reject call
+  site resolves the from-zone from the LOGICAL ingress ifindex via
+  `ifindex_to_zone_id` and gates on the new
+  `icmp_ratelimit::allow_generated_reject(forwarding, from_zone_id)`; an
+  unzoned/unknown zone falls back to a process-global
+  `REJECT_FALLBACK_BUCKET` (never fail-open). TimeExceeded / PacketTooBig
+  keep their single global bucket. The aggregate
+  `reject_rate_limited_total` metric is now a dedicated single atomic
+  (`REJECT_RATE_LIMITED_TOTAL`) bumped on every per-zone deny, so the
+  coordinator status / Prometheus wire format is UNCHANGED. Added 5 tests
+  (headline per-zone isolation, end-to-end call-site isolation, fallback
+  for unknown/unzoned, aggregate-sums-across-zones, reason isolation) —
+  all RED on a revert to a single shared bucket (verified). Full cargo
+  serial suite green. Docs: new docs/generated-reply-rate-limit.md +
+  userspace-dp README reject-limiter paragraph + icmp_ratelimit.rs module
+  header.
+  **File(s)**: userspace-dp/src/afxdp/icmp_ratelimit.rs,
+  userspace-dp/src/afxdp/types/forwarding.rs,
+  userspace-dp/src/afxdp/forwarding_build/zones.rs,
+  userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs,
+  userspace-dp/src/afxdp/README.md, docs/generated-reply-rate-limit.md,
+  _Log.md

--- a/docs/generated-reply-rate-limit.md
+++ b/docs/generated-reply-rate-limit.md
@@ -1,0 +1,125 @@
+# Generated-reply rate limiting (userspace-dp)
+
+SSOT for the token-bucket rate limiter on **locally-generated error/reset
+replies** in the AF_XDP userspace dataplane
+(`userspace-dp/src/afxdp/icmp_ratelimit.rs`). This is distinct from the screen
+flood limiter (`userspace-dp/src/screen/rate.rs`, #3607), which detects inbound
+floods; this one bounds the RATE at which the box AMPLIFIES a trigger into a
+generated reply.
+
+## What is limited
+
+Three locally-originated reply generators run on cold exception paths, each
+building + enqueuing a reply after the RFC-suppression and output-classification
+gates:
+
+| Reason | Generator | Rate-limit scope |
+|--------|-----------|------------------|
+| `TimeExceeded` | ICMPv4 Time Exceeded / ICMPv6 Hop-Limit Exceeded (`icmp::build_local_time_exceeded_request`) | Single global bucket |
+| `PacketTooBig` | ICMPv4 Frag-Needed / ICMPv6 Packet Too Big (PMTUD, #2301/#2330) | Single global bucket |
+| `Reject` | Policy `then reject`, firewall-filter / lo0 `then reject`, and a zone `tcp-rst` deny → TCP RST or ICMP/ICMPv6 admin-prohibited unreachable (`poll_descriptor::reject_reply`) | **Per ingress (from) zone (#3618)** |
+
+Without a limiter, an attacker driving a flood of TTL-1 packets, oversized DF=1
+packets, or rejected flows makes the box emit one generated reply per trigger
+packet — a CPU / TX amplification sink and a reflection vector (the reply is
+addressed to the trigger's spoofable source). The limiter is modelled on Linux's
+`net.ipv4.icmp_msgs_per_sec` (default 1000/s): a bounded-state GCRA token bucket,
+no per-source/per-destination map, so there is no attacker-driven map growth.
+
+The `TokenBucket` is a single-atomic-word GCRA (theoretical-arrival-time); refill
+and consume commit together in one CAS so concurrent workers can never
+double-credit or over-admit (#2955). Default rate/burst are compile-time
+constants `DEFAULT_RATE_PER_SEC = DEFAULT_BURST = 1000`; a zero rate disables the
+limiter.
+
+## #2472 → #3618: why the Reject reason is per-zone
+
+`#2472` introduced a **single global** bucket per reason. For the Reject reason
+that global bucket coupled all zones: a rejected-flow flood ingressing **one**
+(e.g. untrusted WAN) zone drained the shared bucket, so a legitimate policy /
+filter reject in a **different** (e.g. trusted/internal) zone fail-closed to a
+silent drop even though that zone was not under attack. The aggregate cap was
+being asked to also deliver per-zone fairness, and it could not — an operator
+troubleshooting a policy misconfiguration in the quiet zone never saw that zone's
+reject diagnostic while the busy zone stayed flooded.
+
+`#3618` splits the Reject reason into **one bucket per configured zone**:
+
+- `ForwardingState::reject_buckets: FastMap<u16, Arc<TokenBucket>>` — one GCRA
+  bucket per configured zone id, built in `forwarding_build::zones::populate_zones`
+  from the SAME validated zone set as `zone_id_to_name`. Cardinality = configured
+  zones (the Go control plane caps distinct zones at `MaxUsableZoneID = 65533`),
+  so it is config-bounded, never attacker-growable.
+- At the reject call site (`poll_descriptor::reject_reply::enqueue_reject_reply`)
+  the ingress **from-zone** is resolved from the LOGICAL ingress unit ifindex via
+  `ifindex_to_zone_id` (the same SSOT the #3976 reply build and #3035 output
+  classify key off, so a VLAN sub-interface keys its own zone's bucket, and a
+  non-VLAN port resolves identically through the parent mapping).
+- An unzoned (id 0) or otherwise-unknown from-zone falls back to the
+  process-global `REJECT_FALLBACK_BUCKET` — a real bucket, so the gate is **never
+  fail-open** and never panics on a missing key. Unzoned/unknown rejects share
+  that one budget (the rare/degenerate case).
+
+Zone ids are sparse `u16` stable name-hashes over `[0, 65533]` (NOT dense
+`[0, 64)`), so the map is keyed by zone id, not a dense array.
+
+### Why this does not weaken the anti-amplification cap
+
+The realistic reflection attacker floods ONE ingress path (the WAN zone); each
+zone's bucket still caps that path at 1000/s — **identical** to the pre-#3618
+global cap for the single-ingress case. Per-zone buckets remove the cross-zone
+starvation while preserving the per-ingress-zone cap. Reaching the `N × 1000/s`
+aggregate requires an attacker already inside the trust boundary driving rejects
+across many zones at once (a multi-VLAN trunk / compromised internal host), who
+can emit far more damaging traffic than reflected RST/ICMP backscatter; each zone
+is still individually capped. A global second-level ceiling for that east-west
+amplifier is a filed optional follow-up, not built here.
+
+### TimeExceeded / PacketTooBig stay global
+
+TE/PTB keep their single global-per-reason bucket. Their generator sites
+(`icmp.rs`, `tx/dispatch/mod.rs`) do not cleanly carry an ingress zone id (TE is
+built deep in the ICMP builder, PTB in the TX dispatch path); scoping them
+per-zone is a separate change with its own zone plumbing. Out of scope for #3618.
+
+## Lifetime / sharing model (why `Arc<TokenBucket>`)
+
+All workers gate against the SAME per-zone bucket: each worker holds an
+`Arc<ForwardingState>` loaded from the shared `ArcSwap` (`load_full()`), so within
+one forwarding generation they share the one `ForwardingState` instance and its
+atomics — the cap is per-zone, not per-worker.
+
+The buckets are held behind `Arc` (not plain values) because the coordinator
+re-stores a CLONE of the forwarding state at runtime cadence (fabric refresh,
+`snapshot_refresh.rs`), not only on config commit. A plain-value clone would
+snapshot the coordinator-side (stale, worker-untouched) atomics on every refresh
+and effectively RESET the limiter. `Arc<TokenBucket>` is shared by reference
+across `ForwardingState::clone()`, so the limiter state persists across a refresh.
+A genuine config rebuild re-runs `populate_zones` and installs fresh buckets —
+**reset-on-commit**, which is accepted for a diagnostic limiter (a commit is rare,
+operator-initiated, and a fresh burst allowance right after a commit is benign).
+
+## Observability (metric unchanged)
+
+The aggregate `reject_rate_limited_total` is a SINGLE process-global atomic
+(`REJECT_RATE_LIMITED_TOTAL`) bumped on ANY per-zone (or fallback) deny — NOT a
+sum over the per-zone buckets' fields — so `rate_limited_count(Reject)` stays an
+O(1) atomic load and the coordinator status / Prometheus
+`xpf_userspace_reject_rate_limited_total` wire contract is UNCHANGED by the
+per-zone split. Each per-zone `TokenBucket` keeps its own `rate_limited` field
+for OPTIONAL future per-zone attribution; the aggregate metric never reads it.
+
+The per-source split (#3661) — `policy_reject_rate_limit_drops` /
+`filter_reject_rate_limit_drops` — is orthogonal and still sums to the
+source-neutral aggregate.
+
+## Fail-closed invariants preserved
+
+- Every failure leg (bucket-empty, budget-exhausted, unparseable, output-filter
+  drop) still returns false and the caller silently drops the trigger packet —
+  the reject reply is a courtesy; the trigger is dropped regardless, so this is a
+  fairness/observability fix, never a good-traffic-drop or security bypass.
+- A missing zone id maps to the fallback bucket, never a fail-open skip.
+- #3656: a frame that can never produce a reply (inbound RST, inbound ICMP error,
+  non-first fragment, ...) is proven unreplyable BEFORE the token is consumed, so
+  a flood of unreplyable frames cannot drain a zone's bucket (H11).

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -558,9 +558,15 @@ sync.
   (filter); the parse-error leg `generated_reply_classify_parse_errors`
   stays source-neutral (shared by every generated-reply type). The
   rate-limit split (#3661) attributes an empty-bucket drop to the reply's
-  source at the consume site — the shared per-reason `REJECT_BUCKET` is
-  unchanged, so `policy`+`filter` sum to the source-neutral aggregate
-  `reject_rate_limited_total`.
+  source at the consume site. #3618 made the reject rate-limit bucket PER
+  INGRESS (from) ZONE — one `TokenBucket` per configured zone in
+  `ForwardingState::reject_buckets`, resolved from the ingress interface's
+  zone, with a process-global `REJECT_FALLBACK_BUCKET` for an unzoned/unknown
+  zone — so a rejected-flow flood in one zone no longer starves reject
+  generation in another. The observable aggregate `reject_rate_limited_total`
+  stays a SINGLE atomic bumped on any per-zone deny, so the metric is unchanged
+  and `policy`+`filter` still sum to it. See
+  `docs/generated-reply-rate-limit.md`.
   DSCP-matched input/output filters
   are intentionally not flow-cached because DSCP is packet metadata, not
   part of the session cache key; session hits re-evaluate DSCP-sensitive

--- a/userspace-dp/src/afxdp/forwarding_build/zones.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/zones.rs
@@ -33,10 +33,7 @@ pub(super) fn reject_duplicate_zone_ids(
     let mut owner: std::collections::HashMap<u16, &str> =
         std::collections::HashMap::with_capacity(snapshot.zones.len());
     for zone in &snapshot.zones {
-        if zone.id == 0
-            || zone.name.is_empty()
-            || zone.id >= crate::policy::ZONE_ID_RESERVED_MIN
-        {
+        if zone.id == 0 || zone.name.is_empty() || zone.id >= crate::policy::ZONE_ID_RESERVED_MIN {
             continue;
         }
         match owner.get(&zone.id) {
@@ -120,6 +117,20 @@ pub(super) fn populate_zones(snapshot: &ConfigSnapshot, state: &mut ForwardingSt
         state
             .zone_host_inbound
             .insert(zone.id, zone_host_inbound_from_snapshot(zone));
+        // #3618: one per-zone `reject`-reply rate-limit bucket per KNOWN zone,
+        // keyed by the SAME validated zone id. Before #3618 a single
+        // process-global bucket rate-limited every generated reject, so a
+        // rejected-flow flood ingressing one zone drained it and starved
+        // legitimate reject-generation in another zone. Building one bucket per
+        // CONFIGURED zone here (not per-packet) bounds cardinality to the
+        // configured zone set and gives each ingress zone an independent budget.
+        // An unzoned / unknown from-zone (id 0, never in this table) falls back
+        // to the shared `REJECT_FALLBACK_BUCKET` at the gate. Fresh buckets on
+        // every build = reset-on-commit, accepted for a diagnostic limiter.
+        state.reject_buckets.insert(
+            zone.id,
+            std::sync::Arc::new(crate::afxdp::icmp_ratelimit::TokenBucket::new()),
+        );
         // #3071: record the per-zone Junos `tcp-rst` knob keyed by zone id so
         // the policy-deny hot path can answer a denied TCP flow whose ingress
         // (from) zone has tcp-rst with a RST instead of a silent drop. Only

--- a/userspace-dp/src/afxdp/icmp_ratelimit.rs
+++ b/userspace-dp/src/afxdp/icmp_ratelimit.rs
@@ -20,10 +20,25 @@
 // This adds the missing limiter, modelled on Linux's ICMP rate limiting
 // (`net.ipv4.icmp_msgs_per_sec` — a GLOBAL per-host burst, default 1000/s —
 // plus `net.ipv4.icmp_ratelimit`). We use the simple, bounded-state half of
-// that model: a GLOBAL-per-reason token bucket (no per-source / per-destination
-// map, so there is no attacker-driven map growth). Each reason has its own
-// bucket so a TTL-exceeded flood cannot starve the PTB or reject reasons (and
-// vice-versa) — per-reason isolation.
+// that model: a per-reason token bucket (no per-source / per-destination map,
+// so there is no attacker-driven map growth). Each reason has its own bucket so
+// a TTL-exceeded flood cannot starve the PTB or reject reasons (and vice-versa)
+// — per-reason isolation.
+//
+// #3618: the Reject reason is further split PER INGRESS (from) ZONE — one
+// bucket per configured zone, held in `ForwardingState::reject_buckets` and
+// resolved at the reject call site (`poll_descriptor::reject_reply`), with a
+// process-global `REJECT_FALLBACK_BUCKET` for an unzoned/unknown zone. This
+// removes the cross-zone starvation the single global Reject bucket had: a
+// rejected-flow flood ingressing one zone can no longer drain the bucket and
+// suppress a legitimate reject in another zone. TimeExceeded / PacketTooBig
+// keep their single global-per-reason bucket (their generator sites lack a
+// clean ingress zone id — see `docs/generated-reply-rate-limit.md`). The
+// observable aggregate `reject_rate_limited_total` stays a SINGLE atomic
+// (`REJECT_RATE_LIMITED_TOTAL`) bumped on any per-zone deny, so the coordinator
+// status / Prometheus metric format is unchanged. Cardinality is
+// config-bounded (configured zones, Go-capped ≤ 65533), so there is still no
+// attacker-driven map growth.
 //
 // Hot-path: the check is a single CAS loop over ONE atomic word (a GCRA
 // theoretical-arrival-time; #2955 collapsed the prior split token-count +
@@ -39,6 +54,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::neighbor::monotonic_nanos;
+use crate::afxdp::types::ForwardingState;
 
 /// The locally-generated error reasons that share this limiter. Each variant
 /// indexes an independent token bucket, so exhausting one reason never blocks
@@ -89,7 +105,17 @@ const NANOS_PER_SEC: u64 = 1_000_000_000;
 /// `interval`. Because `tat` is the entire state, there is no second field to
 /// tear against — the single CAS atomically refills AND consumes. This is the
 /// same single-TAT pattern used by `event_stream/producer.rs`.
-struct TokenBucket {
+///
+/// #3618: exposed as `pub(in crate::afxdp)` so `ForwardingState` can hold a
+/// per-zone map of these for the Reject reason (`reject_buckets`). The fields
+/// stay private to this module; the only cross-module entry points are
+/// `TokenBucket::new()` (to build a fresh per-zone bucket at config apply) and
+/// the `allow_generated_reject*` gates below (which do the `try_take` +
+/// counter bump). Held behind an `Arc` in `ForwardingState` so the shared
+/// atomics survive `ForwardingState::clone()` (fabric refresh re-stores a
+/// clone at runtime cadence — see `forwarding.rs`).
+#[derive(Debug)]
+pub(in crate::afxdp) struct TokenBucket {
     /// Theoretical arrival time (monotonic nanos). The whole limiter state.
     /// Initialised to 0 so the first `burst` calls after boot pass (an
     /// effectively-full bucket: `0 - horizon` saturates to 0 <= any `now`).
@@ -99,7 +125,7 @@ struct TokenBucket {
 }
 
 impl TokenBucket {
-    const fn new() -> Self {
+    pub(in crate::afxdp) const fn new() -> Self {
         TokenBucket {
             theoretical_arrival_ns: AtomicU64::new(0),
             rate_limited: AtomicU64::new(0),
@@ -127,8 +153,7 @@ impl TokenBucket {
         // interval = nanos between admitted tokens at the steady rate. Round up
         // so a high rate never collapses to a zero interval (which would admit
         // unboundedly). A burst of 0 is treated as 1 (no negative horizon).
-        let interval_ns =
-            (NANOS_PER_SEC.saturating_add(rate_per_sec - 1) / rate_per_sec).max(1);
+        let interval_ns = (NANOS_PER_SEC.saturating_add(rate_per_sec - 1) / rate_per_sec).max(1);
         let burst_horizon_ns = interval_ns.saturating_mul(burst.saturating_sub(1));
 
         let mut tat = self.theoretical_arrival_ns.load(Ordering::Relaxed);
@@ -162,13 +187,39 @@ impl TokenBucket {
 
 static TIME_EXCEEDED_BUCKET: TokenBucket = TokenBucket::new();
 static PACKET_TOO_BIG_BUCKET: TokenBucket = TokenBucket::new();
-static REJECT_BUCKET: TokenBucket = TokenBucket::new();
 
+/// #3618: shared fallback Reject bucket used when a reject's ingress (from)
+/// zone has NO per-zone bucket — an unzoned (id 0) or otherwise-unknown zone
+/// id. It is a REAL bucket (never a fail-open skip), so an unzoned/unknown
+/// reject is still rate-limited; such rejects all share this one budget (the
+/// rare/degenerate case, not a per-zone diagnostic). This replaces the former
+/// single global `REJECT_BUCKET`: the per-zone buckets now live in
+/// `ForwardingState::reject_buckets` (built from the configured zone set), so a
+/// rejected-flow flood on one zone can no longer drain a single global bucket
+/// and starve reject-generation in another zone.
+static REJECT_FALLBACK_BUCKET: TokenBucket = TokenBucket::new();
+
+/// #3618: process-global aggregate count of Reject replies dropped because the
+/// (per-zone OR fallback) bucket was empty. A SINGLE atomic bumped on ANY
+/// per-zone deny — NOT a sum over the per-zone buckets' `rate_limited` fields —
+/// so `rate_limited_count(Reject)` stays an O(1) atomic load and the
+/// coordinator status / Prometheus `reject_rate_limited_total` wire contract is
+/// UNCHANGED by the per-zone split. Each per-zone `TokenBucket` keeps its own
+/// `rate_limited` field for OPTIONAL future per-zone attribution; the aggregate
+/// metric never reads those fields.
+static REJECT_RATE_LIMITED_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// TE / PTB keep their single global-per-reason bucket. For the Reject reason
+/// this returns the shared `REJECT_FALLBACK_BUCKET`: it is the bucket the
+/// non-zone-keyed `allow_generated_error(Reject)` back-compat entry point and
+/// the test reset/drain helpers operate on. The zone-keyed reject path
+/// (`allow_generated_reject*`) resolves a per-zone bucket first and falls back
+/// to this same static, so both stay consistent.
 fn bucket_for(reason: GeneratedErrorReason) -> &'static TokenBucket {
     match reason {
         GeneratedErrorReason::TimeExceeded => &TIME_EXCEEDED_BUCKET,
         GeneratedErrorReason::PacketTooBig => &PACKET_TOO_BIG_BUCKET,
-        GeneratedErrorReason::Reject => &REJECT_BUCKET,
+        GeneratedErrorReason::Reject => &REJECT_FALLBACK_BUCKET,
     }
 }
 
@@ -181,7 +232,12 @@ fn bucket_for(reason: GeneratedErrorReason) -> &'static TokenBucket {
 /// is global-per-reason (no per-source state), matching Linux's
 /// `icmp_msgs_per_sec` model.
 pub(in crate::afxdp) fn allow_generated_error(reason: GeneratedErrorReason) -> bool {
-    allow_generated_error_at(reason, monotonic_nanos(), DEFAULT_RATE_PER_SEC, DEFAULT_BURST)
+    allow_generated_error_at(
+        reason,
+        monotonic_nanos(),
+        DEFAULT_RATE_PER_SEC,
+        DEFAULT_BURST,
+    )
 }
 
 /// Testable core of [`allow_generated_error`] with an injected clock + rate /
@@ -197,15 +253,81 @@ pub(in crate::afxdp) fn allow_generated_error_at(
     let allowed = bucket.try_take(now_ns, rate_per_sec, burst);
     if !allowed {
         bucket.rate_limited.fetch_add(1, Ordering::Relaxed);
+        // #3618: keep the aggregate Reject counter authoritative regardless of
+        // which entry point denied. `rate_limited_count(Reject)` now reads the
+        // dedicated `REJECT_RATE_LIMITED_TOTAL`, so this back-compat entry point
+        // (still reachable via `allow_generated_error(Reject)` + the test
+        // drain/reset helpers, which operate on `REJECT_FALLBACK_BUCKET`) must
+        // bump it too. TE/PTB keep their per-bucket field as the aggregate.
+        if reason == GeneratedErrorReason::Reject {
+            REJECT_RATE_LIMITED_TOTAL.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+    allowed
+}
+
+/// #3618: zone-scoped variant of the Reject gate. Returns true when a
+/// locally-generated reject reply whose ingress (from) zone is `from_zone_id`
+/// MAY be sent (its per-zone bucket had a token), false when it MUST be dropped
+/// because that zone's bucket is empty. The per-zone bucket comes from
+/// `forwarding.reject_buckets` (built from the configured zone set at config
+/// apply); an unzoned (id 0) or otherwise-unknown zone id falls back to the
+/// shared process-global `REJECT_FALLBACK_BUCKET` — a real bucket, so the gate
+/// is NEVER fail-open and never panics on a missing key. On a deny the single
+/// aggregate `REJECT_RATE_LIMITED_TOTAL` is bumped (metric unchanged) alongside
+/// the bucket's own `rate_limited` field (optional per-zone attribution).
+///
+/// TimeExceeded / PacketTooBig stay on the global-per-reason
+/// `allow_generated_error` — they lack a clean ingress zone at their generator
+/// sites (see `docs/generated-reply-rate-limit.md`).
+pub(in crate::afxdp) fn allow_generated_reject(
+    forwarding: &ForwardingState,
+    from_zone_id: u16,
+) -> bool {
+    allow_generated_reject_at(
+        forwarding,
+        from_zone_id,
+        monotonic_nanos(),
+        DEFAULT_RATE_PER_SEC,
+        DEFAULT_BURST,
+    )
+}
+
+/// Testable core of [`allow_generated_reject`] with an injected clock + rate /
+/// burst, so the unit tests can drive a deterministic per-zone burst-then-drain
+/// sequence without sleeping.
+pub(in crate::afxdp) fn allow_generated_reject_at(
+    forwarding: &ForwardingState,
+    from_zone_id: u16,
+    now_ns: u64,
+    rate_per_sec: u64,
+    burst: u64,
+) -> bool {
+    let bucket = forwarding
+        .reject_bucket(from_zone_id)
+        .unwrap_or(&REJECT_FALLBACK_BUCKET);
+    let allowed = bucket.try_take(now_ns, rate_per_sec, burst);
+    if !allowed {
+        // Per-zone attribution (optional future accessor).
+        bucket.rate_limited.fetch_add(1, Ordering::Relaxed);
+        // Aggregate metric — a single atomic, bumped on every per-zone deny.
+        REJECT_RATE_LIMITED_TOTAL.fetch_add(1, Ordering::Relaxed);
     }
     allowed
 }
 
 /// Observable per-reason count of generated error replies dropped because the
 /// reason's token bucket was empty. Surfaced via the coordinator status
-/// (`*_rate_limited_total`).
+/// (`*_rate_limited_total`). #3618: the Reject reason reads the dedicated
+/// process-global aggregate (`REJECT_RATE_LIMITED_TOTAL`), which is bumped on
+/// every per-zone (and fallback) deny — an O(1) atomic load, never a sum over
+/// the per-zone buckets, so the wire/metric format is unchanged. TE/PTB still
+/// read their single bucket's `rate_limited` field.
 pub(in crate::afxdp) fn rate_limited_count(reason: GeneratedErrorReason) -> u64 {
-    bucket_for(reason).rate_limited.load(Ordering::Relaxed)
+    match reason {
+        GeneratedErrorReason::Reject => REJECT_RATE_LIMITED_TOTAL.load(Ordering::Relaxed),
+        _ => bucket_for(reason).rate_limited.load(Ordering::Relaxed),
+    }
 }
 
 /// #2955: serialises every test that drives the GLOBAL per-reason buckets.
@@ -222,8 +344,7 @@ pub(in crate::afxdp) fn rate_limited_count(reason: GeneratedErrorReason) -> u64 
 /// body. (Tests using a LOCAL `TokenBucket` — the #2955 concurrency guards —
 /// touch no shared state and do not take the lock.)
 #[cfg(test)]
-pub(in crate::afxdp) fn global_bucket_test_lock()
--> std::sync::MutexGuard<'static, ()> {
+pub(in crate::afxdp) fn global_bucket_test_lock() -> std::sync::MutexGuard<'static, ()> {
     use std::sync::Mutex;
     static LOCK: Mutex<()> = Mutex::new(());
     LOCK.lock().unwrap_or_else(|e| e.into_inner())
@@ -241,6 +362,12 @@ pub(in crate::afxdp) fn reset_bucket_for_test(reason: GeneratedErrorReason, now_
         .theoretical_arrival_ns
         .store(now_ns, Ordering::Relaxed);
     bucket.rate_limited.store(0, Ordering::Relaxed);
+    // #3618: also clear the dedicated aggregate so a test that asserts an exact
+    // `rate_limited_count(Reject)` starts from a clean slate (the Reject
+    // aggregate is a separate atomic from the fallback bucket's field).
+    if reason == GeneratedErrorReason::Reject {
+        REJECT_RATE_LIMITED_TOTAL.store(0, Ordering::Relaxed);
+    }
 }
 
 #[cfg(test)]
@@ -447,6 +574,130 @@ mod tests {
             rate_limited_count(reason),
             before,
             "a disabled limiter must never bump the rate-limited counter"
+        );
+    }
+
+    use crate::afxdp::types::FastMap;
+    use std::sync::Arc;
+
+    /// Build a `ForwardingState` carrying a fresh per-zone Reject bucket for
+    /// each given zone id (#3618 test helper).
+    fn forwarding_with_reject_zones(zone_ids: &[u16]) -> ForwardingState {
+        let mut reject_buckets: FastMap<u16, Arc<TokenBucket>> = FastMap::default();
+        for &id in zone_ids {
+            reject_buckets.insert(id, Arc::new(TokenBucket::new()));
+        }
+        ForwardingState {
+            reject_buckets,
+            ..ForwardingState::default()
+        }
+    }
+
+    /// #3618 HEADLINE fail-on-revert: a rejected-flow flood that drains ZONE A's
+    /// per-zone Reject bucket must NOT prevent ZONE B from generating its
+    /// reject. Reverting to a SINGLE global Reject bucket makes draining A empty
+    /// the one shared bucket, so B is then denied and this assertion goes RED.
+    /// This is the direct proof of the #3618 per-zone isolation fix — one
+    /// ingress zone can no longer starve another's reject-generation.
+    #[test]
+    fn reject_per_zone_flood_does_not_starve_other_zone_3618() {
+        let _g = global_bucket_test_lock();
+        // Sparse, realistic stable-name-hash zone ids (NOT dense 1,2).
+        let zone_a = 41_337u16;
+        let zone_b = 9_002u16;
+        let t0 = 3_000_000_000u64;
+        let forwarding = forwarding_with_reject_zones(&[zone_a, zone_b]);
+        // Drain zone A at a frozen instant (burst = 4).
+        for i in 0..4 {
+            assert!(
+                allow_generated_reject_at(&forwarding, zone_a, t0, 1000, 4),
+                "zone A token {i} within burst must pass"
+            );
+        }
+        assert!(
+            !allow_generated_reject_at(&forwarding, zone_a, t0, 1000, 4),
+            "zone A bucket must be drained after its burst"
+        );
+        // Zone B, under no load, still generates its reject at the SAME instant.
+        assert!(
+            allow_generated_reject_at(&forwarding, zone_b, t0, 1000, 4),
+            "zone B must NOT be starved by zone A's flood (per-zone isolation)"
+        );
+    }
+
+    /// #3618: an unzoned (id 0) or otherwise-unknown from-zone id has no
+    /// per-zone bucket, so the gate falls back to the shared process-global
+    /// `REJECT_FALLBACK_BUCKET` — a real bucket (never fail-open) that still
+    /// rate-limits and never panics on the absent key. Both an unknown id and
+    /// id 0 SHARE the one fallback budget.
+    #[test]
+    fn reject_unknown_and_unzoned_share_fallback_bucket_3618() {
+        let _g = global_bucket_test_lock();
+        let t0 = 6_000_000_000u64;
+        // Reset the fallback bucket (+ aggregate) to full at epoch t0.
+        reset_bucket_for_test(GeneratedErrorReason::Reject, t0);
+        // Empty map: every zone id resolves to the fallback.
+        let forwarding = ForwardingState::default();
+        let unknown = 55_555u16;
+        // burst = 2 on the shared fallback: an unknown-id reject and an
+        // unzoned (id 0) reject each take one token; the third is denied.
+        assert!(allow_generated_reject_at(&forwarding, unknown, t0, 1000, 2));
+        assert!(allow_generated_reject_at(&forwarding, 0, t0, 1000, 2));
+        assert!(
+            !allow_generated_reject_at(&forwarding, unknown, t0, 1000, 2),
+            "unknown / unzoned rejects share and are bounded by the fallback bucket"
+        );
+    }
+
+    /// #3618 metric-preservation fail-on-revert: the aggregate
+    /// `reject_rate_limited_total` (a SINGLE global atomic, NOT a per-zone sum)
+    /// is bumped on EVERY per-zone deny, so the coordinator status / Prometheus
+    /// contract is unchanged by the per-zone split. Drain two zones by K1 and K2
+    /// and assert the aggregate advanced by exactly K1 + K2.
+    #[test]
+    fn reject_aggregate_counter_sums_across_zones_3618() {
+        let _g = global_bucket_test_lock();
+        let t0 = 8_000_000_000u64;
+        reset_bucket_for_test(GeneratedErrorReason::Reject, t0); // aggregate -> 0
+        let zone_a = 111u16;
+        let zone_b = 222u16;
+        let forwarding = forwarding_with_reject_zones(&[zone_a, zone_b]);
+        let before = rate_limited_count(GeneratedErrorReason::Reject);
+        let k1 = 3u64;
+        let k2 = 5u64;
+        // burst = 1 per zone: one pass, then K denies each.
+        assert!(allow_generated_reject_at(&forwarding, zone_a, t0, 1000, 1));
+        for _ in 0..k1 {
+            assert!(!allow_generated_reject_at(&forwarding, zone_a, t0, 1000, 1));
+        }
+        assert!(allow_generated_reject_at(&forwarding, zone_b, t0, 1000, 1));
+        for _ in 0..k2 {
+            assert!(!allow_generated_reject_at(&forwarding, zone_b, t0, 1000, 1));
+        }
+        assert_eq!(
+            rate_limited_count(GeneratedErrorReason::Reject),
+            before + k1 + k2,
+            "aggregate reject_rate_limited_total must sum every per-zone deny (metric unchanged)"
+        );
+    }
+
+    /// #3618: per-zone Reject buckets stay isolated from the TimeExceeded /
+    /// PacketTooBig reasons (reason isolation, #2472). Draining a zone's Reject
+    /// bucket must not affect the TE/PTB global buckets, and vice-versa.
+    #[test]
+    fn reject_per_zone_isolated_from_other_reasons_3618() {
+        let _g = global_bucket_test_lock();
+        let t0 = 10_000_000_000u64;
+        reset_bucket_for_test(GeneratedErrorReason::TimeExceeded, t0);
+        let zone_a = 700u16;
+        let forwarding = forwarding_with_reject_zones(&[zone_a]);
+        // Drain zone A's Reject bucket (burst = 1).
+        assert!(allow_generated_reject_at(&forwarding, zone_a, t0, 1000, 1));
+        assert!(!allow_generated_reject_at(&forwarding, zone_a, t0, 1000, 1));
+        // TimeExceeded (a different reason, global bucket) is untouched.
+        assert!(
+            allow_generated_error_at(GeneratedErrorReason::TimeExceeded, t0, 1000, 1),
+            "TE bucket must be independent of a zone's Reject exhaustion"
         );
     }
 }

--- a/userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs
@@ -19,7 +19,7 @@ use super::worker::WorkerTxPipeline;
 use super::*;
 use crate::afxdp::event_emit::emit_policy_deny_event;
 use crate::afxdp::icmp::build_reject_icmp_unreachable;
-use crate::afxdp::icmp_ratelimit::{GeneratedErrorReason, allow_generated_error};
+use crate::afxdp::icmp_ratelimit::allow_generated_reject;
 use crate::event_stream::EventStreamWorkerHandle;
 use crate::nat::NatDecision;
 use crate::policy::PolicyAction;
@@ -222,22 +222,23 @@ fn enqueue_reject_reply(
     counters: &mut BatchCounters,
     source: RejectReplySource,
 ) -> bool {
-    // #3656: determine reply-build FEASIBILITY before consuming the shared
-    // REJECT_BUCKET token OR counting a TX-frame-budget drop. A frame that can
+    // #3656: determine reply-build FEASIBILITY before consuming the reject
+    // rate-limit token OR counting a TX-frame-budget drop. A frame that can
     // NEVER produce a reply — an inbound TCP RST, an inbound ICMP/ICMPv6 error,
     // a non-first fragment, an L2 group/broadcast frame, an unparseable frame,
     // or an ingress without a primary of the inbound family — is a PLAIN drop.
     // Building the reply first (a pure, side-effect-free reflection of the
-    // inbound frame) means such a frame consumes NEITHER the shared per-reason
-    // rate-limit token (H11: a flood of unreplyable frames must not drain the
-    // REJECT_BUCKET and starve legitimate rejects — a cheap DoS against active
-    // reject behavior) NOR a budget-drop counter (H12: an impossible reply
-    // must not be mis-attributed as TX queue pressure and hide the true attack
-    // shape). The token / budget are consumed only once `Some(bytes)` proves an
-    // actual reply exists. This is the residual of #3615, which reordered the
-    // event emit + per-source counter split but left the bucket/budget consume
-    // AHEAD of the build. Orthogonal to #3618 (per-zone bucket design) — the
-    // shared bucket is unchanged; only the CONSUMPTION ORDERING moves. The
+    // inbound frame) means such a frame consumes NEITHER the reject rate-limit
+    // token (H11: a flood of unreplyable frames must not drain the reject
+    // bucket and starve legitimate rejects — a cheap DoS against active reject
+    // behavior) NOR a budget-drop counter (H12: an impossible reply must not be
+    // mis-attributed as TX queue pressure and hide the true attack shape). The
+    // token / budget are consumed only once `Some(bytes)` proves an actual
+    // reply exists. This is the residual of #3615, which reordered the event
+    // emit + per-source counter split but left the bucket/budget consume AHEAD
+    // of the build. #3618 made the rate-limit token PER INGRESS ZONE (resolved
+    // below, at the gate), so H11 now protects each zone's bucket independently;
+    // the CONSUMPTION ORDERING (feasibility before consume) is unchanged. The
     // extra build under budget/rate pressure is on the already-cold reject
     // exception path.
     // #3976: resolve the LOGICAL ingress unit ifindex ONCE, up here, so both
@@ -294,33 +295,52 @@ fn enqueue_reject_reply(
         return false;
     }
 
-    // #2472: per-reason token-bucket rate limit on the LOCALLY-GENERATED
+    // #2472/#3618: per-ZONE token-bucket rate limit on the LOCALLY-GENERATED
     // reject reply (TCP RST or ICMP/ICMPv6 unreachable). The SYN-cookie
     // TX-frame budget gate above is a queue-protection gate (it keeps the
     // reply ring from starving transit TX), NOT a per-reason rate cap — under
     // a sustained rejected-flow flood it refills as fast as TX drains. The
     // token bucket bounds the generated-error RATE so a flood of rejected
-    // flows cannot be amplified into unbounded RST/ICMP backscatter. Both
-    // policy and filter reject share this `Reject` bucket (a single emit
-    // path, per the RejectReplySource doc comment). #3656: the token is
+    // flows cannot be amplified into unbounded RST/ICMP backscatter.
+    //
+    // #3618: the bucket is now PER INGRESS (from) ZONE, not a single global
+    // one. `from_zone_id` is resolved from the LOGICAL ingress unit ifindex
+    // (the same SSOT the #3976 reply build + #3035 output-classify key off —
+    // so a VLAN sub-interface keys its OWN zone's bucket, and `ifindex_to_zone_id`
+    // also maps the physical parent so a non-VLAN port resolves identically).
+    // Before #3618 a rejected-flow flood ingressing one zone drained the single
+    // shared bucket and starved legitimate reject-generation in a DIFFERENT
+    // zone; per-zone buckets remove that cross-zone starvation. An unzoned /
+    // unknown ingress interface (id 0) falls back to the shared
+    // REJECT_FALLBACK_BUCKET (never fail-open). Both policy and filter reject
+    // still share the SAME per-zone bucket for a given ingress zone (a single
+    // emit path, per the RejectReplySource doc comment). #3656: the token is
     // consumed ONLY for a buildable reply (feasibility is proven above), so a
-    // flood of unreplyable frames can no longer drain the shared bucket and
+    // flood of unreplyable frames can no longer drain the zone's bucket and
     // starve legitimate rejects (H11). On bucket-empty we fail-closed to the
-    // silent drop the caller already performs and bump the observable `Reject`
-    // rate-limited counter (inside `allow_generated_error`).
-    if !allow_generated_error(GeneratedErrorReason::Reject) {
+    // silent drop the caller already performs and bump the observable aggregate
+    // `Reject` rate-limited counter (inside `allow_generated_reject`), which
+    // stays a SINGLE atomic so the coordinator status / Prometheus metric is
+    // unchanged.
+    let from_zone_id = forwarding
+        .ifindex_to_zone_id
+        .get(&logical_ingress_ifindex)
+        .copied()
+        .unwrap_or(0);
+    if !allow_generated_reject(forwarding, from_zone_id) {
         counters.touched = true;
         // #3661: attribute the rate-limit drop to the reply's SOURCE so a
         // firewall-filter `then reject` starvation is not conflated with a
         // policy `then reject` starvation under a rejected-flow flood. Both
-        // sources still share the single global-per-reason REJECT_BUCKET; the
-        // aggregate `reject_rate_limited_total` (bumped inside
-        // `allow_generated_error`) stays source-NEUTRAL for back-compat, and
-        // these two per-source per-binding counters sum to it exactly (the
-        // Reject bucket has this ONE consume site — #3656 proved the token is
-        // consumed only for a buildable reply, so an unreplyable frame reaches
-        // neither counter). Mirrors the #3615 budget-drop / output-filter
-        // source split a few lines below.
+        // sources still share the SAME per-zone reject bucket for a given
+        // ingress zone (#3618); the aggregate `reject_rate_limited_total`
+        // (bumped inside `allow_generated_reject`) stays source-NEUTRAL for
+        // back-compat and is a single atomic summed across all zones, and these
+        // two per-source per-binding counters sum to it exactly (the reject
+        // bucket has this ONE consume site — #3656 proved the token is consumed
+        // only for a buildable reply, so an unreplyable frame reaches neither
+        // counter). Mirrors the #3615 budget-drop / output-filter source split
+        // a few lines below.
         match source {
             RejectReplySource::Policy => counters.policy_reject_rate_limit_drops += 1,
             RejectReplySource::Filter => counters.filter_reject_rate_limit_drops += 1,
@@ -564,7 +584,9 @@ mod tests {
         frame.extend_from_slice(&[0x36, 0xe4, 0x2b, 0xd5, 0x39, 0xe6]);
         frame.extend_from_slice(&0x0800u16.to_be_bytes());
         let l3 = frame.len();
-        frame.extend_from_slice(&[0x45, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x40, 0x00, 64, PROTO_ICMP, 0, 0]);
+        frame.extend_from_slice(&[
+            0x45, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x40, 0x00, 64, PROTO_ICMP, 0, 0,
+        ]);
         frame.extend_from_slice(&client.octets());
         frame.extend_from_slice(&server.octets());
         let _ = l3; // inbound IP csum not validated by the builders
@@ -610,7 +632,8 @@ mod tests {
             }],
             "",
             "",
-        ).expect("filter state compiles");
+        )
+        .expect("filter state compiles");
         let mut forwarding = ForwardingState {
             filter_state,
             tx_selection_enabled_v4: true,
@@ -643,7 +666,10 @@ mod tests {
             &flow,
             &mut counters,
         );
-        assert!(!sent, "reject reply dropped by egress output filter must not enqueue");
+        assert!(
+            !sent,
+            "reject reply dropped by egress output filter must not enqueue"
+        );
         assert_eq!(counters.policy_reject_sent, 0);
         assert_eq!(counters.policy_reject_output_filter_drops, 1);
         assert_eq!(counters.generated_reply_classify_parse_errors, 0);
@@ -773,7 +799,10 @@ mod tests {
             &flow,
             &mut counters,
         );
-        assert!(sent, "filter non-TCP reject must enqueue an ICMP unreachable");
+        assert!(
+            sent,
+            "filter non-TCP reject must enqueue an ICMP unreachable"
+        );
         assert_eq!(counters.filter_reject_sent, 1);
         assert_eq!(counters.policy_reject_sent, 0);
         let req = pipeline
@@ -781,7 +810,11 @@ mod tests {
             .pop_front()
             .expect("filter reject ICMP request");
         // ICMP unreachable: type 3 at the L4 offset of the reply.
-        assert_eq!(req.bytes[14 + 20], 3, "ICMP type must be Destination Unreachable");
+        assert_eq!(
+            req.bytes[14 + 20],
+            3,
+            "ICMP type must be Destination Unreachable"
+        );
     }
 
     /// #3615 (L04) fail-on-revert: a FILTER `then reject` reply suppressed by
@@ -803,7 +836,10 @@ mod tests {
             &flow,
             &mut counters,
         );
-        assert!(!sent, "filter reject must fail-closed under budget exhaustion");
+        assert!(
+            !sent,
+            "filter reject must fail-closed under budget exhaustion"
+        );
         assert_eq!(
             counters.filter_reject_reply_budget_drops, 1,
             "filter-source budget drop must bump the filter counter"
@@ -914,7 +950,10 @@ mod tests {
             &flow,
             &mut counters,
         );
-        assert!(!sent, "filter reject discarded by egress output filter must not enqueue");
+        assert!(
+            !sent,
+            "filter reject discarded by egress output filter must not enqueue"
+        );
         assert_eq!(
             counters.filter_reject_output_filter_drops, 1,
             "filter-source output-filter drop must bump the filter counter"
@@ -2039,5 +2078,97 @@ mod tests {
             event.action, RT_FLOW_ACTION_REJECT,
             "an enqueued reject must log the truthful REJECT"
         );
+    }
+
+    /// #3618 call-site fail-on-revert (end-to-end): with per-(from-)zone Reject
+    /// buckets, a rejected-flow flood that drains ZONE A's bucket must NOT stop
+    /// ZONE B from emitting its reject through `enqueue_policy_reject_reply`.
+    /// The bucket is selected by resolving the ingress ifindex → zone via
+    /// `ifindex_to_zone_id`, so this exercises the full wiring (ingress ifindex
+    /// → from-zone → per-zone bucket). On the single-global-bucket revert,
+    /// draining zone A empties the one shared bucket and zone B fails closed →
+    /// RED.
+    #[test]
+    fn per_zone_reject_isolation_at_call_site_3618() {
+        use super::cookie_reply::SYN_COOKIE_REPLY_PENDING_RESERVE;
+        use crate::afxdp::icmp_ratelimit::TokenBucket;
+        use crate::afxdp::icmp_ratelimit::{
+            GeneratedErrorReason, allow_generated_reject_at, global_bucket_test_lock,
+            reset_bucket_for_test,
+        };
+        use crate::afxdp::types::FastMap;
+        use std::sync::Arc;
+
+        let _g = global_bucket_test_lock();
+        reset_bucket_for_test(GeneratedErrorReason::Reject, 0);
+
+        let zone_a = 4_321u16;
+        let zone_b = 8_765u16;
+        let ifidx_a = 5i32; // ingress interface in zone A (the flooded zone)
+        let ifidx_b = 6i32; // ingress interface in zone B (a quiet zone)
+
+        // Ingress-ifindex → from-zone map + fresh per-zone Reject buckets.
+        let mut ifindex_to_zone_id: FastMap<i32, u16> = FastMap::default();
+        ifindex_to_zone_id.insert(ifidx_a, zone_a);
+        ifindex_to_zone_id.insert(ifidx_b, zone_b);
+        let mut reject_buckets: FastMap<u16, Arc<TokenBucket>> = FastMap::default();
+        reject_buckets.insert(zone_a, Arc::new(TokenBucket::new()));
+        reject_buckets.insert(zone_b, Arc::new(TokenBucket::new()));
+        let forwarding = ForwardingState {
+            ifindex_to_zone_id,
+            reject_buckets,
+            ..ForwardingState::default()
+        };
+
+        // Drain zone A's bucket. The enqueue call samples the REAL (small)
+        // monotonic clock, so pin zone A's refill epoch to the far future and
+        // drain it there: the smaller call-site `now` yields zero refill and
+        // the bucket stays empty across the call (mirrors the #2472 tests).
+        let far_future = u64::MAX / 2;
+        while allow_generated_reject_at(&forwarding, zone_a, far_future, 1000, 1000) {}
+
+        let (frame, meta, flow) = tcp_v4_syn();
+        let mut pipeline = tx_pipeline(
+            SYN_COOKIE_REPLY_PENDING_RESERVE * 2,
+            SYN_COOKIE_REPLY_PENDING_RESERVE + 1,
+        );
+        let mut counters = BatchCounters::default();
+
+        // Zone A (ingress ifindex 5): its own flood drained the bucket →
+        // fail-closed.
+        let sent_a = enqueue_policy_reject_reply(
+            &mut pipeline,
+            &forwarding,
+            ifidx_a,
+            &frame,
+            meta,
+            &flow,
+            &mut counters,
+        );
+        assert!(
+            !sent_a,
+            "zone A reject must fail-closed under its own rejected-flow flood"
+        );
+        assert_eq!(counters.policy_reject_sent, 0);
+        assert!(pipeline.pending_tx_local.is_empty());
+
+        // Zone B (ingress ifindex 6): untouched bucket → still emits its RST.
+        let sent_b = enqueue_policy_reject_reply(
+            &mut pipeline,
+            &forwarding,
+            ifidx_b,
+            &frame,
+            meta,
+            &flow,
+            &mut counters,
+        );
+        assert!(
+            sent_b,
+            "zone B reject must NOT be starved by zone A's flood (per-zone isolation)"
+        );
+        assert_eq!(counters.policy_reject_sent, 1);
+        assert_eq!(pipeline.pending_tx_local.len(), 1);
+
+        reset_bucket_for_test(GeneratedErrorReason::Reject, 0);
     }
 }

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -138,6 +138,29 @@ pub(in crate::afxdp) struct ForwardingState {
     /// (from) zone is present here is answered with a TCP RST toward the
     /// source instead of a silent drop. Absent zone ⇒ tcp-rst off.
     pub(in crate::afxdp) zone_tcp_rst: FastMap<u16, bool>,
+    /// #3618: per-(from-)zone rate-limit buckets for locally-generated `reject`
+    /// replies (policy `then reject`, firewall-filter / lo0 `then reject`, and
+    /// a zone `tcp-rst` deny). One GCRA `TokenBucket` per CONFIGURED zone id,
+    /// built in `populate_zones` from the SAME validated zone set as
+    /// `zone_id_to_name` (cardinality = configured zones, Go-capped ≤ 65533 —
+    /// not attacker-growable). Before #3618 a SINGLE process-global bucket
+    /// rate-limited every reject, so a rejected-flow flood ingressing one zone
+    /// drained it and starved legitimate reject-generation in a DIFFERENT zone;
+    /// per-zone buckets remove that cross-zone starvation while keeping each
+    /// ingress path capped at the same rate.
+    ///
+    /// Keyed by the ingress interface's configured zone id
+    /// (`ifindex_to_zone_id`); an unzoned (id 0) or unknown from-zone falls back
+    /// to the process-global `REJECT_FALLBACK_BUCKET` at the gate (never
+    /// fail-open). Held as `Arc<TokenBucket>` so the shared atomics survive
+    /// `ForwardingState::clone()` — the coordinator re-stores a clone of the
+    /// forwarding state at runtime cadence (fabric refresh), and a plain-value
+    /// clone would snapshot stale coordinator-side atomics and effectively reset
+    /// the limiter every refresh. A genuine config rebuild re-runs
+    /// `populate_zones` and installs fresh buckets (reset-on-commit, accepted
+    /// for a diagnostic limiter). See `docs/generated-reply-rate-limit.md`.
+    pub(in crate::afxdp) reject_buckets:
+        FastMap<u16, std::sync::Arc<crate::afxdp::icmp_ratelimit::TokenBucket>>,
     pub(in crate::afxdp) egress: FastMap<i32, EgressInterface>,
     pub(in crate::afxdp) ingress_logical_ifindex: FastMap<(i32, u16), i32>,
     pub(in crate::afxdp) fabrics: Vec<FabricLink>,
@@ -391,6 +414,19 @@ impl ForwardingState {
         self.zone_tcp_rst.get(&zone_id).copied().unwrap_or(false)
     }
 
+    /// #3618: the per-zone `reject` rate-limit bucket for ingress (from) zone
+    /// `from_zone_id`, or `None` if the zone is unconfigured / unknown (the
+    /// gate then falls back to the shared `REJECT_FALLBACK_BUCKET`). Returns a
+    /// plain `&TokenBucket` (deref of the held `Arc`) so the limiter gate treats
+    /// a per-zone bucket and the `&'static` fallback uniformly. Used by
+    /// `icmp_ratelimit::allow_generated_reject*`.
+    pub(in crate::afxdp) fn reject_bucket(
+        &self,
+        from_zone_id: u16,
+    ) -> Option<&crate::afxdp::icmp_ratelimit::TokenBucket> {
+        self.reject_buckets.get(&from_zone_id).map(|b| b.as_ref())
+    }
+
     /// #2851/#3182: true iff `ip` is one of the router's OWN configured
     /// interface IPs — i.e. an address this firewall must never learn from a
     /// link-local advertisement. The dynamic
@@ -420,12 +456,8 @@ impl ForwardingState {
     #[inline]
     pub(in crate::afxdp) fn owns_configured_ip(&self, ip: IpAddr) -> bool {
         match ip {
-            IpAddr::V4(v4) => {
-                self.configured_iface_v4.contains(&v4) || self.local_v4.contains(&v4)
-            }
-            IpAddr::V6(v6) => {
-                self.configured_iface_v6.contains(&v6) || self.local_v6.contains(&v6)
-            }
+            IpAddr::V4(v4) => self.configured_iface_v4.contains(&v4) || self.local_v4.contains(&v4),
+            IpAddr::V6(v6) => self.configured_iface_v6.contains(&v6) || self.local_v6.contains(&v6),
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #3618. The locally-generated `reject` reply (policy `then reject`, firewall-filter / lo0 `then reject`, or a zone `tcp-rst` deny — a TCP RST or ICMP/ICMPv6 admin-prohibited unreachable) was rate-limited by a **single process-global** GCRA token bucket. A rejected-flow flood ingressing one (untrusted) zone drained that shared bucket, so a legitimate reject in a **different** zone fail-closed to a silent drop even though that zone was not under attack. The aggregate cap could not also deliver per-zone fairness — an operator troubleshooting a policy misconfig in a quiet zone never saw that zone's reject diagnostic while a busy zone stayed flooded.

Per the converged research plan (`research/3618-reject-bucket`, config-keyed sparse map), the Reject reason is now split into **one bucket per configured ingress (from) zone**.

## What changed

- `ForwardingState::reject_buckets: FastMap<u16, Arc<TokenBucket>>`, built in `populate_zones` from the same validated zone set as `zone_id_to_name`. Cardinality = configured zones (Go-capped ≤ 65533), not attacker-growable. Held behind `Arc` so the shared atomics **survive `ForwardingState::clone()`** — the coordinator re-stores a clone at runtime cadence (fabric refresh); a plain-value clone would snapshot stale coordinator-side atomics and effectively reset the limiter. Genuine config rebuild → fresh buckets (reset-on-commit, accepted for a diagnostic limiter). All workers share one `Arc<ForwardingState>` → cap is per-zone, not per-worker.
- Reject call site (`enqueue_reject_reply`) resolves the from-zone from the **logical** ingress ifindex via `ifindex_to_zone_id` (same SSOT as the #3976 build / #3035 classify, so VLAN sub-ifs key their own zone) and gates on new `icmp_ratelimit::allow_generated_reject(forwarding, from_zone_id)`. Unzoned/unknown → process-global `REJECT_FALLBACK_BUCKET` (**never fail-open**, never panics).
- TimeExceeded / PacketTooBig keep their single global bucket (no clean ingress zone at their generator sites).
- **Metric preserved:** aggregate `reject_rate_limited_total` is now a dedicated single atomic bumped on every per-zone deny (not a sum), so `rate_limited_count` stays O(1) and the coordinator status / Prometheus `xpf_userspace_reject_rate_limited_total` wire contract is UNCHANGED. The #3661 per-source split still sums to it.

Fairness/observability fix only — the trigger packet is dropped fail-closed regardless; never a good-traffic-drop or security bypass. Does not weaken anti-amplification: the realistic reflection attacker floods one ingress path, still capped at 1000/s per zone.

## Tests

Five new tests — headline per-zone isolation, **end-to-end** call-site isolation through `enqueue_policy_reject_reply` (ingress ifindex → from-zone → bucket), fallback for unknown/unzoned ids, aggregate-sums-across-zones (metric preservation), and reason isolation vs TE/PTB. **All go RED on a revert to a single shared bucket (verified).** Full userspace-dp cargo suite (serial): **main binary 3624 passed / 0 failed**; reject/icmp_ratelimit subset 41/0.

## Docs

New `docs/generated-reply-rate-limit.md` (SSOT), userspace-dp README reject-limiter paragraph, `icmp_ratelimit.rs` module header.

## Validation note

Dataplane change on the cold reject path. A cluster reject-rate-limit smoke (config `then reject` in two zones, flood zone A while sending a low-rate denied flow in zone B, confirm zone B still receives its RST/ICMP-unreachable while `xpf_userspace_reject_rate_limited_total` climbs from zone A) is **warranted before merge** but not run in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi