### PR TITLE
flowexport: bridge dead Packets-dropped / NAT-alloc-fail flow counters (#4477)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -39560,3 +39560,58 @@ top.
 - **File(s)**: userspace-dp/src/afxdp/forwarding/mod.rs,
   userspace-dp/src/afxdp/forwarding/tests.rs, docs/fabric-cross-chassis-fwd.md,
   _Log.md
+
+## 2026-07-07 — #4477 (opus-172 H-4): bridge dead Packets-dropped / NAT-alloc-fail flow-stat counters
+
+- **Timestamp**: 2026-07-07T16:40Z
+- **Action**: `show security flow statistics` "Packets dropped"
+  (`GlobalCtrDrops`, idx 2) and "NAT allocation failures"
+  (`GlobalCtrNATAllocFail`, idx 7) were dead counters — the userspace
+  counter bridge `syncBPFCountersLocked` never wrote either index, so
+  `ReadGlobalCounter` returned a clean `(0, nil)` (the #3345
+  `ErrCounterNotPopulated` disclosure never fired) and the CLI, gRPC,
+  REST (`drops` / `nat_alloc_fails`), and Prometheus (`xpf_drops_total` /
+  `xpf_nat_alloc_fails_total`) surfaces printed a false, always-0 value —
+  security telemetry blind during an attack (observability lie). Fix is
+  MIXED (Rust exposes the count + Go bridges it): the Rust helper now
+  tallies each source-NAT allocation failure at the single
+  `record_source_nat_failure` chokepoint (every `SourceNatLookup::
+  Unavailable` funnels there — missing/empty/invalid/exhausted pool,
+  wrong family, non-first fragment on a port-translating rule; the packet
+  is dropped) into a new per-worker batch counter `nat_alloc_fail`,
+  flushed to `BindingLiveState.nat_alloc_fail`, snapshotted, copied onto
+  the wire `BindingStatus.nat_alloc_fail` (new serde field
+  `#[serde(rename="nat_alloc_fail", default)]`, Go `omitempty`). The Go
+  manager sums it across bindings and pushes the per-poll delta into
+  `GlobalCtrNATAllocFail`, and folds it — with policy denies, screen
+  drops, and host-inbound denies — into the aggregate "Packets dropped"
+  figure (`userspaceCounterSnapshot.totalDrops()`) pushed into
+  `GlobalCtrDrops` (a total whose breakdown is exactly the four rows
+  rendered beneath it), mirroring the host-inbound/NAT64/per-screen-reason
+  plumbing. Once bridged the counters carry real values, so the #3345
+  disclosure correctly stays silent for them. Wire fixture regenerated
+  (one new `nat_alloc_fail` key in `binding_status`); the
+  `wire_invariant_default_specimens` cross-language contract test passes.
+  RED-on-revert: Go `TestSyncBPFCountersPushesDropAndNATAllocFail`
+  (idx 2 → 60, idx 7 → 24; both snap to 0 if either delta is reverted) +
+  the extended `sumBindingCounters` sum/totalDrops asserts; Rust
+  `nat_alloc_fail_flushes_and_snapshots` (batch→flush→live→snapshot).
+  Validation: FULL cargo SERIAL green (3674 unit + 54+8+22+1 integration,
+  0 failed); `go test ./pkg/dataplane/... ./pkg/api/... ./pkg/grpcapi/...
+  ./pkg/cli/...` green. Dataplane counter change — a live smoke (a real
+  NAT-pool exhaustion / policy-deny flood shows a non-zero "Packets
+  dropped" / "NAT allocation failures") is a nice-to-have, not run here.
+- **File(s)**: userspace-dp/src/afxdp/mod.rs,
+  userspace-dp/src/afxdp/poll_descriptor/nat_exception.rs,
+  userspace-dp/src/afxdp/umem/mod.rs,
+  userspace-dp/src/afxdp/umem/snapshot.rs,
+  userspace-dp/src/afxdp/worker/mod.rs,
+  userspace-dp/src/afxdp/coordinator/refresh_bindings.rs,
+  userspace-dp/src/afxdp/coordinator/reconcile/reset.rs,
+  userspace-dp/src/protocol/binding.rs,
+  userspace-dp/tests/fixtures/protocol_wire_v1.json,
+  userspace-dp/src/afxdp/tests.rs,
+  pkg/dataplane/userspace/protocol.go,
+  pkg/dataplane/userspace/manager_ha.go,
+  pkg/dataplane/userspace/manager_test.go,
+  docs/junos-cli-reference.md, _Log.md

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -409,6 +409,27 @@ From zone: guest, To zone: lan
     labeled Prometheus series `xpf_screen_drops_by_reason_total{reason=...}`
     exposes the breakdown for alerting; the aggregate `xpf_screen_drops_total`
     is unchanged.
+  - **Packets-dropped / NAT-allocation-failure accounting (#4477):** the
+    `Packets dropped` (`dataplane.GlobalCtrDrops`) and `NAT allocation failures`
+    (`dataplane.GlobalCtrNATAllocFail`) rows of `show security flow statistics`
+    were dead counters — the userspace counter bridge never wrote either index,
+    so `ReadGlobalCounter` returned a clean `(0, nil)` (the #3345
+    `ErrCounterNotPopulated` disclosure never fired) and the CLI, gRPC, REST
+    (`drops` / `nat_alloc_fails`), and Prometheus (`xpf_drops_total` /
+    `xpf_nat_alloc_fails_total`) surfaces printed a false, always-0 value even
+    while the firewall was actively dropping traffic under attack. The Rust
+    helper now counts each source-NAT allocation failure per worker at the single
+    `record_source_nat_failure` chokepoint (`BindingStatus.nat_alloc_fail` — a
+    rule matched but no translated mapping could be allocated: missing/empty/
+    invalid/exhausted pool, wrong family, or a non-first fragment on a
+    port-translating rule; the packet is dropped). The Go manager sums it across
+    bindings and pushes the per-poll delta into `GlobalCtrNATAllocFail`, and
+    folds it — together with policy denies, screen/IDS drops, and host-inbound
+    denies — into the aggregate `Packets dropped` figure pushed into
+    `GlobalCtrDrops` (a total whose breakdown is exactly the four rows rendered
+    beneath it), mirroring the host-inbound / NAT64 / per-screen-reason plumbing.
+    Once bridged the counters carry real values, so the #3345 disclosure
+    correctly stays silent for them.
   - **Token validation (#3200):** `host-inbound-traffic system-services
     <tok>` / `protocols <tok>` is now validated at commit against the
     recognized-token SSOT (`pkg/config/host_inbound_tokens.go`:

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -680,6 +680,22 @@ type userspaceCounterSnapshot struct {
 	snatPackets       uint64
 	dnatPackets       uint64
 	nat64Translations uint64
+	// #4477: source-NAT allocation failures, summed across bindings. Pushed
+	// into dataplane.GlobalCtrNATAllocFail; also a term of the aggregate
+	// "Packets dropped" total pushed into dataplane.GlobalCtrDrops.
+	natAllocFail uint64
+}
+
+// totalDrops (#4477) is the aggregate "Packets dropped" figure surfaced by
+// GlobalCtrDrops. It sums the firewall's enforcement/discard drops — policy
+// denies, screen/IDS drops, host-inbound admission denies, and source-NAT
+// allocation failures. These are exactly the four breakdown lines rendered
+// beneath "Packets dropped" in `show security flow statistics`, so the
+// aggregate equals the sum of its parts (a total-with-breakdown, not a
+// double count into any single reason's own index). Before #4477 GlobalCtrDrops
+// was never written and printed a false, always-0 value.
+func (s userspaceCounterSnapshot) totalDrops() uint64 {
+	return s.policyDenied + s.screenDrops + s.hostInboundDenied + s.natAllocFail
 }
 
 // sumBindingCounters aggregates counters across all bindings in a status response.
@@ -708,6 +724,7 @@ func sumBindingCounters(status *ProcessStatus) userspaceCounterSnapshot {
 		s.snatPackets += b.SNATPackets
 		s.dnatPackets += b.DNATPackets
 		s.nat64Translations += b.Nat64Translations
+		s.natAllocFail += b.NatAllocFail
 	}
 	return s
 }
@@ -734,6 +751,16 @@ func (m *Manager) syncBPFCountersLocked(status *ProcessStatus) {
 		{dataplane.GlobalCtrTxPackets, safeDelta(cur.txPackets, prev.txPackets)},
 		{dataplane.GlobalCtrSessionsNew, safeDelta(cur.sessionCreates, prev.sessionCreates)},
 		{dataplane.GlobalCtrSessionsClosed, safeDelta(cur.sessionExpires, prev.sessionExpires)},
+		// #4477: bridge the aggregate "Packets dropped" total (policy deny +
+		// screen + host-inbound deny + NAT-alloc-fail) into GlobalCtrDrops and
+		// source-NAT allocation failures into GlobalCtrNATAllocFail. Both
+		// indices were never written before #4477 — ReadGlobalCounter returned a
+		// clean (0, nil) so `show security flow statistics` ("Packets dropped" /
+		// "NAT allocation failures"), REST, Prometheus, and the CLI printed a
+		// false 0 with no #3345 ErrCounterNotPopulated disclosure. Bridging real
+		// deltas populates them so the disclosure correctly stays silent.
+		{dataplane.GlobalCtrDrops, safeDelta(cur.totalDrops(), prev.totalDrops())},
+		{dataplane.GlobalCtrNATAllocFail, safeDelta(cur.natAllocFail, prev.natAllocFail)},
 		{dataplane.GlobalCtrPolicyDeny, safeDelta(cur.policyDenied, prev.policyDenied)},
 		// #3326: surface host-inbound admission denies into the counter the CLI,
 		// gRPC status, REST, and Prometheus collector already read

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -5946,6 +5946,7 @@ func TestSumBindingCounters(t *testing.T) {
 				SNATPackets:         20,
 				DNATPackets:         15,
 				Nat64Translations:   9,
+				NatAllocFail:        8,
 			},
 			{
 				RXPackets:                200,
@@ -5964,6 +5965,7 @@ func TestSumBindingCounters(t *testing.T) {
 				SNATPackets:              40,
 				DNATPackets:              30,
 				Nat64Translations:        21,
+				NatAllocFail:             16,
 			},
 		},
 	}
@@ -6017,6 +6019,18 @@ func TestSumBindingCounters(t *testing.T) {
 	// snat/dnat and pushed into GlobalCtrNAT64Xlate by syncBPFCountersLocked.
 	if s.nat64Translations != 30 {
 		t.Fatalf("nat64Translations = %d, want 30", s.nat64Translations)
+	}
+	// #4477: source-NAT allocation failures aggregate across bindings and are
+	// pushed into GlobalCtrNATAllocFail by syncBPFCountersLocked. RED if the
+	// `s.natAllocFail += b.NatAllocFail` line is reverted.
+	if s.natAllocFail != 24 {
+		t.Fatalf("natAllocFail = %d, want 24", s.natAllocFail)
+	}
+	// #4477: totalDrops() is the aggregate "Packets dropped" figure pushed into
+	// GlobalCtrDrops: policyDenied(10) + screenDrops(6) + hostInboundDenied(20) +
+	// natAllocFail(24) = 60.
+	if s.totalDrops() != 60 {
+		t.Fatalf("totalDrops() = %d, want 60", s.totalDrops())
 	}
 	// #3343: per-reason screen drops sum element-wise across bindings. RED if
 	// the `s.screenReasonDrops[i] += b.ScreenReasonDrops[i]` loop is reverted
@@ -6080,6 +6094,74 @@ func TestSyncBPFCountersPushesPerScreenReason(t *testing.T) {
 	// push (the helper bumps the aggregate separately via b.ScreenDrops).
 	if got := m.bpfShim.ReadUserspaceCounterOffset(dataplane.GlobalCtrScreenDrops); got != 0 {
 		t.Fatalf("aggregate GlobalCtrScreenDrops = %d, want 0 (per-reason push must not touch it)", got)
+	}
+}
+
+// TestSyncBPFCountersPushesDropAndNATAllocFail is the #4477 fail-on-revert
+// guard: the userspace helper reports source-NAT allocation failures in
+// BindingStatus.NatAllocFail, and syncBPFCountersLocked must push their delta
+// into dataplane.GlobalCtrNATAllocFail AND fold them (with policy deny + screen
+// + host-inbound deny) into the aggregate dataplane.GlobalCtrDrops. Before
+// #4477 neither index was ever written, so `show security flow statistics`
+// ("Packets dropped" / "NAT allocation failures"), REST, Prometheus, and the
+// CLI printed a permanent, false 0. Reverting either delta drops the counter
+// back to 0 and fails the ReadUserspaceCounterOffset assertions below.
+func TestSyncBPFCountersPushesDropAndNATAllocFail(t *testing.T) {
+	m := New()
+	status := &ProcessStatus{
+		Bindings: []BindingStatus{
+			{
+				Slot:                     0,
+				PolicyDeniedPackets:      3,
+				ScreenDrops:              2,
+				HostInboundDeniedPackets: 6,
+				NatAllocFail:             8,
+			},
+			{
+				Slot:                     1,
+				PolicyDeniedPackets:      7,
+				ScreenDrops:              4,
+				HostInboundDeniedPackets: 14,
+				NatAllocFail:             16,
+			},
+		},
+	}
+
+	m.mu.Lock()
+	m.syncBPFCountersLocked(status)
+	m.mu.Unlock()
+
+	// GlobalCtrNATAllocFail = sum of NatAllocFail across bindings (8 + 16 = 24).
+	if got := m.bpfShim.ReadUserspaceCounterOffset(dataplane.GlobalCtrNATAllocFail); got != 24 {
+		t.Fatalf("GlobalCtrNATAllocFail = %d, want 24 (NAT-alloc-fail bridge reverted?)", got)
+	}
+	// GlobalCtrDrops = policyDeny(10) + screen(6) + host-inbound(20) + NAT-alloc(24) = 60.
+	if got := m.bpfShim.ReadUserspaceCounterOffset(dataplane.GlobalCtrDrops); got != 60 {
+		t.Fatalf("GlobalCtrDrops = %d, want 60 (aggregate-drops bridge reverted?)", got)
+	}
+
+	// A second poll with the same cumulative totals produces a zero delta, so
+	// the counters must stay put (no double count).
+	m.mu.Lock()
+	m.syncBPFCountersLocked(status)
+	m.mu.Unlock()
+	if got := m.bpfShim.ReadUserspaceCounterOffset(dataplane.GlobalCtrNATAllocFail); got != 24 {
+		t.Fatalf("GlobalCtrNATAllocFail after idempotent re-poll = %d, want 24", got)
+	}
+	if got := m.bpfShim.ReadUserspaceCounterOffset(dataplane.GlobalCtrDrops); got != 60 {
+		t.Fatalf("GlobalCtrDrops after idempotent re-poll = %d, want 60", got)
+	}
+
+	// A subsequent poll with higher cumulative totals advances by the delta.
+	status.Bindings[0].NatAllocFail = 18 // +10 over the prior 8
+	m.mu.Lock()
+	m.syncBPFCountersLocked(status)
+	m.mu.Unlock()
+	if got := m.bpfShim.ReadUserspaceCounterOffset(dataplane.GlobalCtrNATAllocFail); got != 34 {
+		t.Fatalf("GlobalCtrNATAllocFail after +10 = %d, want 34", got)
+	}
+	if got := m.bpfShim.ReadUserspaceCounterOffset(dataplane.GlobalCtrDrops); got != 70 {
+		t.Fatalf("GlobalCtrDrops after +10 = %d, want 70", got)
 	}
 }
 

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -2462,7 +2462,18 @@ type BindingStatus struct {
 	// could be allocated (empty/exhausted pool), so the synthetic IPv6
 	// destination was dropped rather than route-looked-up as IPv6. omitempty +
 	// Rust serde `default` keep the same cross-version wire safety.
-	Nat64NoSourcePool              uint64 `json:"nat64_no_source_pool,omitempty"`
+	Nat64NoSourcePool uint64 `json:"nat64_no_source_pool,omitempty"`
+	// #4477: source-NAT allocation failures (a source-NAT rule matched but no
+	// translated mapping could be allocated — missing/empty/invalid/exhausted
+	// pool, wrong family, or a non-first fragment on a port-translating rule);
+	// the packet is dropped. Summed across bindings and pushed into
+	// dataplane.GlobalCtrNATAllocFail (and, with the other enforcement drops,
+	// GlobalCtrDrops) by syncBPFCountersLocked so `show security flow
+	// statistics` ("NAT allocation failures" / "Packets dropped"), REST
+	// (nat_alloc_fails / drops), and Prometheus (xpf_nat_alloc_fails_total /
+	// xpf_drops_total) stop reading a permanent 0. omitempty + the Rust serde
+	// `default` keep cross-version wire safety (an older helper omits it → 0).
+	NatAllocFail                   uint64 `json:"nat_alloc_fail,omitempty"`
 	SlowPathPackets                uint64 `json:"slow_path_packets,omitempty"`
 	SlowPathBytes                  uint64 `json:"slow_path_bytes,omitempty"`
 	SlowPathLocalDeliveryPackets   uint64 `json:"slow_path_local_delivery_packets,omitempty"`

--- a/userspace-dp/src/afxdp/coordinator/reconcile/reset.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/reset.rs
@@ -49,6 +49,7 @@ pub(super) fn reset_binding_counters(bindings: &mut [BindingStatus]) {
         binding.dnat_packets = 0;
         binding.nat64_translations = 0;
         binding.nat64_no_source_pool = 0;
+        binding.nat_alloc_fail = 0;
         binding.slow_path_packets = 0;
         binding.slow_path_bytes = 0;
         binding.slow_path_local_delivery_packets = 0;

--- a/userspace-dp/src/afxdp/coordinator/refresh_bindings.rs
+++ b/userspace-dp/src/afxdp/coordinator/refresh_bindings.rs
@@ -133,6 +133,7 @@ fn copy_live_snapshot(binding: &mut BindingStatus, snap: BindingLiveSnapshot) {
     binding.dnat_packets = snap.dnat_packets;
     binding.nat64_translations = snap.nat64_translations;
     binding.nat64_no_source_pool = snap.nat64_no_source_pool;
+    binding.nat_alloc_fail = snap.nat_alloc_fail;
     binding.slow_path_packets = snap.slow_path_packets;
     binding.slow_path_bytes = snap.slow_path_bytes;
     binding.slow_path_local_delivery_packets = snap.slow_path_local_delivery_packets;
@@ -330,6 +331,7 @@ fn zero_unbound_slot(binding: &mut BindingStatus) {
     binding.dnat_packets = 0;
     binding.nat64_translations = 0;
     binding.nat64_no_source_pool = 0;
+    binding.nat_alloc_fail = 0;
     binding.slow_path_packets = 0;
     binding.slow_path_bytes = 0;
     binding.slow_path_local_delivery_packets = 0;

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -509,6 +509,16 @@ pub(in crate::afxdp) struct BatchCounters {
     // IPv6 (the pre-fix fail-open). Flushed to
     // BindingLiveState.nat64_no_source_pool.
     nat64_no_source_pool: u64,
+    // #4477: source-NAT allocation failures — a source-NAT rule matched but no
+    // translated mapping could be allocated (missing/empty/invalid pool,
+    // exhausted port allocator, wrong family, or a non-first fragment on a
+    // port-translating rule). The packet is dropped. Bumped at the cold
+    // `record_source_nat_failure` site and flushed to
+    // BindingLiveState.nat_alloc_fail; the Go control plane bridges it into the
+    // `GlobalCtrNATAllocFail` counter that `show security flow statistics`
+    // ("NAT allocation failures"), the REST/Prometheus surfaces, and the CLI
+    // read — dead-counter fix for the observability lie.
+    nat_alloc_fail: u64,
     // #1187: 8 disposition-path counters added to eliminate per-packet
     // MESI thrash on BindingLiveState atomics during DDoS / config-
     // reload windows. See docs/pr/1187-telemetry-double-buffer/plan.md
@@ -681,6 +691,12 @@ impl BatchCounters {
             live.nat64_no_source_pool
                 .fetch_add(self.nat64_no_source_pool, Ordering::Relaxed);
             self.nat64_no_source_pool = 0;
+        }
+        // #4477: source-NAT allocation-failure tally.
+        if self.nat_alloc_fail != 0 {
+            live.nat_alloc_fail
+                .fetch_add(self.nat_alloc_fail, Ordering::Relaxed);
+            self.nat_alloc_fail = 0;
         }
         // #1187 disposition-path counters
         if self.screen_drops != 0 {

--- a/userspace-dp/src/afxdp/poll_descriptor/nat_exception.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/nat_exception.rs
@@ -105,6 +105,11 @@ pub(super) fn record_source_nat_failure(
 ) {
     telemetry.counters.touched = true;
     telemetry.counters.exception_packets += 1;
+    // #4477: this is the single source-NAT allocation-failure chokepoint (every
+    // `SourceNatLookup::Unavailable` funnels here). Tally it so the dead
+    // `GlobalCtrNATAllocFail` counter surfaced by `show security flow
+    // statistics`, REST, Prometheus, and the CLI reports a real, non-zero value.
+    telemetry.counters.nat_alloc_fail += 1;
     let mut debug = ResolutionDebug::from_flow(meta.ingress_ifindex as i32, flow);
     debug.from_zone = Some(from_zone_id);
     debug.to_zone = Some(to_zone_id);

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -7354,6 +7354,44 @@ fn disposition_counters_hot_screen_drops_accumulate_in_batch() {
     );
 }
 
+// #4477: source-NAT allocation failures accumulate in the per-poll batch, flush
+// into the live atomic, and surface through snapshot() so the Go control plane
+// can bridge them into GlobalCtrNATAllocFail / GlobalCtrDrops. FAIL-ON-REVERT:
+// dropping the nat_alloc_fail flush block (or the snapshot field) leaves the
+// live atomic / snapshot at 0 and the dead-counter observability lie returns.
+#[test]
+fn nat_alloc_fail_flushes_and_snapshots() {
+    let live = BindingLiveState::new();
+    let mut counters = BatchCounters::default();
+
+    for _ in 0..4 {
+        counters.touched = true;
+        counters.nat_alloc_fail += 1;
+    }
+    assert_eq!(counters.nat_alloc_fail, 4);
+    assert_eq!(
+        live.nat_alloc_fail.load(Ordering::Relaxed),
+        0,
+        "live must be 0 before flush"
+    );
+
+    counters.flush(&live);
+    assert_eq!(counters.nat_alloc_fail, 0, "batch must clear after flush");
+    assert_eq!(
+        live.nat_alloc_fail.load(Ordering::Relaxed),
+        4,
+        "live must receive the count after flush"
+    );
+
+    // snapshot() must surface the live value so refresh_bindings can copy it
+    // onto the wire BindingStatus.
+    assert_eq!(
+        live.snapshot().nat_alloc_fail,
+        4,
+        "snapshot must surface nat_alloc_fail for the wire bridge"
+    );
+}
+
 // #3343: record_screen_drop bumps BOTH the aggregate and the matching
 // per-reason ordinal, and the per-reason slots flush element-wise into the
 // live atomics + snapshot. FAIL-ON-REVERT: dropping the per-reason bump in

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -448,6 +448,12 @@ pub(in crate::afxdp) struct BindingLiveState {
     /// flags a misconfigured/exhausted source pool that would otherwise have
     /// leaked the synthetic IPv6 destination upstream (the pre-fix fail-open).
     pub(super) nat64_no_source_pool: AtomicU64,
+    /// #4477: cumulative source-NAT allocation failures (rule matched, no
+    /// translated mapping could be allocated — missing/empty/invalid/exhausted
+    /// pool, wrong family, or a non-first fragment on a port-translating rule).
+    /// The packet is dropped. Bridged into `GlobalCtrNATAllocFail` (Go side) so
+    /// the `NAT allocation failures` operator counter is no longer a dead 0.
+    pub(super) nat_alloc_fail: AtomicU64,
     pub(super) slow_path_packets: AtomicU64,
     pub(super) slow_path_bytes: AtomicU64,
     pub(super) slow_path_local_delivery_packets: AtomicU64,
@@ -854,6 +860,7 @@ impl BindingLiveState {
             dnat_packets: AtomicU64::new(0),
             nat64_translations: AtomicU64::new(0),
             nat64_no_source_pool: AtomicU64::new(0),
+            nat_alloc_fail: AtomicU64::new(0),
             slow_path_packets: AtomicU64::new(0),
             slow_path_bytes: AtomicU64::new(0),
             slow_path_local_delivery_packets: AtomicU64::new(0),

--- a/userspace-dp/src/afxdp/umem/snapshot.rs
+++ b/userspace-dp/src/afxdp/umem/snapshot.rs
@@ -134,6 +134,7 @@ impl BindingLiveState {
             dnat_packets: self.dnat_packets.load(Ordering::Relaxed),
             nat64_translations: self.nat64_translations.load(Ordering::Relaxed),
             nat64_no_source_pool: self.nat64_no_source_pool.load(Ordering::Relaxed),
+            nat_alloc_fail: self.nat_alloc_fail.load(Ordering::Relaxed),
             slow_path_packets: self.slow_path_packets.load(Ordering::Relaxed),
             slow_path_bytes: self.slow_path_bytes.load(Ordering::Relaxed),
             slow_path_local_delivery_packets: self

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -1412,6 +1412,9 @@ pub(crate) struct BindingLiveSnapshot {
     /// #2291: cumulative fail-closed NAT64 drops (prefix matched, no source
     /// pool available) snapshotted from BindingLiveState.
     pub(crate) nat64_no_source_pool: u64,
+    /// #4477: cumulative source-NAT allocation failures snapshotted from
+    /// BindingLiveState. Bridged into `GlobalCtrNATAllocFail` (Go side).
+    pub(crate) nat_alloc_fail: u64,
     pub(crate) slow_path_packets: u64,
     pub(crate) slow_path_bytes: u64,
     pub(crate) slow_path_local_delivery_packets: u64,

--- a/userspace-dp/src/protocol/binding.rs
+++ b/userspace-dp/src/protocol/binding.rs
@@ -512,6 +512,14 @@ pub(crate) struct BindingStatus {
     // keeps the same cross-version wire safety as nat64_translations above.
     #[serde(rename = "nat64_no_source_pool", default)]
     pub nat64_no_source_pool: u64,
+    /// #4477: source-NAT allocation failures (rule matched, no translated
+    /// mapping could be allocated → packet dropped). `default` keeps the same
+    /// cross-version wire safety as the siblings above (an older helper omits it
+    /// and Go/Rust read 0). The Go control plane bridges this into the
+    /// `GlobalCtrNATAllocFail` global counter (`NAT allocation failures`) and,
+    /// with the other enforcement drops, into `GlobalCtrDrops`.
+    #[serde(rename = "nat_alloc_fail", default)]
+    pub nat_alloc_fail: u64,
     #[serde(rename = "slow_path_packets", default)]
     pub slow_path_packets: u64,
     #[serde(rename = "slow_path_bytes", default)]

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -115,6 +115,7 @@
     "mirrored_packets": 0,
     "nat64_no_source_pool": 0,
     "nat64_translations": 0,
+    "nat_alloc_fail": 0,
     "neighbor_miss_packets": 0,
     "next_table_packets": 0,
     "outstanding_tx": 0,


### PR DESCRIPTION
## Summary

Closes #4477 (opus-172 H-4, observability lie, HIGH).

`show security flow statistics` **"Packets dropped"** (`GlobalCtrDrops`, idx 2) and **"NAT allocation failures"** (`GlobalCtrNATAllocFail`, idx 7) were **dead counters**. The userspace counter bridge `syncBPFCountersLocked` never wrote either index, so `ReadGlobalCounter` returned a clean `(0, nil)`, the #3345 `ErrCounterNotPopulated` disclosure never fired, and the CLI, gRPC, REST (`drops` / `nat_alloc_fails`), and Prometheus (`xpf_drops_total` / `xpf_nat_alloc_fails_total`) surfaces all printed a false, always-0 value — security telemetry blind while the firewall was actively dropping traffic under attack.

## Fix (MIXED — Rust exposes, Go bridges)

**Rust (`userspace-dp`):** tally each source-NAT allocation failure at the single `record_source_nat_failure` chokepoint (every `SourceNatLookup::Unavailable` funnels there — missing/empty/invalid/exhausted pool, wrong family, or a non-first fragment on a port-translating rule; the packet is dropped). New per-worker batch counter `nat_alloc_fail` flushes to `BindingLiveState.nat_alloc_fail`, is snapshotted, and is copied onto the wire `BindingStatus` via a new serde field (`#[serde(rename = "nat_alloc_fail", default)]`). Reset/refresh zeroing paths updated so a rebind cannot leave a stale value.

**Go:** sum `nat_alloc_fail` across bindings and push its per-poll delta into `GlobalCtrNATAllocFail`; fold it — with policy denies, screen drops, and host-inbound denies — into the aggregate **"Packets dropped"** figure (`userspaceCounterSnapshot.totalDrops()`) pushed into `GlobalCtrDrops`. That aggregate's breakdown is exactly the four rows rendered beneath "Packets dropped", so the total equals the sum of its parts (a total-with-breakdown, not a double count into any single reason's own index). Once bridged the counters carry real values, so the #3345 disclosure correctly stays silent for them.

Wire-additive and cross-version safe (Go `omitempty` + Rust serde `default`). The committed `protocol_wire_v1.json` fixture is regenerated with the one new `nat_alloc_fail` key; the cross-language `wire_invariant_default_specimens` test passes.

## Validation

- **RED-on-revert (Go)** `TestSyncBPFCountersPushesDropAndNATAllocFail`: asserts `GlobalCtrDrops == 60` / `GlobalCtrNATAllocFail == 24` after a poll, idempotent on zero-delta re-poll, advances by the delta; both snap to 0 if either bridge line is reverted (verified). `sumBindingCounters` test extended with sum + `totalDrops()` asserts.
- **RED-on-revert (Rust)** `nat_alloc_fail_flushes_and_snapshots`: batch → flush → live atomic → `snapshot()`.
- **FULL cargo** `cargo test --release -- --test-threads=1`: 3674 unit + 54 + 8 + 22 + 1 integration, **0 failed**.
- `go test ./pkg/dataplane/... ./pkg/api/... ./pkg/grpcapi/... ./pkg/cli/...` green; `go vet` clean.

A live smoke (real NAT-pool exhaustion / policy-deny flood producing non-zero "Packets dropped" / "NAT allocation failures") is a nice-to-have and was not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi