### PR TITLE
config/nat: reject mixed scope kinds in one NAT clause

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,39 @@
+## 2026-07-09 — #4881 config/nat: mixed scope kinds in one NAT from/to clause were OR-expanded (wider), not AND-ed fail-closed as the comment claimed
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4881 (Low, NAT scope widening / fail-open). A single NAT
+  rule-set `from` (or source-`to`, or static-`from`) clause that mixes scope
+  KINDS (e.g. `from zone trust` + `from interface ge-0/0/1.0`) was accepted by
+  the schema (zone/interface/routing-instance are independent `multi:true`
+  leaves with no mutual-exclusion validator) and OR-expanded by the #3096
+  Cartesian product (`collectNATScopes` → `applyNATFromScope` loop,
+  `compiler_nat.go`) into multiple typed rule-sets matching EITHER scope —
+  WIDER than the operator's likely AND intent and contrary to Junos'
+  one-kind-per-clause rule. The in-tree `parseNATMatchScopes` comment falsely
+  claimed the mix was "AND-ed fail-closed at match time" (no such AND exists).
+  Added an AST pre-walk `validateNATRuleSetMixedScopeAST`
+  (`compiler_nat_mixed_scope.go`) that rejects any `from` (all three NAT
+  kinds) or source-NAT `to` clause carrying >1 distinct scope kind at strict
+  commit / commit-check (lenient-warn on load/peer-sync via
+  `lenientNATMixedScope`), mirroring `validateDNATRuleSetToScopeAST` (#3444).
+  Detection reuses `parseNATMatchScopes` and aggregates distinct kinds exactly
+  as the compiler's Cartesian input, uses `forEachChild` for the #3562
+  duplicate-block class, and checks destination NAT on `from` only (its `to`
+  is separately rejected by #3444). Corrected the false comment and documented
+  the gate in `docs/config-schema.md`.
+  **File(s)**: pkg/config/compiler_nat_mixed_scope.go,
+  pkg/config/compiler_prewalk.go, pkg/config/compiler.go,
+  pkg/config/compiler_nat.go (comment),
+  pkg/config/compiler_nat_mixed_scope_4881_test.go, docs/config-schema.md
+  **Validation**: `TestValidateNATRuleSetMixedScope` covers zone+interface,
+  zone+routing-instance, interface+routing-instance across source `from`,
+  source `to`, destination `from`, static `from`, plus no-false-positive
+  (single-kind from + single-kind to; same-kind zone list) and the
+  lenient-load warning. Fail-on-revert: neutralizing the validator makes every
+  reject subtest RED while the accept subtests stay green. `go build ./...`,
+  `go vet ./pkg/config/`, and the full `go test ./pkg/config/` suite are green
+  (no existing test mixes kinds within one clause — no regression).
+
 ## 2026-07-09 — #4882 userspace-dp: debug BPF session dump used `core::ptr::read` (align 2) on a `Vec<u8>` (align 1) — UB; use `read_unaligned`
 
 - **Timestamp**: 2026-07-09

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2745,6 +2745,36 @@ reserved for whole-dataplane selection where a rewrite shim
   (add `to_*` to the snapshot + runtime + a regression that a mismatched
   `to zone` DNAT does not translate). Regression coverage:
   `pkg/config/compiler_nat_dnat_to_3444_test.go`.
+- **#4881 (NAT rule-set mixed-scope-kind reject):** a Junos NAT rule-set
+  `from` (and source-NAT `to`) clause scopes matched traffic by EXACTLY ONE
+  kind — `zone`, `interface`, or `routing-instance`. Multiple VALUES of the
+  chosen kind are a legitimate list (`from zone [ trust untrust ]` = match
+  either zone — OR is correct there), but MIXING kinds in one clause is
+  invalid Junos. `setSchema` declares the three as independent `multi:true`
+  children with no mutual-exclusion validator, and the #3096 compiler
+  Cartesian-expands the collected from-scopes × to-scopes into one typed
+  `NATRuleSet` per `(fromScope, toScope)` pair — so `from zone trust` +
+  `from interface ge-0/0/1.0` compiled into TWO rule-sets matching EITHER
+  scope (OR), WIDER than the operator's intent and contradicting the in-tree
+  `parseNATMatchScopes` comment that claimed the mix was "AND-ed fail-closed
+  at match time" (it never was). An AST pre-walk
+  (`validateNATRuleSetMixedScopeAST`, `compiler_nat_mixed_scope.go`) now
+  hard-rejects any `from` (all three NAT kinds) or source-NAT `to` clause
+  carrying >1 distinct scope kind, at strict commit / commit-check, naming
+  the NAT kind, rule-set, clause, and mixed kinds. Detection reuses
+  `parseNATMatchScopes` + aggregates the distinct kinds exactly as
+  `collectNATScopes` feeds the Cartesian product, so what the gate rejects is
+  precisely what the compiler would OR-expand; it runs after the inactive
+  prune + group expansion so an `inactive:` / apply-groups-inherited mix is
+  handled, and iterates every duplicate `security`/`nat`/`source`/etc. block
+  (`forEachChild`, #3562 class). Downgraded to a warning on the tolerant load
+  / peer-sync paths (`lenientNATMixedScope`, #1960) so an older-binary-
+  persisted or peer-synced config that silently accepted a mixed clause still
+  boots (it is OR-expanded as before, now flagged). A single-kind `from` plus
+  a single-kind `to` (each its own clause) and a same-kind value list are
+  untouched. Destination NAT is checked on `from` only — its `to` clause is
+  separately rejected wholesale by `validateDNATRuleSetToScopeAST` (#3444).
+  Regression coverage: `pkg/config/compiler_nat_mixed_scope_4881_test.go`.
 - **#3562 (strict-reject AST walks must iterate EVERY `security` root — the
   duplicate-block discipline):** `parseStatements` (`parser.go`) APPENDS a
   repeated top-level block instead of merging it, and `compileExpanded` /

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1553,6 +1553,20 @@ type compileOpts struct {
 	// lenientUnsupportedInterfaceStanzas.
 	lenientDNATToScope bool
 
+	// lenientNATMixedScope (#4881) downgrades the NAT rule-set mixed-scope-kind
+	// reject (validateNATRuleSetMixedScopeAST) from a hard compile error to a
+	// cfg.Warnings entry. A single `from` / source-`to` / static-`from` NAT
+	// clause that mixes scope KINDS (e.g. `from zone trust` + `from interface
+	// ge-0/0/1.0`) is OR-expanded by the #3096 Cartesian product into multiple
+	// typed rule-sets — matching EITHER scope, which WIDENS the NAT match beyond
+	// the intended ingress/egress boundary and contradicts Junos' one-kind-per-
+	// clause rule. The strict commit / commit-check path hard-rejects so the
+	// operator error is visible; the tolerant load / peer-sync paths downgrade
+	// to a warning so an already-persisted or peer-synced config an older binary
+	// accepted still BOOTS (#1960 fail-closed-on-load class). Same doctrine as
+	// lenientDNATToScope.
+	lenientNATMixedScope bool
+
 	// lenientEventWithinTrigger (#3751) downgrades the event-options
 	// within/trigger numeric gate (validateEventOptionsWithinAST) from a hard
 	// compile error to a cfg.Warnings entry. A non-numeric / negative / zero /
@@ -1737,6 +1751,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientPolicyCommunityRef:              true,
 		lenientVRRPVirtualAddress:              true,
 		lenientDNATToScope:                     true,
+		lenientNATMixedScope:                   true,
 		lenientEventWithinTrigger:              true,
 		lenientFirewallTCPFlags:                true,
 		lenientCoSNumericCodePoint:             true,
@@ -1990,6 +2005,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientPolicyCommunityRef:              true,
 		lenientVRRPVirtualAddress:              true,
 		lenientDNATToScope:                     true,
+		lenientNATMixedScope:                   true,
 		lenientEventWithinTrigger:              true,
 		lenientFirewallTCPFlags:                true,
 		lenientCoSNumericCodePoint:             true,

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -1039,9 +1039,16 @@ var natScopeKinds = []string{"zone", "interface", "routing-instance"}
 //     child's Keys, plus defensive orphan grandchildren — mirroring
 //     parseZoneList / firewallMatchValues).
 //
-// Junos restricts a single from/to clause to ONE kind; xpf accumulates
-// whatever is present so a hostile mixed-kind clause is captured (and AND-ed
-// fail-closed at match time) rather than silently dropped.
+// Junos restricts a single from/to clause to ONE kind. This function
+// accumulates every kind present so the mixed-kind case is VISIBLE rather than
+// silently dropped, but a mixed-kind clause is REJECTED at commit /
+// commit-check by validateNATRuleSetMixedScopeAST (#4881) — it never reaches
+// the Cartesian expansion, which would OR-expand it into multiple rule-sets and
+// widen the match (there is no AND-at-match-time enforcement; the prior comment
+// claiming that was wrong). On the tolerant load / peer-sync path the reject is
+// downgraded to a warning, so a persisted mixed-kind clause still boots and is
+// OR-expanded as before — accumulating every kind here keeps that legacy
+// behaviour intact for the leniently-loaded case.
 func parseNATMatchScopes(node *Node) []natMatchScope {
 	var out []natMatchScope
 	// Inline shape: `from`/`to` carries the scope on its own Keys.

--- a/pkg/config/compiler_nat_mixed_scope.go
+++ b/pkg/config/compiler_nat_mixed_scope.go
@@ -1,0 +1,159 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// compiler_nat_mixed_scope.go carries the #4881 reject-at-commit gate for a NAT
+// rule-set `from` / source-`to` / static-`from` clause that mixes scope KINDS.
+//
+// A Junos NAT rule-set `from` (and source-NAT `to`) clause scopes matched
+// traffic by EXACTLY ONE kind: `zone`, `interface`, or `routing-instance`.
+// Multiple VALUES of the chosen kind are a legitimate list (`from zone [ trust
+// untrust ]` = match either zone — OR is correct there). But MIXING kinds in
+// one clause is invalid Junos.
+//
+// xpf's setSchema declares zone / interface / routing-instance as independent
+// `multi:true` children with no mutual-exclusion validator, and the #3096
+// compiler Cartesian-expands the collected from-scopes × to-scopes into one
+// typed NATRuleSet per (fromScope, toScope) pair (collectNATScopes /
+// applyNATFromScope in compiler_nat.go). So `from zone trust` + `from interface
+// ge-0/0/1.0` compiles into TWO rule-sets — FromZone=trust and
+// FromInterface=ge-0/0/1.0 — with identical rules, matching traffic on EITHER
+// scope. That is OR, i.e. WIDER than the operator's intent, and it directly
+// contradicts the in-tree parseNATMatchScopes comment that claims a mixed-kind
+// clause is "AND-ed fail-closed at match time" (it is not; the AND never
+// happens). Reject the mixed-kind clause at commit so the ambiguous config
+// fails CLOSED (operator error visible) instead of OPEN (silently widened).
+//
+// This is an AST pre-walk (not a SchemaValidate typed leaf) because
+// SchemaValidate returns nil for structural shapes it does not own and cannot
+// REJECT a stanza; the individual zone/interface/routing-instance leaves are
+// each independently legal, so only a cross-leaf check catches the mix. The
+// walk runs on the group-expanded, inactive-pruned tree (compileConfig*Opts
+// strips inactive subtrees and expands groups before compileExpanded), so an
+// apply-groups-inherited mixed clause is caught and an `inactive:` rule-set is
+// ignored for free. Detection mirrors the compiler's own scope collection: it
+// reuses parseNATMatchScopes on each `from` / `to` clause node and aggregates
+// the DISTINCT kinds exactly as collectNATScopes feeds the Cartesian product,
+// so what the gate rejects is precisely what the compiler would OR-expand.
+//
+// Strict path (commit / commit-check, lenient=false): the first offending
+// clause is a hard compile error naming the NAT kind, rule-set, clause, and the
+// mixed kinds. Lenient path (load / peer-sync, lenient=true): every offending
+// clause is a warning and compilation continues — the config an older binary
+// accepted still boots (#1960), now flagged. Mirrors
+// validateDNATRuleSetToScopeAST (#3444). Destination NAT is checked on `from`
+// only: its `to` clause is separately hard-rejected by
+// validateDNATRuleSetToScopeAST, so a mixed-kind DNAT `to` never reaches here.
+
+// natClauseScopeKinds returns the SET of distinct scope kinds (zone /
+// interface / routing-instance), sorted for a deterministic message, present
+// across every `clause` (`from` or `to`) child of a rule-set node. It
+// aggregates across sibling clause nodes exactly as collectNATScopes does, so
+// the kind count matches the compiler's Cartesian-expansion input. An empty
+// clause contributes no kinds (the match-any default is injected later by
+// collectNATScopes, never here).
+func natClauseScopeKinds(rsNode *Node, clause string) []string {
+	seen := make(map[string]bool)
+	for _, child := range rsNode.Children {
+		if child.Name() != clause {
+			continue
+		}
+		for _, sc := range parseNATMatchScopes(child) {
+			if sc.kind != "" {
+				seen[sc.kind] = true
+			}
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	kinds := make([]string, 0, len(seen))
+	for k := range seen {
+		kinds = append(kinds, k)
+	}
+	sort.Strings(kinds)
+	return kinds
+}
+
+// validateNATRuleSetMixedScopeAST walks the `security nat {source|destination|
+// static}` rule-sets of the group-expanded AST and rejects any `from`
+// clause (all three NAT kinds) or source-NAT `to` clause that carries more than
+// one distinct scope kind.
+func validateNATRuleSetMixedScopeAST(nodes []*Node, lenient bool) ([]string, error) {
+	var warnings []string
+	emit := func(natKind, rsName, clause string, kinds []string) error {
+		msg := fmt.Sprintf(
+			"security nat %s rule-set %q: the `%s` clause mixes %d scope kinds "+
+				"(%s) — a Junos NAT from/to clause scopes by exactly ONE kind "+
+				"(zone | interface | routing-instance); mixing kinds OR-expands "+
+				"into multiple rule-sets and WIDENS the match beyond the intended "+
+				"ingress/egress boundary — use a single kind per clause (#4881)",
+			natKind, rsName, clause, len(kinds), strings.Join(kinds, ", "))
+		if !lenient {
+			return fmt.Errorf("%s", msg)
+		}
+		warnings = append(warnings, msg)
+		return nil
+	}
+
+	checkClause := func(natKind, rsName string, rsNode *Node, clause string) error {
+		kinds := natClauseScopeKinds(rsNode, clause)
+		if len(kinds) <= 1 {
+			return nil
+		}
+		return emit(natKind, rsName, clause, kinds)
+	}
+
+	// Iterate ALL matching children at EVERY level (forEachChild), not the
+	// first match: parseStatements APPENDS a repeated block as a sibling and
+	// the compiler compiles every one, so a first-match-only walk is bypassable
+	// (the #3562 multi-level duplicate-block class), mirroring
+	// validateDNATRuleSetToScopeAST.
+	err := forEachChild(nodes, "security", func(sec *Node) error {
+		return forEachChild(sec.Children, "nat", func(nat *Node) error {
+			// Source NAT: `from` AND `to`.
+			if err := forEachChild(nat.Children, "source", func(src *Node) error {
+				for _, rs := range namedInstances(src.FindChildren("rule-set")) {
+					if err := checkClause("source", rs.name, rs.node, "from"); err != nil {
+						return err
+					}
+					if err := checkClause("source", rs.name, rs.node, "to"); err != nil {
+						return err
+					}
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+			// Destination NAT: `from` only (the `to` clause is rejected
+			// wholesale by validateDNATRuleSetToScopeAST).
+			if err := forEachChild(nat.Children, "destination", func(dst *Node) error {
+				for _, rs := range namedInstances(dst.FindChildren("rule-set")) {
+					if err := checkClause("destination", rs.name, rs.node, "from"); err != nil {
+						return err
+					}
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+			// Static NAT: `from` only.
+			return forEachChild(nat.Children, "static", func(st *Node) error {
+				for _, rs := range namedInstances(st.FindChildren("rule-set")) {
+					if err := checkClause("static", rs.name, rs.node, "from"); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+	return warnings, nil
+}

--- a/pkg/config/compiler_nat_mixed_scope_4881_test.go
+++ b/pkg/config/compiler_nat_mixed_scope_4881_test.go
@@ -1,0 +1,150 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// compiler_nat_mixed_scope_4881_test.go: #4881 — a single NAT rule-set `from`
+// (or source-`to`, or static-`from`) clause that mixes scope KINDS (zone +
+// interface + routing-instance) was accepted and OR-expanded by the #3096
+// Cartesian product into multiple typed rule-sets, matching EITHER scope —
+// WIDER than the operator's intent and contrary to Junos' one-kind-per-clause
+// rule. The strict compile gate now rejects the mixed-kind clause at commit /
+// commit-check and warns on the tolerant load / peer-sync path. Reverting the
+// validateNATRuleSetMixedScopeAST wiring makes the "reject" subtests accept the
+// widened config — RED.
+
+func TestValidateNATRuleSetMixedScope(t *testing.T) {
+	// Reject: two different scope KINDS in one source-NAT `from` clause. This is
+	// the exact reproduction from the issue.
+	t.Run("source from zone+interface rejected", func(t *testing.T) {
+		tree := buildNATScopeTree(t,
+			"set security nat source rule-set RS from zone trust",
+			"set security nat source rule-set RS from interface ge-0/0/1.0",
+			"set security nat source rule-set RS rule R1 then source-nat interface",
+		)
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatal("CompileConfig should reject a source-NAT from clause mixing zone + interface")
+		}
+		msg := err.Error()
+		for _, want := range []string{"source", "RS", "from", "zone", "interface"} {
+			if !strings.Contains(msg, want) {
+				t.Fatalf("error should mention %q, got: %v", want, err)
+			}
+		}
+	})
+
+	t.Run("source from zone+routing-instance rejected", func(t *testing.T) {
+		tree := buildNATScopeTree(t,
+			"set security nat source rule-set RS from zone trust",
+			"set security nat source rule-set RS from routing-instance blue",
+			"set security nat source rule-set RS rule R1 then source-nat interface",
+		)
+		if _, err := CompileConfig(tree); err == nil {
+			t.Fatal("CompileConfig should reject a source-NAT from clause mixing zone + routing-instance")
+		}
+	})
+
+	t.Run("source from interface+routing-instance rejected", func(t *testing.T) {
+		tree := buildNATScopeTree(t,
+			"set security nat source rule-set RS from interface ge-0/0/1.0",
+			"set security nat source rule-set RS from routing-instance blue",
+			"set security nat source rule-set RS rule R1 then source-nat interface",
+		)
+		if _, err := CompileConfig(tree); err == nil {
+			t.Fatal("CompileConfig should reject a source-NAT from clause mixing interface + routing-instance")
+		}
+	})
+
+	// The source-NAT `to` clause is also scoped by one kind.
+	t.Run("source to zone+interface rejected", func(t *testing.T) {
+		tree := buildNATScopeTree(t,
+			"set security nat source rule-set RS from zone trust",
+			"set security nat source rule-set RS to zone untrust",
+			"set security nat source rule-set RS to interface ge-0/0/2.0",
+			"set security nat source rule-set RS rule R1 then source-nat interface",
+		)
+		msgErr := func() error { _, e := CompileConfig(tree); return e }()
+		if msgErr == nil {
+			t.Fatal("CompileConfig should reject a source-NAT to clause mixing zone + interface")
+		}
+		if !strings.Contains(msgErr.Error(), "`to`") {
+			t.Fatalf("error should name the `to` clause, got: %v", msgErr)
+		}
+	})
+
+	// Destination NAT: from clause only (a DNAT `to` is separately rejected).
+	t.Run("destination from zone+interface rejected", func(t *testing.T) {
+		tree := buildNATScopeTree(t,
+			"set security nat destination rule-set RD from zone trust",
+			"set security nat destination rule-set RD from interface ge-0/0/1.0",
+			"set security nat destination rule-set RD rule R1 then destination-nat off",
+		)
+		if _, err := CompileConfig(tree); err == nil {
+			t.Fatal("CompileConfig should reject a destination-NAT from clause mixing zone + interface")
+		}
+	})
+
+	// Static NAT: from clause only.
+	t.Run("static from zone+interface rejected", func(t *testing.T) {
+		tree := buildNATScopeTree(t,
+			"set security nat static rule-set RT from zone trust",
+			"set security nat static rule-set RT from interface ge-0/0/1.0",
+		)
+		if _, err := CompileConfig(tree); err == nil {
+			t.Fatal("CompileConfig should reject a static-NAT from clause mixing zone + interface")
+		}
+	})
+
+	// No false positives: a single-kind `from` plus a single-kind `to` (each a
+	// distinct clause, one kind apiece) is valid Junos and must compile clean.
+	t.Run("source from zone + to interface compiles", func(t *testing.T) {
+		tree := buildNATScopeTree(t,
+			"set security nat source rule-set RS from zone trust",
+			"set security nat source rule-set RS to interface ge-0/0/2.0",
+			"set security nat source rule-set RS rule R1 then source-nat interface",
+		)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("single-kind from + single-kind to should compile, got: %v", err)
+		}
+	})
+
+	// No false positives: multiple VALUES of the SAME kind (a zone list) is a
+	// legitimate OR and must compile clean.
+	t.Run("source from two zones compiles", func(t *testing.T) {
+		tree := buildNATScopeTree(t,
+			"set security nat source rule-set RS from zone trust",
+			"set security nat source rule-set RS from zone dmz",
+			"set security nat source rule-set RS rule R1 then source-nat interface",
+		)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("same-kind zone list should compile, got: %v", err)
+		}
+	})
+
+	// Tolerant load / peer-sync: a persisted mixed-kind clause must not brick
+	// the load — it downgrades to a warning.
+	t.Run("lenient load downgrades mixed clause to warning", func(t *testing.T) {
+		tree := buildNATScopeTree(t,
+			"set security nat source rule-set RS from zone trust",
+			"set security nat source rule-set RS from interface ge-0/0/1.0",
+			"set security nat source rule-set RS rule R1 then source-nat interface",
+		)
+		cfg, err := CompileConfigLenient(tree)
+		if err != nil {
+			t.Fatalf("lenient compile should not fail on a mixed-kind clause, got: %v", err)
+		}
+		var found bool
+		for _, w := range cfg.Warnings {
+			if strings.Contains(w, "scope kinds") && strings.Contains(w, "RS") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("lenient compile should record a mixed-scope warning, warnings=%v", cfg.Warnings)
+		}
+	})
+}

--- a/pkg/config/compiler_prewalk.go
+++ b/pkg/config/compiler_prewalk.go
@@ -405,6 +405,23 @@ func runPreWalkGates(tree *ConfigTree, opts compileOpts) ([]string, error) {
 		return nil, err
 	}
 
+	// #4881 NAT rule-set mixed-scope-kind gate. A single `from` / source-`to`
+	// / static-`from` clause that mixes scope KINDS (zone + interface +
+	// routing-instance) is OR-expanded by the #3096 Cartesian product into
+	// multiple typed rule-sets — matching EITHER scope, which WIDENS the NAT
+	// match beyond the intended boundary and contradicts Junos' one-kind-per-
+	// clause rule (and the in-tree "AND-ed fail-closed" comment, which never
+	// happens). Runs on the group-expanded, inactive-pruned tree so an
+	// apply-groups-inherited mixed clause is caught. Strict (commit /
+	// commit-check): hard-reject naming the clause + mixed kinds. Lenient (load
+	// / peer-sync): warn so an already-persisted or peer-synced config an older
+	// binary accepted still boots (#1960).
+	natMixedScopeWarnings, err := validateNATRuleSetMixedScopeAST(
+		tree.Children, opts.lenientNATMixedScope)
+	if err != nil {
+		return nil, err
+	}
+
 	var warnings []string
 	warnings = append(warnings, ctrlCharWarnings...)
 	warnings = append(warnings, trackWarnings...)
@@ -428,5 +445,6 @@ func runPreWalkGates(tree *ConfigTree, opts compileOpts) ([]string, error) {
 	warnings = append(warnings, policyThenDenyWarnings...)
 	warnings = append(warnings, policyMissingMatchWarnings...)
 	warnings = append(warnings, dnatToScopeWarnings...)
+	warnings = append(warnings, natMixedScopeWarnings...)
 	return warnings, nil
 }


### PR DESCRIPTION
## Summary

A single NAT rule-set `from` clause (and the source-NAT `to` clause) scopes traffic by exactly ONE kind: `zone`, `interface`, or `routing-instance`. Multiple values of the chosen kind are a legitimate list (`from zone [ trust untrust ]` = match either zone — OR is correct), but **mixing kinds** in one clause is invalid Junos.

`setSchema` declares the three as independent `multi:true` children with no mutual-exclusion validator, and the #3096 compiler Cartesian-expands the collected from-scopes × to-scopes into one typed `NATRuleSet` per `(fromScope, toScope)` pair. So `from zone trust` + `from interface ge-0/0/1.0` compiled into **two** rule-sets matching **either** scope (OR) — wider than the operator's likely AND intent — directly contradicting the in-tree `parseNATMatchScopes` comment that claimed the mix was "AND-ed fail-closed at match time." The clause failed **open** (wider).

## Fix

Add an AST pre-walk `validateNATRuleSetMixedScopeAST` (`compiler_nat_mixed_scope.go`) that rejects any `from` clause (source/destination/static NAT) or source-NAT `to` clause carrying >1 distinct scope kind. Strict on commit / commit-check (hard error naming the NAT kind, rule-set, clause, and mixed kinds); lenient-warn on load/peer-sync (`lenientNATMixedScope`, #1960). Mirrors `validateDNATRuleSetToScopeAST` (#3444).

Detection reuses `parseNATMatchScopes` and aggregates distinct kinds exactly as `collectNATScopes` feeds the Cartesian product, runs after inactive-prune + group-expansion, and uses `forEachChild` at every level (#3562 duplicate-block class). Destination NAT is checked on `from` only (its `to` is separately rejected by #3444). Also corrects the false `parseNATMatchScopes` comment and documents the gate in `docs/config-schema.md`.

## Tests

`TestValidateNATRuleSetMixedScope` — zone+interface, zone+routing-instance, interface+routing-instance across source `from`, source `to`, destination `from`, static `from`; plus no-false-positive (single-kind from + single-kind to; same-kind zone list) and the lenient-load warning. Neutralizing the validator turns every reject subtest RED while accept subtests stay green.

`go build ./...`, `go vet ./pkg/config/`, and the full config suite are green (no existing test mixes kinds within one clause — no regression).

Closes #4881

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi