### PR TITLE
daemon: extract archiveTimerState sub-struct (#4407 increment 3)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-07-08 — #4407 increment 3: extract archiveTimerState sub-struct
+
+- **Timestamp**: 2026-07-08
+- **Action**: #4407 Daemon god-struct decomposition, increment 3. Grouped the
+  four flat periodic configuration-archival timer fields (#4078:
+  `archiveTimerMu`, `archiveTimerKey`, `archiveTimerStop`, `archiveNewTicker`)
+  into a new `archiveTimerState` sub-struct defined in
+  `daemon_archive_timer.go` (the file that owns the reconcile/run/stop
+  lifecycle), reached as `d.archiveTimer.*` with the fields renamed
+  `mu`/`key`/`stop`/`newTicker`. Pure code motion — no behavior/locking
+  change; the fields keep their exact types. Renaming the field to
+  `d.archiveTimer.key` also removes the prior confusing collision between the
+  old `archiveTimerKey` field and the package-level `archiveTimerKey(interval,
+  sites)` hash-gate helper (kept as-is). `archiveTransfer` stayed flat (the
+  one-shot transfer-on-commit upload seam used in `daemon_flow.go`, a different
+  mechanism), mirroring increment 1's `ipsecSANudgeCh` / increment 2's
+  `lastStandbyNeighborRefresh` decisions.
+- **File(s)**: pkg/daemon/daemon.go, pkg/daemon/daemon_archive_timer.go,
+  pkg/daemon/archive_timer_4078_test.go, pkg/daemon/README.md, _Log.md
+- **Validation**: `go build ./...` clean; `go vet ./pkg/daemon/...` clean;
+  `go test -race ./pkg/daemon/...` green; gofmt clean on the touched files.
+
 ## 2026-07-08 — #4407 increment 2: extract neighborPeriodicGuards sub-struct
 
 - **Timestamp**: 2026-07-08

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -74,6 +74,23 @@ tracker issue #4407 carries the remaining increments.
   `Daemon` field (like increment 1's `ipsecSANudgeCh`) — it is the
   standby-side refresh rate limit read in `daemon_health.go`, a different
   mechanism from the periodic-resolution supervision grouped here.
+- **Increment 3 — periodic configuration-archival timer (#4078):** the four
+  flat supervision fields for the `system archival configuration
+  transfer-interval` timer (`archiveTimerMu`, `archiveTimerKey`,
+  `archiveTimerStop`, `archiveNewTicker`) moved into `archiveTimerState`
+  (defined in `daemon_archive_timer.go`, the file that owns the
+  reconcile/run/stop lifecycle), reached as `d.archiveTimer.*` (fields renamed
+  `mu`/`key`/`stop`/`newTicker`). The fields keep their exact types, so this is
+  pure code motion — no behavior/locking change. A named sub-field (not an
+  embed) matches increments 1 and 2: every access site is bounded to
+  `daemon_archive_timer.go` (plus its `archive_timer_4078_test.go`), and the
+  `d.archiveTimer.key` qualifier additionally removes the prior confusing
+  collision between the old `archiveTimerKey` field and the still-flat
+  package-level `archiveTimerKey(interval, sites)` hash-gate helper.
+  `archiveTransfer` stayed a flat `Daemon` field (like increment 1's
+  `ipsecSANudgeCh` and increment 2's `lastStandbyNeighborRefresh`) — it is the
+  one-shot transfer-on-commit upload seam used by `archiveConfig` in
+  `daemon_flow.go`, a different mechanism from the periodic timer grouped here.
 
 ## Cluster mode
 

--- a/pkg/daemon/archive_timer_4078_test.go
+++ b/pkg/daemon/archive_timer_4078_test.go
@@ -36,8 +36,10 @@ func storeWithHost(t *testing.T, host string) (*Daemon, chan string, chan time.T
 	d := &Daemon{
 		store: store,
 		opts:  Options{ConfigFile: filepath.Join(dir, "xpf.conf")},
-		archiveNewTicker: func(time.Duration) (<-chan time.Time, func()) {
-			return tickCh, func() {}
+		archiveTimer: archiveTimerState{
+			newTicker: func(time.Duration) (<-chan time.Time, func()) {
+				return tickCh, func() {}
+			},
 		},
 		archiveTransfer: func(_ context.Context, srcPath, _ string) error {
 			b, _ := os.ReadFile(srcPath)
@@ -71,9 +73,9 @@ func TestArchiveTimerFiresPeriodicArchive(t *testing.T) {
 	d.reconcileArchiveTimer(cfg)
 	t.Cleanup(d.stopArchiveTimer)
 
-	d.archiveTimerMu.Lock()
-	armed := d.archiveTimerStop != nil
-	d.archiveTimerMu.Unlock()
+	d.archiveTimer.mu.Lock()
+	armed := d.archiveTimer.stop != nil
+	d.archiveTimer.mu.Unlock()
 	if !armed {
 		t.Fatal("timer not armed for transfer-interval + sites")
 	}
@@ -115,18 +117,18 @@ func TestArchiveTimerReschedulesAndStops(t *testing.T) {
 	}
 	d.reconcileArchiveTimer(cfg1)
 
-	d.archiveTimerMu.Lock()
-	gen1 := d.archiveTimerStop
-	d.archiveTimerMu.Unlock()
+	d.archiveTimer.mu.Lock()
+	gen1 := d.archiveTimer.stop
+	d.archiveTimer.mu.Unlock()
 	if gen1 == nil {
 		t.Fatal("timer not armed by cfg1")
 	}
 
 	// Unchanged config → same generation, no bounce.
 	d.reconcileArchiveTimer(cfg1)
-	d.archiveTimerMu.Lock()
-	same := d.archiveTimerStop
-	d.archiveTimerMu.Unlock()
+	d.archiveTimer.mu.Lock()
+	same := d.archiveTimer.stop
+	d.archiveTimer.mu.Unlock()
 	if same != gen1 {
 		t.Fatal("healthy timer bounced on an unchanged config (hash gate broken)")
 	}
@@ -143,9 +145,9 @@ func TestArchiveTimerReschedulesAndStops(t *testing.T) {
 	default:
 		t.Fatal("old timer not stopped on reschedule")
 	}
-	d.archiveTimerMu.Lock()
-	gen2 := d.archiveTimerStop
-	d.archiveTimerMu.Unlock()
+	d.archiveTimer.mu.Lock()
+	gen2 := d.archiveTimer.stop
+	d.archiveTimer.mu.Unlock()
 	if gen2 == nil || gen2 == gen1 {
 		t.Fatal("no fresh timer armed after reschedule")
 	}
@@ -157,9 +159,9 @@ func TestArchiveTimerReschedulesAndStops(t *testing.T) {
 	default:
 		t.Fatal("timer not stopped when transfer-interval removed")
 	}
-	d.archiveTimerMu.Lock()
-	after := d.archiveTimerStop
-	d.archiveTimerMu.Unlock()
+	d.archiveTimer.mu.Lock()
+	after := d.archiveTimer.stop
+	d.archiveTimer.mu.Unlock()
 	if after != nil {
 		t.Fatal("timer still armed after removal")
 	}
@@ -177,9 +179,9 @@ func TestArchiveTimerRequiresSitesAndPositiveInterval(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.System.Archival = &config.ArchivalConfig{TransferInterval: 30}
 	d.reconcileArchiveTimer(cfg)
-	d.archiveTimerMu.Lock()
-	armed := d.archiveTimerStop != nil
-	d.archiveTimerMu.Unlock()
+	d.archiveTimer.mu.Lock()
+	armed := d.archiveTimer.stop != nil
+	d.archiveTimer.mu.Unlock()
 	if armed {
 		t.Fatal("timer armed with no archive-sites")
 	}
@@ -191,9 +193,9 @@ func TestArchiveTimerRequiresSitesAndPositiveInterval(t *testing.T) {
 		ArchiveSites:     []string{"scp://user@host:/archive/"},
 	}
 	d.reconcileArchiveTimer(cfg2)
-	d.archiveTimerMu.Lock()
-	armed2 := d.archiveTimerStop != nil
-	d.archiveTimerMu.Unlock()
+	d.archiveTimer.mu.Lock()
+	armed2 := d.archiveTimer.stop != nil
+	d.archiveTimer.mu.Unlock()
 	if armed2 {
 		t.Fatal("timer armed for transfer-on-commit-only (interval 0)")
 	}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -639,20 +639,23 @@ type Daemon struct {
 	archiveTransfer func(ctx context.Context, srcPath, dest string) error
 
 	// --- periodic configuration-archival timer (#4078) ---
-	// archiveTimerMu guards archiveTimerKey + archiveTimerStop.
-	archiveTimerMu sync.Mutex
-	// archiveTimerKey is the (interval|sites) hash the running periodic-archival
-	// timer was armed for; "" ⇒ no timer running. reconcileArchiveTimer compares
-	// against it so an unrelated commit never bounces a healthy timer.
-	archiveTimerKey string
-	// archiveTimerStop is closed to stop the running periodic-archival goroutine
-	// (reschedule on a transfer-interval/site change, or shutdown). nil ⇒ none.
-	archiveTimerStop chan struct{}
-	// archiveNewTicker builds the periodic-archival tick channel + a stop func.
-	// nil ⇒ realArchiveTicker (a wall-clock time.Ticker). Overridable so tests
-	// drive the periodic archive deterministically without a wall-clock wait
-	// and assert it reuses the archiveToSites transport (#4078).
-	archiveNewTicker func(d time.Duration) (<-chan time.Time, func())
+	// archiveTimer groups the periodic-archival timer supervision state: the
+	// (interval|sites) hash-gate key, the per-generation stop channel, their
+	// guarding mutex, and the tick-source seam. See archiveTimerState in
+	// daemon_archive_timer.go, the file that owns the reconcile/run/stop
+	// lifecycle. This is increment 3 of the #4407 Daemon god-struct
+	// decomposition — pure field grouping, no behavior/locking change; the
+	// fields keep their exact types and are reached as d.archiveTimer.<field>.
+	// A named sub-field (not an embed) matches increments 1 and 2: every access
+	// site is bounded to daemon_archive_timer.go (plus its test), and the
+	// d.archiveTimer.key qualifier also removes the prior confusing collision
+	// with the package-level archiveTimerKey(interval, sites) helper function.
+	// The transfer-on-commit archiveTransfer seam above stays a flat Daemon
+	// field — it is the one-shot upload transport (used by archiveConfig in
+	// daemon_flow.go), a different mechanism from the periodic timer grouped
+	// here (mirroring how increments 1 and 2 kept ipsecSANudgeCh /
+	// lastStandbyNeighborRefresh flat).
+	archiveTimer archiveTimerState
 
 	// --- SNMP link-state monitor seams (#3950) ---
 	// linkStateSubscribe starts a netlink link-update subscription for the

--- a/pkg/daemon/daemon_archive_timer.go
+++ b/pkg/daemon/daemon_archive_timer.go
@@ -4,14 +4,39 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
 )
 
-// realArchiveTicker is the default archiveNewTicker seam: a wall-clock
-// time.Ticker firing every d. Tests override d.archiveNewTicker to drive the
-// periodic archive deterministically without a wall-clock wait (#4078).
+// archiveTimerState groups the #4078 periodic configuration-archival timer
+// supervision state, extracted from the Daemon god-struct as increment 3 of
+// the #4407 decomposition (pure field grouping — no behavior/locking change).
+// It is co-located with the reconcile/run/stop lifecycle that owns it and is
+// reached as d.archiveTimer.<field>; naming the sub-field (rather than an
+// embed) also avoids the prior collision between the old archiveTimerKey field
+// and the package-level archiveTimerKey(interval, sites) helper.
+type archiveTimerState struct {
+	// mu guards key + stop.
+	mu sync.Mutex
+	// key is the (interval|sites) hash the running periodic-archival timer was
+	// armed for; "" ⇒ no timer running. reconcileArchiveTimer compares against
+	// it so an unrelated commit never bounces a healthy timer.
+	key string
+	// stop is closed to stop the running periodic-archival goroutine
+	// (reschedule on a transfer-interval/site change, or shutdown). nil ⇒ none.
+	stop chan struct{}
+	// newTicker builds the periodic-archival tick channel + a stop func. nil ⇒
+	// realArchiveTicker (a wall-clock time.Ticker). Overridable so tests drive
+	// the periodic archive deterministically without a wall-clock wait and
+	// assert it reuses the archiveToSites transport (#4078).
+	newTicker func(d time.Duration) (<-chan time.Time, func())
+}
+
+// realArchiveTicker is the default archiveTimer.newTicker seam: a wall-clock
+// time.Ticker firing every d. Tests override d.archiveTimer.newTicker to drive
+// the periodic archive deterministically without a wall-clock wait (#4078).
 func realArchiveTicker(d time.Duration) (<-chan time.Time, func()) {
 	t := time.NewTicker(d)
 	return t.C, t.Stop
@@ -57,23 +82,23 @@ func (d *Daemon) reconcileArchiveTimer(cfg *config.Config) {
 	}
 	key := archiveTimerKey(interval, sites)
 
-	d.archiveTimerMu.Lock()
-	defer d.archiveTimerMu.Unlock()
-	if key == d.archiveTimerKey {
+	d.archiveTimer.mu.Lock()
+	defer d.archiveTimer.mu.Unlock()
+	if key == d.archiveTimer.key {
 		return // unchanged — do not bounce a healthy timer
 	}
 	// Stop the currently-running timer (if any) before (re)scheduling.
-	if d.archiveTimerStop != nil {
-		close(d.archiveTimerStop)
-		d.archiveTimerStop = nil
+	if d.archiveTimer.stop != nil {
+		close(d.archiveTimer.stop)
+		d.archiveTimer.stop = nil
 	}
-	d.archiveTimerKey = key
+	d.archiveTimer.key = key
 	if interval <= 0 {
 		slog.Info("periodic config archival disabled")
 		return
 	}
 	stop := make(chan struct{})
-	d.archiveTimerStop = stop
+	d.archiveTimer.stop = stop
 	sitesCopy := append([]string(nil), sites...)
 	go d.runArchiveTimer(interval, sitesCopy, stop)
 	slog.Info("periodic config archival scheduled",
@@ -87,7 +112,7 @@ func (d *Daemon) reconcileArchiveTimer(cfg *config.Config) {
 // per-generation stop channel is closed (reschedule/removal via
 // reconcileArchiveTimer) or the daemon-stop context is cancelled. #4078.
 func (d *Daemon) runArchiveTimer(interval int, sites []string, stop <-chan struct{}) {
-	newTicker := d.archiveNewTicker
+	newTicker := d.archiveTimer.newTicker
 	if newTicker == nil {
 		newTicker = realArchiveTicker
 	}
@@ -116,11 +141,11 @@ func (d *Daemon) runArchiveTimer(interval int, sites []string, stop <-chan struc
 // stopArchiveTimer stops the periodic archival timer at daemon shutdown. Safe
 // to call when no timer is running. #4078.
 func (d *Daemon) stopArchiveTimer() {
-	d.archiveTimerMu.Lock()
-	defer d.archiveTimerMu.Unlock()
-	if d.archiveTimerStop != nil {
-		close(d.archiveTimerStop)
-		d.archiveTimerStop = nil
+	d.archiveTimer.mu.Lock()
+	defer d.archiveTimer.mu.Unlock()
+	if d.archiveTimer.stop != nil {
+		close(d.archiveTimer.stop)
+		d.archiveTimer.stop = nil
 	}
-	d.archiveTimerKey = ""
+	d.archiveTimer.key = ""
 }


### PR DESCRIPTION
Addresses #4407 (increment 3: extract the periodic configuration-archival timer fields; further increments tracked).

## What

Third increment of the #4407 `Daemon` god-struct decomposition — pure code motion, no behavior/locking/lifecycle change (the Go compiler enforces completeness). Increments 1 (`dhcpLeaseSyncState`, #4631) and 2 (`neighborPeriodicGuards`, #4632) are merged.

Groups the four flat periodic configuration-archival timer fields (#4078) into a new `archiveTimerState` sub-struct:

| flat field | new field |
|---|---|
| `archiveTimerMu` | `archiveTimer.mu` |
| `archiveTimerKey` | `archiveTimer.key` |
| `archiveTimerStop` | `archiveTimer.stop` |
| `archiveNewTicker` | `archiveTimer.newTicker` |

## Why this cluster

Cleanest remaining boundary: all four fields already sit under one comment block, and every non-declaration access site is confined to a single owning file (`daemon_archive_timer.go`: `reconcileArchiveTimer` / `runArchiveTimer` / `stopArchiveTimer`) plus its `archive_timer_4078_test.go`. The sub-struct is co-located there, matching the increment 1/2 pattern (named field `d.archiveTimer.*`, not an embed, because access is bounded). Renaming to `d.archiveTimer.key` also removes the prior confusing collision between the old `archiveTimerKey` field and the still-flat package-level `archiveTimerKey(interval, sites)` hash-gate helper (left unchanged).

`archiveTransfer` stays a flat `Daemon` field — it is the one-shot transfer-on-commit upload seam used by `archiveConfig` in `daemon_flow.go`, a different mechanism from the periodic timer grouped here (mirroring how increment 1 kept `ipsecSANudgeCh` flat and increment 2 kept `lastStandbyNeighborRefresh` flat).

## Validation

- `go build ./...` clean
- `go vet ./pkg/daemon/...` clean
- `go test -race ./pkg/daemon/...` green
- `gofmt` clean on the touched files
- No new test (pure code motion). Docs: `pkg/daemon/README.md` "Struct decomposition (#4407)" gains an increment-3 bullet; `_Log.md` logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi