### PR TITLE
daemon: treat empty/wildcard host as non-loopback in REST bind clamp (#4903)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,24 @@
+## 2026-07-09 — #4903 daemon: empty-host `:port` wildcard bind bypassed the #4047 loopback clamp
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4903 (CRITICAL security). `hostIsLoopback` returned true for an
+  EMPTY host (`net.SplitHostPort(":8080")` → host "") and for an unparseable
+  host, so `clampBindToLoopback` did NOT clamp `--api-addr :8080` with no
+  api-auth — the mutating REST surface listened on ALL interfaces unauthenticated.
+  Fixed `hostIsLoopback`: empty host is the wildcard (all interfaces) → false;
+  an unparseable non-loopback host → false (fail safe, gets clamped when no-auth);
+  a genuine loopback IP (127.0.0.0/8, ::1) still true, and the literal
+  "localhost" is special-cased true (a loopback spelling that is not a parseable
+  IP). Sole caller is `clampBindToLoopback` → the REST clamp in `daemon_run.go`;
+  the cluster-bind helpers do NOT use `hostIsLoopback`, so blast radius is the
+  REST clamp only. Updated the clamp doc comment + `docs/architecture.md`.
+  **File(s)**: pkg/daemon/daemon_cluster_bind.go,
+  pkg/daemon/web_management_clamp_4047_test.go, docs/architecture.md
+  **Validation**: extended the #4047 tables with `:8080`/`[::]:8080`/`bad_host:8080`/
+  `localhost:8080`/`""`/`::`/`localhost` cases; RED-on-revert confirmed (revert →
+  `hostIsLoopback("")=true` and `:8080` not clamped fail). `go test ./pkg/daemon/`
+  green; `go build ./...` clean.
+
 ## 2026-07-09 — #4752 observability: deterministic-NAT pool block-utilization metric
 
 - **Timestamp**: 2026-07-09

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,7 +193,12 @@ editing cmdtree.
     when the resolved bind is non-loopback and `apiCfg.Auth == nil`, pulls the
     bind back to a same-family loopback (`127.0.0.1` for IPv4, `::1` for IPv6,
     port preserved) and WARNs — so a leniently-loaded vulnerable config comes up
-    on loopback (console/SSH remain the lifeline) instead of exposed. The bind
+    on loopback (console/SSH remain the lifeline) instead of exposed. The
+    non-loopback test (`hostIsLoopback`) treats the Go wildcard spelling
+    `:port`/`[::]:port` (an empty or unspecified host after `SplitHostPort`) and
+    any unparseable host as **non-loopback** so `--api-addr :8080` with no
+    api-auth is clamped, not left listening on every interface (#4903); only a
+    genuine loopback IP or the literal `localhost` is exempt. The bind
     address is built with `net.JoinHostPort` so an IPv6 mgmt address is bracketed
     and both the clamp and `net.Listen` parse it. Adding api-auth and recommitting
     restores the off-loopback bind. HTTPS is covered by the same rule

--- a/pkg/daemon/daemon_cluster_bind.go
+++ b/pkg/daemon/daemon_cluster_bind.go
@@ -50,20 +50,36 @@ func resolveInterfaceAddr(ifname, fallback string) string {
 	return fallback
 }
 
-// hostIsLoopback reports whether a bind host string is a loopback address. An
-// empty or unparseable host is treated as loopback (safe — do NOT clamp on
-// uncertainty and break a legitimate bind); resolveInterfaceAddr always returns
-// a literal IP (or the loopback fallback), so in practice host is a parseable
-// IP. Used by the #4047 part-B runtime clamp (daemon_run.go) to decide whether a
+// hostIsLoopback reports whether a bind host string is a loopback address.
+// Used by the #4047 part-B runtime clamp (daemon_run.go) to decide whether a
 // no-auth web-management bind is network-reachable and must be pulled back to
 // loopback.
+//
+// An EMPTY host is the Go wildcard bind spelling — `net.SplitHostPort(":8080")`
+// yields host "" and listens on ALL interfaces (0.0.0.0 / ::). It is emphatically
+// NOT loopback. Treating it as loopback (the pre-#4903 behaviour) let an
+// unauthenticated `--api-addr :8080` escape the clamp and expose the mutating
+// REST surface network-wide (#4903), exactly the exposure this clamp exists to
+// prevent. An unparseable, non-loopback host is likewise treated as NON-loopback
+// so the no-auth clamp errs toward pulling the bind back to loopback (fail safe)
+// rather than leaving a possibly network-reachable bind exposed. The lone
+// exception is the literal hostname "localhost": it is not a parseable IP but is
+// a legitimate loopback bind spelling that conventionally resolves to loopback,
+// so it stays classified as loopback and is not clamped.
 func hostIsLoopback(host string) bool {
 	if host == "" {
+		// Wildcard bind (all interfaces) — never loopback.
+		return false
+	}
+	if host == "localhost" {
+		// Not a parseable IP, but a legitimate loopback bind spelling.
 		return true
 	}
 	ip := net.ParseIP(host)
 	if ip == nil {
-		return true
+		// Unparseable and not "localhost": fail safe, treat as non-loopback so
+		// a no-auth bind gets clamped rather than left exposed.
+		return false
 	}
 	return ip.IsLoopback()
 }
@@ -75,10 +91,13 @@ func hostIsLoopback(host string) bool {
 // AND unauthenticated — that is the exact case where the unauthenticated
 // mutating config endpoints would otherwise be reachable from the network. The
 // clamp targets a loopback of the SAME address family (::1 for an IPv6 bind,
-// 127.0.0.1 for IPv4) and preserves the port. An authenticated bind, a loopback
-// bind, or an unparseable address is returned unchanged (do not clamp on
-// uncertainty and break a legitimate bind — resolveInterfaceAddr yields a
-// literal IP, so an unparseable host is not expected in practice).
+// 127.0.0.1 for IPv4) and preserves the port. An authenticated bind or a
+// genuine loopback bind (127.0.0.0/8, ::1, or the literal "localhost") is
+// returned unchanged. A bind whose host part fails to parse as an address
+// (`net.SplitHostPort` errors, e.g. a bare no-port string) is also returned
+// unchanged, since there is no port to clamp; but a parsed wildcard/empty or
+// unparseable-but-split host is now classified NON-loopback by hostIsLoopback
+// and clamped when no-auth (fail safe, #4903).
 func clampBindToLoopback(addr string, hasAuth bool) (string, bool) {
 	if hasAuth {
 		return addr, false

--- a/pkg/daemon/web_management_clamp_4047_test.go
+++ b/pkg/daemon/web_management_clamp_4047_test.go
@@ -17,12 +17,14 @@ func TestHostIsLoopback(t *testing.T) {
 		{"127.0.0.1", true},    // canonical IPv4 loopback
 		{"127.0.0.5", true},    // anywhere in 127.0.0.0/8 is loopback
 		{"::1", true},          // IPv6 loopback
+		{"localhost", true},    // hostname (not a parseable IP) but a loopback spelling
 		{"10.0.0.5", false},    // routable IPv4 (RFC1918, but network-reachable)
 		{"192.168.1.1", false}, // routable IPv4
 		{"2001:db8::1", false}, // routable IPv6
 		{"0.0.0.0", false},     // wildcard bind — reachable on every interface
-		{"", true},             // empty host: treated as safe (do not clamp)
-		{"not-an-ip", true},    // unparseable: treated as safe (do not clamp)
+		{"::", false},          // IPv6 wildcard/unspecified — reachable everywhere
+		{"", false},            // #4903: empty host is the ":port" wildcard, NOT loopback
+		{"not-an-ip", false},   // #4903: unparseable, non-loopback => fail safe (clamp)
 	}
 	for _, c := range cases {
 		if got := hostIsLoopback(c.host); got != c.want {
@@ -52,7 +54,16 @@ func TestClampBindToLoopback(t *testing.T) {
 		{"v6 loopback untouched", "[::1]:8080", false, "[::1]:8080", false},
 		// Wildcard bind is off-loopback => clamped.
 		{"v4 wildcard no-auth clamps", "0.0.0.0:8080", false, "127.0.0.1:8080", true},
-		// Unparseable / no-port => left unchanged (do not clamp on uncertainty).
+		// #4903: the Go wildcard spelling ":port" (empty host) is all-interfaces,
+		// NOT loopback — it MUST clamp when unauthenticated (this is the bug).
+		{"empty-host wildcard no-auth clamps", ":8080", false, "127.0.0.1:8080", true},
+		{"empty-host wildcard with auth not clamped", ":8080", true, ":8080", false},
+		{"v6 empty-host wildcard no-auth clamps", "[::]:8080", false, "[::1]:8080", true},
+		// #4903: a split-but-unparseable host fails safe => clamped when no-auth.
+		{"unparseable split host no-auth clamps", "bad_host:8080", false, "127.0.0.1:8080", true},
+		// "localhost" is a loopback spelling => left unchanged.
+		{"localhost loopback untouched", "localhost:8080", false, "localhost:8080", false},
+		// Unparseable / no-port (SplitHostPort errors) => left unchanged (no port to clamp).
 		{"unparseable no-port untouched", "not-an-addr", false, "not-an-addr", false},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
## Summary

The #4047 part-B runtime clamp (`clampBindToLoopback`) pulls an off-loopback, unauthenticated web-management REST bind back to loopback so a leniently-loaded vulnerable config cannot expose the mutating config endpoints network-wide. It delegates the loopback decision to `hostIsLoopback`, which returned `true` for an **empty** host and for an **unparseable** host.

`net.SplitHostPort(":8080")` yields `host == ""` with no error — the Go wildcard bind spelling that listens on **all** interfaces. Because `hostIsLoopback("")` returned `true`, `xpfd --api-addr :8080` with no `web-management api-auth` was **not** clamped and bound every interface with `apiCfg.Auth == nil`, exposing the mutating REST surface off-loopback (`0.0.0.0:8080` was correctly clamped, but the equivalent `:8080` spelling slipped through).

## Fix

`hostIsLoopback`:
- Empty host = all-interfaces wildcard → `false` (gets clamped when no-auth).
- Unparseable, non-loopback host → `false` (fail safe → clamped).
- Genuine loopback IP (`127.0.0.0/8`, `::1`) → still `true`.
- Literal `localhost` → special-cased `true` (a loopback spelling that is not a parseable IP).

## Blast radius

`hostIsLoopback`'s only caller is `clampBindToLoopback`, itself only used by the REST clamp in `daemon_run.go`. The cluster-bind helpers (`selectClusterBindAddr`, `resolveClusterInterfaceAddr`, `parseLiteralIP`) do **not** use `hostIsLoopback`, so legitimate cluster/loopback binds are unaffected. The change only makes the no-auth clamp more aggressive (fail safe) — it can never expose a bind, only clamp one it cannot prove is loopback.

## Tests

Extended the #4047 decision tables with `:8080` / `[::]:8080` wildcard, `bad_host:8080` split-but-unparseable, `localhost:8080`, `""`, `::`, and `localhost` cases. RED-on-revert confirmed: reverting the source makes `hostIsLoopback("")=true` and `clampBindToLoopback(":8080", false)` not-clamp fail. `go test ./pkg/daemon/` green; `go build ./...` clean. Updated the clamp doc comment and `docs/architecture.md`.

Closes #4903