### PR TITLE
event_stream: fix #2875 telemetry-eviction test budget underflow (Closes #4607)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-07-07 — #4607 event_stream: seed queue budget in the #2875 telemetry-eviction test
+
+- **Timestamp**: 2026-07-07
+- **Action**: BROKEN-MASTER fix. `test_paused_telemetry_eviction_does_not_
+  poison_drain_2875` (`userspace-dp/src/event_stream/tests.rs`) panicked on
+  clean master in DEBUG builds — `debug_assert!(false, "dataplane event queue
+  budget underflow")` at `producer.rs:418` — and in RELEASE leaked the
+  `budget underflow (local counter only)` stderr line (the debug_assert is
+  compiled out there, so `decrement_if_positive` just saturated at 0). ROOT
+  CAUSE = TEST DRIFT, not a production bug: the test fills the replay buffer
+  by calling `push_replay_frame` with `telemetry_seq_frame` (`MSG_SCREEN_DROP`)
+  directly, bypassing the producer's `emit`/`try_acquire`. `MSG_SCREEN_DROP`
+  carries a `dataplane_event_kind()`, so evicting the oldest frame calls
+  `release(ScreenDrop)` → `decrement_if_positive` on a per-kind counter that
+  was never acquired → underflow. The sibling
+  `test_paused_session_eviction_poisons_drain_2875` uses `MSG_SESSION_OPEN`,
+  which has no `dataplane_event_kind()`, so it never touches the budget — which
+  is why only the telemetry variant tripped. Production is balanced (every
+  buffered telemetry frame holds a slot from emit to removal) and robust
+  (`decrement_if_positive` saturates); the debug_assert is a correct tripwire
+  the faked test state trips. Also note the test's 4097 same-kind frames are
+  not a production-reachable state — `max_kind_queued` (820) < REPLAY_BUFFER_
+  CAPACITY (4096) caps a single kind at admission. FIX: added a `#[cfg(test)]`
+  `DataplaneEventQueueBudget::acquire_for_test()` (raw counter bump, bypassing
+  the admission cap) + a `push_budgeted_replay_frame` test helper that seeds the
+  slot for any injected frame carrying a `dataplane_event_kind()`, mirroring
+  emit. Test now GREEN in both debug and release; drain still completes
+  (DrainComplete, no spurious FullResync) — the #2875 assertion is unchanged.
+- **File(s)**: `userspace-dp/src/event_stream/producer.rs`,
+  `userspace-dp/src/event_stream/tests.rs`,
+  `userspace-dp/src/event_stream/README.md`, `_Log.md`
+- Closes #4607.
+
 ## 2026-07-07 — #4599 zeroize: erase self-signed REST-API TLS pair under /etc/xpf/tls
 
 - **Timestamp**: 2026-07-07

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -400,7 +400,15 @@ cluster-scoped.
   saturates at zero; an underflow (accounting invariant broken) bumps a
   local-only diagnostic counter and logs one stderr line on first hit
   (#1826 — release builds compile out the debug_assert, the counter is
-  intentionally not wire-plumbed).
+  intentionally not wire-plumbed). The invariant is symmetric: every
+  telemetry frame that reaches the replay buffer acquired one budget slot
+  at emit, so its release on eviction/ACK-trim/shutdown is always balanced.
+  A unit test that injects telemetry frames directly (`push_replay_frame`,
+  bypassing `emit`) MUST seed that slot with
+  `DataplaneEventQueueBudget::acquire_for_test()` for each frame, or the
+  eviction's release trips the debug_assert on a zero counter (#4607 — the
+  #2875 telemetry-eviction test bypassed the seed; session-sync frames need
+  no seed because they carry no `dataplane_event_kind()`).
 - The Go daemon must know every helper→daemon frame type that carries a
   sequence number. For RT_FLOW-style dataplane telemetry, the daemon
   decodes valid frames through the same RT_FLOW adapter used for ringbuf

--- a/userspace-dp/src/event_stream/producer.rs
+++ b/userspace-dp/src/event_stream/producer.rs
@@ -176,6 +176,29 @@ impl DataplaneEventQueueBudget {
         decrement_if_positive(&self.kind_queued[kind_index(kind)]);
         decrement_if_positive(&self.total_queued);
     }
+
+    /// Test-only budget seed: increment the per-kind (and total) queue budget
+    /// that a real `emit`/`try_acquire` would have charged for a frame.
+    ///
+    /// The mod-level replay/drain tests build the replay buffer directly (via
+    /// `push_replay_frame`) to construct a full-buffer eviction scenario,
+    /// deliberately bypassing the producer's `emit` path. Any injected frame
+    /// carrying a `dataplane_event_kind()` (telemetry: deny/screen/filter/
+    /// RT_FLOW) is released through `release()` when it is evicted or popped;
+    /// without the matching acquire the release decrements a zero counter and
+    /// trips the #1826 underflow guard (`decrement_if_positive`). Seeding the
+    /// budget here mirrors production, where every buffered telemetry frame
+    /// holds exactly one budget slot from emit until removal.
+    ///
+    /// Bypasses the admission caps on purpose: the direct-injection tests build
+    /// buffer states larger than a single kind's admission budget (which
+    /// `try_acquire` would refuse), so this is a raw counter bump, not an
+    /// admission decision.
+    #[cfg(test)]
+    pub(super) fn acquire_for_test(&self, kind: DataplaneEventKind) {
+        self.total_queued.fetch_add(1, Ordering::Relaxed);
+        self.kind_queued[kind_index(kind)].fetch_add(1, Ordering::Relaxed);
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/userspace-dp/src/event_stream/tests.rs
+++ b/userspace-dp/src/event_stream/tests.rs
@@ -2052,6 +2052,27 @@ fn telemetry_seq_frame(seq: u64) -> EventFrame {
     }
 }
 
+// Inject a telemetry frame into the replay buffer AND seed the per-kind queue
+// budget the producer's `emit` would have charged for it (#4607). The #2875
+// tests build the buffer directly via `push_replay_frame`, bypassing `emit`;
+// a telemetry frame (SCREEN_DROP etc.) carries a `dataplane_event_kind()`, so
+// when it is evicted/popped the I/O path calls `release()` on its budget. In
+// production that release balances the acquire taken at emit; without the seed
+// here the release decrements a zero counter and trips the #1826 underflow
+// guard (`decrement_if_positive`) — the actual #4607 panic. Session-sync
+// frames (`replay_seq_frame`) have no `dataplane_event_kind()`, so they never
+// touch the budget and do not need this.
+fn push_budgeted_replay_frame(
+    shared: &Arc<EventStreamShared>,
+    replay_buf: &mut VecDeque<EventFrame>,
+    frame: EventFrame,
+) {
+    if let Some(kind) = frame.dataplane_event_kind() {
+        shared.dataplane_event_queue.acquire_for_test(kind);
+    }
+    push_replay_frame(shared, replay_buf, frame);
+}
+
 // #2875 fail-on-revert guard: pause the helper, overrun the bounded replay
 // buffer so a SESSION-SYNC delta is evicted, then issue DrainRequest. The drain
 // MUST be poisoned — it withholds DrainComplete and emits a FullResync instead,
@@ -2124,11 +2145,13 @@ fn test_paused_telemetry_eviction_does_not_poison_drain_2875() {
     let mut replay_buf: VecDeque<EventFrame> = VecDeque::new();
 
     // Fill to capacity with TELEMETRY frames, then evict one while paused.
+    // Each frame is injected with its queue budget seeded (#4607) so the
+    // eviction's `release` is balanced, exactly as production emit/release is.
     for seq in 1..=REPLAY_BUFFER_CAPACITY as u64 {
-        push_replay_frame(&shared, &mut replay_buf, telemetry_seq_frame(seq));
+        push_budgeted_replay_frame(&shared, &mut replay_buf, telemetry_seq_frame(seq));
     }
     shared.paused.store(true, Ordering::Release);
-    push_replay_frame(
+    push_budgeted_replay_frame(
         &shared,
         &mut replay_buf,
         telemetry_seq_frame(REPLAY_BUFFER_CAPACITY as u64 + 1),


### PR DESCRIPTION
## Summary

BROKEN-MASTER fix for #4607. The #2875 regression test
`test_paused_telemetry_eviction_does_not_poison_drain_2875` panicked on
clean master in **debug** builds with `dataplane event queue budget
underflow` at `userspace-dp/src/event_stream/producer.rs:418` (the
`debug_assert!(false, ...)`), and in **release** leaked the one-shot
`budget underflow (local counter only)` stderr line (the debug_assert is
compiled out there, so `decrement_if_positive` just saturated at zero).
`make test-rust` runs `--release`, which is why CI stayed green while a
plain debug `cargo test` went red.

## Root cause: test drift (not a production bug)

The test fills the bounded replay buffer by calling `push_replay_frame`
with `telemetry_seq_frame` (a `MSG_SCREEN_DROP` frame) **directly**,
deliberately bypassing the producer's `emit` / `try_acquire` path so it
can reach `REPLAY_BUFFER_CAPACITY` (single-kind admission caps at
`max_kind_queued` = 820, far below the 4096 buffer, so this buffer state
is unreachable through `emit`). `MSG_SCREEN_DROP` carries a
`dataplane_event_kind()`, so evicting the oldest frame runs
`release(ScreenDrop)` -> `decrement_if_positive` on a per-kind counter
that was **never acquired** -> underflow. The sibling
`test_paused_session_eviction_poisons_drain_2875` uses `MSG_SESSION_OPEN`
(no `dataplane_event_kind()`), so it never touches the budget -- which is
why only the telemetry variant tripped.

Production is correct and balanced: every telemetry frame that reaches
the replay buffer acquired exactly one budget slot at emit, released once
on eviction / ACK-trim / shutdown. `decrement_if_positive` is also robust
(saturates at zero); the `debug_assert` is a correct tripwire the test's
faked buffer state trips.

## Fix (test side)

- `producer.rs`: add `#[cfg(test)] DataplaneEventQueueBudget::acquire_for_test`
  -- raw per-kind + total counter bump (bypasses the admission cap, since
  the direct-injection test builds an over-cap buffer on purpose).
- `tests.rs`: add `push_budgeted_replay_frame` helper that seeds the slot
  for any injected frame carrying a `dataplane_event_kind()`, mirroring
  `emit`; use it in the #2875 telemetry test.
- `event_stream/README.md`: document the symmetric-invariant test contract.

The #2875 assertions (no poison on telemetry eviction, `DrainComplete`
still emitted, no spurious `FullResync`) are unchanged.

## Validation

FULL cargo suite serial (release, `--test-threads=1`, as `make test-rust`):
`3718 passed; 0 failed; 2 ignored` in the main bin (+ 60 / 8 / 22 / 1
across the other targets), with the previously-RED
`test_paused_telemetry_eviction_does_not_poison_drain_2875` now `ok` and
no underflow stderr leak. Also confirmed green in a **debug** build (where
it previously panicked at producer.rs:418).

Closes #4607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
