### PR TITLE
fwdstatus: require positive heartbeat evidence before reporting Online

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43873,3 +43873,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4870 — dhcpserver fail-closed on systemctl is-active query error. unitIsActive now returns (bool, error): a recognized state string is authoritative, an undeterminable query (timeout/exec/garbled) returns an error instead of silent "inactive". reconcileFamilyRestart restarts + surfaces the error on an uncertain query (was: skip restart, report success); clearFamilyLocked stops + surfaces the error and the config-unlink error on a removed family.
   **File(s)**: pkg/dhcpserver/dhcpserver.go, pkg/dhcpserver/test_seams.go, pkg/dhcpserver/dhcpserver_isactive_error_4870_test.go, pkg/dhcpserver/README.md
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4875 fwdstatus require positive in-window heartbeat evidence for Online; empty/nil/future heartbeats -> Degraded (was false-green Online)
+  **File(s)**: pkg/fwdstatus/builder.go, pkg/fwdstatus/fwdstatus_test.go, pkg/fwdstatus/README.md

--- a/pkg/fwdstatus/README.md
+++ b/pkg/fwdstatus/README.md
@@ -52,3 +52,15 @@ root `pkg/dataplane` package, `pkg/cli`, or `pkg/grpcapi`.
   multi-core sum.
 - Windows shorter than the daemon uptime render as `-` to avoid lying
   about a 5 m average that hasn't elapsed yet.
+- **Online requires positive, in-window heartbeat evidence (#4875).**
+  On the userspace path `State` is `Online` only when the helper
+  reported at least one worker heartbeat AND every heartbeat lands in
+  the `[0, 2s]` age window (`heartbeatsHealthy` in `builder.go`). An
+  empty/omitted heartbeat set (worker startup, or a wire-version
+  mismatch that drops the field) and a future-dated heartbeat (a
+  malformed/torn clock conversion — heartbeats share the host clock, so
+  a heartbeat ahead of `now` is never real liveness) both read as
+  `Degraded`, never `Online`. The old `allHeartbeatsFresh` treated an
+  empty slice and a future timestamp as "trivially fresh" and fell
+  straight through to `Online`, giving operators and failover
+  automation a false-green forwarding state.

--- a/pkg/fwdstatus/builder.go
+++ b/pkg/fwdstatus/builder.go
@@ -218,7 +218,7 @@ func Build(
 		fs.State = StateUnknown
 	case isUserspace && usErr != nil:
 		fs.State = StateUnknown
-	case isUserspace && !allHeartbeatsFresh(usStatus.WorkerHeartbeats, time.Now(), 2*time.Second):
+	case isUserspace && !heartbeatsHealthy(usStatus.WorkerHeartbeats, time.Now(), 2*time.Second):
 		fs.State = StateDegraded
 	default:
 		fs.State = StateOnline
@@ -231,13 +231,29 @@ func ticksToNanos(ticks uint64) uint64 {
 	return ticks * 1_000_000_000 / userHZ
 }
 
-// allHeartbeatsFresh returns true iff every heartbeat is within
-// maxAge of now.  Empty slice returns true (no workers → trivially
-// fresh; caller distinguishes the empty vs populated case when
-// interpreting Degraded).
-func allHeartbeatsFresh(hbs []time.Time, now time.Time, maxAge time.Duration) bool {
+// heartbeatsHealthy returns true only on positive, in-window evidence
+// that packet-processing workers are alive: the slice must be
+// non-empty and EVERY heartbeat must fall in the closed age window
+// [0, maxAge] relative to now.  Both endpoints are load-bearing
+// (#4875):
+//
+//   - An empty slice returns false.  A userspace helper that has not
+//     yet published any heartbeat (startup) or a wire-version mismatch
+//     that omits the field must NOT read as Online — the old
+//     "empty → trivially fresh" behavior let a firewall with no live
+//     worker report a false-green forwarding state.
+//   - A future-dated heartbeat (negative age) returns false.  Both the
+//     heartbeat and `now` come from the same host clock, so a heartbeat
+//     ahead of now is a malformed/torn conversion, not real evidence of
+//     liveness; it must not satisfy the freshness check.
+//   - A stale heartbeat (age > maxAge) returns false, as before.
+func heartbeatsHealthy(hbs []time.Time, now time.Time, maxAge time.Duration) bool {
+	if len(hbs) == 0 {
+		return false
+	}
 	for _, hb := range hbs {
-		if now.Sub(hb) > maxAge {
+		age := now.Sub(hb)
+		if age < 0 || age > maxAge {
 			return false
 		}
 	}

--- a/pkg/fwdstatus/fwdstatus_test.go
+++ b/pkg/fwdstatus/fwdstatus_test.go
@@ -499,6 +499,87 @@ func TestBuild_UserspaceBuffer_ClampedTo100(t *testing.T) {
 	}
 }
 
+// #4875: Online requires positive, in-window heartbeat evidence.  An
+// empty heartbeat set (worker startup / wire-version drift omitting the
+// field) and a future-dated heartbeat (malformed clock conversion) must
+// NOT read as Online — both were previously treated as "trivially
+// fresh" and fell straight through to Online (false-green).
+
+func TestBuild_Degraded_EmptyHeartbeats(t *testing.T) {
+	dp := &fakeUserspaceDP{
+		fakeDP: fakeDP{loaded: true},
+		status: userspace.ProcessStatus{
+			// No heartbeats published yet.
+			WorkerHeartbeats: []time.Time{},
+		},
+	}
+	fs, _ := Build(dp, freshProcReader(), time.Now(), SamplerSnapshot{})
+	if fs.State == StateOnline {
+		t.Errorf("empty heartbeats: state %q, must not be Online", fs.State)
+	}
+	if fs.State != StateDegraded {
+		t.Errorf("empty heartbeats: state %q, want Degraded", fs.State)
+	}
+}
+
+func TestBuild_Degraded_NilHeartbeats(t *testing.T) {
+	dp := &fakeUserspaceDP{
+		fakeDP: fakeDP{loaded: true},
+		// WorkerHeartbeats field omitted entirely (nil slice).
+		status: userspace.ProcessStatus{},
+	}
+	fs, _ := Build(dp, freshProcReader(), time.Now(), SamplerSnapshot{})
+	if fs.State == StateOnline {
+		t.Errorf("nil heartbeats: state %q, must not be Online", fs.State)
+	}
+	if fs.State != StateDegraded {
+		t.Errorf("nil heartbeats: state %q, want Degraded", fs.State)
+	}
+}
+
+func TestBuild_Degraded_FutureHeartbeat(t *testing.T) {
+	now := time.Now()
+	dp := &fakeUserspaceDP{
+		fakeDP: fakeDP{loaded: true},
+		status: userspace.ProcessStatus{
+			WorkerHeartbeats: []time.Time{
+				now.Add(-100 * time.Millisecond),
+				now.Add(30 * time.Second), // malformed/future conversion
+			},
+		},
+	}
+	fs, _ := Build(dp, freshProcReader(), time.Now(), SamplerSnapshot{})
+	if fs.State == StateOnline {
+		t.Errorf("future heartbeat: state %q, must not be Online", fs.State)
+	}
+	if fs.State != StateDegraded {
+		t.Errorf("future heartbeat: state %q, want Degraded", fs.State)
+	}
+}
+
+func TestHeartbeatsHealthy(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	cases := []struct {
+		name string
+		hbs  []time.Time
+		want bool
+	}{
+		{"nil", nil, false},
+		{"empty", []time.Time{}, false},
+		{"one-fresh", []time.Time{now.Add(-100 * time.Millisecond)}, true},
+		{"all-fresh", []time.Time{now.Add(-100 * time.Millisecond), now.Add(-1 * time.Second)}, true},
+		{"one-stale", []time.Time{now.Add(-100 * time.Millisecond), now.Add(-5 * time.Second)}, false},
+		{"boundary-eq-maxage", []time.Time{now.Add(-2 * time.Second)}, true},
+		{"future", []time.Time{now.Add(1 * time.Second)}, false},
+		{"future-among-fresh", []time.Time{now.Add(-100 * time.Millisecond), now.Add(500 * time.Millisecond)}, false},
+	}
+	for _, tc := range cases {
+		if got := heartbeatsHealthy(tc.hbs, now, 2*time.Second); got != tc.want {
+			t.Errorf("%s: heartbeatsHealthy=%v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
 // (Cluster-mode rendering moved to the gRPC handler in #879;
 // fwdstatus.Build no longer takes a clusterMode flag. Cluster
 // composition tests live in pkg/grpcapi/.)


### PR DESCRIPTION
## Problem

`show chassis forwarding` reported `State=Online` on the userspace path
without any positive evidence that a packet-processing worker was alive.
The state switch (`pkg/fwdstatus/builder.go`) called `allHeartbeatsFresh`,
which returned `true` for two non-live cases:

- an **empty** heartbeat slice (worker startup, or a wire-version
  mismatch that omits `worker_heartbeats`) — the loop body never runs,
  so it read as "trivially fresh"; and
- a **future-dated** heartbeat — `now.Sub(hb) > maxAge` is false when the
  age is negative, so a malformed/torn clock conversion counted as fresh.

Both fell straight through to `StateOnline` — a false-green forwarding
state that delays operator/automation failover response.

## Fix

Replace `allHeartbeatsFresh` with `heartbeatsHealthy`: `Online` requires
the slice to be non-empty and every heartbeat to fall in the closed age
window `[0, maxAge]`. Heartbeats and `now` share the host clock, so a
future heartbeat is treated as not-fresh. Empty/nil/future heartbeat sets
now classify as `Degraded`, never `Online`.

## Tests

RED-verified the three Build-level cases report `Online` under the old
fail-open logic. Added `TestBuild_Degraded_{Empty,Nil,Future}Heartbeat`
and a table-driven `TestHeartbeatsHealthy` (boundary age==maxAge fresh,
stale, future, mixed). `go test ./pkg/fwdstatus/...` green; `go build
./...` clean. README Gotchas documents the Online-evidence contract.

Closes #4875