### PR TITLE
daemon: group Surface A DDNS state into surfaceAState (#4407 increment 5)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-07-08 — #4407 increment 5: extract surfaceAState sub-struct
+
+- **Timestamp**: 2026-07-08
+- **Action**: #4407 Daemon god-struct decomposition, increment 5. Grouped the
+  six flat Surface A (router/interface-address) DDNS fields (`surfaceA`
+  `*ddns.SurfaceAManager`, `surfaceAReconcileNowCh`, `surfaceAReconcileInFlight`,
+  `surfaceACheckIPAllowlistWarned`, `surfaceACheckIPSourceBindWarned`,
+  `surfaceACheckIPNoURLWarned`) into a new `surfaceAState` sub-struct defined in
+  `daemon_ddns_surface_a.go` (the file that owns the reconcile loop). Fields
+  renamed `mgr`/`reconcileNowCh`/`reconcileInFlight`/`checkIPAllowlistWarned`/
+  `checkIPSourceBindWarned`/`checkIPNoURLWarned` (dropping the redundant
+  `surfaceA` prefix), reached as `d.surfaceA.*`. Pure code motion — identical
+  types (`atomic.Bool` / `sync.Map` in a value sub-field of the never-copied
+  `*Daemon`) + identical access contract, no behavior/locking change. Updated
+  the ~20 production access sites in `daemon_ddns_surface_a.go`, the 2 sites in
+  `daemon_run.go` (construction + loop-start gate), the init literal in
+  `daemon.go`, and the 4 struct-literal sites in
+  `daemon_ddns_surface_a_test.go`. Added `sync` + `sync/atomic` imports to the
+  owner file and removed the now-unused `pkg/ddns` import from `daemon.go`. The
+  Surface B DHCP-lease DDNS manager (`ddns` / `ddnsReconcile*`) stays flat — a
+  different mechanism (the two-mechanism split increment 1's note anticipated).
+  This exhausts the clean single-cluster code-motion increments; the remaining
+  flowexport / fabric-forwarding / SNMP+applyConfigLocked clusters are the broad
+  / `/triple-review`-gated remainder (noted in the README).
+- **File(s)**: `pkg/daemon/daemon.go`, `pkg/daemon/daemon_ddns_surface_a.go`,
+  `pkg/daemon/daemon_run.go`, `pkg/daemon/daemon_ddns_surface_a_test.go`,
+  `pkg/daemon/README.md`, `_Log.md`
+- **Validation**: `go build ./...` clean; `go vet ./pkg/daemon/...` clean;
+  `gofmt -l` clean (my files); `go test -race ./pkg/daemon/...` green.
+
 ## 2026-07-08 — #4407 increment 4: extract hostInboundFailOpenState sub-struct
 
 - **Timestamp**: 2026-07-08

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -108,6 +108,37 @@ tracker issue #4407 carries the remaining increments.
   tests). The similarly-named `*prometheus.Desc` fields in `pkg/api` are a
   SEPARATE collector that scrapes the live window from the active config
   independently of these logs — they are unrelated to this grouping.
+- **Increment 5 — Surface A (router/interface-address) DDNS state (#2691 P2):**
+  the six flat `surfaceA*` fields (the `*ddns.SurfaceAManager`, the depth-1
+  `surfaceAReconcileNowCh` nudge channel, the `surfaceAReconcileInFlight`
+  no-freeze guard, and the three per-warning-dedup `sync.Map`s —
+  `surfaceACheckIPAllowlistWarned` / `surfaceACheckIPSourceBindWarned` /
+  `surfaceACheckIPNoURLWarned`) moved into `surfaceAState` (defined in
+  `daemon_ddns_surface_a.go`, the file that owns the reconcile loop), reached as
+  `d.surfaceA.<field>` with the redundant `surfaceA` prefix dropped (`mgr`,
+  `reconcileNowCh`, `reconcileInFlight`, `checkIPAllowlistWarned`,
+  `checkIPSourceBindWarned`, `checkIPNoURLWarned`). The fields keep their exact
+  types (`atomic.Bool` / `sync.Map` inside a value sub-field of the never-copied
+  `*Daemon`, so the non-copyable members are safe) and their exact access
+  contract, so this is pure code motion — no behavior/locking change. A named
+  sub-field (not an embed) matches increments 1–4: every production access site
+  is bounded to `daemon_ddns_surface_a.go` plus the construct/gate sites in
+  `daemon_run.go` (and the four `daemon_ddns_surface_a_test.go` literals). The
+  **Surface B** DHCP-lease DDNS manager (`ddns` / `ddnsReconcileNowCh` /
+  `ddnsReconcileInFlight`) stays a set of flat `Daemon` fields — it is a
+  DIFFERENT DDNS mechanism, exactly the two-mechanism split increment 1's note
+  anticipated when it kept the mirrored `ddnsReconcile*` fields flat.
+
+This exhausts the CLEAN, single-cluster / single-file pure-code-motion
+increments. The remaining `Daemon` field clusters are the broad /
+review-gated remainder, deliberately NOT taken as further code-motion-only
+increments: **flowexport** (18 `flow*`/`ipfix*` fields spanning three files —
+too broad for one reviewable code-motion PR), **fabric cross-chassis
+forwarding** (the `fabric*` refresh state — broad, spread across the HA
+forwarding path), and the **SNMP + `applyConfigLocked` reconcile-ordering**
+cluster (deferred to `/triple-review` per #4407, because regrouping it
+touches apply-ordering rather than being inert field motion). These are the
+natural stopping point for the mechanical decomposition.
 
 ## Cluster mode
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -21,7 +21,6 @@ import (
 	"github.com/psaab/xpf/pkg/configstore"
 	"github.com/psaab/xpf/pkg/conntrack"
 	"github.com/psaab/xpf/pkg/dataplane"
-	"github.com/psaab/xpf/pkg/ddns"
 	"github.com/psaab/xpf/pkg/dhcp"
 	"github.com/psaab/xpf/pkg/dhcprelay"
 	"github.com/psaab/xpf/pkg/dhcpserver"
@@ -104,43 +103,16 @@ type Daemon struct {
 	// loop) so a hung DNS server can never wedge the loop or starve the
 	// nudge channel.
 	ddnsReconcileInFlight atomic.Bool
-	// surfaceA is the always-on Surface A router/interface-address DDNS manager
-	// (#2691 P2). It publishes THIS firewall's own learned interface addresses
-	// (DHCP-lease / static / netlink) as configured FQDNs through the
-	// `system services dynamic-dns` provider catalog, reusing the pkg/ddns
-	// spine (the same Backend, record, ScopeKey, durable-state primitives). It
-	// is constructed unconditionally so a binding removal always has a running
-	// loop to withdraw; the loop is netlink + DNS-network only (no control
-	// socket), gated to the RG-MASTER per scope, nudged on commit + the #1844
-	// DHCP gateway/address-change hook + MASTER transition.
-	surfaceA *ddns.SurfaceAManager
-	// surfaceAReconcileNowCh / surfaceAReconcileInFlight mirror the ddns* pair:
-	// a depth-1 nudge channel + a no-freeze skip-if-in-flight guard.
-	surfaceAReconcileNowCh    chan struct{}
-	surfaceAReconcileInFlight atomic.Bool
-	// surfaceACheckIPAllowlistWarned dedups the once-per-(provider,allowlist)
-	// runtime log emitted when ddns.ParseAllowlistChecked drops a malformed
-	// checkip-allowlist token (#2839). The observer runs per poll-tick, so the
-	// drop must not log every tick. Keyed by "<provider>\x00<allowlist-string>"
-	// so a corrected commit re-arms the warning.
-	surfaceACheckIPAllowlistWarned sync.Map
-	// surfaceACheckIPSourceBindWarned dedups the once-per-(provider,bind-error)
-	// runtime log emitted when the checkip probe fails CLOSED because the
-	// provider's configured source-address failed to parse (#3733). That parse
-	// failure is the ONLY bind-resolution error CheckIPClient returns; a dead
-	// destination-interface / VRF surfaces later as a dial error inside CheckIP
-	// (already ok=false), not here. The observer runs per poll-tick, so a
-	// persistent misconfig must not log every tick. Keyed by
-	// "<provider>\x00<bind-error>" so a corrected commit re-arms the warning.
-	surfaceACheckIPSourceBindWarned sync.Map
-	// surfaceACheckIPNoURLWarned dedups the once-per-provider runtime log emitted
-	// when a binding selects `address-source checkip` but the referenced provider
-	// carries no checkip-url (#4423 H08). Before the fix the runtime silently fell
-	// back to the interface address (publishing the WRONG address); now the source
-	// stays checkip and the observer skips (fail-closed) while surfacing this WARN
-	// once per provider so the operator sees why nothing publishes. Keyed by the
-	// provider name so a corrected commit (url added) re-arms the warning.
-	surfaceACheckIPNoURLWarned sync.Map
+	// surfaceA groups the always-on Surface A (router/interface-address) DDNS
+	// manager plus its reconcile-supervision + per-warning-dedup state. This is
+	// increment 5 of the #4407 Daemon god-struct decomposition — pure field
+	// grouping, no behavior/locking change; every field keeps its exact type and
+	// access contract and is reached as d.surfaceA.<field>. See surfaceAState in
+	// daemon_ddns_surface_a.go (the file that owns the reconcile loop). Surface B
+	// — the DHCP-lease ddns* manager above — stays a set of flat Daemon fields:
+	// it is a DIFFERENT DDNS mechanism, exactly the two-mechanism split increment
+	// 1's note anticipated when it kept the mirrored ddnsReconcile* fields flat.
+	surfaceA surfaceAState
 	// #2239 HA DHCP-server lease sync (PATH C). These fields were grouped
 	// into dhcpLeaseSyncState (see daemon_dhcp_lease_sync.go) as increment 1
 	// of the #4407 Daemon god-struct decomposition — grouping only, no
@@ -762,7 +734,7 @@ func New(opts Options) (*Daemon, error) {
 		blackholeRoutes:            make(map[int][]netlink.Route),
 		reconcileNowCh:             make(chan struct{}, 1),
 		ddnsReconcileNowCh:         make(chan struct{}, 1),
-		surfaceAReconcileNowCh:     make(chan struct{}, 1),
+		surfaceA:                   surfaceAState{reconcileNowCh: make(chan struct{}, 1)},
 		dhcpLeaseSync:              dhcpLeaseSyncState{nowCh: make(chan struct{}, 1)},
 		ipsecSANudgeCh:             make(chan struct{}, 1),
 		syncReadyTimeout:           5 * time.Second,

--- a/pkg/daemon/daemon_ddns_surface_a.go
+++ b/pkg/daemon/daemon_ddns_surface_a.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"net/netip"
 	"sort"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/vishvananda/netlink"
@@ -47,10 +49,60 @@ const (
 	surfaceACheckIPTimeout = 10 * time.Second
 )
 
+// surfaceAState groups the always-on Surface A (router/interface-address) DDNS
+// state — increment 5 of the #4407 Daemon god-struct decomposition. Pure field
+// grouping, no behavior/locking change: every field keeps its exact type and
+// its access contract, reached as d.surfaceA.<field>. It is a NAMED sub-field
+// (not an embed) like increments 1–4: every access site is bounded to this file
+// (the reconcile-loop owner) plus the construct/gate sites in daemon_run.go, so
+// the explicit d.surfaceA. qualifier is clearer than field promotion. It is a
+// value field of the never-copied *Daemon, so the atomic.Bool / sync.Map
+// members are safe (never copied after first use). The DHCP-lease Surface B
+// manager (d.ddns*) stays flat — a different DDNS mechanism.
+type surfaceAState struct {
+	// mgr is the Surface A manager (#2691 P2). It publishes THIS firewall's own
+	// learned interface addresses (DHCP-lease / static / netlink) as configured
+	// FQDNs through the `system services dynamic-dns` provider catalog, reusing
+	// the pkg/ddns spine (the same Backend, record, ScopeKey, durable-state
+	// primitives). Constructed unconditionally so a binding removal always has a
+	// running loop to withdraw; the loop is netlink + DNS-network only (no
+	// control socket), gated to the RG-MASTER per scope, nudged on commit + the
+	// #1844 DHCP gateway/address-change hook + MASTER transition. nil when the
+	// dataplane is disabled (NoDataplane).
+	mgr *ddns.SurfaceAManager
+	// reconcileNowCh / reconcileInFlight mirror the ddns* pair: a depth-1 nudge
+	// channel + a no-freeze skip-if-in-flight guard.
+	reconcileNowCh    chan struct{}
+	reconcileInFlight atomic.Bool
+	// checkIPAllowlistWarned dedups the once-per-(provider,allowlist) runtime log
+	// emitted when ddns.ParseAllowlistChecked drops a malformed checkip-allowlist
+	// token (#2839). The observer runs per poll-tick, so the drop must not log
+	// every tick. Keyed by "<provider>\x00<allowlist-string>" so a corrected
+	// commit re-arms the warning.
+	checkIPAllowlistWarned sync.Map
+	// checkIPSourceBindWarned dedups the once-per-(provider,bind-error) runtime
+	// log emitted when the checkip probe fails CLOSED because the provider's
+	// configured source-address failed to parse (#3733). That parse failure is
+	// the ONLY bind-resolution error CheckIPClient returns; a dead
+	// destination-interface / VRF surfaces later as a dial error inside CheckIP
+	// (already ok=false), not here. The observer runs per poll-tick, so a
+	// persistent misconfig must not log every tick. Keyed by
+	// "<provider>\x00<bind-error>" so a corrected commit re-arms the warning.
+	checkIPSourceBindWarned sync.Map
+	// checkIPNoURLWarned dedups the once-per-provider runtime log emitted when a
+	// binding selects `address-source checkip` but the referenced provider
+	// carries no checkip-url (#4423 H08). Before the fix the runtime silently
+	// fell back to the interface address (publishing the WRONG address); now the
+	// source stays checkip and the observer skips (fail-closed) while surfacing
+	// this WARN once per provider so the operator sees why nothing publishes.
+	// Keyed by the provider name so a corrected commit (url added) re-arms it.
+	checkIPNoURLWarned sync.Map
+}
+
 // runSurfaceADDNSReconcileLoop is the supervised Surface A reconcile loop. It
 // runs for the daemon's lifetime (joined via wg) and exits on ctx cancel.
 func (d *Daemon) runSurfaceADDNSReconcileLoop(ctx context.Context) {
-	if d.surfaceA == nil {
+	if d.surfaceA.mgr == nil {
 		return
 	}
 	// Immediate first pass so a restart re-publishes / withdraws without
@@ -65,7 +117,7 @@ func (d *Daemon) runSurfaceADDNSReconcileLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 			d.runGuardedSurfaceADDNSReconcile(ctx)
-		case <-d.surfaceAReconcileNowCh:
+		case <-d.surfaceA.reconcileNowCh:
 			d.runGuardedSurfaceADDNSReconcile(ctx)
 		}
 	}
@@ -75,14 +127,14 @@ func (d *Daemon) runSurfaceADDNSReconcileLoop(ctx context.Context) {
 // (skip-if-in-flight), mirroring the lease loop — a hung DNS server leaks at
 // most one goroutine and the loop keeps servicing ctx + the nudge channel.
 func (d *Daemon) runGuardedSurfaceADDNSReconcile(ctx context.Context) {
-	if d.surfaceA == nil {
+	if d.surfaceA.mgr == nil {
 		return
 	}
-	if !d.surfaceAReconcileInFlight.CompareAndSwap(false, true) {
+	if !d.surfaceA.reconcileInFlight.CompareAndSwap(false, true) {
 		return
 	}
 	go func() {
-		defer d.surfaceAReconcileInFlight.Store(false)
+		defer d.surfaceA.reconcileInFlight.Store(false)
 		d.reconcileSurfaceAOnce(ctx)
 	}()
 }
@@ -95,7 +147,7 @@ func (d *Daemon) runGuardedSurfaceADDNSReconcile(ctx context.Context) {
 // publish decision PER RG so a node MASTER for one RG and BACKUP for another
 // publishes only its own RG's records.
 func (d *Daemon) reconcileSurfaceAOnce(ctx context.Context) {
-	if d.surfaceA == nil {
+	if d.surfaceA.mgr == nil {
 		return
 	}
 	cfg := d.store.ActiveConfig()
@@ -119,7 +171,7 @@ func (d *Daemon) reconcileSurfaceAOnce(ctx context.Context) {
 	if cfg.System.Services != nil && cfg.System.Services.DynamicDNS != nil {
 		catalog = cfg.System.Services.DynamicDNS.Providers
 	}
-	if err := d.surfaceA.Reconcile(rctx, scopes, observe, gate, catalog); err != nil {
+	if err := d.surfaceA.mgr.Reconcile(rctx, scopes, observe, gate, catalog); err != nil {
 		slog.Warn("ddns surface-a: reconcile pass had errors (retrying next cycle)", "err", err)
 	}
 }
@@ -319,7 +371,7 @@ func (d *Daemon) surfaceAObserver(cfg *config.Config) ddns.AddressObserver {
 				// commit validator also warns). Skip the log when Provider is nil (an
 				// unresolved provider is already covered by the invalid-binding row).
 				if scope.Provider != nil {
-					if _, dup := d.surfaceACheckIPNoURLWarned.LoadOrStore(scope.Provider.Name, struct{}{}); !dup {
+					if _, dup := d.surfaceA.checkIPNoURLWarned.LoadOrStore(scope.Provider.Name, struct{}{}); !dup {
 						slog.Warn("ddns surface-a: address-source checkip selected but provider has no "+
 							"checkip-url; skipping (fail-closed, NOT falling back to the interface address)",
 							"provider", scope.Provider.Name, "fqdn", scope.FQDN)
@@ -343,7 +395,7 @@ func (d *Daemon) surfaceAObserver(cfg *config.Config) ddns.AddressObserver {
 				// log once per (provider, allowlist-string) so the running daemon also
 				// surfaces it without flooding the per-tick observer.
 				key := scope.Provider.Name + "\x00" + scope.Provider.CheckIPAllowlist
-				if _, dup := d.surfaceACheckIPAllowlistWarned.LoadOrStore(key, struct{}{}); !dup {
+				if _, dup := d.surfaceA.checkIPAllowlistWarned.LoadOrStore(key, struct{}{}); !dup {
 					slog.Warn("ddns surface-a: ignoring malformed checkip-allowlist token(s); "+
 						"bogus-IP allowlist is smaller than configured",
 						"provider", scope.Provider.Name, "tokens", badAllow)
@@ -355,7 +407,7 @@ func (d *Daemon) surfaceAObserver(cfg *config.Config) ddns.AddressObserver {
 			// cached per-binding HTTP client (#2904) so the recurring checkip probe
 			// shares the keep-alive connection pool with the DNS-update path instead
 			// of rebuilding a transport every reconcile pass.
-			client, berr := d.surfaceA.CheckIPClient(scope.Provider)
+			client, berr := d.surfaceA.mgr.CheckIPClient(scope.Provider)
 			if berr != nil {
 				// FAIL-CLOSED (#3733): berr means the provider's configured
 				// source-address failed to parse (netip.ParseAddr) — it is the
@@ -372,7 +424,7 @@ func (d *Daemon) surfaceAObserver(cfg *config.Config) ddns.AddressObserver {
 				// so a persistent misconfig surfaces without flooding the per-tick
 				// observer.
 				key := scope.Provider.Name + "\x00" + berr.Error()
-				if _, dup := d.surfaceACheckIPSourceBindWarned.LoadOrStore(key, struct{}{}); !dup {
+				if _, dup := d.surfaceA.checkIPSourceBindWarned.LoadOrStore(key, struct{}{}); !dup {
 					slog.Warn("ddns surface-a: checkip source bind unusable; "+
 						"skipping probe (fail-closed, not falling back to default route)",
 						"provider", scope.Provider.Name, "err", berr)
@@ -702,11 +754,11 @@ func (d *Daemon) surfaceARG0Writer(master map[int]bool) bool {
 // (config commit / DHCP address change / MASTER takeover). Non-blocking depth-1
 // send: coalesces a burst into one pending wakeup.
 func (d *Daemon) nudgeSurfaceADDNSReconcile() {
-	if d.surfaceAReconcileNowCh == nil {
+	if d.surfaceA.reconcileNowCh == nil {
 		return
 	}
 	select {
-	case d.surfaceAReconcileNowCh <- struct{}{}:
+	case d.surfaceA.reconcileNowCh <- struct{}{}:
 	default:
 	}
 }
@@ -723,7 +775,7 @@ func (d *Daemon) nudgeSurfaceADDNSReconcile() {
 // A standalone node (no cluster) is always the writer. Returns (ok, message)
 // for the operator surface.
 func (d *Daemon) ForceDDNSUpdate(force bool) (bool, string) {
-	if d.surfaceA == nil && d.ddns == nil {
+	if d.surfaceA.mgr == nil && d.ddns == nil {
 		return false, "dynamic-dns: DDNS engine not running (dataplane disabled)"
 	}
 	// Per-RG owner gate (#2972): only a node that masters at least one RG may
@@ -736,8 +788,8 @@ func (d *Daemon) ForceDDNSUpdate(force bool) (bool, string) {
 			"redundancy group; the redundancy-group owner publishes (no action " +
 			"taken on the backup)"
 	}
-	if force && d.surfaceA != nil {
-		d.surfaceA.ForceRefresh()
+	if force && d.surfaceA.mgr != nil {
+		d.surfaceA.mgr.ForceRefresh()
 	}
 	// Nudge both DDNS reconcile loops immediately (Surface A router records and
 	// the DHCP-lease Surface B path) so the forced/checked pass runs now rather
@@ -755,17 +807,17 @@ func (d *Daemon) ForceDDNSUpdate(force bool) (bool, string) {
 // SurfaceAStats returns the Surface A counter snapshot for the API collector /
 // show command, or nil when the manager is not constructed (NoDataplane).
 func (d *Daemon) SurfaceAStats() *ddns.SurfaceAStats {
-	if d.surfaceA == nil {
+	if d.surfaceA.mgr == nil {
 		return nil
 	}
-	st := d.surfaceA.Stats()
+	st := d.surfaceA.mgr.Stats()
 	return &st
 }
 
 // SurfaceAStatus returns the per-scope last-published views for `show` (the
 // operator surface, plan §5.5). Empty when the manager is absent.
 func (d *Daemon) SurfaceAStatus() []ddns.SurfaceAStatusView {
-	if d.surfaceA == nil {
+	if d.surfaceA.mgr == nil {
 		return nil
 	}
 	// Materialize the CURRENTLY configured scopes so the status surfaces every
@@ -777,7 +829,7 @@ func (d *Daemon) SurfaceAStatus() []ddns.SurfaceAStatusView {
 	if cfg := d.store.ActiveConfig(); cfg != nil {
 		scopes, invalid = d.buildSurfaceAScopes(cfg)
 	}
-	views := d.surfaceA.StatusViews(scopes)
+	views := d.surfaceA.mgr.StatusViews(scopes)
 	if len(invalid) > 0 {
 		// #4423 M09: fold the structurally-invalid bindings (no hostname / no
 		// provider / undefined provider) into the operator status so a broken

--- a/pkg/daemon/daemon_ddns_surface_a_test.go
+++ b/pkg/daemon/daemon_ddns_surface_a_test.go
@@ -572,7 +572,7 @@ func TestForceDDNSUpdateOwnerGate(t *testing.T) {
 	t.Run("standalone forces an update", func(t *testing.T) {
 		d := &Daemon{
 			rgStates: make(map[int]*rgStateMachine),
-			surfaceA: ddns.NewSurfaceAManager(),
+			surfaceA: surfaceAState{mgr: ddns.NewSurfaceAManager()},
 		}
 		ok, msg := d.ForceDDNSUpdate(true)
 		if !ok {
@@ -587,7 +587,7 @@ func TestForceDDNSUpdateOwnerGate(t *testing.T) {
 		d := &Daemon{
 			rgStates: make(map[int]*rgStateMachine),
 			cluster:  cluster.NewManager(0, 1),
-			surfaceA: ddns.NewSurfaceAManager(),
+			surfaceA: surfaceAState{mgr: ddns.NewSurfaceAManager()},
 		}
 		d.getOrCreateRGState(1).SetCluster(false)
 		d.getOrCreateRGState(2).SetCluster(false)
@@ -604,7 +604,7 @@ func TestForceDDNSUpdateOwnerGate(t *testing.T) {
 		d := &Daemon{
 			rgStates: make(map[int]*rgStateMachine),
 			cluster:  cluster.NewManager(0, 1),
-			surfaceA: ddns.NewSurfaceAManager(),
+			surfaceA: surfaceAState{mgr: ddns.NewSurfaceAManager()},
 		}
 		d.getOrCreateRGState(1).SetCluster(false)
 		d.getOrCreateRGState(2).SetCluster(true)
@@ -725,7 +725,7 @@ func TestSurfaceAObserverCheckIPHonorsReconcileContext(t *testing.T) {
 	t.Cleanup(srv.Close)
 	t.Cleanup(func() { close(done) })
 
-	d := &Daemon{surfaceA: ddns.NewSurfaceAManager()}
+	d := &Daemon{surfaceA: surfaceAState{mgr: ddns.NewSurfaceAManager()}}
 	cfg := &config.Config{}
 	scope := ddns.SurfaceAScope{
 		Key: ddns.ScopeKey{

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -484,7 +484,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		// #2691 P2: the always-on Surface A manager (router/interface-address
 		// publish). Constructed unconditionally for the same reason as the lease
 		// manager — a binding removal must have a running loop to withdraw.
-		d.surfaceA = ddns.NewSurfaceAManager()
+		d.surfaceA.mgr = ddns.NewSurfaceAManager()
 	}
 
 	// Create the RPM manager eagerly so the pointer is stable for the
@@ -1116,7 +1116,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// reconcile loop. Same lifecycle + control-socket-free + per-RG-gated
 	// discipline as the lease loop above; it reads netlink + the DHCP client
 	// lease set and publishes the firewall's own addresses.
-	if !d.opts.NoDataplane && d.surfaceA != nil {
+	if !d.opts.NoDataplane && d.surfaceA.mgr != nil {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
Addresses #4407 (increment 5: extract the Surface A router/interface-address DDNS fields; remaining clusters are the broad/triple-review-gated set).

## What

Increment 5 of the #4407 `Daemon` god-struct decomposition. Groups the six flat Surface A (`#2691` P2) DDNS fields into a new `surfaceAState` sub-struct, co-located in `daemon_ddns_surface_a.go` (the file that owns the reconcile loop). Pure code motion — no behavior/locking/lifecycle change; the Go compiler enforces completeness across the rename.

Fields moved (redundant `surfaceA` prefix dropped), reached as `d.surfaceA.<field>`:

| old flat field | new |
| --- | --- |
| `surfaceA *ddns.SurfaceAManager` | `mgr` |
| `surfaceAReconcileNowCh chan struct{}` | `reconcileNowCh` |
| `surfaceAReconcileInFlight atomic.Bool` | `reconcileInFlight` |
| `surfaceACheckIPAllowlistWarned sync.Map` | `checkIPAllowlistWarned` |
| `surfaceACheckIPSourceBindWarned sync.Map` | `checkIPSourceBindWarned` |
| `surfaceACheckIPNoURLWarned sync.Map` | `checkIPNoURLWarned` |

`surfaceAState` is a value field of the never-copied `*Daemon`, so the `atomic.Bool` / `sync.Map` members are never copied after first use (`go vet` copylocks clean). Named sub-field (not an embed) matches increments 1–4.

## Two-mechanism split respected

The DHCP-lease **Surface B** DDNS manager (`ddns` / `ddnsReconcileNowCh` / `ddnsReconcileInFlight`) stays a set of flat `Daemon` fields — a different DDNS mechanism, exactly the split increment 1's note anticipated when it kept the mirrored `ddnsReconcile*` fields flat.

## Access sites updated

`daemon_ddns_surface_a.go` (~20, the reconcile-loop owner) · `daemon_run.go` (2: construct + loop-start gate) · `daemon.go` init literal · four `daemon_ddns_surface_a_test.go` struct literals. Added `sync`/`sync/atomic` imports to the owner file; removed the now-unused `pkg/ddns` import from `daemon.go`.

## Stopping point

This exhausts the clean single-cluster / single-file pure-code-motion increments. The remaining `Daemon` clusters are the broad / `/triple-review`-gated remainder (noted in `pkg/daemon/README.md`): **flowexport** (18 fields, 3 files), **fabric cross-chassis forwarding** (broad HA path), and the **SNMP + `applyConfigLocked` reconcile-ordering** cluster (deferred to `/triple-review` per #4407 — regrouping it touches apply-ordering, not inert field motion).

## Validation

- `go build ./...` clean
- `go vet ./pkg/daemon/...` clean
- `gofmt -l` clean (touched files)
- `go test -race ./pkg/daemon/...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi