### PR TITLE
cli: bound the `| last N` filter allocation to a fixed cap (#5037)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,19 @@
+## 2026-07-09 — #5037 cli `| last N` unbounded pre-allocation (security)
+
+- **Timestamp**: 2026-07-09
+  **Action**: #5037. The `| last N` filter (`filterStream`, pkg/cli) parsed N
+  with only a `v > 0` gate and eagerly did `make([]string, N)` before any
+  output — a read-only (`show`, PermView) user could `| last 2000000000` and
+  OOM-kill xpfd (~32 GiB up front). Extracted `parseLastCount` clamping N to a
+  fixed `maxTailLines` (100,000) cap and rewrote the ring to grow lazily, so
+  memory is O(min(N, lines produced)) and never O(operand). Applied the same
+  cap to the remote CLI `applyPipeFilter` (`cmd/cli/shared.go`) for local/
+  remote parity (#4968) — that branch slices rather than pre-allocating so it
+  was not the OOM vector. RED-on-revert: `TestParseLastCountCap` +
+  `TestFilterStreamLastCapTruncates`.
+  **File(s)**: pkg/cli/cli_dispatch.go, cmd/cli/shared.go,
+  pkg/cli/cli_last_cap_5037_test.go, docs/junos-cli-reference.md
+
 ## 2026-07-09 — #4908 cli/show display-fidelity cohort (partial: 6 fixed, 6 deferred)
 
 - **Timestamp**: 2026-07-09

--- a/cmd/cli/shared.go
+++ b/cmd/cli/shared.go
@@ -196,11 +196,20 @@ func applyPipeFilter(lines []string, out io.Writer, pipeType, pipeArg string) {
 	case "count":
 		fmt.Fprintf(out, "Count: %d lines\n", len(lines))
 	case "last":
+		// Clamp N to the same cap the local CLI enforces
+		// (pkg/cli.maxTailLines, #5037) so `| last N` behaves identically on
+		// both surfaces (#4968 local/remote harmony). This branch slices
+		// lines[start:] rather than pre-allocating from N, so it is not the
+		// OOM vector the local filterStream was — the clamp is for parity.
+		const maxTailLines = 100_000
 		n := 10
 		if pipeArg != "" {
 			if v, err := strconv.Atoi(pipeArg); err == nil && v > 0 {
 				n = v
 			}
+		}
+		if n > maxTailLines {
+			n = maxTailLines
 		}
 		start := len(lines) - n
 		if start < 0 {

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -2233,6 +2233,11 @@ Shows last N lines:
 > show log messages | last 20
 ```
 
+`N` is clamped to a fixed maximum (100,000 lines) so an oversized operand
+cannot force an unbounded allocation in the control plane (#5037); the
+buffer also grows lazily, so it only ever holds `min(N, lines produced)`
+lines regardless of how large `N` is.
+
 ### Combined Filters
 
 Pipe filters can be chained:

--- a/pkg/cli/cli_dispatch.go
+++ b/pkg/cli/cli_dispatch.go
@@ -93,6 +93,32 @@ func (c *CLI) dispatchWithPipe(cmd, pipeType, pipeArg string) error {
 // input. match/except/find/no-more hold at most one line at a time; count keeps
 // only a running tally; last keeps a bounded ring buffer of the last n lines —
 // none buffers the full output (#4731).
+// maxTailLines bounds the ring the `| last N` filter retains and grows,
+// independent of the operator-supplied N (#5037). `show` is a read-only
+// (PermView) command, so without a bound a viewer could run
+// `show ... | last 2000000000` and force a ~32 GiB up-front []string
+// allocation, OOM-killing the in-process xpfd before any output is produced.
+// 100,000 lines is far more tail than any operator needs, yet caps the ring's
+// worst-case slice header at ~1.6 MiB (64-bit) plus the retained line strings.
+const maxTailLines = 100_000
+
+// parseLastCount parses the `| last N` operand. It defaults to 10, ignores a
+// non-positive or unparseable N (Junos-compatible leniency), and clamps N to
+// maxTailLines so the retained/grown ring is bounded by a fixed operator cap
+// rather than an untrusted operand (#5037).
+func parseLastCount(arg string) int {
+	n := 10
+	if arg != "" {
+		if v, err := strconv.Atoi(arg); err == nil && v > 0 {
+			n = v
+		}
+	}
+	if n > maxTailLines {
+		n = maxTailLines
+	}
+	return n
+}
+
 func filterStream(src io.Reader, out io.Writer, pipeType, pipeArg string) {
 	ls := &lineSource{r: bufio.NewReader(src)}
 
@@ -130,20 +156,22 @@ func filterStream(src io.Reader, out io.Writer, pipeType, pipeArg string) {
 		}
 		fmt.Fprintf(out, "Count: %d lines\n", count)
 	case "last":
-		n := 10
-		if pipeArg != "" {
-			if v, err := strconv.Atoi(pipeArg); err == nil && v > 0 {
-				n = v
-			}
-		}
+		n := parseLastCount(pipeArg)
 		// Circular buffer of the last n lines: slot i%n holds the i-th
-		// line, overwriting the oldest once more than n have arrived. Only
-		// n lines are ever retained, not the whole output.
-		ring := make([]string, n)
+		// line, overwriting the oldest once more than n have arrived. The
+		// ring GROWS LAZILY (append until it holds n lines, then overwrite)
+		// so its memory is O(min(n, lines produced)) — never O(operand),
+		// never pre-allocated from an untrusted N (#5037). Only n lines are
+		// ever retained, not the whole output.
+		ring := make([]string, 0)
 		count := 0
 		for ls.hasMore() {
 			line, _ := ls.next()
-			ring[count%n] = line
+			if len(ring) < n {
+				ring = append(ring, line)
+			} else {
+				ring[count%n] = line
+			}
 			count++
 		}
 		total := count

--- a/pkg/cli/cli_last_cap_5037_test.go
+++ b/pkg/cli/cli_last_cap_5037_test.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestParseLastCountCap pins the operand bound for `| last N` (#5037). The
+// `show` pipe is read-only (PermView), so an unbounded N would let a viewer
+// force a huge up-front allocation. parseLastCount must default to 10, ignore
+// non-positive/unparseable operands, and clamp any N above maxTailLines to the
+// cap. Reverting the clamp makes the "2000000000" case return the raw operand
+// (which the old code fed straight into make([]string, N)) and this test fails.
+func TestParseLastCountCap(t *testing.T) {
+	cases := []struct {
+		arg  string
+		want int
+	}{
+		{"", 10},                     // default
+		{"5", 5},                     // in-range
+		{"0", 10},                    // non-positive -> default
+		{"-4", 10},                   // negative -> default
+		{"abc", 10},                  // unparseable -> default
+		{"100000", maxTailLines},     // exactly the cap
+		{"100001", maxTailLines},     // just over the cap -> clamped
+		{"2000000000", maxTailLines}, // the ~32 GiB OOM operand -> clamped
+		{"99999999999999999999", 10}, // strconv overflow -> err -> default
+	}
+	for _, c := range cases {
+		if got := parseLastCount(c.arg); got != c.want {
+			t.Errorf("parseLastCount(%q) = %d, want %d", c.arg, got, c.want)
+		}
+	}
+}
+
+// TestFilterStreamLastHugeOperandBounded exercises the whole `| last N` path
+// end-to-end with a huge operand on a modest input (#5037): the ring grows
+// lazily and the operand is capped, so this returns the full input as its tail
+// without attempting an operand-sized allocation. With the pre-fix
+// make([]string, N) this input would try to allocate ~32 GiB.
+func TestFilterStreamLastHugeOperandBounded(t *testing.T) {
+	var in strings.Builder
+	const lines = 2000
+	for i := 0; i < lines; i++ {
+		fmt.Fprintf(&in, "line%06d\n", i)
+	}
+
+	var got bytes.Buffer
+	filterStream(strings.NewReader(in.String()), &got, "last", "2000000000")
+
+	// Input (2000 lines) is far below the cap, so `last <huge>` returns every
+	// line in order — identical to the tail of the whole input.
+	if got.String() != in.String() {
+		t.Fatalf("filterStream last huge-operand: output did not equal the full %d-line input", lines)
+	}
+}
+
+// TestFilterStreamLastCapTruncates proves the cap actually bounds retention:
+// with more input lines than the cap, `| last <over-cap>` returns exactly the
+// last maxTailLines lines (not the whole input, not an operand-sized slice).
+func TestFilterStreamLastCapTruncates(t *testing.T) {
+	total := maxTailLines + 25
+	var in strings.Builder
+	for i := 0; i < total; i++ {
+		fmt.Fprintf(&in, "L%d\n", i)
+	}
+
+	var got bytes.Buffer
+	// Operand well above the cap; retention must be bounded to maxTailLines.
+	filterStream(strings.NewReader(in.String()), &got, "last", "999999999")
+
+	outLines := strings.Split(strings.TrimRight(got.String(), "\n"), "\n")
+	if len(outLines) != maxTailLines {
+		t.Fatalf("last over-cap returned %d lines, want cap %d", len(outLines), maxTailLines)
+	}
+	// The very last line must be preserved (the tail is the newest lines).
+	wantLast := fmt.Sprintf("L%d", total-1)
+	if outLines[len(outLines)-1] != wantLast {
+		t.Fatalf("tail last line = %q, want %q", outLines[len(outLines)-1], wantLast)
+	}
+	// The first retained line must be the (total-maxTailLines)-th line.
+	wantFirst := fmt.Sprintf("L%d", total-maxTailLines)
+	if outLines[0] != wantFirst {
+		t.Fatalf("tail first line = %q, want %q", outLines[0], wantFirst)
+	}
+}


### PR DESCRIPTION
## Problem

The `| last N` output filter (`filterStream`, `pkg/cli/cli_dispatch.go`) parsed `N` with `strconv.Atoi` behind only a `v > 0` gate — no upper bound — then eagerly allocated `ring := make([]string, N)` **before** consuming any output. `show` is a read-only `PermView` command, so a viewer-only user could run `show version | last 2000000000`, requesting a ~32 GiB slice (16 B/header slot) up front and OOM-killing the in-process `xpfd` before producing output. The allocation was O(untrusted operand), independent of output volume.

(Distinct primitive from #4886, which is O(output) re-buffering; here the allocation is O(operand).)

## Fix

- `parseLastCount` clamps `N` to a fixed `maxTailLines` (100,000) operator cap.
- The ring now grows **lazily** (append until it holds `N` lines, then overwrite the oldest), so its memory is O(min(N, lines produced)) and is never pre-allocated from the operand.
- Output for any input at or below the cap is byte-identical to before.
- The remote CLI's `applyPipeFilter` (`cmd/cli/shared.go`) gets the same cap for local/remote parity (#4968). That branch slices `lines[start:]` rather than pre-allocating, so it was not itself the OOM vector — the clamp is for parity.

## Validation

- `TestParseLastCountCap` — default / non-positive / unparseable / over-cap decisions; reverting the clamp makes the huge-operand case return the raw operand → test fails (RED-on-revert).
- `TestFilterStreamLastCapTruncates` — drives the filter with an over-cap input; retention is bounded to the cap.
- `TestFilterStreamLastHugeOperandBounded` — a huge operand on a modest input returns the full tail without an operand-sized allocation.
- Existing #4731 parity tests still pass. `go build ./...` clean; `go vet ./pkg/cli ./cmd/cli` clean; package tests green.

Closes #5037

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi