### PR TITLE
config/nat: read the full source-NAT pool address token stream (#4521)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,31 @@
+## 2026-07-07 — #4521: source-NAT pool `address [ a b c ]` bracket-list no longer truncates to the first IP
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4521 (ps-022 R-02, #2419-class silent-truncation). A source-NAT
+  pool `address` value carries every IP the SNAT allocator may draw from, but
+  `address` is UNMODELED under a source pool in the schema, so SetPath's
+  unmodeled-leaf path collapses a bracket list onto ONE node key
+  (`Keys=["address","a","b","c"]`). `compileNATSource` read only `prop.Keys[1]`
+  (and the range branch required `Keys[2]=="to"`), so a discrete bracket list
+  `set security nat source pool P address [ a b c ]` silently kept ONLY the
+  first IP → the pool shrank to one address → premature source-port exhaustion
+  under load. Added `appendPoolAddresses` (compiler_nat.go), which walks the
+  full `prop.Keys[1:]` token stream (plus the block `prop.Children`) and
+  expands any `<low> to <high>` sub-range in place — the #2419 dual-shape read
+  pattern mirroring `firewallMatchValues`. Now every shape accumulates every
+  address: discrete `set` lines, bracket list, range, mixed `[ a b to c ]`,
+  and the hierarchical `address { ... }` block. Ride-along R-04: added
+  `ch == '@'` to `isIdentChar`/`IsIdentRune` (lexer.go) for unquoted
+  URL/userinfo (`user@host`) completeness — no live failure, the quoted form
+  already worked.
+- **File(s)**: pkg/config/compiler_nat.go, pkg/config/lexer.go,
+  pkg/config/compiler_nat_source_pool_address_4521_test.go,
+  docs/config-schema.md, _Log.md
+- **Validation**: `go test ./pkg/config/...` green; go build ./..., gofmt,
+  go vet clean. RED-on-revert proven: reverting to the `Keys[1]`-only read
+  fails the bracket-list test (1 of 3) and the mixed-range test (1 of 4),
+  while discrete/range/block stay green (those shapes always worked).
+
 ## 2026-07-07 — #4418: close scan/sweep slow-scan evasion on the cleanup 5-min cap AND the source-saturation eviction
 
 - **Timestamp**: 2026-07-07

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -111,8 +111,9 @@ the values on `child.Keys[1:]` (with the hierarchical-block-with-children
 shape still possible for nested forms), a compiler reading a multi-value leaf
 MUST read BOTH `child.Keys[1:]` AND `child.Children` and ACCUMULATE — never
 read only `child.Keys[1]`. `firewallMatchValues` (`compiler_firewall.go`) is
-the canonical helper; `parseDNATPortList` (`compiler_nat.go`) and
-`descriptionText` (`compiler_security.go`) parse the unified single-leaf
+the canonical helper; `parseDNATPortList` and `appendPoolAddresses`
+(`compiler_nat.go`, the latter the source-NAT-pool `address` reader, #4521)
+and `descriptionText` (`compiler_security.go`) parse the unified single-leaf
 shape directly off the node keys. `parseZoneList` (`compiler_nat.go`, the
 static/source/destination-NAT `from`/`to` zone reader) and the WireGuard
 peer `allowed-ips` reader (`parseTunnelWireguardPeer`,
@@ -389,6 +390,25 @@ nat.go`) expand the union — one DNAT entry per protocol, one app term per
 resolved application (an application-set still expands to its members). Coverage:
 `compiler_nat_match_multivalue_3431_test.go` (both AST shapes, all axes) and
 `nat_match_multivalue_3431_test.go` (snapshot expansion).
+
+**A source-NAT pool `address` is multi-value (#4521).** A source pool's
+`address` value carries EVERY IP the SNAT allocator may draw from, in four
+shapes: discrete `set` lines (one `address <ip>;` per IP), a bracket list
+`address [ a b c ]`, a range `address <low> to <high>`, and a hierarchical
+block `address { a; b; c }`. `address` under a source pool is UNMODELED in the
+schema (`schema_security.go` pool children are port / persistent-nat /
+port-overloading-factor / routing-instance), so SetPath's unmodeled-leaf path
+collapses the whole bracket list onto ONE node key (`Keys=["address","a","b",
+"c"]`) — the classic #2419 collapse. Before #4521 `compileNATSource`
+(`compiler_nat.go`) read only `prop.Keys[1]` (and the range branch required
+`Keys[2]=="to"`), so a discrete bracket list with no `to` silently kept ONLY
+the first IP → the pool shrank to one address → premature source-port
+exhaustion under load. The fix reads the FULL `prop.Keys[1:]` token stream
+(plus the block `prop.Children`) via `appendPoolAddresses`, expanding any
+`<low> to <high>` sub-range in place — the #2419 dual-shape read pattern
+(mirroring `firewallMatchValues`), so every shape (discrete, bracket, range,
+mixed `[ a b to c ]`, block) accumulates every address. Coverage:
+`compiler_nat_source_pool_address_4521_test.go`.
 
 **Security host-inbound and session-log surfaces are multi-value (#3703).** The
 same #2419 collapse class recurred on four security leaves that #2419 never

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -1146,6 +1146,38 @@ func applyStaticNATFromScope(rs *StaticNATRuleSet, s natMatchScope) {
 	}
 }
 
+// appendPoolAddresses parses a source-NAT pool `address` token stream and
+// appends every IP onto pool.Addresses, expanding any `<low> to <high>`
+// sub-range in place. The token stream is the multi-value form of the
+// #2419 dual-AST-shape class: a bracket list `[ a b c ]`, a range
+// `a to b`, or a mix `a b to c d` all collapse onto one Keys slice, and a
+// hierarchical block passes each child node's Keys. Reading the FULL token
+// stream (not just the first token) is the #4521 fix — the previous code
+// read only Keys[1], truncating a bracket list to its first IP.
+func appendPoolAddresses(pool *NATPool, tokens []string) error {
+	for i := 0; i < len(tokens); {
+		tok := tokens[i]
+		if tok == "" {
+			i++
+			continue
+		}
+		// Range: "<low> to <high>" — three consecutive tokens with a
+		// following high address present.
+		if i+2 < len(tokens) && tokens[i+1] == "to" {
+			expanded, err := expandAddressRange(tok, tokens[i+2])
+			if err != nil {
+				return fmt.Errorf("pool %q address range: %w", pool.Name, err)
+			}
+			pool.Addresses = append(pool.Addresses, expanded...)
+			i += 3
+			continue
+		}
+		pool.Addresses = append(pool.Addresses, tok)
+		i++
+	}
+	return nil
+}
+
 // expandAddressRange expands "low/mask to high/mask" into individual IP strings.
 // Both low and high must be /32 CIDRs. Max 256 IPs.
 func expandAddressRange(low, high string) ([]string, error) {
@@ -1342,30 +1374,42 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 		for _, prop := range inst.node.Children {
 			switch prop.Name() {
 			case "address":
-				// Check for address range: "addr1 to addr2"
-				if len(prop.Keys) >= 4 && prop.Keys[2] == "to" {
-					expanded, err := expandAddressRange(prop.Keys[1], prop.Keys[3])
-					if err != nil {
-						return fmt.Errorf("pool %q address range: %w", pool.Name, err)
-					}
-					pool.Addresses = append(pool.Addresses, expanded...)
-				} else if len(prop.Keys) >= 2 && prop.Keys[1] != "" {
-					// Inline value form ("address <prefix>;" / flat set).
-					// Deliberately NOT nodeVal: its Children[0] fallback
-					// would double-append the block form, whose children
-					// are walked below (#1808).
-					pool.Addresses = append(pool.Addresses, prop.Keys[1])
+				// A source pool `address` value carries EVERY IP the
+				// SNAT allocator may draw from. It arrives in four
+				// shapes (#2419 dual-AST-shape class — mirror
+				// firewallMatchValues):
+				//
+				//   discrete set lines : one `address <ip>;` prop per IP
+				//   bracket list       : `address [ a b c ]` — UNMODELED
+				//                        in schema (schema_security.go
+				//                        pool children), so SetPath's
+				//                        unmodeled-leaf path collapses
+				//                        every trailing token onto ONE
+				//                        node: Keys=["address","a","b","c"]
+				//   range              : `address <low> to <high>`
+				//                        Keys=["address",low,"to",high]
+				//   hierarchical block : `address { a; b to c; }` — one
+				//                        child node per entry
+				//                        (Keys=["a"] / ["b","to","c"])
+				//
+				// Before #4521 the inline branch read only prop.Keys[1]
+				// and the range branch required Keys[2]=="to", so a
+				// bracket list silently kept ONLY the first IP → the
+				// pool shrank to one address → premature source-port
+				// exhaustion. Read the whole Keys[1:] token stream
+				// (plus the block children), expanding any `<low> to
+				// <high>` sub-range in place. Keys[1:] and Children are
+				// mutually exclusive per the #2419 pattern: the inline
+				// form has no children and the block form has no inline
+				// Keys value, so reading both cannot double-append.
+				if err := appendPoolAddresses(pool, prop.Keys[1:]); err != nil {
+					return err
 				}
-				// Also handle children for hierarchical syntax
 				for _, addrChild := range prop.Children {
-					if len(addrChild.Keys) >= 3 && addrChild.Keys[1] == "to" {
-						expanded, err := expandAddressRange(addrChild.Keys[0], addrChild.Keys[2])
-						if err != nil {
-							return fmt.Errorf("pool %q address range: %w", pool.Name, err)
-						}
-						pool.Addresses = append(pool.Addresses, expanded...)
-					} else if addrChild.IsLeaf && len(addrChild.Keys) >= 1 {
-						pool.Addresses = append(pool.Addresses, addrChild.Keys[0])
+					// A block child's own Keys are the address token
+					// stream (Keys[0] is the IP, not the property name).
+					if err := appendPoolAddresses(pool, addrChild.Keys); err != nil {
+						return err
 					}
 				}
 			case "port":

--- a/pkg/config/compiler_nat_source_pool_address_4521_test.go
+++ b/pkg/config/compiler_nat_source_pool_address_4521_test.go
@@ -1,0 +1,157 @@
+// #4521: a source-NAT pool `address [ a b c ]` in flat-set / bracket-list
+// form silently kept ONLY the first IP. `address` is UNMODELED under a source
+// pool in the schema, so SetPath's unmodeled-leaf path collapses every trailing
+// token onto ONE node (Keys=["address","a","b","c"]); the compiler read only
+// prop.Keys[1] (and the range branch required Keys[2]=="to"), so a discrete
+// bracket list with no `to` truncated to the first address → the SNAT pool
+// shrank to one IP → premature source-port exhaustion (#2419-class silent
+// truncation).
+//
+// The fix reads the WHOLE Keys[1:] token stream (plus the block children) via
+// appendPoolAddresses, expanding any `<low> to <high>` sub-range in place.
+// RED-on-revert:
+//   - bracket list `[ a b c ]` compiles 3 addresses [RED: only 1].
+//   - discrete `set` lines still compile 3/3.
+//   - a range `a to b` still expands correctly.
+//   - the hierarchical block `address { a; b; c }` shape is unaffected.
+//
+// Flat-set syntax is built via ParseSetCommand/SetPath (snatPoolTree), never
+// NewParser; the hierarchical block fixture uses NewParser (the correct tool
+// for block shapes).
+package config
+
+import "testing"
+
+func assertPoolAddrs4521(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("pool addresses = %v (len %d), want %v (len %d)", got, len(got), want, len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("pool address[%d] = %q, want %q (full got=%v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestSourceNATPoolAddressBracketList_4521 is the core RED-on-revert: a
+// bracket list must compile ALL three addresses. On revert (read only
+// prop.Keys[1]) the pool keeps only the first IP.
+func TestSourceNATPoolAddressBracketList_4521(t *testing.T) {
+	tree := snatPoolTree(t,
+		"set security nat source pool p1 address [ 203.0.113.1/32 203.0.113.2/32 203.0.113.3/32 ]")
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	pool := cfg.Security.NAT.SourcePools["p1"]
+	if pool == nil {
+		t.Fatalf("pool p1 missing")
+	}
+	assertPoolAddrs4521(t, pool.Addresses,
+		[]string{"203.0.113.1/32", "203.0.113.2/32", "203.0.113.3/32"})
+}
+
+// TestSourceNATPoolAddressDiscreteLines_4521: three discrete `set` lines still
+// yield 3/3 (the discrete form was already correct; guards against a
+// regression from the multi-value read).
+func TestSourceNATPoolAddressDiscreteLines_4521(t *testing.T) {
+	tree := snatPoolTree(t,
+		"set security nat source pool p1 address 203.0.113.1/32",
+		"set security nat source pool p1 address 203.0.113.2/32",
+		"set security nat source pool p1 address 203.0.113.3/32")
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	pool := cfg.Security.NAT.SourcePools["p1"]
+	if pool == nil {
+		t.Fatalf("pool p1 missing")
+	}
+	assertPoolAddrs4521(t, pool.Addresses,
+		[]string{"203.0.113.1/32", "203.0.113.2/32", "203.0.113.3/32"})
+}
+
+// TestSourceNATPoolAddressRange_4521: an `a to b` range still expands to every
+// IP in the (inclusive) span.
+func TestSourceNATPoolAddressRange_4521(t *testing.T) {
+	tree := snatPoolTree(t,
+		"set security nat source pool p1 address 203.0.113.1/32 to 203.0.113.3/32")
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	pool := cfg.Security.NAT.SourcePools["p1"]
+	if pool == nil {
+		t.Fatalf("pool p1 missing")
+	}
+	assertPoolAddrs4521(t, pool.Addresses,
+		[]string{"203.0.113.1/32", "203.0.113.2/32", "203.0.113.3/32"})
+}
+
+// TestSourceNATPoolAddressBracketMixedRange_4521: a bracket list may mix
+// discrete addresses and a `<low> to <high>` sub-range. `[ .1 .5 to .7 ]` →
+// .1 plus the .5-.7 span.
+func TestSourceNATPoolAddressBracketMixedRange_4521(t *testing.T) {
+	tree := snatPoolTree(t,
+		"set security nat source pool p1 address [ 203.0.113.1/32 203.0.113.5/32 to 203.0.113.7/32 ]")
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	pool := cfg.Security.NAT.SourcePools["p1"]
+	if pool == nil {
+		t.Fatalf("pool p1 missing")
+	}
+	assertPoolAddrs4521(t, pool.Addresses,
+		[]string{"203.0.113.1/32", "203.0.113.5/32", "203.0.113.6/32", "203.0.113.7/32"})
+}
+
+// TestSourceNATPoolAddressHierarchicalBlock_4521: the `address { a; b; c }`
+// block shape (parsed via NewParser — the correct tool for block shapes)
+// compiles every child address. This exercises the prop.Children path.
+func TestSourceNATPoolAddressHierarchicalBlock_4521(t *testing.T) {
+	const cfgText = `
+security {
+    nat {
+        source {
+            pool p1 {
+                address {
+                    203.0.113.1/32;
+                    203.0.113.2/32;
+                    203.0.113.3/32;
+                }
+            }
+            rule-set RS {
+                from zone trust;
+                to zone untrust;
+                rule R1 {
+                    match {
+                        source-address 10.0.0.0/24;
+                    }
+                    then {
+                        source-nat {
+                            pool p1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+`
+	tree, errs := NewParser(cfgText).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	pool := cfg.Security.NAT.SourcePools["p1"]
+	if pool == nil {
+		t.Fatalf("pool p1 missing")
+	}
+	assertPoolAddrs4521(t, pool.Addresses,
+		[]string{"203.0.113.1/32", "203.0.113.2/32", "203.0.113.3/32"})
+}

--- a/pkg/config/lexer.go
+++ b/pkg/config/lexer.go
@@ -282,10 +282,11 @@ func (l *Lexer) readIdentifier(line, col int) Token {
 
 // isIdentChar returns true if ch is valid in a Junos identifier.
 // Junos identifiers can contain letters, digits, hyphens, underscores,
-// dots, slashes, colons, asterisks, plus signs, percent signs, and angle
-// brackets.
+// dots, slashes, colons, asterisks, plus signs, percent signs, at signs,
+// and angle brackets.
 // This handles IP addresses (10.0.1.0/24), interface names (eth0.0),
-// wildcards (*), and group wildcards (<*>).
+// wildcards (*), group wildcards (<*>), and unquoted URLs / userinfo
+// (user@host — #4521 R-04).
 func isIdentChar(ch byte) bool {
 	return (ch >= 'a' && ch <= 'z') ||
 		(ch >= 'A' && ch <= 'Z') ||
@@ -293,7 +294,7 @@ func isIdentChar(ch byte) bool {
 		ch == '-' || ch == '_' || ch == '.' ||
 		ch == '/' || ch == ':' || ch == '*' || ch == '+' ||
 		ch == '%' || ch == '=' || ch == ',' ||
-		ch == '<' || ch == '>'
+		ch == '<' || ch == '>' || ch == '@'
 }
 
 // IsIdentRune is the rune version for use in tab completion.
@@ -302,5 +303,5 @@ func IsIdentRune(r rune) bool {
 		r == '-' || r == '_' || r == '.' ||
 		r == '/' || r == ':' || r == '*' || r == '+' ||
 		r == '%' || r == '=' || r == ',' ||
-		r == '<' || r == '>'
+		r == '<' || r == '>' || r == '@'
 }


### PR DESCRIPTION
Closes #4521

## Problem

A source-NAT pool `address` value carries every IP the SNAT allocator may draw from, but `address` is UNMODELED under a source pool in the schema (`schema_security.go` pool children = port / persistent-nat / port-overloading-factor / routing-instance). SetPath's unmodeled-leaf path therefore collapses a bracket list `address [ a b c ]` onto ONE node key: `Keys=["address","a","b","c"]` — the classic #2419 collapse.

`compileNATSource` (`compiler_nat.go`) read only `prop.Keys[1]`, and the range branch required `Keys[2]=="to"`, so a discrete bracket list with no `to` silently kept ONLY the first IP. The SNAT pool then shrank to a single address → premature source-port exhaustion under load (a #2419-class silent accept-and-truncate). Discrete `set` lines and the `a to b` range form already worked; the bug was bounded to the bracket-list shape.

## Fix

Add `appendPoolAddresses`, which walks the full `prop.Keys[1:]` token stream (plus the block `prop.Children`) and expands any `<low> to <high>` sub-range in place — the #2419 dual-shape read pattern mirroring `firewallMatchValues`. `Keys[1:]` and `Children` are mutually exclusive per that pattern (inline form has no children; block form has no inline Keys value), so reading both cannot double-append. Every shape now accumulates every address: discrete lines, bracket list, range, mixed `[ a b to c ]`, and the hierarchical `address { ... }` block.

Ride-along (ps-022 R-04): add `@` to `isIdentChar`/`IsIdentRune` so an unquoted URL / userinfo token (`user@host`) lexes as one identifier. No live failure — the quoted form already worked — but it closes an unquoted-value completeness gap.

## Validation

- `go test ./pkg/config/...` green; `go build`, `gofmt`, `go vet` clean.
- **RED-on-revert proven**: reverting to the `Keys[1]`-only read fails the bracket-list test (1 of 3) and the mixed-range test (1 of 4), while the discrete / range / block tests stay green (those shapes always worked).
- New coverage: `pkg/config/compiler_nat_source_pool_address_4521_test.go` (bracket list, discrete lines, range, mixed bracket+range, hierarchical block).
- Docs: `docs/config-schema.md` NAT multi-value note + canonical-helper list; `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi