### PR TITLE
feeds: reject and de-dup duplicate feed names

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-09 — #4913 feeds: globally-duplicate feed names orphaned refresh loops + nondeterministic provider
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4913 (Medium, correctness + goroutine leak). feeds.Manager
+  keys its worker map (`m.feeds`) and enforcement snapshot by the effective
+  feed name. `Apply` ranged the UNORDERED `daCfg.FeedServers` map and did
+  `m.feeds[name] = fs` + `go refreshLoop` per entry as it went, so two
+  feed-servers declaring the same effective feed name each started a refresh
+  loop and the later map iteration OVERWROTE the first worker — orphaning its
+  cancel func (StopAll cancels only the survivor, so the overwritten loop kept
+  fetching / firing onUpdate until the parent ctx ended) — while enforcement
+  read whichever provider won the last map iteration (nondeterministic across
+  commits/restarts). Two fixes: (1) `Apply` now builds a COMPLETE,
+  deterministic (sorted server keys), de-duplicated plan BEFORE starting any
+  goroutine and starts exactly one refresh loop per name (first wins; duplicate
+  dropped with a warning), so no cancel is orphaned and the winner is
+  deterministic; (2) a new strict compile gate
+  `validateDynamicAddressFeedNameUniquenessStrict` rejects a globally-duplicate
+  effective feed name at commit / commit-check (lenient-warn on load/peer-sync),
+  mirroring the effective-name derivation of the #3300 reference gate and
+  excluding endpoint-less servers (which Apply skips).
+  **File(s)**: pkg/feeds/feeds.go, pkg/feeds/feeds_dup_name_4913_test.go,
+  pkg/config/compiler_validate_strict_observability.go,
+  pkg/config/compiler_uniformgates.go,
+  pkg/config/dynamic_address_feed_dup_name_4913_test.go
+  **Validation**: `TestApplyDeDupsDuplicateFeedNames` (fail-on-revert:
+  reverting the Apply de-dup starts two loops → nondeterministic winner + a
+  second orphaned fetch → RED) and `TestValidateDynamicAddressFeedNameUniqueness`
+  (fail-on-revert: neutralizing the gate call makes the commit-reject + lenient
+  subtests RED). `go build ./...`, `go vet ./pkg/feeds/ ./pkg/config/`, and the
+  full feeds + config suites are green.
+
 ## 2026-07-09 — #4882 userspace-dp: debug BPF session dump used `core::ptr::read` (align 2) on a `Vec<u8>` (align 1) — UB; use `read_unaligned`
 
 - **Timestamp**: 2026-07-09

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -1154,6 +1154,24 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 		}
 	}
 
+	// #4913 dynamic-address feed-name uniqueness gate. feeds.Manager keys its
+	// worker map + enforcement snapshot by the effective feed name, so two
+	// feed-servers declaring the same name raced on m.feeds[name] — orphaning a
+	// refresh loop (goroutine leak) and backing enforcement with a
+	// nondeterministic provider. Reject the collision so the operator fixes the
+	// typo. Runs AFTER the endpoint gate so the surviving servers are exactly
+	// the ones Apply would register (endpoint-less servers are skipped by both).
+	// Strict on commit / commit-check; lenient on load / peer-sync (warn — the
+	// runtime now de-dups deterministically per #4913 rather than leaking).
+	if err := validateDynamicAddressFeedNameUniquenessStrict(cfg); err != nil {
+		if opts.lenientDynamicAddressFeedRef {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("dynamic-address feed name uniqueness (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #3300 dynamic-address feed cross-reference gate. A
 	// `security dynamic-address address-name <addr> profile feed-name <feed>`
 	// whose feed-name resolves to no declared feed-server feed records an

--- a/pkg/config/compiler_validate_strict_observability.go
+++ b/pkg/config/compiler_validate_strict_observability.go
@@ -206,6 +206,99 @@ func feedServerBaseURLEmpty(fs *FeedServer) bool {
 	return true
 }
 
+// validateDynamicAddressFeedNameUniquenessStrict hard-rejects two
+// dynamic-address feeds that resolve to the SAME effective feed name (#4913).
+//
+// feeds.Manager keys its worker map AND its enforcement snapshot by the
+// effective feed name (pkg/feeds/feeds.go Apply): a feed-server with per-feed
+// entries contributes each FeedEntry.Name; a single-feed server contributes its
+// FeedName, falling back to the server name. Two feeds sharing a name are a
+// config authoring error (a typo): the pre-#4913 Apply ranged the UNORDERED
+// FeedServers map and assigned m.feeds[name] = fs per entry, so the duplicate
+// OVERWROTE the earlier worker — orphaning its cancel func (a goroutine leak:
+// StopAll cancels only the survivor, so the overwritten refresh loop kept
+// fetching / firing onUpdate until the daemon's parent context ended) — and
+// enforcement read whichever provider won the last map iteration
+// (nondeterministic across commits / restarts). Reject the collision at commit
+// so the operator fixes the typo instead of shipping a denylist backed by a
+// nondeterministic provider.
+//
+// The effective-name derivation mirrors feeds.Manager EXACTLY (and the
+// declared-name set built by validateDynamicAddressFeedReferencesStrict). An
+// endpoint-less feed-server (rejected just before by
+// validateDynamicAddressFeedServerEndpointStrict) is SKIPPED by Apply and
+// registers no worker, so it is excluded here too (feedServerBaseURLEmpty) —
+// otherwise a benign endpoint-less shadow name would be miscounted as a live
+// collision. This gate runs AFTER the endpoint gate so, on the strict path, the
+// surviving servers are exactly the ones Apply would register.
+//
+// Strict path (commit / commit-check): the first collision is a hard error
+// naming the feed and both declaring servers. Lenient path (load / peer-sync,
+// opts.lenientDynamicAddressFeedRef): warn so an already-persisted or
+// peer-synced config an older binary accepted still boots — the runtime is now
+// deterministic-with-a-warning via the feeds.Apply de-dup (#4913), starting one
+// worker for the lexicographically-first server instead of leaking, now
+// flagged. Mirrors validateDynamicAddressFeedReferencesStrict.
+func validateDynamicAddressFeedNameUniquenessStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	servers := cfg.Security.DynamicAddress.FeedServers
+	if len(servers) == 0 {
+		return nil
+	}
+	// FeedServers is a map (unordered); sort keys so the first-error
+	// commit-check message is deterministic across runs, and so the "first"
+	// declaring server recorded per name matches feeds.Apply's sorted winner.
+	names := make([]string, 0, len(servers))
+	for name := range servers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	owner := make(map[string]string) // effective feed name -> first declaring server display name
+	for _, name := range names {
+		fs := servers[name]
+		if fs == nil || feedServerBaseURLEmpty(fs) {
+			continue
+		}
+		display := fs.Name
+		if display == "" {
+			display = name
+		}
+		add := func(feedName string) error {
+			if feedName == "" {
+				return nil
+			}
+			if prev, ok := owner[feedName]; ok {
+				return fmt.Errorf("security dynamic-address feed name %q is "+
+					"declared by more than one feed-server (%q and %q) — a feed "+
+					"name is a unique identity: the duplicate would start an "+
+					"orphaned refresh loop and back enforcement with a "+
+					"nondeterministic provider; rename one feed", feedName, prev, display)
+			}
+			owner[feedName] = display
+			return nil
+		}
+		if len(fs.FeedEntries) > 0 {
+			for _, fe := range fs.FeedEntries {
+				if err := add(fe.Name); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		key := fs.FeedName
+		if key == "" {
+			key = fs.Name
+		}
+		if err := add(key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // validateDynamicAddressFeedReferencesStrict hard-rejects a
 // `security dynamic-address address-name <addr> profile feed-name <feed>`
 // binding whose `<feed>` resolves to no declared feed (#3300). The

--- a/pkg/config/dynamic_address_feed_dup_name_4913_test.go
+++ b/pkg/config/dynamic_address_feed_dup_name_4913_test.go
@@ -1,0 +1,138 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// dynamic_address_feed_dup_name_4913_test.go: #4913 — feeds.Manager keys its
+// worker map + enforcement snapshot by the effective feed name, so two
+// feed-servers declaring the SAME effective name orphan a refresh loop
+// (goroutine leak) and back enforcement with a nondeterministic provider. The
+// strict compile gate must reject a globally-duplicate feed name at commit /
+// commit-check and downgrade to a warning on the tolerant load / peer-sync
+// path. Reverting the validateDynamicAddressFeedNameUniquenessStrict wiring
+// makes the "commit rejects" subtests accept the duplicate — RED.
+
+func buildTree4913(t *testing.T, setCommands []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range setCommands {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+func TestValidateDynamicAddressFeedNameUniqueness(t *testing.T) {
+	// Two feed-servers each declare a per-feed entry named "malware" — the
+	// duplicate would overwrite m.feeds["malware"] and orphan one refresh loop.
+	t.Run("commit rejects nested-entry name collision across servers", func(t *testing.T) {
+		tree := buildTree4913(t, []string{
+			"set security dynamic-address feed-server aaa url https://a.example/list.txt",
+			"set security dynamic-address feed-server aaa feed-name malware path /m1.txt",
+			"set security dynamic-address feed-server bbb url https://b.example/list.txt",
+			"set security dynamic-address feed-server bbb feed-name malware path /m2.txt",
+		})
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatal("CompileConfig should reject a feed name declared by two feed-servers")
+		}
+		if !strings.Contains(err.Error(), "malware") {
+			t.Fatalf("error should name the duplicated feed, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "aaa") || !strings.Contains(err.Error(), "bbb") {
+			t.Fatalf("error should name both declaring servers, got: %v", err)
+		}
+	})
+
+	// The subtle case (#4913 "nested-entry vs single-feed-fallback collision"):
+	// a feed-server with neither feed-name nor entries keys on its SERVER name,
+	// which collides with another server's per-feed entry of the same name.
+	t.Run("commit rejects server-name-fallback vs nested-entry collision", func(t *testing.T) {
+		tree := buildTree4913(t, []string{
+			"set security dynamic-address feed-server malware url https://a.example/list.txt",
+			"set security dynamic-address feed-server threat url https://b.example/list.txt",
+			"set security dynamic-address feed-server threat feed-name malware path /m.txt",
+		})
+		if _, err := CompileConfig(tree); err == nil {
+			t.Fatal("CompileConfig should reject a server-name key colliding with another server's feed entry")
+		}
+	})
+
+	// A single-feed FeedName colliding with another server's server-name key.
+	t.Run("commit rejects single-feed-name vs server-name collision", func(t *testing.T) {
+		tree := buildTree4913(t, []string{
+			"set security dynamic-address feed-server alpha url https://a.example/list.txt",
+			"set security dynamic-address feed-server alpha feed-name shared",
+			"set security dynamic-address feed-server shared url https://b.example/list.txt",
+		})
+		if _, err := CompileConfig(tree); err == nil {
+			t.Fatal("CompileConfig should reject a single-feed FeedName colliding with a server-name key")
+		}
+	})
+
+	// No false positives: distinct feed names across servers compile clean.
+	t.Run("commit accepts distinct feed names", func(t *testing.T) {
+		tree := buildTree4913(t, []string{
+			"set security dynamic-address feed-server aaa url https://a.example/list.txt",
+			"set security dynamic-address feed-server aaa feed-name malware path /m1.txt",
+			"set security dynamic-address feed-server bbb url https://b.example/list.txt",
+			"set security dynamic-address feed-server bbb feed-name spyware path /m2.txt",
+		})
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("distinct feed names should compile, got: %v", err)
+		}
+	})
+
+	// Two entries with the same name WITHIN one server are still a collision
+	// (same worker-map key). Flat-set merges duplicate `feed-name malware`
+	// nodes into one entry, so this shape is only reachable via a hierarchical
+	// parse / direct struct — validate the gate directly on a built *Config.
+	t.Run("validator rejects duplicate entry names within one server", func(t *testing.T) {
+		cfg := &Config{}
+		cfg.Security.DynamicAddress.FeedServers = map[string]*FeedServer{
+			"aaa": {
+				Name: "aaa",
+				URL:  "https://a.example/list.txt",
+				FeedEntries: []FeedEntry{
+					{Name: "malware", Path: "/m1.txt"},
+					{Name: "malware", Path: "/m2.txt"},
+				},
+			},
+		}
+		if err := validateDynamicAddressFeedNameUniquenessStrict(cfg); err == nil {
+			t.Fatal("validator should reject two same-named entries within one feed-server")
+		}
+	})
+
+	// Tolerant load / peer-sync: a persisted duplicate must not brick the load
+	// — it downgrades to a warning (the runtime de-dups deterministically).
+	t.Run("lenient load downgrades duplicate to warning", func(t *testing.T) {
+		tree := buildTree4913(t, []string{
+			"set security dynamic-address feed-server aaa url https://a.example/list.txt",
+			"set security dynamic-address feed-server aaa feed-name malware path /m1.txt",
+			"set security dynamic-address feed-server bbb url https://b.example/list.txt",
+			"set security dynamic-address feed-server bbb feed-name malware path /m2.txt",
+		})
+		cfg, err := CompileConfigLenient(tree)
+		if err != nil {
+			t.Fatalf("lenient compile should not fail on a duplicate feed name, got: %v", err)
+		}
+		var found bool
+		for _, w := range cfg.Warnings {
+			if strings.Contains(w, "feed name") && strings.Contains(w, "malware") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("lenient compile should record a duplicate-feed-name warning, warnings=%v", cfg.Warnings)
+		}
+	})
+}

--- a/pkg/feeds/feeds.go
+++ b/pkg/feeds/feeds.go
@@ -170,26 +170,73 @@ func (m *Manager) Apply(ctx context.Context, daCfg *config.DynamicAddressConfig)
 	}
 
 	m.mu.Lock()
-	for _, fsCfg := range daCfg.FeedServers {
+	defer m.mu.Unlock()
+
+	// Build a COMPLETE, deterministic, de-duplicated plan BEFORE starting any
+	// refresh goroutine (#4913). daCfg.FeedServers is a Go map, so ranging it
+	// visits servers in nondeterministic order, and two feed-servers can
+	// declare the SAME effective feed name. The pre-#4913 loop assigned
+	// m.feeds[name] = fs and started a refresh loop per entry as it went, so a
+	// duplicate name OVERWROTE the earlier map entry — orphaning that worker's
+	// cancel func (StopAll then cancels only the survivor, so the overwritten
+	// loop kept fetching / logging / firing onUpdate until the daemon's parent
+	// context ended) — and enforcement read whichever provider won the last map
+	// iteration (nondeterministic across commits / restarts). Sorting the
+	// server keys and keeping only the FIRST occurrence of each effective feed
+	// name makes the winner deterministic and guarantees exactly one refresh
+	// loop — hence exactly one cancel — per name, so no goroutine is orphaned.
+	type feedPlan struct {
+		name     string
+		url      string
+		hold     time.Duration
+		interval time.Duration
+		server   string
+	}
+	serverNames := make([]string, 0, len(daCfg.FeedServers))
+	for sn := range daCfg.FeedServers {
+		serverNames = append(serverNames, sn)
+	}
+	sort.Strings(serverNames)
+
+	var plans []feedPlan
+	seen := make(map[string]bool)
+	for _, sn := range serverNames {
+		fsCfg := daCfg.FeedServers[sn]
+		if fsCfg == nil {
+			continue
+		}
 		baseURL := resolveBaseURL(fsCfg)
 		if baseURL == "" {
 			continue
 		}
-
 		interval := time.Duration(fsCfg.UpdateInterval) * time.Second
 		if interval <= 0 {
 			interval = time.Hour
 		}
 		hold := resolveHoldInterval(fsCfg.HoldInterval)
-		// Human-readable hold for the start log: retainForever (the default)
-		// would otherwise log as "0s".
-		holdStr := "forever"
-		if hold > 0 {
-			holdStr = hold.String()
+
+		plan := func(name, url string) {
+			if name == "" {
+				return
+			}
+			if seen[name] {
+				// A feed name is an identity: two feeds sharing one would race
+				// on m.feeds[name] and orphan a refresh loop. Keep the first
+				// (deterministic winner: lexicographically-first server, then
+				// declaration order) and drop the duplicate with a warning. The
+				// strict compile gate (validateDynamicAddressFeedNameUniqueness
+				// Strict) rejects this at commit; this de-dup is the runtime
+				// safety net for a leniently-loaded / peer-synced config.
+				slog.Warn("dynamic-address: duplicate feed name ignored — only the first declaration starts a refresh loop (declare each feed name once)",
+					"name", name, "server", fsCfg.Name, "url", url)
+				return
+			}
+			seen[name] = true
+			plans = append(plans, feedPlan{name: name, url: url, hold: hold, interval: interval, server: fsCfg.Name})
 		}
 
 		if len(fsCfg.FeedEntries) > 0 {
-			// Multiple named feeds with per-feed paths
+			// Multiple named feeds with per-feed paths.
 			for _, fe := range fsCfg.FeedEntries {
 				feedURL := baseURL
 				if fe.Path != "" {
@@ -199,41 +246,40 @@ func (m *Manager) Apply(ctx context.Context, daCfg *config.DynamicAddressConfig)
 					}
 					feedURL = baseURL + p
 				}
-				feedCtx, cancel := context.WithCancel(ctx)
-				fs := &feedState{
-					name:         fe.Name,
-					url:          feedURL,
-					holdInterval: hold,
-					cancel:       cancel,
-				}
-				m.feeds[fe.Name] = fs
-				warnPlaintextFeed(fe.Name, feedURL)
-				go m.refreshLoop(feedCtx, fs, interval)
-				slog.Info("dynamic address feed started",
-					"name", fe.Name, "server", fsCfg.Name, "url", feedURL,
-					"interval", interval, "hold", holdStr)
+				plan(fe.Name, feedURL)
 			}
 		} else {
-			// Single feed (backward compat): keyed by FeedName or server name
+			// Single feed (backward compat): keyed by FeedName or server name.
 			key := fsCfg.FeedName
 			if key == "" {
 				key = fsCfg.Name
 			}
-			feedCtx, cancel := context.WithCancel(ctx)
-			fs := &feedState{
-				name:         key,
-				url:          baseURL,
-				holdInterval: hold,
-				cancel:       cancel,
-			}
-			m.feeds[key] = fs
-			warnPlaintextFeed(key, baseURL)
-			go m.refreshLoop(feedCtx, fs, interval)
-			slog.Info("dynamic address feed started",
-				"name", key, "url", baseURL, "interval", interval, "hold", holdStr)
+			plan(key, baseURL)
 		}
 	}
-	m.mu.Unlock()
+
+	// Start exactly one refresh loop per unique planned feed.
+	for _, p := range plans {
+		// Human-readable hold for the start log: retainForever (the default)
+		// would otherwise log as "0s".
+		holdStr := "forever"
+		if p.hold > 0 {
+			holdStr = p.hold.String()
+		}
+		feedCtx, cancel := context.WithCancel(ctx)
+		fs := &feedState{
+			name:         p.name,
+			url:          p.url,
+			holdInterval: p.hold,
+			cancel:       cancel,
+		}
+		m.feeds[p.name] = fs
+		warnPlaintextFeed(p.name, p.url)
+		go m.refreshLoop(feedCtx, fs, p.interval)
+		slog.Info("dynamic address feed started",
+			"name", p.name, "server", p.server, "url", p.url,
+			"interval", p.interval, "hold", holdStr)
+	}
 }
 
 // StopAll cancels all running feed refresh goroutines.

--- a/pkg/feeds/feeds_dup_name_4913_test.go
+++ b/pkg/feeds/feeds_dup_name_4913_test.go
@@ -1,0 +1,119 @@
+package feeds
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// feeds_dup_name_4913_test.go: #4913 — two feed-servers declaring the same
+// effective feed name must NOT start two refresh loops. The pre-#4913 Apply
+// ranged the unordered FeedServers map and assigned m.feeds[name] = fs per
+// entry, so a duplicate name started a SECOND refresh loop and OVERWROTE the
+// first worker in the map — orphaning its cancel (StopAll then cancels only the
+// survivor, so the overwritten loop keeps fetching until the parent context
+// ends) — and the winning provider was nondeterministic (map order). Apply now
+// builds a deterministic, de-duplicated plan and starts exactly ONE loop per
+// name. Reverting that de-dup starts two loops → two initial fetches → RED.
+
+// countingFeedServer serves a valid feed body and signals + counts every GET.
+type countingFeedServer struct {
+	count atomic.Int64
+	hits  chan struct{}
+}
+
+func newCountingFeedServer() *countingFeedServer {
+	return &countingFeedServer{hits: make(chan struct{}, 8)}
+}
+
+func (c *countingFeedServer) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		c.count.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("192.0.2.0/24\n"))
+		select {
+		case c.hits <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// TestApplyDeDupsDuplicateFeedNames proves Apply starts exactly one refresh loop
+// for a feed name declared by two feed-servers, picks a DETERMINISTIC winner
+// (lexicographically-first server), and does NOT orphan a second fetcher.
+func TestApplyDeDupsDuplicateFeedNames(t *testing.T) {
+	cs := newCountingFeedServer()
+	ts := httptest.NewServer(cs.handler())
+	defer ts.Close()
+
+	m := New(func() {})
+	// Two servers "aaa" and "bbb" each declare the SAME feed name "dup" with a
+	// distinct path so the winner's URL is identifiable. Both hit the same
+	// counting server. Winner must be the sorted-first server, "aaa".
+	daCfg := &config.DynamicAddressConfig{
+		FeedServers: map[string]*config.FeedServer{
+			"aaa": {
+				Name:        "aaa",
+				URL:         ts.URL,
+				FeedEntries: []config.FeedEntry{{Name: "dup", Path: "/aaa"}},
+			},
+			"bbb": {
+				Name:        "bbb",
+				URL:         ts.URL,
+				FeedEntries: []config.FeedEntry{{Name: "dup", Path: "/bbb"}},
+			},
+		},
+	}
+
+	m.Apply(context.Background(), daCfg)
+	defer m.StopAll()
+
+	// Exactly one worker is registered for the duplicated name, and it is the
+	// deterministic winner (server "aaa", path /aaa).
+	m.mu.RLock()
+	nWorkers := len(m.feeds)
+	winner, ok := m.feeds["dup"]
+	var winnerURL string
+	if ok {
+		winnerURL = winner.url
+	}
+	m.mu.RUnlock()
+
+	if nWorkers != 1 {
+		t.Fatalf("expected exactly 1 registered feed worker, got %d", nWorkers)
+	}
+	if !ok {
+		t.Fatal(`no worker registered for feed name "dup"`)
+	}
+	if winnerURL != ts.URL+"/aaa" {
+		t.Fatalf("nondeterministic winner: feed %q url = %q, want %q (lexicographically-first server aaa)",
+			"dup", winnerURL, ts.URL+"/aaa")
+	}
+
+	// The single worker's initial fetch must arrive.
+	select {
+	case <-cs.hits:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the winning feed never fetched")
+	}
+
+	// A SECOND fetch would mean a duplicate refresh loop was started (the
+	// orphaned-goroutine bug). The default update interval is 1h, so the
+	// winner will not re-fetch within this window — any second hit is the leak.
+	select {
+	case <-cs.hits:
+		t.Fatalf("a second fetch fired — the duplicate feed name started an orphaned refresh loop (#4913 regression); total fetches=%d",
+			cs.count.Load())
+	case <-time.After(time.Second):
+		// good: exactly one refresh loop runs for the name.
+	}
+
+	if got := cs.count.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 total fetch, got %d (duplicate feed name started an orphaned loop)", got)
+	}
+}


### PR DESCRIPTION
## Summary

`feeds.Manager` keys its worker map (`m.feeds`) and enforcement snapshot by the effective feed name (each `FeedEntry.Name`; or a single-feed server's `FeedName`, falling back to the server name). Globally-duplicate feed names were not rejected, and `Apply` ranged the **unordered** `daCfg.FeedServers` map, doing `m.feeds[name] = fs` + `go refreshLoop` per entry. So two servers declaring the same effective name each started a refresh loop, and the later map iteration **overwrote** the first worker — orphaning its cancel func (`StopAll` cancels only the survivor, so the overwritten loop kept fetching/logging/firing `onUpdate` until the parent ctx ended) — while enforcement was backed by whichever provider won the last map iteration (nondeterministic across commits/restarts).

## Fix (two layers)

- **Runtime (`Apply`)**: build a complete, deterministic (sorted server keys), de-duplicated plan **before** starting any goroutine; start exactly one refresh loop per name (first wins, duplicate dropped with a warning). No orphaned cancel; deterministic winner.
- **Config validation**: new strict gate `validateDynamicAddressFeedNameUniquenessStrict` hard-rejects a globally-duplicate effective feed name at commit / commit-check (lenient-warn on load/peer-sync). Derives effective names exactly as `feeds.Manager` does and excludes endpoint-less servers (which `Apply` skips).

## Tests

- `TestApplyDeDupsDuplicateFeedNames` — two servers, same feed name → asserts one refresh loop, deterministic (sorted-first) winner, and no second orphaned fetch. Reverting the de-dup → RED (nondeterministic winner + second fetch).
- `TestValidateDynamicAddressFeedNameUniqueness` — cross-server nested-entry / server-name-fallback / single-feed-name collisions rejected at strict commit; lenient load warns. Neutralizing the gate → RED.

`go build ./...`, `go vet ./pkg/feeds/ ./pkg/config/`, and the full feeds + config suites are green.

Closes #4913

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi