### PR TITLE
daemon: propagate device-map rename/reload failures instead of laundering (#4956)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43941,3 +43941,7 @@ top.
   **File(s)**: pkg/config/compiler.go, pkg/config/compiler_dispatch.go, pkg/config/compiler_firewall.go, pkg/config/compiler_class_of_service.go, pkg/config/compiler_validate_strict_filter.go, pkg/config/compiler_uniformgates.go, pkg/config/lenient_fw_cos_4953_test.go, pkg/config/README.md
   **Action**: #4884(C) devicemap enumerates non-PCI physical NICs (USB/platform/SoC) so key mac entries bind; classifyNetdev seam + doc
   **File(s)**: pkg/devicemap/devicemap.go, pkg/devicemap/devicemap_nonpci_4884_test.go, docs/bare-metal-device-map.md
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4956 propagate device-map rename/reload failures from enumerateAndRenameMapped (accumulate phase-2/3 rename + phase-4 reload errors, return errors.Join instead of unconditional nil) so the #4182 retry marker is preserved; added renameInterfaceFn/networkctlReloadFn seams for unit testing
+  **File(s)**: pkg/daemon/device_map.go, pkg/daemon/device_map_rename_err_4956_test.go

--- a/pkg/daemon/device_map.go
+++ b/pkg/daemon/device_map.go
@@ -10,6 +10,7 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -19,6 +20,15 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/devicemap"
 	"github.com/vishvananda/netlink"
+)
+
+// renameInterfaceFn / networkctlReloadFn are injectable seams for the
+// device-map rename orchestration so the rename/reload error-propagation path
+// (#4956) is unit-testable without a live netlink stack. Production leaves them
+// pointing at the real link-rename + networkctl-reload helpers.
+var (
+	renameInterfaceFn  = renameInterface
+	networkctlReloadFn = networkctlReload
 )
 
 // The pure identity resolver, present-NIC model, and host enumeration live in
@@ -129,14 +139,28 @@ func deviceMapOriginalNameFor(currentNIC, logical string) string {
 // leaf). Protected names are treated as implicitly desired: their .link is
 // NOT scrubbed (so the management NIC keeps its managed name across reboots
 // even when the operator left it out of the device-map — AGY r2 CRITICAL).
+//
+// #4956: a rename (phase 2), stranded-restore (phase 3), or `networkctl
+// reload` (phase 4) failure used to only slog.Warn and then `return nil`
+// unconditionally — laundering the failure to success. The caller chain
+// (applyStartupNamingForConfig → maybeReapplyConfigArrivalNaming) consumes the
+// one-shot #4182 retry marker (emptyHANamingPending) on a nil return, so a
+// mapped NIC that never got its logical name was reported as converged and the
+// single retry was burned, wiring the config onto nonexistent/wrong interface
+// names. Every phase now still runs best-effort (so partial progress + full
+// logging happen), but the accumulated error is RETURNED so the retry marker
+// is preserved and the boot/bootstrap sites surface it loudly.
 func enumerateAndRenameMapped(dm *config.DeviceMapConfig, cfg *config.Config, protected map[string]bool) error {
 	if !dm.Active() {
 		return nil
 	}
-	nics, err := enumeratePresentNICs()
+	nics, err := enumeratePresentNICsFn()
 	if err != nil {
 		return fmt.Errorf("enumerate NICs: %w", err)
 	}
+	// renameErrs accumulates every phase-2/3 rename and phase-4 reload failure
+	// so the function fails (not launders) while still completing every phase.
+	var renameErrs []error
 	rethMembers := rethMembersFromConfig(cfg)
 	bindings := resolveDeviceMap(dm.Entries, nics, rethMembers)
 
@@ -184,7 +208,7 @@ func enumerateAndRenameMapped(dm *config.DeviceMapConfig, cfg *config.Config, pr
 		currentNames[i] = nics[i].Name
 	}
 	strandedTmp, changed := breakNameCollisions("device-map", currentNames, desiredNames,
-		desiredByCurrent, originalByCurrent, renameInterface)
+		desiredByCurrent, originalByCurrent, renameInterfaceFn)
 	// A temp-stranded UNMAPPED NIC (not a desired source) is carried into phase
 	// 3 keyed by its temp name; the presentNIC keeps its ORIGINAL (pre-temp)
 	// name for the predictable-name lookup, matching the pre-#4178 behavior.
@@ -214,8 +238,10 @@ func enumerateAndRenameMapped(dm *config.DeviceMapConfig, cfg *config.Config, pr
 		if writeDeviceMapLinkFile(final, original, rethMembers, dm.Entries) {
 			changed = true
 		}
-		if err := renameInterface(current, final); err != nil {
+		if err := renameInterfaceFn(current, final); err != nil {
 			slog.Warn("device-map: rename failed", "from", current, "to", final, "err", err)
+			renameErrs = append(renameErrs,
+				fmt.Errorf("rename %s -> %s: %w", current, final, err))
 		} else {
 			slog.Info("device-map: renamed interface", "from", current, "to", final)
 			changed = true
@@ -233,9 +259,11 @@ func enumerateAndRenameMapped(dm *config.DeviceMapConfig, cfg *config.Config, pr
 				"temp", tmp, "pci", nic.PCIAddr)
 			continue
 		}
-		if err := renameInterface(tmp, predictable); err != nil {
+		if err := renameInterfaceFn(tmp, predictable); err != nil {
 			slog.Warn("device-map: restore stranded NIC to predictable name failed",
 				"from", tmp, "to", predictable, "err", err)
+			renameErrs = append(renameErrs,
+				fmt.Errorf("restore stranded %s -> %s: %w", tmp, predictable, err))
 		} else {
 			slog.Info("device-map: restored unmapped NIC to predictable name",
 				"from", tmp, "to", predictable)
@@ -272,12 +300,20 @@ func enumerateAndRenameMapped(dm *config.DeviceMapConfig, cfg *config.Config, pr
 	}
 
 	if changed {
-		if err := networkctlReload(); err != nil {
+		if err := networkctlReloadFn(); err != nil {
 			slog.Warn("device-map: networkctl reload failed", "err", err)
+			renameErrs = append(renameErrs, fmt.Errorf("networkctl reload: %w", err))
 		}
 		slog.Info("device-map: interface naming updated")
 	} else {
 		slog.Info("device-map: interface naming unchanged")
+	}
+	// #4956: surface any phase-2/3 rename or phase-4 reload failure so the
+	// caller's retry marker (emptyHANamingPending) is NOT consumed on an
+	// unconverged rename and the reconcile does not proceed on mis-named NICs.
+	if len(renameErrs) > 0 {
+		return fmt.Errorf("device-map: %d interface rename/reload step(s) failed: %w",
+			len(renameErrs), errors.Join(renameErrs...))
 	}
 	return nil
 }

--- a/pkg/daemon/device_map_rename_err_4956_test.go
+++ b/pkg/daemon/device_map_rename_err_4956_test.go
@@ -1,0 +1,108 @@
+package daemon
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// stubMappedRenameSeams points the device-map rename orchestration's injectable
+// seams (NIC inventory, rename, reload) at test doubles and restores them on
+// cleanup. The single present NIC (enp9s0 at 0000:09:00.0) is mapped to a
+// DIFFERENT logical name so phase 2 always attempts a rename.
+func stubMappedRenameSeams(t *testing.T, renameErr, reloadErr error) (renameCalls, reloadCalls *int) {
+	t.Helper()
+	withTempLinkDir(t)
+
+	savedEnum := enumeratePresentNICsFn
+	enumeratePresentNICsFn = func() ([]presentNIC, error) {
+		return []presentNIC{{Name: "enp9s0", PCIAddr: "0000:09:00.0"}}, nil
+	}
+	t.Cleanup(func() { enumeratePresentNICsFn = savedEnum })
+
+	var rc, lc int
+	savedRename := renameInterfaceFn
+	renameInterfaceFn = func(from, to string) error {
+		rc++
+		return renameErr
+	}
+	t.Cleanup(func() { renameInterfaceFn = savedRename })
+
+	savedReload := networkctlReloadFn
+	networkctlReloadFn = func() error {
+		lc++
+		return reloadErr
+	}
+	t.Cleanup(func() { networkctlReloadFn = savedReload })
+
+	return &rc, &lc
+}
+
+func mappedRenameTestConfig() (*config.DeviceMapConfig, *config.Config) {
+	dm := &config.DeviceMapConfig{
+		Entries: []config.DeviceMapEntry{{LogicalName: "ge-0/0/3", PCIAddr: "0000:09:00.0"}},
+	}
+	cfg := &config.Config{Chassis: config.ChassisConfig{DeviceMap: dm}}
+	return dm, cfg
+}
+
+// TestEnumerateAndRenameMapped_RenameFailurePropagates_4956 is the #4956
+// fail-on-revert. A phase-2 mapped-NIC rename failure must PROPAGATE out of
+// enumerateAndRenameMapped (not be laundered to nil), so the caller's one-shot
+// retry marker (emptyHANamingPending) is preserved and the reconcile does not
+// proceed on a mis-named NIC.
+//
+// Revert: change the final `return fmt.Errorf(...)` back to `return nil` and
+// this test goes RED — the failed rename is reported as success.
+func TestEnumerateAndRenameMapped_RenameFailurePropagates_4956(t *testing.T) {
+	renameCalls, _ := stubMappedRenameSeams(t, fmt.Errorf("simulated rename failure"), nil)
+	dm, cfg := mappedRenameTestConfig()
+
+	err := enumerateAndRenameMapped(dm, cfg, nil)
+	if err == nil {
+		t.Fatal("enumerateAndRenameMapped must return an error when a mapped-NIC rename fails, not launder it to nil")
+	}
+	if *renameCalls == 0 {
+		t.Fatal("expected a rename attempt for the mapped NIC")
+	}
+	if !strings.Contains(err.Error(), "rename") {
+		t.Fatalf("error should name the failed rename step: %v", err)
+	}
+}
+
+// TestEnumerateAndRenameMapped_ReloadFailurePropagates_4956 covers the phase-4
+// `networkctl reload` failure: with the rename succeeding, a reload failure
+// must still surface (the config was written but never activated).
+func TestEnumerateAndRenameMapped_ReloadFailurePropagates_4956(t *testing.T) {
+	_, reloadCalls := stubMappedRenameSeams(t, nil, fmt.Errorf("simulated reload failure"))
+	dm, cfg := mappedRenameTestConfig()
+
+	err := enumerateAndRenameMapped(dm, cfg, nil)
+	if err == nil {
+		t.Fatal("enumerateAndRenameMapped must return an error when networkctl reload fails")
+	}
+	if *reloadCalls == 0 {
+		t.Fatal("expected a networkctl reload attempt")
+	}
+	if !strings.Contains(err.Error(), "reload") {
+		t.Fatalf("error should name the failed reload step: %v", err)
+	}
+}
+
+// TestEnumerateAndRenameMapped_SuccessReturnsNil_4956 proves the fix does not
+// over-report errors: when the rename and reload both succeed, the function
+// returns nil so the caller consumes the retry marker exactly once (normal
+// convergence).
+func TestEnumerateAndRenameMapped_SuccessReturnsNil_4956(t *testing.T) {
+	renameCalls, _ := stubMappedRenameSeams(t, nil, nil)
+	dm, cfg := mappedRenameTestConfig()
+
+	if err := enumerateAndRenameMapped(dm, cfg, nil); err != nil {
+		t.Fatalf("enumerateAndRenameMapped must succeed when every rename/reload step succeeds: %v", err)
+	}
+	if *renameCalls == 0 {
+		t.Fatal("expected a rename attempt for the mapped NIC")
+	}
+}


### PR DESCRIPTION
## Problem

`enumerateAndRenameMapped` (device-map mode) logged and continued on a phase-2 final-rename failure, a phase-3 stranded-restore failure, and a phase-4 `networkctl reload` failure, then `return nil` **unconditionally**. The caller chain (`applyStartupNamingForConfig` → `maybeReapplyConfigArrivalNaming`) consumes the one-shot #4182 retry marker (`emptyHANamingPending`) whenever naming returns nil — so a laundered rename failure was reported as converged: the single retry was burned and `applyConfigLocked` continued into VRF/interface/dataplane reconcile with a NIC that never got its mapped name (stranded management / wrong-NIC bind, commit reports no error).

## Fix

Accumulate every phase-2/3 rename failure and the phase-4 reload failure and return them (`errors.Join`) at the tail. Every phase still runs best-effort (partial progress + full logging preserved), but the non-nil return now reaches the retry machinery, which already keeps `emptyHANamingPending` **set** on error and re-attempts on the next config apply. NIC enumeration is routed through the existing `enumeratePresentNICsFn` seam; two new seams (`renameInterfaceFn` / `networkctlReloadFn`) make the paths injectable for unit testing.

Scope is exactly the task direction: propagate the error. It does not expand into the larger "typed naming outcome / abort the whole reconcile" redesign (deferred).

No operator-doc change — the fix is an internal robustness improvement (automatic retry of a transient rename/reload failure) with no new operator action; the function comment documents the contract.

## Test

`device_map_rename_err_4956_test.go` injects a rename failure, a reload failure, and an all-success case — the failure cases surface a non-nil error (verified RED without the propagation), success still returns nil. `pkg/daemon` suite passes; `go build ./...` clean.

Closes #4956

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi