### PR TITLE
#4407: extract applyServicesReconcile from applyConfigLocked (Increment 5)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43668,3 +43668,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4407 Increment 4 — extract applyRoutingRules (FRR + next-table PBR + rib-group + firewall-filter PBR, 67 lines) from applyConfigLocked; pure void byte-identical (no early return; cfg + commitOverlay inputs). Decoupled from the dataplane-apply state
   **File(s)**: pkg/daemon/daemon_apply.go
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4407 Increment 5 — extract applyServicesReconcile (neighbor resolution + RA + IPsec + Kea DHCP server + DHCP clients, 139 lines) from applyConfigLocked; body byte-identical, unnamed (error,error) return threads ipsecErr/dhcpServerErr deferred errors to applyTailReconciles. Decoupled from dataplane-apply state (isCluster contained)
+  **File(s)**: pkg/daemon/daemon_apply.go

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -994,6 +994,30 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 
 	d.applyRoutingRules(cfg, commitOverlay)
 
+	ipsecErr, dhcpServerErr := d.applyServicesReconcile(cfg)
+
+	// Steps 8–21: tail reconcile dispatches (VRRP, system config, syslog,
+	// login/SSH, archival, observability, cluster runtime, host tunables).
+	// Extracted into applyTailReconciles (#4407 Phase A). The head above
+	// (steps 0–7) is ordering-entangled and stays inline; the tail is
+	// independent per-subsystem dispatch reading only cfg (+ nil-guarded
+	// managers), so grouping it here is a behavior-preserving mechanical
+	// move. The three head-produced deferred errors are threaded in; the
+	// helper creates lo0Err/hostInboundErr and returns the identical
+	// five-way errors.Join.
+	return d.applyTailReconciles(cfg, networkdErr, dhcpServerErr, ipsecErr)
+}
+
+// applyServicesReconcile runs the per-service reconcile phases of a config
+// apply that are decoupled from the dataplane-apply / RETH-MAC state: proactive
+// neighbor resolution, RA sender config, IPsec config, the Kea DHCP server, and
+// DHCP clients. Extracted verbatim from applyConfigLocked (#4407); no early
+// return and no crossing input beyond cfg. It produces the IPsec and
+// DHCP-server deferred errors (recorded, not returned early, so a later
+// per-subsystem failure does not abort the apply) and returns them (ipsecErr,
+// dhcpServerErr) for the tail reconcile's five-way errors.Join. Runs in the
+// same slot, after the routing rules and before the tail reconciles.
+func (d *Daemon) applyServicesReconcile(cfg *config.Config) (error, error) {
 	// 4. Proactive neighbor resolution for all known next-hops/gateways.
 	// This ensures bpf_fib_lookup returns SUCCESS (with valid MACs)
 	// instead of NO_NEIGH for the first forwarded packet.
@@ -1133,17 +1157,7 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// the dataplane compile (step 2) so HOST_INBOUND_DHCP flags are
 	// active before a newly started client puts DHCP packets on the wire.
 	d.reconcileDHCPClients(cfg)
-
-	// Steps 8–21: tail reconcile dispatches (VRRP, system config, syslog,
-	// login/SSH, archival, observability, cluster runtime, host tunables).
-	// Extracted into applyTailReconciles (#4407 Phase A). The head above
-	// (steps 0–7) is ordering-entangled and stays inline; the tail is
-	// independent per-subsystem dispatch reading only cfg (+ nil-guarded
-	// managers), so grouping it here is a behavior-preserving mechanical
-	// move. The three head-produced deferred errors are threaded in; the
-	// helper creates lo0Err/hostInboundErr and returns the identical
-	// five-way errors.Join.
-	return d.applyTailReconciles(cfg, networkdErr, dhcpServerErr, ipsecErr)
+	return ipsecErr, dhcpServerErr
 }
 
 // applyRoutingRules applies the routing-rules layer during a config apply:

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -999,12 +999,16 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// Steps 8–21: tail reconcile dispatches (VRRP, system config, syslog,
 	// login/SSH, archival, observability, cluster runtime, host tunables).
 	// Extracted into applyTailReconciles (#4407 Phase A). The head above
-	// (steps 0–7) is ordering-entangled and stays inline; the tail is
-	// independent per-subsystem dispatch reading only cfg (+ nil-guarded
-	// managers), so grouping it here is a behavior-preserving mechanical
-	// move. The three head-produced deferred errors are threaded in; the
-	// helper creates lo0Err/hostInboundErr and returns the identical
-	// five-way errors.Join.
+	// is decomposed into named phase methods (#4407): the decoupled
+	// setup/reconcile phases (loadable independently) — applyVRFReconcile,
+	// applyInterfaceReconcile, applyFabricIPVLAN, applyRoutingRules,
+	// applyServicesReconcile — and the ordering-entangled dataplane-apply /
+	// RETH-MAC core that stays inline (it threads applyResult / rethMACPending
+	// / the deferred errors). The tail is independent per-subsystem dispatch
+	// reading only cfg (+ nil-guarded managers), so grouping it here is a
+	// behavior-preserving mechanical move. The three head-produced deferred
+	// errors are threaded in; the helper creates lo0Err/hostInboundErr and
+	// returns the identical five-way errors.Join.
 	return d.applyTailReconciles(cfg, networkdErr, dhcpServerErr, ipsecErr)
 }
 


### PR DESCRIPTION
## Summary
Increment 5 of the `applyConfigLocked` decomposition (#4407, Inc 1-4 = #4774/#4775/#4776/#4777). Extracts the decoupled per-service reconcile phases.

## What changed
- **Extract `applyServicesReconcile(cfg) (error, error)`** — proactive neighbor resolution, RA sender config, IPsec config, Kea DHCP server, DHCP clients (~139 lines). `applyConfigLocked` calls `ipsecErr, dhcpServerErr := d.applyServicesReconcile(cfg)` and threads them into the existing `applyTailReconciles(cfg, networkdErr, dhcpServerErr, ipsecErr)`.

## Why it's safe (control-flow-preserving, body byte-identical)
- 139-line body **byte-identical** to origin/master (the `var ipsecErr error`/`var dhcpServerErr error` decls stay → **unnamed** `(error, error)` return to avoid named-return redeclaration).
- **No early return** — IPsec/DHCP-server failures are recorded into the two deferred errors (never abort the apply) and returned at the end for the tail's five-way `errors.Join`, identical to before.
- **Decoupled**: references none of `applyResult`/`rethMACPending`/`policySchedulerActiveState`; the function-scoped `isCluster` is now declared+consumed entirely inside (0 uses after).
- No ordering change.

## Validation
Byte-identical body + `go build ./...` + `go vet ./pkg/daemon` + `go test ./pkg/daemon` green; full `go test ./...` in progress.

Refs #4407.