### PR TITLE
config/policymatch: ICMP-constraint reject hint + wildcard config-order test (Closes #4410)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,48 @@
+## 2026-07-07 — #4410 (avo-review-001 F4/F8): app protocol-less ICMP reject hint + wildcard config-order test
+
+- **Timestamp**: 2026-07-07
+- **Action**: Drove the four dropped avo-review-001 findings (F4/F5/F7/F8) to
+  terminal, verifying each against origin/master first (the review source is
+  historically ~98% low-signal, so each was weight-verified hard).
+  - **F4 (Low, GENUINE — fixed)**: a protocol-less `applications application`
+    that carries an `icmp-type` / `icmp-code` constraint is rejected by the
+    #3109 "no protocol specified" gate (`validateApplicationSpecsStrict`,
+    compiler_validate_strict_application.go), but the message did NOT name the
+    icmp-type the operator had already set — it just said "set a protocol".
+    Added an `icmpConstraintDesc` helper and appended a targeted hint naming
+    the concrete `icmp-type N [icmp-code M]` and pointing at `protocol icmp` /
+    `icmpv6`. Non-ICMP protocol-less apps get the byte-identical message
+    (empty hint). RED-on-revert test
+    `TestApplicationProtocolLessICMPType_RejectNamesConstraint` (the bare
+    message never contains "icmp-type 8").
+  - **F5 (Low, ALREADY-FIXED by #3363)**: the implicit default-policy hit
+    counter IS emitted as a Prometheus `xpf_policy_hits_total` series labeled
+    `-`/`-`/`default-policy` (metrics_counters.go collectPolicyCounters, read
+    via `dp.ReadPolicyCounters(dataplane.DefaultPolicySentinelID)`). No change.
+  - **F7 (Low, NOT-MATERIAL)**: `pkg/policymatch.normalizePortAlias` is
+    case-sensitive, but `resolveAppPort` (compiler_applications.go) canonicalizes
+    EVERY named port alias to its numeric value at compile time,
+    case-insensitively (`junosServicePorts[strings.ToLower(...)]`) — for both
+    direct-match and inline-term ports. By the time `portMatches` reads
+    `app.DestinationPort`/`app.SourcePort` the value is numeric ("443"), so the
+    alias branch is never reached. Verified empirically
+    (resolveAppPort("HTTPS")=="443"). No change.
+  - **F8 (test-coverage, GENUINE — added)**: the single-wildcard tier
+    (`from-zone any to-zone X` + `from-zone X to-zone any`) merges in config
+    order, but the only existing test's winner was ALSO config-first — equally
+    consistent with a buggy "from-any bucket always wins". Added the SWAPPED
+    companion case to `TestWildcardZoneAndScopedGlobalPrecedence`
+    (wildcard_scoped_test.go) pinning genuine config-order interleaving.
+    Verified it goes RED under a two-pass (from-any-first) merge while the
+    prior case stays green.
+- **File(s)**: pkg/config/compiler_validate_strict_application.go,
+  pkg/config/compiler_application_junos_ping_3348_test.go,
+  pkg/policymatch/wildcard_scoped_test.go, _Log.md
+- **Validation**: `go test ./pkg/config/ ./pkg/policymatch/` green; `go build
+  ./...`, `go vet`, `gofmt -l` all clean. No docs change: the exact reject
+  strings are not enumerated in docs/ (config-schema.md's icmp-type section
+  covers firewall filters, #3205, a different gate).
+
 ## 2026-07-07 — #4411 (avo-review-002 A4/A6): host-inbound + policymatch test-coverage locks
 
 - **Timestamp**: 2026-07-07

--- a/pkg/config/compiler_application_junos_ping_3348_test.go
+++ b/pkg/config/compiler_application_junos_ping_3348_test.go
@@ -156,6 +156,40 @@ func TestApplicationICMPCodeWithoutType_Rejected(t *testing.T) {
 	}
 }
 
+// #4410 (F4): a protocol-less application that carries an icmp-type / icmp-code
+// constraint is rejected by the #3109 "no protocol specified" gate. The reject
+// message must NAME the icmp-type/icmp-code the operator already set — an
+// operator who typed `icmp-type 8` and forgot `protocol` should be pointed at
+// `protocol icmp` / `icmpv6`, not just told to "set a protocol". Fail-on-revert:
+// without the icmpConstraintDesc hint the message omits the concrete
+// `icmp-type 8` token and these assertions go RED (the bare "no protocol"
+// message never contains "icmp-type 8").
+func TestApplicationProtocolLessICMPType_RejectNamesConstraint(t *testing.T) {
+	cases := []struct {
+		name  string
+		props []string
+		want  string
+	}{
+		{"icmp-type only", []string{"icmp-type 8"}, "icmp-type 8"},
+		{"icmp-type + icmp-code", []string{"icmp-type 8", "icmp-code 0"}, "icmp-type 8 icmp-code 0"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tree := flatTreeFromSets(t, refApp("pinglike", c.props...)...)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("expected commit to REJECT protocol-less icmp-type application")
+			}
+			if !strings.Contains(err.Error(), "no protocol specified") {
+				t.Fatalf("error should still be the no-protocol reject, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Fatalf("reject message must name the ICMP constraint %q, got: %v", c.want, err)
+			}
+		})
+	}
+}
+
 // #3348 inline-term edge case 1 (widening INVERSION): an inline term that
 // lists BOTH a junos-ping alias AND an unconstrained ICMP alias normalizes both
 // to "icmp" and dedups to ONE term. The union of "echo" and "all-ICMP" is

--- a/pkg/config/compiler_validate_strict_application.go
+++ b/pkg/config/compiler_validate_strict_application.go
@@ -190,6 +190,24 @@ func validateApplicationSpecsStrict(cfg *Config) error {
 		// fail-closed family — term-dropping is fail-open for deny rules) and is
 		// tracked separately in #3261.
 		if app.Protocol == "" {
+			// #4410 (F4): a protocol-less application that ALSO carries an
+			// icmp-type / icmp-code constraint gets a targeted hint naming that
+			// constraint. An operator who set `icmp-type <n>` (or `icmp-code <n>`)
+			// but omitted `protocol` almost certainly meant `protocol icmp` (or
+			// icmpv6) — an ICMP type/code is meaningful only on an ICMP protocol
+			// (see the protocolIsICMPFamily gate below for the protocol-present
+			// case). The generic "no protocol" message ignored the icmp-type they
+			// had already typed; naming it turns the reject into an actionable
+			// "you set icmp-type N — add `protocol icmp`/`icmpv6`" instead of a
+			// bare "set a protocol".
+			icmpHint := ""
+			if desc := icmpConstraintDesc(app); desc != "" {
+				icmpHint = fmt.Sprintf(
+					" (this application sets %s but no protocol; an ICMP "+
+						"type/code constraint is meaningful only on `protocol icmp` "+
+						"or `protocol icmpv6` — add one of those)",
+					desc)
+			}
 			return fmt.Errorf(
 				"application %q: no protocol specified; an application referenced by "+
 					"a security policy or NAT rule (or any application when "+
@@ -199,8 +217,8 @@ func validateApplicationSpecsStrict(cfg *Config) error {
 					"keys on protocol+port and cannot represent a protocol-less "+
 					"application — accepting it would disarm the userspace dataplane "+
 					"for the whole config (the referencing policy's enforcement falls "+
-					"to the kernel slow path)",
-				name)
+					"to the kernel slow path)%s",
+				name, icmpHint)
 		}
 		// #3150: resolve the protocol against the SAME authority the dataplane
 		// uses (appid.ProtocolNumber, mirrored by filterProtocolResolvable) — NOT
@@ -637,6 +655,26 @@ func applicationsToValidateStrict(cfg *Config) map[string]struct{} {
 		}
 	}
 	return out
+}
+
+// icmpConstraintDesc renders the ICMP type/code constraint an application
+// carries as a human-readable `icmp-type N [icmp-code M]` token for use in a
+// commit-reject message (#4410 F4). It returns "" when the application has no
+// ICMP constraint, so callers can treat the empty string as "no hint to add".
+func icmpConstraintDesc(app *Application) string {
+	if app == nil {
+		return ""
+	}
+	switch {
+	case app.ICMPType != nil && app.ICMPCode != nil:
+		return fmt.Sprintf("icmp-type %d icmp-code %d", *app.ICMPType, *app.ICMPCode)
+	case app.ICMPType != nil:
+		return fmt.Sprintf("icmp-type %d", *app.ICMPType)
+	case app.ICMPCode != nil:
+		return fmt.Sprintf("icmp-code %d", *app.ICMPCode)
+	default:
+		return ""
+	}
 }
 
 // ApplicationsToValidateStrict exposes the strict-validation reference set

--- a/pkg/policymatch/wildcard_scoped_test.go
+++ b/pkg/policymatch/wildcard_scoped_test.go
@@ -103,6 +103,32 @@ func TestWildcardZoneAndScopedGlobalPrecedence(t *testing.T) {
 			wantAction: config.PolicyDeny, wantName: "any-to-trust-deny",
 		},
 		{
+			// #4410 (F8): the SWAPPED companion of the case above. With the two
+			// single-wildcard sets in the OPPOSITE config order —
+			// `from-zone untrust to-zone any permit` BEFORE `from-zone any
+			// to-zone trust deny` — the SAME untrust->trust query must now flip to
+			// the PERMIT. The prior case alone cannot prove the merge honors config
+			// order: its winner (the from-any deny) is ALSO the config-first rule,
+			// so it is equally consistent with a buggy "from-any bucket always
+			// outranks to-any" precedence. This swapped pair pins genuine
+			// config-order interleaving across the from-any / to-any boundary —
+			// the winner is whichever wildcard set appears first, not a fixed
+			// from-any/to-any tier. A regression that split the merge into two
+			// ordered passes (all from-any, then all to-any, or vice versa) would
+			// keep the earlier case green and turn THIS one RED.
+			name: "single-wildcard tier honors config order (swapped: to-any first)",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyDeny,
+				Zones:         zones("trust", "untrust"),
+				Policies: []*config.ZonePairPolicies{
+					zonePair("untrust", "any", permit("untrust-to-any-permit", config.PolicyMatch{})),
+					zonePair("any", "trust", deny("any-to-trust-deny", config.PolicyMatch{})),
+				},
+			}, config.ApplicationsConfig{}),
+			q:          Query{FromZone: "untrust", ToZone: "trust"},
+			wantAction: config.PolicyPermit, wantName: "untrust-to-any-permit",
+		},
+		{
 			// #3283 example 2: a zone-scoped global must NOT apply outside its
 			// scope. The old simulator applied every global unconditionally.
 			name: "scoped global does NOT apply to non-matching zone",


### PR DESCRIPTION
Drives the four dropped **avo-review-001** findings (F4/F5/F7/F8) tracked in #4410 to terminal. Each was verified against `origin/master` first — avo-review-001 is a historically low-signal source, so every item was weight-verified rather than taken on its word.

## Per-finding disposition

| Finding | Disposition | Evidence |
|---|---|---|
| **F4** (Low) | **GENUINE — fixed** | `validateApplicationSpecsStrict` rejected a protocol-less app carrying `icmp-type`/`icmp-code` with a generic "no protocol" message that ignored the icmp-type the operator set. |
| **F5** (Low, observability) | **ALREADY-FIXED (#3363)** | `collectPolicyCounters` (pkg/api/metrics_counters.go) already emits `xpf_policy_hits_total{from="-",to="-",policy="default-policy"}`, read via `dp.ReadPolicyCounters(dataplane.DefaultPolicySentinelID)`. |
| **F7** (Low) | **NOT-MATERIAL** | `resolveAppPort` (pkg/config/compiler_applications.go) canonicalizes every named port alias to numeric at compile time, case-insensitively, for direct-match **and** inline-term ports; `pkg/policymatch.portMatches` only ever sees a numeric spec, so `normalizePortAlias`'s case-sensitivity is unreachable. Verified: `resolveAppPort("HTTPS") == "443"`. |
| **F8** (test-coverage) | **GENUINE — added** | The single-wildcard tier merges in config order, but the sole existing test's winner was also config-first — could not distinguish genuine config-order from "from-any bucket always wins". |

## Changes (F4 + F8 only)

**F4** — `pkg/config/compiler_validate_strict_application.go`: new `icmpConstraintDesc` helper renders the concrete `icmp-type N [icmp-code M]`; the protocol-less reject now appends a targeted hint pointing at `protocol icmp`/`icmpv6` when the app carries an ICMP constraint. A protocol-less app **without** an ICMP constraint gets the byte-identical message (empty hint) — no behavior change. RED-on-revert test `TestApplicationProtocolLessICMPType_RejectNamesConstraint` (the bare message never contains `icmp-type 8`).

**F8** — `pkg/policymatch/wildcard_scoped_test.go`: added the SWAPPED companion to `TestWildcardZoneAndScopedGlobalPrecedence`. With the two wildcard sets in the opposite config order, the same `untrust->trust` query flips to the permit. Verified the new case goes RED under a two-pass (from-any-first) merge while the prior case stays green.

## Validation
- `go test ./pkg/config/ ./pkg/policymatch/` — green
- `go build ./...`, `go vet ./pkg/config/ ./pkg/policymatch/`, `gofmt -l` — clean
- No docs change: the exact reject strings are not enumerated in `docs/` (config-schema.md's icmp-type section covers firewall filters, #3205 — a different gate).

Closes #4410

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi