### PR TITLE
ddns: fail closed on cached-client source-bind errors (#4437)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,37 @@
+## 2026-07-06 — #4437: DDNS Surface-A cached HTTP client fails closed on source-bind error
+
+- **Timestamp**: 2026-07-06
+- **Action**: Fixed C172-M01 (#4437). The Surface A HTTP publish path
+  (`resolveSurfaceABackend`, cached-client branch) swallowed a
+  cached-client source-bind error and threaded the UNBOUND default
+  client into the backend constructor — so a provider that configured a
+  `source-address` that could not be honored (a malformed address)
+  silently published from the DEFAULT ROUTE (the wrong source /
+  interface the operator explicitly overrode). Verify-first confirmed
+  the bug lived ONLY on the cached path: `httpClientCache.clientFor`
+  returns `(unbound client, err)`, and the old `httpClientFor` closure
+  dropped that error after a warning. The nil-cache path already failed
+  closed (`newProviderHTTPClient` surfaces the same error from inside
+  the constructor, `backend_dyndns2.go:85`), and the checkip observer
+  already failed closed via `CheckIPBound` (#3733). Fix: resolve the
+  source-bound client BEFORE building the backend and PROPAGATE the bind
+  error, so `newSurfaceAHTTP` degrades to the no-op publisher and the
+  reconcile SKIPS the publish (never a withdraw — the record stays as it
+  was on the wire, re-attempted next cycle once the leaf is corrected).
+  A publish with a configured `source-address` that cannot be honored is
+  an error, not a silent use-default. This is defense-in-depth: a non-IP
+  `source-address` is also rejected at commit
+  (`schema_validate_ddns_source_address_2780_test.go`), matching the
+  #3733 posture.
+- **Validation**: RED-on-revert confirmed — reverting the error
+  propagation makes `TestResolveSurfaceABackendFailsClosedOnCachedSourceBindError`
+  fail (returns a live `*dyndns2Backend` on the unbound client) while the
+  no-source happy-path test stays green. `go test ./pkg/ddns/...` green,
+  `go build`, gofmt + `go vet` clean on touched files.
+- **File(s)**: pkg/ddns/surface_a.go, pkg/ddns/backend_http.go,
+  pkg/ddns/surface_a_sourcebind_failclosed_4437_test.go,
+  pkg/ddns/README.md, _Log.md
+
 ## 2026-07-06 — #4433: fail the commit closed when IPsec render/reload fails
 
 - **Timestamp**: 2026-07-06

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -369,9 +369,10 @@ P1b (closes **#2663, #2664, #2665**) builds on the P1a spine:
   adapts them onto the same `resolveBindConfig` discipline. When no
   `source-address` is set the Transport gets no `DialContext` override — the
   default-route behaviour is byte-for-byte unchanged. A malformed `source-address`
-  is a hard error so the backend constructor degrades to no-op (and the checkip
-  client falls back to the unbound default + logs), matching the rfc2136
-  fail-open posture.
+  is a hard error: the backend constructor degrades to the no-op publisher and the
+  publish is SKIPPED — it must NOT fall back to the unbound default and egress from
+  the wrong source (fail-closed; the publish path via the cached client is #4437,
+  the checkip probe is #3733's `CheckIPBound` gate — see the two bullets below).
 
 - **HTTP client / connection-pool reuse across reconcile passes (#2904)** — the
   Surface A engine rebuilds the lightweight backend OBJECT every reconcile pass
@@ -395,6 +396,24 @@ P1b (closes **#2663, #2664, #2665**) builds on the P1a spine:
   configured bindings. Backed by the FAIL-ON-REVERT suite
   `surface_a_httpcache_2904_test.go` (same-binding reuse, cross-provider
   same-binding reuse, per-leaf invalidation, checkip↔update shared pool).
+- **Cached-client source-bind fail-closed (#4437)** — `httpClientCache.clientFor`
+  returns the UNBOUND default client ALONGSIDE the bind-resolution error for a
+  malformed `source-address` (the error path is deliberately not cached so a
+  corrected leaf on the next commit rebuilds cleanly). `resolveSurfaceABackend`
+  used to swallow that error, log a warning, and thread the unbound client into
+  the backend constructor — so a provider that configured a `source-address`
+  silently published from the DEFAULT ROUTE (the wrong source / interface the
+  operator explicitly overrode). The resolver now PROPAGATES the bind error: it
+  resolves the source-bound client BEFORE building the backend, so on a bind error
+  the constructor is never reached, `newSurfaceAHTTP` degrades to the no-op
+  publisher, and the reconcile SKIPS the publish (never a withdraw — the record
+  stays as it was on the wire, re-attempted next cycle once the leaf is corrected).
+  This matches the nil-cache path (which already surfaced the same error from
+  inside `newProviderHTTPClient`) and the checkip observer's #3733 `CheckIPBound`
+  fail-closed gate: a publish with a configured `source-address` that cannot be
+  honored is an error, not a silent use-default. Backed by the FAIL-ON-REVERT suite
+  `surface_a_sourcebind_failclosed_4437_test.go` (cached bind error → no-op +
+  uncached; no-source provider → live backend on the default client).
 - **Superseded-transport reap (#2956)** — the stale entry left behind by a
   binding-leaf change (above) was never looked up again but also never released,
   and the `SurfaceAManager` lives for the whole daemon lifetime, so distinct

--- a/pkg/ddns/backend_http.go
+++ b/pkg/ddns/backend_http.go
@@ -164,9 +164,13 @@ func bindCacheKey(p *config.DDNSProvider) string {
 
 // clientFor returns the cached bound *http.Client for the provider's source
 // binding, building and caching it on first use. The bind-resolution error (a
-// malformed source-address) is returned alongside the UNBOUND default client
-// (fail-open, matching newProviderHTTPClient); the error path is NOT cached so a
-// corrected source-address on the next commit rebuilds cleanly.
+// malformed source-address) is returned alongside the UNBOUND default client;
+// the error path is NOT cached so a corrected source-address on the next commit
+// rebuilds cleanly. Returning the unbound client is a convenience for the
+// no-source caller — a NON-nil error means the source could NOT be honored, and
+// every caller MUST fail CLOSED on it (skip the publish / probe) rather than
+// egress from that unbound client: the publish resolver (resolveSurfaceABackend,
+// #4437) and the checkip observer (CheckIPBound, #3733) both do.
 func (c *httpClientCache) clientFor(p *config.DDNSProvider) (*http.Client, error) {
 	b, err := resolveProviderBindConfig(p)
 	if err != nil {

--- a/pkg/ddns/surface_a.go
+++ b/pkg/ddns/surface_a.go
@@ -506,19 +506,43 @@ func resolveSurfaceABackend(p *config.DDNSProvider, fqdn string, _ int, clients 
 		return nopUpdater{}, nil
 	}
 	// httpClientFor pulls the cached bound client for this provider's binding
-	// when a cache is present, else returns nil (the constructor then builds its
-	// own). A bind-resolution error fails open to the unbound client AND is
-	// logged here once; the constructor degrades the same way it did pre-cache.
-	httpClientFor := func() *http.Client {
+	// when a cache is present, else returns (nil, nil) so the backend constructor
+	// builds — and fail-closes on — its own client via newProviderHTTPClient.
+	//
+	// FAIL-CLOSED on a cached-client source-bind error (#4437): clients.clientFor
+	// returns the UNBOUND default client ALONGSIDE the bind-resolution error (a
+	// malformed / unusable source-address). Earlier this path swallowed that
+	// error, logged a warning, and threaded the unbound client into the backend —
+	// so a provider that configured a `source-address` silently published from the
+	// DEFAULT ROUTE (the wrong source / interface the operator explicitly
+	// overrode). The error is now PROPAGATED, not swallowed: httpBackend turns it
+	// into the no-op publisher (newSurfaceAHTTP) and the reconcile SKIPS the
+	// publish — never a withdraw — exactly as the nil-cache path already does
+	// (newProviderHTTPClient surfaces the same error from inside the constructor)
+	// and as the checkip observer's CheckIPBound gate (#3733). A publish with a
+	// configured source-address that cannot be honored is an error, not a silent
+	// use-default.
+	httpClientFor := func() (*http.Client, error) {
 		if clients == nil {
-			return nil
+			return nil, nil
 		}
-		cl, err := clients.clientFor(p)
-		if err != nil {
-			slog.Warn("ddns surface-a: HTTP source bind unusable; using unbound client",
-				"provider", p.Name, "err", err)
-		}
-		return cl
+		return clients.clientFor(p)
+	}
+	// httpBackend resolves the source-bound client FIRST (fail-closed on a bind
+	// error) and only then builds the HTTP backend. Resolving the client before
+	// the constructor is what keeps the unbound fail-open client from ever being
+	// threaded in: on a bind error the constructor is never reached, so
+	// newSurfaceAHTTP degrades to the no-op backend and the publish is skipped.
+	httpBackend := func(build func(*http.Client) (DNSUpdater, error)) (DNSUpdater, error) {
+		return newSurfaceAHTTP(p, func() (DNSUpdater, error) {
+			cl, err := httpClientFor()
+			if err != nil {
+				return nil, fmt.Errorf("ddns surface-a: provider %q source bind "+
+					"unusable; refusing to publish from the unbound default route: %w",
+					p.Name, err)
+			}
+			return build(cl)
+		})
 	}
 	switch p.Backend {
 	case "rfc2136", "":
@@ -527,15 +551,15 @@ func resolveSurfaceABackend(p *config.DDNSProvider, fqdn string, _ int, clients 
 		}
 		return newSurfaceARFC2136(p, fqdn)
 	case "dyndns2":
-		return newSurfaceAHTTP(p, func() (DNSUpdater, error) { return newDyndns2Backend(p, httpClientFor()) })
+		return httpBackend(func(cl *http.Client) (DNSUpdater, error) { return newDyndns2Backend(p, cl) })
 	case "duckdns":
-		return newSurfaceAHTTP(p, func() (DNSUpdater, error) { return newDuckDNSBackend(p, httpClientFor()) })
+		return httpBackend(func(cl *http.Client) (DNSUpdater, error) { return newDuckDNSBackend(p, cl) })
 	case "cloudflare":
-		return newSurfaceAHTTP(p, func() (DNSUpdater, error) { return newCloudflareBackend(p, httpClientFor()) })
+		return httpBackend(func(cl *http.Client) (DNSUpdater, error) { return newCloudflareBackend(p, cl) })
 	case "route53":
-		return newSurfaceAHTTP(p, func() (DNSUpdater, error) { return newRoute53Backend(p, httpClientFor()) })
+		return httpBackend(func(cl *http.Client) (DNSUpdater, error) { return newRoute53Backend(p, cl) })
 	case "generic":
-		return newSurfaceAHTTP(p, func() (DNSUpdater, error) { return newGenericBackend(p, httpClientFor()) })
+		return httpBackend(func(cl *http.Client) (DNSUpdater, error) { return newGenericBackend(p, cl) })
 	default:
 		slog.Warn("ddns surface-a: unknown provider backend; publishing nothing",
 			"provider", p.Name, "backend", p.Backend)

--- a/pkg/ddns/surface_a_sourcebind_failclosed_4437_test.go
+++ b/pkg/ddns/surface_a_sourcebind_failclosed_4437_test.go
@@ -1,0 +1,91 @@
+package ddns
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// surface_a_sourcebind_failclosed_4437_test.go: FAIL-ON-REVERT coverage for
+// #4437 — a Surface A HTTP provider that configures a `source-address` which
+// cannot be honored (a malformed source-address) must fail CLOSED (resolve to
+// the no-op publisher, so the reconcile SKIPS the publish) rather than falling
+// back to the UNBOUND default-route client and silently publishing from the
+// wrong source. The bug lived ONLY on the cached-client path
+// (resolveBackend / m.httpClients non-nil): httpClientCache.clientFor returns
+// the unbound default client alongside the bind error, and resolveSurfaceABackend
+// used to swallow that error and thread the unbound client into the backend. The
+// nil-cache path already failed closed (newProviderHTTPClient surfaces the same
+// error from inside the constructor); these tests pin the cached path to the
+// same posture, mirroring the checkip observer's #3733 CheckIPBound gate.
+
+// TestResolveSurfaceABackendFailsClosedOnCachedSourceBindError proves that a
+// cached-client source-bind error degrades the provider to the no-op publisher
+// (never a working HTTP backend built on the unbound default client). Goes RED
+// on revert: without the fail-closed gate the unbound client is threaded in, the
+// dyndns2 constructor succeeds, and resolveSurfaceABackend returns a live
+// *dyndns2Backend that would publish from the default route.
+func TestResolveSurfaceABackendFailsClosedOnCachedSourceBindError(t *testing.T) {
+	cache := newHTTPClientCache()
+	p := &config.DDNSProvider{
+		Name:     "p",
+		Backend:  "dyndns2",
+		Server:   "https://dyn.example.net/nic/update",
+		Username: "u",
+		Password: config.Secret("pw"),
+		// A configured-but-unhonorable source binding: clientFor resolves the
+		// bindConfig, fails to parse the address, and returns (unbound client,
+		// error). The publish must NOT egress via that unbound client.
+		SourceAddress: "not-an-ip",
+	}
+
+	b, err := resolveSurfaceABackend(p, "host.example.net", 60, cache)
+	if err != nil {
+		// The degrade is a no-op backend + nil error (newSurfaceAHTTP logs the
+		// error and returns nopUpdater), NOT a hard resolve error — the reconcile
+		// treats the no-op backend as "skip this publish, re-attempt next cycle".
+		t.Fatalf("resolveSurfaceABackend should degrade to the no-op publisher, "+
+			"not hard-error: %v", err)
+	}
+	if !isNopUpdater(b) {
+		t.Fatalf("a cached-client source-bind error must fail CLOSED to the no-op "+
+			"publisher, got %T; a configured source-address that cannot be honored "+
+			"must skip the publish, never egress from the unbound default route", b)
+	}
+
+	// The error path must NOT be cached (a corrected source-address on the next
+	// commit rebuilds cleanly) — the cache holds no entry for the bad binding.
+	if n := cache.size(); n != 0 {
+		t.Fatalf("bind-error path must not cache a client, got %d entr(ies)", n)
+	}
+}
+
+// TestResolveSurfaceABackendNoSourceUsesDefaultClient proves the fail-closed gate
+// keys ONLY on the bind error: a provider with NO source-address (the default
+// route is the intended egress) still resolves to a real, working HTTP backend
+// through the cached default client. Goes RED if the gate ever over-fires and
+// suppresses publishing for every default-route deployment.
+func TestResolveSurfaceABackendNoSourceUsesDefaultClient(t *testing.T) {
+	cache := newHTTPClientCache()
+	p := &config.DDNSProvider{
+		Name:     "p",
+		Backend:  "dyndns2",
+		Server:   "https://dyn.example.net/nic/update",
+		Username: "u",
+		Password: config.Secret("pw"),
+		// No SourceAddress: bindConfig is the zero value, clientFor returns
+		// (default client, nil error) — the operator never asked for a source.
+	}
+
+	b, err := resolveSurfaceABackend(p, "host.example.net", 60, cache)
+	if err != nil {
+		t.Fatalf("a no-source provider must resolve without error, got %v", err)
+	}
+	if isNopUpdater(b) {
+		t.Fatalf("a provider with no source-address must resolve to a real backend " +
+			"(the unbound default client is its intended egress), got the no-op publisher")
+	}
+	if _, ok := b.(*dyndns2Backend); !ok {
+		t.Fatalf("expected a live *dyndns2Backend for the no-source happy path, got %T", b)
+	}
+}


### PR DESCRIPTION
Closes #4437 (codex-172 C172-M01, MED).

## Problem

The DDNS Surface-A HTTP publish path silently degraded a configured
`source-address` to the unbound default route. `resolveSurfaceABackend`'s
cached-client branch calls `httpClientCache.clientFor`, which returns the
UNBOUND default client ALONGSIDE the bind-resolution error for a malformed /
unusable `source-address`. The `httpClientFor` closure dropped that error after
a warning and threaded the unbound client into the backend constructor, so a
provider that configured a `source-address` published from the DEFAULT ROUTE —
the wrong source / interface the operator explicitly overrode — instead of
failing.

## Verify-first

The bug lived ONLY on the cached path (the production reconcile via
`m.httpClients`). The nil-cache path already fails closed:
`newProviderHTTPClient` surfaces the same error from inside the constructor
(`backend_dyndns2.go:85` and siblings), so the backend degrades to the no-op
publisher. The checkip observer already fails closed via `CheckIPBound`
(#3733). Only the cached publish path swallowed the error.

## Fix

Resolve the source-bound client BEFORE building the backend and PROPAGATE the
bind error. On a bind error the constructor is never reached, `newSurfaceAHTTP`
degrades to the no-op publisher, and the reconcile SKIPS the publish. This is
never a withdraw (`nopUpdater` keeps ownership; `publishLocked` returns
`errSurfaceANoBackend`) so the record stays as it was on the wire and is
re-attempted next cycle once the leaf is corrected. A publish with a configured
`source-address` that cannot be honored is an error, not a silent use-default —
matching #4432's H08 checkip fail-closed class. Defense-in-depth: a non-IP
`source-address` is also rejected at commit (2780).

The error path is still not cached, so a corrected `source-address` on the next
commit rebuilds cleanly. The no-source (default-route) path is unchanged — the
gate keys only on the bind error.

## Validation

- RED-on-revert confirmed: reverting the error propagation makes
  `TestResolveSurfaceABackendFailsClosedOnCachedSourceBindError` fail (returns a
  live `*dyndns2Backend` on the unbound client); the no-source happy-path test
  stays green.
- `go test ./pkg/ddns/...` green; `go build`; gofmt + `go vet` clean on touched
  files.
- Docs: `pkg/ddns/README.md` updated (new #4437 fail-closed bullet + corrected
  #2846/clientFor description); `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi