### PR TITLE
cli: make remote pipe filter case-sensitive to match local

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43961,3 +43961,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4964 stop applyAggregator leaking an append-only EventReader callback + a never-flushed 20k-key SessionAggregator per report-enabled commit. Register one stable indirection callback (aggregationCallback) exactly once via aggCBOnce, publish the live aggregator through an atomic.Pointer (aggregatorPtr), swap-to-nil-before-cancel on retire — mirrors the #3932 TraceWriter / #2075 flowexport pattern. Removed the write-only aggregator field; added aggReconMu.
   **File(s)**: pkg/daemon/daemon.go, pkg/daemon/daemon_system.go, pkg/daemon/aggregator_callback_4964_test.go
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4968 make the remote CLI pipe filter case-SENSITIVE to match the local CLI. Extracted the remote dispatchWithPipe switch into a testable applyPipeFilter() helper and removed the strings.ToLower on both operands for match/grep/except/find so `| match Foo` no longer matches `foo` on remote while missing it on local (Junos `| match` never case-folds). Aligns with pkg/cli.filterStream's bare strings.Contains(line, pipeArg).
+  **File(s)**: cmd/cli/shared.go, cmd/cli/pipe_filter_case_4968_test.go

--- a/cmd/cli/pipe_filter_case_4968_test.go
+++ b/cmd/cli/pipe_filter_case_4968_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestApplyPipeFilterCaseSensitive pins the remote CLI pipe filter to the same
+// case-SENSITIVE semantics as the local CLI's pkg/cli.filterStream. Junos
+// `| match` never case-folds; the earlier remote implementation lowercased both
+// operands, so `| match Foo` matched `foo` on remote but not local (#4968).
+func TestApplyPipeFilterCaseSensitive(t *testing.T) {
+	lines := []string{
+		"Foo matches exactly",
+		"foo lower only",
+		"FOO upper only",
+		"unrelated line",
+	}
+
+	cases := []struct {
+		name     string
+		pipeType string
+		pipeArg  string
+		want     []string
+	}{
+		{
+			name:     "match is case sensitive",
+			pipeType: "match",
+			pipeArg:  "Foo",
+			want:     []string{"Foo matches exactly"},
+		},
+		{
+			name:     "grep alias is case sensitive",
+			pipeType: "grep",
+			pipeArg:  "foo",
+			want:     []string{"foo lower only"},
+		},
+		{
+			name:     "except is case sensitive",
+			pipeType: "except",
+			pipeArg:  "Foo",
+			want:     []string{"foo lower only", "FOO upper only", "unrelated line"},
+		},
+		{
+			name:     "find is case sensitive",
+			pipeType: "find",
+			pipeArg:  "FOO",
+			want:     []string{"FOO upper only", "unrelated line"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf strings.Builder
+			applyPipeFilter(lines, &buf, tc.pipeType, tc.pipeArg)
+			got := splitNonEmptyLines(buf.String())
+			if !equalStringSlices(got, tc.want) {
+				t.Fatalf("applyPipeFilter(%q, %q) = %#v, want %#v",
+					tc.pipeType, tc.pipeArg, got, tc.want)
+			}
+		})
+	}
+}
+
+func splitNonEmptyLines(s string) []string {
+	s = strings.TrimSuffix(s, "\n")
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "\n")
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/cli/shared.go
+++ b/cmd/cli/shared.go
@@ -157,34 +157,44 @@ func (c *ctl) dispatchWithPipe(cmd, pipeType, pipeArg string) error {
 		lines = lines[:len(lines)-1]
 	}
 
+	applyPipeFilter(lines, origStdout, pipeType, pipeArg)
+	return cmdErr
+}
+
+// applyPipeFilter applies a Junos-style output filter (| match/grep/except/find/
+// count/last/no-more) to lines, writing the filtered result to out.
+//
+// match/grep/except/find are CASE-SENSITIVE, matching the local CLI's
+// pkg/cli.filterStream (which uses a bare strings.Contains(line, pipeArg)).
+// Junos `| match` never case-folds, so the remote and local surfaces must
+// agree — the earlier strings.ToLower on both operands made `| match Foo`
+// match `foo` on remote but not local, a silent semantic divergence (#4968).
+func applyPipeFilter(lines []string, out io.Writer, pipeType, pipeArg string) {
 	switch pipeType {
 	case "match", "grep":
-		lp := strings.ToLower(pipeArg)
 		for _, line := range lines {
-			if strings.Contains(strings.ToLower(line), lp) {
-				fmt.Fprintln(origStdout, line)
+			if strings.Contains(line, pipeArg) {
+				fmt.Fprintln(out, line)
 			}
 		}
 	case "except":
-		lp := strings.ToLower(pipeArg)
 		for _, line := range lines {
-			if !strings.Contains(strings.ToLower(line), lp) {
-				fmt.Fprintln(origStdout, line)
+			if !strings.Contains(line, pipeArg) {
+				fmt.Fprintln(out, line)
 			}
 		}
 	case "find":
-		lp := strings.ToLower(pipeArg)
 		found := false
 		for _, line := range lines {
-			if !found && strings.Contains(strings.ToLower(line), lp) {
+			if !found && strings.Contains(line, pipeArg) {
 				found = true
 			}
 			if found {
-				fmt.Fprintln(origStdout, line)
+				fmt.Fprintln(out, line)
 			}
 		}
 	case "count":
-		fmt.Fprintf(origStdout, "Count: %d lines\n", len(lines))
+		fmt.Fprintf(out, "Count: %d lines\n", len(lines))
 	case "last":
 		n := 10
 		if pipeArg != "" {
@@ -197,14 +207,13 @@ func (c *ctl) dispatchWithPipe(cmd, pipeType, pipeArg string) error {
 			start = 0
 		}
 		for _, line := range lines[start:] {
-			fmt.Fprintln(origStdout, line)
+			fmt.Fprintln(out, line)
 		}
 	case "no-more":
 		for _, line := range lines {
-			fmt.Fprintln(origStdout, line)
+			fmt.Fprintln(out, line)
 		}
 	}
-	return cmdErr
 }
 
 func (c *ctl) dispatchOperational(line string) error {


### PR DESCRIPTION
## Problem

The remote CLI's `dispatchWithPipe` (`cmd/cli/shared.go`) lowercased both the input line and the pattern for `| match`/`grep`/`except`/`find`, making the filter **case-insensitive**. The local CLI's `filterStream` (`pkg/cli/cli_dispatch.go`) uses a bare `strings.Contains(line, pipeArg)` — **case-sensitive**.

`show ... | match Foo` matched `foo` on the remote path but not on the local path — a silent semantic divergence. Junos `| match` never implicitly case-folds.

## Fix

Extracted the remote filter switch into a testable `applyPipeFilter` helper and dropped the `strings.ToLower` on both operands for `match`/`grep`/`except`/`find` so the remote path matches the local path byte-for-byte. `count`, `last`, `no-more` are unchanged (they never case-folded).

## Validation

- New `cmd/cli` test `TestApplyPipeFilterCaseSensitive` pins case-sensitive `match`/`grep`/`except`/`find`. It is RED against the prior `ToLower` behavior and GREEN after the fix.
- `go build ./...` clean; gofmt clean.

Scope note: this PR intentionally addresses only the case-sensitivity divergence flagged as the vsrx-parity bug. The `io.ReadAll` whole-stream buffering mentioned in the issue title is a separate memory concern left for a follow-up.

Closes #4968

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi