### PR TITLE
config: reject NaN/Inf in ValidatePercent at commit-check

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43892,3 +43892,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4828 — fix AB-BA deadlock in cluster Manager.Start. Start no longer holds m.mu across the previous monitor's Stop(): the monitor poll goroutine calls SetMonitorWeight (takes m.mu) and Stop() joins it via wg.Wait(), so m.mu held across Stop() vs. m.mu wanted by the poll callback is a lock-order inversion that froze the whole HA manager on any config reload racing a monitor state change. Start now serializes on a dedicated monStartMu, takes m.mu only to swap the m.monitor pointer, and runs old.Stop()/new.Start() outside m.mu (mirrors hbStartMu/StartHeartbeat #4033). Added RED-on-revert deadlock reproduction test.
   **File(s)**: pkg/cluster/manager.go, pkg/cluster/manager_start_deadlock_test.go, pkg/cluster/README.md
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4877 ValidatePercent rejects NaN/Inf (commit-check) before range gate
+  **File(s)**: pkg/config/schema_validators.go, pkg/config/schema_validate_test.go

--- a/pkg/config/schema_validate_test.go
+++ b/pkg/config/schema_validate_test.go
@@ -723,4 +723,17 @@ func TestValidatePercent(t *testing.T) {
 	if err := v("150", nil); err == nil {
 		t.Errorf("ValidatePercent 150: expected out-of-range error")
 	}
+	// NaN/Inf bypass the `<`/`>` range check (both comparisons are false
+	// for NaN) and reach the userspace snapshot where json.Marshal fails
+	// on non-finite floats (#4877). Reject them at commit-check.
+	for _, bad := range []string{"NaN", "nan", "+Inf", "-Inf", "Inf", "Infinity"} {
+		if err := v(bad, nil); err == nil {
+			t.Errorf("ValidatePercent %q: expected non-finite rejection", bad)
+		}
+	}
+	// A NaN/Inf guard must not reject an in-range finite value.
+	vf := config.ValidatePercent(0, 1)
+	if err := vf("0.5", nil); err != nil {
+		t.Errorf("ValidatePercent(0,1) 0.5: unexpected error %v", err)
+	}
 }

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -139,6 +139,14 @@ func ValidatePercent(min, max float64) LeafValidator {
 		if err != nil {
 			return fmt.Errorf("not a number: %q", raw)
 		}
+		// NaN/Inf sail past the `<`/`>` range comparisons below (both
+		// comparisons are false for NaN), so a schema-accepted NaN/Inf
+		// reaches the snapshot and blows up at userspace publish where
+		// json.Marshal rejects non-finite floats (#4877). Reject them at
+		// commit-check so the operator gets an actionable leaf error.
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return fmt.Errorf("percent must be a finite number (got %s)", raw)
+		}
 		if v < min || v > max {
 			return fmt.Errorf("percent out of range [%.2f..%.2f] (got %s)", min, max, raw)
 		}


### PR DESCRIPTION
## Summary
`ValidatePercent` range-checked only with `<`/`>`, which NaN/Inf bypass (both comparisons are false for NaN). A schema-accepted non-finite percent — e.g. CoS `guarantee-rate`, wired to `ValidatePercent(0,1)` — is stored into the snapshot and then blows up at userspace publish where `json.Marshal` rejects non-finite floats (`json: unsupported value: NaN`). That converts a clean commit-check rejection into an opaque post-commit apply failure.

## Fix
Reject `math.IsNaN(v) || math.IsInf(v, 0)` before the range comparison, so the operator gets an actionable commit-time leaf error. The CoS-specific validators already guarded non-finite; the generic `ValidatePercent` was the hole.

## Test
`TestValidatePercent` now asserts `NaN`/`+Inf`/`-Inf`/`Infinity` are rejected and an in-range finite value still passes. RED-on-revert verified: reverting the source makes the NaN cases fail.

`go build ./...` clean; `go test ./pkg/config/...` green; gofmt clean.

Closes #4877