### PR TITLE
feat(cli): show effective (compiled) firewall-filter (#4422)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43400,3 +43400,21 @@ top.
   go build clean; go test ./pkg/ddns green; go test -race ./pkg/ddns green;
   full Go suite green.
 - **File(s)**: pkg/ddns/surface_a_provider_transition_4422_test.go, _Log.md
+
+- **Timestamp**: 2026-07-09
+- **Action**: #4422 slice — add `show firewall [filter <name>] effective
+  [family <f>]` CLI surface rendering the compiled FirewallFilterSnapshot the
+  userspace dataplane actually receives (prefix-list resolution, address/port
+  except folding, DSCP code-point resolution, tcp-flags mask lowering,
+  fall-through, fail-closed markers), distinct from the raw
+  `show firewall filter` typed-config view. VERIFY-FIRST: raw view existed
+  (cli_show_security_filters.go) but no surface exposed the effective/compiled
+  snapshot — genuine observability gap. Exported
+  dpuserspace.BuildFirewallFilterSnapshots (thin wrapper over the existing
+  builder); added cmdtree `effective` node; behavior-pinning tests
+  (prefix-list resolved vs raw reference, multi-value survival, DSCP ef->46,
+  fall-through). go build + full Go suite green (53 ok / 0 fail).
+- **File(s)**: pkg/dataplane/userspace/filters.go, pkg/cli/cli_show.go,
+  pkg/cli/cli_show_security_filters.go,
+  pkg/cli/cli_show_effective_filter_4422_test.go, pkg/cmdtree/tree.go,
+  docs/junos-cli-reference.md, _Log.md

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -28,22 +28,23 @@ Junos output formatting in xpf.
 16. [Security: IPsec SAs Detail](#security-ipsec-security-associations-detail)
 17. [Security: IKE SAs](#security-ike-security-associations)
 18. [Security: Log](#security-log)
-19. [Interfaces: Terse](#interfaces-terse)
-20. [Interfaces: Detail](#interfaces-detail)
-21. [Interfaces: Extensive](#interfaces-extensive)
-22. [System: Uptime](#system-uptime)
-23. [System: Memory](#system-memory)
-24. [System: Processes Summary](#system-processes-summary)
-25. [System: Version](#system-version)
-26. [Chassis Cluster: Status](#chassis-cluster-status)
-27. [Chassis Cluster: Interfaces](#chassis-cluster-interfaces)
-28. [Routing: Route Table (Brief)](#routing-route-table-brief)
-29. [Routing: Route Destination Lookup](#routing-route-destination-lookup)
-30. [Routing: Route Summary](#routing-route-summary)
-31. [Routing: BGP Summary](#routing-bgp-summary)
-32. [Routing: ARP](#routing-arp)
-33. [Pipe Filters](#pipe-filters)
-34. [Configuration Display](#configuration-display)
+19. [Firewall: Filters (raw and effective)](#firewall-filters-raw-and-effective)
+20. [Interfaces: Terse](#interfaces-terse)
+21. [Interfaces: Detail](#interfaces-detail)
+22. [Interfaces: Extensive](#interfaces-extensive)
+23. [System: Uptime](#system-uptime)
+24. [System: Memory](#system-memory)
+25. [System: Processes Summary](#system-processes-summary)
+26. [System: Version](#system-version)
+27. [Chassis Cluster: Status](#chassis-cluster-status)
+28. [Chassis Cluster: Interfaces](#chassis-cluster-interfaces)
+29. [Routing: Route Table (Brief)](#routing-route-table-brief)
+30. [Routing: Route Destination Lookup](#routing-route-destination-lookup)
+31. [Routing: Route Summary](#routing-route-summary)
+32. [Routing: BGP Summary](#routing-bgp-summary)
+33. [Routing: ARP](#routing-arp)
+34. [Pipe Filters](#pipe-filters)
+35. [Configuration Display](#configuration-display)
 
 ---
 
@@ -1508,6 +1509,79 @@ the local CLI and the remote `cli` (gRPC text path). Both share one parser,
 forwarded only a numeric count to the daemon and dropped any zone/protocol/
 action selector, so `show security log zone <name>` on the remote client
 silently dumped every event instead of isolating the requested zone.
+
+---
+
+## Firewall: Filters (raw and effective)
+
+**Commands:**
+
+- `show firewall` — all filters, RAW typed config.
+- `show firewall filter <name> [family inet|inet6]` — one filter, RAW.
+- `show firewall effective [family inet|inet6]` — all filters, EFFECTIVE
+  (compiled) view.
+- `show firewall filter <name> effective [family inet|inet6]` — one filter,
+  EFFECTIVE.
+
+The RAW view (`show firewall …`) prints the typed configuration as authored —
+literal addresses, `from source-prefix-list <name>` references by NAME,
+symbolic DSCP names, and each term's raw `then` selectors, alongside live
+per-term hit counters read from the dataplane.
+
+The EFFECTIVE view (`… effective`, #4422) rebuilds and prints the
+`FirewallFilterSnapshot` the userspace dataplane actually receives — the exact
+match/action the matcher enforces. It is read-only and derives entirely from
+the active config (it reads `dpuserspace.BuildFirewallFilterSnapshots`, the
+same builder `buildSnapshot` threads into `ConfigSnapshot.Filters`); it touches
+no dataplane state and reports no hit counters. It differs from the RAW view
+where compilation transforms the term:
+
+- **Prefix-list references are resolved** to their literal prefixes
+  (`from source-prefix-list trusted` → `from source-address 10.0.0.0/8,
+  192.168.0.0/16`), matching #2506 lowering.
+- **`except` prefix-lists** render as `from source-address except …`; an empty
+  positive set renders `(empty set — matches nothing)` and an empty `except`
+  set `(empty set — matches any)`, exposing the fail-closed / match-all
+  Junos empty-set semantics. A mixed positive+except term (rejected at strict
+  commit, #3359) is shown positive-wins.
+- **Multi-value match lists** (bracketed `[ … ]`, #2419) survive the collapse
+  and render every value (`from destination-port 22, 80`).
+- **Symbolic DSCP names resolve to numeric code points** (`ef` → `46`).
+- **`tcp-flags` expressions** render as lowered `require`/`forbid` masks
+  (#3076).
+- **Fall-through** — a `then next term` or modifier-only term (no terminating
+  action) renders `then next term (fall-through)` (#2544); a terminating term
+  renders `then <action>` (default `accept`).
+- **Unrepresentable matches** — a token the compiler cannot lower (an
+  out-of-range ICMP type, an unknown DSCP, an unparseable `tcp-flags`) that
+  reaches the snapshot on the lenient / peer-sync path renders
+  `<unrepresentable — snapshot fails closed>`, mirroring the fail-closed
+  markers the Rust filter compiler acts on (#3406/#3367).
+
+The heading carries a `[effective]` tag (`Filter: demo (family inet)
+[effective]`) so the compiled view is never confused with the raw output.
+
+```
+Filter: demo (family inet) [effective]
+  Term: t1
+    from source-address 10.0.0.0/8, 192.168.0.0/16
+    from protocol tcp
+    from destination-port 22, 80
+    from dscp 46
+    then forwarding-class best-effort
+    then count c1
+    then next term (fall-through)
+  Term: t2
+    then accept
+```
+
+### Format Details
+
+- Heading: `Filter: <name> (family inet|inet6) [effective]`.
+- Per term: `  Term: <name>`, then `from …` match lines, then `then …` action
+  and modifier lines (2-space / 4-space indent).
+- The `effective` keyword is a trailing modifier and composes with the loose
+  `family <f>` selector in either order.
 
 ---
 

--- a/pkg/cli/cli_show.go
+++ b/pkg/cli/cli_show.go
@@ -131,6 +131,19 @@ func (c *CLI) handleShow(args []string) error {
 		return nil
 
 	case "firewall":
+		// #4422: `show firewall [filter <name>] effective [family <f>]` renders
+		// the compiled FirewallFilterSnapshot the dataplane actually receives
+		// (post prefix-list resolution, DSCP code-point resolution, TCP-flags
+		// lowering, fall-through, fail-closed markers) instead of the raw config.
+		// `effective` is a trailing modifier alongside the existing loose
+		// `family <f>` modifier, so scan for both.
+		if firewallArgsHaveWord(args, "effective") {
+			family := firewallFamilyArg(args)
+			if len(args) >= 3 && args[1] == "filter" {
+				return c.showEffectiveFirewallFilter(args[2], family)
+			}
+			return c.showEffectiveFirewallFilters(family)
+		}
 		if len(args) >= 3 && args[1] == "filter" {
 			family := ""
 			if len(args) >= 5 && args[3] == "family" {
@@ -241,4 +254,28 @@ func (c *CLI) handleShow(args []string) error {
 	default:
 		return fmt.Errorf("unknown show target: %s", args[0])
 	}
+}
+
+// firewallArgsHaveWord reports whether word appears anywhere in the firewall
+// show arguments (args[0] is "firewall"). Used to detect the trailing
+// `effective` modifier (#4422) regardless of its position relative to the
+// `filter <name>` / `family <f>` tokens.
+func firewallArgsHaveWord(args []string, word string) bool {
+	for _, a := range args {
+		if a == word {
+			return true
+		}
+	}
+	return false
+}
+
+// firewallFamilyArg extracts the value of the loose trailing `family <f>`
+// modifier from the firewall show arguments, or "" if absent (#4422).
+func firewallFamilyArg(args []string) string {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "family" {
+			return args[i+1]
+		}
+	}
+	return ""
 }

--- a/pkg/cli/cli_show_effective_filter_4422_test.go
+++ b/pkg/cli/cli_show_effective_filter_4422_test.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// #4422: `show firewall [filter <name>] effective` must render the COMPILED
+// FirewallFilterSnapshot the dataplane actually receives — NOT the raw typed
+// config. The sharpest differentiator is a `from source-prefix-list` reference:
+// the raw `show firewall filter` prints the reference name verbatim, while the
+// effective view resolves it to the literal prefixes the matcher enforces
+// (#2506). This also pins multi-value list survival (bracketed destination-port
+// collapse, #2419), DSCP code-point resolution (`ef` -> 46), and fall-through
+// (a modifier-only term renders `then next term`, #2544).
+func newEffectiveFilterTestStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	for _, cmd := range []string{
+		"policy-options prefix-list trusted 10.0.0.0/8",
+		"policy-options prefix-list trusted 192.168.0.0/16",
+		// term t1: scoped by a prefix-list reference + a multi-value port list +
+		// a symbolic DSCP; modifier-only `then` (count + forwarding-class, no
+		// terminating action) => fall-through.
+		"firewall family inet filter demo term t1 from source-prefix-list trusted",
+		"firewall family inet filter demo term t1 from protocol tcp",
+		"firewall family inet filter demo term t1 from destination-port [ 22 80 ]",
+		"firewall family inet filter demo term t1 from dscp ef",
+		"firewall family inet filter demo term t1 then count c1",
+		"firewall family inet filter demo term t1 then forwarding-class best-effort",
+		// term t2: terminating accept.
+		"firewall family inet filter demo term t2 then accept",
+	} {
+		if err := store.SetFromInput(cmd); err != nil {
+			t.Fatalf("SetFromInput(%q) error = %v", cmd, err)
+		}
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+func TestShowEffectiveFirewallFilterRendersCompiledSnapshot(t *testing.T) {
+	c := &CLI{store: newEffectiveFilterTestStore(t)}
+
+	var effErr error
+	effOut := captureStdout(t, func() {
+		effErr = c.handleShow([]string{"firewall", "effective"})
+	})
+	if effErr != nil {
+		t.Fatalf("handleShow(firewall effective) error = %v", effErr)
+	}
+
+	// Heading is tagged [effective] to distinguish from the raw view.
+	if !strings.Contains(effOut, "Filter: demo (family inet) [effective]") {
+		t.Fatalf("effective output = %q, want [effective] heading", effOut)
+	}
+	// The prefix-list reference is RESOLVED to literal prefixes (the compiled
+	// form) — and the raw reference name is NOT surfaced.
+	if !strings.Contains(effOut, "from source-address 10.0.0.0/8, 192.168.0.0/16") {
+		t.Fatalf("effective output = %q, want resolved source-address prefixes", effOut)
+	}
+	if strings.Contains(effOut, "source-prefix-list") {
+		t.Fatalf("effective output = %q, unexpectedly shows the raw prefix-list reference", effOut)
+	}
+	// Multi-value destination-port list collapsed and survived (#2419).
+	if !strings.Contains(effOut, "from destination-port 22, 80") {
+		t.Fatalf("effective output = %q, want multi-value destination-port 22, 80", effOut)
+	}
+	// DSCP name resolved to its numeric code point (ef -> 46).
+	if !strings.Contains(effOut, "from dscp 46") {
+		t.Fatalf("effective output = %q, want DSCP resolved to code point 46", effOut)
+	}
+	// Modifier-only t1 is a fall-through; t2 terminates with accept.
+	if !strings.Contains(effOut, "then next term (fall-through)") {
+		t.Fatalf("effective output = %q, want fall-through for modifier-only term t1", effOut)
+	}
+	if !strings.Contains(effOut, "then accept") {
+		t.Fatalf("effective output = %q, want terminating accept for term t2", effOut)
+	}
+
+	// Contrast: the RAW view prints the prefix-list reference verbatim and does
+	// NOT resolve it — proving the effective view is a distinct, compiled surface.
+	var rawErr error
+	rawOut := captureStdout(t, func() {
+		rawErr = c.handleShow([]string{"firewall", "filter", "demo"})
+	})
+	if rawErr != nil {
+		t.Fatalf("handleShow(firewall filter demo) error = %v", rawErr)
+	}
+	if !strings.Contains(rawOut, "from source-prefix-list trusted") {
+		t.Fatalf("raw output = %q, want the unresolved prefix-list reference", rawOut)
+	}
+	if strings.Contains(rawOut, "[effective]") {
+		t.Fatalf("raw output = %q, unexpectedly tagged [effective]", rawOut)
+	}
+}
+
+// The single-filter form honors the name and family selectors, and reports a
+// clean miss for an unknown filter.
+func TestShowEffectiveFirewallFilterByNameAndFamily(t *testing.T) {
+	c := &CLI{store: newEffectiveFilterTestStore(t)}
+
+	var err error
+	out := captureStdout(t, func() {
+		err = c.handleShow([]string{"firewall", "filter", "demo", "effective", "family", "inet"})
+	})
+	if err != nil {
+		t.Fatalf("handleShow(firewall filter demo effective family inet) error = %v", err)
+	}
+	if !strings.Contains(out, "Filter: demo (family inet) [effective]") {
+		t.Fatalf("output = %q, want inet effective heading", out)
+	}
+
+	// Wrong family: no inet6 filter named demo -> not found.
+	missOut := captureStdout(t, func() {
+		err = c.handleShow([]string{"firewall", "filter", "demo", "effective", "family", "inet6"})
+	})
+	if err != nil {
+		t.Fatalf("handleShow(... family inet6) error = %v", err)
+	}
+	if !strings.Contains(missOut, "Filter not found: demo (family inet6)") {
+		t.Fatalf("output = %q, want not-found for family inet6", missOut)
+	}
+
+	// Unknown filter name.
+	unknownOut := captureStdout(t, func() {
+		err = c.handleShow([]string{"firewall", "filter", "nope", "effective"})
+	})
+	if err != nil {
+		t.Fatalf("handleShow(firewall filter nope effective) error = %v", err)
+	}
+	if !strings.Contains(unknownOut, "Filter not found: nope") {
+		t.Fatalf("output = %q, want not-found for unknown filter", unknownOut)
+	}
+}

--- a/pkg/cli/cli_show_security_filters.go
+++ b/pkg/cli/cli_show_security_filters.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -333,4 +334,221 @@ func (c *CLI) showFirewallFilter(name, requestedFamily string) error {
 		fmt.Printf("warning: filter counter read failed (hit counts may be incomplete): %v\n", readErr)
 	}
 	return nil
+}
+
+// showEffectiveFirewallFilters renders the EFFECTIVE (compiled) firewall-filter
+// snapshots the userspace dataplane actually receives (#4422). Unlike
+// showFirewallFilters (which prints the raw typed config), this rebuilds the
+// FirewallFilterSnapshot the config compiler emits and prints the terms exactly
+// as the matcher enforces them: prefix-list references resolved to literal
+// prefixes, address/port `except` folded (positive-wins on a mixed term), DSCP
+// tokens resolved to numeric code points, TCP-flags lowered to required/
+// forbidden masks, `then next term` / modifier-only fall-through computed, and
+// any unrepresentable match marked fail-closed. It is read-only — it derives the
+// snapshot from the active config and never touches the dataplane.
+func (c *CLI) showEffectiveFirewallFilters(family string) error {
+	cfg := c.store.ActiveConfig()
+	if cfg == nil {
+		fmt.Println("No active configuration")
+		return nil
+	}
+	family = strings.TrimSpace(family)
+	if family != "" && family != "inet" && family != "inet6" {
+		fmt.Printf("invalid family: %s\n", family)
+		return nil
+	}
+	snaps := dpuserspace.BuildFirewallFilterSnapshots(cfg)
+	rendered := 0
+	for i := range snaps {
+		if family != "" && snaps[i].Family != family {
+			continue
+		}
+		renderEffectiveFilterSnapshot(&snaps[i])
+		rendered++
+	}
+	if rendered == 0 {
+		if family != "" {
+			fmt.Printf("No firewall filters configured (family %s)\n", family)
+		} else {
+			fmt.Println("No firewall filters configured")
+		}
+	}
+	return nil
+}
+
+// showEffectiveFirewallFilter renders the effective (compiled) snapshot for a
+// single named filter (#4422). Family "" auto-selects whichever family defines
+// the name (inet then inet6), matching showFirewallFilter.
+func (c *CLI) showEffectiveFirewallFilter(name, family string) error {
+	cfg := c.store.ActiveConfig()
+	if cfg == nil {
+		fmt.Println("No active configuration")
+		return nil
+	}
+	family = strings.TrimSpace(family)
+	if family != "" && family != "inet" && family != "inet6" {
+		fmt.Printf("invalid family: %s\n", family)
+		return nil
+	}
+	snaps := dpuserspace.BuildFirewallFilterSnapshots(cfg)
+	found := false
+	for i := range snaps {
+		if snaps[i].Name != name {
+			continue
+		}
+		if family != "" && snaps[i].Family != family {
+			continue
+		}
+		renderEffectiveFilterSnapshot(&snaps[i])
+		found = true
+	}
+	if !found {
+		if family != "" {
+			fmt.Printf("Filter not found: %s (family %s)\n", name, family)
+		} else {
+			fmt.Printf("Filter not found: %s\n", name)
+		}
+	}
+	return nil
+}
+
+// renderEffectiveFilterSnapshot prints one compiled FirewallFilterSnapshot. The
+// `[effective]` tag in the heading distinguishes it from the raw
+// `show firewall filter` output.
+func renderEffectiveFilterSnapshot(snap *dpuserspace.FirewallFilterSnapshot) {
+	fmt.Printf("Filter: %s (family %s) [effective]\n", snap.Name, snap.Family)
+	if len(snap.Terms) == 0 {
+		fmt.Println("  (no terms — matches nothing)")
+		fmt.Println()
+		return
+	}
+	for i := range snap.Terms {
+		term := &snap.Terms[i]
+		fmt.Printf("  Term: %s\n", term.Name)
+
+		// --- from (match conditions, as lowered for the matcher) ---
+		if s := effectiveAddrMatchLine("source", term.SourceAddresses, term.SourceExcept, term.SourceConstrained); s != "" {
+			fmt.Print(s)
+		}
+		if s := effectiveAddrMatchLine("destination", term.DestAddresses, term.DestExcept, term.DestConstrained); s != "" {
+			fmt.Print(s)
+		}
+		for _, p := range term.Protocols {
+			fmt.Printf("    from protocol %s\n", p)
+		}
+		if len(term.SourcePorts) > 0 {
+			fmt.Printf("    from source-port %s\n", strings.Join(term.SourcePorts, ", "))
+		}
+		if len(term.SourcePortsExcept) > 0 {
+			fmt.Printf("    from source-port-except %s\n", strings.Join(term.SourcePortsExcept, ", "))
+		}
+		if len(term.DestPorts) > 0 {
+			fmt.Printf("    from destination-port %s\n", strings.Join(term.DestPorts, ", "))
+		}
+		if len(term.DestPortsExcept) > 0 {
+			fmt.Printf("    from destination-port-except %s\n", strings.Join(term.DestPortsExcept, ", "))
+		}
+		if len(term.DSCPValues) > 0 {
+			fmt.Printf("    from dscp %s\n", formatWireUint8List(term.DSCPValues))
+		}
+		if term.DSCPMatchUnrepresentable {
+			fmt.Printf("    from dscp <unrepresentable — snapshot fails closed>\n")
+		}
+		if len(term.ICMPTypes) > 0 {
+			fmt.Printf("    from icmp-type %s\n", formatWireUint8List(term.ICMPTypes))
+		}
+		if term.ICMPTypeUnrepresentable {
+			fmt.Printf("    from icmp-type <unrepresentable — snapshot fails closed>\n")
+		}
+		if len(term.ICMPCodes) > 0 {
+			fmt.Printf("    from icmp-code %s\n", formatWireUint8List(term.ICMPCodes))
+		}
+		if term.ICMPCodeUnrepresentable {
+			fmt.Printf("    from icmp-code <unrepresentable — snapshot fails closed>\n")
+		}
+		if term.TCPFlags != nil {
+			fmt.Printf("    from tcp-flags require 0x%02x\n", *term.TCPFlags)
+		}
+		if term.TCPFlagsForbidden != nil {
+			fmt.Printf("    from tcp-flags forbid 0x%02x\n", *term.TCPFlagsForbidden)
+		}
+		if term.TCPFlagsUnparseable {
+			fmt.Printf("    from tcp-flags <unparseable — snapshot fails closed>\n")
+		}
+		if term.IsFragment {
+			fmt.Printf("    from is-fragment\n")
+		}
+		if fm := term.FlexMatch; fm != nil {
+			base := fm.MatchStart
+			if base == "" {
+				base = "layer-3"
+			}
+			fmt.Printf("    from flexible-match-range match-start %s offset %d length %d value 0x%x mask 0x%x\n",
+				base, fm.Offset, fm.Length, fm.Value, fm.Mask)
+		}
+
+		// --- then (action + modifiers) ---
+		if term.RoutingInstance != "" {
+			fmt.Printf("    then routing-instance %s\n", term.RoutingInstance)
+		}
+		if term.ForwardingClass != "" {
+			fmt.Printf("    then forwarding-class %s\n", term.ForwardingClass)
+		}
+		if term.PolicerName != "" {
+			fmt.Printf("    then policer %s\n", term.PolicerName)
+		}
+		if term.DSCPRewrite != nil {
+			fmt.Printf("    then dscp %d\n", *term.DSCPRewrite)
+		}
+		if term.Log {
+			fmt.Printf("    then log\n")
+		}
+		if term.Count != "" {
+			fmt.Printf("    then count %s\n", term.Count)
+		}
+		// NextTerm marks a fall-through term (no terminating action); a
+		// non-fall-through term terminates with its action (default accept).
+		if term.NextTerm {
+			fmt.Printf("    then next term (fall-through)\n")
+		} else {
+			action := term.Action
+			if action == "" {
+				action = "accept"
+			}
+			fmt.Printf("    then %s\n", action)
+		}
+	}
+	fmt.Println()
+}
+
+// effectiveAddrMatchLine formats one direction's compiled address match. It
+// distinguishes the four post-resolution states the matcher enforces
+// (resolvePrefixListAddrs / ResolveFilterPrefixListAddrs): unconstrained
+// (matches any — emits nothing), a positive set (empty positive = matches
+// nothing, fail-closed), an `except` set (empty except = matches any), and the
+// populated forms.
+func effectiveAddrMatchLine(dir string, addrs []string, except, constrained bool) string {
+	if !constrained {
+		return ""
+	}
+	switch {
+	case except && len(addrs) == 0:
+		return fmt.Sprintf("    from %s-address except (empty set — matches any)\n", dir)
+	case except:
+		return fmt.Sprintf("    from %s-address except %s\n", dir, strings.Join(addrs, ", "))
+	case len(addrs) == 0:
+		return fmt.Sprintf("    from %s-address (empty set — matches nothing)\n", dir)
+	default:
+		return fmt.Sprintf("    from %s-address %s\n", dir, strings.Join(addrs, ", "))
+	}
+}
+
+// formatWireUint8List renders a compiled uint8 match set (DSCP code points,
+// ICMP type/code bytes) as comma-separated decimals.
+func formatWireUint8List(vals dpuserspace.WireUint8List) string {
+	parts := make([]string, len(vals))
+	for i, v := range vals {
+		parts[i] = strconv.Itoa(int(v))
+	}
+	return strings.Join(parts, ", ")
 }

--- a/pkg/cmdtree/tree.go
+++ b/pkg/cmdtree/tree.go
@@ -219,6 +219,7 @@ var OperationalTree = map[string]*Node{
 			"client-identifier": {Desc: "Show DHCPv6 DUID(s)"},
 		}},
 		"firewall": {Desc: "Show firewall filter configuration", Children: map[string]*Node{
+			"effective": {Desc: "Show effective (compiled) firewall filter the dataplane receives"},
 			"filter": {Desc: "Show specific filter by name", DynamicFn: func(cfg *config.Config) []string {
 				if cfg == nil {
 					return nil

--- a/pkg/dataplane/userspace/filters.go
+++ b/pkg/dataplane/userspace/filters.go
@@ -11,6 +11,19 @@ import (
 	"github.com/psaab/xpf/pkg/dataplane"
 )
 
+// BuildFirewallFilterSnapshots returns the effective (compiled) firewall-filter
+// snapshots the userspace dataplane actually receives for cfg — the same value
+// buildSnapshot threads into ConfigSnapshot.Filters. It is exported so the
+// `show firewall [filter <name>] effective` CLI surface (#4422) can render
+// exactly what the matcher enforces: post prefix-list resolution, address/port
+// `except` folding (positive-wins on a mixed term), DSCP code-point resolution,
+// TCP-flags mask lowering, fall-through (NextTerm) computation, flex-match
+// lowering, and fail-closed (unrepresentable) marker assignment. It is
+// read-only and derives entirely from cfg — it touches no dataplane state.
+func BuildFirewallFilterSnapshots(cfg *config.Config) []FirewallFilterSnapshot {
+	return buildFirewallFilterSnapshots(cfg)
+}
+
 func buildFirewallFilterSnapshots(cfg *config.Config) []FirewallFilterSnapshot {
 	if cfg == nil {
 		return nil


### PR DESCRIPTION
Addresses #4422 (the "'show effective firewall-filter' surface" observability item).

## Verify-first
The raw firewall-filter renderers (`pkg/cli/cli_show_security_filters.go`,
`showFirewallFilters` / `showFirewallFilter`) print `cfg.Firewall.FiltersInet/6`
— the typed config as authored (prefix-list references by name, symbolic DSCP
names, raw `then` selectors). No CLI, gRPC, or REST surface exposed the
EFFECTIVE (compiled) `FirewallFilterSnapshot` that the userspace dataplane
actually receives (`pkg/dataplane/userspace/filters.go`
`buildFirewallFilterSnapshots`, threaded into `ConfigSnapshot.Filters` by
`builder.go`). The observability gap is genuine.

## What this adds
A read-only CLI surface that renders the compiled snapshot:

```
show firewall effective [family inet|inet6]
show firewall filter <name> effective [family inet|inet6]
```

`effective` is a trailing modifier composing with the loose `family <f>`
selector in either order. The heading carries an `[effective]` tag so the
compiled view is never confused with the raw output. It derives entirely from
the active config and touches no dataplane state.

Where the effective view differs from raw (all are compiler lowerings):
- prefix-list references resolved to literal prefixes (`from source-prefix-list
  trusted` → `from source-address 10.0.0.0/8, 192.168.0.0/16`, #2506);
- `except` prefix-lists and the empty-set fail-closed / match-all semantics
  surfaced explicitly;
- multi-value match lists survive the bracket collapse (#2419);
- symbolic DSCP names resolved to code points (`ef` → `46`);
- `tcp-flags` lowered to `require`/`forbid` masks (#3076);
- fall-through (`then next term` / modifier-only) rendered (#2544);
- unrepresentable matches marked `<unrepresentable — snapshot fails closed>`
  (#3406/#3367).

## Implementation
- Export `dpuserspace.BuildFirewallFilterSnapshots` — a thin read-only wrapper
  over the existing unexported builder, so the CLI renders exactly the snapshot
  the dataplane consumes (no divergent second lowering).
- `showEffectiveFirewallFilters` / `showEffectiveFirewallFilter` +
  `renderEffectiveFilterSnapshot` in `cli_show_security_filters.go`.
- Dispatch in `cli_show.go` (detects `effective` + `family`).
- `effective` node added to the cmdtree firewall show subtree (SSOT for
  operational commands), only under `show firewall` so filter-name completion is
  not polluted.

## Test
`pkg/cli/cli_show_effective_filter_4422_test.go` (behavior-pinning): the
effective view resolves a `source-prefix-list` reference to its literal prefixes
while the raw view still prints the reference name; a bracketed multi-value port
list survives the collapse; `ef` resolves to `46`; a modifier-only term renders
`then next term (fall-through)`. Also covers name/family selectors and
not-found paths.

## Docs
New "Firewall: Filters (raw and effective)" section in
`docs/junos-cli-reference.md`.

## Gates
- `go build ./...` — clean
- `go test ./pkg/cli/... ./pkg/cmdtree/... ./pkg/config/... ./pkg/dataplane/userspace/...` — green
- `go test ./...` — green (53 ok / 0 fail; 3 no-test packages; pre-existing
  `pkg/ddns TestRFC2136` flake not triggered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi