### PR TITLE
proxy-arp: sweep orphaned NTF_PROXY entries on interface removal

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -43965,3 +43965,7 @@ top.
 - **Timestamp**: 2026-07-09
   **Action**: #4968 make the remote CLI pipe filter case-SENSITIVE to match the local CLI. Extracted the remote dispatchWithPipe switch into a testable applyPipeFilter() helper and removed the strings.ToLower on both operands for match/grep/except/find so `| match Foo` no longer matches `foo` on remote while missing it on local (Junos `| match` never case-folds). Aligns with pkg/cli.filterStream's bare strings.Contains(line, pipeArg).
   **File(s)**: cmd/cli/shared.go, cmd/cli/pipe_filter_case_4968_test.go
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4955 fix orphaned NTF_PROXY proxy-arp neighbor entry on interface/config removal. ReconcileProxyARP now folds a priorIfaceMap (interfaces a prior commit installed proxy-arp on, remembered by the daemon) into its managed listing set, so NTF_PROXY entries on interfaces dropped from the config are listed as stale and NeighDel'd (previously managedSet came only from the current config, orphaning them). The add loop is now best-effort and returns a non-nil enabled set on partial failure instead of nil-ing the daemon's remembered state. Daemon reconcileProxyARP now always drives the dataplane reconcile (even on full removal) with the prior-interface set. Added proxyARPApplyFn seam + priorProxyARPIfaceMap helper.
+  **File(s)**: pkg/dataplane/proxyarp.go, pkg/dataplane/proxyarp_test.go, pkg/dataplane/proxyarp_orphan_4955_test.go, pkg/daemon/daemon_proxyarp.go, pkg/daemon/daemon_proxyarp_orphan_4955_test.go, docs/feature-gaps.md

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -905,6 +905,21 @@ evidence, not as active eBPF source-removal blockers.
   a commit that *removes* a responder and re-install the removed responder from a
   stale pre-commit config snapshot -- it always reconciles the post-commit
   `ActiveConfig` (#4001).
+- Removal teardown (#2475 sysctl + #4955 neighbor entry): a commit that drops an
+  interface (or its last address) from `proxy-arp` tears down BOTH the leaked
+  `proxy_arp`/`proxy_ndp` sysctl AND the installed `NTF_PROXY` neighbor entries.
+  The daemon remembers the last-installed `(iface -> families)` set; on each
+  reconcile it feeds those prior interfaces back into `ReconcileProxyARP` as the
+  `priorIfaceMap`, so the stateless dataplane reconcile lists the removed
+  interfaces, finds their `NTF_PROXY` entries absent from the desired set, and
+  `NeighDel`s them (#4955) before disabling the sysctl (#2475). Full removal
+  (config now has zero entries) still runs the reconcile for exactly this sweep.
+  Without it the neighbor entry was orphaned in the kernel and kept answering ARP
+  for the retired IPv4 via the route-topology-dependent pneigh branch until a
+  link reset/reboot -- attracting traffic to an obsolete translation or a
+  reassigned VIP. The add path is also best-effort: a mid-add `NeighSet` failure
+  no longer nils out the remembered set, so a later removal can still tear down
+  what was installed.
 - Breadth tradeoff (IPv4): with the default `medium_id=0`, `proxy_arp=1` makes the
   kernel answer ARP on that interface for ANY target routed out a different
   interface -- broader than Junos `proxy-arp`, which proxies only the listed

--- a/pkg/daemon/daemon_proxyarp.go
+++ b/pkg/daemon/daemon_proxyarp.go
@@ -34,6 +34,12 @@ var proxyARPReconcileFn = (*Daemon).reconcileProxyARP
 // procfs; production wiring is dataplane.DisableProxyResponders.
 var proxyARPDisableFn = dataplane.DisableProxyResponders
 
+// proxyARPApplyFn is the dataplane reconcile the daemon drives each commit. It
+// is a package var so the #4955 test can assert the daemon feeds the
+// prior-interface set through to the NTF_PROXY sweep without touching netlink;
+// production wiring is dataplane.ReconcileProxyARP.
+var proxyARPApplyFn = dataplane.ReconcileProxyARP
+
 // ifaceIndexByName resolves a Linux interface name to its kernel ifindex. It
 // is a package var so the RETH-resolution unit test can drive
 // proxyARPIfaceMap without real interfaces; production wiring is
@@ -79,6 +85,26 @@ func proxyARPIfaceMap(cfg *config.Config) map[string]int {
 	return ifaceMap
 }
 
+// priorProxyARPIfaceMap resolves the interfaces proxy-arp was installed on by a
+// PRIOR commit — the Linux netdev names remembered in d.proxyARPEnabled (which
+// ReconcileProxyARP keys by link.Attrs().Name) — to their current kernel
+// ifindexes. The dataplane reconcile folds these into its managed listing set
+// so it sweeps orphaned NTF_PROXY neighbor entries off interfaces that have
+// since dropped out of the config (#4955). A name that no longer resolves (its
+// netdev was deleted) is skipped: its neighbor entries went away with the
+// netdev, so there is nothing left to sweep.
+func priorProxyARPIfaceMap(priorNames []string) map[string]int {
+	m := make(map[string]int, len(priorNames))
+	for _, name := range priorNames {
+		idx, err := ifaceIndexByName(name)
+		if err != nil {
+			continue
+		}
+		m[name] = idx
+	}
+	return m
+}
+
 // reconcileProxyARP reconciles the kernel proxy-ARP/NDP responder state
 // (NTF_PROXY neighbor entries + the per-interface proxy_arp/proxy_ndp sysctls)
 // for the configured `security nat proxy-arp` addresses. It is a no-op when no
@@ -98,33 +124,44 @@ func proxyARPIfaceMap(cfg *config.Config) map[string]int {
 // via cfg.ResolveKernelIfName; losing it would re-break proxy-arp on RETH or
 // VLAN-tagged interfaces.
 func (d *Daemon) reconcileProxyARP(cfg *config.Config) {
-	// #2475: a commit that REMOVES proxy-arp (cfg now has zero entries) must
-	// still run so the disable-on-removal pass below can drive the leaked
-	// sysctl back to 0 on the interfaces a prior commit enabled. Only skip the
+	// #2475/#4955: a commit that REMOVES proxy-arp (cfg now has zero entries)
+	// must still run so the reconcile can (a) drive the leaked proxy_arp /
+	// proxy_ndp sysctl back to 0 and (b) NeighDel the orphaned NTF_PROXY
+	// entries on the interfaces a prior commit installed them on. Only skip the
 	// expensive netlink reconcile + iface resolution when there is also nothing
 	// to tear down, preserving the "no-op on configs that never use proxy-arp"
 	// property the always-on loop relies on.
 	hasEntries := cfg != nil && len(cfg.Security.NAT.ProxyARP) > 0
-	if !hasEntries {
-		d.proxyARPEnabledMu.Lock()
-		hadPrior := len(d.proxyARPEnabled) > 0
-		d.proxyARPEnabledMu.Unlock()
-		if !hadPrior {
-			return
-		}
+
+	// Snapshot the interfaces a prior commit installed proxy-arp on so the
+	// stateless dataplane reconcile can sweep entries that dropped out of the
+	// config (#4955). Keys are Linux netdev names (ReconcileProxyARP keys its
+	// enabled set by link.Attrs().Name), so they resolve directly via
+	// ifaceIndexByName without cfg.ResolveKernelIfName.
+	d.proxyARPEnabledMu.Lock()
+	priorNames := make([]string, 0, len(d.proxyARPEnabled))
+	for iface := range d.proxyARPEnabled {
+		priorNames = append(priorNames, iface)
+	}
+	d.proxyARPEnabledMu.Unlock()
+
+	if !hasEntries && len(priorNames) == 0 {
+		return
 	}
 
-	var (
-		added   []dataplane.ProxyARPAdded
-		enabled map[string]map[int]struct{}
-		err     error
-	)
+	priorIfaceMap := priorProxyARPIfaceMap(priorNames)
+	ifaceMap := map[string]int{}
 	if hasEntries {
-		ifaceMap := proxyARPIfaceMap(cfg)
-		added, enabled, err = dataplane.ReconcileProxyARP(cfg, ifaceMap)
-		if err != nil {
-			slog.Warn("failed to reconcile proxy ARP", "err", err)
-		}
+		ifaceMap = proxyARPIfaceMap(cfg)
+	}
+
+	// Always run the reconcile: even with zero configured entries it sweeps the
+	// orphaned NTF_PROXY entries on the prior interfaces (desired is empty
+	// there, so every entry found is stale and deleted) and returns a non-nil
+	// enabled set so the diff below tears down the sysctl.
+	added, enabled, err := proxyARPApplyFn(cfg, ifaceMap, priorIfaceMap)
+	if err != nil {
+		slog.Warn("failed to reconcile proxy ARP", "err", err)
 	}
 
 	// #2475 teardown: disable the per-interface proxy responder sysctl on every

--- a/pkg/daemon/daemon_proxyarp_orphan_4955_test.go
+++ b/pkg/daemon/daemon_proxyarp_orphan_4955_test.go
@@ -1,0 +1,70 @@
+package daemon
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// TestReconcileProxyARP_SweepsPriorInterface is the #4955 daemon-side
+// fail-on-revert: when a commit REMOVES proxy-arp, the daemon must still drive
+// the dataplane reconcile and feed it the interfaces a prior commit installed
+// proxy-arp on, so their orphaned NTF_PROXY entries get swept. Before the fix
+// the daemon skipped the dataplane reconcile entirely on full removal (it ran
+// only the #2475 sysctl teardown), so the neighbor entries were never deleted.
+//
+// The dataplane reconcile is stubbed through the proxyARPApplyFn seam so the
+// test asserts the prior-interface set is passed through without needing
+// netlink. Fail-on-revert: the pre-fix daemon never calls proxyARPApplyFn on
+// full removal, so gotPrior stays nil and the ge-0-0-1→11 assertion fails.
+func TestReconcileProxyARP_SweepsPriorInterface(t *testing.T) {
+	withFakeIfaceResolver(t, map[string]int{"ge-0-0-1": 11})
+
+	var applyCalled bool
+	var gotPrior map[string]int
+	prevApply := proxyARPApplyFn
+	proxyARPApplyFn = func(_ *config.Config, _, priorIfaceMap map[string]int) ([]dataplane.ProxyARPAdded, map[string]map[int]struct{}, error) {
+		applyCalled = true
+		gotPrior = priorIfaceMap
+		return nil, map[string]map[int]struct{}{}, nil
+	}
+	t.Cleanup(func() { proxyARPApplyFn = prevApply })
+
+	prevDisable := proxyARPDisableFn
+	proxyARPDisableFn = func(_ map[string]map[int]struct{}) int { return 0 }
+	t.Cleanup(func() { proxyARPDisableFn = prevDisable })
+
+	d := &Daemon{}
+	// A prior commit installed proxy-arp on ge-0-0-1 (Linux netdev name key,
+	// as ReconcileProxyARP records via link.Attrs().Name).
+	d.proxyARPEnabled = map[string]map[int]struct{}{
+		"ge-0-0-1": {unix.AF_INET: {}},
+	}
+
+	// New commit removes proxy-arp entirely.
+	d.reconcileProxyARP(&config.Config{})
+
+	if !applyCalled {
+		t.Fatal("reconcileProxyARP did not drive the dataplane reconcile on full " +
+			"removal — orphaned NTF_PROXY entries never swept (#4955)")
+	}
+	if gotPrior["ge-0-0-1"] != 11 {
+		t.Fatalf("reconcile passed priorIfaceMap = %v, want ge-0-0-1→11 so the "+
+			"orphaned NTF_PROXY entry on the removed interface is swept", gotPrior)
+	}
+}
+
+// TestPriorProxyARPIfaceMap resolves prior Linux netdev names to ifindexes and
+// skips names whose netdev no longer exists (nothing left to sweep there).
+func TestPriorProxyARPIfaceMap(t *testing.T) {
+	withFakeIfaceResolver(t, map[string]int{"ge-0-0-1": 11, "ge-0-0-2": 22})
+
+	got := priorProxyARPIfaceMap([]string{"ge-0-0-1", "ge-0-0-2", "ge-0-0-gone"})
+	if len(got) != 2 || got["ge-0-0-1"] != 11 || got["ge-0-0-2"] != 22 {
+		t.Fatalf("priorProxyARPIfaceMap = %v, want {ge-0-0-1:11, ge-0-0-2:22} "+
+			"(unresolvable name skipped)", got)
+	}
+}

--- a/pkg/dataplane/proxyarp.go
+++ b/pkg/dataplane/proxyarp.go
@@ -182,7 +182,23 @@ func toggleProxyResponders(ifaceFamilies map[string]map[int]struct{}, enable boo
 //     cleanup. ReconcileProxyARP itself is stateless across calls (it only
 //     sees the current config), so the enabled set is the seam the stateful
 //     disable-on-removal is built on.
-func ReconcileProxyARP(cfg *config.Config, ifaceMap map[string]int) ([]ProxyARPAdded, map[string]map[int]struct{}, error) {
+//
+// priorIfaceMap is the (interface name → ifindex) set that proxy-arp was
+// installed on by a PRIOR commit (the daemon's remembered state). Its
+// ifindexes are folded into the managed listing set so NTF_PROXY neighbor
+// entries are also swept off interfaces that have since dropped out of the
+// config: without this the entries are orphaned in the kernel and keep
+// answering ARP/NDP for the removed target (#4955, distinct from the #2475
+// sysctl-only teardown). Because such interfaces are absent from the desired
+// set, every NTF_PROXY entry found on them is stale and NeighDel'd. Pass nil
+// when there is no prior state to sweep.
+//
+// On a partial NeighSet failure the add loop is best-effort (logs and
+// continues) and still returns the computed enabled set plus the first error,
+// rather than aborting with a nil enabled set — otherwise the daemon would
+// forget the interfaces it just tried to manage and never tear them down
+// (#4955 secondary).
+func ReconcileProxyARP(cfg *config.Config, ifaceMap, priorIfaceMap map[string]int) ([]ProxyARPAdded, map[string]map[int]struct{}, error) {
 	type proxyKey struct {
 		ifindex int
 		ip      netip.Addr
@@ -213,7 +229,11 @@ func ReconcileProxyARP(cfg *config.Config, ifaceMap map[string]int) ([]ProxyARPA
 		fams[family] = struct{}{}
 	}
 
-	for _, entry := range cfg.Security.NAT.ProxyARP {
+	var cfgEntries []*config.ProxyARPEntry
+	if cfg != nil {
+		cfgEntries = cfg.Security.NAT.ProxyARP
+	}
+	for _, entry := range cfgEntries {
 		ifindex, ok := ifaceMap[entry.Interface]
 		if !ok {
 			slog.Warn("proxy-arp: interface not found", "iface", entry.Interface)
@@ -251,6 +271,13 @@ func ReconcileProxyARP(cfg *config.Config, ifaceMap map[string]int) ([]ProxyARPA
 	existing := make(map[proxyKey]struct{})
 	managedSet := make(map[int]bool)
 	for _, idx := range managedIfindexes {
+		managedSet[idx] = true
+	}
+	// #4955: also list interfaces that a PRIOR commit installed proxy-arp on
+	// but that have since dropped out of the config. They contribute no desired
+	// entries, so any NTF_PROXY entry still on them is stale and swept below —
+	// closing the orphan where a removed interface kept answering ARP/NDP.
+	for _, idx := range priorIfaceMap {
 		managedSet[idx] = true
 	}
 
@@ -306,7 +333,16 @@ func ReconcileProxyARP(cfg *config.Config, ifaceMap map[string]int) ([]ProxyARPA
 
 	// Add missing entries (family derived from the key — v4 and v6 share the
 	// same NTF_PROXY install path; #2197 item 1).
+	//
+	// #4955: the add loop is best-effort. A NeighSet failure is logged and the
+	// remaining installs still proceed, and the function returns the computed
+	// enabled set (below) plus the first error instead of bailing out with a
+	// nil enabled set. Aborting here previously made the daemon overwrite its
+	// remembered state with nil, so it forgot every interface it had managed
+	// and never disabled the sysctl or swept the neighbor entries on a later
+	// removal.
 	var added []ProxyARPAdded
+	var addErr error
 	for key := range desired {
 		if _, ok := existing[key]; ok {
 			continue
@@ -319,7 +355,12 @@ func ReconcileProxyARP(cfg *config.Config, ifaceMap map[string]int) ([]ProxyARPA
 			Family:    family,
 		}
 		if err := neighSetSeam(neigh); err != nil {
-			return nil, nil, fmt.Errorf("proxy-arp: add %s on ifindex %d: %w", key.ip, key.ifindex, err)
+			slog.Warn("proxy-arp: failed to add entry",
+				"ip", key.ip, "ifindex", key.ifindex, "err", err)
+			if addErr == nil {
+				addErr = fmt.Errorf("proxy-arp: add %s on ifindex %d: %w", key.ip, key.ifindex, err)
+			}
+			continue
 		}
 		ifaceName := ""
 		if link, err := netlink.LinkByIndex(key.ifindex); err == nil {
@@ -376,7 +417,7 @@ func ReconcileProxyARP(cfg *config.Config, ifaceMap map[string]int) ([]ProxyARPA
 		slog.Info("proxy-arp reconciled", "added", len(added), "removed", removed)
 	}
 
-	return added, ifaceFamilies, nil
+	return added, ifaceFamilies, addErr
 }
 
 // DisableProxyResponders writes "0" to the per-interface proxy responder

--- a/pkg/dataplane/proxyarp_orphan_4955_test.go
+++ b/pkg/dataplane/proxyarp_orphan_4955_test.go
@@ -1,0 +1,95 @@
+package dataplane
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// TestReconcileProxyARP_SweepsRemovedInterface is the #4955 fail-on-revert
+// anchor: an NTF_PROXY neighbor entry on an interface that a PRIOR commit
+// installed proxy-arp on, but that has since dropped out of the config, must be
+// NeighDel'd. Before the fix ReconcileProxyARP built its managed listing set
+// exclusively from the current config, so a removed interface's ifindex was
+// never listed and its NTF_PROXY entry was orphaned — the kernel kept answering
+// ARP for the retired target. Feeding the prior interface set in through
+// priorIfaceMap makes the reconcile list it, find the entry stale (nothing in
+// the config wants it), and delete it.
+//
+// Fail-on-revert: dropping the priorIfaceMap→managedSet fold makes managedSet
+// empty (the config has no entries), so nothing is listed and no NeighDel
+// fires — failing the "want 1 NeighDel" assertion.
+func TestReconcileProxyARP_SweepsRemovedInterface(t *testing.T) {
+	const removedIdx = 200
+	orphan := net.ParseIP("10.0.2.50").To4()
+	existing := []netlink.Neigh{{
+		LinkIndex: removedIdx,
+		IP:        orphan,
+		Flags:     unix.NTF_PROXY,
+		Family:    unix.AF_INET,
+	}}
+	_, dels := captureNeigh(t, existing)
+	captureProxySysctl(t, false)
+
+	// Current config has NO proxy-arp entries — the interface (and its address)
+	// was fully removed. The daemon still remembers it installed proxy-arp on
+	// ge-0-0-1 last commit, and passes that through as priorIfaceMap.
+	cfg := &config.Config{}
+	priorIfaceMap := map[string]int{"ge-0-0-1": removedIdx}
+
+	_, _, err := ReconcileProxyARP(cfg, map[string]int{}, priorIfaceMap)
+	if err != nil {
+		t.Fatalf("ReconcileProxyARP: %v", err)
+	}
+
+	if len(*dels) != 1 {
+		t.Fatalf("got %d NeighDel calls, want 1 (orphaned NTF_PROXY sweep): %+v", len(*dels), *dels)
+	}
+	d := (*dels)[0]
+	if d.LinkIndex != removedIdx || d.Family != unix.AF_INET || !d.IP.Equal(orphan) {
+		t.Fatalf("NeighDel = {ifindex %d, family %d, ip %v}, want {%d, AF_INET, %v}",
+			d.LinkIndex, d.Family, d.IP, removedIdx, orphan)
+	}
+	if d.Flags&unix.NTF_PROXY == 0 {
+		t.Fatalf("NeighDel flags = %#x, missing NTF_PROXY", d.Flags)
+	}
+}
+
+// TestReconcileProxyARP_PartialAddKeepsEnabledSet guards the #4955 secondary
+// bug: a NeighSet failure mid-add must NOT abort with a nil enabled set. The
+// daemon overwrites its remembered proxy-arp state with the returned enabled
+// set every reconcile; a nil return wiped it, so the daemon forgot every
+// interface it had managed and never tore down the sysctl or swept the neighbor
+// entries on a later removal. The add loop is now best-effort — it logs the
+// failure, keeps going, and returns the computed (non-nil) enabled set plus the
+// first error.
+//
+// Fail-on-revert: restoring the `return nil, nil, err` fast-path makes the
+// enabled return nil, failing the non-nil assertion.
+func TestReconcileProxyARP_PartialAddKeepsEnabledSet(t *testing.T) {
+	prevList, prevSet, prevDel := neighListSeam, neighSetSeam, neighDelSeam
+	neighListSeam = func(_, _ int) ([]netlink.Neigh, error) { return nil, nil }
+	neighSetSeam = func(_ *netlink.Neigh) error { return errors.New("simulated netlink failure") }
+	neighDelSeam = func(_ *netlink.Neigh) error { return nil }
+	t.Cleanup(func() { neighListSeam, neighSetSeam, neighDelSeam = prevList, prevSet, prevDel })
+	captureProxySysctl(t, false)
+
+	cfg := &config.Config{}
+	cfg.Security.NAT.ProxyARP = []*config.ProxyARPEntry{
+		{Interface: "ge-0-0-2", Addresses: []string{"10.0.2.50/32"}},
+	}
+	ifaceMap := map[string]int{"ge-0-0-2": 7}
+
+	_, enabled, err := ReconcileProxyARP(cfg, ifaceMap, nil)
+	if err == nil {
+		t.Fatalf("want the NeighSet failure surfaced as an error, got nil")
+	}
+	if enabled == nil {
+		t.Fatalf("enabled set is nil after a partial add failure — the daemon's " +
+			"remembered proxy-arp state would be wiped (#4955 secondary)")
+	}
+}

--- a/pkg/dataplane/proxyarp_test.go
+++ b/pkg/dataplane/proxyarp_test.go
@@ -216,7 +216,7 @@ func TestReconcileProxyARP_V6InstallsPneigh(t *testing.T) {
 	}
 	ifaceMap := map[string]int{"ge-0-0-2": idx}
 
-	added, _, err := ReconcileProxyARP(cfg, ifaceMap)
+	added, _, err := ReconcileProxyARP(cfg, ifaceMap, nil)
 	if err != nil {
 		t.Fatalf("ReconcileProxyARP: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestReconcileProxyARP_V6StaleRemoval(t *testing.T) {
 	}
 	ifaceMap := map[string]int{"ge-0-0-2": idx}
 
-	if _, _, err := ReconcileProxyARP(cfg, ifaceMap); err != nil {
+	if _, _, err := ReconcileProxyARP(cfg, ifaceMap, nil); err != nil {
 		t.Fatalf("ReconcileProxyARP: %v", err)
 	}
 
@@ -309,7 +309,7 @@ func TestReconcileProxyARP_V4MappedClassifiesAsV4(t *testing.T) {
 	}
 	ifaceMap := map[string]int{"ge-0-0-2": 7}
 
-	if _, _, err := ReconcileProxyARP(cfg, ifaceMap); err != nil {
+	if _, _, err := ReconcileProxyARP(cfg, ifaceMap, nil); err != nil {
 		t.Fatalf("ReconcileProxyARP: %v", err)
 	}
 	if len(*sets) != 1 {
@@ -342,7 +342,7 @@ func TestReconcileProxyARP_V6Idempotent(t *testing.T) {
 	}
 	ifaceMap := map[string]int{"ge-0-0-2": idx}
 
-	if _, _, err := ReconcileProxyARP(cfg, ifaceMap); err != nil {
+	if _, _, err := ReconcileProxyARP(cfg, ifaceMap, nil); err != nil {
 		t.Fatalf("ReconcileProxyARP: %v", err)
 	}
 	if len(*sets) != 0 {
@@ -380,7 +380,7 @@ func TestReconcileProxyARP_EnablesSysctl(t *testing.T) {
 	// install inside ReconcileProxyARP, so if the install errors we cannot
 	// reach the sysctl step — skip rather than false-fail in an unprivileged
 	// sandbox.
-	if _, _, err := ReconcileProxyARP(cfg, ifaceMap); err != nil {
+	if _, _, err := ReconcileProxyARP(cfg, ifaceMap, nil); err != nil {
 		t.Skipf("ReconcileProxyARP needs privileges in this env: %v", err)
 	}
 	// Clean up the NTF_PROXY neighbor entry this test installed on lo so the
@@ -428,7 +428,7 @@ func TestReconcileProxyARP_V6InstallsPneighLive(t *testing.T) {
 	}
 	ifaceMap := map[string]int{"lo": lo.Index}
 
-	if _, _, err := ReconcileProxyARP(cfg, ifaceMap); err != nil {
+	if _, _, err := ReconcileProxyARP(cfg, ifaceMap, nil); err != nil {
 		t.Skipf("ReconcileProxyARP needs privileges in this env: %v", err)
 	}
 	t.Cleanup(func() {


### PR DESCRIPTION
## Problem

When an interface (or its last address) was dropped from `security nat proxy-arp`, its installed `NTF_PROXY` neighbor entry was never `NeighDel`'d — orphaned in the kernel, so proxy-ARP kept answering for the retired IPv4 via the route-topology-dependent pneigh branch until a link reset/reboot. That attracts traffic to an obsolete NAT translation or a reassigned VIP. Distinct from #2475 (sysctl-only teardown) and #2197 (v6 install).

Root cause: `ReconcileProxyARP` (`pkg/dataplane/proxyarp.go`) built its managed listing set exclusively from the current config, so a removed interface was never listed. And the daemon skipped the dataplane reconcile entirely on full removal.

## Fix

- Thread a `priorIfaceMap` (interface → ifindex, from the daemon's remembered state) into `ReconcileProxyARP`; its ifindexes are folded into the managed listing set, so the reconcile lists the removed interfaces, finds their `NTF_PROXY` entries absent from the desired set, and `NeighDel`s them.
- The daemon snapshots the prior interface set, resolves it via `priorProxyARPIfaceMap`, and now **always** drives the reconcile when prior state exists — including full removal — so the sweep runs. A `proxyARPApplyFn` seam makes it testable without netlink.
- Secondary: the add loop is now best-effort and returns a non-nil enabled set on partial `NeighSet` failure instead of `nil, nil, err` — the old behavior wiped the daemon's remembered state and stranded future teardown.
- `ReconcileProxyARP` is now nil-cfg-safe.

## Validation

- `TestReconcileProxyARP_SweepsRemovedInterface` (dataplane): orphaned entry is `NeighDel`'d via faked netlink seams — RED when the `priorIfaceMap` fold is removed.
- `TestReconcileProxyARP_PartialAddKeepsEnabledSet` (dataplane): non-nil enabled set on add failure — RED against the old `return nil, nil, err`.
- `TestReconcileProxyARP_SweepsPriorInterface` (daemon): daemon drives the reconcile with the prior set on full removal — RED against the pre-fix skip.
- Existing proxy-arp tests updated for the new signature and still green. `go test ./pkg/dataplane/... ./pkg/daemon/...` green; `go build ./...` clean; gofmt clean. `docs/feature-gaps.md` updated.

Closes #4955

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi