### PR TITLE
zeroize: tear down provisioned OS login accounts (#4598)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -40591,3 +40591,35 @@ top.
   single-key non-regression, non-existent multi-key path errors).
 - **File(s)**: pkg/config/ast.go, pkg/configstore/store_command.go,
   pkg/configstore/store_test.go, docs/config-schema.md, _Log.md
+
+## 2026-07-07 — #4598 zeroize tears down provisioned OS login accounts (SECURITY HIGH)
+- **Timestamp**: 2026-07-07
+- **Action**: SECURITY follow-up to #4576/#4585. The OS login accounts xpf
+  provisions live OUTSIDE /etc/xpf and SURVIVED zeroize — /etc/shadow
+  password hashes (reconcileUserPassword), SSH authorized_keys under
+  /home/<user>/.ssh (applySystemLogin), and /etc/sudoers.d/xpf-<user>
+  NOPASSWD grants (reconcileSudoers). applySystemLogin runs only inside the
+  boot-time applyConfig, which a post-zeroize boot SKIPS (bootstrap /
+  nil-active-config), and a full reconcile early-returns on empty config and
+  never userdel's, so a re-tenanted/RMA'd/resold device granted the prior
+  tenant interactive LOGIN + passwordless SUDO — a bigger leak than a
+  config-secret read. Added zeroizeLoginAccounts to performZeroizeWipe (after
+  the #4585 rendered-config erasure, error folded into the surfaced result
+  like #4576/#4585). Marker-aware teardown keyed on the #1944 UID-keyed
+  provenance marker (/var/lib/xpf/provisioned-users/<user>, content = UID at
+  provision time): (A) sweep the whole /etc/sudoers.d/xpf-* namespace
+  unconditionally (operator drop-ins without the prefix untouched); (B) for
+  each marker, userdel -r ONLY when the current /etc/passwd UID still equals
+  the recorded UID — an operator's own account (no marker), root/system
+  accounts (no marker), and an out-of-band recreate (UID mismatch) are NEVER
+  touched. authorized_keys removed BEFORE userdel (SSH vector dies even if
+  userdel fails); marker RETAINED on userdel failure so a retried zeroize
+  re-attempts + the error is surfaced (codes.Internal at the RPC boundary).
+  pkg/grpcapi can't import pkg/daemon (daemon_run.go imports grpcapi → cycle),
+  so the prod paths are mirrored as test-injectable package vars + a
+  zeroizeUserdel seam. RED-on-revert test proven against a neutered body
+  (removal/userdel/error-surfacing assertions fail; the never-touch-non-xpf
+  assertPresent safety checks stay green). go build ./... + go vet + full
+  pkg/grpcapi test green; gofmt clean.
+- **File(s)**: pkg/grpcapi/server_diag.go,
+  pkg/grpcapi/zeroize_login_4598_test.go, docs/system-login.md, _Log.md

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -199,6 +199,47 @@ next `commit`, and the daemon still boots cleanly (bootstrap does not touch
 those services). A failure to erase any of them surfaces as an error rather than
 a clean factory-reset report.
 
+**Provisioned login-account teardown (#4598).** The two erasures above remove
+config + rendered-config secrets, but the OS **login accounts** xpf provisioned
+also live **outside** `/etc/xpf` and **survive** the wipe — and they are the
+*biggest* re-tenant leak because they grant **interactive login + sudo**, not
+just a config-secret read:
+
+- **`/etc/shadow` password hashes** (`reconcileUserPassword`),
+- **SSH `authorized_keys`** under `/home/<user>/.ssh` (`applySystemLogin`),
+- **`/etc/sudoers.d/xpf-<user>`** NOPASSWD grants (`reconcileSudoers`).
+
+They persist for the same reason the rendered configs do: `applySystemLogin`
+runs only inside the boot-time `applyConfig`, which a post-zeroize boot **SKIPS**
+(bootstrap / `nil` active config), and even a full reconcile early-returns on an
+empty config and never `userdel`s. So `zeroize` now tears them down at wipe time
+too (`zeroizeLoginAccounts`, same error-surfacing discipline):
+
+- **Sudoers.** The entire `/etc/sudoers.d/xpf-*` namespace is removed
+  unconditionally (nothing is desired at factory reset), so no passwordless-root
+  grant survives even if a marker is missing. Operator-authored drop-ins without
+  the `xpf-` prefix are **left untouched**.
+- **Users.** A `userdel -r` (removes the `/etc/shadow` + `/etc/passwd` entry and
+  the home tree, incl. `authorized_keys`) fires **only** for an account that has
+  a **provenance marker** in `/var/lib/xpf/provisioned-users/<user>` **and** whose
+  current `/etc/passwd` UID still equals the marker's recorded UID — the same
+  UID-keyed ownership marker used for the declarative D2 lock (#1944 §5.4).
+  `authorized_keys` is removed *before* `userdel` so the SSH-key vector dies even
+  if `userdel` fails; on a `userdel` failure the marker is **retained** so a
+  retried `zeroize` re-attempts, and the failure is surfaced (the device is not
+  reported safe to re-tenant while a live account remains).
+
+**Never-touch safety invariant.** The teardown must never nuke a non-xpf account
+or strand access:
+
+- An **operator's own account** (created out of band, no xpf marker) is never
+  iterated — its keys, sudoers, and login stay intact.
+- **`root` and system accounts** have no marker and are never touched — the
+  console/root lifeline survives the wipe (critical on bare metal).
+- An **out-of-band `userdel`+recreate** with a different UID (marker UID ≠ live
+  UID) is left alone — the current owner is someone else, exactly the #1944
+  leave-then-rejoin-vs-recreate distinction.
+
 **Privileged-subcommand exception — `monitor traffic` (#4067).** Almost
 every command is gated on the top-level word alone, but `monitor traffic`
 spawns a **root `tcpdump` live packet capture** on a data interface, so it

--- a/pkg/grpcapi/server_diag.go
+++ b/pkg/grpcapi/server_diag.go
@@ -908,12 +908,207 @@ func zeroizeRenderedConfigs(frrConf, swanctlSnippet, kea4, kea6 string) error {
 	return firstErr
 }
 
+// zeroize login-account teardown paths (#4598). These mirror the production
+// paths the daemon provisions OS login accounts under (pkg/daemon:
+// provisionedUsersDir, sudoersDir/sudoersPrefix, passwdPath, /home/<user>).
+// They cannot be imported — pkg/daemon imports pkg/grpcapi (daemon_run.go),
+// so a shared symbol would create an import cycle, the same reason the exec
+// timeout helper is duplicated here. They are package vars only so a test can
+// point the teardown at a throwaway tree instead of the real /etc + /home +
+// /var/lib.
+var (
+	// zeroizeProvisionedUsersDir is the per-account provenance-marker directory
+	// (pkg/daemon.provisionedUsersDir). Each file is named for an xpf-created
+	// login account and CONTAINS that account's UID at provision time — the
+	// UID-keyed ownership marker of #1944. It is the authoritative registry of
+	// "which OS users did xpf provision", so the wipe walks it to know exactly
+	// which accounts are safe to remove.
+	zeroizeProvisionedUsersDir = "/var/lib/xpf/provisioned-users"
+	// zeroizeSudoersDir + zeroizeSudoersPrefix mirror pkg/daemon.sudoersDir /
+	// sudoersPrefix — the exclusive namespace of xpf-managed NOPASSWD sudo
+	// drop-ins. Only files with the prefix are ever removed; operator-authored
+	// drop-ins in the same directory are left untouched.
+	zeroizeSudoersDir    = "/etc/sudoers.d"
+	zeroizeSudoersPrefix = "xpf-"
+	// zeroizePasswdPath is /etc/passwd, read to resolve an account's CURRENT
+	// UID so a userdel only ever fires when the live UID still matches the
+	// marker (never on an out-of-band recreate). Mirrors pkg/daemon.passwdPath.
+	zeroizePasswdPath = "/etc/passwd"
+	// zeroizeHomeBase is the home-directory root; authorized_keys lives at
+	// <base>/<user>/.ssh/authorized_keys.
+	zeroizeHomeBase = "/home"
+	// zeroizeUserdel removes an OS account, its /etc/shadow + /etc/passwd
+	// entries, and its home tree (-r). It is a seam so tests can record the
+	// removal without touching real accounts. context.Background(): a client
+	// disconnect must not abort a confirmed factory reset (mirrors runTimeout's
+	// power-action rationale).
+	zeroizeUserdel = func(name string) ([]byte, error) {
+		return combinedOutputTimeout(context.Background(), "userdel", "-r", name)
+	}
+)
+
+// zeroizeLookupUID returns the current numeric UID for name by parsing
+// zeroizePasswdPath directly (cgo-free, mirroring pkg/daemon.lookupUID). It
+// returns (uid, true) on success and (0, false) if the file is unreadable, the
+// account is absent, or the UID field does not parse — the "not our account"
+// disposition that suppresses a userdel.
+func zeroizeLookupUID(name string) (int, bool) {
+	data, err := os.ReadFile(zeroizePasswdPath)
+	if err != nil {
+		return 0, false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.Split(line, ":")
+		if len(fields) < 3 {
+			continue
+		}
+		if fields[0] == name {
+			uid, err := strconv.Atoi(fields[2])
+			if err != nil {
+				return 0, false
+			}
+			return uid, true
+		}
+	}
+	return 0, false
+}
+
+// zeroizeLoginAccounts tears down the OS LOGIN accounts xpf provisioned as part
+// of a factory reset (#4598, follow-up to #4576/#4585). These are the biggest
+// re-tenant leak of the three because they grant INTERACTIVE LOGIN + SUDO, not
+// just a config-secret read:
+//
+//   - /etc/shadow password hashes (pkg/daemon.reconcileUserPassword)
+//   - SSH authorized_keys under /home/<user>/.ssh (pkg/daemon.applySystemLogin)
+//   - /etc/sudoers.d/xpf-<user> NOPASSWD grants (pkg/daemon.reconcileSudoers)
+//
+// All three live OUTSIDE /etc/xpf and SURVIVE the config wipe: applySystemLogin
+// runs only inside the boot-time applyConfig, which a post-zeroize boot SKIPS
+// (bootstrap mode / nil active config — the same boot-skip #4585 documents), and
+// even a full reconcile early-returns on an empty config and never userdel's. So
+// without this teardown a re-tenanted / RMA'd / resold device still carries the
+// prior tenant's login accounts, SSH keys, and passwordless sudo.
+//
+// Ownership discipline — NEVER touch a non-xpf account (the core safety
+// invariant, #1944 §5.4):
+//   - Sudoers: only the xpf-<user> namespace is swept. Operator-authored
+//     drop-ins (no xpf- prefix) are left untouched. The whole namespace is
+//     removed unconditionally — at factory reset nothing is desired — so no
+//     passwordless-root grant survives even if a marker is missing.
+//   - Users: a userdel fires ONLY for an account that has a provenance marker
+//     AND whose CURRENT /etc/passwd UID still equals the marker's recorded UID.
+//     An operator's own account (no marker) is never iterated; a system account
+//     or root (no marker) is never touched; an out-of-band userdel+recreate with
+//     a different UID (marker mismatch) is left alone — exactly the #1944
+//     leave-then-rejoin vs recreate distinction, so the wipe can never nuke the
+//     wrong account or strand access.
+//
+// authorized_keys is removed BEFORE userdel so the SSH-key login vector dies
+// even if userdel later fails; the marker is retained on a userdel FAILURE so a
+// retried zeroize re-attempts the removal (and the failure is surfaced, so the
+// device is not reported safe to re-tenant while a live account remains).
+//
+// Discipline mirrors zeroizeConfigDir / zeroizeRenderedConfigs: os.ErrNotExist
+// is never an error (an already-absent artifact is the goal), removal is
+// best-effort past a single failure, but the FIRST real error is returned so a
+// silently-incomplete teardown is never reported as a clean factory reset.
+func zeroizeLoginAccounts() error {
+	var firstErr error
+	fail := func(err error) {
+		if err != nil && !errors.Is(err, os.ErrNotExist) && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	// (A) Sweep the xpf sudoers namespace. Removing every xpf-<user> drop-in
+	// guarantees no passwordless-root grant survives, independent of the marker
+	// registry. Operator drop-ins without the prefix are never touched.
+	if entries, err := os.ReadDir(zeroizeSudoersDir); err != nil {
+		fail(err) // a real ReadDir error (absent dir is ErrNotExist → excluded)
+	} else {
+		for _, e := range entries {
+			name := e.Name()
+			if e.IsDir() || !strings.HasPrefix(name, zeroizeSudoersPrefix) {
+				continue
+			}
+			fail(os.Remove(filepath.Join(zeroizeSudoersDir, name)))
+		}
+	}
+
+	// (B) Tear down each xpf-provisioned OS user, gated on the UID-keyed marker.
+	entries, err := os.ReadDir(zeroizeProvisionedUsersDir)
+	if err != nil {
+		// Absent dir = xpf never provisioned a login account: nothing to do.
+		// Any other read error is surfaced (we cannot prove the accounts gone).
+		fail(err)
+		return firstErr
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name() // marker filename == account name (Base'd on write)
+		markerFile := filepath.Join(zeroizeProvisionedUsersDir, name)
+
+		recordedUID, uidErr := readProvisionedMarkerUID(markerFile)
+		curUID, curOK := zeroizeLookupUID(name)
+		keysFile := filepath.Join(zeroizeHomeBase, name, ".ssh", "authorized_keys")
+
+		removeMarker := true
+		switch {
+		case !curOK:
+			// Account already absent from /etc/passwd — it cannot authenticate.
+			// Best-effort clean up any orphaned key residue; nothing to userdel.
+			fail(os.Remove(keysFile))
+		case uidErr != nil || curUID != recordedUID:
+			// Corrupt marker OR out-of-band recreate (UID changed): NOT the
+			// account xpf provisioned. Never userdel or touch its home — the
+			// current owner is someone else. Drop our stale marker only.
+		default:
+			// curUID == recordedUID → the exact account xpf provisioned. Kill
+			// the SSH-key vector first (survives a userdel failure), then remove
+			// the account (userdel -r drops /etc/shadow + /etc/passwd + home).
+			fail(os.Remove(keysFile))
+			if out, derr := zeroizeUserdel(name); derr != nil {
+				slog.Error("zeroize: failed to remove xpf-provisioned login account",
+					"user", name, "err", derr, "output", strings.TrimSpace(string(out)))
+				fail(derr)
+				removeMarker = false // keep the marker so a retry re-attempts
+			} else {
+				slog.Info("zeroize: removed xpf-provisioned login account", "user", name)
+			}
+		}
+		if removeMarker {
+			fail(os.Remove(markerFile))
+		}
+	}
+	// Drop the now-empty marker directory (best-effort; ENOTEMPTY after a
+	// retained marker is fine and must not gate the factory reset).
+	_ = os.Remove(zeroizeProvisionedUsersDir)
+	return firstErr
+}
+
+// readProvisionedMarkerUID reads a provenance marker file and returns the UID
+// it records (pkg/daemon.markProvisioned writes the account's UID as decimal
+// text). A read or parse error yields the "not our account" disposition in
+// zeroizeLoginAccounts (no userdel).
+func readProvisionedMarkerUID(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(strings.TrimSpace(string(data)))
+}
+
 // performZeroizeWipe erases the on-disk config, rendered service-config
-// secrets, BPF pins, and managed networkd files (factory reset). It is a
-// package var so a test can drive the `zeroize` SystemAction verb (to assert
-// the #4108 F8 journal wiring) WITHOUT wiping a real /etc/xpf on the
-// developer/appliance box. It returns a non-nil error when a security-critical
-// erasure did not fully complete (#4576/#4585).
+// secrets, provisioned login accounts, BPF pins, and managed networkd files
+// (factory reset). It is a package var so a test can drive the `zeroize`
+// SystemAction verb (to assert the #4108 F8 journal wiring) WITHOUT wiping a
+// real /etc/xpf on the developer/appliance box. It returns a non-nil error when
+// a security-critical erasure did not fully complete (#4576/#4585/#4598).
 var performZeroizeWipe = func() error {
 	// Config state FIRST — the security-critical erasure. A failure here can
 	// leave prior-tenant config/secrets on disk, so it is surfaced to the
@@ -932,6 +1127,18 @@ var performZeroizeWipe = func() error {
 		dhcpserver.DefaultKea4ConfPath,
 		dhcpserver.DefaultKea6ConfPath,
 	); e != nil && err == nil {
+		err = e
+	}
+
+	// Provisioned login accounts (#4598): the OS users xpf created — their
+	// /etc/shadow hashes, SSH authorized_keys, and /etc/sudoers.d/xpf-* grants —
+	// live OUTSIDE /etc/xpf and SURVIVE the config wipe (applySystemLogin runs
+	// only inside the boot-time applyConfig, which a post-zeroize boot SKIPS), so
+	// a re-tenanted device would otherwise grant the prior tenant interactive
+	// login + passwordless sudo. Marker-aware teardown (UID-keyed provenance
+	// marker, #1944) so a non-xpf admin/system/operator account is NEVER touched.
+	// Also security-critical, so fold its first error into the surfaced result.
+	if e := zeroizeLoginAccounts(); e != nil && err == nil {
 		err = e
 	}
 

--- a/pkg/grpcapi/zeroize_login_4598_test.go
+++ b/pkg/grpcapi/zeroize_login_4598_test.go
@@ -1,0 +1,181 @@
+package grpcapi
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// assertPresent is the safety-property counterpart to assertAbsent: it fails if
+// a NON-xpf artifact (an operator/system account's keys or sudoers file) was
+// removed by the login-account teardown.
+func assertPresent(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected %s to SURVIVE zeroize (non-xpf artifact), stat err = %v", path, err)
+	}
+}
+
+// setZeroizeLoginPaths points the #4598 login-account teardown at a throwaway
+// tree and records userdel invocations. It returns the recorder slice pointer.
+func setZeroizeLoginPaths(t *testing.T, provDir, sudoersDir, homeBase, passwdPath string) *[]string {
+	t.Helper()
+	origProv, origSudoers, origHome, origPasswd, origUserdel :=
+		zeroizeProvisionedUsersDir, zeroizeSudoersDir, zeroizeHomeBase, zeroizePasswdPath, zeroizeUserdel
+	t.Cleanup(func() {
+		zeroizeProvisionedUsersDir = origProv
+		zeroizeSudoersDir = origSudoers
+		zeroizeHomeBase = origHome
+		zeroizePasswdPath = origPasswd
+		zeroizeUserdel = origUserdel
+	})
+	zeroizeProvisionedUsersDir = provDir
+	zeroizeSudoersDir = sudoersDir
+	zeroizeHomeBase = homeBase
+	zeroizePasswdPath = passwdPath
+	var deleted []string
+	zeroizeUserdel = func(name string) ([]byte, error) {
+		deleted = append(deleted, name)
+		return nil, nil
+	}
+	return &deleted
+}
+
+// TestZeroizeLoginAccountsRemovesProvisionedNotOthers pins #4598: the zeroize
+// wipe must tear down the OS LOGIN accounts xpf provisioned — their
+// /etc/shadow hashes (via userdel), SSH authorized_keys, and
+// /etc/sudoers.d/xpf-* grants — so a re-tenanted device does not grant the
+// prior tenant interactive login + passwordless sudo. It must do so
+// marker-aware: a non-xpf operator/system account, a UID-mismatch out-of-band
+// recreate, and operator-authored sudoers drop-ins are ALL left untouched.
+//
+// RED on revert: before this fix performZeroizeWipe tore down no OS accounts
+// (applySystemLogin runs only inside the boot-time apply, which a post-zeroize
+// boot SKIPS), so the shadow hash / authorized_keys / xpf-<user> sudoers all
+// SURVIVED — every assertAbsent below (and the userdel recorder) fails on
+// revert. The assertPresent safety checks pin that the teardown never nukes a
+// non-xpf account.
+func TestZeroizeLoginAccountsRemovesProvisionedNotOthers(t *testing.T) {
+	root := t.TempDir()
+	provDir := filepath.Join(root, "provisioned-users")
+	sudoersDir := filepath.Join(root, "sudoers.d")
+	homeBase := filepath.Join(root, "home")
+	passwdPath := filepath.Join(root, "passwd")
+
+	// /etc/passwd: root + a system account + an operator's OWN account (no
+	// marker) + the xpf-provisioned "alice" (UID matches its marker) + "stale"
+	// whose live UID (2001) DIFFERS from its marker (2000) — an out-of-band
+	// userdel+recreate that must NOT be nuked.
+	mustWriteFile(t, passwdPath, []byte(
+		"root:x:0:0:root:/root:/bin/bash\n"+
+			"daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin\n"+
+			"operator:x:1000:1000:operator:/home/operator:/bin/bash\n"+
+			"alice:x:1001:1001:alice:/home/alice:/bin/bash\n"+
+			"stale:x:2001:2001:stale:/home/stale:/bin/bash\n"))
+
+	// Provenance markers (content = UID at provision time). "ghost" has a
+	// marker but no /etc/passwd entry (already removed out of band).
+	aliceMarker := filepath.Join(provDir, "alice")
+	staleMarker := filepath.Join(provDir, "stale")
+	ghostMarker := filepath.Join(provDir, "ghost")
+	mustWriteFile(t, aliceMarker, []byte("1001"))
+	mustWriteFile(t, staleMarker, []byte("2000")) // != live UID 2001 → not ours
+	mustWriteFile(t, ghostMarker, []byte("3000"))
+
+	// sudoers.d: three xpf-<user> grants (all removed by the namespace sweep) +
+	// one operator/system drop-in without the prefix (must survive).
+	xpfAliceSudo := filepath.Join(sudoersDir, "xpf-alice")
+	xpfStaleSudo := filepath.Join(sudoersDir, "xpf-stale")
+	xpfGhostSudo := filepath.Join(sudoersDir, "xpf-ghost")
+	operatorSudo := filepath.Join(sudoersDir, "90-cloud-init-users")
+	mustWriteFile(t, xpfAliceSudo, []byte("alice ALL=(ALL) NOPASSWD: ALL\n"))
+	mustWriteFile(t, xpfStaleSudo, []byte("stale ALL=(ALL) NOPASSWD: ALL\n"))
+	mustWriteFile(t, xpfGhostSudo, []byte("ghost ALL=(ALL) NOPASSWD: ALL\n"))
+	mustWriteFile(t, operatorSudo, []byte("operator ALL=(ALL) ALL\n"))
+
+	// authorized_keys: alice (xpf → removed), ghost (gone → residue removed),
+	// operator (own account, no marker → MUST survive), stale (not ours → MUST
+	// survive: its home belongs to the recreated account).
+	aliceKeys := filepath.Join(homeBase, "alice", ".ssh", "authorized_keys")
+	ghostKeys := filepath.Join(homeBase, "ghost", ".ssh", "authorized_keys")
+	operatorKeys := filepath.Join(homeBase, "operator", ".ssh", "authorized_keys")
+	staleKeys := filepath.Join(homeBase, "stale", ".ssh", "authorized_keys")
+	mustWriteFile(t, aliceKeys, []byte("ssh-ed25519 AAAAxpf alice\n"))
+	mustWriteFile(t, ghostKeys, []byte("ssh-ed25519 AAAAghost ghost\n"))
+	mustWriteFile(t, operatorKeys, []byte("ssh-ed25519 AAAAop operator\n"))
+	mustWriteFile(t, staleKeys, []byte("ssh-ed25519 AAAAnew newowner\n"))
+
+	deleted := setZeroizeLoginPaths(t, provDir, sudoersDir, homeBase, passwdPath)
+
+	if err := zeroizeLoginAccounts(); err != nil {
+		t.Fatalf("zeroizeLoginAccounts returned error: %v", err)
+	}
+
+	// userdel fired for the exact xpf-provisioned account ONLY.
+	got := append([]string(nil), *deleted...)
+	sort.Strings(got)
+	if len(got) != 1 || got[0] != "alice" {
+		t.Errorf("userdel invoked for %v, want exactly [alice] (never stale/ghost/operator/root)", got)
+	}
+
+	// The fix: xpf login vectors are gone (RED on revert).
+	assertAbsent(t, aliceKeys)
+	assertAbsent(t, ghostKeys)
+	assertAbsent(t, xpfAliceSudo)
+	assertAbsent(t, xpfStaleSudo)
+	assertAbsent(t, xpfGhostSudo)
+	assertAbsent(t, aliceMarker)
+	assertAbsent(t, staleMarker)
+	assertAbsent(t, ghostMarker)
+
+	// Safety property: NON-xpf accounts + operator sudoers are untouched.
+	assertPresent(t, operatorKeys) // operator's own account (no marker)
+	assertPresent(t, staleKeys)    // UID-mismatch recreate (not ours)
+	assertPresent(t, operatorSudo) // operator/system drop-in (no xpf- prefix)
+
+	// The empty marker directory is cleaned up.
+	assertAbsent(t, provDir)
+}
+
+// TestZeroizeLoginAccountsSurfacesUserdelFailureAndKeepsMarker pins the
+// error-surfacing + retry contract: a userdel that fails must (a) surface the
+// FIRST error so the factory reset is not reported clean while a live login
+// account remains, and (b) RETAIN the provenance marker so a retried zeroize
+// re-attempts the removal. authorized_keys is still removed (best-effort
+// defense so the SSH vector dies even when userdel fails).
+func TestZeroizeLoginAccountsSurfacesUserdelFailureAndKeepsMarker(t *testing.T) {
+	root := t.TempDir()
+	provDir := filepath.Join(root, "provisioned-users")
+	sudoersDir := filepath.Join(root, "sudoers.d")
+	homeBase := filepath.Join(root, "home")
+	passwdPath := filepath.Join(root, "passwd")
+
+	mustWriteFile(t, passwdPath, []byte("bob:x:1500:1500:bob:/home/bob:/bin/bash\n"))
+	bobMarker := filepath.Join(provDir, "bob")
+	mustWriteFile(t, bobMarker, []byte("1500"))
+	bobKeys := filepath.Join(homeBase, "bob", ".ssh", "authorized_keys")
+	mustWriteFile(t, bobKeys, []byte("ssh-ed25519 AAAAbob bob\n"))
+	mustWriteFile(t, filepath.Join(sudoersDir, "xpf-bob"), []byte("bob ALL=(ALL) NOPASSWD: ALL\n"))
+
+	setZeroizeLoginPaths(t, provDir, sudoersDir, homeBase, passwdPath)
+	zeroizeUserdel = func(name string) ([]byte, error) {
+		return []byte("userdel: user bob is currently used by process 1234"),
+			errors.New("exit status 8")
+	}
+
+	err := zeroizeLoginAccounts()
+	if err == nil {
+		t.Fatalf("zeroizeLoginAccounts with a failing userdel returned nil; want the failure surfaced")
+	}
+
+	// authorized_keys removed even though userdel failed (defense in depth).
+	assertAbsent(t, bobKeys)
+	// sudoers grant removed by the namespace sweep regardless.
+	assertAbsent(t, filepath.Join(sudoersDir, "xpf-bob"))
+	// Marker RETAINED so a retried zeroize re-attempts the userdel.
+	if _, statErr := os.Stat(bobMarker); statErr != nil {
+		t.Errorf("expected the provenance marker %s to be RETAINED after a userdel failure, stat err = %v", bobMarker, statErr)
+	}
+}


### PR DESCRIPTION
## Closes #4598 (SECURITY, HIGH)

SECURITY follow-up to #4576/#4585 (from the #4595 hostile review). The OS **login accounts** xpf provisions survived a factory reset — arguably the biggest re-tenant leak of the three because they grant **interactive login + sudo**, not just a config-secret read.

### Problem
xpf provisions login accounts with material that all lives **outside** `/etc/xpf` and was untouched by zeroize:
- `/etc/shadow` password hashes (`reconcileUserPassword`)
- SSH `authorized_keys` under `/home/<user>/.ssh` (`applySystemLogin`)
- `/etc/sudoers.d/xpf-<user>` NOPASSWD grants (`reconcileSudoers`)

`applySystemLogin` runs only inside the boot-time `applyConfig`, which a post-zeroize boot **SKIPS** (bootstrap / nil active config — the same boot-skip #4585 documents), and even a full reconcile early-returns on an empty config and never `userdel`s. So a re-tenanted / RMA'd / resold device still carried the prior tenant's login accounts, SSH keys, and passwordless sudo.

### Fix
`performZeroizeWipe` now calls `zeroizeLoginAccounts` after the #4585 rendered-config erasure, folding its first error into the surfaced result exactly like #4576/#4585 (`codes.Internal` at the RPC boundary; a partial teardown is never reported as a clean factory reset). The teardown is **marker-aware**, keyed on the #1944 UID-keyed provenance marker (`/var/lib/xpf/provisioned-users/<user>`, content = the account UID at provision time):

- **(A)** Sweep the whole `/etc/sudoers.d/xpf-*` namespace unconditionally (nothing is desired at factory reset), so no passwordless-root grant survives even if a marker is missing. Operator-authored drop-ins without the `xpf-` prefix are left untouched.
- **(B)** For each marker, `userdel -r` **only** when the current `/etc/passwd` UID still equals the recorded UID. `authorized_keys` is removed **before** `userdel` so the SSH-key vector dies even if `userdel` fails; on a `userdel` failure the marker is **retained** so a retried zeroize re-attempts, and the error is surfaced.

### Never-touch safety invariant
- An operator's **own account** (no marker) is never iterated.
- **root and system accounts** (no marker) are never touched — the console/root lifeline survives the wipe (critical on bare metal).
- An **out-of-band `userdel`+recreate** with a different UID (marker mismatch) is left alone — the #1944 leave-then-rejoin vs recreate distinction.

`pkg/grpcapi` cannot import `pkg/daemon` (`daemon_run.go` imports grpcapi → import cycle), so the production paths are mirrored as test-injectable package vars plus a `zeroizeUserdel` seam.

### Validation
- **RED-on-revert** test (`zeroize_login_4598_test.go`) proven against a neutered function body: the removal / userdel-called / error-surfacing assertions fail while the never-touch-non-xpf `assertPresent` safety checks stay green (operator keys, UID-mismatch home, non-xpf sudoers all preserved; `userdel` fires for the one matching account only).
- A second test pins the `userdel`-failure error-surfacing + marker-retention contract.
- `go build ./...` + `go vet ./pkg/grpcapi/` + full `pkg/grpcapi` suite green; `gofmt` clean.
- Docs: `docs/system-login.md` gains the #4598 login-account teardown + never-touch safety subsection.

> HIGH security + `userdel -r` is destructive — reviewers should scrutinize the marker/UID gating (the only thing standing between the wipe and a wrong-account nuke) and the root/console lifeline preservation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi