### PR TITLE
fix(api): deterministic sorted iteration in show-text endpoints (#4712)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-07-08 — #4712: deterministic sorted iteration in show-text endpoints
+
+- **Timestamp**: 2026-07-08
+  **Action**: #4712 — `pkg/api/show_text.go` (the `/show-text` REST handler)
+  ranged over string-keyed config maps directly for 12 topics (schedulers,
+  snmp communities/trap-groups, dhcp-relay server-groups/groups, firewall
+  filters, dynamic-address feeds, address-book addresses/address-sets,
+  applications/application-sets, netflow-v9 templates). Go randomizes map
+  iteration order, so the rendered operator/automation-facing text came back
+  in a different order across requests, breaking config diffing and making
+  downstream tests flaky. Verified all 12 cited fields are `map[string]*...`
+  (nat-static/nat-nptv6 iterate slices → already deterministic, correctly not
+  cited). Fix: added a generic `sortedKeys[V any](map[string]V) []string`
+  helper (collect keys, `sort.Strings`, iterate) and routed all 12 sites
+  through it — minimal, local, no handler restructuring. New regression test
+  stages multi-key maps (scrambled insertion order) for applications,
+  address-book, and snmp, renders each topic 40× and asserts (1) byte-identical
+  output across renders and (2) ascending-key ordering; proved RED under both a
+  reverse-sort and a raw map-range revert. Validation: gofmt -w; go build
+  ./... clean; go test ./pkg/api/... green; FULL Go suite 52 ok / 3 no-test,
+  sole FAIL is the pre-existing pkg/ddns RFC2136 port-bind flake (passes in
+  isolation, unrelated — change is pkg/api-only). No docs change: this
+  restores expected deterministic output; no operator-facing contract or
+  module doc describes the prior (buggy) ordering.
+  **File(s)**: pkg/api/show_text.go, pkg/api/show_text_sorted_4712_test.go,
+  _Log.md
+
 ## 2026-07-08 — #4422 slice: firewall-filter port-on-non-port / TCP-only / ICMP-only regression coverage
 
 - **Timestamp**: 2026-07-08

--- a/pkg/api/show_text.go
+++ b/pkg/api/show_text.go
@@ -3,10 +3,24 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/psaab/xpf/pkg/config"
 )
+
+// sortedKeys returns the keys of a string-keyed map in ascending order. The
+// show-text handlers render config maps as operator/automation-facing text, so
+// iterating them in sorted order keeps the output deterministic across requests
+// (Go map iteration order is randomized). See #4712.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
 
 func (s *Server) showTextHandler(w http.ResponseWriter, r *http.Request) {
 	topic := r.URL.Query().Get("topic")
@@ -23,7 +37,8 @@ func (s *Server) showTextHandler(w http.ResponseWriter, r *http.Request) {
 		if cfg == nil || len(cfg.Schedulers) == 0 {
 			buf.WriteString("No schedulers configured\n")
 		} else {
-			for name, sched := range cfg.Schedulers {
+			for _, name := range sortedKeys(cfg.Schedulers) {
+				sched := cfg.Schedulers[name]
 				fmt.Fprintf(&buf, "Scheduler: %s\n", name)
 				if sched.StartTime != "" {
 					fmt.Fprintf(&buf, "  Start time: %s\n", sched.StartTime)
@@ -60,13 +75,15 @@ func (s *Server) showTextHandler(w http.ResponseWriter, r *http.Request) {
 			}
 			if len(snmpCfg.Communities) > 0 {
 				buf.WriteString("Communities:\n")
-				for name, comm := range snmpCfg.Communities {
+				for _, name := range sortedKeys(snmpCfg.Communities) {
+					comm := snmpCfg.Communities[name]
 					fmt.Fprintf(&buf, "  %s: %s\n", name, comm.Authorization)
 				}
 			}
 			if len(snmpCfg.TrapGroups) > 0 {
 				buf.WriteString("Trap groups:\n")
-				for name, tg := range snmpCfg.TrapGroups {
+				for _, name := range sortedKeys(snmpCfg.TrapGroups) {
+					tg := snmpCfg.TrapGroups[name]
 					fmt.Fprintf(&buf, "  %s: %s\n", name, strings.Join(tg.Targets, ", "))
 				}
 			}
@@ -79,13 +96,15 @@ func (s *Server) showTextHandler(w http.ResponseWriter, r *http.Request) {
 			relay := cfg.ForwardingOptions.DHCPRelay
 			if len(relay.ServerGroups) > 0 {
 				buf.WriteString("Server groups:\n")
-				for name, sg := range relay.ServerGroups {
+				for _, name := range sortedKeys(relay.ServerGroups) {
+					sg := relay.ServerGroups[name]
 					fmt.Fprintf(&buf, "  %s: %s\n", name, strings.Join(sg.Servers, ", "))
 				}
 			}
 			if len(relay.Groups) > 0 {
 				buf.WriteString("Relay groups:\n")
-				for name, g := range relay.Groups {
+				for _, name := range sortedKeys(relay.Groups) {
+					g := relay.Groups[name]
 					fmt.Fprintf(&buf, "  %s:\n", name)
 					fmt.Fprintf(&buf, "    Interfaces: %s\n", strings.Join(g.Interfaces, ", "))
 					fmt.Fprintf(&buf, "    Active server group: %s\n", g.ActiveServerGroup)
@@ -99,7 +118,8 @@ func (s *Server) showTextHandler(w http.ResponseWriter, r *http.Request) {
 			buf.WriteString("No firewall filters configured\n")
 		} else {
 			printFilters := func(family string, filters map[string]*config.FirewallFilter) {
-				for name, filter := range filters {
+				for _, name := range sortedKeys(filters) {
+					filter := filters[name]
 					fmt.Fprintf(&buf, "Filter: %s (family: %s)\n", name, family)
 					for _, term := range filter.Terms {
 						fmt.Fprintf(&buf, "  Term: %s\n", term.Name)
@@ -147,7 +167,8 @@ func (s *Server) showTextHandler(w http.ResponseWriter, r *http.Request) {
 		if cfg == nil || len(cfg.Security.DynamicAddress.FeedServers) == 0 {
 			buf.WriteString("No dynamic address feeds configured\n")
 		} else {
-			for name, feed := range cfg.Security.DynamicAddress.FeedServers {
+			for _, name := range sortedKeys(cfg.Security.DynamicAddress.FeedServers) {
+				feed := cfg.Security.DynamicAddress.FeedServers[name]
 				fmt.Fprintf(&buf, "Feed server: %s\n", name)
 				fmt.Fprintf(&buf, "  URL: %s\n", feed.URL)
 				if feed.FeedName != "" {
@@ -170,13 +191,15 @@ func (s *Server) showTextHandler(w http.ResponseWriter, r *http.Request) {
 			ab := cfg.Security.AddressBook
 			if len(ab.Addresses) > 0 {
 				buf.WriteString("Addresses:\n")
-				for name, addr := range ab.Addresses {
+				for _, name := range sortedKeys(ab.Addresses) {
+					addr := ab.Addresses[name]
 					fmt.Fprintf(&buf, "  %-20s %s\n", name, addr.Value)
 				}
 			}
 			if len(ab.AddressSets) > 0 {
 				buf.WriteString("Address sets:\n")
-				for name, as := range ab.AddressSets {
+				for _, name := range sortedKeys(ab.AddressSets) {
+					as := ab.AddressSets[name]
 					fmt.Fprintf(&buf, "  %-20s members: %s\n", name, strings.Join(as.Addresses, ", "))
 				}
 			}
@@ -188,7 +211,8 @@ func (s *Server) showTextHandler(w http.ResponseWriter, r *http.Request) {
 		} else {
 			if len(cfg.Applications.Applications) > 0 {
 				buf.WriteString("Applications:\n")
-				for name, app := range cfg.Applications.Applications {
+				for _, name := range sortedKeys(cfg.Applications.Applications) {
+					app := cfg.Applications.Applications[name]
 					fmt.Fprintf(&buf, "  %-20s proto=%-6s", name, app.Protocol)
 					if app.DestinationPort != "" {
 						fmt.Fprintf(&buf, " dst-port=%s", app.DestinationPort)
@@ -198,7 +222,8 @@ func (s *Server) showTextHandler(w http.ResponseWriter, r *http.Request) {
 			}
 			if len(cfg.Applications.ApplicationSets) > 0 {
 				buf.WriteString("Application sets:\n")
-				for name, as := range cfg.Applications.ApplicationSets {
+				for _, name := range sortedKeys(cfg.Applications.ApplicationSets) {
+					as := cfg.Applications.ApplicationSets[name]
 					fmt.Fprintf(&buf, "  %-20s members: %s\n", name, strings.Join(as.Applications, ", "))
 				}
 			}
@@ -210,7 +235,8 @@ func (s *Server) showTextHandler(w http.ResponseWriter, r *http.Request) {
 		} else {
 			v9 := cfg.Services.FlowMonitoring.Version9
 			buf.WriteString("Flow monitoring (NetFlow v9):\n")
-			for name, tmpl := range v9.Templates {
+			for _, name := range sortedKeys(v9.Templates) {
+				tmpl := v9.Templates[name]
 				fmt.Fprintf(&buf, "  Template: %s\n", name)
 				if tmpl.FlowActiveTimeout > 0 {
 					fmt.Fprintf(&buf, "    Active timeout: %ds\n", tmpl.FlowActiveTimeout)

--- a/pkg/api/show_text_sorted_4712_test.go
+++ b/pkg/api/show_text_sorted_4712_test.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// #4712: the /show-text handlers render config maps (schedulers, snmp,
+// dhcp-relay, filters, feeds, address-book, applications, v9 templates) as
+// operator/automation-facing text. Go randomizes map iteration order, so before
+// the fix the same active config produced different orderings across requests,
+// breaking config diffing/automation and making downstream tests flaky. The fix
+// routes every map through the shared sortedKeys helper. These tests stage
+// multi-key config maps, render each topic many times, and assert:
+//   1. the rendered text is byte-identical across renders (determinism), and
+//   2. entries appear in ascending key order (the sorted contract).
+// Reverting show_text.go to a raw `for k := range m` makes assertion (1)
+// essentially always RED (P(all N renders identical) ~ (1/k!)^(N-1)) and
+// assertion (2) RED with probability ~1-1/k! on the very first render.
+
+// renderShowTextBody drives the live showTextHandler for one topic and returns
+// the decoded TextResponse Output payload.
+func renderShowTextBody(t *testing.T, s *Server, topic string) string {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/show-text?topic="+topic, nil)
+	s.showTextHandler(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("show-text topic=%s status = %d, want 200; body: %s", topic, rr.Code, rr.Body.String())
+	}
+	var env struct {
+		Success bool         `json:"success"`
+		Data    TextResponse `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+		t.Fatalf("show-text topic=%s: response not valid JSON: %v; body: %s", topic, err, rr.Body.String())
+	}
+	return env.Data.Output
+}
+
+// stageShowTextConfig compiles the given flat set commands into an active
+// config and returns a Server bound to that store, via the real LoadSet +
+// Commit path (same harness as the secret-redaction regression test).
+func stageShowTextConfig(t *testing.T, setCommands []string) *Server {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if _, err := store.LoadSet(strings.Join(setCommands, "\n")); err != nil {
+		t.Fatalf("LoadSet() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return &Server{store: store}
+}
+
+// assertSortedEntries checks that each name in wantSorted appears in output and
+// that their first-occurrence positions are strictly increasing — i.e. the
+// section renders keys in ascending order. wantSorted MUST already be sorted;
+// the caller passes distinct names that are not substrings of one another.
+func assertSortedEntries(t *testing.T, topic, section, output string, wantSorted []string) {
+	t.Helper()
+	prev := -1
+	for _, name := range wantSorted {
+		idx := strings.Index(output, name)
+		if idx < 0 {
+			t.Fatalf("topic=%s %s: name %q missing from output:\n%s", topic, section, name, output)
+		}
+		if idx <= prev {
+			t.Errorf("topic=%s %s: name %q at index %d is not after the previous entry (index %d) — map not iterated in sorted order:\n%s",
+				topic, section, name, idx, prev, output)
+		}
+		prev = idx
+	}
+}
+
+// assertDeterministic renders a topic renders-many times and requires every
+// render to be byte-identical. Under a raw map-range this is flaky-RED because
+// Go randomizes iteration order per range statement.
+func assertDeterministic(t *testing.T, s *Server, topic string, renders int) string {
+	t.Helper()
+	first := renderShowTextBody(t, s, topic)
+	for i := 1; i < renders; i++ {
+		if got := renderShowTextBody(t, s, topic); got != first {
+			t.Fatalf("topic=%s: render %d differs from render 0 — output is non-deterministic across requests\n--- render 0 ---\n%s\n--- render %d ---\n%s",
+				topic, i, first, i, got)
+		}
+	}
+	return first
+}
+
+func TestShowTextDeterministicSortedOrder(t *testing.T) {
+	// Keys are intentionally staged in scrambled (non-sorted) order and chosen
+	// so no name is a substring of another (or of a rendered value/proto/port).
+	setCommands := []string{
+		// applications: Applications map + ApplicationSets map.
+		"set applications application zebra protocol tcp destination-port 22",
+		"set applications application alpha protocol tcp destination-port 80",
+		"set applications application mango protocol udp destination-port 53",
+		"set applications application beta protocol tcp destination-port 443",
+		"set applications application yak protocol tcp destination-port 8080",
+		"set applications application delta protocol udp destination-port 123",
+		"set applications application-set zulu application alpha",
+		"set applications application-set apex application beta",
+		"set applications application-set mid application delta",
+		// address-book: Addresses map + AddressSets map.
+		"set security address-book global address host_zeta 10.0.0.4/32",
+		"set security address-book global address host_alpha 10.0.0.1/32",
+		"set security address-book global address host_gamma 10.0.0.3/32",
+		"set security address-book global address host_beta 10.0.0.2/32",
+		"set security address-book global address-set set_yankee address host_alpha",
+		"set security address-book global address-set set_bravo address host_beta",
+		"set security address-book global address-set set_mike address host_gamma",
+		// snmp: Communities map.
+		"set snmp community comm_delta authorization read-only",
+		"set snmp community comm_alpha authorization read-write",
+		"set snmp community comm_charlie authorization read-only",
+		"set snmp community comm_bravo authorization read-write",
+	}
+	s := stageShowTextConfig(t, setCommands)
+
+	const renders = 40
+
+	t.Run("applications", func(t *testing.T) {
+		out := assertDeterministic(t, s, "applications", renders)
+		apps := []string{"alpha", "beta", "delta", "mango", "yak", "zebra"}
+		if !sort.StringsAreSorted(apps) {
+			t.Fatalf("test bug: apps expectation not sorted: %v", apps)
+		}
+		assertSortedEntries(t, "applications", "Applications", out, apps)
+		// ApplicationSets section renders after the members reference app names,
+		// so anchor on the set names, which occur only in the sets section.
+		sets := []string{"apex", "mid", "zulu"}
+		assertSortedEntries(t, "applications", "Application sets", out, sets)
+	})
+
+	t.Run("address-book", func(t *testing.T) {
+		out := assertDeterministic(t, s, "address-book", renders)
+		addrs := []string{"host_alpha", "host_beta", "host_gamma", "host_zeta"}
+		assertSortedEntries(t, "address-book", "Addresses", out, addrs)
+		sets := []string{"set_bravo", "set_mike", "set_yankee"}
+		assertSortedEntries(t, "address-book", "Address sets", out, sets)
+	})
+
+	t.Run("snmp", func(t *testing.T) {
+		out := assertDeterministic(t, s, "snmp", renders)
+		comms := []string{"comm_alpha", "comm_bravo", "comm_charlie", "comm_delta"}
+		assertSortedEntries(t, "snmp", "Communities", out, comms)
+	})
+}


### PR DESCRIPTION
Closes #4712

## Problem
`pkg/api/show_text.go` (the `/show-text` REST handler) ranged over Go
string-keyed config maps directly for 12 topics without sorting keys, so
`/show-text` responses came back in randomized order across calls. Go
randomizes map iteration order, so identical active config produced
different orderings request-to-request — breaking config diff/validation
tooling and causing test flakiness (gemini-review-041 Low-13; verified
GENUINE, severity Low — cosmetic, no functional/security impact).

## Verify-first
All 12 cited sites iterate `map[string]*...` fields keyed by name, and
`showTextHandler` renders them into an operator/automation-facing
`TextResponse`, so every one is a genuine non-determinism source. The
`nat-static` / `nat-nptv6` topics iterate slices (`NAT.Static`,
`rs.Rules`) — already deterministic — and were correctly not cited; they
are left unchanged.

## Fix
Added a generic `sortedKeys[V any](map[string]V) []string` helper (collect
keys, `sort.Strings`, iterate) and routed all 12 map iterations through it.
Minimal and local to each loop — no handler restructuring.

Sites fixed (all in `pkg/api/show_text.go`):
- `schedulers` — `cfg.Schedulers`
- `snmp` — `Communities`, `TrapGroups`
- `dhcp-relay` — `ServerGroups`, `Groups`
- `firewall` — `FiltersInet` / `FiltersInet6` (via `printFilters`)
- `dynamic-address` — `FeedServers`
- `address-book` — `Addresses`, `AddressSets`
- `applications` — `Applications`, `ApplicationSets`
- `flow-monitoring` — v9 `Templates`

## Test
New `pkg/api/show_text_sorted_4712_test.go` stages multi-key maps in
scrambled insertion order for the `applications`, `address-book`, and
`snmp` topics, renders each topic 40× and asserts:
1. output is byte-identical across renders (determinism), and
2. entries appear in ascending key order (sorted contract).

Proven RED against both a reverse-sort and a raw map-range revert, GREEN
with the fix.

## Gates
- `gofmt -w` — clean
- `go build ./...` — clean
- `go test ./pkg/api/...` — green
- `go test ./...` — 52 ok / 3 no-test; sole FAIL is the pre-existing
  `pkg/ddns` RFC2136 `TestRFC2136UnsignedUpdateWarnsOncePerProvider`
  port-bind flake (`address already in use`), which passes in isolation
  and is unrelated — this change touches `pkg/api` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)