### PR TITLE
userspace-dp: fix unaligned read in debug BPF session dump (#4882)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-07-09 — #4882 userspace-dp: debug BPF session dump used `core::ptr::read` (align 2) on a `Vec<u8>` (align 1) — UB; use `read_unaligned`
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4882 (Low, debug-gated UB). `dump_bpf_session_entries`
+  (`bpf_map/metrics.rs`) decoded a `#[repr(C)]` `UserspaceSessionMapKey`
+  (alignment 2 — `u16` `pad`/`src_port`/`dst_port`) out of a `Vec<u8>` key
+  buffer (alignment 1) via `core::ptr::read`, whose alignment precondition the
+  byte buffer does not guarantee → undefined behavior (faults on arches that
+  reject misaligned loads; x86 tolerates it but it is still UB). Extracted a
+  `decode_session_map_key(&[u8]) -> UserspaceSessionMapKey` helper that uses
+  `core::ptr::read_unaligned` (matching the crate's existing
+  `frame::inspect` unaligned-metadata idiom) and routed the dump loop through
+  it. Byte/wire layout and decoded values are unchanged — only the read is now
+  alignment-safe. Verified no other unaligned `ptr::read`/`&*(ptr as *const T)`
+  struct reads exist in the bpf_map decoder (the mmap XDP-ring `*(... as
+  *const u32)` reads are page-aligned kernel ring offsets, a separate
+  well-defined path, out of scope).
+  **File(s)**: userspace-dp/src/afxdp/bpf_map/metrics.rs
+  **Validation**: added
+  `metrics::tests::decode_session_map_key_from_misaligned_buffer`, which copies
+  a reference key's bytes so the decode source starts at an ODD address
+  (guaranteed misaligned for an align-2 struct regardless of allocator base)
+  and asserts every field round-trips. Full `TMPDIR=/dev/shm
+  CARGO_TARGET_DIR=/dev/shm/cargo cargo test --release` green (dataplane merge
+  gate); `cargo build --release --features debug-log` clean (the debug dump
+  path compiles). No smoke: debug-gated metrics path, zero forwarding change.
+
 ## 2026-07-09 — #4862 config parser: assert EOF so a stray top-level `}` is an error, not a silent truncation
 
 - **Timestamp**: 2026-07-09

--- a/userspace-dp/src/afxdp/bpf_map/metrics.rs
+++ b/userspace-dp/src/afxdp/bpf_map/metrics.rs
@@ -128,6 +128,27 @@ pub(in crate::afxdp) fn count_bpf_session_entries(map_fd: c_int) -> u32 {
     count
 }
 
+/// Decode a `UserspaceSessionMapKey` from a raw BPF key buffer produced by
+/// `bpf_map_get_next_key`.
+///
+/// #4882: the buffer is a `Vec<u8>` (alignment 1) but the struct is
+/// `#[repr(C)]` with `u16` fields (alignment 2). A plain `ptr::read` (or a
+/// `&*(ptr as *const UserspaceSessionMapKey)` cast) requires the source
+/// pointer to be aligned for the target type, which the byte buffer does not
+/// guarantee — that is UB and faults on architectures that reject misaligned
+/// loads (x86 tolerates it but it remains UB and a portability footgun). Use
+/// the crate's existing unaligned-metadata idiom (`frame::inspect`'s
+/// `read_unaligned`).
+fn decode_session_map_key(key_bytes: &[u8]) -> UserspaceSessionMapKey {
+    debug_assert!(key_bytes.len() >= core::mem::size_of::<UserspaceSessionMapKey>());
+    // SAFETY: `read_unaligned` imposes no alignment requirement on the source
+    // pointer. The caller passes a buffer sized to `key_size` (==
+    // `size_of::<UserspaceSessionMapKey>()`), and every bit pattern is a valid
+    // value for this POD `#[repr(C)]` struct (only `u8`/`u16`/`[u8; N]`
+    // fields), so the read is sound.
+    unsafe { core::ptr::read_unaligned(key_bytes.as_ptr().cast::<UserspaceSessionMapKey>()) }
+}
+
 /// Dump first N entries from the BPF USERSPACE_SESSIONS map for debugging.
 #[allow(unused_variables)]
 pub(in crate::afxdp) fn dump_bpf_session_entries(map_fd: c_int, max_entries: u32) {
@@ -149,9 +170,9 @@ pub(in crate::afxdp) fn dump_bpf_session_entries(map_fd: c_int, max_entries: u32
         return;
     }
     loop {
-        // Read the key as UserspaceSessionMapKey
-        let map_key: UserspaceSessionMapKey =
-            unsafe { core::ptr::read(next_key_bytes.as_ptr().cast()) };
+        // Read the key as UserspaceSessionMapKey (alignment-safe: the key
+        // buffer is a `Vec<u8>` with no alignment guarantee — see #4882).
+        let map_key: UserspaceSessionMapKey = decode_session_map_key(&next_key_bytes);
         let _ = unsafe {
             libbpf_sys::bpf_map_lookup_elem(
                 map_fd,
@@ -265,3 +286,60 @@ pub(in crate::afxdp) static SESSION_DELETE_STALE_IGNORED: AtomicU64 = AtomicU64:
 pub(in crate::afxdp) static SESSION_CREATIONS_LOGGED: AtomicU64 = AtomicU64::new(0);
 #[cfg(feature = "debug-log")]
 pub(in crate::afxdp) static ICMPV6_EMBED_LOGGED: AtomicU32 = AtomicU32::new(0);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #4882: the debug BPF session dump decodes a `#[repr(C)]` key struct
+    /// (alignment 2 — it carries `u16` fields) out of a `Vec<u8>` key buffer
+    /// (alignment 1). The old `core::ptr::read` required the source pointer to
+    /// be aligned for the struct, which the byte buffer does not guarantee →
+    /// UB. `decode_session_map_key` uses `read_unaligned`; this drives it
+    /// through a deliberately mis-aligned (odd-address) source and asserts the
+    /// fields decode correctly.
+    #[test]
+    fn decode_session_map_key_from_misaligned_buffer() {
+        let key = UserspaceSessionMapKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: 6,
+            pad: 0,
+            src_port: 0x1234,
+            dst_port: 0xabcd,
+            src_addr: [10, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            dst_addr: [10, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        };
+        let size = core::mem::size_of::<UserspaceSessionMapKey>();
+
+        // Native byte view of the reference key.
+        let key_bytes: &[u8] = unsafe {
+            core::slice::from_raw_parts(
+                (&key as *const UserspaceSessionMapKey).cast::<u8>(),
+                size,
+            )
+        };
+
+        // Copy those bytes so that the decode source starts at an ODD address,
+        // guaranteeing misalignment for an alignment-2 struct regardless of the
+        // allocator's base alignment. The old `ptr::read` on this pointer is UB;
+        // `read_unaligned` is sound.
+        let mut buf = vec![0u8; size + 1];
+        let off = if buf.as_ptr() as usize % 2 == 0 { 1 } else { 0 };
+        buf[off..off + size].copy_from_slice(key_bytes);
+        let misaligned = &buf[off..off + size];
+        assert_eq!(
+            misaligned.as_ptr() as usize % 2,
+            1,
+            "decode source must be misaligned for an alignment-2 struct",
+        );
+
+        let decoded = decode_session_map_key(misaligned);
+
+        assert_eq!(decoded.addr_family, key.addr_family);
+        assert_eq!(decoded.protocol, key.protocol);
+        assert_eq!(decoded.src_port, key.src_port);
+        assert_eq!(decoded.dst_port, key.dst_port);
+        assert_eq!(decoded.src_addr, key.src_addr);
+        assert_eq!(decoded.dst_addr, key.dst_addr);
+    }
+}


### PR DESCRIPTION
## Summary
`dump_bpf_session_entries` (`userspace-dp/src/afxdp/bpf_map/metrics.rs`) decoded a `#[repr(C)]` `UserspaceSessionMapKey` out of the `Vec<u8>` key buffer returned by `bpf_map_get_next_key` via `core::ptr::read`. The struct carries `u16` fields (`pad`, `src_port`, `dst_port`) → **alignment 2**, but a `Vec<u8>` only guarantees **alignment 1**. `ptr::read` requires the source pointer to be aligned for the target type; reading through a pointer that does not satisfy that precondition is **undefined behavior** — it faults on architectures that reject misaligned loads (x86 tolerates it, but it is still UB). The path is `cfg!(feature = "debug-log")`-gated (Low severity), but it is genuine UB and inconsistent with the crate's own `read_unaligned` usage in `frame::inspect`.

## Fix
- Extract `decode_session_map_key(&[u8]) -> UserspaceSessionMapKey` that reads with `core::ptr::read_unaligned` (no alignment requirement on the source), matching the crate's existing unaligned-metadata idiom. Route the dump loop through it.
- **Wire/byte layout and decoded values unchanged** — only the read is now alignment-safe.
- Audited the rest of the bpf_map decoder: no other unaligned `ptr::read` / `&*(ptr as *const T)` struct reads. The mmap XDP-ring `*(ptr as *const u32)` reads in `diagnose_raw_ring_state` are a separate, well-defined path (page-aligned mmap base + kernel-provided naturally-aligned ring offsets), left untouched.

## Validation
- New `decode_session_map_key_from_misaligned_buffer` unit test copies a reference key's bytes so the decode source starts at an **ODD address** (guaranteed misaligned for an align-2 struct regardless of allocator base — the old `ptr::read` on this pointer is UB) and asserts every field round-trips.
- Full `TMPDIR=/dev/shm CARGO_TARGET_DIR=/dev/shm/cargo cargo test --release` **green** (dataplane merge gate).
- `cargo build --release --features debug-log` clean (the debug dump path compiles).
- No smoke needed — debug-gated metrics path, zero forwarding change.

Closes #4882

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi