### PR TITLE
refactor(poll_descriptor): split debug_log_throttle submodule (#4404 inc 1)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-07-08 — #4404 increment 1: split debug_log_throttle submodule
+
+- **Timestamp**: 2026-07-08
+- **Action**: #4404 (poll_descriptor/mod.rs decomposition), increment 1.
+  Pure code-motion split of the cold-path `debug-log` throttle unit out
+  of `poll_descriptor/mod.rs` into a new sibling submodule
+  `poll_descriptor/debug_log_throttle.rs`. Moved verbatim: the two #4120
+  interval caps (`SESSION_MISS_DEBUG_LOG_CAP`, `POLICY_DENY_DEBUG_LOG_CAP`,
+  kept module-private), the two pure `u64 -> bool` predicates
+  (`session_miss_debug_log_allowed`, `policy_deny_debug_log_allowed`, now
+  `pub(super)` so mod.rs's call sites at the former L2024/L3410 still
+  reach them), and the `debug_log_throttle_tests` pinned-contract test
+  module. mod.rs gained `mod debug_log_throttle;` + a `use` import;
+  behavior, visibility surface, and the 3 test cases are identical. This
+  unit was chosen because it has ZERO cross-references back into mod.rs
+  (no dataplane types) — the cleanest available boundary — and directly
+  matches the issue's stated fix of outlining the cold-path debug logging.
+  The `poll_binding_process_descriptor` god-function itself (session-hit /
+  session-miss / flowless arm fusion) is NOT touched; it stays tracked on
+  #4404 and needs /triple-review (single-recycle + CoS guarantee-guard
+  invariants). Gate: FULL `cargo test` = 3739+60+8+22+1 passed / 0 failed
+  across all binaries; new file rustfmt-clean at edition 2024.
+- **File(s)**: userspace-dp/src/afxdp/poll_descriptor/debug_log_throttle.rs
+  (new), userspace-dp/src/afxdp/poll_descriptor/mod.rs, _Log.md
+
 ## 2026-07-08 — #4409 increment 1: extract reuse_existing_lease_locked
 
 - **Timestamp**: 2026-07-08

--- a/userspace-dp/src/afxdp/poll_descriptor/debug_log_throttle.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/debug_log_throttle.rs
@@ -1,0 +1,99 @@
+// #4404 increment 1: cold-path `debug-log` throttle helpers extracted
+// out of the poll_binding_process_descriptor god-function's enclosing
+// module. These are pure functions of the per-interval counter with NO
+// dependency on any dataplane type, so the split is behavior-identical
+// code-motion: the caller in mod.rs calls the same predicates, and the
+// #4120 pinned-contract tests (`debug_log_throttle_tests`) move verbatim
+// alongside the code they pin. See the module header in mod.rs and the
+// #4404 refactor issue.
+
+/// #4120: per-interval numeric cap on the `debug-log` session-miss line.
+/// This cap is the SOLE throttle. A leftover test-env
+/// `is_trust_flow = ingress_ifindex == 5 || from_zone == "lan" ||
+/// 10.x-src` predicate used to OR past this cap, which defeated the
+/// throttle for the ENTIRE trusted side on any real 10.x LAN and flooded
+/// the log — exactly the CLAUDE.md Logging Rules hazard. It was removed;
+/// the numeric cap now governs uniformly.
+const SESSION_MISS_DEBUG_LOG_CAP: u64 = 10;
+
+/// #4120: companion per-interval cap on the `debug-log` transit
+/// policy-deny line. See [`SESSION_MISS_DEBUG_LOG_CAP`].
+const POLICY_DENY_DEBUG_LOG_CAP: u64 = 3;
+
+/// Whether the session-miss `debug-log` line may be emitted this
+/// interval. Governed SOLELY by the numeric interval cap (#4120): the
+/// signature takes only the counter, so no ingress ifindex, zone name,
+/// or source subnet can bypass the throttle.
+#[inline]
+pub(super) fn session_miss_debug_log_allowed(session_miss: u64) -> bool {
+    session_miss <= SESSION_MISS_DEBUG_LOG_CAP
+}
+
+/// Whether the transit policy-deny `debug-log` line may be emitted this
+/// interval. Governed SOLELY by the numeric interval cap (#4120), as a
+/// pure function of the counter (no topology bypass).
+#[inline]
+pub(super) fn policy_deny_debug_log_allowed(policy_deny: u64) -> bool {
+    policy_deny <= POLICY_DENY_DEBUG_LOG_CAP
+}
+
+/// #4120: pin the `debug-log` cold-path throttle to its numeric
+/// per-interval cap and prove the throttle takes NO topology input.
+///
+/// RED-on-revert: re-introducing the removed `is_trust_flow`
+/// (`ingress_ifindex == 5 || from_zone == "lan" || 10.x-src`) bypass
+/// would have to OR past these predicates, so any input that flips the
+/// verdict `true` above the cap (a 10.x source, ifindex 5, or a zone
+/// named `lan`) makes `throttle_governed_solely_by_numeric_cap` fail.
+/// The predicate signature accepts ONLY the counter, so the topology
+/// bypass cannot be reconstructed without changing this pinned contract.
+#[cfg(test)]
+mod debug_log_throttle_tests {
+    use super::*;
+
+    #[test]
+    fn session_miss_debug_log_capped_at_ten() {
+        // At/under the cap ⇒ allowed; strictly above ⇒ suppressed.
+        for n in 0..=SESSION_MISS_DEBUG_LOG_CAP {
+            assert!(
+                session_miss_debug_log_allowed(n),
+                "count {n} within cap must be allowed"
+            );
+        }
+        assert!(!session_miss_debug_log_allowed(
+            SESSION_MISS_DEBUG_LOG_CAP + 1
+        ));
+        assert!(!session_miss_debug_log_allowed(1_000_000));
+        assert!(!session_miss_debug_log_allowed(u64::MAX));
+    }
+
+    #[test]
+    fn policy_deny_debug_log_capped_at_three() {
+        for n in 0..=POLICY_DENY_DEBUG_LOG_CAP {
+            assert!(
+                policy_deny_debug_log_allowed(n),
+                "count {n} within cap must be allowed"
+            );
+        }
+        assert!(!policy_deny_debug_log_allowed(
+            POLICY_DENY_DEBUG_LOG_CAP + 1
+        ));
+        assert!(!policy_deny_debug_log_allowed(1_000_000));
+        assert!(!policy_deny_debug_log_allowed(u64::MAX));
+    }
+
+    #[test]
+    fn throttle_governed_solely_by_numeric_cap() {
+        // The throttle is a pure function of the interval counter: no
+        // ingress ifindex, zone name, or source subnet is an input, so a
+        // flow on the test-env fxp0 slot (ifindex 5), a zone literally
+        // named `lan`, or a 10.0.0.0/8 source is throttled EXACTLY like
+        // any other flow. Past the cap the verdict is unconditionally
+        // `false` — the removed `is_trust_flow` bypass (which flooded the
+        // whole trusted side on a real 10.x LAN) cannot re-appear here.
+        let over = SESSION_MISS_DEBUG_LOG_CAP + 1;
+        assert!(!session_miss_debug_log_allowed(over));
+        let over_deny = POLICY_DENY_DEBUG_LOG_CAP + 1;
+        assert!(!policy_deny_debug_log_allowed(over_deny));
+    }
+}

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -14,14 +14,26 @@
 // stays inline — see docs/pr/1327-poll-descriptor-stages/plan.md for
 // the architectural verdict that further extraction is blocked by
 // mutable-locals coupling.
+//
+// #4404 increment 1: the cold-path `debug-log` throttle predicates
+// (`debug_log_throttle::{session_miss,policy_deny}_debug_log_allowed`,
+// their #4120 caps, and the `debug_log_throttle_tests` pinned-contract
+// tests) moved out to the `debug_log_throttle` sibling — a pure,
+// dependency-free code-motion. Further decomposition of the
+// `poll_binding_process_descriptor` god-function (the session-hit /
+// session-miss / flowless arms it fuses) is tracked on #4404 and needs
+// /triple-review because it touches the single-recycle and CoS
+// guarantee-guard invariants.
 
 mod cookie_reply;
+mod debug_log_throttle;
 mod filter;
 mod flow_cache_hit;
 mod nat_exception;
 pub(in crate::afxdp) mod reject_reply;
 mod rx_telemetry;
 
+use debug_log_throttle::{policy_deny_debug_log_allowed, session_miss_debug_log_allowed};
 use flow_cache_hit::{FlowCacheOutcome, stage_flow_cache_hit};
 use rx_telemetry::record_rx_descriptor_telemetry;
 
@@ -66,36 +78,6 @@ fn policy_packet_icmp(packet_frame: &[u8], meta: UserspaceDpMeta) -> Option<(u8,
     } else {
         None
     }
-}
-
-/// #4120: per-interval numeric cap on the `debug-log` session-miss line.
-/// This cap is the SOLE throttle. A leftover test-env
-/// `is_trust_flow = ingress_ifindex == 5 || from_zone == "lan" ||
-/// 10.x-src` predicate used to OR past this cap, which defeated the
-/// throttle for the ENTIRE trusted side on any real 10.x LAN and flooded
-/// the log — exactly the CLAUDE.md Logging Rules hazard. It was removed;
-/// the numeric cap now governs uniformly.
-const SESSION_MISS_DEBUG_LOG_CAP: u64 = 10;
-
-/// #4120: companion per-interval cap on the `debug-log` transit
-/// policy-deny line. See [`SESSION_MISS_DEBUG_LOG_CAP`].
-const POLICY_DENY_DEBUG_LOG_CAP: u64 = 3;
-
-/// Whether the session-miss `debug-log` line may be emitted this
-/// interval. Governed SOLELY by the numeric interval cap (#4120): the
-/// signature takes only the counter, so no ingress ifindex, zone name,
-/// or source subnet can bypass the throttle.
-#[inline]
-fn session_miss_debug_log_allowed(session_miss: u64) -> bool {
-    session_miss <= SESSION_MISS_DEBUG_LOG_CAP
-}
-
-/// Whether the transit policy-deny `debug-log` line may be emitted this
-/// interval. Governed SOLELY by the numeric interval cap (#4120), as a
-/// pure function of the counter (no topology bypass).
-#[inline]
-fn policy_deny_debug_log_allowed(policy_deny: u64) -> bool {
-    policy_deny <= POLICY_DENY_DEBUG_LOG_CAP
 }
 
 /// #3019: enforce a configured `to-zone junos-host` security policy on the
@@ -5341,67 +5323,6 @@ pub(super) fn poll_binding_process_descriptor(
     }
     received.release();
     drop(received);
-}
-
-/// #4120: pin the `debug-log` cold-path throttle to its numeric
-/// per-interval cap and prove the throttle takes NO topology input.
-///
-/// RED-on-revert: re-introducing the removed `is_trust_flow`
-/// (`ingress_ifindex == 5 || from_zone == "lan" || 10.x-src`) bypass
-/// would have to OR past these predicates, so any input that flips the
-/// verdict `true` above the cap (a 10.x source, ifindex 5, or a zone
-/// named `lan`) makes `throttle_governed_solely_by_numeric_cap` fail.
-/// The predicate signature accepts ONLY the counter, so the topology
-/// bypass cannot be reconstructed without changing this pinned contract.
-#[cfg(test)]
-mod debug_log_throttle_tests {
-    use super::*;
-
-    #[test]
-    fn session_miss_debug_log_capped_at_ten() {
-        // At/under the cap ⇒ allowed; strictly above ⇒ suppressed.
-        for n in 0..=SESSION_MISS_DEBUG_LOG_CAP {
-            assert!(
-                session_miss_debug_log_allowed(n),
-                "count {n} within cap must be allowed"
-            );
-        }
-        assert!(!session_miss_debug_log_allowed(
-            SESSION_MISS_DEBUG_LOG_CAP + 1
-        ));
-        assert!(!session_miss_debug_log_allowed(1_000_000));
-        assert!(!session_miss_debug_log_allowed(u64::MAX));
-    }
-
-    #[test]
-    fn policy_deny_debug_log_capped_at_three() {
-        for n in 0..=POLICY_DENY_DEBUG_LOG_CAP {
-            assert!(
-                policy_deny_debug_log_allowed(n),
-                "count {n} within cap must be allowed"
-            );
-        }
-        assert!(!policy_deny_debug_log_allowed(
-            POLICY_DENY_DEBUG_LOG_CAP + 1
-        ));
-        assert!(!policy_deny_debug_log_allowed(1_000_000));
-        assert!(!policy_deny_debug_log_allowed(u64::MAX));
-    }
-
-    #[test]
-    fn throttle_governed_solely_by_numeric_cap() {
-        // The throttle is a pure function of the interval counter: no
-        // ingress ifindex, zone name, or source subnet is an input, so a
-        // flow on the test-env fxp0 slot (ifindex 5), a zone literally
-        // named `lan`, or a 10.0.0.0/8 source is throttled EXACTLY like
-        // any other flow. Past the cap the verdict is unconditionally
-        // `false` — the removed `is_trust_flow` bypass (which flooded the
-        // whole trusted side on a real 10.x LAN) cannot re-appear here.
-        let over = SESSION_MISS_DEBUG_LOG_CAP + 1;
-        assert!(!session_miss_debug_log_allowed(over));
-        let over_deny = POLICY_DENY_DEBUG_LOG_CAP + 1;
-        assert!(!policy_deny_debug_log_allowed(over_deny));
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Addresses #4404 (increment 1: extract/split `debug_log_throttle`; further increments tracked).

## What

Pure code-motion split of the cold-path `debug-log` throttle unit out of
`userspace-dp/src/afxdp/poll_descriptor/mod.rs` into a new sibling submodule
`poll_descriptor/debug_log_throttle.rs`.

Moved verbatim:
- the two #4120 interval caps `SESSION_MISS_DEBUG_LOG_CAP` / `POLICY_DENY_DEBUG_LOG_CAP` (kept module-private),
- the two pure `u64 -> bool` predicates `session_miss_debug_log_allowed` / `policy_deny_debug_log_allowed` (now `pub(super)` so the `poll_binding_process_descriptor` call sites still reach them),
- the `debug_log_throttle_tests` pinned-contract test module (#4120 RED-on-revert guard).

`mod.rs` gains a `mod debug_log_throttle;` declaration + a `use` import.

## Why this unit / why pure code-motion

This unit has **zero cross-references back into mod.rs** — the predicates depend on no
dataplane type — so it is the cleanest available boundary, and it directly matches the
issue's stated fix of *outlining the cold-path debug logging*. Behavior, the public
visibility surface, and all three test cases are identical; the bodies move verbatim.

The `poll_binding_process_descriptor` god-function itself (session-hit / session-miss /
flowless arm fusion) is **not** touched — per the issue it needs `/triple-review` because
it carries the single-recycle, CoS guarantee-guard, and packet-range/verifier-sensitive
invariants. Those further increments remain tracked on #4404.

## Validation

Full `cargo test` (`CARGO_TARGET_DIR=/tmp/cargo-4404`) passes across every binary:
- main lib: **3739 passed / 0 failed** (the 3 moved tests now run as `afxdp::poll_descriptor::debug_log_throttle::debug_log_throttle_tests::*`)
- other binaries: 60 + 8 + 22 + 1 passed, 0 failed

New file is rustfmt-clean at edition 2024; `mod.rs` changed lines match surrounding style.
Module doc (`mod.rs` header) + `_Log.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi