### PR TITLE
policymatch: include wildcard zone-pairs in zone-detail, order by tier

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43892,3 +43892,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4828 — fix AB-BA deadlock in cluster Manager.Start. Start no longer holds m.mu across the previous monitor's Stop(): the monitor poll goroutine calls SetMonitorWeight (takes m.mu) and Stop() joins it via wg.Wait(), so m.mu held across Stop() vs. m.mu wanted by the poll callback is a lock-order inversion that froze the whole HA manager on any config reload racing a monitor state change. Start now serializes on a dedicated monStartMu, takes m.mu only to swap the m.monitor pointer, and runs old.Stop()/new.Start() outside m.mu (mirrors hbStartMu/StartHeartbeat #4033). Added RED-on-revert deadlock reproduction test.
   **File(s)**: pkg/cluster/manager.go, pkg/cluster/manager_start_deadlock_test.go, pkg/cluster/README.md
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4885 zone-detail includes wildcard/any->any zone-pairs, renders in runtime tier order (exact, single-wildcard, both-any)
+  **File(s)**: pkg/policymatch/zone_detail_summary.go, pkg/policymatch/zone_detail_summary_test.go

--- a/pkg/policymatch/zone_detail_summary.go
+++ b/pkg/policymatch/zone_detail_summary.go
@@ -103,6 +103,26 @@ func ZoneDetailPolicySummary(cfg *config.Config, zone string, schedActive map[st
 	// Tier 1: zone-pair policies. Track policySetID across ALL zone-pair sets
 	// (matching or not, nil or not) exactly like the runtime walker so the
 	// displayed id lands in the correct span-accumulated namespace.
+	//
+	// #4885: two divergences from the runtime evaluator are fixed here.
+	//
+	//  1. A wildcard zone-pair side ("any") governs THIS zone too, but the
+	//     pre-fix `FromZone == zone || ToZone == zone` filter dropped it: a
+	//     `from any to untrust` set governs a trust->untrust flow (any matches
+	//     trust as ingress), and a `from any to any` set governs every zone —
+	//     yet neither literally names `zone`, so both were omitted. Match a
+	//     side when it equals `zone` OR is the "any" wildcard.
+	//  2. The runtime evaluates zone-pair sets in TIER order regardless of
+	//     config placement — exact (both sides concrete), then single-wildcard
+	//     (exactly one side "any"), then both-any (see policymatch.go transit
+	//     Tiers 1-3). Emit the summary in that same order (config order kept
+	//     within each tier) so an operator reads the effective precedence, not
+	//     raw stanza placement.
+	//
+	// policySetID still advances in config order so each rule's displayed id
+	// stays in the correct span-accumulated namespace no matter which tier
+	// bucket its line lands in.
+	var exactLines, singleWildLines, bothAnyLines []string
 	zonePairPolicies := 0
 	var policySetID uint32
 	for _, zpp := range cfg.Security.Policies {
@@ -112,7 +132,11 @@ func ZoneDetailPolicySummary(cfg *config.Config, zone string, schedActive map[st
 			policySetID++
 			continue
 		}
-		if zpp.FromZone == zone || zpp.ToZone == zone {
+		fromAny := zpp.FromZone == "any"
+		toAny := zpp.ToZone == "any"
+		fromAffects := zpp.FromZone == zone || fromAny
+		toAffects := zpp.ToZone == zone || toAny
+		if fromAffects || toAffects {
 			for i, pol := range zpp.Policies {
 				// #3476: skip a nil rule like the runtime walker does.
 				if pol == nil {
@@ -122,13 +146,24 @@ func ZoneDetailPolicySummary(cfg *config.Config, zone string, schedActive map[st
 				inactive := haveSched && dpuserspace.PolicyInactive(pol.SchedulerName, schedActive)
 				mods := zoneDetailModifiers(id, pol.SchedulerName, inactive, pol.Log,
 					pol.Count, pol.Match.SourceAddressExcluded, pol.Match.DestinationAddressExcluded)
-				lines = append(lines, fmt.Sprintf("    [zone-pair] %s -> %s: %s (%s) %s",
-					zpp.FromZone, zpp.ToZone, pol.Name, ActionString(pol.Action), mods))
+				line := fmt.Sprintf("    [zone-pair] %s -> %s: %s (%s) %s",
+					zpp.FromZone, zpp.ToZone, pol.Name, ActionString(pol.Action), mods)
+				switch {
+				case fromAny && toAny:
+					bothAnyLines = append(bothAnyLines, line)
+				case fromAny || toAny:
+					singleWildLines = append(singleWildLines, line)
+				default:
+					exactLines = append(exactLines, line)
+				}
 				zonePairPolicies++
 			}
 		}
 		policySetID++
 	}
+	lines = append(lines, exactLines...)
+	lines = append(lines, singleWildLines...)
+	lines = append(lines, bothAnyLines...)
 
 	// Tier 2: applicable GLOBAL policies. The global tier's policySetID is the
 	// count of zone-pair sets (policySetID after the loop), mirroring the

--- a/pkg/policymatch/zone_detail_summary_test.go
+++ b/pkg/policymatch/zone_detail_summary_test.go
@@ -130,3 +130,80 @@ func TestZoneDetailPolicySummaryNilConfig(t *testing.T) {
 		t.Fatalf("nil cfg should return nil, got %v", lines)
 	}
 }
+
+// TestZoneDetailPolicySummaryWildcardZonePairs pins the #4885 fix: a wildcard
+// zone-pair side ("any") that governs the queried zone must be INCLUDED, and
+// zone-pair lines must render in the runtime's tier order (exact, then
+// single-wildcard, then both-any) regardless of config placement.
+//
+// The config below is deliberately authored in REVERSE tier order —
+// both-any first, single-wildcard next, exact last, plus one unrelated set —
+// so a passing test proves both the inclusion filter and the re-ordering.
+func TestZoneDetailPolicySummaryWildcardZonePairs(t *testing.T) {
+	anyMatch := config.PolicyMatch{
+		SourceAddresses:      []string{"any"},
+		DestinationAddresses: []string{"any"},
+		Applications:         []string{"any"},
+	}
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			DefaultPolicy: config.PolicyDeny,
+			Zones:         zones("trust", "untrust", "dmz"),
+			Policies: []*config.ZonePairPolicies{
+				{ // config idx 0 — both-any: governs every zone
+					FromZone: "any", ToZone: "any",
+					Policies: []*config.Policy{{Name: "anyany", Action: config.PolicyDeny, Match: anyMatch}},
+				},
+				{ // config idx 1 — single-wildcard: from any -> untrust governs a trust ingress
+					FromZone: "any", ToZone: "untrust",
+					Policies: []*config.Policy{{Name: "wild-ingress", Action: config.PolicyPermit, Match: anyMatch}},
+				},
+				{ // config idx 2 — exact: literally names trust
+					FromZone: "trust", ToZone: "untrust",
+					Policies: []*config.Policy{{Name: "exact", Action: config.PolicyPermit, Match: anyMatch}},
+				},
+				{ // config idx 3 — unrelated: neither side is trust/any
+					FromZone: "dmz", ToZone: "untrust",
+					Policies: []*config.Policy{{Name: "unrelated", Action: config.PolicyPermit, Match: anyMatch}},
+				},
+			},
+		},
+	}
+	lines := ZoneDetailPolicySummary(cfg, "trust", nil, false)
+	got := strings.Join(lines, "\n")
+
+	// Inclusion: the wildcard + both-any sets that govern trust must appear;
+	// the unrelated dmz->untrust set must not.
+	idxExact := indexOfLine(t, lines, "exact")
+	idxWild := indexOfLine(t, lines, "wild-ingress")
+	idxAny := indexOfLine(t, lines, "anyany")
+	if strings.Contains(got, "unrelated") {
+		t.Fatalf("dmz->untrust set does not govern trust and must be omitted:\n%s", got)
+	}
+	// Ordering: exact, then single-wildcard, then both-any — despite reverse
+	// config placement.
+	if !(idxExact < idxWild && idxWild < idxAny) {
+		t.Fatalf("zone-pair lines out of runtime tier order (exact=%d wild=%d any=%d):\n%s",
+			idxExact, idxWild, idxAny, got)
+	}
+	// The rendered wildcard sides keep the "any" token.
+	if !strings.Contains(got, "[zone-pair] any -> untrust: wild-ingress") {
+		t.Fatalf("single-wildcard line missing/misrendered:\n%s", got)
+	}
+	if !strings.Contains(got, "[zone-pair] any -> any: anyany") {
+		t.Fatalf("both-any line missing/misrendered:\n%s", got)
+	}
+}
+
+// indexOfLine returns the index of the first line containing sub, failing the
+// test if none matches.
+func indexOfLine(t *testing.T, lines []string, sub string) int {
+	t.Helper()
+	for i, l := range lines {
+		if strings.Contains(l, sub) {
+			return i
+		}
+	}
+	t.Fatalf("no summary line contains %q:\n%s", sub, strings.Join(lines, "\n"))
+	return -1
+}


### PR DESCRIPTION
## Summary
`show security zones detail` (backed by `ZoneDetailPolicySummary`) diverged from the runtime policy evaluator on wildcard zone-pairs:

- **Inclusion**: the Tier-1 filter `zpp.FromZone == zone || zpp.ToZone == zone` required a set to literally name the queried zone, dropping wildcard sets that actually govern it. `from any to untrust` governs a `trust -> untrust` flow (the `any` from-side matches trust as ingress); `from any to any` governs every zone — both were omitted.
- **Ordering**: the runtime evaluates zone-pair sets in tier order (exact, then single-wildcard, then both-any) regardless of config placement; the summary printed raw config order, so an operator could infer the wrong winner.

## Fix
Match a zone-pair side when it equals the queried zone OR is `any`, and bucket rendered lines into exact / single-wildcard / both-any tiers (config order preserved within each tier), appended in runtime evaluation order. `policySetID` still advances in config order so displayed runtime policy ids stay in the correct span-accumulated namespace.

## Test
`TestZoneDetailPolicySummaryWildcardZonePairs` authors the sets in reverse tier order plus one unrelated set; asserts the wildcard/any->any sets are included, the unrelated set omitted, and lines render exact < single-wildcard < both-any. RED-on-revert verified (pre-fix only the exact set appears).

`go build ./...` clean; `go test ./pkg/policymatch/...` green; gofmt clean.

Closes #4885