### PR TITLE
screen: window-aware scan/sweep cleanup reap floor (#4379)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -37640,3 +37640,31 @@ top.
   pkg/daemon/daemon_ha.go, pkg/daemon/daemon_ha_sync.go,
   pkg/daemon/ipsec_sa_sync_empty_4385_test.go, pkg/cluster/sync_test.go,
   pkg/cluster/README.md, _Log.md
+
+- **Timestamp**: 2026-07-06
+- **Action**: #4379 (opus-171 M-1) — window-aware scan/sweep cleanup reap
+  floor. The periodic scan/sweep tracker cleanup used a FIXED 1s floor
+  (`CLEANUP_WINDOW_MICROS`) to reap idle tracker state, but #4353/#4114 made
+  the port-scan / ip-sweep `threshold` a configurable MICROSECOND detection
+  window the compiler PRESERVES even above the Junos 1s max. An operator
+  window > 1s (e.g. 5s) had its accumulating distinct-destination set reaped
+  at 1s before the detection count was reached → a slow scan spread across the
+  configured window EVADED detection (fail-open). Fix: `ScanCore::cleanup` /
+  `PortScanTracker::cleanup` / `IpSweepTracker::cleanup` now take a
+  `reap_floor_micros` argument; `maybe_cleanup_trackers` computes the LONGEST
+  configured window per check across all live profiles
+  (`scan_cleanup_floors`) and passes it as the floor, so state survives for
+  the full configured window. The floor is clamped to a documented ceiling
+  `MAX_CLEANUP_WINDOW_MICROS` (300s / 5min) so a pathological (u32-max ~71min)
+  window cannot retain dead weight indefinitely; the per-source
+  (`MAX_UNIQUE_PER_SOURCE`) / per-zone (`MAX_SOURCES_PER_ZONE`) caps bound
+  memory regardless. RED-on-revert tracker test
+  (`slow_scan_within_window_survives_cleanup_reap`, with an in-test control
+  proving the old 1s floor evades) + sub-1s-reaps-at-window, ceiling-clamp,
+  memory-cap, and ScreenState-level max-window wiring tests. Full cargo
+  release serial: lib 3643 passed / 0 failed / 2 ignored; screen:: subset 206
+  passed / 0 failed (incl. 5 new). All other test binaries 0 failed. Only
+  rustfmt-clean changed lines (repo-wide `cargo fmt` drift reverted; verified
+  rustfmt does not touch the new lines).
+- **File(s)**: userspace-dp/src/screen/scan.rs,
+  userspace-dp/src/screen/mod.rs, userspace-dp/src/screen/tests.rs, _Log.md

--- a/userspace-dp/src/screen/mod.rs
+++ b/userspace-dp/src/screen/mod.rs
@@ -1310,13 +1310,47 @@ impl ScreenState {
     /// from the new-flow hook so it is co-located with the only site that
     /// mutates the trackers. `now_micros` is a monotonic microsecond clock;
     /// the 30s throttle derives seconds from it (#4114).
+    ///
+    /// #4379: the reap floor is WINDOW-AWARE. The `threshold` is a per-zone
+    /// configurable MICROSECOND detection window that the compiler PRESERVES
+    /// even above the Junos 1s max (warn-only, no clamp — see
+    /// `pkg/config/compiler_security_screen.go`). A fixed 1s cleanup floor
+    /// reaped an accumulating distinct-destination set before the detection
+    /// count was reached for any operator window > 1s, so a slow scan spread
+    /// across the operator's window EVADED detection (fail-open). Each tracker
+    /// is reaped at the LONGEST window configured for its check across all live
+    /// profiles, so state survives for the full configured window (the reap
+    /// floor is clamped to a documented ceiling inside `cleanup`, and memory
+    /// stays bounded by the per-source/zone caps regardless).
     fn maybe_cleanup_trackers(&mut self, now_micros: u64) {
         let now_secs = now_micros / 1_000_000;
         if now_secs.saturating_sub(self.last_cleanup_secs) >= 30 {
-            self.port_scan.cleanup(now_micros);
-            self.ip_sweep.cleanup(now_micros);
+            let (port_scan_floor, ip_sweep_floor) = self.scan_cleanup_floors();
+            self.port_scan.cleanup(now_micros, port_scan_floor);
+            self.ip_sweep.cleanup(now_micros, ip_sweep_floor);
             self.last_cleanup_secs = now_secs;
         }
+    }
+
+    /// #4379: compute the window-aware cleanup reap floors — the LONGEST
+    /// configured port-scan and ip-sweep detection windows (microseconds)
+    /// across all live screen profiles. A tracker's state must survive for at
+    /// least the longest window that could still detect a slow scan; reaping
+    /// earlier (the pre-#4379 fixed 1s floor) discards an in-progress
+    /// distinct-destination set and lets a slow scan evade detection. A window
+    /// of 0 (feature disabled for that zone) contributes nothing; if every
+    /// profile disables a check the floor is 0 and cleanup reclaims all of that
+    /// tracker's now-idle state. `cleanup` clamps each floor to
+    /// `MAX_CLEANUP_WINDOW_MICROS` so a pathological window cannot retain dead
+    /// weight indefinitely.
+    fn scan_cleanup_floors(&self) -> (u64, u64) {
+        let mut port_scan_floor = 0u64;
+        let mut ip_sweep_floor = 0u64;
+        for profile in self.profiles.values() {
+            port_scan_floor = port_scan_floor.max(u64::from(profile.port_scan_threshold));
+            ip_sweep_floor = ip_sweep_floor.max(u64::from(profile.ip_sweep_threshold));
+        }
+        (port_scan_floor, ip_sweep_floor)
     }
 
     /// #2209: total scan/sweep records skipped because a per-zone source

--- a/userspace-dp/src/screen/scan.rs
+++ b/userspace-dp/src/screen/scan.rs
@@ -58,12 +58,21 @@
 //!   `scan-table-pressure` screen event (see `take_pressure_event`) so the
 //!   operator is told the detector is saturated — never a per-flow log.
 //!
-//! - **Budgeted cleanup.** The periodic sweep walks the source table
-//!   (`HashMap::retain`, O(sources)) but removes at most `CLEANUP_BUDGET`
-//!   expired entries per call, so the per-tick MUTATION cost is bounded even
-//!   though the scan is not. The real ceiling on the walk is the
-//!   `MAX_SOURCES_PER_ZONE` per-zone source cap, which bounds the table size
-//!   itself; the budget just spreads reclamation across ticks.
+//! - **Budgeted, window-aware cleanup (#4353/#4379).** The periodic sweep
+//!   walks the source table (`HashMap::retain`, O(sources)) but removes at
+//!   most `CLEANUP_BUDGET` expired entries per call, so the per-tick MUTATION
+//!   cost is bounded even though the scan is not. The real ceiling on the walk
+//!   is the `MAX_SOURCES_PER_ZONE` per-zone source cap, which bounds the table
+//!   size itself; the budget just spreads reclamation across ticks. The reap
+//!   floor is WINDOW-AWARE: #4353 made the `threshold` a configurable
+//!   MICROSECOND detection window that the compiler PRESERVES even above the
+//!   Junos 1s max, so cleanup is passed the LONGEST configured window across
+//!   the live profiles (clamped to `MAX_CLEANUP_WINDOW_MICROS`) as its floor.
+//!   A fixed 1s floor (the pre-#4379 shape) reaped an accumulating
+//!   distinct-destination set before the detection count was reached for any
+//!   operator window > 1s, so a slow scan spread across the configured window
+//!   EVADED detection (fail-open); the window-aware floor retains state for
+//!   the full configured window.
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::net::IpAddr;
@@ -117,15 +126,27 @@ const EVICT_SCAN_LIMIT: usize = 64;
 /// `pkg/config/compiler_security_screen.go`. The two MUST stay in sync.
 pub(super) const SCAN_DETECT_COUNT: usize = 10;
 
-/// Conservative upper bound (microseconds) on any configurable detection
-/// window, used ONLY by the periodic, zone-agnostic [`ScanCore::cleanup`] to
-/// decide an entry is dead weight. It equals the Junos maximum `threshold`
-/// (1_000_000 us = 1s); an entry untouched for longer than this is expired
-/// under every in-range per-zone window, so cleanup can reclaim it without
-/// knowing each entry's per-zone window. The inline window reset in
-/// [`ScanCore::check`] and the eviction path use the exact per-zone
-/// `window_micros`; this constant is only the cleanup floor.
-const CLEANUP_WINDOW_MICROS: u64 = 1_000_000;
+/// Documented UPPER BOUND (microseconds) on the window-aware cleanup reap
+/// floor (#4379). The periodic, zone-agnostic [`ScanCore::cleanup`] is now
+/// passed the LONGEST configured detection window across the live screen
+/// profiles as its reap floor (so a legitimate multi-second slow-scan window
+/// is not reaped early — the #4379 evasion), but that floor is clamped here so
+/// a fat-fingered / absurd window cannot make the sweep retain dead-weight
+/// state for an unbounded time.
+///
+/// Why a ceiling is safe: the detection `threshold` is operator-configurable
+/// and the compiler warns-but-PRESERVES values above the Junos 1s maximum
+/// (`pkg/config/compiler_security_screen.go`), so a config could name a
+/// u32-max (~71 min) window. Honouring that verbatim as a reap floor would let
+/// dead-weight entries linger for over an hour. 5 minutes comfortably exceeds
+/// any realistic scan/sweep detection window (the Junos in-range max is 1s;
+/// even a preserved multi-second slow-scan window is far under this) while
+/// bounding the pathological case. This is a RECLAMATION-TIMING bound only:
+/// the per-source / per-zone memory caps ([`MAX_UNIQUE_PER_SOURCE`] /
+/// [`MAX_SOURCES_PER_ZONE`]) bound memory regardless of the window, and the
+/// exact per-zone `window_micros` still governs the inline reset/verdict in
+/// [`ScanCore::check`] and the eviction path.
+const MAX_CLEANUP_WINDOW_MICROS: u64 = 300_000_000;
 
 /// Compile-time guard: the eviction sample must be smaller than the per-zone
 /// source cap, otherwise the "sample a prefix" bound would be meaningless
@@ -346,21 +367,29 @@ impl<T: std::hash::Hash + Eq> ScanCore<T> {
     /// decremented for each removed key so the eviction cap test stays exact.
     ///
     /// `now_micros` is the monotonic microsecond clock. This periodic sweep is
-    /// zone-agnostic (it has no single per-zone `window_micros`), so it uses
-    /// the conservative [`CLEANUP_WINDOW_MICROS`] floor: an entry untouched for
-    /// longer than the Junos maximum window is dead under every in-range
-    /// per-zone window. The exact per-zone window still governs the inline
-    /// reset/verdict in [`ScanCore::check`]; cleanup only reclaims memory.
+    /// zone-agnostic (it has no single per-zone `window_micros`), so the caller
+    /// passes `reap_floor_micros` — the LONGEST configured detection window
+    /// across the live screen profiles (#4379). An entry untouched for longer
+    /// than the longest window is dead under EVERY per-zone window, so cleanup
+    /// can reclaim it. Using the fixed 1s Junos-max floor (the pre-#4379 shape)
+    /// reaped an accumulating set before the detection count was reached for
+    /// any operator window > 1s → a slow scan spread across the configured
+    /// window EVADED detection (fail-open). The floor is clamped to
+    /// [`MAX_CLEANUP_WINDOW_MICROS`] so a pathological (fat-fingered) window
+    /// cannot make the sweep retain dead weight indefinitely; memory is
+    /// independently bounded by the per-source/zone caps regardless. The exact
+    /// per-zone window still governs the inline reset/verdict in
+    /// [`ScanCore::check`]; cleanup only reclaims memory.
     #[inline]
-    fn cleanup(&mut self, now_micros: u64) {
+    fn cleanup(&mut self, now_micros: u64, reap_floor_micros: u64) {
+        let floor = reap_floor_micros.min(MAX_CLEANUP_WINDOW_MICROS);
         let mut removed = 0usize;
         let per_zone_count = &mut self.per_zone_count;
         self.per_src.retain(|key, (start, set)| {
             if removed >= CLEANUP_BUDGET {
                 return true; // budget exhausted — keep the rest for next tick
             }
-            let expired =
-                now_micros.saturating_sub(*start) >= CLEANUP_WINDOW_MICROS || set.is_empty();
+            let expired = now_micros.saturating_sub(*start) >= floor || set.is_empty();
             if expired {
                 removed += 1;
                 if let Some(c) = per_zone_count.get_mut(&key.0) {
@@ -426,9 +455,10 @@ impl PortScanTracker {
     }
 
     /// Remove expired entries (budgeted periodic cleanup). `now_micros` is a
-    /// monotonic microsecond clock.
-    pub(super) fn cleanup(&mut self, now_micros: u64) {
-        self.core.cleanup(now_micros);
+    /// monotonic microsecond clock; `reap_floor_micros` is the window-aware
+    /// reap floor (longest configured port-scan window across profiles, #4379).
+    pub(super) fn cleanup(&mut self, now_micros: u64, reap_floor_micros: u64) {
+        self.core.cleanup(now_micros, reap_floor_micros);
     }
 
     /// Records skipped due to a per-source unique-entry cap or a failed
@@ -480,9 +510,10 @@ impl IpSweepTracker {
     }
 
     /// Remove expired entries (budgeted periodic cleanup). `now_micros` is a
-    /// monotonic microsecond clock.
-    pub(super) fn cleanup(&mut self, now_micros: u64) {
-        self.core.cleanup(now_micros);
+    /// monotonic microsecond clock; `reap_floor_micros` is the window-aware
+    /// reap floor (longest configured ip-sweep window across profiles, #4379).
+    pub(super) fn cleanup(&mut self, now_micros: u64, reap_floor_micros: u64) {
+        self.core.cleanup(now_micros, reap_floor_micros);
     }
 
     /// Records skipped due to a per-source unique-entry cap or a failed
@@ -520,6 +551,12 @@ mod scan_tests {
 
     /// Junos default window (microseconds) used across the windowing tests.
     const W: u64 = 5_000;
+
+    /// The pre-#4379 fixed cleanup floor (the Junos in-range max window, 1s).
+    /// Retained as a test anchor: the budgeted/count cleanup tests age entries
+    /// relative to it and pass it explicitly as the (now window-aware) reap
+    /// floor argument.
+    const OLD_CLEANUP_FLOOR: u64 = 1_000_000;
 
     #[test]
     fn port_scan_keyed_per_zone_no_cross_count() {
@@ -685,7 +722,7 @@ mod scan_tests {
         assert_eq!(t.tracked_sources(), seed);
         // Far past the cleanup window — all are expired, but one sweep removes
         // only up to the budget.
-        t.cleanup(2 * CLEANUP_WINDOW_MICROS);
+        t.cleanup(2 * OLD_CLEANUP_FLOOR, OLD_CLEANUP_FLOOR);
         assert_eq!(t.tracked_sources(), seed - CLEANUP_BUDGET);
     }
 
@@ -854,7 +891,7 @@ mod scan_tests {
         }
         assert_eq!(core.zone_count(5), 10);
         // Age everything out; cleanup removes them and the count follows.
-        core.cleanup(2 * CLEANUP_WINDOW_MICROS);
+        core.cleanup(2 * OLD_CLEANUP_FLOOR, OLD_CLEANUP_FLOOR);
         assert_eq!(core.zone_count(5), 0, "count decremented on cleanup");
         assert_eq!(core.per_src.len(), 0);
     }
@@ -877,6 +914,132 @@ mod scan_tests {
         assert_eq!(
             events, 10,
             "pressure events must be logarithmic in eviction count, got {events}"
+        );
+    }
+
+    /// #4379 fail-on-revert: with an operator-configured detection window LONGER
+    /// than the old fixed 1s cleanup floor, a SLOW scan whose distinct
+    /// destinations are spread across that window (each within the window, the
+    /// span > 1s) must still be DETECTED — the periodic cleanup must NOT reap
+    /// the accumulating tracker state at the old fixed 1s floor. Pre-#4379,
+    /// `cleanup` reaped any entry older than a fixed 1s floor (the historical
+    /// `CLEANUP_WINDOW_MICROS`), so a probe landing >1s after the window opened
+    /// found its distinct-destination set already reclaimed, the count reset to
+    /// 1, and the scan EVADED detection (fail-open). The window-aware floor
+    /// (the configured window) retains the state for the full window. RED on
+    /// revert: the tracker never fires because cleanup drops the state at 1s.
+    #[test]
+    fn slow_scan_within_window_survives_cleanup_reap() {
+        let mut t = IpSweepTracker::default();
+        let src = v4(1);
+        // Operator-configured 5s window (> the old 1s cleanup floor). This is
+        // what #4379 passes to cleanup as the window-aware reap floor.
+        let window = 5_000_000u64;
+        let mut now = 1_000_000u64;
+        let mut fired = false;
+        for i in 0..SCAN_DETECT_COUNT as u32 {
+            let dst = IpAddr::V4(Ipv4Addr::from(0x0e00_0000u32 + i));
+            if t.check(0, src, dst, now, window) {
+                fired = true;
+            }
+            // A periodic cleanup fires between probes (production runs it every
+            // >=30s from the new-flow hook). With the window-aware floor the
+            // live entry survives; with the pre-#4379 fixed 1s floor it is
+            // reaped once `now - start >= 1s`, resetting the distinct count.
+            t.cleanup(now, window);
+            now += 250_000; // 250ms between probes → the 10 probes span ~2.25s
+        }
+        assert!(
+            fired,
+            "a slow scan spread across the configured window must be detected: \
+             the cleanup must not reap live tracker state at the old 1s floor"
+        );
+        // Control: reaping at the OLD fixed 1s floor DOES lose the state — this
+        // is exactly the evasion the window-aware floor closes. A fresh tracker
+        // fed the same slow scan but cleaned at the 1s floor never fires.
+        let mut evaded = IpSweepTracker::default();
+        let mut now2 = 1_000_000u64;
+        let mut fired2 = false;
+        for i in 0..SCAN_DETECT_COUNT as u32 {
+            let dst = IpAddr::V4(Ipv4Addr::from(0x0e00_0000u32 + i));
+            if evaded.check(0, src, dst, now2, window) {
+                fired2 = true;
+            }
+            evaded.cleanup(now2, OLD_CLEANUP_FLOOR); // pre-#4379 fixed floor
+            now2 += 250_000;
+        }
+        assert!(
+            !fired2,
+            "control: reaping at the fixed 1s floor loses the accumulating set \
+             so the slow scan evades — this is the #4379 fail-open"
+        );
+    }
+
+    /// #4379: a SUB-1s configured window reaps at the WINDOW, not at the old
+    /// fixed 1s floor — idle state is not held longer than the operator's
+    /// window needs. RED on revert: the fixed 1s floor would retain the entry
+    /// (6ms < 1s), so this asserts the floor genuinely tracks the window.
+    #[test]
+    fn small_window_reaps_at_window_not_old_floor() {
+        let mut t = IpSweepTracker::default();
+        let src = v4(1);
+        let window = W; // 5ms — a sub-1s window
+        t.check(0, src, v4(9), 1_000_000, window);
+        assert_eq!(t.tracked_sources(), 1);
+        // 6ms later: past the 5ms window but far under the old 1s floor. The
+        // window-aware floor reaps; the pre-#4379 fixed floor would retain.
+        t.cleanup(1_000_000 + window + 1_000, window);
+        assert_eq!(
+            t.tracked_sources(),
+            0,
+            "a sub-1s window must reap at the window, not be held to the 1s floor"
+        );
+    }
+
+    /// #4379 upper bound: an ABSURD configured window (u32-max, ~71 min) does
+    /// NOT make cleanup retain dead weight indefinitely — the reap floor is
+    /// clamped to `MAX_CLEANUP_WINDOW_MICROS`. An entry older than the ceiling
+    /// is reclaimed even though the raw window is far larger. (Memory is
+    /// independently bounded by the per-source/zone caps regardless; this only
+    /// bounds reclamation TIMING.) Guards against a no-clamp regression: a raw
+    /// 71min floor would retain the entry at now=5min+ε.
+    #[test]
+    fn cleanup_floor_clamped_to_ceiling() {
+        let mut t = IpSweepTracker::default();
+        let src = v4(1);
+        let absurd_window = u64::from(u32::MAX); // ~4295s ~ 71min
+        t.check(0, src, v4(9), 0, absurd_window);
+        assert_eq!(t.tracked_sources(), 1);
+        // now just past the CEILING but far under the raw window: the clamp
+        // makes the entry expired; without the clamp it would survive.
+        t.cleanup(MAX_CLEANUP_WINDOW_MICROS + 1, absurd_window);
+        assert_eq!(
+            t.tracked_sources(),
+            0,
+            "the reap floor must be clamped to the ceiling so an absurd window \
+             cannot retain dead-weight state indefinitely"
+        );
+    }
+
+    /// #4379: the memory caps still bound state independently of the
+    /// window-aware cleanup floor. Even with a huge window (so cleanup would
+    /// retain everything), a single source's unique-entry set is capped at
+    /// `MAX_UNIQUE_PER_SOURCE` and the surplus is counted as pressure — the
+    /// cleanup floor change does not unbound memory.
+    #[test]
+    fn memory_caps_bound_state_under_wide_window() {
+        let mut t = IpSweepTracker::default();
+        let src = v4(1);
+        let wide = MAX_CLEANUP_WINDOW_MICROS; // nothing resets or reaps in-test
+        for i in 0..(MAX_UNIQUE_PER_SOURCE + 50) {
+            let dst = IpAddr::V4(Ipv4Addr::from(0x0c10_0000u32 + i as u32));
+            t.check(9, src, dst, 100, wide);
+        }
+        assert_eq!(t.tracked_sources(), 1);
+        assert!(
+            t.skipped_pressure() >= 50,
+            "the per-source set stays capped even under a wide window: {}",
+            t.skipped_pressure()
         );
     }
 }

--- a/userspace-dp/src/screen/tests.rs
+++ b/userspace-dp/src/screen/tests.rs
@@ -3997,6 +3997,40 @@ const ZID: u16 = 7;
 /// (#4114). The detection COUNT is the fixed `super::scan::SCAN_DETECT_COUNT`.
 const SWEEP_W: u32 = 5_000;
 
+/// #4379: the window-aware cleanup reap floor is the LONGEST configured
+/// detection window across ALL live profiles, computed independently per check
+/// (port-scan vs ip-sweep). This locks the wiring that feeds
+/// `PortScanTracker::cleanup` / `IpSweepTracker::cleanup` their reap floor so a
+/// slow scan within an operator window > 1s is not reaped early (the #4379
+/// evasion). A disabled check (window 0) contributes nothing.
+#[test]
+fn scan_cleanup_floors_are_max_configured_window() {
+    let mut state = ScreenState::new();
+    let mut profiles = FxHashMap::default();
+    // zone "a": port-scan 5s, ip-sweep 2s.
+    let mut a = ScreenProfile::default();
+    a.port_scan_threshold = 5_000_000;
+    a.ip_sweep_threshold = 2_000_000;
+    profiles.insert("a".to_string(), a);
+    // zone "b": port-scan 1s, ip-sweep 9s. The floor must be the MAX across
+    // zones per check: port=5s (from a), sweep=9s (from b).
+    let mut b = ScreenProfile::default();
+    b.port_scan_threshold = 1_000_000;
+    b.ip_sweep_threshold = 9_000_000;
+    profiles.insert("b".to_string(), b);
+    // zone "c": both disabled — must not lower the max.
+    profiles.insert("c".to_string(), ScreenProfile::default());
+    state.update_profiles(profiles);
+
+    let (port_floor, sweep_floor) = state.scan_cleanup_floors();
+    assert_eq!(port_floor, 5_000_000, "port floor = max port_scan window");
+    assert_eq!(sweep_floor, 9_000_000, "sweep floor = max ip_sweep window");
+
+    // No profiles at all → both floors 0 (cleanup then reclaims idle state).
+    state.update_profiles(FxHashMap::default());
+    assert_eq!(state.scan_cleanup_floors(), (0, 0));
+}
+
 #[test]
 fn port_scan_detected() {
     let mut profile = ScreenProfile::default();


### PR DESCRIPTION
## Summary

Fixes #4379 (opus-171 M-1): the scan/sweep tracker cleanup reaped idle
per-`(zone, src)` state at a **fixed 1s floor** (`CLEANUP_WINDOW_MICROS`),
but #4353/#4114 made the port-scan / ip-sweep `threshold` a configurable
**microsecond detection window** that the compiler warns-but-**preserves**
even above the Junos 1s max. A configured window > 1s (e.g. `threshold
5000000` = 5s) reached the dataplane intact and `ScanCore::check` honoured it,
but cleanup reaped state at 1s — so a **slow scan** spread across the
operator's window (> 1s, each probe within the window) had its accumulating
distinct-destination set reclaimed **before** the detection count was reached
and **evaded detection (fail-open)**.

## Fix

The cleanup reap floor is now **window-aware**:

- `ScanCore::cleanup` + the `PortScanTracker` / `IpSweepTracker` wrappers take
  `reap_floor_micros` (`userspace-dp/src/screen/scan.rs`).
- `maybe_cleanup_trackers` computes the **longest configured window per check**
  across all live profiles via `scan_cleanup_floors` and passes each tracker
  its floor (`userspace-dp/src/screen/mod.rs`), so state survives for the full
  configured detection window.
- The floor is clamped to a documented ceiling `MAX_CLEANUP_WINDOW_MICROS`
  (300s / 5 min) so a fat-fingered / absurd window (u32-max ~71 min) cannot
  retain dead weight indefinitely. This is a **reclamation-timing** bound only:
  `MAX_UNIQUE_PER_SOURCE` + `MAX_SOURCES_PER_ZONE` bound memory regardless, and
  the exact per-zone window still governs the inline reset/verdict in `check()`
  and the eviction path.

## Tests (RED on revert)

- `slow_scan_within_window_survives_cleanup_reap` — 10-dest scan ~250ms apart
  over ~2.25s within a 5s window is **detected**; an in-test control cleaned at
  the old 1s floor never fires (demonstrates the evasion directly).
- `small_window_reaps_at_window_not_old_floor` — sub-1s window reaps at the
  window.
- `cleanup_floor_clamped_to_ceiling` — u32-max window is clamped (upper bound).
- `memory_caps_bound_state_under_wide_window` — per-source cap still bounds.
- `scan_cleanup_floors_are_max_configured_window` — ScreenState wiring feeds
  each tracker the max configured window.

**Full cargo release serial (`--test-threads=1`):** lib 3643 passed / 0 failed
/ 2 ignored; `screen::` subset 206 passed / 0 failed (incl. 5 new). All other
test binaries 0 failed.

## Docs

`scan.rs` module doc, `ScanCore::cleanup` / `maybe_cleanup_trackers` /
`scan_cleanup_floors` doc comments, and the `MAX_CLEANUP_WINDOW_MICROS`
rationale updated. No operator-facing doc change — the fix restores the
already-documented "detect over the configured window" semantics.

## Validation note

Dataplane screen change: a cluster screen-smoke (a slow scan over a
multi-second configured window IS detected) is warranted before merge.

Closes #4379

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi