### PR TITLE
userspace-dp: fable-173 Rust LOW batch — dead IcmpTeRateLimiter + canonical_route_table Cow (#4673, #4674)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -42448,3 +42448,58 @@ top.
   `go build ./...`, `go test ./cmd/cli/...` green, gofmt clean. No module-doc
   change needed — internal remote-CLI fix, no behavior/contract change.
   **File(s)**: cmd/cli/monitor.go, _Log.md
+
+- **Timestamp**: 2026-07-08
+  **Action**: fable-173 Rust LOW batch — #4673 delete dead
+  IcmpTeRateLimiter; #4674 canonical_route_table -> Cow. #4675
+  (session/lookup.rs metadata.clone()) SKIPPED as unsafe (see below).
+
+  #4673 (LOW, dead-code): deleted the dead `IcmpTeRateLimiter`
+  (const `ICMP_TE_MAX_PER_SEC` + struct + impl, all `#[allow(dead_code)]`)
+  from forwarding/mod.rs. Tree-wide grep confirmed ZERO callers — the live
+  ICMP-TE rate-limit path is GCRA in afxdp/icmp_ratelimit.rs. The const was
+  referenced only by the dead code. Compiler + zero-caller grep is the gate
+  (no RED test for a pure dead-code delete).
+
+  #4674 (LOW perf): `canonical_route_table` now returns
+  `Cow<'static, str>` instead of `String`. The default-table remaps
+  (`inet.0`<->`inet6.0`) borrow the `'static` DEFAULT_V4_TABLE/DEFAULT_V6_TABLE
+  constants and the two lookup-path callers default to
+  `Cow::Borrowed(DEFAULT_V*_TABLE)` — this removes the per-new-flow FIB
+  resolution heap alloc that `.to_string()` forced. Only the rare per-VRF
+  suffix rewrite (`<inst>.inet.0`<->`<inst>.inet6.0`) or a non-canonical
+  passthrough owns a `String`. Callers updated: the two `.unwrap_or_else(||
+  DEFAULT_V*_TABLE.to_string())` -> `.unwrap_or(Cow::Borrowed(...))`; two
+  `tables.contains(&table)` -> `.contains(table.as_ref())`; the cold
+  build-path `.entry(table)` -> `.entry(table.into_owned())` (fib.rs, x2)
+  and the tunnel-endpoint `transport_table` field init ->
+  `transport_table.into_owned()` (tunnels.rs). The next-table recursion
+  comparisons work unchanged via std's symmetric `Cow`/`String`/`&str`
+  PartialEq impls; `&table` deref-coerces to `&str`. Behavior-identical.
+  RED-on-revert: `canonical_route_table_borrows_default_and_owns_vrf` asserts
+  `Cow::Borrowed(_)` for the defaults and `Cow::Owned(_)` for VRF/passthrough
+  — the pre-#4674 `String` return type cannot match those patterns, so the
+  test fails to compile against the reverted signature.
+
+  #4675 (LOW-MED perf): SKIPPED as unsafe, issue kept OPEN. VERIFY-FIRST:
+  `SessionMetadata` (session/entry.rs) is NOT `Copy` — it carries
+  `policy_counter: Option<Arc<PolicyRuleCounter>>`, the #3322 reorder-stable
+  bound hit-counter handle held in shared ownership with `PolicyCounterStore`
+  (the established fast path increments it every packet). The clone's only
+  cost is one `Option<Arc>` refcount bump, and only for policy-forwarded
+  sessions (None -> free). All four clone sites (lookup.rs:183/240/281/321)
+  build OWNED return values (`SessionLookup` / `ForwardSessionMatch` / a
+  tuple) that outlive the table borrow (the &mut self.entries borrow ends
+  before the caller consumes the result). A borrow cannot cross that
+  boundary, and making the type `Copy` would require removing the
+  load-bearing Arc (reintroducing the #3322 live-reorder misattribution) or a
+  return-type split rippling through every lookup caller — neither a LOW-risk
+  change. Per the task's guard, not forcing a lifetime change that breaks the
+  lookup.
+
+  Validation: FULL cargo test suite (userspace-dp) SERIAL.
+  **File(s)**: userspace-dp/src/afxdp/forwarding/mod.rs,
+  userspace-dp/src/afxdp/forwarding_build/fib.rs,
+  userspace-dp/src/afxdp/forwarding_build/tunnels.rs,
+  userspace-dp/src/afxdp/forwarding/tests.rs,
+  userspace-dp/src/afxdp/forwarding/README.md, _Log.md

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -24,7 +24,12 @@ slow-path-injected.
 
 - `DEFAULT_V4_TABLE = "inet.0"`, `DEFAULT_V6_TABLE = "inet6.0"` —
   the default routing tables a packet starts in when no
-  routing-instance scopes it.
+  routing-instance scopes it. `canonical_route_table` (#4674) returns
+  `Cow<'static, str>`: the default-table remaps (`inet.0`↔`inet6.0`)
+  and the lookup-path default both borrow these `'static` constants and
+  allocate nothing on the per-new-flow FIB resolution path; only the
+  rare per-VRF suffix rewrite (`<inst>.inet.0`↔`<inst>.inet6.0`) or a
+  non-canonical passthrough owns a heap `String`.
 - `MAX_NEXT_TABLE_DEPTH = 8` — bounded recursion across `next-table`
   chains to keep a misconfigured loop from running forever.
 

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -1237,42 +1237,6 @@ pub(super) fn select_tcp_mss(
 
 // #989: clamp_tcp_mss / clamp_tcp_mss_frame relocated to `frame/tcp.rs`.
 
-#[allow(dead_code)]
-const ICMP_TE_MAX_PER_SEC: u32 = 100;
-
-/// Rate limiter for ICMP Time Exceeded messages.
-#[allow(dead_code)]
-struct IcmpTeRateLimiter {
-    max_per_sec: u32,
-    count: u32,
-    window_start_ns: u64,
-}
-
-#[allow(dead_code)]
-impl IcmpTeRateLimiter {
-    fn new(max_per_sec: u32) -> Self {
-        Self {
-            max_per_sec,
-            count: 0,
-            window_start_ns: 0,
-        }
-    }
-
-    fn allow(&mut self, now_ns: u64) -> bool {
-        let window = now_ns / 1_000_000_000;
-        let prev_window = self.window_start_ns / 1_000_000_000;
-        if window != prev_window {
-            self.count = 0;
-            self.window_start_ns = now_ns;
-        }
-        if self.count >= self.max_per_sec {
-            return false;
-        }
-        self.count += 1;
-        true
-    }
-}
-
 /// Returns true if the packet is IPsec traffic (ESP protocol 50, AH protocol
 /// 51, or IKE UDP ports 500/4500) that should be passed to the kernel for
 /// XFRM processing.

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::borrow::Cow;
 
 mod host_inbound;
 // #3070: re-export into the afxdp scope so the local-delivery admit path
@@ -45,23 +46,31 @@ pub(super) fn classify_metadata(
     }
 }
 
-pub(super) fn canonical_route_table(table: &str, is_ipv6: bool) -> String {
+/// #4674: returns `Cow<'static, str>` rather than an owned `String`. The
+/// common cases — the default-table remaps (`inet.0`↔`inet6.0`) — borrow the
+/// `'static` `DEFAULT_V4_TABLE`/`DEFAULT_V6_TABLE` constants and never
+/// allocate. Only the rare per-VRF suffix rewrite (`<inst>.inet.0`↔
+/// `<inst>.inet6.0`) or a non-canonical passthrough owns a heap string. This
+/// removes the per-new-flow FIB-resolution alloc that `.to_string()` forced at
+/// every lookup-path caller (see `lookup_forwarding_resolution_inner_ecmp`,
+/// which now defaults to `Cow::Borrowed(DEFAULT_V*_TABLE)`).
+pub(super) fn canonical_route_table(table: &str, is_ipv6: bool) -> Cow<'static, str> {
     if is_ipv6 {
-        if table == "inet.0" {
-            return "inet6.0".to_string();
+        if table == DEFAULT_V4_TABLE {
+            return Cow::Borrowed(DEFAULT_V6_TABLE);
         }
         if let Some(prefix) = table.strip_suffix(".inet.0") {
-            return format!("{prefix}.inet6.0");
+            return Cow::Owned(format!("{prefix}.inet6.0"));
         }
-        return table.to_string();
+        return Cow::Owned(table.to_string());
     }
-    if table == "inet6.0" {
-        return "inet.0".to_string();
+    if table == DEFAULT_V6_TABLE {
+        return Cow::Borrowed(DEFAULT_V4_TABLE);
     }
     if let Some(prefix) = table.strip_suffix(".inet6.0") {
-        return format!("{prefix}.inet.0");
+        return Cow::Owned(format!("{prefix}.inet.0"));
     }
-    table.to_string()
+    Cow::Owned(table.to_string())
 }
 
 /// #3771 (M12): count of neighbors skipped because their kernel state string
@@ -1421,7 +1430,7 @@ pub(super) fn lookup_forwarding_resolution_inner_ecmp(
         IpAddr::V4(ip) => {
             let table = table
                 .map(|table| canonical_route_table(table, false))
-                .unwrap_or_else(|| DEFAULT_V4_TABLE.to_string());
+                .unwrap_or(Cow::Borrowed(DEFAULT_V4_TABLE));
             if state.local_v4.contains(&ip) {
                 // #3151: local-delivery (to-self) attribution is table-scoped,
                 // exactly like the route-path connected scan (#2388). When the
@@ -1454,7 +1463,7 @@ pub(super) fn lookup_forwarding_resolution_inner_ecmp(
                     || state
                         .local_tables_v4
                         .get(&ip)
-                        .is_some_and(|tables| tables.contains(&table));
+                        .is_some_and(|tables| tables.contains(table.as_ref()));
                 if !owned_here {
                     // Owned in a DIFFERENT table only (cross-VRF) — fall
                     // through to the VRF-A route lookup instead of leaking to
@@ -1505,7 +1514,7 @@ pub(super) fn lookup_forwarding_resolution_inner_ecmp(
         IpAddr::V6(ip) => {
             let table = table
                 .map(|table| canonical_route_table(table, true))
-                .unwrap_or_else(|| DEFAULT_V6_TABLE.to_string());
+                .unwrap_or(Cow::Borrowed(DEFAULT_V6_TABLE));
             if state.local_v6.contains(&ip) {
                 // #3151: table-scoped local-delivery attribution (see the v4
                 // branch above and the #2388 route-path connected scan).
@@ -1520,7 +1529,7 @@ pub(super) fn lookup_forwarding_resolution_inner_ecmp(
                     || state
                         .local_tables_v6
                         .get(&ip)
-                        .is_some_and(|tables| tables.contains(&table));
+                        .is_some_and(|tables| tables.contains(table.as_ref()));
                 if !owned_here {
                     // Owned in a DIFFERENT table only (cross-VRF) — fall
                     // through to the route lookup.

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -2626,6 +2626,42 @@ fn forwarding_state_normalizes_ipv6_routes_emitted_in_inet_table() {
 }
 
 #[test]
+fn canonical_route_table_borrows_default_and_owns_vrf() {
+    // #4674: the default-table remaps must borrow the 'static
+    // DEFAULT_V4_TABLE/DEFAULT_V6_TABLE constants so the per-new-flow FIB
+    // resolution path allocates nothing; only the rare per-VRF suffix rewrite
+    // or a non-canonical passthrough owns a heap String. RED-on-revert: the
+    // pre-#4674 `String` return type cannot match the `Cow::Borrowed` /
+    // `Cow::Owned` patterns, so this test fails to compile against the
+    // reverted signature.
+    use std::borrow::Cow;
+
+    // v4 -> v6 default remap: borrowed (zero alloc), equals inet6.0.
+    let v6_default = canonical_route_table("inet.0", true);
+    assert!(matches!(v6_default, Cow::Borrowed(_)));
+    assert_eq!(v6_default, "inet6.0");
+
+    // v6 -> v4 default remap: borrowed (zero alloc), equals inet.0.
+    let v4_default = canonical_route_table("inet6.0", false);
+    assert!(matches!(v4_default, Cow::Borrowed(_)));
+    assert_eq!(v4_default, "inet.0");
+
+    // Per-VRF suffix rewrite: owned (rare path), correct family rewrite.
+    let vrf_v6 = canonical_route_table("myvrf.inet.0", true);
+    assert!(matches!(vrf_v6, Cow::Owned(_)));
+    assert_eq!(vrf_v6, "myvrf.inet6.0");
+
+    let vrf_v4 = canonical_route_table("myvrf.inet6.0", false);
+    assert!(matches!(vrf_v4, Cow::Owned(_)));
+    assert_eq!(vrf_v4, "myvrf.inet.0");
+
+    // Non-canonical passthrough: owned, unchanged.
+    let passthrough = canonical_route_table("custom.table", true);
+    assert!(matches!(passthrough, Cow::Owned(_)));
+    assert_eq!(passthrough, "custom.table");
+}
+
+#[test]
 fn dynamic_neighbor_cache_enables_forward_candidate() {
     let state = build_forwarding_state(&forwarding_snapshot(false));
     let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());

--- a/userspace-dp/src/afxdp/forwarding_build/fib.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/fib.rs
@@ -80,7 +80,7 @@ pub(super) fn populate_routes(
             );
             state
                 .routes_v4
-                .entry(table)
+                .entry(table.into_owned())
                 .or_default()
                 .push(RouteEntryV4 {
                     prefix: PrefixV4::from_net(prefix),
@@ -114,7 +114,7 @@ pub(super) fn populate_routes(
             );
             state
                 .routes_v6
-                .entry(table)
+                .entry(table.into_owned())
                 .or_default()
                 .push(RouteEntryV6 {
                     prefix: PrefixV6::from_net(prefix),

--- a/userspace-dp/src/afxdp/forwarding_build/tunnels.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tunnels.rs
@@ -90,7 +90,7 @@ pub(super) fn populate_tunnel_endpoints(
                 destination,
                 key: endpoint.key,
                 ttl,
-                transport_table,
+                transport_table: transport_table.into_owned(),
                 wg_listen_port: endpoint.wg_listen_port,
                 wg_local_privkey,
                 wg_peers,


### PR DESCRIPTION
Drives two fable-173 Rust LOW residuals as separate commits. Provenance: `/tmp/result-fable-review-173.md`.

## Commits

### #4673 — delete dead `IcmpTeRateLimiter` (LOW, dead-code)
`afxdp/forwarding/mod.rs` carried an `IcmpTeRateLimiter` (const `ICMP_TE_MAX_PER_SEC` + struct + impl), every item `#[allow(dead_code)]`. A tree-wide grep confirmed **zero callers**; the const was referenced only by the dead limiter. The live ICMP Time-Exceeded rate-limit path is the GCRA limiter in `afxdp/icmp_ratelimit.rs`. Deleted the ~34 dead lines. Gate: compiler + zero-caller grep (pure dead-code delete, no behavioral RED test); `cargo build` warning-free after the delete.

### #4674 — `canonical_route_table` returns `Cow<'static, str>` (LOW perf)
The function returned an owned `String`, so the hot caller `lookup_forwarding_resolution_inner_ecmp` ran `.unwrap_or_else(|| DEFAULT_V4_TABLE.to_string())` — one heap alloc per new-flow FIB resolution just to materialize a `'static` constant. Now returns `Cow<'static, str>`: the default-table remaps (`inet.0`↔`inet6.0`) and the lookup-path default borrow the `'static` `DEFAULT_V*_TABLE` constants (zero alloc); only the rare per-VRF suffix rewrite or a non-canonical passthrough owns a `String`.

Caller updates are mechanical and behavior-identical (`.unwrap_or(Cow::Borrowed(...))`; `.contains(table.as_ref())`; cold build-path `.entry(table.into_owned())` in fib.rs ×2 + the `transport_table` field init in tunnels.rs). Next-table recursion comparisons compile unchanged via std's symmetric `Cow`/`String`/`&str` `PartialEq` impls.

**RED-on-revert:** new `canonical_route_table_borrows_default_and_owns_vrf` asserts `Cow::Borrowed(_)` for defaults and `Cow::Owned(_)` for VRF/passthrough — the pre-change `String` return type cannot match those patterns, so the test fails to compile against the reverted signature.

## #4675 — SKIPPED as unsafe (kept OPEN)
The sibling residual (`session/lookup.rs` `entry.metadata.clone()`) is **not** taken here. Verify-first: `SessionMetadata` is not `Copy` — it carries the load-bearing `policy_counter: Option<Arc<PolicyRuleCounter>>` (#3322 reorder-stable bound hit-counter handle, shared ownership with `PolicyCounterStore`, incremented on the established fast path). All four clone sites (lookup.rs:183/240/281/321) build **owned** return values (`SessionLookup` / `ForwardSessionMatch` / a tuple) that outlive the session-table borrow (the `&mut self.entries` borrow ends before the caller consumes the result). A borrow cannot cross that boundary, and making the type `Copy` would require removing the load-bearing Arc (reintroducing #3322 misattribution) or a return-type split rippling through every lookup caller — neither a LOW-risk change. Per the task guard, no forced lifetime change. **#4675 stays open.**

## Validation
Full userspace-dp cargo test suite: **3853 passed, 0 failed** (cold build, exit 0), including the new RED test.

Closes #4673, #4674

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi