### PR TITLE
Refs #4423 (routing M3/L2/L3/L6)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -38167,3 +38167,57 @@ top.
 - **File(s)**: pkg/ipmon/ipmon.go, pkg/ipmon/ipmon_test.go, pkg/ipmon/README.md,
   pkg/api/metrics.go, pkg/api/metrics_descriptors.go, pkg/api/metrics_system.go,
   pkg/api/server.go, pkg/daemon/daemon_run.go, docs/multi-wan.md, _Log.md
+
+- **Timestamp**: 2026-07-06
+- **Action**: #4423 routing sub-items (M3 / L2 / L3 / L6) — verify-first triage
+  (final #4423 subsystem sweep). PR: `fix/4423-routing`. GO-only, no cargo. The
+  four "routing" findings turned out to live in the userspace forwarding
+  pipeline (`pkg/dataplane/userspace/routes.go` Go builder + the Rust FIB
+  `userspace-dp/src/afxdp/forwarding_build/fib.rs` / `forwarding/mod.rs`), NOT
+  in `pkg/routing`. Dispositions:
+  - **M3 (static next-hop gateway inference is global, not table-scoped) —
+    GENUINE, DEFERRED to a Rust/cargo slice.** `resolve_route_next_hops_v4/_v6`
+    infer a bare-gateway static route's egress ifindex via
+    `infer_connected_route_target_v4/_v6`, which scans `state.connected_v4`
+    GLOBALLY and never filters by the route's own table — although every
+    `ConnectedRouteV4` already carries its owning `table` (added by #2388 for
+    the lookup-site filter). The wrong ifindex is baked into
+    `RouteEntryV4.next_hops` at build time and used verbatim at lookup
+    (`forwarding/mod.rs` static arm), so the #2388 lookup-time filter does NOT
+    correct it. In a multi-VRF setup with overlapping gateway subnets a static
+    route in instance A can egress on instance B's interface. Two `fib.rs` doc
+    comments contradict each other (`resolve_route_next_hops_v4` claims
+    "#2388 table-scoped"; `infer_connected_route_target_v4` says "intentionally
+    NOT table-scoped" — the code matches the latter). Turnkey fix recorded in
+    `docs/rib-group-route-leaking.md`: thread the canonical table into the
+    inference and filter `entry.table == table`, mirroring the lookup site; fix
+    the stale doc. It is a `userspace-dp` change requiring the serial cargo
+    build + `make test-failover`, so it is deferred out of this Go-only slice.
+  - **L2 (`canonical_route_table` silently rewrites cross-family names) —
+    NOT-A-BUG.** The helper only swaps the family suffix (`.inet.0` ↔
+    `.inet6.0`) and always PRESERVES the VRF prefix, so it can only normalize a
+    name into the same instance's correct family-specific table, never a wrong
+    VRF. Go already emits correct-family install tables
+    (`normalizeRouteSnapshotFamily`) and `next-table` targets are reduced to a
+    bare instance name (`parseNextTableInstance`) with no family to drift.
+    Locked by `TestNormalizeRouteSnapshotFamily_VRFPreserving_4423`.
+  - **L3 (link-local next-hop needs `%iface`) — NOT-A-BUG.** xpf is
+    Junos-syntax: `next-hop fe80::1 interface reth0.50` (internally encoded as
+    the `ip@interface` FIB spec). `%iface` (RFC 4007 zone-id) has no producer or
+    consumer in the pipeline; `ValidateStaticNextHop` correctly rejects it at
+    commit. Locked by `TestStaticNextHop_ZoneIDPercentRejected_4423`.
+  - **L6 (overlay cannot express an ECMP preferred route) — DEFER (feature).**
+    `applyRouteOverlay` deliberately does whole-entry replacement with a single
+    next-hop — the correct #1827 WAN-failover semantics, pinned by the existing
+    `TestRouteOverlayWholeEntryReplacement`. ECMP preferred routes would be a new
+    feature (RouteOverlayEntry.NextHop → list + config schema + ipmon
+    winner-resolution); recorded plan in `docs/rib-group-route-leaking.md`.
+  - Validation: `go test ./pkg/config/ ./pkg/dataplane/userspace/` green
+    (new lock-in tests + surrounding suites); `go build ./...`; gofmt/vet clean
+    on touched files. No Go code fix was warranted (M3 is Rust/deferred; L2/L3
+    not-a-bug; L6 deferred feature) — this slice delivers the verify-first
+    dispositions, two lock-in tests encoding the L2/L3 disproofs, and the
+    turnkey M3 plan.
+- **File(s)**: pkg/config/schema_validate_route_2448_test.go,
+  pkg/dataplane/userspace/routes_family_normalize_4423_test.go,
+  docs/rib-group-route-leaking.md, _Log.md

--- a/docs/rib-group-route-leaking.md
+++ b/docs/rib-group-route-leaking.md
@@ -102,3 +102,97 @@ prefixes.
 - **Dynamically learned (DHCP) source addresses** — per-prefix cannot enumerate
   them at commit; warned now, would need Phase-2 route-copy or a runtime
   address-watch.
+
+## #4423 routing audit — FIB table-scoping dispositions
+
+The codex routing audit (tracked in issue #4423) raised four static-route /
+FIB-table findings against the userspace forwarding pipeline. Verify-first
+triage against `origin/master` classified them as follows. The relevant code
+is the Go route-snapshot builder (`pkg/dataplane/userspace/routes.go`) and the
+Rust FIB (`userspace-dp/src/afxdp/forwarding_build/fib.rs`,
+`userspace-dp/src/afxdp/forwarding/mod.rs`) — **not** `pkg/routing` (which owns
+netlink VRF/tunnel/ip-rule reconciliation, not FIB next-hop resolution).
+
+### M3 — static next-hop gateway inference is global, not table-scoped — GENUINE (deferred to a Rust slice)
+
+`resolve_route_next_hops_v4` / `resolve_route_next_hops_v6` resolve a static
+route's egress ifindex at FIB-build time. When a next-hop carries an explicit
+`@interface`, the ifindex comes from that interface; otherwise it is **inferred**
+from the connected prefix that contains the gateway IP via
+`infer_connected_route_target_v4`/`_v6`. That inference does a **global** scan of
+`state.connected_v4` and returns the first `prefix.contains(gateway)` match —
+**it never filters by the route's own table**, even though every `ConnectedRouteV4`
+already carries its owning `table` (added by #2388 exactly so the *lookup* site
+can filter — `forwarding/mod.rs` `entry.table == table`).
+
+Consequence: in a multi-VRF deployment with overlapping gateway subnets across
+routing-instances (a normal reason to use VRFs), a bare-gateway static route in
+instance A can bind the egress interface of instance B's overlapping connected
+prefix. The wrong ifindex is baked into `RouteEntryV4.next_hops` at build time
+and consumed verbatim at lookup (`forwarding/mod.rs`, the `ResolvedRouteV4::Static`
+arm uses `nh.ifindex` directly), so the #2388 lookup-time connected filter does
+**not** correct it — that filter only re-scopes connected-route *destination*
+matches, not a static route's pre-resolved next-hops.
+
+Two doc comments in `fib.rs` currently **contradict** each other on this point:
+`resolve_route_next_hops_v4`'s doc claims the inference is "scoped to the route's
+own table (#2388)", while `infer_connected_route_target_v4`'s own doc says it is
+"intentionally NOT table-scoped". The code matches the latter; the former is
+stale/aspirational and should be corrected alongside the fix.
+
+**Turnkey fix (Rust, needs `cargo` — out of the Go-only slice scope):** thread
+the route's canonical install table (already computed as
+`canonical_route_table(&route.table, is_ipv6)` at the `populate_routes` call
+site) into `resolve_route_next_hops_v4`/`_v6` → `resolve_next_hop_target_v4`/`_v6`
+→ `infer_connected_route_target_v4`/`_v6`, and filter the connected scan on
+`entry.table == table`, mirroring the existing #2388 lookup-site predicate. Add a
+Rust unit test with two routing-instances that own overlapping connected
+prefixes and assert a bare-gateway static route in instance A resolves to A's
+ifindex (RED on the current global scan). Fix the two contradictory doc comments.
+This is a dataplane (`userspace-dp`) change and must go through the serial cargo
+build + `make test-failover` gate, so it is deferred out of this Go-only triage.
+
+### L2 — `canonical_route_table` "silently rewrites cross-family table names" — NOT-A-BUG
+
+The premise ("rewritten into the wrong table → operator confusion") does not
+hold. `canonical_route_table` (`forwarding/mod.rs`) only swaps the **family half**
+of the table suffix (`.inet.0` ↔ `.inet6.0`, or bare `inet.0` ↔ `inet6.0`) and
+**always preserves the VRF prefix** — it can only ever normalize a name into the
+same routing-instance's correct family-specific table, never a different VRF.
+The Go side already emits correct-family install-table names
+(`normalizeRouteSnapshotFamily`, driven by the destination family and the
+static-list bucket), and static `next-table` targets are reduced to a bare
+routing-instance name (`parseNextTableInstance`, `pkg/config/compiler_routing.go`)
+that carries no family suffix to drift. The rewrite is a VRF-preserving
+normalization safety net, not a silent corruption. Locked by
+`TestNormalizeRouteSnapshotFamily_VRFPreserving_4423`
+(`pkg/dataplane/userspace/routes_family_normalize_4423_test.go`).
+
+### L3 — IPv6 link-local next-hop needs `%iface`, not `addr@interface` — NOT-A-BUG
+
+xpf is a Junos-syntax firewall. The operator writes a link-local gateway as
+`next-hop fe80::1 interface reth0.50` (separate `interface` clause); the compiler
+encodes it for the Rust FIB as the internal `ip@interface` spec (`routes.go`
+`buildRouteSnapshots` → `fib.rs` `split_once('@')`). The `%iface` RFC 4007
+zone-id form is a Linux getaddrinfo()/`ip route` convention with **no producer or
+consumer** anywhere in the xpf pipeline; `ValidateStaticNextHop`
+(`pkg/config/schema_validators.go`) correctly rejects it at commit (`net.ParseIP`
+does not accept a zone-id and `%` is not an allowed interface-name character).
+Accepting `%iface` would introduce a second, silently-degrading link-local
+syntax for no gain. Locked by `TestStaticNextHop_ZoneIDPercentRejected_4423`.
+
+### L6 — the #1827 ip-monitoring overlay cannot express an ECMP preferred route — DEFER (feature, not a bug)
+
+`applyRouteOverlay` (`routes.go`) intentionally **replaces the entire
+(table, family, prefix) entry set** with the single overlay next-hop — a
+whole-entry replacement, documented in the function contract and pinned by
+`TestRouteOverlayWholeEntryReplacement` ("the ECMP next-hop set is gone, not
+half-merged"). This is the correct #1827 WAN-failover semantics: when a probe
+selects a preferred path, steer *all* traffic for that prefix to the single
+preferred gateway; on withdrawal the original (possibly ECMP) config route
+returns. A multi-next-hop preferred route is a **new feature**, not a bug fix:
+it would require `config.RouteOverlayEntry.NextHop` → `NextHops []string`, a
+config-schema change to let `services ip-monitoring policy … then preferred-route
+… next-hop` take a list, and matching winner-resolution in `pkg/ipmon`. Deferred
+with this plan; the Rust FIB already carries multiple next-hops per route
+(`RouteEntryV4.next_hops`), so only the Go overlay/config surface needs the work.

--- a/pkg/config/schema_validate_route_2448_test.go
+++ b/pkg/config/schema_validate_route_2448_test.go
@@ -151,6 +151,40 @@ func TestSchema2448_ValidateStaticNextHop_AtSpec(t *testing.T) {
 	}
 }
 
+// TestStaticNextHop_ZoneIDPercentRejected_4423 pins the #4423 routing-audit
+// L3 disposition (NOT-A-BUG): the RFC 4007 "scoped address" zone-id form
+// `fe80::1%iface` — a Linux getaddrinfo() / `ip route` convention — is NOT a
+// Junos next-hop spelling and must NOT be accepted. In Junos (and xpf) an
+// IPv6 link-local gateway is written with an explicit egress clause,
+// `next-hop fe80::1 interface reth0.50`, which the compiler encodes for the
+// Rust FIB as the internal `ip@interface` spec (routes.go buildRouteSnapshots
+// → forwarding_build/fib.rs split_once('@')). There is no `%` producer or
+// consumer anywhere in the pipeline, so accepting `%iface` would create a
+// second, silently-degrading link-local syntax (net.ParseIP rejects the
+// zone-id, so the FIB would drop the gateway to ifindex 0). ValidateStaticNextHop
+// (schema_validators.go) already rejects it because `%` is neither part of a
+// parseable IP nor an allowed interface-name character; this test locks that
+// contract so a well-meaning "accept %iface" change cannot regress it.
+func TestStaticNextHop_ZoneIDPercentRejected_4423(t *testing.T) {
+	for _, nh := range []string{
+		"fe80::1%reth0",        // v6 link-local + zone-id (the finding's exact form)
+		"fe80::1%eth0",         // kernel-name zone-id
+		"fe80::1%reth0.50",     // sub-interface zone-id
+		"192.168.1.1%ge-0-0-0", // v4 with a stray '%' — also not a real form
+	} {
+		if err := config.ValidateStaticNextHop(nh, nil); err == nil {
+			t.Fatalf("ValidateStaticNextHop(%q) accepted an RFC-4007 zone-id form; "+
+				"xpf is Junos-syntax and expects `next-hop <ll> interface <if>`, "+
+				"not the Linux %%iface convention", nh)
+		}
+	}
+	// The correct Junos link-local spelling and the internal @iface encoding
+	// stay accepted — the rejection above must not over-reach.
+	if err := config.ValidateStaticNextHop("fe80::1@reth0.50", nil); err != nil {
+		t.Fatalf("Junos-encoded link-local next-hop fe80::1@reth0.50 must be accepted: %v", err)
+	}
+}
+
 func TestSchema2448_NextHop_AcceptsValidForms(t *testing.T) {
 	for _, nh := range []string{
 		"192.168.1.1", // bare IPv4

--- a/pkg/dataplane/userspace/routes_family_normalize_4423_test.go
+++ b/pkg/dataplane/userspace/routes_family_normalize_4423_test.go
@@ -1,0 +1,54 @@
+package userspace
+
+import "testing"
+
+// TestNormalizeRouteSnapshotFamily_VRFPreserving_4423 pins the #4423 routing-
+// audit L2 disposition (NOT-A-BUG). The finding claimed the Go route-snapshot
+// builder's family normalization (and the mirroring Rust helper
+// canonical_route_table) "silently rewrites cross-family table names" into the
+// WRONG table. That premise is false: the normalization only swaps the FAMILY
+// half of the table suffix (.inet.0 <-> .inet6.0) and always PRESERVES the VRF
+// prefix, so a route can only ever be normalized into its own instance's
+// correct family-specific table — never a different routing-instance's table.
+//
+// In practice the drift is unreachable for static routes: buildRouteSnapshots
+// derives the table from which family-specific static list a route was compiled
+// into ("inet.0"/"inet6.0"/"<vrf>.inet.0"/"<vrf>.inet6.0"), so the family is
+// already correct and normalization is a no-op safety net. This test locks the
+// helper's VRF-preserving contract directly so the "rewrite is corruption"
+// premise stays disproved and a future edit cannot turn it into a VRF-crossing
+// rewrite.
+func TestNormalizeRouteSnapshotFamily_VRFPreserving_4423(t *testing.T) {
+	cases := []struct {
+		name        string
+		table       string
+		family      string
+		destination string
+		wantTable   string
+		wantFamily  string
+	}{
+		// A v6 destination whose table name carries a v4 family suffix is
+		// normalized to the v6 half of the SAME table — VRF prefix intact.
+		{"main-v4name-v6dest", "inet.0", "inet", "2001:db8::/32", "inet6.0", "inet6"},
+		{"vrf-v4name-v6dest", "tenant-a.inet.0", "inet", "2001:db8::/48", "tenant-a.inet6.0", "inet6"},
+		// The symmetric v4-destination / v6-table-name case.
+		{"main-v6name-v4dest", "inet6.0", "inet6", "10.0.0.0/8", "inet.0", "inet"},
+		{"vrf-v6name-v4dest", "tenant-b.inet6.0", "inet6", "10.20.0.0/16", "tenant-b.inet.0", "inet"},
+		// Already-correct names are unchanged (the common no-op path).
+		{"main-v4-consistent", "inet.0", "inet", "10.0.0.0/8", "inet.0", "inet"},
+		{"vrf-v6-consistent", "tenant-c.inet6.0", "inet6", "2001:db8:c::/48", "tenant-c.inet6.0", "inet6"},
+		// A multi-label VRF name keeps every label of its prefix.
+		{"dotted-vrf-name", "east.edge.inet.0", "inet", "2001:db8::/32", "east.edge.inet6.0", "inet6"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotTable, gotFamily := normalizeRouteSnapshotFamily(tc.table, tc.family, tc.destination)
+			if gotTable != tc.wantTable {
+				t.Fatalf("table = %q, want %q (VRF prefix must be preserved; only the family suffix may change)", gotTable, tc.wantTable)
+			}
+			if gotFamily != tc.wantFamily {
+				t.Fatalf("family = %q, want %q", gotFamily, tc.wantFamily)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Final #4423 subsystem sweep: the **routing** audit findings. Verify-first
triage against `origin/master`. The four "routing" findings live in the
userspace forwarding pipeline — the Go route-snapshot builder
(`pkg/dataplane/userspace/routes.go`) and the Rust FIB
(`userspace-dp/src/afxdp/forwarding_build/fib.rs`, `forwarding/mod.rs`) —
**not** `pkg/routing`.

## Dispositions

### M3 — static next-hop gateway inference is global, not table-scoped — GENUINE (deferred to a Rust slice)
`resolve_route_next_hops_v4/_v6` infer a bare-gateway static route's egress
ifindex via `infer_connected_route_target_v4/_v6`, which scans
`state.connected_v4` **globally** and never filters by the route's own table —
even though every `ConnectedRouteV4` already carries its owning `table` (added
by #2388 for the lookup-site filter). The wrong ifindex is baked into
`RouteEntryV4.next_hops` at build time and consumed verbatim at lookup
(`forwarding/mod.rs` static arm), so the #2388 lookup-time connected filter does
**not** correct it. In a multi-VRF deployment with overlapping gateway subnets,
a bare-gateway static route in instance A can egress on instance B's interface.

Two `fib.rs` doc comments contradict each other: `resolve_route_next_hops_v4`
claims the inference is "scoped to the route's own table (#2388)", while
`infer_connected_route_target_v4` says it is "intentionally NOT table-scoped".
The code matches the latter; the former is stale.

**Deferred** because the fix is a `userspace-dp` (Rust/cargo) change that must go
through the serial cargo build + `make test-failover` gate — out of this
GO-only slice's scope. Turnkey plan recorded in `docs/rib-group-route-leaking.md`:
thread the canonical install table into the inference and filter
`entry.table == table`, mirroring the existing lookup-site predicate; add a
two-instance overlapping-prefix Rust unit test (RED on the current global scan);
fix the two contradictory doc comments.

### L2 — `canonical_route_table` "silently rewrites cross-family names" — NOT-A-BUG
The helper only swaps the **family half** of the table suffix (`.inet.0` ↔
`.inet6.0`) and **always preserves the VRF prefix**, so it can only normalize a
name into the same instance's correct family-specific table, never a wrong VRF.
Go already emits correct-family install tables (`normalizeRouteSnapshotFamily`)
and static `next-table` targets are reduced to a bare instance name
(`parseNextTableInstance`) with no family suffix to drift. Locked by
`TestNormalizeRouteSnapshotFamily_VRFPreserving_4423`.

### L3 — link-local next-hop needs `%iface` (`addr@interface` rejected) — NOT-A-BUG
xpf is Junos-syntax: `next-hop fe80::1 interface reth0.50`, internally encoded
as the `ip@interface` FIB spec. The `%iface` RFC 4007 zone-id form is a Linux
getaddrinfo()/`ip route` convention with **no producer or consumer** in the
pipeline; `ValidateStaticNextHop` correctly rejects it at commit. Locked by
`TestStaticNextHop_ZoneIDPercentRejected_4423`.

### L6 — overlay cannot express an ECMP preferred route — DEFER (feature)
`applyRouteOverlay` deliberately does whole-entry replacement with a single
next-hop — the correct #1827 WAN-failover semantics, pinned by the existing
`TestRouteOverlayWholeEntryReplacement`. A multi-next-hop preferred route is a
new feature (`RouteOverlayEntry.NextHop` → list + config schema + `pkg/ipmon`
winner-resolution), not a bug fix. Recorded plan in
`docs/rib-group-route-leaking.md`.

## What this PR changes
No Go code fix was warranted (M3 is Rust/deferred; L2/L3 not-a-bug; L6 a deferred
feature). This slice adds two Go **lock-in tests** encoding the L2/L3 disproofs,
records the M3 turnkey plan + L6 feature plan in `docs/rib-group-route-leaking.md`,
and logs the triage in `_Log.md`.

## Validation
- `go test ./pkg/config/ ./pkg/dataplane/userspace/` green
- `go build ./...`; `gofmt`/`go vet` clean on touched files
- GO-only, no cargo (per the slice scope)

Refs #4423.