### PR TITLE
cluster/ipsec: advertise empty IPsec SA set on tunnel-down (#4385)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -37501,3 +37501,30 @@ top.
 - **File(s)**: userspace-dp/src/session/mod.rs,
   userspace-dp/src/session/tests.rs, userspace-dp/src/session/README.md,
   docs/pr/2134-screen-session-limit-enforce/self-review.md, _Log.md
+
+- **Timestamp**: 2026-07-07T01:54Z
+- **Action**: Fix #4385 — IPsec SA sync never advertised the empty set, so an
+  administratively-downed tunnel (active SA set drops to zero) left the standby
+  holding the last non-empty snapshot; on RG0 takeover `reinitiateIPsecSAs`
+  re-initiated the stale names and resurrected the downed tunnel. Root cause:
+  `syncIPsecSAPeriodic` guarded the push with `if len(names) > 0`, suppressing
+  the drop-to-zero advertisement (the standby overwrites `peerIPsecSAs`
+  wholesale, so it never cleared). Fix: extract the push decision into
+  `ipsecSASyncAdvertise(names, lastFP)` — a NON-EMPTY set is advertised every
+  tick (heartbeat re-push; the only mechanism that seeds a reconnected standby,
+  so reconnect-safety is preserved), an EMPTY set is advertised exactly ONCE on
+  the drop-to-zero transition from a previously non-empty set (standby clears
+  its stale peer set), and a steady/never-up empty set is never advertised (no
+  empty-heartbeat churn). `syncIPsecSAPeriodic` keeps a goroutine-local `lastFP`
+  fingerprint (single-instance per comms lifetime). Tests: new pkg/daemon
+  `TestIPsecSASyncAdvertise` (RED-on-revert of the len(names)>0 guard — the
+  downed-tunnel case fails) and pkg/cluster `TestIPsecSAEmptyPushClearsPeer`
+  (empty push clears the receiver's `peerIPsecSAs` + `OnIPsecSAReceived`).
+  Verified RED-on-revert by temporarily restoring the guard (downed-tunnel
+  assertion fails), then restored. go test ./pkg/cluster/... ./pkg/ipsec/...
+  ./pkg/daemon/... green; go build ./...; gofmt + vet clean. HA IPsec SA sync ->
+  parent must run make test-failover before merge (a downed tunnel must NOT
+  resurrect on failover).
+- **File(s)**: pkg/daemon/daemon_ha.go,
+  pkg/daemon/ipsec_sa_sync_empty_4385_test.go, pkg/cluster/sync_test.go,
+  pkg/cluster/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -37528,3 +37528,37 @@ top.
 - **File(s)**: pkg/daemon/daemon_ha.go,
   pkg/daemon/ipsec_sa_sync_empty_4385_test.go, pkg/cluster/sync_test.go,
   pkg/cluster/README.md, _Log.md
+
+- **Timestamp**: 2026-07-06T[fold]Z
+- **Action**: Fold #4385 hostile-review residual (MERGE-NEEDS-MINOR) — the
+  one-shot empty push could be MISSED, leaving a stale set that resurrects the
+  tunnel on takeover across a reconnect gap. Two robustness guards, mirroring
+  the DHCP precedent: (1) CONFIRMED-SEND RETRY — `QueueIPsecSA` now returns
+  whether the frame reached an ACTIVE conn (false on nil/dropped conn); the new
+  `ipsecSANextFP` advances the goroutine-local `lastFP` ONLY on a confirmed
+  send, so a drop-to-zero empty push that no-ops during a reconnect gap leaves
+  `lastFP` non-empty and RETRIES next tick instead of being silently marked
+  sent (the un-fixed advance-on-noop stranded the standby's stale set). (2)
+  PEER-CONNECT RE-ADVERTISE — `OnPeerConnected` nudges the new `ipsecSANudgeCh`
+  (`nudgeIPsecSASync`) and `syncIPsecSAPeriodic` handles it with a FORCED
+  advertise (`advertiseIPsecSAOnce(force=true)` -> `ipsecSASyncAdvertise` force
+  branch) of the current set, empty or not, so a reconnected standby (or a
+  same-process standby that retained its set across a blip) converges
+  immediately instead of waiting up to 30s. Deliberately did NOT clear
+  `peerIPsecSAs` on disconnect — a real primary death (standby never reconnects)
+  must keep the last-known set for `reinitiateIPsecSAs` on takeover; convergence
+  is primary-driven. Verified reconnect-safety BOTH directions (force re-seeds
+  non-empty, force clears empty). Tests: pkg/daemon `TestIPsecSAMissedEmptyRetries`
+  (RED on revert of the confirmed-send gate — `lastFP` wrongly advances to ""
+  and the empty is never retried), `TestIPsecSASyncForceReadvertise` (RED on
+  revert of the force branch), updated `TestIPsecSASyncAdvertise` for the new
+  `force` param; pkg/cluster `TestQueueIPsecSAConfirmedSend` (false on nil conn,
+  true on active conn incl. empty payload). Both reverts verified RED then
+  restored. Master already at branch base (no rebase). go test
+  ./pkg/daemon/... ./pkg/cluster/... ./pkg/ipsec/... green; go build ./...;
+  gofmt + vet clean. HA IPsec SA sync -> parent composes test-failover with
+  #4393 before merge.
+- **File(s)**: pkg/cluster/sync.go, pkg/daemon/daemon.go,
+  pkg/daemon/daemon_ha.go, pkg/daemon/daemon_ha_sync.go,
+  pkg/daemon/ipsec_sa_sync_empty_4385_test.go, pkg/cluster/sync_test.go,
+  pkg/cluster/README.md, _Log.md

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -317,6 +317,29 @@ standby can re-initiate the primary's tunnels on takeover:
   was guarded by `if len(names) > 0`, so a drop-to-zero was never advertised and
   the standby resurrected the downed tunnel on failover. Mirrors the DHCP
   `maybePushFamily` change-detect precedent below.
+- **Reconnect robustness (#4385)** — the one-shot empty push must survive a
+  disconnect gap, so two guards back it:
+  - **Confirmed-send retry.** `QueueIPsecSA` returns whether the frame reached an
+    ACTIVE conn; `ipsecSANextFP` advances `lastFP` ONLY on a confirmed send. An
+    empty advertisement that no-ops on a nil/dropped conn (a drop-to-zero landing
+    during a reconnect gap) leaves `lastFP` non-empty, so it RETRIES next tick
+    instead of being silently marked sent — without this, `lastFP` would advance
+    to empty and the empty would never be re-advertised, stranding the standby's
+    stale set.
+  - **Peer-connect re-advertise.** `OnPeerConnected` nudges `ipsecSANudgeCh`
+    (`nudgeIPsecSASync`), and `syncIPsecSAPeriodic` handles it with a FORCED
+    advertise (`advertiseIPsecSAOnce(force=true)` -> `ipsecSASyncAdvertise` force
+    branch) of the current set, empty or not. A reconnected standby that missed
+    the one-shot empty, or a same-process standby that retained its peer set
+    across a blip, converges immediately (empty -> clears; non-empty ->
+    re-seeds) rather than waiting up to the 30s tick. Mirrors the DHCP
+    peer-connect `nudgeDHCPLeaseSync` (#2239 Q7).
+
+  Note: `peerIPsecSAs` is deliberately NOT cleared on disconnect — a real
+  primary death (the standby never reconnects) must leave the last-known set in
+  place for `reinitiateIPsecSAs` to re-initiate on takeover. Convergence to an
+  empty/updated set is driven by the primary re-advertising, not by the standby
+  self-clearing.
 
 ## DHCP-server lease sync (#2239)
 

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -289,6 +289,35 @@ connection is authenticated, then seals every subsequent frame.
   accept/connect loops retry (~1s) — it never bricks. MUST pass
   `make test-failover` (the path that keeps TCP alive across failover).
 
+## IPsec SA sync
+
+Active IKE/child-SA connection names ride the session-sync channel so the
+standby can re-initiate the primary's tunnels on takeover:
+
+- **Send** — `syncIPsecSAPeriodic` (`pkg/daemon/daemon_ha.go`) runs on the
+  RG0-primary and, every 30s, reads the active set from
+  `ipsec.ActiveConnectionNames()` (live `swanctl --list-sas`) and advertises it
+  via `SessionSync.QueueIPsecSA` (wire type `syncMsgIPsecSA`,
+  `encode/decodeIPsecSAPayload`).
+- **Hold** — the standby stores the peer's set wholesale in `peerIPsecSAs`
+  (`sync_conn.go` overwrites, not merges), readable via `PeerIPsecSAs()`.
+- **Re-initiate on takeover** — `reinitiateIPsecSAs` reads `PeerIPsecSAs()` and
+  `InitiateConnection`s each name when this node becomes RG0-primary.
+- **Empty-set / tunnel-down handling (#4385)** — a NON-EMPTY set is advertised
+  every tick (a heartbeat re-push — the only mechanism that seeds a freshly
+  reconnected/restarted standby, so it must keep pushing even when unchanged).
+  An EMPTY set is advertised exactly ONCE, on the drop-to-zero transition from a
+  previously non-empty set — a tunnel was administratively downed or all its SAs
+  were torn down — so the standby CLEARS its stale `peerIPsecSAs` instead of
+  resurrecting the tunnel on takeover. A steady empty set, INCLUDING a node that
+  never brought an SA up, is never advertised (no empty-heartbeat churn; the
+  standby's default set is already empty). The decision is
+  `ipsecSASyncAdvertise` (goroutine-local `lastFP` fingerprint, empty string =
+  last advertised set was empty / nothing advertised yet). Before #4385 the push
+  was guarded by `if len(names) > 0`, so a drop-to-zero was never advertised and
+  the standby resurrected the downed tunnel on failover. Mirrors the DHCP
+  `maybePushFamily` change-detect precedent below.
+
 ## DHCP-server lease sync (#2239)
 
 DHCP-server (Kea) leases ride the SAME session-sync channel and follow the

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -885,10 +885,18 @@ func (s *SessionSync) PeerIPsecSAs() []string {
 	return cp
 }
 
-func (s *SessionSync) QueueIPsecSA(connectionNames []string) {
+// QueueIPsecSA advertises the active IPsec connection-name set to the peer over
+// the sync channel. It returns whether the frame was actually queued to an
+// ACTIVE connection: false when there is no active conn (nothing sent) or the
+// write failed (conn dropped). The #4385 caller uses this to advance its
+// last-sent fingerprint ONLY on a confirmed send, so a drop-to-zero (empty)
+// advertisement that lands during a reconnect gap is RETRIED on the next tick
+// instead of being silently lost (which would leave the standby holding a stale
+// set that resurrects the tunnel on takeover).
+func (s *SessionSync) QueueIPsecSA(connectionNames []string) bool {
 	conn := s.getActiveConn()
 	if conn == nil {
-		return
+		return false
 	}
 	payload := encodeIPsecSAPayload(connectionNames)
 	s.writeMu.Lock()
@@ -898,10 +906,11 @@ func (s *SessionSync) QueueIPsecSA(connectionNames []string) {
 		slog.Warn("cluster sync: IPsec SA send error", "err", err)
 		s.stats.Errors.Add(1)
 		s.handleDisconnect(conn)
-		return
+		return false
 	}
 	s.stats.IPsecSASent.Add(1)
 	slog.Debug("cluster sync: IPsec SA list sent", "count", len(connectionNames))
+	return true
 }
 
 // RecordDHCPLeasesSeeded adds n to the seeded-leases counter (#2239). The

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -504,6 +504,38 @@ func TestPeerIPsecSAs(t *testing.T) {
 	}
 }
 
+// TestIPsecSAEmptyPushClearsPeer proves the receiver side of the #4385 fix: an
+// empty IPsec SA advertisement (the primary downed a tunnel / all its SAs were
+// torn down) MUST clear the standby's held peer set, so takeover's
+// reinitiateIPsecSAs finds nothing to resurrect. The receiver overwrites the
+// peer set wholesale, so this holds as long as the sender actually emits the
+// empty set (the syncIPsecSAPeriodic decision, tested in pkg/daemon).
+func TestIPsecSAEmptyPushClearsPeer(t *testing.T) {
+	ss := NewSessionSync(":4785", "10.0.0.2:4785", nil)
+
+	var lastReceived []string
+	ss.OnIPsecSAReceived = func(names []string) { lastReceived = names }
+
+	// Primary advertises a live tunnel; the standby records it.
+	ss.handleMessage(nil, syncMsgIPsecSA, encodeIPsecSAPayload([]string{"vpn-a"}))
+	if names := ss.PeerIPsecSAs(); len(names) != 1 || names[0] != "vpn-a" {
+		t.Fatalf("setup: want peer SA [vpn-a], got %v", names)
+	}
+	if len(lastReceived) != 1 {
+		t.Fatalf("setup: OnIPsecSAReceived want 1 name, got %v", lastReceived)
+	}
+
+	// Primary downs the tunnel and advertises the empty set. The standby MUST
+	// clear its peer set so a later takeover does not re-initiate vpn-a.
+	ss.handleMessage(nil, syncMsgIPsecSA, encodeIPsecSAPayload(nil))
+	if names := ss.PeerIPsecSAs(); len(names) != 0 {
+		t.Fatalf("empty push must clear peer SAs, got %v", names)
+	}
+	if len(lastReceived) != 0 {
+		t.Fatalf("empty push: OnIPsecSAReceived want 0 names, got %v", lastReceived)
+	}
+}
+
 func TestSetDataPlane(t *testing.T) {
 	ss := NewSessionSync(":4785", "10.0.0.2:4785", nil)
 	if ss.sessions != nil {

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -536,6 +536,37 @@ func TestIPsecSAEmptyPushClearsPeer(t *testing.T) {
 	}
 }
 
+// TestQueueIPsecSAConfirmedSend pins the #4385 confirmed-send report:
+// QueueIPsecSA returns false when there is no active conn (nothing sent) and
+// true when the frame is written to an active conn. The daemon advances its
+// last-sent fingerprint only on a confirmed send, so a drop-to-zero (empty)
+// advertisement that lands during a reconnect gap is retried instead of lost.
+func TestQueueIPsecSAConfirmedSend(t *testing.T) {
+	ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+
+	// No active conn: both a live-set and an empty advertisement report an
+	// unconfirmed send.
+	if ss.QueueIPsecSA([]string{"vpn-a"}) {
+		t.Fatal("QueueIPsecSA with no active conn must report an unconfirmed send")
+	}
+	if ss.QueueIPsecSA(nil) {
+		t.Fatal("QueueIPsecSA(empty) with no active conn must report an unconfirmed send")
+	}
+
+	// With an active conn the send is confirmed (empty payload included — the
+	// empty-clear must be confirmable).
+	cw := &countingWriter{}
+	ss.mu.Lock()
+	ss.conn0 = cw
+	ss.mu.Unlock()
+	if !ss.QueueIPsecSA([]string{"vpn-a"}) {
+		t.Fatal("QueueIPsecSA with an active conn must report a confirmed send")
+	}
+	if !ss.QueueIPsecSA(nil) {
+		t.Fatal("QueueIPsecSA(empty) with an active conn must report a confirmed send")
+	}
+}
+
 func TestSetDataPlane(t *testing.T) {
 	ss := NewSessionSync(":4785", "10.0.0.2:4785", nil)
 	if ss.sessions != nil {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -141,6 +141,7 @@ type Daemon struct {
 	// ONLY to Kea's own socket + the cluster channel — never the
 	// userspace-helper control socket (CLAUDE.md rule).
 	dhcpLeaseSyncNowCh    chan struct{} // nudge: grant/commit/MASTER takeover
+	ipsecSANudgeCh        chan struct{} // nudge: peer (re)connect -> IPsec SA re-advertise (#4385)
 	dhcpLeaseSyncInFlight atomic.Bool   // no-freeze skip-if-in-flight guard
 	dhcpLeaseLastSentMu   sync.Mutex
 	dhcpLeaseLastSent4    string // last-pushed v4 set fingerprint (change-detect)
@@ -793,6 +794,7 @@ func New(opts Options) (*Daemon, error) {
 		ddnsReconcileNowCh:         make(chan struct{}, 1),
 		surfaceAReconcileNowCh:     make(chan struct{}, 1),
 		dhcpLeaseSyncNowCh:         make(chan struct{}, 1),
+		ipsecSANudgeCh:             make(chan struct{}, 1),
 		syncReadyTimeout:           5 * time.Second,
 		linkByNameFn:               netlink.LinkByName,
 		directAnnounceSchedule:     []time.Duration{0, 250 * time.Millisecond, 1 * time.Second, 2 * time.Second, 4 * time.Second, 6 * time.Second},

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -1339,8 +1339,17 @@ func ipsecSAFingerprint(names []string) string {
 // never brought an SA up, is never advertised: no 30s empty-heartbeat churn,
 // and the standby's default peer set is already empty so there is nothing to
 // clear.
-func ipsecSASyncAdvertise(names []string, lastFP string) (push bool, newFP string) {
+//
+// force=true (a peer (re)connected) advertises the CURRENT set regardless —
+// empty or not — so a standby that missed the one-shot empty during a
+// disconnect gap, or that retained a stale peer set across a same-process blip,
+// converges to our actual state immediately (empty -> it clears; non-empty ->
+// it re-seeds). This mirrors the DHCP peer-connect nudge (force=true re-push).
+func ipsecSASyncAdvertise(names []string, lastFP string, force bool) (push bool, newFP string) {
 	fp := ipsecSAFingerprint(names)
+	if force {
+		return true, fp
+	}
 	if len(names) > 0 {
 		return true, fp
 	}
@@ -1352,11 +1361,68 @@ func ipsecSASyncAdvertise(names []string, lastFP string) (push bool, newFP strin
 	return false, ""
 }
 
+// ipsecSANextFP returns the fingerprint to remember after one advertise attempt.
+// The last-sent fingerprint advances ONLY when a push was due AND the send was
+// confirmed to an active conn (#4385). A push that no-ops on a nil/dropped conn
+// leaves lastFP unchanged, so the (empty or changed) advertisement RETRIES on
+// the next tick rather than being silently marked as sent — the fix for the
+// window where a drop-to-zero empty push lands during a reconnect gap, the
+// fingerprint advances anyway, and the standby is left holding a stale set that
+// resurrects the tunnel on takeover.
+func ipsecSANextFP(push, sendConfirmed bool, fp, lastFP string) string {
+	if push && sendConfirmed {
+		return fp
+	}
+	return lastFP
+}
+
+// advertiseIPsecSAOnce runs one IPsec SA advertise pass on the primary and
+// returns the fingerprint to carry into the next pass. force=true (a peer
+// (re)connect nudge) re-advertises the current set regardless of change. It is
+// a no-op (returns lastFP unchanged) on a non-primary node, when the feature is
+// disabled, when the active-SA read fails, or when the send does not reach an
+// active conn.
+func (d *Daemon) advertiseIPsecSAOnce(lastFP string, force bool) string {
+	if d.cluster == nil || !d.cluster.IsLocalPrimary(0) {
+		return lastFP
+	}
+	cc := d.clusterConfig()
+	if cc == nil || !cc.IPsecSASync {
+		return lastFP
+	}
+	names, err := d.ipsec.ActiveConnectionNames()
+	if err != nil {
+		slog.Debug("cluster: failed to get IPsec connection names", "err", err)
+		return lastFP
+	}
+	push, fp := ipsecSASyncAdvertise(names, lastFP, force)
+	sendConfirmed := false
+	if push && d.sessionSync != nil {
+		sendConfirmed = d.sessionSync.QueueIPsecSA(names)
+	}
+	return ipsecSANextFP(push, sendConfirmed, fp, lastFP)
+}
+
+// nudgeIPsecSASync requests an immediate IPsec SA re-advertise (fired when a
+// peer sync connection is established). Non-blocking depth-1 send that coalesces
+// a burst; safe before the loop starts.
+func (d *Daemon) nudgeIPsecSASync() {
+	if d.ipsecSANudgeCh == nil {
+		return
+	}
+	select {
+	case d.ipsecSANudgeCh <- struct{}{}:
+	default:
+	}
+}
+
 // syncIPsecSAPeriodic runs on the primary node, periodically syncing active IPsec
 // connection names to the secondary via the session sync channel. It advertises
 // the current active set every tick when non-empty (heartbeat re-push) and, per
 // #4385, advertises the empty set once when the active set drops to zero so the
-// standby does not resurrect an administratively-downed tunnel on takeover.
+// standby does not resurrect an administratively-downed tunnel on takeover. A
+// peer-connect nudge forces a re-advertise of the current set (empty or not) so
+// a reconnected standby converges even if it missed the one-shot empty.
 func (d *Daemon) syncIPsecSAPeriodic(ctx context.Context) {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
@@ -1371,23 +1437,12 @@ func (d *Daemon) syncIPsecSAPeriodic(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if d.cluster == nil || !d.cluster.IsLocalPrimary(0) {
-				continue
-			}
-			cc := d.clusterConfig()
-			if cc == nil || !cc.IPsecSASync {
-				continue
-			}
-			names, err := d.ipsec.ActiveConnectionNames()
-			if err != nil {
-				slog.Debug("cluster: failed to get IPsec connection names", "err", err)
-				continue
-			}
-			push, fp := ipsecSASyncAdvertise(names, lastFP)
-			if push && d.sessionSync != nil {
-				d.sessionSync.QueueIPsecSA(names)
-				lastFP = fp
-			}
+			lastFP = d.advertiseIPsecSAOnce(lastFP, false)
+		case <-d.ipsecSANudgeCh:
+			// A peer sync connection was (re)established: force a re-advertise
+			// of the CURRENT set so a standby that missed the one-shot empty
+			// during the gap (or retained a stale set across a blip) converges.
+			lastFP = d.advertiseIPsecSAOnce(lastFP, true)
 		}
 	}
 }

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/netip"
+	"sort"
 	"strings"
 	"time"
 
@@ -1308,11 +1309,63 @@ func (d *Daemon) clusterConfig() *config.ClusterConfig {
 	return cfg.Chassis.Cluster
 }
 
+// ipsecSAFingerprint returns a stable, order-independent fingerprint of an
+// active IPsec connection-name set. The empty set maps to the empty string so
+// a never-up node and a torn-down node share the same sentinel (see
+// ipsecSASyncAdvertise).
+func ipsecSAFingerprint(names []string) string {
+	if len(names) == 0 {
+		return ""
+	}
+	sorted := append([]string(nil), names...)
+	sort.Strings(sorted)
+	return strings.Join(sorted, "\n")
+}
+
+// ipsecSASyncAdvertise decides whether the primary should advertise the current
+// active IPsec connection-name set to the standby, given the fingerprint of the
+// set it last advertised (lastFP; the empty string means the last advertised
+// set was empty or nothing has been advertised yet). It returns whether to push
+// and the fingerprint to remember for the next tick.
+//
+// #4385: a NON-EMPTY set is advertised every tick — a heartbeat re-push so a
+// freshly reconnected/restarted standby relearns the full set within one
+// interval (this is the ONLY mechanism that seeds a new standby's peer set, so
+// it preserves the pre-#4385 reconnect-safety behavior). An EMPTY set is
+// advertised exactly ONCE, on the transition down from a previously non-empty
+// set — a tunnel was administratively downed or all its SAs were torn down — so
+// the standby CLEARS its stale peer set instead of resurrecting the tunnel on
+// takeover (reinitiateIPsecSAs). A steady empty set, INCLUDING a node that
+// never brought an SA up, is never advertised: no 30s empty-heartbeat churn,
+// and the standby's default peer set is already empty so there is nothing to
+// clear.
+func ipsecSASyncAdvertise(names []string, lastFP string) (push bool, newFP string) {
+	fp := ipsecSAFingerprint(names)
+	if len(names) > 0 {
+		return true, fp
+	}
+	// Empty set: advertise once to clear the standby ONLY if we previously
+	// advertised a non-empty set (downed-but-was-up, not never-up).
+	if lastFP != "" {
+		return true, ""
+	}
+	return false, ""
+}
+
 // syncIPsecSAPeriodic runs on the primary node, periodically syncing active IPsec
-// connection names to the secondary via the session sync channel.
+// connection names to the secondary via the session sync channel. It advertises
+// the current active set every tick when non-empty (heartbeat re-push) and, per
+// #4385, advertises the empty set once when the active set drops to zero so the
+// standby does not resurrect an administratively-downed tunnel on takeover.
 func (d *Daemon) syncIPsecSAPeriodic(ctx context.Context) {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
+	// lastFP tracks the fingerprint of the last set advertised to the standby
+	// (empty string = last advertised set was empty / nothing advertised yet).
+	// This goroutine is single-instance per comms lifetime (started once in
+	// daemon_ha_sync.go and re-created with a fresh commsCtx only on a
+	// transport-field change), so the local is safe without a lock.
+	var lastFP string
 	for {
 		select {
 		case <-ctx.Done():
@@ -1330,8 +1383,10 @@ func (d *Daemon) syncIPsecSAPeriodic(ctx context.Context) {
 				slog.Debug("cluster: failed to get IPsec connection names", "err", err)
 				continue
 			}
-			if len(names) > 0 && d.sessionSync != nil {
+			push, fp := ipsecSASyncAdvertise(names, lastFP)
+			if push && d.sessionSync != nil {
 				d.sessionSync.QueueIPsecSA(names)
+				lastFP = fp
 			}
 		}
 	}

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -614,6 +614,15 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 				if cc := d.clusterConfig(); cc != nil && cc.DHCPLeaseSync {
 					d.nudgeDHCPLeaseSync()
 				}
+				// #4385: a peer that just (re)connected may have missed the
+				// one-shot empty IPsec SA advertisement during the gap, or (a
+				// same-process standby) retained a stale peer set across the
+				// blip. Nudge a forced re-advertise of the current set (empty or
+				// not) so it converges — gated on primary + IPsecSASync inside
+				// advertiseIPsecSAOnce, so it is safe regardless of this branch.
+				if cc := d.clusterConfig(); cc != nil && cc.IPsecSASync {
+					d.nudgeIPsecSASync()
+				}
 				if d.cluster == nil || !d.cluster.IsLocalPrimary(0) {
 					slog.Info("cluster: skipping config push (not RG0 primary)")
 					return

--- a/pkg/daemon/ipsec_sa_sync_empty_4385_test.go
+++ b/pkg/daemon/ipsec_sa_sync_empty_4385_test.go
@@ -1,0 +1,68 @@
+package daemon
+
+import "testing"
+
+// TestIPsecSASyncAdvertise pins the #4385 empty-set advertise decision made by
+// syncIPsecSAPeriodic.
+//
+// The bug: syncIPsecSAPeriodic guarded the push with `if len(names) > 0`, so
+// when the primary's active SA set dropped to zero (a tunnel was
+// administratively downed / all its SAs torn down) the empty set was NEVER
+// advertised. The standby overwrites its peer set wholesale, so it retained the
+// last non-empty snapshot and, on RG0 takeover, reinitiateIPsecSAs re-initiated
+// each stale name -> the downed tunnel was resurrected on the new primary.
+//
+// The fix advertises the empty set once on the drop-to-zero transition so the
+// standby clears its stale peer set, while never churning an empty heartbeat on
+// a node that never brought an SA up, and still re-pushing a live set every
+// tick for reconnect-safety.
+//
+// RED-on-revert: restoring the `len(names) > 0` guard (return `len(names) > 0`
+// unconditionally from ipsecSASyncAdvertise) fails the "downed tunnel" case
+// below — the empty set is no longer advertised and the standby keeps the
+// stale SA.
+func TestIPsecSASyncAdvertise(t *testing.T) {
+	// never-up: an empty set from the start is never advertised (no churn; the
+	// standby's default peer set is already empty).
+	if push, fp := ipsecSASyncAdvertise(nil, ""); push || fp != "" {
+		t.Fatalf("never-up: got push=%v fp=%q, want push=false fp=\"\"", push, fp)
+	}
+
+	// SAs come up: the non-empty set is advertised and its fingerprint is
+	// remembered so the NEXT drop-to-zero is detected as a transition.
+	push, up := ipsecSASyncAdvertise([]string{"vpn-a", "vpn-b"}, "")
+	if !push || up == "" {
+		t.Fatalf("SA up: got push=%v fp=%q, want push=true fp!=\"\"", push, up)
+	}
+
+	// steady live set: heartbeat re-push every tick. This is the ONLY mechanism
+	// that seeds a freshly reconnected/restarted standby, so it must keep
+	// pushing even when the set is unchanged (reconnect-safety, unchanged from
+	// pre-#4385 behavior).
+	if push, _ := ipsecSASyncAdvertise([]string{"vpn-a", "vpn-b"}, up); !push {
+		t.Fatal("live set: heartbeat re-push required for reconnect-safety")
+	}
+
+	// tunnel downed: the active set drops to zero AFTER being non-empty -> the
+	// empty set MUST be advertised once so the standby clears stale SAs. This is
+	// the #4385 fix and is RED on revert of the len(names)>0 guard.
+	push, fp := ipsecSASyncAdvertise(nil, up)
+	if !push {
+		t.Fatal("downed tunnel: empty set must be advertised to clear stale peer SAs (#4385)")
+	}
+	if fp != "" {
+		t.Fatalf("downed tunnel: advertised-empty fingerprint got %q, want \"\"", fp)
+	}
+
+	// steady empty after the clear: the empty set is not re-advertised (no 30s
+	// empty-heartbeat churn on the sync channel).
+	if push, _ := ipsecSASyncAdvertise(nil, ""); push {
+		t.Fatal("steady empty: repeated empty set must not churn the sync channel")
+	}
+
+	// the fingerprint is set-identity, not slice-order, so a reordered
+	// swanctl --list-sas result does not look like a change.
+	if a, b := ipsecSAFingerprint([]string{"a", "b"}), ipsecSAFingerprint([]string{"b", "a"}); a != b {
+		t.Fatalf("fingerprint not order-independent: %q vs %q", a, b)
+	}
+}

--- a/pkg/daemon/ipsec_sa_sync_empty_4385_test.go
+++ b/pkg/daemon/ipsec_sa_sync_empty_4385_test.go
@@ -24,29 +24,29 @@ import "testing"
 func TestIPsecSASyncAdvertise(t *testing.T) {
 	// never-up: an empty set from the start is never advertised (no churn; the
 	// standby's default peer set is already empty).
-	if push, fp := ipsecSASyncAdvertise(nil, ""); push || fp != "" {
+	if push, fp := ipsecSASyncAdvertise(nil, "", false); push || fp != "" {
 		t.Fatalf("never-up: got push=%v fp=%q, want push=false fp=\"\"", push, fp)
 	}
 
 	// SAs come up: the non-empty set is advertised and its fingerprint is
 	// remembered so the NEXT drop-to-zero is detected as a transition.
-	push, up := ipsecSASyncAdvertise([]string{"vpn-a", "vpn-b"}, "")
+	push, up := ipsecSASyncAdvertise([]string{"vpn-a", "vpn-b"}, "", false)
 	if !push || up == "" {
 		t.Fatalf("SA up: got push=%v fp=%q, want push=true fp!=\"\"", push, up)
 	}
 
 	// steady live set: heartbeat re-push every tick. This is the ONLY mechanism
-	// that seeds a freshly reconnected/restarted standby, so it must keep
-	// pushing even when the set is unchanged (reconnect-safety, unchanged from
-	// pre-#4385 behavior).
-	if push, _ := ipsecSASyncAdvertise([]string{"vpn-a", "vpn-b"}, up); !push {
+	// that seeds a freshly reconnected/restarted standby's peer set, so it must
+	// keep pushing even when the set is unchanged (reconnect-safety, unchanged
+	// from pre-#4385 behavior).
+	if push, _ := ipsecSASyncAdvertise([]string{"vpn-a", "vpn-b"}, up, false); !push {
 		t.Fatal("live set: heartbeat re-push required for reconnect-safety")
 	}
 
 	// tunnel downed: the active set drops to zero AFTER being non-empty -> the
 	// empty set MUST be advertised once so the standby clears stale SAs. This is
 	// the #4385 fix and is RED on revert of the len(names)>0 guard.
-	push, fp := ipsecSASyncAdvertise(nil, up)
+	push, fp := ipsecSASyncAdvertise(nil, up, false)
 	if !push {
 		t.Fatal("downed tunnel: empty set must be advertised to clear stale peer SAs (#4385)")
 	}
@@ -56,7 +56,7 @@ func TestIPsecSASyncAdvertise(t *testing.T) {
 
 	// steady empty after the clear: the empty set is not re-advertised (no 30s
 	// empty-heartbeat churn on the sync channel).
-	if push, _ := ipsecSASyncAdvertise(nil, ""); push {
+	if push, _ := ipsecSASyncAdvertise(nil, "", false); push {
 		t.Fatal("steady empty: repeated empty set must not churn the sync channel")
 	}
 
@@ -64,5 +64,78 @@ func TestIPsecSASyncAdvertise(t *testing.T) {
 	// swanctl --list-sas result does not look like a change.
 	if a, b := ipsecSAFingerprint([]string{"a", "b"}), ipsecSAFingerprint([]string{"b", "a"}); a != b {
 		t.Fatalf("fingerprint not order-independent: %q vs %q", a, b)
+	}
+}
+
+// TestIPsecSASyncForceReadvertise pins the #4385 peer-connect re-advertise: on a
+// forced pass (a peer sync connection was (re)established) the CURRENT set is
+// advertised regardless of change — empty or not — so a reconnected standby
+// converges to our actual state. RED-on-revert: without the force branch,
+// ipsecSASyncAdvertise(nil, "", true) returns push=false and a standby that
+// missed the one-shot empty stays stale until the set next changes.
+func TestIPsecSASyncForceReadvertise(t *testing.T) {
+	// force + current set empty: re-advertise empty so a stale standby (missed
+	// the one-shot empty, or retained its set across a blip) clears.
+	push, fp := ipsecSASyncAdvertise(nil, "", true)
+	if !push {
+		t.Fatal("force: an empty current set must be re-advertised to clear a stale standby (#4385)")
+	}
+	if fp != "" {
+		t.Fatalf("force empty: fingerprint got %q, want \"\"", fp)
+	}
+
+	// force + current set non-empty: re-advertise the set to re-seed a freshly
+	// reconnected/restarted standby.
+	push, fp = ipsecSASyncAdvertise([]string{"vpn-a"}, "", true)
+	if !push || fp == "" {
+		t.Fatalf("force non-empty: got push=%v fp=%q, want push=true fp!=\"\"", push, fp)
+	}
+}
+
+// TestIPsecSAMissedEmptyRetries pins the #4385 confirmed-send retry: the
+// last-sent fingerprint advances ONLY on a confirmed send, so an empty
+// advertisement that no-ops on a nil/dropped conn (a reconnect gap) is retried
+// on the next tick and eventually clears the standby.
+//
+// RED-on-revert: if ipsecSANextFP advanced lastFP even on an UNCONFIRMED send
+// (return fp whenever push), the missed empty would mark lastFP="" and the next
+// tick would see ipsecSASyncAdvertise(nil, "") -> push=false -> the empty is
+// NEVER retried, leaving the standby holding the stale set that resurrects the
+// tunnel on takeover.
+func TestIPsecSAMissedEmptyRetries(t *testing.T) {
+	// Primary brought {vpn-a} up and advertised it (confirmed).
+	push, fp := ipsecSASyncAdvertise([]string{"vpn-a"}, "", false)
+	up := ipsecSANextFP(push, true, fp, "")
+	if up == "" {
+		t.Fatalf("setup: live set must leave a non-empty last-sent fingerprint, got %q", up)
+	}
+
+	// Tunnel downed during a reconnect gap: the empty push is DUE, but the send
+	// no-ops on a nil conn (sendConfirmed=false). lastFP MUST stay non-empty so
+	// the empty advertisement is retried, not silently lost.
+	push, fp = ipsecSASyncAdvertise(nil, up, false)
+	if !push {
+		t.Fatal("downed tunnel: empty advertisement must be DUE")
+	}
+	lastFP := ipsecSANextFP(push, false /* send did not reach an active conn */, fp, up)
+	if lastFP != up {
+		t.Fatalf("missed send: lastFP must NOT advance (retry-on-next-tick); got %q want %q", lastFP, up)
+	}
+
+	// Next tick, the conn is restored: the empty is STILL due (lastFP unchanged)
+	// and the send is now confirmed -> lastFP advances to empty (standby
+	// cleared, no further churn).
+	push, fp = ipsecSASyncAdvertise(nil, lastFP, false)
+	if !push {
+		t.Fatal("retry: empty advertisement must still be DUE after the missed send")
+	}
+	lastFP = ipsecSANextFP(push, true, fp, lastFP)
+	if lastFP != "" {
+		t.Fatalf("retry: after a confirmed empty send lastFP must be empty, got %q", lastFP)
+	}
+
+	// Steady empty after the clear: no further churn.
+	if push, _ := ipsecSASyncAdvertise(nil, lastFP, false); push {
+		t.Fatal("steady empty after clear: empty set must not churn")
 	}
 }


### PR DESCRIPTION
## Problem

`syncIPsecSAPeriodic` (`pkg/daemon/daemon_ha.go`) guarded the peer push with `if len(names) > 0`, so when the primary's active IPsec SA set dropped to zero — a tunnel administratively downed or all its child SAs torn down — the empty set was **never** advertised over the session-sync channel. The standby overwrites its held peer set wholesale (`sync_conn.go`, `s.peerIPsecSAs = names`), so it retained the last non-empty snapshot. On RG0 takeover, `reinitiateIPsecSAs` re-initiated each stale name → **the downed tunnel was resurrected on the new primary**.

Finding L-4 (low) from opus-review-171; verified genuine-driveable vs current master.

## Fix

Extract the push decision into `ipsecSASyncAdvertise(names, lastFP)`:

- A **non-empty** set is advertised every tick — a heartbeat re-push. This is the *only* mechanism that seeds a freshly reconnected/restarted standby's peer set, so reconnect-safety is preserved unchanged from pre-fix behavior.
- An **empty** set is advertised exactly **once**, on the drop-to-zero transition from a previously non-empty set, so the standby clears its stale `peerIPsecSAs` and does not resurrect the tunnel on takeover.
- A **steady/never-up** empty set is never advertised — no 30s empty-heartbeat churn, no spurious push from a node that never brought an SA up (the standby's default peer set is already empty).

`syncIPsecSAPeriodic` tracks a goroutine-local `lastFP` fingerprint; the loop is single-instance per comms lifetime, so no lock is needed. The wire codec, receiver, and empty-payload round-trip are unchanged. Mirrors the DHCP `maybePushFamily`/`QueueDHCPLeases` empty-set change-detect precedent.

## Tests

- `pkg/daemon` `TestIPsecSASyncAdvertise` pins the decision and is **RED on revert** of the `len(names)>0` guard (the downed-tunnel case fails to advertise the empty set). Verified by temporarily restoring the guard → downed-tunnel assertion fails → restored.
- `pkg/cluster` `TestIPsecSAEmptyPushClearsPeer` proves an empty advertisement clears the receiver's `peerIPsecSAs` and fires `OnIPsecSAReceived` with an empty set.

`go test ./pkg/daemon/... ./pkg/cluster/... ./pkg/ipsec/...` green; `go build ./...`; `gofmt` + `go vet` clean.

## HA note

This touches HA IPsec SA sync. **Run `make test-failover` before merge** — a downed tunnel must NOT resurrect on failover.

Closes #4385

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi