### PR TITLE
test: lock host-inbound protocols-all + policymatch empty-zone (#4411)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,43 @@
+## 2026-07-07 — #4411 (avo-review-002 A4/A6): host-inbound + policymatch test-coverage locks
+
+- **Timestamp**: 2026-07-07
+- **Action**: Closed the two GO-testable test-coverage gaps from #4411
+  (avo-review-002 dropped findings A2/A4/A5/A6). Verified each vs
+  origin/master first.
+  - A4 (Go, ADDED): `host-inbound-traffic protocols all` + `system-services
+    ssh` boundary was untested at the `ClassifyHostInbound` classifier.
+    `protocols all` is deliberately NOT a full admit (#3199) — it expands to the
+    routing-protocol set, not arbitrary L4 ports. New test asserts ssh (tcp/22)
+    admits via system-services, bgp (tcp/179) admits via `protocols all`
+    (token "all"/protocols), and tcp/9999 is DENIED — the negative boundary that
+    `protocols all` does not over-admit. Mutation-verified: making
+    `HostInboundProtocolMatch("all")` a catch-all TCP match reddens the denied
+    row. Existing host_inbound_classify_3627_test.go covered ssh+ping+bgp and
+    `system-services all` full-admit, but never paired `protocols all` with a
+    service.
+  - A6 (Go, ADDED): a `test security match-policies` query that OMITS a
+    from-zone/to-zone selector passes an EMPTY-STRING zone to
+    policymatch.Match; it must fall through the `!zoneKnown` guard to the
+    configured default-policy, never be read as wildcard-any and match a
+    `from-zone any to-zone any` rule. New table-driven test (both empty / from
+    empty / to empty + a defined-pair positive control) locks it. Mutation-
+    verified: making zoneKnown treat "" as known routes the empty-zone cases into
+    the Tier 3 both-any permit -> RED. undefined_zone_3355_test.go covered
+    non-empty undefined zones and the empty-Zones config but not the empty-string
+    selector class.
+  - A2 (Rust follow-up, NOT done here): asserting the `then reject` ICMP output
+    bytes (type 3 code 13 / ICMPv6 type 1 code 1, TCP RST) is a userspace-dp
+    behavior (afxdp/icmp.rs build_reject_icmp_unreachable); its existing tests
+    assert is_some/is_none, not the emitted type/code. Needs a cargo test.
+  - A5 (Rust follow-up, NOT done here): NAT64 port preservation feeding the
+    app-catalog lookup is a pure userspace-dp integration (nat64.rs translation
+    + AppCatalog::lookup); no Go seam. Needs a cargo test.
+  Tests-only, no production change (no bug surfaced — regression-safety-net
+  gaps). go test green on pkg/policymatch, pkg/dataplane/userspace, pkg/config;
+  go build ./... clean; gofmt/vet clean.
+- **File(s)**: pkg/dataplane/userspace/host_inbound_protocols_all_4411_test.go
+  (new), pkg/policymatch/empty_zone_4411_test.go (new), _Log.md
+
 ## 2026-07-07 — #4482 (opus-172 M-5): FRR set-clause/prefix-list sanitize-belt bypass
 
 - **Timestamp**: 2026-07-07

--- a/pkg/dataplane/userspace/host_inbound_protocols_all_4411_test.go
+++ b/pkg/dataplane/userspace/host_inbound_protocols_all_4411_test.go
@@ -1,0 +1,48 @@
+package userspace
+
+import "testing"
+
+// TestClassifyHostInboundProtocolsAllNotFullAdmit locks #4411 A4
+// (avo-review-002): a zone carrying BOTH `host-inbound-traffic protocols all`
+// AND `system-services ssh`. `protocols all` is deliberately NOT a full admit
+// (#3199) — it expands to the routing-protocol set via HostInboundProtocolMatch,
+// NOT arbitrary L4 ports (unlike `system-services all` / `any-service`, which
+// HostInboundFullAdmitService opens wholesale). The boundary this pins:
+//
+//   - ssh (tcp/22) IS admitted, via the system-services token (admitted, not
+//     denied — the "ssh should be admitted-not-denied" property);
+//   - a routing protocol in the `all` expansion (bgp tcp/179) IS admitted, via
+//     the protocols token (positive control that `all` genuinely expands);
+//   - an arbitrary non-routing, non-ssh port (tcp/9999) is DENIED — the NEGATIVE
+//     boundary proving `protocols all` does not over-admit.
+//
+// host_inbound_classify_3627_test.go covers ssh+ping+bgp and the
+// `system-services all` full-admit, but no case pairs `protocols all` with a
+// service to assert this non-over-admit boundary.
+//
+// FAIL-ON-REVERT: turning `protocols all` into a full admit (e.g. teaching
+// HostInboundFullAdmitService to accept "all" as a protocol, or expanding
+// HostInboundProtocolMatch("all") to a catch-all) admits tcp/9999, reddening
+// the denied row.
+func TestClassifyHostInboundProtocolsAllNotFullAdmit(t *testing.T) {
+	const TCP = uint8(6)
+	// system-services ssh + protocols all.
+	cfg := cfgWithHostInbound("edge", []string{"ssh"}, []string{"all"})
+
+	// ssh admitted via system-services (not swallowed by `protocols all`).
+	if got := ClassifyHostInbound(cfg, "edge", TCP, true, 22, nil, "ip"); got.Status != HostInboundTokenAdmit || got.Token != "ssh" || got.Kind != "system-services" {
+		t.Fatalf("ssh tcp/22: got %+v, want token-admit ssh/system-services", got)
+	}
+
+	// bgp (tcp/179) admitted via `protocols all` -> token "all", kind protocols.
+	if got := ClassifyHostInbound(cfg, "edge", TCP, true, 179, nil, "ip"); got.Status != HostInboundTokenAdmit || got.Token != "all" || got.Kind != "protocols" {
+		t.Fatalf("bgp tcp/179 via protocols all: got %+v, want token-admit all/protocols", got)
+	}
+
+	// tcp/9999 is neither ssh nor a routing protocol in the `all` expansion, so
+	// it is DENIED. This is the boundary: `protocols all` must not open arbitrary
+	// ports the way a full-admit system-service would.
+	if got := ClassifyHostInbound(cfg, "edge", TCP, true, 9999, nil, "ip"); got.Status != HostInboundDenied {
+		t.Fatalf("tcp/9999 with protocols all + ssh: got %+v, want denied (protocols all is not a full admit)", got)
+	}
+}

--- a/pkg/policymatch/empty_zone_4411_test.go
+++ b/pkg/policymatch/empty_zone_4411_test.go
@@ -1,0 +1,77 @@
+package policymatch
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestMatchEmptyZoneFallsToDefault locks #4411 A6 (avo-review-002): a
+// `test security match-policies` query that OMITS the from-zone or to-zone
+// selector passes an EMPTY-STRING zone name to Match. An empty string is not a
+// configured zone, so zoneKnown reports false and the query must fall straight
+// through to the configured default-policy — the simulator analogue of
+// policy.rs's `from_id != 0 && to_id != 0` transit guard resolving an unknown
+// (id 0) zone. The danger this locks against is an empty selector being
+// (mis)read as a wildcard-any and MATCHING a `from-zone any to-zone any` rule,
+// which would report a PERMIT the dataplane never grants.
+//
+// undefined_zone_3355_test.go already covers NON-EMPTY undefined zones
+// ("bogus"/"nowhere") and the empty-Zones config; this pins the distinct
+// EMPTY-STRING selector input class (an omitted zone), which no test exercised.
+//
+// FAIL-ON-REVERT: dropping the `!zoneKnown(...)` guard in Match (or making
+// zoneKnown treat "" as known/any) routes every empty-zone case into the Tier 3
+// both-any permit -> Matched=true permit, reddening the want-default-deny rows.
+func TestMatchEmptyZoneFallsToDefault(t *testing.T) {
+	permitAny := &config.Policy{
+		Name:   "wide-open",
+		Action: config.PolicyPermit,
+		Match: config.PolicyMatch{
+			SourceAddresses:      []string{"any"},
+			DestinationAddresses: []string{"any"},
+			Applications:         []string{"any"},
+		},
+	}
+	// A `from-zone any to-zone any` (Tier 3 both-any) permit is the trap: it
+	// matches EVERY concrete zone pair, so an empty-zone query would match it too
+	// if the guard were removed. DefaultPolicy is deny, so the guarded verdict is
+	// distinguishable from the (wrong) permit.
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			DefaultPolicy: config.PolicyDeny,
+			Zones:         zones("trust", "untrust"),
+			Policies: []*config.ZonePairPolicies{
+				{FromZone: "any", ToZone: "any", Policies: []*config.Policy{permitAny}},
+			},
+		},
+		Applications: config.ApplicationsConfig{},
+	}
+
+	cases := []struct {
+		name     string
+		from, to string
+	}{
+		{"both zones empty", "", ""},
+		{"from-zone empty", "", "untrust"},
+		{"to-zone empty", "trust", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res := Match(cfg, Query{FromZone: c.from, ToZone: c.to, Protocol: "tcp", DstPort: 80})
+			if res.Matched {
+				t.Fatalf("empty-zone query matched a both-any rule (#4411 A6); res = %+v", res)
+			}
+			if !res.DefaultUsed || res.Action != config.PolicyDeny {
+				t.Fatalf("want default-policy deny for an empty-zone query, got %+v", res)
+			}
+		})
+	}
+
+	// Positive control: a fully-defined zone pair still matches the both-any
+	// permit, so the guard rejects ONLY the empty-selector class, not real zones.
+	res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 80})
+	if !res.Matched || res.Action != config.PolicyPermit {
+		t.Fatalf("defined zone pair over-blocked by the empty-zone guard; res = %+v", res)
+	}
+}


### PR DESCRIPTION
Closes #4411.

Drives the two GO-testable test-coverage gaps from #4411 (avo-review-002 dropped findings A2/A4/A5/A6). Each behavior was verified correct against current `origin/master` first — these are regression-safety-net additions, not bug fixes. No production change.

## A4 (Go, added) — host-inbound `protocols all` + `system-services ssh` boundary
`protocols all` is deliberately **not** a full admit (#3199): `HostInboundProtocolMatch("all")` expands to the routing-protocol set (OSPF/BGP/RIP/…), not arbitrary L4 ports the way `system-services all` / `any-service` do. No existing test paired `protocols all` with a service to assert the non-over-admit boundary.

`pkg/dataplane/userspace/host_inbound_protocols_all_4411_test.go` (`ClassifyHostInbound`) asserts:
- ssh (tcp/22) is **admitted** via `system-services` (not swallowed by `protocols all`);
- bgp (tcp/179) is **admitted** via the `all` expansion (token `all`/protocols — positive control that `all` expands);
- tcp/9999 is **DENIED** — the negative boundary.

Mutation-verified: expanding `HostInboundProtocolMatch("all")` to a catch-all TCP match reddens the denied row.

## A6 (Go, added) — policymatch empty-string zone falls to default-policy
A `test security match-policies` query that omits a from-zone/to-zone selector passes an empty string to `policymatch.Match`. The `!zoneKnown` guard (the simulator mirror of `policy.rs`'s `from_id != 0 && to_id != 0` transit gate) must route it to the configured default-policy rather than let it read as wildcard-any and match a `from-zone any to-zone any` rule (a permit the dataplane never grants). `undefined_zone_3355_test.go` covered non-empty undefined zones and the empty-Zones config, but not the empty-string selector class.

`pkg/policymatch/empty_zone_4411_test.go` is table-driven (both empty / from empty / to empty, plus a defined-pair positive control). Mutation-verified: making `zoneKnown` treat `""` as known routes the empty-zone cases into the Tier 3 both-any permit → RED.

## A2 / A5 — Rust follow-ups (not in this PR)
- **A2**: asserting the `then reject` ICMP output bytes (type 3 code 13 / ICMPv6 type 1 code 1, TCP RST) is a `userspace-dp` behavior (`afxdp/icmp.rs build_reject_icmp_unreachable`); its existing tests assert `is_some`/`is_none`, not the emitted type/code. Needs a cargo test.
- **A5**: NAT64 port preservation feeding the app-catalog lookup is a pure `userspace-dp` integration (`nat64.rs` translation + `AppCatalog::lookup`); no Go seam. Needs a cargo test.

Both are recorded as follow-ups rather than forced into a Go pass (cargo lane not run here).

## Validation
- `go test ./pkg/policymatch/ ./pkg/dataplane/userspace/ ./pkg/config/` — green
- `go build ./...` — clean
- gofmt / go vet — clean
- Both new tests mutation-verified load-bearing (revert behavior → RED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi