### PR TITLE
dataplane: fix getOriginalKernelName always appending f<func> suffix

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43718,3 +43718,7 @@ top.
   **File(s)**: pkg/api/dhcp.go, pkg/api/dhcp_clear_chunked_4794_test.go
   **Action**: Fix SESSION_CLOSE slog "firewall event" line always logging policy_id=0 (use rec.PolicyID, not zeroed evt.PolicyID); add RED-on-revert test
   **File(s)**: pkg/logging/ringbuf.go, pkg/logging/session_close_slog_policyid_4796_test.go
+
+- **Timestamp**: 2026-07-09
+  **Action**: Fix getOriginalKernelName unconditionally appending "f<func>" to derived PCI-path interface names; extract testable pciFunctionSuffix + isPCIMultifunctionDevice mirroring systemd's names_pci_slot()/is_pci_multifunction() rule; add RED-on-revert test
+  **File(s)**: pkg/dataplane/compiler.go, pkg/dataplane/pci_function_suffix_4795_test.go

--- a/pkg/dataplane/compiler.go
+++ b/pkg/dataplane/compiler.go
@@ -1729,5 +1729,47 @@ func getOriginalKernelName(ifName string, result *CompileResult) string {
 	if err != nil {
 		return ""
 	}
-	return fmt.Sprintf("enp%ds%df%d", bus, slot, fn)
+	return fmt.Sprintf("enp%ds%d%s", bus, slot, pciFunctionSuffix(isPCIMultifunctionDevice(pciAddr), fn))
+}
+
+// pciFunctionSuffix returns the "f<function>" suffix systemd's
+// udev-builtin-net_id "path" naming scheme appends to a predictable PCI
+// interface name (enp<bus>s<slot>[f<function>]) — or "" when the suffix is
+// omitted. systemd's names_pci_slot() (src/udev/udev-builtin-net_id.c)
+// appends the suffix ONLY when the PCI function number is nonzero OR the
+// device is a genuine multi-function device (is_pci_multifunction(), which
+// tests the kernel's PCI_HEADER_TYPE multi-function bit in config space —
+// see isPCIMultifunctionDevice below). A single-function device at
+// function 0 (e.g. a standalone NIC at 0000:09:00.0) is therefore named
+// enp9s0, NOT enp9s0f0 — the #4795 bug: the pre-fix code appended "f%d"
+// unconditionally, producing a wrong .link OriginalName for every
+// single-function card. Kept pure/parameterized so the boundary logic is
+// unit-testable without sysfs.
+func pciFunctionSuffix(multifunction bool, fn uint64) string {
+	if fn == 0 && !multifunction {
+		return ""
+	}
+	return fmt.Sprintf("f%d", fn)
+}
+
+// isPCIMultifunctionDevice reports whether the PCI device at pciAddr
+// (domain:bus:slot.function, e.g. "0000:09:00.0") is a multi-function
+// device per the kernel's PCI_HEADER_TYPE config-space byte (offset 0x0E),
+// bit 0x80 ("Multi-Function Device"). This mirrors systemd's
+// is_pci_multifunction() (src/shared/pci-util.c small helper reading
+// <syspath>/config), the same signal names_pci_slot() uses to decide
+// whether to append the "f<function>" suffix. Any read failure (missing
+// sysfs, short read, permission) conservatively reports false — the same
+// fallback systemd uses on error, and the caller then falls back to the
+// "fn != 0" half of the test.
+func isPCIMultifunctionDevice(pciAddr string) bool {
+	const (
+		pciHeaderTypeOffset = 14 // PCI_HEADER_TYPE, config-space offset 0x0E
+		pciMultiFunctionBit = 0x80
+	)
+	data, err := os.ReadFile(fmt.Sprintf("/sys/bus/pci/devices/%s/config", pciAddr))
+	if err != nil || len(data) <= pciHeaderTypeOffset {
+		return false
+	}
+	return data[pciHeaderTypeOffset]&pciMultiFunctionBit != 0
 }

--- a/pkg/dataplane/pci_function_suffix_4795_test.go
+++ b/pkg/dataplane/pci_function_suffix_4795_test.go
@@ -1,0 +1,69 @@
+package dataplane
+
+import "testing"
+
+// #4795 RED-on-revert: getOriginalKernelName unconditionally appended
+// "f<function>" to a derived PCI-path interface name
+// (fmt.Sprintf("enp%ds%df%d", bus, slot, fn)). systemd's udev-builtin-net_id
+// "path" naming scheme (names_pci_slot()) only appends that suffix when the
+// PCI function number is nonzero OR the device is a genuine multi-function
+// device (the kernel PCI_HEADER_TYPE multi-function bit). A single-function
+// NIC at e.g. 0000:09:00.0 is named enp9s0 by systemd, not enp9s0f0 — the
+// unconditional suffix produced a wrong .link OriginalName for every
+// single-function card, breaking RETH-member interface matching
+// (ensureRethLinkOriginalName / linksetup.go match RETH members by
+// OriginalName, not MAC).
+//
+// pciFunctionSuffix is the extracted pure boundary function; this test
+// pins its logic without touching sysfs.
+func TestPCIFunctionSuffix(t *testing.T) {
+	cases := []struct {
+		name          string
+		multifunction bool
+		fn            uint64
+		want          string
+	}{
+		{
+			name:          "single-function device at function 0 omits suffix",
+			multifunction: false,
+			fn:            0,
+			want:          "",
+		},
+		{
+			name:          "multi-function device at function 0 carries suffix",
+			multifunction: true,
+			fn:            0,
+			want:          "f0",
+		},
+		{
+			name:          "nonzero function always carries suffix even if not flagged multifunction",
+			multifunction: false,
+			fn:            1,
+			want:          "f1",
+		},
+		{
+			name:          "multi-function device at a nonzero function carries suffix",
+			multifunction: true,
+			fn:            2,
+			want:          "f2",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pciFunctionSuffix(tc.multifunction, tc.fn); got != tc.want {
+				t.Errorf("pciFunctionSuffix(%v, %d) = %q, want %q",
+					tc.multifunction, tc.fn, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsPCIMultifunctionDevice_MissingSysfsReturnsFalse pins the
+// conservative failure mode: a nonexistent PCI address (no sysfs config
+// file, as in any non-bare-metal test environment) reports false rather
+// than panicking or erroring, matching systemd's own fail-safe behavior.
+func TestIsPCIMultifunctionDevice_MissingSysfsReturnsFalse(t *testing.T) {
+	if got := isPCIMultifunctionDevice("0000:ff:1f.7"); got != false {
+		t.Errorf("isPCIMultifunctionDevice on a nonexistent PCI address = %v, want false", got)
+	}
+}


### PR DESCRIPTION
## Summary
- `getOriginalKernelName`'s PCI-sysfs fallback built the derived
  interface name as `fmt.Sprintf("enp%ds%df%d", bus, slot, fn)` --
  unconditionally appending the `f<function>` suffix. systemd's
  predictable-name "path" scheme (`names_pci_slot()` in
  `src/udev/udev-builtin-net_id.c`) only appends that suffix when the
  PCI function number is nonzero OR the device is a genuine
  multi-function device (`is_pci_multifunction()`, which tests the
  kernel's `PCI_HEADER_TYPE` "Multi-Function Device" bit in PCI
  config space, offset 0x0E bit 0x80). A single-function NIC at
  `0000:09:00.0` is named `enp9s0` by systemd, not `enp9s0f0`.
- This matters because `getOriginalKernelName` feeds the `.link`
  `OriginalName=` match for RETH member interfaces (matched by PCI
  kernel name, not MAC, since MAC alternates between boot and the
  daemon-assigned virtual MAC). A wrong suffix breaks that match for
  every single-function card.
- Fix: extract `pciFunctionSuffix(multifunction bool, fn uint64)
  string` (pure boundary logic, directly testable) and
  `isPCIMultifunctionDevice(pciAddr string) bool` (reads
  `/sys/bus/pci/devices/<addr>/config` and checks byte 14 bit 0x80,
  mirroring systemd's own mechanism rather than approximating with a
  sibling-directory heuristic). Read failures conservatively return
  `false`, matching systemd's own fallback.

## Test plan
- [x] Added `pci_function_suffix_4795_test.go`: all four boundary
      combinations of `pciFunctionSuffix` (single-function fn=0 -> no
      suffix; multifunction fn=0 -> "f0"; nonzero fn without the
      multifunction flag -> "f1"; multifunction + nonzero fn -> "f2")
      plus a conservative-failure check for
      `isPCIMultifunctionDevice` against a nonexistent PCI address.
- [x] RED-on-revert confirmed: reverting `pciFunctionSuffix` to the
      pre-fix unconditional `"f%d"` fails exactly the single-function
      fn=0 case (produces `"f0"` instead of `""`) -- the precise
      #4795 bug.
- [x] `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/dataplane/...`
      passes (including `pkg/dataplane/userspace`).
- [x] `go build ./...` confirms no other caller of the changed
      return format broke.
- [x] `gofmt -l` clean on touched files.

Closes #4795