### PR TITLE
Refs #4407 Phase A (group tail reconcile dispatches)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-07-07 — #4407 Phase A: group tail reconcile dispatches (steps 8–21)
+
+- **Timestamp**: 2026-07-07
+- **Action**: Phase A of the #4407 `applyConfigLocked` decomposition
+  (PLAN-READY per the converged plan). Grouped the TAIL reconcile
+  dispatches — steps 8–21 (VRRP UpdateInstances, DNS/NTP, hostname/
+  timezone/kernel + lo0/host-inbound nft, ssh-known-hosts, syslog,
+  login+sudoers, ssh, root-auth, syslog-files/config, archive+archival+
+  archive-timer, flow-trace/exporters/dhcp-relay/lldp, event-options/rpm/
+  ipmon, interface-monitors, cluster UpdateConfig+monitor-weight,
+  transport-change restart, RSS reshape + step0 tunables) — into a new
+  helper `applyTailReconciles(cfg, networkdErr, dhcpServerErr, ipsecErr) error`.
+  The ordering-entangled HEAD (steps 0–7: VRF/tunnel/IPVLAN/dataplane/
+  RETH-MAC/networkd/FRR) stays INLINE (Phases B/C, deferred to
+  /triple-review). This is a behavior-preserving mechanical move: the diff
+  is a pure +30-line insertion at the head/tail seam — zero lines of the
+  step 8–21 block moved. The tail reads only cfg (+ nil-guarded managers);
+  no tail step feeds a later head step. Error-join threading: the three
+  head-produced deferred errors (networkdErr/dhcpServerErr/ipsecErr) are
+  passed in as parameters; lo0Err/hostInboundErr are created inside the
+  helper at step 9.5; the helper returns the identical
+  `errors.Join(networkdErr, dhcpServerErr, hostInboundErr, lo0Err, ipsecErr)`
+  in the exact original operand order. Helper runs synchronously in the
+  caller's goroutine under d.applySem (caller holds it) — lock discipline
+  preserved; the async apply callbacks all live in the head.
+- **File(s)**: pkg/daemon/daemon_apply.go, _Log.md
+- **Validation**: gofmt clean, `go build ./...` green, `go vet ./pkg/daemon/`
+  clean, `go test ./pkg/daemon/...` green — including all 6 named
+  characterization tests (snmp/flowexport/dhcprelay/policy-scheduler/
+  persistent-snat/runtime-result). NOTE: HA reconcile/apply path — a
+  cluster-smoke (test-failover: deploy + apply config + confirm no reconcile
+  regression) is warranted before merge.
+
 ## 2026-07-07 — #4406 step 6 (FINAL): extract P6a early-strict + folds from compileExpanded
 
 - **Timestamp**: 2026-07-07

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1433,6 +1433,36 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// active before a newly started client puts DHCP packets on the wire.
 	d.reconcileDHCPClients(cfg)
 
+	// Steps 8–21: tail reconcile dispatches (VRRP, system config, syslog,
+	// login/SSH, archival, observability, cluster runtime, host tunables).
+	// Extracted into applyTailReconciles (#4407 Phase A). The head above
+	// (steps 0–7) is ordering-entangled and stays inline; the tail is
+	// independent per-subsystem dispatch reading only cfg (+ nil-guarded
+	// managers), so grouping it here is a behavior-preserving mechanical
+	// move. The three head-produced deferred errors are threaded in; the
+	// helper creates lo0Err/hostInboundErr and returns the identical
+	// five-way errors.Join.
+	return d.applyTailReconciles(cfg, networkdErr, dhcpServerErr, ipsecErr)
+}
+
+// applyTailReconciles runs steps 8–21 of applyConfigLocked — the tail of the
+// commit/apply pipeline that dispatches to independent subsystems after the
+// ordering-entangled head (VRF/tunnel/IPVLAN/dataplane/RETH-MAC/networkd/FRR,
+// steps 0–7). Each step reads only the compiled config (+ nil-guarded
+// subsystems); none feeds a later head step, so grouping them here is a
+// behavior-preserving mechanical move (#4407 Phase A). The helper runs
+// synchronously in the caller's goroutine under d.applySem (the caller holds
+// it), so the lock discipline of the inline body is preserved; the few
+// intentionally-async callbacks the apply body spawns all live in the head,
+// not here.
+//
+// Error-join contract: the five deferred reconcile errors accumulate across
+// the whole apply body but are joined only at this tail (fail-closed — every
+// step still runs). networkdErr/dhcpServerErr/ipsecErr originate in the head
+// and are threaded in as parameters; lo0Err/hostInboundErr originate in step
+// 9.5 below. The returned errors.Join preserves the exact operand order the
+// inline tail used (#1778/#2987/#4433).
+func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, dhcpServerErr, ipsecErr error) error {
 	// 8. Apply VRRP config — merge user VRRP + RETH VRRP instances
 	vrrpInstances := vrrp.CollectInstances(cfg)
 	if d.cluster != nil {


### PR DESCRIPTION
## Summary

Phase A of the `applyConfigLocked` decomposition (#4407, converged plan
in the issue comment). Groups the **TAIL** reconcile dispatches — steps
8–21 — into a new helper, leaving the ordering-entangled **HEAD** (steps
0–7) inline for Phases B/C (`/triple-review`).

Extract into:

```go
func (d *Daemon) applyTailReconciles(cfg *config.Config,
    networkdErr, dhcpServerErr, ipsecErr error) error
```

The tail covers VRRP `UpdateInstances` (8); DNS/NTP (9); hostname/
timezone/kernel + lo0/host-inbound nft (9.5); ssh-known-hosts (9.6);
syslog (10); login+sudoers (11/11b); ssh (12); root-auth (13); syslog
files/config (14/14b); archive+archival+archive-timer (15/15b/15c);
flow-trace/exporters/dhcp-relay/lldp (16..16d); event-options/rpm/ipmon
(17..17c); interface-monitors (18); cluster `UpdateConfig`+monitor-weight
(19); transport-change comms restart (20); RSS reshape + step-0 host
tunables (21).

## Behavior-preserving mechanical move

- The diff is a **pure +30-line insertion at the head/tail seam** — not a
  single line of the step 8–21 block is modified. The existing
  `errors.Join` return and closing brace simply become the helper's.
- Every tail step reads only `cfg` (+ nil-guarded manager fields); no tail
  step feeds a later head step, so no reordering is required.
- **Error-join threading is identical.** `networkdErr`/`dhcpServerErr`/
  `ipsecErr` originate in the head and are threaded in as parameters;
  `lo0Err`/`hostInboundErr` originate in step 9.5 inside the helper. The
  helper returns the identical
  `errors.Join(networkdErr, dhcpServerErr, hostInboundErr, lo0Err, ipsecErr)`
  in the same operand order (#1778/#2987/#4433).
- Helper runs synchronously in the caller's goroutine under `d.applySem`
  (caller holds it) — lock discipline preserved.

## Validation

- `gofmt` clean, `go build ./...` green, `go vet ./pkg/daemon/` clean.
- `go test ./pkg/daemon/...` green, including the six selective-nil
  characterization tests the plan names as the behavior gate:
  snmp / flowexport / dhcprelay / policy-scheduler / persistent-snat /
  runtime-result.

## Before merge

HA reconcile/apply path — a **cluster-smoke** (`test-failover`: deploy +
apply a config + confirm no reconcile regression) is warranted before
merge, per the plan's Phase A gate.

Refs #4407

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi