### PR TITLE
screen: fold flowless UDP fragment flood count into per-IP bucket (#4567)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -40180,3 +40180,43 @@ top.
 - **Timestamp**: 2026-07-07
 - **Action**: #4533 (follow-up to #4517) — the embedded-ICMP IPv6 ext-header walker `parse_embedded_v6_l4` (userspace-dp/src/afxdp/icmp_embed/parse.rs) was the last of the 10 IPv6 EH walkers NOT aligned to the #2292/#4435 fail-closed doctrine: it kept a PRE-EXISTING 6-iteration bound + a post-loop `Some((offset, protocol))` fall-through, so a quoted inner packet with >6 extension headers returned a bogus ext-type proto instead of failing closed. #4517 had already added the exotic-EH set (135/139/140/253/254) to this walker, so this change is purely the fail-closed alignment + bound bump. Fix: post-loop fall-through changed from `Some((offset, protocol))` to `None` (fail CLOSED on EH-overflow, matching frame/inspect.rs #2292 and the nat64.rs #4435 walkers); loop bound bumped `0..6` -> `0..MAX_IPV6_EXT_HEADERS` (8, the shared const re-exported at crate::afxdp) so a legit quoted packet with up to 7 ext headers still parses. Not a live bug pre-fix (a >6-EH quoted packet returned a proto that failed to match any session -> fail-SAFE drop), consistency-only. PRESERVED: ESP (50) still STOPS the walk (terminal `_` arm, returns Some early — unaffected by bound/post-loop); the #1838/#1853 non-first-fragment None guard; the #4517 exotic EH types still walk; ext-free + <=7-EH normal packets parse to the true proto/ports. RED-on-revert verified (parse.rs unit tests): embedded_ext_chain_overflow_fails_closed (8-EH chain -> parse_embedded_v6_l4 None + parse_embedded_v6 None; on revert the 6-bound returns Some((88, 253)) -> RED), embedded_seven_ext_headers_still_resolve (7 EH incl Mobility/HIP/Shim6/exp -> Some((96, TCP)); on the stale-6 bound returns Some((88,253)) -> RED), embedded_esp_stops_walk (base ESP -> Some((40,50)); ESP behind one HbH -> Some((48,50)) — preservation). FULL cargo test --release SERIAL green. Docs: userspace-dp/src/afxdp/frame/README.md canonical-contract walker list annotated with the #4533 fail-closed alignment; docs/research/2150-parser-consolidation/plan.md V6-c row updated (bound 6->8, EH-overflow fail-closed None).
 - **File(s)**: userspace-dp/src/afxdp/icmp_embed/parse.rs, userspace-dp/src/afxdp/frame/README.md, docs/research/2150-parser-consolidation/plan.md, _Log.md
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4567 (ps-036-c3-4 L-01) — a fragmented UDP flood split its
+  screen count across two count-min-sketch cells. The flow-present UDP flood
+  cap keys on `(dst_ip, dst_port)` (Junos parity, #4112 F18), but a non-first
+  IP fragment carries no L4 header, so the flowless caller
+  (`check_flowless_screens_opts`, poll_stages.rs flowless branch) passes
+  `dst_port == 0`. `udp_flood_drop` (userspace-dp/src/screen/mod.rs) then called
+  `increment_ip_port(dst_ip, 0)`, parking trailing fragments in a stray
+  `(dst_ip, 0)` SENTINEL-port cell — distinct from BOTH the datagram's real
+  `(dst_ip, port)` cell (first/atomic fragments, flow path) AND the
+  per-destination-IP `increment(dst_ip)` cell the ICMP flood path
+  (`icmp_flood_drop`, syn_rate.rs:197) already uses. VERIFY-FIRST confirmed the
+  threshold is read INLINE (the sketch `increment*` return value IS the
+  over-threshold signal), so the bucket incremented is the bucket read — no
+  separate read side to skew. Fix: `udp_flood_drop` branches on `dst_port == 0`
+  and folds the port-less fragment into the per-destination-IP `increment(dst_ip)`
+  bucket (the same abstraction ICMP uses); a first/atomic fragment or normal
+  datagram carries its real port (`dst_port != 0`) and still counts at
+  `(dst_ip, dst_port)`, unchanged; the ICMP path is untouched. Converging a
+  trailing fragment onto its datagram's real `(ip, port)` cell would need
+  reassembly context xpf lacks, so the per-IP fold is the bounded, honest
+  abstraction (LOW: per-port datagram DELIVERY is already capped by
+  first-fragment counting; this only keeps trailing-fragment noise in one
+  consistent per-IP cell instead of a stray `(ip,0)` one). RED-on-revert
+  verified (screen/tests.rs): udp_flood_flowless_fragment_folds_into_per_ip_bucket_4567
+  pre-saturates ONLY the per-IP(D) cells (via cell_indices + saturate_cell test
+  seams) then sends one flowless UDP fragment to D — after the fix it reads the
+  pre-saturated per-IP cells and Drops on the FIRST fragment; on revert it
+  counts the fresh `(D,0)` cells and Passes (Drop⟷Pass flips RED).
+  udp_flood_first_fragment_still_counts_per_ip_port_4567 pre-saturates per-IP(D)
+  then drives flow-path UDP datagrams to `(D,5001)`: first T still Pass, (T+1)th
+  trips its OWN `(ip,port)` bucket — proving the fold does not leak into
+  real-port counting (unchanged by the revert). ICMP unchanged
+  (icmp_flood_drop untouched; existing icmp_flood_flowless_drops guards it).
+  FULL cargo test --release SERIAL green. Docs: udp_flood_drop doc + body,
+  the flowless call-site comment, syn_rate.rs module doc, and the
+  userspace-dp/src/afxdp/README.md #3902 flowless-screens section gained a
+  #4567 note.
+- **File(s)**: userspace-dp/src/screen/mod.rs, userspace-dp/src/screen/syn_rate.rs, userspace-dp/src/screen/tests.rs, userspace-dp/src/afxdp/README.md, _Log.md

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -288,6 +288,21 @@ sync.
     on the flow-present `check_packet_with_zone_id` path — unchanged, with no
     screen double-run on the flow path. A truncated/unparseable header fails
     CLOSED (drop), matching the flow path (`#2146`).
+  - **#4567 — flowless UDP fragment folds into the per-destination-IP flood
+    bucket:** the flow-present UDP flood cap keys on `(dst_ip, dst_port)`
+    (Junos parity, `#4112` F18), but a non-first fragment carries no L4 port,
+    so the flowless caller passes `dst_port == 0`. `udp_flood_drop` now counts
+    that port-less fragment via the per-destination-IP `increment(dst_ip)`
+    bucket — the SAME abstraction the ICMP flood path uses (`icmp_flood_drop`)
+    — instead of `increment_ip_port(dst_ip, 0)`, which parked trailing
+    fragments in a stray `(dst_ip, 0)` sentinel-port cell distinct from both
+    the datagram's real `(dst_ip, port)` cell and the ICMP per-IP cell. A
+    first/atomic fragment or a normal datagram carries its real port and still
+    counts at `(dst_ip, dst_port)`, unchanged. Converging a trailing fragment
+    onto its datagram's real `(ip, port)` cell would need reassembly context
+    xpf lacks, so the per-IP fold is the bounded, honest abstraction (LOW —
+    per-port datagram DELIVERY is already capped by first-fragment counting;
+    this only keeps trailing-fragment noise in one consistent per-IP cell).
   - **#4155 — no screen rate double-count on fabric-redirected traffic:**
     a packet that ingressed the non-owner node was already screened there
     before being fabric-redirected to the RG owner (`docs/fabric-cross-chassis-fwd.md`).

--- a/userspace-dp/src/screen/mod.rs
+++ b/userspace-dp/src/screen/mod.rs
@@ -677,7 +677,8 @@ impl ScreenState {
     /// per-destination cap keys on `(dst_ip, dst_port)` (Junos `udp flood
     /// threshold` caps the rate to a destination IP AND port). On the flowless
     /// path a non-first fragment carries no L4 port, so `dst_port` is 0 there and
-    /// the cap degrades to per-destination-IP (the best available for a fragment).
+    /// the cap folds to the per-destination-IP `increment(dst_ip)` bucket — the
+    /// same abstraction `icmp_flood_drop` uses (#4567; see the body note).
     fn udp_flood_drop(
         &mut self,
         zone: &str,
@@ -687,12 +688,32 @@ impl ScreenState {
         now_ns: u64,
         now_secs: u64,
     ) -> bool {
-        // (1) per-DESTINATION (IP + PORT) cap — PRIMARY (Junos parity). Still
-        // the #3315 `RateCounter` sketch (deferred, `now_secs`).
-        if let Some(sketch) = self.udp_dst_sketch.get_mut(zone)
-            && sketch.increment_ip_port(dst_ip, dst_port, now_secs, threshold)
-        {
-            return true;
+        // (1) per-DESTINATION cap — PRIMARY (Junos parity). Still the #3315
+        // `RateCounter` sketch (deferred, `now_secs`).
+        //
+        // #4567: a non-first IP fragment carries no L4 header, so the flowless
+        // caller passes `dst_port == 0`. Counting it via `increment_ip_port(ip,
+        // 0)` splinters a fragmented UDP flood into its own `(ip, 0)` cell — a
+        // SENTINEL port, not a real one — distinct from BOTH the datagram's real
+        // `(ip, port)` cell (first/atomic fragments, flow path) AND the
+        // per-destination-IP abstraction the ICMP flood path already uses. Fold
+        // the port-less fragment into the SAME per-destination-IP
+        // `increment(dst_ip)` bucket as `icmp_flood_drop`, so trailing fragments
+        // accumulate in one consistent per-IP cell instead of a stray `(ip, 0)`
+        // cell. A first/atomic fragment or a normal datagram always carries its
+        // real port here (`dst_port != 0`) and still counts at `(dst_ip,
+        // dst_port)`, unchanged. Converging a trailing fragment onto its
+        // datagram's real `(ip, port)` cell would need reassembly context xpf
+        // lacks, so the per-IP fold is the bounded, honest abstraction.
+        if let Some(sketch) = self.udp_dst_sketch.get_mut(zone) {
+            let over = if dst_port == 0 {
+                sketch.increment(dst_ip, now_secs, threshold)
+            } else {
+                sketch.increment_ip_port(dst_ip, dst_port, now_secs, threshold)
+            };
+            if over {
+                return true;
+            }
         }
         // (2) per-zone aggregate — SECONDARY ceiling. #3607: `TokenBucket`
         // shaper (`now_ns`).
@@ -1214,7 +1235,9 @@ impl ScreenState {
 
         // UDP flood — per-DESTINATION cap (PRIMARY) + per-zone aggregate ceiling
         // (SECONDARY). A flowless non-first fragment has no L4 port, so `dst_port`
-        // is 0 here and the cap degrades to per-destination-IP (#4112 F18).
+        // is 0 here and `udp_flood_drop` folds it into the per-destination-IP
+        // `increment(dst_ip)` bucket (the ICMP-flood abstraction) rather than a
+        // stray `(ip, 0)` cell (#4112 F18, #4567).
         if udp_flood_threshold > 0
             && pkt.protocol == PROTO_UDP
             && self.udp_flood_drop(

--- a/userspace-dp/src/screen/syn_rate.rs
+++ b/userspace-dp/src/screen/syn_rate.rs
@@ -11,9 +11,10 @@
 //! The same substrate backs the per-destination ICMP/UDP flood caps (#4112):
 //! Junos measures `icmp flood` / `udp flood threshold` PER DESTINATION (UDP
 //! additionally per destination PORT), not per zone aggregate. `increment` keys
-//! on the destination IP (ICMP); `increment_ip_port` mixes the destination port
-//! in (UDP). The per-zone aggregate `RateCounter` is retained as a coarser
-//! SECONDARY ceiling above these per-destination caps.
+//! on the destination IP (ICMP, and a port-less UDP fragment — #4567);
+//! `increment_ip_port` mixes the destination port in (UDP with a real L4 port).
+//! The per-zone aggregate `RateCounter` is retained as a coarser SECONDARY
+//! ceiling above these per-destination caps.
 //!
 //! ## Substrate — count-min sketch of `RateCounter`s, NO eviction
 //!

--- a/userspace-dp/src/screen/tests.rs
+++ b/userspace-dp/src/screen/tests.rs
@@ -5127,6 +5127,77 @@ fn udp_flood_flowless_non_first_fragment_drops() {
 }
 
 #[test]
+fn udp_flood_flowless_fragment_folds_into_per_ip_bucket_4567() {
+    // RED-on-revert (#4567): a non-first UDP fragment (flowless, dst_port=0)
+    // must fold its flood count into the per-DESTINATION-IP `increment(dst_ip)`
+    // bucket — the SAME abstraction the ICMP flood path uses — NOT a distinct
+    // `(dst_ip, port=0)` bucket.
+    //
+    // A single-IP fragment stream trips EITHER bucket, so it cannot tell the two
+    // apart. This discriminator pre-saturates ONLY the per-DESTINATION-IP cells
+    // for D and leaves the `(D, 0)` cells fresh, then sends ONE flowless UDP
+    // fragment to D. After the fix `udp_flood_drop` reads the pre-saturated
+    // per-IP cells and Drops on the FIRST fragment; on revert it counts into the
+    // fresh `(D, 0)` cells (the per-IP cells are never consulted) and Passes. The
+    // Drop⟷Pass flips.
+    const T: u32 = 4;
+    let mut profile = ScreenProfile::default();
+    profile.udp_flood_threshold = T;
+    let mut state = make_state("trust", profile);
+    let d = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+    // Drive the per-DESTINATION-IP cells for D over threshold directly (test
+    // seam), leaving the `(D, port=0)` cells untouched.
+    let cells = state.udp_dst_sketch.get("trust").unwrap().cell_indices(&d);
+    let sketch = state.udp_dst_sketch.get_mut("trust").unwrap();
+    for (row, &col) in cells.iter().enumerate() {
+        sketch.saturate_cell(row, col, 100, T);
+    }
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let pkt = flowless_nonfirst_fragment(src, d, PROTO_UDP);
+    assert_eq!(
+        state.check_flowless_screens("trust", &pkt, true, 100),
+        ScreenVerdict::Drop("udp-flood"),
+        "flowless UDP fragment must count into the pre-saturated per-IP bucket, \
+         not a separate (ip,0) bucket"
+    );
+}
+
+#[test]
+fn udp_flood_first_fragment_still_counts_per_ip_port_4567() {
+    // Guard (#4567): folding a trailing fragment into the per-IP bucket must NOT
+    // change where a first/atomic fragment (flow path, real L4 port) counts.
+    // Pre-saturate the per-DESTINATION-IP cells for D, then drive normal UDP
+    // datagrams to `(D, 5001)` via the flow path: they count at `(D, 5001)`,
+    // independent of the per-IP(D) cells, so the first T still Pass (the
+    // pre-saturated per-IP cells are NOT consulted for a real port) and the
+    // (T+1)th trips its OWN `(ip, port)` bucket.
+    const T: u32 = 4;
+    let mut profile = ScreenProfile::default();
+    profile.udp_flood_threshold = T;
+    let mut state = make_state("trust", profile);
+    let d = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let cells = state.udp_dst_sketch.get("trust").unwrap().cell_indices(&d);
+    let sketch = state.udp_dst_sketch.get_mut("trust").unwrap();
+    for (row, &col) in cells.iter().enumerate() {
+        sketch.saturate_cell(row, col, 100, T);
+    }
+    let pkt = udp_pkt(src, d); // dst_port = 5001 (real L4 port, flow path)
+    for i in 0..T {
+        assert_eq!(
+            state.check_packet_with_zone_id("trust", 3, &pkt, 100),
+            ScreenVerdict::Pass,
+            "flow-path UDP datagram #{i} must count at (ip,port), not per-IP(D)"
+        );
+    }
+    assert_eq!(
+        state.check_packet_with_zone_id("trust", 3, &pkt, 100),
+        ScreenVerdict::Drop("udp-flood"),
+        "the (T+1)th datagram trips its own (ip,port) bucket"
+    );
+}
+
+#[test]
 fn teardrop_still_screened_on_flowless_path() {
     // #3064 regression guard: the L3 fragment screens still fire on the
     // flowless path through check_flowless_screens.


### PR DESCRIPTION
## Summary

Closes #4567. A fragmented UDP flood split its screen count across two
count-min-sketch cells. The flow-present UDP flood cap keys on
`(dst_ip, dst_port)` (Junos parity, #4112 F18), but a non-first IP fragment
carries no L4 header, so the flowless caller passes `dst_port == 0`.
`udp_flood_drop` then called `increment_ip_port(dst_ip, 0)`, parking trailing
fragments in a stray `(dst_ip, 0)` SENTINEL-port cell — distinct from BOTH the
datagram's real `(dst_ip, port)` cell (first/atomic fragments, flow path) AND
the per-destination-IP `increment(dst_ip)` cell the ICMP flood path
(`icmp_flood_drop`) already uses.

## Fix

`udp_flood_drop` (userspace-dp/src/screen/mod.rs) branches on `dst_port == 0`
and folds the port-less fragment into the per-destination-IP `increment(dst_ip)`
bucket — the same abstraction the ICMP flood path uses. The threshold is read
INLINE (the sketch `increment*()` return value IS the over-threshold signal),
so the bucket incremented is the bucket read — the count is neither
double-counted nor lost.

**Preserved:** a first/atomic fragment or a normal datagram carries its real
port (`dst_port != 0`) and still counts at `(dst_ip, dst_port)`; the ICMP flood
path is untouched. Converging a trailing fragment onto its datagram's real
`(ip, port)` cell would need reassembly context xpf lacks, so the per-IP fold is
the bounded, honest abstraction (LOW severity — per-port datagram DELIVERY is
already capped by first-fragment counting; this only keeps trailing-fragment
noise in one consistent per-IP cell).

## Tests (RED-on-revert)

- `udp_flood_flowless_fragment_folds_into_per_ip_bucket_4567` — pre-saturates
  ONLY the per-IP(D) cells (`cell_indices` + `saturate_cell` test seams) then
  sends one flowless UDP fragment to D. After the fix it reads the pre-saturated
  per-IP cells and Drops on the first fragment; on revert it counts the fresh
  `(D,0)` cells and Passes — the Drop⟷Pass flips (verified RED).
- `udp_flood_first_fragment_still_counts_per_ip_port_4567` — pre-saturates
  per-IP(D) then drives flow-path UDP datagrams to `(D,5001)`: first T still
  Pass, (T+1)th trips its own `(ip,port)` bucket — the fold does not leak into
  real-port counting (unchanged by the revert).
- ICMP unchanged (`icmp_flood_drop` untouched; existing `icmp_flood_flowless_drops`
  guards it).

Full `cargo test --release` serial: **3801 passed, 0 failed**.

## Docs

`udp_flood_drop` doc + body, the flowless call-site comment, the syn_rate.rs
module doc, and the userspace-dp/src/afxdp/README.md #3902 flowless-screens
section gained a #4567 note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi