### PR TITLE
cluster #4484 L-9: show control-link auth engaged vs dual-accept

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,23 @@
+## 2026-07-09 — #4484 L-9: control-link auth engaged/dual-accept show surface
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4484 L-9 — no operator surface revealed whether the #4107
+  control-link HMAC authentication was ENGAGED (enforced) or silently
+  degraded to DUAL-ACCEPT (rolling-upgrade grace). Added
+  `controlLinkAuthStatus()` and wired an `Authentication:` line into
+  `FormatControlPlaneStatistics()` (`show chassis cluster
+  control-plane-statistics`). The tri-state is derived from the SAME two
+  facts the auth gates use — `ControlLinkAuthKey` presence +
+  `HeartbeatPeerAuthSeen` — so it tracks the real enforcement decision:
+  no key → dual-accept; key + peer-auth-seen → engaged; key + peer not yet
+  authenticated → dual-accept grace. Inspects only len(key); never renders
+  the secret. No new gRPC RPC / cmdtree command — the command already
+  exists. Added `controllink_auth_status_4484_test.go` (3-state matrix +
+  key-never-leaked + FormatControlPlaneStatistics-includes-Authentication).
+  RED-on-revert verified (removing the line fails the render test).
+  **File(s)**: pkg/cluster/status.go,
+  pkg/cluster/controllink_auth_status_4484_test.go, pkg/cluster/README.md
+
 ## 2026-07-09 — #4671: relocate frame/wg.rs inline tests to sibling wg_tests.rs
 
 - **Timestamp**: 2026-07-09

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -230,6 +230,20 @@ peer liveness (`lastSeen`) or drive election.
   Enforcement therefore engages only once BOTH nodes carry the key and
   are observed signing — a mixed-version / mid-key-rollout cluster never
   splits.
+- **Operator surface (#4484 L-9).** `FormatControlPlaneStatistics`
+  (`show chassis cluster control-plane-statistics`) renders an
+  `Authentication:` line derived from `controlLinkAuthStatus()`, so an
+  operator can tell whether the control link's HMAC auth is actually
+  **engaged** (`engaged (peer authenticated; unauthenticated frames
+  rejected)` — both nodes keyed and signing) or running in
+  **dual-accept** grace (`dual-accept (no control-link key configured)`
+  or `dual-accept (key configured; peer not yet authenticated)`). It is
+  computed from the SAME two facts the auth gates use —
+  `ControlLinkAuthKey` presence + `HeartbeatPeerAuthSeen` — so the line
+  tracks the real enforcement decision, and it inspects only `len(key)`
+  so the secret is never rendered. Before this line, a control link
+  silently degraded to dual-accept (e.g. a peer that stopped signing)
+  was invisible.
 - **Secret hygiene.** The key is `config.Secret`, redacted on every
   JSON/YAML/`String()` path and masked as `##SECRET-DATA##` in raw-AST
   renders (`authentication-key` is already in `ast_redact.go`'s secret

--- a/pkg/cluster/controllink_auth_status_4484_test.go
+++ b/pkg/cluster/controllink_auth_status_4484_test.go
@@ -1,0 +1,87 @@
+// controllink_auth_status_4484_test.go — #4484 L-9: the control-plane
+// statistics surface must reveal whether the #4107 control-link authentication
+// is ENGAGED (enforced) or silently degraded to DUAL-ACCEPT. The status string
+// is derived from the same two facts the auth-decision gates use
+// (ControlLinkAuthKey + HeartbeatPeerAuthSeen), so it tracks the real
+// enforcement posture.
+package cluster
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestControlLinkAuthStatus(t *testing.T) {
+	tests := []struct {
+		name         string
+		key          []byte
+		peerAuthSeen bool
+		wantEngaged  bool   // "engaged" vs "dual-accept"
+		wantContains string // a stable discriminating substring
+	}{
+		{
+			name:         "no key configured -> dual-accept",
+			key:          nil,
+			peerAuthSeen: false,
+			wantEngaged:  false,
+			wantContains: "no control-link key configured",
+		},
+		{
+			name:         "key configured, peer not yet authenticated -> dual-accept grace",
+			key:          []byte("shared-psk-16byte"),
+			peerAuthSeen: false,
+			wantEngaged:  false,
+			wantContains: "peer not yet authenticated",
+		},
+		{
+			name:         "key configured, peer authenticated -> engaged",
+			key:          []byte("shared-psk-16byte"),
+			peerAuthSeen: true,
+			wantEngaged:  true,
+			wantContains: "unauthenticated frames rejected",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Manager{controlAuthKey: tc.key}
+			r := &heartbeatReceiver{mgr: m}
+			m.hbReceiver = r
+			r.peerAuthSeen.Store(tc.peerAuthSeen)
+
+			got := m.controlLinkAuthStatus()
+			engaged := strings.HasPrefix(got, "engaged")
+			if engaged != tc.wantEngaged {
+				t.Errorf("controlLinkAuthStatus() = %q; engaged=%v, want engaged=%v",
+					got, engaged, tc.wantEngaged)
+			}
+			if !strings.Contains(got, tc.wantContains) {
+				t.Errorf("controlLinkAuthStatus() = %q; want to contain %q", got, tc.wantContains)
+			}
+
+			// The secret key bytes must never leak into the rendered status.
+			if len(tc.key) > 0 && strings.Contains(got, string(tc.key)) {
+				t.Errorf("controlLinkAuthStatus() leaked the control-link key: %q", got)
+			}
+		})
+	}
+}
+
+// TestFormatControlPlaneStatisticsIncludesAuth pins that the auth posture is
+// wired into the operator-visible `show chassis cluster
+// control-plane-statistics` render (FormatControlPlaneStatistics), not just the
+// helper. RED-on-revert: dropping the Authentication line makes this fail.
+func TestFormatControlPlaneStatisticsIncludesAuth(t *testing.T) {
+	m := &Manager{controlAuthKey: []byte("shared-psk-16byte")}
+	r := &heartbeatReceiver{mgr: m}
+	m.hbReceiver = r
+	r.peerAuthSeen.Store(true)
+
+	out := m.FormatControlPlaneStatistics()
+	if !strings.Contains(out, "Authentication:") {
+		t.Errorf("FormatControlPlaneStatistics missing Authentication line:\n%s", out)
+	}
+	if !strings.Contains(out, "engaged") {
+		t.Errorf("FormatControlPlaneStatistics did not report engaged auth:\n%s", out)
+	}
+}

--- a/pkg/cluster/status.go
+++ b/pkg/cluster/status.go
@@ -415,7 +415,37 @@ func (m *Manager) FormatControlPlaneStatistics() string {
 	fmt.Fprintf(&b, "    Heartbeat packets received: %d\n", hbStats.Received)
 	fmt.Fprintf(&b, "    Heartbeat send errors:      %d\n", hbStats.SendErrors)
 	fmt.Fprintf(&b, "    Heartbeat receive errors:   %d\n", hbStats.RecvErrors)
+	fmt.Fprintf(&b, "    Authentication:             %s\n", m.controlLinkAuthStatus())
 	return b.String()
+}
+
+// controlLinkAuthStatus summarizes the #4107 control-link authentication
+// posture for the operator (#4484 L-9). Before this surface existed, nothing
+// revealed whether the control link's HMAC authentication was actually
+// ENGAGED (frames are verified and an unauthenticated peer is rejected) or had
+// silently degraded to DUAL-ACCEPT (an unauthenticated peer is still
+// accepted) — the rolling-upgrade grace #4107 deliberately keeps open. The
+// posture is derived from the SAME two facts syncAuthDecision /
+// heartbeatAuthDecision gate on — the local key (ControlLinkAuthKey) and the
+// sticky peer-authenticated flag (HeartbeatPeerAuthSeen) — so this string
+// tracks the real enforcement decision rather than a separate estimate. It
+// only inspects len(key) and never renders the secret.
+func (m *Manager) controlLinkAuthStatus() string {
+	keyConfigured := len(m.ControlLinkAuthKey()) > 0
+	switch {
+	case !keyConfigured:
+		// No local key: this node cannot verify a peer and may be the
+		// not-yet-keyed side of a rolling upgrade — dual-accept grace.
+		return "dual-accept (no control-link key configured)"
+	case m.HeartbeatPeerAuthSeen():
+		// Both nodes are known-keyed and the peer has proven it: an
+		// unauthenticated frame is now rejected as a downgrade attack.
+		return "engaged (peer authenticated; unauthenticated frames rejected)"
+	default:
+		// Local key set but the peer has not authenticated yet (peer still
+		// upgrading / not signing): grace is still open.
+		return "dual-accept (key configured; peer not yet authenticated)"
+	}
 }
 
 // FormatDataPlaneStatistics returns data-plane (session sync) statistics.


### PR DESCRIPTION
Addresses #4484 (L-9). The opus-172 LOW umbrella stays open to track the remaining Rust/lab/deferred items.

## Problem
The #4107 control-link HMAC authentication runs in a deliberate **dual-accept** grace during a rolling upgrade and only **engages** enforcement once both nodes carry the key and are observed signing. But no operator surface revealed which state the link was in, so a control link silently degraded to dual-accept — a peer that stopped signing, a half-configured key — was invisible.

## Fix
Add `controlLinkAuthStatus()` and render an `Authentication:` line in `FormatControlPlaneStatistics` (`show chassis cluster control-plane-statistics`). The posture is a tri-state derived from the **same two facts** `syncAuthDecision` / `heartbeatAuthDecision` gate on:

| Local key | Peer authenticated | Rendered |
|---|---|---|
| no | — | `dual-accept (no control-link key configured)` |
| yes | yes | `engaged (peer authenticated; unauthenticated frames rejected)` |
| yes | no | `dual-accept (key configured; peer not yet authenticated)` |

Because it reuses `ControlLinkAuthKey()` presence + `HeartbeatPeerAuthSeen()`, the line tracks the **real enforcement decision** rather than a separate estimate, and it inspects only `len(key)` so the secret is never rendered. No new gRPC RPC or cmdtree command is needed — the show command already exists; this only adds a line to its render (the deferral in the earlier #4484 PR over-estimated the scope as "new gRPC + CLI cmdtree wiring").

## Tests (RED-on-revert verified)
`controllink_auth_status_4484_test.go`: the three states, that the key bytes never leak into the string, and that the `Authentication:` line is wired into `FormatControlPlaneStatistics` (removing the line FAILS the render test).

## Validation
`go build ./...` clean; `go test ./pkg/cluster/... ./pkg/grpcapi/... ./pkg/cli/...` green; full `go test ./...` clean (pre-existing pkg/ddns port-bind flake ignored); `gofmt`/`go vet` clean. Documented in `pkg/cluster/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi