### PR TITLE
vrrp: liveness watchdog for a held master that dies mid-preempt-hold

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-07-07 — #4584 ps-037-A5 A5-02 vrrp: liveness watchdog for a held master that dies mid-preempt-hold
+
+- **Timestamp**: 2026-07-07
+- **Action**: When a higher-priority node defers preemption of a live
+  lower-priority master (`preempt hold-time <N>`, #2850), arming the hold
+  left `masterDownTimer` IDLE for the whole hold: it fired to reach the arm
+  point and `handleBackupRx` never resets it for a persisting lower advert.
+  So a held (VIP-owning, forwarding) lower-priority master that DIED mid-hold
+  went undetected until `preemptHoldTimer` expired — up to ~hold-time of VIP
+  blackhole for a DEAD master, violating the "dead master → immediate
+  takeover" invariant (#2900 enumerated preempt-off / track-demote but NOT
+  held-master-death). Fix: `armPreemptHold` now ALSO (re)arms `masterDownTimer`
+  for `masterDownInterval` as a liveness watchdog; on its fire while
+  `preemptHoldArmed`, `stepBackup` checks new `heldMasterIsStale()` — a stale
+  held master (silent beyond the master-down horizon) disarms the hold and
+  becomes MASTER now, a still-live one (adverts keep refreshing
+  `lastMasterSeen`) re-arms the watchdog and defers to the natural hold expiry.
+  `heldMasterIsStale` checks ONLY staleness (not the effective>priority
+  comparison) so a track-interface demotion below a still-live master does NOT
+  fire a spurious takeover — the #2900 natural-expiry re-validation
+  (`shouldPreemptObservedMaster`) owns that case. Preserves the normal
+  preempt-hold, priority-0 resign, sync-hold, and ~60ms failover paths.
+  RED-on-revert: `TestHoldWatchdog_DeadHeldMaster_ImmediateTakeover` +
+  `TestHoldWatchdog_LiveHeldMaster_DefersToNaturalExpiry` (both fail on the
+  masterDownTimer re-arm assertion when reverted);
+  `TestHoldWatchdog_NoHoldArmed_NormalFailoverUnchanged` +
+  `TestHeldMasterIsStale`. NOTE: VRRP failover-timing change — needs
+  `make test-failover` before merge (parent runs it).
+- **File(s)**: pkg/vrrp/instance.go,
+  pkg/vrrp/instance_preempt_hold_watchdog_test.go, pkg/vrrp/README.md, _Log.md
+
 ## 2026-07-07 — #4589 A10-b2 F-01 ddns+config: reject empty-host DDNS generic url-template
 
 - **Timestamp**: 2026-07-07

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -229,6 +229,26 @@ blackholing on takeover. Compiled to `Instance.PreemptHoldTime` (seconds);
   `skipNextPreemptHold` in `handleBackupRx` so the imminent 1 ms
   `masterDownTimer` expiry promotes immediately (planned failover stays
   zero-delay).
+- **Liveness watchdog — held master dies mid-hold (#4584)** — the master
+  that was live when the hold armed can DIE *during* the hold. Arming the
+  hold used to leave `masterDownTimer` idle (it fired to arm the hold, and
+  `handleBackupRx` never resets it for a persisting lower advert), so the
+  held VIP-owning master's silence went undetected until the (possibly very
+  long) hold-time elapsed — up to ~hold-time of blackhole for a *dead*
+  master, violating the "dead master → immediate takeover" invariant.
+  `armPreemptHold` now ALSO (re)arms `masterDownTimer` for
+  `masterDownInterval` as a liveness watchdog. On its fire while
+  `preemptHoldArmed`, `stepBackup` checks `heldMasterIsStale()`: a stale
+  held master (last advert beyond the master-down horizon → it went silent)
+  disarms the hold and takes over NOW; a still-live one (adverts keep
+  refreshing `lastMasterSeen` via `recordMasterAdvert`) re-arms the watchdog
+  and lets the hold run to its natural expiry. `heldMasterIsStale` checks
+  ONLY staleness — NOT the effective>master priority comparison — so a
+  track-interface demotion below a *still-live* master does not trigger a
+  spurious watchdog takeover; the natural-expiry re-validation
+  (`shouldPreemptObservedMaster`, #2900) owns the demotion case. So a LIVE
+  held master is still deferred to hold-time (preempt-hold intent preserved)
+  while a DEAD one is taken over within ~one master-down horizon.
 - **Cancellation** — while the hold is armed, a returning >= -priority
   master advert (`handleBackupRx`) resets `masterDownTimer` and
   stop-drains the hold (no longer a lower master to preempt). A

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -758,6 +758,56 @@ func (vi *vrrpInstance) preemptingLiveLowerMaster() bool {
 	return effective > lastMasterPriority
 }
 
+// heldMasterIsStale reports whether the lower-priority master that an armed
+// preempt hold-time (#2850) is currently deferring to has gone SILENT — its
+// last advert is older than the master-down horizon (or none was ever seen).
+// It is the #4584 liveness-watchdog predicate: while the hold is armed the
+// masterDownTimer is repurposed as a watchdog (armPreemptHold), and on its fire
+// a stale held master means the VIP-owning master DIED mid-hold and must be
+// taken over immediately (dead master → immediate takeover), whereas a
+// still-live master (recent advert, lastMasterSeen fresh) keeps deferring to
+// the natural hold expiry.
+//
+// Unlike preemptingLiveLowerMaster/shouldPreemptObservedMaster this checks ONLY
+// staleness, deliberately NOT the effective>lastMasterPriority comparison: a
+// track-interface demotion that drops us below a STILL-LIVE master must NOT
+// trigger a watchdog takeover (that live master is still forwarding). The
+// natural hold-expiry re-validation (shouldPreemptObservedMaster, #2900) owns
+// the demotion case. Uses the same master-down staleness horizon (3*advert +
+// skew on the master's learned interval) as the sibling preempt helpers so all
+// agree on what "silent" means.
+//
+// Lock discipline mirrors shouldPreemptObservedMaster: snapshot under ONE
+// RLock, then compute from the locals (never call an RLocking accessor while
+// holding the lock).
+func (vi *vrrpInstance) heldMasterIsStale() bool {
+	vi.mu.RLock()
+	priority := vi.cfg.Priority
+	trackDown := vi.trackDown
+	trackIface := vi.cfg.TrackInterface
+	trackCost := vi.cfg.TrackPriorityCost
+	advertMS := vi.cfg.AdvertiseInterval
+	masterAdver := vi.masterAdverInterval
+	lastMasterSeen := vi.lastMasterSeen
+	vi.mu.RUnlock()
+
+	effective := priority
+	if priority != 0 && priority != 255 && trackDown && trackIface != "" {
+		effective -= trackCost
+		if effective < 1 {
+			effective = 1
+		} else if effective > 254 {
+			effective = 254
+		}
+	}
+
+	advert := effectiveAdvertInterval(advertMS, masterAdver)
+	skew := time.Duration(256-effective) * advert / 256
+	masterDown := 3*advert + skew
+
+	return lastMasterSeen.IsZero() || time.Since(lastMasterSeen) > masterDown
+}
+
 // stopAndDrainTimer stops t and drains a pending fire from its channel so a
 // subsequent Reset arms a clean interval. Safe on an already-stopped or
 // already-drained timer.
@@ -773,9 +823,22 @@ func stopAndDrainTimer(t *time.Timer) {
 // armPreemptHold (re)arms the preempt hold-time countdown (#2850) for `hold`
 // and records that it is running (#2900). Called only from the run-loop
 // goroutine; the preemptHoldArmed flag is mu-guarded for external readers.
-func (vi *vrrpInstance) armPreemptHold(preemptHoldTimer *time.Timer, hold time.Duration) {
+//
+// It ALSO (re)arms masterDownTimer for masterDownInterval as a liveness
+// watchdog (#4584). Without this the masterDownTimer would sit IDLE for the
+// entire hold: it already fired to reach this arming point, and handleBackupRx
+// never resets it for a persisting lower-priority advert. A held (VIP-owning)
+// lower-priority master that DIES mid-hold would then go undetected until the
+// (possibly very long) hold-time elapsed — up to ~holdTime of VIP blackhole for
+// a dead master, violating the "dead master → immediate takeover" invariant.
+// stepBackup's masterDownTimer.C case treats a fire while preemptHoldArmed as
+// this watchdog: a stale held master triggers immediate takeover, a still-live
+// one re-arms the watchdog and defers to the natural hold expiry.
+func (vi *vrrpInstance) armPreemptHold(masterDownTimer, preemptHoldTimer *time.Timer, hold time.Duration) {
 	stopAndDrainTimer(preemptHoldTimer)
 	preemptHoldTimer.Reset(hold)
+	stopAndDrainTimer(masterDownTimer)
+	masterDownTimer.Reset(vi.masterDownInterval())
 	vi.mu.Lock()
 	vi.preemptHoldArmed = true
 	vi.mu.Unlock()
@@ -802,9 +865,15 @@ func (vi *vrrpInstance) disarmPreemptHold(preemptHoldTimer *time.Timer) {
 // the masterDownTimer fires while a live lower-priority master is still
 // present and a hold-time is configured, the promotion is deferred by arming
 // preemptHoldTimer instead of becoming MASTER immediately. handleBackupRx
-// cancels the armed hold if a >= -priority master returns; a fresh
-// lower-priority advert re-arms the masterDownTimer so the hold restarts when
-// it next expires.
+// cancels the armed hold if a >= -priority master returns.
+//
+// While the hold is armed, armPreemptHold ALSO keeps masterDownTimer running as
+// a liveness watchdog (#4584): a fire while preemptHoldArmed means the held
+// master may have gone silent. The masterDownTimer.C case checks
+// heldMasterIsStale() — a stale (dead) held master triggers immediate takeover,
+// a still-live one re-arms the watchdog and lets the hold run to natural
+// expiry — so a held VIP-owning master that dies mid-hold no longer blackholes
+// for the full hold-time.
 func (vi *vrrpInstance) stepBackup(masterDownTimer, advertTimer, preemptHoldTimer *time.Timer) (stop bool) {
 	select {
 	case <-vi.stopCh:
@@ -812,6 +881,35 @@ func (vi *vrrpInstance) stepBackup(masterDownTimer, advertTimer, preemptHoldTime
 	case pkt := <-vi.rxCh:
 		vi.handleBackupRx(pkt, masterDownTimer, preemptHoldTimer)
 	case <-masterDownTimer.C:
+		// If a preempt hold-time is currently armed, this masterDownTimer fire
+		// is the #4584 liveness watchdog, NOT a fresh master-down. armPreemptHold
+		// re-armed the timer so a held VIP-owning lower-priority master that DIES
+		// mid-hold is detected within one master-down horizon instead of only
+		// when the (possibly long) hold-time elapses.
+		vi.mu.RLock()
+		holdArmed := vi.preemptHoldArmed
+		vi.mu.RUnlock()
+		if holdArmed {
+			if vi.heldMasterIsStale() {
+				// The held lower-priority master went SILENT (died) during the
+				// hold — nothing is forwarding, so restore the "dead master →
+				// immediate takeover" invariant: disarm the hold and become
+				// MASTER now instead of blackholing the VIP until the hold
+				// expires.
+				slog.Info("vrrp: held master silent during preempt hold-time, immediate takeover",
+					"key", vi.key())
+				vi.disarmPreemptHold(preemptHoldTimer)
+				vi.becomeMaster()
+				advertTimer.Reset(vi.advertInterval())
+			} else {
+				// The held master is still alive (adverts keep arriving and
+				// refreshing lastMasterSeen). Preserve the preempt-hold intent:
+				// re-arm the watchdog and let the hold run to its natural expiry.
+				stopAndDrainTimer(masterDownTimer)
+				masterDownTimer.Reset(vi.masterDownInterval())
+			}
+			return false
+		}
 		// Master timed out. If this is preemption of a still-live
 		// lower-priority master AND a preempt hold-time is configured,
 		// defer the takeover by arming the hold timer rather than
@@ -825,7 +923,7 @@ func (vi *vrrpInstance) stepBackup(masterDownTimer, advertTimer, preemptHoldTime
 		if hold := vi.preemptHoldDuration(); !skipHold && hold > 0 && vi.preemptingLiveLowerMaster() {
 			slog.Info("vrrp: preempt deferred by hold-time",
 				"key", vi.key(), "hold", hold)
-			vi.armPreemptHold(preemptHoldTimer, hold)
+			vi.armPreemptHold(masterDownTimer, preemptHoldTimer, hold)
 			return false
 		}
 		vi.becomeMaster()
@@ -1579,8 +1677,12 @@ func (vi *vrrpInstance) masterAdverFloor() time.Duration {
 // resigning (priority-0) master or a returning >= -priority master cancels any
 // in-flight hold: the first because takeover becomes immediate, the second
 // because there is no longer a lower-priority master to preempt. A persisting
-// lower-priority master leaves an armed hold running (the masterDownTimer it
-// was armed from is intentionally not reset on a lower advert).
+// lower-priority master leaves an armed hold running (this path intentionally
+// does not reset masterDownTimer on a lower advert). recordMasterAdvert still
+// refreshes lastMasterSeen from every non-zero advert, which is what keeps the
+// #4584 masterDownTimer liveness watchdog (armed by armPreemptHold) reading the
+// held master as alive; if the adverts stop, the watchdog observes the staleness
+// and takes over.
 func (vi *vrrpInstance) handleBackupRx(pkt *VRRPPacket, masterDownTimer, preemptHoldTimer *time.Timer) {
 	vi.recordMasterAdvert(pkt)
 	pri := vi.getPriority()

--- a/pkg/vrrp/instance_preempt_hold_watchdog_test.go
+++ b/pkg/vrrp/instance_preempt_hold_watchdog_test.go
@@ -1,0 +1,218 @@
+package vrrp
+
+import (
+	"testing"
+	"time"
+)
+
+// Tests for the #4584 preempt hold-time LIVENESS WATCHDOG. When a higher-
+// priority node defers preemption of a live lower-priority master
+// (`preempt hold-time <N>`), armPreemptHold re-arms masterDownTimer as a
+// watchdog so a held (VIP-owning) master that DIES mid-hold is taken over
+// within one master-down horizon instead of blackholing until the (possibly
+// very long) hold-time elapses. A still-live held master keeps deferring to the
+// natural hold expiry — the preempt-hold intent is preserved.
+//
+// Before #4584 the masterDownTimer sat IDLE for the whole hold (it fired to arm
+// the hold and handleBackupRx never reset it for a persisting lower advert), so
+// a held master's silence went undetected until the hold-time elapsed.
+//
+// These drive stepBackup() directly (see instance_preempt_holdtime_test.go for
+// why run() is unsafe in a unit test).
+
+// armHoldKeepMasterDown arms the preempt hold by firing masterDownTimer with a
+// live lower-priority master present, and RETURNS the masterDownTimer so the
+// caller can fire it again as the #4584 watchdog. It asserts the instance
+// stayed BACKUP with the hold armed. The masterDownTimer re-arm (the direct
+// fail-on-revert signal) is asserted by the individual tests.
+func armHoldKeepMasterDown(t *testing.T, vi *vrrpInstance) (masterDown, advert, preemptHold *time.Timer) {
+	t.Helper()
+	masterDown = time.NewTimer(0)
+	t.Cleanup(func() { masterDown.Stop() })
+	time.Sleep(2 * time.Millisecond) // let masterDown fire
+	advert = time.NewTimer(time.Hour)
+	t.Cleanup(func() { advert.Stop() })
+	preemptHold = time.NewTimer(time.Hour)
+	t.Cleanup(func() { preemptHold.Stop() })
+
+	vi.stepBackup(masterDown, advert, preemptHold)
+
+	if vi.getState() != StateBackup {
+		t.Fatalf("state = %s, want BACKUP (hold armed)", vi.getState())
+	}
+	vi.mu.RLock()
+	armed := vi.preemptHoldArmed
+	vi.mu.RUnlock()
+	if !armed {
+		t.Fatalf("preemptHoldArmed = false, want true after arming the hold")
+	}
+	return masterDown, advert, preemptHold
+}
+
+// TestHoldWatchdog_DeadHeldMaster_ImmediateTakeover is the PRIMARY #4584
+// fail-on-revert guard. A priority-200 node arms a 300 s preempt hold against a
+// live priority-100 master, then that held (VIP-owning) master DIES mid-hold
+// (adverts stop, lastMasterSeen goes stale). The re-armed masterDownTimer
+// watchdog must fire and promote NOW — not wait the full 300 s hold. On revert
+// the masterDownTimer is left idle after the hold arms, so nothing detects the
+// silence until the hold expires.
+func TestHoldWatchdog_DeadHeldMaster_ImmediateTakeover(t *testing.T) {
+	vi := newHoldTestInstance(t, 200, 300) // 300 s hold
+	vi.mu.Lock()
+	vi.lastMasterPriority = 100
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+
+	masterDown, advert, preemptHold := armHoldKeepMasterDown(t, vi)
+
+	// #4584 RED-on-revert: armPreemptHold must have re-armed masterDownTimer as
+	// the liveness watchdog. On revert it is left idle (fired and never reset)
+	// → Stop() returns false.
+	if !masterDown.Stop() {
+		t.Fatal("masterDownTimer not re-armed as liveness watchdog after preempt hold armed (#4584 reverted?)")
+	}
+
+	// The held master DIES: no more adverts, lastMasterSeen goes stale.
+	vi.mu.Lock()
+	vi.lastMasterSeen = time.Now().Add(-time.Hour)
+	vi.mu.Unlock()
+
+	// Fire the watchdog (masterDownTimer) while the hold is still armed and the
+	// preemptHold timer is far in the future (300 s). Only the watchdog can
+	// promote us here — the hold has NOT elapsed.
+	masterDown.Reset(0)
+	time.Sleep(2 * time.Millisecond)
+	vi.stepBackup(masterDown, advert, preemptHold)
+
+	if vi.getState() != StateMaster {
+		t.Fatalf("state = %s, want MASTER (dead held master → watchdog immediate takeover)", vi.getState())
+	}
+	vi.mu.RLock()
+	stillArmed := vi.preemptHoldArmed
+	vi.mu.RUnlock()
+	if stillArmed {
+		t.Error("preemptHoldArmed = true after watchdog takeover; the hold must be disarmed")
+	}
+}
+
+// TestHoldWatchdog_LiveHeldMaster_DefersToNaturalExpiry proves the preempt-hold
+// intent is preserved: while the held master KEEPS sending adverts
+// (lastMasterSeen stays fresh), a watchdog fire must NOT preempt it — the
+// instance stays BACKUP, the hold stays armed, and the watchdog re-arms itself.
+// The hold then runs to its NATURAL expiry, which promotes. On revert the
+// masterDown fire re-arms the HOLD (resetting preemptHold) and leaves masterDown
+// idle, so the re-arm assertion fails.
+func TestHoldWatchdog_LiveHeldMaster_DefersToNaturalExpiry(t *testing.T) {
+	vi := newHoldTestInstance(t, 200, 300) // long hold
+	vi.mu.Lock()
+	vi.lastMasterPriority = 100
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+
+	masterDown, advert, preemptHold := armHoldKeepMasterDown(t, vi)
+
+	// The held master is STILL ALIVE — adverts keep refreshing lastMasterSeen.
+	vi.mu.Lock()
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+	stopAndDrainTimer(masterDown)
+	masterDown.Reset(0)
+	time.Sleep(2 * time.Millisecond)
+	vi.stepBackup(masterDown, advert, preemptHold)
+
+	if vi.getState() != StateBackup {
+		t.Fatalf("state = %s, want BACKUP (live held master must not be preempted by the watchdog)", vi.getState())
+	}
+	vi.mu.RLock()
+	armed := vi.preemptHoldArmed
+	vi.mu.RUnlock()
+	if !armed {
+		t.Fatal("preemptHoldArmed = false; the hold must continue while the held master is alive")
+	}
+	// #4584 RED-on-revert: the watchdog must have re-armed masterDown to keep
+	// watching. On revert the masterDown fire re-arms the HOLD instead and
+	// leaves masterDown idle → Stop() returns false.
+	if !masterDown.Stop() {
+		t.Fatal("masterDownTimer not re-armed as watchdog after a live-master fire (#4584 reverted?)")
+	}
+
+	// The hold runs to its NATURAL expiry: firing preemptHold now (live lower
+	// master still fresh) promotes — proving the live master was deferred to
+	// hold-time, not preempted early by the watchdog.
+	vi.mu.Lock()
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+	stopAndDrainTimer(preemptHold)
+	preemptHold.Reset(0)
+	time.Sleep(2 * time.Millisecond)
+	masterDownLong := time.NewTimer(time.Hour)
+	t.Cleanup(func() { masterDownLong.Stop() })
+	vi.stepBackup(masterDownLong, advert, preemptHold)
+	if vi.getState() != StateMaster {
+		t.Fatalf("state = %s, want MASTER (natural hold expiry → takeover)", vi.getState())
+	}
+}
+
+// TestHoldWatchdog_NoHoldArmed_NormalFailoverUnchanged confirms the watchdog
+// branch is skipped when no hold is armed: a masterDownTimer fire with no
+// hold-time configured promotes immediately (normal failover), exactly as
+// before #4584. Guards against routing a normal failover through the watchdog.
+func TestHoldWatchdog_NoHoldArmed_NormalFailoverUnchanged(t *testing.T) {
+	vi := newHoldTestInstance(t, 200, 0) // no hold-time
+	vi.mu.Lock()
+	vi.lastMasterPriority = 100
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+
+	vi.mu.RLock()
+	preArmed := vi.preemptHoldArmed
+	vi.mu.RUnlock()
+	if preArmed {
+		t.Fatal("preemptHoldArmed = true before any hold armed")
+	}
+
+	masterDown := time.NewTimer(0)
+	t.Cleanup(func() { masterDown.Stop() })
+	time.Sleep(2 * time.Millisecond)
+	advert := time.NewTimer(time.Hour)
+	t.Cleanup(func() { advert.Stop() })
+	preemptHold := time.NewTimer(time.Hour)
+	t.Cleanup(func() { preemptHold.Stop() })
+
+	vi.stepBackup(masterDown, advert, preemptHold)
+	if vi.getState() != StateMaster {
+		t.Fatalf("state = %s, want MASTER (no hold-time → normal immediate failover)", vi.getState())
+	}
+}
+
+// TestHeldMasterIsStale exercises the #4584 watchdog predicate directly: a
+// fresh advert reads as live (not stale); a zero or beyond-horizon
+// lastMasterSeen reads as stale (silent/dead held master).
+func TestHeldMasterIsStale(t *testing.T) {
+	vi := newHoldTestInstance(t, 200, 300)
+
+	// Fresh advert → live, not stale.
+	vi.mu.Lock()
+	vi.lastMasterPriority = 100
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+	if vi.heldMasterIsStale() {
+		t.Error("heldMasterIsStale() = true for a fresh advert, want false (live master)")
+	}
+
+	// Beyond the master-down horizon → stale.
+	vi.mu.Lock()
+	vi.lastMasterSeen = time.Now().Add(-time.Hour)
+	vi.mu.Unlock()
+	if !vi.heldMasterIsStale() {
+		t.Error("heldMasterIsStale() = false for a beyond-horizon advert, want true (silent master)")
+	}
+
+	// Never observed → stale.
+	vi.mu.Lock()
+	vi.lastMasterSeen = time.Time{}
+	vi.mu.Unlock()
+	if !vi.heldMasterIsStale() {
+		t.Error("heldMasterIsStale() = false with no advert ever seen, want true")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #4584.

When a higher-priority VRRP node defers preemption of a live lower-priority master via `preempt hold-time <N>` (#2850), arming the hold left `masterDownTimer` **idle** for the whole hold: it fired to reach the arm point, and `handleBackupRx` never resets it for a persisting lower-priority advert. So a held (VIP-owning, forwarding) lower-priority master that **died mid-hold** went undetected until `preemptHoldTimer` expired — up to ~hold-time of VIP blackhole for a genuinely dead master, violating the design's "dead master → immediate takeover" invariant. #2900 enumerated the preempt-disabled and track-demotion mid-hold cases but **not** held-master-death.

## Fix

`armPreemptHold` now **also** (re)arms `masterDownTimer` for `masterDownInterval` as a liveness watchdog. On its fire while `preemptHoldArmed`, `stepBackup` consults the new `heldMasterIsStale()`:

- **stale held master** (last advert beyond the master-down horizon → went silent) → disarm the hold and `becomeMaster()` **now** (immediate takeover of the dead master);
- **still-live held master** (adverts keep refreshing `lastMasterSeen` via `recordMasterAdvert`) → re-arm the watchdog and let the hold run to its **natural** expiry.

`heldMasterIsStale` checks **only** staleness — deliberately not the `effective>master` priority comparison — so a track-interface demotion below a *still-live* master does not fire a spurious watchdog takeover; the natural-expiry re-validation (`shouldPreemptObservedMaster`, #2900) owns that case. It reuses the same master-down staleness horizon (`3*advert + skew` on the learned interval) as the sibling preempt helpers under the same one-RLock snapshot discipline.

A **live** held master is still deferred to hold-time (preempt-hold intent preserved); a **dead** one is taken over within ~one master-down horizon. The normal preempt-hold, priority-0 graceful-resign (`skipNextPreemptHold`), config-update re-validation, sync-hold, and ~60ms fast-failover paths are unchanged.

## Tests (RED-on-revert)

- `TestHoldWatchdog_DeadHeldMaster_ImmediateTakeover` — held master dies mid-hold → watchdog fires → immediate takeover. **RED on revert** (masterDownTimer left idle after the hold arms).
- `TestHoldWatchdog_LiveHeldMaster_DefersToNaturalExpiry` — held master keeps advertising → watchdog fire stays BACKUP, hold continues to natural expiry. **RED on revert** (watchdog re-arm assertion).
- `TestHoldWatchdog_NoHoldArmed_NormalFailoverUnchanged` — no hold → normal immediate failover (watchdog branch skipped).
- `TestHeldMasterIsStale` — the predicate directly (fresh vs beyond-horizon vs never-seen).

`go test ./pkg/vrrp/...` green, incl. `-race`; `go build ./...`, `gofmt`, `go vet` clean.

## ⚠️ Requires `make test-failover` before merge

This is a **VRRP failover-timing** change. Per CLAUDE.md, any change touching VRRP/failover code MUST pass `make test-failover` on the loss userspace cluster before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi