### PR TITLE
cluster: hold never-seen heartbeat promotion behind the cold-boot grace (#4386)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,23 @@
+## 2026-07-06 — #4386 cold-boot split-brain: never-seen heartbeat startup floor
+
+- **Timestamp**: 2026-07-06
+- **Action**: Fixed the cluster heartbeat "peer never seen" path promoting after
+  only threshold*interval (~500ms), which skipped the 30s config-apply grace and
+  caused dual-primary on a simultaneous cold boot. The config apply phase (FRR
+  reload, fabric creation, RETH MAC down/up) disrupts control-link RX for 10-15s,
+  so first heartbeats drop and lastSeen stays 0 on BOTH nodes → both promoted and
+  claimed the RETH virtual MAC. Extracted the per-tick evaluation into a testable
+  `heartbeatReceiver.checkTimeout` seam, added the shared `heartbeatStartupGrace`
+  (30s) const (reused for both the seen-then-lost grace and the never-seen floor),
+  and gated the never-seen promotion behind `neverSeenConfirmed(sinceStart,
+  grace)`. A genuinely-absent peer still promotes once the grace elapses (floor
+  delays, never blocks) so single-node deployments are unaffected. RED-on-revert:
+  restoring the old `> timeout` check promotes a never-seen peer at 5s (mid
+  config-apply window) → the within-grace test fails. go test ./pkg/cluster/...
+  green (incl -race), go build/vet/gofmt clean.
+  **File(s)**: pkg/cluster/heartbeat.go,
+  pkg/cluster/heartbeat_neverseen_floor_test.go, pkg/cluster/README.md, _Log.md
+
 ## 2026-07-06 — #4070 follow-up: exclude token-packed multi-leaves from the union
 
 - **Timestamp**: 2026-07-06

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -109,6 +109,34 @@ The primary consumer of the `Manager.Events()` channel is
 publish, etc.). `pkg/cluster/reth.go::HandleStateChange` is a
 state-handler method, not the event-channel consumer.
 
+## Peer-liveness cold-boot grace (#4386)
+
+`heartbeatReceiver.checkTimeout` (`heartbeat.go`) makes both peer-liveness
+decisions, and both are gated behind a single cold-boot floor,
+`heartbeatStartupGrace` (30s). For that window after a receiver starts, the
+local config apply phase — VRF binding, FRR reload, fabric creation, RETH MAC
+down/up — can disrupt the control-link UDP receive path for 10-15+ seconds:
+
+- **Seen-then-lost** (`lastSeen != 0`): peer-lost is suppressed entirely inside
+  the grace, so a recovering node does not declare a still-live peer dead on
+  the first dropped heartbeat. After the grace, staleness (`heartbeatStale`,
+  `threshold*interval`) drives `handlePeerTimeout`.
+- **Never-seen-at-boot** (`lastSeen == 0`): single-node promotion is held
+  behind the SAME floor via `neverSeenConfirmed(sinceStart, grace)`. Deciding a
+  peer NEVER EXISTED is different from a peer that WAS seen then went silent —
+  on a **simultaneous cold boot** the first heartbeats from a live peer are
+  dropped and `lastSeen` stays 0 on BOTH nodes. Promoting at
+  `threshold*interval` (~500ms) would then make BOTH claim primary and the RETH
+  virtual MAC — a 10-15s split-brain until the link recovers and dual-active
+  resolution demotes one. The floor lets a slow-to-appear peer be heard first.
+
+The floor DELAYS the never-seen decision; it never blocks it. A genuinely
+absent peer — a single-node deployment, or a peer that will never come up —
+still promotes once the grace elapses (`neverSeenConfirmed` returns true at
+`sinceStart >= grace`), so there is no permanent no-master. `handlePeerNeverSeen`
+sets `peerEverSeen` and runs `electSingleNode`; `election.go` bypasses the
+readiness gate when `!peerAlive`, so the surviving node takes over.
+
 ## Control-channel authentication (#4107, PR-A)
 
 The cluster heartbeat drives election: `handlePeerHeartbeat` rebuilds

--- a/pkg/cluster/heartbeat.go
+++ b/pkg/cluster/heartbeat.go
@@ -55,6 +55,24 @@ const (
 	// DefaultHeartbeatThreshold is the default missed heartbeat count before peer is lost.
 	DefaultHeartbeatThreshold = 5
 
+	// heartbeatStartupGrace is the cold-boot config-apply grace window. For
+	// this long after a receiver starts, the local config apply phase (VRF
+	// binding, FRR reload, fabric creation, RETH MAC down/up) can disrupt the
+	// control-link UDP receive path for 10-15+ seconds. BOTH peer-liveness
+	// decisions hold behind this floor so a simultaneous cold boot cannot
+	// split-brain:
+	//   - seen-then-lost: suppress peer-lost entirely — a recovering node must
+	//     not declare a live peer dead on the first dropped heartbeat.
+	//   - never-seen-at-boot: suppress single-node promotion (#4386). Deciding
+	//     a peer NEVER EXISTED is different from a peer that WAS seen then went
+	//     silent: on a simultaneous boot the first heartbeats from a live peer
+	//     are dropped and lastSeen stays 0 on BOTH nodes, so promoting at
+	//     threshold*interval (~500ms) makes BOTH claim the RETH virtual MAC.
+	//     The floor lets a slow-to-appear peer be heard first while a
+	//     genuinely-absent peer (single-node deployment) still promotes once it
+	//     elapses.
+	heartbeatStartupGrace = 30 * time.Second
+
 	// heartbeatAuthMagic marks the optional #4107 PSK/HMAC auth trailer.
 	// Distinct from heartbeatMagic ("BPFX") so a reader can unambiguously
 	// detect a trailer at the tail of a frame. The trailer is appended AFTER
@@ -715,7 +733,6 @@ func (r *heartbeatReceiver) readLoop() {
 
 func (r *heartbeatReceiver) timeoutLoop() {
 	defer r.wg.Done()
-	timeout := time.Duration(r.threshold) * r.interval
 	ticker := time.NewTicker(r.interval)
 	defer ticker.Stop()
 
@@ -724,38 +741,66 @@ func (r *heartbeatReceiver) timeoutLoop() {
 		case <-r.stopCh:
 			return
 		case <-ticker.C:
-			lastNano := r.lastSeen.Load()
-			if lastNano == 0 {
-				// No heartbeat ever received. Once we've waited the full
-				// timeout, declare peer absent so the election can proceed
-				// (non-preempt nodes start as secondary and need this to
-				// take primary when the peer is truly down).
-				if time.Since(r.startedAt) > timeout {
-					r.mgr.handlePeerNeverSeen()
-				}
-				continue
-			}
-			// During the first 30 seconds after startup, suppress
-			// peer-lost entirely. The config apply phase (VRF binding,
-			// FRR reload, fabric creation, RETH MAC) can disrupt the
-			// UDP receive path on the control link for 10-15+ seconds.
-			// Without this grace, the recovering node sees one peer
-			// heartbeat then declares peer lost — creating split-brain.
-			// (r.startedAt is a direct time.Time, so time.Since uses
-			// its embedded monotonic reading — already step-safe.)
-			if time.Since(r.startedAt) < 30*time.Second {
-				continue
-			}
-			// Compare in the CLOCK_MONOTONIC domain. The previous
-			// time.Unix(0, lastNano) round-trip produced a Time with
-			// no monotonic reading, making time.Since pure wall-clock
-			// — a forward step > timeout fired a false peer-lost on
-			// a healthy cluster (#1792).
-			if heartbeatStale(lastNano, MonotonicNanos(), timeout) {
-				r.mgr.handlePeerTimeout()
-			}
+			r.checkTimeout()
 		}
 	}
+}
+
+// checkTimeout runs one peer-liveness evaluation tick. Split out of
+// timeoutLoop so the cold-boot never-seen floor and the steady-state
+// staleness decision are unit testable without driving the ticker goroutine.
+func (r *heartbeatReceiver) checkTimeout() {
+	timeout := time.Duration(r.threshold) * r.interval
+	lastNano := r.lastSeen.Load()
+	if lastNano == 0 {
+		// No heartbeat ever received. Deciding a peer NEVER EXISTED at boot
+		// is not the same as a peer that WAS seen then went silent: on a
+		// simultaneous cold boot the local config apply phase disrupts the
+		// control-link RX for 10-15+ seconds, so the first heartbeats from a
+		// live peer are dropped and lastSeen stays 0 on BOTH nodes. Promoting
+		// at threshold*interval (~500ms) would then make BOTH claim primary
+		// and the RETH virtual MAC — split-brain (#4386). Hold the never-seen
+		// promotion behind the SAME cold-boot grace the seen-then-lost path
+		// uses below. A genuinely-absent peer (single-node deployment, or a
+		// peer that will never come up) still promotes once the grace elapses,
+		// so this delays the decision, it never blocks it.
+		// (r.startedAt is a direct time.Time, so time.Since uses its embedded
+		// monotonic reading — already step-safe.)
+		if neverSeenConfirmed(time.Since(r.startedAt), heartbeatStartupGrace) {
+			r.mgr.handlePeerNeverSeen()
+		}
+		return
+	}
+	// During the cold-boot grace, suppress peer-lost entirely. The config
+	// apply phase (VRF binding, FRR reload, fabric creation, RETH MAC) can
+	// disrupt the UDP receive path on the control link for 10-15+ seconds.
+	// Without this grace, the recovering node sees one peer heartbeat then
+	// declares peer lost — creating split-brain. (r.startedAt is a direct
+	// time.Time, so time.Since uses its embedded monotonic reading — already
+	// step-safe.)
+	if time.Since(r.startedAt) < heartbeatStartupGrace {
+		return
+	}
+	// Compare in the CLOCK_MONOTONIC domain. The previous
+	// time.Unix(0, lastNano) round-trip produced a Time with no monotonic
+	// reading, making time.Since pure wall-clock — a forward step > timeout
+	// fired a false peer-lost on a healthy cluster (#1792).
+	if heartbeatStale(lastNano, MonotonicNanos(), timeout) {
+		r.mgr.handlePeerTimeout()
+	}
+}
+
+// neverSeenConfirmed reports whether a receiver that has never seen a peer
+// heartbeat (lastSeen == 0) has waited out the cold-boot config-apply grace
+// and may now confirm the peer absent to drive single-node election. It is a
+// startup FLOOR, not a steady-state timeout: threshold*interval (~500ms) is
+// correct for a peer that WAS seen then went silent, but far too aggressive
+// for deciding a peer never existed at boot, where the first heartbeats are
+// commonly dropped by the local config apply disruption (#4386). Returning
+// true once sinceStart >= grace guarantees a genuinely-absent peer still
+// promotes — the floor delays the never-seen decision, it never blocks it.
+func neverSeenConfirmed(sinceStart, grace time.Duration) bool {
+	return sinceStart >= grace
 }
 
 // heartbeatStale reports whether the last peer heartbeat is older than

--- a/pkg/cluster/heartbeat_neverseen_floor_test.go
+++ b/pkg/cluster/heartbeat_neverseen_floor_test.go
@@ -1,0 +1,144 @@
+package cluster
+
+import (
+	"testing"
+	"time"
+)
+
+// #4386 cold-boot split-brain regression coverage.
+//
+// The heartbeat "peer never seen" path (lastSeen == 0) used to confirm the
+// peer absent and drive single-node election after only threshold*interval
+// (~500ms). On a SIMULTANEOUS cold boot the local config apply phase (FRR
+// reload, fabric creation, RETH MAC down/up) disrupts the control-link UDP RX
+// for 10-15+ seconds, so the first heartbeats from a live peer are dropped and
+// lastSeen stays 0 on BOTH nodes. Both then promoted at T0+500ms and both
+// claimed the RETH virtual MAC — a 10-15s split-brain. The fix holds the
+// never-seen promotion behind heartbeatStartupGrace, the same cold-boot grace
+// the seen-then-lost path already uses.
+
+// TestNeverSeenConfirmedFloor pins the startup-floor boundary. Within the
+// grace the never-seen decision is held; at/after the grace it fires, so a
+// genuinely-absent peer (single-node deployment) still promotes — the floor
+// delays the decision, it never blocks it permanently.
+func TestNeverSeenConfirmedFloor(t *testing.T) {
+	const grace = 30 * time.Second
+	cases := []struct {
+		name       string
+		sinceStart time.Duration
+		want       bool
+	}{
+		{"steady-state timeout is NOT enough at boot", 500 * time.Millisecond, false},
+		{"mid config-apply disruption window", 5 * time.Second, false},
+		{"just under grace", grace - time.Millisecond, false},
+		{"exactly at grace still promotes (no permanent no-master)", grace, true},
+		{"well past grace promotes", grace + 10*time.Second, true},
+	}
+	for _, tc := range cases {
+		if got := neverSeenConfirmed(tc.sinceStart, grace); got != tc.want {
+			t.Errorf("%s: neverSeenConfirmed(%v, %v) = %v, want %v",
+				tc.name, tc.sinceStart, grace, got, tc.want)
+		}
+	}
+}
+
+// coldBootManager builds a cluster-mode manager with one non-preempt RG that
+// starts secondary (blocked from initial promotion by controlInterface +
+// non-preempt + !peerEverSeen), mirroring a fresh boot before any peer
+// heartbeat has been received.
+func coldBootManager(t *testing.T) *Manager {
+	t.Helper()
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200}))
+	cfg.ControlInterface = "em0" // enables cluster-mode election gating
+	m.UpdateConfig(cfg)
+	if m.IsLocalPrimary(0) {
+		t.Fatal("setup: node should start secondary before any peer heartbeat")
+	}
+	return m
+}
+
+func peerEverSeen(m *Manager) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.peerEverSeen
+}
+
+// TestColdBootNeverSeenFloorSuppressesPromotion is the RED-on-revert guard for
+// #4386. A receiver that has never seen a peer, still inside the cold-boot
+// grace, must NOT confirm the peer absent — so it does not promote and cannot
+// join a dual-primary. After the grace it MUST promote (single-node still
+// works). Reverting the never-seen floor to the old threshold*interval check
+// promotes at ~500ms, making the within-grace assertion fail.
+func TestColdBootNeverSeenFloorSuppressesPromotion(t *testing.T) {
+	// Within the grace (simulating the 5s config-apply RX disruption): no
+	// heartbeat ever seen, but we must hold — a live peer is likely just
+	// slow to be heard. On the buggy path 5s > 500ms → promote → split-brain.
+	m := coldBootManager(t)
+	r := newHeartbeatReceiver(m, nil, DefaultHeartbeatThreshold, DefaultHeartbeatInterval)
+	r.startedAt = time.Now().Add(-5 * time.Second)
+	// r.lastSeen defaults to 0 (never seen).
+	r.checkTimeout()
+	if peerEverSeen(m) {
+		t.Fatal("never-seen peer confirmed absent within the cold-boot grace (split-brain risk)")
+	}
+	if m.IsLocalPrimary(0) {
+		t.Fatal("node promoted to primary within the cold-boot grace on a never-seen peer")
+	}
+
+	// Past the grace with the peer STILL never seen: a genuinely-absent peer
+	// (single-node deployment) must eventually promote — the floor must not
+	// become a permanent no-master.
+	r.startedAt = time.Now().Add(-(heartbeatStartupGrace + time.Second))
+	r.checkTimeout()
+	if !peerEverSeen(m) {
+		t.Fatal("never-seen peer not confirmed absent after the grace elapsed (permanent no-master)")
+	}
+	if !m.IsLocalPrimary(0) {
+		t.Fatal("node did not promote after the cold-boot grace with a genuinely-absent peer")
+	}
+}
+
+// TestSeenThenLostPathUnchangedByNeverSeenFloor confirms the fix only touches
+// the never-seen branch. A peer that WAS seen (lastSeen != 0) then went silent
+// is still governed by the existing cold-boot grace, then declared lost via
+// the unchanged staleness path.
+func TestSeenThenLostPathUnchangedByNeverSeenFloor(t *testing.T) {
+	newSeenLostManager := func() *Manager {
+		m := coldBootManager(t)
+		m.mu.Lock()
+		m.peerEverSeen = true // peer was heard at least once
+		m.peerAlive = true
+		m.mu.Unlock()
+		return m
+	}
+	timeout := time.Duration(DefaultHeartbeatThreshold) * DefaultHeartbeatInterval
+
+	// Within the grace: a stale heartbeat is suppressed (same grace as
+	// before) so a recovering node does not declare its live peer dead.
+	m := newSeenLostManager()
+	r := newHeartbeatReceiver(m, nil, DefaultHeartbeatThreshold, DefaultHeartbeatInterval)
+	r.startedAt = time.Now().Add(-5 * time.Second)
+	r.lastSeen.Store(MonotonicNanos() - (timeout + time.Second).Nanoseconds())
+	r.checkTimeout()
+	m.mu.RLock()
+	aliveInGrace := m.peerAlive
+	m.mu.RUnlock()
+	if !aliveInGrace {
+		t.Fatal("seen-then-lost peer declared dead inside the cold-boot grace")
+	}
+
+	// Past the grace: the staleness path fires exactly as before the fix —
+	// peer is marked lost at threshold*interval staleness.
+	m = newSeenLostManager()
+	r = newHeartbeatReceiver(m, nil, DefaultHeartbeatThreshold, DefaultHeartbeatInterval)
+	r.startedAt = time.Now().Add(-(heartbeatStartupGrace + time.Second))
+	r.lastSeen.Store(MonotonicNanos() - (timeout + time.Second).Nanoseconds())
+	r.checkTimeout()
+	m.mu.RLock()
+	aliveAfterGrace := m.peerAlive
+	m.mu.RUnlock()
+	if aliveAfterGrace {
+		t.Fatal("seen-then-lost peer not declared dead after the grace (lost-peer path regressed)")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the cold-boot split-brain in #4386. The heartbeat "peer never seen"
path (`lastSeen == 0`) in `heartbeatReceiver`'s timeout loop confirmed the
peer absent and drove single-node election after only `threshold*interval`
(~500ms), then `continue`d — so the 30s config-apply grace immediately below
was **unreachable** whenever the peer had never been seen.

On a **simultaneous cold boot**, the local config apply phase (FRR reload,
fabric creation, RETH MAC down/up) disrupts the control-link UDP RX for
10-15+ seconds, so the first heartbeats from a live peer are dropped and
`lastSeen` stays `0` on **both** nodes. At T0+500ms both hit
`handlePeerNeverSeen` → both promoted to primary → both claimed the RETH
virtual MAC + GARP → 10-15s dual-primary until the link recovered.

## Fix

Gate the never-seen promotion behind the **same** cold-boot grace the
seen-then-lost path already uses:

- Extract the per-tick evaluation into a testable `heartbeatReceiver.checkTimeout` seam.
- Add the shared `heartbeatStartupGrace` (30s) const — used for both the
  seen-then-lost grace and the never-seen floor (replaces the inline
  `30*time.Second` literal).
- Route the never-seen decision through `neverSeenConfirmed(sinceStart, grace)`.

The floor **delays** the never-seen decision, it never blocks it: a
genuinely-absent peer (single-node deployment, or a peer that will never come
up) still promotes once the grace elapses (`neverSeenConfirmed` is true at
`sinceStart >= grace`) — no permanent no-master. The seen-then-lost
(`lastSeen != 0`) branch is unchanged.

## Validation

New `pkg/cluster/heartbeat_neverseen_floor_test.go`:

- `TestNeverSeenConfirmedFloor` — floor boundary (500ms/5s/just-under → hold;
  exactly-at / past → promote).
- `TestColdBootNeverSeenFloorSuppressesPromotion` — cold-boot within-grace
  suppression (**RED on revert**: restoring the old `> timeout` check promotes
  a never-seen peer at 5s, mid config-apply window → test fails) **and**
  still-promotes-after-grace single-node case (no permanent no-master).
- `TestSeenThenLostPathUnchangedByNeverSeenFloor` — lost-peer path unchanged.

`go test ./pkg/cluster/...` green incl `-race`; `go build ./...`, `go vet`,
`gofmt` clean.

## Reviewer note (HA)

This is an HA/cluster change — it needs `make test-failover`, specifically a
**simultaneous-boot** scenario: boot both nodes together and assert only one
promotes. The Go tests cover the decision logic; the on-cluster boot-together
assertion is the remaining gate.

Closes #4386

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi