### PR TITLE
fix(config): reject dangling trailing negation in tcp-flags (fail-closed) (#4714)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-07-08 — #4714: reject dangling trailing negation in tcp-flags (fail-closed)
+
+- **Timestamp**: 2026-07-08
+  **Action**: #4714 — `ParseTCPFlagsExpression` in `pkg/config/tcp_flags.go`
+  tracked `pendingNeg` but never checked for a dangling `pendingNeg==true`
+  after the token loop, so a firewall-filter `tcp-flags` value whose `!` had
+  no flag operand parsed WITHOUT error and the negation was silently dropped —
+  a fail-open on the missing forbidden-flag constraint. Verified on
+  origin/master: `tcp-flags "!"` returned `(0,0,false,nil)` (no constraint at
+  all) and `"syn & !"` returned `(SYN,0,true,nil)` (trailing `!` dropped, term
+  now matches SYN with no ACK exclusion). The only caller is the #3076
+  commit-layer guard at `compiler_firewall.go:268` (→ `CompileConfig`), so the
+  malformed expression committed cleanly. Fix (fail-closed): reject a dangling
+  negation with a clear error naming the expression — added an `if pendingNeg`
+  guard after the token loop (catches trailing `!`, e.g. `"!"`, `"syn & !"`)
+  AND a `pendingNeg` check in the `&` case (catches a `!` immediately before a
+  separator with no operand, e.g. `"! & ack"`). Valid negations (`!ack`,
+  `syn & !ack`, `!syn & !ack`, `(syn & !ack)`) are unaffected. Double-negation
+  `!!` (even count → `pendingNeg` false) is out of #4714 scope and deliberately
+  not touched (not a fail-open — it cancels to the un-negated flag).
+  Tests: extended the `TestParseTCPFlagsExpression` table with three dangling
+  cases; added `TestParseTCPFlagsDanglingNegation` (5 reject + 7 accept
+  over-rejection guards asserting exact masks) and a commit-path assert in
+  `TestFirewallFilterTCPFlagsCommitReject`. RED-on-revert confirmed: stashing
+  the parser fix makes every new reject assertion FAIL. Validation: gofmt;
+  `go build ./...` clean; `go test ./pkg/config/...` green; FULL Go suite green
+  (53 packages ok, 0 FAIL).
+  **File(s)**: pkg/config/tcp_flags.go, pkg/config/tcp_flags_test.go, _Log.md
+
 ## 2026-07-08 — #4712: deterministic sorted iteration in show-text endpoints
 
 - **Timestamp**: 2026-07-08

--- a/pkg/config/tcp_flags.go
+++ b/pkg/config/tcp_flags.go
@@ -48,6 +48,10 @@ var tcpFlagBits = map[string]uint8{
 //     disjunction by De Morgan's law
 //   - an unrecognized flag token
 //   - a flag that is both required and forbidden (a contradiction)
+//   - a dangling negation '!' with no flag operand (e.g. "!", "syn & !",
+//     "! & ack") — the '!' would otherwise be silently dropped, weakening the
+//     term (#4714, fail-open); reject it so the operator's intent is never
+//     silently lost
 //
 // An input that carries no flag at all (empty / whitespace only) returns
 // ok=false with no error: the caller leaves the wire field nil, i.e. no
@@ -88,7 +92,14 @@ func ParseTCPFlagsExpression(parts []string) (required, forbidden uint8, ok bool
 	for _, t := range toks {
 		switch t {
 		case "&":
-			// A conjunction separator carries no negation across itself.
+			// A conjunction separator carries no negation across itself. A '!'
+			// standing immediately before the separator has no flag operand —
+			// that is a dangling negation (e.g. "! & ack"). Reject it rather
+			// than silently discarding the '!' (#4714, fail-open).
+			if pendingNeg {
+				return 0, 0, false, fmt.Errorf(
+					"tcp-flags %q: dangling negation \"!\" with no flag operand", expr)
+			}
 			pendingNeg = false
 			continue
 		case "|":
@@ -114,6 +125,15 @@ func ParseTCPFlagsExpression(parts []string) (required, forbidden uint8, ok bool
 			required |= bit
 		}
 		pendingNeg = false
+	}
+
+	// A negation left pending after the last token is a dangling '!' with no
+	// flag operand (e.g. "!", "syn & !"). Without this guard the trailing '!'
+	// is silently dropped and the term matches more than the operator intended
+	// (#4714, fail-open) — reject it so a malformed expression fails at commit.
+	if pendingNeg {
+		return 0, 0, false, fmt.Errorf(
+			"tcp-flags %q: dangling negation \"!\" with no flag operand", expr)
 	}
 
 	if required&forbidden != 0 {

--- a/pkg/config/tcp_flags_test.go
+++ b/pkg/config/tcp_flags_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseTCPFlagsExpression(t *testing.T) {
 	cases := []struct {
@@ -30,6 +33,11 @@ func TestParseTCPFlagsExpression(t *testing.T) {
 		{"unknown-flag", []string{"bogus"}, 0, 0, false, true},
 		{"unknown-in-list", []string{"syn", "bogus"}, 0, 0, false, true},
 		{"contradiction", []string{"syn & !syn"}, 0, 0, false, true},
+		// #4714: a dangling negation with no flag operand must be rejected
+		// (fail-closed) rather than silently dropped (fail-open).
+		{"dangling-neg-only", []string{"!"}, 0, 0, false, true},
+		{"dangling-neg-trailing", []string{"syn & !"}, 0, 0, false, true},
+		{"dangling-neg-before-sep", []string{"! & ack"}, 0, 0, false, true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -46,6 +54,68 @@ func TestParseTCPFlagsExpression(t *testing.T) {
 			if ok != c.ok || req != c.required || forb != c.forbidden {
 				t.Errorf("ParseTCPFlagsExpression(%v) = (req=0x%02x, forb=0x%02x, ok=%v), want (req=0x%02x, forb=0x%02x, ok=%v)",
 					c.in, req, forb, ok, c.required, c.forbidden, c.ok)
+			}
+		})
+	}
+}
+
+// TestParseTCPFlagsDanglingNegation is the #4714 RED-on-revert guard. A
+// tcp-flags expression whose '!' has no flag operand (a trailing '!', or a '!'
+// standing immediately before a '&' separator) must be REJECTED with an error
+// naming the malformed expression — otherwise the '!' is silently dropped and
+// the term matches more than intended (fail-open). Reverting the pendingNeg
+// guards in ParseTCPFlagsExpression makes these inputs parse cleanly and the
+// wantErr assertions below FAIL.
+func TestParseTCPFlagsDanglingNegation(t *testing.T) {
+	// Dangling negation → error naming the expression (fail-closed).
+	danglers := []struct {
+		name string
+		in   []string
+	}{
+		{"neg-only", []string{"!"}},
+		{"trailing-after-flag", []string{"syn & !"}},
+		{"trailing-space-list", []string{"syn ack !"}},
+		{"before-separator", []string{"! & ack"}},
+		{"neg-flag-then-dangling", []string{"!ack & !"}},
+	}
+	for _, d := range danglers {
+		t.Run("reject/"+d.name, func(t *testing.T) {
+			req, forb, ok, err := ParseTCPFlagsExpression(d.in)
+			if err == nil {
+				t.Fatalf("ParseTCPFlagsExpression(%v): expected dangling-negation error, got req=0x%02x forb=0x%02x ok=%v",
+					d.in, req, forb, ok)
+			}
+			if !strings.Contains(err.Error(), "dangling negation") {
+				t.Errorf("ParseTCPFlagsExpression(%v): error %q should name the dangling negation", d.in, err)
+			}
+		})
+	}
+
+	// Over-rejection guard: legitimate expressions — including valid negations —
+	// must still parse to the SAME masks as before the #4714 fix.
+	valid := []struct {
+		name      string
+		in        []string
+		required  uint8
+		forbidden uint8
+	}{
+		{"plain-flag", []string{"syn"}, 0x02, 0},
+		{"conjunction", []string{"syn & ack"}, 0x12, 0},
+		{"neg-flag", []string{"!ack"}, 0, 0x10},
+		{"syn-not-ack", []string{"syn & !ack"}, 0x02, 0x10},
+		{"paren-syn-not-ack", []string{"(syn & !ack)"}, 0x02, 0x10},
+		{"two-negations", []string{"!syn & !ack"}, 0, 0x12},
+		{"space-list", []string{"syn ack"}, 0x12, 0},
+	}
+	for _, v := range valid {
+		t.Run("accept/"+v.name, func(t *testing.T) {
+			req, forb, ok, err := ParseTCPFlagsExpression(v.in)
+			if err != nil {
+				t.Fatalf("ParseTCPFlagsExpression(%v): unexpected error (over-rejection): %v", v.in, err)
+			}
+			if !ok || req != v.required || forb != v.forbidden {
+				t.Errorf("ParseTCPFlagsExpression(%v) = (req=0x%02x, forb=0x%02x, ok=%v), want (req=0x%02x, forb=0x%02x, ok=true)",
+					v.in, req, forb, ok, v.required, v.forbidden)
 			}
 		})
 	}
@@ -87,5 +157,10 @@ func TestFirewallFilterTCPFlagsCommitReject(t *testing.T) {
 	// An unknown flag is rejected at commit.
 	if _, err := build("bogus"); err == nil {
 		t.Error("tcp-flags \"bogus\" should be rejected at commit (fail-closed), but compiled")
+	}
+	// #4714: a dangling trailing negation must be rejected at commit rather
+	// than committing with the '!' silently dropped (fail-open).
+	if _, err := build("syn & !"); err == nil {
+		t.Error("tcp-flags \"syn & !\" (dangling negation) should be rejected at commit (fail-closed), but compiled")
 	}
 }


### PR DESCRIPTION
Closes #4714

## Verify-first (what was accepted before)
`ParseTCPFlagsExpression` (`pkg/config/tcp_flags.go`) lexes a firewall-filter
`tcp-flags` expression and tracks `pendingNeg` for a `!` operator, but after the
token loop it only checked `required&forbidden != 0` and `required==0 &&
forbidden==0` — there was **no `if pendingNeg` guard**. A `!` with no flag
operand therefore parsed without error and the negation was silently dropped.

Confirmed on origin/master (`6fa5ab0c6`):

| input | returned | effect |
|-------|----------|--------|
| `tcp-flags "!"` | `(required=0, forbidden=0, ok=false, err=nil)` | no constraint at all |
| `tcp-flags "syn & !"` | `(required=SYN, forbidden=0, ok=true, err=nil)` | trailing `!` dropped — term now matches SYN with **no** ACK exclusion |

The **sole caller** is the #3076 commit-layer guard in `compileFirewall`
(`compiler_firewall.go:268` → `CompileConfig`), so the malformed expression
committed cleanly instead of being rejected — a **fail-open** on a
security-policy input (the intended negated-flag constraint is lost with no
commit error).

## Fix (fail-closed)
Reject a dangling negation with a clear error naming the expression:

- **After the token loop**: `if pendingNeg { return …"dangling negation \"!\" with no flag operand" }` — catches a trailing `!` (`"!"`, `"syn & !"`).
- **In the `&` case**: the same check before resetting `pendingNeg` — catches a `!` standing immediately before a separator with no operand (`"! & ack"`, `"!ack & !"`).

Valid negations are unchanged: `!ack`, `syn & !ack`, `!syn & !ack`,
`(syn & !ack)` all parse to the same masks as before. Double-negation `!!`
(even count → `pendingNeg` ends false) is deliberately **out of scope** — it
cancels to the un-negated flag and is not a fail-open.

## RED-on-revert + over-rejection guard
- `TestParseTCPFlagsExpression`: +3 dangling cases (`"!"`, `"syn & !"`, `"! & ack"`) → expect error.
- `TestParseTCPFlagsDanglingNegation` (new): **5 reject** cases (assert the error names the "dangling negation") + **7 accept** cases that assert the exact `required`/`forbidden` masks for legitimate expressions incl. negations — the over-rejection guard.
- `TestFirewallFilterTCPFlagsCommitReject`: +assert that `tcp-flags "syn & !"` is rejected at **commit**.

RED-on-revert proven: stashing only the parser fix (tests present) makes every
new reject assertion FAIL, e.g.:
```
ParseTCPFlagsExpression([syn & !]): expected error, got req=0x02 forb=0x00 ok=true
tcp-flags "syn & !" (dangling negation) should be rejected at commit (fail-closed), but compiled
```
Restoring the fix → all green. The 7 accept-cases pass with and without the fix
(guarding against over-rejection).

## Gates
- `gofmt -l` clean.
- `go build ./...` clean.
- `go test ./pkg/config/...` → ok.
- Full `go test ./...` → **53 packages ok, 0 FAIL** (pre-existing pkg/ddns RFC2136 bind flake did not trigger this run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi