### PR TITLE
feat(observability): per-type ICMP/ND host-inbound accept counters (#4759)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-09 — #4759 observability: per-type ICMP/ND host-inbound accept counters
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4759 residual from #4422 — the GLOBAL ICMP-error / ND accept
+  rules in the kernel `inet xpf_hostinbound` chain (daemon_nft.go) were
+  UNCOUNTED, so no per-type visibility into how many ICMP-error/ND packets the
+  host-inbound path admits. BEHAVIOR-PRESERVING counter-only add: split the
+  single `icmpv6 type { 1,2,3,4,133..137 } accept` into error (1-4) + ND
+  (133-137), and attached a named nft counter to each accept rule plus the
+  ICMPv4 error rule (`counter name "<n>" accept` counts then accepts —
+  identical terminal verdict; the split type sets are disjoint and their union
+  is the exact pre-#4759 accepted set, so no packet's admission changes). Three
+  fixed counters `xpfhia_icmp6_nd` / `xpfhia_icmp6_error` / `xpfhia_icmp4_error`,
+  declared unconditionally (accept rules are always present). Added
+  pkg/nftables/host_inbound_accept_counters.go (ReadHostInboundAcceptCounters +
+  name encode/parse, distinct `xpfhia_` prefix so it never cross-parses the
+  `xpfhi_` deny counters sharing the same table) and the Prometheus metric
+  `xpf_host_inbound_icmp_nd_accept_total{type}` (descriptor + Describe() +
+  Collect() before the dataplane gate, mirroring collectHostInboundKernelDenies
+  / collectLo0Counters). AGGREGATE across zones (global rules) per the #4759
+  Low-severity caveat. Tests: updated the ruleset-string assertions (RED before
+  the test update — verified), reader round-trip/nft-safe/foreign-reject +
+  cross-prefix-reject, metric emit-before-gate + read-error-omits-series,
+  neutralized the new pre-gate reader in the zone-false-alert test. go build +
+  full Go suite green (0 fail).
+- **File(s)**: pkg/nftables/host_inbound_accept_counters.go,
+  pkg/nftables/host_inbound_accept_counters_test.go, pkg/daemon/daemon_nft.go,
+  pkg/daemon/host_inbound_nft_test.go, pkg/api/metrics.go,
+  pkg/api/metrics_counters.go, pkg/api/metrics_descriptors.go,
+  pkg/api/metrics_host_inbound_accept_4759_test.go,
+  pkg/api/zone_counters_hide_test.go, docs/feature-coverage.md, _Log.md
+
 ## 2026-07-09 — #4422 observability: lo0 counter + PBR build-health metrics
 
 - **Timestamp**: 2026-07-09

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -224,13 +224,17 @@ the userspace dataplane admission boundary is in
   without those labels the rows collide on an identical `{protocol,
   collector, source}` labelset and Prometheus either rejects the duplicate
   (scrape error) or silently collapses the failing group.
-- **Prometheus metrics** (`/metrics` endpoint). Two kernel-nftables surfaces
+- **Prometheus metrics** (`/metrics` endpoint). Three kernel-nftables surfaces
   are scraped independent of dataplane load (emitted before the dataplane gate,
   so they stay visible in a config-only / degraded boot):
   `xpf_host_inbound_kernel_denies_total{zone,family}` (host-inbound catch-all
-  DROP counters) and `xpf_lo0_counter_hits_total{counter}` (#4422 — lo0
+  DROP counters), `xpf_lo0_counter_hits_total{counter}` (#4422 — lo0
   loopback input-filter `then count` hits from the `inet xpf_lo0` chain,
-  DISTINCT from the userspace fast-path `xpf_filter_hits_total`). Policy-based
+  DISTINCT from the userspace fast-path `xpf_filter_hits_total`), and
+  `xpf_host_inbound_icmp_nd_accept_total{type}` (#4759 — the GLOBAL ICMP-error /
+  ND accept rules on the `inet xpf_hostinbound` chain, counted per type-class
+  `icmp6_nd` / `icmp6_error` / `icmp4_error`; AGGREGATE across all zones because
+  those accept rules are global, not per-zone). Policy-based
   routing (filter-based-forwarding) build health is exported as the
   config-derived gauges `xpf_pbr_rules_installed` and `xpf_pbr_degraded_terms`
   (#4422 — the count of routing-instance filter terms dropped from the kernel

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -58,6 +58,7 @@ type xpfCollector struct {
 	nat64XlateTotal             *prometheus.Desc
 	hostInboundDeny             *prometheus.Desc
 	hostInboundKernelDenies     *prometheus.Desc
+	hostInboundICMPNDAccept     *prometheus.Desc
 	hostInboundAddresslessZones *prometheus.Desc
 	hostInboundAddresslessIface *prometheus.Desc
 	hostInboundAmbiguousAddrs   *prometheus.Desc
@@ -598,6 +599,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.nat64XlateTotal
 	ch <- c.hostInboundDeny
 	ch <- c.hostInboundKernelDenies
+	ch <- c.hostInboundICMPNDAccept
 	ch <- c.hostInboundAddresslessZones
 	ch <- c.hostInboundAddresslessIface
 	ch <- c.hostInboundAmbiguousAddrs
@@ -970,6 +972,14 @@ func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
 	// exists to close). ReadHostInboundDenyCounters reads nft via netlink and has
 	// no dataplane dependency.
 	c.collectHostInboundKernelDenies(ch)
+
+	// #4759: the GLOBAL ICMP-error / ND ACCEPT counters on the same kernel
+	// `inet xpf_hostinbound` chain. These control-message accepts are admitted
+	// regardless of any per-zone host-inbound service set and are installed
+	// INDEPENDENT of dataplane load, so — like the deny counters above — emit them
+	// BEFORE the dataplane gate so the accept series stays visible in a
+	// config-only / degraded boot. Aggregate (global rules, not per-zone).
+	c.collectHostInboundICMPNDAccepts(ch)
 
 	// #3698: configured host-inbound-enforcing zones currently in the transient
 	// fail-open admit window (a non-lifeline interface but no resolvable address

--- a/pkg/api/metrics_counters.go
+++ b/pkg/api/metrics_counters.go
@@ -23,6 +23,14 @@ var readHostInboundDenyCounters = xnft.ReadHostInboundDenyCounters
 // (#4422), mirroring readHostInboundDenyCounters.
 var readLo0Counters = xnft.ReadLo0Counters
 
+// readHostInboundAcceptCounters is the kernel nft host-inbound ICMP-error / ND
+// ACCEPT-counter source (#4759), a package var so the collector's behavior is
+// unit-testable without a live kernel/netlink, mirroring
+// readHostInboundDenyCounters (the accept counters live in the same
+// `inet xpf_hostinbound` table as the deny counters, separated by object-name
+// prefix).
+var readHostInboundAcceptCounters = xnft.ReadHostInboundAcceptCounters
+
 // collectHostInboundKernelDenies scrapes the per-zone/family named DROP counters
 // from the kernel nftables host-inbound chain (#3361) and emits them as
 // xpf_host_inbound_kernel_denies_total. This is the PRIMARY host-inbound
@@ -78,6 +86,37 @@ func (c *xpfCollector) collectLo0Counters(ch chan<- prometheus.Metric) {
 	for _, ctr := range counts {
 		ch <- prometheus.MustNewConstMetric(c.lo0CounterHits,
 			prometheus.CounterValue, float64(ctr.Packets), ctr.Counter)
+	}
+}
+
+// collectHostInboundICMPNDAccepts scrapes the GLOBAL ICMP-error / ND accept
+// counters from the kernel nftables host-inbound chain (`inet xpf_hostinbound`,
+// #4759) and emits them as xpf_host_inbound_icmp_nd_accept_total, labeled by
+// type-class (icmp6_nd, icmp6_error, icmp4_error). These control-message accepts
+// are admitted regardless of any per-zone host-inbound service set (so
+// enforcement never black-holes core L3 operation); before #4759 they were
+// UNCOUNTED, giving no per-type visibility into how many ICMP-error / ND packets
+// the host-inbound path admits. The counts are AGGREGATE (the rules are global,
+// not per-zone) — a per-zone breakdown would need per-zone rule splitting.
+//
+// The nft chain is installed by the daemon INDEPENDENT of dataplane load state
+// and keeps counting in a config-only / degraded boot, so Collect calls this
+// BEFORE the dataplane gate, matching collectHostInboundKernelDenies.
+// ReadHostInboundAcceptCounters reads nft via netlink and has no dataplane
+// dependency.
+//
+// On a read failure the series is SKIPPED (no misleading 0) and
+// xpf_counter_read_errors_total is bumped, matching collectHostInboundKernelDenies
+// and the #3345 missing-sample contract.
+func (c *xpfCollector) collectHostInboundICMPNDAccepts(ch chan<- prometheus.Metric) {
+	counts, err := readHostInboundAcceptCounters()
+	if err != nil {
+		c.counterReadErrors.Add(1)
+		return
+	}
+	for _, ctr := range counts {
+		ch <- prometheus.MustNewConstMetric(c.hostInboundICMPNDAccept,
+			prometheus.CounterValue, float64(ctr.Packets), ctr.Type)
 	}
 }
 

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -111,6 +111,27 @@ func newCollector(srv *Server) *xpfCollector {
 				"xpf_host_inbound_denies_total path).",
 			[]string{"zone", "family"}, nil,
 		),
+		// #4759: per-type-class hit counters for the GLOBAL ICMP-error / ND accept
+		// rules on the same kernel `inet xpf_hostinbound` chain. Those rules admit
+		// ICMPv6 Neighbor Discovery (types 133-137), ICMPv6 error/PMTUD (types
+		// 1-4), and ICMPv4 error/PMTUD (destination-unreachable, time-exceeded,
+		// parameter-problem) regardless of any per-zone host-inbound service set,
+		// so core L3 operation is never black-holed; before #4759 those accepts
+		// were UNCOUNTED. The counts are AGGREGATE — the accept rules are GLOBAL,
+		// not per-zone, so there is no per-zone `type` breakdown (a per-zone split
+		// would need per-zone rule duplication, the #4759 Low-severity caveat).
+		// The counter resets when the daemon rebuilds the table (every commit /
+		// DHCP address change); Prometheus rate() handles the reset. On a read
+		// failure the series is skipped (no misleading 0) and
+		// xpf_counter_read_errors_total is bumped.
+		hostInboundICMPNDAccept: prometheus.NewDesc(
+			"xpf_host_inbound_icmp_nd_accept_total",
+			"Total ICMP-error / ND control-message accepts by the kernel nftables "+
+				"host-inbound chain, per type-class (icmp6_nd, icmp6_error, "+
+				"icmp4_error). Aggregate across all zones (the accept rules are "+
+				"global, not per-zone).",
+			[]string{"type"}, nil,
+		),
 		// #3698: 1 while a configured host-inbound-enforcing zone is in the
 		// transient fail-open admit window — it has a non-lifeline interface but
 		// no resolvable address yet (DHCP WAN before first lease, backup node

--- a/pkg/api/metrics_host_inbound_accept_4759_test.go
+++ b/pkg/api/metrics_host_inbound_accept_4759_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	xnft "github.com/psaab/xpf/pkg/nftables"
+)
+
+// TestHostInboundAcceptCountersEmittedWhenDataplaneUnloaded is the #4759
+// fail-on-revert proof: the kernel nftables host-inbound chain
+// (`inet xpf_hostinbound`) counts the GLOBAL ICMP-error / ND accepts INDEPENDENT
+// of dataplane load state, so xpf_host_inbound_icmp_nd_accept_total must be
+// emitted even with the dataplane unloaded (config-only / degraded boot).
+// Collect must call collectHostInboundICMPNDAccepts BEFORE the
+// `dp == nil || !dp.IsLoaded()` early-return; moving it below the gate makes this
+// RED. The per-type-class series is labeled by `type`.
+func TestHostInboundAcceptCountersEmittedWhenDataplaneUnloaded(t *testing.T) {
+	orig := readHostInboundAcceptCounters
+	defer func() { readHostInboundAcceptCounters = orig }()
+	readHostInboundAcceptCounters = func() ([]xnft.HostInboundAcceptCount, error) {
+		return []xnft.HostInboundAcceptCount{
+			{Type: xnft.HostInboundAcceptICMP6ND, Packets: 9, Bytes: 900},
+			{Type: xnft.HostInboundAcceptICMP6Error, Packets: 4, Bytes: 400},
+			{Type: xnft.HostInboundAcceptICMP4Error, Packets: 2, Bytes: 200},
+		}, nil
+	}
+
+	s := &Server{} // dp intentionally nil — degraded / config-only boot.
+	reg := prometheus.NewPedanticRegistry()
+	reg.MustRegister(newCollector(s))
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+
+	got := map[string]float64{}
+	for _, mf := range mfs {
+		if mf.GetName() != "xpf_host_inbound_icmp_nd_accept_total" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			var typ string
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "type" {
+					typ = l.GetValue()
+				}
+			}
+			got[typ] = m.GetCounter().GetValue()
+		}
+	}
+
+	if len(got) == 0 {
+		t.Fatal("xpf_host_inbound_icmp_nd_accept_total not emitted with dataplane " +
+			"unloaded (collectHostInboundICMPNDAccepts must run BEFORE the dataplane gate)")
+	}
+	if got[xnft.HostInboundAcceptICMP6ND] != 9 {
+		t.Errorf("icmp6_nd = %v, want 9", got[xnft.HostInboundAcceptICMP6ND])
+	}
+	if got[xnft.HostInboundAcceptICMP6Error] != 4 {
+		t.Errorf("icmp6_error = %v, want 4", got[xnft.HostInboundAcceptICMP6Error])
+	}
+	if got[xnft.HostInboundAcceptICMP4Error] != 2 {
+		t.Errorf("icmp4_error = %v, want 2", got[xnft.HostInboundAcceptICMP4Error])
+	}
+}
+
+// TestHostInboundAcceptCounterReadErrorOmitsSeries verifies the #3345 contract:
+// a netlink read failure SKIPS the series (no misleading 0) and bumps the
+// scrape-error counter rather than fabricating a zero.
+func TestHostInboundAcceptCounterReadErrorOmitsSeries(t *testing.T) {
+	orig := readHostInboundAcceptCounters
+	defer func() { readHostInboundAcceptCounters = orig }()
+	readHostInboundAcceptCounters = func() ([]xnft.HostInboundAcceptCount, error) {
+		return nil, errors.New("netlink dial: permission denied")
+	}
+
+	s := &Server{}
+	c := newCollector(s)
+	ch := make(chan prometheus.Metric, 8)
+	c.collectHostInboundICMPNDAccepts(ch)
+	close(ch)
+
+	for m := range ch {
+		t.Errorf("expected no accept-counter series on read error, got %v", m.Desc())
+	}
+	if c.counterReadErrors.Load() == 0 {
+		t.Error("read error must bump counterReadErrors (#3345 contract)")
+	}
+}

--- a/pkg/api/zone_counters_hide_test.go
+++ b/pkg/api/zone_counters_hide_test.go
@@ -104,6 +104,13 @@ func TestCollectDoesNotFalseAlertOnZoneReads(t *testing.T) {
 	origLo0 := readLo0Counters
 	readLo0Counters = func() ([]xnft.Lo0Count, error) { return nil, nil }
 	defer func() { readLo0Counters = origLo0 }()
+	// #4759: neutralize the pre-gate kernel host-inbound ICMP-error / ND accept
+	// counter read too, for the same reason — a sandbox without live nft/netlink
+	// would return a read error and bump counterReadErrors, masking the per-zone
+	// false-alert this test isolates.
+	origAccept := readHostInboundAcceptCounters
+	readHostInboundAcceptCounters = func() ([]xnft.HostInboundAcceptCount, error) { return nil, nil }
+	defer func() { readHostInboundAcceptCounters = origAccept }()
 
 	store := newDescriptorCoverageStore(t)
 	srv := &Server{store: store, gc: conntrack.NewGC(nil, time.Minute), startTime: time.Now()}

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -526,6 +526,16 @@ func buildHostInboundFilterPayload(views []dpuserspace.ZoneHostInboundView, unzo
 		seenCounter[name] = true
 		counters = append(counters, name)
 	}
+	// #4759: the GLOBAL ICMP-error / ND accept rules emitted below carry named
+	// nft counters so the host-inbound admit path is observable per type-class
+	// (ICMPv6 ND, ICMPv6 error/PMTUD, ICMPv4 error/PMTUD). Those accept rules are
+	// UNCONDITIONAL (they precede every per-zone rule and are always present), so
+	// declare all three counter objects up front — declaration and reference
+	// always agree, no matter how many zones exist. The counters are AGGREGATE
+	// (the accept rules are global, not per-zone).
+	for _, typ := range xnft.HostInboundAcceptCounterTypes {
+		addCounter(xnft.HostInboundAcceptCounterName(typ))
+	}
 	for _, v := range views {
 		if hostInboundEmitsDrop(v, v.V4Addrs) {
 			addCounter(xnft.HostInboundDenyCounterName(v.Zone, "ip"))
@@ -586,8 +596,19 @@ func buildHostInboundFilterPayload(views []dpuserspace.ZoneHostInboundView, unzo
 	// (3, also PMTUD frag-needed code 4), time-exceeded (11, traceroute) and
 	// parameter-problem (12) are the v4 error set. Echo-request is NOT here — it
 	// stays gated on the per-zone `ping` system-service.
-	rules = append(rules, "    icmpv6 type { 1, 2, 3, 4, 133, 134, 135, 136, 137 } accept")
-	rules = append(rules, "    icmp type { destination-unreachable, time-exceeded, parameter-problem } accept")
+	//
+	// #4759: each accept carries a named counter so the admit path is observable
+	// per type-class. This is a PURE observability add — `counter name "<n>"
+	// accept` counts then accepts, an identical terminal verdict to a bare
+	// `accept`. The single ICMPv6 rule is split into error (1-4) and ND (133-137)
+	// so the two classes count separately; the two type sets are disjoint and
+	// their union is the exact pre-#4759 set, so every packet that was accepted is
+	// still accepted (verdict-preserving — the userspace host-inbound exemption
+	// #3171 must still mirror the SAME union). The counters are AGGREGATE (global
+	// rules, not per-zone) per the #4759 caveat.
+	rules = append(rules, "    icmpv6 type { 1, 2, 3, 4 } counter name \""+xnft.HostInboundAcceptCounterName(xnft.HostInboundAcceptICMP6Error)+"\" accept")
+	rules = append(rules, "    icmpv6 type { 133, 134, 135, 136, 137 } counter name \""+xnft.HostInboundAcceptCounterName(xnft.HostInboundAcceptICMP6ND)+"\" accept")
+	rules = append(rules, "    icmp type { destination-unreachable, time-exceeded, parameter-problem } counter name \""+xnft.HostInboundAcceptCounterName(xnft.HostInboundAcceptICMP4Error)+"\" accept")
 
 	for _, v := range views {
 		emitHostInboundZone(&rules, v, "ip", v.V4Addrs)

--- a/pkg/daemon/host_inbound_nft_test.go
+++ b/pkg/daemon/host_inbound_nft_test.go
@@ -193,17 +193,39 @@ func TestHostInboundFilterExemptsIPsecAndV6Errors(t *testing.T) {
 	if !strings.Contains(payload, espAH) {
 		t.Errorf("payload missing raw ESP/AH exemption %q\n---\n%s", espAH, payload)
 	}
-	// icmpv6 error/PMTUD types 1-4 + ND 133-137 must be in the accepted set.
-	if !strings.Contains(payload, "icmpv6 type { 1, 2, 3, 4, 133, 134, 135, 136, 137 } accept") {
-		t.Errorf("payload missing icmpv6 error/PMTUD (1-4) + ND in the global accept:\n%s", payload)
+	// #4759: the single ICMPv6 accept was SPLIT into error (1-4) and ND (133-137)
+	// so each type-class counts separately, and each accept now carries a named
+	// nft counter. The split is verdict-preserving — the union {1,2,3,4} ∪
+	// {133,134,135,136,137} is the exact pre-#4759 accepted set, and `counter name
+	// "<n>" accept` counts then accepts (identical terminal verdict to a bare
+	// accept). Assert BOTH split rules carry their counter AND still end in
+	// `accept` (fail-on-revert: dropping a class, dropping the counter, or
+	// changing the verdict turns this RED).
+	if !strings.Contains(payload, "icmpv6 type { 1, 2, 3, 4 } counter name \"xpfhia_icmp6_error\" accept") {
+		t.Errorf("payload missing icmpv6 error/PMTUD (1-4) counted accept:\n%s", payload)
+	}
+	if !strings.Contains(payload, "icmpv6 type { 133, 134, 135, 136, 137 } counter name \"xpfhia_icmp6_nd\" accept") {
+		t.Errorf("payload missing icmpv6 ND (133-137) counted accept:\n%s", payload)
 	}
 	// #3171: the ICMPv4 error/PMTUD set must agree with the userspace
 	// host-inbound exemption (is_icmp_host_inbound_error) so the kernel chain and
 	// the XSK LocalDelivery classifier admit the same ICMP errors on a ping-less
 	// zone. Fail-on-revert: narrowing this back to bare destination-unreachable
-	// turns this RED.
-	if !strings.Contains(payload, "icmp type { destination-unreachable, time-exceeded, parameter-problem } accept") {
-		t.Errorf("payload missing icmpv4 error/PMTUD (dest-unreachable/time-exceeded/parameter-problem) accept:\n%s", payload)
+	// (or dropping the counter / changing the verdict) turns this RED.
+	if !strings.Contains(payload, "icmp type { destination-unreachable, time-exceeded, parameter-problem } counter name \"xpfhia_icmp4_error\" accept") {
+		t.Errorf("payload missing icmpv4 error/PMTUD (dest-unreachable/time-exceeded/parameter-problem) counted accept:\n%s", payload)
+	}
+	// #4759: every accept counter object referenced above must also be DECLARED in
+	// the table body (nft rejects a reference to an undeclared counter). The three
+	// declarations are UNCONDITIONAL (the accept rules are always present).
+	for _, decl := range []string{
+		"counter xpfhia_icmp6_nd {",
+		"counter xpfhia_icmp6_error {",
+		"counter xpfhia_icmp4_error {",
+	} {
+		if !strings.Contains(payload, decl) {
+			t.Errorf("payload missing accept-counter declaration %q:\n%s", decl, payload)
+		}
 	}
 
 	// The ESP/AH exemption MUST precede every per-zone scoped drop, otherwise a

--- a/pkg/nftables/host_inbound_accept_counters.go
+++ b/pkg/nftables/host_inbound_accept_counters.go
@@ -1,0 +1,153 @@
+package nftables
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/nftables"
+	"golang.org/x/sys/unix"
+)
+
+// hostInboundAcceptCounterPrefix tags every named counter object attached to a
+// GLOBAL host-inbound ICMP-error / ND accept rule (#4759) so the metric scraper
+// can pick our accept counters out of the `inet xpf_hostinbound` table and
+// ignore anything else (including the `xpfhi_` deny counters, which use a
+// distinct prefix). The two prefixes never collide: `xpfhi_` is immediately
+// followed by an underscore-terminated family token, while `xpfhia_` has an 'a'
+// in that position, so ParseHostInboundDenyCounterName rejects an accept name
+// and this parser rejects a deny name.
+const hostInboundAcceptCounterPrefix = "xpfhia_"
+
+// Host-inbound ICMP-error / ND accept counter TYPE-class keys (#4759). The
+// global accept rules in pkg/daemon/daemon_nft.go accept a set of ICMP/ICMPv6
+// control-message types regardless of any per-zone host-inbound service set (so
+// enforcement never black-holes core L3 operation). Before #4759 those accepts
+// were UNCOUNTED; each rule now carries the named counter for its type-class,
+// giving aggregate per-class visibility into how many such packets the
+// host-inbound path admits.
+//
+// These are AGGREGATE (the accept rules are GLOBAL, not per-zone) — there is no
+// per-zone breakdown; a per-zone split would require per-zone rule duplication
+// (a larger ruleset change, #4759 caveat).
+const (
+	// HostInboundAcceptICMP6ND counts ICMPv6 Neighbor Discovery accepts
+	// (types 133-137: router/neighbor solicit+advert, redirect).
+	HostInboundAcceptICMP6ND = "icmp6_nd"
+	// HostInboundAcceptICMP6Error counts ICMPv6 error / PMTUD accepts
+	// (types 1-4: destination-unreachable, packet-too-big, time-exceeded,
+	// parameter-problem).
+	HostInboundAcceptICMP6Error = "icmp6_error"
+	// HostInboundAcceptICMP4Error counts ICMPv4 error / PMTUD accepts
+	// (destination-unreachable, time-exceeded, parameter-problem).
+	HostInboundAcceptICMP4Error = "icmp4_error"
+)
+
+// HostInboundAcceptCounterTypes is the ordered, fixed set of accept type-class
+// keys. The daemon declares one counter object per entry and references it on
+// the matching accept rule; the Prometheus collector iterates the same set.
+var HostInboundAcceptCounterTypes = []string{
+	HostInboundAcceptICMP6ND,
+	HostInboundAcceptICMP6Error,
+	HostInboundAcceptICMP4Error,
+}
+
+// HostInboundAcceptCounterName returns the nft named-counter object name for a
+// host-inbound accept type-class. The result is a BARE nft identifier
+// (prefix + fixed key, all in [a-z0-9_]), so it is valid both in the UNQUOTED
+// counter DECLARATION (`counter <n> { }`, which nft v1.1.6 requires unquoted,
+// #3578) and in the QUOTED reference (`counter name "<n>"`) — the two match
+// byte-for-byte.
+func HostInboundAcceptCounterName(typ string) string {
+	return hostInboundAcceptCounterPrefix + typ
+}
+
+// ParseHostInboundAcceptCounterName reverses HostInboundAcceptCounterName. It
+// returns ok=false for any object name that is not one of our host-inbound
+// accept counters (wrong prefix or unknown type-class), so the scraper silently
+// skips foreign / malformed / deny-counter objects that share the table.
+func ParseHostInboundAcceptCounterName(name string) (typ string, ok bool) {
+	rest, found := strings.CutPrefix(name, hostInboundAcceptCounterPrefix)
+	if !found || rest == "" {
+		return "", false
+	}
+	switch rest {
+	case HostInboundAcceptICMP6ND, HostInboundAcceptICMP6Error, HostInboundAcceptICMP4Error:
+		return rest, true
+	}
+	return "", false
+}
+
+// HostInboundAcceptCount is one global host-inbound ICMP-error / ND accept
+// counter read from the `inet xpf_hostinbound` table.
+type HostInboundAcceptCount struct {
+	Type    string // one of the HostInboundAccept* type-class keys
+	Packets uint64
+	Bytes   uint64
+}
+
+// ReadHostInboundAcceptCounters reads the global ICMP-error / ND accept counters
+// from the kernel `inet xpf_hostinbound` table via netlink (no nft shell-out).
+// It returns one entry per xpf-managed accept counter currently installed. The
+// accept counters live in the SAME table as the per-zone DROP counters
+// (ReadHostInboundDenyCounters); the two are separated purely by object-name
+// prefix, so this scraper skips the deny counters and vice versa.
+//
+// When the table is absent (no host-inbound-traffic enforcement is installed, so
+// the daemon removed it) the function returns (nil, nil): no table means no
+// counts, not an error. A genuine netlink failure is returned so the caller can
+// surface "counter unavailable" rather than a misleading zero (the #3345
+// missing-sample contract the Prometheus collector applies to nft counters).
+//
+// Counters reset to zero whenever the daemon rebuilds the table (every commit
+// and every DHCP/DHCPv6 address change on a dataplane interface, which delete +
+// recreate the table); this matches the table lifecycle and is handled by
+// Prometheus rate() reset detection, exactly like ReadHostInboundDenyCounters.
+func ReadHostInboundAcceptCounters() ([]HostInboundAcceptCount, error) {
+	c, err := nftables.New()
+	if err != nil {
+		return nil, fmt.Errorf("nftables conn: %w", err)
+	}
+	tables, err := c.ListTablesOfFamily(nftables.TableFamilyINet)
+	if err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("nftables list tables: %w", err)
+	}
+	var table *nftables.Table
+	for _, t := range tables {
+		if t != nil && t.Name == HostInboundTableName {
+			table = t
+			break
+		}
+	}
+	if table == nil {
+		// No host-inbound enforcement installed -> no accepts counted.
+		return nil, nil
+	}
+	objs, err := c.GetObjects(table)
+	if err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("nftables list objects %s: %w", HostInboundTableName, err)
+	}
+	var out []HostInboundAcceptCount
+	for _, o := range objs {
+		co, ok := o.(*nftables.CounterObj)
+		if !ok {
+			continue
+		}
+		typ, ok := ParseHostInboundAcceptCounterName(co.Name)
+		if !ok {
+			continue
+		}
+		out = append(out, HostInboundAcceptCount{
+			Type:    typ,
+			Packets: co.Packets,
+			Bytes:   co.Bytes,
+		})
+	}
+	return out, nil
+}

--- a/pkg/nftables/host_inbound_accept_counters_test.go
+++ b/pkg/nftables/host_inbound_accept_counters_test.go
@@ -1,0 +1,77 @@
+package nftables
+
+import "testing"
+
+// TestHostInboundAcceptCounterNameRoundTrip is the #4759 contract test for the
+// accept-counter name encoding shared by the renderer (pkg/daemon) and the
+// Prometheus scraper (pkg/api): every fixed type-class key must encode to a name
+// that parses back to the SAME key. Dropping or mis-parsing the prefix turns
+// this RED, which would mislabel the accept metric.
+func TestHostInboundAcceptCounterNameRoundTrip(t *testing.T) {
+	for _, typ := range HostInboundAcceptCounterTypes {
+		name := HostInboundAcceptCounterName(typ)
+		got, ok := ParseHostInboundAcceptCounterName(name)
+		if !ok {
+			t.Errorf("ParseHostInboundAcceptCounterName(%q) failed for type=%q", name, typ)
+			continue
+		}
+		if got != typ {
+			t.Errorf("round-trip mismatch for %q: got type=%q, want %q", name, got, typ)
+		}
+	}
+}
+
+// TestHostInboundAcceptCounterNameNftSafe proves the accept-counter name is a
+// BARE nft identifier — nft v1.1.6 requires the counter DECLARATION unquoted
+// (`counter <n> {}`), which accepts only [A-Za-z0-9_.-] and no leading digit
+// (#3578). The names are fixed compile-time constants, so this is a guard
+// against a future key introducing an unsafe byte or a digit-leading key.
+func TestHostInboundAcceptCounterNameNftSafe(t *testing.T) {
+	safe := func(c byte) bool {
+		return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') || c == '_' || c == '-' || c == '.'
+	}
+	for _, typ := range HostInboundAcceptCounterTypes {
+		name := HostInboundAcceptCounterName(typ)
+		if name == "" || (name[0] >= '0' && name[0] <= '9') {
+			t.Errorf("name %q for type=%q must not be empty or start with a digit", name, typ)
+		}
+		for i := 0; i < len(name); i++ {
+			if !safe(name[i]) {
+				t.Errorf("name %q (type=%q) carries an nft-unsafe byte %q at %d",
+					name, typ, name[i:i+1], i)
+			}
+		}
+	}
+}
+
+// TestParseHostInboundAcceptCounterNameRejectsForeign verifies the scraper
+// ignores any object name that is not one of our accept counters — critically a
+// `xpfhi_` DENY counter, which shares the `inet xpf_hostinbound` table. The two
+// prefixes (`xpfhi_` vs `xpfhia_`) must never cross-parse, or the accept and
+// deny series would double-count each other.
+func TestParseHostInboundAcceptCounterNameRejectsForeign(t *testing.T) {
+	bad := []string{
+		"",
+		"some_other_counter",
+		"xpfhia_",             // prefix only
+		"xpfhia_bogus",        // unknown type-class
+		"xpfhia_icmp6",        // truncated key
+		"xpfhi_ip_3_wan",      // a DENY counter (deny prefix)
+		"xpfhi_ip6_3_wan",     // a DENY counter (deny prefix)
+		"xpfhia_icmp4_error_", // trailing junk
+	}
+	for _, name := range bad {
+		if _, ok := ParseHostInboundAcceptCounterName(name); ok {
+			t.Errorf("ParseHostInboundAcceptCounterName(%q) must be rejected, got ok", name)
+		}
+	}
+	// And the reverse: an accept counter must NOT parse as a deny counter, so the
+	// deny scraper skips it (no bogus zone/family series).
+	for _, typ := range HostInboundAcceptCounterTypes {
+		name := HostInboundAcceptCounterName(typ)
+		if _, _, ok := ParseHostInboundDenyCounterName(name); ok {
+			t.Errorf("accept counter %q must NOT parse as a deny counter", name)
+		}
+	}
+}


### PR DESCRIPTION
Closes #4759

## Verify-first
- `gh issue view 4759`: the GLOBAL ICMP-error / ND accept rules in the kernel `inet xpf_hostinbound` chain (`pkg/daemon/daemon_nft.go`) were UNCOUNTED — no per-type visibility into how many ICMP-error / ND packets the host-inbound path admits. Residual of the #4422 observability triage after lo0/PBR landed in #4758.
- Mirrored the existing counted-rule + reader pattern exactly: the #3361 per-zone deny counters (`pkg/nftables/host_inbound_counters.go`) and the #4422 lo0 counters (`pkg/nftables/lo0_counters.go`) → a named nft counter in the ruleset → a netlink reader → a Prometheus metric (descriptor + Describe() + Collect() before the dataplane gate).
- Confirmed `counter <match> accept` is verdict-identical to a bare `accept` (nft `counter` counts then falls through to the terminal verdict).

## Behavior-preserving proof (counter-add ONLY — no admission change)
- `counter name "<n>" accept` counts then accepts — the same terminal verdict as bare `accept`.
- The single `icmpv6 type { 1,2,3,4,133..137 } accept` is split into error (1-4) and ND (133-137). The two type sets are **disjoint** and their **union is the exact pre-change accepted set**, so every packet that was accepted is still accepted. The userspace host-inbound exemption (#3171) still mirrors the same union.
- The ICMPv4 error rule keeps its identical type set and verdict; only a counter is attached.

## Counters + reader
- Three fixed named counters `xpfhia_icmp6_nd` / `xpfhia_icmp6_error` / `xpfhia_icmp4_error`, declared UNCONDITIONALLY at the top of the table body (the accept rules are always present → declaration and reference always agree). The `xpfhia_` prefix is distinct from the `xpfhi_` deny prefix that shares the same table; the two never cross-parse (guarded by a test), so accept and deny series never double-count.
- `pkg/nftables/host_inbound_accept_counters.go`: `ReadHostInboundAcceptCounters` (netlink, no shell-out) + name encode/parse.

## Metric
- `xpf_host_inbound_icmp_nd_accept_total{type}` (type ∈ `icmp6_nd`, `icmp6_error`, `icmp4_error`). Emitted BEFORE the dataplane gate (the nft chain is installed independent of dataplane load). Read failure SKIPS the series and bumps `xpf_counter_read_errors_total` (#3345 contract).
- **AGGREGATE across all zones** — the accept rules are global, not per-zone; a per-zone breakdown would need per-zone rule duplication (the #4759 Low-severity caveat). Noted in the descriptor help + `docs/feature-coverage.md`.

## Ruleset-test updates
- Updated the exact-string nft-ruleset test to assert both split rules carry their counter AND still end in `accept`, plus the three counter DECLARATIONS. The new counter statement is additive; the accept verdict line is unchanged.

## Tests / RED-on-mutation
- Ruleset test: verified RED before the test update, and RED again on a verdict mutation (`accept` → `drop`).
- Reader: round-trip / nft-safe / foreign-reject tests, including the cross-prefix guard (an accept name never parses as a deny name and vice versa).
- Metric: emit-before-the-dataplane-gate test (dp nil) + read-error-omits-series contract test.
- Neutralized the new pre-gate reader in the zone false-alert test (mirrors the existing lo0/deny neutralization).

## Gates
- `go build ./...` clean.
- `go test ./pkg/daemon/... ./pkg/nftables/... ./pkg/api/...` green.
- Full `go test ./...` green (0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi