### PR TITLE
cluster: gate HA bulk re-drive on outbound-only ack flag (#4360)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -38898,3 +38898,26 @@ top.
 - **File(s)**: pkg/config/compiler.go, pkg/config/compiler_prewalk.go,
   pkg/config/compile_golden_4406_test.go,
   pkg/config/testdata/golden_4406.json, _Log.md
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4360 — HA session-sync survivor-fabric re-drive gate keyed on
+  the SHARED `bulkEverCompleted` flag. That flag is set by EITHER an inbound
+  `BulkEnd` (peer->us) OR an outbound `BulkAck` (us->peer), so a small inbound
+  bulk completing first suppressed re-driving a stranded OUTBOUND bulk: the
+  peer kept an incomplete view of our sessions. Added a dedicated
+  `outboundBulkAcked atomic.Bool` set ONLY in the `syncMsgBulkAck` path
+  (pkg/cluster/sync_conn.go) and re-pointed BOTH the `handleDisconnect`
+  re-drive gate and its in-goroutine re-check from `bulkEverCompleted` to
+  `outboundBulkAcked` (the inner re-check MUST also flip, else it bails on a
+  set `bulkEverCompleted` and the fix is inert). The `coldStart` gate in
+  `handleNewConnection` is intentionally left on `bulkEverCompleted` (a
+  both-fabrics-down reconnect is a separate path). `outboundBulkAcked` is
+  sticky (never reset), matching `bulkEverCompleted`. Added RED-on-revert test
+  `TestBulkSyncRedriveWhenOnlyInboundCompleted` (inbound-completes-first +
+  single-fabric drop must still re-drive) and updated
+  `TestBulkSyncNoRedriveWhenAlreadyCompleted` to set `outboundBulkAcked`.
+  Verified: new test FAILS with the gate reverted to `bulkEverCompleted`,
+  passes with the fix; `go test ./pkg/cluster/... -race` green; go build +
+  vet + gofmt clean. Doc: docs/sync-protocol.md #4090 re-drive section.
+- **File(s)**: pkg/cluster/sync.go, pkg/cluster/sync_conn.go,
+  pkg/cluster/sync_test.go, docs/sync-protocol.md, _Log.md

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -417,8 +417,8 @@ session table until BOTH fabrics happened to drop together.
 
 `handleDisconnect` now closes that gap. After clearing the dropped conn and
 computing `connected := conn0 != nil || conn1 != nil`, when a survivor is still
-up AND `!bulkEverCompleted.Load()` (the cold-start bulk never completed), it
-schedules a single re-drive of `doBulkSync()` over the survivor:
+up AND `!outboundBulkAcked.Load()` (our outbound bulk was never acked by the
+peer), it schedules a single re-drive of `doBulkSync()` over the survivor:
 
 - **Goroutine, not inline.** `handleDisconnect` holds `s.mu`, and
   `doBulkSync → BulkSync/sendBulkMarkers → getActiveConn` re-locks `s.mu`; an
@@ -436,10 +436,27 @@ schedules a single re-drive of `doBulkSync()` over the survivor:
   `BulkEnd` runs `reconcileStaleSessions`, so the re-driven bulk cleanly
   re-primes the standby.
 
-Once any bulk exchange completes (`bulkEverCompleted` set on a received
-`BulkEnd`/`BulkAck`), the gate closes: steady-state incremental sync already
-fails over via the send loop, so no re-drive is needed and a normal
-post-cold-start single-fabric drop does not re-bulk.
+Once the peer acks **our outbound** bulk (`outboundBulkAcked` set on a received
+`BulkAck`), the gate closes: steady-state incremental sync already fails over
+via the send loop, so no re-drive is needed and a normal post-cold-start
+single-fabric drop does not re-bulk.
+
+**#4360 — gate on the outbound-only flag, not the shared one.** The re-drive
+exists to guarantee the peer received *our* table, so its gate keys on
+`outboundBulkAcked`, which is set **only** by an inbound `BulkAck` (the peer
+acknowledging our outbound bulk). It is distinct from `bulkEverCompleted`, which
+is *also* set by an inbound `BulkEnd` (the peer's bulk arriving at us). If the
+gate used the shared `bulkEverCompleted`, a small **inbound** bulk completing
+first would set it and wrongly suppress re-driving a **stranded outbound** bulk,
+leaving the peer with an incomplete view of our sessions. The inner re-check
+inside the re-drive goroutine (the "a concurrent reconnect may have already
+re-primed" early-out) uses the same `outboundBulkAcked` flag for the same
+reason — keying it on `bulkEverCompleted` there would re-open the bug by bailing
+whenever an inbound bulk had completed. `outboundBulkAcked` is sticky (never
+reset): once the peer holds our full table, incremental sync keeps it fresh
+across reconnects. `handleNewConnection`'s `coldStart` gate is unchanged and
+still keys on `bulkEverCompleted` — a both-fabrics-down reconnect is a separate
+path from the survivor re-drive.
 
 ### 2. Periodic Sync Sweep (1s interval, new sessions)
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -333,6 +333,17 @@ type SessionSync struct {
 	pendingBulkAckEpoch  atomic.Uint64
 	pendingBulkAckSince  atomic.Int64
 	bulkEverCompleted    atomic.Bool
+	// outboundBulkAcked is set ONLY when the peer acks OUR outbound bulk
+	// (syncMsgBulkAck), i.e. the peer has received our complete session
+	// table. It is DISTINCT from bulkEverCompleted, which is also set by an
+	// inbound BulkEnd (peer->us). The survivor-fabric re-drive
+	// (handleDisconnect, #4090) exists to guarantee the peer got OUR outbound
+	// bulk, so its gate must key on this outbound-only flag: a small INBOUND
+	// bulk completing first must not suppress re-driving a stranded OUTBOUND
+	// bulk (#4360). Like bulkEverCompleted it is sticky — once acked the peer
+	// holds our full table and incremental sync keeps it fresh across
+	// reconnects, so it is never reset.
+	outboundBulkAcked atomic.Bool
 	// bulkRedriveInFlight guards the survivor-fabric cold-start bulk
 	// re-drive (#4090). A single fabric dropping mid-cold-start-bulk while
 	// the other fabric is up leaves the bulk stranded — pinned to the dead

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -1493,6 +1493,11 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 			s.pendingBulkAckSince.Store(0)
 		}
 		s.bulkEverCompleted.Store(true)
+		// #4360: the peer acked OUR outbound bulk — record it on the
+		// outbound-only flag so a stranded outbound bulk can be re-driven on a
+		// survivor fabric independently of whether an inbound bulk (which also
+		// sets bulkEverCompleted at syncMsgBulkEnd) completed first.
+		s.outboundBulkAcked.Store(true)
 		if s.OnBulkSyncAckReceived != nil {
 			go s.OnBulkSyncAckReceived()
 		}
@@ -1784,7 +1789,7 @@ func (s *SessionSync) handleDisconnect(conn net.Conn) {
 		if s.OnPeerDisconnected != nil {
 			go s.OnPeerDisconnected()
 		}
-	} else if !s.bulkEverCompleted.Load() {
+	} else if !s.outboundBulkAcked.Load() {
 		// #4090: a survivor fabric is still up but the cold-start bulk
 		// never completed. The bulk streams over a SINGLE connection
 		// (BulkSync/sendBulkMarkers pin s.getActiveConn once); if that
@@ -1792,6 +1797,13 @@ func (s *SessionSync) handleDisconnect(conn net.Conn) {
 		// retried on the survivor and handleNewConnection will not
 		// re-trigger it (its wasDisconnected gate needs BOTH fabrics to
 		// have dropped). Re-drive doBulkSync over the survivor.
+		//
+		// #4360: this gates on outboundBulkAcked, NOT bulkEverCompleted.
+		// The re-drive's job is to get OUR outbound bulk to the peer; a
+		// small INBOUND bulk (peer->us) completing first sets
+		// bulkEverCompleted but says nothing about whether the peer
+		// received our table, so keying on the shared flag would wrongly
+		// suppress the re-drive of a stranded outbound bulk.
 		//
 		// This MUST be a goroutine, not inline: handleDisconnect holds
 		// s.mu, and doBulkSync -> BulkSync/sendBulkMarkers -> getActiveConn
@@ -1808,7 +1820,11 @@ func (s *SessionSync) handleDisconnect(conn net.Conn) {
 				defer s.bulkRedriveInFlight.Store(false)
 				// A concurrent reconnect (both-fabric drop then reconnect)
 				// may have already re-primed via handleNewConnection.
-				if s.bulkEverCompleted.Load() {
+				// #4360: re-check the SAME outbound-only flag the gate above
+				// used — bulkEverCompleted may be true from an inbound bulk
+				// while our outbound bulk is still un-acked, and bailing on
+				// it here would make the fix inert.
+				if s.outboundBulkAcked.Load() {
 					return
 				}
 				// Reset the stranded pending-ack epoch so the re-run's fresh

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -4529,9 +4529,10 @@ func TestBulkSyncRedriveOnSurvivorFabric(t *testing.T) {
 }
 
 // TestBulkSyncNoRedriveWhenAlreadyCompleted verifies that a single-fabric drop
-// AFTER the cold-start bulk already completed does NOT re-drive (#4090). Once
-// bulkEverCompleted is set, the steady-state incremental stream already fails
-// over via the send loop, so a re-bulk would be redundant.
+// AFTER our outbound cold-start bulk was acked does NOT re-drive (#4090). Once
+// the peer has acked our table (outboundBulkAcked, #4360), the steady-state
+// incremental stream already fails over via the send loop, so a re-bulk would
+// be redundant.
 func TestBulkSyncNoRedriveWhenAlreadyCompleted(t *testing.T) {
 	c0local, c0peer := net.Pipe()
 	defer c0peer.Close()
@@ -4548,7 +4549,10 @@ func TestBulkSyncNoRedriveWhenAlreadyCompleted(t *testing.T) {
 		mu.Unlock()
 		return nil
 	}
+	// Steady state after a completed cold start: both flags set (an inbound
+	// BulkEnd set bulkEverCompleted AND the peer acked our outbound bulk).
 	ss.bulkEverCompleted.Store(true)
+	ss.outboundBulkAcked.Store(true)
 	ss.mu.Lock()
 	ss.conn0 = c0local
 	ss.conn1 = c1local
@@ -4571,6 +4575,65 @@ func TestBulkSyncNoRedriveWhenAlreadyCompleted(t *testing.T) {
 	if !ss.IsConnected() {
 		t.Fatal("survivor fabric 1 should keep the sync connected")
 	}
+}
+
+// TestBulkSyncRedriveWhenOnlyInboundCompleted is the #4360 RED-on-revert test.
+// An INBOUND bulk (peer->us) completing first sets the SHARED bulkEverCompleted
+// flag, but our OUTBOUND bulk was never acked (outboundBulkAcked stays false).
+// A fabric drop while the outbound bulk is stranded must STILL re-drive it over
+// the survivor so the peer ends with our COMPLETE table. On revert (the gate
+// keyed on the shared bulkEverCompleted flag) the re-drive is wrongly
+// suppressed and this test times out.
+func TestBulkSyncRedriveWhenOnlyInboundCompleted(t *testing.T) {
+	c0local, c0peer := net.Pipe()
+	defer c0peer.Close()
+	c1local, c1peer := net.Pipe()
+	defer c1peer.Close()
+
+	ss := NewSessionSync(":0", "10.0.0.2:4785", &mockSweepDP{})
+	ss.IsPrimaryFn = func() bool { return true }
+
+	redriven := make(chan struct{}, 1)
+	ss.BulkSyncOverride = func() error {
+		select {
+		case redriven <- struct{}{}:
+		default:
+		}
+		return nil
+	}
+	// Inbound bulk completed first — it set the SHARED flag — but the peer has
+	// NOT acked our outbound bulk. outboundBulkAcked is deliberately left false.
+	ss.bulkEverCompleted.Store(true)
+
+	ss.mu.Lock()
+	ss.conn0 = c0local
+	ss.conn1 = c1local
+	ss.stats.Connected.Store(true)
+	ss.mu.Unlock()
+
+	// Drain the survivor so the re-drive's post-override sendBulkMarkers write
+	// (BulkStart/BulkEnd) completes and its goroutine returns cleanly.
+	go func() {
+		for {
+			if _, _, err := readSyncFrame(c1peer); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Fabric 0 drops; fabric 1 survives. The outbound bulk was stranded, so the
+	// re-drive MUST fire even though bulkEverCompleted is set from the inbound
+	// bulk.
+	ss.handleDisconnect(c0local)
+
+	select {
+	case <-redriven:
+		// Re-drive fired over the survivor — correct.
+	case <-time.After(5 * time.Second):
+		t.Fatal("outbound bulk re-drive was suppressed by the shared bulkEverCompleted flag — a stranded outbound bulk never reaches the peer (#4360 RED-on-revert)")
+	}
+
+	ss.Stop()
 }
 
 // TestBulkSyncRedriveInFlightGuard verifies the CAS in-flight guard: while one


### PR DESCRIPTION
## Summary

The survivor-fabric cold-start bulk re-drive (#4090) in `handleDisconnect` gated on the **shared** `bulkEverCompleted` flag, which is set by EITHER an inbound `BulkEnd` (peer→us) OR an outbound `BulkAck` (us→peer). When a small **inbound** bulk completed first it set `bulkEverCompleted`, and if OUR **outbound** bulk then stranded mid-stream on a fabric that dropped, the re-drive was wrongly suppressed → the peer kept an incomplete view of our sessions until BOTH fabrics happened to drop together.

## Fix

- Add a dedicated `outboundBulkAcked atomic.Bool`, set **only** in the `syncMsgBulkAck` path (the peer acknowledging our outbound bulk).
- Re-point the `handleDisconnect` re-drive gate from `!bulkEverCompleted` to `!outboundBulkAcked`.
- Re-point the in-goroutine early-out re-check to the same flag — it bails when the flag is set, so leaving it on `bulkEverCompleted` would make the fix **inert** (a completed inbound bulk would still cancel the re-drive).
- `outboundBulkAcked` is sticky (never reset), matching `bulkEverCompleted`.
- The `coldStart` gate in `handleNewConnection` is intentionally left on `bulkEverCompleted` (both-fabrics-down reconnect is a separate path, out of scope).

## Validation

- New RED-on-revert test `TestBulkSyncRedriveWhenOnlyInboundCompleted`: inbound bulk completes first, then one fabric drops → the outbound re-drive must still fire over the survivor. **Fails** with the gate reverted to `bulkEverCompleted`; passes with the fix.
- Updated `TestBulkSyncNoRedriveWhenAlreadyCompleted` to set `outboundBulkAcked` (steady state has both flags set).
- `go test ./pkg/cluster/... -race`, `go build`, `go vet`, `gofmt` all clean.
- Doc updated: `docs/sync-protocol.md` #4090 re-drive section.

Note: touches HA session-sync — `make test-failover` warranted before merge.

Closes #4360

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi