### PR TITLE
nat: publish reverse-SNAT dnat_table entry for synced SNAT sessions (#4393)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,54 @@
+## 2026-07-06 — #4393: publish reverse-SNAT dnat_table entry for synced SNAT sessions
+
+- **Timestamp**: 2026-07-06
+- **Action**: After failover, a synced SNAT session's embedded-ICMP error
+  (PMTUD Packet-Too-Big / traceroute Time-Exceeded, quoting the NATed inner
+  packet) could not be reverse-NAT'd back to the original client, because the
+  SECONDARY never published the `dnat_table` / `dnat_table_v6` BPF-map entry for
+  the synced SNAT session. The `dnat_table` is the embedded-ICMP reverse-NAT
+  STEERING map: the AF_XDP shim looks up the inbound error's inner
+  `(proto, snat_addr, snat_port)` there to decide the packet must go to the
+  helper's slow path (`try_embedded_icmp_nat_match`). The active node populates
+  it from the worker poll path (`poll_descriptor`, `publish_dnat_table_entry`)
+  when it forwards the first SNAT'd packet; the standby imports the pre-computed
+  NAT decision and never forwards that packet, so it held no `dnat_table` entry
+  — post-failover the inbound ICMP error was passed to the kernel (no NAT state)
+  instead of reverse-NAT'd, so the client never saw the PMTU (TCP stalls on
+  large packets) and traceroute broke (PMTUD blackhole). Fix: publish the
+  reverse-SNAT `dnat_table` entry once per synced forward SNAT session in the
+  coordinator `Coordinator::upsert_synced_session` (`afxdp/ha.rs`), immediately
+  after the existing `publish_shared_session` that populates the process-global
+  `shared_nat_sessions` reverse-NAT map — the `dnat_table` is likewise a single
+  global map, so a once-per-session coordinator publish mirrors the primary's
+  single publish (not a redundant per-worker write). Published unconditionally
+  (NOT gated on `synced_entry_allows_local_replace`, unlike the forward
+  session-map publish) so it is ready the instant this node becomes active; the
+  standby never receives inbound SNAT-return traffic, so an early entry is inert.
+  The matching delete (`delete_dnat_table_entry`, same `dnat_v4/v6_key_bytes`
+  SSOT) runs in `Coordinator::delete_synced_session_gen` alongside the
+  session-map delete, so a peer delete-sync / GC reap frees the entry (non-LRU
+  HASH maps leak one slot per un-deleted SNAT session otherwise). Added shared
+  `DNAT_PUBLISH_ERRORS_SHARED` counter (folded into
+  `dnat_publish_errors_total` → `xpf_userspace_dnat_publish_errors_total`) so a
+  failed coordinator publish stays operator-visible (#2244 parity, no
+  per-binding context on this path). Added test-only `DNAT_PUBLISH_ATTEMPTS`
+  counter (mirrors `DNAT_DELETE_ATTEMPTS`) for the RED-on-revert wiring test.
+- **File(s)**: `userspace-dp/src/afxdp/ha.rs`,
+  `userspace-dp/src/afxdp/checksum.rs`,
+  `userspace-dp/src/afxdp/bpf_map/metrics.rs`,
+  `userspace-dp/src/afxdp/coordinator/status.rs`,
+  `userspace-dp/src/afxdp/ha_tests.rs`, `docs/session-sync-architecture.md`
+- **Validation**: RED-on-revert Rust test
+  `synced_snat_install_publishes_and_delete_releases_dnat_table_entry`
+  (`afxdp/ha_tests.rs`): a peer-synced forward SNAT install attempts exactly one
+  `dnat_table` publish; the delete attempts exactly one keyed delete; a non-SNAT
+  synced session publishes/deletes nothing. RED verified by neutralizing the
+  publish (`got 0 attempts`). Full cargo serial
+  (`cargo test --release -- --test-threads=1`): 3638 + 54 + 8 + 22 + 1
+  passed / 0 failed, 2 ignored. HA post-failover embedded-ICMP behavior —
+  parent to run `make test-failover` (a synced SNAT session + a PMTUD ICMP after
+  failover reverse-translates) before merge.
+
 ## 2026-07-06 — #4388: reserve a peer-synced session's NAT pool port on the standby
 
 - **Timestamp**: 2026-07-06

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -351,6 +351,50 @@ source tuple (reply mis-delivery / a session-hijack surface).
   allocator is process-global (`Arc<PortAllocatorShared>`), so the reservation
   is visible to every worker regardless of which one imported the session.
 
+### Reverse-SNAT `dnat_table` Publish for Synced Sessions (#4393)
+
+The `dnat_table` / `dnat_table_v6` BPF maps are the **embedded-ICMP reverse-NAT
+steering** maps. When an inbound ICMP error (PMTUD Packet-Too-Big, traceroute
+Time-Exceeded) quotes a NATed inner packet whose source is a source-NAT pool
+`(addr, port)`, the AF_XDP shim looks that tuple up in `dnat_table` to decide the
+packet must be handed to the helper's slow path, where `try_embedded_icmp_nat_match`
+reverse-translates the error back to the original pre-NAT client. Without the
+`dnat_table` entry the shim passes the error to the kernel (which has no NAT
+state) — the client never learns the PMTU, TCP stalls on large packets, and
+traceroute breaks.
+
+The active node populates `dnat_table` from the worker poll path
+(`poll_descriptor`, `publish_dnat_table_entry`) when it forwards the first SNAT'd
+packet of a flow. The standby never forwards that packet — it imports the
+pre-computed NAT decision over the fabric — so before #4393 the standby held no
+`dnat_table` entry for synced SNAT sessions. Post-failover the standby-turned-active
+could not steer the inbound embedded-ICMP error into the helper, so PMTUD
+blackholed for exactly the flows that survived the failover.
+
+- **Publish site:** `Coordinator::upsert_synced_session` (`afxdp/ha.rs`) calls
+  `publish_dnat_table_entry` for every forward peer-synced entry, immediately
+  after the `publish_shared_session` that populates the (also process-global)
+  `shared_nat_sessions` reverse-NAT map. `dnat_table` is a **single shared BPF
+  map** (opened once, its fds cloned to every worker), so this is a
+  once-per-synced-session publish, mirroring the primary's single publish rather
+  than a redundant per-worker write. It is **not** gated on
+  `synced_entry_allows_local_replace` (unlike the forward session-map publish):
+  the `dnat_table` is a passive steering map that must be ready the instant this
+  node becomes active, and inbound SNAT-return traffic never reaches the standby,
+  so an early entry is inert until failover. A reverse companion carries no
+  source rewrite and publishes nothing.
+- **Release site:** `Coordinator::delete_synced_session_gen` (`afxdp/ha.rs`)
+  calls `delete_dnat_table_entry` alongside the session-map delete, keyed on the
+  same `dnat_v4_key_bytes` / `dnat_v6_key_bytes` SSOT the publish used, so the
+  delete byte-matches the insert. The maps are non-LRU `HASH`
+  (`max_entries = MAX_SESSIONS`, `BPF_F_NO_PREALLOC`); a missing delete leaks one
+  slot per removed synced SNAT session. A non-SNAT / reverse entry is a no-op.
+- **Observability:** a failed publish from this coordinator path (no per-binding
+  `BindingLiveState`) bumps the shared `DNAT_PUBLISH_ERRORS_SHARED` static, which
+  `Coordinator::dnat_publish_errors_total()` folds into the existing per-binding
+  sum for `xpf_userspace_dnat_publish_errors_total` — so map-pressure reverse-NAT
+  loss stays operator-visible on the standby path too (#2244 parity).
+
 ### Event Stream (Primary Path)
 
 The Rust helper pushes session events over a persistent binary-framed Unix

--- a/userspace-dp/src/afxdp/bpf_map/metrics.rs
+++ b/userspace-dp/src/afxdp/bpf_map/metrics.rs
@@ -239,6 +239,18 @@ pub(in crate::afxdp) static SESSION_PUBLISH_VERIFY_FAIL: AtomicU64 = AtomicU64::
 /// by `Coordinator::session_publish_errors_total()` and surfaced as
 /// `xpf_userspace_session_publish_errors_total`.
 pub(in crate::afxdp) static SESSION_PUBLISH_ERRORS_SHARED: AtomicU64 = AtomicU64::new(0);
+/// #4393: failed reverse-SNAT `dnat_table` BPF-map publishes from the
+/// coordinator's peer-synced install path (`upsert_synced_session`), which
+/// has no per-binding `BindingLiveState`. Always-on (mirrors
+/// `SESSION_PUBLISH_ERRORS_SHARED`): a swallowed publish means the standby
+/// never learns the SNAT reverse-NAT steering entry, so after failover an
+/// inbound embedded-ICMP error (PMTUD Too-Big / traceroute Time-Exceeded)
+/// quoting the NATed inner packet is not steered to the helper and the client
+/// never sees it (PMTUD blackhole). The per-binding worker poll sites use
+/// `BindingLiveState::dnat_publish_errors` instead; the two are summed by
+/// `Coordinator::dnat_publish_errors_total()` and surfaced as
+/// `xpf_userspace_dnat_publish_errors_total`.
+pub(in crate::afxdp) static DNAT_PUBLISH_ERRORS_SHARED: AtomicU64 = AtomicU64::new(0);
 /// #2170 HA deferred-delete generation guard observability. These count how
 /// often the helper's in-memory SyncedSessionEntry generation guard refused a
 /// stale-generation install (`upsert_synced_session`, the delayed-stale-install

--- a/userspace-dp/src/afxdp/checksum.rs
+++ b/userspace-dp/src/afxdp/checksum.rs
@@ -289,6 +289,17 @@ pub(super) fn delete_dnat_table_entry(
 pub(super) static DNAT_DELETE_ATTEMPTS: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
+// #4393 fail-on-revert instrumentation: counts `publish_dnat_table_entry`
+// syscall attempts (an SNAT flow with a live table fd). Used by the
+// coordinator peer-synced-install wiring test in afxdp/ha_tests.rs to prove
+// `upsert_synced_session` publishes the reverse-SNAT `dnat_table` entry for a
+// synced SNAT session — RED if the publish call is removed from
+// `upsert_synced_session` (the standby loses the embedded-ICMP steering entry
+// and PMTUD blackholes after failover). Test-only; mirrors DNAT_DELETE_ATTEMPTS.
+#[cfg(test)]
+pub(super) static DNAT_PUBLISH_ATTEMPTS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
 #[must_use]
 pub(super) fn publish_dnat_table_entry(
     fds: &DnatTableFds,
@@ -319,6 +330,11 @@ pub(super) fn publish_dnat_table_entry(
             dv[4..6].copy_from_slice(&key.src_port.to_be_bytes());
             dv[6] = 0;
 
+            // #4393: count the keyed publish attempt so the synced-install
+            // wiring is testable without a real BPF map (test-only, no-op in
+            // release). Mirrors DNAT_DELETE_ATTEMPTS on the delete side.
+            #[cfg(test)]
+            DNAT_PUBLISH_ATTEMPTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let rc = unsafe {
                 libbpf_sys::bpf_map_update_elem(
                     fd,
@@ -363,6 +379,9 @@ pub(super) fn publish_dnat_table_entry(
             };
             let (dk, dv) = dnat_v6_entry_bytes(key.protocol, snat_v6, snat_port, orig_v6, key.src_port);
 
+            // #4393: count the keyed publish attempt (test-only; see the v4 arm).
+            #[cfg(test)]
+            DNAT_PUBLISH_ATTEMPTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let rc = unsafe {
                 libbpf_sys::bpf_map_update_elem(
                     fd,

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -154,19 +154,23 @@ impl super::Coordinator {
     /// #2244: total failed `dnat_table` reverse-SNAT BPF-map publishes.
     /// Sum of the per-binding `dnat_publish_errors` atomics bumped on the
     /// two worker poll-path `publish_dnat_table_entry` call sites whose
-    /// `bpf_map_update_elem` return code was previously discarded. The
-    /// `dnat_table` backs embedded-ICMP NAT reversal (PMTUD / traceroute
-    /// inbound ICMP errors mapped back to the pre-NAT source); a failed
-    /// publish silently drops the reverse record, so a nonzero value is
-    /// the cause-side signal for `dnat_table` capacity pressure or kernel
-    /// resource exhaustion. Surfaced as
+    /// `bpf_map_update_elem` return code was previously discarded, PLUS the
+    /// shared `DNAT_PUBLISH_ERRORS_SHARED` static bumped on the coordinator's
+    /// peer-synced install path (`upsert_synced_session`, #4393), which has no
+    /// per-binding context. The `dnat_table` backs embedded-ICMP NAT reversal
+    /// (PMTUD / traceroute inbound ICMP errors mapped back to the pre-NAT
+    /// source); a failed publish silently drops the reverse record, so a
+    /// nonzero value is the cause-side signal for `dnat_table` capacity
+    /// pressure or kernel resource exhaustion. Surfaced as
     /// `xpf_userspace_dnat_publish_errors_total`.
     pub fn dnat_publish_errors_total(&self) -> u64 {
-        self.workers
+        let per_binding: u64 = self
+            .workers
             .live
             .values()
             .map(|live| live.dnat_publish_errors.load(Ordering::Relaxed))
-            .sum()
+            .sum();
+        per_binding.saturating_add(DNAT_PUBLISH_ERRORS_SHARED.load(Ordering::Relaxed))
     }
 
     /// #2170: total stale-generation installs refused by the helper's

--- a/userspace-dp/src/afxdp/ha.rs
+++ b/userspace-dp/src/afxdp/ha.rs
@@ -314,6 +314,41 @@ impl super::Coordinator {
             &self.sessions.owner_rg_indexes,
             &entry,
         );
+        // #4393: publish the reverse-SNAT `dnat_table` BPF-map entry for a
+        // peer-synced forward SNAT session. The active node populates this
+        // steering map from the worker poll path when it forwards the first
+        // SNAT'd packet (`poll_descriptor`), but the standby never forwards
+        // that packet — it imports the pre-computed NAT decision here. Without
+        // this publish the standby has no `dnat_table` entry, so after failover
+        // the shim does not steer an inbound embedded-ICMP error (PMTUD
+        // Too-Big / traceroute Time-Exceeded) whose quoted inner packet carries
+        // the SNAT pool `(addr, port)` into the helper's slow path — the error
+        // is passed to the kernel (no NAT state) instead of reverse-NAT'd back
+        // to the original client, so the client never learns the PMTU (TCP
+        // stalls on large packets) and traceroute breaks. Mirrors the primary's
+        // `publish_dnat_table_entry` call site exactly (forward entry only; a
+        // reverse companion carries no SNAT source rewrite). Published
+        // unconditionally (NOT gated on `synced_entry_allows_local_replace`,
+        // unlike the forward session-map publish below): the `dnat_table` is a
+        // passive reverse-NAT steering map that must be ready the instant this
+        // node becomes active, and inbound SNAT-return traffic does not reach
+        // the standby anyway, so an early entry is inert until failover. The
+        // matching delete is `delete_synced_session_gen`'s teardown. The
+        // process-global `dnat_table` map is a single shared object, so this
+        // once-per-synced-session publish (not per worker) mirrors the primary.
+        if !entry.metadata.is_reverse {
+            let dnat_fds = DnatTableFds {
+                v4: self.bpf_maps.dnat_table_fd.as_ref().map(|fd| fd.fd),
+                v6: self.bpf_maps.dnat_table_v6_fd.as_ref().map(|fd| fd.fd),
+            };
+            if !publish_dnat_table_entry(&dnat_fds, &entry.key, entry.decision.nat) {
+                // #4393/#2244: a failed publish (map at capacity / kernel
+                // resource exhaustion) silently loses the reverse-NAT steering
+                // entry. Count it via the shared static (no per-binding context
+                // here) so `dnat_publish_errors_total` stays honest.
+                DNAT_PUBLISH_ERRORS_SHARED.fetch_add(1, Ordering::Relaxed);
+            }
+        }
         // Keep the immediate BPF publish aligned with the worker-side
         // ownership guard so XSK redirect state cannot get ahead of what
         // the local SessionTable would actually accept.
@@ -428,6 +463,22 @@ impl super::Coordinator {
                     entry.decision,
                     &entry.metadata,
                 );
+            }
+            // #4393: release the reverse-SNAT `dnat_table` entry published for
+            // this peer-synced forward SNAT session at `upsert_synced_session`
+            // so it does not leak (the maps are non-LRU HASH with
+            // `max_entries = MAX_SESSIONS`; every un-deleted entry burns a slot
+            // until publishes start failing) or steer a stale inbound ICMP
+            // error after the session is gone. Keyed on the SAME
+            // `dnat_v4_key_bytes` / `dnat_v6_key_bytes` helpers the publish path
+            // used, so it byte-matches the insert key; a non-SNAT / reverse
+            // entry is a no-op.
+            if !entry.metadata.is_reverse {
+                let dnat_fds = DnatTableFds {
+                    v4: self.bpf_maps.dnat_table_fd.as_ref().map(|fd| fd.fd),
+                    v6: self.bpf_maps.dnat_table_v6_fd.as_ref().map(|fd| fd.fd),
+                };
+                delete_dnat_table_entry(&dnat_fds, &entry.key, entry.decision.nat);
             }
         }
         remove_shared_session(

--- a/userspace-dp/src/afxdp/ha_tests.rs
+++ b/userspace-dp/src/afxdp/ha_tests.rs
@@ -762,6 +762,104 @@ fn delete_synced_session_zero_generation_is_unconditional() {
     );
 }
 
+// --- #4393 peer-synced SNAT reverse-NAT dnat_table publish/delete wiring ----
+
+fn synced_snat_entry() -> SyncedSessionEntry {
+    let mut decision = test_decision();
+    // Forward SNAT: the client source is rewritten to the WAN pool
+    // (addr, port) — exactly what the primary published into dnat_table.
+    decision.nat = NatDecision {
+        rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8))),
+        rewrite_src_port: Some(54321),
+        ..NatDecision::default()
+    };
+    SyncedSessionEntry {
+        key: test_key(),
+        decision,
+        metadata: test_metadata(),
+        origin: SessionOrigin::SyncImport,
+        protocol: PROTO_TCP,
+        tcp_flags: 0,
+        generation: 0,
+    }
+}
+
+/// #4393 FAIL-ON-REVERT: installing a peer-synced forward SNAT session on the
+/// standby must publish the reverse-SNAT `dnat_table` entry (the embedded-ICMP
+/// steering map), and deleting the session must release it. Without the publish
+/// the standby has no reverse-NAT steering entry, so after failover an inbound
+/// embedded-ICMP error (PMTUD Too-Big / traceroute Time-Exceeded) quoting the
+/// NATed inner packet is not steered to the helper and is never reverse-NAT'd
+/// back to the original client (PMTUD blackhole).
+///
+/// Real BPF maps cannot be created under `cargo test` (the host runs with
+/// `kernel.unprivileged_bpf_disabled`), so the publish/delete are observed via
+/// the test-only `DNAT_PUBLISH_ATTEMPTS` / `DNAT_DELETE_ATTEMPTS` counters bumped
+/// inside `publish_dnat_table_entry` / `delete_dnat_table_entry` whenever a
+/// keyed syscall is issued. The fd is `-1` (EBADF after the keyed attempt is
+/// counted). RED on revert: remove the publish from `upsert_synced_session` and
+/// the SNAT publish assertion fails; remove the delete from
+/// `delete_synced_session_gen` and the SNAT delete assertion fails. The
+/// non-SNAT control guards against publishing/deleting for flows that carry no
+/// source rewrite.
+#[test]
+fn synced_snat_install_publishes_and_delete_releases_dnat_table_entry() {
+    use crate::afxdp::checksum::{DNAT_DELETE_ATTEMPTS, DNAT_PUBLISH_ATTEMPTS};
+
+    // Serialize against any other test touching the process-global counters.
+    static GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _g = GUARD.lock().expect("counter guard");
+
+    let mut coordinator = Coordinator::new();
+    // A live v4 dnat_table fd so the publish/delete path is reached; -1 makes
+    // the syscall a harmless EBADF after the keyed attempt is counted.
+    coordinator.bpf_maps.dnat_table_fd = Some(OwnedFd { fd: -1 });
+    let key = test_key();
+
+    // Forward SNAT synced install must publish the reverse-SNAT entry.
+    let before_pub = DNAT_PUBLISH_ATTEMPTS.load(Ordering::Relaxed);
+    coordinator.upsert_synced_session(synced_snat_entry());
+    let after_pub = DNAT_PUBLISH_ATTEMPTS.load(Ordering::Relaxed);
+    assert_eq!(
+        after_pub - before_pub,
+        1,
+        "peer-synced forward SNAT install must publish the reverse-SNAT dnat_table entry \
+         (#4393); got {} attempts",
+        after_pub - before_pub
+    );
+
+    // Deleting the synced SNAT session must release the reverse-SNAT entry.
+    let before_del = DNAT_DELETE_ATTEMPTS.load(Ordering::Relaxed);
+    coordinator.delete_synced_session(key.clone());
+    let after_del = DNAT_DELETE_ATTEMPTS.load(Ordering::Relaxed);
+    assert_eq!(
+        after_del - before_del,
+        1,
+        "deleting the synced SNAT session must release its reverse-SNAT dnat_table entry \
+         (#4393); got {} attempts",
+        after_del - before_del
+    );
+
+    // Non-SNAT control: a plain synced session (test_decision -> no source
+    // rewrite) publishes and deletes nothing.
+    let before_pub2 = DNAT_PUBLISH_ATTEMPTS.load(Ordering::Relaxed);
+    coordinator.upsert_synced_session(synced_entry_with_generation(0));
+    let after_pub2 = DNAT_PUBLISH_ATTEMPTS.load(Ordering::Relaxed);
+    assert_eq!(
+        after_pub2 - before_pub2,
+        0,
+        "a non-SNAT synced install must not publish a dnat_table entry"
+    );
+    let before_del2 = DNAT_DELETE_ATTEMPTS.load(Ordering::Relaxed);
+    coordinator.delete_synced_session(key);
+    let after_del2 = DNAT_DELETE_ATTEMPTS.load(Ordering::Relaxed);
+    assert_eq!(
+        after_del2 - before_del2,
+        0,
+        "deleting a non-SNAT synced session must not attempt a dnat_table delete"
+    );
+}
+
 // #2962: kicking an export for an EMPTY owner-RG set is a no-op — it must
 // not consume an export sequence and the wait must drain nothing, preserving
 // the pre-split early return semantics.


### PR DESCRIPTION
## Summary

After failover, a synced source-NAT session's **embedded-ICMP error** (a PMTUD Packet-Too-Big or traceroute Time-Exceeded quoting the NATed inner packet) could not be reverse-translated back to the original client, because the SECONDARY never published the reverse-SNAT `dnat_table` / `dnat_table_v6` BPF-map entry for the synced session.

`dnat_table` is the embedded-ICMP reverse-NAT **steering** map: the AF_XDP shim looks up an inbound ICMP error's inner `(proto, snat_addr, snat_port)` there to decide the packet must go to the helper's slow path (`try_embedded_icmp_nat_match`), which reverse-translates it. The active node populates `dnat_table` from the worker poll path (`poll_descriptor`, `publish_dnat_table_entry`) when it forwards the first SNAT'd packet of a flow. The standby imports the pre-computed NAT decision over the fabric and never forwards that packet, so it held no entry — post-failover the standby-turned-active passed the inbound ICMP error to the kernel (no NAT state) instead of reverse-NAT'ing it. The client never learned the PMTU (TCP stalls on large packets) and traceroute broke — a **PMTUD blackhole** for exactly the flows that survived the failover.

Same synced-install-doesn't-fully-replicate class as #4388 (NAT pool port reserve), distinct table.

## Fix (standby side)

- **Publish:** `Coordinator::upsert_synced_session` (`afxdp/ha.rs`) calls `publish_dnat_table_entry` for every forward peer-synced entry, right after the `publish_shared_session` that populates the (also process-global) `shared_nat_sessions` reverse-NAT map. `dnat_table` is a single shared BPF map (opened once, fds cloned to every worker), so this is a **once-per-synced-session** publish that mirrors the primary's single publish rather than a redundant per-worker write. Not gated on `synced_entry_allows_local_replace` (unlike the forward session-map publish) — the steering map must be ready the instant this node becomes active, and inbound SNAT-return traffic never reaches the standby, so an early entry is inert until failover. Reverse companions publish nothing.
- **Release:** `Coordinator::delete_synced_session_gen` (`afxdp/ha.rs`) calls `delete_dnat_table_entry` alongside the session-map delete, keyed on the same `dnat_v4_key_bytes` / `dnat_v6_key_bytes` SSOT the publish used (non-LRU HASH maps leak one slot per un-deleted SNAT session otherwise).
- **Observability:** a failed coordinator publish (no per-binding context) bumps the new shared `DNAT_PUBLISH_ERRORS_SHARED` static, folded into `dnat_publish_errors_total` → `xpf_userspace_dnat_publish_errors_total` (#2244 parity).

## Validation

- RED-on-revert test `synced_snat_install_publishes_and_delete_releases_dnat_table_entry` (`afxdp/ha_tests.rs`): a peer-synced forward SNAT install attempts exactly one keyed `dnat_table` publish (test-only `DNAT_PUBLISH_ATTEMPTS`, mirroring `DNAT_DELETE_ATTEMPTS`), the delete attempts exactly one keyed delete, and a non-SNAT control does neither. **RED verified** by neutralizing the publish (`got 0 attempts`).
- Full cargo serial (`cargo test --release -- --test-threads=1`): lib **3638 + 54 + 8 + 22 + 1 passed / 0 failed**, 2 ignored (nat:: 203, session:: 149, embedded/PTB icmp 76, afxdp::ha 22 green).
- **HA post-failover embedded-ICMP behavior** — a synced SNAT session + a PMTUD ICMP after failover that must reverse-translate should be exercised by `make test-failover` before merge.

Closes #4393

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi