### PR TITLE
fix(config): redact Secret in YAML marshal/unmarshal (#4710)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-07-09 — #4710: redact Secret in YAML marshal/unmarshal (close the JSON/YAML asymmetry)
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4710 — `config.Secret` (pkg/config/secret.go) had a
+  fail-closed JSON round-trip guard (`MarshalJSON` redacts, `UnmarshalJSON`
+  REFUSES the `<redacted>` sentinel via `errRedactedSecretIngest`) and an
+  already-present defensive `MarshalYAML`, but NO `UnmarshalYAML` — an
+  asymmetry: yaml.v3 would decode the literal `<redacted>` straight into a
+  Secret, bypassing the guard the moment YAML config ingestion is wired up.
+  VERIFY-FIRST decision: NOT premature. `gopkg.in/yaml.v3` already exists in
+  the module graph (go.sum + module cache; pulled via pkg/dhcp + testify), and
+  `Secret`/`SNMPConfig`/`SNMPCommunity` already carry `MarshalYAML` methods, so
+  the project already committed to covering the YAML marshal surface — the
+  missing unmarshal half is the real gap, not a hypothetical new dependency.
+  Added `func (s *Secret) UnmarshalYAML(value *yaml.Node) error` mirroring
+  `UnmarshalJSON` byte-for-byte in behavior (decode scalar → reject
+  `SecretRedacted` with the SAME `errRedactedSecretIngest` sentinel → else
+  assign). Promoted yaml.v3 to a direct require via `go mod tidy` (go.sum
+  unchanged — already present). RED-on-revert test `TestSecretUnmarshalYAML`
+  drives the real yaml.v3 encoder/decoder: plain scalar ingests, a full
+  marshal→unmarshal round-trip of a live Secret is REFUSED; neutering the
+  sentinel guard makes the assertion fail (proven). go build ./... clean, go
+  vet clean, pkg/config green, whole-repo `go test ./...` green.
+  **File(s)**: pkg/config/secret.go, pkg/config/secret_test.go, go.mod
+
 ## 2026-07-09 — #4731: stream `show ... | match/except/count/last` filters instead of buffering full output
 
 - **Timestamp**: 2026-07-09

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	golang.org/x/sys v0.40.0
 	google.golang.org/grpc v1.78.0
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/pkg/config/secret.go
+++ b/pkg/config/secret.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // errRedactedSecretIngest is returned by Secret.UnmarshalJSON when the
@@ -35,9 +37,10 @@ var errRedactedSecretIngest = errors.New(
 // *config.Config back from JSON/YAML (the persistence/sync SSOT is the
 // *ConfigTree AST, db.go / sync_conn.go). A redacting marshaller therefore
 // cannot starve any consumer of a secret. Render/reconcile sites read the
-// cleartext via Reveal(). UnmarshalJSON below additionally refuses the
-// redaction sentinel so that if a compiled-config JSON ingest is ever added
-// it fails loudly instead of silently loading "<redacted>" as a key.
+// cleartext via Reveal(). UnmarshalJSON and UnmarshalYAML below additionally
+// refuse the redaction sentinel so that if a compiled-config JSON or YAML
+// ingest is ever added it fails loudly instead of silently loading
+// "<redacted>" as a key.
 //
 // Secret keeps the underlying string kind (it is a named string type, not a
 // struct) so it stays comparable — usable as a map key and directly
@@ -157,4 +160,26 @@ func (s Secret) MarshalYAML() (any, error) {
 		return "", nil
 	}
 	return SecretRedacted, nil
+}
+
+// UnmarshalYAML mirrors UnmarshalJSON for the gopkg.in/yaml.v3 decoder: it
+// accepts a plain scalar so the type is a drop-in if a tree value is ever
+// decoded from YAML, but REFUSES the redaction sentinel. Without this method
+// yaml.v3 would decode the literal "<redacted>" straight into the Secret,
+// bypassing the fail-closed guard the JSON path enforces (a marshalled-then-
+// reloaded compiled config could silently reload "<redacted>" as a live
+// secret). No config YAML ingest path exists today (the compiled-config SSOT
+// is the AST tree, not YAML); this keeps the YAML surface symmetric with JSON
+// and fails closed if one is ever added. A pointer receiver is required for
+// any yaml.Unmarshaler.
+func (s *Secret) UnmarshalYAML(value *yaml.Node) error {
+	var v string
+	if err := value.Decode(&v); err != nil {
+		return err
+	}
+	if v == SecretRedacted {
+		return errRedactedSecretIngest
+	}
+	*s = Secret(v)
+	return nil
 }

--- a/pkg/config/secret_test.go
+++ b/pkg/config/secret_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 // TestSecretMarshalJSON covers the core redaction contract: a non-empty
@@ -135,6 +137,48 @@ func TestSecretUnmarshalJSON(t *testing.T) {
 	}
 	if !errors.Is(err, errRedactedSecretIngest) {
 		t.Errorf("Unmarshal(sentinel) err = %v, want errRedactedSecretIngest", err)
+	}
+}
+
+// TestSecretUnmarshalYAML is the YAML mirror of TestSecretUnmarshalJSON and
+// the RED-on-revert guard for the fail-closed round-trip: it drives the real
+// gopkg.in/yaml.v3 decoder (not the method directly) so reverting
+// UnmarshalYAML lets yaml.v3 decode the sentinel straight into the Secret and
+// the sentinel-refusal assertion fails. A plain scalar ingests as-is; a full
+// marshal->unmarshal round-trip of a live Secret must be REFUSED, never
+// reloaded as a live secret.
+func TestSecretUnmarshalYAML(t *testing.T) {
+	var s Secret
+	if err := yaml.Unmarshal([]byte("plain\n"), &s); err != nil {
+		t.Fatalf("Unmarshal(plain) error = %v", err)
+	}
+	if s.Reveal() != "plain" {
+		t.Errorf("Unmarshal(plain) = %q, want %q", s.Reveal(), "plain")
+	}
+
+	// The redaction sentinel must be REFUSED (fail-closed), never loaded as a
+	// live secret.
+	err := yaml.Unmarshal([]byte(SecretRedacted+"\n"), &s)
+	if err == nil {
+		t.Fatal("Unmarshal(sentinel) succeeded; want refusal")
+	}
+	if !errors.Is(err, errRedactedSecretIngest) {
+		t.Errorf("Unmarshal(sentinel) err = %v, want errRedactedSecretIngest", err)
+	}
+
+	// Full round-trip: marshalling a live Secret emits the sentinel (never the
+	// cleartext); feeding that YAML back in must be refused. Without
+	// UnmarshalYAML, yaml.v3 decodes the sentinel into s with no error and this
+	// assertion fails — the RED-on-revert signal.
+	yb, err := yaml.Marshal(Secret("supersecret"))
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if strings.Contains(string(yb), "supersecret") {
+		t.Errorf("Marshal() leaked cleartext: %s", yb)
+	}
+	if err := yaml.Unmarshal(yb, &s); !errors.Is(err, errRedactedSecretIngest) {
+		t.Errorf("round-trip Unmarshal(sentinel) err = %v, want errRedactedSecretIngest", err)
 	}
 }
 


### PR DESCRIPTION
Closes #4710

## Problem
`config.Secret` (pkg/config/secret.go) enforced a **fail-closed round-trip guard on the JSON path** but had an asymmetric YAML surface:

- `MarshalJSON` redacts a non-empty Secret to the `<redacted>` sentinel.
- `UnmarshalJSON` **REFUSES** that sentinel (`errRedactedSecretIngest`) so a marshalled-then-reloaded compiled config can never silently reload the placeholder as a live secret.
- `MarshalYAML` was already present (defensive, mirrors `MarshalJSON`).
- **`UnmarshalYAML` was missing** — so `gopkg.in/yaml.v3` would decode the literal `<redacted>` straight into a `Secret`, bypassing the guard the moment a YAML config-ingest path is added (LATENT today; gemini-review-041 Medium-8).

## Why this is justified, not premature (verify-first)
- **The yaml dep already exists**: `gopkg.in/yaml.v3 v3.0.1` is in `go.sum` + the module cache (`go mod why` → pulled via `pkg/dhcp` + testify). No **new** third-party dependency is introduced — `go mod tidy` only promotes yaml.v3 to a direct require (**go.sum unchanged**).
- **The project already covers the YAML marshal surface**: `Secret`, `SNMPConfig`, and `SNMPCommunity` all implement `MarshalYAML`. The missing `UnmarshalYAML` is the real asymmetry, matching the JSON path which has both halves.

## Fix
Add `func (s *Secret) UnmarshalYAML(value *yaml.Node) error` mirroring `UnmarshalJSON` **byte-for-byte in behavior**: decode the scalar → reject `SecretRedacted` with the **same** `errRedactedSecretIngest` sentinel → else assign. Type doc updated to "UnmarshalJSON and UnmarshalYAML … refuse the redaction sentinel".

## RED-on-revert test
`TestSecretUnmarshalYAML` drives the **real yaml.v3 encoder/decoder** (not the method directly):
- plain scalar ingests as-is;
- a full `yaml.Marshal` → `yaml.Unmarshal` round-trip of a live Secret is **REFUSED** with `errRedactedSecretIngest`, and never leaks cleartext.
- Neutering the sentinel guard makes the assertion fail (verified); removing the method leaves the yaml import unused and fails the build.

## Validation
- `gofmt` clean; `go build ./...` clean; `go vet ./pkg/config` clean.
- `go test ./pkg/config/...` → green.
- `go test ./...` → green (pre-existing `pkg/ddns` `TestRFC2136` flake unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi