### PR TITLE
config: reject a stray top-level '}' instead of silently truncating (#4862)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,26 @@
+## 2026-07-09 — #4862 config parser: assert EOF so a stray top-level `}` is an error, not a silent truncation
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4862 (HIGH security, fail-open). `Parser.Parse()` never asserted
+  the lexer reached EOF, and `parseStatements()` breaks on a top-level
+  `TokenRBrace` identically to EOF — so a stray unmatched `}` made the parser
+  STOP with zero ParseErrors and silently drop every statement after it (e.g. an
+  imported Junos config's trailing `security`/`default-policy`). LoadOverride /
+  CheckText only gate on `len(errs)==0`, so the truncated (weaker) config
+  committed with no warning. Fixed `Parse()`: after the top-level
+  `parseStatements()`, loop asserting EOF — a leftover `}` (or any stray token)
+  is a ParseError naming its position, and the parser consumes it and resumes so
+  BOTH the error AND the trailing config surface (never silently dropped; the
+  error still fails the commit). Every iteration consumes >=1 token so the loop
+  always terminates; correctly-nested `{...}` blocks are unaffected
+  (parseStatement consumes each block's own `}`). No separate parser markdown
+  doc exists — the contract is the in-code `Parse()` comment, which I updated.
+  **File(s)**: pkg/config/parser.go, pkg/config/parser_stray_brace_4862_test.go
+  **Validation**: trailing-brace / mid-stream-with-trailing-config /
+  leading-brace error cases + well-formed + deep-nesting clean cases +
+  error-position case. RED-on-revert confirmed. Full `go test ./pkg/config/
+  ./pkg/configstore/ ./pkg/cli/ ./pkg/cmdtree/` green; `go build ./...` clean.
+
 ## 2026-07-09 — #4903 daemon: empty-host `:port` wildcard bind bypassed the #4047 loopback clamp
 
 - **Timestamp**: 2026-07-09

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -37,8 +37,34 @@ func NewParser(input string) *Parser {
 }
 
 // Parse parses the input and returns the configuration tree.
+//
+// After the top-level statement list, the lexer MUST be at EOF. parseStatements
+// breaks on a top-level TokenRBrace (a stray unmatched '}') identically to EOF,
+// so historically a single stray brace made Parse return the partial tree with
+// ZERO errors and silently drop every statement after the brace — a fail-open
+// config-acceptance path (#4862): LoadOverride / CheckText only gate on
+// len(errs)==0, so a truncated config (missing its security/default-policy
+// tail) committed as if it were the authored file. Assert EOF here. A leftover
+// '}' (or any other stray token) is a ParseError naming its position; rather
+// than discard the trailing config on the floor we consume the stray token and
+// resume parsing so BOTH the error and the remaining statements surface (the
+// error still fails the commit — the tree is never silently truncated). Every
+// iteration consumes at least the one stray token, so the loop always
+// terminates. Correctly nested '{ ... }' blocks are unaffected: parseStatement
+// consumes each block's own closing '}', so only an unmatched top-level '}'
+// reaches this check.
 func (p *Parser) Parse() (*ConfigTree, []ParseError) {
 	children := p.parseStatements()
+	for {
+		tok := p.lexer.Peek()
+		if tok.Type == TokenEOF {
+			break
+		}
+		p.addError(tok.Line, tok.Column,
+			fmt.Sprintf("unexpected %s at top level (unmatched '}'?)", tok))
+		p.lexer.Next() // consume the stray token to guarantee forward progress
+		children = append(children, p.parseStatements()...)
+	}
 	tree := &ConfigTree{Children: children}
 	return tree, p.errors
 }

--- a/pkg/config/parser_stray_brace_4862_test.go
+++ b/pkg/config/parser_stray_brace_4862_test.go
@@ -1,0 +1,143 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4862: Parser.Parse() never asserted the lexer reached EOF, and
+// parseStatements() breaks on a top-level TokenRBrace identically to EOF. A
+// single stray unmatched '}' at the top level therefore made the parser STOP
+// with zero ParseErrors and silently drop every statement after the brace.
+// Because LoadOverride / CheckText only gate on len(errs)==0, the truncated
+// (weaker) config committed with no operator-visible warning — a fail-open
+// config-acceptance path that could drop a trailing security/default-policy
+// tail from an imported Junos config.
+//
+// The fix asserts EOF after the top-level parseStatements(): a stray '}' (or
+// any leftover token) is a ParseError, and the parser resumes past it so the
+// trailing config is recovered (never silently dropped) while the error still
+// fails the commit.
+//
+// Fail-on-revert: run these against origin/master (or drop the EOF assertion
+// loop from Parse) and the "Rejects" cases stop erroring and the trailing
+// `security` node vanishes from the tree.
+
+func hasTopLevelKey(tree *ConfigTree, key string) bool {
+	for _, n := range tree.Children {
+		if len(n.Keys) > 0 && n.Keys[0] == key {
+			return true
+		}
+	}
+	return false
+}
+
+// The exact TEST from the issue: a trailing stray brace must be a parse error,
+// not a silent stop.
+func TestParse4862_TrailingStrayBrace_IsError(t *testing.T) {
+	p := NewParser(`system { host-name fw; } }`)
+	tree, errs := p.Parse()
+	if len(errs) == 0 {
+		t.Fatal("expected a ParseError for a trailing stray '}', got none (fail-open silent truncation)")
+	}
+	// The well-formed prefix is still parsed.
+	if !hasTopLevelKey(tree, "system") {
+		t.Error("system stanza before the stray brace was dropped")
+	}
+}
+
+// The dangerous scenario: security-relevant config AFTER a stray brace must not
+// be silently discarded, and the parse must error.
+func TestParse4862_StrayBraceDoesNotDropTrailingConfig(t *testing.T) {
+	p := NewParser(`system {
+    host-name fw;
+} }
+security {
+    policies {
+        default-policy {
+            deny-all;
+        }
+    }
+}`)
+	tree, errs := p.Parse()
+	if len(errs) == 0 {
+		t.Fatal("expected a ParseError for the stray '}', got none")
+	}
+	if !hasTopLevelKey(tree, "system") {
+		t.Error("system stanza (before the stray brace) missing")
+	}
+	if !hasTopLevelKey(tree, "security") {
+		t.Error("security stanza AFTER the stray brace was silently dropped — fail-open")
+	}
+}
+
+// A stray '}' as the very first token still errors and still recovers the
+// trailing config.
+func TestParse4862_LeadingStrayBrace_IsError(t *testing.T) {
+	p := NewParser(`} system { host-name fw; }`)
+	tree, errs := p.Parse()
+	if len(errs) == 0 {
+		t.Fatal("expected a ParseError for a leading stray '}', got none")
+	}
+	if !hasTopLevelKey(tree, "system") {
+		t.Error("system stanza after the leading stray brace was dropped")
+	}
+}
+
+// A well-formed, correctly-nested config must still parse clean — the EOF
+// assertion must not false-positive on properly balanced braces.
+func TestParse4862_WellFormedParsesClean(t *testing.T) {
+	p := NewParser(`system {
+    host-name fw;
+}
+security {
+    policies {
+        default-policy {
+            deny-all;
+        }
+    }
+}`)
+	tree, errs := p.Parse()
+	if len(errs) != 0 {
+		t.Fatalf("well-formed config produced parse errors: %v", errs)
+	}
+	if !hasTopLevelKey(tree, "system") || !hasTopLevelKey(tree, "security") {
+		t.Errorf("well-formed config lost a top-level stanza: %+v", tree.Children)
+	}
+}
+
+// Deeply but correctly nested blocks must not trip the top-level EOF check
+// (each inner block's own closing '}' is consumed by parseStatement).
+func TestParse4862_DeepNestingParsesClean(t *testing.T) {
+	p := NewParser(`interfaces {
+    ge-0-0-0 {
+        unit 0 {
+            family inet {
+                address 10.0.0.1/24;
+            }
+        }
+    }
+}`)
+	_, errs := p.Parse()
+	if len(errs) != 0 {
+		t.Fatalf("correctly-nested config produced parse errors: %v", errs)
+	}
+}
+
+// The recorded error should name the offending line/column so an operator can
+// find the stray brace.
+func TestParse4862_ErrorNamesPosition(t *testing.T) {
+	p := NewParser("system { host-name fw; }\n}\n")
+	_, errs := p.Parse()
+	if len(errs) == 0 {
+		t.Fatal("expected an error")
+	}
+	// The stray brace is on line 2.
+	if errs[0].Line != 2 {
+		t.Errorf("error line = %d, want 2 (the stray brace line): %v", errs[0].Line, errs[0])
+	}
+	if !strings.Contains(errs[0].Message, "}") && !strings.Contains(errs[0].Message, "RBRACE") &&
+		!strings.Contains(strings.ToLower(errs[0].Message), "brace") {
+		t.Errorf("error message should reference the stray brace: %q", errs[0].Message)
+	}
+}


### PR DESCRIPTION
## Summary

`Parser.Parse()` called `parseStatements()` once and returned `(tree, errors)` without ever checking that the lexer reached EOF. `parseStatements()` breaks its loop on a top-level `TokenRBrace` identically to `TokenEOF`, so a single stray unmatched `}` at the top level made the parser **stop with zero `ParseError`s** and silently drop every statement after the brace.

`LoadOverride` / `CheckText` only gate on `len(errs)==0`, so a truncated config compiled and committed as if it were the authored file. A stray brace in an imported/pasted Junos config therefore accepted a prefix and silently discarded the security tail (trailing `security { policies ... }`, `default-policy`), leaving the firewall **weaker than authored** with no operator-visible warning — a fail-open config-acceptance path.

## Fix

After the top-level `parseStatements()`, `Parse()` asserts EOF. A leftover `}` (or any stray token) is a `ParseError` naming its line/column. Rather than discard the trailing config, the parser consumes the stray token and resumes parsing, so **both** the error **and** the remaining statements surface — the error still fails the commit, and the tree is never silently truncated. Every loop iteration consumes at least the one stray token, so parsing always terminates. Correctly nested `{ ... }` blocks are unaffected: `parseStatement` already consumes each block's own closing `}`, so only an unmatched top-level `}` reaches the new check.

## Tests

The issue's exact case (`system { host-name fw; } }`); the dangerous mid-stream case where a `security` stanza follows the stray brace (proving it is **recovered**, not dropped); a leading stray brace; a well-formed config that must still parse clean; deep correct nesting that must not false-positive; and the reported error position. RED-on-revert: against the pre-fix `Parse()` the "Rejects" cases stop erroring and the trailing `security` node vanishes. Full `go test ./pkg/config/ ./pkg/configstore/ ./pkg/cli/ ./pkg/cmdtree/` green; `go build ./...` clean. The parser has no separate markdown doc; the contract is the in-code `Parse()` comment, updated here.

Closes #4862