### PR TITLE
Revert R-04 @ isIdentChar (broke #4099 rescue-config fail-closed test #4523)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-07-07 — Revert R-04 `@` isIdentChar (broke #4099 rescue-config fail-closed test)
+
+- **Timestamp**: 2026-07-07T13:50Z
+- **Action**: #4523/#4521's R-04 ride-along added `@` to the config lexer's
+  `isIdentChar` + `IsIdentRune` (speculative "unquoted URL / userinfo
+  completeness"). That changed parse-error semantics: a token like
+  `SENTINEL@` now lexes as one clean identifier instead of producing a
+  ParseError. The #4099 rescue-config redaction test
+  (`TestLoadRescueConfigRedactedFailClosedOnParseError`) relies on `@`
+  triggering a ParseError whose message embeds a secret sentinel — its
+  precondition ("malformed rescue.conf parses to an error") broke, turning
+  the test RED on origin/master. Reverted the R-04 add: removed
+  `ch == '@'` from `isIdentChar` and `r == '@'` from `IsIdentRune`, plus
+  the accompanying doc-comment change. URLs with `@` must be quoted in
+  Junos anyway, so no live regression. No R-04 test asserted the `@`
+  behavior (the commit added only the lexer change + a NAT pool-address
+  test); the pre-existing `@` tests (schema_validate_route_2448,
+  schema_validate_ddns_hostname_2779) all rely on `@` being rejected/
+  dropped and stay green.
+- **Files**: pkg/config/lexer.go
+- **Validation**: `go test ./pkg/configstore/ -run
+  TestLoadRescueConfigRedactedFailClosedOnParseError` RED before -> GREEN
+  after; full `go test ./pkg/config/... ./pkg/configstore/...` green;
+  go build ./..., gofmt, go vet clean.
+
 ## 2026-07-07 — #4524 (ps-023 13-02, HIGH): neutralize `monitor traffic ... matching` tcpdump option injection
 
 - **Timestamp**: 2026-07-07T21:30Z

--- a/pkg/config/lexer.go
+++ b/pkg/config/lexer.go
@@ -282,11 +282,10 @@ func (l *Lexer) readIdentifier(line, col int) Token {
 
 // isIdentChar returns true if ch is valid in a Junos identifier.
 // Junos identifiers can contain letters, digits, hyphens, underscores,
-// dots, slashes, colons, asterisks, plus signs, percent signs, at signs,
-// and angle brackets.
+// dots, slashes, colons, asterisks, plus signs, percent signs, and angle
+// brackets.
 // This handles IP addresses (10.0.1.0/24), interface names (eth0.0),
-// wildcards (*), group wildcards (<*>), and unquoted URLs / userinfo
-// (user@host — #4521 R-04).
+// wildcards (*), and group wildcards (<*>).
 func isIdentChar(ch byte) bool {
 	return (ch >= 'a' && ch <= 'z') ||
 		(ch >= 'A' && ch <= 'Z') ||
@@ -294,7 +293,7 @@ func isIdentChar(ch byte) bool {
 		ch == '-' || ch == '_' || ch == '.' ||
 		ch == '/' || ch == ':' || ch == '*' || ch == '+' ||
 		ch == '%' || ch == '=' || ch == ',' ||
-		ch == '<' || ch == '>' || ch == '@'
+		ch == '<' || ch == '>'
 }
 
 // IsIdentRune is the rune version for use in tab completion.
@@ -303,5 +302,5 @@ func IsIdentRune(r rune) bool {
 		r == '-' || r == '_' || r == '.' ||
 		r == '/' || r == ':' || r == '*' || r == '+' ||
 		r == '%' || r == '=' || r == ',' ||
-		r == '<' || r == '>' || r == '@'
+		r == '<' || r == '>'
 }


### PR DESCRIPTION
## Problem

#4523/#4521's R-04 ride-along added `@` to the config lexer's `isIdentChar`
and `IsIdentRune` (`pkg/config/lexer.go`) as a speculative "unquoted URL /
userinfo (user@host)" completeness gap. It had no live failure to fix — the
quoted form already worked — but it changed the lexer's parse-error semantics:
a config token like `SENTINEL@` now lexes as one clean identifier instead of
producing a `ParseError`.

That regressed `TestLoadRescueConfigRedactedFailClosedOnParseError`
(`pkg/configstore`, #4099), which went **RED on origin/master**. The #4099
test relies on `@` triggering a `ParseError` whose message embeds a secret
sentinel, so it can prove the rescue-config loader redacts / fails closed
without leaking the raw `ParseError` text. With `@` now a valid ident char,
the malformed fixture parsed cleanly and the setup guard tripped:
`test setup: malformed rescue.conf parsed cleanly; adjust the fixture`.

## Fix

Revert the R-04 add: drop `ch == '@'` from `isIdentChar` and `r == '@'` from
`IsIdentRune`, and restore the original doc comment. URLs containing `@` must
be quoted in Junos anyway — the correct behavior. The ride-along was not worth
the parse-error-semantics change and the broken fail-closed test.

No R-04 test asserted the `@` behavior (that commit added only the lexer change
plus a NAT source-pool address test). The pre-existing `@` tests
(`schema_validate_route_2448`, `schema_validate_ddns_hostname_2779`) all rely
on `@` being rejected / dropped and stay green.

## Validation

- `TestLoadRescueConfigRedactedFailClosedOnParseError`: **RED before → GREEN after**
- Full `go test ./pkg/config/... ./pkg/configstore/...`: green
- `go build ./...`, `gofmt`, `go vet`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi