### PR TITLE
config,daemon: validate system login user name to block sudoers injection (#4895)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,27 @@
+## 2026-07-09 — #4895 security: validate `system login user <name>` (sudoers injection)
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4895 (CRITICAL, CWE-74). `system login user <name>` was an
+  untyped keyed instance with no username validator; the daemon formats the raw
+  key into an /etc/sudoers.d/xpf-<name> NOPASSWD grant, and the lexer decodes
+  `\n` in a quoted string to a literal newline, so `user "x\nnobody ALL=(ALL)
+  NOPASSWD: ALL"` injected a second valid sudoers line that passed visudo and
+  installed. Fix (defense in depth): (1) PRIMARY — added
+  `config.ValidateLoginUsername` (`^[a-z_][a-z0-9_-]*$`, <=32 chars) wired as the
+  `keyValidator` on the login `user` container in schema_system.go → strict
+  commit-check, lenient-warn on load/sync per #1960; (2) DEFENSE —
+  `reconcileSudoers` skips any super-user whose name fails validation and
+  `writeSudoersGrant` re-validates at entry and refuses to format an unvalidated
+  name into sudoers (closes the lenient-load / HA config-sync bypass).
+  **File(s)**: pkg/config/schema_validators.go, pkg/config/schema_system.go,
+  pkg/daemon/daemon_system.go, pkg/config/login_username_4895_test.go,
+  pkg/daemon/daemon_sudoers_username_4895_test.go, docs/config-schema.md
+  **Validation**: unit table + schema-gate tests (hierarchical + flat-set) +
+  daemon-defense tests. RED-on-revert confirmed: reverting the schema+daemon
+  wiring makes the injection commit clean AND writes the literal
+  `xpf-x\nnobody...` sudoers file. Full `go test ./pkg/config/ ./pkg/daemon/`
+  green; `go build ./...` clean.
+
 ## 2026-07-09 — #4752 observability: deterministic-NAT pool block-utilization metric
 
 - **Timestamp**: 2026-07-09

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -5665,6 +5665,42 @@ or installed a blackhole, with no signal. The SSOT is `staticRouteNode()` in
 `routing-instances` static blocks. Regression + fail-on-revert tests:
 `pkg/config/schema_validate_route_2448_test.go`.
 
+### #4895 — `system login user <name>` identity validated (sudoers injection)
+
+`system login user <name>` was an untyped keyed instance with NO username
+validator. The daemon writes an `/etc/sudoers.d/xpf-<name>` NOPASSWD grant for
+every `class super-user` account by formatting the raw config key directly into
+sudoers syntax (`writeSudoersGrant`, `pkg/daemon/daemon_system.go`). Because the
+lexer decodes `\n` inside a quoted string into a literal newline
+(`lexer.readString`), a crafted key such as
+
+    set system login user "x\nnobody ALL=(ALL) NOPASSWD: ALL" class super-user
+
+materialized a username containing a newline, and the grant writer emitted TWO
+valid sudoers lines. Both pass `visudo -cf` (a syntax checker, not a containment
+checker), so the drop-in installed and granted an unmodeled account passwordless
+root (CWE-74).
+
+- **schema (PRIMARY)** — the `user` login container uses `keyValidator:
+  ValidateLoginUsername` (`keyValueType: ValueIdentifier`), a safe POSIX
+  account shape `^[a-z_][a-z0-9_-]*$` capped at 32 characters. A name with a
+  newline, whitespace, `/`, `:`, `,`, `=`, a leading hyphen, uppercase, or a
+  leading digit is a commit error. Strict on the operator commit path,
+  downgraded to a warning on the tolerant Load / SyncApply path
+  (`compileTreeLenient`), the same #1960 doctrine as the other typed leaves.
+- **daemon (DEFENSE)** — `reconcileSudoers` SKIPS any super-user whose name
+  fails `ValidateLoginUsername` (neither desired nor written, so a stale grant
+  is also revoked), and `writeSudoersGrant` re-validates the name at entry and
+  refuses to format an unvalidated name into sudoers. This closes the
+  lenient-load / HA config-sync bypass where a bad name reaches the writer
+  despite the downgraded commit gate.
+
+The validator lives in `schema_validators.go` (shared symbol
+`config.ValidateLoginUsername`); the schema wiring is in `schema_system.go`.
+Regression + fail-on-revert tests: `pkg/config/login_username_4895_test.go`
+(schema gate, hierarchical + flat-set) and
+`pkg/daemon/daemon_sudoers_username_4895_test.go` (daemon defense).
+
 ### #2978 — BGP `multipath ibgp` (iBGP ECMP / `maximum-paths ibgp`)
 
 `set protocols bgp multipath ibgp` enables iBGP equal-cost multipath. FRR's

--- a/pkg/config/login_username_4895_test.go
+++ b/pkg/config/login_username_4895_test.go
@@ -1,0 +1,119 @@
+package config_test
+
+// Regression tests for #4895: `system login user <name>` was an untyped keyed
+// instance with NO username validator. The daemon writes an
+// /etc/sudoers.d/xpf-<name> NOPASSWD grant by formatting the raw config key
+// directly into sudoers syntax, and the lexer decodes `\n` inside a quoted
+// string into a literal newline — so a crafted username like
+//
+//	user "x\nnobody ALL=(ALL) NOPASSWD: ALL" class super-user
+//
+// injects a second, valid sudoers directive that passes visudo and is durably
+// installed (unmodeled passwordless root).
+//
+// The fix adds a strict commit-check keyValidator (ValidateLoginUsername) on
+// the login `user` container: a name must match a safe POSIX account shape
+// (^[a-z_][a-z0-9_-]*$, <=32 chars). This test pins that gate.
+//
+// Fail-on-revert: strip keyValidator from the `user` node (or run against
+// origin/master) and every "Rejects" case below stops erroring — that is the
+// pre-fix silent-accept behaviour.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// --- ValidateLoginUsername unit table -----------------------------------
+
+func TestValidateLoginUsername_Table(t *testing.T) {
+	valid := []string{"admin", "netadmin", "user1", "read_only", "a", "_svc", "op-2", strings.Repeat("a", 32)}
+	for _, name := range valid {
+		if err := config.ValidateLoginUsername(name, nil); err != nil {
+			t.Errorf("ValidateLoginUsername(%q) = %v, want nil", name, err)
+		}
+	}
+
+	invalid := []string{
+		"",                                  // empty
+		"x\nnobody ALL=(ALL) NOPASSWD: ALL", // #4895 embedded-newline injection
+		"has space",                         // whitespace
+		"has\ttab",                          // tab
+		"-leadinghyphen",                    // leading hyphen (getopt hazard)
+		"UPPER",                             // uppercase (outside the safe POSIX shape)
+		"a/b",                               // slash (path/sudoers metachar)
+		"a:b",                               // colon
+		"a,b",                               // comma (sudoers list separator)
+		"a=b",                               // equals (sudoers directive)
+		"a b ALL=(ALL) NOPASSWD: ALL",       // space-injection
+		"9leadingdigit",                     // must start with letter/underscore
+		strings.Repeat("a", 33),             // over the length cap
+	}
+	for _, name := range invalid {
+		if err := config.ValidateLoginUsername(name, nil); err == nil {
+			t.Errorf("ValidateLoginUsername(%q) = nil, want error", name)
+		}
+	}
+}
+
+// --- Commit-check gate: hierarchical (imported Junos) shape -------------
+
+// The `\n` in the raw string below is literally backslash-n; the lexer decodes
+// it to a newline, reproducing the injection key exactly.
+func TestSchema4895_LoginUsername_RejectsNewlineInjection_Hierarchical(t *testing.T) {
+	err := schemaCheck(t, `system {
+    login {
+        user "x\nnobody ALL=(ALL) NOPASSWD: ALL" {
+            class super-user;
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("expected error for login user name with embedded newline, got nil (sudoers injection would be accepted)")
+	}
+}
+
+func TestSchema4895_LoginUsername_RejectsMetachar_Hierarchical(t *testing.T) {
+	err := schemaCheck(t, `system {
+    login {
+        user "bad name" {
+            class super-user;
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("expected error for login user name with whitespace, got nil")
+	}
+}
+
+// A normal username must still commit clean.
+func TestSchema4895_LoginUsername_AcceptsNormal_Hierarchical(t *testing.T) {
+	if err := schemaCheck(t, `system {
+    login {
+        user admin {
+            class super-user;
+        }
+    }
+}`); err != nil {
+		t.Fatalf("normal login user name rejected: %v", err)
+	}
+}
+
+// --- Commit-check gate: flat-set shape ----------------------------------
+
+func TestSchema4895_LoginUsername_RejectsNewlineInjection_FlatSet(t *testing.T) {
+	err := flatSchemaCheck(t,
+		`set system login user "x\nnobody ALL=(ALL) NOPASSWD: ALL" class super-user`)
+	if err == nil {
+		t.Fatal("expected error for flat-set login user name with embedded newline, got nil")
+	}
+}
+
+func TestSchema4895_LoginUsername_AcceptsNormal_FlatSet(t *testing.T) {
+	if err := flatSchemaCheck(t,
+		`set system login user admin class super-user`); err != nil {
+		t.Fatalf("normal flat-set login user name rejected: %v", err)
+	}
+}

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -215,29 +215,40 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 			"login-alarms":        {desc: "Display system alarms on login", children: nil},
 			"login-tip":           {desc: "Display a tip on login", children: nil},
 		}},
-		"user": {desc: "User name", args: 1, placeholder: "<username>", children: map[string]*schemaNode{
-			"uid": {desc: "User ID", args: 1, placeholder: "<uid>", children: nil},
-			// #2008 H6 / #4304 S-2: the class is validated against the
-			// system-defined built-ins UNION any custom `login class <name>`
-			// defined in the SAME candidate tree. The tree-aware validator
-			// replaces the fixed enum so a valid custom-RBAC config is no
-			// longer hard-rejected at commit, while an undefined class still
-			// fails closed. RBAC enforcement is in pkg/cli/permissions.go.
-			"class": {desc: "Login class", args: 1, placeholder: "<class>",
-				valueType: ValueEnumOf, valueDesc: "System-defined class (super-user | operator | read-only | config-viewer | unauthorized) or a custom `login class <name>`",
-				valueExamples: []string{"super-user", "operator", "read-only"},
-				treeValidator: validateLoginClassRef, children: nil},
-			// #1944: close the schema asymmetry the compiler already
-			// half-implemented — give `authentication` a value-bearing
-			// children map (encrypted-password typed leaf + ssh-* keys).
-			"authentication": {desc: "Authentication methods", children: map[string]*schemaNode{
-				"encrypted-password": {desc: "Encrypted password", args: 1, placeholder: "<crypt-hash>",
-					valueType: ValueCryptHash, validator: ValidateCryptHash, children: nil},
-				"ssh-ed25519": {desc: "SSH ED25519 public key", args: 1, placeholder: "<key>", children: nil},
-				"ssh-rsa":     {desc: "SSH RSA public key", args: 1, placeholder: "<key>", children: nil},
-				"ssh-dsa":     {desc: "SSH DSA public key", args: 1, placeholder: "<key>", children: nil},
+		// #4895: the login user NAME is a keyed identity token that the daemon
+		// formats verbatim into an /etc/sudoers.d/xpf-<name> NOPASSWD grant.
+		// The lexer decodes `\n` inside a quoted string into a literal newline,
+		// so an unvalidated name can inject additional sudoers directives. The
+		// keyValidator (typed KEY slot, #1319 PR 3) validates the identity arg
+		// token against a safe POSIX account-name shape at commit-check —
+		// strict on commit, warn on the tolerant load/sync path (#1960). The
+		// daemon's writeSudoersGrant/reconcileSudoers apply the SAME check
+		// defensively so a leniently-loaded name still never reaches sudoers.
+		"user": {desc: "User name", args: 1, placeholder: "<username>",
+			keyValueType: ValueIdentifier, keyValueDesc: "POSIX login user name (lowercase letter/underscore then [a-z0-9_-])",
+			keyValidator: ValidateLoginUsername, children: map[string]*schemaNode{
+				"uid": {desc: "User ID", args: 1, placeholder: "<uid>", children: nil},
+				// #2008 H6 / #4304 S-2: the class is validated against the
+				// system-defined built-ins UNION any custom `login class <name>`
+				// defined in the SAME candidate tree. The tree-aware validator
+				// replaces the fixed enum so a valid custom-RBAC config is no
+				// longer hard-rejected at commit, while an undefined class still
+				// fails closed. RBAC enforcement is in pkg/cli/permissions.go.
+				"class": {desc: "Login class", args: 1, placeholder: "<class>",
+					valueType: ValueEnumOf, valueDesc: "System-defined class (super-user | operator | read-only | config-viewer | unauthorized) or a custom `login class <name>`",
+					valueExamples: []string{"super-user", "operator", "read-only"},
+					treeValidator: validateLoginClassRef, children: nil},
+				// #1944: close the schema asymmetry the compiler already
+				// half-implemented — give `authentication` a value-bearing
+				// children map (encrypted-password typed leaf + ssh-* keys).
+				"authentication": {desc: "Authentication methods", children: map[string]*schemaNode{
+					"encrypted-password": {desc: "Encrypted password", args: 1, placeholder: "<crypt-hash>",
+						valueType: ValueCryptHash, validator: ValidateCryptHash, children: nil},
+					"ssh-ed25519": {desc: "SSH ED25519 public key", args: 1, placeholder: "<key>", children: nil},
+					"ssh-rsa":     {desc: "SSH RSA public key", args: 1, placeholder: "<key>", children: nil},
+					"ssh-dsa":     {desc: "SSH DSA public key", args: 1, placeholder: "<key>", children: nil},
+				}},
 			}},
-		}},
 	}},
 	"dataplane-type": {desc: "Dataplane type", args: 1, placeholder: "<type>", children: nil},
 	"dataplane": {desc: "Dataplane configuration", children: map[string]*schemaNode{

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"math"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -184,3 +185,46 @@ const (
 	// Rust helper backstops the lower bound too (RoutePreferenceOutOfRange).
 	maxWireI32 = int64(math.MaxInt32)
 )
+
+// maxLoginUsernameLen caps a `system login user <name>` identity token. The
+// classic Linux useradd/UT_NAMESIZE practical limit is 32; keeping the cap
+// there also bounds the derived /etc/sudoers.d/xpf-<name> filename and the
+// grant line the daemon writes.
+const maxLoginUsernameLen = 32
+
+// loginUsernameRE is the safe POSIX/Linux account-name shape a `system login
+// user <name>` identity must match: a lowercase letter or underscore, then
+// lowercase letters, digits, underscores, or hyphens. It deliberately excludes
+// whitespace, newlines, `/`, `:`, quotes, and every sudoers metacharacter so a
+// crafted username cannot be formatted into an /etc/sudoers.d grant to inject
+// additional directives (#4895 — the lexer decodes `\n` inside a quoted string
+// into a literal newline, so a name like "x\nnobody ALL=(ALL) NOPASSWD: ALL"
+// would otherwise smuggle a second sudoers line past visudo's syntax check).
+var loginUsernameRE = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
+
+// ValidateLoginUsername is the commit-check validator for a `system login user
+// <name>` identity token (wired as the schema keyValidator on the user
+// container in schema_system.go). It rejects any name that is empty, over
+// maxLoginUsernameLen, or does not match loginUsernameRE — the defense against
+// the #4895 sudoers-injection path where the daemon formats the raw config key
+// into /etc/sudoers.d/xpf-<name>. It is strict on the operator commit path and
+// downgraded to a warning on the tolerant Load / SyncApply path
+// (compileTreeLenient), the same #1960 doctrine as the other typed-leaf gates;
+// the daemon's writeSudoersGrant/reconcileSudoers apply the SAME check
+// defensively so a leniently-loaded or peer-synced bad name still never reaches
+// the sudoers writer. The *Config arg is unused (part of the LeafValidator
+// contract); daemon callers pass nil.
+func ValidateLoginUsername(raw string, _ *Config) error {
+	if raw == "" {
+		return fmt.Errorf("login user name must not be empty")
+	}
+	if len(raw) > maxLoginUsernameLen {
+		return fmt.Errorf("login user name %q too long (max %d characters)", raw, maxLoginUsernameLen)
+	}
+	if !loginUsernameRE.MatchString(raw) {
+		return fmt.Errorf("invalid login user name %q (must match %s: a lowercase letter or underscore "+
+			"followed by lowercase letters, digits, underscores, or hyphens; no whitespace, newlines, or "+
+			"sudoers metacharacters)", raw, loginUsernameRE.String())
+	}
+	return nil
+}

--- a/pkg/daemon/daemon_sudoers_username_4895_test.go
+++ b/pkg/daemon/daemon_sudoers_username_4895_test.go
@@ -1,0 +1,84 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #4895 defense-in-depth: even if a crafted `system login user <name>` slips
+// past the strict commit-check (e.g. the tolerant load / peer-sync path
+// downgrades the schema gate to a warning per #1960), the daemon's sudoers
+// writer must NEVER format an unvalidated name into an /etc/sudoers.d grant.
+// The config lexer decodes `\n` in a quoted string into a literal newline, so
+// a name like "x\nnobody ALL=(ALL) NOPASSWD: ALL" would otherwise inject a
+// second valid sudoers directive (unmodeled passwordless root).
+
+// injectionName is the crafted key: an embedded newline followed by a second
+// sudoers directive. In real config the lexer materializes this from a quoted
+// "\n"; here the literal newline is the post-lexer form.
+const injectionName = "x\nnobody ALL=(ALL) NOPASSWD: ALL"
+
+// TestWriteSudoersGrantRefusesInjection proves writeSudoersGrant refuses a name
+// that fails ValidateLoginUsername and never writes a file. RED on revert: drop
+// the guard and the durable write proceeds, installing the injected directive.
+func TestWriteSudoersGrantRefusesInjection(t *testing.T) {
+	dir := withSudoersTestDir(t)
+
+	if err := writeSudoersGrant(injectionName); err == nil {
+		t.Fatal("writeSudoersGrant accepted an injection username — must refuse")
+	}
+	// No file may have been written under the managed namespace.
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Fatalf("writeSudoersGrant wrote %d file(s) for an invalid name, want 0: %v", len(entries), entries)
+	}
+}
+
+// TestWriteSudoersGrantAcceptsNormal proves the guard does not regress the
+// normal path: a valid name still gets its grant with the expected content.
+func TestWriteSudoersGrantAcceptsNormal(t *testing.T) {
+	dir := withSudoersTestDir(t)
+
+	if err := writeSudoersGrant("admin"); err != nil {
+		t.Fatalf("writeSudoersGrant(admin) = %v, want nil", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "xpf-admin"))
+	if err != nil {
+		t.Fatalf("admin grant not written: %v", err)
+	}
+	if want := "admin ALL=(ALL) NOPASSWD: ALL\n"; string(got) != want {
+		t.Errorf("admin grant = %q, want %q", got, want)
+	}
+}
+
+// TestReconcileSudoersSkipsInjectionName proves reconcileSudoers skips a
+// super-user whose name is unsafe: no drop-in is written and a valid peer in
+// the same config still gets its grant.
+func TestReconcileSudoersSkipsInjectionName(t *testing.T) {
+	dir := withSudoersTestDir(t)
+	d := &Daemon{}
+
+	cfg := loginCfg(
+		&config.LoginUser{Name: injectionName, Class: "super-user"},
+		&config.LoginUser{Name: "admin", Class: "super-user"},
+	)
+	d.reconcileSudoers(cfg)
+
+	// The injected directive must not appear anywhere in the managed namespace.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if e.Name() == "xpf-admin" {
+			continue
+		}
+		t.Errorf("unexpected sudoers file written for an invalid name: %q", e.Name())
+	}
+	// The valid peer still gets its grant.
+	if got, err := os.ReadFile(filepath.Join(dir, "xpf-admin")); err != nil {
+		t.Fatalf("valid peer admin grant not written: %v", err)
+	} else if want := "admin ALL=(ALL) NOPASSWD: ALL\n"; string(got) != want {
+		t.Errorf("admin grant = %q, want %q", got, want)
+	}
+}

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -906,6 +906,17 @@ func (d *Daemon) reconcileSudoers(cfg *config.Config) {
 			if user.Class != "super-user" {
 				continue
 			}
+			// #4895 defense in depth: never format an unvalidated username into
+			// an /etc/sudoers.d grant. Strict commit-check rejects a crafted
+			// name (schema keyValidator), but the tolerant load / peer-sync path
+			// downgrades that to a warning (#1960), so a bad name can still reach
+			// here. Skip it entirely: neither desire nor write it, so any stale
+			// grant is also revoked by the sweep below.
+			if err := config.ValidateLoginUsername(user.Name, nil); err != nil {
+				slog.Warn("refusing sudoers grant for invalid login user name",
+					"user", user.Name, "err", err)
+				continue
+			}
 			desired[sudoersPrefix+user.Name] = struct{}{}
 			if err := writeSudoersGrant(user.Name); err != nil {
 				slog.Warn("failed to write sudoers file",
@@ -940,7 +951,18 @@ func (d *Daemon) reconcileSudoers(cfg *config.Config) {
 // generated file is validated with visudo; if validation fails the file is
 // removed rather than left as a lockout landmine (a broken drop-in breaks
 // ALL sudo invocations).
+//
+// #4895: the username is formatted verbatim into both the drop-in filename
+// and the grant line, and the config lexer decodes `\n` in a quoted string
+// into a literal newline. A name with a newline/whitespace/sudoers
+// metacharacter would inject additional directives that pass visudo's syntax
+// check. Re-validate defensively here — never format an unvalidated name into
+// sudoers, even if a caller bypassed reconcileSudoers' skip or the strict
+// commit-check gate was downgraded on a tolerant load (#1960).
 func writeSudoersGrant(user string) error {
+	if err := config.ValidateLoginUsername(user, nil); err != nil {
+		return fmt.Errorf("refusing sudoers grant for invalid login user name %q: %w", user, err)
+	}
 	path := filepath.Join(sudoersDir, sudoersPrefix+user)
 	line := fmt.Sprintf("%s ALL=(ALL) NOPASSWD: ALL\n", user)
 	if current, _ := os.ReadFile(path); string(current) == line {


### PR DESCRIPTION
## Summary

`system login user <name>` was an untyped keyed instance with **no** username validator. The daemon writes an `/etc/sudoers.d/xpf-<name>` NOPASSWD grant for every `class super-user` account by formatting the raw config key verbatim into sudoers syntax (`writeSudoersGrant`). The config lexer decodes `\n` inside a quoted string into a literal newline, so a crafted key

```
set system login user "x\nnobody ALL=(ALL) NOPASSWD: ALL" class super-user
```

materialized a username containing a newline and the grant writer emitted **two** valid sudoers lines. Both pass `visudo -cf` (a syntax checker, not a containment checker), so the drop-in installed and granted an unmodeled account passwordless root (CWE-74). The trigger surface is broader than interactive commit — HA config-sync from a peer and the lenient/tolerant config load also set the key.

## Fix (defense in depth)

1. **PRIMARY (commit-time)** — new `config.ValidateLoginUsername`, a safe POSIX account-name gate (`^[a-z_][a-z0-9_-]*$`, ≤32 chars) rejecting newlines, whitespace, `/`, `:`, `,`, `=`, leading hyphen, uppercase, and leading digits. Wired as the `keyValidator` on the login `user` container (`schema_system.go`). Strict on the operator commit path, downgraded to a warning on the tolerant Load / SyncApply path (`compileTreeLenient`) per #1960.
2. **DEFENSE (apply-time)** — `reconcileSudoers` skips any super-user whose name fails validation (neither desired nor written, so a stale grant is also revoked), and `writeSudoersGrant` re-validates at entry and refuses to format an unvalidated name into sudoers. This closes the lenient-load / HA config-sync bypass where a bad name reaches the writer despite the downgraded commit gate.

## Tests

`ValidateLoginUsername` unit table; schema-gate rejection in both hierarchical (imported Junos) and flat-set shapes plus normal-name acceptance; daemon-defense tests proving `writeSudoersGrant` refuses the injection name and `reconcileSudoers` skips it while a valid peer still gets its grant. RED-on-revert: reverting the schema + daemon wiring makes the injection commit clean AND writes the literal `xpf-x\nnobody...` sudoers drop-in. Full `go test ./pkg/config/ ./pkg/daemon/` green; `go build ./...` clean. Documented in `docs/config-schema.md`.

Closes #4895