### PR TITLE
Refs #4406 (step 5: extract P5 cross-section derivations)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-07-07 — #4406 step 5: extract P5 cross-section derivations from compileExpanded
+
+- **Timestamp**: 2026-07-07
+- **Action**: Step 5 (the plan's MODERATE phase) of the #4406 compileExpanded
+  god-orchestrator decomposition (after step 1 P1 runPreWalkGates, step 2 P4
+  compileSections, step 3 P7 runTailGates, step 4 P6b runUniformGates). Extracted
+  the P5 "cross-section derivations" phase — the contiguous, NON-reorderable block
+  of post-dispatch mutations between the P4 section dispatch and the P6a
+  early-strict folds (validateDataplaneTypeStrict) — into a new free function
+  `resolveDerivedConfig(cfg *Config, opts compileOpts)` (compiler_derivations.go:53).
+  compileExpanded now calls it in the SAME position, SAME internal order. This
+  phase runs NO validation and returns NO error (unlike the pre-walk / gate
+  phases): it is pure cross-section mutation, so the helper takes cfg+opts and
+  returns nothing — matching the real block, which never returned an error nor
+  threaded warnings. It does NOT read `tree` (all six sub-steps read only cfg +
+  opts), so `tree` is deliberately not a parameter. Load-bearing internal order
+  preserved verbatim: (1) #4329 NodeID stamp — MUST precede the fabric fixup AND
+  validateDeviceMapStrict (P6b), both of which read cc.NodeID; (2)
+  resolveBGPAutonomousSystem; (3) lo0 unit-0 input-filter extract into
+  SystemConfig; (4) applyCoSInterfaceLevelBindings; (5)
+  resolveCoSTrafficControlProfiles — MUST follow the interface-level fold (4);
+  (6) fabric member/interface fixup (LocalFabricMember / FabricInterface /
+  Fabric1Interface / Fabric1PeerAddress auto-detect). P6a folds
+  (resolveZoneLocalAddressBooks / resolveStaticNATThenPrefixNames) stay INLINE —
+  they belong to the separate, deferred P6a step. compiler.go shrinks 125 net
+  lines (15 ins / 125 del). Golden gate (TestCompileGolden4406) passes
+  BYTE-IDENTICAL with NO baseline update — testdata/golden_4406.json untouched
+  (git status clean). Non-local consumer tests green (TestFlatFabric*_4329,
+  TestDeviceMap*, TestStaticNATThen*, CoS traffic-control, BGP-AS, lo0-filter).
+  gofmt clean, go vet clean, go build ./... + full pkg/config suite green.
+- **File(s)**: pkg/config/compiler.go, pkg/config/compiler_derivations.go,
+  _Log.md
+
 ## 2026-07-07 — #4406 step 4: extract P6b uniform gates from compileExpanded
 
 - **Timestamp**: 2026-07-07

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1968,131 +1968,21 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		return nil, err
 	}
 
-	// #4329: stamp the compiled cluster node identity from the runtime
-	// node-id (/etc/xpf/node-id, or the `-node-id` flag on `xpfd
-	// check-config`) when the config carries a chassis-cluster stanza but no
-	// explicit `chassis cluster node` leaf. A canonical vSRX chassis-cluster
-	// config encodes node ownership in the FPC slot (ge-0/0/N=node0,
-	// ge-7/0/N=node1) and runs the SAME flat config on both nodes with no
-	// `node` leaf. Without this stamp, Cluster.NodeID sits at its zero default
-	// on BOTH nodes, so every NodeID-dependent derivation resolves to the
-	// node-0 member on node 1 — reth breaks on the secondary (RethToPhysical
-	// reads NodeID at runtime), AND the compile-time fabric-member /
-	// FabricInterface auto-detect below (SlotToNodeID(member) == cc.NodeID)
-	// binds fab0/fab1 to the node-0 member. Stamping makes the compiled
-	// identity reflect the node the config is compiled FOR, so BOTH reth and
-	// fabric resolve to the LOCAL member on each node and the flat vSRX form
-	// is a drop-in.
-	//
-	// This MUST run after the child loop (Cluster + interfaces are populated)
-	// and BEFORE every NodeID-dependent derivation that follows: the fabric
-	// fixup below and validateDeviceMapStrict later in this function both read
-	// cc.NodeID.
-	//
-	// Guards (all load-bearing):
-	//   - opts.nodeAware && stampNodeID >= 0: only the node-aware entry
-	//     (compileConfigForNodeWithOpts) sets these. The standalone
-	//     CompileConfig path leaves nodeAware false, so single-node compiles
-	//     are unchanged; a negative node-id (defensive) never stamps.
-	//   - Cluster != nil: never fabricate a cluster stanza. A config-less HA
-	//     node (node-id present but empty/no-cluster config — the EMPTY-config
-	//     takeover in pkg/daemon/daemon.go) must keep Cluster == nil so the
-	//     daemon's `haMode` / `Cluster != nil` gates do not flip on a config
-	//     that has no cluster. A real reth/fabric config always carries a
-	//     `chassis cluster` stanza, so this never suppresses a genuine fix.
-	//   - !NodeIDSet: an explicit `chassis cluster node <id>` leaf is the
-	//     operator's SSOT and must win — never clobber it. crossCheckNodeID
-	//     (pkg/configstore) already rejects a leaf that disagrees with the
-	//     runtime node-id, and the GROUPS form (groups node0/node1 each carry
-	//     an explicit `node` leaf) is left bit-identical.
-	if opts.nodeAware && opts.stampNodeID >= 0 &&
-		cfg.Chassis.Cluster != nil && !cfg.Chassis.Cluster.NodeIDSet {
-		cfg.Chassis.Cluster.NodeID = opts.stampNodeID
-	}
-
-	// #3870: resolve the BGP local-AS from `routing-options
-	// autonomous-system` when `protocols bgp local-as` was omitted. Runs
-	// after the child loop so both routing-options and protocols/
-	// routing-instances are populated regardless of their order under root.
-	resolveBGPAutonomousSystem(cfg)
-
-	// Extract lo0 filter input from parsed interfaces into SystemConfig.
-	if lo0 := cfg.Interfaces.Interfaces["lo0"]; lo0 != nil {
-		if u0 := lo0.Units[0]; u0 != nil {
-			cfg.System.Lo0FilterInputV4 = u0.FilterInputV4
-			cfg.System.Lo0FilterInputV6 = u0.FilterInputV6
-		}
-	}
-
-	// #4021: fold interface-level CoS bindings (`class-of-service interfaces
-	// geX { scheduler-map M; ... }` with no `unit`) into the interface's
-	// configured logical units. Runs after the child loop so both the
-	// interface stanza (cfg.Interfaces) and class-of-service are populated
-	// regardless of their order under root; a unit-level binding overrides
-	// the interface-level one per knob (Junos precedence).
-	applyCoSInterfaceLevelBindings(cfg)
-
-	// #4315 (fable-167 F-2): resolve output-traffic-control-profile bindings
-	// into each unit's per-unit shaper (shaping-rate + scheduler-map). Runs
-	// AFTER the interface-level fold so an interface-level profile binding is
-	// already present on each unit. Before modeling, the hierarchical
-	// traffic-control-profile binding was silently dropped — a clean commit
-	// with ZERO shaping; now the shaper actually materializes.
-	resolveCoSTrafficControlProfiles(cfg)
-
-	// Post-compilation fixup: resolve vSRX-style fabric member-interfaces.
-	// For fab0/fab1 with fabric-options member-interfaces, resolve which member
-	// belongs to the local node using FPC slot → node-id mapping (slot 0 → node0,
-	// slot 7 → node1). Also auto-populate FabricInterface/Fabric1Interface when
-	// not explicitly set in chassis cluster config.
-	if cc := cfg.Chassis.Cluster; cc != nil {
-		for ifName, ifc := range cfg.Interfaces.Interfaces {
-			if !strings.HasPrefix(ifName, "fab") || len(ifc.FabricMembers) == 0 {
-				continue
-			}
-			for _, member := range ifc.FabricMembers {
-				slot := InterfaceSlot(member)
-				if slot >= 0 && SlotToNodeID(slot) == cc.NodeID {
-					ifc.LocalFabricMember = member
-					break
-				}
-			}
-		}
-		// Auto-detect fabric interfaces from fab0/fab1 member-interfaces
-		// when not explicitly configured via fabric-interface/fabric1-interface.
-		// Only set if the local node has a member (LocalFabricMember resolved above).
-		// Dual-fabric: if both fab0 and fab1 have local members, set both
-		// FabricInterface and Fabric1Interface (#130).
-		// Single-fabric: only one fab is local → FabricInterface only.
-		if cc.FabricInterface == "" {
-			if f0, ok := cfg.Interfaces.Interfaces["fab0"]; ok && f0.LocalFabricMember != "" {
-				cc.FabricInterface = "fab0"
-			} else if f1, ok := cfg.Interfaces.Interfaces["fab1"]; ok && f1.LocalFabricMember != "" {
-				cc.FabricInterface = "fab1"
-			}
-		}
-		// Auto-detect secondary fabric: fab1 when primary is fab0 and fab1
-		// also has a local member (dual-fabric topology).
-		if cc.Fabric1Interface == "" && cc.FabricInterface == "fab0" {
-			if f1, ok := cfg.Interfaces.Interfaces["fab1"]; ok && f1.LocalFabricMember != "" {
-				cc.Fabric1Interface = "fab1"
-			}
-		}
-		// Auto-derive Fabric1PeerAddress from the fab1 interface's /30 or /31
-		// address when not explicitly configured.
-		if cc.Fabric1Interface != "" && cc.Fabric1PeerAddress == "" {
-			if f1 := cfg.Interfaces.Interfaces[cc.Fabric1Interface]; f1 != nil {
-				if u0 := f1.Units[0]; u0 != nil {
-					for _, addr := range u0.Addresses {
-						if peer := peerFromPointToPoint(addr); peer != "" {
-							cc.Fabric1PeerAddress = peer
-							break
-						}
-					}
-				}
-			}
-		}
-	}
+	// P5 (#4406 step 5): cross-section derivations. Extracted into
+	// resolveDerivedConfig (compiler_derivations.go) — the contiguous,
+	// NON-reorderable block of post-dispatch mutations that fold cross-section
+	// state into the compiled *Config now that every section compiler (P4) has
+	// populated its own sub-struct. In internal order: the #4329 NodeID stamp
+	// (MUST precede the fabric fixup AND validateDeviceMapStrict, which both
+	// read cc.NodeID) → resolveBGPAutonomousSystem → lo0-filter extract →
+	// applyCoSInterfaceLevelBindings → resolveCoSTrafficControlProfiles (MUST
+	// follow the interface-level fold) → fabric member/interface fixup. It runs
+	// NO validation and returns NO error — a pure mutation phase. Behavior-
+	// preserving lift; runs AFTER the P4 section dispatch above and BEFORE the
+	// P6a early-strict folds below, so every derived field the later validators
+	// read is populated in the same order. Do NOT reorder or split the
+	// sub-steps.
+	resolveDerivedConfig(cfg, opts)
 
 	// #1526 — reject retired dataplane backends at commit time.
 	// Placed BEFORE the other strict validators so that an operator

--- a/pkg/config/compiler_derivations.go
+++ b/pkg/config/compiler_derivations.go
@@ -1,0 +1,177 @@
+package config
+
+import "strings"
+
+// resolveDerivedConfig runs the P5 "cross-section derivations" phase of config
+// compilation — the contiguous block of post-dispatch derivations extracted
+// from compileExpanded as step 5 of the #4406 god-orchestrator decomposition
+// (ps-review-011 / codex-173 #4).
+//
+// Unlike the pre-walk (P1) and gate phases (P6b/P7), this phase runs NO
+// validation and returns NO error: it is a pure sequence of mutations that fold
+// cross-section state into the compiled *Config now that every top-level
+// section compiler (P4) has populated its own sub-struct. Each sub-step reads
+// fields written by an EARLIER section compiler or an earlier sub-step here and
+// writes derived fields that the LATER validation phases (P6a early-strict,
+// P6b uniform gates, P7 tail) read. The block therefore mutates cfg in place
+// and threads no warnings.
+//
+// Internal order is LOAD-BEARING — the sub-steps run in exactly this sequence
+// (do NOT reorder or split them):
+//
+//  1. #4329 NodeID stamp — stamp the compiled cluster node identity from the
+//     runtime node-id when the config carries a chassis-cluster stanza but no
+//     explicit `node` leaf. MUST precede every NodeID-dependent derivation:
+//     the fabric fixup (step 6, `SlotToNodeID(member) == cc.NodeID`) AND
+//     validateDeviceMapStrict (later, in the P6b uniform gates) both read
+//     cc.NodeID.
+//  2. resolveBGPAutonomousSystem — resolve the BGP local-AS from
+//     `routing-options autonomous-system` when `protocols bgp local-as` was
+//     omitted; runs after the child loop so routing-options and
+//     protocols/routing-instances are both populated.
+//  3. lo0 filter extract — hoist the lo0 unit-0 input filter names into
+//     SystemConfig for the host-inbound-filter machinery.
+//  4. applyCoSInterfaceLevelBindings — fold interface-level CoS bindings into
+//     each interface's configured logical units.
+//  5. resolveCoSTrafficControlProfiles — resolve output-traffic-control-profile
+//     bindings into each unit's per-unit shaper. MUST run AFTER the
+//     interface-level fold (step 4) so an interface-level profile binding is
+//     already present on each unit.
+//  6. fabric member/interface fixup — resolve vSRX-style fab0/fab1
+//     member-interfaces to the local node's member and auto-populate
+//     FabricInterface/Fabric1Interface/Fabric1PeerAddress. Reads the NodeID
+//     stamped in step 1.
+//
+// Behavior-preserving invariants (do NOT reorder relative to master): this
+// phase runs AFTER the P4 section dispatch and BEFORE the P6a early-strict
+// folds (validateDataplaneTypeStrict onward), so the derived fields the strict
+// and uniform gates read are populated in the same order as the inline block it
+// replaces. It is covered by the reusable golden-output gate in
+// compile_golden_4406_test.go.
+func resolveDerivedConfig(cfg *Config, opts compileOpts) {
+	// #4329: stamp the compiled cluster node identity from the runtime
+	// node-id (/etc/xpf/node-id, or the `-node-id` flag on `xpfd
+	// check-config`) when the config carries a chassis-cluster stanza but no
+	// explicit `chassis cluster node` leaf. A canonical vSRX chassis-cluster
+	// config encodes node ownership in the FPC slot (ge-0/0/N=node0,
+	// ge-7/0/N=node1) and runs the SAME flat config on both nodes with no
+	// `node` leaf. Without this stamp, Cluster.NodeID sits at its zero default
+	// on BOTH nodes, so every NodeID-dependent derivation resolves to the
+	// node-0 member on node 1 — reth breaks on the secondary (RethToPhysical
+	// reads NodeID at runtime), AND the compile-time fabric-member /
+	// FabricInterface auto-detect below (SlotToNodeID(member) == cc.NodeID)
+	// binds fab0/fab1 to the node-0 member. Stamping makes the compiled
+	// identity reflect the node the config is compiled FOR, so BOTH reth and
+	// fabric resolve to the LOCAL member on each node and the flat vSRX form
+	// is a drop-in.
+	//
+	// This MUST run after the child loop (Cluster + interfaces are populated)
+	// and BEFORE every NodeID-dependent derivation that follows: the fabric
+	// fixup below and validateDeviceMapStrict later in the compile both read
+	// cc.NodeID.
+	//
+	// Guards (all load-bearing):
+	//   - opts.nodeAware && stampNodeID >= 0: only the node-aware entry
+	//     (compileConfigForNodeWithOpts) sets these. The standalone
+	//     CompileConfig path leaves nodeAware false, so single-node compiles
+	//     are unchanged; a negative node-id (defensive) never stamps.
+	//   - Cluster != nil: never fabricate a cluster stanza. A config-less HA
+	//     node (node-id present but empty/no-cluster config — the EMPTY-config
+	//     takeover in pkg/daemon/daemon.go) must keep Cluster == nil so the
+	//     daemon's `haMode` / `Cluster != nil` gates do not flip on a config
+	//     that has no cluster. A real reth/fabric config always carries a
+	//     `chassis cluster` stanza, so this never suppresses a genuine fix.
+	//   - !NodeIDSet: an explicit `chassis cluster node <id>` leaf is the
+	//     operator's SSOT and must win — never clobber it. crossCheckNodeID
+	//     (pkg/configstore) already rejects a leaf that disagrees with the
+	//     runtime node-id, and the GROUPS form (groups node0/node1 each carry
+	//     an explicit `node` leaf) is left bit-identical.
+	if opts.nodeAware && opts.stampNodeID >= 0 &&
+		cfg.Chassis.Cluster != nil && !cfg.Chassis.Cluster.NodeIDSet {
+		cfg.Chassis.Cluster.NodeID = opts.stampNodeID
+	}
+
+	// #3870: resolve the BGP local-AS from `routing-options
+	// autonomous-system` when `protocols bgp local-as` was omitted. Runs
+	// after the child loop so both routing-options and protocols/
+	// routing-instances are populated regardless of their order under root.
+	resolveBGPAutonomousSystem(cfg)
+
+	// Extract lo0 filter input from parsed interfaces into SystemConfig.
+	if lo0 := cfg.Interfaces.Interfaces["lo0"]; lo0 != nil {
+		if u0 := lo0.Units[0]; u0 != nil {
+			cfg.System.Lo0FilterInputV4 = u0.FilterInputV4
+			cfg.System.Lo0FilterInputV6 = u0.FilterInputV6
+		}
+	}
+
+	// #4021: fold interface-level CoS bindings (`class-of-service interfaces
+	// geX { scheduler-map M; ... }` with no `unit`) into the interface's
+	// configured logical units. Runs after the child loop so both the
+	// interface stanza (cfg.Interfaces) and class-of-service are populated
+	// regardless of their order under root; a unit-level binding overrides
+	// the interface-level one per knob (Junos precedence).
+	applyCoSInterfaceLevelBindings(cfg)
+
+	// #4315 (fable-167 F-2): resolve output-traffic-control-profile bindings
+	// into each unit's per-unit shaper (shaping-rate + scheduler-map). Runs
+	// AFTER the interface-level fold so an interface-level profile binding is
+	// already present on each unit. Before modeling, the hierarchical
+	// traffic-control-profile binding was silently dropped — a clean commit
+	// with ZERO shaping; now the shaper actually materializes.
+	resolveCoSTrafficControlProfiles(cfg)
+
+	// Post-compilation fixup: resolve vSRX-style fabric member-interfaces.
+	// For fab0/fab1 with fabric-options member-interfaces, resolve which member
+	// belongs to the local node using FPC slot → node-id mapping (slot 0 → node0,
+	// slot 7 → node1). Also auto-populate FabricInterface/Fabric1Interface when
+	// not explicitly set in chassis cluster config.
+	if cc := cfg.Chassis.Cluster; cc != nil {
+		for ifName, ifc := range cfg.Interfaces.Interfaces {
+			if !strings.HasPrefix(ifName, "fab") || len(ifc.FabricMembers) == 0 {
+				continue
+			}
+			for _, member := range ifc.FabricMembers {
+				slot := InterfaceSlot(member)
+				if slot >= 0 && SlotToNodeID(slot) == cc.NodeID {
+					ifc.LocalFabricMember = member
+					break
+				}
+			}
+		}
+		// Auto-detect fabric interfaces from fab0/fab1 member-interfaces
+		// when not explicitly configured via fabric-interface/fabric1-interface.
+		// Only set if the local node has a member (LocalFabricMember resolved above).
+		// Dual-fabric: if both fab0 and fab1 have local members, set both
+		// FabricInterface and Fabric1Interface (#130).
+		// Single-fabric: only one fab is local → FabricInterface only.
+		if cc.FabricInterface == "" {
+			if f0, ok := cfg.Interfaces.Interfaces["fab0"]; ok && f0.LocalFabricMember != "" {
+				cc.FabricInterface = "fab0"
+			} else if f1, ok := cfg.Interfaces.Interfaces["fab1"]; ok && f1.LocalFabricMember != "" {
+				cc.FabricInterface = "fab1"
+			}
+		}
+		// Auto-detect secondary fabric: fab1 when primary is fab0 and fab1
+		// also has a local member (dual-fabric topology).
+		if cc.Fabric1Interface == "" && cc.FabricInterface == "fab0" {
+			if f1, ok := cfg.Interfaces.Interfaces["fab1"]; ok && f1.LocalFabricMember != "" {
+				cc.Fabric1Interface = "fab1"
+			}
+		}
+		// Auto-derive Fabric1PeerAddress from the fab1 interface's /30 or /31
+		// address when not explicitly configured.
+		if cc.Fabric1Interface != "" && cc.Fabric1PeerAddress == "" {
+			if f1 := cfg.Interfaces.Interfaces[cc.Fabric1Interface]; f1 != nil {
+				if u0 := f1.Units[0]; u0 != nil {
+					for _, addr := range u0.Addresses {
+						if peer := peerFromPointToPoint(addr); peer != "" {
+							cc.Fabric1PeerAddress = peer
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Step 5 (the plan's **MODERATE** phase) of the #4406 `compileExpanded`
god-orchestrator decomposition (ps-review-011 / codex-173 #4). Prior steps
extracted P1 `runPreWalkGates`, P4 `compileSections`, P7 `runTailGates`, and P6b
`runUniformGates`. This lifts the **P5 cross-section derivations** block into a
named phase helper.

## What moves

The contiguous, NON-reorderable run of post-dispatch mutations between the P4
section dispatch and the P6a early-strict folds (`validateDataplaneTypeStrict`)
moves into a new free function:

```go
func resolveDerivedConfig(cfg *Config, opts compileOpts)
```

Unlike the pre-walk / gate phases, P5 runs **no validation and returns no
error** — it is pure cross-section mutation, so the helper takes `cfg` + `opts`
and returns nothing (matching the real block, which never returned an error nor
threaded warnings). It reads only `cfg` + `opts` (never `tree`), so `tree` is
deliberately not a parameter.

## Load-bearing internal order (preserved verbatim)

1. **#4329 NodeID stamp** — MUST precede the fabric fixup AND
   `validateDeviceMapStrict` (P6b), both of which read `cc.NodeID`.
2. `resolveBGPAutonomousSystem`.
3. lo0 unit-0 input-filter extract into `SystemConfig`.
4. `applyCoSInterfaceLevelBindings`.
5. `resolveCoSTrafficControlProfiles` — MUST follow the interface-level fold (4).
6. fabric member/interface fixup (`LocalFabricMember` / `FabricInterface` /
   `Fabric1Interface` / `Fabric1PeerAddress` auto-detect).

The P6a folds (`resolveZoneLocalAddressBooks` / `resolveStaticNATThenPrefixNames`)
stay INLINE — they belong to the separate, deferred P6a step.

## Validation

- **Golden gate `TestCompileGolden4406` passes BYTE-IDENTICAL** with NO baseline
  update — `testdata/golden_4406.json` untouched (git status clean). The
  strict/lenient × node0/node1 matrix returns identical `*Config` + `Warnings` +
  error strings.
- Non-local consumer tests green: `TestFlatFabric*_4329`, `TestDeviceMap*`,
  `TestStaticNATThen*`, CoS traffic-control, BGP-AS, lo0-filter.
- `gofmt` clean, `go vet` clean, `go build ./...` + full `pkg/config` suite green.
- `compiler.go` shrinks 125 net lines (15 ins / 125 del).

Behavior-preserving code-motion only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi