### PR TITLE
cli: fix session filter matching only first interface of a zone

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43716,3 +43716,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: Fix SESSION_CLOSE slog "firewall event" line always logging policy_id=0 (use rec.PolicyID, not zeroed evt.PolicyID); add RED-on-revert test
   **File(s)**: pkg/logging/ringbuf.go, pkg/logging/session_close_slog_policyid_4796_test.go
+
+- **Timestamp**: 2026-07-09
+  **Action**: Fix session filter matching only the FIRST interface of a multi-interface zone (widen zoneIfaces to map[uint16][]string, match ANY bound interface); fix the show-path call site + existing test for the field type change; add RED-on-revert test
+  **File(s)**: pkg/cli/session_filter.go, pkg/cli/cli_show_flow.go, pkg/cli/session_display_test.go, pkg/cli/session_filter_multi_iface_4792_test.go

--- a/pkg/cli/cli_show_flow.go
+++ b/pkg/cli/cli_show_flow.go
@@ -259,8 +259,12 @@ func (c *CLI) showFlowSession(args []string) error {
 	egressIfaces := buildSessionEgressIfaces(f.cfg)
 
 	// Populate filter maps for interface-level matching in matchesV4/V6.
-	f.zoneIfaces = zoneIfaces
-	f.egressIfacesMap = egressIfaces
+	// #4792: use the shared populateIfaceMaps builder (session_filter.go)
+	// rather than the single-first-interface zoneIfaces built above for
+	// display, so an interface-filtered show sees EVERY interface bound
+	// to a zone. zoneIfaces/egressIfaces above stay display-only (the
+	// "If:" column shows one representative interface name).
+	f.populateIfaceMaps(c)
 
 	sessionEgressIf := func(fibIfindex uint32, fibVlanID uint16, zoneID uint16, zoneName string) string {
 		if fibIfindex != 0 {

--- a/pkg/cli/session_display_test.go
+++ b/pkg/cli/session_display_test.go
@@ -105,7 +105,7 @@ func TestIfaceMatches(t *testing.T) {
 
 func TestMatchesV4_InterfaceFilter(t *testing.T) {
 	// Zone 1 = trust (ge-0/0/0), Zone 2 = untrust (ge-0/0/1)
-	zoneIfaces := map[uint16]string{1: "ge-0/0/0", 2: "ge-0/0/1"}
+	zoneIfaces := map[uint16][]string{1: {"ge-0/0/0"}, 2: {"ge-0/0/1"}}
 	egressIfaces := map[sessionIfaceKey]string{
 		{ifindex: 10, vlanID: 0}: "ge-0/0/1",
 		{ifindex: 20, vlanID: 0}: "ge-0/0/2",

--- a/pkg/cli/session_filter.go
+++ b/pkg/cli/session_filter.go
@@ -55,7 +55,15 @@ type sessionFilter struct {
 
 	// Populated by populateIfaceMaps (show + clear paths) for
 	// interface matching.
-	zoneIfaces      map[uint16]string          // zone ID → first interface name
+	//
+	// #4792: zoneIfaces holds EVERY interface bound to a zone, not just
+	// the first. A single-value map meant a session ingressing (or, via
+	// the resolveEgressIfaces zone fallback, egressing) on the 2nd+
+	// interface of a multi-interface zone was silently invisible to
+	// `show security flow session interface <name>` / the matching
+	// `clear` — the interface never matched anything, so a filtered show
+	// undercounted and a filtered clear left sessions behind.
+	zoneIfaces      map[uint16][]string        // zone ID → all bound interface names
 	egressIfacesMap map[sessionIfaceKey]string // {ifindex,vlanID} → interface name
 }
 
@@ -202,9 +210,9 @@ func (f *sessionFilter) matchesV4(key dataplane.SessionKey, val dataplane.Sessio
 		return false
 	}
 	if f.iface != "" {
-		inIf := f.zoneIfaces[val.IngressZone]
-		outIf := f.resolveEgressIface(val.FibIfindex, val.FibVlanID, val.EgressZone)
-		if !f.ifaceMatches(inIf) && !f.ifaceMatches(outIf) {
+		inIfs := f.zoneIfaces[val.IngressZone]
+		outIfs := f.resolveEgressIfaces(val.FibIfindex, val.FibVlanID, val.EgressZone)
+		if !f.ifaceMatchesAny(inIfs) && !f.ifaceMatchesAny(outIfs) {
 			return false
 		}
 	}
@@ -247,9 +255,9 @@ func (f *sessionFilter) matchesV6(key dataplane.SessionKeyV6, val dataplane.Sess
 		return false
 	}
 	if f.iface != "" {
-		inIf := f.zoneIfaces[val.IngressZone]
-		outIf := f.resolveEgressIface(val.FibIfindex, val.FibVlanID, val.EgressZone)
-		if !f.ifaceMatches(inIf) && !f.ifaceMatches(outIf) {
+		inIfs := f.zoneIfaces[val.IngressZone]
+		outIfs := f.resolveEgressIfaces(val.FibIfindex, val.FibVlanID, val.EgressZone)
+		if !f.ifaceMatchesAny(inIfs) && !f.ifaceMatchesAny(outIfs) {
 			return false
 		}
 	}
@@ -315,14 +323,17 @@ func (f *sessionFilter) validate() error {
 // the clear path MUST call this before matching — historically it did
 // not, so an interface-filtered clear matched nothing (#1827 PR-3).
 func (f *sessionFilter) populateIfaceMaps(c *CLI) {
-	zoneIfaces := make(map[uint16]string)
+	zoneIfaces := make(map[uint16][]string)
 	if cr := c.applyResult(); cr != nil && f.cfg != nil {
 		for zoneName, zone := range f.cfg.Security.Zones {
 			if zone == nil { // #3493: tolerant/HA-sync path may carry a nil zone value
 				continue
 			}
 			if zid, ok := cr.ZoneIDs[zoneName]; ok && len(zone.Interfaces) > 0 {
-				zoneIfaces[zid] = zone.Interfaces[0]
+				// #4792: keep EVERY interface bound to the zone, not just
+				// the first — a zone with multiple member interfaces
+				// otherwise loses visibility into sessions on the 2nd+.
+				zoneIfaces[zid] = append(zoneIfaces[zid], zone.Interfaces...)
 			}
 		}
 	}
@@ -340,12 +351,27 @@ func (f *sessionFilter) ifaceMatches(ifName string) bool {
 	return ifName == f.iface || strings.HasPrefix(ifName, f.iface+".")
 }
 
-// resolveEgressIface resolves a session's egress interface name from FIB
-// lookup result, falling back to the zone's first interface.
-func (f *sessionFilter) resolveEgressIface(fibIfindex uint32, fibVlanID uint16, egressZone uint16) string {
+// ifaceMatchesAny reports whether ANY of ifNames matches the filter's
+// interface name (see ifaceMatches). Used against a zone's full interface
+// list (#4792) instead of assuming a zone binds exactly one interface.
+func (f *sessionFilter) ifaceMatchesAny(ifNames []string) bool {
+	for _, ifName := range ifNames {
+		if f.ifaceMatches(ifName) {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveEgressIfaces resolves a session's candidate egress interface
+// names: a precise single-element result from the FIB lookup when
+// available, otherwise EVERY interface bound to the egress zone (#4792 —
+// a zone can bind more than one interface, so a single fallback name
+// silently missed sessions egressing on any interface but the first).
+func (f *sessionFilter) resolveEgressIfaces(fibIfindex uint32, fibVlanID uint16, egressZone uint16) []string {
 	if fibIfindex != 0 {
 		if ifName, ok := f.egressIfacesMap[sessionIfaceKey{ifindex: fibIfindex, vlanID: fibVlanID}]; ok && ifName != "" {
-			return ifName
+			return []string{ifName}
 		}
 	}
 	return f.zoneIfaces[egressZone]

--- a/pkg/cli/session_filter_multi_iface_4792_test.go
+++ b/pkg/cli/session_filter_multi_iface_4792_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #4792 RED-on-revert: zoneIfaces (and the resolveEgressIfaces zone
+// fallback) previously stored only the FIRST interface bound to a zone
+// (map[uint16]string, populateIfaceMaps did `zoneIfaces[zid] =
+// zone.Interfaces[0]`). A zone bound to MULTIPLE interfaces (e.g. a trust
+// zone spanning ge-0/0/0 and ge-0/0/2) silently lost visibility into any
+// session ingressing/egressing on the 2nd+ interface: `show security flow
+// session interface ge-0/0/2` (or the matching `clear`) matched nothing for
+// those sessions even though they genuinely belong to that zone/interface.
+//
+// The fix widens zoneIfaces to map[uint16][]string (every interface bound
+// to the zone) and matches when the session's interface is ANY of them.
+func TestMatchesV4_MultiInterfaceZone_MatchesSecondInterface(t *testing.T) {
+	// Zone 1 (trust) spans TWO interfaces: ge-0/0/0 and ge-0/0/2.
+	zoneIfaces := map[uint16][]string{
+		1: {"ge-0/0/0", "ge-0/0/2"},
+		2: {"ge-0/0/1"},
+	}
+
+	t.Run("matches ingress on the zone's second interface", func(t *testing.T) {
+		f := &sessionFilter{
+			iface:      "ge-0/0/2",
+			zoneIfaces: zoneIfaces,
+		}
+		key := dataplane.SessionKey{Protocol: 6}
+		// No FIB egress info (FibIfindex 0) so only the ingress-zone match
+		// can pass this session — proving the ingress-side fix specifically.
+		val := dataplane.SessionValue{IngressZone: 1, EgressZone: 2}
+		if !f.matchesV4(key, val) {
+			t.Error("expected match on ge-0/0/2, the zone's SECOND interface " +
+				"(#4792: a single-interface zoneIfaces map drops every " +
+				"interface but the first)")
+		}
+	})
+
+	t.Run("still matches ingress on the zone's first interface", func(t *testing.T) {
+		f := &sessionFilter{
+			iface:      "ge-0/0/0",
+			zoneIfaces: zoneIfaces,
+		}
+		key := dataplane.SessionKey{Protocol: 6}
+		val := dataplane.SessionValue{IngressZone: 1, EgressZone: 2}
+		if !f.matchesV4(key, val) {
+			t.Error("expected match on ge-0/0/0, the zone's first interface (no regression)")
+		}
+	})
+
+	t.Run("no match for an interface outside the zone", func(t *testing.T) {
+		f := &sessionFilter{
+			iface:      "ge-0/0/9",
+			zoneIfaces: zoneIfaces,
+		}
+		key := dataplane.SessionKey{Protocol: 6}
+		val := dataplane.SessionValue{IngressZone: 1, EgressZone: 2}
+		if f.matchesV4(key, val) {
+			t.Error("expected no match for an interface not bound to either zone")
+		}
+	})
+
+	t.Run("matches egress zone fallback on the second interface", func(t *testing.T) {
+		f := &sessionFilter{
+			iface:      "ge-0/0/2",
+			zoneIfaces: zoneIfaces,
+		}
+		key := dataplane.SessionKey{Protocol: 6}
+		// Ingress zone 2 does not carry ge-0/0/2; only the egress zone (1,
+		// via the zoneIfaces fallback when FIB lookup is unavailable) does.
+		val := dataplane.SessionValue{IngressZone: 2, EgressZone: 1}
+		if !f.matchesV4(key, val) {
+			t.Error("expected match via egress-zone fallback on ge-0/0/2, the " +
+				"zone's second interface (#4792)")
+		}
+	})
+}
+
+// TestMatchesV6_MultiInterfaceZone_MatchesSecondInterface mirrors the V4
+// case for the IPv6 session path (matchesV6 has the identical bug).
+func TestMatchesV6_MultiInterfaceZone_MatchesSecondInterface(t *testing.T) {
+	zoneIfaces := map[uint16][]string{
+		1: {"ge-0/0/0", "ge-0/0/2"},
+	}
+	f := &sessionFilter{
+		iface:      "ge-0/0/2",
+		zoneIfaces: zoneIfaces,
+	}
+	key := dataplane.SessionKeyV6{Protocol: 6}
+	val := dataplane.SessionValueV6{IngressZone: 1, EgressZone: 1}
+	if !f.matchesV6(key, val) {
+		t.Error("expected v6 match on ge-0/0/2, the zone's second interface (#4792)")
+	}
+}


### PR DESCRIPTION
## Summary
- `sessionFilter.zoneIfaces` was `map[uint16]string` ("zone ID ->
  first interface name"), populated as `zoneIfaces[zid] =
  zone.Interfaces[0]`. A zone bound to multiple interfaces (e.g. a
  trust zone spanning `ge-0/0/0` and `ge-0/0/2`) silently lost
  visibility into any session ingressing/egressing on the 2nd+
  interface -- `matchesV4`/`matchesV6` and the egress zone-fallback
  path all only ever saw the first.
- Net effect: `show security flow session interface ge-0/0/2`
  undercounted, and the matching `clear` left those sessions behind,
  for any zone with more than one member interface.
- Fix: widen `zoneIfaces` to `map[uint16][]string` (every interface
  bound to the zone). `matchesV4`/`matchesV6` now check ANY of the
  zone's interfaces via a new `ifaceMatchesAny` helper, and the
  egress fallback (`resolveEgressIface` -> `resolveEgressIfaces`)
  returns the full candidate list instead of one guessed name.
- Two other call sites needed updating for the field-type change
  (both mechanical, no behavior change):
  - `cli_show_flow.go`'s `show` path built its own single-value
    zoneIfaces map for a DISPLAY label ("If: `<name>`") -- left as
    is -- but assigned it directly into `f.zoneIfaces` for filter
    matching; that now calls the shared `populateIfaceMaps` builder
    instead, so an interface-filtered `show` gets the same fix.
  - `session_display_test.go`'s `TestMatchesV4_InterfaceFilter`
    literal updated from `map[uint16]string` to
    `map[uint16][]string` (single-element slices, no behavior
    change).

## Test plan
- [x] Added `session_filter_multi_iface_4792_test.go`: a two-
      interface zone (`ge-0/0/0`, `ge-0/0/2`) matches on both its
      first AND second interface (ingress-zone lookup and egress-
      zone fallback), a negative control for an interface outside
      the zone, and the identical v6 case.
- [x] RED-on-revert confirmed: restricting `ifaceMatchesAny` to only
      the first slice element (the pre-fix behavior) fails the
      second-interface and egress-fallback assertions in both v4
      and v6.
- [x] `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/cli/...`
      passes.
- [x] `go build ./...` confirms no other caller of the changed field
      broke.
- [x] `gofmt -l` clean on touched files.

Closes #4792