### PR TITLE
fix(userspace-dp): surface NAT reconcile parse failures instead of silently dropping rules (#4718)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -42867,3 +42867,32 @@ top.
   Validation: gofmt; go vet; new test PASS (2 subtests); touched packages
   (cmd/cli, pkg/config, pkg/policymatch) green; FULL Go suite green.
   **File(s)**: pkg/policymatch/reject_matrix_4422_test.go, _Log.md
+- **Timestamp**: 2026-07-09
+  **Action**: #4718 — surface NAT reconcile parse failures instead of
+  silently dropping the rule. The three sibling NAT snapshot reconcilers
+  dropped a rule/prefix whose IP/prefix/pool field the Go control plane
+  sent but the helper could not parse, via a bare `continue`/`{}` with NO
+  diagnostic — so an operator debugging config/sync drift got zero signal a
+  NAT rule had vanished. Added `NatCounterStore::record_parse_error` (a
+  loud `eprintln!` naming the offending rule+field, journald via stderr,
+  plus a cumulative `parse_errors` atomic — the testable seam) and wired it
+  into all skip sites: destination.rs (unparseable destination prefix+addr,
+  destination addr, pool addr — issue :324/:330/:343), static_nat.rs
+  (external-ip / internal-ip — :357/:361), source.rs `parse_match_prefix`
+  (unparseable source/destination match prefix — :1375). Continue to install
+  the VALID rules (drop only the bad one — a single malformed rule from a
+  mixed-version peer-sync must NOT take down all NAT). This restores the
+  loud-skip doctrine nat64.rs (#3888) already documents its siblings follow.
+  Rust-only; the Go commit-check remains the primary gate — this is the
+  helper-boundary backstop made observable. RED-on-revert tests added per
+  reconciler (one unparseable rule + valid rules -> valid installed AND
+  parse_errors bumped) + all-valid guard (zero errors). The DNAT test
+  caught an incomplete first cut (pool site unfixed -> counter 1 not 2),
+  confirming the seam is revert-sensitive.
+  Validation: `cargo build` clean; `cargo test --release nat` 674 pass /
+  0 fail (incl. 6 new); full serial suite (see PR).
+  **File(s)**: userspace-dp/src/nat/mod.rs,
+  userspace-dp/src/nat/destination.rs, userspace-dp/src/nat/static_nat.rs,
+  userspace-dp/src/nat/source.rs, userspace-dp/src/nat/tests_destination.rs,
+  userspace-dp/src/nat/tests_static.rs, userspace-dp/src/nat/tests_source.rs,
+  _Log.md

--- a/userspace-dp/src/nat/destination.rs
+++ b/userspace-dp/src/nat/destination.rs
@@ -319,15 +319,29 @@ impl DnatTable {
                     // Unparseable prefix: fall back to the host
                     // `destination_address` if it parses, else drop the entry
                     // (fail-closed, like an unparseable host destination).
+                    // #4718: surface the drop loudly instead of a silent skip.
                     Err(_) => match snap.destination_address.parse::<IpAddr>() {
                         Ok(ip) => DnatDest::Host(ip),
-                        Err(_) => continue,
+                        Err(_) => {
+                            nat_counters.record_parse_error(&format!(
+                                "DNAT rule {:?}: unparseable destination prefix {:?} and address {:?}",
+                                snap.name, snap.destination_prefix, snap.destination_address
+                            ));
+                            continue;
+                        }
                     },
                 }
             } else {
                 match snap.destination_address.parse::<IpAddr>() {
                     Ok(ip) => DnatDest::Host(ip),
-                    Err(_) => continue,
+                    // #4718: surface the drop loudly instead of a silent skip.
+                    Err(_) => {
+                        nat_counters.record_parse_error(&format!(
+                            "DNAT rule {:?}: unparseable destination address {:?}",
+                            snap.name, snap.destination_address
+                        ));
+                        continue;
+                    }
                 }
             };
             // #3844: an off (exemption) entry carries no pool. Parse the pool
@@ -340,7 +354,14 @@ impl DnatTable {
             } else {
                 match snap.pool_address.parse() {
                     Ok(ip) => ip,
-                    Err(_) => continue,
+                    // #4718: surface the drop loudly instead of a silent skip.
+                    Err(_) => {
+                        nat_counters.record_parse_error(&format!(
+                            "DNAT rule {:?}: unparseable pool address {:?}",
+                            snap.name, snap.pool_address
+                        ));
+                        continue;
+                    }
                 }
             };
             // Determine the protocol key to insert this entry under.

--- a/userspace-dp/src/nat/mod.rs
+++ b/userspace-dp/src/nat/mod.rs
@@ -240,6 +240,14 @@ type NatCounterRegistry = FxHashMap<u32, Arc<NatRuleCounter>>;
 #[derive(Clone, Debug, Default)]
 pub(crate) struct NatCounterStore {
     counters: Arc<Mutex<NatCounterRegistry>>,
+    /// #4718: cumulative count of NAT reconcile PARSE failures — a rule or
+    /// match prefix the Go control plane sent whose IP/prefix/pool field this
+    /// helper could not parse, so the offending rule/prefix was dropped from
+    /// the rebuilt forwarding state. Shared behind an `Arc` so a clone handed
+    /// to `from_snapshots` increments the SAME atomic the coordinator (and the
+    /// fail-on-revert test) reads. Monotonic error counter, not a gauge: it is
+    /// only bumped, never reset by a reconcile.
+    parse_errors: Arc<AtomicU64>,
 }
 
 impl NatCounterStore {
@@ -293,5 +301,47 @@ impl NatCounterStore {
             .iter()
             .map(|(&id, counter)| counter.snapshot(id))
             .collect()
+    }
+
+    /// #4718: record one NAT reconcile PARSE failure and surface it LOUDLY.
+    ///
+    /// The three sibling NAT snapshot reconcilers — `DnatTable::from_snapshots`
+    /// (destination.rs), `StaticNatTable::from_snapshots` (static_nat.rs), and
+    /// `parse_source_nat_rules_with_previous` via `parse_match_prefix`
+    /// (source.rs) — drop a rule or match prefix whose IP/prefix/pool field the
+    /// Go control plane emitted but this helper cannot parse. That data path is
+    /// an INTERNAL inconsistency: the Go commit-check already validates operator
+    /// config, so an unparseable field here means a mixed-version peer-sync, a
+    /// serialization bug, or a missed Go validation edge — never an
+    /// operator-present commit. The correct posture is defense-in-depth: DROP
+    /// ONLY the bad rule so the VALID rules in the same batch still install (a
+    /// single malformed rule must not take down all NAT — that would be a worse
+    /// availability outcome than one silently-absent translation), but make the
+    /// drop OBSERVABLE.
+    ///
+    /// Pre-#4718 each of these skips was a bare `continue`/`{}` with no
+    /// diagnostic, so an operator debugging a config/sync drift got ZERO signal
+    /// that a NAT rule had vanished. This restores the loud-skip doctrine the
+    /// NAT64 builder already documents and follows (nat64.rs #3888): the
+    /// `eprintln!` reaches journald via stderr and NAMES the offending rule +
+    /// field; the atomic counter is a cumulative metric and the testable seam
+    /// the fail-on-revert test asserts. These reconcilers run only during
+    /// control-plane config apply / peer-sync, never the packet hot path, so
+    /// the log adds no forwarding latency.
+    pub(crate) fn record_parse_error(&self, detail: &str) {
+        self.parse_errors.fetch_add(1, Ordering::Relaxed);
+        eprintln!("xpf nat reconcile: dropping rule (unparseable field): {detail}");
+    }
+
+    /// #4718: cumulative NAT reconcile parse-failure count (see
+    /// [`record_parse_error`](Self::record_parse_error)). A `> 0` value means
+    /// at least one configured NAT rule/prefix was dropped at the helper
+    /// boundary and did NOT reach the dataplane. The operator-facing surface is
+    /// the per-drop `eprintln!` (journald); this accessor is the testable seam
+    /// the fail-on-revert tests assert, so it is gated to test builds to avoid
+    /// a dead-code warning until a metrics surface consumes it.
+    #[cfg(test)]
+    pub(crate) fn parse_errors(&self) -> u64 {
+        self.parse_errors.load(Ordering::Relaxed)
     }
 }

--- a/userspace-dp/src/nat/source.rs
+++ b/userspace-dp/src/nat/source.rs
@@ -568,10 +568,24 @@ pub(crate) fn parse_source_nat_rules_with_previous(
         // silently match ANY address — the exact fail-open this fix closes (and
         // the same bare-IP live bug fixed for DNAT in #2394).
         for prefix in &snap.source_addresses {
-            parse_match_prefix(prefix, &mut rule.source_v4, &mut rule.source_v6);
+            parse_match_prefix(
+                prefix,
+                &mut rule.source_v4,
+                &mut rule.source_v6,
+                nat_counters,
+                &snap.name,
+                "source-address",
+            );
         }
         for prefix in &snap.destination_addresses {
-            parse_match_prefix(prefix, &mut rule.destination_v4, &mut rule.destination_v6);
+            parse_match_prefix(
+                prefix,
+                &mut rule.destination_v4,
+                &mut rule.destination_v6,
+                nat_counters,
+                &snap.name,
+                "destination-address",
+            );
         }
         // #3429: source-NAT L4 match constraints. `match destination-port`
         // ranges and the pre-expanded `match application` terms. Ranges are kept
@@ -1357,7 +1371,14 @@ pub(crate) fn match_source_nat_result_for_tuple(
 /// that parses as neither is dropped (it narrows the match rather than widening
 /// it); the `*_constrained` flag, set from the snapshot list being non-empty,
 /// makes an all-malformed set fail closed in `nets_match_*`.
-fn parse_match_prefix(prefix: &str, v4: &mut Vec<PrefixV4>, v6: &mut Vec<PrefixV6>) {
+fn parse_match_prefix(
+    prefix: &str,
+    v4: &mut Vec<PrefixV4>,
+    v6: &mut Vec<PrefixV6>,
+    nat_counters: &NatCounterStore,
+    rule_name: &str,
+    axis: &str,
+) {
     match prefix.parse::<IpNet>() {
         Ok(IpNet::V4(net)) => v4.push(PrefixV4::from_net(net)),
         Ok(IpNet::V6(net)) => v6.push(PrefixV6::from_net(net)),
@@ -1372,7 +1393,15 @@ fn parse_match_prefix(prefix: &str, v4: &mut Vec<PrefixV4>, v6: &mut Vec<PrefixV
                     v6.push(PrefixV6::from_net(net));
                 }
             }
-            Err(_) => {}
+            // #4718: a prefix that parses as neither a CIDR nor a bare host IP
+            // is dropped from the match set. The `*_constrained` flag keeps this
+            // fail-closed (an all-malformed set matches NOTHING, never the
+            // pre-#2398 fail-open collapse to match-any), but the drop was
+            // SILENT — surface it loudly + count it so an operator sees the
+            // configured match prefix that never reached the dataplane.
+            Err(_) => nat_counters.record_parse_error(&format!(
+                "source-NAT rule {rule_name:?}: unparseable {axis} match prefix {prefix:?}"
+            )),
         },
     }
 }

--- a/userspace-dp/src/nat/static_nat.rs
+++ b/userspace-dp/src/nat/static_nat.rs
@@ -352,13 +352,28 @@ impl StaticNatTable {
     ) -> Self {
         let mut table = StaticNatTable::default();
         for snap in snaps {
+            // #4718: surface an unparseable external/internal IP loudly instead
+            // of a silent skip, so a leniently-loaded / peer-synced bad rule is
+            // observable rather than a mysteriously-absent translation.
             let ext_prefix = match parse_nat_prefix(&snap.external_ip) {
                 Some(p) => p,
-                None => continue,
+                None => {
+                    nat_counters.record_parse_error(&format!(
+                        "static-NAT rule {:?}: unparseable external-ip {:?}",
+                        snap.name, snap.external_ip
+                    ));
+                    continue;
+                }
             };
             let int_prefix = match parse_nat_prefix(&snap.internal_ip) {
                 Some(p) => p,
-                None => continue,
+                None => {
+                    nat_counters.record_parse_error(&format!(
+                        "static-NAT rule {:?}: unparseable internal-ip {:?}",
+                        snap.name, snap.internal_ip
+                    ));
+                    continue;
+                }
             };
             // #3031: a non-host prefix on EITHER side is a block-to-block
             // (subnet) static-NAT rule. A valid block map needs equal-length

--- a/userspace-dp/src/nat/tests_destination.rs
+++ b/userspace-dp/src/nat/tests_destination.rs
@@ -1650,5 +1650,121 @@ fn dnat_duplicate_any_zone_last_rule_wins() {
     assert_eq!(decision.rewrite_dst_port, Some(9443));
 }
 
+// #4718 FAIL-ON-REVERT: a DNAT batch carrying rules with an UNPARSEABLE
+// destination address / pool address must (1) still install the VALID rules
+// and (2) SURFACE each drop via the NatCounterStore parse-error counter,
+// instead of the pre-#4718 silent `continue`. Reverting `record_parse_error`
+// back to a bare `continue` leaves `parse_errors() == 0` → surfacing
+// assertion RED.
+#[test]
+fn dnat_unparseable_field_surfaces_and_keeps_valid_rules() {
+    let counters = crate::nat::NatCounterStore::default();
+    let table = DnatTable::from_snapshots(
+        &[
+            // Bad: destination address unparseable (empty-prefix host path).
+            DestinationNATRuleSnapshot {
+                name: "bad-dest".to_string(),
+                destination_address: "not-an-ip".to_string(),
+                destination_port: 80,
+                protocol: "tcp".to_string(),
+                pool_address: "192.168.1.99".to_string(),
+                pool_port: 8080,
+                ..DestinationNATRuleSnapshot::default()
+            },
+            // Bad: pool address unparseable on a translate (non-off) rule.
+            DestinationNATRuleSnapshot {
+                name: "bad-pool".to_string(),
+                destination_address: "203.0.113.20".to_string(),
+                destination_port: 80,
+                protocol: "tcp".to_string(),
+                pool_address: "garbage".to_string(),
+                pool_port: 8080,
+                ..DestinationNATRuleSnapshot::default()
+            },
+            // Valid: must still install despite the malformed siblings.
+            DestinationNATRuleSnapshot {
+                name: "good".to_string(),
+                destination_address: "203.0.113.10".to_string(),
+                destination_port: 80,
+                protocol: "tcp".to_string(),
+                pool_address: "192.168.1.10".to_string(),
+                pool_port: 8080,
+                ..DestinationNATRuleSnapshot::default()
+            },
+        ],
+        &counters,
+    );
+    // (1) The valid rule installed.
+    assert_eq!(
+        table.lookup(
+            PROTO_TCP,
+            "198.51.100.1".parse().unwrap(),
+            "203.0.113.10".parse().unwrap(),
+            80,
+            "",
+        ),
+        Some(NatDecision {
+            rewrite_dst: Some("192.168.1.10".parse().unwrap()),
+            rewrite_dst_port: Some(8080),
+            ..NatDecision::default()
+        }),
+        "valid DNAT rule must install despite sibling parse failures"
+    );
+    // The bad pool rule (valid destination) must NOT have installed.
+    assert_eq!(
+        table.lookup(
+            PROTO_TCP,
+            "198.51.100.1".parse().unwrap(),
+            "203.0.113.20".parse().unwrap(),
+            80,
+            "",
+        ),
+        None,
+        "a DNAT rule with an unparseable pool address must be dropped"
+    );
+    // (2) Both drops surfaced — RED on the silent-skip revert.
+    assert_eq!(
+        counters.parse_errors(),
+        2,
+        "each unparseable DNAT field must bump the parse-error counter"
+    );
+}
+
+// #4718 guard: an all-valid DNAT batch installs its rule with ZERO parse
+// errors — no false positive from the surfacing path.
+#[test]
+fn dnat_all_valid_reports_no_parse_errors() {
+    let counters = crate::nat::NatCounterStore::default();
+    let table = DnatTable::from_snapshots(
+        &[DestinationNATRuleSnapshot {
+            name: "good".to_string(),
+            destination_address: "203.0.113.10".to_string(),
+            destination_port: 80,
+            protocol: "tcp".to_string(),
+            pool_address: "192.168.1.10".to_string(),
+            pool_port: 8080,
+            ..DestinationNATRuleSnapshot::default()
+        }],
+        &counters,
+    );
+    assert!(
+        table
+            .lookup(
+                PROTO_TCP,
+                "198.51.100.1".parse().unwrap(),
+                "203.0.113.10".parse().unwrap(),
+                80,
+                "",
+            )
+            .is_some(),
+        "the valid rule must install"
+    );
+    assert_eq!(
+        counters.parse_errors(),
+        0,
+        "an all-valid batch must report zero parse errors"
+    );
+}
+
 // --- Pool-mode SNAT tests ---
 

--- a/userspace-dp/src/nat/tests_source.rs
+++ b/userspace-dp/src/nat/tests_source.rs
@@ -568,3 +568,76 @@ fn reverse_decision_turns_snat_into_reply_dnat() {
     );
 }
 
+// #4718 FAIL-ON-REVERT: a source-NAT rule whose match set contains an
+// UNPARSEABLE prefix must (1) still translate via its VALID prefixes and (2)
+// SURFACE the dropped prefix via the NatCounterStore parse-error counter,
+// instead of the pre-#4718 silent `Err(_) => {}`. Reverting
+// `record_parse_error` back to the empty arm leaves `parse_errors() == 0` →
+// surfacing assertion RED, while the translation still succeeds (the fix does
+// not change the fail-closed match-set behaviour, only makes the drop
+// observable).
+#[test]
+fn source_nat_unparseable_match_prefix_surfaces_and_keeps_valid() {
+    let counters = crate::nat::NatCounterStore::default();
+    let rules = parse_source_nat_rules_with_previous(
+        &[SourceNATRuleSnapshot {
+            name: "snat-mixed".to_string(),
+            from_zone: "lan".to_string(),
+            to_zone: "wan".to_string(),
+            source_addresses: vec![
+                "garbage".to_string(),      // unparseable — surfaced drop
+                "10.0.61.0/24".to_string(), // valid — must still translate
+            ],
+            interface_mode: true,
+            ..SourceNATRuleSnapshot::default()
+        }],
+        None,
+        &counters,
+    );
+    // (1) The valid prefix still translates its source.
+    let hit = match_source_nat(
+        &rules,
+        &NatScopeCtx::default(),
+        "lan",
+        "wan",
+        "10.0.61.7".parse().expect("in valid subnet"),
+        "172.16.80.200".parse().expect("dst"),
+        Some("172.16.80.8".parse().expect("egress")),
+        None,
+    );
+    assert!(
+        hit.is_some(),
+        "valid source-NAT prefix must translate despite a malformed sibling"
+    );
+    // (2) The malformed prefix was surfaced — RED on the silent-skip revert.
+    assert_eq!(
+        counters.parse_errors(),
+        1,
+        "an unparseable source-NAT match prefix must bump the parse-error counter"
+    );
+}
+
+// #4718 guard: an all-valid source-NAT match set reports ZERO parse errors —
+// no false positive from the surfacing path.
+#[test]
+fn source_nat_all_valid_reports_no_parse_errors() {
+    let counters = crate::nat::NatCounterStore::default();
+    let _rules = parse_source_nat_rules_with_previous(
+        &[SourceNATRuleSnapshot {
+            name: "snat-clean".to_string(),
+            from_zone: "lan".to_string(),
+            to_zone: "wan".to_string(),
+            source_addresses: vec!["10.0.61.0/24".to_string(), "10.0.62.5".to_string()],
+            interface_mode: true,
+            ..SourceNATRuleSnapshot::default()
+        }],
+        None,
+        &counters,
+    );
+    assert_eq!(
+        counters.parse_errors(),
+        0,
+        "an all-valid match set must report zero parse errors"
+    );
+}
+

--- a/userspace-dp/src/nat/tests_static.rs
+++ b/userspace-dp/src/nat/tests_static.rs
@@ -677,6 +677,95 @@ fn static_nat_canonical_cidr_mask_v4_installs_entry() {
     assert_eq!(ips, vec!["203.0.113.5".parse::<IpAddr>().unwrap()]);
 }
 
+// #4718 FAIL-ON-REVERT: a static-NAT batch carrying rules with an UNPARSEABLE
+// external-ip / internal-ip must (1) still install the VALID rules and (2)
+// SURFACE each drop via the NatCounterStore parse-error counter, instead of
+// the pre-#4718 silent `continue`. Reverting `record_parse_error` back to a
+// bare `continue` (the old behaviour) leaves `parse_errors() == 0`, turning
+// the surfacing assertion RED — while the valid-rule assertion still passes,
+// proving the fix keeps the good rules installing.
+#[test]
+fn static_nat_unparseable_ip_surfaces_and_keeps_valid_rules() {
+    let counters = crate::nat::NatCounterStore::default();
+    let table = StaticNatTable::from_snapshots(
+        &[
+            // Bad: external-ip is garbage — dropped, but must be surfaced.
+            StaticNATRuleSnapshot {
+                name: "bad-ext".to_string(),
+                external_ip: "not-an-ip".to_string(),
+                internal_ip: "10.0.0.5".to_string(),
+                ..StaticNATRuleSnapshot::default()
+            },
+            // Bad: internal-ip is garbage (external parses, internal does not)
+            // — a second surfaced drop.
+            StaticNATRuleSnapshot {
+                name: "bad-int".to_string(),
+                external_ip: "203.0.113.9".to_string(),
+                internal_ip: "garbage/33".to_string(),
+                ..StaticNATRuleSnapshot::default()
+            },
+            // Valid: must still install despite the malformed siblings.
+            StaticNATRuleSnapshot {
+                name: "good".to_string(),
+                from_zone: "untrust".to_string(),
+                external_ip: "203.0.113.10".to_string(),
+                internal_ip: "192.168.1.10".to_string(),
+                ..StaticNATRuleSnapshot::default()
+            },
+        ],
+        &counters,
+    );
+    // (1) The valid rule installed: inbound DNAT translates ext -> int.
+    assert_eq!(
+        table.match_dnat("203.0.113.10".parse().unwrap(), "untrust"),
+        Some(NatDecision {
+            rewrite_dst: Some("192.168.1.10".parse().unwrap()),
+            ..NatDecision::default()
+        }),
+        "valid static-NAT rule must install despite sibling parse failures"
+    );
+    // The bad rule with a valid external-ip must NOT have installed.
+    assert_eq!(
+        table.match_dnat("203.0.113.9".parse().unwrap(), "untrust"),
+        None,
+        "a static-NAT rule with an unparseable internal-ip must be dropped"
+    );
+    // (2) Both drops surfaced on the counter — RED on the silent-skip revert.
+    assert_eq!(
+        counters.parse_errors(),
+        2,
+        "each unparseable static-NAT field must bump the parse-error counter"
+    );
+}
+
+// #4718 guard: an all-valid static-NAT batch installs its rule with ZERO
+// parse errors — no false positive from the surfacing path.
+#[test]
+fn static_nat_all_valid_reports_no_parse_errors() {
+    let counters = crate::nat::NatCounterStore::default();
+    let table = StaticNatTable::from_snapshots(
+        &[StaticNATRuleSnapshot {
+            name: "good".to_string(),
+            from_zone: "untrust".to_string(),
+            external_ip: "203.0.113.10".to_string(),
+            internal_ip: "192.168.1.10".to_string(),
+            ..StaticNATRuleSnapshot::default()
+        }],
+        &counters,
+    );
+    assert!(
+        table
+            .match_dnat("203.0.113.10".parse().unwrap(), "untrust")
+            .is_some(),
+        "the valid rule must install"
+    );
+    assert_eq!(
+        counters.parse_errors(),
+        0,
+        "an all-valid batch must report zero parse errors"
+    );
+}
+
 #[test]
 fn static_nat_canonical_cidr_mask_v6_installs_entry() {
     // IPv6 canonical host form carries /128; same root cause as the v4 case.


### PR DESCRIPTION
Closes #4718

## Problem
Three NAT snapshot reconcilers in `userspace-dp` dropped a rule/prefix on a
parse failure via a bare `continue`/`{}` with **no diagnostic**, so an
operator debugging a config/sync drift got zero signal that a configured NAT
rule never reached the dataplane (gemini-review-041 Low-3/4/5, all GENUINE).

An unparseable field here is an **internal inconsistency** — the Go
commit-check validates operator config, so it only arises from a
mixed-version peer-sync, a serialization bug, or a missed Go validation edge.
The fix is defense-in-depth: keep dropping **only** the bad rule (so the valid
rules in the same batch still install — failing the whole reconcile on one
malformed rule would take down **all** NAT, a worse availability outcome), but
make the drop **observable**.

## Silent-skip sites fixed (all 3 files)
| File | Function | Sites |
|------|----------|-------|
| `nat/destination.rs` | `DnatTable::from_snapshots` | unparseable destination prefix+address fallback, host destination address, pool address (`:324` / `:330` / `:343`) |
| `nat/static_nat.rs` | `StaticNatTable::from_snapshots` | unparseable `external-ip` / `internal-ip` (`:357` / `:361`) |
| `nat/source.rs` | `parse_match_prefix` | a match prefix parseable as neither CIDR nor bare host IP (`:1375`) — signature gains counter + rule name + axis; fail-closed `*_constrained` behaviour unchanged |

## Surfacing mechanism
Added `NatCounterStore::record_parse_error(detail)`:
- a loud one-line `eprintln!("xpf nat reconcile: dropping rule (unparseable field): …")` **naming the offending rule + field** (journald via stderr — the operator surface), and
- a cumulative `parse_errors` atomic (the **testable seam**; the getter is `#[cfg(test)]`-gated to avoid a dead-code warning until a metrics surface consumes it).

`NatCounterStore` is already threaded by shared reference into all three
builders, so no signature churn on the production callers. This restores the
loud-skip doctrine the NAT64 builder already documents its siblings follow
(`nat64.rs`, #3888); the Go commit gate remains the **primary** defense — this
is the helper-boundary backstop made observable.

## Why not fail-closed-all
Failing the entire forwarding rebuild on one malformed rule would freeze/omit
**every** NAT translation for a single bad rule from a mixed-version peer-sync
— strictly worse than one silently-absent translation. The blast radius is
scoped to the one bad rule, matching the existing NAT64 (#3888) posture.

## Tests (RED-on-revert)
Per reconciler: a batch with one unparseable rule/prefix + valid rules asserts
**(1)** the valid rules install and **(2)** `parse_errors()` is bumped.
Reverting `record_parse_error` to the silent skip leaves the counter `0` → the
surfacing assertion fails. The first cut left the DNAT **pool** site unfixed
and the DNAT test caught it (counter `1`, not `2`) — confirming the seam is
revert-sensitive. An all-valid **guard** per reconciler asserts zero errors
(no false positives).

## Validation
- `cargo build` — clean (0 errors).
- `cargo test --release nat` — **674 passed / 0 failed** (incl. 6 new).
- `cargo test --release -- --test-threads=1` (full serial suite) — **3860 passed / 0 failed / 2 ignored**.

## Docs
No separate doc file changed: the reconcile lenient-load behaviour is
documented in-code (the `nat64.rs` #3888 doctrine, which already *claims* these
siblings emit a loud skip — this PR makes reality match it — plus the new
per-site `#4718` comments). No operator/design doc described the silent-skip
behaviour to correct. `_Log.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
