### PR TITLE
doc: clarify "Packets dropped" = enforcement drops (undercounts no-route)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-07-07 — #4508 doc: clarify `Packets dropped` = enforcement drops (undercounts no-route/fabric/vlan/NAT64)
+
+- **Timestamp**: 2026-07-07
+- **Action**: DOC + label clarification. `Packets dropped`
+  (`dataplane.GlobalCtrDrops`, bridged by `totalDrops()` since #4477) is the
+  sum of the FOUR ENFORCEMENT drop reasons only — policy deny + screen/IDS +
+  host-inbound deny + source-NAT alloc fail. It is NOT the literal total of
+  every discarded packet: no-route/missing-neighbor (surfaced separately as
+  the helper status `Route misses:`, from `route_miss_packets`/
+  `neighbor_miss_packets`), fabric-forwarding drops (`GlobalCtrFabricFwdDrop`
+  idx 32), VLAN-push failures (`GlobalCtrVlanPushFail` idx 40), and NAT64
+  fail-closed drops are all EXCLUDED, so the figure undercounts total
+  discards. Documented the scope + excluded paths in
+  `docs/junos-cli-reference.md` (flow-statistics Format Details + the #4477
+  accounting bullet), extended the `totalDrops()` godoc in
+  `pkg/dataplane/userspace/manager_ha.go`, and clarified the free-form
+  Prometheus `xpf_drops_total` help text in `pkg/api/metrics_descriptors.go`.
+  KEPT the CLI display string `Packets dropped:` verbatim — it is the vSRX
+  `show security flow statistics` field name and relabeling would break the
+  Junos CLI parity this doc exists to guarantee (no test pins the string; the
+  caveat lives in the doc/help-text instead). Added a RED-on-revert test
+  `TestDropsTotalHelpDeclaresEnforcementScope` asserting the clarified help
+  text names `enforcement`/`no-route`/`undercounts` and no longer carries the
+  misleading `Total packets dropped.` wording.
+- **File(s)**: `docs/junos-cli-reference.md`,
+  `pkg/dataplane/userspace/manager_ha.go`,
+  `pkg/api/metrics_descriptors.go`,
+  `pkg/api/metrics_drops_scope_4508_test.go`, `_Log.md`
+- **Validation**: `gofmt -l` clean, `go vet ./pkg/api/ ./pkg/dataplane/
+  userspace/` clean, `go build ./...` OK, `go test ./pkg/api/ ./pkg/dataplane/
+  userspace/` green; verified the new test fails RED when
+  `metrics_descriptors.go` is reverted to `origin/master`.
+
 ## 2026-07-07 — #4607 event_stream: seed queue budget in the #2875 telemetry-eviction test
 
 - **Timestamp**: 2026-07-07

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -202,6 +202,15 @@ Maximum-sessions: 4194304
 - Every line indented 4 spaces.
 - Key-value with colon separator.
 - All numbers right-aligned (no fixed width, just the number).
+- **`Packets dropped` = ENFORCEMENT drops only (#4508).** This figure sums
+  policy denies, screen/IDS drops, host-inbound denies, and source-NAT
+  allocation failures — it is NOT the literal total of every discarded
+  packet. No-route / missing-neighbor drops (helper status `Route misses:`),
+  fabric-forwarding drops, VLAN-push failures, and NAT64 fail-closed drops
+  are counted separately and are excluded here, so `Packets dropped`
+  undercounts total discards. See the `Packets dropped` scope caveat
+  (#4477/#4508) in the counter-accounting notes further below for the full
+  breakdown of excluded paths and their counter indices.
 
 ---
 
@@ -430,6 +439,29 @@ From zone: guest, To zone: lan
     beneath it), mirroring the host-inbound / NAT64 / per-screen-reason plumbing.
     Once bridged the counters carry real values, so the #3345 disclosure
     correctly stays silent for them.
+  - **`Packets dropped` scope — ENFORCEMENT drops only (#4508):** the
+    `Packets dropped` counter is the sum of the four ENFORCEMENT/discard
+    reasons above (policy deny + screen/IDS + host-inbound deny + source-NAT
+    allocation failure). It is deliberately **not** the literal total of every
+    packet the dataplane discards. Other real drop paths are counted
+    elsewhere or not folded into this figure, so `Packets dropped`
+    **undercounts** total discards. Excluded paths and where to read them:
+    - **No-route** (userspace has no route to the destination) and
+      **missing-neighbor** (route resolved but ARP/ND unresolved) drops are
+      counted per binding as `route_miss_packets` / `neighbor_miss_packets`
+      and surfaced separately as the `Route misses:` line in the userspace
+      helper status (`pkg/dataplane/userspace/format/status.go`) — never in
+      `Packets dropped`.
+    - **Fabric-forwarding drops** (`GlobalCtrFabricFwdDrop`, index 32) — a
+      peer-owned synced session whose fabric redirect could not be completed.
+    - **VLAN-push failures** (`GlobalCtrVlanPushFail`, index 40).
+    - **NAT64 fail-closed drops** — the NAT64 translator dropping a packet it
+      cannot safely translate (distinct from the source-NAT allocation
+      failure that IS in the total).
+    This is the vSRX `show security flow statistics` field name, so the label
+    is kept verbatim for Junos parity; the caveat lives here rather than in a
+    relabel. The Prometheus mirror `xpf_drops_total` carries the same scope in
+    its help text (`enforcement drops … does NOT include no-route`).
   - **Token validation (#3200):** `host-inbound-traffic system-services
     <tok>` / `protocols <tok>` is now validated at commit against the
     recognized-token SSOT (`pkg/config/host_inbound_tokens.go`:

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -18,7 +18,18 @@ func newCollector(srv *Server) *xpfCollector {
 		),
 		dropsTotal: prometheus.NewDesc(
 			"xpf_drops_total",
-			"Total packets dropped.",
+			// #4508: enforcement drops only — policy deny + screen/IDS +
+			// host-inbound deny + source-NAT alloc fail (the GlobalCtrDrops
+			// bridge, #4477). This does NOT include no-route/missing-neighbor,
+			// fabric-forwarding (idx 32), VLAN-push (idx 40), or NAT64
+			// fail-closed drops, so it undercounts total discards. No-route
+			// drops surface separately in the userspace helper status
+			// ("Route misses"). Kept the mirror of the vSRX "Packets dropped"
+			// field name/scope; see docs/junos-cli-reference.md.
+			"Packets dropped by enforcement (policy deny, screen/IDS, "+
+				"host-inbound deny, source-NAT alloc fail). Does NOT include "+
+				"no-route, fabric-forwarding, VLAN-push, or NAT64 fail-closed "+
+				"drops, so it undercounts total discards.",
 			nil, nil,
 		),
 		// #3345/#3408: scrape-error signal for counter reads across the global,

--- a/pkg/api/metrics_drops_scope_4508_test.go
+++ b/pkg/api/metrics_drops_scope_4508_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDropsTotalHelpDeclaresEnforcementScope pins the #4508 clarification of
+// the xpf_drops_total help text. The GlobalCtrDrops bridge (#4477) sums only
+// the four ENFORCEMENT reasons (policy deny, screen/IDS, host-inbound deny,
+// source-NAT alloc fail) — it is NOT the literal total of every discarded
+// packet (no-route/missing-neighbor, fabric-forwarding, VLAN-push, and NAT64
+// fail-closed drops are excluded). The pre-#4508 help text was a bare "Total
+// packets dropped." which misled an operator into reading the counter as the
+// total discard count. This test fails RED if that regression is reverted, so
+// the misleading "total" wording cannot silently return.
+func TestDropsTotalHelpDeclaresEnforcementScope(t *testing.T) {
+	c := newCollector(&Server{})
+	// prometheus.Desc.String() embeds the help text verbatim, e.g.
+	//   Desc{fqName: "xpf_drops_total", help: "...", ...}
+	got := c.dropsTotal.String()
+
+	// The clarified scope must name enforcement AND the primary excluded path.
+	for _, want := range []string{"enforcement", "no-route", "undercounts"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("xpf_drops_total help text is missing %q (the #4508 "+
+				"enforcement-scope clarification) — got %q", want, got)
+		}
+	}
+
+	// The misleading bare "Total packets dropped." wording must be gone: the
+	// counter is enforcement-scoped, not a literal total of all discards.
+	if strings.Contains(got, "Total packets dropped.") {
+		t.Errorf("xpf_drops_total help text still carries the misleading "+
+			"pre-#4508 %q wording — it undercounts total discards and must not "+
+			"claim to be the total; got %q", "Total packets dropped.", got)
+	}
+}

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -687,13 +687,27 @@ type userspaceCounterSnapshot struct {
 }
 
 // totalDrops (#4477) is the aggregate "Packets dropped" figure surfaced by
-// GlobalCtrDrops. It sums the firewall's enforcement/discard drops — policy
+// GlobalCtrDrops. It sums the firewall's ENFORCEMENT drops — policy
 // denies, screen/IDS drops, host-inbound admission denies, and source-NAT
 // allocation failures. These are exactly the four breakdown lines rendered
 // beneath "Packets dropped" in `show security flow statistics`, so the
 // aggregate equals the sum of its parts (a total-with-breakdown, not a
 // double count into any single reason's own index). Before #4477 GlobalCtrDrops
 // was never written and printed a false, always-0 value.
+//
+// #4508: this is ENFORCEMENT drops only, NOT the literal total of every packet
+// the dataplane discards. Deliberately EXCLUDED (counted elsewhere or not
+// folded here), so "Packets dropped" UNDERCOUNTS total discards:
+//   - no-route / missing-neighbor drops — bumped as route_miss_packets /
+//     neighbor_miss_packets and surfaced separately as "Route misses:" in the
+//     helper status (see pkg/dataplane/userspace/format/status.go);
+//   - fabric-forwarding drops (dataplane.GlobalCtrFabricFwdDrop, idx 32);
+//   - VLAN-push failures (dataplane.GlobalCtrVlanPushFail, idx 40);
+//   - NAT64 fail-closed drops (distinct from source-NAT alloc failure).
+//
+// If a true total is ever wanted, extend this sum to include those indices —
+// but keep the display label verbatim for vSRX parity. Doc: the "Packets
+// dropped scope" caveat in docs/junos-cli-reference.md.
 func (s userspaceCounterSnapshot) totalDrops() uint64 {
 	return s.policyDenied + s.screenDrops + s.hostInboundDenied + s.natAllocFail
 }


### PR DESCRIPTION
## Summary

`Packets dropped` (`dataplane.GlobalCtrDrops`, bridged by `totalDrops()` since #4477) is the sum of the **four enforcement drop reasons only** — policy deny + screen/IDS + host-inbound deny + source-NAT allocation failure. It is not the literal total of every discarded packet, so an operator can be misled into reading it as a total drop count.

This is a **non-blocking follow-up from the #4507 review** (issue #4508): document the scope instead of silently undercounting.

### Excluded / undercounted drop paths (verified on `origin/master`)
- **No-route / missing-neighbor** — counted per binding as `route_miss_packets` / `neighbor_miss_packets` and surfaced separately as the `Route misses:` line in the userspace helper status (`pkg/dataplane/userspace/format/status.go`); never in `Packets dropped`.
- **Fabric-forwarding drops** — `GlobalCtrFabricFwdDrop`, index 32.
- **VLAN-push failures** — `GlobalCtrVlanPushFail`, index 40.
- **NAT64 fail-closed drops** — distinct from the source-NAT alloc failure that *is* in the total.

## Changes
- `docs/junos-cli-reference.md` — scope note in the flow-statistics Format Details + a full "Packets dropped scope (#4508)" caveat under the #4477 counter-accounting bullet, listing every excluded path and its counter index.
- `pkg/dataplane/userspace/manager_ha.go` — extended the `totalDrops()` godoc to enumerate the excluded paths and note it is enforcement-only.
- `pkg/api/metrics_descriptors.go` — clarified the free-form Prometheus `xpf_drops_total` help text (was the misleading `"Total packets dropped."`).
- `pkg/api/metrics_drops_scope_4508_test.go` — RED-on-revert test asserting the clarified help text names `enforcement`/`no-route`/`undercounts` and no longer claims to be the total.

## Display string kept, not relabeled
The CLI `Packets dropped:` string is **kept verbatim** — it is the vSRX `show security flow statistics` field name, and relabeling would break the Junos CLI parity that `docs/junos-cli-reference.md` exists to document. No test pins the string, but parity is the binding contract, so the clarification lives in the doc + Prometheus help text.

## Validation
- `gofmt -l` clean; `go vet ./pkg/api/ ./pkg/dataplane/userspace/` clean
- `go build ./...` OK
- `go test ./pkg/api/ ./pkg/dataplane/userspace/` green
- New test verified to fail **RED** when `metrics_descriptors.go` is reverted to `origin/master`

Closes #4508

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi