### PR TITLE
userspace-dp fabric: return fast path excludes ALL markerless protocols (#4414)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -39527,3 +39527,36 @@ top.
   Go-only pass. README updated with the new lock's description.
 - **File(s)**: pkg/policymatch/global_scope_regression_4365_test.go (new),
   pkg/policymatch/README.md, _Log.md
+
+## 2026-07-07 — #4414 fabric return fast path excludes ALL markerless protos
+- **Timestamp**: 2026-07-07 15:48 UTC
+- **Action**: Generalized the `cluster_peer_return_fast_path` flow-initiator
+  exclusion (`userspace-dp/src/afxdp/forwarding/mod.rs`). The fast path fires
+  ONLY on a session MISS (from the session-miss decision in
+  `poll_descriptor/mod.rs`) and builds a NAT-less (`NatDecision::default()`),
+  reverse-keyed (`SessionOrigin::ReverseFlow`) seed — so it must fire only for
+  provably-RETURN traffic. #4439 excluded UDP and #4453 excluded the bare TCP
+  RST/FIN, but the guard was still an enumerated deny-list that left every
+  OTHER markerless L4 (ESP, AH, GRE, SCTP, OSPF, …) adopted. A NEW forward flow
+  of such a protocol that ingressed the HAInactive node and was fabric-
+  redirected to the RG owner was fast-pathed on the owner into a NAT-less
+  reverse seed: source-NAT skipped (internal IP on the wire — NAT bypass) and
+  the flow recorded in the wrong direction (reverse seed for a forward flow —
+  session corruption). Replaced the `meta.protocol == PROTO_UDP` guard with a
+  positive allow-list `!matches!(meta.protocol, PROTO_TCP | PROTO_ICMP |
+  PROTO_ICMPV6)` (subsumes the #4439 UDP arm). TCP and ICMP/ICMPv6 are the only
+  protocols with a distinguishable initiator form (TCP SYN + bare RST/FIN
+  excluded; ICMP echo-request excluded), so the admitted set is exactly the
+  provably-return forms. Every markerless protocol now falls through to the
+  owner's normal forward decision, which applies source-NAT and installs a
+  FORWARD session — closing BOTH the NAT bypass and the reverse-seed corruption
+  (same root cause: a non-return flow on the return fast path). Fix B (the
+  principled initiator-exclusion generalization), not the issue's literal Fix A
+  (`apply_nat_on_fabric=true`), which would double-NAT with the owner and leave
+  the reverse-seed corruption unfixed. New RED-on-revert test
+  `cluster_peer_return_fast_path_skips_markerless_proto_new_flow_4414` (ESP / AH
+  / GRE / SCTP / OSPF → None; Some on revert). NOTE: fabric/HA change —
+  `make test-failover` REQUIRED before merge.
+- **File(s)**: userspace-dp/src/afxdp/forwarding/mod.rs,
+  userspace-dp/src/afxdp/forwarding/tests.rs, docs/fabric-cross-chassis-fwd.md,
+  _Log.md

--- a/docs/fabric-cross-chassis-fwd.md
+++ b/docs/fabric-cross-chassis-fwd.md
@@ -539,3 +539,64 @@ ICMP-reply test uses — returns `Some` on revert, `None` with the fix)
 alongside the preserved `_allows_sfmix_to_lan_reply`,
 `_skips_udp_new_flow_4439`, `_skips_pure_tcp_syn`, and
 `_skips_icmp_echo_request`.
+
+## Every markerless protocol must be excluded, not just UDP (#4414)
+
+#4439 excluded UDP and #4453 excluded the bare TCP RST/FIN, but the guard was
+still enumerated protocol-by-protocol. Its own stated invariant — *fire only
+for provably-return traffic, and every protocol without a flow-initiator
+marker (like UDP) can open a NEW flow so must be excluded* — was applied to
+UDP alone. **Every other markerless L4 was left adopted:** ESP, AH, GRE, SCTP,
+OSPF, and any other IP protocol that is neither TCP nor ICMP/ICMPv6 has no
+"non-initiating" form, exactly like UDP.
+
+**The bug.** A session-less packet of such a protocol — a genuinely NEW
+forward flow (e.g. an outbound ESP/GRE/SCTP flow that ingressed the
+locally-**HAInactive** node and was fabric-redirected to the RG owner) —
+reached `cluster_peer_return_fast_path`, resolved to a `ForwardCandidate`, and
+was adopted as return traffic. The two #4439 failures followed on the owner,
+now for the whole non-TCP/non-ICMP protocol space:
+
+1. **NAT bypass.** The reverse seed carried `NatDecision::default()`, and the
+   redirecting node keeps `apply_nat_on_fabric = false` (it forwards the
+   original pre-NAT frame, deferring NAT to the owner), so the source-NAT a
+   new outbound flow requires was applied by *neither* node — the internal
+   source address/port left on the wire.
+2. **Session-state corruption.** The owner installed a **reverse-keyed**
+   (`SessionOrigin::ReverseFlow`) session for what was actually a forward
+   flow, so subsequent packets and the real reply resolved against a
+   mis-directioned session.
+
+Both failures share one root cause: a NON-return flow taking the return fast
+path. Confirmed 2× (opus-review-171 M-3 / ps-review-017 P7).
+
+**The fix.** `cluster_peer_return_fast_path` now returns `None` for any
+`meta.protocol` that is not `PROTO_TCP`, `PROTO_ICMP`, or `PROTO_ICMPV6`
+(subsuming the #4439 UDP-only guard). Only TCP and ICMP/ICMPv6 carry a
+distinguishable initiator form — TCP excludes the initial SYN and bare RST/FIN,
+ICMP excludes the echo REQUEST — so the surviving admitted set is exactly the
+provably-return forms: established TCP (non-SYN, non-closing) and ICMP/ICMPv6
+echo-reply / error responses. A markerless-protocol packet falls through to
+the owner's normal forward decision, where — because the RG owner resolves it
+to a `ForwardCandidate` (not a `FabricRedirect`) — source-NAT is applied
+(`apply_nat = !fabric_redirect || apply_nat_on_fabric` is `true` for a
+non-redirect egress) and a FORWARD session is installed. This closes BOTH the
+NAT bypass and the reverse-seed corruption in one change, since both stem from
+the single "non-return flow on the return fast path" root cause.
+
+The legitimate fabric-forward for an established synced session is untouched:
+it is served by `resolve_flow_session_decision` (the synced session + #2120
+standby retention) before this session-less fast path, so it is a session HIT.
+
+This completes the flow-initiator-exclusion invariant as a positive
+allow-list rather than a growing deny-list: the fast path fires ONLY for TCP
+and ICMP/ICMPv6 in their return forms, and refuses UDP and every other
+markerless protocol.
+
+RED-on-revert coverage: `forwarding/tests.rs`
+`cluster_peer_return_fast_path_skips_markerless_proto_new_flow_4414` (ESP / AH
+/ GRE / SCTP / OSPF against the same ForwardCandidate-resolving target the
+ICMP-reply test uses — returns `Some` on revert, `None` with the fix)
+alongside the preserved `_allows_sfmix_to_lan_reply`,
+`_skips_udp_new_flow_4439`, `_skips_bare_rst_fin_4453`, `_skips_pure_tcp_syn`,
+and `_skips_icmp_echo_request`.

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -753,22 +753,26 @@ pub(super) fn cluster_peer_return_fast_path(
     {
         return None;
     }
-    // #4439: this fast path may fire ONLY for packets that are provably
+    // #4439/#4414: this fast path may fire ONLY for packets that are provably
     // RETURN traffic — the reverse direction of a flow the active owner
-    // already policy/NAT-validated. Every other protocol carries a
-    // packet-level flow-initiator marker we exclude above: TCP excludes the
-    // initial SYN, ICMP excludes the echo REQUEST. UDP has NO such marker —
-    // any UDP datagram can open a new flow, and there is no "non-initiating
-    // UDP" form. A session-less UDP packet reaching here (a real established
-    // UDP reply is served by the synced session in
-    // `resolve_flow_session_decision` before this point) is therefore a NEW
-    // forward flow, NOT return traffic. Fast-pathing it built a NAT-less,
-    // reverse-keyed session for a forward flow — the source-NAT that a new
-    // outbound flow requires was skipped (NAT bypass) and the owner recorded
-    // the flow in the wrong direction (session-state corruption). Fall
-    // through instead so the RG owner runs the packet through its normal
-    // forward decision: source-NAT applied and a FORWARD session installed.
-    if meta.protocol == PROTO_UDP {
+    // already policy/NAT-validated. That requires a protocol with a
+    // packet-level flow-initiator marker so the initiating (forward) form can
+    // be told apart from the return form, and the initiator is excluded above:
+    // TCP excludes the initial SYN (and the bare RST/FIN, #4453); ICMP/ICMPv6
+    // exclude the echo REQUEST. Every OTHER protocol — UDP (#4439), and
+    // likewise ESP/AH/GRE/SCTP/OSPF/… (the #4414 residual) — has NO such
+    // marker: any datagram can open a new flow, and there is no
+    // "non-initiating" form to key on. A session-less packet of one of these
+    // protocols reaching here (a real established reply is served by the
+    // synced session in `resolve_flow_session_decision` before this point) is
+    // therefore a NEW forward flow, NOT return traffic. Fast-pathing it built
+    // a NAT-less, reverse-keyed session for a forward flow — the source-NAT a
+    // new outbound flow requires was skipped (NAT bypass) and the owner
+    // recorded the flow in the wrong direction (session-state corruption).
+    // Refuse every protocol that is not TCP or ICMP/ICMPv6 so it falls through
+    // to the RG owner's normal forward decision: source-NAT applied and a
+    // FORWARD session installed. (Subsumes the #4439 UDP-only guard.)
+    if !matches!(meta.protocol, PROTO_TCP | PROTO_ICMP | PROTO_ICMPV6) {
         return None;
     }
 

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -844,6 +844,66 @@ fn cluster_peer_return_fast_path_skips_udp_new_flow_4439() {
 }
 
 #[test]
+fn cluster_peer_return_fast_path_skips_markerless_proto_new_flow_4414() {
+    // #4414: the #4439 UDP exclusion left every OTHER markerless protocol
+    // (ESP, AH, GRE, SCTP, OSPF, …) still adopted by the fast path. Like UDP
+    // they have no packet-level flow-initiator marker, so a session-less
+    // datagram of one of these protocols arriving on the fabric is a NEW
+    // forward flow, not return traffic. It MUST fall through to the owner's
+    // forward decision — source-NAT applied + a FORWARD session installed —
+    // not be fast-pathed into a NAT-less `SessionOrigin::ReverseFlow` seed
+    // (NAT bypass + reverse-seed session corruption). This is the exact
+    // `_allows_sfmix_to_lan_reply` / `_skips_udp_new_flow_4439` setup (whose
+    // target resolves to a ForwardCandidate) with the protocol flipped to each
+    // markerless L4: on revert the fast path returns Some (the reverse seed /
+    // NAT bypass), so asserting None is RED-on-revert. The ICMP-reply test
+    // proves the legitimate return-traffic fast path is preserved.
+    let mut state = build_forwarding_state(&native_gre_pbr_snapshot(true));
+    state.fabrics.push(FabricLink {
+        parent_ifindex: 4,
+        overlay_ifindex: 104,
+        peer_addr: IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2)),
+        peer_mac: [0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee],
+        local_mac: [0x02, 0xbf, 0x72, 0xff, 0x00, 0x01],
+        up: true,
+    });
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+    dynamic_neighbors.insert(
+        (5, IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102))),
+        NeighborEntry {
+            mac: [0xde, 0xad, 0xbe, 0xef, 0x00, 0x01],
+        },
+    );
+    for proto in [
+        crate::ip_proto::PROTO_ESP,
+        crate::ip_proto::PROTO_AH,
+        crate::ip_proto::PROTO_GRE,
+        crate::ip_proto::PROTO_SCTP,
+        crate::ip_proto::PROTO_OSPF,
+    ] {
+        let meta = UserspaceDpMeta {
+            ingress_ifindex: 4,
+            protocol: proto,
+            l4_offset: 0,
+            ..UserspaceDpMeta::default()
+        };
+        let packet_frame = [0u8];
+        assert!(
+            cluster_peer_return_fast_path(
+                &state,
+                &dynamic_neighbors,
+                &packet_frame,
+                meta,
+                Some(TEST_SFMIX_ZONE_ID),
+                IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
+            )
+            .is_none(),
+            "markerless proto {proto} must not fast-path a NAT-less reverse seed"
+        );
+    }
+}
+
+#[test]
 fn cluster_peer_return_fast_path_skips_bare_rst_fin_4453() {
     // #4453: a bare TCP RST/FIN (closing flags, no SYN) arriving on the
     // fabric is a session-less phantom-closing packet with no return value —


### PR DESCRIPTION
## Summary

`cluster_peer_return_fast_path` (`userspace-dp/src/afxdp/forwarding/mod.rs`) fires ONLY on a session MISS and builds a NAT-less (`NatDecision::default()`), reverse-keyed (`SessionOrigin::ReverseFlow`) seed, so it must fire only for **provably-RETURN** traffic. #4439 excluded UDP and #4453 excluded the bare TCP RST/FIN, but the guard stayed an enumerated **deny-list** that left every OTHER markerless L4 (ESP, AH, GRE, SCTP, OSPF, and any protocol that is neither TCP nor ICMP/ICMPv6) still adopted.

A NEW forward flow of such a protocol that ingressed the locally-**HAInactive** node was fabric-redirected to the RG owner (which forwards the original pre-NAT frame — `apply_nat_on_fabric` stays `false`, deferring NAT to the owner). On the owner the packet is a session miss and the fast path adopted it as return traffic, causing:

1. **NAT bypass** — the reverse seed carried `NatDecision::default()` and the redirecting node applied no NAT, so the source-NAT a new outbound flow requires was applied by *neither* node (internal source IP/port on the wire).
2. **Session-state corruption** — the owner installed a **reverse-keyed** session for what was actually a forward flow.

Both failures share one root cause: a non-return flow taking the return fast path. Confirmed 2× (opus-review-171 M-3 / ps-review-017 P7).

## Fix (option B — the principled generalization, not the literal `apply_nat_on_fabric=true`)

Replaced the `meta.protocol == PROTO_UDP` guard with a positive allow-list:

```rust
if !matches!(meta.protocol, PROTO_TCP | PROTO_ICMP | PROTO_ICMPV6) {
    return None;
}
```

TCP and ICMP/ICMPv6 are the only protocols with a distinguishable initiator form (TCP SYN + bare RST/FIN excluded above; ICMP echo-request excluded above), so the surviving admitted set is exactly the provably-return forms. Every markerless protocol now falls through to the owner's normal forward decision, which applies source-NAT and installs a FORWARD session — closing **both** the NAT bypass and the reverse-seed corruption in one change (same root cause).

The issue's literal fix A (`apply_nat_on_fabric=true` for new fabric-redirected flows) was rejected: it would double-NAT with the owner (the exact opus-171 M-3 double-NAT concern) and leave the reverse-seed corruption unfixed.

Legitimate fabric-forward for an established synced session is untouched — it is served by `resolve_flow_session_decision` (synced session + #2120 standby retention) before this session-less fast path, so it is a session HIT.

## Validation

- New RED-on-revert test `cluster_peer_return_fast_path_skips_markerless_proto_new_flow_4414` (ESP / AH / GRE / SCTP / OSPF → `None`). Verified it returns `Some` (adopts the reverse seed) with the UDP-only guard restored, `None` with the fix. Preserved siblings (`_allows_sfmix_to_lan_reply`, `_skips_udp_new_flow_4439`, `_skips_bare_rst_fin_4453`, `_skips_pure_tcp_syn`, `_skips_icmp_echo_request`) still pass.
- Full `userspace-dp` cargo suite `--release --test-threads=1` green: 3673 main-binary tests + 54 + 8 + 22 + 1, **0 failed**.
- Docs: `docs/fabric-cross-chassis-fwd.md` new #4414 section completing the flow-initiator-exclusion invariant as a positive allow-list.

## ⚠️ Pre-merge gate

Fabric/HA change — **`make test-failover` REQUIRED before merge** (session sync across a failover with a fabric-redirected NAT flow). Not run in this PR.

Closes #4414

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi