### PR TITLE
policymatch: report ContentRejected for the dataplane's full fail-closed set (#4394)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,45 @@
+## 2026-07-06 — #4394: match-policies simulator reports ContentRejected for the dataplane's full fail-closed set
+
+- **Timestamp**: 2026-07-06
+- **Action**: The `request security match-policies` simulator (pkg/policymatch)
+  only detected content-rejection for an UNEXPANDABLE application-set (#3727).
+  The DATAPLANE (userspace-dp/src/policy.rs) ALSO fails the WHOLE snapshot CLOSED
+  on a protocol-less application, an unrepresentable protocol/port, an undefined
+  application reference, and an unresolvable address — in those cases the
+  simulator SKIPPED the term (a per-term no-match) and fell through to a later
+  rule / the configured default-policy, FABRICATING a permit/deny/default verdict
+  the dataplane never enforces (under a default-permit it answered PERMIT while
+  the dataplane denies fail-closed → operator misled). Fix: extended the
+  simulator's config-wide ContentRejected gate to the full fail-closed set by
+  reusing the dataplane SSOT. Added exported
+  `dpuserspace.PolicyContentRejectionReasons(cfg, feedOverlay)` — the exact
+  detection `buildSnapshot` uses (per-rule `__unsupported__` /
+  `__unsupported_address__` sentinels via `collectPolicyContentRejections`, plus
+  the order-insensitive app-catalog build for a `[ any bad-set ]` policy the
+  per-rule scan misses) — and replaced policymatch's app-set-only
+  `policyContentRejectionReasons` with a thin delegate that threads
+  `q.FeedOverlay` so a healthy dynamic-address feed policy does NOT
+  false-positive. The #3323 protocol-less-app test flipped from a fabricated
+  default-deny to ContentRejected (the behavior #4394 mandates). Fixed a latent
+  parity gap the SSOT reuse exposed: the Go `addrRepresentable` gate omitted the
+  Junos `any-ipv4` / `any-ipv6` keywords (only `any4` / `any6`), which the Rust
+  matcher accepts as family wildcards (policy.rs parse_v3_literal_set) — a raw
+  `any-ipv4` policy token on the lenient/HA/hand-built path would emit a spurious
+  `__unsupported_address__` sentinel; added them to the accepted set.
+  RED-on-revert: neutralizing the gate reverts each of the four conditions to a
+  fabricated permit/default (and the whole-config poison case to a positive
+  `clean-http` match). No-over-report control: a fully-representable config still
+  reports its real permit verdict. Go-only (pkg/policymatch + pkg/dataplane/
+  userspace), no cargo.
+- **File(s)**: pkg/dataplane/userspace/policies.go,
+  pkg/policymatch/policymatch.go,
+  pkg/policymatch/content_reject_4394_test.go,
+  pkg/policymatch/protocol_omitted_3323_test.go,
+  pkg/policymatch/app_set_failclosed_3727_test.go,
+  pkg/policymatch/README.md,
+  docs/junos-cli-reference.md,
+  _Log.md
+
 ## 2026-07-06 — #4378: confirm pending commit-confirmed on RG0 demotion
 
 - **Timestamp**: 2026-07-06

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -904,6 +904,22 @@ check, so a malformed request (e.g. `dst_port=abc`) returned 200 during the
 boot window monitors poll but 400 once a config was active. A well-formed
 boot-window query still returns the 200 fail-closed default-deny.
 
+**Content-rejected verdict (#3727, #4394).** When the ACTIVE config names policy
+content the userspace dataplane cannot represent, the helper fails the WHOLE
+snapshot closed — it retains its previous-good snapshot or fresh-boots
+default-deny and enforces NONE of the config. The simulator reports this as a
+first-class `policy content rejected by dataplane (fail-closed)` verdict (naming
+the offending policy + object), NOT a permit/deny/default verdict — matching the
+dataplane instead of misleading the operator (under a default-permit the pre-fix
+simulator answered PERMIT while the dataplane denied). The detection is the
+single dataplane SSOT `dpuserspace.PolicyContentRejectionReasons` and covers: an
+unexpandable application-set (#3727), a protocol-less application, an
+unrepresentable protocol/port, an undefined application reference, and an
+unresolvable address (undefined address-book / prefix-list name, or a book whose
+value is a non-literal dns-name / wildcard / range) (#4394). A single
+unrepresentable rule content-rejects EVERY query for the config (whole-snapshot
+semantics); a healthy config is never flagged.
+
 ---
 
 ## Security: Zones

--- a/pkg/dataplane/userspace/policies.go
+++ b/pkg/dataplane/userspace/policies.go
@@ -145,7 +145,18 @@ func buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg *config.Config, activeSt
 	// under-denying it.
 	addrRepresentable := func(tok string) bool {
 		switch tok {
-		case "", "any", "any4", "any6":
+		// `any4`/`any6` are the internal short forms; `any-ipv4`/`any-ipv6` are
+		// the Junos config keywords. A committed config never carries the Junos
+		// keywords raw — compilePolicy rewrites them to 0.0.0.0/0 // ::/0
+		// (compiler_security_policy.go normalizePolicyAddrToken) — but a lenient /
+		// HA-synced / hand-built snapshot can, and the Rust matcher accepts the
+		// WHOLE set as a family wildcard (policy.rs parse_v3_literal_set:
+		// `"any4" | "any-ipv4" => any_v4`). Accept the same set so the
+		// representability gate never emits a false __unsupported_address__
+		// sentinel (a spurious whole-snapshot fail-close) for a token the matcher
+		// actually honors — which would also make the #4394 match-policies
+		// simulator falsely report ContentRejected for a raw `any-ipv4` policy.
+		case "", "any", "any4", "any6", "any-ipv4", "any-ipv6":
 			return true
 		}
 		if isUserspaceLiteralAddress(tok) {
@@ -549,6 +560,75 @@ func collectPolicyContentRejections(policies []PolicyRuleSnapshot) []string {
 		}
 		reasons = append(reasons, fmt.Sprintf("policy %s names content the userspace matcher cannot represent: %s",
 			policyRejectionScope(rule), strings.Join(causes, "; ")))
+	}
+	return reasons
+}
+
+// PolicyContentRejectionReasons is the config-level SSOT for "the userspace
+// helper would fail this config's policy snapshot CLOSED and enforce NONE of
+// it". It is the single mirror of the runtime fail-closed policy-content set,
+// shared with the `request security match-policies` simulator (pkg/policymatch)
+// so the simulator reports the dataplane's fail-closed retention instead of a
+// fabricated permit/deny/default verdict (#4394) — the same SSOT-reuse pattern
+// as RuntimePolicyIDs and ClassifyHostInbound (#4352).
+//
+// It reproduces buildSnapshot's two policy-content fail-close paths exactly:
+//
+//   - PER-RULE SENTINELS (collectPolicyContentRejections over the BUILT rules):
+//     the policy snapshot builder poisons a rule with the __unsupported__
+//     application term or the __unsupported_address__ literal when it names
+//
+//   - a protocol-less application (proto == "" ->
+//     expandUserspacePolicyApplications ok=false, #3323),
+//
+//   - an unrepresentable protocol or port (appid.ProtocolNumber /
+//     userspacePortSpecRepresentable rejects it, #2124/#4345),
+//
+//   - an undefined application reference (resolveUserspaceApplicationNames
+//     ok=false),
+//
+//   - an unresolvable address (an undefined address-book / prefix-list name,
+//     or a defined book/set whose value is a non-literal dns-name / wildcard
+//     / range or resolves to no concrete prefix — addrRepresentable false,
+//     #3261).
+//     The Rust integrity preflight rejects any such rule
+//     (UnrepresentableApplicationProtocol / UnrepresentableAddress), so the
+//     helper retains its previous-good snapshot or fresh-boots default-deny.
+//     This scan is feed-aware — a healthy dynamic-address feed policy resolves
+//     through feedOverlay and does NOT false-positive.
+//
+//   - APP-CATALOG BUILD (buildAppCatalogSnapshot): pkg/appid BuildCatalog walks
+//     EVERY configured application-set and errors on the first it cannot expand,
+//     which fails the whole snapshot closed REGARDLESS of a leading `any` token
+//     in the referencing policy (the per-rule scan short-circuits on `any`, so a
+//     `match application [ any bad-set ]` policy is missed there but still fails
+//     closed here). It is consulted only when the per-rule scan is empty, so a
+//     bad set already named with a scoped per-rule reason is not double-reported.
+//
+// A non-empty result means the dataplane enforces NONE of this config; an empty
+// result means every policy rule is representable. feedOverlay is the live
+// dynamic-address feed-prefix overlay (nil = no live feeds); callers MUST pass
+// the same overlay the production builder uses so the simulator agrees with the
+// helper on feed-backed address-names.
+func PolicyContentRejectionReasons(cfg *config.Config, feedOverlay map[string][]string) []string {
+	if cfg == nil {
+		return nil
+	}
+	policies, err := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, nil, feedOverlay)
+	if err != nil {
+		// A policy-snapshot build error (e.g. the #2514 address-book content-ID
+		// collision, or a MaxRulesPerPolicy overflow) is itself a fail-closed
+		// condition: buildSnapshot returns the error, the apply path rejects the
+		// config, and the helper retains the prior dataplane state. Report it so
+		// the simulator does not fabricate a verdict the dataplane never enforces.
+		return []string{fmt.Sprintf("policy snapshot cannot be built (fail-closed): %v", err)}
+	}
+	reasons := collectPolicyContentRejections(policies)
+	if len(reasons) == 0 {
+		if _, cerr := buildAppCatalogSnapshot(cfg); cerr != nil {
+			reasons = append(reasons, fmt.Sprintf(
+				"application catalog cannot be built (fail-closed): %v", cerr))
+		}
 	}
 	return reasons
 }

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -366,43 +366,65 @@ unaffected. The surfaces accept the type/code as `icmp_type`/`icmp_code` (REST
 query, gRPC `MatchPolicies` optional fields), `icmp-type`/`icmp-code` (CLI
 tokens), and `ictype=`/`iccode=` (gRPC `test policy` topic).
 
-## Content-rejected verdict (#3727)
+## Content-rejected verdict (#3727, #4394)
 
-A policy that references an application-SET the runtime cannot expand
-(`config.ExpandApplicationSet` errors — a member that does not resolve, nesting
-deeper than the max, or a missing set) makes the runtime fail the WHOLE snapshot
-closed: the app catalog builder (`pkg/appid.BuildCatalog`, consumed by
-`buildAppCatalogSnapshot`) returns an error so `buildSnapshot` itself errors and
-the apply path retains the prior dataplane state (#3438), and the policy
-snapshot builder (`expandUserspacePolicyApplications` →
-`resolveUserspaceApplicationNames`) poisons the rule with the `__unsupported__`
-sentinel the helper integrity preflight rejects (#3261). Either way the
-dataplane retains its previous-good snapshot or fresh-boots default-deny and
-enforces NONE of the config.
-
-Before #3727 `matchApp` SILENTLY SKIPPED the malformed set (a bare `continue`)
-and fell through to a later rule / the configured default-policy — so under a
-`default-policy permit-all` the simulator reported PERMIT for a config the
-dataplane fail-closes (and `match application [ bad-set any ]` returned a
-confident positive match, review M01). `Match` now detects the same condition up
-front, config-wide, BEFORE any per-tier or host-gate evaluation, and returns a
-first-class `Result.ContentRejected` verdict carrying
-`ContentRejectionReasons` that name the offending policy + application-set.
+A policy that references content the userspace matcher cannot represent makes the
+runtime fail the WHOLE snapshot closed — the helper retains its previous-good
+snapshot or fresh-boots default-deny and enforces NONE of the config. `Match`
+detects the SAME fail-closed set up front, config-wide, BEFORE any per-tier or
+host-gate evaluation, and returns a first-class `Result.ContentRejected` verdict
+carrying `ContentRejectionReasons` that name the offending policy + object.
 `DisplayAction` renders the dedicated `ContentRejectedActionString` (the SSOT
 shared by REST/gRPC), and the CLI / `test policy` text surfaces print
-`ContentRejectedShowLine` plus the reasons. The detection is ORDER-INSENSITIVE
-(both `[ bad-set any ]` and `[ any bad-set ]` fail closed, mirroring the
-order-insensitive `BuildCatalog` walk) and config-wide (a malformed set in ANY
-policy fails EVERY query for the config, mirroring the whole-snapshot rejection —
-a query whose own zone pair has a clean rule is still reported content-rejected
-because that clean rule is not enforced either). Scope is only the application-
-SET expansion error; a protocol-less member app (#3323), an unrepresentable
-protocol/port (#2124), and a bare undefined application NAME keep their existing
-term-level behavior. The runtime reference is pinned in
-`pkg/dataplane/userspace/app_set_reject_3727_test.go`
-(`buildSnapshot` errors or records `PolicyContentRejected` for the same input);
-the simulator fail-on-revert artifacts are in
-`app_set_failclosed_3727_test.go`.
+`ContentRejectedShowLine` plus the reasons.
+
+The detection delegates to the single dataplane SSOT
+`dpuserspace.PolicyContentRejectionReasons(cfg, feedOverlay)` — the EXACT
+fail-close set `buildSnapshot` enforces — so the simulator can never drift from
+the helper. It covers every fail-closed policy-content axis:
+
+- **Unexpandable application-SET (#3727)** — `config.ExpandApplicationSet` errors
+  (a member that does not resolve, nesting deeper than the max, or a missing
+  set). Two runtime paths fail closed on it: the app catalog builder
+  (`pkg/appid.BuildCatalog`, consumed by `buildAppCatalogSnapshot`) errors so
+  `buildSnapshot` itself errors (#3438), and the policy snapshot builder poisons
+  the rule with the `__unsupported__` sentinel the helper integrity preflight
+  rejects (#3261). The catalog path is ORDER-INSENSITIVE, so `[ any bad-set ]`
+  fails closed too (the per-rule scan short-circuits a leading `any`).
+- **Protocol-less application (#3323)** — a named app with no protocol
+  (`proto == ""`) is unrepresentable (`expandUserspacePolicyApplications` returns
+  `ok=false` → `__unsupported__`).
+- **Unrepresentable protocol or port (#2124/#4345)** — `appid.ProtocolNumber` or
+  `userspacePortSpecRepresentable` rejects it (e.g. a bogus protocol name, or a
+  destination-port outside the u16 wire space).
+- **Undefined application reference** — `match application X` where X is neither
+  a defined application nor an application-set
+  (`resolveUserspaceApplicationNames` returns `ok=false`).
+- **Unresolvable address (#3261)** — an undefined address-book / prefix-list
+  name, or a defined book/set whose value is a non-literal (Junos dns-name /
+  wildcard-address / range-address) or resolves to no concrete prefix
+  (`addrRepresentable` false → `__unsupported_address__`). The scan is feed-aware
+  (`q.FeedOverlay`): a healthy dynamic-address feed policy resolves through the
+  overlay and is NOT falsely flagged.
+
+Before this, `matchApp` / `matchAddr` SILENTLY SKIPPED the unrepresentable term
+(a per-term no-match) and fell through to a later rule / the configured
+default-policy — so under a `default-policy permit-all` the simulator reported
+PERMIT for a config the dataplane fail-closes (and `match application
+[ bad-set any ]` returned a confident positive match, review M01). #3727 fixed
+the application-SET axis; #4394 extended the gate to the remaining four axes
+above, which the pre-#4394 simulator reported as a fabricated permit/deny/default
+verdict. The detection is config-wide: a single unrepresentable rule anywhere
+fails EVERY query for the config, mirroring the whole-snapshot rejection — a
+query whose own zone pair has a clean rule is still reported content-rejected
+because that clean rule is not enforced either.
+
+The runtime reference is pinned in
+`pkg/dataplane/userspace/app_set_reject_3727_test.go` (`buildSnapshot` errors or
+records `PolicyContentRejected` for the same input); the simulator
+fail-on-revert artifacts are in `app_set_failclosed_3727_test.go` (#3727) and
+`content_reject_4394_test.go` (#4394 — the four extended axes plus the
+no-over-report control).
 
 Where the runtime and the old simulators disagreed, the runtime wins.
 

--- a/pkg/policymatch/app_set_failclosed_3727_test.go
+++ b/pkg/policymatch/app_set_failclosed_3727_test.go
@@ -211,7 +211,7 @@ func TestNoAppSetNoRejection(t *testing.T) {
 				config.PolicyMatch{Applications: []string{"junos-http"}})),
 		},
 	}, config.ApplicationsConfig{})
-	if reasons := policyContentRejectionReasons(cfg); len(reasons) != 0 {
+	if reasons := policyContentRejectionReasons(cfg, nil); len(reasons) != 0 {
 		t.Fatalf("policyContentRejectionReasons = %v, want empty for a config with no application-sets", reasons)
 	}
 }

--- a/pkg/policymatch/content_reject_4394_test.go
+++ b/pkg/policymatch/content_reject_4394_test.go
@@ -1,0 +1,261 @@
+package policymatch
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #4394 — the `request security match-policies` simulator only detected
+// content-rejection for an UNEXPANDABLE application-set (#3727). The DATAPLANE
+// (userspace-dp/src/policy.rs) ALSO fails the WHOLE snapshot CLOSED on:
+//
+//   (1) a protocol-less application (proto=="" -> expandUserspacePolicyApplications
+//       ok=false -> __unsupported__ sentinel -> Rust
+//       SnapshotIntegrityError::UnrepresentableApplicationProtocol);
+//   (2) an unrepresentable protocol or port (appid.ProtocolNumber /
+//       userspacePortSpecRepresentable rejects it -> same sentinel/reject);
+//   (3) an undefined application reference (resolveUserspaceApplicationNames
+//       ok=false -> same sentinel/reject);
+//   (4) an unresolvable address — an undefined address-book / prefix-list name,
+//       or a defined book whose value is a non-literal (dns-name / wildcard /
+//       range) -> __unsupported_address__ sentinel -> Rust
+//       SnapshotIntegrityError::UnrepresentableAddress.
+//
+// In each case the helper retains its previous-good snapshot (or fresh-boots
+// default-deny) and enforces NONE of the config. The pre-#4394 simulator SKIPPED
+// the unrepresentable term (a per-term no-match) and fell through to a later rule
+// / the configured default-policy, FABRICATING a permit/deny/default verdict.
+// Under a default-PERMIT it reported PERMIT for a config the dataplane
+// fail-closes (a dangerous operator lie). These tests pin the fail-closed-parity
+// fix: any of the four conditions makes Match report the first-class
+// ContentRejected verdict for EVERY query, matching the dataplane.
+//
+// RED-ON-REVERT: dropping the config-wide ContentRejected gate (or the
+// dpuserspace.PolicyContentRejectionReasons detection) makes each config fall
+// through to the default-PERMIT (Matched=false, DefaultUsed=true, Action=permit,
+// ContentRejected=false), failing the want-ContentRejected assertions below.
+
+// assertContentRejected checks the ContentRejected verdict invariants shared by
+// all four #4394 conditions: the whole config is content-rejected, no rule
+// matched, no default verdict was fabricated, and the reason names the offending
+// policy scope.
+func assertContentRejected(t *testing.T, res Result, wantScope string) {
+	t.Helper()
+	if !res.ContentRejected {
+		t.Fatalf("ContentRejected = false, want true: the dataplane fails this config closed; the simulator must not fabricate a verdict (res = %+v)", res)
+	}
+	if res.Matched || res.DefaultUsed || res.HostInboundUnmatched {
+		t.Fatalf("Matched=%v DefaultUsed=%v HostInboundUnmatched=%v, want all false for a ContentRejected verdict (res = %+v)",
+			res.Matched, res.DefaultUsed, res.HostInboundUnmatched, res)
+	}
+	if res.DisplayAction() != ContentRejectedActionString {
+		t.Fatalf("DisplayAction() = %q, want ContentRejectedActionString", res.DisplayAction())
+	}
+	reason := strings.Join(res.ContentRejectionReasons, " | ")
+	if !strings.Contains(reason, wantScope) {
+		t.Fatalf("reason %q does not name the offending policy scope %q", reason, wantScope)
+	}
+}
+
+// TestContentRejectProtocolLessApp4394 — condition (1): a named application with
+// no protocol. The default-PERMIT would fabricate a PERMIT verdict pre-fix.
+func TestContentRejectProtocolLessApp4394(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyPermit,
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", permit("permit-noproto",
+				config.PolicyMatch{Applications: []string{"noproto"}})),
+		},
+	}, config.ApplicationsConfig{
+		Applications: map[string]*config.Application{
+			"noproto": {Name: "noproto"}, // no protocol -> unrepresentable
+		},
+	})
+
+	res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 80})
+	assertContentRejected(t, res, "trust->untrust/permit-noproto")
+}
+
+// TestContentRejectUnrepresentablePort4394 — condition (2): a named application
+// whose destination-port exceeds the u16 wire space (userspacePortSpecRepresentable
+// rejects "70000"). Mirrors the #2124/#4345 dataplane reject.
+func TestContentRejectUnrepresentablePort4394(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyPermit,
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", permit("permit-badport",
+				config.PolicyMatch{Applications: []string{"badport"}})),
+		},
+	}, config.ApplicationsConfig{
+		Applications: map[string]*config.Application{
+			// Valid protocol, but a destination-port the u16 wire cannot carry.
+			"badport": {Name: "badport", Protocol: "tcp", DestinationPort: "70000"},
+		},
+	})
+
+	res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 80})
+	assertContentRejected(t, res, "trust->untrust/permit-badport")
+}
+
+// TestContentRejectUnrepresentableProtocol4394 — condition (2) protocol variant:
+// a named application whose protocol appid.ProtocolNumber cannot resolve.
+func TestContentRejectUnrepresentableProtocol4394(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyPermit,
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", permit("permit-badproto",
+				config.PolicyMatch{Applications: []string{"badproto"}})),
+		},
+	}, config.ApplicationsConfig{
+		Applications: map[string]*config.Application{
+			"badproto": {Name: "badproto", Protocol: "not-a-protocol"},
+		},
+	})
+
+	res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 80})
+	assertContentRejected(t, res, "trust->untrust/permit-badproto")
+}
+
+// TestContentRejectUndefinedApp4394 — condition (3): `match application X` where
+// X is neither a defined application nor an application-set. The pre-fix
+// matchSingleApp returned false (no-match) and the query fell through to
+// default-permit; the dataplane instead poisons the rule with the
+// __unsupported__ sentinel and fails the whole snapshot closed.
+func TestContentRejectUndefinedApp4394(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyPermit,
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", permit("permit-undef-app",
+				config.PolicyMatch{Applications: []string{"no-such-app"}})),
+		},
+	}, config.ApplicationsConfig{})
+
+	res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 80})
+	assertContentRejected(t, res, "trust->untrust/permit-undef-app")
+}
+
+// TestContentRejectUnresolvableAddress4394 — condition (4): `match source-address
+// missing-book` where missing-book is not in the address book. The pre-fix
+// matchAddr resolved it to no prefix (MatchNone) and the query fell through to
+// default-permit; the dataplane instead emits the __unsupported_address__
+// sentinel and fails the whole snapshot closed.
+func TestContentRejectUnresolvableAddress4394(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyPermit,
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", permit("permit-missing-book",
+				config.PolicyMatch{SourceAddresses: []string{"missing-book"}})),
+		},
+	}, config.ApplicationsConfig{})
+
+	res := Match(cfg, Query{
+		FromZone: "trust", ToZone: "untrust", Protocol: "tcp",
+		SrcIP: net.ParseIP("10.0.1.5"), DstIP: net.ParseIP("10.0.2.5"), DstPort: 80,
+	})
+	assertContentRejected(t, res, "trust->untrust/permit-missing-book")
+}
+
+// TestContentRejectNonLiteralAddressBook4394 — condition (4) variant: a DEFINED
+// address-book entry whose value is empty (the compiler stores "" for a Junos
+// dns-name / wildcard-address / range-address that the userspace matcher cannot
+// represent). nameRepresentable rejects it, so the dataplane emits the
+// __unsupported_address__ sentinel and fails closed — the simulator must not
+// widen the empty value to match-any / fall through.
+func TestContentRejectNonLiteralAddressBook4394(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyPermit,
+		AddressBook: &config.AddressBook{
+			Addresses: map[string]*config.Address{
+				// Empty Value models a dns-name/wildcard/range that compiled to
+				// no concrete prefix (compiler_validate_warn.go).
+				"dns-book": {Name: "dns-book"},
+			},
+		},
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", permit("permit-dns-book",
+				config.PolicyMatch{DestinationAddresses: []string{"dns-book"}})),
+		},
+	}, config.ApplicationsConfig{})
+
+	res := Match(cfg, Query{
+		FromZone: "trust", ToZone: "untrust", Protocol: "tcp",
+		SrcIP: net.ParseIP("10.0.1.5"), DstIP: net.ParseIP("10.0.2.5"), DstPort: 80,
+	})
+	assertContentRejected(t, res, "trust->untrust/permit-dns-book")
+}
+
+// TestContentRejectPoisonsWholeConfig4394 — the fail-close is CONFIG-WIDE: a
+// single unrepresentable rule (here an undefined app in dmz->wan) content-rejects
+// EVERY query, including one whose own zone pair has a perfectly clean rule the
+// query would otherwise match. Mirrors the whole-snapshot dataplane reject.
+func TestContentRejectPoisonsWholeConfig4394(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyDeny,
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", permit("clean-http",
+				config.PolicyMatch{Applications: []string{"junos-http"}})),
+			zonePair("dmz", "wan", permit("permit-undef-app",
+				config.PolicyMatch{Applications: []string{"no-such-app"}})),
+		},
+	}, config.ApplicationsConfig{})
+
+	// This query matches the clean trust->untrust permit pre-fix, but the config
+	// is poisoned by the dmz->wan undefined-app rule.
+	res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 80})
+	assertContentRejected(t, res, "dmz->wan/permit-undef-app")
+}
+
+// TestContentRejectNoOverReport4394 is the non-regression control: a config whose
+// every rule is representable (defined resolvable book, representable app with a
+// valid port) must NOT be content-rejected and must report its REAL permit/deny
+// verdict. This is the no-over-report proof — the gate flags ONLY the conditions
+// the dataplane actually fails closed on, never a healthy config.
+func TestContentRejectNoOverReport4394(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyDeny,
+		AddressBook: &config.AddressBook{
+			Addresses: map[string]*config.Address{
+				"trust-net": {Name: "trust-net", Value: "10.0.1.0/24"},
+			},
+		},
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", permit("allow-web",
+				config.PolicyMatch{
+					SourceAddresses: []string{"trust-net"},
+					Applications:    []string{"junos-http", "web-8080"},
+				})),
+		},
+	}, config.ApplicationsConfig{
+		Applications: map[string]*config.Application{
+			// Representable custom app: valid protocol + valid u16 port.
+			"web-8080": {Name: "web-8080", Protocol: "tcp", DestinationPort: "8080"},
+		},
+	})
+
+	// Matches junos-http (tcp/80) from the trust-net source.
+	res := Match(cfg, Query{
+		FromZone: "trust", ToZone: "untrust", Protocol: "tcp",
+		SrcIP: net.ParseIP("10.0.1.5"), DstPort: 80,
+	})
+	if res.ContentRejected {
+		t.Fatalf("ContentRejected = true for a fully-representable config (over-report); reasons=%v", res.ContentRejectionReasons)
+	}
+	if !res.Matched || res.Action != config.PolicyPermit || res.PolicyName != "allow-web" {
+		t.Fatalf("healthy config did not report its real permit verdict: Matched=%v Action=%v Name=%q", res.Matched, res.Action, res.PolicyName)
+	}
+
+	// The representable custom app also matches on tcp/8080 (no over-narrowing).
+	res = Match(cfg, Query{
+		FromZone: "trust", ToZone: "untrust", Protocol: "tcp",
+		SrcIP: net.ParseIP("10.0.1.5"), DstPort: 8080,
+	})
+	if res.ContentRejected {
+		t.Fatalf("ContentRejected = true for a representable custom-port app (over-report); reasons=%v", res.ContentRejectionReasons)
+	}
+	if !res.Matched || res.Action != config.PolicyPermit {
+		t.Fatalf("representable custom app tcp/8080 did not match: res = %+v", res)
+	}
+}

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -711,22 +711,24 @@ func Match(cfg *config.Config, q Query) Result {
 		return Result{DefaultUsed: true, Action: config.PolicyDeny}
 	}
 
-	// #3727: the runtime snapshot builder fails the WHOLE snapshot closed when
-	// any policy references an application-set that cannot be expanded — the
-	// builder (pkg/dataplane/userspace expandUserspacePolicyApplications ->
-	// resolveUserspaceApplicationNames) emits the reserved __unsupported__
-	// sentinel term, which the helper integrity preflight rejects
-	// (SnapshotIntegrityError), so the dataplane retains its previous-good
-	// snapshot or fresh-boots default-deny and enforces none of this config.
-	// matchApp used to SILENTLY SKIP the malformed set (`continue`) and fall
-	// through to a later rule / default-policy, so the simulator reported a
-	// permit/deny/default verdict the dataplane never certifies — under a
-	// default-permit it under-reported a fail-closed config as PERMIT. Detect the
-	// same fail-closed condition up front, config-wide (mirroring the
-	// whole-snapshot rejection), BEFORE any per-tier / host-gate evaluation, so
-	// every query for the config reports the runtime's retention rather than a
-	// fabricated answer.
-	if reasons := policyContentRejectionReasons(cfg); len(reasons) > 0 {
+	// #3727/#4394: the runtime snapshot builder fails the WHOLE snapshot closed
+	// when any policy references content the userspace matcher cannot represent —
+	// an unexpandable application-set (#3727), a protocol-less application, an
+	// unrepresentable protocol/port, an undefined application reference, or an
+	// unresolvable address (#4394). In every such case the builder poisons the
+	// rule with the reserved __unsupported__ / __unsupported_address__ sentinel
+	// (or the app-catalog build errors), which the helper integrity preflight
+	// rejects (SnapshotIntegrityError), so the dataplane retains its
+	// previous-good snapshot or fresh-boots default-deny and enforces NONE of
+	// this config. matchApp/matchAddr used to SILENTLY SKIP the unrepresentable
+	// term (a per-term no-match) and fall through to a later rule / default-policy,
+	// so the simulator reported a permit/deny/default verdict the dataplane never
+	// certifies — under a default-permit it under-reported a fail-closed config as
+	// PERMIT. Detect the same fail-closed set up front, config-wide (the shared
+	// dpuserspace.PolicyContentRejectionReasons SSOT, feed-aware via q.FeedOverlay),
+	// BEFORE any per-tier / host-gate evaluation, so every query for the config
+	// reports the runtime's retention rather than a fabricated answer.
+	if reasons := policyContentRejectionReasons(cfg, q.FeedOverlay); len(reasons) > 0 {
 		return Result{ContentRejected: true, ContentRejectionReasons: reasons, Action: config.PolicyDeny}
 	}
 
@@ -1326,109 +1328,33 @@ func expandBookName(cfg *config.Config, overlay map[string][]string, name string
 // protocol IS supplied, matchSingleApp constrains by protocol (and ICMP
 // type/code for a type-constrained term) exactly as before; a non-empty but
 // UNRESOLVABLE protocol fails closed for every protocol-constrained app term.
-// policyContentRejectionReasons detects the config-level condition under which
-// the userspace snapshot builder fails the WHOLE snapshot closed because a
-// policy references an application-SET that cannot be expanded (#3727). Two
-// runtime paths fail closed on the SAME malformed set, so the dataplane never
-// enforces the config:
+// policyContentRejectionReasons detects the config-level conditions under which
+// the userspace snapshot builder fails the WHOLE snapshot closed and enforces
+// NONE of the config, so the simulator must report that fail-closed retention
+// rather than a fabricated permit/deny/default verdict. It delegates to the
+// shared dpuserspace.PolicyContentRejectionReasons SSOT (the exact detection
+// buildSnapshot uses), covering every fail-closed policy-content axis:
 //
-//   - the app catalog builder (pkg/appid BuildCatalog, consumed by
-//     buildAppCatalogSnapshot) returns an ExpandApplicationSet error, so
-//     buildSnapshot itself returns an error and the apply path retains the prior
-//     dataplane state (#3438);
-//   - the policy snapshot builder (pkg/dataplane/userspace
-//     expandUserspacePolicyApplications -> resolveUserspaceApplicationNames)
-//     poisons the rule with the reserved __unsupported__ sentinel term, which
-//     the helper integrity preflight rejects (SnapshotIntegrityError), so the
-//     helper keeps its previous-good snapshot or fresh-boots default-deny
-//     (#3261).
+//   - an unexpandable application-SET (#3727) — the app catalog build errors
+//     (order-insensitive, so `[ any bad-set ]` is caught too) OR the per-rule
+//     application expansion poisons the rule with the __unsupported__ sentinel;
+//   - a protocol-less application (#3323) — proto == "" is unrepresentable;
+//   - an unrepresentable protocol/port (#2124/#4345) — appid.ProtocolNumber /
+//     userspacePortSpecRepresentable rejects it;
+//   - an undefined application reference — resolveUserspaceApplicationNames fails;
+//   - an unresolvable address (#3261) — an undefined address-book / prefix-list
+//     name, or a defined book/set whose value is a non-literal dns-name /
+//     wildcard / range (or resolves to no concrete prefix), poisons the rule
+//     with the __unsupported_address__ sentinel.
 //
-// Either way the config is NEVER enforced, so the simulator must report the
-// fail-closed retention rather than the silent-skip-then-fall-through verdict
-// matchApp's old `continue` fabricated. Every zone-pair and global policy is
-// scanned (regardless of scheduler state — the runtime builds and expands every
-// rule's applications) because the runtime fails the ENTIRE snapshot on the
-// first unrepresentable rule; a single malformed set anywhere makes every
-// verdict for the config fail-closed, not just a query that would hit the bad
-// rule.
-//
-// SCOPE: only the application-SET expansion ERROR — the #3727 gap. A
-// protocol-less member app (#3323), an unrepresentable protocol/port (#2124),
-// or a bare undefined application NAME (a term-level matchSingleApp no-match)
-// still expand a set fine, so they are NOT flagged here and keep their existing
-// simulator behavior; those are separate, already-decided axes.
-func policyContentRejectionReasons(cfg *config.Config) []string {
-	var reasons []string
-	scan := func(scope string, apps []string) {
-		if reason, bad := appSetExpansionRejects(cfg, apps); bad {
-			reasons = append(reasons, fmt.Sprintf(
-				"policy %s names content the userspace matcher cannot represent: %s", scope, reason))
-		}
-	}
-	for _, zpp := range cfg.Security.Policies {
-		if zpp == nil {
-			continue
-		}
-		for _, pol := range zpp.Policies {
-			if pol == nil {
-				continue
-			}
-			scan(fmt.Sprintf("%s->%s/%s", zpp.FromZone, zpp.ToZone, pol.Name), pol.Match.Applications)
-		}
-	}
-	for _, pol := range cfg.Security.GlobalPolicies {
-		if pol == nil {
-			continue
-		}
-		scan(globalPolicyRejectionScope(pol), pol.Match.Applications)
-	}
-	return reasons
-}
-
-// appSetExpansionRejects reports whether the runtime would fail this policy's
-// application list closed because it names an application-set that
-// ExpandApplicationSet cannot expand (member-not-found, nesting-too-deep, or a
-// missing set) (#3727). The detection is ORDER-INSENSITIVE, mirroring the
-// dominant runtime fail-close: pkg/appid BuildCatalog walks EVERY application
-// token and errors on the first unexpandable set regardless of any `any`/empty
-// token in the list (an `any` token is simply skipped for that reference, it
-// does NOT short-circuit the rule), so buildSnapshot returns an error and the
-// dataplane retains the prior state for BOTH `[ bad-set any ]` (the M01 shape,
-// where the simulator previously returned a confident positive match) AND
-// `[ any bad-set ]`. A token that is not an application-set is left to the
-// unchanged bare-application path (matchSingleApp). A well-formed set that
-// expands cleanly is never flagged.
-func appSetExpansionRejects(cfg *config.Config, apps []string) (string, bool) {
-	for _, a := range apps {
-		if _, isSet := cfg.Applications.ApplicationSets[a]; !isSet {
-			continue
-		}
-		if _, err := config.ExpandApplicationSet(a, &cfg.Applications); err != nil {
-			return fmt.Sprintf("application-set %q cannot be expanded: %v", a, err), true
-		}
-	}
-	return "", false
-}
-
-// globalPolicyRejectionScope renders the scope-qualified identity of a global
-// policy for a #3727 content-rejection reason, mirroring the userspace builder's
-// policyRejectionScope: "global/<name>", or "global(<from>-><to>)/<name>" when
-// the policy carries a `match from-zone`/`match to-zone` scope (empty rendered
-// as "any"). The bare name alone is ambiguous because duplicate policy names
-// across scopes are legal.
-func globalPolicyRejectionScope(pol *config.Policy) string {
-	if pol.Match.FromZone != "" || pol.Match.ToZone != "" {
-		from := pol.Match.FromZone
-		if from == "" {
-			from = "any"
-		}
-		to := pol.Match.ToZone
-		if to == "" {
-			to = "any"
-		}
-		return fmt.Sprintf("global(%s->%s)/%s", from, to, pol.Name)
-	}
-	return fmt.Sprintf("global/%s", pol.Name)
+// A single unrepresentable rule anywhere fails the ENTIRE snapshot closed, so
+// every query for the config reports the fail-closed verdict, not just one that
+// would hit the offending rule. The detection is feed-aware (feedOverlay): a
+// healthy dynamic-address feed policy resolves through the overlay and is not
+// falsely flagged — callers pass q.FeedOverlay, the same overlay the production
+// builder uses, so the simulator agrees with the helper on feed-backed names.
+func policyContentRejectionReasons(cfg *config.Config, feedOverlay map[string][]string) []string {
+	return dpuserspace.PolicyContentRejectionReasons(cfg, feedOverlay)
 }
 
 func matchApp(cfg *config.Config, apps []string, proto string, srcPort, dstPort int, icmpType, icmpCode *uint8) bool {
@@ -1480,20 +1406,24 @@ func matchSingleApp(cfg *config.Config, appName string, queryProto uint8, queryP
 	// ("89"/"ospf") and a named/numeric query protocol agree (the old EqualFold
 	// string compare failed "89" vs "ospf").
 	//
-	// #3323: a protocol-less named app is NOT match-any — it fails closed. The
-	// dataplane cannot represent such an app and never enforces it: the snapshot
-	// builder fails closed (deriveUserspaceCapabilities,
+	// #3323/#4394: a protocol-less named app is NOT match-any — it fails closed.
+	// The dataplane cannot represent such an app and never enforces it: the
+	// snapshot builder fails closed (deriveUserspaceCapabilities,
 	// pkg/dataplane/userspace/capabilities.go returns ok=false for proto=="" →
 	// the reserved __unsupported__ sentinel → whole-snapshot reject, #3261) and
 	// strict commit hard-rejects it (pkg/config/compiler_validate_strict.go:
 	// "cannot represent a protocol-less application"). A protocol-less named app
 	// can therefore only exist via a lenient/HA-loaded config, where the runtime
-	// STILL never enforces it; reporting it as a concrete match-any would
-	// over-report vs the runtime — the exact simulator divergence #3323 closes.
-	// appid.ProtocolNumber("") is (0,false), so an empty app.Protocol makes appOK
-	// false and the term fails closed. The literal `application any` token never
-	// reaches matchSingleApp (matchApp short-circuits a == "any"), so this does
-	// not affect the genuine match-any case.
+	// STILL never enforces it. #4394: Match now gates a protocol-less CONFIG app
+	// as a config-wide ContentRejected (the whole-snapshot fail-close) BEFORE any
+	// rule is evaluated, so this per-term guard is unreachable for a config with a
+	// protocol-less app — it is kept defensive so that even if the config-wide
+	// gate were bypassed, reporting the app as a concrete match-any (which the
+	// dataplane never produces) can never happen. appid.ProtocolNumber("") is
+	// (0,false), so an empty app.Protocol makes appOK false and the term fails
+	// closed. The literal `application any` token never reaches matchSingleApp
+	// (matchApp short-circuits a == "any"), so this does not affect the genuine
+	// match-any case.
 	appProto, appOK := appid.ProtocolNumber(app.Protocol)
 	if !appOK || !queryProtoOK || appProto != queryProto {
 		return false

--- a/pkg/policymatch/protocol_omitted_3323_test.go
+++ b/pkg/policymatch/protocol_omitted_3323_test.go
@@ -84,21 +84,29 @@ func TestProtoConstrainedAppWrongProtoNoMatch(t *testing.T) {
 
 // TestProtocolLessNamedAppNeverMatches pins the parity contract for a NAMED
 // application that carries NO protocol. The dataplane cannot represent such an
-// app and never enforces it: the snapshot builder fails closed
-// (deriveUserspaceCapabilities, pkg/dataplane/userspace/capabilities.go returns
-// ok=false for proto=="" → the __unsupported__ sentinel → whole-snapshot reject,
-// #3261) and strict commit hard-rejects it
+// app and never enforces it: the snapshot builder fails the WHOLE snapshot
+// closed (expandUserspacePolicyApplications returns ok=false for proto=="" →
+// the __unsupported__ sentinel → the Rust integrity preflight rejects the whole
+// snapshot, #3261/#3323) and strict commit hard-rejects it
 // (pkg/config/compiler_validate_strict.go). A protocol-less named app can only
-// exist via a lenient/HA-loaded config, where the runtime STILL never enforces
-// it. The simulator must therefore NOT report it as a concrete match — reporting
-// a match-any the dataplane would never produce is the simulator-vs-runtime
-// divergence #3323 is about. It must fall through to the configured
-// default-policy, EVEN when the query supplies a concrete protocol (the app is
-// unrepresentable regardless of the query).
+// exist via a lenient/HA-loaded config, where the runtime retains its
+// previous-good snapshot (or fresh-boots default-deny) and enforces NONE of the
+// config.
 //
-// FAIL-ON-REVERT: restoring the `if app.Protocol != "" { ... }` guard (skipping
-// the protocol gate for an empty app.Protocol) makes a protocol-less named app
-// match-any (Matched=true, permit), failing the want-default-deny assertions.
+// #4394: the simulator must therefore report ContentRejected — NOT a fabricated
+// default-policy verdict. The pre-#4394 simulator fell through to the configured
+// default-policy (a "default verdict"), which is itself a divergence: under a
+// default-PERMIT it would report PERMIT for a config the dataplane fail-closes,
+// and under a default-DENY that retained a previous-good PERMIT snapshot it
+// would report DENY while the dataplane still PERMITS. The config-wide
+// ContentRejected gate mirrors the whole-snapshot fail-close for EVERY query,
+// with or without a concrete query protocol (the app is unrepresentable
+// regardless of the query).
+//
+// FAIL-ON-REVERT: dropping the #4394 config-wide gate (or the
+// dpuserspace.PolicyContentRejectionReasons detection of proto=="") makes the
+// protocol-less named app fall through to default-deny (DefaultUsed=true,
+// ContentRejected=false), failing the want-ContentRejected assertions.
 func TestProtocolLessNamedAppNeverMatches(t *testing.T) {
 	sec := config.SecurityConfig{
 		DefaultPolicy: config.PolicyDeny,
@@ -129,23 +137,23 @@ func TestProtocolLessNamedAppNeverMatches(t *testing.T) {
 	}
 	cfg := cfgWith(sec, apps)
 
-	// Omitted query protocol: must not match.
+	// Omitted query protocol: the whole config is content-rejected.
 	res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust"})
-	if res.Matched {
-		t.Fatalf("protocol-less named app matched an omitted query protocol; res = %+v", res)
+	if !res.ContentRejected {
+		t.Fatalf("want ContentRejected for a protocol-less named app (dataplane fails the snapshot closed), got %+v", res)
 	}
-	if !res.DefaultUsed || res.Action != config.PolicyDeny {
-		t.Fatalf("want default-policy deny for a protocol-less named app, got %+v", res)
+	if res.Matched || res.DefaultUsed {
+		t.Fatalf("Matched=%v DefaultUsed=%v, want both false for a ContentRejected verdict; res = %+v", res.Matched, res.DefaultUsed, res)
 	}
 
-	// Concrete query protocol: still must not match — the app is unrepresentable
-	// regardless of the query, mirroring the dataplane reject.
+	// Concrete query protocol: still ContentRejected — the app is unrepresentable
+	// regardless of the query, mirroring the whole-snapshot dataplane reject.
 	res = Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 80})
-	if res.Matched {
-		t.Fatalf("protocol-less named app matched a concrete query (dataplane rejects it); res = %+v", res)
+	if !res.ContentRejected {
+		t.Fatalf("want ContentRejected for a protocol-less named app with a concrete query, got %+v", res)
 	}
-	if !res.DefaultUsed || res.Action != config.PolicyDeny {
-		t.Fatalf("want default-policy deny for a protocol-less named app, got %+v", res)
+	if res.Matched || res.DefaultUsed {
+		t.Fatalf("Matched=%v DefaultUsed=%v, want both false for a ContentRejected verdict; res = %+v", res.Matched, res.DefaultUsed, res)
 	}
 }
 


### PR DESCRIPTION
## Summary

The `request security match-policies` simulator (`pkg/policymatch`) only detected content-rejection for an UNEXPANDABLE application-set (#3727). The dataplane (`userspace-dp/src/policy.rs`) ALSO fails the WHOLE snapshot CLOSED — retaining its previous-good snapshot or fresh-booting default-deny and enforcing NONE of the config — on four more conditions: a **protocol-less application**, an **unrepresentable protocol/port**, an **undefined application reference**, and an **unresolvable address**. In those cases the pre-fix simulator skipped the term (a per-term no-match) and fell through to a later rule / the configured default-policy, FABRICATING a permit/deny/default verdict the dataplane never enforces. Under a default-permit it answered PERMIT while the dataplane denies fail-closed → the operator was misled.

## Fix

Extend the simulator's config-wide `ContentRejected` gate to the full fail-closed set by reusing the dataplane as the single source of truth (the #4352 host-inbound SSOT pattern):

- New exported `dpuserspace.PolicyContentRejectionReasons(cfg, feedOverlay)` reproduces `buildSnapshot`'s exact policy-content fail-close paths:
  - **per-rule sentinels** (`collectPolicyContentRejections` over the BUILT rules) — `expandUserspacePolicyApplications` returns `ok=false` for a protocol-less app (`proto==""`, #3323), an unrepresentable protocol/port (`appid.ProtocolNumber` / `userspacePortSpecRepresentable`, #2124/#4345), or an undefined application, poisoning the rule with `__unsupported__`; and `addrRepresentable` false for an undefined address-book / prefix-list name or a non-literal book value, poisoning it with `__unsupported_address__` (#3261). The Rust integrity preflight rejects both.
  - **app-catalog build** (`buildAppCatalogSnapshot`) — order-insensitive, so a `[ any bad-set ]` policy the per-rule scan misses (it short-circuits a leading `any`) still fails closed. Consulted only when the per-rule scan is empty, so a bad set already named with a scoped reason is not double-reported.
- `policymatch`'s app-set-only `policyContentRejectionReasons` becomes a thin delegate that threads `q.FeedOverlay`, so a healthy dynamic-address feed policy resolves through the overlay and is NOT falsely flagged. Detection is feed-aware and config-wide (a single unrepresentable rule content-rejects EVERY query, mirroring the whole-snapshot reject).

### Each extended condition mapped to the dataplane fail-close it mirrors
| Simulator condition | policy.rs fail-close |
|---|---|
| protocol-less app (`proto==""`) | `UnrepresentableApplicationProtocol` (`__unsupported__`) |
| unrepresentable protocol/port | `UnrepresentableApplicationProtocol` (`__unsupported__`) |
| undefined application ref | `UnrepresentableApplicationProtocol` (`__unsupported__`) |
| unresolvable address | `UnrepresentableAddress` (`__unsupported_address__`) |
| unexpandable application-set (#3727, retained) | catalog build error + `__unsupported__` |

### Latent parity gap fixed
The Go `addrRepresentable` gate omitted the Junos `any-ipv4` / `any-ipv6` keywords (it listed only the internal `any4` / `any6`), which the Rust matcher accepts as family wildcards (`policy.rs parse_v3_literal_set`). A committed config normalizes them to `0.0.0.0/0` // `::/0`, but a lenient / HA-synced / hand-built snapshot can carry them raw, where the Go gate would emit a spurious `__unsupported_address__` sentinel the Rust side would never produce (also surfaced as a false `ContentRejected` in the simulator). Added them to the accepted set.

## Tests
- `content_reject_4394_test.go` — RED-on-revert for all four extended axes + a whole-config-poison case + a **no-over-report** control (a fully-representable config still reports its real permit verdict). Neutralizing the gate reverts each condition to a fabricated permit/default (and the poison case to a positive `clean-http` match).
- `TestProtocolLessNamedAppNeverMatches` (#3323) flipped from a fabricated default-deny to `ContentRejected` — the behavior #4394 mandates.
- `go test ./pkg/policymatch/... ./pkg/cli/... ./pkg/grpcapi/... ./pkg/dataplane/userspace/... ./pkg/api/...` green; `go build ./...`, `gofmt`, `go vet` clean. Go-only, no cargo.

Closes #4394

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi