### PR TITLE
config: range-gate redundancy-group node priority post-compile

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43902,3 +43902,7 @@ top.
   **File(s)**: cmd/xpfd/upgrade.go, cmd/xpfd/upgrade_args_4869_test.go, docs/in-place-upgrade.md
   **Action**: #4877 ValidatePercent rejects NaN/Inf (commit-check) before range gate
   **File(s)**: pkg/config/schema_validators.go, pkg/config/schema_validate_test.go
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4880 post-compile strict gate rejects out-of-range redundancy-group node priority (closes packed hierarchical + flat-set shapes)
+  **File(s)**: pkg/config/compiler_validate_strict_chassis.go, pkg/config/schema_validate_chassis_test.go

--- a/pkg/config/compiler_validate_strict_chassis.go
+++ b/pkg/config/compiler_validate_strict_chassis.go
@@ -24,6 +24,24 @@ const MaxHeartbeatRedundancyGroups = 255
 // then collide on the same GroupID byte and corrupt peer election.
 const MaxHeartbeatRedundancyGroupID = 255
 
+// MinRedundancyGroupNodePriority / MaxRedundancyGroupNodePriority bound a
+// redundancy-group node priority (Junos vSRX 1..254). 0 is treated as unset
+// (VRRP maps pri==0 to the default 100) and 255 is the RFC 5798 IP-owner
+// reserved value; both are excluded. The schema `priority` leaf
+// (schema_chassis.go ValidateInteger(1,254)) enforces this on the flat-set /
+// expanded shape, but the packed hierarchical one-liner
+// `node 0 priority <v>;` carries the value inside the node instance's own key
+// tail, which the schema walker consumes as identity and never validates —
+// compileChassis still reads it into NodePriorities under no bound (#4880). The
+// value feeds VRRP, which truncates it to uint8 on the wire
+// (pkg/vrrp/instance.go), while the private control-link election uses the raw
+// int (pkg/cluster/group_state.go), so an out-of-range priority both truncates
+// on the wire and diverges the two election views.
+const (
+	MinRedundancyGroupNodePriority = 1
+	MaxRedundancyGroupNodePriority = 254
+)
+
 // validateChassisClusterStrict hard-rejects, at commit / commit-check, a
 // chassis-cluster config whose redundancy-group cardinality or ids exceed
 // what the HA heartbeat wire format can encode (#4434, codex-172 C172-H02).
@@ -75,6 +93,43 @@ func validateChassisClusterStrict(cfg *Config) error {
 				"above %d truncates on the wire and collides with another "+
 				"redundancy-group) — renumber the redundancy-group",
 				id, MaxHeartbeatRedundancyGroupID, MaxHeartbeatRedundancyGroupID)
+		}
+	}
+
+	// #4880: node-priority range gate. The schema `priority` leaf validates the
+	// flat-set / expanded shape, but the packed hierarchical one-liner
+	// `node 0 priority <v>;` bypasses the walker (see
+	// MinRedundancyGroupNodePriority doc). compileChassis stores whatever the
+	// operator wrote into NodePriorities, and it flows to VRRP (uint8-truncated
+	// on the wire) and the private election (raw int) — so re-assert the
+	// [1,254] range on the compiled priorities here, closing BOTH shapes.
+	// Iterate rgs sorted by id, then node ids, so the first-error message is
+	// deterministic across the map-ordered AST walk.
+	rgByID := make([]*RedundancyGroup, 0, len(rgs))
+	for _, rg := range rgs {
+		if rg != nil { // #3494: tolerant/HA-sync path may carry a nil entry.
+			rgByID = append(rgByID, rg)
+		}
+	}
+	sort.Slice(rgByID, func(i, j int) bool { return rgByID[i].ID < rgByID[j].ID })
+	for _, rg := range rgByID {
+		nodeIDs := make([]int, 0, len(rg.NodePriorities))
+		for nodeID := range rg.NodePriorities {
+			nodeIDs = append(nodeIDs, nodeID)
+		}
+		sort.Ints(nodeIDs)
+		for _, nodeID := range nodeIDs {
+			pri := rg.NodePriorities[nodeID]
+			if pri < MinRedundancyGroupNodePriority || pri > MaxRedundancyGroupNodePriority {
+				return fmt.Errorf("chassis cluster: redundancy-group %d node %d priority "+
+					"%d is out of range %d..%d (0 is treated as unset and 255 is the "+
+					"RFC 5798 IP-owner reserved value; the priority feeds VRRP and "+
+					"truncates to a single wire byte, and the private control-link "+
+					"election reads the raw value) — set a priority in %d..%d",
+					rg.ID, nodeID, pri,
+					MinRedundancyGroupNodePriority, MaxRedundancyGroupNodePriority,
+					MinRedundancyGroupNodePriority, MaxRedundancyGroupNodePriority)
+			}
 		}
 	}
 	return nil

--- a/pkg/config/schema_validate_chassis_test.go
+++ b/pkg/config/schema_validate_chassis_test.go
@@ -214,25 +214,89 @@ func TestSchemaValidate_ChassisCluster_HierarchicalRejectsGarbageInterval(t *tes
 	}
 }
 
-// Documented contract pin (NOT an endorsement): the hierarchical packed
-// one-liner `node 0 priority <v>;` carries the priority INSIDE the
-// instance node's own Keys. The PR-1 walker's compiler-faithful rule
-// consumes only the identity tokens of a named-instance container and
-// ignores the rest, so this shape bypasses the typed-leaf gate even
-// though compileChassis happens to read the inline tokens. Rejecting it
-// would require a new walker feature (out of PR-2 scope; see
-// docs/config-schema.md). The flat-set form of the same statement IS
-// validated (see the matrix above) because SetPath groups `priority` into
-// its own child node.
-func TestSchemaValidate_ChassisCluster_PackedOneLinerBypassesGate(t *testing.T) {
-	if err := schemaCheck(t, `chassis {
+// #4880: the hierarchical packed one-liner `node 0 priority <v>;` carries the
+// priority INSIDE the instance node's own Keys. The walker's compiler-faithful
+// rule consumes only the identity tokens of a named-instance container and
+// ignores the rest, so this shape still slips past the typed-leaf schema gate
+// (SchemaValidate) — that walker limitation is unchanged. But compileChassis
+// reads the inline priority into NodePriorities, and it flows to VRRP
+// (uint8-truncated on the wire) and the private control-link election (raw
+// int), so an out-of-range value both truncates and diverges the two election
+// views. A post-compile range gate (validateChassisClusterStrict) now rejects
+// it at commit, matching the flat-set / expanded shape which the schema leaf
+// already gates. This was previously a contract-pin ACCEPTANCE test; it is now
+// a rejection test at the compile layer.
+func TestCompile_ChassisCluster_PackedOneLinerPriorityRejected(t *testing.T) {
+	packed := `chassis {
     cluster {
         redundancy-group 1 {
             node 0 priority 999;
         }
     }
-}`); err != nil {
-		t.Fatalf("packed one-liner is (deliberately) not validated; got: %v", err)
+}`
+	// The walker still does not catch the packed shape — SchemaValidate passes.
+	if err := schemaCheck(t, packed); err != nil {
+		t.Fatalf("SchemaValidate is expected to still pass the packed shape "+
+			"(unchanged walker limitation); got: %v", err)
+	}
+	// The post-compile gate rejects it.
+	tree, errs := config.NewParser(packed).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	if _, err := config.CompileConfig(tree); err == nil {
+		t.Fatal("packed one-liner priority 999 must be rejected at compile")
+	} else if !strings.Contains(err.Error(), "priority") || !strings.Contains(err.Error(), "999") {
+		t.Fatalf("compile error should name the out-of-range priority: %v", err)
+	}
+
+	// A valid packed priority compiles clean (no over-eager rejection).
+	okTree, errs := config.NewParser(`chassis {
+    cluster {
+        redundancy-group 1 {
+            node 0 priority 200;
+        }
+    }
+}`).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	if _, err := config.CompileConfig(okTree); err != nil {
+		t.Fatalf("valid packed priority 200 must compile: %v", err)
+	}
+}
+
+// TestCompile_ChassisCluster_PriorityGateClosesBothShapes asserts the #4880
+// post-compile priority gate is SHAPE-AGNOSTIC: it catches the flat-set /
+// expanded shape (priority in its own child node, built via ParseSetCommand +
+// SetPath) at the same compile layer, so the packed and expanded shapes can no
+// longer disagree. (The schema leaf also rejects the expanded shape earlier at
+// SchemaValidate; this pins the compile backstop directly.)
+func TestCompile_ChassisCluster_PriorityGateClosesBothShapes(t *testing.T) {
+	badTree := &config.ConfigTree{}
+	path, err := config.ParseSetCommand("set chassis cluster redundancy-group 1 node 0 priority 999")
+	if err != nil {
+		t.Fatalf("ParseSetCommand: %v", err)
+	}
+	if err := badTree.SetPath(path); err != nil {
+		t.Fatalf("SetPath: %v", err)
+	}
+	if _, err := config.CompileConfig(badTree); err == nil {
+		t.Fatal("flat-set expanded priority 999 must be rejected at the compile gate")
+	} else if !strings.Contains(err.Error(), "priority") || !strings.Contains(err.Error(), "999") {
+		t.Fatalf("compile error should name the out-of-range priority: %v", err)
+	}
+
+	okTree := &config.ConfigTree{}
+	okPath, err := config.ParseSetCommand("set chassis cluster redundancy-group 1 node 0 priority 200")
+	if err != nil {
+		t.Fatalf("ParseSetCommand: %v", err)
+	}
+	if err := okTree.SetPath(okPath); err != nil {
+		t.Fatalf("SetPath: %v", err)
+	}
+	if _, err := config.CompileConfig(okTree); err != nil {
+		t.Fatalf("valid flat-set priority 200 must compile: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
The schema `priority` leaf gates a redundancy-group node priority (1..254) on the flat-set / expanded shape, but the packed hierarchical one-liner `node 0 priority <v>;` carries the value inside the node instance's own Keys tail. The schema walker consumes only the identity tokens and ignores the tail, so the packed shape slips past the typed-leaf gate — yet `compileChassis` reads the inline priority into `RedundancyGroup.NodePriorities` under no bound.

The stored value reaches HA: VRRP casts it to `uint8` on the wire (`pkg/vrrp/instance.go`) while the private control-link election reads the raw int (`pkg/cluster/group_state.go`). So `node 0 priority 999;` commits, advertises as `uint8(999)=231`, and the two election views disagree — a dual-shape split (the flat-set form is correctly rejected).

## Fix
Add a post-compile range gate in `validateChassisClusterStrict` asserting every compiled `NodePriorities` entry is 1..254 (0 = unset, 255 = RFC 5798 IP-owner reserved). Because it validates the compiled map, it closes both the packed hierarchical and flat-set/expanded shapes at commit. It inherits the existing tolerant/HA-sync downgrade-to-warning (`opts.lenientChassisRG`) so a persisted/peer-synced config still boots (#1960 no-brick), same doctrine as the RG count/id gates beside it.

## Tests
- The former contract-pin ACCEPTANCE test is flipped to `TestCompile_ChassisCluster_PackedOneLinerPriorityRejected`: SchemaValidate still passes the packed shape (walker limitation unchanged) but CompileConfig now rejects it; a valid packed priority still compiles.
- `TestCompile_ChassisCluster_PriorityGateClosesBothShapes` builds the flat-set expanded shape via `ParseSetCommand + SetPath` and asserts the same compile gate rejects it.

RED-on-revert verified for both shapes. `go build ./...` clean; `go test ./pkg/config/...` green; gofmt clean.

Closes #4880