### PR TITLE
ddns: warn on unsigned RFC 2136 UPDATE with no TSIG key (#4483)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,31 @@
+## 2026-07-07 — #4483 (opus-172 M-6): DDNS unsigned-UPDATE forgeable-rcode warn
+
+- **Timestamp**: 2026-07-07T15:40Z
+- **Action**: Fixed opus-172 M-6 (DDNS hardening / observability gap). The RFC
+  2136 backend wires TSIG only when `tsig-key` is set, `exchange()` is UDP-first,
+  and the publish/ownership verdict keys on `resp.Rcode`. With an `update-server`
+  set and no `tsig-key`, the UPDATE goes out unsigned and the rcode is
+  unauthenticated + forgeable — a spoofed `NOERROR` records a name as published
+  though the server wrote nothing (silent blackhole); a spoofed `REFUSED`
+  suppresses a legit publish. Added a WARN-only surface for the weakened posture
+  (a hard reject would brick a previously-inert config): (a) COMMIT-time warning
+  when an `update-server` is set with no `tsig-key`, in
+  `validateDDNSBackendWarnings` (DHCP DDNS) and `validateSurfaceADDNSWarnings`
+  (Surface A provider catalog); (b) once-per-update-server RUNTIME `slog.Warn`
+  the first time an unsigned UPDATE is actually sent (`warnUnsignedOnce` +
+  package-level `unsignedUpdateWarned` sync.Map keyed by server, so the
+  per-Reconcile backend rebuild does not re-warn). Warn-only; TCP-forcing / an
+  explicit `no-tsig` opt-in are noted as follow-ups. RED-on-revert: neutralizing
+  the commit branches makes the config tests report empty warnings; stubbing the
+  runtime call emits 0 WARNs. Verified: `go test ./pkg/ddns/... ./pkg/config/...
+  ./pkg/dhcpserver/... ./pkg/daemon/...` green, go build ./... + vet + gofmt
+  clean. Docs: pkg/ddns/README.md invariant, docs/config-schema.md DDNS warn note.
+- **File(s)**: pkg/ddns/backend_rfc2136.go,
+  pkg/ddns/backend_rfc2136_test.go, pkg/config/compiler_validate_warn.go,
+  pkg/config/compiler_dhcp_ddns_test.go,
+  pkg/config/compiler_surface_a_ddns_test.go, pkg/ddns/README.md,
+  docs/config-schema.md, _Log.md
+
 ## 2026-07-07 — #4480 grpcapi: interface-monitor display honest on missing live status
 
 - **Timestamp**: 2026-07-07T14:24Z

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2626,7 +2626,16 @@ reserved for whole-dataplane selection where a rewrite shim
   `tsig-algorithm`, or an incomplete TSIG tuple (`tsig-key` without
   `tsig-secret`, or `tsig-secret` without `tsig-key`) each emit a WARN-only
   commit message (#2666) — never a hard reject, and the backend degrades
-  safely at runtime. `tsig-secret` is
+  safely at runtime. An `update-server` set with NO `tsig-key` at all also
+  warns (#4483): TSIG is the only authenticator on this path, so an unsigned
+  UPDATE trusts a forgeable response rcode — a spoofed `NOERROR` records a name
+  as published though the server wrote nothing (silent blackhole) and a spoofed
+  `REFUSED` suppresses a legitimate publish. The same no-`tsig-key` warning is
+  emitted for the Surface A provider catalog by `validateSurfaceADDNSWarnings`.
+  Both are WARN-only (a hard reject would brick a previously-inert config); the
+  backend also emits a once-per-update-server runtime `slog.Warn`
+  (`warnUnsignedOnce` in `pkg/ddns/backend_rfc2136.go`) the first time it
+  actually sends an unsigned UPDATE. `tsig-secret` is
   SENSITIVE: it is redacted in `DHCPDynamicDNSConfig.String()` (logging) AND,
   since #2053, by its `config.Secret` field type on every JSON/YAML marshal
   (so the compiled-config dump on `GET /api/v1/config` never leaks it — see

--- a/pkg/config/compiler_dhcp_ddns_test.go
+++ b/pkg/config/compiler_dhcp_ddns_test.go
@@ -508,3 +508,71 @@ func TestDHCPDDNSSchemaRejectsBadEnumAndTTL(t *testing.T) {
 		})
 	}
 }
+
+// TestDHCPDDNSNoTSIGUnsignedWarning is the #4483 commit-warn fail-on-revert
+// proof: a DHCP dynamic-dns update-server configured with NO tsig-key must
+// warn that DNS UPDATEs are sent unsigned and the response rcode is forgeable.
+// A config WITH a complete TSIG tuple must NOT emit that warning. Reverting the
+// no-tsig branch in validateDDNSBackendWarnings makes the first subtest go red.
+func TestDHCPDDNSNoTSIGUnsignedWarning(t *testing.T) {
+	hasWarn := func(ws []string, substr string) bool {
+		for _, w := range ws {
+			if strings.Contains(w, "dhcp dynamic-dns") && strings.Contains(w, substr) {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("update-server without tsig-key warns unsigned/forgeable", func(t *testing.T) {
+		cfg, err := CompileConfig(buildTree(t, []string{
+			"set system services dhcp-local-server dynamic-dns enable",
+			"set system services dhcp-local-server dynamic-dns domain corp.example.com",
+			"set system services dhcp-local-server dynamic-dns update-server 192.0.2.53",
+		}))
+		if err != nil {
+			t.Fatalf("CompileConfig must NOT error on a no-TSIG update-server: %v", err)
+		}
+		ws := ValidateConfig(cfg)
+		if !hasWarn(ws, "unsigned") {
+			t.Fatalf("an update-server with no tsig-key must warn that updates are unsigned: %v", ws)
+		}
+		if !hasWarn(ws, "forgeable") {
+			t.Fatalf("the warn must name the forgeable-response consequence: %v", ws)
+		}
+	})
+
+	t.Run("complete TSIG tuple emits no unsigned warning", func(t *testing.T) {
+		cfg, err := CompileConfig(buildTree(t, []string{
+			"set system services dhcp-local-server dynamic-dns enable",
+			"set system services dhcp-local-server dynamic-dns domain corp.example.com",
+			"set system services dhcp-local-server dynamic-dns update-server 192.0.2.53",
+			"set system services dhcp-local-server dynamic-dns tsig-key k1",
+			"set system services dhcp-local-server dynamic-dns tsig-algorithm hmac-sha256",
+			"set system services dhcp-local-server dynamic-dns tsig-secret c2VjcmV0",
+		}))
+		if err != nil {
+			t.Fatalf("CompileConfig: %v", err)
+		}
+		ws := ValidateConfig(cfg)
+		if hasWarn(ws, "unsigned") {
+			t.Fatalf("a configured tsig-key must NOT warn about unsigned updates: %v", ws)
+		}
+	})
+
+	t.Run("no update-server does not emit the unsigned warning", func(t *testing.T) {
+		// The "no update-server" warning already covers this config; the
+		// unsigned-posture warning is scoped to a SET update-server so the two
+		// do not double-fire on an incomplete config.
+		cfg, err := CompileConfig(buildTree(t, []string{
+			"set system services dhcp-local-server dynamic-dns enable",
+			"set system services dhcp-local-server dynamic-dns domain corp.example.com",
+		}))
+		if err != nil {
+			t.Fatalf("CompileConfig: %v", err)
+		}
+		if hasWarn(ValidateConfig(cfg), "unsigned") {
+			t.Fatal("with no update-server the unsigned-posture warning must not fire")
+		}
+	})
+}

--- a/pkg/config/compiler_surface_a_ddns_test.go
+++ b/pkg/config/compiler_surface_a_ddns_test.go
@@ -224,3 +224,38 @@ func TestSurfaceADDNSWarnsCheckIPSourceWithoutURL(t *testing.T) {
 		t.Fatalf("a provider WITH a checkip-url must not be flagged, got:\n%s", joined)
 	}
 }
+
+// TestSurfaceADDNSWarnsNoTSIG is the #4483 commit-warn fail-on-revert proof for
+// the Surface A provider catalog: an rfc2136 provider with an update-server but
+// NO tsig-key must warn that UPDATEs are sent unsigned and the response rcode is
+// forgeable. A provider with a complete TSIG tuple must NOT emit that warning.
+func TestSurfaceADDNSWarnsNoTSIG(t *testing.T) {
+	tree := buildTree(t, []string{
+		// rfc2136 provider WITH update-server but no tsig-key → unsigned warn.
+		"set system services dynamic-dns provider nokey backend rfc2136",
+		"set system services dynamic-dns provider nokey update-server 192.0.2.53",
+		"set interfaces ge-0-0-2 unit 50 family inet dynamic-dns provider nokey",
+		"set interfaces ge-0-0-2 unit 50 family inet dynamic-dns hostname wan.example.net",
+		// rfc2136 provider with a COMPLETE TSIG tuple → no unsigned warn.
+		"set system services dynamic-dns provider withkey backend rfc2136",
+		"set system services dynamic-dns provider withkey update-server 192.0.2.53",
+		"set system services dynamic-dns provider withkey tsig-key k1",
+		"set system services dynamic-dns provider withkey tsig-algorithm hmac-sha256",
+		"set system services dynamic-dns provider withkey tsig-secret c2VjcmV0",
+		"set interfaces ge-0-0-3 unit 0 family inet dynamic-dns provider withkey",
+		"set interfaces ge-0-0-3 unit 0 family inet dynamic-dns hostname wan2.example.net",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	joined := strings.Join(validateSurfaceADDNSWarnings(cfg), "\n")
+	if !strings.Contains(joined, "provider \"nokey\"") ||
+		!strings.Contains(joined, "no tsig-key") || !strings.Contains(joined, "forgeable") {
+		t.Fatalf("provider nokey (update-server, no tsig-key) must warn unsigned/forgeable, got:\n%s", joined)
+	}
+	// The complete-tuple provider must not be dragged into the unsigned warning.
+	if strings.Contains(joined, "provider \"withkey\"") && strings.Contains(joined, "no tsig-key") {
+		t.Fatalf("a provider WITH a tsig-key must not warn about unsigned updates, got:\n%s", joined)
+	}
+}

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -2071,6 +2071,20 @@ func validateDDNSBackendWarnings(cfg *Config) []string {
 				"update-server %q is not a valid host or host:port; the backend "+
 				"will fail to send updates", d.UpdateServer))
 		}
+		// #4483: an update-server with NO tsig-key sends unsigned UPDATEs and
+		// trusts an UNAUTHENTICATED, forgeable response rcode — a spoofed
+		// NOERROR records a name as published though the server wrote nothing
+		// (silent blackhole), and a spoofed REFUSED suppresses a legitimate
+		// publish. WARN-only so a previously-inert config still commits; the
+		// fix is to configure tsig-key/tsig-secret (miekg then verifies the MAC).
+		if d.UpdateServer != "" && d.TSIGKeyName == "" {
+			warnings = append(warnings, "dhcp dynamic-dns update-server is "+
+				"configured without a tsig-key; DNS UPDATEs are sent unsigned and "+
+				"the server's response rcode is unauthenticated and forgeable — a "+
+				"spoofed NOERROR can record a name as published though nothing was "+
+				"written (silent blackhole) and a spoofed REFUSED can suppress a "+
+				"legitimate publish. Set tsig-key/tsig-secret to authenticate updates")
+		}
 		if d.TSIGKeyName != "" && !ddnsTSIGAlgorithmSupported(d.TSIGAlgorithm) {
 			warnings = append(warnings, fmt.Sprintf("dhcp dynamic-dns "+
 				"tsig-algorithm %q is not supported (use hmac-sha1, hmac-sha224, "+
@@ -2307,6 +2321,19 @@ func validateSurfaceADDNSWarnings(cfg *Config) []string {
 			} else if !ddnsUpdateServerParseable(p.UpdateServer) {
 				warnings = append(warnings, fmt.Sprintf("system services dynamic-dns "+
 					"provider %q update-server %q is not a valid host or host:port", name, p.UpdateServer))
+			}
+			// #4483: an update-server with NO tsig-key sends unsigned UPDATEs
+			// and trusts an unauthenticated, forgeable response rcode (spoofed
+			// NOERROR → silent blackhole; spoofed REFUSED → suppressed publish).
+			// WARN-only; the fix is tsig-key/tsig-secret (miekg verifies the MAC).
+			if p.UpdateServer != "" && p.TSIGKeyName == "" {
+				warnings = append(warnings, fmt.Sprintf("system services dynamic-dns "+
+					"provider %q (backend rfc2136) has an update-server but no tsig-key; "+
+					"DNS UPDATEs are sent unsigned and the server's response rcode is "+
+					"unauthenticated and forgeable — a spoofed NOERROR can record a name "+
+					"as published though nothing was written (silent blackhole) and a "+
+					"spoofed REFUSED can suppress a legitimate publish. Set tsig-key/"+
+					"tsig-secret to authenticate updates", name))
 			}
 			keySet := p.TSIGKeyName != ""
 			secretSet := p.TSIGSecret.Reveal() != ""

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -262,6 +262,25 @@ no change in those packages:
   `xpf_ddns_surface_a_degraded` Prometheus gauge, and on `SurfaceAStats.Degraded`
   / `DegradedReason`.
 - **No secret in any error string** (TSIG secret revealed only at construction).
+- **Unsigned (no-TSIG) UPDATEs are warned, not silent (#4483)** — TSIG is the
+  ONLY authenticator on this path. When `tsig-key` is unset the RFC 2136 UPDATE
+  is sent unsigned (`exchange()` is UDP-first), and the publish/ownership
+  verdict keys on `resp.Rcode` — an UNAUTHENTICATED, forgeable field. An on-path
+  (or ID+port-guessing off-path) attacker can forge a `NOERROR` so the manager
+  records a name as published though the server wrote nothing (silent
+  blackhole), or forge a `REFUSED` to suppress a legitimate publish. The gap is
+  fully closed by configuring `tsig-key`/`tsig-secret` (miekg then verifies the
+  response MAC and rejects a forgery). Because a hard reject would brick a
+  previously-inert config, the weakened posture is surfaced rather than
+  forbidden: a COMMIT-time warning (`validateDDNSBackendWarnings` for DHCP DDNS,
+  `validateSurfaceADDNSWarnings` for the Surface A provider catalog — both in
+  `pkg/config/compiler_validate_warn.go`) whenever an `update-server` is set
+  with no `tsig-key`, AND a once-per-update-server RUNTIME `slog.Warn`
+  (`warnUnsignedOnce` in `backend_rfc2136.go`, deduped in the package-level
+  `unsignedUpdateWarned` map so the per-cycle backend rebuild does not re-warn)
+  the first time an unsigned UPDATE is actually sent. Forcing TCP or an explicit
+  `no-tsig` opt-in acknowledgment are possible follow-ups; the warn is the
+  minimum that makes the operator aware.
 
 The HA writer gate (`ddnsWriterGateOpen`) stays in `pkg/daemon/daemon_ddns.go`
 (it reads cluster RG state); P1a did not move or change it.

--- a/pkg/ddns/backend_rfc2136.go
+++ b/pkg/ddns/backend_rfc2136.go
@@ -6,9 +6,11 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/netip"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/miekg/dns"
@@ -983,12 +985,47 @@ func (u *rfc2136Updater) sendRemoveForward(ctx context.Context, zone string, rr 
 	}
 }
 
+// unsignedUpdateWarned dedups the #4483 once-per-provider runtime warning
+// emitted the first time this process sends an UNSIGNED (no-TSIG) DNS UPDATE to
+// a given update server. It is keyed by the server host:port because the
+// manager rebuilds the rfc2136Updater every Reconcile cycle
+// (NewProductionManager resolves the backend from the policy at the start of
+// each pass), so a per-updater sync.Once would re-warn every cycle. The map
+// only ever grows by the small, bounded number of distinct update servers
+// configured across DHCP DDNS + Surface A providers.
+var unsignedUpdateWarned sync.Map // server string -> struct{}
+
+// warnUnsignedOnce logs a single WARN — the first time this process sends an
+// unsigned update to u.server — that the update is unauthenticated and the
+// server's response rcode is forgeable (#4483). Subsequent unsigned updates to
+// the same server are silent. Configuring tsig-key/tsig-secret closes the gap
+// (miekg verifies the response MAC), so the message points the operator there.
+func (u *rfc2136Updater) warnUnsignedOnce() {
+	if _, loaded := unsignedUpdateWarned.LoadOrStore(u.server, struct{}{}); loaded {
+		return
+	}
+	slog.Warn("ddns: sending UNSIGNED DNS UPDATE (no tsig-key configured); "+
+		"the update is unauthenticated and the server's response rcode is "+
+		"forgeable — a spoofed NOERROR records a name as published though the "+
+		"server wrote nothing (silent blackhole) and a spoofed REFUSED "+
+		"suppresses a legitimate publish. Configure tsig-key/tsig-secret to "+
+		"authenticate updates.",
+		"server", u.server)
+}
+
 // exchange signs (when TSIG configured) and sends a message UDP-first,
 // retrying over TCP on a truncated response. The per-call context bounds
 // the network I/O.
 func (u *rfc2136Updater) exchange(ctx context.Context, m *dns.Msg) (*dns.Msg, error) {
 	if u.tsigKeyName != "" {
 		m.SetTsig(u.tsigKeyName, u.tsigAlgo, 300, time.Now().Unix())
+	} else {
+		// #4483: no TSIG key configured. The UPDATE is sent unsigned and the
+		// publish/ownership verdict below keys on an UNAUTHENTICATED, forgeable
+		// response rcode. Warn once per update server so the operator sees the
+		// weakened posture (the commit-time check already warned; this catches
+		// the runtime path too).
+		u.warnUnsignedOnce()
 	}
 	if u.timeout > 0 {
 		var cancel context.CancelFunc

--- a/pkg/ddns/backend_rfc2136_test.go
+++ b/pkg/ddns/backend_rfc2136_test.go
@@ -1,8 +1,10 @@
 package ddns
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"net"
 	"net/netip"
 	"strings"
@@ -1054,4 +1056,74 @@ func TestExchangeTCPRetryHonorsCallerCancellation(t *testing.T) {
 	if elapsed > time.Second {
 		t.Errorf("caller deadline was not honored: took %v (stall is 2s) — err=%v", elapsed, err)
 	}
+}
+
+// TestRFC2136UnsignedUpdateWarnsOncePerProvider is the #4483 runtime-warn
+// fail-on-revert proof: an updater with NO TSIG key must emit a single WARN,
+// the first time it sends an unsigned UPDATE to a given server, that the update
+// is unauthenticated and the response rcode is forgeable. The warning is
+// deduped per update server (keyed by host:port) across the per-cycle backend
+// rebuilds, so a second UpsertLease to the same server stays silent. An updater
+// WITH a TSIG key must NOT warn.
+func TestRFC2136UnsignedUpdateWarnsOncePerProvider(t *testing.T) {
+	t.Run("no tsig warns exactly once", func(t *testing.T) {
+		srv := newFakeDNSServer(t, nil) // no TSIG on the server side either
+		var ptr, conf int
+		u := testUpdater(t, srv, &config.DHCPDynamicDNSConfig{Enabled: true, Domain: "example.com"}, &ptr, &conf)
+		if u.tsigKeyName != "" {
+			t.Fatalf("precondition: updater must have no TSIG key, got %q", u.tsigKeyName)
+		}
+
+		var buf bytes.Buffer
+		prev := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+		defer slog.SetDefault(prev)
+
+		// First upsert sends a forward + reverse UPDATE (two unsigned
+		// exchanges); the once-per-provider dedup must collapse them to one WARN.
+		if err := u.UpsertLease(context.Background(), recV4("laptop.example.com", "10.0.1.5", 300)); err != nil {
+			t.Fatalf("UpsertLease #1: %v", err)
+		}
+		// A second upsert to the SAME server must not re-warn.
+		if err := u.UpsertLease(context.Background(), recV4("phone.example.com", "10.0.1.6", 300)); err != nil {
+			t.Fatalf("UpsertLease #2: %v", err)
+		}
+
+		out := buf.String()
+		n := strings.Count(out, "UNSIGNED DNS UPDATE")
+		if n != 1 {
+			t.Fatalf("want exactly one unsigned-update WARN across two upserts, got %d; log=%q", n, out)
+		}
+		if !strings.Contains(out, "forgeable") || !strings.Contains(out, "server="+srv.addrUDP) {
+			t.Fatalf("the WARN must name the forgeable posture and the server; log=%q", out)
+		}
+	})
+
+	t.Run("tsig-signed updater does not warn", func(t *testing.T) {
+		secret := map[string]string{"k1.": "c2VjcmV0"}
+		srv := newFakeDNSServer(t, secret)
+		var ptr, conf int
+		u := testUpdater(t, srv, &config.DHCPDynamicDNSConfig{
+			Enabled:       true,
+			Domain:        "example.com",
+			TSIGKeyName:   "k1",
+			TSIGAlgorithm: "hmac-sha256",
+			TSIGSecret:    config.Secret("c2VjcmV0"),
+		}, &ptr, &conf)
+		if u.tsigKeyName == "" {
+			t.Fatal("precondition: updater must have a TSIG key")
+		}
+
+		var buf bytes.Buffer
+		prev := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+		defer slog.SetDefault(prev)
+
+		if err := u.UpsertLease(context.Background(), recV4("laptop.example.com", "10.0.1.5", 300)); err != nil {
+			t.Fatalf("UpsertLease: %v", err)
+		}
+		if strings.Contains(buf.String(), "UNSIGNED DNS UPDATE") {
+			t.Fatalf("a TSIG-signed updater must not warn unsigned; log=%q", buf.String())
+		}
+	})
 }


### PR DESCRIPTION
Closes #4483 (opus-172 M-6).

## Problem
The live RFC 2136 DDNS backend (`pkg/ddns/backend_rfc2136.go`) wires TSIG only when `tsig-key` is set, sends UPDATEs UDP-first (`exchange()`), and keys the publish/ownership verdict on `resp.Rcode`. With an `update-server` configured and **no** `tsig-key`, the UPDATE is unsigned and the rcode is unauthenticated and forgeable:

- a forged `NOERROR` makes the manager record a name as published though the server wrote nothing (silent blackhole);
- a forged `REFUSED` suppresses a legitimate publish.

TSIG fully closes the gap (miekg verifies the response MAC), but nothing told the operator they were running unauthenticated.

## Fix (warn-only, the plan's recommended bounded fix)
A hard reject would brick a previously-inert config, so the weakened posture is surfaced, not forbidden — matching the existing WARN-only DDNS validators.

- **Commit-time warning** when an `update-server` is set with no `tsig-key`, in `validateDDNSBackendWarnings` (DHCP DDNS) and `validateSurfaceADDNSWarnings` (Surface A provider catalog) — `pkg/config/compiler_validate_warn.go`. Scoped to a SET `update-server` (no double-fire with the existing "no update-server" warning) and gated on empty `tsig-key` (distinct from the #2666 incomplete-tuple warnings).
- **Once-per-update-server runtime `slog.Warn`** the first time an unsigned UPDATE is actually sent — `warnUnsignedOnce()` in `backend_rfc2136.go`, deduped by a package-level `unsignedUpdateWarned` sync.Map keyed by server host:port (the manager rebuilds the updater every Reconcile, so a per-updater `sync.Once` would re-warn every pass).

Forcing TCP or an explicit `no-tsig` opt-in acknowledgment are noted as possible follow-ups; the warn is the minimum that makes the operator aware.

## Validation
Fail-on-revert tests:
- `TestDHCPDDNSNoTSIGUnsignedWarning`, `TestSurfaceADDNSWarnsNoTSIG` — a no-tsig update-server warns unsigned/forgeable; a complete TSIG tuple does not.
- `TestRFC2136UnsignedUpdateWarnsOncePerProvider` — two upserts to the same server emit exactly one WARN; a TSIG-signed updater emits none.

Reverting each source change makes the matching test go red. `go test ./pkg/ddns/... ./pkg/config/... ./pkg/dhcpserver/... ./pkg/daemon/...` green; `go build ./...` + `go vet` + `gofmt` clean.

Docs: `pkg/ddns/README.md` invariant + `docs/config-schema.md` DDNS warn note + `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi