### PR TITLE
snmp: bound GET/GETNEXT responses and de-quadratic trimToFit (#4918)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,21 @@
+## 2026-07-09 — #4918 snmp GET/GETNEXT size bound + trimToFit O(n^2) (security)
+
+- **Timestamp**: 2026-07-09
+  **Action**: #4918 (residual of #2612). (1) v2c `handleGet`/`handleGetNext`
+  and the v3 GET/GETNEXT tail returned `buildResponse(...)` directly with no
+  size cap — an oversized response was emitted. Added `boundGetResponse` (v2c)
+  + a matching v3 tail check that replaces an over-`effectiveMaxSize` GET/
+  GETNEXT with `tooBig` + empty varbinds (RFC 3416 §4.2.1/§4.2.2; GET/GETNEXT
+  cannot be trimmed like GETBULK). (2) `trimToFit` did an O(n) decrement-and-
+  rebuild (O(n^2) total, v3 re-running USM/HMAC/enc per drop) — replaced with a
+  fast-path full build + binary search (O(log n) rebuilds) returning the same
+  largest-fitting prefix. GETBULK trimming behaviour is unchanged. RED-on-
+  revert: `TestV2cGet_OversizedReturnsTooBig` /
+  `TestV2cGetNext_OversizedReturnsTooBig` (6.7 KB / 6.6 KB over-size without
+  the bound) + `TestTrimToFit_BinarySearch` (991 build calls when linear).
+  **File(s)**: pkg/snmp/agent.go, pkg/snmp/v3.go,
+  pkg/snmp/getresp_size_4918_test.go, pkg/snmp/README.md
+
 ## 2026-07-09 — #4908 cli/show display-fidelity cohort (partial: 6 fixed, 6 deferred)
 
 - **Timestamp**: 2026-07-09

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -276,14 +276,25 @@ authorization surface: every request is dropped because no community matches.
   484-byte floor (a bogus/tiny advertised value cannot starve the response);
   v2c carries no per-request `msgMaxSize` on the wire, so the effective size is
   the local 4096-byte maximum. During expansion the response is built and then
-  trimmed: trailing varbinds are dropped until the encoded message (including
-  the v3 USM/scopedPDU and any auth/priv overhead) fits. Trimming — not
+  trimmed: the largest leading prefix of varbinds whose encoded message
+  (including the v3 USM/scopedPDU and any auth/priv overhead) fits is kept.
+  `trimToFit` finds that prefix by **binary search** — the encoded length is
+  monotonic in the number of leading varbinds — so it costs O(log n) rebuilds,
+  not the O(n) decrement-and-rebuild it replaced (#4918, which for v3 re-ran
+  USM framing/HMAC/encryption on every dropped varbind). Trimming — not
   `tooBig` — is the normal outcome; the manager continues the walk with a
   follow-up GETBULK from the last returned OID. `tooBig` (with an empty varbind
   list) is returned only in the pathological case where not even a single
-  varbind fits. This prevents emitting an oversized UDP datagram that the peer
-  or the network would fragment or drop. See `effectiveMaxSize` / `trimToFit`
-  in `agent.go`.
+  varbind fits. See `effectiveMaxSize` / `trimToFit` in `agent.go`.
+- **Plain GET/GETNEXT responses are size-bounded too (#4918).** A GET/GETNEXT
+  carries a fixed 1:1 varbind-per-request-OID contract, so an oversized
+  response cannot be trimmed like GETBULK (the manager cannot "continue" a
+  GET). Per RFC 3416 §4.2.1/§4.2.2 an over-size GET/GETNEXT response is
+  replaced with `tooBig` + an empty varbind list rather than emitting a
+  datagram larger than the effective maximum. `boundGetResponse` (v2c, in
+  `agent.go`) and the v3 GET/GETNEXT tail (`v3.go`) enforce this; before #4918
+  only GETBULK was bounded (#2612), so a GET naming many OIDs — or one OID with
+  a long configured string value — could reflect an oversized datagram.
 - **The interface table is snapshotted ONCE per PDU (#4013).** `SetIfDataFn`
   (the daemon's `buildSNMPIfData`) performs a full netlink `LinkList`
   (RTM_GETLINK dump) on every call, so a request handler must NOT read it

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -774,7 +774,7 @@ func (a *Agent) handleGet(community []byte, pduBody []byte) []byte {
 		}
 	}
 
-	return a.buildResponse(community, requestID, errNoError, 0, varbinds)
+	return a.boundGetResponse(community, requestID, varbinds)
 }
 
 // handleGetNext processes a GETNEXT request.
@@ -799,7 +799,22 @@ func (a *Agent) handleGetNext(community []byte, pduBody []byte) []byte {
 		}
 	}
 
-	return a.buildResponse(community, requestID, errNoError, 0, varbinds)
+	return a.boundGetResponse(community, requestID, varbinds)
+}
+
+// boundGetResponse builds a v2c GET/GETNEXT GetResponse and enforces the local
+// message-size ceiling (#4918, residual of #2612 which bounded only GETBULK).
+// A GET/GETNEXT carries a fixed 1:1 varbind-per-request-OID contract, so —
+// unlike GETBULK, whose oversized walk the manager continues with a follow-up
+// request — an oversized GET/GETNEXT response cannot be trimmed. Per RFC 3416
+// §4.2.1/§4.2.2 it is replaced with tooBig + an empty varbind list rather than
+// emitting a datagram larger than maxPacketSize.
+func (a *Agent) boundGetResponse(community []byte, requestID int, varbinds []varbind) []byte {
+	resp := a.buildResponse(community, requestID, errNoError, 0, varbinds)
+	if len(resp) > effectiveMaxSize(maxPacketSize) {
+		return a.buildResponse(community, requestID, errTooBig, 0, nil)
+	}
+	return resp
 }
 
 // handleGetBulk processes a GETBULK request (RFC 3416).
@@ -1169,12 +1184,13 @@ func effectiveMaxSize(advertised int) int {
 }
 
 // trimToFit bounds a GETBULK response to maxSize bytes (RFC 3416 §4.2.3). It
-// builds the response from vbs via build; if the encoded message exceeds
-// maxSize it drops trailing varbinds one at a time and rebuilds until the
-// message fits, returning the truncated-but-well-formed response. A manager
-// that receives a trimmed response continues the walk with a follow-up GETBULK
-// from the last returned OID, so trimming (not tooBig) is the normal, preferred
-// outcome.
+// builds the response from vbs via build; if the full encoded message exceeds
+// maxSize it binary-searches the largest leading prefix of varbinds whose
+// encoded message still fits and returns that truncated-but-well-formed
+// response (#4918: O(log n) rebuilds, not the old O(n) decrement-and-rebuild).
+// A manager that receives a trimmed response continues the walk with a
+// follow-up GETBULK from the last returned OID, so trimming (not tooBig) is the
+// normal, preferred outcome.
 //
 // build must construct a complete SNMP response message from the supplied
 // varbind list (it captures the version-specific envelope: v2c community frame
@@ -1187,13 +1203,39 @@ func effectiveMaxSize(advertised int) int {
 // pathological maxSize, but it is handled rather than emitting an oversized
 // datagram.
 func trimToFit(vbs []varbind, maxSize int, build func([]varbind) []byte) (resp []byte, ok bool) {
-	for n := len(vbs); n >= 0; n-- {
-		resp = build(vbs[:n])
-		if len(resp) <= maxSize {
-			return resp, true
+	// Fast path: the full varbind set almost always fits, so try it first —
+	// one build, no trimming (the common case, unchanged cost).
+	full := build(vbs)
+	if len(full) <= maxSize {
+		return full, true
+	}
+
+	// Oversized. The encoded message length is monotonic non-decreasing in the
+	// number of leading varbinds (each varbind adds bytes), so binary-search
+	// the largest prefix that still fits instead of dropping one varbind at a
+	// time and rebuilding. This turns the trim from O(n) rebuilds (each O(n),
+	// and for v3 each re-running USM framing/HMAC/encryption on the single
+	// serial SNMP goroutine) into O(log n) rebuilds — #4918, the O(n^2)
+	// residual of #2612. The result is identical to the decrement-and-rebuild:
+	// the longest leading prefix of vbs whose encoded response is <= maxSize.
+	empty := build(vbs[:0])
+	if len(empty) > maxSize {
+		return nil, false // even a zero-varbind response cannot fit
+	}
+	// Invariant: build(vbs[:lo]) fits, build(vbs[:hi]) does not (len(vbs) was
+	// just shown oversized). Narrow until lo+1 == hi; lo is then the answer.
+	lo, hi := 0, len(vbs)
+	best := empty
+	for lo+1 < hi {
+		mid := (lo + hi) / 2
+		r := build(vbs[:mid])
+		if len(r) <= maxSize {
+			lo, best = mid, r
+		} else {
+			hi = mid
 		}
 	}
-	return nil, false
+	return best, true
 }
 
 // buildResponse constructs a complete SNMP v2c response packet.

--- a/pkg/snmp/getresp_size_4918_test.go
+++ b/pkg/snmp/getresp_size_4918_test.go
@@ -1,0 +1,171 @@
+package snmp
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// buildV2cGetRequestMulti constructs an SNMP v2c GET request for a LIST of
+// OIDs (the single-OID buildV2cGetRequest lives in agent_set_test.go; the
+// GETNEXT sibling buildV2cGetNextRequest lives in getbulk_size_test.go). The
+// two integer fields after request-id (error-status / error-index) are zero in
+// a request.
+func buildV2cGetRequestMulti(community string, requestID int, oids [][]int) []byte {
+	var vbList []byte
+	for _, oid := range oids {
+		oidBytes := berEncodeTLV(tagObjectIdentifier, berEncodeOID(oid))
+		valBytes := berEncodeTLV(tagNull, nil)
+		vbList = append(vbList, berEncodeTLV(tagSequence, append(oidBytes, valBytes...))...)
+	}
+	vbListEnc := berEncodeTLV(tagSequence, vbList)
+
+	pduBody := berEncodeIntegerTLV(requestID)
+	pduBody = append(pduBody, berEncodeIntegerTLV(0)...) // error-status
+	pduBody = append(pduBody, berEncodeIntegerTLV(0)...) // error-index
+	pduBody = append(pduBody, vbListEnc...)
+	pdu := berEncodeTLV(pduGetRequest, pduBody)
+
+	msg := berEncodeIntegerTLV(snmpVersion2c)
+	msg = append(msg, berEncodeTLV(tagOctetString, []byte(community))...)
+	msg = append(msg, pdu...)
+	return berEncodeTLV(tagSequence, msg)
+}
+
+// ifDescrOIDs returns ifTable ifDescr (column 2) OIDs for ifIndex 1..n. With
+// manyIfData(n)'s long IfDescr values, a GET/GETNEXT over enough of them
+// overflows the 4096-byte response ceiling.
+func ifDescrOIDs(n int) [][]int {
+	oids := make([][]int, 0, n)
+	for i := 1; i <= n; i++ {
+		oid := append(append([]int{}, oidIfTablePrefix...), 2, i)
+		oids = append(oids, oid)
+	}
+	return oids
+}
+
+// TestV2cGet_OversizedReturnsTooBig covers residual (1) of #4918 for plain GET:
+// a GET naming many long-valued OIDs would encode a response larger than
+// maxPacketSize. The response must be bounded — replaced with tooBig + empty
+// varbinds — never emitted over-size. fail-on-revert: drop boundGetResponse's
+// size check and this response exceeds maxPacketSize with errNoError.
+func TestV2cGet_OversizedReturnsTooBig(t *testing.T) {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"public": {Name: "public", Authorization: "read-only"},
+		},
+	})
+	a.SetIfDataFn(func() []IfData { return manyIfData(60) })
+
+	req := buildV2cGetRequestMulti("public", 1, ifDescrOIDs(60))
+	resp := a.handlePacket(req)
+	if resp == nil {
+		t.Fatal("nil response")
+	}
+	if len(resp) > maxPacketSize {
+		t.Fatalf("GET response %d bytes exceeds maxPacketSize %d (size cap not applied)", len(resp), maxPacketSize)
+	}
+	errStatus, oids := v2cResponseVarbinds(t, resp)
+	if errStatus != errTooBig {
+		t.Fatalf("error-status = %d, want tooBig (%d) for an oversized GET", errStatus, errTooBig)
+	}
+	if len(oids) != 0 {
+		t.Fatalf("tooBig response must carry an empty varbind list, got %d varbinds", len(oids))
+	}
+}
+
+// TestV2cGetNext_OversizedReturnsTooBig is residual (1) for GETNEXT: the same
+// fixed 1:1 varbind contract, so an oversized GETNEXT is also replaced with
+// tooBig rather than emitted over-size.
+func TestV2cGetNext_OversizedReturnsTooBig(t *testing.T) {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"public": {Name: "public", Authorization: "read-only"},
+		},
+	})
+	a.SetIfDataFn(func() []IfData { return manyIfData(60) })
+
+	req := buildV2cGetNextRequest("public", 2, ifDescrOIDs(60))
+	resp := a.handlePacket(req)
+	if resp == nil {
+		t.Fatal("nil response")
+	}
+	if len(resp) > maxPacketSize {
+		t.Fatalf("GETNEXT response %d bytes exceeds maxPacketSize %d (size cap not applied)", len(resp), maxPacketSize)
+	}
+	errStatus, oids := v2cResponseVarbinds(t, resp)
+	if errStatus != errTooBig {
+		t.Fatalf("error-status = %d, want tooBig (%d) for an oversized GETNEXT", errStatus, errTooBig)
+	}
+	if len(oids) != 0 {
+		t.Fatalf("tooBig response must carry an empty varbind list, got %d varbinds", len(oids))
+	}
+}
+
+// TestV2cGet_SmallUnchanged: a normal small GET that fits returns all its
+// varbinds with noError — the size bound must not disturb the common path.
+func TestV2cGet_SmallUnchanged(t *testing.T) {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"public": {Name: "public", Authorization: "read-only"},
+		},
+	})
+	a.SetIfDataFn(func() []IfData { return manyIfData(2) })
+
+	req := buildV2cGetRequestMulti("public", 3, ifDescrOIDs(2))
+	resp := a.handlePacket(req)
+	if resp == nil {
+		t.Fatal("nil response")
+	}
+	if len(resp) > maxPacketSize {
+		t.Fatalf("small GET response %d bytes unexpectedly large", len(resp))
+	}
+	errStatus, oids := v2cResponseVarbinds(t, resp)
+	if errStatus != errNoError {
+		t.Fatalf("error-status = %d, want noError for a small GET", errStatus)
+	}
+	if len(oids) != 2 {
+		t.Fatalf("expected 2 varbinds for a 2-OID GET, got %d", len(oids))
+	}
+}
+
+// TestTrimToFit_BinarySearch covers residual (2) of #4918: trimToFit must find
+// the largest fitting prefix with O(log n) rebuilds, not O(n). The build func
+// returns a length monotonic in the prefix size and counts its invocations.
+// With 1000 varbinds trimmed to a 10-varbind prefix, the old decrement-and-
+// rebuild would call build ~991 times; binary search calls it a couple dozen.
+func TestTrimToFit_BinarySearch(t *testing.T) {
+	const n = 1000
+	vbs := make([]varbind, n)
+
+	builds := 0
+	// Encoded length = 10*count + 5, strictly increasing in the prefix length.
+	build := func(sub []varbind) []byte {
+		builds++
+		return make([]byte, len(sub)*10+5)
+	}
+
+	const maxSize = 105 // fits exactly len==10 (10*10+5)
+	resp, ok := trimToFit(vbs, maxSize, build)
+	if !ok {
+		t.Fatal("trimToFit reported no fit; a 10-varbind prefix fits maxSize=105")
+	}
+	if len(resp) != 105 {
+		t.Fatalf("trimmed response = %d bytes, want 105 (the largest fitting prefix)", len(resp))
+	}
+	// Binary search over 1000 items is ~log2(1000)+2 ≈ 12 builds; allow slack.
+	// The old linear decrement-and-rebuild would be ~991 — far over this bound.
+	if builds > 40 {
+		t.Fatalf("trimToFit made %d build calls; expected O(log n) (binary search), not O(n)", builds)
+	}
+}
+
+// TestTrimToFit_NothingFits: when even a zero-varbind response exceeds maxSize,
+// trimToFit reports no fit so the caller falls back to tooBig.
+func TestTrimToFit_NothingFits(t *testing.T) {
+	vbs := make([]varbind, 5)
+	build := func(sub []varbind) []byte { return make([]byte, len(sub)*10+50) }
+	if _, ok := trimToFit(vbs, 1, build); ok {
+		t.Fatal("trimToFit reported a fit for a 1-byte budget; tooBig fallback would be skipped")
+	}
+}

--- a/pkg/snmp/v3.go
+++ b/pkg/snmp/v3.go
@@ -509,7 +509,17 @@ func (a *Agent) handleV3Packet(msgBody []byte) []byte {
 		return nil
 	}
 
-	return a.buildV3Response(msgID, msgFlags, user, echoContext, requestID, errNoError, 0, respVarbinds)
+	// Bound the GET/GETNEXT response to the effective maximum size, matching
+	// the GETBULK cap above (#4918). GET/GETNEXT carry a fixed 1:1
+	// varbind-per-request-OID contract that cannot be trimmed, so an oversized
+	// response is replaced with tooBig + an empty varbind list (RFC 3416
+	// §4.2.1/§4.2.2) rather than emitting an over-size datagram — the v3
+	// residual of #2612, which bounded only GETBULK.
+	resp := a.buildV3Response(msgID, msgFlags, user, echoContext, requestID, errNoError, 0, respVarbinds)
+	if len(resp) > effectiveMaxSize(msgMaxSize) {
+		return a.buildV3Response(msgID, msgFlags, user, echoContext, requestID, errTooBig, 0, nil)
+	}
+	return resp
 }
 
 // verifyAuth checks the HMAC authentication of a v3 message.


### PR DESCRIPTION
Follow-up to #2612 (which bounded only GETBULK response size). Two residuals remained.

## (1) Plain GET/GETNEXT bypassed size bounding

`handleGet`, `handleGetNext` (v2c, `agent.go`) and the v3 GET/GETNEXT tail (`v3.go`) returned `buildResponse(...)` directly with no size cap. A GET naming many OIDs — or a single OID with a long configured string value — could emit a UDP datagram larger than `maxPacketSize`, the exact residual #2612 did not cover.

Unlike GETBULK (whose oversized walk the manager continues with a follow-up request), GET/GETNEXT carry a fixed 1:1 varbind-per-OID contract and cannot be trimmed. Per RFC 3416 §4.2.1/§4.2.2, an oversized response is replaced with `tooBig` + an empty varbind list. New helper `boundGetResponse` enforces this for v2c; the v3 handler applies the same check against `effectiveMaxSize(msgMaxSize)`.

## (2) `trimToFit` was O(n²)

It decremented one varbind at a time and rebuilt the whole response each step — O(n) rebuilds each O(n), and for v3 each re-running USM framing/HMAC/encryption on the single serial SNMP goroutine. Since encoded length is monotonic non-decreasing in the number of leading varbinds, the largest fitting prefix is now found by a fast-path full build (common no-trim case = one build) + a **binary search** when oversized — O(log n) rebuilds. The returned prefix is identical, so **GETBULK trimming behaviour is unchanged**.

## Validation

- `TestV2cGet_OversizedReturnsTooBig` / `TestV2cGetNext_OversizedReturnsTooBig` — 60-OID requests over long ifDescr values (6.7 KB / 6.6 KB unbounded) → response fits `maxPacketSize`, error-status `tooBig`, empty varbind list. Reverting the bound makes the response exceed 4096 with `noError` (RED-on-revert).
- `TestTrimToFit_BinarySearch` — counts build invocations (~12 vs the old ~991 for a 1000→10 trim); reverting to linear → 991 → fails.
- `TestTrimToFit_NothingFits`, `TestV2cGet_SmallUnchanged` — edge/common cases.
- Existing #2612 GETBULK and #4013 snapshot tests still pass. `go build ./...` clean; `go vet ./pkg/snmp` clean; package tests green.

Closes #4918

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi