### PR TITLE
daemon: extract neighborPeriodicGuards sub-struct (#4407 increment 2)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,24 @@
+## 2026-07-08 — #4407 increment 2: extract neighborPeriodicGuards sub-struct
+
+- **Timestamp**: 2026-07-08
+- **Action**: #4407 Daemon god-struct decomposition, increment 2. Grouped the
+  nine flat `runPeriodicNeighborResolution` supervision fields (#1780 Path A:
+  `neighborWarmupInFlight`, `resolveNeighborsInFlight`, `forceProbeInFlight`,
+  `cleanFailedInFlight`, the four `*LastSuccessNanos`, and
+  `neighborPeriodicLoopStarted`) into a new `neighborPeriodicGuards` sub-struct
+  defined in `daemon_neighbor.go` (the file that owns the supervision loop),
+  reached as `d.neighborGuards.*`. Dropped the now-redundant name prefixes
+  (`neighborWarmupInFlight`→`warmInFlight`, `resolveNeighborsInFlight`→
+  `resolveInFlight`, `neighborPeriodicLoopStarted`→`loopStarted`). Pure code
+  motion — no behavior/locking change; `runGuardedNeighborPhase` still takes
+  `&`-pointers to the addressable struct fields. `lastStandbyNeighborRefresh`
+  stayed flat (standby-refresh rate limit in `daemon_health.go`, a different
+  mechanism), mirroring increment 1's `ipsecSANudgeCh` decision.
+- **File(s)**: pkg/daemon/daemon.go, pkg/daemon/daemon_neighbor.go,
+  pkg/daemon/neighbor_periodic_guard_test.go, pkg/daemon/README.md, _Log.md
+- **Validation**: `go build ./...` clean; `go vet ./pkg/daemon/` clean;
+  `go test -race ./pkg/daemon/...` green; gofmt clean on the touched files.
+
 ## 2026-07-07 — #4228 Gap 2 follow-up: accept `buffer-size temporal <us>`
 
 - **Timestamp**: 2026-07-07

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -58,6 +58,22 @@ tracker issue #4407 carries the remaining increments.
   bounded to that one file — the explicit `d.dhcpLeaseSync.` qualifier is
   clearer than field promotion. `ipsecSANudgeCh` stayed a flat `Daemon`
   field (it is IPsec-SA-sync state, not lease-sync).
+- **Increment 2 — periodic neighbor-resolution guards (#1780 Path A):** the
+  nine flat supervision fields for `runPeriodicNeighborResolution` (the
+  per-phase in-flight overlap guards, the per-phase last-success UnixNano
+  timestamps feeding the `neighbor_periodic_last_success_age_seconds{phase}`
+  gauge, the loop-started gate, and the `warmNeighborCache` warmup guard)
+  moved into `neighborPeriodicGuards` (defined in `daemon_neighbor.go`, the
+  file that owns the supervision loop), reached as `d.neighborGuards.*`. The
+  fields keep their exact `atomic.Bool` / `atomic.Int64` types (dropping the
+  now-redundant `neighbor`/`Neighbor`/`Periodic` name prefixes), and
+  `runGuardedNeighborPhase` still takes `&`-pointers to the addressable struct
+  fields, so this is pure code motion — no behavior/locking change. A named
+  sub-field (not an embed) matches increment 1: every non-test access site is
+  bounded to `daemon_neighbor.go`. `lastStandbyNeighborRefresh` stayed a flat
+  `Daemon` field (like increment 1's `ipsecSANudgeCh`) — it is the
+  standby-side refresh rate limit read in `daemon_health.go`, a different
+  mechanism from the periodic-resolution supervision grouped here.
 
 ## Cluster mode
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -286,37 +286,24 @@ type Daemon struct {
 	syncPeerBulkPrimed               atomic.Bool
 	syncPeerConnected                atomic.Bool
 	lastStandbyNeighborRefresh       atomic.Int64
-	neighborWarmupInFlight           atomic.Bool
-	// #1780 Path A: per-phase supervision of runPeriodicNeighborResolution.
-	// Each periodic phase runs in a guarded goroutine so a hung netlink/probe
-	// syscall in one phase can never freeze the for-select loop (the observed
-	// 17.5h stall). In-flight bools skip a phase while a prior pass is still
-	// running (no overlap / netlink-socket leak — a stuck syscall can't be
-	// cancelled, so we leak at most one goroutine per phase, never a growing
-	// pile). The last-success UnixNano feeds the
-	// neighbor_periodic_last_success_age_seconds{phase} gauge so a stalled
-	// phase is observable. neighborWarmupInFlight (above) already follows this
-	// pattern for warmNeighborCache.
-	resolveNeighborsInFlight    atomic.Bool
-	forceProbeInFlight          atomic.Bool
-	cleanFailedInFlight         atomic.Bool
-	resolveLastSuccessNanos     atomic.Int64
-	forceProbeLastSuccessNanos  atomic.Int64
-	cleanFailedLastSuccessNanos atomic.Int64
-	warmLastSuccessNanos        atomic.Int64
-	// neighborPeriodicLoopStarted gates the phase-age gauge: it is set
-	// once runPeriodicNeighborResolution actually starts (the loop only
-	// runs when the dataplane is enabled with active config). Without it,
-	// a daemon that never starts the loop would report every phase as a
-	// forever-climbing "wedged" age — a false positive (Codex #1781 r1).
-	neighborPeriodicLoopStarted atomic.Bool
-	hbSuppressStart             atomic.Int64 // CLOCK_MONOTONIC nanos of first heartbeat suppression; 0 = inactive (#1792)
-	syncPrimeRetryGen           atomic.Uint64
-	syncReadyTimerGen           atomic.Uint64
-	syncReadyTimerMu            sync.Mutex
-	syncReadyTimer              *time.Timer
-	syncReadyTimeout            time.Duration
-	slogHandler                 *logging.SyslogSlogHandler
+	// neighborGuards groups the #1780 Path A per-phase supervision state for
+	// runPeriodicNeighborResolution (in-flight overlap guards, last-success
+	// timestamps, loop-started gate, plus the warmNeighborCache warmup guard).
+	// See neighborPeriodicGuards in daemon_neighbor.go. This is increment 2 of
+	// the #4407 Daemon god-struct decomposition — pure field grouping, no
+	// behavior/locking change; the fields keep their exact atomic types and are
+	// reached as d.neighborGuards.<field>. lastStandbyNeighborRefresh (above)
+	// stays a flat Daemon field: it is the standby-side refresh rate limit read
+	// in daemon_health.go, a different mechanism from the periodic-resolution
+	// supervision grouped here.
+	neighborGuards    neighborPeriodicGuards
+	hbSuppressStart   atomic.Int64 // CLOCK_MONOTONIC nanos of first heartbeat suppression; 0 = inactive (#1792)
+	syncPrimeRetryGen atomic.Uint64
+	syncReadyTimerGen atomic.Uint64
+	syncReadyTimerMu  sync.Mutex
+	syncReadyTimer    *time.Timer
+	syncReadyTimeout  time.Duration
+	slogHandler       *logging.SyslogSlogHandler
 	// #3932: the flow-traceoptions writer is published through an atomic
 	// pointer read lock-free by a SINGLE stable EventReader callback that
 	// traceCBOnce registers exactly once. Each commit that changes

--- a/pkg/daemon/daemon_neighbor.go
+++ b/pkg/daemon/daemon_neighbor.go
@@ -376,6 +376,45 @@ func (d *Daemon) cleanFailedNeighbors() int {
 //     session-derived neighbor cache entries so standby forwarding stays ready
 //     without activation-time warmup.
 //
+// neighborPeriodicGuards groups the #1780 Path A per-phase supervision state
+// for runPeriodicNeighborResolution. Each periodic phase runs in a guarded
+// goroutine so a hung netlink/probe syscall in one phase can never freeze the
+// for-select loop (the observed 17.5h stall). The in-flight bools skip a phase
+// while a prior pass is still running (no overlap / netlink-socket leak — a
+// stuck syscall can't be cancelled, so we leak at most one goroutine per phase,
+// never a growing pile). The *LastSuccessNanos UnixNano feeds the
+// neighbor_periodic_last_success_age_seconds{phase} gauge so a stalled phase is
+// observable.
+//
+// This type was extracted from the flat Daemon fields as increment 2 of the
+// #4407 Daemon god-struct decomposition — pure field grouping, no
+// behavior/locking change. The fields keep their exact atomic types and are
+// reached as d.neighborGuards.<field>; the runGuardedNeighborPhase helper still
+// takes &-pointers to the addressable struct fields.
+type neighborPeriodicGuards struct {
+	// warmInFlight guards warmNeighborCache (the HA session-walk warmup) so a
+	// pass that exceeds one tick interval does not overlap itself;
+	// warmLastSuccessNanos records its last successful completion.
+	warmInFlight atomic.Bool
+	// resolveInFlight / forceProbeInFlight / cleanFailedInFlight are the
+	// per-phase overlap guards for the resolve, force-probe, and clean phases.
+	resolveInFlight     atomic.Bool
+	forceProbeInFlight  atomic.Bool
+	cleanFailedInFlight atomic.Bool
+	// *LastSuccessNanos hold the wall-clock UnixNano of each phase's last
+	// successful completion (0 = never), feeding the phase-age watchdog gauge.
+	resolveLastSuccessNanos     atomic.Int64
+	forceProbeLastSuccessNanos  atomic.Int64
+	cleanFailedLastSuccessNanos atomic.Int64
+	warmLastSuccessNanos        atomic.Int64
+	// loopStarted gates the phase-age gauge: it is set once
+	// runPeriodicNeighborResolution actually starts (the loop only runs when
+	// the dataplane is enabled with active config). Without it, a daemon that
+	// never starts the loop would report every phase as a forever-climbing
+	// "wedged" age — a false positive (Codex #1781 r1).
+	loopStarted atomic.Bool
+}
+
 // NeighborPeriodicPhaseAges returns, per periodic-neighbor-maintenance phase,
 // the seconds since that phase last completed successfully — the #1780 Path A
 // stall diagnostic. A phase frozen by a hung netlink/probe syscall shows a
@@ -391,7 +430,7 @@ func (d *Daemon) cleanFailedNeighbors() int {
 // (maintainClusterNeighborReadiness no-ops when d.cluster == nil and so never
 // updates warmLastSuccessNanos).
 func (d *Daemon) NeighborPeriodicPhaseAges() map[string]float64 {
-	if !d.neighborPeriodicLoopStarted.Load() {
+	if !d.neighborGuards.loopStarted.Load() {
 		return nil
 	}
 	now := time.Now()
@@ -412,14 +451,14 @@ func (d *Daemon) NeighborPeriodicPhaseAges() map[string]float64 {
 		return sec
 	}
 	ages := map[string]float64{
-		"resolve":      age(d.resolveLastSuccessNanos.Load()),
-		"force_probe":  age(d.forceProbeLastSuccessNanos.Load()),
-		"clean_failed": age(d.cleanFailedLastSuccessNanos.Load()),
+		"resolve":      age(d.neighborGuards.resolveLastSuccessNanos.Load()),
+		"force_probe":  age(d.neighborGuards.forceProbeLastSuccessNanos.Load()),
+		"clean_failed": age(d.neighborGuards.cleanFailedLastSuccessNanos.Load()),
 	}
 	// The warm phase only exists under HA; reporting it standalone would be a
 	// forever-climbing false "wedge".
 	if d.cluster != nil {
-		ages["warm"] = age(d.warmLastSuccessNanos.Load())
+		ages["warm"] = age(d.neighborGuards.warmLastSuccessNanos.Load())
 	}
 	return ages
 }
@@ -453,7 +492,7 @@ func (d *Daemon) runPeriodicNeighborResolution(ctx context.Context) {
 	// Mark the loop live so NeighborPeriodicPhaseAges reports phase ages only
 	// once supervision is actually running (avoids the never-started false
 	// positive — Codex #1781 r1).
-	d.neighborPeriodicLoopStarted.Store(true)
+	d.neighborGuards.loopStarted.Store(true)
 
 	// #1780 Path A: each phase runs via runGuardedNeighborPhase (a guarded
 	// goroutine) so one hung netlink/probe phase cannot freeze this loop.
@@ -489,12 +528,12 @@ func (d *Daemon) runPeriodicNeighborResolution(ctx context.Context) {
 	// resolveTick is the 15s pass: resolve + force-probe (both guarded) +
 	// maintain. cleanTick is the 5s pass: clean (guarded).
 	resolveTick := func() {
-		d.runGuardedNeighborPhase(&d.resolveNeighborsInFlight, &d.resolveLastSuccessNanos, resolvePass)
-		d.runGuardedNeighborPhase(&d.forceProbeInFlight, &d.forceProbeLastSuccessNanos, forceProbePass)
+		d.runGuardedNeighborPhase(&d.neighborGuards.resolveInFlight, &d.neighborGuards.resolveLastSuccessNanos, resolvePass)
+		d.runGuardedNeighborPhase(&d.neighborGuards.forceProbeInFlight, &d.neighborGuards.forceProbeLastSuccessNanos, forceProbePass)
 		maintainPass()
 	}
 	cleanTick := func() {
-		d.runGuardedNeighborPhase(&d.cleanFailedInFlight, &d.cleanFailedLastSuccessNanos, cleanPass)
+		d.runGuardedNeighborPhase(&d.neighborGuards.cleanFailedInFlight, &d.neighborGuards.cleanFailedLastSuccessNanos, cleanPass)
 	}
 
 	// Immediate first run — don't wait for first tick. force-probe is
@@ -502,7 +541,7 @@ func (d *Daemon) runPeriodicNeighborResolution(ctx context.Context) {
 	// at startup; it joins on the first 15s tick with a non-overlapping set),
 	// so the immediate pass is resolve + maintain + clean, matching the
 	// pre-#1780 startup sequence exactly.
-	d.runGuardedNeighborPhase(&d.resolveNeighborsInFlight, &d.resolveLastSuccessNanos, resolvePass)
+	d.runGuardedNeighborPhase(&d.neighborGuards.resolveInFlight, &d.neighborGuards.resolveLastSuccessNanos, resolvePass)
 	maintainPass()
 	cleanTick()
 
@@ -552,13 +591,13 @@ func (d *Daemon) maintainClusterNeighborReadiness() {
 	// keeps the snapshot in sync with kernel via netlink events,
 	// and the periodic forceProbeNeighbors tick keeps kernel entries
 	// fresh via proactive ARP/NS.
-	if !d.neighborWarmupInFlight.CompareAndSwap(false, true) {
+	if !d.neighborGuards.warmInFlight.CompareAndSwap(false, true) {
 		return
 	}
 	go func() {
 		defer func() {
-			d.warmLastSuccessNanos.Store(time.Now().UnixNano())
-			d.neighborWarmupInFlight.Store(false)
+			d.neighborGuards.warmLastSuccessNanos.Store(time.Now().UnixNano())
+			d.neighborGuards.warmInFlight.Store(false)
 		}()
 		d.warmNeighborCache()
 	}()

--- a/pkg/daemon/neighbor_periodic_guard_test.go
+++ b/pkg/daemon/neighbor_periodic_guard_test.go
@@ -119,7 +119,7 @@ func TestNeighborPeriodicLoopKeepsTickingWhilePhaseWedged(t *testing.T) {
 	// resolveTick dispatches a phase that wedges forever (models a stuck
 	// netlink syscall) through the real guarded-goroutine helper.
 	resolveTick := func() {
-		d.runGuardedNeighborPhase(&d.resolveNeighborsInFlight, &d.resolveLastSuccessNanos, func() {
+		d.runGuardedNeighborPhase(&d.neighborGuards.resolveInFlight, &d.neighborGuards.resolveLastSuccessNanos, func() {
 			resolveStarted.Store(true)
 			<-release
 		})
@@ -138,7 +138,7 @@ func TestNeighborPeriodicLoopKeepsTickingWhilePhaseWedged(t *testing.T) {
 	}
 	// The wedged resolve phase stayed in flight — no relaunch, no panic, and
 	// crucially the loop kept servicing the clean ticker.
-	if !d.resolveNeighborsInFlight.Load() {
+	if !d.neighborGuards.resolveInFlight.Load() {
 		t.Fatal("expected the wedged resolve phase to remain in-flight")
 	}
 
@@ -156,7 +156,7 @@ func TestNeighborPeriodicPhaseAgesReflectsStall(t *testing.T) {
 		t.Fatalf("expected nil phase ages before loop start, got %v", ages)
 	}
 
-	d.neighborPeriodicLoopStarted.Store(true)
+	d.neighborGuards.loopStarted.Store(true)
 
 	// All phases never-run: each reports ~age-since-start (~30s), proving a
 	// phase that never completes still flags rather than reading zero. warm is
@@ -176,7 +176,7 @@ func TestNeighborPeriodicPhaseAgesReflectsStall(t *testing.T) {
 	// Mark resolve just-completed; its age drops near zero while the others
 	// keep climbing from start — the healthy-vs-stalled contrast operators
 	// read off the gauge.
-	d.resolveLastSuccessNanos.Store(time.Now().UnixNano())
+	d.neighborGuards.resolveLastSuccessNanos.Store(time.Now().UnixNano())
 	ages = d.NeighborPeriodicPhaseAges()
 	if ages["resolve"] > 2 {
 		t.Fatalf("just-completed resolve phase reported age %.1fs; want ~0", ages["resolve"])
@@ -187,7 +187,7 @@ func TestNeighborPeriodicPhaseAgesReflectsStall(t *testing.T) {
 
 	// A last-success timestamp in the future (models a backward clock step)
 	// must clamp to 0, not report a negative age (Copilot #1781 r2).
-	d.cleanFailedLastSuccessNanos.Store(time.Now().Add(10 * time.Second).UnixNano())
+	d.neighborGuards.cleanFailedLastSuccessNanos.Store(time.Now().Add(10 * time.Second).UnixNano())
 	if got := d.NeighborPeriodicPhaseAges()["clean_failed"]; got < 0 {
 		t.Fatalf("backward-clock-step age not clamped: got %.3fs, want >= 0", got)
 	}


### PR DESCRIPTION
Addresses #4407 (increment 2: extract the periodic neighbor-resolution guard fields; further increments tracked).

## What

Second increment of the #4407 `Daemon` god-struct decomposition (increment 1 = DHCP lease-sync, #4631, merged). Pure code motion — no behavior, locking, or lifecycle change; the Go compiler enforces that every access site is updated.

Groups the nine flat supervision fields for `runPeriodicNeighborResolution` (#1780 Path A) into a new `neighborPeriodicGuards` sub-struct defined in `daemon_neighbor.go` (the file that owns the supervision loop), reached as `d.neighborGuards.*`:

- per-phase in-flight overlap guards (`warmInFlight`, `resolveInFlight`, `forceProbeInFlight`, `cleanFailedInFlight`)
- per-phase last-success UnixNano timestamps feeding the `neighbor_periodic_last_success_age_seconds{phase}` gauge
- the `loopStarted` gate

The now-redundant `neighbor`/`Neighbor`/`Periodic` name prefixes were dropped (matching increment 1's convention). Fields keep their exact `atomic.Bool` / `atomic.Int64` types; `runGuardedNeighborPhase` still takes `&`-pointers to the addressable struct fields.

A named sub-field (not an embed) was used because every non-test access site is bounded to `daemon_neighbor.go`. `lastStandbyNeighborRefresh` stayed flat (like increment 1's `ipsecSANudgeCh`) — it is the standby-side refresh rate limit read in `daemon_health.go`, a different mechanism.

## Fields moved / access sites

- `daemon.go`: 9 flat fields → 1 `neighborGuards neighborPeriodicGuards` sub-field
- `daemon_neighbor.go`: sub-struct type definition + 13 access sites
- `neighbor_periodic_guard_test.go`: 5 access sites

## Validation

- `go build ./...` clean
- `go vet ./pkg/daemon/` clean
- `go test -race ./pkg/daemon/...` green
- gofmt clean on the touched files
- Docs: `pkg/daemon/README.md` "Struct decomposition (#4407)" subsection + `_Log.md`

## What remains

Further increments tracked on #4407 (candidates: flowexport reconcile, DDNS/Surface-A, archive timer, host-inbound fail-open maps, direct-mode VIP state). The `applyConfigLocked` reconcile-ordering split is deliberately left for /triple-review per the issue's ordering warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi