### PR TITLE
deploy: write day-0 config ISO owner-only (0600) not world-readable

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-07-07 — #4586 deploy: day-0 config ISO written owner-only (0600), no longer world-readable in CWD
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4586 (ps-037-A10 A10-02, MEDIUM secret-at-rest).
+  `build_config_drive()` in `scripts/deploy/xpf-deploy.py` builds the
+  `<name>-day0.iso` day-0 drive via xorriso/genisoimage under the process
+  umask (~0022 → 0644, world-readable) and never chmod'd the finished ISO.
+  That ISO embeds `xpf.conf` verbatim — the most secret-bearing artifact
+  (system root-authentication hash, security IKE pre-shared-key, SNMP
+  community, DDNS tsig/api-token/password) — and lingers in the build CWD
+  until `destroy`. On a shared build/CI/jump host a co-located UID could
+  `isoinfo -R -x /xpf.conf` the secrets out. Fix = `os.chmod(iso, 0o600)`
+  immediately after `run_capture(argv)` (once the ISO exists on disk), so
+  the drive is owner-only regardless of umask; the owner (daemon/VM) still
+  reads it fine. Also tightened the staged `xpf.conf` chmod from `0o644` to
+  `0o600` (the 0700 mkdtemp already shields it — belt-and-suspenders). Added
+  `test_xpf_deploy_iso_mode.py`: mocks the xorriso call to leave the ISO
+  0644 (the defect), then asserts `build_config_drive()` yields
+  `mode & 0o077 == 0` for both the ISO and the staged conf; RED-on-revert
+  verified (0o644 without the chmod). `python3 -m py_compile` clean; all 6
+  deploy test files + `scripts/run-selftests.sh` green (29 passed / 0 failed).
+- **File(s)**: scripts/deploy/xpf-deploy.py,
+  scripts/deploy/test_xpf_deploy_iso_mode.py, docs/deploy-quickstart.md,
+  _Log.md
+
 ## 2026-07-07 — #4566 cos: CachedThreeColorPolicers grows to a SmallVec so the cached TX path re-meters ALL fall-through policers (not just the first two)
 
 - **Timestamp**: 2026-07-07

--- a/docs/deploy-quickstart.md
+++ b/docs/deploy-quickstart.md
@@ -125,6 +125,14 @@ scripts/deploy/xpf-deploy.py destroy examples/deploy/standalone-passthrough.yaml
 scripts/deploy/xpf-deploy.py --hypervisor libvirt destroy examples/deploy/standalone-passthrough.yaml
 ```
 
+The `<name>-day0.iso` drive is written **owner-only (0600)** in the build
+directory and lingers there until `destroy` removes it. That ISO embeds
+`xpf.conf` verbatim — the most secret-bearing artifact on the box
+(root-authentication hash, IKE pre-shared-keys, SNMP community, DDNS
+tokens) — so the tool never leaves it world-readable even under a lax
+umask (#4586). On a shared build/CI/jump host, run `destroy` (or delete
+the ISO) once the VM is up rather than leaving day-0 secrets on disk.
+
 `deploy` runs a **preflight** before it mutates anything — the image /
 golden qcow2, every NIC source (managed network / host bridge / PF / PCI
 device), and a free instance name must all exist, or it fails with one

--- a/scripts/deploy/test_xpf_deploy_iso_mode.py
+++ b/scripts/deploy/test_xpf_deploy_iso_mode.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Unit test for the day-0 ISO file mode (#4586, ps-037-A10 A10-02).
+
+build_config_drive() writes a day-0 config ISO whose sole payload is
+xpf.conf — the most secret-bearing artifact on the box: the system
+root-authentication hash, the security IKE pre-shared-key, the SNMP
+community, and the DDNS tsig/api-token/password. xorriso/genisoimage
+create that ISO under the process umask (a typical ~0022 yields a
+world-readable 0644 file) and it lingers in CWD until an explicit
+destroy. Any co-located UID could then `isoinfo -R -x /xpf.conf` the
+secrets straight out of it.
+
+The fix chmods the finished ISO to 0o600 immediately after it is built,
+and stages the intermediate xpf.conf 0o600 too. These tests assert both:
+
+  - after build_config_drive() the ISO has no group/other permission bits
+    (mode & 0o077 == 0), regardless of the umask xorriso ran under;
+  - the staged xpf.conf handed to the ISO builder is likewise owner-only.
+
+On revert (drop the os.chmod(iso, 0o600), restore the 0o644 staging
+chmod) both assertions go RED: the ISO comes back 0644 world-readable
+and the staged copy 0644.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_SPEC = importlib.util.spec_from_file_location(
+    "xpf_deploy", Path(__file__).with_name("xpf-deploy.py")
+)
+xpf_deploy = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(xpf_deploy)
+
+
+class _RealBuildRunner:
+    """Runner that takes the real (non-dry) ISO build path."""
+
+    def __init__(self):
+        self.dry = False
+
+
+def _appliance(base_dir, name="fw-secret"):
+    return {
+        "name": name, "mode": "standalone", "node_id": None,
+        "image": "xpf-appliance", "cpu": 2, "memory": "4G",
+        "config": "day0.conf", "base_dir": base_dir, "interfaces": [],
+    }
+
+
+class Day0IsoModeTests(unittest.TestCase):
+    def _build(self, staged_mode_holder):
+        """Drive build_config_drive() with the ISO builder mocked out.
+
+        The fake run_capture emulates xorriso: it materialises the target
+        ISO world-readable (0o644) under a lax umask, exactly the defect
+        the fix must correct. It also records the mode of the staged
+        xpf.conf that is about to be packed, so we can assert the staging
+        chmod too (the stage dir is rmtree'd right after this returns)."""
+
+        def fake_run_capture(argv, dry=False):
+            out = argv[argv.index("-o") + 1]
+            stage = argv[-1]  # final positional arg = staging dir
+            staged = os.path.join(stage, "xpf.conf")
+            if os.path.isfile(staged):
+                staged_mode_holder.append(os.stat(staged).st_mode & 0o777)
+            with open(out, "wb") as f:
+                f.write(b"\x00" * 2048)
+            os.chmod(out, 0o644)  # world-readable, as the real tools leave it
+            return ""
+
+        with tempfile.TemporaryDirectory() as td:
+            with open(os.path.join(td, "day0.conf"), "w") as f:
+                f.write('system { root-authentication { '
+                        'encrypted-password "$6$topsecret"; } }\n')
+            ap = _appliance(td)
+            old_umask = os.umask(0o022)  # force the world-readable default
+            old_cwd = os.getcwd()
+            os.chdir(td)  # ISO lands in CWD — keep it inside the temp dir
+            try:
+                with mock.patch.object(xpf_deploy, "find_xpfd",
+                                       return_value=None), \
+                     mock.patch.object(xpf_deploy.shutil, "which",
+                                       return_value="/usr/bin/xorriso"), \
+                     mock.patch.object(xpf_deploy, "run_capture",
+                                       side_effect=fake_run_capture):
+                    iso = xpf_deploy.build_config_drive(ap, _RealBuildRunner())
+                mode = os.stat(iso).st_mode & 0o777
+            finally:
+                os.chdir(old_cwd)
+                os.umask(old_umask)
+            return mode
+
+    def test_iso_is_owner_only(self):
+        staged = []
+        mode = self._build(staged)
+        # The secret-bearing ISO must not be readable by group/other.
+        self.assertEqual(
+            mode & 0o077, 0,
+            f"day-0 ISO must be owner-only, got {oct(mode)} (#4586)")
+        self.assertEqual(mode, 0o600, f"expected 0o600, got {oct(mode)}")
+
+    def test_staged_conf_is_owner_only(self):
+        staged = []
+        self._build(staged)
+        self.assertEqual(len(staged), 1,
+                         "expected exactly one staged xpf.conf")
+        self.assertEqual(
+            staged[0] & 0o077, 0,
+            f"staged xpf.conf must be owner-only, got {oct(staged[0])} (#4586)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/deploy/xpf-deploy.py
+++ b/scripts/deploy/xpf-deploy.py
@@ -317,7 +317,11 @@ def build_config_drive(ap, runner):
     stage = tempfile.mkdtemp(prefix="xpf-day0-")
     try:
         shutil.copyfile(cfg_path, os.path.join(stage, "xpf.conf"))
-        os.chmod(os.path.join(stage, "xpf.conf"), 0o644)
+        # 0o600, not 0o644: the staged xpf.conf carries every day-0 secret
+        # (root-authentication hash, IKE PSK, SNMP community, DDNS tokens).
+        # The 0700 mkdtemp already shields it, so this is belt-and-suspenders,
+        # but it keeps the staged copy owner-only too (#4586).
+        os.chmod(os.path.join(stage, "xpf.conf"), 0o600)
         if ap["mode"] == "cluster":
             with open(os.path.join(stage, "node-id"), "w") as f:
                 f.write(f"{ap['node_id']}\n")
@@ -327,6 +331,13 @@ def build_config_drive(ap, runner):
         else:
             argv = [mkiso, "-quiet", "-V", "xpf-config", "-J", "-r", "-o", iso, stage]
         run_capture(argv)   # die with the mkiso error, not a bare traceback (H-21)
+        # The ISO embeds xpf.conf — the most secret-bearing day-0 artifact
+        # (root-authentication hash, IKE PSK, SNMP community, DDNS tokens).
+        # xorriso/genisoimage writes it under the process umask (~0022 ->
+        # 0644, world-readable) and it lingers in CWD until destroy. Restrict
+        # it to owner-only so a co-located UID cannot `isoinfo -x /xpf.conf`
+        # the secrets out (#4586). The owner (daemon/VM) still reads it fine.
+        os.chmod(iso, 0o600)
         print(f"==> built day-0 drive {iso} (label xpf-config)")
     finally:
         shutil.rmtree(stage, ignore_errors=True)


### PR DESCRIPTION
## Summary

`build_config_drive()` in `scripts/deploy/xpf-deploy.py` builds the
`<name>-day0.iso` day-0 drive with xorriso/genisoimage under the process
umask (a typical ~0022 yields a **world-readable 0644** file) and never
chmod'd the finished ISO. That ISO embeds `xpf.conf` verbatim — the most
secret-bearing artifact on the box: the system root-authentication hash,
the security IKE pre-shared-key, the SNMP community, and the DDNS
tsig/api-token/password. The ISO lingers in the build CWD until an
explicit `destroy` (often not run), so on a shared build / CI / jump host
a co-located UID could `isoinfo -R -x /xpf.conf` the secrets straight out
of it. The tool silently downgraded the secret to 0644 even when the
operator kept the source config 0600.

## Fix

- `os.chmod(iso, 0o600)` immediately after `run_capture(argv)` builds the
  ISO (once it exists on disk), so the drive is owner-only regardless of
  the umask xorriso ran under. The owner (the daemon / VM that attaches
  it) still reads it fine — only the file mode tightens.
- Tighten the intermediate staged `xpf.conf` chmod from `0o644` to
  `0o600`. The 0700 `mkdtemp` staging dir already shields it, so this is
  belt-and-suspenders, but it keeps the staged copy owner-only too.

## Test

- New `scripts/deploy/test_xpf_deploy_iso_mode.py`: mocks the xorriso
  invocation to leave the ISO `0644` (reproducing the defect) under a lax
  umask, then asserts `build_config_drive()` yields `mode & 0o077 == 0`
  for **both** the finished ISO and the staged `xpf.conf`.
  **RED-on-revert verified** — without the `os.chmod` the ISO comes back
  `0o644`. The selftest runner auto-globs `scripts/deploy/test_*.py`, so
  the new test joins the existing suite.
- `python3 -m py_compile scripts/deploy/xpf-deploy.py` clean.
- All six `scripts/deploy/test_xpf_deploy_*.py` files and
  `scripts/run-selftests.sh` green (29 passed / 0 failed).

## Docs

`docs/deploy-quickstart.md` documents the owner-only ISO + a
"run `destroy` on shared hosts" hygiene note.

Closes #4586

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi