### PR TITLE
config: promote zone->undefined-interface to a strict commit reject (#4515)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -84,6 +84,54 @@
   cases, no other field changed), `docs/host-inbound-multicast.md` (new),
   `docs/host-inbound-service-matrix.md`, `_Log.md`.
 
+## 2026-07-07 — #4515 config: promote zone→undefined-interface to a strict commit reject (F6); F11-part2 kept warn-only (deliberate)
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4515 (ps-review-002 F6/F11, GO-only, pkg/config). VERIFY-FIRST
+  on current master, then drove F6 and SKIPPED F11-part2 with rationale.
+  F6 — a `security zones security-zone <z> interfaces <if>` entry naming an
+  interface NOT defined under `interfaces` was warn-only; Junos hard-rejects it.
+  Promoted to a strict commit / commit-check reject
+  (`validateZoneInterfaceDefinedStrict`, `compiler_validate_strict_zones.go`,
+  gated in `runUniformGates` after the #3072 membership gate), lenient-downgrade
+  to a warning on the tolerant load / peer-sync path
+  (`opts.lenientZoneInterfaceDefined`, #1960 no-brick). The safeguard against the
+  #4191 over-rejection class is `zoneReferenceableInterfaceBases`: a GENEROUS
+  union of every configured interface + `lo0` (always-materialized loopback) +
+  every IPsec `bind-interface` secure-tunnel base (st0.x materialized at apply
+  time). Removed the old warn loop from `ValidateConfig` (kept `configuredIfaces`
+  for the routing-instance warn, which stays warn-only). RED-on-revert: without
+  the gate the undefined-interface config compiles clean (warn-only) — the new
+  test then FAILS; the lenient path warns not bricks; valid + lo0 + bind-st0.0
+  configs commit clean. F11-part2 (malformed address-book VALUE, e.g.
+  `10.0.1.0/32/24`) kept WARN-ONLY deliberately: the `address` schema leaf is an
+  intentionally-open `multi:true children:nil` leaf and the non-literal Junos
+  forms (dns-name/range-address/wildcard-address) are unmodeled — they and a
+  malformed prefix BOTH compile to an empty prefix and share the same warn, so a
+  strict promotion would false-reject the valid non-literal forms (#4191 class);
+  the residual fail-open is narrow/theoretical (empty prefix is fail-closed for
+  permit rules). Fixed test fixtures across pkg/config that referenced zone
+  interfaces without defining them + one real deploy config
+  (`test/incus/xpf-internet-test.conf`, added `enp6s0`). Cross-package blast
+  radius from the new strict gate fixed the same way (add-only interface defs
+  to fixtures) in pkg/configstore, pkg/cli, pkg/api, pkg/grpcapi,
+  pkg/dataplane/userspace so every commit stays bisect-green. #4406 compile
+  golden baseline UNCHANGED (corpus had 0 undefined-interface warnings; the
+  superset union rejects nothing the warn didn't already flag); grpcapi
+  show-text golden UNCHANGED (interface defs don't alter the captured show
+  topics). go test ./pkg/... green (except the PRE-EXISTING, unrelated
+  pkg/fsatomic `TestNoDirectOsWriteFile` flag on daemon/daemon_flow.go);
+  go build; gofmt+vet clean on all touched files.
+- **File(s)**: pkg/config/compiler_validate_strict_zones.go,
+  pkg/config/compiler_uniformgates.go, pkg/config/compiler.go,
+  pkg/config/compiler_validate_warn.go,
+  pkg/config/zone_interface_defined_4515_test.go,
+  pkg/config/zone_interface_membership_test.go,
+  pkg/config/addressbook_name_slash_4340_test.go,
+  pkg/config/parser_routing_test.go, pkg/config/parser_security_test.go,
+  (+ additional pkg/config *_test.go fixtures), test/incus/xpf-internet-test.conf,
+  docs/config-schema.md, _Log.md
+
 ## 2026-07-07 — #3226 host-inbound: commit-time advisory for `system-services all` / `any-service` packet-wide full-admit
 
 - **Timestamp**: 2026-07-07

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -102,6 +102,61 @@ TTL to `[0, 0xffff]` as a defensive backstop so even the in-range IEEE extreme
 (32768 × 10) — and any constructed caller — cannot wrap, matching the standard's
 own `txTTL = min(65535, msgTxInterval × msgTxHold)`.
 
+### `security zones` interface-defined reference (ps-review-002 F6, #4515)
+
+`validateZoneInterfaceDefinedStrict` (`compiler_validate_strict_zones.go`, gated
+in `runUniformGates`) hard-rejects a `security zones security-zone <z> interfaces
+<if>` entry that names an interface which is **not** defined under `interfaces`
+(and is not a daemon-materialized dynamic interface), on the strict commit /
+commit-check path. Junos rejects such a zone member; xpf previously only WARNED
+(`ValidateConfig`) then compiled and kept the zone. At runtime the referenced
+interface is absent, so the daemon brings it DOWN (fail-closed for real traffic)
+— safe but silent: a typo'd `ge-0/0/99` zone member carried no packets with no
+commit-time signal.
+
+The reference set is the **generous** union `zoneReferenceableInterfaceBases`
+builds — this union is the safeguard that makes the promotion safe (the naive
+`cfg.Interfaces.Interfaces`-only set is why the gap was left warn-only; it would
+false-reject a legitimate dynamic-interface reference, the #4191 over-rejection
+class):
+
+- every explicitly-configured interface (`cfg.Interfaces.Interfaces`) — GRE /
+  IPIP / WireGuard tunnels and VRF (routing-instance) member interfaces are
+  covered here for free, because a tunnel device and a routing-instance member
+  must both be configured under `interfaces`;
+- `lo0` — the always-present loopback, a reserved Junos interface a zone may
+  reference (host-inbound self-traffic) with no explicit `set interfaces lo0`;
+- every secure-tunnel base derived from an IPsec `bind-interface`
+  (`cfg.Security.IPsec.VPNs[*].BindInterface`) — `bind-interface st0.0`
+  materializes the st0 xfrmi device at apply time (`daemon_apply` →
+  `routing.ApplyXfrmi`) even with no explicit `set interfaces st0 unit 0`. The
+  base is the bind string with any `.unit` stripped, so every unit of a bound
+  secure tunnel is admitted.
+
+The tolerant load / peer-sync path downgrades to a warning
+(`opts.lenientZoneInterfaceDefined`) so an already-persisted or peer-synced
+config an older binary accepted still boots (#1960 no-brick); runtime behavior on
+that path is unchanged (the unresolved member carries no traffic). Runs AFTER
+`validateZoneInterfaceMembershipStrict` (#3072, the same-interface-in-two-zones
+gate) so a duplicate-assignment error still wins the first-error slot. Covered by
+`pkg/config/zone_interface_defined_4515_test.go`.
+
+Sibling gap **F11-part2** (a malformed address-book VALUE such as
+`10.0.1.0/32/24`) was evaluated in the same issue and kept **warn-only**
+DELIBERATELY: the `security address-book ... address` schema leaf is an
+intentionally-open `multi:true` leaf (`schema_security.go`, `children:nil`) and
+the non-literal Junos forms `dns-name` / `range-address` / `wildcard-address` are
+not modeled — they compile to an empty prefix and warn ("no usable prefix
+configured"). A malformed positional prefix also compiles to an empty prefix
+(the same `looksLikeIPOrCIDR` gate that populates `Address.Value` rejects it), so
+the empty-prefix warn conflates a genuine typo with a valid-but-unmodeled
+non-literal form. Promoting it to a strict reject would false-reject every
+`dns-name`/`range-address`/`wildcard-address` entry (the #4191 over-rejection
+class) unless those forms are modeled first, and the residual fail-open is
+narrow and theoretical (a permit rule referencing an empty-prefix address is
+already fail-CLOSED — it matches nothing; only a deny blocklist entry could fail
+open, the same class as a typo'd address-book NAME). See #4515.
+
 ## Multi-value leaves and bracketed lists (the dual-AST contract)
 
 A `multi: true` leaf with `children: nil` (e.g. `from protocol`,

--- a/pkg/api/security_zone_hostinbound_3328_test.go
+++ b/pkg/api/security_zone_hostinbound_3328_test.go
@@ -49,6 +49,15 @@ func zoneHostInboundAPIStore(t *testing.T) *configstore.Store {
 		t.Fatalf("EnterConfigure() error = %v", err)
 	}
 	if err := store.LoadOverride(`
+interfaces {
+    ge-0/0/9 {
+        unit 0 {
+            family inet {
+                address 10.0.9.1/24;
+            }
+        }
+    }
+}
 security {
     zones {
         security-zone trust {

--- a/pkg/cli/cli_rollback_3447_test.go
+++ b/pkg/cli/cli_rollback_3447_test.go
@@ -27,16 +27,19 @@ func buildRollbackHistoryStore(t *testing.T) *configstore.Store {
 	if err := store.EnterConfigure(); err != nil {
 		t.Fatalf("EnterConfigure: %v", err)
 	}
+	store.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	store.SetFromInput("security zones security-zone trust interfaces eth0.0")
 	if _, err := store.Commit(); err != nil {
 		t.Fatalf("commit 1: %v", err)
 	}
+	store.SetFromInput("interfaces eth1 unit 0 family inet address 10.0.1.1/24")
 	store.SetFromInput("security zones security-zone untrust interfaces eth1.0")
 	if _, err := store.Commit(); err != nil {
 		t.Fatalf("commit 2: %v", err)
 	}
 	// Dirty candidate edit on top of active — this is what a malformed
 	// rollback must NOT silently discard.
+	store.SetFromInput("interfaces eth2 unit 0 family inet address 10.0.2.1/24")
 	store.SetFromInput("security zones security-zone dmz interfaces eth2.0")
 	if !store.IsDirty() {
 		t.Fatal("store should be dirty after candidate edit")

--- a/pkg/cli/cli_show_security_zone_local_3358_test.go
+++ b/pkg/cli/cli_show_security_zone_local_3358_test.go
@@ -21,6 +21,8 @@ func zoneLocal3358Config(t *testing.T) *config.Config {
 	t.Helper()
 	tree := &config.ConfigTree{}
 	cmds := []string{
+		"set interfaces eth0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces eth1 unit 0 family inet address 10.0.2.1/24",
 		"set security zones security-zone trust interfaces eth0",
 		"set security zones security-zone untrust interfaces eth1",
 		// Same name 'web' both globally and zone-locally in trust, with

--- a/pkg/cli/host_inbound_display_3654_test.go
+++ b/pkg/cli/host_inbound_display_3654_test.go
@@ -25,6 +25,10 @@ func hostInboundCLIStore(t *testing.T) *CLI {
 		t.Fatalf("EnterConfigure() error = %v", err)
 	}
 	if err := store.LoadOverride(`
+interfaces {
+    ge-0/0/9 { unit 0 { family inet { address 10.0.9.1/24; } } }
+    ge-0/0/1 { unit 0 { family inet { address 10.0.1.1/24; } } }
+}
 security {
     zones {
         security-zone trust {
@@ -159,6 +163,9 @@ func TestShowInterfacesHostInbound3654(t *testing.T) {
 		t.Fatalf("EnterConfigure() error = %v", err)
 	}
 	if err := store.LoadOverride(`
+interfaces {
+    lo { unit 0 { family inet { address 127.0.0.2/32; } } }
+}
 security {
     zones {
         security-zone lan {

--- a/pkg/config/addressbook_name_slash_3061_test.go
+++ b/pkg/config/addressbook_name_slash_3061_test.go
@@ -67,6 +67,7 @@ func TestSecurityZoneNameSlashRejected(t *testing.T) {
 // (10.0.1.0/24) is fine; only the NAME token is checked.
 func TestAddressBookNameSlashNormalConfigUnaffected(t *testing.T) {
 	tree := buildTree(t, []string{
+		"set interfaces eth0 unit 0 family inet address 10.0.0.1/24",
 		"set security zones security-zone trust interfaces eth0",
 		"set security address-book global address web-server 10.0.1.0/24",
 		"set security address-book global address-set servers address web-server",

--- a/pkg/config/addressbook_name_slash_4340_test.go
+++ b/pkg/config/addressbook_name_slash_4340_test.go
@@ -14,6 +14,8 @@ import "testing"
 // definition AND the policy reference failed at commit.
 func TestAddressBookSlashNameCommits(t *testing.T) {
 	tree := buildTree(t, []string{
+		"set interfaces ge-0-0-0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0-0-1 unit 0 family inet address 10.0.1.1/24",
 		"set security zones security-zone trust interfaces ge-0-0-0",
 		"set security zones security-zone untrust interfaces ge-0-0-1",
 		// v4 and v6 objects named after their prefix (a CIDR value + a `/`
@@ -87,6 +89,8 @@ func TestAddressBookSlashNameCommits(t *testing.T) {
 // it correct while permitting the `/`.
 func TestAddressBookSlashNameZoneLocalFoldRoundTrips(t *testing.T) {
 	tree := buildTree(t, []string{
+		"set interfaces ge-0-0-0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0-0-1 unit 0 family inet address 10.0.1.1/24",
 		"set security zones security-zone trust interfaces ge-0-0-0",
 		"set security zones security-zone untrust interfaces ge-0-0-1",
 		"set security zones security-zone trust address-book address net_172.16.0.0/12 172.16.0.0/12",

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -992,6 +992,24 @@ type compileOpts struct {
 	// loaded config forwards exactly as before, just with an operator-visible
 	// warning. Same doctrine as lenientPolicyZoneRefs.
 	lenientZoneInterfaceMembership bool
+	// lenientZoneInterfaceDefined (ps-review-002 F6, #4515) downgrades the
+	// zone-interface DEFINED gate (validateZoneInterfaceDefinedStrict) from a
+	// hard compile error to a cfg.Warnings entry. The strict commit /
+	// commit-check path hard-rejects a `security zones security-zone <z>
+	// interfaces <if>` entry that names an interface which is neither configured
+	// under `interfaces` nor a daemon-materialized dynamic interface (lo0 / an
+	// IPsec secure-tunnel bind-interface) — Junos rejects such a zone member,
+	// whereas xpf previously only warned then compiled it (the runtime brings the
+	// absent interface DOWN, so it is fail-closed but silent). The tolerant load /
+	// peer-sync paths downgrade to a warning so an already-persisted or
+	// peer-synced config an older binary accepted still BOOTS (#1960 no-brick);
+	// on that path behavior is unchanged (the unresolved member carries no
+	// traffic), just with an operator-visible warning. The reference set is the
+	// GENEROUS zoneReferenceableInterfaceBases union (lo0 + IPsec secure-tunnel
+	// bases + every configured interface) so the promotion cannot false-reject a
+	// legitimate dynamic-interface reference (the #4191 over-rejection class).
+	// Same doctrine as lenientZoneInterfaceMembership.
+	lenientZoneInterfaceDefined bool
 	// lenientHostInboundTokens (#3200) downgrades the host-inbound-traffic
 	// token gate (validateHostInboundTokensStrict) from a hard compile error
 	// to a cfg.Warnings entry. The strict commit / commit-check path
@@ -1618,6 +1636,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientRoutingInstanceTableIDCollision: true,
 		lenientAddressBookNames:                true,
 		lenientZoneInterfaceMembership:         true,
+		lenientZoneInterfaceDefined:            true,
 		lenientHostInboundTokens:               true,
 		lenientDuplicateHostLocalAddress:       true,
 		lenientDestNATAddresses:                true,
@@ -1866,6 +1885,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientRoutingInstanceTableIDCollision: true,
 		lenientAddressBookNames:                true,
 		lenientZoneInterfaceMembership:         true,
+		lenientZoneInterfaceDefined:            true,
 		lenientHostInboundTokens:               true,
 		lenientDuplicateHostLocalAddress:       true,
 		lenientDestNATAddresses:                true,

--- a/pkg/config/compiler_addrbook_warn_3958_test.go
+++ b/pkg/config/compiler_addrbook_warn_3958_test.go
@@ -63,6 +63,8 @@ func TestValidateWarnAddressRefFormsNoFalsePositive(t *testing.T) {
 		// address-book entry + address-set
 		"set security address-book global address good-host 10.0.0.0/8",
 		"set security address-book global address-set trusted address good-host",
+		"set interfaces ge-0-0-1 unit 0 family inet address 10.0.1.1/24",
+		"set interfaces ge-0-0-2 unit 0 family inet address 10.0.2.1/24",
 		"set security zones security-zone lan interfaces ge-0-0-1.0",
 		"set security zones security-zone wan interfaces ge-0-0-2.0",
 

--- a/pkg/config/compiler_default_policy_3065_test.go
+++ b/pkg/config/compiler_default_policy_3065_test.go
@@ -34,6 +34,8 @@ func compileDefaultPolicyFromSet(t *testing.T, cmds []string) *Config {
 // goes RED.
 func TestDefaultPolicyFailsClosed(t *testing.T) {
 	cfg := compileDefaultPolicyFromSet(t, []string{
+		"set interfaces eth0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces eth1 unit 0 family inet address 10.0.1.1/24",
 		"set security zones security-zone trust interfaces eth0",
 		"set security zones security-zone untrust interfaces eth1",
 		"set security policies from-zone trust to-zone untrust policy allow-web match source-address any",
@@ -62,6 +64,8 @@ func TestDefaultPolicyExplicitOverrides(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.value, func(t *testing.T) {
 			cfg := compileDefaultPolicyFromSet(t, []string{
+				"set interfaces eth0 unit 0 family inet address 10.0.0.1/24",
+				"set interfaces eth1 unit 0 family inet address 10.0.1.1/24",
 				"set security zones security-zone trust interfaces eth0",
 				"set security zones security-zone untrust interfaces eth1",
 				"set security policies default-policy " + tc.value,

--- a/pkg/config/compiler_default_policy_log_3534_test.go
+++ b/pkg/config/compiler_default_policy_log_3534_test.go
@@ -98,6 +98,7 @@ func TestDefaultPolicyLogCompiles(t *testing.T) {
 func TestDefaultPolicyLogSchemaValidates(t *testing.T) {
 	for _, flag := range []string{"session-init", "session-close"} {
 		tree := buildDefaultPolicyLogTree(t, []string{
+			"set interfaces eth0 unit 0 family inet address 10.0.0.1/24",
 			"set security zones security-zone trust interfaces eth0",
 			"set security policies default-policy permit-all",
 			"set security policies default-policy-log " + flag,

--- a/pkg/config/compiler_dup_policy_name_3473_test.go
+++ b/pkg/config/compiler_dup_policy_name_3473_test.go
@@ -175,6 +175,8 @@ security {
 func TestDuplicatePolicyNameFlatSetMergesToOnePolicy(t *testing.T) {
 	tree := &ConfigTree{}
 	for _, cmd := range []string{
+		"set interfaces eth0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces eth1 unit 0 family inet address 10.0.1.1/24",
 		"set security zones security-zone trust interfaces eth0",
 		"set security zones security-zone untrust interfaces eth1",
 		"set security policies from-zone trust to-zone untrust policy allow match source-address any",

--- a/pkg/config/compiler_feed_address_token_3294_test.go
+++ b/pkg/config/compiler_feed_address_token_3294_test.go
@@ -31,6 +31,8 @@ func feedBase3294() []string {
 		"set security dynamic-address feed-server threat feed-name malware path /malware.txt",
 		"set security dynamic-address address-name bad-actors profile feed-name malware",
 		"set security address-book global address good-host 10.0.0.0/8",
+		"set interfaces ge-0-0-1 unit 0 family inet address 10.0.1.1/24",
+		"set interfaces ge-0-0-2 unit 0 family inet address 10.0.2.1/24",
 		"set security zones security-zone lan interfaces ge-0-0-1.0",
 		"set security zones security-zone wan interfaces ge-0-0-2.0",
 	}

--- a/pkg/config/compiler_junos_host_direct_warn_4146_test.go
+++ b/pkg/config/compiler_junos_host_direct_warn_4146_test.go
@@ -43,6 +43,8 @@ func junosHostWarnings(t *testing.T, cmds []string) []string {
 // baseZones is the minimal zone/address-book scaffolding the junos-host policy
 // cases reference.
 var junosHostBaseZones = []string{
+	"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
+	"set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.1/24",
 	"set security zones security-zone untrust interfaces ge-0/0/1.0",
 	"set security zones security-zone untrust host-inbound-traffic system-services ssh",
 	"set security zones security-zone trust interfaces ge-0/0/0.0",

--- a/pkg/config/compiler_security_bracket_list_3703_test.go
+++ b/pkg/config/compiler_security_bracket_list_3703_test.go
@@ -27,6 +27,14 @@ import (
 func setTree3703(t *testing.T, cmds ...string) *ConfigTree {
 	t.Helper()
 	tree := &ConfigTree{}
+	// #4515: zone members below reference ge-0/0/0 and ge-0/0/1; define them so
+	// the strict zone-interface-defined gate (validateZoneInterfaceDefinedStrict)
+	// is satisfied — this fixture predates that gate and only exercises
+	// host-inbound / policy-log grammar, not interface validation.
+	cmds = append([]string{
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.1/24",
+	}, cmds...)
 	for _, cmd := range cmds {
 		path, err := ParseSetCommand(cmd)
 		if err != nil {
@@ -128,6 +136,15 @@ func TestHostInbound3703KeepsAllListValues(t *testing.T) {
 // does not regress the block spelling.
 func TestHostInbound3703HierarchicalBlockShape(t *testing.T) {
 	tree := parseHierarchical(t, `
+interfaces {
+    ge-0/0/0 {
+        unit 0 {
+            family inet {
+                address 10.0.0.1/24;
+            }
+        }
+    }
+}
 security {
     zones {
         security-zone trust {

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -405,6 +405,29 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 		}
 	}
 
+	// ps-review-002 F6 (#4515) zone-interface DEFINED gate. Strict on commit /
+	// commit-check (hard-reject a `security zones security-zone <z> interfaces
+	// <if>` entry naming an interface neither configured under `interfaces` nor
+	// materialized as a dynamic interface — lo0 / an IPsec secure-tunnel
+	// bind-interface; Junos rejects such a zone member, xpf previously only
+	// warned then compiled it, so a typo'd member silently carried no traffic).
+	// Lenient on load / peer-sync (warn so an already-persisted or peer-synced
+	// config still boots — #1960 no-brick; the runtime brings the absent
+	// interface DOWN independently, so the leniently-loaded member is inert).
+	// The reference set is the GENEROUS zoneReferenceableInterfaceBases union so
+	// the promotion cannot false-reject a legitimate lo0 / secure-tunnel
+	// reference (the #4191 over-rejection class). Runs AFTER the zone-interface
+	// membership gate so a duplicate-assignment error still wins the first-error
+	// slot.
+	if err := validateZoneInterfaceDefinedStrict(cfg); err != nil {
+		if opts.lenientZoneInterfaceDefined {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("zone interface defined (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #3200 host-inbound-traffic token gate. Strict on commit / commit-check
 	// (hard-reject an unknown/typo system-services or protocols token that
 	// would commit but enforce inconsistently — nft kernel mirror fails OPEN

--- a/pkg/config/compiler_validate_strict_zones.go
+++ b/pkg/config/compiler_validate_strict_zones.go
@@ -294,6 +294,126 @@ func validateZoneInterfaceMembershipStrict(cfg *Config) error {
 	return nil
 }
 
+// zoneReferenceableInterfaceBases returns the set of interface BASE names a
+// `security zones security-zone <z> interfaces <if>` entry may legitimately
+// reference. It is the union validateZoneInterfaceDefinedStrict checks a zone
+// member against, and is DELIBERATELY GENEROUS to avoid the #4191
+// over-rejection class: a false reject would brick an otherwise-valid commit,
+// which is far worse than missing a typo (the daemon already brings an
+// interface that is ABSENT from the config DOWN, so an unresolved zone member
+// is fail-CLOSED for real traffic — a missed typo silently carries no packets,
+// it never fails open).
+//
+// The union is:
+//
+//   - every explicitly-configured interface (cfg.Interfaces.Interfaces) — the
+//     ordinary case; a zone member "ge-0/0/0.0" strips to base "ge-0/0/0".
+//     GRE / IPIP / WireGuard tunnels (`set interfaces gr-0/0/0 tunnel ...`)
+//     and VRF (routing-instance) member interfaces are covered by this term
+//     for free: a tunnel device and a routing-instance member must both be
+//     configured under `interfaces`, so they are already keys of this map.
+//   - "lo0" — the loopback is a reserved, always-present interface in Junos
+//     and is always materialized by the daemon, so a zone may reference it
+//     (host-inbound self-traffic) even with no explicit `set interfaces lo0`.
+//   - every secure-tunnel base derived from an IPsec `bind-interface`
+//     (cfg.Security.IPsec.VPNs[*].BindInterface). `bind-interface st0.0`
+//     materializes the st0 xfrmi device at apply time (daemon_apply
+//     ApplyXfrmi -> routing.ApplyXfrmi) even when the config carries no
+//     explicit `set interfaces st0 unit 0`, so a zone referencing st0.0 is a
+//     valid, daemon-materialized dynamic interface. The base is the bind
+//     string with any ".unit" stripped (st0.0 -> st0, st0 -> st0), so every
+//     unit of a bound secure tunnel is admitted.
+func zoneReferenceableInterfaceBases(cfg *Config) map[string]bool {
+	known := make(map[string]bool, len(cfg.Interfaces.Interfaces)+1)
+	for name := range cfg.Interfaces.Interfaces {
+		known[name] = true
+	}
+	// lo0 is always materialized (loopback); reserved always-present in Junos.
+	known["lo0"] = true
+	// Secure-tunnel devices are materialized from IPsec bind-interface strings
+	// at apply time even without an explicit `set interfaces stN`.
+	for _, vpn := range cfg.Security.IPsec.VPNs {
+		if vpn == nil || vpn.BindInterface == "" {
+			continue
+		}
+		base := vpn.BindInterface
+		if idx := strings.Index(base, "."); idx > 0 {
+			base = base[:idx]
+		}
+		known[base] = true
+	}
+	return known
+}
+
+// validateZoneInterfaceDefinedStrict hard-rejects a `security zones
+// security-zone <z> interfaces <if>` entry that names an interface which is
+// neither configured under `interfaces` nor a daemon-materialized dynamic
+// interface (loopback / IPsec secure-tunnel) — the ps-review-002 F6 parity gap
+// (#4515). Junos hard-rejects a zone member that references an undefined
+// interface; xpf previously only WARNED (compiler_validate_warn.go), then
+// compiled and KEPT the zone. At runtime the referenced interface is absent, so
+// the daemon brings it DOWN (fail-closed for real traffic) — safe, but silent:
+// the operator's typo'd `ge-0/0/99` zone member carries no packets with no
+// commit-time signal. This gate restores the Junos commit-time reject.
+//
+// The reference set is the GENEROUS union zoneReferenceableInterfaceBases
+// builds (see its comment): the naive check that built the set only from
+// cfg.Interfaces.Interfaces is why this gap was left warn-only — it would
+// FALSE-REJECT a zone that legitimately references a daemon-materialized
+// interface such as an IPsec `bind-interface st0.0` secure tunnel or lo0 (the
+// #4191 over-rejection class). Unioning lo0 + the IPsec secure-tunnel bases in
+// first is the safeguard that makes the promotion safe.
+//
+// Strict on the commit / commit-check path (CompileConfig — hard-reject so the
+// operator sees the typo); downgraded to a cfg.Warnings entry on the tolerant
+// load / peer-sync paths (CompileConfigLenient / CompileConfigForNodeLenient,
+// flag lenientZoneInterfaceDefined) so an already-persisted or peer-synced
+// config an older binary accepted still BOOTS (#1960 fail-closed-on-load
+// doctrine) — the runtime keeps its existing behavior (the unresolved member
+// carries no traffic), just with an operator-visible warning instead of a hard
+// reject. Zones are walked in sorted name order so the first-reported error is
+// deterministic. Unit suffixes are stripped exactly as the dataplane
+// interface->zone map (and the prior warn loop) do, so a `.0`/`.50` unit
+// reference resolves against its base.
+func validateZoneInterfaceDefinedStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	known := zoneReferenceableInterfaceBases(cfg)
+	zoneNames := make([]string, 0, len(cfg.Security.Zones))
+	for name := range cfg.Security.Zones {
+		zoneNames = append(zoneNames, name)
+	}
+	sort.Strings(zoneNames)
+	for _, zoneName := range zoneNames {
+		zone := cfg.Security.Zones[zoneName]
+		if zone == nil {
+			continue
+		}
+		for _, ifName := range zone.Interfaces {
+			if ifName == "" {
+				continue
+			}
+			base := ifName
+			if idx := strings.Index(ifName, "."); idx > 0 {
+				base = ifName[:idx]
+			}
+			if !known[base] {
+				return fmt.Errorf(
+					"security zone %q references interface %q, which is not "+
+						"defined under `interfaces` (nor materialized as the lo0 "+
+						"loopback or an IPsec secure-tunnel bind-interface); Junos "+
+						"rejects a zone member that names no configured interface — "+
+						"define the interface or fix the typo (the daemon brings an "+
+						"unconfigured interface DOWN, so the zone member silently "+
+						"carries no traffic)",
+					zoneName, ifName)
+			}
+		}
+	}
+	return nil
+}
+
 // validateHostInboundTokensStrict rejects an unknown / typo'd
 // `security zones <z> host-inbound-traffic { system-services <tok>; protocols
 // <tok>; }` token at commit (#3200). The schema models system-services /

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -428,26 +428,22 @@ func ValidateConfig(cfg *Config) []string {
 		}
 	}
 
-	// Validate zone interface references
+	// Zone interface references (`security zones security-zone <z> interfaces
+	// <if>` naming an interface not defined under `interfaces`) are validated by
+	// the strict commit gate validateZoneInterfaceDefinedStrict (ps-review-002
+	// F6, #4515): hard-reject on commit / commit-check, downgraded to a warning
+	// on the tolerant load / peer-sync path. The strict gate subsumes the
+	// warn-only loop that previously lived here (it would otherwise emit a
+	// duplicate warning alongside the downgraded gate warning on the lenient
+	// path). Its reference set is the GENEROUS zoneReferenceableInterfaceBases
+	// union (lo0 + IPsec secure-tunnel bases + every configured interface), so it
+	// does NOT false-reject a daemon-materialized dynamic-interface reference.
+	//
+	// configuredIfaces (the naive cfg.Interfaces.Interfaces set) is retained for
+	// the routing-instance interface warn below, which stays warn-only.
 	configuredIfaces := make(map[string]bool)
 	for name := range cfg.Interfaces.Interfaces {
 		configuredIfaces[name] = true
-	}
-	for zoneName, zone := range cfg.Security.Zones {
-		if zone == nil { // #3494: tolerant/HA-sync path may carry a nil zone value
-			continue
-		}
-		for _, ifName := range zone.Interfaces {
-			// Strip unit suffix (e.g. "trust0.0" -> "trust0")
-			base := ifName
-			if idx := strings.Index(ifName, "."); idx > 0 {
-				base = ifName[:idx]
-			}
-			if !configuredIfaces[base] {
-				warnings = append(warnings, fmt.Sprintf(
-					"zone %q: interface %q not in interfaces config", zoneName, ifName))
-			}
-		}
 	}
 
 	// Validate scheduler references in policies

--- a/pkg/config/dual_ast_differential_test.go
+++ b/pkg/config/dual_ast_differential_test.go
@@ -185,7 +185,30 @@ var dualASTCases = []dualASTCase{
 	},
 	{
 		name: "security-zones-address-book",
-		hier: `security {
+		hier: `interfaces {
+    ge-0/0/0 {
+        unit 0 {
+            family inet {
+                address 10.0.0.1/24;
+            }
+        }
+    }
+    ge-0/0/1 {
+        unit 0 {
+            family inet {
+                address 10.0.1.1/24;
+            }
+        }
+    }
+    ge-0/0/2 {
+        unit 0 {
+            family inet {
+                address 10.0.2.1/24;
+            }
+        }
+    }
+}
+security {
     zones {
         security-zone trust {
             description "inside zone";

--- a/pkg/config/host_inbound_dup_block_4544_test.go
+++ b/pkg/config/host_inbound_dup_block_4544_test.go
@@ -65,6 +65,15 @@ security {
 func TestHostInboundDupBlock4544InterfaceMerges(t *testing.T) {
 	// Junos / load-override interface block spelling (`interfaces { ifN { ... } }`).
 	tree := parseHierarchical(t, `
+interfaces {
+    ge-0/0/0 {
+        unit 0 {
+            family inet {
+                address 10.0.0.1/24;
+            }
+        }
+    }
+}
 security {
     zones {
         security-zone trust {
@@ -174,6 +183,15 @@ security {
 
 	// Interface-level single block (Junos block spelling).
 	itree := parseHierarchical(t, `
+interfaces {
+    ge-0/0/0 {
+        unit 0 {
+            family inet {
+                address 10.0.0.1/24;
+            }
+        }
+    }
+}
 security {
     zones {
         security-zone trust {

--- a/pkg/config/host_inbound_fulladmit_warn_3226_test.go
+++ b/pkg/config/host_inbound_fulladmit_warn_3226_test.go
@@ -38,6 +38,7 @@ func Test_3226_SystemServicesAllEmitsFullAdmitAdvisory(t *testing.T) {
 	for _, tok := range []string{"all", "any-service"} {
 		t.Run("zone-level-"+tok, func(t *testing.T) {
 			tree := buildTree(t, []string{
+				"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
 				"set security zones security-zone trust interfaces ge-0/0/0.0",
 				"set security zones security-zone trust host-inbound-traffic system-services " + tok,
 			})
@@ -64,6 +65,7 @@ func Test_3226_SystemServicesAllEmitsFullAdmitAdvisory(t *testing.T) {
 // packet-wide full-admit and must draw NO #3226 advisory.
 func Test_3226_SpecificServiceNoAdvisory(t *testing.T) {
 	tree := buildTree(t, []string{
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
 		"set security zones security-zone trust interfaces ge-0/0/0.0",
 		"set security zones security-zone trust host-inbound-traffic system-services ssh",
 		"set security zones security-zone trust host-inbound-traffic system-services ping",
@@ -82,6 +84,8 @@ func Test_3226_SpecificServiceNoAdvisory(t *testing.T) {
 // must warn and name BOTH the zone and the interface.
 func Test_3226_PerInterfaceFullAdmitAdvisory(t *testing.T) {
 	tree := buildTree(t, []string{
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.1/24",
 		"set security zones security-zone wan interfaces ge-0/0/0.0 host-inbound-traffic system-services all",
 		// a sibling interface with a specific service — must NOT warn.
 		"set security zones security-zone wan interfaces ge-0/0/1.0 host-inbound-traffic system-services ssh",

--- a/pkg/config/host_inbound_multicast_warn_4455_test.go
+++ b/pkg/config/host_inbound_multicast_warn_4455_test.go
@@ -52,6 +52,7 @@ func Test_4455_MulticastProtocolEmitsPacketWideAdvisory(t *testing.T) {
 	for _, tc := range cases {
 		t.Run("zone-level-"+tc.name, func(t *testing.T) {
 			tree := buildTree(t, []string{
+				"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
 				"set security zones security-zone trust interfaces ge-0/0/0.0",
 				"set security zones security-zone trust host-inbound-traffic protocols " + tc.token,
 			})
@@ -81,6 +82,7 @@ func Test_4455_UnicastProtocolNoAdvisory(t *testing.T) {
 	for _, tok := range []string{"bgp", "ldp", "msdp", "bfd"} {
 		t.Run(tok, func(t *testing.T) {
 			tree := buildTree(t, []string{
+				"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
 				"set security zones security-zone trust interfaces ge-0/0/0.0",
 				"set security zones security-zone trust host-inbound-traffic protocols " + tok,
 			})
@@ -101,6 +103,7 @@ func Test_4455_UnicastProtocolNoAdvisory(t *testing.T) {
 func Test_4455_NoProtocolsNoAdvisory(t *testing.T) {
 	t.Run("system-services-only", func(t *testing.T) {
 		tree := buildTree(t, []string{
+			"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
 			"set security zones security-zone trust interfaces ge-0/0/0.0",
 			"set security zones security-zone trust host-inbound-traffic system-services ssh",
 			"set security zones security-zone trust host-inbound-traffic system-services ping",
@@ -115,6 +118,7 @@ func Test_4455_NoProtocolsNoAdvisory(t *testing.T) {
 	})
 	t.Run("no-host-inbound", func(t *testing.T) {
 		tree := buildTree(t, []string{
+			"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
 			"set security zones security-zone trust interfaces ge-0/0/0.0",
 		})
 		cfg, err := CompileConfig(tree)
@@ -133,6 +137,7 @@ func Test_4455_NoProtocolsNoAdvisory(t *testing.T) {
 // multicast admission comes from under `all`).
 func Test_4455_ProtocolsAllExpandsToMulticast(t *testing.T) {
 	tree := buildTree(t, []string{
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
 		"set security zones security-zone trust interfaces ge-0/0/0.0",
 		"set security zones security-zone trust host-inbound-traffic protocols all",
 	})
@@ -155,6 +160,8 @@ func Test_4455_ProtocolsAllExpandsToMulticast(t *testing.T) {
 // and name BOTH the zone and the interface.
 func Test_4455_PerInterfaceOverrideAdvisory(t *testing.T) {
 	tree := buildTree(t, []string{
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.1/24",
 		"set security zones security-zone wan interfaces ge-0/0/0.0 host-inbound-traffic protocols ospf",
 		// a sibling interface with a unicast protocol — must NOT warn.
 		"set security zones security-zone wan interfaces ge-0/0/1.0 host-inbound-traffic protocols bgp",

--- a/pkg/config/host_inbound_per_iface_3362_test.go
+++ b/pkg/config/host_inbound_per_iface_3362_test.go
@@ -13,6 +13,8 @@ import (
 // InterfaceHostInbound stays nil — both fail this test.
 func Test_3362_PerInterfaceHostInboundParses(t *testing.T) {
 	tree := buildTree(t, []string{
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.1/24",
 		// zone-level: nothing on the zone, ssh only on the uplink interface.
 		"set security zones security-zone wan interfaces ge-0/0/0.0 host-inbound-traffic system-services ssh",
 		"set security zones security-zone wan interfaces ge-0/0/0.0 host-inbound-traffic protocols ospf",
@@ -73,7 +75,11 @@ func Test_3362_PerInterfaceUnknownTokenFailsCommit(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tree := buildTree(t, tc.cmds)
+			// #4515: define ge-0/0/0 so the strict zone-interface-defined gate is
+			// satisfied and the intended host-inbound-token reject is what fires.
+			tree := buildTree(t, append([]string{
+				"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
+			}, tc.cmds...))
 			if _, err := CompileConfig(tree); err == nil {
 				t.Fatal("expected commit to reject an unknown interface-level host-inbound token")
 			} else if !strings.Contains(err.Error(), tc.wantSub) {
@@ -89,6 +95,7 @@ func Test_3362_PerInterfaceUnknownTokenFailsCommit(t *testing.T) {
 // interface-level token (mixed with a zone-level stanza) must commit.
 func Test_3362_PerInterfaceKnownTokenCommits(t *testing.T) {
 	tree := buildTree(t, []string{
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
 		"set security zones security-zone wan host-inbound-traffic system-services ping",
 		"set security zones security-zone wan interfaces ge-0/0/0.0 host-inbound-traffic system-services ssh",
 		"set security zones security-zone wan interfaces ge-0/0/0.0 host-inbound-traffic protocols all",

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -273,7 +273,11 @@ func TestParseHierarchical(t *testing.T) {
 }
 
 func TestCompileConfig(t *testing.T) {
-	input := `security {
+	input := `interfaces {
+    eth0 { unit 0 { family inet { address 10.0.1.1/24; } } }
+    eth1 { unit 0 { family inet { address 10.0.2.1/24; } } }
+}
+security {
     zones {
         security-zone trust {
             interfaces {
@@ -461,7 +465,7 @@ func TestFormatSetQuotedKeys(t *testing.T) {
 
 func TestSetPathSchema(t *testing.T) {
 	tree := &ConfigTree{}
-	setCommands := []string{"set security zones security-zone trust interfaces eth0.0", "set security zones security-zone trust host-inbound-traffic system-services ssh", "set security zones security-zone trust host-inbound-traffic system-services ping", "set security zones security-zone trust screen untrust-screen", "set security zones security-zone untrust interfaces eth1.0", "set security policies from-zone trust to-zone untrust policy allow-web match source-address any", "set security policies from-zone trust to-zone untrust policy allow-web match destination-address any", "set security policies from-zone trust to-zone untrust policy allow-web match application junos-http", "set security policies from-zone trust to-zone untrust policy allow-web then permit", "set security policies from-zone trust to-zone untrust policy allow-web then log session-init", "set security policies from-zone trust to-zone untrust policy allow-web then count", "set security screen ids-option myscreen tcp land", "set security screen ids-option myscreen icmp ping-death", "set security screen ids-option untrust-screen tcp land", "set security address-book global address srv1 10.0.1.10/32", "set security address-book global address-set servers address srv1", "set interfaces eth0 unit 0 family inet address 10.0.1.1/24", "set applications application my-app protocol tcp", "set applications application my-app destination-port 8080"}
+	setCommands := []string{"set security zones security-zone trust interfaces eth0.0", "set security zones security-zone trust host-inbound-traffic system-services ssh", "set security zones security-zone trust host-inbound-traffic system-services ping", "set security zones security-zone trust screen untrust-screen", "set security zones security-zone untrust interfaces eth1.0", "set interfaces eth1 unit 0 family inet address 10.0.2.1/24", "set security policies from-zone trust to-zone untrust policy allow-web match source-address any", "set security policies from-zone trust to-zone untrust policy allow-web match destination-address any", "set security policies from-zone trust to-zone untrust policy allow-web match application junos-http", "set security policies from-zone trust to-zone untrust policy allow-web then permit", "set security policies from-zone trust to-zone untrust policy allow-web then log session-init", "set security policies from-zone trust to-zone untrust policy allow-web then count", "set security screen ids-option myscreen tcp land", "set security screen ids-option myscreen icmp ping-death", "set security screen ids-option untrust-screen tcp land", "set security address-book global address srv1 10.0.1.10/32", "set security address-book global address-set servers address srv1", "set interfaces eth0 unit 0 family inet address 10.0.1.1/24", "set applications application my-app protocol tcp", "set applications application my-app destination-port 8080"}
 	for _, cmd := range setCommands {
 		path, err := ParseSetCommand(cmd)
 		if err != nil {
@@ -601,7 +605,7 @@ func TestSetPathSingleValueDedup(t *testing.T) {
 
 func TestDeletePath(t *testing.T) {
 	tree := &ConfigTree{}
-	setCommands := []string{"set security zones security-zone trust interfaces eth0.0", "set security zones security-zone trust interfaces eth2.0", "set security zones security-zone trust host-inbound-traffic system-services ssh", "set security zones security-zone untrust interfaces eth1.0", "set security address-book global address srv1 10.0.1.10/32", "set security address-book global address srv2 10.0.2.10/32", "set security policies from-zone trust to-zone untrust policy allow-web match source-address any", "set security policies from-zone trust to-zone untrust policy allow-web match destination-address any", "set security policies from-zone trust to-zone untrust policy allow-web match application junos-http", "set security policies from-zone trust to-zone untrust policy allow-web then permit"}
+	setCommands := []string{"set interfaces eth0 unit 0 family inet address 10.0.1.1/24", "set interfaces eth1 unit 0 family inet address 10.0.2.1/24", "set interfaces eth2 unit 0 family inet address 10.0.3.1/24", "set security zones security-zone trust interfaces eth0.0", "set security zones security-zone trust interfaces eth2.0", "set security zones security-zone trust host-inbound-traffic system-services ssh", "set security zones security-zone untrust interfaces eth1.0", "set security address-book global address srv1 10.0.1.10/32", "set security address-book global address srv2 10.0.2.10/32", "set security policies from-zone trust to-zone untrust policy allow-web match source-address any", "set security policies from-zone trust to-zone untrust policy allow-web match destination-address any", "set security policies from-zone trust to-zone untrust policy allow-web match application junos-http", "set security policies from-zone trust to-zone untrust policy allow-web then permit"}
 	for _, cmd := range setCommands {
 		path, err := ParseSetCommand(cmd)
 		if err != nil {
@@ -973,6 +977,10 @@ func TestApplicationSet(t *testing.T) {
         application junos-https;
         application my-app;
     }
+}
+interfaces {
+    eth0 { unit 0 { family inet { address 10.0.1.1/24; } } }
+    eth1 { unit 0 { family inet { address 10.0.2.1/24; } } }
 }
 security {
     zones {
@@ -1398,7 +1406,11 @@ func TestRPMRootProbeLimitSetSyntax(t *testing.T) {
 }
 
 func TestMultipleSNATRules(t *testing.T) {
-	input := `security {
+	input := `interfaces {
+    eth0 { unit 0 { family inet { address 10.0.1.1/24; } } }
+    eth1 { unit 0 { family inet { address 10.0.2.1/24; } } }
+}
+security {
     zones {
         security-zone trust {
             interfaces { eth0.0; }
@@ -1554,7 +1566,10 @@ func TestEdgeCases(t *testing.T) {
 	if len(cfg.Security.Zones) != 0 {
 		t.Errorf("expected 0 zones from empty block, got %d", len(cfg.Security.Zones))
 	}
-	input2 := `security {
+	input2 := `interfaces {
+    eth0 { unit 0 { family inet { address 10.0.1.1/24; } } }
+}
+security {
     zones {
         security-zone test {
             interfaces {
@@ -1772,13 +1787,18 @@ security {
 	if len(errs) > 0 {
 		t.Fatalf("parse errors: %v", errs)
 	}
-	cfg, err := CompileConfig(tree)
+	// #4515: a zone referencing an undefined interface is now a STRICT commit
+	// reject (validateZoneInterfaceDefinedStrict), downgraded to a warning on
+	// the tolerant load / peer-sync path. Compile leniently so both the
+	// downgraded interface warning and the (still warn-only) SNAT missing-pool
+	// warning surface together, preserving this cross-reference test's intent.
+	cfg, err := CompileConfigLenient(tree)
 	if err != nil {
-		t.Fatalf("CompileConfig: %v", err)
+		t.Fatalf("CompileConfigLenient: %v", err)
 	}
 	var foundIfaceWarn, foundPoolWarn bool
 	for _, w := range cfg.Warnings {
-		if strings.Contains(w, "missing-iface") && strings.Contains(w, "not in interfaces") {
+		if strings.Contains(w, "missing-iface") && strings.Contains(w, "not defined under") {
 			foundIfaceWarn = true
 		}
 		if strings.Contains(w, "missing-pool") && strings.Contains(w, "not defined") {
@@ -2129,7 +2149,7 @@ security {
 
 func TestRouterDiscoveryProtocolSetSyntax(t *testing.T) {
 	tree := &ConfigTree{}
-	for _, cmd := range []string{"set security zones security-zone trust interfaces trust0", "set security zones security-zone trust host-inbound-traffic protocols router-discovery", "set security zones security-zone trust host-inbound-traffic protocols ospf"} {
+	for _, cmd := range []string{"set interfaces trust0 unit 0 family inet address 10.0.0.1/24", "set security zones security-zone trust interfaces trust0", "set security zones security-zone trust host-inbound-traffic protocols router-discovery", "set security zones security-zone trust host-inbound-traffic protocols ospf"} {
 		if err := tree.SetPath(strings.Fields(cmd)[1:]); err != nil {
 			t.Fatalf("SetPath(%q): %v", cmd, err)
 		}
@@ -4561,6 +4581,10 @@ groups {
         }
     }
 }
+interfaces {
+    trust0 { unit 0 { family inet { address 10.0.0.1/24; } } }
+    untrust0 { unit 0 { family inet { address 10.0.2.1/24; } } }
+}
 security {
     zones {
         security-zone trust {
@@ -4648,6 +4672,10 @@ groups {
         }
     }
 }
+interfaces {
+    trust0 { unit 0 { family inet { address 10.0.0.1/24; } } }
+    untrust0 { unit 0 { family inet { address 10.0.2.1/24; } } }
+}
 security {
     zones {
         security-zone trust {
@@ -4731,6 +4759,10 @@ groups {
     }
 }
 apply-groups common;
+interfaces {
+    trust0 { unit 0 { family inet { address 10.0.0.1/24; } } }
+    untrust0 { unit 0 { family inet { address 10.0.2.1/24; } } }
+}
 security {
     zones {
         security-zone trust {
@@ -4790,6 +4822,10 @@ groups {
 system {
     host-name explicit;
 }
+interfaces {
+    trust0 { unit 0 { family inet { address 10.0.0.1/24; } } }
+    untrust0 { unit 0 { family inet { address 10.0.2.1/24; } } }
+}
 security {
     zones {
         security-zone trust {
@@ -4842,7 +4878,7 @@ security {
 }
 
 func TestApplyGroupsNestedSetSyntax(t *testing.T) {
-	setCommands := []string{"set groups allow-out security policies from-zone <*> to-zone <*> policy allow-all-out match source-address any", "set groups allow-out security policies from-zone <*> to-zone <*> policy allow-all-out match destination-address any", "set groups allow-out security policies from-zone <*> to-zone <*> policy allow-all-out match application any", "set groups allow-out security policies from-zone <*> to-zone <*> policy allow-all-out then permit", "set security zones security-zone trust interfaces trust0.0", "set security zones security-zone untrust interfaces untrust0.0", "set security policies from-zone trust to-zone untrust apply-groups allow-out"}
+	setCommands := []string{"set groups allow-out security policies from-zone <*> to-zone <*> policy allow-all-out match source-address any", "set groups allow-out security policies from-zone <*> to-zone <*> policy allow-all-out match destination-address any", "set groups allow-out security policies from-zone <*> to-zone <*> policy allow-all-out match application any", "set groups allow-out security policies from-zone <*> to-zone <*> policy allow-all-out then permit", "set interfaces trust0 unit 0 family inet address 10.0.0.1/24", "set interfaces untrust0 unit 0 family inet address 10.0.2.1/24", "set security zones security-zone trust interfaces trust0.0", "set security zones security-zone untrust interfaces untrust0.0", "set security policies from-zone trust to-zone untrust apply-groups allow-out"}
 	tree := &ConfigTree{}
 	for _, cmd := range setCommands {
 		path, err := ParseSetCommand(cmd)
@@ -5135,7 +5171,7 @@ func TestLo0FilterExtractionSet(t *testing.T) {
 }
 
 func TestHostInboundRouterDiscovery(t *testing.T) {
-	lines := []string{"set security zones security-zone trust host-inbound-traffic system-services ping", "set security zones security-zone trust host-inbound-traffic protocols bgp", "set security zones security-zone trust host-inbound-traffic protocols router-discovery", "set security zones security-zone trust interfaces trust0"}
+	lines := []string{"set interfaces trust0 unit 0 family inet address 10.0.0.1/24", "set security zones security-zone trust host-inbound-traffic system-services ping", "set security zones security-zone trust host-inbound-traffic protocols bgp", "set security zones security-zone trust host-inbound-traffic protocols router-discovery", "set security zones security-zone trust interfaces trust0"}
 	tree := &ConfigTree{}
 	for _, line := range lines {
 		cmd, err := ParseSetCommand(line)

--- a/pkg/config/parser_routing_test.go
+++ b/pkg/config/parser_routing_test.go
@@ -658,6 +658,15 @@ func TestRouterAdvertisement(t *testing.T) {
 
 func TestRoutingInstanceWithZone(t *testing.T) {
 	input := `
+interfaces {
+    enp7s0 {
+        unit 0 {
+            family inet {
+                address 10.0.2.10/24;
+            }
+        }
+    }
+}
 routing-instances {
     isp-a {
         instance-type virtual-router;

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -1263,7 +1263,11 @@ func TestALGAndFlowOptions(t *testing.T) {
 }
 
 func TestDNATWithProtocol(t *testing.T) {
-	input := `security {
+	input := `interfaces {
+    eth1 { unit 0 { family inet { address 10.0.1.1/24; } } }
+    eth2 { unit 0 { family inet { address 10.0.2.1/24; } } }
+}
+security {
     zones {
         security-zone untrust {
             interfaces { eth1.0; }
@@ -2211,7 +2215,14 @@ func TestIPsecNATTraversalFlatSet(t *testing.T) {
 }
 
 func TestHostInboundIPsec(t *testing.T) {
-	input := `security {
+	input := `interfaces {
+    st0 {
+        unit 0 {
+            family inet;
+        }
+    }
+}
+security {
     zones {
         security-zone vpn {
             interfaces { st0; }
@@ -2256,7 +2267,11 @@ func TestHostInboundIPsec(t *testing.T) {
 }
 
 func TestPolicyReject(t *testing.T) {
-	input := `security {
+	input := `interfaces {
+    eth0 { unit 0 { family inet { address 10.0.0.1/24; } } }
+    eth1 { unit 0 { family inet { address 10.0.1.1/24; } } }
+}
+security {
     zones {
         security-zone trust { interfaces { eth0; } }
         security-zone untrust { interfaces { eth1; } }
@@ -2301,7 +2316,7 @@ func TestPolicyReject(t *testing.T) {
 		t.Errorf("expected PolicyReject (%d), got %d", PolicyReject, pol.Action)
 	}
 	tree2 := &ConfigTree{}
-	setCommands := []string{"set security zones security-zone trust interfaces eth0", "set security zones security-zone untrust interfaces eth1", "set security policies from-zone untrust to-zone trust policy block-all match source-address any", "set security policies from-zone untrust to-zone trust policy block-all match destination-address any", "set security policies from-zone untrust to-zone trust policy block-all match application any", "set security policies from-zone untrust to-zone trust policy block-all then reject"}
+	setCommands := []string{"set interfaces eth0 unit 0 family inet address 10.0.0.1/24", "set interfaces eth1 unit 0 family inet address 10.0.1.1/24", "set security zones security-zone trust interfaces eth0", "set security zones security-zone untrust interfaces eth1", "set security policies from-zone untrust to-zone trust policy block-all match source-address any", "set security policies from-zone untrust to-zone trust policy block-all match destination-address any", "set security policies from-zone untrust to-zone trust policy block-all match application any", "set security policies from-zone untrust to-zone trust policy block-all then reject"}
 	for _, cmd := range setCommands {
 		path, err := ParseSetCommand(cmd)
 		if err != nil {
@@ -2751,7 +2766,7 @@ func TestIPsecProposalSetSyntax(t *testing.T) {
 
 func TestZoneSetSyntax(t *testing.T) {
 	tree := &ConfigTree{}
-	for _, cmd := range []string{"set security zones security-zone trust interfaces trust0", "set security zones security-zone trust interfaces trust1", "set security zones security-zone trust screen untrust-screen", "set security screen ids-option untrust-screen tcp land", "set security zones security-zone trust host-inbound-traffic system-services ping", "set security zones security-zone trust host-inbound-traffic system-services ssh", "set security zones security-zone trust host-inbound-traffic protocols ospf", "set security zones security-zone untrust interfaces untrust0"} {
+	for _, cmd := range []string{"set interfaces trust0 unit 0 family inet address 10.0.0.1/24", "set interfaces trust1 unit 0 family inet address 10.0.1.1/24", "set interfaces untrust0 unit 0 family inet address 10.0.2.1/24", "set security zones security-zone trust interfaces trust0", "set security zones security-zone trust interfaces trust1", "set security zones security-zone trust screen untrust-screen", "set security screen ids-option untrust-screen tcp land", "set security zones security-zone trust host-inbound-traffic system-services ping", "set security zones security-zone trust host-inbound-traffic system-services ssh", "set security zones security-zone trust host-inbound-traffic protocols ospf", "set security zones security-zone untrust interfaces untrust0"} {
 		if err := tree.SetPath(strings.Fields(cmd)[1:]); err != nil {
 			t.Fatalf("SetPath(%q): %v", cmd, err)
 		}
@@ -3928,6 +3943,22 @@ func TestPolicyCommunityDeleteMultiListCompile(t *testing.T) {
 
 func TestSecurityZoneTCPRst(t *testing.T) {
 	input := `
+interfaces {
+    ge-0/0/0 {
+        unit 0 {
+            family inet {
+                address 10.0.0.1/24;
+            }
+        }
+    }
+    ge-0/0/1 {
+        unit 0 {
+            family inet {
+                address 10.0.1.1/24;
+            }
+        }
+    }
+}
 security {
     zones {
         security-zone trust {

--- a/pkg/config/screen_alarm_without_drop_test.go
+++ b/pkg/config/screen_alarm_without_drop_test.go
@@ -21,6 +21,7 @@ func TestScreenAlarmWithoutDropCompiles(t *testing.T) {
 		// A profile with a real check PLUS the profile-wide audit modifier.
 		"set security screen ids-option audit tcp land",
 		"set security screen ids-option audit alarm-without-drop",
+		"set interfaces ge-0-0-1 unit 0 family inet address 10.0.1.1/24",
 		"set security zones security-zone untrust screen audit",
 		"set security zones security-zone untrust interfaces ge-0-0-1",
 	})

--- a/pkg/config/zone_interface_defined_4515_test.go
+++ b/pkg/config/zone_interface_defined_4515_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestZoneInterfaceUndefinedFailsCommit is the fail-on-revert guard for the
+// ps-review-002 F6 parity gap (#4515): a `security zones security-zone <z>
+// interfaces <if>` entry that names an interface which is NOT defined under
+// `interfaces {}` (nor a daemon-materialized lo0 / IPsec secure-tunnel) MUST be
+// hard-rejected at commit, exactly as Junos rejects it. Without
+// validateZoneInterfaceDefinedStrict (or its dispatch in runUniformGates) this
+// config compiles cleanly — the pre-#4515 behavior was a warn-only advisory,
+// and the daemon then brought the absent interface DOWN, so the zone member
+// silently carried no traffic with no commit-time signal. The error must name
+// both the zone and the offending interface.
+func TestZoneInterfaceUndefinedFailsCommit(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
+		"set security zones security-zone trust interfaces ge-0/0/0.0",
+		// ge-0/0/99 is a typo — no such interface is configured.
+		"set security zones security-zone untrust interfaces ge-0/0/99.0",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("expected commit to reject a zone referencing an undefined interface, got nil error")
+	}
+	for _, want := range []string{"untrust", "ge-0/0/99.0", "not defined under"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not name %q", err.Error(), want)
+		}
+	}
+}
+
+// TestZoneInterfaceUndefinedLenientDowngradesToWarning asserts the tolerant
+// load / peer-sync path downgrades the undefined-interface rejection to a
+// warning instead of failing the compile, so an already-persisted or
+// peer-synced config an older binary accepted still boots (#4515 / #1960
+// no-brick). Runtime behavior is unchanged on that path (the unresolved member
+// carries no traffic), just with an operator-visible warning.
+func TestZoneInterfaceUndefinedLenientDowngradesToWarning(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
+		"set security zones security-zone trust interfaces ge-0/0/0.0",
+		"set security zones security-zone untrust interfaces ge-0/0/99.0",
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile must not fail on a zone referencing an undefined interface: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "zone interface defined (downgraded to warning on tolerant path)") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a downgraded zone-interface-defined warning, got warnings: %v", cfg.Warnings)
+	}
+}
+
+// TestZoneInterfaceDefinedCommitsClean asserts the common case — every zone
+// member is a configured interface — commits cleanly: the gate does not perturb
+// a valid config (#4515 anti-over-reject).
+func TestZoneInterfaceDefinedCommitsClean(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.1/24",
+		"set security zones security-zone trust interfaces ge-0/0/0.0",
+		"set security zones security-zone untrust interfaces ge-0/0/1.0",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("strict commit rejected a valid config whose zone interfaces are all defined: %v", err)
+	}
+}
+
+// TestZoneInterfaceLoopbackAcceptedWithoutExplicitDef is the F6 safeguard proof
+// for the lo0 branch of the dynamic-interface union (#4515,
+// zoneReferenceableInterfaceBases). A zone may reference lo0 (the always-present
+// loopback, a reserved Junos interface) with NO explicit `set interfaces lo0`,
+// so the promotion must NOT false-reject it (the #4191 over-rejection class).
+func TestZoneInterfaceLoopbackAcceptedWithoutExplicitDef(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security zones security-zone host interfaces lo0.0",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("strict commit rejected a zone referencing lo0 without an explicit interfaces def: %v", err)
+	}
+}
+
+// TestZoneInterfaceIPsecBindInterfaceAcceptedWithoutExplicitDef is the F6
+// safeguard proof for the IPsec secure-tunnel branch of the dynamic-interface
+// union (#4515). `bind-interface st0.0` materializes the st0 xfrmi device at
+// apply time even with no explicit `set interfaces st0 unit 0`, so a zone that
+// references st0.0 is a valid, daemon-materialized dynamic interface the
+// promotion must NOT false-reject (the #4191 over-rejection class). Covering the
+// base st0 admits every unit of the bound tunnel.
+func TestZoneInterfaceIPsecBindInterfaceAcceptedWithoutExplicitDef(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security ipsec vpn myvpn bind-interface st0.0",
+		"set security zones security-zone vpn interfaces st0.0",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("strict commit rejected a zone referencing an IPsec bind-interface secure tunnel: %v", err)
+	}
+}

--- a/pkg/config/zone_interface_membership_test.go
+++ b/pkg/config/zone_interface_membership_test.go
@@ -101,6 +101,8 @@ func TestZoneInterfaceSameZoneRepeatNotFlagged(t *testing.T) {
 // lookups is a first-writer-wins artifact, not a second operator assignment.
 func TestZoneInterfaceDistinctUnitsAcrossZonesNotFlagged(t *testing.T) {
 	tree := buildTree(t, []string{
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/0 unit 1 family inet address 10.0.1.1/24",
 		"set security zones security-zone trust interfaces ge-0/0/0.0",
 		"set security zones security-zone untrust interfaces ge-0/0/0.1",
 	})
@@ -114,6 +116,9 @@ func TestZoneInterfaceDistinctUnitsAcrossZonesNotFlagged(t *testing.T) {
 // (#3072).
 func TestZoneInterfaceOrdinaryConfigUnaffected(t *testing.T) {
 	tree := buildTree(t, []string{
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.1/24",
+		"set interfaces ge-0/0/2 unit 0 family inet address 10.0.2.1/24",
 		"set security zones security-zone trust interfaces ge-0/0/0.0",
 		"set security zones security-zone untrust interfaces ge-0/0/1.0",
 		"set security zones security-zone dmz interfaces ge-0/0/2.0",

--- a/pkg/configstore/persist_failure_test.go
+++ b/pkg/configstore/persist_failure_test.go
@@ -31,6 +31,9 @@ func commitBaseline(t *testing.T, s *Store) {
 	if err := s.EnterConfigure(); err != nil {
 		t.Fatalf("EnterConfigure: %v", err)
 	}
+	if err := s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24"); err != nil {
+		t.Fatalf("SetFromInput (iface): %v", err)
+	}
 	if err := s.SetFromInput("security zones security-zone trust interfaces eth0.0"); err != nil {
 		t.Fatalf("SetFromInput: %v", err)
 	}
@@ -52,6 +55,7 @@ func TestCommit_PersistFailureFailsCommitCleanly(t *testing.T) {
 				t.Fatalf("ListCommitHistory: %v", err)
 			}
 
+			s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 			if err := s.SetFromInput("security zones security-zone untrust interfaces eth1.0"); err != nil {
 				t.Fatalf("SetFromInput: %v", err)
 			}
@@ -117,6 +121,7 @@ func TestRestart_AfterFailedOperatorPersistLoadsPreviousConfig(t *testing.T) {
 	s1 := newTestStoreAt(t, path)
 	commitBaseline(t, s1)
 
+	s1.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 	if err := s1.SetFromInput("security zones security-zone untrust interfaces eth1.0"); err != nil {
 		t.Fatalf("SetFromInput: %v", err)
 	}
@@ -148,6 +153,7 @@ func TestCommitConfirmed_NotArmedOnPersistFailure(t *testing.T) {
 	s := newTestStore(t)
 	commitBaseline(t, s)
 
+	s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 	if err := s.SetFromInput("security zones security-zone untrust interfaces eth1.0"); err != nil {
 		t.Fatalf("SetFromInput: %v", err)
 	}
@@ -181,6 +187,7 @@ func TestCommitConfirmed_PersistFailurePreservesExistingConfirmState(t *testing.
 	baseSet := s.ShowActiveSet()
 
 	// Pending confirmed commit 1 (succeeds).
+	s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 	if err := s.SetFromInput("security zones security-zone untrust interfaces eth1.0"); err != nil {
 		t.Fatalf("SetFromInput: %v", err)
 	}
@@ -194,6 +201,7 @@ func TestCommitConfirmed_PersistFailurePreservesExistingConfirmState(t *testing.
 	timerBefore := s.confirmTimer
 
 	// Commit 2 fails to persist.
+	s.SetFromInput("interfaces eth2 unit 0 family inet address 10.2.0.1/24")
 	if err := s.SetFromInput("security zones security-zone dmz interfaces eth2.0"); err != nil {
 		t.Fatalf("SetFromInput: %v", err)
 	}
@@ -230,6 +238,7 @@ func TestNestedCommitConfirmed_PreservesLastConfirmedTree(t *testing.T) {
 	baseSet := s.ShowActiveSet()
 
 	// Pending confirmed commit 1 (never confirmed).
+	s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 	if err := s.SetFromInput("security zones security-zone untrust interfaces eth1.0"); err != nil {
 		t.Fatalf("SetFromInput: %v", err)
 	}
@@ -238,6 +247,7 @@ func TestNestedCommitConfirmed_PreservesLastConfirmedTree(t *testing.T) {
 	}
 
 	// Nested confirmed commit 2 (also never confirmed).
+	s.SetFromInput("interfaces eth2 unit 0 family inet address 10.2.0.1/24")
 	if err := s.SetFromInput("security zones security-zone dmz interfaces eth2.0"); err != nil {
 		t.Fatalf("SetFromInput: %v", err)
 	}
@@ -261,7 +271,16 @@ func TestNestedCommitConfirmed_PreservesLastConfirmedTree(t *testing.T) {
 	}
 }
 
-const syncContent = "security {\n" +
+const syncContent = "interfaces {\n" +
+	"    eth3 {\n" +
+	"        unit 0 {\n" +
+	"            family inet {\n" +
+	"                address 10.3.0.1/24;\n" +
+	"            }\n" +
+	"        }\n" +
+	"    }\n" +
+	"}\n" +
+	"security {\n" +
 	"    zones {\n" +
 	"        security-zone synced {\n" +
 	"            interfaces {\n" +
@@ -394,6 +413,7 @@ func TestAutoRollback_ProceedsAndFlagsOnPersistFailure(t *testing.T) {
 
 	// Pending confirmed commit (persists fine; disk now holds the
 	// unconfirmed candidate).
+	s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 	if err := s.SetFromInput("security zones security-zone untrust interfaces eth1.0"); err != nil {
 		t.Fatalf("SetFromInput: %v", err)
 	}
@@ -467,6 +487,7 @@ func TestCommit_SuccessClearsDegradedFlag(t *testing.T) {
 	if err := s.EnterConfigure(); err != nil {
 		t.Fatalf("EnterConfigure: %v", err)
 	}
+	s.SetFromInput("interfaces eth4 unit 0 family inet address 10.4.0.1/24")
 	if err := s.SetFromInput("security zones security-zone trust2 interfaces eth4.0"); err != nil {
 		t.Fatalf("SetFromInput: %v", err)
 	}
@@ -490,6 +511,7 @@ func TestStaleConfirmTimerCallbackIsNoOp(t *testing.T) {
 	commitBaseline(t, s)
 
 	// Commit 1 confirmed: arms timer generation g1.
+	s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 	if err := s.SetFromInput("security zones security-zone confirm1 interfaces eth1.0"); err != nil {
 		t.Fatalf("SetFromInput: %v", err)
 	}
@@ -499,6 +521,7 @@ func TestStaleConfirmTimerCallbackIsNoOp(t *testing.T) {
 	g1 := s.confirmGen
 
 	// Nested commit 2 confirmed: supersedes g1 with g2.
+	s.SetFromInput("interfaces eth2 unit 0 family inet address 10.2.0.1/24")
 	if err := s.SetFromInput("security zones security-zone confirm2 interfaces eth2.0"); err != nil {
 		t.Fatalf("SetFromInput: %v", err)
 	}

--- a/pkg/configstore/store_test.go
+++ b/pkg/configstore/store_test.go
@@ -245,7 +245,9 @@ func TestSetAndCommit(t *testing.T) {
 
 	// Set outside config mode should fail after exit
 	cmds := []string{
+		"interfaces eth0 unit 0 family inet address 10.0.0.1/24",
 		"security zones security-zone trust interfaces eth0.0",
+		"interfaces eth1 unit 0 family inet address 10.1.0.1/24",
 		"security zones security-zone untrust interfaces eth1.0",
 	}
 	for _, cmd := range cmds {
@@ -302,6 +304,7 @@ func TestSetOutsideConfigMode(t *testing.T) {
 	s := newTestStore(t)
 
 	// Set without entering config mode should fail
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	err := s.SetFromInput("security zones security-zone trust interfaces eth0.0")
 	if err == nil {
 		t.Error("expected error when setting outside config mode")
@@ -315,8 +318,11 @@ func TestDeletePath(t *testing.T) {
 	}
 
 	cmds := []string{
+		"interfaces eth0 unit 0 family inet address 10.0.0.1/24",
 		"security zones security-zone trust interfaces eth0.0",
+		"interfaces eth1 unit 0 family inet address 10.1.0.1/24",
 		"security zones security-zone trust interfaces eth1.0",
+		"interfaces eth2 unit 0 family inet address 10.2.0.1/24",
 		"security zones security-zone untrust interfaces eth2.0",
 	}
 	for _, cmd := range cmds {
@@ -359,12 +365,14 @@ func TestShowCompare(t *testing.T) {
 	if err := s.EnterConfigure(); err != nil {
 		t.Fatal(err)
 	}
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	s.SetFromInput("security zones security-zone trust interfaces eth0.0")
 	if _, err := s.Commit(); err != nil {
 		t.Fatal(err)
 	}
 
 	// Modify candidate
+	s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 	s.SetFromInput("security zones security-zone untrust interfaces eth1.0")
 
 	diff := s.ShowCompare()
@@ -383,6 +391,7 @@ func TestRollback(t *testing.T) {
 	if err := s.EnterConfigure(); err != nil {
 		t.Fatal(err)
 	}
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	s.SetFromInput("security zones security-zone trust interfaces eth0.0")
 	cfg1, err := s.Commit()
 	if err != nil {
@@ -393,6 +402,7 @@ func TestRollback(t *testing.T) {
 	}
 
 	// Commit 2: add untrust zone
+	s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 	s.SetFromInput("security zones security-zone untrust interfaces eth1.0")
 	cfg2, err := s.Commit()
 	if err != nil {
@@ -429,12 +439,14 @@ func TestRollbackZero(t *testing.T) {
 	if err := s.EnterConfigure(); err != nil {
 		t.Fatal(err)
 	}
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	s.SetFromInput("security zones security-zone trust interfaces eth0.0")
 	if _, err := s.Commit(); err != nil {
 		t.Fatal(err)
 	}
 
 	// Modify candidate
+	s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 	s.SetFromInput("security zones security-zone untrust interfaces eth1.0")
 	if !s.IsDirty() {
 		t.Error("should be dirty after modification")
@@ -465,6 +477,7 @@ func TestDirtyFlag(t *testing.T) {
 		t.Error("should not be dirty initially")
 	}
 
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	s.SetFromInput("security zones security-zone trust interfaces eth0.0")
 	if !s.IsDirty() {
 		t.Error("should be dirty after set")
@@ -485,6 +498,7 @@ func TestCommitConfirmedAutoRollback(t *testing.T) {
 	if err := s.EnterConfigure(); err != nil {
 		t.Fatal(err)
 	}
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	s.SetFromInput("security zones security-zone trust interfaces eth0.0")
 	if _, err := s.Commit(); err != nil {
 		t.Fatal(err)
@@ -498,6 +512,7 @@ func TestCommitConfirmedAutoRollback(t *testing.T) {
 	})
 
 	// Commit confirmed with very short timeout (use CommitConfirmed with 1 min)
+	s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 	s.SetFromInput("security zones security-zone untrust interfaces eth1.0")
 
 	// We can't easily test the real timer with minutes, so verify the state tracking
@@ -640,7 +655,9 @@ func TestLoadAndSave(t *testing.T) {
 	if err := s1.EnterConfigure(); err != nil {
 		t.Fatal(err)
 	}
+	s1.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	s1.SetFromInput("security zones security-zone trust interfaces eth0.0")
+	s1.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 	s1.SetFromInput("security zones security-zone untrust interfaces eth1.0")
 	if _, err := s1.Commit(); err != nil {
 		t.Fatal(err)
@@ -682,12 +699,14 @@ func TestRollbackFilesPersistence(t *testing.T) {
 	}
 
 	// Commit 1
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	s.SetFromInput("security zones security-zone trust interfaces eth0.0")
 	if _, err := s.Commit(); err != nil {
 		t.Fatal(err)
 	}
 
 	// Commit 2
+	s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 	s.SetFromInput("security zones security-zone untrust interfaces eth1.0")
 	if _, err := s.Commit(); err != nil {
 		t.Fatal(err)
@@ -718,12 +737,14 @@ func TestShowRollback(t *testing.T) {
 	}
 
 	// Commit 1
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	s.SetFromInput("security zones security-zone trust interfaces eth0.0")
 	if _, err := s.Commit(); err != nil {
 		t.Fatal(err)
 	}
 
 	// Commit 2
+	s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 	s.SetFromInput("security zones security-zone untrust interfaces eth1.0")
 	if _, err := s.Commit(); err != nil {
 		t.Fatal(err)
@@ -789,13 +810,23 @@ func TestLoadOverride(t *testing.T) {
 	if err := s.EnterConfigure(); err != nil {
 		t.Fatal(err)
 	}
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	s.SetFromInput("security zones security-zone trust interfaces eth0.0")
 	if _, err := s.Commit(); err != nil {
 		t.Fatal(err)
 	}
 
 	// Load override replaces entire candidate
-	hierConfig := `security {
+	hierConfig := `interfaces {
+    eth2 {
+        unit 0 {
+            family inet {
+                address 10.2.0.1/24;
+            }
+        }
+    }
+}
+security {
     zones {
         security-zone dmz {
             interfaces {
@@ -840,10 +871,20 @@ func TestLoadMergeHierarchical(t *testing.T) {
 	if err := s.EnterConfigure(); err != nil {
 		t.Fatal(err)
 	}
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	s.SetFromInput("security zones security-zone trust interfaces eth0.0")
 
 	// Merge hierarchical config — should add untrust without removing trust
-	hierConfig := `security {
+	hierConfig := `interfaces {
+    eth1 {
+        unit 0 {
+            family inet {
+                address 10.1.0.1/24;
+            }
+        }
+    }
+}
+security {
     zones {
         security-zone untrust {
             interfaces {
@@ -879,10 +920,13 @@ func TestLoadMergeSetFormat(t *testing.T) {
 	if err := s.EnterConfigure(); err != nil {
 		t.Fatal(err)
 	}
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	s.SetFromInput("security zones security-zone trust interfaces eth0.0")
 
 	// Merge set-format commands
+	s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 	setConfig := `set security zones security-zone untrust interfaces eth1.0
+set interfaces eth2 unit 0 family inet address 10.2.0.1/24
 set security zones security-zone dmz interfaces eth2.0`
 
 	if err := s.LoadMerge(setConfig); err != nil {
@@ -911,8 +955,10 @@ func TestLoadMergeRejectsGarbageLine(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	setConfig := `set security zones security-zone trust interfaces eth0.0
 not-a-set-line
+set interfaces eth1 unit 0 family inet address 10.1.0.1/24
 set security zones security-zone untrust interfaces eth1.0`
 
 	if err := s.LoadMerge(setConfig); err == nil {
@@ -989,11 +1035,14 @@ func TestLoadMergeWithDelete(t *testing.T) {
 	if err := s.EnterConfigure(); err != nil {
 		t.Fatal(err)
 	}
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	s.SetFromInput("security zones security-zone trust interfaces eth0.0")
+	s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 	s.SetFromInput("security zones security-zone untrust interfaces eth1.0")
 
 	// Merge with delete command
 	setConfig := `delete security zones security-zone untrust
+set interfaces eth2 unit 0 family inet address 10.2.0.1/24
 set security zones security-zone dmz interfaces eth2.0`
 
 	if err := s.LoadMerge(setConfig); err != nil {
@@ -1017,6 +1066,7 @@ func TestLoadOutsideConfigMode(t *testing.T) {
 		t.Error("expected error when loading outside config mode")
 	}
 
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	err = s.LoadMerge("set security zones security-zone trust interfaces eth0.0")
 	if err == nil {
 		t.Error("expected error when loading outside config mode")
@@ -1030,12 +1080,14 @@ func TestShowCompareRollback(t *testing.T) {
 	}
 
 	// Commit 1: trust zone
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	s.SetFromInput("security zones security-zone trust interfaces eth0.0")
 	if _, err := s.Commit(); err != nil {
 		t.Fatal(err)
 	}
 
 	// Commit 2: add untrust
+	s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 	s.SetFromInput("security zones security-zone untrust interfaces eth1.0")
 	if _, err := s.Commit(); err != nil {
 		t.Fatal(err)
@@ -1059,6 +1111,7 @@ func TestShowActiveSetAndCandidateSet(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	s.SetFromInput("security zones security-zone trust interfaces eth0.0")
 	if _, err := s.Commit(); err != nil {
 		t.Fatal(err)
@@ -1086,6 +1139,7 @@ func TestExportJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	s.SetFromInput("security zones security-zone trust interfaces eth0.0")
 	if _, err := s.Commit(); err != nil {
 		t.Fatal(err)
@@ -1110,12 +1164,14 @@ func TestCommitDiffSummary(t *testing.T) {
 	}
 
 	// First commit: add trust zone
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	s.SetFromInput("security zones security-zone trust interfaces eth0.0")
 	if _, err := s.Commit(); err != nil {
 		t.Fatal(err)
 	}
 
 	// Second commit: add untrust zone
+	s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 	s.SetFromInput("security zones security-zone untrust interfaces eth1.0")
 
 	// Check diff summary before commit
@@ -1153,6 +1209,7 @@ func TestListCommitHistory(t *testing.T) {
 	}
 
 	// Commit and check history
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	s.SetFromInput("security zones security-zone trust interfaces eth0.0")
 	if _, err := s.Commit(); err != nil {
 		t.Fatal(err)
@@ -1571,6 +1628,7 @@ func TestCommitWithDescription(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24")
 	s.SetFromInput("security zones security-zone trust interfaces eth0.0")
 	cfg, err := s.CommitWithDescription("initial trust zone setup")
 	if err != nil {
@@ -1608,6 +1666,7 @@ func TestCommitWithDescription(t *testing.T) {
 	}
 
 	// Second commit without description should still work
+	s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24")
 	s.SetFromInput("security zones security-zone untrust interfaces eth1.0")
 	cfg2, err := s.Commit()
 	if err != nil {
@@ -1732,6 +1791,7 @@ func TestRenameConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	cmds := []string{
+		"interfaces eth0 unit 0 family inet address 10.0.0.1/24",
 		"security zones security-zone oldname interfaces eth0.0",
 	}
 	for _, cmd := range cmds {

--- a/pkg/dataplane/userspace/default_policy_3065_test.go
+++ b/pkg/dataplane/userspace/default_policy_3065_test.go
@@ -35,6 +35,8 @@ func TestSnapshotDefaultPolicyFailsClosed(t *testing.T) {
 	}
 
 	base := []string{
+		"set interfaces eth0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces eth1 unit 0 family inet address 10.0.1.1/24",
 		"set security zones security-zone trust interfaces eth0",
 		"set security zones security-zone untrust interfaces eth1",
 	}

--- a/pkg/dataplane/userspace/junos_host_policy_3019_test.go
+++ b/pkg/dataplane/userspace/junos_host_policy_3019_test.go
@@ -18,6 +18,8 @@ import (
 func TestJunosHostPolicySnapshotCarriesRule(t *testing.T) {
 	tree := &config.ConfigTree{}
 	cmds := []string{
+		"set interfaces eth0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces eth1 unit 0 family inet address 10.0.1.1/24",
 		"set security zones security-zone trust interfaces eth0",
 		"set security zones security-zone untrust interfaces eth1",
 		"set security policies from-zone trust to-zone junos-host policy deny-host match source-address any",

--- a/pkg/dataplane/userspace/zone_local_addressbook_3061_test.go
+++ b/pkg/dataplane/userspace/zone_local_addressbook_3061_test.go
@@ -61,6 +61,8 @@ func policyDestAddrs(t *testing.T, snap *ConfigSnapshot, fromZone, toZone, name 
 // revert at the CompileConfig step.
 func TestZoneLocalAddressBookResolves(t *testing.T) {
 	cfg := compileSet(t, []string{
+		"set interfaces eth0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces eth1 unit 0 family inet address 10.0.2.1/24",
 		"set security zones security-zone trust interfaces eth0",
 		"set security zones security-zone untrust interfaces eth1",
 		"set security zones security-zone trust address-book address web-server 10.0.1.100/32",
@@ -95,6 +97,9 @@ func TestZoneLocalAddressBookResolves(t *testing.T) {
 // to the global 10.9.9.9/32 — the zone-local assertion goes RED.
 func TestZoneLocalAddressBookScoping(t *testing.T) {
 	cfg := compileSet(t, []string{
+		"set interfaces eth0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces eth1 unit 0 family inet address 10.0.2.1/24",
+		"set interfaces eth2 unit 0 family inet address 10.0.3.1/24",
 		"set security zones security-zone trust interfaces eth0",
 		"set security zones security-zone untrust interfaces eth1",
 		"set security zones security-zone dmz interfaces eth2",

--- a/pkg/grpcapi/server_show_chassis_forwarding_test.go
+++ b/pkg/grpcapi/server_show_chassis_forwarding_test.go
@@ -23,8 +23,8 @@ import (
 // drifts (key renamed, comparison inverted, etc.), this test fails.
 func Test_PeerCallSkipsDialBack(t *testing.T) {
 	cases := []struct {
-		name        string
-		md          metadata.MD
+		name         string
+		md           metadata.MD
 		wantPeerCall bool
 	}{
 		{"empty metadata", metadata.MD{}, false},

--- a/pkg/grpcapi/server_show_golden_test.go
+++ b/pkg/grpcapi/server_show_golden_test.go
@@ -175,6 +175,8 @@ func newShowGoldenStore(t *testing.T) *configstore.Store {
 // options/instances, VLANs, and login so the corresponding ShowText
 // branches render non-empty output.
 var showGoldenConfigCommands = []string{
+	"interfaces ge-0-0-0 unit 0 family inet address 10.0.0.1/24",
+	"interfaces ge-0-0-1 unit 0 family inet address 10.0.1.1/24",
 	"security zones security-zone trust interfaces ge-0-0-0.0",
 	"security zones security-zone untrust interfaces ge-0-0-1.0",
 	"security screen ids-option untrust-screen tcp syn-flood",

--- a/pkg/grpcapi/server_show_zones_hostinbound_3328_test.go
+++ b/pkg/grpcapi/server_show_zones_hostinbound_3328_test.go
@@ -31,6 +31,9 @@ func zoneHostInboundGRPCStore(t *testing.T) *configstore.Store {
 		t.Fatalf("EnterConfigure() error = %v", err)
 	}
 	if err := store.LoadOverride(`
+interfaces {
+    ge-0/0/9 { unit 0 { family inet { address 10.0.9.1/24; } } }
+}
 security {
     zones {
         security-zone trust {

--- a/pkg/grpcapi/server_show_zones_hostinbound_display_3654_test.go
+++ b/pkg/grpcapi/server_show_zones_hostinbound_display_3654_test.go
@@ -25,6 +25,10 @@ func hostInboundGRPCServer(t *testing.T) *Server {
 		t.Fatalf("EnterConfigure() error = %v", err)
 	}
 	if err := store.LoadOverride(`
+interfaces {
+    ge-0/0/9 { unit 0 { family inet { address 10.0.9.1/24; } } }
+    ge-0/0/1 { unit 0 { family inet { address 10.0.1.1/24; } } }
+}
 security {
     zones {
         security-zone trust {

--- a/pkg/grpcapi/server_show_zones_lifeline_3682_test.go
+++ b/pkg/grpcapi/server_show_zones_lifeline_3682_test.go
@@ -21,6 +21,11 @@ func lifelineZonesGRPCStore(t *testing.T) *configstore.Store {
 		t.Fatalf("EnterConfigure() error = %v", err)
 	}
 	if err := store.LoadOverride(`
+interfaces {
+    em0 { unit 0 { family inet { address 10.0.99.1/24; } } }
+    ge-0/0/0 { unit 0 { family inet { address 10.0.0.1/24; } } }
+    ge-0/0/1 { unit 0 { family inet { address 10.0.1.1/24; } } }
+}
 security {
     zones {
         security-zone mgmt {

--- a/test/incus/xpf-internet-test.conf
+++ b/test/incus/xpf-internet-test.conf
@@ -62,6 +62,13 @@ security {
     }
 }
 interfaces {
+    enp6s0 {
+        unit 0 {
+            family inet {
+                address 10.0.1.1/24;
+            }
+        }
+    }
     enp10s0 {
         unit 0 {
             family inet {


### PR DESCRIPTION
Closes #4515

## Summary

ps-review-002 filed two DELIBERATE warn-only config-validation parity
gaps (F6, F11-part2). This PR drives **F6** to a strict commit reject
with the documented dynamic-interface-union safeguard, and keeps
**F11-part2** warn-only (with a recorded rationale) because a safe
promotion is not available without first modeling the non-literal
address forms.

### F6 — zone -> undefined-interface (DRIVEN)

A `security zones security-zone <z> interfaces <if>` entry naming an
interface NOT defined under `interfaces` was warn-only in
`ValidateConfig`; Junos hard-rejects it. At runtime the interface is
absent so the daemon brings it DOWN (fail-closed) — safe but silent: a
typo'd `ge-0/0/99` zone member carried no packets with no commit-time
signal.

New strict gate `validateZoneInterfaceDefinedStrict`
(`pkg/config/compiler_validate_strict_zones.go`), dispatched in
`runUniformGates` after the #3072 membership gate. Lenient downgrade to a
`cfg.Warnings` entry on the tolerant load / peer-sync path
(`opts.lenientZoneInterfaceDefined`, #1960 no-brick).

The gap was warn-only because a naive promotion off the
`cfg.Interfaces.Interfaces`-only set would false-reject a zone
referencing a daemon-materialized dynamic interface (the #4191
over-rejection class). The safeguard is `zoneReferenceableInterfaceBases`
— a generous union of every configured interface (GRE/IPIP/WireGuard
tunnels + routing-instance members fall out for free, since they must be
configured under `interfaces`) **+ `lo0`** (reserved always-present
loopback) **+ every IPsec `bind-interface` secure-tunnel base** (st0.x is
materialized at apply time by `routing.ApplyXfrmi` even with no explicit
`set interfaces st0`).

### F11-part2 — malformed address-book VALUE (SKIPPED, deliberate)

Kept WARN-ONLY. The `security address-book ... address` schema leaf is a
deliberately-open `multi:true` leaf (`children:nil`); the non-literal
Junos forms `dns-name`/`range-address`/`wildcard-address` are unmodeled
and compile to an empty prefix, sharing the SAME warn as a malformed
prefix. A strict promotion would false-reject those valid non-literal
forms (the #4191 class) unless they are modeled first, and the residual
fail-open is narrow/theoretical (an empty-prefix address is fail-CLOSED
for permit rules — it matches nothing; only a deny blocklist entry could
fail open, the same class as a typo'd address-book NAME). The cited
`invalid address` warn branch is additionally unreachable, since
`Address.Value` is only ever populated through the same
`looksLikeIPOrCIDR` predicate the warn re-checks. Documented in
`docs/config-schema.md`.

## Validation

- New RED-on-revert test `pkg/config/zone_interface_defined_4515_test.go`:
  undefined interface REJECTED on strict commit / WARNS (not bricks) on
  the lenient path / valid + `lo0` + IPsec-`bind-interface st0.0` configs
  commit clean. Neutralizing the gate fails both the strict and lenient
  guards; restoring it passes.
- Existing fixtures that referenced zone interfaces without defining them
  are updated to valid configs (add-only interface definitions) across
  `pkg/config`, `pkg/configstore`, `pkg/cli`, `pkg/api`, `pkg/grpcapi`,
  and `pkg/dataplane/userspace` so every commit stays bisect-green; the
  real deploy config `test/incus/xpf-internet-test.conf` (referenced
  `enp6s0` undefined) is likewise fixed.
- `TestConfigValidationCrossRef` adapted to assert the downgraded
  tolerant-path warning.
- The #4406 compile golden baseline AND the grpcapi show-text golden are
  both UNCHANGED (the corpus has no undefined-interface reference; the
  superset union rejects nothing the warn did not already flag, and the
  interface defs don't alter the captured show topics).
- `go test ./pkg/...` green except the pre-existing, unrelated
  `pkg/fsatomic` `TestNoDirectOsWriteFile` canary (flags
  `daemon/daemon_flow.go:327` on master, untouched here); `go build`;
  gofmt + vet clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
