### PR TITLE
configstore: idle-lease reaper for the config lock (#4476)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-07-07 — #4476 configstore: idle-lease reaper for the config lock
+
+- **Timestamp**: 2026-07-07
+- **Action**: Fixed opus-172 H-3, a management-plane config-edit DoS. The REST
+  config-enter path (`POST /api/v1/config/enter` -> `EnterConfigure`, empty
+  holder) has no disconnect hook — unlike the gRPC `configLockInterceptor` — so
+  a stateless HTTP client that never called `/config/exit` wedged the global
+  config lock, and every CLI/gRPC/REST edit returned `ErrConfigLocked` until
+  `clear system config-lock` or a daemon restart. `configLockAt` was recorded
+  at acquire but read only by a log line — no reaper. Added an idle-lease
+  reaper: `configLockLeaseTTL` (10 min) + `reclaimStaleLockLocked()` (check-on-
+  acquire reclaim in `EnterConfigureSession`/`EnterConfigureExclusive`, gated on
+  `time.Since(configLockAt) >= TTL`) + `touchConfigLockLocked()` (refresh-on-
+  activity, stamped by every mutating store method and same-session re-entry).
+  An actively-edited lock refreshes its lease and is never reclaimed; only a
+  genuinely-idle lock is reclaimed, exactly when another session needs it (no
+  background goroutine). Internal `SyncApply` / `PromoteRollback` paths do not
+  refresh (not user activity). Noted L-1/#4484 (REST clear-config-lock) as a
+  companion, not implemented here.
+- **File(s)**: `pkg/configstore/store_lock.go` (TTL var + reaper/refresh helpers
+  + reclaim wiring in both Enter* methods), `pkg/configstore/store_command.go`
+  (touch in Set/Delete/Deactivate/Activate/Copy/Rename/Insert/Annotate/Load*),
+  `pkg/configstore/store_commit.go` (touch in Commit/CommitConfirmed/Rollback),
+  `pkg/configstore/store_lock_lease_4476_test.go` (RED-on-revert: stale
+  reclaimed, active/refreshed preserved, exclusive stale reclaimed, re-entry
+  refreshes), `pkg/configstore/README.md` (idle-lease reaper section).
+
 ## 2026-07-07 — #4362 wg: drain cookie_gen on peer removal in reconcile_peers
 
 - **Timestamp**: 2026-07-07

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -289,6 +289,53 @@ holder still blocks other sessions (`EnterConfigure*` rejects with
 cannot steal the lock. `ForceExitConfigure` (`clear system config-lock`)
 remains the unconditional operator override.
 
+### Config lock: idle-lease reaper (#4476)
+
+The gRPC config path auto-releases the lock when a client disconnects
+(`configLockInterceptor` in `pkg/grpcapi/server.go` calls
+`ExitConfigureSession` once `ctx.Err() != nil`). The **REST** config
+path has no such hook: `POST /api/v1/config/enter`
+(`configEnterHandler`) takes the global lock with an empty holder, and a
+stateless HTTP client that never calls `/config/exit` leaves it held. On
+its own that wedged every CLI/gRPC/REST config edit with `ErrConfigLocked`
+until `clear system config-lock` or a daemon restart — a management-plane
+config-edit DoS.
+
+`configLockAt` (recorded at acquire) now backs an **idle-lease reaper**:
+
+- **Refresh on activity** — every config mutation calls
+  `touchConfigLockLocked()` (`store_lock.go`), which stamps
+  `configLockAt = now` while `configDir` is set. Both transports funnel
+  edits through the store's mutating methods (`Set`/`Delete`/`Deactivate`/
+  `Activate`/`Copy`/`Rename`/`Insert`/`Annotate`/`Load*` in
+  `store_command.go`; `Commit`/`CommitConfirmed`/`Rollback` in
+  `store_commit.go`), and same-session re-entry refreshes too. Reads
+  (`show`/status polls) deliberately do **not** refresh, so a lock whose
+  holder stops editing ages out. The internal HA-sync ingress
+  (`SyncApply`) and the commit-confirmed timeout revert
+  (`PromoteRollback`) are timer/peer paths, not user activity, and do not
+  refresh.
+- **Reclaim on acquire** — `EnterConfigureSession` /
+  `EnterConfigureExclusive` call `reclaimStaleLockLocked()` before
+  rejecting a would-be entrant. It releases the current lock (mirroring
+  `ForceExitConfigure`'s teardown, including `exclusiveHolder` /
+  `editPath`) **only** when `time.Since(configLockAt) >=
+  configLockLeaseTTL`, then the caller enters cleanly. A stale lock is
+  therefore reclaimed exactly when another session needs it — the only
+  moment a stuck lock causes harm — so no background goroutine is
+  required.
+
+`configLockLeaseTTL` defaults to **10 minutes**: long enough that an
+operator hand-composing a change (each `set`/`delete` refreshes the
+lease) is never reclaimed mid-edit, short enough to bound a wedged REST
+lock. An actively-edited lock is never stolen; only a genuinely-idle one
+is. The tests in `store_lock_lease_4476_test.go` cover both directions
+(stale lock reclaimed, active/refreshed lock preserved) and are the
+RED-on-revert guard. Note that recovery still surfaces the lock while it
+is stale — a companion REST clear-config-lock action (L-1 / #4484) would
+let a REST operator release it explicitly without waiting for the next
+entrant; that is tracked separately.
+
 ### Cluster read-only gate (#3893)
 
 On an HA chassis cluster the RG0 primary is the sole config authority;

--- a/pkg/configstore/store_command.go
+++ b/pkg/configstore/store_command.go
@@ -22,6 +22,7 @@ func (s *Store) Set(path []string) error {
 	if err := s.candidate.SetPath(path); err != nil {
 		return err
 	}
+	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
 	s.dirty = true
 	return nil
 }
@@ -50,6 +51,7 @@ func (s *Store) Delete(path []string) error {
 	if err := s.candidate.DeletePath(path); err != nil {
 		return err
 	}
+	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
 	s.dirty = true
 	return nil
 }
@@ -86,6 +88,7 @@ func (s *Store) DeactivateFromInput(input string) error {
 	if err := applyEditLine(s.candidate, "deactivate "+input); err != nil {
 		return err
 	}
+	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
 	s.dirty = true
 	return nil
 }
@@ -106,6 +109,7 @@ func (s *Store) ActivateFromInput(input string) error {
 	if err := applyEditLine(s.candidate, "activate "+input); err != nil {
 		return err
 	}
+	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
 	s.dirty = true
 	return nil
 }
@@ -123,6 +127,7 @@ func (s *Store) Copy(srcPath, dstPath []string) error {
 	if err := s.candidate.CopyPath(srcPath, dstPath); err != nil {
 		return err
 	}
+	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
 	s.dirty = true
 	return nil
 }
@@ -140,6 +145,7 @@ func (s *Store) Rename(srcPath, dstPath []string) error {
 	if err := s.candidate.RenamePath(srcPath, dstPath); err != nil {
 		return err
 	}
+	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
 	s.dirty = true
 	return nil
 }
@@ -164,6 +170,7 @@ func (s *Store) Insert(elementPath, refPath []string, before bool) error {
 	if err != nil {
 		return err
 	}
+	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
 	s.dirty = true
 	return nil
 }
@@ -212,6 +219,7 @@ func (s *Store) Annotate(path []string, comment string) error {
 	}
 
 	target.Annotation = comment
+	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
 	s.dirty = true
 	return nil
 }
@@ -238,6 +246,7 @@ func (s *Store) LoadOverride(content string) error {
 	}
 
 	s.candidate = tree
+	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
 	s.dirty = true
 	return nil
 }
@@ -313,6 +322,7 @@ func (s *Store) LoadMerge(content string) error {
 		}
 	}
 
+	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
 	s.dirty = true
 	return nil
 }
@@ -417,6 +427,7 @@ func (s *Store) LoadSet(content string) (int, error) {
 		}
 		count++
 	}
+	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
 	s.dirty = true
 	return count, nil
 }

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -102,6 +102,7 @@ func (s *Store) CommitWithDescription(description string) (*config.Config, error
 	s.candidate = s.active.Clone()
 	s.compiled = compiled
 	s.dirty = false
+	s.touchConfigLockLocked() // #4476: a commit is activity — refresh the lease
 
 	// #3861: a PLAIN commit during a pending commit-confirmed window is
 	// the confirmation (Junos semantics: any subsequent explicit commit
@@ -250,6 +251,7 @@ func (s *Store) CommitConfirmed(minutes int) (*config.Config, error) {
 	s.candidate = s.active.Clone()
 	s.compiled = compiled
 	s.dirty = false
+	s.touchConfigLockLocked() // #4476: a commit is activity — refresh the lease
 
 	// Log to journal
 	s.journalLog(&JournalEntry{
@@ -507,6 +509,7 @@ func (s *Store) Rollback(n int) error {
 	if s.candidate == nil {
 		return fmt.Errorf("not in configuration mode")
 	}
+	s.touchConfigLockLocked() // #4476: a rollback is activity — refresh the lease
 
 	if n == 0 {
 		s.candidate = s.active.Clone()

--- a/pkg/configstore/store_lock.go
+++ b/pkg/configstore/store_lock.go
@@ -28,6 +28,60 @@ func (s *Store) ensureWritableLocked() error {
 	return nil
 }
 
+// configLockLeaseTTL bounds how long a config lock may sit idle — with no edit
+// activity — before a new entrant may reclaim it. #4476: the REST config-enter
+// path (POST /api/v1/config/enter) is stateless and has NO disconnect hook,
+// unlike the gRPC configLockInterceptor (pkg/grpcapi/server.go) which
+// auto-releases the lock when a client's connection drops. A REST client that
+// takes the lock and never calls /config/exit would otherwise wedge every
+// CLI/gRPC/REST config edit until `clear system config-lock` or a daemon
+// restart — a management-plane config-edit DoS. Every config mutation refreshes
+// the lease (touchConfigLockLocked), so this TTL only ever reclaims a lock that
+// has seen no edit for the full window; an actively-edited lock, including a
+// long hand-composed change, is never stolen. Kept as a package var so tests
+// can shrink it.
+var configLockLeaseTTL = 10 * time.Minute
+
+// touchConfigLockLocked refreshes the config-lock idle lease on a mutation
+// (#4476). Both transports funnel config edits through the store's mutating
+// methods (REST and gRPC both go via SetFromInput/DeleteFromInput/Commit/...),
+// so refreshing here keeps an active holder's lease fresh regardless of which
+// mode acquired it or whether a session identifier was recorded. Reads
+// (show/status polls) deliberately do NOT refresh, so a lock held by a client
+// that stops editing eventually becomes reclaimable. No-op when not in config
+// mode. Callers MUST hold s.mu.
+func (s *Store) touchConfigLockLocked() {
+	if s.configDir {
+		s.configLockAt = time.Now()
+	}
+}
+
+// reclaimStaleLockLocked releases the current config lock IFF it has been idle
+// (no edit activity) for longer than configLockLeaseTTL, and reports whether it
+// did. It mirrors ForceExitConfigure's teardown but is gated on the idle lease,
+// so an active holder is never disturbed. This is the check-on-acquire reaper
+// for #4476: EnterConfigureSession / EnterConfigureExclusive call it before
+// rejecting a would-be entrant with ErrConfigLocked, so a wedged REST lock is
+// reclaimed exactly when another session needs it (the only moment a stuck lock
+// causes harm). Callers MUST hold s.mu and MUST have already confirmed
+// s.configDir.
+func (s *Store) reclaimStaleLockLocked() bool {
+	if time.Since(s.configLockAt) < configLockLeaseTTL {
+		return false
+	}
+	slog.Warn("reclaiming stale config lock past idle lease",
+		"holder", s.effectiveHolderLocked(),
+		"idle_for", time.Since(s.configLockAt).Round(time.Second),
+		"lease_ttl", configLockLeaseTTL)
+	s.candidate = nil
+	s.configDir = false
+	s.dirty = false
+	s.exclusiveHolder = ""
+	s.configHolder = ""
+	s.editPath = nil
+	return true
+}
+
 // EnterConfigure enters configuration mode by cloning the active config.
 // Returns an error if another session is already in config mode.
 func (s *Store) EnterConfigure() error {
@@ -43,20 +97,34 @@ func (s *Store) EnterConfigureSession(sessionID string) error {
 		return err
 	}
 	if s.configDir {
-		// Allow re-entry by same session.
+		// Allow re-entry by same session — and treat it as activity, so a
+		// long-lived interactive session refreshes its idle lease (#4476)
+		// rather than being reclaimed out from under itself.
 		if sessionID != "" && s.configHolder == sessionID {
+			s.configLockAt = time.Now()
 			return nil
 		}
-		// #2157: return the ErrConfigLocked sentinel (wrapping the plain
-		// message) so deferrable callers (the event-options action worker)
-		// can errors.Is it and retry instead of string-matching.
-		return fmt.Errorf("%w", ErrConfigLocked)
+		// #4476: reclaim a stale lease before rejecting. The current holder may
+		// be a REST client that took the lock and never released it — the
+		// stateless REST path has no disconnect hook like the gRPC
+		// configLockInterceptor — which would otherwise wedge every config edit
+		// forever. reclaimStaleLockLocked only fires on a lock idle past the
+		// lease TTL; an actively-edited lock refreshes configLockAt on every
+		// mutation and is never stolen.
+		if !s.reclaimStaleLockLocked() {
+			// #2157: return the ErrConfigLocked sentinel (wrapping the plain
+			// message) so deferrable callers (the event-options action worker)
+			// can errors.Is it and retry instead of string-matching.
+			return fmt.Errorf("%w", ErrConfigLocked)
+		}
 	}
 	s.candidate = s.active.Clone()
 	s.configDir = true
 	s.dirty = false
+	s.exclusiveHolder = ""
 	s.configHolder = sessionID
 	s.configLockAt = time.Now()
+	s.editPath = nil
 	return nil
 }
 
@@ -68,13 +136,19 @@ func (s *Store) EnterConfigureExclusive(holder string) error {
 		return err
 	}
 	if s.configDir {
-		return fmt.Errorf("%w", ErrConfigLocked)
+		// #4476: reclaim a stale lease before rejecting, same idle-lease
+		// contract as EnterConfigureSession.
+		if !s.reclaimStaleLockLocked() {
+			return fmt.Errorf("%w", ErrConfigLocked)
+		}
 	}
 	s.candidate = s.active.Clone()
 	s.configDir = true
 	s.dirty = false
+	s.configHolder = ""
 	s.exclusiveHolder = holder
 	s.configLockAt = time.Now()
+	s.editPath = nil
 	return nil
 }
 

--- a/pkg/configstore/store_lock_lease_4476_test.go
+++ b/pkg/configstore/store_lock_lease_4476_test.go
@@ -1,0 +1,137 @@
+package configstore
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// backdateConfigLock rewinds the current config lock's acquire/refresh time by
+// `by`, simulating the passage of idle time deterministically (no sleeps, so
+// the tests stay -race clean). Callers must already hold the lock via an
+// EnterConfigure* method.
+func backdateConfigLock(t *testing.T, s *Store, by time.Duration) {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.configDir {
+		t.Fatal("backdateConfigLock: not in config mode")
+	}
+	s.configLockAt = s.configLockAt.Add(-by)
+}
+
+// TestConfigLockStaleLeaseReclaimed is the RED-on-revert guard for #4476.
+//
+// A REST client takes the config lock (POST /api/v1/config/enter ->
+// EnterConfigure, empty holder) and never calls /config/exit. The stateless
+// REST path has NO disconnect hook — unlike the gRPC configLockInterceptor —
+// so before this fix the lock was stuck forever and every subsequent
+// CLI/gRPC/REST config edit returned ErrConfigLocked (a management-plane DoS),
+// recoverable only via `clear system config-lock` or a daemon restart.
+//
+// On revert this test goes RED: after the idle lease expires the second
+// session's EnterConfigureSession still returns ErrConfigLocked because no
+// reaper exists.
+func TestConfigLockStaleLeaseReclaimed(t *testing.T) {
+	s := newTestStore(t)
+
+	// A REST client takes the lock and wanders off.
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if !s.InConfigMode() {
+		t.Fatal("expected config mode after EnterConfigure")
+	}
+
+	// While the lease is fresh, a second session is correctly rejected —
+	// the reaper must not steal a live lock.
+	if err := s.EnterConfigureSession("cli-peer"); !errors.Is(err, ErrConfigLocked) {
+		t.Fatalf("EnterConfigureSession while lease fresh = %v, want ErrConfigLocked", err)
+	}
+
+	// Age the lease past the idle TTL (the wedged REST lock, no edits).
+	backdateConfigLock(t, s, configLockLeaseTTL+time.Minute)
+
+	// The second session must now reclaim the stale lease and enter. RED on
+	// revert: without the reaper this returns ErrConfigLocked forever.
+	if err := s.EnterConfigureSession("cli-peer"); err != nil {
+		t.Fatalf("EnterConfigureSession after stale lease = %v, want reclaim+success", err)
+	}
+	if holder, locked := s.ConfigHolder(); !locked || holder != "cli-peer" {
+		t.Fatalf("ConfigHolder() = (%q, %v), want (%q, true)", holder, locked, "cli-peer")
+	}
+	s.ExitConfigureSession("cli-peer")
+}
+
+// TestConfigLockActiveHolderNotReclaimed proves the reaper never steals a lock
+// from a holder that is actively editing. A config mutation refreshes the idle
+// lease (touchConfigLockLocked), so even after the lease was aged past the TTL,
+// a single edit makes the lock live again and a competing entrant is rejected.
+func TestConfigLockActiveHolderNotReclaimed(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.EnterConfigureSession("editor"); err != nil {
+		t.Fatalf("EnterConfigureSession(editor): %v", err)
+	}
+
+	// Age the lease, then make an edit — the edit must refresh it.
+	backdateConfigLock(t, s, configLockLeaseTTL+time.Minute)
+	if err := s.SetFromInput("system host-name testfw"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+
+	// A competing session must be rejected: the edit refreshed the lease, so
+	// the reaper must NOT reclaim it.
+	if err := s.EnterConfigureSession("intruder"); !errors.Is(err, ErrConfigLocked) {
+		t.Fatalf("EnterConfigureSession against active holder = %v, want ErrConfigLocked", err)
+	}
+	if holder, _ := s.ConfigHolder(); holder != "editor" {
+		t.Fatalf("ConfigHolder() = %q, want %q (lease should not have been reclaimed)", holder, "editor")
+	}
+	s.ExitConfigureSession("editor")
+}
+
+// TestConfigLockExclusiveStaleLeaseReclaimed confirms the reaper also reclaims
+// a stale EXCLUSIVE lock and fully clears the exclusive-holder bookkeeping, so
+// the reclaiming session enters cleanly in shared mode.
+func TestConfigLockExclusiveStaleLeaseReclaimed(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.EnterConfigureExclusive("ghost"); err != nil {
+		t.Fatalf("EnterConfigureExclusive(ghost): %v", err)
+	}
+	backdateConfigLock(t, s, configLockLeaseTTL+time.Minute)
+
+	if err := s.EnterConfigureSession("newpeer"); err != nil {
+		t.Fatalf("EnterConfigureSession reclaim of stale exclusive = %v", err)
+	}
+	if s.IsExclusiveLocked() {
+		t.Fatal("exclusiveHolder not cleared after reclaiming a stale exclusive lock")
+	}
+	if holder, locked := s.ConfigHolder(); !locked || holder != "newpeer" {
+		t.Fatalf("ConfigHolder() = (%q, %v), want (%q, true)", holder, locked, "newpeer")
+	}
+	s.ExitConfigureSession("newpeer")
+}
+
+// TestConfigLockReentryRefreshesLease confirms a same-session re-entry counts
+// as activity and refreshes the lease, so an interactive session that keeps
+// re-entering is never reclaimed.
+func TestConfigLockReentryRefreshesLease(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.EnterConfigureSession("editor"); err != nil {
+		t.Fatalf("EnterConfigureSession(editor): %v", err)
+	}
+	backdateConfigLock(t, s, configLockLeaseTTL+time.Minute)
+
+	// Re-entry by the holder refreshes the lease.
+	if err := s.EnterConfigureSession("editor"); err != nil {
+		t.Fatalf("re-entry by holder = %v, want success", err)
+	}
+	// A different session must still be rejected.
+	if err := s.EnterConfigureSession("intruder"); !errors.Is(err, ErrConfigLocked) {
+		t.Fatalf("EnterConfigureSession after holder re-entry = %v, want ErrConfigLocked", err)
+	}
+	s.ExitConfigureSession("editor")
+}


### PR DESCRIPTION
## Summary

Fixes **opus-172 H-3** (#4476), a management-plane config-edit DoS.

`POST /api/v1/config/enter` (`configEnterHandler` → `EnterConfigure`) takes the global config lock with an empty holder and has **no disconnect/idle auto-release**. The gRPC path releases the lock on client disconnect via `configLockInterceptor` (`pkg/grpcapi/server.go`), but the stateless REST client has no connection to observe. A REST client that takes the lock and never calls `/config/exit` wedged every subsequent CLI/gRPC/REST config edit with `ErrConfigLocked`, recoverable only via `clear system config-lock` or a daemon restart.

`configLockAt` was recorded at acquire but read only by a log line — no reaper existed. This turns it into an **idle lease**.

## Change

- **Refresh on activity** — `touchConfigLockLocked()` stamps `configLockAt = now` while in config mode. Called by every mutating store method (`Set`/`Delete`/`Deactivate`/`Activate`/`Copy`/`Rename`/`Insert`/`Annotate`/`Load*` in `store_command.go`; `Commit`/`CommitConfirmed`/`Rollback` in `store_commit.go`) and by same-session re-entry. Both transports funnel edits through these methods, so an active holder's lease stays fresh regardless of transport/holder identity. Reads (show/status) do **not** refresh; internal `SyncApply`/`PromoteRollback` (timer/peer paths) do not refresh.
- **Reclaim on acquire** — `reclaimStaleLockLocked()` is a check-on-acquire reaper called by `EnterConfigureSession`/`EnterConfigureExclusive` before rejecting a would-be entrant. It releases the current lock (mirroring `ForceExitConfigure`'s teardown, incl. `exclusiveHolder`/`editPath`) **only** when the lease is idle `>= configLockLeaseTTL`, then the caller enters cleanly. A stale lock is reclaimed exactly when another session needs it — no background goroutine.
- **`configLockLeaseTTL` = 10 min** — long enough that a hand-composed change (each edit refreshes) is never reclaimed mid-edit, short enough to bound a wedged REST lock. Package var so tests can shrink it. An actively-edited lock is never stolen; only a genuinely-idle one is.

## Tests

`store_lock_lease_4476_test.go` — RED-on-revert:
- stale lease reclaimed by next entrant (shared + exclusive modes)
- aged lease **refreshed by an edit** → competitor still gets `ErrConfigLocked` (active holder never reclaimed)
- same-session re-entry refreshes the lease

`go test ./pkg/api/... ./pkg/configstore/...` green with `-race`; `go build ./...` and `go vet` clean. RED-on-revert confirmed by neutering the reaper (both stale-reclaim tests fail).

## Note

A companion REST clear-config-lock action (L-1 / #4484) would let a REST operator release a stale lock explicitly without waiting for the next entrant — tracked separately, not implemented here.

Closes #4476

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi