### PR TITLE
Refs #4406 (step 2: extract P4 section dispatch)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,26 @@
+## 2026-07-07 — #4406 step 2: extract P4 section dispatch from compileExpanded
+
+- **Timestamp**: 2026-07-07
+- **Action**: Step 2 of the #4406 compileExpanded god-orchestrator
+  decomposition (after step 1 extracted P1 runPreWalkGates). Extracted the P4
+  "section-compile dispatch" phase — the `for _, node := range tree.Children`
+  switch that routes each root child (in author order) to its already-extracted
+  section compiler (compileSecurity / compileInterfaces / … / compileSNMP /
+  compileBridgeDomains) — into a new free function
+  `compileSections(tree *ConfigTree, cfg *Config, opts compileOpts) error`
+  (compiler_dispatch.go:31, mirroring step 1's runPreWalkGates free-function
+  pattern). compileExpanded now calls it in the SAME position/order between the
+  P3 warning append and the P5 #4329 NodeID stamp. Behavior-preserving
+  code-motion of orchestration glue: same section order, same first-error slot
+  (each `<section>: %w` wrap unchanged), same tree/cfg threading. Net compiler.go
+  −72/+8 (73-line inline switch → 11-line call block with rationale comment).
+- **File(s)**: pkg/config/compiler_dispatch.go (new), pkg/config/compiler.go
+- **Validation**: gofmt clean, go vet clean, `go build ./...` clean.
+  `go test ./pkg/config/ -run Golden4406` PASSED byte-identical WITHOUT a
+  baseline update (no GOLDEN_4406_UPDATE, no golden_4406.actual.json written,
+  testdata/ untouched) — proving P4 has no hidden side effect. Full
+  `go test ./pkg/config/...` green.
+
 ## 2026-07-07 — #4449: correct stale NAT64 policy-tuple rationale comments in afxdp/tests.rs
 
 - **Timestamp**: 2026-07-07

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1958,78 +1958,14 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	}
 	cfg.Warnings = append(cfg.Warnings, preWalkWarnings...)
 
-	for _, node := range tree.Children {
-		switch node.Name() {
-		case "security":
-			if err := compileSecurity(node, &cfg.Security); err != nil {
-				return nil, fmt.Errorf("security: %w", err)
-			}
-		case "interfaces":
-			if err := compileInterfaces(node, &cfg.Interfaces); err != nil {
-				return nil, fmt.Errorf("interfaces: %w", err)
-			}
-		case "applications":
-			if err := compileApplications(node, &cfg.Applications); err != nil {
-				return nil, fmt.Errorf("applications: %w", err)
-			}
-		case "routing-options":
-			if err := compileRoutingOptions(node, &cfg.RoutingOptions); err != nil {
-				return nil, fmt.Errorf("routing-options: %w", err)
-			}
-		case "protocols":
-			if err := compileProtocols(node, &cfg.Protocols); err != nil {
-				return nil, fmt.Errorf("protocols: %w", err)
-			}
-		case "routing-instances":
-			if err := compileRoutingInstances(node, cfg); err != nil {
-				return nil, fmt.Errorf("routing-instances: %w", err)
-			}
-		case "firewall":
-			if err := compileFirewall(node, &cfg.Firewall); err != nil {
-				return nil, fmt.Errorf("firewall: %w", err)
-			}
-		case "class-of-service":
-			if err := compileClassOfService(node, cfg.ClassOfService); err != nil {
-				return nil, fmt.Errorf("class-of-service: %w", err)
-			}
-		case "services":
-			if err := compileServices(node, &cfg.Services); err != nil {
-				return nil, fmt.Errorf("services: %w", err)
-			}
-		case "forwarding-options":
-			if err := compileForwardingOptions(node, &cfg.ForwardingOptions); err != nil {
-				return nil, fmt.Errorf("forwarding-options: %w", err)
-			}
-		case "system":
-			if err := compileSystem(node, &cfg.System, cfg, opts); err != nil {
-				return nil, fmt.Errorf("system: %w", err)
-			}
-		case "schedulers":
-			if err := compileSchedulers(node, cfg); err != nil {
-				return nil, fmt.Errorf("schedulers: %w", err)
-			}
-		case "policy-options":
-			if err := compilePolicyOptions(node, &cfg.PolicyOptions); err != nil {
-				return nil, fmt.Errorf("policy-options: %w", err)
-			}
-		case "chassis":
-			if err := compileChassis(node, &cfg.Chassis); err != nil {
-				return nil, fmt.Errorf("chassis: %w", err)
-			}
-		case "event-options":
-			if err := compileEventOptions(node, &cfg.EventOptions); err != nil {
-				return nil, fmt.Errorf("event-options: %w", err)
-			}
-		case "snmp":
-			// Top-level snmp stanza (same format as system { snmp { ... } })
-			if err := compileSNMP(node, &cfg.System, cfg, opts.lenientSNMPTrapGroup); err != nil {
-				return nil, fmt.Errorf("snmp: %w", err)
-			}
-		case "bridge-domains":
-			if err := compileBridgeDomains(node, &cfg.BridgeDomains); err != nil {
-				return nil, fmt.Errorf("bridge-domains: %w", err)
-			}
-		}
+	// P4 (#4406 step 2): section-compile dispatch. Extracted into
+	// compileSections (compiler_dispatch.go) — the ordered per-section
+	// dispatch that routes each root child (in author order) to its
+	// already-extracted section compiler and returns the FIRST section error.
+	// Behavior-preserving lift; do NOT reorder P4 relative to P3 above or the
+	// P5 cross-section derivations below.
+	if err := compileSections(tree, cfg, opts); err != nil {
+		return nil, err
 	}
 
 	// #4329: stamp the compiled cluster node identity from the runtime

--- a/pkg/config/compiler_dispatch.go
+++ b/pkg/config/compiler_dispatch.go
@@ -1,0 +1,106 @@
+package config
+
+import "fmt"
+
+// compileSections runs the P4 "section-compile dispatch" phase of config
+// compilation — the ordered per-section dispatch extracted from
+// compileExpanded as step 2 of the #4406 god-orchestrator decomposition
+// (ps-review-011 / codex-173 #4).
+//
+// It iterates the root children in author order and routes each recognized
+// top-level stanza to its already-extracted section compiler
+// (compileSecurity / compileInterfaces / compileApplications /
+// compileRoutingOptions / compileProtocols / compileRoutingInstances /
+// compileFirewall / compileClassOfService / compileServices /
+// compileForwardingOptions / compileSystem / compileSchedulers /
+// compilePolicyOptions / compileChassis / compileEventOptions / compileSNMP /
+// compileBridgeDomains), mutating the shared *Config in place. The first
+// section compiler that fails wins the returned error slot; unrecognized
+// stanzas are ignored here (they are gated in the P1 pre-walk).
+//
+// Behavior-preserving invariants (do NOT reorder relative to master): the
+// iteration is over tree.Children in source order and dispatches to the SAME
+// compilers in the SAME order as the inline switch it replaces — duplicate
+// roots (e.g. two `security { }` blocks) still merge in author order, and the
+// first compiler error is returned unchanged with its `<section>: %w` wrap.
+// This phase runs AFTER the base *Config skeleton (P2) and the P3 warning
+// append, and BEFORE the P5 cross-section derivations (the #4329 NodeID stamp
+// and the fabric fixup), so tree must already be group-expanded and
+// inactive-pruned and cfg must already carry its initialized maps. It is
+// covered by the reusable golden-output gate in compile_golden_4406_test.go.
+func compileSections(tree *ConfigTree, cfg *Config, opts compileOpts) error {
+	for _, node := range tree.Children {
+		switch node.Name() {
+		case "security":
+			if err := compileSecurity(node, &cfg.Security); err != nil {
+				return fmt.Errorf("security: %w", err)
+			}
+		case "interfaces":
+			if err := compileInterfaces(node, &cfg.Interfaces); err != nil {
+				return fmt.Errorf("interfaces: %w", err)
+			}
+		case "applications":
+			if err := compileApplications(node, &cfg.Applications); err != nil {
+				return fmt.Errorf("applications: %w", err)
+			}
+		case "routing-options":
+			if err := compileRoutingOptions(node, &cfg.RoutingOptions); err != nil {
+				return fmt.Errorf("routing-options: %w", err)
+			}
+		case "protocols":
+			if err := compileProtocols(node, &cfg.Protocols); err != nil {
+				return fmt.Errorf("protocols: %w", err)
+			}
+		case "routing-instances":
+			if err := compileRoutingInstances(node, cfg); err != nil {
+				return fmt.Errorf("routing-instances: %w", err)
+			}
+		case "firewall":
+			if err := compileFirewall(node, &cfg.Firewall); err != nil {
+				return fmt.Errorf("firewall: %w", err)
+			}
+		case "class-of-service":
+			if err := compileClassOfService(node, cfg.ClassOfService); err != nil {
+				return fmt.Errorf("class-of-service: %w", err)
+			}
+		case "services":
+			if err := compileServices(node, &cfg.Services); err != nil {
+				return fmt.Errorf("services: %w", err)
+			}
+		case "forwarding-options":
+			if err := compileForwardingOptions(node, &cfg.ForwardingOptions); err != nil {
+				return fmt.Errorf("forwarding-options: %w", err)
+			}
+		case "system":
+			if err := compileSystem(node, &cfg.System, cfg, opts); err != nil {
+				return fmt.Errorf("system: %w", err)
+			}
+		case "schedulers":
+			if err := compileSchedulers(node, cfg); err != nil {
+				return fmt.Errorf("schedulers: %w", err)
+			}
+		case "policy-options":
+			if err := compilePolicyOptions(node, &cfg.PolicyOptions); err != nil {
+				return fmt.Errorf("policy-options: %w", err)
+			}
+		case "chassis":
+			if err := compileChassis(node, &cfg.Chassis); err != nil {
+				return fmt.Errorf("chassis: %w", err)
+			}
+		case "event-options":
+			if err := compileEventOptions(node, &cfg.EventOptions); err != nil {
+				return fmt.Errorf("event-options: %w", err)
+			}
+		case "snmp":
+			// Top-level snmp stanza (same format as system { snmp { ... } })
+			if err := compileSNMP(node, &cfg.System, cfg, opts.lenientSNMPTrapGroup); err != nil {
+				return fmt.Errorf("snmp: %w", err)
+			}
+		case "bridge-domains":
+			if err := compileBridgeDomains(node, &cfg.BridgeDomains); err != nil {
+				return fmt.Errorf("bridge-domains: %w", err)
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Step 2 of the #4406 `compileExpanded` god-orchestrator decomposition
(ps-review-011 / codex-173 #4). Step 1 extracted P1 (`runPreWalkGates`);
this step lifts **P4 — the section-compile dispatch** into a helper.

## What

Extracts the `for _, node := range tree.Children` switch (the ordered
per-section dispatch that routes each root child to its already-extracted
section compiler: `compileSecurity` / `compileInterfaces` / … /
`compileSNMP` / `compileBridgeDomains`) into a new free function in
`pkg/config/compiler_dispatch.go`:

```go
func compileSections(tree *ConfigTree, cfg *Config, opts compileOpts) error
```

`compileExpanded` now calls it in the **same position and order**, between the
P3 warning append and the P5 `#4329` NodeID stamp. `compiler.go` shrinks by 72
lines (73-line inline switch → 11-line call block with a rationale comment).

## Behavior-preserving

Pure code-motion of orchestration glue over the already-extracted section
compilers: same `tree.Children` source-order iteration, same dispatch order,
same first-error slot (each `<section>: %w` wrap unchanged), same
`tree`/`cfg`/`opts` threading. No gate is reordered; P4 stays between P3 and
P5 per the converged plan (invariant #6, the source-order first-error
contract). P4 is the SAFE contiguous phase the plan flagged — a clean lift,
no interleaved non-local mutation.

## Validation

- `gofmt` clean, `go vet` clean, `go build ./...` clean.
- **The existing #4406 golden-output harness passes byte-identical WITHOUT a
  baseline update**: `go test ./pkg/config/ -run Golden4406` green with
  `testdata/golden_4406.json` untouched and no `golden_4406.actual.json`
  written — proving the extraction changed no observable output across the
  strict/lenient × generic/node0/node1 matrix.
- Full `go test ./pkg/config/...` green.

Refs #4406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi