### PR TITLE
daemon: stage config archive via fsatomic.WriteFileAtomic (#4621)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,29 @@
+## 2026-07-07 — #4621 fsatomic canary: convert archive staging write to WriteFileAtomic
+
+- **Timestamp**: 2026-07-07
+- **Action**: Fix BROKEN-MASTER — `pkg/fsatomic/TestNoDirectOsWriteFile`
+  (the #1916 repo-wide AST canary) failed on clean master, flagging a direct
+  `os.WriteFile` at `pkg/daemon/daemon_flow.go:327` in
+  `Daemon.archiveToSites`. DIAGNOSIS: that write stages the CURRENT active
+  config (`store.ShowActive()`, may contain encrypted secrets → 0600) into a
+  fresh `os.MkdirTemp` dir, then SCPs it to the archive-sites and deletes the
+  temp dir after all uploads finish. It is NOT DurableState (deleted after
+  transfer; power-loss fsync is pointless on a transient copy) and NOT a
+  BestEffortKernelKnob (a regular tmpfs file — rename works; the allowlist is
+  strictly reserved for procfs/sysfs/bind-mount where rename is impossible by
+  construction). It is AtomicGeneratedConfig. FIX: converted the call to
+  `fsatomic.WriteFileAtomic` (temp-sibling `.<base>.tmp-*` + rename, NO fsync).
+  The rename target IS `srcPath`, so the historical remote basename (default
+  `xpf.conf`) is preserved and a reader never observes a torn file. Added a
+  rationale comment at the call site documenting the classification. Added
+  `TestArchiveConfigStagesAtomically` pinning (a) the historical basename
+  survives the rename and (b) no `.xpf.conf.tmp-*` scratch sibling leaks.
+- **File(s)**: pkg/daemon/daemon_flow.go (import + call),
+  pkg/daemon/archive_atomic_4621_test.go (new), _Log.md
+- **Validation**: `go test ./pkg/fsatomic/ -run TestNoDirectOsWriteFile` now
+  GREEN (was RED on master); `go test ./pkg/daemon/... ./pkg/fsatomic/` green;
+  `go build ./...`, gofmt, `go vet` clean.
+
 ## 2026-07-07 — #2562 NAT64 fail-closed ICMP/ICMPv6 fragment drop + `nat64_frag_dropped` counter
 
 - **Timestamp**: 2026-07-07

--- a/pkg/daemon/archive_atomic_4621_test.go
+++ b/pkg/daemon/archive_atomic_4621_test.go
@@ -1,0 +1,108 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestArchiveConfigStagesAtomically pins the #4621 fix: the archive staging
+// write goes through fsatomic.WriteFileAtomic (AtomicGeneratedConfig class,
+// #1894/#1916) instead of a direct os.WriteFile that bypassed the atomic
+// wrapper. WriteFileAtomic writes a ".<base>.tmp-*" sibling in the temp dir
+// and renames it into place, so:
+//
+//   - the historical remote basename (the boot-file basename, default
+//     xpf.conf) is preserved — the rename target IS srcPath, so a reader/
+//     lister only ever sees the config at its canonical name, never at the
+//     scratch ".tmp-*" name; and
+//   - after the write returns, no ".<base>.tmp-*" scratch sibling is left in
+//     the staging dir (the atomic writer either renamed it into place or
+//     removed it on failure).
+//
+// RED on revert: reverting the source back to os.WriteFile still preserves
+// the basename (so that assertion holds), but there is no additional scratch
+// sibling to check — this test's value is the regression guard that a future
+// change cannot swap in a writer that renames to a different final name or
+// leaks a partial ".tmp-*" file.
+func TestArchiveConfigStagesAtomically(t *testing.T) {
+	dir := t.TempDir()
+	store := newConfigStore(t, filepath.Join(dir, "config.db"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := store.SetFromInput("system host-name atomic-host"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	wantActive := store.ShowActive()
+
+	var mu sync.Mutex
+	var srcPath, gotContent string
+	var stagingSiblings []string
+	done := make(chan struct{}, 1)
+	d := &Daemon{
+		store: store,
+		// Historical remote basename is derived from ConfigFile's basename.
+		opts: Options{ConfigFile: filepath.Join(dir, "xpf.conf")},
+		archiveTransfer: func(_ context.Context, src, _ string) error {
+			b, err := os.ReadFile(src)
+			entries, _ := os.ReadDir(filepath.Dir(src))
+			mu.Lock()
+			srcPath = src
+			gotContent = string(b)
+			for _, e := range entries {
+				if strings.HasPrefix(e.Name(), ".xpf.conf.tmp-") {
+					stagingSiblings = append(stagingSiblings, e.Name())
+				}
+			}
+			mu.Unlock()
+			select {
+			case done <- struct{}{}:
+			default:
+			}
+			return err
+		},
+	}
+	cfg := &config.Config{}
+	cfg.System.Archival = &config.ArchivalConfig{
+		TransferOnCommit: true,
+		ArchiveSites:     []string{"scp://user@host:/archive/"},
+	}
+
+	d.archiveConfig(cfg)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("archiveConfig never invoked the transfer")
+	}
+
+	mu.Lock()
+	src := srcPath
+	content := gotContent
+	siblings := append([]string(nil), stagingSiblings...)
+	mu.Unlock()
+
+	// The atomic rename target is the canonical historical basename, not the
+	// scratch ".tmp-*" name.
+	if base := filepath.Base(src); base != "xpf.conf" {
+		t.Fatalf("staged source basename = %q, want the historical remote name %q", base, "xpf.conf")
+	}
+	// The reader saw a complete file (atomic rename means never a torn read).
+	if content != wantActive {
+		t.Fatalf("staged content != active config.\n got: %q\nwant: %q", content, wantActive)
+	}
+	// No leaked ".xpf.conf.tmp-*" scratch sibling from the atomic writer.
+	if len(siblings) != 0 {
+		t.Fatalf("atomic writer left scratch temp sibling(s) in staging dir: %v", siblings)
+	}
+}

--- a/pkg/daemon/daemon_flow.go
+++ b/pkg/daemon/daemon_flow.go
@@ -17,6 +17,7 @@ import (
 	"github.com/psaab/xpf/pkg/dataplane"
 	"github.com/psaab/xpf/pkg/dhcp"
 	"github.com/psaab/xpf/pkg/frr"
+	"github.com/psaab/xpf/pkg/fsatomic"
 	"github.com/psaab/xpf/pkg/logging"
 	"github.com/vishvananda/netlink"
 )
@@ -322,9 +323,16 @@ func (d *Daemon) archiveToSites(sites []string) {
 		return
 	}
 	srcPath := filepath.Join(tmpDir, base)
+	// AtomicGeneratedConfig (#1894/#1916): the staged snapshot is a
+	// regenerated config file, not durable state — it is deleted after the
+	// SCP uploads finish, so power-loss durability (fsync) is neither
+	// needed nor wanted on this transient copy. WriteFileAtomic writes a
+	// ".<base>.tmp-*" sibling in tmpDir and renames to srcPath, so the
+	// snapshot appears complete-or-not (a lister/reader never observes a
+	// torn file) while preserving the historical remote basename.
 	// 0600 — the active config may contain encrypted secrets; keep the
 	// transient copy owner-only (MkdirTemp already made the dir 0700).
-	if err := os.WriteFile(srcPath, []byte(active), 0600); err != nil {
+	if err := fsatomic.WriteFileAtomic(srcPath, []byte(active), 0600); err != nil {
 		slog.Warn("config archival failed: write temp config", "err", err)
 		os.RemoveAll(tmpDir)
 		return


### PR DESCRIPTION
## Summary

Fixes a RED-on-clean-master test: the #1916 repo-wide fsatomic canary
`pkg/fsatomic/TestNoDirectOsWriteFile` flagged a direct `os.WriteFile` at
`pkg/daemon/daemon_flow.go:327` in `Daemon.archiveToSites`, blocking clean
`go test` runs.

## Diagnosis

The flagged write stages the CURRENT active configuration
(`store.ShowActive()`, may contain encrypted secrets → 0600) into a fresh
`os.MkdirTemp` directory, SCPs it to every archive-site, then removes the temp
directory once all uploads finish. Against the #1894/#1916 persistence taxonomy:

- **Not DurableState** — the staged copy is deleted after transfer, so
  power-loss durability (fsync) is neither needed nor wanted on this transient
  file.
- **Not BestEffortKernelKnob** — it is a regular file in a tmpfs directory;
  `rename(2)` works fine. The canary allowlist is reserved strictly for
  procfs/sysfs/bind-mount writes where rename is impossible by construction, so
  allowlisting an ordinary scratch write would violate that documented contract.
- **It is AtomicGeneratedConfig.**

## Fix

Convert the call to `fsatomic.WriteFileAtomic` (temp-sibling `.<base>.tmp-*` +
rename, no fsync). The rename target is `srcPath` itself, so the historical
remote basename (default `xpf.conf`) is preserved and a reader never observes a
torn file. A rationale comment at the call site documents the classification.

Adds `TestArchiveConfigStagesAtomically` pinning the two atomicity-specific
properties: the historical basename survives the temp-sibling+rename, and no
`.xpf.conf.tmp-*` scratch sibling is left behind. The existing #3867 tests
already cover exact-content and temp-dir cleanup.

## Validation

- `go test ./pkg/fsatomic/ -run TestNoDirectOsWriteFile` now **passes** (was
  RED on master).
- `go test ./pkg/daemon/... ./pkg/fsatomic/` green.
- `go build ./...`, `gofmt`, `go vet` clean.

Closes #4621

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi