### PR TITLE
#3651: document deferred per-zone counter POPULATE + restore design doc

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -41268,3 +41268,38 @@ top.
 - **File(s)**: pkg/config/schema_security.go,
   pkg/config/schema_closedworld_ike_proposal_4313_test.go,
   docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-07
+- **Action**: #3651 — per-zone traffic + flood counter POPULATE. VERIFY-FIRST
+  on master: the userspace dataplane does NOT publish per-zone counters over
+  the wire (`ProcessStatus` carries no per-zone block;
+  `SetZoneCounterOffset`/`SetFloodCounterOffset` populate hook is wired on
+  `loader.go`/`maps_counters.go`/`maps_screen.go` but sourced only by tests).
+  So the populate needs the deferred Rust counter-publish (out of scope; cargo
+  lane busy) — the Go-only slice is DOC + surfacing-what's-available. Found the
+  real gap: four production files (pkg/api/README.md,
+  pkg/api/metrics_counters.go, pkg/api/types.go, pkg/dataplane/loader.go) cite
+  `docs/research/3643-dead-counters/plan.md §5A/§5B`, but that doc lived only on
+  the unmerged research/3643-dead-counters branch — dangling on master.
+  Restored the whole research dir (convention: plan.md + reviewer transcripts +
+  reviewer-ids.md, matching every other docs/research/<n>/), prepended a
+  "§0 Status update" to plan.md (HIDE shipped #3643; POPULATE deferred #3651;
+  substitutes; DERIVE-rejected). Added an operator-facing "Deferred
+  Observability — per-zone traffic + flood counters (#3651)" subsection to
+  docs/userspace-dataplane-gaps.md (current not-available state, the wired
+  populate hook, the §5A wire-plumbing design, live substitutes: global +
+  per-interface Bindings RX/TX + per-policy #2118 + per-screen-reason #3343).
+  Sharpened README's vague "follow-up enhancement issue" -> tracker #3651. Added
+  a RED-on-revert guard (pkg/api/zone_counter_doc_ref_test.go): the cited design
+  doc must exist on master with its §5A/§5B/#3651 anchors — deleting it (which
+  re-dangles the four in-code refs) fails the test. RED-on-revert verified (doc
+  hidden -> FAIL; restored -> PASS). No render-text churn: the HIDE surfaces
+  already render a consistent, honest "not available" across CLI/gRPC/REST, and
+  the only per-zone stat available on the Go side is the rejected DERIVE, so the
+  surfacing is the doc's substitute pointers. go test
+  ./pkg/cli/... ./pkg/grpcapi/... ./pkg/api/... ./pkg/dataplane/ green; go build
+  clean; gofmt clean (pre-existing cli.go:503 vet note untouched).
+- **File(s)**: docs/research/3643-dead-counters/plan.md (+ agy-r1.md,
+  codex-r1.md, claude-smr-plan-r1.md, reviewer-ids.md restored),
+  docs/userspace-dataplane-gaps.md, pkg/api/README.md,
+  pkg/api/zone_counter_doc_ref_test.go, _Log.md

--- a/docs/research/3643-dead-counters/agy-r1.md
+++ b/docs/research/3643-dead-counters/agy-r1.md
@@ -1,0 +1,25 @@
+# AGY adversarial plan review — #3643 r1
+
+Job: adversarial-review-mr1zq1au-fxheaq
+
+## Final Verdict
+- PLAN-NEEDS-MAJOR if the POPULATE (§5A) path is pursued.
+- PLAN-READY if the HIDE (§5B) path is chosen instead (Phase 1 + drop/clean metrics).
+
+## Key findings / required changes
+
+1. Hot-Path HashMap Performance Bottleneck (POPULATE §5A): the helper receives a
+   stable u16 zone id in [1,65533], so it must resolve a slot on 100% of packets.
+   A ZoneCounterSlotMap HashMap::get lookup would severely throttle forwarding.
+   REQUIRED CHANGE: use a flat lookup table zone_slots: [u8; 65536] (64 KB direct
+   array) for O(1) resolution.
+
+2. Missing Clear IPC Path (POPULATE §5A): Go-side offset clears are insufficient;
+   ClearAllCounters must send a new clear_zone_counters control IPC so cleared
+   values do not snap back on the next 1 s status poll (mirror ClearNATRuleCounters
+   / policycounters.go:163).
+
+3. Choosing the fork: per-zone metrics are largely redundant given per-policy
+   (#2118) and per-interface counters, so HIDE (§5B) is the recommended path — it
+   resolves the REST-500, CLI warnings, and Prometheus alert storm with zero code
+   complexity and zero hot-path overhead.

--- a/docs/research/3643-dead-counters/claude-smr-plan-r1.md
+++ b/docs/research/3643-dead-counters/claude-smr-plan-r1.md
@@ -1,0 +1,129 @@
+# Claude SMR hostile plan review — #3643 r1
+
+Reviewer: Claude SMR (hostile). Plan: `plan.md` @ `87749ce81`.
+
+I tried to soft-pass this as "clean POPULATE plan" and stopped myself — the
+plan's whole severity argument rests on one unverified kernel claim, and the
+recommendation buries a real "is this worth doing at all" question. Hostile pass
+below.
+
+## F1 (HIGH → must resolve before PLAN-READY): the OOB-error linchpin is asserted, not proven
+
+The plan's escalation from "misleading 0" to "REST 500 / Prometheus false alert /
+CLI error rows" depends entirely on: *a BPF dense per-CPU array `Lookup(key ≥
+max_entries)` returns `ENOENT` → `ErrKeyNotExist`, and the read surfaces
+propagate that error.* I could not run the empirical probe (no CAP_BPF /
+memlock in the research sandbox — the probe test skipped). So this is
+**corroborated, not proven**:
+
+- `pkg/dataplane/maps_nat.go:366` comment (maintainer, #2255): *"a hash id ≥
+  MaxNATRuleCounters would fail that bounded Lookup"* — a direct statement that
+  the dense-array lookup fails for an OOB stable-hash id. This is the strongest
+  corroboration: the *same class* of counter already hit this and was fixed for
+  exactly this reason.
+- `pkg/dataplane/constants_test.go:85`: *"ifindex == MaxInterfaces is out of
+  range for a dense array"* — repo treats OOB dense-array index as a hard fail.
+- `ReadZoneCounters` (maps_counters.go:95) and `ReadFloodCounters`
+  (maps_screen.go:79) return the raw `Lookup` error and do **not** convert
+  `ErrKeyNotExist`→zero (unlike `ReadInterfaceCounters`, maps_counters.go:81,
+  which does convert — because it's a HASH map where a miss is legitimate).
+
+**Verdict on F1:** high-confidence but the plan MUST label this an assumption
+and Phase 1 MUST NOT be called a "bug fix" until it is smoke-verified on the
+loss cluster (`curl` the REST endpoint, scrape `xpf_counter_read_errors_total`,
+run the CLI). The plan already says this in §11 Q2 — good — but §2/§3 state the
+500/false-alert as fact. Downgrade the prose to "expected (pending
+cluster-verify)" or verify first. If the reads actually clean-zero, the whole
+severity story collapses to the issue's original mild "misleading 0" and Phase 1
+shrinks to a cosmetic honesty fix. **This is the single highest-leverage thing
+to confirm.**
+
+## F2 (MED): the recommendation waffles between POPULATE and HIDE
+
+The plan recommends POPULATE (§5A) but its own §3 concedes per-zone is a
+"nice-to-have already largely covered." A hostile reader asks: if global +
+per-interface (`Bindings[].RXPackets/TXPackets/RXBytes/TXBytes`) + per-policy
+(#2118) + per-screen-reason (#3343) already exist, **what does per-zone add that
+an operator can't already get by summing the zone's interfaces client-side?**
+The honest answer: (a) server-side zone rollup convenience, (b) VLAN-unit-level
+attribution that per-interface can't express. (b) is the only *unique* value —
+and it's exactly what DERIVE (§5C) can't do and POPULATE can. So the real
+decision is narrower than "POPULATE vs HIDE": it is **"do operators need
+VLAN-unit-granular per-zone volume?"** If yes → §5A. If no → per-interface
+already covers whole-interface zones and the marginal value of §5A is low → HIDE.
+The plan should say this crisply and let the user answer the narrow question,
+rather than defaulting to POPULATE.
+
+## F3 (MED): Phase 1 alone re-creates the "misleading 0" the issue filed against
+
+Phase 1 converts error→clean-zero. That *is* the state the issue complains about
+("indistinguishable from no traffic"). So Phase 1 without §5A/§5B is a
+**regression back to the exact complaint**, dressed up as a fix. The plan says
+this (§5 "necessary but not sufficient") but it must be loud: Phase 1 MUST land
+paired with either §5A (real data) or §5B (explicit "not available" — NOT a
+zero). Shipping Phase 1 solo would technically close the 500 while re-opening
+#3643's literal grievance. Good that the plan forbids a bare zero in §5B; make
+that non-negotiable.
+
+## F4 (LOW-MED): §5A wire cost + the "sum across workers" question is under-specified
+
+§11 Q4 flags per-binding vs worker-summed sparse block but the plan doesn't pick.
+Cold-path (the cited precedent) reports per-worker and the Go side sums. For
+zone counters the same choice applies. Recommend: pre-sum across workers in the
+helper into ONE `ProcessStatus`-level sparse per-zone block, so the wire cost is
+O(active zones) once, not O(active zones × bindings). This also matches how
+`sumBindingCounters` already collapses per-binding scalars — but per-zone is a
+map, so summing on the Go side means iterating every binding's map every poll.
+Helper-side pre-sum is cleaner. The plan should commit to this in §5A, not leave
+it open, since it changes the wire shape.
+
+## F5 (LOW): flood — is per-zone even wanted, or is #3343 aggregate enough?
+
+§11 Q6 asks this but the plan keeps per-zone flood in §5A. Given #3343 already
+surfaces syn/icmp/udp-flood drops aggregated globally, and the per-zone flood
+surface (`show security screen ids-option statistics <zone>`) is a niche IDS
+view, a defensible narrowing is: **POPULATE per-zone packets/bytes (§5A) but mark
+per-zone flood "not available" and lean on the #3343 aggregate.** That halves
+the wire/Rust work for the lower-value half. The plan should offer this as an
+explicit sub-option, not bundle flood into §5A by default.
+
+## F6 (LOW): confirm zone-counter slots are node-local (no cross-node slot read)
+
+§7 asserts HA symmetry via deterministic slot assignment. But the *safe* design
+is the cold-path one: slots are **node-local and never ride the sync wire** —
+only the zone-id-keyed rollup is read cross-surface. Confirm no HA session-sync
+or config-sync path serializes a *slot index* (it must serialize zone *ids*).
+If slots stay node-local like cold-path, HA determinism is a non-issue and the
+"sort before assign" requirement is only for single-node reproducibility, not
+correctness. The plan overstates the HA risk; verify and downgrade.
+
+## What's genuinely strong
+
+- The #2255 read-side clone is exactly right and low-risk; citing the maintainer
+  comment that predicts the OOB failure is the best evidence in the plan.
+- Catching that the issue's "dense 1..N zone ids / silent 0" premise is stale
+  (#3075) is the real research contribution — it reframes the whole issue.
+- Rejecting DERIVE on VLAN-unit infidelity (with the project's own reth0.50/.80
+  WAN topology as the counterexample) is correct and well-argued.
+- The ColdPathSlotMap precedent is a real, load-bearing blueprint, not a
+  hand-wave.
+
+## SMR verdict
+
+**PLAN-NEEDS-MINOR → conditionally PLAN-READY.** The architecture is sound and
+well-grounded in shipped precedent (#2255 + ColdPathSlotMap). Conditions:
+1. Relabel the 500/false-alert as *expected, pending cluster-verify* (F1); make
+   the smoke-verify a Phase-1 gate.
+2. Make explicit that Phase 1 must ship paired with real data (§5A) or explicit
+   "not available" (§5B) — never a bare zero (F3).
+3. Reframe the recommendation around the narrow question "is VLAN-unit-granular
+   per-zone volume wanted?" (F2), and offer the "per-zone packets/bytes but
+   aggregate-only flood" sub-option (F5).
+4. Commit to helper-side worker-pre-sum for the wire (F4) and confirm node-local
+   slots (F6).
+
+Net recommendation to the user: **PLAN-READY for a two-phase POPULATE** — Phase 1
+(read-side #2255 clone) unconditional after cluster-verify; Phase 2 (§5A) the
+recommended source **if** per-zone/VLAN-unit volume is wanted, else HIDE (§5B) as
+a legitimate PLAN-KILL of the feature. This is a real fork the user should
+decide, not one the plan should force.

--- a/docs/research/3643-dead-counters/codex-r1.md
+++ b/docs/research/3643-dead-counters/codex-r1.md
@@ -1,0 +1,26 @@
+**Verdict: PLAN-NEEDS-MAJOR**
+
+Findings:
+
+1. **POPULATE is not plan-ready because the hot-path cost claim is unsupported.**  
+   The `ColdPathSlotMap` pattern is a decent sparse wire/slot-retention blueprint, but it is not proof of “2 non-atomic slot writes/pkt, no lookup.” Cold-path currently does a `HashMap` lookup in `lookup_slot` and only records after sampling fires: [cold_path_hist.rs](/home/ps/git/bpfrx/.claude/worktrees/3643-research/userspace-dp/src/afxdp/cold_path_hist.rs:279), [poll_descriptor/mod.rs](/home/ps/git/bpfrx/.claude/worktrees/3643-research/userspace-dp/src/afxdp/poll_descriptor/mod.rs:2266). For per-packet zone counters, the plan must specify where the resolved slot is cached or how it avoids a per-packet map lookup. If this follows `BatchCounters`, it also has atomic flush cost later: [mod.rs](/home/ps/git/bpfrx/.claude/worktrees/3643-research/userspace-dp/src/afxdp/mod.rs:573).
+
+2. **The read-side breakage claim is mostly correct, but the plan overstates several surfaces.**  
+   Stable zone IDs are `[1,65533]`: [zoneid.go](/home/ps/git/bpfrx/.claude/worktrees/3643-research/pkg/config/zoneid.go:38). The userspace shim still exposes the dense-array readers through embedded `bpfShim`, with no `ReadZoneCounters` / `ReadFloodCounters` override: [legacy_dataplane.go](/home/ps/git/bpfrx/.claude/worktrees/3643-research/pkg/dataplane/userspace/legacy_dataplane.go:39). Dense reads return lookup errors for OOB keys: [maps_counters.go](/home/ps/git/bpfrx/.claude/worktrees/3643-research/pkg/dataplane/maps_counters.go:95), [maps_screen.go](/home/ps/git/bpfrx/.claude/worktrees/3643-research/pkg/dataplane/maps_screen.go:79). REST does 500 for zone reads, and Prometheus increments `xpf_counter_read_errors_total`: [security.go](/home/ps/git/bpfrx/.claude/worktrees/3643-research/pkg/api/security.go:104), [metrics_counters.go](/home/ps/git/bpfrx/.claude/worktrees/3643-research/pkg/api/metrics_counters.go:173). But flood counters are not REST/Prometheus surfaces today, Prometheus increments once per zone when ingress fails rather than “2x per zone,” and zone CLI gives an aggregate warning rather than per-zone error rows: [cli_show_security_zones.go](/home/ps/git/bpfrx/.claude/worktrees/3643-research/pkg/cli/cli_show_security_zones.go:172).
+
+3. **Flood POPULATE is materially underspecified.**  
+   Existing screen state has per-zone rate-limiter state, not cumulative per-zone flood event counters: [screen/mod.rs](/home/ps/git/bpfrx/.claude/worktrees/3643-research/userspace-dp/src/screen/mod.rs:153). Durable accounting today is global/per-reason through `record_screen_drop`, not per-zone: [mod.rs](/home/ps/git/bpfrx/.claude/worktrees/3643-research/userspace-dp/src/afxdp/mod.rs:564). So flood population is new accounting, likely on drop paths, not “snapshot existing state.”
+
+4. **Clear/reset semantics are missing for POPULATE.**  
+   The #2255 NAT clone is only mechanical for sparse read offsets. Once helper-reported cumulative counters exist, clearing only Go-side offsets will snap back on the next status poll unless the helper is also cleared or Go stores subtractive baselines. NAT explicitly handles this with helper IPC: [natcounters.go](/home/ps/git/bpfrx/.claude/worktrees/3643-research/pkg/dataplane/userspace/natcounters.go:7). Policy does the same in `ClearAllCounters`: [policycounters.go](/home/ps/git/bpfrx/.claude/worktrees/3643-research/pkg/dataplane/userspace/policycounters.go:163). Zone/flood needs the same contract.
+
+5. **HA slot determinism is over-constrained if the wire carries zone IDs.**  
+   I found no reason a public or cross-node surface should consume the slot as identity. Cold-path publishes slots, but meaningful labels come from zone IDs. Zone-counter slots can be node-local if Go ingests `{zone_id, counters}` and maps by zone ID. Do not make slot determinism an HA invariant unless the slot leaks into the API/wire as identity.
+
+6. **DERIVE is correctly rejected, but the cited topology proof is weak.**  
+   Userspace binds VLAN units to the parent netdev, so parent binding RX/TX cannot generally split traffic by logical VLAN-unit zone: [interfaces.go](/home/ps/git/bpfrx/.claude/worktrees/3643-research/pkg/dataplane/userspace/interfaces.go:90). That disqualifies DERIVE as a correct general solution. However, the loss-cluster example in `ha-cluster-userspace.conf` has `reth0.50` and `reth0.80` both in `wan`, not different zones: [ha-cluster-userspace.conf](/home/ps/git/bpfrx/.claude/worktrees/3643-research/docs/ha-cluster-userspace.conf:154). Use a multi-zone VLAN-parent example instead.
+
+My hostile recommendation: approve the mandatory read-side sparse/unavailable fix only after the factual corrections above. Do not approve POPULATE until the plan nails slot resolution, batching/flush cost, helper clear semantics, flood-drop accounting, and the #3345 read-error contract. HIDE is a defensible product verdict if per-zone counters are not worth that complexity.
+
+Codex session ID: 019f1d6e-3f35-72a3-93b6-614974ea1be5
+Resume in Codex: codex resume 019f1d6e-3f35-72a3-93b6-614974ea1be5

--- a/docs/research/3643-dead-counters/plan.md
+++ b/docs/research/3643-dead-counters/plan.md
@@ -1,0 +1,508 @@
+# #3643 — per-zone `zone_counters` + `flood_counters` dead in the userspace era
+
+**Status:** CONVERGED v2 — 3/3 reviewers agree: HIDE (§5B) is PLAN-READY;
+POPULATE (§5A) is PLAN-NEEDS-MAJOR/DEFER. Recommendation: **HIDE** (with POPULATE
+fully specified below as a deferred option). See §12.
+**Branch:** `research/3643-dead-counters`
+**Base:** origin/master @ `7c54df10c`
+**Verdict target:** POPULATE (PLAN-READY / PLAN-DEFER) vs HIDE (PLAN-KILL)
+
+---
+
+## 0. Status update — HIDE shipped, POPULATE deferred to #3651
+
+This is a `/research` deliverable and predates implementation. Since it
+converged, the fork resolved as recommended:
+
+- **HIDE (§5B) SHIPPED under #3643.** The mandatory read-side fix landed:
+  `dataplane.ReadZoneCounters` / `ReadFloodCounters`
+  (`pkg/dataplane/maps_counters.go`, `maps_screen.go`) key a Go-side sparse
+  offset map, never index the dense BPF array, and return the distinct
+  `dataplane.ErrCounterNotPopulated` sentinel while unpopulated. The CLI,
+  gRPC, and REST surfaces render an explicit "not available" (REST returns
+  200 with `per_zone_counters_available:false`); the always-erroring
+  `xpf_zone_packets_total` / `xpf_zone_bytes_total` Prometheus metrics were
+  dropped. Pinned by the `zone_flood_counters_hide_test.go` /
+  `zone_counters_hide_test.go` suites in `pkg/dataplane`, `pkg/api`,
+  `pkg/cli`, and `pkg/grpcapi`.
+
+- **POPULATE (§5A) is DEFERRED under #3651** — this document is its design
+  of record. VERIFY-FIRST on master: the userspace dataplane does **not**
+  publish per-zone traffic or flood counters over the wire. `ProcessStatus`
+  (`pkg/dataplane/userspace/protocol.go`) carries no per-zone block, and the
+  Go-side POPULATE hook — `SetZoneCounterOffset` / `SetFloodCounterOffset`
+  plus the `ClearZoneCounterOffsets` / `ClearFloodCounterOffsets` resets on
+  `pkg/dataplane/loader.go` — is wired but is sourced only by tests. Lighting
+  the surfaces up requires the Rust work in §5A (a flat `[u8; 65536]` slot
+  LUT on the hot path, ONE helper-pre-summed `ProcessStatus`-level sparse
+  per-zone block, and a `clear_zone_counters` control-socket IPC). That Rust
+  counter-publish is the deferred prerequisite; until it ships, every
+  per-zone read stays "not available". This is the same class as other
+  "shim publishes 0 counters" deferrals (§4).
+
+- **Live substitutes today** (what an operator uses for per-zone-adjacent
+  volume until §5A ships): global flow statistics, per-interface
+  `Bindings[].RX/TX{Packets,Bytes}`, per-policy hit counters (#2118, which
+  are zone-pair scoped), and per-screen-reason drop counters (#3343). The
+  only unique thing per-zone volume adds over these is VLAN-unit-granular
+  attribution — which is exactly why §5C DERIVE (summing per-interface
+  binding counters into zones) is rejected as the source: a single physical
+  binding cannot be split across the logical VLAN-unit zones it hosts, so
+  DERIVE would produce subtly-wrong numbers, worse than an honest "not
+  available."
+
+The per-reviewer r1 write-ups in this directory (`agy-r1.md`, `codex-r1.md`,
+`claude-smr-plan-r1.md`, `reviewer-ids.md`) are the converged transcript.
+
+---
+
+## 1. Status
+
+CONVERGED v2 — 3/3 hostile plan reviews (Codex + AGY + Claude SMR) ran r1 and
+converged (see §12): HIDE is PLAN-READY, POPULATE is PLAN-NEEDS-MAJOR/DEFER.
+This is a `/research` deliverable: it stops at PLAN-READY / PLAN-DEFER /
+PLAN-KILL. No production code changes, no PR. The user proceeds via
+`/engineer 3643` after picking a path (default HIDE; opt into POPULATE §5A).
+
+## 2. Issue framing
+
+#3643 says the per-zone traffic counters (`zone_counters`) and per-zone flood
+counters (`flood_counters`) are **read** by CLI, gRPC, REST, and Prometheus but
+**never written** in the userspace-dp era. The eBPF writers lived in the
+#1476-deleted XDP/TC pipeline; the userspace populate campaign (#2118 per-policy,
+#2501 per-session, #2460 flowexport, #2161 NAT64, #3326 host-inbound, #3343
+per-screen-reason) never covered zone or flood counters. The issue frames the
+symptom as "every read returns a misleading constant 0" and asks for one of:
+(a) POPULATE from the userspace helper, or (b) HIDE the dead surfaces.
+
+**This plan corrects the issue's symptom description** (see §4/§5): on current
+master the reads do **not** return a silent 0 for most configs — they **error**,
+because zone IDs are now stable name-hashes in `[1, 65533]` (#3075) while the
+backing BPF maps are dense arrays of only `MaxZones*2 = 128` / `MaxZones = 64`
+entries. A stable-hash ID ≥ 64 indexes out of bounds, the kernel array lookup
+returns `ENOENT`, and the surfaces surface that as an error. The "constant 0"
+only happens for the ~0.1% of zone names that happen to hash into `[1, 63]`.
+
+**Precise per-surface current behavior (Codex r1 factual corrections applied):**
+- REST `/security/zones` → **HTTP 500** for the whole endpoint on the first
+  failed zone read (`pkg/api/security.go:104` sets `readErr`, then 500s).
+- Prometheus → `xpf_counter_read_errors_total` bumped **once per zone** (not
+  twice): `collectZoneCounters` does `ingress…if err {Add(1); continue}`, so the
+  egress read is skipped (`pkg/api/metrics_counters.go:173-181`). Still a
+  permanent false read-error alert, just 1×/zone/scrape.
+- `show security zones` → drops the Traffic-statistics block and prints **one
+  aggregate trailing warning** (`cli_show_security_zones.go:172`), not a row per
+  zone.
+- `show security screen ids-option statistics` (all-zones) → prints a **per-zone
+  error row** ("Error reading flood counters: …", `cli_show_security_screen.go:412`
+  #3344 path).
+- Flood counters are surfaced by **CLI + gRPC only** — NOT REST, NOT Prometheus
+  (the issue and plan v1 over-stated this). `flood_counters` REST/Prometheus
+  surfaces do not exist.
+
+So the live behavior is *worse and more confusing* than the issue states, and
+the read-side is broken **independently of whether we ever source the data.**
+
+## 3. Honest scope/value framing
+
+The win here is **observability correctness**, not throughput. At absolute
+scale:
+
+- **Bug being fixed (mandatory, any path):** the REST `/security/zones` endpoint
+  returns HTTP 500 for essentially every real config; the Prometheus
+  `xpf_counter_read_errors_total` gauge (a #3345 alerting signal) is bumped
+  1× per zone per scrape forever, firing a false "counter read failing" alert;
+  `show security zones` drops its Traffic-statistics block + prints an aggregate
+  warning; `show security screen ids-option statistics` prints an error row per
+  zone.
+- **Feature being weighed (the fork):** per-zone ingress/egress packet+byte
+  volume and per-zone SYN/ICMP/UDP flood-event counts. This is a Junos-parity
+  nice-to-have. Operators already have global counters, per-interface RX/TX
+  (in `ProcessStatus.Bindings`), per-policy hit counters (#2118), and the
+  aggregate per-screen-reason drop counters (#3343, includes syn/icmp/udp-flood
+  ordinals). Per-zone is incremental visibility, not a missing primitive.
+- **Hot-path cost of POPULATE:** at most two slot-indexed `u64` array writes per
+  forwarded packet (ingress-zone + egress-zone), on the *per-worker*
+  (single-threaded, non-atomic) counter block that already increments
+  `rx_packets`/`forward_candidate_packets`/`screen_drops` per packet. It is not
+  a new atomic or a new map lookup on the hot path — it is one more field in an
+  existing per-packet accumulate.
+
+*If reviewers conclude the perf gain is too small to justify the churn,
+PLAN-KILL is an acceptable verdict.* (Here "perf gain" reads as "observability
+value" — a PLAN-KILL means HIDE: fix the read-side to stop the 500/false-alert
+and honestly mark per-zone stats "not available", sourcing nothing.)
+
+## 4. What's already shipped / partially batched (the plan must compose with)
+
+All citations are `git show origin/master:<path>` verified at `7c54df10c`.
+
+1. **Stable-hash zone IDs (#3075).** `pkg/config/zoneid.go:38 StableZoneID` folds
+   FNV-1a/64 into `[1, ZoneIDReservedMin-1] = [1, 65533]`. `compiler.go:164
+   assignZoneIDs` uses it. The issue's claim "Zone IDs are dense 1..N
+   (compiler.go:186)" is **stale** — that was the pre-#3075 sorted-positional
+   scheme. This is the crux: any per-zone-keyed dense array is infeasible.
+2. **The dense-array-can't-hold-stable-hash-ID lesson is already documented and
+   already bit us once** — `cold_path_hist.rs` (#1635/#3075): the old 65×65 flat
+   `from*65+to` table "dropped every pair with an id ≥ 65 — silently dark-ing the
+   histogram for every real config"; it was replaced by a **sparse
+   `HashMap<(u16,u16), u8>` slot map** (`ColdPathSlotMap`, cold_path_hist.rs:150)
+   with dense slot-indexed accumulators, `inverse[slot]→(from,to)` for reporting,
+   sparse wire (only nonzero slots ride), an `overflow_active` flag, and a
+   `COLD_PATH_LAYOUT_VERSION`. **This is the proven POPULATE blueprint.**
+3. **The read-side fix is a mechanical clone of #2255.** NAT rule counters hit the
+   *identical* problem: counter IDs became a sparse key-derived hash, so
+   `ReadNATRuleCounter` (maps_nat.go:366) was changed to read a **Go-side sparse
+   offset map** (`natRuleCounterOffsets map[uint32]CounterValue`, loader.go:58)
+   and **never index the dense array** — its own comment says "a hash id ≥
+   MaxNATRuleCounters would fail that bounded Lookup." `SetNATRuleCounterOffset`
+   populates it from the status poll; `ClearNATRuleCounterOffsets` clears it.
+   `IncrementGlobalCounter`/`userspaceCounterOffsets` (maps_counters.go:40) is the
+   same Go-side-offset pattern for globals. Zone/flood reads were simply never
+   given this treatment — which is *why they still error.*
+4. **The delta-push status plumbing exists.** `manager_ha.go:716
+   syncBPFCountersLocked` runs every status poll, sums per-binding counters
+   (`sumBindingCounters`), and pushes deltas via `IncrementGlobalCounter` +
+   per-rule NAT via `SetNATRuleCounterOffset`. Adding a per-zone setter call here
+   is the established shape.
+5. **Per-interface RX/TX is already on the wire.** `ProcessStatus.Bindings[]`
+   carries `Ifindex`, `Interface`, `RXPackets`, `RXBytes`, `TXPackets`, `TXBytes`
+   (protocol.go:2211-2367). No new wire is needed to *derive* per-zone volume
+   from per-interface volume (the DERIVE option, §5C).
+6. **Per-zone flood state already exists inside the Rust screen module.**
+   `screen/mod.rs` keeps `syn_counters` keyed by zone, #3315 per-zone
+   per-dst/per-src SYN-flood sketches, and #3343 already tallies syn-flood(0)/
+   icmp-flood(1)/udp-flood(2) reason drops — but only pushes the **aggregate**
+   into `GlobalCtrScreen*`. The per-zone breakdown the flood surface wants is a
+   subset of data the helper already holds.
+7. **The per-packet zone identity is available in the forward path.**
+   `metadata.ingress_zone` / `metadata.egress_zone` (u16) are read at
+   bpf_map/mod.rs:251 and event_emit.rs:143; the same values feed conntrack
+   publish and event emit. A hot-path per-zone increment has the key in hand.
+8. **#3408/#3344/#3345** already reworked these read surfaces to "surface the
+   failure, not a fake 0" — but treated the failure as *occasional*. It is
+   *structural* (always fails for id ≥ 64). The plan must not regress the #3345
+   "read-error signal is real" contract while removing the *false* signal.
+
+## 5. Concrete design
+
+The design splits into a **mandatory read-side fix (Phase 1)** shared by every
+path, then the **fork** (Phase 2): where the per-zone numbers come from.
+
+### Phase 1 — read-side sparse-map fix (mandatory regardless of the fork)
+
+Clone the #2255 NAT pattern onto the `dataplane.Manager` (`bpfShim`), which backs
+all read surfaces via method promotion (`LegacyDataPlaneAdapter`,
+legacy_dataplane.go:52):
+
+```go
+// loader.go Manager struct (guarded by existing m.mu):
+zoneCounterOffsets  map[uint16][2]CounterValue // [zoneID][direction] ingress/egress
+floodCounterOffsets map[uint16]FloodState      // [zoneID]
+
+// maps_counters.go — never index the dense array again:
+func (m *Manager) ReadZoneCounters(zoneID uint16, direction int) (CounterValue, error) {
+    m.mu.Lock(); defer m.mu.Unlock()
+    return m.zoneCounterOffsets[zoneID][direction], nil // clean zero if absent
+}
+func (m *Manager) SetZoneCounterOffset(zoneID uint16, direction int, v CounterValue) { ... }
+func (m *Manager) ClearZoneCounterOffsets() { m.zoneCounterOffsets = nil }
+// maps_screen.go — same for ReadFloodCounters / SetFloodCounterOffset /
+// ClearFloodCounterOffsets.
+```
+
+Wire the clears into `ClearAllCounters` / `ClearZoneCounters` /
+`ClearScreenConfigs`-adjacent paths exactly as `ClearNATRuleCounterOffsets` is
+wired into `ClearNATRuleCounters`. Leave the dead dense BPF maps registered (the
+shim ABI mirror is shared with fixtures) but stop reading them for these two
+counter families — identical to how #2255 left the dead `nat_rule_counters`
+array registered but unread.
+
+**Effect of Phase 1 alone:** OOB errors gone → REST returns 200 with clean
+zeros, Prometheus stops the false read-error bump, CLI stops erroring. But the
+values are honest zeros only if nothing populates them — which reintroduces the
+issue's "misleading 0" complaint. Phase 1 is therefore *necessary but not
+sufficient* to close #3643; it must be paired with either §5A/§5B/§5C (source
+data) or §5-HIDE (remove/mark the surfaces).
+
+### Phase 2 — the fork
+
+#### §5A. POPULATE (full fidelity) — recommended
+
+Mirror `ColdPathSlotMap` for single zone IDs.
+
+- **Rust config-apply:** build a `ZoneCounterSlots { slot_of: Box<[u8; 65536]>,
+  inverse: Vec<Option<u16>>, overflow_active: bool }`. **CRITICAL (Codex+AGY r1):
+  the zone-id→slot resolver on the hot path MUST be a flat direct-index LUT, NOT a
+  `HashMap`.** Cold-path uses a `HashMap<(u16,u16),u8>` because a zone *pair* key
+  is 32-bit (4 G entries, dense-infeasible). A *single* zone id is only 16-bit, so
+  a dense `[u8; 65536]` LUT (64 KB per worker; 0 = unassigned/slot-0-reserved) is
+  feasible and gives `O(1)` no-hash resolution — cold-path's per-sample
+  `HashMap::get` (`cold_path_hist.rs:279`, `poll_descriptor/mod.rs:2266`) would
+  throttle a per-*packet* path. Assign slots to the sorted configured zone-id set
+  at apply; cap at `≤255` active zones (`u8` slot, matching
+  `COLD_PATH_ASSIGNABLE_SLOTS=255`); a zone past the cap sets `overflow_active`
+  and its packets go uncounted (documented, same as cold-path overflow).
+- **Rust hot path (per-worker, non-atomic, in the existing per-packet counter
+  block):** `let s = slot_of[meta.ingress_zone as usize]; if s != 0 {
+  wc.zone_pkts[s].ingress += 1; wc.zone_bytes[s].ingress += len; }` and the
+  egress-slot analog. Two direct-index array reads + writes per forwarded packet
+  on the block that already does `rx_packets += 1`. **No new atomic, no map
+  lookup, no per-packet hash.**
+- **Flood (Codex r1 correction):** the screen module holds per-zone *rate-limiter*
+  state (`screen/mod.rs:153`), **not** cumulative per-zone flood-event counters —
+  durable screen accounting today is global/per-reason via `record_screen_drop`
+  (`afxdp/mod.rs:564`), not per-zone. So per-zone flood is **new drop-path
+  accounting**, not a snapshot of existing state. Add a per-zone syn/icmp/udp
+  drop tally on the `record_screen_drop` path (already off the fast path — only
+  fires on a screen drop). **Recommended narrowing:** ship per-zone packets/bytes
+  and mark per-zone flood "not available", leaning on the #3343 aggregate
+  per-reason counters, unless per-zone flood attribution is explicitly demanded
+  (halves the Rust/wire work for the lower-value half).
+- **Wire (helper pre-sums across workers — Codex+SMR r1):** add ONE
+  `ProcessStatus`-level sparse per-zone block (NOT per-`BindingStatus`) mirroring
+  the cold-path sparse encoding: `[{zone_id, ingress_pkts, ingress_bytes,
+  egress_pkts, egress_bytes[, syn, icmp, udp]}]`, only nonzero entries, layout
+  version bump, `#[serde(default)]` cross-version safety, JSON round-trip test
+  both sides (cold_path_status_test.go / protocol/tests.rs pattern). Pre-summing
+  in the helper keeps wire cost `O(active zones)` per poll, not `O(zones ×
+  bindings)`, and spares the Go side from iterating every binding's map.
+- **Go status poll:** `syncBPFCountersLocked` reads the pre-summed per-zone block
+  and calls `SetZoneCounterOffset` / `SetFloodCounterOffset` (absolute, overwrite
+  — same as `SetNATRuleCounterOffset`, reset-safe because the helper reports
+  cumulative-since-launch totals).
+- **Clear semantics (MANDATORY for POPULATE — Codex+AGY r1):** clearing only the
+  Go offset maps is NOT enough — the helper's cumulative totals snap back on the
+  next 1 s poll. `ClearAllCounters`/`ClearZoneCounters` MUST send a new
+  `clear_zone_counters` (+ flood) control-socket IPC so the helper resets its
+  accumulators, exactly as `ClearNATRuleCounters`
+  (`pkg/dataplane/userspace/natcounters.go`) and the policy clear
+  (`policycounters.go:163`) do for their cumulative helper stores. This is a new
+  control-request family + a helper reset handler, not just a Go map nil-out.
+  (One-time clears only — no new >1/s control-socket caller, per the CLAUDE.md
+  control-socket-contention rule.)
+
+#### §5B. HIDE (PLAN-KILL of the feature) — the conservative fallback
+
+Ship **only Phase 1's read-side fix**, then *remove the misleading surfaces*
+rather than sourcing data:
+- Drop the `xpf_zone_packets_total` / `xpf_zone_bytes_total` Prometheus metrics
+  (they only ever emitted skipped/errored samples — no real data lost) and the
+  per-zone flood metric.
+- In CLI/gRPC/REST, either omit the per-zone Traffic-statistics / flood blocks or
+  render an explicit `not available (per-zone accounting not implemented in the
+  userspace dataplane)` — distinct from `0` and distinct from a read *error*.
+- Keep the global + per-interface + per-policy + per-screen-reason surfaces
+  (all live). Document the gap in the operator docs.
+- Leave a `docs/`-recorded DEFER hook to §5A if a customer demands per-zone
+  volume dashboards.
+
+#### §5C. DERIVE (tempting middle — recommend REJECT as primary)
+
+Since per-interface RX/TX(+bytes) is already on the wire (§4.5) and the compiler
+knows zone→interface, `syncBPFCountersLocked` could aggregate per-binding RX→zone
+ingress and TX→zone egress with **zero hot-path cost and zero wire change**, then
+`SetZoneCounterOffset`. **Fidelity gap that kills it as the primary:** a binding
+is per *physical* netdev — userspace binds VLAN units to the parent netdev
+(`pkg/dataplane/userspace/interfaces.go:90`), so a single binding's RX/TX cannot
+be split by the logical VLAN-unit zone. When one physical interface hosts VLAN
+units in *different* zones (e.g. `ge-0-0-2.50` in one zone and `.80` in another —
+a generic multi-zone-trunk topology; note the loss cluster's own `reth0.50`/`.80`
+are BOTH in `wan` per `docs/ha-cluster-userspace.conf:154`, so it is NOT itself a
+counterexample — use a real multi-zone trunk), DERIVE mis-attributes all of it to
+one zone or fails to match the unit name. Producing *subtly wrong* per-zone
+numbers is worse than an honest "not available." DERIVE is acceptable only as a
+documented low-fidelity fallback for whole-interface-zone deployments, never the
+shipped default.
+
+## 6. Public API preservation
+
+- `Manager.ReadZoneCounters(uint16, int) (CounterValue, error)` — signature
+  preserved; body changes to read the Go-side offset map. All callers
+  (api.go:31, cli/runtime.go:38, grpcapi/runtime.go:19, daemon/runtime_probes.go)
+  unchanged.
+- `Manager.ReadFloodCounters(uint16) (FloodState, error)` — preserved likewise.
+- `Manager.ClearZoneCounters()` / `ClearAllCounters()` — preserved; gain an
+  offset-clear like `ClearNATRuleCounters`.
+- New additive: `SetZoneCounterOffset`, `SetFloodCounterOffset`,
+  `ClearZoneCounterOffsets`, `ClearFloodCounterOffsets` (mirror the NAT-offset
+  method family).
+- Wire (§5A only): additive `#[serde(default)]` per-zone block + layout-version
+  bump; no field removed/renamed. HIDE (§5B) removes Prometheus metric names
+  (the only intentional surface removal).
+
+## 7. Hidden invariants the change must preserve
+
+- **HA symmetry (#3075) — RELAXED after Codex+SMR r1:** the *wire carries zone
+  IDs*, not slot indices, and no public/cross-node surface consumes the slot as
+  identity (confirmed: cold-path slots are node-local and never synced; the
+  zone-counter block is `{zone_id, counters}` and the Go side maps by zone id).
+  So slot assignment can be **node-local** and slot determinism is NOT an HA
+  invariant. Zone IDs themselves must remain a pure function of the zone name
+  (already guaranteed by `StableZoneID`/`buildZoneIDs`, zoneid.go). Sorting zone
+  IDs before slot assignment is desirable only for single-node reproducibility,
+  not correctness. Before shipping §5A, confirm no session-sync/config-sync path
+  serializes a slot index.
+- **Offset absoluteness / reset-safety:** setters overwrite with cumulative
+  totals; `safeDelta` semantics do not apply to `Set*Offset` (only to
+  `IncrementGlobalCounter`). On helper restart the cumulative resets to a smaller
+  value and the absolute overwrite is correct — same as `SetNATRuleCounterOffset`.
+- **#3345 read-error contract:** `xpf_counter_read_errors_total` must still climb
+  on a *genuine* map/IPC read failure. Phase 1 removes only the *structural false*
+  OOB bump; a real failure (e.g. map missing) must still register. Keep the
+  `counterReadErrors.Add(1)` on any error path that survives.
+- **Mutex discipline:** the offset maps share `m.mu` (already protecting
+  `userspaceCounterOffsets`/`natRuleCounterOffsets`). No new lock; no logging
+  under the lock (the #2285 re-entrant-slog hazard).
+- **No per-packet allocation / no per-packet atomic (§5A):** the per-zone
+  increment is a slot-indexed write on the per-worker block, summed at status —
+  never `fetch_add` on a shared cell, never a `HashMap` lookup on the hot path
+  (the slot is resolved from `metadata.ingress_zone` via the pre-built dense
+  `slot_by_zone` only; the hot path writes `zone_pkts[slot]`).
+- **overflow_active honesty:** a zone that overflows the slot cap must be
+  observably uncounted (surface the flag), not silently merged into slot 0.
+- **Fixture/parity:** the shared BPF struct sizes (`bpf/headers`) and the
+  wire fixture (`protocol_wire_v1.json` / cold_path_status_test) must regen if
+  the wire changes (§5A). HIDE (§5B) touches no wire.
+
+## 8. Risk assessment
+
+| Path | Behavioral regression | Lifetime/borrow | Perf regression | Architectural mismatch |
+|------|----------------------|-----------------|-----------------|------------------------|
+| **Phase 1 (read-side, all paths)** | LOW — mechanical #2255 clone; converts error→clean-zero; only behavior change is REST 200-not-500, no false alert | N/A (Go) | NONE (read-time map lookup) | LOW — identical to shipped NAT-offset design |
+| **§5A POPULATE** | MED — new sparse wire + hot-path counter + new clear-IPC family + new per-zone flood drop accounting; more moving parts than v1 admitted (Codex NEEDS-MAJOR) | LOW (Rust slot arrays are fixed `[u8;65536]` LUT + `Vec` accumulators; no new borrows on hot path) | LOW — **iff** the flat `[u8;65536]` LUT is used (2 direct-index writes/pkt); a per-packet `HashMap::get` would throttle forwarding (Codex+AGY) — measure on loss cluster | LOW — clones cold_path_hist + #2255; no dead-end |
+| **§5B HIDE** | LOW — removes surfaces that only ever errored; metric-name removal is the only compat note | N/A | NONE | NONE — accepts global-only, matches "observability is nice-to-have" stance |
+| **§5C DERIVE** | **MED-HIGH** — mis-attributes VLAN-unit zones (wrong numbers in the project's own WAN topology) | N/A | NONE | **HIGH** — produces plausible-but-wrong per-zone data; rejected as primary |
+
+## 9. Test plan
+
+- **Go:** `go test ./pkg/dataplane/... ./pkg/api/... ./pkg/cli/... ./pkg/grpcapi/...`
+  Add: (Phase 1) a unit test that `ReadZoneCounters`/`ReadFloodCounters` return a
+  clean `(zero, nil)` for a stable-hash zone ID ≥ 64 (the current OOB case) — this
+  test *fails on master* (proves the bug) and passes after; (Phase 1) a REST test
+  that `/security/zones` returns 200 not 500 with a large zone ID; (Phase 1) a
+  Prometheus test that `xpf_counter_read_errors_total` does **not** climb from
+  zone/flood reads while still climbing on a genuine injected read error
+  (guard the #3345 contract); (§5A) a status-poll test that a synthetic per-zone
+  block populates `ReadZoneCounters`/`ReadFloodCounters`.
+- **Rust (§5A):** `cargo test` full suite; add `ZoneCounterSlotMap` build tests
+  mirroring `cold_path_hist::tests::build_assigns_slots_for_wide_stable_hash_zone_ids`
+  (assert a zone ID like 40000 gets a slot and counts, not a dense-table drop);
+  overflow test; wire round-trip test both sides (protocol/tests.rs +
+  cold_path_status_test.go analog).
+- **HA-symmetry (§5A):** the existing zone-ID symmetry test must extend to slot
+  assignment determinism.
+- **Smoke (loss userspace cluster, `loss:xpf-userspace-fw0/fw1`):**
+  `make cluster-deploy`; re-apply CoS; 12-stream iperf3 v4+v6 to
+  172.16.80.200 / 2001:559:8585:80::200 and confirm `show security zones` per-zone
+  ingress/egress advance for the trust + WAN zones (§5A) or render "not available"
+  (§5B); confirm REST `/security/zones` is 200 and `xpf_counter_read_errors_total`
+  is flat. For §5A, capture a perf delta (throughput must stay at the ~22-23 Gbps
+  baseline; the per-zone increment must not regress it).
+- **test-failover (§5A only — touches wire/status the HA path reads):**
+  `make test-failover` must stay 0-drop (the plan does not touch session sync,
+  but the wire/layout bump rides the same status channel).
+
+## 10. Out of scope (explicitly)
+
+- Per-zone accounting granularity finer than the zone (per-policy already exists;
+  per-session already exists #2501).
+- Reviving the dense `zone_counters`/`flood_counters` BPF arrays as live maps
+  (they stay registered-but-unread, like `nat_rule_counters` post-#2255).
+- Per-interface counter population (`interface_counters` is separately unwritten
+  in the userspace era — related but a distinct gap; note it, do not fix here).
+- Filing the REST-500/false-alert as a separate bug: this plan folds it into
+  #3643's Phase 1 since it shares the exact root; split only if the user prefers.
+- NPTv6/NAT64-specific per-zone breakdowns.
+
+## 11. Open questions for adversarial review (each invitable to PLAN-KILL)
+
+1. **Is per-zone traffic accounting worth ANY new hot-path code, given global +
+   per-interface + per-policy + per-screen-reason counters already exist?** If
+   the answer is "no", the verdict is HIDE/PLAN-KILL and §5A never ships.
+2. **Is the REST-500 / Prometheus-false-alert claim correct?** It rests on: BPF
+   dense-array `Lookup(key ≥ max_entries)` returns `ENOENT`/`ErrKeyNotExist`
+   (kernel `array_map_lookup_elem`). The empirical probe could not run here (no
+   CAP_BPF in the research sandbox); it is corroborated by
+   `constants_test.go:85` ("ifindex == MaxInterfaces is out of range for a dense
+   array") and the #2255 comment ("a hash id ≥ MaxNATRuleCounters would fail that
+   bounded Lookup"). **Must be smoke-verified on the cluster before Phase 1 is
+   called a bug fix.** If reads actually return clean zeros (not errors), the
+   severity drops to the issue's original "misleading 0" and Phase 1 shrinks.
+3. **Is the ~0.1% in-range probability right, and does it matter?** `63/65533`
+   per zone name; a real config essentially always has ≥1 zone with ID ≥ 64.
+   Could a deployment's zone set happen to all land in `[1,63]` and mask the bug?
+4. **§5A wire: sparse per-`BindingStatus` block vs one worker-summed
+   `ProcessStatus` block?** Cold-path chose per-worker-then-sum. Per-binding
+   inflates the wire under many-zone configs; is the sparse encoding + nonzero
+   filter enough, or should the helper pre-sum across workers?
+5. **§5A HA determinism:** is sorting zone IDs before slot assignment sufficient
+   for both-node/cold-boot slot agreement, or does any surface read the *slot*
+   (not the zone ID) cross-node such that a slot renumber breaks it? (Cold-path
+   slots are node-local and never synced — confirm zone-counter slots can be too.)
+6. **Should the flood surface simply lean on #3343's aggregate per-reason global
+   counters** and mark per-zone flood "not available", even under §5A — i.e. is
+   per-*zone* flood attribution worth the sparse-wire block when the aggregate
+   already exists?
+7. **Is DERIVE (§5C) actually disqualified, or is whole-interface-zone attribution
+   "good enough" for a first cut** with a documented VLAN-unit caveat, given it
+   needs zero Rust/wire change? (I argue no — wrong numbers > honest gap — but
+   invite the counter-argument.)
+8. **Metric removal (§5B):** does dropping `xpf_zone_packets_total`/`_bytes_total`
+   break any committed dashboard/alert contract, or are they safe to remove since
+   they never emitted real data?
+
+---
+
+## 12. Converged reviewer verdicts (r1) + recommendation
+
+All three reviewers ran hostile r1 against `87749ce81`. They **converged in one
+round**: the read-side fix + HIDE path is ready; the POPULATE path is
+NEEDS-MAJOR. v2 above folds every finding.
+
+| Reviewer | Verdict | Core finding |
+|----------|---------|--------------|
+| **Codex** (`task-mr1zpu51-cyf9rg`) | **PLAN-NEEDS-MAJOR** (POPULATE); read-side fix approve-after-corrections; "HIDE is a defensible product verdict" | Hot-path cost unproven (cold-path does a per-sample `HashMap::get`); flood is NEW drop accounting not a snapshot; clear-IPC missing; several read-surface facts overstated (Prometheus 1× not 2×, flood not on REST/Prom, zones-CLI = 1 warning); DERIVE topology example wrong (reth0.50/.80 both in `wan`) |
+| **AGY** (`adversarial-review-mr1zq1au-fxheaq`) | **PLAN-NEEDS-MAJOR** (POPULATE) / **PLAN-READY** (HIDE); **recommends HIDE** | Same hot-path finding — must use a flat `[u8;65536]` LUT, not a HashMap; missing `clear_zone_counters` IPC; per-zone largely redundant with per-policy + per-interface counters → HIDE resolves the 500/alert-storm with zero complexity |
+| **Claude SMR** (`claude-smr-plan-r1.md`) | **PLAN-NEEDS-MINOR → conditionally PLAN-READY** | OOB-error linchpin is corroborated (maps_nat.go:366 maintainer comment) but unverified in-sandbox → must cluster-verify before calling Phase 1 a "bug fix"; Phase 1 alone regresses to the issue's "misleading 0" → must pair with data or explicit "not available"; reframe to the narrow question "is VLAN-unit-granular per-zone volume wanted?"; pre-sum wire; node-local slots |
+
+**Points of unanimous agreement:**
+1. The read-side breakage is real (stable-hash IDs OOB the dense arrays →
+   REST 500 + Prometheus false alert + CLI errors). All three independently
+   confirmed the mechanism against origin/master. **Still must be smoke-verified
+   on the cluster** before Phase 1 is called a bug fix (SMR F1 — no CAP_BPF in
+   the research sandbox to run the empirical probe).
+2. The read-side fix is a low-risk mechanical #2255 clone.
+3. POPULATE, if pursued, MUST use a flat direct-index `[u8;65536]` slot LUT (no
+   per-packet hash), a new `clear_zone_counters` IPC, and new per-zone flood drop
+   accounting — it is NEEDS-MAJOR as spec'd in v1, now specified in v2.
+4. HIDE (Phase 1 read-side fix + explicit "not available" + drop the dead
+   Prometheus per-zone metrics) is PLAN-READY and low-risk.
+5. Per-zone flood is the lowest-value half → lean on the #3343 aggregate.
+
+### Recommendation: **HIDE (PLAN-READY) — i.e. PLAN-KILL the POPULATE feature for now**
+
+Ship the mandatory read-side #2255-clone fix (stops the live REST-500 /
+Prometheus-false-alert / CLI-errors) and **render the per-zone traffic + flood
+surfaces as an explicit "not available (per-zone accounting not implemented in
+the userspace dataplane)" — never a bare 0 — and drop the always-erroring
+`xpf_zone_packets_total`/`xpf_zone_bytes_total` Prometheus metrics.** Rationale
+(2 of 3 reviewers, incl. AGY explicitly): per-zone volume is largely redundant
+with the already-live global + per-interface (`Bindings[].RX/TX{Packets,Bytes}`)
++ per-policy (#2118) + per-screen-reason (#3343) counters; the only *unique*
+value POPULATE adds is VLAN-unit-granular per-zone volume, and no operator demand
+for that is on record. HIDE resolves the live bug with zero hot-path cost and
+minimal risk.
+
+**POPULATE (§5A) is DEFERRED, not deleted** — it is now fully specified (flat LUT
++ pre-summed sparse wire + `clear_zone_counters` IPC + per-zone flood drop
+accounting) and can be picked up via `/engineer 3643` if per-zone / VLAN-unit
+volume dashboards are demanded. DERIVE (§5C) stays rejected as a primary.
+
+**Verdict:** PLAN-READY for HIDE + PLAN-DEFER for POPULATE. Label
+`plan-deferred-research`; keep the issue OPEN (a live read-side bug fix is still
+owed — this is not works-as-intended). Await manual approval — type
+`/engineer 3643` to implement (default: HIDE + read-side fix; opt into POPULATE
+§5A if per-zone volume is wanted). The Phase-1 read-side fix MUST be
+cluster-smoke-verified (REST 200, flat `xpf_counter_read_errors_total`) as part
+of `/engineer`.

--- a/docs/research/3643-dead-counters/reviewer-ids.md
+++ b/docs/research/3643-dead-counters/reviewer-ids.md
@@ -1,0 +1,17 @@
+# #3643 plan-review reviewer ledger
+
+Plan doc: `docs/research/3643-dead-counters/plan.md`
+Branch: `research/3643-dead-counters` @ `87749ce81` (r1) → v2 revision
+
+| Round | Reviewer | ID / file | Verdict |
+|-------|----------|-----------|---------|
+| r1 | Codex | `task-mr1zpu51-cyf9rg` (`codex-r1.md`) | PLAN-NEEDS-MAJOR (POPULATE); read-side approve-after-corrections; HIDE defensible |
+| r1 | AGY | `adversarial-review-mr1zq1au-fxheaq` (`agy-r1.md`) | PLAN-NEEDS-MAJOR (POPULATE) / PLAN-READY (HIDE); recommends HIDE |
+| r1 | Claude SMR | `claude-smr-plan-r1.md` | PLAN-NEEDS-MINOR → conditionally PLAN-READY |
+
+**Convergence (r1):** all three agree the read-side breakage is real, the fix is
+a low-risk #2255 clone, POPULATE is NEEDS-MAJOR (flat LUT + clear-IPC + flood drop
+accounting — now specified in v2), and HIDE is PLAN-READY. 2/3 (AGY explicit,
+Codex "defensible") recommend HIDE. Verdict: PLAN-READY (HIDE) + PLAN-DEFER
+(POPULATE). No r2 needed — v2 folds every finding without changing the
+convergent outcome.

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -99,6 +99,48 @@ These are not "missing", but they are not pure userspace forwarding either:
 | Dataplane event logging | Session open/close/update are emitted by userspace. Policy-deny, screen-drop, logged routing-instance filter hits, non-PBR input filter logs, output filter logs, cached output-filter hits, and lo0 filter logs now enqueue RT_FLOW frames through the non-blocking Rust event-stream producer with existing per-event rate-limit/loss accounting. Go decode/status handling feeds raw userspace RT_FLOW frames through the same `EventReader.ProcessRawEvent` syslog/local-log path as eBPF, with a deterministic UDP syslog fanout harness for policy deny, screen drop, and filter log. Policy-deny events now carry the snapshot's compiled numeric policy ID; filter-log events carry filter/term/action identity from the matched compiled term. #1379 is closed for the feature-gap audit; the final live cluster syslog proof was delivered in the closed #1477 validation set. |
 | `show system buffers` | Userspace helper-status rendering covers AF_XDP UMEM/TX capacity, CoS queued-byte capacity, helper-published session-table and flow-cache capacity, active-session footer, neighbor counts, and worker queue pressure counters. The Phase 5 denominator decision is explicit: session-table and flow-cache values become fill percentages only from Rust-owned helper fields; neighbor-cache entries remain counters until Rust owns a bounded neighbor-cache capacity. Formatter tests pin that dynamic counts cannot move into the utilization table without real denominators. |
 
+## Deferred Observability — per-zone traffic + flood counters (#3651)
+
+Per-zone ingress/egress packet+byte volume (`show security zones` "Traffic
+statistics") and per-zone SYN/ICMP/UDP flood-event counts (`show security screen
+ids-option statistics` "Per-zone flood counters") are **not published by the
+userspace dataplane** and render an explicit **"not available"** on every
+surface (CLI, gRPC text, REST `per_zone_counters_available:false`). This is a
+deliberate, honest gap, not a bug: the eBPF writers that once populated the
+dense `zone_counters` / `flood_counters` BPF arrays were deleted in the #1476
+retirement, and the userspace populate campaign (#2118 per-policy, #2501
+per-session, #2161 NAT64, #3326 host-inbound, #3343 per-screen-reason) never
+covered zone or flood counters.
+
+- **HIDE (#3643) is what shipped.** `dataplane.ReadZoneCounters` /
+  `ReadFloodCounters` key a Go-side sparse offset map instead of indexing the
+  dense array (so a stable-hash zone id `>= MaxZones` no longer OOB-errors the
+  read), returning the distinct `dataplane.ErrCounterNotPopulated` sentinel
+  while unpopulated. The always-erroring `xpf_zone_packets_total` /
+  `xpf_zone_bytes_total` Prometheus metrics were dropped.
+
+- **POPULATE (#3651) is the deferred prerequisite.** The Go-side populate hook
+  is already wired — `SetZoneCounterOffset` / `SetFloodCounterOffset` plus the
+  `ClearZoneCounterOffsets` / `ClearFloodCounterOffsets` resets — but is sourced
+  only by tests. Lighting the surfaces up requires Rust dataplane work: a flat
+  `[u8; 65536]` slot LUT on the hot path (two direct-index `u64` writes per
+  forwarded packet, no per-packet hash/atomic), ONE helper-pre-summed
+  `ProcessStatus`-level sparse per-zone block on the wire, and a
+  `clear_zone_counters` control-socket IPC so a `clear` resets the helper's
+  cumulative accumulators (clearing only the Go offset maps snaps back on the
+  next 1s poll). Full design of record:
+  [`docs/research/3643-dead-counters/plan.md`](research/3643-dead-counters/plan.md)
+  §5A.
+
+- **Live substitutes.** Until #3651 ships, per-zone-adjacent volume is available
+  from the global flow statistics, per-interface `Bindings[].RX/TX{Packets,Bytes}`,
+  per-policy hit counters (#2118, zone-pair scoped), and per-screen-reason drop
+  counters (#3343). The only unique value per-zone volume adds is
+  VLAN-unit-granular attribution — which is why simply summing per-interface
+  binding counters into zones (the §5C DERIVE shortcut) is rejected: one physical
+  binding hosting VLAN units in different zones cannot be split by logical unit,
+  so DERIVE would mis-attribute, which is worse than an honest "not available".
+
 ## Retirement History (closed)
 
 The #1373 eBPF retirement is complete. This section is a record of the closed

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -439,7 +439,8 @@ under the daemon's errgroup. Nothing else imports this package.
   per-zone volume + flood-event counts from the Rust helper) is DEFERRED; the
   sparse offset map's setters are the populate hook. See
   `docs/research/3643-dead-counters/plan.md` (§5A POPULATE spec, §5B HIDE) and
-  the follow-up enhancement issue. Pinned by
+  the deferred POPULATE tracker #3651 (the Rust per-zone counter-publish is the
+  outstanding prerequisite). Pinned by
   `pkg/dataplane/zone_flood_counters_hide_test.go`,
   `pkg/api/zone_counters_hide_test.go`,
   `pkg/cli/zone_flood_counters_hide_test.go`, and

--- a/pkg/api/zone_counter_doc_ref_test.go
+++ b/pkg/api/zone_counter_doc_ref_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #3651: the #3643 HIDE surfaces document the deferred POPULATE design by
+// pointing at docs/research/3643-dead-counters/plan.md §5A/§5B. Four production
+// files cite that path (pkg/api/README.md, pkg/api/metrics_counters.go,
+// pkg/api/types.go, pkg/dataplane/loader.go), so the doc must actually exist on
+// master with those section anchors — otherwise every one of those references
+// dangles.
+//
+// FAIL-ON-REVERT: deleting the design doc (as happened once — it lived only on
+// the unmerged research/3643-dead-counters branch) or dropping its §5A / §5B
+// POPULATE/HIDE anchors re-dangles the in-code references and makes this test
+// go RED. It is the guard that the deferred-POPULATE design of record stays on
+// master until the Rust per-zone counter-publish (#3651) ships.
+func TestZoneCounterDeferredDesignDocExists(t *testing.T) {
+	// pkg/api -> repo root is ../.. (matches the retirement boundary canary).
+	path := filepath.Join("..", "..", "docs", "research", "3643-dead-counters", "plan.md")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("deferred per-zone-counter design doc missing: %v "+
+			"(pkg/api/README.md, pkg/api/metrics_counters.go, pkg/api/types.go, and "+
+			"pkg/dataplane/loader.go all cite %s §5A/§5B)", err, path)
+	}
+	doc := string(b)
+	for _, anchor := range []string{"§5A", "§5B", "#3651"} {
+		if !strings.Contains(doc, anchor) {
+			t.Errorf("design doc %s missing anchor %q that the in-code #3643/#3651 "+
+				"references rely on", path, anchor)
+		}
+	}
+}


### PR DESCRIPTION
## What / why

Addresses #3651 (surfacing slice + doc; the Rust per-zone counter-publish remains the deferred prereq).

**VERIFY-FIRST on master — is per-zone traffic/flood published by the dataplane?** No.
`ProcessStatus` (`pkg/dataplane/userspace/protocol.go`) carries no per-zone
counter block, and the Go-side POPULATE hook — `SetZoneCounterOffset` /
`SetFloodCounterOffset` + the `ClearZoneCounterOffsets` /
`ClearFloodCounterOffsets` resets on `loader.go` / `maps_counters.go` /
`maps_screen.go` — is wired but sourced only by tests. So sourcing real
per-zone numbers requires the deferred Rust counter-publish (§5A). That is the
same class as other "shim publishes 0 counters" deferrals and is **out of scope
here** (Go-only slice). This PR ships the honest doc + surfacing half.

## The concrete gap this closes

Four production files cite `docs/research/3643-dead-counters/plan.md §5A/§5B`,
but that reviewer-converged design doc lived only on the unmerged
`research/3643-dead-counters` branch — every reference was **dangling** on
master:

- `pkg/api/README.md`
- `pkg/api/metrics_counters.go`
- `pkg/api/types.go`
- `pkg/dataplane/loader.go`

## Changes

- **Restore `docs/research/3643-dead-counters/`** (plan.md + reviewer
  transcripts + reviewer-ids.md, matching every other `docs/research/<n>/`
  layout) so the four references resolve. Prepend a **§0 Status update** to
  plan.md reconciling it with reality: HIDE (§5B) shipped under #3643; POPULATE
  (§5A) deferred under #3651; live substitutes; §5C DERIVE rejected.
- **`docs/userspace-dataplane-gaps.md`**: new operator-facing "Deferred
  Observability — per-zone traffic + flood counters (#3651)" subsection —
  current not-available state, the wired populate hook, the §5A wire-plumbing
  design, and the live substitute counters (global flow stats, per-interface
  `Bindings[].RX/TX`, per-policy #2118, per-screen-reason #3343).
- **`pkg/api/README.md`**: sharpen the vague "follow-up enhancement issue" ->
  tracker #3651.
- **`pkg/api/zone_counter_doc_ref_test.go`** (RED-on-revert): the cited design
  doc must exist on master with its §5A / §5B / #3651 anchors — deleting it
  (how the refs dangled) fails the test. Verified RED on revert.

## Surfaced now vs deferred

- **Surfaced now:** the substitute pointers (docs) + a guard that the design of
  record stays on master. No render-text churn — the #3643 HIDE surfaces
  already render a consistent, honest "not available" across CLI / gRPC text /
  REST (`per_zone_counters_available:false`), and the only per-zone stat
  obtainable on the Go side is the rejected DERIVE (would mis-attribute
  VLAN-unit zones), so there is no new correct per-zone number to add.
- **Deferred (#3651 prereq):** the Rust per-zone counter-publish — flat
  `[u8;65536]` slot LUT hot path, one pre-summed `ProcessStatus` sparse block,
  and a `clear_zone_counters` control IPC (§5A).

## Validation

`go test ./pkg/cli/... ./pkg/grpcapi/... ./pkg/api/... ./pkg/dataplane/` green;
`go build` clean; `gofmt` clean. RED-on-revert verified for the new guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi