### PR TITLE
configstore: fail closed on unknown encrypted-envelope format

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,26 @@
+## 2026-07-09 — #4888 configstore: encrypted-envelope with unknown/future `format` fell through as plaintext and empty-loaded instead of failing closed
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4888 (fail-open, security-adjacent). `unmarshalEnvelope`
+  returned (ok=false, err=nil) for ANY body whose `format` was not the
+  current `xpf-master-password-v1`, so `maybeDecryptTreeJSON` handed the
+  raw bytes back as plaintext; `readTreeMeta` then `json.Unmarshal`'d an
+  envelope-shaped body (future format / corruption) into a `ConfigTree`,
+  dropping the unknown `format`/`prf`/`salt`/`nonce`/`data` fields and
+  yielding an EMPTY tree — so `Store.Load` booted a committed-empty config
+  instead of `ErrConfigDBUnreadable`. Fix: fail CLOSED on an
+  envelope-shaped body with an unknown/future `format` OR AES-GCM fields
+  present without the current format; only a body with no format AND no
+  AES-GCM fields passes through as genuine plaintext (verified the legacy
+  no-envelope + current-format paths still pass). ConfigTree JSON is
+  `{"Children":[...]}` — no top-level format/salt/nonce/data — so the
+  plaintext discriminator cannot false-positive. Added a unit test on the
+  `unmarshalEnvelope` contract + an end-to-end `Store.Load` ->
+  `ErrConfigDBUnreadable` test; both RED on revert.
+  **File(s)**: pkg/configstore/crypto.go,
+  pkg/configstore/crypto_envelope_unknown_format_4888_test.go,
+  pkg/configstore/README.md
+
 ## 2026-07-09 — #4882 userspace-dp: debug BPF session dump used `core::ptr::read` (align 2) on a `Vec<u8>` (align 1) — UB; use `read_unaligned`
 
 - **Timestamp**: 2026-07-09

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -153,6 +153,17 @@ inline archive-site passwords).
   loading the cleartext secrets without a trace. Reaching that state needs
   write access to the 0600/0700 `.configdb` (root/owner), so this is a
   visibility improvement, not a privilege-escalation fix.
+- **Unknown inner-envelope format fails closed (#4888).** `unmarshalEnvelope`
+  distinguishes a genuine plaintext body (no `format`, no `salt`/`nonce`/`data`
+  — passed through) from an envelope-shaped body it cannot decrypt: an
+  unknown/future `format` (e.g. a `xpf-master-password-v2` bump), or the
+  AES-GCM fields present without the current `format`, returns an ERROR so
+  `Store.Load` reports `ErrConfigDBUnreadable`. Without this, an inner encrypted
+  envelope past the outer `#xpf-config-envelope` gate whose format was corrupted
+  or is too-new would be `json.Unmarshal`'d into a `ConfigTree` with all unknown
+  fields dropped — an EMPTY tree — booting a committed-empty config (loss of
+  policy) instead of failing closed. This restores at the inner layer the same
+  no-empty-load-on-unknown property the outer envelope provides.
 - **GCM AAD binding (A4-05) — deliberately NOT changed.** `Seal`/`Open` pass
   a nil additional-authenticated-data argument. Binding the envelope header
   (PRF/salt) as AAD is textbook defense-in-depth, but the scheme already

--- a/pkg/configstore/crypto.go
+++ b/pkg/configstore/crypto.go
@@ -189,9 +189,25 @@ func unmarshalEnvelope(data []byte) (encryptedTreeEnvelope, bool, error) {
 	type alias encryptedTreeEnvelope
 	var env alias
 	if err := json.Unmarshal(data, &env); err != nil {
+		// Not JSON, or not the envelope object shape at all — a genuine
+		// plaintext (pre-encryption / legacy) config body. Pass through.
 		return encryptedTreeEnvelope{}, false, nil
 	}
 	if env.Format != encryptedTreeFormat {
+		// Fail CLOSED on an envelope-shaped body whose discriminator we do not
+		// support (#4888). An unknown/future `format`
+		// (e.g. xpf-master-password-v2), or the AES-GCM fields
+		// (salt/nonce/data) present without our current `format`, is a too-new
+		// or corrupted ENCRYPTED DB — it MUST be rejected, never treated as
+		// plaintext. Treating it as plaintext lets json.Unmarshal drop the
+		// unknown fields and decode an EMPTY ConfigTree, so Store.Load would
+		// boot a committed-empty config (loss of policy) instead of failing
+		// closed with ErrConfigDBUnreadable. Only a body with NO format AND no
+		// AES-GCM fields is a genuine plaintext body and passes through.
+		if env.Format != "" || env.Salt != "" || env.Nonce != "" || env.Data != "" {
+			return encryptedTreeEnvelope{}, false, fmt.Errorf(
+				"unsupported encrypted config envelope format %q (too-new or corrupted config DB)", env.Format)
+		}
 		return encryptedTreeEnvelope{}, false, nil
 	}
 	if env.PRF == "" || env.Salt == "" || env.Nonce == "" || env.Data == "" {

--- a/pkg/configstore/crypto_envelope_unknown_format_4888_test.go
+++ b/pkg/configstore/crypto_envelope_unknown_format_4888_test.go
@@ -1,0 +1,99 @@
+package configstore
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestUnmarshalEnvelopeUnknownFormatFailsClosed_4888 pins the fail-closed
+// contract of unmarshalEnvelope: an envelope-shaped body with an unknown /
+// future `format` (or one carrying AES-GCM fields without our current format)
+// MUST be rejected, not treated as plaintext. Only a body with no format and
+// no AES-GCM fields is a genuine plaintext body.
+func TestUnmarshalEnvelopeUnknownFormatFailsClosed_4888(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    string
+		wantOK  bool
+		wantErr bool
+	}{
+		{
+			name: "future format with encrypted fields is rejected",
+			body: `{"format":"xpf-master-password-v2","prf":"sha256",` +
+				`"salt":"AAAA","nonce":"AAAA","data":"AAAA"}`,
+			wantErr: true,
+		},
+		{
+			name:    "encrypted fields without a format are rejected",
+			body:    `{"salt":"AAAA","nonce":"AAAA","data":"AAAA"}`,
+			wantErr: true,
+		},
+		{
+			name:    "unknown format alone is rejected",
+			body:    `{"format":"totally-bogus"}`,
+			wantErr: true,
+		},
+		{
+			name:   "genuine plaintext config tree passes through",
+			body:   `{"Children":[{"Keys":["system"]}]}`,
+			wantOK: false,
+		},
+		{
+			name:   "empty object passes through as plaintext",
+			body:   `{}`,
+			wantOK: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ok, err := unmarshalEnvelope([]byte(tc.body))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("unmarshalEnvelope(%s): err=nil, want a fail-closed error", tc.body)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unmarshalEnvelope(%s): unexpected err %v", tc.body, err)
+			}
+			if ok != tc.wantOK {
+				t.Fatalf("unmarshalEnvelope(%s): ok=%v, want %v", tc.body, ok, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestStoreLoadUnknownInnerEnvelopeFailsClosed_4888 proves the end-to-end
+// fail-closed property: an on-disk DB that passes the OUTER #xpf-config-envelope
+// gate but whose INNER body is an encrypted envelope with an unknown/future
+// `format` is rejected with ErrConfigDBUnreadable, NOT silently decoded to an
+// empty ConfigTree (which would boot a committed-empty config and lose policy).
+func TestStoreLoadUnknownInnerEnvelopeFailsClosed_4888(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	dbDir := filepath.Join(dir, ".configdb")
+	if err := os.MkdirAll(dbDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Inner body: a future/unknown encrypted-tree format. Pre-fix, this fell
+	// through unmarshalEnvelope as "not an envelope" and got parsed as a
+	// ConfigTree with all fields dropped -> empty tree, no error.
+	inner := `{"format":"xpf-master-password-v2","prf":"sha256",` +
+		`"salt":"AAAA","nonce":"AAAA","data":"AAAA"}`
+	body := wrapEnvelope([]byte(inner), "9.9.9", true)
+	if err := os.WriteFile(filepath.Join(dbDir, "active.json"), body, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newTestStoreAt(t, path)
+	err := s.Load()
+	if err == nil {
+		t.Fatal("Load accepted an unknown inner encrypted-envelope format; must fail closed")
+	}
+	if !errors.Is(err, ErrConfigDBUnreadable) {
+		t.Fatalf("Load error not tagged ErrConfigDBUnreadable: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem (#4888, security-adjacent)

`unmarshalEnvelope` returned `(ok=false, err=nil)` for any body whose inner `format` was not the current `xpf-master-password-v1`, so `maybeDecryptTreeJSON` handed the raw bytes back as **plaintext**. `readTreeMeta` then `json.Unmarshal`'d an envelope-shaped body (future format / at-rest corruption) into a `ConfigTree`, dropping the unknown `format`/`prf`/`salt`/`nonce`/`data` fields → an **empty tree**. `Store.Load` booted a committed-empty config (loss of policy) instead of `ErrConfigDBUnreadable`.

This re-opened, at the inner encrypted layer, the exact empty-load-on-unknown class the outer `#xpf-config-envelope` min-reader gate exists to prevent.

## Fix (fail closed)

`unmarshalEnvelope` now distinguishes:
- **Genuine plaintext** (no `format` AND no `salt`/`nonce`/`data`) → pass through unchanged (legacy/no-envelope path).
- **Envelope-shaped but unsupported** (unknown/future `format`, or AES-GCM fields present without the current format) → **return an error**, which `Store.Load` tags `ErrConfigDBUnreadable`.
- Current-format envelope → decrypt as before.

`ConfigTree` JSON is `{"Children":[...]}` — no top-level `format`/`salt`/`nonce`/`data` — so a real plaintext config cannot trip the new discriminator.

## Tests (RED on revert)

- `TestUnmarshalEnvelopeUnknownFormatFailsClosed_4888` — contract table (unknown format / fields-without-format rejected; plaintext + empty object pass through).
- `TestStoreLoadUnknownInnerEnvelopeFailsClosed_4888` — end-to-end: outer envelope wrapping an inner `xpf-master-password-v2` body → `Store.Load` → `ErrConfigDBUnreadable`.

Both go RED on revert. Full `pkg/configstore` suite passes (legacy + current-format + plaintext round-trip intact). Doc: `pkg/configstore/README.md`.

Closes #4888

🤖 Generated with [Claude Code](https://claude.com/claude-code)