### PR TITLE
policymatch/grpcapi: cover #4413 ps-review-007 dropped findings (app dual-port-range + gRPC broadcast route-drop)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,31 @@
+## 2026-07-08 — #4413 ps-review-007 dropped findings: driveable test-coverage
+
+- **Timestamp**: 2026-07-08
+- **Action**: #4413 triage of the six ps-review-007 dropped findings. Two were
+  genuine test-coverage gaps and are now covered with RED-on-revert tests; the
+  other four are already-fixed / already-tested / covered-by-note by merged work
+  and are dispositioned on the issue.
+    - Finding 6 (app both source-port AND destination-port ranges must match):
+      added `TestAppSrcAndDstPortRangesBothMustMatch` — a TCP app constrained on
+      source-port range 5000-6000 AND dest-port range 80-90, asserting AND
+      semantics + inclusive bounds. RED-on-revert on either the SourcePort or
+      DestinationPort guard in `matchSingleApp`, and on the inclusive range test
+      in `portMatches`.
+    - Finding 3 (gRPC broadcast route-drop advisory): added
+      `TestMatchPoliciesSurfacesBroadcastRouteDrop` — the gRPC MatchPolicies
+      handler must carry the #4373 RouteDropBeforePolicy/Class/Note advisory for
+      a broadcast destination on BOTH the matched and default-policy verdict
+      paths, and NOT for a unicast destination. RED-on-revert on the plumbing in
+      either return path of `server_cluster.go`.
+    - Findings 1/5 already-fixed (#4517 IPv6 exotic ext-header walkers + #2292
+      fail-closed-at-bound + #1852 non-first-fragment; #4392/#4534 PBR
+      routing-instance + discard/reject = DENY, with v4/v6 + Go kernel-mirror
+      tests). Finding 4 already-tested (#3642 output filter matches post-NAT
+      tuple). Finding 2 covered by the #4373 RouteDropNote text ("filter-accept
+      log").
+- **File(s)**: pkg/policymatch/app_srcdst_port_range_4413_test.go (new),
+  pkg/grpcapi/server_matchpolicies_routedrop_4413_test.go (new), _Log.md
+
 ## 2026-07-08 — #4407 increment 5: extract surfaceAState sub-struct
 
 - **Timestamp**: 2026-07-08

--- a/pkg/grpcapi/server_matchpolicies_routedrop_4413_test.go
+++ b/pkg/grpcapi/server_matchpolicies_routedrop_4413_test.go
@@ -1,0 +1,111 @@
+package grpcapi
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/policymatch"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// TestMatchPoliciesSurfacesBroadcastRouteDrop is the #4413 (ps-review-007
+// dropped finding) coverage for the gRPC surface: a broadcast (or other
+// route-drop-before-policy class) DESTINATION must carry the #4373 route-drop
+// advisory on the MatchPolicies response, so a gRPC / remote-CLI client is not
+// told a permit/deny verdict describes real forwarding for a destination the
+// transit path drops at route lookup BEFORE the policy engine. The advisory
+// rides EVERY verdict path — a positive match AND the default-policy
+// fall-through.
+//
+// This locks the gRPC handler's plumbing of RouteDropBeforePolicy /
+// RouteDropClass / RouteDropNote (server_cluster.go MatchPolicies), which the
+// #4373 policymatch-layer tests (pkg/policymatch/route_drop_4373_test.go) do
+// not exercise — those assert the simulator Result, not the transport response.
+//
+// RED-on-revert: dropping the RouteDropBeforePolicy/RouteDropClass/RouteDropNote
+// assignment from the matched OR the no-match/default return path in
+// server_cluster.go zeroes the corresponding response field and the matching
+// subtest below fails.
+func TestMatchPoliciesSurfacesBroadcastRouteDrop(t *testing.T) {
+	// hostInboundStore: trust->untrust permit, default deny, defined zones.
+	store := hostInboundStore(t)
+	s := &Server{store: store}
+
+	const bcast = "255.255.255.255"
+
+	// Positive match: trust->untrust permit-any matches even for a broadcast
+	// destination, but the packet never forwards — the advisory must ride the
+	// matched verdict.
+	t.Run("matched-permit", func(t *testing.T) {
+		resp, err := s.MatchPolicies(context.Background(), &pb.MatchPoliciesRequest{
+			FromZone:      "trust",
+			ToZone:        "untrust",
+			DestinationIp: bcast,
+		})
+		if err != nil {
+			t.Fatalf("MatchPolicies(match) error = %v", err)
+		}
+		if !resp.Matched {
+			t.Fatalf("Matched = false, want true (trust->untrust permit-any)")
+		}
+		assertBroadcastAdvisory(t, resp)
+	})
+
+	// No-match / default: untrust->trust has no rule -> default deny. The
+	// broadcast advisory must ride the default verdict too.
+	t.Run("default-deny", func(t *testing.T) {
+		resp, err := s.MatchPolicies(context.Background(), &pb.MatchPoliciesRequest{
+			FromZone:      "untrust",
+			ToZone:        "trust",
+			DestinationIp: bcast,
+		})
+		if err != nil {
+			t.Fatalf("MatchPolicies(default) error = %v", err)
+		}
+		if resp.Matched {
+			t.Fatalf("Matched = true, want false (default deny)")
+		}
+		if !resp.DefaultUsed {
+			t.Fatalf("DefaultUsed = false, want true (default deny path)")
+		}
+		assertBroadcastAdvisory(t, resp)
+	})
+
+	// Control: an ordinary unicast destination reaches the policy engine and
+	// must NOT carry the advisory on either verdict path — so the plumbing is
+	// destination-classified, not stamped unconditionally.
+	t.Run("unicast-no-advisory", func(t *testing.T) {
+		resp, err := s.MatchPolicies(context.Background(), &pb.MatchPoliciesRequest{
+			FromZone:      "trust",
+			ToZone:        "untrust",
+			DestinationIp: "10.0.2.7",
+		})
+		if err != nil {
+			t.Fatalf("MatchPolicies(unicast) error = %v", err)
+		}
+		if resp.RouteDropBeforePolicy || resp.RouteDropClass != "" || resp.RouteDropNote != "" {
+			t.Fatalf("unicast dst wrongly carries route-drop advisory: %+v", resp)
+		}
+	})
+}
+
+func assertBroadcastAdvisory(t *testing.T, resp *pb.MatchPoliciesResponse) {
+	t.Helper()
+	if !resp.RouteDropBeforePolicy {
+		t.Fatalf("RouteDropBeforePolicy = false, want true for a broadcast destination")
+	}
+	if resp.RouteDropClass != "broadcast" {
+		t.Fatalf("RouteDropClass = %q, want %q", resp.RouteDropClass, "broadcast")
+	}
+	if !strings.HasPrefix(resp.RouteDropNote, policymatch.RouteDropNotePrefix) {
+		t.Fatalf("RouteDropNote %q missing SSOT prefix %q", resp.RouteDropNote, policymatch.RouteDropNotePrefix)
+	}
+	if !strings.Contains(resp.RouteDropNote, "broadcast") {
+		t.Fatalf("RouteDropNote %q does not name class broadcast", resp.RouteDropNote)
+	}
+	if !strings.Contains(resp.RouteDropNote, "route lookup") {
+		t.Fatalf("RouteDropNote %q must state the packet is dropped at route lookup", resp.RouteDropNote)
+	}
+}

--- a/pkg/policymatch/app_srcdst_port_range_4413_test.go
+++ b/pkg/policymatch/app_srcdst_port_range_4413_test.go
@@ -1,0 +1,119 @@
+package policymatch
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// srcDstPortRangeAppCfg builds a trust->untrust permit policy whose application
+// term is a custom TCP app constrained to a SOURCE-port RANGE (5000-6000) AND a
+// DESTINATION-port RANGE (80-90). Both dimensions are ranges so this exercises
+// the range branch of portMatches on each axis simultaneously — the case the
+// single-axis #3330 (dest) / #3415 (source) suites do not cover.
+func srcDstPortRangeAppCfg() *config.Config {
+	sec := config.SecurityConfig{
+		DefaultPolicy: config.PolicyDeny,
+		Zones:         zones("trust", "untrust"),
+		Policies: []*config.ZonePairPolicies{
+			{
+				FromZone: "trust",
+				ToZone:   "untrust",
+				Policies: []*config.Policy{
+					{
+						Name:   "range-permit",
+						Action: config.PolicyPermit,
+						Match: config.PolicyMatch{
+							SourceAddresses:      []string{"any"},
+							DestinationAddresses: []string{"any"},
+							Applications:         []string{"dualrange"},
+						},
+					},
+				},
+			},
+		},
+	}
+	apps := config.ApplicationsConfig{
+		Applications: map[string]*config.Application{
+			"dualrange": {
+				Name:            "dualrange",
+				Protocol:        "tcp",
+				SourcePort:      "5000-6000",
+				DestinationPort: "80-90",
+			},
+		},
+	}
+	return cfgWith(sec, apps)
+}
+
+// TestAppSrcAndDstPortRangesBothMustMatch is the #4413 (ps-review-007 dropped
+// finding) coverage: an application constrained on BOTH a source-port range and
+// a destination-port range matches ONLY when the query's source port AND
+// destination port each fall inside their respective range (AND semantics),
+// mirroring the runtime — appid.matchTuple / policy.rs CompiledApplications.matches
+// gate a source-port-constrained app on source port AND a dest-port-constrained
+// app on dest port, both against inclusive ranges. matchSingleApp checks
+// app.SourcePort and app.DestinationPort independently and returns false if
+// either fails, so a query in only one range must NOT match.
+//
+// RED-on-revert (source axis): dropping the `if app.SourcePort != "" { ... }`
+// guard in matchSingleApp makes the "source-out, dest-in" subcase permit
+// (Matched=true) instead of falling to the default deny — this test goes RED.
+//
+// RED-on-revert (destination axis): dropping the `if app.DestinationPort != ""
+// { ... }` guard makes the "source-in, dest-out" subcase permit — RED.
+//
+// RED-on-revert (inclusive bounds): narrowing portMatches' range test to
+// exclusive (`> l && < h`) flips the boundary permits (5000/6000, 80/90) to
+// deny — RED.
+func TestAppSrcAndDstPortRangesBothMustMatch(t *testing.T) {
+	cfg := srcDstPortRangeAppCfg()
+
+	cases := []struct {
+		name        string
+		srcPort     int
+		dstPort     int
+		wantMatched bool
+	}{
+		// Both in range -> permit (positive control, mid-range).
+		{"both-mid-range", 5500, 85, true},
+		// Inclusive lower and upper bounds on both axes still match.
+		{"both-lower-bounds", 5000, 80, true},
+		{"both-upper-bounds", 6000, 90, true},
+
+		// Source in range, destination OUT of range -> deny (dest axis enforced).
+		{"src-in-dst-above", 5500, 91, false},
+		{"src-in-dst-below", 5500, 79, false},
+		// Source OUT of range, destination in range -> deny (source axis enforced).
+		{"src-above-dst-in", 6001, 85, false},
+		{"src-below-dst-in", 4999, 85, false},
+		// Both out of range -> deny.
+		{"both-out", 4999, 91, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := Match(cfg, Query{
+				FromZone: "trust",
+				ToZone:   "untrust",
+				Protocol: "tcp",
+				SrcPort:  tc.srcPort,
+				DstPort:  tc.dstPort,
+			})
+			if res.Matched != tc.wantMatched {
+				t.Fatalf("src=%d dst=%d: Matched = %v, want %v (res %+v)",
+					tc.srcPort, tc.dstPort, res.Matched, tc.wantMatched, res)
+			}
+			if tc.wantMatched {
+				if res.Action != config.PolicyPermit {
+					t.Fatalf("src=%d dst=%d: Action = %v, want permit", tc.srcPort, tc.dstPort, res.Action)
+				}
+			} else {
+				// A non-match falls through to the default deny — never a
+				// fabricated permit for a tuple outside the app's ranges.
+				if !res.DefaultUsed || res.Action != config.PolicyDeny {
+					t.Fatalf("src=%d dst=%d: want default-policy deny, got %+v", tc.srcPort, tc.dstPort, res)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Issue #4413 filed the six ps-review-007 findings that were dropped as nits.
This PR drives the two genuine test-coverage gaps with RED-on-revert tests and
dispositions the other four (already-fixed / already-tested / covered-by-note).

Both commits are **test-only** — no production source is touched.

### Driven (new RED-on-revert tests)

- **Finding 6 — application with both source-port and destination-port ranges.**
  `matchSingleApp` already ANDs the two port constraints and `portMatches`
  admits inclusive ranges, but the single-axis suites (#3330 dest, #3415 source)
  never cover both-range-at-once. New `TestAppSrcAndDstPortRangesBothMustMatch`
  (`pkg/policymatch/app_srcdst_port_range_4413_test.go`) locks the AND semantics
  + inclusive bounds. RED-on-revert verified on each port guard and on the range
  inclusivity.

- **Finding 3 — gRPC MatchPolicies broadcast route-drop advisory.** #4373 stamps
  the route-drop-before-policy advisory on the policymatch `Result` and the gRPC
  handler plumbs it, but the #4373 tests assert the simulator Result, not the
  transport response. New `TestMatchPoliciesSurfacesBroadcastRouteDrop`
  (`pkg/grpcapi/server_matchpolicies_routedrop_4413_test.go`) asserts the
  advisory rides both the matched and default verdict paths for a broadcast
  destination and is absent for unicast. RED-on-revert verified on both return
  paths of `server_cluster.go`.

### Dispositioned on the issue (no code change needed)

| Finding | Disposition | Evidence |
|---|---|---|
| 1 — IPv6 ext-headers + fragments + filter fail-closed | already-fixed | `frame_l4_offset`/`packet_rel_l4_offset` return `None` at the ext-header bound (#2292); `ipv6_is_non_first_fragment` (#1852); exotic EH walking (#4517); filter tests `non_first_fragment_*` |
| 2 — broadcast + filter-accept log misleading | covered-by-note | #4373 `RouteDropNote()` text explicitly names "the packet is dropped at route regardless of the matching policy / **filter-accept log**" |
| 4 — output filter with PBR + NAT order | already-tested | #3642 `output_filter_matches_post_snat_source_forward_leg_3642`, `output_filter_family_selected_by_egress_key_for_nat64_3642` (output filter matches the post-NAT tuple; PBR only affects route selection, not that tuple) |
| 5 — PBR routing-instance + then discard | already-fixed | #4392 `pbr_routing_instance_reject_or_discard_drops_not_forwards_v4/v6`; #4534 Go kernel-mirror RED-on-revert discard/reject subtests in `pkg/routing/routing_test.go` |

## Validation

- `go test ./pkg/policymatch/ ./pkg/grpcapi/` green.
- RED-on-revert confirmed for every new assertion (source-port guard, dest-port
  guard, range inclusivity; gRPC matched-path and default-path plumbing).
- gofmt, go vet, go build clean.

Closes #4413

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi