### PR TITLE
routing: skip PBR/FBF band in userspace FIB snapshot ingest

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-07-07 — #4479 routing: skip PBR/FBF band in userspace FIB snapshot ingest
+
+- **Timestamp**: 2026-07-07
+- **Action**: Fixed opus-172 M-2 (fail-open-adjacent). The userspace route
+  snapshot builder (`buildRouteSnapshots`) mirrors kernel ip rules whose Dst
+  maps to a routing-instance table into per-prefix `next-table` leaks so the
+  userspace FIB can cross-reference VRF tables. It applied NO priority filter,
+  so a policy-based-routing / filter-based-forwarding (FBF) rule in the PBR
+  band (31000-31999) — which carries Src/Tos/IPProto/Sport/Dport SELECTORS in
+  addition to a Dst — was ingested as a BARE dst-only NextTable leak, dropping
+  every selector and widening a constrained, source-scoped steer into an
+  unconditional VRF leak (the userspace twin of the #3730 kernel over-steer).
+  Added a PBR-band skip in the ingest loop: rules in
+  `[config.PBRRulePriorityBase, +config.PBRRuleWindow)` are left out of the
+  userspace FIB (fail-CLOSED — the kernel still applies the real,
+  fully-qualified PBR rule; the snapshot just does not wrongly widen it). The
+  next-table (100-199, priority 0 in tests) and rib-group per-prefix import
+  (30000-30999) leak bands carry a pure per-prefix Dst with no selectors and
+  are still ingested — no regression to inter-VRF leaking. Moved the PBR band
+  constants to `pkg/config` (`PBRRulePriorityBase`, `PBRRuleWindow`) as the
+  SSOT so the install cap (`pkg/routing` `pbrRulePriority`/`maxPBRRules`) and
+  the snapshot skip cannot drift.
+- **Validation**: RED-on-revert test `TestBuildRouteSnapshotsSkipsPBRBandRule`
+  (PBR-band rule with Src+Sport+Dst NOT ingested — fails RED when the skip is
+  removed) plus no-regression `TestBuildRouteSnapshotsIngestsRouteLeakBandRule`
+  (next-table-band rule still ingested — stays green on revert). Existing
+  #3768 / #3876 ingest tests still pass. `go test ./pkg/routing/...
+  ./pkg/dataplane/userspace/... ./pkg/config/...` green; `go build ./...`;
+  gofmt + vet clean.
+- **File(s)**: `pkg/dataplane/userspace/routes.go` (PBR-band skip in the
+  ip-rule ingest loop), `pkg/config/types_system.go` (`PBRRulePriorityBase` /
+  `PBRRuleWindow` SSOT constants), `pkg/routing/rules.go` (`pbrRulePriority` /
+  `maxPBRRules` aliased to the config SSOT),
+  `pkg/dataplane/userspace/routes_pbr_priority_4479_test.go` (new RED-on-revert
+  + no-regression tests), `pkg/routing/README.md` (userspace-snapshot skip note
+  under the PBR band bullet).
+
 ## 2026-07-07 — #4362 wg: drain cookie_gen on peer removal in reconcile_peers
 
 - **Timestamp**: 2026-07-07

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -852,6 +852,25 @@ const (
 	// ProbeRulePriorityBase is the first ip-rule priority of the
 	// probe-pin band (50-99).
 	ProbeRulePriorityBase = 50
+	// PBRRulePriorityBase is the first ip-rule priority of the
+	// policy-based-routing / filter-based-forwarding (FBF) band
+	// (31000-31999): firewall-filter `then routing-instance` actions
+	// installed by pkg/routing's pbrManager. These rules carry match
+	// SELECTORS (source/dest address, DSCP, protocol, source/dest port)
+	// in addition to a Dst, so — unlike the pure per-prefix next-table /
+	// rib-group leak bands — they MUST NOT be mirrored into the userspace
+	// next-table FIB snapshot as a bare dst-only leak (that drops the
+	// selectors and re-opens the #3730 over-steer; see #4479 and
+	// pkg/dataplane/userspace/routes.go buildRouteSnapshots). Both
+	// pkg/routing (install side) and pkg/dataplane/userspace (snapshot
+	// ingest side) consume these, so they live here as the single source
+	// of truth alongside ProbeRulePriorityBase.
+	PBRRulePriorityBase = 31000
+	// PBRRuleWindow is the size of the PBR band; the band is
+	// [PBRRulePriorityBase, PBRRulePriorityBase+PBRRuleWindow) = 31000-31999.
+	// It also bounds the number of PBR ip rules the applier installs
+	// (pkg/routing maxPBRRules) and the priority window clear() scans.
+	PBRRuleWindow = 1000
 )
 
 // RPMTest defines a test within an RPM probe.

--- a/pkg/dataplane/userspace/routes.go
+++ b/pkg/dataplane/userspace/routes.go
@@ -167,6 +167,28 @@ func buildRouteSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot, ove
 			if rule.Dst == nil || rule.Table <= 0 {
 				continue
 			}
+			// #4479 (opus-172 M-2): SKIP policy-based-routing / filter-based-
+			// forwarding rules. xpf installs FBF `then routing-instance`
+			// filter actions as ip rules in the PBR priority band
+			// (config.PBRRulePriorityBase, 31000-31999; pkg/routing
+			// pbrRulePriority) that carry match SELECTORS — source/dest
+			// address, DSCP, protocol, source/dest port — IN ADDITION to a
+			// Dst that happens to point at a routing-instance table. This
+			// synthetic snapshot can only express a bare per-prefix NextTable
+			// leak, so ingesting a PBR rule here would DROP every selector and
+			// widen a constrained, source-scoped steer into an unconditional
+			// dst-only VRF leak — the exact fail-open the kernel FBF path was
+			// hardened against in #3730. Fail CLOSED instead: leave the PBR
+			// rule out of the userspace FIB entirely. The kernel still applies
+			// the real, fully-qualified PBR rule (and the userspace filter
+			// path enforces the term), so the leak is not lost — it just is
+			// not wrongly widened. Only xpf's own pure per-prefix leak bands
+			// (next-table 100-199, rib-group per-prefix import 30000-30999)
+			// carry a Dst with no selectors and are safe to mirror below.
+			if rule.Priority >= config.PBRRulePriorityBase &&
+				rule.Priority < config.PBRRulePriorityBase+config.PBRRuleWindow {
+				continue
+			}
 			instName, ok := tableIDToInst[rule.Table]
 			if !ok {
 				continue

--- a/pkg/dataplane/userspace/routes_pbr_priority_4479_test.go
+++ b/pkg/dataplane/userspace/routes_pbr_priority_4479_test.go
@@ -1,0 +1,123 @@
+package userspace
+
+import (
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// #4479 (opus-172 M-2): the userspace FIB snapshot must NOT ingest a
+// policy-based-routing / filter-based-forwarding (FBF) ip rule as a bare
+// per-prefix NextTable leak.
+//
+// xpf installs FBF `then routing-instance` filter actions as ip rules in the
+// PBR priority band (config.PBRRulePriorityBase, 31000-31999) carrying match
+// SELECTORS — source/dest address, DSCP, protocol, source/dest port — in
+// addition to a Dst that points at a routing-instance table. The synthetic
+// next-table snapshot can only express a per-prefix leak, so mirroring a PBR
+// rule here would DROP the selectors and widen a constrained, source-scoped
+// steer into an unconditional dst-only VRF leak — the exact fail-open the
+// kernel FBF path was hardened against in #3730. buildRouteSnapshots fails
+// CLOSED: a PBR-band rule is skipped and left out of the userspace FIB (the
+// kernel still applies the real, fully-qualified rule).
+//
+// RED-on-revert: without the PBR-band skip, the loop treats ANY ip rule whose
+// Dst maps to a routing-instance table as a NextTable leak, so this rule is
+// ingested as `10.0.61.0/24 -> blue.inet.0` in inet.0 and the assertion fails.
+func TestBuildRouteSnapshotsSkipsPBRBandRule(t *testing.T) {
+	orig := ruleListFn
+	t.Cleanup(func() { ruleListFn = orig })
+
+	const tableID = 100
+	_, src, err := net.ParseCIDR("10.0.61.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, dst, err := net.ParseCIDR("172.16.80.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A realistic FBF rule: source-scoped, port-scoped, Dst matching the
+	// routing-instance table, at a priority inside the PBR band.
+	ruleListFn = func(family int) ([]netlink.Rule, error) {
+		if family == syscall.AF_INET {
+			return []netlink.Rule{{
+				Priority: config.PBRRulePriorityBase, // 31000
+				Src:      src,
+				Dst:      dst,
+				Sport:    &netlink.RulePortRange{Start: 5000, End: 5001},
+				Table:    tableID,
+			}}, nil
+		}
+		return nil, nil
+	}
+
+	cfg := &config.Config{}
+	cfg.RoutingInstances = []*config.RoutingInstanceConfig{
+		{Name: "blue", TableID: tableID},
+	}
+
+	routes, err := buildRouteSnapshots(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("buildRouteSnapshots: %v", err)
+	}
+	for _, r := range routes {
+		if r.NextTable == "blue.inet.0" && r.Destination == "172.16.80.0/24" {
+			t.Fatalf("a PBR-band FBF rule (selectors dropped) must NOT be "+
+				"ingested as a bare dst-only NextTable leak, got %+v", r)
+		}
+		// Nothing in this config should have produced any NextTable leak.
+		if r.NextTable != "" {
+			t.Fatalf("unexpected NextTable leak from a PBR-only config: %+v", r)
+		}
+	}
+}
+
+// TestBuildRouteSnapshotsIngestsRouteLeakBandRule pins the no-regression half:
+// a genuine per-prefix route-leak-band ip rule (next-table band, priority 100)
+// with a Dst matching a routing-instance table is STILL ingested as a
+// NextTable leak. These rules carry a pure per-prefix Dst with no selectors,
+// so mirroring them into the userspace FIB is correct — the PBR-band skip must
+// not touch the next-table / rib-group leak bands.
+func TestBuildRouteSnapshotsIngestsRouteLeakBandRule(t *testing.T) {
+	orig := ruleListFn
+	t.Cleanup(func() { ruleListFn = orig })
+
+	const tableID = 100
+	_, dst, err := net.ParseCIDR("10.20.30.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ruleListFn = func(family int) ([]netlink.Rule, error) {
+		if family == syscall.AF_INET {
+			// next-table leak band (100-199): pure per-prefix Dst, no selectors.
+			return []netlink.Rule{{Priority: 100, Dst: dst, Table: tableID}}, nil
+		}
+		return nil, nil
+	}
+
+	cfg := &config.Config{}
+	cfg.RoutingInstances = []*config.RoutingInstanceConfig{
+		{Name: "blue", TableID: tableID},
+	}
+
+	routes, err := buildRouteSnapshots(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("buildRouteSnapshots: %v", err)
+	}
+	found := false
+	for _, r := range routes {
+		if r.Table == "inet.0" && r.Family == "inet" &&
+			r.Destination == "10.20.30.0/24" && r.NextTable == "blue.inet.0" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("route-leak-band rule was not ingested as a NextTable leak; "+
+			"the PBR-band skip must not affect the next-table band, routes=%+v", routes)
+	}
+}

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -135,6 +135,20 @@ delegate to the owning domain. Exported types:
   and the userspace filter path still enforces the term exactly. The
   degraded error is returned to the daemon (`daemon_apply.go` step 3d) and
   logged; the buildable rules are still installed.
+  **Userspace FIB snapshot skips this band (#4479).** The userspace
+  route-snapshot builder (`buildRouteSnapshots`,
+  `pkg/dataplane/userspace/routes.go`) mirrors kernel ip rules whose Dst maps
+  to a routing-instance table into per-prefix `next-table` leaks so the
+  userspace FIB can cross-reference VRF tables. A PBR rule's Dst also maps to a
+  routing-instance table, but the rule carries selectors (`Src`, DSCP,
+  protocol, `Sport`/`Dport`) the synthetic `NextTable` snapshot cannot express.
+  Ingesting it would drop those selectors and widen the FBF steer into a
+  dst-only VRF leak — the userspace twin of the #3730 over-steer. The builder
+  therefore SKIPS any rule in `[PBRRulePriorityBase, +PBRRuleWindow)` and
+  fails closed: the userspace FIB simply omits the leak while the kernel keeps
+  applying the real, fully-qualified rule. `PBRRulePriorityBase` /
+  `PBRRuleWindow` are the SSOT in `pkg/config`, shared by the install cap
+  (`maxPBRRules`) here and the snapshot skip there so the two cannot drift.
 - `33000–33099`: rib-group inter-VRF leaking (`from all lookup
   <table>`). `ribGroupManager.Apply` only installs a leak rule when an
   instance's `interface-routes` rib-group imports a rib that resolves to

--- a/pkg/routing/rules.go
+++ b/pkg/routing/rules.go
@@ -65,8 +65,10 @@ const mainTableID = 254
 // pbrRulePriority is the base priority for policy-based routing ip rules.
 // BEFORE the main table (32766) so the kernel also honors PBR for XDP_PASS'd
 // packets (e.g. SNAT'd traffic destined for a VRF/GRE tunnel).
-// We use 31000-31999 range.
-const pbrRulePriority = 31000
+// We use 31000-31999 range. The band constant is the SSOT in pkg/config so
+// the userspace FIB snapshot ingest (pkg/dataplane/userspace/routes.go) can
+// skip this same band without drifting from the install side (#4479).
+const pbrRulePriority = config.PBRRulePriorityBase
 
 // nextTableManager reconciles next-table inter-VRF route-leak ip rules.
 // Stateless apart from the borrowed ruleOps; it reconciles against live
@@ -504,8 +506,10 @@ func (r *PBRPortRange) String() string {
 // install, matching the pbrRulePriority window (clear() scans
 // [pbrRulePriority, pbrRulePriority+1000)). A larger DSCP×src×dst expansion
 // is truncated and reported as a degraded build (#3430 M3) rather than
-// silently dropping later terms' steering.
-const maxPBRRules = 1000
+// silently dropping later terms' steering. Window size is the SSOT in
+// pkg/config (PBRRuleWindow) so the install cap and the userspace snapshot
+// skip band cannot drift (#4479).
+const maxPBRRules = config.PBRRuleWindow
 
 // pbrManager reconciles policy-based routing ip rules. Stateless apart
 // from the borrowed ruleOps.


### PR DESCRIPTION
## Summary

Fixes **#4479** (opus-172 M-2, fail-open-adjacent). The userspace route
snapshot builder (`buildRouteSnapshots` in
`pkg/dataplane/userspace/routes.go`) mirrors kernel ip rules whose `Dst`
maps to a routing-instance table into per-prefix `next-table` leaks so the
userspace FIB can cross-reference VRF tables. It applied **no priority
filter** — so a PBR / filter-based-forwarding (FBF) rule (a firewall-filter
`then routing-instance` action, installed in the PBR band 31000-31999) that
carries `Src`/`Tos`/`IPProto`/`Sport`/`Dport` **selectors** in addition to a
`Dst` was ingested as a **bare dst-only `NextTable` leak**, dropping every
selector and widening a constrained, source-scoped steer into an
unconditional VRF leak. This is the userspace twin of the #3730 kernel FBF
over-steer, on the primary dataplane.

## Fix

Skip any ip rule in the PBR band `[config.PBRRulePriorityBase,
+config.PBRRuleWindow)` = 31000-31999 in the ingest loop. A PBR rule whose
selectors the userspace next-table cannot represent is left out of the
userspace FIB entirely (**fail CLOSED**): the kernel still applies the real,
fully-qualified PBR rule, so the leak is not lost — it just is not wrongly
widened. xpf's own pure per-prefix leak bands (next-table 100-199, rib-group
per-prefix import 30000-30999) carry a `Dst` with no selectors and are still
ingested, so inter-VRF leaking is unaffected.

The PBR band bounds moved to `pkg/config` (`PBRRulePriorityBase`,
`PBRRuleWindow`) as the single source of truth, shared by the install cap
(`pkg/routing` `pbrRulePriority`/`maxPBRRules`) and the snapshot skip, so the
two cannot drift.

## Route-leak band vs PBR band (verified on master)

| Band | Priority | Carries Dst | Carries selectors | Ingested? |
|------|----------|-------------|-------------------|-----------|
| next-table (`nextTableRulePriority`) | 100-199 | yes (per-prefix) | no | yes |
| rib-group per-prefix import (`ribGroupLeakRulePriority`) | 30000-30999 | yes (per-prefix) | no | yes |
| **PBR / FBF (`pbrRulePriority`)** | **31000-31999** | yes | **yes** | **skipped (this fix)** |
| rib-group legacy blanket (`from all`) | 33000-33099 | no | — | already skipped (Dst==nil) |
| RPM probe pins | 50-99 | no (fwmark) | — | already skipped (Dst==nil) |

## Validation

- **RED-on-revert:** `TestBuildRouteSnapshotsSkipsPBRBandRule` — a PBR-band
  rule with `Src`+`Sport`+`Dst` is NOT ingested as a bare dst-only leak;
  fails RED when the skip is removed.
- **No regression:** `TestBuildRouteSnapshotsIngestsRouteLeakBandRule` — a
  next-table-band rule IS still ingested; stays green on revert. Existing
  #3768 (priority 0) / #3876 (priority 30000) ingest tests still pass.
- `go test ./pkg/routing/... ./pkg/dataplane/userspace/... ./pkg/config/...`
  green; `go build ./...`; gofmt + vet clean.

Closes #4479

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi