### PR TITLE
cos: re-meter all fall-through three-color policers on the cached TX path (#4566)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-07-07 — #4566 cos: CachedThreeColorPolicers grows to a SmallVec so the cached TX path re-meters ALL fall-through policers (not just the first two)
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4566 (ps-036 c8 F-003 = corpus F-127, LOW — rate-limit slack,
+  NOT a permit/deny bypass). `CachedThreeColorPolicers`
+  (userspace-dp/src/filter/mod.rs) held a fixed two-`Option` layout
+  (`first`/`second`); its `push` silently DROPPED the 3rd (and beyond)
+  fall-through three-color policer, so a flow with >=3 fall-through
+  `then policer` terms escaped the 3rd+ term's committed/peak rate limit on
+  EVERY cached (flow-cache-hit) packet. The live/uncached full-eval path always
+  metered each policer; only the cached replay truncated. Fix = option (a) grow
+  the container to a `smallvec::SmallVec<[Arc<ThreeColorPolicerRuntime>; 2]>`,
+  mirroring the sibling `CachedFilterCounters` (#2573) which had the identical
+  "kept only the last/first N of a fall-through set" bug. Chosen over option (b)
+  decline-the-flow-cache because the cached-path replay
+  (`apply_cached_three_color_policers` → `for_each`) already iterates a variable
+  count, the >2 heap spill happens ONCE at flow-cache install off the packet hot
+  path, and this keeps cached vs live meter-identical for ALL policer counts.
+  Dedup preserved by policer `id`. A flow with <=2 policers behaves identically
+  (still inline, no heap, all metered).
+- **File(s)**: userspace-dp/src/filter/mod.rs (struct + push/extend/from_option/
+  len/for_each rewritten over the SmallVec), userspace-dp/src/filter/tests.rs
+  (RED-on-revert: `flow_cache_hit_runs_all_three_fall_through_policers` asserts
+  len==3 + all three metered [RED: len==2, gamma un-metered on revert];
+  `flow_cache_hit_runs_both_fall_through_policers` guards the unchanged 2-policer
+  case), userspace-dp/src/filter/README.md (#4566 note beside the #2573 one).
+- **Validation**: RED-on-revert confirmed (stash the mod.rs fix → 3-policer test
+  fails `left: 2, right: 3`, 2-policer test still ok). Full cargo suite below.
+
 ## 2026-07-07 — #4570 ra: configEqual now compares ReachableTime/RetransTimer so a commit changing only those RA timers restarts the sender
 
 - **Timestamp**: 2026-07-07

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -128,6 +128,27 @@ Mirrors the BPF firewall-filter pipeline in userspace.
   matched count term (the earlier fall-through count terms were silently
   under-counted on the cached path only).
 
+  The same accumulate-all-fall-through-terms contract applies to
+  three-color policers via `CachedThreeColorPolicers`. Every matched
+  fall-through term's `then policer` runtime is folded into the cached
+  TX-selection result (deduped by policer `id`) and re-metered on each
+  cached replay (`apply_cached_three_color_policers` → `for_each`), so a
+  flow escapes NO term's committed/peak rate limit on the cached path.
+  Like `CachedFilterCounters`, the container is a `SmallVec<[_; 2]>`
+  (built once at flow-cache install, only `for_each`-read on the
+  per-packet replay), so the common single/dual-policer case records with
+  no heap allocation and any spill to the heap for >2 policers happens off
+  the packet hot path. **Before #4566 this was a fixed two-`Option`
+  (`first`/`second`) layout that SILENTLY DROPPED the 3rd (and beyond)
+  fall-through policer on the cached path** — a flow with >=3 fall-through
+  three-color policer terms escaped the 3rd+ term's rate limit on every
+  cached packet (rate-limit slack, not a permit/deny bypass; the uncached
+  full-eval path always metered each). Growing the array (option a) was
+  chosen over declining the flow-cache for such flows (option b): the
+  cached-path replay already iterates a variable count via `for_each`, the
+  spill is off the hot path, and this keeps the cached and live paths
+  meter-identical for ALL policer counts rather than diverging above two.
+
   **No-match default is implicit ACCEPT — a deliberate divergence from
   Junos (#3295).** When a packet matches NO term in a filter, the
   evaluation returns `FilterResult::default()`, whose action is

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -447,63 +447,63 @@ impl PartialEq for ThreeColorPolicerRuntime {
 
 impl Eq for ThreeColorPolicerRuntime {}
 
+/// #2544/#4566: the set of fall-through three-color policer terms a cached
+/// TX-selection decision must re-meter on every flow-cache replay. With #2544
+/// fall-through a single packet can match multiple three-color policer terms;
+/// the previous two-`Option` layout (`first`/`second`) silently DROPPED the 3rd
+/// (and beyond) policer on the cached path, so a flow with >=3 fall-through
+/// policer terms escaped the 3rd+ term's committed/peak rate limit on EVERY
+/// cached packet — the uncached full-eval path meters each (#4566). Now backed
+/// by a `SmallVec` with an inline capacity of 2 (matching the sibling
+/// `CachedFilterCounters`, #2573): the common single- and dual-policer flows
+/// record with NO heap allocation, and any spill to the heap for >2 policers
+/// happens ONCE at flow-cache install, off the per-packet replay (`for_each`)
+/// hot path. Dedup is by policer `id` (`ThreeColorPolicerRuntime` carries an
+/// id) so the same policer referenced by two matched terms is metered once per
+/// packet.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct CachedThreeColorPolicers {
-    first: Option<Arc<ThreeColorPolicerRuntime>>,
-    second: Option<Arc<ThreeColorPolicerRuntime>>,
+    policers: smallvec::SmallVec<[Arc<ThreeColorPolicerRuntime>; 2]>,
 }
 
 impl CachedThreeColorPolicers {
     #[inline]
     pub(crate) fn from_option(runtime: Option<Arc<ThreeColorPolicerRuntime>>) -> Self {
-        Self {
-            first: runtime,
-            second: None,
+        let mut policers = smallvec::SmallVec::new();
+        if let Some(runtime) = runtime {
+            policers.push(runtime);
         }
+        Self { policers }
     }
 
     #[inline]
     pub(crate) fn push(&mut self, runtime: Arc<ThreeColorPolicerRuntime>) {
         if self
-            .first
-            .as_ref()
-            .is_some_and(|existing| existing.id == runtime.id)
-            || self
-                .second
-                .as_ref()
-                .is_some_and(|existing| existing.id == runtime.id)
+            .policers
+            .iter()
+            .any(|existing| existing.id == runtime.id)
         {
             return;
         }
-        if self.first.is_none() {
-            self.first = Some(runtime);
-        } else if self.second.is_none() {
-            self.second = Some(runtime);
-        }
+        self.policers.push(runtime);
     }
 
     #[inline]
     pub(crate) fn extend(&mut self, other: Self) {
-        if let Some(runtime) = other.first {
-            self.push(runtime);
-        }
-        if let Some(runtime) = other.second {
+        for runtime in other.policers {
             self.push(runtime);
         }
     }
 
     #[inline]
     pub(crate) fn len(&self) -> usize {
-        usize::from(self.first.is_some()) + usize::from(self.second.is_some())
+        self.policers.len()
     }
 
     #[inline]
     pub(crate) fn for_each(&self, mut f: impl FnMut(&Arc<ThreeColorPolicerRuntime>)) {
-        if let Some(runtime) = self.first.as_ref() {
-            f(runtime);
-        }
-        if let Some(runtime) = self.second.as_ref() {
-            f(runtime);
+        for policer in &self.policers {
+            f(policer);
         }
     }
 }

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -970,6 +970,147 @@ fn flow_cache_hits_run_three_color_policer() {
     assert_eq!(status[0].drop_packets, 1);
 }
 
+// #4566: three fall-through three-color policer terms on ONE flow. The cached
+// TX-selection replay MUST carry all three policers — the previous two-`Option`
+// layout silently dropped the 3rd, so its rate limit was never enforced on the
+// cached path. RED on revert: `len()` is 2 and `gamma` never meters.
+#[test]
+fn flow_cache_hit_runs_all_three_fall_through_policers() {
+    fn policer(name: &str) -> ThreeColorPolicerSnapshot {
+        ThreeColorPolicerSnapshot {
+            name: name.into(),
+            mode: "single-rate".into(),
+            color_blind: true,
+            // Generous committed burst so a single 100-byte packet is GREEN on
+            // every policer — the assertion checks each one metered, not that it
+            // dropped.
+            committed_rate_bytes_per_sec: 1,
+            committed_burst_bytes: 10_000,
+            peak_or_excess_burst_bytes: 5_000,
+            then_action: "discard".into(),
+            ..Default::default()
+        }
+    }
+    fn fall_through_term(name: &str, policer: &str, terminating: bool) -> FirewallTermSnapshot {
+        FirewallTermSnapshot {
+            name: name.into(),
+            // Empty action => fall-through (continue_term); a terminating
+            // "accept" stops the walk but still merges its own policer first.
+            action: if terminating { "accept".into() } else { String::new() },
+            policer: policer.into(),
+            ..Default::default()
+        }
+    }
+
+    let state = make_filter_state_with_three_color(
+        &[FirewallFilterSnapshot {
+            name: "policed".into(),
+            family: "inet".into(),
+            terms: vec![
+                fall_through_term("t-alpha", "alpha", false),
+                fall_through_term("t-beta", "beta", false),
+                fall_through_term("t-gamma", "gamma", true),
+            ],
+        }],
+        &[policer("alpha"), policer("beta"), policer("gamma")],
+    );
+
+    let filter = state.filters.get("inet:policed").unwrap();
+    let cached = evaluate_filter_ref_tx_selection_cached(
+        filter,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_UDP,
+        12345,
+        5000,
+        0,
+    );
+    // The 3rd policer must NOT be truncated out of the cached set (RED: 2).
+    assert_eq!(
+        cached.three_color_policers.len(),
+        3,
+        "cached path must carry all three fall-through policers"
+    );
+
+    // One cached-path packet must meter ALL THREE policers. On revert `gamma` is
+    // dropped from the cached set and never records a green packet.
+    let action = apply_cached_three_color_policers(&cached.three_color_policers, 0, 100);
+    assert!(!action.drop);
+
+    let status = state.three_color_policer_statuses();
+    for name in ["alpha", "beta", "gamma"] {
+        let item = status
+            .iter()
+            .find(|item| item.name == name)
+            .unwrap_or_else(|| panic!("policer {name} missing from status"));
+        assert_eq!(
+            item.green_packets, 1,
+            "policer {name} must meter the cached-path packet"
+        );
+    }
+}
+
+// #4566 unchanged-behavior guard: a flow with exactly TWO fall-through policer
+// terms still caches both and meters both — identical to pre-fix behavior for
+// the common case (the fix only affects the 3rd+ policer).
+#[test]
+fn flow_cache_hit_runs_both_fall_through_policers() {
+    fn policer(name: &str) -> ThreeColorPolicerSnapshot {
+        ThreeColorPolicerSnapshot {
+            name: name.into(),
+            mode: "single-rate".into(),
+            color_blind: true,
+            committed_rate_bytes_per_sec: 1,
+            committed_burst_bytes: 10_000,
+            peak_or_excess_burst_bytes: 5_000,
+            then_action: "discard".into(),
+            ..Default::default()
+        }
+    }
+
+    let state = make_filter_state_with_three_color(
+        &[FirewallFilterSnapshot {
+            name: "policed".into(),
+            family: "inet".into(),
+            terms: vec![
+                FirewallTermSnapshot {
+                    name: "t-alpha".into(),
+                    action: String::new(),
+                    policer: "alpha".into(),
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    name: "t-beta".into(),
+                    action: "accept".into(),
+                    policer: "beta".into(),
+                    ..Default::default()
+                },
+            ],
+        }],
+        &[policer("alpha"), policer("beta")],
+    );
+
+    let filter = state.filters.get("inet:policed").unwrap();
+    let cached = evaluate_filter_ref_tx_selection_cached(
+        filter,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_UDP,
+        12345,
+        5000,
+        0,
+    );
+    assert_eq!(cached.three_color_policers.len(), 2);
+
+    let action = apply_cached_three_color_policers(&cached.three_color_policers, 0, 100);
+    assert!(!action.drop);
+    let status = state.three_color_policer_statuses();
+    for name in ["alpha", "beta"] {
+        let item = status.iter().find(|item| item.name == name).unwrap();
+        assert_eq!(item.green_packets, 1);
+    }
+}
+
 #[test]
 fn equivalent_snapshot_refresh_preserves_three_color_state_and_counters() {
     let filters = [FirewallFilterSnapshot {


### PR DESCRIPTION
Closes #4566.

## Problem
`CachedThreeColorPolicers` (userspace-dp/src/filter/mod.rs) held a fixed
two-`Option` layout (`first`/`second`); its `push()` silently DROPPED the
3rd (and beyond) fall-through three-color policer. On the cached
flow-cache-hit TX-selection path, a flow with >=3 fall-through
`then policer` terms therefore escaped the 3rd+ term's committed/peak
rate limit on **every** cached packet. The live (uncached) full-eval
path always metered each policer — only the cached replay truncated.

Rate-limit slack, not a permit/deny or forwarding bypass; needs >=3
fall-through policer terms on one flow (rare). LOW severity (ps-036
cohort8 F-003 = review-corpus F-127). Distinct from #4535 (color-blind
default) and #4372 (status export).

## Fix — option (a), grow the container
Back `CachedThreeColorPolicers` with a
`smallvec::SmallVec<[Arc<ThreeColorPolicerRuntime>; 2]>`, exactly
mirroring the sibling `CachedFilterCounters` (#2573) which had the
identical "kept only the first/last N of a fall-through set" bug for
`then count` terms. Dedup preserved by policer `id`.

Chosen over option (b) declining the flow-cache for such flows because:
- the cached-path replay (`apply_cached_three_color_policers` ->
  `for_each`) already iterates a variable count — no hot-path structure
  change;
- the >2 heap spill happens ONCE at flow-cache install, off the
  per-packet replay path;
- it keeps cached and live paths meter-identical for ALL policer counts
  rather than diverging above two.

A flow with <=2 policers behaves identically (still inline, no heap
allocation, all policers metered).

## Tests (filter/tests.rs)
- `flow_cache_hit_runs_all_three_fall_through_policers`: three
  fall-through policer terms -> cached set `len()==3` and one cached
  packet meters all three. **RED on revert:** `len()==2` and the 3rd
  policer never meters (`left: 2, right: 3`).
- `flow_cache_hit_runs_both_fall_through_policers`: two-policer case
  unchanged (`len()==2`, both metered).

## Validation
- RED-on-revert verified: stashing the mod.rs change fails the 3-policer
  test while the 2-policer test still passes.
- Full cargo suite green: **3803 passed / 0 failed** (serial,
  `--test-threads=1`).

Docs: `filter/README.md` gains a #4566 note beside the #2573 one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi