### PR TITLE
config: reject zone list on scoped global policy + codex-164 backlog dispositions (Refs #4415)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,37 @@
+## 2026-07-07 — #4415 (codex-164 backlog, L12): reject zone LIST on scoped global policy
+
+- **Timestamp**: 2026-07-07
+- **Action**: Drove the one GENUINE GO bug in the codex-review-164 unfiled
+  backlog (#4415). A scoped global policy's `match from-zone` / `match to-zone`
+  (#3148) is modeled by a SINGLE-STRING `config.PolicyMatch.FromZone`/`.ToZone`,
+  and the compiler fills it from only the first value token. A Junos zone LIST
+  (`match from-zone [ trust dmz ]`) collapses via the #2419 lexer onto one leaf's
+  Keys (`["from-zone","trust","dmz"]`), so the compiler kept `trust` and SILENTLY
+  DROPPED `dmz` — a security-relevant scope narrowing with no operator-visible
+  signal (verified: `SchemaValidate` returned nil, `Match.FromZone == "trust"`).
+  Tagged both leaves `scalar: true` in `pkg/config/schema_security.go` so
+  `SchemaValidate`'s #3332 `validateScalarValueLeaf` guard REJECTS the list at
+  commit with a clear "the extra token would be silently dropped" error, instead
+  of dropping a zone. Single-zone scope still validates. Modeling a real
+  multi-zone scope (Junos accepts a list here) is deferred as #4415 M03.
+- **File(s)**: `pkg/config/schema_security.go` (scalar: true on global
+  from-zone/to-zone), `pkg/config/schema_global_zone_list_4415_test.go` (new
+  RED-on-revert test), `docs/config-schema.md` (#4415 L12 note in the #3332
+  scalar section).
+- **Other codex-164 items (dispositions, no code):** H02 policy_id-0 exclusion =
+  DELIBERATE, documented in `daemon_policy_invalidate.go` (overloaded wire value,
+  fail-safe under-clear). M01 single-read bpfShim add = DELIBERATE, documented in
+  `policycounters.go:201` (bpfShim never incremented in userspace mode →
+  contributes zero; retained for legacy API parity). M05/L10/L15 host-inbound
+  exotic-zone counter collision + hash-suffix/side-table = DELIBERATE, documented
+  in `nftables/host_inbound_counters.go` (hash suffix explicitly rejected;
+  bounded metric-aggregation artifact, no forwarding/security impact). M07
+  bulk-reader migration = ALREADY-COMPLETE (all six observability surfaces use
+  `NewPolicyCounterReader`). L08 static canary = ALREADY-DONE
+  (`policies_bulk_reader_test.go` x3 across api/cli/grpcapi). M03/L01 multi-zone
+  scope + reserve-id-0 = NEEDS-RESEARCH (deferred). L02/L03 loss-cluster smokes =
+  lab-blocked. L06/L07/L14 = refactors (out of scope this pass).
+
 ## 2026-07-07 — #4373 (Phase-0, E4/H2/H7): match-policies route-drop-before-policy advisory
 
 - **Timestamp**: 2026-07-07

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -579,6 +579,21 @@ tag, asserted only on leaves audited to take a fixed value and NO body
 `hostname`). This is the "design pass on the value-arity contract" the #3332
 body called for; new scalar leaves opt in as they are audited.
 
+**#4415 L12 — scoped global-policy `from-zone`/`to-zone`.** A Junos global
+policy may carry an optional `match from-zone` / `match to-zone` to scope it
+to a chosen zone pair (#3148). The typed model behind it —
+`config.PolicyMatch.FromZone` / `.ToZone` — is a single string, and the
+compiler (`compiler_security_policy.go`) fills it from only the FIRST value
+token. A zone LIST (`match from-zone [ trust dmz ]`) collapses via the #2419
+lexer onto one leaf's Keys (`["from-zone","trust","dmz"]`), so the compiler
+kept `trust` and silently DROPPED `dmz` — a security-relevant scope
+narrowing with no operator-visible signal. Both leaves are now tagged
+`scalar: true`, so `SchemaValidate` rejects the list at commit instead of
+dropping a zone. Modeling a real multi-zone scope (Junos accepts a list here)
+is deferred as #4415 M03; until then the fail-closed rejection is the correct
+behavior. Pinned by
+`pkg/config/schema_global_zone_list_4415_test.go`.
+
 `isScalarValueLeaf` also carries belt-and-braces structural guards, so a
 future mis-tag on a node that is actually multi / typed / a container
 degrades to a no-op rather than a surprise rejection. It exempts:

--- a/pkg/config/schema_global_zone_list_4415_test.go
+++ b/pkg/config/schema_global_zone_list_4415_test.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4415 L12: a scoped global policy models exactly ONE from-zone and ONE
+// to-zone (config.PolicyMatch.FromZone / .ToZone are single strings, set by
+// the compiler from only the first value token). A Junos zone LIST
+// (`match from-zone [ a b ]`) collapses via the #2419 lexer onto one leaf's
+// Keys (["from-zone","a","b"]); the compiler kept only "a" and SILENTLY
+// DROPPED "b", narrowing the policy's scope without any operator-visible
+// signal — a security-relevant miscompile. Tagging the leaves `scalar: true`
+// makes SchemaValidate REJECT the list at commit (the #3332 fail-closed
+// trailing-token guard) instead of dropping a zone. Modeling a real
+// multi-zone scope is the deferred #4415 M03 work; until then rejection is
+// the correct behavior.
+//
+// RED on revert: dropping `scalar: true` from the global from-zone/to-zone
+// leaves in schema_security.go makes SchemaValidate return nil for the list
+// form, so the wantReject assertions below fail.
+
+func buildGlobalZone4415Tree(t *testing.T, cmds ...string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+func TestGlobalPolicyZoneListRejected4415(t *testing.T) {
+	base := []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security zones security-zone dmz",
+	}
+
+	cases := []struct {
+		name       string
+		matchLine  string
+		wantReject bool
+		wantToken  string
+	}{
+		{
+			name:       "from-zone list rejected",
+			matchLine:  "set security policies global policy p match from-zone [ trust dmz ]",
+			wantReject: true,
+			wantToken:  "dmz",
+		},
+		{
+			name:       "to-zone list rejected",
+			matchLine:  "set security policies global policy p match to-zone [ untrust dmz ]",
+			wantReject: true,
+			wantToken:  "dmz",
+		},
+		{
+			name:       "single from-zone accepted",
+			matchLine:  "set security policies global policy p match from-zone trust",
+			wantReject: false,
+		},
+		{
+			name:       "single to-zone accepted",
+			matchLine:  "set security policies global policy p match to-zone untrust",
+			wantReject: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmds := append(append([]string(nil), base...), tc.matchLine,
+				"set security policies global policy p match application any",
+				"set security policies global policy p then deny",
+			)
+			tree := buildGlobalZone4415Tree(t, cmds...)
+			cfg, _ := CompileConfigLenient(tree)
+			err := SchemaValidate(tree, cfg)
+			if tc.wantReject {
+				if err == nil {
+					t.Fatalf("SchemaValidate accepted a zone LIST; want rejection (the second zone would be silently dropped)")
+				}
+				if tc.wantToken != "" && !strings.Contains(err.Error(), tc.wantToken) {
+					t.Errorf("SchemaValidate error = %q; want it to name the dropped token %q", err.Error(), tc.wantToken)
+				}
+			} else if err != nil {
+				t.Fatalf("SchemaValidate rejected a valid single-zone scope: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -272,8 +272,25 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 					// historical global behaviour). These leaves exist ONLY
 					// under global policy match — zone-pair policies take
 					// their zones from the from-zone/to-zone stanza.
-					"from-zone": {desc: "Restrict this global policy to packets from this zone", args: 1, valueHint: ValueHintZoneName, placeholder: "<zone-name>", children: nil},
-					"to-zone":   {desc: "Restrict this global policy to packets to this zone", args: 1, valueHint: ValueHintZoneName, placeholder: "<zone-name>", children: nil},
+					//
+					// #4415 L12: tagged `scalar: true` so a list / trailing
+					// token is REJECTED at commit rather than silently
+					// dropped. The compiler
+					// (compiler_security_policy.go from-zone/to-zone cases)
+					// reads only the FIRST value token (Keys[1] or
+					// Children[0]) into the single-string Match.FromZone /
+					// Match.ToZone, so `match from-zone [ trust dmz ]`
+					// (which the #2419 lexer collapses to
+					// Keys=["from-zone","trust","dmz"]) would silently keep
+					// only "trust" and discard "dmz" — a security-relevant
+					// scope narrowing the operator never sees. Junos accepts
+					// a zone LIST here; modeling that is the deferred
+					// multi-zone-scope work (#4415 M03). Until then the
+					// fail-closed behavior is to reject the list with a clear
+					// error (validateScalarValueLeaf, #3332) so no zone is
+					// dropped without notice.
+					"from-zone": {desc: "Restrict this global policy to packets from this zone", args: 1, scalar: true, valueHint: ValueHintZoneName, placeholder: "<zone-name>", children: nil},
+					"to-zone":   {desc: "Restrict this global policy to packets to this zone", args: 1, scalar: true, valueHint: ValueHintZoneName, placeholder: "<zone-name>", children: nil},
 				}},
 				"then": {desc: "Action", children: policyThenSchemaChildren()},
 				// #3117: scheduler-name on global policies — same compiler +


### PR DESCRIPTION
## Summary

Drives the codex-review-164 unfiled-findings backlog (#4415). Codex is a
high-signal source; I verified every listed finding against current
`origin/master`. Exactly **one** was a genuine Go bug still present — driven
here with a RED-on-revert test. The rest are documented deliberate tradeoffs,
already-complete, or needs-research (dispositioned below).

## The fix (L12) — genuine silent-miscompile

A scoped global policy's `match from-zone` / `match to-zone` (#3148) is modeled
by a **single-string** `config.PolicyMatch.FromZone`/`.ToZone`; the compiler
fills it from only the first value token. A Junos zone **list**
(`match from-zone [ trust dmz ]`) collapses via the #2419 lexer onto one leaf's
Keys (`["from-zone","trust","dmz"]`), so the compiler kept `trust` and
**silently dropped** `dmz`:

- Before: `SchemaValidate` returned nil, `Match.FromZone == "trust"` (verified).
- After: both leaves tagged `scalar: true` → the #3332 `validateScalarValueLeaf`
  guard rejects the list at commit with a clear "the extra token would be
  silently dropped" error. Single-zone scope still validates unchanged.

Modeling a real multi-zone scope (Junos accepts a list here) is the deferred
**M03** research item.

## Per-item disposition (all codex-164 H/M + L01–L15)

| ID | Class | Disposition | Evidence |
|----|-------|-------------|----------|
| L12 | LOW | **FIXED (this PR)** | `scalar: true` on global from/to-zone; `schema_global_zone_list_4415_test.go` |
| H02 | HIGH | DELIBERATE — still correct | policy_id-0 exclusion documented in `daemon_policy_invalidate.go` (overloaded wire value; fail-safe under-clear; mirrors policy.rs `DuplicatePolicyId`) |
| M01 | MED | DELIBERATE — not material | `policycounters.go:201` — bpfShim `policy_counters` never incremented in userspace mode → contributes **zero**; single-read add retained solely for legacy API parity |
| M05 | MED | DELIBERATE — still correct | `nftables/host_inbound_counters.go` `HostInboundDenyCounterName` doc — exotic-zone counter collision is a bounded metric-aggregation artifact; per-(zone,daddr) DROP rules mean no forwarding/security/dedup impact |
| M07 | MED | ALREADY-COMPLETE | all six observability surfaces use `NewPolicyCounterReader` (bulk): `api/metrics_counters.go`, `api/security.go`, `cli/cli_show_security*.go`, `grpcapi/server_show_policies_text.go`, `grpcapi/server_show_zones.go` |
| M03 | MED | NEEDS-RESEARCH (deferred) | single-string `PolicyMatch.FromZone`/`ToZone` at `types_security.go:410-411`; multi-zone scope is a vSRX-parity/scalability design change |
| L01 | LOW | NEEDS-RESEARCH (deferred) | reserve-id-0 redesign = same as H02 |
| L02/L03 | LOW | LAB-BLOCKED (deferred) | loss-cluster smokes for default-policy + scheduler transitions — cannot validate outside the shared cluster |
| L04/L05 | LOW | Folds into M03 | file-as-vSRX-parity = the M03 multi-zone gap |
| L06/L07/L14 | LOW | Refactor (deferred) | code-motion / shared-interface / runtime-id-framework — `NewPolicyCounterReader` already IS the shared reader (L07 partly done) |
| L08 | LOW | ALREADY-DONE | `#4344` static canaries: `policies_bulk_reader_test.go` in api + cli + grpcapi |
| L09 | LOW | Benchmark (deferred) | 10k-rule perf benchmark — low value |
| L10 | LOW | DELIBERATE-rejected | host-inbound hash suffix explicitly declined in `host_inbound_counters.go` doc (kept human-readable + simple reverse lookup) |
| L11/L13 | LOW | Doc/test (deferred) | rematch-support-matrix doc + cross-surface counter-consistency test |
| L15 | LOW | DELIBERATE-rejected | original-zone-name side table — same tradeoff as L10 |

## Validation

- New RED-on-revert test `pkg/config/schema_global_zone_list_4415_test.go`:
  asserts the list form is rejected (and names the dropped token) and that
  single-zone scope is accepted. Dropping `scalar: true` turns it RED (verified).
- Full `pkg/config` suite green; `go build ./...`, `go vet ./pkg/config`,
  `gofmt` clean.
- Docs: `#4415 L12` note added to the `#3332` scalar section of
  `docs/config-schema.md`.

Refs #4415

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi