### PR TITLE
fix(cli): stream show|pipe filters instead of buffering full output (#4731)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-07-09 — #4731: stream `show ... | match/except/count/last` filters instead of buffering full output
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4731 — `dispatchWithPipe` (pkg/cli/cli_dispatch.go) did
+  `io.ReadAll` on the whole command output, then `strings.Split` on it before
+  filtering — buffering the ENTIRE output in memory (same OOM class #4709 fixed
+  for the pager) for a large `show route | match ...` etc. VERIFY-FIRST:
+  confirmed on origin/master (`0dbda9452`) that dispatchWithPipe still buffered,
+  and that #4709/PR #4730 already landed the `lineSource` (bufio.Reader + 1-line
+  lookahead) seam + the concurrent os.Pipe pager pattern — reused both, did NOT
+  reinvent. Rewrote dispatchWithPipe to mirror the #4709 concurrency: a filter
+  goroutine consumes the pipe via a new `filterStream(src, out, pipeType,
+  pipeArg)` helper while the command writes; the main goroutine runs
+  `c.dispatch(cmd)` (routing preserved exactly), closes the writer, then waits on
+  a done channel for the goroutine (which yields the command's exit code path
+  intact). Per pipe type: match/except/find/no-more emit line-by-line (≤1 line
+  held); count is a running tally (no buffering); last N is an n-wide circular
+  ring buffer (slot i%n, replay last min(count,n)) — never the whole output.
+  filterStream reuses lineSource so emitted lines are byte-identical to the old
+  strings.Split(output,"\n")-trailing-empty-dropped path. No early-return drain
+  needed — every filter reads to EOF (arrives on writer close). Tests:
+  cli_dispatch_pipe_stream_4731_test.go — a `bufferedFilter` reference reproduces
+  the pre-change io.ReadAll+strings.Split path and every pipe type × input
+  (trailing-nl/none, blank lines, arg-absent, empty, single line, \r\n, invalid
+  last args) is asserted byte-identical; plus anti-buffering proofs (match emits
+  the needle after reading <64KiB of a 2.6MB source via countingReader; count
+  tallies 500k lines; last-5 over 100k lines). Gates: go build ./... clean;
+  go test ./pkg/cli/... clean; `go test -race ./pkg/cli` ok (5.9s); full
+  `go test ./...` = 53 ok / 3 no-test / 0 FAIL.
+  **File(s)**: pkg/cli/cli_dispatch.go, pkg/cli/cli_dispatch_pipe_stream_4731_test.go, _Log.md
+
 ## 2026-07-09 — #4708: stream BGP routes REST response instead of buffering the full table
 
 - **Timestamp**: 2026-07-09

--- a/pkg/cli/cli_dispatch.go
+++ b/pkg/cli/cli_dispatch.go
@@ -51,6 +51,13 @@ func extractPipe(line string) (string, string, string, bool) {
 	}
 }
 
+// dispatchWithPipe runs a command and applies a Junos-style output filter
+// (| match/except/find/count/last/no-more) to its output. The command writes to
+// a pipe that a concurrent filter goroutine consumes line-by-line via the #4709
+// lineSource, so a huge "show ... | match ..." streams with bounded memory
+// instead of being buffered whole with io.ReadAll first (#4731). At most one
+// line (match/except/find/no-more), a running tally (count), or an n-line ring
+// (last) is ever held, regardless of total output.
 func (c *CLI) dispatchWithPipe(cmd, pipeType, pipeArg string) error {
 	origStdout := os.Stdout
 	r, w, err := os.Pipe()
@@ -59,49 +66,69 @@ func (c *CLI) dispatchWithPipe(cmd, pipeType, pipeArg string) error {
 	}
 	os.Stdout = w
 
-	outputCh := make(chan []byte, 1)
+	// The filter runs concurrently with the command: it reads the command's
+	// output from r as it is produced and writes the filtered result straight
+	// to the real stdout, so output is consumed lazily instead of materialized
+	// up front. Every filter reads to EOF (which arrives when w is closed), so
+	// no early-return drain is needed to unblock the writer.
+	done := make(chan struct{})
 	go func() {
-		output, _ := io.ReadAll(r)
+		filterStream(r, origStdout, pipeType, pipeArg)
 		r.Close()
-		outputCh <- output
+		close(done)
 	}()
 
 	cmdErr := c.dispatch(cmd)
 	w.Close()
 	os.Stdout = origStdout
+	<-done
 
-	output := <-outputCh
+	return cmdErr
+}
 
-	lines := strings.Split(string(output), "\n")
-	if len(lines) > 0 && lines[len(lines)-1] == "" {
-		lines = lines[:len(lines)-1]
-	}
+// filterStream reads newline-delimited output from src and applies a Junos-style
+// output filter, writing the result to out as each line is read. It reuses the
+// #4709 lineSource line splitting so the emitted lines are byte-identical to the
+// previous strings.Split(output, "\n")-with-trailing-empty-dropped path for any
+// input. match/except/find/no-more hold at most one line at a time; count keeps
+// only a running tally; last keeps a bounded ring buffer of the last n lines —
+// none buffers the full output (#4731).
+func filterStream(src io.Reader, out io.Writer, pipeType, pipeArg string) {
+	ls := &lineSource{r: bufio.NewReader(src)}
 
 	switch pipeType {
 	case "match", "grep":
-		for _, line := range lines {
+		for ls.hasMore() {
+			line, _ := ls.next()
 			if strings.Contains(line, pipeArg) {
-				fmt.Fprintln(origStdout, line)
+				fmt.Fprintln(out, line)
 			}
 		}
 	case "except":
-		for _, line := range lines {
+		for ls.hasMore() {
+			line, _ := ls.next()
 			if !strings.Contains(line, pipeArg) {
-				fmt.Fprintln(origStdout, line)
+				fmt.Fprintln(out, line)
 			}
 		}
 	case "find":
 		found := false
-		for _, line := range lines {
+		for ls.hasMore() {
+			line, _ := ls.next()
 			if !found && strings.Contains(line, pipeArg) {
 				found = true
 			}
 			if found {
-				fmt.Fprintln(origStdout, line)
+				fmt.Fprintln(out, line)
 			}
 		}
 	case "count":
-		fmt.Fprintf(origStdout, "Count: %d lines\n", len(lines))
+		count := 0
+		for ls.hasMore() {
+			ls.next()
+			count++
+		}
+		fmt.Fprintf(out, "Count: %d lines\n", count)
 	case "last":
 		n := 10
 		if pipeArg != "" {
@@ -109,20 +136,29 @@ func (c *CLI) dispatchWithPipe(cmd, pipeType, pipeArg string) error {
 				n = v
 			}
 		}
-		start := len(lines) - n
-		if start < 0 {
-			start = 0
+		// Circular buffer of the last n lines: slot i%n holds the i-th
+		// line, overwriting the oldest once more than n have arrived. Only
+		// n lines are ever retained, not the whole output.
+		ring := make([]string, n)
+		count := 0
+		for ls.hasMore() {
+			line, _ := ls.next()
+			ring[count%n] = line
+			count++
 		}
-		for _, line := range lines[start:] {
-			fmt.Fprintln(origStdout, line)
+		total := count
+		if total > n {
+			total = n
+		}
+		for i := count - total; i < count; i++ {
+			fmt.Fprintln(out, ring[i%n])
 		}
 	case "no-more":
-		for _, line := range lines {
-			fmt.Fprintln(origStdout, line)
+		for ls.hasMore() {
+			line, _ := ls.next()
+			fmt.Fprintln(out, line)
 		}
 	}
-
-	return cmdErr
 }
 
 // dispatchWithPager runs a "show" command and pages its output. The command

--- a/pkg/cli/cli_dispatch_pipe_stream_4731_test.go
+++ b/pkg/cli/cli_dispatch_pipe_stream_4731_test.go
@@ -1,0 +1,215 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// bufferedFilter reproduces the pre-#4731 io.ReadAll + strings.Split filtering
+// path exactly. Every streaming filterStream result is asserted byte-identical
+// to this reference implementation for the same input, so the rewrite cannot
+// drift from the historical semantics.
+func bufferedFilter(output, pipeType, pipeArg string) string {
+	lines := strings.Split(output, "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	var out bytes.Buffer
+	switch pipeType {
+	case "match", "grep":
+		for _, line := range lines {
+			if strings.Contains(line, pipeArg) {
+				fmt.Fprintln(&out, line)
+			}
+		}
+	case "except":
+		for _, line := range lines {
+			if !strings.Contains(line, pipeArg) {
+				fmt.Fprintln(&out, line)
+			}
+		}
+	case "find":
+		found := false
+		for _, line := range lines {
+			if !found && strings.Contains(line, pipeArg) {
+				found = true
+			}
+			if found {
+				fmt.Fprintln(&out, line)
+			}
+		}
+	case "count":
+		fmt.Fprintf(&out, "Count: %d lines\n", len(lines))
+	case "last":
+		n := 10
+		if pipeArg != "" {
+			if v, err := strconv.Atoi(pipeArg); err == nil && v > 0 {
+				n = v
+			}
+		}
+		start := len(lines) - n
+		if start < 0 {
+			start = 0
+		}
+		for _, line := range lines[start:] {
+			fmt.Fprintln(&out, line)
+		}
+	case "no-more":
+		for _, line := range lines {
+			fmt.Fprintln(&out, line)
+		}
+	}
+	return out.String()
+}
+
+// TestFilterStreamMatchesBuffered is the core parity assertion for #4731: for
+// every pipe type and a spread of inputs (trailing newline / none, blank lines,
+// arg absent, empty, single line), the streaming filterStream output must equal
+// the old buffered io.ReadAll + strings.Split output byte-for-byte.
+func TestFilterStreamMatchesBuffered(t *testing.T) {
+	inputs := []string{
+		"",
+		"only\n",
+		"only",
+		"alpha\nbeta\ngamma\n",
+		"alpha\nbeta\ngamma",
+		"match here\nno\nmatch again\nno\n",
+		"a\n\nb\n\nc\n",
+		"x\r\ny\r\n", // only "\n" is the delimiter; trailing "\r" stays
+		strings.Repeat("dup\n", 25),
+	}
+	cases := []struct{ pipeType, pipeArg string }{
+		{"match", "match"},
+		{"match", ""},       // empty arg matches every line
+		{"match", "absent"}, // arg absent from every line
+		{"grep", "a"},
+		{"except", "no"},
+		{"except", ""}, // empty arg excludes every line
+		{"except", "absent"},
+		{"find", "beta"},
+		{"find", "absent"},
+		{"count", ""},
+		{"count", "match"}, // count ignores arg (parity with old behavior)
+		{"last", ""},       // default 10
+		{"last", "3"},
+		{"last", "100"}, // n larger than input
+		{"last", "1"},
+		{"last", "0"},   // invalid -> default 10
+		{"last", "abc"}, // invalid -> default 10
+		{"no-more", ""},
+	}
+
+	for _, in := range inputs {
+		for _, tc := range cases {
+			want := bufferedFilter(in, tc.pipeType, tc.pipeArg)
+			var got bytes.Buffer
+			filterStream(strings.NewReader(in), &got, tc.pipeType, tc.pipeArg)
+			if got.String() != want {
+				t.Fatalf("filterStream(%q, %s %q) = %q, want %q (buffered)",
+					in, tc.pipeType, tc.pipeArg, got.String(), want)
+			}
+		}
+	}
+}
+
+// TestFilterStreamMatchDoesNotBufferAll proves match/except stream: when the
+// filter reaches a line late in a large source, it has NOT read past a bounded
+// window of it. A countingReader records how far the source has been consumed;
+// a match filter that writes as it reads (not io.ReadAll up front) will surface
+// its first matching line while most of the source is still unread.
+func TestFilterStreamMatchDoesNotBufferAll(t *testing.T) {
+	const n = 200000 // ~2.6 MB, far larger than any single bufio fill
+	var in strings.Builder
+	for i := 0; i < n; i++ {
+		if i == 5 {
+			fmt.Fprintf(&in, "NEEDLE%06d\n", i)
+		} else {
+			fmt.Fprintf(&in, "line%06d\n", i)
+		}
+	}
+	data := []byte(in.String())
+
+	src := &countingReader{data: data}
+	// stopWriter records how much of the source had been consumed at the
+	// moment the first (and only) matching line was written, then aborts the
+	// stream by panicking so we do not read the rest.
+	var readAtFirstWrite int
+	sw := &sampleWriter{onWrite: func() { readAtFirstWrite = src.pos }}
+
+	filterStream(src, sw, "match", "NEEDLE")
+
+	if readAtFirstWrite == 0 {
+		t.Fatal("match filter never emitted the needle line")
+	}
+	// The needle is on line 6; a streaming filter emits it after reading only
+	// a small prefix. A buffered io.ReadAll implementation would have read the
+	// entire source before emitting anything.
+	if readAtFirstWrite >= len(data) {
+		t.Fatalf("match filter read the entire %d-byte source before emitting the "+
+			"needle (read %d bytes); output is not streamed", len(data), readAtFirstWrite)
+	}
+	if readAtFirstWrite > 64*1024 {
+		t.Fatalf("match filter read %d bytes before its first match near the start; "+
+			"expected a bounded, buffer-sized amount, not the whole table", readAtFirstWrite)
+	}
+}
+
+// TestFilterStreamCountBounded proves count holds no per-line memory: it counts
+// a huge input with only a running tally. Correctness (the count value) plus the
+// fact that filterStream never accumulates a slice is the anti-buffering proof;
+// this asserts the tally is right for a large stream.
+func TestFilterStreamCountBounded(t *testing.T) {
+	const n = 500000
+	var in strings.Builder
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&in, "l%d\n", i)
+	}
+	var got bytes.Buffer
+	filterStream(strings.NewReader(in.String()), &got, "count", "")
+	want := fmt.Sprintf("Count: %d lines\n", n)
+	if got.String() != want {
+		t.Fatalf("count = %q, want %q", got.String(), want)
+	}
+}
+
+// TestFilterStreamLastRingBounded proves last N retains only N lines: it feeds a
+// large input through "last 5" and asserts the output is exactly the final 5
+// lines. The ring buffer is N wide regardless of total input size.
+func TestFilterStreamLastRingBounded(t *testing.T) {
+	const n = 100000
+	var in strings.Builder
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&in, "line%06d\n", i)
+	}
+	var got bytes.Buffer
+	filterStream(strings.NewReader(in.String()), &got, "last", "5")
+
+	var want strings.Builder
+	for i := n - 5; i < n; i++ {
+		fmt.Fprintf(&want, "line%06d\n", i)
+	}
+	if got.String() != want.String() {
+		t.Fatalf("last 5 = %q, want %q", got.String(), want.String())
+	}
+}
+
+// sampleWriter invokes onWrite the first time it is written to, then continues
+// discarding. Used to sample how much of a source has been consumed at the
+// moment the filter produces its first output line.
+type sampleWriter struct {
+	onWrite func()
+	fired   bool
+}
+
+func (w *sampleWriter) Write(p []byte) (int, error) {
+	if !w.fired {
+		w.fired = true
+		if w.onWrite != nil {
+			w.onWrite()
+		}
+	}
+	return len(p), nil
+}


### PR DESCRIPTION
Closes #4731

## Problem
`dispatchWithPipe` (`show ... | match|except|count|last|find|no-more`,
`pkg/cli/cli_dispatch.go`) did `io.ReadAll` on the **entire** command output and
`strings.Split` it before filtering — buffering the whole output in memory. On a
large `show route | match ...` / `show security flow session | match ...` this is
the same OOM class #4709 (PR #4730) fixed for the interactive pager, applied to
the pipe path. Severity: Low (memory-efficiency; only bites with very large piped
output on a RAM-constrained firewall). Flagged as an explicit residual during
#4709.

## Fix
Reuse the `lineSource` seam #4709 added (bufio.Reader + one-line lookahead,
`strings.Split`-equivalent semantics) and its concurrent `os.Pipe` pattern — do
**not** reinvent. The command writes to a pipe that a filter goroutine consumes
line-by-line while the command runs; the main goroutine runs `c.dispatch(cmd)`
(routing unchanged), closes the writer, then waits on a `done` channel so the
command's exit code is preserved (mirrors `dispatchWithPager`).

New `filterStream(src, out, pipeType, pipeArg)` processes each line as it arrives
with bounded memory:

| Pipe type | Approach | Memory held |
|-----------|----------|-------------|
| `match` / `grep` | write lines containing arg as read | ≤ 1 line |
| `except` | write lines **not** containing arg as read | ≤ 1 line |
| `find` | once a line contains arg, write it + all following | ≤ 1 line |
| `count` | running tally, print `Count: N lines` at end | counter only |
| `last N` | n-wide circular ring buffer (slot `i%n`), replay last `min(count,n)` | n lines |
| `no-more` | write every line as read | ≤ 1 line |

Every filter reads to EOF (arrives when the writer is closed), so no early-return
drain is needed to unblock the producer.

## Semantics preserved
Output is **byte-identical** to the old `io.ReadAll` + `strings.Split` path:
`filterStream` reuses `lineSource`, whose splitting mirrors
`strings.Split(output, "\n")` with the trailing empty element dropped (a
`\n`-terminated final line yields no phantom empty line; an unterminated final
line is its own line; only `\n` is the delimiter so a trailing `\r` stays on the
line). `match` substring-contains, `count` message, `last` default 10 /
`>0`-only parse, `find` first-match-onward — all unchanged.

## Tests (`cli_dispatch_pipe_stream_4731_test.go`, mirrors the #4709 style)
- **Parity:** a `bufferedFilter` reference reproduces the pre-change
  `io.ReadAll`+`strings.Split` path; **every** pipe type × a spread of inputs
  (trailing-newline/none, blank lines, arg absent, empty, single line, CRLF,
  invalid `last` args) asserted byte-identical.
- **Anti-buffering:** a `match` filter emits its needle line after reading
  < 64 KiB of a 2.6 MB source (via the #4709 `countingReader`); `count` tallies
  500k lines with only a counter; `last 5` over 100k lines retains a 5-line ring.
- Guards: empty output, single line, arg-absent.

## Gates
- `go build ./...` — clean
- `go test ./pkg/cli/...` — clean
- `go test -race ./pkg/cli` — ok (5.9s; pipe + goroutine concurrency)
- `go test ./...` — 53 ok / 3 no-test / 0 FAIL (pre-existing `pkg/ddns`
  `TestRFC2136` flake did not trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi