### PR TITLE
cluster: authenticate the session-sync stream with the control-link PSK (#4107 F23)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -37129,3 +37129,45 @@ top.
   pkg/config/compiler_validate_strict.go,
   pkg/config/parser_class_of_service_test.go,
   userspace-dp/src/afxdp/types/cos.rs, _Log.md
+
+- **Timestamp**: 2026-07-06
+  **Action**: #4107 F23 — authenticate the cluster session-sync STREAM with
+  the control-link PSK (F1 already closed by #4357). The length-framed sync
+  stream (session state + election/failover control) carried plaintext with
+  no auth. The heartbeat's trailing-HMAC does not work on a length-framed
+  stream (a legacy reader mis-frames a trailing HMAC as the next header), so
+  F23 uses an auth-capability HANDSHAKE at connection setup + a per-frame
+  seal. DESIGN (new `pkg/cluster/sync_auth.go`): (1) `performSyncHandshake`
+  — only a keyed node initiates; each keyed side sends a HELLO
+  (`syncMsgAuthHello`, type 27) with a fresh 32-byte nonce, and when BOTH are
+  keyed each proves PSK possession with `syncMsgAuthProof` (type 28) =
+  HMAC(key, tag‖peer-nonce) (mutual challenge-response, replay-safe via fresh
+  per-connection nonces). HELLO/PROOF are written CONCURRENTLY with the read
+  so the handshake does not deadlock on net.Pipe / two symmetric peers. (2)
+  Per-frame seal: on an authenticated connection every frame gets an 8-byte
+  monotonic sequence + 32-byte HMAC keyed by a per-connection key derived
+  from the PSK + both nonces (`sealFrame`/`verifyFrame`); the receiver drops
+  the conn on a bad HMAC (forgery) or non-increasing sequence (replay).
+  `writeFull` is the single seal chokepoint (all writers hold `s.writeMu`);
+  `receiveLoop` is the single verify point. Chose signed per-frame trailer
+  over bare sequence (a sequence without a MAC is forgeable; MAC cost is
+  negligible). (3) Dual-accept: a no-key node never handshakes (byte-identical
+  legacy peer); a keyed node seeing a legacy/unkeyed peer negotiates
+  UNAUTHENTICATED and preserves the peer's first real frame as a
+  `pendingFrame`. (4) Downgrade-guard (`syncAuthDecision`, mirrors
+  `heartbeatAuthDecision`): once the peer authed on the sync channel (sticky
+  `syncAuthedEver`) OR the heartbeat (`HeartbeatPeerAuthSeen`), a later
+  unauthenticated connection is rejected. Wired via
+  `SessionSync.SetAuthProvider(*Manager)` in daemon_ha_sync.go — same
+  `set chassis cluster authentication-key` secret, no new config leaf.
+  Tests (RED-on-revert verified by neutralizing enforcement → 5 test
+  functions fail): both-keyed authenticates + sealed frame round-trips;
+  mismatched-key rejected; dual-accept legacy peer; downgrade-guard rejects;
+  seal/verify replay+tamper+wrong-key; decision matrix; proof/derived-key
+  construction. Full `go test ./pkg/cluster/ -race` green; go build ./...,
+  go vet, gofmt clean. NOTE: HA session-sync stream — the parent runs
+  `make test-failover` before merge (a reconnect during failover must
+  re-handshake + succeed).
+  **File(s)**: pkg/cluster/sync_auth.go, pkg/cluster/sync_auth_test.go,
+  pkg/cluster/sync.go, pkg/cluster/sync_protocol.go, pkg/cluster/sync_conn.go,
+  pkg/cluster/README.md, pkg/daemon/daemon_ha_sync.go, _Log.md

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -203,22 +203,63 @@ fabric RPCs `Unauthenticated` until corrected — a > 30s inter-node skew is
 an operational NTP fault (NTP is already a cluster prerequisite for
 heartbeat clock-sync and session-timestamp rebasing).
 
-**Remaining follow-up (F23).** The **session-sync stream** frames
-(`sync.go` / `sync_conn.go` / `sync_protocol.go`) are still
-unauthenticated cleartext. Unlike the UDP heartbeat (where an appended
-trailer is transparently ignored by a legacy reader that parses from the
-front), the session-sync stream frames by a length-prefixed header, so a
-legacy peer would mis-frame a trailing HMAC as the next header — a
-stream-safe dual-accept needs an auth **capability handshake at
-connection setup** (negotiate signing before the first data frame) rather
-than a per-frame trailer, and it touches every `writeMsg` /
-`encode*Message` / `writeFull` site plus per-connection replay state and
-MUST pass `make test-failover` (it is the path that keeps TCP alive
-across failover). It is filed as the F23 follow-up on #4107 and is LOW
-severity (matches Juniper's own unauthenticated direct-cable control-link
-posture; the acute HIGH lever — the full-service fabric gRPC surface — is
-closed by PR-B). The shared `ControlLinkAuthKey` and dual-accept helpers
-land here so F23 reuses them.
+**Session-sync stream auth (F23, done — `sync_auth.go`).** The
+**session-sync stream** frames (`sync.go` / `sync_conn.go` /
+`sync_protocol.go`) are now authenticated with the SAME control-link PSK.
+The heartbeat's trailing-HMAC does NOT work here: the stream is
+length-framed, so a legacy reader would mis-frame an appended HMAC as the
+next header. F23 instead uses an auth **capability handshake at connection
+setup** that negotiates — BEFORE any session frame flows — whether the
+connection is authenticated, then seals every subsequent frame.
+
+- **Handshake (`performSyncHandshake`).** Only a node that holds the PSK
+  initiates it. Each keyed side sends a HELLO (`syncMsgAuthHello`, type 27)
+  advertising a fresh 32-byte challenge nonce; when BOTH peers are keyed
+  each proves possession with `syncMsgAuthProof` (type 28) =
+  `HMAC-SHA256(key, tag ‖ peer-nonce)` (mutual challenge-response). Fresh
+  per-connection nonces make the proof replay-safe at setup. HELLO/PROOF
+  are written CONCURRENTLY with reading the peer's frame so the handshake
+  does not deadlock on a fully-synchronous transport (`net.Pipe` in tests /
+  a strict write-then-read on two symmetric peers). Types 27/28 sit above
+  the legacy set so an old peer ignores them (default receive case).
+- **Per-frame seal (`authConn.sealFrame` / `verifyFrame`).** On an
+  AUTHENTICATED connection every frame gets an 8-byte per-connection
+  monotonic sequence + a 32-byte HMAC keyed by a per-connection key derived
+  from the PSK and BOTH handshake nonces (`syncDeriveFrameKey`, canonical
+  nonce order so both peers derive the same key). The receiver rejects a bad
+  HMAC (forgery/tamper) or a non-increasing sequence (replay/regression) and
+  drops the connection. `writeFull` is the single chokepoint that seals (all
+  writers hold `s.writeMu`, so sequence order equals wire order);
+  `receiveLoop` is the single reader that strips + verifies the trailer.
+  Chose a signed per-frame trailer over a bare sequence because a sequence
+  without a MAC is forgeable (an on-path attacker just uses seq+1); the MAC
+  cost is negligible at realistic session-sync rates.
+- **Dual-accept (rolling upgrade).** A node with no key never handshakes
+  and is byte-for-byte a legacy peer; a keyed node that sees a
+  legacy/unkeyed peer (no HELLO, or `keyed=0`) negotiates
+  UNAUTHENTICATED — the stream stays legacy-compatible (no brick). The
+  legacy peer's first real frame, consumed by the handshake read, is
+  preserved as a `pendingFrame` and processed before the receive loop
+  starts. Enforcement engages only once BOTH nodes are keyed and signing.
+- **Downgrade-guard (`syncAuthDecision`, mirrors `heartbeatAuthDecision`).**
+  Once the peer has authenticated on the sync channel (sticky
+  `syncAuthedEver`) OR the heartbeat channel (`HeartbeatPeerAuthSeen`, arms
+  within ~200ms of a keyed peer coming up), a later UNAUTHENTICATED
+  connection from it is REJECTED — a downgrade to cleartext once both nodes
+  are known-keyed is an attack. Consulting the heartbeat closes the window
+  after a keyed node restarts before the first sync auth.
+- **Wiring.** `SessionSync.SetAuthProvider(*Manager)` (`daemon_ha_sync.go`)
+  supplies both `ControlLinkAuthKey()` and `HeartbeatPeerAuthSeen()`. No new
+  config leaf — the same `set chassis cluster authentication-key` secret
+  authenticates the heartbeat (PR-A), the fabric gRPC (PR-B/#4357), and now
+  the session-sync stream. LOW severity (matches Juniper's own
+  unauthenticated direct-cable control-link posture); the acute HIGH lever
+  (the full-service fabric gRPC surface) was closed by #4357.
+- **Failover.** The handshake happens at connect and a reconnect during
+  failover re-handshakes; a keyed↔keyed reconnect completes in
+  milliseconds. A dropped handshake closes the connection and the
+  accept/connect loops retry (~1s) — it never bricks. MUST pass
+  `make test-failover` (the path that keeps TCP alive across failover).
 
 ## DHCP-server lease sync (#2239)
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -232,22 +232,29 @@ func (s TransferReadinessSnapshot) Reason() string {
 // SessionSync manages TCP-based session state replication between cluster
 // peers for stateful failover.
 type SessionSync struct {
-	localAddr  string
-	peerAddr   string
-	sessions   dataplane.SessionStore
-	telemetry  dataplane.Telemetry
-	stats      SyncStats
-	mu         sync.Mutex
-	conn0      net.Conn
-	conn1      net.Conn
-	writeMu    sync.Mutex
-	listener   net.Listener
-	localAddr1 string
-	peerAddr1  string
-	listener1  net.Listener
-	cancel     context.CancelFunc
-	wg         sync.WaitGroup
-	sendCh     chan []byte // buffered channel for outgoing messages
+	localAddr string
+	peerAddr  string
+	sessions  dataplane.SessionStore
+	telemetry dataplane.Telemetry
+	stats     SyncStats
+	mu        sync.Mutex
+	conn0     net.Conn
+	conn1     net.Conn
+	writeMu   sync.Mutex
+	// authProvider supplies the shared control-link PSK + the cross-channel
+	// downgrade-guard signal for #4107 F23 session-sync stream auth. Optional:
+	// nil (or an empty key) ⇒ legacy unauthenticated stream (dual-accept).
+	authProvider atomic.Pointer[syncAuthProviderBox]
+	// syncAuthedEver is the sticky sync-channel downgrade-guard: once any sync
+	// connection authenticates, a later unauthenticated connection is rejected.
+	syncAuthedEver atomic.Bool
+	listener       net.Listener
+	localAddr1     string
+	peerAddr1      string
+	listener1      net.Listener
+	cancel         context.CancelFunc
+	wg             sync.WaitGroup
+	sendCh         chan []byte // buffered channel for outgoing messages
 
 	// incrementalPauseDepth temporarily pauses background incremental producers
 	// during ordered handoff operations.

--- a/pkg/cluster/sync_auth.go
+++ b/pkg/cluster/sync_auth.go
@@ -1,0 +1,417 @@
+package cluster
+
+// Session-sync stream authentication (#4107 F23).
+//
+// The cross-chassis session-sync stream (sync.go / sync_conn.go /
+// sync_protocol.go) is length-framed: every message is a `syncHeader`
+// (magic + type + length) followed by `length` payload bytes. Before this
+// change the stream carried session state, config, and election/failover
+// control messages in cleartext with no authentication — any host that could
+// reach the fabric/control-link IP could open the listener, dump session
+// tuples, or drive a failover.
+//
+// The heartbeat's trailing-HMAC approach (heartbeat.go, #4357/PR-A) does NOT
+// work on a length-framed stream: a legacy reader would mis-frame an appended
+// HMAC as the next message header. So F23 uses an auth-capability HANDSHAKE at
+// connection setup that negotiates — BEFORE any session frame flows — whether
+// the connection is authenticated, and, once authenticated, seals every
+// subsequent frame with a per-connection monotonic sequence + HMAC so an
+// on-path attacker can neither forge nor replay a frame.
+//
+// Design summary:
+//   - Handshake (performSyncHandshake): only a node that holds the shared
+//     control-link PSK (the same `set chassis cluster authentication-key`
+//     secret that #4357 wired for the heartbeat + fabric gRPC) initiates the
+//     handshake. It sends a HELLO advertising a fresh 32-byte challenge nonce;
+//     when BOTH peers are keyed each proves possession of the PSK with an
+//     HMAC over the OTHER side's nonce (mutual challenge-response). Fresh
+//     per-connection nonces make the proof replay-safe at setup.
+//   - Dual-accept (rolling upgrade): a node with no key never handshakes and
+//     is byte-for-byte a legacy peer; a keyed node that sees a legacy/unkeyed
+//     peer negotiates UNAUTHENTICATED and the stream stays legacy-compatible.
+//     Enforcement engages only once BOTH nodes are keyed and signing.
+//   - Downgrade-guard: once a peer has authenticated (on the sync channel OR
+//     the heartbeat channel, HeartbeatPeerAuthSeen), a later UNAUTHENTICATED
+//     connection from it is rejected — mirrors heartbeatAuthDecision / the
+//     #4357 fabric guard.
+//   - Per-frame seal (authConn.sealFrame / verifyFrame): on an authenticated
+//     connection every frame gets an 8-byte per-connection sequence + a
+//     32-byte HMAC (keyed by a per-connection key derived from the PSK and
+//     BOTH handshake nonces). The receiver rejects a bad HMAC (forgery /
+//     tamper) or a non-increasing sequence (replay). Frames on an
+//     unauthenticated connection are pass-through — identical to the legacy
+//     wire — so dual-accept never changes the bytes.
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// syncMsgAuthHello and syncMsgAuthProof are the two handshake message
+	// types. They are ABOVE the legacy message set (<= 26) so a peer that
+	// predates F23 hits the (implicit) default receive case and ignores them —
+	// the same additive-type discipline as the #2239 DHCP-lease messages.
+	syncMsgAuthHello = 27 // {version:u8, keyed:u8, nonce[32]}
+	syncMsgAuthProof = 28 // HMAC-SHA256 proof over the peer's HELLO nonce
+)
+
+const (
+	syncAuthVersion   = 1
+	syncAuthNonceSize = 32
+	syncAuthMACSize   = sha256.Size // 32
+	// syncAuthFrameTrailerSize is appended to each frame on an authenticated
+	// connection: seq(8) + HMAC-SHA256(32).
+	syncAuthFrameTrailerSize = 8 + syncAuthMACSize
+	// syncHandshakeTimeout bounds the whole setup handshake. A hung/absent
+	// peer drops the connection; fabricConnectLoop retries after ~1s, so a
+	// transient handshake failure only delays reconnect — it never bricks
+	// (dual-accept keeps a rolling upgrade alive without the handshake).
+	syncHandshakeTimeout = 10 * time.Second
+)
+
+// Domain-separation tags — bound into every HMAC so a value produced for one
+// purpose can never be reused as another.
+var (
+	syncAuthProofTag    = []byte("xpf-cluster-sync-auth-proof-v1\x00")
+	syncAuthFrameKeyTag = []byte("xpf-cluster-sync-frame-key-v1\x00")
+	syncAuthFrameMACTag = []byte("xpf-cluster-sync-frame-mac-v1\x00")
+)
+
+var (
+	errSyncFrameAuth   = errors.New("cluster sync: frame HMAC verification failed")
+	errSyncFrameReplay = errors.New("cluster sync: frame sequence replay/regression")
+)
+
+// syncAuthMode is the negotiated auth posture for one sync connection.
+type syncAuthMode int
+
+const (
+	syncAuthUnauthenticated syncAuthMode = iota // dual-accept: frames are pass-through
+	syncAuthAuthenticated                       // PSK handshake succeeded; frames sealed
+)
+
+// SyncAuthProvider supplies the shared control-link PSK and the cross-channel
+// downgrade-guard signal to the session-sync stream authenticator (#4107 F23).
+// *Manager satisfies it (ControlLinkAuthKey + HeartbeatPeerAuthSeen). It is
+// OPTIONAL: when no provider is wired, or the key is empty, the sync stream
+// runs in legacy unauthenticated mode (dual-accept), byte-identical to before.
+type SyncAuthProvider interface {
+	ControlLinkAuthKey() []byte
+	HeartbeatPeerAuthSeen() bool
+}
+
+type syncAuthProviderBox struct{ p SyncAuthProvider }
+
+// SetAuthProvider wires the shared-PSK source used to authenticate the
+// session-sync stream. Call once before Start.
+func (s *SessionSync) SetAuthProvider(p SyncAuthProvider) {
+	s.authProvider.Store(&syncAuthProviderBox{p: p})
+}
+
+// authKey returns the current control-link PSK, or nil when no provider is
+// wired / no key is configured. Read live so a key added/changed at commit is
+// picked up on the next handshake.
+func (s *SessionSync) authKey() []byte {
+	if box := s.authProvider.Load(); box != nil && box.p != nil {
+		return box.p.ControlLinkAuthKey()
+	}
+	return nil
+}
+
+// syncPeerAuthSeen reports whether the peer has ever authenticated on EITHER
+// the sync channel (this stream, sticky s.syncAuthedEver) or the heartbeat
+// channel (HeartbeatPeerAuthSeen). Either proves both nodes are keyed, so a
+// subsequent unauthenticated connection is a downgrade attack and must be
+// rejected. Consulting the heartbeat closes the window after a keyed node
+// restarts (heartbeats flow every ~200ms) before the first sync auth.
+func (s *SessionSync) syncPeerAuthSeen() bool {
+	if s.syncAuthedEver.Load() {
+		return true
+	}
+	if box := s.authProvider.Load(); box != nil && box.p != nil {
+		return box.p.HeartbeatPeerAuthSeen()
+	}
+	return false
+}
+
+// authConn wraps a session-sync connection after the setup handshake. When
+// key != nil the connection is AUTHENTICATED: every frame written through
+// writeFull gets a per-connection sequence + HMAC trailer (sealFrame) and
+// receiveLoop verifies + replay-checks it (verifyFrame). key == nil is an
+// UNAUTHENTICATED (dual-accept) pass-through — byte-identical to the legacy
+// path — so the same wrapper type covers both negotiated postures.
+type authConn struct {
+	net.Conn
+	key     []byte        // per-connection frame-MAC key (nil ⇒ pass-through)
+	sendSeq atomic.Uint64 // monotonic per-connection send counter
+	// recvSeq/recvSeen are the replay watermark, touched only by the single
+	// receiveLoop goroutine that owns this connection — no lock needed.
+	recvSeq  uint64
+	recvSeen bool
+}
+
+// authed reports whether this connection seals/verifies frames.
+func (a *authConn) authed() bool { return a != nil && len(a.key) > 0 }
+
+// sealFrame appends the per-connection auth trailer to a fully-encoded frame
+// (header||payload). Callers hold s.writeMu — the invariant that serializes
+// every write to a connection — so the assigned sequence order equals the
+// on-wire order.
+func (a *authConn) sealFrame(frame []byte) []byte {
+	seq := a.sendSeq.Add(1)
+	out := make([]byte, len(frame)+syncAuthFrameTrailerSize)
+	n := copy(out, frame)
+	binary.LittleEndian.PutUint64(out[n:n+8], seq)
+	mac := hmac.New(sha256.New, a.key)
+	mac.Write(syncAuthFrameMACTag)
+	mac.Write(out[:n+8]) // frame || seq
+	copy(out[n+8:], mac.Sum(nil))
+	return out
+}
+
+// verifyFrame authenticates the trailer that follows a frame on an
+// authenticated connection and enforces the strictly-increasing per-connection
+// sequence (replay/regression guard). header+payload are the frame as read by
+// receiveLoop; trailer is the syncAuthFrameTrailerSize bytes read immediately
+// after. On success it advances the watermark; any error causes receiveLoop to
+// drop the connection.
+func (a *authConn) verifyFrame(header, payload, trailer []byte) error {
+	if len(trailer) != syncAuthFrameTrailerSize {
+		return errSyncFrameAuth
+	}
+	seq := binary.LittleEndian.Uint64(trailer[:8])
+	mac := hmac.New(sha256.New, a.key)
+	mac.Write(syncAuthFrameMACTag)
+	mac.Write(header)
+	mac.Write(payload)
+	mac.Write(trailer[:8])
+	if !hmac.Equal(trailer[8:], mac.Sum(nil)) {
+		return errSyncFrameAuth
+	}
+	if a.recvSeen && seq <= a.recvSeq {
+		return errSyncFrameReplay
+	}
+	a.recvSeq = seq
+	a.recvSeen = true
+	return nil
+}
+
+// syncAuthProof computes the challenge-response proof: HMAC-SHA256(key, tag ||
+// challenge). Each side proves possession of the PSK over the PEER's fresh
+// nonce, so a captured proof cannot be replayed onto a new connection.
+func syncAuthProof(key, challenge []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write(syncAuthProofTag)
+	mac.Write(challenge)
+	return mac.Sum(nil)
+}
+
+// syncDeriveFrameKey derives the per-connection frame-MAC key from the PSK and
+// BOTH handshake nonces, ordered canonically so both peers derive the same key.
+// Binding the key to the fresh nonces means a frame captured on one connection
+// cannot verify on another (cross-connection replay is excluded, not only
+// intra-connection replay).
+func syncDeriveFrameKey(key, nonceA, nonceB []byte) []byte {
+	lo, hi := nonceA, nonceB
+	if bytes.Compare(lo, hi) > 0 {
+		lo, hi = hi, lo
+	}
+	mac := hmac.New(sha256.New, key)
+	mac.Write(syncAuthFrameKeyTag)
+	mac.Write(lo)
+	mac.Write(hi)
+	return mac.Sum(nil)
+}
+
+// syncAuthDecision applies the #4107 dual-accept policy for a session-sync
+// connection handshake and returns the negotiated mode, whether to accept the
+// connection, and (on rejection) a short reason for logging — never the key.
+// It mirrors heartbeatAuthDecision.
+//
+//	keyConfigured  — the local ControlLinkAuthKey is set (we can verify).
+//	peerAdvertised — the peer sent an auth HELLO (an upgrade-aware peer).
+//	peerKeyed      — the peer's HELLO advertised that it holds a key.
+//	proofOK        — the peer's challenge-response proof verified (meaningful
+//	                 only when both sides are keyed).
+//	peerAuthSeen   — sticky: the peer has previously authenticated on the sync
+//	                 OR heartbeat channel (so both nodes are keyed and an
+//	                 unauthenticated connection is now a downgrade attack).
+//
+// Policy:
+//   - No local key: dual-accept — this node cannot verify and may be the
+//     not-yet-keyed side of a rolling upgrade.
+//   - Local key + peer keyed (proof exchanged): enforce — reject a bad proof.
+//   - Local key + peer legacy/unkeyed + peer never authenticated: dual-accept.
+//   - Local key + peer legacy/unkeyed + peer HAS authenticated: reject
+//     (downgrade attack once both nodes are known-keyed).
+func syncAuthDecision(keyConfigured, peerAdvertised, peerKeyed, proofOK, peerAuthSeen bool) (mode syncAuthMode, accept bool, reason string) {
+	if !keyConfigured {
+		return syncAuthUnauthenticated, true, ""
+	}
+	if peerAdvertised && peerKeyed {
+		if proofOK {
+			return syncAuthAuthenticated, true, ""
+		}
+		return syncAuthUnauthenticated, false, "hmac verification failed"
+	}
+	if peerAuthSeen {
+		return syncAuthUnauthenticated, false, "missing auth handshake (enforced: peer previously authenticated)"
+	}
+	return syncAuthUnauthenticated, true, ""
+}
+
+// pendingFrame carries a legacy/unkeyed peer's first real frame that was
+// consumed by the handshake read. receiveLoop must process it before reading
+// further so no message is lost and stream order is preserved.
+type pendingFrame struct {
+	typ     uint8
+	payload []byte
+}
+
+// readSyncFrameRaw reads one length-framed sync frame (header+payload) directly
+// from a connection during the handshake, before any per-frame sealing is in
+// effect. It does not strip an auth trailer.
+func readSyncFrameRaw(conn net.Conn) (typ uint8, payload []byte, err error) {
+	hdr := make([]byte, syncHeaderSize)
+	if _, err := io.ReadFull(conn, hdr); err != nil {
+		return 0, nil, err
+	}
+	if [4]byte{hdr[0], hdr[1], hdr[2], hdr[3]} != syncMagic {
+		return 0, nil, errors.New("cluster sync: bad magic during handshake")
+	}
+	typ = hdr[4]
+	length := binary.LittleEndian.Uint32(hdr[8:12])
+	if length > 16*1024*1024 {
+		return 0, nil, fmt.Errorf("cluster sync: handshake frame too large: %d", length)
+	}
+	if length > 0 {
+		payload = make([]byte, length)
+		if _, err := io.ReadFull(conn, payload); err != nil {
+			return 0, nil, err
+		}
+	}
+	return typ, payload, nil
+}
+
+// performSyncHandshake runs the connection-setup auth-capability handshake on a
+// freshly connected sync connection and returns the negotiated mode, the
+// per-connection frame key (non-nil only when authenticated), an optional first
+// frame a legacy/unkeyed peer already sent (the caller must process it before
+// reading further), and an error when the connection must be dropped (bad PSK
+// proof, a downgrade attempt, or an I/O failure).
+//
+// The handshake runs ONLY when a local key is configured. An unkeyed node
+// (legacy build, or a new build with no key yet) sends nothing special and is
+// indistinguishable from — and fully compatible with — a legacy peer, so
+// existing no-key deployments and tests are unaffected (dual-accept).
+//
+// HELLO and PROOF are written concurrently with reading the peer's frame so the
+// handshake works over a fully-synchronous transport (net.Pipe in tests): a
+// strict write-then-read on both symmetric peers would deadlock.
+func (s *SessionSync) performSyncHandshake(conn net.Conn) (syncAuthMode, []byte, *pendingFrame, error) {
+	key := s.authKey()
+	if len(key) == 0 {
+		// No local key ⇒ no handshake; legacy behavior (dual-accept).
+		return syncAuthUnauthenticated, nil, nil, nil
+	}
+
+	if err := conn.SetDeadline(time.Now().Add(syncHandshakeTimeout)); err != nil {
+		return syncAuthUnauthenticated, nil, nil, err
+	}
+	defer conn.SetDeadline(time.Time{})
+
+	localNonce := make([]byte, syncAuthNonceSize)
+	if _, err := rand.Read(localNonce); err != nil {
+		return syncAuthUnauthenticated, nil, nil, fmt.Errorf("cluster sync: handshake nonce: %w", err)
+	}
+	hello := make([]byte, 0, 2+syncAuthNonceSize)
+	hello = append(hello, syncAuthVersion, 1) // version, keyed=1
+	hello = append(hello, localNonce...)
+
+	writeErr := make(chan error, 1)
+	go func() { writeErr <- writeMsg(conn, syncMsgAuthHello, hello) }()
+
+	typ, payload, err := readSyncFrameRaw(conn)
+	if err != nil {
+		<-writeErr
+		return syncAuthUnauthenticated, nil, nil, err
+	}
+	if werr := <-writeErr; werr != nil {
+		return syncAuthUnauthenticated, nil, nil, werr
+	}
+
+	peerAuthSeen := s.syncPeerAuthSeen()
+
+	if typ != syncMsgAuthHello {
+		// Peer sent a real frame, not a HELLO ⇒ legacy or unkeyed peer.
+		_, accept, reason := syncAuthDecision(true, false, false, false, peerAuthSeen)
+		if !accept {
+			return syncAuthUnauthenticated, nil, nil, errors.New(reason)
+		}
+		return syncAuthUnauthenticated, nil, &pendingFrame{typ: typ, payload: payload}, nil
+	}
+
+	if len(payload) < 2+syncAuthNonceSize {
+		return syncAuthUnauthenticated, nil, nil, errors.New("cluster sync: short auth HELLO")
+	}
+	peerKeyed := payload[1] != 0
+	peerNonce := payload[2 : 2+syncAuthNonceSize]
+
+	if !peerKeyed {
+		// Peer is a new build but holds no key ⇒ it is not signing. Dual-accept.
+		_, accept, reason := syncAuthDecision(true, true, false, false, peerAuthSeen)
+		if !accept {
+			return syncAuthUnauthenticated, nil, nil, errors.New(reason)
+		}
+		return syncAuthUnauthenticated, nil, nil, nil
+	}
+
+	// Both keyed ⇒ mutual challenge-response: prove we hold the key over the
+	// PEER's nonce; verify the peer's proof over OUR nonce.
+	proofOut := syncAuthProof(key, peerNonce)
+	go func() { writeErr <- writeMsg(conn, syncMsgAuthProof, proofOut) }()
+
+	ptyp, ppayload, err := readSyncFrameRaw(conn)
+	if err != nil {
+		<-writeErr
+		return syncAuthUnauthenticated, nil, nil, err
+	}
+	if werr := <-writeErr; werr != nil {
+		return syncAuthUnauthenticated, nil, nil, werr
+	}
+
+	proofOK := ptyp == syncMsgAuthProof && hmac.Equal(ppayload, syncAuthProof(key, localNonce))
+	mode, accept, reason := syncAuthDecision(true, true, true, proofOK, peerAuthSeen)
+	if !accept {
+		return syncAuthUnauthenticated, nil, nil, errors.New(reason)
+	}
+	frameKey := syncDeriveFrameKey(key, localNonce, peerNonce)
+	return mode, frameKey, nil, nil
+}
+
+// wrapSyncConn applies the negotiated handshake result to a connection: it
+// wraps conn in an authConn (sealing frames when authenticated) and, when the
+// connection authenticated, arms the sticky downgrade-guard. pending is the
+// legacy peer's first frame (nil when none) and is returned for the caller to
+// process before starting the receive loop.
+func (s *SessionSync) wrapSyncConn(fabricIdx int, conn net.Conn, mode syncAuthMode, frameKey []byte) *authConn {
+	ac := &authConn{Conn: conn}
+	if mode == syncAuthAuthenticated {
+		ac.key = frameKey
+		s.syncAuthedEver.Store(true)
+		slog.Info("cluster sync: connection authenticated with control-link PSK",
+			"fabric", fabricIdx, "remote", connRemoteAddrString(conn))
+	}
+	return ac
+}

--- a/pkg/cluster/sync_auth_test.go
+++ b/pkg/cluster/sync_auth_test.go
@@ -1,0 +1,339 @@
+package cluster
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+// fakeSyncAuthProvider is a test SyncAuthProvider that returns a fixed PSK and a
+// settable heartbeat downgrade-guard signal.
+type fakeSyncAuthProvider struct {
+	key      []byte
+	authSeen bool
+}
+
+func (f *fakeSyncAuthProvider) ControlLinkAuthKey() []byte  { return f.key }
+func (f *fakeSyncAuthProvider) HeartbeatPeerAuthSeen() bool { return f.authSeen }
+
+type handshakeResult struct {
+	mode    syncAuthMode
+	key     []byte
+	pending *pendingFrame
+	err     error
+}
+
+func runHandshake(s *SessionSync, conn net.Conn) <-chan handshakeResult {
+	ch := make(chan handshakeResult, 1)
+	go func() {
+		mode, key, pending, err := s.performSyncHandshake(conn)
+		ch <- handshakeResult{mode: mode, key: key, pending: pending, err: err}
+	}()
+	return ch
+}
+
+func newAuthSync(t *testing.T, key []byte, authSeen bool) *SessionSync {
+	t.Helper()
+	s := NewSessionSync(":0", ":0", nil)
+	if key != nil || authSeen {
+		s.SetAuthProvider(&fakeSyncAuthProvider{key: key, authSeen: authSeen})
+	}
+	return s
+}
+
+// TestSyncAuthHandshakeBothKeyedAuthenticates verifies the happy path: two
+// keyed peers with the SAME PSK complete the mutual challenge-response, both
+// negotiate authenticated, and both derive the same per-connection frame key —
+// after which a sealed session frame round-trips. RED on revert: without the
+// handshake there is no authentication and no derived key.
+func TestSyncAuthHandshakeBothKeyedAuthenticates(t *testing.T) {
+	key := []byte("shared-control-link-secret-key")
+	a := newAuthSync(t, key, false)
+	b := newAuthSync(t, key, false)
+
+	ca, cb := net.Pipe()
+	defer ca.Close()
+	defer cb.Close()
+
+	ach := runHandshake(a, ca)
+	bch := runHandshake(b, cb)
+
+	ar := <-ach
+	br := <-bch
+
+	if ar.err != nil || br.err != nil {
+		t.Fatalf("handshake errored: a=%v b=%v", ar.err, br.err)
+	}
+	if ar.mode != syncAuthAuthenticated || br.mode != syncAuthAuthenticated {
+		t.Fatalf("expected both authenticated, got a=%d b=%d", ar.mode, br.mode)
+	}
+	if len(ar.key) == 0 || !bytes.Equal(ar.key, br.key) {
+		t.Fatalf("frame keys must be non-empty and equal: a=%x b=%x", ar.key, br.key)
+	}
+	if ar.pending != nil || br.pending != nil {
+		t.Fatalf("no pending frame expected on authenticated path")
+	}
+
+	// A sealed session frame must round-trip: seal on A's authConn, verify on
+	// B's authConn (their frame keys are equal).
+	sender := &authConn{Conn: ca, key: ar.key}
+	receiver := &authConn{Conn: cb, key: br.key}
+	frame := encodeRawMessage(syncMsgSessionV4, []byte("session-payload"))
+	sealed := sender.sealFrame(frame)
+
+	header := sealed[:syncHeaderSize]
+	length := binary.LittleEndian.Uint32(header[8:12])
+	payload := sealed[syncHeaderSize : syncHeaderSize+int(length)]
+	trailer := sealed[syncHeaderSize+int(length):]
+	if len(trailer) != syncAuthFrameTrailerSize {
+		t.Fatalf("sealed frame trailer size = %d, want %d", len(trailer), syncAuthFrameTrailerSize)
+	}
+	if err := receiver.verifyFrame(header, payload, trailer); err != nil {
+		t.Fatalf("authenticated frame failed to verify: %v", err)
+	}
+}
+
+// TestSyncAuthHandshakeMismatchedKeyRejected verifies that a peer presenting a
+// bad setup proof (a different PSK) is REJECTED — the connection is dropped and
+// no session data is accepted. RED on revert: without the handshake the
+// connection is accepted regardless of key.
+func TestSyncAuthHandshakeMismatchedKeyRejected(t *testing.T) {
+	a := newAuthSync(t, []byte("key-alpha"), false)
+	b := newAuthSync(t, []byte("key-bravo-different"), false)
+
+	ca, cb := net.Pipe()
+	defer ca.Close()
+	defer cb.Close()
+
+	ach := runHandshake(a, ca)
+	bch := runHandshake(b, cb)
+
+	ar := <-ach
+	br := <-bch
+
+	if ar.err == nil {
+		t.Fatalf("expected rejection on side A, got mode=%d key=%x", ar.mode, ar.key)
+	}
+	if br.err == nil {
+		t.Fatalf("expected rejection on side B, got mode=%d key=%x", br.mode, br.key)
+	}
+	if ar.mode == syncAuthAuthenticated || br.mode == syncAuthAuthenticated {
+		t.Fatalf("mismatched keys must not authenticate: a=%d b=%d", ar.mode, br.mode)
+	}
+}
+
+// TestSyncAuthHandshakeDualAcceptLegacyPeer verifies the rolling-upgrade case:
+// a keyed node talking to a legacy/unkeyed peer (one that sends no HELLO,
+// starting instead with a real frame) negotiates UNAUTHENTICATED and preserves
+// that first frame as a pendingFrame — the stream stays legacy-compatible (no
+// brick).
+func TestSyncAuthHandshakeDualAcceptLegacyPeer(t *testing.T) {
+	a := newAuthSync(t, []byte("psk"), false)
+
+	ca, cb := net.Pipe()
+	defer ca.Close()
+	defer cb.Close()
+
+	ach := runHandshake(a, ca)
+
+	// Legacy peer: consume A's HELLO (so A's concurrent HELLO write unblocks),
+	// then send a normal clock-sync as its first frame.
+	if _, _, err := readSyncFrameRaw(cb); err != nil {
+		t.Fatalf("legacy peer failed to read HELLO: %v", err)
+	}
+	var clockBuf [8]byte
+	binary.LittleEndian.PutUint64(clockBuf[:], 12345)
+	if err := writeMsg(cb, syncMsgClockSync, clockBuf[:]); err != nil {
+		t.Fatalf("legacy peer failed to send clock sync: %v", err)
+	}
+
+	ar := <-ach
+	if ar.err != nil {
+		t.Fatalf("dual-accept should not error: %v", ar.err)
+	}
+	if ar.mode != syncAuthUnauthenticated {
+		t.Fatalf("expected unauthenticated dual-accept, got mode=%d", ar.mode)
+	}
+	if ar.key != nil {
+		t.Fatalf("unauthenticated connection must have no frame key")
+	}
+	if ar.pending == nil || ar.pending.typ != syncMsgClockSync {
+		t.Fatalf("legacy peer's first frame must be preserved as pending, got %+v", ar.pending)
+	}
+}
+
+// TestSyncAuthHandshakeDowngradeGuardRejects verifies the downgrade-guard: once
+// the peer has authenticated (here via the heartbeat channel, authSeen=true), a
+// later UNAUTHENTICATED connection from a legacy/unkeyed peer is REJECTED rather
+// than silently downgraded. RED on revert: without the guard the legacy peer is
+// dual-accepted.
+func TestSyncAuthHandshakeDowngradeGuardRejects(t *testing.T) {
+	a := newAuthSync(t, []byte("psk"), true) // heartbeat already saw the peer auth
+
+	ca, cb := net.Pipe()
+	defer ca.Close()
+	defer cb.Close()
+
+	ach := runHandshake(a, ca)
+
+	// Legacy peer: consume A's HELLO, then send a real frame with no handshake.
+	if _, _, err := readSyncFrameRaw(cb); err != nil {
+		t.Fatalf("legacy peer failed to read HELLO: %v", err)
+	}
+	var clockBuf [8]byte
+	binary.LittleEndian.PutUint64(clockBuf[:], 1)
+	// The peer may fail to write once A rejects and closes; ignore that error.
+	_ = writeMsg(cb, syncMsgClockSync, clockBuf[:])
+
+	ar := <-ach
+	if ar.err == nil {
+		t.Fatalf("downgrade-guard must reject an unauthenticated peer once authed, got mode=%d", ar.mode)
+	}
+	if ar.mode == syncAuthAuthenticated {
+		t.Fatalf("guard rejection must not authenticate")
+	}
+}
+
+// TestSyncAuthDisabledNoHandshake verifies that with no auth provider (or no
+// key) the handshake is a no-op: no bytes are exchanged and the connection is
+// unauthenticated (legacy behavior, byte-identical to before F23).
+func TestSyncAuthDisabledNoHandshake(t *testing.T) {
+	s := NewSessionSync(":0", ":0", nil) // no provider
+
+	ca, cb := net.Pipe()
+	defer ca.Close()
+	defer cb.Close()
+
+	// If performSyncHandshake performed any I/O it would block on the pipe; a
+	// watchdog guarantees the test fails loudly instead of hanging.
+	done := make(chan handshakeResult, 1)
+	go func() {
+		mode, key, pending, err := s.performSyncHandshake(ca)
+		done <- handshakeResult{mode: mode, key: key, pending: pending, err: err}
+	}()
+
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("disabled handshake errored: %v", r.err)
+		}
+		if r.mode != syncAuthUnauthenticated || r.key != nil || r.pending != nil {
+			t.Fatalf("disabled handshake must be an unauthenticated no-op, got %+v", r)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("performSyncHandshake blocked with no key configured (must be a no-op)")
+	}
+	_ = cb
+}
+
+// TestSyncFrameSealVerifyRoundTripAndReplay unit-tests the per-frame seal /
+// verify path: sequential frames verify and advance the watermark; a replayed
+// (regressed sequence) frame, a tampered payload, and a wrong-key MAC are all
+// rejected. RED on revert: sealFrame/verifyFrame do not exist.
+func TestSyncFrameSealVerifyRoundTripAndReplay(t *testing.T) {
+	key := []byte("per-connection-frame-key-abc")
+	send := &authConn{key: key}
+	recv := &authConn{key: key}
+
+	split := func(sealed []byte) (header, payload, trailer []byte) {
+		header = sealed[:syncHeaderSize]
+		length := binary.LittleEndian.Uint32(header[8:12])
+		payload = sealed[syncHeaderSize : syncHeaderSize+int(length)]
+		trailer = sealed[syncHeaderSize+int(length):]
+		return
+	}
+
+	frame1 := encodeRawMessage(syncMsgSessionV4, []byte("one"))
+	frame2 := encodeRawMessage(syncMsgSessionV6, []byte("two"))
+	sealed1 := send.sealFrame(frame1)
+	sealed2 := send.sealFrame(frame2)
+
+	// Sequence must be strictly increasing (1, then 2).
+	if got := binary.LittleEndian.Uint64(sealed1[len(sealed1)-syncAuthFrameTrailerSize : len(sealed1)-syncAuthMACSize]); got != 1 {
+		t.Fatalf("first sealed frame seq = %d, want 1", got)
+	}
+
+	h1, p1, tr1 := split(sealed1)
+	if err := recv.verifyFrame(h1, p1, tr1); err != nil {
+		t.Fatalf("frame1 must verify: %v", err)
+	}
+	h2, p2, tr2 := split(sealed2)
+	if err := recv.verifyFrame(h2, p2, tr2); err != nil {
+		t.Fatalf("frame2 must verify: %v", err)
+	}
+	// Replay frame1 (seq 1 <= watermark 2) must be rejected.
+	if err := recv.verifyFrame(h1, p1, tr1); err != errSyncFrameReplay {
+		t.Fatalf("replayed frame must be rejected as replay, got %v", err)
+	}
+
+	// Tampered payload must fail the HMAC on a fresh receiver.
+	recv2 := &authConn{key: key}
+	tampered := append([]byte(nil), p2...)
+	tampered[0] ^= 0xFF
+	if err := recv2.verifyFrame(h2, tampered, tr2); err != errSyncFrameAuth {
+		t.Fatalf("tampered payload must fail HMAC, got %v", err)
+	}
+
+	// Wrong key must fail the HMAC.
+	recv3 := &authConn{key: []byte("wrong-key")}
+	if err := recv3.verifyFrame(h1, p1, tr1); err != errSyncFrameAuth {
+		t.Fatalf("wrong-key frame must fail HMAC, got %v", err)
+	}
+}
+
+// TestSyncAuthDecisionMatrix exercises the dual-accept + downgrade-guard policy
+// directly (mirrors heartbeatAuthDecision's contract).
+func TestSyncAuthDecisionMatrix(t *testing.T) {
+	cases := []struct {
+		name                                             string
+		keyConfigured, peerAdv, peerKeyed, proofOK, seen bool
+		wantMode                                         syncAuthMode
+		wantAccept                                       bool
+	}{
+		{"no local key accepts all", false, false, false, false, false, syncAuthUnauthenticated, true},
+		{"no local key ignores guard", false, false, false, false, true, syncAuthUnauthenticated, true},
+		{"both keyed good proof authenticates", true, true, true, true, false, syncAuthAuthenticated, true},
+		{"both keyed bad proof rejected", true, true, true, false, false, syncAuthUnauthenticated, false},
+		{"legacy peer not seen dual-accept", true, false, false, false, false, syncAuthUnauthenticated, true},
+		{"unkeyed peer not seen dual-accept", true, true, false, false, false, syncAuthUnauthenticated, true},
+		{"legacy peer seen rejected", true, false, false, false, true, syncAuthUnauthenticated, false},
+		{"unkeyed peer seen rejected", true, true, false, false, true, syncAuthUnauthenticated, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mode, accept, reason := syncAuthDecision(tc.keyConfigured, tc.peerAdv, tc.peerKeyed, tc.proofOK, tc.seen)
+			if mode != tc.wantMode || accept != tc.wantAccept {
+				t.Fatalf("decision = (mode %d, accept %v, %q), want (mode %d, accept %v)", mode, accept, reason, tc.wantMode, tc.wantAccept)
+			}
+			if !accept && reason == "" {
+				t.Fatalf("rejection must carry a reason")
+			}
+		})
+	}
+}
+
+// TestSyncAuthProofBindsToNonce guards the challenge-response construction: the
+// proof is HMAC(key, tag || challenge) and changes with the challenge, so a
+// captured proof cannot be replayed onto a connection with a fresh nonce.
+func TestSyncAuthProofBindsToNonce(t *testing.T) {
+	key := []byte("k")
+	n1 := bytes.Repeat([]byte{1}, syncAuthNonceSize)
+	n2 := bytes.Repeat([]byte{2}, syncAuthNonceSize)
+	if hmac.Equal(syncAuthProof(key, n1), syncAuthProof(key, n2)) {
+		t.Fatal("proof must differ for different challenges")
+	}
+	want := hmac.New(sha256.New, key)
+	want.Write(syncAuthProofTag)
+	want.Write(n1)
+	if !hmac.Equal(syncAuthProof(key, n1), want.Sum(nil)) {
+		t.Fatal("proof must be HMAC(key, tag||challenge)")
+	}
+	// Frame-key derivation must be order-independent (both peers derive equal).
+	if !bytes.Equal(syncDeriveFrameKey(key, n1, n2), syncDeriveFrameKey(key, n2, n1)) {
+		t.Fatal("frame key derivation must be canonical/order-independent")
+	}
+}

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -474,6 +474,28 @@ func configureSessionSyncConn(conn net.Conn) {
 
 func (s *SessionSync) handleNewConnection(ctx context.Context, fabricIdx int, conn net.Conn) {
 	configureSessionSyncConn(conn)
+
+	// #4107 F23: authenticate the stream at connection setup before any session
+	// frame flows. A dropped handshake (bad PSK proof / downgrade attempt / I/O)
+	// closes the connection; the accept/connect loops retry, so this never
+	// bricks a keyed↔keyed reconnect during failover (both nodes are up and
+	// keyed → the handshake completes in milliseconds).
+	mode, frameKey, pending, err := s.performSyncHandshake(conn)
+	if err != nil {
+		slog.Warn("cluster sync: auth handshake failed, dropping connection",
+			"fabric", fabricIdx, "remote", connRemoteAddrString(conn), "err", err)
+		conn.Close()
+		return
+	}
+	// Wrap so writeFull seals and receiveLoop verifies per-frame auth when the
+	// connection authenticated; an unauthenticated wrapper is a pass-through.
+	conn = s.wrapSyncConn(fabricIdx, conn, mode, frameKey)
+	// A legacy/unkeyed peer's first real frame was consumed by the handshake
+	// read — process it before the receive loop starts so no message is lost.
+	if pending != nil {
+		s.handleMessage(conn, pending.typ, pending.payload)
+	}
+
 	s.mu.Lock()
 	wasDisconnected := s.conn0 == nil && s.conn1 == nil
 	activeBefore := -1
@@ -1301,6 +1323,26 @@ func (s *SessionSync) receiveLoop(ctx context.Context, conn net.Conn) {
 			}
 			payload = make([]byte, hdr.Length)
 			if _, err := io.ReadFull(conn, payload); err != nil {
+				return
+			}
+		}
+		// #4107 F23: on an authenticated connection every frame carries a
+		// per-connection sequence + HMAC trailer. Read and verify it before the
+		// message is trusted; a bad HMAC (forgery/tamper) or a non-increasing
+		// sequence (replay/regression) drops the connection.
+		if ac, ok := conn.(*authConn); ok && ac.authed() {
+			trailer := make([]byte, syncAuthFrameTrailerSize)
+			if _, err := io.ReadFull(conn, trailer); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				slog.Debug("cluster sync: read auth trailer error", "err", err)
+				return
+			}
+			if err := ac.verifyFrame(hdrBuf, payload, trailer); err != nil {
+				slog.Warn("cluster sync: frame authentication failed, dropping connection",
+					"local", connLocalAddrString(conn), "remote", connRemoteAddrString(conn), "err", err)
+				s.stats.Errors.Add(1)
 				return
 			}
 		}

--- a/pkg/cluster/sync_protocol.go
+++ b/pkg/cluster/sync_protocol.go
@@ -45,7 +45,18 @@ func rebaseTimestamp(peerTS uint64, offset int64) uint64 {
 
 // writeFull loops until all bytes are written or an error occurs, handling
 // short writes from TCP backpressure.
+//
+// writeFull is the single chokepoint through which every outgoing sync frame
+// passes (writeMsg builds a frame then calls writeFull; the send loop calls it
+// with pre-encoded frames). On an AUTHENTICATED connection (#4107 F23) it seals
+// each complete frame with a per-connection sequence + HMAC trailer here, once,
+// so the seal covers all writers uniformly. All callers hold s.writeMu, so the
+// assigned sequence order equals the on-wire order. Frames on an
+// unauthenticated (dual-accept) connection are written unchanged.
 func writeFull(conn net.Conn, buf []byte) error {
+	if ac, ok := conn.(*authConn); ok && ac.authed() {
+		buf = ac.sealFrame(buf)
+	}
 	if err := conn.SetWriteDeadline(time.Now().Add(syncWriteDeadline)); err != nil {
 		return err
 	}

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -551,6 +551,12 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			} else {
 				d.sessionSync = cluster.NewSessionSync(syncLocal, syncPeer, nil)
 			}
+			// #4107 F23: authenticate the session-sync stream with the same
+			// control-link PSK the heartbeat + fabric-gRPC use (#4357). The
+			// cluster Manager supplies both the key and the heartbeat
+			// downgrade-guard signal (HeartbeatPeerAuthSeen). With no key
+			// configured the stream stays legacy unauthenticated (dual-accept).
+			d.sessionSync.SetAuthProvider(d.cluster)
 
 			d.cluster.SetSyncTransport(syncTransport)
 


### PR DESCRIPTION
## Summary

Closes #4107 (F23 completes it — F1 was already closed by #4357).

The cross-chassis **session-sync stream** (`pkg/cluster/sync.go` /
`sync_conn.go` / `sync_protocol.go`) carried session state, config, and
election/failover control messages in cleartext with no authentication. Any
host that could reach the fabric/control-link IP could open the listener,
dump session tuples, or drive a failover. This authenticates the stream with
the **same control-link PSK** the heartbeat (#4357 PR-A) and fabric gRPC
listener (#4357 PR-B) already use — no new config leaf.

The heartbeat's trailing-HMAC approach does **not** work on a length-framed
stream: a legacy reader would mis-frame an appended HMAC as the next message
header. F23 uses an **auth-capability handshake at connection setup** that
negotiates — before any session frame flows — whether the connection is
authenticated, then seals every subsequent frame.

## Design (chosen: setup handshake + per-frame seal)

- **Handshake (`performSyncHandshake`)** — only a keyed node initiates. Each
  keyed side sends a HELLO (`syncMsgAuthHello`, type 27) with a fresh 32-byte
  nonce; when **both** are keyed each proves PSK possession with
  `syncMsgAuthProof` (type 28) = `HMAC-SHA256(key, tag ‖ peer-nonce)` (mutual
  challenge-response, replay-safe via fresh per-connection nonces). HELLO/PROOF
  are written **concurrently** with the read so the handshake does not deadlock
  on a fully-synchronous transport (`net.Pipe` / two symmetric peers). Types
  27/28 sit above the legacy set, so an old peer ignores them.
- **Per-frame seal (`authConn.sealFrame` / `verifyFrame`)** — on an
  authenticated connection every frame carries an 8-byte per-connection
  monotonic sequence + a 32-byte HMAC keyed by a per-connection key derived
  from the PSK and **both** nonces (`syncDeriveFrameKey`). The receiver drops
  the connection on a bad HMAC (forgery/tamper) or a non-increasing sequence
  (replay). `writeFull` is the single seal chokepoint (all writers hold
  `s.writeMu` → sequence order == wire order); `receiveLoop` is the single
  verify point. Chose a signed per-frame trailer over a bare sequence because
  a sequence without a MAC is forgeable (an on-path attacker just uses seq+1);
  the MAC cost is negligible at realistic session-sync rates — this also
  supplies the required per-connection replay counter.
- **Dual-accept (rolling upgrade)** — a node with no key never handshakes and
  is byte-for-byte a legacy peer; a keyed node seeing a legacy/unkeyed peer
  negotiates UNAUTHENTICATED and preserves the peer's first real frame as a
  `pendingFrame`. Enforcement engages only once both nodes are keyed.
- **Downgrade-guard (`syncAuthDecision`, mirrors `heartbeatAuthDecision`)** —
  once the peer authed on the sync channel (sticky `syncAuthedEver`) OR the
  heartbeat (`HeartbeatPeerAuthSeen`, arms within ~200ms), a later
  unauthenticated connection from it is rejected.

## Tests (RED-on-revert verified)

`pkg/cluster/sync_auth_test.go` — neutralizing enforcement makes 5 test
functions fail:

1. both-keyed authenticates + a sealed session frame round-trips;
2. a **bad setup proof** (mismatched key) is rejected — connection dropped;
3. **dual-accept**: a keyed node + legacy/unkeyed peer → unauthenticated, stream works;
4. **downgrade-guard**: an unauthenticated peer is rejected once the peer has authed;
5. seal/verify enforces **replay** + tamper + wrong-key; plus the decision matrix and proof/derived-key construction.

`go test ./pkg/cluster/ -race` green; `go build ./...`, `go vet`, `gofmt` clean.

## Failover note (reviewer: run `make test-failover` before merge)

This touches the HA session-sync stream — the path that keeps TCP alive across
failover. The handshake happens at connect and a reconnect during failover
**re-handshakes**; a keyed↔keyed reconnect completes in milliseconds, and a
dropped handshake retries (~1s) rather than bricking. The biggest F23 risk is
the handshake breaking the failover reconnect, so `make test-failover` (a
mid-stream node reboot with sustained iperf3, expecting 0 retransmits) is the
gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
