### PR TITLE
config: descend into all same-prefix siblings in navigatePath (#4562)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-07-07 — #4562 config: navigatePath intermediate descent walks ALL same-prefix siblings (display-only)
+
+- **Timestamp**: 2026-07-07
+- **Action**: `navigatePath` (pkg/config/ast.go) intermediate-descent
+  branches previously walked only the FIRST matching sibling's subtree —
+  `current = matched[0].Children` (multi-key branch ~:211) and
+  `current = n.Children` for the first matching node (single-key branch
+  ~:242). When a hand-authored HIERARCHICAL config carries a DUPLICATE
+  context block (two identical 4-key
+  `from-zone untrust to-zone trust { ... }` policy contexts, or two
+  identical single-key `interfaces { ... }` blocks) AND the display path
+  descends deeper (`... policy B`), the second duplicate-context block's
+  statements were dropped from a path-scoped `show` / `| display set`, so
+  a scoped display-set backup silently lost them on restore. Fix: both
+  intermediate-descent branches now descend into the UNION of every
+  same-prefix / same-keyword sibling's children via a new `unionChildren`
+  helper, mirroring the #3980 terminal read-all-siblings fix onto the
+  descent (same #3842 / #2419 class). Single-match is byte-identical
+  (`unionChildren` returns the one node's children directly). DISPLAY-ONLY
+  (all callers are `FormatPath*` in ast_format.go; the compiler reads the
+  full AST directly) — the hidden statement was still ENFORCED, so LOW /
+  display + scoped-backup gap, not a forwarding/security bypass. The
+  terminal #3980 branch is untouched.
+- **File(s)**: pkg/config/ast.go,
+  pkg/config/show_config_dup_context_4562_test.go (RED-on-revert:
+  both-blocks-shown for multi-key + single-key duplicate contexts,
+  single-context control byte-identical), pkg/config/README.md, _Log.md
+- **Validation**: `go test ./pkg/config/` green (incl. #3980 terminal
+  suite); RED-on-revert verified for BOTH branches (revert → policy B /
+  mtu 9000 dropped); gofmt clean, go vet clean, go build ./... clean.
+
 ## 2026-07-07 — #4539 session: cache host-inbound TCP LocalDelivery only off the handshake (single has_syn gate)
 
 - **Timestamp**: 2026-07-07

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -773,6 +773,36 @@ on `set ...`/`load set`, even though the compiler reads all of them via
 them keyed-list + read via `firewallMatchValues`), not a renderer change, and
 is tracked separately.
 
+**Path-scoped `show`/`display set` descends into ALL same-prefix siblings,
+not just the first (#4562 — the intermediate-descent twin of the #3980
+terminal fix):** #3980 fixed the case where a display path *ends* on a
+repeated keyword. `navigatePath` also has two INTERMEDIATE-descent branches
+that walk *past* a matched level to resolve the rest of the path: the
+multi-key branch (`current = matched[0].Children`) and the single-key branch
+(`current = n.Children` for the first matching node). Both previously
+descended into only the FIRST matching sibling's subtree. When a
+hand-authored HIERARCHICAL config carries a DUPLICATE context block — two
+identical 4-key `from-zone untrust to-zone trust { ... }` policy contexts, or
+two identical single-key `interfaces { ... }` blocks — AND the display path
+continues deeper (`... from-zone untrust to-zone trust policy B`), the second
+duplicate-context block's statements were dropped from the path-scoped
+`show` and its `| display set`, so a scoped display-set backup silently lost
+them on restore. The fix descends into the UNION of every same-prefix (or
+same-keyword) sibling's children via `unionChildren` before continuing —
+mirroring the #3980 terminal read-all-siblings behavior onto the descent
+(same #3842 / #2419 read-all-siblings class). Single-match is unchanged
+(`unionChildren` returns the one node's children directly), so a normal
+non-duplicate path and a single-context config render byte-identical.
+`navigatePath` is DISPLAY-ONLY (all callers are `FormatPath*` in
+`ast_format.go`; the compiler reads the full AST directly), so the hidden
+statement was still ENFORCED — the impact was a display / scoped-backup gap,
+not a forwarding or security bypass. Preconditions are narrow: flat-set
+`SetPath` MERGES same-key containers, so only a hand-authored duplicate-
+context config plus a path-SCOPED display command triggers it (an unscoped
+`show configuration` renders the whole tree fine). Regression coverage:
+`pkg/config/show_config_dup_context_4562_test.go` (multi-key + single-key
+duplicate-context descent, single-context no-regression control).
+
 **Security policies missing a required `match` criterion are rejected at commit
 (#3044 — codex-review-061 finding 061-03):** Junos/vSRX requires every security
 policy `match` clause to specify all three core dimensions — `source-address`,

--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -208,47 +208,85 @@ func navigatePath(nodes []*Node, path []string) []*Node {
 				if i >= len(path) {
 					return matched
 				}
-				current = matched[0].Children
+				// Intermediate descent: continue against the UNION of
+				// every same-prefix sibling's children, not just
+				// matched[0]'s. When more than one sibling shares the
+				// full multi-key prefix AND the display path continues
+				// deeper (e.g. two identical
+				// `from-zone untrust to-zone trust { ... }` policy
+				// contexts, then `... policy B`), descending into only
+				// the first block's children dropped statements held
+				// under the second duplicate-context sibling from a
+				// path-scoped `show` / `| display set` (#4562). This is
+				// the intermediate-descent twin of the #3980 terminal
+				// read-all-siblings fix (same #3842 / #2419 class).
+				// Single-match is unchanged: one sibling → its children.
+				current = unionChildren(matched)
 				continue
 			}
 		}
 		// Single-key match.
-		found := false
+		if i+1 >= len(path) {
+			// Terminal path element on a bare keyword: return EVERY
+			// sibling sharing this leading keyword (#3980), not just the
+			// first. A hierarchy level may hold multiple DISTINCT
+			// statements with the same leading keyword — e.g.
+			// `ntp server 1.1.1.1` / `ntp server 2.2.2.2`, several
+			// `from-zone` policy contexts, repeated `archive-sites`.
+			// Returning only the first hid the rest from a path-scoped
+			// `show configuration <path>` and, worse, from its
+			// `| display set`, so a scoped display-set backup silently
+			// dropped the hidden statements on restore. FindChildren-not-
+			// FindChild, the display-side sibling of the #3842 / #2419
+			// read-all-siblings class.
+			var all []*Node
+			for _, sib := range current {
+				if len(sib.Keys) > 0 && sib.Keys[0] == keyword {
+					all = append(all, sib)
+				}
+			}
+			if len(all) == 0 {
+				return nil
+			}
+			return all
+		}
+		// Intermediate single-key descent: continue against the UNION of
+		// every same-keyword sibling's children, not just the first, so a
+		// deeper path resolves across all duplicate same-keyword blocks
+		// (#4562) — the descent-side twin of the terminal #3980 read-all-
+		// siblings fix. Single-match is unchanged: one sibling → its
+		// children.
+		var sibs []*Node
 		for _, n := range current {
 			if len(n.Keys) > 0 && n.Keys[0] == keyword {
-				if i+1 >= len(path) {
-					// Terminal path element on a bare keyword: return
-					// EVERY sibling sharing this leading keyword (#3980),
-					// not just the first. A hierarchy level may hold
-					// multiple DISTINCT statements with the same leading
-					// keyword — e.g. `ntp server 1.1.1.1` /
-					// `ntp server 2.2.2.2`, several `from-zone` policy
-					// contexts, repeated `archive-sites`. Returning only
-					// the first hid the rest from a path-scoped
-					// `show configuration <path>` and, worse, from its
-					// `| display set`, so a scoped display-set backup
-					// silently dropped the hidden statements on restore.
-					// FindChildren-not-FindChild, the display-side sibling
-					// of the #3842 / #2419 read-all-siblings class.
-					var all []*Node
-					for _, sib := range current {
-						if len(sib.Keys) > 0 && sib.Keys[0] == keyword {
-							all = append(all, sib)
-						}
-					}
-					return all
-				}
-				i++
-				current = n.Children
-				found = true
-				break
+				sibs = append(sibs, n)
 			}
 		}
-		if !found {
+		if len(sibs) == 0 {
 			return nil
 		}
+		i++
+		current = unionChildren(sibs)
 	}
 	return nil
+}
+
+// unionChildren concatenates the children of every node in sibling order.
+// It backs navigatePath's intermediate-descent read-all-siblings behavior
+// (#4562): when a display path descends past a level that holds multiple
+// identical same-prefix (or same-keyword) siblings, the deeper lookup must
+// resolve against the union of all those siblings' children, not just the
+// first's. For a single node it returns that node's children unchanged (a
+// shallow copy), so the common single-match path renders identically.
+func unionChildren(nodes []*Node) []*Node {
+	if len(nodes) == 1 {
+		return nodes[0].Children
+	}
+	var out []*Node
+	for _, n := range nodes {
+		out = append(out, n.Children...)
+	}
+	return out
 }
 
 // matchNodeKeys checks if a node's Keys match path elements starting at pos.

--- a/pkg/config/show_config_dup_context_4562_test.go
+++ b/pkg/config/show_config_dup_context_4562_test.go
@@ -1,0 +1,190 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4562: navigatePath's INTERMEDIATE descent (past a level that holds
+// multiple identical same-prefix / same-keyword siblings) previously walked
+// only the FIRST sibling's subtree — `current = matched[0].Children` in the
+// multi-key branch, `current = n.Children` for the first matching node in
+// the single-key branch. When a hand-authored HIERARCHICAL config carries a
+// duplicate context block (two identical 4-key
+// `from-zone untrust to-zone trust { ... }` nodes, or two identical
+// single-key `interfaces { ... }` nodes) AND the display path continues
+// deeper, the second duplicate-context block's statements were dropped from
+// a path-scoped `show configuration <path>` and, worse, from its
+// `| display set` — so a scoped display-set backup silently lost them on
+// restore. This is the intermediate-descent twin of the #3980 terminal
+// read-all-siblings fix (same #3842 / #2419 class). navigatePath is
+// DISPLAY-ONLY (all callers are in ast_format.go; the compiler reads the
+// full AST directly), so the hidden statement was still ENFORCED — the
+// impact is a display / scoped-backup gap, not a forwarding bypass.
+//
+// These are fail-on-revert guards: reverting the intermediate descent to
+// `matched[0].Children` / first-`n.Children` drops the second block and
+// fails the both-blocks assertions below.
+
+// buildDupPolicyContext builds two identical 4-key
+// `from-zone untrust to-zone trust` sibling nodes (the load-override /
+// hierarchical shape) holding DISTINCT policies A and B — exercising the
+// MULTI-KEY intermediate descent branch (ast.go ~:211).
+func buildDupPolicyContext(t *testing.T) *ConfigTree {
+	t.Helper()
+	src := `security {
+    policies {
+        from-zone untrust to-zone trust {
+            policy A {
+                match {
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then {
+                    permit;
+                }
+            }
+        }
+        from-zone untrust to-zone trust {
+            policy B {
+                match {
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then {
+                    deny;
+                }
+            }
+        }
+    }
+}`
+	tree, perrs := NewParser(src).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse errors: %v", perrs)
+	}
+	return tree
+}
+
+// TestShowConfigDupContextMultiKeyDescent covers the multi-key intermediate
+// descent: a display path that descends PAST the duplicated 4-key
+// `from-zone untrust to-zone trust` context must see policies from BOTH
+// duplicate blocks.
+func TestShowConfigDupContextMultiKeyDescent(t *testing.T) {
+	tree := buildDupPolicyContext(t)
+	ctx := []string{"security", "policies", "from-zone", "untrust", "to-zone", "trust"}
+
+	// `show configuration ... trust policy` (bare `policy`, descends past
+	// the 4-key context, terminates on a repeated keyword) must list BOTH
+	// policy A and policy B. RED on revert: only policy A (block A's
+	// children).
+	hier := tree.FormatPath(append(append([]string{}, ctx...), "policy"))
+	if !strings.Contains(hier, "policy A") {
+		t.Errorf("FormatPath([...trust policy]) missing policy A; got:\n%s", hier)
+	}
+	if !strings.Contains(hier, "policy B") {
+		t.Errorf("FormatPath([...trust policy]) missing policy B (dropped second duplicate-context block); got:\n%s", hier)
+	}
+	if n := strings.Count(hier, "policy "); n != 2 {
+		t.Errorf("FormatPath([...trust policy]) rendered %d policies, want 2; got:\n%s", n, hier)
+	}
+
+	// Naming the SECOND block's policy directly (`... policy B`) must
+	// resolve to it. RED on revert: navigatePath descends into block A's
+	// children, never finds B → empty output.
+	setB := tree.FormatPathSet(append(append([]string{}, ctx...), "policy", "B"))
+	if !strings.Contains(setB, "policy B") || !strings.Contains(setB, "then deny") {
+		t.Errorf("FormatPathSet([...trust policy B]) did not resolve policy B; got:\n%s", setB)
+	}
+	if strings.Contains(setB, "policy A") {
+		t.Errorf("FormatPathSet([...trust policy B]) leaked policy A; got:\n%s", setB)
+	}
+
+	// Control: naming the FIRST block's policy is unchanged.
+	setA := tree.FormatPathSet(append(append([]string{}, ctx...), "policy", "A"))
+	if !strings.Contains(setA, "policy A") || !strings.Contains(setA, "then permit") {
+		t.Errorf("FormatPathSet([...trust policy A]) did not resolve policy A; got:\n%s", setA)
+	}
+	if strings.Contains(setA, "policy B") {
+		t.Errorf("FormatPathSet([...trust policy A]) leaked policy B; got:\n%s", setA)
+	}
+}
+
+// TestShowConfigDupContextSingleKeyDescent covers the single-key
+// intermediate descent branch (ast.go ~:242): two identical single-key
+// `interfaces { ge-0-0-0 { ... } }` blocks holding distinct leaves. The
+// display path descends through the duplicated single-key `interfaces`
+// level (and the duplicated single-key `ge-0-0-0` level) before terminating
+// — so both branches are pure single-key.
+func TestShowConfigDupContextSingleKeyDescent(t *testing.T) {
+	src := `interfaces {
+    ge-0-0-0 {
+        mtu 1500;
+    }
+}
+interfaces {
+    ge-0-0-0 {
+        mtu 9000;
+    }
+}`
+	tree, perrs := NewParser(src).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse errors: %v", perrs)
+	}
+
+	// `show configuration interfaces ge-0-0-0 mtu` must list BOTH mtu
+	// leaves. RED on revert: single-key descent walks only the first
+	// `interfaces` block → only mtu 1500.
+	hier := tree.FormatPath([]string{"interfaces", "ge-0-0-0", "mtu"})
+	if !strings.Contains(hier, "mtu 1500") {
+		t.Errorf("FormatPath([interfaces ge-0-0-0 mtu]) missing mtu 1500; got:\n%s", hier)
+	}
+	if !strings.Contains(hier, "mtu 9000") {
+		t.Errorf("FormatPath([interfaces ge-0-0-0 mtu]) missing mtu 9000 (dropped second duplicate single-key block); got:\n%s", hier)
+	}
+	if n := strings.Count(hier, "mtu "); n != 2 {
+		t.Errorf("FormatPath([interfaces ge-0-0-0 mtu]) rendered %d mtu leaves, want 2; got:\n%s", n, hier)
+	}
+
+	set := tree.FormatPathSet([]string{"interfaces", "ge-0-0-0", "mtu"})
+	if !strings.Contains(set, "set interfaces ge-0-0-0 mtu 1500") ||
+		!strings.Contains(set, "set interfaces ge-0-0-0 mtu 9000") {
+		t.Errorf("FormatPathSet([interfaces ge-0-0-0 mtu]) missing a duplicate-block mtu; got:\n%s", set)
+	}
+}
+
+// TestShowConfigSingleContextDescentUnchanged is the over-broadening guard:
+// a config with a SINGLE (non-duplicated) context renders a scoped descent
+// identically — exactly one policy, no leak from the fix.
+func TestShowConfigSingleContextDescentUnchanged(t *testing.T) {
+	src := `security {
+    policies {
+        from-zone untrust to-zone trust {
+            policy A {
+                then {
+                    permit;
+                }
+            }
+        }
+    }
+}`
+	tree, perrs := NewParser(src).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse errors: %v", perrs)
+	}
+	ctx := []string{"security", "policies", "from-zone", "untrust", "to-zone", "trust"}
+
+	hier := tree.FormatPath(append(append([]string{}, ctx...), "policy"))
+	if n := strings.Count(hier, "policy "); n != 1 {
+		t.Errorf("single-context FormatPath([...trust policy]) rendered %d policies, want 1; got:\n%s", n, hier)
+	}
+	if !strings.Contains(hier, "policy A") {
+		t.Errorf("single-context FormatPath([...trust policy]) missing policy A; got:\n%s", hier)
+	}
+
+	setA := tree.FormatPathSet(append(append([]string{}, ctx...), "policy", "A"))
+	if !strings.Contains(setA, "policy A") {
+		t.Errorf("single-context FormatPathSet([...trust policy A]) missing policy A; got:\n%s", setA)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #4562. `navigatePath`'s two INTERMEDIATE-descent branches walked only the FIRST matching sibling's subtree — `current = matched[0].Children` (multi-key branch, `pkg/config/ast.go` ~:211) and `current = n.Children` for the first matching node (single-key branch ~:242). When a hand-authored HIERARCHICAL config carries a DUPLICATE context block (two identical 4-key `from-zone untrust to-zone trust { ... }` policy contexts, or two identical single-key `interfaces { ... }` blocks) AND the display path continues deeper (e.g. `... from-zone untrust to-zone trust policy B`), descending into only the first block's children dropped the second duplicate-context block's statements from a path-scoped `show configuration <path>` and, worse, from its `| display set` — so a scoped display-set backup silently lost them on restore.

This is the intermediate-descent twin of the #3980 terminal read-all-siblings fix (same #3842 / #2419 class), which only covered a path that *ends* on a repeated keyword.

## Fix

Both intermediate-descent branches now continue against the UNION of every same-prefix (multi-key) / same-keyword (single-key) sibling's children via a new `unionChildren` helper. `unionChildren` returns the one node's children directly for a single match, so a normal non-duplicate path and a single-context config render **byte-identical**. The terminal #3980 branch is untouched.

## Why LOW (display-only, not a bypass)

`navigatePath` is DISPLAY-ONLY: all five callers are the `FormatPath*` renderers in `ast_format.go`, and the compiler reads the full AST directly via `FindChildren` — so the "hidden" statement is still ENFORCED. The impact is a display / scoped-backup gap, not a forwarding or security bypass. Preconditions are narrow: flat-set `SetPath` MERGES same-key containers, so only a hand-authored duplicate-context config plus a path-SCOPED display command triggers it (an unscoped `show configuration` renders the whole tree fine).

## Validation

- New `pkg/config/show_config_dup_context_4562_test.go` is **RED-on-revert for BOTH branches** (revert → policy B / mtu 9000 dropped) and holds the single-context no-regression control byte-identical.
- `go test ./pkg/config/` green, including the #3980 terminal suite.
- `gofmt`, `go vet`, `go build ./...` clean.
- Docs: `pkg/config/README.md` extends the #3980 read-all-siblings note to the descent; `_Log.md`.

Closes #4562

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi