### PR TITLE
fix(api): report current CPU utilization, not since-boot average (#4707)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-09 — #4707: report current CPU utilization, not since-boot average
+
+- **Timestamp**: 2026-07-09
+- **Action**: OBSERVABILITY fix. The Prometheus system collector read the
+  cumulative `/proc/stat` aggregate-cpu ticks once per scrape and exported
+  `(user+nice)/total*100*cpus` and `system/total*100*cpus` as `GaugeValue`
+  with no previous-tick state, so both gauges reported a since-boot lifetime
+  AVERAGE that barely moves as uptime grows — a real CPU spike at hour 100 was
+  invisible and load alarms silently never fired. The inline comment even
+  mislabeled it "instantaneous snapshot". Fix (metrics_system.go): persist the
+  prior aggregate-cpu sample on the collector (`cpuSamplePrev`/`cpuSampleValid`
+  in metrics.go, guarded by the existing `c.mu` because Collect can run
+  concurrently for parallel scrapers — same pattern as the fairness-throughput
+  window) and report the inter-scrape delta `(busyΔ/totalΔ)`. Refactored the
+  `/proc/stat` reading behind a seam: `parseProcStatCPU(line)` parses the
+  aggregate line into a `cpuSample{userNice,system,total}`; `cpuUtilization`
+  computes the delta and skips (ok=false) when totals did not advance or a
+  counter went backwards (suspend/hotplug reset); `updateCPUUtilization` folds
+  a sample into collector state and returns emit=false on the FIRST scrape (no
+  predecessor) so no bogus value is published. Updated the two metric help
+  strings (metrics_descriptors.go) to say "over the last scrape interval".
+  Tests (metrics_cpu_current_4707_test.go): parse coverage (full/short/per-core
+  reject), a RED-on-revert delta guard (busy-at-boot-then-idle fixture: delta
+  =10%/2% but cumulative =79.3% — reverting to the since-boot form makes the
+  test FAIL, verified empirically), first-sample-skip handling, and the
+  no-advance/backwards/zero-cpu guards. Validation: gofmt; `go build ./...`
+  clean; `go test ./pkg/api/...` green; FULL Go suite green (53 ok / 0 FAIL /
+  3 no-test).
+  **File(s)**: pkg/api/metrics.go, pkg/api/metrics_system.go,
+  pkg/api/metrics_descriptors.go, pkg/api/metrics_cpu_current_4707_test.go,
+  _Log.md
+
 ## 2026-07-08 — #4705: resolve master-password across ALL system stanzas (no plaintext DB leak)
 
 - **Timestamp**: 2026-07-08

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -155,6 +155,19 @@ type xpfCollector struct {
 	daemonUptime *prometheus.Desc
 	daemonMemRSS *prometheus.Desc
 
+	// #4707: previous /proc/stat aggregate-cpu tick sample, used to compute
+	// the inter-scrape CPU-utilization delta. The pre-#4707 collector divided
+	// cumulative-since-boot busy ticks by cumulative total ticks and exported
+	// the ratio as a gauge — a lifetime average that barely moves as uptime
+	// grows, so a real CPU spike at hour 100 was invisible and load alarms
+	// silently never fired. We now persist the prior sample and report
+	// (busyΔ/totalΔ) between consecutive scrapes (the idiomatic Prometheus
+	// approach). Guarded by c.mu because Collect can run concurrently for
+	// parallel scrapers. cpuSampleValid is false until the first scrape has
+	// stored a predecessor, so no CPU gauge is emitted that first round.
+	cpuSamplePrev  cpuSample
+	cpuSampleValid bool
+
 	// #1780: per-phase age of the Go periodic neighbor-maintenance loop.
 	neighborPeriodicAge *prometheus.Desc
 	frrReloadDegraded   *prometheus.Desc

--- a/pkg/api/metrics_cpu_current_4707_test.go
+++ b/pkg/api/metrics_cpu_current_4707_test.go
@@ -1,0 +1,138 @@
+package api
+
+import "testing"
+
+// TestParseProcStatCPU verifies the aggregate "cpu " line parses into the
+// busy/total tick components the delta computation needs.
+func TestParseProcStatCPU(t *testing.T) {
+	// cpu user nice system idle iowait irq softirq steal
+	got, ok := parseProcStatCPU("cpu 100 5 30 800 10 3 2 0 0 0")
+	if !ok {
+		t.Fatal("parseProcStatCPU returned ok=false for a valid cpu line")
+	}
+	if got.userNice != 105 { // user 100 + nice 5
+		t.Errorf("userNice = %v, want 105", got.userNice)
+	}
+	if got.system != 30 {
+		t.Errorf("system = %v, want 30", got.system)
+	}
+	// total = user+nice+system+idle+iowait+irq+softirq+steal
+	if got.total != 950 {
+		t.Errorf("total = %v, want 950", got.total)
+	}
+
+	// Older-kernel short line (no iowait/irq/softirq/steal).
+	short, ok := parseProcStatCPU("cpu 100 5 30 800")
+	if !ok {
+		t.Fatal("parseProcStatCPU returned ok=false for a short cpu line")
+	}
+	if short.total != 935 { // 100+5+30+800
+		t.Errorf("short.total = %v, want 935", short.total)
+	}
+
+	// A per-core "cpu0 ..." line or non-cpu line must be rejected so the
+	// aggregate scan never folds a per-core row into the aggregate.
+	if _, ok := parseProcStatCPU("cpu0 1 2 3 4 5 6 7 8"); ok {
+		t.Error("parseProcStatCPU accepted a per-core cpu0 line")
+	}
+	if _, ok := parseProcStatCPU("intr 12345"); ok {
+		t.Error("parseProcStatCPU accepted a non-cpu line")
+	}
+}
+
+// TestCPUUtilizationIsDeltaNotCumulative is the core #4707 regression guard.
+//
+// Scenario: the box was hammered at boot then went idle. The cumulative
+// since-boot ratio (the pre-#4707 formula, cur.busy/cur.total) still reports
+// ~89% busy, but the CURRENT utilization between the two scrapes is only 12%.
+// The metric must report the delta, not the cumulative average.
+//
+// RED-on-revert: reverting updateCPUUtilization to the cumulative form
+//
+//	userPct = cur.userNice / cur.total * 100 * cpus  // 8010/10100 = 79.3...
+//
+// yields ~79.3, not 10.0, so the equality assertions below FAIL — proving the
+// test actually pins the delta behavior and would catch a regression.
+func TestCPUUtilizationIsDeltaNotCumulative(t *testing.T) {
+	const cpus = 1.0
+
+	// T1: boot burst — mostly busy. busy = 9000 of 10000 total.
+	prev := cpuSample{userNice: 8000, system: 1000, total: 10000}
+	// T2: 100 more ticks elapsed, almost all idle. Only 12 busy ticks added
+	// (10 user+nice, 2 system) out of 100 total ticks in the interval.
+	cur := cpuSample{userNice: 8010, system: 1002, total: 10100}
+
+	userPct, systemPct, ok := cpuUtilization(prev, cur, cpus)
+	if !ok {
+		t.Fatal("cpuUtilization returned ok=false for advancing counters")
+	}
+
+	// Delta: dUserNice=10, dSystem=2, dTotal=100 -> 10% and 2%.
+	if userPct != 10.0 {
+		t.Errorf("delta userPct = %v, want 10.0", userPct)
+	}
+	if systemPct != 2.0 {
+		t.Errorf("delta systemPct = %v, want 2.0", systemPct)
+	}
+
+	// Explicitly prove the delta diverges from the (buggy) cumulative form so
+	// a silent revert to since-boot averaging cannot pass this test.
+	cumulativeUser := cur.userNice / cur.total * 100 * cpus // ~79.3
+	if cumulativeUser == userPct {
+		t.Fatalf("cumulative (%v) must differ from delta (%v) for this fixture "+
+			"to guard against a revert", cumulativeUser, userPct)
+	}
+	// The stale cumulative average (~79%) must be far above the true current
+	// utilization (10%) — that gap is exactly the #4707 bug this test pins.
+	if cumulativeUser < 70 {
+		t.Errorf("fixture sanity: cumulative user should be ~79%%, got %v", cumulativeUser)
+	}
+}
+
+// TestUpdateCPUUtilizationFirstSampleSkips verifies first-scrape handling: with
+// no predecessor sample the collector emits nothing (emit=false) rather than a
+// bogus value, and the SECOND scrape reports the delta against the first.
+func TestUpdateCPUUtilizationFirstSampleSkips(t *testing.T) {
+	c := &xpfCollector{} // zero value usable; cpuSampleValid starts false
+
+	first := cpuSample{userNice: 8000, system: 1000, total: 10000}
+	if _, _, emit := c.updateCPUUtilization(first, 1.0); emit {
+		t.Fatal("first scrape must not emit a CPU sample (no predecessor)")
+	}
+	if !c.cpuSampleValid {
+		t.Fatal("first scrape must record the sample as the predecessor")
+	}
+
+	second := cpuSample{userNice: 8010, system: 1002, total: 10100}
+	userPct, systemPct, emit := c.updateCPUUtilization(second, 1.0)
+	if !emit {
+		t.Fatal("second scrape must emit the inter-scrape delta")
+	}
+	if userPct != 10.0 || systemPct != 2.0 {
+		t.Errorf("second scrape delta = (%v, %v), want (10, 2)", userPct, systemPct)
+	}
+}
+
+// TestCPUUtilizationNoAdvanceOrBackwards verifies the guard against emitting
+// bogus values when counters don't advance or go backwards (e.g. a counter
+// reset after suspend/hotplug), which would otherwise divide by <= 0.
+func TestCPUUtilizationNoAdvanceOrBackwards(t *testing.T) {
+	s := cpuSample{userNice: 8000, system: 1000, total: 10000}
+
+	// Identical samples: no elapsed ticks -> skip.
+	if _, _, ok := cpuUtilization(s, s, 1.0); ok {
+		t.Error("cpuUtilization must skip when totals did not advance")
+	}
+
+	// Counters went backwards (reset): skip rather than emit a negative %.
+	back := cpuSample{userNice: 10, system: 5, total: 100}
+	if _, _, ok := cpuUtilization(s, back, 1.0); ok {
+		t.Error("cpuUtilization must skip when counters went backwards")
+	}
+
+	// Zero CPUs -> skip (avoids nonsense scaling).
+	next := cpuSample{userNice: 8010, system: 1002, total: 10100}
+	if _, _, ok := cpuUtilization(s, next, 0); ok {
+		t.Error("cpuUtilization must skip when cpus <= 0")
+	}
+}

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -423,12 +423,18 @@ func newCollector(srv *Server) *xpfCollector {
 
 		sysCPUUser: prometheus.NewDesc(
 			"xpf_system_cpu_user_percent",
-			"User CPU utilization percentage.",
+			// #4707: inter-scrape delta (busyΔ/totalΔ), scaled by CPU count,
+			// NOT the since-boot cumulative average. Not emitted on the first
+			// scrape (no predecessor sample yet).
+			"User+nice CPU utilization percentage over the last scrape interval "+
+				"(summed across CPUs).",
 			nil, nil,
 		),
 		sysCPUSystem: prometheus.NewDesc(
 			"xpf_system_cpu_system_percent",
-			"System CPU utilization percentage.",
+			// #4707: inter-scrape delta (busyΔ/totalΔ), scaled by CPU count.
+			"System CPU utilization percentage over the last scrape interval "+
+				"(summed across CPUs).",
 			nil, nil,
 		),
 		sysMemTotal: prometheus.NewDesc(

--- a/pkg/api/metrics_system.go
+++ b/pkg/api/metrics_system.go
@@ -310,42 +310,101 @@ func (c *xpfCollector) collectSystemMetrics(ch chan<- prometheus.Metric) {
 		}
 	}
 
-	// CPU usage from /proc/stat (instantaneous snapshot)
+	// CPU usage from /proc/stat: report the inter-scrape delta, NOT the
+	// since-boot cumulative average (#4707). The counters in /proc/stat are
+	// monotonic-since-boot, so dividing them directly yields a lifetime
+	// average that barely moves once uptime is high. c.updateCPUUtilization
+	// folds this sample into the collector's running state and returns the
+	// (busyΔ/totalΔ) utilization to emit; it reports emit=false on the first
+	// scrape (no predecessor) so no bogus value is published.
 	if f, err := os.Open("/proc/stat"); err == nil {
 		defer f.Close()
 		scanner := bufio.NewScanner(f)
 		if scanner.Scan() {
-			line := scanner.Text()
-			if strings.HasPrefix(line, "cpu ") {
-				fields := strings.Fields(line)
-				// fields: cpu user nice system idle iowait irq softirq steal
-				if len(fields) >= 5 {
-					user, _ := strconv.ParseFloat(fields[1], 64)
-					nice, _ := strconv.ParseFloat(fields[2], 64)
-					system, _ := strconv.ParseFloat(fields[3], 64)
-					idle, _ := strconv.ParseFloat(fields[4], 64)
-					iowait := 0.0
-					if len(fields) >= 6 {
-						iowait, _ = strconv.ParseFloat(fields[5], 64)
-					}
-					total := user + nice + system + idle + iowait
-					if len(fields) >= 9 {
-						irq, _ := strconv.ParseFloat(fields[6], 64)
-						softirq, _ := strconv.ParseFloat(fields[7], 64)
-						steal, _ := strconv.ParseFloat(fields[8], 64)
-						total += irq + softirq + steal
-					}
-					cpus := float64(runtime.NumCPU())
-					if total > 0 && cpus > 0 {
-						ch <- prometheus.MustNewConstMetric(c.sysCPUUser, prometheus.GaugeValue,
-							(user+nice)/total*100*cpus)
-						ch <- prometheus.MustNewConstMetric(c.sysCPUSystem, prometheus.GaugeValue,
-							system/total*100*cpus)
-					}
+			if cur, ok := parseProcStatCPU(scanner.Text()); ok {
+				if userPct, systemPct, emit := c.updateCPUUtilization(cur, float64(runtime.NumCPU())); emit {
+					ch <- prometheus.MustNewConstMetric(c.sysCPUUser, prometheus.GaugeValue, userPct)
+					ch <- prometheus.MustNewConstMetric(c.sysCPUSystem, prometheus.GaugeValue, systemPct)
 				}
 			}
 		}
 	}
+}
+
+// cpuSample holds the cumulative /proc/stat CPU tick counters needed to
+// compute inter-scrape utilization deltas (#4707). userNice and system are the
+// busy components exported as separate gauges; total is the sum of all tick
+// fields (busy + idle + iowait + irq/softirq/steal).
+type cpuSample struct {
+	userNice float64
+	system   float64
+	total    float64
+}
+
+// parseProcStatCPU parses the aggregate "cpu " line from /proc/stat into a
+// cpuSample. It returns ok=false when the line is not a valid aggregate cpu
+// line. Field order: cpu user nice system idle iowait irq softirq steal ...
+// iowait/irq/softirq/steal may be absent on older kernels and default to 0.
+func parseProcStatCPU(line string) (cpuSample, bool) {
+	if !strings.HasPrefix(line, "cpu ") {
+		return cpuSample{}, false
+	}
+	fields := strings.Fields(line)
+	if len(fields) < 5 {
+		return cpuSample{}, false
+	}
+	user, _ := strconv.ParseFloat(fields[1], 64)
+	nice, _ := strconv.ParseFloat(fields[2], 64)
+	system, _ := strconv.ParseFloat(fields[3], 64)
+	idle, _ := strconv.ParseFloat(fields[4], 64)
+	total := user + nice + system + idle
+	if len(fields) >= 6 {
+		iowait, _ := strconv.ParseFloat(fields[5], 64)
+		total += iowait
+	}
+	if len(fields) >= 9 {
+		irq, _ := strconv.ParseFloat(fields[6], 64)
+		softirq, _ := strconv.ParseFloat(fields[7], 64)
+		steal, _ := strconv.ParseFloat(fields[8], 64)
+		total += irq + softirq + steal
+	}
+	return cpuSample{userNice: user + nice, system: system, total: total}, true
+}
+
+// cpuUtilization computes the per-mode utilization percentages between two
+// cumulative samples, scaled by the number of CPUs (matching the historical
+// "percent of one CPU summed across cores" gauge scale). It returns ok=false
+// when the totals did not advance (no elapsed ticks) or any busy counter went
+// backwards (counter reset after suspend/hotplug), so the caller skips a bogus
+// sample. This is the #4707 delta — NOT cur.userNice/cur.total (the reverted
+// cumulative form yields a stale since-boot average).
+func cpuUtilization(prev, cur cpuSample, cpus float64) (userPct, systemPct float64, ok bool) {
+	dTotal := cur.total - prev.total
+	dUserNice := cur.userNice - prev.userNice
+	dSystem := cur.system - prev.system
+	if dTotal <= 0 || cpus <= 0 || dUserNice < 0 || dSystem < 0 {
+		return 0, 0, false
+	}
+	return dUserNice / dTotal * 100 * cpus, dSystem / dTotal * 100 * cpus, true
+}
+
+// updateCPUUtilization folds a fresh /proc/stat cpu sample into the collector's
+// running state and returns the inter-scrape utilization to emit (#4707). emit
+// is false on the first sample (no predecessor) or when the counters did not
+// advance, so the caller emits nothing rather than a bogus since-boot average.
+// Guarded by c.mu because Collect can run concurrently for parallel scrapers.
+func (c *xpfCollector) updateCPUUtilization(cur cpuSample, cpus float64) (userPct, systemPct float64, emit bool) {
+	c.mu.Lock()
+	prev := c.cpuSamplePrev
+	havePrev := c.cpuSampleValid
+	c.cpuSamplePrev = cur
+	c.cpuSampleValid = true
+	c.mu.Unlock()
+
+	if !havePrev {
+		return 0, 0, false
+	}
+	return cpuUtilization(prev, cur, cpus)
 }
 
 // parseMemInfoKB extracts the numeric kB value from a /proc/meminfo line.


### PR DESCRIPTION
Closes #4707

## The bug
`pkg/api/metrics_system.go` read the cumulative `/proc/stat` aggregate-cpu
ticks once per scrape and exported them as **gauges** with no previous-tick
state:

```go
// BEFORE (since-boot cumulative average, exported as a "current" gauge)
total := user + nice + system + idle + iowait (+irq+softirq+steal)
sysCPUUser   = (user+nice)/total*100*cpus
sysCPUSystem =  system    /total*100*cpus
```

Because the counters are monotonic-since-boot, that ratio is a **lifetime
average** — it barely moves as uptime grows. A firewall hammered at boot but
idle now still reports high CPU (and vice-versa), so real CPU spikes are
invisible and load alarms silently never fire. The inline comment even
mislabeled it an "instantaneous snapshot". (From gemini-review-041 Medium-13.)

## The fix — inter-scrape delta
Persist the prior aggregate-cpu sample on the collector and report the delta
`(busyΔ / totalΔ)` between consecutive scrapes — the idiomatic Prometheus form
for a gauge implying "current":

```go
// AFTER
delta userPct   = (cur.userNice - prev.userNice) / (cur.total - prev.total) * 100 * cpus
delta systemPct = (cur.system   - prev.system)   / (cur.total - prev.total) * 100 * cpus
```

The `/proc/stat` reading is refactored behind a small seam so the delta logic
is unit-testable without touching `/proc`:

- `parseProcStatCPU(line)` → `cpuSample{userNice, system, total}`; rejects
  per-core `cpuN`/non-cpu lines; tolerates short older-kernel lines.
- `cpuUtilization(prev, cur, cpus)` → per-mode delta %, `ok=false` when totals
  did not advance or a counter went backwards (suspend/hotplug reset) so no
  bogus/negative value is emitted.
- `updateCPUUtilization` folds a sample into collector state and returns
  `emit=false` on the **first** scrape (no predecessor) → nothing published
  that round instead of a bogus 100%.

## Concurrency
New `cpuSamplePrev` / `cpuSampleValid` fields live on the collector and are
guarded by its existing `c.mu`, taken only for the brief read-swap in
`updateCPUUtilization`. Prometheus can call `Collect` concurrently for parallel
scrapers; this mirrors the existing `c.mu`-guarded fairness-throughput window.
The collector is a registered singleton (`newCollector` in `server.go`), so the
prior sample persists across scrapes.

Metric help strings updated to say "over the last scrape interval (summed
across CPUs)".

## Test — RED-on-revert proven
`pkg/api/metrics_cpu_current_4707_test.go`:

- **`TestCPUUtilizationIsDeltaNotCumulative`** — busy-at-boot-then-idle
  fixture: T1 busy=9000/10000, T2 adds only 12 busy of 100 total ticks. The
  **delta** is 10% user / 2% system; the **cumulative** since-boot form is
  ~79%. The test asserts the delta values, so reverting `updateCPUUtilization`
  to `cur.busy/cur.total` reports ~79% → **test FAILS** (verified empirically:
  reverted the return line and the test went RED with `delta userPct =
  79.30..., want 10.0`, then restored → green).
- **`TestUpdateCPUUtilizationFirstSampleSkips`** — first scrape emits nothing;
  second scrape emits the delta against the first.
- **`TestParseProcStatCPU`** — full/short/per-core-reject parse coverage.
- **`TestCPUUtilizationNoAdvanceOrBackwards`** — no-advance, counters-backwards,
  and zero-cpu all skip.

## Gates
- `gofmt -w` on all touched files
- `go build ./...` — clean
- `go test ./pkg/api/...` — green
- full Go suite — **53 ok / 0 FAIL / 3 no-test** (the pre-existing
  `pkg/ddns TestRFC2136...` "address already in use" flake is unrelated and did
  not occur here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi