### PR TITLE
config: strict-gate wiring canary + policy zone-matrix test (#4422)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -41335,3 +41335,31 @@ top.
   codex-r1.md, claude-smr-plan-r1.md, reviewer-ids.md restored),
   docs/userspace-dataplane-gaps.md, pkg/api/README.md,
   pkg/api/zone_counter_doc_ref_test.go, _Log.md
+
+- **Timestamp**: 2026-07-07
+- **Action**: #4422 high-value Go test-cov batch. Triaged the ~120-item LOW
+  test-coverage tracker: verified the named Go domains (filter cross-field /
+  port-except / actions / flex-match, NAT reversed-range + dport + pools, appid
+  tuple-overflow/source-port, flowexport multi-group wire-collision #3740,
+  observability descriptor/host-inbound/scoped-global, ddns, host-inbound
+  per-interface #3362, FBF ref/direction, ipsec/log/dhcp/sampling refs) are
+  ALREADY covered by this session's #4517-#4625 work — every strict gate and
+  secondary branch checked has a fail-on-revert test. Added the two genuinely
+  non-redundant contract tests: (1) TestEveryStrictCommitGateIsWired — a go/ast
+  completeness canary asserting every top-level validate*Strict(cfg *Config)
+  error gate (~80) is actually invoked in the compile path (catches the
+  "add-a-gate, forget-the-wire" silent commit-gate loss no per-issue test
+  catches; mirrors pkg/api TestCollectorDescriptorCoverage); (2)
+  TestPolicyZoneMatrixCompilesActionsIndependently — the #4422 policy
+  zone-matrix composition guard: mixed permit/deny/reject policies coexisting
+  in one transit zone-pair each keep their own action in config order, the
+  untrust->junos-host host-inbound context stays isolated, and the deny
+  no-match default is orthogonal. Both verified fail-on-revert (unwired
+  validateSourceNATPoolStrict -> canary RED naming it; reject->permit mapping
+  mutation -> matrix RED on t-reject). Rescoped #4422 to the concrete
+  remainder (Rust-cargo flow-cache dataplane tests; lab/smoke host-inbound
+  VLAN/dup-addr/HA + PBR multi-WAN live cells; doc/parity-label items).
+  go test ./pkg/config/ green; gofmt + vet clean. Doc: config-schema.md
+  "Strict commit-time validators" now documents the wiring canary.
+- **File(s)**: pkg/config/strict_gate_wiring_canary_test.go,
+  pkg/config/policy_zone_matrix_4422_test.go, docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -66,6 +66,19 @@ code-motion split — every `(compiler_validate_strict.go)` locator
 elsewhere in this document still names the correct, unchanged function, now
 in whichever sibling file holds it (grep the function name to find it).
 
+Each gate is a hand-wired `if err := validate<X>Strict(cfg); err != nil {
+... }` line in `runUniformGates` (`compiler_uniformgates.go`) / `compiler.go`.
+Adding a gate function without adding that invocation line leaves it DEAD —
+it compiles, its own unit test may still pass if it calls the function
+directly, yet the commit path never runs it and the misconfiguration it
+guards silently ships. `TestEveryStrictCommitGateIsWired`
+(`pkg/config/strict_gate_wiring_canary_test.go`, #4422) is the completeness
+canary that closes that gap: it parses the package source (`go/ast`),
+collects every top-level `func validate*Strict(cfg *Config) error`, and fails
+if any is never invoked in a non-test file. It mirrors the metrics-side
+`pkg/api` `TestCollectorDescriptorCoverage` idiom. So: define a new strict
+gate AND wire it into `runUniformGates`, or the canary goes red naming it.
+
 The live config-mode completers — `pkg/cli` `completeConfigWithDesc` and
 `pkg/grpcapi` `completeConfigPairs` — route `set` paths through
 `config.CompleteSetPathWithValues` over `setSchema`. `cmdtree.ConfigTopLevel`

--- a/pkg/config/policy_zone_matrix_4422_test.go
+++ b/pkg/config/policy_zone_matrix_4422_test.go
@@ -1,0 +1,114 @@
+package config
+
+import "testing"
+
+// TestPolicyZoneMatrixCompilesActionsIndependently is the #4422 policy
+// zone-matrix composition guard: permit / deny / reject policies that COEXIST
+// in one config each compile to their own terminal action, in config order,
+// with no cross-contamination between policies or between contexts (a transit
+// zone-pair vs a to-junos-host host-inbound zone-pair), and the no-match
+// default-policy scope is independent of the per-policy actions.
+//
+// The per-action gates are each covered in isolation (compiler_policy_then_*,
+// policy_terminal_action_3043, compiler_default_policy_3065). What NONE of them
+// exercises is the COMPOSITION: multiple policies of DIFFERENT actions in the
+// SAME zone-pair, plus a second (host-inbound) zone-pair, in one CompileConfig.
+// compilePolicy resolves each policy's Action from its own `then` block and
+// appends to a per-policy terminalActions slice; a regression that shared state
+// across policies (e.g. a package-level or zone-pair-scoped "last action", or a
+// reused/leaked terminalActions slice) would make a later policy's action bleed
+// onto an earlier one, or the transit reject bleed onto the host-inbound permit.
+// This test pins that each compiled Policy.Action is exactly the one authored,
+// in order, per context.
+//
+// FAIL-ON-REVERT: make compilePolicy resolve actions non-independently (e.g.
+// carry the previous policy's Action forward when a policy's own `then` is read,
+// or key the action off the zone-pair rather than the policy) and the ordered
+// per-policy assertions below go RED.
+func TestPolicyZoneMatrixCompilesActionsIndependently(t *testing.T) {
+	cmds := []string{
+		"set interfaces eth0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces eth1 unit 0 family inet address 10.0.1.1/24",
+		"set security zones security-zone trust interfaces eth0",
+		"set security zones security-zone untrust interfaces eth1",
+		// Transit zone-pair trust->untrust: three policies, three DIFFERENT
+		// terminal actions, authored in the order permit, deny, reject.
+		"set security policies from-zone trust to-zone untrust policy t-permit match source-address any",
+		"set security policies from-zone trust to-zone untrust policy t-permit match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy t-permit match application any",
+		"set security policies from-zone trust to-zone untrust policy t-permit then permit",
+		"set security policies from-zone trust to-zone untrust policy t-deny match source-address any",
+		"set security policies from-zone trust to-zone untrust policy t-deny match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy t-deny match application any",
+		"set security policies from-zone trust to-zone untrust policy t-deny then deny",
+		"set security policies from-zone trust to-zone untrust policy t-reject match source-address any",
+		"set security policies from-zone trust to-zone untrust policy t-reject match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy t-reject match application any",
+		"set security policies from-zone trust to-zone untrust policy t-reject then reject",
+		// Host-inbound context untrust->junos-host: a plain permit-any (which
+		// mirrors the coarse host-inbound gate, so it draws NO #4146 advisory
+		// warning) — its action must stay permit, isolated from the transit
+		// reject above.
+		"set security policies from-zone untrust to-zone junos-host policy h-permit match source-address any",
+		"set security policies from-zone untrust to-zone junos-host policy h-permit match destination-address any",
+		"set security policies from-zone untrust to-zone junos-host policy h-permit match application any",
+		"set security policies from-zone untrust to-zone junos-host policy h-permit then permit",
+		// A deny no-match default, independent of the per-policy actions.
+		"set security policies default-policy deny-all",
+	}
+
+	tree := buildPolicyTree(t, cmds)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig rejected a well-formed mixed-action policy matrix: %v", err)
+	}
+
+	// The transit zone-pair must carry exactly the three authored policies, in
+	// order, each with its own action.
+	transit := findZonePair(cfg.Security.Policies, "trust→untrust")
+	if transit == nil {
+		t.Fatal("transit zone-pair trust→untrust missing from compiled config")
+	}
+	wantTransit := []struct {
+		name string
+		act  PolicyAction
+	}{
+		{"t-permit", PolicyPermit},
+		{"t-deny", PolicyDeny},
+		{"t-reject", PolicyReject},
+	}
+	if len(transit.Policies) != len(wantTransit) {
+		t.Fatalf("transit zone-pair has %d policies, want %d", len(transit.Policies), len(wantTransit))
+	}
+	for i, w := range wantTransit {
+		got := transit.Policies[i]
+		if got.Name != w.name {
+			t.Fatalf("transit policy[%d] name = %q, want %q (config order not preserved)", i, got.Name, w.name)
+		}
+		if got.Action != w.act {
+			t.Errorf("transit policy %q action = %s, want %s (mixed-action cross-contamination)",
+				got.Name, policyActionName(got.Action), policyActionName(w.act))
+		}
+	}
+
+	// The host-inbound context is a SEPARATE zone-pair; its permit must not be
+	// contaminated by the transit reject.
+	host := findZonePair(cfg.Security.Policies, "untrust→junos-host")
+	if host == nil {
+		t.Fatal("junos-host zone-pair untrust→junos-host missing from compiled config")
+	}
+	if len(host.Policies) != 1 {
+		t.Fatalf("junos-host zone-pair has %d policies, want 1", len(host.Policies))
+	}
+	if hp := host.Policies[0]; hp.Name != "h-permit" || hp.Action != PolicyPermit {
+		t.Errorf("junos-host policy = %q/%s, want h-permit/permit (host-inbound context not isolated)",
+			hp.Name, policyActionName(hp.Action))
+	}
+
+	// The no-match default is deny, orthogonal to the explicit-policy actions
+	// (a permit policy in the transit pair must not flip the default open).
+	if cfg.Security.DefaultPolicy != PolicyDeny {
+		t.Errorf("default-policy = %s, want deny (default scope leaked from a per-policy action)",
+			policyActionName(cfg.Security.DefaultPolicy))
+	}
+}

--- a/pkg/config/strict_gate_wiring_canary_test.go
+++ b/pkg/config/strict_gate_wiring_canary_test.go
@@ -1,0 +1,145 @@
+package config
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestEveryStrictCommitGateIsWired is a completeness canary for the commit-time
+// strict-validation surface (#4422). The commit path enforces ~80 hand-wired
+// `validate<X>Strict(cfg *Config) error` gates, each an `if err :=
+// validate<X>Strict(cfg); err != nil { return ... }` line in
+// runUniformGates / compiler.go. Every one of those gates turns a silent
+// fail-open / fail-closed / split-brain misconfiguration into an operator-
+// visible commit error (dangling policer / prefix-list / routing-instance /
+// feed references, out-of-range NAT ports, never-match filter cross-fields,
+// unknown host-inbound tokens, and so on — see compiler_validate_strict*.go).
+//
+// The per-issue tests each assert that THEIR gate fires. NONE of them asserts
+// that the COMPLETE set is wired: if a new `validate<X>Strict(cfg *Config)
+// error` is added to compiler_validate_strict*.go but the author forgets the
+// one-line `if err := validate<X>Strict(cfg); err != nil { ... }` invocation in
+// the gate runner, the gate is DEAD — it compiles, its own unit test still
+// passes if that test calls the function directly, yet the commit path never
+// runs it and the misconfiguration it guards silently ships. That is exactly
+// the class of regression this canary catches. It mirrors the established
+// completeness-canary idiom in this codebase (pkg/api
+// TestCollectorDescriptorCoverage for Prometheus descriptors;
+// TestStrictValidationSetMatchesCatalogNames for the app-catalog drift guard).
+//
+// FAIL-ON-REVERT: delete (or comment out) any single
+// `if err := validate<X>Strict(cfg); err != nil { ... }` invocation in
+// compiler_uniformgates.go / compiler.go and this test names that gate as
+// UNWIRED and goes RED.
+//
+// Method: parse every non-test .go file in the package, collect the set of
+// top-level functions whose name ends in "Strict" and whose signature is
+// exactly `(cfg *Config) error` (the gate shape — helpers with other
+// signatures, e.g. validateHostInboundStanzaStrict(zone, ifName string, hib
+// *HostInboundTraffic), are intentionally excluded; they are reached through a
+// (cfg *Config) wrapper that IS a gate), then collect every call expression to
+// a same-named function. A defined gate that is never called anywhere in the
+// production source is unwired.
+func TestEveryStrictCommitGateIsWired(t *testing.T) {
+	fset := token.NewFileSet()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir(.): %v", err)
+	}
+
+	// defined: gate name -> "file:line" of its definition (for the error msg).
+	defined := map[string]string{}
+	// called: any function name that appears as a call target.
+	called := map[string]bool{}
+
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, perr := parser.ParseFile(fset, name, nil, 0)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", name, perr)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.FuncDecl:
+				if node.Recv == nil && strings.HasSuffix(node.Name.Name, "Strict") &&
+					isCfgConfigErrorGateSig(node.Type) {
+					defined[node.Name.Name] = fset.Position(node.Name.Pos()).String()
+				}
+			case *ast.CallExpr:
+				if id, ok := node.Fun.(*ast.Ident); ok {
+					called[id.Name] = true
+				}
+			}
+			return true
+		})
+	}
+
+	// Sanity floor: if the parse walk found far fewer gates than the ~80 the
+	// commit path wires today, the canary is silently mis-parsing (e.g. a build
+	// change moved the source) and would vacuously pass — fail loudly instead.
+	if len(defined) < 50 {
+		t.Fatalf("found only %d `(cfg *Config) error` strict gates; expected ~80 — "+
+			"the wiring canary is mis-parsing the package source and would give a "+
+			"false all-clear", len(defined))
+	}
+
+	var unwired []string
+	for gate, pos := range defined {
+		if !called[gate] {
+			unwired = append(unwired, gate+" (defined at "+pos+")")
+		}
+	}
+	if len(unwired) > 0 {
+		sort.Strings(unwired)
+		t.Fatalf("%d strict commit gate(s) are DEFINED but never invoked in the "+
+			"compile path — the gate is dead and the misconfiguration it guards "+
+			"silently ships (wire it into runUniformGates / compiler.go with an "+
+			"`if err := <gate>(cfg); err != nil { return ... }` line):\n  %s",
+			len(unwired), strings.Join(unwired, "\n  "))
+	}
+}
+
+// isCfgConfigErrorGateSig reports whether a function type is exactly the strict
+// commit-gate shape `func(cfg *Config) error`: one parameter of type *Config
+// and one result of the built-in type `error`. Anything else (extra params, a
+// non-*Config param, a non-error or multi-value result) is not a top-level gate
+// and is excluded from the defined set.
+func isCfgConfigErrorGateSig(ft *ast.FuncType) bool {
+	if ft.Params == nil || ft.Results == nil {
+		return false
+	}
+	// Exactly one parameter, of type *Config.
+	if len(ft.Params.List) != 1 {
+		return false
+	}
+	p := ft.Params.List[0]
+	if len(p.Names) != 1 {
+		return false
+	}
+	star, ok := p.Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	if id, ok := star.X.(*ast.Ident); !ok || id.Name != "Config" {
+		return false
+	}
+	// Exactly one result, of the built-in type error.
+	if len(ft.Results.List) != 1 {
+		return false
+	}
+	r := ft.Results.List[0]
+	if len(r.Names) != 0 { // a named result would still be fine, but gates use none
+		return false
+	}
+	id, ok := r.Type.(*ast.Ident)
+	return ok && id.Name == "error"
+}


### PR DESCRIPTION
Addresses #4422 (high-value Go test-cov batch; remainder rescoped on the issue).

## Context

#4422 is a ~120-item LOW test-coverage tracker from the audit. Triage found that this session's #4517-#4625 work **already drained the named Go domains** — every strict commit gate and secondary branch checked carries a fail-on-revert test:

- filter cross-field / port-except / actions / flex-match (#3723, #3297, #2399, #3203)
- NAT reversed-range / dport / DNAT+source pools (#3906, #3446, #3450)
- appid tuple-overflow + source-port (#3438, #3428, #3725, #2578)
- flowexport multi-group wire-collision (#3740)
- observability descriptor / host-inbound / scoped-global (`TestCollectorDescriptorCoverage`, #3698, #3286)
- ddns, per-interface host-inbound (#3362), FBF reference + direction (#2217, #3432), ipsec/log/dhcp/sampling references

Rather than duplicate that coverage, this PR adds the **two genuinely non-redundant contract tests** the per-issue suite does not express.

## Tests added

**1. `TestEveryStrictCommitGateIsWired`** (`strict_gate_wiring_canary_test.go`) — a `go/ast` completeness canary over the commit-time strict-validation surface. The compile path enforces ~80 hand-wired `if err := validate<X>Strict(cfg); err != nil { ... }` gates. The per-issue tests each assert **their** gate fires; none asserts the **complete set** is wired. Add a new `validate<X>Strict(cfg *Config) error` but forget the one-line invocation and the gate is **dead** — it compiles, its own unit test may still pass, yet the commit path never runs it and the misconfiguration it guards silently ships. The canary collects every top-level gate-shaped function and fails naming any never invoked in non-test code. Mirrors the metrics-side `pkg/api` `TestCollectorDescriptorCoverage` idiom. Green on master (all ~80 wired); **fail-on-revert verified** by unwiring `validateSourceNATPoolStrict` → canary red naming it.

**2. `TestPolicyZoneMatrixCompilesActionsIndependently`** (`policy_zone_matrix_4422_test.go`) — the #4422 policy zone-matrix composition guard. The per-action gates are covered in isolation; none exercises the **composition** of mixed permit/deny/reject policies coexisting in one config. Pins that three different-action policies in one transit zone-pair each keep their own action in config order (no cross-contamination), a `to-zone junos-host` host-inbound zone-pair stays isolated from the transit reject, and the deny no-match default is orthogonal. **Fail-on-revert verified** by a reject→permit mapping mutation → matrix red on the transit reject.

Doc: `config-schema.md` "Strict commit-time validators" now documents the wiring canary + the define-a-gate-must-wire-it invariant.

## Remainder (rescoped on #4422)

- **Rust-cargo** (`userspace-dp`): flow-cache DSCP/PCP cache-sensitivity + TTL-expired-with-policer
- **Lab/smoke** (on-cluster): host-inbound VLAN / duplicate-address / HA-failover smokes; PBR multi-WAN live cells
- **Doc/parity-label**: the "label as vsrx-parity" + "document X posture" items

## Validation

`go test ./pkg/config/` green; `gofmt` + `go vet` clean; both new tests demonstrated fail-on-revert then restored green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi