### PR TITLE
frr #4484 L-6: write frr.conf 0640 owned root:frr, not world-readable 0644

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-07-09 — #4484 L-6: frr.conf 0640 + fresh-create root:frr ownership
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4484 L-6 — frr.conf carries routing-auth secrets (BGP
+  TCP-MD5, OSPF/IS-IS/RIP keys) but was written world-readable 0644. Changed
+  the two `atomicWriteFile` call sites (`writeManagedSection`,
+  `StripManagedSectionFile`) to 0640. Since 0640 is owner+group-readable
+  only, a FRESH create is now installed owned `root:frr` via
+  `fsatomic.WithOwner` (new `atomicWriteOwnerOpt` + `resolveFRRGroup`
+  helpers) so the unprivileged frr daemons can still read it. Owner override
+  applies ONLY when the target does not already exist (existing operator file
+  keeps its own mode+ownership via WithPreserveExisting — never restamped)
+  AND the process is root AND the `frr` group resolves; otherwise skipped
+  (0640 root:root, harmless — nothing reads frr.conf without a running FRR).
+  Mirrors the pkg/dhcpserver #2450 Kea-memfile ownership pattern. Updated the
+  existing `TestWriteManagedSection_PreservesExistingMode` fresh-file
+  assertion 0644→0640; added `frrconf_mode_4484_test.go` (fresh-mode 0640,
+  operator-mode-preserved, owner-decision matrix). RED-on-revert verified
+  (revert to 0644 → fresh-mode test fails).
+  **File(s)**: pkg/frr/manager.go, pkg/frr/frr_test.go,
+  pkg/frr/frrconf_mode_4484_test.go, pkg/frr/README.md
+
 ## 2026-07-09 — #4671: relocate frame/wg.rs inline tests to sibling wg_tests.rs
 
 - **Timestamp**: 2026-07-09

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -16,6 +16,22 @@ lifted into that package), gaining the parent-dir fsync the local
 writer lacked. The file carries operator content outside the managed
 section, so it must survive power loss.
 
+**File mode (#4484 L-6):** the managed section carries routing-auth
+secrets (BGP TCP-MD5, OSPF/IS-IS/RIP keys), so `frr.conf` must not be
+world-readable. The write perm is **0640** (was 0644). Because 0640 is
+readable only by owner+group, a **fresh** create (no operator file to
+preserve) is installed **owned `root:frr`** via `fsatomic.WithOwner`, so
+the unprivileged frr daemons (group `frr`) can still read it —
+`atomicWriteOwnerOpt` resolves the frr gid (`resolveFRRGroup`). The
+owner override is applied **only** when (a) the target does not already
+exist — an existing operator file keeps its own mode+ownership
+(`WithPreserveExisting`, never restamped) — AND (b) the process is root
+and the `frr` group resolves. When the group is absent (FRR not
+installed — a dev host / unit test) or the process is non-root the
+override is skipped and the file lands 0640 `root:root` (harmless:
+nothing reads `frr.conf` without a running FRR). This mirrors the
+pkg/dhcpserver #2450 Kea-memfile ownership handling.
+
 ## File layout
 
 The package is split across five sibling `.go` files (no sub-packages,

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -1157,6 +1157,13 @@ func TestWriteManagedSection_StaleEndMarkerBeforeBegin(t *testing.T) {
 // apply would be a permission regression vs the old os.WriteFile path (which
 // preserved the mode of an existing file).
 func TestWriteManagedSection_PreservesExistingMode(t *testing.T) {
+	// Force the "frr group absent" path so the fresh-file write below does not
+	// attempt a (non-root) fchown to the frr gid (#4484 L-6); the 0640 mode is
+	// enforced regardless of the owner override.
+	restore := resolveFRRGroup
+	resolveFRRGroup = func() (int, bool) { return 0, false }
+	t.Cleanup(func() { resolveFRRGroup = restore })
+
 	dir := t.TempDir()
 	confPath := filepath.Join(dir, "frr.conf")
 
@@ -1183,7 +1190,12 @@ func TestWriteManagedSection_PreservesExistingMode(t *testing.T) {
 		t.Errorf("mode not preserved across atomic write: got %o, want 0640", got)
 	}
 
-	// A brand-new file (no existing target) uses the default 0644.
+	// A brand-new file (no existing target) is created 0640, NOT the old
+	// world-readable 0644: the managed section carries routing-auth secrets
+	// (BGP TCP-MD5, OSPF/IS-IS/RIP keys), so a fresh frr.conf must not be
+	// world-readable (#4484 L-6). On a real appliance the fresh file is also
+	// owned root:frr (WithOwner) so the frr daemons can still read it; here the
+	// group is forced absent, leaving it 0640 root:root.
 	freshPath := filepath.Join(dir, "fresh.conf")
 	mf := &Manager{frrConf: freshPath}
 	if err := mf.writeManagedSection("ip route 10.0.0.0/8 Null0\n"); err != nil {
@@ -1193,8 +1205,8 @@ func TestWriteManagedSection_PreservesExistingMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := fi.Mode().Perm(); got != 0644 {
-		t.Errorf("new file mode: got %o, want 0644", got)
+	if got := fi.Mode().Perm(); got != 0640 {
+		t.Errorf("new file mode: got %o, want 0640 (0644 is world-readable, #4484 L-6)", got)
 	}
 }
 

--- a/pkg/frr/frrconf_mode_4484_test.go
+++ b/pkg/frr/frrconf_mode_4484_test.go
@@ -1,0 +1,102 @@
+// frrconf_mode_4484_test.go — #4484 L-6: frr.conf must not be written
+// world-readable. The xpf-managed section carries routing-authentication
+// secrets (BGP TCP-MD5, OSPF/IS-IS/RIP keys), so a fresh frr.conf is written
+// 0640 (was 0644) and owned root:<frr-group> so the unprivileged frr daemons
+// can still read it, while an existing operator file keeps its own
+// mode+ownership untouched.
+package frr
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestFRRConfFreshWriteMode0640 pins the mode of a freshly created frr.conf to
+// 0640. RED-on-revert: restoring 0644 at the writeManagedSection
+// atomicWriteFile call site makes this fail.
+func TestFRRConfFreshWriteMode0640(t *testing.T) {
+	// Force the "frr group absent" path so the write does not attempt a
+	// (non-root) fchown to the frr gid — that would fail with EPERM and mask
+	// the mode assertion. The 0640 mode is enforced regardless of the owner
+	// override, so this still exercises the security-relevant change.
+	restore := resolveFRRGroup
+	resolveFRRGroup = func() (int, bool) { return 0, false }
+	t.Cleanup(func() { resolveFRRGroup = restore })
+
+	dir := t.TempDir()
+	conf := filepath.Join(dir, "frr.conf")
+	m := &Manager{frrConf: conf}
+	if err := m.writeManagedSection("router bgp 65000\n"); err != nil {
+		t.Fatalf("writeManagedSection: %v", err)
+	}
+	fi, err := os.Stat(conf)
+	if err != nil {
+		t.Fatalf("stat frr.conf: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0o640 {
+		t.Fatalf("fresh frr.conf mode = %04o, want 0640 (0644 is world-readable "+
+			"and leaks routing-auth secrets, #4484 L-6)", got)
+	}
+}
+
+// TestFRRConfPreservesOperatorMode confirms an existing operator frr.conf keeps
+// its own (stricter) mode across a managed-section write — WithPreserveExisting
+// is not overridden by the fresh-create hardening.
+func TestFRRConfPreservesOperatorMode(t *testing.T) {
+	restore := resolveFRRGroup
+	resolveFRRGroup = func() (int, bool) { return 0, false }
+	t.Cleanup(func() { resolveFRRGroup = restore })
+
+	dir := t.TempDir()
+	conf := filepath.Join(dir, "frr.conf")
+	// Operator's pre-existing file at 0600 with no managed markers.
+	if err := os.WriteFile(conf, []byte("hostname r1\nlog syslog informational\n"), 0o600); err != nil {
+		t.Fatalf("seed operator frr.conf: %v", err)
+	}
+	m := &Manager{frrConf: conf}
+	if err := m.writeManagedSection("router bgp 65000\n"); err != nil {
+		t.Fatalf("writeManagedSection: %v", err)
+	}
+	fi, err := os.Stat(conf)
+	if err != nil {
+		t.Fatalf("stat frr.conf: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Fatalf("existing operator frr.conf mode = %04o, want 0600 preserved "+
+			"(fresh-create hardening must not restamp an operator file)", got)
+	}
+}
+
+// TestAtomicWriteOwnerOptDecision pins the owner-override decision matrix:
+// apply owner ONLY on a fresh create when the frr group resolves; never on an
+// existing file (preserve operator ownership); never when the group is absent
+// (best-effort, keep 0640 root:root). RED-on-revert: dropping the exists-gate
+// makes the existing-file case return ok=true; dropping the group-gate makes
+// the absent-group case return ok=true.
+func TestAtomicWriteOwnerOptDecision(t *testing.T) {
+	dir := t.TempDir()
+	fresh := filepath.Join(dir, "does-not-exist.conf")
+	existing := filepath.Join(dir, "exists.conf")
+	if err := os.WriteFile(existing, []byte("x\n"), 0o640); err != nil {
+		t.Fatalf("seed existing: %v", err)
+	}
+
+	restore := resolveFRRGroup
+	t.Cleanup(func() { resolveFRRGroup = restore })
+
+	// Group resolves.
+	resolveFRRGroup = func() (int, bool) { return 4242, true }
+	if _, ok := atomicWriteOwnerOpt(fresh); !ok {
+		t.Fatalf("fresh + group-resolves: want owner override applied, got none")
+	}
+	if _, ok := atomicWriteOwnerOpt(existing); ok {
+		t.Fatalf("existing file: want NO owner override (preserve operator), got one")
+	}
+
+	// Group absent.
+	resolveFRRGroup = func() (int, bool) { return 0, false }
+	if _, ok := atomicWriteOwnerOpt(fresh); ok {
+		t.Fatalf("fresh + group-absent: want NO owner override (best-effort), got one")
+	}
+}

--- a/pkg/frr/manager.go
+++ b/pkg/frr/manager.go
@@ -22,6 +22,8 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"os/user"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -553,7 +555,7 @@ func (m *Manager) writeManagedSection(section string) error {
 	// so a crash or disk-full can never leave frr.conf half-written (which is
 	// what creates the orphaned-begin-marker state handled above in the first
 	// place). rename(2) within a filesystem is atomic.
-	if err := atomicWriteFile(m.frrConf, []byte(content), 0644); err != nil {
+	if err := atomicWriteFile(m.frrConf, []byte(content), 0640); err != nil {
 		return fmt.Errorf("write frr.conf: %w", err)
 	}
 	return nil
@@ -640,7 +642,7 @@ func StripManagedSectionFile(path string) error {
 	if !changed {
 		return nil
 	}
-	if err := atomicWriteFile(path, []byte(stripped), 0644); err != nil {
+	if err := atomicWriteFile(path, []byte(stripped), 0640); err != nil {
 		return fmt.Errorf("strip frr.conf managed section: %w", err)
 	}
 	return nil
@@ -652,7 +654,7 @@ func StripManagedSectionFile(path string) error {
 // half-written file is what creates the orphaned-begin-marker state
 // handled in writeManagedSection).
 //
-// The two options reproduce this function's pre-#1894 semantics
+// The two base options reproduce this function's pre-#1894 semantics
 // verbatim (they were lifted from here, see pkg/fsatomic):
 //   - WithPreserveExisting: an existing target's mode/ownership is
 //     reapplied on the temp fd (fchmod/fchown before rename, no
@@ -664,9 +666,92 @@ func StripManagedSectionFile(path string) error {
 // On top of the previous behavior the durable writer adds the
 // parent-directory fsync that was missing here, making the rename
 // itself crash-safe.
+//
+// #4484 L-6: the managed section carries routing-authentication secrets
+// (BGP TCP-MD5, OSPF/IS-IS/RIP keys), so frr.conf must not be
+// world-readable. Callers now pass perm 0640 instead of the old 0644.
+// A 0640 file is only readable by its owner and group, so on a FRESH
+// create (no operator file to preserve) we install it owned root:<frr>
+// via WithOwner so the unprivileged frr daemons (group frr) can still
+// read it. See atomicWriteOwnerOpt for the fresh-only + best-effort
+// resolution rules that keep this from ever stranding a running FRR or
+// restamping an operator-owned file.
 func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
-	return fsatomic.WriteFileDurable(path, data, perm,
-		fsatomic.WithPreserveExisting(), fsatomic.WithResolveSymlinks())
+	opts := []fsatomic.Option{
+		fsatomic.WithPreserveExisting(),
+		fsatomic.WithResolveSymlinks(),
+	}
+	if owner, ok := atomicWriteOwnerOpt(path); ok {
+		opts = append(opts, owner)
+	}
+	return fsatomic.WriteFileDurable(path, data, perm, opts...)
+}
+
+// atomicWriteOwnerOpt returns a WithOwner(0, frr-gid) option, and ok=false
+// when no ownership override should be applied. It returns an option ONLY
+// when BOTH:
+//
+//   - the target does not already exist — an existing frr.conf keeps its
+//     own mode AND ownership (WithPreserveExisting, and no WithOwner here),
+//     so a commit never restamps an operator's chosen owner (#4484 L-6
+//     "must not override an operator's existing ownership"); and
+//   - the frr group resolves — so we never chown a fresh file to a gid we
+//     could not verify. When the group is absent (FRR not installed — a dev
+//     host or a unit test) we skip the override and the file lands 0640
+//     root:root, which is harmless because nothing reads frr.conf without a
+//     running FRR. This mirrors the pkg/dhcpserver #2450 Kea-memfile owner
+//     handling: own the file by the unprivileged runtime user so a
+//     tightened mode stays readable, best-effort when that user is absent.
+//
+// os.Stat follows symlinks, matching WithResolveSymlinks: a symlink to an
+// existing file is treated as existing (preserve), a dangling symlink as a
+// fresh create (own root:frr on the resolved target).
+func atomicWriteOwnerOpt(path string) (fsatomic.Option, bool) {
+	if _, err := os.Stat(path); err == nil {
+		return nil, false // exists → preserve operator mode+ownership
+	}
+	gid, ok := resolveFRRGroup()
+	if !ok {
+		return nil, false
+	}
+	// uid 0: root owns/writes the xpf-managed frr.conf; the frr group only
+	// needs read access (the daemons load the file at startup), which the
+	// group-read bit of 0640 grants.
+	return fsatomic.WithOwner(0, gid), true
+}
+
+// frrGroupName is the unprivileged group the FRR daemons run under (Debian/
+// Ubuntu appliance base: the `frr` package creates user+group `frr`, and
+// /etc/frr/frr.conf ships mode 0640 owned frr:frr). frr.conf must be readable
+// by this group.
+const frrGroupName = "frr"
+
+// resolveFRRGroup resolves the frr group's numeric gid, and ok=false when no
+// fresh-file chown should be attempted. It is a package var so a test can
+// inject a deterministic gid (or an absent group) without depending on the
+// host's /etc/group. Production uses the real OS group database. The frr.conf
+// write path is the config-apply path (not hot), so resolving per write rather
+// than caching keeps the seam trivially test-injectable at negligible cost.
+//
+// It returns ok=false when the process is not root: only root can chown a
+// fresh frr.conf to root:frr, so a non-root xpf (unit tests, dev hosts) must
+// not attempt the chown (fsatomic would surface the EPERM and fail the write).
+// Production xpfd runs as root, so this gate is a no-op there — and it keeps
+// the frr suite deterministic and portable regardless of whether the test host
+// happens to have an `frr` group.
+var resolveFRRGroup = func() (gid int, ok bool) {
+	if os.Geteuid() != 0 {
+		return 0, false
+	}
+	g, err := user.LookupGroup(frrGroupName)
+	if err != nil {
+		return 0, false
+	}
+	gi, err := strconv.Atoi(g.Gid)
+	if err != nil {
+		return 0, false
+	}
+	return gi, true
 }
 
 // reloadLocked reloads FRR. Caller must hold reloadMu.


### PR DESCRIPTION
Addresses #4484 (L-6). The opus-172 LOW umbrella stays open to track the remaining Rust/lab/deferred items.

## Problem
`frr.conf`'s xpf-managed section carries routing-authentication secrets — BGP TCP-MD5 passwords and OSPF/IS-IS/RIP authentication keys — but the file was written **0644, world-readable** to every local user. Every other secret-bearing file this daemon writes is 0600/0640. (The `StripManagedSectionFile` zeroize-path comment already flagged the "world-readable (0644) /etc/frr/frr.conf" secret residual.)

## Fix
- Change the two `atomicWriteFile` call sites (`writeManagedSection`, `StripManagedSectionFile`) from `0644` → `0640`.
- 0640 is readable only by owner+group, so on a **fresh** create (no operator file to preserve) install the file **owned `root:<frr-group>`** via `fsatomic.WithOwner`, so the unprivileged frr daemons (group `frr`) keep read access.
- The owner override (`atomicWriteOwnerOpt`) applies **only** when BOTH:
  - the target does not already exist — an existing operator file keeps its own mode AND ownership (`WithPreserveExisting`, no `WithOwner`), so a commit never restamps an operator's chosen owner; AND
  - the process is root and the `frr` group resolves — only root can chown to root:frr, so a non-root xpf (unit tests, dev hosts) skips it and the file lands 0640 root:root (harmless: nothing reads frr.conf without a running FRR).

This mirrors the pkg/dhcpserver **#2450** Kea-memfile ownership fix (own a mode-tightened file by the unprivileged runtime user so it stays readable; best-effort when that user is absent). On a real appliance frr.conf ships from the frr package pre-existing 0640 frr:frr, so the fresh path only fires when the file is genuinely absent — and the root gate keeps the frr suite deterministic and portable regardless of whether the test host has an `frr` group.

## Tests (RED-on-revert verified)
- Updated `TestWriteManagedSection_PreservesExistingMode` fresh-file assertion `0644`→`0640`.
- New `frrconf_mode_4484_test.go`: fresh-mode `0640` (FAILS on revert to 0644), operator-mode preservation, and the owner-override decision matrix (fresh+resolves → apply, existing → preserve, group-absent → skip).

## Validation
`go build ./...` clean; `go test ./...` clean (pre-existing pkg/ddns port-bind flake ignored); `gofmt`/`go vet` clean. Documented in `pkg/frr/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi