### PR TITLE
nat: reserve a peer-synced session's NAT pool port on the standby (#4388)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,45 @@
+## 2026-07-06 — #4388: reserve a peer-synced session's NAT pool port on the standby
+
+- **Timestamp**: 2026-07-06
+- **Action**: A peer-synced session installed on the HA standby did NOT reserve
+  its pool-mode source-NAT translated port in the standby's LOCAL allocator. The
+  active node allocates the pool port (`allocate_translation`) and syncs the
+  finished NAT decision; the standby imports the decision but never calls
+  `allocate_translation`, so its allocator had no record the `(pool_addr, port)`
+  was in use. Post-failover a fresh local flow could reuse that exact
+  `(pool_addr, port)` — two sessions colliding on one NAT source tuple (reply
+  mis-delivery / session-hijack surface). Fix: added
+  `PortAllocator::reserve_flow` (`nat/allocator.rs`) which marks a specific
+  `(ip, port)` owned for a flow WITHOUT running the round-robin cursor, storing
+  the same `owner_by_translated` / `addr_index_by_translated` / `live_by_flow`
+  state a normal allocation writes; and `reserve_synced_source_nat_allocation`
+  (`nat/source.rs`) which mirrors `release_source_nat_allocation`'s flow-key /
+  translated-tuple construction so the EXISTING teardown
+  (`release_source_nat_allocation` on reap / delete-sync / purge) frees it with
+  the same key — no new delete path. Reserve is called from `handle_upsert_synced`
+  (forward, peer-synced entries with a translated source port only); the delete
+  release was wired into `handle_delete_synced` (added a `forwarding` param).
+  Config-drift edge (synced pool addr not in any local pool) is skipped
+  gracefully; reverse entries / no-NAT / address-only reserve nothing;
+  idempotent on refresh (allocator is process-global via Arc). The #3122
+  origin-agnostic session-count invariant is untouched (no `install.rs` change).
+  RED-on-revert Rust tests: a synced session reserves its port so a new local
+  allocation skips it (returns 10001 not the reserved 10000); delete releases it
+  (reusable); no-NAT / foreign-pool / reverse reserve nothing. Full cargo serial:
+  nat:: + session:: subset pass; overall 3633 + 54 + 8 + 22 + 1 passed / 0
+  failed, 2 ignored. RUST (userspace-dp) — cargo. HA post-failover NAT-pool
+  collision — parent runs `make test-failover` (a NAT-pool session synced across
+  failover, then a new session must NOT reuse the synced port) before merge.
+  Composes with #4393 (dnat_table sync) as the same synced-install-incompleteness
+  class.
+- **File(s)**: userspace-dp/src/nat/allocator.rs,
+  userspace-dp/src/nat/source.rs, userspace-dp/src/nat/mod.rs,
+  userspace-dp/src/nat/tests.rs, userspace-dp/src/afxdp/mod.rs,
+  userspace-dp/src/afxdp/session_glue/commands/upsert_synced.rs,
+  userspace-dp/src/afxdp/session_glue/commands/delete_synced.rs,
+  userspace-dp/src/afxdp/session_glue/mod.rs,
+  docs/session-sync-architecture.md, _Log.md
+
 ## 2026-07-06 — #4378: confirm pending commit-confirmed on RG0 demotion
 
 - **Timestamp**: 2026-07-06

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -316,6 +316,41 @@ follow-up.
 
 ## Userspace Session Integration
 
+### NAT Pool Port Reservation for Synced Sessions (#4388)
+
+When the helper installs a peer-synced session that carries a pool-mode
+source-NAT translation, it **reserves** the translated `(pool_addr, port)` in
+this node's LOCAL source-NAT allocator. The active node picks the pool port via
+`allocate_translation` and syncs the completed NAT decision over the fabric; the
+standby imports that pre-computed decision and never runs `allocate_translation`
+itself, so without an explicit reservation its allocator has no record that the
+port is in use. Post-failover the standby-turned-active would then hand the SAME
+`(pool_addr, port)` to a fresh local flow — two sessions colliding on one NAT
+source tuple (reply mis-delivery / a session-hijack surface).
+
+- **Reserve site:** `handle_upsert_synced`
+  (`afxdp/session_glue/commands/upsert_synced.rs`) calls
+  `reserve_synced_source_nat_allocation` (`nat/source.rs`) for every forward,
+  peer-synced entry that carries `rewrite_src` + `rewrite_src_port`. It resolves
+  the pool address to its allocator index and marks the port owned via
+  `PortAllocator::reserve_flow` (`nat/allocator.rs`) — the same
+  `owner_by_translated` / `addr_index_by_translated` / `live_by_flow` state a
+  normal allocation writes, keyed by the synced session's flow. The sequential
+  port cursor (`claim_free_port_locked`) then skips the reserved port, exactly
+  as it already skips a live local allocation (#3047 forward-probe).
+- **Release site:** the reservation uses the synced flow key, so the standard
+  teardown — `release_source_nat_allocation`, already called on GC reap
+  (`reap_expired_sessions`), on a peer delete-sync (`handle_delete_synced`), and
+  on DSCP-filter purge — frees it with no new delete path. A reverse synced
+  entry, an address-only / `port no-translation` decision, or a session with no
+  source NAT reserves nothing.
+- **Config-drift edge:** if the synced pool address is not a member of any local
+  pool (the two nodes' pool config diverged), the reserve is skipped gracefully
+  — never a panic, never a reservation on the wrong pool.
+- **Idempotent:** re-reserving the same synced flow on a refresh is a no-op; the
+  allocator is process-global (`Arc<PortAllocatorShared>`), so the reservation
+  is visible to every worker regardless of which one imported the session.
+
 ### Event Stream (Primary Path)
 
 The Rust helper pushes session events over a persistent binary-framed Unix

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::nat::{
     DnatTable, NatDecision, SourceNatFailure, SourceNatLookup, SourceNatRule, StaticNatTable,
     match_source_nat, parse_source_nat_rules_with_previous, release_source_nat_allocation,
-    rollback_source_nat_allocation,
+    reserve_synced_source_nat_allocation, rollback_source_nat_allocation,
 };
 use crate::nat64::{Nat64ReverseInfo, Nat64State};
 use crate::nptv6::Nptv6State;

--- a/userspace-dp/src/afxdp/session_glue/commands/delete_synced.rs
+++ b/userspace-dp/src/afxdp/session_glue/commands/delete_synced.rs
@@ -9,12 +9,26 @@ use super::super::*;
 pub(in crate::afxdp::session_glue) fn handle_delete_synced(
     sessions: &mut SessionTable,
     session_map_fd: c_int,
+    forwarding: &ForwardingState,
     key: SessionKey,
     now_ns: u64,
 ) {
     let delete_alias = sessions.lookup(&key, now_ns, 0);
     sessions.delete(&key);
     if let Some(lookup) = delete_alias {
+        // #4388: release the NAT pool port reserved for this peer-synced
+        // session at install (`handle_upsert_synced` /
+        // `reserve_synced_source_nat_allocation`) so the standby's local
+        // allocator can reuse it. This is the same-key mirror of the
+        // reservation and a no-op for a non-pool / non-reserved session
+        // (`release_flow` returns false when the flow was never tracked).
+        release_source_nat_allocation(
+            &forwarding.source_nat_rules,
+            &key,
+            lookup.decision.nat,
+            lookup.metadata.is_reverse,
+            now_ns,
+        );
         delete_session_map_entry_for_removed_session(
             session_map_fd,
             &key,

--- a/userspace-dp/src/afxdp/session_glue/commands/upsert_synced.rs
+++ b/userspace-dp/src/afxdp/session_glue/commands/upsert_synced.rs
@@ -74,6 +74,24 @@ pub(in crate::afxdp::session_glue) fn handle_upsert_synced(
         },
         allow_replace_local,
     ) {
+        // #4388: reserve the synced session's translated NAT pool port in this
+        // node's LOCAL source-NAT allocator. The standby imports the active
+        // node's pre-computed NAT decision but never runs `allocate_translation`,
+        // so without this its allocator does not know `(pool_addr, port)` is in
+        // use — post-failover a new local flow could reuse it, colliding two
+        // sessions on one NAT source tuple. Only forward, peer-synced entries
+        // reserve (a reverse entry carries the destination rewrite, not the
+        // pool source port; a local-origin entry already allocated its port on
+        // the active path). The reservation is freed by the standard teardown
+        // (`release_source_nat_allocation`) on reap or delete-sync.
+        if entry.origin.is_peer_synced() && !metadata.is_reverse {
+            reserve_synced_source_nat_allocation(
+                &forwarding.source_nat_rules,
+                &key,
+                entry.decision.nat,
+                metadata.is_reverse,
+            );
+        }
         publish_worker_session_map_entry(
             session_map_fd,
             forwarding,

--- a/userspace-dp/src/afxdp/session_glue/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/mod.rs
@@ -693,7 +693,7 @@ pub(super) fn apply_worker_commands(
                 let _ = installed;
             }
             WorkerCommand::DeleteSynced(key) => {
-                commands::handle_delete_synced(sessions, session_map_fd, key, now_ns);
+                commands::handle_delete_synced(sessions, session_map_fd, forwarding, key, now_ns);
             }
             WorkerCommand::EnqueueShapedLocal(req) => {
                 // Trivial variant — kept inline (#1346 plan v2 §4.1).

--- a/userspace-dp/src/nat/allocator.rs
+++ b/userspace-dp/src/nat/allocator.rs
@@ -696,6 +696,75 @@ impl PortAllocator {
         true
     }
 
+    /// #4388: reserve a SPECIFIC translated `(ip, port)` for `flow` WITHOUT
+    /// running the round-robin allocator, so a peer-synced session's NAT pool
+    /// port is marked allocated in this node's LOCAL allocator. Without this,
+    /// the standby never learns that the active node handed `(pool_ip, port)`
+    /// to a synced session (the standby imports the pre-computed NAT decision;
+    /// it never calls `allocate_translation`), so post-failover a fresh local
+    /// flow could `allocate_translation` the SAME `(pool_ip, port)` — two
+    /// sessions colliding on one NAT source tuple (reply mis-delivery / session
+    /// hijack surface).
+    ///
+    /// The reservation is stored EXACTLY like a normal allocation
+    /// (`owner_by_translated` + `addr_index_by_translated` + `live_by_flow`)
+    /// using the synced session's flow key, so:
+    ///   - `claim_free_port_locked` skips the port when the sequential cursor
+    ///     later reaches it (the #3047 forward-probe), and
+    ///   - the EXISTING teardown path (`release_flow` / `rollback_flow` via
+    ///     `release_source_nat_allocation`, already called for every reaped or
+    ///     delete-synced session) frees it with the SAME flow key — no new
+    ///     release site is needed.
+    ///
+    /// Idempotent: re-reserving the same `(flow, translated)` (a synced-session
+    /// refresh) is a no-op that returns `true`. Returns `false` and leaves the
+    /// incumbent untouched if the port is already owned by a DIFFERENT live
+    /// allocation (a local flow raced ahead of the sync on the standby) — the
+    /// caller then tries the next pool rule.
+    pub(super) fn reserve_flow(
+        &self,
+        flow: SourceNatFlowKey,
+        translated: TranslatedTuple,
+        addr_index: usize,
+    ) -> bool {
+        if addr_index >= self.shared.counters.len() {
+            return false;
+        }
+        let mut live = self.shared.live.lock().unwrap_or_else(|e| e.into_inner());
+        // A refresh of the same synced flow: if it already holds this exact
+        // translated tuple, it is reserved — nothing to do. If the tuple
+        // changed (should not happen on a stable sync), drop the stale
+        // reservation first so we do not leak the old port's owner slot.
+        if let Some(existing) = live.live_by_flow.get(&flow).copied() {
+            if existing.translated == translated {
+                return true;
+            }
+            live.live_by_flow.remove(&flow);
+            self.release_translated_locked(&mut live, existing.translated);
+        }
+        // Never steal a port owned by a DIFFERENT live allocation. The synced
+        // decision is authoritative on the wire, but on a healthy standby the
+        // owning RG is passive so no local flow should hold the port; if one
+        // does, leaving the incumbent (and skipping the reserve) is the safe
+        // choice — the caller falls through to the next rule.
+        if let Some(owner) = live.owner_by_translated.get(&translated)
+            && *owner != AllocationOwner::Flow(flow)
+        {
+            return false;
+        }
+        live.owner_by_translated
+            .insert(translated, AllocationOwner::Flow(flow));
+        live.addr_index_by_translated.insert(translated, addr_index);
+        live.live_by_flow.insert(
+            flow,
+            LiveAllocation {
+                translated,
+                persistent_key: None,
+            },
+        );
+        true
+    }
+
     pub(super) fn snapshot(&self) -> PortAllocatorSnapshot {
         let live = self.shared.live.lock().unwrap_or_else(|e| e.into_inner());
         PortAllocatorSnapshot {

--- a/userspace-dp/src/nat/mod.rs
+++ b/userspace-dp/src/nat/mod.rs
@@ -52,7 +52,7 @@ pub(crate) use source::{
     SourceNatFailure, SourceNatFailureReason, SourceNatFlowKey, SourceNatLookup, SourceNatRule,
     match_source_nat, match_source_nat_result, match_source_nat_result_for_tuple,
     parse_source_nat_rules, parse_source_nat_rules_with_previous, release_source_nat_allocation,
-    rollback_source_nat_allocation,
+    reserve_synced_source_nat_allocation, rollback_source_nat_allocation,
 };
 pub(crate) use static_nat::{StaticNatEntry, StaticNatTable};
 pub(crate) use status::source_nat_pool_statuses;

--- a/userspace-dp/src/nat/source.rs
+++ b/userspace-dp/src/nat/source.rs
@@ -727,6 +727,78 @@ fn release_source_nat_allocation_with_mode(
     }
 }
 
+/// #4388: reserve a peer-synced session's translated pool port in THIS node's
+/// local source-NAT allocator so a post-failover local allocation cannot hand
+/// the same `(pool_addr, port)` to a new flow (NAT source collision / session
+/// hijack surface).
+///
+/// The standby imports the active node's pre-computed NAT decision but never
+/// calls `allocate_translation`, so its allocator has no record that
+/// `(pool_addr, port)` is in use. Mirror `release_source_nat_allocation`'s
+/// flow-key / translated-tuple construction EXACTLY so the same-key
+/// `release_flow` / `rollback_flow` on the standard teardown path
+/// (`release_source_nat_allocation`, already called for every reaped or
+/// delete-synced session) frees the reservation — no new delete site.
+///
+/// A synced session WITHOUT a translated source port (no source NAT, or
+/// address-only / `port no-translation`) reserves nothing. If the synced pool
+/// address is not a member of ANY local pool (config drift between nodes), the
+/// reserve is skipped gracefully — it never panics and never fabricates a
+/// reservation on the wrong pool.
+pub(crate) fn reserve_synced_source_nat_allocation(
+    rules: &[SourceNatRule],
+    key: &crate::session::SessionKey,
+    nat: NatDecision,
+    is_reverse: bool,
+) {
+    if is_reverse {
+        return;
+    }
+    let Some(rewrite_src) = nat.rewrite_src else {
+        return;
+    };
+    let Some(rewrite_src_port) = nat.rewrite_src_port else {
+        return;
+    };
+    let translated = TranslatedTuple {
+        ip: rewrite_src,
+        port: rewrite_src_port,
+    };
+    let flow = SourceNatFlowKey {
+        protocol: key.protocol,
+        src_ip: key.src_ip,
+        dst_ip: nat.rewrite_dst.unwrap_or(key.dst_ip),
+        src_port: key.src_port,
+        dst_port: key.dst_port,
+    };
+    for rule in rules {
+        if !rule.pool_mode {
+            continue;
+        }
+        // The absolute allocator address index mirrors the allocation path:
+        // v4 addresses occupy `[0, len_v4)`, v6 addresses follow at
+        // `[len_v4, len_v4 + len_v6)` (see `address_index` / the v6_offset in
+        // `match_source_nat_result_for_tuple`).
+        let addr_index = match rewrite_src {
+            IpAddr::V4(v4) => rule.pool_addresses_v4.iter().position(|a| *a == v4),
+            IpAddr::V6(v6) => rule
+                .pool_addresses_v6
+                .iter()
+                .position(|a| *a == v6)
+                .map(|i| rule.pool_addresses_v4.len() + i),
+        };
+        let Some(addr_index) = addr_index else {
+            continue;
+        };
+        if rule
+            .pool_allocator
+            .reserve_flow(flow, translated, addr_index)
+        {
+            break;
+        }
+    }
+}
+
 pub(crate) fn match_source_nat(
     rules: &[SourceNatRule],
     scope: &NatScopeCtx,

--- a/userspace-dp/src/nat/tests.rs
+++ b/userspace-dp/src/nat/tests.rs
@@ -5,7 +5,7 @@
 
 use super::allocator::{
     ALLOCATION_GC_BUDGET, NS_PER_SEC, PersistentLease, PersistentSourceKey, PoolAddressFamily,
-    sticky_pool_index,
+    TranslatedTuple, sticky_pool_index,
 };
 use super::source::{PersistentNatPermit, SOURCE_NAT_PROTO_ANY, SourceNatFlowKey};
 use super::destination::{PROTO_ANY, PROTO_TCP, PROTO_UDP};
@@ -8459,4 +8459,227 @@ fn nat_counter_clear_zeroes_when_uncontended_3830() {
     let after = counter.snapshot(42);
     assert_eq!(after.packets, 0, "clear zeroes packets when uncontended");
     assert_eq!(after.bytes, 0, "clear zeroes bytes when uncontended");
+}
+
+// #4388 FAIL-ON-REVERT: a peer-synced session's translated NAT pool port must
+// be RESERVED in the standby's LOCAL source-NAT allocator, so a post-failover
+// local allocation cannot hand the SAME (pool_addr, port) to a new flow — two
+// sessions colliding on one NAT source tuple (reply mis-delivery / session
+// hijack surface).
+//
+// The standby imports the active node's pre-computed NAT decision but never
+// calls `allocate_translation`, so before the fix its allocator had no record
+// that (pool_addr, port) was in use and a fresh local flow reused it. Reverting
+// `reserve_synced_source_nat_allocation` (or its call site at
+// `handle_upsert_synced`) makes the "new flow must NOT get the synced port"
+// assertion RED.
+#[test]
+fn synced_session_reserves_nat_pool_port_4388() {
+    let pool_ip: Ipv4Addr = "203.0.113.1".parse().unwrap();
+    // 2-port pool [10000, 10001] so a single sequential allocation spends the
+    // range and forces the post-release reuse through the recycled queue.
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "pool-snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "my-pool".to_string(),
+        pool_addresses: vec!["203.0.113.1/32".to_string()],
+        port_low: 10000,
+        port_high: 10001,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+
+    // A peer-synced session the active node translated to (203.0.113.1, 10000).
+    let synced_key = session_key_from_src("10.0.61.50", 40000, "8.8.8.8", 443);
+    let synced_nat = NatDecision {
+        rewrite_src: Some(IpAddr::V4(pool_ip)),
+        rewrite_src_port: Some(10000),
+        ..NatDecision::default()
+    };
+
+    reserve_synced_source_nat_allocation(&rules, &synced_key, synced_nat, false);
+
+    // The reservation is visible as an owned translated tuple.
+    {
+        let live = rules[0].pool_allocator.debug_live();
+        assert!(
+            live.addr_index_by_translated
+                .contains_key(&TranslatedTuple {
+                    ip: IpAddr::V4(pool_ip),
+                    port: 10000,
+                }),
+            "synced NAT pool port must be reserved in the local allocator"
+        );
+    }
+
+    // A NEW local flow allocates from the same pool: it MUST skip the reserved
+    // 10000 and hand out 10001. On revert (no reservation) it returns 10000 —
+    // a collision with the still-active synced session.
+    let addrs = rules[0].pool_addresses_v4.clone();
+    let new_flow = SourceNatFlowKey {
+        protocol: 6,
+        src_ip: "10.0.61.51".parse().unwrap(),
+        dst_ip: "8.8.8.8".parse().unwrap(),
+        src_port: 40001,
+        dst_port: 443,
+    };
+    let translated = rules[0]
+        .pool_allocator
+        .allocate_translation(
+            new_flow,
+            PoolAddressFamily::V4(&addrs),
+            0,
+            false,
+            false,
+            PersistentNatPermit::TargetHostPort,
+            0,
+            1_000,
+        )
+        .expect("the second pool port must be available");
+    assert_eq!(
+        translated.port, 10001,
+        "a post-failover local flow must NOT reuse the synced session's \
+         reserved port 10000 (#4388 collision)"
+    );
+
+    // Deleting the synced session releases the reservation (mirror of the
+    // standby teardown: `handle_delete_synced` / reap call
+    // `release_source_nat_allocation`).
+    release_source_nat_allocation(&rules, &synced_key, synced_nat, false, 2_000);
+    {
+        let live = rules[0].pool_allocator.debug_live();
+        assert!(
+            !live
+                .addr_index_by_translated
+                .contains_key(&TranslatedTuple {
+                    ip: IpAddr::V4(pool_ip),
+                    port: 10000,
+                }),
+            "releasing the synced session must free its reserved pool port"
+        );
+    }
+
+    // Prove reusability: with the sequential range spent (10001 taken above),
+    // the next allocation drains the recycled queue and reuses the freed 10000.
+    let reuse_flow = SourceNatFlowKey {
+        protocol: 6,
+        src_ip: "10.0.61.52".parse().unwrap(),
+        dst_ip: "8.8.8.8".parse().unwrap(),
+        src_port: 40002,
+        dst_port: 443,
+    };
+    let reused = rules[0]
+        .pool_allocator
+        .allocate_translation(
+            reuse_flow,
+            PoolAddressFamily::V4(&addrs),
+            0,
+            false,
+            false,
+            PersistentNatPermit::TargetHostPort,
+            0,
+            3_000,
+        )
+        .expect("the freed port must be reusable after release");
+    assert_eq!(
+        reused.port, 10000,
+        "the released synced port must be reusable by a later local flow"
+    );
+}
+
+// #4388: a peer-synced session WITHOUT a source-NAT translation (no
+// rewrite_src / rewrite_src_port — plain forwarding, address-only, or `port
+// no-translation`) reserves nothing. The allocator stays empty and a new flow
+// gets the first pool port.
+#[test]
+fn synced_session_without_nat_reserves_nothing_4388() {
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "pool-snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "my-pool".to_string(),
+        pool_addresses: vec!["203.0.113.1/32".to_string()],
+        port_low: 10000,
+        port_high: 10005,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+
+    let synced_key = session_key_from_src("10.0.61.50", 40000, "8.8.8.8", 443);
+    // No translation carried on the synced decision.
+    reserve_synced_source_nat_allocation(&rules, &synced_key, NatDecision::default(), false);
+
+    let live = rules[0].pool_allocator.debug_live();
+    assert!(
+        live.addr_index_by_translated.is_empty(),
+        "a synced session with no NAT translation must reserve nothing"
+    );
+}
+
+// #4388: if the synced pool address is not a member of ANY local pool (config
+// drift between HA nodes), the reserve is skipped gracefully — no panic,
+// nothing reserved on the wrong pool.
+#[test]
+fn synced_session_foreign_pool_addr_skips_reserve_4388() {
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "pool-snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "my-pool".to_string(),
+        pool_addresses: vec!["203.0.113.1/32".to_string()],
+        port_low: 10000,
+        port_high: 10005,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+
+    let synced_key = session_key_from_src("10.0.61.50", 40000, "8.8.8.8", 443);
+    // 198.51.100.9 is NOT in the local pool (config drift).
+    let foreign_nat = NatDecision {
+        rewrite_src: Some("198.51.100.9".parse().unwrap()),
+        rewrite_src_port: Some(10000),
+        ..NatDecision::default()
+    };
+    reserve_synced_source_nat_allocation(&rules, &synced_key, foreign_nat, false);
+
+    let live = rules[0].pool_allocator.debug_live();
+    assert!(
+        live.addr_index_by_translated.is_empty(),
+        "a synced pool address not in any local pool must not reserve anything"
+    );
+}
+
+// #4388: a peer-synced REVERSE entry carries the destination rewrite, not the
+// pool source port, and must reserve nothing (mirrors the is_reverse guard on
+// the release path). The forward entry alone owns the pool-port reservation.
+#[test]
+fn synced_reverse_entry_reserves_nothing_4388() {
+    let pool_ip: Ipv4Addr = "203.0.113.1".parse().unwrap();
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "pool-snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "my-pool".to_string(),
+        pool_addresses: vec!["203.0.113.1/32".to_string()],
+        port_low: 10000,
+        port_high: 10005,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+
+    let synced_key = session_key_from_src("10.0.61.50", 40000, "8.8.8.8", 443);
+    let synced_nat = NatDecision {
+        rewrite_src: Some(IpAddr::V4(pool_ip)),
+        rewrite_src_port: Some(10000),
+        ..NatDecision::default()
+    };
+    // is_reverse = true: the reserve is a no-op.
+    reserve_synced_source_nat_allocation(&rules, &synced_key, synced_nat, true);
+
+    let live = rules[0].pool_allocator.debug_live();
+    assert!(
+        live.addr_index_by_translated.is_empty(),
+        "a reverse synced entry must not reserve a pool source port"
+    );
 }


### PR DESCRIPTION
## Summary

Fixes #4388 (ps-007 P1 + ps-008 P1, re-confirmed CRITICAL). A peer-synced
session installed on the HA standby did **not** reserve its pool-mode
source-NAT translated port in the standby's LOCAL allocator. The active node
picks the pool port via `allocate_translation` and syncs the finished NAT
decision over the fabric; the standby imports that pre-computed decision and
never runs `allocate_translation` itself, so its allocator had no record that
`(pool_addr, port)` was in use.

**Consequence (post-failover collision):** the standby-turned-active would hand
the SAME `(pool_addr, port)` to a fresh local flow — two sessions colliding on
one NAT source tuple, so the remote host's replies mis-deliver and an attacker
could deliberately create sessions to reuse a synced session's port
(session-hijack surface).

## Fix (standby side)

- **`PortAllocator::reserve_flow`** (`nat/allocator.rs`) — marks a specific
  `(ip, port)` owned for a flow **without** running the round-robin cursor,
  writing the same `owner_by_translated` / `addr_index_by_translated` /
  `live_by_flow` state a normal allocation writes, keyed by the synced session's
  flow. The sequential cursor (`claim_free_port_locked`) then skips the reserved
  port exactly as it already skips a live local allocation (#3047
  forward-probe). Idempotent on refresh; refuses to steal a port owned by a
  different live allocation.
- **`reserve_synced_source_nat_allocation`** (`nat/source.rs`) — mirrors
  `release_source_nat_allocation`'s flow-key / translated-tuple construction, so
  the **existing** teardown path (`release_source_nat_allocation`, already
  called on GC reap, on a peer delete-sync, and on DSCP-filter purge) frees the
  reservation with the same flow key — **no new delete site**. Resolves the pool
  address to its allocator index; if the synced pool address is not a member of
  any local pool (config drift between nodes) the reserve is skipped gracefully.
- **Reserve site:** `handle_upsert_synced` — forward, peer-synced entries with a
  translated source port only. **Release site:** `handle_delete_synced` (gained
  a `forwarding` param) now calls `release_source_nat_allocation`, so a peer
  delete-sync frees the reservation; reap / purge already did.

The allocator is process-global (`Arc<PortAllocatorShared>`), so the reservation
is visible to every worker regardless of which one imported the session. The
#3122 origin-agnostic session-count invariant is untouched (no `install.rs`
change).

## Shared-install-incompleteness class

Composes with #4393 (`dnat_table` sync) — the same synced-install-incompleteness
class. The reserve site here is the helper worker install path
(`handle_upsert_synced`), distinct from the Go-side `dnat_table` recreation.

## Validation

- **RED-on-revert Rust tests** (`nat/tests.rs`): a synced session reserves its
  port so a new local allocation skips it (returns `10001`, not the reserved
  `10000`); delete releases it so a later flow reuses it; no-NAT, foreign-pool,
  and reverse synced entries reserve nothing. Verified RED with the reserve
  neutralized.
- **Full cargo serial** (`cargo test --release -- --test-threads=1`): `nat::`
  and `session::` subsets pass; overall **3633 + 54 + 8 + 22 + 1 passed / 0
  failed**, 2 ignored.
- **HA post-failover behavior** — a NAT-pool session synced across failover,
  then a new session that must **not** reuse the synced port, should be
  exercised by `make test-failover` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi