### PR TITLE
cli: neutralize monitor traffic filter tcpdump option injection (#4524)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-07-07 — #4524 (ps-023 13-02, HIGH): neutralize `monitor traffic ... matching` tcpdump option injection
+
+- **Timestamp**: 2026-07-07T21:30Z
+- **Action**: `monitor traffic interface <if> matching <filter>` appended the
+  operator-supplied filter tokens to the root `tcpdump` argv with NO `--`
+  end-of-options separator (`buildMonitorTrafficArgv`, pkg/cli/cli_request.go).
+  The `matching` clause greedily absorbs every token up to the next keyword,
+  so `matching -w /etc/cron.d/x` or `matching -z <cmd>` reached tcpdump as the
+  `-w` (arbitrary file write) / `-z` (post-rotate command exec) OPTION under
+  glibc getopt argv permutation — escalating a control-level (not super-user)
+  login class to root file-write / command-exec past the capture-only RBAC
+  gate (PermControl, #4067), and violating the capture-only contract even for
+  super-user. Fixed by inserting an explicit `"--"` separator before the
+  filter tokens (mirroring the diagcmd ping/traceroute #2084 treatment) so
+  getopt stops scanning for options and every filter token is a pcap filter
+  EXPRESSION operand — an injected `-w`/`-z` becomes a libpcap compile error,
+  not a tcpdump option. Added defense-in-depth `validateMonitorFilter` +
+  `monitorFilterOptionToken` that reject any option-looking filter token (a
+  term starting with `-`, other than a bare `-`) up front with a clear error,
+  wired into `handleMonitorTraffic`. Legitimate pcap filters (`host X and port
+  N`, `tcp port 80`, `not arp`) are unaffected.
+- **Validation**: New `monitor_traffic_injection_4524_test.go` — `-w`/`-z`/
+  `-r`/`--postrotate-command` all land AFTER `--` (neutralized); RED on revert
+  of the `--` insertion (verified: injected tokens precede no separator);
+  `validateMonitorFilter` rejects option tokens and accepts legit filters;
+  legit multi-token filter survives intact after `--`. Updated the #4005
+  argv-shape test to expect the `--` separator. `go test ./pkg/cli/...` green,
+  `go build ./...`, gofmt clean.
+- **File(s)**: pkg/cli/cli_request.go, pkg/cli/monitor_traffic_injection_4524_test.go,
+  pkg/cli/monitor_traffic_filter_4005_test.go, docs/system-login.md, _Log.md
+
 ## 2026-07-07 — #4514 (ps-020 F5): enforce single-rate `then policer` on the userspace dataplane
 
 - **Timestamp**: 2026-07-07T20:00Z

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -169,6 +169,25 @@ matcher the dispatcher uses, so an abbreviated `monitor tr` is gated
 identically to the fully-spelled form and cannot bypass the gate. Other
 `monitor` subcommands and read-only `show` commands are unaffected.
 
+**Filter option-injection hardening — `monitor traffic ... matching` (#4524).**
+The `matching <filter>` clause greedily consumes every token up to the next
+grammar keyword and passes them to the root `tcpdump` capture. Without an
+end-of-options guard a filter such as `matching -w /etc/cron.d/x` or
+`matching -z <cmd>` reaches tcpdump as the `-w` (arbitrary file write) or `-z`
+(post-rotate command execution) **option** under glibc getopt argv
+permutation — escalating a control-level capture privilege to root
+file-write / command-exec, and violating the capture-only contract even for
+`super-user`. `buildMonitorTrafficArgv` (`pkg/cli/cli_request.go`) now inserts
+an explicit `--` end-of-options separator before the filter tokens (mirroring
+the diagcmd ping/traceroute #2084 treatment), so getopt stops scanning for
+options and every filter token is parsed as part of the pcap filter
+**expression** — an injected `-w`/`-z` becomes a filter operand that libpcap
+rejects at compile time rather than a tcpdump option. A defense-in-depth
+`validateMonitorFilter` check additionally rejects any option-looking filter
+token (a term beginning with `-`, other than a bare `-`) up front with a clear
+error. Legitimate pcap filters (`host 10.0.0.1 and port 22`, `tcp port 80`,
+`not arp`) are unaffected.
+
 **Secret redaction in `show configuration` (#4099).** The on-box interactive
 CLI config-render show paths — `show configuration` (hierarchical / `| display
 set` / `| display json` / `| display xml` / `| display inheritance`, including

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -564,19 +564,63 @@ func stripSurroundingQuotes(s string) string {
 
 // buildMonitorTrafficArgv assembles the tcpdump argv for a live capture.
 // The full filter expression is passed as trailing arguments exactly as
-// tcpdump/libpcap expects a filter (all tokens, verbatim).
+// tcpdump/libpcap expects a filter (all tokens, verbatim), but only AFTER
+// an explicit "--" end-of-options separator so no filter token can be
+// interpreted as a tcpdump option.
 func buildMonitorTrafficArgv(iface, filter, count string) []string {
 	cmdArgs := []string{"tcpdump", "-i", iface, "-n", "-l"}
 	if count != "0" {
 		cmdArgs = append(cmdArgs, "-c", count)
 	}
 	if filter != "" {
+		// Insert a "--" end-of-options separator before the operator-supplied
+		// filter (#4524), mirroring the diagcmd ping/traceroute #2084
+		// treatment. The `matching <filter>` clause greedily absorbs every
+		// token up to the next keyword, so without the separator a filter
+		// like `-w /etc/cron.d/x` or `-z <cmd>` reaches tcpdump as an OPTION
+		// under glibc getopt argv permutation — arbitrary root file-write
+		// (-w) or post-rotate command execution (-z) past the capture-only
+		// RBAC boundary. After "--", getopt stops scanning for options and
+		// tcpdump treats every remaining token as part of the pcap filter
+		// EXPRESSION, so an injected `-w`/`-z` becomes a (harmless) filter
+		// operand that libpcap rejects at compile time rather than an option.
+		//
 		// tcpdump accepts the filter expression as separate argv tokens;
 		// splitting on whitespace keeps a multi-token filter intact and
 		// matches how tcpdump joins its own trailing filter arguments.
+		cmdArgs = append(cmdArgs, "--")
 		cmdArgs = append(cmdArgs, strings.Fields(filter)...)
 	}
 	return cmdArgs
+}
+
+// monitorFilterOptionToken reports whether tok would be interpreted by
+// tcpdump/getopt as an option flag rather than as a pcap filter primitive.
+// A legitimate pcap filter expression never begins a term with an option
+// flag (`-w`, `-z`, `-r`, `--postrotate-command`, ...): filter primitives
+// are keywords (host/port/tcp/udp/net/...), addresses, numbers, boolean
+// operators (and/or/not) and parentheses. Such an option-looking token can
+// therefore only be an attempt to smuggle a tcpdump option past the
+// capture-only contract (#4524). A bare "-" (getopt's stdin sentinel, not
+// an option) is allowed so an arithmetic subtraction term is never falsely
+// rejected. This is defense-in-depth: the "--" separator in
+// buildMonitorTrafficArgv already neutralizes the option, but rejecting the
+// token here gives the operator a clear error instead of an opaque libpcap
+// compile failure.
+func monitorFilterOptionToken(tok string) bool {
+	return len(tok) > 1 && tok[0] == '-'
+}
+
+// validateMonitorFilter rejects a pcap filter that contains an
+// option-looking token (see monitorFilterOptionToken). Returns nil for an
+// empty filter or any legitimate pcap expression.
+func validateMonitorFilter(filter string) error {
+	for _, tok := range strings.Fields(filter) {
+		if monitorFilterOptionToken(tok) {
+			return fmt.Errorf("invalid filter token %q: a capture filter cannot contain a tcpdump option flag", tok)
+		}
+	}
+	return nil
 }
 
 // handleMonitorTraffic wraps tcpdump for live packet capture.
@@ -586,6 +630,14 @@ func (c *CLI) handleMonitorTraffic(args []string) error {
 	if iface == "" {
 		fmt.Println("usage: monitor traffic interface <name> [matching <filter>] [count <N>]")
 		return nil
+	}
+
+	// Defense-in-depth (#4524): reject a filter that smuggles a tcpdump
+	// option (`-w`, `-z`, ...) before it can reach the argv. The "--"
+	// separator in buildMonitorTrafficArgv already neutralizes it, but a
+	// clear rejection beats an opaque libpcap syntax error.
+	if err := validateMonitorFilter(filter); err != nil {
+		return err
 	}
 
 	// Resolve fabric IPVLAN overlays to physical parent (#136).

--- a/pkg/cli/monitor_traffic_filter_4005_test.go
+++ b/pkg/cli/monitor_traffic_filter_4005_test.go
@@ -121,20 +121,20 @@ func TestBuildMonitorTrafficArgvFilterReachesTcpdump(t *testing.T) {
 		[]string{"interface", "ge-0-0-0", "matching", `"tcp`, "port", `80"`, "count", "20"},
 	)
 	argv := buildMonitorTrafficArgv(iface, filter, count)
-	want := []string{"tcpdump", "-i", "ge-0-0-0", "-n", "-l", "-c", "20", "tcp", "port", "80"}
+	// The filter follows an explicit "--" end-of-options separator (#4524).
+	want := []string{"tcpdump", "-i", "ge-0-0-0", "-n", "-l", "-c", "20", "--", "tcp", "port", "80"}
 	if !reflect.DeepEqual(argv, want) {
 		t.Fatalf("buildMonitorTrafficArgv =\n  %v\nwant\n  %v", argv, want)
 	}
 
 	// The full filter expression must be present as a contiguous trailing
-	// run — assert the joined tail equals the intended BPF filter.
-	dashL := indexOf(argv, "-l")
-	tail := argv[dashL+1:]
-	// Skip the -c <count> option to isolate the filter tail.
-	if len(tail) >= 2 && tail[0] == "-c" {
-		tail = tail[2:]
+	// run after the "--" separator — assert the joined tail equals the
+	// intended BPF filter.
+	sep := indexOf(argv, "--")
+	if sep < 0 {
+		t.Fatalf("argv %v: missing \"--\" end-of-options separator", argv)
 	}
-	if got := strings.Join(tail, " "); got != "tcp port 80" {
+	if got := strings.Join(argv[sep+1:], " "); got != "tcp port 80" {
 		t.Fatalf("filter tail = %q, want %q", got, "tcp port 80")
 	}
 }

--- a/pkg/cli/monitor_traffic_injection_4524_test.go
+++ b/pkg/cli/monitor_traffic_injection_4524_test.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildMonitorTrafficArgvNeutralizesOptionInjection is the #4524
+// regression guard. `monitor traffic ... matching <filter>` greedily
+// absorbs every token after `matching` up to the next keyword, so an
+// operator (or a control-but-not-super-user login class) could type
+// `matching -w /tmp/x` or `matching -z /tmp/evil` and — absent a "--"
+// end-of-options separator — have tcpdump parse `-w`/`-z` as OPTIONS
+// under glibc getopt argv permutation: `-w` writes an arbitrary root-owned
+// file, `-z <cmd>` runs a post-rotate command. That escalates a
+// capture-only privilege to root file-write / command-exec.
+//
+// The fix inserts a "--" separator before the filter tokens (mirroring the
+// diagcmd ping/traceroute #2084 treatment). After "--", getopt stops
+// scanning for options, so every injected `-w`/`-z` token lands as a pcap
+// filter OPERAND, not a tcpdump option. This test goes RED on revert: with
+// the separator removed the `-w`/`-z` token precedes no "--" (or there is
+// no "--" at all), i.e. it is a live option.
+func TestBuildMonitorTrafficArgvNeutralizesOptionInjection(t *testing.T) {
+	tests := []struct {
+		name    string
+		matcher []string // tokens after `matching`
+		inject  string   // the smuggled option token that must be neutralized
+	}{
+		{
+			name:    "-w file write",
+			matcher: []string{"-w", "/tmp/x"},
+			inject:  "-w",
+		},
+		{
+			name:    "-z post-rotate command exec",
+			matcher: []string{"-z", "/tmp/evil.sh"},
+			inject:  "-z",
+		},
+		{
+			name:    "-r read-file option",
+			matcher: []string{"-r", "/etc/shadow"},
+			inject:  "-r",
+		},
+		{
+			name:    "long postrotate-command option",
+			matcher: []string{"--postrotate-command", "/tmp/evil.sh"},
+			inject:  "--postrotate-command",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := append([]string{"interface", "ge-0-0-0", "matching"}, tt.matcher...)
+			iface, filter, count := parseMonitorTrafficArgs(args)
+			argv := buildMonitorTrafficArgv(iface, filter, count)
+
+			sep := indexOf(argv, "--")
+			if sep < 0 {
+				t.Fatalf("argv %v: missing \"--\" end-of-options separator — injected %q reaches tcpdump as an OPTION", argv, tt.inject)
+			}
+			inj := indexOf(argv, tt.inject)
+			if inj < 0 {
+				t.Fatalf("argv %v: injected token %q missing entirely", argv, tt.inject)
+			}
+			if inj < sep {
+				t.Fatalf("argv %v: injected token %q at %d precedes the \"--\" separator at %d — it is parsed as a tcpdump OPTION, not a filter operand", argv, tt.inject, inj, sep)
+			}
+		})
+	}
+}
+
+// TestValidateMonitorFilterRejectsOptionTokens is the defense-in-depth
+// layer (#4524): an option-looking filter token is rejected outright with
+// a clear error, rather than reaching tcpdump (where it is already
+// neutralized by "--") and producing an opaque libpcap syntax error.
+func TestValidateMonitorFilterRejectsOptionTokens(t *testing.T) {
+	reject := []string{
+		"-w /tmp/x",
+		"-z /tmp/evil.sh",
+		"-r /etc/shadow",
+		"--postrotate-command /tmp/evil.sh",
+		"host 10.0.0.1 -w /tmp/x", // option smuggled after a valid primitive
+	}
+	for _, f := range reject {
+		if err := validateMonitorFilter(f); err == nil {
+			t.Errorf("validateMonitorFilter(%q) = nil, want error (option-looking token not rejected)", f)
+		}
+	}
+}
+
+// TestValidateMonitorFilterAcceptsLegitimateFilters ensures the hardening
+// does not break real pcap filters. These must all pass validation AND
+// survive the argv build as a contiguous filter tail after "--".
+func TestValidateMonitorFilterAcceptsLegitimateFilters(t *testing.T) {
+	accept := []string{
+		"host 10.0.0.1 and port 22",
+		"tcp port 80",
+		"not arp",
+		"udp and not port 53",
+		"icmp",
+		"host 2001:db8::1",
+		"", // no filter at all
+	}
+	for _, f := range accept {
+		if err := validateMonitorFilter(f); err != nil {
+			t.Errorf("validateMonitorFilter(%q) = %v, want nil (legitimate filter rejected)", f, err)
+		}
+	}
+}
+
+// TestBuildMonitorTrafficArgvLegitimateFilterAfterSeparator confirms a
+// legitimate multi-token filter is passed intact as the pcap expression
+// after the "--" separator (`host 10.0.0.1 and port 22`).
+func TestBuildMonitorTrafficArgvLegitimateFilterAfterSeparator(t *testing.T) {
+	args := []string{"interface", "ge-0-0-0", "matching", "host", "10.0.0.1", "and", "port", "22"}
+	iface, filter, count := parseMonitorTrafficArgs(args)
+	if err := validateMonitorFilter(filter); err != nil {
+		t.Fatalf("legitimate filter %q rejected: %v", filter, err)
+	}
+	argv := buildMonitorTrafficArgv(iface, filter, count)
+
+	sep := indexOf(argv, "--")
+	if sep < 0 {
+		t.Fatalf("argv %v: missing \"--\" separator", argv)
+	}
+	if got := strings.Join(argv[sep+1:], " "); got != "host 10.0.0.1 and port 22" {
+		t.Fatalf("filter tail = %q, want %q", got, "host 10.0.0.1 and port 22")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #4524 (ps-023 13-02, HIGH).

`monitor traffic interface <if> matching <filter>` appended the operator-supplied filter tokens to the root `tcpdump` argv with **no `--` end-of-options separator** (`buildMonitorTrafficArgv`, `pkg/cli/cli_request.go`). The `matching` clause greedily absorbs every token up to the next grammar keyword, so:

```
monitor traffic interface ge-0-0-0 matching -w /etc/cron.d/x
  -> exec tcpdump -i ge-0-0-0 -n -l -w /etc/cron.d/x
```

Under glibc getopt argv permutation, tcpdump parses `-w` as an **option** regardless of position -> arbitrary root file write; `-z <cmd>` -> post-rotate command execution. RBAC gates `monitor traffic` at `PermControl` (#4067), so a custom login class holding `control` but **not** super-user escalates to root file-write / command-exec; the capture-only contract is also violated for super-user. Ping/traceroute already route through `diagcmd` and add `--` (#2084) — this path did not.

## Fix

- **Primary (robust, tcpdump-native):** `buildMonitorTrafficArgv` now inserts an explicit `"--"` separator before the filter tokens (mirroring the diagcmd #2084 treatment). After `--`, getopt stops scanning for options, so every filter token is parsed as part of the pcap filter **expression** — an injected `-w`/`-z` becomes a libpcap compile error, not a live option.
- **Defense-in-depth:** `validateMonitorFilter` / `monitorFilterOptionToken` reject any option-looking filter token (a term beginning with `-`, other than a bare `-`) up front with a clear error, wired into `handleMonitorTraffic`. A legitimate pcap filter never begins a term with an option flag, so `host X and port N`, `tcp port 80`, `not arp` are unaffected.

## Validation

- New `monitor_traffic_injection_4524_test.go`: `-w`/`-z`/`-r`/`--postrotate-command` all land **after** `--` (neutralized). **RED on revert** of the `--` insertion — verified: the injected token precedes no separator.
- `validateMonitorFilter` rejects option tokens and accepts legitimate filters; a legit multi-token filter (`host 10.0.0.1 and port 22`) survives intact after `--`.
- Updated the #4005 argv-shape test to expect the `--` separator.
- `go test ./pkg/cli/...` green, `go build ./...`, `gofmt` clean. (`go vet` `cli.go:503 unreachable code` warning is pre-existing, unmodified path.)
- Documented in `docs/system-login.md` + `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi