### PR TITLE
Refs #4423 (flow-cache H7/H8/M3/M4/M7)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,44 @@
+## 2026-07-06 — #4423 (flow-cache H7/H8/M3/M4/M7): verify-first + docs
+
+- **Timestamp**: 2026-07-06
+- **Action**: Verify-first triage of the codex flow-cache audit sub-items on
+  the flow-cache-hit fast path. Outcome: the two HIGHs are not-material on
+  origin/master and the two MEDs are a deliberate caching approximation /
+  benign no-op, so the fix is documentation + disposition, no behavior change.
+    - **H7 (charges/logs before TTL) — NOT-A-BUG**: already fixed by #3779
+      (origin/master `8b384777d`). In
+      `poll_descriptor/flow_cache_hit.rs` the TTL/hop-limit check
+      (lines 151-179) precedes ALL egress side effects — filter counters
+      (182-198), policy hit counter (210-215), three-color policers
+      (216-220), input/output filter logs (221-259), and the terminal drop
+      (260-263).
+    - **H8 (observed_bytes/active-flow before TTL) — NOT-A-BUG (deliberate)**:
+      `lookup_counted` stamps `last_used_epoch` + `observed_bytes`
+      (`flow_cache.rs:918-919`) at lookup time, before the TTL check. This is
+      the DOCUMENTED design decision at `afxdp/README.md` (#3779 note):
+      `observed_bytes`/active-epoch count the packet as SEEN — flow-activity
+      telemetry, not forwarded-byte accounting. Session byte/packet counters
+      (the forwarded-byte reference) DO sit after the TTL check
+      (`account_packet` at 303-308), matching the slow path.
+    - **M3/M4 (silent DSCP-rewrite failure) — NOT-MATERIAL as framed**:
+      `apply_dscp_rewrite_to_frame` `None` = "frame has no IP DSCP field"
+      (non-IP/ARP or too-short), a benign no-op. `assign_*_dscp_rewrite`
+      stamps the queue rewrite onto all items incl. non-IP frames, so a
+      blanket failure counter would false-positive; the genuine-error subset
+      is unreachable on the pre-parsed TX path. Documented the `None`
+      contract on the function + README rather than adding a misinforming
+      counter.
+    - **M7 (cached filter-log first-packet only) — DOCUMENTED**: the cached
+      input/output filter-log replay is seed-captured (single
+      `FilterLogMatch`); per-packet re-evaluation would defeat the cache and
+      is not justified for a `then log` term. Documented the limitation
+      (task-offered resolution) alongside the #3778 frozen-queue precedent.
+- **File(s)**: userspace-dp/src/afxdp/README.md,
+  userspace-dp/src/afxdp/frame/mod.rs, _Log.md
+- **Validation**: `cargo test --release -- --test-threads=1` (full suite).
+  No dataplane forwarding behavior changed (doc + rustdoc only) — no smoke
+  required.
+
 ## 2026-07-06 — #4399: nat_reverse_index 1:N multimap + validate-on-lookup
 
 - **Timestamp**: 2026-07-06

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -611,6 +611,36 @@ sync.
   moves. `observed_bytes`/active-epoch stamping in `lookup_counted` still counts
   the packet as SEEN (deliberate — it is flow-activity telemetry, not
   forwarded-byte accounting).
+  **Cached filter-log replay is seed-captured (first-packet term, #4423 M7):**
+  `emit_cached_input_filter_log` / `emit_cached_output_filter_log` replay the
+  single `FilterLogMatch` (`cached_descriptor.input_filter_log` /
+  `tx_selection.filter_log`) frozen when the flow was cached from its SEED
+  packet, so every hit logs the seed's matched `then log` term. This is a
+  deliberate caching approximation in the same family as the frozen SEED queue
+  (#3778): the flow-cache key excludes DSCP/PCP, so a filter whose `then log`
+  term selection turns on a per-packet field (DSCP) logs the seed's term for
+  the whole cached flow rather than re-evaluating the filter on each hit. The
+  5-tuple-stable common case is exact; re-running the cold-path filter
+  evaluation per packet purely to correct a `then log` term would defeat the
+  cache. Contrast the `then count` side, which #2573 (output) and #3777 (input)
+  fixed to replay EVERY matched counter — a count is a cheap handle bump, a log
+  is a full RT_FLOW event, so the count/log asymmetry is intentional. Per-packet
+  BA-classifier queue selection is already corrected (#3778, above); the
+  per-packet filter-log term is not.
+  **DSCP-rewrite `let _` is a benign no-op, not a silent failure (#4423
+  M3/M4):** `apply_dscp_rewrite_to_frame` (`frame/mod.rs`) returns `None` when
+  the frame has no IPv4/IPv6 DSCP field to rewrite — a non-IP frame (ARP, etc.)
+  or one too short to hold its L3 header. The TX-path callers
+  (`tx/transmit/rewrite.rs` prepared-TX, `tx/transmit/mod.rs` local-TX, the
+  `cos/queue_service/drain.rs` CoS drains) `let _` the result deliberately:
+  `assign_local_dscp_rewrite` / `assign_prepared_dscp_rewrite` stamp the
+  per-CoS-queue rewrite onto ALL queued items, including any non-IP frame that
+  co-resides in a DSCP-rewrite queue, so `None` there is the correct
+  "not applicable" outcome — not a dropped/mis-marked IP packet. A blanket
+  failure counter would false-positive on every legitimate non-IP frame; the
+  only genuine-error subset (an IP frame too short for its own header) is
+  unreachable on this path because TX frames are already-parsed forwarded IP
+  packets. The frame egresses either way; nothing is dropped.
   Producers must use the event-stream worker handle so rate limiting,
   queue-budget accounting, replay, and daemon callback ACK behavior stay
   centralized in `event_stream/`.

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -149,6 +149,17 @@ pub(in crate::afxdp) fn v6_rel_l4_offset(
     }
 }
 
+/// Rewrite the DSCP (IPv4 TOS high 6 bits / IPv6 traffic-class high 6 bits) of
+/// `frame` in place, incrementally fixing the IPv4 header checksum.
+///
+/// Returns `Some(())` when the DSCP was written (or already matched, a no-op
+/// success). Returns `None` when the frame has no IPv4/IPv6 DSCP field to
+/// rewrite: a non-IP frame (ARP and friends) or one too short to hold its L3
+/// header. `None` is a benign "not applicable" outcome, NOT a forwarding error
+/// — TX-path callers `let _` it because a per-CoS-queue DSCP rewrite is stamped
+/// onto every queued item and non-IP frames legitimately co-reside in a
+/// DSCP-rewrite queue. The frame is transmitted either way; see the "#4423
+/// M3/M4" note in `afxdp/README.md`.
 pub(in crate::afxdp) fn apply_dscp_rewrite_to_frame(frame: &mut [u8], dscp: u8) -> Option<()> {
     let dscp = dscp & 0x3f;
     let l3 = frame_l3_offset(frame)?;


### PR DESCRIPTION
Verify-first triage of the codex flow-cache audit sub-items on the
flow-cache-hit fast path (`poll_descriptor/flow_cache_hit.rs`). The two HIGHs
are not-material on `origin/master`; the two MEDs are a deliberate caching
approximation / benign no-op. This PR is documentation + rustdoc only — no
forwarding behavior change.

## Per sub-item

- **H7 (charges output/filter counters + logs before the TTL reject) —
  NOT-A-BUG (already fixed by #3779, `8b384777d`).** The TTL/hop-limit check
  (`flow_cache_hit.rs:151-179`) precedes every egress side effect: filter
  counters (182-198), policy hit counter (210-215), three-color policers
  (216-220), input/output filter logs (221-259), terminal drop (260-263).
- **H8 (observed_bytes + active-flow telemetry before the TTL outcome) —
  NOT-A-BUG (deliberate, documented).** `lookup_counted` stamps
  `last_used_epoch` + `observed_bytes` (`flow_cache.rs:918-919`) as
  flow-activity telemetry ("SEEN"), not forwarded-byte accounting. The
  forwarded-byte reference — session byte/packet counters
  (`account_packet`, `flow_cache_hit.rs:303-308`) — does sit after the TTL
  check.
- **M3/M4 (silent DSCP-rewrite failure) — NOT-MATERIAL as framed.**
  `apply_dscp_rewrite_to_frame` `None` = "frame has no IP DSCP field"
  (non-IP/ARP or too-short), a benign no-op; the queue rewrite is stamped
  onto all items incl. non-IP frames, so a blanket counter would
  false-positive. Genuine-error subset unreachable on the pre-parsed TX
  path. Documented the `None` contract instead of a misinforming counter.
- **M7 (cached filter-log first-packet only) — DOCUMENTED.** Seed-captured
  `FilterLogMatch` replay; per-packet re-eval would defeat the cache (count
  vs log asymmetry, cf. #2573/#3777/#3778). Documented the limitation.

## Validation

`cargo test --release -- --test-threads=1` — full suite green
(3646 + 54 + 8 + 22 + 1 passed, 0 failed). No dataplane forwarding behavior
changed → no smoke required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi