### PR TITLE
config: reject master-password PRF typos at commit (scoped closed-world)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -40626,3 +40626,23 @@ top.
 - **File(s)**: pkg/config/schema_routing.go,
   pkg/config/schema_lldp_ttl_4596_test.go, pkg/lldp/lldp.go,
   pkg/lldp/lldp_test.go, docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-07 (#4578)
+- **Action**: `system master-password pseudorandom-function <fn>` typo silently
+  disabled at-rest config encryption. `configstore.masterPasswordPRF` reads the
+  raw AST; because `system` is open-world (#4515/X-1) a KEYWORD typo
+  (`pseudo-random-fnuction`) committed clean → no `pseudorandom-function` child
+  → fell through to the empty default → encryption silently OFF. Scoped fix
+  (NOT a blanket `system` closed-world, which would false-reject unmodeled
+  leaves, #4191 class): flipped `master-password` to `closedWorld: true` (#4313
+  mechanism; leaf-complete — xpf models/consumes only `pseudorandom-function`)
+  so the keyword typo is rejected at commit, AND enum-validated the value slot
+  (`ValidateMasterPasswordPRF` against `MasterPasswordPRFNames`, case-insensitive
+  mirror of `configstore.prfHash`) so a VALUE typo (`bogus-prf`) is caught too.
+  RED-on-revert tests confirmed for BOTH guards; valid selectors + the
+  default-unset case still commit. A configstore drift test asserts prfHash
+  honours every advertised name.
+- **File(s)**: pkg/config/schema_system.go, pkg/config/schema_validators.go,
+  pkg/config/schema_master_password_prf_4578_test.go, pkg/configstore/crypto.go,
+  pkg/configstore/crypto_prf_sync_4578_test.go, docs/config-schema.md,
+  docs/next-features/master-password.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -854,6 +854,33 @@ only on the strict commit path; `compileTreeLenient` downgrades it to a warning
 on `Store.Load` / `SyncApply`. Production tests:
 `schema_closedworld_ipsec_4313_test.go` (RED on revert of each flag).
 
+**More production flips — `system master-password` (#4578).** The
+`system master-password` subtree now sets `closedWorld:true`
+(`schema_system.go`) after the same leaf-completeness audit: xpf models AND
+consumes exactly one leaf, `pseudorandom-function` (the configstore
+at-rest-encryption PRF selector, read raw from the AST by
+`configstore.masterPasswordPRF`). Because `system` is open-world (#4515/X-1), a
+typo in the KEYWORD (`pseudo-random-fnuction`) previously committed clean —
+`masterPasswordPRF` then found no `pseudorandom-function` child, fell through to
+its empty default, and **at-rest config encryption was silently OFF** while the
+operator believed it was on. The flip rejects the keyword typo at strict commit.
+Paired with it, the `pseudorandom-function` value slot is now enum-validated
+(`ValidateMasterPasswordPRF`, `schema_validators.go`) against the exact selector
+set `configstore.prfHash` understands (`MasterPasswordPRFNames`, matched
+case-insensitively because prfHash lower-cases), so a typo in the VALUE
+(`bogus-prf`, or `hmac-sha256` missing the `2-`) is caught too rather than
+falling through prfHash's default and failing the persisted-tree write with an
+opaque error. This is deliberately SCOPED to the master-password subtree — the
+broader `system` open-world remediation (#4515/X-1) is untouched, because a
+blanket `system` closed-world would false-reject valid-but-unmodeled leaves (the
+#4191 class). A `pkg/configstore` drift test (`crypto_prf_sync_4578_test.go`)
+asserts `prfHash` honours every name the commit gate advertises, so the gate and
+the encrypt path cannot silently diverge. Production tests:
+`schema_master_password_prf_4578_test.go` (RED on revert of the closedWorld flag
+AND the value validator). As with the other flips, the reject fires only on the
+strict commit path; `compileTreeLenient` downgrades it to a warning on
+`Store.Load` / `SyncApply`.
+
 **Remaining per-subtree flips (future PRs, tracked on #4313).** Turning
 `closedWorld` on for the other umbrella candidates (`snmp community` — INCOMPLETE:
 Junos allows `view` / `client-list-name` / `routing-instance`, unmodeled;

--- a/docs/next-features/master-password.md
+++ b/docs/next-features/master-password.md
@@ -24,3 +24,25 @@ Before this change, configuration accepted `master-password` with no runtime eff
 - Configured master-password has a clear runtime effect.
 - No secret/plaintext leakage in logs, config diffs, or telemetry.
 - Unit/integration tests cover config parse, storage, and reload behavior.
+
+## Commit-time validation (#4578)
+`system master-password` is the encryption policy knob, so a typo must FAIL the
+commit rather than silently disable encryption. Two scoped guards enforce this
+(both on the strict commit path; downgraded to warnings on tolerant Load /
+SyncApply):
+
+- The `master-password` subtree is closed-world (`schemaNode.closedWorld`,
+  #4313 mechanism; `pkg/config/schema_system.go`). It is leaf-complete — xpf
+  models and consumes exactly one leaf, `pseudorandom-function` — so a typo in
+  the KEYWORD (`pseudo-random-fnuction`) is rejected instead of committing clean
+  and letting `configstore.masterPasswordPRF` fall through to its empty default
+  (encryption silently OFF).
+- The `pseudorandom-function` value slot is enum-validated
+  (`config.ValidateMasterPasswordPRF` against `config.MasterPasswordPRFNames`,
+  matched case-insensitively) so an unknown PRF selector VALUE is rejected. The
+  name set mirrors `configstore.prfHash` (the SSOT for the name→hash mapping);
+  `pkg/configstore/crypto_prf_sync_4578_test.go` drift-guards the two.
+
+This is scoped strictly to the master-password subtree — the broader `system`
+open-world schema behaviour (#4515/X-1) is intentionally left as-is, because a
+blanket `system` closed-world would false-reject valid-but-unmodeled leaves.

--- a/pkg/config/schema_master_password_prf_4578_test.go
+++ b/pkg/config/schema_master_password_prf_4578_test.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4578 — master-password pseudorandom-function typo must FAIL COMMIT.
+//
+// configstore.masterPasswordPRF reads the raw AST for `system master-password
+// pseudorandom-function <fn>` and, when it finds the leaf, uses the value to
+// derive an at-rest encryption key for the persisted config trees. Because the
+// `system` subtree is open-world (#4515/X-1), a typo previously committed
+// clean:
+//
+//   - a typo in the KEYWORD (`pseudo-random-fnuction`) meant masterPasswordPRF
+//     found no `pseudorandom-function` child and fell through to its empty
+//     default → at-rest encryption silently OFF; or
+//   - a typo in the VALUE (`bogus-prf`) fell through configstore.prfHash's
+//     default and failed the persisted-tree write with an opaque error.
+//
+// The fix is scoped strictly to this subtree: master-password is now
+// closed-world (rejects the keyword typo) and pseudorandom-function is
+// enum-validated (rejects the value typo). Both fire on the strict commit path
+// (SchemaValidate). These tests use the production ParseSetCommand + SetPath +
+// SchemaValidate path (buildTree). Each rejection is RED on revert of the
+// respective flag/validator.
+
+// TestMasterPasswordPRF_RejectsKeywordTypo is the primary RED-on-revert
+// discriminator: a misspelled KEYWORD under the closed-world master-password
+// subtree is rejected at commit. On revert of closedWorld the same input is
+// silently accepted (SchemaValidate returns nil) and encryption is silently
+// disabled — the #4578 bug.
+func TestMasterPasswordPRF_RejectsKeywordTypo(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set system master-password pseudo-random-fnuction juniper-prf1",
+	})
+	err := SchemaValidate(tree, nil)
+	if err == nil {
+		t.Fatal("a typo'd master-password keyword must be rejected at commit " +
+			"(RED on revert: silently accepted → at-rest encryption silently OFF)")
+	}
+	if !strings.Contains(err.Error(), "pseudo-random-fnuction") || !strings.Contains(err.Error(), "closed-world") {
+		t.Fatalf("error must name the typo'd keyword and the closed-world subtree, got: %v", err)
+	}
+}
+
+// TestMasterPasswordPRF_RejectsBadValue covers the value-slot gate: a
+// pseudorandom-function selector configstore.prfHash does not understand is
+// rejected at commit. RED on revert of the ValidateMasterPasswordPRF validator.
+func TestMasterPasswordPRF_RejectsBadValue(t *testing.T) {
+	for _, bad := range []string{"bogus-prf", "hmac-sha256", "sha255"} {
+		tree := buildTree(t, []string{
+			"set system master-password pseudorandom-function " + bad,
+		})
+		err := SchemaValidate(tree, nil)
+		if err == nil {
+			t.Fatalf("an unknown pseudorandom-function %q must be rejected at commit "+
+				"(RED on revert: silently accepted → wrong/absent encryption)", bad)
+		}
+		if !strings.Contains(err.Error(), bad) {
+			t.Fatalf("error must name the bad value %q, got: %v", bad, err)
+		}
+	}
+}
+
+// TestMasterPasswordPRF_AcceptsValidSelectors proves no false-reject: every
+// selector configstore.prfHash understands still commits clean AND compiles to
+// the expected MasterPassword value. Case-insensitivity is exercised too
+// (prfHash lower-cases before matching, so the commit gate must not reject a
+// spelling the runtime accepts).
+func TestMasterPasswordPRF_AcceptsValidSelectors(t *testing.T) {
+	cases := append(append([]string(nil), MasterPasswordPRFNames...), "HMAC-SHA2-256", "Sha512")
+	for _, sel := range cases {
+		tree := buildTree(t, []string{
+			"set system master-password pseudorandom-function " + sel,
+		})
+		if err := SchemaValidate(tree, nil); err != nil {
+			t.Fatalf("valid pseudorandom-function %q must commit clean, got: %v", sel, err)
+		}
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("compile %q: %v", sel, err)
+		}
+		if cfg.System.MasterPassword != sel {
+			t.Fatalf("compiled MasterPassword = %q, want %q", cfg.System.MasterPassword, sel)
+		}
+	}
+}
+
+// TestMasterPasswordPRF_DefaultUnsetStillCommits guards the intentional
+// default: a config with NO master-password stanza (encryption off by default)
+// and a config that names master-password with a valid PRF must both commit —
+// the closed-world flip must not turn "no master-password" into an error.
+func TestMasterPasswordPRF_DefaultUnsetStillCommits(t *testing.T) {
+	// No master-password at all.
+	noStanza := buildTree(t, []string{
+		"set system host-name fw0",
+	})
+	if err := SchemaValidate(noStanza, nil); err != nil {
+		t.Fatalf("a config with no master-password must commit clean (encryption off by default), got: %v", err)
+	}
+
+	// master-password present with a valid PRF.
+	withPRF := buildTree(t, []string{
+		"set system master-password pseudorandom-function juniper-prf1",
+	})
+	if err := SchemaValidate(withPRF, nil); err != nil {
+		t.Fatalf("a valid master-password config must commit clean, got: %v", err)
+	}
+}
+
+// TestValidateMasterPasswordPRF_Unit locks the validator's accept/reject set at
+// the unit level (independent of the schema wiring).
+func TestValidateMasterPasswordPRF_Unit(t *testing.T) {
+	for _, name := range MasterPasswordPRFNames {
+		if err := ValidateMasterPasswordPRF(name, nil); err != nil {
+			t.Errorf("ValidateMasterPasswordPRF(%q) = %v, want nil", name, err)
+		}
+	}
+	for _, bad := range []string{"", "hmac-sha256", "bogus", "prf1"} {
+		if err := ValidateMasterPasswordPRF(bad, nil); err == nil {
+			t.Errorf("ValidateMasterPasswordPRF(%q) = nil, want error", bad)
+		}
+	}
+}

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -110,8 +110,23 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 			"archive-sites": {desc: "Archive site URL", args: 1, multi: true, placeholder: "<url>", children: nil},
 		}},
 	}},
-	"master-password": {desc: "Master password", children: map[string]*schemaNode{
-		"pseudorandom-function": {desc: "Pseudorandom function", args: 1, placeholder: "<function>", children: nil},
+	// #4578: master-password is the configstore at-rest-encryption policy
+	// knob (configstore.masterPasswordPRF reads the raw AST). The subtree is
+	// closed-world (#4313 mechanism) AND leaf-complete — xpf models and
+	// consumes exactly one leaf, `pseudorandom-function` — so a typo in the
+	// KEYWORD (`pseudo-random-fnuction`) is rejected at commit instead of
+	// committing clean and silently DISABLING encryption (masterPasswordPRF
+	// would find no `pseudorandom-function` child and fall through to its empty
+	// default). The value slot is enum-validated so a typo in the PRF VALUE
+	// (`bogus-prf`) is caught too. Scoped strictly to this subtree — the
+	// broader `system` open-world behaviour (#4515/X-1) is untouched.
+	"master-password": {desc: "Master password", closedWorld: true, children: map[string]*schemaNode{
+		"pseudorandom-function": {desc: "Pseudorandom function", args: 1, placeholder: "<function>",
+			valueType:     ValueEnumOf,
+			valueDesc:     "Master-password key-derivation PRF selector (configstore.prfHash)",
+			valueExamples: []string{"hmac-sha2-256", "sha256", "juniper-prf1"},
+			validator:     ValidateMasterPasswordPRF,
+			children:      nil},
 	}},
 	"license": {desc: "License configuration", children: map[string]*schemaNode{
 		"autoupdate": {desc: "Autoupdate", children: map[string]*schemaNode{

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -43,6 +43,49 @@ func ValidateEnum(allowed []string) LeafValidator {
 	}
 }
 
+// MasterPasswordPRFNames is the set of `system master-password
+// pseudorandom-function <fn>` selector names the configstore key-derivation
+// (configstore.prfHash) understands. prfHash is the SSOT for the
+// name->hash.Hash mapping; this list mirrors only the accepted NAMES so a
+// commit-time typo is caught before it reaches the encrypt path (#4578). Keep
+// the two in sync — a name added to prfHash must be added here. It is exported
+// so a configstore test can drift-guard it against prfHash across the package
+// boundary (config→configstore would be an import cycle, so the guard lives on
+// the configstore side).
+//
+// configstore.prfHash lower-cases its input before matching, so
+// ValidateMasterPasswordPRF matches case-insensitively too: any spelling the
+// runtime would accept commits, and only a genuine typo/unknown selector is
+// rejected.
+var MasterPasswordPRFNames = []string{
+	"juniper-prf1",
+	"hmac-sha2-256", "sha256",
+	"hmac-sha2-384", "sha384",
+	"hmac-sha2-512", "sha512",
+	"hmac-sha1", "sha1",
+}
+
+// ValidateMasterPasswordPRF accepts only a pseudorandom-function selector the
+// configstore master-password key-derivation understands
+// (configstore.prfHash), matched case-insensitively. Without this gate a
+// typo'd selector (e.g. "hmac-sha256" missing the "2-", or "bugus-prf") is
+// accepted open-world, then falls through configstore.masterPasswordPRF's
+// default and silently DISABLES at-rest config encryption — or fails the
+// persisted-tree write with an opaque error. Rejecting it at commit turns a
+// silent security downgrade into a clear commit error (#4578). Pairs with the
+// closedWorld flag on the master-password subtree (schema_system.go), which
+// catches a typo in the KEYWORD (`pseudo-random-fnuction`) rather than the
+// value.
+func ValidateMasterPasswordPRF(raw string, _ *Config) error {
+	lower := strings.ToLower(strings.TrimSpace(raw))
+	for _, name := range MasterPasswordPRFNames {
+		if lower == name {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid pseudorandom-function %q (expected one of: %s)", raw, strings.Join(MasterPasswordPRFNames, ", "))
+}
+
 // ValidateIntegerMin returns a closure that accepts any bare integer
 // >= min — the "no upper bound" spelling for typed leaves whose runtime
 // consumes the full integer range. The representational maximum is

--- a/pkg/configstore/crypto.go
+++ b/pkg/configstore/crypto.go
@@ -195,6 +195,13 @@ func deriveEncryptionKeyFromSalt(keyMaterial []byte, prf string, salt []byte) ([
 	return key, nil
 }
 
+// prfHash maps a master-password pseudorandom-function selector name to its
+// hash constructor. It is the SSOT for the name->hash.Hash mapping; the
+// accepted NAMES are mirrored in config.masterPasswordPRFNames, which the
+// commit-time gate (config.ValidateMasterPasswordPRF, #4578) uses to reject a
+// typo'd selector BEFORE it reaches this path. Adding a case here means adding
+// the name there too. Matching is case-insensitive (the commit gate mirrors
+// this ToLower).
 func prfHash(prf string) (func() hash.Hash, error) {
 	switch strings.ToLower(prf) {
 	case "juniper-prf1", "hmac-sha2-256", "sha256":

--- a/pkg/configstore/crypto_prf_sync_4578_test.go
+++ b/pkg/configstore/crypto_prf_sync_4578_test.go
@@ -1,0 +1,28 @@
+package configstore
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #4578 drift guard: the commit-time gate config.ValidateMasterPasswordPRF
+// mirrors the NAME set that prfHash (the SSOT for the name->hash.Hash mapping)
+// accepts. If a selector is added to prfHash but not to
+// config.MasterPasswordPRFNames, that selector would be rejected at commit yet
+// work at runtime; if removed from prfHash but left in the list, a commit would
+// accept a selector the encrypt path then fails on. This test fails on either
+// drift by asserting every advertised name is honoured by prfHash.
+func TestPRFHashAcceptsAdvertisedNames(t *testing.T) {
+	for _, name := range config.MasterPasswordPRFNames {
+		if _, err := prfHash(name); err != nil {
+			t.Errorf("prfHash(%q) = %v, want nil — config.MasterPasswordPRFNames advertises "+
+				"a selector prfHash does not accept (the commit gate and the encrypt path drifted)", name, err)
+		}
+	}
+	// A selector the gate rejects must also fail prfHash (no silent runtime
+	// path around the gate).
+	if _, err := prfHash("hmac-sha256"); err == nil {
+		t.Error("prfHash accepted \"hmac-sha256\" but config.ValidateMasterPasswordPRF rejects it — drift")
+	}
+}


### PR DESCRIPTION
## Summary

`system master-password pseudorandom-function <fn>` is the configstore at-rest-encryption policy knob — `configstore.masterPasswordPRF` reads it straight off the candidate AST and, when present, derives the AES-GCM key that encrypts the persisted active/candidate/rollback config trees. Because the `system` subtree is **open-world** (#4515/X-1), a typo committed clean and silently degraded that security posture:

- a typo in the **KEYWORD** (`pseudo-random-fnuction`) left `masterPasswordPRF` with no `pseudorandom-function` child → it fell through to its empty default → **at-rest encryption was silently OFF** while the operator believed it was on;
- a typo in the **VALUE** (`bogus-prf`, or `hmac-sha256` missing the `2-`) fell through `configstore.prfHash`'s default and failed the persisted-tree write with an opaque error.

## Fix (scoped to the master-password subtree)

This is deliberately **not** a blanket `system` closed-world — that would false-reject valid-but-unmodeled leaves (the #4191 class that keeps #4515 deferred). Two narrow guards:

- **`master-password` → `closedWorld: true`** (the #4313 per-subtree mechanism). The subtree is leaf-complete (xpf models/consumes exactly one leaf, `pseudorandom-function`), so a keyword typo is rejected at strict commit instead of committing clean and being silently dropped.
- **`pseudorandom-function` value slot enum-validated** (`ValidateMasterPasswordPRF` against `MasterPasswordPRFNames`, the exact selector set `configstore.prfHash` understands, matched case-insensitively — prfHash lower-cases before matching, so any spelling the runtime accepts still commits).

`prfHash` stays the SSOT for the name→hash mapping; the exported name list mirrors it, and a new `pkg/configstore` drift test asserts prfHash honours every name the commit gate advertises, so the gate and the encrypt path cannot silently diverge.

Both guards fire only on the strict commit path; `compileTreeLenient` downgrades them to warnings on `Store.Load` / `SyncApply`, matching the existing typed-leaf-gate doctrine.

## Valid PRF selectors (mirrors `configstore.prfHash`)

`juniper-prf1`, `hmac-sha2-256`, `sha256`, `hmac-sha2-384`, `sha384`, `hmac-sha2-512`, `sha512`, `hmac-sha1`, `sha1` (case-insensitive).

## Validation

- **RED-on-revert confirmed for BOTH guards**: the keyword-typo test fails without `closedWorld`; the bad-value test fails without the validator.
- Every valid selector + case-insensitive spellings commit and compile to the expected `MasterPassword` value.
- A config with **no** master-password (encryption off by default) still commits.
- `go test ./pkg/config/... ./pkg/configstore/...` green; `go build ./...`, `gofmt`, `go vet` clean.

Closes #4578

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi