### PR TITLE
routing/PBR: skip steering a routing-instance term with discard/reject (#4534)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,38 @@
+## 2026-07-07 — #4534 PBR kernel-mirror steers a routing-instance term even with discard/reject (fail-open VRF-steer)
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4534 — `buildPBRFromFilter` (pkg/routing/rules.go) looped
+  `filter.Terms`, keyed only on `term.RoutingInstance != ""`, and NEVER read
+  `term.Action`. So a contradictory FBF term (`then routing-instance X;
+  discard`/`reject`) built a steering `ip rule`. The userspace forwarding path
+  was already fixed (#4392: `ingress_route_table_override` returns
+  `RouteOverride::Drop` when `routing_result.action` is Reject|Discard), so
+  userspace DROPS on the filtered interface while the kernel PBR mirror still
+  STEERED — the `ip rule` is global (no `iif` selector), so slow-path /
+  `XDP_PASS` / unfiltered-interface traffic that should DROP was steered into
+  the target VRF (fail-open VRF-steer). The strict conflict gate
+  (`validateFilterRoutingInstanceConflictStrict`, #3308) rejects such a term at
+  commit but is LENIENT on load / peer-sync (#1960 no-brick), so an
+  already-persisted or peer-synced contradiction survives and reaches the
+  builder. FIX: in `buildPBRFromFilter`, right after the `RoutingInstance ==
+  ""` skip, `continue` (record a degraded build error, do NOT build the ip
+  rule) when `term.Action == "discard" || term.Action == "reject"` — mirroring
+  the userspace `is_drop` gate. `term.Action` is one of "accept"/"reject"/
+  "discard"/"" (set by `compileFilterThen`, types_system.go). A plain
+  routing-instance term (no deny, or explicit `then accept`) still builds its
+  steering rule. Also refreshed the STALE present-tense comments that claimed
+  userspace "UNCONDITIONALLY returns the routing table" (pre-#4392) in
+  compiler_uniformgates.go, compiler_validate_strict_filter.go, and
+  firewall_ri_conflict_3308_test.go — both paths now resolve the contradiction
+  to the DENY. RED-on-revert (revert rules.go only, keep the new test): the
+  discard and reject subtests go RED (`got 1` steering rule) while the plain/
+  accept subtest stays GREEN. go test ./pkg/routing/... and the config
+  Filter/RoutingInstance/3308 suites green; gofmt/vet/build clean.
+- **File(s)**: pkg/routing/rules.go, pkg/routing/routing_test.go,
+  pkg/routing/README.md, pkg/config/compiler_uniformgates.go,
+  pkg/config/compiler_validate_strict_filter.go,
+  pkg/config/firewall_ri_conflict_3308_test.go, _Log.md
+
 ## 2026-07-07 — #4526 DHCP renewalTimers int64 overflow (cleanliness)
 
 - **Timestamp**: 2026-07-07T00:00Z

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -819,14 +819,17 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 	// #3308 firewall-filter routing-instance-vs-discard/reject mutual-exclusion
 	// gate. Strict on commit / commit-check (hard-reject a term that co-locates
 	// `then routing-instance <x>` with a terminating `then discard`/`then
-	// reject`). Such a term is contradictory: the PBR runtime
-	// (ingress_route_table_override) logs the deny/reject but UNCONDITIONALLY
-	// returns the routing table, so the packet is routed while the audit stream
-	// records it as denied (the audit lies; fail-open PBR). Lenient on load /
-	// peer-sync (warn so an already-persisted or peer-synced config still boots —
-	// #1960 no-brick; the runtime routes-and-mislogs independently). Runs on the
-	// fully-compiled *Config so the typed term list (RoutingInstance + Action
-	// populated by compileFilterThen) is available.
+	// reject`). Such a term is contradictory: it asks the dataplane to BOTH steer
+	// the packet into <x> AND drop/reject it. Both forwarding paths now resolve
+	// the contradiction to the DENY — the userspace PBR runtime
+	// (ingress_route_table_override) returns RouteOverride::Drop (#4392) and the
+	// kernel `ip rule` mirror (buildPBRFromFilter, pkg/routing) skips the steering
+	// rule (#4534). This gate stays strict at commit so the operator never
+	// authors the contradiction, but is lenient on load / peer-sync (warn so an
+	// already-persisted or peer-synced config still boots — #1960 no-brick; both
+	// runtimes drop the term independently). Runs on the fully-compiled *Config so
+	// the typed term list (RoutingInstance + Action populated by compileFilterThen)
+	// is available.
 	if err := validateFilterRoutingInstanceConflictStrict(cfg); err != nil {
 		if opts.lenientFilterRoutingInstanceConflict {
 			cfg.Warnings = append(cfg.Warnings,

--- a/pkg/config/compiler_validate_strict_filter.go
+++ b/pkg/config/compiler_validate_strict_filter.go
@@ -1225,14 +1225,16 @@ func validateFilterFromMatchStrict(cfg *Config) error {
 // `then discard` / `then reject` — #3308.
 //
 // Such a term is contradictory: it asks the dataplane to BOTH route the packet
-// via the named instance AND drop/reject it. There was no commit-time
-// mutual-exclusion gate, and on the PBR runtime path the deny/reject was reduced
-// to a LOG-ONLY event — ingress_route_table_override (userspace-dp/src/afxdp/
-// forwarding/mod.rs) logs routing_result.action (the discard/reject) and then
-// UNCONDITIONALLY returns the routing-table string, so the packet is still
-// forwarded through <x>.inet.0 / <x>.inet6.0. The audit/syslog stream records
-// the packet as DENY/REJECT while it was actually routed — worse than a syntax
-// gap: the audit trail lies and the security intent is defeated (fail-open PBR).
+// via the named instance AND drop/reject it. Historically there was no
+// commit-time mutual-exclusion gate AND both forwarding paths honored the steer
+// while only logging the deny — a fail-open PBR whose audit trail lied. Both
+// paths now resolve the contradiction to the DENY: the userspace PBR runtime
+// (ingress_route_table_override, userspace-dp/src/afxdp/forwarding/mod.rs)
+// returns RouteOverride::Drop for a reject/discard term (#4392), and the kernel
+// `ip rule` mirror (buildPBRFromFilter, pkg/routing/rules.go) skips the steering
+// rule (#4534). This gate keeps the operator from authoring the contradiction at
+// commit; on the tolerant load / peer-sync path it warns and both runtimes drop
+// the term independently.
 //
 // The conflict is on the typed fields term.RoutingInstance (the
 // `then routing-instance` value) and term.Action ("discard" / "reject", set by

--- a/pkg/config/firewall_ri_conflict_3308_test.go
+++ b/pkg/config/firewall_ri_conflict_3308_test.go
@@ -6,12 +6,13 @@ import (
 )
 
 // #3308: a firewall-filter term that co-locates `then routing-instance <x>`
-// with a terminating `then discard` / `then reject` is contradictory. The PBR
-// runtime (ingress_route_table_override) logs the deny/reject but
-// unconditionally returns the routing table, so the packet is ROUTED while the
-// audit stream records it as denied (the audit trail lies; fail-open PBR).
-// validateFilterRoutingInstanceConflictStrict makes it an operator-visible
-// commit error.
+// with a terminating `then discard` / `then reject` is contradictory — it asks
+// the dataplane to BOTH steer the packet into <x> AND drop it. Both forwarding
+// paths now resolve the contradiction to the DENY: the userspace PBR runtime
+// (ingress_route_table_override) returns RouteOverride::Drop (#4392) and the
+// kernel `ip rule` mirror (buildPBRFromFilter) skips the steering rule (#4534).
+// validateFilterRoutingInstanceConflictStrict still makes it an operator-visible
+// commit error so the contradiction is never authored in the first place.
 //
 // FAIL-ON-REVERT: remove the validateFilterRoutingInstanceConflictStrict
 // invocation (or the function's reject) and these strict-path tests go RED —

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -135,6 +135,19 @@ delegate to the owning domain. Exported types:
   and the userspace filter path still enforces the term exactly. The
   degraded error is returned to the daemon (`daemon_apply.go` step 3d) and
   logged; the buildable rules are still installed.
+  **Contradictory deny terms are not steered (#4534).** A term that
+  co-locates `then routing-instance <x>` with a terminating `then discard` /
+  `then reject` is contradictory — it asks the dataplane to BOTH steer the
+  packet into `<x>` AND drop it. The deny wins on BOTH forwarding paths: the
+  userspace runtime returns `RouteOverride::Drop` (#4392,
+  `ingress_route_table_override`) and `buildPBRFromFilter` SKIPS the steering
+  `ip rule` (records a degraded error). Without the kernel skip the global
+  `ip rule` (no `iif` selector) would fail OPEN — steering slow-path /
+  `XDP_PASS` / unfiltered-interface traffic into the VRF that userspace drops.
+  The strict commit gate (`validateFilterRoutingInstanceConflictStrict`,
+  #3308) rejects such a term at commit, but is lenient on load / peer-sync
+  (#1960 no-brick), so a persisted / peer-synced contradiction can still reach
+  the builder — hence the runtime skip.
   **Userspace FIB snapshot skips this band (#4479).** The userspace
   route-snapshot builder (`buildRouteSnapshots`,
   `pkg/dataplane/userspace/routes.go`) mirrors kernel ip rules whose Dst maps

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -861,6 +861,68 @@ func TestBuildPBRRules(t *testing.T) {
 		}
 	})
 
+	// === #4534 RED-on-revert coverage ===
+	//
+	// A term that co-locates `then routing-instance X` with a terminating
+	// `then discard`/`then reject` is CONTRADICTORY — the deny wins (mirroring
+	// the userspace RouteOverride::Drop, #4392). buildPBRFromFilter must NOT
+	// build a steering ip rule for it, else the kernel mirror fails OPEN and
+	// steers slow-path / XDP_PASS / unfiltered-interface traffic into the VRF
+	// that userspace drops. Pre-fix the builder keyed only on RoutingInstance
+	// and emitted a steering rule regardless of the deny action.
+	for _, action := range []string{"discard", "reject"} {
+		action := action
+		t.Run("routing-instance with "+action+" not steered", func(t *testing.T) {
+			filter := &config.FirewallFilter{
+				Name: "deny-" + action,
+				Terms: []*config.FirewallFilterTerm{
+					{
+						Name:            "contradictory",
+						DSCPs:           []string{"ef"},
+						SourceAddresses: []string{"10.0.1.0/24"},
+						RoutingInstance: "ATT",
+						Action:          action,
+					},
+				},
+			}
+			rules, err := BuildPBRRules(pbrTestConfig("inet", filter, instances, nil))
+			if len(rules) != 0 {
+				t.Fatalf("expected 0 PBR rules for routing-instance+%s (contradictory deny), got %d", action, len(rules))
+			}
+			// The skip is degraded (surfaced) rather than silent.
+			if err == nil {
+				t.Errorf("expected a degraded error reporting the skipped contradictory term, got nil")
+			}
+		})
+	}
+
+	// A plain routing-instance term (no discard/reject) still steers — the fix
+	// must not regress the legitimate filter-based-forwarding case.
+	t.Run("routing-instance without deny still steered", func(t *testing.T) {
+		filter := &config.FirewallFilter{
+			Name: "plain-fbf",
+			Terms: []*config.FirewallFilterTerm{
+				{
+					Name:            "steer",
+					SourceAddresses: []string{"10.0.1.0/24"},
+					RoutingInstance: "ATT",
+				},
+				// `then accept` is the explicit legitimate FBF terminal; it must
+				// still steer (only discard/reject suppress the ip rule).
+				{
+					Name:            "steer-accept",
+					SourceAddresses: []string{"10.0.2.0/24"},
+					RoutingInstance: "ATT",
+					Action:          "accept",
+				},
+			},
+		}
+		rules, _ := BuildPBRRules(pbrTestConfig("inet", filter, instances, nil))
+		if len(rules) != 2 {
+			t.Fatalf("expected 2 PBR rules for plain/accept routing-instance terms, got %d", len(rules))
+		}
+	})
+
 	t.Run("multi-address cross product", func(t *testing.T) {
 		filter := &config.FirewallFilter{
 			Name: "multi",

--- a/pkg/routing/rules.go
+++ b/pkg/routing/rules.go
@@ -774,6 +774,28 @@ func buildPBRFromFilter(filter *config.FirewallFilter, family int, tableIDs map[
 		if term.RoutingInstance == "" {
 			continue
 		}
+
+		// #4534: a term that co-locates `then routing-instance <x>` with a
+		// terminating `then discard` / `then reject` is CONTRADICTORY — it asks
+		// the dataplane to BOTH steer the packet into <x> AND drop/reject it. The
+		// deny wins: the userspace forwarding path (ingress_route_table_override,
+		// userspace-dp/src/afxdp/forwarding/mod.rs) returns RouteOverride::Drop for
+		// such a term (#4392). The kernel `ip rule` mirror must match that
+		// disposition — building a steering rule here would fail OPEN, steering
+		// slow-path / XDP_PASS / unfiltered-interface traffic (the ip rule is
+		// global, no iif selector) into the target VRF that userspace drops. The
+		// strict commit gate (validateFilterRoutingInstanceConflictStrict) rejects
+		// this term, but is LENIENT on load / peer-sync (#1960 no-brick), so a
+		// contradictory term can still reach here — skip it (do NOT steer).
+		if term.Action == "discard" || term.Action == "reject" {
+			errs = append(errs, fmt.Errorf(
+				"PBR filter %s term %s co-locates routing-instance %q with a terminating "+
+					"%q action; the deny wins (mirroring the userspace drop, #4392) — no "+
+					"steering ip rule is built for this contradictory term",
+				filter.Name, term.Name, term.RoutingInstance, term.Action))
+			continue
+		}
+
 		tableID, ok := tableIDs[term.RoutingInstance]
 		if !ok {
 			slog.Warn("PBR: routing-instance not found",


### PR DESCRIPTION
## Summary

`buildPBRFromFilter` (pkg/routing/rules.go) looped `filter.Terms` keyed only on `term.RoutingInstance != ""` and never read `term.Action`, so a contradictory filter-based-forwarding term (`then routing-instance X; discard`/`reject`) built a steering `ip rule`.

The userspace forwarding path was already fixed in #4392 — `ingress_route_table_override` returns `RouteOverride::Drop` when the matched PBR term's action is `Reject`/`Discard` — so userspace DROPS on the filtered interface while the kernel PBR mirror still STEERED. The `ip rule` is global (no `iif` selector), so slow-path / `XDP_PASS` / unfiltered-interface traffic that should be dropped was steered into the target VRF: a **fail-open VRF-steer** in the kernel mirror.

The strict conflict gate `validateFilterRoutingInstanceConflictStrict` (#3308) rejects such a term at commit, but is LENIENT on load / peer-sync (#1960 no-brick), so an already-persisted or peer-synced contradiction survives and reaches the builder.

## Fix

In `buildPBRFromFilter`, immediately after the empty-`RoutingInstance` skip, `continue` (record a degraded build error, build no ip rule) when `term.Action == "discard" || term.Action == "reject"` — mirroring the userspace `is_drop` gate (#4392). `term.Action` is one of `accept`/`reject`/`discard`/`""` (set by `compileFilterThen`). A plain routing-instance term (no deny, or explicit `then accept`) still builds its steering rule, so legitimate FBF is unaffected.

Also refreshed the now-stale present-tense comments claiming userspace "UNCONDITIONALLY returns the routing table" (pre-#4392) in `compiler_uniformgates.go`, `compiler_validate_strict_filter.go`, and `firewall_ri_conflict_3308_test.go`, and documented the kernel skip in the routing README PBR/FBF matrix.

## Validation

- **RED-on-revert**: reverting only `rules.go` (keeping the new test) turns the `discard` and `reject` subtests RED (a steering rule is built, `got 1`) while the plain/`accept` subtest stays GREEN.
- `go test ./pkg/routing/...` and the config `Filter`/`RoutingInstance`/`3308` suites pass.
- `gofmt`, `go vet`, `go build` clean.

Closes #4534

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi