### PR TITLE
Refs #4423 (ip-monitoring M3-M8/L1-L12)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -38057,3 +38057,80 @@ top.
 - **File(s)**: pkg/config/ast_edit.go, pkg/config/event_options_4423_test.go,
   pkg/eventengine/engine.go, pkg/eventengine/engine_4423_test.go,
   pkg/eventengine/README.md, _Log.md
+---
+- **Timestamp**: 2026-07-06
+- **Action**: #4423 ip-monitoring (services ip-monitoring / #1827 preferred-route
+  WAN-failover engine) M3-M8 + L verify-first triage. Branch fix/4423-ipmon.
+  - **M8 — GENUINE (latent), fixed.** `seedResultsLocked(nil)` early-returned,
+    PRESERVING stale FAIL state; a caller with no probe data kept a policy
+    FAILED and its failover route injected off results it no longer has.
+    Now nil is treated identically to an empty snapshot (clear → UNKNOWN).
+    Production callers always pass non-nil (`rpm.Results()` is a non-nil slice;
+    `fireTransition` always sets `Results: m.Results()`), so this only affected
+    direct package/API callers — a correctness hardening. RED-on-revert
+    `TestApplyNilResultsClearsStaleFailState`.
+  - **M4 — GENUINE, fixed.** `NotifyNextHopChange` scheduled an actuation on a
+    DHCP gateway change even while publication was HA-gated off (standby),
+    where the published overlay is the baseline (nil) regardless of the lease
+    — wasted no-op frr-reload + snapshot churn. Gated the relevance scan on
+    `e.publishEnabled`; takeover (`SetPublishEnabled(true)`) re-actuates and
+    the overlay then follows the fresh lease. RED-on-revert
+    `TestNotifyNextHopChangeGatedOffStandby`. HA-adjacent (publication gating)
+    but no forwarding/failover-path change — pure standby-side no-op
+    suppression, so `make test-failover` is not warranted (flagged in the
+    PR).
+  - **L (bounded actuator timeout) — GENUINE, fixed.** The actuator ran under
+    the un-timed shutdown context, so a wedged apply-semaphore acquire (a stuck
+    operator commit) held the run loop off its retry until `Stop`. Added
+    `DefaultActuateTimeout` (30 s) child ctx per actuation — bounds only the
+    ctx-checked semaphore wait (#3758), never a live FRR reload; a timeout
+    returns false and folds into the #3757 self-heal retry. RED-on-revert
+    `TestActuationTimeoutRetriesWithoutStop`.
+  - **L (racy SetNextHopResolver) — GENUINE (latent), fixed.** The resolver
+    field was written without mu while `computeOverlayLocked` reads it under
+    mu; safe in prod (set before Start) but a latent race. Now written under
+    mu. Covered by `-race`.
+  - **L (no actuator-failure metric) — GENUINE gap, fixed.** Added
+    `actuationFailures` counter (incremented on every non-converged actuation)
+    + `ActuationFailures()` getter, exported as
+    `xpf_ipmon_actuation_failures_total`, surfacing the otherwise-silent #3757
+    self-heal retry loop. Wired through api.Config → collector.
+  - **M5 — NOT-MATERIAL.** "DHCP resolver under Engine.mu blocks transition
+    ingestion + status." The resolver is a microsecond map copy-out
+    (`resolveDHCPNextHop` → `dhcp.Manager.LeaseFor`, dhcp.go:652-662 — lock,
+    copy, unlock); NO dhcp `m.mu` critical section spans network I/O (DORA /
+    renewal run outside the lock). The Engine.mu → dhcp.mu order is documented
+    one-way + acyclic (ipmon.go NextHopResolver doc). No material stall.
+  - **M6 — NOT-MATERIAL as framed ("compute once").** `Apply` computes
+    overlayBefore (old policies) AND overlayAfter (new policies) to detect
+    whether an edit/removal changed the effective overlay (HIGH-1 re-injection,
+    ipmon.go:390-394) — the two are semantically distinct, so they cannot
+    collapse to one; overlayAfter is already short-circuited when `changed==true`
+    (the common fail/recover path). The only duplication is the resolver
+    consulted twice for the same lease keys = the same microsecond map read
+    disproved in M5.
+  - **M3 — DEFER (documented residual, #3764).** `rpmProbeGatingRGs`
+    (daemon_rpm.go:133,140) defaults a policy-referenced-but-RETH-unbound probe
+    to the lowest data RG. This is already documented as deferred in
+    `daemon_ipmon.go:376-379` (Layer-2 plan: a per-policy publish allow-set or
+    a commit-check requiring HA-gated probes to bind a RETH). Sane default for
+    the single-data-RG common case; the multi-data-RG split-primary residual is
+    the recorded follow-up. Not force-driven.
+  - **L (unbounded PreferredMetric) — NOT-MATERIAL.** Never rendered to FRR
+    (`renderPreferredRoutes` hardcodes `Preference: 1`, config_render.go:343);
+    it is purely the engine's winner-resolution comparison key (int compare, no
+    arithmetic/overflow) and negatives are already rejected at commit
+    (`setMetric` n<0, compiler_services.go:857). A cap would only risk
+    rejecting a currently-valid config.
+  - **L (wall-clock FormatStatus) — DEFER (cosmetic).** `display.go` uses
+    `time.Until`/`Format` on a human-facing render; in production `e.now ==
+    time.Now`, so the hold-down countdown is correct. Threading the engine
+    clock into the CLI/gRPC render surface is out of scope for a display-only
+    nicety.
+  - Validation: `go test -race ./pkg/ipmon/...` green; `go test
+    ./pkg/api/... ./pkg/daemon/...` green; `go build ./...`; gofmt/vet clean on
+    touched files (pre-existing metrics_wireguard_test.go gofmt drift is on
+    origin/master, untouched). Each of the four fixes verified RED-on-revert.
+- **File(s)**: pkg/ipmon/ipmon.go, pkg/ipmon/ipmon_test.go, pkg/ipmon/README.md,
+  pkg/api/metrics.go, pkg/api/metrics_descriptors.go, pkg/api/metrics_system.go,
+  pkg/api/server.go, pkg/daemon/daemon_run.go, docs/multi-wan.md, _Log.md

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -517,7 +517,8 @@ clear can match sessions allocated from the other pool.
 - Prometheus: `xpf_ipmon_policy_failed{policy}`,
   `xpf_ipmon_policy_transitions_total{policy}`,
   `xpf_ipmon_routes_applied`, `xpf_ipmon_routes_desired`,
-  `xpf_ipmon_unresolved_next_hops`.
+  `xpf_ipmon_unresolved_next_hops`,
+  `xpf_ipmon_actuation_failures_total`.
   - `xpf_ipmon_routes_applied` counts routes **actually applied** — the
     last CONVERGED actuation's overlay live in the FIBs (#3761 H8), NOT
     the desired set. `xpf_ipmon_routes_desired` counts what the engine
@@ -528,6 +529,13 @@ clear can match sessions allocated from the other pool.
     routes skipped for a missing DHCP gateway (#1844); non-zero during a
     failover means the backup uplink's lease is missing and its route is
     NOT injected.
+  - `xpf_ipmon_actuation_failures_total` counts route-overlay actuations
+    that did not converge — a hard FRR reload error, a snapshot-publish
+    failure, an unconfirmed FIB-generation bump, or a bounded-timeout /
+    shutdown abort (#3757/#3758/#4423). The engine retries autonomously
+    (throttle-paced), so a steadily-climbing value — especially paired
+    with a `desired > applied` gap — means ip-monitoring cannot commit
+    its overlay and failover protection is degraded.
 - Transitions log at Info; per-probe detail at Debug.
 
 ## HA model (chassis cluster)

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -204,6 +204,7 @@ type xpfCollector struct {
 	ipmonRoutesApplied      *prometheus.Desc
 	ipmonRoutesDesired      *prometheus.Desc
 	ipmonUnresolvedNextHops *prometheus.Desc
+	ipmonActuationFailures  *prometheus.Desc
 
 	// #1895: count of RPM next-hop probe pins whose kernel fwmark
 	// rule / pinned route failed to install (affected tests hold
@@ -649,6 +650,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.ipmonRoutesApplied
 	ch <- c.ipmonRoutesDesired
 	ch <- c.ipmonUnresolvedNextHops
+	ch <- c.ipmonActuationFailures
 	ch <- c.rpmPinInstallFailures
 	ch <- c.eventActionsCommitted
 	ch <- c.eventActionsRejected

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -644,6 +644,19 @@ func newCollector(srv *Server) *xpfCollector {
 				"is NOT injected.",
 			nil, nil,
 		),
+		ipmonActuationFailures: prometheus.NewDesc(
+			"xpf_ipmon_actuation_failures_total",
+			"Cumulative ip-monitoring route-overlay actuations that did "+
+				"NOT converge — a hard FRR reload error, a snapshot-publish "+
+				"failure, an unconfirmed FIB-generation bump (#3757), or a "+
+				"bounded-timeout/shutdown abort (#3758, #4423). The engine "+
+				"retries autonomously (throttle-paced), so a steadily "+
+				"climbing value means ip-monitoring cannot commit its "+
+				"overlay and failover protection is degraded — pair it with "+
+				"a sustained xpf_ipmon_routes_desired > xpf_ipmon_routes_applied "+
+				"gap.",
+			nil, nil,
+		),
 
 		// #709: owner-profile telemetry. Labels:
 		//   ifindex:      interface ifindex as string

--- a/pkg/api/metrics_system.go
+++ b/pkg/api/metrics_system.go
@@ -242,6 +242,14 @@ func (c *xpfCollector) collectSystemMetrics(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(c.ipmonUnresolvedNextHops,
 			prometheus.GaugeValue, float64(unresolved))
 	}
+	// #4423 L: ip-monitoring actuation-failure counter — surfaces the
+	// otherwise-silent #3757 self-heal retry loop so a stuck overlay
+	// actuation (degraded failover) is observable. Independent of
+	// ipmonStatusFn: it is meaningful even with zero FAILED policies.
+	if c.srv.ipmonActuationFailuresFn != nil {
+		ch <- prometheus.MustNewConstMetric(c.ipmonActuationFailures,
+			prometheus.CounterValue, float64(c.srv.ipmonActuationFailuresFn()))
+	}
 
 	// #2157: event-options remediation action observability. Makes the
 	// previously-silent loss (drop on held config lock) visible.

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -151,6 +151,11 @@ type Config struct {
 	// the xpf_ipmon_* metrics (#1827). Optional; if nil, the family is
 	// omitted.
 	IPMonStatusFn func() []ipmon.PolicyStatus
+	// IPMonActuationFailuresFn surfaces the cumulative count of
+	// ip-monitoring route-overlay actuations that did not converge, for
+	// the xpf_ipmon_actuation_failures_total counter (#4423 L). Optional;
+	// if nil the metric is omitted.
+	IPMonActuationFailuresFn func() uint64
 	// EventActionStatsFn surfaces event-options remediation action
 	// counters for the xpf_event_actions_* / xpf_event_action_queue_depth
 	// metrics (#2157). Optional; if nil, the family is omitted.
@@ -277,6 +282,7 @@ type Server struct {
 	schedulerRepublishFailedFn       func() bool
 	schedulerRepublishStaleSecondsFn func() float64
 	ipmonStatusFn                    func() []ipmon.PolicyStatus
+	ipmonActuationFailuresFn         func() uint64
 	eventActionStatsFn               func() eventengine.Stats
 	rpmPinFailedFn                   func() float64
 	feedsFn                          func() map[string]feeds.FeedInfo
@@ -360,6 +366,7 @@ func NewServer(cfg Config) *Server {
 		schedulerRepublishFailedFn:       cfg.SchedulerRepublishFailedFn,
 		schedulerRepublishStaleSecondsFn: cfg.SchedulerRepublishStaleSecondsFn,
 		ipmonStatusFn:                    cfg.IPMonStatusFn,
+		ipmonActuationFailuresFn:         cfg.IPMonActuationFailuresFn,
 		eventActionStatsFn:               cfg.EventActionStatsFn,
 		rpmPinFailedFn:                   cfg.RPMPinFailedFn,
 		feedsFn:                          cfg.FeedsFn,

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1220,6 +1220,15 @@ func (d *Daemon) Run(ctx context.Context) error {
 				}
 				return nil
 			},
+			// #4423 L: ip-monitoring actuation-failure counter
+			// (xpf_ipmon_actuation_failures_total) — surfaces the silent
+			// #3757 self-heal retry loop so a degraded failover is visible.
+			IPMonActuationFailuresFn: func() uint64 {
+				if d.ipmon != nil {
+					return d.ipmon.ActuationFailures()
+				}
+				return 0
+			},
 			// #2157: event-options remediation action counters for the
 			// xpf_event_actions_* / xpf_event_action_queue_depth family.
 			EventActionStatsFn: func() eventengine.Stats {

--- a/pkg/ipmon/README.md
+++ b/pkg/ipmon/README.md
@@ -71,6 +71,22 @@ future config change is required to recover.
   `dirtyGen` before actuating and clears `dirtySince` only when the
   actuation converged AND no newer change landed meanwhile
   (last-writer-wins preserved).
+- **Bounded per-actuation timeout (#4423 L):** each `actuate()` call
+  runs under a `DefaultActuateTimeout` (30 s) child of the shutdown
+  context, so a wedged consumer — an apply semaphore never released by a
+  stuck operator commit — cannot hold the run loop off its next retry
+  indefinitely while the daemon is up. It bounds only the ctx-checked
+  wait (the semaphore acquire, #3758); a live FRR reload past that point
+  is never interrupted mid-apply. A timed-out actuation returns `false`,
+  so it folds into the same self-heal retry. `Stop` still cancels the
+  parent context, so shutdown abort is unaffected.
+- **Actuation-failure counter (#4423 L):** every non-converged actuation
+  (any of H1/H2/H3 above, or a timeout/shutdown abort) increments a
+  monotonic counter exported as `xpf_ipmon_actuation_failures_total`
+  (`ActuationFailures()`), making the otherwise-silent retry loop
+  observable — a steadily-climbing value means the overlay cannot commit
+  and failover protection is degraded. Pair it with a sustained
+  `xpf_ipmon_routes_desired > xpf_ipmon_routes_applied` gap.
 
 ## HA
 
@@ -80,6 +96,13 @@ and re-derives from fresh probe results within seconds of a takeover.
 the config baseline — while the state machine keeps tracking
 underneath. Primary-only probing/publication scope is computed in
 `pkg/daemon` (`filterRPMForHAGating`, `ipmonPublishAllowed`).
+
+While gated off, `NotifyNextHopChange` is a no-op (#4423 M4): the
+published overlay is the baseline regardless of any DHCP-learned
+gateway, so a lease change on the standby cannot alter what this node
+publishes — scheduling an actuation would only churn a no-op
+frr-reload + snapshot. `SetPublishEnabled(true)` on takeover re-actuates
+and the overlay then follows the fresh lease.
 
 ## DHCP-tracked next-hops (#1844)
 
@@ -149,10 +172,15 @@ FRR DHCP default route; see the RFC 2131 coupling rule in
   The actuator returns `true` on a consistent, converged actuation and
   `false` to keep the state dirty for an autonomous retry (#3757).
 - `Apply(cfg, results)` — install committed policies, preserving FAIL
-  state for surviving (name, probe) pairs.
+  state for surviving (name, probe) pairs. `results` is a full
+  authoritative snapshot; a nil snapshot is treated identically to an
+  empty one — it resets known test state to UNKNOWN rather than carrying
+  a stale FAIL forward (#4423 M8). The daemon always passes a non-nil
+  slice (`rpm.Results()`), so nil only reaches a direct package caller.
 - `HandleTransition(rpm.Transition)` — the sensor input (wired to
   `rpm.Manager.SetTransitionCallback`).
-- `SetNextHopResolver(NextHopResolver)` (before `Start`) and
+- `SetNextHopResolver(NextHopResolver)` (before `Start`; mu-guarded so a
+  late call cannot race the run loop's resolver read, #4423 L) and
   `NotifyNextHopChange()` — the #1844 DHCP next-hop seam (above).
 - `ActiveOverlay() []config.RouteOverlayEntry`.
 - `Status() []PolicyStatus`, `FormatStatus` (`display.go`) — shared by

--- a/pkg/ipmon/ipmon.go
+++ b/pkg/ipmon/ipmon.go
@@ -59,6 +59,16 @@ const (
 	// DefaultThrottle is the minimum spacing between consecutive
 	// actuations (frr-reload cooling window).
 	DefaultThrottle = 3 * time.Second
+	// DefaultActuateTimeout bounds a single actuation so a wedged
+	// consumer (an apply semaphore never released by a stuck operator
+	// commit) cannot hold the run loop off its next retry indefinitely
+	// while the daemon is still up (#4423 L). It aborts only the
+	// ctx-checked wait (the apply-semaphore acquire, #3758) — a live FRR
+	// reload past that point is never interrupted mid-apply — and a
+	// timed-out actuation returns false so the engine keeps the state
+	// dirty and retries on the next throttle-paced sweep. Chosen well
+	// above a legitimate FRR reload + snapshot publish.
+	DefaultActuateTimeout = 30 * time.Second
 )
 
 // UnresolvedRoute describes a FAILED policy's interface-typed preferred
@@ -170,6 +180,15 @@ type Engine struct {
 	// so a change that lands DURING an actuation (last-writer-wins) is
 	// not lost, and a failed actuation stays dirty for retry (#3757).
 	dirtyGen uint64
+	// actuationFailures counts route-overlay actuations that did not
+	// converge (a hard FRR reload error, a snapshot-publish failure, an
+	// unconfirmed FIB-generation bump, or a bounded-timeout/shutdown
+	// abort). Monotonic; feeds xpf_ipmon_actuation_failures_total so the
+	// otherwise-silent #3757 self-heal retry loop is observable — a
+	// steadily-climbing value means ip-monitoring cannot commit its
+	// overlay and failover protection is degraded (#4423 L). Read/written
+	// only under mu.
+	actuationFailures uint64
 
 	// actuate is the daemon route-overlay actuator; called WITHOUT mu
 	// held. It returns true when the overlay converged consistently
@@ -184,13 +203,19 @@ type Engine struct {
 	// (return false) WITHOUT half-actuating.
 	actuate func(ctx context.Context) bool
 	// resolveNextHop resolves interface-typed next-hops at overlay
-	// computation (#1844). Set once via SetNextHopResolver before
-	// Start; nil ⇒ interface-typed candidates always skip (defensive —
+	// computation (#1844). Written by SetNextHopResolver and read by
+	// computeOverlayLocked, both under mu (#4423 L closes the prior
+	// unsynchronized-field race); the daemon still wires it once before
+	// Start. nil ⇒ interface-typed candidates always skip (defensive —
 	// the daemon always wires it).
 	resolveNextHop NextHopResolver
 	now            func() time.Time
 	debounce       time.Duration
 	throttle       time.Duration
+	// actuateTimeout bounds a single actuate() call (0 ⇒ unbounded). Set
+	// once before Start (like debounce/throttle) and read by the run-loop
+	// goroutine without further synchronization (#4423 L).
+	actuateTimeout time.Duration
 
 	kick chan struct{}
 	stop chan struct{}
@@ -234,6 +259,7 @@ func New(actuate func(ctx context.Context) bool) *Engine {
 		now:            time.Now,
 		debounce:       DefaultDebounce,
 		throttle:       DefaultThrottle,
+		actuateTimeout: DefaultActuateTimeout,
 		kick:           make(chan struct{}, 1),
 		stop:           make(chan struct{}),
 		done:           make(chan struct{}),
@@ -243,10 +269,13 @@ func New(actuate func(ctx context.Context) bool) *Engine {
 }
 
 // SetNextHopResolver injects the interface-typed next-hop resolver
-// (#1844). Must be called before Start() — the field is read by the
-// run-loop goroutine without further synchronization.
+// (#1844). The daemon calls it once before Start(); it takes mu so a
+// late call (a test, or a future re-wire) cannot race the run loop's
+// resolver read in computeOverlayLocked (#4423 L).
 func (e *Engine) SetNextHopResolver(r NextHopResolver) {
+	e.mu.Lock()
 	e.resolveNextHop = r
+	e.mu.Unlock()
 }
 
 // NotifyNextHopChange is the DHCP gateway-change trigger (#1844): it
@@ -262,18 +291,26 @@ func (e *Engine) SetNextHopResolver(r NextHopResolver) {
 func (e *Engine) NotifyNextHopChange() {
 	e.mu.Lock()
 	relevant := false
-	for _, st := range e.policies {
-		if !st.failed {
-			continue
-		}
-		for _, pr := range st.cfg.PreferredRoutes {
-			if pr != nil && pr.NextHopInterface != "" {
-				relevant = true
+	// While publication is gated off (HA standby, §4.4) the effective
+	// overlay is the baseline (nil) regardless of any DHCP-learned
+	// gateway, so a lease change cannot alter what this node publishes —
+	// scheduling an actuation would only churn an frr-reload + snapshot
+	// publish for a no-op on the standby (#4423 M4). SetPublishEnabled(true)
+	// on takeover re-actuates and the overlay then follows the fresh lease.
+	if e.publishEnabled {
+		for _, st := range e.policies {
+			if !st.failed {
+				continue
+			}
+			for _, pr := range st.cfg.PreferredRoutes {
+				if pr != nil && pr.NextHopInterface != "" {
+					relevant = true
+					break
+				}
+			}
+			if relevant {
 				break
 			}
-		}
-		if relevant {
-			break
 		}
 	}
 	if relevant {
@@ -671,12 +708,32 @@ func (e *Engine) RoutesApplied() int {
 	return len(e.appliedOverlay)
 }
 
+// ActuationFailures reports the cumulative number of route-overlay
+// actuations that did not converge — a hard FRR reload error, a
+// snapshot-publish failure, an unconfirmed FIB-generation bump (#3757),
+// or a bounded-timeout/shutdown abort (#3758/#4423 L). It is monotonic;
+// the engine retries a failed actuation autonomously (throttle-paced),
+// so a steadily-climbing value means ip-monitoring cannot commit its
+// overlay and failover protection is degraded. Feeds
+// xpf_ipmon_actuation_failures_total.
+func (e *Engine) ActuationFailures() uint64 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.actuationFailures
+}
+
 // seedResultsLocked rebuilds per-test fail state from a results
-// snapshot.
+// snapshot. A nil snapshot is treated identically to an empty one: it
+// CLEARS all known test state (no probe data ⇒ nothing failing) rather
+// than preserving a stale FAIL — keeping a policy FAILED (and its
+// failover route injected) off results the caller no longer has is wrong
+// (#4423 M8). Both production callers pass a full authoritative,
+// non-nil snapshot (Apply from rpm.Results(), always a non-nil slice;
+// HandleTransition from rpm's per-transition snapshot), so nil arrives
+// only from a direct package/API caller with no results — which now
+// resets cleanly to UNKNOWN instead of silently carrying the last
+// failure forward.
 func (e *Engine) seedResultsLocked(results []*rpm.ProbeResult) {
-	if results == nil {
-		return
-	}
 	fresh := make(map[string]map[string]bool)
 	for _, r := range results {
 		if r == nil {
@@ -794,10 +851,22 @@ func (e *Engine) run() {
 			// Outside the lock; the actuator reads ActiveOverlay() itself,
 			// so it publishes the freshest state (last-writer-wins under
 			// flap storms). A nil actuator (tests that drive the state
-			// machine directly) is a converged no-op.
+			// machine directly) is a converged no-op. The actuation runs
+			// under a bounded child of e.actuateCtx so a wedged consumer
+			// cannot hold the loop off its next retry indefinitely while
+			// the daemon is up (#4423 L); Stop still cancels e.actuateCtx
+			// (the parent), so shutdown abort (#3758) is unaffected.
 			ok := true
 			if e.actuate != nil {
-				ok = e.actuate(e.actuateCtx)
+				actCtx := e.actuateCtx
+				var cancel context.CancelFunc
+				if e.actuateTimeout > 0 {
+					actCtx, cancel = context.WithTimeout(e.actuateCtx, e.actuateTimeout)
+				}
+				ok = e.actuate(actCtx)
+				if cancel != nil {
+					cancel()
+				}
 			}
 			e.mu.Lock()
 			if ok && e.dirtyGen == actuatingGen {
@@ -812,6 +881,12 @@ func (e *Engine) run() {
 				// read via ActiveOverlay); record it as the applied state
 				// so status/metrics report applied, not desired (#3761 H8).
 				e.appliedOverlay = e.activeOverlayLocked()
+			}
+			if !ok {
+				// Non-convergence (a consumer failed, or the bounded
+				// timeout/shutdown aborted the wait): count it so the
+				// otherwise-silent self-heal retry is observable (#4423 L).
+				e.actuationFailures++
 			}
 			e.mu.Unlock()
 		}

--- a/pkg/ipmon/ipmon_test.go
+++ b/pkg/ipmon/ipmon_test.go
@@ -659,6 +659,144 @@ func TestApplyPreservesFailedStateAcrossCommit(t *testing.T) {
 	}
 }
 
+// TestApplyNilResultsClearsStaleFailState is the #4423 M8 regression:
+// seedResultsLocked must treat a nil results snapshot as an EMPTY one
+// (clear all test state) rather than preserving a stale FAIL. A caller
+// with no probe data must not keep a policy FAILED — and its failover
+// route injected — off results it no longer has. On revert (the
+// `if results == nil { return }` early-return) the FAIL and the overlay
+// survive the nil-results apply and all three assertions go RED.
+func TestApplyNilResultsClearsStaleFailState(t *testing.T) {
+	e, _ := newTestEngine(nil)
+	e.Apply(testPolicyConfig(), passResults())
+	e.HandleTransition(transition("WAN", "wan-a", "fail", passResults()))
+	if !e.Status()[0].Failed {
+		t.Fatal("setup: policy not FAILED after a failing probe")
+	}
+	if len(e.ActiveOverlay()) == 0 {
+		t.Fatal("setup: no overlay after failure")
+	}
+
+	// Re-apply the same policy set with NO results snapshot (nil).
+	e.Apply(testPolicyConfig(), nil)
+	if e.Status()[0].Failed {
+		t.Fatal("stale FAIL preserved across Apply(cfg, nil) — M8 regression")
+	}
+	if got := e.ActiveOverlay(); got != nil {
+		t.Fatalf("overlay = %+v after nil-results apply, want withdrawn", got)
+	}
+	if e.Status()[0].Known {
+		t.Fatal("policy still reported Known after results reset to nil/empty")
+	}
+
+	// nil and empty-slice snapshots are equivalent: an empty snapshot
+	// already cleared today, and nil must match.
+	e.Apply(testPolicyConfig(), passResults())
+	e.HandleTransition(transition("WAN", "wan-a", "fail", passResults()))
+	if !e.Status()[0].Failed {
+		t.Fatal("setup: re-fail did not take")
+	}
+	e.Apply(testPolicyConfig(), []*rpm.ProbeResult{})
+	if e.Status()[0].Failed {
+		t.Fatal("empty-slice snapshot did not clear FAIL")
+	}
+}
+
+// TestNotifyNextHopChangeGatedOffStandby is the #4423 M4 regression:
+// while publication is gated off (HA standby) a DHCP gateway change must
+// NOT schedule an actuation — the published overlay is the baseline
+// (nil) regardless of the lease, so recomputing/actuating is wasted
+// frr-reload + snapshot churn on the standby. On revert (NotifyNextHopChange
+// ignores publishEnabled) the gated-off gateway change actuates and the
+// "no new actuation" assertion goes RED.
+func TestNotifyNextHopChangeGatedOffStandby(t *testing.T) {
+	var actuations atomic.Int32
+	e := New(func(context.Context) bool { actuations.Add(1); return true })
+	e.debounce = 5 * time.Millisecond
+	e.throttle = 5 * time.Millisecond
+	r := &fakeResolver{}
+	r.set("ge-0-0-3", "198.51.100.1")
+	e.SetNextHopResolver(r.resolve)
+	e.Apply(dhcpPolicyConfig(), passResults())
+	e.Start()
+	defer e.Stop()
+
+	// Fail an interface-typed policy, then gate publication off (standby).
+	failWAN(e)
+	e.SetPublishEnabled(false)
+	time.Sleep(50 * time.Millisecond) // let the failure + gate-off actuations settle
+	base := actuations.Load()
+
+	// A DHCP gateway change while gated off must not actuate.
+	r.set("ge-0-0-3", "198.51.100.254")
+	for i := 0; i < 3; i++ {
+		e.NotifyNextHopChange()
+	}
+	time.Sleep(60 * time.Millisecond)
+	if got := actuations.Load(); got != base {
+		t.Fatalf("NotifyNextHopChange actuated while publication gated off: %d -> %d (M4)", base, got)
+	}
+
+	// On takeover the overlay follows the fresh lease again.
+	e.SetPublishEnabled(true)
+	deadline := time.Now().Add(2 * time.Second)
+	for actuations.Load() == base && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if actuations.Load() == base {
+		t.Fatal("takeover did not actuate after a gated-off gateway change")
+	}
+}
+
+// TestActuationTimeoutRetriesWithoutStop is the #4423 L (bounded actuator
+// timeout) regression: a wedged actuation must be aborted by the bounded
+// per-actuation timeout and retried WITHOUT waiting for Stop, so a stuck
+// consumer cannot hold the run loop off its retry indefinitely while the
+// daemon is up. On revert (actuate runs under the un-timed e.actuateCtx)
+// the first actuation blocks until Stop and the second attempt never
+// happens — attempts stays 1 and the retry assertion goes RED. It also
+// asserts the failure counter climbs across the wedged retries.
+func TestActuationTimeoutRetriesWithoutStop(t *testing.T) {
+	var attempts atomic.Int32
+	var unblock atomic.Bool
+	e := New(func(ctx context.Context) bool {
+		attempts.Add(1)
+		if unblock.Load() {
+			return true
+		}
+		<-ctx.Done() // wedged: unblocks only on the bounded timeout (or Stop)
+		return false
+	})
+	e.debounce = 2 * time.Millisecond
+	e.throttle = 5 * time.Millisecond
+	e.actuateTimeout = 20 * time.Millisecond
+	e.Apply(testPolicyConfig(), passResults())
+	e.Start()
+	defer e.Stop()
+
+	e.HandleTransition(transition("WAN", "wan-a", "fail", passResults()))
+
+	deadline := time.Now().Add(2 * time.Second)
+	for attempts.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := attempts.Load(); got < 2 {
+		t.Fatalf("attempts = %d — bounded actuation timeout did not fire, no retry without Stop", got)
+	}
+	if e.ActuationFailures() == 0 {
+		t.Fatal("ActuationFailures still 0 while actuations kept timing out")
+	}
+
+	// Convergence quiesces the loop.
+	unblock.Store(true)
+	time.Sleep(120 * time.Millisecond)
+	settled := attempts.Load()
+	time.Sleep(120 * time.Millisecond)
+	if extra := attempts.Load() - settled; extra > 1 {
+		t.Fatalf("kept firing after convergence: +%d attempts, want quiescent", extra)
+	}
+}
+
 // TestFilterOverlayForConfig is the Codex PR #1843 HIGH-1 regression
 // test: a commit that removes a policy or edits its preferred-route
 // spec must not republish the stale overlay entries on the commit's


### PR DESCRIPTION
Verify-first triage of the **services ip-monitoring** (#1827 preferred-route WAN-failover engine) `M3-M8` + `L` sub-items from the #4423 audit backlog. Four fixes (each RED-on-revert), the rest disproved or deferred with recorded evidence. GO-only (`pkg/ipmon` engine + `pkg/api` metric wiring); no dataplane/cargo.

## Fixed (GENUINE)

- **M8 (latent correctness):** `seedResultsLocked(nil)` early-returned, **preserving stale FAIL state** — a caller with no probe data kept a policy FAILED and its failover route injected off results it no longer has. `nil` is now treated identically to an empty snapshot (reset to UNKNOWN). Production callers always pass non-nil (`rpm.Results()` is a non-nil slice; `fireTransition` always sets `Results: m.Results()`), so this only reached direct package/API callers — a correctness hardening. RED-on-revert `TestApplyNilResultsClearsStaleFailState`.
- **M4:** `NotifyNextHopChange` scheduled an actuation on a DHCP gateway change **even while publication was HA-gated off** (standby), where the overlay is the baseline (nil) regardless of the lease — wasted no-op frr-reload + snapshot churn. The relevance scan is now gated on `publishEnabled`; takeover re-actuates and the overlay then follows the fresh lease. Standby-side no-op suppression only — no forwarding/failover-path change. RED-on-revert `TestNotifyNextHopChangeGatedOffStandby`.
- **L (bounded actuator timeout):** the actuator ran under the un-timed shutdown context, so a wedged apply-semaphore acquire (a stuck operator commit) held the run loop off its retry until `Stop`. Each `actuate()` now runs under a `DefaultActuateTimeout` (30 s) child context that bounds only the ctx-checked semaphore wait (#3758) — never a live FRR reload; a timeout returns false and folds into the #3757 self-heal retry. RED-on-revert `TestActuationTimeoutRetriesWithoutStop`.
- **L (racy SetNextHopResolver):** the resolver field was written without `mu` while `computeOverlayLocked` reads it under `mu` (safe in production, set before `Start`, but a latent race). Now written under `mu`. Covered by `-race`.
- **L (no actuator-failure metric):** added a monotonic `actuationFailures` counter + `ActuationFailures()` getter, exported as **`xpf_ipmon_actuation_failures_total`** through `api.Config`, surfacing the otherwise-silent #3757 self-heal retry loop so a degraded failover is observable.

## Disposition of the rest (disproving evidence)

- **M5 — NOT-MATERIAL.** "DHCP resolver under `Engine.mu` blocks ingestion/status." The resolver is a microsecond map copy-out (`resolveDHCPNextHop` → `dhcp.Manager.LeaseFor`, dhcp.go:652-662); **no dhcp `m.mu` critical section spans network I/O** (DORA/renewal run outside the lock). The `Engine.mu → dhcp.mu` order is documented one-way + acyclic. No material stall.
- **M6 — NOT-MATERIAL as framed ("compute once").** `Apply` computes overlayBefore (old policies) AND overlayAfter (new policies) to detect whether an edit/removal changed the effective overlay (HIGH-1 re-injection, ipmon.go:390-394) — semantically distinct, cannot collapse; overlayAfter is short-circuited when `changed==true`. The only duplication is the microsecond resolver read disproved in M5.
- **M3 — DEFER (documented residual, #3764).** `rpmProbeGatingRGs` (daemon_rpm.go:133,140) defaults a policy-referenced-but-RETH-unbound probe to the lowest data RG. Already documented as deferred in `daemon_ipmon.go:376-379` (Layer-2 plan). Sane default for the single-data-RG common case.
- **L (unbounded PreferredMetric) — NOT-MATERIAL.** Never rendered to FRR (`renderPreferredRoutes` hardcodes `Preference: 1`, config_render.go:343); a pure winner-resolution comparison key (no arithmetic/overflow); negatives already rejected at commit (compiler_services.go:857).
- **L (wall-clock FormatStatus) — DEFER (cosmetic).** Human-facing render; production `e.now == time.Now`.

## HA note

M4 is publication-gating adjacent but suppresses only a **standby-side no-op** (nothing on the forwarding/failover path changes), so `make test-failover` is not warranted for this change.

## Validation

`go test -race ./pkg/ipmon/...` green; `./pkg/api/... ./pkg/daemon/... ./pkg/grpcapi/... ./pkg/cli/... ./pkg/config/...` green; `go build ./...`; gofmt/vet clean on touched files (the `metrics_wireguard_test.go` gofmt drift is pre-existing on origin/master). Each of the four fixes verified RED-on-revert. Docs: `pkg/ipmon/README.md`, `docs/multi-wan.md`.

Refs #4423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi