### PR TITLE
show firewall: surface three-color policer status per term (#4372)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -40818,3 +40818,26 @@ top.
   string fallback when either side is unparseable so a genuine change is never
   masked) and routed the two CIDR compares through it. RED-on-revert verified.
 - **File(s)**: pkg/ra/ra.go, pkg/ra/ra_test.go, pkg/ra/README.md, _Log.md
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4372 (avo-review-002 A1, GO-only — no Rust/wire change) — the
+  Rust dataplane already published per-color three-color policer counters over
+  the `three_color_policer_counters` status (Prometheus
+  `xpf_userspace_three_color_policer_*_total` and the dataplane status-summary
+  "Three-color policers:" table already surfaced them; the issue's "not in
+  Prometheus" claim was stale). The genuine gap was the Junos-style `show
+  firewall` / `show firewall filter` CLI, which showed only per-term hit counts
+  and never the policer status. Added `BuildThreeColorPolicerStatusIndex`
+  (by-name index, mirroring `BuildFirewallFilterTermCounterIndex`) and a
+  `writeThreeColorPolicerStatus` renderer, then wired both into `showFirewall`
+  and `showFirewallFilter`: each `then policer <name>` term now prints the
+  reference line plus the policer mode / color mode and the green(conform) /
+  yellow(exceed) / red(violate) / dropped packet+byte counters. Legacy
+  single-rate `firewall policer` defs lower into the same runtime (#4514) so
+  both namespaces render. RED-on-revert verified (neutralizing the renderer
+  drops the "Policer ..." block; a no-policer term is unaffected). go
+  build/vet/gofmt clean; pkg/cli, pkg/api, pkg/grpcapi, pkg/dataplane/userspace
+  tests green.
+- **File(s)**: pkg/dataplane/userspace/filtercounters.go,
+  pkg/grpcapi/server_show_firewall.go,
+  pkg/grpcapi/server_show_firewall_test.go, docs/cos-traffic-shaping.md, _Log.md

--- a/docs/cos-traffic-shaping.md
+++ b/docs/cos-traffic-shaping.md
@@ -1251,6 +1251,15 @@ Currently implemented:
   every worker
 - ownership is now spread deterministically across eligible workers when
   multiple shaped egress interfaces share the same TX path
+- `show firewall` / `show firewall filter <name>` now surfaces the three-color
+  policer status inline under each `then policer <name>` term (#4372): the
+  policer mode (single-rate / two-rate), color mode (color-aware / color-blind),
+  and the per-color green (conform) / yellow (exceed) / red (violate) plus
+  treatment-drop packet/byte counters the userspace dataplane publishes over its
+  `three_color_policer_counters` status. Legacy single-rate `firewall policer`
+  definitions are lowered into the same three-color runtime (#4514), so both
+  policer namespaces render. The same counters are also printed as a
+  "Three-color policers:" table in the dataplane status summary.
 
 Still planned:
 
@@ -1306,6 +1315,11 @@ implemented and exercised in the userspace dataplane:
 - shared-root budget leasing across owner workers on the same shaped interface
 - base interface/runtime observability via
   `show class-of-service interface [IFACE[.UNIT]]`
+- three-color policer per-color counters exported to Prometheus
+  (`xpf_userspace_three_color_policer_packets_total` /
+  `_bytes_total` labelled by `policer`+`color`, and
+  `_drops_total` / `_drop_bytes_total` labelled by `policer`) AND surfaced in
+  `show firewall` / `show firewall filter` per referencing term (#4372)
 
 The following pieces are still not complete:
 

--- a/pkg/dataplane/userspace/filtercounters.go
+++ b/pkg/dataplane/userspace/filtercounters.go
@@ -21,3 +21,26 @@ func BuildFirewallFilterTermCounterIndex(status *ProcessStatus) map[FirewallFilt
 	}
 	return index
 }
+
+// BuildThreeColorPolicerStatusIndex maps each userspace-published three-color
+// policer status by its policer name so a `show firewall` term rendering can
+// look up the per-color (green/yellow/red) conform/exceed counters for the
+// policer a `then policer <name>` term references. Legacy single-rate `firewall
+// policer` definitions are lowered into the same three-color runtime at compile
+// (#4514), so both the `firewall policer` and `firewall three-color-policer`
+// namespaces surface here keyed by the config name a filter term references.
+// Unnamed entries (defensive) are skipped. A nil status yields an empty index,
+// mirroring BuildFirewallFilterTermCounterIndex.
+func BuildThreeColorPolicerStatusIndex(status *ProcessStatus) map[string]ThreeColorPolicerStatus {
+	index := make(map[string]ThreeColorPolicerStatus)
+	if status == nil {
+		return index
+	}
+	for _, policer := range status.ThreeColorPolicerCounters {
+		if policer.Name == "" {
+			continue
+		}
+		index[policer.Name] = policer
+	}
+	return index
+}

--- a/pkg/grpcapi/server_show_firewall.go
+++ b/pkg/grpcapi/server_show_firewall.go
@@ -23,6 +23,30 @@ import (
 	"github.com/psaab/xpf/pkg/policymatch"
 )
 
+// writeThreeColorPolicerStatus renders the per-color (green/yellow/red)
+// conform/exceed and treatment-drop counters for a `then policer <name>` term,
+// mirroring the inline per-term `Hit count:` surfacing (#4372). The counters
+// come from the userspace dataplane's three_color_policer_counters wire status;
+// legacy single-rate `firewall policer` definitions are lowered into the same
+// three-color runtime (#4514), so this renders both policer namespaces. Junos
+// terms are green=conform (in committed rate), yellow=exceed (above committed,
+// within peak/excess), red=violate.
+func writeThreeColorPolicerStatus(buf *strings.Builder, ps dpuserspace.ThreeColorPolicerStatus) {
+	mode := ps.Mode
+	if mode == "" {
+		mode = "unknown"
+	}
+	colorMode := "color-aware"
+	if ps.ColorBlind {
+		colorMode = "color-blind"
+	}
+	fmt.Fprintf(buf, "    Policer %s (%s, %s):\n", ps.Name, mode, colorMode)
+	fmt.Fprintf(buf, "      green (conform):  %d packets, %d bytes\n", ps.GreenPackets, ps.GreenBytes)
+	fmt.Fprintf(buf, "      yellow (exceed):  %d packets, %d bytes\n", ps.YellowPackets, ps.YellowBytes)
+	fmt.Fprintf(buf, "      red (violate):    %d packets, %d bytes\n", ps.RedPackets, ps.RedBytes)
+	fmt.Fprintf(buf, "      dropped:          %d packets, %d bytes\n", ps.DropPackets, ps.DropBytes)
+}
+
 // showFirewall renders the `cli show firewall` output. Writes to
 // `buf`. Returns no error — the original case body had no error
 // returns; counters that fail to load are silently skipped (same
@@ -38,6 +62,7 @@ func (s *Server) showFirewall(cfg *config.Config, buf *strings.Builder) {
 		userspaceStatus = &status
 	}
 	userspaceCounters := dpuserspace.BuildFirewallFilterTermCounterIndex(userspaceStatus)
+	policerStatuses := dpuserspace.BuildThreeColorPolicerStatusIndex(userspaceStatus)
 	// Resolve filter IDs for counter display
 	var filterIDs map[string]uint32
 	if s.dp != nil && s.dp.IsLoaded() {
@@ -129,6 +154,9 @@ func (s *Server) showFirewall(cfg *config.Config, buf *strings.Builder) {
 				if term.LossPriority != "" {
 					fmt.Fprintf(buf, "    then loss-priority %s\n", term.LossPriority)
 				}
+				if term.Policer != "" {
+					fmt.Fprintf(buf, "    then policer %s\n", term.Policer)
+				}
 				action := term.Action
 				if action == "" {
 					action = "accept"
@@ -157,6 +185,11 @@ func (s *Server) showFirewall(cfg *config.Config, buf *strings.Builder) {
 				}
 				if hasCounters || userspaceOk {
 					fmt.Fprintf(buf, "    Hit count: %d packets, %d bytes\n", totalPkts, totalBytes)
+				}
+				if term.Policer != "" {
+					if ps, ok := policerStatuses[term.Policer]; ok {
+						writeThreeColorPolicerStatus(buf, ps)
+					}
 				}
 			}
 			buf.WriteString("\n")
@@ -425,6 +458,7 @@ func (s *Server) showFirewallFilter(req *pb.ShowTextRequest, cfg *config.Config,
 				userspaceStatus = &status
 			}
 			userspaceCounters := dpuserspace.BuildFirewallFilterTermCounterIndex(userspaceStatus)
+			policerStatuses := dpuserspace.BuildThreeColorPolicerStatusIndex(userspaceStatus)
 			var filterIDs map[string]uint32
 			if s.dp != nil && s.dp.IsLoaded() {
 				if cr := s.applyResult(); cr != nil {
@@ -503,6 +537,9 @@ func (s *Server) showFirewallFilter(req *pb.ShowTextRequest, cfg *config.Config,
 				if term.Count != "" {
 					fmt.Fprintf(buf, "    then count %s\n", term.Count)
 				}
+				if term.Policer != "" {
+					fmt.Fprintf(buf, "    then policer %s\n", term.Policer)
+				}
 				action := term.Action
 				if action == "" {
 					action = "accept"
@@ -530,6 +567,11 @@ func (s *Server) showFirewallFilter(req *pb.ShowTextRequest, cfg *config.Config,
 				}
 				if hasCounters || userspaceOk {
 					fmt.Fprintf(buf, "    Hit count: %d packets, %d bytes\n", totalPkts, totalBytes)
+				}
+				if term.Policer != "" {
+					if ps, ok := policerStatuses[term.Policer]; ok {
+						writeThreeColorPolicerStatus(buf, ps)
+					}
 				}
 			}
 			buf.WriteString("\n")

--- a/pkg/grpcapi/server_show_firewall_test.go
+++ b/pkg/grpcapi/server_show_firewall_test.go
@@ -89,6 +89,134 @@ func TestShowTextFirewallFilterHonorsFamilyAndUserspaceCounters(t *testing.T) {
 	}
 }
 
+func newFirewallPolicerShowStore(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	for _, cmd := range []string{
+		// A valid single-rate three-color policer referenced by one term. The
+		// strict filter validator rejects a dangling `then policer` reference,
+		// so the policer must be defined for the config to commit.
+		"firewall three-color-policer tcp-limit single-rate color-blind",
+		"firewall three-color-policer tcp-limit single-rate committed-information-rate 1m",
+		"firewall three-color-policer tcp-limit single-rate committed-burst-size 15k",
+		"firewall three-color-policer tcp-limit single-rate excess-burst-size 30k",
+		"firewall family inet filter rate-in term policed from destination-port 80",
+		"firewall family inet filter rate-in term policed then policer tcp-limit",
+		"firewall family inet filter rate-in term policed then accept",
+		// A second term with NO policer — must be unaffected by the policer
+		// surfacing.
+		"firewall family inet filter rate-in term plain from destination-port 22",
+		"firewall family inet filter rate-in term plain then accept",
+	} {
+		if err := store.SetFromInput(cmd); err != nil {
+			t.Fatalf("SetFromInput(%q) error = %v", cmd, err)
+		}
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// TestShowFirewallSurfacesThreeColorPolicerStatus is the #4372 RED-on-revert
+// guard: `show firewall` / `show firewall filter` must surface the per-color
+// (green/yellow/red conform/exceed) and treatment-drop counters the userspace
+// dataplane publishes for a three-color policer a term references. Reverting
+// the surfacing drops the "Policer ..." block (RED). A term with no policer is
+// unaffected.
+func TestShowFirewallSurfacesThreeColorPolicerStatus(t *testing.T) {
+	store := newFirewallPolicerShowStore(t)
+	s := &Server{
+		store: store,
+		dp: &firewallFilterShowUserspaceDP{
+			Manager: dataplane.New(),
+			status: dpuserspace.ProcessStatus{
+				ThreeColorPolicerCounters: []dpuserspace.ThreeColorPolicerStatus{
+					{
+						ID:            3,
+						Name:          "tcp-limit",
+						Mode:          "single-rate",
+						ColorBlind:    true,
+						GreenPackets:  100,
+						GreenBytes:    6400,
+						YellowPackets: 20,
+						YellowBytes:   1280,
+						RedPackets:    5,
+						RedBytes:      320,
+						DropPackets:   5,
+						DropBytes:     320,
+					},
+				},
+			},
+		},
+	}
+
+	wants := []string{
+		"then policer tcp-limit",
+		"Policer tcp-limit (single-rate, color-blind):",
+		"green (conform):  100 packets, 6400 bytes",
+		"yellow (exceed):  20 packets, 1280 bytes",
+		"red (violate):    5 packets, 320 bytes",
+		"dropped:          5 packets, 320 bytes",
+	}
+
+	// show firewall filter <name>
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "firewall-filter:rate-in:inet"})
+	if err != nil {
+		t.Fatalf("ShowText(firewall-filter) error = %v", err)
+	}
+	filterOut := resp.GetOutput()
+	for _, want := range wants {
+		if !strings.Contains(filterOut, want) {
+			t.Fatalf("show firewall filter output missing %q:\n%s", want, filterOut)
+		}
+	}
+	// The no-policer term must not sprout a policer block.
+	if strings.Count(filterOut, "Policer tcp-limit") != 1 {
+		t.Fatalf("show firewall filter rendered the policer block %d times, want 1:\n%s",
+			strings.Count(filterOut, "Policer tcp-limit"), filterOut)
+	}
+
+	// show firewall (all filters)
+	var buf strings.Builder
+	s.showFirewall(store.ActiveConfig(), &buf)
+	allOut := buf.String()
+	for _, want := range wants {
+		if !strings.Contains(allOut, want) {
+			t.Fatalf("show firewall output missing %q:\n%s", want, allOut)
+		}
+	}
+}
+
+// TestShowFirewallOmitsPolicerBlockWithoutThreeColorPolicer is the negative half
+// of the #4372 guard: a filter with no `then policer` reference renders no
+// "Policer" block even when the dataplane publishes unrelated policer counters.
+func TestShowFirewallOmitsPolicerBlockWithoutThreeColorPolicer(t *testing.T) {
+	store := newFirewallFilterShowStore(t)
+	s := &Server{
+		store: store,
+		dp: &firewallFilterShowUserspaceDP{
+			Manager: dataplane.New(),
+			status: dpuserspace.ProcessStatus{
+				ThreeColorPolicerCounters: []dpuserspace.ThreeColorPolicerStatus{
+					{ID: 1, Name: "unreferenced", Mode: "single-rate", GreenPackets: 9},
+				},
+			},
+		},
+	}
+
+	var buf strings.Builder
+	s.showFirewall(store.ActiveConfig(), &buf)
+	out := buf.String()
+	if strings.Contains(out, "Policer ") {
+		t.Fatalf("show firewall rendered a policer block for a filter with no policer:\n%s", out)
+	}
+}
+
 func TestShowTextScreenSYNCookieCounterRowsUsesUserspaceStatus(t *testing.T) {
 	s := &Server{
 		dp: &firewallFilterShowUserspaceDP{


### PR DESCRIPTION
Closes #4372 (A1, the substantive slice).

## Lane: Go-only (no Rust / no wire change)

VERIFY-FIRST on current master (base 3bbe3d39c): the Rust dataplane already
records per-color three-color policer counters (`filter/mod.rs`
`ThreeColorPolicerCounters` + `status()`) and publishes them over the
`three_color_policer_counters` control status. Go already decodes them into
`ProcessStatus.ThreeColorPolicerCounters`; the Prometheus collector already
exports `xpf_userspace_three_color_policer_{packets,bytes,drops,drop_bytes}_total`
(`emitThreeColorPolicerCounters`); and the dataplane status summary already
prints a "Three-color policers:" table. So the issue's "not in Prometheus" claim
was stale — the only genuine gap was the Junos-style `show firewall` CLI, which
showed only per-term hit counts. No wire field is added, so the protocol fixture
and cross-language contract test are untouched.

## Change

- `BuildThreeColorPolicerStatusIndex` — a by-name index mirroring
  `BuildFirewallFilterTermCounterIndex` (`pkg/dataplane/userspace/filtercounters.go`).
- `writeThreeColorPolicerStatus` — renders the policer mode, color mode, and the
  green (conform) / yellow (exceed) / red (violate) / dropped packet+byte
  counters (`pkg/grpcapi/server_show_firewall.go`).
- Wired into both `showFirewall` and `showFirewallFilter`: each
  `then policer <name>` term now prints the (previously-omitted) reference line
  plus the policer status block. Legacy single-rate `firewall policer` defs lower
  into the same runtime (#4514), so both namespaces render. A term with no
  published policer status (or no policer) is unaffected.

## Prometheus

Already exported (verified) — no change needed. The doc note records this so the
verify-first finding isn't lost.

## Validation

- RED-on-revert test (`server_show_firewall_test.go`): the "Policer ..." block
  appears for a configured three-color policer in both `show firewall` and
  `show firewall filter`, and is absent for a term with no policer. Neutralizing
  the renderer fails the test (verified).
- `go build ./...`, `go vet`, `gofmt` clean.
- `pkg/cli`, `pkg/api`, `pkg/grpcapi`, `pkg/dataplane/userspace` suites green.

## Remainder (not in this PR)

Issue #4372 also carries A3 (traceroute TCP-admission parity — verify-first),
A7 (session-limit doc note), and the A2/A4/A5/A6 test-coverage items folded into
the #4365 batch. Those are separate from the A1 observability slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi