### PR TITLE
grpcapi: zeroize erases rendered service-config secrets at wipe time (#4585)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-07-07 — #4585 zeroize erases rendered service-config secrets at wipe time (frr.conf routing-auth, swanctl PSK, kea)
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4585 (SECURITY, follow-up to #4576/#4582). #4582 erases the
+  config STATE (.configdb SSOT + master.key + text rollback + journal), but the
+  RENDERED service configs xpfd writes outside /etc/xpf survived the wipe until
+  the completing reboot's reconcile. VERIFY-FIRST finding (elevates MED→HIGH):
+  a post-zeroize boot has NO committed config, so the daemon enters #1922
+  bootstrap mode (applyConfig suppressed, daemon_run.go:689) or, on an HA node,
+  a normal boot with a nil active config (the boot apply is gated on
+  ActiveConfig() != nil, daemon_run.go:717) — EITHER way the boot SKIPS the
+  FRR/IPsec/Kea reconcile-to-empty. So the rendered secrets are a PERSISTENT
+  residual across the reboot, not transient; /etc/frr/frr.conf is mode 0644
+  world-readable and carries BGP-MD5/OSPF/IS-IS auth keys. Fix: performZeroizeWipe
+  now also calls zeroizeRenderedConfigs — strips the frr.conf xpf-managed section
+  (new standalone frr.StripManagedSectionFile, disk-only no reload; operator
+  content outside the markers preserved, unmanaged frr.conf untouched), removes
+  the /etc/swanctl/conf.d/xpf.conf PSK snippet, removes /etc/kea/kea-dhcp{4,6}.conf.
+  Mirrors #4582 discipline: os.ErrNotExist excluded, first real error folded into
+  the surfaced result (.configdb error takes priority) → codes.Internal, never a
+  false clean-reset. Refactored writeManagedSection's marker-strip into the pure
+  stripManagedSection (single SSOT for the #2908 anchoring + #1646 orphaned-begin
+  invariants). Exported dhcpserver.DefaultKea{4,6}ConfPath. RED-on-revert tests
+  TestZeroizeRenderedConfigsErasesSecrets (secret + managed section gone, operator
+  content preserved, snippet/kea absent) + TestZeroizeRenderedConfigsLeavesUnmanagedFRRUntouched.
+- **File(s)**: pkg/frr/manager.go, pkg/dhcpserver/dhcpserver.go,
+  pkg/grpcapi/server_diag.go, pkg/grpcapi/zeroize_rendered_4585_test.go,
+  docs/system-login.md, _Log.md
+
 ## 2026-07-07 — #4586 deploy: day-0 config ISO written owner-only (0600), no longer world-readable in CWD
 
 - **Timestamp**: 2026-07-07

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -170,13 +170,34 @@ the top-level `.conf` files (live config + `rescue.conf`), and `.config.journal`
 (+ rotated segments). A wipe that cannot fully erase this state returns an error
 rather than reporting a clean factory reset.
 
-The wipe erases that SSOT/rollback/journal state **directly**. The **rendered
-service configs** xpfd writes outside `/etc/xpf` — `/etc/frr/frr.conf` (0644,
-BGP-MD5 / OSPF / IS-IS auth secrets), `/etc/swanctl/conf.d/*` (IKE PSKs),
-`/etc/kea/kea-dhcp{4,6}.conf` — are **not** removed by the wipe itself; they are
-reset on the **completing reboot** when the daemon reconciles to the empty
-config. Erasing them in the wipe itself (closing the window between wipe and
-reboot) is tracked as follow-up **#4585**.
+**Rendered service-config erasure (#4585).** The wipe erases that
+SSOT/rollback/journal state directly, but the prior tenant's secrets are ALSO
+rendered into service configs xpfd writes **outside** `/etc/xpf`. `zeroize` now
+erases those at wipe time too (`zeroizeRenderedConfigs`, same key-first /
+error-surfacing discipline):
+
+- **`/etc/frr/frr.conf`** — mode **0644 world-readable**; the `! BEGIN/END BPFRX
+  MANAGED CONFIG` section carries BGP-MD5 / OSPF / IS-IS authentication keys.
+  Only that section is stripped (`frr.StripManagedSectionFile`, disk-only — no
+  FRR reload); operator content outside the markers is preserved and a purely
+  operator-managed `frr.conf` is left untouched.
+- **`/etc/swanctl/conf.d/xpf.conf`** — the IKE PSKs live in this single
+  xpf-owned snippet; it is removed outright.
+- **`/etc/kea/kea-dhcp{4,6}.conf`** — xpf owns these whole files; removed outright.
+
+This must be done by the wipe itself, not deferred to the reconcile on the
+completing reboot: a post-zeroize boot has **no committed config**, so the
+daemon enters **#1922 bootstrap mode** (or, on an HA node, a normal boot with a
+`nil` active config) and **SKIPS** the boot-time `applyConfig` that would
+otherwise reconcile FRR/IPsec/Kea to empty (bootstrap suppresses the apply, and
+the normal-boot apply is gated on `ActiveConfig() != nil`). Without the direct
+wipe the rendered secrets would be a **persistent** residual across the reboot —
+a re-tenanted device would keep the prior tenant's routing-auth keys in a
+world-readable file — not the transient one earlier notes assumed. FRR /
+strongSwan / Kea regenerate their configs from the now-empty xpf config on the
+next `commit`, and the daemon still boots cleanly (bootstrap does not touch
+those services). A failure to erase any of them surfaces as an error rather than
+a clean factory-reset report.
 
 **Privileged-subcommand exception — `monitor traffic` (#4067).** Almost
 every command is gated on the top-level word alone, but `monitor traffic`

--- a/pkg/dhcpserver/dhcpserver.go
+++ b/pkg/dhcpserver/dhcpserver.go
@@ -77,8 +77,14 @@ func unitIsActive(unit string) bool {
 }
 
 const (
-	kea4Config = "/etc/kea/kea-dhcp4.conf"
-	kea6Config = "/etc/kea/kea-dhcp6.conf"
+	// DefaultKea4ConfPath / DefaultKea6ConfPath are the Kea server config files
+	// xpf renders. Exported so a factory-reset zeroize can erase them directly
+	// (#4585) — xpf owns these whole files, so a wipe removes them outright.
+	DefaultKea4ConfPath = "/etc/kea/kea-dhcp4.conf"
+	DefaultKea6ConfPath = "/etc/kea/kea-dhcp6.conf"
+
+	kea4Config = DefaultKea4ConfPath
+	kea6Config = DefaultKea6ConfPath
 	kea4Svc    = "kea-dhcp4-server"
 	kea6Svc    = "kea-dhcp6-server"
 	// Kea memfile lease databases (per family). Shared by the display

--- a/pkg/frr/manager.go
+++ b/pkg/frr/manager.go
@@ -537,49 +537,9 @@ func (m *Manager) writeManagedSection(section string) error {
 		}
 	}
 
-	// Strip existing managed section.
-	//
-	// A correct file has a begin marker followed by an end marker. But a
-	// prior torn write (os.WriteFile is not atomic — a crash or disk-full
-	// mid-write can truncate after the begin marker) can leave an orphaned
-	// markerBegin with no markerEnd. If we only stripped on the both-found
-	// case, the orphan would survive: we would append a second managed block,
-	// leaving two begin markers. The next write's strings.Index(markerEnd)
-	// then matches the new block's end while content[:start] cuts from the
-	// orphaned begin — deleting everything between them, which may include
-	// unrelated FRR config the operator appended. So we treat a begin with no
-	// end as a corrupt tail and discard it to EOF.
-	//
-	// The end-marker search is anchored AFTER the begin marker (#2908). A
-	// stale end-marker positioned *before* the begin marker (an operator
-	// hand-edit, an interleaved partial copy, or external tooling) must not
-	// be matched: an unanchored strings.Index(content, markerEnd) would
-	// return end < start, and the strip content[:start] + content[end:] would
-	// then DUPLICATE the text between end and start while leaving the live
-	// begin marker in place — corrupting the file with two begin markers and
-	// breaking FRR reload. Anchoring the search keeps the end >= start
-	// invariant, so the slice can never duplicate. (This is distinct from the
-	// #1646 orphaned-begin case handled by the else branch below.)
-	content := string(existing)
-	if start := strings.Index(content, markerBegin); start >= 0 {
-		// Search for the end marker strictly after the begin marker, then map
-		// the relative index back to an absolute offset.
-		searchFrom := start + len(markerBegin)
-		if rel := strings.Index(content[searchFrom:], markerEnd); rel >= 0 {
-			end := searchFrom + rel + len(markerEnd)
-			// Also consume the trailing newline
-			if end < len(content) && content[end] == '\n' {
-				end++
-			}
-			content = content[:start] + content[end:]
-		} else {
-			// Orphaned begin marker (torn write): discard from the begin
-			// marker to EOF. Whatever followed an unterminated managed block
-			// is xpf-generated partial config that must not be preserved, and
-			// keeping the orphan begin would cause the next write to over-cut.
-			content = content[:start]
-		}
-	}
+	// Strip any existing managed section (see stripManagedSection for the
+	// torn-write / stale-marker invariants that logic protects).
+	content, _ := stripManagedSection(string(existing))
 
 	// Append new managed section
 	if section != "" {
@@ -595,6 +555,93 @@ func (m *Manager) writeManagedSection(section string) error {
 	// place). rename(2) within a filesystem is atomic.
 	if err := atomicWriteFile(m.frrConf, []byte(content), 0644); err != nil {
 		return fmt.Errorf("write frr.conf: %w", err)
+	}
+	return nil
+}
+
+// stripManagedSection removes the xpf-managed block (markerBegin..markerEnd)
+// from content, returning the stripped content and whether anything was
+// removed (changed=false means content had no managed section and is returned
+// verbatim). It is the pure core shared by writeManagedSection (which strips
+// before appending the new section) and StripManagedSectionFile.
+//
+// A correct file has a begin marker followed by an end marker. But a prior
+// torn write (the pre-#1894 os.WriteFile was not atomic — a crash or disk-full
+// mid-write can truncate after the begin marker) can leave an orphaned
+// markerBegin with no markerEnd. If we only stripped on the both-found case,
+// the orphan would survive: a caller appending a second managed block would
+// leave two begin markers, and the next write's strings.Index(markerEnd) would
+// match the new block's end while content[:start] cuts from the orphaned begin
+// — deleting everything between them, which may include unrelated FRR config
+// the operator appended. So a begin with no end is treated as a corrupt tail
+// and discarded to EOF.
+//
+// The end-marker search is anchored AFTER the begin marker (#2908). A stale
+// end-marker positioned *before* the begin marker (an operator hand-edit, an
+// interleaved partial copy, or external tooling) must not be matched: an
+// unanchored strings.Index(content, markerEnd) would return end < start, and
+// the strip content[:start] + content[end:] would then DUPLICATE the text
+// between end and start while leaving the live begin marker in place —
+// corrupting the file with two begin markers and breaking FRR reload.
+// Anchoring the search keeps the end >= start invariant, so the slice can
+// never duplicate. (This is distinct from the #1646 orphaned-begin case
+// handled by the else branch.)
+func stripManagedSection(content string) (string, bool) {
+	start := strings.Index(content, markerBegin)
+	if start < 0 {
+		return content, false
+	}
+	// Search for the end marker strictly after the begin marker, then map the
+	// relative index back to an absolute offset.
+	searchFrom := start + len(markerBegin)
+	if rel := strings.Index(content[searchFrom:], markerEnd); rel >= 0 {
+		end := searchFrom + rel + len(markerEnd)
+		// Also consume the trailing newline.
+		if end < len(content) && content[end] == '\n' {
+			end++
+		}
+		return content[:start] + content[end:], true
+	}
+	// Orphaned begin marker (torn write): discard from the begin marker to EOF.
+	// Whatever followed an unterminated managed block is xpf-generated partial
+	// config that must not be preserved, and keeping the orphan begin would
+	// cause the next write to over-cut.
+	return content[:start], true
+}
+
+// StripManagedSectionFile removes the xpf-managed section from the frr.conf at
+// path WITHOUT reloading FRR — the disk-only half of Clear(). It exists so a
+// factory-reset zeroize (#4585) can erase the routing-authentication secrets
+// (BGP MD5 / OSPF / IS-IS keys) that the managed section carries in a
+// world-readable (0644) /etc/frr/frr.conf, without a running FRR or a
+// constructed Manager. A post-zeroize boot enters #1922 bootstrap mode (or, on
+// an HA node, normal boot with a nil active config) and SKIPS the boot-time
+// applyConfig that would otherwise reconcile FRR to empty, so the managed
+// section — and its routing-auth secrets — would otherwise be a PERSISTENT
+// residual on the re-tenanted box, not a transient one.
+//
+// Scope: xpf-owned content only. The managed markers bound the xpf section;
+// operator content outside them is preserved (the same marker-anchored strip
+// writeManagedSection uses). A file with NO managed section is left
+// byte-for-byte untouched (changed=false ⇒ no rewrite), so a purely
+// operator-managed frr.conf is never modified. An absent file is not an error
+// (nothing to strip). The rewrite is atomic and preserves the existing file's
+// mode/symlink (atomicWriteFile), so a crash mid-strip cannot leave a
+// half-written frr.conf.
+func StripManagedSectionFile(path string) error {
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read frr.conf: %w", err)
+	}
+	stripped, changed := stripManagedSection(string(existing))
+	if !changed {
+		return nil
+	}
+	if err := atomicWriteFile(path, []byte(stripped), 0644); err != nil {
+		return fmt.Errorf("strip frr.conf managed section: %w", err)
 	}
 	return nil
 }

--- a/pkg/grpcapi/server_diag.go
+++ b/pkg/grpcapi/server_diag.go
@@ -22,8 +22,11 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	dpformat "github.com/psaab/xpf/pkg/dataplane/userspace/format"
+	"github.com/psaab/xpf/pkg/dhcpserver"
 	"github.com/psaab/xpf/pkg/diagcmd"
+	"github.com/psaab/xpf/pkg/frr"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"github.com/psaab/xpf/pkg/ipsec"
 	"github.com/psaab/xpf/pkg/monitoriface"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
@@ -770,13 +773,14 @@ const (
 // WireGuard private keys, and SNMP communities and would otherwise be reloaded
 // on the next boot.
 //
-// NOTE (scope, tracked as #4585): this erases the SSOT and rollback/journal
-// state DIRECTLY, but the RENDERED service configs xpfd writes outside
-// configDir — /etc/frr/frr.conf (0644, BGP-MD5/OSPF/ISIS auth), /etc/swanctl/
-// conf.d/* (IKE PSKs), /etc/kea/kea-dhcp{4,6}.conf — are NOT removed here. They
-// are reset on the COMPLETING reboot when the daemon reconciles to the empty
-// config; erasing them in the wipe itself (so the window between wipe and
-// reboot leaks nothing) is the #4585 follow-up.
+// NOTE (scope): this erases the SSOT and rollback/journal state under
+// configDir. The RENDERED service configs xpfd writes OUTSIDE configDir —
+// /etc/frr/frr.conf (0644, BGP-MD5/OSPF/ISIS auth), /etc/swanctl/conf.d/xpf.conf
+// (IKE PSKs), /etc/kea/kea-dhcp{4,6}.conf — are erased separately by
+// zeroizeRenderedConfigs (#4585). Both run under performZeroizeWipe. Erasing
+// the rendered configs in the wipe (rather than deferring to the reboot) is
+// required because a post-zeroize boot has no committed config and SKIPS the
+// reconcile that would otherwise clear them — see zeroizeRenderedConfigs.
 //
 // The artifacts removed (configBase is the config file's base name, e.g.
 // "xpf.conf", used to recognize the numbered text rollback slots):
@@ -856,16 +860,80 @@ func isTextRollbackFile(name, configBase string) bool {
 	return true
 }
 
-// performZeroizeWipe erases the on-disk config, BPF pins, and managed networkd
-// files (factory reset). It is a package var so a test can drive the `zeroize`
-// SystemAction verb (to assert the #4108 F8 journal wiring) WITHOUT wiping a
-// real /etc/xpf on the developer/appliance box. It returns a non-nil error when
-// the security-critical config erasure did not fully complete (#4576).
+// zeroizeRenderedConfigs erases the RENDERED service configs xpfd writes
+// OUTSIDE configDir — the artifacts that hold the prior tenant's secrets in
+// cleartext but are not part of the .configdb SSOT wiped by zeroizeConfigDir
+// (#4585, follow-up to #4576):
+//
+//   - frrConf (/etc/frr/frr.conf, mode 0644 WORLD-READABLE): the xpf-managed
+//     section carries BGP MD5 / OSPF / IS-IS authentication keys. Only that
+//     section is stripped (frr.StripManagedSectionFile) — operator content
+//     outside the markers is preserved and a purely operator-managed frr.conf
+//     is left untouched. No FRR reload: FRR restarts clean on the reboot.
+//   - swanctlSnippet (/etc/swanctl/conf.d/xpf.conf): the IKE PSKs live in this
+//     single xpf-owned snippet, so it is removed outright.
+//   - kea4/kea6 (/etc/kea/kea-dhcp{4,6}.conf): xpf owns these whole files, so
+//     they are removed outright.
+//
+// WHY the wipe must erase these DIRECTLY rather than lean on the completing
+// reboot: a post-zeroize boot has NO committed config, so the daemon enters
+// #1922 bootstrap mode (or, on an HA node, a normal boot with a nil active
+// config) and SKIPS the boot-time applyConfig that would otherwise reconcile
+// FRR/IPsec/Kea to empty (pkg/daemon/daemon_run.go: bootstrap suppresses the
+// apply, and the normal-boot apply is gated on ActiveConfig() != nil). The
+// rendered secrets are therefore a PERSISTENT residual across the reboot, not a
+// transient one — a device handed to the next tenant would keep the prior
+// tenant's routing-auth keys in a world-readable file. (See docs/system-login.md.)
+//
+// Discipline mirrors zeroizeConfigDir: os.ErrNotExist is not an error (an
+// already-absent artifact is the goal), removal is best-effort past a single
+// failure, but the FIRST real error is returned so a silently-incomplete wipe
+// is never reported as a clean factory reset.
+func zeroizeRenderedConfigs(frrConf, swanctlSnippet, kea4, kea6 string) error {
+	var firstErr error
+	fail := func(err error) {
+		if err != nil && !errors.Is(err, os.ErrNotExist) && firstErr == nil {
+			firstErr = err
+		}
+	}
+	// FRR: strip only the xpf-managed section (the routing-auth secrets); the
+	// file may carry operator content outside the markers. StripManagedSectionFile
+	// already treats an absent file as a no-op (nil) and leaves an unmanaged
+	// frr.conf untouched.
+	fail(frr.StripManagedSectionFile(frrConf))
+	// swanctl snippet + Kea configs: xpf owns these whole files, remove them.
+	fail(os.Remove(swanctlSnippet))
+	fail(os.Remove(kea4))
+	fail(os.Remove(kea6))
+	return firstErr
+}
+
+// performZeroizeWipe erases the on-disk config, rendered service-config
+// secrets, BPF pins, and managed networkd files (factory reset). It is a
+// package var so a test can drive the `zeroize` SystemAction verb (to assert
+// the #4108 F8 journal wiring) WITHOUT wiping a real /etc/xpf on the
+// developer/appliance box. It returns a non-nil error when a security-critical
+// erasure did not fully complete (#4576/#4585).
 var performZeroizeWipe = func() error {
 	// Config state FIRST — the security-critical erasure. A failure here can
 	// leave prior-tenant config/secrets on disk, so it is surfaced to the
 	// caller (#4576).
 	err := zeroizeConfigDir(defaultConfigDir, defaultConfigBase)
+
+	// Rendered service configs (#4585): also security-critical — routing-auth
+	// keys in a world-readable frr.conf, IKE PSKs, Kea configs. A post-zeroize
+	// boot enters bootstrap / nil-active-config normal boot and SKIPS the
+	// reconcile that would clear them, so the wipe must erase them itself. Fold
+	// its first error into the surfaced result (the .configdb error takes
+	// priority) so a partial wipe is never reported as a clean factory reset.
+	if e := zeroizeRenderedConfigs(
+		frr.DefaultFRRConf,
+		filepath.Join(ipsec.DefaultSwanctlDir, ipsec.BPFRXConfFile),
+		dhcpserver.DefaultKea4ConfPath,
+		dhcpserver.DefaultKea6ConfPath,
+	); e != nil && err == nil {
+		err = e
+	}
 
 	// BPF pins + managed networkd files carry no secret material, so their
 	// removal stays best-effort (logged, never fatal — they do not gate the

--- a/pkg/grpcapi/zeroize_rendered_4585_test.go
+++ b/pkg/grpcapi/zeroize_rendered_4585_test.go
@@ -1,0 +1,103 @@
+package grpcapi
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// renderedSecret4585 stands in for any prior-tenant secret rendered into a
+// service config outside /etc/xpf (BGP MD5 / OSPF / IS-IS routing-auth key, IKE
+// PSK, Kea credential). The test proves zeroizeRenderedConfigs erases every one
+// of them so a device yanked/re-tenanted after a factory reset does not hand the
+// next owner the prior tenant's secrets.
+const renderedSecret4585 = "MARKER-SECRET-4585-routing-auth"
+
+// TestZeroizeRenderedConfigsErasesSecrets pins #4585: the zeroize wipe must
+// erase the RENDERED service configs (not just the .configdb SSOT #4582 wipes)
+// because a post-zeroize boot enters bootstrap / nil-active-config normal boot
+// and SKIPS the reconcile that would otherwise clear them — so the secrets are a
+// PERSISTENT residual, not transient.
+//
+// RED on revert: before this fix zeroizeRenderedConfigs / StripManagedSectionFile
+// did not exist and performZeroizeWipe removed only .configdb state, so the
+// frr.conf managed section (routing-auth keys, mode 0644 world-readable), the
+// swanctl PSK snippet, and the Kea configs all SURVIVED the wipe. Each assertion
+// below fails on revert.
+func TestZeroizeRenderedConfigsErasesSecrets(t *testing.T) {
+	dir := t.TempDir()
+
+	// FRR: operator content OUTSIDE the markers + an xpf-managed section that
+	// carries a routing-auth secret INSIDE the markers.
+	frrConf := filepath.Join(dir, "frr.conf")
+	const operatorContent = "hostname r1\nrouter bgp 65000\n ! operator-managed, must survive\n"
+	frrBody := operatorContent +
+		"! BEGIN BPFRX MANAGED CONFIG - do not edit this section\n" +
+		"router ospf\n area 0 authentication message-digest\n" +
+		" ip ospf message-digest-key 1 md5 " + renderedSecret4585 + "\n" +
+		"! END BPFRX MANAGED CONFIG\n"
+	mustWriteFile(t, frrConf, []byte(frrBody))
+
+	// swanctl snippet (IKE PSK) + Kea configs — xpf owns these whole files.
+	swanctlSnippet := filepath.Join(dir, "swanctl", "xpf.conf")
+	kea4 := filepath.Join(dir, "kea", "kea-dhcp4.conf")
+	kea6 := filepath.Join(dir, "kea", "kea-dhcp6.conf")
+	mustWriteFile(t, swanctlSnippet, []byte("secrets {\n ike-peer { secret = "+renderedSecret4585+" }\n}\n"))
+	mustWriteFile(t, kea4, []byte(renderedSecret4585))
+	mustWriteFile(t, kea6, []byte(renderedSecret4585))
+
+	if err := zeroizeRenderedConfigs(frrConf, swanctlSnippet, kea4, kea6); err != nil {
+		t.Fatalf("zeroizeRenderedConfigs returned error: %v", err)
+	}
+
+	// FRR: the managed section AND its secret are stripped; operator content
+	// outside the markers is preserved.
+	got, err := os.ReadFile(frrConf)
+	if err != nil {
+		t.Fatalf("read frr.conf after strip: %v", err)
+	}
+	if strings.Contains(string(got), renderedSecret4585) {
+		t.Errorf("frr.conf still carries the routing-auth secret after zeroize:\n%s", got)
+	}
+	if strings.Contains(string(got), "BPFRX MANAGED CONFIG") {
+		t.Errorf("frr.conf still carries the xpf managed section after zeroize:\n%s", got)
+	}
+	if !strings.Contains(string(got), "router bgp 65000") {
+		t.Errorf("zeroize removed operator content outside the managed section:\n%s", got)
+	}
+
+	// swanctl snippet + Kea configs removed outright.
+	assertAbsent(t, swanctlSnippet)
+	assertAbsent(t, kea4)
+	assertAbsent(t, kea6)
+}
+
+// TestZeroizeRenderedConfigsLeavesUnmanagedFRRUntouched pins the ownership
+// scope: a purely operator-managed frr.conf (no xpf managed section) must be
+// left byte-for-byte untouched — the wipe erases xpf-owned secrets, never an
+// operator's hand-managed FRR content. Absent swanctl/Kea paths are a clean
+// no-op (os.ErrNotExist is excluded, mirroring zeroizeConfigDir).
+func TestZeroizeRenderedConfigsLeavesUnmanagedFRRUntouched(t *testing.T) {
+	dir := t.TempDir()
+	frrConf := filepath.Join(dir, "frr.conf")
+	const operatorOnly = "hostname r1\nrouter bgp 65000\n neighbor 10.0.0.1 password operatorsecret\n"
+	mustWriteFile(t, frrConf, []byte(operatorOnly))
+
+	if err := zeroizeRenderedConfigs(
+		frrConf,
+		filepath.Join(dir, "absent-swanctl.conf"),
+		filepath.Join(dir, "absent-kea4.conf"),
+		filepath.Join(dir, "absent-kea6.conf"),
+	); err != nil {
+		t.Fatalf("zeroizeRenderedConfigs with absent snippets returned error: %v", err)
+	}
+
+	got, err := os.ReadFile(frrConf)
+	if err != nil {
+		t.Fatalf("read frr.conf: %v", err)
+	}
+	if string(got) != operatorOnly {
+		t.Errorf("zeroize modified an operator-managed frr.conf with no xpf section:\ngot:  %q\nwant: %q", got, operatorOnly)
+	}
+}


### PR DESCRIPTION
Closes #4585. Follow-up to #4576/#4582.

## Problem
`#4582` erases the config STATE under `/etc/xpf` (`.configdb` SSOT + `master.key` + text rollback slots + audit journal), but the prior tenant's secrets are ALSO rendered into service configs xpfd writes OUTSIDE `/etc/xpf`, and those survived the wipe:

- **`/etc/frr/frr.conf`** (mode **0644, world-readable**): the xpf-managed section carries BGP-MD5 / OSPF / IS-IS authentication keys.
- **`/etc/swanctl/conf.d/xpf.conf`**: the IKE PSKs.
- **`/etc/kea/kea-dhcp{4,6}.conf`**.

## VERIFY-FIRST finding (MED → HIGH)
The issue asked whether a post-zeroize bootstrap boot actually reconciles FRR/IPsec/Kea to empty. **It does not.** A post-zeroize boot has no committed config, so the daemon:
- enters **#1922 bootstrap mode** — boot-time `applyConfig` is suppressed (`pkg/daemon/daemon_run.go:689-690`); or
- on an HA node (`/etc/xpf/node-id` present), takes a normal boot but with a **nil** active config, and the boot apply is gated on `ActiveConfig() != nil` (`daemon_run.go:717`).

Either path **SKIPS** the FRR/IPsec/Kea reconcile-to-empty. `clearFRRForFailClosedBoot` is gated on `configCompileFailed` (false here), so it does not fire either. The rendered secrets are therefore a **persistent residual across the reboot**, not transient — a re-tenanted device keeps the prior tenant's routing-auth keys in a world-readable file. This is HIGH.

## Fix
`performZeroizeWipe` now also calls `zeroizeRenderedConfigs`:
- **FRR**: strips ONLY the xpf-managed section (new standalone `frr.StripManagedSectionFile` — disk-only, no FRR reload). Operator content outside the markers is preserved and a purely operator-managed `frr.conf` is left untouched. The marker-strip logic is refactored out of `writeManagedSection` into the pure `stripManagedSection`, keeping the #2908 end-anchoring / #1646 orphaned-begin invariants a single source of truth.
- **swanctl snippet + Kea configs**: xpf owns these whole files, removed outright. Kea paths exported as `dhcpserver.DefaultKea{4,6}ConfPath`.

Discipline mirrors #4582: `os.ErrNotExist` is not an error, removal is best-effort past a single failure, and the first real error is folded into the surfaced result (the `.configdb` error keeps priority) so a partial wipe returns `codes.Internal` instead of a false clean-reset. The daemon still boots post-zeroize — FRR / strongSwan / Kea regenerate from the now-empty config on the next commit, and bootstrap mode does not touch those services.

## Validation
- `go build ./...`, `go test ./pkg/frr/ ./pkg/dhcpserver/ ./pkg/grpcapi/` green; `gofmt` + `go vet` clean.
- RED-on-revert: `TestZeroizeRenderedConfigsErasesSecrets` (secret + managed section gone, operator content preserved, snippet/Kea absent) and `TestZeroizeRenderedConfigsLeavesUnmanagedFRRUntouched` (unmanaged frr.conf byte-identical; absent snippet/Kea a clean no-op).
- Docs: `docs/system-login.md` updated (rendered configs now erased at wipe time + the reconcile-verification finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi