### PR TITLE
Addresses #4373 (E1): WARN when then log session-close is inert on a deny/reject policy

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-07 — #4373 (E1): WARN when `then log session-close` is inert on a deny/reject policy
+
+- **Timestamp**: 2026-07-07
+- **Action**: avo-review-007 E1 — an operator who writes a named/global policy
+  `then reject; then log session-close` expecting a close record is confused
+  when none appears: a deny/reject verdict installs NO session, so the RT_FLOW
+  SESSION_CREATE/SESSION_CLOSE records those flags request never fire (the deny
+  is logged unconditionally via the policy-deny RT_FLOW record —
+  `userspace-dp` `emit_policy_deny_event` fires on every non-permit verdict,
+  never gated on a per-policy log flag; VERIFIED in the Rust source). The log
+  RENDERING side was already unambiguous (SESSION_CLOSE omits the action byte
+  #2513; POLICY_DENY carries a distinct reason #3610). The GAP was config-time:
+  the default-policy analog (`validateDefaultPolicyLogWarnings`, #3534) warns on
+  a deny-all/reject-all default, but there was NO per-policy equivalent. Added
+  `validatePolicyLogInertOnDenyWarnings` — a WARN-only commit advisory for each
+  named or global policy with action deny/reject that carries a
+  session-init/session-close `then log` selection, naming the inert mode(s) and
+  verdict. WARN-only (valid Junos; #1960 no-brick). Wired into `ValidateConfig`
+  right after the #3534 default-policy analog.
+- **File(s)**: pkg/config/compiler_validate_warn.go (new
+  `validatePolicyLogInertOnDenyWarnings` + ValidateConfig wiring),
+  pkg/config/compiler_policy_log_inert_deny_4373_test.go (new),
+  docs/config-schema.md (#4373 subsection), docs/junos-cli-reference.md
+  (`show security zones` log-modes note), _Log.md
+- **Validation**: `go test ./pkg/config/ ./pkg/logging/` green;
+  RED-on-revert confirmed (removing the ValidateConfig append →
+  TestPolicyLogInertOnDenyWarns FAILs on all 4 deny/reject cases; permit +
+  no-log negatives stay green); `go build`, gofmt, `go vet` clean. Rust
+  dataplane unchanged — the E4/H2/H7 live NoRoute/martian drop counter remains
+  a deferred `userspace-dp` (Rust) slice (E4/H2/H7 Go simulator half shipped in
+  #4504); E6 ext-header-denied counter is likewise a Rust concern.
+
 ## 2026-07-07 — #4621 fsatomic canary: convert archive staging write to WriteFileAtomic
 
 - **Timestamp**: 2026-07-07

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3400,6 +3400,43 @@ and Rust `policy::tests::default_verdict_carries_default_policy_log_flags` +
 `afxdp::tests::build_forwarding_state_threads_default_policy_log_flags` +
 the `wire_invariant_default_specimens` fixture.
 
+### #4373 — `then log session-init|session-close` inert on a deny/reject policy (WARN)
+
+avo-review-007 E1. The per-policy analog of the #3534 default-policy advisory
+above. An operator writes a NAMED or GLOBAL policy `then reject; then log
+session-close` expecting an RT_FLOW close record when the flow is rejected — but
+a **deny/reject verdict installs no session**, so the requested
+RT_FLOW_SESSION_CREATE / RT_FLOW_SESSION_CLOSE records never fire (session-close
+has no session to close). The deny is logged unconditionally via the RT_FLOW
+**policy-deny** record instead (`userspace-dp` `emit_policy_deny_event` fires on
+every non-permit verdict, never gated on a per-policy log flag), so `then log
+session-init` is redundant and `then log session-close` is inert. Per-policy
+`then log` session records fire only for a **`then permit`** policy, whose
+admitted session the dataplane stamps the log flags onto at install (the #2508
+path). Without a signal the policy REPORTS session-close logging on every
+operator surface (REST/gRPC/CLI) yet produces no close record — a silent
+observability gap that reads as a bug.
+
+**Advisory (WARN):** `validatePolicyLogInertOnDenyWarnings`
+(`compiler_validate_warn.go`) emits a WARN-only commit-time message for each
+named/global policy whose action is deny/reject and that carries a
+session-init/session-close `then log` selection, naming the inert mode(s) and
+the verdict. Never an error — `then log` on a deny/reject is valid Junos and a
+hard reject would brick a previously-committed config (#1960 no-brick). This is
+distinct from the bare-`then log` gate (`validatePolicyLogActionStrict`, #3060),
+which still hard-rejects a `then log` naming neither mode. The log RENDERING side
+of the same confusion (a reject is logged as `POLICY_DENY` / `FILTER_LOG
+action=reject`, never a misleading `SESSION_CLOSE`) was already unambiguous —
+`SESSION_CLOSE` omits the action byte (#2513) and `POLICY_DENY` carries a
+distinct reason (#3610); this advisory closes the remaining CONFIG-time
+confusion. The E4/H2/H7 route-drop-before-policy half of avo-review-007 shipped
+separately (#4504); the live NoRoute/martian drop counter remains a deferred
+`userspace-dp` (Rust) slice.
+
+Regression coverage: `pkg/config/compiler_policy_log_inert_deny_4373_test.go`
+(zone-pair + global deny/reject warn fail-on-revert; permit + no-log negative
+gates).
+
 ### #2401 — Security-policy undefined-zone references (commit fail-closed)
 
 A `set security policies from-zone <a> to-zone <b> { policy ... }` stanza

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -1149,7 +1149,12 @@ its logging/inversion intent (#3684):
   - `log <modes>` -- the session-log triggers (`at-create`, `at-close`) via
     the shared `PolicyLog.SessionLogModes` SSOT (#3667). The `[default]` row
     reflects `default-policy-log session-init/session-close` (#3534), the log
-    posture for flows that hit the implicit default verdict (M13).
+    posture for flows that hit the implicit default verdict (M13). NOTE: this
+    line shows the CONFIGURED modes even on a `then deny`/`then reject` policy,
+    where they are inert -- a deny/reject installs no session, so no
+    session-init/session-close record fires (the deny is logged via the
+    policy-deny RT_FLOW record). Commit emits a WARN naming the inert selection
+    (#4373); `then log` session records fire only for a `then permit` policy.
   - `count` -- the policy has `then count` hit-count accounting.
   - `source-address (except)` / `destination-address (except)` -- a Junos
     `source-address-excluded` / `destination-address-excluded` inverted match

--- a/pkg/config/compiler_policy_log_inert_deny_4373_test.go
+++ b/pkg/config/compiler_policy_log_inert_deny_4373_test.go
@@ -1,0 +1,172 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// buildPolicyLogInertTree parses flat set commands via the ParseSetCommand +
+// SetPath loop (NewParser must not be used for set syntax — see CLAUDE.md
+// "Testing flat set syntax").
+func buildPolicyLogInertTree(t *testing.T, cmds []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// policyLogInertBaseZones is the minimal zone/interface scaffolding the #4373
+// per-policy cases reference (a trust->untrust zone pair).
+var policyLogInertBaseZones = []string{
+	"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
+	"set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.1/24",
+	"set security zones security-zone trust interfaces ge-0/0/0.0",
+	"set security zones security-zone untrust interfaces ge-0/0/1.0",
+}
+
+// policyLogInertWarning returns the ValidateConfig warning that mentions the
+// #4373 per-policy inert-log advisory, or "" if none was emitted.
+func policyLogInertWarning(t *testing.T, cmds []string) string {
+	t.Helper()
+	cfg, err := CompileConfig(buildPolicyLogInertTree(t, cmds))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	for _, w := range ValidateConfig(cfg) {
+		if strings.Contains(w, "#4373") && strings.Contains(w, "inert") {
+			return w
+		}
+	}
+	return ""
+}
+
+// TestPolicyLogInertOnDenyWarns is the #4373 (avo-review-007 E1) fail-on-revert
+// guard: a NAMED or GLOBAL security policy with `then deny`/`then reject` plus
+// `then log session-init`/`session-close` emits the commit-time inert-log
+// advisory — the deny/reject verdict installs no session, so the requested
+// RT_FLOW session-init/session-close record never fires. Reverting the
+// validatePolicyLogInertOnDenyWarnings call (or the trigger) drops the warning
+// and this test goes RED.
+func TestPolicyLogInertOnDenyWarns(t *testing.T) {
+	cases := []struct {
+		name    string
+		who     string   // fully-qualified policy substring the warning carries
+		verdict string   // "deny" or "reject" the warning must name
+		want    []string // additional substrings (configured modes)
+		cmds    []string
+	}{
+		{
+			name:    "zone-pair reject with session-close (E1 verbatim)",
+			who:     "trust->untrust/p-reject",
+			verdict: "reject",
+			want:    []string{"session-close"},
+			cmds: append(append([]string{}, policyLogInertBaseZones...),
+				"set security policies from-zone trust to-zone untrust policy p-reject match source-address any",
+				"set security policies from-zone trust to-zone untrust policy p-reject match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy p-reject match application any",
+				"set security policies from-zone trust to-zone untrust policy p-reject then reject",
+				"set security policies from-zone trust to-zone untrust policy p-reject then log session-close",
+			),
+		},
+		{
+			name:    "zone-pair deny with session-init",
+			who:     "trust->untrust/p-deny",
+			verdict: "deny",
+			want:    []string{"session-init"},
+			cmds: append(append([]string{}, policyLogInertBaseZones...),
+				"set security policies from-zone trust to-zone untrust policy p-deny match source-address any",
+				"set security policies from-zone trust to-zone untrust policy p-deny match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy p-deny match application any",
+				"set security policies from-zone trust to-zone untrust policy p-deny then deny",
+				"set security policies from-zone trust to-zone untrust policy p-deny then log session-init",
+			),
+		},
+		{
+			name:    "zone-pair deny with both modes",
+			who:     "trust->untrust/p-both",
+			verdict: "deny",
+			want:    []string{"session-init", "session-close"},
+			cmds: append(append([]string{}, policyLogInertBaseZones...),
+				"set security policies from-zone trust to-zone untrust policy p-both match source-address any",
+				"set security policies from-zone trust to-zone untrust policy p-both match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy p-both match application any",
+				"set security policies from-zone trust to-zone untrust policy p-both then deny",
+				"set security policies from-zone trust to-zone untrust policy p-both then log session-init",
+				"set security policies from-zone trust to-zone untrust policy p-both then log session-close",
+			),
+		},
+		{
+			name:    "global reject with session-close",
+			who:     "global/g-reject",
+			verdict: "reject",
+			want:    []string{"session-close"},
+			cmds: append(append([]string{}, policyLogInertBaseZones...),
+				"set security policies global policy g-reject match source-address any",
+				"set security policies global policy g-reject match destination-address any",
+				"set security policies global policy g-reject match application any",
+				"set security policies global policy g-reject then reject",
+				"set security policies global policy g-reject then log session-close",
+			),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := policyLogInertWarning(t, tc.cmds)
+			if got == "" {
+				t.Fatalf("expected a #4373 per-policy inert-log warning, got none")
+			}
+			if !strings.Contains(got, tc.who) {
+				t.Errorf("warning %q missing policy id %q", got, tc.who)
+			}
+			if !strings.Contains(got, tc.verdict) {
+				t.Errorf("warning %q missing verdict %q", got, tc.verdict)
+			}
+			for _, w := range tc.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("warning %q missing mode %q", got, w)
+				}
+			}
+		})
+	}
+}
+
+// TestPolicyLogPermitNoInertWarn confirms the warning is gated on the verdict:
+// a `then permit` policy that configures `then log session-close` DOES install a
+// session for the close record to fire on, so NO inert warning is emitted — the
+// normal session-close logging path is unchanged.
+func TestPolicyLogPermitNoInertWarn(t *testing.T) {
+	cmds := append(append([]string{}, policyLogInertBaseZones...),
+		"set security policies from-zone trust to-zone untrust policy p-permit match source-address any",
+		"set security policies from-zone trust to-zone untrust policy p-permit match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy p-permit match application any",
+		"set security policies from-zone trust to-zone untrust policy p-permit then permit",
+		"set security policies from-zone trust to-zone untrust policy p-permit then log session-close",
+	)
+	if got := policyLogInertWarning(t, cmds); got != "" {
+		t.Fatalf("unexpected inert-log warning under `then permit`: %q", got)
+	}
+}
+
+// TestPolicyLogDenyNoLogNoWarn confirms the warning is gated on the log
+// selection: a `then reject` policy with NO `then log` does not carry inert log
+// flags, so no advisory fires (the advisory only surfaces a configured-but-inert
+// selection, not every deny/reject).
+func TestPolicyLogDenyNoLogNoWarn(t *testing.T) {
+	cmds := append(append([]string{}, policyLogInertBaseZones...),
+		"set security policies from-zone trust to-zone untrust policy p-silent match source-address any",
+		"set security policies from-zone trust to-zone untrust policy p-silent match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy p-silent match application any",
+		"set security policies from-zone trust to-zone untrust policy p-silent then reject",
+	)
+	if got := policyLogInertWarning(t, cmds); got != "" {
+		t.Fatalf("unexpected inert-log warning under a no-log `then reject`: %q", got)
+	}
+}

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -1438,6 +1438,15 @@ func ValidateConfig(cfg *Config) []string {
 	// must not brick a previously-committed config).
 	warnings = append(warnings, validateDefaultPolicyLogWarnings(cfg)...)
 
+	// #4373 (avo-review-007 E1): the per-policy analog of the default-policy log
+	// advisory above. A NAMED or GLOBAL policy with `then deny`/`then reject` plus
+	// `then log session-init`/`session-close` installs no session, so the RT_FLOW
+	// SESSION_CREATE/CLOSE record never fires — an operator who adds `then reject;
+	// then log session-close` expecting a close record is confused when none
+	// appears. The deny is logged unconditionally via the policy-deny RT_FLOW
+	// record instead. WARN-only (valid Junos; must not brick a committed config).
+	warnings = append(warnings, validatePolicyLogInertOnDenyWarnings(cfg)...)
+
 	// #4146 (H-1 slice c): warn when a `to-zone junos-host` policy expresses a
 	// constraint STRICTER than the coarse kernel host-inbound gate can enforce
 	// on the DIRECT host-bound path. Ordinary traffic to a firewall interface
@@ -1686,6 +1695,84 @@ func validateDefaultPolicyLogWarnings(cfg *Config) []string {
 			"is already logged via the policy-deny RT_FLOW record). These flags "+
 			"take effect only with `default-policy permit-all`",
 		strings.Join(modes, "/"), action)}
+}
+
+// validatePolicyLogInertOnDenyWarnings emits a WARN-only commit-time message
+// for each NAMED or GLOBAL security policy whose terminal action is deny/reject
+// yet configures `then log session-init` and/or `session-close` (#4373 E1,
+// avo-review-007). This is the per-policy analog of the default-policy advisory
+// above (validateDefaultPolicyLogWarnings, #3534).
+//
+// The confusion: an operator writes `then reject; then log session-close`
+// expecting a close record when the flow is rejected. But a deny/reject verdict
+// installs NO session, so the RT_FLOW SESSION_CREATE / SESSION_CLOSE records
+// those flags request never fire — session-close has no session to close.
+// The deny is instead logged unconditionally via the RT_FLOW policy-deny record
+// (userspace-dp emit_policy_deny_event fires on EVERY non-permit verdict, never
+// gated on a per-policy log flag), so `then log session-init` is redundant and
+// `then log session-close` is inert. `then log` session records fire only for a
+// `then permit` policy, whose admitted session the dataplane stamps the log
+// flags onto at install (the #2508 per-policy path). Without this advisory the
+// operator sees a policy that REPORTS session-close logging (REST/gRPC/CLI show
+// the flag) yet produces no close record — a silent observability gap.
+//
+// WARN-only: `then log` on a deny/reject is valid Junos syntax and a hard
+// reject would brick a previously-committed config (#1960 no-brick doctrine).
+// The bare-`then log` gate (validatePolicyLogActionStrict, #3060) still applies
+// independently. Iteration is over the ordered policy slices (zone-pair, then
+// global), so the warnings are stable across commits.
+func validatePolicyLogInertOnDenyWarnings(cfg *Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	var warnings []string
+	check := func(who string, pol *Policy) {
+		if pol == nil || pol.Log == nil {
+			return
+		}
+		if pol.Action != PolicyDeny && pol.Action != PolicyReject {
+			return
+		}
+		if !pol.Log.SessionInit && !pol.Log.SessionClose {
+			return
+		}
+		var modes []string
+		if pol.Log.SessionInit {
+			modes = append(modes, "session-init")
+		}
+		if pol.Log.SessionClose {
+			modes = append(modes, "session-close")
+		}
+		action := "deny"
+		if pol.Action == PolicyReject {
+			action = "reject"
+		}
+		warnings = append(warnings, fmt.Sprintf(
+			"security policy %s `then log %s` is inert under `then %s`: a "+
+				"deny/reject verdict installs no session, so no RT_FLOW "+
+				"session-init/session-close record is produced (the verdict is "+
+				"already logged via the policy-deny RT_FLOW record). `then log` "+
+				"session records fire only for a `then permit` policy (#4373)",
+			who, strings.Join(modes, "/"), action))
+	}
+	for _, zpp := range cfg.Security.Policies {
+		if zpp == nil {
+			continue
+		}
+		for _, pol := range zpp.Policies {
+			if pol == nil {
+				continue
+			}
+			check(fmt.Sprintf("%s->%s/%s", zpp.FromZone, zpp.ToZone, pol.Name), pol)
+		}
+	}
+	for _, pol := range cfg.Security.GlobalPolicies {
+		if pol == nil {
+			continue
+		}
+		check(fmt.Sprintf("global/%s", pol.Name), pol)
+	}
+	return warnings
 }
 
 // junosHostPolicySourceScoped reports whether a policy match carries a genuine


### PR DESCRIPTION
## Addresses #4373 (avo-review-007 E1) — Go config-layer half

**The confusion (E1, verbatim):** an operator writes a named/global policy
`then reject; then log session-close` expecting an RT_FLOW close record when a
flow is rejected. But a **deny/reject verdict installs NO session**, so the
requested `RT_FLOW_SESSION_CREATE` / `RT_FLOW_SESSION_CLOSE` records never fire
(session-close has no session to close). The deny is logged unconditionally via
the `RT_FLOW` **policy-deny** record instead. The policy still REPORTS
session-close logging on every operator surface (REST/gRPC/CLI) yet produces no
close record — a silent observability gap that reads as a bug.

**Verify-first:** the log RENDERING side was already unambiguous — a reject is
logged as `POLICY_DENY` (distinct reason, #3610) / `FILTER_LOG action=reject`,
never a misleading `SESSION_CLOSE` (which omits the action byte, #2513). I
confirmed in the Rust dataplane that `emit_policy_deny_event`
(`userspace-dp/src/afxdp/event_emit.rs`) fires on **every** non-permit verdict
and is never gated on a per-policy log flag, so both session-init (redundant)
and session-close (inert) mirror the default-policy advisory's rationale. The
remaining gap was **config-time**: the default-policy analog
(`validateDefaultPolicyLogWarnings`, #3534) warns on a deny-all/reject-all
default, but there was **no per-policy equivalent**.

## The fix (Go only)

`validatePolicyLogInertOnDenyWarnings` (`pkg/config/compiler_validate_warn.go`)
— a WARN-only commit advisory for each named or global policy whose action is
deny/reject and that carries a session-init/session-close `then log` selection,
naming the inert mode(s) and the verdict. Never an error (`then log` on a
deny/reject is valid Junos; a hard reject would brick a committed config —
#1960 no-brick). Wired into `ValidateConfig` right after the #3534
default-policy analog. The bare-`then log` gate (#3060) still applies
independently.

## Tests / validation

- `pkg/config/compiler_policy_log_inert_deny_4373_test.go` — zone-pair reject +
  session-close (E1 verbatim), deny + session-init, deny + both, global reject +
  session-close all **warn**; `then permit` + session-close and a no-log
  `then reject` **do not** warn (normal session-close logging unchanged).
- **RED-on-revert confirmed:** removing the `ValidateConfig` append makes
  `TestPolicyLogInertOnDenyWarns` fail on all four deny/reject cases; the
  negative gates stay green.
- `go test ./pkg/config/ ./pkg/logging/` green; `go build ./...`, `gofmt`,
  `go vet` clean.

## Deferred (Rust, separate cargo slice)

The E4/H2/H7 **live NoRoute/martian drop counter** (the dataplane half of the
same avo-review-007 remedy — its Go match-policies simulator advisory shipped in
#4504) and the **E6 IPv6 ext-header-denied counter** remain `userspace-dp`
(Rust) slices; a cargo lane is already busy, so this PR is Go-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi