### PR TITLE
daemon: group host-inbound fail-open sets into a sub-struct (#4407 inc 4)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-07-08 — #4407 increment 4: extract hostInboundFailOpenState sub-struct
+
+- **Timestamp**: 2026-07-08
+- **Action**: #4407 Daemon god-struct decomposition, increment 4. Grouped the
+  three flat host-inbound fail-open / ambiguity previous-apply sets
+  (`hostInboundAddresslessZones` #3698, `hostInboundAddresslessIfaces` #3710,
+  `hostInboundAmbiguousAddrs` #3718) into a new `hostInboundFailOpenState`
+  sub-struct defined in `daemon_nft.go` (the file that owns the three
+  `logHostInbound*Transitions` diff/log functions). Fields renamed
+  `addresslessZones`/`addresslessIfaces`/`ambiguousAddrs` (dropping the
+  redundant `hostInbound` prefix), reached as `d.hostInboundFailOpen.*`. Pure
+  code motion — identical `map[string]bool` types + identical applySem-only
+  access contract, no behavior/locking change. Updated the 3 production access
+  sites in `daemon_nft.go` (plus their docstring references) and the 5 test
+  access sites in `host_inbound_addressless_3698_test.go` /
+  `host_inbound_ambiguous_3718_test.go`. The similarly-named `*prometheus.Desc`
+  fields in `pkg/api` are a separate collector (scrapes active config
+  independently) — untouched.
+- **File(s)**: `pkg/daemon/daemon.go`, `pkg/daemon/daemon_nft.go`,
+  `pkg/daemon/host_inbound_addressless_3698_test.go`,
+  `pkg/daemon/host_inbound_ambiguous_3718_test.go`, `pkg/daemon/README.md`,
+  `_Log.md`
+- **Validation**: `go build ./...` clean; `go vet ./pkg/daemon/...` clean;
+  `gofmt -l` clean; `go test -race ./pkg/daemon/...` green.
+
 ## 2026-07-08 — #4407 increment 3: extract archiveTimerState sub-struct
 
 - **Timestamp**: 2026-07-08

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -91,6 +91,23 @@ tracker issue #4407 carries the remaining increments.
   `ipsecSANudgeCh` and increment 2's `lastStandbyNeighborRefresh`) — it is the
   one-shot transfer-on-commit upload seam used by `archiveConfig` in
   `daemon_flow.go`, a different mechanism from the periodic timer grouped here.
+- **Increment 4 — host-inbound fail-open / ambiguity previous-apply sets
+  (#3698 / #3710 / #3718):** the three flat `map[string]bool` fields
+  (`hostInboundAddresslessZones`, `hostInboundAddresslessIfaces`,
+  `hostInboundAmbiguousAddrs`) moved into `hostInboundFailOpenState` (defined in
+  `daemon_nft.go`, the file that owns the three `logHostInbound*Transitions`
+  diff/log functions), reached as `d.hostInboundFailOpen.*` (fields renamed
+  `addresslessZones`/`addresslessIfaces`/`ambiguousAddrs`, dropping the
+  redundant `hostInbound` prefix). All three hold the set observed on the
+  PREVIOUS apply and are diffed against the current set to emit
+  state-transition logs only; they keep their exact `map[string]bool` types and
+  the identical applySem-only access contract, so this is pure code motion — no
+  behavior/locking change. A named sub-field (not an embed) matches increments
+  1–3: every access site is bounded to `daemon_nft.go` (plus the
+  `host_inbound_addressless_3698_test.go` / `host_inbound_ambiguous_3718_test.go`
+  tests). The similarly-named `*prometheus.Desc` fields in `pkg/api` are a
+  SEPARATE collector that scrapes the live window from the active config
+  independently of these logs — they are unrelated to this grouping.
 
 ## Cluster mode
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -361,39 +361,18 @@ type Daemon struct {
 	// pushed (and what text it would carry via d.store.ShowActive()).
 	syncPeerForTest func()
 
-	// hostInboundAddresslessZones is the set of configured host-inbound-
-	// enforcing zones observed in the transient fail-open admit window on the
-	// PREVIOUS apply (#3698): a zone with a non-lifeline interface but no
-	// resolvable address yet, so the daemon emits no host-inbound deny for it.
-	// applyHostInboundFilter diffs the current set against this to emit
-	// state-transition logs only (a zone ENTERING or LEAVING the window),
-	// keeping the warning low-noise across repeated commits / DHCP renewals.
-	// Written and read only under applySem in applyHostInboundFilter.
-	hostInboundAddresslessZones map[string]bool
-
-	// hostInboundAddresslessIfaces is the set of {zone, interface-unit, family}
-	// host-inbound fail-open windows observed on the PREVIOUS apply (#3710), keyed
-	// as "<zone>|<iface>|<family>". This is the per-interface/per-family refinement
-	// of hostInboundAddresslessZones: a DHCP/DHCPv6 client on a non-lifeline unit
-	// with no resolved address in that family yet, which the zone-level signal
-	// hides in a MIXED zone (a DHCP-pending unit beside a statically-addressed
-	// sibling, or the v6 side of a dual-stack edge whose v6 lease lands after v4).
-	// applyHostInboundFilter diffs the current set against this to emit
-	// state-transition logs only. Written and read only under applySem.
-	hostInboundAddresslessIfaces map[string]bool
-
-	// hostInboundAmbiguousAddrs is the set of firewall-local addresses observed
-	// on the PREVIOUS apply that are host-inbound-reachable from more than one
-	// security zone with DIFFERING host-inbound service/protocol sets (#3718
-	// Option B), keyed as "<family>|<addr>". The kernel host-inbound chain
-	// matches destination address only, so such an address's admission verdict
-	// is decided order-dependently by whichever zone sorts first (and can
-	// disagree with the ingress-scoped userspace-dp path). The strict commit gate
-	// rejects this; a tolerant / peer-synced load (#1960) can slip one through,
-	// and unlike the addressless window it is NOT self-healing.
-	// applyHostInboundFilter diffs the current set against this to emit
-	// state-transition logs only. Written and read only under applySem.
-	hostInboundAmbiguousAddrs map[string]bool
+	// hostInboundFailOpen groups the three previous-apply host-inbound
+	// fail-open / ambiguity sets (#3698 addressless zones, #3710 addressless
+	// {zone,iface,family} windows, #3718 order-dependent ambiguous addresses).
+	// applyHostInboundFilter diffs the current sets against these to emit
+	// state-transition logs only, keeping the warnings low-noise across
+	// repeated commits / DHCP renewals. All three are written and read only
+	// under applySem in applyHostInboundFilter. See hostInboundFailOpenState in
+	// daemon_nft.go (the file that owns the diff/log functions). This is
+	// increment 4 of the #4407 Daemon god-struct decomposition — pure field
+	// grouping, no behavior/locking change; the fields keep their exact
+	// map[string]bool types and are reached as d.hostInboundFailOpen.<field>.
+	hostInboundFailOpen hostInboundFailOpenState
 
 	// mgmtVRFInterfaces tracks interfaces bound to the management VRF (vrf-mgmt).
 	// Used by collectDHCPRoutes to exclude management routes from FRR.

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -299,12 +299,49 @@ func (d *Daemon) applyHostInboundFilter(cfg *config.Config) error {
 	return nil
 }
 
+// hostInboundFailOpenState groups the three previous-apply host-inbound
+// fail-open / ambiguity sets used purely for low-noise state-transition
+// logging. It is increment 4 of the #4407 Daemon god-struct decomposition —
+// the fields moved verbatim from flat Daemon fields (dropping the redundant
+// hostInbound prefix), no behavior/locking change. Every access site is bounded
+// to this file (the diff/log functions below) plus its 3698/3718 tests, so a
+// named sub-field on Daemon (d.hostInboundFailOpen.<field>) is used rather than
+// an embed. All three maps are written and read only under applySem via
+// applyHostInboundFilter.
+type hostInboundFailOpenState struct {
+	// addresslessZones is the set of configured host-inbound-enforcing zones
+	// observed in the transient fail-open admit window on the PREVIOUS apply
+	// (#3698): a zone with a non-lifeline interface but no resolvable address
+	// yet, so the daemon emits no host-inbound deny for it.
+	addresslessZones map[string]bool
+
+	// addresslessIfaces is the set of {zone, interface-unit, family} host-inbound
+	// fail-open windows observed on the PREVIOUS apply (#3710), keyed as
+	// "<zone>|<iface>|<family>". This is the per-interface/per-family refinement
+	// of addresslessZones: a DHCP/DHCPv6 client on a non-lifeline unit with no
+	// resolved address in that family yet, which the zone-level signal hides in a
+	// MIXED zone (a DHCP-pending unit beside a statically-addressed sibling, or
+	// the v6 side of a dual-stack edge whose v6 lease lands after v4).
+	addresslessIfaces map[string]bool
+
+	// ambiguousAddrs is the set of firewall-local addresses observed on the
+	// PREVIOUS apply that are host-inbound-reachable from more than one security
+	// zone with DIFFERING host-inbound service/protocol sets (#3718 Option B),
+	// keyed as "<family>|<addr>". The kernel host-inbound chain matches
+	// destination address only, so such an address's admission verdict is decided
+	// order-dependently by whichever zone sorts first (and can disagree with the
+	// ingress-scoped userspace-dp path). The strict commit gate rejects this; a
+	// tolerant / peer-synced load (#1960) can slip one through, and unlike the
+	// addressless window it is NOT self-healing.
+	ambiguousAddrs map[string]bool
+}
+
 // logHostInboundAddresslessTransitions emits a state-transition log whenever a
 // configured host-inbound-enforcing zone ENTERS or LEAVES the transient
 // fail-open admit window (#3698) — a zone with a non-lifeline interface but no
 // resolvable address yet, for which the kernel host-inbound chain emits no deny.
 // It compares the current addressless set against the set observed on the
-// previous apply (d.hostInboundAddresslessZones) so a zone that stays addressless
+// previous apply (d.hostInboundFailOpen.addresslessZones) so a zone that stays addressless
 // across repeated commits / DHCP renewals is logged once (on entry), not every
 // apply — the low-noise contract for a self-healing window. Runs under applySem
 // (the sole caller, applyHostInboundFilter, is invoked from applyConfigLocked),
@@ -315,18 +352,18 @@ func (d *Daemon) logHostInboundAddresslessTransitions(cfg *config.Config) {
 	current := make(map[string]bool)
 	for _, z := range dpuserspace.AddresslessEnforcingZones(cfg) {
 		current[z.Zone] = true
-		if !d.hostInboundAddresslessZones[z.Zone] {
+		if !d.hostInboundFailOpen.addresslessZones[z.Zone] {
 			slog.Warn("host-inbound zone has no address yet — host-inbound default-deny NOT enforced for it until an address appears (transient fail-open admit window)",
 				"zone", z.Zone, "interfaces", strings.Join(z.Interfaces, ","))
 		}
 	}
-	for zone := range d.hostInboundAddresslessZones {
+	for zone := range d.hostInboundFailOpen.addresslessZones {
 		if !current[zone] {
 			slog.Info("host-inbound zone now has an address — host-inbound default-deny enforced (fail-open admit window closed)",
 				"zone", zone)
 		}
 	}
-	d.hostInboundAddresslessZones = current
+	d.hostInboundFailOpen.addresslessZones = current
 }
 
 // logHostInboundAddresslessIfaceTransitions emits a state-transition log whenever
@@ -340,7 +377,7 @@ func (d *Daemon) logHostInboundAddresslessTransitions(cfg *config.Config) {
 // (the kernel chain emits `<fam> daddr <set> ... drop` separately for inet and
 // inet6), so those finer gaps are real fail-open windows the zone-level collapse
 // cannot express. It compares the current per-interface set against the set
-// observed on the previous apply (d.hostInboundAddresslessIfaces) so a unit that
+// observed on the previous apply (d.hostInboundFailOpen.addresslessIfaces) so a unit that
 // stays DHCP-pending across repeated commits / renewals is logged once (on
 // entry), not every apply. Runs under applySem (via applyHostInboundFilter), so
 // the map access needs no extra locking. The current set is also exported as the
@@ -350,18 +387,18 @@ func (d *Daemon) logHostInboundAddresslessIfaceTransitions(cfg *config.Config) {
 	for _, i := range dpuserspace.AddresslessEnforcingInterfaces(cfg) {
 		key := i.Zone + "|" + i.Interface + "|" + i.Family
 		current[key] = true
-		if !d.hostInboundAddresslessIfaces[key] {
+		if !d.hostInboundFailOpen.addresslessIfaces[key] {
 			slog.Warn("host-inbound interface has no address in this family yet — host-inbound default-deny NOT enforced for it until a lease arrives (transient fail-open admit window); the zone-level signal is hidden by an addressed sibling / family",
 				"zone", i.Zone, "interface", i.Interface, "family", i.Family, "reason", i.Reason)
 		}
 	}
-	for key := range d.hostInboundAddresslessIfaces {
+	for key := range d.hostInboundFailOpen.addresslessIfaces {
 		if !current[key] {
 			slog.Info("host-inbound interface now has an address in this family — host-inbound default-deny enforced (fail-open admit window closed)",
 				"key", key)
 		}
 	}
-	d.hostInboundAddresslessIfaces = current
+	d.hostInboundFailOpen.addresslessIfaces = current
 }
 
 // logHostInboundAmbiguousTransitions emits a state-transition log whenever a
@@ -376,7 +413,7 @@ func (d *Daemon) logHostInboundAddresslessIfaceTransitions(cfg *config.Config) {
 // / peer-synced load (#1960) can slip one through, and unlike the addressless
 // window it does NOT self-heal, so the warning stands until the operator fixes
 // the config. It compares against the set observed on the previous apply
-// (d.hostInboundAmbiguousAddrs) so a persisting ambiguity is logged once (on
+// (d.hostInboundFailOpen.ambiguousAddrs) so a persisting ambiguity is logged once (on
 // entry), not every apply. Runs under applySem (via applyHostInboundFilter), so
 // the map access needs no extra locking. The current set is also exported as the
 // xpf_host_inbound_ambiguous_addresses gauge (pkg/api), scraped independently.
@@ -385,18 +422,18 @@ func (d *Daemon) logHostInboundAmbiguousTransitions(cfg *config.Config) {
 	for _, a := range dpuserspace.AmbiguousHostInboundAddresses(cfg) {
 		key := a.Family + "|" + a.Address
 		current[key] = true
-		if !d.hostInboundAmbiguousAddrs[key] {
+		if !d.hostInboundFailOpen.ambiguousAddrs[key] {
 			slog.Warn("host-inbound address is reachable from multiple zones with differing host-inbound sets — the kernel destination-address-only verdict is order-dependent and may disagree with the ingress-scoped userspace path (zone-isolation failure); assign the address to one zone or make the host-inbound sets identical (#3718)",
 				"address", a.Address, "family", a.Family, "zones", strings.Join(a.Zones, ","))
 		}
 	}
-	for key := range d.hostInboundAmbiguousAddrs {
+	for key := range d.hostInboundFailOpen.ambiguousAddrs {
 		if !current[key] {
 			slog.Info("host-inbound address ambiguity resolved — the address no longer has an order-dependent host-inbound verdict",
 				"address", key)
 		}
 	}
-	d.hostInboundAmbiguousAddrs = current
+	d.hostInboundFailOpen.ambiguousAddrs = current
 }
 
 // hostInboundHasEnforceableView reports whether at least one view carries a

--- a/pkg/daemon/host_inbound_addressless_3698_test.go
+++ b/pkg/daemon/host_inbound_addressless_3698_test.go
@@ -91,8 +91,8 @@ func TestLogHostInboundAddresslessTransitions(t *testing.T) {
 	if warnsFor("trust") != 0 {
 		t.Errorf("scoped trust zone must not warn, got %d", warnsFor("trust"))
 	}
-	if d.hostInboundAddresslessZones["wan"] != true {
-		t.Errorf("state not tracked: hostInboundAddresslessZones[wan] = %v", d.hostInboundAddresslessZones["wan"])
+	if d.hostInboundFailOpen.addresslessZones["wan"] != true {
+		t.Errorf("state not tracked: hostInboundFailOpen.addresslessZones[wan] = %v", d.hostInboundFailOpen.addresslessZones["wan"])
 	}
 
 	// Apply 2: still addressless → NO new WARN (state-transition dedup).
@@ -109,7 +109,7 @@ func TestLogHostInboundAddresslessTransitions(t *testing.T) {
 	if warnsFor("wan") != 1 {
 		t.Errorf("recovery must not emit another warn, wan warns = %d", warnsFor("wan"))
 	}
-	if d.hostInboundAddresslessZones["wan"] {
-		t.Errorf("state not cleared after recovery: hostInboundAddresslessZones[wan] still set")
+	if d.hostInboundFailOpen.addresslessZones["wan"] {
+		t.Errorf("state not cleared after recovery: hostInboundFailOpen.addresslessZones[wan] still set")
 	}
 }

--- a/pkg/daemon/host_inbound_ambiguous_3718_test.go
+++ b/pkg/daemon/host_inbound_ambiguous_3718_test.go
@@ -69,8 +69,8 @@ func TestLogHostInboundAmbiguousTransitions(t *testing.T) {
 	if warnsFor("192.0.2.1") != 1 {
 		t.Fatalf("first apply: warns = %d, want 1", warnsFor("192.0.2.1"))
 	}
-	if !d.hostInboundAmbiguousAddrs["inet|192.0.2.1"] {
-		t.Errorf("state not tracked: hostInboundAmbiguousAddrs missing inet|192.0.2.1")
+	if !d.hostInboundFailOpen.ambiguousAddrs["inet|192.0.2.1"] {
+		t.Errorf("state not tracked: hostInboundFailOpen.ambiguousAddrs missing inet|192.0.2.1")
 	}
 
 	// Apply 2: still ambiguous → NO new WARN (state-transition dedup).
@@ -87,7 +87,7 @@ func TestLogHostInboundAmbiguousTransitions(t *testing.T) {
 	if warnsFor("192.0.2.1") != 1 {
 		t.Errorf("recovery must not emit another warn, warns = %d", warnsFor("192.0.2.1"))
 	}
-	if d.hostInboundAmbiguousAddrs["inet|192.0.2.1"] {
+	if d.hostInboundFailOpen.ambiguousAddrs["inet|192.0.2.1"] {
 		t.Errorf("state not cleared after recovery: inet|192.0.2.1 still set")
 	}
 }


### PR DESCRIPTION
Addresses #4407 (increment 4: extract the host-inbound fail-open / ambiguity previous-apply set fields; further increments tracked).

## What

Pure code motion. The three flat `map[string]bool` fields on the `Daemon`
god-struct that hold the PREVIOUS-apply host-inbound fail-open / ambiguity
sets are grouped into a named `hostInboundFailOpenState` sub-struct:

- `hostInboundAddresslessZones` (#3698) → `addresslessZones`
- `hostInboundAddresslessIfaces` (#3710) → `addresslessIfaces`
- `hostInboundAmbiguousAddrs` (#3718) → `ambiguousAddrs`

Reached as `d.hostInboundFailOpen.<field>`.

## Why this cluster is the cleanest remaining boundary

All three fields share:

- **One type** — `map[string]bool`.
- **One mechanism** — the set observed on the previous apply, diffed against
  the current set to emit state-transition logs only (low-noise across repeated
  commits / DHCP renewals).
- **One lock** — written and read only under `applySem` via
  `applyHostInboundFilter`.
- **One backing file** — all production access is in `daemon_nft.go` (the three
  `logHostInbound*Transitions` diff/log functions), plus the two 3698/3718
  tests.

The struct is co-located with its owning functions in `daemon_nft.go`. A named
sub-field (not an embed) matches increments 1-3. Fields drop the redundant
`hostInbound` prefix. No behavior/locking/lifecycle change — the Go compiler
enforces access-site completeness.

The similarly-named `*prometheus.Desc` fields in `pkg/api` are a **separate**
collector that scrapes the live window from the active config independently of
these logs; they are unrelated and untouched.

## Validation

- `go build ./...` clean
- `go vet ./pkg/daemon/...` clean
- `gofmt -l` clean
- `go test -race ./pkg/daemon/...` green

Docs: increment 4 appended to `pkg/daemon/README.md`; `_Log.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi