### PR TITLE
session: back-count per-IP limit-session counts on enable edge (#4377)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -37278,3 +37278,36 @@ top.
   userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs,
   userspace-dp/src/afxdp/README.md, docs/generated-reply-rate-limit.md,
   _Log.md
+
+## 2026-07-06 — #4377: session limit-session per-IP cap enable-transition back-count
+
+- **Timestamp**: 2026-07-06
+- **Action**: Fix the per-IP `limit-session` cap-bypass on the OFF->ON enable
+  edge (opus-171 H-1). The install increment and the sole-sink `remove_entry`
+  decrement share the origin-agnostic counted-class predicate
+  (`!is_reverse && !origin.is_transient_local_seed()`) but keep no per-entry
+  record of whether an entry was actually charged; each is gated only on
+  `session_limit_active` at the moment of the op. `set_session_limit_active`
+  cleared both count maps on ON->OFF but did NOTHING on OFF->ON, so a forward
+  session installed while the gate was OFF (or after a disable cleared the
+  maps) was uncounted, yet its teardown while ON still decremented — an
+  increment-less decrement that drives `count[X]` below the live counted count;
+  `saturating_sub` + evict-at-0 hide the underflow, so `count[X]` can reach 0
+  while sessions are live and X gets a fresh full allotment (cap bypass). Fix:
+  back-count-on-enable — on the OFF->ON edge walk the live slab via
+  `key_to_handle` (matching `iter_with_origin`) and increment the per-IP maps
+  for every counted-class entry, using the SAME predicate as the sinks so #3122
+  peer-SYNCED sessions are back-counted exactly as their teardown will
+  decrement. O(N) once per rare enable, no per-entry memory. Corrected the
+  mod.rs doc that called not-back-counting "benign" (wrong for the decrement
+  side). New RED-on-revert test
+  `session_limit_backcount_on_enable_covers_preexisting_sessions` (install N
+  while INACTIVE + 1 synced import -> enable -> src count == N+1 incl. synced;
+  new install caps; teardown of pre-existing decrements a real increment; count
+  never below live) and updated `session_limit_clear_on_disable` (re-enable
+  back-counts the 3 live sessions -> 3, then 4). Both RED with the back-count
+  disabled. Full cargo serial: session:: subset 149 passed / 0 failed; overall
+  3629 + 54 + 8 + 22 + 1 = 3714 passed / 0 failed, 2 ignored.
+- **File(s)**: userspace-dp/src/session/mod.rs,
+  userspace-dp/src/session/tests.rs, userspace-dp/src/session/README.md,
+  docs/pr/2134-screen-session-limit-enforce/self-review.md, _Log.md

--- a/docs/pr/2134-screen-session-limit-enforce/self-review.md
+++ b/docs/pr/2134-screen-session-limit-enforce/self-review.md
@@ -43,10 +43,13 @@ choke point every create/remove already passes through.
   The new-flow check fires once per new flow, before its session exists,
   via a non-mutating query, and emits the `session-limit-{src,dst}`
   screen-drop event + counter.
-- **OFF-gate + clear-on-disable**: `set_session_limit_active` driven from
-  the applied screen-profile snapshot (startup + runtime reload). OFF =
-  zero maintenance cost. ON→OFF clears the maps so a re-enable can't
-  resume from stale over-counted values (reviewer-B r2 MAJOR).
+- **OFF-gate + clear-on-disable + back-count-on-enable**:
+  `set_session_limit_active` driven from the applied screen-profile
+  snapshot (startup + runtime reload). OFF = zero maintenance cost. ON→OFF
+  clears the maps so a re-enable can't resume from stale over-counted
+  values (reviewer-B r2 MAJOR). OFF→ON (#4377) REBUILDS the maps from the
+  live slab so every pre-existing counted session is charged before its
+  teardown can decrement — see "back-count-on-enable" below.
 
 ## Hot-path shape
 
@@ -105,9 +108,35 @@ drop was rewritten to prove the same property via the port-scan check
 
 - Per-worker scoping (worst-case N×limit dilution when one IP spreads
   across N RX queues) — pre-existing, same under the eBPF per-CPU map.
-- OFF→ON re-enable does not back-count pre-existing live sessions —
-  benign, Junos-approximate (documented in `session/README.md`).
 - Global per-IP (not per-zone-per-IP) — matches Junos per-IP counting.
+
+### back-count-on-enable (#4377)
+
+The original design left OFF→ON re-enable NOT back-counting pre-existing
+live sessions, described as "benign, Junos-approximate". That was WRONG
+for the DECREMENT side and was fixed in #4377. The increment (install)
+and decrement (`remove_entry`, the sole removal sink) use the same
+origin-agnostic presence predicate but keep no per-entry record of
+whether the entry was actually counted — they are gated only on
+`session_limit_active` at the moment of the op. A session installed while
+the gate was OFF (or after a disable cleared the maps) is uncounted, but
+its teardown while ON still decrements. That increment-less decrement
+drives `count[X]` below the live counted-session count; `saturating_sub` +
+evict-at-0 hide the underflow, so `count[X]` can reach 0 while sessions
+are live and X is handed a fresh full allotment — a cap bypass on the
+enable edge (and on any disable→enable toggle). Only a runtime enable on
+an already-forwarding box is exposed, and it self-heals once the
+pre-existing uncounted sessions drain, but the exposure is real.
+
+Fix: `set_session_limit_active` walks the live slab on the OFF→ON edge
+(via `key_to_handle`, matching `iter_with_origin`) and increments the
+per-IP maps for every counted-class entry
+(`!is_reverse && !origin.is_transient_local_seed()`). The predicate is
+identical to the install/decrement sinks, so the back-count includes
+#3122 peer-SYNCED sessions exactly as their teardown will decrement them.
+O(N) once per rare enable, no per-entry memory cost. Regression:
+`session_limit_backcount_on_enable_covers_preexisting_sessions` (+ the
+updated `session_limit_clear_on_disable`).
 
 ## Validation
 

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -845,17 +845,38 @@ per new flow, before its session exists, via a non-mutating
 `session_limit_{src,dst}_count` query, and emits the
 `session-limit-src` / `session-limit-dst` screen-drop event + counter.
 
-**OFF-gate + clear-on-disable.** `set_session_limit_active(active)` is
-driven from the applied screen-profile snapshot (startup +
-runtime-reload, next to `set_timeouts` /
-`ScreenState::update_profiles`). When no zone configures `limit-session`
+**OFF-gate + clear-on-disable + back-count-on-enable (#4377).**
+`set_session_limit_active(active)` is driven from the applied
+screen-profile snapshot (startup + runtime-reload, next to `set_timeouts`
+/ `ScreenState::update_profiles`). When no zone configures `limit-session`
 the gate is OFF and every maintenance op short-circuits, so the ~99% of
 deployments pay nothing. On an ON→OFF runtime transition the gate setter
 **clears both count maps** — otherwise the decrement paths stop firing
 and a later re-enable would resume from stale, over-counted values and
-spuriously block an under-limit IP. After a re-enable the maps start
-empty and re-populate from new installs; pre-existing live sessions are
-not back-counted (benign, Junos-approximate).
+spuriously block an under-limit IP.
+
+On an OFF→ON transition the gate setter **rebuilds both count maps from
+the live slab** (#4377). This is NOT optional / benign: install and
+`remove_entry` share the same presence predicate but keep no per-entry
+record of whether the entry was actually charged — each is gated only on
+`session_limit_active` at the moment of the op. A forward session
+installed while the gate was OFF (or after a disable cleared the maps) is
+uncounted, yet its teardown while ON still fires the sole-sink decrement.
+That increment-less decrement drives `count[X]` BELOW the live
+counted-session count; `saturating_sub` + evict-at-0 hide the underflow,
+so `count[X]` can reach 0 while sessions are live and X is handed a fresh
+full allotment — a **cap bypass** on the enable edge (or any
+disable→enable toggle). The back-count walks `key_to_handle` (the
+authoritative primary index, matching `iter_with_origin`) and increments
+the per-IP maps for every counted-class entry
+(`!is_reverse && !origin.is_transient_local_seed()`), using the SAME
+origin-agnostic predicate as the install/decrement sinks so #3122
+peer-SYNCED sessions are back-counted exactly as their later teardown
+will decrement them. Now every decrement balances an increment and the
+cap enforces on the true live count. O(N) once per rare enable, no
+per-entry memory. Regression:
+`session_limit_backcount_on_enable_covers_preexisting_sessions` and the
+`session_limit_clear_on_disable` re-enable assertions.
 
 **Per-worker scoping — the effective cap is `configured × num_workers`
 (#2186).** Each worker owns its `SessionTable` by value, so the per-IP

--- a/userspace-dp/src/session/mod.rs
+++ b/userspace-dp/src/session/mod.rs
@@ -690,15 +690,53 @@ impl SessionTable {
     /// decrement paths, so without this the maps would freeze at stale,
     /// over-counted values and a later re-enable would resume from wrong
     /// values and spuriously block an under-limit IP. Mirrors the
-    /// `ScreenState::update_profiles` retain discipline. On a re-enable
-    /// the maps start empty and re-populate from new installs;
-    /// pre-existing live sessions are NOT back-counted (benign,
-    /// Junos-approximate — Junos likewise does not retroactively count
-    /// pre-existing flows when a screen option is enabled).
+    /// `ScreenState::update_profiles` retain discipline.
+    ///
+    /// #4377 back-count-on-enable: on the OFF->ON edge the maps are
+    /// REBUILT from the live slab so they reflect EVERY session that will
+    /// later fire the decrement. Not back-counting is NOT benign for the
+    /// decrement side: the sole removal sink (`remove_entry`) decrements
+    /// for any forward non-seed entry whenever the gate is active at
+    /// removal, with no per-entry record of whether the entry was ever
+    /// counted. A forward session installed while the gate was OFF (or
+    /// after a disable cleared the maps) is therefore uncounted, yet its
+    /// teardown while ON still decrements — an increment-less decrement
+    /// that drives `count[X]` BELOW the live counted-session count for X.
+    /// `saturating_sub` + evict-at-0 hide the underflow, so X's count can
+    /// reach 0 while sessions are live and X is handed a fresh full
+    /// allotment (cap bypass). Rebuilding on enable makes every decrement
+    /// balance an increment. The walk uses the same origin-agnostic
+    /// counted-class predicate as the install/decrement sinks
+    /// (`!is_reverse && !origin.is_transient_local_seed()` — #3122:
+    /// peer-SYNCED sessions ARE counted, only reverse + transient-local
+    /// seed are excluded), so back-counting includes imported sessions
+    /// exactly as their later teardown will decrement them. O(N) once per
+    /// rare enable, no per-entry memory cost.
     pub fn set_session_limit_active(&mut self, active: bool) {
         if !active {
             self.session_limit_src_counts.clear();
             self.session_limit_dst_counts.clear();
+        } else if !self.session_limit_active {
+            // #4377: OFF->ON edge — rebuild the count maps from every live
+            // counted-class session so decrements always balance an
+            // increment. Walk via `key_to_handle` (the authoritative
+            // primary index, matching `iter_with_origin`) so an orphan
+            // slab record without a forward-key mapping is skipped.
+            // Disjoint-field borrows (`key_to_handle` / `entries` read,
+            // count maps mutated) — inline the increment rather than call
+            // `session_limit_inc`, which would take `&mut self` whole.
+            for (key, handle) in &self.key_to_handle {
+                if let Some(record) = self.entries.get(*handle as usize) {
+                    if !record.entry.metadata.is_reverse
+                        && !record.entry.origin.is_transient_local_seed()
+                    {
+                        let c = self.session_limit_src_counts.entry(key.src_ip).or_insert(0);
+                        *c = c.saturating_add(1);
+                        let c = self.session_limit_dst_counts.entry(key.dst_ip).or_insert(0);
+                        *c = c.saturating_add(1);
+                    }
+                }
+            }
         }
         self.session_limit_active = active;
     }

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -5289,8 +5289,20 @@ fn session_limit_clear_on_disable() {
     assert_eq!(table.session_limit_src_map_len(), 0, "src map must clear on disable");
     assert_eq!(table.session_limit_dst_map_len(), 0, "dst map must clear on disable");
 
-    // Re-enable: a fresh flow starts the count from 0 (not stale 3).
+    // #4377 back-count-on-enable: the 3 sessions are STILL live, so
+    // re-enabling must REBUILD the maps from them — count == 3, NOT the
+    // old (buggy) "restart from 0". Clear-on-disable + back-count-on-enable
+    // is idempotent: if clear-on-disable were omitted, the re-enable walk
+    // would double-count to 6, so this still guards clear-on-disable.
     table.set_session_limit_active(true);
+    assert_eq!(
+        table.session_limit_src_count(src),
+        3,
+        "re-enable must back-count the 3 live sessions, not restart from 0"
+    );
+
+    // A fresh flow from the same IP adds to the back-counted total — the
+    // cap now sees the true live count instead of a fresh empty allotment.
     let key = SessionKey {
         src_ip: src,
         src_port: 52999,
@@ -5307,8 +5319,152 @@ fn session_limit_clear_on_disable() {
     ));
     assert_eq!(
         table.session_limit_src_count(src),
+        4,
+        "new install must add to the back-counted 3, not to a stale 0"
+    );
+}
+
+/// #4377 FAIL-ON-REVERT: the per-IP session-limit maps must be REBUILT
+/// on the OFF->ON enable edge from the live slab, so a session installed
+/// while the gate was INACTIVE is counted the moment the gate turns on —
+/// its later teardown decrements a real increment instead of driving the
+/// count below the live counted-session count (the #4377 cap bypass).
+///
+/// REVERT SIGNATURE: without the back-count, re-enable restarts the count
+/// at 0; the pre-existing sessions' teardown then saturating_sub's below
+/// 0 (hidden as 0) while sessions are still live, and the IP is handed a
+/// fresh full allotment — a cap bypass. This test drives that exact path
+/// and asserts the corrected counts at every step. It FAILS (the first
+/// count assertion sees 0, not N) if `set_session_limit_active`'s
+/// OFF->ON back-count is reverted.
+#[test]
+fn session_limit_backcount_on_enable_covers_preexisting_sessions() {
+    let mut table = SessionTable::new();
+    // Gate starts OFF (default). Install N forward sessions from one IP
+    // while INACTIVE — none are counted (the OFF-gate skips the increment).
+    let n = 4u32;
+    let src = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 40));
+    let dst = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 40));
+    let now = 1_000_000_000u64;
+    let mut keys: Vec<SessionKey> = Vec::new();
+    for i in 0..n {
+        let key = SessionKey {
+            src_ip: src,
+            dst_ip: dst,
+            src_port: 54000 + i as u16,
+            ..limit_key(40, 40, 0)
+        };
+        assert!(table.install_with_protocol_with_origin(
+            key.clone(),
+            decision(),
+            metadata(),
+            SessionOrigin::ForwardFlow,
+            now,
+            PROTO_TCP,
+            0x10,
+        ));
+        keys.push(key);
+    }
+    // #3122 invariant: also import ONE peer-synced session from the same
+    // src IP (different dst so we can watch src back-count include it).
+    let synced_dst = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 41));
+    let synced_key = SessionKey {
+        src_ip: src,
+        dst_ip: synced_dst,
+        src_port: 54900,
+        ..limit_key(40, 41, 0)
+    };
+    let mut synced_meta = metadata();
+    synced_meta.owner_rg_id = 1;
+    let _ = table.upsert_synced_with_origin(
+        SessionInstall {
+            key: synced_key.clone(),
+            decision: decision(),
+            metadata: synced_meta,
+            origin: SessionOrigin::SyncImport,
+            now_ns: now,
+            protocol: PROTO_TCP,
+            tcp_flags: 0x10,
+        },
+        false,
+    );
+    // Gate OFF: nothing counted yet (the maps are empty).
+    assert_eq!(table.session_limit_src_count(src), 0, "OFF: no count maintained");
+    assert_eq!(table.session_limit_src_map_len(), 0);
+
+    // OFF->ON edge: back-count. src has N local + 1 synced = N+1 live
+    // counted sessions; both dst IPs get their own counted entries. The
+    // #3122 synced session MUST be included (origin-agnostic predicate).
+    table.set_session_limit_active(true);
+    assert_eq!(
+        table.session_limit_src_count(src),
+        n + 1,
+        "OFF->ON must back-count all live counted sessions incl. the #3122 synced import"
+    );
+    assert_eq!(
+        table.session_limit_dst_count(dst),
+        n,
+        "dst back-count must equal the N forward sessions to that dst"
+    );
+    assert_eq!(
+        table.session_limit_dst_count(synced_dst),
         1,
-        "re-enable must start from 0, not the stale pre-disable count"
+        "the #3122 synced session's dst must be back-counted too"
+    );
+
+    // Enforcement is now correct: a new flow from src sees the true live
+    // count (N+1), not a fresh 0 allotment.
+    let over_key = SessionKey {
+        src_ip: src,
+        dst_ip: dst,
+        src_port: 54990,
+        ..limit_key(40, 40, 0)
+    };
+    assert!(table.install_with_protocol_with_origin(
+        over_key,
+        decision(),
+        metadata(),
+        SessionOrigin::ForwardFlow,
+        now + 1_000_000,
+        PROTO_TCP,
+        0x10,
+    ));
+    assert_eq!(
+        table.session_limit_src_count(src),
+        n + 2,
+        "new install adds to the back-counted total"
+    );
+
+    // Teardown of a PRE-EXISTING (installed-while-off) session decrements
+    // from the back-counted total — it never drives the count below the
+    // live counted-session count. Delete all N pre-existing forward
+    // sessions one at a time and watch the count step down correctly.
+    let mut expected = n + 2; // (N back-counted forward) + 1 synced + 1 new install
+    for key in &keys {
+        table.delete(key);
+        expected -= 1;
+        assert_eq!(
+            table.session_limit_src_count(src),
+            expected,
+            "teardown of a pre-existing session must decrement a real increment"
+        );
+    }
+    // After draining the N pre-existing forward sessions, src still has
+    // the 1 synced + 1 new-install = 2 live counted sessions.
+    assert_eq!(table.session_limit_src_count(src), 2);
+
+    // The invariant the whole fix defends: the per-IP count equals the
+    // number of live counted entries for that IP — never below it.
+    let mut live_src = 0u32;
+    table.iter_with_origin(|k, _d, md, origin| {
+        if k.src_ip == src && !md.is_reverse && !origin.is_transient_local_seed() {
+            live_src += 1;
+        }
+    });
+    assert_eq!(
+        table.session_limit_src_count(src),
+        live_src,
+        "count must equal live counted entries — never dropped below (the #4377 bypass)"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes the per-IP `limit-session` cap bypass on the OFF->ON enable transition (opus-171 H-1, #4377).

The install increment (`install.rs` via `session_limit_inc`) and the sole-removal-sink decrement (`remove_entry`, `mod.rs`) share the origin-agnostic counted-class predicate (`!is_reverse && !origin.is_transient_local_seed()`, #3122) but keep **no per-entry record of whether an entry was actually charged** — each is gated only on `session_limit_active` at the moment of the op. `set_session_limit_active` cleared both count maps on ON->OFF but did **nothing** on OFF->ON.

Result: a forward session installed while the gate was OFF (or after a disable cleared the maps) is uncounted, yet its later teardown while ON still fires the decrement — an increment-less decrement that drives `count[X]` **below** the live counted-session count. `saturating_sub` + evict-at-0 hide the underflow, so `count[X]` can reach 0 while sessions are live and X is handed a fresh full allotment (cap bypass). Only a runtime enable on an already-forwarding box (or a disable->enable toggle) is exposed, and it self-heals once the pre-existing uncounted sessions drain, but the exposure is real.

## Fix

Back-count-on-enable. On the OFF->ON edge, `set_session_limit_active` walks the live slab via `key_to_handle` (the authoritative primary index, matching `iter_with_origin`) and increments the per-IP src/dst count maps for every counted-class entry, using the **same predicate** as the install/decrement sinks. This preserves the #3122 origin-agnostic invariant — peer-SYNCED sessions are back-counted exactly as their teardown will decrement them — so every decrement now balances an increment and the cap enforces on the true live count. O(N) once per rare enable, no per-entry memory cost.

The `mod.rs` doc that called not-back-counting "benign, Junos-approximate" is corrected (wrong for the decrement side). `session/README.md` and the #2134 self-review are updated.

## Tests

- New RED-on-revert `session_limit_backcount_on_enable_covers_preexisting_sessions`: install N forward sessions from one IP while INACTIVE + one #3122 peer-synced import -> enable -> src count == N+1 (synced included) -> new install caps correctly -> teardown of each pre-existing session steps the count down without ever dropping below the live counted-session count.
- Updated `session_limit_clear_on_disable`: re-enable now back-counts the 3 live sessions (== 3, not the old buggy 0), fresh install nets 4.
- Both go RED with the back-count disabled.
- Full cargo serial suite green: `session::` subset 149/0; overall 3714 passed / 0 failed, 2 ignored (incl. HA session-sync / #3122 unit tests).

Closes #4377

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi