### PR TITLE
userspace-dp: gate NEW inbound IKE at Stage 11 against host-inbound (#4323)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -41567,3 +41567,41 @@ top.
   /triple-review increment per the issue's warning.
 - **File(s)**: pkg/daemon/daemon.go, pkg/daemon/daemon_dhcp_lease_sync.go,
   pkg/daemon/daemon_dhcp_lease_sync_test.go, pkg/daemon/README.md, _Log.md
+
+- **Timestamp**: 2026-07-08
+- **Action**: #4323 — gate NEW inbound IKE at Stage 11 (IPsec passthrough)
+  against per-zone host-inbound (Option B, deferred hardening from #3616).
+  Stage 11 (`stage_ipsec_passthrough_check`) previously reinjected ALL
+  IPsec (ESP/AH/IKE) toward the kernel XFRM stack unconditionally, so an
+  unsolicited inbound IKE on the SECONDARY AF_XDP path (DNAT-to-self /
+  native-GRE-inner) reached strongSwan even on a zone omitting
+  `system-services ike`. Added `classify_ipsec_admission` (forwarding/
+  mod.rs): ESP/AH + IPsec data plane (ESP-in-UDP on 4500, NAT-T
+  keepalive) + every established/reply IKE packet are `Exempt`
+  (unconditional passthrough — the SA authorizes; mirrors the kernel
+  chain's global ESP/AH accept and `ct established,related accept`); only
+  the FIRST packet of a NEW inbound IKE exchange (ISAKMP Responder SPI ==
+  0, with RFC-3948 NAT-T non-ESP-marker demux on 4500) is
+  `NewInboundIke`. The stage gates a `NewInboundIke` on the resolved
+  LOGICAL ingress zone (`resolve_ingress_logical_ifindex` +
+  `zone_pair_ids_for_flow_with_override(ingress_zone_override)` +
+  `host_inbound_admits_iface`); a zone that omits `ike`/`ipsec` yields
+  `Denied` → silent drop, `host_inbound_denied_packets` accounted +
+  `RT_FLOW_CLOSE_REASON_HOST_INBOUND` event (reusing the existing
+  deny plumbing — no new counter/contract surface). OQ5 (established
+  signal) resolved STATELESSLY from the ISAKMP header (no session lookup —
+  the secondary path installs no session for passthrough flows). R4
+  preserved: the gate is a separate admit BEFORE the reinject, NOT a
+  `local_ifindex` change. New RED-on-revert test
+  `stage_ipsec_passthrough_gates_new_ike_4323` (denied-dropped +
+  permitted-admitted + established-unaffected + ESP/ESP-in-UDP exempt);
+  verified RED with the gate neutralized. Docs: forwarding/README.md
+  IPsec section, docs/userspace-dataplane-architecture.md, host_inbound.rs
+  `ike`/`ipsec` arm, plan.md DEFERRED→SHIPPED.
+- **File(s)**: userspace-dp/src/afxdp/forwarding/mod.rs,
+  userspace-dp/src/afxdp/poll_stages.rs,
+  userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/afxdp/forwarding/host_inbound.rs,
+  userspace-dp/src/afxdp/forwarding/README.md,
+  docs/userspace-dataplane-architecture.md,
+  docs/research/3616-ipsec-host-inbound/plan.md, _Log.md

--- a/docs/research/3616-ipsec-host-inbound/plan.md
+++ b/docs/research/3616-ipsec-host-inbound/plan.md
@@ -17,15 +17,22 @@
 >   `docs/userspace-dataplane-architecture.md` record the two-path model and the
 >   ratified exemption.
 >
-> **DEFERRED (Option B):** the NEW-inbound-IKE / inner-ESP host-inbound gate at
-> Stage 11. It must reproduce the kernel chain's `ct established,related accept`-
-> first ordering (OQ5) and resolve the logical / GRE-inner ingress zone (OQ6), or
-> it drops return/established/tunnelled IPsec. Reopen if a real DNAT-to-self-IKE
-> deployment or a stricter parity mandate arrives. NOTE: naively "carrying the
-> real ingress/local context into the synthetic decision so host-inbound is
-> enforced" is Option B, not Option A — and doing it in the routing decision
-> breaks routing (R4), so the gate is a separate `host_inbound_admits_iface` call
-> BEFORE the reinject, not a change to `local_ifindex`.
+> **DEFERRED (Option B) — SHIPPED in #4323.** The NEW-inbound-IKE host-inbound
+> gate at Stage 11 is now implemented (`stage_ipsec_passthrough_check` +
+> `classify_ipsec_admission`). OQ5 (the established/related signal) was resolved
+> STATELESSLY from the ISAKMP header rather than from conntrack: the first packet
+> of a new exchange carries an all-zero Responder SPI (gated on `ike`/`ipsec`),
+> and every later packet carries a set Responder SPI (exempt) — the stateless
+> mirror of `ct established,related accept`-first, so return/reply IKE never
+> drops. This needs no session table (the secondary path installs no session for
+> a passthrough flow). OQ6 (zone resolution) reuses the resolver's logical
+> ingress ifindex + `zone_pair_ids_for_flow_with_override(ingress_zone_override)`.
+> ESP/AH + the IPsec data plane (ESP-in-UDP, NAT-T keepalive) stay unconditionally
+> exempt. The gate is a separate `host_inbound_admits_iface` call BEFORE the
+> reinject, NOT a change to `local_ifindex` (R4 preserved). Residual: a forged
+> non-zero Responder SPI on a NEW packet reads as exempt and reaches strongSwan,
+> which drops it as an unknown SA — the initiation packet that actually
+> establishes a tunnel always carries a zero Responder SPI and is gated.
 
 - Issue: #3616 (`userspace-dp: IPsec/IKE/ESP/AH passthrough (Stage 11) bypasses
   per-zone host-inbound service enforcement — decide + pin vSRX parity`)

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -1461,19 +1461,25 @@ is [`userspace-dataplane-gaps.md`](userspace-dataplane-gaps.md).
   handling where required. Host-terminated IPsec (ESP/AH/IKE) is
   recognized by `stage_ipsec_passthrough_check` (Stage 11) and reinjected
   toward the kernel XFRM stack. Stage 11 runs BEFORE the per-zone
-  host-inbound admission gate and is **exempt** from it — a ratified
-  userspace-dataplane semantic (#3616 Option A). The PRIMARY host-inbound
-  enforcement for direct IPsec-to-self is the kernel nftables chain
-  (`pkg/daemon/daemon_nft.go`), which gates NEW inbound IKE on
-  `system-services ike`/`ipsec`, accepts raw ESP/AH globally (the SA is
-  the authorization), and rides established/return IKE on `ct
-  established,related accept`. The synthetic Stage-11 reinject decision
-  keeps `local_ifindex` = 0 (a non-zero value would divert it into the
-  GRE local-tunnel-delivery channel and mis-deliver IPsec-to-self, not
-  enforce host-inbound). Gating NEW IKE / inner-ESP at Stage 11 on the
-  SECONDARY AF_XDP path (DNAT-to-self, native-GRE inner) is deferred
-  hardening (Option B) — see
-  `userspace-dp/src/afxdp/forwarding/README.md` and
+  host-inbound admission gate; raw ESP/AH and the IPsec data plane are
+  **exempt** from it (the SA is the authorization — ratified #3616 Option
+  A), but a **NEW inbound IKE initiation is GATED** on the ingress zone's
+  `system-services ike`/`ipsec` (#4323 Option B). `classify_ipsec_admission`
+  splits the two by the ISAKMP Responder SPI: an all-zero Responder SPI is
+  the first packet of a new exchange (gated); a set Responder SPI is an
+  established/reply packet (exempt — the stateless mirror of `ct
+  established,related accept`, so return IKE never drops). A denied NEW IKE
+  is a silent drop (`host_inbound_denied_packets` +
+  `RT_FLOW_CLOSE_REASON_HOST_INBOUND`) so it never reaches the local IKE
+  daemon. The PRIMARY host-inbound enforcement for direct IPsec-to-self is
+  the kernel nftables chain (`pkg/daemon/daemon_nft.go`), with the same
+  ESP/AH-global-accept + NEW-IKE-gate + established-first semantics; the
+  #4323 gate brings the SECONDARY AF_XDP path (DNAT-to-self, native-GRE
+  inner) to parity. The synthetic Stage-11 reinject decision keeps
+  `local_ifindex` = 0 (a non-zero value would divert it into the GRE
+  local-tunnel-delivery channel and mis-deliver IPsec-to-self); the #4323
+  gate is a separate admit check BEFORE the reinject, never a routing-
+  decision change. See `userspace-dp/src/afxdp/forwarding/README.md` and
   `docs/research/3616-ipsec-host-inbound/plan.md`.
 - Packets failing forwarding resolution can enter the bounded slow path,
   but ONLY for the slow-path-eligible dispositions: `LocalDelivery`,

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -595,47 +595,69 @@ coverage would require the shim to surface an "AH present" signal
 instead of walking past the header — out of scope here, and
 unnecessary given the local-dest shunt.
 
-### Host-inbound ordering: IPsec passthrough is EXEMPT (ratified — #3616)
+### Host-inbound ordering: ESP/AH exempt, NEW IKE gated (#3616 Option A + #4323 Option B)
 
 Stage 11 runs BEFORE the per-zone host-inbound admission gate
-(`host_inbound_admits_iface`) and short-circuits with
-`RecycleAndContinue`, so a packet it claims never reaches that gate.
-IPsec passthrough is therefore **exempt** from `host-inbound-traffic
-system-services ike`/`ipsec` on the AF_XDP path. This is a **ratified**
-userspace-dataplane semantic (#3616 Option A), not an accident:
+(`host_inbound_admits_iface`) and, on a match, short-circuits the poll
+loop (`Passthrough`/`Denied`), so a packet it claims never reaches the
+later local-delivery gate. Within Stage 11 the admission split is by
+class (`classify_ipsec_admission`):
 
-- **Two enforcement paths.** The PRIMARY host-inbound enforcement for
-  IPsec-to-self is the kernel nftables chain
-  (`pkg/daemon/daemon_nft.go`). The XDP shim shunts direct
-  local-destination IPsec to the kernel BEFORE userspace-dp sees it —
-  raw outer ESP is shunted unconditionally
-  (`userspace-xdp/src/lib.rs`), and IKE/AH to a local address ride the
-  `is_local_destination` shunt. That chain accepts raw ESP/AH globally
-  (the SA is the authorization — Junos parity), gates NEW inbound IKE on
-  `system-services ike`/`ipsec`, and lets established/return IKE ride
-  `ct established,related accept` first. `TestHostInboundFilterExempts
-  IPsecAndV6Errors` guards that ordering.
-- **The SECONDARY AF_XDP path** (Stage 11) is reached only when IPsec is
-  NOT shunted to the kernel: DNAT/static-NAT-to-self IKE, native-GRE
-  inner IPsec whose inner destination is a firewall-local address
-  (redirected to the XSK and decapped in userspace), and transit/NAT
-  IPv4 AH. On this path Stage 11 exempts IPsec from host-inbound.
-- **The synthetic reinject decision keeps `local_ifindex` = 0**
-  (`ipsec_passthrough_decision`). It MUST: a non-zero `local_ifindex`
-  makes `maybe_reinject_slow_path_from_frame` route the reinject through
-  the GRE `local_tunnel_deliveries` channel instead of the generic
-  kernel TUN injector (`tx/dispatch/slow_path.rs`), mis-delivering
-  IPsec-to-self. Carrying a real ingress ifindex here would NOT enforce
-  host-inbound (the gate is never reached); the real ingress ifindex is
-  carried only in telemetry via `meta`.
+- **ESP (50) / AH (51) and the IPsec data plane are unconditionally
+  EXEMPT** — always passed through (`Passthrough`), regardless of the
+  zone's `host-inbound-traffic system-services ike`/`ipsec`. The
+  negotiated SA is the authorization (Junos parity), mirroring the
+  kernel chain's global `meta l4proto { 50, 51 } accept`. ESP-in-UDP on
+  4500 (a non-zero ESP SPI in the first payload word) and the 1-byte
+  NAT-T keepalive are demuxed as data plane and stay exempt too.
+- **A NEW inbound IKE initiation is GATED (#4323 Option B).** The FIRST
+  packet of a new IKE exchange — an ISAKMP header whose **Responder
+  SPI/cookie is all-zero** (IKEv2 IKE_SA_INIT request / IKEv1 Main- or
+  Aggressive-mode first message; on UDP 4500 the ISAKMP follows the RFC
+  3948 4-byte non-ESP marker) — is admitted only if the resolved ingress
+  zone lists `ike`/`ipsec`. A zone that omits the token DROPS it
+  (`Denied`, silent, `host_inbound_denied_packets` accounted +
+  `RT_FLOW_CLOSE_REASON_HOST_INBOUND` event) so an unsolicited inbound
+  IKE never reaches the local IKE daemon (strongSwan).
+- **Every established/reply IKE packet stays EXEMPT.** Once the exchange
+  is under way the Responder SPI is set, so `classify_ipsec_admission`
+  returns `Exempt` — the stateless mirror of the kernel chain's `ct
+  established,related accept`-first ordering. Return IKE (e.g. the reply
+  for a firewall-initiated tunnel) is never dropped even on a zone that
+  omits `ike`, which is why the gate needs no conntrack state (the
+  secondary path installs no session for a passthrough flow, so a
+  session lookup would be dead). Residual: a forged non-zero Responder
+  SPI on a NEW packet would read as `Exempt` and reach strongSwan, which
+  drops it as an unknown SA — the initiation packet that actually
+  establishes a tunnel always carries a zero Responder SPI and is gated.
 
-**Deferred hardening (Option B).** A per-zone host-inbound gate for NEW
-IKE / inner-ESP at Stage 11 is a scoped, low-priority follow-up. To be
-correct it must reproduce the kernel chain's `ct established,related
-accept`-first ordering (else it drops return/established IKE — e.g. the
-reply for a firewall-initiated tunnel) and resolve the correct logical /
-GRE-inner ingress zone (not a raw physical-ifindex zone lookup). The
-exposure it would close is real but config-gated (native GRE + inner
-IPsec-to-self, or DNAT-to-self IKE, on a zone omitting `ike`/`ipsec`),
-so it is deferred rather than shipped. See
-`docs/research/3616-ipsec-host-inbound/plan.md`.
+**Two enforcement paths.** The PRIMARY host-inbound enforcement for
+IPsec-to-self is the kernel nftables chain (`pkg/daemon/daemon_nft.go`).
+The XDP shim shunts direct local-destination IPsec to the kernel BEFORE
+userspace-dp sees it — raw outer ESP is shunted unconditionally
+(`userspace-xdp/src/lib.rs`), and IKE/AH to a local address ride the
+`is_local_destination` shunt. That chain accepts raw ESP/AH globally,
+gates NEW inbound IKE on `system-services ike`/`ipsec`, and lets
+established/return IKE ride `ct established,related accept` first.
+`TestHostInboundFilterExemptsIPsecAndV6Errors` guards that ordering. The
+SECONDARY AF_XDP path (Stage 11) is reached only when IPsec is NOT
+shunted to the kernel: DNAT/static-NAT-to-self IKE, native-GRE inner
+IPsec whose inner destination is a firewall-local address (redirected to
+the XSK and decapped in userspace), and transit/NAT IPv4 AH. The #4323
+gate closes the NEW-inbound-IKE host-inbound parity gap on this path.
+
+**Zone resolution.** The gate resolves the LOGICAL ingress ifindex +
+from-zone exactly as the local-delivery resolver does
+(`resolve_ingress_logical_ifindex` + `zone_pair_ids_for_flow_with_override`
+with the `ingress_zone_override` from fabric-ingress classification), so
+a VLAN sub-interface keys its own unit and a per-interface host-inbound
+override governs where present — not a raw physical-ifindex zone lookup.
+
+**The synthetic reinject decision keeps `local_ifindex` = 0**
+(`ipsec_passthrough_decision`). It MUST: a non-zero `local_ifindex`
+makes `maybe_reinject_slow_path_from_frame` route the reinject through
+the GRE `local_tunnel_deliveries` channel instead of the generic kernel
+TUN injector (`tx/dispatch/slow_path.rs`), mis-delivering IPsec-to-self.
+The #4323 gate is a SEPARATE admit check BEFORE the reinject, never a
+change to the routing decision's `local_ifindex`. See
+`docs/research/3616-ipsec-host-inbound/plan.md` (Option B).

--- a/userspace-dp/src/afxdp/forwarding/host_inbound.rs
+++ b/userspace-dp/src/afxdp/forwarding/host_inbound.rs
@@ -152,13 +152,15 @@ fn classify_system_service(token: &str, hi: &mut ZoneHostInbound) {
         // before host-inbound enforcement, so `ipsec` is effectively a superset
         // of `ike`. Aliased to keep parity with the nft mirror + the #3200 SSOT.
         //
-        // #3616: this admit set gates IKE only on the PRIMARY kernel nftables
-        // host-inbound path (`pkg/daemon/daemon_nft.go`). The SECONDARY AF_XDP
-        // `stage_ipsec_passthrough_check` recognizes ESP/AH/IKE and reinjects
-        // them toward the kernel XFRM stack BEFORE this gate runs, so on that
-        // path the token's udp-500/4500 admit is never consulted — IPsec
-        // passthrough is EXEMPT (ratified #3616 Option A). Gating NEW IKE /
-        // inner-ESP at Stage 11 is deferred hardening (Option B).
+        // #3616/#4323: this admit set gates IKE on BOTH host-inbound paths. On
+        // the PRIMARY kernel nftables path (`pkg/daemon/daemon_nft.go`) it opens
+        // udp 500/4500 per zone. On the SECONDARY AF_XDP path
+        // (`stage_ipsec_passthrough_check`, #4323 Option B) the same udp-500/4500
+        // admit is consulted for a NEW inbound IKE initiation (an ISAKMP header
+        // with an all-zero Responder SPI) via `host_inbound_admits_iface`: a zone
+        // omitting `ike`/`ipsec` drops it before it reaches the local IKE daemon.
+        // Raw ESP/AH and every established/reply IKE packet stay EXEMPT on that
+        // path (ratified #3616 Option A) — the SA is the authorization.
         "ike" | "ipsec" => {
             hi.udp_ports.insert(500);
             hi.udp_ports.insert(4500);

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -1305,6 +1305,82 @@ pub(super) fn is_ipsec_traffic(protocol: u8, dst_port: u16) -> bool {
         || (protocol == PROTO_UDP && (dst_port == 500 || dst_port == 4500))
 }
 
+/// #4323: the Stage-11 admission class of an IPsec packet that `is_ipsec_traffic`
+/// already matched. Only a NEW inbound IKE initiation is subject to the per-zone
+/// host-inbound `ike`/`ipsec` gate; every other IPsec class is unconditionally
+/// exempt (the negotiated SA is the authorization).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum IpsecAdmissionClass {
+    /// ESP/AH raw data plane, ESP-in-UDP, a NAT-T keepalive, OR a NON-initial
+    /// IKE packet (the exchange already carries a responder SPI). Always
+    /// passthrough — mirrors the kernel host-inbound chain's global
+    /// `meta l4proto { 50, 51 } accept` (ESP/AH) and `ct established,related
+    /// accept` (later IKE), so the IPsec data plane and every return/reply IKE
+    /// packet transit even on a zone that omits `ike`.
+    Exempt,
+    /// The FIRST packet of a NEW inbound IKE exchange (we would be the
+    /// responder): an ISAKMP header whose Responder SPI/cookie is all-zero
+    /// (IKEv2 IKE_SA_INIT request / IKEv1 Main- or Aggressive-mode first
+    /// message). This is the packet the Junos `system-services ike` knob is
+    /// meant to gate, so it is subject to the per-zone host-inbound admit check.
+    NewInboundIke,
+}
+
+/// #4323: classify an IPsec packet (one `is_ipsec_traffic` matched) into its
+/// Stage-11 admission class. Only a NEW inbound IKE initiation
+/// ([`IpsecAdmissionClass::NewInboundIke`]) is gated on host-inbound; every
+/// other class is [`IpsecAdmissionClass::Exempt`] (unconditional passthrough).
+///
+/// New-vs-established is derived STATELESSLY from the ISAKMP header rather than
+/// from conntrack state (the userspace-dp secondary path installs no session for
+/// a passthrough flow, so a session lookup would be dead here): the first packet
+/// of a new exchange has an all-zero Responder SPI, and every later packet
+/// carries the responder's SPI. This admits all return/reply IKE (the AGY-M2
+/// established-first requirement) without a session table.
+///
+/// `l4_offset` is the UDP header offset within `packet_frame`; the ISAKMP header
+/// follows the 8-byte UDP header (and, on NAT-T UDP 4500, the 4-byte non-ESP
+/// marker). A missing / too-short ISAKMP header fails CLOSED (`NewInboundIke`) so
+/// a truncated IKE to an unpermitted source is gated, never silently admitted.
+pub(super) fn classify_ipsec_admission(
+    packet_frame: &[u8],
+    l4_offset: usize,
+    protocol: u8,
+    dst_port: u16,
+) -> IpsecAdmissionClass {
+    // ESP (50) / AH (51): raw IPsec data plane — the SA is the authorization.
+    if protocol != PROTO_UDP {
+        return IpsecAdmissionClass::Exempt;
+    }
+    // UDP payload (ISAKMP or, on 4500, the NAT-T non-ESP marker) starts after
+    // the fixed 8-byte UDP header.
+    let Some(payload) = packet_frame.get(l4_offset + 8..) else {
+        return IpsecAdmissionClass::NewInboundIke;
+    };
+    let isakmp = if dst_port == 4500 {
+        // RFC 3948 NAT-T demux: a 4-byte all-zero non-ESP marker precedes IKE on
+        // UDP 4500. Anything else on 4500 is ESP-in-UDP (its non-zero ESP SPI is
+        // the first word) or a 1-byte NAT-T keepalive — both exempt like raw ESP.
+        match payload.get(0..4) {
+            Some([0, 0, 0, 0]) => &payload[4..],
+            _ => return IpsecAdmissionClass::Exempt,
+        }
+    } else {
+        // UDP 500 — ISAKMP directly, no non-ESP marker.
+        payload
+    };
+    // ISAKMP header: Initiator SPI [0..8], Responder SPI [8..16]. A new exchange's
+    // first packet carries an all-zero Responder SPI; a set Responder SPI means
+    // the exchange is under way (established/related) — exempt.
+    match isakmp.get(8..16) {
+        Some(responder_spi) if responder_spi.iter().all(|&b| b == 0) => {
+            IpsecAdmissionClass::NewInboundIke
+        }
+        Some(_) => IpsecAdmissionClass::Exempt,
+        None => IpsecAdmissionClass::NewInboundIke,
+    }
+}
+
 #[cfg(test)]
 pub(super) fn lookup_forwarding_for_ip(
     state: &ForwardingState,

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -26,10 +26,10 @@ use flow_cache_hit::{FlowCacheOutcome, stage_flow_cache_hit};
 use rx_telemetry::record_rx_descriptor_telemetry;
 
 use super::poll_stages::{
-    FabricIngressOutcome, ScreenCheckOutcome, StageOutcome, SynCookieAckOutcome,
-    stage_classify_fabric_ingress, stage_ipsec_passthrough_check, stage_link_layer_classify,
-    stage_native_gre_decap, stage_parse_flow_and_learn, stage_screen_check,
-    stage_screen_syn_cookie_ack_on_session_miss,
+    FabricIngressOutcome, IpsecPassthroughOutcome, ScreenCheckOutcome, StageOutcome,
+    SynCookieAckOutcome, stage_classify_fabric_ingress, stage_ipsec_passthrough_check,
+    stage_link_layer_classify, stage_native_gre_decap, stage_parse_flow_and_learn,
+    stage_screen_check, stage_screen_syn_cookie_ack_on_session_miss,
 };
 use super::*;
 use crate::policy::evaluate_policy_result_with_icmp;
@@ -737,17 +737,43 @@ pub(super) fn poll_binding_process_descriptor(
                     }
                 }
                 // #946 Phase 1 stage 11: IPsec passthrough. ESP
-                // (proto 50) and IKE (UDP 500/4500) reinject via
-                // the slow-path TUN; recycle the UMEM frame.
-                if let StageOutcome::RecycleAndContinue = stage_ipsec_passthrough_check(
+                // (proto 50), AH and the IPsec data plane reinject via
+                // the slow-path TUN; recycle the UMEM frame. #4323: a NEW
+                // inbound IKE initiation the ingress zone's host-inbound
+                // set does not permit is denied here (silent drop) before
+                // it can reach the local IKE daemon.
+                match stage_ipsec_passthrough_check(
                     flow.as_ref(),
                     packet_frame,
                     meta,
+                    ingress_zone_override,
                     &binding.live,
                     worker_ctx,
                 ) {
-                    binding.scratch.scratch_recycle.push(desc.addr);
-                    continue;
+                    IpsecPassthroughOutcome::NotClaimed => {}
+                    IpsecPassthroughOutcome::Passthrough => {
+                        binding.scratch.scratch_recycle.push(desc.addr);
+                        continue;
+                    }
+                    IpsecPassthroughOutcome::Denied { from_zone_id } => {
+                        // #4323: NEW inbound IKE denied by the ingress zone's
+                        // host-inbound set. Emit the tuple-rich deny event and
+                        // account the drop (GlobalCtrHostInboundDeny), then
+                        // recycle the frame — a silent drop, never a reject.
+                        if let Some(flow) = flow.as_ref() {
+                            emit_host_inbound_deny(
+                                worker_ctx.forwarding,
+                                worker_ctx.event_stream,
+                                flow,
+                                meta,
+                                from_zone_id,
+                                now_ns,
+                            );
+                        }
+                        telemetry.counters.host_inbound_denied_packets += 1;
+                        binding.scratch.scratch_recycle.push(desc.addr);
+                        continue;
+                    }
                 }
                 // ── Flow cache fast path (#1327 Step 1) ────────────────
                 // Extracted to poll_descriptor/flow_cache_hit.rs. The

--- a/userspace-dp/src/afxdp/poll_stages.rs
+++ b/userspace-dp/src/afxdp/poll_stages.rs
@@ -857,39 +857,102 @@ fn ipsec_passthrough_decision() -> SessionDecision {
     }
 }
 
+/// #4323: the outcome of Stage 11 (IPsec passthrough) for the poll loop.
+pub(super) enum IpsecPassthroughOutcome {
+    /// Not IPsec (or no parsed flow) — the packet falls through Stage 11
+    /// unchanged and the caller keeps processing it.
+    NotClaimed,
+    /// IPsec traffic reinjected toward the kernel XFRM stack — the caller
+    /// recycles the UMEM frame and moves to the next descriptor.
+    Passthrough,
+    /// A NEW inbound IKE initiation the ingress zone's host-inbound set does
+    /// NOT permit — a silent drop (Junos host-inbound posture). The caller
+    /// recycles the frame, accounts `host_inbound_denied_packets`, and emits the
+    /// tuple-rich host-inbound deny event on `from_zone_id`.
+    Denied { from_zone_id: u16 },
+}
+
 /// Stage 11 — IPsec passthrough.
 ///
 /// ESP (proto 50), AH (proto 51, IPv4) and IKE (UDP 500/4500) must
 /// transit the kernel XFRM subsystem. On a match, this stage builds a
 /// synthetic `SessionDecision` with `LocalDelivery` disposition
 /// (`ipsec_passthrough_decision`) and reinjects the packet via the
-/// slow-path TUN device, then signals `RecycleAndContinue` so the
-/// caller drops the UMEM frame.
+/// slow-path TUN device, then returns `Passthrough` so the caller drops
+/// the UMEM frame.
 ///
-/// This passthrough runs BEFORE the per-zone host-inbound admission
-/// gate and is EXEMPT from it — the ratified userspace-dataplane
-/// semantic (#3616 Option A). Direct host-bound IPsec-to-self is
-/// enforced on the PRIMARY path by the kernel nftables host-inbound
-/// chain (`pkg/daemon/daemon_nft.go`), which gates NEW inbound IKE on
-/// `system-services ike`/`ipsec` while accepting raw ESP/AH globally and
-/// letting established/return IKE ride `ct established,related accept`.
-/// Gating NEW IKE / inner-ESP on this SECONDARY AF_XDP path is deferred
-/// (Option B — see `ipsec_passthrough_decision`).
+/// #4323 (Option B): a NEW inbound IKE initiation (an ISAKMP header with an
+/// all-zero Responder SPI — see `classify_ipsec_admission`) is first gated on
+/// the ingress zone's host-inbound `ike`/`ipsec` admission. A zone that omits
+/// `ike` drops the unsolicited inbound IKE (`Denied`) so it never reaches the
+/// local IKE daemon; a zone that lists `ike`/`ipsec` admits it. ESP/AH, the
+/// IPsec data plane (ESP-in-UDP / NAT-T keepalive) and every established/reply
+/// IKE packet stay EXEMPT (unconditional passthrough) — the SA is the
+/// authorization, mirroring the kernel chain's global ESP/AH accept and
+/// `ct established,related accept` for return IKE.
 ///
-/// Non-IPsec packets fall through unchanged.
+/// This SECONDARY AF_XDP path is reached by DNAT/static-NAT-to-self IKE and by
+/// native-GRE-inner local IPsec; direct IKE to a firewall interface IP / VIP is
+/// still enforced on the PRIMARY path by the kernel nftables host-inbound chain
+/// (`pkg/daemon/daemon_nft.go`).
+///
+/// Non-IPsec packets fall through unchanged (`NotClaimed`).
 #[inline]
 pub(super) fn stage_ipsec_passthrough_check(
     flow: Option<&SessionFlow>,
     packet_frame: &[u8],
     meta: UserspaceDpMeta,
+    ingress_zone_override: Option<u16>,
     binding_live: &BindingLiveState,
     worker_ctx: &WorkerContext,
-) -> StageOutcome<()> {
+) -> IpsecPassthroughOutcome {
     let Some(flow) = flow else {
-        return StageOutcome::Continue(());
+        return IpsecPassthroughOutcome::NotClaimed;
     };
-    if !is_ipsec_traffic(meta.protocol, flow.forward_key.dst_port) {
-        return StageOutcome::Continue(());
+    let dst_port = flow.forward_key.dst_port;
+    if !is_ipsec_traffic(meta.protocol, dst_port) {
+        return IpsecPassthroughOutcome::NotClaimed;
+    }
+    // #4323 Option B: gate ONLY a NEW inbound IKE initiation; ESP/AH and every
+    // established/related IPsec class stay unconditionally exempt.
+    if let crate::afxdp::forwarding::IpsecAdmissionClass::NewInboundIke =
+        crate::afxdp::forwarding::classify_ipsec_admission(
+            packet_frame,
+            meta.l4_offset as usize,
+            meta.protocol,
+            dst_port,
+        )
+    {
+        // Resolve the LOGICAL ingress ifindex + from-zone exactly as the
+        // local-delivery resolver does (a VLAN sub-interface keys its own unit;
+        // a fabric-ingress packet keys the override zone), then apply the
+        // per-interface / per-zone host-inbound admit check.
+        // `host_inbound_admits_iface` honours a per-interface override where one
+        // exists and otherwise falls back to the from-zone set.
+        let ingress_logical = crate::afxdp::forwarding::resolve_ingress_logical_ifindex(
+            worker_ctx.forwarding,
+            meta.ingress_ifindex as i32,
+            meta.ingress_vlan_id,
+        )
+        .unwrap_or(meta.ingress_ifindex as i32);
+        let (from_zone_id, _to_zone_id) =
+            crate::afxdp::forwarding::zone_pair_ids_for_flow_with_override(
+                worker_ctx.forwarding,
+                ingress_logical,
+                ingress_zone_override,
+                0,
+            );
+        if !crate::afxdp::forwarding::host_inbound_admits_iface(
+            worker_ctx.forwarding,
+            ingress_logical,
+            from_zone_id,
+            PROTO_UDP,
+            dst_port,
+            matches!(flow.dst_ip, IpAddr::V6(_)),
+            0,
+        ) {
+            return IpsecPassthroughOutcome::Denied { from_zone_id };
+        }
     }
     let ipsec_decision = ipsec_passthrough_decision();
     maybe_reinject_slow_path_from_frame(
@@ -904,7 +967,7 @@ pub(super) fn stage_ipsec_passthrough_check(
         "slow_path",
         worker_ctx.forwarding,
     );
-    StageOutcome::RecycleAndContinue
+    IpsecPassthroughOutcome::Passthrough
 }
 
 #[cfg(test)]
@@ -3095,20 +3158,20 @@ mod tests {
             1,
         );
 
-        // Ratified-EXEMPT classes: each is passed through (reinjected)
-        // regardless of the zone host-inbound config. The `nat_snapshot`
-        // fixture zones are host-inbound ENFORCING (`system-services all`); the
-        // exemption would hold identically on a zone that OMITS ike/ipsec —
-        // Stage 11 never consults the host-inbound set. AH is v4-only (the shim
-        // walks the IPv6 NEXTHDR_AUTH header, see README). (family, proto, dst).
+        // UNCONDITIONALLY-EXEMPT classes: raw ESP/AH are passed through
+        // (reinjected) regardless of the zone host-inbound config — the
+        // negotiated SA is the authorization, mirroring the kernel chain's global
+        // `meta l4proto { 50, 51 } accept`. The `nat_snapshot` fixture zones
+        // carry `system-services all`, but the ESP/AH exemption holds identically
+        // on a zone that OMITS ike/ipsec (Stage 11 never consults the
+        // host-inbound set for these classes). AH is v4-only (the shim walks the
+        // IPv6 NEXTHDR_AUTH header, see README). IKE (UDP 500/4500) admission is
+        // now GATED on host-inbound (#4323) and is covered separately by
+        // `stage_ipsec_passthrough_gates_new_ike_4323`. (family, proto, dst).
         let exempt = [
-            (libc::AF_INET, PROTO_ESP, 0u16),     // IPv4 ESP
-            (libc::AF_INET, PROTO_AH, 0u16),      // IPv4 AH (v4-only)
-            (libc::AF_INET, PROTO_UDP, 500u16),   // IPv4 IKE
-            (libc::AF_INET, PROTO_UDP, 4500u16),  // IPv4 NAT-T
-            (libc::AF_INET6, PROTO_ESP, 0u16),    // IPv6 ESP
-            (libc::AF_INET6, PROTO_UDP, 500u16),  // IPv6 IKE
-            (libc::AF_INET6, PROTO_UDP, 4500u16), // IPv6 NAT-T
+            (libc::AF_INET, PROTO_ESP, 0u16),  // IPv4 ESP
+            (libc::AF_INET, PROTO_AH, 0u16),   // IPv4 AH (v4-only)
+            (libc::AF_INET6, PROTO_ESP, 0u16), // IPv6 ESP
         ];
         for (family, protocol, dst_port) in exempt {
             let flow = ipsec_flow(family, protocol, dst_port);
@@ -3116,24 +3179,31 @@ mod tests {
             meta.addr_family = family as u8;
             meta.protocol = protocol;
             let outcome =
-                stage_ipsec_passthrough_check(Some(&flow), &frame, meta, &live, &worker_ctx);
+                stage_ipsec_passthrough_check(Some(&flow), &frame, meta, None, &live, &worker_ctx);
             assert!(
-                matches!(outcome, StageOutcome::RecycleAndContinue),
-                "Stage 11 must exempt IPsec (family {family}, proto {protocol}, \
+                matches!(outcome, IpsecPassthroughOutcome::Passthrough),
+                "Stage 11 must exempt raw IPsec (family {family}, proto {protocol}, \
                  dst_port {dst_port}) from host-inbound and reinject it \
-                 (RecycleAndContinue) — ratified #3616 Option A"
+                 (Passthrough) — ratified #3616 Option A / #4323 ESP-AH exemption"
             );
         }
 
         // Non-IPsec traffic is NOT intercepted — it falls through Stage 11
-        // unchanged (`Continue`).
+        // unchanged (`NotClaimed`).
         let non_ipsec = ipsec_flow(libc::AF_INET, PROTO_UDP, 443);
         let mut meta = tcp_v4_meta(&frame, TCP_FLAG_ACK);
         meta.protocol = PROTO_UDP;
         assert!(
             matches!(
-                stage_ipsec_passthrough_check(Some(&non_ipsec), &frame, meta, &live, &worker_ctx),
-                StageOutcome::Continue(())
+                stage_ipsec_passthrough_check(
+                    Some(&non_ipsec),
+                    &frame,
+                    meta,
+                    None,
+                    &live,
+                    &worker_ctx
+                ),
+                IpsecPassthroughOutcome::NotClaimed
             ),
             "non-IPsec UDP (dst_port 443) must fall through Stage 11 unchanged"
         );
@@ -3142,10 +3212,316 @@ mod tests {
         let meta = tcp_v4_meta(&frame, TCP_FLAG_ACK);
         assert!(
             matches!(
-                stage_ipsec_passthrough_check(None, &frame, meta, &live, &worker_ctx),
-                StageOutcome::Continue(())
+                stage_ipsec_passthrough_check(None, &frame, meta, None, &live, &worker_ctx),
+                IpsecPassthroughOutcome::NotClaimed
             ),
             "a flowless packet is not claimed by Stage 11"
+        );
+    }
+
+    /// #4323: build a minimal IPv4/UDP frame whose UDP payload (offset 42, after
+    /// a 14-byte Ethernet + 20-byte IPv4 + 8-byte UDP header) carries an ISAKMP
+    /// header. `natt_marker` prepends the RFC 3948 4-byte non-ESP marker (as on
+    /// NAT-T UDP 4500); `responder_spi_zero` controls the Responder SPI — zero
+    /// marks the FIRST packet of a new exchange (a NEW inbound IKE), non-zero an
+    /// established/reply packet. Only the byte layout at/after `l4_offset` matters
+    /// to `classify_ipsec_admission`; the L2/L3/UDP header bytes are filler (the
+    /// stage reads `meta.protocol`, not the IP header, and does not verify
+    /// checksums).
+    fn ike_v4_frame(natt_marker: bool, responder_spi_zero: bool) -> Vec<u8> {
+        let mut frame = vec![0u8; 42];
+        frame[12] = 0x08; // IPv4 ethertype (readability only)
+        frame[13] = 0x00;
+        frame[14] = 0x45; // IPv4 version/IHL
+        frame[23] = PROTO_UDP; // IP protocol (readability only)
+        if natt_marker {
+            frame.extend_from_slice(&[0, 0, 0, 0]); // NAT-T non-ESP marker
+        }
+        // ISAKMP: Initiator SPI (non-zero), Responder SPI (zero or set).
+        frame.extend_from_slice(&[0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]);
+        if responder_spi_zero {
+            frame.extend_from_slice(&[0u8; 8]);
+        } else {
+            frame.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x00, 0x01]);
+        }
+        // next-payload / version (2.0) / exchange (34 = IKE_SA_INIT) / flags.
+        frame.extend_from_slice(&[0x00, 0x20, 0x22, 0x08]);
+        frame.extend_from_slice(&0u32.to_be_bytes()); // message id
+        frame.extend_from_slice(&0u32.to_be_bytes()); // length (filler)
+        frame
+    }
+
+    /// #4323: an ESP-in-UDP frame on UDP 4500 — the first payload word is a
+    /// NON-zero ESP SPI (NOT the all-zero non-ESP marker), so it is the IPsec
+    /// data plane and must stay EXEMPT, never gated as IKE.
+    fn esp_in_udp_v4_frame() -> Vec<u8> {
+        let mut frame = vec![0u8; 42];
+        frame[12] = 0x08;
+        frame[13] = 0x00;
+        frame[14] = 0x45;
+        frame[23] = PROTO_UDP;
+        frame.extend_from_slice(&[0xaa, 0xbb, 0xcc, 0xdd]); // ESP SPI (non-zero)
+        frame.extend_from_slice(&[0u8; 16]); // ESP seq + start of payload
+        frame
+    }
+
+    fn ike_v4_meta(frame: &[u8], ingress_ifindex: u32) -> UserspaceDpMeta {
+        UserspaceDpMeta {
+            magic: USERSPACE_META_MAGIC,
+            version: USERSPACE_META_VERSION,
+            length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+            ingress_ifindex,
+            l3_offset: 14,
+            l4_offset: 34,
+            payload_offset: 42,
+            pkt_len: (frame.len() - 14) as u16,
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_UDP,
+            ..UserspaceDpMeta::default()
+        }
+    }
+
+    /// #4323: a snapshot with a DENY zone (`deny-zone`, ifindex 24, host-inbound
+    /// omits `ike`) and a PERMIT zone (`permit-zone`, ifindex 25, host-inbound
+    /// lists `ike`), so the Stage-11 IKE gate can be exercised on both.
+    fn ike_gate_snapshot() -> crate::ConfigSnapshot {
+        use crate::test_zone_ids::{TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID};
+        crate::ConfigSnapshot {
+            zones: vec![
+                crate::ZoneSnapshot {
+                    name: "deny-zone".to_string(),
+                    id: TEST_LAN_ZONE_ID,
+                    host_inbound_configured: true,
+                    // ping only — NO ike/ipsec, so a NEW inbound IKE is denied.
+                    host_inbound_system_services: vec!["ping".to_string()],
+                    ..Default::default()
+                },
+                crate::ZoneSnapshot {
+                    name: "permit-zone".to_string(),
+                    id: TEST_WAN_ZONE_ID,
+                    host_inbound_configured: true,
+                    host_inbound_system_services: vec!["ike".to_string()],
+                    ..Default::default()
+                },
+            ],
+            interfaces: vec![
+                crate::InterfaceSnapshot {
+                    name: "ge-0-0-1".to_string(),
+                    zone: "deny-zone".to_string(),
+                    linux_name: "ge-0-0-1".to_string(),
+                    ifindex: 24,
+                    hardware_addr: "02:bf:72:01:00:01".to_string(),
+                    addresses: vec![crate::InterfaceAddressSnapshot {
+                        family: "inet".to_string(),
+                        address: "10.0.61.1/24".to_string(),
+                        scope: 0,
+                    }],
+                    ..Default::default()
+                },
+                crate::InterfaceSnapshot {
+                    name: "ge-0-0-2".to_string(),
+                    zone: "permit-zone".to_string(),
+                    linux_name: "ge-0-0-2".to_string(),
+                    ifindex: 25,
+                    hardware_addr: "02:bf:72:02:00:01".to_string(),
+                    addresses: vec![crate::InterfaceAddressSnapshot {
+                        family: "inet".to_string(),
+                        address: "172.16.80.8/24".to_string(),
+                        scope: 0,
+                    }],
+                    ..Default::default()
+                },
+            ],
+            default_policy: "deny".to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// #4323 RED-on-revert: Stage 11 gates a NEW inbound IKE initiation on the
+    /// ingress zone's host-inbound `ike`/`ipsec` admission, while ESP/AH, the
+    /// IPsec data plane (ESP-in-UDP) and every established/reply IKE packet stay
+    /// exempt (unconditional passthrough).
+    ///
+    /// - NEW IKE (Responder SPI == 0) from a zone OMITTING ike  → `Denied`.
+    /// - NEW IKE from a zone LISTING ike                        → `Passthrough`.
+    /// - NEW NAT-T IKE (4500 + non-ESP marker) from deny zone   → `Denied`.
+    /// - established IKE (Responder SPI set) from deny zone      → `Passthrough`.
+    /// - ESP-in-UDP (4500, non-marker) from deny zone           → `Passthrough`.
+    /// - raw ESP from deny zone                                  → `Passthrough`.
+    ///
+    /// Fail-on-revert: drop the `NewInboundIke` gate (always reinject) and the
+    /// two `Denied` assertions flip — a NEW inbound IKE from an unpermitted
+    /// source would reach the local IKE daemon unfiltered.
+    #[test]
+    fn stage_ipsec_passthrough_gates_new_ike_4323() {
+        const DENY_IF: u32 = 24;
+        const PERMIT_IF: u32 = 25;
+
+        let forwarding = build_forwarding_state(&ike_gate_snapshot());
+        let ident = BindingIdentity {
+            slot: 0,
+            queue_id: 0,
+            worker_id: 0,
+            interface: Arc::<str>::from("ge-0-0-1"),
+            ifindex: DENY_IF as i32,
+        };
+        let live = BindingLiveState::new();
+        let binding_lookup = WorkerBindingLookup::default();
+        let mirror_targets = MirrorTargetMap::default();
+        let ha_state = BTreeMap::new();
+        let dynamic_neighbors = Arc::new(ShardedNeighborMap::default());
+        let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+        let local_tunnel_deliveries = Arc::new(ArcSwap::from_pointee(BTreeMap::new()));
+        let recent_exceptions = Arc::new(Mutex::new(VecDeque::new()));
+        let last_resolution = Arc::new(Mutex::new(None));
+        let peer_worker_commands = Vec::new();
+        let dnat_fds = DnatTableFds::default();
+        let rg_epochs = std::array::from_fn(|_| AtomicU32::new(0));
+        let (event_handle, _event_rx) = crate::event_stream::test_worker_handle(
+            8,
+            DataplaneEventRateLimitConfig {
+                events_per_second: 0,
+                burst: 0,
+            },
+        );
+        let worker_ctx = WorkerContext {
+            ident: &ident,
+            binding_lookup: &binding_lookup,
+            mirror_targets: &mirror_targets,
+            forwarding: &forwarding,
+            ha_state: &ha_state,
+            dynamic_neighbors: &dynamic_neighbors,
+            neighbor_resolver: None,
+            shared_sessions: &shared_sessions,
+            shared_nat_sessions: &shared_nat_sessions,
+            shared_forward_wire_sessions: &shared_forward_wire_sessions,
+            shared_owner_rg_indexes: &shared_owner_rg_indexes,
+            slow_path: None,
+            event_stream: Some(&event_handle),
+            local_tunnel_deliveries: &local_tunnel_deliveries,
+            recent_exceptions: &recent_exceptions,
+            last_resolution: &last_resolution,
+            peer_worker_commands: &peer_worker_commands,
+            dnat_fds: &dnat_fds,
+            rg_epochs: &rg_epochs,
+            cold_path_sample_mask: 0xff,
+        };
+
+        // NEW inbound IKE (Responder SPI == 0) on the DENY zone → dropped.
+        let new_ike = ike_v4_frame(false, true);
+        let flow = ipsec_flow(libc::AF_INET, PROTO_UDP, 500);
+        let outcome = stage_ipsec_passthrough_check(
+            Some(&flow),
+            &new_ike,
+            ike_v4_meta(&new_ike, DENY_IF),
+            None,
+            &live,
+            &worker_ctx,
+        );
+        assert!(
+            matches!(
+                outcome,
+                IpsecPassthroughOutcome::Denied {
+                    from_zone_id
+                } if from_zone_id == TEST_LAN_ZONE_ID
+            ),
+            "NEW inbound IKE from a zone omitting `ike` must be Denied (silent \
+             drop), not reach the IKE daemon (#4323)",
+        );
+
+        // NEW inbound IKE on the PERMIT zone → admitted (passthrough).
+        let permit_flow = ipsec_flow(libc::AF_INET, PROTO_UDP, 500);
+        assert!(
+            matches!(
+                stage_ipsec_passthrough_check(
+                    Some(&permit_flow),
+                    &new_ike,
+                    ike_v4_meta(&new_ike, PERMIT_IF),
+                    None,
+                    &live,
+                    &worker_ctx,
+                ),
+                IpsecPassthroughOutcome::Passthrough
+            ),
+            "NEW inbound IKE from a zone listing `ike` must be admitted (Passthrough)",
+        );
+
+        // NEW NAT-T IKE (UDP 4500 + non-ESP marker, Responder SPI == 0) on the
+        // DENY zone → dropped.
+        let new_natt = ike_v4_frame(true, true);
+        let natt_flow = ipsec_flow(libc::AF_INET, PROTO_UDP, 4500);
+        assert!(
+            matches!(
+                stage_ipsec_passthrough_check(
+                    Some(&natt_flow),
+                    &new_natt,
+                    ike_v4_meta(&new_natt, DENY_IF),
+                    None,
+                    &live,
+                    &worker_ctx,
+                ),
+                IpsecPassthroughOutcome::Denied { .. }
+            ),
+            "NEW inbound NAT-T IKE (4500) from a zone omitting `ike` must be Denied",
+        );
+
+        // ESTABLISHED IKE (Responder SPI set) on the DENY zone → passthrough
+        // (mirrors `ct established,related accept`; return/reply IKE never drops).
+        let est_ike = ike_v4_frame(false, false);
+        assert!(
+            matches!(
+                stage_ipsec_passthrough_check(
+                    Some(&flow),
+                    &est_ike,
+                    ike_v4_meta(&est_ike, DENY_IF),
+                    None,
+                    &live,
+                    &worker_ctx,
+                ),
+                IpsecPassthroughOutcome::Passthrough
+            ),
+            "established/reply IKE (Responder SPI set) must stay exempt even on a \
+             zone omitting `ike` — established-first ordering (#4323)",
+        );
+
+        // ESP-in-UDP (UDP 4500, first word a non-zero ESP SPI, NOT a marker) on
+        // the DENY zone → passthrough (IPsec data plane, exempt like raw ESP).
+        let esp_udp = esp_in_udp_v4_frame();
+        assert!(
+            matches!(
+                stage_ipsec_passthrough_check(
+                    Some(&natt_flow),
+                    &esp_udp,
+                    ike_v4_meta(&esp_udp, DENY_IF),
+                    None,
+                    &live,
+                    &worker_ctx,
+                ),
+                IpsecPassthroughOutcome::Passthrough
+            ),
+            "ESP-in-UDP on 4500 must stay exempt (data plane), never gated as IKE",
+        );
+
+        // Raw ESP (proto 50) on the DENY zone → passthrough (SA authorizes).
+        let esp_flow = ipsec_flow(libc::AF_INET, PROTO_ESP, 0);
+        let mut esp_meta = ike_v4_meta(&new_ike, DENY_IF);
+        esp_meta.protocol = PROTO_ESP;
+        assert!(
+            matches!(
+                stage_ipsec_passthrough_check(
+                    Some(&esp_flow),
+                    &new_ike,
+                    esp_meta,
+                    None,
+                    &live,
+                    &worker_ctx,
+                ),
+                IpsecPassthroughOutcome::Passthrough
+            ),
+            "raw ESP must stay unconditionally exempt on any zone (#4323)",
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes #4323 (deferred Option B hardening from #3616).

Stage 11 (`stage_ipsec_passthrough_check`) reinjected **all** IPsec (ESP/AH/IKE) toward the kernel XFRM stack unconditionally. On the SECONDARY AF_XDP path — DNAT/static-NAT-to-self IKE and native-GRE-inner local IPsec — an unsolicited inbound IKE therefore reached the local IKE daemon (strongSwan) even on a zone that omits `host-inbound-traffic system-services ike`. The PRIMARY kernel nftables chain already gates NEW inbound IKE on that token; this brings the AF_XDP path to parity.

## The gate

`classify_ipsec_admission` (forwarding/mod.rs) splits an IPsec packet by class:

- **ESP (50) / AH (51) + IPsec data plane** (ESP-in-UDP on 4500, NAT-T keepalive) → `Exempt` (unconditional passthrough — the SA is the authorization; mirrors the kernel's global `meta l4proto { 50, 51 } accept`).
- **NEW inbound IKE initiation** — the first packet of a new exchange, an ISAKMP header whose **Responder SPI is all-zero** (IKEv2 IKE_SA_INIT request / IKEv1 first message; RFC-3948 non-ESP-marker demux on 4500) → `NewInboundIke`, gated on the ingress zone's `ike`/`ipsec`. A zone omitting the token → `Denied` (silent drop, `host_inbound_denied_packets` + `RT_FLOW_CLOSE_REASON_HOST_INBOUND`); a zone listing it → `Passthrough`.
- **Established/reply IKE** (Responder SPI set) → `Exempt` — the stateless mirror of `ct established,related accept`, so return IKE never drops.

**OQ5 (established-first) resolved statelessly** from the ISAKMP header — the secondary path installs no session for a passthrough flow, so a conntrack lookup would be dead. **OQ6 (zone)** reuses the resolver's logical ingress ifindex + `zone_pair_ids_for_flow_with_override(ingress_zone_override)`. **R4 preserved:** the gate is a separate admit **before** the reinject, never a `local_ifindex` change.

Residual (documented): a forged non-zero Responder SPI on a NEW packet reads as `Exempt` and reaches strongSwan, which drops it as an unknown SA — the initiation packet that actually establishes a tunnel always carries a zero Responder SPI and is gated.

## Validation

- New RED-on-revert `stage_ipsec_passthrough_gates_new_ike_4323`: NEW IKE denied-zone → Denied; permit-zone → Passthrough; NAT-T NEW IKE denied-zone → Denied; established IKE denied-zone → Passthrough; ESP-in-UDP + raw ESP denied-zone → Passthrough. Verified RED with the gate neutralized.
- `stage_ipsec_passthrough_exempts_all_classes_3616` narrowed to the unconditionally-exempt ESP/AH classes.
- Full cargo suite (serial): 3735 + 60 + 8 + 22 + 1 passed, 0 failed.
- `go test ./pkg/dataplane/...` green.
- This touches the dataplane forwarding/IPsec path — a per-zone host-inbound-IPsec-deny cluster smoke / security-matrix on real traffic is a nice-to-have follow-up (logic is unit-proven; the deny path reuses the existing #3070/#3485 host-inbound plumbing, mechanism unchanged).

## Docs

forwarding/README.md IPsec section, `docs/userspace-dataplane-architecture.md`, host_inbound.rs `ike`/`ipsec` arm, and `docs/research/3616-ipsec-host-inbound/plan.md` (DEFERRED → SHIPPED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi