### PR TITLE
snmp: stop the ctx-watcher and trap worker in Agent.Stop (#4916)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,19 @@
+## 2026-07-09 — #4916 snmp: Agent.Stop leaked the ctx-watcher + trap worker and could deliver queued traps after Stop
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4916 (goroutine leak + stale telemetry). `Agent.Stop` only set
+  `stopped` and closed the socket; the daemon-wide context stays live across a
+  day-2 SNMP disable, so the `<-ctx.Done()` watcher blocked forever and the trap
+  worker ranged an unclosed channel forever, still delivering any queued backlog
+  to the old target/community. Gave the agent a per-agent lifecycle context
+  (`lifeCancel`), a `trapStop` channel, and a `trapWG`. Stop now cancels the
+  watcher context, signals the worker to ABANDON its queue (worker selects on
+  `trapStop` and re-checks it before each send — no post-Stop delivery), closes
+  the socket, and waits for the worker to exit. Stop is idempotent (guarded on
+  `stopped`); `enqueueTrap` drops (never starts a worker) once stopped.
+  **File(s)**: pkg/snmp/agent.go, pkg/snmp/traps.go, pkg/snmp/README.md,
+  pkg/snmp/agent_stop_leak_4916_test.go
+
 ## 2026-07-09 — #4910 grpcapi: active MonitorInterface stream could block daemon shutdown forever (GracefulStop with no timeout)
 
 - **Timestamp**: 2026-07-09

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -202,6 +202,17 @@ the boot apply and the boot block from double-starting the agent. The agent +
 monitor goroutines bind to a lifetime context derived from `d.daemonCtx` and are
 torn down explicitly at shutdown (`teardownSNMP`).
 
+`Agent.Stop()` is self-contained and idempotent (#4916): the daemon-wide
+context stays live across a day-2 SNMP disable, so Stop cannot rely on it. Stop
+cancels a per-agent lifecycle context (unblocking the `<-ctx.Done()` watcher
+goroutine `Start` spawns), signals the async trap worker to ABANDON its queued
+backlog (so no trap is delivered to a removed/rotated receiver after the
+authorizing config was revoked), closes the UDP socket, and waits for the
+worker to exit. After Stop, `enqueueTrap` drops rather than starting a new
+worker. Without this, each disable/re-enable cycle leaked a goroutine pair and
+the trap worker could keep sending a stale backlog with the old community to
+the old target.
+
 The reconcile runs **early** in `applyConfigLocked` — before the dataplane
 apply, which can abort the reconcile pipeline early (it returns on
 `ErrPolicySchedulerProtocolIncompatible`). `Store.Commit()` has already

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -200,6 +200,24 @@ type Agent struct {
 	trapQueue      chan trapJob
 	trapWorkerOnce sync.Once
 	trapsDropped   atomic.Uint64
+
+	// Lifecycle shutdown (#4916). Stop must cancel the context-watcher
+	// goroutine AND stop the trap worker so a day-2 SNMP disable (Stop called
+	// while the daemon context is still live) does not leak a goroutine pair
+	// nor deliver a queued trap to a removed/rotated receiver after the config
+	// that authorized it was revoked. All three are guarded by mu:
+	//   - lifeCancel cancels the derived lifecycle context the ctx-watcher
+	//     waits on, so Stop unblocks the watcher even when the parent context
+	//     stays live.
+	//   - trapStop is closed by Stop to tell the worker to ABANDON its queue
+	//     (no post-Stop delivery); the worker also re-checks it before each
+	//     send so a Stop that races a dequeued job never delivers it.
+	//   - trapWG lets Stop wait for the worker to exit. It counts only a
+	//     worker that actually started (lazy, via trapWorkerOnce), so Stop
+	//     returns immediately when none ran.
+	lifeCancel context.CancelFunc
+	trapStop   chan struct{}
+	trapWG     sync.WaitGroup
 }
 
 // trapJob is one queued trap-delivery unit: a pre-built SNMP packet and its
@@ -462,14 +480,20 @@ func (a *Agent) Start(ctx context.Context) error {
 		return fmt.Errorf("snmp: listen: %w", err)
 	}
 
+	// Derive a lifecycle context so BOTH parent-context cancellation and an
+	// explicit day-2 Stop() unblock the watcher below (#4916). Stop calls
+	// lifeCancel; the parent ctx cancelling also propagates here.
+	lifeCtx, cancel := context.WithCancel(ctx)
+
 	a.mu.Lock()
 	a.conn = conn
+	a.lifeCancel = cancel
 	a.mu.Unlock()
 
 	slog.Info("SNMP agent listening", "addr", ":161")
 
 	go func() {
-		<-ctx.Done()
+		<-lifeCtx.Done()
 		a.Stop()
 	}()
 
@@ -500,15 +524,38 @@ func (a *Agent) Start(ctx context.Context) error {
 	}
 }
 
-// Stop shuts down the SNMP agent.
+// Stop shuts down the SNMP agent. It is idempotent and safe to call
+// concurrently: the ctx-watcher goroutine and a day-2 reconcile both call it.
+//
+// #4916: besides closing the UDP socket, Stop must (a) cancel the lifecycle
+// context so the ctx-watcher goroutine unblocks even when the parent daemon
+// context is still live, and (b) signal the trap worker to abandon its queue
+// and wait for it to exit — so no goroutine pair leaks per disable/re-enable
+// cycle and no queued trap is delivered to a removed/rotated receiver after the
+// authorizing config was revoked.
 func (a *Agent) Stop() {
 	a.mu.Lock()
-	defer a.mu.Unlock()
+	if a.stopped {
+		a.mu.Unlock()
+		return // already stopped: idempotent, no double-close / double-wait
+	}
 	a.stopped = true
+	if a.lifeCancel != nil {
+		a.lifeCancel() // unblock the ctx-watcher goroutine
+	}
+	if a.trapStop != nil {
+		close(a.trapStop) // tell the trap worker to abandon its queue
+	}
 	if a.conn != nil {
 		a.conn.Close()
 		a.conn = nil
 	}
+	a.mu.Unlock()
+
+	// Wait for the trap worker to exit OUTSIDE the lock: it may be mid-send,
+	// and enqueueTrap briefly takes a.mu. trapWG counts only a worker that
+	// actually started, so this returns immediately when none ran.
+	a.trapWG.Wait()
 	slog.Info("SNMP agent stopped")
 }
 

--- a/pkg/snmp/agent_stop_leak_4916_test.go
+++ b/pkg/snmp/agent_stop_leak_4916_test.go
@@ -1,0 +1,119 @@
+package snmp
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// #4916: Agent.Stop() previously only set stopped + closed the socket. It did
+// not cancel the ctx-watcher goroutine (so on a day-2 disable, with the daemon
+// context still live, `<-ctx.Done()` blocked forever) and did not stop/drain
+// the trap worker (which ranged an unclosed channel forever and could deliver a
+// queued trap to a removed/rotated receiver after Stop). Each disable/re-enable
+// cycle leaked another goroutine pair.
+
+// TestStop_CancelsWatcherContext proves Stop cancels the lifecycle context the
+// ctx-watcher goroutine waits on. RED on revert: drop the a.lifeCancel() call in
+// Stop and the modeled watcher never unblocks, so this times out.
+func TestStop_CancelsWatcherContext(t *testing.T) {
+	a := &Agent{}
+	ctx, cancel := context.WithCancel(context.Background())
+	a.lifeCancel = cancel
+
+	// Model the goroutine Start() spawns: it blocks until the lifecycle
+	// context is cancelled, then would call a.Stop().
+	watcherDone := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		close(watcherDone)
+	}()
+
+	a.Stop()
+
+	select {
+	case <-watcherDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not cancel the lifecycle context — the ctx-watcher goroutine would leak (#4916)")
+	}
+}
+
+// TestStop_StopsTrapWorkerNoPostDelivery proves Stop() stops the trap worker
+// (no goroutine leak) and that a queued backlog is ABANDONED — no trap is
+// delivered to a removed/rotated receiver after Stop. RED on revert: restore
+// `for job := range a.trapQueue` + a Stop that neither signals nor waits, and
+// the worker drains the backlog after Stop (a second delivery is observed) and
+// never joins (Stop hangs / the goroutine leaks).
+func TestStop_StopsTrapWorkerNoPostDelivery(t *testing.T) {
+	orig := trapSender
+	defer func() { trapSender = orig }()
+
+	var calls, delivered atomic.Int64
+	entered := make(chan struct{}, 64)
+	release := make(chan struct{})
+	trapSender = func(target string, pkt []byte) error {
+		n := calls.Add(1)
+		entered <- struct{}{} // signal every send attempt
+		if n == 1 {
+			<-release // hold the first send until the test releases it
+		}
+		delivered.Add(1)
+		return nil
+	}
+
+	a := &Agent{startTime: time.Now()}
+	// Enqueue a backlog. The worker starts, dequeues the first job, and blocks
+	// inside the sender; the rest sit in the queue behind it.
+	for i := 0; i < 8; i++ {
+		a.enqueueTrap(trapJob{target: "192.0.2.9:162", pkt: []byte{1}})
+	}
+
+	// Wait until the worker is actually blocked in the first send.
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("trap worker never entered the sender")
+	}
+
+	// Stop concurrently (it waits for the worker), then release the in-flight
+	// send so the worker can observe the stop signal on its next loop.
+	stopped := make(chan struct{})
+	go func() { a.Stop(); close(stopped) }()
+	time.Sleep(50 * time.Millisecond) // let Stop set stopped + close trapStop
+	close(release)
+
+	// No queued trap may begin delivery after Stop. The only permitted send is
+	// the one already in flight when Stop was called (send #1); any SECOND
+	// sender entry is a post-Stop delivery of the abandoned backlog.
+	select {
+	case <-entered:
+		t.Fatal("a queued trap was delivered after Stop — the worker did not abandon its backlog (#4916)")
+	case <-time.After(500 * time.Millisecond):
+		// good: no further delivery
+	}
+
+	// Stop must return: the worker joined (no goroutine leak).
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not return — the trap worker leaked (Stop never stops/awaits it)")
+	}
+	if got := delivered.Load(); got != 1 {
+		t.Fatalf("delivered = %d, want exactly 1 (only the in-flight send may complete)", got)
+	}
+
+	// Idempotent: a second Stop (ctx-watcher + day-2 reconcile both call it)
+	// must not panic or block.
+	a.Stop()
+
+	// A trap enqueued after Stop must be dropped, never delivered.
+	before := a.trapsDropped.Load()
+	a.enqueueTrap(trapJob{target: "192.0.2.9:162", pkt: []byte{1}})
+	if a.trapsDropped.Load() != before+1 {
+		t.Fatal("post-Stop enqueue was not dropped")
+	}
+	if got := delivered.Load(); got != 1 {
+		t.Fatalf("a post-Stop enqueue was delivered: delivered = %d, want 1", got)
+	}
+}

--- a/pkg/snmp/traps.go
+++ b/pkg/snmp/traps.go
@@ -333,12 +333,33 @@ func sortedTrapGroups(cfg *config.SNMPConfig) []*config.SNMPTrapGroup {
 // here — the queue only fills when targets are not draining, and blocking the
 // link monitor on SNMP observability is exactly the failure #2991 fixes.
 func (a *Agent) enqueueTrap(job trapJob) {
+	a.mu.Lock()
+	if a.stopped {
+		// #4916: the agent has been stopped (day-2 disable / rotation). Never
+		// start a worker or enqueue a post-Stop trap — dropping here is what
+		// guarantees no trap reaches a removed/rotated receiver after Stop.
+		a.mu.Unlock()
+		dropped := a.trapsDropped.Add(1)
+		slog.Warn("SNMP trap dropped: agent stopped",
+			"target", job.target, "group", job.group,
+			"event", job.event, "iface", job.iface, "dropped_total", dropped)
+		return
+	}
 	a.trapWorkerOnce.Do(func() {
-		a.trapQueue = make(chan trapJob, trapQueueDepth)
-		go a.trapWorker()
+		if a.trapQueue == nil {
+			a.trapQueue = make(chan trapJob, trapQueueDepth)
+		}
+		if a.trapStop == nil {
+			a.trapStop = make(chan struct{})
+		}
+		a.trapWG.Add(1)
+		go a.trapWorker(a.trapQueue, a.trapStop)
 	})
+	q := a.trapQueue
+	a.mu.Unlock()
+
 	select {
-	case a.trapQueue <- job:
+	case q <- job:
 	default:
 		dropped := a.trapsDropped.Add(1)
 		slog.Warn("SNMP trap queue full, dropping trap",
@@ -351,16 +372,40 @@ func (a *Agent) enqueueTrap(job trapJob) {
 // queued trap off the link-monitor goroutine (#2991). A single worker bounds
 // goroutine growth and serializes the slow dials; the queue capacity bounds
 // memory.
-func (a *Agent) trapWorker() {
-	for job := range a.trapQueue {
-		if err := trapSender(job.target, job.pkt); err != nil {
-			slog.Warn("SNMP trap send failed",
-				"target", job.target, "group", job.group,
-				"event", job.event, "iface", job.iface, "err", err)
-		} else {
-			slog.Info("SNMP trap sent",
-				"target", job.target, "group", job.group,
-				"event", job.event, "iface", job.iface, "ifindex", job.ifindex)
+//
+// #4916: the worker selects on stop as well as the queue and re-checks stop
+// before every send, so a Stop() ABANDONS the queued backlog (no trap is
+// delivered to a removed/rotated receiver after the authorizing config was
+// revoked) and the goroutine always exits — no leak per disable/re-enable
+// cycle. The queue and stop channel are passed in (rather than read from the
+// struct) so the worker never races Stop's field access. Stop waits on trapWG.
+func (a *Agent) trapWorker(queue chan trapJob, stop chan struct{}) {
+	defer a.trapWG.Done()
+	for {
+		select {
+		case <-stop:
+			return
+		case job, ok := <-queue:
+			if !ok {
+				return
+			}
+			// Re-check stop before delivering: the outer select picks
+			// randomly when both cases are ready, so a job dequeued
+			// concurrently with Stop must not be sent after Stop.
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if err := trapSender(job.target, job.pkt); err != nil {
+				slog.Warn("SNMP trap send failed",
+					"target", job.target, "group", job.group,
+					"event", job.event, "iface", job.iface, "err", err)
+			} else {
+				slog.Info("SNMP trap sent",
+					"target", job.target, "group", job.group,
+					"event", job.event, "iface", job.iface, "ifindex", job.ifindex)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

`Agent.Stop()` only set `stopped` and closed the UDP socket. It did not cancel
the context-watcher goroutine, stop the trap worker, or wait for either to exit.
Because the daemon-wide context stays live across a **day-2 SNMP disable**, the
`<-ctx.Done()` watcher goroutine `Start()` spawns remained blocked forever, and
`trapWorker` kept ranging an unclosed channel forever. Worse, any traps still
queued (prebuilt packets, targets, old community values) could be delivered
**after** the config that authorized them was removed — stale telemetry to a
rotated/removed receiver with a revoked credential — and each disable/re-enable
cycle leaked another goroutine pair.

## Fix — an explicit agent lifecycle

- **lifeCancel** — `Start` derives a per-agent lifecycle context from the parent
  and stores its cancel func; the watcher waits on the derived context, so
  `Stop()` unblocks it even while the parent stays live.
- **trapStop + trapWG** — `enqueueTrap` lazily creates the stop channel
  alongside the queue and registers the worker in the WaitGroup. `trapWorker`
  selects on `trapStop` as well as the queue, and re-checks `trapStop` before
  every send (the outer select picks randomly when both are ready), so a `Stop`
  **abandons** the queued backlog — no trap is delivered after Stop.
- **Stop** cancels the watcher context, closes `trapStop`, closes the socket,
  and waits for the worker to exit (outside the lock). It is **idempotent**: a
  `stopped` guard makes the second call (watcher + day-2 reconcile both call
  Stop) a no-op — no double-close, no double-wait, no panic. Once stopped,
  `enqueueTrap` drops rather than starting a new worker.

An in-flight send already dialing when Stop is called is bounded by the 2s dial
timeout; no *new* send begins after Stop. Documented in the SNMP README.

## Validation

- `go build ./...` clean; `go vet ./pkg/snmp` clean; full `pkg/snmp` suite green
  (new tests also pass under `-race`).
- New RED-on-revert tests, both verified RED by reverting Stop/trapWorker/enqueueTrap
  then restored to green:
  - `TestStop_CancelsWatcherContext` — Stop must cancel the lifecycle context (watcher unblocks).
  - `TestStop_StopsTrapWorkerNoPostDelivery` — worker must abandon the backlog + join (no post-Stop delivery, no leak); also covers idempotent double-Stop and post-Stop enqueue drop.

Closes #4916

🤖 Generated with [Claude Code](https://claude.com/claude-code)