### PR TITLE
config: make ValidateConfig read-only for surplus-sharing (#4966)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43941,3 +43941,8 @@ top.
   **File(s)**: pkg/config/compiler.go, pkg/config/compiler_dispatch.go, pkg/config/compiler_firewall.go, pkg/config/compiler_class_of_service.go, pkg/config/compiler_validate_strict_filter.go, pkg/config/compiler_uniformgates.go, pkg/config/lenient_fw_cos_4953_test.go, pkg/config/README.md
   **Action**: #4884(C) devicemap enumerates non-PCI physical NICs (USB/platform/SoC) so key mac entries bind; classifyNetdev seam + doc
   **File(s)**: pkg/devicemap/devicemap.go, pkg/devicemap/devicemap_nonpci_4884_test.go, docs/bare-metal-device-map.md
+
+## 2026-07-09 — #4966 ValidateConfig non-idempotent SurplusSharing mutation
+- **Timestamp**: 2026-07-09
+- **Action**: Made ValidateConfig read-only. Removed the `sched.SurplusSharing = false` strip in the warn pass; moved the effective gate to `buildClassOfServiceSnapshot` (`SurplusSharing && TransmitRateExact`) so the runtime never sees the inert flag while configured intent is preserved. Sorted the ADDNS warning block for deterministic order.
+- **File(s)**: pkg/config/compiler_validate_warn.go, pkg/dataplane/userspace/cos.go, pkg/config/parser_class_of_service_test.go, pkg/dataplane/userspace/manager_cos_test.go

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -1188,8 +1188,17 @@ func ValidateConfig(cfg *Config) []string {
 		// below to warn only for a percent that has no base to resolve against.
 		schedulersResolvingPercent := cosSchedulersWithShapedBinding(cos)
 		// #915: surplus-sharing is meaningful only on transmit-rate
-		// exact schedulers; warn-and-strip when set without exact so
-		// the runtime never sees the no-op flag (see #1183 lesson).
+		// exact schedulers; warn when set without exact (see #1183
+		// lesson). #4966: ValidateConfig is a READ-ONLY pass — it must
+		// NOT mutate the config. The "runtime never sees the no-op
+		// flag" guarantee is enforced at the compile-to-runtime edge
+		// instead: buildClassOfServiceSnapshot gates SurplusSharing on
+		// TransmitRateExact, so configured intent is preserved on the
+		// active config while the effective (runtime) value is false.
+		// Mutating here made validation non-idempotent — a second
+		// ValidateConfig saw SurplusSharing already cleared and emitted
+		// no warning, so recomputing surfaces (show system alarms)
+		// dropped the warning entirely.
 		for _, sched := range cos.Schedulers {
 			if sched == nil {
 				continue
@@ -1198,7 +1207,6 @@ func ValidateConfig(cfg *Config) []string {
 				warnings = append(warnings, fmt.Sprintf(
 					"class-of-service scheduler %q surplus-sharing is meaningful only with transmit-rate exact; ignored",
 					sched.Name))
-				sched.SurplusSharing = false
 			}
 			// #1746: warn-not-strip. A policy without enforcement is a
 			// harmless no-op (the dataplane gates it on
@@ -3260,6 +3268,11 @@ func validateSurfaceADDNSWarnings(cfg *Config) []string {
 			"is left stale). Use separate hostnames per family for a clean per-family "+
 			"teardown.", k.provider, k.fqdn))
 	}
+	// #4966: several loops above range over provider/family maps, so the
+	// raw append order is nondeterministic run-to-run. Sort the block
+	// before returning it so the surfaced commit warnings (and every
+	// alarm surface that re-derives them) are stable.
+	sort.Strings(warnings)
 	return warnings
 }
 

--- a/pkg/config/parser_class_of_service_test.go
+++ b/pkg/config/parser_class_of_service_test.go
@@ -818,10 +818,13 @@ system {
 	}
 }
 
-// #915: ValidateConfig warn-and-strips surplus-sharing when set
-// without transmit-rate exact (#1183 lesson — runtime never sees
-// the no-op flag).
-func TestSchedulerSurplusSharingWithoutExactWarnsAndStrips(t *testing.T) {
+// #915/#4966: ValidateConfig WARNS about surplus-sharing set without
+// transmit-rate exact, but must NOT strip it — validation is a
+// read-only pass and stripping made it non-idempotent (#4966). The
+// configured intent stays on the active config; the runtime never sees
+// the inert flag because buildClassOfServiceSnapshot gates it on
+// TransmitRateExact (asserted in the userspace snapshot tests).
+func TestSchedulerSurplusSharingWithoutExactWarnsButPreservesIntent(t *testing.T) {
 	lines := []string{
 		"set class-of-service forwarding-classes queue 4 iperf-a",
 		"set class-of-service schedulers iperf-a transmit-rate 1g",
@@ -845,27 +848,89 @@ func TestSchedulerSurplusSharingWithoutExactWarnsAndStrips(t *testing.T) {
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	// CompileConfig calls ValidateConfig internally and stores
-	// warnings on cfg.Warnings; calling ValidateConfig again is a
-	// no-op because the strip already cleared SurplusSharing.
-	gotWarn := false
-	for _, w := range cfg.Warnings {
-		if strings.Contains(w, "surplus-sharing") &&
-			strings.Contains(w, "iperf-a") {
-			gotWarn = true
-			break
+	hasSurplusWarn := func(warns []string) bool {
+		for _, w := range warns {
+			if strings.Contains(w, "surplus-sharing") &&
+				strings.Contains(w, "iperf-a") {
+				return true
+			}
 		}
+		return false
 	}
-	if !gotWarn {
-		t.Fatalf("expected warn-and-strip warning on cfg.Warnings; got: %v",
+	if !hasSurplusWarn(cfg.Warnings) {
+		t.Fatalf("expected surplus-sharing warning on cfg.Warnings; got: %v",
 			cfg.Warnings)
 	}
 	sched := cfg.ClassOfService.Schedulers["iperf-a"]
 	if sched == nil {
 		t.Fatal("scheduler missing")
 	}
-	if sched.SurplusSharing {
-		t.Fatal("expected SurplusSharing=false after warn-and-strip")
+	// Intent preserved: ValidateConfig no longer strips the flag.
+	if !sched.SurplusSharing {
+		t.Fatal("expected SurplusSharing preserved (not stripped) after compile")
+	}
+	// Idempotent: a re-run of ValidateConfig on the active config must
+	// re-emit the same warning (the recompute surfaces depend on this)
+	// and must NOT mutate SurplusSharing.
+	if warns := ValidateConfig(cfg); !hasSurplusWarn(warns) {
+		t.Fatalf("second ValidateConfig dropped the surplus-sharing warning; got: %v", warns)
+	}
+	if !sched.SurplusSharing {
+		t.Fatal("ValidateConfig mutated SurplusSharing (must be read-only)")
+	}
+}
+
+// #4966: ValidateConfig is a read-only pass and MUST be idempotent —
+// calling it twice yields an identical warning slice and leaves the
+// config it was given unchanged. Before the fix, the surplus-sharing
+// warn-and-strip mutated the config, so the second call saw a
+// different state and produced a different result.
+func TestValidateConfigIdempotentAndNonMutating(t *testing.T) {
+	lines := []string{
+		"set class-of-service forwarding-classes queue 4 iperf-a",
+		"set class-of-service schedulers iperf-a transmit-rate 1g",
+		"set class-of-service schedulers iperf-a surplus-sharing",
+		"set class-of-service scheduler-maps edge-map forwarding-class iperf-a scheduler iperf-a",
+		"set class-of-service interfaces ge-0/0/2 unit 80 shaping-rate 10g",
+		"set class-of-service interfaces ge-0/0/2 unit 80 scheduler-map edge-map",
+		"set system dataplane-type userspace",
+	}
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	sched := cfg.ClassOfService.Schedulers["iperf-a"]
+	if sched == nil {
+		t.Fatal("scheduler missing")
+	}
+	before := sched.SurplusSharing
+
+	first := ValidateConfig(cfg)
+	if sched.SurplusSharing != before {
+		t.Fatalf("ValidateConfig mutated SurplusSharing: before=%v after=%v", before, sched.SurplusSharing)
+	}
+	second := ValidateConfig(cfg)
+	if sched.SurplusSharing != before {
+		t.Fatalf("second ValidateConfig mutated SurplusSharing: before=%v after=%v", before, sched.SurplusSharing)
+	}
+	if len(first) != len(second) {
+		t.Fatalf("ValidateConfig not idempotent: len(first)=%d len(second)=%d\nfirst=%v\nsecond=%v",
+			len(first), len(second), first, second)
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Fatalf("ValidateConfig warning %d differs across calls:\n first=%q\nsecond=%q", i, first[i], second[i])
+		}
 	}
 }
 

--- a/pkg/dataplane/userspace/cos.go
+++ b/pkg/dataplane/userspace/cos.go
@@ -164,14 +164,20 @@ func buildClassOfServiceSnapshot(cfg *config.Config) *ClassOfServiceSnapshot {
 				continue
 			}
 			snap.Schedulers = append(snap.Schedulers, CoSSchedulerSnapshot{
-				Name:                  sched.Name,
-				TransmitRateBytes:     sched.TransmitRateBytes,
-				TransmitRatePercent:   sched.TransmitRatePercent,
-				TransmitRateExact:     sched.TransmitRateExact,
-				Priority:              sched.Priority,
-				BufferSizeBytes:       sched.BufferSizeBytes,
-				BufferSizePercent:     sched.BufferSizePercent,
-				SurplusSharing:        sched.SurplusSharing,
+				Name:                sched.Name,
+				TransmitRateBytes:   sched.TransmitRateBytes,
+				TransmitRatePercent: sched.TransmitRatePercent,
+				TransmitRateExact:   sched.TransmitRateExact,
+				Priority:            sched.Priority,
+				BufferSizeBytes:     sched.BufferSizeBytes,
+				BufferSizePercent:   sched.BufferSizePercent,
+				// #915/#4966: surplus-sharing is a no-op without
+				// transmit-rate exact. ValidateConfig warns but no
+				// longer strips it (that made validation mutate the
+				// config); the effective gate lives here so the
+				// runtime never receives the inert flag while the
+				// active config keeps the operator's configured intent.
+				SurplusSharing:        sched.SurplusSharing && sched.TransmitRateExact,
 				EqualFlowEnforcement:  sched.EqualFlowEnforcement,
 				EqualFlowTargetPolicy: sched.EqualFlowTargetPolicy,
 				CodelTargetNS:         sched.CodelTargetNS,

--- a/pkg/dataplane/userspace/manager_cos_test.go
+++ b/pkg/dataplane/userspace/manager_cos_test.go
@@ -352,6 +352,51 @@ func TestBuildClassOfServiceSnapshotIncludesSurplusSharing(t *testing.T) {
 	}
 }
 
+// #4966: surplus-sharing is a no-op without transmit-rate exact.
+// ValidateConfig warns but no longer strips it from the config, so the
+// snapshot builder is the effective gate — a scheduler with
+// SurplusSharing=true but TransmitRateExact=false must serialize
+// SurplusSharing=false so the runtime never receives the inert flag.
+func TestBuildClassOfServiceSnapshotGatesSurplusSharingOnExact(t *testing.T) {
+	cfg := &config.Config{
+		ClassOfService: &config.ClassOfServiceConfig{
+			Schedulers: map[string]*config.CoSScheduler{
+				// Configured intent: surplus-sharing set, but the rate
+				// is NOT exact, so the effective value must be false.
+				"inert": {
+					Name:              "inert",
+					TransmitRateBytes: 125_000_000,
+					TransmitRateExact: false,
+					SurplusSharing:    true,
+					Priority:          "low",
+				},
+				// Exact + surplus-sharing: effective value stays true.
+				"live": {
+					Name:              "live",
+					TransmitRateBytes: 125_000_000,
+					TransmitRateExact: true,
+					SurplusSharing:    true,
+					Priority:          "low",
+				},
+			},
+		},
+	}
+	snap := buildClassOfServiceSnapshot(cfg)
+	if snap == nil {
+		t.Fatal("expected non-nil snapshot")
+	}
+	got := map[string]bool{}
+	for _, s := range snap.Schedulers {
+		got[s.Name] = s.SurplusSharing
+	}
+	if got["inert"] {
+		t.Errorf("expected SurplusSharing gated off on non-exact scheduler; got %v", got)
+	}
+	if !got["live"] {
+		t.Errorf("expected SurplusSharing preserved on exact scheduler; got %v", got)
+	}
+}
+
 func TestBuildClassOfServiceSnapshotIncludesEqualFlowEnforcement(t *testing.T) {
 	cfg := &config.Config{
 		ClassOfService: &config.ClassOfServiceConfig{


### PR DESCRIPTION
## Problem

`ValidateConfig` is a non-fatal, read-only validation pass, but the
class-of-service warn loop (`pkg/config/compiler_validate_warn.go`)
**mutated** the config it was handed: a scheduler with `surplus-sharing`
set without `transmit-rate exact` got a warning appended AND
`sched.SurplusSharing = false`.

Consequences:
- **Non-idempotent** — a second `ValidateConfig` saw the flag already
  cleared and emitted no surplus-sharing warning, so alarm surfaces that
  re-derive warnings from the active config (`show system alarms`)
  silently dropped it.
- A read-only `show` mutated the committed config.
- The dynamic-DNS warning block ranged over maps → nondeterministic
  order run-to-run.

## Fix

- Stop stripping in the validate pass (keep the warning).
- Enforce "runtime never sees the no-op flag" (#915/#1183) at the
  compile-to-runtime edge: `buildClassOfServiceSnapshot` now serializes
  `SurplusSharing && TransmitRateExact`. Configured intent is preserved
  on the active config; the effective runtime value is `false`.
- The format renderer already gates the surplus line on `queue.exact`,
  so operator-visible output is unchanged.
- Sort the dynamic-DNS warning block for deterministic order.

## Tests

- `TestValidateConfigIdempotentAndNonMutating` — two `ValidateConfig`
  calls yield an identical warning slice and leave the config unchanged.
- `TestSchedulerSurplusSharingWithoutExactWarnsButPreservesIntent` —
  warning still emitted, `SurplusSharing` intent preserved, second
  validate re-emits.
- `TestBuildClassOfServiceSnapshotGatesSurplusSharingOnExact` — a
  non-exact scheduler serializes `SurplusSharing=false`.

All three fail if the strip is reintroduced or the gate removed
(verified RED-on-revert).

Closes #4966