### PR TITLE
ps-040 LOW residuals: config validators, ENOENT tolerance, secret-safe logging, applySem race, IPv6 NAT metric, node-ID validation, monitor stdin poll

### DIFF
--- a/cmd/cli/monitor.go
+++ b/cmd/cli/monitor.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"sync"
 
 	"golang.org/x/sys/unix"
 
@@ -28,9 +29,17 @@ type remoteMonitorFrame struct {
 	err   error
 }
 
-// TODO: setMonitorRawMode, restoreMonitorTermMode, and monitorInputIsTTY
-// duplicate helpers in pkg/cli/monitor_interface.go. Extract to a shared
-// package (e.g. pkg/termutil) when the remote CLI gains more terminal ops.
+// TODO: setMonitorRawMode, restoreMonitorTermMode, monitorInputIsTTY,
+// keyReader, and startKeyReader duplicate helpers in
+// pkg/cli/monitor_interface.go. Extract to a shared package (e.g. pkg/termutil)
+// when the remote CLI gains more terminal ops.
+//
+// VMIN=0/VTIME=1 selects a poll-with-timeout read (#3985, #4694): os.Stdin.Read
+// returns immediately when a key is available and otherwise returns (0, nil)
+// after ~100ms with no data. This lets the key-reader goroutine observe its
+// stop signal between reads and return, instead of staying parked forever in a
+// blocking Read after the monitor exits (VMIN=1/VTIME=0 would block
+// indefinitely and steal the operator's next keystroke).
 func setMonitorRawMode(fd int) (*unix.Termios, error) {
 	old, err := unix.IoctlGetTermios(fd, unix.TCGETS)
 	if err != nil {
@@ -38,8 +47,8 @@ func setMonitorRawMode(fd int) (*unix.Termios, error) {
 	}
 	raw := *old
 	raw.Lflag &^= unix.ECHO | unix.ICANON | unix.ISIG
-	raw.Cc[unix.VMIN] = 1
-	raw.Cc[unix.VTIME] = 0
+	raw.Cc[unix.VMIN] = 0
+	raw.Cc[unix.VTIME] = 1
 	if err := unix.IoctlSetTermios(fd, unix.TCSETS, &raw); err != nil {
 		return nil, err
 	}
@@ -48,6 +57,62 @@ func setMonitorRawMode(fd int) (*unix.Termios, error) {
 
 func restoreMonitorTermMode(fd int, old *unix.Termios) {
 	_ = unix.IoctlSetTermios(fd, unix.TCSETS, old)
+}
+
+// keyReader reads single bytes from r and forwards them on keyCh until done is
+// closed, then returns. r must be a poll-mode reader (a raw tty configured with
+// VMIN=0/VTIME>0 via setMonitorRawMode) so Read returns periodically with n==0
+// when idle, letting the loop observe done and return. Without this the
+// goroutine would remain blocked in Read after the monitor exits and consume
+// the operator's next keystroke (#3985 / #4694). A byte read after done is
+// closed is discarded rather than forwarded, so no stale monitor input reaches
+// a caller.
+func keyReader(r io.Reader, keyCh chan<- byte, done <-chan struct{}) {
+	buf := make([]byte, 1)
+	for {
+		select {
+		case <-done:
+			return
+		default:
+		}
+		n, err := r.Read(buf)
+		if err != nil {
+			return
+		}
+		if n == 0 {
+			// VTIME poll timeout with no data — loop and re-check done.
+			continue
+		}
+		select {
+		case keyCh <- buf[0]:
+		case <-done:
+			return
+		}
+	}
+}
+
+// startKeyReader launches a keyReader goroutine reading from r and returns the
+// key channel plus a stop function. The stop function closes the done channel
+// and blocks until the goroutine has returned, guaranteeing no reader is left
+// competing for stdin once the monitor exits (#3985 / #4694). Callers defer
+// stop so it runs before the terminal is restored and control returns to the
+// CLI.
+func startKeyReader(r io.Reader) (<-chan byte, func()) {
+	keyCh := make(chan byte, 8)
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		keyReader(r, keyCh, done)
+	}()
+	var once sync.Once
+	return keyCh, func() {
+		once.Do(func() {
+			close(done)
+			wg.Wait()
+		})
+	}
 }
 
 func monitorInputIsTTY(fd int) bool {
@@ -125,23 +190,13 @@ func (c *ctl) handleInteractiveMonitorInterfaceSummary(req *pb.MonitorInterfaceR
 	fmt.Print(monitorEnterAltScreen + monitorHideCursor)
 	defer fmt.Print(monitorShowCursor + monitorExitAltScreen)
 
-	keyCh := make(chan byte, 8)
-	doneCh := make(chan struct{})
-	defer close(doneCh)
-	go func() {
-		buf := make([]byte, 1)
-		for {
-			n, err := os.Stdin.Read(buf)
-			if err != nil || n == 0 {
-				return
-			}
-			select {
-			case keyCh <- buf[0]:
-			case <-doneCh:
-				return
-			}
-		}
-	}()
+	// Stop the stdin reader before restoring the terminal so no goroutine is
+	// left parked in os.Stdin.Read stealing the next command's key (#3985 /
+	// #4694). The old inline goroutine used a blocking VMIN=1/VTIME=0 read and
+	// returned on the first n==0, so it either blocked forever after the
+	// monitor exited or, under a poll reader, died on the first idle poll.
+	keyCh, stopKeys := startKeyReader(os.Stdin)
+	defer stopKeys()
 
 	frameCh := make(chan remoteMonitorFrame, 16)
 	ctx, cancel := context.WithCancel(c.ctx())

--- a/cmd/cli/monitor_keyreader_4694_test.go
+++ b/cmd/cli/monitor_keyreader_4694_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"io"
+	"testing"
+	"time"
+)
+
+// fakeTTY models a raw terminal opened with VMIN=0/VTIME>0 (as setMonitorRawMode
+// now configures): Read returns a queued byte immediately, and otherwise
+// returns (0, nil) after a short idle timeout — the poll-with-timeout behavior
+// the #3985 / #4694 fix relies on to let the key-reader goroutine observe its
+// stop signal.
+type fakeTTY struct {
+	ch   chan byte
+	idle time.Duration
+}
+
+func (f *fakeTTY) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	select {
+	case b, ok := <-f.ch:
+		if !ok {
+			return 0, io.EOF
+		}
+		p[0] = b
+		return 1, nil
+	case <-time.After(f.idle):
+		// VTIME poll timeout with no data available.
+		return 0, nil
+	}
+}
+
+// TestMonitorKeyReaderLifecycle exercises the ported remote-CLI monitor stdin
+// key-reader (#4694): it forwards keys while running, stays alive across idle
+// polls, and returns promptly once its done channel is closed.
+//
+// RED-on-revert: the pre-#4694 inline goroutine was
+//
+//	for {
+//	    n, err := os.Stdin.Read(buf)
+//	    if err != nil || n == 0 { return }
+//	    keyCh <- buf[0]
+//	}
+//
+// which has no done handling and returns on the first n==0 poll. Against this
+// VMIN=0/VTIME reader it exits within one idle interval, so the "still alive
+// while running" assertion below fails. With the old VMIN=1/VTIME=0 termios the
+// same loop instead blocked forever in Read after the monitor exited, parking
+// the goroutine so it stole the operator's next keystroke.
+func TestMonitorKeyReaderLifecycle(t *testing.T) {
+	tty := &fakeTTY{ch: make(chan byte, 8), idle: 2 * time.Millisecond}
+	keyCh := make(chan byte, 8)
+	done := make(chan struct{})
+	exited := make(chan struct{})
+	go func() {
+		keyReader(tty, keyCh, done)
+		close(exited)
+	}()
+
+	tty.ch <- 'q'
+	select {
+	case k := <-keyCh:
+		if k != 'q' {
+			t.Fatalf("forwarded key = %q, want 'q'", k)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("key 'q' was not forwarded to the monitor")
+	}
+
+	// While done is open the reader must keep polling, not exit on an idle poll.
+	select {
+	case <-exited:
+		t.Fatal("keyReader returned while running (early-exit / leak regression — #4694)")
+	case <-time.After(100 * time.Millisecond):
+		// Still alive after many idle polls — correct.
+	}
+
+	// Closing done must make the goroutine return promptly.
+	close(done)
+	select {
+	case <-exited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("keyReader did not return after done closed — leaked stdin reader (#4694)")
+	}
+}
+
+// TestMonitorKeyReaderDiscardsKeyAfterDone verifies a byte read concurrently
+// with the stop signal is discarded, not forwarded, once done is closed.
+func TestMonitorKeyReaderDiscardsKeyAfterDone(t *testing.T) {
+	tty := &fakeTTY{ch: make(chan byte, 8), idle: time.Hour} // never idles out
+	keyCh := make(chan byte)                                 // unbuffered: forwarding needs a live receiver
+	done := make(chan struct{})
+	exited := make(chan struct{})
+	go func() {
+		keyReader(tty, keyCh, done)
+		close(exited)
+	}()
+
+	close(done)   // stop before any key is available
+	tty.ch <- 'x' // key arrives after done closed
+
+	select {
+	case k := <-keyCh:
+		t.Fatalf("key %q forwarded after done closed (leaked-reader keystroke theft — #4694)", k)
+	case <-exited:
+		// Reader returned without forwarding the post-done key — correct.
+	case <-time.After(2 * time.Second):
+		t.Fatal("keyReader did not return after done closed (#4694)")
+	}
+}
+
+// TestMonitorStartKeyReaderStopDrains verifies the stop function blocks until
+// the reader goroutine has returned and is safe to call more than once.
+func TestMonitorStartKeyReaderStopDrains(t *testing.T) {
+	tty := &fakeTTY{ch: make(chan byte, 8), idle: 2 * time.Millisecond}
+	keyCh, stop := startKeyReader(tty)
+
+	tty.ch <- 'q'
+	select {
+	case k := <-keyCh:
+		if k != 'q' {
+			t.Fatalf("forwarded key = %q, want 'q'", k)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("key not forwarded via startKeyReader")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		stop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stop() did not return — reader goroutine not draining (#4694)")
+	}
+
+	// Idempotent: a second stop must not panic on a re-closed channel.
+	stop()
+}

--- a/pkg/api/metrics_nat.go
+++ b/pkg/api/metrics_nat.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
 )
 
@@ -40,15 +41,50 @@ func (c *xpfCollector) collectNATPoolMetrics(ch chan<- prometheus.Metric, dp api
 		}
 
 		if pool.Deterministic != nil {
-			hostCount := 0
-			if _, n, err := net.ParseCIDR(pool.Deterministic.HostAddress); err == nil {
-				ones, bits := n.Mask.Size()
-				hostCount = 1 << uint(bits-ones)
-			}
 			ch <- prometheus.MustNewConstMetric(c.natPoolDeterministicInfo, prometheus.GaugeValue,
 				1.0, name,
 				strconv.Itoa(pool.Deterministic.BlockSize),
-				strconv.Itoa(hostCount))
+				strconv.Itoa(deterministicSubscriberCapacity(pool)))
 		}
 	}
+}
+
+// deterministicSubscriberCapacity returns the value reported in the
+// natPoolDeterministicInfo `host_count` label for a deterministic CGNAT pool.
+//
+// For an IPv4 subscriber CIDR the capacity is the number of host addresses,
+// 1<<(32-ones). For IPv6 (bits==128) that shift is >=64, which is 0 in Go
+// (#4692) — so, mirroring the compiler_nat.go deterministic-capacity gate
+// (which caps the IPv6 subscriber count by pool capacity rather than by the
+// host CIDR), report the pool's block/subscriber capacity: blocksPerIP =
+// portRange/blockSize, totalBlocks = len(addresses)*blocksPerIP. Returns 0
+// when the host CIDR is unparseable or the block size is non-positive.
+func deterministicSubscriberCapacity(pool *config.NATPool) int {
+	if pool == nil || pool.Deterministic == nil {
+		return 0
+	}
+	_, n, err := net.ParseCIDR(pool.Deterministic.HostAddress)
+	if err != nil {
+		return 0
+	}
+	ones, bits := n.Mask.Size()
+	if bits != 128 {
+		// IPv4 subscriber CIDR — host-address count.
+		return 1 << uint(bits-ones)
+	}
+	// IPv6 — 1<<(128-ones) overflows Go's shift width. Report pool capacity.
+	bs := pool.Deterministic.BlockSize
+	if bs <= 0 {
+		return 0
+	}
+	portLow := pool.PortLow
+	if portLow == 0 {
+		portLow = 1024
+	}
+	portHigh := pool.PortHigh
+	if portHigh == 0 {
+		portHigh = 65535
+	}
+	blocksPerIP := (portHigh - portLow + 1) / bs
+	return len(pool.Addresses) * blocksPerIP
 }

--- a/pkg/api/metrics_nat_det_ipv6_4692_test.go
+++ b/pkg/api/metrics_nat_det_ipv6_4692_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #4692: the natPoolDeterministicInfo host_count label for an IPv6 subscriber
+// CIDR computed 1<<(128-ones), a shift >=64 that yields 0 in Go — so an IPv6
+// deterministic pool reported a subscriber capacity of 0. Mirror the
+// compiler_nat.go deterministic-capacity gate and report the pool's
+// block/subscriber capacity (totalBlocks) instead.
+//
+// RED-on-revert: restoring the unconditional `1 << uint(bits-ones)` makes the
+// IPv6 case return 0 and the >0 assertion below fires RED.
+func TestDeterministicSubscriberCapacity_IPv6ReportsPoolCapacity(t *testing.T) {
+	// IPv6 /64 subscriber CIDR: 1<<(128-64) is a >=64-bit shift (0 in Go).
+	// PortLow/PortHigh default to 1024..65535 (64512 ports); blockSize 2016 =>
+	// 32 blocks per address; 2 addresses => 64 total blocks.
+	pool := &config.NATPool{
+		Addresses: []string{"203.0.113.1", "203.0.113.2"},
+		Deterministic: &config.DeterministicNATConfig{
+			BlockSize:   2016,
+			HostAddress: "2001:db8::/64",
+		},
+	}
+	got := deterministicSubscriberCapacity(pool)
+	if got == 0 {
+		t.Fatal("IPv6 deterministic pool reported 0 capacity (1<<(128-ones) shift overflow) — #4692")
+	}
+	wantBlocks := 2 * ((65535 - 1024 + 1) / 2016) // 2 * 32 = 64
+	if got != wantBlocks {
+		t.Fatalf("IPv6 capacity = %d, want totalBlocks %d", got, wantBlocks)
+	}
+}
+
+// IPv4 must keep reporting the host-address count so the fix does not regress
+// the pre-existing behavior.
+func TestDeterministicSubscriberCapacity_IPv4HostCount(t *testing.T) {
+	pool := &config.NATPool{
+		Addresses: []string{"203.0.113.1"},
+		Deterministic: &config.DeterministicNATConfig{
+			BlockSize:   64,
+			HostAddress: "100.64.0.0/24", // /24 => 256 subscriber addresses
+		},
+	}
+	if got := deterministicSubscriberCapacity(pool); got != 256 {
+		t.Fatalf("IPv4 capacity = %d, want 256 (1<<(32-24))", got)
+	}
+}
+
+// An unparseable / non-positive-block pool must not panic and reports 0.
+func TestDeterministicSubscriberCapacity_Degenerate(t *testing.T) {
+	if got := deterministicSubscriberCapacity(&config.NATPool{
+		Deterministic: &config.DeterministicNATConfig{HostAddress: "not-a-cidr"},
+	}); got != 0 {
+		t.Fatalf("unparseable host CIDR must report 0, got %d", got)
+	}
+	if got := deterministicSubscriberCapacity(&config.NATPool{
+		Addresses:     []string{"203.0.113.1"},
+		Deterministic: &config.DeterministicNATConfig{BlockSize: 0, HostAddress: "2001:db8::/64"},
+	}); got != 0 {
+		t.Fatalf("non-positive block size must report 0, got %d", got)
+	}
+}

--- a/pkg/config/schema_policy_then_int_4688_test.go
+++ b/pkg/config/schema_policy_then_int_4688_test.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4688: the policy-statement `then local-preference | metric | metric-type`
+// leaves are typed integers gated at the Go commit boundary. Before the fix
+// they had no validator, so:
+//
+//   - `then local-preference abc` committed silently — the compiler's
+//     strconv.Atoi failed under an err==nil gate with no else, HasLocalPreference
+//     stayed false, and the FRR clause was never emitted (fail-open, no warning).
+//   - `then local-preference 42949672960` parsed as int64 in the compiler,
+//     rendered, then FRR (u32) rejected it at frr-reload and aborted the WHOLE
+//     reload (fable-167 R-1 class).
+//
+// FAIL-ON-REVERT: dropping the `valueType: ValueInteger, validator:
+// ValidateInteger(...)` on these three leaves makes the untyped leaves accept
+// any token again, so the reject assertions below fire RED.
+func TestPolicyStatementThenInteger_SchemaGate(t *testing.T) {
+	set := func(leaf, val string) string {
+		return "set policy-options policy-statement p1 term t1 then " + leaf + " " + val
+	}
+	reject := func(leaf, val string) {
+		t.Helper()
+		tree := flatTreeFromSets(t, set(leaf, val))
+		if err := SchemaValidate(tree, nil); err == nil {
+			t.Fatalf("then %s %q: expected SchemaValidate to reject, got nil", leaf, val)
+		}
+	}
+	accept := func(leaf, val string) {
+		t.Helper()
+		tree := flatTreeFromSets(t, set(leaf, val))
+		if err := SchemaValidate(tree, nil); err != nil {
+			t.Fatalf("then %s %q: expected SchemaValidate to accept, got %v", leaf, val, err)
+		}
+	}
+
+	// Non-numeric and u32-overflow reject on local-preference / metric.
+	for _, leaf := range []string{"local-preference", "metric"} {
+		reject(leaf, "abc")
+		reject(leaf, "-1")
+		reject(leaf, "4294967296") // maxWireU32 + 1 (FRR-reload-abort class)
+		accept(leaf, "0")
+		accept(leaf, "42")
+		accept(leaf, "4294967295") // maxWireU32
+	}
+
+	// metric-type is the OSPF external route type: only 1 or 2.
+	reject("metric-type", "abc")
+	reject("metric-type", "0")
+	reject("metric-type", "3")
+	accept("metric-type", "1")
+	accept("metric-type", "2")
+}
+
+// #4688: the reject error names the offending value so the operator sees which
+// value was out of range instead of a silent drop / opaque FRR-reload abort.
+func TestPolicyStatementThenLocalPreference_ErrorMentionsValue(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set policy-options policy-statement p1 term t1 then local-preference 42949672960")
+	err := SchemaValidate(tree, nil)
+	if err == nil {
+		t.Fatal("expected an out-of-range local-preference to be rejected at commit")
+	}
+	if !strings.Contains(err.Error(), "42949672960") {
+		t.Fatalf("error %q must name the out-of-range value 42949672960", err.Error())
+	}
+}

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -195,13 +195,31 @@ var schemaPolicyOptions = &schemaNode{desc: "Policy options", children: map[stri
 				"as-path":      {desc: "AS path", args: 1, multi: true, placeholder: "<name>", children: nil},
 			}},
 			"then": {desc: "Action", children: map[string]*schemaNode{
-				"accept":           {desc: "Accept route", children: nil},
-				"reject":           {desc: "Reject route", children: nil},
-				"next-hop":         {desc: "Next hop", args: 1, placeholder: "<address>", children: nil},
-				"load-balance":     {desc: "Load balance", args: 1, placeholder: "<policy>", children: nil},
-				"local-preference": {desc: "Local preference", args: 1, placeholder: "<value>", children: nil},
-				"metric":           {desc: "Metric", args: 1, placeholder: "<value>", children: nil},
-				"metric-type":      {desc: "Metric type", args: 1, placeholder: "<type>", children: nil},
+				"accept":       {desc: "Accept route", children: nil},
+				"reject":       {desc: "Reject route", children: nil},
+				"next-hop":     {desc: "Next hop", args: 1, placeholder: "<address>", children: nil},
+				"load-balance": {desc: "Load balance", args: 1, placeholder: "<policy>", children: nil},
+				// #4688: type these three `then` leaves. Without a validator a
+				// non-numeric value (`then local-preference abc`) committed
+				// silently — the compiler's strconv.Atoi failed under an
+				// err==nil gate with no else, so HasLocalPreference stayed false
+				// and the FRR clause was never emitted (fail-open, no warning).
+				// A uint32-overflow value (`then local-preference 42949672960`)
+				// parsed as int64 in the compiler, rendered, then FRR (u32)
+				// rejected it at frr-reload and aborted the WHOLE reload
+				// (fable-167 R-1 class). ValidateInteger(0, maxWireU32) gates
+				// local-preference/metric at commit — naming the leaf — so a
+				// bad value never reaches FRR. metric-type is the OSPF external
+				// route type, valid values 1 or 2.
+				"local-preference": {desc: "Local preference", args: 1, placeholder: "<value>",
+					valueType: ValueInteger, valueDesc: "Local preference (0..4294967295)",
+					valueExamples: []string{"100", "200"}, validator: ValidateInteger(0, maxWireU32), children: nil},
+				"metric": {desc: "Metric", args: 1, placeholder: "<value>",
+					valueType: ValueInteger, valueDesc: "Metric (0..4294967295)",
+					valueExamples: []string{"5", "100"}, validator: ValidateInteger(0, maxWireU32), children: nil},
+				"metric-type": {desc: "Metric type", args: 1, placeholder: "<type>",
+					valueType: ValueInteger, valueDesc: "OSPF external metric type (1 or 2)",
+					valueExamples: []string{"1", "2"}, validator: ValidateInteger(1, 2), children: nil},
 				// `then community` supports the Junos community operations
 				// (add | delete | set | none) plus the legacy bare
 				// `then community <value>` (= replace). multi:true packs the

--- a/pkg/configstore/archive_rotate_enoent_4689_test.go
+++ b/pkg/configstore/archive_rotate_enoent_4689_test.go
@@ -1,0 +1,76 @@
+package configstore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// #4689: archive rotation must tolerate a benign ENOENT. rotateArchives is
+// spawned per commit and picks the oldest archive after an un-locked ReadDir,
+// so two rapid back-to-back commits can race to remove the same file — the
+// loser's os.Remove fails with ENOENT, which is an already-gone, not a real
+// cleanup failure.
+//
+// RED-on-revert: dropping the `&& !os.IsNotExist(err)` guard in
+// archiveRemoveErr (i.e. `return os.Remove(path)`) makes the missing-file case
+// return a non-nil error and this test goes RED.
+func TestArchiveRemoveErr_ENOENTTolerant(t *testing.T) {
+	dir := t.TempDir()
+
+	// Missing file — the concurrent-rotation race outcome — is benign.
+	if err := archiveRemoveErr(filepath.Join(dir, "config-gone.conf")); err != nil {
+		t.Fatalf("missing archive must be tolerated (benign ENOENT), got %v", err)
+	}
+
+	// A present archive is removed and reports no error.
+	p := filepath.Join(dir, "config-1.conf")
+	if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed archive: %v", err)
+	}
+	if err := archiveRemoveErr(p); err != nil {
+		t.Fatalf("removing a present archive must succeed, got %v", err)
+	}
+	if _, err := os.Stat(p); !os.IsNotExist(err) {
+		t.Fatalf("archive %s must be gone after removal (stat err=%v)", p, err)
+	}
+}
+
+// TestRotateArchivesConcurrentNoError exercises the real rotateArchives under a
+// back-to-back concurrent rotation over a shared directory: the loser of a
+// remove race must not error out. With the ENOENT guard in place all extra
+// archives end up removed regardless of how the two rotations interleave.
+func TestRotateArchivesConcurrentNoError(t *testing.T) {
+	dir := t.TempDir()
+	const total = 40
+	for i := 0; i < total; i++ {
+		p := filepath.Join(dir, "config-"+string(rune('a'+i/10))+string(rune('0'+i%10))+".conf")
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatalf("seed archive %d: %v", i, err)
+		}
+	}
+
+	done := make(chan struct{}, 2)
+	for g := 0; g < 2; g++ {
+		go func() {
+			rotateArchives(dir, 1)
+			done <- struct{}{}
+		}()
+	}
+	<-done
+	<-done
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	kept := 0
+	for _, e := range entries {
+		if !e.IsDir() {
+			kept++
+		}
+	}
+	if kept != 1 {
+		t.Fatalf("rotation must keep exactly maxArchives=1 file, kept %d", kept)
+	}
+}

--- a/pkg/configstore/rollback_corrupt_log_4690_test.go
+++ b/pkg/configstore/rollback_corrupt_log_4690_test.go
@@ -1,0 +1,76 @@
+package configstore
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #4690: a corrupt rollback file must be logged by POSITION ONLY (line/column),
+// never by forwarding the config.ParseError / its text. A rollback file is the
+// full active config TEXT with cleartext secret leaves (IKE PSK, auth keys,
+// SNMP community), and config.ParseError.Error() embeds ParseError.Message,
+// which the lexer/parser can populate with offending token/character content.
+// Routing errs[0] into the log therefore risks echoing file content — the same
+// invariant the #4099 rescue path enforces.
+//
+// RED-on-revert: restoring `slog.Warn("skipping corrupt rollback file",
+// "path", path, "err", errs[0])` makes the log carry the ParseError's Error()
+// text (its Message), so the "message text absent" assertion below fires RED.
+func TestLoadRollbackHistoryCorruptFileLogsPositionOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/config"
+	s := newTestStoreAt(t, path)
+
+	// A realistic corrupt rollback file: valid config carrying a secret PSK,
+	// then a stray '|' token that the parser rejects. The PSK value is
+	// consumed as a leaf value (never echoed by the parser), and the parse
+	// error message is a generic "unexpected '|'" — but the OLD code forwarded
+	// that whole ParseError text into the log; the fix logs only line/column.
+	const secret = "SUPERSECRETPSK987"
+	corrupt := "security {\n" +
+		"    ike {\n" +
+		"        pre-shared-key ascii-text \"" + secret + "\";\n" +
+		"    }\n" +
+		"}\n" +
+		"| stray-token\n"
+	if err := os.WriteFile(s.rollbackPath(1), []byte(corrupt), 0o600); err != nil {
+		t.Fatalf("seed corrupt rollback file: %v", err)
+	}
+
+	// Compute the ParseError this text produces so the assertion targets the
+	// exact Message that the old code would have leaked into the log.
+	_, perrs := config.NewParser(corrupt).Parse()
+	if len(perrs) == 0 {
+		t.Fatal("test setup: corrupt config must fail to parse")
+	}
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+
+	s.loadRollbackHistory()
+
+	logged := buf.String()
+	if !strings.Contains(logged, "skipping corrupt rollback file") {
+		t.Fatalf("expected a corrupt-rollback warning, got:\n%s", logged)
+	}
+	// The parse-error MESSAGE must NOT appear (this is the RED-on-revert gate):
+	// forwarding errs[0] renders its Error() text ("... unexpected '|'").
+	if strings.Contains(logged, perrs[0].Message) {
+		t.Fatalf("corrupt-rollback log leaked the ParseError message %q:\n%s", perrs[0].Message, logged)
+	}
+	// Defense-in-depth: the secret must never appear either.
+	if strings.Contains(logged, secret) {
+		t.Fatalf("corrupt-rollback log leaked secret file content:\n%s", logged)
+	}
+	// Position must still be logged so operators can locate the corruption.
+	if !strings.Contains(logged, "line=") || !strings.Contains(logged, "column=") {
+		t.Fatalf("corrupt-rollback log must carry line/column position, got:\n%s", logged)
+	}
+}

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -802,7 +802,14 @@ func (s *Store) loadRollbackHistory() {
 		parser := config.NewParser(string(data))
 		tree, errs := parser.Parse()
 		if len(errs) > 0 {
-			slog.Warn("skipping corrupt rollback file", "path", path, "err", errs[0])
+			// Log POSITION only (#4690, mirroring the #4099 rescue-path
+			// invariant): config.ParseError.Error() embeds ParseError.Message,
+			// which the lexer/parser can populate with the OFFENDING TOKEN
+			// VALUE (e.g. an unterminated `pre-shared-key "SECRET…`). Forwarding
+			// errs[0] / the ParseError text would echo secret file content into
+			// the log. Line/Column are ints and cannot hold a token.
+			slog.Warn("skipping corrupt rollback file",
+				"path", path, "line", errs[0].Line, "column", errs[0].Column)
 			continue
 		}
 		// Use file modification time as timestamp

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -481,13 +481,31 @@ func rotateArchives(dir string, maxArchives int) {
 	// Sort alphabetically (timestamps sort naturally)
 	sort.Strings(archives)
 
-	// Remove oldest
+	// Remove oldest.
 	for i := 0; i < len(archives)-maxArchives; i++ {
 		path := filepath.Join(dir, archives[i])
-		if err := os.Remove(path); err != nil {
+		if err := archiveRemoveErr(path); err != nil {
 			slog.Warn("failed to remove old archive", "path", path, "err", err)
 		}
 	}
+}
+
+// archiveRemoveErr removes a single rotated archive file and returns the error
+// that warrants a warning, or nil when the file was removed or was already
+// gone.
+//
+// ENOENT-tolerant (#4689, mirroring the #3441 L3 cleanupRollbackFiles
+// pattern): rotateArchives is spawned per commit and reads the archive
+// directory without a per-store archive lock, so two rapid back-to-back
+// commits can each pick the same oldest archive and race to remove it. The
+// loser's os.Remove then fails with ENOENT — a benign already-gone, not a real
+// cleanup failure — so it is suppressed. Any other error (e.g. EACCES) is
+// still returned so the caller logs it.
+func archiveRemoveErr(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 // rescuePath returns the path for the rescue configuration file.

--- a/pkg/daemon/host_tunables_daemon.go
+++ b/pkg/daemon/host_tunables_daemon.go
@@ -41,6 +41,7 @@
 package daemon
 
 import (
+	"context"
 	"log/slog"
 )
 
@@ -193,6 +194,26 @@ func (d *Daemon) applyStep0TunablesWith(userspaceDP, claimHostTunables bool,
 // Best-effort: never returns an error. Safe to call when no tunable
 // was ever captured (no-op).
 func (d *Daemon) restoreStep0TunablesOnShutdown() {
+	// Serialize against an un-drained apply (#4691). applyStep0TunablesWith
+	// mutates the shared priorTunables snapshot's maps (governors, budget,
+	// mlx5Adaptive, neighRetrans) OUTSIDE priorTunablesMu — the mutex only
+	// guards the pointer read/write, while applyCoalescence /
+	// applyHostTunables / applyNeighRetransTime write the maps after the
+	// mutex is dropped. A DHCP lease apply can still be in flight when
+	// shutdown fires; it runs under d.applySem (via applyConfig), so
+	// acquiring applySem here serializes this restore's snapshot handoff +
+	// map iteration against that apply, matching the lock the apply path
+	// already holds. Without it, restore's os.Remove/write of the map entries
+	// races the apply's concurrent writes to the same maps.
+	if d.applySem != nil {
+		if err := d.applySem.Acquire(context.Background(), 1); err != nil {
+			slog.Warn("shutdown: host tunables restore could not acquire apply lock, "+
+				"proceeding without it", "err", err)
+		} else {
+			defer d.applySem.Release(1)
+		}
+	}
+
 	d.priorTunablesMu.Lock()
 	prior := d.priorTunables
 	active := d.priorTunablesActive

--- a/pkg/daemon/host_tunables_restore_applysem_4691_test.go
+++ b/pkg/daemon/host_tunables_restore_applysem_4691_test.go
@@ -1,0 +1,61 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// #4691: restoreStep0TunablesOnShutdown must serialize against an un-drained
+// apply by acquiring d.applySem before touching the priorTunables snapshot.
+// applyStep0TunablesWith mutates the snapshot's maps outside priorTunablesMu
+// (under d.applySem, via applyConfig), so a DHCP lease apply still in flight at
+// shutdown would otherwise race the restore's snapshot handoff + map ops.
+//
+// Lock-held assertion: hold applySem (simulating an in-flight apply), then
+// launch restore. It must BLOCK until applySem is released, and complete
+// promptly afterwards.
+//
+// RED-on-revert: dropping the d.applySem.Acquire in
+// restoreStep0TunablesOnShutdown lets restore run to completion while the
+// semaphore is held, so the "blocked while held" assertion below fires RED.
+func TestRestoreStep0TunablesAcquiresApplySem(t *testing.T) {
+	d := &Daemon{applySem: semaphore.NewWeighted(1)}
+
+	// Simulate an in-flight apply holding the apply lock.
+	if err := d.applySem.Acquire(context.Background(), 1); err != nil {
+		t.Fatalf("pre-acquire applySem: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		d.restoreStep0TunablesOnShutdown()
+		close(done)
+	}()
+
+	// While the apply lock is held, restore must not finish.
+	select {
+	case <-done:
+		t.Fatal("restoreStep0TunablesOnShutdown completed while applySem was held — " +
+			"it did not serialize against the apply lock (#4691)")
+	case <-time.After(150 * time.Millisecond):
+		// Correctly blocked on applySem.
+	}
+
+	// Release the apply lock; restore must now proceed to completion.
+	d.applySem.Release(1)
+	select {
+	case <-done:
+		// Completed once the lock was free.
+	case <-time.After(2 * time.Second):
+		t.Fatal("restoreStep0TunablesOnShutdown did not complete after applySem released (#4691)")
+	}
+
+	// The lock must be free again afterwards (restore released it).
+	if !d.applySem.TryAcquire(1) {
+		t.Fatal("restoreStep0TunablesOnShutdown did not release applySem")
+	}
+	d.applySem.Release(1)
+}

--- a/pkg/grpcapi/server_diag_system_action.go
+++ b/pkg/grpcapi/server_diag_system_action.go
@@ -337,6 +337,15 @@ func (s *Server) SystemAction(ctx context.Context, req *pb.SystemActionRequest) 
 				if err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid node ID: %s", nodeStr)
 				}
+				// Reject an out-of-range node before the local/proxy routing
+				// decision (#4693, #4125 class). Without this a local caller's
+				// `cluster-failover:<rg>:node99` fell through to the outbound
+				// proxy-dial path (targetNode != NodeID), driving avoidable
+				// peer dials to a node ID that cannot exist. The sibling
+				// cluster-failover-data:node branch already validates this way.
+				if !cluster.IsSupportedClusterNodeID(targetNode) {
+					return nil, status.Errorf(codes.InvalidArgument, "unsupported cluster failover target node %d", targetNode)
+				}
 				if targetNode != s.cluster.NodeID() {
 					if peerForwardedFromContext(ctx) {
 						return nil, status.Errorf(codes.FailedPrecondition, "forwarded cluster failover target node %d is not local", targetNode)

--- a/pkg/grpcapi/system_action_failover_node_4693_test.go
+++ b/pkg/grpcapi/system_action_failover_node_4693_test.go
@@ -1,0 +1,38 @@
+package grpcapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// #4693: the cluster-failover:<rgID>:node<N> handler branch must validate the
+// node ID via cluster.IsSupportedClusterNodeID (the two-chassis 0/1 range)
+// before the local/proxy routing decision, mirroring the sibling
+// cluster-failover-data:node branch and the #4125 fabric-gate class. Without
+// it, a local caller's node99 request (node99 != local NodeID) fell through to
+// the outbound peer proxy-dial path instead of being rejected.
+//
+// RED-on-revert: removing the IsSupportedClusterNodeID check lets node99 reach
+// proxyPeerSystemAction, which (no peerSystemActionFn wired, no reachable peer)
+// returns a non-InvalidArgument error and this InvalidArgument assertion fires
+// RED.
+func TestSystemActionClusterFailoverRejectsUnsupportedTargetNode(t *testing.T) {
+	s := NewServer("", Config{Cluster: cluster.NewManager(0, 1)})
+
+	// Fail the test loudly if the request ever reaches the peer proxy path:
+	// a rejected node ID must never drive a proxy dial.
+	s.peerSystemActionFn = func(ctx context.Context, req *pb.SystemActionRequest) (*pb.SystemActionResponse, error) {
+		t.Fatalf("proxy dial attempted for unsupported node in action %q", req.Action)
+		return nil, nil
+	}
+
+	_, err := s.SystemAction(context.Background(), &pb.SystemActionRequest{Action: "cluster-failover:1:node99"})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("status code = %s, want %s (err=%v)", status.Code(err), codes.InvalidArgument, err)
+	}
+}


### PR DESCRIPTION
Drives the 7 ps-040 LOW residuals as one batch. Each is a separate commit with a RED-on-revert test. All Go/config; no dataplane (cargo) changes.

## Fixes

- **#4688** (config, LOW-MED): `pkg/config/schema_routing.go` — type the policy-statement `then local-preference | metric | metric-type` leaves. local-preference/metric take `ValidateInteger(0, maxWireU32)`, metric-type `ValidateInteger(1, 2)`. Non-numeric no longer silently drops (fail-open); a u32-overflow no longer reaches FRR and aborts the whole reload (fable-167 R-1 class).
- **#4689** (configstore, INFO): `store_persist.go` — archive rotation tolerates a benign ENOENT via a new `archiveRemoveErr` helper (mirrors #3441 L3). A rapid back-to-back commit rotation race no longer logs a spurious warning.
- **#4690** (configstore, LOW): `store_commit.go` — a corrupt rollback file is logged by POSITION (line/column) only, never by forwarding the `config.ParseError` text, which can echo secret file content (mirrors the #4099 rescue invariant).
- **#4691** (daemon, LOW): `host_tunables_daemon.go` — `restoreStep0TunablesOnShutdown` acquires `d.applySem` so the shutdown restore serializes against an un-drained DHCP apply that mutates the same `priorTunables` maps outside `priorTunablesMu`.
- **#4692** (api, LOW): `metrics_nat.go` — the IPv6 deterministic-NAT `host_count` label no longer computes `1<<(128-ones)` (a >=64-bit shift = 0 in Go). It reports the pool block/subscriber capacity (totalBlocks), mirroring the compiler_nat.go gate.
- **#4693** (grpcapi, LOW): `server_diag_system_action.go` — the `cluster-failover:<rgID>:node<N>` handler branch validates the node ID via `cluster.IsSupportedClusterNodeID` before the local/proxy routing decision (mirrors the sibling data branch and #4125). A local `node99` no longer drives an outbound proxy dial.
- **#4694** (cmd/cli, LOW-MED): `cmd/cli/monitor.go` — port the #3985 remedy: `VMIN=0/VTIME=1` poll-with-timeout raw mode + `keyReader`/`startKeyReader`, replacing the blocking inline goroutine so the interactive monitor's stdin reader no longer steals the next command's keystroke.

## Validation

- Per-issue RED-on-revert test verified to FAIL when the fix is reverted.
- `go build ./...`, `go test` on every touched package green, gofmt clean, `go vet` clean (all vs current master, post-rebase).
- Pre-existing out-of-scope note: `go vet` flags `reqCopy := *req` in the unchanged `startStream` closure in `cmd/cli/monitor.go` (copying a proto message that embeds a Mutex). It exists on origin/master and is not addressed here.

Closes #4688, #4689, #4690, #4691, #4692, #4693, #4694

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi