### PR TITLE
snmp: inject trap sender per-Agent to fix -race data race

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,21 @@
+## 2026-07-09 — #5023 snmp: fix -race data race on the package-global trapSender
+
+- **Timestamp**: 2026-07-09
+  **Action**: #5023 (test-infra correctness). `go test -race ./pkg/snmp/`
+  failed deterministically on `TestSendLinkTraps_DoesNotBlock`: the trap
+  worker goroutine read the package-global `trapSender` func var while the
+  #2991/#4916 tests wrote it during setup — an unsynchronized read/write.
+  Moved the sender off the package global onto a per-Agent `trapSender`
+  field, set to `sendTrap` by the constructors (bare-struct test Agents may
+  leave it nil; the worker falls back to `sendTrap`). The worker snapshots
+  the field once at start, so there is no shared mutable state between the
+  worker and any injector. Updated the #2991 and #4916 tests to inject their
+  slow/mock sender on their own Agent instead of mutating the global.
+  Verified RED on origin/master (DATA RACE + FAIL) and clean under `-race`
+  with the fix.
+  **File(s)**: pkg/snmp/agent.go, pkg/snmp/traps.go, pkg/snmp/README.md,
+  pkg/snmp/traps_async_2991_test.go, pkg/snmp/agent_stop_leak_4916_test.go
+
 ## 2026-07-09 — #4916 snmp: Agent.Stop leaked the ctx-watcher + trap worker and could deliver queued traps after Stop
 
 - **Timestamp**: 2026-07-09

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -313,8 +313,10 @@ authorization surface: every request is dropped because no community matches.
   for both `NewAgent` and bare-struct test agents). When the queue is full
   the trap is DROPPED and `trapsDropped` is incremented rather than
   blocking the caller — dropping is the correct backpressure when targets
-  are not draining. The delivery is replaceable through the `trapSender`
-  package var (the seam tests use to inject a slow sender). Before #2991
+  are not draining. The delivery is replaceable through the per-Agent
+  `trapSender` field (the seam tests use to inject a slow/mock sender on
+  their own Agent; #5023 moved it off a shared package var so the injection
+  no longer races the running trap worker's read under `-race`). Before #2991
   delivery was synchronous and inline, so an unreachable trap target (or a
   hung DNS lookup for an FQDN target) blocked link-state processing for up
   to the 2s dial timeout × target count.

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -201,6 +201,17 @@ type Agent struct {
 	trapWorkerOnce sync.Once
 	trapsDropped   atomic.Uint64
 
+	// trapSender delivers a single pre-built trap to a target. It is a
+	// per-Agent field (not a package global) so tests can inject a
+	// deliberately slow/blocking or mock sender on their OWN Agent without a
+	// cross-goroutine write to a shared global that races the running trap
+	// worker's read (#5023). Defaults to sendTrap (set by the constructors); a
+	// bare-struct test Agent may leave it nil, in which case the worker falls
+	// back to sendTrap. Production never reassigns it after construction, and
+	// the worker snapshots it once at start, so there is no shared mutable
+	// state between the worker and any injector.
+	trapSender func(target string, pkt []byte) error
+
 	// Lifecycle shutdown (#4916). Stop must cancel the context-watcher
 	// goroutine AND stop the trap worker so a day-2 SNMP disable (Stop called
 	// while the daemon context is still live) does not leak a goroutine pair
@@ -259,6 +270,7 @@ func NewAgentWithBootsPath(cfg *config.SNMPConfig, bootsPath string) *Agent {
 		cfg:             cfg,
 		startTime:       time.Now(),
 		engineBootsPath: bootsPath,
+		trapSender:      sendTrap,
 	}
 	a.initEngine()
 	a.initV3Users()

--- a/pkg/snmp/agent_stop_leak_4916_test.go
+++ b/pkg/snmp/agent_stop_leak_4916_test.go
@@ -46,13 +46,12 @@ func TestStop_CancelsWatcherContext(t *testing.T) {
 // the worker drains the backlog after Stop (a second delivery is observed) and
 // never joins (Stop hangs / the goroutine leaks).
 func TestStop_StopsTrapWorkerNoPostDelivery(t *testing.T) {
-	orig := trapSender
-	defer func() { trapSender = orig }()
-
 	var calls, delivered atomic.Int64
 	entered := make(chan struct{}, 64)
 	release := make(chan struct{})
-	trapSender = func(target string, pkt []byte) error {
+	// #5023: inject the mock sender on THIS Agent, not a shared package global
+	// (which would race the running trap worker's read under -race).
+	sender := func(target string, pkt []byte) error {
 		n := calls.Add(1)
 		entered <- struct{}{} // signal every send attempt
 		if n == 1 {
@@ -62,7 +61,7 @@ func TestStop_StopsTrapWorkerNoPostDelivery(t *testing.T) {
 		return nil
 	}
 
-	a := &Agent{startTime: time.Now()}
+	a := &Agent{startTime: time.Now(), trapSender: sender}
 	// Enqueue a backlog. The worker starts, dequeues the first job, and blocks
 	// inside the sender; the rest sit in the queue behind it.
 	for i := 0; i < 8; i++ {

--- a/pkg/snmp/traps.go
+++ b/pkg/snmp/traps.go
@@ -206,13 +206,10 @@ func (a *Agent) buildLinkTrapsForVersion(community, version string, linkUp bool,
 	}
 }
 
-// trapSender delivers a single pre-built trap to a target. It is a package
-// var (not a direct call) so tests can inject a deliberately slow/blocking
-// sender to prove the link-monitor caller does not block on trap delivery
-// (#2991). Production code never reassigns it.
-var trapSender = sendTrap
-
-// sendTrap sends a pre-built trap packet to a single target on port 162.
+// sendTrap sends a pre-built trap packet to a single target on port 162. It is
+// the default value of Agent.trapSender (#5023); tests inject a slow/blocking
+// or mock sender per-Agent instead of mutating a shared package global that
+// races the running trap worker's read.
 func sendTrap(target string, pkt []byte) error {
 	// Ensure the target has a port.
 	host, port, err := net.SplitHostPort(target)
@@ -381,6 +378,14 @@ func (a *Agent) enqueueTrap(job trapJob) {
 // struct) so the worker never races Stop's field access. Stop waits on trapWG.
 func (a *Agent) trapWorker(queue chan trapJob, stop chan struct{}) {
 	defer a.trapWG.Done()
+	// Snapshot the sender once at worker start. It is set at construction
+	// (NewAgent) or by a test on its own Agent before the worker is lazily
+	// started, so this read never races a concurrent write (#5023). A
+	// bare-struct Agent that never set the field falls back to sendTrap.
+	send := a.trapSender
+	if send == nil {
+		send = sendTrap
+	}
 	for {
 		select {
 		case <-stop:
@@ -397,7 +402,7 @@ func (a *Agent) trapWorker(queue chan trapJob, stop chan struct{}) {
 				return
 			default:
 			}
-			if err := trapSender(job.target, job.pkt); err != nil {
+			if err := send(job.target, job.pkt); err != nil {
 				slog.Warn("SNMP trap send failed",
 					"target", job.target, "group", job.group,
 					"event", job.event, "iface", job.iface, "err", err)

--- a/pkg/snmp/traps_async_2991_test.go
+++ b/pkg/snmp/traps_async_2991_test.go
@@ -19,10 +19,10 @@ import (
 // sender").
 func TestSendLinkTraps_DoesNotBlock(t *testing.T) {
 	const slow = 2 * time.Second
-	orig := trapSender
-	defer func() { trapSender = orig }()
 	released := make(chan struct{})
-	trapSender = func(target string, pkt []byte) error {
+	// #5023: inject the slow sender on THIS Agent (no shared package global,
+	// so no race with the running trap worker's read).
+	slowSender := func(target string, pkt []byte) error {
 		// Block until the test releases us (models a hung dial/DNS).
 		<-released
 		return nil
@@ -41,7 +41,8 @@ func TestSendLinkTraps_DoesNotBlock(t *testing.T) {
 				}},
 			},
 		},
-		startTime: time.Now(),
+		startTime:  time.Now(),
+		trapSender: slowSender,
 	}
 
 	done := make(chan struct{})


### PR DESCRIPTION
## Summary

`go test -race ./pkg/snmp/` failed deterministically on
`TestSendLinkTraps_DoesNotBlock` with a data race on the package-global
`trapSender` func var: the trap worker goroutine reads it inside `trapWorker`
(traps.go) while the #2991 async test — and the #4916 stop-leak test — swap it
for a mock during setup, with no synchronization between the worker's read and
the test's write.

## Fix

Move the sender off the package global onto a per-Agent `trapSender` field:

- The constructors (`NewAgent` / `NewAgentWithBootsPath`) default it to
  `sendTrap`; a bare-struct test `Agent` may leave it nil and the worker falls
  back to `sendTrap`.
- `trapWorker` snapshots the field once at start (before its loop), so there is
  no shared mutable state between the worker and any injector — the seam the
  tests need without a cross-goroutine write to a shared global.
- The #2991 and #4916 tests inject their slow/mock sender on their own `Agent`
  instead of reassigning the global.
- Refreshed the `pkg/snmp` README trap-delivery note to describe the per-Agent
  field.

## Validation

- Verified **RED on origin/master**: restoring the pre-fix files reproduces
  `WARNING: DATA RACE` + `FAIL` on `TestSendLinkTraps_DoesNotBlock`.
- **Clean with the fix**: `go test -race ./pkg/snmp/` passes.
- `go vet` + `gofmt` clean on the touched files.

Closes #5023

🤖 Generated with [Claude Code](https://claude.com/claude-code)