### PR TITLE
frr: sanitize the three route-map slots #4482 missed; complete the guard

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -40818,3 +40818,26 @@ top.
   string fallback when either side is unparseable so a genuine change is never
   masked) and routed the two CIDR compares through it. RED-on-revert verified.
 - **File(s)**: pkg/ra/ra.go, pkg/ra/ra_test.go, pkg/ra/README.md, _Log.md
+
+- **Timestamp**: 2026-07-08
+- **Action**: #4498 (FRR sanitize-belt residual + #4482 test completeness, GO,
+  pkg/frr) — the #4494 hostile review flagged three route-map free-text slots
+  the #4482 sweep missed, still rendering with a bare `%s` on the tolerant-load
+  path (peer-sync / rollback / lenient load, where the strict #1798 commit gate
+  only warns, #1960): `set ip/ipv6 next-hop <term.NextHop>`, `set origin
+  <term.Origin>`, and `match source-protocol <proto>`. All three now pass
+  through `sanitizeFRRValue` (parity with the #4482/#4097 belt) so a value with
+  an embedded newline cannot inject a standalone frr.conf command. Extended
+  `TestGeneratePolicyOptions_SetClauseAndPrefixListSanitized_4482` from 3-of-10
+  wrapped slots to drive an injection payload through EVERY wrapped route-map
+  slot (prefix-list ip+ipv6, match community, match as-path, set community
+  replace/additive, set comm-list delete, set as-path prepend) PLUS the three
+  new #4498 slots (set ip/ipv6 next-hop, set origin, match source-protocol),
+  with a per-slot collapse assertion so a revert of any single site is caught.
+  The inline route-filter slot is fail-closed by the #2105 net.ParseCIDR belt
+  (asserted directly, not via payload collapse). RED-on-revert verified: the
+  generic injection scan fails when all sanitize sites — or only the four new
+  #4498 sites — are unwrapped. go test ./pkg/frr/... ./pkg/config/... green;
+  go build ./...; gofmt+vet clean.
+- **File(s)**: pkg/frr/policy_render.go,
+  pkg/frr/policy_setclause_injection_4482_test.go, pkg/frr/README.md, _Log.md

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -418,6 +418,22 @@ also carries operator content:
   cannot inject a standalone frr.conf command. Guarded by
   `TestGeneratePolicyOptions_SetClauseAndPrefixListSanitized_4482` (fail on
   revert of any wrapped site).
+- **Three route-map slots the #4482 sweep missed are now wrapped too
+  (#4498).** The #4494 hostile review noted that `set ip/ipv6 next-hop
+  <term.NextHop>`, `set origin <term.Origin>`, and `match source-protocol
+  <proto>` still rendered their value with a bare `%s` on the tolerant-load
+  path — a residual of the same class #4482 closed (next-hop is the most
+  notable: an IP-typed slot, but a malformed leniently-loaded value could
+  still inject). All three now pass through `sanitizeFRRValue` for parity with
+  the rest of the route-map belt, so EVERY free-text route-map interpolation is
+  sanitized regardless of load path. The #4482 guard test was extended to
+  drive an injection payload through all ten #4482 slots PLUS these three, so a
+  revert of any single wrapped site is caught (the previous guard exercised
+  only 3 of the wrapped slots — an incomplete fail-on-revert). The inline
+  route-filter prefix-list slot's sanitize sits BEHIND the #2105 `net.ParseCIDR`
+  belt (a control-char prefix is skipped fail-closed before the sanitize call),
+  so its coverage is asserted as the fail-closed property, not a payload
+  collapse.
 - **A BGP-neighbor SHOW command validates its IP before it reaches vtysh
   (#4588).** The #1798/#4097/#4482 belts above cover the config-RENDER path;
   the operational SHOW path is a separate surface. `GetBGPNeighborReceivedRoutes`

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -1683,7 +1683,13 @@ func (m *Manager) renderRouteMapForPolicy(po *config.PolicyOptionsConfig, emitNa
 				if proto == "direct" {
 					proto = "connected"
 				}
-				fmt.Fprintf(&b, " match source-protocol %s\n", proto)
+				// #4498: sanitize the protocol token — the same #4097/#4482
+				// render-side belt the other route-map free-text slots use.
+				// A tolerant-load / peer-synced / rolled-back FromProtocols
+				// value with an embedded newline must not inject an extra
+				// frr.conf line (the strict #1798 commit gate rejects it, but
+				// the lenient load path only warns, #1960).
+				fmt.Fprintf(&b, " match source-protocol %s\n", sanitizeFRRValue(proto))
 			}
 
 			// fromCommunity / fromASPath are ONE entry of a possibly
@@ -1724,9 +1730,14 @@ func (m *Manager) renderRouteMapForPolicy(po *config.PolicyOptionsConfig, emitNa
 					// v6 address (whole route-map fails to parse); v6 uses the
 					// dedicated "set ipv6 next-hop global" form. Mirror the
 					// AF detection used by the prefix-list renderer above.
-					fmt.Fprintf(&b, " set ipv6 next-hop global %s\n", term.NextHop)
+					fmt.Fprintf(&b, " set ipv6 next-hop global %s\n", sanitizeFRRValue(term.NextHop))
 				} else {
-					fmt.Fprintf(&b, " set ip next-hop %s\n", term.NextHop)
+					// #4498: sanitize the next-hop — an IP-typed slot, but on
+					// the tolerant load / peer-sync / rollback path a stored
+					// malformed value with an embedded newline reaches the
+					// renderer (the strict #1798 commit gate does not cover
+					// those paths, #1960). Parity with the #4482 set-clause belt.
+					fmt.Fprintf(&b, " set ip next-hop %s\n", sanitizeFRRValue(term.NextHop))
 				}
 			}
 
@@ -1762,7 +1773,10 @@ func (m *Manager) renderRouteMapForPolicy(po *config.PolicyOptionsConfig, emitNa
 			// the same #4097 render-side belt the community-list / as-path-list
 			// definitions use — so a tolerant-load / peer-synced / rolled-back
 			// value with an embedded newline cannot inject an extra frr.conf
-			// line regardless of load path.
+			// line regardless of load path. #4498 extended the belt to the
+			// three remaining bare-%s route-map slots the #4482 sweep missed:
+			// `set ip/ipv6 next-hop`, `set origin`, and `match
+			// source-protocol` (all rendered above).
 			//   - add    → `set community <v> additive` (append)
 			//   - delete → `set comm-list <name> delete` (strip by list)
 			//   - none   → `set community none` (strip all)
@@ -1799,7 +1813,11 @@ func (m *Manager) renderRouteMapForPolicy(po *config.PolicyOptionsConfig, emitNa
 				fmt.Fprintf(&b, " set as-path prepend %s\n", sanitizeFRRValue(strings.Join(term.ASPathPrepend, " ")))
 			}
 			if term.Origin != "" {
-				fmt.Fprintf(&b, " set origin %s\n", term.Origin)
+				// #4498: sanitize the origin token — parity with the #4482
+				// set-clause belt so a tolerant-load / peer-synced /
+				// rolled-back value with an embedded newline cannot inject an
+				// extra frr.conf line.
+				fmt.Fprintf(&b, " set origin %s\n", sanitizeFRRValue(term.Origin))
 			}
 
 			// Non-terminating term: fall through to the next sequence after

--- a/pkg/frr/policy_setclause_injection_4482_test.go
+++ b/pkg/frr/policy_setclause_injection_4482_test.go
@@ -20,13 +20,39 @@ import (
 // The fix routes ALL FRR-rendered free-text through sanitizeFRRValue regardless
 // of load path, collapsing the newline to a space so the value stays on its
 // single rendered line. Reverting any of the wrapped sites turns this RED: a
-// bare `router bgp 65000` / `neighbor` line appears in the managed section.
+// bare `router bgp` / `neighbor` line appears in the managed section.
+//
+// #4498 completes the coverage. The original guard exercised only 3 of the
+// route-map free-text slots (prefix-list, set community, set as-path prepend);
+// this test now drives an injection payload through EVERY wrapped slot so a
+// revert of any one of them is caught:
+//
+//   - ip / ipv6 prefix-list entry            (#4482)
+//   - match community                        (#4482)
+//   - match as-path                          (#4482)
+//   - set community (replace)                (#4482)
+//   - set community <v> additive             (#4482)
+//   - set comm-list <name> delete            (#4482)
+//   - set as-path prepend                    (#4482)
+//   - set ip / ipv6 next-hop                 (#4498 residual)
+//   - set origin                             (#4498 residual)
+//   - match source-protocol                  (#4498 residual)
+//
+// The inline route-filter prefix-list slot (renderRouteFilterEntry) is also a
+// sanitizeFRRValue call site, but it sits BEHIND the #2105 net.ParseCIDR belt:
+// a control-char prefix fails net.ParseCIDR and the entry is skipped entirely
+// (fail-closed) before the sanitize call is ever reached, so its sanitize is
+// pure defense-in-depth and cannot be exercised with a control-char payload.
+// The test asserts that fail-closed property directly (no injected line, and
+// the malformed prefix never appears in the output).
 func TestGeneratePolicyOptions_SetClauseAndPrefixListSanitized_4482(t *testing.T) {
 	m := &Manager{frrConf: "/dev/null"}
 	po := &config.PolicyOptionsConfig{
 		PrefixLists: map[string]*config.PrefixList{
-			// Newline-injecting prefix value.
-			"pl-evil": {Name: "pl-evil", Prefixes: []string{"10.0.0.0/8\n router bgp 65000"}},
+			// Newline-injecting prefix values — IPv4 and IPv6 variants
+			// exercise both the `ip` and `ipv6` prefix-list render arms.
+			"pl-evil":  {Name: "pl-evil", Prefixes: []string{"10.0.0.0/8\n router bgp 65000"}},
+			"pl-evil6": {Name: "pl-evil6", Prefixes: []string{"2001:db8::/32\n router bgp 65000"}},
 		},
 		PolicyStatements: map[string]*config.PolicyStatement{
 			"P": {
@@ -45,6 +71,50 @@ func TestGeneratePolicyOptions_SetClauseAndPrefixListSanitized_4482(t *testing.T
 						ASPathPrepend: []string{"65001\n router bgp 65000", "65001"},
 						Action:        "accept",
 					},
+					{
+						Name: "t3",
+						// match source-protocol / match community / match
+						// as-path / set ip next-hop / set origin — every
+						// remaining scalar free-text slot in one term.
+						FromProtocols: []string{"bgp\n router bgp 65000"},
+						FromCommunity: []string{"cm1\n neighbor 7.7.7.7 remote-as 65000"},
+						FromASPath:    []string{"ap1\n router bgp 65000"},
+						NextHop:       "1.2.3.4\n router bgp 65000",
+						Origin:        "igp\n router bgp 65000",
+						Action:        "accept",
+					},
+					{
+						Name: "t4",
+						// set community <v> additive — injection.
+						CommunityOp:  "add",
+						CommunityAdd: "65000:2\n neighbor 8.8.8.8 remote-as 65000",
+						Action:       "accept",
+					},
+					{
+						Name: "t5",
+						// set comm-list <name> delete — injection.
+						CommunityOp:     "delete",
+						CommunityDelete: []string{"clist1\n neighbor 9.9.9.9 remote-as 65000"},
+						Action:          "accept",
+					},
+					{
+						Name: "t6",
+						// set ipv6 next-hop global — a next-hop containing ":"
+						// routes through the IPv6 render arm.
+						NextHop: "2001:db8::1\n router bgp 65000",
+						Action:  "accept",
+					},
+					{
+						Name: "t7",
+						// Inline route-filter with a control-char prefix. The
+						// #2105 net.ParseCIDR belt fails-closed BEFORE the
+						// sanitize call, so no prefix-list line is emitted at
+						// all (asserted below).
+						RouteFilters: []*config.RouteFilter{
+							{Prefix: "10.9.0.0/16\n router bgp 65000", MatchType: "orlonger"},
+						},
+						Action: "accept",
+					},
 				},
 			},
 		},
@@ -62,14 +132,37 @@ func TestGeneratePolicyOptions_SetClauseAndPrefixListSanitized_4482(t *testing.T
 		}
 	}
 
-	// The payloads survive collapsed onto their single directive lines.
-	if !strings.Contains(got, "ip prefix-list pl-evil seq 5 permit 10.0.0.0/8  router bgp 65000\n") {
-		t.Errorf("prefix-list entry not sanitized onto one line, got:\n%s", got)
+	// Every wrapped slot's payload must survive collapsed onto its single
+	// directive line (newline → space, so the "\n " in each payload becomes a
+	// double space). A per-slot assertion pinpoints exactly which sanitize
+	// call regressed if one is reverted.
+	wantOnOneLine := []struct {
+		slot string
+		want string
+	}{
+		{"ip prefix-list", "ip prefix-list pl-evil seq 5 permit 10.0.0.0/8  router bgp 65000\n"},
+		{"ipv6 prefix-list", "ipv6 prefix-list pl-evil6 seq 5 permit 2001:db8::/32  router bgp 65000\n"},
+		{"set community (replace)", " set community 65000:1  neighbor 6.6.6.6 remote-as 65000\n"},
+		{"set as-path prepend", " set as-path prepend 65001  router bgp 65000 65001\n"},
+		{"match source-protocol", " match source-protocol bgp  router bgp 65000\n"},
+		{"match community", " match community cm1  neighbor 7.7.7.7 remote-as 65000\n"},
+		{"match as-path", " match as-path ap1  router bgp 65000\n"},
+		{"set ip next-hop", " set ip next-hop 1.2.3.4  router bgp 65000\n"},
+		{"set origin", " set origin igp  router bgp 65000\n"},
+		{"set community additive", " set community 65000:2  neighbor 8.8.8.8 remote-as 65000 additive\n"},
+		{"set comm-list delete", " set comm-list clist1  neighbor 9.9.9.9 remote-as 65000 delete\n"},
+		{"set ipv6 next-hop", " set ipv6 next-hop global 2001:db8::1  router bgp 65000\n"},
 	}
-	if !strings.Contains(got, " set community 65000:1  neighbor 6.6.6.6 remote-as 65000\n") {
-		t.Errorf("set community not sanitized onto one line, got:\n%s", got)
+	for _, tc := range wantOnOneLine {
+		if !strings.Contains(got, tc.want) {
+			t.Errorf("%s not sanitized onto one line (want %q), got:\n%s", tc.slot, tc.want, got)
+		}
 	}
-	if !strings.Contains(got, " set as-path prepend 65001  router bgp 65000 65001\n") {
-		t.Errorf("set as-path prepend not sanitized onto one line, got:\n%s", got)
+
+	// Inline route-filter: the malformed prefix is fail-closed by the #2105
+	// net.ParseCIDR belt, so the payload never reaches the rendered config at
+	// all (neither the CIDR nor its injected tail appears).
+	if strings.Contains(got, "10.9.0.0/16") {
+		t.Errorf("inline route-filter: malformed prefix should be fail-closed (skipped), got:\n%s", got)
 	}
 }


### PR DESCRIPTION
Follow-up to #4494 (both items were deferred non-blocking from that PR's hostile review). Closes the residual FRR sanitize-belt gap plus the incomplete #4482 fail-on-revert guard.

## Item 1 — residual bare-%s route-map slots

The #4482 sweep wrapped the `set community` / `set as-path prepend` clauses, the `match community` / `match as-path` names, and the prefix-list entries in `sanitizeFRRValue`, but three route-map free-text slots still rendered their value with a bare `%s`:

- `set ip/ipv6 next-hop <term.NextHop>` (`pkg/frr/policy_render.go`)
- `set origin <term.Origin>`
- `match source-protocol <proto>`

On the tolerant-load path (peer-sync / rollback / lenient load, where the strict #1798 commit control-char gate only warns, #1960) a stored value with an embedded newline — materialized by the lexer from a quoted `\n` escape — reaches the renderer and injects a standalone frr.conf command. next-hop is the most notable (an IP-typed slot, but a malformed leniently-loaded value could still inject). All three now pass through `sanitizeFRRValue`, so EVERY free-text route-map interpolation is sanitized regardless of load path.

## Item 2 — #4482 test completeness

`TestGeneratePolicyOptions_SetClauseAndPrefixListSanitized_4482` exercised an injection payload through only 3 of the wrapped slots (prefix, set community, set as-path prepend); reverting the sanitize on match-community / match-as-path / set-additive / comm-list-delete would not have been caught. The guard now drives a payload through every wrapped route-map slot PLUS the three new #4498 slots, with a per-slot collapse assertion so a revert of any single site fails the test. The inline route-filter prefix-list slot sits behind the #2105 `net.ParseCIDR` belt (a control-char prefix is skipped fail-closed before the sanitize call), so its coverage is asserted as the fail-closed property, not a payload collapse.

## Validation

- `go test ./pkg/frr/... ./pkg/config/...` green; `go build ./...`; gofmt + `go vet` clean.
- RED-on-revert verified: the generic injection scan fails both when all sanitize sites are unwrapped and when only the four new #4498 sites are unwrapped.

Docs: `pkg/frr/README.md` (new #4498 bullet in the sanitize-belt section) + `_Log.md`.

Closes #4498

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi