### PR TITLE
ipsec: fail the commit closed when swanctl render/reload fails (#4433)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-07-06 — #4433: fail the commit closed when IPsec render/reload fails
+
+- **Timestamp**: 2026-07-06
+- **Action**: Fixed C172-H01 (#4433). The commit/apply path swallowed the
+  `d.ipsec.Apply()` error at WARN (`daemon_apply.go` step 6), so a swanctl
+  render/write/`--load-all` failure was logged and IGNORED. Because
+  `swanctl --load-all` leaves the previously-loaded config in place on
+  failure, the OLD tunnels stayed active while a NEW config was reported
+  committed — the enforced IPsec runtime silently diverged from the
+  committed policy (stale security runtime). Verify-first confirmed the
+  Manager side was already correct: `applyConfig`/`reload` return the error
+  up through `Manager.Apply`; the bug was purely the daemon swallow.
+  Fix: capture the error into `ipsecErr` and join it into the
+  `applyConfigLocked` tail result alongside `networkdErr` / `dhcpServerErr`
+  / `hostInboundErr` / `lo0Err` (the established fail-closed-on-commit
+  pattern, #1778/#2987/#3333/#3392). The config stays promoted + peer-synced
+  and every remaining reconcile step still runs (non-fatal best-effort
+  error class per `applyErrSkipsPeerSync`), so the operator sees a
+  degraded-state error surfaced by `commitAndApply` instead of a false
+  success. The DHCP-lease re-render path (`reapplyIPsecForLeaseChange`) is a
+  fire-and-forget event handler with no operator-facing commit result and is
+  intentionally left logging at WARN.
+- **RED-on-revert**: `TestApplyConfigLocked_IPsecApplyErrorFailsCommit`
+  (pkg/daemon) drives `applyConfigLocked` with the swanctl configDir pointed
+  at an unwritable path and asserts the return mentions "IPsec"; verified RED
+  (returns nil, error swallowed) when the fix is reverted. Companion
+  `TestApplyReloadErrorPropagates` (pkg/ipsec) documents the Manager reload
+  contract via the swanctl seam. `go test ./pkg/ipsec/... ./pkg/daemon/...`
+  green; `go build ./...`; gofmt/vet clean.
+- **File(s)**: pkg/daemon/daemon_apply.go,
+  pkg/daemon/daemon_ipsec_apply_test.go,
+  pkg/ipsec/reload_error_4433_test.go, pkg/ipsec/README.md, _Log.md
+
 ## 2026-07-06 — #4426: reject single-family prefix-lists under `family any`
 
 - **Timestamp**: 2026-07-06

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1333,9 +1333,21 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// 6. Apply IPsec config
 	// Always call Apply so stale swanctl config is removed when VPNs are
 	// deleted from config.
+	//
+	// #4433: a swanctl render/reload failure must fail the commit closed
+	// rather than be swallowed at WARN — otherwise the OLD tunnels stay
+	// active (swanctl --load-all leaves the previously-loaded config in
+	// place on failure) while a NEW config is reported committed, so the
+	// enforced IPsec runtime silently diverges from the committed policy.
+	// The error is joined into the commit result at the tail (alongside
+	// networkdErr / dhcpServerErr / hostInboundErr / lo0Err); the remaining
+	// apply steps still run and the config stays promoted + peer-synced, so
+	// the operator SEES the degraded IPsec state instead of a false success.
+	var ipsecErr error
 	if d.ipsec != nil {
 		if err := d.ipsec.Apply(ipsec.PrepareConfig(cfg)); err != nil {
 			slog.Warn("failed to apply IPsec config", "err", err)
+			ipsecErr = fmt.Errorf("apply IPsec config: %w", err)
 		}
 	}
 
@@ -1664,12 +1676,13 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 		d.applyStep0Tunables(userspaceDP, claimHostTunables, governor, netdevBudget,
 			coalesceExplicit, coalesceEnable, coalesceRX, coalesceTX, rssAllowed)
 	}
-	// #1778 + #2987: deferred reconcile failures — every reconcile step
-	// above has run; surface the networkd write failure and the Kea
-	// restart/stop failure through the commit so a write that left stale
-	// kernel state fails the commit (fail-closed) instead of reporting
-	// success. Both are joined so neither masks the other.
-	return errors.Join(networkdErr, dhcpServerErr, hostInboundErr, lo0Err)
+	// #1778 + #2987 + #4433: deferred reconcile failures — every reconcile
+	// step above has run; surface the networkd write failure, the Kea
+	// restart/stop failure, and the IPsec render/reload failure through the
+	// commit so a step that left stale kernel/swanctl state fails the commit
+	// (fail-closed) instead of reporting success. All are joined so none
+	// masks the other.
+	return errors.Join(networkdErr, dhcpServerErr, hostInboundErr, lo0Err, ipsecErr)
 }
 
 // compileErrorMustAbortApply reports whether a dataplane ApplyConfig error

--- a/pkg/daemon/daemon_ipsec_apply_test.go
+++ b/pkg/daemon/daemon_ipsec_apply_test.go
@@ -1,0 +1,61 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/ipsec"
+)
+
+// TestApplyConfigLocked_IPsecApplyErrorFailsCommit is the #4433 regression: an
+// IPsec swanctl render/reload failure previously only logged a slog.Warn and
+// the commit succeeded, so the OLD tunnels stayed active (swanctl --load-all
+// leaves the previously-loaded config in place on failure) while a NEW config
+// was reported committed — the enforced IPsec runtime silently diverged from
+// the committed policy. The daemon must now surface the ipsec.Apply error as
+// the applyConfigLocked return so the commit reports failure (fail-closed),
+// matching the networkd / Kea / host-inbound / lo0 tail-error contract.
+//
+// The failure is injected deterministically by pointing the IPsec manager's
+// swanctl config dir at an UNWRITABLE path (a parent path component that is a
+// regular file, so os.MkdirAll returns ENOTDIR inside applyConfig). The swallow
+// at step 6 caught EVERY Apply error class — render, write, and reload — so a
+// write-leg failure exercises the identical propagate-vs-swallow code path a
+// reload-leg failure would (the reload contract itself is covered by
+// pkg/ipsec's TestApplyReloadErrorPropagates).
+func TestApplyConfigLocked_IPsecApplyErrorFailsCommit(t *testing.T) {
+	networkDir := t.TempDir()
+
+	d, cfg := minimalNetworkdDaemon(t, networkDir, &dataplane.ApplyResult{})
+
+	// A regular file used as a parent path component makes the swanctl
+	// configDir unwritable: os.MkdirAll(<file>/conf.d) fails with ENOTDIR,
+	// so applyConfig returns a non-nil error before the reload.
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	d.ipsec = ipsec.NewWithConfigDir(filepath.Join(blocker, "conf.d"))
+
+	// A VPN in the config forces Apply down the applyConfig (render + write +
+	// reload) path rather than the empty-config clear path, so the unwritable
+	// configDir is exercised.
+	cfg.Security.IPsec.VPNs = map[string]*config.IPsecVPN{
+		"vpn1": {Gateway: "gw1"},
+	}
+
+	err := d.applyConfigLocked(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("applyConfigLocked must fail when ipsec.Apply cannot render/write/reload " +
+			"the swanctl config (got nil — the render/reload error was swallowed, " +
+			"leaving stale tunnels active under a new committed config)")
+	}
+	if !strings.Contains(err.Error(), "IPsec") {
+		t.Fatalf("applyConfigLocked error should mention the IPsec failure: %v", err)
+	}
+}

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -15,7 +15,16 @@ the apply path pays no fsync (the file is regenerated on every apply).
   `/etc/swanctl/conf.d`.
 - `Apply(ipsecCfg *config.IPsecConfig) error` — `manager.go`. Generate
   config and reload strongSwan, then terminate the live SAs of any
-  connection deleted since the last Apply (#3941).
+  connection deleted since the last Apply (#3941). **The returned error is
+  load-bearing (#4433):** a render/write/`swanctl --load-all` failure leaves
+  the previously-loaded strongSwan config (the OLD tunnels) active, so the
+  commit path (`daemon_apply.go` step 6) MUST surface this error rather than
+  swallow it at WARN — otherwise a new config is reported committed while the
+  enforced IPsec runtime is stale. The daemon joins it into the
+  `applyConfigLocked` tail result alongside networkd / Kea / host-inbound /
+  lo0 (fail-closed on commit); the config stays promoted + peer-synced and the
+  remaining reconcile steps still run, so the operator sees a degraded-state
+  error instead of a false success.
 - `Clear() error` — `manager.go`. Remove the xpf snippet, reload, and
   terminate every previously-applied connection's live SAs (#3941).
 - `SAStatus`, `TerminateAllSAs`, `InitiateConnection`, `GetSAStatus`,

--- a/pkg/ipsec/reload_error_4433_test.go
+++ b/pkg/ipsec/reload_error_4433_test.go
@@ -1,0 +1,39 @@
+package ipsec
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestApplyReloadErrorPropagates documents the Manager-side half of the #4433
+// contract: when `swanctl --load-all` fails, strongSwan leaves the previously
+// loaded config in place (the OLD tunnels stay active), so Manager.Apply MUST
+// return that reload error to its caller. The daemon then joins it into the
+// commit result (see pkg/daemon TestApplyConfigLocked_IPsecApplyErrorFailsCommit)
+// so the operator is not told the new IPsec policy is enforced when it is not.
+func TestApplyReloadErrorPropagates(t *testing.T) {
+	reloadErr := errors.New("charon vici socket refused")
+
+	m := NewWithConfigDir(t.TempDir())
+	// Render + write succeed; only the reload shell-out fails.
+	m.swanctl = func(args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "--load-all" {
+			return []byte("unable to load config"), reloadErr
+		}
+		return nil, nil
+	}
+
+	err := m.Apply(vpnCfg("vpn1"))
+	if err == nil {
+		t.Fatal("Manager.Apply must return the swanctl --load-all failure " +
+			"(got nil — a reload failure was swallowed, leaving stale tunnels " +
+			"active under the new config)")
+	}
+	if !errors.Is(err, reloadErr) {
+		t.Fatalf("Apply error must wrap the underlying reload error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--load-all") {
+		t.Fatalf("Apply error should name the failed swanctl --load-all call: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

Closes #4433 (codex-172 C172-H01, HIGH).

The commit/apply path swallowed the `d.ipsec.Apply()` error at WARN
(`daemon_apply.go` step 6):

```go
if d.ipsec != nil {
    if err := d.ipsec.Apply(ipsec.PrepareConfig(cfg)); err != nil {
        slog.Warn("failed to apply IPsec config", "err", err) // dropped
    }
}
```

A swanctl render, write, or `swanctl --load-all` failure was logged and
then IGNORED. Because `--load-all` leaves the previously-loaded config in
place when it fails, the **OLD tunnels stayed active while a NEW config
was reported committed** — the enforced IPsec runtime silently diverged
from the committed policy (stale security runtime).

## Verify-first

The `ipsec.Manager` side was already correct: `applyConfig()` / `reload()`
return the error up through `Manager.Apply()`. The bug was purely the
daemon swallow — the one apply-subsystem that did not follow the
established fail-closed-on-commit pattern.

## Fix

Capture the error into `ipsecErr` and join it into the
`applyConfigLocked` tail result alongside `networkdErr` / `dhcpServerErr`
/ `hostInboundErr` / `lo0Err` (#1778 / #2987 / #3333 / #3392). This is a
**non-fatal best-effort** error class per `applyErrSkipsPeerSync`, so:

- the config stays promoted + persisted,
- the peer config-sync still runs (no cluster divergence, #4034),
- every remaining reconcile step still executes,
- the operator sees a **degraded-state error** surfaced by
  `commitAndApply` instead of a false success.

The DHCP-lease re-render path (`reapplyIPsecForLeaseChange`) is a
fire-and-forget event handler with no operator-facing commit result and
is intentionally left logging at WARN.

## Tests (RED-on-revert verified)

- `TestApplyConfigLocked_IPsecApplyErrorFailsCommit` (pkg/daemon) drives
  `applyConfigLocked` with the swanctl configDir pointed at an unwritable
  path and asserts the return mentions `IPsec`. Verified RED (returns
  `nil`, error swallowed) on revert — mirrors the sibling
  `TestApplyConfigLocked_NetworkdWriteErrorFailsCommit` injection style.
  The swallow caught every Apply error class (render/write/reload), so a
  deterministic write-leg failure exercises the identical propagation
  path a reload failure would.
- `TestApplyReloadErrorPropagates` (pkg/ipsec) documents the Manager-side
  reload contract via the swanctl seam.

`go test ./pkg/ipsec/... ./pkg/daemon/...` green; `go build ./...`;
gofmt/vet clean. Docs updated (`pkg/ipsec/README.md` Apply entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi