### PR TITLE
grpcapi: clamp non-loopback primary gRPC bind to loopback (#5035)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,18 @@
+## 2026-07-09 — #5035 grpcapi primary listener loopback clamp (security)
+
+- **Timestamp**: 2026-07-09
+  **Action**: #5035. The primary gRPC listener (`Run`) is unauthenticated
+  (only `configLockInterceptor`), so a non-loopback `--grpc-addr` would
+  expose destructive RPCs (SystemAction zeroize/reboot, Commit/Delete/
+  Rollback) to the network. Added `clampGRPCBindToLoopback` mirroring the
+  #4903/#4928 web-management/cluster doctrine and wired it into `Run` so a
+  wildcard/routable bind is pulled back to a same-family loopback + warned.
+  The default 127.0.0.1 path is unchanged. RED-on-revert:
+  `TestRunClampsNonLoopbackBind` + pure `TestClampGRPCBindToLoopback`.
+  **File(s)**: pkg/grpcapi/server.go,
+  pkg/grpcapi/server_grpc_loopback_clamp_5035_test.go,
+  pkg/grpcapi/README.md
+
 ## 2026-07-09 — #4908 cli/show display-fidelity cohort (partial: 6 fixed, 6 deferred)
 
 - **Timestamp**: 2026-07-09

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -15,6 +15,21 @@ tab completion. The wire schema is `proto/xpf/v1`.
   and blocks until the context is cancelled.
 - Tab completion: `Complete` RPC, backed by `pkg/cmdtree`.
 
+## Trust boundary (loopback-only, #5035)
+
+The primary listener started by `Run` installs **no** authentication or
+TLS — only `configLockInterceptor` — so every RPC (including destructive
+`SystemAction` zeroize/reboot/halt/power-off and Commit/Delete/Rollback)
+is inherently trusted. That trust holds only if the listener is
+loopback-bound. `Run` therefore clamps a non-loopback `--grpc-addr`
+(`0.0.0.0`, a routable address, or the `:port` wildcard) back to a
+same-family loopback (`clampGRPCBindToLoopback`) and warns, mirroring the
+web-management (#4903) and cluster-bind (#4928) doctrine. There is no
+auth mode that unlocks a non-loopback bind here: the intentionally
+network-exposed gRPC surface is the **separate** fabric listener
+(`RunFabricListener`), which authenticates (#4107) and allowlists (#4122)
+every call.
+
 ## Callers
 
 `cmd/xpfd` (instantiates and runs); `cmd/cli` (consumes); HTTP REST

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -187,8 +187,12 @@ func (s *Server) userspaceDataplaneControl() (userspaceControlProvider, error) {
 
 // NewServer creates a new gRPC server.
 // NOTE: gRPC is local-only (127.0.0.1) so all RPCs are inherently trusted.
-// Login class RBAC enforcement could be added here via per-RPC interceptors if
-// gRPC is ever exposed on non-loopback addresses.
+// Run enforces that trust boundary: a non-loopback bind address is clamped
+// back to loopback (clampGRPCBindToLoopback, #5035) because this listener has
+// no authentication. Login class RBAC enforcement could be added here via
+// per-RPC interceptors if gRPC is ever intentionally exposed on non-loopback
+// addresses; until then, cross-node access uses the authenticated fabric
+// listener (RunFabricListener), not this one.
 func NewServer(addr string, cfg Config) *Server {
 	return &Server{
 		store:                 cfg.Store,
@@ -257,7 +261,66 @@ func stopGRPCServer(srv *grpc.Server, timeout time.Duration) {
 	}
 }
 
+// grpcHostIsLoopback reports whether a gRPC bind host is a loopback address.
+// It mirrors the web-management / cluster bind doctrine (#4903/#4928): an EMPTY
+// host is the Go wildcard spelling (`net.SplitHostPort(":50051")` yields host ""
+// and listens on ALL interfaces) and is NOT loopback; the literal "localhost"
+// is a legitimate loopback bind spelling; an unparseable, non-loopback host
+// fails safe as NON-loopback so the bind is clamped rather than left exposed.
+func grpcHostIsLoopback(host string) bool {
+	if host == "" {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
+}
+
+// clampGRPCBindToLoopback pulls a non-loopback PRIMARY gRPC bind back to a
+// loopback of the same address family (#5035). The primary gRPC listener
+// (Run) installs only configLockInterceptor — no TLS, no authentication — so
+// NewServer's documented contract is that gRPC is loopback-only and every RPC
+// is inherently trusted (SystemAction zeroize/reboot/halt/power-off,
+// Commit/Delete/Rollback, the whole config surface). A non-loopback
+// `--grpc-addr` (`0.0.0.0`, a routable address) would therefore expose the
+// full unauthenticated control plane to the network. Unlike the
+// web-management clamp there is NO auth mode that unlocks a non-loopback bind
+// here: the intentionally network-exposed gRPC surface is the SEPARATE fabric
+// listener (RunFabricListener), which authenticates (#4107) and allowlists
+// (#4122) every call. A genuine loopback bind (127.0.0.0/8, ::1, "localhost")
+// is returned unchanged; a bind whose host part fails to split (no port to
+// clamp) is also returned unchanged.
+func clampGRPCBindToLoopback(addr string) (string, bool) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil || grpcHostIsLoopback(host) {
+		return addr, false
+	}
+	loopback := "127.0.0.1"
+	if ip := net.ParseIP(host); ip != nil && ip.To4() == nil {
+		// An IPv6 (non-v4-mapped) bind clamps to the IPv6 loopback so the
+		// listener stays same-family.
+		loopback = "::1"
+	}
+	return net.JoinHostPort(loopback, port), true
+}
+
 func (s *Server) Run(ctx context.Context) error {
+	// Fail-safe loopback clamp (#5035): the primary gRPC listener is
+	// unauthenticated, so a non-loopback bind would expose destructive RPCs to
+	// the network. Pull it back to a loopback of the same family and WARN; the
+	// daemon still boots and gRPC stays reachable on loopback (the console/SSH
+	// remain the lifeline). Cross-node access uses the authenticated fabric
+	// listener, not this one.
+	if clamped, ok := clampGRPCBindToLoopback(s.addr); ok {
+		slog.Warn("gRPC bind is non-loopback but the primary gRPC listener is unauthenticated (loopback-only trust boundary); clamping to loopback — use the authenticated cluster fabric listener for cross-node access — #5035",
+			"requested", s.addr, "clamped", clamped)
+		s.addr = clamped
+	}
 	lis, err := net.Listen("tcp", s.addr)
 	if err != nil {
 		return fmt.Errorf("gRPC listen: %w", err)

--- a/pkg/grpcapi/server_grpc_loopback_clamp_5035_test.go
+++ b/pkg/grpcapi/server_grpc_loopback_clamp_5035_test.go
@@ -1,0 +1,74 @@
+package grpcapi
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestClampGRPCBindToLoopback pins the pure decision (#5035): the primary,
+// unauthenticated gRPC listener must never bind off-loopback. A wildcard or
+// routable bind is pulled back to a same-family loopback; a genuine loopback
+// bind is returned unchanged.
+func TestClampGRPCBindToLoopback(t *testing.T) {
+	cases := []struct {
+		addr        string
+		wantAddr    string
+		wantClamped bool
+	}{
+		// Off-loopback binds MUST be clamped (the exposure this fixes).
+		{"0.0.0.0:50051", "127.0.0.1:50051", true},
+		{":50051", "127.0.0.1:50051", true}, // Go wildcard spelling — all interfaces
+		{"192.0.2.1:50051", "127.0.0.1:50051", true},
+		{"[::]:50051", "[::1]:50051", true},
+		{"[2001:db8::1]:50051", "[::1]:50051", true},
+		// Genuine loopback binds are left unchanged.
+		{"127.0.0.1:50051", "127.0.0.1:50051", false},
+		{"127.0.0.53:50051", "127.0.0.53:50051", false},
+		{"[::1]:50051", "[::1]:50051", false},
+		{"localhost:50051", "localhost:50051", false},
+		// No port to clamp — returned unchanged.
+		{"not-an-addr", "not-an-addr", false},
+	}
+	for _, c := range cases {
+		gotAddr, gotClamped := clampGRPCBindToLoopback(c.addr)
+		if gotAddr != c.wantAddr || gotClamped != c.wantClamped {
+			t.Errorf("clampGRPCBindToLoopback(%q) = (%q, %v), want (%q, %v)",
+				c.addr, gotAddr, gotClamped, c.wantAddr, c.wantClamped)
+		}
+	}
+}
+
+// TestRunClampsNonLoopbackBind proves the clamp is actually wired into Run
+// (#5035): Run is given a routable, host-unassignable TEST-NET-1 address. With
+// the clamp, Run rewrites the bind to loopback and keeps serving; without it
+// (revert), net.Listen fails to assign 192.0.2.1 and Run returns an error
+// almost immediately — which this test detects as an early exit.
+func TestRunClampsNonLoopbackBind(t *testing.T) {
+	s := &Server{addr: "192.0.2.1:0"} // RFC 5737 TEST-NET-1: never assigned to a host
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Run(ctx) }()
+
+	select {
+	case err := <-errCh:
+		// Run exited before we cancelled the context — it never bound, so the
+		// clamp is absent and the non-loopback bind was attempted directly.
+		t.Fatalf("Run exited early (bind was not clamped to loopback): %v", err)
+	case <-time.After(300 * time.Millisecond):
+		// Still serving after the grace window — the bind was clamped to
+		// loopback and net.Listen succeeded.
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Run returned error after cancel: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+}


### PR DESCRIPTION
## Problem

The primary gRPC listener (`Server.Run`, `pkg/grpcapi/server.go`) installs only `configLockInterceptor` — **no TLS, no authentication**. `NewServer`'s documented contract is that gRPC is loopback-only, so every RPC is inherently trusted, including destructive ones (`SystemAction` zeroize/reboot/halt/power-off, `Commit`/`Delete`/`Rollback`).

Nothing enforced that contract: `cmd/xpfd` accepts any `--grpc-addr` and `NewServer` stored it unchanged. `--grpc-addr=0.0.0.0` (or a routable address) exposes the full unauthenticated control plane to the network — remote unauthenticated root-equivalent control from one bind mistake. The two auth layers (`fabricAuth*` #4107, `fabricAllowlist*` #4122) protect **only** the separate fabric listener (`RunFabricListener`).

## Fix

Add `clampGRPCBindToLoopback`, mirroring the #4903/#4928 web-management/cluster bind doctrine:

- A non-loopback bind (`0.0.0.0`, a routable address, or the `:port` wildcard) is pulled back to a loopback of the **same** address family (`127.0.0.1` / `::1`) and a warning is logged.
- A genuine loopback bind (`127.0.0.0/8`, `::1`, `localhost`) is returned unchanged.
- `Run` applies the clamp **before** `net.Listen`, so the listener never binds off-loopback.

There is no auth mode that unlocks a non-loopback bind here — cross-node access uses the authenticated fabric listener, not this one. The default `127.0.0.1:50051` path is unaffected.

## Validation

- `TestRunClampsNonLoopbackBind` — drives `Run` with a host-unassignable TEST-NET-1 address; with the clamp it keeps serving (bind → loopback), reverting the clamp makes `Run` fail to bind and the test detects the early exit (RED-on-revert).
- `TestClampGRPCBindToLoopback` — pins the pure decision across wildcard/routable/loopback/IPv6 inputs.
- `go build ./...` clean; `go vet ./pkg/grpcapi/` clean; full `pkg/grpcapi` package tests green.

Closes #5035

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi