### PR TITLE
config: hard-reject out-of-range CoS queue + bound LLDP TTL (#4594, #4596)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -40473,3 +40473,18 @@ top.
   pkg/config/compiler_cos_fc_queue_4594_test.go,
   pkg/config/parser_class_of_service_test.go, docs/config-schema.md,
   _Log.md
+
+- **Timestamp**: 2026-07-07 (#4596)
+- **Action**: `protocols lldp transmit-interval` / `hold-multiplier` were
+  untyped (bare `Atoi`, no validator), so `transmit-interval 16384` ×
+  default hold-multiplier 4 = 65536 wrapped `uint16(seconds)` in
+  `encodeTTL` to a TTL of 0, immediately expiring the neighbor. Added
+  `ValidateInteger` validators bounding the two leaves to the IEEE 802.1AB
+  LLDP-MIB / Junos ranges (transmit-interval 5..32768, hold-multiplier
+  2..10) AND a defensive `[0, 0xffff]` clamp in `encodeTTL` (matching the
+  standard's `txTTL = min(65535, msgTxInterval × msgTxHold)`). RED-on-revert
+  tests: schema rejects out-of-range interval/multiplier, in-range commits,
+  clamp caps a computed TTL > 65535 (and the 16384×4 wrap-to-0 case).
+- **File(s)**: pkg/config/schema_routing.go,
+  pkg/config/schema_lldp_ttl_4596_test.go, pkg/lldp/lldp.go,
+  pkg/lldp/lldp_test.go, docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -40453,3 +40453,23 @@ top.
   single-key non-regression, non-existent multi-key path errors).
 - **File(s)**: pkg/config/ast.go, pkg/configstore/store_command.go,
   pkg/configstore/store_test.go, docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-07 (#4594)
+- **Action**: class-of-service forwarding-class queue outside 0..255 was
+  warn-only (`ValidateConfig`) and COMMITTED, while the userspace helper
+  deserializes the queue id via a checked `u8::try_from` and fail-closes
+  the WHOLE CoS snapshot on `CosQueueIdOutOfRange` (#2410) — silently
+  keeping stale CoS forwarding state (config/dataplane divergence). Added
+  `validateClassOfServiceForwardingClassQueueStrict` and wired it into
+  `runUniformGates`: HARD-REJECT on strict commit / commit-check, downgrade
+  to a warning on the tolerant load / peer-sync path
+  (`lenientCoSForwardingClassQueue`, #1960 no-brick). Mirrors the fairness
+  rss-expectation queue reject and the sibling CoS strict gates.
+  RED-on-revert tests: strict rejects queue 999, lenient warns not bricks,
+  valid queues (0/7/255) commit clean.
+- **File(s)**: pkg/config/compiler.go,
+  pkg/config/compiler_validate_strict_cos.go,
+  pkg/config/compiler_uniformgates.go,
+  pkg/config/compiler_cos_fc_queue_4594_test.go,
+  pkg/config/parser_class_of_service_test.go, docs/config-schema.md,
+  _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -88,6 +88,20 @@ load / peer-sync path downgrades to a warning
 committed under an older binary still boots (#1960 no-brick); the
 `CosQueueIdOutOfRange` fail-close is the stale-but-safe backstop on that boot.
 
+### `protocols lldp` TTL bounds (#4596)
+
+The `transmit-interval` and `hold-multiplier` leaves (`schema_routing.go`) now
+carry `ValidateInteger` typed-leaf validators bounding them to the IEEE 802.1AB
+LLDP-MIB ranges Junos also enforces — `lldpMessageTxInterval` **5..32768** and
+`lldpMessageTxHoldMultiplier` **2..10**. Their product feeds the 16-bit LLDP TTL
+TLV (`ttl = transmit-interval × hold-multiplier`); before this gate both leaves
+were untyped (bare `Atoi`), so e.g. `transmit-interval 16384` × default
+hold-multiplier 4 = 65536 wrapped `uint16` to a TTL of 0 and IMMEDIATELY expired
+the neighbor. `encodeTTL` (`pkg/lldp/lldp.go`) additionally clamps the computed
+TTL to `[0, 0xffff]` as a defensive backstop so even the in-range IEEE extreme
+(32768 × 10) — and any constructed caller — cannot wrap, matching the standard's
+own `txTTL = min(65535, msgTxInterval × msgTxHold)`.
+
 ## Multi-value leaves and bracketed lists (the dual-AST contract)
 
 A `multi: true` leaf with `children: nil` (e.g. `from protocol`,

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -72,6 +72,22 @@ The live config-mode completers — `pkg/cli` `completeConfigWithDesc` and
 only supplies the config-mode TOP-LEVEL keywords (`set`/`delete`/`commit`/
 `load`/...) plus the retained `set system dataplane` description overlay.
 
+### `class-of-service forwarding-classes queue` range (#4594)
+
+`validateClassOfServiceForwardingClassQueueStrict`
+(`compiler_validate_strict_cos.go`, gated in `runUniformGates`) hard-rejects a
+forwarding-class whose `queue` is outside **0..255** on the strict commit /
+commit-check path. The value used to be warn-only (`ValidateConfig`) and
+COMMITTED, while the userspace helper deserializes the queue id via a checked
+`u8::try_from` and fail-closes the WHOLE CoS snapshot on `CosQueueIdOutOfRange`
+(#2410), silently keeping the node's STALE CoS forwarding state — a
+config/dataplane divergence the operator could not see. xpf's valid range is
+0..255 (the dataplane's `u8` queue id), NOT Junos-classic 0..7. The tolerant
+load / peer-sync path downgrades to a warning
+(`opts.lenientCoSForwardingClassQueue`) so an already-persisted queue that
+committed under an older binary still boots (#1960 no-brick); the
+`CosQueueIdOutOfRange` fail-close is the stale-but-safe backstop on that boot.
+
 ## Multi-value leaves and bracketed lists (the dual-AST contract)
 
 A `multi: true` leaf with `children: nil` (e.g. `from protocol`,

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -280,6 +280,21 @@ type compileOpts struct {
 	// Same doctrine as lenientSchedulerMapRef.
 	lenientCoSLossPriority bool
 
+	// lenientCoSForwardingClassQueue (#4594) downgrades the
+	// class-of-service forwarding-class queue-range check
+	// (validateClassOfServiceForwardingClassQueueStrict) from a hard
+	// error to a warning on the tolerant load / peer-sync paths. An
+	// out-of-range queue (queue < 0 || queue > 255) was warn-only at
+	// commit before this gate (ValidateConfig only), so it COMMITTED —
+	// while the userspace helper fail-closes the WHOLE CoS snapshot on
+	// CosQueueIdOutOfRange (#2410) and keeps its STALE CoS forwarding
+	// state, a config/dataplane divergence the operator cannot see.
+	// Commit / commit-check now reject it loudly; a config persisted by
+	// an older binary — or synced from a peer — must still boot through
+	// it (warn) rather than fail-closed-on-load (#1960 class). Same
+	// doctrine as lenientCoSLossPriority.
+	lenientCoSForwardingClassQueue bool
+
 	// lenientIPsecGatewayRefs (#2074) downgrades the IPsec VPN -> IKE
 	// gateway cross-reference check from a hard error to a warning on the
 	// tolerant load / peer-sync paths (CompileConfigLenient /
@@ -1554,6 +1569,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientIPsecPolicyProposalRef:          true,
 		lenientSchedulerMapRef:                 true,
 		lenientCoSLossPriority:                 true,
+		lenientCoSForwardingClassQueue:         true,
 		lenientIPsecGatewayRefs:                true,
 		lenientIKEPolicyChainRef:               true,
 		lenientIPsecTrafficSelectors:           true,
@@ -1801,6 +1817,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientIPsecPolicyProposalRef:          true,
 		lenientSchedulerMapRef:                 true,
 		lenientCoSLossPriority:                 true,
+		lenientCoSForwardingClassQueue:         true,
 		lenientIPsecGatewayRefs:                true,
 		lenientIKEPolicyChainRef:               true,
 		lenientIPsecTrafficSelectors:           true,

--- a/pkg/config/compiler_cos_fc_queue_4594_test.go
+++ b/pkg/config/compiler_cos_fc_queue_4594_test.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4594: a class-of-service forwarding-class whose queue is outside 0..255
+// must be HARD-REJECTED on the strict commit / commit-check path. Before the
+// gate the out-of-range queue was warn-only (ValidateConfig) and COMMITTED,
+// while the userspace helper fail-closes the WHOLE CoS snapshot on
+// CosQueueIdOutOfRange (#2410) and silently keeps stale CoS forwarding state.
+//
+// RED on revert: without validateClassOfServiceForwardingClassQueueStrict
+// wired into runUniformGates, CompileConfig (strict) returns nil and the bad
+// queue commits.
+func TestCoSForwardingClassQueueOutOfRange_StrictReject_4594(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set class-of-service forwarding-classes queue 999 iperf-video",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected strict commit to reject out-of-range forwarding-class queue 999")
+	}
+	if !strings.Contains(err.Error(), "queue 999") ||
+		!strings.Contains(err.Error(), "0..255") {
+		t.Fatalf("error should name the out-of-range queue and the 0..255 range, got: %v", err)
+	}
+}
+
+// A queue inside 0..255 (including the boundaries) commits clean on the strict
+// path — the gate is scoped to out-of-range values, not a blanket reject.
+func TestCoSForwardingClassQueueValid_StrictAccept_4594(t *testing.T) {
+	for _, q := range []string{"0", "7", "255"} {
+		tree := flatTreeFromSets(t,
+			"set class-of-service forwarding-classes queue "+q+" iperf-video",
+		)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("valid forwarding-class queue %s wrongly rejected on strict commit: %v", q, err)
+		}
+	}
+}
+
+// The tolerant load / peer-sync path (CompileConfigLenient) must NOT brick on
+// an already-persisted out-of-range queue — it downgrades to a warning so an
+// upgrading node still boots (#1960 no-brick). RED on revert: with the gate
+// unconditional (no lenient flag) the lenient path would return an error.
+func TestCoSForwardingClassQueueOutOfRange_LenientWarns_4594(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set class-of-service forwarding-classes queue 999 iperf-video",
+	)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient load of out-of-range queue must not brick, got error: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "forwarding-class queue") && strings.Contains(w, "queue 999") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient path must warn about the out-of-range queue, warnings: %v", cfg.Warnings)
+	}
+}
+
+// Unit-level guard on the validator itself: a NEGATIVE queue (only reachable
+// via a constructed / externally-assembled config, since the grammar has no
+// minus token on the operator set path) is rejected too.
+func TestValidateCoSForwardingClassQueue_NegativeRejected_4594(t *testing.T) {
+	cos := &ClassOfServiceConfig{
+		ForwardingClasses: map[string]*CoSForwardingClass{
+			"bad": {Name: "bad", Queue: -1},
+		},
+	}
+	if err := validateClassOfServiceForwardingClassQueueStrict(cos); err == nil {
+		t.Fatal("expected negative forwarding-class queue to be rejected")
+	}
+	ok := &ClassOfServiceConfig{
+		ForwardingClasses: map[string]*CoSForwardingClass{
+			"ef": {Name: "ef", Queue: 5},
+		},
+	}
+	if err := validateClassOfServiceForwardingClassQueueStrict(ok); err != nil {
+		t.Fatalf("in-range forwarding-class queue wrongly rejected: %v", err)
+	}
+}

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -62,6 +62,24 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 		}
 	}
 
+	// #4594 class-of-service forwarding-class queue-range gate. Strict on
+	// commit / commit-check (hard-reject a queue outside 0..255, which the
+	// userspace helper deserializes via a checked u8::try_from and
+	// fail-closes the WHOLE CoS snapshot on — CosQueueIdOutOfRange #2410 —
+	// while silently keeping stale CoS forwarding state). Lenient on load /
+	// peer-sync (warn so an already-persisted config that only warned +
+	// committed under an older binary, or a peer-synced config, still boots
+	// — #1960 no-brick; the dataplane's CosQueueIdOutOfRange fail-close is
+	// the stale-but-safe backstop on that boot).
+	if err := validateClassOfServiceForwardingClassQueueStrict(cfg.ClassOfService); err != nil {
+		if opts.lenientCoSForwardingClassQueue {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("class-of-service forwarding-class queue (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #1956 device-map cross-entry validation. Strict on commit /
 	// commit-check (hard-reject duplicate names/PCI/MAC, RETH key-mac,
 	// FPC/node misalignment); lenient on load / peer-sync (warn so an

--- a/pkg/config/compiler_validate_strict_cos.go
+++ b/pkg/config/compiler_validate_strict_cos.go
@@ -259,6 +259,51 @@ func validateClassOfServiceLossPriorityStrict(cos *ClassOfServiceConfig) error {
 	return nil
 }
 
+// validateClassOfServiceForwardingClassQueueStrict hard-rejects a
+// class-of-service forwarding-class whose queue is outside the accepted
+// 0..255 range (#4594). Before this gate the out-of-range queue was
+// warn-only (ValidateConfig) and COMMITTED, but the userspace helper
+// deserializes the queue id via a checked u8::try_from and fail-closes the
+// ENTIRE CoS snapshot on CosQueueIdOutOfRange (#2410) — silently keeping the
+// node's STALE CoS forwarding state. The operator sees a committed config that
+// is not being enforced (a config/dataplane divergence). Reject it loudly at
+// commit / commit-check instead, mirroring the fairness rss-expectation
+// queue-range reject in compiler_class_of_service.go and the sibling CoS strict
+// gates.
+//
+// xpf's valid queue range is 0..255 (the dataplane's u8 queue id), NOT the
+// Junos-classic 0..7 — see the warn text in compiler_validate_warn.go and the
+// CosQueueIdOutOfRange backstop.
+//
+// On the tolerant load / peer-sync paths the call site downgrades this to a
+// warning (opts.lenientCoSForwardingClassQueue) so a config persisted by an
+// older binary — which only warned, then committed — or synced from a peer
+// still boots (#1960 no-brick); the dataplane's CosQueueIdOutOfRange fail-close
+// keeps the stale-but-safe posture on that boot. Forwarding classes are visited
+// in sorted order so commit-check surfaces a STABLE first-error message.
+func validateClassOfServiceForwardingClassQueueStrict(cos *ClassOfServiceConfig) error {
+	if cos == nil {
+		return nil
+	}
+	names := make([]string, 0, len(cos.ForwardingClasses))
+	for name := range cos.ForwardingClasses {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		class := cos.ForwardingClasses[name]
+		if class == nil {
+			continue
+		}
+		if class.Queue < 0 || class.Queue > 255 {
+			return fmt.Errorf(
+				"class-of-service forwarding-class %q uses out-of-range queue %d (expected 0..255)",
+				class.Name, class.Queue)
+		}
+	}
+	return nil
+}
+
 func validateClassOfServiceStrict(cos *ClassOfServiceConfig) error {
 	if cos == nil {
 		return nil

--- a/pkg/config/parser_class_of_service_test.go
+++ b/pkg/config/parser_class_of_service_test.go
@@ -1458,7 +1458,13 @@ system {
 	}
 }
 
-func TestValidateClassOfServiceQueueRangeWarning(t *testing.T) {
+// TestValidateClassOfServiceQueueRange pins the #4594 behavior split: an
+// out-of-range forwarding-class queue is HARD-REJECTED on the strict commit /
+// commit-check path (it used to only warn + commit, while the userspace helper
+// fail-closed the whole CoS snapshot on CosQueueIdOutOfRange and kept stale
+// state), but DOWNGRADED to a warning on the tolerant load / peer-sync path so
+// an already-persisted config still boots (#1960 no-brick).
+func TestValidateClassOfServiceQueueRange(t *testing.T) {
 	input := `class-of-service {
     forwarding-classes {
         queue 300 invalid-class;
@@ -1473,13 +1479,19 @@ system {
 	if len(errs) > 0 {
 		t.Fatalf("parse errors: %v", errs)
 	}
-	cfg, err := CompileConfig(tree)
+	// Strict commit path: hard-reject.
+	if _, err := CompileConfig(tree); err == nil ||
+		!strings.Contains(err.Error(), `forwarding-class "invalid-class" uses out-of-range queue 300`) {
+		t.Fatalf("strict commit must reject out-of-range queue 300, got: %v", err)
+	}
+	// Tolerant load / peer-sync path: warn, do not brick.
+	cfg, err := CompileConfigLenient(tree)
 	if err != nil {
-		t.Fatalf("compile error: %v", err)
+		t.Fatalf("lenient load must not brick on out-of-range queue: %v", err)
 	}
 	warnings := strings.Join(cfg.Warnings, "\n")
 	if !strings.Contains(warnings, `forwarding-class "invalid-class" uses out-of-range queue 300`) {
-		t.Fatalf("expected queue range warning, got: %s", warnings)
+		t.Fatalf("expected queue range warning on tolerant path, got: %s", warnings)
 	}
 }
 

--- a/pkg/config/schema_lldp_ttl_4596_test.go
+++ b/pkg/config/schema_lldp_ttl_4596_test.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4596: protocols lldp transmit-interval / hold-multiplier were untyped
+// (bare Atoi, no validator), so an out-of-range value committed and — with the
+// pre-clamp encodeTTL — could wrap the LLDP TTL to 0, immediately expiring the
+// neighbor. The two leaves now carry the IEEE 802.1AB LLDP-MIB ranges
+// (msgTxInterval 5..32768, msgTxHold 2..10) that Junos also enforces.
+//
+// RED on revert: an untyped leaf stores the value and SchemaValidate returns
+// nil.
+func TestLLDPTransmitIntervalRange_4596(t *testing.T) {
+	// Above the 32768 max — rejected.
+	bad := flatTreeFromSets(t, "set protocols lldp transmit-interval 40000")
+	if err := SchemaValidate(bad, nil); err == nil ||
+		!strings.Contains(err.Error(), "40000") {
+		t.Fatalf("out-of-range transmit-interval must be rejected naming the value, got: %v", err)
+	}
+	// Below the 5 min — rejected.
+	low := flatTreeFromSets(t, "set protocols lldp transmit-interval 0")
+	if err := SchemaValidate(low, nil); err == nil {
+		t.Fatal("transmit-interval 0 must be rejected (below the 5s minimum)")
+	}
+	// In-range values commit clean, including the boundaries.
+	for _, v := range []string{"5", "30", "16384", "32768"} {
+		ok := flatTreeFromSets(t, "set protocols lldp transmit-interval "+v)
+		if err := SchemaValidate(ok, nil); err != nil {
+			t.Errorf("valid transmit-interval %s rejected: %v", v, err)
+		}
+	}
+}
+
+func TestLLDPHoldMultiplierRange_4596(t *testing.T) {
+	// Above the 10 max — rejected.
+	bad := flatTreeFromSets(t, "set protocols lldp hold-multiplier 20")
+	if err := SchemaValidate(bad, nil); err == nil ||
+		!strings.Contains(err.Error(), "20") {
+		t.Fatalf("out-of-range hold-multiplier must be rejected naming the value, got: %v", err)
+	}
+	// Below the 2 min — rejected.
+	low := flatTreeFromSets(t, "set protocols lldp hold-multiplier 1")
+	if err := SchemaValidate(low, nil); err == nil {
+		t.Fatal("hold-multiplier 1 must be rejected (below the 2 minimum)")
+	}
+	// In-range values commit clean, including the boundaries.
+	for _, v := range []string{"2", "4", "10"} {
+		ok := flatTreeFromSets(t, "set protocols lldp hold-multiplier "+v)
+		if err := SchemaValidate(ok, nil); err != nil {
+			t.Errorf("valid hold-multiplier %s rejected: %v", v, err)
+		}
+	}
+}

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -582,9 +582,18 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 		"interface": {desc: "Interface", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: map[string]*schemaNode{
 			"disable": {desc: "Disable LLDP", children: nil},
 		}},
-		"transmit-interval": {desc: "Transmit interval", args: 1, placeholder: "<seconds>", children: nil},
-		"hold-multiplier":   {desc: "Hold multiplier", args: 1, placeholder: "<multiplier>", children: nil},
-		"disable":           {desc: "Disable LLDP", children: nil},
+		// #4596: bound to the IEEE 802.1AB LLDP-MIB ranges Junos also
+		// enforces — lldpMessageTxInterval (5..32768s) and
+		// lldpMessageTxHoldMultiplier (2..10). Their product feeds the LLDP
+		// TTL TLV; encodeTTL additionally clamps to 65535 so even the
+		// in-range extreme (32768 × 10) cannot wrap the uint16 wire value.
+		"transmit-interval": {desc: "Transmit interval", args: 1, placeholder: "<seconds>",
+			valueType: ValueInteger, valueDesc: "LLDP transmit interval in seconds (IEEE 802.1AB msgTxInterval, 5..32768)",
+			validator: ValidateInteger(5, 32768), children: nil},
+		"hold-multiplier": {desc: "Hold multiplier", args: 1, placeholder: "<multiplier>",
+			valueType: ValueInteger, valueDesc: "LLDP TTL hold multiplier (IEEE 802.1AB msgTxHold, 2..10)",
+			validator: ValidateInteger(2, 10), children: nil},
+		"disable": {desc: "Disable LLDP", children: nil},
 	}},
 }}
 

--- a/pkg/lldp/lldp.go
+++ b/pkg/lldp/lldp.go
@@ -723,6 +723,21 @@ func encodePortID(name string) []byte {
 }
 
 func encodeTTL(seconds int) []byte {
+	// The LLDP TTL TLV is a 16-bit unsigned value (IEEE 802.1AB); the wire
+	// TTL is msgTxInterval × msgTxHold, which the standard caps at
+	// txTTL = min(65535, msgTxInterval × msgTxHold). Clamp to [0, 0xffff]
+	// here so a large transmit-interval × hold-multiplier product cannot
+	// wrap uint16 back to a small or zero TTL (a TTL of 0 makes every peer
+	// IMMEDIATELY expire this neighbor — #4596). The schema validators on
+	// transmit-interval / hold-multiplier keep operator input in a sane
+	// range; this clamp is the defensive backstop for any in-range-but-large
+	// product (e.g. 16384s × 4 = 65536) and for constructed callers.
+	if seconds < 0 {
+		seconds = 0
+	}
+	if seconds > 0xffff {
+		seconds = 0xffff
+	}
 	val := make([]byte, 2)
 	binary.BigEndian.PutUint16(val, uint16(seconds))
 	return val

--- a/pkg/lldp/lldp_test.go
+++ b/pkg/lldp/lldp_test.go
@@ -125,6 +125,41 @@ func TestEncodeTTL(t *testing.T) {
 	}
 }
 
+// #4596: encodeTTL must clamp a computed TTL to the 16-bit wire maximum
+// (65535) so a large transmit-interval × hold-multiplier product cannot wrap
+// uint16 back to a small/zero TTL, which would make every peer IMMEDIATELY
+// expire this neighbor. RED on revert: without the clamp, uint16(65536) is 0
+// and uint16(160000) is 28928 (both wrong).
+func TestEncodeTTL_ClampsOverflow_4596(t *testing.T) {
+	cases := []struct {
+		name    string
+		seconds int
+		want    uint16
+	}{
+		// transmit-interval 16384 × default hold-multiplier 4 = 65536,
+		// which wraps to exactly 0 without the clamp — the issue's headline
+		// "immediately expire the neighbor" scenario.
+		{"16384x4-wraps-to-zero", 16384 * 4, 0xffff},
+		// The in-range IEEE extreme: 32768 × 10 = 327680.
+		{"ieee-extreme", 32768 * 10, 0xffff},
+		{"exact-max", 0xffff, 0xffff},
+		{"just-over-max", 0x10000, 0xffff},
+		{"negative-guard", -1, 0},
+		{"in-range-passthrough", 120, 120},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := binary.BigEndian.Uint16(encodeTTL(tc.seconds))
+			if got != tc.want {
+				t.Fatalf("encodeTTL(%d) TTL = %d, want %d", tc.seconds, got, tc.want)
+			}
+			if got == 0 && tc.want != 0 {
+				t.Fatal("TTL wrapped to 0 — neighbors would immediately expire")
+			}
+		})
+	}
+}
+
 func TestBuildFrame(t *testing.T) {
 	mac := net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
 	frame, err := BuildFrame(mac, "trust0", 120, "xpf", "stateful firewall")


### PR DESCRIPTION
Two low-severity config-validator hardenings, one commit each.

## #4594 — CoS forwarding-class queue strict reject

A `class-of-service forwarding-classes queue <n> <fc>` with `n` outside
0..255 was only WARNED about (`ValidateConfig`) and then COMMITTED, while
the userspace helper deserializes the queue id via a checked
`u8::try_from` and fail-closes the WHOLE CoS snapshot on
`CosQueueIdOutOfRange` (#2410) — silently keeping the node's STALE CoS
forwarding state (a config/dataplane divergence the operator cannot see).

`validateClassOfServiceForwardingClassQueueStrict` now HARD-REJECTS on
the strict commit / commit-check path and downgrades to a warning on the
tolerant load / peer-sync path (`lenientCoSForwardingClassQueue`, #1960
no-brick — an already-persisted queue that committed under an older
binary still boots). Mirrors the fairness rss-expectation queue reject
and the sibling CoS strict gates. xpf's valid range is the dataplane's
`u8` queue id (0..255), not Junos-classic 0..7.

## #4596 — LLDP TTL bounds

`protocols lldp transmit-interval` / `hold-multiplier` were untyped
(bare `Atoi`), and `encodeTTL` wrote `uint16(seconds)` with no clamp.
`transmit-interval 16384` × default hold-multiplier 4 = 65536 wraps
`uint16` to a TTL of 0, immediately expiring the neighbor.

The two leaves now carry `ValidateInteger` validators bounding them to
the IEEE 802.1AB LLDP-MIB ranges Junos also enforces
(`lldpMessageTxInterval` 5..32768, `lldpMessageTxHoldMultiplier` 2..10),
and `encodeTTL` defensively clamps the computed TTL to `[0, 0xffff]` so
even the in-range IEEE extreme (32768 × 10) or a constructed caller
cannot wrap — matching the standard's `txTTL = min(65535, msgTxInterval ×
msgTxHold)`.

## Validation

- RED-on-revert tests for both fixes (strict rejects / lenient warns /
  in-range commits / clamp caps, including the 16384×4 wrap-to-0 case).
- `go test ./pkg/config/... ./pkg/lldp/...` green; `go build ./...`
  clean; gofmt + go vet clean.
- Docs: `docs/config-schema.md` (both range notes) + `_Log.md`.

Closes #4594, closes #4596

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
