### PR TITLE
vrrp: anchor dual-stack equal-priority tie-break to one family (#4376)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,29 @@
+## 2026-07-06 — #4376: VRRP dual-stack equal-priority tie-break family-consistency
+
+- **Timestamp**: 2026-07-06 16:53 PDT
+- **Action**: Fixed the dual-stack VRRP equal-priority tie-break split. The old
+  `handleMasterRx` tie-break keyed off the ARRIVING advert's family (v4 advert
+  vs `getLocalIP`, v6 advert vs `getLocalIPv6` link-local). A single instance is
+  dual-stack (`CollectRethInstances` puts v4+v6 on one instance; `sendAdvert`
+  emits BOTH a v4 and a v6 advert from unrelated sources), so two equal-priority
+  nodes with DISAGREEING v4-vs-v6 orderings each stepped down on the other
+  family's advert → both BACKUP → both masterDown timers expire → both MASTER →
+  permanent no-master oscillation (RG outage, #4376). Replaced the inline
+  branch with `resolveEqualPriorityMaster`, which anchors the tie-break to ONE
+  family via `hasIPv4VIP()` (classified from the immutable configured VIP set):
+  a v4-bearing (dual-stack or v4-only) instance decides ONLY off v4 adverts and
+  ignores v6-family adverts; a v6-only instance decides off the link-local v6
+  advert — both nodes then compare the same pair. Also fixed the secondary
+  defect: a nil (unresolved) local source now YIELDS (`becomeBackup`) instead of
+  defaulting to stay-MASTER (the old "treat unresolved as we-win"); no
+  oscillation because a node that cannot resolve its source cannot put a valid
+  same-family advert on the wire. Added 4 unit tests (3 RED on revert to the
+  family-split code, verified). Updated `pkg/vrrp/README.md` with a new
+  "Equal-priority tie-break — dual-stack family-consistency (#4376)" section.
+  HA VRRP state-machine change — parent runs `make test-failover` before merge.
+- **File(s)**: pkg/vrrp/instance.go, pkg/vrrp/vrrp_test.go, pkg/vrrp/README.md,
+  _Log.md
+
 ## 2026-07-06 — #4228 Gap 2: resolve CoS transmit-rate / shaping-rate percent
 
 - **Timestamp**: 2026-07-06

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -226,6 +226,53 @@ blackholing on takeover. Compiled to `Instance.PreemptHoldTime` (seconds);
   preempt and is not wired to interface `preempt hold-time` (out of scope
   for #2850).
 
+## Equal-priority tie-break — dual-stack family-consistency (#4376)
+
+RFC 5798 §6.4.3 resolves a MASTER-MASTER collision at **equal priority** by
+higher source IP. `handleMasterRx` runs this only against an equal-priority
+peer advert (a higher-priority advert steps down unconditionally; priority-0
+is a peer resignation). `resolveEqualPriorityMaster` performs the comparison.
+
+A single instance is genuinely **dual-stack**: `CollectRethInstances` puts all
+of a unit's v4+v6 addresses on ONE instance, and `sendAdvert` emits BOTH a v4
+advert (source `getLocalIP`, the lowest primary v4) and a v6 advert (source
+`getLocalIPv6`, the link-local) from two **unrelated** sources. The v4 and v6
+orderings between two nodes can therefore **disagree**.
+
+The tie-break must NOT key off whichever family's advert happened to arrive. If
+it did, two equal-priority nodes with disagreeing orderings (A: higher-v4 /
+lower link-local, B: lower-v4 / higher link-local) would each step down on the
+**other** family's advert — A backs down on B's higher-v6, B backs down on A's
+higher-v4 — so BOTH go BACKUP, both `masterDown` timers expire, both re-elect:
+a permanent no-master oscillation (RG outage). Equal priority is reachable — a
+simultaneous cold boot leaves both at 100, and a control/heartbeat-only
+partition leaves both at 200.
+
+Fix: **anchor the tie-break to ONE address family** so both nodes compare the
+same pair of addresses. `hasIPv4VIP()` classifies the instance from its
+**configured VIP families** (immutable per instance — a transient address flush
+cannot flip the anchor):
+
+- **v4-bearing** (dual-stack or v4-only): resolve the collision on **v4 adverts
+  only**, comparing `getLocalIP()`. A v6-family advert is **ignored** for the
+  tie-break (the peer's v4 advert drives the symmetric decision on both sides).
+- **v6-only** (no v4 VIP): resolve on the **link-local v6** advert via
+  `getLocalIPv6()`.
+
+Secondary defect (same fix): when the anchored family's local source is **nil**
+(unresolved — e.g. the #2528 RETH-MAC-flush window), the old code let
+`peerHigher` stay false and **stayed MASTER by default** ("treat unresolved as
+we-win"). It now **yields** (`becomeBackup`) to the actively advertising
+equal-priority peer. This does not oscillate: a node that cannot resolve its own
+source cannot put a valid same-family advert on the wire (`sendPacket` errors),
+so the peer never receives an advert from it and only one side steps down; the
+source re-resolves on the advert-send path and a healthy node re-elects cleanly.
+
+Regression coverage: `TestHandleMasterRx_DualStack_DisagreeingOrderings_ConvergeOneMaster`
+(both converge to one master), `..._DualStack_IgnoresV6Advert`,
+`..._V6Only_TieBreaksOnLinkLocal`, `..._NilLocal_DoesNotStayMaster` in
+`vrrp_test.go`.
+
 ## Interface tracking (#1814)
 
 Single-interface tracking per VRRP group:

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -1583,24 +1583,96 @@ func (vi *vrrpInstance) handleMasterRx(pkt *VRRPPacket, masterDownTimer, advertT
 		// Higher priority — step down unconditionally.
 		vi.becomeBackup(masterDownTimer, advertTimer)
 	} else if pktPri == pri && pkt.SrcIP != nil {
-		// Equal priority — RFC 5798 §6.4.3 tie-break: higher IP wins.
-		// Handle both IPv4 and IPv6 address families.
-		localIP := vi.getLocalIP()
-		localIPv6 := vi.getLocalIPv6()
-		var peerHigher bool
-		if pkt.SrcIP.To4() != nil && localIP != nil {
-			peerHigher = bytes.Compare(pkt.SrcIP.To4(), localIP.To4()) > 0
-		} else if pkt.SrcIP.To4() == nil && localIPv6 != nil {
-			peerHigher = bytes.Compare(pkt.SrcIP.To16(), localIPv6.To16()) > 0
-		}
-		if peerHigher {
-			slog.Info("vrrp: equal priority tie-break, peer IP is higher — stepping down",
-				"key", vi.key(), "our_ip", localIP, "our_ipv6", localIPv6,
-				"peer_ip", pkt.SrcIP, "priority", pri)
-			vi.becomeBackup(masterDownTimer, advertTimer)
-		}
+		// Equal priority — RFC 5798 §6.4.3 tie-break: higher source IP wins.
+		// The comparison is anchored to ONE address family so both nodes
+		// decide off the SAME ordering (#4376) — see resolveEqualPriorityMaster.
+		vi.resolveEqualPriorityMaster(pkt, masterDownTimer, advertTimer)
 	}
 	// Lower priority, or equal with our IP higher: stay Master.
+}
+
+// resolveEqualPriorityMaster runs the RFC 5798 §6.4.3 MASTER-MASTER tie-break
+// for an equal-priority peer advert while we are MASTER.
+//
+// A single instance is genuinely dual-stack: CollectRethInstances puts all of a
+// unit's v4+v6 addresses on ONE instance, and sendAdvert emits BOTH a v4 advert
+// (from getLocalIP, the lowest primary v4) and a v6 advert (from getLocalIPv6,
+// the link-local) from two UNRELATED sources. If the tie-break keyed off
+// whichever family happened to arrive, two equal-priority nodes with DISAGREEING
+// v4-vs-v6 orderings (A: higher-v4/lower-LL, B: lower-v4/higher-LL) would each
+// step down on the other family's advert — both go BACKUP, both masterDown
+// timers expire, both re-elect: permanent no-master oscillation (#4376).
+//
+// Fix: anchor the tie-break to ONE family so both nodes compare the SAME pair of
+// addresses. A v4-bearing instance (dual-stack or v4-only, i.e. it advertises a
+// v4 VIP) decides ONLY off v4 adverts and ignores the peer's v6-family advert;
+// a v6-only instance decides off the link-local v6 advert. The classifier keys
+// off the configured VIP families (immutable per instance), NOT the resolved
+// local address, so a transient address flush cannot flip a dual-stack instance
+// to the v6 ordering and reintroduce the split.
+func (vi *vrrpInstance) resolveEqualPriorityMaster(pkt *VRRPPacket, masterDownTimer, advertTimer *time.Timer) {
+	peerV4 := pkt.SrcIP.To4() != nil
+
+	var localCmp, peerCmp net.IP
+	if vi.hasIPv4VIP() {
+		// v4-bearing: anchor on v4. Ignore the peer's v6-family advert — the
+		// peer's v4 advert drives the symmetric decision on both nodes.
+		if !peerV4 {
+			return
+		}
+		localCmp, peerCmp = vi.getLocalIP().To4(), pkt.SrcIP.To4()
+	} else {
+		// v6-only: anchor on the link-local v6 address.
+		if peerV4 {
+			return
+		}
+		if lip6 := vi.getLocalIPv6(); lip6 != nil {
+			localCmp = lip6.To16()
+		}
+		peerCmp = pkt.SrcIP.To16()
+	}
+
+	if localCmp == nil {
+		// Unresolved local advert source: we cannot run the tie-break and must
+		// NOT treat that as "we win" (#4376 secondary defect — the old code let
+		// peerHigher stay false and stay MASTER by default). Yield to the
+		// actively advertising equal-priority peer. This does NOT oscillate: a
+		// node that cannot determine its own source address cannot put a valid
+		// advert of this family on the wire (sendPacket errors), so the peer
+		// never receives a same-family advert from it and only one side steps
+		// down. The address re-resolves on the advert-send path and a healthy
+		// node re-elects cleanly.
+		slog.Info("vrrp: equal priority tie-break, local source unresolved — stepping down",
+			"key", vi.key(), "peer_ip", pkt.SrcIP, "priority", vi.getPriority())
+		vi.becomeBackup(masterDownTimer, advertTimer)
+		return
+	}
+
+	if bytes.Compare(peerCmp, localCmp) > 0 {
+		slog.Info("vrrp: equal priority tie-break, peer IP is higher — stepping down",
+			"key", vi.key(), "our_ip", localCmp, "peer_ip", pkt.SrcIP,
+			"priority", vi.getPriority())
+		vi.becomeBackup(masterDownTimer, advertTimer)
+	}
+	// Peer lower/equal: stay Master.
+}
+
+// hasIPv4VIP reports whether this instance advertises at least one IPv4 virtual
+// address (dual-stack or IPv4-only). It anchors the equal-priority MASTER-MASTER
+// tie-break to the v4 family so both nodes decide off the same ordering (#4376).
+// cfg.VirtualAddresses is immutable per instance (VIP changes rebuild the
+// instance), so no lock is needed — same rationale as vipAddrSet.
+func (vi *vrrpInstance) hasIPv4VIP() bool {
+	for _, vip := range vi.cfg.VirtualAddresses {
+		addr := vip
+		if idx := strings.Index(addr, "/"); idx >= 0 {
+			addr = addr[:idx]
+		}
+		if ip := net.ParseIP(addr); ip != nil && ip.To4() != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // becomeMaster transitions to Master state: add VIPs, send advert, emit event,

--- a/pkg/vrrp/vrrp_test.go
+++ b/pkg/vrrp/vrrp_test.go
@@ -1102,9 +1102,10 @@ func TestHandleMasterRx_LowerPriority_StaysMaster(t *testing.T) {
 func TestHandleMasterRx_EqualPriority_HigherPeerIP_StepsDown(t *testing.T) {
 	eventCh := make(chan VRRPEvent, 16)
 	vi := newInstance(Instance{
-		Interface: "eth0",
-		GroupID:   101,
-		Priority:  200,
+		Interface:        "eth0",
+		GroupID:          101,
+		Priority:         200,
+		VirtualAddresses: []string{"10.0.0.100/24"}, // v4-bearing
 	}, &net.Interface{Name: "eth0"}, eventCh, nil)
 	vi.setLocalIP(net.IPv4(10, 0, 0, 1)) // lower IP
 	vi.setState(StateMaster)
@@ -1128,9 +1129,10 @@ func TestHandleMasterRx_EqualPriority_HigherPeerIP_StepsDown(t *testing.T) {
 func TestHandleMasterRx_EqualPriority_LowerPeerIP_StaysMaster(t *testing.T) {
 	eventCh := make(chan VRRPEvent, 16)
 	vi := newInstance(Instance{
-		Interface: "eth0",
-		GroupID:   101,
-		Priority:  200,
+		Interface:        "eth0",
+		GroupID:          101,
+		Priority:         200,
+		VirtualAddresses: []string{"10.0.0.100/24"}, // v4-bearing
 	}, &net.Interface{Name: "eth0"}, eventCh, nil)
 	vi.setLocalIP(net.IPv4(10, 0, 0, 2)) // higher IP
 	vi.setState(StateMaster)
@@ -1253,6 +1255,158 @@ func TestHandleMasterRx_EqualPriority_LowerPeerIPv6_StaysMaster(t *testing.T) {
 
 	if vi.getState() != StateMaster {
 		t.Errorf("state = %s, want MASTER (equal priority, we have higher IPv6)", vi.getState())
+	}
+}
+
+// TestHandleMasterRx_DualStack_DisagreeingOrderings_ConvergeOneMaster proves the
+// #4376 fix: two equal-priority dual-stack nodes whose v4 and v6 source orderings
+// DISAGREE must converge to exactly ONE master. Node A has the higher v4 but the
+// lower link-local; node B has the lower v4 but the higher link-local. Each node
+// emits BOTH a v4 and a v6 advert. With the family-split tie-break (pre-fix) A
+// steps down on B's higher-v6 advert while B steps down on A's higher-v4 advert —
+// both go BACKUP and oscillate. The family-consistent tie-break anchors on v4, so
+// the lower-v4 node (B) backs down and the higher-v4 node (A) stays master.
+func TestHandleMasterRx_DualStack_DisagreeingOrderings_ConvergeOneMaster(t *testing.T) {
+	vips := []string{"10.0.0.100/24", "2001:db8::100/64"} // dual-stack
+
+	newMaster := func(v4, v6 net.IP) *vrrpInstance {
+		eventCh := make(chan VRRPEvent, 16)
+		vi := newInstance(Instance{
+			Interface:        "eth0",
+			GroupID:          101,
+			Priority:         200,
+			VirtualAddresses: vips,
+		}, &net.Interface{Name: "eth0"}, eventCh, nil)
+		vi.setLocalIP(v4)
+		vi.setLocalIPv6(v6)
+		vi.setState(StateMaster)
+		return vi
+	}
+
+	// Node A: higher v4 (.2), lower link-local (fe80::1).
+	nodeA := newMaster(net.IPv4(10, 0, 0, 2), net.ParseIP("fe80::1"))
+	// Node B: lower v4 (.1), higher link-local (fe80::2).
+	nodeB := newMaster(net.IPv4(10, 0, 0, 1), net.ParseIP("fe80::2"))
+
+	// Adverts each node emits, one per family from its own source addresses.
+	aV4 := &VRRPPacket{Priority: 200, SrcIP: net.IPv4(10, 0, 0, 2)}
+	aV6 := &VRRPPacket{Priority: 200, SrcIP: net.ParseIP("fe80::1")}
+	bV4 := &VRRPPacket{Priority: 200, SrcIP: net.IPv4(10, 0, 0, 1)}
+	bV6 := &VRRPPacket{Priority: 200, SrcIP: net.ParseIP("fe80::2")}
+
+	newTimers := func() (*time.Timer, *time.Timer) {
+		return time.NewTimer(time.Hour), time.NewTimer(time.Hour)
+	}
+
+	// Feed A the peer's v6 advert FIRST (the order that triggered the old bug),
+	// then the v4 advert. Only feed while still MASTER (production invariant:
+	// handleMasterRx runs in MASTER state only).
+	amd, aad := newTimers()
+	defer amd.Stop()
+	defer aad.Stop()
+	nodeA.handleMasterRx(bV6, amd, aad)
+	if nodeA.getState() == StateMaster {
+		nodeA.handleMasterRx(bV4, amd, aad)
+	}
+
+	// Feed B the peer's v4 advert first, then v6.
+	bmd, bad := newTimers()
+	defer bmd.Stop()
+	defer bad.Stop()
+	nodeB.handleMasterRx(aV4, bmd, bad)
+	if nodeB.getState() == StateMaster {
+		nodeB.handleMasterRx(aV6, bmd, bad)
+	}
+
+	if nodeA.getState() != StateMaster {
+		t.Errorf("node A (higher v4) state = %s, want MASTER", nodeA.getState())
+	}
+	if nodeB.getState() != StateBackup {
+		t.Errorf("node B (lower v4) state = %s, want BACKUP", nodeB.getState())
+	}
+}
+
+// TestHandleMasterRx_DualStack_IgnoresV6Advert proves a dual-stack master does
+// NOT step down on a higher-v6 advert — the v6 family is not the tie-break anchor
+// (#4376). Pre-fix this stepped down (family-split), the root of the oscillation.
+func TestHandleMasterRx_DualStack_IgnoresV6Advert(t *testing.T) {
+	eventCh := make(chan VRRPEvent, 16)
+	vi := newInstance(Instance{
+		Interface:        "eth0",
+		GroupID:          101,
+		Priority:         200,
+		VirtualAddresses: []string{"10.0.0.100/24", "2001:db8::100/64"}, // dual-stack
+	}, &net.Interface{Name: "eth0"}, eventCh, nil)
+	vi.setLocalIP(net.IPv4(10, 0, 0, 2))    // higher v4 → we win the v4 anchor
+	vi.setLocalIPv6(net.ParseIP("fe80::1")) // lower link-local
+	vi.setState(StateMaster)
+
+	md := time.NewTimer(time.Hour)
+	defer md.Stop()
+	ad := time.NewTimer(time.Hour)
+	defer ad.Stop()
+
+	// Higher-v6 peer advert must be ignored for the tie-break.
+	pkt := &VRRPPacket{Priority: 200, SrcIP: net.ParseIP("fe80::2")}
+	vi.handleMasterRx(pkt, md, ad)
+
+	if vi.getState() != StateMaster {
+		t.Errorf("state = %s, want MASTER (dual-stack must ignore v6 advert for tie-break)", vi.getState())
+	}
+}
+
+// TestHandleMasterRx_V6Only_TieBreaksOnLinkLocal proves a v6-only instance (no v4
+// VIP) still resolves the equal-priority tie-break on the link-local v6 address
+// (#4376 keeps the v6-only path intact).
+func TestHandleMasterRx_V6Only_TieBreaksOnLinkLocal(t *testing.T) {
+	eventCh := make(chan VRRPEvent, 16)
+	vi := newInstance(Instance{
+		Interface:        "eth0",
+		GroupID:          101,
+		Priority:         200,
+		VirtualAddresses: []string{"2001:db8::100/64"}, // v6-only
+	}, &net.Interface{Name: "eth0"}, eventCh, nil)
+	vi.setLocalIPv6(net.ParseIP("fe80::1")) // lower link-local
+	vi.setState(StateMaster)
+
+	md := time.NewTimer(time.Hour)
+	defer md.Stop()
+	ad := time.NewTimer(time.Hour)
+	defer ad.Stop()
+
+	pkt := &VRRPPacket{Priority: 200, SrcIP: net.ParseIP("fe80::2")} // higher
+	vi.handleMasterRx(pkt, md, ad)
+
+	if vi.getState() != StateBackup {
+		t.Errorf("state = %s, want BACKUP (v6-only, peer link-local higher)", vi.getState())
+	}
+}
+
+// TestHandleMasterRx_NilLocal_DoesNotStayMaster proves the #4376 secondary fix: a
+// v4-bearing master whose local source address is unresolved (nil) must NOT treat
+// that as "we win". It yields to the actively advertising equal-priority peer
+// instead of holding the VIP forever.
+func TestHandleMasterRx_NilLocal_DoesNotStayMaster(t *testing.T) {
+	eventCh := make(chan VRRPEvent, 16)
+	vi := newInstance(Instance{
+		Interface:        "eth0",
+		GroupID:          101,
+		Priority:         200,
+		VirtualAddresses: []string{"10.0.0.100/24"}, // v4-bearing
+	}, &net.Interface{Name: "eth0"}, eventCh, nil)
+	// Deliberately do NOT setLocalIP — local source unresolved.
+	vi.setState(StateMaster)
+
+	md := time.NewTimer(time.Hour)
+	defer md.Stop()
+	ad := time.NewTimer(time.Hour)
+	defer ad.Stop()
+
+	pkt := &VRRPPacket{Priority: 200, SrcIP: net.IPv4(10, 0, 0, 2)}
+	vi.handleMasterRx(pkt, md, ad)
+
+	if vi.getState() != StateBackup {
+		t.Errorf("state = %s, want BACKUP (nil local must not default to stay-master)", vi.getState())
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the dual-stack VRRP equal-priority tie-break split (#4376, opus-171 H-2, HIGH).

`handleMasterRx`'s equal-priority (RFC 5798 §6.4.3) tie-break selected the local
compare address from the **arriving advert's family**: a v4 advert compared the
peer source against `getLocalIP()` (lowest primary v4), a v6 advert compared
against `getLocalIPv6()` (link-local). But a single instance is genuinely
dual-stack — `CollectRethInstances` puts all of a unit's v4+v6 addresses on ONE
instance, and `sendAdvert` emits BOTH a v4 advert (from `getLocalIP`) and a v6
advert (from `getLocalIPv6`) from two unrelated sources.

Two equal-priority nodes with **disagreeing** v4-vs-v6 orderings (A:
higher-v4 / lower link-local, B: lower-v4 / higher link-local) therefore each
stepped down on the *other* family's advert: A on B's higher-v6, B on A's
higher-v4 → both BACKUP → both `masterDown` timers expire → both MASTER →
**permanent no-master oscillation / RG outage**. Equal priority is reachable —
a simultaneous cold boot leaves both at priority 100; a control/heartbeat-only
partition leaves both at 200.

## Fix

`resolveEqualPriorityMaster` replaces the inline branch and **anchors the
tie-break to ONE address family** so both nodes compare the same pair of
addresses. `hasIPv4VIP()` classifies the instance from its **configured VIP
families** (immutable per instance — a transient address flush cannot flip the
anchor):

- **v4-bearing** (dual-stack or v4-only): resolve on **v4 adverts only** via
  `getLocalIP()`; **ignore** v6-family adverts (the peer's v4 advert drives the
  symmetric decision on both sides).
- **v6-only** (no v4 VIP): resolve on the **link-local v6** advert.

**Secondary defect (same fix):** when the anchored family's local source is
`nil` (unresolved — e.g. the #2528 RETH-MAC-flush window), the old code left
`peerHigher` false and **stayed MASTER by default** ("treat unresolved as
we-win"). It now **yields** (`becomeBackup`) to the actively advertising
equal-priority peer. This does not oscillate: a node that cannot resolve its own
source cannot put a valid same-family advert on the wire (`sendPacket` errors),
so the peer never receives an advert from it and only one side steps down.

## Tests

Four new `pkg/vrrp` unit tests; the three fix-specific ones are **RED on a
revert** to the family-split code (verified locally):

- `TestHandleMasterRx_DualStack_DisagreeingOrderings_ConvergeOneMaster` — both nodes converge to exactly one master.
- `TestHandleMasterRx_DualStack_IgnoresV6Advert` — dual-stack master ignores a higher-v6 advert.
- `TestHandleMasterRx_V6Only_TieBreaksOnLinkLocal` — v6-only path preserved.
- `TestHandleMasterRx_NilLocal_DoesNotStayMaster` — nil local yields instead of staying master.

`go test ./pkg/vrrp/...` green; `go build ./...`, gofmt, vet clean. Docs:
new "Equal-priority tie-break — dual-stack family-consistency (#4376)" section
in `pkg/vrrp/README.md`.

## Validation note

HA VRRP state-machine change — **must pass `make test-failover` before merge**.
The specific dual-stack-equal-priority scenario is exercised by the unit tests;
a standard failover run may not hit it.

Closes #4376

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi