### PR TITLE
screen: per-boot random seed for the SYN-flood count-min sketch (#4382)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -39560,3 +39560,35 @@ top.
 - **File(s)**: userspace-dp/src/afxdp/forwarding/mod.rs,
   userspace-dp/src/afxdp/forwarding/tests.rs, docs/fabric-cross-chassis-fwd.md,
   _Log.md
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4382 — screen SYN-flood count-min sketch: fold a per-boot
+  random seed into the cell hash so the per-source mapping is not offline-
+  predictable (targeted false-positive throttling). VERIFY-FIRST on
+  origin/master b7cc73f61: `SynRateSketch::cell_index`/`cell_index_ip_port`
+  (userspace-dp/src/screen/syn_rate.rs) hashed only the public compile-time
+  `ROW_SEEDS[row]` + IP octets via `FxHasher` — no per-boot secret. Because the
+  seeds+hash are public and deterministic, an off-box attacker within a
+  BCP38-permitted range could precompute which source IPs land in a chosen
+  victim's `ROWS` cells and drive them over `source-threshold`, throttling the
+  victim's legit SYNs. FIX: added a `seed: u64` field to `SynRateSketch`, drawn
+  once at construction from `hot_hash_seed::hot_path_hash_seed()` (the #2364
+  per-process secret that the session indices / flow-cache set index / ECMP /
+  CoS SFQ hashes already use — one audited getrandom entropy path), and folded
+  it into BOTH `cell_index` and `cell_index_ip_port` alongside `ROW_SEEDS[row]`
+  (`h.write_u64(self.seed)`). Row independence still comes from `ROW_SEEDS`; the
+  per-boot seed adds secrecy — the source→cell mapping is unknowable offline and
+  reshuffles on every restart. Counting behaviour (thresholds, AND/MIN trip,
+  detection) is unchanged: the seed only changes WHICH cell a key maps to, and
+  it is stable for the process lifetime so a key maps to a stable cell across
+  its window. Split `with_cols` into a seed-parameterized `with_cols_seeded`
+  core (mirrors `FlowCache::set_index_seeded`) so tests can pin a seed;
+  production draws the process-global seed. Tests: `cell_mapping_stable_
+  within_one_seed` (intra-seed stability), `cell_mapping_depends_on_per_boot_
+  seed` (RED-on-revert: no seed diverges across 4095 seeds when the fold is
+  removed), `single_source_flood_trips_under_pinned_seed` (detection
+  preserved). RED-on-revert VERIFIED: removing the `cell_index` fold makes
+  `cell_mapping_depends_on_per_boot_seed` FAIL while stability stays green.
+- **File(s)**: userspace-dp/src/screen/syn_rate.rs,
+  docs/syn-cookie-flood-protection.md, docs/userspace-dataplane-architecture.md,
+  _Log.md

--- a/docs/syn-cookie-flood-protection.md
+++ b/docs/syn-cookie-flood-protection.md
@@ -190,7 +190,25 @@ implemented as the AND of the per-row results, never OR/MAX). No eviction means
 no Hot-Set-Lockout / Cold-Start-Eviction-Race starvation (a victim is always
 tracked and its cells only increase within the sliding window). Collisions can
 only OVER-count (fail-closed: never a false-negative; the only error is a
-false-positive bounded by `~(load)^ROWS`). Each sketch is allocated PER
+false-positive bounded by `~(load)^ROWS`).
+
+**Per-boot seeded cell hash (#4382).** The `ROWS` row hashes fold in a per-boot
+secret seed (`SynRateSketch::seed`, drawn once from
+`hot_hash_seed::hot_path_hash_seed` — the same #2364 per-process secret the
+session indices / flow-cache set index / ECMP / CoS SFQ hashes use) ALONGSIDE
+the public per-row `ROW_SEEDS`. The row constants give row INDEPENDENCE; the
+per-boot seed gives SECRECY. Without it, `cell_index`/`cell_index_ip_port` would
+be a public deterministic function of the source IP, so an off-box attacker
+(within their own BCP38-permitted range) could precompute which source IPs land
+in a chosen victim's four cells and drive them over `source-threshold` to
+throttle the victim's legitimate SYNs — a targeted false-positive. Folding the
+per-boot seed makes the source→cell mapping unknowable offline and reshuffles it
+on every restart, so no colliding source-IP set can be constructed. The seed is
+stable for the process lifetime (a key maps to a stable cell across its whole
+window — counting behaviour, thresholds, and detection are unchanged) and is
+node-local (never wire/HA-synced; each node reseeds independently).
+
+Each sketch is allocated PER
 THRESHOLD, not per zone: the per-destination sketch only when
 `destination-threshold > 0`, the per-source sketch only when
 `source-threshold > 0` (`update_profiles`, `screen/mod.rs` ~333/345), and each

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -524,8 +524,11 @@ non-cryptographic hash keyed by a per-boot secret).
 > (`SessionKey`-keyed `key_to_handle` / `nat_reverse_index` /
 > `forward_wire_index` / `reverse_translated_index`, plus the per-IP
 > `session_limit_{src,dst}_counts`), the flow-cache set index
-> (`FlowCache::set_index`), and the fabric queue hash
-> (`worker::fabric_queue_hash`) — fold in a per-process secret seed
+> (`FlowCache::set_index`), the fabric queue hash
+> (`worker::fabric_queue_hash`), and the screen SYN/ICMP/UDP-flood
+> per-source/per-destination count-min sketch cell index
+> (`SynRateSketch::cell_index` / `cell_index_ip_port`, #4382) — fold in a
+> per-process secret seed
 > (`crate::hot_hash_seed::hot_path_hash_seed`, drawn once at first use via
 > the same `getrandom(2)` + CLOCK_MONOTONIC/pid/stack fallback +
 > never-zero path that backs the CoS SFQ seed). The seed is:

--- a/userspace-dp/src/screen/syn_rate.rs
+++ b/userspace-dp/src/screen/syn_rate.rs
@@ -101,10 +101,17 @@ const _: () = assert!(DST_COLS.is_power_of_two() && SRC_COLS.is_power_of_two());
 /// Independent per-row seeds. Distinct values so the `ROWS` rows hash
 /// independently — same-seed rows would collapse the sketch to a single row and
 /// inflate the false-positive rate (it never affects the fail-closed bias).
-/// Fixed (not random) so they are deterministic across workers and easy to
-/// reason about in tests; the seeded hash still resists hash-flooding because
-/// the attacker cannot choose source IPs to collide a specific victim's cells
-/// across all rows without also tripping the aggregate.
+///
+/// These fixed per-row constants provide row INDEPENDENCE, not secrecy: they are
+/// public, so on their own they do NOT stop an off-box attacker from precomputing
+/// which source IPs land in a chosen victim's `ROWS` cells and driving those cells
+/// over `source-threshold` to throttle a victim's legit SYNs (a targeted
+/// false-positive, #4382). Secrecy comes from the PER-BOOT `SynRateSketch::seed`
+/// (drawn once from `hot_hash_seed::hot_path_hash_seed`, #2364) that
+/// `cell_index`/`cell_index_ip_port` fold in ALONGSIDE `ROW_SEEDS[row]`: the
+/// source→cell mapping is unknowable offline and reshuffles on every restart, so
+/// the attacker cannot construct a colliding IP set — exactly as the flow
+/// cache / session map / ECMP / CoS hashes already do.
 const ROW_SEEDS: [u64; ROWS] = [
     0x9E37_79B9_7F4A_7C15,
     0xC2B2_AE3D_27D4_EB4F,
@@ -119,10 +126,26 @@ pub(super) struct SynRateSketch {
     rows: Box<[Box<[RateCounter]>]>,
     /// Index mask (`cols - 1`); `cols` is a power of two.
     mask: usize,
+    /// Per-boot secret folded into the cell hash alongside `ROW_SEEDS[row]`
+    /// (#4382). Drawn once from `hot_hash_seed::hot_path_hash_seed()` at
+    /// construction and stable for the process lifetime, so a given key maps to
+    /// a stable cell across its whole window (counting behaviour unchanged) while
+    /// the key→cell mapping is unpredictable off-box and reshuffles on every
+    /// restart — the attacker cannot precompute a colliding source-IP set.
+    seed: u64,
 }
 
 impl SynRateSketch {
     fn with_cols(cols: usize) -> Self {
+        Self::with_cols_seeded(cols, crate::hot_hash_seed::hot_path_hash_seed())
+    }
+
+    /// Seed-parameterized core of `with_cols`. Split out so adversarial tests can
+    /// pin the seed and assert (a) intra-seed stability of the key→cell mapping
+    /// and (b) cross-seed reshuffling — mirroring `FlowCache::set_index_seeded`.
+    /// Production always calls through `with_cols`, which supplies the per-boot
+    /// process seed.
+    fn with_cols_seeded(cols: usize, seed: u64) -> Self {
         debug_assert!(
             cols.is_power_of_two(),
             "SynRateSketch cols must be a power of two"
@@ -134,6 +157,7 @@ impl SynRateSketch {
         Self {
             rows,
             mask: cols - 1,
+            seed,
         }
     }
 
@@ -153,6 +177,7 @@ impl SynRateSketch {
     fn cell_index(&self, row: usize, ip: &IpAddr) -> usize {
         let mut h = FxHasher::default();
         h.write_u64(ROW_SEEDS[row]);
+        h.write_u64(self.seed);
         match ip {
             IpAddr::V4(a) => h.write(&a.octets()),
             IpAddr::V6(a) => h.write(&a.octets()),
@@ -187,6 +212,7 @@ impl SynRateSketch {
     fn cell_index_ip_port(&self, row: usize, ip: &IpAddr, port: u16) -> usize {
         let mut h = FxHasher::default();
         h.write_u64(ROW_SEEDS[row]);
+        h.write_u64(self.seed);
         match ip {
             IpAddr::V4(a) => h.write(&a.octets()),
             IpAddr::V6(a) => h.write(&a.octets()),
@@ -335,11 +361,12 @@ mod tests {
 
     /// Independent per-row seeds: a single IP does not map to the same column in
     /// every row (which would collapse the sketch to one effective row). Not a
-    /// hard guarantee for every IP, but the fixed seeds make this deterministic
-    /// for a sampled address.
+    /// hard guarantee for every IP; a pinned seed makes this deterministic for a
+    /// sampled address (production additionally folds the per-boot seed in — row
+    /// independence still comes from the per-row `ROW_SEEDS`).
     #[test]
     fn rows_use_independent_seeds() {
-        let s = SynRateSketch::for_src();
+        let s = SynRateSketch::with_cols_seeded(SRC_COLS, 0x1234_5678_9ABC_DEF0);
         let idx = s.cell_indices(&v4(203, 0, 113, 7));
         let all_same = idx.iter().all(|&c| c == idx[0]);
         assert!(
@@ -384,5 +411,93 @@ mod tests {
             tripped,
             "a flooded destination trips per-dest regardless of source spread"
         );
+    }
+
+    /// A fixed set of source IPs used to compare cell mappings across seeds.
+    fn sample_ips(n: u32) -> Vec<IpAddr> {
+        (0..n)
+            .map(|i| v4(203, 0, (i >> 8) as u8, (i & 0xff) as u8))
+            .collect()
+    }
+
+    /// The `ROWS` cell indices each IP maps to, under a pinned seed. Equal
+    /// vectors ⇒ identical key→cell mapping.
+    fn cell_distribution(seed: u64, ips: &[IpAddr]) -> Vec<[usize; ROWS]> {
+        let s = SynRateSketch::with_cols_seeded(SRC_COLS, seed);
+        ips.iter().map(|ip| s.cell_indices(ip)).collect()
+    }
+
+    /// #4382 (counting consistency): the key→cell mapping MUST be stable for a
+    /// fixed seed, or a key's SYNs scatter across cells within its own window and
+    /// the count-min counters never accumulate. Repeat under one pinned seed and
+    /// demand byte-identical mappings.
+    #[test]
+    fn cell_mapping_stable_within_one_seed() {
+        let ips = sample_ips(64);
+        let seed = 0x0123_4567_89AB_CDEF;
+        let first = cell_distribution(seed, &ips);
+        for _ in 0..64 {
+            assert_eq!(
+                first,
+                cell_distribution(seed, &ips),
+                "cell mapping must be stable for a fixed seed"
+            );
+        }
+    }
+
+    /// #4382 (hardening / RED-on-revert): the source→cell mapping must NOT be an
+    /// externally probeable pure function of the source IP. Two different
+    /// per-boot seeds must produce a DIFFERENT cell distribution for the SAME
+    /// attacker IP set, so an off-box attacker cannot precompute a colliding
+    /// source-IP set to drive a victim's cells over `source-threshold`. With the
+    /// per-boot `seed` dropped from `cell_index` (the reverted state) the
+    /// distribution is seed-independent and NO seed diverges → this FAILS.
+    #[test]
+    fn cell_mapping_depends_on_per_boot_seed() {
+        let ips = sample_ips(128);
+        let ref_seed = 0xA5A5_0000_C3C3_FFFFu64;
+        let reference = cell_distribution(ref_seed, &ips);
+        // Under a uniform seeded hash an entire 128-element distribution matching
+        // the reference by accident is vanishingly unlikely; one differing seed
+        // is essentially immediate. Bound the loop so a truly seed-independent
+        // hash (the reverted state) FAILS rather than hangs.
+        let mut diverged = false;
+        for seed in 1u64..4096u64 {
+            if seed == ref_seed {
+                continue;
+            }
+            if cell_distribution(seed, &ips) != reference {
+                diverged = true;
+                break;
+            }
+        }
+        assert!(
+            diverged,
+            "sketch cell distribution did not change across seeds — cell_index \
+             is per-boot-seed-independent (#4382 regression)"
+        );
+    }
+
+    /// #4382 (detection preserved): the per-boot seed changes only WHICH cells a
+    /// key maps to, never the counting. A real single-source flood still crosses
+    /// `source-threshold` under an arbitrary pinned seed — same thresholds, same
+    /// trip behaviour as `single_key_trips_above_threshold`.
+    #[test]
+    fn single_source_flood_trips_under_pinned_seed() {
+        for &seed in &[1u64, 0xDEAD_BEEF_CAFE_F00D, u64::MAX] {
+            let mut s = SynRateSketch::with_cols_seeded(SRC_COLS, seed);
+            let attacker = v4(198, 51, 100, 7);
+            const T: u32 = 5;
+            for _ in 0..T {
+                assert!(
+                    !s.increment(&attacker, 100, T),
+                    "first {T} SYNs admitted (seed {seed:#x})"
+                );
+            }
+            assert!(
+                s.increment(&attacker, 100, T),
+                "over-threshold SYN trips (seed {seed:#x})"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #4382.

The per-source/per-destination SYN-flood count-min sketch (`userspace-dp/src/screen/syn_rate.rs`) mapped a key to its `ROWS` cells using only the **public compile-time `ROW_SEEDS` constants** + IP octets, hashed with `FxHasher`. The seeds and hash are public and deterministic, so `cell_index`/`cell_index_ip_port` were an externally probeable pure function of the source IP. An off-box attacker, using only crafted colliding source IPs from their own BCP38-permitted range, could precompute which addresses land in a chosen victim's four cells and drive those cells over `source-threshold` to **throttle the victim's legitimate SYNs** (a targeted false-positive). The per-source sketch is consulted whenever `source-threshold > 0` and the zone is not SYN-cookie active, so the sub-aggregate regime was uncovered.

## Fix

Add a per-boot secret to the cell hash — exactly the #2364 hot-path hash hardening already applied to the session indices, flow-cache set index, ECMP, and CoS SFQ hashes:

- New `seed: u64` field on `SynRateSketch`, drawn once at construction from `hot_hash_seed::hot_path_hash_seed()` (the same audited `getrandom(2)` + `CLOCK_MONOTONIC`/pid/stack fallback + never-zero entropy path).
- Folded into **both** `cell_index` and `cell_index_ip_port` alongside the per-row `ROW_SEEDS[row]` (`h.write_u64(self.seed)`).
- Row constants still give the `ROWS` their independence; the per-boot seed adds **secrecy** — the source→cell mapping is unknowable offline and reshuffles on every restart.

**Counting behaviour is unchanged.** The seed only changes *which* cell a key maps to; it is process-global and stable for the process lifetime, so a key maps to a stable cell across its whole sliding window and the thresholds, AND/MIN trip rule, and single-source detection are identical. `with_cols` is split into a seed-parameterized `with_cols_seeded` core (mirrors `FlowCache::set_index_seeded`) so tests can pin a seed.

## Multi-row handling

Both hash rows already differ via the distinct `ROW_SEEDS[row]`; the single per-boot `seed` is folded into every row's hash, keeping the rows independent while making the whole mapping per-boot secret.

## Tests

- `cell_mapping_stable_within_one_seed` — key→cell mapping stable for a fixed seed (counting consistency).
- `cell_mapping_depends_on_per_boot_seed` — two seeds produce different cell distributions for the same attacker IP set; **RED on revert** (with the seed fold removed, no seed diverges across 4095 seeds → FAILS).
- `single_source_flood_trips_under_pinned_seed` — a real single-source flood still crosses `source-threshold` under an arbitrary pinned seed (**detection preserved**).
- `rows_use_independent_seeds` now pins a seed so it stays deterministic.

## Validation

- Full `userspace-dp` cargo suite (`cargo test --release -- --test-threads=1`): **3676 passed / 0 failed / 2 ignored**; the 10 `screen::syn_rate` tests pass.
- **RED-on-revert verified**: removing the `cell_index` seed fold makes `cell_mapping_depends_on_per_boot_seed` FAIL while the stability test stays green.
- rustfmt-clean (changed lines only).

## Docs

- `docs/syn-cookie-flood-protection.md` — substrate section gains a per-boot seeded cell-hash note.
- `docs/userspace-dataplane-architecture.md` — the #2364 hardening note lists the sketch cell index as a seeded site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi