### PR TITLE
config: warn on managed-FRR routing protocol without host-inbound token (#4455 Component B)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43696,3 +43696,7 @@ top.
 - **Timestamp**: 2026-07-09
   - **Action**: #4652 — decompose segment_forwarded_tcp_frames_from_frame: extract emit_ipv4_segment / emit_ipv6_segment / encap_tunnel_segment inline helpers (byte-identical arm bodies + &mut-param reborrow)
   - **File(s)**: userspace-dp/src/afxdp/frame/tcp_segmentation.rs
+
+- **Timestamp**: 2026-07-09
+  - **Action**: #4455 Component B — commit-time WARN advisory for managed-FRR routing protocol (OSPF/OSPFv3/RIP) enabled on an interface whose zone omits the matching host-inbound-traffic token (the inverse of the shipped #4454 advisory)
+  - **File(s)**: pkg/config/compiler_validate_warn.go, pkg/config/host_inbound_managed_routing_mismatch_4455_test.go, docs/host-inbound-multicast.md

--- a/docs/host-inbound-multicast.md
+++ b/docs/host-inbound-multicast.md
@@ -61,6 +61,20 @@ reject**: the config is valid Junos, and rejecting or narrowing it would break a
 zone that relies on today's accept (see the migration decision below). This
 mirrors the #3226 `system-services all` packet-wide-admit advisory pattern.
 
+A **companion advisory** (`validateHostInboundManagedRoutingMismatch`, #4455
+Component B) closes the *inverse* blind spot: the advisory above fires only when
+a multicast token is **present** (the already-compliant case), so a zone running
+a managed FRR routing protocol with **no** matching token — the actual silent
+fail-open — was invisible. Component B cross-checks the interfaces xpf renders
+into FRR for OSPFv2/OSPFv3/RIP (`pkg/frr/policy_render.go`, global stanza and
+each routing-instance) against each interface's zone's effective
+`host-inbound-traffic protocols` set (zone-level ∪ per-interface override,
+`all`-expanded) and WARNs when the matching token (`ospf`/`ospf3`/`rip`) is
+absent, so the operator can make the admission explicit. Same WARN-only,
+zero-dataplane-surface doctrine (the Component A per-zone `iifname` DROP
+enforcement stays deferred/PLAN-KILLed). BGP/LDP (unicast) and PIM (unmanaged)
+are out of scope.
+
 ## Protocol → multicast-group catalog
 
 The single source of truth is `hostInboundMulticastCatalog` in

--- a/docs/host-inbound-multicast.md
+++ b/docs/host-inbound-multicast.md
@@ -68,9 +68,15 @@ a managed FRR routing protocol with **no** matching token — the actual silent
 fail-open — was invisible. Component B cross-checks the interfaces xpf renders
 into FRR for OSPFv2/OSPFv3/RIP (`pkg/frr/policy_render.go`, global stanza and
 each routing-instance) against each interface's zone's effective
-`host-inbound-traffic protocols` set (zone-level ∪ per-interface override,
-`all`-expanded) and WARNs when the matching token (`ospf`/`ospf3`/`rip`) is
-absent, so the operator can make the admission explicit. Same WARN-only,
+`host-inbound-traffic protocols` set and WARNs when the matching token
+(`ospf`/`ospf3`/`rip`) is absent, so the operator can make the admission
+explicit. Zone attribution reuses the dataplane's `buildInterfaceZoneMap`
+semantics (`zoneIfaceLogicalKeys`: a bare zone member `reth0` claims every
+configured unit `reth0.10`), and the effective admission set reuses
+`ZoneConfig.InterfaceHostInboundEffective` (zone-level ∪ per-interface override
+with #3720 physical-parent inheritance for logical units, `all`-expanded) — so
+the advisory matches runtime enforcement exactly (no missed or false warnings
+on unit interfaces). Same WARN-only,
 zero-dataplane-surface doctrine (the Component A per-zone `iifname` DROP
 enforcement stays deferred/PLAN-KILLed). BGP/LDP (unicast) and PIM (unmanaged)
 are out of scope.

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -1622,6 +1622,7 @@ func ValidateConfig(cfg *Config) []string {
 	// interface). Surface that Junos-parity/hardening gap at commit; the per-zone
 	// iifname enforcement remains deferred.
 	warnings = append(warnings, validateHostInboundMulticastWarnings(cfg)...)
+	warnings = append(warnings, validateHostInboundManagedRoutingMismatch(cfg)...)
 
 	return warnings
 }
@@ -1694,6 +1695,159 @@ func validateHostInboundMulticastWarnings(cfg *Config) []string {
 				hi.Protocols)
 		}
 	}
+	return warnings
+}
+
+// hostInboundAdmitsRoutingProtocol reports whether a host-inbound-traffic
+// `protocols` token set admits the given routing-protocol token, honoring the
+// `all` expansion (#3199 — `all` expands to every routing protocol, so it
+// admits ospf/ospf3/rip). Used by the #4455 Component B advisory below.
+func hostInboundAdmitsRoutingProtocol(protocols []string, token string) bool {
+	for _, p := range protocols {
+		if p == token {
+			return true
+		}
+		if p == "all" {
+			for _, e := range HostInboundAllExpansionProtocols() {
+				if e == token {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// validateHostInboundManagedRoutingMismatch emits the #4455 (HI-1) Component B
+// commit-time WARN advisory: a managed FRR routing protocol — OSPFv2, OSPFv3, or
+// RIP, which xpf renders into FRR (pkg/frr/policy_render.go) — is enabled on an
+// interface whose security zone's EFFECTIVE `host-inbound-traffic protocols` set
+// (zone-level ∪ per-interface override, #3362 additive; `all`-expanded) OMITS
+// the matching token (ospf/ospf3/rip).
+//
+// This surfaces the ACTUAL silent multicast fail-open that the shipped
+// validateHostInboundMulticastWarnings misses: that advisory fires only when a
+// multicast token is PRESENT (the already-compliant case), so a zone running
+// OSPF/RIP with NO matching token — the real #4455 parity gap — is invisible
+// today. Component B closes that observability gap.
+//
+// WARN-only, ZERO dataplane surface: no nft change, no Rust change, no `iifname`
+// predicate (the Component A DROP enforcement is PLAN-KILLed/deferred — the
+// host-bound routing multicast is admitted PACKET-WIDE via the kernel
+// input-chain `policy accept` fall-through regardless of the zone token). It
+// never rejects or changes forwarding; the config is valid Junos. Mirrors the
+// #3226/#4454 advisory doctrine and honors #1960 lenient-load.
+//
+// Scope: OSPFv2 (→ ospf), OSPFv3 (→ ospf3), RIP (→ rip), for both the global
+// `protocols` stanza and each routing-instance's protocols. BGP/LDP/MSDP are
+// unicast (no multicast group) and out of scope; PIM is unmanaged today
+// (docs/feature-gaps.md) so it has no managed source to cross-check.
+func validateHostInboundManagedRoutingMismatch(cfg *Config) []string {
+	if cfg == nil || cfg.Security.Zones == nil {
+		return nil
+	}
+	// Build interface-ref -> zone-name from zone membership. An interface not in
+	// any security zone has no host-inbound admission dimension, so it is not
+	// warned on (the lookup below simply misses).
+	ifZone := make(map[string]string)
+	for zname, z := range cfg.Security.Zones {
+		if z == nil { // #3494: tolerant/HA-sync path may carry a nil zone value
+			continue
+		}
+		for _, ifn := range z.Interfaces {
+			ifZone[ifn] = zname
+		}
+	}
+	if len(ifZone) == 0 {
+		return nil
+	}
+
+	type managedRP struct {
+		proto  string // human label for the message
+		token  string // host-inbound token to require
+		ifaces []string
+	}
+	collect := func(ospf *OSPFConfig, ospfv3 *OSPFv3Config, rip *RIPConfig) []managedRP {
+		var out []managedRP
+		if ospf != nil {
+			var ifs []string
+			for _, a := range ospf.Areas {
+				if a == nil {
+					continue
+				}
+				for _, i := range a.Interfaces {
+					if i != nil && i.Name != "" {
+						ifs = append(ifs, i.Name)
+					}
+				}
+			}
+			if len(ifs) > 0 {
+				out = append(out, managedRP{"ospf", "ospf", ifs})
+			}
+		}
+		if ospfv3 != nil {
+			var ifs []string
+			for _, a := range ospfv3.Areas {
+				if a == nil {
+					continue
+				}
+				for _, i := range a.Interfaces {
+					if i != nil && i.Name != "" {
+						ifs = append(ifs, i.Name)
+					}
+				}
+			}
+			if len(ifs) > 0 {
+				out = append(out, managedRP{"ospf3", "ospf3", ifs})
+			}
+		}
+		if rip != nil && len(rip.Interfaces) > 0 {
+			out = append(out, managedRP{"rip", "rip", append([]string(nil), rip.Interfaces...)})
+		}
+		return out
+	}
+
+	var all []managedRP
+	all = append(all, collect(cfg.Protocols.OSPF, cfg.Protocols.OSPFv3, cfg.Protocols.RIP)...)
+	for _, ri := range cfg.RoutingInstances {
+		if ri != nil {
+			all = append(all, collect(ri.OSPF, ri.OSPFv3, ri.RIP)...)
+		}
+	}
+
+	var warnings []string
+	for _, rp := range all {
+		for _, ifn := range rp.ifaces {
+			zname, ok := ifZone[ifn]
+			if !ok {
+				continue
+			}
+			z := cfg.Security.Zones[zname]
+			if z == nil {
+				continue
+			}
+			// Effective admission set = zone-level ∪ per-interface override.
+			var eff []string
+			if z.HostInboundTraffic != nil {
+				eff = append(eff, z.HostInboundTraffic.Protocols...)
+			}
+			if hi := z.InterfaceHostInbound[ifn]; hi != nil {
+				eff = append(eff, hi.Protocols...)
+			}
+			if hostInboundAdmitsRoutingProtocol(eff, rp.token) {
+				continue
+			}
+			warnings = append(warnings, fmt.Sprintf(
+				"protocols %s is enabled on interface %q (security zone %q) but that "+
+					"zone's host-inbound-traffic protocols set omits %q — the protocol's "+
+					"host-bound multicast is currently admitted PACKET-WIDE via the kernel "+
+					"input-chain accept fall-through (a known Junos-parity gap, #4455), not "+
+					"scoped to the zone. Add `host-inbound-traffic protocols %s` to zone %q "+
+					"(or the interface override) to make the admission explicit.",
+				rp.proto, ifn, zname, rp.token, rp.token, zname))
+		}
+	}
+	sort.Strings(warnings)
 	return warnings
 }
 

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -1746,16 +1746,32 @@ func validateHostInboundManagedRoutingMismatch(cfg *Config) []string {
 	if cfg == nil || cfg.Security.Zones == nil {
 		return nil
 	}
-	// Build interface-ref -> zone-name from zone membership. An interface not in
-	// any security zone has no host-inbound admission dimension, so it is not
+	// Build interface-ref -> zone-name mirroring the dataplane's
+	// buildInterfaceZoneMap (#3072): a bare zone member (`reth0`) claims the
+	// physical key AND every configured unit (`reth0.10`), a unit-qualified entry
+	// claims exactly that unit — via the zoneIfaceLogicalKeys SSOT — with
+	// first-writer-wins over sorted zone names. This matches runtime zone
+	// attribution, so an OSPF interface `reth0.10` under a zone listing bare
+	// `reth0` resolves correctly (an exact-string map would miss it). An
+	// interface not in any zone has no host-inbound dimension, so it is not
 	// warned on (the lookup below simply misses).
 	ifZone := make(map[string]string)
-	for zname, z := range cfg.Security.Zones {
+	znames := make([]string, 0, len(cfg.Security.Zones))
+	for name := range cfg.Security.Zones {
+		znames = append(znames, name)
+	}
+	sort.Strings(znames)
+	for _, zname := range znames {
+		z := cfg.Security.Zones[zname]
 		if z == nil { // #3494: tolerant/HA-sync path may carry a nil zone value
 			continue
 		}
-		for _, ifn := range z.Interfaces {
-			ifZone[ifn] = zname
+		for _, ifEntry := range z.Interfaces {
+			for _, key := range zoneIfaceLogicalKeys(cfg, ifEntry) {
+				if _, seen := ifZone[key]; !seen {
+					ifZone[key] = zname
+				}
+			}
 		}
 	}
 	if len(ifZone) == 0 {
@@ -1826,15 +1842,14 @@ func validateHostInboundManagedRoutingMismatch(cfg *Config) []string {
 			if z == nil {
 				continue
 			}
-			// Effective admission set = zone-level ∪ per-interface override.
-			var eff []string
-			if z.HostInboundTraffic != nil {
-				eff = append(eff, z.HostInboundTraffic.Protocols...)
-			}
-			if hi := z.InterfaceHostInbound[ifn]; hi != nil {
-				eff = append(eff, hi.Protocols...)
-			}
-			if hostInboundAdmitsRoutingProtocol(eff, rp.token) {
+			// EFFECTIVE host-inbound protocols for this interface: zone-level ∪ the
+			// per-interface override WITH #3720 physical-parent inheritance for a
+			// logical unit — reuse the InterfaceHostInboundEffective SSOT so the
+			// advisory matches the dataplane's admission resolution exactly (a
+			// parent `reth0` override admitting ospf must cover unit `reth0.10`,
+			// else this warns falsely).
+			_, effProto, _ := z.InterfaceHostInboundEffective(ifn)
+			if hostInboundAdmitsRoutingProtocol(effProto, rp.token) {
 				continue
 			}
 			warnings = append(warnings, fmt.Sprintf(

--- a/pkg/config/host_inbound_managed_routing_mismatch_4455_test.go
+++ b/pkg/config/host_inbound_managed_routing_mismatch_4455_test.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func hasWarn4455B(warnings []string, substr string) bool {
+	for _, w := range warnings {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestHostInboundManagedRoutingMismatch covers the #4455 Component B advisory:
+// a managed FRR routing protocol (OSPF/OSPFv3/RIP) enabled on an interface whose
+// zone omits the matching host-inbound-traffic token warns; supplying the token
+// (or `all`, or a per-interface override) silences it; and there is no false
+// warning without managed routing or for an out-of-zone interface.
+func TestHostInboundManagedRoutingMismatch(t *testing.T) {
+	mkZone := func(iface string, zoneProtocols []string) *ZoneConfig {
+		z := &ZoneConfig{Interfaces: []string{iface}}
+		if zoneProtocols != nil {
+			z.HostInboundTraffic = &HostInboundTraffic{Protocols: zoneProtocols}
+		}
+		return z
+	}
+	ospfOn := func(iface string) *OSPFConfig {
+		return &OSPFConfig{Areas: []*OSPFArea{{Interfaces: []*OSPFInterface{{Name: iface}}}}}
+	}
+
+	// (a) OSPF enabled, zone omits `protocols ospf` → warns.
+	cfgA := &Config{}
+	cfgA.Security.Zones = map[string]*ZoneConfig{"trust": mkZone("ge-0/0/0.0", nil)}
+	cfgA.Protocols.OSPF = ospfOn("ge-0/0/0.0")
+	if w := validateHostInboundManagedRoutingMismatch(cfgA); !hasWarn4455B(w, `protocols ospf is enabled on interface "ge-0/0/0.0" (security zone "trust")`) {
+		t.Fatalf("(a) expected OSPF-without-token warning, got %v", w)
+	}
+
+	// (b) zone WITH `protocols ospf` → no warning.
+	cfgB := &Config{}
+	cfgB.Security.Zones = map[string]*ZoneConfig{"trust": mkZone("ge-0/0/0.0", []string{"ospf"})}
+	cfgB.Protocols.OSPF = ospfOn("ge-0/0/0.0")
+	if w := validateHostInboundManagedRoutingMismatch(cfgB); len(w) != 0 {
+		t.Fatalf("(b) expected no warning with protocols ospf, got %v", w)
+	}
+
+	// (b2) `all` counts as present.
+	cfgB2 := &Config{}
+	cfgB2.Security.Zones = map[string]*ZoneConfig{"trust": mkZone("ge-0/0/0.0", []string{"all"})}
+	cfgB2.Protocols.OSPF = ospfOn("ge-0/0/0.0")
+	if w := validateHostInboundManagedRoutingMismatch(cfgB2); len(w) != 0 {
+		t.Fatalf("(b2) expected no warning with protocols all, got %v", w)
+	}
+
+	// (c) per-interface #3362 override supplies the token → no warning.
+	cfgC := &Config{}
+	zc := mkZone("ge-0/0/0.0", nil)
+	zc.InterfaceHostInbound = map[string]*HostInboundTraffic{"ge-0/0/0.0": {Protocols: []string{"ospf"}}}
+	cfgC.Security.Zones = map[string]*ZoneConfig{"trust": zc}
+	cfgC.Protocols.OSPF = ospfOn("ge-0/0/0.0")
+	if w := validateHostInboundManagedRoutingMismatch(cfgC); len(w) != 0 {
+		t.Fatalf("(c) expected no warning with per-interface override, got %v", w)
+	}
+
+	// (d) RIP + OSPFv3 families warn on missing tokens.
+	cfgD := &Config{}
+	cfgD.Security.Zones = map[string]*ZoneConfig{"trust": mkZone("ge-0/0/0.0", nil)}
+	cfgD.Protocols.RIP = &RIPConfig{Interfaces: []string{"ge-0/0/0.0"}}
+	cfgD.Protocols.OSPFv3 = &OSPFv3Config{Areas: []*OSPFv3Area{{Interfaces: []*OSPFv3Interface{{Name: "ge-0/0/0.0"}}}}}
+	wD := validateHostInboundManagedRoutingMismatch(cfgD)
+	if !hasWarn4455B(wD, `protocols rip is enabled`) || !hasWarn4455B(wD, `protocols ospf3 is enabled`) {
+		t.Fatalf("(d) expected RIP + OSPFv3 warnings, got %v", wD)
+	}
+
+	// (e) no managed routing → no warning.
+	cfgE := &Config{}
+	cfgE.Security.Zones = map[string]*ZoneConfig{"trust": mkZone("ge-0/0/0.0", nil)}
+	if w := validateHostInboundManagedRoutingMismatch(cfgE); len(w) != 0 {
+		t.Fatalf("(e) expected no warning without managed routing, got %v", w)
+	}
+
+	// (f) OSPF on an interface NOT in any zone → no warning (no host-inbound dimension).
+	cfgF := &Config{}
+	cfgF.Security.Zones = map[string]*ZoneConfig{"trust": mkZone("ge-0/0/1.0", nil)}
+	cfgF.Protocols.OSPF = ospfOn("ge-0/0/0.0")
+	if w := validateHostInboundManagedRoutingMismatch(cfgF); len(w) != 0 {
+		t.Fatalf("(f) expected no warning for interface not in any zone, got %v", w)
+	}
+
+	// (g) a routing-instance's OSPF is also checked.
+	cfgG := &Config{}
+	cfgG.Security.Zones = map[string]*ZoneConfig{"trust": mkZone("ge-0/0/0.0", nil)}
+	cfgG.RoutingInstances = []*RoutingInstanceConfig{{Name: "vr1", OSPF: ospfOn("ge-0/0/0.0")}}
+	if w := validateHostInboundManagedRoutingMismatch(cfgG); !hasWarn4455B(w, `protocols ospf is enabled`) {
+		t.Fatalf("(g) expected routing-instance OSPF warning, got %v", w)
+	}
+}

--- a/pkg/config/host_inbound_managed_routing_mismatch_4455_test.go
+++ b/pkg/config/host_inbound_managed_routing_mismatch_4455_test.go
@@ -97,4 +97,37 @@ func TestHostInboundManagedRoutingMismatch(t *testing.T) {
 	if w := validateHostInboundManagedRoutingMismatch(cfgG); !hasWarn4455B(w, `protocols ospf is enabled`) {
 		t.Fatalf("(g) expected routing-instance OSPF warning, got %v", w)
 	}
+
+	// (i) BARE zone member claims configured units: zone lists physical `reth0`,
+	// OSPF runs on unit `reth0.10` — in-zone at runtime (buildInterfaceZoneMap
+	// bare-member expansion), so a missing token must warn (would be invisible to
+	// an exact-string map).
+	cfgI := &Config{}
+	cfgI.Interfaces.Interfaces = map[string]*InterfaceConfig{"reth0": {Name: "reth0", Units: map[int]*InterfaceUnit{10: {}}}}
+	cfgI.Security.Zones = map[string]*ZoneConfig{"trust": {Interfaces: []string{"reth0"}}}
+	cfgI.Protocols.OSPF = ospfOn("reth0.10")
+	if w := validateHostInboundManagedRoutingMismatch(cfgI); !hasWarn4455B(w, `protocols ospf is enabled on interface "reth0.10" (security zone "trust")`) {
+		t.Fatalf("(i) expected warning for OSPF unit under a bare zone member, got %v", w)
+	}
+
+	// (j) PHYSICAL-PARENT override inheritance (#3720): a per-interface override
+	// on the parent `reth0` admitting ospf must cover unit `reth0.10` — no FALSE
+	// warning (an exact `InterfaceHostInbound[reth0.10]` lookup would miss it).
+	cfgJ := &Config{}
+	cfgJ.Interfaces.Interfaces = map[string]*InterfaceConfig{"reth0": {Name: "reth0", Units: map[int]*InterfaceUnit{10: {}}}}
+	zj := &ZoneConfig{Interfaces: []string{"reth0"}}
+	zj.InterfaceHostInbound = map[string]*HostInboundTraffic{"reth0": {Protocols: []string{"ospf"}}}
+	cfgJ.Security.Zones = map[string]*ZoneConfig{"trust": zj}
+	cfgJ.Protocols.OSPF = ospfOn("reth0.10")
+	if w := validateHostInboundManagedRoutingMismatch(cfgJ); len(w) != 0 {
+		t.Fatalf("(j) expected no warning: parent override admits ospf (inherited by the unit), got %v", w)
+	}
+
+	// (h) REGISTRATION PIN: the advisory must be wired into ValidateConfig, not
+	// merely callable in isolation — removing the append registration line must
+	// make a real commit-warn assertion go red (the direct-helper cases above
+	// would not catch that). Uses cfgA (OSPF without token → warns).
+	if w := ValidateConfig(cfgA); !hasWarn4455B(w, `protocols ospf is enabled on interface "ge-0/0/0.0" (security zone "trust")`) {
+		t.Fatalf("(h) ValidateConfig must surface the Component B advisory (registration), got %v", w)
+	}
 }


### PR DESCRIPTION
The #4455 `/research` converged on a **split verdict** (2-of-3: Codex + Claude SMR):
- **Component A** (per-zone multicast/broadcast DROP: nft `iifname` gate + Rust lockstep) — **PLAN-KILL**: the XDP shim diverts host-bound multicast to the kernel before the XSK (Rust lockstep is dead code), native VRRP reads via AF_PACKET pre-netfilter (HA-failover risk is moot), and a correct `iifname` predicate is a fragile first-ever RETH/GRE/kernel-netdev attribution for near-zero reachable benefit.
- **Component B** (this PR) — **PLAN-READY**.

## What ships
`validateHostInboundManagedRoutingMismatch` — a commit-time WARN advisory that closes the *inverse* blind spot the shipped #4454 advisory misses. #4454 fires only when a multicast token is **present** (the already-compliant case), so the real silent fail-open — a zone running FRR **OSPF/OSPFv3/RIP with no matching token**, whose host-bound routing multicast is admitted PACKET-WIDE via the kernel input-chain accept fall-through — was invisible at commit.

The new advisory enumerates the interfaces xpf renders into FRR for OSPFv2/OSPFv3/RIP (`pkg/frr/policy_render.go`, global stanza + every routing-instance), resolves each to its security zone, and WARNs when the zone's **effective** `host-inbound-traffic protocols` set (zone-level ∪ per-interface #3362 override, `all`-expanded) omits the matching token (`ospf`/`ospf3`/`rip`).

## Safety
WARN-only, **zero dataplane surface** — no nft change, no Rust change, no `iifname` predicate — so none of the Component A risks apply. Never rejects or changes forwarding (valid Junos); mirrors the #3226/#4454 doctrine and honors #1960 lenient-load. BGP/LDP (unicast) + PIM (unmanaged) out of scope.

## Validation
- `go build` + `go vet` + `gofmt` clean.
- New table test: OSPF-without-token (warns); with-token / `all` / per-interface-override (silent); RIP + OSPFv3; routing-instance OSPF; no-managed-routing + out-of-zone-interface (no false warning). **RED-on-revert** verified.
- Full pkg/config + pkg/daemon + pkg/api + pkg/configstore green.

Advances #4455 (Component B; Component A PLAN-KILLed — deferred design preserved in the research plan appendix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)