### PR TITLE
config: fix int64-overflow panic in interface-range member-range

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43724,3 +43724,7 @@ top.
   **File(s)**: pkg/dataplane/compiler.go, pkg/dataplane/pci_function_suffix_4795_test.go
   **Action**: Fix session filter matching only the FIRST interface of a multi-interface zone (widen zoneIfaces to map[uint16][]string, match ANY bound interface); fix the show-path call site + existing test for the field type change; add RED-on-revert test
   **File(s)**: pkg/cli/session_filter.go, pkg/cli/cli_show_flow.go, pkg/cli/session_display_test.go, pkg/cli/session_filter_multi_iface_4792_test.go
+
+- **Timestamp**: 2026-07-09
+  **Action**: Fix #4807 — interface-range member-range int64-overflow panic (`en-sn+1` wrapped negative for a huge trailing end integer, bypassing the 4096-member cap and reaching `make()` with a negative capacity); compare `en-sn >= interfaceRangeMaxMembers` before the `+1` so the guard cannot overflow; add RED-on-revert tests reproducing the exact `math.MaxInt64`-adjacent reproducer
+  **File(s)**: pkg/config/compiler_interface_range.go, pkg/config/compiler_interface_range_4027_test.go

--- a/pkg/config/compiler_interface_range.go
+++ b/pkg/config/compiler_interface_range.go
@@ -262,7 +262,15 @@ func expandMemberRange(rangeName string, toks []string) ([]string, []string) {
 				"(endpoints must share a prefix and differ only in a trailing number); ignored",
 			rangeName, start, end)}
 	}
-	if en-sn+1 > interfaceRangeMaxMembers {
+	// splitTrailingInt only ever returns non-negative values (it scans a
+	// pure decimal digit run), so sn >= 0 and, given the sn > en rejection
+	// above, en >= sn >= 0 here. That makes en-sn itself overflow-safe (a
+	// non-negative difference bounded by en). Comparing en-sn against the
+	// cap BEFORE adding 1 avoids the en-sn+1 overflow that a start/end pair
+	// near math.MaxInt64 could otherwise trigger — en-sn+1 would wrap to a
+	// large negative number, silently bypassing this guard and reaching the
+	// make() below with a negative capacity (a crashing panic, #4807).
+	if en-sn >= interfaceRangeMaxMembers {
 		return nil, []string{fmt.Sprintf(
 			"interfaces interface-range %s: member-range %s to %s exceeds %d interfaces; ignored",
 			rangeName, start, end, interfaceRangeMaxMembers)}

--- a/pkg/config/compiler_interface_range_4027_test.go
+++ b/pkg/config/compiler_interface_range_4027_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestInterfaceRangeExpandsMembers is the #4027 RED-on-revert guard: an
 // `interfaces interface-range <name>` stanza must expand into its member
@@ -221,5 +224,60 @@ func TestInterfaceRangeNoStanzaUnchanged(t *testing.T) {
 	}
 	if u0 := ifc.Units[0]; u0 == nil || !containsStr(u0.Addresses, "10.0.0.1/24") {
 		t.Fatalf("plain interface unit 0 address lost")
+	}
+}
+
+// TestInterfaceRangeMemberRangeHugeEndOverflow is the #4807 RED-on-revert
+// guard: a member-range whose end value is a trailing integer near
+// math.MaxInt64 must be rejected with a clean warning, not panic the
+// compiler. Before the fix, `en-sn+1` (both plain `int`, 64-bit on amd64)
+// overflowed to a large negative number for this input, which (a) beat the
+// `en-sn+1 > interfaceRangeMaxMembers` guard (a negative number is never
+// greater than 4096) and (b) reached `make([]string, 0, en-sn+1)` with a
+// negative capacity, panicking with "runtime error: makeslice: cap out of
+// range" and crashing the whole daemon on every future compile of this
+// config (boot-time load included — no strict/lenient gate covers this
+// prewalk pass). This test goes RED on that overflow behavior.
+func TestInterfaceRangeMemberRangeHugeEndOverflow(t *testing.T) {
+	tree := setTree(t,
+		"set interfaces interface-range R member-range ge-0/0/0 to ge-0/0/9223372036854775807",
+		"set interfaces interface-range R mtu 9000",
+	)
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig returned an error instead of a clean warning: %v", err)
+	}
+
+	// Must not have expanded into millions/billions of phantom members.
+	if n := len(cfg.Interfaces.Interfaces); n > interfaceRangeMaxMembers {
+		t.Fatalf("member-range expanded to %d interfaces, want <= %d (cap)",
+			n, interfaceRangeMaxMembers)
+	}
+
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "exceeds") && strings.Contains(w, "interfaces") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a member-range-exceeds-cap warning, got: %v", cfg.Warnings)
+	}
+}
+
+// TestExpandMemberRangeHugeEndDoesNotOverflow directly exercises
+// expandMemberRange (the #4807 unit) with the exact overflow-triggering
+// inputs from the issue: start "ge-0/0/0", end "ge-0/0/9223372036854775807".
+// Before the fix this panicked inside make(); it must now return a nil
+// member list and a warning.
+func TestExpandMemberRangeHugeEndDoesNotOverflow(t *testing.T) {
+	members, warnings := expandMemberRange("R", []string{"ge-0/0/0", "to", "ge-0/0/9223372036854775807"})
+	if members != nil {
+		t.Errorf("expandMemberRange with overflow-triggering end returned %d members, want none", len(members))
+	}
+	if len(warnings) == 0 {
+		t.Errorf("expandMemberRange with overflow-triggering end returned no warning")
 	}
 }


### PR DESCRIPTION
## Summary
- `expandMemberRange` (`pkg/config/compiler_interface_range.go`) computed the member count as `en-sn+1` (plain `int`, 64-bit) for both the `interfaceRangeMaxMembers` cap check and the `make()` slice capacity. A member-range with a trailing end integer near `math.MaxInt64` overflows `en-sn+1` to a large negative number, bypassing the cap guard and reaching `make([]string, 0, en-sn+1)` with a negative capacity — a panic that crashes the whole daemon on every compile of the config, including at boot (no recover() in the call chain).
- Fix: compare `en-sn >= interfaceRangeMaxMembers` before adding 1. Given the preceding `sn > en` rejection, `en >= sn >= 0` always holds here, so `en-sn` is a non-negative difference bounded by `en` and cannot overflow. Once that check passes, `en-sn < interfaceRangeMaxMembers` (4096), so the subsequent `en-sn+1` used in `make()` is bounded too.

## Test plan
- [x] `TestInterfaceRangeMemberRangeHugeEndOverflow` — end-to-end via `CompileConfig` using the issue's exact reproducer (`ge-0/0/0 to ge-0/0/9223372036854775807`); asserts a clean warning, no panic.
- [x] `TestExpandMemberRangeHugeEndDoesNotOverflow` — direct unit test of `expandMemberRange`.
- [x] RED-on-revert confirmed: reverting the fix reproduces the exact `runtime error: makeslice: cap out of range` panic from the issue.
- [x] `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/config/...` green.
- [x] `gofmt -l` clean on touched files.

Closes #4807

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi