### PR TITLE
daemon: bind one stable session-aggregation callback (#4964)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43955,3 +43955,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4961 scope RA supersession per-interface — WithdrawInterfaces/WithdrawOnce bump a per-interface epoch (ifaceEpoch) instead of the whole-manager fence; releaseDrain restart + applyDeferred check the per-interface baseline (drainEntry.startIfaceEpoch) so an unrelated withdraw of interface B no longer cancels interface A's in-flight restart (IPv6 loss)
   **File(s)**: pkg/ra/ra.go, pkg/ra/per_iface_epoch_4961_test.go, pkg/ra/README.md
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4964 stop applyAggregator leaking an append-only EventReader callback + a never-flushed 20k-key SessionAggregator per report-enabled commit. Register one stable indirection callback (aggregationCallback) exactly once via aggCBOnce, publish the live aggregator through an atomic.Pointer (aggregatorPtr), swap-to-nil-before-cancel on retire — mirrors the #3932 TraceWriter / #2075 flowexport pattern. Removed the write-only aggregator field; added aggReconMu.
+  **File(s)**: pkg/daemon/daemon.go, pkg/daemon/daemon_system.go, pkg/daemon/aggregator_callback_4964_test.go

--- a/pkg/daemon/aggregator_callback_4964_test.go
+++ b/pkg/daemon/aggregator_callback_4964_test.go
@@ -1,0 +1,99 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/logging"
+)
+
+// TestApplyAggregatorRegistersExactlyOneCallback is the RED-on-revert proof for
+// #4964: applyAggregator must register its session-aggregation EventReader
+// callback exactly ONCE regardless of how many report-enabled commits run.
+//
+// Before the fix applyAggregator called er.AddCallback(agg.HandleEvent) on
+// every report-enabled reconcile. The EventReader callback list is append-only
+// (ringbuf.go exposes only the all-or-nothing ClearCallbacks), so N commits
+// leaked N callbacks, each feeding a stale never-flushed aggregator, and every
+// event was then dispatched to all N — an unbounded per-event cost and memory
+// leak over the daemon's lifetime.
+//
+// Reverting to the per-call AddCallback makes CallbackCount grow by one per
+// apply, so this test fails at the very first assertion below.
+func TestApplyAggregatorRegistersExactlyOneCallback(t *testing.T) {
+	er := logging.NewEventReader(nil, nil)
+	d := &Daemon{}
+
+	cfg := &config.Config{}
+	cfg.Security.Log.Report = true
+
+	const cycles = 50
+	for i := 0; i < cycles; i++ {
+		d.applyAggregator(er, cfg)
+		if got := er.CallbackCount(); got != 1 {
+			t.Fatalf("after %d report-enabled applies the EventReader must carry "+
+				"exactly one aggregation callback; got %d (append-only leak: the "+
+				"pre-#4964 per-apply AddCallback)", i+1, got)
+		}
+		if d.aggregatorPtr.Load() == nil {
+			t.Fatalf("apply %d: report enabled must publish a live aggregator", i+1)
+		}
+	}
+
+	// Stop the last running Run goroutine so the test does not leak it.
+	t.Cleanup(func() {
+		if d.aggCancel != nil {
+			d.aggCancel()
+		}
+	})
+}
+
+// TestApplyAggregatorDisableClearsPointerKeepsCallback verifies the disable
+// path: turning reporting off retires the live aggregator (nil pointer, so the
+// stable callback becomes a no-op and no further events are accumulated) while
+// leaving the single registered callback in place. Re-enabling must NOT add a
+// second callback.
+func TestApplyAggregatorDisableClearsPointerKeepsCallback(t *testing.T) {
+	er := logging.NewEventReader(nil, nil)
+	d := &Daemon{}
+
+	enabled := &config.Config{}
+	enabled.Security.Log.Report = true
+	disabled := &config.Config{} // Report defaults false
+
+	// Enable: one callback, live aggregator.
+	d.applyAggregator(er, enabled)
+	if got := er.CallbackCount(); got != 1 {
+		t.Fatalf("enable: expected 1 callback, got %d", got)
+	}
+	if d.aggregatorPtr.Load() == nil {
+		t.Fatal("enable: expected a live aggregator pointer")
+	}
+
+	// Disable: pointer nil-ed, callback retained (stable, now a no-op).
+	d.applyAggregator(er, disabled)
+	if got := er.CallbackCount(); got != 1 {
+		t.Fatalf("disable: the stable callback must remain (no per-apply churn); got %d", got)
+	}
+	if d.aggregatorPtr.Load() != nil {
+		t.Fatal("disable: aggregator pointer must be nil so the callback is a no-op")
+	}
+	if d.aggCancel != nil {
+		t.Fatal("disable: the Run cancel func must be cleared")
+	}
+
+	// Re-enable: still exactly one callback (aggCBOnce), fresh live aggregator.
+	d.applyAggregator(er, enabled)
+	if got := er.CallbackCount(); got != 1 {
+		t.Fatalf("re-enable: still exactly one callback (aggCBOnce); got %d", got)
+	}
+	if d.aggregatorPtr.Load() == nil {
+		t.Fatal("re-enable: expected a live aggregator pointer")
+	}
+
+	t.Cleanup(func() {
+		if d.aggCancel != nil {
+			d.aggCancel()
+		}
+	})
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -290,11 +290,28 @@ type Daemon struct {
 	eventBuf       *logging.EventBuffer
 	eventReader    *logging.EventReader
 	eventEngine    *eventengine.Engine
-	aggregator     *logging.SessionAggregator
-	aggCancel      context.CancelFunc
-	vrrpMgr        *vrrp.Manager
-	gc             *conntrack.GC
-	startTime      time.Time // daemon start time; used to suppress stale config sync
+	// #4964: the session-aggregation reporter is published through an atomic
+	// pointer read lock-free by a SINGLE stable EventReader callback that
+	// aggCBOnce registers exactly once. Each report-enabled commit SWAPS the
+	// active aggregator (nil-ing the pointer before cancelling the old Run
+	// goroutine) instead of registering a new callback, so a long-lived daemon
+	// that re-commits with reporting enabled leaves exactly one callback and
+	// one live aggregator regardless of commit count. Before #4964
+	// applyAggregator called er.AddCallback on every report-enabled reconcile:
+	// the callback list is append-only (ringbuf.go: only ClearCallbacks
+	// removes, and it is all-or-nothing), so N commits leaked N callbacks each
+	// feeding a stale never-flushed 20k-key Space-Saving aggregator, and every
+	// event was then dispatched to all N — growing per-event cost and memory
+	// even after reporting was disabled. Disabling reporting stores nil; the
+	// stable callback stays but becomes a no-op. aggReconMu serializes the
+	// swap on the commit path; the callback reads the pointer lock-free.
+	aggregatorPtr atomic.Pointer[logging.SessionAggregator]
+	aggCancel     context.CancelFunc
+	aggCBOnce     sync.Once
+	aggReconMu    sync.Mutex
+	vrrpMgr       *vrrp.Manager
+	gc            *conntrack.GC
+	startTime     time.Time // daemon start time; used to suppress stale config sync
 
 	// #846: applySem (capacity 1) serializes applyConfig + the
 	// commit→apply pair across all entry points (HTTP/gRPC commits,

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -212,14 +212,46 @@ func resolveSourceAddr(cfg *config.Config, srcIface string) string {
 	return ""
 }
 
-// applyAggregator starts or stops the session aggregation reporter.
+// aggregationCallback is the single, stable session-aggregation handler
+// registered on the EventReader exactly ONCE (aggCBOnce). It reads the live
+// SessionAggregator lock-free from the atomic pointer, so a config commit can
+// swap the aggregator — or clear it to nil on disable — without ever
+// registering a second callback. This is the #4964 fix mirroring the #3932
+// flow-trace / #2075 flow-export indirection: the previous applyAggregator
+// called er.AddCallback on every report-enabled reconcile, so a long-lived
+// daemon leaked one callback (and one never-flushed aggregator) per commit and
+// dispatched every event to all of them. A nil pointer (reporting disabled)
+// makes this a no-op.
+func (d *Daemon) aggregationCallback(rec logging.EventRecord, raw []byte) {
+	agg := d.aggregatorPtr.Load()
+	if agg == nil {
+		return
+	}
+	agg.HandleEvent(rec, raw)
+}
+
+// applyAggregator starts or stops the session aggregation reporter. The stable
+// indirection callback (aggregationCallback) is registered on er exactly once
+// — the first time reporting is enabled — and every later call only SWAPS the
+// active aggregator, cancelling the Run goroutine of the one it replaced. So N
+// report-enabled commits leave exactly one registered callback and one live
+// aggregator (#4964). Disabling reporting stores a nil aggregator; the stable
+// callback stays but becomes a no-op.
 func (d *Daemon) applyAggregator(er *logging.EventReader, cfg *config.Config) {
-	// Stop existing aggregator
+	d.aggReconMu.Lock()
+	defer d.aggReconMu.Unlock()
+
+	// Stop the currently-running aggregator generation (if any). Swap the
+	// published pointer to nil FIRST so no in-flight event can enter the
+	// retired aggregator via the stable callback, THEN cancel its flush
+	// goroutine. Retiring in the other order would let HandleEvent keep
+	// feeding a cancelled aggregator whose Run no longer flushes (the #4964
+	// leak).
 	if d.aggCancel != nil {
+		d.aggregatorPtr.Store(nil)
 		d.aggCancel()
 		d.aggCancel = nil
 	}
-	d.aggregator = nil
 
 	if !cfg.Security.Log.Report {
 		return
@@ -232,11 +264,23 @@ func (d *Daemon) applyAggregator(er *logging.EventReader, cfg *config.Config) {
 		er.ForwardLogMsg(severity, msg)
 	})
 
-	er.AddCallback(agg.HandleEvent)
-
 	ctx, cancel := context.WithCancel(context.Background())
+
+	// Publish the new aggregator BEFORE arming the callback (and before Run
+	// starts) so the stable callback, once registered, never observes a nil
+	// during startup. Add accumulates immediately; Run only flushes.
+	d.aggregatorPtr.Store(agg)
 	d.aggCancel = cancel
-	d.aggregator = agg
+
+	// Register the single stable callback exactly once, the first time
+	// reporting is enabled. A boot with reporting disabled registers nothing;
+	// the first enable arms it. er is the same EventReader across every commit
+	// (daemon_run.go assigns the boot reader to d.eventReader, daemon_apply.go
+	// passes d.eventReader), so one registration covers all generations.
+	d.aggCBOnce.Do(func() {
+		er.AddCallback(d.aggregationCallback)
+	})
+
 	go agg.Run(ctx)
 	slog.Info("session aggregation reporting enabled (5 min interval)")
 }


### PR DESCRIPTION
## Problem

`applyAggregator` (`pkg/daemon/daemon_system.go`, callers at :77/:96/:179) called `er.AddCallback(agg.HandleEvent)` on **every** report-enabled reconcile. The `EventReader` callback list is append-only — `pkg/logging/ringbuf.go` exposes only the all-or-nothing `ClearCallbacks`, so daemon reconciliation could not remove just the old aggregator's callback.

Cancelling `SessionAggregator.Run` stopped only the periodic flush; the retained callback kept firing `HandleEvent -> Add` into two 10k-key Space-Saving sets that never flush again. A long-lived daemon accumulated O(reconcile-count) live callbacks plus stale never-flushed 20k-key aggregators across ordinary commits — per-event dispatch cost and memory grew without bound, even after reporting was disabled.

## Fix

Mirror the established indirection-callback pattern (#3932 flow-trace writer, #2075 flow exporters):

- Register a **single** stable callback (`aggregationCallback`) on the `EventReader` exactly once via `aggCBOnce`.
- Publish the live `SessionAggregator` through an `atomic.Pointer` (`aggregatorPtr`) the callback reads lock-free.
- Each report-enabled commit only **swaps** the active aggregator; disabling reporting stores `nil` and the stable callback becomes a no-op.
- Retirement nil-s the pointer **before** cancelling the old `Run` goroutine so no in-flight event enters a cancelled aggregator whose flush loop has stopped.
- `aggReconMu` serializes the swap; the write-only `aggregator` field is removed.

## Validation

New `pkg/daemon/aggregator_callback_4964_test.go`:
- 50 report-enabled applies leave `CallbackCount() == 1`.
- enable/disable/re-enable keeps exactly one callback while nil-ing the pointer on disable.

Both assertions fail (CallbackCount grows) when reverted to the per-call `AddCallback` — RED-on-revert verified. `go build ./...`, `go vet ./pkg/daemon`, and the full `pkg/daemon` suite pass. No operator-facing behavior change, so no module doc update needed.

Closes #4964