### PR TITLE
xpfd: reject stray positional args in `xpfd upgrade`

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43892,3 +43892,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4828 — fix AB-BA deadlock in cluster Manager.Start. Start no longer holds m.mu across the previous monitor's Stop(): the monitor poll goroutine calls SetMonitorWeight (takes m.mu) and Stop() joins it via wg.Wait(), so m.mu held across Stop() vs. m.mu wanted by the poll callback is a lock-order inversion that froze the whole HA manager on any config reload racing a monitor state change. Start now serializes on a dedicated monStartMu, takes m.mu only to swap the m.monitor pointer, and runs old.Stop()/new.Start() outside m.mu (mirrors hbStartMu/StartHeartbeat #4033). Added RED-on-revert deadlock reproduction test.
   **File(s)**: pkg/cluster/manager.go, pkg/cluster/manager_start_deadlock_test.go, pkg/cluster/README.md
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4869 xpfd upgrade rejects stray positional args (fs.NArg()!=0) so `xpfd upgrade rolling` errors instead of running the uncoordinated standalone cut; extracted testable parseUpgradeArgs
+  **File(s)**: cmd/xpfd/upgrade.go, cmd/xpfd/upgrade_args_4869_test.go, docs/in-place-upgrade.md

--- a/cmd/xpfd/upgrade.go
+++ b/cmd/xpfd/upgrade.go
@@ -26,34 +26,23 @@ func runUpgradeSubcommand(args []string) {
 		return
 	}
 
-	fs := flag.NewFlagSet("upgrade", flag.ContinueOnError)
-	rolling := fs.Bool("rolling", false,
-		"HA rolling upgrade: drive a controlled per-node drain + cut so the "+
-			"cluster keeps forwarding (one node down at a time)")
-	stagedDir := fs.String("staged-dir", upgrade.DefaultStagedDir, "dpkg-staged binary set dir")
-	versionsDir := fs.String("versions-dir", upgrade.DefaultVersionsDir, "runtime versioned dir")
-	stagedGenDir := fs.String("staged-gen-dir", upgrade.DefaultStagedGenDir,
-		"staged-generation root the cut copies from (#1981 Option B)")
-	sbinDir := fs.String("sbin-dir", upgrade.DefaultSbinDir, "operator-tool symlink dir")
-	configDBDir := fs.String("configdb-dir", upgrade.DefaultConfigDBDir, "config DB dir (for rollback snapshot)")
-	journalPath := fs.String("journal", upgrade.DefaultJournalPath, "crash-safe state journal path")
-	unit := fs.String("unit", upgrade.DefaultUnit, "systemd unit name")
-	healthDeadline := fs.Duration("health-deadline", 30*time.Second,
-		"post-start helper-health deadline before auto-rollback (standalone)")
-	if err := fs.Parse(args); err != nil {
+	flags, err := parseUpgradeArgs(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "upgrade: %v\n", err)
 		os.Exit(1)
 	}
+	rolling := &flags.rolling
 
 	cfg := upgrade.Config{
-		StagedDir:           *stagedDir,
-		VersionsDir:         *versionsDir,
-		StagedGenDir:        *stagedGenDir,
-		SbinDir:             *sbinDir,
-		ConfigDBDir:         *configDBDir,
-		JournalPath:         *journalPath,
-		Unit:                *unit,
-		StartHealthDeadline: *healthDeadline,
-		Sys:                 upgrade.NewSystem(*unit),
+		StagedDir:           flags.stagedDir,
+		VersionsDir:         flags.versionsDir,
+		StagedGenDir:        flags.stagedGenDir,
+		SbinDir:             flags.sbinDir,
+		ConfigDBDir:         flags.configDBDir,
+		JournalPath:         flags.journalPath,
+		Unit:                flags.unit,
+		StartHealthDeadline: flags.healthDeadline,
+		Sys:                 upgrade.NewSystem(flags.unit),
 		Logf:                func(format string, a ...any) { fmt.Printf(format+"\n", a...) },
 	}
 	r, err := upgrade.NewRunner(cfg)
@@ -76,4 +65,57 @@ func runUpgradeSubcommand(args []string) {
 		os.Exit(1)
 	}
 	fmt.Println("upgrade complete")
+}
+
+// upgradeFlags holds the parsed `xpfd upgrade` flags. Kept in a struct so the
+// flag parsing + positional-arg validation is unit-testable without the
+// os.Exit / real-System side effects of the dispatch.
+type upgradeFlags struct {
+	rolling                                                                       bool
+	stagedDir, versionsDir, stagedGenDir, sbinDir, configDBDir, journalPath, unit string
+	healthDeadline                                                                time.Duration
+}
+
+// parseUpgradeArgs parses the `xpfd upgrade [--rolling] [flags]` argument set.
+//
+// #4869: it REJECTS any leftover positional argument. `flag.FlagSet.Parse`
+// stops at the first non-flag token and leaves it in `fs.Args()`, so before
+// this guard `xpfd upgrade rolling` (missing the two dashes) silently left
+// `--rolling` false and ran the STANDALONE STOP->FLIP->START cut — an
+// uncoordinated cut on a clustered node with no drain/takeover. A mistyped or
+// misplaced argument must be a hard usage error, not a wrong/default run.
+func parseUpgradeArgs(args []string) (upgradeFlags, error) {
+	fs := flag.NewFlagSet("upgrade", flag.ContinueOnError)
+	rolling := fs.Bool("rolling", false,
+		"HA rolling upgrade: drive a controlled per-node drain + cut so the "+
+			"cluster keeps forwarding (one node down at a time)")
+	stagedDir := fs.String("staged-dir", upgrade.DefaultStagedDir, "dpkg-staged binary set dir")
+	versionsDir := fs.String("versions-dir", upgrade.DefaultVersionsDir, "runtime versioned dir")
+	stagedGenDir := fs.String("staged-gen-dir", upgrade.DefaultStagedGenDir,
+		"staged-generation root the cut copies from (#1981 Option B)")
+	sbinDir := fs.String("sbin-dir", upgrade.DefaultSbinDir, "operator-tool symlink dir")
+	configDBDir := fs.String("configdb-dir", upgrade.DefaultConfigDBDir, "config DB dir (for rollback snapshot)")
+	journalPath := fs.String("journal", upgrade.DefaultJournalPath, "crash-safe state journal path")
+	unit := fs.String("unit", upgrade.DefaultUnit, "systemd unit name")
+	healthDeadline := fs.Duration("health-deadline", 30*time.Second,
+		"post-start helper-health deadline before auto-rollback (standalone)")
+	if err := fs.Parse(args); err != nil {
+		return upgradeFlags{}, err
+	}
+	if fs.NArg() != 0 {
+		return upgradeFlags{}, fmt.Errorf("unexpected argument(s) %v; "+
+			"usage: xpfd upgrade [--rolling] [flags] "+
+			"(HA rolling upgrade needs the leading dashes: --rolling)", fs.Args())
+	}
+	return upgradeFlags{
+		rolling:        *rolling,
+		stagedDir:      *stagedDir,
+		versionsDir:    *versionsDir,
+		stagedGenDir:   *stagedGenDir,
+		sbinDir:        *sbinDir,
+		configDBDir:    *configDBDir,
+		journalPath:    *journalPath,
+		unit:           *unit,
+		healthDeadline: *healthDeadline,
+	}, nil
 }

--- a/cmd/xpfd/upgrade_args_4869_test.go
+++ b/cmd/xpfd/upgrade_args_4869_test.go
@@ -1,0 +1,68 @@
+package main
+
+import "testing"
+
+// #4869: `xpfd upgrade` must REJECT stray positional arguments rather than
+// silently dropping them and running a wrong/default action. The canonical
+// hazard is `xpfd upgrade rolling` (missing the two dashes): the bool flag
+// stays false and the STANDALONE STOP->FLIP->START cut runs on a clustered
+// node with no drain/takeover. A positional before flags, or any unknown
+// token, must be a hard error with NO run.
+func TestParseUpgradeArgsRejectsPositionals_4869(t *testing.T) {
+	cases := [][]string{
+		{"rolling"},                       // the classic missing-dashes typo
+		{"rolling", "--staged-dir", "/x"}, // positional shadows the trailing flags too
+		{"bogus"},
+		{"--rolling", "extra"}, // valid flag + stray positional
+		{"start"},
+	}
+	for _, args := range cases {
+		t.Run(joinArgs(args), func(t *testing.T) {
+			if _, err := parseUpgradeArgs(args); err == nil {
+				t.Fatalf("parseUpgradeArgs(%v) returned nil; expected rejection of the "+
+					"positional argument (must not silently run a default/standalone cut)", args)
+			}
+		})
+	}
+}
+
+// The supported forms still parse cleanly and map to the right runner.
+func TestParseUpgradeArgsValidForms_4869(t *testing.T) {
+	// Bare `xpfd upgrade` -> standalone cut (rolling false).
+	f, err := parseUpgradeArgs(nil)
+	if err != nil {
+		t.Fatalf("bare upgrade: %v", err)
+	}
+	if f.rolling {
+		t.Fatal("bare upgrade must NOT select the rolling path")
+	}
+
+	// `xpfd upgrade --rolling` -> HA rolling cut.
+	f, err = parseUpgradeArgs([]string{"--rolling"})
+	if err != nil {
+		t.Fatalf("--rolling: %v", err)
+	}
+	if !f.rolling {
+		t.Fatal("--rolling must select the rolling path")
+	}
+
+	// A recognized value flag is accepted and threaded through.
+	f, err = parseUpgradeArgs([]string{"--rolling", "--unit", "xpfd-test.service"})
+	if err != nil {
+		t.Fatalf("--rolling --unit: %v", err)
+	}
+	if !f.rolling || f.unit != "xpfd-test.service" {
+		t.Fatalf("flags not parsed: rolling=%v unit=%q", f.rolling, f.unit)
+	}
+}
+
+func joinArgs(a []string) string {
+	if len(a) == 0 {
+		return "<empty>"
+	}
+	s := a[0]
+	for _, x := range a[1:] {
+		s += "_" + x
+	}
+	return s
+}

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -287,6 +287,14 @@ Cuts the LOCAL clustered node with a controlled drain so the cluster
 keeps forwarding. Run on each node in turn (the deploy driver sequences
 both); exactly one node is primary throughout.
 
+The rolling path is selected ONLY by the `--rolling` flag. `xpfd upgrade`
+now REJECTS any stray positional argument (#4869): `flag.Parse` stops at
+the first non-flag token, so `xpfd upgrade rolling` (missing the two
+dashes) would otherwise leave `--rolling` false and silently run the
+uncoordinated STANDALONE cut on a clustered node — no drain, no
+takeover. A mistyped or misplaced argument is a hard usage error, not a
+wrong/default run.
+
 1. assert peer alive + session sync established + HA protocol compatible
    (`CurrentHAProtocolVersion`) — else ABORT to image-replace (Path C),
    never drop connections.


### PR DESCRIPTION
## Problem

`runUpgradeSubcommand` (`cmd/xpfd/upgrade.go`) parsed flags but never
checked `fs.NArg()`. `flag.FlagSet.Parse` stops at the first non-flag
token and leaves it in `fs.Args()`, so `xpfd upgrade rolling` (missing the
two dashes) left `--rolling` false and ran the STANDALONE STOP->FLIP->START
cut instead of the guarded HA rolling upgrade — an uncoordinated cut on a
clustered node with no drain/takeover (dropped sessions, possibly stranded
VIPs).

## Fix

Reject `fs.NArg() != 0` with a usage error before constructing/running the
runner, so a mistyped/misplaced argument is a hard error, not a wrong run.
The error names the likely fix (leading dashes on `--rolling`). Flag
parsing + validation extracted into a pure, unit-testable `parseUpgradeArgs`.

## Tests

RED-on-revert tests: `rolling`, an unknown token, a positional-before-flags,
and `--rolling extra` all error with no run; bare `xpfd upgrade` and
`xpfd upgrade --rolling [--unit ...]` still parse to the correct runner.
`go test ./cmd/xpfd/` green; `go build ./...` clean.
docs/in-place-upgrade.md updated.

Closes #4869