### PR TITLE
api: fix DHCP clear-identifiers wiping all DUIDs on chunked body

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43710,3 +43710,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: Guard config-DB AES-GCM decrypt against wrong-length nonce (fail closed with error instead of panic); add RED-on-revert test
   **File(s)**: pkg/configstore/crypto.go, pkg/configstore/crypto_nonce_length_4793_test.go
+
+- **Timestamp**: 2026-07-09
+  **Action**: Fix clearDHCPIdentifiersHandler wiping ALL DHCPv6 DUIDs on a chunked-encoded clear-one request (gate body decode on ContentLength != 0, tolerate empty-body io.EOF); add RED-on-revert test
+  **File(s)**: pkg/api/dhcp.go, pkg/api/dhcp_clear_chunked_4794_test.go

--- a/pkg/api/dhcp.go
+++ b/pkg/api/dhcp.go
@@ -1,7 +1,10 @@
 package api
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
@@ -66,8 +69,25 @@ func (s *Server) clearDHCPIdentifiersHandler(w http.ResponseWriter, r *http.Requ
 	}
 
 	var req ClearDHCPIdentifierRequest
-	if r.ContentLength > 0 {
-		if !decodeJSONBody(w, r, &req) {
+	// #4794: gate on ContentLength != 0, not > 0. A chunked-encoded request
+	// (Transfer-Encoding: chunked) reports ContentLength == -1 (unknown
+	// length), so the old "> 0" gate skipped the body decode entirely and
+	// fell through to ClearAllDUIDs() below even when the operator's body
+	// asked to clear a single interface -- wiping every DHCPv6 DUID instead.
+	// ContentLength == 0 (a genuinely empty body, no Transfer-Encoding) still
+	// skips the decode, matching the documented "no interface = clear all"
+	// contract. A chunked request that happens to carry zero bytes hits
+	// io.EOF on Decode, which is tolerated below (not a 400) for the same
+	// reason.
+	if r.ContentLength != 0 {
+		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+				return
+			}
+			writeError(w, http.StatusBadRequest, "invalid JSON body")
 			return
 		}
 	}

--- a/pkg/api/dhcp_clear_chunked_4794_test.go
+++ b/pkg/api/dhcp_clear_chunked_4794_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dhcp"
+)
+
+// #4794 RED-on-revert: clearDHCPIdentifiersHandler gated the JSON body
+// decode on r.ContentLength > 0. A Transfer-Encoding: chunked request
+// reports ContentLength == -1 (unknown length), so the old gate skipped the
+// decode entirely, req.Interface stayed "", and the handler fell through to
+// ClearAllDUIDs() -- wiping every DHCPv6 DUID even when the operator's body
+// asked to clear ONE interface. The response "message" field is the
+// observable proxy for which branch executed: a single-interface clear
+// returns "DHCPv6 DUID cleared for <iface>"; a clear-all returns "All
+// DHCPv6 DUIDs cleared".
+//
+// dhcp.NewManagerForTesting builds a *dhcp.Manager with no netlink handle
+// and no persisted DUID files, so ClearDUID/ClearAllDUIDs are pure no-ops
+// against an empty in-memory map -- exactly what's needed to observe ONLY
+// the routing decision, not real DUID state.
+
+func newTestDHCPManager() *dhcp.Manager {
+	return dhcp.NewManagerForTesting(nil)
+}
+
+func TestClearDHCPIdentifiers_ChunkedBody_ClearsSingleInterface(t *testing.T) {
+	s := &Server{dhcp: newTestDHCPManager()}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/dhcp/identifiers/clear",
+		strings.NewReader(`{"interface":"ge-0/0/0.0"}`))
+	req.ContentLength = -1 // simulate Transfer-Encoding: chunked
+
+	s.clearDHCPIdentifiersHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "DHCPv6 DUID cleared for ge-0/0/0.0") {
+		t.Fatalf("chunked clear-one request did not clear the named interface "+
+			"(likely fell through to clear-all — #4794): %s", body)
+	}
+	if strings.Contains(body, "All DHCPv6 DUIDs cleared") {
+		t.Fatalf("chunked clear-one request wrongly cleared ALL DUIDs — #4794: %s", body)
+	}
+}
+
+// TestClearDHCPIdentifiers_KnownLengthBody_Unchanged is the no-regression
+// guard: a normal (non-chunked, known Content-Length) body already worked
+// before the fix and must keep working identically.
+func TestClearDHCPIdentifiers_KnownLengthBody_Unchanged(t *testing.T) {
+	s := &Server{dhcp: newTestDHCPManager()}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/dhcp/identifiers/clear",
+		strings.NewReader(`{"interface":"ge-0/0/0.0"}`))
+	// httptest.NewRequest already sets a known ContentLength for a
+	// strings.Reader body; leave it untouched.
+
+	s.clearDHCPIdentifiersHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "DHCPv6 DUID cleared for ge-0/0/0.0") {
+		t.Fatalf("known-length clear-one request did not clear the named interface: %s", body)
+	}
+}
+
+// TestClearDHCPIdentifiers_EmptyBody_ClearsAll is the documented "no body /
+// no interface = clear all" contract, for BOTH a genuinely empty body
+// (ContentLength == 0) and a chunked request that happens to carry zero
+// bytes (ContentLength == -1, empty body -> Decode returns io.EOF, which
+// must be tolerated rather than surfacing HTTP 400).
+func TestClearDHCPIdentifiers_EmptyBody_ClearsAll(t *testing.T) {
+	cases := []struct {
+		name          string
+		contentLength int64
+	}{
+		{"no body (ContentLength 0)", 0},
+		{"chunked empty body (ContentLength -1)", -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{dhcp: newTestDHCPManager()}
+
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/api/v1/dhcp/identifiers/clear", nil)
+			req.ContentLength = tc.contentLength
+
+			s.clearDHCPIdentifiersHandler(rr, req)
+
+			if rr.Code != 200 {
+				t.Fatalf("status = %d, want 200 (empty body must not 400); body: %s",
+					rr.Code, rr.Body.String())
+			}
+			body := rr.Body.String()
+			if !strings.Contains(body, "All DHCPv6 DUIDs cleared") {
+				t.Fatalf("empty-body request did not clear all: %s", body)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `clearDHCPIdentifiersHandler` gated the JSON body decode on
  `r.ContentLength > 0`. A `Transfer-Encoding: chunked` request
  reports `ContentLength == -1` (unknown until read), so the gate
  skipped the decode entirely, `req.Interface` stayed empty, and the
  handler fell through to `ClearAllDUIDs()` -- wiping every DHCPv6
  DUID even when the operator's body named exactly one interface.
  Some HTTP clients default to chunked transfer when the body length
  isn't precomputed, so this is reachable without a hostile client.
- Fix: gate on `r.ContentLength != 0` instead, which correctly covers
  known-length (decode), chunked/unknown-length (now decodes too),
  and genuinely-empty (skip decode, clear-all as documented).
- A chunked body that happens to carry zero bytes must still reach
  the documented "no interface = clear all" contract rather than a
  400, so the decode is inlined (not routed through `decodeJSONBody`,
  which treats every decode error as 400) and `io.EOF` is tolerated.

## Test plan
- [x] Added `dhcp_clear_chunked_4794_test.go` using the existing
      `dhcp.NewManagerForTesting` seam so the handler exercises real
      `ClearDUID`/`ClearAllDUIDs` logic.
- [x] Chunked request (`ContentLength` forced to `-1`) carrying
      `{"interface":"ge-0/0/0.0"}` clears only that interface.
- [x] Known-length body behaves identically to before (no regression).
- [x] Genuinely-empty body and chunked-empty body both still clear
      all with HTTP 200 (not 400).
- [x] RED-on-revert confirmed: reverting the gate to `ContentLength >
      0` makes the chunked-body test fail with "All DHCPv6 DUIDs
      cleared" instead of the named interface.
- [x] `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/api/... ./pkg/dhcp/...`
      passes.
- [x] `gofmt -l` clean on touched files.

Closes #4794