### PR TITLE
ddns: release Manager mutex across RFC 2136 DNS I/O

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,29 @@
+## 2026-07-09 — #5006 ddns: Manager held m.mu across blocking RFC 2136 DNS UPDATE I/O — stalled Stats()/OwnedRecordViews()
+
+- **Timestamp**: 2026-07-09
+  **Action**: #5006 (Medium, telemetry stall). The DHCP dynamic-DNS
+  `Manager.ReconcileScoped` held `m.mu` for the whole pass — including the
+  blocking RFC 2136 DNS UPDATE wire I/O in `upsertLocked`
+  (`updater.UpsertLease`) and `deleteOwnedLocked` (`updater.DeleteLease`),
+  bounded only by the ~5s DDNS reconcile timeout. The telemetry/CLI readers
+  `Stats()` and `OwnedRecordViews()` take `m.mu.Lock()`, so
+  `show system services dynamic-dns` and Prometheus scrapes blocked for the
+  full DNS exchange when the authoritative server was slow/offline. Mirrored
+  the sibling `SurfaceAManager.providerIO`: added a `Manager.providerIO`
+  helper that releases `m.mu` around the ONE wire call and re-acquires it
+  (panic-safe), and routed both `UpsertLease` and `DeleteLease` through it.
+  Safe because the daemon serializes reconcile passes (`ddnsReconcileInFlight`)
+  so no concurrent pass mutates `m.state` during the drop — only the read-only
+  telemetry callers, which is exactly what must be unblocked. The write-ahead
+  ownership intent is still persisted under the lock BEFORE the wire add and
+  the result recorded under the re-acquired lock AFTER it.
+  **File(s)**: pkg/ddns/manager.go, pkg/ddns/manager_lockio_5006_test.go
+  **Validation**: new `TestManagerLockNotHeldDuringUpsert` /
+  `TestManagerLockNotHeldDuringDelete` (fail-on-revert: reverting the
+  providerIO wrapping makes both HANG on the blocked reader and fire the 2s
+  t.Fatal — verified RED). `go build ./...`, `go vet ./pkg/ddns/`, and the full
+  `go test ./pkg/ddns/` suite are green.
+
 ## 2026-07-09 — #4882 userspace-dp: debug BPF session dump used `core::ptr::read` (align 2) on a `Vec<u8>` (align 1) — UB; use `read_unaligned`
 
 - **Timestamp**: 2026-07-09

--- a/pkg/ddns/manager.go
+++ b/pkg/ddns/manager.go
@@ -1038,6 +1038,28 @@ func (m *Manager) withdrawAllLocked(ctx context.Context) error {
 	return firstErr
 }
 
+// providerIO performs ONE provider network call (UpsertLease/DeleteLease) with
+// m.mu RELEASED, then re-acquires the lock before returning (#5006, mirroring
+// SurfaceAManager.providerIO / #2778). The caller MUST hold m.mu on entry and
+// will hold it again on return. Releasing the lock around the wire op — bounded
+// by the ~5s DDNS reconcile timeout — is the whole point: a slow or hung
+// authoritative RFC 2136 server must NOT block the telemetry/CLI readers
+// Stats() / OwnedRecordViews() (`show system services dynamic-dns` + the
+// Prometheus scrape both take m.mu). The daemon serializes reconcile passes
+// (ddnsReconcileInFlight, pkg/daemon/daemon.go), so no concurrent pass mutates
+// m.state while the lock is dropped here — only the read-only Stats() /
+// OwnedRecordViews() callers may run, which is exactly what must be unblocked.
+// The write-ahead ownership intent (upsertLocked) is persisted under the lock
+// BEFORE this call and the wire result is recorded under the re-acquired lock
+// AFTER it, so the durable store is never mutated concurrently. Panic-safe: the
+// lock is re-acquired even if fn panics, keeping ReconcileScoped's deferred
+// Unlock balanced (a panicking backend would otherwise double-unlock).
+func (m *Manager) providerIO(fn func() error) error {
+	m.mu.Unlock()
+	defer m.mu.Lock()
+	return fn()
+}
+
 // upsertLocked publishes a record and records ownership on success. With no
 // live backend (nopUpdater), the upsert is a logged no-op AND ownership is
 // deliberately NOT recorded: recording ownership for a record that never
@@ -1105,7 +1127,7 @@ func (m *Manager) upsertLocked(ctx context.Context, updater DNSUpdater, rec Leas
 		return err
 	}
 
-	if err := updater.UpsertLease(ctx, rec); err != nil {
+	if err := m.providerIO(func() error { return updater.UpsertLease(ctx, rec) }); err != nil {
 		// ORDER MATTERS (#2676): check errDDNSPTRPending BEFORE
 		// errDDNSConflictRefused. errDDNSPTRPending is returned ONLY after the
 		// forward A/AAAA add SUCCEEDED, so its presence proves the forward is
@@ -1215,7 +1237,7 @@ func (m *Manager) deleteOwnedLocked(ctx context.Context, updater DNSUpdater, own
 	// delete still satisfies the DHCID-match prerequisite. Only when THIS is the
 	// last owned record under the name is the DHCID removed with it.
 	rec.KeepForwardDHCID = m.dhcidSharedWithOther(owned)
-	if err := updater.DeleteLease(ctx, rec); err != nil {
+	if err := m.providerIO(func() error { return updater.DeleteLease(ctx, rec) }); err != nil {
 		m.deleteFail.Add(1)
 		return err
 	}

--- a/pkg/ddns/manager_lockio_5006_test.go
+++ b/pkg/ddns/manager_lockio_5006_test.go
@@ -1,0 +1,160 @@
+package ddns
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// manager_lockio_5006_test.go: #5006 — the DHCP dynamic-DNS Manager must NOT
+// hold m.mu across the blocking RFC 2136 DNS UPDATE wire I/O
+// (upsertLocked/deleteOwnedLocked call updater.UpsertLease/DeleteLease, bounded
+// only by the ~5s DDNS reconcile timeout). The telemetry/CLI readers Stats()
+// and OwnedRecordViews() take m.mu, so a slow/offline authoritative server used
+// to stall `show system services dynamic-dns` and Prometheus scrapes for the
+// full DNS exchange. These are the fail-on-revert proofs: revert the providerIO
+// lock-release wrapping in manager.go and the "reader proceeds while wire I/O is
+// blocked" assertions HANG until the bounded wait fires t.Fatal.
+//
+// The blockingUpdater double is shared with surface_a_lockio_test.go (same
+// package): every UpsertLease/DeleteLease signals entry on `entered` and blocks
+// until `release` is closed.
+
+// managerWithBlockingUpdater builds a production-shaped Manager whose live
+// (non-nop) updater is the blocking double. Leaving m.newUpdater nil keeps the
+// static updater in force for the pass, so the reconcile drives the real
+// write-ahead → wire-add → confirm path through bu.
+func managerWithBlockingUpdater(t *testing.T, bu *blockingUpdater, src *fakeLeaseSource) *Manager {
+	t.Helper()
+	dir := t.TempDir()
+	return newManagerForTesting(
+		src.parser(),
+		bu,
+		filepath.Join(dir, "state.json"),
+		filepath.Join(dir, "leases4.csv"),
+		filepath.Join(dir, "leases6.csv"),
+		"node0",
+		func() time.Time { return time.Unix(1_700_000_000, 0) },
+	)
+}
+
+// TestManagerLockNotHeldDuringUpsert proves m.mu is released while the provider
+// UpsertLease is in flight (#5006). A blocking provider holds the wire add open;
+// concurrently Stats() and OwnedRecordViews() (both take m.mu) MUST complete. If
+// the lock were held across the I/O the readers would block until release and
+// the bounded wait below fires — the fail-on-revert assertion.
+func TestManagerLockNotHeldDuringUpsert(t *testing.T) {
+	bu := newBlockingUpdater()
+	src := &fakeLeaseSource{v4: laptopMacLease()}
+	m := managerWithBlockingUpdater(t, bu, src)
+	cfg := ddnsCfg("dns.example.com")
+
+	reconcileDone := make(chan error, 1)
+	go func() { reconcileDone <- m.Reconcile(context.Background(), cfg) }()
+
+	// Wait until the provider Upsert is actually in flight (wire add open).
+	select {
+	case <-bu.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider UpsertLease never started")
+	}
+
+	// While the wire op is blocked, the telemetry readers (which take m.mu)
+	// MUST proceed. If the lock were held across the I/O they block and the
+	// bounded wait fires — the #5006 regression.
+	readerDone := make(chan struct{})
+	go func() {
+		_ = m.Stats()
+		_ = m.OwnedRecordViews()
+		close(readerDone)
+	}()
+	select {
+	case <-readerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stats()/OwnedRecordViews() blocked while DNS UpsertLease was in flight — m.mu held across wire I/O (#5006 regression)")
+	}
+
+	close(bu.release)
+	select {
+	case err := <-reconcileDone:
+		if err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Reconcile did not finish after provider released")
+	}
+	if bu.upserts != 1 {
+		t.Fatalf("expected exactly one upsert, got %d", bu.upserts)
+	}
+	if st := m.Stats(); st.UpsertOK != 1 {
+		t.Fatalf("expected UpsertOK=1 after release, got %+v", st)
+	}
+}
+
+// TestManagerLockNotHeldDuringDelete proves m.mu is released while a withdraw's
+// provider DeleteLease is in flight (#5006). First publish a record, then drive
+// a withdraw (family disabled → owned record deleted) while the provider delete
+// blocks; a concurrent Stats()/OwnedRecordViews() must proceed.
+func TestManagerLockNotHeldDuringDelete(t *testing.T) {
+	bu := newBlockingUpdater()
+	src := &fakeLeaseSource{v4: laptopMacLease()}
+	m := managerWithBlockingUpdater(t, bu, src)
+	cfg := ddnsCfg("dns.example.com")
+
+	// Publish once (let the add through immediately).
+	pubDone := make(chan error, 1)
+	go func() { pubDone <- m.Reconcile(context.Background(), cfg) }()
+	<-bu.entered
+	close(bu.release)
+	if err := <-pubDone; err != nil {
+		t.Fatalf("publish reconcile: %v", err)
+	}
+	if st := m.Stats(); st.OwnedRecords != 1 {
+		t.Fatalf("expected 1 owned record after publish, got %+v", st)
+	}
+
+	// Re-arm the release gate for the delete pass.
+	bu.release = make(chan struct{})
+
+	// Reconcile with DDNS disabled → the owned record is withdrawn (Pass 1
+	// delete of a now-disabled family) through the SAME live updater.
+	disabled := ddnsCfg("dns.example.com")
+	disabled.DynamicDNS.Enabled = false
+	withdrawDone := make(chan error, 1)
+	go func() { withdrawDone <- m.Reconcile(context.Background(), disabled) }()
+
+	select {
+	case <-bu.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider DeleteLease never started")
+	}
+
+	readerDone := make(chan struct{})
+	go func() {
+		_ = m.Stats()
+		_ = m.OwnedRecordViews()
+		close(readerDone)
+	}()
+	select {
+	case <-readerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stats()/OwnedRecordViews() blocked while DNS DeleteLease was in flight — m.mu held across wire I/O (#5006 regression)")
+	}
+
+	close(bu.release)
+	select {
+	case err := <-withdrawDone:
+		if err != nil {
+			t.Fatalf("withdraw reconcile: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("withdraw Reconcile did not finish after provider released")
+	}
+	if bu.deletes != 1 {
+		t.Fatalf("expected exactly one delete, got %d", bu.deletes)
+	}
+	if st := m.Stats(); st.DeleteOK != 1 || st.OwnedRecords != 0 {
+		t.Fatalf("expected DeleteOK=1 and no owned records after withdraw, got %+v", st)
+	}
+}


### PR DESCRIPTION
## Summary

The DHCP dynamic-DNS `Manager.ReconcileScoped` held `m.mu` (deferred Unlock) for the entire reconcile pass — including the blocking RFC 2136 DNS UPDATE network I/O in `upsertLocked` (`updater.UpsertLease`) and `deleteOwnedLocked` (`updater.DeleteLease`), bounded only by the ~5s DDNS reconcile timeout. The telemetry/CLI readers `Stats()` and `OwnedRecordViews()` take `m.mu.Lock()`, so `show system services dynamic-dns` and Prometheus scrapes stalled for the full DNS exchange whenever the authoritative server was slow or offline.

## Fix

Mirror the sibling `SurfaceAManager.providerIO`: add a `Manager.providerIO` helper that releases `m.mu` around the one wire call and re-acquires it via `defer` (panic-safe, keeps `ReconcileScoped`'s deferred Unlock balanced). Route both `UpsertLease` and `DeleteLease` through it.

Safe because the daemon serializes DDNS reconcile passes (`ddnsReconcileInFlight`), so no concurrent pass mutates `m.state` during the drop — only the read-only telemetry callers may run, which is exactly what must be unblocked. The write-ahead ownership intent is still persisted under the lock BEFORE the wire add, and the wire result recorded under the re-acquired lock AFTER it.

## Tests

`TestManagerLockNotHeldDuringUpsert` / `TestManagerLockNotHeldDuringDelete` drive a reconcile through a blocking updater and assert `Stats()`/`OwnedRecordViews()` proceed while the wire op is in flight. Reverting the `providerIO` wrapping makes both hang on the blocked reader until the bounded 2s wait fires `t.Fatal` (verified RED). `go build ./...`, `go vet ./pkg/ddns/`, and the full `go test ./pkg/ddns/` suite are green.

Closes #5006

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi