### PR TITLE
logging: fix SyslogClient.Close() connection resurrection race

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43724,3 +43724,7 @@ top.
   **File(s)**: pkg/dataplane/compiler.go, pkg/dataplane/pci_function_suffix_4795_test.go
   **Action**: Fix session filter matching only the FIRST interface of a multi-interface zone (widen zoneIfaces to map[uint16][]string, match ANY bound interface); fix the show-path call site + existing test for the field type change; add RED-on-revert test
   **File(s)**: pkg/cli/session_filter.go, pkg/cli/cli_show_flow.go, pkg/cli/session_display_test.go, pkg/cli/session_filter_multi_iface_4792_test.go
+
+- **Timestamp**: 2026-07-09
+  **Action**: Fix #4806 — SyslogClient.Close() didn't nil s.conn or mark the client closed, so a Send() racing Close() could see the stale closed conn, hit a write error, and silently reconnect/resurrect a torn-down connection; add a `closed` flag (mu-guarded) checked at the top of Send/SendBinary, and nil s.conn in Close(); add RED-on-revert tests reproducing the resurrection
+  **File(s)**: pkg/logging/syslog.go, pkg/logging/syslog_close_resurrection_4806_test.go

--- a/pkg/logging/syslog.go
+++ b/pkg/logging/syslog.go
@@ -100,6 +100,17 @@ type SyslogClient struct {
 	// Seams for deterministic testing. nil → real implementations.
 	nowFn  func() time.Time         // clock source (default time.Now)
 	dialFn func() (net.Conn, error) // dial override (default s.dial)
+
+	// closed is set true by Close() (mu-guarded) and checked at the top of
+	// Send/SendBinary. Without it, a Send racing a Close (both serialize on
+	// mu, so this is a happens-after ordering, not a data race) can run
+	// AFTER Close() returns, see the pre-#4806 code's now-stale
+	// s.conn != nil, hit a "use of closed network connection" write error,
+	// and — since that is treated as a generic write failure — fall into
+	// reconnect(), silently re-establishing a brand-new socket to a target
+	// the caller believed was torn down (#4806). Checking closed instead of
+	// conn != nil makes Close() terminal: no Send after Close() may dial.
+	closed bool
 }
 
 // now returns the client's clock (overridable in tests).
@@ -338,6 +349,11 @@ func (s *SyslogClient) clearReconnectCooldown() {
 // window; the message is dropped (fail-fast) rather than blocking on a dial.
 var errReconnectCooldown = fmt.Errorf("syslog reconnect in cooldown")
 
+// errSyslogClientClosed signals that Close() already ran on this client
+// (#4806); Send/SendBinary return it immediately without touching s.conn or
+// attempting a reconnect.
+var errSyslogClientClosed = fmt.Errorf("syslog client closed")
+
 // dropReason classifies why a message was dropped, for the counter and the
 // rate-limited warning.
 type dropReason int
@@ -458,6 +474,11 @@ func (s *SyslogClient) Send(severity int, msg string) error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if s.closed {
+		// Close() already ran: fail fast, never reconnect (#4806).
+		return errSyslogClientClosed
+	}
 
 	if err := s.writeMsg(line); err != nil {
 		// For stream protocols, attempt one cooldown-gated reconnect. UDP
@@ -584,6 +605,11 @@ func (s *SyslogClient) SendBinary(data []byte) error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if s.closed {
+		// Close() already ran: fail fast, never reconnect (#4806).
+		return errSyslogClientClosed
+	}
 
 	if err := s.writeBinaryMsg(data); err != nil {
 		if s.protocol != "udp" {
@@ -758,12 +784,19 @@ func ParseFacility(name string) int {
 	}
 }
 
-// Close closes the underlying connection.
+// Close closes the underlying connection and marks the client closed (#4806).
+// Once Close returns, Send/SendBinary always fail fast — they never dial a
+// fresh connection, even if a caller races a Send against this Close (the
+// shared mu serializes the two: whichever acquires it first runs to
+// completion before the other observes the closed state).
 func (s *SyslogClient) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.closed = true
 	if s.conn != nil {
-		return s.conn.Close()
+		err := s.conn.Close()
+		s.conn = nil
+		return err
 	}
 	return nil
 }

--- a/pkg/logging/syslog_close_resurrection_4806_test.go
+++ b/pkg/logging/syslog_close_resurrection_4806_test.go
@@ -1,0 +1,175 @@
+package logging
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// dialCountConn is a net.Conn fake used as the target of a resurrecting
+// reconnect dial; it always accepts writes so a post-fix-reverted reconnect
+// (if one wrongly happened) would let Send "succeed" against it.
+type dialCountConn struct{}
+
+func (c *dialCountConn) Read(_ []byte) (int, error)         { return 0, nil }
+func (c *dialCountConn) Write(b []byte) (int, error)        { return len(b), nil }
+func (c *dialCountConn) Close() error                       { return nil }
+func (c *dialCountConn) LocalAddr() net.Addr                { return ccAddr{} }
+func (c *dialCountConn) RemoteAddr() net.Addr               { return ccAddr{} }
+func (c *dialCountConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *dialCountConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *dialCountConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+// closedAwareConn is a net.Conn fake that faithfully reproduces the real
+// net.Conn behavior this bug exploits: once Close() has been called on it,
+// Write returns a "use of closed network connection"-style error instead of
+// silently succeeding. A bare always-succeeds fake would mask the bug — the
+// reverted Send would just "succeed" writing to the stale conn instead of
+// hitting the write-error -> reconnect path that actually resurrects a
+// connection in production (#4806).
+type closedAwareConn struct {
+	mu     sync.Mutex
+	closed bool
+}
+
+func (c *closedAwareConn) Read(_ []byte) (int, error) { return 0, nil }
+func (c *closedAwareConn) Write(b []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return 0, errors.New("use of closed network connection")
+	}
+	return len(b), nil
+}
+func (c *closedAwareConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closed = true
+	return nil
+}
+func (c *closedAwareConn) LocalAddr() net.Addr                { return ccAddr{} }
+func (c *closedAwareConn) RemoteAddr() net.Addr               { return ccAddr{} }
+func (c *closedAwareConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *closedAwareConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *closedAwareConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+// TestSendAfterCloseDoesNotResurrectConnection is the #4806 RED-on-revert
+// guard. Before the fix, Close() closed s.conn without nilling it and
+// without recording a closed flag. A Send() that runs AFTER Close() returns
+// (the documented happens-after race: an event-dispatch goroutine that
+// snapshotted the client slice just before ReplaceSyslogClients ran) would
+// see the stale, non-nil (now-closed) s.conn, get a "use of closed network
+// connection" write error from it, and — because Send treats any
+// non-timeout stream write error as a signal to reconnect — dial a BRAND
+// NEW connection to a target the caller believed was torn down. This test
+// drives exactly that sequence (using a conn fake that actually errors on
+// Write once closed, and a dialFn that counts dials) and asserts Send fails
+// closed instead of resurrecting a connection.
+func TestSendAfterCloseDoesNotResurrectConnection(t *testing.T) {
+	firstConn := &closedAwareConn{}
+	var dialed atomic.Int32
+	c := &SyslogClient{
+		hostname:          "test",
+		remoteAddr:        "203.0.113.1:514",
+		protocol:          "tcp",
+		Facility:          FacilityLocal0,
+		writeTimeout:      defaultWriteTimeout,
+		reconnectCooldown: defaultReconnectCooldown,
+		conn:              firstConn,
+		dialFn: func() (net.Conn, error) {
+			dialed.Add(1)
+			return &dialCountConn{}, nil
+		},
+	}
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Send AFTER Close must fail immediately and must NOT dial a fresh
+	// connection to resurrect the client.
+	if err := c.Send(SyslogInfo, "post-close message"); err == nil {
+		t.Fatalf("Send after Close returned nil error, want a closed-client error")
+	}
+	if got := dialed.Load(); got != 0 {
+		t.Fatalf("Send after Close dialed %d times, want 0 (resurrected a closed connection, #4806)", got)
+	}
+
+	c.mu.Lock()
+	stillClosed := c.closed
+	connAfterSend := c.conn
+	c.mu.Unlock()
+	if !stillClosed {
+		t.Fatalf("closed flag was cleared by Send")
+	}
+	if connAfterSend != nil {
+		t.Fatalf("conn is non-nil after Send following Close: %#v (resurrected)", connAfterSend)
+	}
+}
+
+// TestSendBinaryAfterCloseDoesNotResurrectConnection mirrors the Send test
+// above for SendBinary, the record used by the binary syslog transport.
+func TestSendBinaryAfterCloseDoesNotResurrectConnection(t *testing.T) {
+	firstConn := &closedAwareConn{}
+	var dialed atomic.Int32
+	c := &SyslogClient{
+		hostname:          "test",
+		remoteAddr:        "203.0.113.1:514",
+		protocol:          "tcp",
+		Facility:          FacilityLocal0,
+		writeTimeout:      defaultWriteTimeout,
+		reconnectCooldown: defaultReconnectCooldown,
+		conn:              firstConn,
+		dialFn: func() (net.Conn, error) {
+			dialed.Add(1)
+			return &dialCountConn{}, nil
+		},
+	}
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if err := c.SendBinary([]byte{0x00, 0x01, 0x02}); err == nil {
+		t.Fatalf("SendBinary after Close returned nil error, want a closed-client error")
+	}
+	if got := dialed.Load(); got != 0 {
+		t.Fatalf("SendBinary after Close dialed %d times, want 0 (resurrected a closed connection, #4806)", got)
+	}
+}
+
+// TestCloseNilsConn locks the second half of the #4806 fix: Close() must nil
+// s.conn (not just close it), so any code that still checks `conn != nil`
+// (rather than the closed flag) also observes the torn-down state.
+func TestCloseNilsConn(t *testing.T) {
+	c := clientWithConn(&closeCountConn{})
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	c.mu.Lock()
+	conn := c.conn
+	closed := c.closed
+	c.mu.Unlock()
+	if conn != nil {
+		t.Fatalf("s.conn is non-nil after Close: %#v", conn)
+	}
+	if !closed {
+		t.Fatalf("s.closed is false after Close")
+	}
+}
+
+// TestCloseIdempotent asserts a second Close() call is a harmless no-op (does
+// not double-close a nil conn or panic) — Close() is called from teardown
+// paths that may run more than once.
+func TestCloseIdempotent(t *testing.T) {
+	c := clientWithConn(&closeCountConn{})
+	if err := c.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- `SyslogClient.Close()` closed `s.conn` but left the field non-nil and had no closed-state flag. A `Send()` racing a `Close()` (both serialize on `s.mu`, so it's a happens-after ordering, not a data race) could run AFTER `Close()` returns, see the stale `s.conn != nil`, hit a "use of closed network connection" write error, and — treated as a generic write failure — fall into `reconnect()`, silently re-establishing a brand-new socket to a syslog target the caller believed was torn down.
- Reachable via `EventReader.ReplaceSyslogClients` (`pkg/logging/ringbuf.go`), which swaps the client slice and Closes each old client outside the lock, racing `ForwardLogMsg`/`logEvent` goroutines that snapshot-then-release the client slice before calling `Send`.
- Fix: add a `closed bool` field (mu-guarded), set by `Close()` (which now also nils `s.conn`), and checked at the top of `Send()`/`SendBinary()` before touching the connection. `Close()` becomes terminal — no `Send` after `Close()` returns can dial.

## Test plan
- [x] `TestSendAfterCloseDoesNotResurrectConnection` / `TestSendBinaryAfterCloseDoesNotResurrectConnection` — use a `closedAwareConn` fake that faithfully errors on `Write` once closed (not a bare always-succeeds fake, which would mask the bug), plus a dial counter; assert Send/SendBinary after Close fail immediately and never dial.
- [x] `TestCloseNilsConn` / `TestCloseIdempotent` — lock down the nil-conn and double-Close-safe behavior.
- [x] RED-on-revert confirmed: removing the closed-flag checks and conn-nilling reproduces the exact bug (Send after Close silently succeeds by dialing a fresh connection).
- [x] `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/logging/...` and `go build ./...` green.
- [x] `gofmt -l` clean on touched files.

Closes #4806

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi