### PR TITLE
fairness-eval arg/TSV robustness + RA configEqual CIDR normalization (#4590 LOW batch)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -40703,3 +40703,22 @@ top.
   pkg/config/schema_master_password_prf_4578_test.go, pkg/configstore/crypto.go,
   pkg/configstore/crypto_prf_sync_4578_test.go, docs/config-schema.md,
   docs/next-features/master-password.md, _Log.md
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4590 (ps-038-A1 F1/F2, RUST fairness-eval harness) — make the
+  offline `fairness-eval` CI merge gate fail-fast on bad input instead of
+  silently producing a verdict on wrong data. F1: refactored `parse_args`
+  into a testable `parse_args_from` returning `Result<Args, ParseError>`; the
+  four numeric flags (`--warmup-secs`, `--final-burst-secs`, `--n-workers`,
+  `--shaper-rate-bps`) now error (exit 2) on a mistyped/overflowing value via
+  `parse_required_numeric_value` instead of `.unwrap_or(default)`, and
+  `--n-workers 0` is rejected unconditionally (empty per-worker distribution →
+  verdict on no data). F2: `parse_binding_flows_tsv`/`parse_cos_flows_tsv`
+  count skipped malformed rows and print a stderr warning (still lenient by
+  design, but no longer silent). Added unit tests for both (RED-on-revert
+  verified by neutering). Removed now-dead exit-calling arg wrappers. Full
+  cargo suite 3718/1 (the one failure, event_stream ..._2875, is pre-existing
+  on clean origin/master — unrelated to fairness_eval).
+- **File(s)**: userspace-dp/src/fairness_eval/args.rs,
+  userspace-dp/src/fairness_eval/inputs.rs,
+  userspace-dp/src/fairness_eval/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -40722,3 +40722,14 @@ top.
 - **File(s)**: userspace-dp/src/fairness_eval/args.rs,
   userspace-dp/src/fairness_eval/inputs.rs,
   userspace-dp/src/fairness_eval/README.md, _Log.md
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4590 (ps-037-A5 A5-03, GO, pkg/ra) — `configEqual` compared
+  `NAT64Prefix` and each advertised `Prefixes[i].Prefix` as raw strings, so an
+  operator re-typing an equivalent-but-non-canonical CIDR (`64:ff9b::/96` →
+  `0064:ff9b::/96`) forced a spurious RA sender restart (sub-second RA gap)
+  even though `buildRA` re-parses via `netip.ParsePrefix` and the wire is
+  identical. Added `prefixEqual` (normalize via `netip.ParsePrefix`, exact
+  string fallback when either side is unparseable so a genuine change is never
+  masked) and routed the two CIDR compares through it. RED-on-revert verified.
+- **File(s)**: pkg/ra/ra.go, pkg/ra/ra_test.go, pkg/ra/README.md, _Log.md

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -267,6 +267,17 @@ best-effort).
   §4.2 ND timer hints wire-stamped by #4307; here 0=unspecified maps directly
   to a zero wire field with no unset/default coercion, so a plain int compare
   is exact and no companion set-flag is needed).
+  - **The converse also holds: CIDR fields compare by parsed value, not raw
+    text (#4590 A5-03).** `buildRA` re-parses `NAT64Prefix` and each advertised
+    `Prefixes[i].Prefix` via `netip.ParsePrefix`, so two strings that parse to
+    the same `netip.Prefix` produce byte-identical wire. A raw-string compare
+    therefore over-triggered: an operator re-typing an equivalent-but-
+    non-canonical form (`64:ff9b::/96` → `0064:ff9b::/96`) forced a spurious
+    sender restart (sub-second RA gap) with no wire change. `configEqual` now
+    routes those fields through `prefixEqual`, which normalizes via
+    `netip.ParsePrefix` and falls back to an exact string compare when either
+    side fails to parse (so a genuine change is never masked — an unnecessary
+    restart is harmless, a missed one is not).
 - IPv6 NODAD is set on the per-instance NDP socket so it doesn't fight
   the kernel's own duplicate-address detection on the link-local
   address.

--- a/pkg/ra/ra.go
+++ b/pkg/ra/ra.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/netip"
 	"sync"
 	"time"
 
@@ -808,7 +809,13 @@ func configEqual(a, b *config.RAInterfaceConfig) bool {
 		a.MaxAdvInterval != b.MaxAdvInterval ||
 		a.MinAdvInterval != b.MinAdvInterval ||
 		a.LinkMTU != b.LinkMTU ||
-		a.NAT64Prefix != b.NAT64Prefix ||
+		// #4590 (A5-03): compare CIDR fields by parsed value, not raw text.
+		// buildRA re-parses NAT64Prefix via netip.ParsePrefix (sender.go), so
+		// an operator re-typing an equivalent-but-non-canonical form
+		// ("64:ff9b::/96" -> "0064:ff9b::/96") produces identical wire yet a
+		// raw-string compare here reported a diff and forced a spurious RA
+		// sender restart (sub-second RA gap). Normalizing suppresses that.
+		!prefixEqual(a.NAT64Prefix, b.NAT64Prefix) ||
 		a.NAT64PrefixLife != b.NAT64PrefixLife ||
 		a.SourceLinkLocal != b.SourceLinkLocal ||
 		// #4570: reachable-time / retransmit-timer are stamped onto the wire
@@ -829,7 +836,7 @@ func configEqual(a, b *config.RAInterfaceConfig) bool {
 		return false
 	}
 	for i := range a.Prefixes {
-		if a.Prefixes[i].Prefix != b.Prefixes[i].Prefix ||
+		if !prefixEqual(a.Prefixes[i].Prefix, b.Prefixes[i].Prefix) ||
 			a.Prefixes[i].OnLink != b.Prefixes[i].OnLink ||
 			a.Prefixes[i].Autonomous != b.Prefixes[i].Autonomous ||
 			a.Prefixes[i].ValidLifetime != b.Prefixes[i].ValidLifetime ||
@@ -848,4 +855,26 @@ func configEqual(a, b *config.RAInterfaceConfig) bool {
 	}
 
 	return true
+}
+
+// prefixEqual reports whether two CIDR strings denote the same prefix,
+// tolerating equivalent-but-non-canonical textual forms. configEqual is a
+// change-detector that gates the RA sender restart; the wire is always built
+// by re-parsing the CIDR via netip.ParsePrefix (buildRA, sender.go), so two
+// strings that parse to the same netip.Prefix produce byte-identical RA
+// output. Comparing the raw strings therefore restarted the sender on a
+// purely cosmetic re-type (#4590 A5-03). If either side fails to parse (""
+// = unset, or a value that slipped past validation), fall back to an exact
+// string compare so a genuine change is never masked — an unnecessary
+// restart is harmless, a missed one is not.
+func prefixEqual(a, b string) bool {
+	if a == b {
+		return true
+	}
+	pa, errA := netip.ParsePrefix(a)
+	pb, errB := netip.ParsePrefix(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return pa == pb
 }

--- a/pkg/ra/ra_test.go
+++ b/pkg/ra/ra_test.go
@@ -522,6 +522,66 @@ func TestConfigEqual_DifferentRetransTimer(t *testing.T) {
 	}
 }
 
+// TestConfigEqual_EquivalentNAT64Prefix asserts that two textually-different
+// but equivalent NAT64 CIDR forms compare EQUAL, so a cosmetic re-type does
+// not trigger a spurious RA sender restart (#4590 A5-03). RED-on-revert:
+// restore the raw-string `a.NAT64Prefix != b.NAT64Prefix` compare and this
+// fails (the two forms are unequal as strings).
+func TestConfigEqual_EquivalentNAT64Prefix(t *testing.T) {
+	a := &config.RAInterfaceConfig{Interface: "trust0", NAT64Prefix: "64:ff9b::/96"}
+	b := &config.RAInterfaceConfig{Interface: "trust0", NAT64Prefix: "0064:ff9b:0:0::/96"}
+
+	if !configEqual(a, b) {
+		t.Error("equivalent NAT64 prefix forms should be equal (no spurious restart)")
+	}
+}
+
+// TestConfigEqual_DifferentNAT64Prefix asserts a genuine NAT64 prefix change
+// is still detected as NOT-equal (the normalization must not mask real edits).
+func TestConfigEqual_DifferentNAT64Prefix(t *testing.T) {
+	a := &config.RAInterfaceConfig{Interface: "trust0", NAT64Prefix: "64:ff9b::/96"}
+	b := &config.RAInterfaceConfig{Interface: "trust0", NAT64Prefix: "2001:db8::/96"}
+
+	if configEqual(a, b) {
+		t.Error("different NAT64 prefixes should not be equal (sender must restart)")
+	}
+}
+
+// TestConfigEqual_EquivalentAdvertisedPrefix asserts the same normalization
+// applies to advertised on-link prefixes, not just NAT64 (#4590 A5-03).
+func TestConfigEqual_EquivalentAdvertisedPrefix(t *testing.T) {
+	a := &config.RAInterfaceConfig{
+		Interface: "trust0",
+		Prefixes:  []*config.RAPrefix{{Prefix: "2001:db8::/64", OnLink: true, Autonomous: true}},
+	}
+	b := &config.RAInterfaceConfig{
+		Interface: "trust0",
+		Prefixes:  []*config.RAPrefix{{Prefix: "2001:0db8:0:0::/64", OnLink: true, Autonomous: true}},
+	}
+
+	if !configEqual(a, b) {
+		t.Error("equivalent advertised prefix forms should be equal (no spurious restart)")
+	}
+}
+
+// TestPrefixEqual_MalformedFallsBackToStringCompare asserts that when a CIDR
+// fails to parse, prefixEqual falls back to an exact string compare so a real
+// change is never masked (#4590 A5-03).
+func TestPrefixEqual_MalformedFallsBackToStringCompare(t *testing.T) {
+	if prefixEqual("not-a-cidr", "also-not-a-cidr") {
+		t.Error("distinct unparseable strings must not be treated as equal")
+	}
+	if !prefixEqual("", "") {
+		t.Error("two unset (empty) prefixes must be equal")
+	}
+	if !prefixEqual("garbage", "garbage") {
+		t.Error("identical unparseable strings must be equal via string fallback")
+	}
+	if prefixEqual("64:ff9b::/96", "") {
+		t.Error("a set prefix must differ from unset")
+	}
+}
+
 // TestConfigEqual_SameTimers guards against a spurious restart: two configs
 // with identical reachable-time/retransmit-timer (including the 0=unspecified
 // default) stay equal, so a no-op commit does not create an RA gap.

--- a/userspace-dp/src/fairness_eval/README.md
+++ b/userspace-dp/src/fairness_eval/README.md
@@ -10,3 +10,20 @@ verdict construction, and JSON report emission.
 Keep behavior compatible with `userspace-dp/tests/fairness_eval_blackbox.rs`:
 CLI flags, exit codes, TSV parsing, JSON fields, and failure-reason ordering
 are the public contract.
+
+## Input robustness (ps-038-A1 F1/F2)
+
+This is a merge gate for the CoS fairness contract (#1630/#1614), so a
+malformed input must never silently produce a PASS/FAIL on wrong data:
+
+- **Numeric CLI args fail fast.** A mistyped or overflowing value for
+  `--warmup-secs`, `--final-burst-secs`, `--n-workers`, or `--shaper-rate-bps`
+  now exits 2 (arg-validation error) instead of silently reverting to the
+  default. `--n-workers 0` is rejected unconditionally (a zero worker count
+  yields an empty per-worker distribution → a verdict on no data). The
+  parsing core is `args::parse_args_from`, tested directly in `args.rs`.
+- **Malformed TSV rows are counted and warned.** `parse_binding_flows_tsv` /
+  `parse_cos_flows_tsv` still skip a non-numeric or wrong-column-count row
+  (lenient by design), but now count the skips and print
+  `skipped N malformed row(s)` to stderr so a truncated/corrupted Prometheus
+  scrape is visible rather than silently undercounting a worker's samples.

--- a/userspace-dp/src/fairness_eval/args.rs
+++ b/userspace-dp/src/fairness_eval/args.rs
@@ -24,7 +24,46 @@ pub(crate) struct Args {
     pub(crate) expect_saturation: bool,
 }
 
+const USAGE: &str = "Usage: fairness-eval --iperf-json PATH --binding-flows PATH \\\n  [--cos-flows PATH --cos-ifindex N --cos-queue-id N] \\\n  [--iface NAME] [--warmup-secs N] [--final-burst-secs N] \\\n  [--n-workers N] [--shaper-rate-bps N] [--rss-expectation EXPR] \\\n  [--expect-saturation]\n\n--iface NAME: filter binding-flows rows to this interface (recommended for legacy per-binding mode).\n--cos-flows: class-specific CoS active-flow TSV; when present, Cstruct uses the selected CoS queue.\n--rss-expectation: any, balanced, at-least-active-workers:N, max-worker-flow-share:X, or cstruct-max:X.\n--expect-saturation: declare the offered load >= structural cap; enforces Gate 3 (aggregate >= 95% of the Na/Nv-scaled cap).";
+
+/// Outcome of a failed `parse_args_from` — distinguishes a usage/validation
+/// error (exit 2) from an explicit `--help` request (exit 0).
+#[derive(Debug)]
+pub(crate) enum ParseError {
+    /// Bad or missing argument. Carries the operator-facing message.
+    Usage(String),
+    /// `-h`/`--help` was passed; the caller prints usage and exits 0.
+    HelpRequested,
+}
+
 pub(crate) fn parse_args() -> Args {
+    match parse_args_from(std::env::args().skip(1)) {
+        Ok(args) => args,
+        Err(ParseError::HelpRequested) => {
+            eprintln!("{USAGE}");
+            std::process::exit(0);
+        }
+        Err(ParseError::Usage(msg)) => {
+            eprintln!("fairness-eval: {msg}");
+            std::process::exit(2);
+        }
+    }
+}
+
+/// Parse an argument iterator into `Args`, returning a structured error
+/// instead of calling `std::process::exit`. This is the testable core of
+/// `parse_args`.
+///
+/// A mistyped or out-of-range numeric value for `--warmup-secs`,
+/// `--final-burst-secs`, `--n-workers`, or `--shaper-rate-bps` now returns
+/// `ParseError::Usage` rather than silently falling back to the default
+/// (ps-038-A1 F1). A silent fallback here could seed a false PASS/FAIL from
+/// this fairness merge gate (#1630/#1614), so the harness fails fast on an
+/// operator CLI mistake.
+pub(crate) fn parse_args_from<I>(raw_args: I) -> Result<Args, ParseError>
+where
+    I: IntoIterator<Item = String>,
+{
     let mut iperf_json: Option<PathBuf> = None;
     let mut binding_flows: Option<PathBuf> = None;
     let mut cos_flows: Option<PathBuf> = None;
@@ -37,91 +76,98 @@ pub(crate) fn parse_args() -> Args {
     let mut shaper_rate_bps: u64 = 0;
     let mut rss_expectation: String = "any".to_string();
     let mut expect_saturation: bool = false;
-    let mut args = std::env::args().skip(1).peekable();
+    let mut args = raw_args.into_iter();
     while let Some(arg) = args.next() {
         match arg.as_str() {
             "--iperf-json" => {
-                iperf_json = args.next().map(PathBuf::from);
+                iperf_json = Some(PathBuf::from(numeric_or_string(
+                    parse_required_string_value("--iperf-json", args.next()),
+                )?));
             }
             "--binding-flows" => {
-                binding_flows = args.next().map(PathBuf::from);
+                binding_flows = Some(PathBuf::from(numeric_or_string(
+                    parse_required_string_value("--binding-flows", args.next()),
+                )?));
             }
             "--cos-flows" => {
-                cos_flows = Some(PathBuf::from(parse_required_string_arg(
-                    "--cos-flows",
-                    args.next(),
-                )));
+                cos_flows = Some(PathBuf::from(numeric_or_string(
+                    parse_required_string_value("--cos-flows", args.next()),
+                )?));
             }
             "--cos-ifindex" => {
-                cos_ifindex = Some(parse_required_numeric_arg("--cos-ifindex", args.next()));
+                cos_ifindex = Some(numeric_or_string(parse_required_numeric_value(
+                    "--cos-ifindex",
+                    args.next(),
+                ))?);
             }
             "--cos-queue-id" => {
-                cos_queue_id = Some(parse_required_numeric_arg("--cos-queue-id", args.next()));
+                cos_queue_id = Some(numeric_or_string(parse_required_numeric_value(
+                    "--cos-queue-id",
+                    args.next(),
+                ))?);
             }
             "--iface" => {
                 iface = args.next().unwrap_or_default();
             }
             "--warmup-secs" => {
-                warmup_secs = args.next().and_then(|s| s.parse().ok()).unwrap_or(5);
+                warmup_secs =
+                    numeric_or_string(parse_required_numeric_value("--warmup-secs", args.next()))?;
             }
             "--final-burst-secs" => {
-                final_burst_secs = args.next().and_then(|s| s.parse().ok()).unwrap_or(1);
+                final_burst_secs = numeric_or_string(parse_required_numeric_value(
+                    "--final-burst-secs",
+                    args.next(),
+                ))?;
             }
             "--n-workers" => {
-                n_workers = args.next().and_then(|s| s.parse().ok()).unwrap_or(6);
+                n_workers =
+                    numeric_or_string(parse_required_numeric_value("--n-workers", args.next()))?;
             }
             "--shaper-rate-bps" => {
-                shaper_rate_bps = args.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+                shaper_rate_bps = numeric_or_string(parse_required_numeric_value(
+                    "--shaper-rate-bps",
+                    args.next(),
+                ))?;
             }
             "--rss-expectation" => {
-                rss_expectation = parse_required_string_arg("--rss-expectation", args.next());
+                rss_expectation = numeric_or_string(parse_required_string_value(
+                    "--rss-expectation",
+                    args.next(),
+                ))?;
             }
             "--expect-saturation" => {
                 expect_saturation = true;
             }
             "-h" | "--help" => {
-                eprintln!(
-                    "Usage: fairness-eval --iperf-json PATH --binding-flows PATH \\\n  [--cos-flows PATH --cos-ifindex N --cos-queue-id N] \\\n  [--iface NAME] [--warmup-secs N] [--final-burst-secs N] \\\n  [--n-workers N] [--shaper-rate-bps N] [--rss-expectation EXPR] \\\n  [--expect-saturation]\n\n--iface NAME: filter binding-flows rows to this interface (recommended for legacy per-binding mode).\n--cos-flows: class-specific CoS active-flow TSV; when present, Cstruct uses the selected CoS queue.\n--rss-expectation: any, balanced, at-least-active-workers:N, max-worker-flow-share:X, or cstruct-max:X.\n--expect-saturation: declare the offered load >= structural cap; enforces Gate 3 (aggregate >= 95% of the Na/Nv-scaled cap)."
-                );
-                std::process::exit(0);
+                return Err(ParseError::HelpRequested);
             }
             _ => {
-                eprintln!("fairness-eval: unknown arg {arg}; try --help");
-                std::process::exit(2);
+                return Err(ParseError::Usage(format!("unknown arg {arg}; try --help")));
             }
         }
     }
-    let iperf_json = match iperf_json {
-        Some(p) => p,
-        None => {
-            eprintln!("fairness-eval: --iperf-json is required");
-            std::process::exit(2);
-        }
-    };
-    let binding_flows = match binding_flows {
-        Some(p) => p,
-        None => {
-            eprintln!("fairness-eval: --binding-flows is required");
-            std::process::exit(2);
-        }
-    };
+    let iperf_json =
+        iperf_json.ok_or_else(|| ParseError::Usage("--iperf-json is required".to_string()))?;
+    let binding_flows = binding_flows
+        .ok_or_else(|| ParseError::Usage("--binding-flows is required".to_string()))?;
+    // A zero worker count is always an operator mistake: the per-worker
+    // aggregation runs over `0..n_workers`, so n_workers==0 yields an empty
+    // distribution and the verdict passes on no data. Reject it
+    // unconditionally, not only under --expect-saturation (ps-038-A1 F1).
+    if n_workers == 0 {
+        return Err(ParseError::Usage("--n-workers must be > 0".to_string()));
+    }
     // --expect-saturation requires the Nₐ/Nᵥ-scaled cap inputs. A missing
-    // --shaper-rate-bps or a zero --n-workers is an operator CLI mistake,
-    // not a fairness regression, so fail fast with an arg-validation error
-    // (exit 2) instead of letting it surface as a Gate-3 FAIL (exit 1) —
-    // otherwise automation would misclassify a config error as a
-    // fairness failure (Copilot #2).
+    // --shaper-rate-bps is an operator CLI mistake, not a fairness
+    // regression, so fail fast with an arg-validation error (exit 2) instead
+    // of letting it surface as a Gate-3 FAIL (exit 1) — otherwise automation
+    // would misclassify a config error as a fairness failure (Copilot #2).
     if expect_saturation && shaper_rate_bps == 0 {
-        eprintln!(
-            "fairness-eval: --expect-saturation requires --shaper-rate-bps > 0 to compute the Na/Nv-scaled structural cap"
-        );
-        std::process::exit(2);
+        return Err(ParseError::Usage(
+            "--expect-saturation requires --shaper-rate-bps > 0 to compute the Na/Nv-scaled structural cap".to_string(),
+        ));
     }
-    if expect_saturation && n_workers == 0 {
-        eprintln!("fairness-eval: --expect-saturation requires --n-workers > 0");
-        std::process::exit(2);
-    }
-    Args {
+    Ok(Args {
         iperf_json,
         binding_flows,
         cos_flows,
@@ -134,30 +180,13 @@ pub(crate) fn parse_args() -> Args {
         shaper_rate_bps,
         rss_expectation,
         expect_saturation,
-    }
+    })
 }
 
-fn parse_required_numeric_arg<T>(flag: &str, raw: Option<String>) -> T
-where
-    T: std::str::FromStr,
-{
-    match parse_required_numeric_value(flag, raw) {
-        Ok(value) => value,
-        Err(err) => {
-            eprintln!("fairness-eval: {err}");
-            std::process::exit(2);
-        }
-    }
-}
-
-fn parse_required_string_arg(flag: &str, raw: Option<String>) -> String {
-    match parse_required_string_value(flag, raw) {
-        Ok(value) => value,
-        Err(err) => {
-            eprintln!("fairness-eval: {err}");
-            std::process::exit(2);
-        }
-    }
+/// Map a `Result<T, String>` from the low-level parse helpers into the
+/// structured `ParseError::Usage` used by `parse_args_from`.
+fn numeric_or_string<T>(res: Result<T, String>) -> Result<T, ParseError> {
+    res.map_err(ParseError::Usage)
 }
 
 fn parse_required_string_value(flag: &str, raw: Option<String>) -> Result<String, String> {
@@ -243,5 +272,111 @@ mod tests {
         let err = parse_required_string_value("--cos-flows", Some("--cos-ifindex".to_string()))
             .unwrap_err();
         assert!(err.contains("--cos-flows"), "err: {err}");
+    }
+
+    fn argv(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn usage_msg(res: Result<Args, ParseError>) -> String {
+        match res {
+            Err(ParseError::Usage(msg)) => msg,
+            Err(ParseError::HelpRequested) => panic!("expected Usage error, got HelpRequested"),
+            Ok(_) => panic!("expected Usage error, got Ok"),
+        }
+    }
+
+    #[test]
+    fn parse_args_from_accepts_valid_numeric_flags() {
+        let args = parse_args_from(argv(&[
+            "--iperf-json",
+            "/tmp/iperf.json",
+            "--binding-flows",
+            "/tmp/bind.tsv",
+            "--warmup-secs",
+            "7",
+            "--final-burst-secs",
+            "3",
+            "--n-workers",
+            "12",
+            "--shaper-rate-bps",
+            "25000000000",
+        ]))
+        .expect("valid args parse");
+        assert_eq!(args.warmup_secs, 7);
+        assert_eq!(args.final_burst_secs, 3);
+        assert_eq!(args.n_workers, 12);
+        assert_eq!(args.shaper_rate_bps, 25_000_000_000);
+    }
+
+    #[test]
+    fn parse_args_from_rejects_bad_numeric_value_no_silent_fallback() {
+        // ps-038-A1 F1: a mistyped / overflowing numeric value must error,
+        // NOT silently fall back to the default.
+        for flag in [
+            "--warmup-secs",
+            "--final-burst-secs",
+            "--n-workers",
+            "--shaper-rate-bps",
+        ] {
+            let msg = usage_msg(parse_args_from(argv(&[
+                "--iperf-json",
+                "/tmp/iperf.json",
+                "--binding-flows",
+                "/tmp/bind.tsv",
+                flag,
+                "not-a-number",
+            ])));
+            assert!(
+                msg.contains(flag) && msg.contains("numeric"),
+                "flag {flag}: msg {msg}"
+            );
+        }
+
+        // u32 overflow on --n-workers is also a parse error, not a default.
+        let msg = usage_msg(parse_args_from(argv(&[
+            "--iperf-json",
+            "/tmp/iperf.json",
+            "--binding-flows",
+            "/tmp/bind.tsv",
+            "--n-workers",
+            "99999999999",
+        ])));
+        assert!(msg.contains("--n-workers"), "msg {msg}");
+    }
+
+    #[test]
+    fn parse_args_from_rejects_zero_workers_unconditionally() {
+        // ps-038-A1 F1: n_workers==0 yields an empty per-worker distribution
+        // and a verdict on no data — reject even without --expect-saturation.
+        let msg = usage_msg(parse_args_from(argv(&[
+            "--iperf-json",
+            "/tmp/iperf.json",
+            "--binding-flows",
+            "/tmp/bind.tsv",
+            "--n-workers",
+            "0",
+        ])));
+        assert!(
+            msg.contains("--n-workers") && msg.contains("> 0"),
+            "msg {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_args_from_requires_inputs_and_reports_help() {
+        assert!(
+            usage_msg(parse_args_from(argv(&["--binding-flows", "/tmp/b.tsv"])))
+                .contains("--iperf-json")
+        );
+        assert!(
+            usage_msg(parse_args_from(argv(&["--iperf-json", "/tmp/i.json"])))
+                .contains("--binding-flows")
+        );
+        assert!(matches!(
+            parse_args_from(argv(&["--help"])),
+            Err(ParseError::HelpRequested)
+        ));
+        assert!(usage_msg(parse_args_from(argv(&["--bogus"]))).contains("unknown arg"));
     }
 }

--- a/userspace-dp/src/fairness_eval/inputs.rs
+++ b/userspace-dp/src/fairness_eval/inputs.rs
@@ -170,116 +170,106 @@ pub(crate) fn parse_binding_flows_tsv(path: &PathBuf) -> Result<Vec<BindingFlows
     // versions), if only 3 columns are present, the iface filter is
     // treated as no-filter and worker_id defaults to binding_slot.
     let s = read_to_string(path)?;
+    let (rows, skipped) = parse_binding_flows_rows(&s);
+    warn_skipped("parse_binding_flows_tsv", path, skipped);
+    Ok(rows)
+}
+
+fn parse_binding_flows_rows(s: &str) -> (Vec<BindingFlowsRow>, usize) {
     let mut rows: Vec<BindingFlowsRow> = Vec::new();
+    let mut skipped = 0usize;
     for line in s.lines() {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.len() == 6 {
-            let ts: u64 = match parts[0].parse() {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-            let slot: u32 = match parts[1].parse() {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-            let qid: u32 = match parts[2].parse() {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-            let wid: u32 = match parts[3].parse() {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-            let iface = parts[4].to_string();
-            let count: u32 = match parts[5].parse() {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-            rows.push(BindingFlowsRow {
-                timestamp: ts,
-                binding_slot: slot,
-                queue_id: qid,
-                worker_id: wid,
-                iface,
-                count,
-            });
-        } else if parts.len() == 3 {
-            // Legacy 3-column format: timestamp, binding_slot, count.
-            // Pretend slot==worker_id and iface=="" so it still works
-            // (caller responsible for ensuring single-iface workload).
-            let ts: u64 = match parts[0].parse() {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-            let slot: u32 = match parts[1].parse() {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-            let count: u32 = match parts[2].parse() {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-            rows.push(BindingFlowsRow {
-                timestamp: ts,
-                binding_slot: slot,
-                queue_id: 0,
-                worker_id: slot,
-                iface: String::new(),
-                count,
-            });
+        match parse_binding_flows_line(line) {
+            Some(row) => rows.push(row),
+            None => skipped += 1,
         }
-        // Other formats: silently skipped.
     }
-    Ok(rows)
+    (rows, skipped)
+}
+
+fn parse_binding_flows_line(line: &str) -> Option<BindingFlowsRow> {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.len() == 6 {
+        Some(BindingFlowsRow {
+            timestamp: parts[0].parse().ok()?,
+            binding_slot: parts[1].parse().ok()?,
+            queue_id: parts[2].parse().ok()?,
+            worker_id: parts[3].parse().ok()?,
+            iface: parts[4].to_string(),
+            count: parts[5].parse().ok()?,
+        })
+    } else if parts.len() == 3 {
+        // Legacy 3-column format: timestamp, binding_slot, count.
+        // Pretend slot==worker_id and iface=="" so it still works
+        // (caller responsible for ensuring single-iface workload).
+        let slot: u32 = parts[1].parse().ok()?;
+        Some(BindingFlowsRow {
+            timestamp: parts[0].parse().ok()?,
+            binding_slot: slot,
+            queue_id: 0,
+            worker_id: slot,
+            iface: String::new(),
+            count: parts[2].parse().ok()?,
+        })
+    } else {
+        None
+    }
 }
 
 pub(crate) fn parse_cos_flows_tsv(path: &PathBuf) -> Result<Vec<CosFlowsRow>, String> {
     // Format: timestamp\tifindex\tqueue_id\tworker_id\tcount.
     // Source metric: xpf_userspace_cos_active_flow_count.
     let s = read_to_string(path)?;
+    let (rows, skipped) = parse_cos_flows_rows(&s);
+    warn_skipped("parse_cos_flows_tsv", path, skipped);
+    Ok(rows)
+}
+
+fn parse_cos_flows_rows(s: &str) -> (Vec<CosFlowsRow>, usize) {
     let mut rows: Vec<CosFlowsRow> = Vec::new();
+    let mut skipped = 0usize;
     for line in s.lines() {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.len() != 5 {
-            continue;
+        match parse_cos_flows_line(line) {
+            Some(row) => rows.push(row),
+            None => skipped += 1,
         }
-        let ts: u64 = match parts[0].parse() {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        let ifindex: i32 = match parts[1].parse() {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        let qid: u32 = match parts[2].parse() {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        let wid: u32 = match parts[3].parse() {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        let count: u32 = match parts[4].parse() {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        rows.push(CosFlowsRow {
-            timestamp: ts,
-            ifindex,
-            queue_id: qid,
-            worker_id: wid,
-            count,
-        });
     }
-    Ok(rows)
+    (rows, skipped)
+}
+
+fn parse_cos_flows_line(line: &str) -> Option<CosFlowsRow> {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.len() != 5 {
+        return None;
+    }
+    Some(CosFlowsRow {
+        timestamp: parts[0].parse().ok()?,
+        ifindex: parts[1].parse().ok()?,
+        queue_id: parts[2].parse().ok()?,
+        worker_id: parts[3].parse().ok()?,
+        count: parts[4].parse().ok()?,
+    })
+}
+
+/// Emit a stderr warning when a TSV parse skipped one or more malformed rows.
+/// A silent skip (ps-038-A1 F2) can undercount one worker's samples and flip
+/// the CoV/fairness gate silently; surfacing the count lets the harness
+/// operator notice a corrupted/truncated Prometheus scrape.
+fn warn_skipped(parser: &str, path: &PathBuf, skipped: usize) {
+    if skipped > 0 {
+        eprintln!(
+            "fairness-eval: {parser}: skipped {skipped} malformed row(s) in {}",
+            path.display()
+        );
+    }
 }
 
 #[cfg(test)]
@@ -378,5 +368,39 @@ mod tests {
         assert_eq!(rows[0].queue_id, 4);
         assert_eq!(rows[0].worker_id, 1);
         assert_eq!(rows[0].count, 7);
+    }
+
+    #[test]
+    fn binding_flows_counts_skipped_malformed_rows() {
+        // ps-038-A1 F2: malformed rows must be COUNTED (and surfaced via a
+        // warning), not silently dropped. Comment + blank lines are NOT
+        // skips; a non-numeric field and a wrong-column-count row are.
+        let content = "\
+# header comment\n\
+\n\
+1000\t0\t0\t0\tge-0-0-2\t2\n\
+1000\tXXX\t0\t0\tge-0-0-2\t2\n\
+1000\t0\t0\n\
+1000 0 0 0 ge-0-0-2\n\
+2000\t1\t1\t1\tge-0-0-2\t3\n";
+        let (rows, skipped) = parse_binding_flows_rows(content);
+        // 2 valid 6-col rows + 1 valid 3-col row.
+        assert_eq!(rows.len(), 3, "valid rows: {rows:?}");
+        // 1 non-numeric 6-col + 1 unsupported 4-col => 2 skips.
+        assert_eq!(skipped, 2, "skipped count");
+    }
+
+    #[test]
+    fn cos_flows_counts_skipped_malformed_rows() {
+        // ps-038-A1 F2 for the CoS TSV parser.
+        let content = "\
+# timestamp\tifindex\tqueue_id\tworker_id\tcount\n\
+1000\t80\t4\t1\t7\n\
+1000\t80\tbad\t1\t7\n\
+1000\t80\t4\t1\n";
+        let (rows, skipped) = parse_cos_flows_rows(content);
+        assert_eq!(rows.len(), 1, "valid rows: {rows:?}");
+        // 1 non-numeric queue_id + 1 wrong-column-count => 2 skips.
+        assert_eq!(skipped, 2, "skipped count");
     }
 }


### PR DESCRIPTION
Drives the CLEAN, non-test-failover-gated LOW items from #4590 (ps-037/038 audit). All items are LOW; two lanes.

## Driven

### fairness-eval harness (RUST, ps-038-A1 F1/F2) — `userspace-dp/src/fairness_eval/`
The offline `fairness-eval` binary is a merge gate for the CoS fairness contract (#1630/#1614), so a malformed input must not silently produce a verdict on wrong data.

- **F1 — numeric CLI args no longer silently fall back to defaults** (`args.rs`). `--warmup-secs`, `--final-burst-secs`, `--n-workers`, `--shaper-rate-bps` used `.unwrap_or(default)`, so a mistyped/overflowing value silently reverted. Refactored `parse_args` into a testable `parse_args_from` returning `Result<Args, ParseError>`; the four flags now error (exit 2) on a bad value via the existing `parse_required_numeric_value`. `--n-workers 0` is rejected unconditionally (empty per-worker distribution → verdict on no data). Dead exit-calling wrappers removed.
- **F2 — TSV parsers count + warn on skipped malformed rows** (`inputs.rs`). `parse_binding_flows_tsv` / `parse_cos_flows_tsv` stay lenient (still skip a bad row) but now count skips and print `skipped N malformed row(s)` to stderr, so a truncated/corrupted Prometheus scrape is visible instead of silently undercounting a worker.

### RA configEqual CIDR normalization (GO, ps-037-A5 A5-03) — `pkg/ra/`
`configEqual` gates the RA sender restart. It compared `NAT64Prefix` and each advertised `Prefixes[i].Prefix` as raw strings, but `buildRA` re-parses those CIDRs via `netip.ParsePrefix` before stamping the wire — so an operator re-typing an equivalent-but-non-canonical form (`64:ff9b::/96` → `0064:ff9b::/96`) forced a spurious sender restart (sub-second RA gap) with no wire change. Added `prefixEqual` (normalize via `netip.ParsePrefix`; exact-string fallback when either side is unparseable so a genuine change is never masked) and routed the two CIDR compares through it. This is the converse of the #4119 / #4570 configEqual completeness fixes.

## Skipped (deliberate — this PR does not close #4590)

- **A2 L-001 (RUST nat, persistent-NAT lease not HA-synced)** — the triage lane is **needs-research**, not a clean mechanical patch: the fix is a wire-format design decision (extend HA session-sync to carry `persistent_nat` + `PersistentSourceKey`, spanning Go control-plane + Rust dataplane) vs. documenting the EIM-resets-on-failover limitation. Out of scope for an inline LOW patch.
- **A5-07 (GARP burst not paced across RGs)** — **speculative** (no concrete storm threshold; 100 RGs × ~4 sub-64-byte frames over ~150 ms is far below typical storm-control) and any change to GARP pacing risks the #2081/#2082 storm-control / failover-timing invariants and would require `make test-failover` to validate safely. Deferred rather than force a speculative, failover-gated change into an inline merge.

## Validation
- `go test ./pkg/ra/...` green; `gofmt`/`go vet` clean; `go build ./...` OK.
- Full `cargo test` (serial): **3718 passed, 2 ignored**, 1 failure — `event_stream::tests::test_paused_telemetry_eviction_does_not_poison_drain_2875`, which is **pre-existing on clean origin/master** (verified by stashing these changes and re-running) and unrelated to `fairness_eval`. All 38 `fairness_eval::*` tests pass. `rustfmt --check` clean on changed files.
- RED-on-revert verified for every driven item: A5-03 equivalent-form tests fail when the raw-string compare is restored; F1 zero-workers guard and F2 skip counters fail when neutered.

Addresses #4590.