### PR TITLE
#4407: extract applyInterfaceReconcile from applyConfigLocked (Increment 1)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43652,3 +43652,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4662 Increment 7 (final core) — extract setupDataplaneAndInitialConfig (PHASE 3 tail: dataplane backend build + NAT seed + first applyConfig + dnsBootDone + reconcile blackholes, 124 lines) from Run(); body byte-identical, returns error for the one fatal dataplane-create early-return; Run wraps with err-check. Ordering-sensitive dataplane-arming path
   **File(s)**: pkg/daemon/daemon_run.go
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4407 Increment 1 — extract applyInterfaceReconcile (tunnels/xfrm/bonds/legacy-RETH interface-creation steps 1-1.8, 41 lines) from applyConfigLocked; pure void byte-identical extraction (no output/early-return/crossing-state). First slice of the daemon_apply.go decomposition
+  **File(s)**: pkg/daemon/daemon_apply.go

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -719,47 +719,7 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// 0.6. Program default routes in the management VRF for DHCP leases.
 	d.applyMgmtVRFRoutes()
 
-	// 1. Create tunnel interfaces (interface-level + per-unit tunnels)
-	if d.routing != nil {
-		if err := d.routing.ApplyTunnels(collectAppliedTunnels(cfg)); err != nil {
-			slog.Warn("failed to apply tunnels", "err", err)
-		}
-	}
-
-	// 1.5. Create xfrmi interfaces for IPsec VPN tunnels.
-	// Must happen before BPF compilation so compileZones() can discover
-	// the xfrmi interfaces and map them to security zones.
-	// Always call ApplyXfrmi so stale xfrmi devices are removed when VPNs
-	// are deleted from config.
-	if d.routing != nil {
-		if err := d.routing.ApplyXfrmi(cfg.Security.IPsec.VPNs); err != nil {
-			slog.Warn("failed to apply xfrmi interfaces", "err", err)
-		}
-	}
-
-	// 1.7. Create bond (LAG) interfaces for fabric-options member-interfaces.
-	// Always call ApplyBonds (even with empty list) so stale bonds from
-	// previous configs get cleaned up via ClearBonds().
-	if d.routing != nil {
-		var bondIfaces []*config.InterfaceConfig
-		for _, ifc := range cfg.Interfaces.Interfaces {
-			if ifc == nil {
-				continue
-			}
-			if len(ifc.FabricMembers) > 0 {
-				bondIfaces = append(bondIfaces, ifc)
-			}
-		}
-		if err := d.routing.ApplyBonds(bondIfaces); err != nil {
-			slog.Warn("failed to apply bonds", "err", err)
-		}
-	}
-
-	// 1.8. Clean up legacy RETH bond devices from previous binary versions.
-	// VRRP now runs directly on physical member interfaces — no bonds needed.
-	if d.routing != nil {
-		d.routing.ClearRethInterfaces()
-	}
+	d.applyInterfaceReconcile(cfg)
 
 	// 1.9. Create IPVLAN interfaces for fabric members (fab0, fab1).
 	// The physical member (ge-0-0-0) keeps its name; fab0 is IPVLAN L2
@@ -1443,6 +1403,58 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// helper creates lo0Err/hostInboundErr and returns the identical
 	// five-way errors.Join.
 	return d.applyTailReconciles(cfg, networkdErr, dhcpServerErr, ipsecErr)
+}
+
+// applyInterfaceReconcile creates/reconciles the interface-level network
+// devices during a config apply: tunnel interfaces (interface + per-unit),
+// xfrmi interfaces for IPsec VPNs (before BPF compilation so compileZones can
+// map them to zones), fabric bond/LAG member interfaces, and cleanup of legacy
+// RETH bond devices. Extracted verbatim from applyConfigLocked (#4407); all
+// steps are idempotent reconciles (unchanged config = no-op) that log-and-
+// continue on error, so there is no crossing output and no early return. Runs
+// in the same slot, after the VRF reconcile and before fabric IPVLAN creation.
+func (d *Daemon) applyInterfaceReconcile(cfg *config.Config) {
+	// 1. Create tunnel interfaces (interface-level + per-unit tunnels)
+	if d.routing != nil {
+		if err := d.routing.ApplyTunnels(collectAppliedTunnels(cfg)); err != nil {
+			slog.Warn("failed to apply tunnels", "err", err)
+		}
+	}
+
+	// 1.5. Create xfrmi interfaces for IPsec VPN tunnels.
+	// Must happen before BPF compilation so compileZones() can discover
+	// the xfrmi interfaces and map them to security zones.
+	// Always call ApplyXfrmi so stale xfrmi devices are removed when VPNs
+	// are deleted from config.
+	if d.routing != nil {
+		if err := d.routing.ApplyXfrmi(cfg.Security.IPsec.VPNs); err != nil {
+			slog.Warn("failed to apply xfrmi interfaces", "err", err)
+		}
+	}
+
+	// 1.7. Create bond (LAG) interfaces for fabric-options member-interfaces.
+	// Always call ApplyBonds (even with empty list) so stale bonds from
+	// previous configs get cleaned up via ClearBonds().
+	if d.routing != nil {
+		var bondIfaces []*config.InterfaceConfig
+		for _, ifc := range cfg.Interfaces.Interfaces {
+			if ifc == nil {
+				continue
+			}
+			if len(ifc.FabricMembers) > 0 {
+				bondIfaces = append(bondIfaces, ifc)
+			}
+		}
+		if err := d.routing.ApplyBonds(bondIfaces); err != nil {
+			slog.Warn("failed to apply bonds", "err", err)
+		}
+	}
+
+	// 1.8. Clean up legacy RETH bond devices from previous binary versions.
+	// VRRP now runs directly on physical member interfaces — no bonds needed.
+	if d.routing != nil {
+		d.routing.ClearRethInterfaces()
+	}
 }
 
 // applyTailReconciles runs steps 8–21 of applyConfigLocked — the tail of the


### PR DESCRIPTION
## Summary
Begin decomposing `applyConfigLocked` (901 LOC config-apply reconcile pipeline) via the same byte-identical phase-extraction that decomposed `Daemon.Run` (#4662). Extract the interface-creation steps.

## What changed
- **Extract `applyInterfaceReconcile(cfg)`** — steps 1 (tunnel interfaces), 1.5 (xfrmi for IPsec VPNs), 1.7 (fabric bond/LAG members), 1.8 (legacy RETH bond cleanup), ~41 lines. `applyConfigLocked` calls it in the same slot (after VRF reconcile, before fabric IPVLAN).

## Why it's safe (pure void byte-identical code-motion)
- 41-line body **byte-identical** to origin/master (verified line-for-line).
- All idempotent reconciles that log-and-continue → **no crossing output, no early return**, no crossing input beyond `cfg` (block-local `bondIfaces` contained; rest is `d.*`).
- **No ordering change**: runs in the exact same position, preserving the load-bearing "xfrmi before BPF compilation" ordering and the "always call ApplyXfrmi/ApplyBonds so stale devices get cleaned up" invariants.

## Scope
Increment 1 of the `applyConfigLocked` half of #4407; the fabric IPVLAN / dataplane-apply phases (overlay state + userspace-DP IPVLAN deferral) and the daemon.go god-struct half remain.

## Validation
Byte-identical body + `go build ./...` + `go vet ./pkg/daemon` + `go test ./pkg/daemon` green; full `go test ./...` in progress.

Refs #4407.