### PR TITLE
cos: resolve transmit-rate / shaping-rate percent (Refs #4228 Gap 2)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-07-06 — #4228 Gap 2: resolve CoS transmit-rate / shaping-rate percent
+
+- **Timestamp**: 2026-07-06
+- **Action**: #4320 accepted `transmit-rate percent`/`shaping-rate percent` but
+  left them ACCEPTED-BUT-INERT. This resolves the percent to an absolute rate,
+  mirroring the buffer-size percent precedent exactly (same `ceil` rounding,
+  same clamp). `transmit-rate percent` resolves PER INTERFACE in the Rust
+  `forwarding_build::cos` builder against the bound interface's
+  `cos_shaping_rate_bytes_per_sec` (a named scheduler maps onto interfaces of
+  different rates, so the percent is carried on the shared snapshot and
+  materialized per interface via `cos_effective_transmit_rate_bytes` /
+  `cos_percent_rate_bytes`). `shaping-rate percent` resolves in the Go compiler
+  (`resolveCoSTrafficControlProfiles`) against the interface's configured line
+  rate (`speed`/`bandwidth`) and folds into the unit root shaper. New Go field
+  `CoSSchedulerSnapshot.TransmitRatePercent` (+ Rust `transmit_rate_percent`,
+  serde default, mirrors `buffer_size_percent`) carries the scheduler percent.
+  Advisories reworded: percent now resolves; only `remainder`, an unbound
+  percent scheduler, and a shaping-rate percent on a speed-less interface remain
+  inert (per-binding / per-scheduler advisories flag exactly those).
+- **File(s)**: userspace-dp/src/protocol/cos.rs,
+  userspace-dp/src/afxdp/forwarding_build/cos.rs,
+  userspace-dp/src/afxdp/forwarding_build/tests.rs,
+  userspace-dp/src/afxdp/tests.rs, userspace-dp/src/protocol/tests.rs,
+  userspace-dp/src/afxdp/tx/cos_classify_tests.rs (field literals),
+  pkg/config/compiler_class_of_service.go (resolveCoSTrafficControlProfiles +
+  coSInterfaceLineRateBytes + resolveCoSPercentRateBytes +
+  cosSchedulersWithShapedBinding), pkg/config/compiler_validate_warn.go
+  (advisories), pkg/config/schema_validate_cos_rate_percent_4228_test.go,
+  pkg/dataplane/userspace/protocol.go, pkg/dataplane/userspace/cos.go,
+  docs/cos-traffic-shaping.md.
+
 ## 2026-07-06 — #4070 follow-up: exclude token-packed multi-leaves from the union
 
 - **Timestamp**: 2026-07-06

--- a/docs/cos-traffic-shaping.md
+++ b/docs/cos-traffic-shaping.md
@@ -210,15 +210,39 @@ optionally followed by `exact`:
 `shaping-rate` (traffic-control-profiles) accepts an absolute bandwidth or
 `shaping-rate percent <n>`. These forms are accepted so imported vSRX
 configs commit unchanged (the percent form is the most common Junos
-scheduler idiom). **The percent / remainder forms are currently
-ACCEPTED-BUT-INERT:** the userspace dataplane consumes an absolute byte/sec
-rate, and xpf does not yet resolve a percent/remainder against the bound
-interface's rate — a scheduler can be mapped onto interfaces of different
-speeds, so resolution is a multi-pass follow-up. A commit advisory
-(`ValidateConfig`) surfaces the inertness; a queue with only a percent/
-remainder `transmit-rate` gets no explicit rate until resolution lands, and
-a `shaping-rate percent` leaves the unit unshaped. The commit gate still
-rejects garbage (`transmit-rate percent 150`, `transmit-rate asd`).
+scheduler idiom).
+
+**Percent resolution (#4228 Gap 2 — now ENFORCED).** Both percent forms
+resolve to an absolute byte/sec rate, mirroring the `buffer-size percent`
+resolution exactly (same `ceil` rounding, same clamp to `[1, MaxUint64]`):
+
+- **`transmit-rate percent <n>`** resolves PER INTERFACE, in the Rust
+  `forwarding_build::cos` builder, against the bound interface's root
+  shaping-rate (`cos_shaping_rate_bytes_per_sec`). A named scheduler mapped
+  onto interfaces of different shaping rates materializes a *different*
+  absolute rate on each — which is why the percent is carried to the
+  dataplane (not pre-resolved) on the shared scheduler snapshot. A resolved
+  percent drives the queue guarantee, surplus weight, and token bucket just
+  like an absolute `transmit-rate`. Residual inert cases: a scheduler not
+  bound (via a scheduler-map) to an interface with a root shaping-rate, or an
+  interface with a transparent root (no shaping-rate) — there is no base to
+  resolve against, so the queue gets no explicit rate (a `ValidateConfig`
+  advisory flags the unbound case).
+- **`shaping-rate percent <n>`** (traffic-control-profiles) resolves in the
+  Go compiler (`resolveCoSTrafficControlProfiles`) against the bound
+  interface's configured line rate (`set interfaces <if> speed <rate>` or
+  `bandwidth`) — Junos resolves shaping-rate percent against the interface
+  speed. The resolved absolute rate is folded into the unit's root shaper
+  exactly as an absolute `shaping-rate` would be. Resolution is per-binding:
+  the same profile bound to interfaces of different speeds folds a different
+  rate onto each. If the interface has no configured speed/bandwidth the
+  percent cannot resolve and the unit is left unshaped; a per-binding
+  `ValidateConfig` advisory names the interface and the fix.
+
+**Still inert:** `transmit-rate remainder` (leftover-bandwidth resolution is
+a follow-up) — a `ValidateConfig` advisory surfaces it. The commit gate still
+rejects garbage (`transmit-rate percent 150`, `transmit-rate asd`) and a
+both-forms-set config (an absolute rate AND a percent).
 
 ### First-Pass Fairness Boundary
 
@@ -892,6 +916,9 @@ materializes exactly as if the operator had set `shaping-rate` /
 `scheduler-map` directly on the unit. A **direct unit-level knob wins** over
 the profile (Junos precedence), and an interface-level
 `output-traffic-control-profile` applies to every configured logical unit.
+A profile `shaping-rate percent <n>` resolves against the bound interface's
+configured line rate before the fold (see the percent-resolution note under
+"`transmit-rate` / `shaping-rate` value forms" above, #4228 Gap 2).
 
 Before #4315 both `traffic-control-profiles` and
 `output-traffic-control-profile` were unmodeled: the binding committed

--- a/pkg/config/compiler_class_of_service.go
+++ b/pkg/config/compiler_class_of_service.go
@@ -797,7 +797,12 @@ func resolveCoSPercentRateBytes(baseBytesPerSec uint64, percent float64) uint64 
 	if scaled < 1 {
 		return 1
 	}
-	if scaled > float64(^uint64(0)) {
+	// float64(^uint64(0)) rounds UP to 2^64 (MaxUint64 is not float64-exact),
+	// so a `scaled` of exactly 2^64 would slip past a `>` compare and then
+	// overflow the float->uint64 conversion (out-of-range is implementation-
+	// defined in Go, unlike Rust's saturating `as`). Use `>=` to clamp the
+	// exact-boundary case deterministically to MaxUint64.
+	if scaled >= float64(^uint64(0)) {
 		return ^uint64(0)
 	}
 	return uint64(scaled)

--- a/pkg/config/compiler_class_of_service.go
+++ b/pkg/config/compiler_class_of_service.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -674,7 +675,7 @@ func resolveCoSTrafficControlProfiles(cfg *Config) {
 		return
 	}
 	cos := cfg.ClassOfService
-	resolve := func(unit *CoSInterfaceUnit) {
+	resolve := func(unit *CoSInterfaceUnit, ifaceLineRateBytes uint64) {
 		if unit == nil || unit.OutputTrafficControlProfile == "" {
 			return
 		}
@@ -683,7 +684,20 @@ func resolveCoSTrafficControlProfiles(cfg *Config) {
 			return
 		}
 		if unit.ShapingRateBytes == 0 {
-			unit.ShapingRateBytes = tcp.ShapingRateBytes
+			// #4228 Gap 2: fold the profile shaping-rate into the unit root
+			// shaper. An absolute profile rate carries directly; a `percent
+			// <n>` form resolves against the bound interface's configured line
+			// rate (Junos resolves shaping-rate percent against the interface
+			// speed). Resolution is per-BINDING — the same profile bound to
+			// interfaces of different speeds folds a different absolute rate
+			// onto each unit. When the interface has no configured speed we
+			// cannot resolve the percent, so the unit is left unshaped and the
+			// ValidateConfig advisory (compiler_validate_warn.go) surfaces it.
+			if tcp.ShapingRateBytes > 0 {
+				unit.ShapingRateBytes = tcp.ShapingRateBytes
+			} else if resolved := resolveCoSPercentRateBytes(ifaceLineRateBytes, tcp.ShapingRatePercent); resolved > 0 {
+				unit.ShapingRateBytes = resolved
+			}
 		}
 		if unit.SchedulerMap == "" {
 			unit.SchedulerMap = tcp.SchedulerMap
@@ -693,11 +707,100 @@ func resolveCoSTrafficControlProfiles(cfg *Config) {
 		if iface == nil {
 			continue
 		}
-		resolve(iface.Level)
+		lineRate := coSInterfaceLineRateBytes(cfg, iface.Name)
+		resolve(iface.Level, lineRate)
 		for _, unit := range iface.Units {
-			resolve(unit)
+			resolve(unit, lineRate)
 		}
 	}
+}
+
+// cosSchedulersWithShapedBinding returns the set of scheduler names that are
+// bound — via a scheduler-map applied to an interface unit with a non-zero
+// root shaping-rate — to at least one shaped interface. A `transmit-rate
+// percent <n>` on such a scheduler RESOLVES: forwarding_build/cos.rs computes
+// the absolute byte/sec rate against the interface's shaping-rate. A scheduler
+// NOT in this set has no shaping base, so its percent stays inert; the
+// ValidateConfig advisory flags exactly that residual. Must run AFTER
+// resolveCoSTrafficControlProfiles so unit.ShapingRateBytes reflects a folded
+// traffic-control-profile shaping-rate (including a resolved shaping-rate
+// percent).
+func cosSchedulersWithShapedBinding(cos *ClassOfServiceConfig) map[string]bool {
+	resolved := make(map[string]bool)
+	if cos == nil {
+		return resolved
+	}
+	markUnit := func(unit *CoSInterfaceUnit) {
+		if unit == nil || unit.SchedulerMap == "" || unit.ShapingRateBytes == 0 {
+			return
+		}
+		sm := cos.SchedulerMaps[unit.SchedulerMap]
+		if sm == nil {
+			return
+		}
+		for _, entry := range sm.Entries {
+			if entry != nil && entry.Scheduler != "" {
+				resolved[entry.Scheduler] = true
+			}
+		}
+	}
+	for _, iface := range cos.Interfaces {
+		if iface == nil {
+			continue
+		}
+		markUnit(iface.Level)
+		for _, unit := range iface.Units {
+			markUnit(unit)
+		}
+	}
+	return resolved
+}
+
+// coSInterfaceLineRateBytes returns the configured line rate of a physical
+// interface in bytes/sec, or 0 when unknown. It is the base against which a
+// `shaping-rate percent <n>` traffic-control-profile resolves (Junos resolves
+// shaping-rate percent against the interface speed). An explicit `bandwidth`
+// (already bits/sec) wins over the `speed` string; "auto"/"" (or an
+// unparseable value) yields 0, which leaves the percent inert with a commit
+// advisory rather than fabricating a rate.
+func coSInterfaceLineRateBytes(cfg *Config, ifaceName string) uint64 {
+	if cfg == nil || ifaceName == "" {
+		return 0
+	}
+	iface := cfg.Interfaces.Interfaces[ifaceName]
+	if iface == nil {
+		return 0
+	}
+	if iface.Bandwidth > 0 {
+		return iface.Bandwidth / 8
+	}
+	speed := strings.ToLower(strings.TrimSpace(iface.Speed))
+	if speed == "" || speed == "auto" {
+		return 0
+	}
+	return parseBandwidthLimit(speed)
+}
+
+// resolveCoSPercentRateBytes resolves a Junos CoS `percent <n>` rate against a
+// base rate in bytes/sec. It mirrors the Rust `cos_percent_buffer_bytes` /
+// `cos_percent_rate_bytes` resolution EXACTLY — same (0,100] domain guard,
+// same `math.Ceil` rounding, same clamp to [1, MaxUint64] — so a
+// shaping-rate/transmit-rate percent rounds identically on the Go and Rust
+// sides. Returns 0 when the base is unknown (0) or the percent is out of
+// range; the caller then leaves the knob inert.
+func resolveCoSPercentRateBytes(baseBytesPerSec uint64, percent float64) uint64 {
+	if baseBytesPerSec == 0 || math.IsNaN(percent) || math.IsInf(percent, 0) ||
+		percent <= 0 || percent > 100 {
+		return 0
+	}
+	scaled := math.Ceil(float64(baseBytesPerSec) * percent / 100.0)
+	if scaled < 1 {
+		return 1
+	}
+	if scaled > float64(^uint64(0)) {
+		return ^uint64(0)
+	}
+	return uint64(scaled)
 }
 
 func collectCoSFairnessRSSExpectation(queueNode *Node) (string, error) {

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -933,15 +933,33 @@ func ValidateConfig(cfg *Config) []string {
 					"class-of-service traffic-control-profiles guaranteed-rate / delay-buffer-rate are accepted for compatibility but inert: the userspace dataplane enforces only the profile's shaping-rate and scheduler-map on the bound unit (#4315), so those values have no runtime effect")
 				warnedTCPInert = true
 			}
-			// #4228 Gap 2: shaping-rate percent is typed + stored but inert —
-			// the dataplane folds an ABSOLUTE shaping-rate into the bound unit's
-			// root shaper, and xpf does not yet resolve a percent against the
-			// interface speed, so a percent-only shaping-rate leaves the unit
-			// unshaped. Warn per profile so the operator is not misled.
-			if tcp.ShapingRatePercent > 0 {
-				warnings = append(warnings, fmt.Sprintf(
-					"class-of-service traffic-control-profiles %q shaping-rate percent is accepted for Junos compatibility but inert: the userspace dataplane enforces an absolute shaping-rate and xpf does not yet resolve the percent against the bound interface's speed, so the unit is left unshaped (#4228 Gap 2)",
-					tcp.Name))
+		}
+		// #4228 Gap 2: a `shaping-rate percent <n>` traffic-control-profile now
+		// RESOLVES against the bound interface's configured line rate
+		// (resolveCoSTrafficControlProfiles folds the resolved absolute rate
+		// into unit.ShapingRateBytes). Warn only per-BINDING for the residual
+		// inert case: a percent-only profile bound to an interface with no
+		// configured `speed`/`bandwidth`, where the percent could not resolve
+		// (unit.ShapingRateBytes stayed 0) and the unit is left unshaped.
+		warnShapingPercentInert := func(unit *CoSInterfaceUnit, ifaceName string) {
+			if unit == nil || unit.OutputTrafficControlProfile == "" || unit.ShapingRateBytes > 0 {
+				return
+			}
+			tcp := cos.TrafficControlProfiles[unit.OutputTrafficControlProfile]
+			if tcp == nil || tcp.ShapingRatePercent <= 0 || tcp.ShapingRateBytes > 0 {
+				return
+			}
+			warnings = append(warnings, fmt.Sprintf(
+				"class-of-service traffic-control-profiles %q shaping-rate percent %.4g%% bound on interface %q has no effect: the interface has no configured speed/bandwidth, so xpf cannot resolve the percent against a line rate and the unit is left unshaped (set `interfaces %s speed <rate>` to enable it) (#4228 Gap 2)",
+				tcp.Name, tcp.ShapingRatePercent, ifaceName, ifaceName))
+		}
+		for _, iface := range cos.Interfaces {
+			if iface == nil {
+				continue
+			}
+			warnShapingPercentInert(iface.Level, iface.Name)
+			for _, unit := range iface.Units {
+				warnShapingPercentInert(unit, iface.Name)
 			}
 		}
 		// #4316 (fable-167 F-3b): inet-precedence classifiers/rewrite and exp
@@ -970,6 +988,10 @@ func ValidateConfig(cfg *Config) []string {
 					class.Name, class.Queue))
 			}
 		}
+		// #4228 Gap 2: schedulers whose transmit-rate percent resolves (bound
+		// via a scheduler-map to an interface with a root shaping-rate). Used
+		// below to warn only for a percent that has no base to resolve against.
+		schedulersResolvingPercent := cosSchedulersWithShapedBinding(cos)
 		// #915: surplus-sharing is meaningful only on transmit-rate
 		// exact schedulers; warn-and-strip when set without exact so
 		// the runtime never sees the no-op flag (see #1183 lesson).
@@ -1016,22 +1038,23 @@ func ValidateConfig(cfg *Config) []string {
 					"class-of-service scheduler %q codel-target is accepted for compatibility but inert: the userspace dataplane has no CoDel AQM (#1829 Phase 2 not shipped), so the configured target has no runtime effect",
 					sched.Name))
 			}
-			// #4228 Gap 2: transmit-rate percent/remainder is typed + stored
-			// (so garbage is rejected at commit) but currently inert — the
-			// userspace dataplane consumes an absolute byte/sec transmit-rate,
-			// and xpf does not yet resolve the percent/remainder against the
-			// bound interface's rate (that resolution is multi-pass: a scheduler
-			// can be mapped onto interfaces of different speeds). Warn so an
-			// operator is not misled into believing the queue got an explicit
-			// rate. Mirrors the accepted-but-inert doctrine.
-			if sched.TransmitRatePercent > 0 || sched.TransmitRateRemainder {
-				form := "percent"
-				if sched.TransmitRateRemainder {
-					form = "remainder"
-				}
+			// #4228 Gap 2: transmit-rate percent now RESOLVES per-interface —
+			// forwarding_build/cos.rs computes the absolute byte/sec rate
+			// against the bound interface's shaping-rate (the multi-pass
+			// concern is handled by carrying the percent to the dataplane and
+			// materializing it per interface). Warn only for the residual inert
+			// cases: `remainder` (leftover-bandwidth resolution is still a
+			// follow-up) and a `percent` scheduler with no shaping base to
+			// resolve against — i.e. not bound via a scheduler-map to an
+			// interface that has a root shaping-rate.
+			if sched.TransmitRateRemainder {
 				warnings = append(warnings, fmt.Sprintf(
-					"class-of-service scheduler %q transmit-rate %s is accepted for Junos compatibility but inert: the userspace dataplane consumes an absolute byte/sec rate and xpf does not yet resolve the percent/remainder against the bound interface's rate, so the queue gets no explicit transmit-rate (#4228 Gap 2)",
-					sched.Name, form))
+					"class-of-service scheduler %q transmit-rate remainder is accepted for Junos compatibility but inert: the userspace dataplane consumes an absolute byte/sec rate and xpf does not yet resolve `remainder` against the leftover interface bandwidth, so the queue gets no explicit transmit-rate (#4228 Gap 2)",
+					sched.Name))
+			} else if sched.TransmitRatePercent > 0 && !schedulersResolvingPercent[sched.Name] {
+				warnings = append(warnings, fmt.Sprintf(
+					"class-of-service scheduler %q transmit-rate percent %.4g%% is accepted but has no effect: the scheduler is not bound via a scheduler-map to an interface with a root shaping-rate, so there is no base to resolve the percent against (#4228 Gap 2)",
+					sched.Name, sched.TransmitRatePercent))
 			}
 		}
 		for _, schedMap := range cos.SchedulerMaps {

--- a/pkg/config/schema_validate_cos_rate_percent_4228_test.go
+++ b/pkg/config/schema_validate_cos_rate_percent_4228_test.go
@@ -214,19 +214,87 @@ func TestCoSShapingRateBytesAndPercentConflict_Rejected(t *testing.T) {
 	}
 }
 
-// Advisory: a percent transmit-rate is accepted but flagged inert.
-func TestCoSTransmitRatePercent_EmitsInertAdvisory(t *testing.T) {
+// Advisory: a percent transmit-rate on a scheduler that is NOT bound (via a
+// scheduler-map) to an interface with a root shaping-rate has no base to
+// resolve against, so it stays inert and ValidateConfig flags it. #4228 Gap 2
+// made the percent resolve when bound to a shaped interface (see
+// TestCoSTransmitRatePercent_ResolvesAgainstInterfaceShapingRate in the Rust
+// forwarding_build suite); this covers the unbound residual.
+func TestCoSTransmitRatePercent_UnboundEmitsNoEffectAdvisory(t *testing.T) {
 	cfg := mustCompileSet4228(t,
 		"set class-of-service schedulers be transmit-rate percent 50",
 	)
 	warnings := config.ValidateConfig(cfg)
 	found := false
 	for _, w := range warnings {
-		if strings.Contains(w, "transmit-rate percent") && strings.Contains(w, "inert") {
+		if strings.Contains(w, "transmit-rate percent") && strings.Contains(w, "no base to resolve") {
 			found = true
 		}
 	}
 	if !found {
-		t.Fatalf("expected an accepted-but-inert advisory for transmit-rate percent, got: %v", warnings)
+		t.Fatalf("expected a no-effect advisory for an unbound transmit-rate percent, got: %v", warnings)
+	}
+}
+
+// #4228 Gap 2: a percent transmit-rate on a scheduler that IS bound via a
+// scheduler-map to a shaped interface RESOLVES — the Go control plane must NOT
+// emit the unbound no-effect advisory for it. FAIL-ON-REVERT: with the
+// resolution reverted the scheduler is never in the resolved set and the
+// advisory fires unconditionally, so this assertion flips.
+func TestCoSTransmitRatePercent_BoundToShapedInterface_NoAdvisory(t *testing.T) {
+	cfg := mustCompileSet4228(t,
+		"set class-of-service schedulers be transmit-rate percent 50",
+		"set class-of-service forwarding-classes queue 0 best-effort",
+		"set class-of-service scheduler-maps m1 forwarding-class best-effort scheduler be",
+		"set class-of-service interfaces ge-0/0/2 unit 0 shaping-rate 100m",
+		"set class-of-service interfaces ge-0/0/2 unit 0 scheduler-map m1",
+	)
+	warnings := config.ValidateConfig(cfg)
+	for _, w := range warnings {
+		if strings.Contains(w, "transmit-rate percent") && strings.Contains(w, "no base to resolve") {
+			t.Fatalf("bound-to-shaped-interface percent must not emit the no-effect advisory, got: %q", w)
+		}
+	}
+}
+
+// #4228 Gap 2 (shaping-rate percent, Go resolution): a `shaping-rate percent`
+// traffic-control-profile bound to an interface with a configured speed
+// resolves to an absolute per-unit root shaper rate. FAIL-ON-REVERT: without
+// the resolveCoSTrafficControlProfiles percent branch the unit stays unshaped
+// (ShapingRateBytes == 0).
+func TestCoSShapingRatePercent_ResolvesAgainstInterfaceSpeed(t *testing.T) {
+	cfg := mustCompileSet4228(t,
+		"set interfaces ge-0/0/2 speed 10g",
+		"set class-of-service traffic-control-profiles p1 shaping-rate percent 90",
+		"set class-of-service interfaces ge-0/0/2 unit 0 output-traffic-control-profile p1",
+	)
+	unit := cfg.ClassOfService.Interfaces["ge-0/0/2"].Units[0]
+	// 10g bits/s / 8 = 1_250_000_000 bytes/s; 90% = 1_125_000_000.
+	if unit.ShapingRateBytes != 1_125_000_000 {
+		t.Fatalf("ShapingRateBytes = %d, want 1125000000 (90%% of 10g line rate)", unit.ShapingRateBytes)
+	}
+}
+
+// #4228 Gap 2: a shaping-rate percent bound to an interface with NO configured
+// speed cannot resolve, so the unit is left unshaped and a per-binding advisory
+// flags it.
+func TestCoSShapingRatePercent_NoInterfaceSpeed_EmitsNoEffectAdvisory(t *testing.T) {
+	cfg := mustCompileSet4228(t,
+		"set class-of-service traffic-control-profiles p1 shaping-rate percent 90",
+		"set class-of-service interfaces ge-0/0/2 unit 0 output-traffic-control-profile p1",
+	)
+	unit := cfg.ClassOfService.Interfaces["ge-0/0/2"].Units[0]
+	if unit.ShapingRateBytes != 0 {
+		t.Fatalf("ShapingRateBytes = %d, want 0 (no interface speed to resolve percent against)", unit.ShapingRateBytes)
+	}
+	warnings := config.ValidateConfig(cfg)
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "shaping-rate percent") && strings.Contains(w, "no configured speed") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a no-effect advisory for an unresolvable shaping-rate percent, got: %v", warnings)
 	}
 }

--- a/pkg/dataplane/userspace/cos.go
+++ b/pkg/dataplane/userspace/cos.go
@@ -166,6 +166,7 @@ func buildClassOfServiceSnapshot(cfg *config.Config) *ClassOfServiceSnapshot {
 			snap.Schedulers = append(snap.Schedulers, CoSSchedulerSnapshot{
 				Name:                  sched.Name,
 				TransmitRateBytes:     sched.TransmitRateBytes,
+				TransmitRatePercent:   sched.TransmitRatePercent,
 				TransmitRateExact:     sched.TransmitRateExact,
 				Priority:              sched.Priority,
 				BufferSizeBytes:       sched.BufferSizeBytes,

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -364,9 +364,17 @@ type CoSDSCPRewriteRuleEntrySnapshot struct {
 type CoSSchedulerSnapshot struct {
 	Name              string `json:"name"`
 	TransmitRateBytes uint64 `json:"transmit_rate_bytes,omitempty"`
-	TransmitRateExact bool   `json:"transmit_rate_exact,omitempty"`
-	Priority          string `json:"priority,omitempty"`
-	BufferSizeBytes   uint64 `json:"buffer_size_bytes,omitempty"`
+	// TransmitRatePercent (#4228 Gap 2) carries the Junos `transmit-rate
+	// percent <n>` share (0,100]. Additive to preserve the legacy
+	// transmit_rate_bytes wire contract: an older dataplane ignores it; a
+	// newer dataplane resolves it PER-INTERFACE (forwarding_build/cos.rs)
+	// against the bound interface's cos_shaping_rate_bytes_per_sec when no
+	// absolute transmit_rate_bytes is set. omitempty keeps the wire
+	// byte-identical for configs that use an absolute rate.
+	TransmitRatePercent float64 `json:"transmit_rate_percent,omitempty"`
+	TransmitRateExact   bool    `json:"transmit_rate_exact,omitempty"`
+	Priority            string  `json:"priority,omitempty"`
+	BufferSizeBytes     uint64  `json:"buffer_size_bytes,omitempty"`
 	// BufferSizePercent is additive to preserve the legacy
 	// buffer_size_bytes wire contract. Older dataplanes ignore it;
 	// newer dataplanes use it only when buffer_size_bytes is absent.

--- a/userspace-dp/src/afxdp/forwarding_build/cos.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/cos.rs
@@ -285,6 +285,38 @@ fn cos_percent_buffer_bytes(pool_bytes: u64, percent: f64) -> Option<u64> {
     }
 }
 
+/// #4228 Gap 2: resolve a Junos `transmit-rate percent <n>` share against a
+/// base rate in bytes/sec. Mirrors `cos_percent_buffer_bytes` EXACTLY — same
+/// (0,100] domain guard, same `ceil` rounding, same clamp to [1, u64::MAX] —
+/// so a scheduler's transmit-rate percent and buffer-size percent round
+/// identically. Returns `None` when the base is unknown (0, e.g. a transparent
+/// root with no interface shaping-rate) or the percent is out of range; the
+/// caller then leaves the queue without an explicit transmit-rate (the
+/// documented inert fallback, matching the buffer-size None->default path).
+fn cos_percent_rate_bytes(base_rate_bytes: u64, percent: f64) -> Option<u64> {
+    cos_percent_buffer_bytes(base_rate_bytes, percent)
+}
+
+/// #4228 Gap 2: the effective absolute transmit-rate for a scheduler bound to
+/// an interface whose root shaping rate is `iface_shaping_rate_bytes`. An
+/// explicit absolute `transmit_rate_bytes` wins; otherwise a `transmit_rate
+/// percent <n>` resolves against the interface's shaping rate. `None` means no
+/// explicit guarantee (transparent / best-effort), preserving the historical
+/// behavior for schedulers with neither form set.
+fn cos_effective_transmit_rate_bytes(
+    scheduler: Option<&CoSSchedulerSnapshot>,
+    iface_shaping_rate_bytes: u64,
+) -> Option<u64> {
+    let sched = scheduler?;
+    if sched.transmit_rate_bytes > 0 {
+        return Some(sched.transmit_rate_bytes);
+    }
+    if sched.transmit_rate_percent > 0.0 {
+        return cos_percent_rate_bytes(iface_shaping_rate_bytes, sched.transmit_rate_percent);
+    }
+    None
+}
+
 fn cos_surplus_weight(rate_bytes: u64, root_rate_bytes: u64) -> u32 {
     if rate_bytes == 0 || root_rate_bytes == 0 {
         return 1;
@@ -518,9 +550,18 @@ pub(super) fn build_cos_iface_config(
             // transmit-rate keeps its `surplus_weight = 16` (scheduler is
             // Some), unchanged.
             let scheduler_unresolved = scheduler.is_none();
-            let explicit_transmit_rate_bytes = scheduler.and_then(|sched| {
-                (sched.transmit_rate_bytes > 0).then_some(sched.transmit_rate_bytes)
-            });
+            // #4228 Gap 2: resolve the scheduler's transmit-rate to an absolute
+            // byte/sec rate PER INTERFACE. An explicit absolute rate wins; a
+            // `percent <n>` form resolves against THIS interface's shaping rate
+            // (`cos_shaping_rate_bytes_per_sec`) — the same interface-shaping
+            // base family buffer-size percent uses — so the previously
+            // accepted-but-inert percent now drives the guarantee, surplus
+            // weight, and token bucket. A named scheduler mapped onto interfaces
+            // of different shaping rates materializes a different absolute rate
+            // on each, which is exactly why the percent is carried (not
+            // pre-resolved) on the shared snapshot.
+            let explicit_transmit_rate_bytes =
+                cos_effective_transmit_rate_bytes(scheduler, iface.cos_shaping_rate_bytes_per_sec);
             let guarantee_enabled = explicit_transmit_rate_bytes.is_some();
             let transmit_rate_bytes =
                 explicit_transmit_rate_bytes.unwrap_or(iface.cos_shaping_rate_bytes_per_sec);

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -174,6 +174,7 @@ fn build_cos_state_translates_scheduler_map_entries() {
                 CoSSchedulerSnapshot {
                     name: "be-sched".into(),
                     transmit_rate_bytes: 3_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
@@ -186,6 +187,7 @@ fn build_cos_state_translates_scheduler_map_entries() {
                 CoSSchedulerSnapshot {
                     name: "ef-sched".into(),
                     transmit_rate_bytes: 7_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: true,
                     priority: "strict-high".into(),
                     buffer_size_bytes: 64_000,
@@ -258,6 +260,7 @@ fn build_cos_state_resolves_percent_buffer_size_from_interface_burst_pool() {
             schedulers: vec![CoSSchedulerSnapshot {
                 name: "be-sched".into(),
                 transmit_rate_bytes: 3_000_000,
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: false,
                 priority: "low".into(),
                 buffer_size_bytes: 0,
@@ -296,6 +299,118 @@ fn build_cos_state_resolves_percent_buffer_size_from_interface_burst_pool() {
     );
 }
 
+// #4228 Gap 2: a `transmit-rate percent <n>` scheduler resolves to an absolute
+// byte/sec rate against the bound interface's shaping-rate — the SAME
+// interface-shaping base family buffer-size percent uses. RED on revert: with
+// the percent left inert the queue takes `explicit_transmit_rate_bytes = None`,
+// so its rate collapses to the whole interface shaping-rate (10_000_000, not
+// 0.5x) and `guarantee_enabled` stays false.
+#[test]
+fn build_cos_state_resolves_transmit_rate_percent_against_interface_shaping_rate() {
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            ifindex: 42,
+            cos_shaping_rate_bytes_per_sec: 10_000_000,
+            cos_shaping_burst_bytes: 256_000,
+            cos_scheduler_map: "wan-map".into(),
+            ..Default::default()
+        }],
+        class_of_service: Some(ClassOfServiceSnapshot {
+            forwarding_classes: vec![CoSForwardingClassSnapshot {
+                name: "best-effort".into(),
+                queue: 0,
+            }],
+            schedulers: vec![CoSSchedulerSnapshot {
+                name: "be-sched".into(),
+                transmit_rate_bytes: 0,
+                transmit_rate_percent: 50.0,
+                transmit_rate_exact: false,
+                priority: "low".into(),
+                buffer_size_bytes: 0,
+                buffer_size_percent: 0.0,
+                surplus_sharing: false,
+                equal_flow_enforcement: false,
+                equal_flow_target_policy: String::new(),
+                codel_target_ns: 0,
+            }],
+            scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                name: "wan-map".into(),
+                entries: vec![CoSSchedulerMapEntrySnapshot {
+                    forwarding_class: "best-effort".into(),
+                    scheduler: "be-sched".into(),
+                }],
+            }],
+            dscp_classifiers: vec![],
+            ieee8021_classifiers: vec![],
+            dscp_rewrite_rules: vec![],
+        }),
+        ..Default::default()
+    };
+
+    let state = build_cos_state(&snapshot);
+    let iface = state.interfaces.get(&42).expect("missing CoS interface");
+    assert_eq!(
+        iface.queues[0].transmit_rate_bytes, 5_000_000,
+        "transmit-rate percent 50 must resolve to 50% of the 10_000_000 B/s interface shaping-rate"
+    );
+    assert!(
+        iface.queues[0].guarantee_enabled,
+        "a resolved percent transmit-rate must enable the queue guarantee (no longer inert)"
+    );
+}
+
+// #4228 Gap 2: a percent transmit-rate on an interface with NO root
+// shaping-rate (transparent root) has no base to resolve against; it stays
+// inert — no fabricated guarantee — matching the buffer-size None->default path.
+#[test]
+fn build_cos_state_transmit_rate_percent_no_shaping_rate_stays_inert() {
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            ifindex: 42,
+            cos_shaping_rate_bytes_per_sec: 0,
+            cos_scheduler_map: "wan-map".into(),
+            ..Default::default()
+        }],
+        class_of_service: Some(ClassOfServiceSnapshot {
+            forwarding_classes: vec![CoSForwardingClassSnapshot {
+                name: "best-effort".into(),
+                queue: 0,
+            }],
+            schedulers: vec![CoSSchedulerSnapshot {
+                name: "be-sched".into(),
+                transmit_rate_bytes: 0,
+                transmit_rate_percent: 50.0,
+                transmit_rate_exact: false,
+                priority: "low".into(),
+                buffer_size_bytes: 0,
+                buffer_size_percent: 0.0,
+                surplus_sharing: false,
+                equal_flow_enforcement: false,
+                equal_flow_target_policy: String::new(),
+                codel_target_ns: 0,
+            }],
+            scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                name: "wan-map".into(),
+                entries: vec![CoSSchedulerMapEntrySnapshot {
+                    forwarding_class: "best-effort".into(),
+                    scheduler: "be-sched".into(),
+                }],
+            }],
+            dscp_classifiers: vec![],
+            ieee8021_classifiers: vec![],
+            dscp_rewrite_rules: vec![],
+        }),
+        ..Default::default()
+    };
+
+    let state = build_cos_state(&snapshot);
+    let iface = state.interfaces.get(&42).expect("missing CoS interface");
+    assert!(
+        !iface.queues[0].guarantee_enabled,
+        "a percent with no interface shaping-rate has no base and must not fabricate a guarantee"
+    );
+}
+
 #[test]
 fn build_cos_state_prefers_legacy_byte_buffer_when_both_fields_present() {
     let snapshot = ConfigSnapshot {
@@ -314,6 +429,7 @@ fn build_cos_state_prefers_legacy_byte_buffer_when_both_fields_present() {
             schedulers: vec![CoSSchedulerSnapshot {
                 name: "be-sched".into(),
                 transmit_rate_bytes: 3_000_000,
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: false,
                 priority: "low".into(),
                 buffer_size_bytes: 128_000,
@@ -379,6 +495,7 @@ fn build_cos_state_propagates_surplus_sharing_from_snapshot() {
                 CoSSchedulerSnapshot {
                     name: "iperf-a".into(),
                     transmit_rate_bytes: 1_000_000_000 / 8,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: true,
                     priority: "low".into(),
                     buffer_size_bytes: 128 * 1024,
@@ -391,6 +508,7 @@ fn build_cos_state_propagates_surplus_sharing_from_snapshot() {
                 CoSSchedulerSnapshot {
                     name: "iperf-b".into(),
                     transmit_rate_bytes: 10_000_000_000 / 8,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: true,
                     priority: "low".into(),
                     buffer_size_bytes: 128 * 1024,
@@ -451,6 +569,7 @@ fn build_cos_state_propagates_equal_flow_target_policy_gated_on_enforcement() {
     let make_sched = |name: &str, enforcement: bool, policy: &str| CoSSchedulerSnapshot {
         name: name.into(),
         transmit_rate_bytes: 1_000_000_000 / 8,
+        transmit_rate_percent: 0.0,
         transmit_rate_exact: true,
         priority: "low".into(),
         buffer_size_bytes: 128 * 1024,
@@ -573,6 +692,7 @@ fn build_cos_state_fails_closed_on_unknown_equal_flow_target_policy() {
             schedulers: vec![CoSSchedulerSnapshot {
                 name: "s-bad".into(),
                 transmit_rate_bytes: 1_000_000_000 / 8,
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: true,
                 priority: "low".into(),
                 buffer_size_bytes: 128 * 1024,
@@ -636,6 +756,7 @@ fn build_cos_state_fails_closed_on_unknown_scheduler_priority() {
             schedulers: vec![CoSSchedulerSnapshot {
                 name: "s-bad".into(),
                 transmit_rate_bytes: 1_000_000_000 / 8,
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: true,
                 priority: "hgh".into(),
                 buffer_size_bytes: 128 * 1024,
@@ -724,6 +845,7 @@ fn build_cos_state_derives_exact_queue_default_burst_from_queue_rate() {
             schedulers: vec![CoSSchedulerSnapshot {
                 name: "be-sched".into(),
                 transmit_rate_bytes: 100_000_000 / 8,
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: true,
                 priority: "low".into(),
                 buffer_size_bytes: 0,
@@ -786,6 +908,7 @@ fn build_cos_state_uses_effective_transmit_rate_for_surplus_weight() {
             schedulers: vec![CoSSchedulerSnapshot {
                 name: "be-sched".into(),
                 transmit_rate_bytes: 0,
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: false,
                 priority: "low".into(),
                 buffer_size_bytes: 0,
@@ -837,6 +960,7 @@ fn build_cos_state_marks_no_rate_scheduler_map_queue_residual_only() {
             schedulers: vec![CoSSchedulerSnapshot {
                 name: "be-sched".into(),
                 transmit_rate_bytes: 0,
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: false,
                 priority: "low".into(),
                 buffer_size_bytes: 0,
@@ -986,6 +1110,7 @@ fn build_cos_state_binds_dscp_classifier_to_usable_interface_queue_ids() {
                 CoSSchedulerSnapshot {
                     name: "be".into(),
                     transmit_rate_bytes: 1_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 0,
@@ -998,6 +1123,7 @@ fn build_cos_state_binds_dscp_classifier_to_usable_interface_queue_ids() {
                 CoSSchedulerSnapshot {
                     name: "voice".into(),
                     transmit_rate_bytes: 2_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "high".into(),
                     buffer_size_bytes: 0,
@@ -1918,6 +2044,7 @@ fn build_forwarding_state_enables_tx_selection_when_cos_interfaces_exist() {
             schedulers: vec![CoSSchedulerSnapshot {
                 name: "be-sched".into(),
                 transmit_rate_bytes: 10_000_000,
+                transmit_rate_percent: 0.0,
                 ..Default::default()
             }],
             scheduler_maps: vec![CoSSchedulerMapSnapshot {
@@ -3161,6 +3288,7 @@ fn build_cos_state_zero_shaping_rate_queue_inherits_transparent() {
             schedulers: vec![CoSSchedulerSnapshot {
                 name: "no-rate".into(),
                 transmit_rate_bytes: 0, // <- fallback chains to 0
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: false,
                 priority: "low".into(),
                 buffer_size_bytes: 0,
@@ -3220,6 +3348,7 @@ fn build_cos_state_no_rate_exact_surplus_equal_flow_is_residual_only() {
             schedulers: vec![CoSSchedulerSnapshot {
                 name: "no-rate-exact".into(),
                 transmit_rate_bytes: 0,
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: true,
                 priority: "high".into(),
                 buffer_size_bytes: 0,
@@ -4643,6 +4772,7 @@ fn build_cos_state_classifier_unmaterialized_queue_falls_back_to_default() {
             schedulers: vec![CoSSchedulerSnapshot {
                 name: "be".into(),
                 transmit_rate_bytes: 1_000_000,
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: false,
                 priority: "low".into(),
                 buffer_size_bytes: 0,

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -7966,6 +7966,7 @@ fn txn_flow_cache_hit_reclassifies_ba_dscp_per_packet_3778() {
             CoSSchedulerSnapshot {
                 name: "be-sched".into(),
                 transmit_rate_bytes: 4_000_000,
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: false,
                 priority: "low".into(),
                 buffer_size_bytes: 128_000,
@@ -7978,6 +7979,7 @@ fn txn_flow_cache_hit_reclassifies_ba_dscp_per_packet_3778() {
             CoSSchedulerSnapshot {
                 name: "ef-sched".into(),
                 transmit_rate_bytes: 6_000_000,
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: false,
                 priority: "strict-high".into(),
                 buffer_size_bytes: 64_000,

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -776,6 +776,7 @@ fn resolve_cos_queue_id_prefers_egress_output_filter_forwarding_class() {
                 CoSSchedulerSnapshot {
                     name: "be-sched".into(),
                     transmit_rate_bytes: 4_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
@@ -788,6 +789,7 @@ fn resolve_cos_queue_id_prefers_egress_output_filter_forwarding_class() {
                 CoSSchedulerSnapshot {
                     name: "ef-sched".into(),
                     transmit_rate_bytes: 6_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "strict-high".into(),
                     buffer_size_bytes: 64_000,
@@ -888,6 +890,7 @@ fn flowless_packet_gets_ba_classification_from_dscp() {
                 CoSSchedulerSnapshot {
                     name: "be-sched".into(),
                     transmit_rate_bytes: 4_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
@@ -900,6 +903,7 @@ fn flowless_packet_gets_ba_classification_from_dscp() {
                 CoSSchedulerSnapshot {
                     name: "ef-sched".into(),
                     transmit_rate_bytes: 6_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "strict-high".into(),
                     buffer_size_bytes: 64_000,
@@ -1002,6 +1006,7 @@ fn resolve_cos_queue_id_uses_reverse_output_source_port_filter() {
                 CoSSchedulerSnapshot {
                     name: "scheduler-be".into(),
                     transmit_rate_bytes: 100_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: true,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
@@ -1014,6 +1019,7 @@ fn resolve_cos_queue_id_uses_reverse_output_source_port_filter() {
                 CoSSchedulerSnapshot {
                     name: "scheduler-iperf-a".into(),
                     transmit_rate_bytes: 1_000_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: true,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
@@ -1154,6 +1160,7 @@ fn resolve_cached_cos_tx_selection_prefers_egress_output_filter_and_keeps_counte
                 CoSSchedulerSnapshot {
                     name: "be-sched".into(),
                     transmit_rate_bytes: 4_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
@@ -1166,6 +1173,7 @@ fn resolve_cached_cos_tx_selection_prefers_egress_output_filter_and_keeps_counte
                 CoSSchedulerSnapshot {
                     name: "ef-sched".into(),
                     transmit_rate_bytes: 6_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "strict-high".into(),
                     buffer_size_bytes: 64_000,
@@ -1275,6 +1283,7 @@ fn resolve_cos_queue_id_uses_ingress_input_filter_when_no_output_filter_exists()
                 CoSSchedulerSnapshot {
                     name: "be-sched".into(),
                     transmit_rate_bytes: 4_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
@@ -1287,6 +1296,7 @@ fn resolve_cos_queue_id_uses_ingress_input_filter_when_no_output_filter_exists()
                 CoSSchedulerSnapshot {
                     name: "ef-sched".into(),
                     transmit_rate_bytes: 6_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "strict-high".into(),
                     buffer_size_bytes: 64_000,
@@ -1392,6 +1402,7 @@ fn resolve_cached_cos_tx_selection_uses_ingress_input_filter_when_no_output_exis
                 CoSSchedulerSnapshot {
                     name: "be-sched".into(),
                     transmit_rate_bytes: 4_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
@@ -1404,6 +1415,7 @@ fn resolve_cached_cos_tx_selection_uses_ingress_input_filter_when_no_output_exis
                 CoSSchedulerSnapshot {
                     name: "ef-sched".into(),
                     transmit_rate_bytes: 6_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "strict-high".into(),
                     buffer_size_bytes: 64_000,
@@ -1493,6 +1505,7 @@ fn resolve_cached_cos_tx_selection_keeps_counter_only_output_filter_hits() {
             schedulers: vec![CoSSchedulerSnapshot {
                 name: "be-sched".into(),
                 transmit_rate_bytes: 4_000_000,
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: false,
                 priority: "low".into(),
                 buffer_size_bytes: 128_000,
@@ -1575,6 +1588,7 @@ fn resolve_cos_tx_selection_counts_counter_only_output_filter_hits() {
             schedulers: vec![CoSSchedulerSnapshot {
                 name: "be-sched".into(),
                 transmit_rate_bytes: 4_000_000,
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: false,
                 priority: "low".into(),
                 buffer_size_bytes: 128_000,
@@ -1798,6 +1812,7 @@ fn resolve_cos_tx_selection_uses_ingress_filter_dscp_rewrite_when_no_output_filt
                 CoSSchedulerSnapshot {
                     name: "be-sched".into(),
                     transmit_rate_bytes: 4_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
@@ -1810,6 +1825,7 @@ fn resolve_cos_tx_selection_uses_ingress_filter_dscp_rewrite_when_no_output_filt
                 CoSSchedulerSnapshot {
                     name: "ef-sched".into(),
                     transmit_rate_bytes: 6_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "strict-high".into(),
                     buffer_size_bytes: 64_000,
@@ -1910,6 +1926,7 @@ fn resolve_cos_tx_selection_skips_ingress_filter_without_tx_selection_effects() 
             schedulers: vec![CoSSchedulerSnapshot {
                 name: "be-sched".into(),
                 transmit_rate_bytes: 10_000_000,
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: false,
                 priority: "low".into(),
                 buffer_size_bytes: 128_000,
@@ -2057,6 +2074,7 @@ fn resolve_cos_queue_id_falls_back_to_default_queue_without_filter_match() {
             schedulers: vec![CoSSchedulerSnapshot {
                 name: "be-sched".into(),
                 transmit_rate_bytes: 10_000_000,
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: false,
                 priority: "low".into(),
                 buffer_size_bytes: 128_000,
@@ -2142,6 +2160,7 @@ fn resolve_cos_queue_id_uses_dscp_classifier_when_filters_do_not_set_class() {
                 CoSSchedulerSnapshot {
                     name: "be-sched".into(),
                     transmit_rate_bytes: 4_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
@@ -2154,6 +2173,7 @@ fn resolve_cos_queue_id_uses_dscp_classifier_when_filters_do_not_set_class() {
                 CoSSchedulerSnapshot {
                     name: "voice-sched".into(),
                     transmit_rate_bytes: 6_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "strict-high".into(),
                     buffer_size_bytes: 64_000,
@@ -2240,6 +2260,7 @@ fn resolve_cos_queue_id_uses_ieee8021_classifier_when_filters_do_not_set_class()
                 CoSSchedulerSnapshot {
                     name: "be-sched".into(),
                     transmit_rate_bytes: 4_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
@@ -2252,6 +2273,7 @@ fn resolve_cos_queue_id_uses_ieee8021_classifier_when_filters_do_not_set_class()
                 CoSSchedulerSnapshot {
                     name: "voice-sched".into(),
                     transmit_rate_bytes: 6_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "strict-high".into(),
                     buffer_size_bytes: 64_000,
@@ -2340,6 +2362,7 @@ fn resolve_cos_queue_id_does_not_use_ieee8021_classifier_for_untagged_packets() 
                 CoSSchedulerSnapshot {
                     name: "be-sched".into(),
                     transmit_rate_bytes: 4_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
@@ -2352,6 +2375,7 @@ fn resolve_cos_queue_id_does_not_use_ieee8021_classifier_for_untagged_packets() 
                 CoSSchedulerSnapshot {
                     name: "bulk-sched".into(),
                     transmit_rate_bytes: 6_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
@@ -2467,6 +2491,7 @@ fn resolve_cos_queue_id_preserves_ingress_classification_when_output_filter_has_
                 CoSSchedulerSnapshot {
                     name: "be-sched".into(),
                     transmit_rate_bytes: 10_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
@@ -2479,6 +2504,7 @@ fn resolve_cos_queue_id_preserves_ingress_classification_when_output_filter_has_
                 CoSSchedulerSnapshot {
                     name: "ef-sched".into(),
                     transmit_rate_bytes: 10_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "strict-high".into(),
                     buffer_size_bytes: 128_000,
@@ -2570,6 +2596,7 @@ fn resolve_cos_tx_selection_preserves_output_filter_dscp_rewrite_without_forward
             schedulers: vec![CoSSchedulerSnapshot {
                 name: "be-sched".into(),
                 transmit_rate_bytes: 10_000_000,
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: false,
                 priority: "low".into(),
                 buffer_size_bytes: 128_000,
@@ -2713,6 +2740,7 @@ fn cos_dscp_rewrite_keys_on_forwarding_class_and_loss_priority() {
                 CoSSchedulerSnapshot {
                     name: "be-sched".into(),
                     transmit_rate_bytes: 2_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 64_000,
@@ -2725,6 +2753,7 @@ fn cos_dscp_rewrite_keys_on_forwarding_class_and_loss_priority() {
                 CoSSchedulerSnapshot {
                     name: "voice-sched".into(),
                     transmit_rate_bytes: 4_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "strict-high".into(),
                     buffer_size_bytes: 64_000,
@@ -2737,6 +2766,7 @@ fn cos_dscp_rewrite_keys_on_forwarding_class_and_loss_priority() {
                 CoSSchedulerSnapshot {
                     name: "data-sched".into(),
                     transmit_rate_bytes: 4_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "medium-high".into(),
                     buffer_size_bytes: 64_000,
@@ -3141,6 +3171,7 @@ fn classify_generated_reply_assigns_forwarding_class_queue() {
                 CoSSchedulerSnapshot {
                     name: "be".into(),
                     transmit_rate_bytes: 4_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
@@ -3153,6 +3184,7 @@ fn classify_generated_reply_assigns_forwarding_class_queue() {
                 CoSSchedulerSnapshot {
                     name: "a".into(),
                     transmit_rate_bytes: 6_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 64_000,
@@ -3493,6 +3525,7 @@ fn resolve_cos_tx_selection_honors_tcp_flags_per_packet_match() {
                 CoSSchedulerSnapshot {
                     name: "be-sched".into(),
                     transmit_rate_bytes: 4_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
@@ -3505,6 +3538,7 @@ fn resolve_cos_tx_selection_honors_tcp_flags_per_packet_match() {
                 CoSSchedulerSnapshot {
                     name: "ef-sched".into(),
                     transmit_rate_bytes: 6_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "strict-high".into(),
                     buffer_size_bytes: 64_000,
@@ -3692,6 +3726,7 @@ fn pbr_classify_then_route_snapshot() -> ConfigSnapshot {
                 CoSSchedulerSnapshot {
                     name: "be-sched".into(),
                     transmit_rate_bytes: 4_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
@@ -3704,6 +3739,7 @@ fn pbr_classify_then_route_snapshot() -> ConfigSnapshot {
                 CoSSchedulerSnapshot {
                     name: "ef-sched".into(),
                     transmit_rate_bytes: 6_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "strict-high".into(),
                     buffer_size_bytes: 64_000,
@@ -3858,6 +3894,7 @@ fn count_fc_two_class_service() -> ClassOfServiceSnapshot {
             CoSSchedulerSnapshot {
                 name: "be-sched".into(),
                 transmit_rate_bytes: 4_000_000,
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: false,
                 priority: "low".into(),
                 buffer_size_bytes: 128_000,
@@ -3870,6 +3907,7 @@ fn count_fc_two_class_service() -> ClassOfServiceSnapshot {
             CoSSchedulerSnapshot {
                 name: "ef-sched".into(),
                 transmit_rate_bytes: 6_000_000,
+                transmit_rate_percent: 0.0,
                 transmit_rate_exact: false,
                 priority: "strict-high".into(),
                 buffer_size_bytes: 64_000,
@@ -4427,6 +4465,7 @@ fn hb166_t3_middle_case_snapshot() -> ConfigSnapshot {
                 CoSSchedulerSnapshot {
                     name: "be-sched".into(),
                     transmit_rate_bytes: 4_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
@@ -4439,6 +4478,7 @@ fn hb166_t3_middle_case_snapshot() -> ConfigSnapshot {
                 CoSSchedulerSnapshot {
                     name: "ef-sched".into(),
                     transmit_rate_bytes: 6_000_000,
+                    transmit_rate_percent: 0.0,
                     transmit_rate_exact: false,
                     priority: "strict-high".into(),
                     buffer_size_bytes: 64_000,

--- a/userspace-dp/src/protocol/cos.rs
+++ b/userspace-dp/src/protocol/cos.rs
@@ -86,6 +86,17 @@ pub(crate) struct CoSSchedulerSnapshot {
     pub name: String,
     #[serde(rename = "transmit_rate_bytes", default)]
     pub transmit_rate_bytes: u64,
+    /// #4228 Gap 2: the Junos `transmit-rate percent <n>` share (0,100].
+    /// Legacy snapshots carry only `transmit_rate_bytes`; this defaults to
+    /// 0.0. Resolved PER-INTERFACE in `forwarding_build::cos` against the
+    /// bound interface's `cos_shaping_rate_bytes_per_sec` (a named scheduler
+    /// can map onto interfaces of different shaping rates, so the absolute
+    /// rate is materialized per interface, not stored on the shared
+    /// scheduler). An absolute `transmit_rate_bytes` wins when both are
+    /// present; the Go strict validator rejects that combination on commit,
+    /// so a well-formed snapshot never sets both.
+    #[serde(rename = "transmit_rate_percent", default)]
+    pub transmit_rate_percent: f64,
     #[serde(rename = "transmit_rate_exact", default)]
     pub transmit_rate_exact: bool,
     #[serde(default)]

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -1221,6 +1221,7 @@ fn cos_scheduler_snapshot_surplus_sharing_round_trip_true() {
     let snap = CoSSchedulerSnapshot {
         name: "iperf-a".into(),
         transmit_rate_bytes: 125_000_000,
+        transmit_rate_percent: 0.0,
         transmit_rate_exact: true,
         priority: "low".into(),
         buffer_size_bytes: 65_536,
@@ -1240,6 +1241,7 @@ fn cos_scheduler_snapshot_equal_flow_enforcement_round_trip_true() {
     let snap = CoSSchedulerSnapshot {
         name: "iperf-a".into(),
         transmit_rate_bytes: 125_000_000,
+        transmit_rate_percent: 0.0,
         transmit_rate_exact: true,
         priority: "low".into(),
         buffer_size_bytes: 65_536,
@@ -1263,6 +1265,7 @@ fn cos_scheduler_snapshot_equal_flow_target_policy_round_trip() {
     let snap = CoSSchedulerSnapshot {
         name: "iperf-a".into(),
         transmit_rate_bytes: 125_000_000,
+        transmit_rate_percent: 0.0,
         transmit_rate_exact: true,
         priority: "low".into(),
         buffer_size_bytes: 65_536,
@@ -1287,6 +1290,7 @@ fn cos_scheduler_snapshot_buffer_size_percent_round_trip() {
     let snap = CoSSchedulerSnapshot {
         name: "percent-sched".into(),
         transmit_rate_bytes: 125_000_000,
+        transmit_rate_percent: 0.0,
         transmit_rate_exact: true,
         priority: "low".into(),
         buffer_size_bytes: 0,

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -451,7 +451,8 @@
     "priority": "",
     "surplus_sharing": false,
     "transmit_rate_bytes": 0,
-    "transmit_rate_exact": false
+    "transmit_rate_exact": false,
+    "transmit_rate_percent": 0.0
   },
   "destination_nat_rule_snapshot": {
     "counter_id": 0,


### PR DESCRIPTION
Refs #4228 (Gap 2 of 7 — tracker stays OPEN).

## What

PR #4320 accepted the Junos `transmit-rate percent <n>` and `shaping-rate
percent <n>` value forms but left them **accepted-but-inert** — a percent-only
scheduler or traffic-control-profile committed cleanly and silently did
nothing. This resolves the percent to an absolute rate, mirroring the existing
`buffer-size percent` precedent **exactly** (same `ceil` rounding, same clamp
to `[1, MaxUint64]`).

## How

**`transmit-rate percent` — resolved PER INTERFACE in Rust.**
`forwarding_build::cos` resolves the scheduler percent against the bound
interface's root shaping-rate (`cos_shaping_rate_bytes_per_sec`) — the same
interface-shaping base family `buffer-size percent` uses. A named scheduler can
map onto interfaces of different shaping rates, so the percent is *carried* to
the dataplane on the shared scheduler snapshot (new
`CoSSchedulerSnapshot.transmit_rate_percent`, serde default, mirroring
`buffer_size_percent`) and materialized per interface via new
`cos_effective_transmit_rate_bytes` / `cos_percent_rate_bytes` helpers. A
resolved percent drives the queue guarantee, surplus weight, and token bucket
just like an absolute `transmit-rate`. Transparent root (no shaping-rate) → no
base → stays inert, no fabricated guarantee (matches the buffer-size
`None`→default path).

**`shaping-rate percent` — resolved in the Go compiler.**
`resolveCoSTrafficControlProfiles` resolves the profile percent against the
bound interface's configured line rate (`set interfaces <if> speed`/`bandwidth`)
— Junos resolves shaping-rate percent against the interface speed — and folds
the resolved absolute rate into the unit root shaper. Per-binding: the same
profile bound to interfaces of different speeds folds a different rate onto
each. No configured speed → cannot resolve → unit left unshaped (per-binding
advisory names the interface + the fix).

**Design note (why the split).** A scheduler is a shared named object
materialized into a queue *per interface* in Rust, so its percent must be
carried and resolved there. A traffic-control-profile's shaping-rate is already
folded into the per-unit `ShapingRateBytes` in Go, and the interface speed base
lives only in Go config — so shaping-rate percent resolves at that existing
fold point (no new wire field, no interface-speed plumbing to the dataplane).

**Advisories reworded.** Percent now resolves; only `transmit-rate remainder`,
an unbound percent scheduler (not mapped to a shaped interface), and a
shaping-rate percent on a speed-less interface remain inert — flagged by
per-binding / per-scheduler advisories. The strict commit gate is unchanged:
garbage (`transmit-rate percent 150`) and a both-forms-set config are still
hard-rejected.

## Validation

- **Rust** `build_cos_state_resolves_transmit_rate_percent_against_interface_shaping_rate`
  (RED on revert: rate collapses to the whole interface rate, guarantee
  disables — verified empirically) + a transparent-root inert test.
- **Go** shaping-rate percent resolves to `0.9 × 10g` (RED on revert:
  `ShapingRateBytes` stays 0 — verified empirically) + bound/unbound advisory
  split tests.
- **FULL cargo suite SERIAL** green: 3628 + 54 + 8 + 22 + 1 passed, **0
  failed** (572 `cos::` tests). Go `./pkg/config/...` and `./pkg/dataplane/...`
  green. Protocol wire fixture regenerated for the one additive
  `transmit_rate_percent` field.

## Follow-up

This is a **dataplane CoS change** — a cluster CoS-percent smoke on
`loss:xpf-userspace-fw0/1` (apply a `transmit-rate percent` scheduler, confirm
the shaped rate under iperf) is warranted before/around merge.

Remaining #4228 gaps stay open (tracker not closed): Gap 1 (drop-profiles/WRED),
Gap 4 (802.1p PCP rewrite), Gap 5b (default classifier), Gap 6b (unbounded
strict-high), `clear class-of-service statistics`, `transmit-rate remainder`
resolution, and `buffer-size temporal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi