### PR TITLE
docs(multi-wan): document flow-based FBF/PBR steering (#4412 E3)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,29 @@
+## 2026-07-07 — #4412 (avo-review-007 backlog E3): document flow-based FBF/PBR
+
+- **Timestamp**: 2026-07-07
+- **Action**: Drove the avo-review-007 dropped-findings backlog (#4412).
+  Verified each of E2/E3/E5/E7/H1/H4/H6 against origin/master. Only E3
+  needed a change: it is a verified-CORRECT documentation gap — the FBF
+  (`then routing-instance`) steer is decided on the first packet of a
+  flow and cached in the session (`ingress_route_table_override` runs on
+  the session miss; `resolve_flow_session_decision` returns the cached
+  egress/VRF on every hit without re-running the filter, per
+  `userspace-dp/src/afxdp/forwarding/README.md:226-233`). Editing the
+  FBF filter therefore does NOT re-steer live flows, a firewall-filter
+  commit does not clear sessions (only `policy-rematch` re-evaluates
+  security POLICIES), and per-packet-L4 FBF terms (tcp-flags /
+  is-fragment / icmp-*) are the cache-sensitive exception. This was only
+  in the dataplane dev README; added an operator-facing note to the FBF
+  section of `docs/multi-wan.md`.
+  Dispositions of the rest (recorded on #4412): E5 ALREADY-FIXED
+  (`TestMatchPoliciesGRPCHostInboundOffHostOmitted` +
+  `TestMatchPoliciesDefaultUsedTyped`); E2/E7/H1/H4/H6 are userspace-dp
+  Rust dataplane test-coverage items (afxdp/filter cargo suites) — filed
+  as follow-ups (cargo lane busy, not run here).
+- **File(s)**: docs/multi-wan.md, _Log.md
+- **Validation**: docs-only change; `go build ./...` + `go vet` green
+  (no Go source touched); gofmt clean.
+
 ## 2026-07-07 — #4482 (opus-172 M-5): FRR set-clause/prefix-list sanitize-belt bypass
 
 - **Timestamp**: 2026-07-07

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -378,6 +378,43 @@ counted on the PBR fast path and exported as
 `xpf_filter_hits_total{filter,family,term}` — the steering-volume
 counter per FBF policy.
 
+### FBF is flow-based — the steer is decided once, on the first packet
+
+The FBF (`then routing-instance`) decision is made on the **first
+packet of a flow** (the session miss), when the ingress filter runs and
+`ingress_route_table_override` selects the routing-instance. That
+egress/VRF resolution is cached in the session; every subsequent packet
+of the same flow takes the established fast path
+(`resolve_flow_session_decision`), which returns the cached decision
+**without re-running the filter**. Consequences the operator should
+expect:
+
+- **Editing the FBF filter (or the steered instance's routes) does NOT
+  retroactively re-steer live flows.** An established session keeps the
+  routing-instance it was assigned at flow start until it ages out at
+  the inactivity timeout or is cleared. Only NEW flows pick up the new
+  steering. This is deliberate flow-based behavior, identical in
+  substance to the ip-monitoring case in *Session behavior on uplink
+  transition* below — SRX behaves the same way.
+- **A firewall-filter commit does not clear sessions.** `policy-rematch`
+  re-evaluates security POLICIES, not FBF filters, so there is no
+  session invalidation on a filter change. `clear security flow
+  session` (e.g. `... zone <ingress>` or a NAT-pool / 5-tuple filter)
+  is THE mechanism to force live flows onto a changed FBF steer.
+- **Exception — per-packet-L4 FBF terms are cache-sensitive.** A steer
+  whose `from` carries `tcp-flags` / `is-fragment` / `icmp-type` /
+  `icmp-code` declines the flow cache and is re-evaluated per packet
+  (`docs/feature-gaps.md`, path (b) of the #1431 runbook); a config
+  rotation purges those affected sessions, so they DO pick up a changed
+  steer. A steer matching only on the 5-tuple / DSCP is the cached case
+  above.
+- **After HA failover the FBF decision is preserved.** A peer-synced
+  session carries the primary's FBF-derived egress, so the new primary
+  keeps steering the flow to the same routing-instance (the synced
+  session resolves lookup-first but inherits the stored PBR-derived
+  egress zone from the primary). New flows on the new primary use its
+  own FBF config.
+
 ### Two-upstream lab (test/incus)
 
 `test/incus/fbf-two-upstream-config.set` layers the recipe above onto


### PR DESCRIPTION
## Summary

Drives the avo-review-007 dropped-findings backlog (#4412: E2/E3/E5/E7/H1/H4/H6).
avo-review-007 is a historically low-signal source, so each item was
weight-verified against `origin/master`. Only **E3** required a change — a
verified-CORRECT documentation gap. The rest are already-fixed or Rust
test-coverage follow-ups (dispositions below).

## E3 (fixed here) — flow-based FBF/PBR is undocumented for operators

The FBF (`then routing-instance`) steer is decided on the **first packet** of a
flow and cached in the session: `ingress_route_table_override` runs on the
session miss, and every subsequent packet takes the established fast path
(`resolve_flow_session_decision`), which returns the cached egress/VRF **without
re-running the filter** (`userspace-dp/src/afxdp/forwarding/README.md:226-233`).
So editing the FBF filter does NOT re-steer live flows. This was only in the
dataplane dev README — added an operator-facing note to the FBF section of
`docs/multi-wan.md` covering:

- Filter edits do not re-steer established flows (only new flows); matches SRX
  and the existing ip-monitoring "Session behavior on uplink transition" note.
- A firewall-filter commit does not clear sessions (`policy-rematch` is
  security-POLICIES-only); `clear security flow session` forces re-steering.
- Exception: per-packet-L4 FBF terms (tcp-flags / is-fragment / icmp-*) are
  cache-sensitive and re-evaluated per packet (config rotation purges them).
- HA failover preserves the FBF decision via the synced session.

Docs-only. `go build ./...` + `go vet` green, gofmt clean.

## Per-item disposition (all 7 tracked — no-dismissal)

| Item | Disposition | Evidence |
|------|-------------|----------|
| E2 | NEEDS-RUST → #4499 | reject path installs no session; test belongs in `afxdp/tests.rs` |
| **E3** | **FIXED here** | `docs/multi-wan.md` FBF section |
| E5 | ALREADY-FIXED | `TestMatchPoliciesGRPCHostInboundOffHostOmitted` (transit `host_inbound` nil on match + default) + `TestMatchPoliciesDefaultUsedTyped` (default_used typed bit). The finding's "PolicyId=0xFFFFFFFF for default" sub-claim is a misread — `server_cluster.go:304` deliberately leaves `PolicyId` ABSENT on the unmatched/default path (proto3 presence), it is not the sentinel. |
| E7 | NEEDS-RUST → #4499 | PBR + NAT64 interaction test in `afxdp/tests.rs` |
| H1 | NEEDS-RUST → #4499 | output filter on PBR egress test in `afxdp/tests.rs` |
| H4 | NEEDS-RUST → #4499 | output-filter re-eval on HA failover (integration); session sync carries no output-filter state — correct, but the runtime assertion is Rust/integration |
| H6 | NEEDS-RUST → #4499 | IPv6 ext-header + PBR fail-closed test in `filter/tests.rs` + `afxdp/tests.rs` |

Rust test-coverage items (E2/E7/H1/H4/H6) are tracked in #4499 (cargo lane —
not run in this Go-only pass).

Closes #4412

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi