### PR TITLE
devicemap: enumerate non-PCI physical NICs so key-mac entries bind

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43908,3 +43908,7 @@ top.
   **File(s)**: pkg/config/compiler_validate_strict_chassis.go, pkg/config/schema_validate_chassis_test.go
   **Action**: #4866 cmdtree RI/RG completion DynamicFns nil-skip tolerated (#3494) entries via shared helpers
   **File(s)**: pkg/cmdtree/tree.go, pkg/cmdtree/completion_nil_ri_rg_4866_test.go
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4884(C) devicemap enumerates non-PCI physical NICs (USB/platform/SoC) so key mac entries bind; classifyNetdev seam + doc
+  **File(s)**: pkg/devicemap/devicemap.go, pkg/devicemap/devicemap_nonpci_4884_test.go, docs/bare-metal-device-map.md

--- a/docs/bare-metal-device-map.md
+++ b/docs/bare-metal-device-map.md
@@ -104,6 +104,11 @@ immediately on commit.
   fallback — PCI moved, re-pin)`).
 - **No permanent MAC** (common on some VFs/virtio): the entry binds PCI-only
   and `show` marks it `(PCI-only, unverified)`; `key mac` is rejected.
+- **Non-PCI physical NICs** (USB / platform / SoC ethernet) have no PCI
+  address but do carry a factory MAC. They are enumerated (with an empty PCI
+  column) so a `key mac` entry binds them; only purely virtual netdevs
+  (loopback, bridge, veth, bond, vlan, vrf, tun/tap) are excluded from the
+  inventory. Map such a NIC with `key mac` (`pci` is unavailable).
 - **RETH members are PCI-only.** A RETH member's MAC alternates
   physical↔virtual, so its entry must be PCI-keyed (`key mac` is rejected at
   commit). It keeps `.link` `OriginalName=` matching as before.

--- a/pkg/devicemap/devicemap.go
+++ b/pkg/devicemap/devicemap.go
@@ -253,9 +253,35 @@ func ExtractPCIAddr(path string) string {
 	return last
 }
 
+// classifyNetdev decides whether a /sys/class/net entry is a mappable physical
+// NIC and extracts its PCI address (empty for a non-PCI bus). devErr is the
+// error from resolving the entry's `device` symlink and devReal its resolved
+// target when devErr == nil.
+//
+// A physical NIC — PCI, USB, platform, or SoC — exposes a `device` symlink and
+// is KEPT even when it has no PCI address, so a `key mac` device-map entry can
+// still bind it (#4884). Before this, ANY NIC without a PCI address was dropped
+// from the inventory BEFORE its permanent MAC was read, so on a bare-metal /
+// SoC / USB-NIC appliance a valid MAC-only mapping never saw its target and the
+// interface was stranded (marked unbound). A purely virtual netdev — loopback,
+// bridge, veth, bond, vlan, vrf, tun/tap, and the xpf-created VRF/tunnel
+// devices — has no `device` symlink and is dropped: it is not a mappable
+// hardware NIC and would only flood the inventory / `candidates` list.
+func classifyNetdev(name, devReal string, devErr error) (pci string, keep bool) {
+	if name == "lo" {
+		return "", false
+	}
+	if devErr != nil {
+		return "", false // virtual netdev — no backing hardware device
+	}
+	return ExtractPCIAddr(devReal), true
+}
+
 // EnumeratePresentNICs builds the present-NIC inventory from sysfs + netlink:
-// current kernel name, PCI address, permanent (factory) MAC, running MAC, and
-// link state. Sorted by PCI address for stable output.
+// current kernel name, PCI address (empty for non-PCI buses), permanent
+// (factory) MAC, running MAC, and link state. Sorted by PCI address, then
+// kernel name, for stable output (non-PCI NICs share an empty PCI address, so
+// the name tiebreak keeps their order deterministic).
 func EnumeratePresentNICs() ([]PresentNIC, error) {
 	entries, err := os.ReadDir("/sys/class/net")
 	if err != nil {
@@ -264,15 +290,9 @@ func EnumeratePresentNICs() ([]PresentNIC, error) {
 	var nics []PresentNIC
 	for _, e := range entries {
 		name := e.Name()
-		if name == "lo" {
-			continue
-		}
-		devReal, err := filepath.EvalSymlinks(filepath.Join("/sys/class/net", name, "device"))
-		if err != nil {
-			continue // not a PCI device
-		}
-		pci := ExtractPCIAddr(devReal)
-		if pci == "" {
+		devReal, derr := filepath.EvalSymlinks(filepath.Join("/sys/class/net", name, "device"))
+		pci, keep := classifyNetdev(name, devReal, derr)
+		if !keep {
 			continue
 		}
 		nic := PresentNIC{Name: name, PCIAddr: pci}
@@ -286,6 +306,11 @@ func EnumeratePresentNICs() ([]PresentNIC, error) {
 		}
 		nics = append(nics, nic)
 	}
-	sort.Slice(nics, func(i, j int) bool { return nics[i].PCIAddr < nics[j].PCIAddr })
+	sort.Slice(nics, func(i, j int) bool {
+		if nics[i].PCIAddr != nics[j].PCIAddr {
+			return nics[i].PCIAddr < nics[j].PCIAddr
+		}
+		return nics[i].Name < nics[j].Name
+	})
 	return nics, nil
 }

--- a/pkg/devicemap/devicemap_nonpci_4884_test.go
+++ b/pkg/devicemap/devicemap_nonpci_4884_test.go
@@ -1,0 +1,97 @@
+package devicemap
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #4884 (C175-HC-088): EnumeratePresentNICs dropped every NIC without a PCI
+// address BEFORE its permanent MAC was read, so a non-PCI physical NIC
+// (USB / platform / SoC) mapped by `key mac` never entered the inventory and a
+// valid MAC-only device-map entry resolved UNBOUND — stranding the interface on
+// bare-metal / SoC / USB-NIC appliances. The drop decision now lives in the
+// pure classifyNetdev seam; these tests pin it and the downstream bind.
+
+func TestClassifyNetdev(t *testing.T) {
+	tests := []struct {
+		name     string
+		nic      string
+		devReal  string
+		devErr   error
+		wantPCI  string
+		wantKeep bool
+	}{
+		{
+			name:     "loopback dropped",
+			nic:      "lo",
+			wantKeep: false,
+		},
+		{
+			name:     "virtual netdev (no device symlink) dropped",
+			nic:      "br0",
+			devErr:   errors.New("no such file or directory"),
+			wantKeep: false,
+		},
+		{
+			name:     "pci nic kept with address",
+			nic:      "enp8s0",
+			devReal:  "/sys/devices/pci0000:00/0000:00:1c.4/0000:08:00.0",
+			wantPCI:  "0000:08:00.0",
+			wantKeep: true,
+		},
+		{
+			// #4884: the regression case — a USB NIC has a `device` symlink
+			// (physical) but no PCI address. It MUST be kept so a `key mac`
+			// entry can bind it.
+			name:     "usb nic kept with empty pci",
+			nic:      "enx001122334455",
+			devReal:  "/sys/devices/platform/soc/1c1b000.usb/usb1/1-1/1-1:1.0",
+			wantPCI:  "",
+			wantKeep: true,
+		},
+		{
+			// #4884: SoC/platform ethernet MAC — physical, non-PCI.
+			name:     "platform soc nic kept with empty pci",
+			nic:      "eth0",
+			devReal:  "/sys/devices/platform/soc@0/30be0000.ethernet",
+			wantPCI:  "",
+			wantKeep: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pci, keep := classifyNetdev(tc.nic, tc.devReal, tc.devErr)
+			if keep != tc.wantKeep {
+				t.Fatalf("classifyNetdev(%q) keep = %v, want %v", tc.nic, keep, tc.wantKeep)
+			}
+			if keep && pci != tc.wantPCI {
+				t.Fatalf("classifyNetdev(%q) pci = %q, want %q", tc.nic, pci, tc.wantPCI)
+			}
+		})
+	}
+}
+
+// TestResolveBindsNonPCIMACOnlyNIC pins the end-to-end benefit: once a non-PCI
+// physical NIC (PCIAddr == "" with a factory MAC) is enumerated — which
+// classifyNetdev now permits — a `key mac` device-map entry binds it instead of
+// stranding it UNBOUND (#4884).
+func TestResolveBindsNonPCIMACOnlyNIC(t *testing.T) {
+	// A USB/SoC NIC as EnumeratePresentNICs now yields it: no PCI address, a
+	// factory permanent MAC.
+	nics := []PresentNIC{{Name: "enx00aabbccddee", PCIAddr: "", PermMAC: "00:aa:bb:cc:dd:ee"}}
+	entries := []config.DeviceMapEntry{
+		{LogicalName: "ge-0/0/0", MAC: "00:aa:bb:cc:dd:ee"},
+	}
+	got := Resolve(entries, nics, nil)
+	if len(got) != 1 {
+		t.Fatalf("want 1 binding, got %d", len(got))
+	}
+	if !got[0].Status.Bound() {
+		t.Fatalf("non-PCI MAC-only NIC must bind, got status %v", got[0].Status)
+	}
+	if got[0].CurrentNIC != "enx00aabbccddee" {
+		t.Fatalf("bound wrong NIC: %+v", got[0])
+	}
+}


### PR DESCRIPTION
## Summary
`EnumeratePresentNICs` dropped every `/sys/class/net` entry without a PCI address BEFORE reading its permanent MAC — an EvalSymlinks error on the `device` symlink OR an empty `ExtractPCIAddr` both `continue`d the loop. A non-PCI **physical** NIC (USB / platform / SoC ethernet) has a `device` symlink but no PCI bus address, so it was excluded from the present-NIC inventory. `Resolve` matches a `key mac` entry against `byPermMAC` built from that inventory, so a MAC-only device-map entry never saw its target and resolved **UNBOUND** — stranding management/data interfaces on bare-metal / SoC / USB-NIC appliances despite a valid committed MAC mapping (Codex C175-HC-088).

## Fix
Extract the drop decision into a pure `classifyNetdev` seam (matching the package's unit-testable-core discipline). A NIC is **kept** when it has a `device` symlink (physical: PCI, USB, platform, SoC), carrying an empty PCI address for the non-PCI buses so the MAC leg can still bind it; only a purely **virtual** netdev (no `device` symlink: loopback, bridge, veth, bond, vlan, vrf, tun/tap, xpf-created VRF/tunnel devices) is dropped. The sort gains a kernel-name tiebreak so the non-PCI NICs (which share an empty PCI key) stay deterministic. Resolver, daemon rename, and `show chassis device-map candidates` consume the now-complete inventory unchanged; PCI NICs behave exactly as before.

## Tests
- `TestClassifyNetdev` pins the drop decision (loopback + virtual dropped; PCI kept with address; USB + platform/SoC kept with empty PCI).
- `TestResolveBindsNonPCIMACOnlyNIC` pins the end-to-end benefit — a `key mac` entry now binds a non-PCI factory-MAC NIC instead of going UNBOUND.

RED-on-revert verified (reintroducing the non-PCI drop fails the USB/platform cases). `go build ./...` clean; `go test ./pkg/devicemap/... ./pkg/daemon/...` green; gofmt clean. Operator doc updated.

## Scope note (cohort)
This closes **sub-defect C** of the #4884 cohort (device-map enumeration). The other two are broader reworks and remain for **follow-up**:
- **A** — session interface filter treats every ingress as the zone's first interface (`pkg/cli/session_filter.go`, `pkg/cli/cli_clear.go`): needs ingress-interface identity carried on sessions + all-interfaces-per-zone population.
- **B** — `show interfaces` mixes authored/logical/kernel names (`pkg/cli/cli_show_interfaces*.go`): needs a consistent authored↔logical↔kernel name-resolution model across the show/filter surfaces.

Closes #4884