### PR TITLE
perf(userspace-dp): chunk NAT GC to release the alloc mutex between reclaims (#4676)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43496,3 +43496,35 @@ top.
   pkg/cli/cli_show_security_filters.go,
   pkg/cli/cli_show_effective_filter_4422_test.go, pkg/cmdtree/tree.go,
   docs/junos-cli-reference.md, _Log.md
+
+- **Timestamp**: 2026-07-09
+- **Action**: #4676 — chunk NAT GC to release the alloc mutex between reclaims.
+  Phase-1 (#2852) made the port CLAIM lock-free (AddressOccupancy atomic
+  bitmap); the residual was that the opportunistic expiry GC still ran under
+  the shared `live: Mutex<PortAllocatorLiveState>` for its whole sweep,
+  lengthening the "tiny" `live_by_flow` insert critical section on the hot
+  allocation path and blocking concurrent allocations for the full sweep.
+  Added `gc_expired_chunked`: each chunk collects up to GC_CHUNK(8) expired
+  leases under a SHORT `live` CS (map mutations only), drops the guard, then
+  frees the reclaimed ports on the lock-free occupancy bitmap
+  (free_recycle = fetch_and + per-address recycle push) with `live` NOT held,
+  then re-takes `live` for the next batch. Factored the per-reclaim into
+  `collect_expired_{global,for_addr}_locked` + `reclaim_expired_lease_locked`
+  (records (addr,port) into a batch instead of freeing inline) shared by the
+  chunked path and the nested pressure-path GC (`allocate_translation_locked`
+  keeps holding `live` across claim+insert, so its GC stays nested — the
+  reclaimed ports are freed inline while the guard is held, byte-identical
+  behavior). Hot path + release path now call the chunked GC OFF the insert CS:
+  GC touches only persistent_by_source + the two expiration indexes + occupancy
+  (disjoint from live_by_flow), so running it in its own lock scope is
+  behaviorally equivalent and the insert CS is genuinely tiny. Concurrency-safe:
+  each reclaim re-checks active_flows==0 && expiry matches (skips a concurrent
+  refresh/rollback); the port bit stays SET from lease-removal until the free,
+  so a concurrent claim() cannot re-hand-out the port in the gap (no
+  double-claim / no lost-reclaim). Tests (RED-on-revert): seam test asserts the
+  sweep acquires `live` >= 2 times (non-reentrant std Mutex => released between
+  batches; collapsing to a single CS fails it — verified), plus reclaim
+  correctness, active/unexpired-lease sparing, and a 4-thread alloc+release+GC
+  concurrency-consistency stress. cargo build clean; new tests pass.
+- **File(s)**: userspace-dp/src/nat/allocator.rs,
+  userspace-dp/src/nat/tests_pool.rs, _Log.md

--- a/userspace-dp/src/nat/allocator.rs
+++ b/userspace-dp/src/nat/allocator.rs
@@ -84,6 +84,8 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 #[cfg(test)]
 use std::sync::MutexGuard;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+#[cfg(test)]
+use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, Mutex};
 
 pub(super) const NS_PER_SEC: u64 = 1_000_000_000;
@@ -582,6 +584,14 @@ const GC_PERIOD: u32 = 10;
 pub(super) const ALLOCATION_GC_BUDGET: usize = 8;
 const RELEASE_GC_BUDGET: usize = 64;
 const PRESSURE_GC_BUDGET: usize = 64;
+/// #4676: leases reclaimed per short `live` critical section by the chunked
+/// opportunistic GC (`gc_expired_chunked`). The sweep drops the alloc mutex
+/// and frees the reclaimed ports on the lock-free occupancy bitmap between
+/// chunks, so a concurrent `allocate_translation` map-insert is not blocked
+/// for the full sweep. Sized to `ALLOCATION_GC_BUDGET` so the hot-path amortized
+/// GC (budget 8) is a single chunk (no extra lock churn) while the larger
+/// release/idle budgets (64) yield the mutex several times.
+const GC_CHUNK: usize = 8;
 
 #[derive(Debug)]
 struct PortAllocatorShared {
@@ -602,6 +612,13 @@ struct PortAllocatorShared {
     reuses_total: AtomicU64,
     exhaustion_total: AtomicU64,
     max_tracked_flows: usize,
+    /// #4676 test seam: counts how many times `gc_expired_chunked` acquired the
+    /// `live` mutex. A std `Mutex` is non-reentrant, so N > 1 acquisitions over
+    /// a single sweep is proof the sweep RELEASED the lock between chunks (you
+    /// cannot re-acquire a lock you still hold). Reverting the chunking to a
+    /// single critical section collapses this to 1.
+    #[cfg(test)]
+    gc_lock_acquisitions: AtomicUsize,
 }
 
 /// Bounded pool-mode SNAT allocator.
@@ -632,6 +649,8 @@ impl Default for PortAllocator {
                 reuses_total: AtomicU64::new(0),
                 exhaustion_total: AtomicU64::new(0),
                 max_tracked_flows: 0,
+                #[cfg(test)]
+                gc_lock_acquisitions: AtomicUsize::new(0),
             }),
             port_low: 1024,
             port_high: 65535,
@@ -663,6 +682,8 @@ impl PortAllocator {
                 reuses_total: AtomicU64::new(0),
                 exhaustion_total: AtomicU64::new(0),
                 max_tracked_flows,
+                #[cfg(test)]
+                gc_lock_acquisitions: AtomicUsize::new(0),
             }),
             port_low,
             port_high,
@@ -754,6 +775,23 @@ impl PortAllocator {
         if let Some(occ) = self.shared.occupancy.get(addr_index) {
             occ.cursor.store(offset, Ordering::Relaxed);
         }
+    }
+
+    /// Test-only: drive the #4676 chunked opportunistic GC directly (the same
+    /// entry point the hot allocation path and the periodic release path use),
+    /// so a white-box test can assert both the reclaim result and the seam
+    /// (`debug_gc_lock_acquisitions`).
+    #[cfg(test)]
+    pub(super) fn debug_gc_expired_chunked(&self, now_ns: u64, budget: usize) -> usize {
+        self.gc_expired_chunked(now_ns, budget)
+    }
+
+    /// Test-only: how many times `gc_expired_chunked` has acquired the `live`
+    /// mutex. Because a std `Mutex` is non-reentrant, a value > 1 over a single
+    /// sweep is direct proof the sweep RELEASED the lock between chunks.
+    #[cfg(test)]
+    pub(super) fn debug_gc_lock_acquisitions(&self) -> usize {
+        self.shared.gc_lock_acquisitions.load(Ordering::Relaxed)
     }
 
     /// Pick a pool address index for the current address family.
@@ -862,8 +900,16 @@ impl PortAllocator {
                     ip: family_addresses.ip_at(rel),
                     port,
                 };
+                // #4676: run the amortized expiry GC OFF the insert critical
+                // section — chunked, the alloc mutex released between batches,
+                // reclaimed ports freed lock-free. GC touches only the
+                // persistent-lease maps + occupancy while the insert CS below
+                // touches only `live_by_flow`, so the two are disjoint and the
+                // insert CS stays genuinely tiny (the port is already claimed on
+                // the lock-free bitmap, so GC here is opportunistic cleanup, not
+                // load-bearing for this allocation).
+                self.gc_expired_chunked(now_ns, ALLOCATION_GC_BUDGET);
                 let mut live = self.shared.live.lock().unwrap_or_else(|e| e.into_inner());
-                self.gc_expired_locked(&mut live, now_ns, ALLOCATION_GC_BUDGET);
                 if let Some(existing) = live.live_by_flow.get(&flow) {
                     // Idempotent re-entry for an already-allocated flow (a second
                     // packet racing session install). Give back the port we just
@@ -1174,8 +1220,15 @@ impl PortAllocator {
             );
         }
         live.gc_counter = live.gc_counter.wrapping_add(1);
-        if live.gc_counter % GC_PERIOD == 0 {
-            self.gc_expired_locked(&mut live, now_ns, RELEASE_GC_BUDGET);
+        let run_gc = live.gc_counter % GC_PERIOD == 0;
+        // #4676: drop the release guard BEFORE the periodic idle-lease sweep so
+        // the (up to RELEASE_GC_BUDGET) sweep runs chunked with the alloc mutex
+        // released between batches instead of blocking concurrent allocations
+        // for the whole sweep. The release mutations above are already committed
+        // under this guard, so the GC re-locking a fresh guard observes them.
+        drop(live);
+        if run_gc {
+            self.gc_expired_chunked(now_ns, RELEASE_GC_BUDGET);
         }
         true
     }
@@ -1476,11 +1529,117 @@ impl PortAllocator {
         }
     }
 
+    /// #4676: run the opportunistic global expiry GC WITHOUT holding the alloc
+    /// mutex across the whole sweep.
+    ///
+    /// The sweep is chunked: each chunk collects up to `GC_CHUNK` expired
+    /// leases from the global expiration index under a SHORT `live` critical
+    /// section (the map mutations that MUST be serialized), releases the guard,
+    /// then frees those ports on the lock-free occupancy bitmap
+    /// (`AddressOccupancy::free_recycle`, a `fetch_and` + per-address recycle
+    /// push) with `live` NOT held. Releasing `live` between chunks lets a
+    /// concurrent `allocate_translation` acquire the mutex for its tiny
+    /// `live_by_flow` insert instead of blocking for the full sweep — the
+    /// Phase-1 (#2852) residual this addresses.
+    ///
+    /// Safety: each reclaim stays idempotent. Under the short CS the lease is
+    /// re-checked (`active_flows == 0 && expires_at_ns` matches) before removal,
+    /// so a concurrent `release_flow`/`rollback_flow` that refreshed or bumped
+    /// the lease is skipped. The port bit is the ownership token and stays SET
+    /// from lease removal until we free it, so a concurrent `claim()` cannot
+    /// re-hand-out the port in the gap (no double-claim); once freed it returns
+    /// to the pool. `budget` bounds total reclaims (amortized GC). This is
+    /// disjoint from the caller's insert CS: GC touches only
+    /// `persistent_by_source` + the expiration indexes + occupancy, never
+    /// `live_by_flow`, so running it in its own lock scope is behaviorally
+    /// equivalent to the pre-#4676 nested call.
+    fn gc_expired_chunked(&self, now_ns: u64, budget: usize) -> usize {
+        if now_ns == 0 || budget == 0 {
+            return 0;
+        }
+        let mut reclaimed = 0;
+        let mut freed: Vec<(usize, u16)> = Vec::new();
+        while reclaimed < budget {
+            let chunk = (budget - reclaimed).min(GC_CHUNK);
+            freed.clear();
+            let collected = {
+                let mut live = self.shared.live.lock().unwrap_or_else(|e| e.into_inner());
+                #[cfg(test)]
+                self.shared
+                    .gc_lock_acquisitions
+                    .fetch_add(1, Ordering::Relaxed);
+                self.collect_expired_global_locked(&mut live, now_ns, chunk, &mut freed)
+                // `live` guard dropped here, BEFORE the lock-free port frees
+                // below and BEFORE the loop re-acquires it for the next chunk.
+            };
+            for &(addr_index, port) in &freed {
+                self.free_translated_port(addr_index, port, true);
+            }
+            reclaimed += collected;
+            if collected < chunk {
+                // A short chunk means the expired frontier is exhausted (the
+                // earliest remaining lease is not yet expired, or the index is
+                // empty). Stop instead of re-locking for a guaranteed-empty
+                // chunk. Any lease that expires later is reclaimed by a
+                // subsequent amortized GC pass — GC is opportunistic, never the
+                // sole reclaim path.
+                break;
+            }
+        }
+        reclaimed
+    }
+
+    /// Nested (guard-held) global expiry GC for the near-capacity pressure
+    /// fallback in `allocate_translation_locked`, where `live` is held across
+    /// the whole claim+insert and cannot be released mid-flight. Shares the
+    /// `collect_expired_global_locked` primitive with the chunked path; the
+    /// only difference is that the reclaimed ports are freed inline while the
+    /// caller still holds `live` (unchanged pre-#4676 behavior).
     fn gc_expired_locked(
         &self,
         live: &mut PortAllocatorLiveState,
         now_ns: u64,
         budget: usize,
+    ) -> usize {
+        let mut freed: Vec<(usize, u16)> = Vec::new();
+        let reclaimed = self.collect_expired_global_locked(live, now_ns, budget, &mut freed);
+        for (addr_index, port) in freed {
+            self.free_translated_port(addr_index, port, true);
+        }
+        reclaimed
+    }
+
+    /// Nested (guard-held) per-address expiry GC for the pressure fallback.
+    /// Same guard-held free discipline as `gc_expired_locked`.
+    fn gc_expired_for_addr_locked(
+        &self,
+        live: &mut PortAllocatorLiveState,
+        addr_index: usize,
+        now_ns: u64,
+        budget: usize,
+    ) -> usize {
+        let mut freed: Vec<(usize, u16)> = Vec::new();
+        let reclaimed =
+            self.collect_expired_for_addr_locked(live, addr_index, now_ns, budget, &mut freed);
+        for (addr_index, port) in freed {
+            self.free_translated_port(addr_index, port, true);
+        }
+        reclaimed
+    }
+
+    /// Collect up to `budget` expired idle leases from the GLOBAL expiration
+    /// index under a HELD `live` guard: pop the earliest-expiring entries,
+    /// remove them from `persistent_by_source` and both expiration indexes, and
+    /// record each reclaimed lease's `(addr_index, port)` in `freed` for the
+    /// caller to release on the lock-free occupancy bitmap. Returns the count
+    /// collected. Does NOT touch the occupancy bitmap — port release is
+    /// deferred so it need not be serialized behind the alloc mutex (#4676).
+    fn collect_expired_global_locked(
+        &self,
+        live: &mut PortAllocatorLiveState,
+        now_ns: u64,
+        budget: usize,
+        freed: &mut Vec<(usize, u16)>,
     ) -> usize {
         if now_ns == 0 || budget == 0 {
             return 0;
@@ -1499,19 +1658,23 @@ impl PortAllocator {
                     by_addr.remove(&(expires_at_ns, key));
                 }
             }
-            if self.release_expired_lease_locked(live, key, expires_at_ns) {
+            if self.reclaim_expired_lease_locked(live, key, expires_at_ns, freed) {
                 reclaimed += 1;
             }
         }
         reclaimed
     }
 
-    fn gc_expired_for_addr_locked(
+    /// Per-address variant of `collect_expired_global_locked`: pops from
+    /// `lease_expirations_by_addr[addr_index]` (and mirrors the removal into the
+    /// global index). Records reclaimed ports into `freed`.
+    fn collect_expired_for_addr_locked(
         &self,
         live: &mut PortAllocatorLiveState,
         addr_index: usize,
         now_ns: u64,
         budget: usize,
+        freed: &mut Vec<(usize, u16)>,
     ) -> usize {
         if now_ns == 0 || budget == 0 || addr_index >= live.lease_expirations_by_addr.len() {
             return 0;
@@ -1530,18 +1693,26 @@ impl PortAllocator {
             }
             live.lease_expirations_by_addr[addr_index].remove(&(expires_at_ns, key));
             live.lease_expirations.remove(&(expires_at_ns, key));
-            if self.release_expired_lease_locked(live, key, expires_at_ns) {
+            if self.reclaim_expired_lease_locked(live, key, expires_at_ns, freed) {
                 reclaimed += 1;
             }
         }
         reclaimed
     }
 
-    fn release_expired_lease_locked(
+    /// Remove one expired idle lease from `persistent_by_source` under a HELD
+    /// `live` guard and RECORD its `(addr_index, port)` in `freed` — it does NOT
+    /// clear the occupancy bit (the caller frees the collected ports, possibly
+    /// after dropping `live`, keeping the lock-free bitmap op off the alloc
+    /// mutex, #4676). Re-checks the lease is still idle and its expiry still
+    /// matches so a concurrent refresh/rollback is not clobbered. Returns true
+    /// iff a lease was reclaimed.
+    fn reclaim_expired_lease_locked(
         &self,
         live: &mut PortAllocatorLiveState,
         key: PersistentSourceKey,
         expires_at_ns: u64,
+        freed: &mut Vec<(usize, u16)>,
     ) -> bool {
         let Some(lease) = live.persistent_by_source.get(&key).copied() else {
             return false;
@@ -1551,10 +1722,13 @@ impl PortAllocator {
         }
         // The lease still exists and is idle: its occupancy bit is still set
         // (no other allocation could have claimed it while the lease held it —
-        // the bit is the ownership token). Remove the lease and free its port
-        // (recycle). If the bit was somehow already clear the free is a no-op.
+        // the bit is the ownership token). Remove the lease and record its port
+        // so the caller frees it (recycle). Because the bit stays set until that
+        // free, a concurrent claim cannot re-hand-out the port even after the
+        // lease is gone from the map.
         live.persistent_by_source.remove(&key);
-        self.free_translated_port(lease.addr_index, lease.translated.port, true)
+        freed.push((lease.addr_index, lease.translated.port));
+        true
     }
 }
 

--- a/userspace-dp/src/nat/tests_pool.rs
+++ b/userspace-dp/src/nat/tests_pool.rs
@@ -3946,3 +3946,292 @@ fn pool_snat_fills_to_exact_capacity_then_exhausts() {
         "one flow beyond exact capacity must exhaust"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #4676: chunked opportunistic GC releases the alloc mutex between batches.
+//
+// Phase-1 (#2852) made the port CLAIM lock-free, but the expiry GC still ran
+// under the shared `live` mutex for its whole sweep, lengthening the "tiny"
+// insert critical section on the hot allocation path. The chunked sweep now
+// collects a bounded batch of expired leases under a SHORT `live` critical
+// section, drops the guard, frees the reclaimed ports on the lock-free
+// occupancy bitmap, then re-takes `live` for the next batch. These tests pin
+// (1) the seam — the sweep acquires `live` more than once, i.e. it releases it
+// between batches (RED on revert to a single critical section), (2) reclaim
+// correctness — every expired idle lease is reclaimed and its port freed, and
+// (3) that active / not-yet-expired leases are spared, plus a concurrency
+// stress that a chunked GC racing live allocations never corrupts state.
+// ---------------------------------------------------------------------------
+
+/// Install `count` idle, already-expired persistent leases on pool address
+/// `addr_index` (one per port starting at `port_low`), with their occupancy
+/// bits set and their expiry indexed — exactly the residue the live
+/// alloc+release path leaves behind for an idle-but-not-yet-GC'd lease. Lets
+/// the chunked GC be driven in isolation.
+fn install_expired_idle_leases(
+    alloc: &PortAllocator,
+    addr_index: usize,
+    ip: Ipv4Addr,
+    port_low: u16,
+    count: u16,
+    expires_at_ns: u64,
+) {
+    {
+        let mut live = alloc.debug_live();
+        for i in 0..count {
+            let port = port_low + i;
+            let key = PersistentSourceKey {
+                protocol: 6,
+                src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, (i >> 8) as u8, (i & 0xff) as u8)),
+                src_port: 40000 + i,
+                remote: None,
+            };
+            live.persistent_by_source.insert(
+                key,
+                PersistentLease {
+                    translated: TranslatedTuple {
+                        ip: IpAddr::V4(ip),
+                        port,
+                    },
+                    addr_index,
+                    expires_at_ns,
+                    timeout_ns: NS_PER_SEC,
+                    active_flows: 0,
+                    completed_flows: 1,
+                    activation_saw_completion: true,
+                    activation_previous_expires_at_ns: 0,
+                    activation_had_previous_lease: false,
+                },
+            );
+            live.lease_expirations.insert((expires_at_ns, key));
+            live.lease_expirations_by_addr[addr_index].insert((expires_at_ns, key));
+        }
+    }
+    for i in 0..count {
+        alloc.debug_seed_owner(addr_index, IpAddr::V4(ip), port_low + i);
+    }
+}
+
+/// (1) The seam: a multi-batch chunked sweep acquires `live` more than once,
+/// which (a std `Mutex` being non-reentrant) is direct proof it RELEASED the
+/// mutex between batches so a concurrent allocation's insert can slip in.
+/// Reverting the chunking to a single critical section collapses the
+/// acquisition count to 1 and fails this test.
+#[test]
+fn pool_snat_gc_chunked_releases_lock_between_batches() {
+    let ip: Ipv4Addr = "203.0.113.1".parse().unwrap();
+    let count: u16 = 20; // > GC_CHUNK (8): a budget-20 sweep needs >= 3 batches.
+    let alloc = PortAllocator::new(1, 1024, 1024 + count);
+    install_expired_idle_leases(&alloc, 0, ip, 1024, count, 500);
+
+    assert_eq!(alloc.debug_occupied_count(), count as usize);
+    {
+        let live = alloc.debug_live();
+        assert_eq!(live.persistent_by_source.len(), count as usize);
+        assert_eq!(live.lease_expirations.len(), count as usize);
+        assert_eq!(live.lease_expirations_by_addr[0].len(), count as usize);
+    }
+
+    // now_ns = 1000 is past every lease's expiry (500).
+    let reclaimed = alloc.debug_gc_expired_chunked(1_000, count as usize);
+
+    assert_eq!(
+        reclaimed, count as usize,
+        "every expired idle lease must be reclaimed"
+    );
+    assert!(
+        alloc.debug_gc_lock_acquisitions() >= 2,
+        "chunked GC must acquire `live` more than once (released between batches); got {}",
+        alloc.debug_gc_lock_acquisitions()
+    );
+    // No port left occupied after its lease was removed (no lost-reclaim leak).
+    assert_eq!(
+        alloc.debug_occupied_count(),
+        0,
+        "every reclaimed port must be freed on the occupancy bitmap"
+    );
+    let live = alloc.debug_live();
+    assert!(live.persistent_by_source.is_empty());
+    assert!(live.lease_expirations.is_empty());
+    assert!(live.lease_expirations_by_addr[0].is_empty());
+}
+
+/// (2) Correctness: the chunked sweep reclaims ONLY expired idle leases. An
+/// active lease (active_flows > 0, absent from the expiry index) and an idle
+/// but not-yet-expired lease are both spared — their ports stay occupied and
+/// their map entries survive.
+#[test]
+fn pool_snat_gc_chunked_spares_active_and_unexpired_leases() {
+    let ip: Ipv4Addr = "203.0.113.2".parse().unwrap();
+    let alloc = PortAllocator::new(1, 1024, 4096);
+    // 5 expired idle leases (ports 1024..1029, expiry 500).
+    install_expired_idle_leases(&alloc, 0, ip, 1024, 5, 500);
+
+    let active_key = PersistentSourceKey {
+        protocol: 6,
+        src_ip: "10.1.1.1".parse().unwrap(),
+        src_port: 1,
+        remote: None,
+    };
+    let future_key = PersistentSourceKey {
+        protocol: 6,
+        src_ip: "10.1.1.2".parse().unwrap(),
+        src_port: 2,
+        remote: None,
+    };
+    {
+        let mut live = alloc.debug_live();
+        // Active lease: active_flows = 1, deliberately NOT indexed (active
+        // leases never sit in the expiry index — GC must not touch it).
+        live.persistent_by_source.insert(
+            active_key,
+            PersistentLease {
+                translated: TranslatedTuple {
+                    ip: IpAddr::V4(ip),
+                    port: 2000,
+                },
+                addr_index: 0,
+                expires_at_ns: 500,
+                timeout_ns: NS_PER_SEC,
+                active_flows: 1,
+                completed_flows: 0,
+                activation_saw_completion: false,
+                activation_previous_expires_at_ns: 0,
+                activation_had_previous_lease: false,
+            },
+        );
+        // Idle but not-yet-expired lease (expiry 10_000, past now=1000).
+        live.persistent_by_source.insert(
+            future_key,
+            PersistentLease {
+                translated: TranslatedTuple {
+                    ip: IpAddr::V4(ip),
+                    port: 2001,
+                },
+                addr_index: 0,
+                expires_at_ns: 10_000,
+                timeout_ns: NS_PER_SEC,
+                active_flows: 0,
+                completed_flows: 1,
+                activation_saw_completion: true,
+                activation_previous_expires_at_ns: 0,
+                activation_had_previous_lease: false,
+            },
+        );
+        live.lease_expirations.insert((10_000, future_key));
+        live.lease_expirations_by_addr[0].insert((10_000, future_key));
+    }
+    alloc.debug_seed_owner(0, IpAddr::V4(ip), 2000);
+    alloc.debug_seed_owner(0, IpAddr::V4(ip), 2001);
+
+    // now_ns = 1000: past the 5 expired leases (500) but before the future
+    // lease (10_000). The active lease is never reached (not indexed).
+    let reclaimed = alloc.debug_gc_expired_chunked(1_000, 64);
+
+    assert_eq!(reclaimed, 5, "only the 5 expired idle leases are reclaimed");
+    for p in 1024..1029 {
+        assert!(
+            !alloc.debug_is_port_occupied(0, p),
+            "expired lease port {p} must be freed"
+        );
+    }
+    assert!(
+        alloc.debug_is_port_occupied(0, 2000),
+        "active lease port must stay occupied (never early-freed)"
+    );
+    assert!(
+        alloc.debug_is_port_occupied(0, 2001),
+        "not-yet-expired lease port must stay occupied"
+    );
+    let live = alloc.debug_live();
+    assert!(live.persistent_by_source.contains_key(&active_key));
+    assert!(live.persistent_by_source.contains_key(&future_key));
+    assert_eq!(live.persistent_by_source.len(), 2);
+    assert_eq!(live.lease_expirations.len(), 1);
+    assert!(live.lease_expirations.contains(&(10_000, future_key)));
+    assert_eq!(live.lease_expirations_by_addr[0].len(), 1);
+}
+
+/// (3) Concurrency: many threads drive real persistent + non-persistent
+/// allocate/release cycles (so both chunked-GC entry points — the hot alloc
+/// path and the periodic release path — race live allocations) on a shared
+/// allocator. now_ns advances faster than the lease timeout so GC actively
+/// reclaims expired leases DURING the run. Afterwards a single full GC must
+/// leave the allocator perfectly consistent: no lease, no occupied port, no
+/// stale index entry, no leaked flow — proving a chunked GC racing allocations
+/// neither double-frees, misses, nor strands a port.
+#[test]
+fn pool_snat_gc_chunked_concurrent_alloc_release_stays_consistent() {
+    use std::thread;
+    let ip: Ipv4Addr = "203.0.113.3".parse().unwrap();
+    let alloc = PortAllocator::new(1, 1024, 64000);
+    let threads = 4u32;
+    let per_thread = 1500u32;
+
+    thread::scope(|s| {
+        for t in 0..threads {
+            let alloc = alloc.clone();
+            s.spawn(move || {
+                let addrs = [ip];
+                for i in 0..per_thread {
+                    // Advance now_ns by 2s/iter (> the 1s min lease timeout) so
+                    // leases from earlier iterations are expired and reclaimed
+                    // by the concurrent chunked GC as the run proceeds.
+                    let now_ns = 1_000_000_000u64 + (i as u64) * 2 * NS_PER_SEC;
+                    // Unique source per (t, i) => a distinct flow AND lease key.
+                    let src_ip = IpAddr::V4(Ipv4Addr::new(
+                        10,
+                        t as u8,
+                        (i >> 8) as u8,
+                        (i & 0xff) as u8,
+                    ));
+                    let persistent = i % 2 == 0;
+                    let flow = SourceNatFlowKey {
+                        protocol: 6,
+                        src_ip,
+                        dst_ip: "8.8.8.8".parse().unwrap(),
+                        src_port: 1024 + (i % 60000) as u16,
+                        dst_port: 443,
+                    };
+                    if let Ok(translated) = alloc.allocate_translation(
+                        flow,
+                        PoolAddressFamily::V4(&addrs),
+                        0,
+                        false,
+                        persistent,
+                        PersistentNatPermit::AnyRemoteHost,
+                        NS_PER_SEC,
+                        now_ns,
+                    ) {
+                        assert!(
+                            alloc.release_flow(flow, translated, now_ns + 1),
+                            "release of a just-allocated unique flow must succeed"
+                        );
+                    }
+                }
+            });
+        }
+    });
+
+    // Single-threaded full GC well past every lease's expiry: every idle lease
+    // is now reclaimable, and every flow has been released.
+    alloc.debug_gc_expired_chunked(u64::MAX / 2, usize::MAX);
+
+    let snap = alloc.snapshot();
+    assert_eq!(
+        snap.live_flows, 0,
+        "all flows released; no live flow may remain"
+    );
+    assert_eq!(
+        snap.persistent_leases, 0,
+        "all idle expired leases must be reclaimed by the final GC"
+    );
+    assert_eq!(
+        snap.used_ports, 0,
+        "no port may stay occupied once every lease is reclaimed"
+    );
+    assert_eq!(alloc.debug_occupied_count(), 0);
+    let live = alloc.debug_live();
+    assert!(live.lease_expirations.is_empty());
+    assert!(live.lease_expirations_by_addr[0].is_empty());
+}


### PR DESCRIPTION
Closes #4676

## What

Phase-1 (#2852) made the SNAT port CLAIM lock-free (the `AddressOccupancy`
atomic bitmap), leaving one residual serialization: the opportunistic
lease-expiry GC still ran under the shared `live: Mutex<PortAllocatorLiveState>`
for its whole sweep. On the hot allocation path that GC ran **inside** the
"tiny" `live_by_flow` insert critical section, so a concurrent allocation's
map-insert was blocked for the full sweep.

This chunks the sweep off the insert critical section. `gc_expired_chunked`:

1. collects up to `GC_CHUNK` (8) expired leases from the expiration index under
   a **short** `live` critical section (the map mutations that must be
   serialized),
2. drops the guard,
3. frees the reclaimed ports on the lock-free occupancy bitmap
   (`free_recycle` = `fetch_and` + per-address recycle push) with `live` **not**
   held,
4. re-takes `live` for the next batch.

Releasing the mutex between batches lets a concurrent `allocate_translation`
grab it for its insert instead of waiting out the whole sweep.

The per-reclaim is factored into `collect_expired_{global,for_addr}_locked` +
`reclaim_expired_lease_locked`, which record each reclaimed `(addr_index, port)`
into a batch instead of freeing inline. The near-capacity **pressure** fallback
(`allocate_translation_locked`) holds `live` across its whole claim+insert and
cannot release mid-flight, so its GC stays nested — it frees the batch inline
while the guard is still held, **byte-identical** to the pre-change behavior
(including the #3011 FIFO recycle push order). Only the hot allocation path and
the periodic release-path GC move off the insert critical section.

## Concurrency-safety argument

- **Disjointness.** GC touches only `persistent_by_source` + the two expiration
  indexes + the occupancy bitmap. The hot-path insert critical section touches
  only `live_by_flow` and its exact cap check. GC never changes
  `live_by_flow.len()`, so it cannot affect the cap check — running GC in its
  own lock scope before the insert is behaviorally equivalent to the old nested
  call.
- **Idempotent reclaim.** Under the short critical section each lease is
  re-checked (`active_flows == 0` **and** its `expires_at_ns` still matches the
  index entry) before removal, so a concurrent `release_flow`/`rollback_flow`
  that refreshed or restored the lease is skipped (never double-reclaimed,
  never clobbered).
- **No double-claim / no lost-reclaim.** The port bit is the ownership token and
  stays **set** from lease removal until the deferred free, so a concurrent
  `claim()` cannot re-hand-out the port in the gap between lease removal and
  port free. No port is left occupied after its lease is gone.
- **Bounded, opportunistic.** `budget` still bounds total reclaims. A short
  chunk means the expired frontier is exhausted and the sweep stops; any
  later-expiring lease is reclaimed by a subsequent amortized pass — GC is
  opportunistic, never the sole reclaim path.

The pressure fallback's locking model is unchanged (still nested), so this is a
bounded lock-split, not a core-locking-model restructure.

## Tests (RED on revert)

- `pool_snat_gc_chunked_releases_lock_between_batches` — the **seam**: a
  multi-batch sweep acquires `live` more than once. A `std::sync::Mutex` is
  non-reentrant, so >1 acquisition is direct proof the sweep RELEASED the lock
  between batches. **Verified RED on revert**: collapsing the chunking to a
  single critical section (`GC_CHUNK` huge) fails the `>= 2` assertion.
- `pool_snat_gc_chunked_spares_active_and_unexpired_leases` — every expired idle
  lease reclaimed and its port freed; an active lease (not indexed) and a
  not-yet-expired idle lease both spared (ports stay occupied, entries survive).
- `pool_snat_gc_chunked_concurrent_alloc_release_stays_consistent` — a 4-thread
  concurrent allocate+release+GC stress (both chunked-GC entry points racing
  live allocations); after a final full GC the allocator must be perfectly
  consistent (no lease, no occupied port, no stale index entry, no leaked flow).

## Validation

```
cargo build                                  clean (no new warnings)
cargo test --release -- --test-threads=1     3869 passed / 0 failed / 2 ignored
cargo test --release nat                     678 nat + 1 doc-guard passed / 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
