### PR TITLE
config,cluster: cap redundancy-group count/id to heartbeat wire width (#4434)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -38167,3 +38167,44 @@ top.
 - **File(s)**: pkg/ipmon/ipmon.go, pkg/ipmon/ipmon_test.go, pkg/ipmon/README.md,
   pkg/api/metrics.go, pkg/api/metrics_descriptors.go, pkg/api/metrics_system.go,
   pkg/api/server.go, pkg/daemon/daemon_run.go, docs/multi-wan.md, _Log.md
+
+## 2026-07-06 — #4434 HA heartbeat redundancy-group wire-width cap (codex-172 C172-H02)
+
+- **Timestamp**: 2026-07-06
+- **Action**: Cap chassis-cluster redundancy-group cardinality and id to the
+  single-byte HA heartbeat wire fields; add a defensive marshaler cap.
+  - **Root cause (verified on origin/master)**: the heartbeat group-count field
+    is `buf[8] = uint8(len(pkt.Groups))` (heartbeat.go marshalHeartbeatBody) and
+    each per-group id is `HeartbeatGroup.GroupID uint8`, populated via
+    `uint8(rg.GroupID)` (heartbeat_manager.go buildHeartbeat). The chassis
+    schema does NOT validate the `redundancy-group <id>` instance slot
+    (schema_chassis.go documents it as an unvalidated identity token) and
+    `compileChassis` parses the id with `strconv.Atoi` under no bound. So 256+
+    RGs advertised a count byte of 0 while 256 records were still written (wire
+    desync), a GroupID >255 truncated and collided, and ~293 RGs indexed past
+    the fixed 1472-byte frame and panicked the marshaler. No pre-existing cap
+    existed anywhere — real uncapped wire-safety bug, DRIVEN.
+  - **Fix (commit gate)**: new `validateChassisClusterStrict` in
+    `pkg/config/compiler_validate_strict_chassis.go` hard-rejects at
+    commit / commit-check when `len(RedundancyGroups) > 255` or any
+    `RedundancyGroup.ID` is outside `0..255`, with wire-width-explaining
+    messages. Dispatched from `compileExpanded` (compiler.go) right after
+    `validateFlowAgingStrict`, following the established lenient-downgrade
+    doctrine: strict on commit, warn on the tolerant Load / peer-sync paths
+    (new `lenientChassisRG` opt, set in `CompileConfigLenient` and
+    `CompileConfigForNodeLenient`) so an already-persisted / peer-synced
+    config still boots (#1960 no-brick).
+  - **Fix (marshaler guard)**: `marshalHeartbeatBody` now bounds the group
+    section to `maxHeartbeatGroups = 255`, keeping the count byte consistent
+    with the records written and guaranteeing no index-out-of-range panic even
+    if an over-size config slips past the gate (lenient path). One-shot
+    `slog.Warn` via `sync.Once` so the per-send hot path never floods journald.
+  - **RED-on-revert**: neutralizing the gate → both config subtests accept the
+    bad config (nil error); neutralizing the marshaler cap → 400-group marshal
+    panics `index out of range [1472] with length 1472` and the 256-group count
+    byte wraps to 0. Restored; full `pkg/config` + `pkg/cluster` suites green,
+    `go build ./...`, gofmt + vet clean on touched files.
+- **File(s)**: pkg/config/compiler_validate_strict_chassis.go,
+  pkg/config/compiler_validate_strict_chassis_4434_test.go,
+  pkg/config/compiler.go, pkg/cluster/heartbeat.go,
+  pkg/cluster/heartbeat_rg_cap_4434_test.go, docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1565,7 +1565,16 @@ reserved for whole-dataplane selection where a rewrite shim
   NOT typed, with reasons in the `schema_chassis.go` comments: the
   `redundancy-group <id>` / RG-scoped `node <id>` instance-name slots
   (the walker's compiler-faithful contract consumes identity tokens
-  without validation — typing them needs a new walker feature),
+  without validation — typing them needs a new walker feature; note
+  #4434 added a *semantic* commit-time cap on redundancy-group
+  cardinality and id — `validateChassisClusterStrict` in
+  `compiler_validate_strict.go`'s sibling
+  `compiler_validate_strict_chassis.go` — because the HA heartbeat wire
+  encodes both the group COUNT and each GroupID as a single byte
+  (`pkg/cluster/heartbeat.go`): >255 groups wrap the count byte to 0 and
+  desync the wire, an id >255 truncates and collides. That gate runs on
+  the compiled `*Config`, NOT through the schema walker, so it does not
+  change the identity-token typing decision above),
   `interface-monitor <if> weight <n>` (tokens pack inline into a
   `children==nil` leaf; typing the weight needs a children map, which
   would flip SetPath grouping), `control-ports` (not compiled), and the

--- a/pkg/cluster/heartbeat.go
+++ b/pkg/cluster/heartbeat.go
@@ -154,7 +154,27 @@ const heartbeatHeaderSize = 9
 // heartbeatGroupSize is GroupID(1) + Priority(2) + Weight(1) + State(1).
 const heartbeatGroupSize = 5
 
+// maxHeartbeatGroups is the largest number of redundancy-group entries the
+// heartbeat wire format can carry. The group-count field (buf[8]) and every
+// per-group id byte are uint8, so a 256th group would overflow the count to 0
+// and desync it from the records still written; and the frame is a fixed
+// maxHeartbeatSize buffer written as 9 + N*5 bytes, so ~293 groups index past
+// it and panic. 255 is the binding uint8 count limit and also fits the buffer
+// (9 + 255*5 = 1284 <= maxHeartbeatSize). The commit-time gate
+// config.validateChassisClusterStrict rejects any config above this; the
+// marshaler caps here as a defensive backstop so it stays panic-safe and the
+// count byte always matches the body even on a leniently-loaded / peer-synced
+// config (#4434).
+const maxHeartbeatGroups = 255
+
 const maxHeartbeatSoftwareVersionSize = 255
+
+// oversizeHeartbeatGroupsWarn logs the defensive group-count truncation in
+// marshalHeartbeatBody at most once per process. Once
+// config.validateChassisClusterStrict gates commits this path should never
+// fire, but the heartbeat sender runs every heartbeat-interval, so an
+// unguarded per-send log would flood journald (#4434).
+var oversizeHeartbeatGroupsWarn sync.Once
 
 func normalizeHAProtocolVersion(version uint16) uint16 {
 	if version == 0 {
@@ -189,10 +209,26 @@ func marshalHeartbeatBody(pkt *HeartbeatPacket, tailReserve int) []byte {
 	buf[4] = heartbeatVersion
 	buf[5] = pkt.NodeID
 	binary.LittleEndian.PutUint16(buf[6:8], pkt.ClusterID)
-	buf[8] = uint8(len(pkt.Groups))
+	// #4434: bound the group section to the heartbeat wire limit. The count
+	// byte and each per-group id byte are uint8 and the frame is a fixed
+	// buffer, so an over-size redundancy-group set would overflow the count
+	// (256 -> 0, desyncing it from the records actually written) or index
+	// past the buffer and panic. The commit gate rejects such a config; this
+	// defensive cap keeps a leniently-loaded / peer-synced config panic-safe
+	// and the count byte consistent with the body.
+	groups := pkt.Groups
+	if len(groups) > maxHeartbeatGroups {
+		oversizeHeartbeatGroupsWarn.Do(func() {
+			slog.Warn("cluster: redundancy-group count exceeds heartbeat wire "+
+				"limit; advertising only the first groups",
+				"groups", len(pkt.Groups), "wire_limit", maxHeartbeatGroups)
+		})
+		groups = groups[:maxHeartbeatGroups]
+	}
+	buf[8] = uint8(len(groups))
 
 	off := heartbeatHeaderSize
-	for _, g := range pkt.Groups {
+	for _, g := range groups {
 		buf[off] = g.GroupID
 		binary.LittleEndian.PutUint16(buf[off+1:off+3], g.Priority)
 		buf[off+3] = g.Weight

--- a/pkg/cluster/heartbeat_rg_cap_4434_test.go
+++ b/pkg/cluster/heartbeat_rg_cap_4434_test.go
@@ -1,0 +1,80 @@
+package cluster
+
+import "testing"
+
+// #4434 (codex-172 C172-H02): the heartbeat group-count byte and each
+// per-group id byte are uint8, and the frame is a fixed maxHeartbeatSize
+// buffer written as heartbeatHeaderSize + N*heartbeatGroupSize. Before the
+// defensive cap, marshaling 256 groups overflowed the count byte to 0 (wire
+// desync against the records written) and ~293 groups indexed past the buffer
+// and panicked. marshalHeartbeatBody now bounds the group section to
+// maxHeartbeatGroups.
+//
+// FAIL-ON-REVERT: drop the maxHeartbeatGroups cap in marshalHeartbeatBody and
+// TestMarshalHeartbeatDoesNotPanicOnOversizeGroups panics (index out of range)
+// and TestMarshalHeartbeatCountMatchesBodyOnOversizeGroups sees a count byte
+// of 0 that disagrees with the body.
+
+func oversizeGroups(n int) []HeartbeatGroup {
+	g := make([]HeartbeatGroup, n)
+	for i := range g {
+		g[i] = HeartbeatGroup{GroupID: uint8(i), Priority: 100, Weight: 1, State: 1}
+	}
+	return g
+}
+
+func TestMarshalHeartbeatDoesNotPanicOnOversizeGroups(t *testing.T) {
+	// 400 groups would index past the 1472-byte buffer without the cap.
+	pkt := &HeartbeatPacket{NodeID: 0, ClusterID: 1, Groups: oversizeGroups(400)}
+	data := MarshalHeartbeat(pkt) // must not panic
+	if len(data) == 0 {
+		t.Fatalf("MarshalHeartbeat returned empty output")
+	}
+	if data[8] != maxHeartbeatGroups {
+		t.Fatalf("group-count byte = %d, want capped %d", data[8], maxHeartbeatGroups)
+	}
+	// Re-parse: the group section must be self-consistent (count == records),
+	// so the peer decodes exactly maxHeartbeatGroups groups.
+	got, err := UnmarshalHeartbeat(data)
+	if err != nil {
+		t.Fatalf("UnmarshalHeartbeat of a capped frame failed: %v", err)
+	}
+	if len(got.Groups) != maxHeartbeatGroups {
+		t.Fatalf("decoded %d groups, want %d", len(got.Groups), maxHeartbeatGroups)
+	}
+}
+
+func TestMarshalHeartbeatCountMatchesBodyOnOversizeGroups(t *testing.T) {
+	// Exactly 256 groups is the count-byte overflow boundary: uint8(256) == 0.
+	pkt := &HeartbeatPacket{NodeID: 0, ClusterID: 1, Groups: oversizeGroups(256)}
+	data := MarshalHeartbeat(pkt)
+	if data[8] == 0 {
+		t.Fatalf("group-count byte wrapped to 0 on 256 groups (wire desync)")
+	}
+	if data[8] != maxHeartbeatGroups {
+		t.Fatalf("group-count byte = %d, want capped %d", data[8], maxHeartbeatGroups)
+	}
+}
+
+func TestMarshalHeartbeatInRangeGroupsUnchanged(t *testing.T) {
+	// A normal group set (well under the wire limit) is encoded verbatim.
+	pkt := &HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 42,
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 200, Weight: 255, State: 1},
+			{GroupID: 1, Priority: 100, Weight: 200, State: 2},
+		},
+	}
+	data := MarshalHeartbeat(pkt)
+	if data[8] != 2 {
+		t.Fatalf("group-count byte = %d, want 2", data[8])
+	}
+	got, err := UnmarshalHeartbeat(data)
+	if err != nil {
+		t.Fatalf("UnmarshalHeartbeat failed: %v", err)
+	}
+	if len(got.Groups) != 2 || got.Groups[1].GroupID != 1 {
+		t.Fatalf("round-trip mismatch: %+v", got.Groups)
+	}
+}

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1239,6 +1239,19 @@ type compileOpts struct {
 	// anyway (#3440 H1), so a leniently-loaded bad value is inert. Same
 	// doctrine as lenientScreenUnknown.
 	lenientFlowAging bool
+	// lenientChassisRG (#4434) downgrades the chassis-cluster heartbeat
+	// wire-width gate (validateChassisClusterStrict) from a hard compile
+	// error to a cfg.Warnings entry. The strict commit / commit-check path
+	// hard-rejects a redundancy-group cardinality or id that exceeds the
+	// single-byte heartbeat count / GroupID fields (256 RGs advertise as a
+	// count of 0 and desync the wire; an id > 255 truncates and collides).
+	// The tolerant load / peer-sync paths downgrade to a warning so an
+	// already-persisted or peer-synced config still BOOTS (#1960 no-brick);
+	// the heartbeat marshaler independently caps the group section to the
+	// wire limit (pkg/cluster/heartbeat.go maxHeartbeatGroups), so a
+	// leniently-loaded over-size config is bounded on the wire, not a panic.
+	// Same doctrine as lenientFlowAging.
+	lenientChassisRG bool
 	// lenientReservedZoneNames (#3055) downgrades the reserved zone-name
 	// definition gate (validateReservedZoneNamesStrict) from a hard compile
 	// error to a cfg.Warnings entry. The strict commit / commit-check path
@@ -1577,6 +1590,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientScreenUnknown:                   true,
 		lenientTrailingTokens:                  true,
 		lenientFlowAging:                       true,
+		lenientChassisRG:                       true,
 		lenientReservedZoneNames:               true,
 		lenientBackupRouterDst:                 true,
 		lenientSecureTunnelBindIface:           true,
@@ -1821,6 +1835,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientScreenUnknown:                   true,
 		lenientTrailingTokens:                  true,
 		lenientFlowAging:                       true,
+		lenientChassisRG:                       true,
 		lenientReservedZoneNames:               true,
 		lenientBackupRouterDst:                 true,
 		lenientSecureTunnelBindIface:           true,
@@ -2894,6 +2909,25 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientFlowAging {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("flow aging (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #4434 chassis-cluster heartbeat wire-width gate. Strict on commit /
+	// commit-check (hard-reject a redundancy-group cardinality or id that
+	// exceeds the single-byte heartbeat count / GroupID fields — 256 RGs
+	// advertise as a count of 0 and desync the wire, an id > 255 truncates
+	// and collides with another group). Lenient on load / peer-sync (warn so
+	// an already-persisted or peer-synced config still boots — #1960
+	// no-brick; the heartbeat marshaler independently caps the group section
+	// to the wire limit, marshalHeartbeatBody, so a leniently-loaded
+	// over-size config is bounded, not a panic). Runs on the fully-compiled
+	// *Config (RedundancyGroups populated by compileChassis).
+	if err := validateChassisClusterStrict(cfg); err != nil {
+		if opts.lenientChassisRG {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("chassis cluster redundancy-group (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_validate_strict_chassis.go
+++ b/pkg/config/compiler_validate_strict_chassis.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+)
+
+// MaxHeartbeatRedundancyGroups is the largest number of chassis-cluster
+// redundancy groups the HA heartbeat wire format can advertise. The
+// heartbeat group-count field is a single byte
+// (pkg/cluster/heartbeat.go marshalHeartbeatBody writes
+// buf[8] = uint8(len(pkt.Groups))), so a 256th group would overflow the
+// count to 0 while 256 records are still written — the count byte and the
+// body desync and the peer mis-parses the group section. (The marshaler
+// also indexes a fixed maxHeartbeatSize buffer, so ~293 groups panic on
+// write.) 255 is the binding uint8 count limit.
+const MaxHeartbeatRedundancyGroups = 255
+
+// MaxHeartbeatRedundancyGroupID is the largest redundancy-group id the HA
+// heartbeat wire format can carry. The per-group GroupID field is a single
+// byte (pkg/cluster/heartbeat.go HeartbeatGroup.GroupID is uint8, populated
+// via uint8(rg.GroupID) in heartbeat_manager.go buildHeartbeat), so an id
+// above 255 truncates on the wire and two distinct redundancy groups would
+// then collide on the same GroupID byte and corrupt peer election.
+const MaxHeartbeatRedundancyGroupID = 255
+
+// validateChassisClusterStrict hard-rejects, at commit / commit-check, a
+// chassis-cluster config whose redundancy-group cardinality or ids exceed
+// what the HA heartbeat wire format can encode (#4434, codex-172 C172-H02).
+//
+// The heartbeat count byte and per-group id byte are both uint8. There is
+// no schema-level value validation on the `redundancy-group <id>` instance
+// slot (schema_chassis.go documents it as an unvalidated identity token),
+// and compileChassis parses the id with strconv.Atoi under no bound, so an
+// operator could commit 256+ groups (count byte wraps to 0 — the peer sees
+// "zero groups" while the body still carries them) or a group id > 255 (the
+// id byte truncates and aliases another group). Both silently corrupt
+// election on the wire.
+//
+// On the tolerant load / peer-sync paths the compileExpanded call site
+// downgrades this to a warning (opts.lenientChassisRG) so an already-
+// persisted or peer-synced config still boots (#1960 no-brick); the
+// heartbeat marshaler independently caps the group section to the wire
+// limit (pkg/cluster/heartbeat.go marshalHeartbeatBody, maxHeartbeatGroups),
+// so a leniently-loaded over-size config is bounded on the wire, not a
+// panic.
+func validateChassisClusterStrict(cfg *Config) error {
+	if cfg == nil || cfg.Chassis.Cluster == nil {
+		return nil
+	}
+	rgs := cfg.Chassis.Cluster.RedundancyGroups
+
+	if len(rgs) > MaxHeartbeatRedundancyGroups {
+		return fmt.Errorf("chassis cluster: %d redundancy-groups exceeds the "+
+			"heartbeat wire limit of %d (the heartbeat group-count field is one "+
+			"byte, so %d groups would advertise as a count of 0 and desync the "+
+			"peer's group parse) — reduce the number of redundancy-groups",
+			len(rgs), MaxHeartbeatRedundancyGroups, len(rgs))
+	}
+
+	// RedundancyGroups is built from a map-ordered AST walk; sort the ids so
+	// the first-error commit-check message is deterministic across runs.
+	ids := make([]int, 0, len(rgs))
+	for _, rg := range rgs {
+		if rg == nil { // #3494: tolerant/HA-sync path may carry a nil entry.
+			continue
+		}
+		ids = append(ids, rg.ID)
+	}
+	sort.Ints(ids)
+	for _, id := range ids {
+		if id < 0 || id > MaxHeartbeatRedundancyGroupID {
+			return fmt.Errorf("chassis cluster: redundancy-group id %d is out of "+
+				"range 0..%d (the heartbeat per-group id field is one byte; an id "+
+				"above %d truncates on the wire and collides with another "+
+				"redundancy-group) — renumber the redundancy-group",
+				id, MaxHeartbeatRedundancyGroupID, MaxHeartbeatRedundancyGroupID)
+		}
+	}
+	return nil
+}

--- a/pkg/config/compiler_validate_strict_chassis_4434_test.go
+++ b/pkg/config/compiler_validate_strict_chassis_4434_test.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// #4434 (codex-172 C172-H02): the HA heartbeat group-count field and each
+// per-group id byte are uint8 (pkg/cluster/heartbeat.go), and neither the
+// chassis schema nor compileChassis bounded the redundancy-group cardinality
+// or id. So a config with 256+ redundancy-groups advertised a count byte of 0
+// (wire desync against the 256 records still written) and a redundancy-group
+// id > 255 truncated on the wire and collided with another group.
+// validateChassisClusterStrict makes both an operator-visible commit error.
+//
+// FAIL-ON-REVERT: remove the validateChassisClusterStrict dispatch in
+// compileExpanded (compiler.go) or the range checks in the validator and the
+// over-size / over-id subtests go green on the BAD config — exactly the
+// wire-desync regression this test exists to catch. The tolerant-path and
+// in-range subtests pin that the gate does not over-reject.
+
+// rgSetLines returns the flat-set lines that define n redundancy groups with
+// sequential ids 0..n-1, each with a well-formed node priority so the compiler
+// materializes a RedundancyGroup instance.
+func rgSetLines(n int) []string {
+	lines := make([]string, 0, n+1)
+	lines = append(lines, "set chassis cluster cluster-id 1")
+	for i := 0; i < n; i++ {
+		lines = append(lines,
+			fmt.Sprintf("set chassis cluster redundancy-group %d node 0 priority 100", i))
+	}
+	return lines
+}
+
+func TestChassisRedundancyGroupCardinalityFailsCommit(t *testing.T) {
+	// 256 groups (ids 0..255) — the count byte would wrap uint8(256) == 0.
+	tree := buildTree(t, rgSetLines(MaxHeartbeatRedundancyGroups+1))
+
+	cfg, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("expected commit to reject %d redundancy-groups (heartbeat "+
+			"count byte is uint8), got nil error", MaxHeartbeatRedundancyGroups+1)
+	}
+	if !strings.Contains(err.Error(), "redundancy-groups exceeds") {
+		t.Fatalf("error %q does not describe the redundancy-group cardinality cap", err.Error())
+	}
+	_ = cfg
+
+	// Tolerant path (load / peer-sync) must NOT brick — it downgrades to a
+	// warning so an already-persisted config still boots.
+	lcfg, lerr := CompileConfigLenient(tree)
+	if lerr != nil {
+		t.Fatalf("lenient compile must not reject an over-size RG set (no-brick), got %v", lerr)
+	}
+	if !warningsContain(lcfg.Warnings, "chassis cluster redundancy-group") {
+		t.Fatalf("lenient compile should have warned about the RG cardinality; warnings=%v", lcfg.Warnings)
+	}
+}
+
+func TestChassisRedundancyGroupIDFailsCommit(t *testing.T) {
+	// A single group with an id > 255 truncates on the wire.
+	tree := buildTree(t, []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster redundancy-group 300 node 0 priority 100",
+	})
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("expected commit to reject redundancy-group id 300 (heartbeat " +
+			"id byte is uint8), got nil error")
+	}
+	if !strings.Contains(err.Error(), "id 300") || !strings.Contains(err.Error(), "out of") {
+		t.Fatalf("error %q does not name the out-of-range redundancy-group id", err.Error())
+	}
+}
+
+func TestChassisRedundancyGroupInRangeCommits(t *testing.T) {
+	// The boundary: 255 groups (ids 0..254) and an id of exactly 255 both fit
+	// the uint8 wire fields and must commit cleanly.
+	tree := buildTree(t, rgSetLines(MaxHeartbeatRedundancyGroups))
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("commit rejected %d in-range redundancy-groups: %v", MaxHeartbeatRedundancyGroups, err)
+	}
+
+	boundary := buildTree(t, []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster redundancy-group 0 node 0 priority 200",
+		fmt.Sprintf("set chassis cluster redundancy-group %d node 1 priority 100", MaxHeartbeatRedundancyGroupID),
+	})
+	if _, err := CompileConfig(boundary); err != nil {
+		t.Fatalf("commit rejected a boundary redundancy-group id %d: %v", MaxHeartbeatRedundancyGroupID, err)
+	}
+
+	// A cluster with no redundancy-group stanza at all is unaffected.
+	none := buildTree(t, []string{"set chassis cluster cluster-id 1"})
+	if _, err := CompileConfig(none); err != nil {
+		t.Fatalf("commit rejected a cluster with no redundancy-groups: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #4434 (codex-172 C172-H02, HIGH).

## Verify-first

Confirmed on `origin/master` that the bug is real and uncapped:

- `pkg/cluster/heartbeat.go` `marshalHeartbeatBody`: `buf[8] = uint8(len(pkt.Groups))` — the group-count field is one byte.
- `pkg/cluster/heartbeat_manager.go` `buildHeartbeat`: `GroupID: uint8(rg.GroupID)` — each per-group id is one byte (`HeartbeatGroup.GroupID uint8`).
- `pkg/config/schema_chassis.go`: the `redundancy-group <id>` slot is an **unvalidated identity token** (documented in-file), and `compileChassis` (`compiler_system.go`) parses the id with `strconv.Atoi` under **no bound**. No strict validator for chassis-cluster cardinality/id existed anywhere.

So a valid-looking config could desync election on the wire: 256 RGs → count byte `uint8(256) == 0` while 256 records are still written; a GroupID > 255 truncates and collides; ~293 RGs index past the fixed 1472-byte frame and panic the marshaler.

## Fix

Minimal safe fix (a strict commit cap, not a wire-widening + protocol-version bump):

1. **Commit gate** — new `validateChassisClusterStrict` (`pkg/config/compiler_validate_strict_chassis.go`) hard-rejects `len(RedundancyGroups) > 255` or any id outside `0..255` at commit / commit-check, with wire-width-explaining messages. Dispatched from `compileExpanded` next to the other strict gates, with the standard lenient downgrade (new `lenientChassisRG`) on the tolerant Load / peer-sync paths so an already-persisted / peer-synced config still boots (#1960 no-brick).
2. **Marshaler guard** — `marshalHeartbeatBody` bounds the group section to `maxHeartbeatGroups = 255`, writes the count byte from the capped length (no desync), and warns once via `sync.Once` (no per-send flood). Guarantees the marshaler is panic-safe and wire-consistent even for a config that reached the wire via the lenient path.

## Tests (RED on revert)

- `pkg/config`: 256-RG set and id-300 RG rejected at commit; lenient path downgrades to a warning; 255 RGs / id 255 / no-RG commit cleanly.
- `pkg/cluster`: marshaler does not panic on 400 groups; 256-group count byte does not wrap to 0; normal set round-trips unchanged.
- Confirmed RED on revert: gate disabled → bad config accepted; cap removed → marshaler panics `index out of range [1472] with length 1472`.
- Full `pkg/config` + `pkg/cluster` suites green; `go build ./...`; gofmt + vet clean.

GO-only (`pkg/config` + `pkg/cluster`); no Rust/cargo. Docs: `docs/config-schema.md` note added; heartbeat wire width documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi