### PR TITLE
configstore: bound the commit description length (#4891)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,19 @@
+## 2026-07-09 — #4891 configstore: bound the commit description so an oversized journal record cannot self-poison the tail scanner
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4891 (audit integrity). An unbounded commit description
+  marshaled into one oversized JSONL journal line; the bounded reverse-tail
+  scanner (`maxTailLineBytes` = 16 MiB) then treats a line past its cap as a
+  poisoned fragment and discards it — so an oversized-but-valid commit record
+  vanished from bounded history views after allocating memory/disk
+  proportional to its size. Added `maxCommitDescriptionBytes` (4 KiB);
+  `CommitWithDescription` now rejects an over-cap comment with a clear error
+  before any persist/promote (strict-at-commit, #1960), and `journalLog`
+  defensively truncates any over-cap `Detail` (UTF-8-safe + explicit marker)
+  as a structural boundary belt for all callers.
+  **File(s)**: pkg/configstore/store_commit.go, pkg/configstore/store_persist.go,
+  pkg/configstore/README.md, pkg/configstore/commit_description_cap_4891_test.go
+
 ## 2026-07-09 — #4910 grpcapi: active MonitorInterface stream could block daemon shutdown forever (GracefulStop with no timeout)
 
 - **Timestamp**: 2026-07-09

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -584,6 +584,15 @@ owned by the `journal/` subpackage.
   actions. `limit <= 0` still reads everything. Line assembly is
   capped at 16 MiB (corrupt newline-free content is skipped, not
   buffered whole).
+- **Detail cap (#4891)** — an operator-supplied commit description is
+  bounded at `maxCommitDescriptionBytes` (4 KiB). `CommitWithDescription`
+  rejects an over-cap comment with a clear error BEFORE persist/promote
+  (the #1960 strict-at-commit doctrine), so an oversized comment never
+  bloats the journal. As a structural belt, `journalLog` also truncates
+  any `Detail` past the cap (UTF-8-safe, with an explicit
+  `…[truncated N bytes]` marker) — without the bound an oversized line
+  would exceed the 16 MiB tail-assembly cap above and the reverse-tail
+  scanner would silently discard the record it was meant to preserve.
 - **Rotation** — at append time, when the current segment reaches
   1 MiB it rotates to `.config.journal.1` (keep 2 rotated segments,
   oldest deleted). A pre-#1896 fat journal rotates to `.1` intact on

--- a/pkg/configstore/commit_description_cap_4891_test.go
+++ b/pkg/configstore/commit_description_cap_4891_test.go
@@ -1,0 +1,93 @@
+package configstore
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// #4891: an unbounded commit description marshals into a single oversized JSONL
+// journal line that the bounded reverse-tail scanner later treats as a poisoned
+// line and discards — the legitimate commit record vanishes from bounded audit
+// views after allocating memory/disk proportional to its size. The operator
+// commit path must reject an over-cap description strictly (#1960) BEFORE
+// anything is persisted or promoted, and the journal boundary must bound any
+// Detail defensively.
+
+// TestCommitWithDescription_RejectsOversized is the RED-on-revert guard for the
+// strict cap. Revert the length check and the commit succeeds (nil error) with
+// the oversized comment persisted — failing both assertions below.
+func TestCommitWithDescription_RejectsOversized(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+
+	huge := strings.Repeat("A", maxCommitDescriptionBytes+1)
+	cfg, err := s.CommitWithDescription(huge)
+	if err == nil {
+		t.Fatal("CommitWithDescription accepted an over-cap description — must reject (#4891)")
+	}
+	if cfg != nil {
+		t.Errorf("rejected commit returned a non-nil config: %v", cfg)
+	}
+	if !strings.Contains(err.Error(), "too long") {
+		t.Errorf("error = %q, want it to mention the description is too long", err)
+	}
+
+	// The rejected commit must have mutated nothing: no history entry, no
+	// journal record. A leaked entry is exactly the audit bloat #4891 avoids.
+	if h := s.ListHistory(); len(h) != 0 {
+		t.Errorf("rejected commit pushed %d history entries, want 0", len(h))
+	}
+	entries, err := s.ListCommitHistory(10)
+	if err != nil {
+		t.Fatalf("ListCommitHistory: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("rejected commit wrote %d journal entries, want 0", len(entries))
+	}
+
+	// A commit with a description exactly at the cap still succeeds — the
+	// bound must not regress the normal path.
+	atCap := strings.Repeat("B", maxCommitDescriptionBytes)
+	if _, err := s.CommitWithDescription(atCap); err != nil {
+		t.Fatalf("CommitWithDescription(at cap) = %v, want success", err)
+	}
+}
+
+// TestTruncateDetail_BoundsAndMarks guards the journal-boundary belt: a Detail
+// past the cap is truncated to a bounded, UTF-8-valid, explicitly-marked
+// string. Revert the truncation in journalLog / truncateDetail and an oversized
+// Detail passes through unbounded.
+func TestTruncateDetail_BoundsAndMarks(t *testing.T) {
+	// Under the cap: returned verbatim.
+	small := "rotated the vpn psk"
+	if got := truncateDetail(small, maxCommitDescriptionBytes); got != small {
+		t.Errorf("truncateDetail(small) = %q, want verbatim", got)
+	}
+
+	// Over the cap: bounded and marked.
+	over := strings.Repeat("x", maxCommitDescriptionBytes*3)
+	got := truncateDetail(over, maxCommitDescriptionBytes)
+	if len(got) >= len(over) {
+		t.Fatalf("truncateDetail did not shrink an over-cap Detail: len=%d, orig=%d", len(got), len(over))
+	}
+	if !strings.Contains(got, "truncated") {
+		t.Errorf("truncated Detail lacks the explicit marker: %q", got[len(got)-40:])
+	}
+	if !utf8.ValidString(got) {
+		t.Errorf("truncated Detail is not valid UTF-8")
+	}
+
+	// A multibyte rune straddling the cut boundary must not leave a partial
+	// rune. Build content whose byte cap lands mid-rune ('世' is 3 bytes).
+	multibyte := strings.Repeat("世", maxCommitDescriptionBytes) // 3 bytes each
+	m := truncateDetail(multibyte, maxCommitDescriptionBytes)
+	if !utf8.ValidString(m) {
+		t.Errorf("truncateDetail split a multibyte rune")
+	}
+}

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -23,6 +23,24 @@ var (
 	rbRemove           = os.Remove
 )
 
+// maxCommitDescriptionBytes bounds the operator-supplied commit description
+// (the `commit comment` text) that is recorded verbatim in the in-memory
+// history entry and the durable JSONL audit journal.
+//
+// #4891: an unbounded description marshals into a single oversized JSONL line.
+// The journal's bounded reverse-tail scanner (journal.maxTailLineBytes, 16 MiB)
+// treats any line past its cap as a poisoned newline-free fragment and discards
+// it — so an oversized-but-valid commit record would VANISH from bounded
+// history / `show system commit` views after allocating memory and disk
+// proportional to its size. 4 KiB is far above any human-authored commit
+// comment while keeping every journal line orders of magnitude below the
+// tail-scanner cap. Enforced strictly on the operator commit path (fail the
+// commit with a clear error before anything is persisted — the #1960 strict-at-
+// commit doctrine) and, as a structural belt at the journal boundary,
+// defensively truncated in journalLog so no Detail from any caller can poison
+// the tail scanner.
+const maxCommitDescriptionBytes = 4 << 10
+
 // CommitCheck validates the candidate configuration without applying it.
 func (s *Store) CommitCheck() (*config.Config, error) {
 	s.mu.RLock()
@@ -73,6 +91,15 @@ func (s *Store) CommitWithDescription(description string) (*config.Config, error
 	}
 	if s.candidate == nil {
 		return nil, fmt.Errorf("not in configuration mode")
+	}
+
+	// #4891: reject an over-cap commit description BEFORE anything is
+	// persisted or promoted. Fail-fast with a clear error (the #1960
+	// strict-at-commit doctrine) so an oversized comment never bloats the
+	// journal nor hides itself behind the tail scanner's corrupt-line defense.
+	if len(description) > maxCommitDescriptionBytes {
+		return nil, fmt.Errorf("commit description too long: %d bytes (max %d)",
+			len(description), maxCommitDescriptionBytes)
 	}
 
 	compiled, err := s.compileTree(s.candidate)

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/fsatomic"
@@ -261,9 +262,33 @@ func (s *Store) writeActiveMarker(tree *config.ConfigTree, committed bool) error
 // and the persist_error path must not recurse into journaling its own
 // failure (#1896).
 func (s *Store) journalLog(e *JournalEntry) {
+	// #4891 boundary belt: never hand the journal a Detail larger than the
+	// commit-description cap. An oversized JSONL line would be discarded by
+	// the journal's bounded reverse-tail scanner (maxTailLineBytes), silently
+	// dropping a real audit record. The operator commit path already rejects
+	// an over-cap description with a clear error; this bounds every OTHER
+	// Detail source (sync notes, error text) so the "no journal line poisons
+	// the tail scanner" invariant holds structurally regardless of caller.
+	if len(e.Detail) > maxCommitDescriptionBytes {
+		e.Detail = truncateDetail(e.Detail, maxCommitDescriptionBytes)
+	}
 	if err := s.journal.Log(e); err != nil {
 		slog.Warn("config journal append failed", "action", e.Action, "err", err)
 	}
+}
+
+// truncateDetail bounds an audit Detail to at most max content bytes, backing
+// off to a valid UTF-8 boundary, and appends an explicit marker so a reader
+// sees the record was clipped rather than silently losing tail bytes (#4891).
+func truncateDetail(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	cut := s[:max]
+	for len(cut) > 0 && !utf8.ValidString(cut) {
+		cut = cut[:len(cut)-1]
+	}
+	return cut + fmt.Sprintf("…[truncated %d bytes]", len(s)-len(cut))
 }
 
 // journalConfigHash returns the sha256 hex of the tree's Format() text


### PR DESCRIPTION
## Summary

An operator-supplied commit description was stored in the JSONL audit journal
with **no length cap**. A very large description marshals into a single
oversized journal line, and the journal's bounded reverse-tail scanner
(`maxTailLineBytes` = 16 MiB) treats any line past its cap as a poisoned
newline-free fragment and **discards it**. So an oversized-but-valid commit
audit record could vanish from bounded history / `show system commit` views —
after the process already paid allocation and disk proportional to the string.
The config payload size gate applies to the parsed config text, not the
description, so nothing bounded it.

## Fix (bound at the configstore boundary)

- Add `maxCommitDescriptionBytes` (4 KiB) — far above any human-authored commit
  comment, orders of magnitude below the 16 MiB tail cap.
- `CommitWithDescription` rejects an over-cap description with a clear error
  **before** anything is persisted or promoted (the #1960 strict-at-commit
  doctrine): the commit fails, the candidate is intact, nothing is journaled.
- `journalLog` defensively truncates any `Detail` past the cap as a structural
  belt for every other journal caller. `truncateDetail` backs off to a valid
  UTF-8 boundary and appends an explicit `…[truncated N bytes]` marker.

Documented in the configstore README audit-journal section.

## Validation

- `go build ./...` clean; `go vet ./pkg/configstore` clean; full
  `pkg/configstore` + `journal` suites green.
- New RED-on-revert tests, both verified RED by reverting the production change
  then restored to green:
  - `TestCommitWithDescription_RejectsOversized` — an over-cap comment must be rejected and nothing persisted/journaled.
  - `TestTruncateDetail_BoundsAndMarks` — the boundary belt must bound + mark + stay UTF-8-valid.

Closes #4891

🤖 Generated with [Claude Code](https://claude.com/claude-code)