### PR TITLE
fix(userspace-dp): clamp IPv4 datagram end (L-3) + redact syn-cookie key in Debug (L-7) (#4484)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,54 @@
+## 2026-07-09 — #4484 L-3 + L-7: clamp IPv4 datagram end + redact syn-cookie key in Debug
+
+- **Timestamp**: 2026-07-09 (session 015oARShYtiJJ2H4UB4nXGqi)
+  **Action**: #4484 L-3 — `tcp_segment_consumed_len`
+  (`userspace-dp/src/afxdp/frame/tcp.rs`) derived the IPv4 datagram end
+  from the header's `total_len` (`ip_datagram_end = l3 + total_len`) with
+  NO clamp to `frame.len()`. A crafted/corrupted packet advertising an
+  inflated `total_len` pushed `ip_datagram_end` past the real frame, so
+  the downstream `payload_len = ip_datagram_end.saturating_sub(
+  tcp_data_start)` over-counted the segment length, and the no-ACK RST
+  carried `ack = seq + inflated_seg_len` — an unacceptable ack the peer
+  discards, degrading the `reject`/RST path to a silent drop (a
+  fail-closed self-DoS on the reject leg). Fix: clamp the derived
+  datagram end to `frame.len()` after the family match (covers v4 —
+  the reported residual — and bounds the v6 `payload_len` path too); a
+  well-formed packet has the datagram end within the frame, so it is a
+  no-op for valid traffic. VERIFY-FIRST: read the site on origin/master;
+  confirmed the v4 branch had no `.min(frame.len())` and the ack math
+  feeds off it. RED-on-revert proof: a SYN frame with `total_len=1200`
+  but a real 54-byte frame → with the clamp `ack = seq+1`; removing the
+  clamp yields `ack = seq+1161` (1261 vs expected 101), test FAILS.
+  Guard test: a well-formed `total_len==46`, 60-byte SYN+6-payload frame
+  still acks `seq + 1 + 6` (clamp is a no-op).
+  #4484 L-7 — `ForwardingState`
+  (`userspace-dp/src/afxdp/types/forwarding.rs`) derives `Debug`, and the
+  `syn_cookie_master_key: Option<[u8; 16]>` field auto-rendered the raw
+  16-byte SYN-cookie master key into any log/trace that formats the state.
+  Fix: wrap the field in a `SynCookieMasterKey(Option<[u8; 16]>)` newtype
+  whose manual `Debug` redacts (`Some(<redacted>)` / `None`, never the
+  bytes), mirroring the WireGuard-key redaction discipline
+  (`TunnelEndpoint`/`WgRuntimePeer`) already in this file. `ForwardingState`
+  keeps `#[derive(Debug)]` so all other fields render unchanged and no
+  future field silently drops from Debug. Read/write sites updated to
+  `.0` (`forwarding_build/mod.rs`, `worker/loop_body/{mod,setup}.rs`).
+  VERIFY-FIRST: confirmed the struct derives Debug and the key field had
+  no hand-redaction; the sibling secrets use manual `debug_struct` impls.
+  RED-on-revert proof: deriving `Debug` on the newtype re-leaks
+  `SynCookieMasterKey(Some([171, 171, ...]))`, test FAILS; guard asserts
+  sibling fields (`local_v4`) still render. Gates: `cargo build` clean;
+  full serial suite `cargo test --release -- --test-threads=1` = 3775
+  passed / 0 failed / 2 ignored (+60 doctest, +8 self, +22 fairness, +1
+  snat, all 0-fail); `cargo test --release tcp` 173/0; `cargo test
+  --release syn_cookie` 55/0.
+- **File(s)**: userspace-dp/src/afxdp/frame/tcp.rs,
+  userspace-dp/src/afxdp/frame/tcp_tests.rs,
+  userspace-dp/src/afxdp/types/forwarding.rs,
+  userspace-dp/src/afxdp/forwarding_build/mod.rs,
+  userspace-dp/src/afxdp/forwarding_build/tests.rs,
+  userspace-dp/src/afxdp/worker/loop_body/mod.rs,
+  userspace-dp/src/afxdp/worker/loop_body/setup.rs, _Log.md
+
 ## 2026-07-09 — #4484 L-9: control-link auth engaged/dual-accept show surface
 
 - **Timestamp**: 2026-07-09

--- a/userspace-dp/src/afxdp/forwarding_build/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/mod.rs
@@ -338,7 +338,8 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
     state.nptv6 = Nptv6State::try_from_snapshots(&snapshot.nptv6_rules)?;
     state.screen_profiles = build_screen_profiles(snapshot);
     state.screen_missing_profiles = build_screen_missing_profiles(snapshot);
-    state.syn_cookie_master_key = parse_syn_cookie_master_key(&snapshot.syn_cookie_master_key);
+    state.syn_cookie_master_key =
+        SynCookieMasterKey(parse_syn_cookie_master_key(&snapshot.syn_cookie_master_key));
     state.tcp_mss_all_tcp = snapshot.flow.tcp_mss_all_tcp;
     state.tcp_mss_ipsec_vpn = snapshot.flow.tcp_mss_ipsec_vpn;
     state.tcp_mss_gre_in = snapshot.flow.tcp_mss_gre_in;

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -84,12 +84,45 @@ fn syn_cookie_master_key_from_snapshot_reaches_forwarding_state() {
     };
     let state = build_forwarding_state(&snapshot);
     assert_eq!(
-        state.syn_cookie_master_key,
+        state.syn_cookie_master_key.0,
         Some([
             0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
             0xee, 0xff,
         ]),
         "control-plane-delivered key must reach the dataplane for source validation"
+    );
+}
+
+// #4484 L-7: `ForwardingState` derives `Debug`; the SYN-cookie master key
+// must never render in cleartext through it. The `SynCookieMasterKey`
+// wrapper redacts in `Debug` (`Some(<redacted>)` / `None`). Fail-on-revert:
+// drop the manual `Debug` impl (deriving `Debug` on the newtype) and the raw
+// bytes reappear (`Some([171, 171, ...])`), so both asserts below FAIL.
+#[test]
+fn syn_cookie_master_key_debug_redacts_the_secret_in_forwarding_state() {
+    let mut state = ForwardingState::default();
+    state.syn_cookie_master_key = SynCookieMasterKey(Some([0xab; 16]));
+    let rendered = format!("{state:?}");
+    // The secret bytes never appear (0xab = 171 decimal in the derived form).
+    assert!(
+        !rendered.contains("171"),
+        "raw SYN-cookie key byte leaked into Debug output: {rendered}"
+    );
+    // The field renders with the redaction marker instead.
+    assert!(
+        rendered.contains("syn_cookie_master_key: Some(<redacted>)"),
+        "expected redacted marker, got: {rendered}"
+    );
+    // Guard: sibling fields still render (Debug is not wholesale suppressed).
+    assert!(
+        rendered.contains("local_v4"),
+        "other fields must still render in Debug: {rendered}"
+    );
+    // A None key renders plainly (no phantom marker).
+    let none = ForwardingState::default();
+    assert!(
+        format!("{none:?}").contains("syn_cookie_master_key: None"),
+        "unset key must render as None"
     );
 }
 

--- a/userspace-dp/src/afxdp/frame/tcp.rs
+++ b/userspace-dp/src/afxdp/frame/tcp.rs
@@ -426,6 +426,17 @@ fn tcp_segment_consumed_len(frame: &[u8], parsed: TcpReplySource) -> Option<u32>
         }
         _ => return None,
     };
+    // Clamp the datagram end to the captured frame length. The IP length
+    // field (v4 total_len / v6 payload_len) is attacker-controlled: a
+    // crafted or corrupted packet can advertise a length that runs past
+    // the actual frame. Left unclamped, `ip_datagram_end` overshoots the
+    // frame, `payload_len` below over-counts by the overshoot, and the
+    // no-ACK RST then carries `ack = seq + inflated_seg_len` — an
+    // unacceptable ack the peer discards, degrading the `reject`/RST leg
+    // to a silent drop (a fail-closed self-DoS on the reject path). For a
+    // well-formed packet the datagram end is already within the frame, so
+    // this is a no-op (v4 #4484 L-3; also bounds the v6 path).
+    let ip_datagram_end = ip_datagram_end.min(frame.len());
     // TCP header start (after IPv6 ext headers, if any) and length from
     // the inbound segment's data-offset field.
     let l4 = frame_l4_offset(frame, parsed.addr_family)?;

--- a/userspace-dp/src/afxdp/frame/tcp_tests.rs
+++ b/userspace-dp/src/afxdp/frame/tcp_tests.rs
@@ -792,6 +792,68 @@ fn reject_rst_v4_syn_with_data_acks_seq_plus_one_plus_payload() {
     );
 }
 
+#[test]
+fn reject_rst_v4_inflated_total_len_clamped_to_frame_acks_seq_plus_one() {
+    // #4484 L-3: a crafted/corrupted IPv4 packet advertises a total_len
+    // far larger than the actual captured frame. `tcp_segment_consumed_len`
+    // must clamp the derived datagram end to `frame.len()` so the no-ACK RST
+    // acks exactly the SYN (seq + 1), NOT seq + 1 + phantom_payload. The
+    // inflated value would produce an unacceptable ack the SYN-SENT peer
+    // discards, degrading the reject to a silent drop (fail-closed self-DoS).
+    //
+    // Fail-on-revert: remove the `.min(frame.len())` clamp and the ack
+    // becomes seq + 1 + (14 + 1200 - 54) = seq + 1161, so this FAILS.
+    let mut eth = eth_header(0x0800);
+    eth[0..6].copy_from_slice(&[0x02, 0, 0, 0, 0, 0xdd]);
+    eth[6..12].copy_from_slice(&[0x02, 0, 0, 0, 0, 0xcc]);
+    // Header claims a 1200-byte datagram, but the real frame is only
+    // 14 (eth) + 20 (IP) + 20 (TCP) = 54 bytes — no payload present.
+    let ip = ipv4_header(1200, 6);
+    let mut tcp = tcp_header_skeleton(TCP_FLAG_SYN, 5);
+    tcp[4..8].copy_from_slice(&100u32.to_be_bytes());
+    let mut frame = Vec::new();
+    frame.extend_from_slice(&eth);
+    frame.extend_from_slice(&ip);
+    frame.extend_from_slice(&tcp);
+    assert_eq!(frame.len(), 54, "fixture frame must be 54 bytes");
+    let out = build_reject_rst_frame(&frame).expect("RST for SYN with inflated total_len");
+    let tcp_out = &out[ETH_HDR_LEN + IPV4_HDR_LEN..ETH_HDR_LEN + IPV4_HDR_LEN + 20];
+    // No-ACK inbound: seq=0, RST|ACK, ack = seq + 1 (SYN only, no payload).
+    assert_eq!(tcp_out[13], TCP_FLAG_RST | TCP_FLAG_ACK);
+    assert_eq!(
+        u32::from_be_bytes([tcp_out[8], tcp_out[9], tcp_out[10], tcp_out[11]]),
+        101,
+        "ack must be seq+1 (SYN); the phantom total_len payload must be clamped away"
+    );
+}
+
+#[test]
+fn reject_rst_v4_exact_total_len_unchanged_by_clamp() {
+    // Guard: a well-formed packet whose total_len == the real datagram
+    // length (no overshoot) is unaffected by the clamp — the SYN+data
+    // payload math is preserved. total_len = 20 (IP) + 20 (TCP) + 6 = 46,
+    // frame = 14 + 46 = 60 bytes; ack = seq + SYN(1) + 6 payload bytes.
+    let mut eth = eth_header(0x0800);
+    eth[0..6].copy_from_slice(&[0x02, 0, 0, 0, 0, 0xdd]);
+    eth[6..12].copy_from_slice(&[0x02, 0, 0, 0, 0, 0xcc]);
+    let ip = ipv4_header(46, 6);
+    let mut tcp = tcp_header_skeleton(TCP_FLAG_SYN, 5);
+    tcp[4..8].copy_from_slice(&200u32.to_be_bytes());
+    let mut frame = Vec::new();
+    frame.extend_from_slice(&eth);
+    frame.extend_from_slice(&ip);
+    frame.extend_from_slice(&tcp);
+    frame.extend_from_slice(&[0x11, 0x22, 0x33, 0x44, 0x55, 0x66]); // 6 payload bytes
+    assert_eq!(frame.len(), 60, "fixture frame must be 60 bytes");
+    let out = build_reject_rst_frame(&frame).expect("RST for well-formed SYN+data");
+    let tcp_out = &out[ETH_HDR_LEN + IPV4_HDR_LEN..ETH_HDR_LEN + IPV4_HDR_LEN + 20];
+    assert_eq!(
+        u32::from_be_bytes([tcp_out[8], tcp_out[9], tcp_out[10], tcp_out[11]]),
+        200 + 1 + 6,
+        "ack = seq + SYN(1) + 6 payload bytes (clamp is a no-op for valid packets)"
+    );
+}
+
 // ---------- #2148: IPv6 extension-header L4-offset correctness ----------
 //
 // The three stale helpers (frame_has_tcp_rst,

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -10,6 +10,26 @@
 
 use super::*;
 
+/// SYN-cookie master key (16 bytes) wrapped so its `Debug` never renders
+/// the secret bytes (#4484 L-7). `ForwardingState` derives `Debug`; the
+/// auto-derived `Debug` on a bare `Option<[u8; 16]>` would print the raw
+/// key into any log/trace that formats the forwarding state. This wrapper
+/// redacts in `Debug` — `Some(<redacted>)` / `None`, never the bytes —
+/// while staying a transparent `Option<[u8; 16]>` at every read/write site
+/// (access `.0`). Mirrors the manual-redaction discipline the WireGuard
+/// key fields use (`TunnelEndpoint`/`WgRuntimePeer` in this file).
+#[derive(Clone, Default, PartialEq, Eq)]
+pub(in crate::afxdp) struct SynCookieMasterKey(pub(in crate::afxdp) Option<[u8; 16]>);
+
+impl std::fmt::Debug for SynCookieMasterKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            Some(_) => f.write_str("Some(<redacted>)"),
+            None => f.write_str("None"),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub(in crate::afxdp) struct ForwardingState {
     pub(in crate::afxdp) local_v4: FastSet<Ipv4Addr>,
@@ -217,7 +237,7 @@ pub(in crate::afxdp) struct ForwardingState {
     /// emits a rate-limited runtime WARN for it (verdict still Pass). A zone
     /// in neither map simply has no screen configured (legit Pass).
     pub(in crate::afxdp) screen_missing_profiles: FastMap<String, String>,
-    pub(in crate::afxdp) syn_cookie_master_key: Option<[u8; 16]>,
+    pub(in crate::afxdp) syn_cookie_master_key: SynCookieMasterKey,
     pub(in crate::afxdp) tunnel_interfaces: FastSet<i32>,
     pub(in crate::afxdp) filter_state: crate::filter::FilterState,
     pub(in crate::afxdp) cos: CoSState,

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -399,7 +399,7 @@ pub(crate) fn worker_loop(
             // runtime forwarding-snapshot rotation so a newly-introduced
             // dangling screen reference starts WARNing (and a fixed one stops).
             screen_state.update_missing_profiles(new_forwarding.screen_missing_profiles.clone());
-            screen_state.update_syn_cookie_master_key(new_forwarding.syn_cookie_master_key);
+            screen_state.update_syn_cookie_master_key(new_forwarding.syn_cookie_master_key.0);
             sessions.set_timeouts(new_forwarding.session_timeouts);
             // #3527: re-apply the per-screened-zone half-open overrides on every
             // runtime forwarding-snapshot rotation. `set_opening_overrides` is a

--- a/userspace-dp/src/afxdp/worker/loop_body/setup.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/setup.rs
@@ -123,7 +123,7 @@ pub(super) fn worker_loop_setup(
     // #3082: thread the references-missing-profile set so the screen None
     // branch can WARN (still Pass) for the lenient/HA-sync fail-open.
     screen_state.update_missing_profiles(forwarding.screen_missing_profiles.clone());
-    screen_state.update_syn_cookie_master_key(forwarding.syn_cookie_master_key);
+    screen_state.update_syn_cookie_master_key(forwarding.syn_cookie_master_key.0);
     sessions.set_timeouts(forwarding.session_timeouts);
     // #3527: push the per-screened-zone half-open (`syn-flood timeout`)
     // overrides next to `set_timeouts`. Empty in the common case (no zone


### PR DESCRIPTION
Addresses #4484 (umbrella stays open). Drives two genuine Rust residuals in one PR, one commit each (bisectable).

## L-3 — clamp IPv4 datagram end to frame length (fail-closed self-DoS)

**Verify-first (origin/master):** `tcp_segment_consumed_len` in
`userspace-dp/src/afxdp/frame/tcp.rs` derived the IPv4 datagram end from
the header's `total_len` field (`ip_datagram_end = parsed.l3 + total_len`,
via `checked_add`) with **no** `.min(frame.len())` clamp. `total_len` is
attacker-controlled; `frame_l4_offset` validates only the IHL, so an
inflated `total_len` passes parsing and reaches this site. The value flows
into `payload_len = ip_datagram_end.saturating_sub(tcp_data_start)`, which
feeds the no-ACK RST's `ack = seq + seg_len` — so an inflated `total_len`
produces an over-large ack the SYN-SENT peer discards, degrading the
`reject`/RST leg to a silent drop (fail-closed self-DoS).

**Fix:** clamp the derived datagram end to `frame.len()` after the
address-family match (bounds the v4 `total_len` path — the reported
residual — and the v6 `payload_len` path). No-op for well-formed packets.

**RED-on-revert:** `reject_rst_v4_inflated_total_len_..` — a SYN frame
claiming `total_len=1200` in a real 54-byte frame acks `seq+1` with the
clamp; removing the clamp yields `seq+1161` (1261 vs 101) → test FAILS.
**Guard:** `reject_rst_v4_exact_total_len_unchanged_by_clamp` — a
well-formed `total_len==46` / 60-byte SYN+6-payload frame still acks
`seq+1+6` (clamp is a no-op).

## L-7 — redact syn_cookie_master_key in Debug (secret leak)

**Verify-first (origin/master):** `ForwardingState`
(`userspace-dp/src/afxdp/types/forwarding.rs`) derives `Debug`; the field
`syn_cookie_master_key: Option<[u8; 16]>` had no hand-redaction, so the
auto-derived `Debug` prints the 16-byte SYN-cookie master key in
cleartext. The sibling secrets in this file (`TunnelEndpoint` /
`WgRuntimePeer` WG keys) hand-implement `Debug` with `<redacted>`.

**Fix:** wrap the field in a `SynCookieMasterKey(Option<[u8; 16]>)`
newtype whose manual `Debug` redacts (`Some(<redacted>)` / `None`, never
the bytes). `ForwardingState` keeps `#[derive(Debug)]`, so every other
field renders unchanged and no future field silently drops from Debug (a
hand-written 67-field impl would be large and drift-prone). Read/write
sites access `.0` (`forwarding_build/mod.rs`,
`worker/loop_body/{mod,setup}.rs`).

**RED-on-revert:** `syn_cookie_master_key_debug_redacts_the_secret_in_forwarding_state`
— formatting a `ForwardingState` with a non-None key asserts the raw
bytes never appear and the field renders `Some(<redacted>)`; deriving
`Debug` on the newtype re-leaks `Some([171, 171, ...])` → test FAILS.
**Guard:** the same test asserts sibling fields (`local_v4`) still render.

## Gates (full, serial, dataplane crate)

- `cargo build` — clean (warnings only, pre-existing).
- `cargo test --release -- --test-threads=1` — **3775 passed / 0 failed /
  2 ignored** (main binary) + 60 doctest + 8 self + 22 fairness + 1 snat,
  all 0-fail; `cargo` exit 0.
- `cargo test --release tcp` — 173 passed / 0 failed.
- `cargo test --release syn_cookie` — 55 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
