### PR TITLE
userspace-dp: gate PBR routing-instance override on the term action (#4392)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-06 — #4392 PBR `then routing-instance X; reject/discard` FORWARDED instead of dropping
+
+- **Timestamp**: 2026-07-06
+- **Action**: Fixed a CRITICAL security bypass (ps-review-008 P3). A firewall
+  filter / PBR term `from { ... } then { routing-instance X; reject | discard; }`
+  carries BOTH a routing-instance override AND a terminating drop action.
+  `ingress_route_table_override` (userspace-dp/src/afxdp/forwarding/mod.rs)
+  captured the term action but used it ONLY for filter-log normalization and
+  ALWAYS returned `Some(routing_instance)`, so the caller route-looked-up and
+  FORWARDED the packet into VRF X — a VRF leak plus a false audit (the filter
+  log recorded a deny while the data plane forwarded). Changed the function to
+  return a three-way `RouteOverride { None | Table(<ri>) | Drop }`: a matched
+  routing-instance term whose action is `Reject`/`Discard` returns `Drop`.
+  Both callers (poll_descriptor/mod.rs — the flow-backed session-miss arm AND
+  the flowless arm) now `match` the result: on `Drop` they recycle the frame
+  and skip the route-lookup/forward. On the session-miss path a `PbrRejectSink`
+  (tx pipeline + counters) is passed, so a `reject` synthesizes the TCP RST /
+  ICMP-unreachable reply inside the override (reusing the existing
+  `enqueue_filter_reject_reply`, byte-identical to a non-PBR `then reject`) and
+  the filter log reports the truthful REJECT; a `discard`, and the whole
+  flowless path (no L4 header to reflect), drop silently. An accept-only
+  routing-instance term still returns `Table(<ri>)` and forwards — normal PBR
+  is unchanged. Added a `native_gre_pbr_action_snapshot(action)` fixture (v4 +
+  inet6 routing-instance terms) and 4 tests: reject/discard DROP on v4 and v6
+  (flowless/sink-less path), accept-still-forwards no-regression (v4 + v6), and
+  session-miss reply synthesis (budget-0 → `filter_reject_reply_budget_drops`
+  bumps, proving the reply was attempted). RED-on-revert verified: with the
+  drop gate disabled all 3 drop tests FAIL (they get `Table` = forward). Full
+  cargo serial suite green. Docs: forwarding/README.md, filter/README.md,
+  afxdp/README.md (the PBR + reject/discard drop-gate interaction).
+- **File(s)**: userspace-dp/src/afxdp/forwarding/mod.rs,
+  userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/afxdp/test_fixtures.rs,
+  userspace-dp/src/afxdp/frame/tests.rs,
+  userspace-dp/src/afxdp/forwarding/README.md,
+  userspace-dp/src/filter/README.md, userspace-dp/src/afxdp/README.md,
+  _Log.md
+
 ## 2026-07-06 — #4228 Gap 2: resolve CoS transmit-rate / shaping-rate percent
 
 - **Timestamp**: 2026-07-06

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -279,7 +279,11 @@ sync.
     (the frame `TermMatchExtra` carries `is_fragment` + `l4_present = false`,
     so an `is-fragment` term matches while tcp-flags / icmp-type / flex
     predicates fail closed); (2) `ingress_route_table_override` PBR, then a
-    route lookup against the override table when a PBR term matched;
+    route lookup against the override table when a PBR term matched — a
+    routing-instance term that also carries `reject`/`discard` returns
+    `RouteOverride::Drop` (#4392) and the packet is recycled here (silently,
+    no reject reply is synthesized on the flowless path), NEVER forwarded into
+    the routing instance;
     (3) zone policy via `evaluate_policy_result_l3_aware(.., l4_present =
     false)` — gated to `ForwardCandidate` (transit) so host-inbound
     (#3292) / NoRoute / fabric arms are untouched. The `MissingNeighbor`

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -199,11 +199,26 @@ limitation, tracked by #2387.
   interface's native `routing_instance` selects only the connected-route
   table NAME (#2388 above) — it does NOT scope a transit packet's
   destination-FIB lookup. Only a PBR interface filter's
-  `ingress_route_table_override` (`forwarding/mod.rs`, sole caller in
+  `ingress_route_table_override` (`forwarding/mod.rs`, callers in
   `poll_descriptor/mod.rs`) actually steers a transit packet to a per-VRF
   table. In default (non-PBR) mode the destination FIB is the global
   `inet.0`/`inet6.0` and local-delivery uses the global `local_v[46]` sets,
   so overlapping-address multi-VRF does not forward correctly there at all.
+- **PBR `routing-instance` + a drop action is a DENY, not a forward (#4392).**
+  A term `from { ... } then { routing-instance X; reject | discard; }` carries
+  BOTH a routing-instance override AND a terminating drop action. Before #4392
+  `ingress_route_table_override` applied the override unconditionally and the
+  packet was FORWARDED into VRF X — a VRF leak plus a false audit (the filter
+  log recorded a deny while the data plane forwarded). It now returns a
+  three-way `RouteOverride { None | Table(<ri>) | Drop }`: a `reject`/`discard`
+  action returns `Drop`, so the caller recycles the frame and never
+  route-looks-up/forwards. On the flow-backed session-miss path a
+  `PbrRejectSink` is supplied, so a `reject` synthesizes the TCP RST /
+  ICMP-unreachable reply exactly like a non-PBR `then reject` (and the filter
+  log reports the truthful REJECT); a `discard`, and the flowless path (a
+  non-first fragment / L3-only packet has no L4 header to reflect), drop
+  silently. An accept-only routing-instance term still returns `Table(<ri>)`
+  and forwards — normal PBR is unchanged.
 - **PBR per-VRF forwarding is NOT session-isolated.** Because the identity
   is the bare 5-tuple, the established-session fast path
   (`resolve_flow_session_decision`) runs BEFORE the PBR table override, so

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -1482,6 +1482,42 @@ pub(super) fn lookup_forwarding_resolution_inner_ecmp(
     }
 }
 
+/// #4392: a reject-reply sink for the flow-backed PBR drop path. Present on the
+/// flow-backed session-miss path, which carries a full L4 header and can
+/// synthesize a TCP RST / ICMP-unreachable exactly like a non-PBR `then reject`.
+/// `None` on the flowless path (a non-first fragment / L3-only packet has no L4
+/// header to reflect), where a PBR `reject`/`discard` degrades to a silent drop
+/// — identical to the flowless non-PBR input-filter deny.
+pub(super) struct PbrRejectSink<'a> {
+    pub(super) tx_pipeline: &'a mut crate::afxdp::worker::WorkerTxPipeline,
+    pub(super) ingress_ifindex: i32,
+    pub(super) counters: &'a mut crate::afxdp::BatchCounters,
+}
+
+/// #4392: the route-lookup decision returned by `ingress_route_table_override`.
+///
+/// A PBR term `from { ... } then { routing-instance X; reject | discard; }`
+/// carries BOTH a routing-instance override AND a drop action. Before this fix
+/// the override was applied unconditionally and the packet was FORWARDED into
+/// VRF X — a VRF leak plus a false audit (the filter log recorded a deny while
+/// the data plane forwarded). The drop action now gates the override.
+pub(super) enum RouteOverride {
+    /// No interface input filter affects route lookup here, or no PBR
+    /// routing-instance term matched. Use the default route table.
+    None,
+    /// A PBR routing-instance term matched with a non-drop (accept) action.
+    /// Steer the route lookup to this override table (`<ri>.inet[6].0`) and
+    /// forward — normal policy-based routing, unchanged.
+    Table(String),
+    /// A PBR routing-instance term matched with a `reject`/`discard` action.
+    /// The caller MUST DROP: do NOT apply the override, do NOT route-lookup or
+    /// forward. Any reject reply (TCP RST / ICMP unreachable) has already been
+    /// synthesized inside `ingress_route_table_override` when a `PbrRejectSink`
+    /// was supplied and the action is `reject`; `discard`, and the flowless
+    /// (sink-less) path, drop silently.
+    Drop,
+}
+
 pub(super) fn ingress_route_table_override(
     forwarding: &ForwardingState,
     frame: &[u8],
@@ -1490,7 +1526,8 @@ pub(super) fn ingress_route_table_override(
     ingress_zone_override: Option<u16>,
     event_stream: Option<&crate::event_stream::EventStreamWorkerHandle>,
     now_ns: u64,
-) -> Option<String> {
+    reject_sink: Option<PbrRejectSink<'_>>,
+) -> RouteOverride {
     let ingress_ifindex = resolve_ingress_logical_ifindex(
         forwarding,
         meta.ingress_ifindex as i32,
@@ -1503,26 +1540,56 @@ pub(super) fn ingress_route_table_override(
         ingress_ifindex,
         is_v6,
     ) {
-        return None;
+        return RouteOverride::None;
     }
     // #2362: PBR terms may carry per-packet L4 match conditions (tcp-flags /
     // is-fragment / icmp-type / icmp-code); build the extra inputs so a
     // `from { tcp-flags ...; } then routing-instance ...` term matches exactly
     // the authored packets.
     let extra = crate::afxdp::frame::term_match_extra_from_frame(frame, meta);
-    let routing_result = crate::filter::evaluate_interface_filter_routing_instance_event_counted(
-        &forwarding.filter_state,
-        ingress_ifindex,
-        is_v6,
-        flow.src_ip,
-        flow.dst_ip,
-        meta.protocol,
-        flow.forward_key.src_port,
-        flow.forward_key.dst_port,
-        meta.dscp,
-        extra,
-        meta.pkt_len as u64,
-    )?;
+    let routing_result =
+        match crate::filter::evaluate_interface_filter_routing_instance_event_counted(
+            &forwarding.filter_state,
+            ingress_ifindex,
+            is_v6,
+            flow.src_ip,
+            flow.dst_ip,
+            meta.protocol,
+            flow.forward_key.src_port,
+            flow.forward_key.dst_port,
+            meta.dscp,
+            extra,
+            meta.pkt_len as u64,
+        ) {
+            Some(result) => result,
+            None => return RouteOverride::None,
+        };
+    // #4392: a matched PBR routing-instance term may ALSO carry a drop action
+    // (`then { routing-instance X; reject | discard; }`). Such a term is a DENY,
+    // NOT a forward: the routing-instance override must NOT be applied. On the
+    // flow-backed session-miss path a `PbrRejectSink` is supplied, so a `reject`
+    // synthesizes the TCP RST / ICMP-unreachable reply here — byte-identical to
+    // a non-PBR `then reject` — and its ACTUAL outcome is threaded into the
+    // filter log (#3615) below. A `discard`, and the flowless (sink-less) path,
+    // drop silently.
+    let is_drop = matches!(
+        routing_result.action,
+        crate::filter::FilterAction::Reject | crate::filter::FilterAction::Discard
+    );
+    let reject_reply_enqueued = match (routing_result.action, reject_sink) {
+        (crate::filter::FilterAction::Reject, Some(sink)) => {
+            crate::afxdp::poll_descriptor::reject_reply::enqueue_filter_reject_reply(
+                sink.tx_pipeline,
+                forwarding,
+                sink.ingress_ifindex,
+                frame,
+                meta,
+                flow,
+                sink.counters,
+            )
+        }
+        _ => false,
+    };
     // #2619: emit the accumulated log_match — it captures fall-through
     // `then { log; next term; }` terms ahead of the routing-instance term that
     // the PBR path previously dropped, AND the routing-instance term's own log
@@ -1551,15 +1618,22 @@ pub(super) fn ingress_route_table_override(
             FilterLogSource::Pbr,
             // #2520: AppID via the hot-path app_catalog.lookup.
             resolve_flow_app_id(&forwarding.app_catalog, flow),
-            // #3615: the PBR (routing-instance) filter path synthesizes NO
-            // reject reply, so a `then reject` term logs the truthful DENY
-            // (silent drop) rather than claiming an active reject was sent.
-            false,
+            // #3615/#4392: report the TRUTHFUL reject outcome. A forward
+            // (non-drop) PBR term never rejects (false). A `then reject` on the
+            // flow-backed session-miss path synthesizes an RST/ICMP reply above
+            // and logs REJECT; a `discard`, or the flowless (sink-less) path,
+            // logs the truthful DENY (silent drop).
+            reject_reply_enqueued,
             now_ns,
         );
     }
+    if is_drop {
+        // #4392: reject/discard PBR term — the caller must drop; do NOT apply
+        // the routing-instance override or route-lookup/forward.
+        return RouteOverride::Drop;
+    }
     let routing_instance = routing_result.routing_instance;
-    Some(if is_v6 {
+    RouteOverride::Table(if is_v6 {
         format!("{routing_instance}.inet6.0")
     } else {
         format!("{routing_instance}.inet.0")

--- a/userspace-dp/src/afxdp/frame/tests.rs
+++ b/userspace-dp/src/afxdp/frame/tests.rs
@@ -511,9 +511,14 @@ fn ingress_filter_routing_instance_steers_flow_into_native_gre_table() {
             burst: 0,
         },
     );
-    let override_table =
-        ingress_route_table_override(&state, &[], meta, &flow, None, Some(&event_handle), 99);
-    assert_eq!(override_table.as_deref(), Some("sfmix.inet.0"));
+    // #4392: an accept (non-drop) routing-instance term still forwards via the
+    // override table — RouteOverride::Table, not Drop.
+    let RouteOverride::Table(override_table) =
+        ingress_route_table_override(&state, &[], meta, &flow, None, Some(&event_handle), 99, None)
+    else {
+        panic!("accept routing-instance term must forward via override table");
+    };
+    assert_eq!(override_table, "sfmix.inet.0");
     let filter_event = event_rx
         .try_recv()
         .expect("filter-log event")
@@ -529,7 +534,7 @@ fn ingress_filter_routing_instance_steers_flow_into_native_gre_table() {
         &state,
         &Default::default(),
         flow.dst_ip,
-        override_table.as_deref(),
+        Some(override_table.as_str()),
     );
     assert_eq!(
         resolved.disposition,
@@ -538,6 +543,239 @@ fn ingress_filter_routing_instance_steers_flow_into_native_gre_table() {
     assert_eq!(resolved.egress_ifindex, 362);
     assert_eq!(resolved.tx_ifindex, 6);
     assert_eq!(resolved.tunnel_endpoint_id, 1);
+}
+
+// #4392: a PBR `from { ... } then { routing-instance X; reject | discard; }`
+// term is a DENY, not a forward. Before the fix the routing-instance override
+// was applied unconditionally and the packet was FORWARDED into VRF X (a VRF
+// leak + false audit). The drop action must now gate the override:
+// reject/discard -> RouteOverride::Drop; accept-only -> RouteOverride::Table.
+
+fn pbr_v4_flow() -> SessionFlow {
+    SessionFlow {
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(10, 255, 192, 41)),
+        forward_key: SessionKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_ICMP,
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(10, 255, 192, 41)),
+            src_port: 0,
+            dst_port: 0,
+        },
+    }
+}
+
+fn pbr_v4_meta() -> UserspaceDpMeta {
+    UserspaceDpMeta {
+        ingress_ifindex: 5,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_ICMP,
+        ..Default::default()
+    }
+}
+
+fn pbr_v6_flow() -> SessionFlow {
+    let src: std::net::Ipv6Addr = "2001:559:8585:61::100".parse().expect("v6 src");
+    let dst: std::net::Ipv6Addr = "2001:559:8585:80::200".parse().expect("v6 dst");
+    SessionFlow {
+        src_ip: IpAddr::V6(src),
+        dst_ip: IpAddr::V6(dst),
+        forward_key: SessionKey {
+            addr_family: libc::AF_INET6 as u8,
+            protocol: crate::ip_proto::PROTO_ICMPV6,
+            src_ip: IpAddr::V6(src),
+            dst_ip: IpAddr::V6(dst),
+            src_port: 0,
+            dst_port: 0,
+        },
+    }
+}
+
+fn pbr_v6_meta() -> UserspaceDpMeta {
+    UserspaceDpMeta {
+        ingress_ifindex: 5,
+        addr_family: libc::AF_INET6 as u8,
+        protocol: crate::ip_proto::PROTO_ICMPV6,
+        ..Default::default()
+    }
+}
+
+/// #4392: build a `WorkerTxPipeline` with a fixed TX-frame budget so the reject
+/// reply either enqueues (budget available) or fails closed onto the
+/// `filter_reject_reply_budget_drops` counter (budget == 0). Mirrors the
+/// reject_reply.rs test helper; all fields are `pub(crate)`.
+fn pbr_reject_tx_pipeline(max_pending_tx: usize) -> crate::afxdp::worker::WorkerTxPipeline {
+    crate::afxdp::worker::WorkerTxPipeline {
+        free_tx_frames: std::collections::VecDeque::new(),
+        pending_tx_prepared: std::collections::VecDeque::new(),
+        pending_tx_local: std::collections::VecDeque::new(),
+        max_pending_tx,
+        outstanding_tx: 0,
+        pending_fill_frames: std::collections::VecDeque::new(),
+        in_flight_prepared_recycles: FastMap::default(),
+        tx_submit_ns: Vec::new().into_boxed_slice(),
+    }
+}
+
+#[test]
+fn pbr_routing_instance_reject_or_discard_drops_not_forwards_v4() {
+    // Flowless (sink-less) path: a reject/discard PBR term must DROP, never
+    // return an override table to forward into. RED-on-revert: the pre-fix code
+    // returns Some("sfmix.inet.0") == RouteOverride::Table, forwarding the deny.
+    let flow = pbr_v4_flow();
+    let meta = pbr_v4_meta();
+    for action in ["reject", "discard"] {
+        let state = build_forwarding_state(&native_gre_pbr_action_snapshot(action));
+        let result = ingress_route_table_override(&state, &[], meta, &flow, None, None, 0, None);
+        assert!(
+            matches!(result, RouteOverride::Drop),
+            "v4 PBR `then routing-instance sfmix; {action}` must DROP, not forward"
+        );
+    }
+}
+
+#[test]
+fn pbr_routing_instance_reject_or_discard_drops_not_forwards_v6() {
+    let flow = pbr_v6_flow();
+    let meta = pbr_v6_meta();
+    for action in ["reject", "discard"] {
+        let state = build_forwarding_state(&native_gre_pbr_action_snapshot(action));
+        let result = ingress_route_table_override(&state, &[], meta, &flow, None, None, 0, None);
+        assert!(
+            matches!(result, RouteOverride::Drop),
+            "v6 PBR `then routing-instance sfmix; {action}` must DROP, not forward"
+        );
+    }
+}
+
+#[test]
+fn pbr_routing_instance_accept_still_forwards_no_regression() {
+    // An accept-only routing-instance term (no drop action) must STILL steer
+    // the route lookup into the override table — normal PBR is unchanged.
+    let state = build_forwarding_state(&native_gre_pbr_action_snapshot(""));
+
+    let v4 = ingress_route_table_override(
+        &state,
+        &[],
+        pbr_v4_meta(),
+        &pbr_v4_flow(),
+        None,
+        None,
+        0,
+        None,
+    );
+    match v4 {
+        RouteOverride::Table(table) => assert_eq!(table, "sfmix.inet.0"),
+        _ => panic!("accept v4 routing-instance term must forward via sfmix.inet.0"),
+    }
+
+    let v6 = ingress_route_table_override(
+        &state,
+        &[],
+        pbr_v6_meta(),
+        &pbr_v6_flow(),
+        None,
+        None,
+        0,
+        None,
+    );
+    match v6 {
+        RouteOverride::Table(table) => assert_eq!(table, "sfmix.inet6.0"),
+        _ => panic!("accept v6 routing-instance term must forward via sfmix.inet6.0"),
+    }
+}
+
+#[test]
+fn pbr_routing_instance_reject_synthesizes_reply_on_session_miss() {
+    // Flow-backed session-miss path: a `reject` PBR term supplies a reject sink,
+    // so the drop synthesizes an RST/ICMP reply exactly like a non-PBR
+    // `then reject`. Drive the TX-frame budget to 0 so the reply attempt is
+    // OBSERVABLE via `filter_reject_reply_budget_drops` without needing a valid
+    // egress/neighbor — the budget gate is reached only for a BUILDABLE reply,
+    // so a bump proves the reply was actually synthesized and attempted.
+    let state = build_forwarding_state(&native_gre_pbr_action_snapshot("reject"));
+    let frame = build_ipv4_tcp_frame(
+        Ipv4Addr::new(10, 0, 61, 100),
+        Ipv4Addr::new(10, 255, 192, 41),
+        49152,
+        443,
+        1,
+        0,
+        TCP_FLAG_SYN,
+    );
+    let meta = UserspaceDpMeta {
+        ingress_ifindex: 5,
+        l3_offset: 14,
+        l4_offset: 34,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        pkt_len: (frame.len() - 14) as u16,
+        ..Default::default()
+    };
+    let flow = SessionFlow {
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(10, 255, 192, 41)),
+        forward_key: SessionKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(10, 255, 192, 41)),
+            src_port: 49152,
+            dst_port: 443,
+        },
+    };
+    let mut pipeline = pbr_reject_tx_pipeline(0);
+    let mut counters = crate::afxdp::BatchCounters::default();
+    let result = ingress_route_table_override(
+        &state,
+        &frame,
+        meta,
+        &flow,
+        None,
+        None,
+        0,
+        Some(PbrRejectSink {
+            tx_pipeline: &mut pipeline,
+            ingress_ifindex: 5,
+            counters: &mut counters,
+        }),
+    );
+    assert!(
+        matches!(result, RouteOverride::Drop),
+        "session-miss reject PBR term must DROP"
+    );
+    assert_eq!(
+        counters.filter_reject_reply_budget_drops, 1,
+        "a reject reply must be synthesized and attempted on the session-miss path"
+    );
+
+    // No-regression: an accept-only term with a sink attempts NO reply.
+    let accept_state = build_forwarding_state(&native_gre_pbr_action_snapshot(""));
+    let mut accept_pipeline = pbr_reject_tx_pipeline(0);
+    let mut accept_counters = crate::afxdp::BatchCounters::default();
+    let accept = ingress_route_table_override(
+        &accept_state,
+        &frame,
+        meta,
+        &flow,
+        None,
+        None,
+        0,
+        Some(PbrRejectSink {
+            tx_pipeline: &mut accept_pipeline,
+            ingress_ifindex: 5,
+            counters: &mut accept_counters,
+        }),
+    );
+    assert!(
+        matches!(accept, RouteOverride::Table(_)),
+        "accept routing-instance term must forward"
+    );
+    assert_eq!(
+        accept_counters.filter_reject_reply_budget_drops, 0,
+        "an accept PBR term must NOT synthesize a reject reply"
+    );
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -1637,7 +1637,13 @@ pub(super) fn poll_binding_process_descriptor(
                             binding.scratch.scratch_recycle.push(desc.addr);
                             continue;
                         }
-                        let route_table_override = ingress_route_table_override(
+                        // #4392: a PBR `then { routing-instance X; reject |
+                        // discard; }` term is a DENY, not a forward. Pass the
+                        // reject sink so a flow-backed `reject` synthesizes the
+                        // RST/ICMP reply (byte-identical to a non-PBR
+                        // `then reject`); on `RouteOverride::Drop` recycle the
+                        // frame and skip the route-lookup/forward entirely.
+                        let route_table_override = match ingress_route_table_override(
                             worker_ctx.forwarding,
                             packet_frame,
                             meta,
@@ -1645,7 +1651,19 @@ pub(super) fn poll_binding_process_descriptor(
                             ingress_zone_override,
                             worker_ctx.event_stream,
                             now_ns,
-                        );
+                            Some(PbrRejectSink {
+                                tx_pipeline: &mut binding.tx_pipeline,
+                                ingress_ifindex: binding.ifindex,
+                                counters: &mut *telemetry.counters,
+                            }),
+                        ) {
+                            RouteOverride::Drop => {
+                                binding.scratch.scratch_recycle.push(desc.addr);
+                                continue;
+                            }
+                            RouteOverride::Table(table) => Some(table),
+                            RouteOverride::None => None,
+                        };
 
                         let resolution = if should_block_tunnel_interface_nat_session_miss(
                             worker_ctx.forwarding,
@@ -3307,17 +3325,36 @@ pub(super) fn poll_binding_process_descriptor(
                     //     term must reach LocalDelivery, NOT be steered into an
                     //     override table that has no local route (→ NoRoute →
                     //     drop). The override governs only the transit fallback.
-                    let route_override = l3_ctx.as_ref().and_then(|l3_flow| {
-                        ingress_route_table_override(
-                            worker_ctx.forwarding,
-                            packet_frame,
-                            meta,
-                            l3_flow,
-                            ingress_zone_override,
-                            worker_ctx.event_stream,
-                            now_ns,
-                        )
-                    });
+                    // #4392: on the flowless path a PBR `then { routing-instance
+                    // X; reject | discard; }` term is still a DENY. Pass no
+                    // reject sink — a flowless deny is a silent drop (a non-first
+                    // fragment / L3-only packet has no L4 header to reflect),
+                    // identical to the flowless non-PBR input-filter deny above.
+                    // On `RouteOverride::Drop` recycle the frame and skip the
+                    // override/route-lookup/forward.
+                    let route_table_override = match l3_ctx
+                        .as_ref()
+                        .map(|l3_flow| {
+                            ingress_route_table_override(
+                                worker_ctx.forwarding,
+                                packet_frame,
+                                meta,
+                                l3_flow,
+                                ingress_zone_override,
+                                worker_ctx.event_stream,
+                                now_ns,
+                                None,
+                            )
+                        })
+                        .unwrap_or(RouteOverride::None)
+                    {
+                        RouteOverride::Drop => {
+                            binding.scratch.scratch_recycle.push(desc.addr);
+                            continue;
+                        }
+                        RouteOverride::Table(table) => Some(table),
+                        RouteOverride::None => None,
+                    };
                     let base_resolution = match l3_ctx.as_ref() {
                         Some(l3_flow) => flowless_base_resolution(
                             worker_ctx.forwarding,
@@ -3328,7 +3365,7 @@ pub(super) fn poll_binding_process_descriptor(
                             meta.ingress_vlan_id,
                             meta.protocol,
                             l3_flow.dst_ip,
-                            route_override.as_deref(),
+                            route_table_override.as_deref(),
                         ),
                         None => enforce_ha_resolution_snapshot(
                             worker_ctx.forwarding,

--- a/userspace-dp/src/afxdp/test_fixtures.rs
+++ b/userspace-dp/src/afxdp/test_fixtures.rs
@@ -335,6 +335,44 @@ pub(super) fn native_gre_pbr_snapshot(include_neighbor: bool) -> ConfigSnapshot 
     snapshot
 }
 
+/// #4392: a snapshot whose reth1.0 input filter carries a PBR
+/// `then { routing-instance sfmix; <action>; }` term for BOTH inet and inet6,
+/// where `action` is `"reject"` / `"discard"` (a DROP term) or `""` (an
+/// accept-only routing-instance override, the no-regression forward case).
+/// Used to prove the drop-action gate on `ingress_route_table_override`: a
+/// reject/discard term must return `RouteOverride::Drop`, an accept term must
+/// still return `RouteOverride::Table("sfmix.inet[6].0")`.
+pub(super) fn native_gre_pbr_action_snapshot(action: &str) -> ConfigSnapshot {
+    let mut snapshot = native_gre_pbr_snapshot(true);
+    // Stamp the action onto the existing v4 routing-instance term
+    // (`sfmix-route`, the first term of the first filter).
+    snapshot.filters[0].terms[0].action = action.to_string();
+    // Wire an inet6 sibling filter so the v6 path exercises the same gate.
+    if let Some(iface) = snapshot.interfaces.iter_mut().find(|i| i.name == "reth1.0") {
+        iface.filter_input_v6 = "sfmix-pbr6".to_string();
+    }
+    snapshot.filters.push(FirewallFilterSnapshot {
+        name: "sfmix-pbr6".to_string(),
+        family: "inet6".to_string(),
+        terms: vec![
+            FirewallTermSnapshot {
+                name: "sfmix-route6".to_string(),
+                destination_addresses: vec!["2001:559:8585:80::/64".to_string()],
+                routing_instance: "sfmix".to_string(),
+                action: action.to_string(),
+                log: true,
+                ..Default::default()
+            },
+            FirewallTermSnapshot {
+                name: "default".to_string(),
+                action: "accept".to_string(),
+                ..Default::default()
+            },
+        ],
+    });
+    snapshot
+}
+
 pub(super) fn forwarding_snapshot_with_next_table(include_neighbor: bool) -> ConfigSnapshot {
     ConfigSnapshot {
         // #2391: the interface references "wan"; define it so the forwarding

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -222,6 +222,21 @@ Mirrors the BPF firewall-filter pipeline in userspace.
   `affects_route_lookup`; that under-counted to zero on the discard/reject
   and session-hit exits, where the routing evaluator is never the counter.)
 
+- **A routing-instance term that ALSO carries `reject`/`discard` is a DENY
+  (#4392).** The non-PBR precheck DEFERS any matched routing-instance term
+  (`eval.rs`: a matched term with a non-empty `routing_instance` returns the
+  default `Accept` result), so a `then { routing-instance X; reject; }` term
+  reaches the routing evaluator via `ingress_route_table_override`, NOT the
+  precheck's terminal discard/reject exit above. The routing evaluator carries
+  the term's `action`; when it is `reject`/`discard` the override is now GATED
+  — `ingress_route_table_override` returns `RouteOverride::Drop` instead of a
+  forward table, so the caller drops (synthesizing the reject reply on the
+  flow-backed session-miss path, silent otherwise) rather than steering the
+  packet into VRF X. Before #4392 the override was applied unconditionally and
+  the deny was silently FORWARDED into the routing instance (a VRF leak + false
+  audit). Counter ownership is unchanged: the routing evaluator still counts the
+  matched term on this defer exit.
+
   **The CoS TX-selection INGRESS leg is counter-suppressed (#4085).** An
   interface INPUT filter is action-evaluated for its `then count` exactly
   once (the #2620 precheck above / the DSCP-sensitive session-hit re-eval).


### PR DESCRIPTION
## Summary

Closes #4392. Fixes a CRITICAL security bypass (ps-review-008 P3): a
firewall-filter / PBR term
`from { ... } then { routing-instance X; reject | discard; }` carries BOTH a
routing-instance override AND a terminating drop action, but
`ingress_route_table_override` used the action only to normalize the filter log
and **always** returned `Some(routing_instance)`. The caller then ran the route
lookup and **FORWARDED** the packet into VRF X — a VRF leak (the deny traffic
crossed into a different routing instance) plus a false audit (the filter log
recorded a deny while the data plane forwarded). Both the flow-backed
session-miss path and the flowless path were affected.

## Fix

`ingress_route_table_override` now returns a three-way
`RouteOverride { None | Table(<ri>) | Drop }`:

- A matched routing-instance term whose action is **Reject/Discard** returns
  `Drop`. Both callers (`poll_descriptor` session-miss + flowless) `match` the
  result and, on `Drop`, recycle the frame and skip the route-lookup/forward.
- An **accept-only** routing-instance term still returns `Table(<ri>)` and
  forwards — normal policy-based routing is unchanged (no regression).

The drop is byte-identical to a non-PBR `then reject`:

- **Session-miss path** supplies a `PbrRejectSink` (tx pipeline + counters), so a
  `reject` synthesizes the TCP RST / ICMP-unreachable reply inside the override
  via the existing `enqueue_filter_reject_reply`, and the filter log reports the
  truthful **REJECT** (#3615).
- **`discard`, and the whole flowless path** (a non-first fragment / L3-only
  packet has no L4 header to reflect) drop silently and log the truthful DENY.

## Tests

New `native_gre_pbr_action_snapshot(action)` fixture (v4 + inet6 routing-instance
terms) plus four tests:

- `pbr_routing_instance_reject_or_discard_drops_not_forwards_v4` / `_v6` — the
  flowless/sink-less path DROPS for reject and discard.
- `pbr_routing_instance_accept_still_forwards_no_regression` — accept-only term
  still forwards via `sfmix.inet.0` / `sfmix.inet6.0`.
- `pbr_routing_instance_reject_synthesizes_reply_on_session_miss` — with a sink
  and a TCP-frame reject, `filter_reject_reply_budget_drops` bumps (proving the
  reply was synthesized and attempted); an accept term with a sink attempts no
  reply.

**RED-on-revert verified**: with the drop gate disabled, all three drop tests
fail (they get `Table` = forward). Full cargo serial suite green
(3717 passed / 0 failed).

## Docs

`forwarding/README.md`, `filter/README.md`, `afxdp/README.md` document the PBR +
reject/discard drop-gate interaction.

## Validation note

This is a dataplane forwarding/security change. A cluster PBR-reject smoke is
warranted before merge: a `then { routing-instance X; reject; }` term should see
its traffic **dropped, not forwarded to X** (and the reverse for an accept-only
routing-instance term). Not run here (implement-only task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi