### PR TITLE
grpcapi: bound gRPC listener shutdown so a stream can't wedge it

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,23 @@
+## 2026-07-09 — #4910 grpcapi: active MonitorInterface stream could block daemon shutdown forever (GracefulStop with no timeout)
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4910 (availability). Both gRPC listeners (`Run` loopback,
+  `RunFabricListener` fabric) called `srv.GracefulStop()` with no timeout,
+  and the unbounded server-streaming `MonitorInterface` RPC only watched
+  its client `stream.Context()`. A client (loopback, or an authenticated
+  fabric peer) holding that stream open during shutdown blocked
+  GracefulStop — and thus `Run`/`RunFabricListener` — forever, wedging
+  daemon stop/failover/restart. Fix: added `stopGRPCServer(srv, timeout)`
+  — GracefulStop in a goroutine + `Stop()` after `grpcStopTimeout` (2s) —
+  used by both listeners; `Run`'s serve/shutdown loop factored into
+  `serveUntilDone` for testability. Force-Stop cancels the stuck stream's
+  context so the handler returns; a clean/idle shutdown still returns as
+  soon as GracefulStop completes (no dropped events on normal disconnect).
+  Added `TestServeUntilDoneBoundedByStuckMonitorStream_4910` (RED on
+  revert: hangs 7s) + `TestStopGRPCServerIdleReturnsPromptly_4910`.
+  **File(s)**: pkg/grpcapi/server.go,
+  pkg/grpcapi/server_shutdown_monitor_4910_test.go, pkg/grpcapi/README.md
+
 ## 2026-07-09 — #4882 userspace-dp: debug BPF session dump used `core::ptr::read` (align 2) on a `Vec<u8>` (align 1) — UB; use `read_unaligned`
 
 - **Timestamp**: 2026-07-09

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -198,6 +198,18 @@ contract.
 - Server-streaming RPCs (Ping, Traceroute, MonitorPacketDrop,
   MonitorInterface) must drain on client disconnect; cancel the context
   to free buffered output.
+- **Bounded shutdown (#4910).** Both listeners stop through
+  `stopGRPCServer` (`server.go`): `GracefulStop` runs in a goroutine and,
+  if active RPCs have not finished within `grpcStopTimeout`, `Stop()`
+  force-closes the connections. This is required because `MonitorInterface`
+  streams forever off only its client `stream.Context()` — a client
+  holding that stream open during shutdown would otherwise block
+  `GracefulStop`, and therefore `Run` / `RunFabricListener`, indefinitely
+  (a stuck daemon stop / failover / restart). `Run`'s serve+shutdown loop
+  is factored into `serveUntilDone(ctx, srv, lis)` so the bounded-stop path
+  is exercisable over an in-memory listener. A normal, RPC-idle shutdown
+  (or one where every client has disconnected) returns as soon as
+  `GracefulStop` completes — the timeout is only a backstop.
 - Request-path external commands (ps, df, ss, journalctl, chronyc,
   ntpq, timedatectl, tail, ip neigh flush, systemctl power actions)
   must go through the bounded helpers in `exec_timeout.go` (#1805):

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -227,6 +227,36 @@ func NewServer(addr string, cfg Config) *Server {
 }
 
 // Run starts the gRPC server and blocks until ctx is cancelled.
+// grpcStopTimeout bounds the graceful shutdown of a gRPC listener (#4910). On
+// ctx cancellation a listener first tries GracefulStop so in-flight RPCs can
+// finish, but the unbounded server-streaming MonitorInterface RPC only watches
+// its client stream context — a client holding that stream open would
+// otherwise block GracefulStop, and therefore Run / RunFabricListener, forever
+// (a stuck daemon stop / failover / restart). After this grace period the
+// server is force-Stop()'d so shutdown always completes.
+const grpcStopTimeout = 2 * time.Second
+
+// stopGRPCServer stops srv with a BOUNDED graceful shutdown (#4910):
+// GracefulStop runs in a goroutine so active RPCs get a chance to finish, but
+// if they have not within timeout, Stop() force-closes the connections —
+// which cancels a stuck streaming handler's stream context so it returns and
+// GracefulStop unblocks. A normal, RPC-idle shutdown (or one where every
+// client has disconnected) returns as soon as GracefulStop completes, well
+// before the timeout, so a clean disconnect drops nothing.
+func stopGRPCServer(srv *grpc.Server, timeout time.Duration) {
+	stopped := make(chan struct{})
+	go func() {
+		srv.GracefulStop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(timeout):
+		srv.Stop()
+		<-stopped
+	}
+}
+
 func (s *Server) Run(ctx context.Context) error {
 	lis, err := net.Listen("tcp", s.addr)
 	if err != nil {
@@ -237,6 +267,14 @@ func (s *Server) Run(ctx context.Context) error {
 		grpc.MaxRecvMsgSize(maxRecvMsgSize),
 		grpc.UnaryInterceptor(s.configLockInterceptor),
 	)
+	return s.serveUntilDone(ctx, srv, lis)
+}
+
+// serveUntilDone registers the service on srv, serves lis, and on ctx
+// cancellation stops srv with a bounded graceful shutdown (stopGRPCServer). It
+// is split out of Run so the shutdown path can be exercised over an in-memory
+// listener in tests.
+func (s *Server) serveUntilDone(ctx context.Context, srv *grpc.Server, lis net.Listener) error {
 	pb.RegisterBpfrxServiceServer(srv, s)
 
 	errCh := make(chan error, 1)
@@ -254,7 +292,7 @@ func (s *Server) Run(ctx context.Context) error {
 	case <-ctx.Done():
 	}
 
-	srv.GracefulStop()
+	stopGRPCServer(srv, grpcStopTimeout)
 	return nil
 }
 
@@ -307,7 +345,7 @@ func (s *Server) RunFabricListener(ctx context.Context, addr, vrfDevice string) 
 	}()
 
 	<-ctx.Done()
-	srv.GracefulStop()
+	stopGRPCServer(srv, grpcStopTimeout)
 }
 
 // fabricAllowedUnaryMethods is the fail-closed allowlist (#4122) of unary RPCs

--- a/pkg/grpcapi/server_shutdown_monitor_4910_test.go
+++ b/pkg/grpcapi/server_shutdown_monitor_4910_test.go
@@ -1,0 +1,113 @@
+package grpcapi
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// TestServeUntilDoneBoundedByStuckMonitorStream_4910 proves that an active,
+// unbounded MonitorInterface stream cannot block gRPC shutdown forever. The
+// server-lifetime context is cancelled while a client holds a MonitorInterface
+// stream open; serveUntilDone (the shared Run / RunFabricListener shutdown
+// path) must still return within the bounded grpcStopTimeout because
+// stopGRPCServer force-Stop()'s the server after the grace period.
+//
+// RED-on-revert: replacing the bounded stopGRPCServer with a plain
+// srv.GracefulStop() makes serveUntilDone hang here (the stream keeps
+// stream.Context() live), and the test times out.
+func TestServeUntilDoneBoundedByStuckMonitorStream_4910(t *testing.T) {
+	store, err := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err != nil {
+		t.Fatalf("configstore.New: %v", err)
+	}
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := store.LoadOverride("system { host-name fw; }"); err != nil {
+		t.Fatalf("LoadOverride: %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	s := &Server{store: store, addr: "bufnet"}
+
+	lis := bufconn.Listen(1 << 20)
+	srv := grpc.NewServer(
+		grpc.MaxRecvMsgSize(maxRecvMsgSize),
+		grpc.UnaryInterceptor(s.configLockInterceptor),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.serveUntilDone(ctx, srv, lis) }()
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	defer conn.Close()
+	client := pb.NewBpfrxServiceClient(conn)
+
+	// Hold a MonitorInterface stream open (summary mode). We deliberately do
+	// NOT cancel this client context: a client keeping the stream open is
+	// exactly what blocks GracefulStop.
+	streamCtx, streamCancel := context.WithCancel(context.Background())
+	defer streamCancel()
+	stream, err := client.MonitorInterface(streamCtx, &pb.MonitorInterfaceRequest{})
+	if err != nil {
+		t.Fatalf("MonitorInterface: %v", err)
+	}
+	// Receive the first frame so the handler is inside its streaming loop and
+	// the RPC is genuinely in-flight against GracefulStop.
+	if _, err := stream.Recv(); err != nil {
+		t.Fatalf("first stream.Recv: %v", err)
+	}
+
+	// Cancel the server lifetime. serveUntilDone must return within the bounded
+	// grace period despite the still-open stream.
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("serveUntilDone returned error: %v", err)
+		}
+	case <-time.After(grpcStopTimeout + 5*time.Second):
+		t.Fatalf("serveUntilDone did not return within %v of ctx cancel — an open "+
+			"MonitorInterface stream blocked shutdown", grpcStopTimeout+5*time.Second)
+	}
+}
+
+// TestStopGRPCServerIdleReturnsPromptly_4910 confirms the bounded stop does not
+// impose the timeout on a clean, RPC-idle shutdown: with no in-flight RPC,
+// GracefulStop completes immediately and stopGRPCServer returns well under the
+// grace period (so a normal client disconnect drops nothing and shutdown stays
+// fast).
+func TestStopGRPCServerIdleReturnsPromptly_4910(t *testing.T) {
+	lis := bufconn.Listen(1 << 20)
+	srv := grpc.NewServer()
+	go func() { _ = srv.Serve(lis) }()
+
+	start := time.Now()
+	stopGRPCServer(srv, grpcStopTimeout)
+	if elapsed := time.Since(start); elapsed >= grpcStopTimeout {
+		t.Fatalf("idle stopGRPCServer took %v (>= %v) — it should return as soon as GracefulStop completes",
+			elapsed, grpcStopTimeout)
+	}
+}


### PR DESCRIPTION
## Problem (#4910, availability)

Both gRPC listeners (`Run` loopback, `RunFabricListener` fabric) stopped with a bare `srv.GracefulStop()` — no timeout, no `Stop()` fallback. The unbounded server-streaming `MonitorInterface` RPC loops forever watching only its client `stream.Context()`, never a server-lifetime signal. A client (loopback caller, or an authenticated fabric peer) holding a `MonitorInterface` stream open during shutdown keeps its stream context live, so `GracefulStop` waits on it forever — `Run`/`RunFabricListener` never return and daemon stop/failover/restart hangs indefinitely.

## Fix

- New `stopGRPCServer(srv, timeout)`: `GracefulStop` in a goroutine + `Stop()` after `grpcStopTimeout` (2s). Force-`Stop()` closes connections, cancelling a stuck streaming handler's stream context so it returns and `GracefulStop` unblocks. Both listeners use it.
- `Run`'s serve+shutdown loop factored into `serveUntilDone(ctx, srv, lis)` so the shutdown path is exercisable over an in-memory listener.

A normal, RPC-idle shutdown (or one where every client already disconnected) returns as soon as `GracefulStop` completes — the 2s timeout is a backstop only, well inside the unit's `TimeoutStopSec=20`, and never on the common path so failover timing is unaffected. No events are dropped on a clean disconnect (that path is `stream.Context().Done()`, unchanged).

Note: deliberately did **not** add a shared server-wide shutdown context — `RunFabricListener` runs on `commsCtx` (cancelled independently on cluster-comms restart), so a shared cancel would kill loopback monitor streams when only the fabric comms recycled. The per-listener bounded stop avoids that coupling.

## Tests (RED on revert)

- `TestServeUntilDoneBoundedByStuckMonitorStream_4910` — opens a `MonitorInterface` stream over bufconn, cancels the server context, asserts `serveUntilDone` returns within the bounded window. RED (hangs to the 7s deadline) when `stopGRPCServer` is reverted to a plain `GracefulStop`.
- `TestStopGRPCServerIdleReturnsPromptly_4910` — an idle stop returns well under the timeout.

`go build ./...`, `go vet`, `gofmt`, full `pkg/grpcapi` suite, and `pkg/daemon` + `cmd/xpfd` build all pass. Doc: `pkg/grpcapi/README.md`.

Closes #4910

🤖 Generated with [Claude Code](https://claude.com/claude-code)