### PR TITLE
zeroize: erase self-signed REST-API TLS pair under /etc/xpf/tls (#4599)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-07-07 — #4599 zeroize: erase self-signed REST-API TLS pair under /etc/xpf/tls
+
+- **Timestamp**: 2026-07-07
+- **Action**: `zeroizeConfigDir` (`pkg/grpcapi/server_diag.go`) removed the
+  `.configdb` SSOT + top-level `.conf`/rollback/journal artifacts but never
+  recursed into the `tls/` subdir, so `/etc/xpf/tls/key.pem` (the
+  device-generated self-signed localhost REST-API private key) and its
+  `cert.pem` SURVIVED a factory reset — a re-tenant leak (LOW: device-generated,
+  self-signed, localhost-only). The top-level ReadDir loop uses `os.Remove`,
+  which cannot delete a non-empty dir and never matched the "tls" name anyway.
+  Added an explicit `fail(os.RemoveAll(filepath.Join(configDir, "tls")))` after
+  the `.configdb` removal, folded into the same first-error surfacing (→
+  codes.Internal). Safe because `generateSelfSignedCertAt` (`pkg/api/server.go`)
+  regenerates a fresh pair on absence at the next boot (LoadX509KeyPair fails →
+  regen). RED-on-revert test `TestZeroizeConfigDirWipesTLSKey`
+  (`pkg/grpcapi/zeroize_tls_4599_test.go`): tls/key.pem + cert.pem + tls/ absent
+  after wipe, existing SSOT/rollback/journal removals still hold, non-xpf
+  bystander untouched. Doc: `docs/system-login.md` #4576 erased-paths list.
+- **File(s)**: `pkg/grpcapi/server_diag.go`,
+  `pkg/grpcapi/zeroize_tls_4599_test.go`, `docs/system-login.md`, `_Log.md`
+- Closes #4599.
+
 ## 2026-07-07 — #4589 A10-b2 F-01 ddns+config: reject empty-host DDNS generic url-template
 
 - **Timestamp**: 2026-07-07

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -166,9 +166,13 @@ the next boot (RMA / resale / re-tenant). The wipe removes the `.configdb` SSOT
 (so an interrupted wipe cannot leave AES-GCM ciphertext behind next to the key
 that decrypts it), the numbered text rollback slots `<config>.N` (full config
 text with cleartext secret leaves — reloaded at boot by `loadRollbackHistory`),
-the top-level `.conf` files (live config + `rescue.conf`), and `.config.journal`
-(+ rotated segments). A wipe that cannot fully erase this state returns an error
-rather than reporting a clean factory reset.
+the top-level `.conf` files (live config + `rescue.conf`), `.config.journal`
+(+ rotated segments), and the self-signed REST-API TLS pair under `tls/`
+(`tls/key.pem` — the device-generated localhost HTTPS private key — and
+`tls/cert.pem`, #4599; xpf-generated, not tenant config, and regenerated on
+absence by `generateSelfSignedCertAt` on the next boot). A wipe that cannot
+fully erase this state returns an error rather than reporting a clean factory
+reset.
 
 **Rendered service-config erasure (#4585).** The wipe erases that
 SSOT/rollback/journal state directly, but the prior tenant's secrets are ALSO

--- a/pkg/grpcapi/server_diag.go
+++ b/pkg/grpcapi/server_diag.go
@@ -801,6 +801,11 @@ const (
 //     fsynced BEFORE the wipe (so an interrupted wipe leaves a trail, and a
 //     remote syslog collector keeps the durable cross-wipe record), but a
 //     completed factory reset must not hand its audit log to the next owner.
+//   - tls/                      — the self-signed REST-API TLS pair (#4599):
+//     tls/key.pem (the device-generated localhost HTTPS private key, 0600) +
+//     tls/cert.pem. xpf-generated, not tenant config; generateSelfSignedCertAt
+//     (pkg/api) regenerates a fresh pair on absence at the next boot, so
+//     removing them is safe and hands no prior-tenant key to the next owner.
 //
 // Removal is KEY-FIRST: master.key is deleted before the encrypted DB body, so
 // an interrupted wipe (crash / power loss mid-RemoveAll) can never leave the
@@ -825,6 +830,14 @@ func zeroizeConfigDir(configDir, configBase string) error {
 	// The config SSOT (active.json, candidate.json, rollback.N.json + any
 	// residual key). RemoveAll erases the whole tree and is nil on absent.
 	fail(os.RemoveAll(dbDir))
+
+	// The self-signed REST-API TLS material (#4599): tls/key.pem (the
+	// device-generated localhost HTTPS private key) + tls/cert.pem. These are
+	// xpf-generated, not tenant config — generateSelfSignedCertAt (pkg/api)
+	// regenerates a fresh pair on absence at the next boot, so removing them is
+	// safe. A subdir, so the top-level ReadDir loop's os.Remove never catches it;
+	// erase the whole tree explicitly.
+	fail(os.RemoveAll(filepath.Join(configDir, "tls")))
 
 	// Top-level artifacts in a single ReadDir pass.
 	entries, err := os.ReadDir(configDir)

--- a/pkg/grpcapi/zeroize_tls_4599_test.go
+++ b/pkg/grpcapi/zeroize_tls_4599_test.go
@@ -1,0 +1,70 @@
+package grpcapi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestZeroizeConfigDirWipesTLSKey pins #4599: a factory-reset wipe must remove
+// the self-signed REST-API TLS pair under /etc/xpf/tls (key.pem — the
+// device-generated localhost HTTPS private key — and cert.pem) so the prior
+// tenant's key is not handed to the next owner. The pair is xpf-generated and
+// regenerated on absence (generateSelfSignedCertAt), so removing it is safe.
+//
+// RED on revert: before this fix, zeroizeConfigDir removed only the .configdb
+// SSOT + top-level .conf/rollback/journal artifacts and never recursed into the
+// tls/ subdir (the top-level ReadDir loop uses os.Remove, which cannot delete a
+// non-empty directory and never matched the "tls" name anyway), so tls/key.pem
+// and tls/cert.pem SURVIVED — the two assertAbsent calls on them fail.
+func TestZeroizeConfigDirWipesTLSKey(t *testing.T) {
+	dir := t.TempDir()
+	configBase := "xpf.conf"
+	configPath := filepath.Join(dir, configBase)
+	marker := []byte(zeroizeMarker)
+
+	// The self-signed REST-API TLS pair (#4599 target).
+	tlsDir := filepath.Join(dir, "tls")
+	tlsKey := filepath.Join(tlsDir, "key.pem")
+	tlsCert := filepath.Join(tlsDir, "cert.pem")
+	mustWriteFile(t, tlsKey, []byte("-----BEGIN EC PRIVATE KEY-----\n"))
+	mustWriteFile(t, tlsCert, []byte("-----BEGIN CERTIFICATE-----\n"))
+
+	// Regression guard: the existing SSOT/rollback/journal removals must still
+	// hold with the tls/ removal in place.
+	masterKey := filepath.Join(dir, ".configdb", "master.key")
+	activeJSON := filepath.Join(dir, ".configdb", "active.json")
+	journalPath := filepath.Join(dir, ".config.journal")
+	textRollback := configPath + ".1"
+	mustWriteFile(t, masterKey, make([]byte, 32))
+	mustWriteFile(t, activeJSON, marker)
+	mustWriteFile(t, journalPath, marker)
+	mustWriteFile(t, configPath, marker)
+	mustWriteFile(t, textRollback, marker)
+
+	// A non-xpf file in the same dir must be LEFT ALONE.
+	bystander := filepath.Join(dir, "node-id")
+	mustWriteFile(t, bystander, []byte("0"))
+
+	if err := zeroizeConfigDir(dir, configBase); err != nil {
+		t.Fatalf("zeroizeConfigDir returned error: %v", err)
+	}
+
+	// The TLS pair AND its directory are gone (the #4599 fix; RED on revert).
+	for _, p := range []string{tlsKey, tlsCert, tlsDir} {
+		assertAbsent(t, p)
+	}
+
+	// The pre-existing removals still hold.
+	for _, p := range []string{
+		filepath.Join(dir, ".configdb"), masterKey, activeJSON,
+		journalPath, configPath, textRollback,
+	} {
+		assertAbsent(t, p)
+	}
+
+	// Scope guard: the non-xpf file survives.
+	if _, err := os.Stat(bystander); err != nil {
+		t.Errorf("zeroize removed a non-xpf file %s: %v", bystander, err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #4599.

`zeroizeConfigDir` (`pkg/grpcapi/server_diag.go`) erased the `.configdb`
SSOT + `master.key`, the numbered text rollback slots, the top-level
`.conf` files, and the audit journal, but never recursed into the `tls/`
subdir. A factory reset therefore left `/etc/xpf/tls/key.pem` (the
device-generated self-signed localhost REST-API private key) and its
`cert.pem` behind — a re-tenant residual. The top-level `ReadDir` pass
uses `os.Remove`, which cannot delete a non-empty directory and never
matched the `"tls"` name anyway, so the pair silently survived every
prior wipe.

**Severity: LOW** — the pair is device-generated, self-signed, and
localhost-only (not a tenant config secret), and is regenerated on a
re-tenant. But a completed factory reset should not hand the prior
owner's private key to the next owner.

## Fix

- Add `fail(os.RemoveAll(filepath.Join(configDir, "tls")))` after the
  `.configdb` removal in `zeroizeConfigDir`. It reuses the existing
  best-effort-past-failure / first-real-error discipline, so the removal
  folds into the surfaced result (`codes.Internal` on a real failure) and
  `os.ErrNotExist` is not an error.
- **Safe to remove:** `generateSelfSignedCertAt` (`pkg/api/server.go`)
  regenerates a fresh cert/key on absence at the next boot
  (`tls.LoadX509KeyPair` fails on the missing pair → falls through to
  regen-and-persist), so no crash and no stale key.

## Test (RED on revert)

`TestZeroizeConfigDirWipesTLSKey`
(`pkg/grpcapi/zeroize_tls_4599_test.go`) writes `tls/key.pem` +
`tls/cert.pem` alongside the `.configdb`/conf/rollback/journal set and
asserts the whole `tls/` tree is absent after the wipe while the
pre-existing removals still hold and a non-xpf bystander file is left
untouched. Reverting only the code change makes all three `tls/`
assertions fail (verified). `go test ./pkg/grpcapi/` green; `go build
./cmd/xpfd/` ok; gofmt + vet clean.

## Docs

`docs/system-login.md` #4576 erased-paths list now includes the `tls/`
pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi