### PR TITLE
config: close 3 more leaf-complete subtrees to closed-world (#4313)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -41888,3 +41888,30 @@ top.
   which needs /triple-review.
 - **File(s)**: userspace-dp/src/policy.rs,
   userspace-dp/src/policy_snapshot_error.rs, _Log.md
+
+- **Timestamp**: 2026-07-08
+- **Action**: #4313 — three MORE per-subtree closed-world flips (extends
+  #4578 master-password + #4623 IKE proposal). (1) `security ipsec proposal`
+  (Phase-2 ESP crypto): modeled the two missing leaves — `lifetime-kilobytes`
+  (captured to `IPsecProposal.LifetimeKilobytes`, accepted-only + ValidateConfig
+  advisory since the strongSwan renderer emits only `rekey_time`, not
+  `rekey_bytes`) and cosmetic `description` (compiler-ignored) — THEN flipped
+  `closedWorld:true`. Sibling of the closed IKE proposal; silent-drop of a
+  typo'd `encryption-algorithm` FAILS OPEN on crypto (ESP SA negotiates without
+  the operator's cipher). (2) `security nat nat64` (xpf-native NAT64 stanza):
+  flipped the container `closedWorld:true` — leaf-complete by construction
+  (only `rule-set` → `prefix`/`source-pool`; `compileNAT64` + `NAT64RuleSet`
+  read/hold only those two). A typo'd `prefx` left `Prefix` empty →
+  `validateNAT64PrefixStrict` skipped the rule → NAT64 silently inert. (3)
+  `security nat natv6v4`: flipped `closedWorld:true` — only `no-v6-frag-header`.
+  Each flip: RED-on-revert rejection test (typo REJECTED at strict commit,
+  named + "closed-world"; verified RED by toggling the flags false), full
+  modeled-leaf-set commits clean (no false-reject), lenient path warns-not-
+  bricks. `go test ./pkg/config/...` green; gofmt/vet/build clean;
+  golden_4406 unaffected (new leaves unused by the corpus).
+- **File(s)**: pkg/config/schema_security.go, pkg/config/types_security.go,
+  pkg/config/compiler_ipsec.go, pkg/config/compiler_validate_warn.go,
+  pkg/config/schema_closedworld_ipsec_proposal_4313_test.go,
+  pkg/config/schema_closedworld_nat64_4313_test.go,
+  pkg/config/schema_closedworld_natv6v4_4313_test.go,
+  docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1012,10 +1012,38 @@ Phase-1 IKE proposal above. The completeness audit that gates the flip:
   `schema_closedworld_ipsec_proposal_4313_test.go` (RED on revert of the flag;
   the lenient-no-brick case and the advisory are covered too).
 
+**More production flips — `security nat nat64` and `security nat natv6v4`
+(xpf-native NAT64 stanzas, #4313).** Both now set `closedWorld:true`
+(`schema_security.go`). These are xpf-NATIVE stanzas (Junos does NAT64 via
+source/destination NAT + `then static-nat inet`, not this spelling), so the
+grammar IS exactly what xpf models and compiles — there is no external Junos
+superset to false-reject, making them leaf-complete by construction:
+
+- `security nat nat64` — the container's only child is `rule-set`, and a
+  rule-set's only children are `prefix` and `source-pool` (both modeled value
+  leaves whose value rides on the same statement line). The compiler
+  (`compileNAT64`) reads ONLY those two and the struct (`NAT64RuleSet`) holds
+  ONLY `Prefix` + `SourcePool`. `closedWorld` is set on the `nat64` container so
+  it is inherited down (the `childClosed` fold): a typo at the nat64 level
+  (`rulset`) OR under a rule-set (`prefx` / `source-pol`) is rejected. Silent-
+  drop was a real footgun: a typo'd `prefx` left `NAT64RuleSet.Prefix` empty,
+  `validateNAT64PrefixStrict` skipped the rule (`Prefix == ""` → continue), and
+  NAT64 translation silently did nothing — IPv6-only clients lost IPv4
+  reachability with no error. Tests: `schema_closedworld_nat64_4313_test.go`.
+- `security nat natv6v4` — its entire grammar is the single flag
+  `no-v6-frag-header` (modeled); the compiler reads ONLY that keyword and the
+  struct (`NATv6v4Config`) holds ONLY `NoV6FragHeader`. A typo
+  (`no-v6-frag-heder`) previously committed clean and silently left the IPv6
+  fragment header in translated packets; it is now rejected at strict commit.
+  Tests: `schema_closedworld_natv6v4_4313_test.go`.
+
+As with every flip, the reject fires only on the strict commit path;
+`compileTreeLenient` downgrades it to a warning on `Store.Load` / `SyncApply`.
+
 **The systematic per-subtree closure continues (#4313).** Each of the flips
 above (destination-NAT then, the three IPsec option containers, master-password,
-the Phase-1 IKE proposal, now the Phase-2 IPsec proposal) closes one
-leaf-complete high-risk subtree; the
+the Phase-1 IKE proposal, now the Phase-2 IPsec proposal and the two
+xpf-native NAT64 stanzas) closes one leaf-complete high-risk subtree; the
 blanket-default flip stays deferred (it would break the deliberately-lenient
 accept-with-advisory knobs #2078/#4231 and false-reject valid-but-unmodeled
 Junos, the #4191 class). Both the remaining per-subtree flips and the

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -978,9 +978,44 @@ that made it leaf-complete. The completeness audit that gates the flip:
   tests: `schema_closedworld_ike_proposal_4313_test.go` (RED on revert of the
   flag; the lenient-no-brick case is covered too).
 
+**More production flips — `security ipsec proposal` (Phase-2 ESP crypto,
+#4313).** The Phase-2 ESP proposal container (`security ipsec proposal <name>`)
+now sets `closedWorld:true` (`schema_security.go`), the sibling of the closed
+Phase-1 IKE proposal above. The completeness audit that gates the flip:
+
+- The full Junos `security ipsec proposal <name>` grammar is exactly `protocol`,
+  `encryption-algorithm`, `authentication-algorithm`, `dh-group`,
+  `lifetime-seconds`, `lifetime-kilobytes`, and `description`. The first five
+  were already modeled; this change models `lifetime-kilobytes` (the ESP
+  volume-based rekey knob that DISTINGUISHES the Phase-2 proposal from the
+  Phase-1 IKE proposal — Phase-1 has none, which is why `description` alone
+  completed it) and the cosmetic `description`. The compiler (`compiler_ipsec.go`,
+  the IPsec proposal loop) reads `protocol` / `encryption-algorithm` /
+  `authentication-algorithm` / `dh-group` / `lifetime-seconds` /
+  `lifetime-kilobytes` and ignores `description`, i.e. a subset of the modeled
+  set — so closing carries no false-reject risk (the #4191 class).
+- Every modeled leaf carries its value on the same statement line (no nested
+  value block in Junos), so closed-world never descends into an AST child of a
+  value leaf in EITHER parser shape.
+- Silent-drop here FAILS OPEN on crypto exactly like the IKE proposal: a
+  fat-fingered `encryption-algorith` or `authentication-algoritm` used to commit
+  clean, the compiler then found no such child, and the ESP SA negotiated
+  WITHOUT the operator's chosen cipher/hash — a silent downgrade. The flip
+  rejects the typo at strict commit; the tolerant `Store.Load` / `SyncApply`
+  path downgrades it to a warning (`compileTreeLenient`, #1960).
+- `lifetime-kilobytes` is CAPTURED (`IPsecProposal.LifetimeKilobytes`) but
+  accepted-only: the strongSwan renderer emits `rekey_time` (seconds) and no
+  `rekey_bytes`, so volume-based rekey is not yet enforced. `ValidateConfig`
+  emits an accepted-only advisory (`compiler_validate_warn.go`) so an operator
+  is not silently misled into believing the SA rekeys on bytes — strictly
+  better than the pre-flip silent commit-and-drop. Production tests:
+  `schema_closedworld_ipsec_proposal_4313_test.go` (RED on revert of the flag;
+  the lenient-no-brick case and the advisory are covered too).
+
 **The systematic per-subtree closure continues (#4313).** Each of the flips
 above (destination-NAT then, the three IPsec option containers, master-password,
-now the Phase-1 IKE proposal) closes one leaf-complete high-risk subtree; the
+the Phase-1 IKE proposal, now the Phase-2 IPsec proposal) closes one
+leaf-complete high-risk subtree; the
 blanket-default flip stays deferred (it would break the deliberately-lenient
 accept-with-advisory knobs #2078/#4231 and false-reject valid-but-unmodeled
 Junos, the #4191 class). Both the remaining per-subtree flips and the
@@ -989,17 +1024,17 @@ blanket-flip doctrine decision remain tracked on #4313.
 **Remaining per-subtree flips (future PRs, tracked on #4313).** Turning
 `closedWorld` on for the other umbrella candidates (`snmp community` — INCOMPLETE:
 Junos allows `view` / `client-list-name` / `routing-instance`, unmodeled;
-`security ipsec proposal` — INCOMPLETE: Junos allows a `description` leaf AND a
-`lifetime-kilobytes` volume-rekey leaf, both unmodeled (the Phase-1 IKE proposal
-above is now closed — it has no `lifetime-kilobytes`, so `description` alone
-completed it, but the Phase-2 ESP proposal needs both modeled first);
 `security nat static … then static-nat` —
 UNSAFE: `static-nat` is a free-form leaf and the Junos hierarchical form
 `static-nat { prefix { … } }` would false-reject under closed-world; `security
-screen ids-option` — INCOMPLETE, deliberately open-world; `protocols {ospf,bgp}
-interface`, `interfaces … family`, and the deferred source-NAT then above) is
-only safe once that subtree is LEAF-COMPLETE — every valid Junos keyword under
-it is modeled — otherwise the flip false-rejects a valid config. Each flip is
+screen ids-option` — INCOMPLETE, deliberately open-world; `security ipsec vpn
+<v> ike` bindings — INCOMPLETE: Junos allows `proxy-identity` /
+`no-anti-replay`, unmodeled; the source-NAT rule `then` — deferred (rule-level
+persistent-nat, see above); `protocols {ospf,bgp} interface` and `interfaces …
+family`) is only safe once that subtree is LEAF-COMPLETE — every valid Junos
+keyword under it is modeled — otherwise the flip false-rejects a valid config.
+The Phase-2 `security ipsec proposal` is now CLOSED (both `description` and
+`lifetime-kilobytes` were modeled first — see above). Each remaining flip is
 its own follow-up gated on a Junos-leaf completeness audit for that subtree. Do
 NOT set `closedWorld` on a subtree without that audit.
 

--- a/pkg/config/compiler_ipsec.go
+++ b/pkg/config/compiler_ipsec.go
@@ -305,6 +305,15 @@ func compileIPsec(node *Node, sec *SecurityConfig) error {
 				if n, err := strconv.Atoi(v); err == nil {
 					prop.LifetimeSeconds = n
 				}
+			case "lifetime-kilobytes":
+				// #4313: captured for the closed-world leaf-completeness of
+				// `security ipsec proposal` and the accepted-only advisory
+				// (compiler_validate_warn.go). Volume-based rekey is not yet
+				// programmed into the ESP child SA, so the value is recorded
+				// but not enforced.
+				if n, err := strconv.Atoi(v); err == nil {
+					prop.LifetimeKilobytes = n
+				}
 			}
 		}
 		sec.IPsec.Proposals[prop.Name] = prop

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -749,6 +749,32 @@ func ValidateConfig(cfg *Config) []string {
 		}
 	}
 
+	// #4313: `security ipsec proposal <p> lifetime-kilobytes <kb>` is now typed
+	// + captured (schema leaf + compileIPsec) so the closed-world flip on the
+	// Phase-2 proposal is leaf-complete, but the ESP child SA is not yet
+	// programmed with a volume-based rekey threshold (the renderer emits only
+	// rekey_time, not rekey_bytes). Mirror the #2078/#4231 accepted-only
+	// doctrine: warn so an operator who sets a volume rekey is not silently
+	// misled into believing the SA rekeys on bytes. Full enforcement is a
+	// renderer + dataplane follow-up.
+	{
+		var lkbProps []string
+		for name := range cfg.Security.IPsec.Proposals {
+			if p := cfg.Security.IPsec.Proposals[name]; p != nil && p.LifetimeKilobytes > 0 {
+				lkbProps = append(lkbProps, name)
+			}
+		}
+		if len(lkbProps) > 0 {
+			sort.Strings(lkbProps)
+			warnings = append(warnings, fmt.Sprintf(
+				"security ipsec proposal %s lifetime-kilobytes configured but "+
+					"accepted-only — xpf does not program a volume-based (byte) "+
+					"rekey threshold; the SA rekeys on lifetime-seconds only "+
+					"(config-only parity, #4313)",
+				strings.Join(lkbProps, ", ")))
+		}
+	}
+
 	// #4291 (fable-167 N-2): the NAT `port-overloading` knobs are now typed +
 	// committed (schema leaves + compileNAT) but the userspace AF_XDP SNAT
 	// allocator enforces neither. `security nat source interface port-overloading

--- a/pkg/config/schema_closedworld_ipsec_proposal_4313_test.go
+++ b/pkg/config/schema_closedworld_ipsec_proposal_4313_test.go
@@ -1,0 +1,170 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4313 — another PRODUCTION closed-world subtree flip: the Phase-2 ESP
+// crypto container `security ipsec proposal <name>`, the sibling of the
+// already-closed Phase-1 `security ike proposal`.
+//
+// The subtree is LEAF-COMPLETE: the full Junos grammar is exactly protocol,
+// encryption-algorithm, authentication-algorithm, dh-group, lifetime-seconds,
+// lifetime-kilobytes, and description. The first five were already modeled;
+// this change modeled lifetime-kilobytes (the ESP volume-rekey knob that
+// distinguishes the Phase-2 proposal from the Phase-1 IKE proposal — Phase-1
+// has none) and the cosmetic description, so a valid proposal carrying either
+// is not false-rejected (the #4191 class). The compiler (compiler_ipsec.go,
+// the IPsec proposal loop) reads a subset of the modeled set (description is
+// cosmetic / compiler-ignored; lifetime-kilobytes is captured but
+// accepted-only). Every leaf carries its value on the same statement line (no
+// nested value block in Junos), so closed-world never descends into an AST
+// child of a value leaf in either parser shape.
+//
+// Silent-drop here FAILS OPEN on crypto: before the flip a typo in
+// `encryption-algorithm` / `authentication-algorithm` committed clean and the
+// compiler negotiated the ESP SA WITHOUT the operator's chosen cipher/hash — a
+// silent downgrade. The flip REJECTS the typo at strict commit (SchemaValidate)
+// instead of committing clean and being silently dropped by the compiler — the
+// #4313 silent-inert bug.
+//
+// These tests use the production ParseSetCommand + SetPath + SchemaValidate
+// path (buildTree). Each rejection test is RED on revert of the closedWorld
+// flag: without it, SchemaValidate returns nil (open-world silent-accept) and
+// the test fails.
+
+// ipsecProposalSet builds a minimal IPsec (Phase-2) proposal whose body is the
+// supplied set lines (e.g. "encryption-algorithm aes-256-cbc", "bogus x").
+func ipsecProposalSet(bodyLines ...string) []string {
+	out := []string{}
+	for _, l := range bodyLines {
+		out = append(out, "set security ipsec proposal p1 "+l)
+	}
+	return out
+}
+
+// TestClosedWorldIPsecProposal_RejectsUnknownKeyword is the core RED-on-revert
+// discriminator: an unmodeled keyword under the closed-world IPsec proposal is
+// rejected at strict commit. On revert of closedWorld the same input is
+// silently accepted (SchemaValidate returns nil) and this test fails — proving
+// the flip closes the #4313 silent-inert gap.
+func TestClosedWorldIPsecProposal_RejectsUnknownKeyword(t *testing.T) {
+	tree := buildTree(t, ipsecProposalSet("bogus aes-256-cbc"))
+	err := SchemaValidate(tree, nil)
+	if err == nil {
+		t.Fatal("an unmodeled keyword under the closed-world IPsec proposal must be rejected at commit (RED on revert: silently accepted + dropped)")
+	}
+	if !strings.Contains(err.Error(), "bogus") || !strings.Contains(err.Error(), "closed-world") {
+		t.Fatalf("error must name the keyword and the closed-world subtree, got: %v", err)
+	}
+}
+
+// TestClosedWorldIPsecProposal_RejectsCryptoTypo is the VALUE of the fix: a
+// fat-fingered crypto leaf is caught at commit rather than silently ignored —
+// the operator learns the chosen cipher/hash/PFS would be dropped and the ESP
+// SA silently downgraded.
+func TestClosedWorldIPsecProposal_RejectsCryptoTypo(t *testing.T) {
+	for _, typo := range []string{
+		"encryption-algorith aes-256-cbc",
+		"authentication-algoritm hmac-sha-256-128",
+		"dh-grop group14",
+		"protcol esp",
+		// a typo on the ESP-only volume-rekey knob (silently keeps the
+		// lifetime-seconds-only rekey the operator meant to harden)
+		"lifetime-kilobyte 100000",
+	} {
+		tree := buildTree(t, ipsecProposalSet(typo))
+		err := SchemaValidate(tree, nil)
+		if err == nil {
+			t.Fatalf("a typo'd IPsec proposal leaf %q must be rejected at commit, not silently dropped (crypto fails open)", typo)
+		}
+		// the first token is the misspelled keyword
+		bad := strings.Fields(typo)[0]
+		if !strings.Contains(err.Error(), bad) || !strings.Contains(err.Error(), "closed-world") {
+			t.Fatalf("error must name the typo %q and the closed-world subtree, got: %v", bad, err)
+		}
+	}
+}
+
+// TestClosedWorldIPsecProposal_AcceptsValid proves no false-reject: every valid
+// Junos IPsec proposal leaf still commits clean under closed-world — each on
+// its own AND combined into a fully-specified real-world proposal — including
+// the two leaves added to make the subtree leaf-complete (lifetime-kilobytes,
+// description).
+func TestClosedWorldIPsecProposal_AcceptsValid(t *testing.T) {
+	// each modeled leaf on its own
+	for _, leaf := range []string{
+		"protocol esp",
+		"encryption-algorithm aes-256-cbc",
+		"authentication-algorithm hmac-sha-256-128",
+		"dh-group group14",
+		"lifetime-seconds 28800",
+		"lifetime-kilobytes 100000",
+		`description "corp phase-2 proposal"`,
+	} {
+		tree := buildTree(t, ipsecProposalSet(leaf))
+		if err := SchemaValidate(tree, nil); err != nil {
+			t.Fatalf("valid IPsec proposal leaf %q must commit clean under closed-world, got: %v", leaf, err)
+		}
+	}
+	// a fully-specified proposal (the real-world shape)
+	full := buildTree(t, ipsecProposalSet(
+		"protocol esp",
+		"encryption-algorithm aes-256-cbc",
+		"authentication-algorithm hmac-sha-256-128",
+		"dh-group group14",
+		"lifetime-seconds 28800",
+		"lifetime-kilobytes 100000",
+	))
+	if err := SchemaValidate(full, nil); err != nil {
+		t.Fatalf("a fully-specified IPsec proposal must commit clean under closed-world, got: %v", err)
+	}
+}
+
+// TestClosedWorldIPsecProposal_LenientDoesNotBrick documents the #1960 no-brick
+// contract: the closed-world reject is a SchemaValidate error, which the
+// tolerant Store.Load / SyncApply ingress downgrades to a warning
+// (configstore.compileTreeLenient). At the compile layer the schema gate is
+// NOT run — the lenient path is precisely CompileConfigLenient — so a config
+// with the typo still COMPILES (the unknown leaf silently dropped) rather than
+// bricking the load.
+func TestClosedWorldIPsecProposal_LenientDoesNotBrick(t *testing.T) {
+	typoTree := buildTree(t, append(
+		ipsecProposalSet("encryption-algorith aes-256-cbc"),
+		"set security ipsec policy pol1 proposals p1",
+	))
+	// strict gate rejects (the operator commit path)
+	if err := SchemaValidate(typoTree, nil); err == nil {
+		t.Fatal("precondition: strict SchemaValidate must reject the typo")
+	}
+	// lenient compile (the Store.Load / SyncApply path) must NOT brick.
+	if _, err := CompileConfigLenient(typoTree); err != nil {
+		t.Fatalf("the lenient load/peer-sync path must not brick on a closed-world typo (#1960); got: %v", err)
+	}
+}
+
+// TestClosedWorldIPsecProposal_LifetimeKilobytesAdvisory proves the modeled
+// lifetime-kilobytes is captured and surfaces the accepted-only advisory so an
+// operator is not silently misled into believing volume-based rekey is
+// enforced.
+func TestClosedWorldIPsecProposal_LifetimeKilobytesAdvisory(t *testing.T) {
+	tree := buildTree(t, ipsecProposalSet("lifetime-kilobytes 100000"))
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if p := cfg.Security.IPsec.Proposals["p1"]; p == nil || p.LifetimeKilobytes != 100000 {
+		t.Fatalf("lifetime-kilobytes must be captured into IPsecProposal.LifetimeKilobytes, got: %#v", p)
+	}
+	var found bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "lifetime-kilobytes") && strings.Contains(w, "accepted-only") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected an accepted-only lifetime-kilobytes advisory, got warnings: %v", cfg.Warnings)
+	}
+}

--- a/pkg/config/schema_closedworld_nat64_4313_test.go
+++ b/pkg/config/schema_closedworld_nat64_4313_test.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4313 — PRODUCTION closed-world subtree flip: `security nat nat64`.
+//
+// nat64 is an xpf-NATIVE stanza (Junos does NAT64 via source/destination NAT +
+// `then static-nat inet`, not this spelling), so its grammar IS exactly what
+// xpf models and compiles — there is no external Junos superset to
+// false-reject. The container's only child is `rule-set`; a rule-set's only
+// children are `prefix` and `source-pool` (both modeled value leaves whose
+// value rides on the same statement line). The compiler (compileNAT64) reads
+// ONLY prefix + source-pool and the struct (NAT64RuleSet) holds ONLY those
+// two, so the subtree is leaf-complete by construction.
+//
+// Silent-drop here is a real footgun: a typo'd `prefx` left NAT64RuleSet.Prefix
+// empty, validateNAT64PrefixStrict skipped the rule (Prefix == "" → continue),
+// and NAT64 translation silently did nothing — IPv6-only clients lost IPv4
+// reachability with no error. The flip REJECTS the typo at strict commit.
+//
+// Each rejection test is RED on revert of the closedWorld flag: without it,
+// SchemaValidate returns nil (open-world silent-accept) and the test fails.
+
+func cwNAT64Set(bodyLines ...string) []string {
+	out := []string{}
+	for _, l := range bodyLines {
+		out = append(out, "set security nat nat64 "+l)
+	}
+	return out
+}
+
+// TestClosedWorldNAT64_RejectsUnknownKeyword covers both closed levels: a typo
+// at the nat64 level (`rulset`) and under a rule-set instance (`prefx`).
+func TestClosedWorldNAT64_RejectsUnknownKeyword(t *testing.T) {
+	for _, typo := range []string{
+		"rulset r1 prefix 64:ff9b::/96",        // nat64-level typo
+		"rule-set r1 prefx 64:ff9b::/96",       // rule-set-level typo (prefix)
+		"rule-set r1 source-pol p1",            // rule-set-level typo (source-pool)
+		"rule-set r1 destination-prefix ::/96", // unmodeled keyword under rule-set
+	} {
+		tree := buildTree(t, cwNAT64Set(typo))
+		err := SchemaValidate(tree, nil)
+		if err == nil {
+			t.Fatalf("a typo'd NAT64 leaf %q must be rejected at commit, not silently dropped (NAT64 silently inert)", typo)
+		}
+		bad := strings.Fields(typo)[0]
+		if !strings.Contains(err.Error(), bad) || !strings.Contains(err.Error(), "closed-world") {
+			t.Fatalf("error must name the typo %q and the closed-world subtree, got: %v", bad, err)
+		}
+	}
+}
+
+// TestClosedWorldNAT64_AcceptsValid proves no false-reject: every modeled NAT64
+// leaf still commits clean under closed-world.
+func TestClosedWorldNAT64_AcceptsValid(t *testing.T) {
+	for _, leaf := range []string{
+		"rule-set r1 prefix 64:ff9b::/96",
+		"rule-set r1 source-pool p1",
+	} {
+		tree := buildTree(t, cwNAT64Set(leaf))
+		if err := SchemaValidate(tree, nil); err != nil {
+			t.Fatalf("valid NAT64 leaf %q must commit clean under closed-world, got: %v", leaf, err)
+		}
+	}
+	// a fully-specified rule-set
+	full := buildTree(t, cwNAT64Set(
+		"rule-set r1 prefix 64:ff9b::/96",
+		"rule-set r1 source-pool p1",
+	))
+	if err := SchemaValidate(full, nil); err != nil {
+		t.Fatalf("a fully-specified NAT64 rule-set must commit clean under closed-world, got: %v", err)
+	}
+}
+
+// TestClosedWorldNAT64_LenientDoesNotBrick documents the #1960 no-brick
+// contract: the closed-world reject is a SchemaValidate error, downgraded to a
+// warning on the tolerant Store.Load / SyncApply path (CompileConfigLenient).
+func TestClosedWorldNAT64_LenientDoesNotBrick(t *testing.T) {
+	typoTree := buildTree(t, cwNAT64Set("rule-set r1 prefx 64:ff9b::/96"))
+	if err := SchemaValidate(typoTree, nil); err == nil {
+		t.Fatal("precondition: strict SchemaValidate must reject the typo")
+	}
+	if _, err := CompileConfigLenient(typoTree); err != nil {
+		t.Fatalf("the lenient load/peer-sync path must not brick on a closed-world typo (#1960); got: %v", err)
+	}
+}

--- a/pkg/config/schema_closedworld_natv6v4_4313_test.go
+++ b/pkg/config/schema_closedworld_natv6v4_4313_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4313 — PRODUCTION closed-world subtree flip: `security nat natv6v4`.
+//
+// natv6v4 is an xpf-NATIVE options stanza whose entire grammar is the single
+// flag `no-v6-frag-header` (modeled). The compiler (compiler_nat.go) reads ONLY
+// that keyword and the struct (NATv6v4Config) holds ONLY NoV6FragHeader, so the
+// subtree is leaf-complete by construction and closing it cannot false-reject a
+// valid config. A typo (`no-v6-frag-heder`) previously committed clean and
+// silently left the IPv6 fragment header in translated packets; it is now
+// rejected at strict commit (lenient path warns, #1960).
+
+func natv6v4Set(bodyLines ...string) []string {
+	out := []string{}
+	for _, l := range bodyLines {
+		out = append(out, "set security nat natv6v4 "+l)
+	}
+	return out
+}
+
+// TestClosedWorldNATv6v4_RejectsUnknownKeyword is the RED-on-revert
+// discriminator: an unmodeled keyword under natv6v4 is rejected at strict
+// commit. On revert of closedWorld the same input is silently accepted.
+func TestClosedWorldNATv6v4_RejectsUnknownKeyword(t *testing.T) {
+	for _, typo := range []string{
+		"no-v6-frag-heder",
+		"bogus",
+	} {
+		tree := buildTree(t, natv6v4Set(typo))
+		err := SchemaValidate(tree, nil)
+		if err == nil {
+			t.Fatalf("a typo'd natv6v4 keyword %q must be rejected at commit, not silently dropped", typo)
+		}
+		if !strings.Contains(err.Error(), typo) || !strings.Contains(err.Error(), "closed-world") {
+			t.Fatalf("error must name the typo %q and the closed-world subtree, got: %v", typo, err)
+		}
+	}
+}
+
+// TestClosedWorldNATv6v4_AcceptsValid proves no false-reject: the one modeled
+// flag still commits clean under closed-world.
+func TestClosedWorldNATv6v4_AcceptsValid(t *testing.T) {
+	tree := buildTree(t, natv6v4Set("no-v6-frag-header"))
+	if err := SchemaValidate(tree, nil); err != nil {
+		t.Fatalf("valid natv6v4 no-v6-frag-header must commit clean under closed-world, got: %v", err)
+	}
+}
+
+// TestClosedWorldNATv6v4_LenientDoesNotBrick documents the #1960 no-brick
+// contract.
+func TestClosedWorldNATv6v4_LenientDoesNotBrick(t *testing.T) {
+	typoTree := buildTree(t, natv6v4Set("no-v6-frag-heder"))
+	if err := SchemaValidate(typoTree, nil); err == nil {
+		t.Fatal("precondition: strict SchemaValidate must reject the typo")
+	}
+	if _, err := CompileConfigLenient(typoTree); err != nil {
+		t.Fatalf("the lenient load/peer-sync path must not brick on a closed-world typo (#1960); got: %v", err)
+	}
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -586,13 +586,39 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 				}},
 			}},
 		}},
-		"nat64": {desc: "NAT64 (IPv6-to-IPv4) translation", children: map[string]*schemaNode{
+		// #4313 — closed-world flip. `security nat nat64` is an xpf-NATIVE
+		// stanza (Junos does NAT64 via source/destination NAT + `then static-nat
+		// inet`, not this spelling), so its grammar IS exactly what xpf models
+		// and compiles — there is no external Junos superset to false-reject.
+		// The container's only child is `rule-set`, and a rule-set's only
+		// children are `prefix` and `source-pool` (both modeled, both value
+		// leaves whose value rides on the same statement line). The compiler
+		// (compiler_nat.go compileNAT64) reads ONLY prefix + source-pool and the
+		// struct (NAT64RuleSet) holds ONLY those two — so the subtree is
+		// leaf-complete by construction and closing it cannot false-reject a
+		// valid config. Silent-drop here is a real footgun: a typo'd `prefx`
+		// left NAT64RuleSet.Prefix empty, validateNAT64PrefixStrict skipped the
+		// rule (`Prefix == ""` → continue), and the NAT64 translation silently
+		// did nothing — IPv6-only clients lost IPv4 reachability with no error.
+		// closedWorld inherits down every level (childClosed fold), so a typo at
+		// the nat64 level (`rulset`) OR under a rule-set (`prefx`/`source-pol`)
+		// is REJECTED at strict commit; the tolerant Load/SyncApply path
+		// downgrades to a warning (#1960).
+		"nat64": {desc: "NAT64 (IPv6-to-IPv4) translation", closedWorld: true, children: map[string]*schemaNode{
 			"rule-set": {desc: "NAT64 rule-set name", args: 1, placeholder: "<rule-set-name>", children: map[string]*schemaNode{
 				"prefix":      {desc: "NAT64 IPv6 prefix (must be /96)", args: 1, placeholder: "<ipv6-prefix>", children: nil},
 				"source-pool": {desc: "Source NAT pool for the translated IPv4 source", args: 1, placeholder: "<pool-name>", children: nil},
 			}},
 		}},
-		"natv6v4": {desc: "NAT64 IPv6-to-IPv4 options", children: map[string]*schemaNode{
+		// #4313 — closed-world flip. `security nat natv6v4` is an xpf-NATIVE
+		// options stanza whose entire grammar is the single flag
+		// `no-v6-frag-header` (modeled). The compiler (compiler_nat.go) reads
+		// ONLY that keyword and the struct (NATv6v4Config) holds ONLY
+		// NoV6FragHeader, so the subtree is leaf-complete by construction. A
+		// typo (`no-v6-frag-heder`) previously committed clean and silently left
+		// the IPv6 fragment header in translated packets; it is now rejected at
+		// strict commit (lenient path warns, #1960).
+		"natv6v4": {desc: "NAT64 IPv6-to-IPv4 options", closedWorld: true, children: map[string]*schemaNode{
 			"no-v6-frag-header": {desc: "Omit the IPv6 fragment header in translated packets", children: nil},
 		}},
 		"proxy-arp": {desc: "Proxy ARP for NAT pool addresses", children: map[string]*schemaNode{

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -981,7 +981,29 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 		// that dropped `group14` to DHGroup=0 (silent PFS loss), and this
 		// gate deliberately rejected the prefixed spelling to stay
 		// compiler-faithful; the compiler fix lets both gates accept it.
-		"proposal": {desc: "IPsec (Phase 2) proposal name", args: 1, placeholder: "<proposal-name>", children: map[string]*schemaNode{
+		// #4313 — closed-world flip (Phase-2 ESP crypto), the sibling of the
+		// already-closed Phase-1 `security ike proposal`. The subtree is now
+		// LEAF-COMPLETE: the full Junos `security ipsec proposal <name>` grammar
+		// is exactly protocol, encryption-algorithm, authentication-algorithm,
+		// dh-group, lifetime-seconds, lifetime-kilobytes, and description. The
+		// first five were already modeled; this change models lifetime-kilobytes
+		// (the ESP volume-rekey knob that DISTINGUISHES the Phase-2 proposal from
+		// the Phase-1 IKE proposal — Phase-1 has none) and the cosmetic
+		// description. The compiler (compiler_ipsec.go, the IPsec proposal loop)
+		// reads protocol / encryption-algorithm / authentication-algorithm /
+		// dh-group / lifetime-seconds / lifetime-kilobytes and ignores
+		// description, i.e. a subset of the modeled set — so closing carries no
+		// false-reject risk (the #4191 class). Every leaf carries its value on
+		// the same statement line (no nested value block in Junos), so
+		// closed-world never descends into an AST child of a value leaf in
+		// either parser shape. Silent-drop here FAILS OPEN on crypto exactly
+		// like the IKE proposal: a fat-fingered `encryption-algorith` used to
+		// commit clean and the ESP SA negotiated WITHOUT the operator's cipher
+		// (a silent downgrade). The flip rejects the typo at strict commit; the
+		// tolerant Load/SyncApply path downgrades it to a warning (#1960).
+		// lifetime-kilobytes is captured but accepted-only (not enforced) — see
+		// the ValidateConfig advisory in compiler_validate_warn.go.
+		"proposal": {desc: "IPsec (Phase 2) proposal name", args: 1, placeholder: "<proposal-name>", closedWorld: true, children: map[string]*schemaNode{
 			// #4298 (V-2): type the protocol so a typo fails closed. `ah`
 			// is an accepted value here (grammar-valid) but hard-rejected at
 			// commit by validateIPsecProposalProtocolStrict — xpf does not
@@ -999,6 +1021,20 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 			"lifetime-seconds": {desc: "IPsec SA lifetime in seconds", args: 1, placeholder: "<seconds>",
 				valueType: ValueInteger, valueDesc: "IPsec SA lifetime in seconds",
 				valueExamples: []string{"3600", "28800"}, validator: ValidateIntegerMin(1), children: nil},
+			// #4313: modeled so the closed-world flip is LEAF-COMPLETE. The ESP
+			// volume-based rekey threshold; captured (IPsecProposal.LifetimeKilobytes)
+			// but accepted-only — the renderer does not yet program a byte-based
+			// rekey, so ValidateConfig emits an advisory (compiler_validate_warn.go).
+			"lifetime-kilobytes": {desc: "IPsec SA volume-based rekey threshold in kilobytes (accepted, not enforced)", args: 1, placeholder: "<kilobytes>",
+				valueType: ValueInteger, valueDesc: "IPsec SA lifetime in kilobytes",
+				valueExamples: []string{"100000", "4294967294"}, validator: ValidateIntegerMin(1), children: nil},
+			// #4313: modeled so the closed-world flip is LEAF-COMPLETE. Junos
+			// allows a cosmetic `description` on an IPsec proposal; xpf ignores it
+			// at compile (the IPsec proposal loop has no case for it), but it MUST
+			// be modeled or closed-world would false-reject a valid config that
+			// carries it. scalar:true rejects a trailing token (#3332) — a
+			// multi-word description must be quoted.
+			"description": {desc: "Proposal description", args: 1, scalar: true, placeholder: "<text>", children: nil},
 		}},
 		"policy": {desc: "IPsec policy name", args: 1, placeholder: "<policy-name>", children: map[string]*schemaNode{
 			"perfect-forward-secrecy": {desc: "Perfect forward secrecy (keys group<N>)", children: nil},

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -1101,6 +1101,14 @@ type IPsecProposal struct {
 	AuthAlg         string // "hmac-sha-256" (ignored for GCM)
 	DHGroup         int    // DH group number
 	LifetimeSeconds int
+	// LifetimeKilobytes is the Junos ESP volume-based rekey threshold
+	// (`lifetime-kilobytes`). It is CAPTURED so the #4313 closed-world flip
+	// on `security ipsec proposal` is leaf-complete (a valid proposal
+	// carrying it is not false-rejected) and so ValidateConfig can emit the
+	// accepted-only advisory — the userspace dataplane / strongSwan renderer
+	// does not yet program a volume-based rekey, so the value is accepted but
+	// not enforced (config-only parity, #2078/#4231 doctrine).
+	LifetimeKilobytes int
 }
 
 // IPsecPolicyDef defines Phase 2 policy (PFS + proposal reference).


### PR DESCRIPTION
Addresses #4313 (closes 3 more leaf-complete subtrees; the systematic per-subtree closure continues).

Extends the per-subtree closed-world flips of #4578 (master-password) and #4623 (Phase-1 IKE proposal). The #4313 root cause is the opt-in schema gate (`schema_walk.go`): an unmodeled Junos keyword under an opt-in subtree resolves to a nil schema child, commits clean, and is silently dropped by the compiler. A blanket flip is infeasible (it would break the deliberately-lenient accept-with-advisory knobs #2078/#4231 and false-reject valid-but-unmodeled Junos — the #4191 class), so the driveable path is a per-subtree `closedWorld:true` flip where the subtree is leaf-COMPLETE.

Three more subtrees, each after a leaf-completeness audit, one commit per subtree:

**1. `security ipsec proposal` (Phase-2 ESP crypto)** — the sibling of the closed Phase-1 IKE proposal. Silent-drop FAILS OPEN on crypto: a fat-fingered `encryption-algorith` used to commit clean and the ESP SA negotiated WITHOUT the operator's cipher. The subtree was INCOMPLETE (Junos allows `description` and `lifetime-kilobytes`, both unmodeled), so this commit models both FIRST — `lifetime-kilobytes` captured (`IPsecProposal.LifetimeKilobytes`) but accepted-only with a `ValidateConfig` advisory (the renderer emits `rekey_time`, not `rekey_bytes`), and cosmetic compiler-ignored `description` — THEN flips the container. The compiler reads a subset of the modeled set, so no false-reject.

**2. `security nat nat64`** — an xpf-native stanza (Junos does NAT64 differently), leaf-complete by construction: only `rule-set` → `prefix`/`source-pool`, which `compileNAT64` + `NAT64RuleSet` are the sole readers/holders of. `closedWorld` on the container inherits down. A typo'd `prefx` left `Prefix` empty, `validateNAT64PrefixStrict` skipped the rule, and NAT64 silently did nothing — IPv6-only clients lost IPv4 reachability with no error.

**3. `security nat natv6v4`** — an xpf-native flag stanza whose entire grammar is `no-v6-frag-header`. A typo silently left the IPv6 fragment header in translated packets.

Each flip fires only on the strict operator commit path; the tolerant Load/SyncApply path downgrades it to a warning (`compileTreeLenient`, #1960), so a stored or peer-synced config is never bricked.

Validation (per subtree, RED on revert): `schema_closedworld_ipsec_proposal_4313_test.go`, `schema_closedworld_nat64_4313_test.go`, `schema_closedworld_natv6v4_4313_test.go` — a typo'd/unmodeled keyword under each newly-closed subtree is REJECTED at strict commit naming the keyword + "closed-world" (verified RED by toggling each flag false); every modeled leaf still commits clean (no false-reject; the ipsec test exercises the full leaf set including the two added leaves); the lenient path warns-not-bricks. `go test ./pkg/config/...` green; gofmt/vet/build clean; golden_4406 unaffected. Docs updated in `docs/config-schema.md` (each flip + its completeness audit; `security ipsec proposal` removed from the remaining-flips list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi