### PR TITLE
daemon: harden applySystemLogin against option injection (#5005)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,19 @@
+## 2026-07-09 — #5005 daemon: applySystemLogin option-injection (missing `--` + no defensive username re-validation)
+
+- **Timestamp**: 2026-07-09
+  **Action**: #5005 (security). `applySystemLogin` ran root `id`/`useradd`/
+  `chown` with the config username as a leading positional arg and no `--`
+  end-of-options separator, and never re-validated the name. On the tolerant
+  load / peer-sync path the strict commit-check is downgraded to a warning
+  (#1960), so a leading-dash name could reach these root tools as an option.
+  Fixed by mirroring the #4895 sudoers writer: defensively call
+  `config.ValidateLoginUsername` at the top of the per-user loop (skip+warn on
+  failure) AND add `--` before the operand in every exec (`id -- <name>`,
+  `useradd ... -- <name>`, `chown -R -- <owner> <dir>`). Made `runCommandTimeout`
+  a stubbable package var so the option-injection test can capture argv.
+  **File(s)**: pkg/daemon/daemon_system.go, pkg/daemon/exec_timeout.go,
+  pkg/daemon/daemon_login_optinjection_5005_test.go
+
 ## 2026-07-09 — #4910 grpcapi: active MonitorInterface stream could block daemon shutdown forever (GracefulStop with no timeout)
 
 - **Timestamp**: 2026-07-09

--- a/pkg/daemon/daemon_login_optinjection_5005_test.go
+++ b/pkg/daemon/daemon_login_optinjection_5005_test.go
@@ -1,0 +1,121 @@
+package daemon
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5005: applySystemLogin runs root-privileged id/useradd/chown with the
+// config-supplied username as a positional argument. On the tolerant load /
+// peer-sync path the strict commit-check for the username is downgraded to a
+// warning (#1960), so a leading-dash / otherwise unsafe name can reach the
+// account writer. The writer must (a) defensively re-validate the name and skip
+// it entirely (mirroring the #4895 sudoers writer), and (b) pass a `--`
+// end-of-options separator before the operand so a name is never parsed as an
+// option (option injection).
+
+type recordedCmd struct {
+	name string
+	args []string
+}
+
+// withHermeticAccountDB points the passwd/shadow readers at nonexistent temp
+// paths so lookupUID/currentShadowHash deterministically report "absent" — the
+// reconcile then takes no chpasswd action and applySystemLogin's only external
+// effects are the id/useradd calls we capture.
+func withHermeticAccountDB(t *testing.T) {
+	t.Helper()
+	missing := filepath.Join(t.TempDir(), "nonexistent")
+	origPasswd, origShadow := passwdPath, shadowPath
+	passwdPath = missing
+	shadowPath = missing
+	t.Cleanup(func() { passwdPath, shadowPath = origPasswd, origShadow })
+}
+
+// captureRunCommand stubs the runCommandTimeout seam, recording every argv and
+// forcing the "user does not exist" branch (non-nil error from `id`) so the
+// useradd call is always exercised.
+func captureRunCommand(t *testing.T) *[]recordedCmd {
+	t.Helper()
+	var calls []recordedCmd
+	orig := runCommandTimeout
+	runCommandTimeout = func(name string, args ...string) ([]byte, error) {
+		calls = append(calls, recordedCmd{name: name, args: append([]string(nil), args...)})
+		if name == "id" {
+			return nil, fmt.Errorf("id: no such user (stub)")
+		}
+		return nil, nil
+	}
+	t.Cleanup(func() { runCommandTimeout = orig })
+	return &calls
+}
+
+// TestApplySystemLoginSkipsUnsafeName is the RED-on-revert guard for the
+// defensive re-validation half of #5005: a leading-dash username must never
+// reach id/useradd/chown. Revert the ValidateLoginUsername skip and `-r` flows
+// straight into `id -- -r` / `useradd ... -- -r`, so the "no argv references the
+// unsafe name" assertion fails.
+func TestApplySystemLoginSkipsUnsafeName(t *testing.T) {
+	withHermeticAccountDB(t)
+	calls := captureRunCommand(t)
+
+	d := &Daemon{}
+	cfg := loginCfg(
+		&config.LoginUser{Name: "-r", Class: "operator"},    // option-injection attempt
+		&config.LoginUser{Name: "admin", Class: "operator"}, // valid peer still provisioned
+	)
+	d.applySystemLogin(cfg)
+
+	sawAdmin := false
+	for _, c := range *calls {
+		for _, a := range c.args {
+			if a == "-r" {
+				t.Fatalf("unsafe username reached %q argv %v — defensive re-validation missing (#5005)", c.name, c.args)
+			}
+			if a == "admin" {
+				sawAdmin = true
+			}
+		}
+	}
+	if !sawAdmin {
+		t.Fatal("valid peer 'admin' was never provisioned — the skip must not drop good users")
+	}
+}
+
+// TestApplySystemLoginUsesEndOfOptions is the RED-on-revert guard for the `--`
+// half of #5005. It asserts the id and useradd invocations for a valid user
+// place a `--` immediately before the username operand. Drop either `--` and
+// the operand appears without its separator, failing the assertion.
+func TestApplySystemLoginUsesEndOfOptions(t *testing.T) {
+	withHermeticAccountDB(t)
+	calls := captureRunCommand(t)
+
+	d := &Daemon{}
+	d.applySystemLogin(loginCfg(&config.LoginUser{Name: "admin", Class: "operator"}))
+
+	var idArgs, useraddArgs []string
+	for _, c := range *calls {
+		switch c.name {
+		case "id":
+			idArgs = c.args
+		case "useradd":
+			useraddArgs = c.args
+		}
+	}
+
+	if len(idArgs) != 2 || idArgs[0] != "--" || idArgs[1] != "admin" {
+		t.Errorf("id argv = %v, want [-- admin] (missing end-of-options separator, #5005)", idArgs)
+	}
+	if !endsWithSeparatedOperand(useraddArgs, "admin") {
+		t.Errorf("useradd argv = %v, want a `--` immediately before the operand %q (#5005)", useraddArgs, "admin")
+	}
+}
+
+// endsWithSeparatedOperand reports whether argv ends with "--", operand.
+func endsWithSeparatedOperand(argv []string, operand string) bool {
+	n := len(argv)
+	return n >= 2 && argv[n-2] == "--" && argv[n-1] == operand
+}

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -818,17 +818,35 @@ func (d *Daemon) applySystemLogin(cfg *config.Config) {
 			continue // never create/modify root via config
 		}
 
+		// #5005 defense in depth: never format an unvalidated username into a
+		// root-privileged id/useradd/chown invocation. The strict commit-check
+		// rejects a crafted name (schema keyValidator, ValidateLoginUsername),
+		// but the tolerant load / peer-sync path downgrades that to a warning
+		// (#1960), so a leading-dash or otherwise unsafe name can still reach
+		// here. Skip it entirely — the same doctrine the sudoers writer already
+		// applies (reconcileSudoers/writeSudoersGrant, #4895). Combined with the
+		// `--` end-of-options separators below, this fails closed against option
+		// injection into the account/SSH-key writer.
+		if err := config.ValidateLoginUsername(user.Name, nil); err != nil {
+			slog.Warn("refusing to provision invalid login user name",
+				"user", user.Name, "err", err)
+			continue
+		}
+
 		// Check if user already exists. A non-zero exit means "user
 		// doesn't exist"; a timeout also lands here, in which case the
-		// useradd below fails with "already exists" and is logged.
-		_, err := runCommandTimeout("id", user.Name)
+		// useradd below fails with "already exists" and is logged. The `--`
+		// stops id treating a name as an option (#5005).
+		_, err := runCommandTimeout("id", "--", user.Name)
 		if err != nil {
 			// User doesn't exist — create it
 			args := []string{"-m", "-s", "/bin/bash"}
 			if user.UID > 0 {
 				args = append(args, "-u", fmt.Sprintf("%d", user.UID))
 			}
-			args = append(args, user.Name)
+			// `--` before the operand so a name is never parsed as a useradd
+			// option (#5005 option-injection defense).
+			args = append(args, "--", user.Name)
 			if out, err := runCommandTimeout("useradd", args...); err != nil {
 				slog.Warn("failed to create user",
 					"user", user.Name, "err", err, "output", string(out))
@@ -892,7 +910,8 @@ func (d *Daemon) applySystemLogin(cfg *config.Config) {
 			// content then matches on reboot, the whole block (and the chown)
 			// would skip forever — never repairing the dir owner (Codex r2
 			// HIGH). Running it every apply closes that window.
-			if out, err := runCommandTimeout("chown", "-R", user.Name+":"+user.Name, sshDir); err != nil {
+			// `--` stops chown parsing "-name:-name" as options (#5005).
+			if out, err := runCommandTimeout("chown", "-R", "--", user.Name+":"+user.Name, sshDir); err != nil {
 				slog.Warn("failed to chown ssh dir",
 					"user", user.Name, "dir", sshDir,
 					"err", err, "output", strings.TrimSpace(string(out)))

--- a/pkg/daemon/exec_timeout.go
+++ b/pkg/daemon/exec_timeout.go
@@ -21,7 +21,13 @@ const externalCommandTimeout = 15 * time.Second
 // the error reflects the context deadline; callers log the failure and
 // continue — apply success/failure semantics are unchanged, failures
 // just become visible and bounded.
-func runCommandTimeout(name string, args ...string) ([]byte, error) {
+//
+// It is a package var (not a bare func) so tests can capture the argv a
+// caller passes to root-privileged tools without spawning real processes —
+// the seam the #5005 applySystemLogin option-injection test uses to assert
+// the `--` end-of-options separator reaches id/useradd/chown. Production
+// code never reassigns it.
+var runCommandTimeout = func(name string, args ...string) ([]byte, error) {
 	return runCommandStdinTimeout(nil, name, args...)
 }
 


### PR DESCRIPTION
## Summary

`applySystemLogin` (`pkg/daemon/daemon_system.go`) ran the root-privileged
`id`, `useradd`, and `chown` commands with the config-supplied login username
as a **leading positional argument** and **no `--` end-of-options separator**,
and never defensively re-validated the name. A username beginning with `-` is
therefore interpreted as an *option* by those tools (option injection):

- `id -u` prints UID 0 and exits 0 → the daemon concludes the user exists and
  skips `useradd`.
- `-r` turns `useradd -m -s /bin/bash -r` into a system-account create.
- `chown -R -name:...` misparses.

The strict operator commit-check rejects such names (`ValidateLoginUsername`,
wired as the schema `keyValidator`), but the tolerant Load / peer `SyncApply`
path (`compileTreeLenient`) downgrades that to a warning (#1960), so a
leniently-loaded or peer-synced config can carry a leading-dash username that
reaches `applySystemLogin`. This is the account/SSH-key-writer analog of the
sudoers-writer path already hardened in #4895.

## Fix (mirrors the #4895 sudoers writer)

1. Re-validate the username with `config.ValidateLoginUsername` at the top of
   the per-user loop; skip+warn on failure so an unsafe name never reaches any
   root exec.
2. Add a `--` end-of-options separator before the operand in every exec:
   `id -- <name>`, `useradd ... -- <name>`, `chown -R -- <owner> <dir>`.
3. Make `runCommandTimeout` a stubbable package var (the same seam idiom as
   `validateSudoersFile` / `trapSender`) so the test can capture argv without
   spawning real processes.

## Validation

- `go build ./...` clean; `go vet ./pkg/daemon` clean; full `pkg/daemon` suite green.
- New RED-on-revert tests, both verified RED by reverting the production change
  then restored to green:
  - `TestApplySystemLoginSkipsUnsafeName` — `-r` must never reach `id`/`useradd`/`chown`.
  - `TestApplySystemLoginUsesEndOfOptions` — `id`/`useradd` must place `--` before the operand.

Closes #5005

🤖 Generated with [Claude Code](https://claude.com/claude-code)