### PR TITLE
rpm: close the http-get probe's connection instead of leaking it

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,22 @@
+## 2026-07-09 — #4912 rpm: HTTP probe leaked a keep-alive transport + fd per bodyless (204) response
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4912 (resource leak). `probeHTTP` built a fresh
+  `http.Transport` per probe with keep-alives implicitly ENABLED and
+  `IdleConnTimeout == 0`, ran one GET, and dropped the transport. For a
+  bodyless response (204 / Content-Length: 0), `resp.Body.Close()`
+  returned the connection to that unowned transport's idle pool with no
+  idle timeout, so the socket + persistent-connection read-loop goroutine
+  retained each other forever — one fd + goroutine leaked per probe to an
+  empty health endpoint. Fix: set `DisableKeepAlives: true`, defer
+  `transport.CloseIdleConnections()`, and drain (`io.Copy(io.Discard,
+  ...)`) + close the body on every path. Added
+  `TestProbeHTTPBodylessResponseNoConnLeak_4912` — a repeated-204 probe
+  with a connection-counting listener that asserts the server's open-conn
+  count drains to zero; RED on revert (4 conns stay open).
+  **File(s)**: pkg/rpm/rpm.go,
+  pkg/rpm/http_transport_leak_4912_test.go, pkg/rpm/README.md
+
 ## 2026-07-09 — #4882 userspace-dp: debug BPF session dump used `core::ptr::read` (align 2) on a `Vec<u8>` (align 1) — UB; use `read_unaligned`
 
 - **Timestamp**: 2026-07-09

--- a/pkg/rpm/README.md
+++ b/pkg/rpm/README.md
@@ -76,6 +76,15 @@ pins probes to devices/next-hops via `SO_BINDTODEVICE` / `SO_MARK`.
   failures; ambiguous dial errnos default to PATH.
 - The raw-socket seam is injectable (`icmpListenFunc` in `icmp.go`) so
   prober logic is unit-testable without privileges.
+- **The http-get probe's transport is one-shot** (#4912): `probeHTTP`
+  builds a per-probe `http.Transport`, sets `DisableKeepAlives: true`, and
+  defers `CloseIdleConnections()`, then drains+closes the response body on
+  every path. A bodyless response (HTTP 204 / `Content-Length: 0`) is
+  fully consumed by `Body.Close()`, so the keep-alive default would return
+  the socket to the idle pool of that now-unowned transport (whose
+  `IdleConnTimeout == 0` never expires) — leaking one fd + read-loop
+  goroutine per probe to an empty health endpoint. Disabling keep-alives
+  closes the connection after the single request instead.
 - `destination-interface` takes precedence over the routing-instance
   VRF device for `SO_BINDTODEVICE`; otherwise VRF binding uses
   `vrf-<ri-name>` — not the destination interface itself.

--- a/pkg/rpm/http_transport_leak_4912_test.go
+++ b/pkg/rpm/http_transport_leak_4912_test.go
@@ -1,0 +1,102 @@
+package rpm
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// countingListener wraps a net.Listener and tracks how many accepted
+// connections are currently open, so a test can assert that a probe closes its
+// TCP connection instead of parking it in an unowned keep-alive idle pool.
+type countingListener struct {
+	net.Listener
+	mu   sync.Mutex
+	open int
+}
+
+func (l *countingListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	l.mu.Lock()
+	l.open++
+	l.mu.Unlock()
+	return &countingConn{Conn: c, l: l}, nil
+}
+
+func (l *countingListener) openCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.open
+}
+
+type countingConn struct {
+	net.Conn
+	l    *countingListener
+	once sync.Once
+}
+
+func (c *countingConn) Close() error {
+	c.once.Do(func() {
+		c.l.mu.Lock()
+		c.l.open--
+		c.l.mu.Unlock()
+	})
+	return c.Conn.Close()
+}
+
+// TestProbeHTTPBodylessResponseNoConnLeak_4912 proves the HTTP RPM probe does
+// not leak a keep-alive connection per bodyless (204) response. Each probe uses
+// a fresh, unowned http.Transport with no idle-connection timeout; if the
+// connection were returned to that transport's idle pool (the keep-alive
+// default) it would stay open forever. The fix disables keep-alives (and drops
+// idle connections on return), so every probe's connection closes.
+//
+// The assertion is that the server's open-connection count returns to zero
+// after several 204 probes. Against the pre-fix code the connections stay
+// pooled/open and the count never drains -> the test fails.
+func TestProbeHTTPBodylessResponseNoConnLeak_4912(t *testing.T) {
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Bodyless response — the deterministic idle-pool return path.
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	cl := &countingListener{Listener: ts.Listener}
+	ts.Listener = cl
+	ts.Start()
+	defer ts.Close()
+
+	m := &Manager{}
+	test := &config.RPMTest{Target: ts.URL}
+
+	const probes = 4
+	for i := 0; i < probes; i++ {
+		rtt, err := m.probeHTTP(context.Background(), test, probeSockOpts{})
+		if err != nil {
+			t.Fatalf("probe %d: unexpected error: %v", i, err)
+		}
+		if rtt <= 0 {
+			t.Fatalf("probe %d: rtt=%v, want > 0", i, rtt)
+		}
+	}
+
+	// The probe closes its connection synchronously on return, but the server
+	// side observes the close asynchronously; poll briefly for the count to
+	// drain to zero.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cl.openCount() == 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("server still has %d open connection(s) after %d bodyless probes — "+
+		"the probe is leaking keep-alive connections", cl.openCount(), probes)
+}

--- a/pkg/rpm/rpm.go
+++ b/pkg/rpm/rpm.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -748,9 +749,22 @@ func (m *Manager) probeHTTP(ctx context.Context, test *config.RPMTest, opts prob
 	if err != nil {
 		return 0, err
 	}
+	// This transport is created per-probe and dropped when probeHTTP returns.
+	// DisableKeepAlives means the underlying TCP connection is closed after the
+	// single request instead of being parked in the transport's idle pool. A
+	// pooled connection would leak here (#4912): a bodyless response (HTTP 204
+	// or Content-Length: 0) is fully consumed by resp.Body.Close(), so the
+	// keep-alive path returns the socket to the pool — but the transport has no
+	// owner and IdleConnTimeout == 0 (no limit), so the socket and its
+	// persistent-connection read-loop goroutine retain each other forever.
+	// Frequent probes to an empty health endpoint would then leak one fd +
+	// goroutine per attempt. CloseIdleConnections() on return is a belt-and-
+	// suspenders drop of anything that did get pooled.
 	transport := &http.Transport{
-		DialContext: dialer.DialContext,
+		DialContext:       dialer.DialContext,
+		DisableKeepAlives: true,
 	}
+	defer transport.CloseIdleConnections()
 	client := &http.Client{Timeout: 10 * time.Second, Transport: transport}
 
 	start := time.Now()
@@ -762,6 +776,10 @@ func (m *Manager) probeHTTP(ctx context.Context, test *config.RPMTest, opts prob
 	if err != nil {
 		return 0, fmt.Errorf("HTTP GET failed: %w", err)
 	}
+	// Drain then close the body on every path — including a bodyless 204 — so
+	// the connection is fully consumed before close and never lingers
+	// half-read (#4912).
+	_, _ = io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 	rtt := time.Since(start)
 


### PR DESCRIPTION
## Problem (#4912, resource leak)

Each HTTP RPM probe allocated a fresh `http.Transport` with keep-alives implicitly enabled and `IdleConnTimeout == 0` (no limit), did one GET, and dropped the transport without disabling keep-alives or closing idle connections. For a bodyless response (HTTP 204 / `Content-Length: 0`), `resp.Body.Close()` fully consumes the body, so the keep-alive path returns the connection to that transport's idle pool. With no owner and no idle timeout, the transport and its persistent-connection read loop retain each other and the socket forever — frequent probes to an empty health endpoint leak one fd + goroutine per attempt (gradual descriptor/goroutine exhaustion). `client.Timeout` bounds the request, not idle-connection lifetime.

## Fix

Make the per-probe transport strictly one-shot:
- `DisableKeepAlives: true` — connection closes after the single request instead of being pooled.
- `defer transport.CloseIdleConnections()` — belt-and-suspenders drop of anything pooled.
- Drain (`io.Copy(io.Discard, resp.Body)`) then close the body on every path, including a bodyless 204.

## Test (RED on revert)

`TestProbeHTTPBodylessResponseNoConnLeak_4912` — drives several 204 probes through a connection-counting listener and asserts the server's open-connection count drains to zero. RED on revert: the pre-fix code leaves all probe connections pooled/open (4/4 after the run).

`go build ./...`, `go vet ./pkg/rpm`, `gofmt`, and the full `pkg/rpm` suite pass. Doc: `pkg/rpm/README.md`.

Closes #4912

🤖 Generated with [Claude Code](https://claude.com/claude-code)