### PR TITLE
cmdtree: nil-skip tolerated RI/RG entries in completion DynamicFns

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43898,3 +43898,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4877 ValidatePercent rejects NaN/Inf (commit-check) before range gate
   **File(s)**: pkg/config/schema_validators.go, pkg/config/schema_validate_test.go
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4866 cmdtree RI/RG completion DynamicFns nil-skip tolerated (#3494) entries via shared helpers
+  **File(s)**: pkg/cmdtree/tree.go, pkg/cmdtree/completion_nil_ri_rg_4866_test.go

--- a/pkg/cmdtree/completion_nil_ri_rg_4866_test.go
+++ b/pkg/cmdtree/completion_nil_ri_rg_4866_test.go
@@ -1,0 +1,90 @@
+package cmdtree
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #4866: the operational-tree DynamicFns for routing-instance and
+// redundancy-group names dereferenced every slice element (ri.Name / rg.ID)
+// with only a `cfg == nil` guard. A nil *RoutingInstanceConfig /
+// *RedundancyGroup element is a tolerated shape on the tolerant-load / HA-sync
+// config path (#3494 injects exactly these), which the daemon's own validators
+// and route builder already skip. cmdtree is the completion SSOT for the local
+// CLI, remote CLI, and gRPC, so a read-only completion / `?` help request that
+// hit that shape crashed the control plane. These drive the real completers;
+// reverting the `ri == nil` / `rg == nil` guards in the shared helpers makes
+// them panic (RED on revert).
+
+func nilTolerantRIRGConfig() *config.Config {
+	cfg := &config.Config{}
+	// A real routing instance followed by a tolerated nil element.
+	cfg.RoutingInstances = []*config.RoutingInstanceConfig{
+		{Name: "vr-blue"},
+		nil,
+	}
+	// A real redundancy group followed by a tolerated nil element.
+	cfg.Chassis.Cluster = &config.ClusterConfig{
+		RedundancyGroups: []*config.RedundancyGroup{
+			{ID: 1},
+			nil,
+		},
+	}
+	return cfg
+}
+
+func assertNoEmptyCandidate(t *testing.T, cands []string) {
+	t.Helper()
+	for _, c := range cands {
+		if c == "" {
+			t.Fatalf("nil entry produced an empty completion candidate: %v", cands)
+		}
+	}
+}
+
+func TestRoutingInstanceCompletionNilEntryNoPanic(t *testing.T) {
+	cfg := nilTolerantRIRGConfig()
+
+	// Every routing-instance-name completer must skip the nil entry and
+	// surface the real instance name without panicking.
+	paths := [][]string{
+		{"show", "route", "instance"},
+		{"test", "routing", "instance"},
+		{"ping", "routing-instance"},
+		{"traceroute", "routing-instance"},
+	}
+	for _, p := range paths {
+		cands := CompleteFromTree(OperationalTree, p, "", cfg)
+		if !contains(cands, "vr-blue") {
+			t.Fatalf("%v: expected routing instance vr-blue, got %v", p, cands)
+		}
+		assertNoEmptyCandidate(t, cands)
+	}
+
+	// `show route table` mixes the main tables with per-instance tables; the
+	// nil entry must be skipped, the real instance's tables surfaced.
+	cands := CompleteFromTree(OperationalTree, []string{"show", "route", "table"}, "", cfg)
+	for _, want := range []string{"inet.0", "inet6.0", "vr-blue.inet.0", "vr-blue.inet6.0"} {
+		if !contains(cands, want) {
+			t.Fatalf("show route table: expected %q, got %v", want, cands)
+		}
+	}
+	assertNoEmptyCandidate(t, cands)
+}
+
+func TestRedundancyGroupCompletionNilEntryNoPanic(t *testing.T) {
+	cfg := nilTolerantRIRGConfig()
+
+	paths := [][]string{
+		{"request", "chassis", "cluster", "failover", "redundancy-group"},
+		{"request", "chassis", "cluster", "failover", "reset", "redundancy-group"},
+	}
+	for _, p := range paths {
+		cands := CompleteFromTree(OperationalTree, p, "", cfg)
+		if !contains(cands, "1") {
+			t.Fatalf("%v: expected redundancy-group id 1, got %v", p, cands)
+		}
+		assertNoEmptyCandidate(t, cands)
+	}
+}

--- a/pkg/cmdtree/tree.go
+++ b/pkg/cmdtree/tree.go
@@ -129,6 +129,63 @@ type Candidate struct {
 	Desc string
 }
 
+// routingInstanceNames returns the configured routing-instance names for the
+// `show route instance`, `test routing instance`, and `ping/traceroute
+// routing-instance` completers. It skips a nil slice element — the tolerant /
+// HA-sync config path (#3494) may leave nil *RoutingInstanceConfig entries the
+// daemon's own validators and route builder already tolerate. cmdtree is the
+// completion SSOT for the local CLI, remote CLI, and gRPC, so a read-only
+// completion request must never panic on that shape (#4866).
+func routingInstanceNames(cfg *config.Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	names := make([]string, 0, len(cfg.RoutingInstances))
+	for _, ri := range cfg.RoutingInstances {
+		if ri == nil {
+			continue
+		}
+		names = append(names, ri.Name)
+	}
+	return names
+}
+
+// routingInstanceTableNames returns the per-instance route-table names
+// (`<instance>.inet.0` / `<instance>.inet6.0`) appended to the main tables for
+// `show route table` completion, nil-skipping like routingInstanceNames
+// (#4866).
+func routingInstanceTableNames(cfg *config.Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	names := make([]string, 0, 2*len(cfg.RoutingInstances))
+	for _, ri := range cfg.RoutingInstances {
+		if ri == nil {
+			continue
+		}
+		names = append(names, ri.Name+".inet.0", ri.Name+".inet6.0")
+	}
+	return names
+}
+
+// redundancyGroupIDs returns the configured redundancy-group IDs for the
+// `request chassis cluster failover [reset] redundancy-group` completers,
+// skipping a nil *RedundancyGroup entry the tolerant / HA-sync path (#3494)
+// may leave in the slice (#4866).
+func redundancyGroupIDs(cfg *config.Config) []string {
+	if cfg == nil || cfg.Chassis.Cluster == nil {
+		return nil
+	}
+	names := make([]string, 0, len(cfg.Chassis.Cluster.RedundancyGroups))
+	for _, rg := range cfg.Chassis.Cluster.RedundancyGroups {
+		if rg == nil {
+			continue
+		}
+		names = append(names, fmt.Sprintf("%d", rg.ID))
+	}
+	return names
+}
+
 // OperationalTree defines tab completion for operational mode.
 // This is the canonical source — all other trees derive from this.
 var OperationalTree = map[string]*Node{
@@ -248,28 +305,15 @@ var OperationalTree = map[string]*Node{
 			"detail":  {Desc: "Display detailed output"},
 			"summary": {Desc: "Show routing table statistics"},
 			"table": {Desc: "Show routes in named routing table", DynamicFn: func(cfg *config.Config) []string {
-				if cfg == nil {
-					return []string{"inet.0", "inet6.0"}
-				}
-				// Include main tables plus per-instance tables.
-				names := []string{"inet.0", "inet6.0"}
-				for _, ri := range cfg.RoutingInstances {
-					names = append(names, ri.Name+".inet.0", ri.Name+".inet6.0")
-				}
-				return names
+				// Include main tables plus per-instance tables. #4866:
+				// routingInstanceTableNames nil-skips tolerated nil RI entries.
+				return append([]string{"inet.0", "inet6.0"}, routingInstanceTableNames(cfg)...)
 			}},
 			"protocol": {Desc: "Show routes learned from named protocol", DynamicFn: func(_ *config.Config) []string {
 				return []string{"static", "direct", "local", "ospf", "bgp", "rip", "isis", "kernel", "connected"}
 			}},
 			"instance": {Desc: "Show routes for a routing instance", DynamicFn: func(cfg *config.Config) []string {
-				if cfg == nil {
-					return nil
-				}
-				names := make([]string, 0, len(cfg.RoutingInstances))
-				for _, ri := range cfg.RoutingInstances {
-					names = append(names, ri.Name)
-				}
-				return names
+				return routingInstanceNames(cfg) // #4866: nil-skip tolerated entries
 			}},
 		}},
 		"security": {Desc: "Show security information", Children: map[string]*Node{
@@ -819,14 +863,7 @@ var OperationalTree = map[string]*Node{
 						}},
 					}},
 					"redundancy-group": {Desc: "Failover a specific redundancy group", DynamicFn: func(cfg *config.Config) []string {
-						if cfg == nil || cfg.Chassis.Cluster == nil {
-							return nil
-						}
-						names := make([]string, 0, len(cfg.Chassis.Cluster.RedundancyGroups))
-						for _, rg := range cfg.Chassis.Cluster.RedundancyGroups {
-							names = append(names, fmt.Sprintf("%d", rg.ID))
-						}
-						return names
+						return redundancyGroupIDs(cfg) // #4866: nil-skip tolerated RG entries
 					}, Children: map[string]*Node{
 						"node": {Desc: "Target node ID (local or peer)", DynamicFn: func(cfg *config.Config) []string {
 							if cfg == nil || cfg.Chassis.Cluster == nil {
@@ -838,14 +875,7 @@ var OperationalTree = map[string]*Node{
 					}},
 					"reset": {Desc: "Reset manual failover", Children: map[string]*Node{
 						"redundancy-group": {Desc: "Reset failover for a redundancy group", DynamicFn: func(cfg *config.Config) []string {
-							if cfg == nil || cfg.Chassis.Cluster == nil {
-								return nil
-							}
-							names := make([]string, 0, len(cfg.Chassis.Cluster.RedundancyGroups))
-							for _, rg := range cfg.Chassis.Cluster.RedundancyGroups {
-								names = append(names, fmt.Sprintf("%d", rg.ID))
-							}
-							return names
+							return redundancyGroupIDs(cfg) // #4866: nil-skip tolerated RG entries
 						}},
 					}},
 				}},
@@ -1009,14 +1039,7 @@ var OperationalTree = map[string]*Node{
 		"routing": {Desc: "Test route lookup", Children: map[string]*Node{
 			"destination": {Desc: "Destination IP or prefix to look up"},
 			"instance": {Desc: "Routing instance for route lookup", DynamicFn: func(cfg *config.Config) []string {
-				if cfg == nil {
-					return nil
-				}
-				names := make([]string, 0, len(cfg.RoutingInstances))
-				for _, ri := range cfg.RoutingInstances {
-					names = append(names, ri.Name)
-				}
-				return names
+				return routingInstanceNames(cfg) // #4866: nil-skip tolerated entries
 			}},
 		}},
 		"security-zone": {Desc: "Show zone for interface", Children: map[string]*Node{
@@ -1038,28 +1061,14 @@ var OperationalTree = map[string]*Node{
 		"source": {Desc: "Source address to use"},
 		"size":   {Desc: "Request data size in bytes"},
 		"routing-instance": {Desc: "Routing instance for route lookup", DynamicFn: func(cfg *config.Config) []string {
-			if cfg == nil {
-				return nil
-			}
-			names := make([]string, 0, len(cfg.RoutingInstances))
-			for _, ri := range cfg.RoutingInstances {
-				names = append(names, ri.Name)
-			}
-			return names
+			return routingInstanceNames(cfg) // #4866: nil-skip tolerated entries
 		}},
 	}},
 	"traceroute": {Desc: "Trace route to remote host", Children: map[string]*Node{
 		"<host>": {Desc: "Hostname or IP address of remote host"},
 		"source": {Desc: "Source address to use"},
 		"routing-instance": {Desc: "Routing instance for route lookup", DynamicFn: func(cfg *config.Config) []string {
-			if cfg == nil {
-				return nil
-			}
-			names := make([]string, 0, len(cfg.RoutingInstances))
-			for _, ri := range cfg.RoutingInstances {
-				names = append(names, ri.Name)
-			}
-			return names
+			return routingInstanceNames(cfg) // #4866: nil-skip tolerated entries
 		}},
 	}},
 	"quit": {Desc: "Exit CLI"},


### PR DESCRIPTION
## Summary
The operational command-tree DynamicFns for routing-instance and redundancy-group names dereferenced every slice element (`ri.Name` / `rg.ID`) with only a `cfg == nil` guard. A nil `*RoutingInstanceConfig` / `*RedundancyGroup` element is a tolerated shape on the tolerant-load / HA-sync config path (pkg/config's #3494 warning-pass test injects exactly these; the daemon's validators and route builder already skip them).

cmdtree is the completion SSOT for the local CLI, remote CLI, and gRPC, so a non-mutating `<TAB>` / `?` completion request against such a config panicked the control plane. Six DynamicFns were affected: `show route table`, `show route instance`, `test routing instance`, `ping`/`traceroute routing-instance` (RI), and `request chassis cluster failover [reset] redundancy-group` (RG).

## Fix
Add three nil-skipping helpers — `routingInstanceNames`, `routingInstanceTableNames`, `redundancyGroupIDs` — and route every affected DynamicFn through them, collapsing the duplicated inline loops. `show route table` keeps its main-table prefix and appends the nil-skipped per-instance tables (preserving cfg==nil behavior).

## Test
`completion_nil_ri_rg_4866_test.go` drives each real completer with a config carrying a real entry plus a tolerated nil element and asserts the real name is surfaced with no panic / no empty candidate. RED-on-revert verified: removing the guards panics on the nil deref.

`go build ./...` clean; `go test ./pkg/cmdtree/...` green; gofmt clean.

Closes #4866