### PR TITLE
CLI/gRPC/config LOW hardening batch (#4589): BGP ASN, monitor count, test-routing, Rollback, scp argv, DDNS host

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,20 @@
+## 2026-07-07 — #4589 A10-01 cli: bound `monitor traffic count` (negative / unbounded)
+
+- **Timestamp**: 2026-07-07
+- **Action**: `parseMonitorTrafficArgs` (`pkg/cli/cli_request.go`) only
+  rejected a non-numeric `count`; `strconv.Atoi("-1")` and a huge value
+  both parsed clean, so `count -1` reached tcpdump's `-c` as an opaque
+  "invalid packet count" error and an unbounded value was silently
+  accepted (redundant with the already-supported `count 0` = unlimited).
+  Bounded the value to `n < 0 || n > 8192` after Atoi, matching the
+  sibling `monitor security packet-drop` cap (1..8192, monitor.go), while
+  keeping 0 as the explicit unlimited mode (buildMonitorTrafficArgv omits
+  `-c`). UX/consistency only — RBAC-gated (PermControl), no injection (the
+  `--` filter fence is intact). RED-on-revert test
+  `TestParseMonitorTrafficCountBounded`/`...InRangeAccepted`.
+- **File(s)**: pkg/cli/cli_request.go,
+  pkg/cli/monitor_traffic_count_bound_4589_test.go, _Log.md
+
 ## 2026-07-07 — #4589 A3 F-01 config: range-validate BGP peer-as / top-level local-as (uint32 wrap)
 
 - **Timestamp**: 2026-07-07

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,20 @@
+## 2026-07-07 — #4589 A3 F-01 config: range-validate BGP peer-as / top-level local-as (uint32 wrap)
+
+- **Timestamp**: 2026-07-07
+- **Action**: BGP `peer-as` (group + neighbor) and top-level `local-as`
+  carried no upper-bound schema validator, so an out-of-range ASN passed
+  the strict commit schema and the compiler's `Atoi -> uint32(v)` cast
+  silently wrapped it (`peer-as 4294967297` -> `remote-as 1`; `peer-as -1`
+  -> `remote-as 4294967295`) — a wrong-but-valid FRR config Junos rejects.
+  The `PeerAS==0` strict gate (#2963) only catches AS0, not a non-zero
+  wrap. Added `valueType: ValueInteger, validator: ValidateInteger(1,
+  4294967295)` to the two `peer-as` leaves and top-level `local-as` in
+  `schema_routing.go`, mirroring the sibling `local-as` group/neighbor
+  leaves that already had it. RED-on-revert test
+  `TestBGPPeerASRangeRejected`/`...Accepted`.
+- **File(s)**: pkg/config/schema_routing.go,
+  pkg/config/bgp_peeras_range_4589_test.go, _Log.md
+
 ## 2026-07-07 — #4588 frr: validate a BGP-neighbor SHOW command's IP before it reaches vtysh (unauthenticated local gRPC show path)
 
 - **Timestamp**: 2026-07-07

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,23 @@
+## 2026-07-07 — #4589 A10-b2 F-01 ddns+config: reject empty-host DDNS generic url-template
+
+- **Timestamp**: 2026-07-07
+- **Action**: The generic-backend url-template validators
+  (`validateGenericURLTemplate` in `pkg/ddns/backend_generic.go` and its
+  commit-time mirror `ddnsGenericURLTemplateValid` in
+  `pkg/config/compiler_validate_warn.go`) only rejected an EMPTY authority,
+  so `http://:8080/upd` — non-empty authority (":8080") but EMPTY host —
+  passed both the commit warning and the runtime constructor (Go's dialer
+  then treats the empty-host URL as localhost). Require a non-empty host
+  after dropping a trailing `:port` and unwrapping a bracketed IPv6 literal,
+  in lockstep across both packages (config cannot import pkg/ddns). Residual
+  of the #2841 empty-authority-only check. RED-on-revert tests
+  `TestGenericURLTemplatePortOnlyHostRejected` (ddns) +
+  `TestP3GenericURLTemplatePortOnlyHostWarns` (config).
+- **File(s)**: pkg/ddns/backend_generic.go,
+  pkg/config/compiler_validate_warn.go,
+  pkg/ddns/backend_generic_porthost_4589_test.go,
+  pkg/config/ddns_porthost_4589_test.go, _Log.md
+
 ## 2026-07-07 — #4589 A7 F-02 daemon+config: harden scp archive-site argv (leading-dash injection)
 
 - **Timestamp**: 2026-07-07

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,19 @@
+## 2026-07-07 — #4589 A8-01 grpcapi+api: guard Rollback against a negative n
+
+- **Timestamp**: 2026-07-07
+- **Action**: The `Rollback` mutation RPC (`pkg/grpcapi/server_config.go`)
+  and its REST leg `configRollbackHandler` (`pkg/api/config.go`) had no
+  `n<0` guard, so a negative n flowed into `store.Rollback(n)` →
+  `history.Get(n-1)` → `history.Get(<0)` → the opaque "history position -1
+  out of range" store error. Fail-closed (no wrong rollback target) but a
+  poor message. Added a `req.N < 0` reject with a clear InvalidArgument /
+  400 message on both surfaces. Unlike ShowRollback (#4556, n<=0) the
+  mutation keeps n==0 valid (Junos `rollback 0` = revert to active), so
+  only n<0 is rejected. RED-on-revert test `TestRollbackRejectsNegativeN`
+  (asserts the clean message + no "out of range" leak) / `...AcceptsZeroN`.
+- **File(s)**: pkg/grpcapi/server_config.go, pkg/api/config.go,
+  pkg/grpcapi/server_rollback_negative_n_4589_test.go, _Log.md
+
 ## 2026-07-07 — #4589 A8-b2 F-002 grpcapi: report unknown/malformed test-routing selectors
 
 - **Timestamp**: 2026-07-07

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,23 @@
+## 2026-07-07 — #4589 A7 F-02 daemon+config: harden scp archive-site argv (leading-dash injection)
+
+- **Timestamp**: 2026-07-07
+- **Action**: `scpArchiveTransfer` (`pkg/daemon/daemon_flow.go`) ran
+  `scp -o ... <srcPath> <dest>` with no `--` separator, and `dest` is an
+  operator-configured `archive-sites` URL taken verbatim
+  (`compiler_system.go`). A leading-dash URL (`-oProxyCommand=...`) is
+  parsed by scp's getopt as an OPTION → arbitrary command exec as the
+  xpfd root user (CWE-88). Two belts: (1) inserted `--` before src/dest so
+  getopt stops scanning; (2) added a commit-time reject of a leading-dash
+  archive-site in BOTH parse shapes (flat-set + hierarchical) in
+  `compileSystem`, since such a URL is never a valid scp destination.
+  Config-commit is already root-equivalent in xpf's coarse login-class
+  model, so this is defense-in-depth hardening, not a privilege
+  escalation. RED-on-revert tests
+  `TestArchivalLeadingDashSiteRejected{FlatSet,Hierarchical}` /
+  `TestArchivalValidSiteAccepted`.
+- **File(s)**: pkg/daemon/daemon_flow.go, pkg/config/compiler_system.go,
+  pkg/config/archival_leading_dash_4589_test.go, _Log.md
+
 ## 2026-07-07 — #4589 A8-01 grpcapi+api: guard Rollback against a negative n
 
 - **Timestamp**: 2026-07-07

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,23 @@
+## 2026-07-07 — #4589 A8-b2 F-002 grpcapi: report unknown/malformed test-routing selectors
+
+- **Timestamp**: 2026-07-07
+- **Action**: `showTestRouting` (`pkg/grpcapi/server_show_routes_text.go`)
+  used `if len(parts) != 2 { continue }` + a switch with no default arm,
+  SILENTLY dropping a malformed segment or an unknown selector key. A
+  typo'd `test-routing:dest=...,instnace=dmz` left `instance` at "" so the
+  lookup fell back to the MAIN routing table for what the operator asked
+  as a VRF query — a misleading diagnostic with no warning (parity gap vs
+  the #3696 showTestPolicy hardening). Mirrored the #3696 pattern: track a
+  `parseErr` on a malformed segment (no key=value / empty key or value)
+  and on an unknown key (default arm), and report it before the lookup.
+  Reported before the routing-nil check (a selector grammar error is a
+  client-input error independent of routing-manager availability), which
+  also keeps it testable with the default nil-manager Server. Golden
+  (`test-routing:dest=10.0.2.1`) unaffected. RED-on-revert test
+  `TestShowTestRoutingReportsUnknownSelector`/`...ValidSelectorNotFlagged`.
+- **File(s)**: pkg/grpcapi/server_show_routes_text.go,
+  pkg/grpcapi/server_show_test_routing_unknownkey_4589_test.go, _Log.md
+
 ## 2026-07-07 — #4589 A10-01 cli: bound `monitor traffic count` (negative / unbounded)
 
 - **Timestamp**: 2026-07-07

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -158,6 +158,14 @@ func (s *Server) configRollbackHandler(w http.ResponseWriter, r *http.Request) {
 	if !decodeJSONBody(w, r, &req) {
 		return
 	}
+	// #4589 A8-01: mirror the gRPC Rollback guard. n==0 = revert to active
+	// (valid); a negative n reaches history.Get(<0) and surfaces the opaque
+	// "history position -1 out of range" store error. Reject up front.
+	if req.N < 0 {
+		writeError(w, http.StatusBadRequest,
+			fmt.Sprintf("invalid n %d: rollback index must be non-negative (0 = revert to active)", req.N))
+		return
+	}
 	if err := s.store.Rollback(req.N); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -554,8 +554,19 @@ func parseMonitorTrafficArgs(args []string) (iface, filter, count string, err er
 			}
 			i++
 			count = args[i]
-			if _, cerr := strconv.Atoi(count); cerr != nil {
+			n, cerr := strconv.Atoi(count)
+			if cerr != nil {
 				return "", "", "", fmt.Errorf("monitor traffic: 'count' requires a numeric value, got %q", count)
+			}
+			// Bound the count like the sibling `monitor security packet-drop`
+			// (1..8192, monitor.go). 0 stays the explicit "unlimited" mode
+			// (buildMonitorTrafficArgv omits `-c` when count=="0"); a negative
+			// previously reached tcpdump's `-c` as an opaque "invalid packet
+			// count" error, and an unbounded huge value is redundant with the
+			// already-supported 0=unlimited mode. Reject both CLI-side so the
+			// numeric leaf matches the project's sibling-command bounding.
+			if n < 0 || n > 8192 {
+				return "", "", "", fmt.Errorf("monitor traffic: 'count' must be 0 (unlimited) or 1..8192, got %q", count)
 			}
 		}
 	}

--- a/pkg/cli/monitor_traffic_count_bound_4589_test.go
+++ b/pkg/cli/monitor_traffic_count_bound_4589_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import "testing"
+
+// #4589 A10-01: `monitor traffic count` only rejected a non-numeric value;
+// a negative (`count -1`) reached tcpdump's `-c` as an opaque "invalid
+// packet count" error, and an unbounded huge value was silently accepted
+// even though it is redundant with the already-supported 0=unlimited mode.
+// The sibling `monitor security packet-drop` bounds its count to 1..8192
+// (monitor.go); this pins the same bound on `monitor traffic count`,
+// keeping 0 as the explicit unlimited mode.
+//
+// RED-on-revert: without the `n < 0 || n > 8192` guard the negative and
+// over-cap cases return a numeric count with nil err.
+func TestParseMonitorTrafficCountBounded(t *testing.T) {
+	cases := [][]string{
+		{"interface", "ge-0-0-0", "count", "-1"},    // negative
+		{"interface", "ge-0-0-0", "count", "99999"}, // over the 8192 cap
+	}
+	for _, args := range cases {
+		_, _, count, err := parseMonitorTrafficArgs(args)
+		if err == nil {
+			t.Errorf("parseMonitorTrafficArgs(%v) = count %q, nil err; want an error (out-of-range count must be rejected)", args, count)
+		}
+	}
+}
+
+// 0 (unlimited) and an in-range positive count still parse, so the bound
+// does not regress legitimate captures.
+func TestParseMonitorTrafficCountInRangeAccepted(t *testing.T) {
+	tests := []struct {
+		args []string
+		want string
+	}{
+		{[]string{"interface", "ge-0-0-0", "count", "0"}, "0"},       // explicit unlimited
+		{[]string{"interface", "ge-0-0-0", "count", "100"}, "100"},   // in range
+		{[]string{"interface", "ge-0-0-0", "count", "8192"}, "8192"}, // boundary
+	}
+	for _, tc := range tests {
+		_, _, count, err := parseMonitorTrafficArgs(tc.args)
+		if err != nil {
+			t.Errorf("parseMonitorTrafficArgs(%v) unexpected err: %v", tc.args, err)
+			continue
+		}
+		if count != tc.want {
+			t.Errorf("parseMonitorTrafficArgs(%v) count=%q, want %q", tc.args, count, tc.want)
+		}
+	}
+}

--- a/pkg/config/archival_leading_dash_4589_test.go
+++ b/pkg/config/archival_leading_dash_4589_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4589 A7 F-02: an `archive-sites` URL is passed verbatim to
+// `scp <src> <dest>` at transfer-on-commit time. A leading-dash value
+// (`-oProxyCommand=...`) is never a valid scp destination and, before the
+// `--` end-of-options separator was added to the scp argv, was parsed by
+// scp's getopt as an OPTION — CWE-88 argv injection running as the xpfd
+// root user. Reject a leading-dash archive-site at commit in BOTH parse
+// shapes (flat-set and hierarchical).
+//
+// RED-on-revert: without the compiler guard the leading-dash site compiles
+// clean (CompileConfig returns nil).
+func TestArchivalLeadingDashSiteRejectedFlatSet(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		`set system archival configuration transfer-on-commit`,
+		`set system archival configuration archive-sites "-oProxyCommand=x"`,
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a leading-dash archive-site; expected rejection")
+	}
+	if !strings.Contains(err.Error(), "must not begin with '-'") {
+		t.Errorf("error %q missing the leading-dash reason", err.Error())
+	}
+}
+
+func TestArchivalLeadingDashSiteRejectedHierarchical(t *testing.T) {
+	input := `
+system {
+    archival {
+        configuration {
+            transfer-on-commit;
+            archive-sites {
+                "-oProxyCommand=x";
+            }
+        }
+    }
+}
+`
+	p := NewParser(input)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("CompileConfig accepted a leading-dash archive-site (hierarchical); expected rejection")
+	}
+}
+
+// A normal scp URL is still accepted — the guard does not false-positive on
+// legitimate archive sites.
+func TestArchivalValidSiteAccepted(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		`set system archival configuration transfer-on-commit`,
+		`set system archival configuration archive-sites "scp://backup@10.0.0.1:/configs"`,
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig rejected a valid archive-site: %v", err)
+	}
+	if cfg.System.Archival == nil || len(cfg.System.Archival.ArchiveSites) != 1 {
+		t.Fatalf("valid archive-site not compiled: %+v", cfg.System.Archival)
+	}
+}

--- a/pkg/config/bgp_peeras_range_4589_test.go
+++ b/pkg/config/bgp_peeras_range_4589_test.go
@@ -1,0 +1,51 @@
+package config
+
+import "testing"
+
+// #4589 A3 F-01: BGP peer-as / top-level local-as carried no upper-bound
+// validator, so an out-of-range ASN slipped through the strict commit schema
+// and the compiler's `Atoi -> uint32(v)` cast SILENTLY WRAPPED it to a
+// different-but-valid ASN (peer-as 4294967297 -> remote-as 1) or, for a
+// negative, to 4294967295 — a wrong-but-valid FRR config Junos would reject.
+// The sibling `local-as` (group + neighbor) leaves already carried
+// ValidateInteger(1, 4294967295); this pins the same validator onto the two
+// peer-as leaves and top-level local-as.
+//
+// RED-on-revert: drop the validators from schema_routing.go and the
+// out-of-range cases below commit clean (SchemaValidate returns nil).
+func TestBGPPeerASRangeRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		set  string
+	}{
+		{"group peer-as wrap", "set protocols bgp group EXT peer-as 4294967296"},
+		{"neighbor peer-as wrap", "set protocols bgp group EXT neighbor 10.0.2.1 peer-as 4294967297"},
+		{"top-level local-as wrap", "set protocols bgp local-as 4294967296"},
+		{"group peer-as negative", "set protocols bgp group EXT peer-as -1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildTreeFromSet(t, []string{tc.set})
+			if err := SchemaValidate(tree, nil); err == nil {
+				t.Fatalf("SchemaValidate accepted out-of-range ASN %q; expected rejection", tc.set)
+			}
+		})
+	}
+}
+
+// A valid 2-byte ASN and the 4-byte boundary ASN are accepted on every
+// peer-as / local-as leaf.
+func TestBGPPeerASRangeAccepted(t *testing.T) {
+	cases := []string{
+		"set protocols bgp group EXT peer-as 65000",
+		"set protocols bgp group EXT neighbor 10.0.2.1 peer-as 65000",
+		"set protocols bgp local-as 65000",
+		"set protocols bgp group EXT peer-as 4294967295",
+	}
+	for _, set := range cases {
+		tree := buildTreeFromSet(t, []string{set})
+		if err := SchemaValidate(tree, nil); err != nil {
+			t.Fatalf("SchemaValidate rejected valid ASN %q: %v", set, err)
+		}
+	}
+}

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -199,6 +199,13 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 					// "$9$..."]).
 					if len(asNode.Keys) >= 2 {
 						url := asNode.Keys[1]
+						// #4589 A7 F-02: reject a leading-dash archive-site at
+						// commit. Runtime archival shells out to `scp <src> <dest>`;
+						// a `-`-prefixed URL is never a valid scp destination and,
+						// pre-`--`-separator, was parsed as an scp option (CWE-88).
+						if strings.HasPrefix(url, "-") {
+							return fmt.Errorf("system archival archive-sites %q: an archive-site URL must not begin with '-' (it is passed to scp as a destination, not an option)", url)
+						}
 						sys.Archival.ArchiveSites = append(sys.Archival.ArchiveSites, url)
 						for i := 2; i+1 < len(asNode.Keys); i++ {
 							if asNode.Keys[i] == "password" {
@@ -223,6 +230,11 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 					for _, site := range asNode.Children {
 						if len(site.Keys) >= 1 {
 							url := site.Keys[0]
+							// #4589 A7 F-02: reject a leading-dash archive-site at
+							// commit (hierarchical form). See the flat-set twin above.
+							if strings.HasPrefix(url, "-") {
+								return fmt.Errorf("system archival archive-sites %q: an archive-site URL must not begin with '-' (it is passed to scp as a destination, not an option)", url)
+							}
 							sys.Archival.ArchiveSites = append(sys.Archival.ArchiveSites, url)
 							if site.FindChild("password") != nil {
 								sys.Archival.ArchiveSitesWithPassword = append(

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -2290,7 +2290,22 @@ func ddnsGenericURLTemplateValid(tmpl string) bool {
 	if at := strings.LastIndex(authority, "@"); at >= 0 {
 		authority = authority[at+1:]
 	}
-	return authority != ""
+	// #4589 A10-b2 F-01: require a non-empty HOST after dropping a trailing
+	// :port (and unwrapping a bracketed IPv6 literal). `http://:8080/upd` has
+	// a non-empty authority but an EMPTY host — the old `authority != ""`
+	// check let it warn-clean AND construct-clean. Kept byte-for-byte in
+	// lockstep with pkg/ddns.ddnsTemplateHost (config cannot import pkg/ddns).
+	host := authority
+	if strings.HasPrefix(host, "[") {
+		if end := strings.Index(host, "]"); end >= 0 {
+			host = host[1:end]
+		} else {
+			host = ""
+		}
+	} else if colon := strings.IndexByte(host, ':'); colon >= 0 {
+		host = host[:colon]
+	}
+	return host != ""
 }
 
 // ddnsAllowlistMalformedTokens mirrors pkg/ddns.ParseAllowlistChecked's

--- a/pkg/config/ddns_porthost_4589_test.go
+++ b/pkg/config/ddns_porthost_4589_test.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4589 A10-b2 F-01: ddnsGenericURLTemplateValid (the #2841 commit-time
+// mirror of pkg/ddns.validateGenericURLTemplate) only checked
+// `authority != ""`, so `http://:8080/upd` — non-empty authority, EMPTY
+// host — warned-clean AND constructed-clean, deferring the failure to the
+// first publish. Require a non-empty host after dropping the :port (and
+// unwrapping a bracketed IPv6 literal). Kept in lockstep with
+// pkg/ddns.ddnsTemplateHost.
+//
+// RED-on-revert: without the host extraction the port-only provider does
+// not warn.
+func TestP3GenericURLTemplatePortOnlyHostWarns(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set system services dynamic-dns provider port-only backend generic",
+		`set system services dynamic-dns provider port-only url-template "http://:8080/upd?ip=%i"`,
+		// A bracketed IPv6 literal host is VALID and must not warn.
+		"set system services dynamic-dns provider v6 backend generic",
+		`set system services dynamic-dns provider v6 url-template "http://[2001:db8::1]:8080/upd?ip=%i"`,
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	joined := strings.Join(validateSurfaceADDNSWarnings(cfg), "\n")
+	if !strings.Contains(joined, `provider "port-only" url-template`) {
+		t.Fatalf("expected a url-template warning for the port-only host; got:\n%s", joined)
+	}
+	if strings.Contains(joined, `provider "v6" url-template`) {
+		t.Fatalf("a bracketed IPv6 host must not warn; got:\n%s", joined)
+	}
+}

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -315,7 +315,7 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 		}},
 	}},
 	"bgp": {desc: "BGP configuration", children: map[string]*schemaNode{
-		"local-as":         {desc: "Local AS number", args: 1, placeholder: "<as-number>", children: nil},
+		"local-as":         {desc: "Local AS number", args: 1, valueType: ValueInteger, placeholder: "<as-number>", validator: ValidateInteger(1, 4294967295), children: nil},
 		"router-id":        {desc: "Router ID", args: 1, placeholder: "<address>", children: nil},
 		"cluster-id":       {desc: "Cluster ID", args: 1, placeholder: "<id>", children: nil},
 		"graceful-restart": {desc: "Graceful restart", children: nil},
@@ -333,7 +333,7 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 		"export": {desc: "Export policy", args: 1, multi: true, placeholder: "<policy-name>", children: nil},
 		"import": {desc: "Import policy", args: 1, multi: true, placeholder: "<policy-name>", children: nil},
 		"group": {desc: "BGP group", args: 1, placeholder: "<group-name>", children: map[string]*schemaNode{
-			"peer-as":            {desc: "Peer AS number", args: 1, placeholder: "<as-number>", children: nil},
+			"peer-as":            {desc: "Peer AS number", args: 1, valueType: ValueInteger, placeholder: "<as-number>", validator: ValidateInteger(1, 4294967295), children: nil},
 			"local-as":           {desc: "Local AS number for this peering", args: 1, valueType: ValueInteger, placeholder: "<as-number>", validator: ValidateInteger(1, 4294967295), children: nil},
 			"local-address":      {desc: "Local address (BGP update-source)", args: 1, placeholder: "<address>", children: nil},
 			"hold-time":          {desc: "Hold time (seconds)", args: 1, valueType: ValueInteger, placeholder: "<seconds>", validator: ValidateBGPHoldTime, children: nil},
@@ -368,7 +368,7 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 			}},
 			"neighbor": {desc: "BGP neighbor", args: 1, placeholder: "<address>", children: map[string]*schemaNode{
 				"description":            {desc: "Description", args: 1, scalar: true, placeholder: "<text>", children: nil},
-				"peer-as":                {desc: "Peer AS number", args: 1, placeholder: "<as-number>", children: nil},
+				"peer-as":                {desc: "Peer AS number", args: 1, valueType: ValueInteger, placeholder: "<as-number>", validator: ValidateInteger(1, 4294967295), children: nil},
 				"local-as":               {desc: "Local AS number for this peering", args: 1, valueType: ValueInteger, placeholder: "<as-number>", validator: ValidateInteger(1, 4294967295), children: nil},
 				"local-address":          {desc: "Local address (BGP update-source)", args: 1, placeholder: "<address>", children: nil},
 				"hold-time":              {desc: "Hold time (seconds)", args: 1, valueType: ValueInteger, placeholder: "<seconds>", validator: ValidateBGPHoldTime, children: nil},

--- a/pkg/daemon/daemon_flow.go
+++ b/pkg/daemon/daemon_flow.go
@@ -364,9 +364,18 @@ func (d *Daemon) archiveToSites(sites []string) {
 // capturing transfer and assert archiveConfig serializes the CURRENT active
 // config rather than the stale boot file (#3867).
 func scpArchiveTransfer(ctx context.Context, srcPath, dest string) error {
+	// #4589 A7 F-02: `--` end-of-options separator before the positional
+	// src/dest. `dest` is an operator-configured `archive-sites` URL taken
+	// verbatim (compiler_system.go); without the separator a leading-dash
+	// value (`-oProxyCommand=...`) is parsed by scp's getopt as an OPTION,
+	// not a destination — CWE-88 argv injection running as the xpfd root
+	// user. After `--`, getopt stops scanning so src/dest are always
+	// positional. Belt-and-suspenders with the commit-time leading-dash
+	// reject in compiler_system.go.
 	out, err := exec.CommandContext(ctx, "scp",
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "BatchMode=yes",
+		"--",
 		srcPath, dest,
 	).CombinedOutput()
 	if err != nil {

--- a/pkg/ddns/backend_generic.go
+++ b/pkg/ddns/backend_generic.go
@@ -131,10 +131,35 @@ func validateGenericURLTemplate(tmpl string) error {
 	if at := strings.LastIndex(authority, "@"); at >= 0 {
 		authority = authority[at+1:]
 	}
-	if authority == "" {
+	// #4589 A10-b2 F-01: require a non-empty HOST after dropping a trailing
+	// :port (and unwrapping a bracketed IPv6 literal). `http://:8080/upd` has
+	// a non-empty authority (":8080") but an EMPTY host, so the old
+	// `authority == ""` check let it through — Go's dialer then treats an
+	// empty-host URL as localhost. Kept byte-for-byte in lockstep with
+	// ddnsGenericURLTemplateValid (compiler_validate_warn.go), the #2841
+	// commit-time mirror this is a residual of.
+	if ddnsTemplateHost(authority) == "" {
 		return fmt.Errorf("url-template %q has no host", config.RedactURL(tmpl))
 	}
 	return nil
+}
+
+// ddnsTemplateHost extracts the host from a URL authority whose userinfo has
+// already been stripped: it drops a trailing :port and unwraps a bracketed
+// IPv6 literal, returning "" when there is no host segment (e.g. ":8080" or an
+// unterminated "[..."). Kept in lockstep with the inline copy in
+// pkg/config.ddnsGenericURLTemplateValid (config cannot import pkg/ddns).
+func ddnsTemplateHost(authority string) string {
+	if strings.HasPrefix(authority, "[") {
+		if end := strings.Index(authority, "]"); end >= 0 {
+			return authority[1:end]
+		}
+		return ""
+	}
+	if colon := strings.IndexByte(authority, ':'); colon >= 0 {
+		return authority[:colon]
+	}
+	return authority
 }
 
 // renderGenericURL expands the inadyn-style template specifiers. %u/%p are

--- a/pkg/ddns/backend_generic_porthost_4589_test.go
+++ b/pkg/ddns/backend_generic_porthost_4589_test.go
@@ -1,0 +1,45 @@
+package ddns
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #4589 A10-b2 F-01: validateGenericURLTemplate only rejected an EMPTY
+// authority, so `http://:8080/upd` — a non-empty authority (":8080") with an
+// EMPTY host — slipped through, and Go's dialer treats an empty-host URL as
+// localhost. Require a non-empty host after dropping the :port (and
+// unwrapping a bracketed IPv6 literal). Residual of the #2841
+// empty-authority-only check.
+//
+// RED-on-revert: without the ddnsTemplateHost gate the port-only cases
+// return nil (accepted).
+func TestGenericURLTemplatePortOnlyHostRejected(t *testing.T) {
+	reject := []string{
+		"http://:8080/upd?ip=%i",         // port only, no host
+		"https://:443/upd",               // port only, https
+		"https://user:%p@:8080/upd?h=%h", // userinfo stripped -> port only
+	}
+	for _, tmpl := range reject {
+		if err := validateGenericURLTemplate(tmpl); err == nil {
+			t.Errorf("validateGenericURLTemplate(%q) = nil, want error (empty host)", tmpl)
+		}
+		if _, err := newGenericBackend(&config.DDNSProvider{
+			Name: "g", Backend: "generic", URLTemplate: tmpl,
+		}, nil); err == nil {
+			t.Errorf("newGenericBackend(%q) = nil error, want rejection", tmpl)
+		}
+	}
+
+	accept := []string{
+		"http://[2001:db8::1]:8080/upd?ip=%i", // bracketed IPv6 literal + port
+		"http://[2001:db8::1]/upd",            // bracketed IPv6 literal, no port
+		"https://host:8443/upd?ip=%i",         // real host + port
+	}
+	for _, tmpl := range accept {
+		if err := validateGenericURLTemplate(tmpl); err != nil {
+			t.Errorf("validateGenericURLTemplate(%q) = %v, want nil", tmpl, err)
+		}
+	}
+}

--- a/pkg/grpcapi/server_config.go
+++ b/pkg/grpcapi/server_config.go
@@ -250,6 +250,16 @@ func (s *Server) ConfirmCommit(_ context.Context, _ *pb.ConfirmCommitRequest) (*
 }
 
 func (s *Server) Rollback(_ context.Context, req *pb.RollbackRequest) (*pb.RollbackResponse, error) {
+	// #4589 A8-01: n==0 is the valid Junos `rollback 0` (revert to active);
+	// n>=1 selects history slot n. A negative n maps to history.Get(n-1) =
+	// history.Get(<-1>) → the opaque store error "history position -1 out of
+	// range". Reject it up front with a clear message. Unlike ShowRollback
+	// (#4556, n<=0) the mutation RPC keeps n==0 valid, so only n<0 is
+	// rejected. Fail-closed either way — no wrong rollback target.
+	if req.N < 0 {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"invalid n %d: rollback index must be non-negative (0 = revert to active)", req.N)
+	}
 	if err := s.store.Rollback(int(req.N)); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}

--- a/pkg/grpcapi/server_rollback_negative_n_4589_test.go
+++ b/pkg/grpcapi/server_rollback_negative_n_4589_test.go
@@ -1,0 +1,58 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// #4589 A8-01: the Rollback MUTATION RPC had no n<0 guard, so a negative n
+// flowed into store.Rollback(n) → history.Get(n-1) → history.Get(<0) → the
+// opaque "history position -1 out of range" store error. Reject it up front
+// with a clear message. Unlike ShowRollback (#4556, which rejects n<=0), the
+// mutation keeps n==0 valid (Junos `rollback 0` = revert to active), so only
+// n<0 is rejected.
+//
+// RED-on-revert: dropping the n<0 guard returns the store's out-of-range
+// error (still InvalidArgument, but the confusing "out of range" message and
+// no guard on the raw wire value).
+func TestRollbackRejectsNegativeN(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	s := &Server{store: store}
+	for _, n := range []int32{-1, -5} {
+		_, err := s.Rollback(context.Background(), &pb.RollbackRequest{N: n})
+		if err == nil {
+			t.Fatalf("n=%d: expected error, got nil", n)
+		}
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("n=%d: status = %v, want InvalidArgument", n, status.Code(err))
+		}
+		if !strings.Contains(err.Error(), "rollback index must be non-negative") {
+			t.Fatalf("n=%d: error = %q, want substring %q", n, err.Error(), "rollback index must be non-negative")
+		}
+		if strings.Contains(err.Error(), "out of range") {
+			t.Fatalf("n=%d: error leaked the opaque store message %q", n, err.Error())
+		}
+	}
+}
+
+// n==0 (revert to active) is unchanged by the guard: a fresh store rolls back
+// to its active config cleanly.
+func TestRollbackAcceptsZeroN(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	s := &Server{store: store}
+	if _, err := s.Rollback(context.Background(), &pb.RollbackRequest{N: 0}); err != nil {
+		t.Fatalf("n=0 (revert to active) rejected by the negative-n guard: %v", err)
+	}
+}

--- a/pkg/grpcapi/server_show_routes_text.go
+++ b/pkg/grpcapi/server_show_routes_text.go
@@ -178,19 +178,44 @@ func (s *Server) showRoutePrefix(req *pb.ShowTextRequest, cfg *config.Config, bu
 func (s *Server) showTestRouting(req *pb.ShowTextRequest, buf *strings.Builder) (*pb.ShowTextResponse, error) {
 	params := strings.TrimPrefix(req.Topic, "test-routing:")
 	var dest, instance string
-	for _, kv := range strings.Split(params, ",") {
-		parts := strings.SplitN(kv, "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		switch parts[0] {
-		case "dest":
-			dest = parts[1]
-		case "instance":
-			instance = parts[1]
+	var parseErr error
+	// #4589 A8-b2 F-002: mirror the #3696 showTestPolicy hardening. The old
+	// `if len(parts) != 2 { continue }` plus a switch with no default arm
+	// SILENTLY dropped a malformed segment or an unknown/typo'd selector key
+	// — a typo'd `instnace=dmz` left `instance` at "" so the lookup fell back
+	// to the MAIN routing table for what the operator asked as a VRF query,
+	// with no warning. Report a malformed segment (no key=value, or an empty
+	// key/value) and an unknown key instead of ignoring it. A bare
+	// `test-routing:` (empty params) still falls through to the
+	// "Missing dest parameter" diagnostic below.
+	if params != "" {
+		for _, kv := range strings.Split(params, ",") {
+			parts := strings.SplitN(kv, "=", 2)
+			if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+				if parseErr == nil {
+					parseErr = fmt.Errorf("malformed selector segment %q (expected key=value)", kv)
+				}
+				continue
+			}
+			switch parts[0] {
+			case "dest":
+				dest = parts[1]
+			case "instance":
+				instance = parts[1]
+			default:
+				if parseErr == nil {
+					parseErr = fmt.Errorf("unknown selector %q", parts[0])
+				}
+			}
 		}
 	}
-	if s.routing == nil {
+	if parseErr != nil {
+		// Report malformed grammar / an unknown key before anything else, so a
+		// typo cannot silently widen the query to the wrong routing table. A
+		// selector grammar error is a client-input error independent of
+		// routing-manager availability, so it precedes the nil-manager check.
+		fmt.Fprintf(buf, "%v\n", parseErr)
+	} else if s.routing == nil {
 		buf.WriteString("Routing manager not available\n")
 	} else if dest == "" {
 		buf.WriteString("Missing dest parameter\n")

--- a/pkg/grpcapi/server_show_test_routing_unknownkey_4589_test.go
+++ b/pkg/grpcapi/server_show_test_routing_unknownkey_4589_test.go
@@ -1,0 +1,72 @@
+package grpcapi
+
+import (
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #4589 A8-b2 F-002: showTestRouting used `if len(parts) != 2 { continue }`
+// plus a switch with no default arm, so a malformed segment or an
+// unknown/typo'd selector key was SILENTLY dropped — a typo'd
+// `instnace=dmz` left `instance` at "" and the lookup fell back to the MAIN
+// routing table for a VRF query with no warning (parity gap vs the #3696
+// showTestPolicy hardening). The handler must now report the typo.
+//
+// routing is nil here (the default Server), so a valid selector proceeds to
+// the "Routing manager not available" diagnostic; a typo is reported first.
+//
+// RED-on-revert: without the default arm the typo'd `instnace` case emits
+// "Routing manager not available" (silently using the main table) instead
+// of naming the unknown key.
+func TestShowTestRoutingReportsUnknownSelector(t *testing.T) {
+	s := &Server{}
+
+	cases := []struct {
+		name       string
+		topic      string
+		wantSubstr string
+	}{
+		{
+			name:       "typo'd instance key",
+			topic:      "test-routing:dest=10.0.0.0/24,instnace=dmz",
+			wantSubstr: `unknown selector "instnace"`,
+		},
+		{
+			name:       "malformed segment",
+			topic:      "test-routing:dest=10.0.0.0/24,garbage",
+			wantSubstr: "malformed selector segment",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf strings.Builder
+			if _, err := s.showTestRouting(&pb.ShowTextRequest{Topic: tc.topic}, &buf); err != nil {
+				t.Fatalf("showTestRouting(%q) error = %v", tc.topic, err)
+			}
+			out := buf.String()
+			if !strings.Contains(out, tc.wantSubstr) {
+				t.Errorf("showTestRouting(%q) = %q; want it to contain %q", tc.topic, out, tc.wantSubstr)
+			}
+		})
+	}
+}
+
+// A valid selector set (correct `instance=` key) does NOT report an unknown
+// selector; with routing nil it falls through to the manager-unavailable
+// diagnostic, proving the hardening does not false-positive on good input.
+func TestShowTestRoutingValidSelectorNotFlagged(t *testing.T) {
+	s := &Server{}
+	var buf strings.Builder
+	if _, err := s.showTestRouting(&pb.ShowTextRequest{Topic: "test-routing:dest=10.0.0.0/24,instance=dmz"}, &buf); err != nil {
+		t.Fatalf("showTestRouting error = %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "unknown selector") || strings.Contains(out, "malformed selector") {
+		t.Errorf("showTestRouting flagged a valid selector: %q", out)
+	}
+	if !strings.Contains(out, "Routing manager not available") {
+		t.Errorf("showTestRouting(valid, routing=nil) = %q; want the manager-unavailable diagnostic", out)
+	}
+}


### PR DESCRIPTION
Closes #4589.

Grouped LOW hardening residuals from the ps-037/ps-038 audit sweep. All Go, non-cargo, each driven as a separate commit with a RED-on-revert test.

## Items

1. **A3 F-01 (config)** — `config: range-validate BGP peer-as / top-level local-as (uint32 wrap)`
   BGP `peer-as` (group + neighbor) and top-level `local-as` had no upper-bound schema validator, so an out-of-range ASN passed the strict commit schema and the compiler's `Atoi -> uint32(v)` cast silently wrapped it (`peer-as 4294967297` -> `remote-as 1`). Added `ValidateInteger(1, 4294967295)` to the three unguarded leaves, mirroring the sibling `local-as` leaves that already had it.

2. **A10-01 (cli)** — `cli: bound monitor traffic count (negative / unbounded)`
   `parseMonitorTrafficArgs` only rejected a non-numeric `count`; a negative reached tcpdump's `-c` as an opaque error and a huge value was silently accepted. Bounded to `n < 0 || n > 8192` (matching the sibling `monitor security packet-drop`), keeping `0` = unlimited.

3. **A8-b2 F-002 (grpcapi)** — `grpcapi: report unknown/malformed test-routing selectors`
   `showTestRouting` silently dropped a malformed segment / unknown selector key (no default arm), so a typo'd `instnace=dmz` returned the MAIN routing table for a VRF query. Mirrored the #3696 `showTestPolicy` hardening (parseErr + default arm), reported before the lookup.

4. **A8-01 (grpcapi + api)** — `grpcapi,api: guard Rollback against a negative n`
   The `Rollback` mutation RPC and its REST leg had no `n<0` guard, surfacing the opaque "history position -1 out of range" store error. Added a `req.N < 0` reject on both surfaces; `n==0` (revert to active) stays valid.

5. **A7 F-02 (daemon + config)** — `daemon,config: harden scp archive-site argv (leading-dash injection)`
   `scpArchiveTransfer` ran `scp <src> <dest>` with no `--` separator and `dest` is a verbatim operator-configured `archive-sites` URL — a leading-dash value is parsed by scp's getopt as an option (CWE-88). Added `--` before src/dest and a commit-time reject of leading-dash archive-sites in both parse shapes. Defense-in-depth (config-commit is already root-equivalent).

6. **A10-b2 F-01 (ddns + config)** — `ddns,config: reject empty-host DDNS generic url-template`
   Both the runtime `validateGenericURLTemplate` and its commit-time mirror only rejected an EMPTY authority, so `http://:8080/upd` (empty host) slipped through. Now require a non-empty host after dropping `:port` / unwrapping bracketed IPv6, in lockstep across both packages. Residual of #2841.

## Validation

- RED-on-revert verified for every item (stash the fix, the reject/report test flips to accept/silent).
- `go build ./...` green; `go test ./pkg/config/... ./pkg/cli/... ./pkg/grpcapi/... ./pkg/ddns/... ./pkg/api/... ./pkg/daemon/...` green.
- `gofmt` clean on all changed files; `go vet` clean on touched packages (pre-existing `pkg/cli/cli.go:503` unreachable-code finding is unrelated — cli.go is unmodified).

All items are LOW severity, verified present + reachable on current master. No cargo/dataplane changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi