### PR TITLE
ddns: make corrupt-state fail-closed posture durable across restart (#4873)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43873,3 +43873,6 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4870 — dhcpserver fail-closed on systemctl is-active query error. unitIsActive now returns (bool, error): a recognized state string is authoritative, an undeterminable query (timeout/exec/garbled) returns an error instead of silent "inactive". reconcileFamilyRestart restarts + surfaces the error on an uncertain query (was: skip restart, report success); clearFamilyLocked stops + surfaces the error and the config-unlink error on a removed family.
   **File(s)**: pkg/dhcpserver/dhcpserver.go, pkg/dhcpserver/test_seams.go, pkg/dhcpserver/dhcpserver_isactive_error_4870_test.go, pkg/dhcpserver/README.md
+- **Timestamp**: 2026-07-09
+  **Action**: #4873 (A) — make the DDNS corrupt-state fail-closed posture durable across restart. loadStateOrDegrade now writes a durable <path>.degraded marker when it quarantines a corrupt/unsupported ownership file, and honors that marker first on every load, so a restart after quarantine stays degraded instead of coming up clean-but-empty (fail-open) and resuming publish/withdraw with ownership forgotten. Covers both the main manager and SurfaceA (same gate).
+  **File(s)**: pkg/ddns/state.go, pkg/ddns/manager.go, pkg/ddns/corrupt_state_durable_4873_test.go, pkg/ddns/README.md

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -16,7 +16,7 @@ moved with its assertions intact.
 | File | Contents |
 |------|----------|
 | `manager.go` | `Manager` (the DDNS reconcile engine — moved from `dhcpserver/ddns.go`): `policyFromConfig`, `Reconcile`, `reconcileOnceLocked`, `upsertLocked`/`deleteOwnedLocked`, `withdrawAllLocked`, `ownerWatermark`, `dhcidSharedWithOther` (#2700 shared-DHCID guard), `Stats` (incl. `PTRPendingNow`, #2708), `OwnedRecordView(s)`, the `errDDNSNoBackendToWithdraw` keep-ownership sentinel (#2699), the write-ahead durability + never-delete-non-owned boundary. Also the `Lease` record + `LeaseParser` seam. |
-| `state.go` | Ownership state store (`ownedRecord`, `ddnsState`, `loadDDNSState`, durable `save` via `fsatomic.WriteFileDurable`) — moved from `dhcpserver/ddns_state.go`. Also the fail-closed load classifiers `errDDNSStateCorrupt` / `errDDNSStateUnsupportedVersion` + `quarantineBadState` (#2650). |
+| `state.go` | Ownership state store (`ownedRecord`, `ddnsState`, `loadDDNSState`, durable `save` via `fsatomic.WriteFileDurable`) — moved from `dhcpserver/ddns_state.go`. Also the fail-closed load classifiers `errDDNSStateCorrupt` / `errDDNSStateUnsupportedVersion` + `quarantineBadState` (#2650) + the durable `<path>.degraded` marker helpers `readDegradedMarker` / `writeDegradedMarker` (#4873) that keep the fail-closed posture across restart. |
 | `backend.go` | `DNSUpdater` interface, `LeaseDNSRecord`, `nopUpdater`, the record + reverse-PTR-name helpers — moved from `dhcpserver/ddns_dns.go`. |
 | `backend_rfc2136.go` | The LIVE RFC 2136 backend (`rfc2136Updater`): exact-RR adds/deletes, TSIG, RFC 4701 DHCID + RFC 4703 replace-owned two-attempt, the `errDDNSConflictRefused` / `errDDNSPTRPending` sentinels — moved from `dhcpserver/ddns_rfc2136.go`. `sendRemoveForward(..., keepDHCID)` keeps a shared DHCID on a partial dual-stack teardown (#2700); `dnsCanonicalFQDN` mirrors the DHCID FQDN canonicalization. |
 | `hostname.go` | Deterministic hostname → DNS-label normalization (pure) — moved from `dhcpserver/ddns_hostname.go`. |
@@ -242,6 +242,19 @@ no change in those packages:
   state is surfaced as a `show ... dynamic-dns` ALARM and the
   `xpf_dhcp_ddns_degraded` Prometheus gauge so the lost cleanup authority is
   never silent.
+  - **The fail-closed posture is DURABLE across restart (#4873).** Quarantine
+    renames the corrupt canonical file away, so a naive reload on the next boot
+    would find no file, load an EMPTY store with a nil error, and NOT degrade —
+    silently resuming publish/withdraw with all prior ownership forgotten (the
+    fail-open the in-memory `degraded` flag alone cannot prevent, since it does
+    not outlive the process). `loadStateOrDegrade` therefore writes a durable
+    `<path>.degraded` marker (via `fsatomic.WriteFileDurable`) whenever it
+    quarantines a corrupt/unsupported file, and honors that marker FIRST on every
+    load: while the marker exists the manager stays degraded regardless of the
+    canonical file's state. An operator resolves it EXPLICITLY by removing the
+    marker (after inspecting/importing the quarantined `.corrupt-*` copy) — a bare
+    restart no longer clears it. An unreadable (permission/IO, non-classified)
+    file is NOT marker-persisted, because those bytes may be fine on retry.
 - **Surface A ownership state fails CLOSED too (#2971)** — the Surface A
   (router/interface-address) `SurfaceAManager` previously BYPASSED the #2650
   wrapper: `NewSurfaceAManager` called `loadDDNSState` directly and, on any load
@@ -256,8 +269,9 @@ no change in those packages:
   WHOLE pass (no publish, no withdraw, no `save()` — the bad file is preserved)
   until the operator resolves it. A MISSING file (first boot) is NOT degraded, so
   a fresh node — including a STANDALONE (nil-gate) node — still publishes
-  normally; a restart with the bad file quarantined aside re-reads an absent
-  (clean-empty) store and resumes publishing. The degraded state is surfaced as a
+  normally; a restart after a corrupt file was quarantined stays degraded via the
+  durable `.degraded` marker (#4873) until the operator removes it — it no longer
+  re-reads an absent store and silently resumes publishing. The degraded state is surfaced as a
   `show services dynamic-dns` Surface A ALARM (CLI + gRPC) and the
   `xpf_ddns_surface_a_degraded` Prometheus gauge, and on `SurfaceAStats.Degraded`
   / `DegradedReason`.

--- a/pkg/ddns/corrupt_state_durable_4873_test.go
+++ b/pkg/ddns/corrupt_state_durable_4873_test.go
@@ -1,0 +1,127 @@
+package ddns
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestCorruptStateDegradedSurvivesRestart is the #4873 (A) fail-on-revert test.
+//
+// A corrupt ownership state file is quarantined (renamed to `.corrupt-<ts>`) and
+// the manager fails closed in-process. But the fail-closed posture must ALSO be
+// DURABLE: quarantine removes the only canonical file, so a naive reload on the
+// next boot would find no file, load an EMPTY store with a nil error, and
+// silently resume publish/withdraw with all prior ownership forgotten. A durable
+// `.degraded` marker keeps a restarted manager degraded until an operator
+// resolves it.
+//
+// fail-on-revert: without the durable marker the SECOND construction (simulating
+// a restart over the same directory, canonical file already quarantined away)
+// comes up NOT degraded, and its reconcile publishes the lease — the exact
+// fail-open. Both assertions below then fail.
+func TestCorruptStateDegradedSurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.json")
+	clock := func() time.Time { return time.Unix(1_700_000_000, 0) }
+
+	// Boot 1: a corrupt store left behind by a crash / disk fault.
+	writeCSV(t, statePath, "{ this is not valid json at all")
+	m1 := newManagerForTesting(
+		(&fakeLeaseSource{v4: laptopMacLease()}).parser(),
+		newFakeUpdater(),
+		statePath,
+		filepath.Join(dir, "leases4.csv"),
+		filepath.Join(dir, "leases6.csv"),
+		"node0",
+		clock,
+	)
+	if !m1.degraded {
+		t.Fatal("boot 1: manager must be DEGRADED after loading a corrupt state file")
+	}
+	// The corrupt file must have been quarantined away.
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("boot 1: corrupt state file must be quarantined (renamed away); stat err=%v", err)
+	}
+	// A DURABLE degraded marker must exist beside the store.
+	if _, err := os.Stat(degradedMarkerPath(statePath)); err != nil {
+		t.Fatalf("boot 1: durable degraded marker must be written; stat err=%v", err)
+	}
+
+	// Boot 2: a brand-new manager over the SAME directory (simulating a
+	// restart). The canonical file is gone (quarantined), so ONLY the durable
+	// marker can keep it fail-closed.
+	up2 := newFakeUpdater()
+	m2 := newManagerForTesting(
+		(&fakeLeaseSource{v4: laptopMacLease()}).parser(),
+		up2,
+		statePath,
+		filepath.Join(dir, "leases4.csv"),
+		filepath.Join(dir, "leases6.csv"),
+		"node0",
+		clock,
+	)
+	if !m2.degraded {
+		t.Fatal("boot 2 (restart): manager must STILL be degraded from the durable marker, " +
+			"not resume clean-but-empty (fail-open)")
+	}
+
+	// The restarted manager must not proceed as owner/updated: an ENABLED
+	// reconcile with a live lease must publish and withdraw NOTHING.
+	cfg := &config.DHCPServerConfig{
+		DynamicDNS: &config.DHCPDynamicDNSConfig{
+			Enabled:    true,
+			Domain:     "example.com",
+			TTLSeconds: 300,
+		},
+	}
+	if err := m2.Reconcile(context.Background(), cfg); err == nil {
+		t.Fatal("boot 2: reconcile must return an error while degraded (fail closed)")
+	}
+	if names := up2.upsertNames(); len(names) != 0 {
+		t.Fatalf("boot 2: degraded manager must NOT publish any record, got upserts %v", names)
+	}
+	if names := up2.deleteNames(); len(names) != 0 {
+		t.Fatalf("boot 2: degraded manager must NOT withdraw any record, got deletes %v", names)
+	}
+	// The reconcile must NOT recreate a fresh (empty) canonical state file.
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatal("boot 2: degraded manager must not recreate the ownership state file")
+	}
+}
+
+// TestDegradedMarkerGatesEvenWithValidState confirms the durable marker is
+// authoritative: even if a syntactically VALID canonical state file is present,
+// a lingering `.degraded` marker keeps the manager fail-closed until an operator
+// removes it (explicit resolution). This guards against a partial "recovery"
+// that restores state bytes but leaves the fail-closed signal in place.
+func TestDegradedMarkerGatesEvenWithValidState(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.json")
+	// A valid, empty-but-parseable state file.
+	writeCSV(t, statePath, `{"version":1,"records":[]}`)
+	// And a durable degraded marker from a prior corruption event.
+	if err := writeDegradedMarker(statePath, "ddns: prior corruption not yet resolved"); err != nil {
+		t.Fatalf("writeDegradedMarker: %v", err)
+	}
+
+	st, degraded, reason := loadStateOrDegrade(statePath, func() time.Time { return time.Unix(1, 0) })
+	if !degraded {
+		t.Fatal("a present degraded marker must fail closed even with a valid state file")
+	}
+	if reason == "" {
+		t.Fatal("degraded reason must be surfaced from the marker")
+	}
+	if st == nil {
+		t.Fatal("loadStateOrDegrade must still return a constructible store")
+	}
+	// The valid canonical file must NOT be quarantined (it was not corrupt) — a
+	// marker gate is not a re-classification.
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("valid state file must be left in place under a marker gate; stat err=%v", err)
+	}
+}

--- a/pkg/ddns/manager.go
+++ b/pkg/ddns/manager.go
@@ -318,6 +318,22 @@ type Manager struct {
 // unreadable file (permission / IO) is NOT quarantined — the bytes may be fine
 // and re-readable, so it would be wrong to move the file under a transient fault.
 func loadStateOrDegrade(path string, now func() time.Time) (st *ddnsState, degraded bool, reason string) {
+	// #4873: honor a DURABLE degraded marker FIRST. Quarantine (below) renames
+	// the corrupt canonical file away, so on the next boot a naive reload would
+	// find no file, load an empty store with a nil error, and silently resume
+	// publish/withdraw with all prior ownership forgotten (fail-open). While the
+	// marker exists we stay degraded regardless of the canonical file's state,
+	// until an operator explicitly removes the marker after repair/import. Still
+	// load the store so the manager has a path-initialized (constructible)
+	// handle; its contents are unused while every reconcile op is suspended.
+	if mreason, ok := readDegradedMarker(path); ok {
+		st, _ = loadDDNSState(path)
+		slog.Error("ddns: FAILING CLOSED on a persisted degraded marker; publishing and "+
+			"withdrawals are SUSPENDED until the operator removes it", "reason", mreason,
+			"marker", degradedMarkerPath(path))
+		return st, true, mreason
+	}
+
 	st, err := loadDDNSState(path)
 	if err == nil {
 		return st, false, ""
@@ -338,6 +354,15 @@ func loadStateOrDegrade(path string, now func() time.Time) (st *ddnsState, degra
 				"publishing and withdrawals are SUSPENDED until the operator resolves it",
 				"err", err, "quarantine", qp)
 			reason += " (quarantined to " + qp + ")"
+		}
+		// Persist the fail-closed posture durably (#4873): quarantine just
+		// removed the canonical file, so without this a restart would come up
+		// clean-but-empty and resume as if it owns nothing. The marker keeps the
+		// manager degraded across restarts until the operator resolves it.
+		if werr := writeDegradedMarker(path, reason); werr != nil {
+			slog.Error("ddns: could not persist the degraded marker; a RESTART may FAIL OPEN "+
+				"(resume with empty ownership)", "err", werr, "marker", degradedMarkerPath(path))
+			reason += " (degraded-marker write failed: " + werr.Error() + ")"
 		}
 	} else {
 		slog.Error("ddns: FAILING CLOSED on unreadable ownership state; publishing and withdrawals "+

--- a/pkg/ddns/state.go
+++ b/pkg/ddns/state.go
@@ -373,6 +373,54 @@ func quarantineBadState(path string, now time.Time) (string, error) {
 	return dst, nil
 }
 
+// degradedMarkerSuffix names the DURABLE fail-closed marker written beside the
+// ownership store when a corrupt / unsupported-version file is quarantined
+// (#4873). Its presence keeps the manager DEGRADED across restarts. Quarantine
+// renames the only canonical file away, so without a durable marker the next
+// boot would find no file, load an EMPTY store with a NIL error, and silently
+// resume publish/withdraw with all prior ownership forgotten — the exact
+// fail-open this closes (a previously-published A/AAAA/PTR can then leak into
+// authoritative DNS forever, or a later publish can re-claim a peer-owned name
+// with no DHCID ownership record left to veto it). The in-memory `degraded`
+// flag alone does not survive the process. The manager stays degraded until an
+// operator explicitly resolves it by removing this marker (after inspecting or
+// importing the quarantined `.corrupt-*` copy).
+const degradedMarkerSuffix = ".degraded"
+
+func degradedMarkerPath(statePath string) string {
+	return statePath + degradedMarkerSuffix
+}
+
+// readDegradedMarker reports whether a durable degraded marker exists for the
+// ownership store at statePath and returns the recorded reason. A marker that
+// exists but cannot be read is still treated as PRESENT (ok=true) with a
+// generic reason — an unreadable fail-closed marker must never silently clear
+// the fail-closed posture. Only a genuine not-exist yields ok=false.
+func readDegradedMarker(statePath string) (reason string, ok bool) {
+	data, err := os.ReadFile(degradedMarkerPath(statePath))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false
+		}
+		return "ddns: ownership state degraded (marker present but unreadable: " + err.Error() + ")", true
+	}
+	reason = strings.TrimSpace(string(data))
+	if reason == "" {
+		reason = "ddns: ownership state degraded (persisted #4873 marker present)"
+	}
+	return reason, true
+}
+
+// writeDegradedMarker durably persists the fail-closed posture beside the
+// ownership store (#4873) so it survives a restart after the corrupt file was
+// quarantined away.
+func writeDegradedMarker(statePath, reason string) error {
+	if err := os.MkdirAll(dirOf(statePath), 0o755); err != nil {
+		return fmt.Errorf("create ddns state dir for degraded marker: %w", err)
+	}
+	return fsatomic.WriteFileDurable(degradedMarkerPath(statePath), []byte(reason+"\n"), 0o600)
+}
+
 // save persists the store durably (fsync-on-write). Records are sorted by
 // key for a deterministic file.
 func (s *ddnsState) save() error {


### PR DESCRIPTION
## Summary
A corrupt/unknown-version DDNS ownership store already fails closed **in-process** (#2650): `loadStateOrDegrade` sets `Manager.degraded`, quarantines the bad file to `<path>.corrupt-<ts>`, and the reconciler refuses all publish/withdraw. But that posture was only in-memory. Quarantine renames the sole canonical file away, so on the next boot `loadDDNSState` finds no file, returns an empty store with a **nil** error, and the manager comes up **NOT degraded** — silently resuming publish/withdraw with all prior ownership forgotten. That fail-open leaks previously-published A/AAAA/PTR records into authoritative DNS forever and lets a later publish re-claim a peer-owned name (the lost DHCID/ownership can no longer veto it).

## Fix
`loadStateOrDegrade` now:
- writes a **durable** `<path>.degraded` marker (`fsatomic.WriteFileDurable`) whenever it quarantines a corrupt/unsupported file;
- **honors that marker first** on every load — while it exists the manager stays degraded regardless of the canonical file's state.

Resolution is explicit: the operator removes the marker after inspecting/importing the quarantined `.corrupt-*` copy; a bare restart no longer clears it. An unreadable (permission/IO, non-classified) file is deliberately **not** marker-persisted (bytes may be fine on retry); an unreadable marker is treated as present (fail closed). The gate covers both the main manager and the Surface A manager (they share `loadStateOrDegrade`).

## Test
`pkg/ddns/corrupt_state_durable_4873_test.go`:
- boot 1: corrupt store degrades and writes the durable marker;
- boot 2 (fresh manager over the same dir, canonical file already quarantined away): stays degraded from the marker, publishes/withdraws nothing, does not recreate state;
- a lingering marker fails closed even with a valid state file present.

Red-on-revert verified: reverting `loadStateOrDegrade` to the in-memory-only behavior makes boot 2 come up clean-but-empty and the tests red. `go test ./pkg/ddns/...` green; `go build ./...` clean. Documented in `pkg/ddns/README.md`.

Scope note: this fixes defect **A** (corrupt-state quarantine durability across restart, which the issue's TEST targets). Defects **B** (write-ahead state-dir fsync) and **C** (per-family withdraw updater identity) are separate and left to follow-up.

Closes #4873