### PR TITLE
configstore: persist commit-confirmed state across a crash (#4577)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -40327,3 +40327,23 @@ top.
   userspace-dp/src/afxdp/README.md #3902 flowless-screens section gained a
   #4567 note.
 - **File(s)**: userspace-dp/src/screen/mod.rs, userspace-dp/src/screen/syn_rate.rs, userspace-dp/src/screen/tests.rs, userspace-dp/src/afxdp/README.md, _Log.md
+
+- **Timestamp**: 2026-07-07 (#4577)
+- **Action**: Persist commit-confirmed pending state so the auto-rollback
+  safety hatch survives a daemon crash/reboot inside the confirm window.
+  The rollback timer was an in-memory `time.AfterFunc` only — a crash in the
+  window made the UNCONFIRMED config permanent (management-stranding trap).
+  `CommitConfirmed` now writes a durable, 0600, master-password-encrypted
+  `.configdb/confirm.json` (absolute deadline + rollback-target tree +
+  first-commit flag) AFTER the successful writeActive+promote. `Store.Load`
+  (`recoverPendingConfirmLocked`) rolls back if the deadline passed during
+  downtime, or re-arms the timer for the remaining duration if still open.
+  Every confirmation path (`clearPendingConfirmLocked`) and the timeout
+  rollback (`PromoteRollback`) remove `confirm.json`; nested re-arm rewrites
+  it. RED-on-revert Go tests (expired→rollback-to-Base, within-window→re-arm,
+  explicit-confirm→permanent, bare-commit→permanent). Junos parity: the
+  pending confirm now survives a reboot and rolls back if not confirmed.
+- **File(s)**: pkg/configstore/db.go, pkg/configstore/store_commit.go,
+  pkg/configstore/store_persist.go,
+  pkg/configstore/commit_confirmed_persist_4577_test.go,
+  pkg/configstore/README.md, _Log.md

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -30,6 +30,7 @@ re-created 0600 on the next commit.
 | File | Path | Mode | Writer |
 |------|------|------|--------|
 | Active / candidate / rollback DB | `.configdb/{active,candidate,rollback.N}.json` | 0600 | `db.go writeTreeMarked` |
+| Pending commit-confirmed state (#4577) | `.configdb/confirm.json` | 0600 | `db.go WriteConfirm` |
 | `master.key` | `.configdb/master.key` | 0600 | `crypto.go readOrCreateMasterKey` |
 | Text rollback slots | `<config>.N` (e.g. `xpf.conf.1`) | 0600 | `store_commit.go saveRollbackFiles` |
 | Rescue config | `rescue.conf` | 0600 | `store_persist.go SaveRescueConfig` |
@@ -151,6 +152,35 @@ per-path:
   disconnected operator should treat an unanswered commit as
   ambiguous — same as Junos — and inspect `show configuration` after
   reconnecting.
+- **`commit confirmed` survives a crash inside the window (#4577).**
+  The auto-rollback timer is an in-memory `time.AfterFunc` that does NOT
+  outlive the process, so before this fix a daemon crash/reboot inside
+  the confirm window made the UNCONFIRMED config PERMANENT — the
+  safety hatch was silently lost (an operator commits a
+  management-stranding config relying on the auto-revert, the daemon
+  crashes, the box is stranded). `CommitConfirmed` now also persists a
+  `confirm.json` in `.configdb` holding the absolute **deadline**, the
+  **rollback-target tree** (`confirmPrevTree` — the ORIGINAL
+  last-confirmed tree for a nested re-arm), and the **first-commit**
+  flag (`confirmPrevCfg == nil`, the #1922 Item 1b never-committed
+  case). It is written durably (temp+fsync+rename+dir-fsync),
+  encrypted with the same master-password machinery as `active.json`
+  (the target tree may carry secret leaves), 0600, AFTER the successful
+  `writeActive`+promote (a failed commit-confirmed never leaves a
+  `confirm.json`). `Store.Load` (`recoverPendingConfirmLocked`) restores
+  it at boot: if the deadline already passed during downtime it rolls
+  back to the prev tree now (including the Item 1b committed=0 marker on
+  a first-commit target); if the deadline is still in the future it
+  re-arms the timer for the REMAINING duration. Every confirmation path
+  (`clearPendingConfirmLocked` — plain commit / HA sync / explicit
+  confirm / demotion) and the timeout rollback (`PromoteRollback`)
+  remove `confirm.json`; a nested `commit confirmed` re-writes it with
+  the extended deadline. A clean restart inside the window also keeps
+  the hatch (Junos parity: the pending confirm persists across a
+  reboot and rolls back if not confirmed). One residual window remains:
+  a crash in the microseconds between the `writeActive` syscall and the
+  `confirm.json` write leaves no `confirm.json` — vastly smaller than
+  the whole multi-minute window this closes.
 - **`CommitConfirmed` ordering.** Confirm state is only touched after
   the persist succeeds: on failure the rollback timer is NOT armed and
   an existing pending confirm (timer + rollback target) is left fully

--- a/pkg/configstore/commit_confirmed_persist_4577_test.go
+++ b/pkg/configstore/commit_confirmed_persist_4577_test.go
@@ -1,0 +1,209 @@
+package configstore
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// #4577: the commit-confirmed rollback deadline used to be an IN-MEMORY
+// time.AfterFunc only — no confirm.json was persisted and Store.Load never
+// re-armed it. A daemon crash/reboot INSIDE the confirm window therefore made
+// the UNCONFIRMED config permanent, silently losing the auto-rollback safety
+// hatch (the operator commits a management-stranding config relying on
+// commit-confirmed to auto-revert, the daemon crashes, the box is stranded).
+//
+// These tests simulate a crash+restart by arming a commit-confirmed on one
+// Store, then constructing a FRESH Store over the SAME .configdb and calling
+// Load (the daemon boot path). The confirm state must survive.
+
+// armed builds a Store at path, commits Base, then commit-confirmed Confirmed,
+// leaving a pending window. Returns the store (its in-memory timer keeps
+// running with `minutes`; harmless for the test).
+func armedConfirmStore(t *testing.T, path string, minutes int) *Store {
+	t.Helper()
+	s := newTestStoreAt(t, path)
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetFromInput("system host-name Base"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetFromInput("system host-name Confirmed"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.CommitConfirmed(minutes); err != nil {
+		t.Fatalf("CommitConfirmed: %v", err)
+	}
+	if !s.IsConfirmPending() {
+		t.Fatal("should have a pending confirm after CommitConfirmed")
+	}
+	// The confirm.json must exist after arming.
+	if rec, err := s.db.ReadConfirm(); err != nil || rec == nil {
+		t.Fatalf("CommitConfirmed must persist confirm.json: rec=%v err=%v", rec, err)
+	}
+	return s
+}
+
+// RED-on-revert (a): the confirm window expired during downtime. A fresh
+// Store.Load MUST roll back to the pre-confirm config (Base) — the unconfirmed
+// config (Confirmed) is NOT permanent. Before the fix Load ignored the
+// (nonexistent) persisted state and left Confirmed active forever.
+func TestConfirmRecovery_ExpiredRollsBackOnLoad_4577(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	_ = armedConfirmStore(t, path, 10)
+
+	// Force the persisted deadline into the past (simulate a downtime longer
+	// than the window — the minutes granularity of the public API cannot go
+	// sub-minute). In-package access to the DB is deliberate.
+	s0 := newTestStoreAt(t, path)
+	rec, err := s0.db.ReadConfirm()
+	if err != nil || rec == nil {
+		t.Fatalf("ReadConfirm: rec=%v err=%v", rec, err)
+	}
+	rec.Deadline = time.Now().Add(-2 * time.Minute)
+	if err := s0.db.WriteConfirm(rec); err != nil {
+		t.Fatalf("WriteConfirm (past deadline): %v", err)
+	}
+
+	// Crash+restart: a brand-new Store over the same .configdb.
+	s := newTestStoreAt(t, path)
+	if err := s.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if s.IsConfirmPending() {
+		t.Error("an expired confirm window must NOT stay pending after Load")
+	}
+	got := s.ActiveConfig()
+	if got == nil {
+		t.Fatal("ActiveConfig is nil after recovery rollback")
+	}
+	if got.System.HostName != "Base" {
+		t.Fatalf("expired confirm window: active host-name = %q, want Base "+
+			"(the unconfirmed config was NOT rolled back — #4577 regression)",
+			got.System.HostName)
+	}
+	// The persisted state must be cleared once resolved.
+	if r, err := s.db.ReadConfirm(); err != nil || r != nil {
+		t.Fatalf("confirm.json must be removed after recovery rollback: rec=%v err=%v", r, err)
+	}
+	// A second restart must be a clean, non-pending load of the rolled-back
+	// config (idempotent recovery).
+	s2 := newTestStoreAt(t, path)
+	if err := s2.Load(); err != nil {
+		t.Fatalf("second Load: %v", err)
+	}
+	if s2.IsConfirmPending() {
+		t.Error("second restart must not resurrect the resolved window")
+	}
+	if s2.ActiveConfig().System.HostName != "Base" {
+		t.Fatalf("second restart: active host-name = %q, want Base", s2.ActiveConfig().System.HostName)
+	}
+}
+
+// RED-on-revert (b): still within the window. A fresh Store.Load MUST re-arm
+// the timer (a pending confirm is still tracked) and keep the unconfirmed
+// config active until the re-armed timer fires — at which point it rolls back
+// to the ORIGINAL pre-confirm target (Base).
+func TestConfirmRecovery_WithinWindowReArmsOnLoad_4577(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	_ = armedConfirmStore(t, path, 10) // 10-minute window, still open
+
+	s := newTestStoreAt(t, path)
+	if err := s.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if !s.IsConfirmPending() {
+		t.Fatal("a still-open confirm window must be re-armed (pending) after Load — #4577")
+	}
+	if got := s.ActiveConfig().System.HostName; got != "Confirmed" {
+		t.Fatalf("within window: active host-name = %q, want Confirmed "+
+			"(the unconfirmed config must stay active until the re-armed timer fires)", got)
+	}
+	// confirm.json is left in place while the window is open.
+	if r, err := s.db.ReadConfirm(); err != nil || r == nil {
+		t.Fatalf("confirm.json must remain while the window is open: rec=%v err=%v", r, err)
+	}
+
+	// Drive the re-armed timer deterministically: it must roll back to the
+	// ORIGINAL rollback target (Base), proving the persisted target was
+	// restored correctly.
+	gen := s.ConfirmGenForTesting()
+	s.InvokeRollbackTimerForTesting(gen)
+
+	if got := s.ActiveConfig().System.HostName; got != "Base" {
+		t.Fatalf("re-armed confirm timer rolled back to %q, want Base "+
+			"(recovered rollback target wrong — #4577)", got)
+	}
+	if s.IsConfirmPending() {
+		t.Error("after the re-armed timer fires the window must be resolved")
+	}
+	if r, err := s.db.ReadConfirm(); err != nil || r != nil {
+		t.Fatalf("confirm.json must be removed after the re-armed timer fires: rec=%v err=%v", r, err)
+	}
+}
+
+// A normal confirm-within-window (explicit ConfirmCommit) must make the config
+// permanent: confirm.json is removed, and a subsequent restart loads the
+// confirmed config with NO pending window and NO rollback.
+func TestConfirmRecovery_ExplicitConfirmIsPermanent_4577(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	s0 := armedConfirmStore(t, path, 10)
+	if err := s0.ConfirmCommit(); err != nil {
+		t.Fatalf("ConfirmCommit: %v", err)
+	}
+	if r, err := s0.db.ReadConfirm(); err != nil || r != nil {
+		t.Fatalf("ConfirmCommit must remove confirm.json: rec=%v err=%v", r, err)
+	}
+
+	s := newTestStoreAt(t, path)
+	if err := s.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if s.IsConfirmPending() {
+		t.Error("a confirmed config must NOT be pending after restart")
+	}
+	if got := s.ActiveConfig().System.HostName; got != "Confirmed" {
+		t.Fatalf("confirmed config after restart: active host-name = %q, want Confirmed", got)
+	}
+}
+
+// A bare `commit` during the window confirms the pending config (Junos
+// semantics). confirm.json is removed and a restart must NOT roll back — the
+// bare-commit config is permanent.
+func TestConfirmRecovery_BareCommitConfirms_4577(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	s0 := armedConfirmStore(t, path, 10)
+
+	// Background/eventengine PLAIN commit during the window (reaches
+	// CommitWithDescription directly, which calls clearPendingConfirmLocked).
+	if err := s0.SetFromInput("system host-name Remediated"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s0.Commit(); err != nil {
+		t.Fatalf("plain Commit during confirm window: %v", err)
+	}
+	if s0.IsConfirmPending() {
+		t.Error("a plain commit must confirm (clear) the pending window")
+	}
+	if r, err := s0.db.ReadConfirm(); err != nil || r != nil {
+		t.Fatalf("a plain commit must remove confirm.json: rec=%v err=%v", r, err)
+	}
+
+	s := newTestStoreAt(t, path)
+	if err := s.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if s.IsConfirmPending() {
+		t.Error("no pending window must survive a bare-commit confirmation")
+	}
+	if got := s.ActiveConfig().System.HostName; got != "Remediated" {
+		t.Fatalf("bare-commit-confirmed config after restart: active host-name = %q, "+
+			"want Remediated (the confirmed config must be permanent — not rolled back)", got)
+	}
+}

--- a/pkg/configstore/db.go
+++ b/pkg/configstore/db.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/fsatomic"
@@ -151,6 +152,87 @@ func (db *DB) DeleteRollback(n int) error {
 	err := os.Remove(db.rollbackPath(n))
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("delete rollback %d: %w", n, err)
+	}
+	return nil
+}
+
+// confirmRecord is the persisted pending commit-confirmed state (#4577). It
+// survives a daemon crash/reboot INSIDE the confirm window so the
+// auto-rollback safety hatch is not silently lost: the in-memory
+// time.AfterFunc rollback timer does not outlive the process, so without this
+// record a crash before the operator confirms would make an UNCONFIRMED config
+// permanent (the classic management-stranding trap). Store.Load re-arms the
+// timer when the deadline is still in the future, or rolls back to PrevTree
+// when it already passed during downtime.
+type confirmRecord struct {
+	// Deadline is the absolute wall-clock time the confirm window expires.
+	Deadline time.Time `json:"deadline"`
+	// PrevTree is the rollback target — the config that was active BEFORE the
+	// still-unconfirmed commit-confirmed. For a NESTED confirmed commit it
+	// stays the ORIGINAL last-confirmed config (mirrors confirmPrevTree).
+	PrevTree *config.ConfigTree `json:"prev_tree"`
+	// FirstCommit records that PrevTree is the empty bootstrap tree (the
+	// commit-confirmed was the first commit on a fresh store, confirmPrevCfg
+	// was nil at arm time). The rollback must then re-enter never-committed
+	// state (committed=0 marker), matching the in-memory PromoteRollback
+	// #1922 Item 1b path — not persist an operator-committed-empty config.
+	FirstCommit bool `json:"first_commit"`
+}
+
+// confirmPath returns the path to the pending commit-confirmed state file.
+func (db *DB) confirmPath() string {
+	return filepath.Join(db.dir, "confirm.json")
+}
+
+// WriteConfirm persists the pending commit-confirmed state durably (#4577):
+// temp + fsync + rename + dir fsync, so the deadline+rollback-target survive
+// power loss. The embedded PrevTree may carry secret leaves (IKE PSK, auth
+// keys), so it is encrypted with the same master-password machinery as
+// active.json (keyed off the prev tree's master-password leaf) and written
+// owner-only 0600. No #1917 compatibility envelope is used — the file is
+// transient recovery state, not a committed config, and confirmRecord evolves
+// via additive JSON fields.
+func (db *DB) WriteConfirm(rec *confirmRecord) error {
+	data, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal confirm state: %w", err)
+	}
+	data, err = db.maybeEncryptTreeJSON(data, rec.PrevTree)
+	if err != nil {
+		return fmt.Errorf("encrypt confirm state: %w", err)
+	}
+	if err := fsatomic.WriteFileDurable(db.confirmPath(), data, 0600); err != nil {
+		return fmt.Errorf("persist confirm state: %w", err)
+	}
+	return nil
+}
+
+// ReadConfirm loads the pending commit-confirmed state, or (nil, nil) if none
+// is persisted (#4577).
+func (db *DB) ReadConfirm() (*confirmRecord, error) {
+	data, err := os.ReadFile(db.confirmPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read confirm state: %w", err)
+	}
+	data, err = db.maybeDecryptTreeJSON(data)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt confirm state: %w", err)
+	}
+	rec := &confirmRecord{}
+	if err := json.Unmarshal(data, rec); err != nil {
+		return nil, fmt.Errorf("parse confirm state: %w", err)
+	}
+	return rec, nil
+}
+
+// DeleteConfirm removes the pending commit-confirmed state file (#4577).
+// Absent is not an error.
+func (db *DB) DeleteConfirm() error {
+	if err := os.Remove(db.confirmPath()); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("delete confirm state: %w", err)
 	}
 	return nil
 }

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -266,12 +266,55 @@ func (s *Store) CommitConfirmed(minutes int) (*config.Config, error) {
 	// performAutoRollback.
 	s.confirmGen++
 	gen := s.confirmGen
+	deadline := time.Now().Add(time.Duration(minutes) * time.Minute)
 	s.confirmTimer = time.AfterFunc(time.Duration(minutes)*time.Minute, func() {
 		s.fireConfirmTimer(gen)
 	})
 
+	// #4577: persist the pending-confirm state so the auto-rollback deadline
+	// survives a daemon crash/reboot inside the window. The in-memory timer
+	// above is lost on restart; without confirm.json the just-promoted (and
+	// still UNCONFIRMED) config would become permanent. Written AFTER the
+	// successful writeActive+promote so a FAILED commit-confirmed never leaves
+	// a confirm.json (persist-before-promote already returned above on
+	// failure). PrevTree is confirmPrevTree — the ORIGINAL last-confirmed tree
+	// for a nested re-arm; firstCommit mirrors the confirmPrevCfg==nil #1922
+	// Item 1b path. A residual crash window remains between the writeActive
+	// syscall and this write (microseconds vs. the whole multi-minute window
+	// before this fix).
+	s.writeConfirmState(s.confirmPrevTree, deadline, s.confirmPrevCfg == nil)
+
 	slog.Info("commit confirmed started", "timeout_minutes", minutes)
 	return compiled, nil
+}
+
+// writeConfirmState persists the pending commit-confirmed state (#4577) so the
+// auto-rollback deadline + rollback target survive a daemon crash/reboot.
+// Best-effort: a failure is logged, not fatal — the in-memory timer still
+// covers the no-crash case (the #1799 degrade-not-fail doctrine). Caller holds
+// s.mu.
+func (s *Store) writeConfirmState(prevTree *config.ConfigTree, deadline time.Time, firstCommit bool) {
+	if s.db == nil {
+		return
+	}
+	rec := &confirmRecord{Deadline: deadline, PrevTree: prevTree, FirstCommit: firstCommit}
+	if err := s.db.WriteConfirm(rec); err != nil {
+		slog.Warn("failed to persist commit-confirmed state; auto-rollback will not "+
+			"survive a crash within the confirm window", "err", err, "issue", "#4577")
+	}
+}
+
+// removeConfirmState deletes the persisted pending commit-confirmed state
+// (#4577). Called whenever a pending confirm is RESOLVED — confirmed (plain
+// commit / HA sync / explicit confirm / demotion) or rolled back (timer
+// fired). Best-effort; caller holds s.mu.
+func (s *Store) removeConfirmState() {
+	if s.db == nil {
+		return
+	}
+	if err := s.db.DeleteConfirm(); err != nil {
+		slog.Warn("failed to remove persisted commit-confirmed state", "err", err, "issue", "#4577")
+	}
 }
 
 // clearPendingConfirmLocked cancels an armed commit-confirmed rollback
@@ -302,6 +345,13 @@ func (s *Store) clearPendingConfirmLocked() bool {
 	s.confirmTimer = nil
 	s.confirmPrevTree = nil
 	s.confirmPrevCfg = nil
+	// #4577: the pending confirm is now confirmed (plain commit / HA sync /
+	// explicit confirm / demotion) — drop the persisted crash-recovery state
+	// so a later restart does not resurrect a stale rollback window. A nested
+	// confirmed re-arm does NOT pass through here (it re-writes confirm.json
+	// with the extended deadline in CommitConfirmed), so this only fires on a
+	// genuine confirmation.
+	s.removeConfirmState()
 	return true
 }
 
@@ -469,6 +519,14 @@ func (s *Store) PromoteRollback(gen uint64) (prevCfg *config.Config, ok bool) {
 	} else {
 		s.persistDegraded = false
 	}
+
+	// #4577: the confirm window is resolved (rolled back) — drop the persisted
+	// crash-recovery state so a restart does not re-arm/re-roll a completed
+	// window. Idempotent: a crash between the writeActive above and this
+	// remove leaves a confirm.json whose deadline has passed and whose
+	// rollback target equals the now-persisted active, so a Load recovery
+	// re-runs the rollback as a no-op.
+	s.removeConfirmState()
 
 	// Log to journal
 	s.journalLog(&JournalEntry{

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -107,7 +107,116 @@ func (s *Store) Load() error {
 	s.active = tree
 	s.compiled = compiled
 	s.loadRollbackHistory()
+	s.recoverPendingConfirmLocked()
 	return nil
+}
+
+// recoverPendingConfirmLocked restores a commit-confirmed window that was
+// still pending when the daemon last stopped (#4577). The in-memory
+// time.AfterFunc rollback timer does not survive a process restart, so without
+// this an UNCONFIRMED config that the operator armed with `commit confirmed`
+// (relying on it to auto-revert) becomes PERMANENT after a crash/reboot inside
+// the window — the safety hatch is silently lost and a management-stranding
+// config can lock the operator out. Junos persists the pending confirm across
+// a reboot and rolls back if it is not confirmed; this gives xpf the same
+// property.
+//
+// Runs at the tail of a SUCCESSFUL Load (active.json read+compiled), under
+// s.mu. Two outcomes:
+//   - deadline already passed during downtime -> roll back to the persisted
+//     prev tree NOW (the operator never confirmed) exactly as the in-memory
+//     PromoteRollback would have, including the #1922 Item 1b first-commit
+//     never-committed marker, then clear the state.
+//   - deadline still in the future -> re-arm the timer for the REMAINING
+//     duration so the original auto-rollback still fires; a clean restart
+//     inside the window therefore also keeps the hatch.
+func (s *Store) recoverPendingConfirmLocked() {
+	if s.db == nil {
+		return
+	}
+	rec, err := s.db.ReadConfirm()
+	if err != nil {
+		slog.Warn("failed to read persisted commit-confirmed state; cannot restore the "+
+			"pending auto-rollback window", "err", err, "issue", "#4577")
+		return
+	}
+	if rec == nil {
+		return
+	}
+	prevTree := rec.PrevTree
+	if prevTree == nil {
+		prevTree = &config.ConfigTree{}
+	}
+
+	if time.Now().After(rec.Deadline) {
+		// Expired during downtime: the operator never confirmed, so the
+		// unconfirmed config on disk must NOT stand. Revert to the prev tree
+		// with the same persistence semantics as PromoteRollback.
+		s.active = prevTree
+		var perr error
+		if rec.FirstCommit {
+			// #1922 Item 1b: the rollback target is the empty bootstrap tree;
+			// persist committed=0 and clear everCommitted so a later restart
+			// re-classifies into bootstrap, not operator-committed-empty.
+			s.compiled = nil
+			s.persistMarkerCommitted = false
+			s.everCommitted = false
+			perr = s.writeActiveMarker(prevTree, false)
+		} else {
+			compiled, cerr := s.compileTreeLenient(prevTree)
+			if cerr != nil {
+				slog.Warn("recovered commit-confirmed rollback target failed to compile; "+
+					"continuing with the reverted tree", "err", cerr, "issue", "#4577")
+			}
+			s.compiled = compiled
+			s.persistMarkerCommitted = true
+			s.everCommitted = true
+			perr = s.writeActive(prevTree)
+		}
+		if perr != nil {
+			s.noteActivePersistFailureLocked("confirm_recovery_rollback", perr)
+		} else {
+			s.persistDegraded = false
+		}
+		if s.candidate != nil {
+			s.candidate = s.active.Clone()
+		}
+		s.removeConfirmState()
+		s.journalLog(&JournalEntry{
+			Action:     "auto_rollback",
+			Detail:     "commit-confirmed window expired during daemon downtime; reverted on boot (#4577)",
+			ConfigHash: journalConfigHash(s.active),
+		})
+		slog.Warn("commit-confirmed window expired while the daemon was down; configuration "+
+			"rolled back to the pre-confirm state on boot", "issue", "#4577")
+		return
+	}
+
+	// Still within the window: re-arm the timer for the remaining duration so
+	// the original auto-rollback still fires. The active config loaded above
+	// stays the unconfirmed tree; only confirmPrevTree/confirmPrevCfg (the
+	// rollback target) are restored so a subsequent expiry / plain-commit /
+	// sync resolves correctly. confirm.json is left in place until the window
+	// is resolved.
+	remaining := time.Until(rec.Deadline)
+	s.confirmPrevTree = prevTree
+	if rec.FirstCommit {
+		s.confirmPrevCfg = nil
+	} else {
+		compiled, cerr := s.compileTreeLenient(prevTree)
+		if cerr != nil {
+			slog.Warn("recovered commit-confirmed rollback target failed to compile; the "+
+				"pending auto-rollback will revert store state only", "err", cerr, "issue", "#4577")
+		}
+		s.confirmPrevCfg = compiled
+	}
+	s.confirmGen++
+	gen := s.confirmGen
+	s.confirmTimer = time.AfterFunc(remaining, func() {
+		s.fireConfirmTimer(gen)
+	})
+	slog.Info("restored pending commit-confirmed window after restart; auto-rollback re-armed",
+		"remaining", remaining.String(), "issue", "#4577")
 }
 
 // Save persists the active configuration to disk.


### PR DESCRIPTION
## Summary

Closes #4577.

The commit-confirmed auto-rollback deadline was an in-memory `time.AfterFunc` only (`store_commit.go`). No `confirm.json` was persisted and `Store.Load` never re-armed it, so a daemon **crash or reboot inside the confirm window made the UNCONFIRMED config permanent** — the auto-rollback safety hatch was silently lost. An operator who commits a management-stranding config relying on `commit confirmed` to auto-revert is stranded permanently if the daemon crashes before confirmation. Junos persists the pending confirm across a reboot and rolls back if not confirmed; this gives xpf the same property.

## Fix

- **`DB.WriteConfirm` / `ReadConfirm` / `DeleteConfirm`** (`db.go`) manage a `.configdb/confirm.json` record holding the absolute **deadline**, the **rollback-target tree** (`confirmPrevTree` — the ORIGINAL last-confirmed tree for a nested re-arm), and the **first-commit** flag (`confirmPrevCfg == nil`, the #1922 Item 1b never-committed case). Written durably (temp+fsync+rename+dir-fsync), encrypted with the same master-password machinery as `active.json` (the target may carry secret leaves), 0600.
- **`CommitConfirmed`** writes `confirm.json` AFTER the successful `writeActive`+promote — a failed commit-confirmed never leaves one.
- **`Store.Load` (`recoverPendingConfirmLocked`)** restores it at boot: deadline already passed during downtime → roll back to the prev tree now (incl. the Item 1b committed=0 marker on a first-commit target); deadline still in the future → re-arm the timer for the remaining duration. A clean restart inside the window also keeps the hatch.
- Every confirmation path (`clearPendingConfirmLocked` — plain commit / HA sync / explicit confirm / demotion) and the timeout rollback (`PromoteRollback`) remove `confirm.json`; a nested `commit confirmed` re-writes it with the extended deadline.

The normal no-crash flow (arm → confirm-within-window → permanent) is unchanged; a bare commit still confirms; the timeout target is the same tree the in-memory `AfterFunc` rolled back to. One residual window remains: a crash in the microseconds between the `writeActive` syscall and the `confirm.json` write leaves no `confirm.json` — vastly smaller than the whole multi-minute window this closes.

## Validation

- New RED-on-revert Go tests (`commit_confirmed_persist_4577_test.go`) simulate crash+restart by arming a commit-confirmed on one `Store` then `Load`-ing a fresh `Store` over the same `.configdb`:
  - **expired** deadline → rolls back to the pre-confirm config (Base)
  - **within window** → re-arms (pending), and the re-armed timer rolls back to the ORIGINAL target
  - **explicit confirm** and **bare commit** → config is permanent (no rollback)
- Disabling `recoverPendingConfirmLocked` flips the first two tests RED (verified).
- `pkg/configstore` + `pkg/daemon` rollback/bootstrap/confirm suites, `go vet`, `gofmt`, and `go build ./...` all green.
- Docs: `pkg/configstore/README.md` (persist-failure semantics + `.configdb` file layout) and `_Log.md`.

GO-only (`pkg/configstore`); no cargo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi