### PR TITLE
config: close security ike proposal to closed-world (#4313)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -41138,3 +41138,31 @@ top.
   pkg/logging/eventbuf_subscriber_cap_4484_test.go, pkg/frr/policy_render.go,
   pkg/frr/frr_test.go, pkg/api/README.md, pkg/logging/README.md,
   pkg/frr/README.md, _Log.md
+
+## 2026-07-07 — #4313 closed-world flip: security ike proposal (Phase-1 crypto)
+
+- **Timestamp**: 2026-07-07
+- **Action**: Extended the #4313 per-subtree closed-world closure (after PR-B
+  destination-NAT then, PR-C IPsec option containers, #4578 master-password) by
+  flipping the Phase-1 IKE proposal container
+  (`security ike proposal <name>`) to `closedWorld: true`. First modeled the one
+  missing Junos leaf (`description`, cosmetic/compiler-ignored, scalar) so the
+  subtree is LEAF-COMPLETE: full grammar = authentication-method /
+  authentication-algorithm / dh-group / encryption-algorithm / lifetime-seconds
+  / description, all modeled; the compiler (compiler_ipsec.go IKE proposal loop)
+  reads a strict subset. Phase-1 has no lifetime-kilobytes (a Phase-2/ESP knob),
+  so — unlike the sibling `security ipsec proposal`, which stays deferred pending
+  both description AND lifetime-kilobytes — description alone completes it.
+  Silent-drop here FAILS OPEN on crypto: a typo'd encryption/authentication
+  algorithm used to commit clean and negotiate the IKE SA WITHOUT the operator's
+  chosen cipher/hash (silent downgrade). The flip rejects the typo at strict
+  commit (SchemaValidate); the tolerant Store.Load / SyncApply path downgrades
+  to a warning (compileTreeLenient, #1960 — verified no-brick). RED-on-revert
+  verified: with closedWorld reverted, the reject/typo/lenient-precondition
+  tests fail (silently accepted) while AcceptsValid stays green (no
+  false-reject). go test ./pkg/config/... ./pkg/configstore/... green (golden
+  4406 unchanged — schema-only + compiler-ignored child); go build ./... clean;
+  gofmt + vet clean.
+- **File(s)**: pkg/config/schema_security.go,
+  pkg/config/schema_closedworld_ike_proposal_4313_test.go,
+  docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -881,11 +881,51 @@ AND the value validator). As with the other flips, the reject fires only on the
 strict commit path; `compileTreeLenient` downgrades it to a warning on
 `Store.Load` / `SyncApply`.
 
+**More production flips — `security ike proposal` (Phase-1 crypto, #4313).**
+The Phase-1 IKE proposal container (`security ike proposal <name>`) now sets
+`closedWorld:true` (`schema_security.go`) after adding the one missing leaf
+that made it leaf-complete. The completeness audit that gates the flip:
+
+- The full Junos `security ike proposal <name>` grammar is exactly
+  `authentication-method`, `authentication-algorithm`, `dh-group`,
+  `encryption-algorithm`, `lifetime-seconds`, and `description`. The first five
+  were already modeled; this change models `description` (cosmetic, scalar,
+  compiler-ignored) so the closed subtree does not false-reject a valid proposal
+  that carries it. The compiler (`compiler_ipsec.go`, the IKE proposal loop)
+  reads a STRICT SUBSET of the modeled set (the five crypto leaves; description
+  falls through its switch), so closing carries no false-reject risk (the #4191
+  class). Phase-1 has **no** `lifetime-kilobytes` — that is a Phase-2/ESP
+  volume-rekey knob — so, unlike the sibling `security ipsec proposal`, this
+  subtree is complete with `description` alone.
+- Every modeled leaf carries its value on the same statement line (no nested
+  value block in Junos), so closed-world never descends into an AST child of a
+  value leaf in EITHER parser shape.
+- Silent-drop here FAILS OPEN on crypto: a fat-fingered `encryption-algorith`
+  or `authentication-algoritm` used to commit clean, the compiler then found no
+  such child, and the Phase-1 SA negotiated WITHOUT the operator's chosen
+  cipher/hash — a silent downgrade to whatever the proposal (or a proposal-set
+  default) still carried, believed to be aes-256 while it was not. The flip
+  rejects the typo at strict commit; the tolerant `Store.Load` / `SyncApply`
+  path downgrades it to a warning (`compileTreeLenient`, #1960). Production
+  tests: `schema_closedworld_ike_proposal_4313_test.go` (RED on revert of the
+  flag; the lenient-no-brick case is covered too).
+
+**The systematic per-subtree closure continues (#4313).** Each of the flips
+above (destination-NAT then, the three IPsec option containers, master-password,
+now the Phase-1 IKE proposal) closes one leaf-complete high-risk subtree; the
+blanket-default flip stays deferred (it would break the deliberately-lenient
+accept-with-advisory knobs #2078/#4231 and false-reject valid-but-unmodeled
+Junos, the #4191 class). Both the remaining per-subtree flips and the
+blanket-flip doctrine decision remain tracked on #4313.
+
 **Remaining per-subtree flips (future PRs, tracked on #4313).** Turning
 `closedWorld` on for the other umbrella candidates (`snmp community` — INCOMPLETE:
 Junos allows `view` / `client-list-name` / `routing-instance`, unmodeled;
-`security ipsec proposal` / `security ike proposal` — INCOMPLETE: Junos allows a
-`description` leaf, unmodeled; `security nat static … then static-nat` —
+`security ipsec proposal` — INCOMPLETE: Junos allows a `description` leaf AND a
+`lifetime-kilobytes` volume-rekey leaf, both unmodeled (the Phase-1 IKE proposal
+above is now closed — it has no `lifetime-kilobytes`, so `description` alone
+completed it, but the Phase-2 ESP proposal needs both modeled first);
+`security nat static … then static-nat` —
 UNSAFE: `static-nat` is a free-form leaf and the Junos hierarchical form
 `static-nat { prefix { … } }` would false-reject under closed-world; `security
 screen ids-option` — INCOMPLETE, deliberately open-world; `protocols {ospf,bgp}

--- a/pkg/config/schema_closedworld_ike_proposal_4313_test.go
+++ b/pkg/config/schema_closedworld_ike_proposal_4313_test.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4313 — another PRODUCTION closed-world subtree flip, extending PR-B's
+// destination-NAT then and PR-C's IPsec option containers (traffic-selector,
+// vpn-monitor, dead-peer-detection) plus #4578's master-password.
+//
+// The Phase-1 IKE proposal crypto container (`security ike proposal <name>`)
+// now sets schemaNode.closedWorld (schema_security.go). Its subtree is
+// LEAF-COMPLETE: the full Junos grammar is exactly authentication-method,
+// authentication-algorithm, dh-group, encryption-algorithm, lifetime-seconds,
+// and description — all modeled — and the compiler (compiler_ipsec.go, the IKE
+// proposal loop) reads a strict subset of those (description is cosmetic /
+// compiler-ignored). Every leaf carries its value on the same statement line
+// (no nested value block in Junos), so closing the subtree cannot false-reject
+// a valid config (the #4191 class the umbrella warns about).
+//
+// Silent-drop here FAILS OPEN on crypto: before the flip a typo in
+// `encryption-algorithm` / `authentication-algorithm` committed clean and the
+// compiler negotiated the Phase-1 SA WITHOUT the operator's chosen cipher/hash
+// — a silent downgrade. The flip REJECTS the typo at strict commit
+// (SchemaValidate) instead of committing clean and being silently dropped by
+// the compiler — the #4313 silent-inert bug.
+//
+// These tests use the production ParseSetCommand + SetPath + SchemaValidate
+// path (buildTree). Each rejection test is RED on revert of the closedWorld
+// flag: without it, SchemaValidate returns nil (open-world silent-accept) and
+// the test fails.
+
+// ikeProposalSet builds a minimal IKE proposal whose body is the supplied set
+// lines (e.g. "encryption-algorithm aes-256-cbc", "bogus x").
+func ikeProposalSet(bodyLines ...string) []string {
+	out := []string{}
+	for _, l := range bodyLines {
+		out = append(out, "set security ike proposal p1 "+l)
+	}
+	return out
+}
+
+// TestClosedWorldIKEProposal_RejectsUnknownKeyword is the core RED-on-revert
+// discriminator: an unmodeled keyword under the closed-world IKE proposal is
+// rejected at strict commit. On revert of closedWorld the same input is
+// silently accepted (SchemaValidate returns nil) and this test fails — proving
+// the flip closes the #4313 silent-inert gap.
+func TestClosedWorldIKEProposal_RejectsUnknownKeyword(t *testing.T) {
+	tree := buildTree(t, ikeProposalSet("bogus aes-256-cbc"))
+	err := SchemaValidate(tree, nil)
+	if err == nil {
+		t.Fatal("an unmodeled keyword under the closed-world IKE proposal must be rejected at commit (RED on revert: silently accepted + dropped)")
+	}
+	if !strings.Contains(err.Error(), "bogus") || !strings.Contains(err.Error(), "closed-world") {
+		t.Fatalf("error must name the keyword and the closed-world subtree, got: %v", err)
+	}
+}
+
+// TestClosedWorldIKEProposal_RejectsCryptoTypo is the VALUE of the fix: a
+// fat-fingered crypto leaf (`encryption-algorith`, `authentication-algoritm`)
+// is caught at commit rather than silently ignored — the operator learns the
+// chosen cipher/hash would be dropped and the Phase-1 SA silently downgraded.
+func TestClosedWorldIKEProposal_RejectsCryptoTypo(t *testing.T) {
+	for _, typo := range []string{
+		"encryption-algorith aes-256-cbc",
+		"authentication-algoritm sha-256",
+		"authentication-methid pre-shared-keys",
+		"dh-grop group14",
+	} {
+		tree := buildTree(t, ikeProposalSet(typo))
+		err := SchemaValidate(tree, nil)
+		if err == nil {
+			t.Fatalf("a typo'd IKE proposal crypto leaf %q must be rejected at commit, not silently dropped (crypto fails open)", typo)
+		}
+		// the first token is the misspelled keyword
+		bad := strings.Fields(typo)[0]
+		if !strings.Contains(err.Error(), bad) || !strings.Contains(err.Error(), "closed-world") {
+			t.Fatalf("error must name the typo %q and the closed-world subtree, got: %v", bad, err)
+		}
+	}
+}
+
+// TestClosedWorldIKEProposal_AcceptsValid proves no false-reject: every valid
+// Junos IKE proposal leaf still commits clean under closed-world — each on its
+// own AND combined into a fully-specified real-world proposal (the shape the
+// existing parser tests use), plus the cosmetic `description` that was modeled
+// to make the subtree leaf-complete.
+func TestClosedWorldIKEProposal_AcceptsValid(t *testing.T) {
+	// each modeled leaf on its own
+	for _, leaf := range []string{
+		"authentication-method pre-shared-keys",
+		"authentication-algorithm sha-256",
+		"dh-group group14",
+		"encryption-algorithm aes-256-cbc",
+		"lifetime-seconds 28800",
+		`description "corp phase-1 proposal"`,
+	} {
+		tree := buildTree(t, ikeProposalSet(leaf))
+		if err := SchemaValidate(tree, nil); err != nil {
+			t.Fatalf("valid IKE proposal leaf %q must commit clean under closed-world, got: %v", leaf, err)
+		}
+	}
+	// a fully-specified proposal (the real-world shape)
+	full := buildTree(t, ikeProposalSet(
+		"authentication-method pre-shared-keys",
+		"authentication-algorithm sha-256",
+		"dh-group group14",
+		"encryption-algorithm aes-256-cbc",
+		"lifetime-seconds 28800",
+	))
+	if err := SchemaValidate(full, nil); err != nil {
+		t.Fatalf("a fully-specified IKE proposal must commit clean under closed-world, got: %v", err)
+	}
+}
+
+// TestClosedWorldIKEProposal_LenientDoesNotBrick documents the #1960 no-brick
+// contract: the closed-world reject is a SchemaValidate error, which the
+// tolerant Store.Load / SyncApply ingress downgrades to a warning
+// (configstore.compileTreeLenient). At the compile layer the schema gate is
+// NOT run — the lenient path is precisely CompileConfigLenient — so a config
+// with the typo still COMPILES (the unknown leaf silently dropped, exactly the
+// pre-gate behaviour the lenient path preserves) rather than bricking the load.
+// This is the strict-reject / lenient-warn split (#1960/#1319): strict commit
+// rejects, tolerant load warns-and-continues.
+func TestClosedWorldIKEProposal_LenientDoesNotBrick(t *testing.T) {
+	typoTree := buildTree(t, append(
+		ikeProposalSet("encryption-algorith aes-256-cbc"),
+		"set security ike policy pol1 proposals p1",
+	))
+	// strict gate rejects (the operator commit path)
+	if err := SchemaValidate(typoTree, nil); err == nil {
+		t.Fatal("precondition: strict SchemaValidate must reject the typo")
+	}
+	// lenient compile (the Store.Load / SyncApply path) must NOT brick — the
+	// compiler silently drops the unknown leaf and produces a config.
+	if _, err := CompileConfigLenient(typoTree); err != nil {
+		t.Fatalf("the lenient load/peer-sync path must not brick on a closed-world typo (#1960); got: %v", err)
+	}
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -844,7 +844,34 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 		// identically. This is the deliberate asymmetry with the Phase-2
 		// IPsec proposal below, whose compiler does NOT strip the prefix
 		// and therefore validates dh-group as a plain positive integer.
-		"proposal": {desc: "IKE proposal name", args: 1, placeholder: "<proposal-name>", children: map[string]*schemaNode{
+		// #4313 — closed-world flip (Phase-1 IKE proposal crypto). The Junos
+		// `security ike proposal <name>` grammar is LEAF-COMPLETE after adding
+		// `description` below: the full keyword set is exactly
+		// authentication-method, authentication-algorithm, dh-group,
+		// encryption-algorithm, lifetime-seconds, and description — all modeled
+		// here. The compiler (compiler_ipsec.go, the IKE proposal loop) reads a
+		// STRICT SUBSET of those (authentication-method / encryption-algorithm /
+		// authentication-algorithm / dh-group / lifetime-seconds); `description`
+		// is cosmetic and compiler-ignored. Every modeled leaf carries its value
+		// on the same statement line (no nested value block in Junos), so
+		// closed-world never descends into an AST child of a value leaf in
+		// EITHER parser shape — it cannot false-reject a valid config (the #4191
+		// class the umbrella warns about). Phase-1 has no lifetime-kilobytes
+		// (that is a Phase-2/ESP volume-rekey knob), so — unlike the sibling
+		// `security ipsec proposal` — this subtree is complete with description
+		// alone.
+		//
+		// Silent-drop here FAILS OPEN on crypto: a fat-fingered
+		// `encryption-algorith aes-256-cbc` or `authentication-algoritm sha-256`
+		// used to commit clean, the compiler then found no such child, and the
+		// IKE Phase-1 SA negotiated WITHOUT the operator's chosen cipher/hash —
+		// a silent downgrade to whatever the proposal (or a proposal-set
+		// default) still carried, believed to be aes-256 while it was not. The
+		// flip REJECTS the typo at strict operator commit (SchemaValidate); the
+		// tolerant Store.Load / SyncApply path downgrades the reject to a warning
+		// (#1960, configstore compileTreeLenient), so a stored or peer-synced
+		// config is never bricked.
+		"proposal": {desc: "IKE proposal name", args: 1, placeholder: "<proposal-name>", closedWorld: true, children: map[string]*schemaNode{
 			"authentication-method": {desc: "IKE authentication method", args: 1, placeholder: "<method>",
 				valueType: ValueEnumOf, valueDesc: "IKE phase 1 authentication method",
 				valueExamples: []string{"pre-shared-keys", "rsa-signatures", "ecdsa-signatures"},
@@ -857,6 +884,13 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 			"lifetime-seconds": {desc: "IKE SA lifetime in seconds", args: 1, placeholder: "<seconds>",
 				valueType: ValueInteger, valueDesc: "IKE SA lifetime in seconds",
 				valueExamples: []string{"3600", "28800"}, validator: ValidateIntegerMin(1), children: nil},
+			// #4313: modeled so the closed-world flip is LEAF-COMPLETE. Junos
+			// allows a cosmetic `description` on an IKE proposal; xpf ignores it
+			// at compile (the IKE proposal loop has no case for it), but it MUST
+			// be modeled or closed-world would false-reject a valid config that
+			// carries it. scalar:true rejects a trailing token (#3332) — a
+			// multi-word description must be quoted.
+			"description": {desc: "Proposal description", args: 1, scalar: true, placeholder: "<text>", children: nil},
 		}},
 		"policy": {desc: "IKE policy name", args: 1, placeholder: "<policy-name>", children: map[string]*schemaNode{
 			// #3896: type mode/version/nat-traversal so a typo fails closed at


### PR DESCRIPTION
Addresses #4313 (closes `security ike proposal` as leaf-complete closed-world, extending #4578; the systematic per-subtree closure + the blanket-flip decision remain tracked).

## What

Flip the Phase-1 IKE proposal container `security ike proposal <name>` to `closedWorld: true` so a typo'd/unmodeled leaf under it is REJECTED at strict commit instead of committing clean and being silently dropped by the compiler — the #4313 silent-inert root cause (`schema_walk` resolves an unmodeled keyword to a nil child and returns nil-no-error).

This continues the per-subtree closure pattern established by:
- PR-B: `security nat destination … rule … then`
- PR-C: `security ipsec vpn … traffic-selector` / `vpn-monitor`, `security {ike,ipsec} gateway … dead-peer-detection`
- #4578: `system master-password`

## Why this subtree (leaf-complete + fail-open dangerous)

- **Leaf-complete after one addition.** The full Junos `security ike proposal` grammar is exactly `authentication-method`, `authentication-algorithm`, `dh-group`, `encryption-algorithm`, `lifetime-seconds`, `description`. The first five were already modeled; this models the missing `description` (cosmetic, `scalar`, compiler-ignored) so the closed subtree cannot false-reject a valid proposal that carries it. The compiler (`compiler_ipsec.go` IKE proposal loop) reads a **strict subset** of the modeled set — no false-reject risk (the #4191 class). Phase-1 has **no** `lifetime-kilobytes` (a Phase-2/ESP knob), so unlike the sibling `security ipsec proposal`, `description` alone completes it; the Phase-2 proposal stays a documented deferred candidate.
- **Value-on-same-line only.** Every modeled leaf carries its value on the same statement line (no nested value block in Junos), so closed-world never descends into an AST child of a value leaf in either parser shape.
- **Silent-drop FAILS OPEN on crypto.** A fat-fingered `encryption-algorith` / `authentication-algoritm` used to commit clean, the compiler then found no such child, and the IKE Phase-1 SA negotiated WITHOUT the operator's chosen cipher/hash — a silent downgrade believed to be aes-256 while it was not.

## Strict-reject / lenient-warn (#1960)

The reject fires only on the strict operator commit path (`SchemaValidate`); the tolerant `Store.Load` / `SyncApply` ingress downgrades it to a warning (`configstore.compileTreeLenient`), so a stored or peer-synced config is never bricked.

## Validation

- New production tests `schema_closedworld_ike_proposal_4313_test.go` (`ParseSetCommand` + `SetPath` + `SchemaValidate`): reject-unknown-keyword, reject-crypto-typo (four misspelled crypto leaves), accept every valid leaf incl. the new `description` and a fully-specified proposal (no false-reject), and a lenient-no-brick case.
- **RED on revert of the flag**: with `closedWorld` reverted the reject tests fail (silently accepted) while accept-valid stays green.
- `go test ./pkg/config/... ./pkg/configstore/...` green; golden 4406 unchanged (schema-only + compiler-ignored child); `go build ./...` clean; gofmt + vet clean.
- Docs: `docs/config-schema.md` gains the new flip's leaf-completeness audit + "systematic per-subtree closure continues" note; `_Log.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi