### PR TITLE
config: reject firewall-filter term with conflicting terminating actions

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,39 @@
+## 2026-07-07 — #4375 (avo-review-007 H3): firewall-filter conflicting terminating actions rejected at commit
+
+- **Timestamp**: 2026-07-07T07:50Z
+- **Action**: Fixed #4375. A firewall-filter term specifying more than one
+  terminating action (`then accept` + `then reject`, accept+discard,
+  reject+discard) was silently accepted. `compileFilterThen` writes the action
+  onto the single-valued `FirewallFilterTerm.Action`, overwriting last-write-wins,
+  so a contradictory term compiled to whichever keyword came last with a clean
+  commit — the operator's intent was ambiguous and the compiled behavior did not
+  necessarily match what they wrote. Junos treats accept/reject/discard as
+  mutually exclusive (one terminating action per term). FIX: `compileFilterThen`
+  now records every terminating keyword on a new `FirewallFilterTerm.Terminal-
+  Actions` slice (both leaf and child AST shapes), and new
+  `validateFilterTerminalConflictStrict` hard-rejects any term whose DISTINCT
+  terminal count exceeds one, naming family/filter/term + the conflicting
+  actions. Non-terminal modifiers (count/log/forwarding-class/loss-priority/dscp/
+  traffic-class/policer/routing-instance) coexist with a terminal and are NOT
+  flagged; repeating the same terminal (redundancy) is allowed. Strict on commit,
+  downgraded to a warning on the tolerant load / peer-sync path
+  (`lenientFilterTerminalConflict`, #1960 no-brick; last-wins Action drives the
+  dataplane). Gate wired immediately after the #3308 routing-instance conflict
+  gate. RED-on-revert: `firewall_terminal_conflict_4375_test.go` — the 4 conflict
+  tests go RED (silently accepted) without the gate; the count+terminal, single-
+  terminal, and duplicate-same-terminal tests confirm no over-reject. Verified:
+  `go test ./pkg/config/...` green (regenerated the #4406 golden baseline — the
+  only diff was the new TerminalActions field, either null or ["accept"]), go
+  build ./... + vet + gofmt clean. Pre-existing unrelated failure:
+  `TestUserspaceLinkCycleDoesNotReenterLegacyLoader` (pkg/dataplane canary,
+  fails identically on clean origin/master). Docs: docs/config-schema.md #4375
+  section.
+- **File(s)**: pkg/config/compiler_firewall.go, pkg/config/types_system.go,
+  pkg/config/compiler_validate_strict_filter.go,
+  pkg/config/compiler_uniformgates.go, pkg/config/compiler.go,
+  pkg/config/firewall_terminal_conflict_4375_test.go,
+  pkg/config/testdata/golden_4406.json, docs/config-schema.md, _Log.md
+
 ## 2026-07-07 — #4483 (opus-172 M-6): DDNS unsigned-UPDATE forgeable-rcode warn
 
 - **Timestamp**: 2026-07-07T15:40Z

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3767,6 +3767,45 @@ reject still rejects, `TestFilterAction_Unknown_LenientWarns`,
 (`unknown_nonempty_action_fails_closed_discard`,
 `empty_action_falls_through_to_accept`).
 
+### #4375 — firewall-filter conflicting terminating actions (commit fail-closed)
+
+Junos treats the three terminating actions `accept` / `reject` / `discard`
+as **mutually exclusive**: a filter term has at most ONE terminating action.
+xpf stores the resolved action on the single-valued `FirewallFilterTerm.Action`,
+which `compileFilterThen` overwrites **last-write-wins** — so a term carrying
+BOTH `then accept` AND `then reject` (in one `then {}` block or across two, since
+#3850 applies every block) silently compiled to whichever keyword appeared last.
+Commit reported SUCCESS, the operator's intent was ambiguous, and the compiled
+behavior did not necessarily match what they wrote — a silent misconfiguration.
+Provenance: avo-review-007 H3.
+
+`compileFilterThen` now records EVERY terminating keyword it sees on
+`FirewallFilterTerm.TerminalActions` (in order, with duplicates), and
+**`validateFilterTerminalConflictStrict`** (`compiler_validate_strict_filter.go`)
+hard-rejects any term whose **distinct**-terminal count exceeds one, naming the
+family / filter / term / the conflicting actions. Two constructs are explicitly
+NOT flagged so a real config is not over-rejected: repeating the SAME terminal
+(e.g. two `then discard` blocks — a redundancy, one distinct terminal), and a
+non-terminating modifier co-located with exactly one terminal (`then count X
+accept` — `count`/`log`/`forwarding-class`/`loss-priority`/`dscp`/
+`traffic-class`/`policer`/`routing-instance` are NOT terminals and coexist with
+one). `then routing-instance` co-located with a terminating `discard`/`reject`
+is a separate contradiction handled by `validateFilterRoutingInstanceConflict-
+Strict` (#3308); `next term` is a fall-through control, not a terminating action.
+
+**Strict/lenient split (flag `lenientFilterTerminalConflict`, sibling of
+`lenientFilterRoutingInstanceConflict`):** strict on the commit / commit-check
+path (`CompileConfig` — hard-reject), downgraded to a `cfg.Warnings` entry on the
+tolerant load / peer-sync paths (`CompileConfigLenient` /
+`CompileConfigForNodeLenient`) so an already-persisted or peer-synced config
+carrying a contradictory term still BOOTS (#1960 fail-closed-on-load doctrine) —
+the last-wins `Action` drives the dataplane deterministically on that boot. The
+gate runs immediately after `validateFilterRoutingInstanceConflictStrict`.
+Regression coverage: `pkg/config/firewall_terminal_conflict_4375_test.go`
+(accept/reject, accept/discard, reject/discard conflicts + inet6 — fail-on-revert
+guards; `then count X log accept`, a single terminal, and duplicate-same-terminal
+accepted — anti-over-reject; lenient path does not hard-fail).
+
 ### #3445 — lo0 input-filter `then` modifiers: nft-mirror support policy (commit warning)
 
 The lo0.0 input filter (`interfaces lo0 unit 0 family inet[6] filter input

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -669,6 +669,20 @@ type compileOpts struct {
 	// no-brick); the runtime routes-and-mislogs the term independently. Same
 	// doctrine as lenientFilterPortExcept.
 	lenientFilterRoutingInstanceConflict bool
+	// lenientFilterTerminalConflict (#4375, avo-review-007 H3) downgrades the
+	// firewall-filter conflicting-terminal-actions gate
+	// (validateFilterTerminalConflictStrict) from a hard compile error to a
+	// cfg.Warnings entry. The strict commit / commit-check path hard-rejects a
+	// term that specifies more than one DISTINCT terminating action
+	// (accept/reject/discard — mutually exclusive in Junos). Before this gate
+	// compileFilterThen wrote each keyword onto the single-valued term.Action
+	// (last-write-wins), so a term with `then accept` AND `then reject` silently
+	// compiled to whichever came last — an ambiguous config accepted with one
+	// side of the operator's intent lost. The tolerant load / peer-sync paths
+	// downgrade to a warning so an already-persisted or peer-synced config still
+	// BOOTS (#1960 no-brick); the last-wins Action drives the dataplane
+	// deterministically. Sibling of lenientFilterRoutingInstanceConflict (#3308).
+	lenientFilterTerminalConflict bool
 	// lenientFilterDSCP (#3309) downgrades the firewall-filter DSCP /
 	// traffic-class range gate (validateFilterDSCPStrict) from a hard compile
 	// error to a cfg.Warnings entry. The strict commit / commit-check path
@@ -1552,6 +1566,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientFilterFromMatch:                 true,
 		lenientFilterAddressLiterals:           true,
 		lenientFilterRoutingInstanceConflict:   true,
+		lenientFilterTerminalConflict:          true,
 		lenientFilterDSCP:                      true,
 		lenientNPTv6:                           true,
 		lenientNAT64Prefix:                     true,
@@ -1797,6 +1812,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientFilterFromMatch:                 true,
 		lenientFilterAddressLiterals:           true,
 		lenientFilterRoutingInstanceConflict:   true,
+		lenientFilterTerminalConflict:          true,
 		lenientFilterDSCP:                      true,
 		lenientNPTv6:                           true,
 		lenientNAT64Prefix:                     true,

--- a/pkg/config/compiler_firewall.go
+++ b/pkg/config/compiler_firewall.go
@@ -1054,8 +1054,10 @@ func compileFilterThen(node *Node, term *FirewallFilterTerm) {
 			switch k {
 			case "accept":
 				term.Action = "accept"
+				term.TerminalActions = append(term.TerminalActions, "accept")
 			case "reject":
 				term.Action = "reject"
+				term.TerminalActions = append(term.TerminalActions, "reject")
 				// Junos `then reject <message-type>`: the term is a plain
 				// reject; capture a KNOWN message-type for fidelity. Only
 				// consume the following token if it is a recognized type — a
@@ -1067,6 +1069,7 @@ func compileFilterThen(node *Node, term *FirewallFilterTerm) {
 				}
 			case "discard":
 				term.Action = "discard"
+				term.TerminalActions = append(term.TerminalActions, "discard")
 			case "next":
 				// `then next term` / bare `then next` — explicit fall-through
 				// to the next term (a no-op terminating-wise). Consume an
@@ -1118,8 +1121,10 @@ func compileFilterThen(node *Node, term *FirewallFilterTerm) {
 		switch child.Name() {
 		case "accept":
 			term.Action = "accept"
+			term.TerminalActions = append(term.TerminalActions, "accept")
 		case "reject":
 			term.Action = "reject"
+			term.TerminalActions = append(term.TerminalActions, "reject")
 			// `then reject <message-type>` — capture a KNOWN type for fidelity;
 			// a typo after reject is flagged (see leaf-form note above). The
 			// message-type is the second key (block form) or a single child.
@@ -1141,6 +1146,7 @@ func compileFilterThen(node *Node, term *FirewallFilterTerm) {
 			}
 		case "discard":
 			term.Action = "discard"
+			term.TerminalActions = append(term.TerminalActions, "discard")
 		case "next":
 			// `then next term` / bare `then next` — explicit fall-through.
 			term.NextTerm = true

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -836,6 +836,26 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 		}
 	}
 
+	// #4375 (avo-review-007 H3) firewall-filter conflicting-terminal-actions gate.
+	// Strict on commit / commit-check (hard-reject a term that specifies more than
+	// one DISTINCT terminating action — accept/reject/discard are mutually
+	// exclusive in Junos). Before this gate compileFilterThen wrote each keyword
+	// onto the single-valued term.Action (last-write-wins), so a term with `then
+	// accept` AND `then reject` silently compiled to whichever came last — the
+	// operator's intent was ambiguous. Lenient on load / peer-sync (warn so an
+	// already-persisted or peer-synced config still boots — #1960 no-brick; the
+	// last-wins Action drives the dataplane independently). Runs on the
+	// fully-compiled *Config so the typed term list (TerminalActions populated by
+	// compileFilterThen) is available.
+	if err := validateFilterTerminalConflictStrict(cfg); err != nil {
+		if opts.lenientFilterTerminalConflict {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("firewall filter terminal-action conflict (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #3309 firewall-filter DSCP / traffic-class range gate. Strict on commit /
 	// commit-check (hard-reject a `from dscp`/`from traffic-class` match or a
 	// `then dscp`/`then traffic-class` rewrite token that is neither a known

--- a/pkg/config/compiler_validate_strict_filter.go
+++ b/pkg/config/compiler_validate_strict_filter.go
@@ -1283,6 +1283,83 @@ func validateFilterRoutingInstanceConflictStrict(cfg *Config) error {
 	return check("inet6", cfg.Firewall.FiltersInet6)
 }
 
+// validateFilterTerminalConflictStrict hard-rejects a firewall-filter term that
+// specifies more than one DISTINCT terminating action (accept / reject /
+// discard) — #4375 (avo-review-007 H3).
+//
+// Junos treats accept/reject/discard as mutually exclusive: a term has exactly
+// ONE terminating action. xpf stores the action on the single-valued field
+// term.Action, which compileFilterThen overwrites last-write-wins, so a term
+// with `then accept` AND `then reject` (whether in one `then {}` block or across
+// two — #3850 applies every block) silently compiled to whichever keyword came
+// last. The operator's intent was ambiguous and the compiled behavior did not
+// necessarily match what they wrote — a silent misconfiguration.
+//
+// compileFilterThen now records every terminating keyword it sees on
+// term.TerminalActions (in order, with duplicates). This gate reports the
+// conflict when the term carries more than one DISTINCT terminal. Repeating the
+// SAME terminal (e.g. two `then discard` blocks) is a redundancy, not a
+// conflict, and is allowed. The non-terminating modifiers (count/log/
+// forwarding-class/loss-priority/dscp/traffic-class/policer/routing-instance)
+// are not terminals and coexist with a terminal — a term with `then count X
+// accept` is valid. (`then routing-instance` co-located with a terminating
+// discard/reject is a separate contradiction handled by
+// validateFilterRoutingInstanceConflictStrict, #3308.)
+//
+// The walk is deterministic (filters sorted by name, terms in config order) so
+// the first-reported error is stable across runs. On the tolerant load /
+// peer-sync path the caller downgrades the returned error to a warning (#1960
+// no-brick); the last-wins term.Action still drives the dataplane, so a
+// leniently-loaded contradictory term forwards deterministically — but the
+// operator never reaches that state through a commit. Mirrors
+// validateFilterRoutingInstanceConflictStrict.
+func validateFilterTerminalConflictStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	check := func(family string, filters map[string]*FirewallFilter) error {
+		names := make([]string, 0, len(filters))
+		for name := range filters {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			filter := filters[name]
+			if filter == nil {
+				continue
+			}
+			for _, term := range filter.Terms {
+				if term == nil || len(term.TerminalActions) < 2 {
+					continue
+				}
+				// Collect distinct terminals in first-seen order so the error
+				// is stable and reads in the order the operator wrote them.
+				seen := make(map[string]bool, len(term.TerminalActions))
+				distinct := make([]string, 0, len(term.TerminalActions))
+				for _, a := range term.TerminalActions {
+					if !seen[a] {
+						seen[a] = true
+						distinct = append(distinct, a)
+					}
+				}
+				if len(distinct) > 1 {
+					return fmt.Errorf(
+						"firewall family %s filter %q term %q: conflicting "+
+							"terminating actions %s — a term may have at most one "+
+							"terminating action (accept/reject/discard are mutually "+
+							"exclusive)",
+						family, name, term.Name, strings.Join(distinct, " and "))
+				}
+			}
+		}
+		return nil
+	}
+	if err := check("inet", cfg.Firewall.FiltersInet); err != nil {
+		return err
+	}
+	return check("inet6", cfg.Firewall.FiltersInet6)
+}
+
 // validateFilterDSCPStrict hard-rejects a firewall-filter term whose
 // `from dscp` / `from traffic-class` MATCH token or `then dscp` /
 // `then traffic-class` REWRITE token is neither a known DSCP code-point name nor

--- a/pkg/config/firewall_terminal_conflict_4375_test.go
+++ b/pkg/config/firewall_terminal_conflict_4375_test.go
@@ -1,0 +1,125 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4375 (avo-review-007 H3): a firewall-filter term that specifies more than one
+// terminating action (accept / reject / discard) is contradictory — Junos treats
+// the three as mutually exclusive (a term has exactly ONE terminating action).
+// Before validateFilterTerminalConflictStrict, compileFilterThen wrote each
+// keyword onto the single-valued term.Action field (last-write-wins) so a term
+// with `then accept` AND `then reject` silently compiled to whichever appeared
+// last — the operator's intent was ambiguous and the compiled behavior did not
+// necessarily match what they wrote. The gate makes it an operator-visible
+// commit error.
+//
+// FAIL-ON-REVERT: remove the validateFilterTerminalConflictStrict invocation (or
+// the function's reject) and these strict-path tests go RED — CompileConfig
+// accepts the contradictory term.
+
+func TestFilterAcceptRejectConflict_4375(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter f term t then accept",
+		"set firewall family inet filter f term t then reject",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("term with both accept and reject must be rejected at commit " +
+			"(#4375 — conflicting terminating actions resolve last-wins)")
+	}
+	if !strings.Contains(err.Error(), "accept") ||
+		!strings.Contains(err.Error(), "reject") ||
+		!strings.Contains(err.Error(), "terminating") {
+		t.Fatalf("error %q must name both conflicting terminating actions", err)
+	}
+	if !strings.Contains(err.Error(), `filter "f"`) ||
+		!strings.Contains(err.Error(), `term "t"`) {
+		t.Fatalf("error %q must name the offending filter and term", err)
+	}
+	if _, lerr := CompileConfigLenient(tree); lerr != nil {
+		t.Fatalf("lenient path must not hard-fail on the accept/reject conflict: %v", lerr)
+	}
+}
+
+func TestFilterAcceptDiscardConflict_4375(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter f term t then accept",
+		"set firewall family inet filter f term t then discard",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("term with both accept and discard must be rejected at commit (#4375)")
+	}
+	if !strings.Contains(err.Error(), "accept") ||
+		!strings.Contains(err.Error(), "discard") {
+		t.Fatalf("error %q must name the accept/discard conflict", err)
+	}
+	if _, lerr := CompileConfigLenient(tree); lerr != nil {
+		t.Fatalf("lenient path must not hard-fail on the accept/discard conflict: %v", lerr)
+	}
+}
+
+func TestFilterRejectDiscardConflict_4375(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter f term t then reject",
+		"set firewall family inet filter f term t then discard",
+	)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("term with both reject and discard must be rejected at commit (#4375)")
+	}
+}
+
+// inet6 must be gated identically (the validator walks both families).
+func TestFilterTerminalConflictV6_4375(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet6 filter f6 term t then accept",
+		"set firewall family inet6 filter f6 term t then discard",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("inet6 term with accept + discard must be rejected (#4375)")
+	}
+	if !strings.Contains(err.Error(), "inet6") {
+		t.Fatalf("error %q must name the inet6 family", err)
+	}
+}
+
+// A term with a non-terminating modifier (count) plus exactly ONE terminating
+// action is valid Junos and must compile cleanly — count/log/forwarding-class/
+// dscp/policer are NOT terminating actions and coexist with a terminal.
+func TestFilterCountPlusTerminalAllowed_4375(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter ok term t then count c1",
+		"set firewall family inet filter ok term t then log",
+		"set firewall family inet filter ok term t then accept",
+	)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("count + log + accept (one terminal, non-terminal modifiers) must compile: %v", err)
+	}
+}
+
+// A single terminating action is the ordinary case and must compile.
+func TestFilterSingleTerminalAllowed_4375(t *testing.T) {
+	for _, action := range []string{"accept", "reject", "discard"} {
+		tree := buildFilterTree(t,
+			"set firewall family inet filter ok term t then "+action,
+		)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("single terminal %q must compile: %v", action, err)
+		}
+	}
+}
+
+// Repeating the SAME terminating action (e.g. two `then discard` blocks) is a
+// redundancy, not a conflict — one distinct terminal — and must compile.
+func TestFilterDuplicateSameTerminalAllowed_4375(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter ok term t then discard",
+		"set firewall family inet filter ok term t then discard",
+	)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("two identical `then discard` blocks (one distinct terminal) must compile: %v", err)
+	}
+}

--- a/pkg/config/testdata/golden_4406.json
+++ b/pkg/config/testdata/golden_4406.json
@@ -979,6 +979,7 @@
                 "TCPFlags": null,
                 "IsFragment": false,
                 "Action": "",
+                "TerminalActions": null,
                 "UnknownActions": null,
                 "RejectMessageType": "",
                 "NextTerm": false,
@@ -1013,6 +1014,9 @@
                 "TCPFlags": null,
                 "IsFragment": false,
                 "Action": "accept",
+                "TerminalActions": [
+                  "accept"
+                ],
                 "UnknownActions": null,
                 "RejectMessageType": "",
                 "NextTerm": false,
@@ -2211,6 +2215,7 @@
                 "TCPFlags": null,
                 "IsFragment": false,
                 "Action": "",
+                "TerminalActions": null,
                 "UnknownActions": null,
                 "RejectMessageType": "",
                 "NextTerm": false,
@@ -2245,6 +2250,9 @@
                 "TCPFlags": null,
                 "IsFragment": false,
                 "Action": "accept",
+                "TerminalActions": [
+                  "accept"
+                ],
                 "UnknownActions": null,
                 "RejectMessageType": "",
                 "NextTerm": false,
@@ -3441,6 +3449,7 @@
                 "TCPFlags": null,
                 "IsFragment": false,
                 "Action": "",
+                "TerminalActions": null,
                 "UnknownActions": null,
                 "RejectMessageType": "",
                 "NextTerm": false,
@@ -3475,6 +3484,9 @@
                 "TCPFlags": null,
                 "IsFragment": false,
                 "Action": "accept",
+                "TerminalActions": [
+                  "accept"
+                ],
                 "UnknownActions": null,
                 "RejectMessageType": "",
                 "NextTerm": false,
@@ -4671,6 +4683,7 @@
                 "TCPFlags": null,
                 "IsFragment": false,
                 "Action": "",
+                "TerminalActions": null,
                 "UnknownActions": null,
                 "RejectMessageType": "",
                 "NextTerm": false,
@@ -4705,6 +4718,9 @@
                 "TCPFlags": null,
                 "IsFragment": false,
                 "Action": "accept",
+                "TerminalActions": [
+                  "accept"
+                ],
                 "UnknownActions": null,
                 "RejectMessageType": "",
                 "NextTerm": false,
@@ -5903,6 +5919,7 @@
                 "TCPFlags": null,
                 "IsFragment": false,
                 "Action": "",
+                "TerminalActions": null,
                 "UnknownActions": null,
                 "RejectMessageType": "",
                 "NextTerm": false,
@@ -5937,6 +5954,9 @@
                 "TCPFlags": null,
                 "IsFragment": false,
                 "Action": "accept",
+                "TerminalActions": [
+                  "accept"
+                ],
                 "UnknownActions": null,
                 "RejectMessageType": "",
                 "NextTerm": false,
@@ -7133,6 +7153,7 @@
                 "TCPFlags": null,
                 "IsFragment": false,
                 "Action": "",
+                "TerminalActions": null,
                 "UnknownActions": null,
                 "RejectMessageType": "",
                 "NextTerm": false,
@@ -7167,6 +7188,9 @@
                 "TCPFlags": null,
                 "IsFragment": false,
                 "Action": "accept",
+                "TerminalActions": [
+                  "accept"
+                ],
                 "UnknownActions": null,
                 "RejectMessageType": "",
                 "NextTerm": false,

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -1220,6 +1220,22 @@ type FirewallFilterTerm struct {
 	TCPFlags         []string // TCP flags: "syn", "ack", "fin", "rst", "psh", "urg"
 	IsFragment       bool     // match IP fragments
 	Action           string   // "accept", "reject", "discard", ""
+	// TerminalActions records EVERY terminating action keyword
+	// (accept/reject/discard) compileFilterThen encountered across all of the
+	// term's `then` blocks, in order and including duplicates. Action itself is
+	// single-valued and last-write-wins, so a term with `then accept` AND `then
+	// reject` would silently resolve to whichever came last — the operator's
+	// intent was ambiguous and the compiled behavior did not necessarily match
+	// what they wrote (#4375, avo-review-007 H3). This slice is the
+	// mutual-exclusion channel: validateFilterTerminalConflictStrict hard-rejects
+	// any term whose distinct-terminal count exceeds one; the tolerant load /
+	// peer-sync path downgrades to a warning (#1960 no-brick) and the last-wins
+	// Action still drives the dataplane. Junos treats accept/reject/discard as
+	// mutually exclusive (a term has exactly one terminating action); the
+	// non-terminating modifiers (count/log/forwarding-class/loss-priority/dscp/
+	// traffic-class/policer/routing-instance) coexist with a terminal and are NOT
+	// recorded here.
+	TerminalActions []string
 	// UnknownActions records `then` tokens that are neither a recognized
 	// terminating action nor a recognized modifier (#2399 finding 032-16).
 	// An unknown or misspelled action would otherwise be silently dropped


### PR DESCRIPTION
## Summary

Closes #4375 (avo-review-007 H3).

A firewall-filter term specifying more than one **terminating** action —
`then accept` + `then reject` (or accept+discard, reject+discard) — was
silently accepted at commit. `compileFilterThen` writes the resolved action
onto the single-valued `FirewallFilterTerm.Action`, overwriting
**last-write-wins**, so a contradictory term compiled to whichever keyword
appeared last (in one `then {}` block or across two — #3850 applies every
block) and commit reported success. The operator's intent was ambiguous and
the compiled behavior did not necessarily match what they wrote. Junos treats
`accept`/`reject`/`discard` as mutually exclusive: a term has at most one
terminating action.

## Fix

- `compileFilterThen` records **every** terminating keyword on a new
  `FirewallFilterTerm.TerminalActions` slice (both the leaf and child AST
  shapes).
- New `validateFilterTerminalConflictStrict` (`compiler_validate_strict_filter.go`)
  hard-rejects any term whose **distinct**-terminal count exceeds one, naming
  the family / filter / term and the conflicting actions.
- Non-terminating modifiers (`count`/`log`/`forwarding-class`/`loss-priority`/
  `dscp`/`traffic-class`/`policer`/`routing-instance`) coexist with a terminal —
  `then count X accept` stays valid. Repeating the same terminal (two
  `then discard` blocks) is a redundancy, not a conflict.
- Strict on commit / commit-check; downgraded to a `cfg.Warnings` entry on the
  tolerant load / peer-sync paths (`lenientFilterTerminalConflict`) so an
  already-persisted or peer-synced config still boots (#1960 no-brick) — the
  last-wins `Action` drives the dataplane deterministically on that boot. Gate
  runs immediately after the #3308 routing-instance conflict gate.

## Validation

- `firewall_terminal_conflict_4375_test.go`: accept/reject, accept/discard,
  reject/discard, and inet6 conflict tests go **RED on revert** (silently
  accepted); count+log+accept, single-terminal, and duplicate-same-terminal
  tests confirm no over-reject; lenient path does not hard-fail.
- `go test ./pkg/config/...` green (regenerated the #4406 golden baseline — the
  sole diff is the new `TerminalActions` field, `null` or `["accept"]`).
- `go build ./...` + `go vet` + `gofmt` clean.
- Docs: `docs/config-schema.md` #4375 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
