### PR TITLE
cmd/xpfd: skip publish GC when journal protection is unknown

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,22 @@
+## 2026-07-09 — #4876 cmd/xpfd: publish-generation ran destructive staged-generation GC even when the journal protection set was unreadable
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4876 (upgrade / fail-open). `xpfd publish-generation` read
+  the upgrade journal to protect a crashed/resumable cut's pinned source
+  generation from its GC, but on a journal read error only WARNed and ran
+  GC anyway with an empty protection set; a present-but-malformed journal
+  degraded to ("",nil), same result. A crash-after-STOP cut whose journal
+  became unreadable could have its pinned source reaped, bricking the
+  resume. Fix: `ReadJournalSourceGeneration` now errors on a
+  present-but-malformed journal (absent still returns ("",nil)); the verb
+  routes through a new `gcProtectionForPublish` helper that SKIPS GC when
+  the protection set is unknown (read error / malformed). Added
+  fail-on-revert tests at both the reader and caller level.
+  **File(s)**: pkg/upgrade/runner.go,
+  pkg/upgrade/read_journal_malformed_4876_test.go,
+  cmd/xpfd/publish_generation.go,
+  cmd/xpfd/publish_generation_gc_4876_test.go, docs/in-place-upgrade.md
+
 ## 2026-07-09 — #4882 userspace-dp: debug BPF session dump used `core::ptr::read` (align 2) on a `Vec<u8>` (align 1) — UB; use `read_unaligned`
 
 - **Timestamp**: 2026-07-09

--- a/cmd/xpfd/publish_generation.go
+++ b/cmd/xpfd/publish_generation.go
@@ -74,16 +74,45 @@ func runPublishGenerationSubcommand(args []string) {
 	// durable journal with the lock released — so the GC must read the journal
 	// and protect its SourceGeneration, else a resume hard-fails on a GC'd
 	// source (and a crash-after-STOP would be left daemon-down with no
-	// recoverable cut). Best-effort: a journal read error does not block the
-	// publish (the cut's own GC also protects its source).
-	protected := map[string]bool{}
-	if pinned, jerr := upgrade.ReadJournalSourceGeneration(*journalPath); jerr != nil {
-		fmt.Fprintf(os.Stderr, "publish-generation: WARN read journal for GC protection: %v\n", jerr)
-	} else if pinned != "" {
-		protected[pinned] = true
+	// recoverable cut).
+	//
+	// The protection set MUST be known before running destructive GC (#4876):
+	// if the journal is present but unreadable (I/O error) or malformed, we
+	// cannot see which generation a crashed cut pins, so GC is SKIPPED rather
+	// than run with an empty protection set that could reap the pinned source.
+	// Skipping is safe — the extra staged generations are harmless and the
+	// next publish with a readable journal reclaims them.
+	protected, runGC, warn := gcProtectionForPublish(*journalPath)
+	if warn != "" {
+		fmt.Fprintf(os.Stderr, "publish-generation: WARN %s\n", warn)
 	}
-	if gcErr := cfg.GC(protected); gcErr != nil {
-		fmt.Fprintf(os.Stderr, "publish-generation: WARN gc: %v\n", gcErr)
+	if runGC {
+		if gcErr := cfg.GC(protected); gcErr != nil {
+			fmt.Fprintf(os.Stderr, "publish-generation: WARN gc: %v\n", gcErr)
+		}
 	}
 	fmt.Printf("publish-generation complete (generation %s)\n", genid)
+}
+
+// gcProtectionForPublish computes the staged-generation GC protection set for
+// publish-generation and reports whether destructive GC may proceed.
+//
+// It reads the upgrade journal's pinned source generation. An absent or
+// legacy (no-pin) journal is genuinely unprotected: GC proceeds (runGC=true)
+// with the resolved protection set. A journal that is PRESENT but unreadable
+// (I/O error) or malformed makes the protection set UNKNOWN — GC MUST be
+// skipped (runGC=false) so a crashed/resumable cut's pinned source is never
+// reaped and the resume bricked (#4876). warn is a non-empty operator message
+// on the skip path, empty otherwise.
+func gcProtectionForPublish(journalPath string) (protected map[string]bool, runGC bool, warn string) {
+	protected = map[string]bool{}
+	pinned, err := upgrade.ReadJournalSourceGeneration(journalPath)
+	if err != nil {
+		return protected, false, fmt.Sprintf(
+			"read journal for GC protection: %v; skipping GC to avoid reaping a pinned generation", err)
+	}
+	if pinned != "" {
+		protected[pinned] = true
+	}
+	return protected, true, ""
 }

--- a/cmd/xpfd/publish_generation_gc_4876_test.go
+++ b/cmd/xpfd/publish_generation_gc_4876_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestGCProtectionForPublish_4876 pins the fail-closed GC-protection gate the
+// publish-generation verb uses. A crashed/resumable cut leaves a durable
+// journal pinning its source generation; if publish-generation cannot read
+// that pin, running destructive GC with an empty protection set can reap the
+// pinned source and brick the resume. The gate must therefore SKIP GC whenever
+// the protection set is unknown (present-but-unreadable / malformed journal)
+// and only run it when the journal is absent or successfully read.
+func TestGCProtectionForPublish_4876(t *testing.T) {
+	dir := t.TempDir()
+
+	// Absent journal: genuinely unprotected -> GC proceeds, empty protection.
+	absent := filepath.Join(dir, "absent-journal.json")
+	protected, runGC, warn := gcProtectionForPublish(absent)
+	if !runGC {
+		t.Fatalf("absent journal: runGC=false, want true (no crashed cut to protect)")
+	}
+	if len(protected) != 0 {
+		t.Fatalf("absent journal: protected=%v, want empty", protected)
+	}
+	if warn != "" {
+		t.Fatalf("absent journal: warn=%q, want empty", warn)
+	}
+
+	// Well-formed journal pinning a generation: GC proceeds AND protects it.
+	pinned := filepath.Join(dir, "pinned-journal.json")
+	if err := os.WriteFile(pinned, []byte(`{"target_version":"2.0.0","state":"copied","source_generation":"g0-deadbeef"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	protected, runGC, warn = gcProtectionForPublish(pinned)
+	if !runGC {
+		t.Fatalf("pinned journal: runGC=false, want true")
+	}
+	if !protected["g0-deadbeef"] {
+		t.Fatalf("pinned journal: protected=%v, want g0-deadbeef protected", protected)
+	}
+	if warn != "" {
+		t.Fatalf("pinned journal: warn=%q, want empty", warn)
+	}
+
+	// Legacy well-formed journal with no pin: GC proceeds, nothing to protect.
+	legacy := filepath.Join(dir, "legacy-journal.json")
+	if err := os.WriteFile(legacy, []byte(`{"target_version":"2.0.0","state":"copied"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	protected, runGC, _ = gcProtectionForPublish(legacy)
+	if !runGC || len(protected) != 0 {
+		t.Fatalf("legacy journal: (runGC=%v, protected=%v), want (true, empty)", runGC, protected)
+	}
+
+	// Present-but-malformed journal: protection UNKNOWN -> GC MUST be skipped.
+	// This is the #4876 fail-closed guard. Before the fix, a malformed journal
+	// degraded to ("",nil) and GC ran with an empty protection set.
+	malformed := filepath.Join(dir, "malformed-journal.json")
+	if err := os.WriteFile(malformed, []byte(`{not valid json`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, runGC, warn = gcProtectionForPublish(malformed)
+	if runGC {
+		t.Fatalf("malformed journal: runGC=true, want false — destructive GC must be skipped when protection is unknown")
+	}
+	if warn == "" {
+		t.Fatalf("malformed journal: warn empty, want a non-empty operator message on the GC-skip path")
+	}
+}

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -499,7 +499,14 @@ window for ALL FOUR managed binaries:
   and `current-gen` is never reaped even if it is not the newest by name
   or mtimes are perturbed). It ignores (never counts, never deletes) any
   directory whose name is not a valid `genid`, and sweeps `.partial`
-  orphans.
+  orphans. **Fail-closed protection (#4876):** the publish's GC runs ONLY
+  when the journal protection set is known. A crashed cut leaves a durable
+  journal pinning its source generation with the host lock released; if
+  that journal is present but cannot be read (I/O error) or is malformed,
+  the pinned generation is UNKNOWN, so publish-generation SKIPS the GC
+  rather than run it with an empty protection set and reap the crashed
+  cut's source (which would leave the resume unrecoverable). An absent
+  journal means no crashed cut, so GC proceeds normally.
 - **Same-version replacement (B-P3b OPT1).** `versions/<ver>` carries a
   `.srcgen` stamp; the copy-skip is generation-aware. A same-version
   re-stage with NEW bytes (a new generation) RE-COPIES a stale, non-live

--- a/pkg/upgrade/read_journal_malformed_4876_test.go
+++ b/pkg/upgrade/read_journal_malformed_4876_test.go
@@ -1,0 +1,38 @@
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReadJournalSourceGenerationMalformedErrors_4876 pins the fail-closed
+// contract for a PRESENT-but-malformed upgrade journal. A corrupted/truncated
+// journal cannot name the generation a crashed cut pins, so it MUST surface an
+// error (not degrade to ("",nil)) — otherwise the destructive publish GC would
+// run with an empty protection set and could reap the pinned source (#4876).
+func TestReadJournalSourceGenerationMalformedErrors_4876(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "journal.json")
+
+	// Absent journal is NOT an error (nothing to protect).
+	if g, err := ReadJournalSourceGeneration(path); err != nil || g != "" {
+		t.Fatalf("absent journal: got (%q,%v), want (\"\",nil)", g, err)
+	}
+
+	// Present but unparseable: must error so the caller fails closed.
+	if err := os.WriteFile(path, []byte(`{"source_generation": "g0-abc"`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if g, err := ReadJournalSourceGeneration(path); err == nil {
+		t.Fatalf("malformed journal: got (%q,nil), want a non-nil error (fail closed)", g)
+	}
+
+	// Well-formed journal still returns its pin with no error.
+	if err := os.WriteFile(path, []byte(`{"source_generation":"g0-abc"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if g, err := ReadJournalSourceGeneration(path); err != nil || g != "g0-abc" {
+		t.Fatalf("well-formed journal: got (%q,%v), want (g0-abc,nil)", g, err)
+	}
+}

--- a/pkg/upgrade/runner.go
+++ b/pkg/upgrade/runner.go
@@ -263,18 +263,20 @@ func (r *Runner) saveJournal(j *Journal) error {
 }
 
 // ReadJournalSourceGeneration returns the SourceGeneration recorded in the
-// upgrade journal at path, or "" if the journal is absent, unparsable, or has
-// no pinned generation. It is used by `xpfd publish-generation` to PROTECT a
+// upgrade journal at path, or "" if the journal is absent or has no pinned
+// generation. It is used by `xpfd publish-generation` to PROTECT a
 // crashed/resumable cut's pinned generation from the publish GC (the journal
 // is durable; the host-wide lock that would otherwise serialize the cut is NOT
 // held across a crash).
 //
-// Both a missing journal AND a malformed (unparsable) one return ("", nil): a
-// journal that does not parse cannot name a genid to protect, and this is a
-// best-effort GC-protection seam (the cut's own gc(j) protects its source from
-// the authoritative in-memory journal). Only a genuine READ error (I/O,
-// permission) surfaces — that is worth logging, and the caller treats it as
-// "no protection" without failing the publish. The returned genid is only ever
+// An ABSENT journal returns ("", nil): there is no crashed cut to protect, so
+// the caller may GC freely. A journal that is PRESENT but cannot be read (I/O,
+// permission) OR cannot be parsed (malformed/truncated) returns a non-nil
+// error: the protection set is UNKNOWN, and the destructive publish GC MUST
+// fail closed (skip GC) rather than proceed with an empty protection set and
+// reap the pinned source generation of a crash-after-STOP cut, which would
+// leave the upgrade unrecoverable / daemon-down (#4876). A well-formed journal
+// returns its SourceGeneration (possibly ""). The returned genid is only ever
 // used as a GC-protection key, never as a path, so the caller need not
 // validate it.
 func ReadJournalSourceGeneration(path string) (string, error) {
@@ -287,10 +289,13 @@ func ReadJournalSourceGeneration(path string) (string, error) {
 	}
 	j := &Journal{}
 	if uerr := json.Unmarshal(data, j); uerr != nil {
-		// A malformed journal names no genid to protect; degrade to "no
-		// protection" rather than surfacing an error a best-effort caller would
-		// only log-and-ignore.
-		return "", nil
+		// A present-but-malformed journal must NOT be silently treated as "no
+		// protection" (#4876): a crashed/resumable cut may have pinned a source
+		// generation this corrupted/truncated journal can no longer name.
+		// Surface it as an error so the destructive publish-generation GC fails
+		// closed (skips GC) instead of reaping a pinned generation and bricking
+		// the resume.
+		return "", fmt.Errorf("parse upgrade journal %s: %w", path, uerr)
 	}
 	return j.SourceGeneration, nil
 }


### PR DESCRIPTION
## Problem (#4876)

`xpfd publish-generation` reads the upgrade journal to protect a crashed/resumable cut's pinned source generation from its staged-generation GC. But the read was best-effort: on an I/O error it printed a WARN and ran `cfg.GC(protected)` anyway with an **empty** protection set, and a present-but-malformed journal degraded to `("",nil)` — same result. A crash-after-STOP cut whose journal became unreadable could then have its pinned source generation reaped by a later publish, leaving the upgrade unrecoverable (daemon-down). Cold path, but irreversible.

(The team-lead brief framed this as "GC runs even when the publish failed" — note a failed `Publish()` already `os.Exit(1)`s before GC, so the real, verified gap is the journal-unreadable path per the issue.)

## Fix

- `ReadJournalSourceGeneration` now distinguishes an **absent** journal (`"",nil` — no crashed cut to protect) from a **present-but-unreadable/malformed** one (returns an error).
- `publish-generation` routes its GC decision through a new testable `gcProtectionForPublish` helper that runs GC **only** when the protection set is known; on an unreadable/malformed journal it **skips** GC (harmless extra generations; the next readable-journal publish reclaims them).

## Tests (RED on revert)

- `pkg/upgrade`: `TestReadJournalSourceGenerationMalformedErrors_4876` — malformed journal must error.
- `cmd/xpfd`: `TestGCProtectionForPublish_4876` — malformed/unreadable journal → `runGC=false`.

Both go RED when the reader is reverted to degrade a malformed journal to no-protection. `go build ./...`, `go vet`, `gofmt`, and `pkg/upgrade` + `cmd/xpfd` package tests pass. Doc: `docs/in-place-upgrade.md` GC-retention notes.

Closes #4876

🤖 Generated with [Claude Code](https://claude.com/claude-code)