### PR TITLE
userspace-dp: publish per-zone traffic counters (#3651)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -41976,3 +41976,57 @@ top.
   pkg/daemon/daemon_dhcp_lease_sync.go, pkg/daemon/daemon_ha_sync.go,
   pkg/daemon/daemon_apply.go, pkg/daemon/daemon_dhcp_cluster_test.go,
   test/incus/dhcp-lease-failover.sh, pkg/dhcpserver/README.md, _Log.md
+
+## 2026-07-08 — #3651 POPULATE per-zone traffic counters (deferred half of #3643)
+
+- **Timestamp**: 2026-07-08
+- **Action**: Implemented the userspace-dp POPULATE half of #3643 (design of
+  record: docs/research/3643-dead-counters/plan.md §5A). Per-zone
+  ingress/egress packet+byte volume is now sourced from the Rust AF_XDP
+  dataplane and surfaced on `show security zones` Traffic statistics, REST
+  `/security/zones`, and the Prometheus collector — no longer
+  `ErrCounterNotPopulated` ("not available"). Per-zone FLOOD counters stay
+  deferred per the §5A recommended narrowing (lean on the #3343 aggregate).
+  RUST: new `userspace-dp/src/afxdp/zone_counters.rs` — flat direct-index
+  `[u8;65536]` zone-id→slot LUT (`ZoneCounterSlotMap`, 63 assignable slots +
+  `overflow_active`), a per-worker thread-local dense coalescer
+  (`record_zone_traffic`, two array reads/pkt, NO per-packet hash/atomic —
+  mirrors the policy/filter hit-counter coalesce-then-fold), and a
+  coordinator-owned zone-id-keyed `ZoneCounterStore` folded per RX batch
+  (`flush_recorded_zone_counters`, at loop_body next to the filter/policy
+  flush). Store rides ForwardingState (carried forward from `previous` in
+  forwarding_build) so totals survive commits; zone-id keying removes the
+  cold-path slot-reassignment zero-out entirely. Hot-path recorded at the fast
+  path (flow_cache_hit), slow path (poll_descriptor forward-candidate), and the
+  tunnel/next-table paths (record_forwarding_disposition ForwardCandidate,
+  Hot-only). Helper pre-sums across workers into the ProcessStatus-level
+  `zone_traffic_counters` sparse block (layout version 1, nonzero rows only);
+  `clear_zone_counters` control IPC resets the store. GO: ProcessStatus gains
+  ZoneCounterLayoutVersion / ZoneCounterOverflowActive / ZoneTrafficCounters
+  (tag-matched to Rust); syncBPFCountersLocked mirrors each row via
+  SetZoneCounterOffset; new zonecounters.go adds the ClearZoneCounters override
+  (+ ClearAllCounters wiring + LegacyDataPlaneAdapter route) sending the IPC.
+  Tag-matched wire; regenerated protocol_wire_v1.json + cross-language contract
+  round-trip both sides. RED-on-revert: TestSyncBPFCountersPopulatesZoneCounters
+  reverts to ErrCounterNotPopulated if the Go decode loop is removed. FULL
+  cargo test 3842/0; go test ./pkg/dataplane/... ./pkg/api/... ./pkg/grpcapi/...
+  green.
+- **File(s)**: userspace-dp/src/afxdp/zone_counters.rs (new),
+  userspace-dp/src/afxdp/mod.rs, userspace-dp/src/afxdp/types/forwarding.rs,
+  userspace-dp/src/afxdp/forwarding_build/mod.rs,
+  userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs,
+  userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/afxdp/disposition.rs,
+  userspace-dp/src/afxdp/worker/loop_body/mod.rs,
+  userspace-dp/src/afxdp/coordinator/mod.rs,
+  userspace-dp/src/protocol/control.rs, userspace-dp/src/protocol/tests.rs,
+  userspace-dp/src/server/handlers/mod.rs, userspace-dp/src/server/helpers.rs,
+  userspace-dp/src/server/lifecycle.rs,
+  userspace-dp/tests/fixtures/protocol_wire_v1.json,
+  pkg/dataplane/userspace/protocol.go, pkg/dataplane/userspace/manager_ha.go,
+  pkg/dataplane/userspace/zonecounters.go (new),
+  pkg/dataplane/userspace/policycounters.go,
+  pkg/dataplane/userspace/legacy_dataplane.go,
+  pkg/dataplane/userspace/zone_counters_status_test.go (new),
+  docs/userspace-dataplane-gaps.md, docs/research/3643-dead-counters/plan.md,
+  _Log.md

--- a/docs/research/3643-dead-counters/plan.md
+++ b/docs/research/3643-dead-counters/plan.md
@@ -26,9 +26,18 @@ converged, the fork resolved as recommended:
   `zone_counters_hide_test.go` suites in `pkg/dataplane`, `pkg/api`,
   `pkg/cli`, and `pkg/grpcapi`.
 
-- **POPULATE (§5A) is DEFERRED under #3651** — this document is its design
-  of record. VERIFY-FIRST on master: the userspace dataplane does **not**
-  publish per-zone traffic or flood counters over the wire. `ProcessStatus`
+- **POPULATE traffic (§5A) SHIPPED under #3651; per-zone flood still deferred.**
+  This document is its design of record. The Rust helper now accounts per-zone
+  ingress/egress packet+byte volume on the forward hot path (flat `[u8; 65536]`
+  zone-id → slot LUT + per-worker thread-local coalescer in
+  `userspace-dp/src/afxdp/zone_counters.rs`), pre-sums across workers into the
+  `ProcessStatus.zone_traffic_counters` sparse block (layout version 1), and the
+  Go status poll mirrors it into the zone-counter offset map via
+  `SetZoneCounterOffset` so `show security zones` / REST / Prometheus report
+  live volume; a `clear_zone_counters` IPC resets the helper store. The lower-
+  value per-zone FLOOD half stays deferred (lean on the #3343 aggregate). The
+  historical VERIFY-FIRST note below described the pre-#3651 master where the
+  userspace dataplane did **not** publish per-zone traffic or flood counters. `ProcessStatus`
   (`pkg/dataplane/userspace/protocol.go`) carries no per-zone block, and the
   Go-side POPULATE hook — `SetZoneCounterOffset` / `SetFloodCounterOffset`
   plus the `ClearZoneCounterOffsets` / `ClearFloodCounterOffsets` resets on

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -99,47 +99,59 @@ These are not "missing", but they are not pure userspace forwarding either:
 | Dataplane event logging | Session open/close/update are emitted by userspace. Policy-deny, screen-drop, logged routing-instance filter hits, non-PBR input filter logs, output filter logs, cached output-filter hits, and lo0 filter logs now enqueue RT_FLOW frames through the non-blocking Rust event-stream producer with existing per-event rate-limit/loss accounting. Go decode/status handling feeds raw userspace RT_FLOW frames through the same `EventReader.ProcessRawEvent` syslog/local-log path as eBPF, with a deterministic UDP syslog fanout harness for policy deny, screen drop, and filter log. Policy-deny events now carry the snapshot's compiled numeric policy ID; filter-log events carry filter/term/action identity from the matched compiled term. #1379 is closed for the feature-gap audit; the final live cluster syslog proof was delivered in the closed #1477 validation set. |
 | `show system buffers` | Userspace helper-status rendering covers AF_XDP UMEM/TX capacity, CoS queued-byte capacity, helper-published session-table and flow-cache capacity, active-session footer, neighbor counts, and worker queue pressure counters. The Phase 5 denominator decision is explicit: session-table and flow-cache values become fill percentages only from Rust-owned helper fields; neighbor-cache entries remain counters until Rust owns a bounded neighbor-cache capacity. Formatter tests pin that dynamic counts cannot move into the utilization table without real denominators. |
 
-## Deferred Observability — per-zone traffic + flood counters (#3651)
+## Observability — per-zone traffic (populated, #3651) + flood counters (deferred)
 
 Per-zone ingress/egress packet+byte volume (`show security zones` "Traffic
-statistics") and per-zone SYN/ICMP/UDP flood-event counts (`show security screen
-ids-option statistics` "Per-zone flood counters") are **not published by the
-userspace dataplane** and render an explicit **"not available"** on every
-surface (CLI, gRPC text, REST `per_zone_counters_available:false`). This is a
-deliberate, honest gap, not a bug: the eBPF writers that once populated the
-dense `zone_counters` / `flood_counters` BPF arrays were deleted in the #1476
-retirement, and the userspace populate campaign (#2118 per-policy, #2501
-per-session, #2161 NAT64, #3326 host-inbound, #3343 per-screen-reason) never
-covered zone or flood counters.
+statistics") is now **populated by the userspace dataplane** (#3651). Per-zone
+SYN/ICMP/UDP flood-event counts (`show security screen ids-option statistics`
+"Per-zone flood counters") remain **not published** and render an explicit
+**"not available"** — deferred, leaning on the #3343 aggregate per-reason drop
+counters (see below).
 
-- **HIDE (#3643) is what shipped.** `dataplane.ReadZoneCounters` /
+- **HIDE (#3643) is what shipped first.** `dataplane.ReadZoneCounters` /
   `ReadFloodCounters` key a Go-side sparse offset map instead of indexing the
   dense array (so a stable-hash zone id `>= MaxZones` no longer OOB-errors the
   read), returning the distinct `dataplane.ErrCounterNotPopulated` sentinel
   while unpopulated. The always-erroring `xpf_zone_packets_total` /
   `xpf_zone_bytes_total` Prometheus metrics were dropped.
 
-- **POPULATE (#3651) is the deferred prerequisite.** The Go-side populate hook
-  is already wired — `SetZoneCounterOffset` / `SetFloodCounterOffset` plus the
-  `ClearZoneCounterOffsets` / `ClearFloodCounterOffsets` resets — but is sourced
-  only by tests. Lighting the surfaces up requires Rust dataplane work: a flat
-  `[u8; 65536]` slot LUT on the hot path (two direct-index `u64` writes per
-  forwarded packet, no per-packet hash/atomic), ONE helper-pre-summed
-  `ProcessStatus`-level sparse per-zone block on the wire, and a
-  `clear_zone_counters` control-socket IPC so a `clear` resets the helper's
-  cumulative accumulators (clearing only the Go offset maps snaps back on the
-  next 1s poll). Full design of record:
+- **POPULATE traffic (#3651) is what now ships.** The Rust helper accounts
+  per-zone traffic on the forward hot path via a flat direct-index
+  `[u8; 65536]` zone-id → slot LUT (`userspace-dp/src/afxdp/zone_counters.rs`
+  `ZoneCounterSlotMap`, 63 assignable slots + `overflow_active`): two array
+  reads per forwarded packet into a per-worker thread-local coalescer (no
+  per-packet hash, no per-packet atomic — the same coalesce-then-fold pattern
+  as the policy/filter hit counters), folded per RX batch into a
+  coordinator-owned, zone-id-keyed `ZoneCounterStore` that rides `ForwardingState`
+  and survives config commits. The helper pre-sums across workers into ONE
+  `ProcessStatus`-level sparse per-zone block (`zone_traffic_counters`, layout
+  version 1, only nonzero rows). The Go status poll
+  (`syncBPFCountersLocked`) mirrors each row into the bpfShim offset map via
+  `SetZoneCounterOffset`, so `show security zones` Traffic statistics, the REST
+  `/security/zones` endpoint, and the Prometheus collector report live volume.
+  A `clear_zone_counters` control IPC resets the helper's cumulative store (the
+  Go `ClearZoneCounters` / `ClearAllCounters` overrides send it) so an operator
+  clear does not snap back on the next 1 s poll. Design of record:
   [`docs/research/3643-dead-counters/plan.md`](research/3643-dead-counters/plan.md)
   §5A.
 
-- **Live substitutes.** Until #3651 ships, per-zone-adjacent volume is available
-  from the global flow statistics, per-interface `Bindings[].RX/TX{Packets,Bytes}`,
-  per-policy hit counters (#2118, zone-pair scoped), and per-screen-reason drop
-  counters (#3343). The only unique value per-zone volume adds is
-  VLAN-unit-granular attribution — which is why simply summing per-interface
-  binding counters into zones (the §5C DERIVE shortcut) is rejected: one physical
-  binding hosting VLAN units in different zones cannot be split by logical unit,
-  so DERIVE would mis-attribute, which is worse than an honest "not available".
+- **POPULATE flood is still deferred.** Per-zone SYN/ICMP/UDP flood-event
+  attribution is NEW drop-path accounting (the screen module holds per-zone
+  rate-limiter state, not cumulative per-zone flood-event counters), and per the
+  §5A "recommended narrowing" it is the lower-value half. `SetFloodCounterOffset`
+  stays sourced only by tests, so `ReadFloodCounters` keeps returning
+  `ErrCounterNotPopulated` ("not available"). The live substitute is the #3343
+  aggregate per-reason drop counters (syn/icmp/udp-flood ordinals), which are
+  populated. Picking this up means adding a per-zone tally on the
+  `record_screen_drop` path (off the fast path) and a second sparse wire block.
+
+- **Live substitutes for the flood gap.** Global flow statistics, per-interface
+  `Bindings[].RX/TX{Packets,Bytes}`, per-policy hit counters (#2118, zone-pair
+  scoped), and per-screen-reason drop counters (#3343). Note that simply summing
+  per-interface binding counters into zones (the §5C DERIVE shortcut) was
+  rejected as the traffic source: one physical binding hosting VLAN units in
+  different zones cannot be split by logical unit, so DERIVE would mis-attribute
+  — worse than the honest hot-path accounting that #3651 now does.
 
 ## Retirement History (closed)
 

--- a/pkg/dataplane/userspace/legacy_dataplane.go
+++ b/pkg/dataplane/userspace/legacy_dataplane.go
@@ -289,6 +289,21 @@ func (a *LegacyDataPlaneAdapter) ClearNATRuleCounters() error {
 	return m.ClearNATRuleCounters()
 }
 
+// ClearZoneCounters routes the operator per-zone traffic-counter clear through
+// the userspace Manager override (#3651) rather than the embedded bpfShim
+// method. The bpfShim method only zeroes the Go offset map; the Manager
+// override ALSO sends the clear_zone_counters IPC so the helper's cumulative
+// ZoneCounterStore resets and the cleared value does not snap back on the next
+// status poll. The embedded dataplane.DataPlane (= bpfShim) would otherwise be
+// promoted here, so this explicit method is required for the durable clear.
+func (a *LegacyDataPlaneAdapter) ClearZoneCounters() error {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return err
+	}
+	return m.ClearZoneCounters()
+}
+
 // ClearAllCounters routes the operator clear-all through the userspace Manager
 // override (#2218) so the helper NAT translation hit store is reset alongside
 // the BPF maps; otherwise the per-rule NAT totals snap back on the next poll.

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -835,6 +835,21 @@ func (m *Manager) syncBPFCountersLocked(status *ProcessStatus) {
 			Bytes:   c.Bytes,
 		})
 	}
+
+	// #3651: mirror the helper's pre-summed per-zone traffic totals into the
+	// bpfShim zone-counter offset map so Manager.ReadZoneCounters (and thus
+	// `show security zones` Traffic statistics, REST /security/zones, and the
+	// Prometheus collector) reports live per-zone volume instead of
+	// ErrCounterNotPopulated ("not available"). The helper reports cumulative
+	// totals keyed by the stable zone id; SetZoneCounterOffset stores them
+	// absolutely (overwrite), reset-safe on helper restart.
+	for i := range status.ZoneTrafficCounters {
+		z := &status.ZoneTrafficCounters[i]
+		m.bpfShim.SetZoneCounterOffset(z.ZoneID,
+			dataplane.CounterValue{Packets: z.IngressPackets, Bytes: z.IngressBytes},
+			dataplane.CounterValue{Packets: z.EgressPackets, Bytes: z.EgressBytes},
+		)
+	}
 }
 
 // safeDelta returns cur - prev. On counter reset (prev > cur), returns cur

--- a/pkg/dataplane/userspace/policycounters.go
+++ b/pkg/dataplane/userspace/policycounters.go
@@ -329,6 +329,14 @@ func (m *Manager) ClearAllCounters() error {
 	if err := m.clearHelperNATCountersLocked(); err != nil {
 		errs = append(errs, err)
 	}
+	// #3651: a clear-all must also reset the helper per-zone traffic store,
+	// otherwise the per-zone totals snap back on the next status poll (the
+	// helper reports cumulative-since-start and syncBPFCountersLocked overwrites
+	// the offset absolutely). bpfShim.ClearAllCounters() already zeroed the Go
+	// offset map; this sends the clear_zone_counters IPC.
+	if err := m.clearHelperZoneCountersLocked(); err != nil {
+		errs = append(errs, err)
+	}
 	return errors.Join(errs...)
 }
 

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -1469,17 +1469,33 @@ type ProcessStatus struct {
 	// bpfShim nat_rule_counters offset map so Manager.ReadNATRuleCounter (and
 	// thus `show security nat source/destination/static rule`) reports the
 	// live translation count instead of a perpetual 0.
-	NATRuleCounters           []NATRuleCounterStatus            `json:"nat_rule_counters,omitempty"`
-	FilterTermCounters        []FirewallFilterTermCounterStatus `json:"filter_term_counters,omitempty"`
-	ThreeColorPolicerCounters []ThreeColorPolicerStatus         `json:"three_color_policer_counters,omitempty"`
-	SourceNATPools            []SourceNATPoolStatus             `json:"source_nat_pools,omitempty"`
-	LastResolution            *PacketResolution                 `json:"last_resolution,omitempty"`
-	SlowPath                  SlowPathStatus                    `json:"slow_path,omitempty"`
-	LastCacheFlushAt          uint64                            `json:"last_cache_flush_at,omitempty"`    // monotonic secs (#312)
-	DataplaneMode             string                            `json:"dataplane_mode,omitempty"`         // Current active mode: "ebpf_only", "userspace_compat", "userspace_strict"
-	ConfiguredMode            string                            `json:"configured_mode,omitempty"`        // Desired mode from config
-	EntryPrograms             map[int]string                    `json:"entry_programs,omitempty"`         // ifindex -> attached XDP program name
-	DegradedPathCounters      map[string]uint64                 `json:"degraded_path_counters,omitempty"` // reason_name -> count
+	NATRuleCounters    []NATRuleCounterStatus            `json:"nat_rule_counters,omitempty"`
+	FilterTermCounters []FirewallFilterTermCounterStatus `json:"filter_term_counters,omitempty"`
+	// #3651: per-zone ingress/egress traffic (packet + byte) volume, summed
+	// across every worker/binding by the helper (ProcessStatus-level
+	// pre-summed sparse block, one row per zone with nonzero traffic keyed by
+	// the stable zone id). syncBPFCountersLocked mirrors each row into the
+	// legacy bpfShim zone-counter offset map via SetZoneCounterOffset so
+	// Manager.ReadZoneCounters (and thus `show security zones` Traffic
+	// statistics, REST /security/zones, and the Prometheus collector) reports
+	// live per-zone volume instead of ErrCounterNotPopulated ("not
+	// available"). ZoneCounterLayoutVersion selects the decode path (0/absent =
+	// pre-#3651 helper, no per-zone data); ZoneCounterOverflowActive means the
+	// configured zone count exceeded the helper's dense hot-path slot capacity
+	// so some zones went uncounted. JSON tags MUST match the Rust serde
+	// rename(...) exactly.
+	ZoneCounterLayoutVersion  uint32                     `json:"zone_counter_layout_version,omitempty"`
+	ZoneCounterOverflowActive bool                       `json:"zone_counter_overflow_active,omitempty"`
+	ZoneTrafficCounters       []ZoneTrafficCounterStatus `json:"zone_traffic_counters,omitempty"`
+	ThreeColorPolicerCounters []ThreeColorPolicerStatus  `json:"three_color_policer_counters,omitempty"`
+	SourceNATPools            []SourceNATPoolStatus      `json:"source_nat_pools,omitempty"`
+	LastResolution            *PacketResolution          `json:"last_resolution,omitempty"`
+	SlowPath                  SlowPathStatus             `json:"slow_path,omitempty"`
+	LastCacheFlushAt          uint64                     `json:"last_cache_flush_at,omitempty"`    // monotonic secs (#312)
+	DataplaneMode             string                     `json:"dataplane_mode,omitempty"`         // Current active mode: "ebpf_only", "userspace_compat", "userspace_strict"
+	ConfiguredMode            string                     `json:"configured_mode,omitempty"`        // Desired mode from config
+	EntryPrograms             map[int]string             `json:"entry_programs,omitempty"`         // ifindex -> attached XDP program name
+	DegradedPathCounters      map[string]uint64          `json:"degraded_path_counters,omitempty"` // reason_name -> count
 	// #1636 option C: proactive-neighbor-warm telemetry. WarmDrops counts
 	// warm requests dropped because the bounded warmer queue was full
 	// (transient); WarmDisconnected counts requests dropped because the
@@ -2093,6 +2109,22 @@ type NATRuleCounterStatus struct {
 	CounterID uint32 `json:"counter_id,omitempty"`
 	Packets   uint64 `json:"packets,omitempty"`
 	Bytes     uint64 `json:"bytes,omitempty"`
+}
+
+// ZoneTrafficCounterStatus is one per-zone traffic-volume row reported by the
+// userspace dataplane inside ProcessStatus.ZoneTrafficCounters (#3651). ZoneID
+// is the stable name-hash zone id (StableZoneID / ZoneSnapshot.id); ingress
+// totals count packets/bytes that entered the firewall through an interface in
+// the zone, egress totals count packets/bytes that left through one. Totals are
+// cumulative since helper start (or the last clear_zone_counters IPC). The Rust
+// struct is ZoneTrafficCounterStatus (protocol/control.rs) with matching serde
+// rename tags.
+type ZoneTrafficCounterStatus struct {
+	ZoneID         uint16 `json:"zone_id,omitempty"`
+	IngressPackets uint64 `json:"ingress_packets,omitempty"`
+	IngressBytes   uint64 `json:"ingress_bytes,omitempty"`
+	EgressPackets  uint64 `json:"egress_packets,omitempty"`
+	EgressBytes    uint64 `json:"egress_bytes,omitempty"`
 }
 
 type HAStateUpdateRequest struct {

--- a/pkg/dataplane/userspace/zone_counters_status_test.go
+++ b/pkg/dataplane/userspace/zone_counters_status_test.go
@@ -1,0 +1,143 @@
+package userspace
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #3651: syncBPFCountersLocked must mirror the helper's pre-summed per-zone
+// traffic block into the bpfShim zone-counter offset map so Manager.
+// ReadZoneCounters reports live volume instead of ErrCounterNotPopulated.
+//
+// RED-on-revert: delete the ZoneTrafficCounters loop in syncBPFCountersLocked
+// (the Go decode half of #3651) and the reads below revert to
+// ErrCounterNotPopulated ("not available"), failing this test.
+func TestSyncBPFCountersPopulatesZoneCounters(t *testing.T) {
+	m := &Manager{bpfShim: dataplane.New()}
+
+	// A stable-hash zone id reads "not available" before any populate.
+	if _, err := m.bpfShim.ReadZoneCounters(40000, 0); !errors.Is(err, dataplane.ErrCounterNotPopulated) {
+		t.Fatalf("pre-populate ReadZoneCounters(40000,ingress) err = %v, want ErrCounterNotPopulated", err)
+	}
+
+	status := &ProcessStatus{
+		ZoneCounterLayoutVersion: 1,
+		ZoneTrafficCounters: []ZoneTrafficCounterStatus{
+			{ZoneID: 40000, IngressPackets: 10, IngressBytes: 1500, EgressPackets: 4, EgressBytes: 600},
+			{ZoneID: 7, IngressPackets: 3, IngressBytes: 180, EgressPackets: 9, EgressBytes: 540},
+		},
+	}
+	m.syncBPFCountersLocked(status)
+
+	// Ingress (direction 0) and egress (direction 1) both surface, no error.
+	ing, err := m.bpfShim.ReadZoneCounters(40000, 0)
+	if err != nil {
+		t.Fatalf("ReadZoneCounters(40000,ingress) err = %v, want nil", err)
+	}
+	if ing.Packets != 10 || ing.Bytes != 1500 {
+		t.Fatalf("zone 40000 ingress = %+v, want {Packets:10 Bytes:1500}", ing)
+	}
+	eg, err := m.bpfShim.ReadZoneCounters(40000, 1)
+	if err != nil {
+		t.Fatalf("ReadZoneCounters(40000,egress) err = %v, want nil", err)
+	}
+	if eg.Packets != 4 || eg.Bytes != 600 {
+		t.Fatalf("zone 40000 egress = %+v, want {Packets:4 Bytes:600}", eg)
+	}
+	ing7, err := m.bpfShim.ReadZoneCounters(7, 0)
+	if err != nil {
+		t.Fatalf("ReadZoneCounters(7,ingress) err = %v, want nil", err)
+	}
+	if ing7.Packets != 3 || ing7.Bytes != 180 {
+		t.Fatalf("zone 7 ingress = %+v, want {Packets:3 Bytes:180}", ing7)
+	}
+
+	// A zone the helper never reported still reads "not available".
+	if _, err := m.bpfShim.ReadZoneCounters(999, 0); !errors.Is(err, dataplane.ErrCounterNotPopulated) {
+		t.Fatalf("unreported zone ReadZoneCounters(999) err = %v, want ErrCounterNotPopulated", err)
+	}
+
+	// Absolute overwrite: a fresh status snaps to the new cumulative totals.
+	m.syncBPFCountersLocked(&ProcessStatus{
+		ZoneCounterLayoutVersion: 1,
+		ZoneTrafficCounters: []ZoneTrafficCounterStatus{
+			{ZoneID: 40000, IngressPackets: 25, IngressBytes: 4000, EgressPackets: 11, EgressBytes: 1600},
+		},
+	})
+	ing2, err := m.bpfShim.ReadZoneCounters(40000, 0)
+	if err != nil {
+		t.Fatalf("post-overwrite ReadZoneCounters(40000,ingress) err = %v", err)
+	}
+	if ing2.Packets != 25 || ing2.Bytes != 4000 {
+		t.Fatalf("zone 40000 ingress after overwrite = %+v, want {Packets:25 Bytes:4000}", ing2)
+	}
+}
+
+// #3651: the ZoneTrafficCounters block survives JSON round-trip both directions
+// (Go-encode -> JSON -> Go-decode, and Go-decode of a Rust-style payload). The
+// Rust-side mirror is protocol/tests.rs::
+// zone_traffic_counters_wire_roundtrip_and_default_omits.
+func TestZoneTrafficCounterStatusWireRoundTrip(t *testing.T) {
+	// A default ProcessStatus omits the layout-version / overflow keys
+	// (omitempty), matching the Rust skip_serializing_if behaviour.
+	def, err := json.Marshal(&ProcessStatus{})
+	if err != nil {
+		t.Fatalf("marshal default ProcessStatus: %v", err)
+	}
+	for _, k := range []string{"zone_counter_layout_version", "zone_counter_overflow_active"} {
+		if strings.Contains(string(def), k) {
+			t.Fatalf("default ProcessStatus must omit %q: %s", k, def)
+		}
+	}
+
+	orig := ProcessStatus{
+		ZoneCounterLayoutVersion:  1,
+		ZoneCounterOverflowActive: true,
+		ZoneTrafficCounters: []ZoneTrafficCounterStatus{
+			{ZoneID: 40000, IngressPackets: 10, IngressBytes: 1500, EgressPackets: 4, EgressBytes: 600},
+		},
+	}
+	payload, err := json.Marshal(&orig)
+	if err != nil {
+		t.Fatalf("marshal populated ProcessStatus: %v", err)
+	}
+	var back ProcessStatus
+	if err := json.Unmarshal(payload, &back); err != nil {
+		t.Fatalf("unmarshal ProcessStatus: %v", err)
+	}
+	if back.ZoneCounterLayoutVersion != 1 || !back.ZoneCounterOverflowActive {
+		t.Fatalf("layout/overflow not preserved: %+v", back)
+	}
+	if len(back.ZoneTrafficCounters) != 1 {
+		t.Fatalf("zone_traffic_counters len = %d, want 1", len(back.ZoneTrafficCounters))
+	}
+	z := back.ZoneTrafficCounters[0]
+	if z.ZoneID != 40000 || z.IngressPackets != 10 || z.IngressBytes != 1500 ||
+		z.EgressPackets != 4 || z.EgressBytes != 600 {
+		t.Fatalf("zone row not preserved: %+v", z)
+	}
+
+	// Decode a Rust-style helper payload (json tags emitted by control.rs).
+	const rustJSON = `{
+		"pid": 1,
+		"zone_counter_layout_version": 1,
+		"zone_traffic_counters": [
+			{"zone_id": 7, "ingress_packets": 2, "ingress_bytes": 200,
+			 "egress_packets": 1, "egress_bytes": 100}
+		]
+	}`
+	var decoded ProcessStatus
+	if err := json.Unmarshal([]byte(rustJSON), &decoded); err != nil {
+		t.Fatalf("decode Rust-style payload: %v", err)
+	}
+	if decoded.ZoneCounterLayoutVersion != 1 || len(decoded.ZoneTrafficCounters) != 1 {
+		t.Fatalf("Rust payload not decoded: %+v", decoded)
+	}
+	if decoded.ZoneTrafficCounters[0].ZoneID != 7 || decoded.ZoneTrafficCounters[0].EgressBytes != 100 {
+		t.Fatalf("Rust zone row mismatch: %+v", decoded.ZoneTrafficCounters[0])
+	}
+}

--- a/pkg/dataplane/userspace/zonecounters.go
+++ b/pkg/dataplane/userspace/zonecounters.go
@@ -1,0 +1,61 @@
+package userspace
+
+import (
+	"errors"
+)
+
+// ClearZoneCounters resets the per-zone ingress/egress traffic counters
+// (#3651). This is the userspace.Manager override of the embedded bpfShim
+// method, and it is the path the operator zone-counter clear resolves to via
+// the LegacyDataPlaneAdapter delegation.
+//
+// Clearing requires TWO actions, exactly mirroring ClearNATRuleCounters:
+//
+//  1. bpfShim.ClearZoneCounters() drops the Go-side zone-counter offset map
+//     (and the legacy dense BPF array, when present) that ReadZoneCounters
+//     keys -- the only source of per-zone values today.
+//  2. clearHelperZoneCountersLocked() sends the clear_zone_counters IPC so the
+//     Rust helper's cumulative ZoneCounterStore is reset.
+//
+// Step 2 is the load-bearing half. The helper reports cumulative totals on
+// every 1/s status poll, and syncBPFCountersLocked writes them into the offset
+// map ABSOLUTELY (SetZoneCounterOffset overwrites). Without resetting the
+// helper store, the next poll would restore the cumulative total and the
+// cleared value would snap back within <=1s. After the IPC clear the helper
+// reports 0, so the offset stays 0.
+func (m *Manager) ClearZoneCounters() error {
+	var errs []error
+	if m.bpfShim != nil {
+		if err := m.bpfShim.ClearZoneCounters(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := m.clearHelperZoneCountersLocked(); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+// clearHelperZoneCountersLocked sends the clear_zone_counters IPC to the Rust
+// helper so its ZoneCounterStore resets to zero, then records the refreshed
+// (zeroed) status. Mirrors clearHelperNATCountersLocked. Caller holds m.mu.
+//
+// With no live helper process the cached helper-reported zone counters in
+// m.lastStatus are dropped directly so a clear takes effect even in the
+// userspace-only / pre-start state (parity with the bpfShim offset clear).
+func (m *Manager) clearHelperZoneCountersLocked() error {
+	if m.proc == nil || m.proc.Process == nil {
+		m.lastStatus.ZoneTrafficCounters = nil
+		return nil
+	}
+
+	var status ProcessStatus
+	if err := m.requestLocked(ControlRequest{Type: "clear_zone_counters"}, &status); err != nil {
+		return err
+	}
+	m.recordHelperStatusLocked(&status)
+	return nil
+}

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -840,6 +840,40 @@ impl Coordinator {
         self.nat_counters.clear();
     }
 
+    /// #3651: per-zone ingress/egress traffic-volume snapshot for
+    /// `ProcessStatus.zone_traffic_counters`, filtered to currently-configured
+    /// zones so a zone removed between the worker fold and this status build
+    /// never surfaces. Empty when no configured zone has moved traffic yet.
+    pub fn zone_traffic_counters(&self) -> Vec<crate::protocol::ZoneTrafficCounterStatus> {
+        let configured = &self.forwarding.zone_id_to_name;
+        self.forwarding
+            .zone_counter_store
+            .snapshot()
+            .into_iter()
+            .filter(|s| configured.contains_key(&s.zone_id))
+            .collect()
+    }
+
+    /// #3651: true when the configured zone count exceeded the hot-path slot
+    /// capacity, so some zones are silently uncounted (surfaced on the wire as
+    /// `zone_counter_overflow_active`).
+    pub fn zone_counter_overflow_active(&self) -> bool {
+        self.forwarding.zone_counter_slot_map.overflow_active
+    }
+
+    /// #3651: the zone-counter wire layout version this helper emits.
+    pub fn zone_counter_layout_version(&self) -> u32 {
+        crate::afxdp::zone_counters::ZONE_COUNTER_LAYOUT_VERSION
+    }
+
+    /// #3651: operator clear of per-zone traffic counters. Resets the helper's
+    /// cumulative store so the Go side's absolute `SetZoneCounterOffset`
+    /// overwrite reports 0 instead of snapping the pre-clear total back on the
+    /// next 1 s status poll (the load-bearing half of the operator clear).
+    pub fn clear_zone_counters(&self) {
+        self.forwarding.zone_counter_store.clear();
+    }
+
     /// Current in-memory FIB generation (the value flow-cache lookups
     /// validate against). Read by the `bump_fib_generation` control handler
     /// to build a rollback-rejection error and by tests.

--- a/userspace-dp/src/afxdp/disposition.rs
+++ b/userspace-dp/src/afxdp/disposition.rs
@@ -129,6 +129,16 @@ pub(super) enum DispositionCounters<'a> {
 }
 
 impl DispositionCounters<'_> {
+    /// #3651: true on the worker per-packet hot path (`Hot`), false for the
+    /// cold RPC-inject path (`Cold`). Per-zone traffic accounting only runs on
+    /// `Hot` because the coalescer's thread-local is folded into the shared
+    /// store from the worker RX-batch flush — the control thread that drives
+    /// `Cold` never reaches that flush, so its accumulation would be lost.
+    #[inline]
+    fn is_hot(&self) -> bool {
+        matches!(self, Self::Hot(_))
+    }
+
     #[inline]
     fn bump_validated(&mut self, packet_length: u32) {
         match self {
@@ -333,6 +343,21 @@ pub(super) fn record_forwarding_disposition(
         }
         ForwardingDisposition::ForwardCandidate | ForwardingDisposition::FabricRedirect => {
             counters.bump_forward_candidate();
+            // #3651: per-zone traffic volume for forward paths that resolve
+            // through record_forwarding_disposition (tunnel decap, next-table,
+            // fabric redirect). Hot-path only (the Cold RPC-inject path's
+            // thread-local coalescer is never flushed); needs the shim meta for
+            // the ingress zone.
+            if counters.is_hot()
+                && let Some(m) = meta
+            {
+                crate::afxdp::zone_counters::record_zone_traffic(
+                    &forwarding.zone_counter_slot_map,
+                    m.ingress_zone,
+                    forwarding.egress_zone_id(resolution.egress_ifindex),
+                    m.pkt_len as u64,
+                );
+            }
         }
         ForwardingDisposition::HAInactive => {
             update_last_resolution(last_resolution, resolution, debug, forwarding);

--- a/userspace-dp/src/afxdp/forwarding_build/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/mod.rs
@@ -364,6 +364,23 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
         let (slot_map, _slots_to_zero) = ColdPathSlotMap::build(prev_map, &pairs);
         state.cold_path_slot_map = std::sync::Arc::new(slot_map);
     }
+    // #3651: build the per-zone traffic-counter slot map from the configured
+    // zone set and carry the cumulative store forward from the previous state
+    // (first apply creates it) so totals survive config commits. Unlike the
+    // cold-path histogram, the store is zone-id keyed, so the slot map is a
+    // plain rebuild with no previous-map retention / slot zero-out.
+    {
+        use crate::afxdp::zone_counters::{ZoneCounterSlotMap, ZoneCounterStore};
+        let zone_ids: Vec<u16> = snapshot.zones.iter().map(|z| z.id).collect();
+        state.zone_counter_slot_map = std::sync::Arc::new(ZoneCounterSlotMap::build(&zone_ids));
+        state.zone_counter_store = previous
+            .map(|p| p.zone_counter_store.clone())
+            .unwrap_or_else(ZoneCounterStore::default);
+        // Drop totals for zones no longer configured (memory hygiene; the
+        // status accessor also filters to configured zones).
+        let configured: rustc_hash::FxHashSet<u16> = zone_ids.iter().copied().collect();
+        state.zone_counter_store.reconcile(&configured);
+    }
     // Build filter state from snapshot. #2505: this is fallible — an
     // unresolvable `from protocol` token raises a SnapshotIntegrityError that
     // propagates here, aborting the reconcile preflight (before teardown /

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -134,6 +134,8 @@ mod umem;
 #[allow(dead_code)]
 #[path = "cold_path_hist.rs"]
 mod cold_path_hist;
+// #3651: per-zone ingress/egress traffic counters (POPULATE half of #3643).
+mod zone_counters;
 // Clean-room WireGuard tunnel termination — see
 // docs/pr/wireguard-clean/plan.md. Engine + tests only in this PR;
 // hot-path activation lands in a follow-up.

--- a/userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs
@@ -316,6 +316,18 @@ pub(super) fn stage_flow_cache_hit(
             // a packet reaching here has a live TTL. No TTL test remains on the
             // forward fast path.
             telemetry.counters.forward_candidate_packets += 1;
+            // #3651: per-zone traffic volume for this forwarded packet — two
+            // flat-LUT reads (ingress zone from the shim meta, egress zone from
+            // the resolved egress ifindex) into the per-worker thread-local
+            // coalescer, folded into the shared store per RX batch.
+            crate::afxdp::zone_counters::record_zone_traffic(
+                &worker_ctx.forwarding.zone_counter_slot_map,
+                meta.ingress_zone,
+                worker_ctx
+                    .forwarding
+                    .egress_zone_id(cached_decision.resolution.egress_ifindex),
+                meta.pkt_len as u64,
+            );
             if cached_decision.nat.rewrite_src.is_some() {
                 telemetry.counters.snat_packets += 1;
             }

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -4008,6 +4008,17 @@ pub(super) fn poll_binding_process_descriptor(
                             .push((flow.forward_key.clone(), decision.nat));
                     }
                     telemetry.counters.forward_candidate_packets += 1;
+                    // #3651: per-zone traffic volume for this slow-path (first-
+                    // packet / non-cacheable) forwarded packet, mirroring the
+                    // flow-cache-hit fast path.
+                    crate::afxdp::zone_counters::record_zone_traffic(
+                        &worker_ctx.forwarding.zone_counter_slot_map,
+                        meta.ingress_zone,
+                        worker_ctx
+                            .forwarding
+                            .egress_zone_id(decision.resolution.egress_ifindex),
+                        meta.pkt_len as u64,
+                    );
                     if decision.nat.rewrite_src.is_some() {
                         telemetry.counters.snat_packets += 1;
                     }

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -275,6 +275,18 @@ pub(in crate::afxdp) struct ForwardingState {
     /// via `lookup_slot`. Rotated via the ForwardingState ArcSwap.
     pub(in crate::afxdp) cold_path_slot_map:
         std::sync::Arc<crate::afxdp::cold_path_hist::ColdPathSlotMap>,
+    /// #3651: flat zone-id → hot-path slot LUT for per-zone traffic counters,
+    /// rebuilt from the configured zone set at each config apply. Read on every
+    /// forwarded packet via `record_zone_traffic` (two array reads, no hash).
+    /// Rotated via the ForwardingState ArcSwap alongside `cold_path_slot_map`.
+    pub(in crate::afxdp) zone_counter_slot_map:
+        std::sync::Arc<crate::afxdp::zone_counters::ZoneCounterSlotMap>,
+    /// #3651: coordinator-owned cumulative per-zone traffic totals. Keyed by
+    /// stable zone id, `Clone` shares the inner `Arc<Mutex>`, so cloning this
+    /// state (worker publish) and carrying it forward across config applies
+    /// (`forwarding_build`) keeps totals alive until the operator
+    /// `clear_zone_counters` IPC resets them.
+    pub(in crate::afxdp) zone_counter_store: crate::afxdp::zone_counters::ZoneCounterStore,
 }
 
 /// #3070/#3405: a zone's compiled host-inbound-traffic admission set. Built from
@@ -412,6 +424,19 @@ impl ForwardingState {
     /// unconfigured / unknown zone (e.g. `0`) is always tcp-rst off.
     pub(in crate::afxdp) fn zone_tcp_rst_enabled(&self, zone_id: u16) -> bool {
         self.zone_tcp_rst.get(&zone_id).copied().unwrap_or(false)
+    }
+
+    /// #3651: the egress (to) zone id for `egress_ifindex`, or `0` when the
+    /// interface is unknown / unzoned. Mirrors the egress half of
+    /// `zone_pair_ids_for_flow_with_override`; used by the per-zone traffic
+    /// counter (`record_zone_traffic`) on the forward path where only the
+    /// egress ifindex (not zone) is in hand.
+    #[inline]
+    pub(in crate::afxdp) fn egress_zone_id(&self, egress_ifindex: i32) -> u16 {
+        self.egress
+            .get(&egress_ifindex)
+            .map(|iface| iface.zone_id)
+            .unwrap_or(0)
     }
 
     /// #3618: the per-zone `reject` rate-limit bucket for ingress (from) zone

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -824,6 +824,14 @@ pub(crate) fn worker_loop(
         // shared counters once per RX batch (alongside the filter-counter
         // flush) so `show security policies hit-count` converges within a tick.
         crate::policy::flush_recorded_policy_hit_counters();
+        // #3651: fold this worker's coalesced per-zone traffic tally into the
+        // shared zone-counter store, same cadence. `forwarding` is stable
+        // across this iteration's binding sweep, so the slot map matches the
+        // one the `record_zone_traffic` calls used.
+        crate::afxdp::zone_counters::flush_recorded_zone_counters(
+            &forwarding.zone_counter_store,
+            &forwarding.zone_counter_slot_map,
+        );
         #[cfg(feature = "debug-log")]
         {
             dbg.accumulate(&dbg_poll);

--- a/userspace-dp/src/afxdp/zone_counters.rs
+++ b/userspace-dp/src/afxdp/zone_counters.rs
@@ -1,0 +1,437 @@
+//! #3651: per-zone ingress/egress traffic (packet + byte) counters.
+//!
+//! The eBPF-era dense `zone_counters` BPF array was deleted in the #1476
+//! retirement; the Go read surfaces (`show security zones` Traffic statistics,
+//! REST `/security/zones`, the Prometheus collector) key a sparse offset map
+//! and report `ErrCounterNotPopulated` ("not available") because nothing
+//! sources per-zone volume. This module is the userspace POPULATE half
+//! (design of record: `docs/research/3643-dead-counters/plan.md` §5A).
+//!
+//! ## Hot path (no per-packet hash, no per-packet atomic)
+//!
+//! [`ZoneCounterSlotMap`] is a flat direct-index `[u8; 65536]` zone-id → slot
+//! LUT built at config-apply time. A forwarded packet resolves its ingress and
+//! egress zone slot with two array reads (Codex+AGY r1 mandate: a per-packet
+//! `HashMap::get` would throttle forwarding) and accumulates into a per-worker
+//! thread-local dense [`ZonePending`] accumulator — the same coalesce-then-fold
+//! technique `policy::record_policy_hit_counter` / `filter::record_filter_counter`
+//! use. The per-RX-batch [`flush_recorded_zone_counters`] folds the coalesced
+//! per-slot deltas into the coordinator-owned [`ZoneCounterStore`].
+//!
+//! ## Store (zone-id keyed → no slot-reassignment hazard)
+//!
+//! The shared store is keyed by the STABLE zone id, not by slot. The flush
+//! translates slot → zone id through the slot map's inverse, so a config apply
+//! that renumbers slots never mis-attributes counts: accumulate and flush
+//! inside one loop iteration always use the same slot map, and the store cell
+//! is addressed by the stable zone id. That removes the cold-path `zero_slot`
+//! reassignment machinery entirely. The store rides `ForwardingState` (cloned
+//! forward from the previous state across applies, like a persistent Arc) so
+//! totals survive config commits, and is reset only by the operator
+//! `clear_zone_counters` control IPC.
+
+use std::cell::RefCell;
+use std::sync::{Arc, Mutex};
+
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::protocol::ZoneTrafficCounterStatus;
+
+/// Dense hot-path slot count. Slot 0 is reserved (unassigned / unzoned), so
+/// `ZONE_COUNTER_SLOTS - 1` zones are assignable to a slot; a configured zone
+/// past that capacity sets `overflow_active` and its traffic goes uncounted
+/// (documented, same posture as the cold-path histogram `overflow_active`).
+/// 63 assignable slots covers every realistic deployment (the legacy dense
+/// `zone_counters` array held 64) while keeping the per-worker thread-local
+/// accumulator small (64 × 4 × 8 = 2 KiB).
+pub(in crate::afxdp) const ZONE_COUNTER_SLOTS: usize = 64;
+
+/// Number of assignable slots (slot 0 reserved).
+pub(in crate::afxdp) const ZONE_COUNTER_ASSIGNABLE_SLOTS: usize = ZONE_COUNTER_SLOTS - 1;
+
+/// Wire/layout version stamped into `ProcessStatus.zone_counter_layout_version`
+/// when the block is populated (#3651). 0/absent = pre-#3651 helper.
+pub(in crate::afxdp) const ZONE_COUNTER_LAYOUT_VERSION: u32 = 1;
+
+/// Flat direct-index zone-id → hot-path slot LUT, built at config apply.
+///
+/// `slot_of[zone_id]` is 0 for an unassigned zone (unzoned id 0, or a zone
+/// past the slot capacity), else the dense slot `[1, ZONE_COUNTER_ASSIGNABLE_SLOTS]`.
+/// `inverse[slot]` recovers the zone id for the flush's slot → zone-id
+/// translation (0 = free slot). A single 16-bit zone id makes the flat LUT
+/// feasible where the cold-path 32-bit zone-PAIR key needed a `HashMap`.
+pub(in crate::afxdp) struct ZoneCounterSlotMap {
+    slot_of: Box<[u8; 65536]>,
+    inverse: [u16; ZONE_COUNTER_SLOTS],
+    /// True if some configured zone could not be assigned a slot because the
+    /// `ZONE_COUNTER_ASSIGNABLE_SLOTS` capacity was exhausted. Surfaced as
+    /// `ProcessStatus.zone_counter_overflow_active`.
+    pub(in crate::afxdp) overflow_active: bool,
+}
+
+impl Default for ZoneCounterSlotMap {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl std::fmt::Debug for ZoneCounterSlotMap {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Summarize rather than dumping the 64 KiB LUT.
+        let assigned = self.inverse.iter().filter(|&&z| z != 0).count();
+        f.debug_struct("ZoneCounterSlotMap")
+            .field("assigned_zones", &assigned)
+            .field("overflow_active", &self.overflow_active)
+            .finish()
+    }
+}
+
+impl ZoneCounterSlotMap {
+    /// An empty map: every zone resolves to slot 0 (uncounted).
+    pub(in crate::afxdp) fn empty() -> Self {
+        Self {
+            slot_of: Box::new([0u8; 65536]),
+            inverse: [0u16; ZONE_COUNTER_SLOTS],
+            overflow_active: false,
+        }
+    }
+
+    /// Build the slot map from the configured zone-id set. Slots are assigned
+    /// in sorted zone-id order (deterministic for a given config); a duplicate
+    /// or zero id is ignored. Because the shared store is zone-id keyed, slot
+    /// assignment does NOT need to be stable across applies (unlike the
+    /// cold-path histogram, whose slot IS the accumulator index), so this is a
+    /// plain rebuild with no previous-map retention.
+    pub(in crate::afxdp) fn build(zone_ids: &[u16]) -> Self {
+        let mut ids: Vec<u16> = zone_ids.iter().copied().filter(|&z| z != 0).collect();
+        ids.sort_unstable();
+        ids.dedup();
+
+        let mut slot_of = Box::new([0u8; 65536]);
+        let mut inverse = [0u16; ZONE_COUNTER_SLOTS];
+        let mut overflow_active = false;
+        let mut next_slot = 1usize;
+        for zid in ids {
+            if next_slot > ZONE_COUNTER_ASSIGNABLE_SLOTS {
+                overflow_active = true;
+                break;
+            }
+            slot_of[zid as usize] = next_slot as u8;
+            inverse[next_slot] = zid;
+            next_slot += 1;
+        }
+        Self {
+            slot_of,
+            inverse,
+            overflow_active,
+        }
+    }
+
+    /// Resolve the hot-path slot for `zone_id` (0 = unassigned / uncounted).
+    #[inline]
+    pub(in crate::afxdp) fn slot_of(&self, zone_id: u16) -> u8 {
+        self.slot_of[zone_id as usize]
+    }
+}
+
+/// Cumulative per-zone traffic totals, guarded by a single mutex (folded into
+/// off the hot path, at RX-batch cadence, so the lock is uncontended in
+/// practice — mirrors the `PolicyCounterStore` registry lock).
+#[derive(Clone, Copy, Debug, Default)]
+struct ZoneTotals {
+    ingress_packets: u64,
+    ingress_bytes: u64,
+    egress_packets: u64,
+    egress_bytes: u64,
+}
+
+/// Coordinator-owned, config-apply-surviving cumulative per-zone traffic
+/// store, keyed by the stable zone id. `Clone` shares the inner `Arc<Mutex>`,
+/// so cloning `ForwardingState` (worker publish) keeps every generation
+/// pointing at the same totals.
+#[derive(Clone, Debug, Default)]
+pub(in crate::afxdp) struct ZoneCounterStore {
+    totals: Arc<Mutex<FxHashMap<u16, ZoneTotals>>>,
+}
+
+impl ZoneCounterStore {
+    /// Sparse snapshot for the status wire: one row per zone with any traffic.
+    /// Deterministic order (sorted by zone id) for a stable wire.
+    pub(in crate::afxdp) fn snapshot(&self) -> Vec<ZoneTrafficCounterStatus> {
+        let totals = self.totals.lock().expect("zone counter store poisoned");
+        let mut out: Vec<ZoneTrafficCounterStatus> = totals
+            .iter()
+            .filter(|(_, t)| {
+                t.ingress_packets != 0
+                    || t.ingress_bytes != 0
+                    || t.egress_packets != 0
+                    || t.egress_bytes != 0
+            })
+            .map(|(&zone_id, t)| ZoneTrafficCounterStatus {
+                zone_id,
+                ingress_packets: t.ingress_packets,
+                ingress_bytes: t.ingress_bytes,
+                egress_packets: t.egress_packets,
+                egress_bytes: t.egress_bytes,
+            })
+            .collect();
+        out.sort_unstable_by_key(|s| s.zone_id);
+        out
+    }
+
+    /// Operator clear (`clear_zone_counters` IPC): drop all cumulative totals
+    /// so the helper reports 0 on the next status poll (otherwise the Go side's
+    /// absolute `SetZoneCounterOffset` overwrite would snap the cleared value
+    /// back within <= 1 s). Load-bearing half of the operator clear.
+    pub(in crate::afxdp) fn clear(&self) {
+        self.totals
+            .lock()
+            .expect("zone counter store poisoned")
+            .clear();
+    }
+
+    /// Drop totals for zones that are no longer configured (config apply
+    /// hygiene). Correctness does not depend on this — the coordinator snapshot
+    /// accessor also filters to configured zones — but it bounds the map to the
+    /// live zone set.
+    pub(in crate::afxdp) fn reconcile(&self, configured: &FxHashSet<u16>) {
+        self.totals
+            .lock()
+            .expect("zone counter store poisoned")
+            .retain(|zone_id, _| configured.contains(zone_id));
+    }
+
+    /// Fold a worker's coalesced per-slot deltas into the store, translating
+    /// slot → zone id via the slot map inverse. Off the hot path (once per RX
+    /// batch), so the single lock acquisition is cheap.
+    fn fold_pending(&self, pending: &ZonePending, slot_map: &ZoneCounterSlotMap) {
+        let mut totals = self.totals.lock().expect("zone counter store poisoned");
+        for slot in 1..ZONE_COUNTER_SLOTS {
+            let zone_id = slot_map.inverse[slot];
+            if zone_id == 0 {
+                continue;
+            }
+            let ip = pending.ingress_packets[slot];
+            let ib = pending.ingress_bytes[slot];
+            let ep = pending.egress_packets[slot];
+            let eb = pending.egress_bytes[slot];
+            if ip == 0 && ib == 0 && ep == 0 && eb == 0 {
+                continue;
+            }
+            let entry = totals.entry(zone_id).or_default();
+            entry.ingress_packets = entry.ingress_packets.saturating_add(ip);
+            entry.ingress_bytes = entry.ingress_bytes.saturating_add(ib);
+            entry.egress_packets = entry.egress_packets.saturating_add(ep);
+            entry.egress_bytes = entry.egress_bytes.saturating_add(eb);
+        }
+    }
+}
+
+/// Per-worker thread-local dense slot accumulator. Touched only by the owning
+/// worker thread on the hot path; folded into the shared store per RX batch.
+struct ZonePending {
+    ingress_packets: [u64; ZONE_COUNTER_SLOTS],
+    ingress_bytes: [u64; ZONE_COUNTER_SLOTS],
+    egress_packets: [u64; ZONE_COUNTER_SLOTS],
+    egress_bytes: [u64; ZONE_COUNTER_SLOTS],
+    touched: bool,
+}
+
+impl Default for ZonePending {
+    fn default() -> Self {
+        Self {
+            ingress_packets: [0; ZONE_COUNTER_SLOTS],
+            ingress_bytes: [0; ZONE_COUNTER_SLOTS],
+            egress_packets: [0; ZONE_COUNTER_SLOTS],
+            egress_bytes: [0; ZONE_COUNTER_SLOTS],
+            touched: false,
+        }
+    }
+}
+
+impl ZonePending {
+    fn reset(&mut self) {
+        if !self.touched {
+            return;
+        }
+        self.ingress_packets = [0; ZONE_COUNTER_SLOTS];
+        self.ingress_bytes = [0; ZONE_COUNTER_SLOTS];
+        self.egress_packets = [0; ZONE_COUNTER_SLOTS];
+        self.egress_bytes = [0; ZONE_COUNTER_SLOTS];
+        self.touched = false;
+    }
+}
+
+thread_local! {
+    static ZONE_PENDING: RefCell<ZonePending> = RefCell::new(ZonePending::default());
+}
+
+/// Record one forwarded packet against its ingress and egress zone. The zone
+/// ids are already resolved (ingress from the shim meta, egress from the
+/// forwarding resolution), so this is two flat-LUT reads plus a thread-local
+/// accumulate — no hash, no atomic, no allocation. An unassigned zone (slot 0)
+/// contributes nothing.
+#[inline]
+pub(in crate::afxdp) fn record_zone_traffic(
+    slot_map: &ZoneCounterSlotMap,
+    ingress_zone_id: u16,
+    egress_zone_id: u16,
+    packet_bytes: u64,
+) {
+    let ingress_slot = slot_map.slot_of(ingress_zone_id);
+    let egress_slot = slot_map.slot_of(egress_zone_id);
+    if ingress_slot == 0 && egress_slot == 0 {
+        return;
+    }
+    ZONE_PENDING.with(|pending| {
+        let mut p = pending.borrow_mut();
+        if ingress_slot != 0 {
+            let s = ingress_slot as usize;
+            p.ingress_packets[s] = p.ingress_packets[s].saturating_add(1);
+            p.ingress_bytes[s] = p.ingress_bytes[s].saturating_add(packet_bytes);
+            p.touched = true;
+        }
+        if egress_slot != 0 {
+            let s = egress_slot as usize;
+            p.egress_packets[s] = p.egress_packets[s].saturating_add(1);
+            p.egress_bytes[s] = p.egress_bytes[s].saturating_add(packet_bytes);
+            p.touched = true;
+        }
+    });
+}
+
+/// Fold this worker thread's coalesced per-zone deltas into the shared store.
+/// Called once per RX batch alongside `flush_recorded_filter_counters` /
+/// `flush_recorded_policy_hit_counters`. `slot_map` must be the SAME map the
+/// intervening `record_zone_traffic` calls used (guaranteed: both read the
+/// loop iteration's `forwarding` snapshot), so the slot → zone-id translation
+/// is consistent.
+pub(in crate::afxdp) fn flush_recorded_zone_counters(
+    store: &ZoneCounterStore,
+    slot_map: &ZoneCounterSlotMap,
+) {
+    ZONE_PENDING.with(|pending| {
+        let mut p = pending.borrow_mut();
+        if !p.touched {
+            return;
+        }
+        store.fold_pending(&p, slot_map);
+        p.reset();
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_assigns_slots_for_wide_stable_hash_zone_ids() {
+        // #3075 stable name-hash ids span [1, 65533]; a dense id-indexed table
+        // would drop these. The flat LUT + slot map must count them.
+        let map = ZoneCounterSlotMap::build(&[40000, 7, 65533]);
+        assert!(!map.overflow_active);
+        // sorted → 7 gets slot 1, 40000 slot 2, 65533 slot 3.
+        assert_eq!(map.slot_of(7), 1);
+        assert_eq!(map.slot_of(40000), 2);
+        assert_eq!(map.slot_of(65533), 3);
+        assert_eq!(map.inverse[1], 7);
+        assert_eq!(map.inverse[2], 40000);
+        assert_eq!(map.inverse[3], 65533);
+        // Unconfigured / unzoned resolve to slot 0.
+        assert_eq!(map.slot_of(0), 0);
+        assert_eq!(map.slot_of(123), 0);
+    }
+
+    #[test]
+    fn build_dedups_and_skips_zero() {
+        let map = ZoneCounterSlotMap::build(&[0, 5, 5, 9, 0, 5]);
+        assert_eq!(map.slot_of(5), 1);
+        assert_eq!(map.slot_of(9), 2);
+        assert_eq!(map.slot_of(0), 0);
+        assert!(!map.overflow_active);
+    }
+
+    #[test]
+    fn build_sets_overflow_past_capacity() {
+        let ids: Vec<u16> = (1..=(ZONE_COUNTER_ASSIGNABLE_SLOTS as u16 + 5)).collect();
+        let map = ZoneCounterSlotMap::build(&ids);
+        assert!(
+            map.overflow_active,
+            "exceeding {ZONE_COUNTER_ASSIGNABLE_SLOTS} assignable slots must set overflow_active"
+        );
+        // Exactly the capacity is assigned; the rest are slot 0.
+        let assigned = (1..=65535u16).filter(|&z| map.slot_of(z) != 0).count();
+        assert_eq!(assigned, ZONE_COUNTER_ASSIGNABLE_SLOTS);
+    }
+
+    #[test]
+    fn record_flush_snapshot_accumulates_both_directions() {
+        let store = ZoneCounterStore::default();
+        let map = ZoneCounterSlotMap::build(&[100, 200]);
+        // A packet from zone 100 to zone 200: +ingress on 100, +egress on 200.
+        record_zone_traffic(&map, 100, 200, 1500);
+        record_zone_traffic(&map, 100, 200, 500);
+        // A reply from zone 200 to zone 100.
+        record_zone_traffic(&map, 200, 100, 40);
+        flush_recorded_zone_counters(&store, &map);
+
+        let mut snap = store.snapshot();
+        snap.sort_unstable_by_key(|s| s.zone_id);
+        assert_eq!(snap.len(), 2);
+
+        let z100 = &snap[0];
+        assert_eq!(z100.zone_id, 100);
+        assert_eq!(z100.ingress_packets, 2);
+        assert_eq!(z100.ingress_bytes, 2000);
+        assert_eq!(z100.egress_packets, 1);
+        assert_eq!(z100.egress_bytes, 40);
+
+        let z200 = &snap[1];
+        assert_eq!(z200.zone_id, 200);
+        assert_eq!(z200.ingress_packets, 1);
+        assert_eq!(z200.ingress_bytes, 40);
+        assert_eq!(z200.egress_packets, 2);
+        assert_eq!(z200.egress_bytes, 2000);
+    }
+
+    #[test]
+    fn unassigned_and_zero_zones_are_uncounted() {
+        let store = ZoneCounterStore::default();
+        let map = ZoneCounterSlotMap::build(&[100]);
+        // Egress zone 999 is unconfigured (slot 0); ingress 0 is unzoned.
+        record_zone_traffic(&map, 0, 999, 1500);
+        // Ingress 100 counted; egress 999 uncounted.
+        record_zone_traffic(&map, 100, 999, 1500);
+        flush_recorded_zone_counters(&store, &map);
+        let snap = store.snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].zone_id, 100);
+        assert_eq!(snap[0].ingress_packets, 1);
+        assert_eq!(snap[0].egress_packets, 0);
+    }
+
+    #[test]
+    fn clear_resets_totals() {
+        let store = ZoneCounterStore::default();
+        let map = ZoneCounterSlotMap::build(&[100]);
+        record_zone_traffic(&map, 100, 100, 64);
+        flush_recorded_zone_counters(&store, &map);
+        assert_eq!(store.snapshot().len(), 1);
+        store.clear();
+        assert!(store.snapshot().is_empty());
+    }
+
+    #[test]
+    fn reconcile_drops_removed_zones() {
+        let store = ZoneCounterStore::default();
+        let map = ZoneCounterSlotMap::build(&[100, 200]);
+        record_zone_traffic(&map, 100, 200, 64);
+        flush_recorded_zone_counters(&store, &map);
+        assert_eq!(store.snapshot().len(), 2);
+        let keep: FxHashSet<u16> = [100u16].into_iter().collect();
+        store.reconcile(&keep);
+        let snap = store.snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].zone_id, 100);
+    }
+}

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -22,6 +22,28 @@ use super::snapshot::{ConfigSnapshot, FabricSnapshot, NeighborSnapshot, Userspac
 pub(crate) const CONFIG_SNAPSHOT_PROTOCOL_VERSION: i32 = 3;
 pub(crate) const INJECT_PACKET_TUPLE_PROTOCOL_VERSION: i32 = 1;
 
+/// #3651: one per-zone traffic-volume row inside the `ProcessStatus`-level
+/// `zone_traffic_counters` sparse block. `zone_id` is the stable name-hash
+/// zone id (`StableZoneID`, matching `ZoneSnapshot.id`); ingress totals count
+/// packets/bytes that entered the firewall through an interface in the zone,
+/// egress totals count packets/bytes that left through one. Totals are
+/// cumulative since helper start (or the last `clear_zone_counters` IPC). The
+/// Go mirror is `ZoneTrafficCounterStatus` with json tags
+/// `zone_id`/`ingress_packets`/`ingress_bytes`/`egress_packets`/`egress_bytes`.
+#[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub(crate) struct ZoneTrafficCounterStatus {
+    #[serde(rename = "zone_id", default)]
+    pub zone_id: u16,
+    #[serde(rename = "ingress_packets", default)]
+    pub ingress_packets: u64,
+    #[serde(rename = "ingress_bytes", default)]
+    pub ingress_bytes: u64,
+    #[serde(rename = "egress_packets", default)]
+    pub egress_packets: u64,
+    #[serde(rename = "egress_bytes", default)]
+    pub egress_bytes: u64,
+}
+
 /// Maximum accepted size, in bytes, of a single newline-delimited
 /// control-socket request body before it is decoded (#2523).
 ///
@@ -492,6 +514,32 @@ pub(crate) struct ProcessStatus {
     pub nat_rule_counters: Vec<NatRuleCounterStatus>,
     #[serde(rename = "filter_term_counters", default)]
     pub filter_term_counters: Vec<FirewallFilterTermCounterStatus>,
+    /// #3651: per-zone ingress/egress traffic (packet + byte) volume, summed
+    /// across every worker/binding by the helper (`ProcessStatus`-level
+    /// pre-summed sparse block — one row per zone with nonzero traffic, keyed
+    /// by the stable zone id). The Go control plane mirrors each row into the
+    /// legacy `dataplane.Manager` zone-counter offset map via
+    /// `SetZoneCounterOffset`, so `show security zones` (Traffic statistics),
+    /// the REST `/security/zones` endpoint, and the Prometheus collector report
+    /// live per-zone volume instead of `ErrCounterNotPopulated` ("not
+    /// available"). `zone_counter_layout_version` selects the decode path
+    /// (0/absent = pre-#3651 helper, no per-zone data); a nonzero
+    /// `zone_counter_overflow_active` means the configured zone count exceeded
+    /// the helper's dense hot-path slot capacity and some zones went uncounted.
+    #[serde(
+        rename = "zone_counter_layout_version",
+        default,
+        skip_serializing_if = "crate::protocol::u32_is_zero"
+    )]
+    pub zone_counter_layout_version: u32,
+    #[serde(
+        rename = "zone_counter_overflow_active",
+        default,
+        skip_serializing_if = "crate::protocol::bool_is_false"
+    )]
+    pub zone_counter_overflow_active: bool,
+    #[serde(rename = "zone_traffic_counters", default)]
+    pub zone_traffic_counters: Vec<ZoneTrafficCounterStatus>,
     #[serde(rename = "three_color_policer_counters", default)]
     pub three_color_policer_counters: Vec<ThreeColorPolicerStatus>,
     #[serde(rename = "source_nat_pools", default)]

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -1551,6 +1551,64 @@ fn app_catalog_entry_roundtrip() {
 // control-plane consumption gate.
 // ---------------------------------------------------------------------------
 
+// #3651: the per-zone traffic block round-trips both directions and a
+// default (no per-zone data) ProcessStatus omits the layout-version /
+// overflow keys. The Go mirror lives in
+// pkg/dataplane/userspace/zone_counters_status_test.go.
+#[test]
+fn zone_traffic_counters_wire_roundtrip_and_default_omits() {
+    // Default helper: no zone data -> version/overflow omitted from the wire.
+    let default_status = ProcessStatus::default();
+    let body = serde_json::to_string(&default_status).expect("serialize default ProcessStatus");
+    assert!(
+        !body.contains("zone_counter_layout_version"),
+        "default ProcessStatus must omit zone_counter_layout_version: {body}"
+    );
+    assert!(
+        !body.contains("zone_counter_overflow_active"),
+        "default ProcessStatus must omit zone_counter_overflow_active: {body}"
+    );
+
+    // Populated block round-trips (Rust encode -> JSON -> Rust decode).
+    let mut status = ProcessStatus::default();
+    status.zone_counter_layout_version = 1;
+    status.zone_counter_overflow_active = true;
+    status.zone_traffic_counters = vec![ZoneTrafficCounterStatus {
+        zone_id: 40000,
+        ingress_packets: 10,
+        ingress_bytes: 1500,
+        egress_packets: 4,
+        egress_bytes: 600,
+    }];
+    let json = serde_json::to_string(&status).expect("serialize populated ProcessStatus");
+    let back: ProcessStatus = serde_json::from_str(&json).expect("deserialize ProcessStatus");
+    assert_eq!(back.zone_counter_layout_version, 1);
+    assert!(back.zone_counter_overflow_active);
+    assert_eq!(back.zone_traffic_counters.len(), 1);
+    let z = &back.zone_traffic_counters[0];
+    assert_eq!(z.zone_id, 40000);
+    assert_eq!(z.ingress_packets, 10);
+    assert_eq!(z.ingress_bytes, 1500);
+    assert_eq!(z.egress_packets, 4);
+    assert_eq!(z.egress_bytes, 600);
+
+    // A Go-style payload (zone fields injected into an otherwise-default
+    // ProcessStatus so every required field is present) decodes into the zone
+    // struct — mirrors the Go encode side / a mixed-version helper.
+    let mut v = serde_json::to_value(ProcessStatus::default()).expect("default to value");
+    v["zone_counter_layout_version"] = serde_json::json!(1);
+    v["zone_traffic_counters"] = serde_json::json!([
+        {"zone_id": 7, "ingress_packets": 2, "ingress_bytes": 200,
+         "egress_packets": 1, "egress_bytes": 100}
+    ]);
+    let decoded: ProcessStatus =
+        serde_json::from_value(v).expect("decode Go-style zone payload");
+    assert_eq!(decoded.zone_counter_layout_version, 1);
+    assert_eq!(decoded.zone_traffic_counters.len(), 1);
+    assert_eq!(decoded.zone_traffic_counters[0].zone_id, 7);
+    assert_eq!(decoded.zone_traffic_counters[0].egress_bytes, 100);
+}
+
 #[test]
 fn wire_invariant_default_specimens() {
     use serde_json::{Map, Value};
@@ -1633,6 +1691,7 @@ fn wire_invariant_default_specimens() {
     s.insert("userspace_capabilities".into(), dump(&UserspaceCapabilities::default()));
     s.insert("worker_runtime_status".into(), dump(&WorkerRuntimeStatus::default()));
     s.insert("zone_snapshot".into(), dump(&ZoneSnapshot::default()));
+    s.insert("zone_traffic_counter_status".into(), dump(&ZoneTrafficCounterStatus::default()));
     let specimens = Value::Object(s);
 
     let actual = serde_json::to_string_pretty(&specimens)

--- a/userspace-dp/src/server/handlers/mod.rs
+++ b/userspace-dp/src/server/handlers/mod.rs
@@ -9,7 +9,7 @@
 //   - `match request.request_type.as_str()` dispatch into per-verb
 //     handlers (substantive verbs) or inline bodies (trivial arms:
 //     `ping`/`status`, `update_fabrics`, `clear_policy_counters`,
-//     `clear_nat_counters`, `shutdown`, catch-all)
+//     `clear_nat_counters`, `clear_zone_counters`, `shutdown`, catch-all)
 //   - Post-match `refresh_status` + status attach (gated by
 //     `!suppress_status`)
 //   - Post-lock `write_state` (when `persist_state` is set)
@@ -196,6 +196,17 @@ pub(crate) fn handle_stream(
             // this store the cleared total would snap back on the next poll.
             "clear_nat_counters" => {
                 guard.afxdp.clear_nat_counters();
+                refresh_status(&mut guard);
+                persist_state = true;
+            }
+            // #3651: reset the helper-side cumulative per-zone traffic totals.
+            // Load-bearing half of the operator `clear` (the Go side also
+            // drops its zone-counter offset map): the helper reports cumulative
+            // totals every poll and the Go side mirrors them ABSOLUTELY via
+            // SetZoneCounterOffset, so without this reset the cleared value
+            // would snap back on the next poll.
+            "clear_zone_counters" => {
+                guard.afxdp.clear_zone_counters();
                 refresh_status(&mut guard);
                 persist_state = true;
             }

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -283,6 +283,18 @@ pub(crate) fn refresh_status(state: &mut ServerState) {
     state.status.policy_rule_counters = state.afxdp.policy_rule_counters();
     state.status.nat_rule_counters = state.afxdp.nat_rule_counters();
     state.status.filter_term_counters = state.afxdp.filter_term_counters();
+    // #3651: publish the pre-summed per-zone traffic block. Stamp the layout
+    // version only when there is data (rows or overflow) so a helper with no
+    // configured/active zones keeps the wire omitted (cold-path convention).
+    state.status.zone_traffic_counters = state.afxdp.zone_traffic_counters();
+    state.status.zone_counter_overflow_active = state.afxdp.zone_counter_overflow_active();
+    state.status.zone_counter_layout_version = if state.status.zone_traffic_counters.is_empty()
+        && !state.status.zone_counter_overflow_active
+    {
+        0
+    } else {
+        state.afxdp.zone_counter_layout_version()
+    };
     state.status.three_color_policer_counters = state.afxdp.three_color_policer_counters();
     state.status.source_nat_pools = state.afxdp.source_nat_pool_statuses();
     let (flow_worker_map, flow_worker_map_truncated) = state.afxdp.flow_worker_map();

--- a/userspace-dp/src/server/lifecycle.rs
+++ b/userspace-dp/src/server/lifecycle.rs
@@ -275,6 +275,11 @@ pub(crate) fn run() -> Result<(), String> {
             policy_rule_counters: Vec::new(),
             nat_rule_counters: Vec::new(),
             filter_term_counters: Vec::new(),
+            // #3651: per-zone traffic block is empty until the first status
+            // refresh reads the helper's zone-counter store.
+            zone_counter_layout_version: 0,
+            zone_counter_overflow_active: false,
+            zone_traffic_counters: Vec::new(),
             three_color_policer_counters: Vec::new(),
             source_nat_pools: Vec::new(),
             last_resolution: None,

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -921,7 +921,8 @@
     "worker_command_queue_poison_recoveries": 0,
     "worker_heartbeats": [],
     "worker_runtime": [],
-    "workers": 0
+    "workers": 0,
+    "zone_traffic_counters": []
   },
   "queue_control_request": {
     "armed": false,
@@ -1227,5 +1228,12 @@
     "id": 0,
     "name": "",
     "tcp_rst": false
+  },
+  "zone_traffic_counter_status": {
+    "egress_bytes": 0,
+    "egress_packets": 0,
+    "ingress_bytes": 0,
+    "ingress_packets": 0,
+    "zone_id": 0
   }
 }


### PR DESCRIPTION
## Summary

Addresses **#3651** — per-zone **traffic** counters are now published by the
userspace dataplane; per-zone **flood** counters remain deferred per the §5A
recommended narrowing. This is the POPULATE half of #3643 (the HIDE half
shipped earlier).

Before this change, `dataplane.ReadZoneCounters` returned
`ErrCounterNotPopulated` ("not available") on every surface because nothing
sourced per-zone volume. Now `show security zones` Traffic statistics, REST
`/security/zones`, and the Prometheus collector report **live** per-zone
ingress/egress packet+byte volume. Design of record:
`docs/research/3643-dead-counters/plan.md` §5A.

## Rust (userspace-dp publish)

- New `userspace-dp/src/afxdp/zone_counters.rs`: a flat direct-index
  `[u8;65536]` zone-id → slot LUT (`ZoneCounterSlotMap`, 63 assignable slots +
  `overflow_active`) built at config apply. Hot path resolves the ingress zone
  (shim meta) and egress zone (resolved egress ifindex) with **two array
  reads** and accumulates into a **per-worker thread-local** dense coalescer —
  no per-packet hash, no per-packet atomic (same coalesce-then-fold technique
  as the policy/filter hit counters).
- Per-RX-batch `flush_recorded_zone_counters` folds the coalesced deltas into a
  coordinator-owned, **zone-id-keyed** `ZoneCounterStore` (rides
  `ForwardingState`, carried forward from `previous` across applies so totals
  survive commits). Zone-id keying removes the cold-path slot-reassignment
  zero-out entirely.
- Accounting at all forward chokepoints: fast path (`flow_cache_hit`), slow
  path (`poll_descriptor` forward-candidate), and tunnel/next-table
  (`record_forwarding_disposition` ForwardCandidate, Hot-path only).
- Helper pre-sums across workers into ONE `ProcessStatus`-level sparse block
  `zone_traffic_counters` (layout version 1, nonzero rows only). New
  `clear_zone_counters` control IPC resets the store.

## Go (decode + surfacing)

- `ProcessStatus` gains `ZoneCounterLayoutVersion` / `ZoneCounterOverflowActive`
  / `ZoneTrafficCounters` (JSON tags matched to Rust serde).
- `syncBPFCountersLocked` mirrors each row into the bpfShim offset map via
  `SetZoneCounterOffset` (absolute overwrite, reset-safe on helper restart).
- New `zonecounters.go`: `ClearZoneCounters` override (+ `ClearAllCounters`
  wiring + `LegacyDataPlaneAdapter` route) sends `clear_zone_counters` so an
  operator clear does not snap back on the next 1 s poll.

## Wire contract

Tag-matched both sides; `protocol_wire_v1.json` regenerated; cross-language
default-specimen + round-trip contract tests extended (Go
`zone_counters_status_test.go` + Rust `protocol/tests.rs`).

## Deferred

Per-zone **flood** counters (§5A recommended narrowing — the lower-value half;
lean on the #3343 aggregate per-reason drop counters). `SetFloodCounterOffset`
stays test-only; `ReadFloodCounters` keeps returning `ErrCounterNotPopulated`.
The issue stays open for that half.

## Validation

- **RED-on-revert**: `TestSyncBPFCountersPopulatesZoneCounters` reverts to
  `ErrCounterNotPopulated` if the Go decode loop is removed.
- Rust `zone_counters` unit tests: build / wide-stable-hash-id / overflow /
  record+flush+snapshot / clear / reconcile.
- **FULL cargo test 3842/0**; `go test ./pkg/dataplane/... ./pkg/api/...
  ./pkg/grpcapi/...` green.
- Docs: flipped the #3651 gap doc from deferred → shipped (traffic) and
  recorded the flood deferral.

Not smoke-tested on the loss cluster in this run (no cluster access); the
hot-path increment is counter-only (cannot alter forwarding), and the wire
contract is pinned by the regenerated fixture + both-sides round-trip tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi