### PR TITLE
firewall: reject single-family prefix-lists under `family any` (#4426)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,37 @@
+## 2026-07-06 — #4426: reject single-family prefix-lists under `family any`
+
+- **Timestamp**: 2026-07-06
+- **Action**: Closed the C164-H04 audit residual (#4426). #4296 rejects a
+  static family-specific match (address literal, per-family icmp
+  type/code) under `family any` but deliberately excludes
+  `source-prefix-list` / `destination-prefix-list` because a NAMED
+  prefix-list may mix families. Verify-first (probe test on
+  origin/master) confirmed the gap is live: a `family any` filter with a
+  v4-only `source-prefix-list` compiles cleanly into BOTH the inet and
+  inet6 pools (#4287 dual-compile), leaving the v6 arm constrained by a
+  v4-only list — it matches no v6 packet and falls through to the
+  implicit ACCEPT (silent v6 under-block). Extended
+  `validateFirewallFilterFamilyAnyMatchesAST` to resolve each
+  prefix-list reference against the candidate tree's `policy-options
+  prefix-list` definitions (new `firewallPrefixListFamilies` /
+  `prefixFamily`, mirroring `compilePolicyOptions`' #3996 dual-shape
+  read). Coverage is aggregated PER DIRECTION across every `from` block:
+  a direction whose referenced prefix-lists collectively cover exactly
+  ONE family is rejected at strict commit / warned on the lenient
+  load-sync path, matching the #4296 remedy (reject-at-commit pointing
+  the operator at `family inet`/`family inet6`). A mixed-family list, two
+  single-family lists that together cover both families, an empty list,
+  and an undefined reference are all NOT flagged (undefined stays the
+  province of `validateFirewallPrefixListReferencesStrict`).
+  RED-on-revert proven: v4-only + v6-only reject tests and the lenient
+  warn test all go RED on the origin/master `compiler_firewall.go`.
+  `go build ./...`, `go vet`, `gofmt`, and the full `pkg/config` +
+  `pkg/dataplane` suites are green. Commit-path only (no dataplane wire
+  change) — no cluster smoke required.
+- **File(s)**: pkg/config/compiler_firewall.go,
+  pkg/config/compiler_firewall_family_any_prefixlist_4426_test.go,
+  docs/config-schema.md, _Log.md
+
 ## 2026-07-06 — #4399: nat_reverse_index 1:N multimap + validate-on-lookup
 
 - **Timestamp**: 2026-07-06

--- a/_Log.md
+++ b/_Log.md
@@ -25,6 +25,18 @@
   province of `validateFirewallPrefixListReferencesStrict`).
   RED-on-revert proven: v4-only + v6-only reject tests and the lenient
   warn test all go RED on the origin/master `compiler_firewall.go`.
+  Coordinator-review fold: the gate now tracks POSITIVE vs `except`
+  refs separately (`hasPos`/`hasExc`, `posFam`/`excFam`) because they
+  fail in OPPOSITE ways under `family any` — a single-family positive
+  list under-blocks the missing family (arm matches nothing) while a
+  sole single-family `except` list OVER-matches it (arm is `except` over
+  an empty set = match ALL; the clean-except branch of
+  resolvePrefixListAddrs, #4338). The two cases now emit DIFFERENT
+  messages (an inverted "under-block" message for the `except` case
+  would be misinformation worse than the gap). Verified the
+  `except`+`accept` fail-open (v6 arm accepts EVERY v6 packet) is caught
+  with the over-accept wording. RED-on-revert also proven for the except
+  branch (the pre-fold version emits the inverted under-block message).
   `go build ./...`, `go vet`, `gofmt`, and the full `pkg/config` +
   `pkg/dataplane` suites are green. Commit-path only (no dataplane wire
   change) — no cluster smoke required.

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1148,12 +1148,29 @@ prefix-list reference against the candidate tree's `policy-options prefix-list`
 definitions (via `firewallPrefixListFamilies`, which mirrors
 `compilePolicyOptions`' #3996 dual-shape prefix read so the family verdict
 matches what the compiler loads). Coverage is aggregated **per direction**
-across every `from` block of the term: if a direction's referenced prefix-lists
-collectively cover **exactly one** family, the term is rejected at strict commit
-/ warned on the lenient load path with a message naming the under-blocked arm
-and the offending lists. Accepted (not flagged):
+across every `from` block of the term, tracking **positive** and **`except`**
+references separately (`hasPos`/`hasExc`, `posFam`/`excFam`) because they fail
+in **opposite** ways under `family any`, mirroring `resolvePrefixListAddrs`
+(#4338):
 
-- a **mixed-family** prefix-list (v4 AND v6 prefixes in one list),
+- A single-family **positive** list (`from source-prefix-list v4-only`) leaves
+  the missing-family arm with no matching prefixes → matches **nothing** → falls
+  through to the implicit ACCEPT → a silent **under-block**.
+- A single-family **`except`** list (`from source-prefix-list v4-only except`)
+  is the clean-except case: the missing-family arm evaluates `except` over a set
+  with no entries for that family = **match ALL** → an **over-block** on `then
+  discard`, a fail-**open** over-accept on `then accept` — the *opposite* of an
+  under-block. (A defined positive ref makes the direction positive-wins and any
+  `except` ref is dropped, so the except branch only fires for a *sole* `except`
+  reference — exactly the runtime's clean-except path.)
+
+Each is rejected at strict commit / warned on the lenient load path with a
+message describing the **correct** failure mode (an inverted "under-block"
+message for the `except` case would be misinformation worse than the gap).
+Accepted (not flagged):
+
+- a **mixed-family** prefix-list (v4 AND v6 prefixes in one list — positive or
+  `except`),
 - **two single-family lists** in one direction that together cover both
   families (`source-prefix-list { v4-only; v6-only; }`),
 - an **empty** list (both-families-absent → left to the empty-set match
@@ -1163,9 +1180,11 @@ and the offending lists. Accepted (not flagged):
 Same reachability as #4287/#4296 (hierarchical / peer-synced AST only; the flat
 `set` grammar does not model `family any`). Fail-on-revert:
 `pkg/config/compiler_firewall_family_any_prefixlist_4426_test.go` (strict reject
-of a v4-only and a v6-only list; lenient warn preserving the dual-compile;
-mixed-family and two-list-both-families commit; single-family filters with
-single-family lists not flagged).
+of a v4-only and a v6-only positive list with the under-block message; strict
+reject of a v4-only `except` list — and an `except`+`accept` fail-open — with
+the over-match message, NOT the under-block wording; lenient warn preserving the
+dual-compile; mixed-family, mixed-family-except, and two-list-both-families
+commit; single-family filters with single-family lists not flagged).
 
 ## Repeated same-type sibling matches (NOT bracketed multi-value)
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1132,6 +1132,41 @@ Fail-on-revert: `pkg/config/compiler_firewall_family_any_match_4296_test.go`
 family-agnostic `protocol` under `family any` still commits into both pools;
 single-family filters with address literals not flagged).
 
+### Single-family prefix-lists under `family any` are rejected (#4426)
+
+The #4296 gate deliberately leaves `source-prefix-list` /
+`destination-prefix-list` alone because a *named* prefix-list MAY mix v4+v6 —
+its family content is not knowable from the leaf keyword. But a reference whose
+**resolved** prefixes cover only ONE family reproduces the exact same
+under-block (audit codex-164 C164-H04): `from source-prefix-list v4-only then
+discard` under `family any` dual-compiles the v4-only list into the inet6 pool,
+where the v6 arm has zero v6 prefixes, matches nothing, and falls through to the
+implicit ACCEPT — a silent v6 under-block.
+
+`validateFirewallFilterFamilyAnyMatchesAST` therefore also resolves every
+prefix-list reference against the candidate tree's `policy-options prefix-list`
+definitions (via `firewallPrefixListFamilies`, which mirrors
+`compilePolicyOptions`' #3996 dual-shape prefix read so the family verdict
+matches what the compiler loads). Coverage is aggregated **per direction**
+across every `from` block of the term: if a direction's referenced prefix-lists
+collectively cover **exactly one** family, the term is rejected at strict commit
+/ warned on the lenient load path with a message naming the under-blocked arm
+and the offending lists. Accepted (not flagged):
+
+- a **mixed-family** prefix-list (v4 AND v6 prefixes in one list),
+- **two single-family lists** in one direction that together cover both
+  families (`source-prefix-list { v4-only; v6-only; }`),
+- an **empty** list (both-families-absent → left to the empty-set match
+  semantics), and an **undefined** reference (left to
+  `validateFirewallPrefixListReferencesStrict`).
+
+Same reachability as #4287/#4296 (hierarchical / peer-synced AST only; the flat
+`set` grammar does not model `family any`). Fail-on-revert:
+`pkg/config/compiler_firewall_family_any_prefixlist_4426_test.go` (strict reject
+of a v4-only and a v6-only list; lenient warn preserving the dual-compile;
+mixed-family and two-list-both-families commit; single-family filters with
+single-family lists not flagged).
+
 ## Repeated same-type sibling matches (NOT bracketed multi-value)
 
 The dual-AST contract above covers a single leaf carrying a bracketed list

--- a/pkg/config/compiler_firewall.go
+++ b/pkg/config/compiler_firewall.go
@@ -439,12 +439,81 @@ func validateFirewallFilterFamilyCollisionsAST(nodes []*Node, lenient bool) ([]s
 // (next-header is the inet6 spelling of `protocol` and matches family-agnostic
 // L4 protocol NUMBERS, so it is NOT family-specific and is deliberately absent.
 // source-prefix-list / destination-prefix-list reference NAMED prefix-lists that
-// may legitimately mix v4 and v6 prefixes, so they are also not flagged here.)
+// may legitimately mix v4 and v6 prefixes, so they are NOT in this static set —
+// their family content is not knowable from the leaf keyword alone. A prefix-list
+// whose RESOLVED prefixes cover only ONE family is caught separately by the
+// content-aware check in validateFirewallFilterFamilyAnyMatchesAST — see #4426.)
 var familyAnySpecificMatches = map[string]bool{
 	"source-address":      true,
 	"destination-address": true,
 	"icmp-type":           true,
 	"icmp-code":           true,
+}
+
+// plFamily records which address families a prefix-list's resolved prefixes
+// cover. Both false means empty or all-unclassifiable; both true means a
+// legitimately mixed v4+v6 list; exactly one true is a single-family list.
+type plFamily struct {
+	hasV4 bool
+	hasV6 bool
+}
+
+// prefixFamily classifies a single prefix-list entry as IPv4 or IPv6 by the
+// only discriminator that cannot collide: a v6 literal always contains a colon
+// and a v4 dotted-quad always contains a dot but never a colon. The optional
+// `/len` mask is stripped first. A token that is neither (garbage — caught
+// elsewhere by the prefix-list validators) sets neither flag so it never drives
+// a false single-family verdict.
+func prefixFamily(p string) (v4, v6 bool) {
+	host := p
+	if i := strings.IndexByte(host, '/'); i >= 0 {
+		host = host[:i]
+	}
+	if strings.Contains(host, ":") {
+		return false, true
+	}
+	if strings.Contains(host, ".") {
+		return true, false
+	}
+	return false, false
+}
+
+// firewallPrefixListFamilies collects, for every `policy-options prefix-list
+// NAME`, the address families its resolved prefixes cover. It mirrors
+// compilePolicyOptions' prefix reading exactly (namedInstances +
+// inst.node.Children, each child's full Keys slice — the #3996 dual-shape
+// read), so the family verdict matches what the compiler actually loads. The
+// tree passed here is already apply-groups-expanded, so applied group
+// prefix-lists are inlined at top level; an un-applied group's prefix-list is
+// absent, matching the compiler (which ignores both it and any reference to
+// it). Used by the #4426 family-any single-family prefix-list gate.
+func firewallPrefixListFamilies(nodes []*Node) map[string]plFamily {
+	out := map[string]plFamily{}
+	for _, top := range nodes {
+		if top == nil || top.Name() != "policy-options" {
+			continue
+		}
+		for _, inst := range namedInstances(top.FindChildren("prefix-list")) {
+			if inst.name == "" {
+				continue
+			}
+			fam := out[inst.name]
+			for _, entry := range inst.node.Children {
+				for _, p := range entry.Keys {
+					if p == "" {
+						continue
+					}
+					if v4, v6 := prefixFamily(p); v4 {
+						fam.hasV4 = true
+					} else if v6 {
+						fam.hasV6 = true
+					}
+				}
+			}
+			out[inst.name] = fam
+		}
+	}
+	return out
 }
 
 // validateFirewallFilterFamilyAnyMatchesAST walks every top-level `firewall`
@@ -473,10 +542,26 @@ var familyAnySpecificMatches = map[string]bool{
 // an already-persisted or peer-synced config that an older binary silently
 // accepted still BOOTS (#1960 / #3261 fail-closed-on-load doctrine).
 //
+// #4426 residual: a `source-prefix-list` / `destination-prefix-list` reference
+// is not a static family-specific keyword (a named prefix-list MAY mix families),
+// so it is deliberately NOT in familyAnySpecificMatches. But a reference whose
+// RESOLVED prefixes cover only ONE family reproduces the SAME v6 (or v4)
+// under-block: `from source-prefix-list v4-only then discard` under `family any`
+// dual-compiles the v4-only list into the inet6 pool, where the v6 arm has zero
+// v6 prefixes, matches nothing, and falls through to the implicit ACCEPT. This
+// gate therefore also resolves each prefix-list reference against the candidate
+// tree's `policy-options prefix-list` definitions and rejects (strict) / warns
+// (lenient) when a DIRECTION's referenced prefix-lists collectively cover a
+// single family only. A mixed-family list, or two lists that together cover both
+// families in one direction, is accepted — that is the legitimate `family any`
+// shape #4287 enables. An empty or undefined reference is left to the empty-set
+// semantics and validateFirewallPrefixListReferencesStrict respectively.
+//
 // The traversal mirrors compileFirewall's family/filter/term/from walk exactly
 // (BOTH AST shapes) and aggregates across every top-level `firewall {}` block.
 func validateFirewallFilterFamilyAnyMatchesAST(nodes []*Node, lenient bool) ([]string, error) {
 	var warnings []string
+	plFamilies := firewallPrefixListFamilies(nodes)
 	for _, fwNode := range nodes {
 		if fwNode.Name() != "firewall" {
 			continue
@@ -508,9 +593,42 @@ func validateFirewallFilterFamilyAnyMatchesAST(nodes []*Node, lenient bool) ([]s
 						continue
 					}
 					for _, termInst := range namedInstances(filterInst.node.FindChildren("term")) {
+						// Per-direction prefix-list family coverage, accumulated
+						// across every `from` block of the term (#4426). Index 0 =
+						// source, 1 = destination.
+						var dirFam [2]plFamily
+						var dirNames [2][]string
 						for _, fromNode := range termInst.node.FindChildren("from") {
 							for _, child := range fromNode.Children {
 								mname := child.Name()
+								// #4426: accumulate the resolved family coverage of
+								// every source/destination-prefix-list reference so a
+								// single-family list under `family any` is caught below.
+								dir := -1
+								switch mname {
+								case "source-prefix-list":
+									dir = 0
+								case "destination-prefix-list":
+									dir = 1
+								}
+								if dir >= 0 {
+									for _, ref := range firewallPrefixListRefs(child) {
+										fam, ok := plFamilies[ref.Name]
+										if !ok {
+											// Undefined reference — left to
+											// validateFirewallPrefixListReferencesStrict.
+											continue
+										}
+										if fam.hasV4 {
+											dirFam[dir].hasV4 = true
+										}
+										if fam.hasV6 {
+											dirFam[dir].hasV6 = true
+										}
+										dirNames[dir] = append(dirNames[dir], ref.Name)
+									}
+									continue
+								}
 								if !familyAnySpecificMatches[mname] {
 									continue
 								}
@@ -526,6 +644,30 @@ func validateFirewallFilterFamilyAnyMatchesAST(nodes []*Node, lenient bool) ([]s
 								}
 								warnings = append(warnings, msg)
 							}
+						}
+						// #4426: a direction whose referenced prefix-lists together
+						// cover exactly ONE family under `family any` under-blocks the
+						// other family (the missing-family arm matches nothing / falls
+						// through). Reject strict / warn lenient, mirroring the #4296
+						// remedy. Both-families and empty coverage are fine.
+						for dir, keyword := range [2]string{"source-prefix-list", "destination-prefix-list"} {
+							fam := dirFam[dir]
+							if fam.hasV4 == fam.hasV6 {
+								// both (legit mixed / dual-list) or neither (empty).
+								continue
+							}
+							haveFam, missFam := "inet (v4)", "inet6 (v6)"
+							if fam.hasV6 {
+								haveFam, missFam = "inet6 (v6)", "inet (v4)"
+							}
+							msg := fmt.Sprintf(
+								"firewall filter %q term %q: `from %s %s` references only %s prefixes under `family any` — a family any filter compiles into BOTH the inet (v4) and inet6 (v6) pools (#4287), so the %s arm has no matching prefixes and silently under-blocks that family; use `family inet` / `family inet6`, or a prefix-list covering both families (#4426)",
+								filterInst.name, termInst.name, keyword,
+								strings.Join(dirNames[dir], " "), haveFam, missFam)
+							if !lenient {
+								return nil, fmt.Errorf("%s", msg)
+							}
+							warnings = append(warnings, msg)
 						}
 					}
 				}

--- a/pkg/config/compiler_firewall.go
+++ b/pkg/config/compiler_firewall.go
@@ -593,10 +593,18 @@ func validateFirewallFilterFamilyAnyMatchesAST(nodes []*Node, lenient bool) ([]s
 						continue
 					}
 					for _, termInst := range namedInstances(filterInst.node.FindChildren("term")) {
-						// Per-direction prefix-list family coverage, accumulated
-						// across every `from` block of the term (#4426). Index 0 =
-						// source, 1 = destination.
-						var dirFam [2]plFamily
+						// Per-direction prefix-list coverage, accumulated across
+						// every `from` block of the term (#4426). Index 0 = source,
+						// 1 = destination. POSITIVE (`source-prefix-list X`) and
+						// EXCEPT (`source-prefix-list X except`) refs are tracked
+						// SEPARATELY because they fail differently under `family
+						// any`: a single-family POSITIVE list under-blocks the
+						// missing family (its arm matches nothing), while a
+						// single-family EXCEPT list OVER-matches the missing family
+						// (that arm is `except` over an empty set = match ALL — the
+						// clean-except branch of resolvePrefixListAddrs, #4338).
+						var posFam, excFam [2]plFamily
+						var hasPos, hasExc [2]bool
 						var dirNames [2][]string
 						for _, fromNode := range termInst.node.FindChildren("from") {
 							for _, child := range fromNode.Children {
@@ -619,13 +627,24 @@ func validateFirewallFilterFamilyAnyMatchesAST(nodes []*Node, lenient bool) ([]s
 											// validateFirewallPrefixListReferencesStrict.
 											continue
 										}
-										if fam.hasV4 {
-											dirFam[dir].hasV4 = true
-										}
-										if fam.hasV6 {
-											dirFam[dir].hasV6 = true
-										}
 										dirNames[dir] = append(dirNames[dir], ref.Name)
+										if ref.Except {
+											hasExc[dir] = true
+											if fam.hasV4 {
+												excFam[dir].hasV4 = true
+											}
+											if fam.hasV6 {
+												excFam[dir].hasV6 = true
+											}
+										} else {
+											hasPos[dir] = true
+											if fam.hasV4 {
+												posFam[dir].hasV4 = true
+											}
+											if fam.hasV6 {
+												posFam[dir].hasV6 = true
+											}
+										}
 									}
 									continue
 								}
@@ -645,25 +664,62 @@ func validateFirewallFilterFamilyAnyMatchesAST(nodes []*Node, lenient bool) ([]s
 								warnings = append(warnings, msg)
 							}
 						}
-						// #4426: a direction whose referenced prefix-lists together
-						// cover exactly ONE family under `family any` under-blocks the
-						// other family (the missing-family arm matches nothing / falls
-						// through). Reject strict / warn lenient, mirroring the #4296
-						// remedy. Both-families and empty coverage are fine.
+						// #4426: a direction whose referenced prefix-lists cover
+						// exactly ONE family under `family any` is a commit-time
+						// surprise — but the failure mode (and so the message) differs
+						// by whether the coverage is POSITIVE or EXCEPT. Reject strict /
+						// warn lenient in both cases, mirroring the #4296 remedy.
+						// Both-families and empty coverage are fine.
 						for dir, keyword := range [2]string{"source-prefix-list", "destination-prefix-list"} {
-							fam := dirFam[dir]
+							// Effective match semantics for this direction, mirroring
+							// resolvePrefixListAddrs (#4338): a DEFINED positive ref
+							// makes the direction positive-wins (any `except` ref is
+							// dropped, warned separately); only a SOLE `except` (no
+							// positive ref) uses the clean-except match-ALL semantics.
+							var fam plFamily
+							except := false
+							switch {
+							case hasPos[dir]:
+								fam = posFam[dir] // positive-wins; except refs ignored
+							case hasExc[dir]:
+								fam = excFam[dir]
+								except = true
+							default:
+								continue // no defined refs in this direction
+							}
 							if fam.hasV4 == fam.hasV6 {
 								// both (legit mixed / dual-list) or neither (empty).
 								continue
 							}
-							haveFam, missFam := "inet (v4)", "inet6 (v6)"
-							if fam.hasV6 {
-								haveFam, missFam = "inet6 (v6)", "inet (v4)"
+							names := strings.Join(dirNames[dir], " ")
+							var msg string
+							if except {
+								// Single-family `except` list: the arm for the family
+								// the list does NOT cover evaluates `except` over an
+								// empty set = MATCH ALL — an over-block on `then
+								// discard`, a fail-OPEN over-accept on `then accept`.
+								// This is the OPPOSITE of an under-block, so it needs
+								// its own message (#4426, coordinator review).
+								haveFam, overFam := "inet (v4)", "inet6 (v6)"
+								if fam.hasV6 {
+									haveFam, overFam = "inet6 (v6)", "inet (v4)"
+								}
+								msg = fmt.Sprintf(
+									"firewall filter %q term %q: `from %s %s except` references only %s prefixes under `family any` — a family any filter compiles into BOTH the inet (v4) and inet6 (v6) pools (#4287), and an `except` over a prefix set with no %s entries matches EVERY %s packet (an over-block on `then discard`, a fail-open over-accept on `then accept`); use `family inet` / `family inet6`, or an except prefix-list covering both families (#4426)",
+									filterInst.name, termInst.name, keyword, names, haveFam, overFam, overFam)
+							} else {
+								// Single-family POSITIVE list: the arm for the missing
+								// family has no matching prefixes → matches nothing →
+								// falls through to the implicit ACCEPT (silent
+								// under-block).
+								haveFam, missFam := "inet (v4)", "inet6 (v6)"
+								if fam.hasV6 {
+									haveFam, missFam = "inet6 (v6)", "inet (v4)"
+								}
+								msg = fmt.Sprintf(
+									"firewall filter %q term %q: `from %s %s` references only %s prefixes under `family any` — a family any filter compiles into BOTH the inet (v4) and inet6 (v6) pools (#4287), so the %s arm has no matching prefixes and silently under-blocks that family; use `family inet` / `family inet6`, or a prefix-list covering both families (#4426)",
+									filterInst.name, termInst.name, keyword, names, haveFam, missFam)
 							}
-							msg := fmt.Sprintf(
-								"firewall filter %q term %q: `from %s %s` references only %s prefixes under `family any` — a family any filter compiles into BOTH the inet (v4) and inet6 (v6) pools (#4287), so the %s arm has no matching prefixes and silently under-blocks that family; use `family inet` / `family inet6`, or a prefix-list covering both families (#4426)",
-								filterInst.name, termInst.name, keyword,
-								strings.Join(dirNames[dir], " "), haveFam, missFam)
 							if !lenient {
 								return nil, fmt.Errorf("%s", msg)
 							}

--- a/pkg/config/compiler_firewall_family_any_prefixlist_4426_test.go
+++ b/pkg/config/compiler_firewall_family_any_prefixlist_4426_test.go
@@ -1,0 +1,283 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4426 (audit codex-164 C164-H04): #4296 rejects a static family-specific
+// match (address literal, per-family icmp type/code) under `family any`, but a
+// `source-prefix-list` / `destination-prefix-list` reference is NOT a static
+// family keyword — it was deliberately excluded because a named prefix-list may
+// mix families. A reference whose RESOLVED prefixes cover only ONE family
+// reproduces the exact same under-block: `family any` dual-compiles the term
+// into BOTH the inet and inet6 pools (#4287), and the arm for the family the
+// list does not cover has no matching prefixes, matches nothing, and falls
+// through to the implicit ACCEPT — a silent under-block of that family.
+//
+// These configs are non-Junos and reach compileFirewall's structured path only
+// via a HIERARCHICAL config-file / peer-synced AST (the flat `set` schema does
+// not model `family any`), so the fixtures use parseHier.
+
+// RED-on-revert: a `family any` filter whose source-prefix-list resolves to
+// IPv4-only prefixes must be REJECTED at strict commit. On revert of the #4426
+// content-aware check this goes GREEN (compiles cleanly) — the v6 arm is
+// constrained by a v4-only list, matches no v6 packet, and falls through to
+// ACCEPT (fail-open v6 under-block).
+func TestFirewallFilterFamilyAnyV4OnlyPrefixListRejected(t *testing.T) {
+	tree := parseHier(t, `
+policy-options {
+    prefix-list v4-blocks {
+        10.0.0.0/8;
+        192.168.0.0/16;
+    }
+}
+firewall {
+    family any {
+        filter blockNet {
+            term t {
+                from {
+                    source-prefix-list {
+                        v4-blocks;
+                    }
+                }
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+`)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of a v4-only source-prefix-list under family any, got nil")
+	}
+	if !strings.Contains(err.Error(), "blockNet") || !strings.Contains(err.Error(), "family any") ||
+		!strings.Contains(err.Error(), "#4426") || !strings.Contains(err.Error(), "v4-blocks") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+	if !strings.Contains(err.Error(), "inet6 (v6)") {
+		t.Fatalf("error should name the under-blocked inet6 arm: %v", err)
+	}
+}
+
+// The mirror case: a v6-only destination-prefix-list under family any
+// under-blocks the inet (v4) arm and is rejected.
+func TestFirewallFilterFamilyAnyV6OnlyPrefixListRejected(t *testing.T) {
+	tree := parseHier(t, `
+policy-options {
+    prefix-list v6-blocks {
+        2001:db8::/32;
+    }
+}
+firewall {
+    family any {
+        filter blockNet6 {
+            term t {
+                from {
+                    destination-prefix-list {
+                        v6-blocks;
+                    }
+                }
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+`)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of a v6-only destination-prefix-list under family any, got nil")
+	}
+	if !strings.Contains(err.Error(), "blockNet6") || !strings.Contains(err.Error(), "#4426") ||
+		!strings.Contains(err.Error(), "destination-prefix-list") || !strings.Contains(err.Error(), "inet (v4)") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// A MIXED-family prefix-list (v4 AND v6 prefixes in one list) under family any
+// is legitimate — both arms have matching prefixes — and must NOT be flagged.
+func TestFirewallFilterFamilyAnyMixedPrefixListCommits(t *testing.T) {
+	tree := parseHier(t, `
+policy-options {
+    prefix-list dual {
+        10.0.0.0/8;
+        2001:db8::/32;
+    }
+}
+firewall {
+    family any {
+        filter blockDual {
+            term t {
+                from {
+                    source-prefix-list {
+                        dual;
+                    }
+                }
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+`)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: a mixed-family prefix-list under family any must commit, got: %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#4426") {
+			t.Fatalf("unexpected #4426 warning on a valid mixed-family config: %q", w)
+		}
+	}
+	if cfg.Firewall.FiltersInet["blockDual"] == nil || cfg.Firewall.FiltersInet6["blockDual"] == nil {
+		t.Fatal("family any blockDual must land in both pools (#4287)")
+	}
+}
+
+// Two SEPARATE single-family prefix-lists in ONE direction together cover both
+// families — the term is correct for both arms and must NOT be flagged.
+func TestFirewallFilterFamilyAnyTwoSingleFamilyListsCommit(t *testing.T) {
+	tree := parseHier(t, `
+policy-options {
+    prefix-list v4-blocks {
+        10.0.0.0/8;
+    }
+    prefix-list v6-blocks {
+        2001:db8::/32;
+    }
+}
+firewall {
+    family any {
+        filter blockBoth {
+            term t {
+                from {
+                    source-prefix-list {
+                        v4-blocks;
+                        v6-blocks;
+                    }
+                }
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+`)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: two single-family lists covering both families must commit, got: %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#4426") {
+			t.Fatalf("unexpected #4426 warning when both families are covered: %q", w)
+		}
+	}
+}
+
+// Lenient (load / peer-sync): a v4-only prefix-list under family any downgrades
+// to a warning so an already-persisted or peer-synced config still boots — the
+// dual-compile behavior is preserved (the v6 arm merely never matches).
+func TestFirewallFilterFamilyAnyV4OnlyPrefixListLenientWarns(t *testing.T) {
+	tree := parseHier(t, `
+policy-options {
+    prefix-list v4-blocks {
+        10.0.0.0/8;
+    }
+}
+firewall {
+    family any {
+        filter blockNet {
+            term t {
+                from {
+                    source-prefix-list {
+                        v4-blocks;
+                    }
+                }
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+`)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient: a v4-only family-any prefix-list must downgrade to a warning, got error: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "blockNet") && strings.Contains(w, "#4426") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a #4426 family-any prefix-list warning on the lenient path, got: %v", cfg.Warnings)
+	}
+	// Behavior preserved: both pools still carry the filter.
+	if cfg.Firewall.FiltersInet["blockNet"] == nil || cfg.Firewall.FiltersInet6["blockNet"] == nil {
+		t.Fatal("lenient path must preserve the #4287 dual-compile")
+	}
+}
+
+// A single-family prefix-list under a NORMAL single-family filter (family inet
+// with a v4-only list) is legitimate and must NOT be flagged — the gate is
+// scoped to `family any` only.
+func TestFirewallFilterSingleFamilyPrefixListNotFlagged(t *testing.T) {
+	tree := parseHier(t, `
+policy-options {
+    prefix-list v4-blocks {
+        10.0.0.0/8;
+    }
+    prefix-list v6-blocks {
+        2001:db8::/32;
+    }
+}
+firewall {
+    family inet {
+        filter v4 {
+            term t {
+                from {
+                    source-prefix-list {
+                        v4-blocks;
+                    }
+                }
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+    family inet6 {
+        filter v6 {
+            term t {
+                from {
+                    source-prefix-list {
+                        v6-blocks;
+                    }
+                }
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+`)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: single-family filters with single-family prefix-lists must commit, got: %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#4426") {
+			t.Fatalf("unexpected #4426 warning on a valid single-family config: %q", w)
+		}
+	}
+}

--- a/pkg/config/compiler_firewall_family_any_prefixlist_4426_test.go
+++ b/pkg/config/compiler_firewall_family_any_prefixlist_4426_test.go
@@ -98,6 +98,170 @@ firewall {
 	}
 }
 
+// RED-on-revert (coordinator review): a SOLE `except` single-family list under
+// family any is a DIFFERENT failure from the positive case. The runtime
+// clean-except lowering (resolvePrefixListAddrs, #4338) treats `except` over a
+// prefix set with no v6 entries as MATCH-ALL for the v6 arm, so a v4-only
+// `except` OVER-blocks v6 (discards every v6 packet) — never "under-blocks / no
+// matching prefixes". The reject is kept (a real commit-time surprise), but the
+// message must describe the OVER-match, not an under-block.
+func TestFirewallFilterFamilyAnyExceptV4OnlyOverMatch(t *testing.T) {
+	tree := parseHier(t, `
+policy-options {
+    prefix-list mgmt-v4 {
+        10.0.0.0/8;
+    }
+}
+firewall {
+    family any {
+        filter lockdown {
+            term t {
+                from {
+                    source-prefix-list {
+                        mgmt-v4 except;
+                    }
+                }
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+`)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of a v4-only except prefix-list under family any, got nil")
+	}
+	e := err.Error()
+	if !strings.Contains(e, "lockdown") || !strings.Contains(e, "#4426") ||
+		!strings.Contains(e, "except") || !strings.Contains(e, "mgmt-v4") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+	// Must describe the OVER-match of the v6 arm, NOT an under-block.
+	if !strings.Contains(e, "matches EVERY inet6 (v6)") {
+		t.Fatalf("except message must describe the v6 over-match: %v", err)
+	}
+	if strings.Contains(e, "under-block") || strings.Contains(e, "no matching prefixes") {
+		t.Fatalf("except message must NOT claim an under-block (factually inverted): %v", err)
+	}
+}
+
+// The except+accept fail-open specifically: `from source-prefix-list mgmt-v4
+// except; then accept` under family any → the v6 arm accepts EVERY v6 packet (a
+// security fail-OPEN). The gate must catch it and describe the over-accept.
+func TestFirewallFilterFamilyAnyExceptAcceptFailOpenCaught(t *testing.T) {
+	tree := parseHier(t, `
+policy-options {
+    prefix-list mgmt-v4 {
+        10.0.0.0/8;
+    }
+}
+firewall {
+    family any {
+        filter permitMgmt {
+            term t {
+                from {
+                    source-prefix-list {
+                        mgmt-v4 except;
+                    }
+                }
+                then {
+                    accept;
+                }
+            }
+        }
+    }
+}
+`)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: except+accept fail-open under family any must be rejected, got nil")
+	}
+	e := err.Error()
+	if !strings.Contains(e, "permitMgmt") || !strings.Contains(e, "#4426") ||
+		!strings.Contains(e, "matches EVERY inet6 (v6)") || !strings.Contains(e, "over-accept") {
+		t.Fatalf("except+accept message must describe the v6 over-accept fail-open: %v", err)
+	}
+}
+
+// The positive case must STILL produce the under-block message (regression guard
+// that the except branch did not change the positive wording).
+func TestFirewallFilterFamilyAnyPositiveKeepsUnderBlockMessage(t *testing.T) {
+	tree := parseHier(t, `
+policy-options {
+    prefix-list v4-blocks {
+        10.0.0.0/8;
+    }
+}
+firewall {
+    family any {
+        filter blockNet {
+            term t {
+                from {
+                    source-prefix-list {
+                        v4-blocks;
+                    }
+                }
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+`)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of a positive v4-only prefix-list, got nil")
+	}
+	e := err.Error()
+	if !strings.Contains(e, "under-blocks") || !strings.Contains(e, "no matching prefixes") {
+		t.Fatalf("positive message must keep the under-block wording: %v", err)
+	}
+	if strings.Contains(e, "matches EVERY") {
+		t.Fatalf("positive message must NOT use the over-match wording: %v", err)
+	}
+}
+
+// A MIXED-family `except` list under family any is symmetric (each arm excludes
+// its own family's prefixes and matches the rest) — must NOT be flagged.
+func TestFirewallFilterFamilyAnyExceptMixedCommits(t *testing.T) {
+	tree := parseHier(t, `
+policy-options {
+    prefix-list dual {
+        10.0.0.0/8;
+        2001:db8::/32;
+    }
+}
+firewall {
+    family any {
+        filter lockdown {
+            term t {
+                from {
+                    source-prefix-list {
+                        dual except;
+                    }
+                }
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+`)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: a mixed-family except list under family any must commit, got: %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#4426") {
+			t.Fatalf("unexpected #4426 warning on a mixed-family except config: %q", w)
+		}
+	}
+}
+
 // A MIXED-family prefix-list (v4 AND v6 prefixes in one list) under family any
 // is legitimate — both arms have matching prefixes — and must NOT be flagged.
 func TestFirewallFilterFamilyAnyMixedPrefixListCommits(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #4426 (audit codex-164 **C164-H04**, one agent said DRIVE / another NOT-MATERIAL — resolved via verify-first as a **genuine, uncovered bug**).

`#4296` rejects a *static* family-specific match (a v4/v6 `source`/`destination-address` literal, a per-family `icmp-type`/`icmp-code`) under a `family any` firewall filter, but it **deliberately excludes** `source-prefix-list` / `destination-prefix-list` references because a *named* prefix-list may legitimately mix v4+v6 — its family content is not knowable from the leaf keyword.

That exclusion left a residual: a prefix-list whose **resolved** prefixes cover only **one** family reproduces the *same* under-block. `#4287` dual-compiles a `family any` filter into **both** the inet and inet6 pools, so `from source-prefix-list v4-only then discard` lands the v4-only list in the inet6 pool, where the v6 arm has zero v6 prefixes → matches nothing → falls through to the implicit **ACCEPT** → silent v6 under-block.

**Verify-first (definitive):** a probe on `origin/master` confirmed such a config compiles cleanly into both pools with **no** rejection. The `#4296` gate covers only the address/icmp leaves, not the firewall-filter prefix-list path.

## Fix

`validateFirewallFilterFamilyAnyMatchesAST` now also resolves each prefix-list reference against the candidate tree's `policy-options prefix-list` definitions (new `firewallPrefixListFamilies` / `prefixFamily`, mirroring `compilePolicyOptions`' #3996 dual-shape read). Coverage is aggregated **per direction** across every `from` block: a direction whose referenced prefix-lists collectively cover **exactly one** family is **rejected at strict commit / warned on the lenient load-sync path**, matching #4296's chosen remedy (reject-at-commit, `#1960` no-brick doctrine).

Deliberately **NOT** flagged (no false-reject of legitimate `family any`):
- a **mixed-family** prefix-list (v4 AND v6 in one list),
- **two single-family lists** in one direction that together cover both families,
- an **empty** list (left to empty-set match semantics),
- an **undefined** reference (left to `validateFirewallPrefixListReferencesStrict`).

## Validation

- **RED-on-revert proven** for the v4-only reject, v6-only reject, and lenient-warn cases against the `origin/master` `compiler_firewall.go`.
- `go build ./...`, `go vet ./pkg/config/... ./pkg/dataplane/...`, `gofmt` clean; full `pkg/config` + `pkg/dataplane` suites green.
- Commit-path only (no dataplane wire change) → no cluster smoke required.
- Docs: new #4426 subsection in `docs/config-schema.md`; `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi