### PR TITLE
daemon: extract DHCP lease-sync fields into a sub-struct (#4407 inc 1)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -41441,3 +41441,31 @@ top.
   "Strict commit-time validators" now documents the wiring canary.
 - **File(s)**: pkg/config/strict_gate_wiring_canary_test.go,
   pkg/config/policy_zone_matrix_4422_test.go, docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-08
+- **Action**: #4407 increment 1 — extract the #2239 DHCP-server lease-sync
+  (PATH C) fields out of the Daemon god-struct into a named sub-struct.
+  Pure code motion, no behavior/locking/lifecycle change (Go compiler
+  enforces completeness). Moved the 5 flat fields dhcpLeaseSyncNowCh,
+  dhcpLeaseSyncInFlight, dhcpLeaseLastSentMu, dhcpLeaseLastSent4,
+  dhcpLeaseLastSent6 into a new dhcpLeaseSyncState{nowCh, inFlight,
+  lastSentMu, lastSent4, lastSent6} defined in daemon_dhcp_lease_sync.go
+  (co-located with the push/seed orchestration it backs). Access is now
+  d.dhcpLeaseSync.<field>. Chose this cluster because it has the cleanest
+  boundary of all candidate groups: all production access lives in ONE
+  file (daemon_dhcp_lease_sync.go) plus the single constructor in
+  daemon.go and one test composite literal — versus the fabric cluster
+  (15 fields across 5 files, ~96 refs) or the SNMP-reconcile cluster
+  (touches the ordering-sensitive daemon_apply.go the issue warns about).
+  Used a named sub-field (not an embed) since the access sites are bounded
+  — the explicit d.dhcpLeaseSync. qualifier is clearer than promotion.
+  IMPORTANT: left ipsecSANudgeCh (which was interleaved among the lease
+  fields) as a flat Daemon field — it is IPsec-SA-sync state, not
+  lease-sync. Validation: go build ./... clean; go vet ./pkg/daemon/...
+  clean; gofmt clean; go test ./pkg/daemon/... green (4.3s); race test of
+  the lease-sync suite green. Remaining #4407 increments (fabric, SNMP,
+  flowexport, DDNS-surfaceA, neighbor, archive, host-inbound, ...) tracked
+  on the issue; applyConfigLocked reconcile-ordering split deferred to a
+  /triple-review increment per the issue's warning.
+- **File(s)**: pkg/daemon/daemon.go, pkg/daemon/daemon_dhcp_lease_sync.go,
+  pkg/daemon/daemon_dhcp_lease_sync_test.go, pkg/daemon/README.md, _Log.md

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -41,6 +41,24 @@ the primary compile/apply gate.
 - `CompileHealth` — `daemon.go`. Snapshot of the most recent compile
   outcome; `pkg/api` consumes it for the `/health` endpoint.
 
+### Struct decomposition (#4407, in progress)
+
+The `Daemon` struct historically fused 150+ flat fields spanning ~15
+subsystems. It is being decomposed incrementally into per-subsystem
+sub-structs — pure code motion, no behavior/locking/lifecycle change (the
+Go compiler enforces completeness). Each increment groups one cohesive,
+self-contained field cluster and lands as its own reviewable PR; the
+tracker issue #4407 carries the remaining increments.
+
+- **Increment 1 — DHCP-server lease sync (PATH C, #2239):** the flat
+  `dhcpLeaseSync*` / `dhcpLeaseLast*` fields moved into
+  `dhcpLeaseSyncState` (defined in `daemon_dhcp_lease_sync.go`, the file
+  that owns the push/seed orchestration), reached as `d.dhcpLeaseSync.*`.
+  A named sub-field (not an embed) was used because the access sites are
+  bounded to that one file — the explicit `d.dhcpLeaseSync.` qualifier is
+  clearer than field promotion. `ipsecSANudgeCh` stayed a flat `Daemon`
+  field (it is IPsec-SA-sync state, not lease-sync).
+
 ## Cluster mode
 
 Detected by the presence of `/etc/xpf/node-id` (contents `0` or `1`).

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -141,23 +141,16 @@ type Daemon struct {
 	// once per provider so the operator sees why nothing publishes. Keyed by the
 	// provider name so a corrected commit (url added) re-arms the warning.
 	surfaceACheckIPNoURLWarned sync.Map
-	// #2239 HA DHCP-server lease sync (PATH C). The push loop runs on the
-	// RG-MASTER, reads the active lease set (Kea control socket → memfile
-	// fallback), and replicates it over the cluster sync channel. The standby
-	// holds the peer set in SessionSync.peerDHCPLeases{4,6} and seeds Kea on
-	// takeover. These mirror the ddnsReconcile* fields above. The loop talks
-	// ONLY to Kea's own socket + the cluster channel — never the
-	// userspace-helper control socket (CLAUDE.md rule).
-	dhcpLeaseSyncNowCh    chan struct{} // nudge: grant/commit/MASTER takeover
-	ipsecSANudgeCh        chan struct{} // nudge: peer (re)connect -> IPsec SA re-advertise (#4385)
-	dhcpLeaseSyncInFlight atomic.Bool   // no-freeze skip-if-in-flight guard
-	dhcpLeaseLastSentMu   sync.Mutex
-	dhcpLeaseLastSent4    string // last-pushed v4 set fingerprint (change-detect)
-	dhcpLeaseLastSent6    string // last-pushed v6 set fingerprint (change-detect)
-	feeds                 *feeds.Manager
-	rpm                   *rpm.Manager
-	rpmMu                 sync.Mutex // serializes reconcileRPM callers (#1827)
-	activeRPMHash         [32]byte   // config-hash gate for RPM re-apply (#1827)
+	// #2239 HA DHCP-server lease sync (PATH C). These fields were grouped
+	// into dhcpLeaseSyncState (see daemon_dhcp_lease_sync.go) as increment 1
+	// of the #4407 Daemon god-struct decomposition — grouping only, no
+	// behavior change. The mirrored ddnsReconcile* fields above remain flat.
+	dhcpLeaseSync  dhcpLeaseSyncState
+	ipsecSANudgeCh chan struct{} // nudge: peer (re)connect -> IPsec SA re-advertise (#4385)
+	feeds          *feeds.Manager
+	rpm            *rpm.Manager
+	rpmMu          sync.Mutex // serializes reconcileRPM callers (#1827)
+	activeRPMHash  [32]byte   // config-hash gate for RPM re-apply (#1827)
 	// rpmPinsFailed records that the last probe-pin install left at
 	// least one pin unprogrammed (#1895): the install is retried
 	// (without restarting probes) on hash-gated reconcileRPM calls AND
@@ -801,7 +794,7 @@ func New(opts Options) (*Daemon, error) {
 		reconcileNowCh:             make(chan struct{}, 1),
 		ddnsReconcileNowCh:         make(chan struct{}, 1),
 		surfaceAReconcileNowCh:     make(chan struct{}, 1),
-		dhcpLeaseSyncNowCh:         make(chan struct{}, 1),
+		dhcpLeaseSync:              dhcpLeaseSyncState{nowCh: make(chan struct{}, 1)},
 		ipsecSANudgeCh:             make(chan struct{}, 1),
 		syncReadyTimeout:           5 * time.Second,
 		linkByNameFn:               netlink.LinkByName,

--- a/pkg/daemon/daemon_dhcp_lease_sync.go
+++ b/pkg/daemon/daemon_dhcp_lease_sync.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -53,6 +55,23 @@ const (
 	// before seeding on takeover.
 	dhcpLeaseSeedSocketWait = 10 * time.Second
 )
+
+// dhcpLeaseSyncState groups the #2239 HA DHCP-server lease-sync (PATH C)
+// runtime state that used to live as flat dhcpLease* fields on Daemon
+// (#4407 god-struct decomposition, increment 1). The push loop runs on the
+// RG-MASTER, reads the active lease set (Kea control socket → memfile
+// fallback), and replicates it over the cluster sync channel; the standby
+// holds the peer set in SessionSync.peerDHCPLeases{4,6} and seeds Kea on
+// takeover. The loop talks ONLY to Kea's own socket + the cluster channel —
+// never the userspace-helper control socket (CLAUDE.md rule). Grouping only;
+// no field semantics, locking, or lifecycle changed.
+type dhcpLeaseSyncState struct {
+	nowCh      chan struct{} // nudge: grant/commit/MASTER takeover
+	inFlight   atomic.Bool   // no-freeze skip-if-in-flight guard
+	lastSentMu sync.Mutex
+	lastSent4  string // last-pushed v4 set fingerprint (change-detect)
+	lastSent6  string // last-pushed v6 set fingerprint (change-detect)
+}
 
 // dhcpLeaseSyncEnabled reports whether #2239 lease sync is configured for this
 // commit: a cluster with the `dhcp-lease-synchronization` knob set. Standalone
@@ -107,7 +126,7 @@ func (d *Daemon) runDHCPLeaseSyncLoop(ctx context.Context) {
 			d.dispatchDHCPLeasePush(ctx, true)
 		case <-change.C:
 			d.dispatchDHCPLeasePush(ctx, false)
-		case <-d.dhcpLeaseSyncNowCh:
+		case <-d.dhcpLeaseSync.nowCh:
 			// Nudge: commit or MASTER takeover or peer-connected → push now.
 			d.dispatchDHCPLeasePush(ctx, true)
 		}
@@ -119,11 +138,11 @@ func (d *Daemon) runDHCPLeaseSyncLoop(ctx context.Context) {
 // read can never wedge the loop. force=true bypasses the change-detect (full
 // re-push); force=false pushes only when the set changed since the last push.
 func (d *Daemon) dispatchDHCPLeasePush(ctx context.Context, force bool) {
-	if !d.dhcpLeaseSyncInFlight.CompareAndSwap(false, true) {
+	if !d.dhcpLeaseSync.inFlight.CompareAndSwap(false, true) {
 		return
 	}
 	go func() {
-		defer d.dhcpLeaseSyncInFlight.Store(false)
+		defer d.dhcpLeaseSync.inFlight.Store(false)
 		d.pushDHCPLeasesOnce(ctx, force)
 	}()
 }
@@ -175,20 +194,20 @@ func (d *Daemon) pushDHCPLeasesOnce(ctx context.Context, force bool) {
 // on-grant push, while the heartbeat (force=true) carries refreshed Remaining.
 func (d *Daemon) maybePushFamily(family int, leases []dhcpserver.SyncLease, force bool) {
 	fp := dhcpLeaseSetFingerprint(leases)
-	d.dhcpLeaseLastSentMu.Lock()
-	prev := d.dhcpLeaseLastSent4
+	d.dhcpLeaseSync.lastSentMu.Lock()
+	prev := d.dhcpLeaseSync.lastSent4
 	if family == 6 {
-		prev = d.dhcpLeaseLastSent6
+		prev = d.dhcpLeaseSync.lastSent6
 	}
 	changed := fp != prev
 	if force || changed {
 		if family == 6 {
-			d.dhcpLeaseLastSent6 = fp
+			d.dhcpLeaseSync.lastSent6 = fp
 		} else {
-			d.dhcpLeaseLastSent4 = fp
+			d.dhcpLeaseSync.lastSent4 = fp
 		}
 	}
-	d.dhcpLeaseLastSentMu.Unlock()
+	d.dhcpLeaseSync.lastSentMu.Unlock()
 	if !force && !changed {
 		return
 	}
@@ -215,11 +234,11 @@ func dhcpLeaseSetFingerprint(leases []dhcpserver.SyncLease) string {
 // MASTER takeover, peer reconnect). Non-blocking depth-1 send, coalescing a
 // burst. Safe before the loop starts.
 func (d *Daemon) nudgeDHCPLeaseSync() {
-	if d.dhcpLeaseSyncNowCh == nil {
+	if d.dhcpLeaseSync.nowCh == nil {
 		return
 	}
 	select {
-	case d.dhcpLeaseSyncNowCh <- struct{}{}:
+	case d.dhcpLeaseSync.nowCh <- struct{}{}:
 	default:
 	}
 }

--- a/pkg/daemon/daemon_dhcp_lease_sync_test.go
+++ b/pkg/daemon/daemon_dhcp_lease_sync_test.go
@@ -121,13 +121,13 @@ func leaseSyncTestDaemon(t *testing.T, sock4, sock6 string, withKnob bool) *Daem
 	ss := cluster.NewSessionSync("127.0.0.1:0", "127.0.0.1:0", nil)
 
 	d := &Daemon{
-		store:              s,
-		applySem:           semaphore.NewWeighted(1),
-		rgStates:           make(map[int]*rgStateMachine),
-		cluster:            cluster.NewManager(0, 1),
-		dhcpServer:         mgr,
-		sessionSync:        ss,
-		dhcpLeaseSyncNowCh: make(chan struct{}, 1),
+		store:         s,
+		applySem:      semaphore.NewWeighted(1),
+		rgStates:      make(map[int]*rgStateMachine),
+		cluster:       cluster.NewManager(0, 1),
+		dhcpServer:    mgr,
+		sessionSync:   ss,
+		dhcpLeaseSync: dhcpLeaseSyncState{nowCh: make(chan struct{}, 1)},
 	}
 	return d
 }


### PR DESCRIPTION
Addresses #4407 (increment 1: extract the #2239 DHCP-server lease-sync (PATH C) fields into `dhcpLeaseSyncState`; further increments tracked on the issue).

## What

Pure code motion — the first bounded increment of the #4407 `Daemon` god-struct decomposition. No behavior, locking, or lifecycle change; the Go compiler enforces field-access completeness.

Five flat `Daemon` fields — `dhcpLeaseSyncNowCh`, `dhcpLeaseSyncInFlight`, `dhcpLeaseLastSentMu`, `dhcpLeaseLastSent4`, `dhcpLeaseLastSent6` — are grouped into a new `dhcpLeaseSyncState{ nowCh, inFlight, lastSentMu, lastSent4, lastSent6 }`, defined in `daemon_dhcp_lease_sync.go` (co-located with the push/seed orchestration it backs) and reached as `d.dhcpLeaseSync.<field>`.

## Why this cluster

Of all the candidate groups (fabric forwarding = 15 fields across 5 files/~96 refs; SNMP reconcile = touches the ordering-sensitive `daemon_apply.go` the issue warns about; DDNS/flowexport = split across several files), the DHCP lease-sync cluster has the cleanest boundary: **every production access site lives in one file** (`daemon_dhcp_lease_sync.go`), plus the single constructor in `daemon.go` and one test composite literal.

- **Named sub-field, not an embed** — the access sites are bounded, so the explicit `d.dhcpLeaseSync.` qualifier is clearer than field promotion.
- `ipsecSANudgeCh`, which was physically interleaved among the lease fields, **stays a flat `Daemon` field** — it is IPsec-SA-sync state, not lease-sync.

## Scope discipline

The ordering-sensitive `applyConfigLocked` split (the #4378 commit-confirmed-on-demotion / deploy-wipes-CoS / #1956 networkd-after-teardown reconcile order the issue explicitly warns about) is **deliberately not touched** here — deferred to a later `/triple-review` increment on #4407.

## Validation

- `go build ./...` clean
- `go vet ./pkg/daemon/...` clean
- `gofmt` clean (only my three files; pre-existing deviations elsewhere untouched)
- `go test ./pkg/daemon/...` green
- `-race` test of the lease-sync suite green

Docs: `pkg/daemon/README.md` gains a "Struct decomposition (#4407)" note recording increment 1 and the embed-vs-named-field rationale.