### PR TITLE
ra: scope withdraw supersession per-interface so it cannot cancel a peer (#4961)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43945,3 +43945,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4954 give networkd Manager reload/reconfigure activation debt — a failed networkctl reload now re-attempts on the next identical Apply (reloadPending/reconfigurePending) instead of returning a false success when files are unchanged
   **File(s)**: pkg/networkd/networkd.go, pkg/networkd/reload_debt_4954_test.go, pkg/networkd/README.md
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4961 scope RA supersession per-interface — WithdrawInterfaces/WithdrawOnce bump a per-interface epoch (ifaceEpoch) instead of the whole-manager fence; releaseDrain restart + applyDeferred check the per-interface baseline (drainEntry.startIfaceEpoch) so an unrelated withdraw of interface B no longer cancels interface A's in-flight restart (IPv6 loss)
+  **File(s)**: pkg/ra/ra.go, pkg/ra/per_iface_epoch_4961_test.go, pkg/ra/README.md

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -155,11 +155,24 @@ after HA failover. To make that **structural**, not flag-defended:
   flight is NOT dead (`dead()` returns false until `connReady` is closed), so
   an in-progress slow bind is never spuriously torn down. Net effect: a
   transient open failure recovers on the next reconcile with NO config change.
-- **Deferred / restart Apply is epoch-guarded.** An `Apply` start that
-  waits behind a tombstone (a pre-existing drain, or its own changed-config
-  stop) captures the manager epoch; if a newer `Withdraw`/`Clear`/`Apply`
-  bumped the epoch in the interim, the deferred/restart start is aborted
-  (it must not re-arm RA on a node that has since transitioned to BACKUP).
+- **Deferred / restart Apply is epoch-guarded (two-level, #4961).** An
+  `Apply` start that waits behind a tombstone (a pre-existing drain, or its own
+  changed-config stop) captures TWO baselines: the whole-manager fence
+  (`m.epoch`) and the target interface's per-interface revision
+  (`m.ifaceEpoch[name]`, recorded on the restart's `drainEntry.startIfaceEpoch`
+  and captured per deferred interface). The (re)placement starts only if BOTH
+  are unchanged. The whole-manager fence is bumped by `Apply`, `Withdraw`, and
+  `Clear` (a node-wide transition to BACKUP must abort every in-flight start).
+  The INTERFACE-SCOPED withdraws (`WithdrawInterfaces`, `WithdrawOnce`) bump
+  ONLY the per-interface revision of the interfaces they name — NOT the fence.
+  Before #4961 they bumped the global fence, so an unrelated
+  `WithdrawInterfaces([B])` (e.g. from a concurrent HA reconcile, which is not
+  under `applySem`) cancelled interface A's in-flight changed-config restart:
+  the epoch mismatch suppressed A's replacement AND deleted its tombstone, so A
+  silently lost its RA sender and A's hosts lost their IPv6 default route /
+  RDNSS until the next RG transition. Scoping supersession per interface fixes
+  that while a withdraw NAMING A still supersedes A's restart (both the
+  per-interface epoch bump and the `goodbyeWanted` flip fire).
 - **Bounded writes.** Every owner `WriteTo` sets a 1 s write deadline so a
   stuck socket cannot wedge withdrawal; the owner always returns promptly,
   which is what makes owner-performs-the-close safe for both modes.

--- a/pkg/ra/per_iface_epoch_4961_test.go
+++ b/pkg/ra/per_iface_epoch_4961_test.go
@@ -1,0 +1,132 @@
+package ra
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestWithdrawInterfacesUnrelatedDoesNotCancelRestart_4961 is the #4961
+// fail-on-revert. A changed-config restart of interface A (here "lo") is
+// in-flight — its old sender is stopped and its replacement is about to start
+// via releaseDrain's onProvenClose. A concurrent WithdrawInterfaces naming a
+// DIFFERENT interface must NOT cancel A's restart.
+//
+// Pre-fix: WithdrawInterfaces bumped the GLOBAL epoch, so releaseDrain saw
+// m.epoch != startEpoch and suppressed A's replacement AND deleted its
+// tombstone — A silently lost its RA sender (IPv6 loss on A's hosts). With the
+// per-interface epoch, an unrelated withdraw bumps only that interface's epoch,
+// so A's restart completes.
+//
+// Revert (make WithdrawInterfaces bump the global epoch again) and this test
+// goes RED: onProvenClose is never called and no replacement sender exists.
+func TestWithdrawInterfacesUnrelatedDoesNotCancelRestart_4961(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+	m := New()
+	old, cfg, startEpoch := installRestartEntry(t, fl, m)
+
+	// A withdraw of an UNRELATED interface: it must not touch lo's restart.
+	m.WithdrawInterfaces([]string{"eth-unrelated-4961"})
+
+	started := false
+	onProvenClose := func() error {
+		started = true
+		return m.startLocked(cfg)
+	}
+	if err := m.releaseDrain("lo", old, startEpoch, onProvenClose); err != nil {
+		t.Fatalf("releaseDrain: %v", err)
+	}
+
+	if !started {
+		t.Fatal("lo's changed-config restart was cancelled by an unrelated " +
+			"WithdrawInterfaces([eth-unrelated-4961]) — replacement suppressed " +
+			"(IPv6 loss on lo) — #4961")
+	}
+	m.mu.Lock()
+	_, live := m.senders["lo"]
+	_, stillDraining := m.draining["lo"]
+	m.mu.Unlock()
+	if !live {
+		t.Fatal("expected a live replacement sender for lo after the restart completed")
+	}
+	if stillDraining {
+		t.Fatal("lo tombstone should have been released after the restart")
+	}
+	_ = m.Clear()
+}
+
+// TestWithdrawInterfacesSameIfaceCancelsRestart_4961 is the positive control:
+// a withdraw NAMING the restarting interface must still supersede its restart
+// (the per-interface epoch bump + the goodbyeWanted flip both fire), so the fix
+// does not over-permit — a genuine same-interface withdraw still wins.
+func TestWithdrawInterfacesSameIfaceCancelsRestart_4961(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+	m := New()
+	old, cfg, startEpoch := installRestartEntry(t, fl, m)
+
+	// A withdraw NAMING lo: flips goodbyeWanted on lo's tombstone AND bumps
+	// lo's per-interface epoch — either alone must suppress the replacement.
+	m.WithdrawInterfaces([]string{"lo"})
+
+	started := false
+	onProvenClose := func() error {
+		started = true
+		return m.startLocked(cfg)
+	}
+	if err := m.releaseDrain("lo", old, startEpoch, onProvenClose); err != nil {
+		t.Fatalf("releaseDrain: %v", err)
+	}
+	if started {
+		t.Fatal("a WithdrawInterfaces([lo]) must supersede lo's restart — the " +
+			"replacement must NOT start")
+	}
+	m.mu.Lock()
+	_, live := m.senders["lo"]
+	m.mu.Unlock()
+	if live {
+		t.Fatal("no replacement sender should exist for lo after a same-interface withdraw")
+	}
+}
+
+// TestWithdrawInterfacesUnrelatedDoesNotBumpGlobalEpoch_4961 pins the
+// mechanism: an interface-scoped withdraw leaves the whole-manager fence
+// (m.epoch) untouched and bumps only the named interface's per-interface epoch.
+func TestWithdrawInterfacesUnrelatedDoesNotBumpGlobalEpoch_4961(t *testing.T) {
+	m := New()
+	m.mu.Lock()
+	globalBefore := m.epoch
+	m.mu.Unlock()
+
+	m.WithdrawInterfaces([]string{"eth-x-4961"})
+
+	m.mu.Lock()
+	globalAfter := m.epoch
+	ifEpoch := m.ifaceEpoch["eth-x-4961"]
+	m.mu.Unlock()
+
+	if globalAfter != globalBefore {
+		t.Fatalf("WithdrawInterfaces must not bump the whole-manager fence: %d -> %d", globalBefore, globalAfter)
+	}
+	if ifEpoch == 0 {
+		t.Fatal("WithdrawInterfaces must bump the named interface's per-interface epoch")
+	}
+
+	// WithdrawOnce (also interface-scoped) must behave the same.
+	m.mu.Lock()
+	globalBefore = m.epoch
+	m.mu.Unlock()
+	m.WithdrawOnce([]*config.RAInterfaceConfig{testCfg("eth-y-4961")})
+	m.mu.Lock()
+	globalAfter = m.epoch
+	m.mu.Unlock()
+	if globalAfter != globalBefore {
+		t.Fatalf("WithdrawOnce must not bump the whole-manager fence: %d -> %d", globalBefore, globalAfter)
+	}
+}

--- a/pkg/ra/ra.go
+++ b/pkg/ra/ra.go
@@ -52,6 +52,13 @@ type drainEntry struct {
 	cfg            *config.RAInterfaceConfig // config for a standalone goodbye, if owed
 	goodbyeWanted  bool                      // a graceful Withdraw targeted this interface
 	goodbyeClaimed bool                      // the owner has taken responsibility to emit it
+	// startIfaceEpoch is the per-interface epoch (m.ifaceEpoch[name]) captured
+	// when a CHANGED-config restart installed this entry (#4961). releaseDrain
+	// starts the replacement only if this interface's epoch is UNCHANGED — i.e.
+	// no interface-scoped withdraw (WithdrawInterfaces/WithdrawOnce naming THIS
+	// interface) superseded the restart. It is 0 (and unused) for removal /
+	// Clear / WithdrawOnce entries, which pass onProvenClose=nil.
+	startIfaceEpoch uint64
 }
 
 // Manager manages per-interface RA sender goroutines.
@@ -66,24 +73,47 @@ type Manager struct {
 	// standalone goodbye it claimed has fully completed.
 	draining map[string]*drainEntry
 
-	// epoch is bumped on every state-mutating call (Apply, Withdraw,
-	// WithdrawInterfaces, WithdrawOnce, Clear). A deferred Apply captures the
-	// epoch before releasing m.mu and ABORTS its deferred start if the epoch
-	// changed — a newer call (e.g. a BACKUP transition) superseded it (#2033
-	// I16b). This prevents a stale Apply from starting RA on a demoted node.
+	// epoch is the WHOLE-MANAGER fence, bumped by the whole-manager mutators
+	// (Apply, Withdraw, Clear). A deferred Apply / changed-config restart
+	// captures it before releasing m.mu and ABORTS if it changed — a newer
+	// whole-manager call (e.g. a BACKUP transition's Withdraw/Clear, or a fresh
+	// full Apply) superseded it (#2033 I16b). This prevents a stale Apply from
+	// starting RA on a demoted node.
+	//
+	// #4961: the INTERFACE-SCOPED withdraws (WithdrawInterfaces / WithdrawOnce)
+	// no longer bump this global fence — bumping it made an unrelated
+	// WithdrawInterfaces([B]) cancel a DIFFERENT interface A's in-flight
+	// changed-config restart (epoch mismatch → A's replacement suppressed AND
+	// its tombstone deleted → A loses its RA sender → IPv6 loss on A's hosts).
+	// They now bump only the per-interface epoch below, so supersession is
+	// scoped to the interfaces they actually name.
 	epoch uint64
+
+	// ifaceEpoch is the per-interface supersession revision (#4961), bumped by
+	// the interface-scoped withdraws (WithdrawInterfaces / WithdrawOnce) for
+	// each interface they name. A changed-config restart records the target
+	// interface's epoch on its drainEntry (startIfaceEpoch) and a deferred Apply
+	// captures it per interface; releaseDrain / applyDeferred start the
+	// (re)placement only if THIS interface's epoch is still unchanged. A withdraw
+	// of interface B thus cannot cancel interface A's restart.
+	ifaceEpoch map[string]uint64
 }
 
 // New creates a new RA manager.
 func New() *Manager {
 	return &Manager{
-		senders:  make(map[string]*sender),
-		draining: make(map[string]*drainEntry),
+		senders:    make(map[string]*sender),
+		draining:   make(map[string]*drainEntry),
+		ifaceEpoch: make(map[string]uint64),
 	}
 }
 
-// bumpEpoch increments the manager epoch. Callers must hold m.mu.
+// bumpEpoch increments the whole-manager fence epoch. Callers must hold m.mu.
 func (m *Manager) bumpEpoch() { m.epoch++ }
+
+// bumpIfaceEpoch increments the per-interface supersession revision for name
+// (#4961). Callers must hold m.mu.
+func (m *Manager) bumpIfaceEpoch(name string) { m.ifaceEpoch[name]++ }
 
 // interfaceBusy reports whether the named interface currently has an active
 // sender or a draining tombstone. Callers must hold m.mu.
@@ -187,10 +217,14 @@ func (m *Manager) releaseDrain(name string, s *sender, startEpoch uint64, onProv
 
 		// No (further) goodbye owed. Decide the replacement under THIS lock with
 		// FRESH epoch + goodbyeWanted (round-5: no cached boolean). Start ONLY
-		// if epoch is still ours AND no goodbye was wanted (a withdraw overrides
-		// a replace). Neither can change while we hold the lock.
+		// if the whole-manager fence is still ours (no Clear/Withdraw/full-Apply
+		// superseded), THIS interface's per-interface epoch is unchanged (#4961:
+		// no interface-scoped withdraw naming this interface superseded), AND no
+		// goodbye was wanted (a withdraw overrides a replace). None can change
+		// while we hold the lock.
 		var startErr error
-		if onProvenClose != nil && m.epoch == startEpoch && !e.goodbyeWanted {
+		if onProvenClose != nil && m.epoch == startEpoch &&
+			m.ifaceEpoch[name] == e.startIfaceEpoch && !e.goodbyeWanted {
 			// Old conn PROVEN closed + tombstone still held → ≤1 live conn.
 			startErr = onProvenClose()
 		}
@@ -308,7 +342,16 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 				slog.Info("ra: restarting sender", "interface", name)
 			}
 			delete(m.senders, name)
-			m.draining[name] = &drainEntry{sender: existing, cfg: existing.cfg}
+			// #4961: record THIS interface's per-interface epoch on the restart
+			// tombstone. releaseDrain starts the replacement only if the epoch is
+			// still this value — an interface-scoped withdraw naming this
+			// interface bumps it and suppresses the (now-superseded) restart,
+			// while a withdraw of a DIFFERENT interface leaves it untouched.
+			m.draining[name] = &drainEntry{
+				sender:          existing,
+				cfg:             existing.cfg,
+				startIfaceEpoch: m.ifaceEpoch[name],
+			}
 			existing.signalStop(modeHard)
 			toStop = append(toStop, stopReq{name, existing})
 			toRestart = append(toRestart, cfg)
@@ -329,6 +372,14 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 	}
 
 	epoch := m.epoch
+	// #4961: capture each deferred interface's per-interface epoch as the
+	// baseline applyDeferred re-checks, so an interface-scoped withdraw naming
+	// that interface (but NOT one naming a different interface) aborts its
+	// deferred start.
+	deferredIfaceEpoch := make(map[string]uint64, len(deferred))
+	for _, cfg := range deferred {
+		deferredIfaceEpoch[cfg.Interface] = m.ifaceEpoch[cfg.Interface]
+	}
 	m.mu.Unlock()
 
 	restartSet := make(map[string]*config.RAInterfaceConfig, len(toRestart))
@@ -379,7 +430,7 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 	// Second pass for interfaces that were ALREADY draining when we held the
 	// lock (not our own restart tombstones — those are handled above).
 	if len(deferred) > 0 {
-		if err := m.applyDeferred(deferred, epoch); err != nil && firstErr == nil {
+		if err := m.applyDeferred(deferred, epoch, deferredIfaceEpoch); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
@@ -388,10 +439,13 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 }
 
 // applyDeferred waits (bounded) for each deferred interface's tombstone to
-// clear, then re-acquires m.mu and starts it — but only if the manager epoch
-// still matches startEpoch (else a newer call superseded this Apply, #2033
-// I16b). It must be called WITHOUT m.mu held.
-func (m *Manager) applyDeferred(configs []*config.RAInterfaceConfig, startEpoch uint64) error {
+// clear, then re-acquires m.mu and starts it — but only if neither the
+// whole-manager fence (startEpoch) nor THIS interface's per-interface epoch
+// (startIfaceEpoch[iface], #4961) changed. A whole-manager Withdraw/Clear/Apply
+// bumps the former; an interface-scoped withdraw naming this interface bumps the
+// latter. A withdraw of a DIFFERENT interface changes neither, so this start
+// still proceeds. It must be called WITHOUT m.mu held.
+func (m *Manager) applyDeferred(configs []*config.RAInterfaceConfig, startEpoch uint64, startIfaceEpoch map[string]uint64) error {
 	var firstErr error
 	for _, cfg := range configs {
 		if !m.waitTombstoneClear(cfg.Interface) {
@@ -401,8 +455,9 @@ func (m *Manager) applyDeferred(configs []*config.RAInterfaceConfig, startEpoch 
 		}
 
 		m.mu.Lock()
-		if m.epoch != startEpoch {
-			// A newer Withdraw/Clear/Apply superseded this start; abort.
+		if m.epoch != startEpoch || m.ifaceEpoch[cfg.Interface] != startIfaceEpoch[cfg.Interface] {
+			// A newer whole-manager call (epoch) or an interface-scoped withdraw
+			// naming this interface (ifaceEpoch) superseded this start; abort.
 			slog.Debug("ra: deferred Apply superseded by newer epoch, skipping",
 				"interface", cfg.Interface)
 			m.mu.Unlock()
@@ -504,7 +559,13 @@ func (m *Manager) Withdraw() error {
 // interfaces. Other senders are left running.
 func (m *Manager) WithdrawInterfaces(names []string) {
 	m.mu.Lock()
-	m.bumpEpoch()
+	// #4961: bump ONLY the per-interface epochs for the named interfaces, NOT
+	// the whole-manager fence. Bumping the global fence made this cancel an
+	// UNRELATED interface's in-flight changed-config restart (IPv6 loss on that
+	// interface). Interface-scoped supersession is now scoped to `names`.
+	for _, name := range names {
+		m.bumpIfaceEpoch(name)
+	}
 	owned := m.claimGracefulLocked(names)
 	epoch := m.epoch
 	m.mu.Unlock()
@@ -640,7 +701,12 @@ func (m *Manager) WithdrawOnce(configs []*config.RAInterfaceConfig) {
 func (m *Manager) claimWithdrawOnceLocked(configs []*config.RAInterfaceConfig) []*config.RAInterfaceConfig {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.bumpEpoch()
+	// #4961: interface-scoped op — bump only the named interfaces' per-interface
+	// epochs, not the whole-manager fence, so a WithdrawOnce of interface B
+	// cannot cancel interface A's in-flight restart / deferred start.
+	for _, cfg := range configs {
+		m.bumpIfaceEpoch(cfg.Interface)
+	}
 	var toGoodbye []*config.RAInterfaceConfig
 	for _, cfg := range configs {
 		if m.interfaceBusy(cfg.Interface) {


### PR DESCRIPTION
## Problem

`pkg/ra`'s `Manager` carried a single global `epoch` bumped by **every** state-mutating call, including `WithdrawInterfaces` / `WithdrawOnce`. A changed-config restart of interface A captured that epoch and, in `releaseDrain`, started A's replacement only while the epoch was unchanged. An unrelated `WithdrawInterfaces([B])` bumped the **same** global epoch during A's join window → A's replacement suppressed **and** A's tombstone deleted → A lost its RA sender (no replacement, no goodbye). A's hosts then lost their IPv6 default route / RDNSS when the advertised lifetimes expired, with no auto-repair until the next RG transition. RA is driven concurrently from config-apply (under `applySem`) and HA reconcile (`daemon_ha.go`, **not** under `applySem`), so the cross-interface race is real.

## Fix

Split the epoch into two levels:
- whole-manager fence `epoch` — still bumped by node-wide mutators `Apply` / `Withdraw` / `Clear`;
- per-interface `ifaceEpoch[name]` — bumped only by the interface-scoped `WithdrawInterfaces` / `WithdrawOnce` for the interfaces they name.

A restart records the target's per-interface epoch on its `drainEntry.startIfaceEpoch`; a deferred Apply captures it per interface. `releaseDrain`'s replacement decision and `applyDeferred`'s start decision now require **both** the fence and this interface's epoch unchanged. A withdraw of B bumps only B → A's restart completes; a withdraw naming A bumps A (and flips `goodbyeWanted`) → A's restart is still superseded. `releaseDrain`'s signature is unchanged (baseline rides on the `drainEntry`), so the round-4/round-5 serialization tests are untouched.

## Test

`per_iface_epoch_4961_test.go`: an in-flight `lo` restart survives an unrelated `WithdrawInterfaces([eth-unrelated])` (verified RED when `WithdrawInterfaces` bumps the global fence), plus a same-interface positive control and a fence-not-bumped assertion. Full `pkg/ra` suite passes under `-race`; `go build ./...` clean.

Closes #4961

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi