### PR TITLE
routing: report probePinManager.clear() netlink dump failures

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43734,3 +43734,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: Fix #4810 — loadRollbackHistory skipped an unreadable/corrupt intermediate rollback slot with a bare `continue`, collapsing every later slot's positional index down by one, so `rollback N` silently resolved to slot N+1's config; push a tombstone (nil-Config) HistoryEntry to preserve position==slot-number, add Store.rollbackEntry() to reject a tombstoned slot with a clear error (used by Rollback + all ShowRollback*/ShowCompareRollback* readers), and guard saveRollbackFiles against writing/dereferencing a tombstone on the next commit; add RED-on-revert tests for the index-shift, the Rollback(n) end-to-end symptom, and the save-side nil-deref panic risk
   **File(s)**: pkg/configstore/store_commit.go, pkg/configstore/store_format.go, pkg/configstore/durability_3441_test.go
+
+- **Timestamp**: 2026-07-09
+  **Action**: Fix #4822 — probePinManager.clear() swallowed RuleList/RouteListFiltered netlink dump errors with a bare `continue` and always returned nil, making Apply()'s wired-up error-log dead code; aggregate dump errors with errors.Join (mirroring pkg/routing/rules.go) so a failed dump is observable while per-item RuleDel/RouteDel failures on successfully-enumerated items stay Debug-only best-effort (unchanged); add RED-on-revert tests for both dump-failure paths plus a partial-failure test proving the other family's band still gets reclaimed
+  **File(s)**: pkg/routing/probe_pin.go, pkg/routing/probe_pin_test.go

--- a/pkg/routing/probe_pin.go
+++ b/pkg/routing/probe_pin.go
@@ -20,6 +20,7 @@
 package routing
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -242,10 +243,22 @@ func (p *probePinManager) Apply(pins []ProbePin) map[string]error {
 // clear removes all ip rules in the probe-pin priority band and flushes
 // every route in the reserved probe tables (both families). Run at
 // daemon startup as well so a crashed daemon never leaks stale pins.
+//
+// A RuleList/RouteListFiltered dump failure is aggregated and returned
+// (errors.Join, mirroring the pattern in rules.go) rather than silently
+// skipped (#4822): a swallowed dump failure meant clear()'s wired-up
+// error return could never fire, so Apply()'s caller had no way to detect
+// an incomplete band clear (stale rules/routes from a removed pin can
+// survive and mis-route a later probe cycle). Per-item RuleDel/RouteDel
+// failures on an item we DID enumerate stay Debug-only best-effort — the
+// band clear() on the NEXT apply remains the backstop for those, same as
+// before.
 func (p *probePinManager) clear() error {
+	var errs []error
 	for _, family := range []int{unix.AF_INET, unix.AF_INET6} {
 		rules, err := p.ops.RuleList(family)
 		if err != nil {
+			errs = append(errs, fmt.Errorf("rule list (family %d): %w", family, err))
 			continue
 		}
 		for _, r := range rules {
@@ -261,6 +274,7 @@ func (p *probePinManager) clear() error {
 			routes, err := p.ops.RouteListFiltered(family,
 				&netlink.Route{Table: table}, netlink.RT_FILTER_TABLE)
 			if err != nil {
+				errs = append(errs, fmt.Errorf("route list (family %d, table %d): %w", family, table, err))
 				continue
 			}
 			for i := range routes {
@@ -271,5 +285,5 @@ func (p *probePinManager) clear() error {
 			}
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }

--- a/pkg/routing/probe_pin_test.go
+++ b/pkg/routing/probe_pin_test.go
@@ -21,6 +21,11 @@ type fakeProbePinOps struct {
 	failRouteAdd map[int]error  // route table → error
 	failRuleDel  map[int]error  // rule priority → error (rollback failure)
 	ruleDelCalls int
+
+	// #4822: dump-failure injection for clear()'s RuleList/RouteListFiltered
+	// error-aggregation test.
+	failRuleList          map[int]error // family → error
+	failRouteListFiltered map[int]error // table → error
 }
 
 func (f *fakeProbePinOps) RuleAdd(r *netlink.Rule) error {
@@ -46,6 +51,9 @@ func (f *fakeProbePinOps) RuleDel(r *netlink.Rule) error {
 }
 
 func (f *fakeProbePinOps) RuleList(family int) ([]netlink.Rule, error) {
+	if err, ok := f.failRuleList[family]; ok {
+		return nil, err
+	}
 	var out []netlink.Rule
 	for _, r := range f.rules {
 		if r.Family == family {
@@ -74,6 +82,9 @@ func (f *fakeProbePinOps) RouteDel(r *netlink.Route) error {
 }
 
 func (f *fakeProbePinOps) RouteListFiltered(family int, filter *netlink.Route, _ uint64) ([]netlink.Route, error) {
+	if err, ok := f.failRouteListFiltered[filter.Table]; ok {
+		return nil, err
+	}
 	var out []netlink.Route
 	for _, r := range f.routes {
 		if r.Table != filter.Table {
@@ -252,6 +263,65 @@ func TestProbePinClearRemovesOnlyBand(t *testing.T) {
 	}
 	if len(ops.routes) != 1 || ops.routes[0].Table != 254 {
 		t.Fatalf("probe-table routes not flushed (or main-table route lost): %+v", ops.routes)
+	}
+}
+
+// TestProbePinClearReportsRuleListFailure is the #4822 RED-on-revert guard:
+// a RuleList dump failure must make clear() return a non-nil error instead
+// of being silently swallowed. Before the fix, clear() unconditionally
+// returned nil even when every family's dump failed, so Apply()'s
+// slog.Warn("failed to clear probe pin band", ...) — the only observable
+// signal of an incomplete band clear — could never fire.
+func TestProbePinClearReportsRuleListFailure(t *testing.T) {
+	ops := &fakeProbePinOps{
+		links:        map[string]int{},
+		failRuleList: map[int]error{unix.AF_INET: fmt.Errorf("injected ENOBUFS")},
+	}
+	p := &probePinManager{ops: ops}
+	if err := p.clear(); err == nil {
+		t.Fatal("clear() = nil error, want non-nil after an injected RuleList failure")
+	}
+}
+
+// TestProbePinClearReportsRouteListFilteredFailure is the #4822
+// RED-on-revert guard for the RouteListFiltered dump-failure path,
+// mirroring TestProbePinClearReportsRuleListFailure above.
+func TestProbePinClearReportsRouteListFilteredFailure(t *testing.T) {
+	ops := &fakeProbePinOps{
+		links:                 map[string]int{},
+		failRouteListFiltered: map[int]error{config.ProbeTableBase: fmt.Errorf("injected ENOBUFS")},
+	}
+	p := &probePinManager{ops: ops}
+	if err := p.clear(); err == nil {
+		t.Fatal("clear() = nil error, want non-nil after an injected RouteListFiltered failure")
+	}
+}
+
+// TestProbePinClearStillReclaimsOnPartialDumpFailure asserts the fix does
+// not regress the #1827/AGY r2-3 startup-cleanup goal: when only ONE
+// family's RuleList fails, the OTHER family's band is still cleared (and
+// clear() still reports the partial failure via a non-nil error) — an
+// aggregated error must not turn back into a silent early return that skips
+// remaining, healthy families.
+func TestProbePinClearStillReclaimsOnPartialDumpFailure(t *testing.T) {
+	_, stale, _ := net.ParseCIDR("2001:db8::1/128")
+	ops := &fakeProbePinOps{
+		links:        map[string]int{},
+		failRuleList: map[int]error{unix.AF_INET: fmt.Errorf("injected ENOBUFS")},
+		rules: []netlink.Rule{
+			{Priority: config.ProbeRulePriorityBase, Family: unix.AF_INET6, Table: config.ProbeTableBase},
+		},
+		routes: []netlink.Route{
+			{Table: config.ProbeTableBase, Dst: stale},
+		},
+	}
+	p := &probePinManager{ops: ops}
+	err := p.clear()
+	if err == nil {
+		t.Fatal("clear() = nil error, want non-nil (AF_INET RuleList failed)")
+	}
+	if len(ops.rules) != 0 {
+		t.Fatalf("AF_INET6 band rule survived a partial (AF_INET-only) dump failure: %+v", ops.rules)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `probePinManager.clear()` (`pkg/routing/probe_pin.go`) swallowed `RuleList`/`RouteListFiltered` netlink dump errors with a bare `continue` and always returned `nil`, making `Apply()`'s existing `if err := p.clear(); err != nil { slog.Warn(...) }` dead code — a failed band-clear dump was completely invisible.
- Fix: aggregate the dump errors with `errors.Join`, mirroring the identical pattern already used elsewhere in `pkg/routing/rules.go`. Per-family/per-table `continue` semantics (reclaim what IS enumerable) are preserved; per-item `RuleDel`/`RouteDel` failures on successfully-enumerated items stay Debug-only best-effort, unchanged.

## Test plan
- [x] `TestProbePinClearReportsRuleListFailure` / `TestProbePinClearReportsRouteListFilteredFailure` — inject a dump error via new fake hooks, assert `clear()` returns non-nil.
- [x] `TestProbePinClearStillReclaimsOnPartialDumpFailure` — only one family's dump fails; asserts the OTHER family's band is still cleared and the error is still reported.
- [x] RED-on-revert confirmed for all three new tests.
- [x] `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/routing/...` and `go build ./...` green.
- [x] `gofmt -l` clean on touched files.

Closes #4822

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi