### PR TITLE
screen: fail closed on a malformed IPv4 option TLV (#4543)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,44 @@
+## 2026-07-07 — #4543 screen: fail closed on a malformed IPv4 option TLV (source-route bypass)
+
+- **Timestamp**: 2026-07-07T17:15Z
+- **Action**: The IPv4 options TLV walk in `extract_screen_info`
+  (userspace-dp/src/screen/extract.rs) `break`d out of the scan on a
+  MALFORMED length-prefixed option (a length byte at the very end of the
+  options region, a declared length `< 2`, or one running past the
+  options end). Because the `kind == LSRR/SSRR` test necessarily precedes
+  the length check, a `break` on a bad option ABORTED the walk before an
+  LSRR(131)/SSRR(137) placed AFTER it could be seen, leaving
+  `saw_ipv4_source_route=false` → `check_source_route` returned Pass. An
+  attacker could prepend `[type=0x44,len=0x01]` to an LSRR (IHL>5) and
+  transit the `source-route` screen the operator enabled to drop it. #4167
+  added TRUNCATION fail-closed for the IPv4 header but not MALFORMED-OPTION
+  fail-closed — an inconsistency with its own contract. Fix: the two
+  malformed-option arms now `return Err(ScreenParseError::
+  TruncatedIpv4Header)` (the "ip-malformed" drop reason) instead of
+  `break`, so the caller (poll_stages.rs / poll_descriptor) fail-closes
+  and DROPS the frame, mirroring #4167's truncation fail-closed and vSRX,
+  which drops malformed IP options / source-route regardless of option
+  order. A well-formed options list (including a well-formed LSRR/SSRR
+  after a benign option) is unaffected — every option's length is
+  consistent so the walk advances normally and the LSRR/SSRR arm still
+  fires; a no-options packet is unaffected. No new error variant was
+  needed — `TruncatedIpv4Header` already maps to "ip-malformed"
+  (SCREEN_IP_MALFORMED, 1<<18) and matches the semantic. No standalone
+  doc changed: the fail-closed contract lives in the extract.rs
+  doc-comment block (updated with a #4543 note), matching how #4167
+  documented itself (code comment + _Log.md, no separate markdown doc).
+- **File(s)**: userspace-dp/src/screen/extract.rs (two malformed-option
+  arms → `return Err`; function doc-comment #4543 note),
+  userspace-dp/src/screen/tests.rs (three RED-on-revert tests), _Log.md
+- **Validation**: RED-on-revert verified — reverting BOTH malformed arms
+  to `break` fails `extract_screen_info_ipv4_malformed_option_before_lsrr_
+  fails_closed` (returns Ok with `saw_ipv4_source_route=false`) and
+  `extract_screen_info_ipv4_option_length_overruns_region_fails_closed`,
+  while `extract_screen_info_ipv4_wellformed_lsrr_after_benign_option_
+  trips` (over-drop guard) stays green. FULL cargo test --release
+  --test-threads=1: 3704 + 54 + 8 + 22 + 1 = 3789 passed, 0 failed, 2
+  ignored (215 screen tests within the main-binary count).
+
 ## 2026-07-07 — #4535 three-color policer unspecified color mode defaults to color-blind (Junos parity)
 
 - **Timestamp**: 2026-07-07T15:30Z

--- a/userspace-dp/src/screen/extract.rs
+++ b/userspace-dp/src/screen/extract.rs
@@ -29,6 +29,16 @@ use super::packet::{PROTO_TCP, ScreenPacketInfo, ScreenParseError};
 /// `check_icmp_fragment`/`check_source_route` — the IPv4 mirror of the
 /// IPv6 fail-open the #2146 hardening closed.
 ///
+/// #4543: the IPv4 options TLV walk is now fail-closed on a MALFORMED
+/// option too, not only on a truncated header. A length-prefixed option
+/// whose length byte is missing, is `< 2`, or runs past the options
+/// region returns `Err(TruncatedIpv4Header)` instead of `break`ing. The
+/// LSRR/SSRR kind test precedes the length check, so the old `break`
+/// aborted the scan before a source-route option placed AFTER a bad
+/// option could be seen — a `source-route` screen bypass. This completes
+/// #4167's fail-closed contract for the option region and matches vSRX,
+/// which drops malformed IP options / source-route regardless of order.
+///
 /// #3120: the IPv6 walk now CONTINUES past the Fragment header for a
 /// FIRST fragment (fragment offset == 0) instead of stopping at it, so a
 /// `Fragment → Destination-Options → TCP` chain (RFC 8200 permits an
@@ -128,6 +138,25 @@ pub(crate) fn extract_screen_info(
         // NOP(1) is one byte, every other option is length-prefixed.
         // The options region is guaranteed captured by the fail-closed
         // `l3_offset + ihl_bytes > frame.len()` check above.
+        //
+        // FAIL-CLOSED (#4543): a MALFORMED length-prefixed option (a
+        // length byte at the very end of the options region with no room
+        // for the length field, or a declared length < 2, or one that
+        // runs past the options end) returns `Err(TruncatedIpv4Header)`
+        // instead of `break`. The kind==LSRR/SSRR test necessarily
+        // precedes the length check, so a `break` on a malformed option
+        // ABORTED the walk before a source-route option placed AFTER it
+        // could be seen — leaving `saw_ipv4_source_route=false` so
+        // `check_source_route` passed a packet the extractor could not
+        // fully parse. An attacker could prepend `[type=0x44,len=0x01]`
+        // to an LSRR and evade the `source-route` screen the operator
+        // enabled. Dropping the malformed frame mirrors #4167's
+        // truncation fail-closed contract and vSRX, which drops malformed
+        // IP options / source-route regardless of option ordering. A
+        // WELL-FORMED options list (including a well-formed LSRR/SSRR the
+        // screen must catch) is unaffected: every option's length is
+        // consistent, so the walk advances normally and the LSRR/SSRR arm
+        // still fires.
         if info.ip_ihl > 5 {
             const IPOPT_EOOL: u8 = 0;
             const IPOPT_NOP: u8 = 1;
@@ -150,14 +179,20 @@ pub(crate) fn extract_screen_info(
                 }
                 // Length-prefixed option: byte at pos+1 is the total
                 // option length (including the kind/length bytes). A
-                // malformed length (<2 or running past the options end)
-                // ends the walk to avoid an infinite/over-read loop.
+                // length byte at the very end of the options region (no
+                // room to read it) is a MALFORMED option — fail closed
+                // (#4543) rather than `break`, which would let an LSRR/
+                // SSRR placed AFTER the bad option evade the source-route
+                // screen.
                 if pos + 1 >= opt_end {
-                    break;
+                    return Err(ScreenParseError::TruncatedIpv4Header);
                 }
                 let opt_len = frame[pos + 1] as usize;
+                // A declared length < 2 (impossible for a length-prefixed
+                // option) or one running past the options end is MALFORMED
+                // — fail closed (#4543), same reasoning as above.
                 if opt_len < 2 || pos + opt_len > opt_end {
-                    break;
+                    return Err(ScreenParseError::TruncatedIpv4Header);
                 }
                 pos += opt_len;
             }

--- a/userspace-dp/src/screen/tests.rs
+++ b/userspace-dp/src/screen/tests.rs
@@ -1830,6 +1830,131 @@ fn extract_screen_info_ipv4_lsrr_detected() {
 }
 
 #[test]
+fn extract_screen_info_ipv4_malformed_option_before_lsrr_fails_closed() {
+    // #4543 (ps-027 S-03): a MALFORMED option placed BEFORE an LSRR must
+    // NOT let the source-route option evade the screen. The kind==LSRR
+    // test precedes the length check, so the pre-fix `break`-on-malformed
+    // aborted the walk at the bad option, leaving saw_ipv4_source_route=
+    // false → check_source_route passed the packet. The fix returns
+    // Err(TruncatedIpv4Header) so the malformed frame is DROPPED (the
+    // "ip-malformed" fail-closed path, mirroring #4167). Layout: version=4,
+    // ihl=9 (36 bytes = 20 base + 16 options); options = a bad
+    // length-prefixed option {type=0x44, len=0x01} (len < 2 → malformed),
+    // then an LSRR {131, len=7, ...}. Goes RED on revert (the packet would
+    // parse Ok with saw_ipv4_source_route=false).
+    let ihl_words = 9u8;
+    let hdr_len = (ihl_words as usize) * 4; // 36
+    let mut frame = vec![0u8; 14 + hdr_len + 20];
+    let ip = 14;
+    frame[ip] = 0x40 | ihl_words; // version=4, ihl=9
+    frame[ip + 2..ip + 4].copy_from_slice(&((hdr_len + 20) as u16).to_be_bytes());
+    frame[ip + 9] = 6; // TCP
+    let opt = ip + 20;
+    // Malformed option: a length-prefixed type with a declared length of
+    // 1 (< 2, impossible for a length-prefixed option).
+    frame[opt] = 0x44; // type (not EOOL/NOP/LSRR/SSRR)
+    frame[opt + 1] = 0x01; // malformed length
+    // An LSRR placed AFTER the malformed option — the source-route the
+    // operator's screen is meant to catch.
+    frame[opt + 2] = 131; // LSRR
+    frame[opt + 3] = 7; // option length
+    frame[opt + 4] = 4; // pointer
+    let res = extract_screen_info(
+        &frame,
+        libc::AF_INET as u8,
+        6,
+        0x02,
+        (hdr_len + 20) as u16,
+        IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+        IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8)),
+        12345,
+        80,
+        14,
+    );
+    assert_eq!(
+        res.expect_err("malformed IPv4 option before LSRR must fail closed"),
+        ScreenParseError::TruncatedIpv4Header
+    );
+}
+
+#[test]
+fn extract_screen_info_ipv4_option_length_overruns_region_fails_closed() {
+    // #4543: a length-prefixed option whose declared length runs PAST the
+    // options region is malformed and must fail closed (not `break`).
+    // Layout: version=4, ihl=6 (24 bytes = 20 base + 4 options); a single
+    // option {type=7 (record-route), len=8} — but only 4 option bytes
+    // exist, so the length overruns opt_end. Goes RED on revert.
+    let ihl_words = 6u8;
+    let hdr_len = (ihl_words as usize) * 4; // 24
+    let mut frame = vec![0u8; 14 + hdr_len + 20];
+    let ip = 14;
+    frame[ip] = 0x40 | ihl_words;
+    frame[ip + 2..ip + 4].copy_from_slice(&((hdr_len + 20) as u16).to_be_bytes());
+    frame[ip + 9] = 6;
+    let opt = ip + 20;
+    frame[opt] = 7; // record-route (length-prefixed)
+    frame[opt + 1] = 8; // declares 8 bytes but only 4 remain → overruns
+    let res = extract_screen_info(
+        &frame,
+        libc::AF_INET as u8,
+        6,
+        0x02,
+        (hdr_len + 20) as u16,
+        IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+        IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8)),
+        12345,
+        80,
+        14,
+    );
+    assert_eq!(
+        res.expect_err("IPv4 option length overrunning region must fail closed"),
+        ScreenParseError::TruncatedIpv4Header
+    );
+}
+
+#[test]
+fn extract_screen_info_ipv4_wellformed_lsrr_after_benign_option_trips() {
+    // #4543 over-drop guard: a WELL-FORMED options list where an LSRR
+    // follows a benign length-prefixed option (router-alert, type 148,
+    // len 4) must STILL set saw_ipv4_source_route — the fail-closed fix
+    // must not disturb valid multi-option walks. Layout: version=4, ihl=10
+    // (40 bytes = 20 base + 20 options); router-alert {148, len=4}, then
+    // LSRR {131, len=7, ptr=4, ...}, then EOOL/pad.
+    let ihl_words = 10u8;
+    let hdr_len = (ihl_words as usize) * 4; // 40
+    let mut frame = vec![0u8; 14 + hdr_len + 20];
+    let ip = 14;
+    frame[ip] = 0x40 | ihl_words;
+    frame[ip + 2..ip + 4].copy_from_slice(&((hdr_len + 20) as u16).to_be_bytes());
+    frame[ip + 9] = 6; // TCP
+    let opt = ip + 20;
+    frame[opt] = 148; // router-alert (benign)
+    frame[opt + 1] = 4; // length
+    // LSRR follows at opt+4.
+    frame[opt + 4] = 131; // LSRR
+    frame[opt + 5] = 7; // option length
+    frame[opt + 6] = 4; // pointer
+    // remaining bytes zeroed (route data / EOOL padding)
+    let info = extract_screen_info(
+        &frame,
+        libc::AF_INET as u8,
+        6,
+        0x02,
+        (hdr_len + 20) as u16,
+        IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+        IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8)),
+        12345,
+        80,
+        14,
+    )
+    .expect("well-formed router-alert + LSRR packet must parse Ok");
+    assert!(
+        info.saw_ipv4_source_route,
+        "LSRR after a well-formed benign option must still trip the source-route screen"
+    );
+}
+
+#[test]
 fn extract_screen_info_ipv4_router_alert_not_source_route() {
     // #2973 fail-on-revert: an IPv4 header with a benign router-alert
     // option (148, length 4) must NOT set saw_ipv4_source_route.


### PR DESCRIPTION
## Summary

Closes #4543 (ps-027 S-03, low — screen fail-open).

The IPv4 options TLV walk in `extract_screen_info`
(`userspace-dp/src/screen/extract.rs`) `break`d out of the scan on a
MALFORMED length-prefixed option (a length byte at the very end of the
options region, a declared length `< 2`, or one running past the
options end). Because the `kind == LSRR(131)/SSRR(137)` test necessarily
precedes the length check, a `break` on a malformed option aborted the
walk BEFORE a source-route option placed AFTER it could be seen —
leaving `saw_ipv4_source_route=false` so `check_source_route` returned
`Pass`.

Scenario: an attacker prepends `[type=0x44, len=0x01]` to an LSRR (in an
IHL>5 header) and transits the `source-route` screen the operator
enabled to drop it. Bounded (the packet is malformed and xpf's AF_XDP
forwarder does not honor source-routing), but a real novel fail-open —
and an inconsistency with #4167, which added TRUNCATION fail-closed for
the IPv4 header but not MALFORMED-OPTION fail-closed.

## Fix

The two malformed-option arms now `return
Err(ScreenParseError::TruncatedIpv4Header)` instead of `break`, so the
caller (`poll_stages.rs` / `poll_descriptor`) fail-closes and DROPS the
frame under the `ip-malformed` reason (`SCREEN_IP_MALFORMED`, 1<<18).
This mirrors #4167's truncation fail-closed and vSRX, which drops
malformed IP options / source-route regardless of option ordering. No
new error variant was added — `TruncatedIpv4Header` already maps to
`ip-malformed` and carries the correct semantic.

Preserved: a well-formed options list is unaffected — every option's
length is consistent, so the walk advances normally and a well-formed
LSRR/SSRR (including one placed AFTER a benign option) still trips the
source-route screen; a no-options packet is unaffected.

No standalone doc changed: the fail-closed contract lives in the
`extract.rs` function doc-comment block (updated with a #4543 note),
matching how #4167 documented itself (code comment + `_Log.md`, no
separate markdown doc).

## Validation

RED-on-revert verified — reverting BOTH malformed arms back to `break`:
- `extract_screen_info_ipv4_malformed_option_before_lsrr_fails_closed`
  FAILS (frame parses `Ok` with `saw_ipv4_source_route=false`)
- `extract_screen_info_ipv4_option_length_overruns_region_fails_closed`
  FAILS
- `extract_screen_info_ipv4_wellformed_lsrr_after_benign_option_trips`
  (over-drop guard) stays GREEN

FULL `cargo test --release --test-threads=1`: **3789 passed, 0 failed, 2
ignored** (215 screen tests within the main-binary count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi