### PR TITLE
dhcp: deterministic DHCPv6 IA_NA address selection (#4383)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,31 @@
+## 2026-07-06 — #4383: DHCPv6 IA_NA multi-address deterministic selection
+
+- **Timestamp**: 2026-07-06
+- **Action**: The DHCPv6 IA_NA extraction loop in `parseV6Reply`
+  (`pkg/dhcp/dhcp.go`) did a last-wins overwrite of `addr`/`validLT` for
+  every IAADDR option, so a reply carrying multiple IAADDR options (RFC
+  8415 §21.4 permits several per IA_NA, and multiple IA_NA per reply)
+  installed whichever address enumerated last and paired the whole lease
+  with that address's valid-lifetime — an order-dependent choice that
+  could prefer a deprecated address and carry a stale lifetime. Fix:
+  extracted the selection into a pure helper `selectIANAAddress` that
+  skips any IAADDR with valid-lifetime 0 (expired/declined, RFC 8415
+  §12.1 — ties into F-264), then picks the longest preferred-lifetime,
+  tie-broken by first-seen (strict greater-than over option order), and
+  returns the CHOSEN address's own valid-lifetime so `lease.LeaseTime` is
+  never paired with a stale value. `parseV6Reply` now calls the helper.
+  Also added a nil-guard to `discoverIPv6Router` (consistent with the
+  existing nil-nlHandle guards) so `parseV6Reply` is unit-testable with a
+  bare `Manager`. Tests (`dhcpv6_iana_test.go`): multi-IAADDR selects the
+  longest-preferred + LeaseTime = its valid-lifetime; single-address
+  unchanged; valid-lifetime-0 skipped; all-zero => no usable IA_NA error;
+  tie-break first-seen; selection scans across multiple IA_NA options. All
+  four deterministic subtests go RED when the helper is reverted to
+  last-wins (verified via in-place Edit-revert, restored). `go test
+  ./pkg/dhcp/...` green; `go build ./...`, gofmt, vet clean.
+- **File(s)**: pkg/dhcp/dhcp.go, pkg/dhcp/dhcpv6_iana_test.go,
+  pkg/dhcp/README.md, _Log.md
+
 ## 2026-07-06 — #4388: reserve a peer-synced session's NAT pool port on the standby
 
 - **Timestamp**: 2026-07-06

--- a/pkg/dhcp/README.md
+++ b/pkg/dhcp/README.md
@@ -164,6 +164,16 @@ External only: `github.com/insomniacslk/dhcp`, `github.com/vishvananda/netlink`.
   address reconciliation on DHCP-marked interfaces.
 - DHCP-learned default routes go into FRR with admin distance 200 — lower
   priority than static routes, so a configured static default wins.
+- **DHCPv6 IA_NA holds one address, selected deterministically** (#4383):
+  a reply may carry multiple IAADDR options within an IA_NA (and multiple
+  IA_NA options), but xpf's `Lease` model installs a single `/128`.
+  `selectIANAAddress` (`dhcp.go`) chooses one — it skips any IAADDR whose
+  valid-lifetime is 0 (an expired/declined address, RFC 8415 §12.1;
+  ties into F-264), then prefers the longest preferred-lifetime,
+  tie-broken by first-seen (option order). `lease.LeaseTime` is paired
+  with the CHOSEN address's own valid-lifetime, never a stale value from
+  a different IAADDR. This replaced a last-wins overwrite that installed
+  whichever address enumerated last. Pinned by `dhcpv6_iana_test.go`.
 - **RFC 3442 classless static routes (option 121 / legacy 249, #4118).**
   `leaseFromACKv4` parses option 121 (the standard `ClasslessStaticRoute`
   accessor) and falls back to the legacy Microsoft option 249 (raw

--- a/pkg/dhcp/dhcp.go
+++ b/pkg/dhcp/dhcp.go
@@ -1362,6 +1362,63 @@ func (m *Manager) doDHCPv6(ctx context.Context, ifaceName string, mode dhcpExcha
 	return m.parseV6Reply(ctx, ifaceName, adv, v6opts)
 }
 
+// selectIANAAddress chooses a single, deterministic IA_NA address from a
+// DHCPv6 reply. RFC 8415 §21.4 permits an IA_NA to carry more than one
+// IAADDR option, and a reply may carry more than one IA_NA; xpf's lease
+// model holds exactly one address, so enumeration order must NOT decide
+// which one is installed (#4383). The previous last-wins overwrite kept
+// whichever IAADDR enumerated last and paired the lease lifetime with
+// that address's valid-lifetime, so a deprecated address could win over a
+// preferred one and the lease could carry a stale lifetime.
+//
+// Selection is deterministic:
+//   - skip any IAADDR with valid-lifetime 0 — RFC 8415 §12.1 treats a
+//     zero valid-lifetime as an expired/declined address (F-264);
+//   - among the rest, prefer the longest preferred-lifetime;
+//   - ties are broken by first-seen (option order).
+//
+// The returned valid-lifetime belongs to the CHOSEN address, so the
+// caller pairs lease.LeaseTime with the right lifetime rather than a
+// stale one from a different IAADDR. Returns an invalid Addr and zero
+// duration when the reply carries no usable IA_NA address.
+func selectIANAAddress(adv *dhcpv6.Message) (netip.Addr, time.Duration) {
+	var (
+		best      netip.Addr
+		bestValid time.Duration
+		bestPref  time.Duration
+		found     bool
+	)
+	for _, opt := range adv.Options.Options {
+		ianaOpt, ok := opt.(*dhcpv6.OptIANA)
+		if !ok {
+			continue
+		}
+		for _, subOpt := range ianaOpt.Options.Options {
+			iaaddr, ok := subOpt.(*dhcpv6.OptIAAddress)
+			if !ok {
+				continue
+			}
+			// Expired/declined address — never install it (F-264).
+			if iaaddr.ValidLifetime == 0 {
+				continue
+			}
+			a, ok := netip.AddrFromSlice(iaaddr.IPv6Addr)
+			if !ok {
+				continue
+			}
+			// Strict greater-than keeps the FIRST address at the maximum
+			// preferred-lifetime (first-seen tie-break).
+			if !found || iaaddr.PreferredLifetime > bestPref {
+				best = a
+				bestValid = iaaddr.ValidLifetime
+				bestPref = iaaddr.PreferredLifetime
+				found = true
+			}
+		}
+	}
+	return best, bestValid
+}
+
 // parseV6Reply extracts the lease (IA_NA address, lifetime, DNS, gateway)
 // and any delegated prefixes (IA_PD) from a DHCPv6 Reply/Advertise. It is
 // shared by the solicit, renew, and rebind paths (#2994); the server DUID
@@ -1385,23 +1442,17 @@ func (m *Manager) parseV6Reply(ctx context.Context, ifaceName string, adv *dhcpv
 		}
 	}
 
-	// Extract IA_NA addresses
+	// Extract the IA_NA address. A reply may carry multiple IAADDR
+	// options (and multiple IA_NA options); selectIANAAddress chooses one
+	// deterministically — longest preferred-lifetime, tie-broken by
+	// first-seen, expired valid-lifetime-0 addresses skipped — and returns
+	// that address's own valid-lifetime so the lease lifetime is never
+	// paired with a stale value from a different address (#4383).
 	var addr netip.Addr
 	var validLT time.Duration
 
 	if wantNA {
-		for _, opt := range adv.Options.Options {
-			if ianaOpt, ok := opt.(*dhcpv6.OptIANA); ok {
-				for _, subOpt := range ianaOpt.Options.Options {
-					if iaaddr, ok := subOpt.(*dhcpv6.OptIAAddress); ok {
-						if a, ok2 := netip.AddrFromSlice(iaaddr.IPv6Addr); ok2 {
-							addr = a
-							validLT = iaaddr.ValidLifetime
-						}
-					}
-				}
-			}
-		}
+		addr, validLT = selectIANAAddress(adv)
 	}
 
 	// Extract IA_PD delegated prefixes
@@ -1578,6 +1629,9 @@ func extractDelegatedPrefixes(msg *dhcpv6.Message, ifaceName string, now time.Ti
 // the NTF_ROUTER flag (learned from Router Advertisements).
 // Retries a few times since RAs may not have been processed yet.
 func (m *Manager) discoverIPv6Router(ctx context.Context, ifaceName string) netip.Addr {
+	if m.nlHandle == nil {
+		return netip.Addr{}
+	}
 	link, err := m.nlHandle.LinkByName(ifaceName)
 	if err != nil {
 		return netip.Addr{}

--- a/pkg/dhcp/dhcpv6_iana_test.go
+++ b/pkg/dhcp/dhcpv6_iana_test.go
@@ -1,0 +1,196 @@
+package dhcp
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/insomniacslk/dhcp/dhcpv6"
+)
+
+// mustIP parses an IPv6 literal for test IAADDR options.
+func mustIP(t *testing.T, s string) net.IP {
+	t.Helper()
+	ip := net.ParseIP(s)
+	if ip == nil {
+		t.Fatalf("bad test IP %q", s)
+	}
+	return ip
+}
+
+// iaNAReply builds a DHCPv6 Reply carrying a single IA_NA with the given
+// IAADDR options, in order.
+func iaNAReply(t *testing.T, addrs ...*dhcpv6.OptIAAddress) *dhcpv6.Message {
+	t.Helper()
+	adv, err := dhcpv6.NewMessage()
+	if err != nil {
+		t.Fatalf("NewMessage: %v", err)
+	}
+	adv.MessageType = dhcpv6.MessageTypeReply
+	iana := &dhcpv6.OptIANA{IaId: [4]byte{0, 0, 0, 1}}
+	for _, a := range addrs {
+		iana.Options.Add(a)
+	}
+	adv.AddOption(iana)
+	return adv
+}
+
+// TestParseV6ReplyMultiIAAddrDeterministic covers #4383: an IA_NA reply may
+// carry more than one IAADDR option, and xpf must select ONE address
+// deterministically instead of installing whichever enumerated last.
+//
+// Reverting selectIANAAddress to the old last-wins overwrite turns the
+// multi-address and valid-lifetime-0 subtests RED — last-wins would install
+// the last-enumerated address and pair the lease with that address's
+// (possibly stale or zero) valid-lifetime.
+func TestParseV6ReplyMultiIAAddrDeterministic(t *testing.T) {
+	m := &Manager{} // nil nlHandle: discoverIPv6Router returns no gateway
+
+	t.Run("longest preferred-lifetime wins, lease uses its valid-lifetime", func(t *testing.T) {
+		// B has the longest preferred-lifetime but is enumerated FIRST, so
+		// last-wins would wrongly pick A (last). Deterministic selection
+		// picks B and pairs LeaseTime with B's own valid-lifetime (600s),
+		// not A's stale 200s.
+		adv := iaNAReply(t,
+			&dhcpv6.OptIAAddress{
+				IPv6Addr:          mustIP(t, "2001:db8::b"),
+				PreferredLifetime: 300 * time.Second,
+				ValidLifetime:     600 * time.Second,
+			},
+			&dhcpv6.OptIAAddress{
+				IPv6Addr:          mustIP(t, "2001:db8::a"),
+				PreferredLifetime: 100 * time.Second,
+				ValidLifetime:     200 * time.Second,
+			},
+		)
+
+		res, err := m.parseV6Reply(context.Background(), "test0", adv, nil)
+		if err != nil {
+			t.Fatalf("parseV6Reply: %v", err)
+		}
+		wantAddr := netip.MustParseAddr("2001:db8::b")
+		if got := res.lease.Address.Addr(); got != wantAddr {
+			t.Errorf("selected address = %v, want %v (longest preferred-lifetime)", got, wantAddr)
+		}
+		if got, want := res.lease.LeaseTime, 600*time.Second; got != want {
+			t.Errorf("lease time = %v, want %v (chosen address's valid-lifetime)", got, want)
+		}
+	})
+
+	t.Run("single-address reply unchanged", func(t *testing.T) {
+		adv := iaNAReply(t, &dhcpv6.OptIAAddress{
+			IPv6Addr:          mustIP(t, "2001:db8::5"),
+			PreferredLifetime: 100 * time.Second,
+			ValidLifetime:     500 * time.Second,
+		})
+		res, err := m.parseV6Reply(context.Background(), "test0", adv, nil)
+		if err != nil {
+			t.Fatalf("parseV6Reply: %v", err)
+		}
+		if got := res.lease.Address.Addr(); got != netip.MustParseAddr("2001:db8::5") {
+			t.Errorf("address = %v, want 2001:db8::5", got)
+		}
+		if got, want := res.lease.LeaseTime, 500*time.Second; got != want {
+			t.Errorf("lease time = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("valid-lifetime-0 address skipped", func(t *testing.T) {
+		// Z has the longest preferred-lifetime AND is enumerated last, so
+		// both last-wins and a naive longest-preferred pick would install
+		// it — but a valid-lifetime-0 address is expired/declined (F-264)
+		// and must be skipped, leaving A the only usable choice.
+		adv := iaNAReply(t,
+			&dhcpv6.OptIAAddress{
+				IPv6Addr:          mustIP(t, "2001:db8::a"),
+				PreferredLifetime: 50 * time.Second,
+				ValidLifetime:     400 * time.Second,
+			},
+			&dhcpv6.OptIAAddress{
+				IPv6Addr:          mustIP(t, "2001:db8::dead"),
+				PreferredLifetime: 999 * time.Second,
+				ValidLifetime:     0,
+			},
+		)
+		res, err := m.parseV6Reply(context.Background(), "test0", adv, nil)
+		if err != nil {
+			t.Fatalf("parseV6Reply: %v", err)
+		}
+		if got := res.lease.Address.Addr(); got != netip.MustParseAddr("2001:db8::a") {
+			t.Errorf("address = %v, want 2001:db8::a (valid-lifetime-0 must be skipped)", got)
+		}
+		if got, want := res.lease.LeaseTime, 400*time.Second; got != want {
+			t.Errorf("lease time = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("all addresses valid-lifetime-0 => no usable IA_NA", func(t *testing.T) {
+		adv := iaNAReply(t, &dhcpv6.OptIAAddress{
+			IPv6Addr:          mustIP(t, "2001:db8::dead"),
+			PreferredLifetime: 100 * time.Second,
+			ValidLifetime:     0,
+		})
+		if _, err := m.parseV6Reply(context.Background(), "test0", adv, nil); err == nil {
+			t.Error("expected error when the only IA_NA address has valid-lifetime 0")
+		}
+	})
+}
+
+// TestSelectIANAAddressTieBreak verifies the first-seen tie-break when two
+// IAADDR options share the longest preferred-lifetime.
+func TestSelectIANAAddressTieBreak(t *testing.T) {
+	adv := iaNAReply(t,
+		&dhcpv6.OptIAAddress{
+			IPv6Addr:          mustIP(t, "2001:db8::c"),
+			PreferredLifetime: 300 * time.Second,
+			ValidLifetime:     700 * time.Second,
+		},
+		&dhcpv6.OptIAAddress{
+			IPv6Addr:          mustIP(t, "2001:db8::d"),
+			PreferredLifetime: 300 * time.Second,
+			ValidLifetime:     800 * time.Second,
+		},
+	)
+	addr, validLT := selectIANAAddress(adv)
+	if addr != netip.MustParseAddr("2001:db8::c") {
+		t.Errorf("tie-break address = %v, want 2001:db8::c (first-seen)", addr)
+	}
+	if validLT != 700*time.Second {
+		t.Errorf("tie-break valid-lifetime = %v, want 700s (first-seen address's own)", validLT)
+	}
+}
+
+// TestSelectIANAAddressMultipleIANA verifies selection scans across more
+// than one IA_NA option in the same reply, not just the first.
+func TestSelectIANAAddressMultipleIANA(t *testing.T) {
+	adv, err := dhcpv6.NewMessage()
+	if err != nil {
+		t.Fatalf("NewMessage: %v", err)
+	}
+	adv.MessageType = dhcpv6.MessageTypeReply
+
+	iana1 := &dhcpv6.OptIANA{IaId: [4]byte{0, 0, 0, 1}}
+	iana1.Options.Add(&dhcpv6.OptIAAddress{
+		IPv6Addr:          mustIP(t, "2001:db8::1"),
+		PreferredLifetime: 100 * time.Second,
+		ValidLifetime:     200 * time.Second,
+	})
+	iana2 := &dhcpv6.OptIANA{IaId: [4]byte{0, 0, 0, 2}}
+	iana2.Options.Add(&dhcpv6.OptIAAddress{
+		IPv6Addr:          mustIP(t, "2001:db8::2"),
+		PreferredLifetime: 500 * time.Second,
+		ValidLifetime:     900 * time.Second,
+	})
+	adv.AddOption(iana1)
+	adv.AddOption(iana2)
+
+	addr, validLT := selectIANAAddress(adv)
+	if addr != netip.MustParseAddr("2001:db8::2") {
+		t.Errorf("address = %v, want 2001:db8::2 (longest preferred across IA_NA options)", addr)
+	}
+	if validLT != 900*time.Second {
+		t.Errorf("valid-lifetime = %v, want 900s", validLT)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #4383 (opus-171 L-2). The DHCPv6 IA_NA extraction loop in
`parseV6Reply` (`pkg/dhcp/dhcp.go`) did a **last-wins overwrite** of
`addr`/`validLT` for every IAADDR option. RFC 8415 §21.4 permits multiple
IAADDR options inside a single IA_NA (and a reply may carry multiple
IA_NA options), so xpf installed whichever address enumerated **last** and
paired the whole lease with that address's valid-lifetime — an
order-dependent choice that could prefer a deprecated address and carry a
stale lifetime. xpf's `Lease` model holds a single `/128`.

## Fix

Extracted the selection into a pure, testable helper `selectIANAAddress`
that chooses deterministically across all IAADDR options in all IA_NA
options:

- **skip** any IAADDR with valid-lifetime 0 — RFC 8415 §12.1 treats a
  zero valid-lifetime as an expired/declined address (ties into F-264);
- among the rest **prefer the longest preferred-lifetime**;
- break ties by **first-seen** (strict greater-than over option order).

The helper returns the **chosen** address's own valid-lifetime, so
`lease.LeaseTime` is never paired with a stale value from a different
IAADDR. When no usable address remains, the caller still returns the
existing `no IA_NA address` error.

Also added a nil-`nlHandle` guard to `discoverIPv6Router` (matching the
guards already present at the other `nlHandle` call sites) so
`parseV6Reply` is unit-testable with a bare `Manager` — no netlink.

## Tests (`pkg/dhcp/dhcpv6_iana_test.go`)

- two-IAADDR reply selects the longest-preferred address + `LeaseTime` =
  its valid-lifetime (longest-preferred enumerated first so last-wins
  would pick the wrong one);
- single-address reply unchanged;
- valid-lifetime-0 IAADDR skipped even when it carries the longest
  preferred-lifetime and enumerates last;
- all-zero-valid reply => no-usable-IA_NA error;
- first-seen tie-break and multi-IA_NA scan covered directly on the helper.

The four deterministic subtests go **RED** when the helper is reverted to
the old last-wins body (verified in place, then restored). `go test
./pkg/dhcp/...` green; `go build ./...`, `gofmt`, `go vet` clean.
Go-only, no dataplane/cargo, no HA/test-failover needed.

Closes #4383

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi