### PR TITLE
ra: compare ReachableTime/RetransTimer in configEqual (#4570)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-07-07 — #4570 ra: configEqual now compares ReachableTime/RetransTimer so a commit changing only those RA timers restarts the sender
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4570 (ps-036 c12-14, LOW) — `configEqual` (pkg/ra/ra.go) is the
+  change-detector `Apply` gates the sender restart on (ra.go:282 → `continue`
+  when equal), but its scalar comparison list ended at `SourceLinkLocal` and
+  NEVER compared `ReachableTime` / `RetransTimer`. `buildRA` DOES stamp both
+  onto the wire (sender.go:718-719, the #4307 fix), so a day-2 commit changing
+  ONLY `reachable-time` and/or `retransmit-timer` compared EQUAL → the sender
+  was not restarted → the wire kept advertising the OLD RFC 4861 §4.2 ND timer
+  hints until an unrelated RA edit or a daemon restart. A genuine "commit clean
+  = enforced" violation; the codebase's own #4119 `DefaultLifetimeSet` comment
+  flags the identical bug class. Severity LOW: config-authoring trigger only
+  (not attacker-reachable), blast radius = advisory host-side ND timers (no
+  forwarding/security bypass, not fail-open), self-healing on the next
+  unrelated RA edit or restart. Fix: appended
+  `a.ReachableTime != b.ReachableTime || a.RetransTimer != b.RetransTimer` to
+  the scalar list (ra.go, right after SourceLinkLocal). Unlike DefaultLifetime
+  (#4119), 0=unspecified maps DIRECTLY to a zero wire field with no
+  unset/default coercion, so a plain int compare is exact and NO companion
+  "Set" flag is needed. PRESERVED: every existing comparison unchanged; two
+  configs with identical timers still compare equal (no spurious restart / no
+  RA gap). RED-on-revert verified (ra_test.go): reachable-time-only change →
+  NOT-equal (TestConfigEqual_DifferentReachableTime) [RED on revert],
+  retransmit-timer-only change → NOT-equal
+  (TestConfigEqual_DifferentRetransTimer) [RED on revert], identical timers →
+  equal (TestConfigEqual_SameTimers) [PASS on revert — guards no spurious
+  restart]. go test ./pkg/ra/... green; go build ./pkg/ra/ green; gofmt/vet
+  clean. Doc: pkg/ra/README.md gains a "configEqual must track EVERY field
+  buildRA stamps onto the wire" change-detection-contract gotcha cross-refing
+  #4307 (wire-stamping) and #4119 (the DefaultLifetimeSet sibling fix).
+- **File(s)**: pkg/ra/ra.go, pkg/ra/ra_test.go, pkg/ra/README.md, _Log.md
+
 ## 2026-07-07 — #4512 nat64: reserve a peer-synced session's translated pool port on the standby (cross-node HA)
 
 - **Timestamp**: 2026-07-07

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -252,6 +252,21 @@ best-effort).
     a bad option degrades to "missing that one option" instead of a total RA
     blackout. NDP options are independent on the wire, so per-option probing is
     faithful to how the combined RA marshals.
+- **`configEqual` must track EVERY field `buildRA` stamps onto the wire.**
+  `Apply` gates the sender restart on `configEqual(existing.cfg, cfg)` — an
+  interface whose config compares EQUAL keeps running untouched (no RA gap),
+  so any wire-affecting field that `buildRA` (`sender.go`) reads but
+  `configEqual` (`ra.go`) omits produces a silent "commit clean but not
+  enforced": the operator commits a change, sees no error, yet the wire keeps
+  advertising the old value until an unrelated RA edit or a daemon restart
+  reconciles it. The scalar comparison list is therefore the change-detection
+  contract and must be kept in lockstep with the fields `buildRA` marshals.
+  Two fixes of this exact class: `DefaultLifetimeSet` (#4119 — the set-flag is
+  part of the identity because unset→1800 and explicit-0 marshal DIFFERENT
+  Router Lifetimes) and `ReachableTime` / `RetransTimer` (#4570 — the RFC 4861
+  §4.2 ND timer hints wire-stamped by #4307; here 0=unspecified maps directly
+  to a zero wire field with no unset/default coercion, so a plain int compare
+  is exact and no companion set-flag is needed).
 - IPv6 NODAD is set on the per-instance NDP socket so it doesn't fight
   the kernel's own duplicate-address detection on the link-local
   address.

--- a/pkg/ra/ra.go
+++ b/pkg/ra/ra.go
@@ -810,7 +810,18 @@ func configEqual(a, b *config.RAInterfaceConfig) bool {
 		a.LinkMTU != b.LinkMTU ||
 		a.NAT64Prefix != b.NAT64Prefix ||
 		a.NAT64PrefixLife != b.NAT64PrefixLife ||
-		a.SourceLinkLocal != b.SourceLinkLocal {
+		a.SourceLinkLocal != b.SourceLinkLocal ||
+		// #4570: reachable-time / retransmit-timer are stamped onto the wire
+		// by buildRA (#4307, sender.go) but were omitted from this
+		// change-detector, so a day-2 commit changing ONLY those two RA-header
+		// timers left configEqual==true → Apply's `continue` skipped the
+		// sender restart → the wire kept advertising the OLD values until an
+		// unrelated RA edit or daemon restart. Unlike DefaultLifetime (#4119),
+		// 0 = "unspecified" maps DIRECTLY to a zero wire field with no
+		// unset/default coercion, so a plain int compare is exact — no "Set"
+		// companion is needed to distinguish absent from explicit-0.
+		a.ReachableTime != b.ReachableTime ||
+		a.RetransTimer != b.RetransTimer {
 		return false
 	}
 

--- a/pkg/ra/ra_test.go
+++ b/pkg/ra/ra_test.go
@@ -497,6 +497,43 @@ func TestConfigEqual_DifferentFlags(t *testing.T) {
 	}
 }
 
+// TestConfigEqual_DifferentReachableTime asserts that a commit changing ONLY
+// reachable-time is detected as NOT-equal so Apply restarts the sender and the
+// new value reaches the wire (#4570). RED-on-revert: drop the ReachableTime
+// comparison from configEqual and this fails.
+func TestConfigEqual_DifferentReachableTime(t *testing.T) {
+	a := &config.RAInterfaceConfig{Interface: "trust0", ReachableTime: 30000}
+	b := &config.RAInterfaceConfig{Interface: "trust0", ReachableTime: 60000}
+
+	if configEqual(a, b) {
+		t.Error("different ReachableTime should not be equal (sender must restart)")
+	}
+}
+
+// TestConfigEqual_DifferentRetransTimer asserts that a commit changing ONLY
+// retransmit-timer is detected as NOT-equal (#4570). RED-on-revert: drop the
+// RetransTimer comparison from configEqual and this fails.
+func TestConfigEqual_DifferentRetransTimer(t *testing.T) {
+	a := &config.RAInterfaceConfig{Interface: "trust0", RetransTimer: 1000}
+	b := &config.RAInterfaceConfig{Interface: "trust0", RetransTimer: 2000}
+
+	if configEqual(a, b) {
+		t.Error("different RetransTimer should not be equal (sender must restart)")
+	}
+}
+
+// TestConfigEqual_SameTimers guards against a spurious restart: two configs
+// with identical reachable-time/retransmit-timer (including the 0=unspecified
+// default) stay equal, so a no-op commit does not create an RA gap.
+func TestConfigEqual_SameTimers(t *testing.T) {
+	a := &config.RAInterfaceConfig{Interface: "trust0", ReachableTime: 30000, RetransTimer: 1000}
+	b := &config.RAInterfaceConfig{Interface: "trust0", ReachableTime: 30000, RetransTimer: 1000}
+
+	if !configEqual(a, b) {
+		t.Error("identical timers should be equal (no spurious sender restart)")
+	}
+}
+
 func TestRandomAdvInterval(t *testing.T) {
 	s := &sender{
 		cfg: &config.RAInterfaceConfig{


### PR DESCRIPTION
Closes #4570.

## Problem

`configEqual` (`pkg/ra/ra.go`) is the change-detector that `Apply` gates the
RA sender restart on — an interface whose config compares EQUAL keeps its
sender running untouched (no RA gap). Its scalar comparison list ended at
`SourceLinkLocal` and never compared `ReachableTime` / `RetransTimer`, yet
`buildRA` DOES stamp both onto the wire (`sender.go`, the #4307 fix).

So a day-2 commit changing ONLY `reachable-time` and/or `retransmit-timer`
compared EQUAL → the sender was not restarted → the wire kept advertising the
OLD RFC 4861 §4.2 ND timer hints until an unrelated RA-field edit or a daemon
restart reconciled it. A genuine "commit clean = enforced" violation; the
codebase's own #4119 `DefaultLifetimeSet` comment already flags the identical
bug class.

**Severity LOW:** config-authoring trigger only (not attacker-reachable);
blast radius = advisory host-side ND timers (no forwarding/security bypass,
not fail-open); self-heals on the next unrelated RA edit or restart.

## Fix

Append `a.ReachableTime != b.ReachableTime || a.RetransTimer != b.RetransTimer`
to `configEqual`'s scalar list, right after `SourceLinkLocal`. Unlike
`DefaultLifetime` (#4119), `0 = "unspecified"` maps DIRECTLY to a zero wire
field with no unset/default coercion, so a plain int compare is exact and no
companion "Set" flag is needed. Every existing comparison is unchanged; two
configs with identical timers still compare equal (no spurious restart / RA gap).

## Tests (RED-on-revert)

- `TestConfigEqual_DifferentReachableTime` — reachable-time-only change →
  NOT-equal (Apply restarts the sender). RED on revert.
- `TestConfigEqual_DifferentRetransTimer` — retransmit-timer-only change →
  NOT-equal. RED on revert.
- `TestConfigEqual_SameTimers` — identical timers → equal (no spurious
  restart). Passes on revert (guard).

`go test ./pkg/ra/...` green; `go build`, `gofmt`, `go vet` clean.

## Docs

`pkg/ra/README.md` gains a "configEqual must track EVERY field `buildRA` stamps
onto the wire" change-detection-contract gotcha cross-referencing #4307
(wire-stamping) and #4119 (the `DefaultLifetimeSet` sibling fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi