### PR TITLE
userspace HA: resolve session-sync pair against one snapshot (#5007)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,31 @@
+## 2026-07-09 — #5007 userspace HA: resolve forward+reverse session-sync pair against ONE snapshot (close the m.mu-drop drift window)
+
+- **Timestamp**: 2026-07-09
+  **Action**: #5007 (bug, HA session-sync concurrency). `SetSessionV4`/
+  `SetSessionV6` installed a forward session then its reverse companion under
+  one `m.mu` hold, but `syncSessionRequestLocked` deliberately drops `m.mu`
+  around the control-socket I/O (unlock → `requestSessionSync` → lock). The
+  reverse companion was BUILT after the forward's socket round-trip, so a
+  concurrent `ApplyConfig` swapping `m.lastSnapshot` in that gap made the
+  reverse resolve egress/zone/tunnel-endpoint metadata against a DIFFERENT
+  snapshot than the forward (drifted `owner_rg_id` / egress). Fix: extracted
+  `mirrorSessionPairV4`/`mirrorSessionPairV6`, which build BOTH the forward and
+  reverse `SessionSyncRequest` under a single uninterrupted `m.mu` hold (all
+  snapshot reads complete before any unlock), then transmit both via a new
+  `syncSessionRequestsLocked` that drops `m.mu` once for the socket sends. The
+  deliberate non-blocking-publish property is preserved — socket I/O still runs
+  with `m.mu` released; only the snapshot READS were pulled ahead of the drop.
+  **File(s)**: pkg/dataplane/userspace/manager_ha.go,
+  pkg/dataplane/userspace/manager_sessionsync_snapshot_5007_test.go
+  **Validation**: added
+  `TestMirrorSessionPairV4ResolvedAgainstConsistentSnapshot_5007` — a
+  deterministic fail-on-revert test that forces an ApplyConfig-style snapshot
+  swap during the forward request's socket I/O and asserts the reverse
+  companion still carries the forward's snapshot `owner_rg_id`. It fails RED on
+  the pre-#5007 interleaved shape (reverse OwnerRGID=2, snapshot B) and passes
+  GREEN on the fix. `go test -race ./pkg/dataplane/userspace/` passes; `go vet`
+  and `gofmt` clean; `cmd/xpfd` builds. Go-only change — no Rust touched.
+
 ## 2026-07-09 — #4882 userspace-dp: debug BPF session dump used `core::ptr::read` (align 2) on a `Vec<u8>` (align 1) — UB; use `read_unaligned`
 
 - **Timestamp**: 2026-07-09

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -61,6 +61,22 @@ installed into both places:
 install, they clear the cached FIB result so the receiving node recomputes
 node-local forwarding.
 
+Locally-created forward sessions take a parallel path: `SetSessionV4()` /
+`SetSessionV6()` install into the kernel/BPF maps, then mirror the forward
+entry **and a pre-installed reverse companion** (#310 — so the helper holds the
+reverse before RG activation, avoiding activation-time synthesis) to the local
+Rust helper over the session control socket. Both requests resolve
+egress/zone/tunnel-endpoint metadata from `m.lastSnapshot` and the compile
+result. **#5007 invariant: the forward/reverse pair MUST be resolved against
+ONE consistent snapshot.** The mirror helpers (`mirrorSessionPairV4` /
+`mirrorSessionPairV6`) build BOTH `SessionSyncRequest`s under a single
+uninterrupted `m.mu` hold — completing every snapshot read *before* any socket
+I/O drops the lock — then transmit both via `syncSessionRequestsLocked`, which
+releases `m.mu` for the send. This preserves the deliberate "session installs
+must not block snapshot publishes" property while closing the window where a
+concurrent `ApplyConfig` (which swaps `m.lastSnapshot` under `m.mu`) could make
+the reverse companion resolve against a different snapshot than the forward.
+
 That is only one direction of the userspace integration. Locally-created
 userspace sessions do **not** flow back through `SetClusterSyncedSession*`.
 They are exported through:

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -868,10 +868,31 @@ func (m *Manager) SetSessionV4(key dataplane.SessionKey, val dataplane.SessionVa
 	if !shouldMirrorUserspaceSession(val.IsReverse) {
 		return nil
 	}
+	m.mirrorSessionPairV4(key, val)
+	return nil
+}
+
+// mirrorSessionPairV4 mirrors a forward session and its pre-installed reverse
+// companion (#310) to the Rust helper.
+//
+// #5007: it resolves BOTH requests against ONE consistent config snapshot by
+// building them under a single uninterrupted m.mu hold — BEFORE any control
+// socket I/O drops the lock — then transmits both. buildSessionSyncRequestV4
+// resolves egress/zone/tunnel-endpoint metadata from m.lastSnapshot (and the
+// compile result); a concurrent ApplyConfig publishes a new m.lastSnapshot
+// while holding m.mu, so resolving both requests during one continuous hold
+// guarantees the forward/reverse pair derives from the SAME snapshot.
+// Transmitting only after both builds preserves the deliberate "socket I/O
+// must not block snapshot publishes" property (syncSessionRequestsLocked
+// drops m.mu for the send).
+func (m *Manager) mirrorSessionPairV4(key dataplane.SessionKey, val dataplane.SessionValue) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	// Send the forward session to the Rust worker.
-	_ = m.syncSessionV4Locked("upsert", key, &val)
+	if m.proc == nil {
+		return
+	}
+	reqs := make([]SessionSyncRequest, 0, 2)
+	reqs = append(reqs, m.buildSessionSyncRequestV4("upsert", key, &val))
 	// Pre-install the reverse companion so the Rust worker has it before
 	// RG activation, avoiding activation-time synthesis (#310).
 	if val.ReverseKey.Protocol != 0 {
@@ -886,9 +907,10 @@ func (m *Manager) SetSessionV4(key dataplane.SessionKey, val dataplane.SessionVa
 		revVal.FibDmac = [6]byte{}
 		revVal.FibSmac = [6]byte{}
 		revVal.FibGen = 0
-		_ = m.syncSessionV4Locked("upsert", val.ReverseKey, &revVal)
+		reqs = append(reqs, m.buildSessionSyncRequestV4("upsert", val.ReverseKey, &revVal))
 	}
-	return nil
+	// Snapshot reads are complete; transmit both requests in sequence.
+	m.syncSessionRequestsLocked(reqs...)
 }
 
 func (m *Manager) SetClusterSyncedSessionV4(key dataplane.SessionKey, val dataplane.SessionValue) error {
@@ -925,10 +947,22 @@ func (m *Manager) SetSessionV6(key dataplane.SessionKeyV6, val dataplane.Session
 	if !shouldMirrorUserspaceSession(val.IsReverse) {
 		return nil
 	}
+	m.mirrorSessionPairV6(key, val)
+	return nil
+}
+
+// mirrorSessionPairV6 is the IPv6 analogue of mirrorSessionPairV4 — see that
+// method for the #5007 single-snapshot rationale. It builds the forward
+// request and its reverse companion under one uninterrupted m.mu hold, then
+// transmits both.
+func (m *Manager) mirrorSessionPairV6(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	// Send the forward session to the Rust worker.
-	_ = m.syncSessionV6Locked("upsert", key, &val)
+	if m.proc == nil {
+		return
+	}
+	reqs := make([]SessionSyncRequest, 0, 2)
+	reqs = append(reqs, m.buildSessionSyncRequestV6("upsert", key, &val))
 	// Pre-install the reverse companion so the Rust worker has it before
 	// RG activation, avoiding activation-time synthesis (#310).
 	if val.ReverseKey.Protocol != 0 {
@@ -943,9 +977,10 @@ func (m *Manager) SetSessionV6(key dataplane.SessionKeyV6, val dataplane.Session
 		revVal.FibDmac = [6]byte{}
 		revVal.FibSmac = [6]byte{}
 		revVal.FibGen = 0
-		_ = m.syncSessionV6Locked("upsert", val.ReverseKey, &revVal)
+		reqs = append(reqs, m.buildSessionSyncRequestV6("upsert", val.ReverseKey, &revVal))
 	}
-	return nil
+	// Snapshot reads are complete; transmit both requests in sequence.
+	m.syncSessionRequestsLocked(reqs...)
 }
 
 func (m *Manager) SetClusterSyncedSessionV6(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) error {
@@ -1216,6 +1251,33 @@ func (m *Manager) syncSessionRequestLocked(req SessionSyncRequest) error {
 		slog.Debug("userspace session sync mirror failed", "operation", req.Operation, "err", err)
 	}
 	return err
+}
+
+// syncSessionRequestsLocked transmits one or more PRE-BUILT session-sync
+// requests to the Rust helper over the control socket. Like
+// syncSessionRequestLocked it drops m.mu once for the socket I/O (so snapshot
+// publishes are not blocked by a session install) and reacquires it before
+// returning; the caller keeps the lock across the call. It performs NO
+// snapshot reads — callers MUST have built every request under a single,
+// uninterrupted prior m.mu hold so a forward/reverse companion pair is
+// resolved against one consistent snapshot (#5007). Sending both requests
+// under a single unlock also keeps the pair's transmit contiguous.
+func (m *Manager) syncSessionRequestsLocked(reqs ...SessionSyncRequest) {
+	if len(reqs) == 0 {
+		return
+	}
+	m.mu.Unlock()
+	for i := range reqs {
+		ctrlReq := ControlRequest{
+			Type:           "sync_session",
+			SuppressStatus: true,
+			SessionSync:    &reqs[i],
+		}
+		if err := m.requestSessionSync(ctrlReq); err != nil {
+			slog.Debug("userspace session sync mirror failed", "operation", reqs[i].Operation, "err", err)
+		}
+	}
+	m.mu.Lock()
 }
 
 func (m *Manager) zoneNameByID(zoneID uint16) string {

--- a/pkg/dataplane/userspace/manager_sessionsync_snapshot_5007_test.go
+++ b/pkg/dataplane/userspace/manager_sessionsync_snapshot_5007_test.go
@@ -3,6 +3,7 @@ package userspace
 import (
 	"encoding/json"
 	"net"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
@@ -50,9 +51,19 @@ func injectShimCompileResult(t *testing.T, bpfShim *dataplane.Manager, cr *datap
 // It drives mirrorSessionPairV4 directly (not the SetSessionV4 wrapper) so it
 // never touches m.bpfShim's kernel session map and needs no BPF privileges.
 func TestMirrorSessionPairV4ResolvedAgainstConsistentSnapshot_5007(t *testing.T) {
-	dir := t.TempDir()
-	controlSock := filepath.Join(dir, "control.sock")
-	sessionSock := filepath.Join(dir, "userspace-dp-sessions.sock")
+	// Use a SHORT temp dir (not t.TempDir(), whose path embeds the 60-char
+	// test name) so the derived unix socket path stays well under the 108-byte
+	// sun_path limit even under a long TMPDIR (CI runners, GOTMPDIR=/dev/shm).
+	// sessionSocketPath() derives the session socket from the control socket's
+	// directory + the fixed "userspace-dp-sessions.sock" basename, so only the
+	// directory is shortened — the load-bearing basename is preserved.
+	sockDir, err := os.MkdirTemp("", "xs")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	defer os.RemoveAll(sockDir)
+	controlSock := filepath.Join(sockDir, "control.sock")
+	sessionSock := filepath.Join(sockDir, "userspace-dp-sessions.sock")
 
 	ln, err := net.Listen("unix", sessionSock)
 	if err != nil {

--- a/pkg/dataplane/userspace/manager_sessionsync_snapshot_5007_test.go
+++ b/pkg/dataplane/userspace/manager_sessionsync_snapshot_5007_test.go
@@ -1,0 +1,197 @@
+package userspace
+
+import (
+	"encoding/json"
+	"net"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// injectShimCompileResult sets the unexported dataplane.Manager.lastCompile
+// field so zoneNameByID resolves zone IDs to names without a real compile.
+func injectShimCompileResult(t *testing.T, bpfShim *dataplane.Manager, cr *dataplane.CompileResult) {
+	t.Helper()
+	if bpfShim == nil {
+		t.Fatal("injectShimCompileResult: bpfShim manager is nil")
+	}
+	elem := reflect.ValueOf(bpfShim).Elem()
+	rv := elem.FieldByName("lastCompile")
+	if !rv.IsValid() {
+		t.Fatal("injectShimCompileResult: dataplane.Manager has no field named \"lastCompile\"")
+	}
+	if !rv.CanAddr() {
+		t.Fatal("injectShimCompileResult: lastCompile is not addressable")
+	}
+	reflect.NewAt(rv.Type(), unsafe.Pointer(rv.UnsafeAddr())).Elem().Set(reflect.ValueOf(cr))
+}
+
+// TestMirrorSessionPairV4ResolvedAgainstConsistentSnapshot_5007 pins the #5007
+// fix: mirrorSessionPairV4 (driven by SetSessionV4) must resolve the forward
+// session AND its reverse companion against ONE consistent config snapshot,
+// even when a concurrent ApplyConfig swaps m.lastSnapshot mid-install.
+//
+// The reverse companion carries FibIfindex=0, so its only snapshot-derived
+// field is OwnerRGID, resolved from the egress zone via
+// resolveOwnerRGFromZone(m.lastSnapshot, ...). This test forces an
+// ApplyConfig-style snapshot swap DURING the forward request's control-socket
+// I/O (the deliberate m.mu drop in syncSessionRequestsLocked). With the fix
+// both requests are BUILT before any socket I/O drops m.mu, so the reverse
+// still reflects snapshot A. Reverting to the pre-#5007 shape — building the
+// reverse AFTER the forward's socket round-trip — makes the reverse resolve
+// against the swapped-in snapshot B and this test fails RED.
+//
+// It drives mirrorSessionPairV4 directly (not the SetSessionV4 wrapper) so it
+// never touches m.bpfShim's kernel session map and needs no BPF privileges.
+func TestMirrorSessionPairV4ResolvedAgainstConsistentSnapshot_5007(t *testing.T) {
+	dir := t.TempDir()
+	controlSock := filepath.Join(dir, "control.sock")
+	sessionSock := filepath.Join(dir, "userspace-dp-sessions.sock")
+
+	ln, err := net.Listen("unix", sessionSock)
+	if err != nil {
+		t.Fatalf("listen session socket: %v", err)
+	}
+	defer ln.Close()
+
+	// Snapshot A: the "trust" egress zone maps to redundancy group 1.
+	snapshotA := &ConfigSnapshot{
+		Interfaces: []InterfaceSnapshot{
+			{Name: "reth1.0", Ifindex: 6, Zone: "untrust", RedundancyGroup: 1},
+			{Name: "reth0.80", Ifindex: 12, Zone: "trust", RedundancyGroup: 1},
+		},
+	}
+	// Snapshot B is identical EXCEPT the "trust" zone now maps to group 2.
+	// A reverse companion resolved against B would carry OwnerRGID=2.
+	snapshotB := &ConfigSnapshot{
+		Interfaces: []InterfaceSnapshot{
+			{Name: "reth1.0", Ifindex: 6, Zone: "untrust", RedundancyGroup: 1},
+			{Name: "reth0.80", Ifindex: 12, Zone: "trust", RedundancyGroup: 2},
+		},
+	}
+
+	var mu sync.Mutex
+	var received []*SessionSyncRequest
+	forwardReceived := make(chan struct{}, 1)
+	swapDone := make(chan struct{})
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close()
+				var req ControlRequest
+				if err := json.NewDecoder(conn).Decode(&req); err != nil {
+					return
+				}
+				if req.SessionSync != nil {
+					mu.Lock()
+					received = append(received, req.SessionSync)
+					mu.Unlock()
+					if !req.SessionSync.IsReverse {
+						// Forward request in flight: trigger the concurrent
+						// ApplyConfig snapshot swap and hold this response until
+						// the swap has fully landed, so the pre-#5007 code path
+						// would build the reverse against snapshot B.
+						select {
+						case forwardReceived <- struct{}{}:
+						default:
+						}
+						<-swapDone
+					}
+				}
+				_ = json.NewEncoder(conn).Encode(ControlResponse{OK: true})
+			}(conn)
+		}
+	}()
+
+	m := New()
+	m.proc = &exec.Cmd{}
+	m.cfg.ControlSocket = controlSock
+	m.lastSnapshot = snapshotA
+	// zoneNameByID needs a compile result to turn zone IDs into names; the
+	// reverse's egress zone (id 1) must resolve to "trust".
+	injectShimCompileResult(t, m.bpfShim, &dataplane.CompileResult{
+		ZoneIDs: map[string]uint16{"trust": 1, "untrust": 2},
+	})
+
+	// Swap goroutine: mimics ApplyConfig publishing a new snapshot under m.mu
+	// while the forward request is mid-socket-I/O.
+	go func() {
+		defer close(swapDone)
+		select {
+		case <-forwardReceived:
+		case <-time.After(2 * time.Second):
+			return
+		}
+		m.mu.Lock()
+		m.lastSnapshot = snapshotB
+		m.mu.Unlock()
+	}()
+
+	key := dataplane.SessionKey{
+		SrcIP:    [4]byte{10, 0, 61, 102},
+		DstIP:    [4]byte{172, 16, 80, 200},
+		SrcPort:  hostToNetwork16(50952),
+		DstPort:  hostToNetwork16(5201),
+		Protocol: 6,
+	}
+	val := dataplane.SessionValue{
+		IsReverse:   0,
+		IngressZone: 1, // trust
+		EgressZone:  2, // untrust
+		FibIfindex:  6, // forward egress resolves by ifindex; RG stays 1 in A and B
+		ReverseKey: dataplane.SessionKey{
+			SrcIP:    [4]byte{172, 16, 80, 200},
+			DstIP:    [4]byte{10, 0, 61, 102},
+			SrcPort:  hostToNetwork16(5201),
+			DstPort:  hostToNetwork16(50952),
+			Protocol: 6,
+		},
+	}
+
+	m.mirrorSessionPairV4(key, val)
+
+	mu.Lock()
+	got := append([]*SessionSyncRequest(nil), received...)
+	mu.Unlock()
+
+	if len(got) != 2 {
+		t.Fatalf("received %d session-sync requests, want 2 (forward + reverse): %+v", len(got), got)
+	}
+	var fwd, rev *SessionSyncRequest
+	for _, r := range got {
+		if r.IsReverse {
+			rev = r
+		} else {
+			fwd = r
+		}
+	}
+	if fwd == nil {
+		t.Fatal("no forward session-sync request received")
+	}
+	if rev == nil {
+		t.Fatal("no reverse session-sync request received")
+	}
+	// The forward was resolved against snapshot A (built before any socket
+	// I/O). Its egress interface (ifindex 6) has RG 1 in both snapshots.
+	if fwd.OwnerRGID != 1 {
+		t.Fatalf("forward OwnerRGID = %d, want 1 (snapshot A)", fwd.OwnerRGID)
+	}
+	// The reverse companion MUST also reflect snapshot A. If it carries the
+	// snapshot-B group (2), the forward/reverse pair drifted across the
+	// mid-install ApplyConfig swap — the #5007 regression.
+	if rev.OwnerRGID != 1 {
+		t.Fatalf("reverse OwnerRGID = %d, want 1 (snapshot A) — forward/reverse "+
+			"companion resolved against a different snapshot than the forward (#5007)", rev.OwnerRGID)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #5007. `SetSessionV4`/`SetSessionV6` installed a forward session and then
its **reverse companion** under one `m.mu` acquisition, but
`syncSessionRequestLocked` deliberately drops `m.mu` around the control-socket
I/O (`m.mu.Unlock()` → `requestSessionSync` → `m.mu.Lock()`, so snapshot
publishes are not blocked by session installs). Because the reverse companion
was **built after** the forward request's socket round-trip, a concurrent
`ApplyConfig` that grabbed `m.mu` in that gap and swapped `m.lastSnapshot` made
the reverse resolve egress-interface / zone / tunnel-endpoint metadata against a
**different snapshot** than the forward — a cross-write consistency race that
left the forward/reverse pair with drifted `owner_rg_id` / egress metadata.

## Fix

Extract the mirror logic into `mirrorSessionPairV4` / `mirrorSessionPairV6`.
They build **both** the forward and reverse `SessionSyncRequest` under a single
uninterrupted `m.mu` hold — every snapshot read (`m.lastSnapshot`, compile
result) completes **before** any unlock — then transmit both via a new
`syncSessionRequestsLocked` that drops `m.mu` **once** for the socket sends and
reacquires it before returning.

The deliberate non-blocking-publish property is preserved: socket I/O still runs
with `m.mu` released; only the snapshot **reads** were pulled ahead of the lock
drop. Holding a single unlock across both sends also keeps the pair's transmit
contiguous. `ApplyConfig` swaps `m.lastSnapshot` under `m.mu` (verified:
`manager_compile.go` publish path), so building both requests during one
continuous hold guarantees they derive from one consistent snapshot.

## Test (fail-on-revert)

`TestMirrorSessionPairV4ResolvedAgainstConsistentSnapshot_5007` forces an
`ApplyConfig`-style snapshot swap **during** the forward request's socket I/O
(via a fake session socket that holds the forward response until the swap
lands), then asserts the reverse companion still carries the forward's snapshot
`owner_rg_id`. It drives `mirrorSessionPairV4` directly, so it needs **no BPF
map / memlock privileges**. Verified:

- **RED** on the pre-#5007 interleaved build/transmit shape (reverse
  `OwnerRGID=2`, the swapped-in snapshot B).
- **GREEN** on the fix (`OwnerRGID=1`, snapshot A — consistent with the forward).

## Validation

- `go test -race ./pkg/dataplane/userspace/` — **PASS** (authoritative gate for
  this concurrency fix).
- `go vet` + `gofmt` clean; `cmd/xpfd` builds.
- `cargo test --release` (userspace-dp): **3888 passed, 0 failed** (unchanged Rust — run for completeness).
- **Go-only change — no Rust touched.** The issue and fix are entirely in the Go
  control plane (`pkg/dataplane/userspace/manager_ha.go`); `cargo test` covers
  unchanged Rust.

> **HA session-sync change — parent must run `make test-failover` before merge.**
