### PR TITLE
daemon: fix DHCP-server-in-cluster enablement — untagged reth1.0 filter + runtime knob-flip (#4647)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -41915,3 +41915,34 @@ top.
   pkg/config/schema_closedworld_nat64_4313_test.go,
   pkg/config/schema_closedworld_natv6v4_4313_test.go,
   docs/config-schema.md, _Log.md
+
+## 2026-07-08 — #4647 DHCP-server-in-cluster enablement (BUG A + BUG B)
+
+- **Timestamp**: 2026-07-08
+- **Action**: Fixed two enablement bugs the #2261 live smoke surfaced (the
+  memfile loader itself PASSED). BUG A (serious): the untagged reth1.0
+  dhcp-local-server group never matched the master-RG filter, so
+  clearFamilyLocked wiped the Kea config and DHCP-server-in-cluster was
+  non-functional with the canonical `interface reth1.0`. Root cause:
+  `filterDHCPConfigForMasterRGs` exact-string-compared the resolved group
+  interface `ge-0-0-1.0` (resolveDHCPRethInterfaces → ResolveReth keeps the
+  `.0`) against the bare master-RG member `ge-0-0-1` (rethInterfacesForRG emits
+  no suffix for a VlanID==0 unit). Fix: `stripUntaggedUnitSuffix` normalizes a
+  trailing `.0` on BOTH sides of the compare AND keeps the normalized bare
+  member in the kept set (the real device Kea binds to). Tagged units
+  (reth1.100 → ge-0-0-1.100) are untouched and match only their VLAN member.
+  BUG B: `runDHCPLeaseSyncLoop` was launched only from the connect-time comms
+  block, so a runtime `set chassis cluster dhcp-lease-synchronization; commit`
+  was a silent no-op (counters 0/0 until restart). Fix: new idempotent
+  `ensureDHCPLeaseSyncLoop(enabled)` reconciled from the apply path (section 20)
+  and shared with the connect-time launch (routed through the same
+  start/stop, guards double-launch); loop scoped to the live cluster comms
+  context (`clusterCommsCtx`), reset in stopClusterComms. Also fixed the smoke
+  script: `xpf-cli` → `/usr/local/sbin/cli`, DHCP_CLIENT_IFACE default eth1 →
+  eth0 (LAN host has eth0). RED-on-revert verified for both bugs. go test
+  ./pkg/daemon/... ./pkg/dhcpserver/... green; go build ./... ok; gofmt/vet
+  clean; bash -n on the smoke script ok.
+- **File(s)**: pkg/daemon/daemon_ha.go, pkg/daemon/daemon.go,
+  pkg/daemon/daemon_dhcp_lease_sync.go, pkg/daemon/daemon_ha_sync.go,
+  pkg/daemon/daemon_apply.go, pkg/daemon/daemon_dhcp_cluster_test.go,
+  test/incus/dhcp-lease-failover.sh, pkg/dhcpserver/README.md, _Log.md

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -439,6 +439,13 @@ type Daemon struct {
 	// on config change (#87).
 	clusterCommsCancel context.CancelFunc
 
+	// clusterCommsCtx is the currently-live cluster comms sub-context (the
+	// context clusterCommsCancel cancels). Held so runtime knob toggles can
+	// (re)launch comms-scoped loops — e.g. the #2239 DHCP lease-sync push loop
+	// started on a `dhcp-lease-synchronization` commit (#4647) — against the
+	// same lifetime as the connect-time launch. Nil when comms are stopped.
+	clusterCommsCtx context.Context
+
 	// activeClusterTransport stores the transport config used by the
 	// currently running cluster comms. Compared on each applyConfig to
 	// detect changes that require a comms restart (#87).

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1655,6 +1655,15 @@ func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, dhcpServer
 			d.stopClusterComms()
 			d.startClusterComms(d.daemonCtx)
 		}
+
+		// #4647 BUG-B: reconcile the #2239 DHCP lease-sync push loop against
+		// the just-committed `dhcp-lease-synchronization` knob. Without this a
+		// runtime knob-ON commit on a running cluster was a silent no-op (the
+		// loop was launched only from the connect-time block) — counters stayed
+		// 0/0 until an xpfd restart. ensureDHCPLeaseSyncLoop is idempotent, so a
+		// knob-unchanged commit is a no-op, a knob-ON commit (re)launches the
+		// loop against the live comms context, and a knob-OFF commit stops it.
+		d.ensureDHCPLeaseSyncLoop(d.dhcpLeaseSyncEnabled(cfg))
 	}
 
 	// 21. Re-apply D3 RSS indirection on config change (#797 HIGH #2).

--- a/pkg/daemon/daemon_dhcp_filter_4647_test.go
+++ b/pkg/daemon/daemon_dhcp_filter_4647_test.go
@@ -1,0 +1,99 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// dhcpClusterTestConfig builds a minimal HA config with a single reth in RG1
+// whose member is ge-0/0/1 (→ Linux ge-0-0-1), plus a dhcp-local-server group
+// binding to the given interface reference (e.g. "reth1.0" untagged or
+// "reth1.100" tagged). vlanID sets the reth unit's 802.1Q tag (0 = untagged).
+func dhcpClusterTestConfig(groupIface string, vlanID int) *config.Config {
+	return &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"reth1": {
+					Name:            "reth1",
+					RedundancyGroup: 1,
+					Units:           map[int]*config.InterfaceUnit{0: {VlanID: vlanID}},
+				},
+				"ge-0/0/1": {
+					Name:            "ge-0/0/1",
+					RedundantParent: "reth1",
+				},
+			},
+		},
+		System: config.SystemConfig{
+			DHCPServer: config.DHCPServerConfig{
+				DHCPLocalServer: &config.DHCPLocalServerConfig{
+					Groups: map[string]*config.DHCPServerGroup{
+						"g1": {Interfaces: []string{groupIface}},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestFilterDHCPConfigForMasterRGs_UntaggedRethUnitMatches is the #4647 BUG-A
+// regression: a `dhcp-local-server ... interface reth1.0` group must SURVIVE the
+// master-RG filter when reth1's member is MASTER, and the kept interface must be
+// the bare Linux member "ge-0-0-1" (the real device Kea binds to). Before the
+// fix, resolveDHCPRethInterfaces produced "ge-0-0-1.0" but rethInterfacesForRG
+// emitted the bare "ge-0-0-1", the exact string compare failed, the group was
+// dropped, and Kea's config was wiped even though the RG was MASTER — so DHCP
+// server in a cluster never started with the canonical config.
+func TestFilterDHCPConfigForMasterRGs_UntaggedRethUnitMatches(t *testing.T) {
+	d := newTestDaemon()
+	cfg := dhcpClusterTestConfig("reth1.0", 0)
+	d.getOrCreateRGState(1).SetVRRP("reth1", true)
+
+	got := d.filterDHCPConfigForMasterRGs(cfg)
+	if got == nil || got.DHCPLocalServer == nil {
+		t.Fatal("reth1.0 group on a MASTER RG must survive the filter (Kea config generated); got nil (BUG-A RED)")
+	}
+	g, ok := got.DHCPLocalServer.Groups["g1"]
+	if !ok {
+		t.Fatal("group g1 dropped by the master-RG filter (BUG-A RED)")
+	}
+	if len(g.Interfaces) != 1 || g.Interfaces[0] != "ge-0-0-1" {
+		t.Fatalf("expected kept interface [ge-0-0-1] (bare member Kea binds to), got %v", g.Interfaces)
+	}
+}
+
+// TestFilterDHCPConfigForMasterRGs_TaggedRethUnitMatches verifies the fix does
+// not break a TAGGED unit: `interface reth1.100` must match only the tagged
+// member "ge-0-0-1.100" (the ".100" is preserved, not normalized away).
+func TestFilterDHCPConfigForMasterRGs_TaggedRethUnitMatches(t *testing.T) {
+	d := newTestDaemon()
+	cfg := dhcpClusterTestConfig("reth1.100", 100)
+	d.getOrCreateRGState(1).SetVRRP("reth1.100", true)
+
+	got := d.filterDHCPConfigForMasterRGs(cfg)
+	if got == nil || got.DHCPLocalServer == nil {
+		t.Fatal("reth1.100 group on a MASTER RG must survive the filter; got nil")
+	}
+	g, ok := got.DHCPLocalServer.Groups["g1"]
+	if !ok {
+		t.Fatal("tagged group g1 dropped by the master-RG filter")
+	}
+	if len(g.Interfaces) != 1 || g.Interfaces[0] != "ge-0-0-1.100" {
+		t.Fatalf("expected kept interface [ge-0-0-1.100] (tagged member), got %v", g.Interfaces)
+	}
+}
+
+// TestFilterDHCPConfigForMasterRGs_NonMasterRGFiltered verifies a group whose
+// RG is NOT master is still filtered to nil (the normalize must not
+// accidentally match a non-master RG's interface).
+func TestFilterDHCPConfigForMasterRGs_NonMasterRGFiltered(t *testing.T) {
+	d := newTestDaemon()
+	cfg := dhcpClusterTestConfig("reth1.0", 0)
+	// RG1 is BACKUP (not master): no VRRP instance marked master.
+	d.getOrCreateRGState(1).SetVRRP("reth1", false)
+
+	if got := d.filterDHCPConfigForMasterRGs(cfg); got != nil {
+		t.Fatalf("reth1.0 group on a BACKUP RG must be filtered to nil (Kea cleared), got %+v", got)
+	}
+}

--- a/pkg/daemon/daemon_dhcp_lease_sync.go
+++ b/pkg/daemon/daemon_dhcp_lease_sync.go
@@ -71,6 +71,14 @@ type dhcpLeaseSyncState struct {
 	lastSentMu sync.Mutex
 	lastSent4  string // last-pushed v4 set fingerprint (change-detect)
 	lastSent6  string // last-pushed v6 set fingerprint (change-detect)
+
+	// loopMu guards the push-loop lifecycle (#4647). loopCancel is the
+	// cancel func of the currently-running push loop's context (nil when the
+	// loop is not running). ensureDHCPLeaseSyncLoop starts/stops the loop
+	// idempotently on a `dhcp-lease-synchronization` knob toggle so a runtime
+	// commit — not only a daemon restart — (re)launches it.
+	loopMu     sync.Mutex
+	loopCancel context.CancelFunc
 }
 
 // dhcpLeaseSyncEnabled reports whether #2239 lease sync is configured for this
@@ -104,9 +112,63 @@ func (d *Daemon) dhcpLeaseSyncGateOpen() bool {
 	return false
 }
 
+// ensureDHCPLeaseSyncLoop starts or stops the #2239 lease-sync push loop to
+// match the `dhcp-lease-synchronization` knob at runtime (#4647). It is
+// idempotent and safe to call from both the cluster connect-time launch
+// (daemon_ha_sync.go) and the config-apply path (daemon_apply.go): a commit
+// that toggles the knob (re)launches or stops the loop WITHOUT a daemon
+// restart. Before #4647 the loop was launched only from the connect-time block,
+// so a knob-ON commit on a running cluster was a silent no-op (counters stayed
+// 0/0 until a restart).
+//
+// The loop is scoped to the live cluster comms context (clusterCommsCtx) so it
+// shares the lifetime of the session-sync channel it pushes over; a comms
+// restart / stopClusterComms tears it down and the next connect-time launch
+// starts a fresh loop (see resetDHCPLeaseSyncLoop).
+func (d *Daemon) ensureDHCPLeaseSyncLoop(enabled bool) {
+	d.dhcpLeaseSync.loopMu.Lock()
+	defer d.dhcpLeaseSync.loopMu.Unlock()
+
+	if !enabled {
+		if d.dhcpLeaseSync.loopCancel != nil {
+			d.dhcpLeaseSync.loopCancel()
+			d.dhcpLeaseSync.loopCancel = nil
+			slog.Info("cluster: DHCP lease-sync push loop stopped (knob disabled)")
+		}
+		return
+	}
+	if d.dhcpLeaseSync.loopCancel != nil {
+		return // already running — idempotent (guards double-launch)
+	}
+	// Comms must be up: the loop reads the peer session-sync channel and
+	// early-returns if either dhcpServer or sessionSync is nil. When they are
+	// not ready yet (e.g. the apply path runs before the peer connects), skip
+	// here — the connect-time launch calls this again once sessionSync is
+	// established, so the knob-ON state is not lost.
+	if d.dhcpServer == nil || d.sessionSync == nil || d.clusterCommsCtx == nil {
+		return
+	}
+	loopCtx, cancel := context.WithCancel(d.clusterCommsCtx)
+	d.dhcpLeaseSync.loopCancel = cancel
+	go d.runDHCPLeaseSyncLoop(loopCtx)
+	slog.Info("cluster: DHCP lease-sync push loop started")
+}
+
+// resetDHCPLeaseSyncLoop clears the push-loop lifecycle handle when cluster
+// comms are torn down (#4647). The loop's context derives from the comms
+// context, so cancelling comms already stops the goroutine; this only clears
+// the cancel handle so the next comms session's connect-time launch starts a
+// fresh loop instead of no-oping on a stale handle.
+func (d *Daemon) resetDHCPLeaseSyncLoop() {
+	d.dhcpLeaseSync.loopMu.Lock()
+	d.dhcpLeaseSync.loopCancel = nil
+	d.dhcpLeaseSync.loopMu.Unlock()
+}
+
 // runDHCPLeaseSyncLoop is the supervised lease-sync push loop. It runs for the
-// daemon lifetime (joined via wg) and exits on ctx cancellation. It is started
-// only in cluster mode with the knob enabled (see daemon_ha_sync.go).
+// lifetime of the cluster comms session (joined via the comms context) and
+// exits on ctx cancellation. It is (re)launched idempotently by
+// ensureDHCPLeaseSyncLoop in cluster mode with the knob enabled.
 func (d *Daemon) runDHCPLeaseSyncLoop(ctx context.Context) {
 	if d.dhcpServer == nil || d.sessionSync == nil {
 		return

--- a/pkg/daemon/daemon_dhcp_leasesync_4647_test.go
+++ b/pkg/daemon/daemon_dhcp_leasesync_4647_test.go
@@ -1,0 +1,64 @@
+package daemon
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/dhcpserver"
+)
+
+// TestEnsureDHCPLeaseSyncLoop_KnobToggle is the #4647 BUG-B regression: a
+// runtime `dhcp-lease-synchronization` toggle must (re)launch or stop the
+// lease-sync push loop WITHOUT a daemon restart, and must be idempotent (no
+// double-launch). Before the fix the loop was launched only from the
+// connect-time block, so ensureDHCPLeaseSyncLoop did not exist and a knob-ON
+// commit was a silent no-op.
+func TestEnsureDHCPLeaseSyncLoop_KnobToggle(t *testing.T) {
+	d := newTestDaemon()
+	d.dhcpServer = &dhcpserver.Manager{}
+	d.sessionSync = &cluster.SessionSync{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.clusterCommsCtx = ctx
+
+	if d.dhcpLeaseSync.loopCancel != nil {
+		t.Fatal("precondition: lease-sync loop must not be running")
+	}
+
+	// Knob ON (the apply-path reconcile) → loop launched without a restart.
+	d.ensureDHCPLeaseSyncLoop(true)
+	if d.dhcpLeaseSync.loopCancel == nil {
+		t.Fatal("knob-ON toggle must (re)launch the lease-sync loop; loopCancel is nil (BUG-B RED)")
+	}
+	first := d.dhcpLeaseSync.loopCancel
+
+	// Idempotent: a second ON toggle must NOT replace the running loop.
+	d.ensureDHCPLeaseSyncLoop(true)
+	if reflect.ValueOf(d.dhcpLeaseSync.loopCancel).Pointer() != reflect.ValueOf(first).Pointer() {
+		t.Fatal("double-launch: second ON toggle replaced the running loop's cancel handle")
+	}
+
+	// Knob OFF → loop stopped, handle cleared.
+	d.ensureDHCPLeaseSyncLoop(false)
+	if d.dhcpLeaseSync.loopCancel != nil {
+		t.Fatal("knob-OFF toggle must stop the loop; loopCancel still set")
+	}
+}
+
+// TestEnsureDHCPLeaseSyncLoop_CommsDownNoLaunch verifies the loop is NOT started
+// when cluster comms are not yet up (clusterCommsCtx nil) — that case is owned
+// by the connect-time launch, so a premature apply-path call must be a no-op
+// rather than leaking a loop bound to a nil/daemon context.
+func TestEnsureDHCPLeaseSyncLoop_CommsDownNoLaunch(t *testing.T) {
+	d := newTestDaemon()
+	d.dhcpServer = &dhcpserver.Manager{}
+	d.sessionSync = &cluster.SessionSync{}
+	// clusterCommsCtx deliberately left nil (comms not established).
+
+	d.ensureDHCPLeaseSyncLoop(true)
+	if d.dhcpLeaseSync.loopCancel != nil {
+		t.Fatal("ON toggle with comms down must not launch the loop (connect-time owns it)")
+	}
+}

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -1107,18 +1107,39 @@ func (d *Daemon) clearRethServicesForRG(rgID int) {
 	d.nudgeSurfaceADDNSReconcile()
 }
 
+// stripUntaggedUnitSuffix normalizes a resolved Linux interface name by
+// removing a trailing ".0" unit suffix. An untagged reth unit (e.g. `reth1.0`)
+// resolves via ResolveReth to "ge-0-0-1.0", but the real kernel interface Kea
+// binds to — and the name rethInterfacesForRG emits for a VlanID==0 unit — is
+// the bare member "ge-0-0-1" (there is NO ".0" VLAN device for an untagged
+// unit). A tagged unit (".100") is left intact so it only matches its tagged
+// member.
+//
+// #4647: the master-RG DHCP filter compared the resolved group interface
+// ("ge-0-0-1.0") against the bare master-RG member ("ge-0-0-1") with an exact
+// string compare, so the canonical `interface reth1.0` config never matched,
+// the group was dropped, and clearFamilyLocked wiped the Kea config even though
+// the RG was MASTER — DHCP-server-in-cluster was non-functional. Normalizing the
+// untagged ".0" on both sides restores the match while keeping tagged units
+// bound to their VLAN member.
+func stripUntaggedUnitSuffix(iface string) string {
+	return strings.TrimSuffix(iface, ".0")
+}
+
 // filterDHCPConfigForMasterRGs returns a DHCP config containing only groups
 // whose interfaces belong to RGs that are currently MASTER. Returns nil if
 // no groups match.
 func (d *Daemon) filterDHCPConfigForMasterRGs(cfg *config.Config) *config.DHCPServerConfig {
-	// Collect all interfaces belonging to master RGs.
+	// Collect all interfaces belonging to master RGs. Normalize the untagged
+	// ".0" suffix (#4647) so the set is keyed by the bare member name that the
+	// resolved group interface also normalizes to below.
 	masterIfaces := make(map[string]bool)
 	for rgID, isMaster := range d.snapshotRethMasterState() {
 		if !isMaster {
 			continue
 		}
 		for _, n := range rethInterfacesForRG(cfg, rgID) {
-			masterIfaces[n] = true
+			masterIfaces[stripUntaggedUnitSuffix(n)] = true
 		}
 	}
 
@@ -1133,8 +1154,15 @@ func (d *Daemon) filterDHCPConfigForMasterRGs(cfg *config.Config) *config.DHCPSe
 		for name, group := range groups {
 			var kept []string
 			for _, iface := range group.Interfaces {
-				if masterIfaces[iface] {
-					kept = append(kept, iface)
+				// #4647: normalize the untagged ".0" so a `reth1.0`
+				// group (resolved to "ge-0-0-1.0") matches its master RG
+				// member ("ge-0-0-1"). Keep the NORMALIZED name — the
+				// bare member is the real kernel interface Kea binds to;
+				// "ge-0-0-1.0" is not a device. Tagged units keep their
+				// ".<vlan>" and match only the tagged member.
+				norm := stripUntaggedUnitSuffix(iface)
+				if masterIfaces[norm] {
+					kept = append(kept, norm)
 				}
 			}
 			if len(kept) > 0 {

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -406,6 +406,7 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 	// be restarted on config change (#87) without cancelling the daemon ctx.
 	commsCtx, commsCancel := context.WithCancel(ctx)
 	d.clusterCommsCancel = commsCancel
+	d.clusterCommsCtx = commsCtx
 	d.activeClusterTransport = clusterTransportFromConfig(cfg)
 
 	// Determine VRF device if control/fabric interfaces are in mgmt VRF.
@@ -811,10 +812,11 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			// #2239: start the DHCP-server lease-sync push loop if enabled.
 			// The loop is gated on the RG-MASTER node-level gate internally;
 			// on the BACKUP it pushes nothing and the standby holds the peer
-			// set via OnDHCPLeasesReceived.
-			if cc.DHCPLeaseSync && d.dhcpServer != nil {
-				go d.runDHCPLeaseSyncLoop(commsCtx)
-			}
+			// set via OnDHCPLeasesReceived. Routed through the idempotent
+			// starter (#4647) so a later `dhcp-lease-synchronization` knob
+			// toggle from the apply path shares this same launch/stop path
+			// (and cannot double-launch).
+			d.ensureDHCPLeaseSyncLoop(cc.DHCPLeaseSync)
 
 			// Initialize per-fabric refresh channels for event-driven
 			// updates (#124). Each fabric owns its own channel so a
@@ -975,6 +977,11 @@ func (d *Daemon) stopClusterComms() {
 		d.clusterCommsCancel()
 		d.clusterCommsCancel = nil
 	}
+	d.clusterCommsCtx = nil
+	// #4647: the lease-sync loop is scoped to the comms context just
+	// cancelled, so it is already stopping; clear the cancel handle so the
+	// next comms session's connect-time launch starts a fresh loop.
+	d.resetDHCPLeaseSyncLoop()
 	if d.cluster != nil {
 		d.cluster.StopHeartbeat()
 	}

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -690,6 +690,35 @@ starve session installs. All seed/read errors are fail-open (logged + counted
 by the daemon; serving is never blocked). Test seams:
 `SetLeaseSyncSeamsForTesting` injects a stub dialer + paths.
 
+**Cluster enablement fixes (#4647, found via the #2261 live smoke).** The
+memfile loader itself was correct; two bugs in the surrounding daemon-side
+enablement plumbing (`pkg/daemon`) meant the feature never engaged with the
+canonical config:
+
+- **BUG A — untagged `reth1.0` never matched the master-RG filter.**
+  `filterDHCPConfigForMasterRGs` (`daemon_ha.go`) keeps a `dhcp-local-server`
+  group only if its resolved interface belongs to a MASTER RG. For an UNTAGGED
+  reth unit, `rethInterfacesForRG` emits the bare member `ge-0-0-1`, but
+  `resolveDHCPRethInterfaces` resolves `reth1.0` → `ge-0-0-1.0` (ResolveReth
+  keeps the `.0`). The exact string compare failed, the group was dropped, and
+  `clearFamilyLocked` wiped `/etc/kea/kea-dhcp4.conf` even though the RG was
+  MASTER — so DHCP-server-in-cluster was non-functional with the canonical
+  `interface reth1.0` in `docs/ha-cluster-userspace.conf`. The fix normalizes a
+  trailing `.0` (untagged unit) on BOTH sides of the compare
+  (`stripUntaggedUnitSuffix`) AND keeps the normalized bare member in the kept
+  set — `ge-0-0-1` is the real kernel device Kea binds to; `ge-0-0-1.0` is not a
+  device. A TAGGED unit (`reth1.100` → `ge-0-0-1.100`) is left intact and still
+  matches only its VLAN member.
+- **BUG B — runtime knob-flip was a silent no-op.** The `#2239` lease-sync push
+  loop (`runDHCPLeaseSyncLoop`) was launched ONLY from the cluster
+  connect-time block, gated on the knob at connect. A runtime `set chassis
+  cluster dhcp-lease-synchronization; commit` on a RUNNING cluster left the loop
+  unstarted (counters stayed 0/0 until an xpfd restart). The apply path now
+  reconciles the loop against the just-committed knob via the idempotent
+  `ensureDHCPLeaseSyncLoop` (shared with the connect-time launch, so it cannot
+  double-launch): a knob-ON commit (re)launches it against the live comms
+  context, a knob-OFF commit stops it, without a restart.
+
 ## Callers
 
 `pkg/daemon` (constructs the always-on `DDNSManager`, runs the reconcile

--- a/test/incus/dhcp-lease-failover.sh
+++ b/test/incus/dhcp-lease-failover.sh
@@ -25,7 +25,7 @@
 #
 # Usage:
 #   ./test/incus/dhcp-lease-failover.sh
-#   DHCP_CLIENT_IFACE=eth1 ./test/incus/dhcp-lease-failover.sh
+#   DHCP_CLIENT_IFACE=eth1 ./test/incus/dhcp-lease-failover.sh   # override iface
 
 set -euo pipefail
 
@@ -45,7 +45,9 @@ source "${SCRIPT_DIR}/cluster-env.sh"
 # The default smoke LAN host is a STATIC address; a lab run points this at a
 # host configured to DHCP off the firewall's dhcp-local-server pool.
 DHCP_CLIENT="${DHCP_CLIENT:-$CLUSTER_LAN_HOST}"
-DHCP_CLIENT_IFACE="${DHCP_CLIENT_IFACE:-eth1}"
+# Default eth0 (the loss LAN host presents its DHCP client on eth0, not eth1);
+# override with DHCP_CLIENT_IFACE=<if> for a fixture that uses a different NIC.
+DHCP_CLIENT_IFACE="${DHCP_CLIENT_IFACE:-eth0}"
 # Kea memfile paths on the firewall nodes (see pkg/dhcpserver leaseFile()).
 KEA_MEMFILE4="${KEA_MEMFILE4:-/var/lib/kea/kea-leases4.csv}"
 KEA_MEMFILE6="${KEA_MEMFILE6:-/var/lib/kea/kea-leases6.csv}"
@@ -74,7 +76,7 @@ ssh_fw() { incus exec "$1" -- bash -lc "$2"; }
 preflight() {
 	info "Preflight: knob-ON + dhcp-local-server + a DHCP client fixture"
 	local cfg
-	cfg="$(ssh_fw "$FW0" 'xpf-cli -c "show configuration chassis cluster" 2>/dev/null' || true)"
+	cfg="$(ssh_fw "$FW0" '/usr/local/sbin/cli -c "show configuration chassis cluster" 2>/dev/null' || true)"
 	if ! grep -q "dhcp-lease-synchronization" <<<"$cfg"; then
 		cat >&2 <<EOF
 LAB PREREQUISITE MISSING: dhcp-lease-synchronization is not enabled.


### PR DESCRIPTION
Closes #4647

Two enablement bugs the #2261 DHCP-lease-failover live smoke surfaced on the
loss cluster. The memfile loader itself PASSED; both bugs are in the
surrounding daemon-side plumbing.

## BUG A (serious) — cluster DHCP server never starts with the canonical config

`filterDHCPConfigForMasterRGs` (`pkg/daemon/daemon_ha.go`) kept a
`dhcp-local-server` group only if its resolved interface string-equalled a
master-RG reth member. For an UNTAGGED reth unit the two derivations disagree:

- `rethInterfacesForRG` emits the bare member `ge-0-0-1` for a `VlanID==0`
  unit (no suffix), while
- `resolveDHCPRethInterfaces` resolves `reth1.0` → `ge-0-0-1.0` (`ResolveReth`
  keeps the `.0`, `pkg/config/types.go`).

The exact compare failed → the group was filtered to nil →
`ApplyClusterCommit(nil)` → `clearFamilyLocked` REMOVED
`/etc/kea/kea-dhcp4.conf` → Kea stayed `failed`. Changing only
`interface reth1.0` → `reth1` flipped Kea from never-generating to
PRESENT+serving, proving the filter (not the loader) was the fault. So
DHCP-server-in-cluster was entirely non-functional with the canonical Junos
`interface reth1.0` in `docs/ha-cluster-userspace.conf`.

**Fix:** normalize a trailing `.0` (untagged unit) on BOTH sides of the compare
(`stripUntaggedUnitSuffix`) AND keep the normalized bare member in the kept set
— `ge-0-0-1` is the real kernel device Kea binds to; `ge-0-0-1.0` is not a
device. A TAGGED unit (`reth1.100` → `ge-0-0-1.100`) is left intact and still
matches only its VLAN member.

## BUG B — runtime knob-flip was a silent no-op

`runDHCPLeaseSyncLoop` was launched ONLY from the cluster connect-time block,
gated on the knob at peer-connect. A runtime
`set chassis cluster dhcp-lease-synchronization; commit` did NOT start the push
loop — counters stayed 0/0 until an xpfd restart.

**Fix:** a new idempotent `ensureDHCPLeaseSyncLoop(enabled)` reconciled from the
apply path (`applyTailReconciles`, section 20) starts the loop when the knob is
on and stops it when off, without a restart. The connect-time block now routes
through the same helper, so both launch sites share one start/stop path and
cannot double-launch (guarded by `loopCancel` under `loopMu`). The loop is
scoped to the live cluster comms context (`clusterCommsCtx`) so it shares the
lifetime of the session-sync channel it pushes over; `stopClusterComms` clears
it.

## Smoke script (lab-env, minor)

`test/incus/dhcp-lease-failover.sh`: `xpf-cli` → `/usr/local/sbin/cli` (the
binary is `cli`), and `DHCP_CLIENT_IFACE` default `eth1` → `eth0` (the loss LAN
host presents its DHCP client on eth0; still overridable).

## Tests

- BUG A (`daemon_dhcp_filter_4647_test.go`): untagged `reth1.0` group on a
  MASTER RG survives the filter with kept `[ge-0-0-1]` (RED-on-revert: filtered
  to nil with the old exact compare); tagged `reth1.100` still matches
  `[ge-0-0-1.100]`; a BACKUP-RG group is still filtered to nil.
- BUG B (`daemon_dhcp_leasesync_4647_test.go`): a knob-ON toggle launches the
  loop (RED-on-revert: not launched); a second ON toggle does not double-launch;
  a knob-OFF toggle stops it; an ON toggle with comms down does not launch.

`go test ./pkg/daemon/... ./pkg/dhcpserver/...` green; `go build ./...` ok;
gofmt/vet clean; `bash -n` on the smoke script ok.

**Cluster validation flag:** this touches cluster/HA DHCP plumbing. The #2261
`test/incus/dhcp-lease-failover.sh` smoke (lab-gated) should be re-run to
confirm the canonical `interface reth1.0` config now serves and the knob-ON
counters increment without a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
