### PR TITLE
configstore: fix annotate on named/multi-key containers (#4587)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -40369,3 +40369,25 @@ top.
   pkg/configstore/store_persist.go,
   pkg/configstore/commit_confirmed_persist_4577_test.go,
   pkg/configstore/README.md, _Log.md
+
+- **Timestamp**: 2026-07-07 (#4587)
+- **Action**: Fix `annotate` failing for named / multi-key containers
+  (zones, policies, interface-units, family inet). `Store.Annotate` used a
+  hand-rolled walk that consumed ONE path token per node but matched it
+  against ANY key in the node's `Keys`, so a multi-key node
+  (`Keys=[security-zone,trust]`) was entered on its first key and then
+  failed to find the argument token (`trust`) as a child — `path not found`
+  for every named container; annotate worked only for pure single-key
+  chains like `system`. Replaced the walk with a new
+  `ConfigTree.AnnotatePath` that reuses the same multi-key-aware
+  `navigatePath` traversal `show <path>`/`FormatPath` use (the
+  #3980/#4562 read-all-siblings resolver). The comment is set on the first
+  resolved node (single-node semantics; `annotate system` byte-identical),
+  an unresolved path still returns a clear `path not found` error and
+  mutates nothing, and the #3900 comment-delimiter rejection
+  (`ValidateAnnotationText`, before resolution) is unchanged. RED-on-revert
+  test `TestAnnotateMultiKeyContainers` (zone / zone-description-leaf /
+  from-zone-to-zone-policy / interface-unit / family-inet resolve,
+  single-key non-regression, non-existent multi-key path errors).
+- **File(s)**: pkg/config/ast.go, pkg/configstore/store_command.go,
+  pkg/configstore/store_test.go, docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -320,6 +320,31 @@ append-on-reinsert) was removed. Covered by `TestRenameNonFirstSibling` in
 `A->A2` still works, colliding `B->C` rejected with the tree unchanged, and a
 post-rename `CompileConfig` seeing `[A B2 C]`).
 
+**`annotate <path> "comment"` resolves through `navigatePath` (#4587).**
+`annotate` attaches a `/* comment */` to the statement at a path, and — like
+`delete`/`deactivate`/`rename` above — the path routinely crosses NAMED /
+multi-key containers: `security zones security-zone trust`, `security policies
+from-zone <z> to-zone <z> policy <p>`, `interfaces <name> unit <n>`, `family
+inet`. `Store.Annotate` (`pkg/configstore/store_command.go`) previously used a
+hand-rolled walk that consumed ONE path token per node but matched it against
+ANY key in the node's `Keys`, so it entered a multi-key node on its first key
+(`security-zone` of `Keys=[security-zone,trust]`) and then failed to find the
+argument token (`trust`) as a child — `path not found` for every zone, policy,
+interface-unit, and family-inet path. Annotate worked only for a chain of pure
+single-key nodes such as `system`. It now delegates to
+`ConfigTree.AnnotatePath` (`pkg/config/ast.go`), which reuses the SAME
+multi-key-aware `navigatePath` traversal that `show <path>` / `FormatPath`
+use (the #3980/#4562 read-all-siblings display resolver) — a multi-key node is
+consumed as a unit, so every named container resolves. The comment is set on
+the first resolved node (single-node semantics; the single-key `system` case is
+byte-identical), and an unresolved path still returns a clear `path not found:
+<path>` error and mutates nothing. The #3900 comment-delimiter rejection
+(`ValidateAnnotationText`) runs BEFORE resolution and is unchanged. Covered by
+`TestAnnotateMultiKeyContainers` in `pkg/configstore/store_test.go` (zone /
+zone-description-leaf / from-zone-to-zone-policy / interface-unit / family-inet
+resolve + RED on revert, single-key `system` non-regression, non-existent
+multi-key path still errors).
+
 **Firewall-filter `source/destination-prefix-list` refs are dual-AST too
 (#3843).** These `from` leaves are NOT `multi: true` value-tails — each
 reference carries an optional trailing `except` modifier, so they compile

--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -289,6 +289,32 @@ func unionChildren(nodes []*Node) []*Node {
 	return out
 }
 
+// AnnotatePath sets the annotation comment on the configuration node named by
+// path. Resolution goes through navigatePath, the same multi-key-aware
+// traversal `show <path>` uses, so a named / multi-key container is consumed
+// as one unit: security-zone <name>, from-zone <z> to-zone <z> policy <p>,
+// interfaces <name> unit <n>, family inet, and friends all resolve.
+//
+// It replaces the hand-rolled one-token-per-node walk that Store.Annotate
+// carried before #4587, which matched a multi-key node by ANY single key then
+// looked for the argument token as a child and failed ("path not found") for
+// every named container — annotate worked only for a chain of pure single-key
+// nodes such as `system`. The comment is set on the FIRST resolved node,
+// preserving the prior single-node semantics; a single-key path like `system`
+// resolves to exactly the same node and result as before. A path that does not
+// resolve returns a clear error naming the path and mutates nothing.
+func (t *ConfigTree) AnnotatePath(path []string, comment string) error {
+	if len(path) == 0 {
+		return fmt.Errorf("path not found: (empty path)")
+	}
+	matches := navigatePath(t.Children, path)
+	if len(matches) == 0 {
+		return fmt.Errorf("path not found: %s", strings.Join(path, " "))
+	}
+	matches[0].Annotation = comment
+	return nil
+}
+
 // matchNodeKeys checks if a node's Keys match path elements starting at pos.
 // Returns the number of path elements consumed (len(node.Keys)) on match, 0 otherwise.
 func matchNodeKeys(n *Node, path []string, pos int) int {

--- a/pkg/configstore/store_command.go
+++ b/pkg/configstore/store_command.go
@@ -196,29 +196,20 @@ func (s *Store) Annotate(path []string, comment string) error {
 		return err
 	}
 
-	children := s.candidate.Children
-	var target *config.Node
-	for _, key := range path {
-		found := false
-		for _, child := range children {
-			for _, k := range child.Keys {
-				if k == key {
-					target = child
-					children = child.Children
-					found = true
-					break
-				}
-			}
-			if found {
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("path not found: %s", strings.Join(path, " "))
-		}
+	// #4587: resolve the target via the shared navigatePath traversal
+	// (ConfigTree.AnnotatePath) instead of a hand-rolled walk. The old walk
+	// consumed ONE path token per node but matched it against ANY key in a
+	// node's Keys, so a named / multi-key container — Keys=[security-zone,
+	// trust], [from-zone,untrust,to-zone,trust,policy,p], [family,inet] — was
+	// entered on its first key and then failed to find the argument token
+	// (trust, inet, ...) as a child: "path not found" for every zone, policy,
+	// interface-unit, and family-inet path. Annotate worked only for a chain
+	// of pure single-key nodes such as `system`. navigatePath consumes a
+	// multi-key node as a unit, so those paths now resolve; the single-key
+	// case is unchanged.
+	if err := s.candidate.AnnotatePath(path, comment); err != nil {
+		return err
 	}
-
-	target.Annotation = comment
 	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
 	s.dirty = true
 	return nil

--- a/pkg/configstore/store_test.go
+++ b/pkg/configstore/store_test.go
@@ -1395,6 +1395,83 @@ func TestAnnotateRejectsCommentDelimiter(t *testing.T) {
 	}
 }
 
+// TestAnnotateMultiKeyContainers is the #4587 guard: `annotate` must resolve a
+// path through NAMED / multi-key containers (security-zone <name>, from-zone
+// <z> to-zone <z> policy <p>, interfaces <name> unit <n>, family inet), not
+// only a chain of pure single-key nodes like `system`. The old hand-rolled
+// walk consumed one path token per node but matched it against ANY key in a
+// node's Keys, so it entered a multi-key node on its first key and then failed
+// to find the argument token as a child ("path not found"). This test RED-s on
+// revert for every multi-key path below while the single-key `system` case
+// stays green.
+func TestAnnotateMultiKeyContainers(t *testing.T) {
+	s := newTestStore(t)
+	s.EnterConfigure()
+
+	// Build a config exercising each multi-key container shape.
+	setup := [][]string{
+		{"security", "zones", "security-zone", "trust", "host-inbound-traffic", "system-services", "ssh"},
+		{"security", "zones", "security-zone", "trust", "description", "trusted-side"},
+		{"security", "policies", "from-zone", "trust", "to-zone", "untrust", "policy", "allow-web", "match", "source-address", "any"},
+		{"interfaces", "ge-0/0/0", "unit", "0", "family", "inet", "address", "10.0.0.1/24"},
+	}
+	for _, p := range setup {
+		if err := s.Set(p); err != nil {
+			t.Fatalf("setup Set(%v): %v", p, err)
+		}
+	}
+
+	// Each of these paths crosses at least one multi-key node. On the old
+	// walk every one returned "path not found"; navigatePath consumes the
+	// multi-key node as a unit so they resolve. Distinct comments let the
+	// show-output assertion pin each annotation to its target.
+	cases := []struct {
+		path    []string
+		comment string
+	}{
+		// Named container: security-zone <name>.
+		{[]string{"security", "zones", "security-zone", "trust"}, "zone-trust-note"},
+		// Terminal leaf reached THROUGH the named container.
+		{[]string{"security", "zones", "security-zone", "trust", "description"}, "zone-desc-note"},
+		// from-zone <z> to-zone <z> policy <p> (four-key context + keyed policy).
+		{[]string{"security", "policies", "from-zone", "trust", "to-zone", "untrust", "policy", "allow-web"}, "policy-note"},
+		// interfaces <name> unit <n>.
+		{[]string{"interfaces", "ge-0/0/0", "unit", "0"}, "unit-note"},
+		// family inet (multi-key leaf-container).
+		{[]string{"interfaces", "ge-0/0/0", "unit", "0", "family", "inet"}, "family-note"},
+	}
+	for _, c := range cases {
+		if err := s.Annotate(c.path, c.comment); err != nil {
+			t.Errorf("Annotate(%v) must resolve a multi-key path: %v", c.path, err)
+		}
+	}
+
+	text := s.ShowCandidate()
+	for _, c := range cases {
+		want := "/* " + c.comment + " */"
+		if !strings.Contains(text, want) {
+			t.Errorf("annotation %q not in show output for path %v:\n%s", want, c.path, text)
+		}
+	}
+
+	// The single-key `system` case must still work, byte-identically.
+	if err := s.Set([]string{"system", "host-name", "fw1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Annotate([]string{"system"}, "system-note"); err != nil {
+		t.Fatalf("single-key annotate must still work: %v", err)
+	}
+	if text := s.ShowCandidate(); !strings.Contains(text, "/* system-note */") {
+		t.Errorf("single-key annotation missing:\n%s", text)
+	}
+
+	// A non-existent multi-key path still returns a clear error and mutates
+	// nothing.
+	if err := s.Annotate([]string{"security", "zones", "security-zone", "does-not-exist"}, "nope"); err == nil {
+		t.Error("expected error annotating a non-existent multi-key path")
+	}
+}
+
 func TestLoadSet(t *testing.T) {
 	s := newTestStore(t)
 	if err := s.EnterConfigure(); err != nil {


### PR DESCRIPTION
## Summary

`annotate <path> "comment"` failed with `path not found` for every NAMED /
multi-key container — security zones, from-zone/to-zone/policy, interface
units, and even `family inet`. It worked only for a chain of pure single-key
nodes such as `system`.

`Store.Annotate` (`pkg/configstore/store_command.go`) resolved the target with
a hand-rolled walk that consumed ONE path token per node but matched it against
ANY key in the node's `Keys`. Named containers are MULTI-KEY nodes
(`security-zone trust` → `Node{Keys:[security-zone,trust]}`), so the walk
entered a multi-key node on its first key and then failed to find the argument
token (`trust`, `inet`, ...) as a child. It failed safe (an error, no
corruption) but was untested.

## Fix

Replace the walk with a new `ConfigTree.AnnotatePath` (`pkg/config/ast.go`) that
reuses the same multi-key-aware `navigatePath` traversal `show <path>` /
`FormatPath` already use (the #3980/#4562 read-all-siblings display resolver). A
multi-key node is consumed as a unit, so every named container resolves.

Preserved:
- comment set on the FIRST resolved node (single-node semantics); the single-key
  `system` path is byte-identical;
- an unresolved path still returns a clear `path not found: <path>` error and
  mutates nothing;
- the #3900 comment-delimiter rejection (`ValidateAnnotationText`) runs BEFORE
  resolution and is unchanged.

## Validation

- New RED-on-revert `TestAnnotateMultiKeyContainers`: zone container,
  description leaf reached through the zone, from-zone/to-zone/policy context,
  interface unit, and `family inet` all return `path not found` on the old walk;
  single-key `system` non-regression; non-existent multi-key path still errors.
- `go test ./pkg/configstore/... ./pkg/config/...` green; `go build ./...`;
  `gofmt` + `go vet` clean.
- Docs: `docs/config-schema.md` config-edit-verb section documents the
  annotate/`navigatePath` rewire.

Closes #4587

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi