### PR TITLE
flowexport: bound collector writes, clamp refresh ticker, anchor sysUptime at boot (#4423 H07/M09/M10/M13)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -37725,3 +37725,51 @@ top.
   rustfmt does not touch the new lines).
 - **File(s)**: userspace-dp/src/screen/scan.rs,
   userspace-dp/src/screen/mod.rs, userspace-dp/src/screen/tests.rs, _Log.md
+
+## 2026-07-06 — flowexport collector-stall hardening (#4423 H07/M09/M10/M13)
+
+- **Timestamp**: 2026-07-06
+- **Action**: Verify-first + drive the flowexport audit backlog (#4423,
+  originally codex flowexport H07 + M09/M10/M13). Three genuine bugs fixed,
+  one disproved not-material.
+  - **H07 (HIGH, GENUINE)** — one blocking collector write stalled ALL
+    collectors + template refresh + batch flush + shutdown drain.
+    `collectorConns.writeAll` (transport.go) is a serial loop over the group's
+    connections in the ONE per-exporter `Run` goroutine, and set no write
+    deadline; a connected-UDP `Write` can block indefinitely on a full send
+    buffer (ENOBUFS / congested / down path). Fix: each write sets
+    `SetWriteDeadline(now + collectorWriteTimeout)` (2s default `var`), so a
+    stuck collector times out (datagram dropped, marked unhealthy #2464)
+    instead of parking the goroutine. RED-on-revert:
+    `TestWriteAll_SlowCollectorDoesNotStallOthers` (blocking fake conn;
+    without the deadline writeAll never returns → 3s guard fires).
+  - **M09 (NOT-MATERIAL)** — "BuildExportConfig drops all but the first
+    template group." Disproved: `BuildExportConfig`/`BuildIPFIXExportConfig`
+    (manager.go:530/539, return groups[0]) have NO production caller — the
+    daemon uses `ResolveV9TemplateGroups`/`ResolveIPFIXTemplateGroups`
+    (daemon_flowexport.go:120/136), which return ALL groups and start one
+    exporter per group. The single-group return is documented/intentional for
+    a retained single-aggregate helper. No fix; recorded on #4423.
+  - **M10 (GENUINE robustness)** — `Run` built its template ticker with
+    `time.NewTicker(cfg.TemplateRefreshRate)`, which panics on `<= 0` (fatal
+    under `go e.Run`). Reachable via the public `NewExporter`/`NewIPFIXExporter`
+    constructors with a hand-built zero-rate ExportConfig. Fix:
+    `templateRefreshInterval` clamps non-positive → `defaultTemplateRefreshRate`
+    (60s), used by both v9 and IPFIX `Run`. RED-on-revert:
+    `TestTemplateRefreshInterval_ClampsNonPositive` +
+    `TestExporterRun_ZeroRefreshRateNoPanic`.
+  - **M13 (GENUINE, v9-only)** — NetFlow v9 `bootTime` was `time.Now()` at
+    exporter construction, so after a daemon restart a session that started
+    before the restart had `StartTime < bootTime` and `uptimeMs` clamped its
+    `FirstSwitched` to 0 (flow age truncated to "at boot"). Fix: `bootTime =
+    systemBootTime()` (now − `CLOCK_BOOTTIME`), the real device boot instant,
+    via a `bootTimeFunc` test seam. IPFIX unaffected (absolute
+    flowStart/EndMilliseconds). RED-on-revert:
+    `TestExporterBootTimeAnchorsAtDeviceBoot`.
+  - Validation: `go test ./pkg/flowexport/...` green; `go build`/vet/gofmt
+    clean; `pkg/daemon` builds + tests green. Each fix verified RED-on-revert
+    individually.
+- **File(s)**: pkg/flowexport/transport.go, pkg/flowexport/netflow.go,
+  pkg/flowexport/ipfix.go, pkg/flowexport/collector_health_test.go,
+  pkg/flowexport/collector_stall_4423_test.go, pkg/flowexport/README.md,
+  _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -37773,3 +37773,39 @@ top.
   pkg/flowexport/ipfix.go, pkg/flowexport/collector_health_test.go,
   pkg/flowexport/collector_stall_4423_test.go, pkg/flowexport/README.md,
   _Log.md
+
+## 2026-07-06 — flowexport #4423 fold: unhealthy-collector backoff + wording (Copilot review)
+
+- **Timestamp**: 2026-07-06
+- **Action**: Fold 3 Copilot findings on PR #4428 before merge.
+  - **Copilot #2 (REAL steady-state gap)** — the H07 write deadline bounds a
+    SINGLE stall to `collectorWriteTimeout` (2s) but a PERSISTENTLY-blocked
+    collector still ate a fresh 2s write attempt on EVERY flush/template-refresh,
+    delaying the healthy collectors + the flush/refresh cadence forever. Fix: a
+    per-collector `nextRetryAt` backoff gate in `writeAll` (transport.go) SKIPS
+    an unhealthy collector until `unhealthyProbeInterval` (30s, a `var`) elapses,
+    then re-probes; a successful probe clears the gate and resumes per-flush
+    writes. Steady-state cost of a dead collector drops from 2s/100ms-flush to
+    one bounded probe/30s. Skips are counted (`collectorConn.skipped` →
+    `CollectorHealth.WriteSkipped`) and surfaced in `show services
+    flow-monitoring` (gRPC + CLI) and the new Prometheus counter
+    `xpf_flow_export_collector_write_skipped_total` — not a silent drop.
+  - **Copilot #1 + #3 (wording overpromise)** — the `collectorWriteTimeout` /
+    `writeAll` comments said a slow collector "cannot stall" the goroutine and
+    the README said "instead of blocking the pipeline," but a write still blocks
+    up to the timeout per attempt. Reworded: the deadline BOUNDS (caps) the
+    stall, does not eliminate it; the backoff then skips an unhealthy collector
+    between probes.
+  - RED-on-revert: `TestWriteAll_UnhealthyCollectorSkippedDuringBackoff` (skip
+    during backoff + recovery-probe resume; without the gate the unhealthy
+    collector's attempts climb with the flush count → RED, verified). Existing
+    `TestCollectorHealth_StateChangeEdges` /
+    `..._StateChangeCallbackOncePerTransition` set `unhealthyProbeInterval = 0`
+    (they assert consecutive-write edge detection, orthogonal to backoff).
+  - Validation: `go test -race ./pkg/flowexport/...` green; `go build ./...`;
+    gofmt/vet clean on touched files (pre-existing metrics_wireguard_test.go
+    gofmt drift + cli.go:503 vet warning are on origin/master, untouched).
+- **File(s)**: pkg/flowexport/transport.go, pkg/flowexport/collector_health_test.go,
+  pkg/flowexport/collector_stall_4423_test.go, pkg/flowexport/README.md,
+  pkg/api/metrics.go, pkg/api/metrics_descriptors.go, pkg/api/metrics_system.go,
+  pkg/grpcapi/server_show_flow.go, pkg/cli/cli_show_flow.go, _Log.md

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -554,6 +554,7 @@ type xpfCollector struct {
 	// collector address (bounded — one per configured flow-server).
 	flowExportCollectorWriteAttemptsTotal *prometheus.Desc
 	flowExportCollectorWriteFailuresTotal *prometheus.Desc
+	flowExportCollectorWriteSkippedTotal  *prometheus.Desc
 	flowExportCollectorHealthy            *prometheus.Desc
 	flowExportCollectorLastSuccessSeconds *prometheus.Desc
 	flowExportCollectorLastFailureSeconds *prometheus.Desc
@@ -846,6 +847,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.wgHandshakeAttemptsAbortedTotal
 	ch <- c.flowExportCollectorWriteAttemptsTotal
 	ch <- c.flowExportCollectorWriteFailuresTotal
+	ch <- c.flowExportCollectorWriteSkippedTotal
 	ch <- c.flowExportCollectorHealthy
 	ch <- c.flowExportCollectorLastSuccessSeconds
 	ch <- c.flowExportCollectorLastFailureSeconds

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -1831,6 +1831,11 @@ func newCollector(srv *Server) *xpfCollector {
 			"Total NetFlow v9 / IPFIX UDP write failures per collector (a climbing value while attempts climb means the collector is unreachable and flow records are being silently dropped). Labeled by instance and template as well as collector and source, so a failing template group sharing a collector address is attributable, not hidden (#3741).",
 			[]string{"protocol", "instance", "template", "collector", "source"}, nil,
 		),
+		flowExportCollectorWriteSkippedTotal: prometheus.NewDesc(
+			"xpf_flow_export_collector_write_skipped_total",
+			"Total NetFlow v9 / IPFIX writes SKIPPED per collector because it was unhealthy and still inside its probe-backoff window (#4423). A climbing value (while attempts/failures hold) means a persistently-dead collector is being skipped between probes rather than re-attempted every flush — the deliberate steady-state cost cap for a dead collector. Same label set as attempts/failures.",
+			[]string{"protocol", "instance", "template", "collector", "source"}, nil,
+		),
 		flowExportCollectorHealthy: prometheus.NewDesc(
 			"xpf_flow_export_collector_healthy",
 			"1 when the last write to this flow-export collector succeeded, 0 when the last write failed. Labeled by instance and template as well as collector and source (#3741).",

--- a/pkg/api/metrics_system.go
+++ b/pkg/api/metrics_system.go
@@ -147,6 +147,8 @@ func (c *xpfCollector) collectFlowExportMetrics(ch chan<- prometheus.Metric) {
 			prometheus.CounterValue, float64(h.WriteAttempts), h.Protocol, h.Instance, h.Template, h.Address, h.SourceAddress)
 		ch <- prometheus.MustNewConstMetric(c.flowExportCollectorWriteFailuresTotal,
 			prometheus.CounterValue, float64(h.WriteFailures), h.Protocol, h.Instance, h.Template, h.Address, h.SourceAddress)
+		ch <- prometheus.MustNewConstMetric(c.flowExportCollectorWriteSkippedTotal,
+			prometheus.CounterValue, float64(h.WriteSkipped), h.Protocol, h.Instance, h.Template, h.Address, h.SourceAddress)
 		healthy := 0.0
 		if h.Healthy {
 			healthy = 1

--- a/pkg/cli/cli_show_flow.go
+++ b/pkg/cli/cli_show_flow.go
@@ -1226,6 +1226,9 @@ func (c *CLI) showFlowMonitoringStatistics() error {
 		fmt.Printf("    State:          %s\n", state)
 		fmt.Printf("    Write attempts: %d\n", h.WriteAttempts)
 		fmt.Printf("    Write failures: %d\n", h.WriteFailures)
+		if h.WriteSkipped > 0 {
+			fmt.Printf("    Write skipped:  %d (unhealthy backoff)\n", h.WriteSkipped)
+		}
 		if !h.LastSuccessTime.IsZero() {
 			fmt.Printf("    Last success:   %s\n", h.LastSuccessTime.Format("2006-01-02 15:04:05"))
 		}

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -691,6 +691,43 @@ group; emitted before the dataplane gate — exporters are control-plane). A
 climbing `dropped_total`, or a sustained nonzero `depth`, is the operator
 signal that the export drain cannot keep up.
 
+## Export-pipeline resiliency (#4423)
+
+Three hardening fixes to the exporter goroutine and its sysUptime clock.
+
+- **Per-collector write deadline (H07).** `writeAll` (`transport.go`) fans a
+  packet out to every collector in the group SERIALLY, in the ONE per-exporter
+  `Run` goroutine that also drives the template refresh, the 100 ms batch
+  flush, and the shutdown drain. A connected-UDP `Write` is normally
+  instantaneous but can block indefinitely on a full socket send buffer
+  (ENOBUFS / a congested or down egress path parks the goroutine in the
+  netpoller until the buffer drains). One blocked write therefore stalled ALL
+  of the above — the other collectors starved, templates stopped refreshing,
+  the batch backed up (see #3747, which bounds the resulting memory growth but
+  does not un-stall the drain), and ctx-cancel shutdown hung past the unit
+  `TimeoutStopSec`. Each write now sets `SetWriteDeadline(now +
+  collectorWriteTimeout)` (default 2 s), so a stuck write times out, the
+  datagram is dropped (best-effort UDP) and the collector is marked unhealthy
+  (#2464) instead of blocking the pipeline. `collectorWriteTimeout` is a
+  package `var` so tests shrink it.
+- **Template-refresh ticker clamp (M10).** `Run` built its template ticker with
+  `time.NewTicker(cfg.TemplateRefreshRate)`, which PANICS on a `<= 0` duration
+  — fatal under `go e.Run(ctx)`. The production resolver always fills at least
+  60 s, but the public `NewExporter` / `NewIPFIXExporter` constructors accept
+  any `*ExportConfig`. `templateRefreshInterval` (`transport.go`) now clamps a
+  non-positive rate to `defaultTemplateRefreshRate` (60 s).
+- **sysUptime anchored at device boot (M13).** The NetFlow v9 header
+  `SysUptime` and the record `FirstSwitched`/`LastSwitched` fields are all
+  "system uptime" relative (RFC 3954). The exporter anchored them at
+  `time.Now()` taken when the exporter was CONSTRUCTED, so after a daemon
+  restart (commit, crash recovery, HA failback) any flow that started before
+  the restart had `StartTime` earlier than the anchor and `uptimeMs` clamped
+  its `FirstSwitched` to 0 — truncating the flow age to "at boot". `bootTime`
+  is now `systemBootTime()` (now − `CLOCK_BOOTTIME`), the real device boot
+  instant which predates every session, via the `bootTimeFunc` seam (tests
+  inject a deterministic boot). IPFIX is unaffected — it exports absolute
+  `flowStart/EndMilliseconds`, not an uptime-relative value.
+
 ## Entry points
 
 NetFlow v9:

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -695,21 +695,34 @@ signal that the export drain cannot keep up.
 
 Three hardening fixes to the exporter goroutine and its sysUptime clock.
 
-- **Per-collector write deadline (H07).** `writeAll` (`transport.go`) fans a
-  packet out to every collector in the group SERIALLY, in the ONE per-exporter
-  `Run` goroutine that also drives the template refresh, the 100 ms batch
-  flush, and the shutdown drain. A connected-UDP `Write` is normally
-  instantaneous but can block indefinitely on a full socket send buffer
-  (ENOBUFS / a congested or down egress path parks the goroutine in the
-  netpoller until the buffer drains). One blocked write therefore stalled ALL
-  of the above — the other collectors starved, templates stopped refreshing,
-  the batch backed up (see #3747, which bounds the resulting memory growth but
-  does not un-stall the drain), and ctx-cancel shutdown hung past the unit
-  `TimeoutStopSec`. Each write now sets `SetWriteDeadline(now +
-  collectorWriteTimeout)` (default 2 s), so a stuck write times out, the
-  datagram is dropped (best-effort UDP) and the collector is marked unhealthy
-  (#2464) instead of blocking the pipeline. `collectorWriteTimeout` is a
-  package `var` so tests shrink it.
+- **Per-collector write deadline + unhealthy-collector backoff (H07).**
+  `writeAll` (`transport.go`) fans a packet out to every collector in the group
+  SERIALLY, in the ONE per-exporter `Run` goroutine that also drives the
+  template refresh, the 100 ms batch flush, and the shutdown drain. A
+  connected-UDP `Write` is normally instantaneous but can block indefinitely on
+  a full socket send buffer (ENOBUFS / a congested or down egress path parks
+  the goroutine in the netpoller until the buffer drains). One blocked write
+  therefore stalled ALL of the above INDEFINITELY — the other collectors
+  starved, templates stopped refreshing, the batch backed up (see #3747, which
+  bounds the resulting memory growth but does not un-stall the drain), and
+  ctx-cancel shutdown hung past the unit `TimeoutStopSec`.
+
+  Two bounds are applied. (1) Each ATTEMPTED write sets `SetWriteDeadline(now +
+  collectorWriteTimeout)` (default 2 s): this does NOT eliminate the stall — it
+  CAPS it, so a slow collector blocks the shared goroutine by at most the
+  timeout per attempt, never indefinitely (the datagram is then dropped,
+  best-effort UDP, and the collector is marked unhealthy #2464). (2) A
+  per-collector `nextRetryAt` backoff gate then SKIPS an already-unhealthy
+  collector until `unhealthyProbeInterval` (default 30 s) elapses, so a
+  PERSISTENTLY-dead collector costs one bounded probe per interval instead of a
+  fresh timeout on every flush — without which a dead collector would still
+  delay the healthy collectors + the template/flush cadence by up to 2 s every
+  100 ms forever. A successful re-probe clears the gate and resumes normal
+  per-flush writes. Skipped writes are counted (`skipped` →
+  `CollectorHealth.WriteSkipped` → `show services flow-monitoring` +
+  `xpf_flow_export_collector_write_skipped_total`) so the backoff is
+  observable, not a silent drop. `collectorWriteTimeout` and
+  `unhealthyProbeInterval` are package `var`s so tests shrink them.
 - **Template-refresh ticker clamp (M10).** `Run` built its template ticker with
   `time.NewTicker(cfg.TemplateRefreshRate)`, which PANICS on a `<= 0` duration
   — fatal under `go e.Run(ctx)`. The production resolver always fills at least

--- a/pkg/flowexport/collector_health_test.go
+++ b/pkg/flowexport/collector_health_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"time"
 )
 
 // writeFakeConn is a net.Conn fake whose Write returns a programmable
@@ -26,6 +27,10 @@ func (c *writeFakeConn) Write(b []byte) (int, error) {
 }
 
 func (c *writeFakeConn) Close() error { return nil }
+
+// SetWriteDeadline is a no-op; writeAll sets a per-write deadline (#4423 H07)
+// and the embedded nil net.Conn's promoted method would otherwise panic.
+func (c *writeFakeConn) SetWriteDeadline(time.Time) error { return nil }
 
 func (c *writeFakeConn) setErr(err error) {
 	c.mu.Lock()

--- a/pkg/flowexport/collector_health_test.go
+++ b/pkg/flowexport/collector_health_test.go
@@ -119,6 +119,13 @@ func TestCollectorHealth_FailureTracksLastError(t *testing.T) {
 // FAIL-ON-REVERT: master has no Healthy field; the test cannot compile
 // against it, and the edge semantics it asserts do not exist pre-fix.
 func TestCollectorHealth_StateChangeEdges(t *testing.T) {
+	// Disable the #4423 probe backoff so every write is attempted — this test
+	// asserts edge detection across CONSECUTIVE failed writes, which the
+	// backoff would otherwise skip.
+	origProbe := unhealthyProbeInterval
+	unhealthyProbeInterval = 0
+	t.Cleanup(func() { unhealthyProbeInterval = origProbe })
+
 	sentinel := errors.New("no route to host")
 	fc := &writeFakeConn{}
 	cc := newHealthTestConns([]string{"10.0.0.9:4739"}, []*writeFakeConn{fc})
@@ -171,6 +178,13 @@ func TestCollectorHealth_StateChangeEdges(t *testing.T) {
 // flag observed before/after each writeAll, mirroring exactly what the
 // warn/info log in writeAll keys off. #2464.
 func TestCollectorHealth_StateChangeCallbackOncePerTransition(t *testing.T) {
+	// Disable the #4423 probe backoff so every write is attempted (this test
+	// steps through consecutive failures then successes — the backoff would
+	// skip the intermediate unhealthy writes and never reach the recovery).
+	origProbe := unhealthyProbeInterval
+	unhealthyProbeInterval = 0
+	t.Cleanup(func() { unhealthyProbeInterval = origProbe })
+
 	sentinel := errors.New("unreachable")
 	fc := &writeFakeConn{}
 	cc := newHealthTestConns([]string{"10.0.0.20:2055"}, []*writeFakeConn{fc})

--- a/pkg/flowexport/collector_stall_4423_test.go
+++ b/pkg/flowexport/collector_stall_4423_test.go
@@ -2,6 +2,7 @@ package flowexport
 
 import (
 	"context"
+	"errors"
 	"net"
 	"sync"
 	"testing"
@@ -104,6 +105,86 @@ func TestWriteAll_SlowCollectorDoesNotStallOthers(t *testing.T) {
 	if h[0].WriteFailures != 1 || h[0].Healthy {
 		t.Fatalf("blocked collector: failures=%d healthy=%v, want 1/false",
 			h[0].WriteFailures, h[0].Healthy)
+	}
+}
+
+// TestWriteAll_UnhealthyCollectorSkippedDuringBackoff is the #4423 H07-follow-up
+// (Copilot #2) fail-on-revert guard: once a collector fails a write it must be
+// SKIPPED on subsequent flushes until the probe interval elapses, so a
+// persistently-dead collector does not cost a fresh (potentially full-timeout)
+// write attempt on every flush and thereby keep delaying the healthy
+// collectors. A healthy collector is written on every flush; a recovered
+// collector resumes normal per-flush writes.
+//
+// Against the pre-backoff code every flush re-attempts the unhealthy collector,
+// so its WriteAttempts climbs with the flush count and WriteSkipped stays 0 —
+// the assertions below flip RED.
+func TestWriteAll_UnhealthyCollectorSkippedDuringBackoff(t *testing.T) {
+	origProbe := unhealthyProbeInterval
+	unhealthyProbeInterval = 30 * time.Second
+	t.Cleanup(func() { unhealthyProbeInterval = origProbe })
+
+	bad := &writeFakeConn{err: errors.New("connection refused")}
+	good := &writeFakeConn{}
+	cc := newHealthTestConns(
+		[]string{"10.0.0.1:2055", "10.0.0.2:2055"},
+		[]*writeFakeConn{bad, good},
+	)
+
+	// Flush 1: bad is healthy -> attempted -> fails -> unhealthy + backoff armed.
+	// Flushes 2 and 3: bad is unhealthy and within the window -> SKIPPED.
+	cc.writeAll([]byte("1"), "send")
+	cc.writeAll([]byte("2"), "send")
+	cc.writeAll([]byte("3"), "send")
+
+	h := cc.health()
+	badH, goodH := h[0], h[1]
+	if badH.WriteAttempts != 1 {
+		t.Fatalf("unhealthy collector attempts = %d, want 1 (must be SKIPPED during "+
+			"backoff, not re-attempted every flush) — #4423 Copilot #2", badH.WriteAttempts)
+	}
+	if badH.WriteFailures != 1 {
+		t.Fatalf("unhealthy collector failures = %d, want 1", badH.WriteFailures)
+	}
+	if badH.WriteSkipped != 2 {
+		t.Fatalf("unhealthy collector skipped = %d, want 2 (flushes 2 and 3)", badH.WriteSkipped)
+	}
+	if badH.Healthy {
+		t.Fatal("unhealthy collector should still be unhealthy during backoff")
+	}
+	// The healthy collector is written on every flush regardless.
+	if goodH.WriteAttempts != 3 {
+		t.Fatalf("healthy collector attempts = %d, want 3 (always written, never "+
+			"starved by the unhealthy collector)", goodH.WriteAttempts)
+	}
+	if goodH.WriteSkipped != 0 {
+		t.Fatalf("healthy collector skipped = %d, want 0", goodH.WriteSkipped)
+	}
+
+	// Recovery: clear the error and expire the backoff window, then flush. The
+	// collector is re-probed, the probe succeeds, and it becomes healthy again.
+	bad.setErr(nil)
+	cc.conns[0].mu.Lock()
+	cc.conns[0].nextRetryAt = time.Now().Add(-time.Second) // window elapsed
+	cc.conns[0].mu.Unlock()
+
+	cc.writeAll([]byte("4"), "send") // probe -> success -> healthy
+	if h = cc.health(); !h[0].Healthy {
+		t.Fatal("collector should recover after a successful probe past the backoff window")
+	}
+	if h[0].WriteAttempts != 2 {
+		t.Fatalf("attempts after recovery probe = %d, want 2", h[0].WriteAttempts)
+	}
+
+	// Flush 5: now healthy -> written every flush again (no more skips).
+	cc.writeAll([]byte("5"), "send")
+	if h = cc.health(); h[0].WriteAttempts != 3 {
+		t.Fatalf("attempts after resume = %d, want 3 (healthy collector written every flush)",
+			h[0].WriteAttempts)
+	}
+	if h[0].WriteSkipped != 2 {
+		t.Fatalf("skipped after resume = %d, want 2 (unchanged — only the two backoff "+
+			"flushes were skipped)", h[0].WriteSkipped)
 	}
 }
 

--- a/pkg/flowexport/collector_stall_4423_test.go
+++ b/pkg/flowexport/collector_stall_4423_test.go
@@ -1,0 +1,184 @@
+package flowexport
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// timeoutError is a net.Error whose Timeout() reports true, matching what a
+// real net.Conn write returns once its write deadline elapses.
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "i/o timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
+
+// blockingConn models a collector whose socket send buffer never drains: its
+// Write blocks until either the write deadline set via SetWriteDeadline
+// elapses (returning a timeout error, like a real *net.UDPConn) or release is
+// closed. Without a deadline the Write blocks forever — which is exactly the
+// #4423 H07 stall: one such collector parks the shared export goroutine and
+// starves every other collector, the template refresh, the batch flush, and
+// the shutdown drain.
+type blockingConn struct {
+	net.Conn
+	mu       sync.Mutex
+	deadline time.Time
+	release  chan struct{}
+}
+
+func (c *blockingConn) SetWriteDeadline(t time.Time) error {
+	c.mu.Lock()
+	c.deadline = t
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *blockingConn) Write(b []byte) (int, error) {
+	c.mu.Lock()
+	dl := c.deadline
+	c.mu.Unlock()
+	if dl.IsZero() {
+		// Pre-fix path: writeAll never set a deadline, so block until the
+		// test releases us. Against the fix this branch is never taken.
+		<-c.release
+		return len(b), nil
+	}
+	select {
+	case <-c.release:
+		return len(b), nil
+	case <-time.After(time.Until(dl)):
+		return 0, timeoutError{}
+	}
+}
+
+func (c *blockingConn) Close() error { return nil }
+
+// TestWriteAll_SlowCollectorDoesNotStallOthers is the #4423 H07 fail-on-revert
+// guard: writeAll must bound each collector write with a deadline so one
+// blocked collector cannot stall the shared export goroutine that also drives
+// every other collector, the template refresh, the batch flush, and the
+// shutdown drain.
+//
+// Against the pre-fix code (no SetWriteDeadline in writeAll) the blockingConn's
+// deadline stays zero, its Write blocks forever, and writeAll never returns —
+// the 3s guard below fires. With the fix each write is deadlined, the blocked
+// write times out, and delivery to the healthy collector proceeds.
+func TestWriteAll_SlowCollectorDoesNotStallOthers(t *testing.T) {
+	orig := collectorWriteTimeout
+	collectorWriteTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { collectorWriteTimeout = orig })
+
+	blocked := &blockingConn{release: make(chan struct{})}
+	t.Cleanup(func() { close(blocked.release) }) // unblock any parked Write
+
+	good := &writeFakeConn{}
+	cc := &collectorConns{conns: []*collectorConn{
+		{conn: blocked, addr: "10.0.0.1:2055", healthy: true},
+		{conn: good, addr: "10.0.0.2:2055", healthy: true},
+	}}
+
+	done := make(chan struct{})
+	go func() {
+		cc.writeAll([]byte("pkt"), "data send failed")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("writeAll stalled on a blocked collector: one slow collector " +
+			"blocked the shared export goroutine (#4423 H07)")
+	}
+
+	h := cc.health()
+	// The healthy collector after the blocked one still got its write.
+	if h[1].WriteAttempts != 1 || !h[1].Healthy {
+		t.Fatalf("good collector: attempts=%d healthy=%v, want 1/true "+
+			"(starved by the blocked collector)", h[1].WriteAttempts, h[1].Healthy)
+	}
+	// The blocked collector's deadlined write is recorded as a failure.
+	if h[0].WriteFailures != 1 || h[0].Healthy {
+		t.Fatalf("blocked collector: failures=%d healthy=%v, want 1/false",
+			h[0].WriteFailures, h[0].Healthy)
+	}
+}
+
+// TestTemplateRefreshInterval_ClampsNonPositive is the #4423 M10 fail-on-revert
+// guard for the helper: a non-positive refresh rate must clamp to the default
+// so time.NewTicker (which panics on d <= 0) is never handed a zero.
+func TestTemplateRefreshInterval_ClampsNonPositive(t *testing.T) {
+	if got := templateRefreshInterval(0); got != defaultTemplateRefreshRate {
+		t.Fatalf("templateRefreshInterval(0) = %v, want %v", got, defaultTemplateRefreshRate)
+	}
+	if got := templateRefreshInterval(-5 * time.Second); got != defaultTemplateRefreshRate {
+		t.Fatalf("templateRefreshInterval(-5s) = %v, want %v", got, defaultTemplateRefreshRate)
+	}
+	if got := templateRefreshInterval(30 * time.Second); got != 30*time.Second {
+		t.Fatalf("templateRefreshInterval(30s) = %v, want 30s", got)
+	}
+}
+
+// TestExporterRun_ZeroRefreshRateNoPanic is the #4423 M10 fail-on-revert guard
+// at the Run layer: a hand-built ExportConfig with TemplateRefreshRate 0 (which
+// the public constructors accept) must not panic the Run goroutine. Against the
+// pre-fix code time.NewTicker(0) panics; a panic under `go e.Run(ctx)` is fatal.
+func TestExporterRun_ZeroRefreshRateNoPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Run panicked with zero TemplateRefreshRate: %v (#4423 M10)", r)
+		}
+	}()
+
+	// Empty Collectors -> dialCollectors opens no sockets and returns no error.
+	e, err := NewExporter(&ExportConfig{TemplateRefreshRate: 0})
+	if err != nil {
+		t.Fatalf("NewExporter: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Run builds the tickers then returns on ctx.Done
+	e.Run(ctx)
+
+	ie, err := NewIPFIXExporter(&ExportConfig{TemplateRefreshRate: 0})
+	if err != nil {
+		t.Fatalf("NewIPFIXExporter: %v", err)
+	}
+	ictx, icancel := context.WithCancel(context.Background())
+	icancel()
+	ie.Run(ictx)
+}
+
+// TestExporterBootTimeAnchorsAtDeviceBoot is the #4423 M13 fail-on-revert
+// guard: the NetFlow v9 sysUptime reference must anchor at the device boot
+// instant (which predates every session), not at exporter-construction time.
+// After a daemon restart a session that started before the restart has a
+// StartTime earlier than the construction instant, so anchoring there clamps
+// its FirstSwitched to 0 (uptimeMs floors a negative delta), truncating the
+// flow age to "at boot".
+//
+// A deterministic 48h-ago boot is injected (well within the ~49.7-day uint32
+// millisecond sysUptime window and independent of the host's real uptime).
+// Against the pre-fix code (bootTime = time.Now() at construction) a session
+// that started an hour ago yields FirstSwitched 0; with the fix it is nonzero.
+func TestExporterBootTimeAnchorsAtDeviceBoot(t *testing.T) {
+	boot := time.Now().Add(-48 * time.Hour)
+	orig := bootTimeFunc
+	bootTimeFunc = func() time.Time { return boot }
+	t.Cleanup(func() { bootTimeFunc = orig })
+
+	e, err := NewExporter(&ExportConfig{}) // empty collectors: no sockets
+	if err != nil {
+		t.Fatalf("NewExporter: %v", err)
+	}
+
+	// A session that started an hour ago — before this exporter was constructed
+	// (post-restart) but long after device boot.
+	sessionStart := time.Now().Add(-time.Hour)
+	if got := uptimeMs(e.bootTime, sessionStart); got == 0 {
+		t.Fatal("FirstSwitched truncated to 0 for a pre-exporter session: bootTime " +
+			"must anchor at device boot, not exporter-construction time (#4423 M13)")
+	}
+}

--- a/pkg/flowexport/ipfix.go
+++ b/pkg/flowexport/ipfix.go
@@ -807,7 +807,8 @@ func NewIPFIXExporter(cfg *ExportConfig) (*IPFIXExporter, error) {
 func (e *IPFIXExporter) Run(ctx context.Context) {
 	e.sendTemplates()
 
-	templateTicker := time.NewTicker(e.cfg.TemplateRefreshRate)
+	// #4423 M10: clamp a non-positive refresh rate so NewTicker never panics.
+	templateTicker := time.NewTicker(templateRefreshInterval(e.cfg.TemplateRefreshRate))
 	defer templateTicker.Stop()
 
 	batchTicker := time.NewTicker(100 * time.Millisecond)

--- a/pkg/flowexport/netflow.go
+++ b/pkg/flowexport/netflow.go
@@ -9,7 +9,41 @@ import (
 	"time"
 
 	"github.com/psaab/xpf/pkg/logging"
+	"golang.org/x/sys/unix"
 )
+
+// bootTimeFunc resolves the device boot instant used as the NetFlow v9
+// sysUptime reference (the NetFlow v9 header SysUptime and the FirstSwitched /
+// LastSwitched record fields are all "system uptime" relative — RFC 3954 §5.1
+// / §8). It is a seam so tests can inject a deterministic boot time. Defaults
+// to systemBootTime; overridden only by tests.
+var bootTimeFunc = systemBootTime
+
+// systemBootTime returns the wall-clock instant the machine booted, computed
+// from CLOCK_BOOTTIME (seconds-since-boot) subtracted from now (#4423 M13).
+//
+// The exporter previously anchored sysUptime at time.Now() taken when the
+// exporter was CONSTRUCTED. After a daemon restart (config commit, crash
+// recovery, HA failback) that anchor moves forward to the restart instant, so
+// any flow that STARTED before the restart — a long-lived session, an
+// HA-synced session carrying an earlier creation timestamp — has StartTime
+// earlier than the anchor and uptimeMs clamps its FirstSwitched to 0,
+// truncating the flow age to "at boot". Anchoring at the real device boot
+// (which predates every session) makes FirstSwitched/LastSwitched and the
+// header SysUptime carry the true device-relative uptime instead. On the rare
+// error path we fall back to time.Now() (the pre-fix behaviour), never a zero
+// time.
+func systemBootTime() time.Time {
+	var ts unix.Timespec
+	if err := unix.ClockGettime(unix.CLOCK_BOOTTIME, &ts); err != nil {
+		return time.Now()
+	}
+	uptime := time.Duration(ts.Sec)*time.Second + time.Duration(ts.Nsec)*time.Nanosecond
+	if uptime <= 0 {
+		return time.Now()
+	}
+	return time.Now().Add(-uptime)
+}
 
 // NetFlow v9 field type IDs (RFC 3954).
 const (
@@ -526,8 +560,11 @@ type Exporter struct {
 // callback so there is exactly one counter per exporter.
 func NewExporter(cfg *ExportConfig) (*Exporter, error) {
 	e := &Exporter{
-		cfg:      cfg,
-		bootTime: time.Now(),
+		cfg: cfg,
+		// #4423 M13: anchor sysUptime at real device boot, not exporter-
+		// construction time, so a session that started before a daemon restart
+		// is not truncated to FirstSwitched=0.
+		bootTime: bootTimeFunc(),
 		// #3740: stable per-group SourceID (RFC 3954 §5.1) derived from the
 		// config identity so two same-collector groups no longer collide on
 		// SourceID=1. HA-symmetric (pure function of config-synced fields).
@@ -554,7 +591,8 @@ func (e *Exporter) Run(ctx context.Context) {
 	// Send initial template
 	e.sendTemplates()
 
-	templateTicker := time.NewTicker(e.cfg.TemplateRefreshRate)
+	// #4423 M10: clamp a non-positive refresh rate so NewTicker never panics.
+	templateTicker := time.NewTicker(templateRefreshInterval(e.cfg.TemplateRefreshRate))
 	defer templateTicker.Stop()
 
 	batchTicker := time.NewTicker(100 * time.Millisecond)

--- a/pkg/flowexport/transport.go
+++ b/pkg/flowexport/transport.go
@@ -150,6 +150,43 @@ func dialCollectors(collectors []CollectorConfig) (*collectorConns, error) {
 	return cc, nil
 }
 
+// collectorWriteTimeout bounds how long a single collector write may block
+// before it is abandoned as a failure (#4423 H07). writeAll runs in the ONE
+// per-exporter Run goroutine that ALSO drives every other collector in the
+// group, the periodic template refresh, the 100ms batch flush, and the
+// shutdown drain. A connected-UDP Write is normally instantaneous, but it can
+// block indefinitely on a full socket send buffer (ENOBUFS / a congested or
+// down egress path parks the goroutine in the netpoller until the buffer
+// drains). Without a deadline that single blocked write stalls ALL of the
+// above — the other collectors starve, templates stop refreshing, the batch
+// backs up, and ctx-cancel shutdown hangs past the unit TimeoutStopSec. The
+// deadline makes a stuck write time out (the datagram is dropped, best-effort
+// UDP, and the collector is marked unhealthy) instead of blocking the pipeline.
+// A var, not a const, so tests can shrink it. 2s is far above any healthy UDP
+// write yet well within the 20s systemd stop timeout even for several hung
+// collectors.
+var collectorWriteTimeout = 2 * time.Second
+
+// defaultTemplateRefreshRate is the fallback template-refresh cadence used when
+// an ExportConfig carries a non-positive TemplateRefreshRate (#4423 M10). The
+// production resolver always fills at least 60s, but the public NewExporter /
+// NewIPFIXExporter constructors accept any *ExportConfig, and time.NewTicker
+// panics on a <= 0 duration.
+const defaultTemplateRefreshRate = 60 * time.Second
+
+// templateRefreshInterval clamps a template-refresh rate to a strictly
+// positive duration so time.NewTicker never panics on a zero/negative rate
+// (#4423 M10). A hand-built ExportConfig (tests, external callers) that left
+// TemplateRefreshRate at 0 falls back to the default cadence instead of
+// crashing the Run goroutine — and a panic there is fatal (it runs under
+// `go e.Run(ctx)`).
+func templateRefreshInterval(d time.Duration) time.Duration {
+	if d <= 0 {
+		return defaultTemplateRefreshRate
+	}
+	return d
+}
+
 // writeAll transmits pkt to every collector connection and records the
 // per-collector write-health (#2464). A failure to one collector does
 // not stop delivery to the others (the export DATA path is unchanged —
@@ -157,6 +194,11 @@ func dialCollectors(collectors []CollectorConfig) (*collectorConns, error) {
 // non-fatal). The change is observability: each write bumps the
 // attempt counter, a success refreshes LastSuccessTime, and a failure
 // records LastError/LastErrorTime + the failure counter.
+//
+// Each write is bounded by collectorWriteTimeout (#4423 H07) so one slow or
+// blocked collector cannot stall the shared export goroutine — which also
+// drives the other collectors, the template refresh, the batch flush, and the
+// shutdown drain.
 //
 // Logging is RATE-LIMITED to the unhealthy<->healthy EDGE, not every
 // write: writeAll runs once per export flush (the v9/IPFIX batch ticker
@@ -168,6 +210,11 @@ func dialCollectors(collectors []CollectorConfig) (*collectorConns, error) {
 // (template vs data) in the debug line kept for deep tracing.
 func (cc *collectorConns) writeAll(pkt []byte, errMsg string) {
 	for _, c := range cc.conns {
+		// Bound the write so a full send buffer on one collector cannot park
+		// the shared goroutine indefinitely (#4423 H07). A write that trips
+		// the deadline returns a timeout error handled by the failure branch
+		// below, exactly like any other unreachable-collector error.
+		_ = c.conn.SetWriteDeadline(time.Now().Add(collectorWriteTimeout))
 		_, err := c.conn.Write(pkt)
 		c.attempts.Add(1)
 		now := time.Now()

--- a/pkg/flowexport/transport.go
+++ b/pkg/flowexport/transport.go
@@ -33,6 +33,12 @@ type collectorConn struct {
 
 	attempts atomic.Uint64
 	failures atomic.Uint64
+	// skipped counts writes NOT attempted because the collector is unhealthy
+	// and still inside its probe-backoff window (#4423 H07 follow-up). It makes
+	// the backoff observable: a persistently-dead collector's skipped count
+	// climbs while attempts/failures do not, distinguishing "skipped for
+	// backoff" from a real per-flush failure.
+	skipped atomic.Uint64
 
 	mu              sync.Mutex
 	lastError       string
@@ -46,6 +52,12 @@ type collectorConn struct {
 	// the recovery edge is unambiguous.
 	healthy    bool
 	consecFail uint64
+	// nextRetryAt is the earliest time writeAll will re-probe this collector
+	// after a failed write (#4423 H07 follow-up). While unhealthy and before
+	// nextRetryAt the collector is SKIPPED, so a persistently-blocked collector
+	// costs one bounded probe per unhealthyProbeInterval instead of a full
+	// collectorWriteTimeout stall on every flush. Zero on a healthy collector.
+	nextRetryAt time.Time
 }
 
 // ExporterCollectorHealth is one collector's write-health snapshot
@@ -72,9 +84,14 @@ type CollectorHealth struct {
 	// disambiguates two same-family collectors that bind distinct
 	// sources (#3745) so a source-bound connection failure is
 	// identifiable in the CLI / REST / Prometheus surfaces.
-	SourceAddress   string    `json:"source_address,omitempty"`
-	WriteAttempts   uint64    `json:"write_attempts"`
-	WriteFailures   uint64    `json:"write_failures"`
+	SourceAddress string `json:"source_address,omitempty"`
+	WriteAttempts uint64 `json:"write_attempts"`
+	WriteFailures uint64 `json:"write_failures"`
+	// WriteSkipped is the count of writes NOT attempted because the collector
+	// was unhealthy and still inside its probe-backoff window (#4423). A
+	// climbing value (while attempts/failures hold) is the signal that a dead
+	// collector is being skipped rather than re-attempted every flush.
+	WriteSkipped    uint64    `json:"write_skipped"`
 	Healthy         bool      `json:"healthy"`
 	LastError       string    `json:"last_error,omitempty"`
 	LastErrorTime   time.Time `json:"last_error_time,omitempty"`
@@ -150,7 +167,7 @@ func dialCollectors(collectors []CollectorConfig) (*collectorConns, error) {
 	return cc, nil
 }
 
-// collectorWriteTimeout bounds how long a single collector write may block
+// collectorWriteTimeout BOUNDS how long a single collector write may block
 // before it is abandoned as a failure (#4423 H07). writeAll runs in the ONE
 // per-exporter Run goroutine that ALSO drives every other collector in the
 // group, the periodic template refresh, the 100ms batch flush, and the
@@ -158,14 +175,34 @@ func dialCollectors(collectors []CollectorConfig) (*collectorConns, error) {
 // block indefinitely on a full socket send buffer (ENOBUFS / a congested or
 // down egress path parks the goroutine in the netpoller until the buffer
 // drains). Without a deadline that single blocked write stalls ALL of the
-// above — the other collectors starve, templates stop refreshing, the batch
-// backs up, and ctx-cancel shutdown hangs past the unit TimeoutStopSec. The
-// deadline makes a stuck write time out (the datagram is dropped, best-effort
-// UDP, and the collector is marked unhealthy) instead of blocking the pipeline.
+// above INDEFINITELY — the other collectors starve, templates stop refreshing,
+// the batch backs up, and ctx-cancel shutdown hangs past the unit
+// TimeoutStopSec.
+//
+// The deadline does NOT eliminate the stall — it caps it: a slow collector can
+// still block the shared goroutine by AT MOST collectorWriteTimeout per
+// ATTEMPTED write (the datagram is then dropped, best-effort UDP, and the
+// collector is marked unhealthy #2464). The per-flush steady-state cost of a
+// PERSISTENTLY-dead collector is then bounded further by the unhealthyProbe-
+// Interval backoff below, which SKIPS an unhealthy collector between probes so
+// it does not eat a fresh collectorWriteTimeout on every flush.
+//
 // A var, not a const, so tests can shrink it. 2s is far above any healthy UDP
 // write yet well within the 20s systemd stop timeout even for several hung
 // collectors.
 var collectorWriteTimeout = 2 * time.Second
+
+// unhealthyProbeInterval is how long a collector that failed a write is SKIPPED
+// before writeAll re-probes it (#4423 H07 follow-up). Without this gate a
+// persistently-blocked collector (its send buffer stays full) costs a fresh
+// collectorWriteTimeout stall on EVERY flush/template-refresh, delaying the
+// healthy collectors and the template/flush cadence forever — the deadline
+// bounds a SINGLE stall but not the steady-state cost of a dead collector.
+// Skipping an unhealthy collector until nextRetryAt drops that steady-state
+// cost to one bounded probe per interval (a 2s-bounded write every 30s, not a
+// 2s stall every 100ms). A recovered probe resumes normal per-flush writes. A
+// var so tests can shrink it.
+var unhealthyProbeInterval = 30 * time.Second
 
 // defaultTemplateRefreshRate is the fallback template-refresh cadence used when
 // an ExportConfig carries a non-positive TemplateRefreshRate (#4423 M10). The
@@ -195,10 +232,14 @@ func templateRefreshInterval(d time.Duration) time.Duration {
 // attempt counter, a success refreshes LastSuccessTime, and a failure
 // records LastError/LastErrorTime + the failure counter.
 //
-// Each write is bounded by collectorWriteTimeout (#4423 H07) so one slow or
-// blocked collector cannot stall the shared export goroutine — which also
+// Each attempted write is BOUNDED by collectorWriteTimeout (#4423 H07) so a
+// slow or blocked collector stalls the shared export goroutine — which also
 // drives the other collectors, the template refresh, the batch flush, and the
-// shutdown drain.
+// shutdown drain — by at most that timeout per attempt, never indefinitely.
+// An already-unhealthy collector is additionally SKIPPED between probes
+// (unhealthyProbeInterval), so its steady-state cost is one bounded probe per
+// interval rather than a fresh timeout on every flush; skipped writes are
+// counted (skipped) for observability.
 //
 // Logging is RATE-LIMITED to the unhealthy<->healthy EDGE, not every
 // write: writeAll runs once per export flush (the v9/IPFIX batch ticker
@@ -210,6 +251,17 @@ func templateRefreshInterval(d time.Duration) time.Duration {
 // (template vs data) in the debug line kept for deep tracing.
 func (cc *collectorConns) writeAll(pkt []byte, errMsg string) {
 	for _, c := range cc.conns {
+		// Backoff gate: an unhealthy collector still inside its probe window is
+		// SKIPPED, so a persistently-blocked collector does not cost a fresh
+		// collectorWriteTimeout stall on every flush (#4423 H07 follow-up).
+		c.mu.Lock()
+		if !c.healthy && time.Now().Before(c.nextRetryAt) {
+			c.mu.Unlock()
+			c.skipped.Add(1)
+			continue
+		}
+		c.mu.Unlock()
+
 		// Bound the write so a full send buffer on one collector cannot park
 		// the shared goroutine indefinitely (#4423 H07). A write that trips
 		// the deadline returns a timeout error handled by the failure branch
@@ -225,6 +277,9 @@ func (cc *collectorConns) writeAll(pkt []byte, errMsg string) {
 			c.lastErrorTime = now
 			c.lastFailureTime = now
 			c.consecFail++
+			// Arm the backoff: skip this collector until the probe interval
+			// elapses so the next flushes don't each eat a full timeout.
+			c.nextRetryAt = now.Add(unhealthyProbeInterval)
 			wasHealthy := c.healthy
 			c.healthy = false
 			c.mu.Unlock()
@@ -239,6 +294,8 @@ func (cc *collectorConns) writeAll(pkt []byte, errMsg string) {
 		}
 		c.mu.Lock()
 		c.lastSuccessTime = now
+		// A successful (re)probe clears the backoff and resumes per-flush writes.
+		c.nextRetryAt = time.Time{}
 		wasUnhealthy := !c.healthy
 		c.healthy = true
 		c.consecFail = 0
@@ -264,6 +321,7 @@ func (cc *collectorConns) health() []CollectorHealth {
 			SourceAddress:   c.srcAddr,
 			WriteAttempts:   c.attempts.Load(),
 			WriteFailures:   c.failures.Load(),
+			WriteSkipped:    c.skipped.Load(),
 			Healthy:         c.healthy,
 			LastError:       c.lastError,
 			LastErrorTime:   c.lastErrorTime,

--- a/pkg/grpcapi/server_show_flow.go
+++ b/pkg/grpcapi/server_show_flow.go
@@ -78,6 +78,9 @@ func (s *Server) showFlowMonitoringStatistics(buf *strings.Builder) {
 		fmt.Fprintf(buf, "    State:          %s\n", state)
 		fmt.Fprintf(buf, "    Write attempts: %d\n", h.WriteAttempts)
 		fmt.Fprintf(buf, "    Write failures: %d\n", h.WriteFailures)
+		if h.WriteSkipped > 0 {
+			fmt.Fprintf(buf, "    Write skipped:  %d (unhealthy backoff)\n", h.WriteSkipped)
+		}
 		if !h.LastSuccessTime.IsZero() {
 			fmt.Fprintf(buf, "    Last success:   %s\n", h.LastSuccessTime.Format("2006-01-02 15:04:05"))
 		}


### PR DESCRIPTION
Refs #4423 (flowexport H07/M09/M10/M13).

Verify-first pass over the flowexport audit backlog. Three genuine bugs fixed, one disproved not-material.

## H07 (HIGH) — one blocking collector write stalled the whole exporter
`collectorConns.writeAll` (transport.go) fans a packet out to every collector in the group **serially**, in the ONE per-exporter `Run` goroutine that also drives the template refresh, the 100 ms batch flush, and the shutdown drain — and it set **no write deadline**. A connected-UDP `Write` is normally instantaneous but can block indefinitely on a full socket send buffer (ENOBUFS, or a congested / down egress path parks the goroutine in the netpoller). One blocked write starved every other collector, stopped templates refreshing, backed up the batch (the #3747 bound caps the memory but does not un-stall the drain), and hung ctx-cancel shutdown past the unit `TimeoutStopSec`.

**Fix:** each write sets `SetWriteDeadline(now + collectorWriteTimeout)` (2 s default, a `var` so tests shrink it). A stuck write times out — the datagram is dropped (best-effort UDP) and the collector is marked unhealthy (#2464) — instead of blocking the pipeline.

## M10 (robustness) — refresh ticker panics on a zero rate
`Run` built its template ticker with `time.NewTicker(cfg.TemplateRefreshRate)`, which **panics on `<= 0`** — fatal under `go e.Run(ctx)`. The production resolver always fills ≥ 60 s, but the public `NewExporter` / `NewIPFIXExporter` constructors accept any `*ExportConfig`. `templateRefreshInterval` now clamps a non-positive rate to `defaultTemplateRefreshRate` (60 s) in both the v9 and IPFIX `Run` paths.

## M13 (NetFlow v9 only) — sysUptime truncates pre-restart sessions
The v9 header `SysUptime` and record `FirstSwitched`/`LastSwitched` are all "system uptime" relative (RFC 3954), but `bootTime` was `time.Now()` at exporter **construction**. After a daemon restart any flow that started before the restart had `StartTime < bootTime`, so `uptimeMs` clamped its `FirstSwitched` to 0 (flow age truncated to "at boot"). `bootTime` is now `systemBootTime()` (`now − CLOCK_BOOTTIME`), the real device boot instant which predates every session, via a `bootTimeFunc` test seam. IPFIX is unaffected (absolute `flowStart/EndMilliseconds`).

## M09 (not-material — no change)
"BuildExportConfig drops all but the first template group." Disproved: `BuildExportConfig` / `BuildIPFIXExportConfig` (`return groups[0]`) have **no production caller** — the daemon uses `ResolveV9TemplateGroups` / `ResolveIPFIXTemplateGroups` (`daemon_flowexport.go:120/136`), which return **all** groups and start one exporter per group. The single-group return is a documented, intentional single-aggregate helper.

## Tests
Each fix has a RED-on-revert test (verified individually):
- `TestWriteAll_SlowCollectorDoesNotStallOthers` (H07)
- `TestTemplateRefreshInterval_ClampsNonPositive` + `TestExporterRun_ZeroRefreshRateNoPanic` (M10)
- `TestExporterBootTimeAnchorsAtDeviceBoot` (M13)

`go test ./pkg/flowexport/...` green; `go build ./...`; gofmt/vet clean; `pkg/daemon` builds + tests green. README "Export-pipeline resiliency (#4423)" documents all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi