### PR TITLE
vrrp/config: bound VRRP GroupID to the RFC 5798 VRID range (#4573)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,46 @@
+## 2026-07-07 — #4573 vrrp/config: VRRP GroupID (VRID) range gate + priority Atoi-swallow fix
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4573 (ps-037-A3 B-001/B-002, low-med) — the `vrrp-group <id>`
+  instance slot had NO value validator (documented identity-token deferral,
+  schema_interfaces.go) and `parseVRRPGroups` stored any numeric id verbatim,
+  while the native VRRP engine truncates it onto the single VRID wire byte
+  (`uint8(vi.cfg.GroupID)`, pkg/vrrp/instance.go:1148/1249/1364/1425/1834/1849).
+  So `vrrp-group 256` wrapped to the RFC 5798-reserved VRID 0 (a strict RFC peer
+  such as Juniper discards the advert → the VIP never masters → HA cold-boot
+  blackhole) and 257 aliased VRID 1 onto an unrelated group. The chassis RG-id
+  analog was hardened (validateChassisClusterStrict, #4434) but VRRP was left
+  unguarded — that asymmetry is the gap. B-001 fix: new
+  `validateVRRPGroupIDStrict` (pkg/config/compiler_validate_strict_vrrp.go,
+  MinVRRPGroupID=1/MaxVRRPGroupID=255) is the exact sibling of the chassis gate
+  — hard-rejects an out-of-range id on STRICT commit, downgrades to a warning on
+  the tolerant load / HA-sync path (`lenientVRRPGroupID`, #1960 no-brick); wired
+  into the compiler tail-gate pass alongside validateChassisClusterStrict
+  (compiler_uniformgates.go). Defensive runtime range guard at instance creation
+  (pkg/vrrp/vrrp.go MinVRID/MaxVRID; manager.go UpdateInstances skips + slog.Warn
+  an out-of-range VRID) so a value that slips through the lenient path never
+  advertises VRID 0. B-002 fix: the priority / preempt hold-time /
+  advertise-interval parse in parseVRRPGroups (compiler_interfaces.go, BOTH the
+  flat-set Keys arm and the hierarchical child-node arm) no longer swallows the
+  `strconv.Atoi` error with `_ =` — a bad parse now keeps the constructor
+  default (priority 100) instead of silently resetting to 0 (the RFC 5798
+  resignation value). RED-on-revert verified: (config) 256/0/-1/300/65536 →
+  strict commit REJECTS with a named error, lenient WARNS not bricks, in-range
+  1/100/255 commit clean with no warning [revert: neuter validator → out-of-range
+  accepted]; (priority) non-numeric `priority abc` on the lenient path keeps 100
+  [revert hierarchical arm to `_ =` → got 0]; (runtime) UpdateInstances drops
+  GroupID 0/256/-1 and keeps 100, boundary 1/255 build [revert guard → all 4
+  built]. go test ./pkg/config/... ./pkg/vrrp/... green; go build ./... green;
+  gofmt/vet clean. test-failover is a nice-to-have (the change only REJECTS
+  invalid configs, so valid-config failover timing is unaffected) — deferred to
+  the parent.
+- **File(s)**: pkg/config/compiler_validate_strict_vrrp.go,
+  pkg/config/compiler_validate_strict_vrrp_4573_test.go,
+  pkg/config/compiler_uniformgates.go, pkg/config/compiler.go,
+  pkg/config/compiler_interfaces.go, pkg/config/schema_interfaces.go,
+  pkg/vrrp/vrrp.go, pkg/vrrp/manager.go, pkg/vrrp/vrid_guard_4573_test.go,
+  docs/config-schema.md, _Log.md
+
 ## 2026-07-07 — #4570 ra: configEqual now compares ReachableTime/RetransTimer so a commit changing only those RA timers restarts the sender
 
 - **Timestamp**: 2026-07-07

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1710,7 +1710,32 @@ reserved for whole-dataplane selection where a rewrite shim
   groups are keyed `<address-CIDR>_grp<id>`, so a dual-stack unit may
   carry an `inet` AND an `inet6` vrrp-group with the SAME group id without
   collision (the address strings differ → two distinct
-  `unit.VRRPGroups` entries). **#2850 — `preempt hold-time`:** the
+  `unit.VRRPGroups` entries). **#4573 — VRRP VRID range gate:** the
+  `vrrp-group <id>` instance-name slot stays an unvalidated identity
+  token in the schema (same deferral class as `redundancy-group <id>`),
+  but a *semantic* commit-time cap now bounds it —
+  `validateVRRPGroupIDStrict` in `compiler_validate_strict_vrrp.go`,
+  the exact sibling of the chassis `validateChassisClusterStrict`
+  (#4434). The VRRP VRID is a single wire byte (RFC 5798 §5.2.3, valid
+  range 1..255): the native engine truncates the configured id onto it
+  (`uint8(vi.cfg.GroupID)`, `pkg/vrrp/instance.go`), so `vrrp-group 256`
+  wrapped to the RESERVED VRID 0 (a strict RFC peer such as Juniper
+  discards the advert → the VIP never masters → HA cold-boot blackhole)
+  and 257 aliased VRID 1 onto an unrelated group. Non-numeric garbage was
+  always dropped by `parseVRRPGroups`, but an out-of-range NUMERIC id
+  used to produce a live wrong-VRID instance — that asymmetry is closed.
+  Like the #4434 gate it runs on the compiled `*Config`, NOT the schema
+  walker (so it does not change the identity-token typing decision), and
+  the tolerant load / peer-sync path downgrades it to a warning
+  (`lenientVRRPGroupID`, #1960 no-brick) with a defensive runtime range
+  check at instance creation (`pkg/vrrp` `MinVRID`/`MaxVRID`,
+  `manager.go UpdateInstances`) that refuses to advertise an
+  out-of-range VRID for a value that slips through the lenient path.
+  B-002 companion: the `priority`/`preempt hold-time`/`advertise-interval`
+  parse in `parseVRRPGroups` no longer swallows an `strconv.Atoi` error
+  with `_ =` — a bad parse kept the constructor default (priority 100)
+  instead of silently resetting to 0 (the RFC 5798 resignation value).
+  **#2850 — `preempt hold-time`:** the
   `vrrp-group <id> preempt` leaf gained a nested `hold-time <seconds>`
   child (`schema_interfaces.go`, typed `ValidateInteger(1, 3600)`), Junos
   `set interfaces <if> unit <n> family inet vrrp-group <id> preempt

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1266,6 +1266,21 @@ type compileOpts struct {
 	// leniently-loaded over-size config is bounded on the wire, not a panic.
 	// Same doctrine as lenientFlowAging.
 	lenientChassisRG bool
+	// lenientVRRPGroupID (#4573) downgrades the VRRP VRID wire-width gate
+	// (validateVRRPGroupIDStrict) from a hard compile error to a cfg.Warnings
+	// entry. The strict commit / commit-check path hard-rejects a
+	// `vrrp-group <id>` outside the RFC 5798 VRID range 1..255 (the id is
+	// truncated onto a single wire byte, so 256 wraps to the reserved VRID 0
+	// and the VIP never masters, 257 aliases VRID 1 onto another group). The
+	// `vrrp-group <id>` instance slot has no schema value validator (documented
+	// deferral, schema_interfaces.go), so an out-of-range numeric id used to
+	// commit cleanly and produce a live wrong-VRID instance. The tolerant load
+	// / peer-sync paths downgrade to a warning so an already-persisted or
+	// peer-synced config an older binary accepted still BOOTS (#1960 no-brick);
+	// the pkg/vrrp instance-creation range check independently refuses to
+	// advertise an out-of-range VRID, so a leniently-loaded bad id is bounded,
+	// not a wrong-VRID advert. Same doctrine as lenientChassisRG.
+	lenientVRRPGroupID bool
 	// lenientReservedZoneNames (#3055) downgrades the reserved zone-name
 	// definition gate (validateReservedZoneNamesStrict) from a hard compile
 	// error to a cfg.Warnings entry. The strict commit / commit-check path
@@ -1606,6 +1621,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientTrailingTokens:                  true,
 		lenientFlowAging:                       true,
 		lenientChassisRG:                       true,
+		lenientVRRPGroupID:                     true,
 		lenientReservedZoneNames:               true,
 		lenientBackupRouterDst:                 true,
 		lenientSecureTunnelBindIface:           true,
@@ -1852,6 +1868,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientTrailingTokens:                  true,
 		lenientFlowAging:                       true,
 		lenientChassisRG:                       true,
+		lenientVRRPGroupID:                     true,
 		lenientReservedZoneNames:               true,
 		lenientBackupRouterDst:                 true,
 		lenientSecureTunnelBindIface:           true,

--- a/pkg/config/compiler_interfaces.go
+++ b/pkg/config/compiler_interfaces.go
@@ -728,7 +728,14 @@ func parseVRRPGroups(unit *InterfaceUnit, addrName string, addrNode *Node) {
 			case "priority":
 				if i+1 < len(keys) {
 					i++
-					vg.Priority, _ = strconv.Atoi(keys[i])
+					// #4573: only overwrite on a clean parse. A swallowed
+					// Atoi error (`_ =`) used to reset Priority to 0 — the
+					// RFC 5798 resignation value — on the lenient / HA-sync
+					// path; keep the constructor default (100) or the prior
+					// value instead of silently resigning the group.
+					if n, err := strconv.Atoi(keys[i]); err == nil {
+						vg.Priority = n
+					}
 				}
 			case "preempt":
 				vg.Preempt = true
@@ -737,7 +744,10 @@ func parseVRRPGroups(unit *InterfaceUnit, addrName string, addrNode *Node) {
 				// shape: ... preempt hold-time 30. Consume the
 				// optional `hold-time <n>` pair when present.
 				if i+2 < len(keys) && keys[i+1] == "hold-time" {
-					vg.PreemptHoldTime, _ = strconv.Atoi(keys[i+2])
+					// #4573: keep the prior value on a bad parse (`_ =`).
+					if n, err := strconv.Atoi(keys[i+2]); err == nil {
+						vg.PreemptHoldTime = n
+					}
 					i += 2
 				}
 			case "accept-data":
@@ -745,7 +755,10 @@ func parseVRRPGroups(unit *InterfaceUnit, addrName string, addrNode *Node) {
 			case "advertise-interval":
 				if i+1 < len(keys) {
 					i++
-					vg.AdvertiseInterval, _ = strconv.Atoi(keys[i])
+					// #4573: keep the prior value on a bad parse (`_ =`).
+					if n, err := strconv.Atoi(keys[i]); err == nil {
+						vg.AdvertiseInterval = n
+					}
 				}
 			case "authentication-type":
 				if i+1 < len(keys) {
@@ -814,7 +827,12 @@ func parseVRRPGroups(unit *InterfaceUnit, addrName string, addrNode *Node) {
 				}
 			case "priority":
 				if v := nodeVal(prop); v != "" {
-					vg.Priority, _ = strconv.Atoi(v)
+					// #4573: only overwrite on a clean parse — see the
+					// flat-set arm above (a swallowed Atoi would resign the
+					// group at priority 0 on the lenient path).
+					if n, err := strconv.Atoi(v); err == nil {
+						vg.Priority = n
+					}
 				}
 			case "preempt":
 				vg.Preempt = true
@@ -826,16 +844,24 @@ func parseVRRPGroups(unit *InterfaceUnit, addrName string, addrNode *Node) {
 				// (immediate).
 				if ht := prop.FindChild("hold-time"); ht != nil {
 					if v := nodeVal(ht); v != "" {
-						vg.PreemptHoldTime, _ = strconv.Atoi(v)
+						// #4573: keep the prior value on a bad parse (`_ =`).
+						if n, err := strconv.Atoi(v); err == nil {
+							vg.PreemptHoldTime = n
+						}
 					}
 				} else if len(prop.Keys) >= 3 && prop.Keys[1] == "hold-time" {
-					vg.PreemptHoldTime, _ = strconv.Atoi(prop.Keys[2])
+					if n, err := strconv.Atoi(prop.Keys[2]); err == nil {
+						vg.PreemptHoldTime = n
+					}
 				}
 			case "accept-data":
 				vg.AcceptData = true
 			case "advertise-interval":
 				if v := nodeVal(prop); v != "" {
-					vg.AdvertiseInterval, _ = strconv.Atoi(v)
+					// #4573: keep the prior value on a bad parse (`_ =`).
+					if n, err := strconv.Atoi(v); err == nil {
+						vg.AdvertiseInterval = n
+					}
 				}
 			case "authentication-type":
 				vg.AuthType = nodeVal(prop)

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -314,6 +314,24 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 		}
 	}
 
+	// #4573 VRRP VRID wire-width gate. Strict on commit / commit-check
+	// (hard-reject a `vrrp-group <id>` outside the RFC 5798 VRID range 1..255 —
+	// the id is truncated onto a single wire byte, so 256 wraps to the reserved
+	// VRID 0 and the VIP never masters, and 257 aliases VRID 1 onto another
+	// group). Lenient on load / peer-sync (warn so an already-persisted or
+	// peer-synced config still boots — #1960 no-brick; the pkg/vrrp runtime
+	// range check independently refuses to advertise an out-of-range VRID, so a
+	// leniently-loaded bad id is bounded, not a wrong-VRID advert). Runs on the
+	// fully-compiled *Config (VRRPGroups populated by parseVRRPGroups).
+	if err := validateVRRPGroupIDStrict(cfg); err != nil {
+		if opts.lenientVRRPGroupID {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("vrrp-group id (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #3055 reserved zone-name definition gate. Strict on commit / commit-check
 	// (hard-reject a `security zones security-zone <name>` whose name is a
 	// reserved sentinel — "junos-global" is reclassified by the userspace

--- a/pkg/config/compiler_validate_strict_vrrp.go
+++ b/pkg/config/compiler_validate_strict_vrrp.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+)
+
+// MinVRRPGroupID / MaxVRRPGroupID bound the VRRP Virtual Router ID (VRID) that
+// a `vrrp-group <id>` block may carry. RFC 5798 §5.2.3 defines the VRID as an
+// 8-bit field whose valid range is 1..255 — 0 is not a usable VRID (a router
+// that receives an advertisement with VRID 0 has no group 0 to match it
+// against, so a strict RFC peer such as Juniper silently discards it). The
+// native VRRP engine truncates the configured id straight onto that byte
+// (pkg/vrrp/instance.go writes `uint8(vi.cfg.GroupID)` into the VRID field at
+// send and matches it on receive, e.g. instance.go:1148/1834/1849), so a
+// `vrrp-group 256` wraps to VRID 0 (peer discards → the VIP never masters, an
+// HA cold-boot blackhole) and `vrrp-group 257` aliases VRID 1 onto an unrelated
+// group (cross-talk / dual-master).
+const (
+	MinVRRPGroupID = 1
+	MaxVRRPGroupID = 255
+)
+
+// validateVRRPGroupIDStrict hard-rejects, at commit / commit-check, a
+// `vrrp-group <id>` whose id falls outside the RFC 5798 VRID range 1..255
+// (#4573, ps-037-A3 B-001).
+//
+// The config-mode schema documents the `vrrp-group <id>` instance slot as an
+// unvalidated identity token (schema_interfaces.go vrrpGroupSchemaNode) — the
+// deferral is safe for NON-numeric garbage (parseVRRPGroups drops an
+// unparseable id, compiler_interfaces.go), but an OUT-OF-RANGE NUMERIC id is
+// stored verbatim and later truncated onto the single VRID wire byte, producing
+// a live wrong-VRID instance. This mirrors the chassis redundancy-group id gate
+// (validateChassisClusterStrict, MaxHeartbeatRedundancyGroupID) that the schema
+// comment cites as its model — that analog was hardened while VRRP was left
+// unguarded, and this closes the asymmetry.
+//
+// On the tolerant load / peer-sync paths the compileExpanded call site
+// downgrades this to a warning (opts.lenientVRRPGroupID) so an already-
+// persisted or peer-synced config an older binary accepted still boots (#1960
+// no-brick); a defensive runtime range check at instance creation
+// (pkg/vrrp/manager.go UpdateInstances) refuses to advertise an out-of-range
+// VRID for a value that slips through the lenient path.
+func validateVRRPGroupIDStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	// Deterministic walk (interface name → unit number → group key) so the
+	// first-error commit-check message is stable across map-ordered runs,
+	// matching the compiler_validate_strict.go VRRP containment walk.
+	ifNames := make([]string, 0, len(cfg.Interfaces.Interfaces))
+	for name := range cfg.Interfaces.Interfaces {
+		ifNames = append(ifNames, name)
+	}
+	sort.Strings(ifNames)
+	for _, ifName := range ifNames {
+		ifc := cfg.Interfaces.Interfaces[ifName]
+		if ifc == nil {
+			continue
+		}
+		unitNums := make([]int, 0, len(ifc.Units))
+		for n := range ifc.Units {
+			unitNums = append(unitNums, n)
+		}
+		sort.Ints(unitNums)
+		for _, un := range unitNums {
+			unit := ifc.Units[un]
+			if unit == nil || len(unit.VRRPGroups) == 0 {
+				continue
+			}
+			gkeys := make([]string, 0, len(unit.VRRPGroups))
+			for k := range unit.VRRPGroups {
+				gkeys = append(gkeys, k)
+			}
+			sort.Strings(gkeys)
+			for _, gk := range gkeys {
+				vg := unit.VRRPGroups[gk]
+				if vg == nil {
+					continue
+				}
+				if vg.ID < MinVRRPGroupID || vg.ID > MaxVRRPGroupID {
+					return fmt.Errorf("vrrp-group id %d on %s unit %d is out of "+
+						"range %d..%d (the VRRP VRID is one wire byte, RFC 5798 "+
+						"§5.2.3; an id above %d truncates on the wire — 256 wraps "+
+						"to the reserved VRID 0 and the VIP never masters, 257 "+
+						"aliases VRID 1 onto another group) — renumber the "+
+						"vrrp-group", vg.ID, ifName, un, MinVRRPGroupID,
+						MaxVRRPGroupID, MaxVRRPGroupID)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/config/compiler_validate_strict_vrrp_4573_test.go
+++ b/pkg/config/compiler_validate_strict_vrrp_4573_test.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4573 (ps-037-A3 B-001 / B-002): the `vrrp-group <id>` instance slot has no
+// schema value validator (a documented deferral, schema_interfaces.go), and
+// parseVRRPGroups stored any numeric id verbatim while the VRRP state machine
+// truncates it onto the single VRID wire byte (uint8(vi.cfg.GroupID)). So a
+// `vrrp-group 256` wrapped to the reserved VRID 0 (a strict RFC peer discards
+// the advert → the VIP never masters → HA cold-boot blackhole) and 257 aliased
+// VRID 1 onto another group. validateVRRPGroupIDStrict makes an out-of-range id
+// an operator-visible commit error, mirroring the chassis redundancy-group id
+// gate (validateChassisClusterStrict). B-002: the priority/hold-time flat-set
+// and hierarchical parse used `_ =` Atoi, silently resetting Priority to 0 (RFC
+// 5798 resignation) on a bad parse; the fix keeps the default/prior value.
+//
+// FAIL-ON-REVERT: drop the validateVRRPGroupIDStrict dispatch in
+// compileExpanded (compiler_uniformgates.go) or the range check in the
+// validator and the out-of-range subtests go green on the BAD config — exactly
+// the wrong-VRID regression this test exists to catch. The in-range and
+// lenient-path subtests pin that the gate does not over-reject and does not
+// brick a persisted config.
+
+// vrrpGroupSetLines returns the flat-set lines that define a single vrrp-group
+// with the given id under reth0 unit 0 family inet.
+func vrrpGroupSetLines(id string) []string {
+	base := "set interfaces reth0 unit 0 family inet address 10.0.61.10/24 vrrp-group " + id
+	return []string{
+		base + " virtual-address 10.0.61.1/24",
+		base + " priority 200",
+	}
+}
+
+func TestVRRPGroupIDOutOfRangeFailsCommit(t *testing.T) {
+	// 256 truncates uint8(256) == 0 (reserved VRID); 0 and -1 are below the
+	// RFC 5798 valid range (1..255).
+	for _, id := range []string{"256", "0", "-1", "300", "65536"} {
+		t.Run("id="+id, func(t *testing.T) {
+			tree := replaySetLines(t, vrrpGroupSetLines(id))
+			if _, err := CompileConfig(tree); err == nil {
+				t.Fatalf("expected commit to reject vrrp-group %s (VRID is a "+
+					"single wire byte, RFC 5798 range 1..255), got nil error", id)
+			} else if !strings.Contains(err.Error(), "vrrp-group id "+id) ||
+				!strings.Contains(err.Error(), "out of") {
+				t.Fatalf("error %q does not name the out-of-range vrrp-group id %s",
+					err.Error(), id)
+			}
+
+			// Tolerant path (load / peer-sync) must NOT brick — it downgrades
+			// to a warning so an already-persisted config still boots (#1960).
+			lcfg, lerr := CompileConfigLenient(tree)
+			if lerr != nil {
+				t.Fatalf("lenient compile must not reject an out-of-range "+
+					"vrrp-group id (no-brick), got %v", lerr)
+			}
+			if !warningsContain(lcfg.Warnings, "vrrp-group id") {
+				t.Fatalf("lenient compile should have warned about the "+
+					"vrrp-group id; warnings=%v", lcfg.Warnings)
+			}
+		})
+	}
+}
+
+func TestVRRPGroupIDInRangeCommits(t *testing.T) {
+	// The boundaries: 1 and 255 both fit the VRID byte and must commit cleanly
+	// with no rejection and no warning.
+	for _, id := range []string{"1", "100", "255"} {
+		t.Run("id="+id, func(t *testing.T) {
+			tree := replaySetLines(t, vrrpGroupSetLines(id))
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("in-range vrrp-group %s must commit cleanly, got %v", id, err)
+			}
+			if warningsContain(cfg.Warnings, "vrrp-group id") {
+				t.Fatalf("in-range vrrp-group %s should not warn; warnings=%v",
+					id, cfg.Warnings)
+			}
+			vg := firstVRRPGroupWithVIP(t, cfg, "10.0.61.1/24")
+			if vg == nil {
+				t.Fatalf("vrrp-group %s did not compile its VIP", id)
+			}
+		})
+	}
+}
+
+// TestVRRPPriorityNonNumericKeepsDefault pins B-002: a non-numeric priority on
+// the lenient compile path no longer silently resets Priority to 0 (RFC 5798
+// resignation). The constructor default (100) survives the bad Atoi.
+func TestVRRPPriorityNonNumericKeepsDefault(t *testing.T) {
+	// Flat-set shape: `priority abc` packs "abc" onto the group's Keys run.
+	tree := replaySetLines(t, []string{
+		"set interfaces reth0 unit 0 family inet address 10.0.61.10/24 vrrp-group 1 virtual-address 10.0.61.1/24",
+		"set interfaces reth0 unit 0 family inet address 10.0.61.10/24 vrrp-group 1 priority abc",
+	})
+	// Use the lenient path: strict commit would reject via the schema
+	// ValidateInteger(1,255) leaf, but the lenient / HA-sync load reaches
+	// parseVRRPGroups with the bad token.
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile: %v", err)
+	}
+	vg := firstVRRPGroupWithVIP(t, cfg, "10.0.61.1/24")
+	if vg == nil {
+		t.Fatal("vrrp-group did not compile its VIP")
+	}
+	// FAIL-ON-REVERT: with the `_ =` Atoi swallow the group resigns at
+	// priority 0; the fix keeps the constructor default of 100.
+	if vg.Priority != 100 {
+		t.Fatalf("non-numeric priority should keep the default 100, got %d "+
+			"(a swallowed Atoi would resign the group at 0)", vg.Priority)
+	}
+}

--- a/pkg/config/schema_interfaces.go
+++ b/pkg/config/schema_interfaces.go
@@ -17,8 +17,13 @@ package config
 // the compiler silently drop the instance, but these ids are
 // cross-referenced from other subsystems — e.g. class-of-service
 // `interfaces <if> unit <n>` — and deserve one dedicated pass that
-// types every referencing slot together), `track-interface
-// priority-cost`
+// types every referencing slot together). NOTE (#4573): the SCHEMA
+// deferral above is only safe for NON-numeric garbage; an
+// OUT-OF-RANGE NUMERIC `vrrp-group <id>` is bounded by a semantic
+// commit gate on the compiled *Config — `validateVRRPGroupIDStrict`
+// (`compiler_validate_strict_vrrp.go`), the RFC 5798 VRID-range 1..255
+// analog of the chassis `validateChassisClusterStrict` (#4434) — NOT
+// through this schema walker. `track-interface priority-cost`
 // (already strict-rejected by the #1814 AST pre-walk in the
 // compiler — typing here would shadow those curated errors), the
 // dhcp/dhcpv6 client knobs and tunnel keepalives (deferred:

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -328,6 +328,20 @@ func (m *Manager) UpdateInstances(desired []*Instance) error {
 	desiredMap := make(map[instanceKey]*Instance, len(desired))
 	desiredIfaces := make(map[string]struct{}, len(desired))
 	for _, inst := range desired {
+		// #4573 defensive VRID range guard. The GroupID is truncated onto the
+		// single VRID wire byte (uint8(vi.cfg.GroupID) in instance.go). An
+		// out-of-range id normally cannot reach here — the config commit gate
+		// (validateVRRPGroupIDStrict) rejects it — but the tolerant load /
+		// HA-sync path downgrades that gate to a warning (#1960 no-brick), so a
+		// bad id could slip through and advertise the reserved VRID 0 (256→0) or
+		// an aliased VRID (257→1). Refuse to build such an instance rather than
+		// emit a wrong-VRID advert that a strict RFC peer discards.
+		if inst.GroupID < MinVRID || inst.GroupID > MaxVRID {
+			slog.Warn("vrrp: skipping instance with out-of-range VRID",
+				"interface", inst.Interface, "group_id", inst.GroupID,
+				"valid_range", fmt.Sprintf("%d..%d", MinVRID, MaxVRID))
+			continue
+		}
 		key := instanceKey{iface: inst.Interface, groupID: inst.GroupID}
 		desiredMap[key] = inst
 		desiredIfaces[inst.Interface] = struct{}{}

--- a/pkg/vrrp/vrid_guard_4573_test.go
+++ b/pkg/vrrp/vrid_guard_4573_test.go
@@ -1,0 +1,76 @@
+package vrrp
+
+import "testing"
+
+// #4573 defensive runtime VRID guard: UpdateInstances must refuse to build a
+// VRRP instance whose GroupID falls outside the RFC 5798 VRID range 1..255. The
+// config-layer commit gate (validateVRRPGroupIDStrict) rejects an out-of-range
+// id, but the tolerant load / HA-sync path downgrades that gate to a warning
+// (#1960 no-brick), so a bad id could reach the manager and would otherwise be
+// truncated onto the single VRID wire byte — advertising the reserved VRID 0
+// (256→0) or an aliased VRID (257→1). The guard drops such an instance instead.
+//
+// FAIL-ON-REVERT: remove the range guard at the top of the UpdateInstances
+// desired loop and the out-of-range ids get instances built (openInstanceSocket
+// called, m.instances populated) — the wrong-VRID advert this guard prevents.
+func TestUpdateInstances_SkipsOutOfRangeVRID(t *testing.T) {
+	m, rec := newTestManagerNoNetwork()
+	defer stopManagerForTest(m)
+
+	desired := []*Instance{
+		{Interface: "reth0", GroupID: 0, VirtualAddresses: []string{"10.0.61.1/24"}},   // reserved VRID 0
+		{Interface: "reth0", GroupID: 256, VirtualAddresses: []string{"10.0.61.2/24"}}, // wraps to 0
+		{Interface: "reth0", GroupID: -1, VirtualAddresses: []string{"10.0.61.3/24"}},  // below range
+		{Interface: "reth1", GroupID: 100, VirtualAddresses: []string{"10.0.62.1/24"}}, // valid
+	}
+	if err := m.UpdateInstances(desired); err != nil {
+		t.Fatalf("UpdateInstances: %v", err)
+	}
+
+	m.mu.RLock()
+	n := len(m.instances)
+	_, haveValid := m.instances[instanceKey{iface: "reth1", groupID: 100}]
+	_, haveZero := m.instances[instanceKey{iface: "reth0", groupID: 0}]
+	_, haveWrap := m.instances[instanceKey{iface: "reth0", groupID: 256}]
+	_, haveNeg := m.instances[instanceKey{iface: "reth0", groupID: -1}]
+	m.mu.RUnlock()
+
+	if !haveValid {
+		t.Error("valid VRID 100 instance should have been built")
+	}
+	if haveZero || haveWrap || haveNeg {
+		t.Errorf("out-of-range VRID instances must be skipped (zero=%v wrap=%v neg=%v)",
+			haveZero, haveWrap, haveNeg)
+	}
+	if n != 1 {
+		t.Fatalf("expected exactly 1 instance (only the valid VRID), got %d", n)
+	}
+
+	// Only the single valid instance should have opened a socket.
+	open, _, _ := rec.snapshot()
+	if open != 1 {
+		t.Errorf("openInstanceSocket calls = %d, want 1 (only the valid VRID)", open)
+	}
+}
+
+// TestUpdateInstances_BoundaryVRIDsBuild pins that the range boundaries (1 and
+// 255) are ACCEPTED — the guard must not over-reject a valid id.
+func TestUpdateInstances_BoundaryVRIDsBuild(t *testing.T) {
+	m, _ := newTestManagerNoNetwork()
+	defer stopManagerForTest(m)
+
+	desired := []*Instance{
+		{Interface: "reth0", GroupID: 1, VirtualAddresses: []string{"10.0.61.1/24"}},
+		{Interface: "reth1", GroupID: 255, VirtualAddresses: []string{"10.0.62.1/24"}},
+	}
+	if err := m.UpdateInstances(desired); err != nil {
+		t.Fatalf("UpdateInstances: %v", err)
+	}
+
+	m.mu.RLock()
+	n := len(m.instances)
+	m.mu.RUnlock()
+	if n != 2 {
+		t.Fatalf("both boundary VRIDs (1 and 255) must build, got %d instances", n)
+	}
+}

--- a/pkg/vrrp/vrrp.go
+++ b/pkg/vrrp/vrrp.go
@@ -9,6 +9,20 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 )
 
+// MinVRID / MaxVRID bound the VRRP Virtual Router ID that may be advertised on
+// the wire. RFC 5798 §5.2.3 defines the VRID as an 8-bit field with a valid
+// range of 1..255; 0 is not a usable VRID. The state machine truncates the
+// configured GroupID straight onto that byte (instance.go writes
+// `uint8(vi.cfg.GroupID)` into the VRID field), so an out-of-range GroupID that
+// slips past the config-layer commit gate (validateVRRPGroupIDStrict) on a
+// lenient / HA-sync load would otherwise advertise VRID 0 (peer discards) or an
+// aliased VRID. The manager range-checks GroupID against these bounds at
+// instance creation (#4573) and refuses to build such an instance.
+const (
+	MinVRID = 1
+	MaxVRID = 255
+)
+
 // Instance describes a single VRRP instance.
 type Instance struct {
 	Interface         string


### PR DESCRIPTION
Closes #4573

## Problem

The `vrrp-group <id>` instance slot carried no schema value validator (a documented identity-token deferral in `schema_interfaces.go`) and `parseVRRPGroups` stored any numeric id verbatim, while the native VRRP engine truncates it straight onto the single VRID wire byte (`uint8(vi.cfg.GroupID)` in `pkg/vrrp/instance.go`).

- `vrrp-group 256` -> wraps to the **RFC 5798-reserved VRID 0** -> a strict RFC peer (Juniper) discards the advert -> the VIP never masters -> HA cold-boot blackhole.
- `vrrp-group 257` -> aliases VRID 1 onto an unrelated group -> cross-talk / dual-master.

The schema deferral is only safe for NON-numeric garbage (dropped by `parseVRRPGroups`); an out-of-range **numeric** id produced a live wrong-VRID instance. The chassis redundancy-group id analog the schema comment cites as its model was hardened in #4434 (`validateChassisClusterStrict`) while VRRP was left unguarded — this closes that asymmetry.

## Fix

**B-001 — VRID range gate.** New `validateVRRPGroupIDStrict` (`compiler_validate_strict_vrrp.go`, `MinVRRPGroupID=1` / `MaxVRRPGroupID=255`), the exact sibling of the chassis gate: hard-reject on **strict** commit, downgrade to a `cfg.Warnings` entry on the tolerant load / peer-sync path (`lenientVRRPGroupID`, #1960 no-brick). Wired into the compiler tail-gate pass alongside `validateChassisClusterStrict`. A defensive **runtime** range guard at instance creation (`pkg/vrrp` `MinVRID`/`MaxVRID`; `manager.go UpdateInstances` skips + logs an out-of-range VRID) refuses to advertise VRID 0 for a value that slips through the lenient path.

**B-002 — priority Atoi swallow.** The `priority` / `preempt hold-time` / `advertise-interval` parse in `parseVRRPGroups` (both the flat-set Keys arm and the hierarchical child-node arm) used `_ =` to discard the `strconv.Atoi` error, silently resetting the field to 0 on a bad parse. For priority that is the RFC 5798 **resignation** value — worse than a no-op. Now only assign on a clean parse (keeps the default 100 / prior value).

## Tests (RED on revert)

- Config gate rejects `256/0/-1/300/65536` with a named commit error, WARNS (not bricks) on the lenient path, admits in-range `1/100/255` with no warning.
- Non-numeric `priority abc` on the lenient path keeps 100 instead of 0.
- Runtime guard drops GroupID `0/256/-1` while building the valid `100` and the `1`/`255` boundaries.

`go test ./pkg/config/... ./pkg/vrrp/...` green; `go build ./...` green; gofmt/vet clean.

**test-failover:** nice-to-have, deferred to the parent — the change only REJECTS invalid configs, so valid-config failover timing is unaffected.

## Docs

`docs/config-schema.md` and the `schema_interfaces.go` deferral comment gain the #4573 VRID-range note with the RFC 5798 reference and the chassis-RG-id (#4434) parity cross-reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi