### PR TITLE
userspace-dp FIB: table-scope static bare-gateway ifindex inference (#4446)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -38435,3 +38435,49 @@ top.
   pkg/config/compiler_validate_strict_chassis_4434_test.go,
   pkg/config/compiler.go, pkg/cluster/heartbeat.go,
   pkg/cluster/heartbeat_rg_cap_4434_test.go, docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4446 — table-scope the userspace-dp FIB static bare-gateway
+  next-hop ifindex inference (audit #4423 M3, GENUINE HIGH).
+  - **Root cause**: `infer_connected_route_target_v4`/`_v6`
+    (`userspace-dp/src/afxdp/forwarding_build/fib.rs`) scanned
+    `state.connected_v[46]` GLOBALLY, returning the first
+    `prefix.contains(gateway)` match regardless of table. The wrong ifindex
+    was baked into `RouteEntryV*.next_hops` at BUILD time and consumed
+    verbatim at lookup (`forwarding/mod.rs`, `ResolvedRouteV*::Static` arm),
+    so the #2388 lookup-time connected filter could not correct it → in a
+    multi-VRF setup with overlapping gateway subnets a route in VRF A could
+    egress on VRF B's interface. Two `fib.rs` doc comments contradicted.
+  - **Fix**: thread the route's canonical install table
+    (`canonical_route_table(&route.table, is_ipv6)`, computed in
+    `populate_routes` BEFORE next-hop resolution) through
+    `resolve_route_next_hops_v[46]` → `resolve_next_hop_target_v[46]` →
+    `infer_connected_route_target_v[46]`, and filter the connected scan on
+    `entry.table == table` (mirrors the #2388 lookup-site predicate at build
+    time so the correct ifindex is baked in). Cross-table leak preserved: a
+    route-leak / next-table reach is a `NextTable` snapshot with no
+    forwarding next-hop, so it never touches this inference (re-resolved in
+    the target table by the recursion). Reconciled both contradicting
+    `fib.rs` doc comments + the `forwarding/README.md` "stays global" note.
+  - **RED-on-revert**: `static_bare_gateway_infers_ifindex_in_own_table_v4`
+    / `_v6` — two instances ("red"/"blue") own the same 192.168.0.0/24 (and
+    2001:db8::/64); "blue" leads the scan order, so the global scan bound
+    blue's ifindex 102 into red's route (assert 101 → RED). Verified by
+    temporarily reverting the filter: both fail (left 102, right 101);
+    `static_bare_gateway_single_table_still_resolves` stays green
+    (single-table + next-table leak unaffected). `native_gre*` fixtures made
+    config-realistic (GRE inner iface `routing_instance = "sfmix"`); test B
+    `owner_rg_for_resolution_uses_native_gre_endpoint_group` resolves in
+    `sfmix.inet.0`.
+  - **Validation**: FULL `cargo test --release -- --test-threads=1` = 3744
+    passed / 0 failed / 2 ignored (3659 main bin + 54 + 8 + 22 + 1);
+    fib/forwarding/tunnel subset 127/0. rustfmt applied to changed lines
+    (edition-2024; reverted the two unrelated pre-existing whole-file drifts
+    in fib.rs). NOTE: multi-VRF routing change — a routing smoke /
+    `make test-failover` is warranted (dataplane forwarding path).
+- **File(s)**: userspace-dp/src/afxdp/forwarding_build/fib.rs,
+  userspace-dp/src/afxdp/forwarding_build/tests.rs,
+  userspace-dp/src/afxdp/forwarding/README.md,
+  userspace-dp/src/afxdp/test_fixtures.rs,
+  userspace-dp/src/afxdp/frame/tests.rs,
+  docs/rib-group-route-leaking.md, _Log.md

--- a/docs/rib-group-route-leaking.md
+++ b/docs/rib-group-route-leaking.md
@@ -113,7 +113,32 @@ Rust FIB (`userspace-dp/src/afxdp/forwarding_build/fib.rs`,
 `userspace-dp/src/afxdp/forwarding/mod.rs`) — **not** `pkg/routing` (which owns
 netlink VRF/tunnel/ip-rule reconciliation, not FIB next-hop resolution).
 
-### M3 — static next-hop gateway inference is global, not table-scoped — GENUINE (deferred to a Rust slice)
+### M3 — static next-hop gateway inference is global, not table-scoped — FIXED (#4446)
+
+**Resolved in #4446.** The build-time inference is now table-scoped: the
+route's canonical install table is threaded from `populate_routes` through
+`resolve_route_next_hops_v[46]` → `resolve_next_hop_target_v[46]` →
+`infer_connected_route_target_v[46]`, which filters the connected scan on
+`entry.table == table` (mirroring the #2388 lookup-site predicate, but at
+BUILD time so the correct ifindex is baked into `RouteEntryV*.next_hops`).
+The two contradictory `fib.rs` doc comments are reconciled (both now state
+the inference is table-scoped) and the `forwarding/README.md` "stays global"
+note is corrected. A route-leak / `next-table` cross-VRF reach is unaffected
+— a leaked route is a `NextTable` snapshot with no forwarding next-hop, so
+it never touches this inference and is re-resolved in the target table's own
+scope by the recursion. Locked by
+`static_bare_gateway_infers_ifindex_in_own_table_v4` / `_v6` (RED on the
+global scan: with "blue" leading the scan order, red's route bound blue's
+ifindex 102 instead of red's 101) plus the
+`static_bare_gateway_single_table_still_resolves` anti-regression
+(`forwarding_build/tests.rs`). The `native_gre*` fixtures were made
+config-realistic — the GRE inner interface now carries
+`routing_instance = "sfmix"`, so its connected /30 lands in `sfmix.inet.0`,
+the same table as the bare-gateway route it backs.
+
+The original triage write-up follows.
+
+
 
 `resolve_route_next_hops_v4` / `resolve_route_next_hops_v6` resolve a static
 route's egress ifindex at FIB-build time. When a next-hop carries an explicit

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -41,10 +41,19 @@ Route metadata crosses the Go→Rust snapshot boundary as `RouteSnapshot`
   `routing_instance` (`""` = default → `inet.0`/`inet6.0`; a named
   instance → `<ri>.inet.0`/`<ri>.inet6.0`). The lookup filters connected
   candidates on the resolving table, so a per-VRF / `next-table` lookup
-  never matches another routing-instance's connected prefix. (Gateway →
-  egress inference at build time, `infer_connected_route_target_*`,
-  stays global — that resolves "which interface reaches this gateway IP",
-  not a destination egress.)
+  never matches another routing-instance's connected prefix. Gateway →
+  egress inference at build time (`infer_connected_route_target_*`,
+  "which interface reaches this bare-gateway IP") is **also** table-scoped
+  (#4446): it filters `connected_v[46]` on the route's own canonical
+  install table before the prefix match, so a bare-gateway static route in
+  VRF A never binds VRF B's overlapping connected prefix. The inferred
+  ifindex is baked into `RouteEntryV*.next_hops` and consumed verbatim at
+  lookup, so this scoping MUST happen at build time — the lookup-time
+  #2388 connected filter cannot re-scope an already-resolved next-hop. A
+  route-leak / `next-table` cross-VRF reach is unaffected: a leaked route
+  carries no forwarding next-hop (it is a `NextTable` snapshot), so it
+  never reaches this inference and is re-resolved in the target table's
+  own scope by the recursion.
   - **Local-delivery (to-self) attribution is table-scoped too (#3151).**
     The `lookup_forwarding_resolution_inner_ecmp` shortcut for a
     destination in `local_v[46]` resolves `local_ifindex` /

--- a/userspace-dp/src/afxdp/forwarding_build/fib.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/fib.rs
@@ -65,13 +65,19 @@ pub(super) fn populate_routes(
                     family: route.family.clone(),
                 });
             }
+            // #4446: compute the route's canonical install table BEFORE
+            // resolving its next-hops, so a bare-gateway static route infers
+            // its egress ifindex ONLY from a connected prefix in its OWN
+            // table (mirrors the #2388 lookup-site connected filter, but at
+            // BUILD time so the correct ifindex is baked into RouteEntryV4).
+            let table = canonical_route_table(&route.table, false);
             let next_hops = resolve_route_next_hops_v4(
                 route,
                 &iface_ctx.name_to_ifindex,
                 &iface_ctx.linux_to_ifindex,
                 state,
+                &table,
             );
-            let table = canonical_route_table(&route.table, false);
             state
                 .routes_v4
                 .entry(table)
@@ -95,13 +101,17 @@ pub(super) fn populate_routes(
                     family: route.family.clone(),
                 });
             }
+            // #4446: canonical install table computed before next-hop
+            // resolution (see the v4 arm) so the connected-prefix inference
+            // is scoped to the route's own table.
+            let table = canonical_route_table(&route.table, true);
             let next_hops = resolve_route_next_hops_v6(
                 route,
                 &iface_ctx.name_to_ifindex,
                 &iface_ctx.linux_to_ifindex,
                 state,
+                &table,
             );
-            let table = canonical_route_table(&route.table, true);
             state
                 .routes_v6
                 .entry(table)
@@ -259,15 +269,20 @@ pub(super) fn populate_fabrics(
 /// forwarding next-hop (returns empty). Each candidate resolves its egress
 /// ifindex from an explicit `@interface` spec, else by inferring the
 /// connected interface that contains the gateway IP — scoped to the
-/// route's own table (#2388) so a gateway is never resolved against
-/// another routing-instance's connected prefix. Candidates whose interface
-/// fails to resolve are still retained with ifindex 0 (matching the
-/// pre-#2389 single-next-hop fallback, which kept next_hop with ifindex 0).
+/// route's own canonical `table` (#4446) so a gateway is never resolved
+/// against another routing-instance's overlapping connected prefix. This
+/// mirrors the #2388 lookup-site connected filter, applied here at BUILD
+/// time so the correct ifindex is baked into `RouteEntryV4.next_hops` (the
+/// lookup consumes `nh.ifindex` verbatim, so a wrong build-time bind could
+/// not be corrected at lookup). Candidates whose interface fails to resolve
+/// are still retained with ifindex 0 (matching the pre-#2389 single-next-hop
+/// fallback, which kept next_hop with ifindex 0).
 pub(in crate::afxdp) fn resolve_route_next_hops_v4(
     route: &RouteSnapshot,
     names: &BTreeMap<String, i32>,
     linux_names: &BTreeMap<String, i32>,
     state: &ForwardingState,
+    table: &str,
 ) -> Vec<RouteNextHopV4> {
     if route.discard || !route.next_table.is_empty() {
         return Vec::new();
@@ -283,6 +298,7 @@ pub(in crate::afxdp) fn resolve_route_next_hops_v4(
                 names,
                 linux_names,
                 state,
+                table,
             );
             RouteNextHopV4 {
                 next_hop,
@@ -293,11 +309,16 @@ pub(in crate::afxdp) fn resolve_route_next_hops_v4(
         .collect()
 }
 
+/// #2389/#4446: v6 twin of [`resolve_route_next_hops_v4`]. `table` is the
+/// route's canonical install table; a bare-gateway static route infers its
+/// egress ifindex only from a connected prefix in that table (never a
+/// different routing-instance's overlapping prefix).
 pub(in crate::afxdp) fn resolve_route_next_hops_v6(
     route: &RouteSnapshot,
     names: &BTreeMap<String, i32>,
     linux_names: &BTreeMap<String, i32>,
     state: &ForwardingState,
+    table: &str,
 ) -> Vec<RouteNextHopV6> {
     if route.discard || !route.next_table.is_empty() {
         return Vec::new();
@@ -313,6 +334,7 @@ pub(in crate::afxdp) fn resolve_route_next_hops_v6(
                 names,
                 linux_names,
                 state,
+                table,
             );
             RouteNextHopV6 {
                 next_hop,
@@ -329,6 +351,7 @@ fn resolve_next_hop_target_v4(
     names: &BTreeMap<String, i32>,
     linux_names: &BTreeMap<String, i32>,
     state: &ForwardingState,
+    table: &str,
 ) -> (i32, u16) {
     interface
         .and_then(|name| resolve_ifindex(name, names, linux_names))
@@ -342,7 +365,7 @@ fn resolve_next_hop_target_v4(
                     .unwrap_or(0),
             )
         })
-        .or_else(|| next_hop.and_then(|ip| infer_connected_route_target_v4(state, ip)))
+        .or_else(|| next_hop.and_then(|ip| infer_connected_route_target_v4(state, ip, table)))
         .unwrap_or((0, 0))
 }
 
@@ -352,6 +375,7 @@ fn resolve_next_hop_target_v6(
     names: &BTreeMap<String, i32>,
     linux_names: &BTreeMap<String, i32>,
     state: &ForwardingState,
+    table: &str,
 ) -> (i32, u16) {
     interface
         .and_then(|name| resolve_ifindex(name, names, linux_names))
@@ -365,7 +389,7 @@ fn resolve_next_hop_target_v6(
                     .unwrap_or(0),
             )
         })
-        .or_else(|| next_hop.and_then(|ip| infer_connected_route_target_v6(state, ip)))
+        .or_else(|| next_hop.and_then(|ip| infer_connected_route_target_v6(state, ip, table)))
         .unwrap_or((0, 0))
 }
 
@@ -421,28 +445,39 @@ pub(in crate::afxdp) fn resolve_ifindex(
 pub(in crate::afxdp) fn infer_connected_route_target_v4(
     state: &ForwardingState,
     ip: Ipv4Addr,
+    table: &str,
 ) -> Option<(i32, u16)> {
-    // Gateway -> egress-interface inference at FIB-build time: "which
-    // interface can reach this next-hop gateway IP". This is a global
-    // connected-prefix match and is intentionally NOT table-scoped — a
-    // route's configured gateway resolves to whatever connected interface
-    // contains it. The #2388 cross-VRF leak is a LOOKUP-time concern
-    // (which connected prefix a destination egresses on) and is fixed at
-    // the lookup site by filtering connected_v4 on the resolving table.
+    // #4446: Gateway -> egress-interface inference at FIB-build time:
+    // "which interface in the ROUTE'S OWN table can reach this next-hop
+    // gateway IP". The connected scan is filtered on `entry.table == table`
+    // (the canonical install table threaded from `populate_routes`),
+    // mirroring the #2388 lookup-site connected filter. Without the filter
+    // the scan was GLOBAL and a bare-gateway static route in VRF A could
+    // bind VRF B's overlapping connected prefix -> cross-VRF wrong egress:
+    // the inferred ifindex is baked into `RouteEntryV4.next_hops` and used
+    // verbatim at lookup, so the lookup-time #2388 filter could NOT correct
+    // it. A route-leak / next-table cross-VRF reach is not affected: a
+    // leaked route is emitted as a `NextTable` snapshot with no forwarding
+    // next-hop (never reaches this inference), and the recursion re-resolves
+    // in the target table's own scope. `connected_v4` is sorted
+    // longest-prefix-first, so the first in-table match is the most specific.
     state
         .connected_v4
         .iter()
-        .find(|entry| entry.prefix.contains(ip))
+        .find(|entry| entry.table == table && entry.prefix.contains(ip))
         .map(|entry| (entry.ifindex, entry.tunnel_endpoint_id))
 }
 
 pub(in crate::afxdp) fn infer_connected_route_target_v6(
     state: &ForwardingState,
     ip: Ipv6Addr,
+    table: &str,
 ) -> Option<(i32, u16)> {
+    // #4446: table-scoped gateway inference — see
+    // `infer_connected_route_target_v4` for the full rationale.
     state
         .connected_v6
         .iter()
-        .find(|entry| entry.prefix.contains(ip))
+        .find(|entry| entry.table == table && entry.prefix.contains(ip))
         .map(|entry| (entry.ifindex, entry.tunnel_endpoint_id))
 }

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -2597,6 +2597,230 @@ fn route_nonnegative_preference_builds() {
     .expect("non-negative preferences must build");
 }
 
+// ---------------------------------------------------------------------
+// #4446: static bare-gateway next-hop ifindex inference is table-scoped.
+// A bare-gateway static route infers its egress ifindex ONLY from a
+// connected prefix in the route's OWN routing-instance table, never a
+// different instance's overlapping connected prefix. Reverting the fix
+// restores the GLOBAL connected scan, which binds the first
+// prefix.contains() match regardless of table -> cross-VRF wrong egress.
+// ---------------------------------------------------------------------
+
+/// #4446: two routing instances ("red", "blue") own the SAME connected
+/// subnet 192.168.0.0/24 on different interfaces (a normal reason to use
+/// VRFs). A bare-gateway static route in each instance resolves its gateway
+/// to its OWN instance's interface at FIB-build time.
+///
+/// RED-on-revert: the pre-#4446 global `connected_v4` scan returns the FIRST
+/// `prefix.contains()` match. "blue" is inserted first, so the global scan
+/// binds blue's ifindex (102) into red's route — this `assert_eq!(101)`
+/// goes red. The single-table case is unaffected (each route already
+/// resolves to the sole in-table connected interface); only the
+/// overlapping-VRF case regresses.
+#[test]
+fn static_bare_gateway_infers_ifindex_in_own_table_v4() {
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![
+            // BLUE inserted FIRST so its connected prefix LEADS the global
+            // scan order — the pre-fix global inference would bind it to
+            // red's route. The table-scoped fix filters it out for red.
+            InterfaceSnapshot {
+                name: "ge-0-0-2".into(),
+                ifindex: 102,
+                routing_instance: "blue".into(),
+                hardware_addr: "02:00:00:00:00:02".into(),
+                addresses: vec![crate::protocol::snapshot::InterfaceAddressSnapshot {
+                    family: "inet".into(),
+                    address: "192.168.0.2/24".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            InterfaceSnapshot {
+                name: "ge-0-0-1".into(),
+                ifindex: 101,
+                routing_instance: "red".into(),
+                hardware_addr: "02:00:00:00:00:01".into(),
+                addresses: vec![crate::protocol::snapshot::InterfaceAddressSnapshot {
+                    family: "inet".into(),
+                    address: "192.168.0.1/24".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        ],
+        routes: vec![
+            // Bare-gateway static route in RED; gateway 192.168.0.254 is in
+            // BOTH instances' overlapping 192.168.0.0/24.
+            crate::RouteSnapshot {
+                table: "red.inet.0".into(),
+                family: "inet".into(),
+                destination: "10.0.0.0/8".into(),
+                next_hops: vec!["192.168.0.254".into()],
+                ..Default::default()
+            },
+            // ...and in BLUE, same gateway, different instance.
+            crate::RouteSnapshot {
+                table: "blue.inet.0".into(),
+                family: "inet".into(),
+                destination: "10.0.0.0/8".into(),
+                next_hops: vec!["192.168.0.254".into()],
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    let state = build_forwarding_state(&snapshot);
+
+    let red = state.routes_v4.get("red.inet.0").expect("red.inet.0 table");
+    assert_eq!(
+        red[0].next_hops[0].ifindex, 101,
+        "red's bare-gateway route must egress red's interface, not blue's overlapping prefix"
+    );
+
+    let blue = state
+        .routes_v4
+        .get("blue.inet.0")
+        .expect("blue.inet.0 table");
+    assert_eq!(
+        blue[0].next_hops[0].ifindex, 102,
+        "blue's bare-gateway route must egress blue's interface"
+    );
+}
+
+/// #4446: v6 twin — the same table-scoped inference for IPv6 bare-gateway
+/// routes (`infer_connected_route_target_v6`). "blue" leads the global scan;
+/// red's route must still bind red's ifindex.
+#[test]
+fn static_bare_gateway_infers_ifindex_in_own_table_v6() {
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![
+            InterfaceSnapshot {
+                name: "ge-0-0-2".into(),
+                ifindex: 102,
+                routing_instance: "blue".into(),
+                hardware_addr: "02:00:00:00:00:02".into(),
+                addresses: vec![crate::protocol::snapshot::InterfaceAddressSnapshot {
+                    family: "inet6".into(),
+                    address: "2001:db8::2/64".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            InterfaceSnapshot {
+                name: "ge-0-0-1".into(),
+                ifindex: 101,
+                routing_instance: "red".into(),
+                hardware_addr: "02:00:00:00:00:01".into(),
+                addresses: vec![crate::protocol::snapshot::InterfaceAddressSnapshot {
+                    family: "inet6".into(),
+                    address: "2001:db8::1/64".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        ],
+        routes: vec![
+            crate::RouteSnapshot {
+                table: "red.inet6.0".into(),
+                family: "inet6".into(),
+                destination: "2001:db8:beef::/48".into(),
+                next_hops: vec!["2001:db8::254".into()],
+                ..Default::default()
+            },
+            crate::RouteSnapshot {
+                table: "blue.inet6.0".into(),
+                family: "inet6".into(),
+                destination: "2001:db8:beef::/48".into(),
+                next_hops: vec!["2001:db8::254".into()],
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    let state = build_forwarding_state(&snapshot);
+
+    let red = state
+        .routes_v6
+        .get("red.inet6.0")
+        .expect("red.inet6.0 table");
+    assert_eq!(
+        red[0].next_hops[0].ifindex, 101,
+        "red's v6 bare-gateway route must egress red's interface"
+    );
+
+    let blue = state
+        .routes_v6
+        .get("blue.inet6.0")
+        .expect("blue.inet6.0 table");
+    assert_eq!(
+        blue[0].next_hops[0].ifindex, 102,
+        "blue's v6 bare-gateway route must egress blue's interface"
+    );
+}
+
+/// #4446 anti-regression: the common single-table (default-instance) case is
+/// unaffected — a bare-gateway static route still resolves its gateway to the
+/// sole connected interface. A legitimate cross-table reach is expressed as a
+/// `next-table` route (no forwarding next-hop, so it never touches this
+/// inference) and is likewise unaffected: its `next_hops` stay empty.
+#[test]
+fn static_bare_gateway_single_table_still_resolves() {
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "ge-0-0-1".into(),
+            ifindex: 201,
+            hardware_addr: "02:00:00:00:02:01".into(),
+            addresses: vec![crate::protocol::snapshot::InterfaceAddressSnapshot {
+                family: "inet".into(),
+                address: "192.168.0.1/24".into(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+        routes: vec![
+            crate::RouteSnapshot {
+                table: "inet.0".into(),
+                family: "inet".into(),
+                destination: "10.0.0.0/8".into(),
+                next_hops: vec!["192.168.0.254".into()],
+                ..Default::default()
+            },
+            // A next-table leak: no forwarding next-hop, so the inference is
+            // never exercised and `next_hops` stays empty.
+            crate::RouteSnapshot {
+                table: "inet.0".into(),
+                family: "inet".into(),
+                destination: "172.16.0.0/12".into(),
+                next_table: "blue.inet.0".into(),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    let state = build_forwarding_state(&snapshot);
+    let table = state.routes_v4.get("inet.0").expect("inet.0 table");
+    let bare = table
+        .iter()
+        .find(|r| r.prefix.contains("10.0.0.0".parse().unwrap()))
+        .expect("bare-gateway route");
+    assert_eq!(
+        bare.next_hops[0].ifindex, 201,
+        "single-table bare-gateway route still resolves to its connected interface"
+    );
+    let leak = table
+        .iter()
+        .find(|r| !r.next_table.is_empty())
+        .expect("next-table route");
+    assert!(
+        leak.next_hops.is_empty(),
+        "a next-table leak carries no forwarding next-hop (inference untouched)"
+    );
+}
+
 /// #3771 (M11): a neighbor declaring family="inet" with an IPv6 IP fails the
 /// snapshot CLOSED via `NeighborFamilyMismatch`. fail-on-revert: restoring the
 /// family-ignoring `populate_neighbors` installs the neighbor and the build

--- a/userspace-dp/src/afxdp/frame/tests.rs
+++ b/userspace-dp/src/afxdp/frame/tests.rs
@@ -789,10 +789,16 @@ fn native_gre_logical_egress_retains_zone_without_mac() {
 #[test]
 fn owner_rg_for_resolution_uses_native_gre_endpoint_group() {
     let state = build_forwarding_state(&native_gre_snapshot(true));
-    let resolved = lookup_forwarding_resolution_with_dynamic(
+    // #4446: the GRE inner interface lives in the sfmix routing-instance, so
+    // its connected /30 (which owns the tunnel peer 10.255.192.41) is in
+    // sfmix.inet.0. Resolve in that table to reach the tunnel — a default
+    // (inet.0) lookup no longer sees the sfmix-scoped connected prefix
+    // (table-scoped inference; mirrors the #2388 lookup filter).
+    let resolved = lookup_forwarding_resolution_in_table_with_dynamic(
         &state,
         &Default::default(),
         IpAddr::V4(Ipv4Addr::new(10, 255, 192, 41)),
+        Some("sfmix.inet.0"),
     );
     assert_eq!(resolved.tunnel_endpoint_id, 1);
     assert_eq!(owner_rg_for_resolution(&state, resolved), 1);

--- a/userspace-dp/src/afxdp/test_fixtures.rs
+++ b/userspace-dp/src/afxdp/test_fixtures.rs
@@ -126,6 +126,14 @@ pub(super) fn native_gre_snapshot(include_neighbor: bool) -> ConfigSnapshot {
             InterfaceSnapshot {
                 name: "gr-0/0/0.0".to_string(),
                 zone: "sfmix".to_string(),
+                // #4446: the GRE inner interface belongs to the sfmix
+                // routing-instance (real config: `set routing-instances
+                // sfmix interface gr-0/0/0.0`), so its connected /30 lands in
+                // sfmix.inet.0 — the SAME table as the bare-gateway static
+                // route below. The build-time gateway inference is now
+                // table-scoped, so the connected route MUST be in the route's
+                // table (mirrors the #2388 lookup-site filter).
+                routing_instance: "sfmix".to_string(),
                 linux_name: "gr-0-0-0".to_string(),
                 ifindex: 362,
                 mtu: 1476,


### PR DESCRIPTION
Closes #4446 (audit #4423 M3, GENUINE HIGH).

## Problem

`infer_connected_route_target_v4`/`_v6`
(`userspace-dp/src/afxdp/forwarding_build/fib.rs`) inferred a bare-gateway
static route's egress ifindex by scanning `state.connected_v[46]` **globally**
and returning the first `prefix.contains(gateway)` match, never filtering by
the route's own table -- even though every `ConnectedRouteV[46]` already
carries its owning canonical `table` (added by #2388 for the lookup-time
filter).

The wrong ifindex was baked into `RouteEntryV*.next_hops` at FIB-build time and
consumed verbatim at lookup (`forwarding/mod.rs`, the `ResolvedRouteV*::Static`
arm reads `nh.ifindex` directly), so the #2388 lookup-time connected filter
could **not** correct it. In a multi-VRF deployment with overlapping gateway
subnets across routing-instances, a bare-gateway static route in instance A
could bind instance B's overlapping connected prefix -> **cross-VRF wrong
egress**. Two `fib.rs` doc comments contradicted each other (one claimed #2388
table scoping, the other "intentionally NOT table-scoped"; the code matched the
latter).

## Fix

Thread the route's canonical install table (`canonical_route_table(&route.table,
is_ipv6)`, computed in `populate_routes` **before** next-hop resolution) through
`resolve_route_next_hops_v[46]` -> `resolve_next_hop_target_v[46]` ->
`infer_connected_route_target_v[46]`, and filter the connected scan on
`entry.table == table` -- mirroring the #2388 lookup-site predicate, but at
**build time** so the correct ifindex is baked in.

**Cross-table leak preserved:** a route-leak / `next-table` reach is emitted as
a `NextTable` snapshot with **no forwarding next-hop**, so it never touches this
inference and is re-resolved in the target table's own scope by the recursion.
Reconciled both contradicting `fib.rs` doc comments and the
`forwarding/README.md` "stays global" note.

The `native_gre*` fixtures were made config-realistic: the GRE inner interface
now carries `routing_instance = "sfmix"` (real config: `set routing-instances
sfmix interface gr-0/0/0.0`), so its connected /30 lands in `sfmix.inet.0` --
the same table as the bare-gateway route it backs. The fixtures previously
relied on the global scan to bridge a table mismatch a real config never
produces.

## Tests (RED-on-revert)

- `static_bare_gateway_infers_ifindex_in_own_table_v4` / `_v6`: two instances
  ("red"/"blue") own the same 192.168.0.0/24 (and 2001:db8::/64); "blue" leads
  the scan order, so the global scan binds blue's ifindex 102 into red's route.
  Verified RED by reverting the filter (left 102, right 101).
- `static_bare_gateway_single_table_still_resolves`: anti-regression --
  single-table + `next-table` leak unaffected.

Full `cargo test --release -- --test-threads=1` = **3744 passed / 0 failed / 2
ignored** (3659 main + 54 + 8 + 22 + 1); fib/forwarding/tunnel subset **127/0**.

**Note:** multi-VRF routing/dataplane change -- a routing smoke /
`make test-failover` on the loss userspace cluster is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi