### PR TITLE
metrics: scrape lo0 nft counters + PBR build health (#4422)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,31 @@
+## 2026-07-09 — #4422 observability: lo0 counter + PBR build-health metrics
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4422 observability subset triage + drive. Verified all 8
+  observability items vs origin/master. ALREADY-DONE: default-policy-scope
+  labels (metrics_counters.go #3363/#3286), addressless-zone (#3698/#3710),
+  NetFlow health endpoint+metrics (#2464), xpf_ipmon_unresolved_next_hops docs
+  (multi-wan.md #1844), show effective firewall-filter (#4756). REPORTED
+  (needs a kernel-nft ruleset change / dataplane, not driven here): per-type
+  ICMP/ND host-inbound counters. DROVE two genuine Go-side gaps the prior
+  #4629 pass mis-marked "covered": (1) lo0 counter integration — the kernel
+  `inet xpf_lo0` `then count` counters were never scraped (daemon_nft.go said
+  "nothing scrapes them"); added pkg/nftables ReadLo0Counters +
+  xpf_lo0_counter_hits_total{counter}, emitted before the dataplane gate,
+  DISTINCT from the userspace xpf_filter_hits_total. (2) PBR/FBF build health
+  — added routing.PBRBuildStats (pure config fn) + xpf_pbr_rules_installed /
+  xpf_pbr_degraded_terms gauges (no "widened" state — builder is fail-closed).
+  Wired descriptor-coverage test + fail-on-revert unit tests. Updated
+  daemon_nft.go comment, docs/multi-wan.md, docs/feature-coverage.md. go
+  build + full Go suite green (0 fail; pre-existing ddns RFC2136 flake
+  ignored).
+- **File(s)**: pkg/nftables/lo0_counters.go, pkg/nftables/lo0_counters_test.go,
+  pkg/routing/rules.go, pkg/routing/routing_test.go, pkg/api/metrics.go,
+  pkg/api/metrics_descriptors.go, pkg/api/metrics_counters.go,
+  pkg/api/metrics_lo0_test.go, pkg/api/metrics_pbr_test.go,
+  pkg/api/metrics_descriptor_coverage_test.go, pkg/api/zone_counters_hide_test.go,
+  pkg/daemon/daemon_nft.go, docs/multi-wan.md, docs/feature-coverage.md, _Log.md
+
 ## 2026-07-09 — #4484 L-9: control-link auth engaged/dual-accept show surface
 
 - **Timestamp**: 2026-07-09

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -224,7 +224,17 @@ the userspace dataplane admission boundary is in
   without those labels the rows collide on an identical `{protocol,
   collector, source}` labelset and Prometheus either rejects the duplicate
   (scrape error) or silently collapses the failing group.
-- **Prometheus metrics** (`/metrics` endpoint).
+- **Prometheus metrics** (`/metrics` endpoint). Two kernel-nftables surfaces
+  are scraped independent of dataplane load (emitted before the dataplane gate,
+  so they stay visible in a config-only / degraded boot):
+  `xpf_host_inbound_kernel_denies_total{zone,family}` (host-inbound catch-all
+  DROP counters) and `xpf_lo0_counter_hits_total{counter}` (#4422 — lo0
+  loopback input-filter `then count` hits from the `inet xpf_lo0` chain,
+  DISTINCT from the userspace fast-path `xpf_filter_hits_total`). Policy-based
+  routing (filter-based-forwarding) build health is exported as the
+  config-derived gauges `xpf_pbr_rules_installed` and `xpf_pbr_degraded_terms`
+  (#4422 — the count of routing-instance filter terms dropped from the kernel
+  FBF mirror by the fail-closed under-steer rule; see `docs/multi-wan.md`).
 - **SNMP**: system + ifTable MIB. Community `clients` source-IP restriction
   ENFORCED (#4289): `snmp community <c> clients { <prefix> [restrict]; }`
   scopes a community to the listed source prefixes — a v2c query from a source

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -362,6 +362,18 @@ How it lands (the `instance-type forwarding` divergence fix):
   and marks the build degraded rather than widening a constrained term
   to an address-only rule that would steer traffic the operator
   excluded. The userspace fast path still enforces the term exactly.
+- **PBR build-health metrics (#4422)**: `xpf_pbr_rules_installed`
+  gauges the number of kernel `ip rule` FBF entries the active config
+  yields (the desired-install set), and `xpf_pbr_degraded_terms` gauges
+  the number of routing-instance filter terms DROPPED from the kernel
+  mirror by the fail-closed rule above. A sustained
+  `xpf_pbr_degraded_terms > 0` means the kernel slow path under-steers
+  vs the userspace fast path — an operator alerting hook for a config
+  whose FBF cannot be fully represented as `ip rule`s. There is
+  deliberately no "widened" metric: the builder never widens an
+  unrepresentable match (fail-closed), so an over-steer is never
+  mirrored. Both gauges are config-derived and emitted even in a
+  config-only / degraded boot.
 - **Dataplane**: filter evaluation returns the term's
   routing-instance; the route lookup targets `ISP-B.inet.0` /
   `ISP-B.inet6.0`, where the snapshot builder files the instance's
@@ -376,7 +388,11 @@ How it lands (the `instance-type forwarding` divergence fix):
 Per-policy counters: `then count <name>` on the steering term is
 counted on the PBR fast path and exported as
 `xpf_filter_hits_total{filter,family,term}` — the steering-volume
-counter per FBF policy.
+counter per FBF policy. (A `then count` on a filter attached to the
+**lo0 loopback** input hook is instead enforced by the kernel nft
+`inet xpf_lo0` chain, not the fast path, and is exported separately as
+`xpf_lo0_counter_hits_total{counter}`, #4422 — see
+`docs/feature-coverage.md` Observability.)
 
 ### FBF is flow-based — the steer is decided once, on the first packet
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -61,6 +61,9 @@ type xpfCollector struct {
 	hostInboundAddresslessZones *prometheus.Desc
 	hostInboundAddresslessIface *prometheus.Desc
 	hostInboundAmbiguousAddrs   *prometheus.Desc
+	lo0CounterHits              *prometheus.Desc
+	pbrRulesInstalled           *prometheus.Desc
+	pbrDegradedTerms            *prometheus.Desc
 	tcEgressPacketsTotal        *prometheus.Desc
 	syncookieTotal              *prometheus.Desc
 	flowCacheTotal              *prometheus.Desc
@@ -598,6 +601,9 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.hostInboundAddresslessZones
 	ch <- c.hostInboundAddresslessIface
 	ch <- c.hostInboundAmbiguousAddrs
+	ch <- c.lo0CounterHits
+	ch <- c.pbrRulesInstalled
+	ch <- c.pbrDegradedTerms
 	ch <- c.tcEgressPacketsTotal
 	ch <- c.syncookieTotal
 	ch <- c.flowCacheTotal
@@ -987,6 +993,19 @@ func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
 	// addressless window, NOT self-healing — so emit it BEFORE the dataplane gate
 	// so it stays visible in a config-only / degraded boot too.
 	c.collectHostInboundAmbiguousAddresses(ch)
+
+	// #4422: kernel nftables lo0 loopback input-filter `then count` hits. The
+	// `inet xpf_lo0` chain is installed by the daemon INDEPENDENT of dataplane
+	// load state and keeps counting host-inbound loopback traffic in a
+	// config-only / degraded boot, so emit it BEFORE the dataplane gate — the
+	// counts are DISTINCT from the userspace fast-path xpf_filter_hits_total.
+	c.collectLo0Counters(ch)
+
+	// #4422: policy-based-routing (filter-based-forwarding) build health. Derived
+	// from the active config (routing.PBRBuildStats, a pure function — no
+	// netlink), so it is a control-plane signal emitted BEFORE the dataplane gate:
+	// a degraded FBF mirror must stay visible in a config-only / degraded boot.
+	c.collectPBRStatus(ch)
 
 	dp := c.srv.dp
 	if dp == nil || !dp.IsLoaded() {

--- a/pkg/api/metrics_counters.go
+++ b/pkg/api/metrics_counters.go
@@ -10,12 +10,18 @@ import (
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	xnft "github.com/psaab/xpf/pkg/nftables"
+	"github.com/psaab/xpf/pkg/routing"
 )
 
 // readHostInboundDenyCounters is the kernel nft host-inbound deny-counter source,
 // a package var so the collector's degraded-boot behavior is unit-testable
 // without a live kernel/netlink (#3361).
 var readHostInboundDenyCounters = xnft.ReadHostInboundDenyCounters
+
+// readLo0Counters is the kernel nft lo0 input-filter counter source, a package
+// var so the collector's behavior is unit-testable without a live kernel/netlink
+// (#4422), mirroring readHostInboundDenyCounters.
+var readLo0Counters = xnft.ReadLo0Counters
 
 // collectHostInboundKernelDenies scrapes the per-zone/family named DROP counters
 // from the kernel nftables host-inbound chain (#3361) and emits them as
@@ -47,6 +53,52 @@ func (c *xpfCollector) collectHostInboundKernelDenies(ch chan<- prometheus.Metri
 		ch <- prometheus.MustNewConstMetric(c.hostInboundKernelDenies,
 			prometheus.CounterValue, float64(ctr.Packets), ctr.Zone, ctr.Family)
 	}
+}
+
+// collectLo0Counters scrapes the per-`then count` named counters from the kernel
+// nftables lo0 input-filter chain (`inet xpf_lo0`, #4422) and emits them as
+// xpf_lo0_counter_hits_total. lo0 host-inbound traffic is enforced by the KERNEL
+// nft chain, so these counts are DISTINCT from the userspace-dp fast-path
+// xpf_filter_hits_total (they are not double counts).
+//
+// The lo0 table is installed by the daemon INDEPENDENT of dataplane load state,
+// so Collect calls this BEFORE the dataplane gate — the counters keep advancing
+// in a config-only / degraded boot. ReadLo0Counters reads nft via netlink and has
+// no dataplane dependency.
+//
+// On a read failure the series is SKIPPED (no misleading 0) and
+// xpf_counter_read_errors_total is bumped, matching collectHostInboundKernelDenies
+// and the #3345 missing-sample contract.
+func (c *xpfCollector) collectLo0Counters(ch chan<- prometheus.Metric) {
+	counts, err := readLo0Counters()
+	if err != nil {
+		c.counterReadErrors.Add(1)
+		return
+	}
+	for _, ctr := range counts {
+		ch <- prometheus.MustNewConstMetric(c.lo0CounterHits,
+			prometheus.CounterValue, float64(ctr.Packets), ctr.Counter)
+	}
+}
+
+// collectPBRStatus emits the policy-based-routing (filter-based-forwarding)
+// build-health gauges xpf_pbr_rules_installed and xpf_pbr_degraded_terms (#4422).
+// routing.PBRBuildStats is a pure function of the active config (no netlink), so
+// this is a control-plane signal emitted BEFORE the dataplane gate, matching the
+// config-derived host-inbound addressless collectors. Both gauges are emitted
+// unconditionally (0 when there is no active config or no FBF term) so a
+// zero-degradation state is a present sample distinct from "collector absent" —
+// the alerting hook is xpf_pbr_degraded_terms > 0.
+func (c *xpfCollector) collectPBRStatus(ch chan<- prometheus.Metric) {
+	var cfg *config.Config
+	if c.srv != nil && c.srv.store != nil {
+		cfg = c.srv.store.ActiveConfig()
+	}
+	installed, degraded := routing.PBRBuildStats(cfg)
+	ch <- prometheus.MustNewConstMetric(c.pbrRulesInstalled,
+		prometheus.GaugeValue, float64(installed))
+	ch <- prometheus.MustNewConstMetric(c.pbrDegradedTerms,
+		prometheus.GaugeValue, float64(degraded))
 }
 
 // collectHostInboundAddresslessZones emits xpf_host_inbound_addressless_zones

--- a/pkg/api/metrics_descriptor_coverage_test.go
+++ b/pkg/api/metrics_descriptor_coverage_test.go
@@ -531,6 +531,8 @@ func TestCollectorDescriptorCoverage(t *testing.T) {
 		"xpf_daemon_neighbor_periodic_last_success_age_seconds",            // #1780 neighbor watchdog
 		"xpf_ipmon_policy_failed",                                          // #1827 ip-monitoring
 		"xpf_frr_reload_degraded",                                          // #1880 FRR degraded reload
+		"xpf_pbr_rules_installed",                                          // #4422 PBR/FBF build health
+		"xpf_pbr_degraded_terms",                                           // #4422 PBR/FBF degraded terms
 		"xpf_userspace_worker_dead",                                        // emitWorkerRuntime
 		"xpf_userspace_worker_cold_path_samples_v3_total",                  // cold-path v3
 		"xpf_cos_drain_invocations_total",                                  // CoS owner profile

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -165,6 +165,53 @@ func newCollector(srv *Server) *xpfCollector {
 				"address and family.",
 			[]string{"address", "family"}, nil,
 		),
+		// #4422: per-`then count` hit counters for the kernel lo0 loopback input
+		// filter (`inet xpf_lo0` table). lo0 host-inbound traffic is enforced by
+		// the KERNEL nftables chain (not the userspace fast path), so its
+		// firewall-filter `then count <name>` counts live in nft named-counter
+		// objects, DISTINCT from xpf_filter_hits_total (which merges the
+		// userspace-dp fast-path per-term hits for data-interface filters,
+		// including FBF steering). Before #4422 nothing scraped the lo0 counters.
+		// The table is installed independent of dataplane load, so this is a
+		// control-plane signal emitted BEFORE the dataplane gate. The counter
+		// object is shared by name across terms/families (Junos named-counter
+		// semantics), so the series is labeled by the count name only. Counters
+		// reset on every table rebuild (commit / DHCP re-render); rate() handles
+		// the reset. On a read failure the series is skipped (no misleading 0) and
+		// xpf_counter_read_errors_total is bumped.
+		lo0CounterHits: prometheus.NewDesc(
+			"xpf_lo0_counter_hits_total",
+			"Total lo0 loopback input-filter hits by firewall-filter `then count` "+
+				"name, read from the kernel nftables lo0 chain (distinct from the "+
+				"userspace-dp xpf_filter_hits_total fast-path counters).",
+			[]string{"counter"}, nil,
+		),
+		// #4422: policy-based-routing (filter-based-forwarding) build health.
+		// xpf_pbr_rules_installed is the number of kernel `ip rule` FBF entries
+		// the active config's routing-instance filter terms yield (the
+		// desired-install set). Config-derived (routing.PBRBuildStats, a pure
+		// function of config), emitted BEFORE the dataplane gate.
+		pbrRulesInstalled: prometheus.NewDesc(
+			"xpf_pbr_rules_installed",
+			"Number of kernel ip-rule filter-based-forwarding entries the active "+
+				"config's routing-instance filter terms yield (#4422).",
+			nil, nil,
+		),
+		// #4422: number of routing-instance filter terms DROPPED from the kernel
+		// FBF mirror (fail-closed under-steer to the main table) — an
+		// unrepresentable except set, a DSCP-0 match, a contradictory
+		// routing-instance+discard/reject term (#4534), an ip-rule-unrepresentable
+		// L4/per-packet predicate (#3730), or the priority-window overflow (#3430
+		// M3). Non-zero means the kernel slow path under-steers vs the userspace
+		// fast path (which still enforces every term exactly). There is no
+		// "widened" state — the builder refuses to widen an unrepresentable match.
+		pbrDegradedTerms: prometheus.NewDesc(
+			"xpf_pbr_degraded_terms",
+			"Number of routing-instance filter terms dropped from the kernel "+
+				"filter-based-forwarding mirror (fail-closed under-steer), because "+
+				"the term carries a predicate an ip rule cannot express (#4422).",
+			nil, nil,
+		),
 		tcEgressPacketsTotal: prometheus.NewDesc(
 			"xpf_tc_egress_packets_total",
 			"Total TC egress packets processed.",

--- a/pkg/api/metrics_lo0_test.go
+++ b/pkg/api/metrics_lo0_test.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	xnft "github.com/psaab/xpf/pkg/nftables"
+)
+
+// TestLo0CounterHitsEmittedWhenDataplaneUnloaded is the #4422 fail-on-revert
+// proof: the kernel nftables lo0 loopback input-filter chain (`inet xpf_lo0`) is
+// installed and counts host-inbound loopback traffic INDEPENDENT of dataplane
+// load state, so xpf_lo0_counter_hits_total must be emitted even with the
+// dataplane unloaded (config-only / degraded boot). Collect must call
+// collectLo0Counters BEFORE the `dp == nil || !dp.IsLoaded()` early-return;
+// moving it back below the gate makes this RED (with dp nil, Collect returns
+// before reaching it and the series vanishes). The lo0 counts are DISTINCT from
+// the userspace fast-path xpf_filter_hits_total.
+func TestLo0CounterHitsEmittedWhenDataplaneUnloaded(t *testing.T) {
+	orig := readLo0Counters
+	defer func() { readLo0Counters = orig }()
+	readLo0Counters = func() ([]xnft.Lo0Count, error) {
+		return []xnft.Lo0Count{
+			{Counter: "ssh-hits", Packets: 12, Bytes: 1200},
+			{Counter: "bgp-in", Packets: 4, Bytes: 400},
+		}, nil
+	}
+
+	s := &Server{} // dp intentionally nil — degraded / config-only boot.
+	reg := prometheus.NewPedanticRegistry()
+	reg.MustRegister(newCollector(s))
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+
+	got := map[string]float64{}
+	for _, mf := range mfs {
+		if mf.GetName() != "xpf_lo0_counter_hits_total" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			var counter string
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "counter" {
+					counter = l.GetValue()
+				}
+			}
+			got[counter] = m.GetCounter().GetValue()
+		}
+	}
+
+	if len(got) == 0 {
+		t.Fatal("xpf_lo0_counter_hits_total not emitted with dataplane unloaded " +
+			"(collectLo0Counters must run BEFORE the dataplane gate)")
+	}
+	if got["ssh-hits"] != 12 {
+		t.Errorf("ssh-hits = %v, want 12", got["ssh-hits"])
+	}
+	if got["bgp-in"] != 4 {
+		t.Errorf("bgp-in = %v, want 4", got["bgp-in"])
+	}
+}
+
+// TestLo0CounterReadErrorOmitsSeries verifies the #3345 contract on this path: a
+// netlink read failure SKIPS the series (no misleading 0) and bumps the
+// scrape-error counter rather than fabricating a zero.
+func TestLo0CounterReadErrorOmitsSeries(t *testing.T) {
+	orig := readLo0Counters
+	defer func() { readLo0Counters = orig }()
+	readLo0Counters = func() ([]xnft.Lo0Count, error) {
+		return nil, errors.New("netlink dial: permission denied")
+	}
+
+	s := &Server{}
+	c := newCollector(s)
+	ch := make(chan prometheus.Metric, 8)
+	c.collectLo0Counters(ch)
+	close(ch)
+
+	for m := range ch {
+		t.Errorf("expected no lo0-counter series on read error, got %v", m.Desc())
+	}
+	if c.counterReadErrors.Load() == 0 {
+		t.Error("read error must bump counterReadErrors (#3345 contract)")
+	}
+}

--- a/pkg/api/metrics_pbr_test.go
+++ b/pkg/api/metrics_pbr_test.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// TestPBRStatusEmittedWhenDataplaneUnloaded is the #4422 fail-on-revert proof:
+// the PBR/FBF build-health gauges are derived from the active config
+// (routing.PBRBuildStats, a pure function — no netlink), so they must be emitted
+// even with the dataplane unloaded (config-only / degraded boot). Collect must
+// call collectPBRStatus BEFORE the `dp == nil || !dp.IsLoaded()` early-return;
+// moving it back below the gate makes this RED. Both gauges are emitted
+// unconditionally so a zero-degradation state is a present sample distinct from
+// "collector absent" — the alerting hook is xpf_pbr_degraded_terms > 0.
+func TestPBRStatusEmittedWhenDataplaneUnloaded(t *testing.T) {
+	s := &Server{} // dp intentionally nil, store nil — degraded / config-only boot.
+	reg := prometheus.NewPedanticRegistry()
+	reg.MustRegister(newCollector(s))
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+
+	got := map[string]float64{}
+	for _, mf := range mfs {
+		switch mf.GetName() {
+		case "xpf_pbr_rules_installed", "xpf_pbr_degraded_terms":
+			ms := mf.GetMetric()
+			if len(ms) != 1 {
+				t.Fatalf("%s: got %d metrics, want 1", mf.GetName(), len(ms))
+			}
+			got[mf.GetName()] = ms[0].GetGauge().GetValue()
+		}
+	}
+
+	if _, ok := got["xpf_pbr_rules_installed"]; !ok {
+		t.Error("xpf_pbr_rules_installed not emitted with dataplane unloaded " +
+			"(collectPBRStatus must run BEFORE the dataplane gate)")
+	}
+	if _, ok := got["xpf_pbr_degraded_terms"]; !ok {
+		t.Error("xpf_pbr_degraded_terms not emitted with dataplane unloaded")
+	}
+	// No active config → nothing installed, nothing degraded.
+	if got["xpf_pbr_rules_installed"] != 0 {
+		t.Errorf("xpf_pbr_rules_installed = %v, want 0 (no config)", got["xpf_pbr_rules_installed"])
+	}
+	if got["xpf_pbr_degraded_terms"] != 0 {
+		t.Errorf("xpf_pbr_degraded_terms = %v, want 0 (no config)", got["xpf_pbr_degraded_terms"])
+	}
+}

--- a/pkg/api/zone_counters_hide_test.go
+++ b/pkg/api/zone_counters_hide_test.go
@@ -97,6 +97,13 @@ func TestCollectDoesNotFalseAlertOnZoneReads(t *testing.T) {
 	orig := readHostInboundDenyCounters
 	readHostInboundDenyCounters = func() ([]xnft.HostInboundDenyCount, error) { return nil, nil }
 	defer func() { readHostInboundDenyCounters = orig }()
+	// #4422: neutralize the pre-gate kernel lo0 counter read too, for the same
+	// reason as the host-inbound read above — a sandbox without live nft/netlink
+	// would otherwise return a read error and bump counterReadErrors, masking the
+	// per-zone false-alert this test isolates.
+	origLo0 := readLo0Counters
+	readLo0Counters = func() ([]xnft.Lo0Count, error) { return nil, nil }
+	defer func() { readLo0Counters = origLo0 }()
 
 	store := newDescriptorCoverageStore(t)
 	srv := &Server{store: store, gc: conntrack.NewGC(nil, time.Minute), startTime: time.Now()}

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -144,8 +144,10 @@ func (d *Daemon) applyLo0Filter(cfg *config.Config) error {
 // `then count`), so redeclaring them on the next commit would collide
 // ("File exists"); delete+recreate guarantees each counter is declared exactly
 // once and leaves no stale counter for a removed term. A consequence is that the
-// lo0 counters reset to zero on every rebuild (every commit / DHCP re-render) —
-// nothing scrapes them so there is no metric impact. nft parses an `-f -`
+// lo0 counters reset to zero on every rebuild (every commit / DHCP re-render);
+// since #4422 they are scraped as xpf_lo0_counter_hits_total (pkg/nftables
+// ReadLo0Counters → pkg/api collectLo0Counters), and Prometheus rate() handles
+// the reset the same way it does for the host-inbound deny counters. nft parses an `-f -`
 // payload atomically, so a syntax error on any line rejects the ENTIRE payload.
 // (The pre-#2069 `flush ruleset inet xpf_lo0` was NOT valid nft and made the
 // filter fail OPEN; the delete+recreate idiom is unconditionally valid.)

--- a/pkg/nftables/lo0_counters.go
+++ b/pkg/nftables/lo0_counters.go
@@ -1,5 +1,21 @@
 package nftables
 
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/nftables"
+	"golang.org/x/sys/unix"
+)
+
+// Lo0TableName is the kernel nftables table that enforces the lo0 loopback
+// input firewall filter (`interfaces lo0 unit 0 family inet[6] filter input`,
+// #3445). The Go control plane (pkg/daemon/daemon_nft.go) renders it via
+// `nft -f -`; this package reads its named `then count` counters back via
+// netlink for the observability surface (#4422).
+const Lo0TableName = "xpf_lo0"
+
 // lo0CounterPrefix namespaces every named counter object attached to a kernel
 // lo0 input-filter rule (the `inet xpf_lo0` table) so the object is recognizably
 // xpf-managed and always begins with a letter. A bare nft identifier may not
@@ -24,4 +40,94 @@ const lo0CounterPrefix = "xpflo0_"
 // table fail to load, so the lossy name is strictly better than no mirror.
 func Lo0CounterName(name string) string {
 	return lo0CounterPrefix + sanitizeNftIdent(name)
+}
+
+// ParseLo0CounterName reverses Lo0CounterName: it strips the fixed prefix and
+// returns the counter label, or ok=false for any object name that is not one of
+// our lo0 `then count` counters (wrong prefix), so the scraper silently skips
+// foreign / malformed counter objects in the table.
+//
+// Unlike ParseHostInboundDenyCounterName there is no length-encoding to reverse:
+// the object name is just the sanitized Junos count name. A Junos `then count`
+// name is normally a bare identifier, so the returned label equals the operator
+// name; only an exotic name with bytes outside [A-Za-z0-9_.-] is the lossy
+// sanitized form (see Lo0CounterName), which is the same aggregation artifact the
+// declaration side already documents.
+func ParseLo0CounterName(name string) (counter string, ok bool) {
+	rest, found := strings.CutPrefix(name, lo0CounterPrefix)
+	if !found || rest == "" {
+		return "", false
+	}
+	return rest, true
+}
+
+// Lo0Count is one lo0 input-filter `then count` counter read from the
+// `inet xpf_lo0` table.
+type Lo0Count struct {
+	Counter string // the (sanitized) Junos `then count <name>`
+	Packets uint64
+	Bytes   uint64
+}
+
+// ReadLo0Counters reads the named `then count` counters from the kernel
+// `inet xpf_lo0` lo0 input-filter table via netlink (no nft shell-out). It
+// returns one entry per xpf-managed lo0 counter currently installed.
+//
+// When the table is absent (no lo0 input filter is attached, so the daemon
+// removed it) the function returns (nil, nil): no filter means no counts, not an
+// error. A genuine netlink failure is returned so the caller can surface
+// "counter unavailable" rather than a misleading zero (the #3345 missing-sample
+// contract the Prometheus collector applies to dataplane counters).
+//
+// Counters reset to zero whenever the daemon rebuilds the table (every commit and
+// every DHCP/DHCPv6 re-render, which delete + recreate the table, #3445); this
+// matches the table lifecycle and is handled by Prometheus rate() reset
+// detection, exactly like ReadHostInboundDenyCounters.
+func ReadLo0Counters() ([]Lo0Count, error) {
+	c, err := nftables.New()
+	if err != nil {
+		return nil, fmt.Errorf("nftables conn: %w", err)
+	}
+	tables, err := c.ListTablesOfFamily(nftables.TableFamilyINet)
+	if err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("nftables list tables: %w", err)
+	}
+	var table *nftables.Table
+	for _, t := range tables {
+		if t != nil && t.Name == Lo0TableName {
+			table = t
+			break
+		}
+	}
+	if table == nil {
+		// No lo0 input filter installed -> no counts.
+		return nil, nil
+	}
+	objs, err := c.GetObjects(table)
+	if err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("nftables list objects %s: %w", Lo0TableName, err)
+	}
+	var out []Lo0Count
+	for _, o := range objs {
+		co, ok := o.(*nftables.CounterObj)
+		if !ok {
+			continue
+		}
+		counter, ok := ParseLo0CounterName(co.Name)
+		if !ok {
+			continue
+		}
+		out = append(out, Lo0Count{
+			Counter: counter,
+			Packets: co.Packets,
+			Bytes:   co.Bytes,
+		})
+	}
+	return out, nil
 }

--- a/pkg/nftables/lo0_counters_test.go
+++ b/pkg/nftables/lo0_counters_test.go
@@ -1,0 +1,71 @@
+package nftables
+
+import "testing"
+
+// TestLo0CounterNameRoundTrip is the #4422 contract test for the lo0 named-counter
+// encoding shared by the renderer (pkg/daemon) and the Prometheus scraper
+// (pkg/api): a bare-safe Junos `then count <name>` must encode to an nft object
+// name that parses back to the SAME label. Unlike the host-inbound encoding there
+// is no length prefix — the object name is just the prefixed count name.
+func TestLo0CounterNameRoundTrip(t *testing.T) {
+	cases := []string{
+		"ssh-hits",
+		"bgp_in",
+		"dotted.count",
+		"1leading-digit", // legal Junos count name; the prefix guarantees a valid ident
+		"a-very_long.count-name",
+	}
+	for _, name := range cases {
+		obj := Lo0CounterName(name)
+		got, ok := ParseLo0CounterName(obj)
+		if !ok {
+			t.Errorf("ParseLo0CounterName(%q) failed for count=%q", obj, name)
+			continue
+		}
+		// Bare-safe names sanitize to themselves, so the round-trip is exact.
+		if got != name {
+			t.Errorf("round-trip mismatch for %q: got %q, want %q", obj, got, name)
+		}
+	}
+}
+
+// TestParseLo0CounterNameRejectsForeign asserts the scraper silently skips
+// objects that are not our lo0 counters (wrong or empty prefix), so a foreign
+// counter object in the inet table never mislabels a metric series.
+func TestParseLo0CounterNameRejectsForeign(t *testing.T) {
+	foreign := []string{
+		"",               // empty
+		"xpflo0_",        // prefix only, no name
+		"xpfhi_ip_3_wan", // a host-inbound deny counter, not lo0
+		"someother",      // unrelated object
+		"lo0_hits",       // missing the xpf prefix
+	}
+	for _, name := range foreign {
+		if _, ok := ParseLo0CounterName(name); ok {
+			t.Errorf("ParseLo0CounterName(%q) = ok, want rejected", name)
+		}
+	}
+}
+
+// TestLo0CounterNameSanitizesExoticBytes mirrors the host-inbound bare-safe
+// guarantee (#3578): a Junos count name carrying bytes the nft lexer rejects in a
+// bare identifier ([A-Za-z0-9_.-]) must sanitize so the UNQUOTED counter
+// declaration parses. The result always begins with the fixed prefix (a letter),
+// never a digit.
+func TestLo0CounterNameSanitizesExoticBytes(t *testing.T) {
+	safe := func(c byte) bool {
+		return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') || c == '_' || c == '-' || c == '.'
+	}
+	for _, name := range []string{"colon:c", "plus+c", "star*c", "a:b+c"} {
+		obj := Lo0CounterName(name)
+		for i := 0; i < len(obj); i++ {
+			if !safe(obj[i]) {
+				t.Errorf("Lo0CounterName(%q) = %q has unsafe byte %q at %d", name, obj, obj[i], i)
+			}
+		}
+		if obj[0] >= '0' && obj[0] <= '9' {
+			t.Errorf("Lo0CounterName(%q) = %q starts with a digit", name, obj)
+		}
+	}
+}

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -1622,6 +1622,60 @@ func TestBuildPBRRules_OtherInterfaceUnaffected(t *testing.T) {
 	}
 }
 
+// TestPBRBuildStats pins the #4422 observability contract: PBRBuildStats returns
+// the installed ip-rule count and the count of routing-instance filter terms
+// DROPPED from the kernel FBF mirror (fail-closed under-steer), matching what
+// BuildPBRRules produces. These feed the xpf_pbr_rules_installed /
+// xpf_pbr_degraded_terms gauges.
+func TestPBRBuildStats(t *testing.T) {
+	instances := []*config.RoutingInstanceConfig{
+		{Name: "ATT", TableID: 101},
+	}
+
+	t.Run("nil config is zero", func(t *testing.T) {
+		if installed, degraded := PBRBuildStats(nil); installed != 0 || degraded != 0 {
+			t.Errorf("PBRBuildStats(nil) = %d/%d, want 0/0", installed, degraded)
+		}
+	})
+
+	t.Run("installed counts built rules", func(t *testing.T) {
+		filter := &config.FirewallFilter{
+			Name: "fbf",
+			Terms: []*config.FirewallFilterTerm{
+				{Name: "a", SourceAddresses: []string{"10.0.1.0/24"}, RoutingInstance: "ATT"},
+				{Name: "b", DestAddresses: []string{"192.168.0.0/16"}, RoutingInstance: "ATT"},
+			},
+		}
+		installed, degraded := PBRBuildStats(pbrTestConfig("inet", filter, instances, nil))
+		if installed != 2 {
+			t.Errorf("installed = %d, want 2", installed)
+		}
+		if degraded != 0 {
+			t.Errorf("degraded = %d, want 0", degraded)
+		}
+	})
+
+	t.Run("degraded counts dropped contradictory terms", func(t *testing.T) {
+		// Two contradictory routing-instance+deny terms (#4534) are each dropped
+		// from the FBF mirror with a surfaced error, plus one valid steering term.
+		filter := &config.FirewallFilter{
+			Name: "mixed",
+			Terms: []*config.FirewallFilterTerm{
+				{Name: "ok", SourceAddresses: []string{"10.0.1.0/24"}, RoutingInstance: "ATT"},
+				{Name: "bad1", SourceAddresses: []string{"10.0.2.0/24"}, RoutingInstance: "ATT", Action: "discard"},
+				{Name: "bad2", SourceAddresses: []string{"10.0.3.0/24"}, RoutingInstance: "ATT", Action: "reject"},
+			},
+		}
+		installed, degraded := PBRBuildStats(pbrTestConfig("inet", filter, instances, nil))
+		if installed != 1 {
+			t.Errorf("installed = %d, want 1 (only the valid term steers)", installed)
+		}
+		if degraded != 2 {
+			t.Errorf("degraded = %d, want 2 (both contradictory terms dropped)", degraded)
+		}
+	})
+}
+
 // TestCollectAttachedInputFilters pins the attachment-collection contract that
 // per-interface FBF scoping rests on (#4422): only interface-unit INPUT filters
 // are collected, split by family; OUTPUT filters are excluded; and the same

--- a/pkg/routing/rules.go
+++ b/pkg/routing/rules.go
@@ -724,6 +724,45 @@ func BuildPBRRules(cfg *config.Config) ([]PBRRule, error) {
 	return rules, errors.Join(errs...)
 }
 
+// PBRBuildStats returns observability counts derived from BuildPBRRules for the
+// active config (#4422). It is a pure function of cfg (no netlink), safe to call
+// on the Prometheus scrape path — the same posture as the config-derived
+// host-inbound addressless collectors.
+//
+//   - installed: the number of kernel `ip rule` FBF entries the
+//     routing-instance filter terms yield (post-truncation to the maxPBRRules
+//     priority window). This is the desired-install count; ApplyPBRRules
+//     installs exactly this set (a later netlink failure there is a separate,
+//     logged concern).
+//   - degraded: the number of routing-instance filter terms DROPPED from the
+//     kernel FBF mirror (fail-closed under-steer to the main table) — an
+//     unrepresentable `except` set, a DSCP-0 match, a contradictory
+//     `routing-instance` + `discard`/`reject` term (#4534), an
+//     ip-rule-unrepresentable L4/per-packet predicate (#3730), or the
+//     maxPBRRules overflow (#3430 M3, counted as one condition). A non-zero
+//     value means the kernel slow path under-steers vs the userspace fast path
+//     (which still enforces every term exactly).
+//
+// There is deliberately no "widened" count: BuildPBRRules REFUSES to widen an
+// unrepresentable match to an address-only over-steer (fail-closed drop), so an
+// over-steer is never mirrored — the "widened" audit state does not exist by
+// design.
+func PBRBuildStats(cfg *config.Config) (installed, degraded int) {
+	rules, err := BuildPBRRules(cfg)
+	installed = len(rules)
+	if err != nil {
+		// BuildPBRRules returns errors.Join(errs...); its joinError exposes the
+		// per-term error slice via Unwrap() []error, so the count of degraded
+		// terms is exact. The single-error fallback is defensive only.
+		if u, ok := err.(interface{ Unwrap() []error }); ok {
+			degraded = len(u.Unwrap())
+		} else {
+			degraded = 1
+		}
+	}
+	return installed, degraded
+}
+
 // collectAttachedInputFilters returns the set of filter names attached as an
 // interface-unit INPUT filter, split by family. These are the only filters
 // whose `then routing-instance` terms take effect as Junos FBF (#3430 H1).


### PR DESCRIPTION
Addresses #4422 (observability subset). Triaged all 8 observability items vs
current `origin/master`; drove the two that were genuine Go-side metric gaps
(the prior #4629 test-coverage pass mis-marked them "covered"). The rest are
already done or need a kernel-nft ruleset / dataplane change (reported to the
lead, not driven here).

## Per-item triage

| Item | Disposition | Evidence |
|------|-------------|----------|
| default-policy-scope Prometheus labels | ALREADY-DONE | `metrics_counters.go:342` emits the implicit default-policy hit series `from_zone="-"/to_zone="-"/policy=DefaultPolicyName` (#3363); scoped-global labels #3286 |
| addressless-zone runtime metric | ALREADY-DONE | `xpf_host_inbound_addressless_zones` (#3698) + `_interfaces` (#3710), `metrics_counters.go:52`/`:76` |
| NetFlow health-endpoint states | ALREADY-DONE | `/api/v1/services/flow-exporters` (`health.go:85`) + `xpf_flow_export_collector_*` (#2464), per-collector Healthy/last-error/last-success |
| xpf_ipmon_unresolved_next_hops in docs | ALREADY-DONE | documented in `docs/multi-wan.md:554-569` (metric exists at `metrics_descriptors.go:655`, #1844) |
| show effective firewall-filter | ALREADY-DONE (SKIP) | PR #4756 (merged) |
| per-type ICMP/ND host-inbound counters | REPORTED (not driven) | generic `xpf_host_inbound_kernel_denies_total{zone,family}` exists; the ICMP-error/ND **accept** rules (`daemon_nft.go:585-588`) are UNCOUNTED and global — a per-type breakdown needs new nft counters on the enforcement ruleset (bounded Go+nft, but a ruleset change with heavy exact-string test churn; recommend a separate focused PR) |
| **lo0 counter integration** | **DRIVEN** | kernel `inet xpf_lo0` `then count` counters were never scraped (`daemon_nft.go:147` "nothing scrapes them") — added `nftables.ReadLo0Counters` + `xpf_lo0_counter_hits_total{counter}` |
| **PBR skipped/widened/degraded metric** | **DRIVEN** | the #4422 comment itself admits "a `xpf_pbr_*` ... metric does not exist yet — that is a feature" — added `routing.PBRBuildStats` + `xpf_pbr_rules_installed` / `xpf_pbr_degraded_terms` |

## What this PR adds

**lo0 counter integration.** lo0 host-inbound loopback traffic is enforced by
the KERNEL nft `inet xpf_lo0` chain (not the userspace fast path), so its
firewall-filter `then count <name>` hits live in nft named-counter objects,
DISTINCT from `xpf_filter_hits_total`. Added `nftables.ReadLo0Counters`
(mirrors `ReadHostInboundDenyCounters`: netlink, table-absent → nil, reset on
rebuild handled by `rate()`) and `xpf_lo0_counter_hits_total{counter}`, emitted
before the dataplane gate (counts in a config-only / degraded boot) and skipping
the series on read error (bumps `xpf_counter_read_errors_total`, the #3345
contract).

**PBR / FBF build health.** Added `routing.PBRBuildStats` (a pure config
function — no netlink) returning the installed ip-rule count and the count of
routing-instance filter terms dropped from the kernel FBF mirror (fail-closed
under-steer). Exposed as config-derived gauges `xpf_pbr_rules_installed` and
`xpf_pbr_degraded_terms`, emitted unconditionally (alert on `degraded_terms > 0`).
No "widened" metric — the builder is fail-closed and never widens an
unrepresentable match, so that audit state does not exist by design.

## Tests / docs
- `TestCollectorDescriptorCoverage` want-list updated with both PBR gauges; lo0
  left out (needs live nft, like the host-inbound deny counter) with its own
  injected-reader test.
- Fail-on-revert unit tests: both metrics survive a dataplane-unloaded boot and
  honor the read-error skip contract; `PBRBuildStats` counting; nft lo0 name
  round-trip/sanitize.
- Stubbed `readLo0Counters` in `TestCollectDoesNotFalseAlertOnZoneReads` (same
  reason the host-inbound reader is already stubbed there).
- Updated `daemon_nft.go` comment, `docs/multi-wan.md`, `docs/feature-coverage.md`.

## Gates
- `go build ./...` — clean
- `go test ./...` — green (pre-existing `pkg/ddns` `TestRFC2136` flake ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi