### PR TITLE
fix(upgrade): surface RejoinAndConfirm PeerAlive/SyncEstablished errors instead of discarding (#4717)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -42896,3 +42896,21 @@ top.
   Validation: gofmt; go vet; new test PASS (2 subtests); touched packages
   (cmd/cli, pkg/config, pkg/policymatch) green; FULL Go suite green.
   **File(s)**: pkg/policymatch/reject_matrix_4422_test.go, _Log.md
+
+## 2026-07-09 — #4717 RejoinAndConfirm surface PeerAlive/SyncEstablished errors
+- **Timestamp**: 2026-07-09
+- **Action**: Fix — RejoinAndConfirm discarded the `aerr`/`serr` captured from
+  PeerAlive/SyncEstablished each poll; on deadline it formatted only the
+  alive/synced booleans, losing the transport/gRPC cause. Now retains the last
+  non-nil error from each predicate and wraps them (naming which check failed)
+  into the timeout error. Happy path unchanged (both checks pass → nil). Mirrors
+  DrainAndConfirm's existing timeout, which already wraps the last DrainComplete
+  error. Diagnostics-only; no control-flow/abort change.
+- **Edit**: pkg/upgrade/kernel_drain.go (surface last aerr/serr in timeout error)
+- **Edit**: pkg/upgrade/rolling_test.go (fakeCluster peerAliveErr/syncErr seams)
+- **Edit**: pkg/upgrade/kernel_drain_test.go (RED-on-revert: surfacing tests for
+  SyncEstablished + PeerAlive failures; success-path guard)
+- **Edit**: docs/in-place-upgrade.md (rejoin diagnostics note)
+- **Validation**: go build ./... clean; go test ./pkg/upgrade/ -count=1 ok;
+  full `go test ./...` green; RED-on-revert verified (both surfacing tests FAIL
+  when kernel_drain.go reverted, success guard still PASS).

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -619,6 +619,16 @@ until `status` reports `promoted=<ver>` AND `uname -r` matches, then
 A reverted node boots the OLD kernel and reports `promoted!=<ver>` → the
 driver STOPS and never touches the peer (never-both-down).
 
+If `rejoin` cannot confirm within its deadline, `RejoinAndConfirm`
+(`pkg/upgrade/kernel_drain.go`) now surfaces the last non-nil
+`PeerAlive`/`SyncEstablished` transport error in the returned error —
+naming which check failed — instead of printing only the alive/synced
+booleans (#4717). So an operator whose rejoin stalls on a refused gRPC
+dial (xpfd still restarting) sees the actual cause in the `xpfd upgrade
+kernel rejoin` stderr rather than having to correlate syslog. This is
+diagnostics only: the happy path is unchanged and a failed rejoin
+already STOPPED the roll before touching the peer.
+
 Three independent safety nets keep an UNVERIFIED candidate from ever
 carrying traffic:
 

--- a/pkg/upgrade/kernel_drain.go
+++ b/pkg/upgrade/kernel_drain.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -119,15 +120,40 @@ func RejoinAndConfirm(cl RollingCluster, deadline time.Duration) error {
 	// Confirm the peer is still a healthy member and sync is re-established —
 	// i.e. the cluster is whole again — before declaring the rejoin done.
 	dl := time.Now().Add(deadline)
+	// Retain the last non-nil transport/gRPC error from each predicate so a
+	// deadline miss reports WHY the rejoin never confirmed, not just the
+	// alive/synced booleans (gemini-review-041 Low-2, #4717). Without this an
+	// operator sees only "peer-alive=false sync-established=false" and must dig
+	// through syslog to learn it was e.g. a refused gRPC dial while xpfd was
+	// still restarting. Mirrors DrainAndConfirm's timeout, which already wraps
+	// the last DrainComplete error.
+	var lastAErr, lastSErr error
 	for {
 		alive, aerr := cl.PeerAlive()
 		synced, serr := cl.SyncEstablished()
 		if aerr == nil && serr == nil && alive && synced {
 			return nil
 		}
+		if aerr != nil {
+			lastAErr = aerr
+		}
+		if serr != nil {
+			lastSErr = serr
+		}
 		if time.Now().After(dl) {
-			return fmt.Errorf("rejoin not confirmed within %s "+
+			base := fmt.Errorf("rejoin not confirmed within %s "+
 				"(peer-alive=%v sync-established=%v)", deadline, alive, synced)
+			var details []string
+			if lastAErr != nil {
+				details = append(details, fmt.Sprintf("last peer-alive error: %v", lastAErr))
+			}
+			if lastSErr != nil {
+				details = append(details, fmt.Sprintf("last sync-established error: %v", lastSErr))
+			}
+			if len(details) > 0 {
+				return fmt.Errorf("%w; %s", base, strings.Join(details, "; "))
+			}
+			return base
 		}
 		sleepBounded(dl)
 	}

--- a/pkg/upgrade/kernel_drain_test.go
+++ b/pkg/upgrade/kernel_drain_test.go
@@ -1,6 +1,8 @@
 package upgrade
 
 import (
+	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -95,5 +97,55 @@ func TestRejoinAndConfirmTimesOutOnNoSync(t *testing.T) {
 	}
 	if !f.resetCalled {
 		t.Fatal("ResetFailover should still have been attempted")
+	}
+}
+
+// #4717: on a deadline miss driven by a failing SyncEstablished check, the
+// returned error must SURFACE the underlying transport/gRPC error (naming which
+// check failed) — not discard it and print only the synced=false boolean.
+// Reverting to the discarded-error code makes this assertion fail (RED-on-revert):
+// the error then contains neither "sync-established error" nor the wrapped cause.
+func TestRejoinAndConfirmSurfacesSyncError(t *testing.T) {
+	wantCause := errors.New("dial xpfd gRPC 127.0.0.1:50051: connection refused")
+	f := &fakeCluster{peerAlive: true, synced: true, syncErr: wantCause}
+	err := RejoinAndConfirm(f, 30*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error when SyncEstablished keeps failing")
+	}
+	if !strings.Contains(err.Error(), "sync-established error") {
+		t.Fatalf("timeout error must name the failed SyncEstablished check; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), wantCause.Error()) {
+		t.Fatalf("timeout error must surface the underlying SyncEstablished cause; got: %v", err)
+	}
+	if !f.resetCalled {
+		t.Fatal("ResetFailover should still have been attempted")
+	}
+}
+
+// #4717: the same surfacing must apply to a failing PeerAlive check — the error
+// names the peer-alive check and carries its underlying cause instead of only
+// reporting peer-alive=false. RED-on-revert: the discarded-error code drops it.
+func TestRejoinAndConfirmSurfacesPeerAliveError(t *testing.T) {
+	wantCause := errors.New("dial xpfd gRPC 127.0.0.1:50051: connection refused")
+	f := &fakeCluster{peerAlive: false, synced: true, peerAliveErr: wantCause}
+	err := RejoinAndConfirm(f, 30*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error when PeerAlive keeps failing")
+	}
+	if !strings.Contains(err.Error(), "peer-alive error") {
+		t.Fatalf("timeout error must name the failed PeerAlive check; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), wantCause.Error()) {
+		t.Fatalf("timeout error must surface the underlying PeerAlive cause; got: %v", err)
+	}
+}
+
+// #4717 guard: the SUCCESS path is unchanged — both checks pass -> nil, with no
+// spurious error text. Protects the happy path from the surfacing change.
+func TestRejoinAndConfirmSuccessUnchanged(t *testing.T) {
+	f := &fakeCluster{peerAlive: true, synced: true}
+	if err := RejoinAndConfirm(f, 5*time.Second); err != nil {
+		t.Fatalf("successful rejoin must return nil unchanged; got: %v", err)
 	}
 }

--- a/pkg/upgrade/rolling_test.go
+++ b/pkg/upgrade/rolling_test.go
@@ -22,11 +22,18 @@ type fakeCluster struct {
 	syncPolls    int
 	forced       bool
 	resetCalled  bool
+	// #4717 test seams: when set, the predicate returns this error on EVERY
+	// poll (persistent transport failure), so a deadline miss must surface it.
+	peerAliveErr error
+	syncErr      error
 }
 
-func (f *fakeCluster) PeerAlive() (bool, error) { return f.peerAlive, nil }
+func (f *fakeCluster) PeerAlive() (bool, error) { return f.peerAlive, f.peerAliveErr }
 func (f *fakeCluster) SyncEstablished() (bool, error) {
 	f.syncPolls++
+	if f.syncErr != nil {
+		return false, f.syncErr
+	}
 	// Poll #1 is the PRE-cut precondition check (daemon up) — always OK.
 	// Polls #2..#(1+syncErrPolls) model the POST-cut gRPC-startup gap: the
 	// local socket refuses connections while xpfd restarts. After that the


### PR DESCRIPTION
Closes #4717

## Problem — discarded-error sites
`RejoinAndConfirm` (`pkg/upgrade/kernel_drain.go`) captures `aerr` from
`cl.PeerAlive()` and `serr` from `cl.SyncEstablished()` on every poll, but on a
deadline miss it returned:

```go
return fmt.Errorf("rejoin not confirmed within %s "+
    "(peer-alive=%v sync-established=%v)", deadline, alive, synced)
```

— formatting only the `alive`/`synced` booleans and **discarding** `aerr`/`serr`.
During an ISSU / kernel-roll rejoin, the transport/gRPC cause (e.g. a refused
gRPC dial while xpfd is still restarting) was lost; an operator saw only
`peer-alive=false sync-established=false` and had to correlate syslog to learn
why. (gemini-review-041 Low-2, verified GENUINE, severity Low — observability.)

## Fix — how the errors are now surfaced
Retain the **last non-nil** error from each predicate and wrap it into the
timeout error, **naming which check failed**:

```
rejoin not confirmed within 30ms (peer-alive=true sync-established=false); last sync-established error: dial xpfd gRPC 127.0.0.1:50051: connection refused
```

The base error string is unchanged (existing callers/tests still match); the
underlying cause(s) are appended. This mirrors `DrainAndConfirm`'s timeout in the
same file, which already wraps the last `DrainComplete` error.

## Caller-behavior analysis — happy path preserved, only failure made observable
- **Sole production caller:** `cmd/xpfd/upgrade_kernel.go` (`upgrade kernel rejoin`)
  — on error it prints to stderr and `os.Exit(1)`; on success prints
  `rejoined ...`. The error was already surfaced to the operator; this change
  only enriches its content.
- **No control-flow change.** The function already returned an error on timeout
  and the caller already treated it as fatal. A failed rejoin already STOPPED the
  roll before touching the peer (never-both-down). No new abort is introduced —
  the failure is merely made **observable** instead of silently swallowed.
- **Happy path exact:** `aerr == nil && serr == nil && alive && synced` still
  returns `nil` unchanged. No per-poll logging added (diagnostics live only in
  the terminal error), consistent with `pkg/upgrade`'s no-logger convention.

## Tests — RED-on-revert
- `TestRejoinAndConfirmSurfacesSyncError` — persistent `SyncEstablished` failure
  → asserts the timeout error **names** the sync-established check and **carries**
  the underlying cause.
- `TestRejoinAndConfirmSurfacesPeerAliveError` — persistent `PeerAlive` failure
  → asserts the same for the peer-alive check.
- `TestRejoinAndConfirmSuccessUnchanged` — guard: both checks pass → `nil`.
- Minimal `fakeCluster` seam (`peerAliveErr`/`syncErr`, nil-default so existing
  tests are unaffected) injects the failures without restructuring.

Reverting `pkg/upgrade/kernel_drain.go` to the discarded-error code makes both
surfacing tests **FAIL** (the error then contains neither the named check nor the
cause); the success guard still PASSES. Verified locally.

## Gates
- `go build ./...` — clean
- `go test ./pkg/upgrade/... -count=1` — ok (all 5 sub-packages)
- `go test ./...` — green (no failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi