### PR TITLE
#4768: Prometheus metrics for the #4743 martian + IPv6 ext-header drop counters

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43632,3 +43632,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4662 Increment 3 — extract startHTTPServer (HTTP REST API server startup block, 278 lines, PHASE 5) from Run(); byte-identical body (dedent verified), 3 params (ctx, wg, eventBuf), guard stays in Run(). Leaf block, no ordering dependency
   **File(s)**: pkg/daemon/daemon_run.go
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4768 — Prometheus metrics xpf_userspace_martian_dropped_total + xpf_userspace_ipv6_ext_header_dropped_total (sum #4743 per-binding counters across bindings). Desc fields + newCollector + Describe wiring + emitDropClassCounters + RED-on-revert test + junos-cli-reference note
+  **File(s)**: pkg/api/metrics.go, pkg/api/metrics_descriptors.go, pkg/api/metrics_userspace.go, pkg/api/metrics_drop_class_4768_test.go, docs/junos-cli-reference.md

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -469,6 +469,11 @@ From zone: guest, To zone: lan
       forwarded flowless (`l4_present = false`), an ext-header IDS-evasion; it is
       distinct from a TRUNCATED chain (which stays flowless). Not in `Packets
       dropped`.
+      - **Prometheus (#4768):** both counters are also exposed as aggregate
+        scrape series — `xpf_userspace_martian_dropped_total` and
+        `xpf_userspace_ipv6_ext_header_dropped_total` — summed across bindings
+        and emitted unconditionally (0 is a real "no such drops" signal), so an
+        operator can alert on them without polling the status text.
     - **Fabric-forwarding drops** (`GlobalCtrFabricFwdDrop`, index 32) — a
       peer-owned synced session whose fabric redirect could not be completed.
     - **VLAN-push failures** (`GlobalCtrVlanPushFail`, index 40).

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -405,8 +405,11 @@ type xpfCollector struct {
 	userspaceRejectReplyBudgetDrops    *prometheus.Desc
 	userspaceRejectOutputFilterDrops   *prometheus.Desc
 	userspaceRejectRateLimitedBySource *prometheus.Desc
-	userspaceFlowCacheActiveFlows      *prometheus.Desc
-	userspaceFlowCacheCapacity         *prometheus.Desc
+	// #4768: per-binding drop-class counters (#4743) summed across bindings.
+	userspaceMartianDropped       *prometheus.Desc
+	userspaceIPv6ExtHeaderDropped *prometheus.Desc
+	userspaceFlowCacheActiveFlows *prometheus.Desc
+	userspaceFlowCacheCapacity    *prometheus.Desc
 	// #1379: daemon-side userspace event-stream transport counters.
 	userspaceEventStreamFramesTotal          *prometheus.Desc
 	userspaceEventStreamProducerFramesTotal  *prometheus.Desc
@@ -764,6 +767,8 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.userspaceRejectReplyBudgetDrops
 	ch <- c.userspaceRejectOutputFilterDrops
 	ch <- c.userspaceRejectRateLimitedBySource
+	ch <- c.userspaceMartianDropped
+	ch <- c.userspaceIPv6ExtHeaderDropped
 	ch <- c.userspaceFlowCacheActiveFlows
 	ch <- c.userspaceFlowCacheCapacity
 	ch <- c.userspaceEventStreamFramesTotal

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -1342,6 +1342,31 @@ func newCollector(srv *Server) *xpfCollector {
 				"it (#3661).",
 			[]string{"source"}, nil,
 		),
+		userspaceMartianDropped: prometheus.NewDesc(
+			"xpf_userspace_martian_dropped_total",
+			"Packets dropped with a NoRoute disposition whose destination is a "+
+				"martian address (IPv4 multicast/broadcast/unspecified/loopback, "+
+				"IPv6 multicast/unspecified/loopback) — a firewall never forwards "+
+				"these and they have no legitimate route, so they miss the FIB and "+
+				"drop as NoRoute. A strict sub-breakout of the route-miss total "+
+				"(every martian drop also bumps route_miss_packets), summed across "+
+				"bindings, so an operator can tell a martian-dst drop apart from an "+
+				"ordinary route miss and correlate it with a firewall-filter accept "+
+				"log (#4743/#4768). Emitted unconditionally so 0 is a real "+
+				"\"no martian drops\" signal.",
+			nil, nil,
+		),
+		userspaceIPv6ExtHeaderDropped: prometheus.NewDesc(
+			"xpf_userspace_ipv6_ext_header_dropped_total",
+			"Packets fail-closed-dropped because their IPv6 extension-header "+
+				"chain is unparseable or exceeds the MAX_IPV6_EXT_HEADERS walk "+
+				"bound (an over-limit chain the helper cannot inspect), summed "+
+				"across bindings. Distinct from a truncated chain; makes the "+
+				"otherwise-silent fail-closed drop observable (#4743/#4768, "+
+				"relates to #4555). Emitted unconditionally so 0 is a real "+
+				"\"no ext-header drops\" signal.",
+			nil, nil,
+		),
 		userspaceFlowCacheActiveFlows: prometheus.NewDesc(
 			"xpf_userspace_flow_cache_active_flows",
 			"Aggregate active userspace flow-cache entries across bindings.",

--- a/pkg/api/metrics_drop_class_4768_test.go
+++ b/pkg/api/metrics_drop_class_4768_test.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// #4768: emitDropClassCounters must SUM the per-binding #4743 drop-class
+// counters (MartianDropped, IPv6ExtHeaderDropped) across all bindings and
+// emit one aggregate CounterValue series each, unconditionally (0 is a real
+// signal). RED-on-revert: dropping a binding from the sum, mislabeling the
+// series, or gating on nonzero would fail this.
+func TestEmitDropClassCounters_4768(t *testing.T) {
+	c := &xpfCollector{
+		userspaceMartianDropped: prometheus.NewDesc(
+			"xpf_userspace_martian_dropped_total", "test", nil, nil),
+		userspaceIPv6ExtHeaderDropped: prometheus.NewDesc(
+			"xpf_userspace_ipv6_ext_header_dropped_total", "test", nil, nil),
+	}
+
+	status := dpuserspace.ProcessStatus{
+		Bindings: []dpuserspace.BindingStatus{
+			{MartianDropped: 3, IPv6ExtHeaderDropped: 0},
+			{MartianDropped: 4, IPv6ExtHeaderDropped: 10},
+			{MartianDropped: 0, IPv6ExtHeaderDropped: 5},
+		},
+	}
+	// Expected aggregates: martian 3+4+0=7, ext-header 0+10+5=15.
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		c.emitDropClassCounters(ch, status)
+		close(ch)
+	}()
+	byName := map[string]float64{}
+	count := 0
+	for m := range ch {
+		count++
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("write metric: %v", err)
+		}
+		if pb.Counter == nil {
+			t.Fatalf("metric %s is not a Counter", m.Desc().String())
+		}
+		byName[m.Desc().String()] = pb.Counter.GetValue()
+	}
+
+	if count != 2 {
+		t.Fatalf("want exactly 2 aggregate metrics, got %d", count)
+	}
+
+	var martian, extHdr float64
+	for desc, v := range byName {
+		switch {
+		case strings.Contains(desc, "martian_dropped_total"):
+			martian = v
+		case strings.Contains(desc, "ipv6_ext_header_dropped_total"):
+			extHdr = v
+		default:
+			t.Errorf("unexpected metric desc: %s", desc)
+		}
+	}
+	if martian != 7 {
+		t.Errorf("martian_dropped: want summed 7 (3+4+0), got %v", martian)
+	}
+	if extHdr != 15 {
+		t.Errorf("ipv6_ext_header_dropped: want summed 15 (0+10+5), got %v", extHdr)
+	}
+
+	// Empty bindings still emit both series at 0 (unconditional).
+	ch2 := make(chan prometheus.Metric)
+	go func() {
+		c.emitDropClassCounters(ch2, dpuserspace.ProcessStatus{})
+		close(ch2)
+	}()
+	zeros := 0
+	for m := range ch2 {
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("write metric: %v", err)
+		}
+		if pb.Counter.GetValue() != 0 {
+			t.Errorf("empty bindings: want 0, got %v", pb.Counter.GetValue())
+		}
+		zeros++
+	}
+	if zeros != 2 {
+		t.Errorf("empty bindings: want 2 series emitted at 0, got %d", zeros)
+	}
+}

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -52,6 +52,26 @@ func (c *xpfCollector) collectUserspaceStatus(ch chan<- prometheus.Metric, dp ap
 	c.emitZoneIDCollision(ch, status)
 	c.emitRejectObservability(ch, status)
 	c.emitFabricSkipCounters(ch, status)
+	c.emitDropClassCounters(ch, status)
+}
+
+// emitDropClassCounters exposes the #4743 per-binding drop-class counters as
+// aggregate Prometheus series (#4768): martian-destination NoRoute drops and
+// over-limit IPv6 extension-header fail-closed drops, each summed across
+// bindings. #4766 already surfaces these as "Martian drops:" / "IPv6 ext-header
+// drops:" status rows; this adds the scrape surface. Both are emitted
+// unconditionally so a 0 is a real "no such drops" signal, not an absent
+// series (matching the reject-observability convention above). martian_dropped
+// is a sub-breakout of route_miss_packets (every martian drop also bumps the
+// route miss), so the martian series is always <= the route-miss volume.
+func (c *xpfCollector) emitDropClassCounters(ch chan<- prometheus.Metric, status dpuserspace.ProcessStatus) {
+	var martian, ipv6ExtHeader uint64
+	for _, b := range status.Bindings {
+		martian += b.MartianDropped
+		ipv6ExtHeader += b.IPv6ExtHeaderDropped
+	}
+	ch <- prometheus.MustNewConstMetric(c.userspaceMartianDropped, prometheus.CounterValue, float64(martian))
+	ch <- prometheus.MustNewConstMetric(c.userspaceIPv6ExtHeaderDropped, prometheus.CounterValue, float64(ipv6ExtHeader))
 }
 
 // emitFabricSkipCounters exposes the #3773 (M13) fabric-link skip


### PR DESCRIPTION
## Summary
Adds the Prometheus scrape surface for the #4743 drop counters (merged #4766, which surfaces them as status rows only).

## What changed
- Two collector descriptors: `xpf_userspace_martian_dropped_total`, `xpf_userspace_ipv6_ext_header_dropped_total` — registered in `newCollector`, wired into `Describe()` (the #1726 coverage canary auto-derives from Describe⊇Collect, no manual allowlist edit).
- `emitDropClassCounters` sums `BindingStatus.MartianDropped` / `IPv6ExtHeaderDropped` across `status.Bindings`, emits one aggregate CounterValue each, unconditionally (0 is a real "no drops" signal — matches the `emitRejectObservability` convention). Called from `collectUserspaceStatus`.
- `martian_dropped` stays a strict sub-breakout of route_miss (always ≤ route-miss volume), the #4766 invariant.

## Test (RED-on-revert)
`TestEmitDropClassCounters_4768`: 3-binding status (martian 3/4/0, ext-header 0/10/5) → asserts summed aggregates (7, 15) + empty-bindings-still-emit-0. Dropping a binding from the sum, mislabeling, or gating on nonzero fails.

## Validation
`go build ./...` + `go vet` + `go test ./pkg/api` (coverage canary + new test) green; full `go test ./...` in progress.

Closes #4768. Follow-up to #4743/#4766.