### PR TITLE
cmd/cli: proto.Clone MonitorInterfaceRequest in startStream (#4697)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -42368,3 +42368,21 @@ top.
   taxonomy + sampling), pkg/dataplane/userspace/format/buffers_golden_test.go
   (new), pkg/dataplane/userspace/format/testdata/system_buffers.golden (new),
   _Log.md
+
+- **Timestamp**: 2026-07-08
+  **Action**: #4697 — fix govet copylocks in cmd/cli monitor.go startStream.
+  The interactive `monitor interface` summary loop's `startStream` closure did
+  `reqCopy := *req` where `req` is a `*pb.MonitorInterfaceRequest` — a generated
+  proto message embedding `protoimpl.MessageState` (which contains a
+  `sync.Mutex`). The shallow struct copy tripped `go vet` copylocks
+  ("assignment copies lock value to reqCopy"). Pre-existing on origin/master
+  (surfaced during #4694, not introduced by #4696). Replaced with
+  `proto.Clone(req).(*pb.MonitorInterfaceRequest)` (deep copy, no lock copy),
+  set the per-stream `SummaryMode` on the clone, and passed the clone pointer
+  directly to `MonitorInterface`. `reqCopy` is only mutated on that one field
+  and then read, so the clone is behaviorally identical. Added the
+  `google.golang.org/protobuf/proto` import (already a direct dep, v1.36.11).
+  Verified: `go vet ./cmd/cli/...` clean (warning gone; returns on revert),
+  `go build ./...`, `go test ./cmd/cli/...` green, gofmt clean. No module-doc
+  change needed — internal remote-CLI fix, no behavior/contract change.
+  **File(s)**: cmd/cli/monitor.go, _Log.md

--- a/cmd/cli/monitor.go
+++ b/cmd/cli/monitor.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"golang.org/x/sys/unix"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/psaab/xpf/pkg/cmdtree"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
@@ -211,11 +212,16 @@ func (c *ctl) handleInteractiveMonitorInterfaceSummary(req *pb.MonitorInterfaceR
 			streamCancel()
 		}
 		streamGen++
-		reqCopy := *req
+		// Deep-copy via proto.Clone rather than a shallow struct copy: the
+		// generated message embeds protoimpl.MessageState (a sync.Mutex), so
+		// `reqCopy := *req` is a lock copy (govet copylocks). proto.Clone
+		// yields a fresh message whose per-stream SummaryMode we can set
+		// without aliasing the caller's req (#4697).
+		reqCopy := proto.Clone(req).(*pb.MonitorInterfaceRequest)
 		reqCopy.SummaryMode = mode
 		gen := streamGen
 		streamCtx, cancelStream := context.WithCancel(ctx)
-		stream, err := c.client.MonitorInterface(streamCtx, &reqCopy)
+		stream, err := c.client.MonitorInterface(streamCtx, reqCopy)
 		if err != nil {
 			cancelStream()
 			return err


### PR DESCRIPTION
## Summary

Fixes a pre-existing `go vet` **copylocks** warning in `cmd/cli/monitor.go`.
The interactive `monitor interface` summary loop's `startStream` closure copied
the request with `reqCopy := *req`, where `req` is a
`*pb.MonitorInterfaceRequest`. That generated proto message embeds
`protoimpl.MessageState`, which contains a `sync.Mutex`, so the shallow struct
copy is a lock copy:

```
cmd/cli/monitor.go:214:14: assignment copies lock value to reqCopy:
  ...MonitorInterfaceRequest contains ...MessageState contains sync.Mutex
```

The warning is pre-existing on `origin/master` (surfaced during the #4694
monitor.go work, **not** introduced by #4696). It is benign in practice —
`reqCopy` only ever has its `SummaryMode` field set per stream and is then read —
but copying a locked type is incorrect.

## Fix

Replace the shallow copy with `proto.Clone(req).(*pb.MonitorInterfaceRequest)`.
This produces a fresh message with no lock copied; the per-stream `SummaryMode`
is set on the clone and the clone pointer is passed straight to
`MonitorInterface` (`proto.Clone` already returns a pointer, so the `&reqCopy`
address-of is dropped). Behavior is unchanged. Added the
`google.golang.org/protobuf/proto` import (already a direct module dependency,
v1.36.11).

## Validation

- `go vet ./cmd/cli/...` — clean (copylocks warning gone; RED: it returns on revert)
- `go build ./...` — passes
- `go test ./cmd/cli/...` — passes
- `gofmt` — clean

No module-doc change needed — internal remote-CLI correctness fix with no
behavior or contract change.

Closes #4697

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi