### PR TITLE
test(userspace-dp): reject/PBR coverage follow-ups from #4412 (#4499)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43315,3 +43315,25 @@ top.
   interfaces, family split, output excluded). Mutation-verified the asserts
   bite. Full Go suite green (53 pkg ok).
 - **File(s)**: pkg/routing/routing_test.go, _Log.md
+
+- **Timestamp**: 2026-07-09 (session 015oARShYtiJJ2H4UB4nXGqi)
+- **Action**: #4499 residual test-coverage (reject-path + NAT64/AppCatalog).
+  VERIFY-FIRST reconcile: the bulk of #4499 (E7 PBR+NAT64 override, H1 PBR
+  egress output-filter, H6 IPv6 PBR dest-port fail-closed, H4 Rust-kernel
+  output-filter re-eval) was ALREADY landed by the merged commit 7a320521b;
+  A2 (reject ICMP type-3/code-13, ICMPv6-1/1, and TCP RST byte-level) is
+  ALREADY comprehensively covered (reject_icmp_unreachable_v4/v6_* in
+  afxdp/tests.rs + build_reject_rst_frame tests in frame/tcp_tests.rs) — the
+  issue-comment premise was stale. Two genuine residual gaps remained and are
+  now pinned: (E2) deny-path emits POLICY_DENY, never a session-init
+  (SessionCreate) record, for both `then reject` (RST enqueued) and plain
+  `then deny` (silent drop) via deny_reply_and_emit; (A5) NAT64 translation
+  preserves the L4 service port so AppCatalog::lookup_forward resolves the same
+  application on the translated v4 flow as the original v6 flow (port read back
+  from the translated frame + a non-80 control). Mutation-verified RED: the E2
+  kind pins bite when emit_policy_deny_event's kind is flipped to
+  SessionCreate; A5 bites when the translated dst port is corrupted. Full
+  binary suite 3772 passed / 0 failed / 2 ignored. Production untouched
+  (test-only).
+- **File(s)**: userspace-dp/src/afxdp/poll_descriptor/reject_reply_tests.rs,
+  userspace-dp/src/nat64_tests.rs, _Log.md

--- a/userspace-dp/src/afxdp/poll_descriptor/reject_reply_tests.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/reject_reply_tests.rs
@@ -1670,6 +1670,138 @@ fn deny_reply_and_emit_success_logs_reject() {
     );
 }
 
+/// #4499 E2 (reject half): a policy `then reject` deny path emits a single
+/// RT_FLOW record whose KIND is `PolicyDeny` — NOT a `SessionCreate`
+/// (session-init) record — and NO second frame follows. The reject branch in
+/// the poll loop never reaches the session-install path, so a `then reject`
+/// policy configured with `then log session-init` produces the policy-deny log
+/// and the RST, but no session and hence no session-init log. This pins the
+/// EVENT KIND (the existing `deny_reply_and_emit_success_logs_reject` pins only
+/// the action byte). Fail-on-revert: if the deny path ever emitted a
+/// `SessionCreate`-kind record (a session-init leak on a denied flow), the kind
+/// assertion flips; if it emitted a trailing frame, the drain assertion flips.
+#[test]
+fn deny_reply_and_emit_reject_logs_policy_deny_kind_not_session_init_4499() {
+    use super::cookie_reply::SYN_COOKIE_REPLY_PENDING_RESERVE;
+    use crate::event_stream::codec::DataplaneEventKind;
+    let _g = crate::afxdp::icmp_ratelimit::global_bucket_test_lock();
+    crate::afxdp::icmp_ratelimit::reset_bucket_for_test(
+        crate::afxdp::icmp_ratelimit::GeneratedErrorReason::Reject,
+        0,
+    );
+    let (frame, meta, flow) = tcp_v4_syn();
+    let (handle, rx) = unlimited_event_handle();
+    let mut pipeline = tx_pipeline(
+        SYN_COOKIE_REPLY_PENDING_RESERVE * 2,
+        SYN_COOKIE_REPLY_PENDING_RESERVE + 1,
+    );
+    let forwarding = ForwardingState::default();
+    let mut counters = BatchCounters::default();
+    deny_reply_and_emit(
+        &mut pipeline,
+        &forwarding,
+        Some(&handle),
+        5,
+        &frame,
+        meta,
+        &flow,
+        &mut counters,
+        &NatDecision::default(),
+        7,
+        9,
+        0,
+        101,
+        PolicyAction::Reject,
+        0,
+        123,
+    );
+    // The RST is enqueued (active reject).
+    assert_eq!(counters.policy_reject_sent, 1, "the RST must be enqueued");
+    assert_eq!(pipeline.pending_tx_local.len(), 1);
+    // Exactly ONE record, and it is a POLICY_DENY — never a SESSION_CREATE.
+    let event = rx
+        .try_recv()
+        .expect("policy-deny event frame")
+        .decode_dataplane_event()
+        .expect("policy-deny payload");
+    assert_eq!(
+        event.kind,
+        DataplaneEventKind::PolicyDeny,
+        "#4499 E2: a `then reject` deny logs POLICY_DENY, never a session-init (SessionCreate)"
+    );
+    assert_eq!(event.action, RT_FLOW_ACTION_REJECT);
+    assert!(
+        rx.try_recv().is_err(),
+        "#4499 E2: no second (session-init) frame may follow a denied flow"
+    );
+}
+
+/// #4499 E2 (deny half): a policy `then deny` (plain deny, no ingress-zone
+/// `tcp-rst`) is a SILENT drop — `deny_reply_and_emit` enqueues NO reply, yet
+/// still emits a single RT_FLOW record whose kind is `PolicyDeny` and whose
+/// action is the truthful DENY. As with the reject half, the deny branch never
+/// installs a session, so even with `then log session-init` there is no
+/// session-init (SessionCreate) record: exactly one POLICY_DENY frame and no
+/// trailing frame. The existing `deny_reply_no_zone_tcp_rst_is_silent_drop`
+/// exercises only `enqueue_deny_reply` (the no-reply decision) and never drives
+/// the event emit; this pins the combined emit path for plain deny.
+/// Fail-on-revert: a plain deny that started synthesizing an RST flips the
+/// no-reply assertion; a plain deny that emitted a session-init flips the kind
+/// / drain assertions.
+#[test]
+fn deny_reply_and_emit_plain_deny_silent_logs_deny_no_session_init_4499() {
+    use crate::event_stream::codec::DataplaneEventKind;
+    let (frame, meta, flow) = tcp_v4_syn();
+    let (handle, rx) = unlimited_event_handle();
+    let mut pipeline = tx_pipeline(64, 64); // ample budget; plain deny still silent
+    let forwarding = ForwardingState::default(); // ingress zone 7 has no tcp-rst
+    let mut counters = BatchCounters::default();
+    deny_reply_and_emit(
+        &mut pipeline,
+        &forwarding,
+        Some(&handle),
+        5,
+        &frame,
+        meta,
+        &flow,
+        &mut counters,
+        &NatDecision::default(),
+        7, // from_zone (not tcp-rst enabled)
+        9, // to_zone
+        0, // owner_rg
+        101,
+        PolicyAction::Deny,
+        0,
+        123,
+    );
+    // Silent drop: no RST/ICMP reply enqueued, no reject counter bumped.
+    assert!(
+        pipeline.pending_tx_local.is_empty(),
+        "#4499 E2: a plain `then deny` (no zone tcp-rst) must enqueue no reply"
+    );
+    assert_eq!(counters.policy_reject_sent, 0);
+    // Exactly ONE POLICY_DENY record with the truthful DENY action, and no
+    // trailing session-init frame.
+    let event = rx
+        .try_recv()
+        .expect("policy-deny event frame")
+        .decode_dataplane_event()
+        .expect("policy-deny payload");
+    assert_eq!(
+        event.kind,
+        DataplaneEventKind::PolicyDeny,
+        "#4499 E2: a `then deny` logs POLICY_DENY, never a session-init (SessionCreate)"
+    );
+    assert_eq!(
+        event.action, RT_FLOW_ACTION_DENY,
+        "#4499 E2: a plain deny logs the truthful DENY action"
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "#4499 E2: a denied flow installs no session, so no session-init frame follows"
+    );
+}
+
 /// #3618 call-site fail-on-revert (end-to-end): with per-(from-)zone Reject
 /// buckets, a rejected-flow flood that drains ZONE A's bucket must NOT stop
 /// ZONE B from emitting its reject through `enqueue_policy_reject_reply`.

--- a/userspace-dp/src/nat64_tests.rs
+++ b/userspace-dp/src/nat64_tests.rs
@@ -559,6 +559,78 @@ fn translate_v6_to_v4_tcp() {
     assert_eq!(checksum16_ipv4_pseudo(src, dst, PROTO_TCP, tcp_payload), 0);
 }
 
+/// #4499 A5: NAT64 translation preserves the L4 ports, so the `AppCatalog`
+/// application resolution — which keys ONLY on (protocol, src_port, dst_port)
+/// and is deliberately address-agnostic — yields the SAME application for the
+/// original IPv6 flow and its NAT64-translated IPv4 flow. A v6 SYN to tcp/80
+/// (an `junos-http`-shaped catalog entry) is translated to v4; the destination
+/// service port is read back FROM the translated packet bytes and fed to
+/// `AppCatalog::lookup_forward`, which must still resolve `junos-http`.
+///
+/// This composes `nat64::translate_v6_to_v4` (the port-copy) with
+/// `policy::AppCatalog::lookup_forward` (the port-keyed resolution) as the A5
+/// finding asks. Because the service port is read out of the translated frame
+/// rather than hard-coded, a regression that corrupted the L4 port during
+/// translation would make the lookup miss (app_id 0 / UNKNOWN) and turn this
+/// RED — the exact "port not preserved across translation" failure. A no-match
+/// control (a non-80 dst) and the pre-translation v6 lookup (same app, proving
+/// address-independence) round out the pin.
+#[test]
+fn nat64_translation_preserves_port_for_appcatalog_lookup_4499() {
+    const HTTP_APP_ID: u16 = 42;
+    // A `junos-http`-shaped catalog: tcp, destination port 80 only.
+    let catalog = crate::policy::AppCatalog::from_snapshot(&[crate::AppCatalogEntry {
+        app_id: HTTP_APP_ID,
+        protocol: PROTO_TCP,
+        dst_port_low: 80,
+        dst_port_high: 80,
+        src_port_low: 0,
+        src_port_high: 0,
+    }]);
+
+    let src_v6: Ipv6Addr = "2001:db8::1".parse().unwrap();
+    let dst_v6: Ipv6Addr = "64:ff9b::c633:6432".parse().unwrap();
+    let snat_v4 = Ipv4Addr::new(198, 51, 100, 1);
+    let dst_v4 = Ipv4Addr::new(198, 51, 100, 50);
+    let client_port = 12345u16;
+    let http_port = 80u16;
+
+    // Pre-translation: the IPv6 flow resolves to junos-http purely by port
+    // (the catalog never sees an address), establishing the baseline.
+    assert_eq!(
+        catalog.lookup_forward(PROTO_TCP, client_port, http_port),
+        HTTP_APP_ID,
+        "the original v6 flow to tcp/80 resolves junos-http"
+    );
+
+    let ipv6_pkt = make_ipv6_tcp_packet(src_v6, dst_v6, client_port, http_port, b"GET /");
+    let ipv4_pkt = translate_v6_to_v4(&ipv6_pkt, snat_v4, dst_v4, false).expect("translate");
+
+    // Read the L4 ports back out of the TRANSLATED v4 frame (TCP header at
+    // offset 20): src at 20..22, dst at 22..24. If translation corrupted them
+    // the lookup below misses.
+    let xlated_src_port = u16::from_be_bytes([ipv4_pkt[20], ipv4_pkt[21]]);
+    let xlated_dst_port = u16::from_be_bytes([ipv4_pkt[22], ipv4_pkt[23]]);
+    assert_eq!(xlated_src_port, client_port, "NAT64 preserves the source port");
+    assert_eq!(xlated_dst_port, http_port, "NAT64 preserves the dst service port");
+
+    // Post-translation: the SAME application resolves from the translated
+    // ports — the NAT64'd IPv4 flow is still classified junos-http.
+    assert_eq!(
+        catalog.lookup_forward(PROTO_TCP, xlated_src_port, xlated_dst_port),
+        HTTP_APP_ID,
+        "#4499 A5: the NAT64-translated v4 flow resolves the same app (port preserved)"
+    );
+
+    // Control: a translated flow to a NON-80 port must NOT resolve junos-http
+    // (proves the assertion above is port-sensitive, not a constant pass).
+    assert_eq!(
+        catalog.lookup_forward(PROTO_TCP, xlated_src_port, 8080),
+        0,
+        "a non-80 translated dst must not spuriously resolve junos-http"
+    );
+}
+
 #[test]
 fn translate_v4_to_v6_tcp() {
     let src_v4 = Ipv4Addr::new(198, 51, 100, 50);


### PR DESCRIPTION
Closes #4499

## VERIFY-FIRST reconcile against origin/master

Most of #4499 was already landed; this PR closes only the **genuine residual gaps** and documents what was already covered.

**Already covered (no new test needed):**
- **E7** (PBR routing-instance override survives NAT64, no VRF leak), **H1** (output filter on the PBR egress, no bypass), **H6** (IPv6 PBR destination-port fail-closed), **H4 Rust-kernel** (output filter re-evaluated from egress config, never synced session state) — all landed by merged commit `7a320521b`.
- **A2** (reject ICMP type-3/code-13, ICMPv6 type-1/code-1, and TCP RST byte-level) — already comprehensively pinned by `reject_icmp_unreachable_v4/v6_*` (afxdp/tests.rs) and the `build_reject_rst_frame` tests (frame/tcp_tests.rs: flags, seq/ack, ports, MAC/IP swap, checksum, window=0, ext-header). The issue-comment premise ("existing tests assert is_some/is_none not the bytes") was stale.
- **H4 full cross-chassis failover-under-traffic** — a cluster integration test, out of scope for a Rust-only cargo PR (the Rust-kernel property it rests on is pinned).
- Packet-level NAT64 port preservation is already asserted by `translate_v6_to_v4_tcp`.

## Gaps this PR closes

**E2 — reject/deny installs no session, no session-init log.** The poll-loop deny branch calls `deny_reply_and_emit` then sets disposition `PolicyDenied`, never reaching the session-install path — so a denied flow, even one whose policy has `then log session-init`, emits only the `POLICY_DENY` RT_FLOW record and never a session-init (`SessionCreate`) record. The existing `deny_reply_and_emit_*` tests pin only the action byte; the two new tests pin the event **kind** is `PolicyDeny` (not `SessionCreate`) and that exactly one frame is emitted (no trailing session-init):
- `deny_reply_and_emit_reject_logs_policy_deny_kind_not_session_init_4499` — `then reject`: RST enqueued, one `PolicyDeny`/REJECT record, nothing follows.
- `deny_reply_and_emit_plain_deny_silent_logs_deny_no_session_init_4499` — plain `then deny` (no zone `tcp-rst`): silent drop (no reply), one `PolicyDeny`/DENY record, nothing follows. Drives the combined emit path that `deny_reply_no_zone_tcp_rst_is_silent_drop` never exercised.

**A5 — AppCatalog lookup with a NAT64-translated port.** NAT64 copies the L4 header verbatim (only the IP layer changes), so the address-agnostic AppCatalog port resolution yields the same application before and after translation. `nat64_translation_preserves_port_for_appcatalog_lookup_4499` translates a v6 SYN to tcp/80, reads the service port **back out of the translated v4 frame**, and asserts `AppCatalog::lookup_forward` still resolves the app — with a non-80 control and the pre-translation v6 baseline. Reading the port from the translated bytes ties the assertion to `nat64::translate_v6_to_v4`'s port copy.

## Mutation-verified (each new assertion bites)
- E2 kind pins → **RED** when `emit_policy_deny_event`'s `kind` is flipped to `SessionCreate` (both E2 tests fail; A5 unaffected).
- A5 → **RED** when the translated destination port is corrupted (`out[22] ^= 0xff`).
- All reverted; production is byte-identical.

## Production untouched
Only two test files changed (`reject_reply_tests.rs`, `nat64_tests.rs`) plus `_Log.md`. No production source touched — this is coverage, not a fix or refactor. No real bug was uncovered.

## Gates
- `cargo build` — clean.
- Full binary suite serial (`cargo test --release --bin xpf-userspace-dp -- --test-threads=1`): **3772 passed / 0 failed / 2 ignored** (grew by the 3 new tests).
- `reject` filter: 229 passed / 0 failed. `pbr` filter: 19 passed / 0 failed.