### PR TITLE
config: gate firewall tcp-flags + CoS numeric code-point rejects leniently (#4953)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43906,3 +43906,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4866 cmdtree RI/RG completion DynamicFns nil-skip tolerated (#3494) entries via shared helpers
   **File(s)**: pkg/cmdtree/tree.go, pkg/cmdtree/completion_nil_ri_rg_4866_test.go
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4953 route firewall tcp-flags (#3076) + CoS numeric DSCP/PCP code-point (#2447) rejects through the strict/tolerant policy — moved to validateFirewallTCPFlagsStrict + lenientCoSNumericCodePoint-gated call sites so CompileConfigLenient/ForNodeLenient warn (boot) instead of failing closed on an already-persisted config (#1960)
+  **File(s)**: pkg/config/compiler.go, pkg/config/compiler_dispatch.go, pkg/config/compiler_firewall.go, pkg/config/compiler_class_of_service.go, pkg/config/compiler_validate_strict_filter.go, pkg/config/compiler_uniformgates.go, pkg/config/lenient_fw_cos_4953_test.go, pkg/config/README.md

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -61,15 +61,32 @@ Regression coverage: `pkg/config/parser_recursion_dos_hb164_test.go`,
   compilation (zones, policies, NAT IDs, etc.) happens later in
   `pkg/dataplane.Manager.Compile`.
   This stage also performs a few **fail-closed semantic checks** that the
-  `setSchema` typed-leaf gate cannot express. `compileFirewall` rejects a
-  firewall-filter `from tcp-flags` expression the conjunctive dataplane
-  matcher cannot enforce — disjunction (`|`), a negated group (`!(...)`),
-  an unknown flag, or a contradictory required/forbidden pair (#3076) —
-  via `ParseTCPFlagsExpression` (`tcp_flags.go`). Before this gate such an
+  `setSchema` typed-leaf gate cannot express. The firewall-filter
+  `from tcp-flags` enforceability check rejects an expression the
+  conjunctive dataplane matcher cannot represent — disjunction (`|`), a
+  negated group (`!(...)`), an unknown flag, a dangling negation, or a
+  contradictory required/forbidden pair (#3076/#4714) — via
+  `ParseTCPFlagsExpression` (`tcp_flags.go`). Before this gate such an
   expression committed cleanly and the constraint was silently dropped on
   the wire (the term matched regardless of flags — a fail-open hole); a
   representable expression such as `syn & !ack` is parsed into
   required-bits + forbidden-bits masks and carried to the dataplane.
+  **#4953:** this reject (and the class-of-service numeric DSCP/PCP
+  code-point range reject #2447) moved OUT of the section compilers
+  (`compileFirewall` / `compileClassOfService`, which the P4 dispatch
+  calls with no `compileOpts` so they cannot be mode-gated) and became
+  strict/tolerant gates: `validateFirewallTCPFlagsStrict`
+  (`compiler_validate_strict_filter.go`, run in `runUniformGates`) and the
+  `lenientCoSNumericCodePoint`-gated call sites in `compileClassOfService`.
+  Commit / commit-check stay strict; the tolerant `Store.Load` /
+  `Store.SyncApply` path (`lenientFirewallTCPFlags` /
+  `lenientCoSNumericCodePoint`) downgrades to a warning so a config an
+  older binary persisted — or a peer authored — before the reject existed
+  cannot blackout-boot a node or alarm-loop HA config sync (#1960
+  no-brick). The leniently-loaded tcp-flags term keeps its raw value,
+  which the userspace snapshot builder marks `TCPFlagsUnparseable` to fail
+  the term CLOSED (#3367) — a deny sentinel, never a match-all widening;
+  the out-of-range code-point entry is dropped (the pre-#2447 fail-safe).
 - `ValueType` — `value_type.go`. Classifies a typed leaf's value
   (`ValueRate`, `ValueByteSizeOrPercent`, `ValueEnumOf`, ...) and supplies
   the `?`-completion placeholder via `Placeholder()`. Lives here (not

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1572,6 +1572,41 @@ type compileOpts struct {
 	// lenientEventAttributesMatch (its attributes-match sibling).
 	lenientEventWithinTrigger bool
 
+	// lenientFirewallTCPFlags (#4953) downgrades the firewall-filter
+	// `from tcp-flags` enforceability reject (validateFirewallTCPFlagsStrict:
+	// disjunction, negated group, unknown flag, dangling negation, or a
+	// required/forbidden contradiction) from a hard compile error to a
+	// cfg.Warnings entry. Before #3076 such an expression committed cleanly and
+	// the constraint was silently dropped on the wire (fail-OPEN); #3076 added
+	// an inline reject in compileFirewall, but the P4 section dispatch calls
+	// compileFirewall with NO compileOpts, so the reject could not be
+	// mode-gated — an upgraded node whose already-persisted config carried the
+	// expression blacked out on load (CompileConfigLenient returned the error →
+	// ActiveConfig()==nil) and a standby's SyncApply alarm-looped. Set ONLY on
+	// the tolerant load / peer-sync paths so an already-accepted config still
+	// BOOTS; commit / commit-check stay strict. The leniently-loaded term keeps
+	// its raw TCPFlags, which the userspace snapshot builder marks
+	// TCPFlagsUnparseable to fail the term CLOSED (#3367) — a fail-closed deny
+	// sentinel, never a match-all widening. Same doctrine as lenientFilterDSCP.
+	lenientFirewallTCPFlags bool
+
+	// lenientCoSNumericCodePoint (#4953) downgrades the class-of-service
+	// numeric DSCP/PCP code-point range reject (a `code-point`/`code-points`
+	// token that is an integer outside the 6-bit DSCP domain 0..63 or the
+	// 3-bit PCP domain 0..7, on either a classifier or a rewrite-rule) from a
+	// hard compile error to a cfg.Warnings entry. Before #2447 such a token was
+	// silently dropped at the Go layer and the dataplane masked it (dscp&0x3f /
+	// pcp.min(7)) onto a DIFFERENT traffic class; #2447 made it a hard commit
+	// reject, but the reject lives inside compileClassOfService (which the P4
+	// dispatch calls with no compileOpts), so it could not be mode-gated — an
+	// upgraded node whose already-persisted config carried the value blacked
+	// out on load and a standby's SyncApply alarm-looped. Set ONLY on the
+	// tolerant load / peer-sync paths so an already-accepted config still
+	// BOOTS; on that boot the offending entry is dropped, exactly the pre-#2447
+	// fail-safe. Commit / commit-check stay strict. Same doctrine as
+	// lenientFirewallTCPFlags.
+	lenientCoSNumericCodePoint bool
+
 	// nodeAware / stampNodeID (#4329) carry the runtime cluster node
 	// identity (from /etc/xpf/node-id, or `-node-id` on `xpfd
 	// check-config`) into compileExpanded so it can be stamped onto the
@@ -1703,6 +1738,8 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientVRRPVirtualAddress:              true,
 		lenientDNATToScope:                     true,
 		lenientEventWithinTrigger:              true,
+		lenientFirewallTCPFlags:                true,
+		lenientCoSNumericCodePoint:             true,
 	})
 }
 
@@ -1954,6 +1991,8 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientVRRPVirtualAddress:              true,
 		lenientDNATToScope:                     true,
 		lenientEventWithinTrigger:              true,
+		lenientFirewallTCPFlags:                true,
+		lenientCoSNumericCodePoint:             true,
 	})
 }
 

--- a/pkg/config/compiler_class_of_service.go
+++ b/pkg/config/compiler_class_of_service.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -9,7 +10,38 @@ import (
 	fairnesscontract "github.com/psaab/xpf/pkg/fairness"
 )
 
-func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
+// numericCodePointRangeError marks a numeric DSCP/PCP code-point token that
+// fell outside its valid domain (DSCP 0..63, PCP 0..7). It is a distinct error
+// type so the tolerant load / peer-sync path (opts.lenientCoSNumericCodePoint)
+// can downgrade JUST this class of finding to a warning while every other
+// class-of-service compile error stays a hard reject.
+//
+// #2447 made an out-of-range numeric code-point a hard commit reject (before
+// that it was silently dropped at the Go layer and the dataplane masked it —
+// dscp&0x3f / pcp.min(7) — onto a DIFFERENT traffic class). #4953 keeps that
+// reject STRICT at commit / commit-check but LENIENT on load / peer-sync so a
+// config an older binary persisted (or a peer authored) still BOOTS (#1960
+// no-brick): the leniently-loaded entry is dropped, exactly the pre-#2447
+// fail-safe, and the operator's next strict commit rejects it loudly.
+type numericCodePointRangeError struct{ msg string }
+
+func (e *numericCodePointRangeError) Error() string { return e.msg }
+
+// newCodePointRangeError builds a numericCodePointRangeError with a formatted,
+// operator-facing message (the message text is unchanged from the #2447 gate;
+// only the concrete error type is now distinguishable via errors.As).
+func newCodePointRangeError(format string, args ...any) error {
+	return &numericCodePointRangeError{msg: fmt.Sprintf(format, args...)}
+}
+
+// isNumericCodePointRangeError reports whether err (or anything it wraps) is a
+// numericCodePointRangeError — the tolerant-path downgrade predicate.
+func isNumericCodePointRangeError(err error) bool {
+	var e *numericCodePointRangeError
+	return errors.As(err, &e)
+}
+
+func compileClassOfService(node *Node, cos *ClassOfServiceConfig, opts compileOpts, warnings *[]string) error {
 	if cos == nil {
 		return nil
 	}
@@ -147,6 +179,14 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 					}
 					codePoints, err := collectCoSDSCPCodePoints(lpNode)
 					if err != nil {
+						if opts.lenientCoSNumericCodePoint && isNumericCodePointRangeError(err) {
+							if warnings != nil {
+								*warnings = append(*warnings, fmt.Sprintf(
+									"class-of-service classifiers dscp %q (downgraded to warning on tolerant path): %v",
+									classifier.Name, err))
+							}
+							continue
+						}
 						return fmt.Errorf("class-of-service classifiers dscp %q: %w", classifier.Name, err)
 					}
 					if len(codePoints) == 0 {
@@ -183,6 +223,14 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 					}
 					codePoints, err := collectCoS8021CodePoints(lpNode)
 					if err != nil {
+						if opts.lenientCoSNumericCodePoint && isNumericCodePointRangeError(err) {
+							if warnings != nil {
+								*warnings = append(*warnings, fmt.Sprintf(
+									"class-of-service classifiers ieee-802.1 %q (downgraded to warning on tolerant path): %v",
+									classifier.Name, err))
+							}
+							continue
+						}
 						return fmt.Errorf("class-of-service classifiers ieee-802.1 %q: %w", classifier.Name, err)
 					}
 					if len(codePoints) == 0 {
@@ -235,6 +283,14 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 					}
 					codePoint, ok, err := collectCoSDSCPRewriteCodePoint(lpNode)
 					if err != nil {
+						if opts.lenientCoSNumericCodePoint && isNumericCodePointRangeError(err) {
+							if warnings != nil {
+								*warnings = append(*warnings, fmt.Sprintf(
+									"class-of-service rewrite-rules dscp %q (downgraded to warning on tolerant path): %v",
+									rewriteRule.Name, err))
+							}
+							continue
+						}
 						return fmt.Errorf("class-of-service rewrite-rules dscp %q: %w", rewriteRule.Name, err)
 					}
 					if !ok {
@@ -275,6 +331,14 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 					}
 					codePoint, ok, err := collectCoS8021RewriteCodePoint(lpNode)
 					if err != nil {
+						if opts.lenientCoSNumericCodePoint && isNumericCodePointRangeError(err) {
+							if warnings != nil {
+								*warnings = append(*warnings, fmt.Sprintf(
+									"class-of-service rewrite-rules ieee-802.1 %q (downgraded to warning on tolerant path): %v",
+									rewriteRule.Name, err))
+							}
+							continue
+						}
 						return fmt.Errorf("class-of-service rewrite-rules ieee-802.1 %q: %w", rewriteRule.Name, err)
 					}
 					if !ok {
@@ -1031,7 +1095,7 @@ func collectCoS8021CodePoints(node *Node) ([]uint8, error) {
 			return nil
 		}
 		if v < 0 || v > 7 {
-			return fmt.Errorf(
+			return newCodePointRangeError(
 				"class-of-service ieee-802.1 classifier code-point %d is out of range (must be 0..7)",
 				v)
 		}
@@ -1115,7 +1179,7 @@ func collectCoS8021RewriteCodePoint(node *Node) (uint8, bool, error) {
 			return 0, false, nil
 		}
 		if v < 0 || v > 7 {
-			return 0, false, fmt.Errorf(
+			return 0, false, newCodePointRangeError(
 				"class-of-service ieee-802.1 rewrite-rule code-point %d is out of range (must be 0..7)",
 				v)
 		}
@@ -1169,7 +1233,7 @@ func expandCoSCodePointToken(raw string) ([]uint8, error) {
 	}
 	if v, err := strconv.Atoi(raw); err == nil {
 		if v < 0 || v > 63 {
-			return nil, fmt.Errorf(
+			return nil, newCodePointRangeError(
 				"class-of-service dscp code-point %d is out of range (must be 0..63)",
 				v)
 		}

--- a/pkg/config/compiler_dispatch.go
+++ b/pkg/config/compiler_dispatch.go
@@ -60,7 +60,7 @@ func compileSections(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 				return fmt.Errorf("firewall: %w", err)
 			}
 		case "class-of-service":
-			if err := compileClassOfService(node, cfg.ClassOfService); err != nil {
+			if err := compileClassOfService(node, cfg.ClassOfService, opts, &cfg.Warnings); err != nil {
 				return fmt.Errorf("class-of-service: %w", err)
 			}
 		case "services":

--- a/pkg/config/compiler_firewall.go
+++ b/pkg/config/compiler_firewall.go
@@ -265,19 +265,21 @@ func compileFirewall(node *Node, fw *FirewallConfig) error {
 						compileFilterThen(thenNode, term)
 					}
 
-					// #3076: reject a tcp-flags expression the dataplane cannot
-					// enforce (disjunction, a negated group, an unknown flag, or
-					// a self-contradictory required/forbidden pair) at commit.
-					// Without this gate such an expression committed cleanly and
-					// the constraint was silently dropped on the wire — the term
-					// matched regardless of flags (fail-open). Rejecting here is
-					// fail-closed: a dropped security constraint never silently
-					// passes.
-					if len(term.TCPFlags) > 0 {
-						if _, _, _, err := ParseTCPFlagsExpression(term.TCPFlags); err != nil {
-							return fmt.Errorf("firewall filter %q term %q: %w", filter.Name, term.Name, err)
-						}
-					}
+					// #3076: a tcp-flags expression the dataplane cannot enforce
+					// (disjunction, a negated group, an unknown flag, or a
+					// self-contradictory required/forbidden pair) is rejected —
+					// without a reject such an expression committed cleanly and
+					// the constraint was silently dropped on the wire (fail-open).
+					// #4953: the reject moved OUT of the section compiler and into
+					// the strict/tolerant gate validateFirewallTCPFlagsStrict
+					// (runUniformGates) so the commit / commit-check path still
+					// hard-rejects but the load / peer-sync path downgrades to a
+					// warning — an already-persisted or peer-synced config an
+					// older binary accepted still BOOTS (#1960 no-brick). The term
+					// keeps its raw (unparseable) TCPFlags, which the userspace
+					// snapshot builder detects and marks TCPFlagsUnparseable so the
+					// Rust filter compiler fails the term CLOSED (#3367) — the raw
+					// value IS the deny sentinel, never widening to match-all.
 
 					filter.Terms = append(filter.Terms, term)
 				}

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -1317,6 +1317,29 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 		}
 	}
 
+	// #3076 / #4953: firewall-filter `from tcp-flags` enforceability gate.
+	// An expression the conjunctive dataplane matcher cannot represent
+	// (disjunction, negated group, unknown flag, dangling negation, or a
+	// required/forbidden contradiction) compiled cleanly before #3076 and the
+	// constraint was silently dropped on the wire (fail-open — the term
+	// matched every TCP segment). Strict on commit / commit-check (hard reject
+	// so the operator error is visible); lenient on load / peer-sync (warn so a
+	// config an older binary persisted, or a peer authored, before the reject
+	// existed still boots — #1960 no-brick). On the leniently-loaded boot the
+	// term keeps its raw TCPFlags and the userspace snapshot builder marks it
+	// TCPFlagsUnparseable, failing the term CLOSED (#3367) rather than widening
+	// it. This reject previously lived inline in compileFirewall, which the P4
+	// dispatch calls with no compileOpts — so it could not be mode-gated and an
+	// upgraded / peer-synced node blacked out or alarm-looped HA sync.
+	if err := validateFirewallTCPFlagsStrict(cfg); err != nil {
+		if opts.lenientFirewallTCPFlags {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("firewall filter tcp-flags (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #2506: firewall-filter `from source-prefix-list <name>` /
 	// `destination-prefix-list <name>` cross-reference. A term naming a
 	// prefix-list not defined under `policy-options prefix-list` compiled

--- a/pkg/config/compiler_validate_strict_filter.go
+++ b/pkg/config/compiler_validate_strict_filter.go
@@ -78,6 +78,63 @@ func validateFirewallPolicerReferencesStrict(cfg *Config) error {
 	return check("inet6", cfg.Firewall.FiltersInet6)
 }
 
+// validateFirewallTCPFlagsStrict hard-rejects a firewall-filter term whose
+// `from tcp-flags <expr>` the conjunctive dataplane matcher cannot enforce —
+// a disjunction (`ack | rst`), a negated parenthesized group (a disjunction by
+// De Morgan), an unknown flag token, a dangling negation, or a
+// self-contradictory required/forbidden pair (#3076 / #4714). Without a reject
+// such an expression committed cleanly and the constraint was silently dropped
+// on the wire — the term matched regardless of flags (fail-OPEN, a dropped
+// security constraint).
+//
+// #4953: this gate is the strict/tolerant home of the #3076 reject that used
+// to live inline in compileFirewall (where it could not be mode-gated — the
+// section compiler receives no compileOpts). The commit / commit-check path
+// hard-rejects; the tolerant load / peer-sync path downgrades to a warning
+// (opts.lenientFirewallTCPFlags) so a config an older binary persisted — or a
+// peer authored — before this reject existed still BOOTS (#1960 no-brick).
+// The leniently-loaded term keeps its raw (unparseable) TCPFlags, which the
+// userspace snapshot builder detects (ParseTCPFlagsExpression errors) and marks
+// TCPFlagsUnparseable so the Rust filter compiler fails the term CLOSED
+// (#3367) — a fail-closed deny sentinel, NEVER a fail-open widening.
+//
+// Both families (inet + inet6) are walked, sorted by filter name then by term
+// position, so the first-reported error is deterministic (Go map order is
+// randomized). Mirrors validateFirewallPolicerReferencesStrict.
+func validateFirewallTCPFlagsStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	check := func(family string, filters map[string]*FirewallFilter) error {
+		names := make([]string, 0, len(filters))
+		for name := range filters {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			filter := filters[name]
+			if filter == nil {
+				continue
+			}
+			for _, term := range filter.Terms {
+				if term == nil || len(term.TCPFlags) == 0 {
+					continue
+				}
+				if _, _, _, err := ParseTCPFlagsExpression(term.TCPFlags); err != nil {
+					return fmt.Errorf(
+						"firewall family %s filter %q term %q: %w",
+						family, name, term.Name, err)
+				}
+			}
+		}
+		return nil
+	}
+	if err := check("inet", cfg.Firewall.FiltersInet); err != nil {
+		return err
+	}
+	return check("inet6", cfg.Firewall.FiltersInet6)
+}
+
 // validateFirewallPrefixListReferencesStrict hard-rejects a firewall-filter
 // term whose `from source-prefix-list <name>` / `destination-prefix-list
 // <name>` (with or without `except`) names a prefix-list not defined under

--- a/pkg/config/lenient_fw_cos_4953_test.go
+++ b/pkg/config/lenient_fw_cos_4953_test.go
@@ -1,0 +1,155 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// buildTree4953 assembles a ConfigTree from flat `set` commands using the
+// ParseSetCommand + SetPath loop (the parser merges newline-separated lines,
+// so the flat-set path is the only correct way to build a multi-line tree).
+func buildTree4953(t *testing.T, lines []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	return tree
+}
+
+// TestFirewallTCPFlagsStrictVsLenient_4953 proves the #4953 fix for the
+// firewall `from tcp-flags` reject: an unrepresentable expression (a
+// disjunction) is REJECTED on the strict commit path (CompileConfig) but
+// DOWNGRADED to a warning (config still loads) on the tolerant load / peer-sync
+// path (CompileConfigLenient / CompileConfigForNodeLenient).
+//
+// Fail-on-revert: re-inline the #3076 reject in compileFirewall (or drop the
+// lenientFirewallTCPFlags gating) and the lenient legs go RED — the already-
+// persisted config fails to load (boot blackout / HA sync loop), the exact
+// regression this fix closes.
+func TestFirewallTCPFlagsStrictVsLenient_4953(t *testing.T) {
+	lines := []string{
+		"set firewall family inet filter f term t from protocol tcp",
+		"set firewall family inet filter f term t from tcp-flags \"ack | rst\"",
+		"set firewall family inet filter f term t then discard",
+		"set system dataplane-type userspace",
+	}
+	tree := buildTree4953(t, lines)
+
+	// Strict commit: hard reject.
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("strict CompileConfig must reject an unrepresentable tcp-flags disjunction")
+	} else if !strings.Contains(err.Error(), "tcp-flags") {
+		t.Fatalf("strict error must name tcp-flags, got: %v", err)
+	}
+
+	// Tolerant load: must LOAD (no error) and warn.
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must not fail on a persisted bad tcp-flags config (boot blackout): %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("CompileConfigLenient returned nil config for a bad tcp-flags config")
+	}
+	if !warningsContain(cfg.Warnings, "tcp-flags") {
+		t.Fatalf("CompileConfigLenient must record a tcp-flags downgrade warning, got: %v", cfg.Warnings)
+	}
+	// The term is kept with its raw TCPFlags so the dataplane fails it closed.
+	if got := lookupTermTCPFlags(cfg, "f", "t"); len(got) == 0 {
+		t.Fatal("leniently-loaded term must retain its raw TCPFlags (deny sentinel), got none")
+	}
+
+	// Node-aware tolerant path (HA SyncApply) must also load.
+	if _, err := CompileConfigForNodeLenient(tree, 0); err != nil {
+		t.Fatalf("CompileConfigForNodeLenient must not fail on a persisted bad tcp-flags config: %v", err)
+	}
+}
+
+// TestCoSNumericCodePointStrictVsLenient_4953 proves the #4953 fix for the
+// class-of-service numeric DSCP/PCP code-point range reject: an out-of-range
+// value is REJECTED on the strict commit path but DOWNGRADED to a warning
+// (config still loads, offending entry dropped) on the tolerant path.
+//
+// Fail-on-revert: drop the lenientCoSNumericCodePoint gating (or restore the
+// unconditional return) and the lenient legs go RED.
+func TestCoSNumericCodePointStrictVsLenient_4953(t *testing.T) {
+	cases := []struct {
+		name  string
+		line  string
+		value string
+	}{
+		{
+			name:  "dscp-classifier",
+			line:  "set class-of-service classifiers dscp c forwarding-class best-effort loss-priority low code-points 110",
+			value: "110",
+		},
+		{
+			name:  "pcp-classifier",
+			line:  "set class-of-service classifiers ieee-802.1 c forwarding-class best-effort loss-priority low code-points 9",
+			value: "9",
+		},
+		{
+			name:  "dscp-rewrite",
+			line:  "set class-of-service rewrite-rules dscp r forwarding-class best-effort loss-priority low code-point 200",
+			value: "200",
+		},
+		{
+			name:  "pcp-rewrite",
+			line:  "set class-of-service rewrite-rules ieee-802.1 r forwarding-class best-effort loss-priority low code-point 9",
+			value: "9",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lines := []string{
+				"set class-of-service forwarding-classes queue 0 best-effort",
+				tc.line,
+				"set system dataplane-type userspace",
+			}
+			tree := buildTree4953(t, lines)
+
+			// Strict commit: hard reject naming the value + range.
+			if _, err := CompileConfig(tree); err == nil {
+				t.Fatalf("strict CompileConfig must reject out-of-range code-point %s", tc.value)
+			} else if !strings.Contains(err.Error(), tc.value) {
+				t.Fatalf("strict error must name the value %s, got: %v", tc.value, err)
+			}
+
+			// Tolerant load: must LOAD and warn.
+			cfg, err := CompileConfigLenient(tree)
+			if err != nil {
+				t.Fatalf("CompileConfigLenient must not fail on a persisted out-of-range code-point (boot blackout): %v", err)
+			}
+			if cfg == nil {
+				t.Fatal("CompileConfigLenient returned nil config")
+			}
+			if !warningsContain(cfg.Warnings, "class-of-service") {
+				t.Fatalf("CompileConfigLenient must record a class-of-service downgrade warning, got: %v", cfg.Warnings)
+			}
+
+			// Node-aware tolerant path must also load.
+			if _, err := CompileConfigForNodeLenient(tree, 0); err != nil {
+				t.Fatalf("CompileConfigForNodeLenient must not fail on a persisted out-of-range code-point: %v", err)
+			}
+		})
+	}
+}
+
+func lookupTermTCPFlags(cfg *Config, filter, term string) []string {
+	f := cfg.Firewall.FiltersInet[filter]
+	if f == nil {
+		return nil
+	}
+	for _, tm := range f.Terms {
+		if tm != nil && tm.Name == term {
+			return tm.TCPFlags
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Problem

The P4 firewall `from tcp-flags` reject (#3076) and the class-of-service numeric DSCP/PCP code-point range reject (#2447) lived inside the section compilers `compileFirewall` / `compileClassOfService`. The P4 dispatch (`compileSections`) calls those with **no** `compileOpts`, so the rejects could not be mode-gated — `CompileConfigLenient` / `CompileConfigForNodeLenient` returned the section error before the P6/P7 lenient downgrades ran.

An already-persisted config that an older binary committed (before either reject existed) then:
- failed `Store.Load` on an upgraded binary → operational blackout (`ActiveConfig()==nil`), or
- failed a standby's `Store.SyncApply` → HA config-sync alarm loop.

This is the exact fail-closed-on-load class the #1960 doctrine + the existing `lenient*` flags address; these two gates were missed.

## Fix

- **tcp-flags:** removed the inline reject from `compileFirewall`; added `validateFirewallTCPFlagsStrict` (`compiler_validate_strict_filter.go`), called in `runUniformGates` gated by `lenientFirewallTCPFlags`. Tolerant path warns and keeps the term with its raw `TCPFlags` — the userspace snapshot builder marks it `TCPFlagsUnparseable` (#3367) so the Rust filter compiler fails the term **closed**. The raw value is the deny sentinel; never widens to match-all.
- **numeric DSCP/PCP:** out-of-range code-point errors get a distinct type (`numericCodePointRangeError`); `compileClassOfService` takes `compileOpts` + a warnings sink and downgrades at the four collector call sites on `lenientCoSNumericCodePoint` (drops the offending entry — the pre-#2447 fail-safe). Every other CoS compile error stays a hard reject.

Both flags set on `CompileConfigLenient` + `CompileConfigForNodeLenient` only; commit / commit-check stay strict. Scope is tcp-flags + numeric DSCP/PCP; **no NAT behavior touched** (the finding's deterministic-NAT sub-claim is unproven and excluded).

## Test

`lenient_fw_cos_4953_test.go` — each offending config is rejected on strict `CompileConfig` and loads with a downgrade warning on both lenient paths (verified RED without the gating). `pkg/config` + `pkg/configstore` suites pass; `go build ./...` clean.

Closes #4953

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi