### PR TITLE
cli: fail closed in commit/rollback grammar and int->int32 narrowing

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43884,3 +43884,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4875 fwdstatus require positive in-window heartbeat evidence for Online; empty/nil/future heartbeats -> Degraded (was false-green Online)
   **File(s)**: pkg/fwdstatus/builder.go, pkg/fwdstatus/fwdstatus_test.go, pkg/fwdstatus/README.md
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4868 CLI commit/rollback grammar + int32 narrowing fail-closed — remote+local commit reject unknown modifier and parse commit-confirmed minutes via ParseInt(10,32) with [1,65535]; store bounds the window; remote rollback uses ParseInt(10,32) to reject int32-wrap-to-0
+  **File(s)**: cmd/cli/main.go, cmd/cli/shared.go, pkg/cli/cli_config.go, pkg/configstore/store_commit.go, +3 tests, pkg/configstore/README.md

--- a/cmd/cli/commit_rollback_4868_test.go
+++ b/cmd/cli/commit_rollback_4868_test.go
@@ -1,0 +1,141 @@
+// Tests for #4868 on the remote CLI surface: commit/rollback grammar +
+// int->int32 narrowing must fail CLOSED. Before the fix:
+//   - an unknown `commit` modifier (e.g. the typo `commit confimed 10`) fell
+//     through to the permanent Commit RPC (a management-stranding change with
+//     no rollback timer);
+//   - `commit confirmed junk|0|-1` silently kept the 10-minute default, and
+//     `commit confirmed 4294967297` narrowed through int32 to Minutes=1;
+//   - `rollback 4294967296` was a valid int that wrapped through int32 to 0,
+//     silently discarding the candidate.
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc"
+)
+
+// commitRecorderClient records Commit / CommitConfirmed RPCs. GetStatus is
+// stubbed so refreshPrompt() on the success path does not nil-panic. Any other
+// RPC nil-panics, which is what we want — the commit path must only ever touch
+// these.
+type commitRecorderClient struct {
+	pb.BpfrxServiceClient
+
+	commitCalls  int
+	confirmCalls int
+	lastMinutes  int32
+}
+
+func (f *commitRecorderClient) Commit(
+	_ context.Context, _ *pb.CommitRequest, _ ...grpc.CallOption,
+) (*pb.CommitResponse, error) {
+	f.commitCalls++
+	return &pb.CommitResponse{}, nil
+}
+
+func (f *commitRecorderClient) CommitConfirmed(
+	_ context.Context, in *pb.CommitConfirmedRequest, _ ...grpc.CallOption,
+) (*pb.CommitConfirmedResponse, error) {
+	f.confirmCalls++
+	f.lastMinutes = in.GetMinutes()
+	return &pb.CommitConfirmedResponse{}, nil
+}
+
+func (f *commitRecorderClient) GetStatus(
+	_ context.Context, _ *pb.GetStatusRequest, _ ...grpc.CallOption,
+) (*pb.GetStatusResponse, error) {
+	return &pb.GetStatusResponse{}, nil
+}
+
+// An unknown modifier must ERROR before any RPC — never fall through to the
+// permanent Commit.
+func TestRemoteCommitUnknownModifierNoRPC_4868(t *testing.T) {
+	for _, line := range []string{"commit confimed 10", "commit bogus", "commit synchronize"} {
+		t.Run(line, func(t *testing.T) {
+			fake := &commitRecorderClient{}
+			c := &ctl{client: fake, configMode: true}
+			if err := c.dispatchConfig(line); err == nil {
+				t.Fatalf("%q: expected an error for an unknown commit modifier", line)
+			}
+			if fake.commitCalls != 0 || fake.confirmCalls != 0 {
+				t.Fatalf("%q: issued Commit=%d CommitConfirmed=%d; expected 0 — "+
+					"an unknown modifier must not permanent-commit", line, fake.commitCalls, fake.confirmCalls)
+			}
+		})
+	}
+}
+
+// A malformed / zero / negative / int32-overflowing / over-max timeout must
+// ERROR before any RPC — never silently arm a default or a truncated value.
+func TestRemoteCommitConfirmedInvalidNoRPC_4868(t *testing.T) {
+	for _, line := range []string{
+		"commit confirmed junk",
+		"commit confirmed 1x",
+		"commit confirmed 0",
+		"commit confirmed -1",
+		"commit confirmed 4294967297", // int32 overflow (old code -> Minutes=1)
+		"commit confirmed 99999",      // over the Junos max
+		"commit confirmed 5 extra",    // wrong arity
+	} {
+		t.Run(line, func(t *testing.T) {
+			fake := &commitRecorderClient{}
+			c := &ctl{client: fake, configMode: true}
+			if err := c.dispatchConfig(line); err == nil {
+				t.Fatalf("%q: expected an error", line)
+			}
+			if fake.confirmCalls != 0 {
+				t.Fatalf("%q: issued CommitConfirmed %d times (Minutes=%d); expected 0",
+					line, fake.confirmCalls, fake.lastMinutes)
+			}
+		})
+	}
+}
+
+// Valid confirmed timeouts pass the exact minutes (no narrowing / no default
+// swallow).
+func TestRemoteCommitConfirmedValidMinutes_4868(t *testing.T) {
+	cases := []struct {
+		line string
+		want int32
+	}{
+		{"commit confirmed", 10}, // default
+		{"commit confirmed 5", 5},
+		{"commit confirmed 65535", 65535}, // max boundary
+	}
+	for _, tc := range cases {
+		t.Run(tc.line, func(t *testing.T) {
+			fake := &commitRecorderClient{}
+			c := &ctl{client: fake, configMode: true}
+			if err := c.dispatchConfig(tc.line); err != nil {
+				t.Fatalf("%q: %v", tc.line, err)
+			}
+			if fake.confirmCalls != 1 || fake.lastMinutes != tc.want {
+				t.Fatalf("%q: calls=%d Minutes=%d; want 1 / %d",
+					tc.line, fake.confirmCalls, fake.lastMinutes, tc.want)
+			}
+		})
+	}
+}
+
+// #4868 C: a rollback index that fits int64 but not int32 must be rejected,
+// not wrapped to 0 (silent candidate discard). Complements the #3447 malformed
+// cases in rollback_3447_test.go.
+func TestRemoteRollbackInt32WrapNoRPC_4868(t *testing.T) {
+	for _, arg := range []string{"4294967296", "4294967297", "2147483648"} {
+		t.Run(arg, func(t *testing.T) {
+			fake := &rollbackRecorderClient{}
+			c := &ctl{client: fake, configMode: true}
+			if err := c.dispatchConfig("rollback " + arg); err == nil {
+				t.Fatalf("rollback %q returned nil; expected out-of-range rejection", arg)
+			}
+			if fake.calls != 0 {
+				t.Fatalf("rollback %q issued the RPC %d times (last N=%d); expected 0 — "+
+					"int32 wrap to 0 discards the candidate", arg, fake.calls, fake.lastN)
+			}
+		})
+	}
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -211,6 +211,11 @@ func main() {
 	}
 }
 
+// maxConfirmedMinutes bounds `commit confirmed <minutes>` (Junos range
+// 1..65535). Kept in sync with configstore.MaxCommitConfirmedMinutes (the
+// remote CLI does not import configstore); the daemon re-enforces it.
+const maxConfirmedMinutes = 65535
+
 func (c *ctl) handleCommit(args []string) error {
 	if len(args) > 0 && args[0] == "check" {
 		resp, err := c.client.CommitCheck(c.ctx(), &pb.CommitCheckRequest{})
@@ -243,11 +248,26 @@ func (c *ctl) handleCommit(args []string) error {
 	}
 
 	if len(args) > 0 && args[0] == "confirmed" {
+		if len(args) > 2 {
+			return fmt.Errorf("usage: commit confirmed [minutes]")
+		}
+		// #4868: `commit confirmed` is the rollback guard when changing
+		// reachability, so a malformed/out-of-range timeout must ERROR rather
+		// than silently arming the 10-minute default (junk|0|-1) or truncating a
+		// large value through int32 (`4294967297` -> 1). Parse within the
+		// int32/Junos range and enforce [1, maxConfirmedMinutes].
 		minutes := int32(10)
 		if len(args) >= 2 {
-			if v, err := strconv.Atoi(args[1]); err == nil && v > 0 {
-				minutes = int32(v)
+			v, err := strconv.ParseInt(args[1], 10, 32)
+			if err != nil || v <= 0 {
+				return fmt.Errorf("commit confirmed: invalid timeout %q "+
+					"(want a positive number of minutes, 1..%d)", args[1], maxConfirmedMinutes)
 			}
+			if v > maxConfirmedMinutes {
+				return fmt.Errorf("commit confirmed: timeout %d exceeds maximum %d minutes",
+					v, maxConfirmedMinutes)
+			}
+			minutes = int32(v)
 		}
 		resp, err := c.client.CommitConfirmed(c.ctx(), &pb.CommitConfirmedRequest{Minutes: minutes})
 		if err != nil {
@@ -257,6 +277,15 @@ func (c *ctl) handleCommit(args []string) error {
 		printRemoteConfigWarnings(resp.Warnings)
 		fmt.Printf("commit confirmed will be automatically rolled back in %d minutes unless confirmed\n", minutes)
 		return nil
+	}
+
+	// #4868: any first token that is not a recognized modifier (e.g. the typo
+	// `commit confimed 10`) must NOT fall through to the permanent commit below
+	// — that would be a management-stranding change with no rollback timer.
+	// Reject it before any mutation. Valid modifiers mirror cmdtree
+	// (check / comment / confirmed).
+	if len(args) > 0 {
+		return fmt.Errorf("commit: unknown option %q (valid: check, comment, confirmed)", args[0])
 	}
 
 	resp, err := c.client.Commit(c.ctx(), &pb.CommitRequest{})

--- a/cmd/cli/shared.go
+++ b/cmd/cli/shared.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -435,8 +436,18 @@ func (c *ctl) dispatchConfig(line string) error {
 			// Strict integer parse: a malformed token (e.g. "foo",
 			// "1x") or a negative value must NOT silently fall through
 			// to rollback 0, which discards the candidate (#3447).
-			v, err := strconv.Atoi(parts[1])
+			//
+			// #4868: parse into the int32 the RPC carries. `strconv.Atoi`
+			// returns a 64-bit int on this target, so `4294967296` parsed
+			// clean, passed the >=0 check, then `int32(v)` WRAPPED to 0 —
+			// silently resetting the candidate to the active config. Using
+			// ParseInt(_, 10, 32) rejects any value that does not fit int32
+			// (ErrRange) instead of wrapping it.
+			v, err := strconv.ParseInt(parts[1], 10, 32)
 			if err != nil {
+				if errors.Is(err, strconv.ErrRange) {
+					return fmt.Errorf("rollback: rollback number %q out of range", parts[1])
+				}
 				return fmt.Errorf("rollback: invalid rollback number %q", parts[1])
 			}
 			if v < 0 {

--- a/pkg/cli/cli_commit_4868_test.go
+++ b/pkg/cli/cli_commit_4868_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// #4868 (local CLI): `commit confirmed <minutes>` must reject a malformed /
+// zero / negative / int32-overflowing / over-max timeout instead of silently
+// arming the 10-minute default (banana|0|-1) or a truncated value — the
+// candidate must stay UNcommitted and no confirm window armed.
+func TestLocalCommitConfirmedInvalidRejected_4868(t *testing.T) {
+	for _, arg := range []string{"banana", "1x", "0", "-1", "4294967297", "99999"} {
+		t.Run(arg, func(t *testing.T) {
+			store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+			if err := store.EnterConfigure(); err != nil {
+				t.Fatal(err)
+			}
+			c := &CLI{store: store}
+			if _, err := store.LoadSet("set system host-name Edited"); err != nil {
+				t.Fatal(err)
+			}
+			if err := c.handleCommit([]string{"confirmed", arg}); err == nil {
+				t.Fatalf("commit confirmed %q: expected an error", arg)
+			}
+			if store.IsConfirmPending() {
+				t.Fatalf("commit confirmed %q: armed a confirm window despite an invalid timeout", arg)
+			}
+			if !store.IsDirty() {
+				t.Fatalf("commit confirmed %q: committed the candidate despite an invalid timeout", arg)
+			}
+		})
+	}
+}
+
+// A valid timeout arms the confirm window.
+func TestLocalCommitConfirmedValidArms_4868(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	c := &CLI{store: store}
+	if _, err := store.LoadSet("set system host-name Edited"); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.handleCommit([]string{"confirmed", "5"}); err != nil {
+		t.Fatalf("commit confirmed 5: %v", err)
+	}
+	if !store.IsConfirmPending() {
+		t.Fatal("commit confirmed 5 should arm a pending confirm window")
+	}
+}
+
+// An unrecognized modifier must ERROR before any mutation — never fall through
+// to a permanent commit.
+func TestLocalCommitUnknownModifierRejected_4868(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	c := &CLI{store: store}
+	if _, err := store.LoadSet("set system host-name Edited"); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.handleCommit([]string{"confimed", "10"}); err == nil { // typo
+		t.Fatal("commit confimed: expected an error for an unknown modifier")
+	}
+	if !store.IsDirty() {
+		t.Fatal("an unknown commit modifier must NOT commit the candidate")
+	}
+}

--- a/pkg/cli/cli_config.go
+++ b/pkg/cli/cli_config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
 )
 
 // commitApply invokes the reconcile path for a freshly-committed config.
@@ -211,11 +212,25 @@ func (c *CLI) handleCommit(args []string) error {
 	}
 
 	if len(args) > 0 && args[0] == "confirmed" {
+		if len(args) > 2 {
+			return fmt.Errorf("usage: commit confirmed [minutes]")
+		}
+		// #4868: `commit confirmed` is the operator's rollback guard, so a
+		// malformed/out-of-range timeout must ERROR rather than silently arm the
+		// 10-minute default (banana|0|-1) or truncate a large value. Parse into
+		// the int32/Junos range and enforce [1, MaxCommitConfirmedMinutes].
 		minutes := 10
 		if len(args) >= 2 {
-			if v, err := strconv.Atoi(args[1]); err == nil && v > 0 {
-				minutes = v
+			v, err := strconv.ParseInt(args[1], 10, 32)
+			if err != nil || v <= 0 {
+				return fmt.Errorf("commit confirmed: invalid timeout %q "+
+					"(want a positive number of minutes, 1..%d)", args[1], configstore.MaxCommitConfirmedMinutes)
 			}
+			if v > configstore.MaxCommitConfirmedMinutes {
+				return fmt.Errorf("commit confirmed: timeout %d exceeds maximum %d minutes",
+					v, configstore.MaxCommitConfirmedMinutes)
+			}
+			minutes = int(v)
 		}
 
 		compiled, err := c.runCommitConfirmed(minutes)
@@ -229,6 +244,14 @@ func (c *CLI) handleCommit(args []string) error {
 		printConfigWarnings(compiled.Warnings)
 		fmt.Printf("commit confirmed will be automatically rolled back in %d minutes unless confirmed\n", minutes)
 		return nil
+	}
+
+	// #4868: an unrecognized first token (e.g. the typo `commit confimed 10`)
+	// must NOT fall through to the permanent commit below — that would be a
+	// management-stranding change with no rollback timer. Reject it before any
+	// mutation. Valid modifiers mirror cmdtree (check / comment / confirmed).
+	if len(args) > 0 {
+		return fmt.Errorf("commit: unknown option %q (valid: check, comment, confirmed)", args[0])
 	}
 
 	// Bare commit during a pending commit-confirmed window (#4000). Junos

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -199,6 +199,20 @@ per-path:
   disconnected operator should treat an unanswered commit as
   ambiguous — same as Junos — and inspect `show configuration` after
   reconnecting.
+- **`commit confirmed <minutes>` is range-bounded (#4868).**
+  `CommitConfirmed` rejects a timeout above `MaxCommitConfirmedMinutes`
+  (65535, the Junos range) so `time.Duration(minutes)*time.Minute` cannot
+  overflow int64 nanoseconds into a wrapped/negative deadline that fires
+  an immediate or wrong auto-rollback after the candidate is already
+  promoted. The guard runs before `writeActive`/promote (no mutation on
+  reject) and the gRPC handler maps it to `InvalidArgument`. Both CLIs
+  parse the timeout with `ParseInt(_, 10, 32)` and enforce `[1, 65535]`
+  before the RPC, so a malformed/zero/negative/`MaxInt32+1`/`2^32+1`
+  timeout ERRORS instead of silently arming the 10-minute default or a
+  truncated value; an unknown `commit` modifier (e.g. the typo `commit
+  confimed`) and an out-of-int32 `rollback` index are likewise rejected
+  before any mutation rather than falling through to a permanent commit /
+  rollback-0 candidate discard.
 - **`commit confirmed` survives a crash inside the window (#4577).**
   The auto-rollback timer is an in-memory `time.AfterFunc` that does NOT
   outlive the process, so before this fix a daemon crash/reboot inside

--- a/pkg/configstore/commit_confirmed_maxrange_4868_test.go
+++ b/pkg/configstore/commit_confirmed_maxrange_4868_test.go
@@ -1,0 +1,38 @@
+package configstore
+
+import "testing"
+
+// #4868: the store bounds the commit-confirmed window so
+// `time.Duration(minutes)*time.Minute` cannot overflow int64 nanoseconds into
+// a wrapped/negative deadline that fires an immediate/wrong auto-rollback after
+// the candidate has already been promoted. An over-max value is rejected with
+// no promotion / no armed timer; the max boundary is accepted.
+func TestCommitConfirmedRejectsOverMax_4868(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetFromInput("system host-name Base"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.CommitConfirmed(MaxCommitConfirmedMinutes + 1); err == nil {
+		t.Fatalf("CommitConfirmed(%d) accepted; want rejection over max %d",
+			MaxCommitConfirmedMinutes+1, MaxCommitConfirmedMinutes)
+	}
+	if s.IsConfirmPending() {
+		t.Fatal("an over-max CommitConfirmed must NOT arm a confirm window")
+	}
+	if !s.IsDirty() {
+		t.Fatal("an over-max CommitConfirmed must NOT promote the candidate")
+	}
+
+	// The max boundary is accepted.
+	if _, err := s.CommitConfirmed(MaxCommitConfirmedMinutes); err != nil {
+		t.Fatalf("CommitConfirmed(%d) at the max boundary should succeed: %v",
+			MaxCommitConfirmedMinutes, err)
+	}
+	if !s.IsConfirmPending() {
+		t.Fatal("a max-boundary CommitConfirmed should arm a confirm window")
+	}
+}

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -193,6 +193,13 @@ func (s *Store) SetRollbackExecutor(fn func(gen uint64)) {
 // code did before #1799) meant a commit-2 timeout "rolled back" to the
 // equally-unconfirmed commit 1 and stayed there forever, because
 // commit 1's own timer had been cancelled.
+// MaxCommitConfirmedMinutes is the inclusive upper bound on a
+// `commit confirmed <minutes>` auto-rollback window, matching the Junos
+// range (1..65535 minutes). It bounds the timer so
+// `time.Duration(minutes)*time.Minute` cannot overflow int64 nanoseconds
+// (#4868). CLI parse sites enforce the same bound before the RPC.
+const MaxCommitConfirmedMinutes = 65535
+
 func (s *Store) CommitConfirmed(minutes int) (*config.Config, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -213,6 +220,17 @@ func (s *Store) CommitConfirmed(minutes int) (*config.Config, error) {
 
 	if minutes <= 0 {
 		minutes = 10
+	}
+	// #4868: bound the confirm window. Without an upper bound a large value
+	// overflows `time.Duration(minutes)*time.Minute` (int64 nanoseconds) below,
+	// yielding a wrapped/negative deadline that fires an immediate or wrong
+	// auto-rollback AFTER the candidate has already been promoted. Reject
+	// out-of-range values here (defense in depth — the CLIs validate first, and
+	// the gRPC handler maps this to InvalidArgument) rather than silently
+	// wrapping. `minutes` never reaches the AfterFunc unclamped.
+	if minutes > MaxCommitConfirmedMinutes {
+		return nil, fmt.Errorf("commit confirmed: timeout %d exceeds maximum %d minutes",
+			minutes, MaxCommitConfirmedMinutes)
 	}
 
 	// #1799 Option A: persist BEFORE promoting and BEFORE touching


### PR DESCRIPTION
Three related fail-open defects in the CLI commit/rollback grammar and
int->int32 narrowing. `commit confirmed` is the rollback guard when
changing reachability, so silent defaulting/truncation is safety-critical.

## A — remote `commit` grammar (`cmd/cli/main.go`)
Only exact `check`/`comment`/`confirmed` prefixes returned early; any
other first token (typo `commit confimed 10`) fell through to the
permanent `Commit` RPC — a management-stranding change with no rollback
timer. `commit confirmed junk|0|-1` kept the 10-min default;
`commit confirmed 4294967297` narrowed through `int32` to Minutes=1. Now:
unknown token errors before any RPC; timeout parsed with `ParseInt(_,10,32)`
and enforced `[1,65535]` + arity check.

## B — local `commit confirmed` duration (`pkg/cli/cli_config.go` + `pkg/configstore/store_commit.go`)
Same permissive Atoi; large values overflowed `time.Duration(minutes)*time.Minute`
into a wrapped/negative deadline (immediate/wrong rollback post-promote).
Local CLI now applies the same validation + unknown-modifier reject;
`Store.CommitConfirmed` rejects a timeout above `MaxCommitConfirmedMinutes`
(65535) before any mutation (gRPC maps to InvalidArgument).

## C — rollback index (`cmd/cli/shared.go`)
`4294967296` passed the #3447 range checks then `int32(...)` yielded 0 →
server resets candidate to active (silent uncommitted-change loss).
`ParseInt(_,10,32)` rejects any out-of-int32 value (ErrRange).

## Tests
RED-on-revert tests on all three surfaces (remote no-RPC on unknown /
invalid / int32-wrap; valid passes exact minutes; local leaves candidate
uncommitted; store rejects over-max, accepts max boundary). `go test
./cmd/cli/ ./pkg/cli/ ./pkg/configstore/` green; `go build ./...` clean.

Closes #4868