### PR TITLE
daemon: extract dataplane-apply + RETH-MAC/HA core from applyConfigLocked (#4407)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43688,3 +43688,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4404/#4421 batch-3 (final) test-split: relocate inline mod tests from 5 remaining userspace-dp files (xsk_ffi, shared_umem, wg/tai64n, fairness, coordinator/status) into sibling _tests.rs via #[path]. Verbatim move + rustfmt-2024 siblings; parents byte-identical; test-counts preserved. Exhausts the >150-test-line clean-split cohort
   **File(s)**: 5 parents + 5 new *_tests.rs
+
+- **Timestamp**: 2026-07-09
+  - **Action**: #4407 — extract applyConfigLocked dataplane-apply + RETH-MAC/VIP/worker-rebind core into applyDataplaneAndHACore (named-return threading of commitOverlay + networkdErr; 3 #2926 boundaries preserved)
+  - **File(s)**: pkg/daemon/daemon_apply.go

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -631,7 +631,8 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// 1.9–2.7. Dataplane apply + RETH-MAC/VIP/worker-rebind critical section
 	// (#4407). Returns the ip-monitoring commit overlay and the captured
 	// networkd write error for the routing rules + tail reconcile below; an
-	// error is a #2926 context-abort boundary — bail before the tail.
+	// error (a #2926 context abort or an ApplyConfig compile abort) bails
+	// before the tail.
 	commitOverlay, networkdErr, err := d.applyDataplaneAndHACore(ctx, cfg)
 	if err != nil {
 		return err
@@ -665,10 +666,11 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 // — and the two values the tail still needs are returned: the ip-monitoring
 // commit overlay (fed to applyRoutingRules and the FRR render) and the captured
 // networkd write error (threaded into applyTailReconciles' five-way Join). The
-// three #2926 context-abort boundaries (before ApplyConfig, on an ApplyConfig
-// abort, and before the FRR reload) are preserved as an early error return; the
-// caller bails without running the routing / service / tail reconciles, exactly
-// as the inline `return err` did. commitOverlay and networkdErr are named
+// three early error returns — the two #2926 context-abort boundaries
+// (ctx.Err() before ApplyConfig and before the FRR reload) and the
+// compileErrorMustAbortApply dataplane abort on an ApplyConfig failure — are
+// preserved; the caller bails without running the routing / service / tail
+// reconciles, exactly as the inline `return err` did. commitOverlay and networkdErr are named
 // returns so the pre-networkd boundaries can return them (nil) before the
 // networkd phase assigns networkdErr. Runs in the same slot, after the
 // fabric-IPVLAN reconcile and before the routing rules.

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -628,6 +628,51 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 
 	d.applyFabricIPVLAN(cfg)
 
+	// 1.9–2.7. Dataplane apply + RETH-MAC/VIP/worker-rebind critical section
+	// (#4407). Returns the ip-monitoring commit overlay and the captured
+	// networkd write error for the routing rules + tail reconcile below; an
+	// error is a #2926 context-abort boundary — bail before the tail.
+	commitOverlay, networkdErr, err := d.applyDataplaneAndHACore(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
+	d.applyRoutingRules(cfg, commitOverlay)
+
+	ipsecErr, dhcpServerErr := d.applyServicesReconcile(cfg)
+
+	// Steps 8–21: tail reconcile dispatches (VRRP, system config, syslog,
+	// login/SSH, archival, observability, cluster runtime, host tunables).
+	// Extracted into applyTailReconciles (#4407 Phase A). The head above
+	// is decomposed into named phase methods (#4407): the decoupled
+	// setup/reconcile phases (loadable independently) — applyVRFReconcile,
+	// applyInterfaceReconcile, applyFabricIPVLAN, applyRoutingRules,
+	// applyServicesReconcile — and the ordering-entangled dataplane-apply /
+	// RETH-MAC core that stays inline (it threads applyResult / rethMACPending
+	// / the deferred errors). The tail is independent per-subsystem dispatch
+	// reading only cfg (+ nil-guarded managers), so grouping it here is a
+	// behavior-preserving mechanical move. The three head-produced deferred
+	// errors are threaded in; the helper creates lo0Err/hostInboundErr and
+	// returns the identical five-way errors.Join.
+	return d.applyTailReconciles(cfg, networkdErr, dhcpServerErr, ipsecErr)
+}
+
+// applyDataplaneAndHACore runs the ordering-entangled dataplane-apply and
+// RETH-MAC / VRRP-VIP / AF_XDP-worker-rebind critical section of a config
+// apply (#4407). Extracted verbatim from applyConfigLocked; the head-produced
+// state that the earlier decoupled phases do not touch stays local here —
+// rethMACPending and the deferred-worker-startup flag/defer are self-contained
+// — and the two values the tail still needs are returned: the ip-monitoring
+// commit overlay (fed to applyRoutingRules and the FRR render) and the captured
+// networkd write error (threaded into applyTailReconciles' five-way Join). The
+// three #2926 context-abort boundaries (before ApplyConfig, on an ApplyConfig
+// abort, and before the FRR reload) are preserved as an early error return; the
+// caller bails without running the routing / service / tail reconciles, exactly
+// as the inline `return err` did. commitOverlay and networkdErr are named
+// returns so the pre-networkd boundaries can return them (nil) before the
+// networkd phase assigns networkdErr. Runs in the same slot, after the
+// fabric-IPVLAN reconcile and before the routing rules.
+func (d *Daemon) applyDataplaneAndHACore(ctx context.Context, cfg *config.Config) (commitOverlay []config.RouteOverlayEntry, networkdErr error, err error) {
 	// 1.9. Pre-check: will RETH MAC programming require a link cycle?
 	// If yes, tell the userspace DP to skip initial worker startup during
 	// ApplyConfig(). Workers will be started by NotifyLinkCycle() after MAC
@@ -680,7 +725,7 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// against the INCOMING config (Codex PR #1843 HIGH-1) so a commit
 	// that removes or edits a policy never republishes the stale
 	// entries; the same filtered view feeds the FRR render in step 3.
-	commitOverlay := d.commitOverlayForConfig(cfg)
+	commitOverlay = d.commitOverlayForConfig(cfg)
 	if setter, ok := d.dp.(routeOverlaySetter); ok {
 		setter.SetRouteOverlay(commitOverlay)
 	}
@@ -705,7 +750,7 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// follows it begin, they run as one unit (no mid-sequence abort) — the
 	// next boundary is before the FRR reload.
 	if err := ctx.Err(); err != nil {
-		return err
+		return commitOverlay, networkdErr, err
 	}
 
 	// 2. Apply dataplane config through the runtime config sink.
@@ -715,7 +760,7 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 		if applyResult, err = d.dp.ApplyConfig(context.Background(), cfg); err != nil {
 			d.recordCompileFailure(err)
 			if compileErrorMustAbortApply(err) {
-				return err
+				return commitOverlay, networkdErr, err
 			}
 		} else {
 			d.recordCompileSuccess()
@@ -783,7 +828,6 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// mirroring dhcpServerErr: every downstream reconcile step still runs so a
 	// networkd write error does not skip RETH MAC programming, VRRP VIP
 	// reconcile, FRR, RA, IPsec, etc. and leave HA state half-applied.
-	var networkdErr error
 	if d.networkd != nil && applyResult != nil {
 		if err := d.networkd.Apply(applyResult.ManagedInterfaces); err != nil {
 			slog.Warn("failed to apply networkd config", "err", err)
@@ -989,27 +1033,10 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// store.Commit the store already holds the new config, so this is a clean
 	// "apply the rest on next start" boundary, not a divergence.)
 	if err := ctx.Err(); err != nil {
-		return err
+		return commitOverlay, networkdErr, err
 	}
 
-	d.applyRoutingRules(cfg, commitOverlay)
-
-	ipsecErr, dhcpServerErr := d.applyServicesReconcile(cfg)
-
-	// Steps 8–21: tail reconcile dispatches (VRRP, system config, syslog,
-	// login/SSH, archival, observability, cluster runtime, host tunables).
-	// Extracted into applyTailReconciles (#4407 Phase A). The head above
-	// is decomposed into named phase methods (#4407): the decoupled
-	// setup/reconcile phases (loadable independently) — applyVRFReconcile,
-	// applyInterfaceReconcile, applyFabricIPVLAN, applyRoutingRules,
-	// applyServicesReconcile — and the ordering-entangled dataplane-apply /
-	// RETH-MAC core that stays inline (it threads applyResult / rethMACPending
-	// / the deferred errors). The tail is independent per-subsystem dispatch
-	// reading only cfg (+ nil-guarded managers), so grouping it here is a
-	// behavior-preserving mechanical move. The three head-produced deferred
-	// errors are threaded in; the helper creates lo0Err/hostInboundErr and
-	// returns the identical five-way errors.Join.
-	return d.applyTailReconciles(cfg, networkdErr, dhcpServerErr, ipsecErr)
+	return commitOverlay, networkdErr, nil
 }
 
 // applyServicesReconcile runs the per-service reconcile phases of a config


### PR DESCRIPTION
Completes the **`applyConfigLocked` half** of #4407 by lifting the
ordering-entangled **dataplane-apply + RETH-MAC / VRRP-VIP / AF_XDP-worker-rebind
critical section** (former inline steps 1.9–2.7, ~360 LOC) into a new
`applyDataplaneAndHACore` method. `applyConfigLocked` now reads as a linear
sequence of named phases (applyInterfaceReconcile → applyFabricIPVLAN →
applyVRFReconcile → **applyDataplaneAndHACore** → applyRoutingRules →
applyServicesReconcile → applyTailReconciles).

The **daemon.go Daemon god-struct** half of #4407 (150+ fields → per-subsystem
sub-structs) remains — hence *Advances*, not *Closes*.

## What changed
Control-flow-preserving move, not a rewrite. The core body is **byte-identical**
to the former inline block except six named-return edits:
- `commitOverlay` + `networkdErr` become **named returns** so the two #2926
  context-abort boundaries that fire *before* the networkd phase can return them
  (nil at that point). `var networkdErr error` (old line 786) dropped; `commitOverlay :=`→`=`.
- the three inline `return err` sites (pre-ApplyConfig boundary, `compileErrorMustAbortApply`
  abort, pre-FRR-reload boundary) → `return commitOverlay, networkdErr, err`; the caller
  bails before routing/service/tail reconciles, exactly as the inline returns skipped them.

State that never crossed the block boundary stays local: `rethMACPending`, the
deferred-worker-startup flag + its safety-net `defer` (self-contained), `applyResult`,
`policySchedulerApplyTime`/`policySchedulerActiveState`.

## Validation
- `gofmt` clean; `go build` + `go vet` + full `go test ./...` green.
- Moved body diffs against origin/master with **only the six intended named-return hunks**.
- Loss-cluster `test-failover` (this path programs RETH virtual MACs + reconciles VRRP VIPs on failover).

Advances #4407

🤖 Generated with [Claude Code](https://claude.com/claude-code)