### PR TITLE
wg: drain cookie_gen on peer removal in reconcile_peers

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,23 @@
+## 2026-07-07 — #4362 wg: drain cookie_gen on peer removal in reconcile_peers
+
+- **Timestamp**: 2026-07-07
+- **Action**: Fixed the #4094-PR-B follow-up leak. `WgEngine::reconcile_peers`
+  drained a removed peer's `sessions_by_local_index` demux entries and its
+  `pending`/`pending_by_peer` handshake reservations, but NOT `cookie_gen`
+  (the per-peer initiator-cookie state, keyed by peer pubkey and living
+  OUTSIDE the atomically-swapped `PeerTable`). A removed peer therefore left
+  a stale `InitiatorCookie` (~56 bytes) unreachable but resident until process
+  restart. Added a `cookie_gen.lock()` drain block over the removed pubkeys
+  right after the `pending`/`pending_by_peer` block (same removed-peer test:
+  `old.peer_index_by_pubkey.keys()` minus `new_index`). Verified `cookie_gen`
+  is the ONLY per-pubkey engine side-map not already drained on removal
+  (`peer_index_by_pubkey` is rebuilt wholesale in the new table;
+  `CookieChecker.buckets` is keyed by source `IpAddr` and self-ages).
+- **File(s)**: `userspace-dp/src/afxdp/wg/engine.rs` (drain block + reconcile
+  doc-comment), `userspace-dp/src/afxdp/wg/engine_tests.rs` (RED-on-revert
+  `reconcile_peers_drains_dropped_peer_cookie_gen`), `docs/wireguard-interop.md`
+  (PR-B lifecycle/peer-removal note).
+
 ## 2026-07-07 — #4407 Phase A: group tail reconcile dispatches (steps 8–21)
 
 - **Timestamp**: 2026-07-07

--- a/docs/wireguard-interop.md
+++ b/docs/wireguard-interop.md
@@ -550,6 +550,14 @@ in `WgEngine::cookie_gen`, keyed by responder pubkey):
   `xpf_userspace_wg_cookie_replies_total{event=consumed}`) on a successful
   decrypt+store; `hs_rx_cookie_unsupported` (its former S7-placeholder wire name,
   now a real drop-by-reason site) on an unattributable / undecryptable reply.
+- **Lifecycle / peer removal (#4362)** — `cookie_gen` is keyed by peer pubkey
+  and, like `pending_by_peer`, lives OUTSIDE the atomically-swapped `PeerTable`.
+  `WgEngine::reconcile_peers` therefore drains a removed peer's `cookie_gen`
+  entry alongside its `sessions_by_local_index` demux entries and pending
+  handshake reservations — otherwise each peer removal would leak a stale
+  `InitiatorCookie` (~56 bytes) until process restart. A kept peer's entry is
+  left untouched. RED-on-revert: `engine_tests.rs`
+  `reconcile_peers_drains_dropped_peer_cookie_gen`.
 
 **RED-on-revert (PR-B):** `cookie.rs`
 `initiator_cookie_roundtrip_stamps_accepted_mac2` (a responder cookie-reply is

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -825,7 +825,11 @@ impl WgEngine {
     ///      successfully (the session Arc is still in the demux map),
     ///      then fail the AllowedIPs gate because the peer is no
     ///      longer in the index, and the demux entry would leak
-    ///      forever.
+    ///      forever. Removal also drains the removed peers' other
+    ///      per-pubkey side maps that live outside `PeerTable`:
+    ///      `pending`/`pending_by_peer` (in-flight handshake
+    ///      reservations) and `cookie_gen` (#4362, initiator cookie
+    ///      state) — otherwise each removal leaks a stale entry.
     ///   3. `ArcSwap::store` publishes the new `PeerTable` in one
     ///      release-store. Subsequent `.load()` calls observe either
     ///      the entire old table or the entire new one — never a mix.
@@ -936,6 +940,27 @@ impl WgEngine {
                 if let Some(reserved_idx) = by_peer.remove(pubkey) {
                     pending.remove(&reserved_idx);
                 }
+            }
+        }
+        // #4362: drain per-peer INITIATOR COOKIE state for removed peers.
+        // `cookie_gen` (#4094 PR-B) holds each peer's last-decrypted
+        // responder cookie plus the MAC1 of our last-sent initiation to it,
+        // keyed by peer pubkey. Like `pending_by_peer` above it is NOT part
+        // of the atomically-swapped `PeerTable`, so without an explicit
+        // drain a removed peer leaves a stale `InitiatorCookie` entry that
+        // is unreachable (no `Peer` in the table) yet lives until process
+        // restart — a small per-removal leak bounded by config-churn
+        // history. Drain it here alongside the other per-peer cleanups so
+        // peer removal is complete. Still under `reconcile_lock`; the
+        // `consume_cookie_reply` slow path releases its `pending` read lock
+        // before taking `cookie_gen`, so there is no lock-order coupling.
+        {
+            let mut cg = self.cookie_gen.lock().unwrap();
+            for pubkey in old.peer_index_by_pubkey.keys() {
+                if new_index.contains_key(pubkey) {
+                    continue;
+                }
+                cg.remove(pubkey);
             }
         }
         // Publish the new table. Atomic release-store; any reader

--- a/userspace-dp/src/afxdp/wg/engine_tests.rs
+++ b/userspace-dp/src/afxdp/wg/engine_tests.rs
@@ -481,6 +481,67 @@ fn reconcile_peers_leaves_kept_peer_sessions_intact() {
     );
 }
 
+/// #4362 regression: `reconcile_peers` must drain a removed peer's
+/// per-pubkey `cookie_gen` (initiator cookie state, #4094 PR-B) and
+/// leave a kept peer's entry intact. `cookie_gen` is keyed by peer
+/// pubkey and lives OUTSIDE the atomically-swapped `PeerTable`, so
+/// without an explicit drain (matching `pending_by_peer`) a removed
+/// peer leaks a stale `InitiatorCookie` until process restart. RED on
+/// revert: dropping the `cookie_gen.remove` block leaves peer A's
+/// entry present after reconcile.
+#[test]
+fn reconcile_peers_drains_dropped_peer_cookie_gen() {
+    let (init_priv, _init_pub) = keypair();
+    let (_peer_a_priv, peer_a_pub) = keypair();
+    let (_peer_b_priv, peer_b_pub) = keypair();
+    let engine = WgEngine::new(WgEngineConfig {
+        local_private_key: init_priv.into(),
+        listen_port: 51820,
+        peers: vec![
+            WgPeerConfig {
+                pubkey: peer_a_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+                preshared_key: [0u8; 32].into(),
+            },
+            WgPeerConfig {
+                pubkey: peer_b_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.1.0/24").unwrap()],
+                preshared_key: [0u8; 32].into(),
+            },
+        ],
+    });
+    // Seed initiator-cookie state for both peers, as `add_initiator_macs`
+    // / `consume_cookie_reply` would after a real cookie-reply exchange.
+    {
+        let mut cg = engine.cookie_gen.lock().unwrap();
+        cg.insert(peer_a_pub, crate::afxdp::wg::cookie::InitiatorCookie::new());
+        cg.insert(peer_b_pub, crate::afxdp::wg::cookie::InitiatorCookie::new());
+        assert!(cg.contains_key(&peer_a_pub));
+        assert!(cg.contains_key(&peer_b_pub));
+    }
+    // Reconcile dropping only peer A.
+    engine.reconcile_peers(&[WgPeerConfig {
+        pubkey: peer_b_pub,
+        endpoint: None,
+        persistent_keepalive: 0,
+        allowed_ips: vec![ipnet::IpNet::from_str("10.0.1.0/24").unwrap()],
+        preshared_key: [0u8; 32].into(),
+    }]);
+    let cg = engine.cookie_gen.lock().unwrap();
+    assert!(
+        !cg.contains_key(&peer_a_pub),
+        "dropped peer's cookie_gen entry must be drained on reconcile (#4362)"
+    );
+    assert!(
+        cg.contains_key(&peer_b_pub),
+        "kept peer's cookie_gen entry must survive an unrelated peer removal"
+    );
+}
+
 /// r5 regression: hot-path readers must observe a torn-free
 /// snapshot across `reconcile_peers`. A concurrent
 /// reconcile/hot-read interleaving where the reader sees


### PR DESCRIPTION
Closes #4362

## Problem

`WgEngine::reconcile_peers` drained a removed peer's demux entries
(`sessions_by_local_index`) and its in-flight handshake reservations
(`pending` / `pending_by_peer`), but NOT `cookie_gen` — the per-peer
initiator cookie state added in #4094 PR-B. `cookie_gen` is keyed by
peer pubkey and lives OUTSIDE the atomically-swapped `PeerTable`, so a
removed peer left behind a stale ~56-byte `InitiatorCookie` that was
unreachable (no `Peer` in the table) yet resident until process
restart. The leak is small and self-healing (re-adding the same pubkey
within the 120s cookie TTL costs at most one extra challenge
round-trip), but it violated the "peer removal fully revokes per-peer
state" contract the other side maps already honor and grew with
config-churn history.

## Fix

Add a `cookie_gen.lock()` drain block over the removed pubkeys right
after the `pending` / `pending_by_peer` block, using the same
removed-peer test (`old.peer_index_by_pubkey.keys()` minus
`new_index`). Verified `cookie_gen` is the ONLY per-pubkey engine side
map not already drained on removal: `peer_index_by_pubkey` is rebuilt
wholesale into the new table, and `CookieChecker.buckets` is keyed by
source `IpAddr` and self-ages. The drain runs under `reconcile_lock`;
the `consume_cookie_reply` slow path releases its `pending` read lock
before taking `cookie_gen`, so there is no lock-order coupling.

## Test

`reconcile_peers_drains_dropped_peer_cookie_gen` (engine_tests.rs)
seeds initiator-cookie state for two peers, reconciles dropping only
peer A, and asserts A's entry is drained while B's survives.
**RED on revert:** with the drain block neutered the test fails on the
"dropped peer's cookie_gen entry must be drained" assertion.

Docs updated: `reconcile_peers` atomicity doc-comment and the
`docs/wireguard-interop.md` PR-B section now record the peer-removal
lifecycle.

## Validation

Full cargo suite, serial (`--test-threads=1`): **3697 passed / 0
failed**. wg engine subset **23/0** (including the new test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi