### PR TITLE
logging: fix SESSION_CLOSE binary/slog policy_id=0 and action=deny

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-07-09 — #4914 logging: SESSION_CLOSE binary record + generic slog no longer report policy_id=0 / action=deny
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4914 (telemetry correctness; residual of #4796). On a
+  SESSION_CLOSE, logEvent zeroes evt.PolicyID (#2853 repurposes [44:48] for
+  the created-subsec-nanos) and only rec.PolicyID carries the admitting
+  policy from [136:140] (#3056); the wire action byte is intentionally 0.
+  Two sinks still misrepresented the close: (1) formatBinaryRecord encoded
+  evt.PolicyID (0) and evt.Action (0 -> actionDeny), so every binary
+  session-close record read policy_id=0 + action=deny; (2) the generic slog
+  "firewall event" close branch still emitted action=actionName(0)="deny".
+  Fixed formatBinaryRecord to encode rec.PolicyID and to flag the close
+  action byte actionNotApplicable (0xFF, documented sentinel — the fixed-
+  shape record cannot omit a field like the text formatters do). Fixed the
+  slog close line to omit action and carry the close reason instead, matching
+  the standard/structured lines (#2513). Scoped to SESSION_CLOSE (the
+  SESSION_OPEN binary action byte is locked by an existing unit test and is
+  out of this issue's scope). Added a live parity fixture through
+  ProcessRawEvent asserting the admitting policy id + no-deny across buffer,
+  callback, slog, standard, structured, and binary sinks (RED on revert of
+  any of the three production changes). Updated TestFormatBinaryRecord_Basic
+  to populate rec.PolicyID (the field the record now reads).
+  **File(s)**: pkg/logging/ringbuf.go, pkg/logging/binary_test.go,
+  pkg/logging/session_close_binary_slog_4914_test.go
+
 ## 2026-07-09 — #4916 snmp: Agent.Stop leaked the ctx-watcher + trap worker and could deliver queued traps after Stop
 
 - **Timestamp**: 2026-07-09

--- a/pkg/logging/binary_test.go
+++ b/pkg/logging/binary_test.go
@@ -32,9 +32,14 @@ func TestFormatBinaryRecord_Basic(t *testing.T) {
 		Time:        time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC),
 		InZoneName:  "trust",
 		OutZoneName: "untrust",
-		PolicyName:  "allow-web",
-		AppName:     "junos-https",
-		SessionID:   100,
+		// #4914: the binary record now encodes rec.PolicyID (the authoritative
+		// post-processing policy id) rather than evt.PolicyID. In the live
+		// pipeline logEvent mirrors evt.PolicyID into rec.PolicyID for every
+		// non-close event, so set it here to match evt.PolicyID above.
+		PolicyID:   42,
+		PolicyName: "allow-web",
+		AppName:    "junos-https",
+		SessionID:  100,
 	}
 
 	buf := formatBinaryRecord(evt, rec, SyslogInfo, 0)

--- a/pkg/logging/ringbuf.go
+++ b/pkg/logging/ringbuf.go
@@ -126,6 +126,15 @@ const (
 	actionDeny   = 0
 	actionPermit = 1
 	actionReject = 2
+	// actionNotApplicable flags the binary-log action byte on a SESSION_CLOSE,
+	// which carries no forwarding decision. Its wire action byte is
+	// intentionally 0, which the raw encoding would stamp as "deny" (actionDeny)
+	// and mislead binary forensic consumers into reading a normal close as a
+	// drop (#4914). The standard and structured text formatters OMIT the action
+	// field on a close (#2513); the fixed-shape binary record cannot omit a
+	// field, so it carries this explicit "not applicable" sentinel instead of a
+	// bogus 0.
+	actionNotApplicable = 0xFF
 )
 
 const (
@@ -686,13 +695,22 @@ func (er *EventReader) logEvent(data []byte) {
 		// policy_id=0 for every session close. rec.PolicyID is the same field
 		// PolicyName resolution and the RT_FLOW_SESSION_CLOSE record already
 		// use, so this keeps the slog line consistent with them.
+		//
+		// #4914: OMIT action on a close. The wire action byte is intentionally
+		// 0 for a session close, so actionName(evt.Action) renders "deny" —
+		// logging it here classified every normal termination as a drop and
+		// drove false drop alerts / broken correlation. The standard and
+		// structured RT_FLOW_SESSION_CLOSE lines already omit action (#2513);
+		// this generic slog branch was the residual sink still emitting it.
+		// Carry the close reason instead, which is what the structured line
+		// surfaces.
 		slog.Info("firewall event",
 			"type", eventName,
 			"src", srcStr,
 			"dst", dstStr,
 			"proto", protoStr,
-			"action", actionStr,
 			"policy_id", rec.PolicyID,
+			"reason", rec.CloseReason,
 			"ingress_zone", inZone,
 			"egress_zone", outZone,
 			"session_packets", rec.SessionPkts,
@@ -1250,7 +1268,8 @@ const (
 //	  [3:5]     Total record length (uint16 big-endian, includes header)
 //	  [5]       EventType
 //	  [6]       Protocol number
-//	  [7]       Action (0=deny, 1=permit, 2=reject)
+//	  [7]       Action (0=deny, 1=permit, 2=reject, 255=n/a for a
+//	            SESSION_CLOSE, which carries no forwarding decision)
 //	  [8]       AddrFamily (2=IPv4, 10=IPv6)
 //	  [9]       Severity (syslog level)
 //	  [10:18]   Timestamp (uint64 LE, Unix nanoseconds)
@@ -1296,7 +1315,16 @@ func formatBinaryRecord(evt *rawEvent, rec *EventRecord, severity int, closeReas
 	// Event fields
 	buf[5] = evt.EventType
 	buf[6] = evt.Protocol
-	buf[7] = evt.Action
+	// #4914: a SESSION_CLOSE carries no forwarding decision — its wire action
+	// byte is intentionally 0, which as a raw actionDeny would tell a binary
+	// forensic consumer that a normal termination was a drop. Flag it "not
+	// applicable" so tooling does not attribute closes to a deny. Every other
+	// event type keeps its real action byte.
+	if evt.EventType == eventTypeSessionClose {
+		buf[7] = actionNotApplicable
+	} else {
+		buf[7] = evt.Action
+	}
 	buf[8] = evt.AddrFamily
 	buf[9] = uint8(severity)
 	// Timestamp
@@ -1307,8 +1335,14 @@ func formatBinaryRecord(evt *rawEvent, rec *EventRecord, severity int, closeReas
 	// Ports (big-endian, as parsed from BPF)
 	binary.BigEndian.PutUint16(buf[50:52], evt.SrcPort)
 	binary.BigEndian.PutUint16(buf[52:54], evt.DstPort)
-	// PolicyID
-	binary.LittleEndian.PutUint32(buf[54:58], evt.PolicyID)
+	// PolicyID. #4914: encode rec.PolicyID, not evt.PolicyID. They match for
+	// every non-close frame, but on a SESSION_CLOSE evt.PolicyID was zeroed by
+	// logEvent (#2853 repurposes the [44:48] slot for the created-subsec-nanos)
+	// and only rec.PolicyID carries the admitting policy from the trailing
+	// [136:140] slot (#3056). Encoding evt.PolicyID stamped policy_id=0 on every
+	// binary session-close record; rec.PolicyID matches the resolved PolicyName
+	// and the standard/structured RT_FLOW_SESSION_CLOSE lines.
+	binary.LittleEndian.PutUint32(buf[54:58], rec.PolicyID)
 	// Zone IDs
 	binary.LittleEndian.PutUint16(buf[58:60], evt.IngressZone)
 	binary.LittleEndian.PutUint16(buf[60:62], evt.EgressZone)

--- a/pkg/logging/session_close_binary_slog_4914_test.go
+++ b/pkg/logging/session_close_binary_slog_4914_test.go
@@ -1,0 +1,165 @@
+package logging
+
+import (
+	"encoding/binary"
+	"net"
+	"strings"
+	"testing"
+)
+
+// #4914: residual of #4796. On a SESSION_CLOSE, logEvent zeroes evt.PolicyID
+// (#2853 repurposes the [44:48] slot for the created-subsec-nanos) and only
+// rec.PolicyID carries the admitting policy from the trailing [136:140] slot
+// (#3056); the wire action byte is intentionally 0 for a close. Two sinks still
+// misrepresented that close:
+//
+//   - the binary log record encoded evt.PolicyID (0) and evt.Action (0 ->
+//     "deny"), so every binary session-close record read policy_id=0 +
+//     action=deny;
+//   - the generic slog "firewall event" close line still emitted
+//     action=actionName(0) = "deny".
+//
+// This fixture drives one live extended-close frame through ProcessRawEvent and
+// asserts parity across the buffer, callback, slog, standard, structured, and
+// binary sinks: the admitting policy id shows everywhere and no sink reports a
+// normal close as a deny.
+//
+// RED on revert of any of the three production changes:
+//   - generic slog close branch re-adding `"action", actionStr` -> the slog
+//     line contains action=deny (assertion below fails);
+//   - formatBinaryRecord encoding evt.PolicyID -> binary policy_id = 0 (fails);
+//   - formatBinaryRecord encoding evt.Action for a close -> binary action byte
+//     = 0/actionDeny instead of actionNotApplicable (fails).
+func TestSessionCloseParity_PolicyIDAndActionAcrossSinks(t *testing.T) {
+	const (
+		admittingPolicy = uint32(7777)
+		policyName      = "allow-web"
+		ingressZone     = uint16(1)
+		egressZone      = uint16(2)
+	)
+
+	// Build a full extended (rawEventExtSize) SESSION_CLOSE frame.
+	data := make([]byte, rawEventExtSize)
+	binary.LittleEndian.PutUint64(data[0:8], 1_700_000_000_000_000_000) // decision ts (ns)
+	copy(data[8:12], net.ParseIP("10.0.1.5").To4())
+	copy(data[24:28], net.ParseIP("10.0.2.7").To4())
+	binary.BigEndian.PutUint16(data[40:42], 12345) // src port
+	binary.BigEndian.PutUint16(data[42:44], 443)   // dst port
+	binary.LittleEndian.PutUint16(data[48:50], ingressZone)
+	binary.LittleEndian.PutUint16(data[50:52], egressZone)
+	data[52] = eventTypeSessionClose
+	data[53] = 6          // TCP
+	data[54] = actionDeny // wire action byte is intentionally 0 on a close
+	data[55] = addrFamilyInet
+	data[134] = closeReasonTCPFIN     // close reason code
+	data[rawEventLogSyslogOffset] = 1 // #2508 per-policy gate: DO log this close
+	binary.LittleEndian.PutUint32(data[rawEventPolicyCloseOffset:rawEventPolicyCloseOffset+4], admittingPolicy)
+
+	buf := captureInfoLogs(t)
+
+	reader := NewEventReader(nil, NewEventBuffer(16))
+	reader.SetPolicyNames(map[uint32]string{admittingPolicy: policyName})
+	reader.SetZoneNames(map[uint16]string{ingressZone: "trust", egressZone: "untrust"})
+
+	var cbRec EventRecord
+	var cbCalls int
+	reader.AddCallback(func(rec EventRecord, _ []byte) {
+		cbRec = rec
+		cbCalls++
+	})
+
+	if ok := reader.ProcessRawEvent(data); !ok {
+		t.Fatalf("ProcessRawEvent returned false")
+	}
+
+	// --- callback sink ---
+	if cbCalls != 1 {
+		t.Fatalf("callback fired %d times, want 1", cbCalls)
+	}
+	if cbRec.Type != "SESSION_CLOSE" {
+		t.Fatalf("callback rec.Type = %q, want SESSION_CLOSE", cbRec.Type)
+	}
+	if cbRec.PolicyID != admittingPolicy {
+		t.Fatalf("callback rec.PolicyID = %d, want %d (admitting policy from [136:140])",
+			cbRec.PolicyID, admittingPolicy)
+	}
+	if cbRec.PolicyName != policyName {
+		t.Fatalf("callback rec.PolicyName = %q, want %q", cbRec.PolicyName, policyName)
+	}
+	if cbRec.CloseReason != "TCP FIN" {
+		t.Fatalf("callback rec.CloseReason = %q, want %q", cbRec.CloseReason, "TCP FIN")
+	}
+
+	// --- buffer sink ---
+	buffered := reader.buffer.Latest(1)
+	if len(buffered) != 1 {
+		t.Fatalf("buffer holds %d records, want 1", len(buffered))
+	}
+	if buffered[0].PolicyID != admittingPolicy {
+		t.Fatalf("buffer rec.PolicyID = %d, want %d", buffered[0].PolicyID, admittingPolicy)
+	}
+
+	// --- slog sink (generic "firewall event" close line) ---
+	out := buf.String()
+	if !strings.Contains(out, "firewall event") {
+		t.Fatalf("expected a \"firewall event\" slog line, got: %s", out)
+	}
+	if !strings.Contains(out, "policy_id=7777") {
+		t.Fatalf("slog close line missing policy_id=7777: %s", out)
+	}
+	if strings.Contains(out, "action=") {
+		t.Fatalf("slog close line still emits an action field (a close is not a "+
+			"forwarding decision; the wire byte 0 renders \"deny\" and drives "+
+			"false drop alerts, #4914): %s", out)
+	}
+	if !strings.Contains(out, `reason="TCP FIN"`) {
+		t.Fatalf("slog close line missing reason=\"TCP FIN\": %s", out)
+	}
+
+	// --- standard text sink ---
+	std := formatSyslogMsg(cbRec)
+	if !strings.Contains(std, "policy=7777") {
+		t.Fatalf("standard close line missing policy=7777: %s", std)
+	}
+	if strings.Contains(std, "action=") {
+		t.Fatalf("standard close line unexpectedly carries action=: %s", std)
+	}
+
+	// --- structured text sink ---
+	structured := formatStructuredMsg(cbRec, 6)
+	if !strings.Contains(structured, `policy-name="allow-web"`) {
+		t.Fatalf("structured close line missing policy-name=\"allow-web\": %s", structured)
+	}
+	if !strings.Contains(structured, `reason="TCP FIN"`) {
+		t.Fatalf("structured close line missing reason=\"TCP FIN\": %s", structured)
+	}
+
+	// --- binary sink ---
+	// Model logEvent's evt for a close: evt.PolicyID was zeroed and the wire
+	// action byte is 0. The record must nonetheless encode the admitting policy
+	// (from rec.PolicyID) and flag the action "not applicable".
+	evt := &rawEvent{
+		EventType:  eventTypeSessionClose,
+		Protocol:   6,
+		Action:     actionDeny, // 0, as on the wire
+		AddrFamily: addrFamilyInet,
+		PolicyID:   0, // zeroed by logEvent on a close
+	}
+	copy(evt.SrcIP[:4], net.ParseIP("10.0.1.5").To4())
+	copy(evt.DstIP[:4], net.ParseIP("10.0.2.7").To4())
+	binRec := formatBinaryRecord(evt, &cbRec, SyslogInfo, closeReasonTCPFIN)
+
+	binPolicy := binary.LittleEndian.Uint32(binRec[54:58])
+	if binPolicy != admittingPolicy {
+		t.Fatalf("binary record policy_id = %d, want %d (must encode rec.PolicyID, "+
+			"not the zeroed evt.PolicyID, #4914)", binPolicy, admittingPolicy)
+	}
+	if binRec[7] != actionNotApplicable {
+		t.Fatalf("binary record action byte = %d, want %d (a close carries no "+
+			"forwarding decision; encoding the wire 0 reads as actionDeny, #4914)",
+			binRec[7], actionNotApplicable)
+	}
+	if binRec[142] != closeReasonTCPFIN {
+		t.Fatalf("binary record close reason = %d, want %d", binRec[142], closeReasonTCPFIN)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #4796. On a `SESSION_CLOSE`, `logEvent` zeroes `evt.PolicyID`
(#2853 repurposes the `[44:48]` slot for the created-subsec-nanos) and only
`rec.PolicyID` is repopulated, from the trailing `[136:140]` admitting-policy
slot (#3056); the wire action byte is intentionally 0 for a close. Two sinks
still misrepresented every close:

- **Binary log record** (`formatBinaryRecord`) encoded `evt.PolicyID` (0) and
  `evt.Action` (0 → `actionDeny`), so every binary session-close record reported
  `policy_id=0` and `action=deny` — binary forensic consumers could not
  attribute a close to its admitting policy and read normal terminations as
  drops.
- **Generic slog "firewall event" close branch** still emitted
  `action=actionName(0)="deny"`. The standard/structured RT_FLOW_SESSION_CLOSE
  text lines were fixed to omit close action in #2513, but this branch was
  missed — classifying normal terminations as denies and driving false drop
  alerts / broken correlation.

## Fix

- `formatBinaryRecord` now encodes `rec.PolicyID` (the authoritative policy id;
  byte-identical to `evt.PolicyID` for every non-close event since `logEvent`
  mirrors them) and flags the close action byte `actionNotApplicable` (0xFF) — a
  documented sentinel, since the fixed-shape binary record cannot omit a field
  the way the text formatters do.
- The generic slog close line omits `action` and carries the close `reason`
  instead, matching the standard/structured lines.
- Scope is `SESSION_CLOSE`: the `SESSION_OPEN` binary action byte is asserted by
  an existing unit test and is out of this issue's scope.

## Validation

- Added a **live extended-close parity fixture** through `ProcessRawEvent`
  asserting the admitting policy id and no-deny across the buffer, callback,
  slog, standard, structured, and binary sinks.
- Verified **RED** by surgically reverting each of the three production changes
  (the fixture fails), and **GREEN** once restored.
- `go test ./pkg/logging/`, `go vet`, `gofmt`, and `go build ./...` clean.
- Updated `TestFormatBinaryRecord_Basic` to populate `rec.PolicyID`, the field
  the record now reads.

Closes #4914

🤖 Generated with [Claude Code](https://claude.com/claude-code)