### PR TITLE
ddns/nat64: fix stale Surface-A RFC2136-only doc; document NAT64 policy enforcement (#4440)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,39 @@
+## 2026-07-07 — #4440: codex-172 lows (DDNS Surface-A doc + NAT64 policy verify)
+
+- **Timestamp**: 2026-07-07
+- **Action**: Drove OPEN issue #4440 (codex-172 low-severity, two parts).
+  (1) DOC: the Surface-A manager constructor `NewSurfaceAManager`
+  doc-comment still described RFC-2136-only backend resolution ("It
+  resolves the live RFC 2136 backend per provider at reconcile time"),
+  but Surface A now resolves HTTP providers too (dyndns2, duckdns,
+  cloudflare, route53, generic) via `resolveSurfaceABackend`. Rewrote the
+  comment to state resolve-per-Reconcile picks the RFC 2136 UPDATE backend
+  OR one of the HTTP providers, all siblings behind the same DNSUpdater
+  interface. Comment-only; `go build`/`go test ./pkg/ddns/...` green,
+  gofmt + vet clean.
+  (2) VERIFY (NAT64 synthetic-IPv6-dest "blanket-permit" concern):
+  DISPROVEN — NAT64 flows ARE policy-enforced on the extracted real IPv4
+  destination (#2358), not blanket-permitted. Confirmed empirically by
+  running the userspace-dp NAT64 policy tests + a scratch discriminator
+  (reverted): `policy_dst_ip = effective_resolution_target` = extracted
+  IPv4 (poll_descriptor/mod.rs ~L1505-1555, fed to
+  evaluate_policy_result_with_icmp ~L2467), matched via the #2358
+  `(V6 src, V4 dst)` cross-family arm in policy.rs::try_match_rule ~L3907.
+  A rule scoped to a NON-covering IPv4 host (`9.9.9.9/32` vs extracted
+  `8.8.8.8`) DENIES the flow (falls to deny default); a `64:ff9b::/96`
+  whole-prefix rule permits only via the v6-only-set → IPv4-match-any
+  convention, NOT a NAT64 policy-skip. Added a "Policy IS enforced on
+  NAT64 flows" note with the disproving file:line to
+  docs/next-features/twice-nat.md (#2358 section). SECONDARY (deferred to
+  a separate Rust follow-up per Go/docs-PR scope): the afxdp/tests.rs
+  rationale comments (~L11683-11692, L12057-12065, L12099-12104) still
+  claim NAT64 is "DELIBERATELY EXCLUDED from post-translation matching /
+  matched on the SYNTHETIC IPv6 destination, NOT the extracted IPv4" —
+  stale pre-#2358 wording (the tests still pass; only the comments are
+  wrong).
+- **File(s)**: pkg/ddns/surface_a.go, docs/next-features/twice-nat.md,
+  _Log.md
+
 ## 2026-07-06 — #4439: fabric-return fast path must not adopt NEW UDP flows
 
 - **Timestamp**: 2026-07-06

--- a/docs/next-features/twice-nat.md
+++ b/docs/next-features/twice-nat.md
@@ -98,6 +98,26 @@ unintended match-all. Only the ForwardCandidate (primary) NAT64 path
 classifies NAT64 and feeds the v4 tuple; the MissingNeighbor cold path
 does not classify NAT64 and is not the NAT64 forwarding path.
 
+**Policy IS enforced on NAT64 flows — the synthetic IPv6 destination is
+NOT blanket-permitted (verify, #4440 / codex-172).** A NAT64-translated
+flow goes through the normal zone-policy evaluation with a real,
+deny-able destination tuple; there is no bypass. The forwarding path
+binds `policy_dst_ip = effective_resolution_target` (the extracted real
+IPv4 destination for a NAT64 match) at
+`userspace-dp/src/afxdp/poll_descriptor/mod.rs` (the `effective_resolution_target`
+NAT64 arm ~L1505-1555) and feeds it to `evaluate_policy_result_with_icmp`
+(~L2467), which matches via the `(V6 src, V4 dst)` cross-family arm in
+`userspace-dp/src/policy.rs::try_match_rule` (~L3907). An explicit `deny`
+rule matching the NAT64 destination DROPS the flow — pinned by
+`policy_inbound_nat64_denies_on_synthetic_v6_deny_rule`
+(`userspace-dp/src/afxdp/tests.rs`), and a rule scoped to a
+NON-matching real IPv4 host (e.g. `9.9.9.9/32` when the extracted dst is
+`8.8.8.8`) does NOT permit — it falls to the deny default. The only
+reason a policy authored against the whole synthetic prefix
+(`64:ff9b::/96`) still permits is the IPv4-match-any convention above (a
+v6-only destination set with no v4 prefix), NOT a NAT64-specific
+policy-skip.
+
 ### 2. Add end-to-end coverage
 Add explicit tests for:
 

--- a/pkg/ddns/surface_a.go
+++ b/pkg/ddns/surface_a.go
@@ -413,9 +413,12 @@ type SurfaceAManager struct {
 // manager is still constructible (the daemon starts) but Reconcile refuses to
 // publish or withdraw any record until the operator resolves the bad file
 // (corrupt/unsupported files are quarantined aside). A MISSING file (first boot)
-// is NOT degraded — a fresh node publishes normally. It resolves the live RFC
-// 2136 backend per provider at reconcile time. The runtime cache is seeded from
-// the durable store so a restart does not republish an unchanged address.
+// is NOT degraded — a fresh node publishes normally. It resolves the live
+// backend per provider at reconcile time (resolve-per-Reconcile): the RFC 2136
+// dynamic-DNS UPDATE backend OR one of the HTTP providers — dyndns2, duckdns,
+// cloudflare, route53, generic — all siblings behind the same DNSUpdater
+// interface (see resolveSurfaceABackend). The runtime cache is seeded from the
+// durable store so a restart does not republish an unchanged address.
 func NewSurfaceAManager() *SurfaceAManager {
 	st, degraded, reason := loadStateOrDegrade(defaultSurfaceAStatePath, time.Now)
 	m := &SurfaceAManager{


### PR DESCRIPTION
Closes #4440. Two low-severity items from codex-172 (filed per no-dismissal). Go doc + docs only — no code-behavior change.

## (1) DDNS Surface-A constructor doc (GO)
`NewSurfaceAManager`'s doc-comment (`pkg/ddns/surface_a.go`) still read "It resolves the live RFC 2136 backend per provider at reconcile time", but Surface A resolves HTTP providers (dyndns2, duckdns, cloudflare, route53, generic) as first-class siblings behind the same `DNSUpdater` interface (`resolveSurfaceABackend` / `resolveBackend`). Rewrote the comment to describe the multi-provider resolve-per-Reconcile reality.

Comment-only: `go build ./pkg/ddns/...` + `go test ./pkg/ddns/...` green, gofmt + vet clean.

## (2) NAT64 synthetic-IPv6-destination policy "blanket-permit" — VERIFIED, no bug
The synthetic IPv6 destination for a NAT64-translated flow does NOT bypass policy. NAT64 flows go through the normal zone-policy evaluation on the extracted REAL IPv4 destination (#2358):

- `userspace-dp/src/afxdp/poll_descriptor/mod.rs` ~L1505-1555 binds `policy_dst_ip = effective_resolution_target` (the extracted IPv4 dst for a NAT64 match), fed to `evaluate_policy_result_with_icmp` (~L2467).
- `userspace-dp/src/policy.rs::try_match_rule` ~L3907 — the #2358 `(V6 src, V4 dst)` cross-family arm matches the rule's IPv4 destination set.

Confirmed empirically (ran the userspace-dp NAT64 policy tests + a reverted scratch discriminator): a rule scoped to a NON-covering IPv4 host (`9.9.9.9/32` when the extracted dst is `8.8.8.8`) DENIES the flow; `8.8.8.8/32` PERMITS it. A rule against the whole synthetic prefix (`64:ff9b::/96`) still permits only because a v6-only destination set with no v4 prefix compiles to IPv4-match-any (the documented legacy address-set convention), NOT a NAT64 policy-skip.

Documented the "policy IS enforced on NAT64 flows / not a bypass" conclusion with the disproving file:line in `docs/next-features/twice-nat.md` (#2358 section).

## Deferred
The pre-#2358 rationale comments in `userspace-dp/src/afxdp/tests.rs` (still claiming NAT64 matches on the synthetic IPv6 destination) are stale but the tests pass. Filed as **#4449** (Rust comment-only cleanup) to keep this a Go/docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi