### PR TITLE
upgrade: fail closed on ambiguous kernel-roll / self-recover state

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43877,3 +43877,7 @@ top.
   **File(s)**: userspace-dp/src/nat/allocator.rs, userspace-dp/src/nat/tests_pool.rs, docs/deterministic-nat-cgnat.md
   **Action**: #4870 — dhcpserver fail-closed on systemctl is-active query error. unitIsActive now returns (bool, error): a recognized state string is authoritative, an undeterminable query (timeout/exec/garbled) returns an error instead of silent "inactive". reconcileFamilyRestart restarts + surfaces the error on an uncertain query (was: skip restart, report success); clearFamilyLocked stops + surfaces the error and the config-unlink error on a removed family.
   **File(s)**: pkg/dhcpserver/dhcpserver.go, pkg/dhcpserver/test_seams.go, pkg/dhcpserver/dhcpserver_isactive_error_4870_test.go, pkg/dhcpserver/README.md
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4872 pkg/upgrade fail-closed hardening — (A) Promote checks RunningKernel before pruning on BootCurrent error; indeterminate state preserves journal + no reboot; (B) StrictWatchdog arm failure aborts; watchdog helpers propagate I/O errors; (C) self-recover rejects lease missing expires_at; (D) grace clock resets on any observation error
+  **File(s)**: pkg/upgrade/kernel_run.go, pkg/upgrade/kernel_linux.go, pkg/upgrade/kernel_selfrecover.go, pkg/upgrade/kernel_test.go, pkg/upgrade/kernel_selfrecover_test.go, docs/in-place-upgrade.md

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -610,6 +610,32 @@ candidate boot, `xpf-kernel-promote.service` runs the kernel-space
 `/var/lib/xpf/kernel-upgrade.state` makes the trial crash-safe and
 idempotent across the reboot.
 
+**Fail-closed on ambiguous boot/watchdog state (#4872).** The gate never
+treats an unreadable observation as a definite safe state:
+
+- *BootCurrent read error.* When `efibootmgr`/NVRAM can't report which
+  slot the firmware booted, `Promote` no longer blindly runs
+  `cleanupAlreadyOnKnownGood` (which PRUNES the candidate slot —
+  `/lib/modules/<candidate>` + `/boot/*-<candidate>`). It first reads
+  `RunningKernel`: if it equals the candidate we ARE on the candidate, so
+  it runs the verification gate (`verifyAndPromote`) instead of deleting
+  the kernel it is running; only a positively-identified non-candidate
+  running kernel takes the prune path. If BOTH `BootCurrent` and
+  `RunningKernel` are unreadable the state is indeterminate —
+  `recoverIndeterminate` preserves the journal + candidate, does NO prune
+  and NO reboot, and surfaces a non-revert error so the oneshot maps it to
+  an infra exit (not the exit-3 reboot). The next boot re-runs the gate.
+- *StrictWatchdog (D1) arm failure.* The preflight only checks the BAKED
+  watchdog-persistence flag; `armCandidate` now also treats a real
+  `ArmWatchdog` failure as fatal UNDER STRICT MODE — it aborts the arm
+  (no `BootNext`, no reboot, journal stays INSTALLED) rather than
+  rebooting into the candidate with no functioning watchdog. D2 keeps the
+  best-effort log-and-continue. The `realKernelSystem` watchdog helpers no
+  longer swallow I/O errors: `ArmWatchdog` surfaces a `WDIOC_SETTIMEOUT`
+  failure (after still attempting the keepalive), and `DisarmWatchdog`
+  propagates open/write/close failures (a genuinely-absent device is still
+  a clean nil).
+
 In a cluster the roll is driven ONE NODE AT A TIME by the external
 orchestrator (`scripts/deploy/xpf-deploy.py kernel-roll`): drain
 secondary-first (`xpfd upgrade kernel drain`, which confirms the peer
@@ -672,7 +698,17 @@ carrying traffic:
    (`/var/lib/xpf/kernel-roll.lease`), a drained local node, and a
    healthy primary peer, held continuously for the grace window. A
    manually drained node or a #1917 binary-rolling drain never wrote a
-   kernel-roll lease (`leaseNone`) and is left alone.
+   kernel-roll lease (`leaseNone`) and is left alone. The lease must carry
+   a real `expires_at` (#4872): a semantic-empty body (`{}`) or one that
+   omits the deadline decodes to `NodeID=0` + the zero time and, on node
+   0, would otherwise read as an already-expired lease naming us and
+   spuriously self-recover during a maintenance drain — a missing deadline
+   is now rejected as no-decision (`leaseNone`). The grace window also
+   requires CONTINUOUS positive evidence: any observation error
+   (`Armed`/`LocalDrained`/`PeerHealthyPrimary`, e.g. a transient
+   management outage) RESETS `drainedSince`, so a run of errored ticks
+   can't silently age the deadline and let the next positive tick rejoin
+   immediately.
 3. **Still-armed gate.** Self-recovery refuses to rejoin while the kernel
    journal is still ARMED even if the lease has expired — a legitimately
    long-hanging roll (one that outran its lease TTL) is still a trial in

--- a/pkg/upgrade/kernel_linux.go
+++ b/pkg/upgrade/kernel_linux.go
@@ -312,11 +312,22 @@ func (s *realKernelSystem) ArmWatchdog() error {
 	defer unix.Close(fd)
 
 	timeout := watchdogTimeoutSecs()
-	// WDIOC_SETTIMEOUT failure (driver doesn't support it) is non-fatal — fall
-	// through to a keepalive write to at least pet whatever default timeout the
-	// driver has; the keepalive is the minimal arm signal.
-	_, _, _ = unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(unix.WDIOC_SETTIMEOUT), uintptr(unsafe.Pointer(&timeout)))
-	return writeWatchdogKeepalive(fd)
+	// Attempt to set a generous timeout, then pet. We ALWAYS attempt the
+	// keepalive first so a driver that lacks WDIOC_SETTIMEOUT still gets a pet on
+	// its default timeout (the D2 weak-arm). But a SETTIMEOUT failure means we
+	// could NOT establish the generous timeout the roll relies on, so we must
+	// SURFACE it rather than swallow it (#4872 B): a StrictWatchdog (D1)
+	// deployment treats an arm failure as fatal and refuses to reboot with a
+	// watchdog whose timeout we could not control. The caller (armCandidate)
+	// decides strict-vs-best-effort; this method's job is to report the truth.
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(unix.WDIOC_SETTIMEOUT), uintptr(unsafe.Pointer(&timeout)))
+	if err := writeWatchdogKeepalive(fd); err != nil {
+		return err
+	}
+	if errno != 0 {
+		return fmt.Errorf("watchdog WDIOC_SETTIMEOUT(%ds): %w", timeout, errno)
+	}
+	return nil
 }
 
 func (s *realKernelSystem) Reboot() error {
@@ -482,15 +493,31 @@ func (s *realKernelSystem) SetBootOrderFront(bootID string) error {
 }
 
 func (s *realKernelSystem) DisarmWatchdog() error {
+	// A genuinely-absent watchdog device is "nothing to disarm" — nil. But an
+	// I/O failure while a device IS present (open/write/close) was previously
+	// swallowed into nil, hiding a watchdog that is still armed and could bounce
+	// the box (#4872 B). Surface those errors so the caller can log them (or, in
+	// strict contexts, react) instead of assuming a clean disarm.
 	if _, err := os.Stat("/dev/watchdog"); err != nil {
-		return nil
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat /dev/watchdog: %w", err)
 	}
 	fd, err := unix.Open("/dev/watchdog", unix.O_WRONLY|unix.O_NONBLOCK, 0)
 	if err != nil {
-		return nil
+		return fmt.Errorf("open /dev/watchdog for disarm: %w", err)
 	}
-	_, _ = unix.Write(fd, []byte{'V'})
-	_ = unix.Close(fd)
+	// The magic-close 'V' tells the driver to disable the watchdog on close
+	// (WDIOF_MAGICCLOSE). Both the write and the close must succeed for the
+	// disarm to actually take effect.
+	if _, werr := unix.Write(fd, []byte{'V'}); werr != nil {
+		_ = unix.Close(fd)
+		return fmt.Errorf("write watchdog magic-close: %w", werr)
+	}
+	if cerr := unix.Close(fd); cerr != nil {
+		return fmt.Errorf("close /dev/watchdog: %w", cerr)
+	}
 	return nil
 }
 

--- a/pkg/upgrade/kernel_run.go
+++ b/pkg/upgrade/kernel_run.go
@@ -297,7 +297,19 @@ func (r *KernelRunner) armCandidate(j *KernelJournal) error {
 	}
 
 	if err := sys.ArmWatchdog(); err != nil {
-		// Non-fatal under D2: BootNext is the loop-safety. Log and continue.
+		if r.cfg.StrictWatchdog {
+			// D1 (strict): a strict deployment REQUIRES a functioning watchdog.
+			// The preflight only checked the BAKED persistence flag
+			// (WatchdogStatus); the actual arm failing HERE means we would reboot
+			// into the candidate with no functioning watchdog, silently defeating
+			// strict mode's guarantee (#4872 B). Abort the arm — do NOT set
+			// BootNext, do NOT reboot. The journal is still INSTALLED (we have not
+			// transitioned to ARMED yet) and BootNext was never set, so the box
+			// stays on the known-good default and a retry can re-arm cleanly.
+			return fmt.Errorf("%w: strict-watchdog (D1) arm failed: %v", ErrKernelChannelUnavailable, err)
+		}
+		// D2 (best-effort): BootNext is the loop-safety. Log and continue; an
+		// early-boot hang would need one external/console reset to recover.
 		r.logf("kernel-upgrade arm: WARNING arm watchdog: %v (continuing; BootNext closes the loop)", err)
 	}
 
@@ -358,9 +370,39 @@ func (r *KernelRunner) Promote() error {
 	}
 	cur, err := sys.BootCurrent()
 	if err != nil {
-		// Can't tell which slot we booted. Do NOT reboot (that risks a loop on
-		// a flaky efibootmgr — r1 AGY): clean up to known-good in place.
-		return r.cleanupAlreadyOnKnownGood(j, fmt.Errorf("read BootCurrent: %w", err))
+		// Can't read which slot the firmware booted. The old code treated this
+		// as "already on known-good" and ran cleanupAlreadyOnKnownGood, which
+		// PRUNES the candidate slot (deletes /lib/modules/<candidate> +
+		// /boot/*-<candidate>). But a transient efibootmgr/NVRAM read error does
+		// NOT mean we are off the candidate — if BootNext actually booted it, we
+		// would be deleting the running kernel's own modules/boot files (#4872 A).
+		// Fail CLOSED on the destructive prune: check RunningKernel first.
+		running, rkErr := sys.RunningKernel()
+		switch {
+		case rkErr != nil:
+			// Neither the booted slot NOR the running kernel is knowable. We
+			// cannot prove we are off the candidate, so we must NOT prune, and we
+			// must NOT reboot (a read-only-root reboot loop is the other hazard).
+			// Preserve the journal + candidate untouched and surface the error;
+			// the next boot re-runs this gate, and any reboot meanwhile lands on
+			// the known-good BootOrder front (BootNext already consumed).
+			return r.recoverIndeterminate(j, fmt.Errorf(
+				"read BootCurrent: %v; running kernel also unreadable: %w", err, rkErr))
+		case running == j.CandidateVersion:
+			// We ARE running the candidate despite the BootCurrent read error.
+			// Do NOT prune the kernel we are running — run the verification gate
+			// so a healthy candidate can still promote and an unhealthy one takes
+			// the controlled (bounded) revert path, never the silent-delete path.
+			r.logf("kernel-upgrade: BootCurrent unreadable (%v) but running kernel IS "+
+				"candidate %s; running verification gate (NOT pruning)", err, running)
+			return r.verifyAndPromote(j, candID, running)
+		default:
+			// Positive evidence we booted a non-candidate (known-good) kernel:
+			// pruning the un-promoted candidate slot is safe.
+			return r.cleanupAlreadyOnKnownGood(j, fmt.Errorf(
+				"read BootCurrent: %v; running kernel %s != candidate %s — on known-good",
+				err, running, j.CandidateVersion))
+		}
 	}
 	if cur != candID {
 		// Firmware ignored BootNext / fell back — this boot is ALREADY on a
@@ -381,9 +423,21 @@ func (r *KernelRunner) Promote() error {
 	if running != j.CandidateVersion {
 		return r.revert(j, fmt.Errorf("running kernel %s != candidate %s", running, j.CandidateVersion))
 	}
+	return r.verifyAndPromote(j, candID, running)
+}
+
+// verifyAndPromote runs the post-Gate-2 verification (verify-dataplane +
+// forward beacon) and, on success, promotes the candidate; on any failure it
+// reverts. It is entered only after we have CONFIRMED the running kernel is the
+// candidate (`running == j.CandidateVersion`), either via the normal
+// BootCurrent==candidate path or the #4872-A fail-closed path where BootCurrent
+// was unreadable but RunningKernel positively identified the candidate — so it
+// never prunes the kernel it is validating.
+func (r *KernelRunner) verifyAndPromote(j *KernelJournal, candID, running string) error {
+	sys := r.cfg.Sys
 
 	// Gate 3: verify-dataplane (the #1864 kernel verifier) on the candidate.
-	ok, err = sys.VerifyDataplane()
+	ok, err := sys.VerifyDataplane()
 	if err != nil {
 		return r.revert(j, fmt.Errorf("verify-dataplane error: %w", err))
 	}
@@ -427,6 +481,23 @@ func (r *KernelRunner) Promote() error {
 	}
 	r.logf("kernel-upgrade: PROMOTED candidate %s (slot %s now default)", running, j.InactiveSlot)
 	return r.clearKernelJournal()
+}
+
+// recoverIndeterminate handles the post-reboot case where NEITHER the booted
+// slot (BootCurrent) NOR the running kernel (uname -r) is readable, so we
+// cannot prove we are off the candidate. Both the destructive prune (which
+// could delete a candidate we are actually running — #4872 A) and a reboot
+// (read-only-root reboot loop) are unsafe here, so this fails CLOSED: it
+// preserves the journal + candidate untouched, performs no prune and no reboot,
+// and returns the (non-revert) error so the promotion oneshot maps it to an
+// infra exit (NOT exit 3). The next boot re-runs the gate; if NVRAM/uname is
+// readable then it resolves normally, and any reboot meanwhile falls through
+// BootOrder to the known-good slot (BootNext already consumed).
+func (r *KernelRunner) recoverIndeterminate(j *KernelJournal, why error) error {
+	r.logf("kernel-upgrade: INDETERMINATE post-reboot state (%v); cannot confirm we are off "+
+		"the candidate — preserving journal + candidate (NO prune, NO reboot) for the next "+
+		"boot / operator to resolve", why)
+	return fmt.Errorf("kernel-upgrade promote: indeterminate boot state (no prune, no reboot): %w", why)
 }
 
 // revert records the revert reason, prunes the un-promoted candidate, and

--- a/pkg/upgrade/kernel_selfrecover.go
+++ b/pkg/upgrade/kernel_selfrecover.go
@@ -156,6 +156,20 @@ func (s *KernelSelfRecovery) readLeaseState() leaseState {
 		s.cfg.Logf("kernel self-recovery: ignoring unparsable lease %s: %v", s.cfg.LeasePath, err)
 		return leaseNone
 	}
+	// A well-formed lease MUST carry a real TTL deadline. A semantic-empty body
+	// (`{}`) or one that omits expires_at decodes to the zero time AND NodeID 0
+	// (the zero value); on node 0 that would slip past the NodeID guard and,
+	// because any real Now() is After the zero time, classify as an ALREADY-
+	// EXPIRED lease naming us — spuriously arming self-recovery and tearing a
+	// deliberately drained node back into the election during a maintenance
+	// window (#4872 C). Require expires_at: a missing/zero deadline is not a
+	// valid lease. Treat it as no-decision (leaseNone is a NO-OP in Tick), the
+	// safe direction that never triggers an unintended ResetFailover.
+	if l.ExpiresAt.IsZero() {
+		s.cfg.Logf("kernel self-recovery: ignoring lease %s missing required expires_at "+
+			"(NodeID=%d); treating as no-lease this tick", s.cfg.LeasePath, l.NodeID)
+		return leaseNone
+	}
 	if l.NodeID != s.cfg.NodeID {
 		return leaseOther
 	}
@@ -194,6 +208,12 @@ func (s *KernelSelfRecovery) Tick() (bool, error) {
 	if s.cfg.Armed != nil {
 		armed, err := s.cfg.Armed()
 		if err != nil {
+			// An observation error breaks the CONTINUOUS-evidence requirement:
+			// reset the grace clock so a run of errored ticks (e.g. a transient
+			// management outage) cannot silently age the deadline and let the next
+			// positive tick rejoin immediately (#4872 D). Grace must accrue only
+			// while every predicate is positively observed.
+			s.drainedSince = time.Time{}
 			return false, fmt.Errorf("kernel self-recovery: armed check: %w", err)
 		}
 		if armed {
@@ -206,6 +226,8 @@ func (s *KernelSelfRecovery) Tick() (bool, error) {
 
 	drained, err := s.cl.LocalDrained()
 	if err != nil {
+		// Observation error -> reset the grace clock (see #4872 D above).
+		s.drainedSince = time.Time{}
 		return false, fmt.Errorf("kernel self-recovery: local drained check: %w", err)
 	}
 	if !drained {
@@ -215,6 +237,8 @@ func (s *KernelSelfRecovery) Tick() (bool, error) {
 
 	peerOK, err := s.cl.PeerHealthyPrimary()
 	if err != nil {
+		// Observation error -> reset the grace clock (see #4872 D above).
+		s.drainedSince = time.Time{}
 		return false, fmt.Errorf("kernel self-recovery: peer health check: %w", err)
 	}
 	if !peerOK {

--- a/pkg/upgrade/kernel_selfrecover_test.go
+++ b/pkg/upgrade/kernel_selfrecover_test.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -215,5 +216,81 @@ func TestSelfRecoveryTimerResetsOnConditionLapse(t *testing.T) {
 	now = now.Add(40 * time.Second) // 80s total but only 40s since re-observe
 	if did, _ := sr.Tick(); did {
 		t.Fatal("timer should have reset on the lapse; not yet past grace")
+	}
+}
+
+// #4872 C: a semantic-empty lease body ({}) decodes to NodeID=0 + zero
+// ExpiresAt. On node 0 that would slip past the NodeID guard and read as an
+// ALREADY-EXPIRED lease naming us, spuriously arming self-recovery during a
+// deliberate maintenance drain. A lease with no expires_at must be rejected.
+func TestSelfRecoveryEmptyLeaseDoesNotRecover(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	cl := &fakeSRCluster{drained: true, peerOK: true}
+	sr := newSR(t, cl, &now, 1*time.Second)
+	if err := os.WriteFile(sr.cfg.LeasePath, []byte("{}"), 0644); err != nil {
+		t.Fatalf("write lease: %v", err)
+	}
+	_, _ = sr.Tick()
+	now = now.Add(10 * time.Second) // well past grace
+	if did, err := sr.Tick(); did || err != nil || cl.resets != 0 {
+		t.Fatalf("#4872 C: a semantic-empty {} lease must NOT trigger node-0 self-recovery "+
+			"(did=%v err=%v resets=%d)", did, err, cl.resets)
+	}
+}
+
+// #4872 C: a lease carrying node_id but no expires_at is missing a required
+// field and must not authorize self-recovery either.
+func TestSelfRecoveryLeaseMissingExpiryDoesNotRecover(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	cl := &fakeSRCluster{drained: true, peerOK: true}
+	sr := newSR(t, cl, &now, 1*time.Second)
+	if err := os.WriteFile(sr.cfg.LeasePath, []byte(`{"node_id":0,"holder":"orch"}`), 0644); err != nil {
+		t.Fatalf("write lease: %v", err)
+	}
+	_, _ = sr.Tick()
+	now = now.Add(10 * time.Second)
+	if did, _ := sr.Tick(); did || cl.resets != 0 {
+		t.Fatal("#4872 C: a lease missing expires_at must NOT trigger self-recovery")
+	}
+}
+
+// #4872 D: an observation error must RESET the grace clock so grace accrues
+// only while every predicate is continuously observed positive. A run of
+// errored ticks (transient management outage) must not silently age the
+// deadline and let the next positive tick rejoin immediately.
+func TestSelfRecoveryObservationErrorResetsGrace(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	cl := &fakeSRCluster{drained: true, peerOK: true}
+	sr := newSR(t, cl, &now, 60*time.Second)
+	writeLease(t, sr.cfg.LeasePath, KernelRollLease{NodeID: 0, ExpiresAt: now.Add(-time.Minute)})
+
+	// Tick 1: start the grace timer.
+	if did, err := sr.Tick(); did || err != nil {
+		t.Fatalf("tick 1 should only start the timer (did=%v err=%v)", did, err)
+	}
+	// Nearly a full grace window elapses, then a tick hits an observation error.
+	now = now.Add(59 * time.Second)
+	cl.peerErr = fmt.Errorf("transient management outage")
+	if did, err := sr.Tick(); did || err == nil {
+		t.Fatalf("errored tick must not recover and must surface the error (did=%v err=%v)", did, err)
+	}
+	// Clear the error and advance PAST the ORIGINAL deadline (61s since tick 1)
+	// but only just past the errored tick: with the grace clock reset this must
+	// NOT rejoin yet (pre-fix it would, because drainedSince still pointed at
+	// tick 1).
+	now = now.Add(2 * time.Second)
+	cl.peerErr = nil
+	if did, err := sr.Tick(); did || err != nil {
+		t.Fatalf("#4872 D: grace clock must restart after the errored-tick gap; must NOT "+
+			"rejoin yet (did=%v err=%v)", did, err)
+	}
+	if cl.resets != 0 {
+		t.Fatal("#4872 D: rejoined despite the reset grace window")
+	}
+	// After a fresh CONTINUOUS grace window it does recover.
+	now = now.Add(61 * time.Second)
+	if did, err := sr.Tick(); !did || err != nil || cl.resets != 1 {
+		t.Fatalf("should recover after a fresh continuous grace window (did=%v err=%v resets=%d)",
+			did, err, cl.resets)
 	}
 }

--- a/pkg/upgrade/kernel_test.go
+++ b/pkg/upgrade/kernel_test.go
@@ -32,6 +32,10 @@ type fakeKernelSystem struct {
 	wdArmed   bool
 
 	bootCurrent       string
+	bootCurrentErr    error
+	runningErr        error
+	armWatchdogErr    error
+	disarmWatchdogErr error
 	bootOrderFrontErr bool
 	verifyPass        bool
 	verifyErr         error
@@ -84,7 +88,7 @@ func (f *fakeKernelSystem) FreeBytes(p string) (uint64, error) {
 	}
 	return 1 << 40, nil
 }
-func (f *fakeKernelSystem) RunningKernel() (string, error) { return f.running, nil }
+func (f *fakeKernelSystem) RunningKernel() (string, error) { return f.running, f.runningErr }
 func (f *fakeKernelSystem) KernelHeld() (bool, error)      { return f.held, nil }
 func (f *fakeKernelSystem) InstallCandidateKernel(v string) (string, error) {
 	f.log("install:" + v)
@@ -119,8 +123,14 @@ func (f *fakeKernelSystem) SetBootNext(id string) error {
 	f.bootNext = id
 	return nil
 }
-func (f *fakeKernelSystem) ArmWatchdog() error { f.wdArmed = true; return nil }
-func (f *fakeKernelSystem) Reboot() error      { f.log("reboot"); f.rebooted = true; return nil }
+func (f *fakeKernelSystem) ArmWatchdog() error {
+	if f.armWatchdogErr != nil {
+		return f.armWatchdogErr
+	}
+	f.wdArmed = true
+	return nil
+}
+func (f *fakeKernelSystem) Reboot() error { f.log("reboot"); f.rebooted = true; return nil }
 func (f *fakeKernelSystem) WritePromotionMarker(u string) error {
 	f.promotionMarker = u
 	return nil
@@ -129,6 +139,9 @@ func (f *fakeKernelSystem) ReadPromotionMarker() (string, error) { return f.prom
 func (f *fakeKernelSystem) ClearPromotionMarker() error          { f.promotionMarker = ""; return nil }
 func (f *fakeKernelSystem) ClearRollLease() error                { return nil }
 func (f *fakeKernelSystem) BootCurrent() (string, error) {
+	if f.bootCurrentErr != nil {
+		return "", f.bootCurrentErr
+	}
 	if f.bootCurrent != "" {
 		return f.bootCurrent, nil
 	}
@@ -153,7 +166,13 @@ func (f *fakeKernelSystem) SetBootOrderFront(id string) error {
 	f.order = out
 	return nil
 }
-func (f *fakeKernelSystem) DisarmWatchdog() error { f.wdArmed = false; return nil }
+func (f *fakeKernelSystem) DisarmWatchdog() error {
+	if f.disarmWatchdogErr != nil {
+		return f.disarmWatchdogErr
+	}
+	f.wdArmed = false
+	return nil
+}
 func (f *fakeKernelSystem) PruneInactiveSlot(slot, kg, cand string) error {
 	f.log("prune:" + slot)
 	f.selectors[slot] = kg
@@ -593,5 +612,123 @@ func TestKernelPromoteRevertsOnBootOrderFailure(t *testing.T) {
 	err := r.Promote()
 	if !errorsIsReverted(err) {
 		t.Fatalf("expected a REVERT when promote BootOrder reorder fails, got %v", err)
+	}
+}
+
+// --- #4872 A: a transient BootCurrent read error while ACTUALLY running the
+// candidate must NOT prune the running candidate; it runs the verification gate
+// (and a healthy candidate still promotes). ---
+func TestKernelPromoteBootCurrentErrRunningCandidateDoesNotPrune(t *testing.T) {
+	f := newFakeKernelSystem()
+	r := newKernelRunner(t, f)
+	if err := r.Arm("6.18.5-12-generic"); err != nil {
+		t.Fatalf("Arm: %v", err)
+	}
+	// The candidate DID boot, but efibootmgr/NVRAM read of BootCurrent is flaky.
+	f.bootCurrentErr = fmt.Errorf("simulated efibootmgr read failure")
+	f.running = "6.18.5-12-generic" // we ARE running the candidate
+	f.verifyPass = true
+	f.beaconPass = true
+
+	if err := r.Promote(); err != nil {
+		t.Fatalf("healthy candidate must promote despite a BootCurrent read error, got %v", err)
+	}
+	if contains(f.calls, "prune:"+SlotB) {
+		t.Fatal("#4872 A: pruned the RUNNING candidate on a transient BootCurrent read error")
+	}
+	if !contains(f.calls, "bootorder-front:0004") {
+		t.Fatal("#4872 A: candidate not promoted on the fail-closed verify path")
+	}
+}
+
+// --- #4872 A: BootCurrent AND RunningKernel both unreadable -> indeterminate.
+// Fail closed: NO prune, NO reboot, surface a NON-revert error, journal
+// preserved so the next boot re-runs the gate. ---
+func TestKernelPromoteIndeterminateFailsClosed(t *testing.T) {
+	f := newFakeKernelSystem()
+	r := newKernelRunner(t, f)
+	if err := r.Arm("6.18.5-12-generic"); err != nil {
+		t.Fatalf("Arm: %v", err)
+	}
+	f.bootCurrentErr = fmt.Errorf("efibootmgr read failure")
+	f.runningErr = fmt.Errorf("uname -r failure")
+
+	err := r.Promote()
+	if err == nil {
+		t.Fatal("#4872 A: indeterminate boot state must surface an error, not proceed as healthy")
+	}
+	if errorsIsReverted(err) {
+		t.Fatalf("#4872 A: indeterminate must NOT be a revert (exit-3 reboot-loop risk), got %v", err)
+	}
+	if contains(f.calls, "prune:"+SlotB) {
+		t.Fatal("#4872 A: pruned the candidate while unable to prove we are off it")
+	}
+	j, _ := r.loadKernelJournal()
+	if j.State != KernelStateArmed {
+		t.Fatalf("#4872 A: journal not preserved on indeterminate state (state=%s)", j.State)
+	}
+}
+
+// --- #4872 A: BootCurrent unreadable but RunningKernel positively identifies a
+// NON-candidate (known-good) kernel -> pruning the un-promoted candidate is
+// safe; no reboot, no promote. ---
+func TestKernelPromoteBootCurrentErrRunningKnownGoodCleansUp(t *testing.T) {
+	f := newFakeKernelSystem()
+	r := newKernelRunner(t, f)
+	if err := r.Arm("6.18.5-12-generic"); err != nil {
+		t.Fatalf("Arm: %v", err)
+	}
+	f.bootCurrentErr = fmt.Errorf("efibootmgr read failure")
+	f.running = "6.18.5-10-generic" // known-good, NOT the candidate
+
+	if err := r.Promote(); err != nil {
+		t.Fatalf("on positively-known-good boot, expect nil cleanup, got %v", err)
+	}
+	if !contains(f.calls, "prune:"+SlotB) {
+		t.Fatal("expected the un-promoted candidate pruned when positively on known-good")
+	}
+	if contains(f.calls, "bootorder-front:0004") {
+		t.Fatal("must not promote when not running the candidate")
+	}
+}
+
+// --- #4872 B: under StrictWatchdog (D1) an ArmWatchdog failure ABORTS the arm
+// (no BootNext, no reboot) rather than silently rebooting into a candidate with
+// no functioning watchdog. ---
+func TestKernelArmStrictWatchdogArmFailureAborts(t *testing.T) {
+	f := newFakeKernelSystem()
+	f.armWatchdogErr = fmt.Errorf("simulated /dev/watchdog I/O error")
+	r, _ := NewKernelRunner(KernelConfig{
+		JournalPath:    filepath.Join(t.TempDir(), "k.state"),
+		Sys:            f,
+		StrictWatchdog: true,
+	})
+	err := r.Arm("6.18.5-12-generic")
+	if !errors.Is(err, ErrKernelChannelUnavailable) {
+		t.Fatalf("#4872 B: strict-watchdog arm failure must abort with ErrKernelChannelUnavailable, got %v", err)
+	}
+	if f.rebooted {
+		t.Fatal("#4872 B: must NOT reboot into a candidate with no functioning watchdog under D1")
+	}
+	if f.bootNext != "" {
+		t.Fatal("#4872 B: must NOT set BootNext when the strict arm failed")
+	}
+	j, _ := r.loadKernelJournal()
+	if j.State.atLeast(KernelStateArmed) {
+		t.Fatalf("#4872 B: journal advanced to %s despite the strict arm failure", j.State)
+	}
+}
+
+// --- #4872 B: under D2 (best-effort) an ArmWatchdog failure is logged and the
+// arm still proceeds (BootNext is the loop-safety). ---
+func TestKernelArmD2WatchdogArmFailureProceeds(t *testing.T) {
+	f := newFakeKernelSystem()
+	f.armWatchdogErr = fmt.Errorf("simulated /dev/watchdog I/O error")
+	r := newKernelRunner(t, f) // D2 (StrictWatchdog defaults false)
+	if err := r.Arm("6.18.5-12-generic"); err != nil {
+		t.Fatalf("D2 should proceed despite an arm failure, got %v", err)
+	}
+	if !f.rebooted {
+		t.Fatal("D2 should still arm BootNext + reboot")
 	}
 }


### PR DESCRIPTION
Four related fail-open / destructive-cleanup defects in `pkg/upgrade`
(kernel A/B-boot upgrade + HA self-recovery), each treating an uncertain
observation as a definite terminal state. Hardened to fail closed.

## A — unreadable BootCurrent must not prune a running candidate
On `sys.BootCurrent()` error, `Promote` ran `cleanupAlreadyOnKnownGood`
-> `PruneInactiveSlot`, deleting the candidate's `/lib/modules/<candidate>`
+ `/boot/*-<candidate>` WITHOUT checking `RunningKernel`. A transient
efibootmgr/NVRAM read error could delete the currently-running candidate
kernel. Now reads `RunningKernel` first: running==candidate -> run the
verification gate (`verifyAndPromote`); positively-non-candidate -> prune;
both unreadable -> `recoverIndeterminate` (preserve journal + candidate,
no prune, no reboot, surface a non-revert error).

## B — watchdog failures hidden under StrictWatchdog
`armCandidate` now aborts the arm (no BootNext/reboot, journal stays
INSTALLED) when `ArmWatchdog` fails in strict mode. The `realKernelSystem`
helpers stop swallowing I/O errors: `ArmWatchdog` surfaces a
`WDIOC_SETTIMEOUT` failure (keepalive still attempted); `DisarmWatchdog`
propagates open/write/close failures (absent device still nil).

## C — semantic-empty self-recover lease authorized rejoin
JSON `{}` decodes to `NodeID=0` + zero time and on node 0 read as an
expired lease naming us -> spurious `ResetFailover` breaking a maintenance
drain. `readLeaseState` now rejects a zero `ExpiresAt` as no-decision.

## D — self-recovery errors did not reset the grace clock
An error from `Armed`/`LocalDrained`/`PeerHealthyPrimary` returned without
resetting `drainedSince`, so a run of errored ticks aged the deadline and
let the next positive tick rejoin immediately. Each error path now resets
`drainedSince` — grace requires continuous positive evidence.

## Tests
Six tests, each RED-verified against pre-fix source (BootCurrent-error
does-not-prune, both-unreadable indeterminate, strict-arm-failure abort,
empty/missing-expiry lease no-recover, observation-error grace reset),
plus D2/known-good guards. `go test ./pkg/upgrade/...` green; `go build
./...` clean. docs/in-place-upgrade.md updated.

Closes #4872