### PR TITLE
fabric: select an UP fabric for the cross-chassis redirect (#4082)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -37129,3 +37129,49 @@ top.
   pkg/config/compiler_validate_strict.go,
   pkg/config/parser_class_of_service_test.go,
   userspace-dp/src/afxdp/types/cos.rs, _Log.md
+
+- **Timestamp**: 2026-07-06
+  **Action**: #4082 — cross-chassis fabric redirect selects an UP fabric
+  instead of pinning to the first resolvable one (dual-fabric failover).
+  The userspace-dp `resolve_fabric_redirect_from_list` picked the first
+  fabric with a valid parent ifindex — functionally `fab0`, since the Go
+  list is name-sorted. A DOWN `fab0` keeps a nonzero parent ifindex (and
+  a stale/permanent neighbor keeps its peer MAC), so the redirect stayed
+  pinned to `fab0` and blackholed instead of failing over to an UP
+  `fab1`. Threaded a per-fabric `up` flag end to end: (1) Rust wire field
+  `FabricSnapshot.up` with `#[serde(default = "default_true")]` so a
+  stale daemon omitting it reads up=true (fail-open, bit-identical to
+  today); (2) Go `FabricSnapshot.Up` (`json:"up"`, NO omitempty — a
+  down fabric must serialize `"up":false`) populated from
+  `fabricParentUp(parentLinux)` reading the parent netdev oper-state via
+  netlink (fails toward up on OperUnknown/Dormant so a healthy fabric is
+  never mis-marked down); (3) selection prefers the first
+  `parent_ifindex > 0 && up` in the stable sorted order (deterministic,
+  revert-to-primary), else falls back to the first resolvable fabric
+  (fail-open). Sub-second propagation rides the existing
+  `monitorFabricState` (#124) RTM_NEWLINK path — no new Rust link-state
+  monitor. Tests: Rust `fabric_redirect_prefers_up_fabric_4082`
+  (RED-on-revert: fab0-down/fab1-up selects fab1; both-up selects fab0;
+  both-down fails open to fab0; up-fabric selected irrespective of list
+  slot) + `fabric_snapshot_up_serde_default_true_4082` (absent field →
+  true, explicit false/true honored). Go
+  `TestFabricSnapshotUpWireField4082` (up not omitempty, round-trips) +
+  `TestFabricParentUpUnresolvable4082`. Updated all FabricLink /
+  FabricSnapshot test literals with `up: true`. Doc: docs/fabric-cross-
+  chassis-fwd.md dual-fabric egress selection subsection (+ the live
+  dual-fabric validation gap — no two-parent harness exists). HA
+  fabric-forwarding change → parent runs test-failover before merge.
+  **File(s)**: userspace-dp/src/protocol/snapshot.rs,
+  userspace-dp/src/afxdp/types/forwarding.rs,
+  userspace-dp/src/afxdp/forwarding/mod.rs,
+  userspace-dp/src/afxdp/forwarding/tests.rs,
+  userspace-dp/src/afxdp/ha_tests.rs,
+  userspace-dp/src/afxdp/flow_cache_tests.rs,
+  userspace-dp/src/afxdp/session_glue/tests.rs,
+  userspace-dp/src/afxdp/coordinator/tests.rs,
+  userspace-dp/src/afxdp/test_fixtures.rs,
+  userspace-dp/src/main_tests.rs, userspace-dp/src/server/tests.rs,
+  pkg/dataplane/userspace/protocol.go,
+  pkg/dataplane/userspace/fabric.go,
+  pkg/dataplane/userspace/fabric_up_4082_test.go,
+  docs/fabric-cross-chassis-fwd.md, _Log.md

--- a/docs/fabric-cross-chassis-fwd.md
+++ b/docs/fabric-cross-chassis-fwd.md
@@ -84,6 +84,55 @@ A single-fabric cluster leaves `fabricRefreshCh1` nil; the non-blocking send
 falls through its `default` arm, so `triggerFabricRefresh()` is a no-op for
 the absent fabric.
 
+**Dual-fabric egress selection by parent up-state (#4082):** the
+cross-chassis redirect egresses over a fabric parent ifindex, but the
+Rust selection (`resolve_fabric_redirect_from_list`,
+`userspace-dp/src/afxdp/forwarding/mod.rs`) historically picked the FIRST
+fabric with a valid parent ifindex — functionally `fab0` (the list is
+Go-sorted by name). A DOWN `fab0` still has a nonzero parent ifindex (and
+a stale/permanent neighbor entry can keep its peer MAC resolved), so the
+redirect stayed pinned to `fab0` and blackholed instead of failing over to
+an UP `fab1`. The data-path thus lacked the fabric redundancy the
+control-plane session-sync path already has (`activeConnLocked`,
+`pkg/cluster/sync_conn.go`, prefers conn0/fab0 and falls back to conn1/fab1).
+
+The fix threads a per-fabric `up` flag end to end:
+
+- **Go source of truth.** `buildFabricSnapshots`
+  (`pkg/dataplane/userspace/fabric.go`) stamps `FabricSnapshot.Up` from
+  `fabricParentUp(parentLinux)`, which reads the parent netdev's live
+  oper-state via `netlink.LinkByName`. Detection fails toward "up": only a
+  definite kernel down state (admin-down, `OperDown`, `OperLowerLayerDown`,
+  `OperNotPresent`) reports not-up; `OperUnknown`/`OperDormant` (common for
+  virtual/overlay parents with a live carrier) count as up, so a healthy
+  fabric is never mis-marked down. The wire field is `"up"` WITHOUT
+  `omitempty` — a genuinely-down fabric must serialize `"up":false`, not
+  drop the field.
+- **Sub-second propagation, no new monitor.** A carrier change on the
+  parent is an `RTM_NEWLINK` oper-state delta that `monitorFabricState`
+  (#124) already subscribes to → `triggerFabricRefresh()` →
+  `SyncFabricState` → `buildFabricSnapshots` re-push, with the 30s
+  safety-net tick as backstop. No userspace link-state monitor is added.
+- **Rust selection.** `resolve_fabric_redirect_from_list` prefers the
+  first fabric with `parent_ifindex > 0 && up`, walking the stable
+  Go-sorted order so both nodes deterministically favor `fab0` while it is
+  up (revert-to-primary on recovery, mirroring `activeConnLocked`). If NO
+  fabric reports up it falls back to the first resolvable fabric —
+  **fail-open**: a blackhole is no worse than a drop, and this preserves
+  the pre-#4082 behavior for a genuine all-fabrics-down state.
+- **Rolling-upgrade back-compat.** The Rust `FabricSnapshot.up` decodes
+  with `#[serde(default = "default_true")]`, so a stale daemon that omits
+  the field leaves every fabric reading up=true — bit-identical to the
+  pre-#4082 pin-to-first behavior.
+
+Single-fabric clusters are unaffected: one fabric in the list is selected
+whether or not its `up` flag is momentarily false (fail-open). **Validation
+gap:** the tested loss cluster and the standalone VM both run a single
+`fab0`, so no harness currently exercises the live `fab0`-down/`fab1`-up
+failover; the unit test (`fabric_redirect_prefers_up_fabric_4082`) covers
+the selection logic, but end-to-end dual-fabric failover needs a
+two-parent cluster build-out.
+
 ### Fix 2: VRRP Coordinated Preemption (Defense-in-depth)
 
 **Concept:** All VRRP instances preempt simultaneously when `ReleaseSyncHold()`

--- a/pkg/dataplane/userspace/fabric.go
+++ b/pkg/dataplane/userspace/fabric.go
@@ -56,12 +56,47 @@ func buildFabricSnapshots(cfg *config.Config) []FabricSnapshot {
 			PeerAddress:     in.peer,
 			LocalMAC:        parentMAC,
 			PeerMAC:         peerMAC,
+			Up:              fabricParentUp(parentLinux),
 		})
 	}
 	sort.Slice(out, func(i, j int) bool {
 		return out[i].Name < out[j].Name
 	})
 	return out
+}
+
+// fabricParentUp reports whether the fabric parent link's carrier/oper state is
+// usable for forwarding (#4082). The cross-chassis redirect egresses over the
+// parent ifindex, so a DOWN parent means the redirect would blackhole; the Rust
+// selection prefers a fabric whose parent reports up. Detection fails toward
+// "up": only a definite kernel down state (admin-down, oper-down, or
+// lower-layer-down) returns false. Many virtual/overlay parents report
+// OperUnknown even with a live carrier, and mis-marking a healthy fabric down
+// would wrongly divert a dual-fabric cluster to its secondary — so an
+// indeterminate oper-state is treated as up. An empty name or a link that fails
+// to resolve returns false (the fabric is skipped in Rust on ifindex<=0 anyway).
+func fabricParentUp(linuxName string) bool {
+	if linuxName == "" {
+		return false
+	}
+	link, err := netlink.LinkByName(linuxName)
+	if err != nil || link == nil {
+		return false
+	}
+	attrs := link.Attrs()
+	// An administratively-down parent can never forward.
+	if attrs.Flags&net.FlagUp == 0 {
+		return false
+	}
+	switch attrs.OperState {
+	case netlink.OperDown, netlink.OperLowerLayerDown, netlink.OperNotPresent:
+		return false
+	default:
+		// OperUp, OperUnknown, OperDormant, OperTesting: treat as up. Fail
+		// toward "up" at the detection layer (the Rust selection also fails
+		// open when no fabric reports up).
+		return true
+	}
 }
 
 func buildFabricPeerMAC(overlayIfindex, parentIfindex int, peer string) string {

--- a/pkg/dataplane/userspace/fabric_up_4082_test.go
+++ b/pkg/dataplane/userspace/fabric_up_4082_test.go
@@ -1,0 +1,68 @@
+package userspace
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// #4082: the fabric parent up-state must ride the snapshot wire so the Rust
+// dataplane can prefer an UP fabric for the cross-chassis redirect. The `up`
+// field MUST serialize unconditionally (no omitempty): a genuinely-down fabric
+// has to emit "up":false, because the Rust decoder defaults an ABSENT field to
+// true (fail-open back-compat). If omitempty dropped a false value the down
+// fabric would decode back to up and the failover would be defeated.
+func TestFabricSnapshotUpWireField4082(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		up   bool
+		want string
+	}{
+		{name: "down", up: false, want: `"up":false`},
+		{name: "up", up: true, want: `"up":true`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(FabricSnapshot{Name: "fab0", ParentIfindex: 21, Up: tc.up})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			got := string(b)
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("FabricSnapshot JSON %q missing %q (up must not be omitempty)", got, tc.want)
+			}
+
+			var back FabricSnapshot
+			if err := json.Unmarshal(b, &back); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if back.Up != tc.up {
+				t.Fatalf("round-trip Up = %v, want %v", back.Up, tc.up)
+			}
+		})
+	}
+
+	// A snapshot without the field (a stale peer, or a producer that omitted
+	// it) unmarshals to the Go zero value false — the fail-open-to-true
+	// default lives on the RUST decoder, not here, so the Go producer must
+	// always set Up explicitly (which buildFabricSnapshots does).
+	var absent FabricSnapshot
+	if err := json.Unmarshal([]byte(`{"name":"fab0","parent_ifindex":21}`), &absent); err != nil {
+		t.Fatalf("unmarshal absent: %v", err)
+	}
+	if absent.Up {
+		t.Fatalf("absent up decodes to Go zero value false, got true")
+	}
+}
+
+// fabricParentUp must fail safe on inputs that cannot resolve a link: an empty
+// name and a nonexistent interface both return false (the fabric is skipped in
+// Rust on ifindex<=0 anyway, and the Rust selection fails open when no fabric
+// reports up).
+func TestFabricParentUpUnresolvable4082(t *testing.T) {
+	if fabricParentUp("") {
+		t.Fatalf("empty parent name must report not-up")
+	}
+	if fabricParentUp("xpf-nonexistent-fab-4082") {
+		t.Fatalf("nonexistent parent link must report not-up")
+	}
+}

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -413,6 +413,14 @@ type FabricSnapshot struct {
 	PeerAddress     string `json:"peer_address,omitempty"`
 	LocalMAC        string `json:"local_mac,omitempty"`
 	PeerMAC         string `json:"peer_mac,omitempty"`
+	// Up is the local fabric parent link's carrier/oper state (#4082). The
+	// Rust dataplane prefers an UP fabric when resolving the cross-chassis
+	// redirect, so a dual-fabric cluster fails over to the secondary when the
+	// primary parent drops. This field MUST NOT be omitempty: a genuinely-down
+	// fabric has to serialize "up":false, not drop the field — the Rust decoder
+	// defaults an absent field to true (fail-open), so dropping it on down
+	// would defeat the failover.
+	Up bool `json:"up"`
 }
 
 type TunnelEndpointSnapshot struct {

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -2027,6 +2027,7 @@ fn queue_warm_pass_warms_fabric_peer_over_parent_ifindex() {
         peer_addr: IpAddr::V4(Ipv4Addr::new(10, 99, 0, 2)),
         peer_mac: [0; 6],
         local_mac: [0; 6],
+        up: true,
     });
     coord.queue_warm_pass(false);
     let item = rx.try_recv().expect("fabric peer warm item");

--- a/userspace-dp/src/afxdp/flow_cache_tests.rs
+++ b/userspace-dp/src/afxdp/flow_cache_tests.rs
@@ -1548,6 +1548,7 @@ fn fabric_redirect_cache_entry_uses_flow_owner_rg_for_epoch_invalidation() {
         peer_addr: IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2)),
         peer_mac: [0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee],
         local_mac: [0x02, 0xbf, 0x72, 0xff, 0x00, 0x01],
+        up: true,
     });
     forwarding.egress.insert(
         6,

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -173,6 +173,10 @@ pub(in crate::afxdp) fn build_fabric_link_or_skip(
         peer_addr,
         peer_mac,
         local_mac,
+        // #4082: carry the parent carrier/oper state through so the redirect can
+        // prefer an UP fabric. An old daemon that omits the wire field defaults
+        // to true (fail-open) via `FabricSnapshot::default_true`.
+        up: fabric.up,
     })
 }
 
@@ -588,9 +592,21 @@ pub(super) fn resolve_fabric_redirect(
 pub(super) fn resolve_fabric_redirect_from_list(
     fabrics: &[FabricLink],
 ) -> Option<ForwardingResolution> {
+    // #4082: prefer the FIRST fabric whose local parent carrier is UP so a
+    // dual-fabric cluster fails the cross-chassis redirect over to fab1 when
+    // fab0's parent link goes down. The fabric list arrives in a stable
+    // Go-sorted-by-name order (pkg/dataplane/userspace/fabric.go), so both
+    // nodes deterministically prefer fab0 while it is up — no hash/round-robin,
+    // matching the control-plane `activeConnLocked` fab0-preferred failover.
+    // If NO fabric reports up (a stale peer that omits the `up` field defaults
+    // every fabric to up=true, so this only triggers on a genuine all-down
+    // state), fall back to the first resolvable fabric — fail-open, never worse
+    // than the pre-#4082 pin-to-first behavior (a blackhole is no worse than
+    // dropping).
     let fabric = fabrics
         .iter()
-        .find(|fabric| fabric.parent_ifindex > 0)
+        .find(|fabric| fabric.parent_ifindex > 0 && fabric.up)
+        .or_else(|| fabrics.iter().find(|fabric| fabric.parent_ifindex > 0))
         .copied()?;
     Some(ForwardingResolution {
         disposition: ForwardingDisposition::FabricRedirect,

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -350,6 +350,7 @@ fn build_forwarding_state_uses_fabric_snapshot_macs_without_parent_interface() {
         peer_address: "10.99.13.2".to_string(),
         local_mac: "02:bf:72:ff:00:01".to_string(),
         peer_mac: "00:aa:bb:cc:dd:ee".to_string(),
+        up: true,
     }];
     let state = build_forwarding_state(&snapshot);
     let redirect = resolve_fabric_redirect(&state).expect("fabric redirect");
@@ -755,6 +756,7 @@ fn cluster_peer_return_fast_path_allows_sfmix_to_lan_reply() {
         peer_addr: IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2)),
         peer_mac: [0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee],
         local_mac: [0x02, 0xbf, 0x72, 0xff, 0x00, 0x01],
+        up: true,
     });
     let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
     dynamic_neighbors.insert(
@@ -801,6 +803,7 @@ fn cluster_peer_return_fast_path_skips_pure_tcp_syn() {
         peer_addr: IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2)),
         peer_mac: [0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee],
         local_mac: [0x02, 0xbf, 0x72, 0xff, 0x00, 0x01],
+        up: true,
     });
     let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
     let meta = UserspaceDpMeta {
@@ -832,6 +835,7 @@ fn cluster_peer_return_fast_path_skips_icmp_echo_request() {
         peer_addr: IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2)),
         peer_mac: [0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee],
         local_mac: [0x02, 0xbf, 0x72, 0xff, 0x00, 0x01],
+        up: true,
     });
     let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
     let meta = UserspaceDpMeta {
@@ -864,6 +868,7 @@ fn cluster_peer_return_fast_path_skips_icmpv6_echo_request() {
         peer_addr: IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2)),
         peer_mac: [0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee],
         local_mac: [0x02, 0xbf, 0x72, 0xff, 0x00, 0x01],
+        up: true,
     });
     let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
     let meta = UserspaceDpMeta {
@@ -887,6 +892,98 @@ fn cluster_peer_return_fast_path_skips_icmpv6_echo_request() {
     );
 }
 
+// #4082: the cross-chassis fabric redirect must prefer a fabric whose local
+// parent carrier is UP so a dual-fabric cluster fails over to the secondary
+// when the primary parent goes down. RED-on-revert: reverting the selection to
+// the pre-#4082 pin-to-first-resolvable makes the fab0-DOWN case pick fab0 and
+// blackhole.
+#[test]
+fn fabric_redirect_prefers_up_fabric_4082() {
+    let fab0 = FabricLink {
+        parent_ifindex: 21,
+        overlay_ifindex: 101,
+        peer_addr: IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2)),
+        peer_mac: [0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee],
+        local_mac: [0x02, 0xbf, 0x72, 0xff, 0x00, 0x01],
+        up: true,
+    };
+    let fab1 = FabricLink {
+        parent_ifindex: 22,
+        overlay_ifindex: 102,
+        peer_addr: IpAddr::V4(Ipv4Addr::new(10, 99, 14, 2)),
+        peer_mac: [0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xef],
+        local_mac: [0x02, 0xbf, 0x72, 0xff, 0x00, 0x02],
+        up: true,
+    };
+
+    // fab0 DOWN, fab1 UP → select fab1. This is the failover the fix delivers;
+    // reverting to the pin-to-first-resolvable selects fab0 (ifindex 21) here
+    // and the redirect blackholes.
+    let mut d0 = fab0;
+    d0.up = false;
+    let r = resolve_fabric_redirect_from_list(&[d0, fab1]).expect("redirect");
+    assert_eq!(
+        r.egress_ifindex, 22,
+        "down primary must fail the redirect over to fab1"
+    );
+    assert_eq!(r.tx_ifindex, 22);
+    assert_eq!(r.next_hop, Some(fab1.peer_addr));
+
+    // Both UP → select fab0 (first in the stable Go-sorted order). No behavior
+    // change for the common single- or dual-fabric-both-up case.
+    let r = resolve_fabric_redirect_from_list(&[fab0, fab1]).expect("redirect");
+    assert_eq!(
+        r.egress_ifindex, 21,
+        "both up selects the primary fab0 (unchanged from pre-#4082)"
+    );
+
+    // Both DOWN → fail-open to the first resolvable fabric (fab0). A blackhole
+    // is no worse than a drop, and this preserves the pre-#4082 behavior for a
+    // genuine all-fabrics-down state.
+    let mut a = fab0;
+    let mut b = fab1;
+    a.up = false;
+    b.up = false;
+    let r = resolve_fabric_redirect_from_list(&[a, b]).expect("redirect");
+    assert_eq!(
+        r.egress_ifindex, 21,
+        "all fabrics down falls open to the first resolvable fabric"
+    );
+
+    // Reversed order with fab1 the only up link still selects fab1 regardless of
+    // position — selection is by up-state, not slot.
+    let mut d1 = fab1;
+    d1.up = false;
+    let r = resolve_fabric_redirect_from_list(&[d1, fab0]).expect("redirect");
+    assert_eq!(
+        r.egress_ifindex, 21,
+        "the up fabric is selected irrespective of list position"
+    );
+}
+
+// #4082: a snapshot from a STALE daemon that omits the `up` wire field must
+// deserialize to up=true (fail-open back-compat), while an explicit `up:false`
+// is honored.
+#[test]
+fn fabric_snapshot_up_serde_default_true_4082() {
+    let absent: FabricSnapshot =
+        serde_json::from_str(r#"{"name":"fab0","parent_ifindex":21}"#).expect("parse absent up");
+    assert!(
+        absent.up,
+        "an absent `up` field defaults to true (stale-daemon fail-open)"
+    );
+
+    let down: FabricSnapshot =
+        serde_json::from_str(r#"{"name":"fab0","parent_ifindex":21,"up":false}"#)
+            .expect("parse up=false");
+    assert!(!down.up, "an explicit up=false is honored");
+
+    let up: FabricSnapshot =
+        serde_json::from_str(r#"{"name":"fab0","parent_ifindex":21,"up":true}"#)
+            .expect("parse up=true");
+    assert!(up.up, "an explicit up=true is honored");
+}
+
 #[test]
 fn missing_neighbor_session_metadata_preserves_fabric_ingress() {
     let mut state = build_forwarding_state(&native_gre_pbr_snapshot(false));
@@ -896,6 +993,7 @@ fn missing_neighbor_session_metadata_preserves_fabric_ingress() {
         peer_addr: IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2)),
         peer_mac: [0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee],
         local_mac: [0x02, 0xbf, 0x72, 0xff, 0x00, 0x01],
+        up: true,
     });
     let decision = SessionDecision {
         resolution: ForwardingResolution {
@@ -4040,6 +4138,7 @@ fn fabric_snapshot_template() -> FabricSnapshot {
         peer_address: "10.99.13.2".into(),
         local_mac: "02:bf:72:ff:00:01".into(),
         peer_mac: "00:aa:bb:cc:dd:ee".into(),
+        up: true,
     }
 }
 

--- a/userspace-dp/src/afxdp/ha_tests.rs
+++ b/userspace-dp/src/afxdp/ha_tests.rs
@@ -212,6 +212,7 @@ fn test_forwarding_state_with_fabric() -> ForwardingState {
         peer_addr: IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2)),
         peer_mac: [0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee],
         local_mac: [0x02, 0xbf, 0x72, 0xff, 0x00, 0x01],
+        up: true,
     });
     forwarding
 }

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -290,6 +290,7 @@ fn test_forwarding_state_with_fabric() -> ForwardingState {
         peer_addr: IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2)),
         peer_mac: [0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee],
         local_mac: [0x02, 0xbf, 0x72, 0xff, 0x00, 0x01],
+        up: true,
     });
     forwarding
 }

--- a/userspace-dp/src/afxdp/test_fixtures.rs
+++ b/userspace-dp/src/afxdp/test_fixtures.rs
@@ -613,6 +613,7 @@ pub(super) fn nat_snapshot_with_fabric() -> ConfigSnapshot {
         peer_address: "10.99.13.2".to_string(),
         local_mac: "02:bf:72:ff:00:01".to_string(),
         peer_mac: "00:aa:bb:cc:dd:ee".to_string(),
+        up: true,
     }];
     snapshot.neighbors.push(NeighborSnapshot {
         interface: "fab0".to_string(),

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -719,6 +719,11 @@ pub(in crate::afxdp) struct FabricLink {
     pub(in crate::afxdp) peer_addr: IpAddr,
     pub(in crate::afxdp) peer_mac: [u8; 6],
     pub(in crate::afxdp) local_mac: [u8; 6],
+    /// #4082: the local fabric parent link's carrier/oper state, threaded from
+    /// `FabricSnapshot.up`. `resolve_fabric_redirect_from_list` prefers a fabric
+    /// with `up == true` so a dual-fabric cluster fails the cross-chassis
+    /// redirect over to the secondary when the primary parent carrier drops.
+    pub(in crate::afxdp) up: bool,
 }
 
 /// #3773 (M13): why a configured fabric link was skipped during a forwarding

--- a/userspace-dp/src/main_tests.rs
+++ b/userspace-dp/src/main_tests.rs
@@ -950,6 +950,7 @@ fn queue_planner_includes_fabric_parent_interface() {
             peer_address: "10.99.13.2".to_string(),
             local_mac: String::new(),
             peer_mac: String::new(),
+            up: true,
         }],
         ..Default::default()
     };
@@ -988,6 +989,7 @@ fn queue_planner_deduplicates_fabric_parent_already_in_interfaces() {
             peer_address: "10.99.13.2".to_string(),
             local_mac: String::new(),
             peer_mac: String::new(),
+            up: true,
         }],
         ..Default::default()
     };

--- a/userspace-dp/src/protocol/snapshot.rs
+++ b/userspace-dp/src/protocol/snapshot.rs
@@ -463,6 +463,21 @@ pub(crate) struct FabricSnapshot {
     pub local_mac: String,
     #[serde(rename = "peer_mac", default)]
     pub peer_mac: String,
+    /// #4082: the local fabric parent link's carrier/oper state. The Go daemon
+    /// stamps this from the parent netdev's live oper-state so a dual-fabric
+    /// cluster can fail the cross-chassis redirect over to a secondary fabric
+    /// when the primary parent goes DOWN. `default = "default_true"` keeps a
+    /// STALE daemon that omits the field bit-identical to pre-#4082: an absent
+    /// `up` deserializes to `true`, so every fabric from an old peer reads up
+    /// and selection is unchanged (fail-open). The Go producer must NOT use
+    /// `omitempty` — a genuinely-down fabric must serialize `"up":false`, not
+    /// drop the field (which would default back to true here).
+    #[serde(rename = "up", default = "default_true")]
+    pub up: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Clone, Serialize, Deserialize, Default)]

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -1757,6 +1757,7 @@ fn update_fabrics_persists_resolved_fabric_set() {
         peer_address: "10.99.13.2".into(),
         local_mac: "02:bf:72:ff:00:01".into(),
         peer_mac: "00:aa:bb:cc:dd:ee".into(),
+        up: true,
     };
     {
         let mut request = req("update_fabrics");
@@ -1806,6 +1807,7 @@ fn update_fabrics_unchanged_set_does_not_rewrite_state_file() {
         peer_address: "10.99.13.2".into(),
         local_mac: "02:bf:72:ff:00:01".into(),
         peer_mac: "00:aa:bb:cc:dd:ee".into(),
+        up: true,
     };
     let state = new_state(ProcessStatus::default());
     let state_file = unique_state_file("fabric-nochurn");

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -505,7 +505,8 @@
     "parent_linux_name": "",
     "peer_address": "",
     "peer_mac": "",
-    "rx_queues": 0
+    "rx_queues": 0,
+    "up": false
   },
   "firewall_filter_snapshot": {
     "family": "",


### PR DESCRIPTION
## Summary

The userspace-dp cross-chassis fabric redirect for a peer-owned synced session (`resolve_fabric_redirect_from_list`, `userspace-dp/src/afxdp/forwarding/mod.rs`) picked the first fabric with a valid parent ifindex. Because the Go snapshot builder sorts the fabric list by name, that is functionally **fab0**. A DOWN fab0 still has a nonzero parent ifindex (and a stale/permanent neighbor entry can keep its peer MAC resolved), so in a dual-fabric cluster the redirect stayed pinned to fab0 and **blackholed** instead of failing over to an UP fab1. The data path thus lacked the fabric redundancy the control-plane session-sync path already has (`activeConnLocked` prefers conn0/fab0, falls back to conn1/fab1).

## Fix — a per-fabric `up` flag, threaded end to end

- **Wire field.** Rust `FabricSnapshot.up` (`protocol/snapshot.rs`) with `#[serde(default = "default_true")]` — a stale daemon omitting the field reads up=true, bit-identical to pre-#4082 (fail-open). Go `FabricSnapshot.Up` (`protocol.go`) with `json:"up"` and **no** `omitempty` — a down fabric must serialize `"up":false`, not drop the field (the Rust decoder defaults an absent field back to true).
- **Go population.** `buildFabricSnapshots` (`fabric.go`) stamps `Up` from `fabricParentUp(parentLinux)`, reading the parent netdev oper-state via `netlink.LinkByName`. Detection fails toward "up": only a definite kernel down state (admin-down / `OperDown` / `OperLowerLayerDown` / `OperNotPresent`) reports not-up; `OperUnknown`/`OperDormant` count as up so a healthy virtual/overlay parent is never mis-marked down. Propagation rides the existing `monitorFabricState` (#124) RTM_NEWLINK path — no new link-state monitor.
- **Rust selection.** `resolve_fabric_redirect_from_list` prefers the first fabric with `parent_ifindex > 0 && up` in the stable Go-sorted order (deterministic, revert-to-primary). If **no** fabric reports up it falls back to the first resolvable fabric — **fail-open**: a blackhole is no worse than a drop, and this preserves pre-#4082 behavior for a genuine all-fabrics-down state.

## Tests

- Rust `fabric_redirect_prefers_up_fabric_4082` — RED-on-revert guard: fab0-down/fab1-up → fab1 (reverting to pin-to-first selects fab0 and blackholes); both-up → fab0 (unchanged common case); both-down → fail-open to fab0; up-fabric selected irrespective of list slot.
- Rust `fabric_snapshot_up_serde_default_true_4082` — absent field → true (back-compat), explicit false/true honored.
- Go `TestFabricSnapshotUpWireField4082` (up not omitempty, round-trips) + `TestFabricParentUpUnresolvable4082` (empty/nonexistent parent fail-safe).
- Regenerated `protocol_wire_v1.json` golden fixture for the additive `up` key.

## Validation

- Full `cargo test --release -- --test-threads=1`: **green** — main bin 3621 passed / 0 failed (incl. the two new tests + the wire invariant), plus 54 + 8 + 22 + 1 across the other test binaries, all 0 failed.
- `go test ./pkg/dataplane/userspace/`: green.

## Notes for the reviewer

- **HA fabric-forwarding change** → please run `make test-failover` (cross-chassis redirect during failover) before merge.
- **Live dual-fabric validation gap** (the /research deferral reason): the tested loss cluster and the standalone VM both run a single `fab0`, so no harness currently exercises the live fab0-down/fab1-up failover. The unit test covers the selection logic; end-to-end dual-fabric failover needs a two-parent cluster build-out. Documented in `docs/fabric-cross-chassis-fwd.md`.

Closes #4082

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi