### PR TITLE
cluster: break AB-BA deadlock between Manager.Start and monitor poll loop (#4828)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43881,3 +43881,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4875 fwdstatus require positive in-window heartbeat evidence for Online; empty/nil/future heartbeats -> Degraded (was false-green Online)
   **File(s)**: pkg/fwdstatus/builder.go, pkg/fwdstatus/fwdstatus_test.go, pkg/fwdstatus/README.md
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4828 — fix AB-BA deadlock in cluster Manager.Start. Start no longer holds m.mu across the previous monitor's Stop(): the monitor poll goroutine calls SetMonitorWeight (takes m.mu) and Stop() joins it via wg.Wait(), so m.mu held across Stop() vs. m.mu wanted by the poll callback is a lock-order inversion that froze the whole HA manager on any config reload racing a monitor state change. Start now serializes on a dedicated monStartMu, takes m.mu only to swap the m.monitor pointer, and runs old.Stop()/new.Start() outside m.mu (mirrors hbStartMu/StartHeartbeat #4033). Added RED-on-revert deadlock reproduction test.
+  **File(s)**: pkg/cluster/manager.go, pkg/cluster/manager_start_deadlock_test.go, pkg/cluster/README.md

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -512,6 +512,16 @@ outside the monitor loop:
 - HA delete-sync callbacks fire from the GC loop. They must not block, and
   must log at `slog.Debug` — earlier `slog.Info` flooded at 15 req/s and
   drowned out real diagnostics (per CLAUDE.md logging rules).
+- **`Manager.Start` must NOT hold `m.mu` across the monitor's `Stop()` (#4828).**
+  The `Monitor` poll goroutine calls back into `SetMonitorWeight`, which takes
+  `m.mu`; `Stop()` joins that goroutine via `wg.Wait()`. Holding `m.mu` while
+  waiting for the goroutine to exit is an AB-BA deadlock (any config reload
+  racing a monitor state-change permanently freezes the manager). `Start`
+  therefore serializes on a dedicated `monStartMu`, takes `m.mu` ONLY to swap
+  the `m.monitor` pointer, then runs the old `Stop()` / new `Start()` outside
+  `m.mu`. This mirrors the `hbStartMu` discipline `StartHeartbeat` uses for the
+  same reason (#4033). Any future method that both takes `m.mu` and joins a
+  goroutine that re-enters the manager must follow the same split.
 - The incremental sync sweep (`sync_conn.go`) re-syncs a session ONLY on
   `val.Created >= threshold` — it deliberately does NOT re-publish an
   established flow on `LastSeen` activity (#270 narrowed this; #131's

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -108,8 +108,17 @@ type Manager struct {
 	mu             sync.RWMutex
 	eventCh        chan ClusterEvent
 	monitor        *Monitor
-	garpCounts     map[int]int // rgID -> gratuitous ARP count from config
-	history        *EventHistory
+	// monStartMu serializes Start's stop-previous + swap + start-new monitor
+	// sequence. It is a SEPARATE lock from m.mu because Start must NOT hold
+	// m.mu across the old monitor's Stop(): Stop() joins the poll goroutine
+	// (mon.wg.Wait()), and that goroutine calls back into SetMonitorWeight,
+	// which takes m.mu — holding m.mu across Stop() is a classic AB-BA
+	// deadlock (#4828). monStartMu serializes concurrent Start calls without
+	// participating in that ordering (no goroutine Stop() waits on ever takes
+	// monStartMu), mirroring hbStartMu / StartHeartbeat (#4033).
+	monStartMu sync.Mutex
+	garpCounts map[int]int // rgID -> gratuitous ARP count from config
+	history    *EventHistory
 
 	// kernelUpgradeHold, when set, unconditionally holds this node SECONDARY in
 	// election (#1930 INC-2): a kernel-upgrade candidate boot must not become
@@ -379,15 +388,30 @@ func (m *Manager) sendEvent(groupID int, oldState, newState NodeState, reason st
 }
 
 // Start begins periodic interface/IP monitoring.
+//
+// The stop-previous + swap + start-new sequence is serialized by monStartMu,
+// but m.mu is released before the blocking calls: holding m.mu across the old
+// monitor's Stop() deadlocks (#4828). Stop() joins the poll goroutine via
+// wg.Wait(), and an in-flight SetMonitorWeight callback on that goroutine takes
+// m.mu — so m.mu held here (AB) vs. m.mu wanted by the poll callback while
+// Start waits on wg (BA) is a lock-order inversion. Only the m.monitor pointer
+// swap needs m.mu; Stop()/Start() on the Monitor objects are self-synchronized
+// (mon.mu + mon.wg), so they run outside m.mu. monStartMu keeps two concurrent
+// Start calls from stopping/starting each other's monitors.
 func (m *Manager) Start(ctx context.Context) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.monStartMu.Lock()
+	defer m.monStartMu.Unlock()
 
-	if m.monitor != nil {
-		m.monitor.Stop()
+	m.mu.Lock()
+	old := m.monitor
+	mon := NewMonitor(m, nil) // groups set via UpdateConfig
+	m.monitor = mon
+	m.mu.Unlock()
+
+	if old != nil {
+		old.Stop()
 	}
-	m.monitor = NewMonitor(m, nil) // groups set via UpdateConfig
-	m.monitor.Start(ctx)
+	mon.Start(ctx)
 }
 
 // Stop halts monitoring and heartbeat goroutines.

--- a/pkg/cluster/manager_start_deadlock_test.go
+++ b/pkg/cluster/manager_start_deadlock_test.go
@@ -1,0 +1,132 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// deadlockNlHandle is a nlLinkGetter that, on its first LinkByName call,
+// reproduces the exact in-flight callback that makes Manager.Start's old lock
+// ordering deadlock: it runs on the monitor poll goroutine (the one
+// Monitor.Stop joins via wg.Wait), signals the test, waits for the test to
+// arrange the race, then calls back into the manager's SetMonitorWeight —
+// which takes m.mu. If Manager.Start is holding m.mu across Monitor.Stop, that
+// callback blocks forever (AB-BA), so the poll goroutine never exits and
+// wg.Wait never returns. See #4828.
+type deadlockNlHandle struct {
+	mgr     *Manager
+	rgID    int
+	iface   string
+	weight  int
+	reached chan struct{} // closed once the poll goroutine is on-CPU in LinkByName
+	proceed chan struct{} // closed by the test once Start is (about to be) mid-Stop
+	once    sync.Once
+}
+
+func (h *deadlockNlHandle) LinkByName(name string) (netlink.Link, error) {
+	h.once.Do(func() {
+		close(h.reached)
+		<-h.proceed
+		// Model the poll loop's SetMonitorWeight callback (monitor.go). This
+		// acquires m.mu; if Start holds m.mu across Stop() this blocks
+		// permanently and the poll goroutine can never exit.
+		h.mgr.SetMonitorWeight(h.rgID, h.iface, true, h.weight)
+	})
+	return nil, fmt.Errorf("deadlockNlHandle: no such link %q (test)", name)
+}
+
+func (h *deadlockNlHandle) Close() {}
+
+// TestManagerStartMonitorStopNoDeadlock reproduces the #4828 AB-BA deadlock:
+// Manager.Start() must not hold m.mu across the previous monitor's Stop(),
+// because the monitor poll goroutine calls SetMonitorWeight (which takes m.mu)
+// and Stop() blocks joining that goroutine. Pre-fix this test times out
+// (deadlock); post-fix Start() returns promptly.
+func TestManagerStartMonitorStopNoDeadlock(t *testing.T) {
+	m := NewManager(0, 1)
+
+	// A redundancy group with one interface monitor so the poll loop reaches
+	// pollInterfaceMonitors -> nlHandle.LinkByName. Node 0 owns slot-0 names.
+	groups := []*config.RedundancyGroup{
+		{
+			ID: 0,
+			InterfaceMonitors: []*config.InterfaceMonitor{
+				{Interface: "ge-0/0/0", Weight: 100},
+			},
+		},
+	}
+
+	fake := &deadlockNlHandle{
+		mgr:     m,
+		rgID:    0,
+		iface:   "ge-0/0/0",
+		weight:  100,
+		reached: make(chan struct{}),
+		proceed: make(chan struct{}),
+	}
+
+	// Install a monitor with the injected handle directly (white-box) so the
+	// existing monitor's poll goroutine is the one whose SetMonitorWeight
+	// callback races Start()'s Stop(). Manager.Start() itself creates its own
+	// monitor via NewMonitor, so we cannot inject the handle through Start.
+	prev := NewMonitor(m, groups)
+	prev.nlHandle = fake
+	m.mu.Lock()
+	m.monitor = prev
+	m.mu.Unlock()
+
+	monCtx, monCancel := context.WithCancel(context.Background())
+	defer monCancel()
+	prev.Start(monCtx)
+
+	// Wait until the poll goroutine is on-CPU inside LinkByName and parked on
+	// proceed. It is now guaranteed not to touch m.mu until we release it.
+	select {
+	case <-fake.reached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("monitor poll goroutine never reached LinkByName")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		// Pre-fix: acquires m.mu, calls prev.Stop() -> wg.Wait() while still
+		// holding m.mu. Post-fix: swaps the pointer, releases m.mu, then Stops.
+		m.Start(context.Background())
+		close(done)
+	}()
+
+	// Give the Start goroutine time to acquire the (uncontended) m.mu and enter
+	// prev.Stop(). Nothing else contends m.mu during this window: the poll
+	// goroutine is parked on proceed. After this, pre-fix code has Start
+	// holding m.mu inside wg.Wait().
+	time.Sleep(250 * time.Millisecond)
+
+	// Release the poll goroutine's SetMonitorWeight callback. Pre-fix it now
+	// blocks on m.mu (held by Start), so wg.Wait() -> Start() never returns.
+	close(fake.proceed)
+
+	select {
+	case <-done:
+		// Fixed: Start released m.mu before Stop(), so the callback completed,
+		// the poll goroutine exited, and Start returned.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Manager.Start() deadlocked against the monitor poll goroutine (#4828 AB-BA)")
+	}
+
+	// The manager should have swapped in a fresh monitor.
+	m.mu.RLock()
+	cur := m.monitor
+	m.mu.RUnlock()
+	if cur == nil || cur == prev {
+		t.Fatalf("Manager.Start did not install a new monitor: cur=%p prev=%p", cur, prev)
+	}
+
+	// Tear down the replacement monitor's goroutine.
+	m.Stop()
+}


### PR DESCRIPTION
## Summary

`Manager.Start()` held `m.mu` for its entire body, including the call to the
previous monitor's `Stop()`. `Monitor.Stop()` blocks on `wg.Wait()` joining the
poll goroutine, and that goroutine calls back into `SetMonitorWeight`, which
unconditionally takes the SAME `m.mu`. Any `Start()` (config reload /
reconfigure) racing the poll loop mid-callback permanently deadlocked the
cluster manager — a classic AB-BA lock-order inversion. With `m.mu` pinned
forever, every other `Manager` method (heartbeat, election, VRRP priority
updates) wedged too: HA failover frozen until a daemon restart.

Fixes #4828.

## Fix

`m.mu` in the `Start` critical section only guards the `m.monitor` pointer swap;
the `Stop()`/`Start()` calls on the `Monitor` objects are self-synchronized via
`mon.mu` + `mon.wg` and never needed `m.mu`. `Start` now:

- serializes the whole sequence on a new dedicated `monStartMu` (so two
  concurrent `Start` calls cannot stop/start each other's monitors),
- takes `m.mu` ONLY to swap the `m.monitor` pointer, then
- runs the old `Stop()` / new `Start()` OUTSIDE `m.mu`.

`monStartMu` never participates in the poll-callback lock order (no goroutine
that `Stop()` joins ever takes it), so it cannot reintroduce the inversion. This
mirrors the existing `hbStartMu` discipline `StartHeartbeat` already uses for the
same class of problem (#4033).

## Validation

- **New RED-on-revert test** (`manager_start_deadlock_test.go`): drives `Start()`
  concurrently with a monitor poll goroutine parked mid-`SetMonitorWeight`
  callback, with a 5s deadlock-detector timeout. Times out against the old
  `Start` (deadlock reproduced), green with the fix.
- `go test -race ./pkg/cluster/...` — green.
- `go build ./...`, `go vet ./pkg/cluster/` — clean; `gofmt` applied.
- **`make test-failover` on the loss userspace cluster — 13 passed, 0 failed.**
  Unclean sysrq-reboot failover + rejoin-as-secondary (which restarts xpfd and
  re-invokes `Manager.Start`) + manual failback, all with zero iperf3 drops.

## Docs

- `pkg/cluster/README.md` Gotchas: documented the lock-ordering invariant.

Closes #4828

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi