### PR TITLE
cli: surface queried ICMP type/code in `test policy` echo (#4497 F3)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -41725,3 +41725,25 @@ top.
   userspace-dp/src/afxdp/forwarding/README.md,
   docs/userspace-dataplane-architecture.md,
   docs/research/3616-ipsec-host-inbound/plan.md, _Log.md
+
+- **Timestamp**: 2026-07-08
+- **Action**: #4497 (avo-001 F3) — surface queried ICMP type/code in the
+  local CLI `test policy` query echo. The `testPolicy` verdict echoed
+  `Source: src -> dst:port [proto]` but dropped the ICMP type/code the
+  operator queried, so a `protocol icmp icmp-type 8 icmp-code 0` lookup
+  printed the bare `[icmp]` — hiding WHICH ICMP packet was tested even
+  though the parser already threads type/code into
+  `policymatch.Query.ICMPType/ICMPCode` (#3284) and the simulator matches
+  an icmp-type-constrained application (junos-ping = type 8). Added the
+  shared `formatQueryProtoTail` helper so the echo now reads
+  `[icmp type 8 code 0]`; a non-ICMP query prints the bare `[proto]`
+  unchanged. RED-on-revert test `testpolicy_icmp_4497_test.go`
+  (icmp-echoes-type/code + tcp-control-unaffected + a direct
+  `formatQueryProtoTail` unit table); verified RED with the echo reverted
+  (output regressed to `[icmp]`). F2 (Rust global-scope test mirror) was
+  done in #4639. Display-only Go change; no schema/wire impact. Possible
+  follow-ups (out of scope here): echo the tuple in `show security
+  match-policies` and add `queried_icmp_type/code` to the gRPC
+  `MatchPoliciesResponse` (proto regen; cargo/Rust lane busy).
+- **File(s)**: pkg/cli/cli_request.go,
+  pkg/cli/testpolicy_icmp_4497_test.go, pkg/cli/README.md, _Log.md

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -88,3 +88,13 @@ both the daemon-local CLI (xpfd in TTY mode) and the remote CLI
   scope), making it the poorest of the four match-policies surfaces. The
   rendering is shared via `printPolicyMatchIdentity`; it is a display-only change,
   no schema/wire impact.
+- #4497 (avo-001 F3): the local `test policy` (`testPolicy`) query echo now
+  surfaces the queried **ICMP/ICMPv6 type and code** in the trailing tuple
+  annotation. A `test policy … protocol icmp icmp-type 8 icmp-code 0` verdict
+  ends with `… [icmp type 8 code 0]` (previously the bare `[icmp]`), so the
+  operator reads the exact ICMP packet the simulator matched — the type/code the
+  parser already threads into `policymatch.Query.ICMPType/ICMPCode` (#3284) and
+  matches against an icmp-type-constrained application (junos-ping = type 8).
+  The annotation is rendered by the shared `formatQueryProtoTail` helper; a
+  non-ICMP query prints the bare `[proto]` exactly as before. Display-only; no
+  schema/wire impact.

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -282,11 +282,45 @@ func (c *CLI) testPolicy(args []string) error {
 	if dstPort > 0 {
 		fmt.Printf(":%d", dstPort)
 	}
-	if proto != "" {
-		fmt.Printf(" [%s]", proto)
+	// #4497 (avo-001 F3): echo the queried ICMP/ICMPv6 type and code alongside
+	// the protocol so the `test policy` verdict names the FULL tuple the
+	// simulator matched, not just the protocol. A
+	// `protocol icmp icmp-type 8 icmp-code 0` query is answered against the
+	// declared type/code (junos-ping = type 8, #3284); dropping the type/code
+	// from the echo hid WHICH ICMP packet was tested. A non-ICMP query (no
+	// type/code) prints the bare `[proto]` exactly as before.
+	if tail := formatQueryProtoTail(proto, icmpType, icmpCode); tail != "" {
+		fmt.Printf(" %s", tail)
 	}
 	fmt.Println()
 	return nil
+}
+
+// formatQueryProtoTail renders the trailing `[proto ...]` annotation for the
+// `test policy` query echo (#4497, avo-001 F3). It surfaces the queried
+// ICMP/ICMPv6 type and code so the operator reads the exact tuple the simulator
+// matched, not just the protocol name. A nil type/code is omitted; an empty
+// protocol with no type/code yields "" (nothing to annotate).
+func formatQueryProtoTail(proto string, icmpType, icmpCode *uint8) string {
+	if proto == "" && icmpType == nil && icmpCode == nil {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteByte('[')
+	sep := ""
+	if proto != "" {
+		b.WriteString(proto)
+		sep = " "
+	}
+	if icmpType != nil {
+		fmt.Fprintf(&b, "%stype %d", sep, *icmpType)
+		sep = " "
+	}
+	if icmpCode != nil {
+		fmt.Fprintf(&b, "%scode %d", sep, *icmpCode)
+	}
+	b.WriteByte(']')
+	return b.String()
 }
 
 // printPolicyMatchIdentity renders the shared PolicyID / RuleID / scope /

--- a/pkg/cli/testpolicy_icmp_4497_test.go
+++ b/pkg/cli/testpolicy_icmp_4497_test.go
@@ -1,0 +1,141 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newICMPPolicyCLI builds a committed store with two permit policies:
+//   - allow-icmp matches an ICMP echo-request application (protocol icmp,
+//     icmp-type 8, icmp-code 0)
+//   - allow-tcp matches a TCP web application (protocol tcp, destination-port 80)
+//
+// with a deny-all default. This lets a `test policy` query exercise BOTH the
+// ICMP type/code query surface and the untouched non-ICMP path.
+func newICMPPolicyCLI(t *testing.T) *CLI {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+applications {
+    application icmp-echo {
+        protocol icmp;
+        icmp-type 8;
+        icmp-code 0;
+    }
+    application tcp-web {
+        protocol tcp;
+        destination-port 80;
+    }
+}
+security {
+    policies {
+        default-policy deny-all;
+        from-zone trust to-zone untrust {
+            policy allow-icmp {
+                match { source-address any; destination-address any; application icmp-echo; }
+                then { permit; }
+            }
+            policy allow-tcp {
+                match { source-address any; destination-address any; application tcp-web; }
+                then { permit; }
+            }
+        }
+    }
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return &CLI{store: store}
+}
+
+// TestTestPolicyICMPTypeCodeEcho is the #4497 (avo-001 F3) RED-on-revert guard
+// for the local CLI `test policy` ICMP type/code query surface. An ICMP query
+// carrying `protocol icmp icmp-type 8 icmp-code 0` must:
+//
+//   - MATCH the icmp-type/icmp-code-constrained application (the query surface
+//     threads Query.ICMPType/ICMPCode into the shared simulator, #3284), and
+//   - ECHO the queried type/code in the verdict tuple so the operator sees WHICH
+//     ICMP packet was tested, not just `[icmp]`.
+//
+// The non-ICMP TCP query is the control: it matches its policy and prints the
+// bare `[tcp]` tuple with NO type/code annotation.
+//
+// FAIL-ON-REVERT: dropping the ICMP type/code from the `test policy` query echo
+// (formatQueryProtoTail) reduces the ICMP output to `[icmp]`, so the
+// `[icmp type 8 code 0]` assertion flips red. The TCP control proves the change
+// is scoped to ICMP queries.
+func TestTestPolicyICMPTypeCodeEcho(t *testing.T) {
+	c := newICMPPolicyCLI(t)
+
+	t.Run("icmp echoes type and code", func(t *testing.T) {
+		var err error
+		args := []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "icmp", "icmp-type", "8", "icmp-code", "0"}
+		out := captureStdout(t, func() { err = c.testPolicy(args) })
+		if err != nil {
+			t.Fatalf("testPolicy(%v) err = %v", args, err)
+		}
+		if !strings.Contains(out, "Policy match") {
+			t.Fatalf("ICMP type-8/code-0 query did not match the icmp-type-constrained policy:\n%s", out)
+		}
+		if !strings.Contains(out, "[icmp type 8 code 0]") {
+			t.Fatalf("test policy did not surface the queried ICMP type/code in the tuple echo:\n%s", out)
+		}
+	})
+
+	t.Run("tcp control unaffected", func(t *testing.T) {
+		var err error
+		args := []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "tcp", "destination-port", "80"}
+		out := captureStdout(t, func() { err = c.testPolicy(args) })
+		if err != nil {
+			t.Fatalf("testPolicy(%v) err = %v", args, err)
+		}
+		if !strings.Contains(out, "Policy match") {
+			t.Fatalf("TCP dst-80 query did not match the tcp-web policy:\n%s", out)
+		}
+		if !strings.Contains(out, "[tcp]") {
+			t.Fatalf("non-ICMP query lost its bare [tcp] protocol echo:\n%s", out)
+		}
+		if strings.Contains(out, "type ") || strings.Contains(out, "code ") {
+			t.Fatalf("non-ICMP query leaked an ICMP type/code annotation:\n%s", out)
+		}
+	})
+}
+
+// TestFormatQueryProtoTail unit-tests the #4497 tuple-tail formatter directly so
+// the ICMP type/code echo rules (and the untouched non-ICMP / empty cases) are
+// pinned independent of the surrounding `test policy` output.
+func TestFormatQueryProtoTail(t *testing.T) {
+	u8 := func(v uint8) *uint8 { return &v }
+	cases := []struct {
+		name     string
+		proto    string
+		icmpType *uint8
+		icmpCode *uint8
+		want     string
+	}{
+		{"empty", "", nil, nil, ""},
+		{"tcp only", "tcp", nil, nil, "[tcp]"},
+		{"icmp type and code", "icmp", u8(8), u8(0), "[icmp type 8 code 0]"},
+		{"icmp type only", "icmp", u8(3), nil, "[icmp type 3]"},
+		{"icmp6 type only", "icmp6", u8(128), nil, "[icmp6 type 128]"},
+		{"type without proto", "", u8(8), u8(0), "[type 8 code 0]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatQueryProtoTail(tc.proto, tc.icmpType, tc.icmpCode); got != tc.want {
+				t.Fatalf("formatQueryProtoTail(%q, %v, %v) = %q, want %q", tc.proto, tc.icmpType, tc.icmpCode, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #4497 (F3 CLI ICMP type/code surface; F2 done in #4639).

## F3 gap (avo-review-001)
The local CLI `test policy` verdict echoed the queried tuple as
`Source: src -> dst:port [proto]` but **dropped the ICMP/ICMPv6 type and code**
the operator supplied. A `test policy … protocol icmp icmp-type 8 icmp-code 0`
lookup printed the bare `[icmp]`, hiding WHICH ICMP packet was tested — even
though the shared selector parser already threads the type/code into
`policymatch.Query.ICMPType/ICMPCode` (#3284) and the simulator matches an
icmp-type-constrained application (junos-ping = type 8). avo-001 F3 flagged the
`test security match-policies` ICMP type/code query surface as threaded/matched
but never surfaced back to the operator, and carrying no test.

## Change
`pkg/cli/cli_request.go` — add a shared `formatQueryProtoTail` helper that renders
the trailing `[proto ...]` annotation and folds in the queried ICMP type/code, so
the echo now reads `[icmp type 8 code 0]`. A non-ICMP query (no type/code) still
prints the bare `[proto]` exactly as before; a nil type or code is omitted.
**Display-only — no schema/wire impact.**

## Validation
- New RED-on-revert test `pkg/cli/testpolicy_icmp_4497_test.go`:
  - `icmp-type 8 icmp-code 0` query both **matches** the constrained policy AND
    **echoes** `[icmp type 8 code 0]`
  - TCP control proves the change is scoped to ICMP queries (`[tcp]`, no type/code)
  - direct `formatQueryProtoTail` unit table pins type-only / icmp6 / empty / no-proto
  - **Verified RED** by reverting the echo (output regressed to `[icmp]`).
- `go test ./pkg/cli/... ./pkg/grpcapi/... ./pkg/policymatch/...` green.
- gofmt + vet clean on the touched files.
- Docs: `pkg/cli/README.md` + `_Log.md`.

## Possible follow-ups (out of scope here)
- Echo the tuple in `show security match-policies` (no query-echo line today).
- Add `queried_icmp_type/code` to the gRPC `MatchPoliciesResponse` (proto regen;
  the cargo/Rust lane is busy so this PR is Go-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi