### PR TITLE
configstore: A4 LOW hardening (journal 0600 + plaintext-downgrade warn) — Closes #4579

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -40626,3 +40626,30 @@ top.
 - **File(s)**: pkg/config/schema_routing.go,
   pkg/config/schema_lldp_ttl_4596_test.go, pkg/lldp/lldp.go,
   pkg/lldp/lldp_test.go, docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-07 (#4579 A4-02 / A4-06 driven; A4-05 skipped)
+- **Action**: configstore A4 LOW hardening batch (ps-037-A4). A4-02:
+  tightened the audit journal `.config.journal` from world-readable 0644
+  to owner-only 0600 (`journal/journal.go Log`). The journal is
+  metadata-only, but its `Detail` field carries the operator's free-text
+  commit comment verbatim (a comment can name a credential), so it now
+  matches the 0600 posture of the rest of the config surface (#4056);
+  folded into the #4056 secret-sweep test. A4-06: added a one-time
+  `slog.Warn` in `db.go readTreeMeta` when a stored config is read back as
+  UNENCRYPTED plaintext while its tree still declares a `master-password`
+  — a downgrade / unencrypted-restore / tamper signal that would otherwise
+  load cleartext secrets silently. `maybeDecryptTreeJSON` now returns a
+  `decrypted bool`; the two call sites were updated. A4-05 (bind the GCM
+  envelope header as AAD) was SKIPPED: the scheme already fails closed on
+  any header swap (HKDF binds PRF+salt → wrong key → tag failure), and
+  switching from nil AAD to a bound AAD is a ciphertext-format change that
+  would fail to `Open` an `active.json` sealed by an older build →
+  upgrade-brick. Non-exploitable gap does not justify the brick risk.
+  RED-on-revert: journal test fails at 0644; plaintext-downgrade test
+  fails with the warn neutralized. Negative controls (encrypted
+  round-trip, plaintext-without-master-password) stay silent. go test
+  ./pkg/configstore/... green; go build ./... green; gofmt+vet clean.
+- **File(s)**: pkg/configstore/journal/journal.go, pkg/configstore/crypto.go,
+  pkg/configstore/db.go, pkg/configstore/file_perms_4056_test.go,
+  pkg/configstore/plaintext_downgrade_warn_4579_test.go,
+  pkg/configstore/README.md, _Log.md

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -124,6 +124,30 @@ inline archive-site passwords).
   configstore directory. The "master-password" naming is an HKDF
   info string only — it isn't a user-supplied password.
 
+### At-rest crypto hardening notes (#4579 A4-05/A4-06)
+
+- **Unexpected-plaintext warning (A4-06).** Every write path encrypts the
+  body when the tree declares a master-password, so `readTreeMeta` reading
+  a config back as *plaintext* while its tree still declares a
+  master-password means the file was written without the AES-GCM envelope
+  — a downgrade to an older build, a restore from an unencrypted backup, or
+  tampering. `maybeDecryptTreeJSON` reports whether it actually decrypted;
+  `readTreeMeta` logs a one-time `slog.Warn` on the plaintext-with-declared-
+  master-password case so the silent at-rest exposure is visible instead of
+  loading the cleartext secrets without a trace. Reaching that state needs
+  write access to the 0600/0700 `.configdb` (root/owner), so this is a
+  visibility improvement, not a privilege-escalation fix.
+- **GCM AAD binding (A4-05) — deliberately NOT changed.** `Seal`/`Open` pass
+  a nil additional-authenticated-data argument. Binding the envelope header
+  (PRF/salt) as AAD is textbook defense-in-depth, but the scheme already
+  fails *closed* on any header swap: the key is HKDF-derived from the PRF
+  and the stored salt, so tampering with either yields the wrong key and
+  `Open` fails the GCM tag anyway. More importantly, switching to a non-nil
+  AAD is a **ciphertext-format change**: an `active.json` sealed by an older
+  build with nil AAD would fail to open after the change (the tag no longer
+  matches), bricking decryption on upgrade. The non-exploitable gap does not
+  justify an upgrade-brick risk, so the nil AAD is retained.
+
 ## Callers
 
 `pkg/daemon`, `pkg/cli`, `pkg/grpcapi`, `pkg/api`.

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -35,12 +35,19 @@ re-created 0600 on the next commit.
 | Text rollback slots | `<config>.N` (e.g. `xpf.conf.1`) | 0600 | `store_commit.go saveRollbackFiles` |
 | Rescue config | `rescue.conf` | 0600 | `store_persist.go SaveRescueConfig` |
 | Config archives | `<archive-dir>/config-*.conf` | 0600 | `store_persist.go writeArchive` |
+| Audit journal (#4579 A4-02) | `.config.journal` | 0600 | `journal/journal.go Log` |
 
 The `.configdb` and archive directories are created **0700** (they hold
 only secret-bearing files); the daemon owns them, so read-back is
-unaffected. The v2 audit journal (`.config.journal`) stays 0644 by
-design — it is compact metadata only (timestamp/action/detail), never
-config content or secret values (#1896).
+unaffected. The v2 audit journal (`.config.journal`) is compact metadata
+only (timestamp/action/config-hash) and never config content or secret
+values (#1896), so it is not a secret store the way the JSON DB is.
+It is nevertheless written **0600** (#4579 A4-02): its `Detail` field
+carries the operator's free-text commit comment verbatim, so a comment
+that names a credential ("rotated the vpn psk to …") would otherwise be
+world-readable. Tightening it to match the rest of the config surface is
+cheap defense-in-depth; the daemon owns the file, so the history tail
+read is unaffected.
 
 ### Threat model — what 0600 + 0700 defends, and what it does not (#4056)
 

--- a/pkg/configstore/crypto.go
+++ b/pkg/configstore/crypto.go
@@ -106,49 +106,55 @@ func (db *DB) maybeEncryptTreeJSON(data []byte, tree *config.ConfigTree) ([]byte
 	return marshalEnvelope(env)
 }
 
-func (db *DB) maybeDecryptTreeJSON(data []byte) ([]byte, error) {
+// maybeDecryptTreeJSON returns the plaintext body of a stored config.
+// The second return value reports whether the input was an AES-GCM
+// envelope that was actually decrypted (true) or was passed through as
+// plaintext because it carried no envelope (false). Callers that know
+// the config declares a master-password use the flag to detect an
+// unexpected plaintext downgrade (#4579 A4-06).
+func (db *DB) maybeDecryptTreeJSON(data []byte) ([]byte, bool, error) {
 	env, ok, err := unmarshalEnvelope(data)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if !ok {
-		return data, nil
+		return data, false, nil
 	}
 
 	keyMaterial, err := db.readMasterKey()
 	if err != nil {
-		return nil, fmt.Errorf("encrypted config but master key unavailable: %w", err)
+		return nil, false, fmt.Errorf("encrypted config but master key unavailable: %w", err)
 	}
 	salt, err := base64.StdEncoding.DecodeString(env.Salt)
 	if err != nil {
-		return nil, fmt.Errorf("decode salt: %w", err)
+		return nil, false, fmt.Errorf("decode salt: %w", err)
 	}
 	key, err := deriveEncryptionKeyFromSalt(keyMaterial, env.PRF, salt)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	nonce, err := base64.StdEncoding.DecodeString(env.Nonce)
 	if err != nil {
-		return nil, fmt.Errorf("decode nonce: %w", err)
+		return nil, false, fmt.Errorf("decode nonce: %w", err)
 	}
 	ciphertext, err := base64.StdEncoding.DecodeString(env.Data)
 	if err != nil {
-		return nil, fmt.Errorf("decode ciphertext: %w", err)
+		return nil, false, fmt.Errorf("decode ciphertext: %w", err)
 	}
 
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, fmt.Errorf("create cipher: %w", err)
+		return nil, false, fmt.Errorf("create cipher: %w", err)
 	}
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
-		return nil, fmt.Errorf("create GCM: %w", err)
+		return nil, false, fmt.Errorf("create GCM: %w", err)
 	}
 	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
-		return nil, fmt.Errorf("decrypt config tree: %w", err)
+		return nil, false, fmt.Errorf("decrypt config tree: %w", err)
 	}
-	return plaintext, nil
+	return plaintext, true, nil
 }
 
 func marshalEnvelope(env encryptedTreeEnvelope) ([]byte, error) {

--- a/pkg/configstore/db.go
+++ b/pkg/configstore/db.go
@@ -4,6 +4,7 @@ package configstore
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"time"
@@ -217,7 +218,7 @@ func (db *DB) ReadConfirm() (*confirmRecord, error) {
 		}
 		return nil, fmt.Errorf("read confirm state: %w", err)
 	}
-	data, err = db.maybeDecryptTreeJSON(data)
+	data, _, err = db.maybeDecryptTreeJSON(data)
 	if err != nil {
 		return nil, fmt.Errorf("decrypt confirm state: %w", err)
 	}
@@ -266,7 +267,7 @@ func (db *DB) readTreeMeta(path string) (*config.ConfigTree, bool, error) {
 		committed = hdr.Committed
 	}
 
-	data, err = db.maybeDecryptTreeJSON(data)
+	data, decrypted, err := db.maybeDecryptTreeJSON(data)
 	if err != nil {
 		return nil, true, fmt.Errorf("decrypt %s: %w", path, err)
 	}
@@ -274,6 +275,25 @@ func (db *DB) readTreeMeta(path string) (*config.ConfigTree, bool, error) {
 	tree := &config.ConfigTree{}
 	if err := json.Unmarshal(data, tree); err != nil {
 		return nil, true, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	// Unexpected-plaintext warning (#4579 A4-06). When master-password is
+	// set, every write path encrypts the body (maybeEncryptTreeJSON keyed
+	// off the tree's master-password leaf), so a config that DECLARES a
+	// master-password should never be read back as plaintext. If it is,
+	// the file was written without the AES-GCM envelope — a downgrade to
+	// an older build, a restore from an unencrypted backup, or tampering.
+	// Reaching this state needs write access to the 0600/0700 .configdb
+	// (root/owner), so it is not a privilege-escalation vector; the warn
+	// makes the silent at-rest exposure visible instead of loading the
+	// cleartext secrets without a trace. Boot-time / commit-paced read, so
+	// a one-time slog.Warn is safe (never in a per-packet/-session loop).
+	if !decrypted && masterPasswordPRF(tree) != "" {
+		slog.Warn("configuration declares a master-password but was read as "+
+			"UNENCRYPTED plaintext (expected an AES-GCM envelope) — the config "+
+			"may have been downgraded, restored from an unencrypted backup, or "+
+			"tampered with; secrets are exposed at rest",
+			"path", path, "issue", "#4579")
 	}
 	return tree, committed, nil
 }

--- a/pkg/configstore/file_perms_4056_test.go
+++ b/pkg/configstore/file_perms_4056_test.go
@@ -155,6 +155,40 @@ func TestRescueConfigOwnerOnly_4056(t *testing.T) {
 	}
 }
 
+// TestConfigJournalOwnerOnly_4579 pins that the commit audit journal
+// (.config.journal) is written owner-only 0600 (#4579 A4-02, folding it into
+// the #4056 secret-sweep). The journal records metadata (timestamps, actions,
+// config hashes), but Detail carries the operator's free-text commit comment
+// verbatim — which can inadvertently name a credential — so it matches the
+// 0600 posture of the rest of the config surface rather than sitting
+// world-readable.
+//
+// RED on revert: journal.Log opens the file 0644 (world-readable), so
+// assertOwnerOnlyFile fails.
+func TestConfigJournalOwnerOnly_4579(t *testing.T) {
+	s := newTestStore(t)
+	// A commit writes an audit record to .config.journal (journalLog on the
+	// commit path). Use a commit comment so Detail is non-empty — the field
+	// whose free-text content motivates the 0600 tightening.
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := s.SetFromInput("system host-name journal-perms-4579"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := s.CommitWithDescription("rotated the site psk"); err != nil {
+		t.Fatalf("CommitWithDescription: %v", err)
+	}
+
+	journalPath := filepath.Join(filepath.Dir(s.filePath), ".config.journal")
+	assertOwnerOnlyFile(t, journalPath)
+
+	// Owner can still tail the journal at 0600 (the history view reads it).
+	if _, err := os.ReadFile(journalPath); err != nil {
+		t.Fatalf("owner cannot read back 0600 journal: %v", err)
+	}
+}
+
 // TestArchiveOwnerOnly_4056 pins that a config archive file (config-*.conf,
 // full config text with cleartext secrets) is written 0600 and its directory
 // 0700.

--- a/pkg/configstore/journal/journal.go
+++ b/pkg/configstore/journal/journal.go
@@ -10,9 +10,14 @@
 // Detail, and full config trees already live in the rollback slots with
 // explicit retention.
 //
-// v2 entries are compact metadata only. Reads are reverse tail scans
-// bounded by the requested limit; the file rotates by size with a
-// keep-N segment policy; appends are fsynced (operator-paced — the
+// v2 entries are compact metadata only and the file is written
+// owner-only 0600 (#4579 A4-02): although the metadata is not itself a
+// secret store, Detail carries the operator's free-text commit comment
+// verbatim, so the journal matches the 0600 posture of the rest of the
+// config surface (#4056) instead of sitting world-readable. Reads are
+// reverse tail scans bounded by the requested limit; the file rotates
+// by size with a keep-N segment policy; appends are fsynced
+// (operator-paced — the
 // commit path already pays several fsyncs for active.json and rollback
 // slot 1, see #1894). Legacy fat v1 lines decode tolerantly (unknown
 // JSON fields are ignored), and the first append after upgrade rotates
@@ -177,7 +182,18 @@ func (j *Journal) Log(entry *Entry) error {
 
 	// O_RDWR (not O_WRONLY): the torn-tail check below reads the
 	// last byte through the same fd.
-	f, err := os.OpenFile(j.path, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
+	//
+	// Owner-only 0600 (#4579 A4-02): v2 entries are metadata only
+	// (Timestamp/Action/ConfigHash plus a free-text Detail), so the
+	// journal is not a secret store the way active.json is. But Detail
+	// carries the operator-supplied commit comment verbatim, and an
+	// operator can put anything there — including, by mistake, a
+	// credential ("rotated the vpn psk to hunter2"). The rest of the
+	// .configdb-adjacent config surface is already 0600 (#4056); the
+	// journal is written next to it and should match rather than sit
+	// world-readable as a defense-in-depth gap. The daemon owns the file,
+	// so 0600 does not affect append or tail read-back.
+	f, err := os.OpenFile(j.path, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
 		return fmt.Errorf("open journal: %w", err)
 	}

--- a/pkg/configstore/plaintext_downgrade_warn_4579_test.go
+++ b/pkg/configstore/plaintext_downgrade_warn_4579_test.go
@@ -1,0 +1,134 @@
+package configstore
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/fsatomic"
+)
+
+// masterPwTree builds the minimal config tree that declares a
+// master-password pseudorandom-function — the leaf masterPasswordPRF
+// (crypto.go) reads to decide whether a stored config must be encrypted.
+func masterPwTree() *config.ConfigTree {
+	return &config.ConfigTree{
+		Children: []*config.Node{{
+			Keys: []string{"system"},
+			Children: []*config.Node{{
+				Keys: []string{"master-password"},
+				Children: []*config.Node{{
+					Keys:   []string{"pseudorandom-function", "sha256"},
+					IsLeaf: true,
+				}},
+			}},
+		}},
+	}
+}
+
+// captureWarnLogs redirects slog to a buffer at Warn level for the test's
+// lifetime and returns the buffer.
+func captureWarnLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(old) })
+	return &buf
+}
+
+// TestPlaintextDowngradeWarn_4579 pins the #4579 A4-06 hardening: reading a
+// config that DECLARES a master-password but is stored as UNENCRYPTED
+// plaintext emits an operator warning. Every write path encrypts the body
+// when master-password is set (maybeEncryptTreeJSON keyed off the tree's
+// master-password leaf), so plaintext-with-master-password can only arise
+// from a downgrade to an older build, a restore from an unencrypted backup,
+// or tampering — surfacing it beats loading the cleartext secrets silently.
+//
+// RED on revert: readTreeMeta drops the warn, so no record is logged and the
+// substring assertion fails.
+func TestPlaintextDowngradeWarn_4579(t *testing.T) {
+	buf := captureWarnLogs(t)
+	s := newTestStore(t)
+
+	// Write active.json as PLAINTEXT (no AES-GCM envelope) even though the
+	// tree declares a master-password — the exact downgrade case. Wrap the
+	// body in the #1917 compatibility envelope like a real committed DB so
+	// readTreeMeta reaches the decrypt/parse path.
+	tree := masterPwTree()
+	if masterPasswordPRF(tree) != "sha256" {
+		t.Fatalf("test tree does not declare a master-password: %+v", tree)
+	}
+	body, err := json.MarshalIndent(tree, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal tree: %v", err)
+	}
+	framed := wrapEnvelope(body, "", true)
+	if err := fsatomic.WriteFileDurable(s.db.activePath(), framed, 0600); err != nil {
+		t.Fatalf("write plaintext active.json: %v", err)
+	}
+
+	got, err := s.db.ReadActive()
+	if err != nil {
+		t.Fatalf("ReadActive: %v", err)
+	}
+	if got == nil || masterPasswordPRF(got) != "sha256" {
+		t.Fatalf("read-back tree lost the master-password declaration: %+v", got)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "#4579") || !strings.Contains(logged, "UNENCRYPTED plaintext") {
+		t.Fatalf("expected an unexpected-plaintext warning (#4579 A4-06); got log:\n%s", logged)
+	}
+}
+
+// TestEncryptedRoundTripNoWarn_4579 is the negative control: a config with a
+// master-password written through the normal (encrypting) path reads back
+// WITHOUT the downgrade warning — so the A4-06 warn does not cry wolf on the
+// legitimate encrypted DB.
+func TestEncryptedRoundTripNoWarn_4579(t *testing.T) {
+	buf := captureWarnLogs(t)
+	s := newTestStore(t)
+
+	// WriteActive encrypts because the tree declares a master-password, so
+	// ReadActive decrypts (decrypted=true) and the warn must stay silent.
+	tree := masterPwTree()
+	if err := s.db.WriteActive(tree); err != nil {
+		t.Fatalf("WriteActive: %v", err)
+	}
+	if _, err := s.db.ReadActive(); err != nil {
+		t.Fatalf("ReadActive: %v", err)
+	}
+	if strings.Contains(buf.String(), "#4579") {
+		t.Fatalf("encrypted round-trip must not warn; got log:\n%s", buf.String())
+	}
+}
+
+// TestPlaintextNoMasterPasswordNoWarn_4579 is the other negative control: a
+// plaintext config that does NOT declare a master-password (the common case,
+// no encryption configured) must not warn — the warn is specific to the
+// declared-but-unencrypted downgrade.
+func TestPlaintextNoMasterPasswordNoWarn_4579(t *testing.T) {
+	buf := captureWarnLogs(t)
+	s := newTestStore(t)
+
+	tree := &config.ConfigTree{Children: []*config.Node{{
+		Keys:     []string{"system"},
+		Children: []*config.Node{{Keys: []string{"host-name", "plainbox"}, IsLeaf: true}},
+	}}}
+	if masterPasswordPRF(tree) != "" {
+		t.Fatalf("control tree unexpectedly declares a master-password: %+v", tree)
+	}
+	if err := s.db.WriteActive(tree); err != nil { // no PRF => plaintext write
+		t.Fatalf("WriteActive: %v", err)
+	}
+	if _, err := s.db.ReadActive(); err != nil {
+		t.Fatalf("ReadActive: %v", err)
+	}
+	if strings.Contains(buf.String(), "#4579") {
+		t.Fatalf("plaintext config without master-password must not warn; got log:\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
Closes #4579.

configstore A4 LOW hardening batch (ps-037-A4). All three items were
re-verified against current master; two are driven, one is deliberately
skipped with the reasoning recorded.

## A4-02 — journal 0644 → 0600 (driven)

`.config.journal` was world-readable 0644. It is metadata-only
(timestamp/action/config-hash), but its `Detail` field records the
operator's free-text commit comment verbatim, so a comment that names a
credential would be world-readable. Tightened `journal.Log` to 0600 to
match the rest of the config surface (#4056) and folded the journal into
the #4056 secret-sweep test (`TestConfigJournalOwnerOnly_4579`, RED on
revert at 0644). Defense-in-depth, not an exploitable-leak fix.

## A4-06 — warn on unexpected plaintext downgrade (driven)

Every write path encrypts the config body when a master-password is set,
so reading a config back as plaintext while its tree still declares a
master-password means it was written without the AES-GCM envelope (older
build, unencrypted-backup restore, or tampering). `maybeDecryptTreeJSON`
now reports whether it decrypted; `readTreeMeta` emits a one-time
`slog.Warn` on the plaintext-with-declared-master-password case so the
at-rest exposure is visible instead of loading cleartext secrets
silently. Boot/commit-paced, never a hot loop. Requires root/owner write
to the 0600/0700 `.configdb`, so this is a visibility improvement, not a
priv-esc fix. `TestPlaintextDowngradeWarn_4579` (RED on revert) plus two
negative controls (encrypted round-trip, plaintext-without-master-password)
prove no false positive.

## A4-05 — bind GCM envelope header as AAD (SKIPPED, deliberate)

`Seal`/`Open` pass nil AAD. Binding the header as AAD is textbook
defense-in-depth, but the scheme already fails **closed** on any header
swap: the key is HKDF-derived from the PRF + stored salt, so a tampered
header derives the wrong key and `Open` fails the GCM tag regardless.
Switching to a non-nil AAD is a **ciphertext-format change** — an
`active.json` sealed by an older build with nil AAD would fail to `Open`
after the change, bricking decryption on upgrade. The non-exploitable gap
does not justify the upgrade-brick risk, so the nil AAD is retained. The
reasoning is recorded in `pkg/configstore/README.md`.

## Validation

- `go test ./pkg/configstore/...` green (uncached); RED-on-revert
  confirmed for both driven items.
- `go build ./...` green; `gofmt -l` clean; `go vet ./pkg/configstore/...`
  clean.
- Docs updated: `pkg/configstore/README.md` (perms table + journal note +
  at-rest crypto hardening notes) and `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
