### PR TITLE
Refs #4373 (Phase-0 log clarity): route-drop-before-policy advisory in match-policies

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,43 @@
+## 2026-07-07 — #4373 (Phase-0, E4/H2/H7): match-policies route-drop-before-policy advisory
+
+- **Timestamp**: 2026-07-07
+- **Action**: Drove the Go-side Phase-0 slice of #4373 (reject/filter/PBR log
+  confusion). The driveable Go item is the E4/H2/H7 "same remedy" simulator
+  half: `show security match-policies` / `test policy` / REST / gRPC returned a
+  permit/deny verdict for a destination the transit forwarding path drops at
+  ROUTE LOOKUP before policy runs (multicast / limited broadcast / unspecified /
+  loopback), so the verdict — and a filter `then accept; then log` for the same
+  tuple — over-promised forwarding the dataplane never performs.
+  - Added `Result.RouteDropBeforePolicy` + `RouteDropClass` + `RouteDropNote()`
+    SSOT + `routeDropClass()` helper in `pkg/policymatch/policymatch.go`; `Match`
+    became a named-return and stamps the advisory on EVERY transit verdict path
+    (matched + default + content-rejected) via a defer. `to-zone junos-host` is
+    exempt (local-delivery gate, not transit route lookup); a nil dst (omitted
+    selector) is NOT classified as `0.0.0.0`.
+  - Surfaced the advisory on all four live surfaces from one wording: local CLI
+    (`pkg/cli/cli_show_security.go`, `cli_request.go`), remote CLI
+    (`cmd/cli/show.go`), REST (`pkg/api/types.go` + `security.go`,
+    `route_drop_*` JSON fields), gRPC (`proto` fields 22-24 +
+    `pkg/grpcapi/server_cluster.go`).
+  - VERIFIED already-handled (disproving file:line): E1 (reject vs
+    session-close) does NOT reproduce — `pkg/logging/ringbuf.go` renders
+    `FILTER_LOG` with `action=reject` + `source=pbr|input|output`
+    (`actionName`/`filterLogSourceName`), `SESSION_CLOSE` omits `action`
+    (#2513), and `POLICY_DENY` carries a distinct `reason` (#3610), so
+    filter-reject / policy-deny / teardown are already distinguishable.
+  - DEFERRED to Rust (cargo lane busy, do-not-run): the dataplane NoRoute/martian
+    drop COUNTER for E4/H2/H7 (so a live filter-accept log has a matching
+    visible drop) — the userspace-dp half of the same remedy.
+  - RED-on-revert: `pkg/policymatch/route_drop_4373_test.go` — neutralizing the
+    Match stamping reddens the multicast/broadcast/unspecified/loopback rows.
+    `go test` green (policymatch, cli, cmd/cli, api, grpcapi, logging); gofmt
+    clean; `make proto` regen additive-only.
+- **File(s)**: pkg/policymatch/policymatch.go,
+  pkg/policymatch/route_drop_4373_test.go (new), pkg/cli/cli_show_security.go,
+  pkg/cli/cli_request.go, cmd/cli/show.go, pkg/api/types.go, pkg/api/security.go,
+  proto/xpf/v1/xpf.proto, pkg/grpcapi/xpfv1/xpf.pb.go,
+  pkg/grpcapi/server_cluster.go, docs/junos-cli-reference.md, _Log.md
+
 ## 2026-07-07 — #4411 (avo-review-002 A4/A6): host-inbound + policymatch test-coverage locks
 
 - **Timestamp**: 2026-07-07

--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -1302,6 +1302,14 @@ func (c *ctl) showMatchPolicies(args []string) error {
 		// surfaces, which already report resp.Action.
 		fmt.Printf("No matching policy found for %s -> %s (%s)\n", req.FromZone, req.ToZone, resp.Action)
 	}
+	// #4373 (E4/H2/H7): the server flags a multicast/broadcast/unspecified/
+	// loopback destination that the forwarding path drops at route lookup before
+	// policy runs. Print the SSOT advisory it carries so a remote-CLI verdict is
+	// not read as real forwarding — parity with the local CLI + REST surfaces
+	// over the same policymatch.RouteDropNote wording.
+	if note := resp.GetRouteDropNote(); note != "" {
+		fmt.Printf("  %s\n", note)
+	}
 	return nil
 }
 

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -920,6 +920,45 @@ value is a non-literal dns-name / wildcard / range) (#4394). A single
 unrepresentable rule content-rejects EVERY query for the config (whole-snapshot
 semantics); a healthy config is never flagged.
 
+**Route-drop-before-policy advisory (#4373 E4/H2/H7).** A transit query whose
+`destination-ip` is a class the forwarding path drops at ROUTE LOOKUP *before*
+the policy engine runs — IPv4/IPv6 multicast, the IPv4 limited broadcast
+`255.255.255.255`, the unspecified address (`0.0.0.0` / `::`), or loopback
+(`127.0.0.0/8` / `::1`) — now carries an advisory line next to the verdict:
+
+```
+route-drop advisory: destination is multicast — transit traffic to this
+address is dropped at route lookup BEFORE security-policy evaluation, so this
+verdict does not describe real forwarding (the packet is dropped at route
+regardless of the matching policy / filter-accept log)
+```
+
+This closes an operator-confusion class: without it the simulator (and a
+firewall filter `then accept; then log` for the same tuple) reports a PERMIT
+the dataplane never forwards — the packet is silently dropped at route with no
+session and no policy eval, so the operator sees a permit/accept verdict but no
+traffic. The advisory is **additive** — it does NOT change the permit/deny
+verdict, `Matched`, or `default_used` — and rides both a positive match and the
+default-policy fall-through. It is emitted on all four live surfaces from one
+SSOT wording (`policymatch.RouteDropNote`): local + remote CLI `show security
+match-policies` / `test policy`, REST `match-policies`
+(`route_drop_before_policy` / `route_drop_class` / `route_drop_note` JSON
+fields), and the gRPC `MatchPolicies` RPC (fields 22–24). A `to-zone
+junos-host` query is exempt (it takes the local-delivery gate, not the transit
+route lookup), and an OMITTED `destination-ip` is never classified (nil dst
+means "any destination", not `0.0.0.0`).
+
+Note the two remaining halves of the same #4373 class: (1) the runtime
+RT_FLOW/event log already distinguishes a filter action from a teardown — a
+`then reject` emits a `FILTER_LOG`/`POLICY_DENY` with `action=reject` (and a
+`FILTER_LOG` `source=pbr|input|output`), while a `SESSION_CLOSE` deliberately
+omits `action` and carries a close `reason` (#2513/#3610), so a filter-reject,
+a policy-deny, and a session-teardown are already tellable apart in the log
+(the E1 confusion does not reproduce). (2) A dataplane NoRoute/martian drop
+COUNTER — so a *live* filter-accept log has a matching visible drop on the box —
+is the DEFERRED userspace-dp (Rust) half of the E4/H2/H7 remedy, tracked in
+#4373; the Go simulator advisory above is the control-plane half.
+
 ---
 
 ## Security: Zones

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -717,6 +717,12 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 			// tested (FromZone/ToZone carry matched-policy scope, unset here).
 			QueriedFromZone: fromZone,
 			QueriedToZone:   toZone,
+			// #4373 (E4/H2/H7): a multicast/broadcast/unspecified/loopback
+			// destination is dropped at route before policy, so even the default
+			// verdict does not describe real forwarding — carry the advisory.
+			RouteDropBeforePolicy: res.RouteDropBeforePolicy,
+			RouteDropClass:        res.RouteDropClass,
+			RouteDropNote:         res.RouteDropNote(),
 		})
 		return
 	}
@@ -763,6 +769,13 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 		// classifier verdict here too (present for any host-bound query; nil for
 		// a transit/global match, which has no host gate).
 		HostInbound: hostInboundToREST(res.HostInbound),
+		// #4373 (E4/H2/H7): a matched policy for a multicast/broadcast/
+		// unspecified/loopback destination still does not forward — the flow is
+		// dropped at route before policy. Carry the advisory so a positive match
+		// verdict is not read as real forwarding.
+		RouteDropBeforePolicy: res.RouteDropBeforePolicy,
+		RouteDropClass:        res.RouteDropClass,
+		RouteDropNote:         res.RouteDropNote(),
 	})
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -600,6 +600,21 @@ type MatchPoliciesResult struct {
 	// verdict, which has no host-inbound gate. Additional context, never a
 	// verdict — it does not change Matched / HostInboundUnmatched.
 	HostInbound *MatchPoliciesHostInbound `json:"host_inbound,omitempty"`
+	// RouteDropBeforePolicy is true when the query DESTINATION is a class the
+	// transit forwarding path drops at ROUTE LOOKUP before the policy engine runs
+	// (#4373 E4/H2/H7): multicast, the IPv4 limited broadcast, the unspecified
+	// address, or loopback. For such a destination the permit/deny Action does
+	// NOT describe real forwarding — the packet is dropped at route regardless of
+	// the matching policy (and a `then accept; then log` filter logs an accept
+	// the flow never survives). ADVISORY, like HostInbound: it does not change
+	// Matched / Action / DefaultUsed. RouteDropClass names the class and
+	// RouteDropNote carries the SSOT operator string (policymatch.RouteDropNote)
+	// so the REST answer states the caveat identically to the CLI surfaces.
+	// Omitted for an ordinary unicast destination and for a host-bound query
+	// (which takes the local-delivery gate, not transit route lookup).
+	RouteDropBeforePolicy bool   `json:"route_drop_before_policy,omitempty"`
+	RouteDropClass        string `json:"route_drop_class,omitempty"`
+	RouteDropNote         string `json:"route_drop_note,omitempty"`
 }
 
 // MatchPoliciesHostInbound is the REST projection of the host-inbound-traffic

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -246,6 +246,12 @@ func (c *CLI) testPolicy(args []string) error {
 		fmt.Printf("  %s\n", policymatch.HostInboundShowLine)
 		return nil
 	}
+	// #4373 (E4/H2/H7): a multicast/broadcast/unspecified/loopback destination is
+	// dropped at route lookup before policy runs — surface the advisory so the
+	// `test policy` verdict below is not read as real forwarding.
+	if note := res.RouteDropNote(); note != "" {
+		fmt.Printf("  %s\n", note)
+	}
 	if !res.Matched {
 		fmt.Printf("Default %s (no matching policy for %s -> %s)\n",
 			policymatch.ActionString(res.Action), fromZone, toZone)

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -441,6 +441,14 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 		}
 		return nil
 	}
+	// #4373 (E4/H2/H7): if the destination is multicast/broadcast/unspecified/
+	// loopback the forwarding path drops it at route lookup before policy runs,
+	// so the verdict below (and a `then accept; then log` filter for the same
+	// tuple) does not describe real forwarding. Print the advisory ahead of the
+	// verdict so the operator reads the caveat, not just the permit/deny.
+	if note := res.RouteDropNote(); note != "" {
+		fmt.Printf("  %s\n", note)
+	}
 	if !res.Matched {
 		fmt.Printf("No matching policy found for %s -> %s (default %s)\n",
 			fromZone, toZone, policymatch.ActionString(res.Action))

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -284,6 +284,12 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 			// tested (from_zone/to_zone carry matched-policy scope, unset here).
 			QueriedFromZone: req.FromZone,
 			QueriedToZone:   req.ToZone,
+			// #4373 (E4/H2/H7): a multicast/broadcast/unspecified/loopback
+			// destination is dropped at route before policy, so even the default
+			// verdict does not describe real forwarding — carry the advisory.
+			RouteDropBeforePolicy: res.RouteDropBeforePolicy,
+			RouteDropClass:        res.RouteDropClass,
+			RouteDropNote:         res.RouteDropNote(),
 		}, nil
 	}
 	return &pb.MatchPoliciesResponse{
@@ -329,6 +335,13 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 		// classifier verdict here too (present for any host-bound query; nil for
 		// a transit/global match, which has no host gate).
 		HostInbound: hostInboundToProto(res.HostInbound),
+		// #4373 (E4/H2/H7): a matched policy for a multicast/broadcast/
+		// unspecified/loopback destination still does not forward — the flow is
+		// dropped at route before policy. Carry the advisory so a positive match
+		// verdict is not read as real forwarding.
+		RouteDropBeforePolicy: res.RouteDropBeforePolicy,
+		RouteDropClass:        res.RouteDropClass,
+		RouteDropNote:         res.RouteDropNote(),
 	}, nil
 }
 

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -6673,9 +6673,27 @@ type MatchPoliciesResponse struct {
 	// (nil) for every transit / global / default / content-rejected verdict,
 	// which has no host-inbound gate. It is additional context, never a verdict:
 	// it does not change `matched` / `host_inbound_unmatched`.
-	HostInbound   *HostInboundAdmission `protobuf:"bytes,21,opt,name=host_inbound,json=hostInbound,proto3" json:"host_inbound,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	HostInbound *HostInboundAdmission `protobuf:"bytes,21,opt,name=host_inbound,json=hostInbound,proto3" json:"host_inbound,omitempty"`
+	// #4373 (E4/H2/H7): route_drop_before_policy is true when the query
+	// DESTINATION is a class the transit forwarding path drops at ROUTE LOOKUP
+	// before the policy engine runs — multicast, the IPv4 limited broadcast
+	// 255.255.255.255, the unspecified address, or loopback. For such a
+	// destination the permit/deny `action` does NOT describe real forwarding: the
+	// packet is dropped at route regardless of the matching policy (and a
+	// firewall `then accept; then log` for the same tuple logs an accept the flow
+	// never survives — the E4 confusion). route_drop_class names the class and
+	// route_drop_note carries the SSOT operator advisory string
+	// (policymatch.RouteDropNote) so gRPC / remote-CLI clients state the caveat
+	// identically to the local CLI + REST surfaces. ADVISORY, like host_inbound —
+	// it does not change `matched` / `action` / `default_used`. Populated on the
+	// transit verdict paths (matched + no-match/default); omitted for an ordinary
+	// unicast destination and for a host-bound query (which takes the
+	// local-delivery gate, not transit route lookup).
+	RouteDropBeforePolicy bool   `protobuf:"varint,22,opt,name=route_drop_before_policy,json=routeDropBeforePolicy,proto3" json:"route_drop_before_policy,omitempty"`
+	RouteDropClass        string `protobuf:"bytes,23,opt,name=route_drop_class,json=routeDropClass,proto3" json:"route_drop_class,omitempty"`
+	RouteDropNote         string `protobuf:"bytes,24,opt,name=route_drop_note,json=routeDropNote,proto3" json:"route_drop_note,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *MatchPoliciesResponse) Reset() {
@@ -6853,6 +6871,27 @@ func (x *MatchPoliciesResponse) GetHostInbound() *HostInboundAdmission {
 		return x.HostInbound
 	}
 	return nil
+}
+
+func (x *MatchPoliciesResponse) GetRouteDropBeforePolicy() bool {
+	if x != nil {
+		return x.RouteDropBeforePolicy
+	}
+	return false
+}
+
+func (x *MatchPoliciesResponse) GetRouteDropClass() string {
+	if x != nil {
+		return x.RouteDropClass
+	}
+	return ""
+}
+
+func (x *MatchPoliciesResponse) GetRouteDropNote() string {
+	if x != nil {
+		return x.RouteDropNote
+	}
+	return ""
 }
 
 // HostInboundAdmission is the structured host-inbound-traffic classifier verdict
@@ -8465,7 +8504,7 @@ const file_xpf_proto_rawDesc = "" +
 	"\n" +
 	"_icmp_typeB\f\n" +
 	"\n" +
-	"_icmp_code\"\xcb\x06\n" +
+	"_icmp_code\"\xd6\a\n" +
 	"\x15MatchPoliciesResponse\x12\x1f\n" +
 	"\vpolicy_name\x18\x01 \x01(\tR\n" +
 	"policyName\x12\x16\n" +
@@ -8489,7 +8528,10 @@ const file_xpf_proto_rawDesc = "" +
 	"\vdescription\x18\x12 \x01(\tR\vdescription\x12%\n" +
 	"\x0escheduler_name\x18\x13 \x01(\tR\rschedulerName\x12)\n" +
 	"\x10scheduler_active\x18\x14 \x01(\bR\x0fschedulerActive\x12?\n" +
-	"\fhost_inbound\x18\x15 \x01(\v2\x1c.xpf.v1.HostInboundAdmissionR\vhostInboundB\f\n" +
+	"\fhost_inbound\x18\x15 \x01(\v2\x1c.xpf.v1.HostInboundAdmissionR\vhostInbound\x127\n" +
+	"\x18route_drop_before_policy\x18\x16 \x01(\bR\x15routeDropBeforePolicy\x12(\n" +
+	"\x10route_drop_class\x18\x17 \x01(\tR\x0erouteDropClass\x12&\n" +
+	"\x0froute_drop_note\x18\x18 \x01(\tR\rrouteDropNoteB\f\n" +
 	"\n" +
 	"_policy_id\"\x9e\x01\n" +
 	"\x14HostInboundAdmission\x12:\n" +

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -625,6 +625,88 @@ type Result struct {
 	// HostInboundProtocolMatch), so the reported token cannot drift from the port
 	// the kernel actually opens.
 	HostInbound *dpuserspace.HostInboundAdmission
+
+	// RouteDropBeforePolicy is true when the query's DESTINATION address is a
+	// class the transit forwarding path drops at ROUTE LOOKUP, before the
+	// security-policy engine ever runs (#4373 E4/H2/H7): IPv4/IPv6 multicast,
+	// the IPv4 limited broadcast 255.255.255.255, the unspecified address, or a
+	// loopback address. For such a destination the dataplane has no forwarding
+	// route to reach policy evaluation, so the permit/deny verdict this Result
+	// carries does NOT describe what happens to real traffic — the packet is
+	// dropped at route regardless of any policy that "matches". A firewall
+	// filter `then accept; then log` for the same tuple likewise logs an ACCEPT
+	// the packet never survives (the E4 "filter-accept log but the flow is
+	// dropped at route" confusion). This is ADVISORY context, exactly like
+	// HostInbound: it does NOT change Matched / Action / DefaultUsed. Every
+	// operator surface (CLI show, `test policy`, REST) must surface RouteDropNote
+	// so a simulator verdict cannot over-promise forwarding for a
+	// non-transit-routable destination. Only a TRANSIT query is annotated; a
+	// `to-zone junos-host` query takes the local-delivery gate, not the transit
+	// route lookup, so it is never stamped. The route-drop itself is enforced in
+	// userspace-dp; a dataplane NoRoute/martian drop COUNTER (so a live filter-
+	// accept log has a matching visible drop) is the deferred Rust half of the
+	// same remedy.
+	RouteDropBeforePolicy bool
+	// RouteDropClass names the destination address class ("multicast",
+	// "broadcast", "unspecified", or "loopback") when RouteDropBeforePolicy is
+	// set; empty otherwise. It feeds RouteDropNote so the operator sees WHICH
+	// class triggered the route-drop advisory.
+	RouteDropClass string
+}
+
+// RouteDropNotePrefix is the stable leading token of the route-drop advisory
+// (#4373), kept as an SSOT so every match-policies surface (CLI show, `test
+// policy`, REST) and its tests share one wording and cannot drift. A caller
+// renders RouteDropNote(), never a hand-built string.
+const RouteDropNotePrefix = "route-drop advisory:"
+
+// RouteDropNote returns the operator-facing advisory line for a Result whose
+// destination address is dropped at route lookup before policy evaluation
+// (#4373 E4/H2/H7), or "" when the Result carries no route-drop condition. The
+// line states plainly that the verdict does not describe real forwarding, so an
+// operator does not read a permit/deny for a multicast/broadcast/unspecified/
+// loopback destination as if the flow is actually forwarded. It is ADVISORY —
+// it does not alter the verdict — and mirrors the HostInboundShowLine /
+// ContentRejectedShowLine SSOT pattern so the surfaces stay in lock-step.
+func (r Result) RouteDropNote() string {
+	if !r.RouteDropBeforePolicy {
+		return ""
+	}
+	class := r.RouteDropClass
+	if class == "" {
+		class = "non-routable"
+	}
+	return fmt.Sprintf("%s destination is %s — transit traffic to this address is "+
+		"dropped at route lookup BEFORE security-policy evaluation, so this verdict "+
+		"does not describe real forwarding (the packet is dropped at route regardless "+
+		"of the matching policy / filter-accept log)", RouteDropNotePrefix, class)
+}
+
+// routeDropClass classifies a query DESTINATION address into the transit
+// forwarding class that is dropped at route lookup before policy evaluation
+// (#4373 E4/H2/H7), or "" for an ordinary unicast destination that reaches the
+// policy engine. Multicast (IPv4 224.0.0.0/4, IPv6 ff00::/8), the IPv4 limited
+// broadcast 255.255.255.255, the unspecified address (0.0.0.0 / ::), and
+// loopback (127.0.0.0/8 / ::1) are all destinations the transit forwarding path
+// has no route to hand to policy. A nil dst (the "unspecified destination"
+// simulator wildcard) is NOT classified: it means the operator did not pin a
+// destination, not that the destination is 0.0.0.0.
+func routeDropClass(dst net.IP) string {
+	if dst == nil {
+		return ""
+	}
+	switch {
+	case dst.IsMulticast():
+		return "multicast"
+	case dst.Equal(net.IPv4bcast):
+		return "broadcast"
+	case dst.IsUnspecified():
+		return "unspecified"
+	case dst.IsLoopback():
+		return "loopback"
+	default:
+		return ""
+	}
 }
 
 // HostInboundActionString is the operator-facing verdict rendered for a
@@ -706,7 +788,25 @@ func (r Result) DisplayAction() string {
 // A `to-zone junos-host` query is host-bound and takes the separate host-gate
 // path (matchJunosHost, #3285): exact ingress->junos-host then
 // `from-zone any`->junos-host, with NO global/default transit fallback.
-func Match(cfg *config.Config, q Query) Result {
+func Match(cfg *config.Config, q Query) (res Result) {
+	// #4373 (E4/H2/H7): a TRANSIT destination that is multicast / broadcast /
+	// unspecified / loopback is dropped by the forwarding path at ROUTE LOOKUP,
+	// before the policy engine runs, so any permit/deny verdict below (and a
+	// firewall `then accept; then log` for the same tuple) over-promises
+	// forwarding the dataplane never performs. Classify the destination up front
+	// and stamp the advisory onto whatever Result the tier chain returns via a
+	// defer, so EVERY return path (default, matched, content-rejected) carries it
+	// without threading the flag through each construction. Host-bound
+	// (junos-host) queries take the local-delivery gate, not transit route
+	// lookup, so they are exempt — matchJunosHost never sees this stamp.
+	if q.ToZone != JunosHostZone {
+		if class := routeDropClass(q.DstIP); class != "" {
+			defer func() {
+				res.RouteDropBeforePolicy = true
+				res.RouteDropClass = class
+			}()
+		}
+	}
 	if cfg == nil {
 		return Result{DefaultUsed: true, Action: config.PolicyDeny}
 	}

--- a/pkg/policymatch/route_drop_4373_test.go
+++ b/pkg/policymatch/route_drop_4373_test.go
@@ -1,0 +1,128 @@
+package policymatch
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestRouteDropBeforePolicyStamped is the #4373 (E4/H2/H7) regression: a
+// TRANSIT query whose DESTINATION is a class the forwarding path drops at route
+// lookup BEFORE the policy engine runs (multicast / limited broadcast /
+// unspecified / loopback) must carry the route-drop advisory on the Result, so
+// no match-policies surface over-promises forwarding for a destination the
+// dataplane never routes to policy. The advisory is additive — it does NOT
+// change the permit/deny verdict — and rides EVERY verdict path (a positive
+// match AND the default-policy fall-through).
+//
+// RED-on-revert: drop the Match() route-drop stamping (or the routeDropClass
+// helper) and RouteDropBeforePolicy is false / RouteDropClass is "" /
+// RouteDropNote is "" for the multicast, broadcast, unspecified, and loopback
+// destinations below — the verdict is then indistinguishable from a normal
+// forwarded flow.
+func TestRouteDropBeforePolicyStamped(t *testing.T) {
+	// trust -> untrust permits everything; the verdict is a positive permit so
+	// the advisory must ride a MATCHED result, not only a default one.
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyDeny,
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", permit("permit-any", config.PolicyMatch{})),
+		},
+	}, config.ApplicationsConfig{})
+
+	cases := []struct {
+		name      string
+		dst       net.IP
+		wantClass string
+	}{
+		{"ipv4-multicast", net.ParseIP("224.0.0.5"), "multicast"},
+		{"ipv6-multicast", net.ParseIP("ff02::1"), "multicast"},
+		{"ipv4-broadcast", net.ParseIP("255.255.255.255"), "broadcast"},
+		{"ipv4-unspecified", net.ParseIP("0.0.0.0"), "unspecified"},
+		{"ipv6-unspecified", net.ParseIP("::"), "unspecified"},
+		{"ipv4-loopback", net.ParseIP("127.0.0.1"), "loopback"},
+		{"ipv6-loopback", net.ParseIP("::1"), "loopback"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", DstIP: tc.dst})
+			// The verdict itself is unchanged: the rule still matches permit.
+			if !res.Matched || res.Action != config.PolicyPermit {
+				t.Fatalf("verdict changed: got Matched=%v Action=%v, want matched permit", res.Matched, res.Action)
+			}
+			if !res.RouteDropBeforePolicy {
+				t.Fatalf("RouteDropBeforePolicy = false, want true for %s dst %s", tc.wantClass, tc.dst)
+			}
+			if res.RouteDropClass != tc.wantClass {
+				t.Fatalf("RouteDropClass = %q, want %q", res.RouteDropClass, tc.wantClass)
+			}
+			note := res.RouteDropNote()
+			if !strings.HasPrefix(note, RouteDropNotePrefix) {
+				t.Fatalf("RouteDropNote %q missing SSOT prefix %q", note, RouteDropNotePrefix)
+			}
+			if !strings.Contains(note, tc.wantClass) {
+				t.Fatalf("RouteDropNote %q does not name class %q", note, tc.wantClass)
+			}
+			if !strings.Contains(note, "route lookup") {
+				t.Fatalf("RouteDropNote %q must state the packet is dropped at route lookup", note)
+			}
+		})
+	}
+}
+
+// TestRouteDropAdvisoryOnDefaultVerdict proves the advisory also rides the
+// default-policy fall-through (no matching policy): a multicast destination in
+// an empty policy set still reports the route-drop caveat next to the default
+// deny, so the operator does not read the default verdict as a real forward
+// either.
+func TestRouteDropAdvisoryOnDefaultVerdict(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{DefaultPolicy: config.PolicyDeny}, config.ApplicationsConfig{})
+	res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", DstIP: net.ParseIP("239.1.2.3")})
+	if res.Matched {
+		t.Fatalf("expected default (no match), got matched %+v", res)
+	}
+	if !res.RouteDropBeforePolicy || res.RouteDropClass != "multicast" {
+		t.Fatalf("default verdict missing multicast route-drop advisory: %+v", res)
+	}
+	if res.RouteDropNote() == "" {
+		t.Fatalf("default verdict RouteDropNote is empty, want the SSOT advisory")
+	}
+}
+
+// TestRouteDropNotAppliedToUnicastOrHost pins the two exemptions: an ordinary
+// unicast transit destination reaches the policy engine (no advisory), and a
+// host-bound (junos-host) query takes the local-delivery gate rather than the
+// transit route lookup, so it is NEVER stamped even for a multicast dst (which
+// cannot be host-bound in practice, but the exemption must be structural). A
+// nil destination — the "unspecified destination" simulator wildcard — must NOT
+// be classified as the 0.0.0.0 unspecified address.
+func TestRouteDropNotAppliedToUnicastOrHost(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyDeny,
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", permit("permit-any", config.PolicyMatch{})),
+		},
+	}, config.ApplicationsConfig{})
+
+	// Ordinary unicast dst: reaches policy, no advisory.
+	uni := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", DstIP: net.ParseIP("10.0.2.7")})
+	if uni.RouteDropBeforePolicy || uni.RouteDropClass != "" || uni.RouteDropNote() != "" {
+		t.Fatalf("unicast dst wrongly flagged as route-drop: %+v", uni)
+	}
+
+	// nil dst (operator omitted the destination): the unspecified-address
+	// classifier must NOT fire — omitted != 0.0.0.0.
+	nilDst := Match(cfg, Query{FromZone: "trust", ToZone: "untrust"})
+	if nilDst.RouteDropBeforePolicy {
+		t.Fatalf("nil dst wrongly classified as route-drop: %+v", nilDst)
+	}
+
+	// Host-bound query with a multicast dst: exempt (host path, not transit
+	// route lookup).
+	host := Match(cfg, Query{FromZone: "trust", ToZone: JunosHostZone, DstIP: net.ParseIP("224.0.0.5")})
+	if host.RouteDropBeforePolicy {
+		t.Fatalf("host-bound query wrongly stamped with transit route-drop: %+v", host)
+	}
+}

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -847,6 +847,24 @@ message MatchPoliciesResponse {
   // which has no host-inbound gate. It is additional context, never a verdict:
   // it does not change `matched` / `host_inbound_unmatched`.
   HostInboundAdmission host_inbound = 21;
+  // #4373 (E4/H2/H7): route_drop_before_policy is true when the query
+  // DESTINATION is a class the transit forwarding path drops at ROUTE LOOKUP
+  // before the policy engine runs — multicast, the IPv4 limited broadcast
+  // 255.255.255.255, the unspecified address, or loopback. For such a
+  // destination the permit/deny `action` does NOT describe real forwarding: the
+  // packet is dropped at route regardless of the matching policy (and a
+  // firewall `then accept; then log` for the same tuple logs an accept the flow
+  // never survives — the E4 confusion). route_drop_class names the class and
+  // route_drop_note carries the SSOT operator advisory string
+  // (policymatch.RouteDropNote) so gRPC / remote-CLI clients state the caveat
+  // identically to the local CLI + REST surfaces. ADVISORY, like host_inbound —
+  // it does not change `matched` / `action` / `default_used`. Populated on the
+  // transit verdict paths (matched + no-match/default); omitted for an ordinary
+  // unicast destination and for a host-bound query (which takes the
+  // local-delivery gate, not transit route lookup).
+  bool route_drop_before_policy = 22;
+  string route_drop_class = 23;
+  string route_drop_note = 24;
 }
 
 // HostInboundAdmissionStatus classifies how the ingress zone's


### PR DESCRIPTION
## Refs #4373 (Phase-0 log clarity)

Drives the Go-side Phase-0 slice of #4373 (avo-review-007 E4/H2/H7 — reject/filter/PBR log confusion). The driveable Go item is the E4/H2/H7 "same remedy" **simulator half**.

### Problem
`show security match-policies` / `test policy` (+ REST + gRPC) returned a permit/deny verdict for a transit destination the forwarding path drops at **route lookup, before the policy engine runs** — IPv4/IPv6 multicast, the IPv4 limited broadcast `255.255.255.255`, the unspecified address, or loopback. The packet is dropped at route with no session and no policy eval, so the verdict over-promised forwarding the dataplane never performs. A firewall filter `then accept; then log` for the same tuple has the identical confusion: it logs an ACCEPT the flow never survives.

### Change (control-plane / simulator half)
- `pkg/policymatch/policymatch.go`: new `Result.RouteDropBeforePolicy` + `RouteDropClass` + SSOT `RouteDropNote()` + `routeDropClass()` helper. `Match` is now a named-return and stamps the advisory on **every** transit verdict path (matched / default / content-rejected) via a defer. `to-zone junos-host` is exempt (local-delivery gate, not transit route lookup); a nil (omitted) dst is **not** misread as `0.0.0.0`.
- Surfaced from one wording on all four live surfaces: local CLI (`pkg/cli`), remote CLI (`cmd/cli`), REST (`pkg/api`, `route_drop_*` JSON fields), gRPC `MatchPolicies` (`proto` fields 22-24, additive `make proto` regen).
- Advisory is **additive** — it does not change `Matched` / `Action` / `default_used`.

### Verified already-handled (no change needed)
E1 (a `then reject` producing a confusing session-close log) does **not** reproduce: `pkg/logging/ringbuf.go` already renders `FILTER_LOG` with `action=reject` + `source=pbr|input|output`, a `SESSION_CLOSE` that omits `action` (#2513), and a `POLICY_DENY` with a distinct `reason` (#3610) — filter-reject / policy-deny / teardown are already distinguishable in the RT_FLOW log.

### Deferred to Rust (cargo lane busy — not run here)
The dataplane **NoRoute/martian drop counter** (so a live filter-accept log has a matching visible drop on the box) is the userspace-dp half of the E4/H2/H7 remedy — follow-up on #4373.

### Validation
- RED-on-revert: `pkg/policymatch/route_drop_4373_test.go` — neutralizing the `Match` stamping reddens the multicast / broadcast / unspecified / loopback rows + the default-verdict row.
- `go test` green: policymatch, cli, cmd/cli, api, grpcapi, logging. gofmt clean. `make proto` additive-only. `go build ./...` clean.
- Docs: `docs/junos-cli-reference.md` policy-simulator section + `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi