### PR TITLE
ddns: reject plaintext http endpoints + redirect downgrade for credentialed backends

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43853,3 +43853,5 @@ top.
   **File(s)**: pkg/config/syslog_logfile.go, pkg/cli/cli_show_system.go, pkg/grpcapi/server_show.go, +tests
   **Action**: #4857 — validate interface name in DHCP duidPath; reject path traversal in ClearDUID/load/save so a crafted `interface` cannot unlink a root file outside the DUID state dir
   **File(s)**: pkg/dhcp/dhcp.go, pkg/dhcp/clearduid_traversal_4857_test.go
+  **Action**: #4861 — reject plaintext http:// endpoints for credentialed DDNS backends at commit (compileDDNSServices, strict/lenient) + refuse HTTPS->HTTP redirect downgrade in the shared HTTP client (newHTTPClientBound CheckRedirect)
+  **File(s)**: pkg/config/compiler_ddns_tls.go, pkg/config/compiler_system.go, pkg/ddns/backend_http.go, +tests

--- a/pkg/config/compiler_ddns_tls.go
+++ b/pkg/config/compiler_ddns_tls.go
@@ -1,0 +1,68 @@
+package config
+
+import "strings"
+
+// ddnsBackendCarriesCredentials reports whether an HTTP DDNS backend attaches
+// credentials to its update requests — Basic auth (dyndns2/generic), a query or
+// bearer token (DuckDNS/Cloudflare), or SigV4 (Route 53). Such a backend must
+// only ever talk to an https:// endpoint (#4861); an rfc2136 backend (DNS, not
+// HTTP) and an unknown backend are false. For the generic templated backend the
+// credential may be Basic auth or an inadyn %u/%p specifier embedded in the
+// url-template.
+func ddnsBackendCarriesCredentials(p *DDNSProvider) bool {
+	switch p.Backend {
+	case "dyndns2":
+		return p.Username != "" || p.Password.Reveal() != ""
+	case "duckdns", "cloudflare":
+		return p.APIToken.Reveal() != ""
+	case "route53":
+		return p.AWSAccessKeyID != "" || p.AWSSecretAccessKey.Reveal() != ""
+	case "generic":
+		return p.Username != "" || p.Password.Reveal() != "" ||
+			strings.Contains(p.URLTemplate, "%u") || strings.Contains(p.URLTemplate, "%p")
+	}
+	return false
+}
+
+// ddnsPlaintextCredentialEndpoint reports the operator-supplied endpoint field
+// (server / url-template) and value when a CREDENTIALED HTTP DDNS backend is
+// configured with an explicit non-https scheme (#4861). A bare host with no
+// scheme is fine — every HTTP backend composes it over https — so only an
+// explicit http:// (or any non-https scheme) endpoint that would carry the
+// credential in cleartext is flagged. Returns bad=false for a non-credentialed
+// backend or an https/empty/bare endpoint.
+//
+// Scheme extraction is the substring before "://" compared case-insensitively
+// (RFC 3986 §3.1), string-based rather than url.Parse-based because a generic
+// url-template legitimately embeds %h/%i/%u/%p specifiers (and a userinfo
+// credential) that make url.Parse mangle or reject the value — the same reason
+// validateGenericURLTemplate is string-based.
+func ddnsPlaintextCredentialEndpoint(p *DDNSProvider) (field, value string, bad bool) {
+	if !ddnsBackendCarriesCredentials(p) {
+		return "", "", false
+	}
+	check := func(field, s string) (string, string, bool) {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return "", "", false
+		}
+		i := strings.Index(s, "://")
+		if i < 0 {
+			// Bare host (no scheme) → composed over https by the backend.
+			return "", "", false
+		}
+		if !strings.EqualFold(s[:i], "https") {
+			return field, s, true
+		}
+		return "", "", false
+	}
+	if f, v, b := check("server", p.Server); b {
+		return f, v, true
+	}
+	if p.Backend == "generic" {
+		if f, v, b := check("url-template", p.URLTemplate); b {
+			return f, v, true
+		}
+	}
+	return "", "", false
+}

--- a/pkg/config/compiler_ddns_tls_4861_test.go
+++ b/pkg/config/compiler_ddns_tls_4861_test.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4861: a credentialed HTTP DDNS backend (dyndns2 Basic auth, DuckDNS /
+// Cloudflare token, Route 53 SigV4, generic with %u/%p or Basic auth) must not
+// carry its update credential over a plaintext http:// endpoint. Strict (commit
+// / commit-check) hard-rejects such a `server` / `url-template`; lenient (load /
+// peer-sync) warns. A bare host (no scheme, composed over https) and an https://
+// endpoint are accepted; a NON-credentialed backend over http is not this
+// finding's concern and is not rejected here.
+//
+// All tests use the production ParseSetCommand + SetPath path (buildTree).
+
+func hasDDNSHTTPSWarning(cfg *Config, provider string) bool {
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "provider \""+provider+"\"") && strings.Contains(w, "https://") {
+			return true
+		}
+	}
+	return false
+}
+
+// A credentialed dyndns2/cloudflare/route53/generic backend with a plaintext
+// http:// endpoint is rejected at commit, naming the provider.
+func TestDDNSCredentialedPlaintextEndpointRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		set  []string
+	}{
+		{"dyndns2", []string{
+			"set system services dynamic-dns provider p backend dyndns2",
+			"set system services dynamic-dns provider p username alice",
+			"set system services dynamic-dns provider p password s3cret",
+			"set system services dynamic-dns provider p server http://updates.example/nic/update",
+		}},
+		{"cloudflare", []string{
+			"set system services dynamic-dns provider p backend cloudflare",
+			"set system services dynamic-dns provider p api-token TOKEN123",
+			"set system services dynamic-dns provider p zone example.net",
+			"set system services dynamic-dns provider p server http://api.example",
+		}},
+		{"route53", []string{
+			"set system services dynamic-dns provider p backend route53",
+			"set system services dynamic-dns provider p aws-access-key AKIA",
+			"set system services dynamic-dns provider p aws-secret-key SECRET",
+			"set system services dynamic-dns provider p hosted-zone-id Z123",
+			"set system services dynamic-dns provider p server http://route53.example",
+		}},
+		{"generic", []string{
+			"set system services dynamic-dns provider p backend generic",
+			`set system services dynamic-dns provider p url-template "http://user:%p@host.example/upd?ip=%i"`,
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildTree(t, tc.set)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("%s credentialed http:// endpoint compiled without error (#4861 regression)", tc.name)
+			}
+			if !strings.Contains(err.Error(), "https://") || !strings.Contains(err.Error(), "provider \"p\"") {
+				t.Fatalf("error should name the provider and require https, got: %v", err)
+			}
+		})
+	}
+}
+
+// An https:// (and a bare-host) endpoint for a credentialed backend is accepted.
+func TestDDNSCredentialedHTTPSEndpointAccepted(t *testing.T) {
+	for _, srv := range []string{
+		"https://updates.example/nic/update", // explicit https
+		"updates.example",                    // bare host → composed over https
+	} {
+		tree := buildTree(t, []string{
+			"set system services dynamic-dns provider p backend dyndns2",
+			"set system services dynamic-dns provider p username alice",
+			"set system services dynamic-dns provider p password s3cret",
+			"set system services dynamic-dns provider p server " + srv,
+		})
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("credentialed backend with server %q should compile, got: %v", srv, err)
+		}
+	}
+}
+
+// A NON-credentialed generic backend over http (url-template with %i but no
+// %u/%p and no username/password) is NOT this finding's concern and must still
+// compile — guards against over-rejecting.
+func TestDDNSNonCredentialedPlaintextAccepted(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set system services dynamic-dns provider p backend generic",
+		`set system services dynamic-dns provider p url-template "http://host.example/upd?ip=%i"`,
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("non-credentialed generic http:// template should compile, got: %v", err)
+	}
+}
+
+// The lenient (tolerant load / peer-sync) path WARNS instead of rejecting a
+// credentialed plaintext endpoint so an already-persisted config an older
+// binary accepted still boots (#1960).
+func TestDDNSCredentialedPlaintextLenientWarns(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set system services dynamic-dns provider p backend dyndns2",
+		"set system services dynamic-dns provider p username alice",
+		"set system services dynamic-dns provider p password s3cret",
+		"set system services dynamic-dns provider p server http://updates.example/nic/update",
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient load of a credentialed plaintext endpoint must NOT fail, got: %v", err)
+	}
+	if !hasDDNSHTTPSWarning(cfg, "p") {
+		t.Fatalf("lenient load must emit an https warning, warnings=%v", cfg.Warnings)
+	}
+	// The provider is still materialized (the field is accepted; only the
+	// warning is new) — matches the #4837 lenient discipline.
+	if cfg.System.Services == nil || cfg.System.Services.DynamicDNS == nil ||
+		cfg.System.Services.DynamicDNS.Providers["p"] == nil {
+		t.Fatalf("lenient load should still materialize the provider catalog")
+	}
+}

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -574,15 +574,34 @@ var ddnsProviderStringProps = map[string]bool{
 // way, matching pre-#4837 runtime behavior exactly; only the warning is new.
 func compileDDNSServices(node *Node, lenient bool) (*DDNSServicesConfig, []string, error) {
 	cat := &DDNSServicesConfig{Providers: map[string]*DDNSProvider{}}
+	var warnings []string
 	for _, inst := range namedInstances(node.FindChildren("provider")) {
 		p := compileDDNSProvider(inst.name, inst.node)
-		if p != nil {
-			cat.Providers[p.Name] = p
+		if p == nil {
+			continue
+		}
+		cat.Providers[p.Name] = p
+		// TLS enforcement (#4861): a credentialed HTTP backend
+		// (dyndns2/duckdns/cloudflare/route53/generic) must not carry its
+		// update credential over a plaintext http:// endpoint. Strict
+		// (commit / commit-check) hard-rejects; lenient (load / peer-sync)
+		// downgrades to a warning so an already-persisted config an older
+		// binary accepted still boots (#1960 fail-closed-on-load class). The
+		// redirect-downgrade half (an https endpoint 30x'd to http) is blocked
+		// at runtime by the shared client's CheckRedirect (pkg/ddns).
+		if field, val, bad := ddnsPlaintextCredentialEndpoint(p); bad {
+			msg := fmt.Sprintf("system services dynamic-dns provider %q (backend %s) "+
+				"%s %q must be an https:// endpoint — a credentialed backend over a "+
+				"plaintext http:// endpoint transmits the update credential in cleartext",
+				p.Name, p.Backend, field, RedactURL(val))
+			if !lenient {
+				return nil, nil, fmt.Errorf("%s", msg)
+			}
+			warnings = append(warnings, msg)
 		}
 	}
 	// Engine tunables: a duration ("24h") or a bare-seconds integer. They may
 	// appear as a child node OR packed into the block's Keys (flat-set).
-	var warnings []string
 	for _, leaf := range []string{"forced-refresh", "error-backoff-max"} {
 		v := ddnsServicesScalar(node, leaf)
 		if v == "" {

--- a/pkg/ddns/backend_http.go
+++ b/pkg/ddns/backend_http.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -99,9 +100,32 @@ func newHTTPClientBound(b bindConfig) *http.Client {
 		tr.DialContext = d.DialContext
 	}
 	return &http.Client{
-		Timeout:   httpClientTimeout,
-		Transport: tr,
+		Timeout:       httpClientTimeout,
+		Transport:     tr,
+		CheckRedirect: refuseSchemeDowngrade,
 	}
+}
+
+// refuseSchemeDowngrade is the shared *http.Client.CheckRedirect for every HTTP
+// DDNS backend. It refuses an HTTPS->HTTP redirect downgrade (#4861): a
+// credentialed backend (dyndns2 Basic auth, DuckDNS/Cloudflare query/bearer
+// token, Route 53 SigV4) that started over TLS must never be walked onto a
+// plaintext connection by a 30x Location, which would put the update credential
+// on the wire in cleartext for an on-path attacker. Same-scheme redirects and
+// an HTTP->HTTPS upgrade are still followed. The default 10-redirect cap is
+// re-implemented here because setting CheckRedirect replaces Go's built-in cap.
+func refuseSchemeDowngrade(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return errors.New("ddns http: stopped after 10 redirects")
+	}
+	if len(via) > 0 {
+		prev := via[len(via)-1].URL
+		if strings.EqualFold(prev.Scheme, "https") && !strings.EqualFold(req.URL.Scheme, "https") {
+			return fmt.Errorf("ddns http: refusing HTTPS->%s redirect downgrade to %s "+
+				"(would expose update credentials in cleartext)", req.URL.Scheme, req.URL.Host)
+		}
+	}
+	return nil
 }
 
 // httpClientCache caches the hardened *http.Client (and its underlying

--- a/pkg/ddns/redirect_downgrade_4861_test.go
+++ b/pkg/ddns/redirect_downgrade_4861_test.go
@@ -1,0 +1,74 @@
+package ddns
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+// mkReq is a small helper building a *http.Request for a scheme+host.
+func mkReq(t *testing.T, rawurl string) *http.Request {
+	t.Helper()
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		t.Fatalf("parse %q: %v", rawurl, err)
+	}
+	return &http.Request{URL: u}
+}
+
+// TestRefuseSchemeDowngrade pins #4861: the shared HTTP DDNS client must refuse
+// an HTTPS->HTTP redirect downgrade so a 30x Location cannot walk a credentialed
+// update onto a plaintext connection. Same-scheme redirects and an HTTP->HTTPS
+// upgrade are still followed, and the 10-redirect cap is preserved.
+//
+// RED on revert: dropping CheckRedirect (or its downgrade branch) makes the
+// https->http subtest return nil, so the client would follow the downgrade and
+// transmit credentials in cleartext.
+func TestRefuseSchemeDowngrade(t *testing.T) {
+	cases := []struct {
+		name    string
+		prev    string // previous hop
+		next    string // redirect target
+		wantErr bool
+	}{
+		{"https->http downgrade refused", "https://prov.example/upd", "http://prov.example/upd", true},
+		{"https->http other host refused", "https://prov.example/upd", "http://evil.example/upd", true},
+		{"https->https allowed", "https://prov.example/upd", "https://prov.example/v2", false},
+		{"http->https upgrade allowed", "http://prov.example/upd", "https://prov.example/upd", false},
+		{"http->http allowed", "http://prov.example/upd", "http://prov.example/v2", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			via := []*http.Request{mkReq(t, tc.prev)}
+			err := refuseSchemeDowngrade(mkReq(t, tc.next), via)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected the redirect to be refused, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected the redirect to be allowed, got: %v", err)
+			}
+		})
+	}
+
+	// The 10-redirect cap is preserved even when every hop is same-scheme.
+	via := make([]*http.Request, 10)
+	for i := range via {
+		via[i] = mkReq(t, "https://prov.example/upd")
+	}
+	if err := refuseSchemeDowngrade(mkReq(t, "https://prov.example/upd"), via); err == nil {
+		t.Fatalf("expected the 10-redirect cap to fire, got nil")
+	}
+}
+
+// TestHTTPClientWiresCheckRedirect asserts every shared HTTP DDNS client carries
+// the downgrade-refusing CheckRedirect (the wiring, RED on revert).
+func TestHTTPClientWiresCheckRedirect(t *testing.T) {
+	cl := newHTTPClient()
+	if cl.CheckRedirect == nil {
+		t.Fatal("newHTTPClient() has no CheckRedirect; HTTPS->HTTP downgrade is not blocked")
+	}
+	via := []*http.Request{mkReq(t, "https://prov.example/upd")}
+	if err := cl.CheckRedirect(mkReq(t, "http://prov.example/upd"), via); err == nil {
+		t.Fatal("client CheckRedirect followed an HTTPS->HTTP downgrade; want refused")
+	}
+}


### PR DESCRIPTION
## Summary
Credentialed HTTP DDNS backends (dyndns2 Basic auth, DuckDNS/Cloudflare token, Route 53 SigV4, generic with `%u`/`%p` or Basic auth) accepted a plaintext `http://` endpoint and followed an HTTPS→HTTP redirect downgrade, transmitting the update credential without TLS.

## Fix (two independent halves)
- **Commit-time validation** (`pkg/config`): `compileDDNSServices` rejects a credentialed backend with an explicit non-https `server`/`url-template`. Strict (`CompileConfig`) errors naming the provider; lenient (`CompileConfigLenient`) warns (#1960). Bare host / https accepted; a non-credentialed http backend is out of scope. Scheme extraction is string-based (RFC 3986 §3.1) since generic templates embed `%h/%i/%u/%p` + userinfo.
- **Runtime redirect guard** (`pkg/ddns`): the shared hardened client (`newHTTPClientBound`, used by every HTTP backend + checkip) sets a `CheckRedirect` that refuses an HTTPS→HTTP downgrade; same-scheme and HTTP→HTTPS still followed; the 10-redirect cap is re-implemented.

## Test
- `pkg/config`: credentialed `http://` across dyndns2/cloudflare/route53/generic rejected at commit; https/bare-host accepted; non-credentialed http template still compiles; lenient path warns.
- `pkg/ddns`: client refuses HTTPS→HTTP redirect and wires `CheckRedirect`.
- RED on revert on both halves.

Closes #4861