### PR TITLE
networkd: retry a failed networkctl reload on the next identical Apply (#4954)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43939,3 +43939,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4884(C) devicemap enumerates non-PCI physical NICs (USB/platform/SoC) so key mac entries bind; classifyNetdev seam + doc
   **File(s)**: pkg/devicemap/devicemap.go, pkg/devicemap/devicemap_nonpci_4884_test.go, docs/bare-metal-device-map.md
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4954 give networkd Manager reload/reconfigure activation debt — a failed networkctl reload now re-attempts on the next identical Apply (reloadPending/reconfigurePending) instead of returning a false success when files are unchanged
+  **File(s)**: pkg/networkd/networkd.go, pkg/networkd/reload_debt_4954_test.go, pkg/networkd/README.md

--- a/pkg/networkd/README.md
+++ b/pkg/networkd/README.md
@@ -44,9 +44,9 @@ Standard library only.
 
 ## Gotchas
 
-- `Apply()` only calls `networkctl reload` when files actually changed.
-  This matters: a reload bounces interfaces, and an idempotent reapply
-  must be cheap.
+- `Apply()` calls `networkctl reload` when files actually changed **or**
+  a prior activation is still owed (see reload-debt below). This matters:
+  a reload bounces interfaces, and an idempotent reapply must be cheap.
 - Interfaces not in the typed config get `ActivationPolicy=always-down`
   in their `.network` file, so they stay down across reboots.
 - **DHCP is gated per-family (#2986).** A static address is suppressed
@@ -68,6 +68,21 @@ Standard library only.
   reconcile steps (RETH MAC, VRRP VIPs, FRR, RA, IPsec). A swallowed
   write (read-only `/etc`, full disk, EACCES, blocked path) used to report
   a clean commit against stale kernel state — a fail-open hole.
+- **A failed reload/reconfigure owes activation debt (#4954).** The
+  generated files are written to disk BEFORE `networkctl reload` runs, so
+  a reload that fails leaves the kernel running the pre-failure config
+  while the files on disk already match the desired state. Without state,
+  an identical re-commit sees `writeIfChanged → (false, nil)` for every
+  file (`changed==false`), skips the reload, and returns nil — a FALSE
+  success masking a route leak / stranded NIC / management lockout. The
+  `Manager` now carries `reloadPending` / `reconfigurePending` debt: a
+  failed reload sets `reloadPending` and re-runs the idempotent reload on
+  the next `Apply` even with unchanged files, clearing the debt only on
+  success (and still returning the error until then). The per-interface
+  `networkctl reconfigure` follow-up is best-effort (warn-only, Apply
+  still returns nil) but is likewise retried from `reconfigurePending`
+  until it succeeds. Distinct from #2987 (write-error-fails-commit) and
+  the stale-file sweep.
 - **An empty desired set is NOT a no-op (#2988).** `Apply(nil)` (last
   managed interface removed) still runs the `10-xpf-*` stale-file sweep
   and requests a reload so old addresses/bonds/bridges/renames don't

--- a/pkg/networkd/networkd.go
+++ b/pkg/networkd/networkd.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/psaab/xpf/pkg/fsatomic"
@@ -81,6 +82,26 @@ type Manager struct {
 	// rename + addressing and lock the operator out (#1956 AGY r3 CRITICAL,
 	// also the #1922 lifeline invariant). nil => no exemption (legacy).
 	protectedResolver func() map[string]bool
+
+	// mu guards the activation-debt fields below. Apply runs serialized under
+	// the daemon's applySem today, but the debt is process-durable state that
+	// outlives a single call, so it is locked defensively.
+	mu sync.Mutex
+	// reloadPending records that a previous Apply wrote generated files to
+	// disk and then had `networkctl reload` FAIL (#4954). Because the files
+	// are already on disk, a later Apply with byte-identical content sees no
+	// change (writeIfChanged → changed=false) and would otherwise SKIP the
+	// reload and return nil — masking a config the kernel never activated as a
+	// green commit (route leak / stranded NIC / management lockout persists).
+	// The debt forces the next Apply to re-run the idempotent reload even with
+	// unchanged files, and is cleared only once the reload finally succeeds.
+	reloadPending bool
+	// reconfigurePending mirrors reloadPending for the per-interface
+	// `networkctl reconfigure` address-application follow-up (bonds / VLANs),
+	// which was warn-only and likewise never retried. It holds the logical
+	// interface names that still owe a reconfigure; the next activation pass
+	// retries them and clears the set on success.
+	reconfigurePending map[string]bool
 }
 
 // SetProtectedResolver registers the management protected-set provider so
@@ -227,8 +248,13 @@ func (m *Manager) Apply(interfaces []InterfaceConfig) error {
 		// kernel reflects whatever did get written, but surface the error.
 		if changed {
 			if err := runNetworkctl("reload"); err != nil {
+				// #4954: a failed reload here also owes activation debt so a
+				// later identical retry re-attempts it rather than reporting a
+				// false success.
+				m.setReloadPending(true)
 				writeErrs = append(writeErrs, fmt.Errorf("networkctl reload: %w", err))
 			} else {
+				m.setReloadPending(false)
 				restoreSlowPathRPFilter()
 			}
 		}
@@ -236,10 +262,32 @@ func (m *Manager) Apply(interfaces []InterfaceConfig) error {
 			len(writeErrs), errors.Join(writeErrs...))
 	}
 
-	if changed {
-		slog.Info("networkd config updated, reloading", "interfaces", len(interfaces))
-		if err := runNetworkctl("reload"); err != nil {
-			return fmt.Errorf("networkctl reload: %w", err)
+	// #4954: an Apply must (re)activate whenever files changed this call OR a
+	// prior Apply left reload/reconfigure debt. Because the generated files are
+	// already on disk, an identical retry after a failed activation sees no
+	// change (changed==false) yet the kernel still runs the pre-failure config;
+	// without the debt the retry would skip the networkctl commands and return
+	// a false success. The debt is cleared only when the idempotent command
+	// finally succeeds.
+	m.mu.Lock()
+	reloadDebt := m.reloadPending
+	reconfDebt := len(m.reconfigurePending) > 0
+	m.mu.Unlock()
+
+	needReload := changed || reloadDebt
+	if needReload || reconfDebt {
+		if needReload {
+			if changed {
+				slog.Info("networkd config updated, reloading", "interfaces", len(interfaces))
+			} else {
+				slog.Info("networkd re-running deferred reload after a prior failed reload",
+					"interfaces", len(interfaces))
+			}
+			if err := runNetworkctl("reload"); err != nil {
+				m.setReloadPending(true)
+				return fmt.Errorf("networkctl reload: %w", err)
+			}
+			m.setReloadPending(false)
 		}
 		// Dynamically created interfaces (bonds, VLANs) may not get their
 		// addresses applied by reload alone. Reconfigure all managed
@@ -254,17 +302,46 @@ func (m *Manager) Apply(interfaces []InterfaceConfig) error {
 		}
 		if len(reconf) > 0 {
 			args := append([]string{"reconfigure"}, reconf...)
-			// Best-effort (reload above already applied the files), but
-			// the failure is no longer silent.
+			// Best-effort (reload above already applied the files), but the
+			// failure is no longer silent AND no longer forgotten: record the
+			// debt so the next Apply retries even with unchanged files (#4954).
 			if err := runNetworkctl(args...); err != nil {
+				m.setReconfigurePending(reconf)
 				slog.Warn("networkctl reconfigure failed",
 					"interfaces", len(reconf), "err", err)
+			} else {
+				m.setReconfigurePending(nil)
 			}
+		} else {
+			// Nothing managed to reconfigure — clear any stale debt.
+			m.setReconfigurePending(nil)
 		}
 		restoreSlowPathRPFilter()
 	}
 
 	return nil
+}
+
+// setReloadPending records or clears the #4954 reload activation debt.
+func (m *Manager) setReloadPending(pending bool) {
+	m.mu.Lock()
+	m.reloadPending = pending
+	m.mu.Unlock()
+}
+
+// setReconfigurePending records the set of interface names that still owe a
+// `networkctl reconfigure` (#4954), or clears the debt when names is empty.
+func (m *Manager) setReconfigurePending(names []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(names) == 0 {
+		m.reconfigurePending = nil
+		return
+	}
+	m.reconfigurePending = make(map[string]bool, len(names))
+	for _, n := range names {
+		m.reconfigurePending[n] = true
+	}
 }
 
 // procSysNetRoot is the root of the IPv4 sysctl tree. It is a package var

--- a/pkg/networkd/reload_debt_4954_test.go
+++ b/pkg/networkd/reload_debt_4954_test.go
@@ -1,0 +1,135 @@
+package networkd
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestApply_ReloadDebtRetriedAfterFailure is the #4954 fail-on-revert. A
+// `networkctl reload` that fails must leave the Manager owing activation debt
+// so an IDENTICAL retry (byte-identical generated files → writeIfChanged sees
+// no change) actually RE-ATTEMPTS the reload rather than short-circuiting to a
+// false success while the kernel still runs the pre-failure config.
+//
+// Pre-fix: the second Apply sees changed==false, skips the reload, returns nil
+// — masking the un-activated config. With the reload-debt fix the second Apply
+// re-runs reload and surfaces the still-failing state; the third (now
+// succeeding) Apply activates and clears the debt.
+func TestApply_ReloadDebtRetriedAfterFailure(t *testing.T) {
+	dir := t.TempDir()
+	m := NewInDir(dir)
+
+	var reloadCalls int
+	reloadFails := true
+	orig := runNetworkctl
+	runNetworkctl = func(args ...string) error {
+		if len(args) > 0 && args[0] == "reload" {
+			reloadCalls++
+			if reloadFails {
+				return errors.New("simulated networkctl reload failure")
+			}
+		}
+		return nil
+	}
+	t.Cleanup(func() { runNetworkctl = orig })
+
+	ifaces := []InterfaceConfig{
+		{Name: "trust0", MACAddress: "52:54:00:aa:bb:cc", Addresses: []string{"10.0.1.10/24"}},
+	}
+
+	// 1) First Apply writes files, reload FAILS → Apply must return an error.
+	if err := m.Apply(ifaces); err == nil {
+		t.Fatal("first Apply must fail when networkctl reload fails")
+	}
+	if reloadCalls != 1 {
+		t.Fatalf("first Apply should have attempted reload once, got %d", reloadCalls)
+	}
+
+	// 2) Identical retry: files are byte-identical (no change), but the reload
+	//    debt must force a re-attempt. Reload still fails → Apply still errors.
+	if err := m.Apply(ifaces); err == nil {
+		t.Fatal("identical retry after a failed reload must re-attempt and surface the still-failing reload, not return a false success")
+	}
+	if reloadCalls != 2 {
+		t.Fatalf("identical retry must RE-RUN reload (debt), got total reloadCalls=%d (want 2)", reloadCalls)
+	}
+
+	// 3) Reload now succeeds: the retry activates and clears the debt.
+	reloadFails = false
+	if err := m.Apply(ifaces); err != nil {
+		t.Fatalf("retry after reload recovers should succeed: %v", err)
+	}
+	if reloadCalls != 3 {
+		t.Fatalf("recovering retry must run reload, got total reloadCalls=%d (want 3)", reloadCalls)
+	}
+
+	// 4) Debt is now clear: a further identical Apply with unchanged files and
+	//    no debt must NOT reload again (no spurious activation).
+	if err := m.Apply(ifaces); err != nil {
+		t.Fatalf("steady-state Apply should succeed: %v", err)
+	}
+	if reloadCalls != 3 {
+		t.Fatalf("steady-state identical Apply must not reload once debt is cleared, got reloadCalls=%d (want 3)", reloadCalls)
+	}
+}
+
+// TestApply_ReconfigureDebtRetriedAfterFailure covers the mirrored
+// `networkctl reconfigure` debt: a reconfigure failure is warn-only (Apply
+// still returns nil) but must be retried on the next Apply even with unchanged
+// files, then cleared on success.
+func TestApply_ReconfigureDebtRetriedAfterFailure(t *testing.T) {
+	dir := t.TempDir()
+	m := NewInDir(dir)
+
+	var reconfigureCalls int
+	reconfigureFails := true
+	orig := runNetworkctl
+	runNetworkctl = func(args ...string) error {
+		if len(args) > 0 && args[0] == "reconfigure" {
+			reconfigureCalls++
+			if reconfigureFails {
+				return errors.New("simulated networkctl reconfigure failure")
+			}
+		}
+		return nil
+	}
+	t.Cleanup(func() { runNetworkctl = orig })
+
+	ifaces := []InterfaceConfig{
+		{Name: "trust0", MACAddress: "52:54:00:aa:bb:cc", Addresses: []string{"10.0.1.10/24"}},
+	}
+
+	// 1) First Apply: reload OK, reconfigure FAILS → warn-only, Apply returns nil.
+	if err := m.Apply(ifaces); err != nil {
+		t.Fatalf("first Apply should succeed (reconfigure is best-effort): %v", err)
+	}
+	if reconfigureCalls != 1 {
+		t.Fatalf("first Apply should attempt reconfigure once, got %d", reconfigureCalls)
+	}
+
+	// 2) Identical retry (unchanged files): reconfigure debt must force a
+	//    re-attempt even though nothing changed.
+	if err := m.Apply(ifaces); err != nil {
+		t.Fatalf("retry Apply should succeed (best-effort reconfigure): %v", err)
+	}
+	if reconfigureCalls != 2 {
+		t.Fatalf("identical retry must RE-RUN reconfigure (debt), got %d (want 2)", reconfigureCalls)
+	}
+
+	// 3) Reconfigure now succeeds → debt cleared.
+	reconfigureFails = false
+	if err := m.Apply(ifaces); err != nil {
+		t.Fatalf("recovering Apply should succeed: %v", err)
+	}
+	if reconfigureCalls != 3 {
+		t.Fatalf("recovering retry must run reconfigure, got %d (want 3)", reconfigureCalls)
+	}
+
+	// 4) Debt cleared: an identical Apply must not reconfigure again.
+	if err := m.Apply(ifaces); err != nil {
+		t.Fatalf("steady-state Apply should succeed: %v", err)
+	}
+	if reconfigureCalls != 3 {
+		t.Fatalf("steady-state Apply must not reconfigure once debt is cleared, got %d (want 3)", reconfigureCalls)
+	}
+}


### PR DESCRIPTION
## Problem

The networkd `Manager` held no cross-call state. `Apply` used a call-local `changed` flag and, on a `networkctl reload` failure, returned the error **after** the generated files were already written to disk. An identical re-commit then saw byte-identical content (`writeIfChanged` returns `(false, nil)`), left `changed==false`, **skipped the reload, and returned nil** — a false success while systemd-networkd / the kernel still ran the pre-failure config (route leak, stranded data NIC, or management lockout survives a green commit). A process restart reconstructed no pending state, so the hole persisted. The per-interface `networkctl reconfigure` follow-up was warn-only and likewise never retried.

## Fix

Give the `Manager` reload/reconfigure **activation debt**:
- a failed reload sets `reloadPending`; the next `Apply` re-runs the idempotent reload even with unchanged files and clears the debt only on success (still returning the error until then);
- a failed reconfigure records interface names in `reconfigurePending` and retries them on the next activation pass (still best-effort — `Apply` returns nil — but no longer forgotten).

Debt fields are mutex-guarded. Distinct from #2987 (write-error-fails-commit) and #2988 (empty-set sweep).

## Test

`reload_debt_4954_test.go` drives fail → identical-retry-re-attempts → recover → steady-state for both the reload and reconfigure debt paths (verified RED without the debt tracking). `pkg/networkd` suite passes; `go build ./...` clean.

Closes #4954

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi