### PR TITLE
Refs #4420 (HI-1/HI-2 host-inbound fail-opens)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -38435,3 +38435,47 @@ top.
   pkg/config/compiler_validate_strict_chassis_4434_test.go,
   pkg/config/compiler.go, pkg/cluster/heartbeat.go,
   pkg/cluster/heartbeat_rg_cap_4434_test.go, docs/config-schema.md, _Log.md
+
+## 2026-07-07 — #4420 HI-2 host-inbound fail-open: addressed-but-unzoned interface default-deny (HI-1 verified + deferred)
+- **Timestamp**: 2026-07-07
+- **Action**: Close the #4420 HI-2 host-inbound fail-open. An interface that
+  carries an address but is assigned to NO security zone had its address applied
+  (networkd managed set is built from `cfg.Interfaces`, not zones) yet was NOT
+  scoped by any per-zone host-inbound deny, so host-bound traffic fell through
+  the kernel `xpf_hostinbound` chain's `policy accept` to the host stack with no
+  admission — a fail-open, and a deviation from Junos (an unzoned interface
+  passes no flow / host-inbound traffic). Verified reachable: no commit gate
+  rejects it (`show security zones` even renders "not assigned to any security
+  zone"), and a strict commit-reject was ruled out because 21+ existing tests +
+  real operator workflows legitimately set an interface address before zoning.
+  - **Fix**: new `userspace.BuildUnzonedHostInboundAddrs(cfg)` collects the
+    firewall-local addresses of non-lifeline interfaces in no zone (zoned
+    addresses subtracted, lifelines fxp0/em0/fab* excluded, only when >= 1 zone
+    so a bootstrap/zoneless box is untouched). `daemon_nft.go`
+    `buildHostInboundFilterPayload` now emits a catch-all DROP scoping them
+    (`emitUnzonedHostInboundDeny`), after the global established/ESP-AH/ND/PMTUD
+    accepts, counted under the reserved `junos-host` sentinel label so the #3361
+    kernel-deny scraper reports `zone="junos-host"`. Kernel-only (unzoned
+    interfaces are not AF_XDP-bound), no userspace-dp/Rust change. Mirrors the
+    #3405 per-zone default-deny.
+  - **HI-1 (verified GENUINE, DEFERRED)**: the same chain matches destination
+    address only, so host-bound multicast/broadcast (OSPF/RIP/VRRP/PIM
+    link-local groups, limited/directed broadcast) is not scoped by any `daddr`
+    set and falls through `policy accept` — not subjected to per-zone
+    host-inbound protocols admission (daemon_nft.go `policy accept` +
+    daddr-scoped drops). Correct fix needs per-zone ingress-interface (iifname)
+    multicast admission in lockstep with the Rust classifier AND is a
+    behavior/hardening change (a zone running a routing protocol in FRR without
+    the matching `host-inbound-traffic protocols` knob relies on today's
+    accept). Deferred to a follow-up; documented as a known limitation.
+  - **RED-on-revert**: neutering `emitUnzonedHostInboundDeny` → the payload test
+    fails (missing the unzoned DROP + sentinel counter). Restored; touched Go
+    suites (daemon, dataplane/userspace, config, nftables) green, `go build
+    ./...`, gofmt + vet clean.
+- **File(s)**: pkg/dataplane/userspace/zones.go,
+  pkg/dataplane/userspace/host_inbound_unzoned_4420_test.go,
+  pkg/daemon/daemon_nft.go,
+  pkg/daemon/host_inbound_unzoned_4420_test.go,
+  pkg/daemon/host_inbound_nft_test.go,
+  pkg/daemon/host_inbound_per_iface_3362_test.go,
+  pkg/daemon/nft_chain_priority_test.go, pkg/daemon/README.md, _Log.md

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -526,6 +526,29 @@ never lock an operator out of a remote box it manages.
   HA; `ct state established,related` and IPv6 ND + v4/v6 PMTUD control messages
   are accepted before any deny; a configured zone that resolves to zero
   recognized matches fails OPEN (no deny) rather than locking the zone out.
+  **Unzoned interfaces (#4420 HI-2):** an interface that carries an address but
+  is assigned to NO security zone is not covered by any per-zone view above, so
+  before #4420 its firewall-local addresses fell through the chain's
+  `policy accept` to the host stack with NO host-inbound admission — a fail-open,
+  and a deviation from Junos (an interface not in a zone passes no flow /
+  host-inbound traffic at all). `applyHostInboundFilter` now also scopes a
+  catch-all DROP to those addresses (`userspace.BuildUnzonedHostInboundAddrs`,
+  counted under the reserved `junos-host` sentinel label so the #3361 scraper
+  reports them as `zone="junos-host"`). Lifelines are excluded and zoned
+  addresses subtracted, so it can never strand management or conflict with a zone
+  rule; it is emitted only when the zone model is in use (>= 1 zone), so a
+  bootstrap / zoneless box is left untouched. Unzoned interfaces are not
+  AF_XDP-bound, so the kernel nft deny is the sole and sufficient enforcement
+  point (no userspace-dp change). **Known limitation (#4420 HI-1):** the chain
+  matches destination address only, so host-bound MULTICAST / BROADCAST (OSPF /
+  RIP / VRRP / PIM link-local groups, limited / directed broadcast) is not scoped
+  by any `daddr` set and still falls through `policy accept` — it is NOT
+  subjected to the per-zone host-inbound protocols admission (a Junos-parity
+  gap). Closing it needs per-zone ingress-interface (`iifname`) multicast
+  admission in lockstep with the Rust classifier and is a behavior / hardening
+  change (a zone running a routing protocol in FRR without the matching
+  `host-inbound-traffic protocols` knob relies on today's accept), so it is
+  tracked separately rather than folded here.
   Token→nft mapping (`hostInboundServiceMatches`/`hostInboundProtocolMatches`)
   mirrors the Rust classifier and must stay in sync. **Structured SSOT (#3627
   B1a):** since #3627 these two functions no longer carry their own hard-coded

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -241,6 +241,16 @@ func buildLo0FilterPayload(cfg *config.Config, filterV4, filterV6 string) string
 // nft failure cannot brick startup; the next clean commit re-renders.
 func (d *Daemon) applyHostInboundFilter(cfg *config.Config) error {
 	views := dpuserspace.BuildZoneHostInboundViews(cfg)
+	// #4420 HI-2: firewall-local addresses on interfaces assigned to NO security
+	// zone. xpfd applies an interface's address regardless of zone membership,
+	// but the per-zone views above scope the default-deny to ZONED addresses
+	// only, so host-bound traffic to an addressed-but-unzoned interface would
+	// fall through the chain's `policy accept` and reach the host stack with no
+	// host-inbound admission (fail-open; Junos passes no traffic on an unzoned
+	// interface). These get their own catch-all DROP below. Lifelines are
+	// excluded and zoned addresses are subtracted by the builder, so this can
+	// never strand management or conflict with a zone rule.
+	unzonedV4, unzonedV6 := dpuserspace.BuildUnzonedHostInboundAddrs(cfg)
 	// #3698: surface the transient fail-open admit window. A configured
 	// host-inbound-enforcing zone whose non-lifeline interfaces have no
 	// resolvable address yet (DHCP WAN before its first lease, backup node before
@@ -265,25 +275,27 @@ func (d *Daemon) applyHostInboundFilter(cfg *config.Config) error {
 	// peer-synced load can slip one through, and it is NOT self-healing — so log
 	// the state transition and export it as xpf_host_inbound_ambiguous_addresses.
 	d.logHostInboundAmbiguousTransitions(cfg)
-	if !hostInboundHasEnforceableView(views) {
-		// No host-inbound-configured zone with a resolvable address — nothing to
-		// enforce. Remove any stale table. nftDeleteTable is idempotent (an
-		// add-then-delete payload, so no error when the table is absent — the
-		// common case), so a non-nil error here is a REAL teardown failure that
-		// left a stale deny in the kernel: surface it so the commit fails closed
-		// rather than reporting that host-inbound was relaxed when it was not.
+	if !hostInboundHasEnforceableView(views) && len(unzonedV4) == 0 && len(unzonedV6) == 0 {
+		// No host-inbound-configured zone with a resolvable address AND no
+		// addressed-but-unzoned interface (#4420 HI-2) — nothing to enforce.
+		// Remove any stale table. nftDeleteTable is idempotent (an add-then-delete
+		// payload, so no error when the table is absent — the common case), so a
+		// non-nil error here is a REAL teardown failure that left a stale deny in
+		// the kernel: surface it so the commit fails closed rather than reporting
+		// that host-inbound was relaxed when it was not.
 		if out, err := nftDeleteTable("inet", "xpf_hostinbound"); err != nil {
 			slog.Warn("failed to delete stale host-inbound filter table", "err", err, "output", string(out))
 			return fmt.Errorf("delete stale host-inbound nftables table: %w", err)
 		}
 		return nil
 	}
-	nftConf := buildHostInboundFilterPayload(views)
+	nftConf := buildHostInboundFilterPayload(views, unzonedV4, unzonedV6)
 	if out, err := nftApplyPayload(nftConf); err != nil {
 		slog.Warn("failed to apply host-inbound filter", "err", err, "output", string(out))
 		return fmt.Errorf("apply host-inbound nftables filter: %w", err)
 	}
-	slog.Info("host-inbound filter applied", "zones", len(views))
+	slog.Info("host-inbound filter applied", "zones", len(views),
+		"unzoned_deny_v4", len(unzonedV4), "unzoned_deny_v6", len(unzonedV6))
 	return nil
 }
 
@@ -447,7 +459,7 @@ func hostInboundHasEnforceableView(views []dpuserspace.ZoneHostInboundView) bool
 //     the table body and scraped per zone/family into the
 //     xpf_host_inbound_kernel_denies_total metric (#3361) — distinct from the
 //     userspace-dp xpf_host_inbound_denies_total path (#3326).
-func buildHostInboundFilterPayload(views []dpuserspace.ZoneHostInboundView) string {
+func buildHostInboundFilterPayload(views []dpuserspace.ZoneHostInboundView, unzonedV4, unzonedV6 []string) string {
 	// Pre-pass: collect the named DROP counters the chain will reference, so they
 	// can be declared at the top of the table body BEFORE the chain. A counter is
 	// emitted exactly when emitHostInboundZone emits a catch-all drop
@@ -482,6 +494,15 @@ func buildHostInboundFilterPayload(views []dpuserspace.ZoneHostInboundView) stri
 		if hostInboundEmitsDrop(v, v.V6Addrs) {
 			addCounter(xnft.HostInboundDenyCounterName(v.Zone, "ip6"))
 		}
+	}
+	// #4420 HI-2: the addressed-but-unzoned catch-all DROP references its own
+	// named counter under the reserved junos-host sentinel label (declared here
+	// exactly once, matching the per-zone declaration contract above).
+	if len(unzonedV4) > 0 {
+		addCounter(xnft.HostInboundDenyCounterName(dpuserspace.UnzonedHostInboundZoneLabel, "ip"))
+	}
+	if len(unzonedV6) > 0 {
+		addCounter(xnft.HostInboundDenyCounterName(dpuserspace.UnzonedHostInboundZoneLabel, "ip6"))
 	}
 
 	var rules []string
@@ -533,9 +554,31 @@ func buildHostInboundFilterPayload(views []dpuserspace.ZoneHostInboundView) stri
 		emitHostInboundZone(&rules, v, "ip", v.V4Addrs)
 		emitHostInboundZone(&rules, v, "ip6", v.V6Addrs)
 	}
+	// #4420 HI-2: catch-all DROP for firewall-local addresses on interfaces in NO
+	// security zone. Emitted AFTER the per-zone rules and the global
+	// established / ESP-AH / ND / PMTUD accepts, so those still admit their
+	// traffic on an unzoned interface (a decrypted host-terminated tunnel, ND,
+	// PMTUD) while every other host-bound service/protocol is denied — the Junos
+	// fail-closed posture for an interface with no zone. The address set is
+	// already lifeline-excluded and zone-subtracted by BuildUnzonedHostInboundAddrs.
+	emitUnzonedHostInboundDeny(&rules, "ip", unzonedV4)
+	emitUnzonedHostInboundDeny(&rules, "ip6", unzonedV6)
 	rules = append(rules, "  }")
 	rules = append(rules, "}")
 	return strings.Join(rules, "\n") + "\n"
+}
+
+// emitUnzonedHostInboundDeny appends the #4420 HI-2 catch-all DROP for the given
+// family's addressed-but-unzoned firewall-local addresses. It is a pure
+// destination-scoped silent drop (Junos default-deny to the host) counted under
+// the reserved junos-host sentinel label, so the #3361 kernel-deny scraper picks
+// it up as zone="junos-host". No-op when the family has no unzoned address.
+func emitUnzonedHostInboundDeny(rules *[]string, family string, addrs []string) {
+	if len(addrs) == 0 {
+		return
+	}
+	cn := xnft.HostInboundDenyCounterName(dpuserspace.UnzonedHostInboundZoneLabel, family)
+	*rules = append(*rules, "    "+family+" daddr "+nftAddrSet(addrs)+" counter name \""+cn+"\" drop")
 }
 
 // hostInboundEmitsDrop reports whether emitHostInboundZone will emit a catch-all

--- a/pkg/daemon/host_inbound_nft_test.go
+++ b/pkg/daemon/host_inbound_nft_test.go
@@ -81,7 +81,7 @@ func hostInboundTestConfig() *config.Config {
 func TestHostInboundFilterAcceptsListedDeniesRest(t *testing.T) {
 	cfg := hostInboundTestConfig()
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views)
+	payload := buildHostInboundFilterPayload(views, nil, nil)
 
 	mustContain := []string{
 		"table inet xpf_hostinbound",
@@ -131,7 +131,7 @@ func TestHostInboundFilterAcceptsListedDeniesRest(t *testing.T) {
 func TestHostInboundFilterDropRulesCounted(t *testing.T) {
 	cfg := hostInboundTestConfig()
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views)
+	payload := buildHostInboundFilterPayload(views, nil, nil)
 
 	for _, fam := range []struct{ family, addr string }{
 		{"ip", "172.16.50.8"},
@@ -187,7 +187,7 @@ func TestHostInboundFilterDropRulesCounted(t *testing.T) {
 func TestHostInboundFilterExemptsIPsecAndV6Errors(t *testing.T) {
 	cfg := hostInboundTestConfig()
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views)
+	payload := buildHostInboundFilterPayload(views, nil, nil)
 
 	espAH := "meta l4proto { 50, 51 } accept"
 	if !strings.Contains(payload, espAH) {
@@ -232,7 +232,7 @@ func TestHostInboundFilterExemptsIPsecAndV6Errors(t *testing.T) {
 func TestHostInboundFilterNoStanzaDefaultDeny(t *testing.T) {
 	cfg := hostInboundTestConfig()
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views)
+	payload := buildHostInboundFilterPayload(views, nil, nil)
 
 	// lan's reth1 address must now be scoped by a catch-all drop.
 	wantDrop := hiDrop("ip", "10.0.61.1", "lan")
@@ -254,7 +254,7 @@ func TestHostInboundFilterNoStanzaDefaultDeny(t *testing.T) {
 func TestHostInboundFilterLifelineNeverDenied(t *testing.T) {
 	cfg := hostInboundTestConfig()
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views)
+	payload := buildHostInboundFilterPayload(views, nil, nil)
 
 	// em0's address (cluster control plane) must never be denied/scoped, even
 	// though the control zone declares a host-inbound stanza.
@@ -286,7 +286,7 @@ func TestHostInboundFilterAllOpensZoneNoDeny(t *testing.T) {
 		},
 	}
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views)
+	payload := buildHostInboundFilterPayload(views, nil, nil)
 	if !strings.Contains(payload, "ip daddr 10.1.1.1 accept") {
 		t.Errorf("`all` zone must accept everything to its addr:\n%s", payload)
 	}
@@ -317,7 +317,7 @@ func TestHostInboundFilterProtocolsAllScopedToRouting(t *testing.T) {
 		},
 	}
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views)
+	payload := buildHostInboundFilterPayload(views, nil, nil)
 
 	// Routing protocols must be accepted: ospf (proto 89), bgp (tcp/179),
 	// vrrp (proto 112).
@@ -371,7 +371,7 @@ func TestHostInboundFilterExplicitSshStillAdmitted(t *testing.T) {
 		},
 	}
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views)
+	payload := buildHostInboundFilterPayload(views, nil, nil)
 
 	if !strings.Contains(payload, "ip daddr 10.3.3.1 tcp dport 22 accept") {
 		t.Errorf("system-services ssh must accept tcp/22:\n%s", payload)
@@ -408,7 +408,7 @@ func TestHostInboundFilterFamilyAware(t *testing.T) {
 		},
 	}
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views)
+	payload := buildHostInboundFilterPayload(views, nil, nil)
 
 	// v4-only tokens accepted under ip, dual-family ssh under both.
 	mustContain := []string{
@@ -477,7 +477,7 @@ func TestHostInboundFilterConfiguredControlInterfaceLifeline(t *testing.T) {
 		},
 	}
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views)
+	payload := buildHostInboundFilterPayload(views, nil, nil)
 
 	// fxp1's control-link address must NEVER appear (accept or drop): it is the
 	// configured cluster control-interface and so a lifeline (#3277).
@@ -657,7 +657,7 @@ func identResetTestConfig() *config.Config {
 func TestHostInboundFilterIdentResetEmitsReset(t *testing.T) {
 	cfg := identResetTestConfig()
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views)
+	payload := buildHostInboundFilterPayload(views, nil, nil)
 
 	// The ident-reset rule must be a reject-with-tcp-reset on TCP/113, per family.
 	mustContain := []string{
@@ -720,7 +720,7 @@ func TestHostInboundFilterAllSuppressesIdentReset(t *testing.T) {
 		},
 	}
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views)
+	payload := buildHostInboundFilterPayload(views, nil, nil)
 
 	if !strings.Contains(payload, "ip daddr 10.1.1.1 accept") {
 		t.Errorf("`all` zone must accept everything to its addr:\n%s", payload)
@@ -793,7 +793,7 @@ func TestHostInboundFilterIdentResetPayloadParses(t *testing.T) {
 		HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ssh"}},
 	}
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views)
+	payload := buildHostInboundFilterPayload(views, nil, nil)
 
 	// Sanity: the raw payload must still carry the #3310 reject rule and the
 	// #3361 named-counter declaration — otherwise the parse check is vacuous.
@@ -838,7 +838,7 @@ func TestHostInboundFilterIdentResetPayloadParses(t *testing.T) {
 func TestHostInboundFilterCounterDeclarationUnquoted(t *testing.T) {
 	cfg := hostInboundTestConfig()
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views)
+	payload := buildHostInboundFilterPayload(views, nil, nil)
 
 	// No QUOTED counter declaration may appear (a reference is `counter name
 	// "<n>"`, never `counter "<n>" {`).

--- a/pkg/daemon/host_inbound_per_iface_3362_test.go
+++ b/pkg/daemon/host_inbound_per_iface_3362_test.go
@@ -38,7 +38,7 @@ func Test_3362_NftScopesPerInterfaceOverride(t *testing.T) {
 		},
 	}
 
-	payload := buildHostInboundFilterPayload(buildAndCheckViews(t, cfg))
+	payload := buildHostInboundFilterPayload(buildAndCheckViews(t, cfg), nil, nil)
 
 	corpDropV4 := "counter name \"" + xnft.HostInboundDenyCounterName("corp", "ip") + "\" drop"
 	mustContain := []string{
@@ -104,7 +104,7 @@ func Test_3362_NftDeclaresEachCounterOnce(t *testing.T) {
 		t.Fatalf("expected >=2 views for zone corp (override + default), got %d", corpViews)
 	}
 
-	payload := buildHostInboundFilterPayload(views)
+	payload := buildHostInboundFilterPayload(views, nil, nil)
 
 	// Each named DROP counter for the zone must be DECLARED exactly once.
 	for _, fam := range []string{"ip", "ip6"} {

--- a/pkg/daemon/host_inbound_unzoned_4420_test.go
+++ b/pkg/daemon/host_inbound_unzoned_4420_test.go
@@ -1,0 +1,92 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	xnft "github.com/psaab/xpf/pkg/nftables"
+)
+
+// hostInboundUnzonedTestConfig extends the shared host-inbound fixture with an
+// addressed interface assigned to NO security zone (#4420 HI-2 fail-open) and an
+// addressed LIFELINE (fab*) also in no zone (must never be denied).
+func hostInboundUnzonedTestConfig() *config.Config {
+	cfg := hostInboundTestConfig()
+	cfg.Interfaces.Interfaces["ge-0/0/9"] = &config.InterfaceConfig{
+		Name: "ge-0/0/9",
+		Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"192.0.2.1/24", "2001:db8:99::1/64"}},
+		},
+	}
+	cfg.Interfaces.Interfaces["fab5"] = &config.InterfaceConfig{
+		Name: "fab5",
+		Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.5.5.5/24"}},
+		},
+	}
+	return cfg
+}
+
+// TestHostInboundUnzonedInterfaceDenied is the #4420 HI-2 fail-on-revert proof:
+// the kernel host-inbound chain emits a catch-all DROP scoping the firewall-local
+// addresses of an addressed-but-unzoned interface (counted under the reserved
+// junos-host sentinel), so host-bound traffic to it is denied by default instead
+// of falling through the chain's `policy accept` to the host stack (the fail-open,
+// and a deviation from Junos where an unzoned interface passes no traffic). A
+// ZONED address must not leak into that deny, and an unzoned LIFELINE must never
+// be denied. Reverting emitUnzonedHostInboundDeny (or BuildUnzonedHostInboundAddrs)
+// turns this RED.
+func TestHostInboundUnzonedInterfaceDenied(t *testing.T) {
+	cfg := hostInboundUnzonedTestConfig()
+	views := dpuserspace.BuildZoneHostInboundViews(cfg)
+	v4, v6 := dpuserspace.BuildUnzonedHostInboundAddrs(cfg)
+	payload := buildHostInboundFilterPayload(views, v4, v6)
+
+	sentinel := dpuserspace.UnzonedHostInboundZoneLabel
+	wantV4 := hiDrop("ip", "192.0.2.1", sentinel)
+	wantV6 := hiDrop("ip6", "2001:db8:99::1", sentinel)
+	for _, want := range []string{
+		wantV4, wantV6,
+		"counter " + xnft.HostInboundDenyCounterName(sentinel, "ip") + " {",
+		"counter " + xnft.HostInboundDenyCounterName(sentinel, "ip6") + " {",
+	} {
+		if !strings.Contains(payload, want) {
+			t.Errorf("payload missing unzoned host-inbound deny %q\n---\n%s", want, payload)
+		}
+	}
+
+	// The LIFELINE (fab5) address must NEVER be denied.
+	if strings.Contains(payload, "10.5.5.5") {
+		t.Errorf("payload denies a LIFELINE (fab5) unzoned address 10.5.5.5:\n%s", payload)
+	}
+	// A ZONED address (wan reth0.50) must not appear under the unzoned sentinel.
+	if strings.Contains(payload, hiDrop("ip", "172.16.50.8", sentinel)) {
+		t.Errorf("zoned wan address leaked into the unzoned deny:\n%s", payload)
+	}
+
+	// The global established accept must precede the unzoned catch-all drop, so
+	// ND / PMTUD / established / ESP still work on an unzoned interface.
+	if idxDrop := strings.Index(payload, wantV4); idxDrop >= 0 {
+		if idxEstab := strings.Index(payload, "ct state established,related accept"); idxEstab < 0 || idxEstab > idxDrop {
+			t.Errorf("established accept must precede the unzoned catch-all drop:\n%s", payload)
+		}
+	}
+}
+
+// TestHostInboundUnzonedNoZonesNoTable asserts a config with unzoned addressed
+// interfaces but ZERO security zones emits no unzoned deny (the builder is a
+// no-op without the zone model), so a bootstrap/zoneless box is never turned
+// into deny-all host-inbound (#4420 HI-2 scope guard).
+func TestHostInboundUnzonedNoZonesNoTable(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0/0/9": {Name: "ge-0/0/9", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"192.0.2.1/24"}},
+		}},
+	}
+	if v4, v6 := dpuserspace.BuildUnzonedHostInboundAddrs(cfg); v4 != nil || v6 != nil {
+		t.Fatalf("zoneless config must yield no unzoned deny, got v4=%v v6=%v", v4, v6)
+	}
+}

--- a/pkg/daemon/nft_chain_priority_test.go
+++ b/pkg/daemon/nft_chain_priority_test.go
@@ -54,7 +54,7 @@ func TestNftLocalDeliveryChainsDistinctPriority(t *testing.T) {
 	// views. Use a representative enforced config so the rendered table is the
 	// real commit-time shape.
 	views := buildAndCheckViews(t, hostInboundTestConfig())
-	hiPayload := buildHostInboundFilterPayload(views)
+	hiPayload := buildHostInboundFilterPayload(views, nil, nil)
 	hiPri := nftHookInputPriority(t, "host-inbound", hiPayload)
 
 	if lo0Pri == hiPri {

--- a/pkg/dataplane/userspace/host_inbound_unzoned_4420_test.go
+++ b/pkg/dataplane/userspace/host_inbound_unzoned_4420_test.go
@@ -1,0 +1,66 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func sliceHas(s []string, v string) bool {
+	for _, e := range s {
+		if e == v {
+			return true
+		}
+	}
+	return false
+}
+
+// TestBuildUnzonedHostInboundAddrs is the #4420 HI-2 fail-on-revert proof for the
+// builder: an interface that carries an address but is assigned to NO security
+// zone contributes its firewall-local addresses to the unzoned host-inbound deny
+// set, a zoned interface's address does NOT, and an unzoned LIFELINE (fab*) is
+// excluded so management is never denied. Reverting BuildUnzonedHostInboundAddrs
+// (returning nil) turns the "present" assertions RED.
+func TestBuildUnzonedHostInboundAddrs(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		// zoned data interface (its addr must NOT appear in the unzoned deny).
+		"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.1.10/24"}},
+		}},
+		// addressed interface in NO zone — the fail-open HI-2 closes.
+		"ge-0/0/9": {Name: "ge-0/0/9", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"192.0.2.1/24", "2001:db8:99::1/64"}},
+		}},
+		// addressed LIFELINE in no zone — must be excluded (fab* prefix).
+		"fab5": {Name: "fab5", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.5.5.5/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		// no host-inbound stanza => #3405 default-deny still scopes 10.0.1.10.
+		"trust": {Name: "trust", Interfaces: []string{"ge-0/0/0.0"}},
+	}
+
+	v4, v6 := BuildUnzonedHostInboundAddrs(cfg)
+	if !sliceHas(v4, "192.0.2.1") {
+		t.Errorf("unzoned v4 addr 192.0.2.1 missing from unzoned deny set: %v", v4)
+	}
+	if !sliceHas(v6, "2001:db8:99::1") {
+		t.Errorf("unzoned v6 addr 2001:db8:99::1 missing from unzoned deny set: %v", v6)
+	}
+	if sliceHas(v4, "10.0.1.10") {
+		t.Errorf("ZONED addr 10.0.1.10 must not be in the unzoned deny set: %v", v4)
+	}
+	if sliceHas(v4, "10.5.5.5") {
+		t.Errorf("LIFELINE addr 10.5.5.5 must not be in the unzoned deny set: %v", v4)
+	}
+
+	// A zone-less / bootstrap config must yield NO unzoned deny (never turns a
+	// no-zones box into deny-all host-inbound).
+	nozone := &config.Config{}
+	nozone.Interfaces.Interfaces = cfg.Interfaces.Interfaces
+	if nv4, nv6 := BuildUnzonedHostInboundAddrs(nozone); nv4 != nil || nv6 != nil {
+		t.Errorf("zoneless config must yield no unzoned deny, got v4=%v v6=%v", nv4, nv6)
+	}
+}

--- a/pkg/dataplane/userspace/zones.go
+++ b/pkg/dataplane/userspace/zones.go
@@ -324,6 +324,91 @@ func BuildZoneHostInboundViews(cfg *config.Config) []ZoneHostInboundView {
 	return out
 }
 
+// UnzonedHostInboundZoneLabel is the sentinel zone label under which the kernel
+// host-inbound catch-all deny for firewall-local addresses on interfaces
+// assigned to NO security zone is counted (#4420 HI-2). It reuses the reserved
+// Junos self-traffic context token "junos-host": that token can NEVER name an
+// operator-defined security zone (validateReservedZoneNamesStrict rejects it),
+// so the nft named-counter object it yields (nftables.HostInboundDenyCounterName)
+// can never collide with a real per-zone deny counter, and the #3361 scraper
+// (ParseHostInboundDenyCounterName) recovers a stable, self-explanatory
+// zone="junos-host" label for these "traffic to the host with no source zone"
+// host-inbound drops.
+const UnzonedHostInboundZoneLabel = "junos-host"
+
+// BuildUnzonedHostInboundAddrs returns the firewall-local host addresses (bare
+// IPs, prefix stripped, split by family) of interfaces that carry an address but
+// are assigned to NO security zone (#4420 HI-2).
+//
+// xpfd applies an interface's configured / leased address regardless of zone
+// membership (pkg/dataplane/compiler_iface.go builds the networkd managed set
+// from cfg.Interfaces, not from zones), yet BuildZoneHostInboundViews scopes the
+// kernel host-inbound default-deny ONLY to ZONED addresses. The kernel
+// `xpf_hostinbound` chain runs with `policy accept`, so host-bound traffic to an
+// addressed-but-unzoned interface falls through to accept — the host stack is
+// exposed on it with no host-inbound admission. That is a fail-open, and a
+// deviation from Junos, where an interface not in a security zone passes no
+// flow / host-inbound traffic at all. This builder collects those addresses so
+// the daemon can emit a catch-all DROP scoping them, restoring the Junos
+// fail-closed posture and mirroring the #3405 per-zone default-deny.
+//
+// Scope / safety:
+//   - Only meaningful when the operator uses the zone model at all (>= 1 zone):
+//     a zone-less bootstrap / degenerate config is left untouched (nil), so this
+//     never turns a no-zones box into deny-all host-inbound.
+//   - Management / cluster-control LIFELINE interfaces (fxp0 / em0 / fab*, plus
+//     the configured control / fabric links) are excluded exactly as the zone
+//     path excludes them, so the deny can never strand management or break HA.
+//   - Addresses already scoped by a zone view are subtracted, so a (mis)config
+//     placing one firewall-local address on both a zoned and an unzoned
+//     interface never yields a duplicate / conflicting rule for the same daddr.
+//   - Unzoned interfaces are NOT AF_XDP-bound (only zoned dataplane interfaces
+//     get the shim), so their host-bound traffic is delivered entirely through
+//     the kernel; the kernel nft deny is the sole and sufficient enforcement
+//     point and no userspace-dp (AF_XDP) change is required.
+func BuildUnzonedHostInboundAddrs(cfg *config.Config) (v4, v6 []string) {
+	if cfg == nil || len(cfg.Security.Zones) == 0 || len(cfg.Interfaces.Interfaces) == 0 {
+		return nil, nil
+	}
+	lifelines := hostInboundLifelineSet(cfg)
+	// Addresses already covered by a zone deny — exclude so the unzoned catch-all
+	// never duplicates or conflicts with a zone rule for the same daddr.
+	zoned := map[string]bool{}
+	for _, view := range BuildZoneHostInboundViews(cfg) {
+		for _, a := range view.V4Addrs {
+			zoned[a] = true
+		}
+		for _, a := range view.V6Addrs {
+			zoned[a] = true
+		}
+	}
+	seen4 := map[string]bool{}
+	seen6 := map[string]bool{}
+	for _, snap := range buildInterfaceSnapshots(cfg) {
+		if snap.Zone != "" || hostInboundLifelineInterface(snap.Name, lifelines) {
+			continue
+		}
+		for _, a := range snap.Addresses {
+			host := hostIPFromCIDR(a.Address)
+			if host == "" || zoned[host] {
+				continue
+			}
+			if strings.Contains(host, ":") {
+				if !seen6[host] {
+					seen6[host] = true
+					v6 = append(v6, host)
+				}
+			} else if !seen4[host] {
+				seen4[host] = true
+				v4 = append(v4, host)
+			}
+		}
+	}
+	sort.Strings(v4)
+	sort.Strings(v6)
+	return v4, v6
+}
+
 // AddresslessEnforcingZone names a configured host-inbound-ENFORCING security
 // zone that currently resolves NO firewall-local address across its non-lifeline
 // interfaces (#3698). Such a zone contributes nothing to the kernel-nft


### PR DESCRIPTION
Closes the **HI-2** host-inbound fail-open from the #4420 fable-171 HI cluster; **HI-1** verified genuine but deferred (needs a per-zone iifname multicast-admission design + Rust lockstep).

## HI-2 — addressed-but-unzoned interface has no host-inbound default-deny (GENUINE, fixed)

An interface that carries an address but is assigned to **no security zone** has its address applied to the kernel (the networkd managed set is built from `cfg.Interfaces`, not from zones — `pkg/dataplane/compiler_iface.go`) yet is **not** scoped by any per-zone host-inbound deny. The kernel `xpf_hostinbound` chain runs with `policy accept` and drops only to zoned addresses (`daemon_nft.go`), so host-bound traffic to the unzoned interface falls through to the host stack with **no host-inbound admission** — a fail-open, and a deviation from Junos (an interface not in a zone passes no flow / host-inbound traffic).

**Verify-first — reachable, and reject ruled out:** no commit gate rejects the state (`show security zones` even renders `Interface X is not assigned to any security zone`), and a strict commit-reject is a non-starter — 21+ existing `pkg/config` tests and normal operator workflows legitimately set an interface address before/without zoning it, so a hard reject would be a mass false-positive. The Junos-parity fix is therefore a **runtime default-deny**, mirroring the #3405 per-zone default-deny.

**Fix**
- `userspace.BuildUnzonedHostInboundAddrs(cfg)` collects the firewall-local addresses of non-lifeline interfaces in no zone. Zoned addresses subtracted (no duplicate/conflicting `daddr` rule); lifelines (fxp0 / em0 / fab* + configured control/fabric) excluded so management/HA is never stranded; no-op unless the zone model is in use (≥1 zone) so a bootstrap/zoneless box is untouched.
- `buildHostInboundFilterPayload` emits a catch-all DROP scoping those addresses (`emitUnzonedHostInboundDeny`), **after** the global established / ESP-AH / ND / PMTUD accepts so those still work on an unzoned interface, counted under the reserved `junos-host` sentinel label so the #3361 scraper surfaces it as `zone="junos-host"`.

**Kernel-only:** unzoned interfaces are not AF_XDP-bound, so the kernel nft deny is the sole/sufficient enforcement point — no userspace-dp / Rust change.

## HI-1 — host-bound multicast/broadcast bypasses the protocols gate (GENUINE, deferred)

The same chain matches destination address only, so host-bound **multicast/broadcast** (OSPF/RIP/VRRP/PIM link-local groups, limited/directed broadcast) is not scoped by any `daddr` set and falls through `policy accept`, bypassing per-zone host-inbound protocols admission. The Rust LocalDelivery classifier keys on local **unicast** addresses only, so it does not gate multicast either.

Deferred (not force-folded): the correct fix needs **per-zone ingress-interface (`iifname`) multicast admission in lockstep with the Rust classifier**, and it is a **behavior/hardening change** — a zone running a routing protocol in FRR without the matching `host-inbound-traffic protocols` knob relies on today's accept. Documented as a known limitation in `pkg/daemon/README.md`; a follow-up issue tracks the design.

## Validation
- New RED-on-revert tests: `pkg/dataplane/userspace/host_inbound_unzoned_4420_test.go`, `pkg/daemon/host_inbound_unzoned_4420_test.go`. Neutering `emitUnzonedHostInboundDeny` fails the payload assertions (verified).
- Touched Go suites green (daemon, dataplane/userspace, config, nftables); `go build ./...`, gofmt + vet clean on touched files.
- Docs: `pkg/daemon/README.md` host-inbound section (HI-2 behavior + HI-1 limitation), `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi