### PR TITLE
dhcpserver: fail closed on a systemctl is-active query error (#4870)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43862,3 +43862,6 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4897 — SNMPv3 enforce per-user minimum security level floor in handleV3Packet: an auth-keyed user must authenticate and a privacy-keyed user must use authPriv; drop under-leveled requests (e.g. noAuthNoPriv against an authPriv user) before decoding the scoped PDU. Replaced the "authPriv user served at noAuthNoPriv" test with an authPriv/authNoPriv/noAuth matrix.
   **File(s)**: pkg/snmp/v3.go, pkg/snmp/v3_seclevel_test.go, pkg/snmp/README.md
+- **Timestamp**: 2026-07-09
+  **Action**: #4870 — dhcpserver fail-closed on systemctl is-active query error. unitIsActive now returns (bool, error): a recognized state string is authoritative, an undeterminable query (timeout/exec/garbled) returns an error instead of silent "inactive". reconcileFamilyRestart restarts + surfaces the error on an uncertain query (was: skip restart, report success); clearFamilyLocked stops + surfaces the error and the config-unlink error on a removed family.
+  **File(s)**: pkg/dhcpserver/dhcpserver.go, pkg/dhcpserver/test_seams.go, pkg/dhcpserver/dhcpserver_isactive_error_4870_test.go, pkg/dhcpserver/README.md

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -19,7 +19,19 @@ parses a torn file, no fsync on the apply path.
   **Fail-closed:** restart failures (and failures to stop an active
   unit that left the config) are returned, so a commit surfaces
   "DHCP server failed" instead of silently succeeding with no
-  service.
+  service. The `systemctl is-active` probe (`unitIsActive`) is itself
+  tri-state (#4870): a recognized state string is authoritative
+  (active / inactive / failed) regardless of exit code, but a query
+  that CANNOT determine the state — timeout, exec error, garbled/empty
+  output — returns an error rather than the previous silent "inactive".
+  On such an uncertain query the reconcile fails closed: it restarts a
+  configured family (to enforce the freshly generated config) or stops
+  a removed family (to enforce the removal) AND surfaces the query
+  error, so a transient probe blip during a cluster commit can no
+  longer skip the enforcement while the commit reports success (the old
+  fail-open left stale/removed Kea policy serving). The generated-config
+  unlink error on a removed family is surfaced too (a leftover file
+  could resurrect a removed subnet on a later manual/boot start).
 - `ApplyAsync(cfg, reason)` — `dhcpserver.go`. Enqueues an `Apply` to
   a single lazily started worker via a 1-slot latest-wins mailbox and
   returns immediately (#1835 F2). Used by the VRRP transition

--- a/pkg/dhcpserver/dhcpserver.go
+++ b/pkg/dhcpserver/dhcpserver.go
@@ -52,18 +52,28 @@ func runSystemctl(args ...string) error {
 }
 
 // unitIsActive reports whether a systemd unit is active (or on its way
-// up) by querying `systemctl is-active`. A non-zero exit means "not
-// active" — the state string is on stdout either way, so exit status
-// is not treated as a query failure. If systemctl cannot run at all
-// the output is empty and the unit is reported inactive (there is
-// nothing useful to stop in that case anyway).
-func unitIsActive(unit string) bool {
+// up) by querying `systemctl is-active`. It returns (active, err):
+//
+//   - A recognized state string on stdout is an authoritative answer,
+//     regardless of exit code. `systemctl is-active` exits non-zero for
+//     an inactive/failed/unknown unit but still prints the state, so
+//     that expected ExitError is NOT a query failure — active is
+//     reported (true/false) with a nil error.
+//   - No recognized state string (empty/garbled output, a missing
+//     systemctl binary, a context timeout/kill) means the query could
+//     NOT determine the unit's state. That is returned as a non-nil
+//     error so callers fail CLOSED (#4870) instead of silently mapping
+//     the uncertainty to "inactive" — which let a transient is-active
+//     failure skip a restart/stop and report the commit as successful
+//     while stale/removed Kea policy kept being served.
+func unitIsActive(unit string) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), systemctlTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "systemctl", "is-active", unit)
 	cmd.WaitDelay = 5 * time.Second
-	out, _ := cmd.Output()
-	switch strings.TrimSpace(string(out)) {
+	out, runErr := cmd.Output()
+	state := strings.TrimSpace(string(out))
+	switch state {
 	case "active", "activating", "reloading", "deactivating":
 		// "deactivating" counts as active-for-stop (Codex review on PR
 		// #1835): a previous daemon or external restart job can be
@@ -71,9 +81,19 @@ func unitIsActive(unit string) bool {
 		// here would let that queued start resurrect Kea after this
 		// commit removed its config. An extra stop on a unit that was
 		// going down anyway is harmless.
-		return true
+		return true, nil
+	case "inactive", "failed", "unknown", "maintenance":
+		// A definitive not-active answer. `systemctl is-active` prints
+		// these to stdout and exits non-zero, so runErr here is the
+		// expected ExitError, not a query failure — discard it.
+		return false, nil
 	}
-	return false
+	// No recognized state: the query itself failed. Surface the reason
+	// so the caller can fail closed rather than assume "inactive".
+	if runErr == nil {
+		runErr = fmt.Errorf("unrecognized output %q", state)
+	}
+	return false, fmt.Errorf("systemctl is-active %s: %w", unit, runErr)
 }
 
 const (
@@ -117,7 +137,7 @@ type Manager struct {
 	// Seams for tests (see test_seams.go). Production instances get
 	// the package-level implementations from New().
 	runSystemctl func(args ...string) error
-	unitActive   func(unit string) bool
+	unitActive   func(unit string) (bool, error)
 	warn         func(msg string, args ...any)
 
 	// Generation-ordered supersession (#1835 F2 redesign after the
@@ -278,10 +298,8 @@ func (m *Manager) apply(gen uint64, cfg *config.DHCPServerConfig, restartInactiv
 	if want4 {
 		if err := m.generateKea4Config(cfg); err != nil {
 			errs = append(errs, fmt.Errorf("generate kea4 config: %w", err))
-		} else if restartInactive || m.unitActive(kea4Svc) {
-			if err := m.runSystemctl("restart", kea4Svc); err != nil {
-				errs = append(errs, fmt.Errorf("restart %s: %w", kea4Svc, err))
-			}
+		} else if err := m.reconcileFamilyRestart(kea4Svc, restartInactive); err != nil {
+			errs = append(errs, err)
 		}
 	} else if err := m.clearFamilyLocked(kea4Svc, m.confPath4); err != nil {
 		errs = append(errs, err)
@@ -290,10 +308,8 @@ func (m *Manager) apply(gen uint64, cfg *config.DHCPServerConfig, restartInactiv
 	if want6 {
 		if err := m.generateKea6Config(cfg); err != nil {
 			errs = append(errs, fmt.Errorf("generate kea6 config: %w", err))
-		} else if restartInactive || m.unitActive(kea6Svc) {
-			if err := m.runSystemctl("restart", kea6Svc); err != nil {
-				errs = append(errs, fmt.Errorf("restart %s: %w", kea6Svc, err))
-			}
+		} else if err := m.reconcileFamilyRestart(kea6Svc, restartInactive); err != nil {
+			errs = append(errs, err)
 		}
 	} else if err := m.clearFamilyLocked(kea6Svc, m.confPath6); err != nil {
 		errs = append(errs, err)
@@ -378,20 +394,67 @@ func (m *Manager) applyAsyncWorker() {
 	}
 }
 
+// reconcileFamilyRestart restarts a Kea unit whose config was just
+// regenerated. It restarts when the unit is already active (to pick up
+// the fresh config) or when restartInactive is set (cluster-commit
+// semantics: bring the unit up even if it was down). Caller must hold
+// m.mu.
+//
+// Fail-closed (#4870 A): if the `systemctl is-active` query itself fails
+// (timeout/exec error, not a definitive "inactive"), the previous code
+// mapped the uncertainty to "inactive" and SKIPPED the restart, so on a
+// cluster commit a transient blip left the old Kea process serving stale
+// policy while the commit returned success. Now an uncertain query is
+// treated as needing enforcement: the unit is restarted (idempotent —
+// this authoritatively loads the freshly generated config) AND the query
+// error is surfaced so a synchronous commit does not report success on an
+// unverified enforcement.
+func (m *Manager) reconcileFamilyRestart(svc string, restartInactive bool) error {
+	var errs []error
+	active, qerr := m.unitActive(svc)
+	if qerr != nil {
+		errs = append(errs, fmt.Errorf("query %s active state: %w", svc, qerr))
+		slog.Warn("could not query Kea unit state; restarting to enforce config",
+			"service", svc, "err", qerr)
+	}
+	if restartInactive || active || qerr != nil {
+		if err := m.runSystemctl("restart", svc); err != nil {
+			errs = append(errs, fmt.Errorf("restart %s: %w", svc, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
 // clearFamilyLocked stops one Kea unit if systemd reports it active
 // and removes its generated config file. Caller must hold m.mu.
+//
+// Fail-closed (#4870 A): an is-active query failure no longer silently
+// skips the stop (which would leave a removed subnet still served). On an
+// uncertain query the stop is issued authoritatively (a stop on an
+// already-inactive unit is harmless) and the query error is surfaced. The
+// config-file unlink error is also surfaced now (a leftover generated
+// config lets a later manual/boot start of Kea resurrect the removed
+// subnet); an already-absent file is success.
 func (m *Manager) clearFamilyLocked(svc, confPath string) error {
-	var err error
-	if m.unitActive(svc) {
+	var errs []error
+	active, qerr := m.unitActive(svc)
+	if qerr != nil {
+		errs = append(errs, fmt.Errorf("query %s active state: %w", svc, qerr))
+		slog.Warn("could not query Kea unit state; stopping to enforce removal",
+			"service", svc, "err", qerr)
+	}
+	if active || qerr != nil {
 		if e := m.runSystemctl("stop", svc); e != nil {
-			err = fmt.Errorf("stop %s: %w", svc, e)
+			errs = append(errs, fmt.Errorf("stop %s: %w", svc, e))
 			slog.Warn("failed to stop Kea unit", "service", svc, "err", e)
 		} else {
 			slog.Info("stopped Kea unit not in current config", "service", svc)
 		}
 	}
-	os.Remove(confPath)
-	return err
+	if e := os.Remove(confPath); e != nil && !os.IsNotExist(e) {
+		errs = append(errs, fmt.Errorf("remove %s: %w", confPath, e))
+	}
+	return errors.Join(errs...)
 }
 
 // Clear stops both Kea units (if systemd reports them active) and
@@ -413,7 +476,12 @@ func (m *Manager) Clear() {
 func (m *Manager) IsRunning() bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.unitActive(kea4Svc) || m.unitActive(kea6Svc)
+	// A query error is treated as not-running for this status reporter: a
+	// unit whose state cannot be determined must not be reported as an
+	// active DHCP server (#4870).
+	a4, _ := m.unitActive(kea4Svc)
+	a6, _ := m.unitActive(kea6Svc)
+	return a4 || a6
 }
 
 // Lease represents a DHCP lease from Kea's lease database.

--- a/pkg/dhcpserver/dhcpserver_isactive_error_4870_test.go
+++ b/pkg/dhcpserver/dhcpserver_isactive_error_4870_test.go
@@ -1,0 +1,94 @@
+package dhcpserver
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// #4870 A: a `systemctl is-active` query FAILURE (timeout/exec error, as
+// distinct from a definitive "inactive" answer) must not be silently mapped to
+// "inactive". The old unitIsActive discarded the command error and returned
+// false, so on a cluster commit the configured-but-active Kea unit's restart
+// was skipped, lastAppliedGen advanced, and the commit returned nil while the
+// old Kea kept serving stale policy — a fail-open. The apply path must instead
+// fail closed: enforce the config (restart/stop) despite the uncertainty AND
+// surface the query error so the commit does not report success.
+
+// isActiveErr is a unitActive seam whose query fails for the named units
+// (returning a non-nil error, the tri-state "could not determine" case).
+func isActiveErr(errUnits ...string) func(unit string) (bool, error) {
+	set := map[string]bool{}
+	for _, u := range errUnits {
+		set[u] = true
+	}
+	return func(unit string) (bool, error) {
+		if set[unit] {
+			return false, fmt.Errorf("systemctl is-active %s: context deadline exceeded", unit)
+		}
+		return false, nil // definitively inactive
+	}
+}
+
+// TestClusterCommitIsActiveErrorFailsClosed pins the restart branch. A cluster
+// commit (restartInactive=false) whose is-active query errors must restart the
+// configured unit to enforce the freshly generated config AND return an error,
+// instead of skipping the restart and reporting success.
+//
+// fail-on-revert: mapping the query error back to "inactive" (the old behavior)
+// skips the restart and returns nil, so both assertions below fail.
+func TestClusterCommitIsActiveErrorFailsClosed(t *testing.T) {
+	m, calls := testManager(t, map[string]bool{}, "")
+	m.SetUnitActiveForTesting(isActiveErr(kea4Svc))
+
+	err := m.ApplyClusterCommit(v4Config("ge-0-0-0"))
+	if err == nil {
+		t.Fatal("ApplyClusterCommit must fail closed on an is-active query error, got nil")
+	}
+	if !strings.Contains(err.Error(), kea4Svc) {
+		t.Errorf("error should name the unit: %v", err)
+	}
+	if !calledWith(*calls, "restart "+kea4Svc) {
+		t.Errorf("expected kea4 restart to enforce fresh config despite the query error, got %v", *calls)
+	}
+}
+
+// TestRemovedFamilyIsActiveErrorFailsClosed pins the clear branch. A removed
+// family whose is-active query errors must issue the stop authoritatively (a
+// stop on an already-inactive unit is harmless) AND surface the error, instead
+// of skipping the stop and letting the removed subnet keep being served.
+//
+// fail-on-revert: mapping the query error to "inactive" skips the stop and
+// returns nil, so both assertions fail.
+func TestRemovedFamilyIsActiveErrorFailsClosed(t *testing.T) {
+	m, calls := testManager(t, map[string]bool{}, "")
+	// v4-only config: the kea6 family is removed. Its is-active query errors.
+	m.SetUnitActiveForTesting(isActiveErr(kea6Svc))
+
+	err := m.Apply(v4Config("ge-0-0-0"))
+	if err == nil {
+		t.Fatal("Apply must fail closed on a removed-family is-active query error, got nil")
+	}
+	if !strings.Contains(err.Error(), kea6Svc) {
+		t.Errorf("error should name the unit: %v", err)
+	}
+	if !calledWith(*calls, "stop "+kea6Svc) {
+		t.Errorf("expected kea6 stop to enforce removal despite the query error, got %v", *calls)
+	}
+}
+
+// TestClusterCommitIsActiveDefinitiveInactiveStillSkips confirms the fix does
+// NOT over-restart: a DEFINITIVE inactive answer (nil query error) on a cluster
+// commit still skips the restart, exactly as before — only a query FAILURE
+// forces enforcement.
+func TestClusterCommitIsActiveDefinitiveInactiveStillSkips(t *testing.T) {
+	m, calls := testManager(t, map[string]bool{}, "")
+	// Default seam: every unit is definitively inactive (false, nil).
+
+	if err := m.ApplyClusterCommit(v4Config("ge-0-0-0")); err != nil {
+		t.Fatalf("ApplyClusterCommit: %v", err)
+	}
+	if calledWith(*calls, "restart "+kea4Svc) {
+		t.Errorf("a definitively-inactive unit must not be restarted on a cluster commit, got %v", *calls)
+	}
+}

--- a/pkg/dhcpserver/test_seams.go
+++ b/pkg/dhcpserver/test_seams.go
@@ -22,7 +22,10 @@ import (
 //   - runSystemctl: replaces the real `systemctl <args...>` shell-out
 //     (restart/stop). Return nil for success.
 //   - unitActive: replaces the `systemctl is-active <unit>` query used
-//     for authoritative reconcile (#1778).
+//     for authoritative reconcile (#1778). This convenience seam wraps a
+//     bool-only fake as always-succeeding (nil query error); tests that
+//     need to exercise the #4870 fail-closed query-error path inject an
+//     error-returning fake via SetUnitActiveForTesting.
 func NewManagerForTesting(
 	confPath4, confPath6 string,
 	runSystemctl func(args ...string) error,
@@ -32,9 +35,17 @@ func NewManagerForTesting(
 		confPath4:    confPath4,
 		confPath6:    confPath6,
 		runSystemctl: runSystemctl,
-		unitActive:   unitActive,
+		unitActive:   func(unit string) (bool, error) { return unitActive(unit), nil },
 		warn:         slog.Warn,
 	}
+}
+
+// SetUnitActiveForTesting overrides the `systemctl is-active` seam with a
+// tri-state fake so tests can exercise the #4870 fail-closed path where
+// the query itself fails (timeout/exec error) rather than returning a
+// definitive active/inactive answer.
+func (m *Manager) SetUnitActiveForTesting(fn func(unit string) (bool, error)) {
+	m.unitActive = fn
 }
 
 // SetLeaseSyncSeamsForTesting injects the #2239 lease-sync test seams: a


### PR DESCRIPTION
## Summary
The Kea apply/lifecycle path treated a `systemctl is-active` query **failure** as "inactive" — a fail-open defect (#4870 A). `unitIsActive` ran `out, _ := cmd.Output()` and mapped every unrecognized result to `false`, so a timeout / exec error / garbled output was indistinguishable from a unit that is genuinely down. On a cluster commit (`ApplyClusterCommit` → `apply(gen, cfg, restartInactive=false)`) a transient blip made the configured-but-active unit's restart be skipped, `lastAppliedGen` advanced, and the commit returned nil while the old Kea kept serving stale policy. The removed-family clear path likewise skipped the stop on a query error and ignored the config-unlink error.

## Fix
- `unitIsActive` is now tri-state `(active bool, err error)`: a recognized systemd state string is authoritative regardless of exit code (`is-active` exits non-zero for inactive/failed/unknown but still prints the state — that expected ExitError is not a query failure); only an undeterminable result (empty/garbled output, missing binary, timeout/kill) returns an error.
- `reconcileFamilyRestart` (factored out of `apply`): on a query error, restart to authoritatively enforce the freshly generated config AND surface the error. A definitive inactive answer on a cluster commit still skips the restart — no over-restart.
- `clearFamilyLocked`: on a query error, stop authoritatively (harmless on an inactive unit) and surface the error; also surface the generated-config unlink error so a leftover config cannot resurrect a removed subnet.
- `IsRunning` treats a query error as not-running (safe direction for a status reporter).

The `unitActive` seam became `func(unit string) (bool, error)`; `NewManagerForTesting` keeps its bool-only convenience signature, and a new `SetUnitActiveForTesting` injects the error-returning fake.

## Test
`pkg/dhcpserver/dhcpserver_isactive_error_4870_test.go`:
- cluster commit whose is-active query errors → restarts the unit AND returns an error;
- removed family whose query errors → stops the unit AND returns an error;
- a definitively-inactive unit on a cluster commit still skips the restart (no over-restart).

Red-on-revert verified: restoring the old "query error → inactive" logic makes the two fail-closed tests red. `go test ./pkg/dhcpserver/... ./pkg/daemon/...` green; `go build ./...` clean. Documented in `pkg/dhcpserver/README.md`.

Scope note: this fixes defect **A** (the is-active query-error fail-open, which the issue's TEST targets). Defect **B** (a bounded convergence retry for async apply after a transient systemd failure) is a larger lifecycle change left to follow-up.

Closes #4870