### PR TITLE
cluster: run session-sync auth handshake off the accept loop (#4370)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -38898,3 +38898,29 @@ top.
 - **File(s)**: pkg/config/compiler.go, pkg/config/compiler_prewalk.go,
   pkg/config/compile_golden_4406_test.go,
   pkg/config/testdata/golden_4406.json, _Log.md
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4370 — the session-sync auth handshake ran SYNCHRONOUSLY in
+  the inbound accept loop (`acceptLoop` → `handleNewConnection` →
+  `performSyncHandshake`), so a slow/hung handshake on ONE connection stalled
+  accepting the NEXT for up to `syncHandshakeTimeout` (an active control-link
+  peer could serially block accepts). TWO fixes: (1) shortened
+  `syncHandshakeTimeout` 10s→3s (the keyed↔keyed challenge-response is
+  sub-millisecond; 3s only bounds a hung/absent peer and keeps a stalled
+  handshake goroutine inside the 5s `Stop` budget); (2) moved connection setup
+  off the accept loop — `acceptLoop` now runs `handleNewConnection` in a
+  per-connection, `s.wg`-tracked goroutine, so a stalled handshake no longer
+  blocks accepting OTHERS. Auth gate preserved: the conn is not wired into
+  `conn0`/`conn1` and no session frame is read until `performSyncHandshake`
+  succeeds INSIDE the goroutine; a failed handshake closes it. The outbound
+  `fabricConnectLoop` stays synchronous (dedicated per-fabric dialer).
+  Concurrent setup is safe: `conn0`/`conn1` assignment is `s.mu`-guarded with
+  close-old semantics, `doBulkSync` serializes via `bulkSendMu`. Tests:
+  `TestAcceptLoopHandshakeDoesNotBlockOthers` (A stalls after reading the
+  server HELLO, B must still receive its HELLO within ms — RED on revert: B's
+  read times out because the loop is parked on A) and
+  `TestSyncHandshakeTimeoutIsShort` (pins the [1s,3s] bound — RED on revert to
+  10s). Both RED-on-revert verified. `go build ./...`, `go vet ./pkg/cluster/`,
+  gofmt clean; `go test ./pkg/cluster/ -race` green.
+- **File(s)**: pkg/cluster/sync_conn.go, pkg/cluster/sync_auth.go,
+  pkg/cluster/sync_accept_test.go, pkg/cluster/README.md, _Log.md

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -288,6 +288,22 @@ connection is authenticated, then seals every subsequent frame.
   milliseconds. A dropped handshake closes the connection and the
   accept/connect loops retry (~1s) — it never bricks. MUST pass
   `make test-failover` (the path that keeps TCP alive across failover).
+- **Accept-loop isolation + short bound (#4370).** The inbound
+  `acceptLoop` runs each connection's setup (handshake + wire-up +
+  cold-start bulk sync, inside `handleNewConnection`) in a
+  per-connection goroutine — a slow or hung handshake on ONE connection
+  can no longer stall accepting the NEXT for up to `syncHandshakeTimeout`
+  (previously an active control-link peer could serially block accepts).
+  The auth gate is unchanged: the connection is not wired into
+  `conn0`/`conn1` and no session frame is read from it until
+  `performSyncHandshake` succeeds INSIDE the goroutine; a failed
+  handshake closes it. The goroutine is `s.wg`-tracked so `Stop()` waits
+  for in-flight setup. The outbound `fabricConnectLoop` stays synchronous
+  (a dedicated per-fabric dialer that must not redial mid-handling).
+  `syncHandshakeTimeout` is **3s** (was 10s): the keyed↔keyed path is
+  sub-millisecond, so the bound only covers a hung/absent peer, and a
+  shorter bound keeps a stalled handshake goroutine within the 5s `Stop`
+  budget.
 
 ## IPsec SA sync
 

--- a/pkg/cluster/sync_accept_test.go
+++ b/pkg/cluster/sync_accept_test.go
@@ -1,0 +1,85 @@
+package cluster
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestSyncHandshakeTimeoutIsShort pins the #4370 bound: the setup handshake
+// timeout must stay short (the keyed challenge-response completes in
+// milliseconds; a longer bound only extends how long a hung/absent peer ties up
+// a per-connection handshake goroutine and eats into the 5s Stop budget). RED
+// on revert to the original 10s.
+func TestSyncHandshakeTimeoutIsShort(t *testing.T) {
+	if syncHandshakeTimeout < 1*time.Second || syncHandshakeTimeout > 3*time.Second {
+		t.Fatalf("syncHandshakeTimeout = %v, want a short accept-loop bound in [1s, 3s] (#4370)", syncHandshakeTimeout)
+	}
+}
+
+// TestAcceptLoopHandshakeDoesNotBlockOthers verifies the #4370 fix: a
+// slow/hung auth handshake on one accepted connection does NOT stall the accept
+// loop from accepting and handshaking OTHER connections.
+//
+// Client A connects and reads the server's auth HELLO — proving the server
+// accepted A and is now committed to (blocked in) A's handshake read — then
+// stalls, never sending its own frame. Client B then connects. With the
+// per-connection goroutine, the accept loop keeps accepting, so B receives the
+// server HELLO within milliseconds. RED on revert: the synchronous accept loop
+// is parked inside A's handshake for the full syncHandshakeTimeout, so B is
+// never accepted and B's read times out.
+func TestAcceptLoopHandshakeDoesNotBlockOthers(t *testing.T) {
+	key := []byte("shared-control-link-secret-key")
+	s := newAuthSync(t, key, false)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.acceptLoop(ctx, ln, 0)
+
+	// Client A: connect, consume the server HELLO, then stall.
+	connA, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial A: %v", err)
+	}
+	defer connA.Close()
+	if err := connA.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("A set deadline: %v", err)
+	}
+	if typ, _, err := readSyncFrameRaw(connA); err != nil {
+		t.Fatalf("A did not receive server HELLO: %v", err)
+	} else if typ != syncMsgAuthHello {
+		t.Fatalf("A: expected server HELLO type %d, got %d", syncMsgAuthHello, typ)
+	}
+	// A now holds the server's handshake read; on the pre-fix synchronous accept
+	// loop the loop is stuck here for the full syncHandshakeTimeout.
+
+	// Client B: connect after the server is committed to A. The accept loop must
+	// still accept B and start its handshake promptly.
+	connB, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial B: %v", err)
+	}
+	defer connB.Close()
+	if err := connB.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("B set deadline: %v", err)
+	}
+	start := time.Now()
+	typ, _, err := readSyncFrameRaw(connB)
+	if err != nil {
+		t.Fatalf("B did not receive server HELLO while A's handshake was in flight "+
+			"(accept loop stalled on A?): %v", err)
+	}
+	if typ != syncMsgAuthHello {
+		t.Fatalf("B: expected server HELLO type %d, got %d", syncMsgAuthHello, typ)
+	}
+	if elapsed := time.Since(start); elapsed > 1*time.Second {
+		t.Fatalf("B's handshake started too late (%v) — accept loop appears serialized on A", elapsed)
+	}
+}

--- a/pkg/cluster/sync_auth.go
+++ b/pkg/cluster/sync_auth.go
@@ -77,7 +77,14 @@ const (
 	// peer drops the connection; fabricConnectLoop retries after ~1s, so a
 	// transient handshake failure only delays reconnect — it never bricks
 	// (dual-accept keeps a rolling upgrade alive without the handshake).
-	syncHandshakeTimeout = 10 * time.Second
+	//
+	// The keyed↔keyed challenge-response completes in milliseconds when both
+	// nodes are up; this bound only covers a hung or absent peer. It is kept
+	// short (#4370) because the accepting node runs the handshake per inbound
+	// connection — a longer bound lets a stalled connection tie up a handshake
+	// goroutine (and, on Stop, keep it inside the 5s shutdown budget). 3s is
+	// ample headroom over the sub-millisecond keyed path.
+	syncHandshakeTimeout = 3 * time.Second
 )
 
 // Domain-separation tags — bound into every HMAC so a value produced for one

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -1191,7 +1191,24 @@ func (s *SessionSync) acceptLoop(ctx context.Context, ln net.Listener, fabricIdx
 			}
 		}
 		slog.Info("cluster sync: peer connected", "remote", conn.RemoteAddr(), "fabric", fabricIdx)
-		s.handleNewConnection(ctx, fabricIdx, conn)
+		// #4370: run connection setup (the auth handshake + wire-up + cold-start
+		// bulk sync inside handleNewConnection) in a per-connection goroutine so
+		// a slow or hung handshake on ONE connection cannot stall accepting the
+		// NEXT for up to syncHandshakeTimeout. An active control-link attacker
+		// could otherwise open connections that each serially block the accept
+		// loop for the full handshake bound. The auth gate is preserved because
+		// the connection is not wired into conn0/conn1 (and no session frame is
+		// read from it) until performSyncHandshake succeeds INSIDE the goroutine;
+		// a failed handshake closes the connection and returns. The goroutine is
+		// tracked by s.wg (this loop already holds a wg token, so Add is safe)
+		// so Stop() waits for in-flight setup. The outbound fabricConnectLoop
+		// stays synchronous — it is a dedicated per-fabric dialer that must not
+		// redial while a connection is being handled.
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			s.handleNewConnection(ctx, fabricIdx, conn)
+		}()
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #4370.

The inbound session-sync accept loop (`acceptLoop` → `handleNewConnection` → `performSyncHandshake`) ran the #4107 F23 auth-capability handshake **synchronously**, so a slow/hung handshake on one accepted connection stalled accepting the **next** for up to `syncHandshakeTimeout` (10s). An active peer on the shared control link could open connections that each serially block the accept loop for the full handshake bound. LOW severity (trusted, PSK-gated direct-cable segment; mirrors the pre-existing synchronous `doBulkSync`) — cheap hardening.

## Changes

1. **Shorten `syncHandshakeTimeout` 10s → 3s** (`pkg/cluster/sync_auth.go`). The keyed↔keyed challenge-response is sub-millisecond; the bound only covers a hung/absent peer, and a shorter bound keeps a stalled per-connection handshake goroutine within the 5s `Stop()` budget.
2. **Move connection setup off the accept loop** (`pkg/cluster/sync_conn.go`). `acceptLoop` now runs `handleNewConnection` in a per-connection, `s.wg`-tracked goroutine. A stalled handshake no longer blocks accepting others. **Auth gate preserved** — the conn is not wired into `conn0`/`conn1` and no session frame is read from it until `performSyncHandshake` succeeds *inside* the goroutine; a failed handshake closes it. The outbound `fabricConnectLoop` stays synchronous (dedicated per-fabric dialer).

Concurrent setup is safe: `conn0`/`conn1` assignment is `s.mu`-guarded with close-old semantics (as before), and `doBulkSync` serializes via `bulkSendMu`.

## Tests (both RED on revert, verified)

- `TestAcceptLoopHandshakeDoesNotBlockOthers` — client A connects, reads the server HELLO (proving the server accepted A and is committed to A's handshake read), then stalls; client B must still receive its server HELLO within ms. On the synchronous loop, B is never accepted → B's read times out. (Confirmed FAIL on revert: only one "peer connected" logged, B `i/o timeout`.)
- `TestSyncHandshakeTimeoutIsShort` — pins the timeout to `[1s, 3s]`; RED on revert to 10s.

## Validation

- `go build ./...`, `go vet ./pkg/cluster/`, `gofmt` clean
- `go test ./pkg/cluster/ -race` green

HA session-sync accept path — **`make test-failover` warranted before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi