### PR TITLE
afxdp/tests: correct stale NAT64 policy-tuple rationale comments (#4449)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,37 @@
+## 2026-07-07 — #4449: correct stale NAT64 policy-tuple rationale comments in afxdp/tests.rs
+
+- **Timestamp**: 2026-07-07
+- **Action**: Fixed #4449 (comment-only, deferred from #4440's verify-first).
+  The NAT64 policy-tuple rationale comments in
+  `userspace-dp/src/afxdp/tests.rs` still described the PRE-#2358 behavior
+  ("NAT64 policy is matched on the SYNTHETIC IPv6 destination, NOT the
+  extracted IPv4 destination"). This is factually stale: #2358 (commit
+  `09d0a929b`) made the primary ForwardCandidate path feed
+  `policy_dst_ip = effective_resolution_target` = the EXTRACTED real IPv4
+  destination for NAT64, matched by the cross-family (V6 src, V4 dst) arm in
+  `policy.rs::try_match_rule` (mod.rs L1541-1591; policy.rs L3893-3939). The
+  `64:ff9b::/96` whole-prefix permit/deny tests stay green only because a
+  v6-only destination set (no v4 prefix) compiles to IPv4-match-any under the
+  legacy address-set convention, so it matches the extracted v4 dst on the
+  match-any path — not via any synthetic-IPv6 match.
+  - **Verify-first nuance**: the MissingNeighbor cold-path arm (mod.rs
+    L4232-4263) genuinely RETAINS synthetic-v6 matching for NAT64 — it does
+    NOT re-classify NAT64, so `decision.nat.rewrite_dst` is None and
+    `policy_dst_ip` falls back to `flow.dst_ip` (the synthetic IPv6 dst). The
+    4th comment's synthetic-v6 description is therefore CORRECT; only its
+    stale "exactly the ForwardCandidate NAT64 exclusion" claim was fixed to
+    note the divergence from #2358's ForwardCandidate path. Rewriting it to
+    "extracted IPv4" would have introduced a FALSE statement.
+  - **Scope**: comment-only. No assertion, test-logic, or function-name
+    change (function names still say `synthetic_v6`, a pre-#2358 misnomer,
+    noted in the comments). Four `//`/`///` blocks updated: the header block
+    (~L11686), the permit-test doc, the deny-test doc, and the
+    MissingNeighbor-test doc.
+  - **Validation**: `cargo test --no-run --release` (compile-check of the
+    `#[cfg(test)]` test target — a `cargo build --release` alone does not
+    compile tests.rs). Comment-only, no full test run needed.
+- **File(s)**: userspace-dp/src/afxdp/tests.rs, _Log.md
+
 ## 2026-07-07 — #4453: gate bare RST/FIN out of the cluster-peer return fast path
 
 - **Timestamp**: 2026-07-07

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -11683,12 +11683,23 @@ fn publish_dnat_table_entry_v6_attempts_publish() {
 // If the policy lookup reverts to the pre-translation tuple/zone these
 // tests flip and fail.
 //
-// NAT64 is DELIBERATELY EXCLUDED from post-translation matching. It is a
-// cross-family translation (IPv6 source, IPv4 destination) and the policy
-// matcher requires same-family src+dst, so NAT64 policy is matched on the
-// SYNTHETIC IPv6 destination (the only same-family tuple available at the
-// policy-eval site), NOT the extracted IPv4 destination. The NAT64 tests
-// below pin that synthetic-IPv6 behavior.
+// NAT64 (#2358): the PRIMARY (ForwardCandidate) path now ALSO matches on
+// the POST-translation destination — the EXTRACTED real IPv4 host the
+// synthetic NAT64 address decodes to, NOT the synthetic IPv6 dst. NAT64 is
+// a cross-family translation (IPv6 source, IPv4 destination), so the
+// forwarding path feeds a mixed (V6 src, V4 dst) tuple and
+// `policy.rs::try_match_rule` carries a dedicated (V6 src, V4 dst) arm that
+// matches the source against the rule's IPv6 source set and the destination
+// against the rule's IPv4 destination set. The permit/deny tests below use
+// whole-prefix `64:ff9b::/96` destination rules that still PERMIT/DENY the
+// flow — but via the extracted IPv4 dst: a v6-only destination set (no v4
+// prefix) compiles to IPv4-match-any under the legacy address-set
+// convention, so it matches the extracted v4 dst on the match-any path, NOT
+// via any synthetic-IPv6 match. The MissingNeighbor cold-path arm is the
+// one exception — it does NOT re-classify NAT64, so it retains a synthetic
+// IPv6 fallback (see that test's comment below). The test function names
+// still say `synthetic_v6`, a pre-#2358 misnomer. See
+// `docs/next-features/twice-nat.md`.
 // =====================================================================
 
 /// v6 ingress meta for the txn harness (TCP, ingress on `ifindex`).
@@ -12054,15 +12065,17 @@ fn lan_to_wan_permit(dst: &str, name: &str) -> PolicyRuleSnapshot {
     }
 }
 
-/// NAT64: a policy permitting ONLY the EXTRACTED IPv4 server (8.8.8.8/32)
-/// NAT64 (DELIBERATELY EXCLUDED from the #2345 post-translation tuple, see
-/// the long comment at the policy-tuple binding in poll_descriptor): NAT64
-/// is cross-family (V6 src, V4 dst) and xpf's policy matcher requires
-/// same-family src+dst, so feeding the extracted IPv4 destination would
-/// match no rule and break ALL NAT64 connectivity. NAT64 therefore keeps
-/// its historical behavior: policy matches on the SYNTHETIC IPv6 dst (the
-/// only same-family tuple available). This test pins that a policy on the
-/// synthetic IPv6 prefix permits + forwards the NAT64 flow.
+/// NAT64 (#2358): the inbound policy is evaluated on the EXTRACTED real IPv4
+/// destination (8.8.8.8, decoded from the synthetic `64:ff9b::808:808` dst),
+/// NOT the synthetic IPv6 dst. On the ForwardCandidate path `policy_dst_ip`
+/// = `effective_resolution_target` = the extracted IPv4, and
+/// `policy.rs::try_match_rule` matches it via the cross-family (V6 src, V4
+/// dst) arm. This test permits on the whole `64:ff9b::/96` prefix and still
+/// forwards the flow — but only because a v6-only destination set (no v4
+/// prefix) compiles to IPv4-match-any under the legacy address-set
+/// convention, so the rule matches the extracted v4 dst on the match-any
+/// path (a whole-prefix NAT64 rule, NOT a synthetic-IPv6 match). The
+/// `synthetic_v6` in the test name is a pre-#2358 misnomer.
 #[test]
 fn policy_inbound_nat64_matches_synthetic_v6_destination_permit() {
     let snapshot = nat64_snapshot(lan_to_wan_permit("64:ff9b::/96", "permit-synthetic-v6"));
@@ -12096,12 +12109,15 @@ fn policy_inbound_nat64_matches_synthetic_v6_destination_permit() {
     assert_eq!(sessions.len(), 2, "NAT64 forward + reverse install");
 }
 
-/// NAT64 fail-on-revert: an explicit DENY on the synthetic IPv6 NAT64
-/// destination prefix must DROP the flow. This proves the NAT64 policy
-/// match runs on the synthetic IPv6 destination (the documented #2345
-/// NAT64 behavior): if NAT64 were folded onto the extracted IPv4 tuple,
-/// the V6 deny rule would no longer match (cross-family) and the flow would
-/// fall to the default policy, changing the verdict.
+/// NAT64 fail-on-revert (#2358): an explicit DENY whose destination is the
+/// whole `64:ff9b::/96` NAT64 prefix must DROP the flow; a trailing
+/// permit-any is the only other rule, so the deny is the ONLY thing that can
+/// drop it. On the ForwardCandidate path the inbound policy is evaluated on
+/// the EXTRACTED IPv4 destination, and the v6-only `64:ff9b::/96` destination
+/// set compiles to IPv4-match-any (legacy convention), so the cross-family
+/// (V6 src, V4 dst) arm matches the extracted v4 dst and the deny wins over
+/// the trailing permit-any. If the post-translation match tuple regressed,
+/// the verdict would change and this test would fail.
 #[test]
 fn policy_inbound_nat64_denies_on_synthetic_v6_deny_rule() {
     let mut deny = lan_to_wan_permit("64:ff9b::/96", "deny-synthetic-v6");
@@ -12389,14 +12405,18 @@ fn policy_inbound_nptv6_missing_neighbor_denies_when_only_external_prefix_permit
 /// NAT64 MissingNeighbor: directly pins that Copilot's feared "NAT64
 /// default-deny at MissingNeighbor" does NOT happen. With the IPv4 server's
 /// next-hop neighbor (172.16.80.1) unresolved, the NAT64 flow takes the
-/// MissingNeighbor arm; the policy on the SYNTHETIC IPv6 prefix permits it
-/// (NOT default-denied). This holds because at the MissingNeighbor site
-/// NAT64 populates neither nptv6_nat nor pre_routing_dnat, so
-/// `decision.nat.rewrite_dst` is None and `policy_dst_ip` falls back to
-/// `flow.dst_ip` (the synthetic IPv6 dst) — exactly the ForwardCandidate
-/// NAT64 exclusion. If the fallback were reverted to unconditionally feed
-/// the extracted IPv4 dst, the synthetic-V6 policy would no longer match
-/// (cross-family) and this flow would default-deny — failing this test.
+/// MissingNeighbor cold-path arm; the policy on the synthetic IPv6 prefix
+/// permits it (NOT default-denied). Unlike the #2358 ForwardCandidate path
+/// (which matches NAT64 on the EXTRACTED real IPv4 dst), this arm does NOT
+/// re-classify NAT64: it populates neither nptv6_nat nor pre_routing_dnat,
+/// so `decision.nat.rewrite_dst` is None and `policy_dst_ip` falls back to
+/// `flow.dst_ip` — the synthetic IPv6 dst — which the same-family (V6 src,
+/// V6 dst) arm matches against the `64:ff9b::/96` rule (see the retained
+/// synthetic-v6 fallback comment at the MissingNeighbor policy binding in
+/// poll_descriptor). If that fallback were reverted to unconditionally feed
+/// the extracted IPv4 dst WITHOUT reconstructing the NAT64 v4 tuple here, the
+/// synthetic-V6 policy would no longer match and this flow would
+/// default-deny — failing this test.
 #[test]
 fn policy_inbound_nat64_missing_neighbor_permits_on_synthetic_v6_not_default_deny() {
     let mut snapshot =


### PR DESCRIPTION
## Summary

Comment-only cleanup of stale NAT64 policy-tuple rationale comments in `userspace-dp/src/afxdp/tests.rs` (deferred from #4440's verify-first). The comments still described the pre-#2358 behavior — that NAT64 policy matches on the **synthetic IPv6 destination** — which #2358 (commit `09d0a929b`) made factually wrong.

## What #2358 actually established

On the primary (ForwardCandidate) path the inbound policy is now evaluated on the **extracted real IPv4 destination**:
- `poll_descriptor/mod.rs`: `effective_resolution_target = IpAddr::V4(dst_v4)` for a NAT64 match, and `policy_dst_ip = effective_resolution_target`.
- `policy.rs::try_match_rule`: a dedicated cross-family `(V6 src, V4 dst)` arm matches the source against the rule's IPv6 source set and the destination against the rule's IPv4 destination set.

The `64:ff9b::/96` whole-prefix permit/deny tests stay green only because a v6-only destination set (no v4 prefix) compiles to **IPv4-match-any** under the legacy address-set convention, so it matches the extracted v4 dst on the match-any path — not via any synthetic-IPv6 match.

## Verify-first nuance

The issue over-generalized: the **MissingNeighbor cold-path arm** genuinely **retains** synthetic-v6 matching for NAT64, because it does not re-classify NAT64, so `decision.nat.rewrite_dst` is `None` and `policy_dst_ip` falls back to `flow.dst_ip` (the synthetic IPv6 dst). That test's synthetic-v6 description is therefore correct; only its stale "exactly the ForwardCandidate NAT64 exclusion" claim was fixed to note the divergence from #2358's ForwardCandidate path. Rewriting it to "extracted IPv4" would have introduced a **false** statement.

## Scope

Comment-only. No assertion, test-logic, or function-name change. The test function names still say `synthetic_v6` (a pre-#2358 misnomer, now noted in the comments). Four comment blocks updated: the header block, the permit-test doc, the deny-test doc, and the MissingNeighbor-test doc.

## Validation

`cargo test --no-run --release` compiles the `#[cfg(test)]` test target clean (a `cargo build --release` alone does not compile `tests.rs`). Comment-only, no full test run needed.

Closes #4449

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi