### PR TITLE
grpcapi: zeroize wipes .configdb SSOT + master.key (#4576)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -40257,3 +40257,26 @@ top.
   userspace-dp/src/afxdp/README.md #3902 flowless-screens section gained a
   #4567 note.
 - **File(s)**: userspace-dp/src/screen/mod.rs, userspace-dp/src/screen/syn_rate.rs, userspace-dp/src/screen/tests.rs, userspace-dp/src/afxdp/README.md, _Log.md
+
+- **Timestamp**: 2026-07-07
+- **Action**: Fix #4576 (SECURITY HIGH) — `request system zeroize` did not wipe
+  the `.configdb` SSOT or `master.key`, so a factory reset left the prior
+  tenant's full config + secrets (IKE PSKs, WireGuard keys, SNMP communities)
+  and the key that decrypts them. Extracted `zeroizeConfigDir(configDir,
+  configBase)` from `performZeroizeWipe` (now testable against a temp dir).
+  It removes `master.key` FIRST (key-first: an interrupted wipe cannot leave
+  decryptable ciphertext), then `os.RemoveAll(.configdb)`, then in one ReadDir
+  pass the top-level `.conf`/`rollback*` (preserved), the `<base>.N` text
+  rollback slots (canonical rollback history w/ cleartext secrets, reloaded at
+  boot), and `.config.journal[.N]` (audit journal — wiped per #4576, superseding
+  the #4108 journal-survives-zeroize claim). Best-effort past a failure but
+  returns the first real error; the `zeroize` RPC surfaces it as codes.Internal
+  instead of reporting a clean reset. BPF pins + networkd files stay best-effort
+  (no secrets). Docs: system-login.md, configstore/README.md, LogSystemAction +
+  logSystemAction comments updated for the journal-wipe reversal.
+- **File(s)**: pkg/grpcapi/server_diag.go,
+  pkg/grpcapi/system_action_journal_4108_test.go,
+  pkg/grpcapi/zeroize_configdb_4576_test.go,
+  pkg/configstore/store_commit.go,
+  pkg/configstore/system_action_journal_4108_test.go,
+  docs/system-login.md, pkg/configstore/README.md, _Log.md

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -159,16 +159,24 @@ pre-execution fsync (an *interrupted* wipe still leaves the record on disk) plus
 any remote syslog collector. See the configstore README "Audit journal" section
 for the record format.
 
-**Factory-reset erasure (#4576).** `zeroize` is a security primitive: it must
-leave no prior-tenant config or secret material on disk (RMA / resale /
-re-tenant). The wipe removes the `.configdb` SSOT (`active.json`,
-`candidate.json`, `rollback.N.json`) and **`master.key` first** (so an
-interrupted wipe cannot leave AES-GCM ciphertext behind next to the key that
-decrypts it), the numbered text rollback slots `<config>.N` (full config text
-with cleartext secret leaves — reloaded at boot by `loadRollbackHistory`), the
-top-level `.conf` files (live config + `rescue.conf`), and `.config.journal`
+**Factory-reset erasure (#4576).** `zeroize` erases the xpf configuration
+**state** so the prior tenant's committed config + secrets are not reloaded on
+the next boot (RMA / resale / re-tenant). The wipe removes the `.configdb` SSOT
+(`active.json`, `candidate.json`, `rollback.N.json`) and **`master.key` first**
+(so an interrupted wipe cannot leave AES-GCM ciphertext behind next to the key
+that decrypts it), the numbered text rollback slots `<config>.N` (full config
+text with cleartext secret leaves — reloaded at boot by `loadRollbackHistory`),
+the top-level `.conf` files (live config + `rescue.conf`), and `.config.journal`
 (+ rotated segments). A wipe that cannot fully erase this state returns an error
 rather than reporting a clean factory reset.
+
+The wipe erases that SSOT/rollback/journal state **directly**. The **rendered
+service configs** xpfd writes outside `/etc/xpf` — `/etc/frr/frr.conf` (0644,
+BGP-MD5 / OSPF / IS-IS auth secrets), `/etc/swanctl/conf.d/*` (IKE PSKs),
+`/etc/kea/kea-dhcp{4,6}.conf` — are **not** removed by the wipe itself; they are
+reset on the **completing reboot** when the daemon reconciles to the empty
+config. Erasing them in the wipe itself (closing the window between wipe and
+reboot) is tracked as follow-up **#4585**.
 
 **Privileged-subcommand exception — `monitor traffic` (#4067).** Almost
 every command is gated on the top-level word alone, but `monitor traffic`

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -149,10 +149,26 @@ through `PermAll`, so `PermMaint` need not appear in its permission list.
 
 **Audit trail (#4108 F8).** When one of these destructive verbs runs, the gRPC
 `SystemAction` handler writes a fsynced `system_action` entry (verb + timestamp)
-to the configstore audit journal (`.config.journal`) **before** executing, so a
-durable, attributable record survives even a `zeroize` (the `journald` line does
-not). See the configstore README "Audit journal" section for the record format
-and zeroize-survival details.
+to the configstore audit journal (`.config.journal`) **before** executing, so an
+attributable record is durable on disk before the action runs (the `journald`
+line is not). For `reboot`/`halt`/`power-off` the record persists across the
+reboot. For `zeroize`, the wipe now **deliberately removes `.config.journal`**
+(#4576 — a completed factory reset must not hand its audit log, commit history,
+or comments to the next tenant); the durable cross-wipe trail is therefore the
+pre-execution fsync (an *interrupted* wipe still leaves the record on disk) plus
+any remote syslog collector. See the configstore README "Audit journal" section
+for the record format.
+
+**Factory-reset erasure (#4576).** `zeroize` is a security primitive: it must
+leave no prior-tenant config or secret material on disk (RMA / resale /
+re-tenant). The wipe removes the `.configdb` SSOT (`active.json`,
+`candidate.json`, `rollback.N.json`) and **`master.key` first** (so an
+interrupted wipe cannot leave AES-GCM ciphertext behind next to the key that
+decrypts it), the numbered text rollback slots `<config>.N` (full config text
+with cleartext secret leaves — reloaded at boot by `loadRollbackHistory`), the
+top-level `.conf` files (live config + `rescue.conf`), and `.config.journal`
+(+ rotated segments). A wipe that cannot fully erase this state returns an error
+rather than reporting a clean factory reset.
 
 **Privileged-subcommand exception — `monitor traffic` (#4067).** Almost
 every command is gated on the top-level word alone, but `monitor traffic`

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -451,13 +451,18 @@ owned by the `journal/` subpackage.
   (written by `grpcapi.Server.SystemAction` BEFORE the action runs). The
   append is fsynced, so the record is durable on disk before the box goes
   down or the config is wiped — the `slog.Warn` line only reaches
-  journald, which does not survive a `zeroize`. The journal file itself
-  survives a `zeroize`: `.config.journal` neither ends in `.conf` nor
-  starts with `rollback`, so it is not in the wipe's removal set.
-  `system_action` is deliberately EXCLUDED from `ListCommitHistory`
-  (`show system commit` shows config commits only). The local gRPC
-  transport is unauthenticated, so no operator identity is attributed —
-  action + timestamp is the best-effort record.
+  journald, which does not survive a reboot. For `reboot`/`halt`/`power-off`
+  the on-disk record persists across the reboot. For `zeroize`, the wipe
+  now **removes `.config.journal`** (and its rotated `.config.journal.N`
+  segments) as part of the factory reset (#4576 — a completed reset must
+  not hand its audit log / commit history / comments to the next tenant,
+  and legacy v1 fat lines could carry full config incl. secrets in a 0644
+  file). The cross-wipe trail is therefore the pre-execution fsync (an
+  *interrupted* wipe still leaves the record) plus remote syslog — not
+  on-box journal survival. `system_action` is deliberately EXCLUDED from
+  `ListCommitHistory` (`show system commit` shows config commits only). The
+  local gRPC transport is unauthenticated, so no operator identity is
+  attributed — action + timestamp is the best-effort record.
 - **`config_hash`** — sha256 hex of the post-action active tree's
   `Format()` text, the same text `saveRollbackFiles` writes: while a
   slot is retained, `sha256sum <config>.N` correlates the rollback

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -566,10 +566,12 @@ func (s *Store) ListCommitHistory(limit int) ([]*JournalEntry, error) {
 //
 // The caller MUST invoke this BEFORE running the action, because the append
 // is synchronous and fsynced (journal.Log), so the record is durable on disk
-// before the box goes down or the config is wiped. The journal file itself
-// (`.config.journal`) also survives a zeroize: it neither ends in `.conf` nor
-// starts with `rollback`, so it is not in the zeroize removal set — belt and
-// braces on top of the pre-execution fsync.
+// before the box goes down or the config is wiped. For reboot/halt/power-off
+// the on-disk record persists across the reboot. For `zeroize` the wipe now
+// deliberately REMOVES `.config.journal` (#4576 — a completed factory reset
+// must not hand its audit log to the next tenant), so the cross-wipe trail is
+// the pre-execution fsync (an interrupted wipe still leaves it) plus remote
+// syslog — this supersedes the earlier journal-survives-zeroize belt-and-braces.
 //
 // Journaling must never block a confirmed power/wipe action, so an append
 // failure is warned (journalLog), not returned. Detail carries the action

--- a/pkg/configstore/system_action_journal_4108_test.go
+++ b/pkg/configstore/system_action_journal_4108_test.go
@@ -5,10 +5,12 @@ import "testing"
 // TestLogSystemAction_WritesJournalEntry pins #4108 F8: a destructive
 // maintenance verb (reboot/halt/power-off/zeroize) writes a fsynced
 // `system_action` audit entry to the commit journal, so a durable,
-// attributable record survives even when the action wipes the config or takes
-// the box down. RED on revert: making Store.LogSystemAction a no-op (or
-// dropping the s.logSystemAction call in the SystemAction handler) leaves the
-// journal empty and this test fails.
+// attributable record is on disk BEFORE the action runs (the record persists
+// across reboot/halt/power-off; for zeroize the wipe then removes
+// `.config.journal` — #4576 — so the cross-wipe trail is this pre-execution
+// fsync plus remote syslog). RED on revert: making Store.LogSystemAction a
+// no-op (or dropping the s.logSystemAction call in the SystemAction handler)
+// leaves the journal empty and this test fails.
 func TestLogSystemAction_WritesJournalEntry(t *testing.T) {
 	s := newTestStore(t)
 

--- a/pkg/grpcapi/server_diag.go
+++ b/pkg/grpcapi/server_diag.go
@@ -763,12 +763,20 @@ const (
 	defaultConfigBase = "xpf.conf"
 )
 
-// zeroizeConfigDir erases every xpf-authored configuration artifact under
-// configDir as part of a factory reset (#4576). This is a security primitive:
-// after it returns cleanly, no prior-tenant config or secret material remains
-// on disk, so a device pulled for RMA / resale / re-tenant does not leak the
-// previous owner's policy, IKE PSKs, WireGuard private keys, or SNMP
-// communities.
+// zeroizeConfigDir erases the xpf configuration STATE under configDir as part
+// of a factory reset (#4576): the .configdb SSOT + master.key, the numbered
+// text rollback slots, the top-level .conf files, and the audit journal — the
+// artifacts that persist the prior tenant's committed policy, IKE PSKs,
+// WireGuard private keys, and SNMP communities and would otherwise be reloaded
+// on the next boot.
+//
+// NOTE (scope, tracked as #4585): this erases the SSOT and rollback/journal
+// state DIRECTLY, but the RENDERED service configs xpfd writes outside
+// configDir — /etc/frr/frr.conf (0644, BGP-MD5/OSPF/ISIS auth), /etc/swanctl/
+// conf.d/* (IKE PSKs), /etc/kea/kea-dhcp{4,6}.conf — are NOT removed here. They
+// are reset on the COMPLETING reboot when the daemon reconciles to the empty
+// config; erasing them in the wipe itself (so the window between wipe and
+// reboot leaks nothing) is the #4585 follow-up.
 //
 // The artifacts removed (configBase is the config file's base name, e.g.
 // "xpf.conf", used to recognize the numbered text rollback slots):

--- a/pkg/grpcapi/server_diag.go
+++ b/pkg/grpcapi/server_diag.go
@@ -3,12 +3,14 @@ package grpcapi
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -723,11 +725,15 @@ func (s *Server) proxyPeerSystemAction(ctx context.Context, req *pb.SystemAction
 
 // logSystemAction records a destructive maintenance action to the configstore
 // audit journal BEFORE it executes (#4108 F8). The store append is synchronous
-// and fsynced, so an attributable record is durable on disk even when the
-// action wipes the config (zeroize) or takes the box down (reboot/halt/
-// power-off) — the slog.Warn line only reaches journald, which does not
-// survive a zeroize. Best-effort: a journal write failure never blocks a
-// confirmed power/wipe action (the store layer warns rather than failing).
+// and fsynced, so an attributable record is durable on disk before the action
+// runs — the slog.Warn line only reaches journald, which does not survive a
+// reboot. For reboot/halt/power-off the on-disk journal record persists across
+// the reboot; for zeroize the wipe now deliberately removes .config.journal
+// (#4576 — a completed factory reset must not hand its audit log to the next
+// tenant), so the durable cross-wipe trail is the pre-execution fsync (an
+// interrupted wipe still leaves it) plus any remote syslog collector.
+// Best-effort: a journal write failure never blocks a confirmed power/wipe
+// action (the store layer warns rather than failing).
 func (s *Server) logSystemAction(action string) {
 	if s.store == nil {
 		return
@@ -748,28 +754,127 @@ var schedulePowerAction = func(systemctlArg string) {
 	}()
 }
 
+// defaultConfigDir / defaultConfigBase mirror the daemon's config-path default
+// (cmd/xpfd `-config /etc/xpf/xpf.conf`, pkg/daemon). performZeroizeWipe erases
+// the fixed appliance paths; a non-default `-config` location is out of scope
+// (the pre-#4576 wipe already assumed /etc/xpf).
+const (
+	defaultConfigDir  = "/etc/xpf"
+	defaultConfigBase = "xpf.conf"
+)
+
+// zeroizeConfigDir erases every xpf-authored configuration artifact under
+// configDir as part of a factory reset (#4576). This is a security primitive:
+// after it returns cleanly, no prior-tenant config or secret material remains
+// on disk, so a device pulled for RMA / resale / re-tenant does not leak the
+// previous owner's policy, IKE PSKs, WireGuard private keys, or SNMP
+// communities.
+//
+// The artifacts removed (configBase is the config file's base name, e.g.
+// "xpf.conf", used to recognize the numbered text rollback slots):
+//   - .configdb/master.key      — the AES-GCM key that decrypts an encrypted DB
+//   - .configdb/                — the SSOT: active.json, candidate.json,
+//     rollback.N.json (Store.Load reloads active.json on next boot)
+//   - <configBase>.<N>          — the CANONICAL text rollback slots
+//     (saveRollbackFiles / loadRollbackHistory), full config TEXT with
+//     cleartext secret leaves; loadRollbackHistory reloads them at boot, so
+//     leaving them behind would let the prior tenant's config be rolled back
+//     to — the exact leak #4576 closes
+//   - *.conf                    — the live config + rescue.conf (pre-#4576 set)
+//   - rollback*                 — legacy rollback naming (pre-#4576 set)
+//   - .config.journal[.N]       — the JSONL audit journal + rotated segments
+//     (0644, prior-tenant commit history/comments; legacy v1 fat lines may
+//     carry full config incl. secrets). This SUPERSEDES the #4108 "journal
+//     survives a zeroize" belt-and-braces: the system_action record is still
+//     fsynced BEFORE the wipe (so an interrupted wipe leaves a trail, and a
+//     remote syslog collector keeps the durable cross-wipe record), but a
+//     completed factory reset must not hand its audit log to the next owner.
+//
+// Removal is KEY-FIRST: master.key is deleted before the encrypted DB body, so
+// an interrupted wipe (crash / power loss mid-RemoveAll) can never leave the
+// ciphertext behind together with the key that decrypts it — once the key is
+// gone any surviving ciphertext is unrecoverable.
+//
+// It is best-effort past a failure (a single stubborn file does not abort the
+// rest of the erasure) but returns the FIRST real error so a
+// silently-incomplete zeroize is never reported as a successful factory reset.
+// os.ErrNotExist is not an error here (an already-absent artifact is the goal).
+func zeroizeConfigDir(configDir, configBase string) error {
+	var firstErr error
+	fail := func(err error) {
+		if err != nil && !errors.Is(err, os.ErrNotExist) && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	dbDir := filepath.Join(configDir, ".configdb")
+	// KEY-FIRST (#4576): master.key before the encrypted DB body.
+	fail(os.Remove(filepath.Join(dbDir, "master.key")))
+	// The config SSOT (active.json, candidate.json, rollback.N.json + any
+	// residual key). RemoveAll erases the whole tree and is nil on absent.
+	fail(os.RemoveAll(dbDir))
+
+	// Top-level artifacts in a single ReadDir pass.
+	entries, err := os.ReadDir(configDir)
+	fail(err)
+	for _, f := range entries {
+		name := f.Name()
+		if strings.HasSuffix(name, ".conf") ||
+			strings.HasPrefix(name, "rollback") ||
+			name == ".config.journal" ||
+			strings.HasPrefix(name, ".config.journal.") ||
+			isTextRollbackFile(name, configBase) {
+			fail(os.Remove(filepath.Join(configDir, name)))
+		}
+	}
+	return firstErr
+}
+
+// isTextRollbackFile reports whether name is a numbered text rollback slot for
+// the config file configBase — "<configBase>.<N>" with N one-or-more decimal
+// digits (store_commit.go rollbackPath). These files carry the full prior
+// config text including cleartext secret leaves, so a factory reset removes
+// them. configBase itself ("xpf.conf") is caught by the .conf suffix rule.
+func isTextRollbackFile(name, configBase string) bool {
+	rest, ok := strings.CutPrefix(name, configBase+".")
+	if !ok || rest == "" {
+		return false
+	}
+	for _, r := range rest {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 // performZeroizeWipe erases the on-disk config, BPF pins, and managed networkd
 // files (factory reset). It is a package var so a test can drive the `zeroize`
 // SystemAction verb (to assert the #4108 F8 journal wiring) WITHOUT wiping a
-// real /etc/xpf on the developer/appliance box.
-var performZeroizeWipe = func() {
-	// Remove configs
-	configDir := "/etc/xpf"
-	files, _ := os.ReadDir(configDir)
-	for _, f := range files {
-		if strings.HasSuffix(f.Name(), ".conf") || strings.HasPrefix(f.Name(), "rollback") {
-			os.Remove(configDir + "/" + f.Name())
+// real /etc/xpf on the developer/appliance box. It returns a non-nil error when
+// the security-critical config erasure did not fully complete (#4576).
+var performZeroizeWipe = func() error {
+	// Config state FIRST — the security-critical erasure. A failure here can
+	// leave prior-tenant config/secrets on disk, so it is surfaced to the
+	// caller (#4576).
+	err := zeroizeConfigDir(defaultConfigDir, defaultConfigBase)
+
+	// BPF pins + managed networkd files carry no secret material, so their
+	// removal stays best-effort (logged, never fatal — they do not gate the
+	// success/failure of the factory reset).
+	if e := os.RemoveAll("/sys/fs/bpf/xpf"); e != nil {
+		slog.Warn("zeroize: remove BPF pins failed", "err", e)
+	}
+	if ndFiles, e := os.ReadDir("/etc/systemd/network"); e == nil {
+		for _, f := range ndFiles {
+			if strings.HasPrefix(f.Name(), "10-xpf-") {
+				if re := os.Remove(filepath.Join("/etc/systemd/network", f.Name())); re != nil && !errors.Is(re, os.ErrNotExist) {
+					slog.Warn("zeroize: remove networkd file failed", "file", f.Name(), "err", re)
+				}
+			}
 		}
 	}
-	// Remove BPF pins
-	os.RemoveAll("/sys/fs/bpf/xpf")
-	// Remove managed networkd files
-	ndFiles, _ := os.ReadDir("/etc/systemd/network")
-	for _, f := range ndFiles {
-		if strings.HasPrefix(f.Name(), "10-xpf-") {
-			os.Remove("/etc/systemd/network/" + f.Name())
-		}
-	}
+	return err
 }
 
 func (s *Server) SystemAction(ctx context.Context, req *pb.SystemActionRequest) (*pb.SystemActionResponse, error) {
@@ -797,12 +902,22 @@ func (s *Server) SystemAction(ctx context.Context, req *pb.SystemActionRequest) 
 	case "zeroize":
 		slog.Warn("system zeroize requested via gRPC")
 		// Journal BEFORE the wipe: the fsynced record is durable on disk
-		// before any config file is removed, so a factory reset still leaves
-		// an attributable audit trail (#4108 F8). The journal file itself
-		// (.config.journal) is not in the removal set below (it neither ends
-		// in .conf nor starts with rollback), so the record also survives.
+		// before any config file is removed, so an interrupted wipe still
+		// leaves an attributable trail and a remote syslog collector keeps the
+		// cross-wipe record (#4108 F8). The wipe itself now removes
+		// .config.journal (a completed factory reset must not hand its audit
+		// log to the next tenant — #4576), superseding the earlier
+		// journal-survives-zeroize belt-and-braces.
 		s.logSystemAction("zeroize")
-		performZeroizeWipe()
+		if err := performZeroizeWipe(); err != nil {
+			// A partial wipe may leave prior-tenant config/secrets on disk
+			// (#4576). Surface it instead of reporting a clean factory reset —
+			// the operator must know the erasure did not fully complete and
+			// the device is NOT safe to re-tenant.
+			slog.Error("system zeroize did not fully erase config state", "err", err)
+			return nil, status.Errorf(codes.Internal,
+				"zeroize incomplete: config state may remain on disk: %v", err)
+		}
 		return &pb.SystemActionResponse{Message: "System zeroized. Configuration erased. Reboot to complete factory reset."}, nil
 
 	case "clear-config-lock":

--- a/pkg/grpcapi/system_action_journal_4108_test.go
+++ b/pkg/grpcapi/system_action_journal_4108_test.go
@@ -30,7 +30,7 @@ func TestSystemActionJournalsDestructiveVerbs(t *testing.T) {
 	var poweredArg string
 	var wiped bool
 	schedulePowerAction = func(arg string) { poweredArg = arg }
-	performZeroizeWipe = func() { wiped = true }
+	performZeroizeWipe = func() error { wiped = true; return nil }
 
 	cases := []struct {
 		action      string

--- a/pkg/grpcapi/zeroize_configdb_4576_test.go
+++ b/pkg/grpcapi/zeroize_configdb_4576_test.go
@@ -1,0 +1,160 @@
+package grpcapi
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// zeroizeMarker stands in for any prior-tenant secret leaf (IKE PSK, WireGuard
+// key, SNMP community). The test proves no file carrying it survives a zeroize
+// and that a fresh Store.Load does not resurrect it.
+const zeroizeMarker = "MARKER-SECRET-4576-ike-psk"
+
+func mustWriteFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func assertAbsent(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be absent after zeroize, stat err = %v", path, err)
+	}
+}
+
+// TestZeroizeConfigDirWipesSSOTAndSecrets pins #4576: a factory-reset wipe must
+// remove the .configdb SSOT and master.key (plus the text rollback slots and
+// the audit journal) so the prior tenant's config + secrets do not survive.
+//
+// RED on revert: before this fix, performZeroizeWipe removed only top-level
+// .conf / rollback* files, so .configdb/master.key, .configdb/active.json,
+// .configdb/rollback.N.json, the <base>.N text rollback slots and
+// .config.journal all SURVIVED — every assertAbsent below on those paths fails,
+// and a fresh Load reloads the prior tenant's config.
+func TestZeroizeConfigDirWipesSSOTAndSecrets(t *testing.T) {
+	dir := t.TempDir()
+	configBase := "xpf.conf"
+	configPath := filepath.Join(dir, configBase)
+	dbDir := filepath.Join(dir, ".configdb")
+	marker := []byte(zeroizeMarker)
+
+	// The prior tenant's on-disk state: every artifact that carries config or
+	// secret material.
+	masterKey := filepath.Join(dbDir, "master.key")
+	activeJSON := filepath.Join(dbDir, "active.json")
+	candidateJSON := filepath.Join(dbDir, "candidate.json")
+	rollbackJSON := filepath.Join(dbDir, "rollback.1.json")
+	journalPath := filepath.Join(dir, ".config.journal")
+	journalSeg := filepath.Join(dir, ".config.journal.1")
+	textRollback := configPath + ".1"
+	rescue := filepath.Join(dir, "rescue.conf")
+
+	mustWriteFile(t, masterKey, make([]byte, 32))
+	mustWriteFile(t, activeJSON, marker)
+	mustWriteFile(t, candidateJSON, marker)
+	mustWriteFile(t, rollbackJSON, marker)
+	mustWriteFile(t, journalPath, marker)
+	mustWriteFile(t, journalSeg, marker)
+	mustWriteFile(t, configPath, marker)
+	mustWriteFile(t, textRollback, marker)
+	mustWriteFile(t, rescue, marker)
+
+	// A non-xpf file in the same dir must be LEFT ALONE — the wipe is scoped to
+	// xpf-authored artifacts, not everything under /etc/xpf.
+	bystander := filepath.Join(dir, "node-id")
+	mustWriteFile(t, bystander, []byte("0"))
+
+	if err := zeroizeConfigDir(dir, configBase); err != nil {
+		t.Fatalf("zeroizeConfigDir returned error: %v", err)
+	}
+
+	// Every secret-bearing artifact is gone (the fix; RED on revert).
+	for _, p := range []string{
+		dbDir, masterKey, activeJSON, candidateJSON, rollbackJSON,
+		journalPath, journalSeg, configPath, textRollback, rescue,
+	} {
+		assertAbsent(t, p)
+	}
+
+	// Scope guard: the non-xpf file survives.
+	if _, err := os.Stat(bystander); err != nil {
+		t.Errorf("zeroize removed a non-xpf file %s: %v", bystander, err)
+	}
+
+	// A fresh Store.Load on the wiped dir yields the default/empty config:
+	// NewDB recreates an empty .configdb, ReadActive sees no active.json, Load
+	// starts fresh with no crash and no prior-tenant secret.
+	store, err := configstore.New(configPath)
+	if err != nil {
+		t.Fatalf("configstore.New after zeroize: %v", err)
+	}
+	if err := store.Load(); err != nil {
+		t.Fatalf("Load after zeroize: %v", err)
+	}
+	if got := store.ActiveTree().FormatSet(); strings.Contains(got, zeroizeMarker) {
+		t.Errorf("post-zeroize active config still contains prior-tenant secret:\n%s", got)
+	}
+	if store.EverCommitted() {
+		t.Errorf("post-zeroize store reports EverCommitted=true; want fresh/never-committed")
+	}
+}
+
+// TestIsTextRollbackFile pins the numbered text-rollback-slot recognizer so it
+// removes the canonical rollback history (<base>.N) without eating unrelated
+// files.
+func TestIsTextRollbackFile(t *testing.T) {
+	base := "xpf.conf"
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"xpf.conf.1", true},
+		{"xpf.conf.42", true},
+		{"xpf.conf", false},      // the live config (caught by the .conf rule)
+		{"xpf.conf.bak", false},  // not all-digits
+		{"xpf.conf.", false},     // empty slot number
+		{"xpf.conf.1a", false},   // trailing non-digit
+		{"rescue.conf.1", false}, // different base
+		{"node-id", false},
+	}
+	for _, tc := range cases {
+		if got := isTextRollbackFile(tc.name, base); got != tc.want {
+			t.Errorf("isTextRollbackFile(%q, %q) = %v, want %v", tc.name, base, got, tc.want)
+		}
+	}
+}
+
+// TestZeroizeSurfacesWipeError pins #4576 requirement 3: a wipe that fails to
+// fully erase config state must surface an error at the RPC boundary, not
+// report a clean factory reset.
+func TestZeroizeSurfacesWipeError(t *testing.T) {
+	orig := performZeroizeWipe
+	t.Cleanup(func() { performZeroizeWipe = orig })
+	performZeroizeWipe = func() error { return errors.New("simulated .configdb wipe failure") }
+
+	dir := t.TempDir()
+	store := newConfigStore(t, filepath.Join(dir, "xpf.conf"))
+	s := &Server{store: store}
+
+	resp, err := s.SystemAction(context.Background(), &pb.SystemActionRequest{Action: "zeroize"})
+	if err == nil {
+		t.Fatalf("SystemAction(zeroize) with failing wipe returned nil error, resp=%v", resp)
+	}
+	if status.Code(err) != codes.Internal {
+		t.Errorf("SystemAction(zeroize) error code = %v, want Internal", status.Code(err))
+	}
+}


### PR DESCRIPTION
## Summary

`request system zeroize` / `performZeroizeWipe` removed only the top-level `/etc/xpf/*.conf` and `rollback*` files. The actual source-of-truth — `/etc/xpf/.configdb/` (`active.json`, `candidate.json`, `rollback.N.json`), the `master.key` that decrypts `config.Secret`-encrypted leaves, the numbered text rollback slots `xpf.conf.N`, and the `.config.journal` audit trail — **all survived**. On the next boot `Store.Load` reloaded the prior tenant's full committed config (security policies, address books, IKE gateways with PSKs, WireGuard private keys, SNMP communities), and `master.key` decrypted them. A device pulled for RMA / resale / re-tenant leaked the previous owner's cleartext-recoverable secrets — the exact trust boundary a zeroize is supposed to close. **HIGH, factory-reset data leak.**

## Fix

Extracted `zeroizeConfigDir(configDir, configBase)` from `performZeroizeWipe` so the wipe logic is testable against a temp dir instead of the real `/etc/xpf`. It:

- removes **`.configdb/master.key` FIRST (key-first)**: an interrupted wipe (crash / power loss mid-`RemoveAll`) can never leave AES-GCM ciphertext behind next to the key that decrypts it — once the key is gone any surviving ciphertext is unrecoverable;
- `os.RemoveAll(.configdb)` for the SSOT;
- in one `ReadDir` pass removes the top-level `.conf` / `rollback*` set (preserved from before), the `<base>.N` text rollback slots (the **canonical** rollback history — full config text with cleartext secrets that `loadRollbackHistory` reloads at boot), and `.config.journal` plus its rotated `.config.journal.N` segments;
- is best-effort past a failure but **returns the first real error** so a silently-incomplete zeroize is never reported as a clean reset. The `SystemAction("zeroize")` RPC surfaces that error as `codes.Internal` instead of a success message. `os.ErrNotExist` is not treated as an error.

BPF pins (`/sys/fs/bpf/xpf`) and managed networkd files carry no secret material, so their removal stays best-effort (logged, never fatal).

### `.config.journal` policy — wiped (explicit decision)

The audit journal is a `0644` world-readable file carrying the prior tenant's commit history/comments (and, for a box upgraded from the v1 journal, possibly full config incl. secrets in legacy fat lines). A completed factory reset must not hand its audit log to the next owner. This deliberately supersedes the #4108 journal-survives-zeroize belt-and-braces: the `system_action` record is still fsynced **before** the wipe (an interrupted wipe leaves a trail) and a remote syslog collector keeps the durable cross-wipe record.

## Tests (`pkg/grpcapi/zeroize_configdb_4576_test.go`)

- **`TestZeroizeConfigDirWipesSSOTAndSecrets`** — populates a temp config dir with every secret-bearing artifact, wipes, asserts `.configdb` + `master.key` + `active.json` + `rollback.N.json` + text rollback slot + `.config.journal[.N]` + top-level `.conf` all **absent** (RED on revert — verified empirically: the pre-fix wipe leaves the whole `.configdb` + `master.key` + text rollback + journal behind), a non-xpf file is left alone, and a fresh `configstore.New` + `Load` yields the default/empty config (no crash, no prior-tenant secret, `EverCommitted=false`);
- **`TestIsTextRollbackFile`** — the numbered-slot recognizer;
- **`TestZeroizeSurfacesWipeError`** — a failing wipe returns `codes.Internal` at the RPC boundary.

`go build ./...`, `gofmt`, `go vet`, and `go test ./pkg/grpcapi/ ./pkg/configstore/...` all green.

## Docs

`docs/system-login.md`, `pkg/configstore/README.md`, and the `LogSystemAction` / `logSystemAction` comments updated for the journal-wipe reversal and the factory-reset erasure contract.

## Edge / follow-up notes

- **Scope**: the wipe targets the fixed appliance paths `/etc/xpf` + base `xpf.conf` (mirrors the daemon default). A non-default `-config` location is out of scope — the pre-#4576 wipe already assumed `/etc/xpf`.
- **Symlinked / read-only config dir**: a `RemoveAll` failure on such a mount now surfaces as a `codes.Internal` error rather than a false "erased" success.

Closes #4576

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi