### PR TITLE
logging: fix SESSION_CLOSE slog line always logging policy_id=0

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43710,3 +43710,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: Guard config-DB AES-GCM decrypt against wrong-length nonce (fail closed with error instead of panic); add RED-on-revert test
   **File(s)**: pkg/configstore/crypto.go, pkg/configstore/crypto_nonce_length_4793_test.go
+
+- **Timestamp**: 2026-07-09
+  **Action**: Fix SESSION_CLOSE slog "firewall event" line always logging policy_id=0 (use rec.PolicyID, not zeroed evt.PolicyID); add RED-on-revert test
+  **File(s)**: pkg/logging/ringbuf.go, pkg/logging/session_close_slog_policyid_4796_test.go

--- a/pkg/logging/ringbuf.go
+++ b/pkg/logging/ringbuf.go
@@ -679,13 +679,20 @@ func (er *EventReader) logEvent(data []byte) {
 		outZone = fmt.Sprintf("%d", evt.EgressZone)
 	}
 	if evt.EventType == eventTypeSessionClose {
+		// #4796: on a SESSION_CLOSE, evt.PolicyID was zeroed above (#2853
+		// repurposes the [44:48] slot for the created-subsec-nanos) and only
+		// rec.PolicyID is repopulated from the trailing [136:140] admitting-
+		// policy slot (#3056). Logging evt.PolicyID here always emitted
+		// policy_id=0 for every session close. rec.PolicyID is the same field
+		// PolicyName resolution and the RT_FLOW_SESSION_CLOSE record already
+		// use, so this keeps the slog line consistent with them.
 		slog.Info("firewall event",
 			"type", eventName,
 			"src", srcStr,
 			"dst", dstStr,
 			"proto", protoStr,
 			"action", actionStr,
-			"policy_id", evt.PolicyID,
+			"policy_id", rec.PolicyID,
 			"ingress_zone", inZone,
 			"egress_zone", outZone,
 			"session_packets", rec.SessionPkts,

--- a/pkg/logging/session_close_slog_policyid_4796_test.go
+++ b/pkg/logging/session_close_slog_policyid_4796_test.go
@@ -1,0 +1,70 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/binary"
+	"log/slog"
+	"net"
+	"strings"
+	"testing"
+)
+
+// #4796 RED-on-revert: on a SESSION_CLOSE frame, evt.PolicyID is zeroed
+// (ringbuf.go's logEvent -- #2853 repurposes the [44:48] slot for the
+// created-subsec-nanos) and only rec.PolicyID is repopulated, from the
+// trailing [136:140] admitting-policy slot (#3056). The slog "firewall
+// event" line previously logged evt.PolicyID for a close, so it always
+// recorded policy_id=0 -- even though the RT_FLOW_SESSION_CLOSE record and
+// the resolved policy name both correctly used rec.PolicyID.
+//
+// captureInfoLogs redirects slog to a buffer at Info level for the test's
+// lifetime and returns the buffer (mirrors captureWarnLogs in
+// pkg/configstore/plaintext_downgrade_warn_4579_test.go).
+func captureInfoLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(old) })
+	return &buf
+}
+
+// rawSessionCloseFrame builds a SESSION_CLOSE raw event frame carrying
+// admittingPolicyID at the #3056 close-only offset ([136:140] LE u32), with
+// the per-policy syslog gate ([135]) set so logEvent does not suppress the
+// human-facing slog line.
+func rawSessionCloseFrame(admittingPolicyID uint32) []byte {
+	data := make([]byte, rawEventWireSize)
+	data[40], data[41] = 0x30, 0x39 // src port
+	data[42], data[43] = 0x01, 0xbb // dst port
+	data[52] = eventTypeSessionClose
+	data[53] = 6 // TCP
+	data[55] = addrFamilyInet
+	copy(data[8:12], net.ParseIP("10.0.1.5").To4())
+	copy(data[24:28], net.ParseIP("10.0.2.7").To4())
+	data[rawEventLogSyslogOffset] = 1 // #2508 per-policy gate: log this close
+	binary.LittleEndian.PutUint32(data[rawEventPolicyCloseOffset:rawEventPolicyCloseOffset+4], admittingPolicyID)
+	return data
+}
+
+func TestSessionCloseSlogLine_CarriesAdmittingPolicyID(t *testing.T) {
+	buf := captureInfoLogs(t)
+
+	reader := NewEventReader(nil, NewEventBuffer(16))
+	if ok := reader.ProcessRawEvent(rawSessionCloseFrame(42)); !ok {
+		t.Fatalf("ProcessRawEvent returned false")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "firewall event") {
+		t.Fatalf("expected a \"firewall event\" slog line, got: %s", out)
+	}
+	if strings.Contains(out, "policy_id=0") {
+		t.Fatalf("SESSION_CLOSE slog line logged policy_id=0 (evt.PolicyID was "+
+			"zeroed for the #2853 created-subsec-nanos repurpose; want the "+
+			"admitting policy from rec.PolicyID): %s", out)
+	}
+	if !strings.Contains(out, "policy_id=42") {
+		t.Fatalf("SESSION_CLOSE slog line missing policy_id=42: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- `logEvent`'s slog "firewall event" line for a SESSION_CLOSE logged
  `evt.PolicyID`, but `evt.PolicyID` is unconditionally zeroed for
  close frames a few lines earlier (#2853 repurposes the wire
  `[44:48]` slot for the created-instant sub-second nanosecond
  remainder) and never reassigned. The admitting policy for a close
  instead lands in `rec.PolicyID`, read from the trailing `[136:140]`
  slot (#3056).
- Net effect: every SESSION_CLOSE "firewall event" slog line carried
  `policy_id=0`, regardless of the admitting policy -- a real
  observability gap. The RT_FLOW_SESSION_CLOSE record and the
  resolved policy name were unaffected; they already read
  `rec.PolicyID`.
- Fix: log `rec.PolicyID` instead of `evt.PolicyID` in the
  SESSION_CLOSE branch only. The screen-drop and default branches
  still correctly use `evt.PolicyID` (untouched for non-close frames).

## Test plan
- [x] Added `TestSessionCloseSlogLine_CarriesAdmittingPolicyID`: drives
      `EventReader.ProcessRawEvent` with a hand-built SESSION_CLOSE
      frame carrying policy ID 42 at the #3056 offset and the #2508
      per-policy log gate set, captures slog output via a redirected
      text handler, asserts `policy_id=42` and not `policy_id=0`.
- [x] RED-on-revert confirmed: reverting the log call to
      `evt.PolicyID` makes the line show `policy_id=0` again and the
      test fails.
- [x] `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/logging/...`
      passes.
- [x] `gofmt -l` clean on touched files.

Closes #4796