### PR TITLE
userspace-dp: gate bare RST/FIN out of the fabric return fast path (#4453)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-07 — #4453: gate bare RST/FIN out of the cluster-peer return fast path
+
+- **Timestamp**: 2026-07-07
+- **Action**: Fixed #4453 (residual from #4400/#4439, from the #4451
+  hostile review). `cluster_peer_return_fast_path`
+  (`userspace-dp/src/afxdp/forwarding/mod.rs`) excluded the TCP initial
+  SYN, the ICMP echo-request, and (per #4439) all UDP from its
+  provably-return fast path, but NOT a bare TCP RST/FIN
+  (`is_closing && !has_syn`). A transit bare RST/FIN to a locally
+  HAInactive RG is downgraded to a `FabricRedirect` and forwarded to the
+  peer, where it arrives as fabric ingress, misses every session scope,
+  and was fast-pathed into a NAT-less `SessionOrigin::ReverseFlow` seed —
+  installing on the peer, via the trusted fabric path, exactly the
+  phantom-closing session the peer's own #4400 guard prevents locally.
+  - **Fix**: added a third initiator-exclusion arm to
+    `cluster_peer_return_fast_path` (right after the initial-SYN check):
+    `PROTO_TCP && is_closing(tcp_flags) && !has_syn(tcp_flags)` returns
+    `None` — the SAME predicate #4400 uses locally
+    (`strict_syn_check_drops_new_flow`). The bare RST/FIN falls through to
+    the peer's normal forward decision, whose own session-miss #4400 guard
+    drops it. The legitimate synced-session fabric-forward is untouched
+    (served by `resolve_flow_session_decision` before the fast path — a
+    session HIT, not session-less). This completes the fast-path
+    invariant: fire ONLY for provably-return traffic (exclude TCP-SYN,
+    ICMP-echo-request, all UDP, AND the bare RST/FIN).
+  - **Validation**: RED-on-revert
+    `forwarding/tests.rs::cluster_peer_return_fast_path_skips_bare_rst_fin_4453`
+    — bare RST / FIN / FIN|ACK / RST|ACK against the same
+    ForwardCandidate-resolving target the ICMP-reply test uses; returns
+    `Some` (reverse seed) with the arm neutralized, `None` with the fix
+    (verified by neutralizing the arm — bare RST 0x04 panicked "must not
+    fast-path a reverse seed"). Preserved `_allows_sfmix_to_lan_reply`,
+    `_skips_udp_new_flow_4439`, `_skips_pure_tcp_syn`,
+    `_skips_icmp_echo_request`. Full cargo suite serial (see PR).
+  - **File(s)**: `userspace-dp/src/afxdp/forwarding/mod.rs`,
+    `userspace-dp/src/afxdp/forwarding/tests.rs`,
+    `docs/fabric-cross-chassis-fwd.md`, `_Log.md`.
+
 ## 2026-07-07 — #4400: strict-syn-check drop for bare RST/FIN on session-miss
 
 - **Timestamp**: 2026-07-07

--- a/docs/fabric-cross-chassis-fwd.md
+++ b/docs/fabric-cross-chassis-fwd.md
@@ -494,3 +494,48 @@ ForwardCandidate-resolving target the ICMP-reply test uses — returns `Some` on
 revert, `None` with the fix) alongside the preserved
 `cluster_peer_return_fast_path_allows_sfmix_to_lan_reply` (ICMP echo reply
 still fast-paths) and `_skips_pure_tcp_syn` / `_skips_icmp_echo_request`.
+
+## The return fast path must not adopt a bare RST/FIN either (#4453)
+
+The #4439 UDP exclusion left one class of session-less packet still adopted:
+a **bare TCP RST/FIN** (`is_closing(flags) && !has_syn(flags)`). It is NOT an
+initial SYN, so the `is_initial_syn` exclusion above misses it, and it is not
+UDP. Reaching this fast path it was therefore fast-pathed into a NAT-less,
+reverse-keyed seed — the same seed-a-closing-session failure the local
+session-miss path already rejects.
+
+**The bug.** #4400 added `strict_syn_check_drops_new_flow(protocol, flags) ==
+PROTO_TCP && is_closing(flags) && !has_syn(flags)` and dropped a bare RST/FIN
+on the LOCAL session-MISS cold path — an immediately-closing session has no
+forwarding value (pure churn, a cheap RST/FIN-flood DoS surface). But the
+fabric return fast path had no equivalent guard. A transit bare RST/FIN to a
+locally-**HAInactive** RG is converted to a `FabricRedirect` by the safety net
+(`resolve_fabric_redirect` / the HAInactive downgrade in
+`enforce_ha_resolution_snapshot`) and forwarded to the peer. On the peer it
+arrives as **fabric ingress**, misses every session scope, and
+`cluster_peer_return_fast_path` adopted it — installing on the peer, **via the
+trusted fabric path**, exactly the phantom-closing session the peer's own
+#4400 guard prevents locally. It is gated behind the trusted internal fabric
+link (not externally forgeable without targeting an HAInactive RG), so the
+impact is per-worker session-table churn on the peer, not a data-plane
+compromise — but it defeats the #4400 invariant across the fabric.
+
+**The fix.** `cluster_peer_return_fast_path` now returns `None` for
+`PROTO_TCP && is_closing(flags) && !has_syn(flags)` (the SAME predicate as
+#4400). A bare RST/FIN falls through to the peer's normal forward decision,
+whose own session-miss #4400 guard drops it — no reverse seed installed. This
+completes the fast-path flow-initiator-exclusion invariant: it fires ONLY for
+provably-return traffic, excluding the TCP initial SYN, the ICMP echo request,
+all UDP, AND the bare TCP RST/FIN. The legitimate fabric-forward for an
+established synced session is untouched — an established flow's real RST/FIN is
+served by `resolve_flow_session_decision` (the synced session) before this
+point, so it is a session HIT, never session-less. TCP data (non-SYN,
+non-closing) and ICMP echo-reply return traffic continue to fast-path.
+
+RED-on-revert coverage: `forwarding/tests.rs`
+`cluster_peer_return_fast_path_skips_bare_rst_fin_4453` (bare RST / FIN /
+FIN|ACK / RST|ACK against the same ForwardCandidate-resolving target the
+ICMP-reply test uses — returns `Some` on revert, `None` with the fix)
+alongside the preserved `_allows_sfmix_to_lan_reply`,
+`_skips_udp_new_flow_4439`, `_skips_pure_tcp_syn`, and
+`_skips_icmp_echo_request`.

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -731,6 +731,28 @@ pub(super) fn cluster_peer_return_fast_path(
     if meta.protocol == PROTO_TCP && crate::tcp_flags::is_initial_syn(meta.tcp_flags) {
         return None;
     }
+    // #4453: a bare TCP RST/FIN (closing flags, SYN clear) is the same
+    // session-less phantom-closing packet the LOCAL session-miss path drops
+    // via the #4400 strict-syn-check (`strict_syn_check_drops_new_flow` ==
+    // PROTO_TCP && is_closing && !has_syn). It carries no return value: a real
+    // established flow's RST/FIN is served by the synced session in
+    // `resolve_flow_session_decision` before this point. Without this arm, a
+    // transit bare RST/FIN to a locally-HAInactive RG is converted to a
+    // FabricRedirect (safety net) and forwarded to the peer, where it arrives
+    // as fabric ingress and gets fast-pathed into a NAT-less
+    // `SessionOrigin::ReverseFlow` seed — installing on the peer, via the
+    // trusted fabric path, exactly the immediately-closing session the peer's
+    // own #4400 guard prevents locally. Exclude it here (SAME predicate as
+    // #4400) so it falls through to the peer's normal forward decision, whose
+    // session-miss guard drops it — no reverse seed. This completes the
+    // fast-path invariant: fire ONLY for provably-return traffic (exclude the
+    // TCP initial SYN, the ICMP echo request, all UDP, AND the bare RST/FIN).
+    if meta.protocol == PROTO_TCP
+        && crate::tcp_flags::is_closing(meta.tcp_flags)
+        && !crate::tcp_flags::has_syn(meta.tcp_flags)
+    {
+        return None;
+    }
     // #4439: this fast path may fire ONLY for packets that are provably
     // RETURN traffic — the reverse direction of a flow the active owner
     // already policy/NAT-validated. Every other protocol carries a

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -844,6 +844,65 @@ fn cluster_peer_return_fast_path_skips_udp_new_flow_4439() {
 }
 
 #[test]
+fn cluster_peer_return_fast_path_skips_bare_rst_fin_4453() {
+    // #4453: a bare TCP RST/FIN (closing flags, no SYN) arriving on the
+    // fabric is a session-less phantom-closing packet with no return value —
+    // the exact packet the LOCAL #4400 strict-syn-check drops on a session
+    // miss. It MUST fall through to the owner's forward decision (where the
+    // peer's own session-miss guard drops it), NOT be fast-pathed into a
+    // NAT-less `SessionOrigin::ReverseFlow` seed. This is the same
+    // `_allows_sfmix_to_lan_reply` setup (whose target resolves to a
+    // ForwardCandidate) with a bare RST / FIN / FIN|ACK: on revert the fast
+    // path returns Some (the reverse seed installed on the peer via the
+    // fabric path), so asserting None is RED-on-revert. The ICMP-reply test
+    // above proves the legitimate return-traffic fast path is preserved, and
+    // the SYN test below proves the initial-SYN exclusion is untouched.
+    let mut state = build_forwarding_state(&native_gre_pbr_snapshot(true));
+    state.fabrics.push(FabricLink {
+        parent_ifindex: 4,
+        overlay_ifindex: 104,
+        peer_addr: IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2)),
+        peer_mac: [0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee],
+        local_mac: [0x02, 0xbf, 0x72, 0xff, 0x00, 0x01],
+        up: true,
+    });
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+    dynamic_neighbors.insert(
+        (5, IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102))),
+        NeighborEntry {
+            mac: [0xde, 0xad, 0xbe, 0xef, 0x00, 0x01],
+        },
+    );
+    for flags in [
+        crate::tcp_flags::TCP_RST,
+        crate::tcp_flags::TCP_FIN,
+        crate::tcp_flags::TCP_FIN | crate::tcp_flags::TCP_ACK,
+        crate::tcp_flags::TCP_RST | crate::tcp_flags::TCP_ACK,
+    ] {
+        let meta = UserspaceDpMeta {
+            ingress_ifindex: 4,
+            protocol: PROTO_TCP,
+            tcp_flags: flags,
+            l4_offset: 0,
+            ..UserspaceDpMeta::default()
+        };
+        let packet_frame = [0u8];
+        assert!(
+            cluster_peer_return_fast_path(
+                &state,
+                &dynamic_neighbors,
+                &packet_frame,
+                meta,
+                Some(TEST_SFMIX_ZONE_ID),
+                IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
+            )
+            .is_none(),
+            "bare closing flags {flags:#04x} must not fast-path a reverse seed"
+        );
+    }
+}
+
+#[test]
 fn cluster_peer_return_fast_path_skips_pure_tcp_syn() {
     let mut state = build_forwarding_state(&native_gre_pbr_snapshot(true));
     state.fabrics.push(FabricLink {

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -1964,10 +1964,15 @@ pub(super) fn poll_binding_process_descriptor(
                         // peer RST tearing down a firewall-originated TCP session
                         // (BGP, IKE, management) still reaches the local stack,
                         // and NoRoute / FabricRedirect / HAInactive never seed a
-                        // local session from this packet. Legitimate cross-
-                        // chassis teardowns for a peer-owned session take the
-                        // `cluster_peer_return_fast_path` above (which exits
-                        // before this point), so no fabric exemption is needed.
+                        // local session from this packet. Legitimate teardowns
+                        // for a SYNCED peer-owned session are session HITs served
+                        // by `resolve_flow_session_decision` before the fast path;
+                        // a session-MISS fabric-ingress bare RST/FIN now falls
+                        // through `cluster_peer_return_fast_path` (which REFUSES
+                        // it per #4453) and is dropped RIGHT HERE by this
+                        // strict-syn-check — so the local guard and the #4453
+                        // fabric arm give consistent bare-RST/FIN handling on
+                        // both the local and fabric-ingress paths.
                         // Counted in the aggregate `screen_drops` flow-statistics
                         // tally (no per-reason ordinal — that array mirrors the
                         // Junos SCREEN checks, and strict-syn-check is a flow


### PR DESCRIPTION
## Summary

Closes #4453 (residual from #4400/#4439, filed from the #4451 hostile review).

`cluster_peer_return_fast_path` (`userspace-dp/src/afxdp/forwarding/mod.rs`) is the fabric sync-race fast path — it may fire ONLY for provably-RETURN traffic, building a NAT-less, reverse-keyed seed. It already excludes each protocol's flow-initiator: the TCP initial SYN, the ICMP echo REQUEST, and (per #4439) all UDP. It did **NOT** exclude a bare TCP RST/FIN (`is_closing(flags) && !has_syn(flags)`) — the same session-less phantom-closing packet the LOCAL session-miss path already drops via the #4400 strict-syn-check.

**Impact:** a transit bare RST/FIN to a locally HAInactive RG is downgraded to a `FabricRedirect` and forwarded to the peer, where it arrives as fabric ingress, misses every session scope, and was fast-pathed into a NAT-less `SessionOrigin::ReverseFlow` seed — installing on the peer, via the trusted fabric path, exactly the immediately-closing session the peer's own #4400 guard prevents locally. Gated behind the trusted internal fabric link (not externally forgeable without targeting an HAInactive RG), so the impact is per-worker session-table churn on the peer, not a data-plane compromise — but it defeats the #4400 invariant across the fabric.

## Fix

One arm (mirrors #4439), added right after the initial-SYN check in `cluster_peer_return_fast_path`:

```rust
if meta.protocol == PROTO_TCP
    && crate::tcp_flags::is_closing(meta.tcp_flags)
    && !crate::tcp_flags::has_syn(meta.tcp_flags)
{
    return None;
}
```

The SAME predicate #4400 uses locally (`strict_syn_check_drops_new_flow`). The bare RST/FIN falls through to the peer's normal forward decision, whose own session-miss #4400 guard drops it — no reverse seed. This completes the fast-path invariant: fire ONLY for provably-return traffic (exclude TCP-SYN, ICMP-echo-request, all UDP, AND the bare RST/FIN). The legitimate synced-session fabric-forward is untouched — an established flow's real RST/FIN is a session HIT served by `resolve_flow_session_decision` before the fast path.

## Validation

- **RED-on-revert:** new `forwarding/tests.rs::cluster_peer_return_fast_path_skips_bare_rst_fin_4453` — bare RST / FIN / FIN|ACK / RST|ACK against the same ForwardCandidate-resolving target the ICMP-reply test uses. Returns `Some` (the reverse seed) with the arm neutralized (verified: bare RST 0x04 panicked "must not fast-path a reverse seed"), `None` with the fix.
- Preserved `_allows_sfmix_to_lan_reply`, `_skips_udp_new_flow_4439`, `_skips_pure_tcp_syn`, `_skips_icmp_echo_request`.
- **Full cargo suite serial** (`--test-threads=1`): main binary 3660/0 (2 ignored), lib 54/0, integration 8/0 + 22/0 + 1/0 — all targets green.
- Docs: `docs/fabric-cross-chassis-fwd.md`.

**NOTE:** HA fabric path change → `make test-failover` warranted before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi