### PR TITLE
policymatch: lock #3148 global-policy scope tier with a cross-language regression matrix

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -39157,3 +39157,31 @@ top.
   vet + gofmt clean. Doc: docs/sync-protocol.md #4090 re-drive section.
 - **File(s)**: pkg/cluster/sync.go, pkg/cluster/sync_conn.go,
   pkg/cluster/sync_test.go, docs/sync-protocol.md, _Log.md
+
+## 2026-07-07 — #4365 global-policy scope tier cross-language regression matrix (Go)
+- **Timestamp**: 2026-07-07
+- **Action**: Added a mirror-ready SSOT regression matrix locking the #3148
+  global-policy `match from-zone`/`match to-zone` scope tier (Tier 4,
+  `globalScopeMatches`) in the shared policymatch simulator. avo-review-001 F1
+  flagged that `TestSharedMatcherRegressionMatrix` had ZERO global-scope cases,
+  so a future change to the Go simulator OR the Rust dataplane
+  (`userspace-dp/src/policy.rs GlobalZoneScope::matches`) could silently diverge
+  — the simulator backs `show security match-policies` while the Rust path is
+  the only forwarding path. New sibling table-driven test
+  `TestSharedMatcherGlobalScopeRegressionMatrix` asserts the FULL verdict
+  contract (Matched/Global/Action/PolicyName, the #3331 from/to-zone SCOPE, and
+  the shared `RuntimePolicyIDs` PolicyID at the matched rule's [set,slice]
+  coordinate) across: (a) both-axis scope match permits; (a') global-set index
+  tracks len(Policies) with a provably nonzero ID behind a preceding zone-pair
+  set; (b/b') non-matching from-/to-zone scope falls to default; (b'')
+  undefined/typo'd scope fails CLOSED; (c) empty scope == any; (c') explicit
+  any/any preserved in scope; (c''/c''') partial from-zone-only scope; (d) exact
+  zone-pair (Tier 1) outranks a matching scoped global; (d') both-any wildcard
+  (Tier 3) outranks a matching global (the "precedence after both-any" lock).
+  Tests-only, no production change (no bug surfaced — the scope logic is
+  correct; this is a regression-safety-net gap). Mutation-verified load-bearing:
+  widening `globalScopeMatches` to always-match turns the non-matching-scope
+  cases RED. F2 (Rust mirror) and F3 (CLI ICMP query) are out of scope for this
+  Go-only pass. README updated with the new lock's description.
+- **File(s)**: pkg/policymatch/global_scope_regression_4365_test.go (new),
+  pkg/policymatch/README.md, _Log.md

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -438,3 +438,15 @@ The regression matrix from the issue is pinned in `policymatch_test.go`
 (`TestSharedMatcherRegressionMatrix`), and `TestOldNarrowMatcherDiverges` is
 the concrete fail-on-revert artifact proving the old per-surface logic returns
 the opposite verdict on the affected cases.
+
+The #3148 global-policy `match from-zone`/`match to-zone` scope tier (Tier 4)
+has its own cross-language SSOT lock in
+`global_scope_regression_4365_test.go` (`TestSharedMatcherGlobalScopeRegression`
+`Matrix`, #4365): a table of vectors that assert the full verdict contract
+(`Matched`/`Global`/`Action`/`PolicyName`, the #3331 from/to-zone SCOPE, and the
+`RuntimePolicyIDs` `PolicyID`) for a matching scope, a non-matching scope
+(from-, to-, and undefined/fail-closed), an empty/`any` scope spanning all
+zones, and tier precedence (a matching exact zone-pair and a matching both-any
+wildcard each outrank a matching scoped global). The Rust dataplane
+(`userspace-dp/src/policy.rs` `GlobalZoneScope::matches`) mirrors these vectors
+so the simulator and the wire cannot diverge on the scoped-global tier.

--- a/pkg/policymatch/global_scope_regression_4365_test.go
+++ b/pkg/policymatch/global_scope_regression_4365_test.go
@@ -1,0 +1,289 @@
+package policymatch
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// TestSharedMatcherGlobalScopeRegressionMatrix locks the #3148 global-policy
+// from-zone/to-zone match-scope tier (Tier 4, `globalScopeMatches`) as a
+// cross-language SSOT regression matrix (#4365). The Rust dataplane
+// (userspace-dp/src/policy.rs `GlobalZoneScope::matches`) is the only forwarding
+// path and the Go simulator here backs `show security match-policies`; the two
+// MUST agree or the operator's test output permits/denies differently than the
+// wire. These vectors are the Go half of that lock — the Rust side mirrors them
+// in `global_policy_zone_scope_tier_ordering` (F2). Each case asserts the FULL
+// verdict contract the runtime stamps: Matched, Global, Action, PolicyName, the
+// #3331 FromZone/ToZone SCOPE (empty == "any" for a global), and the stable
+// PolicyID drawn from the shared RuntimePolicyIDs namespace — a global policy's
+// runtime set is the one that immediately follows the last zone-pair set
+// (policySetID == len(cfg.Security.Policies)).
+//
+// The behaviors pinned are exactly the #4365 gap: (a) a scoped global matches
+// only when BOTH the from-zone and to-zone scope match; (b) a non-matching
+// scope falls through to the configured default; (c) an empty/`any` scope
+// applies to every zone; (d) tier precedence — a matching zone-pair policy AND a
+// matching both-any wildcard each OUTRANK a matching scoped global (Tier 1 and
+// Tier 3 before Tier 4), so `Global` is false and the scoped global never fires.
+func TestSharedMatcherGlobalScopeRegressionMatrix(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *config.Config
+		q           Query
+		wantMatched bool
+		wantGlobal  bool
+		wantDefault bool
+		wantAction  config.PolicyAction
+		wantName    string // "" => default (no policy matched)
+		wantFrom    string // expected Result.FromZone scope (only checked when matched)
+		wantTo      string // expected Result.ToZone scope (only checked when matched)
+		// idSet/idSlice are the [policySetID, sliceIndex] RuntimePolicyIDs
+		// coordinate of the matched rule. For a global match idSet is IGNORED and
+		// the runtime set index is derived as len(cfg.Security.Policies); for a
+		// zone-pair match idSet is the zone-pair set index. Unused when not matched.
+		idSet   int
+		idSlice int
+	}{
+		{
+			// (a) BOTH from-zone and to-zone scope match -> the scoped global
+			// fires. Result carries Global=true and the scope as FromZone/ToZone.
+			name: "scoped global matches when both from and to scope match",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyDeny,
+				GlobalPolicies: []*config.Policy{
+					permit("g-scoped", config.PolicyMatch{FromZone: "trust", ToZone: "untrust"}),
+				},
+			}, config.ApplicationsConfig{}),
+			q:           Query{FromZone: "trust", ToZone: "untrust"},
+			wantMatched: true, wantGlobal: true, wantAction: config.PolicyPermit,
+			wantName: "g-scoped", wantFrom: "trust", wantTo: "untrust",
+			idSlice: 0, // global set (len(Policies)==0), first global rule
+		},
+		{
+			// (a') Same scoped global, but a preceding UNRELATED zone-pair set
+			// exists so the global's runtime set index is len(Policies)==1 and its
+			// PolicyID is provably nonzero — this locks that the global-set index
+			// tracks len(cfg.Security.Policies), not a fixed 0.
+			name: "scoped global runtime id tracks len(policies)",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyDeny,
+				Policies: []*config.ZonePairPolicies{
+					// Never matches a trust->untrust query; only shifts indices.
+					zonePair("dmz", "wan", permit("unrelated", config.PolicyMatch{})),
+				},
+				GlobalPolicies: []*config.Policy{
+					permit("g-scoped", config.PolicyMatch{FromZone: "trust", ToZone: "untrust"}),
+				},
+			}, config.ApplicationsConfig{}),
+			q:           Query{FromZone: "trust", ToZone: "untrust"},
+			wantMatched: true, wantGlobal: true, wantAction: config.PolicyPermit,
+			wantName: "g-scoped", wantFrom: "trust", wantTo: "untrust",
+			idSlice: 0, // global set == len(Policies)==1
+		},
+		{
+			// (b) from-zone scope does NOT match (scope trust, flow dmz) -> the
+			// global is skipped and the verdict is the configured default.
+			name: "scoped global from-zone mismatch falls through to default",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyPermit,
+				GlobalPolicies: []*config.Policy{
+					deny("g-trust-only", config.PolicyMatch{FromZone: "trust"}),
+				},
+			}, config.ApplicationsConfig{}),
+			q:           Query{FromZone: "dmz", ToZone: "untrust"},
+			wantMatched: false, wantDefault: true, wantAction: config.PolicyPermit,
+		},
+		{
+			// (b') to-zone scope does NOT match (scope untrust, flow dmz) -> default.
+			name: "scoped global to-zone mismatch falls through to default",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyPermit,
+				GlobalPolicies: []*config.Policy{
+					deny("g-to-untrust", config.PolicyMatch{ToZone: "untrust"}),
+				},
+			}, config.ApplicationsConfig{}),
+			q:           Query{FromZone: "trust", ToZone: "dmz"},
+			wantMatched: false, wantDefault: true, wantAction: config.PolicyPermit,
+		},
+		{
+			// (b'') An undefined/typo'd scope fails CLOSED — it matches nothing and
+			// never silently widens to all-zones, so the verdict is the default.
+			name: "undefined global scope fails closed to default",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyPermit,
+				GlobalPolicies: []*config.Policy{
+					deny("g-typo", config.PolicyMatch{FromZone: "trsut"}), // typo
+				},
+			}, config.ApplicationsConfig{}),
+			q:           Query{FromZone: "trust", ToZone: "untrust"},
+			wantMatched: false, wantDefault: true, wantAction: config.PolicyPermit,
+		},
+		{
+			// (c) An empty (unset) scope applies to EVERY zone. FromZone/ToZone in
+			// the Result stay "" (callers render "" as "any" for a global).
+			name: "empty scope global applies to any zone pair",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyPermit,
+				GlobalPolicies: []*config.Policy{
+					deny("g-any", config.PolicyMatch{}),
+				},
+			}, config.ApplicationsConfig{}),
+			q:           Query{FromZone: "dmz", ToZone: "wan"},
+			wantMatched: true, wantGlobal: true, wantAction: config.PolicyDeny,
+			wantName: "g-any", wantFrom: "", wantTo: "",
+			idSlice: 0,
+		},
+		{
+			// (c') An explicit `any`/`any` scope ALSO applies everywhere, and the
+			// literal "any" is preserved in the reported scope (distinct from the
+			// empty-string case above).
+			name: "explicit any scope global applies and preserves any in scope",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyPermit,
+				GlobalPolicies: []*config.Policy{
+					deny("g-anyany", config.PolicyMatch{FromZone: "any", ToZone: "any"}),
+				},
+			}, config.ApplicationsConfig{}),
+			q:           Query{FromZone: "dmz", ToZone: "wan"},
+			wantMatched: true, wantGlobal: true, wantAction: config.PolicyDeny,
+			wantName: "g-anyany", wantFrom: "any", wantTo: "any",
+			idSlice: 0,
+		},
+		{
+			// (c'') Partial scope: from-zone constrained, to-zone empty (== any).
+			// A matching from-zone with ANY to-zone fires.
+			name: "partial scope from-zone-only matches any to-zone",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyDeny,
+				GlobalPolicies: []*config.Policy{
+					permit("g-from-trust", config.PolicyMatch{FromZone: "trust"}),
+				},
+			}, config.ApplicationsConfig{}),
+			q:           Query{FromZone: "trust", ToZone: "wan"},
+			wantMatched: true, wantGlobal: true, wantAction: config.PolicyPermit,
+			wantName: "g-from-trust", wantFrom: "trust", wantTo: "",
+			idSlice: 0,
+		},
+		{
+			// (c''') Same partial-scope global, non-matching from-zone -> default.
+			name: "partial scope from-zone-only rejects non-matching from-zone",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyDeny,
+				GlobalPolicies: []*config.Policy{
+					permit("g-from-trust", config.PolicyMatch{FromZone: "trust"}),
+				},
+			}, config.ApplicationsConfig{}),
+			q:           Query{FromZone: "dmz", ToZone: "wan"},
+			wantMatched: false, wantDefault: true, wantAction: config.PolicyDeny,
+		},
+		{
+			// (d) TIER PRECEDENCE: a matching exact zone-pair policy (Tier 1)
+			// OUTRANKS a scoped global (Tier 4) that ALSO matches the same tuple.
+			// The zone-pair permit wins; Global is false and the global-deny never
+			// fires. Result scope is the zone-pair stanza, PolicyID the zone-pair
+			// set coordinate [0,0].
+			name: "exact zone-pair outranks matching scoped global",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyDeny,
+				Policies: []*config.ZonePairPolicies{
+					zonePair("trust", "untrust", permit("zp-allow", config.PolicyMatch{})),
+				},
+				GlobalPolicies: []*config.Policy{
+					deny("g-scoped-deny", config.PolicyMatch{FromZone: "trust", ToZone: "untrust"}),
+				},
+			}, config.ApplicationsConfig{}),
+			q:           Query{FromZone: "trust", ToZone: "untrust"},
+			wantMatched: true, wantGlobal: false, wantAction: config.PolicyPermit,
+			wantName: "zp-allow", wantFrom: "trust", wantTo: "untrust",
+			idSet: 0, idSlice: 0,
+		},
+		{
+			// (d') TIER PRECEDENCE after the both-any wildcard: a matching both-any
+			// (`from-zone any to-zone any`) zone-pair rule (Tier 3) OUTRANKS a
+			// matching unscoped global (Tier 4). The both-any deny wins; the global
+			// permit never fires. This is the "tier precedence after both-any
+			// wildcard" lock (#4365) — the global tier is consulted ONLY after the
+			// both-any wildcard tier.
+			name: "both-any wildcard outranks matching global",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyPermit,
+				Policies: []*config.ZonePairPolicies{
+					zonePair("any", "any", deny("wild-deny", config.PolicyMatch{})),
+				},
+				GlobalPolicies: []*config.Policy{
+					permit("g-allow", config.PolicyMatch{}),
+				},
+			}, config.ApplicationsConfig{}),
+			q:           Query{FromZone: "trust", ToZone: "untrust"},
+			wantMatched: true, wantGlobal: false, wantAction: config.PolicyDeny,
+			wantName: "wild-deny", wantFrom: "any", wantTo: "any",
+			idSet: 0, idSlice: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := Match(tt.cfg, tt.q)
+			if res.Matched != tt.wantMatched {
+				t.Fatalf("Matched = %v, want %v (res=%+v)", res.Matched, tt.wantMatched, res)
+			}
+			if res.DefaultUsed != tt.wantDefault {
+				t.Fatalf("DefaultUsed = %v, want %v (res=%+v)", res.DefaultUsed, tt.wantDefault, res)
+			}
+			if res.Action != tt.wantAction {
+				t.Fatalf("Action = %v, want %v (res=%+v)", res.Action, tt.wantAction, res)
+			}
+			if res.Global != tt.wantGlobal {
+				t.Fatalf("Global = %v, want %v (res=%+v)", res.Global, tt.wantGlobal, res)
+			}
+			if !tt.wantMatched {
+				// A default verdict must not leak a policy identity or scope.
+				if res.PolicyName != "" {
+					t.Fatalf("default verdict leaked PolicyName %q", res.PolicyName)
+				}
+				return
+			}
+			if res.PolicyName != tt.wantName {
+				t.Fatalf("PolicyName = %q, want %q", res.PolicyName, tt.wantName)
+			}
+			if res.FromZone != tt.wantFrom || res.ToZone != tt.wantTo {
+				t.Fatalf("scope = %q->%q, want %q->%q", res.FromZone, res.ToZone, tt.wantFrom, tt.wantTo)
+			}
+			// Lock the PolicyID against the shared RuntimePolicyIDs SSOT at the
+			// matched rule's coordinate — the exact key the dataplane write side
+			// and `show policies` Index column use, so a Go/Rust divergence in the
+			// global-set index (len(Policies)) or slice ordering is caught here.
+			ids := dpuserspace.RuntimePolicyIDs(tt.cfg)
+			setIdx := tt.idSet
+			if tt.wantGlobal {
+				setIdx = len(tt.cfg.Security.Policies)
+			}
+			wantID := ids[[2]uint32{uint32(setIdx), uint32(tt.idSlice)}]
+			if res.PolicyID != wantID {
+				t.Fatalf("PolicyID = %d, want %d (SSOT coord [%d,%d])", res.PolicyID, wantID, setIdx, tt.idSlice)
+			}
+		})
+	}
+
+	// Reinforce the a' vector's intent: with a preceding zone-pair set the scoped
+	// global's runtime PolicyID is provably NONZERO, proving the global-set index
+	// is derived from len(Policies) rather than a hard-coded 0.
+	t.Run("global runtime id is nonzero after a preceding zone-pair set", func(t *testing.T) {
+		cfg := cfgWith(config.SecurityConfig{
+			DefaultPolicy: config.PolicyDeny,
+			Policies: []*config.ZonePairPolicies{
+				zonePair("dmz", "wan", permit("unrelated", config.PolicyMatch{})),
+			},
+			GlobalPolicies: []*config.Policy{
+				permit("g-scoped", config.PolicyMatch{FromZone: "trust", ToZone: "untrust"}),
+			},
+		}, config.ApplicationsConfig{})
+		res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust"})
+		if !res.Matched || !res.Global || res.PolicyID == 0 {
+			t.Fatalf("expected nonzero-ID global match, got Matched=%v Global=%v PolicyID=%d",
+				res.Matched, res.Global, res.PolicyID)
+		}
+	})
+}


### PR DESCRIPTION
## What

Closes #4365.

The #3148 global-policy `match from-zone`/`match to-zone` scope tier (Tier 4, `globalScopeMatches`) is a security-relevant catch-all evaluated before the configured default-policy. It is implemented in both the Go simulator (backs `show security match-policies`) and the Rust dataplane (`userspace-dp/src/policy.rs GlobalZoneScope::matches`, the only forwarding path), but `TestSharedMatcherRegressionMatrix` had ZERO global-scope cases (avo-review-001 F1). Without a vector table pinning the tier, a future change to either implementation could silently diverge and permit/deny differently than the operator's test output.

## Change (tests only)

Adds `TestSharedMatcherGlobalScopeRegressionMatrix` (`pkg/policymatch/global_scope_regression_4365_test.go`) — a mirror-ready SSOT table asserting the full verdict contract the runtime stamps: `Matched`/`Global`/`Action`/`PolicyName`, the #3331 from/to-zone SCOPE (empty == "any" for a global), and the stable `PolicyID` drawn from the shared `RuntimePolicyIDs` namespace at the matched rule's `[set, slice]` coordinate.

Behaviors locked (the exact #4365 gap):
- (a) both-axis scope match permits; global-set index tracks `len(cfg.Security.Policies)` with a provably nonzero PolicyID behind a preceding zone-pair set;
- (b) a non-matching from-zone or to-zone scope falls through to the configured default; an undefined/typo'd scope fails **closed** (never silently widening to all-zones);
- (c) an empty scope spans every zone; an explicit `any`/`any` scope is preserved verbatim in the reported scope; a partial from-zone-only scope matches any to-zone;
- (d) **tier precedence** — a matching exact zone-pair policy (Tier 1) AND a matching both-any wildcard (Tier 3) each OUTRANK a matching scoped global (Tier 4); the "precedence after the both-any wildcard" lock.

No production change. The scope logic is correct — this is the regression-safety-net the review flagged, and the Go half of the cross-language lock the Rust `global_policy_zone_scope_tier_ordering` mirror (F2, out of scope for this Go-only pass) pairs with. F3 (CLI ICMP type/code query) is also out of scope here.

## Validation
- New matrix is **mutation-verified load-bearing**: widening `globalScopeMatches` to always-match turns the non-matching-scope cases RED.
- `go test ./pkg/policymatch/...` green; `go build ./...`, `gofmt`, `go vet` clean.
- README (`pkg/policymatch/README.md`) updated with the new lock's description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi