### PR TITLE
config: host-bound multicast admission advisory + protocol->group catalog (#4455)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,31 @@
+## 2026-07-07 — #4455 (HI-1) host-inbound: multicast packet-wide advisory + protocol→group catalog (bounded slice)
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4455 DRIVEABLE bounded slice (GO-only, no forwarding change).
+  Verify-first on master confirmed host-bound routing multicast is fail-OPEN
+  but BOUNDED: `buildHostInboundFilterPayload` (`pkg/daemon/daemon_nft.go`)
+  matches host-local UNICAST `daddr` only and runs `policy accept`, so a packet
+  to a well-known group (OSPF 224.0.0.5, VRRP 224.0.0.18, PIM 224.0.0.13) falls
+  through packet-wide; the Rust `host_inbound_admits` has no address dimension.
+  Shipped: (1) a protocol→multicast-group catalog SSOT
+  (`pkg/config/host_inbound_multicast.go`) settling deferred decision (2); (2) a
+  WARN-only commit-time advisory (`validateHostInboundMulticastWarnings` in
+  `compiler_validate_warn.go`) mirroring the #3226 pattern — fires when a zone /
+  per-interface override admits a multicast routing protocol (expands
+  `protocols all`), names the zone + concrete groups; (3) design doc
+  `docs/host-inbound-multicast.md` with the group table + fail-open-bounded note
+  + the deferred 4-decision plan. RED-on-revert test
+  `host_inbound_multicast_warn_4455_test.go` (multicast→advisory, unicast bgp/
+  ldp/msdp/bfd→none, system-services-only/no-HIT→none, per-iface override,
+  `protocols all` expansion, catalog SSOT shape). The per-zone iifname
+  enforcement + #1960 migration gating + kernel/Rust lockstep remain DEFERRED.
+- **File(s)**: `pkg/config/host_inbound_multicast.go` (new),
+  `pkg/config/host_inbound_multicast_warn_4455_test.go` (new),
+  `pkg/config/compiler_validate_warn.go`,
+  `pkg/config/testdata/golden_4406.json` (baseline regen: +#4455 advisory on 12
+  cases, no other field changed), `docs/host-inbound-multicast.md` (new),
+  `docs/host-inbound-service-matrix.md`, `_Log.md`.
+
 ## 2026-07-07 — #3226 host-inbound: commit-time advisory for `system-services all` / `any-service` packet-wide full-admit
 
 - **Timestamp**: 2026-07-07

--- a/docs/host-inbound-multicast.md
+++ b/docs/host-inbound-multicast.md
@@ -1,0 +1,124 @@
+# Host-bound routing multicast admission (#4455, HI-1)
+
+This doc records the current behavior of host-bound **multicast** admission, the
+protocol→multicast-group catalog that the eventual per-zone enforcement will use,
+and the four coupled design decisions that keep the full enforcement deferred. It
+is a **design artifact**: today the catalog backs only a commit-time advisory and
+makes **no forwarding decision**.
+
+## Current behavior: fail-open-but-bounded
+
+The kernel `xpf_hostinbound` `chain input`
+(`pkg/daemon/daemon_nft.go`, `buildHostInboundFilterPayload`) is:
+
+```
+type filter hook input priority <p>; policy accept;
+ct state established,related accept
+meta l4proto { 50, 51 } accept            # raw ESP/AH (host-terminated IPsec)
+icmpv6 type { 1,2,3,4,133,134,135,136,137 } accept   # ND + PMTUD/error
+icmp type { destination-unreachable, time-exceeded, parameter-problem } accept
+<per-zone>  <fam> daddr <zone-local-unicast-addrs> ... accept / counter drop
+```
+
+Every per-zone rule is scoped by `<fam> daddr <zone-local-addrs>` — a set of the
+firewall's own **unicast** interface addresses. A host-bound packet addressed to
+a well-known routing **multicast** group (OSPF `224.0.0.5`, VRRP `224.0.0.18`,
+PIM `224.0.0.13`, …) matches **no** per-zone `daddr` set, so it falls through the
+chain's `policy accept` to the host stack **without** any per-zone
+`host-inbound-traffic protocols` scoping.
+
+The Rust AF_XDP classifier
+(`userspace-dp/src/afxdp/forwarding/host_inbound.rs`, `host_inbound_admits`) keys
+only on `(ingress_zone_id, protocol, dst_port, is_v6, icmp_type)` — it has **no
+destination-address dimension** — so it does not gate host-bound multicast
+either.
+
+**This is a Junos-parity/hardening gap, not an open door.** The exposure is
+bounded:
+
+- The host kernel delivers multicast only to groups a configured daemon actually
+  **joined** (a routing daemon the operator enabled). Nothing is delivered to a
+  group with no local subscriber.
+- The always-on control set (IPv6 ND, PMTUD/error ICMP, ESP/AH) is already
+  globally accepted, independent of the zone token set.
+
+So OSPF / VRRP / PIM do **not** break today. The gap is that their host-bound
+multicast is admitted **packet-wide** (on every ingress interface) rather than
+scoped to the zone whose `host-inbound-traffic protocols` opted in — broader than
+Junos, where host-bound routing multicast is admitted per-zone via
+`host-inbound-traffic protocols <x>`.
+
+## Commit-time advisory (shipped)
+
+`ValidateConfig` (`pkg/config/compiler_validate_warn.go`,
+`validateHostInboundMulticastWarnings`) emits a **WARN-only** commit-time
+advisory for each zone-level `host-inbound-traffic` stanza AND each per-interface
+override (#3362) whose `protocols` set admits a multicast routing protocol. The
+advisory names the zone (and interface), lists the concrete well-known groups,
+and states that the multicast is currently admitted packet-wide via the input
+chain's accept fall-through — a known parity gap (#4455). It is **never a hard
+reject**: the config is valid Junos, and rejecting or narrowing it would break a
+zone that relies on today's accept (see the migration decision below). This
+mirrors the #3226 `system-services all` packet-wide-admit advisory pattern.
+
+## Protocol → multicast-group catalog
+
+The single source of truth is `hostInboundMulticastCatalog` in
+`pkg/config/host_inbound_multicast.go`. Only protocols whose host-bound **control
+traffic** rides a well-known multicast group are listed; unicast routing control
+(BGP TCP/179, LDP, MSDP, BFD to a peer address) and L2/non-IP protocols (IS-IS)
+are deliberately absent. Family split mirrors `HostInboundProtocolFamily`.
+
+| `protocols` token | IPv4 group(s) | IPv6 group(s) | Notes |
+|---|---|---|---|
+| `ospf`  | `224.0.0.5`, `224.0.0.6` | — | OSPFv2 AllSPFRouters / AllDRouters (IP proto 89) |
+| `ospf3` | — | `ff02::5`, `ff02::6` | OSPFv3 (IP proto 89, IPv6) |
+| `rip`   | `224.0.0.9` | — | RIPv2 (UDP 520) |
+| `ripng` | — | `ff02::9` | RIPng (UDP 521) |
+| `pim`   | `224.0.0.13` | `ff02::d` | ALL-PIM-ROUTERS (IP proto 103), dual-family |
+| `igmp`  | `224.0.0.1`, `224.0.0.22` | — | all-hosts / IGMPv3 reports (IP proto 2), IPv4 only |
+| `dvmrp` | `224.0.0.4` | — | ALL-DVMRP-ROUTERS, carried inside IGMP (IP proto 2), IPv4 only |
+| `vrrp`  | `224.0.0.18` | `ff02::12` | VRRP (IP proto 112), dual-family |
+| `router-discovery` | `224.0.0.1`, `224.0.0.2` | — | IRDP advertisements / solicitations (IPv4); the IPv6 equivalent is ND RS/RA, already in the always-accepted set |
+
+`protocols all` expands (via `HostInboundAllExpansionProtocols`, #3199) to the
+routing-protocol set including every catalog member above, so it also triggers
+the advisory.
+
+## Why the enforcement is deferred: four coupled decisions
+
+Turning this catalog into an enforced per-zone multicast admission gate is a
+**behavior change** that is fail-**closed** on revert of today's accept, so it
+needs a converged plan. The four coupled decisions (tracked on #4455):
+
+1. **New `iifname`-scoped rule structure.** Multicast admission is
+   per-zone/per-interface (the destination is a group, not a firewall address).
+   `buildHostInboundFilterPayload` has no `iifname` predicate today; the enforced
+   form needs a new `iifname <zone-members> ip daddr <groups> accept` rule
+   structure plus a multicast catch-all drop.
+
+2. **The protocol→multicast-group catalog** (this doc / `hostInboundMulticastCatalog`)
+   agreed against Junos semantics. Settled here as the design artifact.
+
+3. **#1960 migration gating.** Enforcing per-zone multicast admission is
+   fail-**closed** on revert of today's accept: a zone running an FRR routing
+   protocol **without** the matching `host-inbound-traffic protocols` knob
+   currently relies on the unconditional accept, and enforcement would break it
+   (Junos requires both). This needs the strict-on-commit / warn-on-tolerant-load
+   (#1960) treatment plus an operator migration story.
+
+4. **Kernel/Rust lockstep.** The multicast dimension must be added to BOTH the
+   nft set AND `host_inbound_admits` without split-brain — the Rust classifier
+   has no destination-address dimension to extend yet. The existing lockstep
+   contract (`docs/host-inbound-service-matrix.md`, the "keep in lockstep"
+   comments, and the Go↔Rust parity tests) governs this.
+
+Until those land, the catalog is inert design data and the commit-time advisory
+is the only operator-visible surface.
+
+## See also
+
+- `docs/host-inbound-service-matrix.md` — the per-token service/protocol matrix
+  and the sibling #3226 `system-services all` packet-wide-admit advisory.
+- `pkg/config/host_inbound_tokens.go` — the recognized-token allowlist, family
+  maps, and per-tuple L4 match SSOT.

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -185,6 +185,19 @@ lives on the `research/3226-system-services` branch
 independent of that decision — it makes the current behavior visible without
 changing any forwarding.
 
+## Host-bound routing multicast is admitted packet-wide (#4455)
+
+The per-zone rules above match host-local **unicast** `daddr` only, so host-bound
+**multicast** (OSPF `224.0.0.5/6`, VRRP `224.0.0.18`, PIM `224.0.0.13`, …) falls
+through the input chain's `policy accept` **without** per-zone
+`host-inbound-traffic protocols` scoping — admitted packet-wide on every ingress
+interface, not scoped to the opting-in zone. This is fail-open-but-bounded (the
+host delivers only to groups a joined daemon subscribed), a Junos-parity gap.
+`ValidateConfig` emits a WARN-only commit-time advisory for a zone admitting a
+multicast routing protocol; the per-zone `iifname` enforcement is deferred. Full
+protocol→group catalog and the deferred four-decision plan:
+[`docs/host-inbound-multicast.md`](host-inbound-multicast.md).
+
 ## Global always-accepts (independent of the zone token set)
 
 These are accepted on EVERY host-inbound-configured zone regardless of its

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -1466,6 +1466,84 @@ func ValidateConfig(cfg *Config) []string {
 	// #4309 (fable-review-167 I-4): DHCP relay overrides accepted-only advisory.
 	warnings = append(warnings, validateDHCPRelayParityWarnings(cfg)...)
 
+	// #4455 (HI-1): a zone that admits a multicast routing protocol relies on the
+	// kernel input-chain `policy accept` fall-through to deliver that protocol's
+	// host-bound multicast PACKET-WIDE (not scoped to the zone's ingress
+	// interface). Surface that Junos-parity/hardening gap at commit; the per-zone
+	// iifname enforcement remains deferred.
+	warnings = append(warnings, validateHostInboundMulticastWarnings(cfg)...)
+
+	return warnings
+}
+
+// validateHostInboundMulticastWarnings emits the #4455 (HI-1) commit-time
+// advisory for a zone whose `host-inbound-traffic protocols` admits a MULTICAST
+// routing protocol (OSPF/RIP/PIM/VRRP/IGMP/router-discovery/... — see the
+// protocol->group catalog in host_inbound_multicast.go and
+// docs/host-inbound-multicast.md).
+//
+// VERIFY-FIRST (current master): the kernel `xpf_hostinbound` `chain input`
+// (buildHostInboundFilterPayload) matches host-local UNICAST daddr only and runs
+// `policy accept`, so a host-bound packet to a well-known routing multicast group
+// (224.0.0.5, 224.0.0.18, ...) matches no per-zone `daddr` set and is admitted
+// PACKET-WIDE — on EVERY ingress interface — rather than scoped to the zone whose
+// `host-inbound-traffic protocols` opted in (as Junos implies). The Rust AF_XDP
+// classifier (host_inbound_admits) has no destination-address dimension, so it
+// does not gate host-bound multicast either. This is FAIL-OPEN-BUT-BOUNDED (the
+// host delivers only to groups a joined daemon subscribed; ND/PMTUD/ESP control
+// is already globally accepted), a parity/hardening gap — NOT an open door.
+//
+// WARN-only: the config is valid Junos, and the enforcement (a per-zone
+// `iifname`-scoped admission model on BOTH surfaces, the #1960 fail-closed-on-
+// revert migration gating, and the kernel/Rust lockstep) is DEFERRED (#4455), so
+// this must not reject or change forwarding. Mirrors the #3226 `system-services
+// all` packet-wide-admit advisory. Emitted for the zone-level stanza AND every
+// per-interface override (#3362); one advisory per stanza.
+func validateHostInboundMulticastWarnings(cfg *Config) []string {
+	if cfg == nil || cfg.Security.Zones == nil {
+		return nil
+	}
+	var warnings []string
+	advise := func(where string, protocols []string) {
+		toks := hostInboundMulticastTokensPresent(protocols)
+		if len(toks) == 0 {
+			return
+		}
+		warnings = append(warnings, fmt.Sprintf(
+			"%s: host-bound routing multicast (%s) is currently admitted "+
+				"PACKET-WIDE via the kernel input-chain accept fall-through, "+
+				"not scoped to this zone's ingress interface — a known "+
+				"Junos-parity gap (#4455), pending the per-zone iifname "+
+				"multicast admission model.", where,
+			hostInboundMulticastGroupSummary(toks)))
+	}
+	names := make([]string, 0, len(cfg.Security.Zones))
+	for name := range cfg.Security.Zones {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		zone := cfg.Security.Zones[name]
+		if zone == nil { // #3494: tolerant/HA-sync path may carry a nil zone value
+			continue
+		}
+		if zone.HostInboundTraffic != nil {
+			advise(
+				fmt.Sprintf("zone %q host-inbound-traffic", name),
+				zone.HostInboundTraffic.Protocols)
+		}
+		// #3362: per-interface overrides carry the same `protocols` grammar and
+		// the same packet-wide multicast breadth — warn on each.
+		for _, ifRef := range zone.SortedInterfaceHostInboundRefs() {
+			hi := zone.InterfaceHostInbound[ifRef]
+			if hi == nil {
+				continue
+			}
+			advise(
+				fmt.Sprintf("zone %q interface %q host-inbound-traffic", name, ifRef),
+				hi.Protocols)
+		}
+	}
 	return warnings
 }
 

--- a/pkg/config/host_inbound_multicast.go
+++ b/pkg/config/host_inbound_multicast.go
@@ -1,0 +1,159 @@
+package config
+
+import (
+	"sort"
+	"strings"
+)
+
+// host_inbound_multicast.go is the protocol -> well-known multicast-group
+// catalog for host-bound routing multicast (#4455, HI-1).
+//
+// VERIFY-FIRST CONTEXT (current master). The kernel `xpf_hostinbound`
+// `chain input` (pkg/daemon/daemon_nft.go, buildHostInboundFilterPayload) runs
+// `type filter hook input ... policy accept` and matches host-local UNICAST
+// destination addresses only — every per-zone rule is scoped by
+// `<fam> daddr <zone-addrs>`. A host-bound packet addressed to a well-known
+// routing MULTICAST group (OSPF 224.0.0.5/6, VRRP 224.0.0.18, PIM 224.0.0.13,
+// ...) matches NO per-zone `daddr` set, so it falls through the chain's
+// `policy accept` to the host stack WITHOUT any per-zone
+// `host-inbound-traffic protocols` scoping. The Rust AF_XDP classifier
+// (host_inbound_admits, userspace-dp/src/afxdp/forwarding/host_inbound.rs) keys
+// only on (zone, protocol, dst_port, family, icmp_type) — it has NO
+// destination-address dimension — so it does not gate host-bound multicast
+// either.
+//
+// This is FAIL-OPEN-BUT-BOUNDED, a Junos-parity/hardening gap rather than an
+// open door: the host kernel delivers multicast only to groups a configured
+// daemon actually joined (a routing daemon the operator enabled), and the
+// always-on control set (IPv6 ND, PMTUD/error ICMP, ESP/AH) is already globally
+// accepted. So OSPF/VRRP/PIM do NOT break today; the parity gap is that the
+// admission is PACKET-WIDE (on every ingress interface) instead of scoped to
+// the zone whose `host-inbound-traffic protocols` opted in.
+//
+// This catalog is the design artifact that settles decision (2) of the deferred
+// enforcement (#4455): the protocol -> multicast-group enumeration the eventual
+// per-zone `iifname`-scoped nft set and the Rust address dimension will admit.
+// TODAY it backs ONLY the commit-time advisory
+// (validateHostInboundMulticastWarnings) — it makes NO forwarding decision. The
+// full enforcement (a new `iifname` predicate on BOTH surfaces, the #1960
+// migration gating because enforcement is fail-CLOSED on revert of today's
+// accept, and the kernel/Rust lockstep) remains DEFERRED. See
+// docs/host-inbound-multicast.md for the four coupled decisions.
+
+// HostInboundMulticastGroups is the well-known multicast groups a routing
+// protocol's host-bound control traffic is addressed to, split by family. A
+// dual-family protocol (pim, vrrp) populates both; a family-specific protocol
+// (ospf/rip/igmp/router-discovery are IPv4, ospf3/ripng are IPv6) populates
+// only its family, matching HostInboundProtocolFamily.
+type HostInboundMulticastGroups struct {
+	V4    []string // well-known IPv4 groups (nil for an IPv6-only protocol)
+	V6    []string // well-known IPv6 groups (nil for an IPv4-only protocol)
+	Label string   // short human label for the advisory / doc (e.g. "OSPFv2")
+}
+
+// hostInboundMulticastCatalog maps a `host-inbound-traffic protocols` token to
+// its well-known multicast groups. Only protocols whose host-bound CONTROL
+// traffic rides a well-known multicast group are listed — unicast routing
+// control (bgp/ldp/msdp/nhrp: TCP/UDP to a peer address; bfd: UDP to the peer)
+// is deliberately absent, and L2/non-IP protocols (isis) never reach the IP
+// input chain. `all` is handled by the callers via
+// HostInboundAllExpansionProtocols (it expands to this set's members plus the
+// unicast ones). Family split mirrors HostInboundProtocolFamily.
+var hostInboundMulticastCatalog = map[string]HostInboundMulticastGroups{
+	// OSPFv2 AllSPFRouters / AllDRouters (IP proto 89, IPv4).
+	"ospf": {V4: []string{"224.0.0.5", "224.0.0.6"}, Label: "OSPFv2"},
+	// OSPFv3 AllSPFRouters / AllDRouters (IP proto 89, IPv6).
+	"ospf3": {V6: []string{"ff02::5", "ff02::6"}, Label: "OSPFv3"},
+	// RIPv2 (UDP 520, IPv4).
+	"rip": {V4: []string{"224.0.0.9"}, Label: "RIPv2"},
+	// RIPng (UDP 521, IPv6).
+	"ripng": {V6: []string{"ff02::9"}, Label: "RIPng"},
+	// PIM ALL-PIM-ROUTERS (IP proto 103, dual-family).
+	"pim": {V4: []string{"224.0.0.13"}, V6: []string{"ff02::d"}, Label: "PIM"},
+	// IGMP all-hosts / IGMPv3 membership reports (IP proto 2, IPv4 only).
+	"igmp": {V4: []string{"224.0.0.1", "224.0.0.22"}, Label: "IGMP"},
+	// DVMRP ALL-DVMRP-ROUTERS — carried inside IGMP (IP proto 2), IPv4 only.
+	"dvmrp": {V4: []string{"224.0.0.4"}, Label: "DVMRP"},
+	// VRRP (IP proto 112, dual-family; ff02::12 is the IPv6 VRRP group).
+	"vrrp": {V4: []string{"224.0.0.18"}, V6: []string{"ff02::12"}, Label: "VRRP"},
+	// ICMP router discovery (IRDP): advertisements to 224.0.0.1 (all-hosts),
+	// solicitations to 224.0.0.2 (all-routers). IPv4 only — the IPv6 equivalent
+	// is Neighbor Discovery RS/RA, already in the always-accepted ND set.
+	"router-discovery": {V4: []string{"224.0.0.1", "224.0.0.2"}, Label: "router-discovery (IRDP)"},
+}
+
+// HostInboundMulticastProtocol reports whether a `host-inbound-traffic
+// protocols` token is a MULTICAST routing protocol (its host-bound control
+// traffic is addressed to a well-known multicast group) and returns its groups.
+// Unicast routing-control tokens (bgp/ldp/msdp/nhrp/bfd), L2 tokens (isis), and
+// the `all` meta-token return ok=false — callers expand `all` via
+// HostInboundAllExpansionProtocols before consulting this.
+func HostInboundMulticastProtocol(token string) (HostInboundMulticastGroups, bool) {
+	g, ok := hostInboundMulticastCatalog[strings.ToLower(token)]
+	return g, ok
+}
+
+// HostInboundMulticastProtocolTokens returns the multicast routing-protocol
+// tokens (catalog keys) in sorted order, for deterministic advisory/doc output.
+func HostInboundMulticastProtocolTokens() []string {
+	out := make([]string, 0, len(hostInboundMulticastCatalog))
+	for tok := range hostInboundMulticastCatalog {
+		out = append(out, tok)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// hostInboundMulticastTokensPresent returns the sorted set of MULTICAST
+// routing-protocol tokens implied by a zone/interface `host-inbound-traffic
+// protocols` list, expanding the `all` meta-token to its routing-protocol set
+// (#3199, HostInboundAllExpansionProtocols) first. Unicast/L2 tokens are
+// dropped. Returns nil when the list admits no multicast protocol.
+func hostInboundMulticastTokensPresent(protocols []string) []string {
+	seen := map[string]bool{}
+	var add func(tok string)
+	add = func(tok string) {
+		tok = strings.ToLower(tok)
+		if tok == "all" {
+			for _, p := range HostInboundAllExpansionProtocols() {
+				add(p)
+			}
+			return
+		}
+		if _, ok := hostInboundMulticastCatalog[tok]; ok {
+			seen[tok] = true
+		}
+	}
+	for _, p := range protocols {
+		add(p)
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(seen))
+	for tok := range seen {
+		out = append(out, tok)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// hostInboundMulticastGroupSummary renders a compact, deterministic
+// "PROTOCOL group[/group...]" summary for the given multicast tokens, for the
+// commit-time advisory text — e.g. "OSPFv2 224.0.0.5/224.0.0.6, PIM
+// 224.0.0.13/ff02::d". Tokens must already be filtered to catalog members
+// (hostInboundMulticastTokensPresent) and sorted.
+func hostInboundMulticastGroupSummary(tokens []string) string {
+	parts := make([]string, 0, len(tokens))
+	for _, tok := range tokens {
+		g, ok := hostInboundMulticastCatalog[tok]
+		if !ok {
+			continue
+		}
+		groups := make([]string, 0, len(g.V4)+len(g.V6))
+		groups = append(groups, g.V4...)
+		groups = append(groups, g.V6...)
+		parts = append(parts, g.Label+" "+strings.Join(groups, "/"))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/pkg/config/host_inbound_multicast_warn_4455_test.go
+++ b/pkg/config/host_inbound_multicast_warn_4455_test.go
@@ -1,0 +1,198 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// hostInboundMulticastWarnings returns the #4455 (HI-1) commit-time advisories
+// emitted by ValidateConfig for a zone that admits a multicast routing
+// protocol. The advisory phrase ("admitted PACKET-WIDE") is unique to this
+// check.
+func hostInboundMulticastWarnings(cfg *Config) []string {
+	var out []string
+	for _, w := range ValidateConfig(cfg) {
+		if strings.Contains(w, "admitted PACKET-WIDE") && strings.Contains(w, "#4455") {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+// Test_4455_MulticastProtocolEmitsPacketWideAdvisory is the #4455 RED-on-revert
+// guard for the commit-time advisory. A zone whose `host-inbound-traffic
+// protocols` admits a MULTICAST routing protocol (ospf/pim/vrrp/rip/igmp/
+// router-discovery) relies on the kernel input-chain `policy accept`
+// fall-through to deliver that protocol's host-bound multicast packet-wide
+// (buildHostInboundFilterPayload matches host-local unicast daddr only), which
+// is broader than Junos's per-zone scoping. The zone must:
+//
+//   - COMPILE with NO error (valid Junos; the advisory is a WARNING, never a
+//     reject — enforcement is deferred per #4455), and
+//   - carry the packet-wide multicast advisory naming the zone AND the concrete
+//     well-known group (e.g. OSPF 224.0.0.5).
+//
+// RED-on-revert: delete the validateHostInboundMulticastWarnings call in
+// ValidateConfig (or the advise() emit) and every sub-test that expects an
+// advisory turns RED.
+func Test_4455_MulticastProtocolEmitsPacketWideAdvisory(t *testing.T) {
+	cases := []struct {
+		name  string
+		token string
+		group string // a well-known group the advisory must name
+	}{
+		{"ospf", "ospf", "224.0.0.5"},
+		{"ospf3", "ospf3", "ff02::5"},
+		{"rip", "rip", "224.0.0.9"},
+		{"pim", "pim", "224.0.0.13"},
+		{"vrrp", "vrrp", "224.0.0.18"},
+		{"igmp", "igmp", "224.0.0.1"},
+		{"router-discovery", "router-discovery", "224.0.0.2"},
+	}
+	for _, tc := range cases {
+		t.Run("zone-level-"+tc.name, func(t *testing.T) {
+			tree := buildTree(t, []string{
+				"set security zones security-zone trust interfaces ge-0/0/0.0",
+				"set security zones security-zone trust host-inbound-traffic protocols " + tc.token,
+			})
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("CompileConfig must accept protocols %s (valid Junos, warn-not-reject): %v", tc.token, err)
+			}
+			got := hostInboundMulticastWarnings(cfg)
+			if len(got) != 1 {
+				t.Fatalf("protocols %s: expected exactly one packet-wide multicast advisory, got %d: %v", tc.token, len(got), got)
+			}
+			if !strings.Contains(got[0], `zone "trust"`) {
+				t.Errorf("advisory must name the zone, got: %q", got[0])
+			}
+			if !strings.Contains(got[0], tc.group) {
+				t.Errorf("advisory must name the well-known group %q, got: %q", tc.group, got[0])
+			}
+		})
+	}
+}
+
+// Test_4455_UnicastProtocolNoAdvisory pins the other half of the contract: a
+// zone whose `host-inbound-traffic protocols` lists only UNICAST routing-control
+// protocols (bgp is TCP/179 to a peer, ldp/msdp/bfd are unicast) rides no
+// well-known multicast group and must draw NO #4455 advisory.
+func Test_4455_UnicastProtocolNoAdvisory(t *testing.T) {
+	for _, tok := range []string{"bgp", "ldp", "msdp", "bfd"} {
+		t.Run(tok, func(t *testing.T) {
+			tree := buildTree(t, []string{
+				"set security zones security-zone trust interfaces ge-0/0/0.0",
+				"set security zones security-zone trust host-inbound-traffic protocols " + tok,
+			})
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("CompileConfig: %v", err)
+			}
+			if got := hostInboundMulticastWarnings(cfg); len(got) != 0 {
+				t.Fatalf("unicast protocol %q must NOT draw a multicast advisory, got: %v", tok, got)
+			}
+		})
+	}
+}
+
+// Test_4455_NoProtocolsNoAdvisory pins that a zone with only system-services
+// (no `protocols` stanza) and a zone with no host-inbound-traffic at all draw
+// NO #4455 advisory — the check is scoped to multicast routing protocols.
+func Test_4455_NoProtocolsNoAdvisory(t *testing.T) {
+	t.Run("system-services-only", func(t *testing.T) {
+		tree := buildTree(t, []string{
+			"set security zones security-zone trust interfaces ge-0/0/0.0",
+			"set security zones security-zone trust host-inbound-traffic system-services ssh",
+			"set security zones security-zone trust host-inbound-traffic system-services ping",
+		})
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("CompileConfig: %v", err)
+		}
+		if got := hostInboundMulticastWarnings(cfg); len(got) != 0 {
+			t.Fatalf("system-services-only zone must NOT draw a multicast advisory, got: %v", got)
+		}
+	})
+	t.Run("no-host-inbound", func(t *testing.T) {
+		tree := buildTree(t, []string{
+			"set security zones security-zone trust interfaces ge-0/0/0.0",
+		})
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("CompileConfig: %v", err)
+		}
+		if got := hostInboundMulticastWarnings(cfg); len(got) != 0 {
+			t.Fatalf("zone with no host-inbound-traffic must NOT draw a multicast advisory, got: %v", got)
+		}
+	})
+}
+
+// Test_4455_ProtocolsAllExpandsToMulticast pins that `protocols all` — which
+// expands to the routing-protocol set (#3199) INCLUDING the multicast
+// protocols — draws the advisory (the expansion is where the packet-wide
+// multicast admission comes from under `all`).
+func Test_4455_ProtocolsAllExpandsToMulticast(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security zones security-zone trust interfaces ge-0/0/0.0",
+		"set security zones security-zone trust host-inbound-traffic protocols all",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig must accept protocols all: %v", err)
+	}
+	got := hostInboundMulticastWarnings(cfg)
+	if len(got) != 1 {
+		t.Fatalf("protocols all must draw exactly one multicast advisory, got %d: %v", len(got), got)
+	}
+	// `all` expands to OSPF among others, so the OSPF group must appear.
+	if !strings.Contains(got[0], "224.0.0.5") {
+		t.Errorf("protocols all advisory must name an expanded multicast group (e.g. OSPF 224.0.0.5), got: %q", got[0])
+	}
+}
+
+// Test_4455_PerInterfaceOverrideAdvisory covers the #3362 per-interface override
+// path: a multicast `protocols` set only on one interface of a zone must warn
+// and name BOTH the zone and the interface.
+func Test_4455_PerInterfaceOverrideAdvisory(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security zones security-zone wan interfaces ge-0/0/0.0 host-inbound-traffic protocols ospf",
+		// a sibling interface with a unicast protocol — must NOT warn.
+		"set security zones security-zone wan interfaces ge-0/0/1.0 host-inbound-traffic protocols bgp",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig must accept a per-interface protocols override: %v", err)
+	}
+	got := hostInboundMulticastWarnings(cfg)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one per-interface multicast advisory, got %d: %v", len(got), got)
+	}
+	if !strings.Contains(got[0], `zone "wan"`) || !strings.Contains(got[0], `interface "ge-0/0/0.0"`) {
+		t.Errorf("per-interface advisory must name both zone and interface, got: %q", got[0])
+	}
+}
+
+// Test_4455_CatalogSSOTShape guards the protocol->multicast-group catalog SSOT:
+// every catalog token is a recognized host-inbound protocol, and none is a
+// unicast-only or L2 protocol misfiled as multicast.
+func Test_4455_CatalogSSOTShape(t *testing.T) {
+	for _, tok := range HostInboundMulticastProtocolTokens() {
+		if !KnownHostInboundProtocols[tok] {
+			t.Errorf("catalog token %q is not a KnownHostInboundProtocols token", tok)
+		}
+		if HostInboundL2Protocols[tok] {
+			t.Errorf("catalog token %q is an L2 protocol and rides no IP multicast group", tok)
+		}
+		g, ok := HostInboundMulticastProtocol(tok)
+		if !ok {
+			t.Errorf("HostInboundMulticastProtocol(%q) must report ok for a catalog token", tok)
+		}
+		if len(g.V4) == 0 && len(g.V6) == 0 {
+			t.Errorf("catalog token %q has no multicast groups", tok)
+		}
+	}
+	// bgp is unicast — must NOT be in the multicast catalog.
+	if _, ok := HostInboundMulticastProtocol("bgp"); ok {
+		t.Errorf("bgp is unicast and must not be a multicast-catalog protocol")
+	}
+}

--- a/pkg/config/testdata/golden_4406.json
+++ b/pkg/config/testdata/golden_4406.json
@@ -1231,6 +1231,8 @@
       "BridgeDomains": null,
       "Warnings": [
         "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly.",
+        "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
+        "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "apply-groups \"${node}\" resolved using default node0 context during generic compile"
       ]
     },
@@ -2467,7 +2469,9 @@
       "EventOptions": null,
       "BridgeDomains": null,
       "Warnings": [
-        "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly."
+        "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly.",
+        "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
+        "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model."
       ]
     },
     "error": ""
@@ -3703,7 +3707,9 @@
       "EventOptions": null,
       "BridgeDomains": null,
       "Warnings": [
-        "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly."
+        "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly.",
+        "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
+        "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model."
       ]
     },
     "error": ""
@@ -4940,6 +4946,8 @@
       "BridgeDomains": null,
       "Warnings": [
         "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly.",
+        "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
+        "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "apply-groups \"${node}\" resolved using default node0 context during generic compile"
       ]
     },
@@ -6176,7 +6184,9 @@
       "EventOptions": null,
       "BridgeDomains": null,
       "Warnings": [
-        "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly."
+        "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly.",
+        "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
+        "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model."
       ]
     },
     "error": ""
@@ -7412,7 +7422,9 @@
       "EventOptions": null,
       "BridgeDomains": null,
       "Warnings": [
-        "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly."
+        "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly.",
+        "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
+        "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model."
       ]
     },
     "error": ""
@@ -8370,6 +8382,8 @@
       "BridgeDomains": null,
       "Warnings": [
         "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly.",
+        "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
+        "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "apply-groups \"${node}\" resolved using default node0 context during generic compile"
       ]
     },
@@ -9327,7 +9341,9 @@
       "EventOptions": null,
       "BridgeDomains": null,
       "Warnings": [
-        "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly."
+        "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly.",
+        "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
+        "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model."
       ]
     },
     "error": ""
@@ -10284,7 +10300,9 @@
       "EventOptions": null,
       "BridgeDomains": null,
       "Warnings": [
-        "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly."
+        "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly.",
+        "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
+        "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model."
       ]
     },
     "error": ""
@@ -11242,6 +11260,8 @@
       "BridgeDomains": null,
       "Warnings": [
         "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly.",
+        "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
+        "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "apply-groups \"${node}\" resolved using default node0 context during generic compile"
       ]
     },
@@ -12199,7 +12219,9 @@
       "EventOptions": null,
       "BridgeDomains": null,
       "Warnings": [
-        "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly."
+        "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly.",
+        "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
+        "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model."
       ]
     },
     "error": ""
@@ -13156,7 +13178,9 @@
       "EventOptions": null,
       "BridgeDomains": null,
       "Warnings": [
-        "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly."
+        "zone \"control\" host-inbound-traffic: system-services \"all\" is a broad packet-wide full-admit that accepts EVERY IP protocol/port (GRE/ESP/AH/OSPF/PIM/VRRP/future proto numbers) to the zone's local addresses — a superset of Junos's per-service union; if you intend only specific services, list them explicitly.",
+        "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
+        "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model."
       ]
     },
     "error": ""


### PR DESCRIPTION
Addresses #4455 (HI-1) with the **bounded advisory/catalog slice**; the per-zone
`iifname` enforcement + the #1960 migration gating + the kernel/Rust lockstep
remain **deferred**.

## What this ships (GO-only, no forwarding change)

Verify-first on master confirmed host-bound routing multicast is **fail-OPEN but
BOUNDED**, not an open door: `buildHostInboundFilterPayload`
(`pkg/daemon/daemon_nft.go:462`) matches host-local **unicast** `daddr` only and
runs `policy accept` (`:524`), so a packet to a well-known group (OSPF
`224.0.0.5/6`, VRRP `224.0.0.18`, PIM `224.0.0.13`) matches no per-zone `daddr`
set and falls through the accept **without** per-zone
`host-inbound-traffic protocols` scoping. The Rust `host_inbound_admits`
(`host_inbound.rs:474`) keys only on zone/proto/port/family/icmp-type — no
address dimension — so it does not gate host-bound multicast either. The host
delivers only to groups a joined daemon subscribed, and ND/PMTUD/ESP control is
already globally accepted, so OSPF/VRRP/PIM do **not** break today. The gap is
that admission is **packet-wide** rather than per-zone (broader than Junos).

- **`pkg/config/host_inbound_multicast.go`** (new): the protocol→multicast-group
  catalog SSOT (ospf/ospf3/rip/ripng/pim/igmp/dvmrp/vrrp/router-discovery → their
  well-known v4+v6 groups), family-split to mirror `HostInboundProtocolFamily`.
  Settles deferred design decision (2). Inert design data — no forwarding
  decision today.
- **`validateHostInboundMulticastWarnings`** (`compiler_validate_warn.go`): a
  WARN-only commit-time advisory mirroring the #3226 `system-services all`
  pattern. Fires when a zone-level stanza or a #3362 per-interface override
  admits a multicast routing protocol (expands `protocols all`); names the zone
  (+ interface) and the concrete groups. Never a reject.
- **`docs/host-inbound-multicast.md`** (new): the design artifact — the group
  table, the fail-open-but-bounded explanation, and the four coupled decisions
  that keep enforcement deferred. Cross-linked from
  `docs/host-inbound-service-matrix.md`.

## Why this is the value-shipping slice

The full per-zone multicast gate is a behavior change that is **fail-CLOSED on
revert** of today's accept (it would break a zone running an FRR routing protocol
without the matching `host-inbound-traffic protocols` knob) and needs the four
coupled decisions in #4455. This slice surfaces the parity gap and settles the
catalog **without** changing forwarding.

## Validation

RED-on-revert test `host_inbound_multicast_warn_4455_test.go`: multicast protocol
→ advisory naming zone + group; unicast (bgp/ldp/msdp/bfd) → none;
system-services-only and no-host-inbound → none; per-interface override names
zone+interface; `protocols all` expansion draws it; catalog SSOT shape. Deleting
the `ValidateConfig` call turns the advisory sub-tests RED (verified). The
`golden_4406` baseline was regenerated — the only diff is the added #4455
advisory on 12 cases whose zones set `protocols router-discovery`, no other
config field changed. `go test ./pkg/config/` green, `go vet` clean, `gofmt`
clean, `go build ./...` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi