### PR TITLE
cluster: confirm pending commit-confirmed on RG0 demotion (#4378)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-07-06 — #4378: confirm pending commit-confirmed on RG0 demotion
+
+- **Timestamp**: 2026-07-06
+- **Action**: A node running an unconfirmed `commit confirmed` that is DEMOTED
+  from RG0 primary (StateSecondary/StateSecondaryHold) before the operator
+  confirms left its armed rollback timer running. `PromoteRollback` has no
+  cluster-read-only guard, so the timer still fired on the now-standby node and
+  reverted its store + dataplane to the pre-confirm tree while the new primary
+  kept the committed config → config divergence surfacing at the next failover.
+  Fix: on RG0 demotion, CONFIRM the pending window (cancel the timer + bump
+  confirmGen) via a new `store.ConfirmPendingOnDemotion()` called from the
+  demotion branch. CONFIRM (not roll back) is correct because the committed
+  config was already pushed to the peer via config-sync at commit-confirmed time
+  (`commitConfirmedAndApply` → `applyAndSyncCommitted` → `pushCommittedConfigToPeer`),
+  so the peer/new-primary already runs it; confirming keeps both nodes
+  converged. Extracted the inline RG0 ownership switch into a testable
+  `applyRG0OwnershipTransition(cluster.NodeState)` method. RED-on-revert tests
+  added at both layers (configstore + daemon): dropping the confirm leaves the
+  armed timer to revert the demoted node to the pre-confirm tree. Go-only, no
+  cargo. HA demotion-transition change — parent runs `make test-failover`
+  before merge.
+- **File(s)**: pkg/configstore/store_commit.go,
+  pkg/daemon/daemon_ha.go,
+  pkg/configstore/commit_confirm_demote_4378_test.go,
+  pkg/daemon/commit_confirm_demote_4378_test.go,
+  docs/ha-cluster-test-plan.md, _Log.md
+
 ## 2026-07-06 — #4228 Gap 2: resolve CoS transmit-rate / shaping-rate percent
 
 - **Timestamp**: 2026-07-06

--- a/docs/ha-cluster-test-plan.md
+++ b/docs/ha-cluster-test-plan.md
@@ -682,6 +682,63 @@ printf 'show configuration | display set\nexit\n' | incus exec xpf-fw1 -- cli
   RED-on-revert (the non-fatal case drops to zero peer pushes if the fix is
   reverted).
 
+### TC-5d: Commit-Confirmed Straddling a Failover Confirms on the Demoted Node (#4378)
+
+**Objective:** Verify that when a node running an unconfirmed `commit confirmed`
+is DEMOTED from RG0 primary (weight-based failover, planned failover, or
+sync-hold) BEFORE the operator confirms, the pending rollback timer does NOT
+fire on the now-standby node and revert its config — both nodes stay converged
+on the committed config.
+
+Background: distinct from the TC-5b *timeout* case. Here the window never times
+out on the original primary — it is demoted first. At `commit confirmed` time
+the committed config was already pushed to the peer via config-sync
+(`commitConfirmedAndApply` → `applyAndSyncCommitted` → `pushCommittedConfigToPeer`),
+so the peer — now RG0 primary — is already running it. Before #4378 the RG0
+demotion branch (`applyRG0OwnershipTransition`, `StateSecondary`/
+`StateSecondaryHold`) called ONLY `SetClusterReadOnly(true)` and left the armed
+rollback timer running; `PromoteRollback` has no read-only guard, so the timer
+still fired on the demoted standby and reverted its store + dataplane to the
+pre-confirm tree while the new primary kept the commit → config divergence,
+surfacing as a mismatch at the NEXT failover. The fix confirms the pending
+window on demotion (`store.ConfirmPendingOnDemotion`, which cancels the timer
+and bumps `confirmGen` so an already-fired-but-blocked callback no-ops in
+`PromoteRollback`). CONFIRM — not roll back — is correct precisely because the
+peer already holds the committed config; rolling back only the standby is what
+creates the divergence.
+
+```bash
+# 1. On fw0 (RG0 primary), commit-confirmed a distinctive change WITHOUT
+#    confirming (long timeout so the window is still open at demotion):
+printf 'configure\nset security policies from-zone lan to-zone wan policy test-demote match source-address any destination-address any application any then permit\ncommit confirmed 5\nexit\nexit\n' | incus exec xpf-fw0 -- cli
+
+# 2. Verify the UNCONFIRMED policy replicated to fw1:
+printf 'show configuration security policies from-zone lan to-zone wan | display set\nexit\n' | incus exec xpf-fw1 -- cli   # test-demote present
+
+# 3. Fail RG0 over to fw1 (demotes fw0 while the window is still open):
+printf 'request chassis cluster failover redundancy-group 0 node 1\nexit\n' | incus exec xpf-fw0 -- cli
+
+# 4. Wait past the ORIGINAL confirm window (well over 5 minutes is not needed —
+#    the timer is cancelled on demotion; give it a slack minute) and verify
+#    BOTH nodes still carry test-demote (no rollback fired on demoted fw0):
+sleep 90
+printf 'show configuration security policies from-zone lan to-zone wan | display set\nexit\n' | incus exec xpf-fw0 -- cli   # test-demote STILL present
+printf 'show configuration security policies from-zone lan to-zone wan | display set\nexit\n' | incus exec xpf-fw1 -- cli   # test-demote present
+```
+
+**Pass criteria:**
+- After the demotion, `test-demote` is present on BOTH the demoted node and the
+  new primary — the standby did not roll back.
+- fw0's journal shows `cluster: confirmed pending commit-confirmed on RG0
+  demotion` and NO `commit confirmed timed out` entry.
+- A subsequent failover back serves the committed config, not the pre-confirm
+  tree.
+- Unit tests pin the behavior with RED-on-revert:
+  `pkg/configstore/commit_confirm_demote_4378_test.go` and
+  `pkg/daemon/commit_confirm_demote_4378_test.go` (drop
+  `ConfirmPendingOnDemotion` from the demotion branch and the armed timer
+  reverts the demoted node to the pre-confirm tree).
+
 ### TC-6: Session Synchronization
 
 **Objective:** Verify active sessions are synced to secondary for hitless failover.

--- a/pkg/configstore/commit_confirm_demote_4378_test.go
+++ b/pkg/configstore/commit_confirm_demote_4378_test.go
@@ -1,0 +1,100 @@
+package configstore
+
+import "testing"
+
+// #4378: when a node running a `commit confirmed` window is DEMOTED from RG0
+// primary (StateSecondary/StateSecondaryHold) before the operator confirms,
+// the daemon calls ConfirmPendingOnDemotion. That MUST confirm the pending
+// window — cancel the armed rollback timer and bump the confirm generation —
+// so the timer does NOT later revert the demoted (now standby) node to its
+// pre-confirm tree while the new primary keeps the committed config. Rolling
+// back the standby while the primary keeps the commit is config divergence
+// (the #4378 bug, surfacing at the next failover).
+//
+// CONFIRM (keep the commit), not roll back, is correct: the committing node
+// pushed the committed config to the peer via config-sync at commit-confirmed
+// time, so the peer — now primary — already runs it. Confirming keeps both
+// nodes converged.
+//
+// RED-on-revert: without ConfirmPendingOnDemotion (or if it fails to clear the
+// timer), the arm-time timer callback still matches confirmGen and reverts
+// active to the baseline, so the host-name assertion fails.
+func TestConfirmPendingOnDemotionConfirmsWindow_4378(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Baseline confirmed commit — this is the pre-confirm rollback target the
+	// pending timer would otherwise revert to.
+	if err := s.SetFromInput("system host-name Base"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	// commit confirmed: arms the rollback timer, target = Base.
+	if err := s.SetFromInput("system host-name Committed"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.CommitConfirmed(1); err != nil {
+		t.Fatalf("CommitConfirmed: %v", err)
+	}
+	if !s.IsConfirmPending() {
+		t.Fatal("should have a pending confirm after CommitConfirmed")
+	}
+	// The confirm timer's real closure captures this generation at arm time.
+	armGen := s.ConfirmGenForTesting()
+
+	// The node is demoted from RG0 primary mid-window.
+	if !s.ConfirmPendingOnDemotion() {
+		t.Fatal("ConfirmPendingOnDemotion must report it confirmed a pending window")
+	}
+
+	// The demotion must have CONFIRMED the pending window.
+	if s.IsConfirmPending() {
+		t.Error("demotion must clear the pending commit-confirmed timer")
+	}
+	if got := s.ActiveConfig().System.HostName; got != "Committed" {
+		t.Fatalf("active host-name after demotion = %q, want Committed", got)
+	}
+
+	// Simulate the armed timer firing with the arm-time generation (exactly
+	// what time.AfterFunc's closure does; also models the Stop()-lost race
+	// where the callback already started). The confirmGen bump must make it a
+	// no-op — the committed config C must SURVIVE on the demoted standby.
+	s.InvokeRollbackTimerForTesting(armGen)
+
+	if got := s.ActiveConfig().System.HostName; got != "Committed" {
+		t.Fatalf("confirm-timer fire reverted the committed config on the demoted standby: "+
+			"active host-name = %q, want Committed (the standby rolled back while the "+
+			"primary keeps the commit — #4378 config divergence)", got)
+	}
+}
+
+// #4378: a node WITHOUT a pending commit-confirmed being demoted is a no-op —
+// ConfirmPendingOnDemotion returns false and errors nothing (demotion fires on
+// every clean weight-based failover; the common case is no pending window).
+func TestConfirmPendingOnDemotionNoPendingIsNoop_4378(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetFromInput("system host-name Base"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.IsConfirmPending() {
+		t.Fatal("no commit confirmed was issued — nothing should be pending")
+	}
+	if s.ConfirmPendingOnDemotion() {
+		t.Error("ConfirmPendingOnDemotion with no pending window must return false (no-op)")
+	}
+	if got := s.ActiveConfig().System.HostName; got != "Base" {
+		t.Fatalf("no-op demotion must not touch active config: host-name = %q, want Base", got)
+	}
+}

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -316,6 +316,36 @@ func (s *Store) ConfirmCommit() error {
 	return nil
 }
 
+// ConfirmPendingOnDemotion confirms any pending `commit confirmed` window
+// because this node is being DEMOTED from RG0 primary (#4378). It is the
+// demotion-event analogue of #3861's confirm-on-plain-commit / confirm-on-sync:
+// it cancels the armed rollback timer and bumps confirmGen (via
+// clearPendingConfirmLocked) so an already-fired-but-blocked callback no-ops in
+// PromoteRollback, and returns true iff a pending window was cleared. Unlike
+// ConfirmCommit it does NOT return an error when nothing is pending — demotion
+// fires on every clean weight-based failover and the common case is no pending
+// commit-confirmed.
+//
+// CONFIRM (keep the committed config), not roll back: the committing node
+// pushed the committed config to the peer via config-sync at commit-confirmed
+// time (commitConfirmedAndApply -> applyAndSyncCommitted ->
+// pushCommittedConfigToPeer). The peer — now RG0 primary — is therefore
+// already running that committed config. Rolling THIS node's store back to the
+// pre-confirm tree while the primary keeps the commit would diverge the two
+// nodes (the #4378 bug, surfacing at the next failover). Confirming keeps both
+// nodes converged on the committed config.
+func (s *Store) ConfirmPendingOnDemotion() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.clearPendingConfirmLocked() {
+		return false
+	}
+
+	slog.Info("commit confirmed: confirmed on RG0 demotion (peer holds the synced config)")
+	return true
+}
+
 // IsConfirmPending returns true if a commit confirmed is awaiting confirmation.
 func (s *Store) IsConfirmPending() bool {
 	s.mu.RLock()

--- a/pkg/daemon/commit_confirm_demote_4378_test.go
+++ b/pkg/daemon/commit_confirm_demote_4378_test.go
@@ -1,0 +1,128 @@
+// #4378: commit-confirmed rollback timer must not fire on a node demoted from
+// RG0 primary. The RG0 ownership transition (applyRG0OwnershipTransition, the
+// StateSecondary/StateSecondaryHold branch) must confirm any in-flight
+// `commit confirmed` window before going read-only, so the armed rollback
+// timer does NOT revert the demoted (now standby) node to its pre-confirm
+// tree while the new primary keeps the committed config — config divergence
+// surfacing at the next failover.
+//
+// CONFIRM (keep the commit), not roll back, is correct: the committing node
+// pushed the committed config to the peer via config-sync at commit-confirmed
+// time, so the peer — now primary — already runs it; confirming keeps both
+// nodes converged.
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// newDemoteTestStore builds a store with a CONFIRMED baseline "Base" and an
+// armed (pending) `commit confirmed` promoting active to "Committed". The
+// arm-time confirm generation is returned so a test can drive the real
+// rollback-timer dispatch. Without a registered rollbackExecutor, the store's
+// timer dispatch falls back to performAutoRollback (store-state only, no
+// dataplane) — reverting active to "Base" — which is exactly the standby
+// divergence #4378 must prevent.
+func newDemoteTestStore(t *testing.T) (*configstore.Store, uint64) {
+	t.Helper()
+	s, err := configstore.New(filepath.Join(t.TempDir(), "config"))
+	if err != nil {
+		t.Fatalf("configstore.New: %v", err)
+	}
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := s.SetFromInput("system host-name Base"); err != nil {
+		t.Fatalf("set host-name Base: %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("commit Base: %v", err)
+	}
+	if err := s.SetFromInput("system host-name Committed"); err != nil {
+		t.Fatalf("set host-name Committed: %v", err)
+	}
+	if _, err := s.CommitConfirmed(1); err != nil {
+		t.Fatalf("CommitConfirmed: %v", err)
+	}
+	if !s.IsConfirmPending() {
+		t.Fatal("should have a pending confirm after CommitConfirmed")
+	}
+	return s, s.ConfirmGenForTesting()
+}
+
+// RG0 demotion during a commit-confirmed window confirms the window: the timer
+// is cleared, the store goes read-only, and a subsequent arm-time timer fire
+// is a no-op — the committed config survives on the demoted standby.
+//
+// RED-on-revert: drop the ConfirmPendingOnDemotion call from the StateSecondary
+// branch and the window stays armed, so InvokeRollbackTimerForTesting reverts
+// active to "Base" — the standby diverges from the primary that keeps
+// "Committed".
+func TestRG0DemotionConfirmsPendingCommitConfirmed_4378(t *testing.T) {
+	s, armGen := newDemoteTestStore(t)
+	d := &Daemon{store: s}
+
+	// Node is demoted from RG0 primary (StateSecondary) mid-window.
+	d.applyRG0OwnershipTransition(cluster.StateSecondary)
+
+	if s.IsConfirmPending() {
+		t.Error("RG0 demotion must clear the pending commit-confirmed timer")
+	}
+	if !s.ClusterReadOnly() {
+		t.Error("RG0 demotion must leave the store cluster-read-only")
+	}
+	if got := s.ActiveConfig().System.HostName; got != "Committed" {
+		t.Fatalf("active host-name after demotion = %q, want Committed", got)
+	}
+
+	// The armed timer fires with its arm-time generation. The confirmGen bump
+	// from the demotion confirm must make it a no-op.
+	s.InvokeRollbackTimerForTesting(armGen)
+
+	if got := s.ActiveConfig().System.HostName; got != "Committed" {
+		t.Fatalf("commit-confirmed timer fired on the demoted standby and reverted config: "+
+			"active host-name = %q, want Committed (standby rolled back while the primary "+
+			"keeps the commit — #4378 config divergence)", got)
+	}
+}
+
+// StateSecondaryHold is the sync-hold flavor of demotion and must confirm the
+// pending window identically.
+func TestRG0DemotionSecondaryHoldConfirms_4378(t *testing.T) {
+	s, armGen := newDemoteTestStore(t)
+	d := &Daemon{store: s}
+
+	d.applyRG0OwnershipTransition(cluster.StateSecondaryHold)
+
+	if s.IsConfirmPending() {
+		t.Error("RG0 demotion (SecondaryHold) must clear the pending commit-confirmed timer")
+	}
+	s.InvokeRollbackTimerForTesting(armGen)
+	if got := s.ActiveConfig().System.HostName; got != "Committed" {
+		t.Fatalf("SecondaryHold demotion did not confirm: active host-name = %q, want Committed", got)
+	}
+}
+
+// Promotion to RG0 primary must NOT touch a pending commit-confirmed window
+// (the promoting node is the one that OWNS the in-flight window); it only
+// clears read-only. This guards against a future over-broad "confirm on any
+// RG0 transition" regression.
+func TestRG0PromotionLeavesPendingWindow_4378(t *testing.T) {
+	s, _ := newDemoteTestStore(t)
+	// Pretend the node was read-only (secondary) before promotion.
+	s.SetClusterReadOnly(true)
+	d := &Daemon{store: s}
+
+	d.applyRG0OwnershipTransition(cluster.StatePrimary)
+
+	if !s.IsConfirmPending() {
+		t.Error("RG0 promotion must not clear a pending commit-confirmed window")
+	}
+	if s.ClusterReadOnly() {
+		t.Error("RG0 promotion must clear cluster-read-only")
+	}
+}

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -326,32 +326,54 @@ func (d *Daemon) watchClusterEvents(ctx context.Context) {
 
 			// RG0-specific: config ownership and IPsec SA re-initiation.
 			if ev.GroupID == 0 {
-				switch ev.NewState {
-				case cluster.StatePrimary:
-					slog.Info("cluster: became primary for RG0, enabling config writes")
-					d.store.SetClusterReadOnly(false)
-
-					// On failover to primary: re-initiate synced IPsec SAs.
-					if cc := d.clusterConfig(); cc != nil && cc.IPsecSASync && d.ipsec != nil && d.sessionSync != nil {
-						go d.reinitiateIPsecSAs()
-					}
-
-					// #2239: on failover to primary, nudge the lease-sync push
-					// loop so this node begins replicating its (now owned)
-					// lease set. The actual Kea pre-seed + post-start lease-add
-					// seed are tied to the per-RG Kea start in
-					// applyRethServicesForRG (where Kea is restarted on the
-					// VRRP MASTER transition).
-					if cc := d.clusterConfig(); cc != nil && cc.DHCPLeaseSync && d.dhcpServer != nil && d.sessionSync != nil {
-						d.nudgeDHCPLeaseSync()
-					}
-
-				case cluster.StateSecondary, cluster.StateSecondaryHold:
-					slog.Info("cluster: became secondary for RG0, disabling config writes")
-					d.store.SetClusterReadOnly(true)
-				}
+				d.applyRG0OwnershipTransition(ev.NewState)
 			}
 		}
+	}
+}
+
+// applyRG0OwnershipTransition reacts to a RG0 ownership change: it toggles the
+// store's cluster read-only gate (only RG0 primary may write config) and, on
+// promotion, re-initiates synced IPsec SAs and nudges DHCP lease-sync.
+//
+// #4378: on DEMOTION it also confirms any in-flight `commit confirmed` window
+// BEFORE going read-only. The committing node had already pushed the committed
+// config to the peer (now RG0 primary) via config-sync
+// (commitConfirmedAndApply -> applyAndSyncCommitted -> pushCommittedConfigToPeer),
+// so the primary is running that config. Confirming keeps both nodes on it.
+// Without this, the armed rollback timer would still fire on the demoted
+// standby (PromoteRollback carries no read-only guard), reverting its
+// store+dataplane to the pre-confirm tree while the primary keeps the commit —
+// config divergence that surfaces at the next failover.
+func (d *Daemon) applyRG0OwnershipTransition(newState cluster.NodeState) {
+	switch newState {
+	case cluster.StatePrimary:
+		slog.Info("cluster: became primary for RG0, enabling config writes")
+		d.store.SetClusterReadOnly(false)
+
+		// On failover to primary: re-initiate synced IPsec SAs.
+		if cc := d.clusterConfig(); cc != nil && cc.IPsecSASync && d.ipsec != nil && d.sessionSync != nil {
+			go d.reinitiateIPsecSAs()
+		}
+
+		// #2239: on failover to primary, nudge the lease-sync push loop so
+		// this node begins replicating its (now owned) lease set. The actual
+		// Kea pre-seed + post-start lease-add seed are tied to the per-RG Kea
+		// start in applyRethServicesForRG (where Kea is restarted on the VRRP
+		// MASTER transition).
+		if cc := d.clusterConfig(); cc != nil && cc.DHCPLeaseSync && d.dhcpServer != nil && d.sessionSync != nil {
+			d.nudgeDHCPLeaseSync()
+		}
+
+	case cluster.StateSecondary, cluster.StateSecondaryHold:
+		slog.Info("cluster: became secondary for RG0, disabling config writes")
+		// #4378: confirm any pending commit-confirmed before going read-only
+		// so its rollback timer does not fire on the demoted standby and
+		// diverge from the peer that holds the synced committed config.
+		if d.store.ConfirmPendingOnDemotion() {
+			slog.Info("cluster: confirmed pending commit-confirmed on RG0 demotion")
+		}
+		d.store.SetClusterReadOnly(true)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #4378 (opus-171 H-4). A node running an unconfirmed `commit confirmed` that is **demoted from RG0 primary** (`StateSecondary`/`StateSecondaryHold`) before the operator confirms left its armed rollback timer running. The RG0 demotion branch called only `SetClusterReadOnly(true)`, and `PromoteRollback` carries no cluster-read-only guard, so the timer still fired on the now-standby node and reverted its store + dataplane to the pre-confirm tree — while the new primary kept the committed config. Result: **config divergence** that surfaces at the next failover.

## Fix

On RG0 demotion, **CONFIRM** the pending commit-confirmed window instead of letting it roll back:

- New `store.ConfirmPendingOnDemotion()` (`pkg/configstore/store_commit.go`) wraps `clearPendingConfirmLocked` — cancels the armed timer, bumps `confirmGen` (so an already-fired-but-blocked callback no-ops in `PromoteRollback`), and returns `false` without an error when nothing is pending (demotion fires on every clean weight-based failover).
- Called from the demotion branch, now extracted into a testable `applyRG0OwnershipTransition(cluster.NodeState)` method (`pkg/daemon/daemon_ha.go`).

### Why CONFIRM, not roll back

At `commit confirmed` time the committed config was already pushed to the peer via config-sync (`commitConfirmedAndApply` → `applyAndSyncCommitted` → `pushCommittedConfigToPeer`), so the peer — now RG0 primary — is already running it. Confirming keeps both nodes converged on the committed config; rolling back **only** the demoted standby is exactly what creates the divergence.

## Validation

- **RED-on-revert at both layers**: `pkg/configstore/commit_confirm_demote_4378_test.go` (store method) and `pkg/daemon/commit_confirm_demote_4378_test.go` (the demotion call site). Neutering the confirm leaves the armed timer to revert the demoted node to the pre-confirm tree (host-name `Committed` → `Base`); the daemon-log RED run shows `commit confirmed timed out, configuration rolled back`. Promotion is asserted **not** to touch a pending window.
- `go build ./...`, `go vet`, `gofmt` clean; `go test ./pkg/configstore/... ./pkg/daemon/...` green. Go-only, no cargo.

## HA note

Demotion-transition change — **`make test-failover` should be run before merge** (parent's responsibility per the task).

Docs: `docs/ha-cluster-test-plan.md` TC-5d (commit-confirmed straddling a failover confirms on the demoted node).

Closes #4378

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi