### PR TITLE
Refs #4406 (step 6: extract P6a early-strict + folds — decomposition COMPLETE)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,42 @@
+## 2026-07-07 — #4406 step 6 (FINAL): extract P6a early-strict + folds from compileExpanded
+
+- **Timestamp**: 2026-07-07
+- **Action**: Step 6 — the plan's RISKY final phase — of the #4406
+  compileExpanded god-orchestrator decomposition (after step 1 P1
+  runPreWalkGates, step 2 P4 compileSections, step 3 P7 runTailGates, step 4
+  P6b runUniformGates, step 5 P5 resolveDerivedConfig). Extracted the P6a
+  "early-strict + folds" phase — the block between resolveDerivedConfig (P5)
+  and runUniformGates (P6b) — into a new free function
+  `runEarlyStrictAndFolds(cfg *Config, opts compileOpts) error`
+  (compiler_earlystrict.go). The plan flags P6a RISKY because it interleaves
+  validation with two cfg-mutations whose output is consumed non-locally in
+  P6b, plus a fail-fast gate and an errors.Join accumulator. Verified
+  extractable, NOT deferred: the `strictErrs` accumulator is FULLY CONTAINED
+  within P6a (declared, appended by the five #1538 independent strict families,
+  errors.Join'd + returned there) and is NOT threaded into runUniformGates, so
+  the DEFER trigger (accumulator threaded across the P6a/P6b boundary) does not
+  hold. The two folds (resolveZoneLocalAddressBooks,
+  resolveStaticNATThenPrefixNames) mutate cfg.Security by pointer and persist
+  across the helper boundary because cfg is threaded by pointer and the helper
+  runs BEFORE runUniformGates — so validateStaticNATThenTargetStrict and the
+  policy match-address validators in P6b (invariant #5) still see the folded
+  book. Internal order preserved VERBATIM: validateDataplaneTypeStrict
+  (fail-fast, #1526 first-error slot) -> validateAddressBookEntryNamesStrict on
+  the pristine book (#3061/#4340, lenient-downgrade append to cfg.Warnings) ->
+  zone-local fold -> static-NAT prefix-name fold -> the five-family errors.Join
+  accumulator. Each `return nil, err` in the block became `return err` in the
+  helper; compileExpanded now calls `if err := runEarlyStrictAndFolds(cfg,
+  opts); err != nil { return nil, err }`. compileExpanded is now FULLY
+  decomposed into named phase helpers (P1..P7) — a ~15-line orchestrator.
+  GOLDEN GATE: TestCompileGolden4406 passes BYTE-IDENTICAL with NO baseline
+  update (testdata/golden_4406.json untouched, no .actual.json written); full
+  pkg/config suite green; the non-local-consumer tests
+  (StaticNATThen/AddressBook/ZoneLocal/DataplaneType/IPMonitoring/
+  ClassOfServiceStrict) green; go build ./cmd/xpfd + go vet + gofmt clean. Net
+  78 lines lifted out of compiler.go (93 deletions / 15 insertions).
+- **File(s)**: pkg/config/compiler.go, pkg/config/compiler_earlystrict.go,
+  _Log.md
+
 ## 2026-07-07 — #4406 step 5: extract P5 cross-section derivations from compileExpanded
 
 - **Timestamp**: 2026-07-07

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1984,99 +1984,21 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	// sub-steps.
 	resolveDerivedConfig(cfg, opts)
 
-	// #1526 — reject retired dataplane backends at commit time.
-	// Placed BEFORE the other strict validators so that an operator
-	// editing a candidate that has BOTH a retired dataplane-type and
-	// an unrelated structural error (CoS, policers, scheduler-map)
-	// sees the migration message first. The retirement is the
-	// documented migration path; the other errors only become
-	// actionable after migration. This precheck stays fail-fast
-	// (the no-leak contract is pinned by
-	// TestDataplaneTypeDPDKRejectedAtCommitFiresFirst in
-	// parser_ast_test.go).
-	//
-	// Store.Load and Store.SyncApply tolerate retired-backend
-	// configs via rewriteRetiredDataplaneType which strips the
-	// retired leaf from the AST before compile (#1373 ebpf +
-	// #1525 dpdk handle both this way). See
-	// pkg/configstore/dataplane_retire.go.
-	if err := validateDataplaneTypeStrict(cfg); err != nil {
-		return nil, err
-	}
-
-	// #3061 (narrowed in #4340) — enforce the two naming invariants that keep
-	// the synthetic zone-local/<zone>/<name> internal names minted by
-	// resolveZoneLocalAddressBooks collision-proof, BEFORE folding zone-local
-	// books: an operator address-book entry name may not begin with the reserved
-	// `zone-local/` prefix, and a security-zone name may not contain `/`. A `/`
-	// elsewhere in an entry name (net_10.0.0.0/8) is permitted — the
-	// prefix-in-name convention real vSRX configs use (#4340). This MUST run on
-	// the pristine global book — i.e. before the fold injects the `/`-bearing
-	// synthetic names — so it is placed here rather than in the post-fold
-	// accumulator. Strict on commit / commit-check (hard-reject); tolerant load /
-	// peer-sync downgrade to a warning (#1960 no-brick; the fold's no-clobber
-	// guard keeps it from silently overwriting an operator entry).
-	if err := validateAddressBookEntryNamesStrict(cfg); err != nil {
-		if opts.lenientAddressBookNames {
-			cfg.Warnings = append(cfg.Warnings,
-				fmt.Sprintf("address-book/zone name (downgraded to warning on tolerant path): %v", err))
-		} else {
-			return nil, err
-		}
-	}
-	// #3061 — fold zone-local address books into the global book under
-	// zone-qualified internal names and rewrite policy match tokens. Runs after
-	// the name gate (above) and before the policy match-address resolution
-	// validators (validatePolicyMatchAddressesStrict /
-	// validatePolicyMatchAddressSetMembersStrict), which depend on the rewritten
-	// tokens and synthetic global entries.
-	resolveZoneLocalAddressBooks(&cfg.Security)
-
-	// #4290 — resolve `then static-nat prefix-name <name>` translation targets
-	// into their literal prefix now that the global address book is fully
-	// folded (compileNAT can run before compileAddressBook within a `security {}`
-	// root, so this cannot happen inline in the then switch). An unresolvable
-	// reference leaves Then=="" and is rejected below by
-	// validateStaticNATThenTargetStrict (warn on the tolerant path).
-	resolveStaticNATThenPrefixNames(&cfg.Security)
-
-	// #1538 — accumulate independent strict-validator families so
-	// `commit check` surfaces one error per family in a single
-	// response. This saves operator round-trips on first-touch
-	// upgrades from legacy candidates that carry several dormant
-	// structural findings at once. Validators in this group MUST
-	// remain independent: each reads its own typed sub-struct of
-	// *Config and does not depend on another's success. Each
-	// validator still fail-fasts INTERNALLY (one error per family
-	// in a single response), which is sufficient for the upgrade
-	// UX win; full intra-validator accumulation is deliberately
-	// out of scope. If a future validator depends on another's
-	// success it must be added as a separate post-accumulator
-	// step with its own guard rather than slotted in alongside
-	// the independent set.
-	var strictErrs []error
-	if err := validateClassOfServiceStrict(cfg.ClassOfService); err != nil {
-		strictErrs = append(strictErrs, err)
-	}
-	if err := validateThreeColorPolicersStrict(cfg.Firewall.ThreeColorPolicers); err != nil {
-		strictErrs = append(strictErrs, err)
-	}
-	if err := validatePolicySchedulerReferencesStrict(cfg); err != nil {
-		strictErrs = append(strictErrs, err)
-	}
-	if err := validateRPMProbePinsStrict(cfg); err != nil {
-		strictErrs = append(strictErrs, err)
-	}
-	if err := validateIPMonitoringStrict(cfg); err != nil {
-		strictErrs = append(strictErrs, err)
-	}
-	// #1830 (e): the #1733 equal-flow worker-cap validator
-	// (validateEqualFlowWorkerCapStrict / MaxEqualFlowWorkers) is retired.
-	// The v8 lease rotation now sizes its per-worker scratch from the true
-	// worker count (heap scratch in rotate_epoch_v8.rs), so
-	// equal-flow-enforcement no longer fail-opens above 32 workers and the
-	// commit-time rejection has nothing left to guard.
-	if err := errors.Join(strictErrs...); err != nil {
+	// P6a (#4406 step 6, FINAL): early-strict validation + the two folds.
+	// Extracted into runEarlyStrictAndFolds (compiler_earlystrict.go) — the
+	// RISKY entangled phase that interleaves validation with two cfg-mutations
+	// whose output is consumed non-locally in P6b: the fail-fast
+	// validateDataplaneTypeStrict (#1526, wins the first-error slot), the
+	// pristine-book address-book/zone name gate (#3061/#4340, before the fold
+	// injects `/`-bearing synthetic names), the resolveZoneLocalAddressBooks and
+	// resolveStaticNATThenPrefixNames folds (MUT cfg.Security, read by the P6b
+	// policy match-address + validateStaticNATThenTargetStrict gates — invariant
+	// #5), and the #1538 errors.Join independent-strict-family accumulator (fully
+	// CONTAINED here — NOT threaded into P6b). Behavior-preserving lift; runs
+	// AFTER the P5 derivations above and BEFORE the P6b uniform gates below, so
+	// the strict first-error slot (invariant #6) and the tolerant-path warning
+	// order (invariant #7) are unchanged. Do NOT reorder the interleave.
+	if err := runEarlyStrictAndFolds(cfg, opts); err != nil {
 		return nil, err
 	}
 

--- a/pkg/config/compiler_earlystrict.go
+++ b/pkg/config/compiler_earlystrict.go
@@ -1,0 +1,144 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+)
+
+// runEarlyStrictAndFolds runs the P6a "early-strict + folds" phase of config
+// compilation — the entangled block extracted from compileExpanded as step 6
+// (the final step) of the #4406 god-orchestrator decomposition (ps-review-011
+// / codex-173 #4).
+//
+// Unlike the pure-mutation P5 (resolveDerivedConfig) and the uniform fail-open
+// P6b (runUniformGates), this phase INTERLEAVES validation with two mutations
+// whose output is consumed non-locally in P6b. The plan (#4406) flags it RISKY,
+// so its internal ORDER and the errors.Join accumulator semantics are load-
+// bearing and a VERBATIM lift of the master block:
+//
+//  1. validateDataplaneTypeStrict — fail-fast (no lenient downgrade). #1526:
+//     placed FIRST so a retired dataplane-type wins the first-error slot over
+//     any unrelated structural error; the migration message is the documented
+//     path. Pinned by TestDataplaneTypeDPDKRejectedAtCommitFiresFirst.
+//  2. validateAddressBookEntryNamesStrict on the PRISTINE global book (#3061 /
+//     #4340) — MUST run before the zone-local fold injects the `/`-bearing
+//     synthetic names. Strict on commit; downgraded to a warning on the
+//     tolerant lenientAddressBookNames path (#1960 no-brick).
+//  3. resolveZoneLocalAddressBooks (MUT cfg.Security) — folds zone-local books
+//     into the global book under zone-qualified internal names. Output consumed
+//     non-locally by the P6b policy match-address validators.
+//  4. resolveStaticNATThenPrefixNames (MUT cfg.Security) — resolves
+//     `then static-nat prefix-name` targets now that the global book is folded.
+//     Output consumed non-locally by validateStaticNATThenTargetStrict (P6b,
+//     invariant #5) — the mutation persists across the helper boundary because
+//     cfg is threaded by pointer and this phase runs BEFORE runUniformGates.
+//  5. The #1538 independent strict-validator accumulator: five families each
+//     append to strictErrs (fully CONTAINED here — NOT threaded into P6b), then
+//     errors.Join surfaces one error per family in a single `commit check`
+//     response.
+//
+// Behavior-preserving invariants (do NOT reorder relative to master): runs
+// AFTER the P5 resolveDerivedConfig derivations and BEFORE the P6b uniform
+// gates, so the strict first-error slot (invariant #6) and the tolerant-path
+// warning accumulation ORDER (invariant #7) are unchanged. It mutates the
+// shared *Config in place (the folds + the lenient warning append) and returns
+// the FIRST fail-fast error or the joined accumulator error. Covered by the
+// reusable golden-output gate in compile_golden_4406_test.go.
+func runEarlyStrictAndFolds(cfg *Config, opts compileOpts) error {
+	// #1526 — reject retired dataplane backends at commit time.
+	// Placed BEFORE the other strict validators so that an operator
+	// editing a candidate that has BOTH a retired dataplane-type and
+	// an unrelated structural error (CoS, policers, scheduler-map)
+	// sees the migration message first. The retirement is the
+	// documented migration path; the other errors only become
+	// actionable after migration. This precheck stays fail-fast
+	// (the no-leak contract is pinned by
+	// TestDataplaneTypeDPDKRejectedAtCommitFiresFirst in
+	// parser_ast_test.go).
+	//
+	// Store.Load and Store.SyncApply tolerate retired-backend
+	// configs via rewriteRetiredDataplaneType which strips the
+	// retired leaf from the AST before compile (#1373 ebpf +
+	// #1525 dpdk handle both this way). See
+	// pkg/configstore/dataplane_retire.go.
+	if err := validateDataplaneTypeStrict(cfg); err != nil {
+		return err
+	}
+
+	// #3061 (narrowed in #4340) — enforce the two naming invariants that keep
+	// the synthetic zone-local/<zone>/<name> internal names minted by
+	// resolveZoneLocalAddressBooks collision-proof, BEFORE folding zone-local
+	// books: an operator address-book entry name may not begin with the reserved
+	// `zone-local/` prefix, and a security-zone name may not contain `/`. A `/`
+	// elsewhere in an entry name (net_10.0.0.0/8) is permitted — the
+	// prefix-in-name convention real vSRX configs use (#4340). This MUST run on
+	// the pristine global book — i.e. before the fold injects the `/`-bearing
+	// synthetic names — so it is placed here rather than in the post-fold
+	// accumulator. Strict on commit / commit-check (hard-reject); tolerant load /
+	// peer-sync downgrade to a warning (#1960 no-brick; the fold's no-clobber
+	// guard keeps it from silently overwriting an operator entry).
+	if err := validateAddressBookEntryNamesStrict(cfg); err != nil {
+		if opts.lenientAddressBookNames {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("address-book/zone name (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+	// #3061 — fold zone-local address books into the global book under
+	// zone-qualified internal names and rewrite policy match tokens. Runs after
+	// the name gate (above) and before the policy match-address resolution
+	// validators (validatePolicyMatchAddressesStrict /
+	// validatePolicyMatchAddressSetMembersStrict), which depend on the rewritten
+	// tokens and synthetic global entries.
+	resolveZoneLocalAddressBooks(&cfg.Security)
+
+	// #4290 — resolve `then static-nat prefix-name <name>` translation targets
+	// into their literal prefix now that the global address book is fully
+	// folded (compileNAT can run before compileAddressBook within a `security {}`
+	// root, so this cannot happen inline in the then switch). An unresolvable
+	// reference leaves Then=="" and is rejected below by
+	// validateStaticNATThenTargetStrict (warn on the tolerant path).
+	resolveStaticNATThenPrefixNames(&cfg.Security)
+
+	// #1538 — accumulate independent strict-validator families so
+	// `commit check` surfaces one error per family in a single
+	// response. This saves operator round-trips on first-touch
+	// upgrades from legacy candidates that carry several dormant
+	// structural findings at once. Validators in this group MUST
+	// remain independent: each reads its own typed sub-struct of
+	// *Config and does not depend on another's success. Each
+	// validator still fail-fasts INTERNALLY (one error per family
+	// in a single response), which is sufficient for the upgrade
+	// UX win; full intra-validator accumulation is deliberately
+	// out of scope. If a future validator depends on another's
+	// success it must be added as a separate post-accumulator
+	// step with its own guard rather than slotted in alongside
+	// the independent set.
+	var strictErrs []error
+	if err := validateClassOfServiceStrict(cfg.ClassOfService); err != nil {
+		strictErrs = append(strictErrs, err)
+	}
+	if err := validateThreeColorPolicersStrict(cfg.Firewall.ThreeColorPolicers); err != nil {
+		strictErrs = append(strictErrs, err)
+	}
+	if err := validatePolicySchedulerReferencesStrict(cfg); err != nil {
+		strictErrs = append(strictErrs, err)
+	}
+	if err := validateRPMProbePinsStrict(cfg); err != nil {
+		strictErrs = append(strictErrs, err)
+	}
+	if err := validateIPMonitoringStrict(cfg); err != nil {
+		strictErrs = append(strictErrs, err)
+	}
+	// #1830 (e): the #1733 equal-flow worker-cap validator
+	// (validateEqualFlowWorkerCapStrict / MaxEqualFlowWorkers) is retired.
+	// The v8 lease rotation now sizes its per-worker scratch from the true
+	// worker count (heap scratch in rotate_epoch_v8.rs), so
+	// equal-flow-enforcement no longer fail-opens above 32 workers and the
+	// commit-time rejection has nothing left to guard.
+	if err := errors.Join(strictErrs...); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Final step of the `compileExpanded` god-orchestrator decomposition
(ps-review-011 / codex-173 #4), landing the plan's **RISKY** phase after steps
1-5 (P1 `runPreWalkGates`, P4 `compileSections`, P7 `runTailGates`, P6b
`runUniformGates`, P5 `resolveDerivedConfig`).

Extracts the **P6a "early-strict + folds"** phase — the block between
`resolveDerivedConfig` (P5) and `runUniformGates` (P6b) — into a new
package-internal free function `runEarlyStrictAndFolds(cfg *Config, opts
compileOpts) error` in `pkg/config/compiler_earlystrict.go`. **`compileExpanded`
is now a ~15-line orchestrator** that calls the named phase helpers P1..P7 in
order — the decomposition is COMPLETE.

## Extractable, not deferred

The plan flags P6a RISKY (validation interleaved with two cfg-mutations consumed
non-locally in P6b, a fail-fast gate, and an `errors.Join` accumulator) and says
to DEFER **only if** the `strictErrs` accumulator is threaded across the
P6a/P6b boundary. It is not: `strictErrs` is declared, appended by the five
#1538 independent strict-validator families, `errors.Join`'d, and returned
**entirely within P6a**. `runUniformGates` (P6b) is a separate function that
never touches it — the accumulator is fully contained, so the lift cannot change
behavior.

## Load-bearing semantics preserved

- **Internal order is a verbatim lift**: `validateDataplaneTypeStrict`
  (fail-fast, #1526 first-error slot) -> `validateAddressBookEntryNamesStrict`
  on the **pristine** book (#3061/#4340, before the fold injects `/`-bearing
  synthetic names; lenient path appends to `cfg.Warnings`) -> zone-local fold ->
  static-NAT prefix-name fold -> the five-family `errors.Join` accumulator.
- **Folds persist by pointer**: `resolveZoneLocalAddressBooks` /
  `resolveStaticNATThenPrefixNames` mutate `cfg.Security`; because `cfg` is
  threaded by pointer and the helper runs BEFORE `runUniformGates`, the folded
  book is visible to the non-local consumers in P6b
  (`validateStaticNATThenTargetStrict` — invariant #5 — and the policy
  match-address validators).
- Each `return nil, err` became `return err`; `compileExpanded` dispatches the
  first error via `if err := runEarlyStrictAndFolds(cfg, opts); err != nil {
  return nil, err }`. Strict first-error slot (invariant #6) and tolerant-path
  warning order (invariant #7) unchanged.

## Validation

- **Golden gate `TestCompileGolden4406` passes BYTE-IDENTICAL** with NO baseline
  update (`testdata/golden_4406.json` untouched, no `.actual.json` written) —
  the whole compiled `*Config` (incl. the order-sensitive `cfg.Warnings`) + the
  error string is unchanged across the full strict/lenient x generic/node0/node1
  corpus matrix.
- Full `pkg/config` suite green, including the non-local-consumer tests
  (StaticNATThen / AddressBook / ZoneLocal / DataplaneType / IPMonitoring /
  ClassOfServiceStrict).
- `go build ./cmd/xpfd`, `go vet ./pkg/config`, `gofmt` clean.
- Net 78 lines lifted out of `compiler.go` (93 deletions / 15 insertions).

Refs #4406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi