### PR TITLE
perf(config): parse SNMP client CIDRs once instead of per-request (#4711)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -42974,3 +42974,25 @@ top.
 - **Validation**: go build ./... clean; go test ./pkg/upgrade/ -count=1 ok;
   full `go test ./...` green; RED-on-revert verified (both surfacing tests FAIL
   when kernel_drain.go reverted, success guard still PASS).
+
+## 2026-07-09 — #4711 parse SNMP client CIDRs once (perf)
+- **Timestamp**: 2026-07-09
+- **Action**: SNMPCommunity.AllowsSource re-parsed every configured `clients`
+  prefix (net.ParseCIDR/ParseIP) on EVERY incoming v2c packet. Pre-parse the
+  allowlist ONCE at config-compile time into an unexported []compiledSNMPClient
+  (clientNets) so AllowsSource does an allocation-free longest-prefix match.
+  compileClientNets runs in the compiler (compiler_system.go) after Clients is
+  finalized, before the config reaches the SNMP agent — no concurrent readers.
+  A directly-constructed community (nil clientNets, e.g. a unit test) falls back
+  to on-the-fly parsing for the SAME decision; the fallback reads only local
+  state, so it stays race-free. Semantics preserved exactly: empty list =
+  allow-all, longest-prefix match with per-entry `restrict`, no-match =
+  default-deny, malformed entry skipped-inert (never a silent allow-all).
+- **File(s)**: pkg/config/snmp_clients.go (compiledSNMPClient type,
+  compileClientNets, cache-reading AllowsSource), pkg/config/types_system.go
+  (clientNets field), pkg/config/compiler_system.go (build cache at compile),
+  pkg/config/snmp_clients_4711_test.go (new: cache populated, compiled-vs-
+  fallback parity, malformed skipped-inert, empty allow-all)
+- **Validation**: gofmt clean; go build ./... clean; go vet ./pkg/config
+  ./pkg/snmp clean (no copylocks); go test ./pkg/config/... + ./pkg/snmp/...
+  pass; full `go test ./...` green (53 ok / 0 fail / 3 no-test-files, 56 pkgs).

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -1141,6 +1141,13 @@ func compileSNMP(node *Node, sys *SystemConfig, cfg *Config, lenient bool) error
 				if comm.Authorization == "" {
 					comm.Authorization = "read-only"
 				}
+				// #4711: pre-parse the `clients` prefixes once now that
+				// comm.Clients is finalized, so AllowsSource does an
+				// allocation-free match per incoming v2c packet instead of
+				// re-parsing every prefix on every packet. Runs here, before
+				// the config is published to the SNMP agent, so the cache is
+				// set with no concurrent readers.
+				comm.clientNets = compileClientNets(comm.Clients)
 				snmp.Communities[comm.Name] = comm
 			}
 		case "trap-group":

--- a/pkg/config/snmp_clients.go
+++ b/pkg/config/snmp_clients.go
@@ -11,6 +11,46 @@ import "net"
 // ignored (a security fail-open). The compiler now captures the allowlist
 // (parseSNMPClients) and the SNMP agent enforces it before serving a v2c
 // request (AllowsSource).
+//
+// #4711: the `clients` prefixes are parsed ONCE at config-compile time into
+// clientNets (a []compiledSNMPClient) rather than re-parsed on every incoming
+// v2c packet. AllowsSource then does an allocation-free longest-prefix match
+// over the precomputed *net.IPNet set. compileClientNets runs during compilation
+// (compiler_system.go), before the config is published to the SNMP agent, so the
+// cache is set with no concurrent readers; AllowsSource never mutates it.
+
+// compiledSNMPClient is a `clients` allowlist entry with its prefix already
+// parsed into a *net.IPNet (#4711). ones is the prefix length (net.IPMask
+// Size), cached so the longest-prefix comparison in AllowsSource needs no
+// per-packet Mask.Size() call. restrict mirrors SNMPClient.Restrict.
+type compiledSNMPClient struct {
+	net      *net.IPNet
+	ones     int
+	restrict bool
+}
+
+// compileClientNets pre-parses a `clients` allowlist into the allocation-free
+// match set consumed by AllowsSource (#4711). An unparseable prefix is skipped
+// (inert), exactly as the former per-call parse skipped it — never a silent
+// allow-all. Returns nil for an empty allowlist; a non-empty allowlist whose
+// entries are all unparseable yields a non-nil empty slice, so a populated but
+// fully-inert list still default-denies (and is distinguishable from "not yet
+// compiled").
+func compileClientNets(clients []SNMPClient) []compiledSNMPClient {
+	if len(clients) == 0 {
+		return nil
+	}
+	out := make([]compiledSNMPClient, 0, len(clients))
+	for _, cl := range clients {
+		_, ipnet, err := parseClientPrefix(cl.Prefix)
+		if err != nil || ipnet == nil {
+			continue // an unparseable prefix is inert, never a silent allow-all
+		}
+		ones, _ := ipnet.Mask.Size()
+		out = append(out, compiledSNMPClient{net: ipnet, ones: ones, restrict: cl.Restrict})
+	}
+	return out
+}
 
 // AllowsSource reports whether a v2c query from srcIP may be served under this
 // community. Semantics (Junos):
@@ -24,6 +64,12 @@ import "net"
 // A nil srcIP (e.g. a non-IP transport / test path with no address) is allowed
 // so enforcement never blocks a request whose source cannot be determined; the
 // real serving path always supplies the UDP source address.
+//
+// #4711: the match runs against clientNets, the prefixes parsed once at compile
+// time. A community built directly (e.g. a unit test) that never went through
+// the compiler has a nil clientNets; AllowsSource then parses on the fly for the
+// same decision — this reads only local state, so it stays race-free under
+// concurrent serving, and the real serving path always has clientNets populated.
 func (c *SNMPCommunity) AllowsSource(srcIP net.IP) bool {
 	if c == nil {
 		return false
@@ -34,20 +80,21 @@ func (c *SNMPCommunity) AllowsSource(srcIP net.IP) bool {
 	if srcIP == nil {
 		return true
 	}
+	nets := c.clientNets
+	if nets == nil {
+		// Not compiled (directly-constructed community) — parse on the fly.
+		// Same decision, just not the precomputed fast path.
+		nets = compileClientNets(c.Clients)
+	}
 	bestBits := -1
 	bestAllow := false
-	for _, cl := range c.Clients {
-		_, ipnet, err := parseClientPrefix(cl.Prefix)
-		if err != nil || ipnet == nil {
-			continue // an unparseable prefix is inert, never a silent allow-all
-		}
-		if !ipnet.Contains(srcIP) {
+	for _, cn := range nets {
+		if !cn.net.Contains(srcIP) {
 			continue
 		}
-		ones, _ := ipnet.Mask.Size()
-		if ones > bestBits {
-			bestBits = ones
-			bestAllow = !cl.Restrict
+		if cn.ones > bestBits {
+			bestBits = cn.ones
+			bestAllow = !cn.restrict
 		}
 	}
 	if bestBits < 0 {

--- a/pkg/config/snmp_clients_4711_test.go
+++ b/pkg/config/snmp_clients_4711_test.go
@@ -1,0 +1,142 @@
+package config
+
+import (
+	"net"
+	"testing"
+)
+
+// #4711: the `clients` source-IP allowlist is parsed ONCE at compile time into
+// SNMPCommunity.clientNets, and AllowsSource matches against that precomputed
+// set instead of re-parsing every prefix on every incoming v2c packet. These
+// tests pin (a) the cache is populated by the compiler, (b) the compiled fast
+// path and the directly-constructed on-the-fly fallback return identical
+// allow/deny decisions (semantics preserved), and (c) malformed / empty
+// allowlist handling matches the former per-call convention.
+
+// The compiler must pre-parse the prefixes: after CompileConfig, clientNets is
+// populated (one entry per parseable prefix) so AllowsSource never re-parses.
+func TestSNMPClientsCompiledCachePopulated(t *testing.T) {
+	c := communityFrom(t, buildTreeFromSet(t, []string{
+		"set snmp community public authorization read-only",
+		"set snmp community public clients 10.0.0.0/24",
+		"set snmp community public clients 192.168.1.5",
+		"set snmp community public clients 0.0.0.0/0 restrict",
+	}), "public")
+
+	if len(c.Clients) != 3 {
+		t.Fatalf("expected 3 client entries, got %+v", c.Clients)
+	}
+	if len(c.clientNets) != 3 {
+		t.Fatalf("expected 3 pre-parsed clientNets after compile, got %d (%+v)", len(c.clientNets), c.clientNets)
+	}
+	// The bare IP became a /32 host route; the restrict flag rode along.
+	byPrefix := map[string]compiledSNMPClient{}
+	for _, cn := range c.clientNets {
+		byPrefix[cn.net.String()] = cn
+	}
+	if cn, ok := byPrefix["192.168.1.5/32"]; !ok || cn.ones != 32 || cn.restrict {
+		t.Errorf("bare IP 192.168.1.5 not cached as an allow /32: %+v (ok=%v)", cn, ok)
+	}
+	if cn, ok := byPrefix["0.0.0.0/0"]; !ok || cn.ones != 0 || !cn.restrict {
+		t.Errorf("0.0.0.0/0 restrict not cached as a deny /0: %+v (ok=%v)", cn, ok)
+	}
+}
+
+// An unscoped community (no `clients`) leaves clientNets nil and stays allow-all
+// — the empty-list default must be untouched by the caching.
+func TestSNMPClientsCompiledCacheEmptyIsAllowAll(t *testing.T) {
+	c := communityFrom(t, parseHier(t, `snmp { community open { authorization read-only; } }`), "open")
+	if c.clientNets != nil {
+		t.Errorf("unscoped community should have nil clientNets, got %+v", c.clientNets)
+	}
+	for _, src := range []string{"10.0.0.1", "8.8.8.8", "2001:db8::1"} {
+		if !c.AllowsSource(net.ParseIP(src)) {
+			t.Errorf("AllowsSource(%s) = false on an unscoped community, want allow-all", src)
+		}
+	}
+}
+
+// Semantics preserved: for a representative allowlist (CIDR + bare IP + a
+// restrict entry, IPv4 and IPv6), the compiled fast path and the
+// directly-constructed on-the-fly fallback must return the SAME decision for
+// sources inside and outside each entry. A directly-built community (clientNets
+// nil) exercises the fallback; the compiled one exercises the cache.
+func TestSNMPClientsCompiledVsFallbackParity(t *testing.T) {
+	clients := []SNMPClient{
+		{Prefix: "10.1.0.0/16"},
+		{Prefix: "10.1.2.0/24", Restrict: true},
+		{Prefix: "192.168.1.5"}, // bare IPv4 → /32
+		{Prefix: "2001:db8::/32"},
+		{Prefix: "2001:db8:dead::/48", Restrict: true},
+	}
+
+	// Directly constructed: clientNets stays nil → AllowsSource parses on the
+	// fly (the fallback path).
+	direct := &SNMPCommunity{Name: "d", Clients: clients}
+	if direct.clientNets != nil {
+		t.Fatal("directly-constructed community should not have a pre-built cache")
+	}
+
+	// Compiled: clientNets is pre-parsed → AllowsSource uses the cache.
+	compiled := &SNMPCommunity{Name: "c", Clients: clients}
+	compiled.clientNets = compileClientNets(compiled.Clients)
+	if len(compiled.clientNets) != len(clients) {
+		t.Fatalf("expected %d cached nets, got %d", len(clients), len(compiled.clientNets))
+	}
+
+	cases := map[string]bool{
+		"10.1.5.1":         true,  // 10.1.0.0/16 allow
+		"10.1.2.9":         false, // 10.1.2.0/24 restrict (longest match)
+		"192.168.1.5":      true,  // bare /32 allow
+		"192.168.1.6":      false, // no match → default-deny
+		"8.8.8.8":          false, // no match → default-deny
+		"2001:db8::1":      true,  // 2001:db8::/32 allow
+		"2001:db8:dead::1": false, // 2001:db8:dead::/48 restrict (longest)
+		"2001:dead::1":     false, // no match → default-deny
+	}
+	for src, want := range cases {
+		ip := net.ParseIP(src)
+		gd := direct.AllowsSource(ip)
+		gc := compiled.AllowsSource(ip)
+		if gd != gc {
+			t.Errorf("AllowsSource(%s): fallback=%v compiled=%v — decisions diverge", src, gd, gc)
+		}
+		if gc != want {
+			t.Errorf("AllowsSource(%s) = %v, want %v", src, gc, want)
+		}
+	}
+}
+
+// Malformed-CIDR convention preserved: an unparseable prefix is skipped (inert)
+// — never a silent allow-all — both when compiled and on the fallback path. A
+// list of ONLY malformed entries still default-denies (non-nil empty cache),
+// distinguishable from an unscoped (nil-cache) allow-all community.
+func TestSNMPClientsMalformedSkippedInert(t *testing.T) {
+	clients := []SNMPClient{
+		{Prefix: "not-an-ip"},
+		{Prefix: "10.5.0.0/24"},
+	}
+	// Compiled: the bad entry is dropped from the cache, the good one kept.
+	nets := compileClientNets(clients)
+	if len(nets) != 1 || nets[0].net.String() != "10.5.0.0/24" {
+		t.Fatalf("malformed entry should be skipped, kept %+v", nets)
+	}
+
+	c := &SNMPCommunity{Name: "m", Clients: clients, clientNets: nets}
+	if !c.AllowsSource(net.ParseIP("10.5.0.9")) {
+		t.Error("10.5.0.9 should be allowed by 10.5.0.0/24 despite a malformed sibling")
+	}
+	if c.AllowsSource(net.ParseIP("8.8.8.8")) {
+		t.Error("8.8.8.8 should be denied — a malformed entry must not become allow-all")
+	}
+
+	// All-malformed list: non-nil empty cache, and default-deny (NOT allow-all).
+	badOnly := compileClientNets([]SNMPClient{{Prefix: "bad"}, {Prefix: "10.0.0.0/99"}})
+	if badOnly == nil || len(badOnly) != 0 {
+		t.Fatalf("all-malformed list should compile to a non-nil empty cache, got %+v", badOnly)
+	}
+	deny := &SNMPCommunity{Name: "b", Clients: []SNMPClient{{Prefix: "bad"}}, clientNets: badOnly}
+	if deny.AllowsSource(net.ParseIP("10.0.0.1")) {
+		t.Error("a community whose clients are all malformed must default-deny, not allow-all")
+	}
+}

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -521,6 +521,15 @@ type SNMPCommunity struct {
 	// is allow-all (the Junos default). Enforced by the SNMP agent via
 	// AllowsSource (snmp_clients.go).
 	Clients []SNMPClient
+
+	// clientNets is Clients pre-parsed into an allocation-free match set
+	// (#4711). The compiler populates it via compileClientNets after Clients
+	// is finalized, before the config reaches the SNMP agent, so AllowsSource
+	// matches without re-parsing every prefix on every incoming v2c packet.
+	// Unexported: derived state, not part of the config surface (not marshaled,
+	// not persisted); a config path that skips compilation leaves it nil and
+	// AllowsSource parses on the fly. See snmp_clients.go.
+	clientNets []compiledSNMPClient
 }
 
 // SNMPClient is one entry of an SNMP community `clients` source-IP allowlist:


### PR DESCRIPTION
Closes #4711

## Problem
`SNMPCommunity.AllowsSource` (`pkg/config/snmp_clients.go`) called
`parseClientPrefix` (`net.ParseCIDR` / `net.ParseIP`) for every configured
`clients` prefix on **every** incoming SNMP v2c packet
(`pkg/snmp/agent.go` `handleV2cPacket`), re-parsing and allocating the same
`*net.IPNet` set on each request instead of using compile-time-known data.
(gemini-review-041 Low-8, perf.)

## Fix — where the parse moved to
The `clients` prefixes are now parsed **once at config-compile time**. In
`pkg/config/compiler_system.go`, after `comm.Clients` is finalized and before
the compiled config is published to the SNMP agent, `compileClientNets` builds
an unexported `[]compiledSNMPClient` (`clientNets`) on the community — each
entry's prefix parsed to a `*net.IPNet` with its prefix length cached.
`AllowsSource` then does an **allocation-free** longest-prefix match over that
set (no per-packet `ParseCIDR`). The cache is written during compilation with
no concurrent readers, and `AllowsSource` never mutates it, so serving is
race-free. `clientNets` is unexported derived state — not marshaled, not
persisted, not part of the config surface.

## Semantics preserved (same allow/deny)
No change to who is allowed/denied — only **when** the parse happens:
- empty `clients` → allow-all (Junos default);
- longest-prefix match wins, honoring the per-entry `restrict` deny;
- `clients` set but source matches no entry → default-deny;
- a malformed prefix is **skipped (inert)** — never a silent allow-all.

## Malformed-CIDR handling
Matches the existing convention: the former per-call code silently skipped an
unparseable entry, so `compileClientNets` skips it too (now once, at compile).
**No** new commit-time rejection is added — a config that loads today still
loads (per #1960). An all-malformed list compiles to a non-nil empty cache and
still default-denies.

## Concurrency
Cache is built at compile time before the config reaches the agent (no
concurrent readers). A community constructed directly (nil `clientNets`, e.g. a
unit test) that never went through the compiler falls back to on-the-fly
parsing for the **identical** decision; the fallback reads only local state, so
it stays race-free, and the real serving path always has `clientNets`
populated.

## Tests
`pkg/config/snmp_clients_4711_test.go`:
- compiled cache populated (bare IP → `/32`, `restrict` flag carried);
- **compiled-vs-fallback parity** over a representative IPv4+IPv6 allowlist
  (CIDRs + bare IP + `restrict`; sources inside and outside each) — same
  allow/deny on both paths;
- malformed entry skipped-inert, all-malformed list still default-denies;
- empty-list allow-all preserved.

Existing #4289 tests (which compile the config) now exercise the cache path
unchanged and still pass.

## Validation
- `gofmt` clean; `go build ./...` clean.
- `go vet ./pkg/config ./pkg/snmp` clean (no copylocks from the added field).
- `go test ./pkg/config/...` and `./pkg/snmp/...` pass.
- Full `go test ./...` green: **53 ok / 0 fail / 3 no-test-files** across 56
  packages. (Pre-existing `pkg/ddns` `TestRFC2136` flake did not fire.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)