### PR TITLE
dataplane: clamp workers before the heartbeat zero-init loop (#4572)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-07-07 — #4572 dataplane: clamp workers before the heartbeat zero-init loop so a large positive workers value can't wrap uint32 into a multi-billion-iteration apply hang
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4572 (ps-037-A6 F-A6-001, LOW control-plane DoS) —
+  `programBootstrapMapsLocked` (pkg/dataplane/userspace/maps_sync.go) zero-inits
+  the `userspace_heartbeat` Array (`Array<u64>`, max_entries 4096) with
+  `slot < uint32(cfg.Workers)*2*16`. VERIFY-FIRST corrected the issue's
+  headline: the NEGATIVE case (`workers -1` -> `uint32(-1)*32 = 4,294,967,264`
+  iterations) is already defended one layer up — `deriveUserspaceConfig`
+  (capabilities.go:26) coerces `workers<=0 -> 1` before the value reaches the
+  loop, and the sole caller (manager_compile.go:296) always passes that derived
+  ucfg. The LIVE, currently-reachable hang is a large POSITIVE value: the schema
+  leaf is min-only (`ValidateIntegerMin(1)`) and `deriveUserspaceConfig` does
+  NOT cap the upper side, so `workers 999999999` passes strict commit, survives
+  derivation, reaches the loop, and `uint32(999999999)*32` wraps uint32 to
+  ~1.9B iterations of `heartbeatMap.Update` — an apply/commit hang for hours (a
+  DoS, not fail-open; needs a trusted config source). Fix: hoisted
+  `workers := maxInt(cfg.Workers, 1)` before the `userspace_ctrl` struct and
+  used it for both `Workers` (was raw `uint32(cfg.Workers)`, line 154) and
+  `QueueCount` (already clamped, line 155) — restoring the line-154/179
+  consistency the issue flagged; and the loop bound is now
+  `heartbeatZeroSlots(cfg.Workers, heartbeatMap.MaxEntries())`, a new pure
+  helper that clamps the worker count into `[1, mapCap/heartbeatSlotsPerWorker]`
+  (128 workers at the current 4096-entry map) so the returned slot count can
+  never wrap uint32 or index past the fixed-size Array. PRESERVED: a normal
+  `workers 6` -> `heartbeatZeroSlots(6, 4096) = 192` (6*32), byte-identical to
+  the old `uint32(6)*32`; only <1 (clamped to 1 -> 32) and >128 (clamped to
+  4096) diverge. RED-on-revert verified
+  (maps_sync_heartbeat_slots_4572_test.go): reverting the helper body to raw
+  `uint32(workers)*heartbeatSlotsPerWorker` flips `heartbeatZeroSlots(-1,4096)`
+  to 4,294,967,264 (the exact hang count) and the over-cap / huge-positive
+  cases to out-of-bounds slot counts -> RED, while `six_unchanged` stays green.
+  go build ./... + go vet + go test ./pkg/dataplane/userspace/... green. Doc:
+  docs/config-schema.md gains a "#4572 (workers zero-init loop backstop)" bullet
+  next to the analogous #2524 ring-entries min-only backstop.
+- **File(s)**: pkg/dataplane/userspace/maps_sync.go, pkg/dataplane/userspace/maps_sync_heartbeat_slots_4572_test.go, docs/config-schema.md, _Log.md
+
 ## 2026-07-07 — #4570 ra: configEqual now compares ReachableTime/RetransTimer so a commit changing only those RA timers restarts the sender
 
 - **Timestamp**: 2026-07-07

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1826,6 +1826,30 @@ reserved for whole-dataplane selection where a rewrite shim
   non-power-of-two values at the `--ring-entries` CLI boundary
   (`server/lifecycle.rs validate_ring_entries_arg`). Go and Rust ceilings
   must stay equal.
+- **#4572 (workers zero-init loop backstop):** `system dataplane workers`
+  is the sibling min-only (`ValidateIntegerMin(1)`) leaf, and its runtime
+  ceiling is "owned by the runtime" (schema comment) rather than a strict
+  upper bound. `programBootstrapMapsLocked` zero-inits the
+  `userspace_heartbeat` Array (`Array<u64>`, `max_entries = 4096`) with
+  `slot < uint32(cfg.Workers)*2*16`. The **negative** case the issue
+  headlines (`workers -1` → `uint32(-1)*32 = 4,294,967,264` iterations) is
+  already defended one layer up: `deriveUserspaceConfig` (capabilities.go)
+  coerces `workers<=0 -> 1` before the value ever reaches the loop. The
+  **live** exposure is a large **positive** value: strict commit ACCEPTS it
+  (min-only validator) and `deriveUserspaceConfig` does not cap the upper
+  side, so `workers 999999999` reaches the loop and
+  `uint32(999999999)*32` wraps `uint32` to ~1.9B iterations of
+  `heartbeatMap.Update` — an apply/commit hang for hours (a control-plane
+  DoS, not a fail-open). The Go side now clamps once
+  (`workers := maxInt(cfg.Workers, 1)`, mirroring the adjacent `QueueCount`
+  / disabled-ctrl coercions) for the `userspace_ctrl` fields, and the
+  heartbeat zero-init loop bound is computed by
+  `heartbeatZeroSlots(cfg.Workers, heartbeatMap.MaxEntries())`
+  (`pkg/dataplane/userspace/maps_sync.go`): it clamps the worker count into
+  `[1, mapCap/heartbeatSlotsPerWorker]` so neither a negative nor an absurd
+  positive worker count can make the loop wrap `uint32` or index past the
+  fixed-size Array. This is the "lenient WARN-not-hang" contract applied at
+  the runtime consumer.
 - **#1746:** added the `class-of-service schedulers <s>
   equal-flow-target-policy (slowest | mean | ideal-share)` typed enum
   leaf (ValueEnumOf + `ValidateEnum`, same recipe as the scheduler

--- a/pkg/dataplane/userspace/maps_sync.go
+++ b/pkg/dataplane/userspace/maps_sync.go
@@ -148,11 +148,23 @@ func (m *Manager) programBootstrapMapsLocked(snapshot *ConfigSnapshot, cfg confi
 	if wgPort != 0 {
 		ctrlFlags |= userspaceCtrlFlagWgRx
 	}
+	// Clamp the worker count before it feeds the ctrl fields and the
+	// heartbeat zero-init loop below (#4572). deriveUserspaceConfig
+	// already coerces workers<=0 -> 1 (capabilities.go), so the negative
+	// case is defended one layer up; this restores the line-154/179
+	// consistency with the QueueCount clamp on the next line and keeps the
+	// low bound local to the map programmer. The genuinely dangerous input
+	// is a large POSITIVE workers: the schema leaf is min-only
+	// (ValidateIntegerMin(1)) and deriveUserspaceConfig does not cap the
+	// upper side, so e.g. `workers 999999999` reaches the loop below and
+	// uint32(999999999)*32 wraps to ~1.9B iterations that hang the apply
+	// for hours — bounded by heartbeatZeroSlots' map-capacity clamp.
+	workers := maxInt(cfg.Workers, 1)
 	ctrl := userspaceCtrlValue{
 		Enabled:            0,
 		MetadataVersion:    userspaceMetadataVersion,
-		Workers:            uint32(cfg.Workers),
-		QueueCount:         uint32(maxInt(cfg.Workers, 1)),
+		Workers:            uint32(workers),
+		QueueCount:         uint32(workers),
 		Flags:              ctrlFlags,
 		WgListenPort:       wgPort,
 		ConfigGeneration:   0,
@@ -176,7 +188,12 @@ func (m *Manager) programBootstrapMapsLocked(snapshot *ConfigSnapshot, cfg confi
 	// XDP shim correctly refuses to redirect until userspace begins updating.
 	{
 		var zeroHB uint64
-		for slot := uint32(0); slot < uint32(cfg.Workers)*2*16; slot++ {
+		// heartbeatZeroSlots clamps the worker count low to 1 and high to
+		// the Array's real capacity, so neither a negative nor an absurd
+		// cfg.Workers can make this loop wrap uint32 or index past the map
+		// (#4572).
+		slots := heartbeatZeroSlots(cfg.Workers, heartbeatMap.MaxEntries())
+		for slot := uint32(0); slot < slots; slot++ {
 			_ = heartbeatMap.Update(slot, zeroHB, ebpf.UpdateAny)
 		}
 	}
@@ -1690,6 +1707,36 @@ func pickInterfaceSnapshotV6(iface InterfaceSnapshot) net.IP {
 		}
 	}
 	return fallback
+}
+
+// heartbeatSlotsPerWorker is the number of userspace_heartbeat Array
+// slots reserved per dataplane worker (2 directions x up to 16 queues).
+// programBootstrapMapsLocked zero-inits workers*heartbeatSlotsPerWorker
+// slots on every apply.
+const heartbeatSlotsPerWorker = 2 * 16
+
+// heartbeatZeroSlots returns how many leading userspace_heartbeat Array
+// slots programBootstrapMapsLocked must zero-init for a configured worker
+// count. It clamps the worker count into [1, mapCap/heartbeatSlotsPerWorker]
+// so the returned slot count can never wrap uint32 or exceed the fixed-size
+// Array, regardless of what cfg.Workers carries.
+//
+// The low clamp mirrors the QueueCount / disabled-ctrl coercions
+// (workers<=0 -> 1). The negative-workers case is already defended by
+// deriveUserspaceConfig (capabilities.go), so the load-bearing guard is
+// the HIGH clamp: `workers` is a min-only schema leaf (ValidateIntegerMin(1))
+// with no upper bound in deriveUserspaceConfig, so a large positive value
+// (e.g. 999999999) reaches this function and a raw
+// uint32(workers)*heartbeatSlotsPerWorker wraps uint32 to ~1.9B loop
+// iterations that hang the apply for hours (#4572). Clamping the worker
+// count to mapCap/heartbeatSlotsPerWorker before the multiply keeps the
+// returned slot count <= mapCap and never wraps.
+func heartbeatZeroSlots(workers int, mapCap uint32) uint32 {
+	w := uint32(maxInt(workers, 1))
+	if maxW := mapCap / heartbeatSlotsPerWorker; w > maxW {
+		w = maxW
+	}
+	return w * heartbeatSlotsPerWorker
 }
 
 func maxInt(a, b int) int {

--- a/pkg/dataplane/userspace/maps_sync_heartbeat_slots_4572_test.go
+++ b/pkg/dataplane/userspace/maps_sync_heartbeat_slots_4572_test.go
@@ -1,0 +1,56 @@
+package userspace
+
+import "testing"
+
+// TestHeartbeatZeroSlots_4572 pins the heartbeat zero-init loop bound.
+//
+// Regression for #4572: programBootstrapMapsLocked previously looped
+// `slot < uint32(cfg.Workers)*2*16`. The negative case (workers -1 ->
+// uint32(-1)*32 = 4,294,967,264 iterations) is guarded upstream by
+// deriveUserspaceConfig (workers<=0 -> 1). The LIVE hang is a large
+// positive value: `workers` is a min-only schema leaf (ValidateIntegerMin(1))
+// with no upper cap in deriveUserspaceConfig, so `workers 999999999`
+// reaches the loop and uint32(999999999)*32 wraps uint32 to ~1.9B
+// iterations of heartbeatMap.Update — an apply hang for hours.
+// heartbeatZeroSlots clamps the worker count into
+// [1, mapCap/heartbeatSlotsPerWorker], bounding both directions.
+func TestHeartbeatZeroSlots_4572(t *testing.T) {
+	const mapCap = 4096 // userspace_heartbeat Array max_entries (lib.rs)
+	const perWorker = uint32(heartbeatSlotsPerWorker)
+
+	cases := []struct {
+		name    string
+		workers int
+		want    uint32
+	}{
+		// The bug values: negative / zero must clamp to a single worker's
+		// worth of slots, NOT wrap to billions.
+		{"negative_one", -1, perWorker},
+		{"zero", 0, perWorker},
+		{"large_negative", -5_000_000_000, perWorker},
+		// Normal values are unchanged (6 workers -> 6*32 = 192).
+		{"one", 1, perWorker},
+		{"six_unchanged", 6, 6 * perWorker},
+		{"cap_exact", mapCap / int(perWorker), mapCap}, // 128 workers -> 4096
+		// Absurd positives clamp to the map capacity instead of
+		// overrunning the Array or wrapping uint32.
+		{"over_cap", 200, mapCap},
+		{"huge_positive", 999_999_999, mapCap},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := heartbeatZeroSlots(tc.workers, mapCap)
+			if got != tc.want {
+				t.Fatalf("heartbeatZeroSlots(%d, %d) = %d, want %d",
+					tc.workers, mapCap, got, tc.want)
+			}
+			// The whole point of the fix: the loop bound is always small
+			// enough to run instantly and always within the Array.
+			if got > mapCap {
+				t.Fatalf("heartbeatZeroSlots(%d, %d) = %d exceeds map "+
+					"capacity %d — would index past the Array", tc.workers,
+					mapCap, got, mapCap)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`programBootstrapMapsLocked` (`pkg/dataplane/userspace/maps_sync.go`) zero-inits the `userspace_heartbeat` Array (`Array<u64>`, `max_entries 4096`) with `slot < uint32(cfg.Workers)*2*16`. `cfg.Workers` is an `int` and the `system dataplane workers` schema leaf is min-only (`ValidateIntegerMin(1)`) with its ceiling "owned by the runtime".

**VERIFY-FIRST correction to the issue's premise:** the **negative** case #4572 headlines (`workers -1` → `uint32(-1)*32 = 4,294,967,264` iterations) is already defended one layer up — `deriveUserspaceConfig` (`capabilities.go:26`) coerces `workers<=0 -> 1` before the value reaches the loop, and the sole caller (`manager_compile.go:296`) always passes that derived config.

**The live, currently-reachable hang is a large POSITIVE value.** Strict commit accepts it (min-only validator) and `deriveUserspaceConfig` does not cap the upper side, so `workers 999999999` reaches the loop and `uint32(999999999)*32` wraps `uint32` to ~1.9B iterations of `heartbeatMap.Update` — an apply/commit hang for hours (a control-plane DoS, not a fail-open; requires a trusted config source already carrying the value).

## Fix

- Hoist `workers := maxInt(cfg.Workers, 1)` and use it for both `userspace_ctrl` fields — `Workers` (was raw `uint32(cfg.Workers)`) and `QueueCount` (already clamped) — restoring the line-154/179 consistency the issue flagged.
- Compute the loop bound with a new pure helper `heartbeatZeroSlots(cfg.Workers, heartbeatMap.MaxEntries())` that clamps the worker count into `[1, mapCap/heartbeatSlotsPerWorker]` (128 workers at the current 4096-entry map), so the returned slot count can never wrap `uint32` or index past the fixed-size Array regardless of input.

## Preserve

A normal `workers 6` is unchanged: `heartbeatZeroSlots(6, 4096) = 192`, identical to the old `uint32(6)*32`. Only `<1` (clamped to 1 → 32) and `>128` (clamped to 4096) diverge.

## Validation

- `maps_sync_heartbeat_slots_4572_test.go` pins the clamp: negative/zero/large-negative → 32; `six` → 192 (unchanged); 128 → 4096; over-cap and 999999999 → 4096.
- **RED-on-revert confirmed:** reverting the helper body to raw `uint32(workers)*heartbeatSlotsPerWorker` flips `heartbeatZeroSlots(-1,4096)` to 4,294,967,264 (the exact hang count) and the over-cap cases to out-of-bounds slot counts, while `six_unchanged` stays green.
- `go build ./...`, `go vet ./pkg/dataplane/userspace/...`, and `go test ./pkg/dataplane/userspace/...` all pass.
- `docs/config-schema.md` documents the backstop next to the analogous #2524 ring-entries min-only case.

Closes #4572

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi