### PR TITLE
userspace-dp: don't fabric-fast-path NEW UDP flows as return (#4439)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-06 — #4439: fabric-return fast path must not adopt NEW UDP flows
+
+- **Timestamp**: 2026-07-06
+- **Action**: Fixed #4439 (ps-013/014/015, HIGH, confirmed 3×). A NEW
+  non-TCP (UDP) flow fabric-redirected from the inactive node to the RG
+  owner was fast-pathed as RETURN traffic on the owner by
+  `cluster_peer_return_fast_path`, which built a NAT-less
+  (`NatDecision::default()`) reverse-keyed (`is_reverse: true`) seed →
+  SNAT skipped (NAT bypass) + a reverse session installed for a forward
+  flow (session-state corruption).
+  - **Root cause**: the fast path may fire only for provably-RETURN
+    traffic and excludes each protocol's flow-initiator (TCP initial
+    SYN, ICMP echo REQUEST), but UDP has no non-initiating form and was
+    allowed. It is reached only after `resolve_flow_session_decision`
+    misses every scope, so any UDP packet landing here is session-less =
+    a NEW forward flow, not return traffic.
+  - **Fix**: `cluster_peer_return_fast_path` (forwarding/mod.rs) now
+    returns `None` for `PROTO_UDP`, completing the initiator-exclusion
+    invariant. The session-less UDP packet falls through to the normal
+    forward decision on the owner, which resolves it to a
+    `ForwardCandidate` (not a `FabricRedirect`) → `apply_nat` is `true` →
+    source-NAT applied + a FORWARD session installed. No
+    `apply_nat_on_fabric` change: the non-owner keeps redirecting the
+    original pre-NAT frame (Fix-1 design); the owner's forward pipeline
+    already anticipates fabric-ingress session-miss packets (#4155).
+  - **Preserved**: established synced-session return traffic is served by
+    `resolve_flow_session_decision` (synced session + #2120 retention),
+    not this fast path; TCP (non-SYN) and ICMP (echo-reply) still
+    fast-path.
+  - **RED-on-revert**: `forwarding/tests.rs`
+    `cluster_peer_return_fast_path_skips_udp_new_flow_4439` — UDP against
+    the same ForwardCandidate-resolving target the ICMP-reply test uses
+    (returns `Some` on revert, `None` with the fix); the preserved
+    `_allows_sfmix_to_lan_reply` (ICMP reply) proves the legit path.
+- **File(s)**: userspace-dp/src/afxdp/forwarding/mod.rs,
+  userspace-dp/src/afxdp/forwarding/tests.rs,
+  docs/fabric-cross-chassis-fwd.md, _Log.md
+
 ## 2026-07-06 — #4433: fail the commit closed when IPsec render/reload fails
 
 - **Timestamp**: 2026-07-06

--- a/docs/fabric-cross-chassis-fwd.md
+++ b/docs/fabric-cross-chassis-fwd.md
@@ -433,3 +433,64 @@ RED-on-revert coverage: `screen/tests.rs`
 scope guards) and `afxdp/poll_stages.rs`
 (`fabric_ingress_skips_rate_flood_direct_still_counts_4155`, driving the live
 `stage_screen_check`).
+
+## The cluster-peer return fast path must not adopt NEW UDP flows (#4439)
+
+`cluster_peer_return_fast_path` (`userspace-dp/src/afxdp/forwarding/mod.rs`,
+called from the session-MISS decision in `poll_descriptor/mod.rs`) exists for
+the sync-race sub-window: a packet the active RG owner already
+policy/NAT-validated is fabric-redirected to the peer, arrives before the
+synced session installs, and must still be handed to the local egress instead
+of being treated as a brand-new flow. It builds a NAT-less
+(`NatDecision::default()`), reverse-keyed (`is_reverse: true`) seed and
+forwards the packet.
+
+It is reached **only after** `resolve_flow_session_decision` misses in every
+scope (local + synced forward key + forward-NAT reply key), so a genuine
+established flow's return packet — including the whole failback-preservation
+case above — is served by the synced session and never lands here. Anything
+reaching this fast path is therefore **session-less**.
+
+**The bug.** This fast path may fire ONLY for packets that are provably RETURN
+traffic. Every protocol with a packet-level flow-initiator marker is excluded:
+TCP excludes the initial SYN, ICMP excludes the echo REQUEST. **UDP has no such
+marker** — any datagram can open a new flow, and there is no "non-initiating
+UDP" form. Before #4439 a session-less UDP datagram that was a genuinely NEW
+forward flow (e.g. an outbound flow that ingressed the non-owner node and was
+fabric-redirected to the RG owner) was adopted by this fast path as return
+traffic. Two failures followed on the owner:
+
+1. **NAT bypass.** The reverse seed carried `NatDecision::default()`, so the
+   **source-NAT** a new outbound flow requires was never applied — the packet
+   left with its private source address/port.
+2. **Session-state corruption.** The owner installed a **reverse-keyed**
+   (`SessionOrigin::ReverseFlow`) session for what was actually a forward flow,
+   so subsequent packets and the real reply resolved against a mis-directioned
+   session.
+
+Confirmed 3× (ps-013/014/015).
+
+**The fix.** `cluster_peer_return_fast_path` now returns `None` for
+`meta.protocol == PROTO_UDP`, completing the flow-initiator-exclusion
+invariant (TCP-SYN, ICMP-echo-request, and now all UDP). A session-less UDP
+packet falls through to the normal forward decision, where — because the RG
+owner resolves it to a `ForwardCandidate` (not a `FabricRedirect`) — source-NAT
+is applied (`apply_nat = !fabric_redirect || apply_nat_on_fabric` is `true` for
+a non-redirect egress) and a FORWARD session is installed. The session-miss
+forward path already anticipates fabric-ingress packets (the #4155 sync-race
+`packet_fabric_ingress` handling), so no other change is required; the
+non-owner keeps redirecting the original pre-NAT frame (`apply_nat_on_fabric`
+stays `false`), matching the Fix 1 "peer processes it through its full
+pipeline" design.
+
+The legitimate fabric-forward for an established synced session is untouched:
+it is served by `resolve_flow_session_decision` (the synced session + #2120
+standby retention), not by this session-less fast path. TCP (non-SYN) and ICMP
+(echo-reply) return traffic continue to fast-path as before.
+
+RED-on-revert coverage: `forwarding/tests.rs`
+`cluster_peer_return_fast_path_skips_udp_new_flow_4439` (UDP against the same
+ForwardCandidate-resolving target the ICMP-reply test uses — returns `Some` on
+revert, `None` with the fix) alongside the preserved
+`cluster_peer_return_fast_path_allows_sfmix_to_lan_reply` (ICMP echo reply
+still fast-paths) and `_skips_pure_tcp_syn` / `_skips_icmp_echo_request`.

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -731,6 +731,24 @@ pub(super) fn cluster_peer_return_fast_path(
     if meta.protocol == PROTO_TCP && crate::tcp_flags::is_initial_syn(meta.tcp_flags) {
         return None;
     }
+    // #4439: this fast path may fire ONLY for packets that are provably
+    // RETURN traffic — the reverse direction of a flow the active owner
+    // already policy/NAT-validated. Every other protocol carries a
+    // packet-level flow-initiator marker we exclude above: TCP excludes the
+    // initial SYN, ICMP excludes the echo REQUEST. UDP has NO such marker —
+    // any UDP datagram can open a new flow, and there is no "non-initiating
+    // UDP" form. A session-less UDP packet reaching here (a real established
+    // UDP reply is served by the synced session in
+    // `resolve_flow_session_decision` before this point) is therefore a NEW
+    // forward flow, NOT return traffic. Fast-pathing it built a NAT-less,
+    // reverse-keyed session for a forward flow — the source-NAT that a new
+    // outbound flow requires was skipped (NAT bypass) and the owner recorded
+    // the flow in the wrong direction (session-state corruption). Fall
+    // through instead so the RG owner runs the packet through its normal
+    // forward decision: source-NAT applied and a FORWARD session installed.
+    if meta.protocol == PROTO_UDP {
+        return None;
+    }
 
     let fabric_return_resolution =
         lookup_forwarding_resolution_with_dynamic(forwarding, dynamic_neighbors, resolution_target);

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -795,6 +795,55 @@ fn cluster_peer_return_fast_path_allows_sfmix_to_lan_reply() {
 }
 
 #[test]
+fn cluster_peer_return_fast_path_skips_udp_new_flow_4439() {
+    // #4439: a session-less UDP datagram arriving on the fabric is a NEW
+    // forward flow, not return traffic (UDP has no packet-level initiator
+    // marker like TCP SYN / ICMP echo-request). It MUST fall through to the
+    // owner's forward decision — source-NAT applied + a FORWARD session
+    // installed — not be fast-pathed as a NAT-less reverse seed. This is the
+    // exact `_allows_sfmix_to_lan_reply` setup (whose ICMP-reply target
+    // resolves to a ForwardCandidate) with the protocol flipped to UDP: on
+    // revert the fast path returns Some (the reverse seed / NAT bypass), so
+    // asserting None is RED-on-revert. The ICMP-reply test above proves the
+    // legitimate return-traffic fast path is preserved.
+    let mut state = build_forwarding_state(&native_gre_pbr_snapshot(true));
+    state.fabrics.push(FabricLink {
+        parent_ifindex: 4,
+        overlay_ifindex: 104,
+        peer_addr: IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2)),
+        peer_mac: [0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee],
+        local_mac: [0x02, 0xbf, 0x72, 0xff, 0x00, 0x01],
+        up: true,
+    });
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+    dynamic_neighbors.insert(
+        (5, IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102))),
+        NeighborEntry {
+            mac: [0xde, 0xad, 0xbe, 0xef, 0x00, 0x01],
+        },
+    );
+    let meta = UserspaceDpMeta {
+        ingress_ifindex: 4,
+        protocol: PROTO_UDP,
+        l4_offset: 0,
+        ..UserspaceDpMeta::default()
+    };
+    let packet_frame = [0u8];
+
+    assert!(
+        cluster_peer_return_fast_path(
+            &state,
+            &dynamic_neighbors,
+            &packet_frame,
+            meta,
+            Some(TEST_SFMIX_ZONE_ID),
+            IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
+        )
+        .is_none()
+    );
+}
+
+#[test]
 fn cluster_peer_return_fast_path_skips_pure_tcp_syn() {
     let mut state = build_forwarding_state(&native_gre_pbr_snapshot(true));
     state.fabrics.push(FabricLink {


### PR DESCRIPTION
## Summary

Closes #4439 (ps-013/014/015, HIGH, confirmed 3x).

A NEW non-TCP (UDP) flow fabric-redirected from the inactive node to the RG
owner was fast-pathed as RETURN traffic on the owner by
`cluster_peer_return_fast_path`, which built a NAT-less
(`NatDecision::default()`) reverse-keyed (`is_reverse: true`) seed. Two
failures followed on the owner:

1. **NAT bypass** — the reverse seed carried `NatDecision::default()`, so the
   source-NAT a new outbound flow requires was never applied.
2. **Session-state corruption** — the owner installed a reverse-keyed
   (`SessionOrigin::ReverseFlow`) session for what was actually a forward flow.

## Root cause

`cluster_peer_return_fast_path` may fire only for packets that are provably
RETURN traffic, and it excludes each protocol's flow-initiator: TCP the
initial SYN, ICMP the echo REQUEST. **UDP has no such marker** — any datagram
can open a new flow and there is no "non-initiating UDP" form. The fast path
is reached only after `resolve_flow_session_decision` misses every scope
(local + synced forward key + forward-NAT reply key), so anything landing here
is session-less = a NEW forward flow, not return traffic — but session-less
UDP was still adopted as return.

## Fix

`cluster_peer_return_fast_path` (`userspace-dp/src/afxdp/forwarding/mod.rs`)
now returns `None` for `meta.protocol == PROTO_UDP`, completing the
flow-initiator-exclusion invariant (TCP-SYN, ICMP-echo-request, and now all
UDP). The session-less UDP packet falls through to the normal forward decision
on the owner, which resolves it to a `ForwardCandidate` (not a
`FabricRedirect`) so `apply_nat = !fabric_redirect || apply_nat_on_fabric` is
`true` — source-NAT is applied and a FORWARD session is installed. No
`apply_nat_on_fabric` change is needed: the non-owner keeps redirecting the
original pre-NAT frame (the Fix-1 "peer processes it through its full
pipeline" design), and the session-miss forward path already anticipates
fabric-ingress packets (#4155 `packet_fabric_ingress`).

## Preserved

The legitimate fabric-forward for an established synced session is untouched —
it is served by `resolve_flow_session_decision` (synced session + #2120
standby retention), not this session-less fast path. TCP (non-SYN) and ICMP
(echo-reply) return traffic still fast-path.

## Validation

- **RED-on-revert**: `forwarding/tests.rs`
  `cluster_peer_return_fast_path_skips_udp_new_flow_4439` — UDP against the
  same ForwardCandidate-resolving target the ICMP-reply test uses; returns
  `Some` (reverse seed / NAT bypass) on revert, `None` with the fix. Verified
  by neutralizing the guard (test FAILED), then restoring (test PASSED).
- **Preserved**: `_allows_sfmix_to_lan_reply` (ICMP echo reply still
  fast-paths), `_skips_pure_tcp_syn`, `_skips_icmp_echo_request`.
- **Full cargo suite, serial** (`--test-threads=1`): 3647/0 in the main binary
  (fabric 88/0, session 406/0, nat 613/0); all test targets green.
- **HA note**: fabric cross-chassis forwarding → `make test-failover`
  warranted before merge (a new non-TCP flow across a fabric redirect now gets
  NAT; a synced session's failover still forwards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
