### PR TITLE
frr: validate BGP-neighbor SHOW IP before it reaches vtysh (#4588)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-07 — #4588 frr: validate a BGP-neighbor SHOW command's IP before it reaches vtysh (unauthenticated local gRPC show path)
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4588 (ps-037-A7 F-A7-004 + ps-038-A8-b2 F-001, LOW-MED
+  defense-in-depth). `pkg/frr/vtysh.go`
+  `GetBGPNeighborReceivedRoutes`/`GetBGPNeighborAdvertisedRoutes`/
+  `GetBGPNeighborDetail` guarded only `ip == ""` then concatenated the IP
+  straight into `vtysh -c "show bgp neighbor <ip> …"`. The IP is
+  operator-supplied via `GetBGPStatus` (`pkg/grpcapi/server_routing.go`,
+  `received-routes:<ip>`/`advertised-routes:<ip>`/`neighbor:<ip>` selectors,
+  no `net.ParseIP`) + `pkg/cli/cli_show_routing.go`. The local gRPC listener
+  (127.0.0.1:50051) is unauthenticated and — unlike the config-render path
+  (`sanitizeFRRValue`/`validateNodesControlChars`, #4097/#1798) — the SHOW
+  path was never sanitized, so a newline-bearing token
+  (`1.1.1.1\nconfigure terminal…`) could reach `vtysh -c`, which historically
+  splits its argument on newlines = a second raw FRR CLI command with no
+  commit-audit trail. `realExecutor.Vtysh` is `exec.CommandContext` (no OS
+  shell, so shell metacharacters were already inert; the delta is the raw
+  newline vector + stealth). Fix = the load-bearing belt at each wrapper:
+  `if net.ParseIP(ip) == nil { return error }` closest to the exec (received/
+  advertised reject empty too; detail still allows empty = all neighbors) +
+  defense-in-depth at the boundary: `GetBGPStatus` re-validates and returns
+  `codes.InvalidArgument`. `net.ParseIP` accepts both IPv4 and IPv6, so a
+  valid neighbor is unchanged.
+- **File(s)**: pkg/frr/vtysh.go (net import + 3 wrapper guards),
+  pkg/grpcapi/server_routing.go (net import + 3 boundary guards),
+  pkg/frr/bgp_neighbor_ip_guard_4588_test.go (RED-on-revert: newline/space/
+  garbage/empty IP → error + Vtysh NOT invoked [vtyshCalls==0]; valid v4/v6 →
+  exact command built, no newline; empty ip → all-neighbors still works),
+  pkg/grpcapi/server_bgp_status_ip_guard_4588_test.go (boundary: malformed
+  neighbor IP → codes.InvalidArgument; "neighbor"/"neighbor:" all-selectors
+  not rejected), pkg/frr/README.md (#4588 gotcha beside #4097/#4482),
+  pkg/grpcapi/README.md (boundary-validation note), _Log.md.
+- **Validation**: RED-on-revert confirmed (drop both guards → the frr belt
+  test AND the grpcapi boundary test FAIL; restore → green). `go test
+  ./pkg/frr/... ./pkg/grpcapi/...` green; `go build`, `gofmt -l` clean, `go
+  vet` clean.
+
 ## 2026-07-07 — #4566 cos: CachedThreeColorPolicers grows to a SmallVec so the cached TX path re-meters ALL fall-through policers (not just the first two)
 
 - **Timestamp**: 2026-07-07

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -418,6 +418,29 @@ also carries operator content:
   cannot inject a standalone frr.conf command. Guarded by
   `TestGeneratePolicyOptions_SetClauseAndPrefixListSanitized_4482` (fail on
   revert of any wrapped site).
+- **A BGP-neighbor SHOW command validates its IP before it reaches vtysh
+  (#4588).** The #1798/#4097/#4482 belts above cover the config-RENDER path;
+  the operational SHOW path is a separate surface. `GetBGPNeighborReceivedRoutes`
+  / `GetBGPNeighborAdvertisedRoutes` / `GetBGPNeighborDetail` (`vtysh.go`)
+  concatenate a neighbor IP straight into `vtysh -c "show bgp neighbor <ip> …"`.
+  That IP arrives from the operator via `GetBGPStatus` (`pkg/grpcapi/server_routing.go`,
+  `received-routes:<ip>` / `advertised-routes:<ip>` / `neighbor:<ip>` selectors)
+  and `pkg/cli/cli_show_routing.go` — and unlike the config path it was never
+  sanitized. The local gRPC listener (127.0.0.1:50051) is unauthenticated, so a
+  malformed token (`1.1.1.1\nconfigure terminal…`) could reach the vtysh command
+  line: `realExecutor.Vtysh` is `exec.CommandContext` (no OS shell, so shell
+  metacharacters are inert) but `vtysh -c` historically splits its argument on
+  NEWLINES, which would turn an embedded `\n` into a second raw FRR CLI command
+  with no commit-audit trail. Each wrapper now rejects a non-parseable IP with
+  `net.ParseIP(ip) == nil → error` (the load-bearing belt, closest to the exec);
+  `GetBGPNeighborDetail` still allows an EMPTY ip (selects every neighbor).
+  `GetBGPStatus` re-validates at the trust boundary and returns
+  `codes.InvalidArgument` (defense-in-depth). `net.ParseIP` accepts IPv4 and
+  IPv6 neighbors, so the happy path is unchanged. Guarded by
+  `TestBGPNeighbor*RejectsUnvalidatedIP` / `TestBGPNeighborValidIPsPass`
+  (`bgp_neighbor_ip_guard_4588_test.go`) and
+  `TestGetBGPStatusRejectsUnvalidatedNeighborIP`
+  (`pkg/grpcapi/server_bgp_status_ip_guard_4588_test.go`).
 - **Group address-family flags are gated by neighbor address version
   (#2454).** When `compiler_protocols.go` copies a BGP group's `family inet`
   / `family inet6` flags down to each neighbor, it parses the neighbor's

--- a/pkg/frr/bgp_neighbor_ip_guard_4588_test.go
+++ b/pkg/frr/bgp_neighbor_ip_guard_4588_test.go
@@ -1,0 +1,130 @@
+package frr
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBGPNeighborReceivedRoutesRejectsUnvalidatedIP proves the #4588 belt:
+// GetBGPNeighborReceivedRoutes must reject a neighbor "IP" that carries a
+// space or embedded newline (raw vtysh CLI injection payload) BEFORE it
+// builds and runs the vtysh command. The show path is reachable over the
+// unauthenticated local gRPC channel (GetBGPStatus), and unlike the config
+// path it is not sanitized — so a newline-bearing token must never reach
+// `vtysh -c` (FRR historically splits its -c argument on newlines).
+//
+// On revert (drop the net.ParseIP guard, restore `if ip == ""`), the raw
+// ip is concatenated into the command and Vtysh is invoked — the
+// vtyshCalls==0 and lastVtyshCmd assertions go RED.
+func TestBGPNeighborReceivedRoutesRejectsUnvalidatedIP(t *testing.T) {
+	badIPs := []string{
+		"1.1.1.1\nconfigure terminal",
+		"1.1.1.1 received-routes\nconfigure terminal\nno router bgp 65000",
+		"1.1.1.1 all",  // trailing token — not a bare IP
+		"not-an-ip",    // pure garbage
+		"",             // empty must still error
+		"1.1.1.1/24",   // prefix, not a host address
+		"1.1.1.1\t x ", // tab/space bearing
+	}
+	for _, bad := range badIPs {
+		fake := &fakeExecutor{}
+		m := &Manager{exec: fake}
+		out, err := m.GetBGPNeighborReceivedRoutes(bad)
+		if err == nil {
+			t.Errorf("GetBGPNeighborReceivedRoutes(%q): expected error, got nil (out=%q)", bad, out)
+		}
+		if fake.vtyshCalls != 0 {
+			t.Errorf("GetBGPNeighborReceivedRoutes(%q): Vtysh was invoked (%d calls, cmd=%q) — the raw IP reached the command line",
+				bad, fake.vtyshCalls, fake.lastVtyshCmd)
+		}
+	}
+}
+
+// TestBGPNeighborAdvertisedRoutesRejectsUnvalidatedIP is the advertised-routes
+// twin of the received-routes belt test (#4588).
+func TestBGPNeighborAdvertisedRoutesRejectsUnvalidatedIP(t *testing.T) {
+	fake := &fakeExecutor{}
+	m := &Manager{exec: fake}
+	bad := "2001:db8::1\nconfigure terminal"
+	if _, err := m.GetBGPNeighborAdvertisedRoutes(bad); err == nil {
+		t.Errorf("GetBGPNeighborAdvertisedRoutes(%q): expected error, got nil", bad)
+	}
+	if fake.vtyshCalls != 0 {
+		t.Errorf("GetBGPNeighborAdvertisedRoutes(%q): Vtysh invoked (%d, cmd=%q)", bad, fake.vtyshCalls, fake.lastVtyshCmd)
+	}
+}
+
+// TestBGPNeighborDetailRejectsUnvalidatedIP verifies the detail wrapper
+// rejects a non-empty malformed ip but STILL allows the empty ip (which
+// selects every neighbor — a legitimate operation) (#4588).
+func TestBGPNeighborDetailRejectsUnvalidatedIP(t *testing.T) {
+	// Malformed non-empty ip -> error, no vtysh call.
+	fake := &fakeExecutor{}
+	m := &Manager{exec: fake}
+	bad := "1.1.1.1\nno router bgp 65000"
+	if _, err := m.GetBGPNeighborDetail(bad); err == nil {
+		t.Errorf("GetBGPNeighborDetail(%q): expected error, got nil", bad)
+	}
+	if fake.vtyshCalls != 0 {
+		t.Errorf("GetBGPNeighborDetail(%q): Vtysh invoked (%d, cmd=%q)", bad, fake.vtyshCalls, fake.lastVtyshCmd)
+	}
+
+	// Empty ip is legal: selects all neighbors, DOES call vtysh.
+	fakeAll := &fakeExecutor{
+		vtyshResp: map[string]string{"show bgp neighbor": "all neighbors output"},
+	}
+	mAll := &Manager{exec: fakeAll}
+	out, err := mAll.GetBGPNeighborDetail("")
+	if err != nil {
+		t.Fatalf("GetBGPNeighborDetail(\"\"): unexpected error: %v", err)
+	}
+	if out != "all neighbors output" {
+		t.Errorf("GetBGPNeighborDetail(\"\"): got %q, want all-neighbors output", out)
+	}
+	if fakeAll.lastVtyshCmd != "show bgp neighbor" {
+		t.Errorf("GetBGPNeighborDetail(\"\"): cmd = %q, want %q", fakeAll.lastVtyshCmd, "show bgp neighbor")
+	}
+}
+
+// TestBGPNeighborValidIPsPass proves a syntactically valid neighbor IP —
+// both IPv4 and IPv6 — passes the guard and builds the expected vtysh
+// command verbatim (#4588 must not regress the happy path).
+func TestBGPNeighborValidIPsPass(t *testing.T) {
+	cases := []struct {
+		name    string
+		call    func(m *Manager, ip string) (string, error)
+		ip      string
+		wantCmd string
+	}{
+		{"received-v4", (*Manager).GetBGPNeighborReceivedRoutes, "10.0.0.1", "show bgp neighbor 10.0.0.1 received-routes"},
+		{"received-v6", (*Manager).GetBGPNeighborReceivedRoutes, "2001:db8::1", "show bgp neighbor 2001:db8::1 received-routes"},
+		{"advertised-v4", (*Manager).GetBGPNeighborAdvertisedRoutes, "10.0.0.1", "show bgp neighbor 10.0.0.1 advertised-routes"},
+		{"advertised-v6", (*Manager).GetBGPNeighborAdvertisedRoutes, "2001:db8::1", "show bgp neighbor 2001:db8::1 advertised-routes"},
+		{"detail-v4", (*Manager).GetBGPNeighborDetail, "10.0.0.1", "show bgp neighbor 10.0.0.1"},
+		{"detail-v6", (*Manager).GetBGPNeighborDetail, "2001:db8::1", "show bgp neighbor 2001:db8::1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeExecutor{
+				vtyshResp: map[string]string{tc.wantCmd: "ok"},
+			}
+			m := &Manager{exec: fake}
+			out, err := tc.call(m, tc.ip)
+			if err != nil {
+				t.Fatalf("%s(%q): unexpected error: %v", tc.name, tc.ip, err)
+			}
+			if out != "ok" {
+				t.Errorf("%s(%q): got %q, want %q", tc.name, tc.ip, out, "ok")
+			}
+			if fake.vtyshCalls != 1 {
+				t.Errorf("%s(%q): Vtysh calls = %d, want 1", tc.name, tc.ip, fake.vtyshCalls)
+			}
+			if fake.lastVtyshCmd != tc.wantCmd {
+				t.Errorf("%s(%q): cmd = %q, want %q", tc.name, tc.ip, fake.lastVtyshCmd, tc.wantCmd)
+			}
+			if strings.Contains(fake.lastVtyshCmd, "\n") {
+				t.Errorf("%s(%q): built command contains a newline: %q", tc.name, tc.ip, fake.lastVtyshCmd)
+			}
+		})
+	}
+}

--- a/pkg/frr/vtysh.go
+++ b/pkg/frr/vtysh.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"os/exec"
 	"syscall"
 	"time"
@@ -189,26 +190,46 @@ func (m *Manager) GetOSPFRoutes() (string, error) {
 }
 
 // GetBGPNeighborReceivedRoutes returns received routes for a BGP neighbor.
+//
+// The neighbor IP is concatenated straight into the `vtysh -c` command,
+// so it MUST be a syntactically valid IP address. This is the belt that
+// keeps a raw, newline- or space-bearing token off the vtysh command
+// line: the show path is reachable over the UNAUTHENTICATED local gRPC
+// channel (GetBGPStatus, 127.0.0.1:50051) and, unlike the config path
+// (sanitizeFRRValue/validateNodesControlChars, #4097/#1798), never went
+// through a sanitizer. net.ParseIP rejects empty, spaces, and embedded
+// newlines while accepting both IPv4 and IPv6 neighbors (#4588).
 func (m *Manager) GetBGPNeighborReceivedRoutes(ip string) (string, error) {
-	if ip == "" {
-		return "", fmt.Errorf("neighbor IP required")
+	if net.ParseIP(ip) == nil {
+		return "", fmt.Errorf("invalid neighbor IP %q", ip)
 	}
 	return m.executor().Vtysh("show bgp neighbor " + ip + " received-routes")
 }
 
 // GetBGPNeighborAdvertisedRoutes returns advertised routes for a BGP neighbor.
+//
+// The neighbor IP is validated with net.ParseIP before it reaches the
+// vtysh command line — see GetBGPNeighborReceivedRoutes for the rationale
+// (unauthenticated local gRPC show path, no config-style sanitizer, #4588).
 func (m *Manager) GetBGPNeighborAdvertisedRoutes(ip string) (string, error) {
-	if ip == "" {
-		return "", fmt.Errorf("neighbor IP required")
+	if net.ParseIP(ip) == nil {
+		return "", fmt.Errorf("invalid neighbor IP %q", ip)
 	}
 	return m.executor().Vtysh("show bgp neighbor " + ip + " advertised-routes")
 }
 
 // GetBGPNeighborDetail returns detailed info for a specific BGP neighbor,
 // or all neighbors if ip is empty.
+//
+// An empty ip is legal (it selects every neighbor). A non-empty ip is
+// validated with net.ParseIP so no raw token reaches the vtysh command
+// line — see GetBGPNeighborReceivedRoutes for the rationale (#4588).
 func (m *Manager) GetBGPNeighborDetail(ip string) (string, error) {
 	cmd := "show bgp neighbor"
 	if ip != "" {
+		if net.ParseIP(ip) == nil {
+			return "", fmt.Errorf("invalid neighbor IP %q", ip)
+		}
 		cmd += " " + ip
 	}
 	return m.executor().Vtysh(cmd)

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -312,3 +312,16 @@ contract.
   fields — a bare cast wrapped negative for a large pool (~40k addresses
   over the default 64512-port window) and corrupted the
   `avail = total - used` display.
+- Request-supplied tokens that are interpolated into an operational
+  shell-out must be validated at the boundary (#4588). `GetBGPStatus`
+  (`server_routing.go`) parses a neighbor IP out of `req.Type`
+  (`received-routes:<ip>` / `advertised-routes:<ip>` / `neighbor:<ip>`) and
+  hands it to the `pkg/frr` `GetBGPNeighbor*` wrappers, which concatenate it
+  into a `vtysh -c "show bgp neighbor <ip> …"` command. Because the local
+  gRPC listener is UNAUTHENTICATED, the handler rejects a non-parseable IP
+  with `codes.InvalidArgument` (`net.ParseIP`) before it reaches vtysh — a
+  newline-bearing token would otherwise become a second raw FRR CLI command
+  (`vtysh -c` splits on newlines) with no commit-audit trail. `req.Type ==
+  "neighbor"` and `neighbor:` with an empty ip stay legal (they select every
+  neighbor). The `pkg/frr` wrappers re-validate as the load-bearing belt;
+  see `pkg/frr/README.md` "#4588".

--- a/pkg/grpcapi/server_bgp_status_ip_guard_4588_test.go
+++ b/pkg/grpcapi/server_bgp_status_ip_guard_4588_test.go
@@ -1,0 +1,62 @@
+package grpcapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/frr"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestGetBGPStatusRejectsUnvalidatedNeighborIP proves the #4588 boundary
+// guard: GetBGPStatus is reachable over the UNAUTHENTICATED local gRPC
+// listener, so a malformed / newline-bearing neighbor "IP" in the request
+// Type must be rejected with codes.InvalidArgument BEFORE it is handed to
+// the frr wrapper (which would otherwise concatenate it onto the vtysh
+// command line). A real frr.Manager is wired so the handler passes the
+// s.frr == nil gate; the ParseIP check fires first, so no vtysh shell-out
+// happens for the malformed inputs.
+//
+// On revert (drop the net.ParseIP boundary check), these calls fall
+// through to the frr wrappers and no longer return InvalidArgument.
+func TestGetBGPStatusRejectsUnvalidatedNeighborIP(t *testing.T) {
+	s := &Server{frr: frr.New()}
+
+	bad := []string{
+		"received-routes:1.1.1.1\nconfigure terminal",
+		"received-routes:not-an-ip",
+		"received-routes:", // empty
+		"advertised-routes:1.1.1.1\nno router bgp 65000",
+		"advertised-routes:garbage",
+		"neighbor:1.1.1.1\nconfigure terminal",
+		"neighbor:bogus",
+	}
+	for _, typ := range bad {
+		resp, err := s.GetBGPStatus(context.Background(), &pb.GetBGPStatusRequest{Type: typ})
+		if err == nil {
+			t.Errorf("GetBGPStatus(%q): expected InvalidArgument, got nil (resp=%v)", typ, resp)
+			continue
+		}
+		if st, _ := status.FromError(err); st.Code() != codes.InvalidArgument {
+			t.Errorf("GetBGPStatus(%q): code = %v, want InvalidArgument (err=%v)", typ, st.Code(), err)
+		}
+	}
+}
+
+// TestGetBGPStatusNeighborAllStillWorks proves the boundary guard does not
+// break the legitimate "all neighbors" selectors: req.Type == "neighbor"
+// and "neighbor:" (empty ip) must NOT be rejected as InvalidArgument
+// (they select every neighbor). They reach the frr wrapper, which shells
+// out to vtysh — in CI that returns codes.Internal (no vtysh binary), NOT
+// InvalidArgument. The distinction is what this test asserts (#4588).
+func TestGetBGPStatusNeighborAllStillWorks(t *testing.T) {
+	s := &Server{frr: frr.New()}
+	for _, typ := range []string{"neighbor", "neighbor:"} {
+		_, err := s.GetBGPStatus(context.Background(), &pb.GetBGPStatusRequest{Type: typ})
+		if st, _ := status.FromError(err); st.Code() == codes.InvalidArgument {
+			t.Errorf("GetBGPStatus(%q): must not be rejected as InvalidArgument (all-neighbors selector)", typ)
+		}
+	}
+}

--- a/pkg/grpcapi/server_routing.go
+++ b/pkg/grpcapi/server_routing.go
@@ -3,6 +3,7 @@ package grpcapi
 import (
 	"context"
 	"fmt"
+	"net"
 	"sort"
 	"strings"
 
@@ -139,9 +140,17 @@ func (s *Server) GetBGPStatus(_ context.Context, req *pb.GetBGPStatusRequest) (*
 			}
 		}
 	default:
-		// "received-routes:<ip>" for neighbor received routes
+		// "received-routes:<ip>" for neighbor received routes.
+		// Validate the IP at the trust boundary (this handler is reachable
+		// over the UNAUTHENTICATED local gRPC listener) so a malformed or
+		// newline-bearing token is rejected with InvalidArgument before it
+		// reaches the vtysh command line. The frr wrappers re-check as the
+		// load-bearing belt (#4588).
 		if strings.HasPrefix(req.Type, "received-routes:") {
 			ip := strings.TrimPrefix(req.Type, "received-routes:")
+			if net.ParseIP(ip) == nil {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid neighbor IP %q", ip)
+			}
 			output, err := s.frr.GetBGPNeighborReceivedRoutes(ip)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "%v", err)
@@ -151,17 +160,25 @@ func (s *Server) GetBGPStatus(_ context.Context, req *pb.GetBGPStatusRequest) (*
 		// "advertised-routes:<ip>" for neighbor advertised routes
 		if strings.HasPrefix(req.Type, "advertised-routes:") {
 			ip := strings.TrimPrefix(req.Type, "advertised-routes:")
+			if net.ParseIP(ip) == nil {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid neighbor IP %q", ip)
+			}
 			output, err := s.frr.GetBGPNeighborAdvertisedRoutes(ip)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "%v", err)
 			}
 			return &pb.GetBGPStatusResponse{Output: output}, nil
 		}
-		// "neighbor" or "neighbor:<ip>" for detailed neighbor info
+		// "neighbor" or "neighbor:<ip>" for detailed neighbor info.
+		// An empty ip selects every neighbor (legal); a non-empty ip must
+		// parse as an IP address before it reaches vtysh (#4588).
 		if req.Type == "neighbor" || strings.HasPrefix(req.Type, "neighbor:") {
 			ip := ""
 			if strings.HasPrefix(req.Type, "neighbor:") {
 				ip = strings.TrimPrefix(req.Type, "neighbor:")
+			}
+			if ip != "" && net.ParseIP(ip) == nil {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid neighbor IP %q", ip)
 			}
 			output, err := s.frr.GetBGPNeighborDetail(ip)
 			if err != nil {


### PR DESCRIPTION
## Summary

Closes #4588 (ps-037-A7 F-A7-004 + ps-038-A8-b2 F-001, LOW-MED defense-in-depth).

The `pkg/frr/vtysh.go` `GetBGPNeighborReceivedRoutes` / `GetBGPNeighborAdvertisedRoutes` / `GetBGPNeighborDetail` wrappers guarded only `ip == ""` then concatenated the neighbor IP straight into `vtysh -c "show bgp neighbor <ip> ..."`. The IP is operator-supplied via `GetBGPStatus` (`pkg/grpcapi/server_routing.go` — `received-routes:` / `advertised-routes:` / `neighbor:` selectors, no `net.ParseIP`) and `pkg/cli/cli_show_routing.go`.

The local gRPC listener (127.0.0.1:50051) is unauthenticated, and unlike the config-render path (`sanitizeFRRValue` / `validateNodesControlChars`, #4097/#1798) the operational SHOW path was never sanitized. `realExecutor.Vtysh` is `exec.CommandContext` (no OS shell, so shell metacharacters are already inert), but `vtysh -c` historically splits its argument on **newlines**, so `1.1.1.1\nconfigure terminal ...` would reach vtysh as a second raw FRR CLI command with no commit-audit trail. Bounded to LOW-MED (the same unauthenticated channel already exposes total config control) but a real belt gap versus the sanitized config path.

## Fix

- **Load-bearing belt** at each `pkg/frr/vtysh.go` wrapper, closest to the exec: `if net.ParseIP(ip) == nil { return error }`. received/advertised reject empty too; `GetBGPNeighborDetail` still allows an empty ip (selects every neighbor).
- **Defense-in-depth** at the trust boundary: `GetBGPStatus` re-validates each neighbor-IP arm and returns `codes.InvalidArgument` before delegating.
- `net.ParseIP` accepts both IPv4 and IPv6, so a valid neighbor is unchanged.

## Validation

- **RED-on-revert confirmed**: dropping both guards makes the frr belt test and the grpcapi boundary test FAIL (a bad IP builds/runs the vtysh command; a bad selector is no longer `InvalidArgument`); restoring turns them green.
- New frr tests assert Vtysh is **not** invoked for a newline/space/garbage/empty IP, that a valid v4 and v6 neighbor builds the exact command with no embedded newline, and that an empty ip still lists all neighbors.
- `go test ./pkg/frr/... ./pkg/grpcapi/...` green; `go build`, `gofmt -l`, `go vet` clean.
- Docs: `pkg/frr/README.md` + `pkg/grpcapi/README.md` gotchas + `_Log.md`.

GO-only change (pkg/frr + pkg/grpcapi); no cargo/dataplane touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi