### PR TITLE
dhcp: avoid int64 overflow in renewalTimers T2 remainder (#4526)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,23 @@
+## 2026-07-07 — #4526 DHCP renewalTimers int64 overflow (cleanliness)
+
+- **Timestamp**: 2026-07-07T00:00Z
+- **Action**: `renewalTimers` (pkg/dhcp/commit.go) computed the T2
+  remainder as `leaseTime*7/8 - leaseTime/2`. `leaseTime` is a
+  `time.Duration` (int64 ns); for a lease above ~41.8yr (MaxInt64/7 ns) —
+  notably the 0xFFFFFFFF-second RFC infinite-lease sentinel, which
+  IPAddressLeaseTime passes through uncapped (dhcp.go) — the `leaseTime*7`
+  intermediate overflows int64, wraps negative, and the result clamps to
+  the 1s floor. Impact is effectively nil (in that regime t1 = leaseTime/2
+  is decades out and fires first, so there is no rebind storm), so this is
+  a cleanliness fix. Reordered to divide-before-multiply
+  `leaseTime / 8 * 3` — algebraically the same 37.5% remainder with no
+  intermediate above the lease itself. The two forms are bit-identical for
+  every whole-second lease (1e9 ns is divisible by 8, no rounding
+  divergence; verified for 3600/60/40/2/0/86400s). Added a RED-on-revert
+  test case (`max-uint32 infinite-lease sentinel`): with the old form it
+  fails `t2Remaining = 1s, want 447392h25m35.625s`; other cases stay green.
+- **Files**: pkg/dhcp/commit.go, pkg/dhcp/commit_test.go
+
 ## 2026-07-07 — Revert R-04 `@` isIdentChar (broke #4099 rescue-config fail-closed test)
 
 - **Timestamp**: 2026-07-07T13:50Z

--- a/pkg/dhcp/commit.go
+++ b/pkg/dhcp/commit.go
@@ -40,16 +40,24 @@ import (
 // renewalTimers computes the two waits of one renewal cycle from a
 // lease duration: t1 is the wait until the renew attempt (50% of the
 // lease time, clamped to a 30s minimum), t2Remaining is the additional
-// wait from T1 to the rebind attempt (87.5% − 50% of the lease time,
-// clamped to a 1s minimum). The formulas are unchanged from the
-// pre-#1777 inline code; they are extracted so both families share one
-// definition and tests can pin the clamps.
+// wait from T1 to the rebind attempt (87.5% − 50% = 37.5% of the lease
+// time, clamped to a 1s minimum). The remainder is computed as
+// leaseTime/8*3 (divide-before-multiply) rather than the algebraically
+// equal leaseTime*7/8 - leaseTime/2: the latter overflows int64 for a
+// lease above ~41.8yr (MaxInt64/7 ns) — notably the 0xFFFFFFFF-second
+// RFC infinite sentinel — wrapping negative and clamping T2 to 1s
+// (#4526). The divide-first form has no intermediate above the lease
+// itself. For every whole-second lease the two forms are bit-identical
+// (1e9 ns is divisible by 8, so no rounding divergence). The 50%/37.5%
+// split and clamps are unchanged from the pre-#1777 inline code; they
+// are extracted so both families share one definition and tests can pin
+// the clamps.
 func renewalTimers(leaseTime time.Duration) (t1, t2Remaining time.Duration) {
 	t1 = leaseTime / 2
 	if t1 < 30*time.Second {
 		t1 = 30 * time.Second
 	}
-	t2Remaining = leaseTime*7/8 - leaseTime/2
+	t2Remaining = leaseTime / 8 * 3
 	if t2Remaining < time.Second {
 		t2Remaining = time.Second
 	}

--- a/pkg/dhcp/commit_test.go
+++ b/pkg/dhcp/commit_test.go
@@ -68,6 +68,15 @@ func TestRenewalTimers(t *testing.T) {
 		{"t2 remainder clamped to 1s", 2 * time.Second, 30 * time.Second, time.Second},
 		{"zero lease time", 0, 30 * time.Second, time.Second},
 		{"60s lease", 60 * time.Second, 30 * time.Second, 22500 * time.Millisecond},
+		// #4526: the 0xFFFFFFFF-second RFC infinite-lease sentinel. The
+		// old leaseTime*7/8 - leaseTime/2 form overflows int64 here and
+		// wraps negative → T2 was clamped to 1s. The divide-first form
+		// yields a sane ~37.5% remainder (3/8 of the lease). RED on
+		// revert: this asserts the large positive value, not the 1s clamp.
+		{"max-uint32 infinite-lease sentinel",
+			0xFFFFFFFF * time.Second,
+			0xFFFFFFFF * time.Second / 2,
+			0xFFFFFFFF * time.Second / 8 * 3},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #4526 (LOW, cleanliness). `renewalTimers` in `pkg/dhcp/commit.go`
computed the T2 remainder as `leaseTime*7/8 - leaseTime/2`. `leaseTime`
is a `time.Duration` (int64 ns); for a lease longer than ~41.8yr
(`MaxInt64/7` ns) the `leaseTime*7` intermediate overflows int64, wraps
negative, and the result clamps to the 1s floor. The 0xFFFFFFFF-second
RFC infinite-lease sentinel hits this exactly (`IPAddressLeaseTime` is
uncapped in `dhcp.go`).

**Impact is effectively nil.** In the overflow regime `t1 = leaseTime/2`
is decades out and always fires before T2, so the client renews on the
correct T1 timer and never reaches the clamped T2 — there is no rebind
storm / tight loop. This is a cleanliness fix only.

## Fix

Reorder to divide-before-multiply: `leaseTime / 8 * 3`. Same 37.5%
remainder (87.5% − 50%), but no intermediate above the lease itself, so
it cannot overflow for any representable duration. The two forms are
bit-identical for every whole-second lease (1e9 ns is divisible by 8, so
no integer-division rounding divergence — verified for
3600/60/40/2/0/86400s).

## Test

Added a RED-on-revert case `max-uint32 infinite-lease sentinel` to
`TestRenewalTimers`. On the old form it fails
`t2Remaining = 1s, want 447392h25m35.625s` (the overflow→1s clamp), with
the normal-lease cases staying green. `go test ./pkg/dhcp/...`,
`go build`, `gofmt`, `go vet` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi