### PR TITLE
ha/dhcpserver: fix three coupled lease-sync bugs (#5040 #5041 #4871)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,20 @@
+## 2026-07-09 — HA dhcpserver lease-sync trio (#5040 / #5041 / #4871)
+
+- **Timestamp**: 2026-07-09
+  **Action**: #5041 ha/dhcpserver — Kea `subnet-id` was a positional counter
+  over each node's MASTER-filtered subnet list, so the SAME subnet got a
+  DIFFERENT id on the two HA nodes and synced leases (which carry `subnet-id`
+  verbatim) misbound on the receiver. Replaced the counter with
+  `stableSubnetID(subnet)` — an FNV-1a hash of the canonical CIDR folded into
+  Kea's valid `[1, 0xFFFFFFFE]` range — plus a deterministic sorted-order
+  linear probe (`nextSubnetID`) for the astronomically-rare same-config
+  collision. The id is now identical per subnet across nodes, filtered subsets,
+  reordering, and reloads (subsumes #2668). Updated the #2668 regen test to
+  self-capture (no longer pins positional golden ids) and added
+  `TestKeaSubnetIDStableAcrossFilteredSubsets` (RED on revert to positional).
+  **File(s)**: pkg/dhcpserver/dhcpserver.go, pkg/dhcpserver/dhcpserver_test.go,
+  docs/research/2239-dhcp-ha-lease-sync/plan.md
+
 ## 2026-07-09 — #4908 cli/show display-fidelity cohort (partial: 6 fixed, 6 deferred)
 
 - **Timestamp**: 2026-07-09

--- a/_Log.md
+++ b/_Log.md
@@ -1,6 +1,23 @@
 ## 2026-07-09 — HA dhcpserver lease-sync trio (#5040 / #5041 / #4871)
 
 - **Timestamp**: 2026-07-09
+  **Action**: #5040 ha/dhcpserver — the active-active takeover memfile pre-seed
+  passed ONLY the peer's leases to PreSeedMemfile{4,6}, which atomically
+  OVERWROTE the shared Kea memfile — wiping the leases of RGs this node still
+  masters, so the restarted Kea could re-allocate their in-use addresses
+  (duplicate allocation). New `PreSeedMemfileMerged{4,6}(ctx, peer, now)` reads
+  this node's CURRENT local active leases (socket-preferred, memfile fallback —
+  the GetSyncLeases path) and writes the UNION with the peer set, keyed by lease
+  identity (`mergeLeasesByIdentity`, local live binding wins a conflict).
+  FAIL-CLOSED: an untrusted/corrupt local read returns an error and leaves the
+  memfile intact (post-start lease-add is the backstop) rather than replacing it
+  with peer-only rows. `preSeedDHCPLeaseMemfile` now calls the merged variant
+  under a bounded ctx. Tests: TestPreSeedMemfileMerged4_PreservesLocalLeases
+  (RED on revert to peer-only overwrite) + _FailsClosedOnUntrustedLocal.
+  **File(s)**: pkg/dhcpserver/lease_sync.go, pkg/daemon/daemon_dhcp_lease_sync.go,
+  pkg/dhcpserver/lease_sync_test.go, docs/research/2239-dhcp-ha-lease-sync/plan.md
+
+- **Timestamp**: 2026-07-09
   **Action**: #5041 ha/dhcpserver — Kea `subnet-id` was a positional counter
   over each node's MASTER-filtered subnet list, so the SAME subnet got a
   DIFFERENT id on the two HA nodes and synced leases (which carry `subnet-id`

--- a/_Log.md
+++ b/_Log.md
@@ -1,6 +1,25 @@
 ## 2026-07-09 — HA dhcpserver lease-sync trio (#5040 / #5041 / #4871)
 
 - **Timestamp**: 2026-07-09
+  **Action**: #4871 ha/dhcpserver — synced DHCP lease lifetimes stopped aging on
+  the standby and were re-anchored/resurrected at takeover. SyncLease.Remaining
+  is seconds-left at the sender's read time with no sample epoch; the receiver
+  stored a value copy with no receipt time, so standby residence was never
+  subtracted and expired leases came back on promotion (duplicate allocation).
+  Fix: SessionSync now stamps peerDHCPLeases{4,6}RecvAt on receipt (a monotonic
+  time.Now() reading); PeerDHCPLeases{4,6} subtract the monotonic residence via
+  peerDHCPLeasesAged and DROP any lease aged to <=0 (never floor to 1). The
+  dhcpserver seed writers (seedSyncLeases, writeMemfile{4,6}) also drop
+  Remaining<=0 as a fail-safe instead of flooring; syncLeaseToKea's floor is now
+  a documented last-resort guard only. Tests: cluster TestPeerDHCPLeasesAged
+  (ages 600->500, drops the 60s lease held 100s; held set untouched — RED on
+  revert to plain copy) + dhcpserver TestSeedAndPreSeed_DropExpiredLeases
+  (socket + memfile paths drop expired — RED on restoring the floor).
+  **File(s)**: pkg/cluster/sync.go, pkg/cluster/lease_sync_wire_test.go,
+  pkg/dhcpserver/lease_sync.go, pkg/dhcpserver/lease_sync_test.go,
+  docs/research/2239-dhcp-ha-lease-sync/plan.md
+
+- **Timestamp**: 2026-07-09
   **Action**: #5040 ha/dhcpserver — the active-active takeover memfile pre-seed
   passed ONLY the peer's leases to PreSeedMemfile{4,6}, which atomically
   OVERWROTE the shared Kea memfile — wiping the leases of RGs this node still

--- a/docs/research/2239-dhcp-ha-lease-sync/plan.md
+++ b/docs/research/2239-dhcp-ha-lease-sync/plan.md
@@ -409,6 +409,26 @@ to clock skew.
   apply semantics.
 - **Standalone unchanged.** Loop gated on `cluster != nil` && `DHCPLeaseSync`.
 
+### 6.1 Post-implementation corrections (codex-review-177 / codex-175)
+
+Three defects in the shipped PATH C were found after merge; the invariants
+they add are now part of the module contract:
+
+- **Stable subnet identity across nodes (#5041).** The Kea `subnet-id` MUST be
+  a deterministic function of the subnet's canonical CIDR identity, NOT a
+  positional counter over the node's rendered subnet list. Each HA node renders
+  only its MASTER-filtered subset (`filterDHCPConfigForMasterRGs`), so a
+  positional id gave the SAME logical subnet a DIFFERENT id on the two nodes; a
+  synced lease carries `subnet-id` verbatim, so it misbound on the receiver
+  (Kea rejected it or bound it to the wrong subnet), defeating the
+  duplicate-allocation protection. `stableSubnetID` (pkg/dhcpserver) hashes the
+  CIDR (FNV-1a, folded into Kea's valid `[1, 0xFFFFFFFE]` range) so the id is
+  identical on both nodes across filtered subsets, group reordering, and
+  failover generations. The `#2668` reload-stability property is subsumed. A
+  same-config hash collision between two DISTINCT subnets is resolved by a
+  deterministic linear probe walked in the canonical (sorted-group, sorted-pool)
+  render order so it stays a function of the rendered set.
+
 ---
 
 ## 7. Risk table

--- a/docs/research/2239-dhcp-ha-lease-sync/plan.md
+++ b/docs/research/2239-dhcp-ha-lease-sync/plan.md
@@ -442,6 +442,22 @@ they add are now part of the module contract:
   path and FAILS CLOSED — on an untrusted (corrupt) local source it returns an
   error and leaves the existing memfile intact rather than replacing it with
   peer-only rows; the async post-start `lease{4,6}-add` seed is the backstop.
+- **Synced leases age on the standby (#4871).** `SyncLease.Remaining` is
+  seconds-of-lifetime-left at the SENDER's read time and carries no sample
+  epoch, so the receiver MUST record WHEN it received each family's set and
+  subtract that standby RESIDENCE before either seed. Without it a lease held
+  for minutes (worst under a stale/partitioned sync channel — exactly when
+  failover matters) is re-anchored at seed to now_local+Remaining and
+  RESURRECTED past its true expiry, so the promoted node re-allocates an
+  address/prefix the original server already reassigned. `SessionSync` stamps
+  `peerDHCPLeases{4,6}RecvAt` on receipt (a `time.Now()` reading, monotonic in
+  production) and `PeerDHCPLeases{4,6}` subtract the monotonic residence,
+  DROPPING any lease that has aged to zero — NEVER flooring it to one second (a
+  floor revives an expired binding just as surely). The dhcpserver seed writers
+  (`seedSyncLeases`, `writeMemfile{4,6}`) also drop `Remaining<=0` as a fail-safe
+  rather than flooring. Remaining-lifetime + local re-anchor still gives peer
+  wall-clock-skew immunity (§6 clock invariant); residence subtraction closes
+  the standby-hold hole in it.
 
 ---
 

--- a/docs/research/2239-dhcp-ha-lease-sync/plan.md
+++ b/docs/research/2239-dhcp-ha-lease-sync/plan.md
@@ -428,6 +428,20 @@ they add are now part of the module contract:
   same-config hash collision between two DISTINCT subnets is resolved by a
   deterministic linear probe walked in the canonical (sorted-group, sorted-pool)
   render order so it stays a function of the rendered set.
+- **Takeover pre-seed is a UNION, never a replace (#5040).** On a per-RG
+  active-active takeover this node is ALREADY MASTER for one or more RGs whose
+  leases are live in the local Kea; the takeover then restarts Kea under the
+  union config (already-mastered RG + newly-taken RG). The pre-seed
+  (`preSeedDHCPLeaseMemfile` → `PreSeedMemfileMerged{4,6}`) MUST write the union
+  of this node's current local active leases and the held peer leases, NOT the
+  peer-only set. A peer-only atomic overwrite of the shared memfile wiped this
+  node's still-mastered rows, so the restarted Kea had no record of those in-use
+  bindings and could re-allocate their addresses (duplicate allocation). The
+  merge is keyed by lease identity with the LOCAL live binding winning a
+  conflict. It reads the local set via the socket-preferred / memfile-fallback
+  path and FAILS CLOSED — on an untrusted (corrupt) local source it returns an
+  error and leaves the existing memfile intact rather than replacing it with
+  peer-only rows; the async post-start `lease{4,6}-add` seed is the backstop.
 
 ---
 

--- a/pkg/cluster/lease_sync_wire_test.go
+++ b/pkg/cluster/lease_sync_wire_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/psaab/xpf/pkg/dhcpserver"
 )
@@ -139,6 +140,46 @@ func TestPeerDHCPLeasesHold(t *testing.T) {
 	s.storePeerDHCPLeases(4, nil)
 	if len(s.PeerDHCPLeases4()) != 0 {
 		t.Errorf("full-set replace did not clear v4")
+	}
+}
+
+// TestPeerDHCPLeasesAged is the #4871 regression guard. SyncLease.Remaining is
+// seconds-of-lifetime-left at the SENDER's read time with no sample epoch, so a
+// set held on the standby must be AGED by the receiver's residence before it is
+// seeded on takeover — otherwise a held lease is re-anchored to
+// now_local+Remaining and resurrected past its true expiry (duplicate
+// allocation). A lease that has aged to zero must be DROPPED, not floored to 1.
+//
+// Fail-on-revert: reverting peerDHCPLeasesAged to a plain copy makes both
+// assertions fail — the still-valid lease keeps its full 600 (not 500) and the
+// expired lease is returned instead of dropped.
+func TestPeerDHCPLeasesAged(t *testing.T) {
+	s := &SessionSync{}
+	now := time.Unix(1_700_000_000, 0)
+	// Received 100s ago.
+	recvAt := now.Add(-100 * time.Second)
+	s.peerDHCPLeases4 = []dhcpserver.SyncLease{
+		{Family: 4, Address: "10.0.0.5", Remaining: 600}, // -> 500 after aging
+		{Family: 4, Address: "10.0.0.6", Remaining: 60},  // -> dropped (60-100<=0)
+	}
+	s.peerDHCPLeases4RecvAt = recvAt
+
+	got := s.peerDHCPLeasesAged(4, now)
+	if len(got) != 1 {
+		t.Fatalf("aged set: got %d leases, want 1 (the expired one must be dropped): %+v", len(got), got)
+	}
+	if got[0].Address != "10.0.0.5" {
+		t.Fatalf("wrong lease survived: %+v", got[0])
+	}
+	if got[0].Remaining != 500 {
+		t.Errorf("aged Remaining = %d, want 500 (600 - 100s residence)", got[0].Remaining)
+	}
+	// The held set itself must be untouched (aging works on copies).
+	s.peerDHCPLeasesMu.Lock()
+	held := s.peerDHCPLeases4[0].Remaining
+	s.peerDHCPLeasesMu.Unlock()
+	if held != 600 {
+		t.Errorf("aging mutated the held set: Remaining = %d, want 600", held)
 	}
 }
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -304,9 +304,20 @@ type SessionSync struct {
 	// #2239: the standby holds the peer's most-recent full lease set per
 	// family (the peerIPsecSAs precedent). On takeover the daemon reads these
 	// and seeds the just-started Kea. Replaced wholesale on each full-set push.
-	peerDHCPLeases4  []dhcpserver.SyncLease
-	peerDHCPLeases6  []dhcpserver.SyncLease
-	peerDHCPLeasesMu sync.Mutex
+	//
+	// #4871: peerDHCPLeases{4,6}RecvAt records WHEN this node received each
+	// family's held set. SyncLease.Remaining is seconds-of-lifetime-left at the
+	// SENDER's read time and carries no sample epoch, so a set held on the
+	// standby ages only if the receiver subtracts its own residence before
+	// seeding — otherwise a lease held for minutes is re-anchored to
+	// now_local+Remaining on takeover and RESURRECTED past its true expiry
+	// (duplicate allocation). RecvAt is a time.Now() reading (monotonic in
+	// production), so PeerDHCPLeases{4,6} subtract a monotonic residence.
+	peerDHCPLeases4       []dhcpserver.SyncLease
+	peerDHCPLeases6       []dhcpserver.SyncLease
+	peerDHCPLeases4RecvAt time.Time
+	peerDHCPLeases6RecvAt time.Time
+	peerDHCPLeasesMu      sync.Mutex
 	// IsPrimaryFn reports whether the local node is primary for the default sync scope.
 	IsPrimaryFn func() bool
 	// IsPrimaryForRGFn reports whether the local node is primary for a given RG.
@@ -932,23 +943,56 @@ func (s *SessionSync) RecordDHCPLeasesSeeded(n int) {
 	}
 }
 
-// PeerDHCPLeases4 returns a copy of the v4 lease set held from the peer (#2239).
-// The standby seeds these into Kea on takeover.
+// PeerDHCPLeases4 returns the v4 lease set held from the peer, AGED by this
+// node's standby residence (#2239/#4871). The standby seeds these into Kea on
+// takeover.
 func (s *SessionSync) PeerDHCPLeases4() []dhcpserver.SyncLease {
-	s.peerDHCPLeasesMu.Lock()
-	defer s.peerDHCPLeasesMu.Unlock()
-	cp := make([]dhcpserver.SyncLease, len(s.peerDHCPLeases4))
-	copy(cp, s.peerDHCPLeases4)
-	return cp
+	return s.peerDHCPLeasesAged(4, time.Now())
 }
 
-// PeerDHCPLeases6 returns a copy of the v6 lease set held from the peer (#2239).
+// PeerDHCPLeases6 returns the aged v6 lease set held from the peer (#2239/#4871).
 func (s *SessionSync) PeerDHCPLeases6() []dhcpserver.SyncLease {
+	return s.peerDHCPLeasesAged(6, time.Now())
+}
+
+// peerDHCPLeasesAged returns a copy of the held peer lease set for a family with
+// each lease's Remaining lifetime reduced by this node's standby RESIDENCE —
+// the monotonic time elapsed since the set was received — and leases that have
+// aged to zero DROPPED (#4871).
+//
+// Remaining is seconds-of-lifetime-left at the SENDER's read time and carries
+// no sample epoch. Without this subtraction a lease held on the standby for
+// minutes is re-anchored at seed to now_local+Remaining and resurrected past
+// its true expiry, so the promoted node could re-allocate an address/prefix the
+// original server already reassigned (duplicate allocation). A lease at or below
+// zero is dropped, NOT floored to one second — a floor would revive an expired
+// binding just as surely. now is injected for tests; production passes
+// time.Now() (which, like the stored RecvAt, carries a monotonic reading, so
+// the residence is a monotonic delta immune to wall-clock steps).
+func (s *SessionSync) peerDHCPLeasesAged(family int, now time.Time) []dhcpserver.SyncLease {
 	s.peerDHCPLeasesMu.Lock()
 	defer s.peerDHCPLeasesMu.Unlock()
-	cp := make([]dhcpserver.SyncLease, len(s.peerDHCPLeases6))
-	copy(cp, s.peerDHCPLeases6)
-	return cp
+	src := s.peerDHCPLeases4
+	recvAt := s.peerDHCPLeases4RecvAt
+	if family == 6 {
+		src = s.peerDHCPLeases6
+		recvAt = s.peerDHCPLeases6RecvAt
+	}
+	var residence int
+	if !recvAt.IsZero() {
+		if d := int(now.Sub(recvAt).Seconds()); d > 0 {
+			residence = d
+		}
+	}
+	out := make([]dhcpserver.SyncLease, 0, len(src))
+	for _, l := range src {
+		l.Remaining -= residence // l is a value copy; the held set is untouched
+		if l.Remaining <= 0 {
+			continue // aged out on the standby — drop, never resurrect at seed
+		}
+		out = append(out, l)
+	}
+	return out
 }
 
 // SetPeerDHCPLeasesForTesting injects a held peer lease set for a family so
@@ -961,11 +1005,17 @@ func (s *SessionSync) SetPeerDHCPLeasesForTesting(family int, leases []dhcpserve
 // storePeerDHCPLeases replaces the held lease set for a family (full-set push
 // semantics). Called from the receive path.
 func (s *SessionSync) storePeerDHCPLeases(family int, leases []dhcpserver.SyncLease) {
+	// #4871: stamp the receipt time so PeerDHCPLeases{4,6} can subtract standby
+	// residence before seeding. time.Now() carries a monotonic reading, so the
+	// later now.Sub(recvAt) is a monotonic residence.
+	recvAt := time.Now()
 	s.peerDHCPLeasesMu.Lock()
 	if family == 6 {
 		s.peerDHCPLeases6 = leases
+		s.peerDHCPLeases6RecvAt = recvAt
 	} else {
 		s.peerDHCPLeases4 = leases
+		s.peerDHCPLeases4RecvAt = recvAt
 	}
 	s.peerDHCPLeasesMu.Unlock()
 }

--- a/pkg/daemon/daemon_dhcp_lease_sync.go
+++ b/pkg/daemon/daemon_dhcp_lease_sync.go
@@ -305,13 +305,21 @@ func (d *Daemon) nudgeDHCPLeaseSync() {
 	}
 }
 
-// preSeedDHCPLeaseMemfile writes the held peer leases into the Kea memfile
-// CSV(s) BEFORE Kea is (re)started on takeover (#2239 Q3, the dup-alloc-window
-// closer per SMR NIT-1). Pre-seeding the memfile means the just-started Kea
-// loads the in-use bindings into its lease manager at boot, so it can NEVER
-// answer a DISCOVER with an in-use address even in the brief window before the
-// post-start lease-add seed runs. Best-effort + fail-open: a write failure is
-// logged; the post-start lease-add (seedDHCPLeasesFromPeer) is the backstop.
+// preSeedDHCPLeaseMemfile writes leases into the Kea memfile CSV(s) BEFORE Kea
+// is (re)started on takeover (#2239 Q3, the dup-alloc-window closer per SMR
+// NIT-1). Pre-seeding the memfile means the just-started Kea loads the in-use
+// bindings into its lease manager at boot, so it can NEVER answer a DISCOVER
+// with an in-use address even in the brief window before the post-start
+// lease-add seed runs. Best-effort + fail-open: a write failure is logged; the
+// post-start lease-add (seedDHCPLeasesFromPeer) is the backstop.
+//
+// #5040: the pre-seed writes the UNION of this node's current local active
+// leases and the held peer leases, NOT the peer-only set. On a per-RG
+// active-active takeover this node is already MASTER for some RGs whose leases
+// are live locally; overwriting the shared memfile with peer-only rows wiped
+// those still-mastered leases and let Kea re-allocate their in-use addresses.
+// The merge (PreSeedMemfileMerged{4,6}) reads the local set and fails closed on
+// an untrusted local source rather than replacing it.
 //
 // Called from the MASTER-takeover path BEFORE dhcpServer.ApplyAsync(start).
 func (d *Daemon) preSeedDHCPLeaseMemfile() {
@@ -322,16 +330,18 @@ func (d *Daemon) preSeedDHCPLeaseMemfile() {
 	if cc == nil || !cc.DHCPLeaseSync {
 		return
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), dhcpLeaseReadTimeout)
+	defer cancel()
 	now := time.Now()
 	if leases := d.sessionSync.PeerDHCPLeases4(); len(leases) > 0 {
-		if err := d.dhcpServer.PreSeedMemfile4(leases, now); err != nil {
+		if err := d.dhcpServer.PreSeedMemfileMerged4(ctx, leases, now); err != nil {
 			slog.Warn("cluster: DHCP v4 lease memfile pre-seed failed (post-start lease-add is backstop)", "err", err)
 		} else {
 			slog.Info("cluster: DHCP v4 leases pre-seeded into memfile before Kea start", "count", len(leases))
 		}
 	}
 	if leases := d.sessionSync.PeerDHCPLeases6(); len(leases) > 0 {
-		if err := d.dhcpServer.PreSeedMemfile6(leases, now); err != nil {
+		if err := d.dhcpServer.PreSeedMemfileMerged6(ctx, leases, now); err != nil {
 			slog.Warn("cluster: DHCP v6 lease memfile pre-seed failed (post-start lease-add is backstop)", "err", err)
 		} else {
 			slog.Info("cluster: DHCP v6 leases pre-seeded into memfile before Kea start", "count", len(leases))

--- a/pkg/dhcpserver/dhcpserver.go
+++ b/pkg/dhcpserver/dhcpserver.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"log/slog"
 	"net"
@@ -831,6 +832,50 @@ func stablePools(pools []*config.DHCPPool) []*config.DHCPPool {
 	return out
 }
 
+// keaSubnetIDMax is the largest Kea subnet-id we assign. Kea subnet-ids are
+// uint32 with two reserved sentinels: 0 (SUBNET_ID_UNUSED) and 0xFFFFFFFF
+// (SUBNET_ID_GLOBAL). We therefore map into the closed range
+// [1, 0xFFFFFFFE].
+const keaSubnetIDMax = 0xFFFFFFFE
+
+// stableSubnetID derives a DETERMINISTIC Kea subnet-id from the subnet's
+// canonical CIDR identity (#5041). The prior scheme was a positional counter
+// (subnetID := 1; subnetID++) over each node's list of subnets. In an HA
+// cluster each node renders only its MASTER-filtered subset
+// (filterDHCPConfigForMasterRGs), so the SAME logical subnet landed at a
+// DIFFERENT position — and thus a DIFFERENT subnet_id — on the two nodes. A
+// synced lease carries its subnet_id verbatim, so it misbound on the receiver
+// (Kea rejected it or bound it to the wrong subnet), defeating the
+// duplicate-allocation protection lease sync exists to provide.
+//
+// Hashing the CIDR string makes the id a pure function of the subnet identity:
+// the same subnet gets the same id on both nodes regardless of the
+// MASTER-filtered subset, group ordering, or failover generation — the #5041
+// invariant. The #2668 property (stable across reloads of an unchanged config)
+// is subsumed. Distinct id spaces per family are irrelevant here: v4 and v6 are
+// separate Kea daemons with independent subnet_id spaces, and a synced lease is
+// seeded into the daemon matching its family, so we hash the CIDR alone.
+func stableSubnetID(subnet string) int {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(subnet))
+	// Fold uint32 into [1, keaSubnetIDMax].
+	return int(h.Sum32()%keaSubnetIDMax) + 1
+}
+
+// nextSubnetID advances a subnet-id by one within the valid range, wrapping
+// keaSubnetIDMax back to 1. It is the deterministic linear probe used to
+// resolve the (astronomically unlikely) case of two DISTINCT subnets in the
+// SAME rendered config hashing to the same id: probing in the canonical
+// (sorted-group, sorted-pool) render order keeps the resolution a function of
+// the rendered SET, so it never reintroduces map-iteration nondeterminism. Two
+// subnets on a single Kea instance must never share an id or Kea would misbind.
+func nextSubnetID(id int) int {
+	if id >= keaSubnetIDMax {
+		return 1
+	}
+	return id + 1
+}
+
 func (m *Manager) generateKea4Config(cfg *config.DHCPServerConfig) error {
 	type keaPool struct {
 		Pool string `json:"pool"`
@@ -857,22 +902,27 @@ func (m *Manager) generateKea4Config(cfg *config.DHCPServerConfig) error {
 	m.warnAmbiguousV4SubnetSelection(cfg.DHCPLocalServer)
 
 	var subnets []keaSubnet4
-	subnetID := 1
-	// #2668: assign Kea subnet_id over a DETERMINISTIC, reload-stable order.
-	// Ranging the Groups map directly used Go's randomized map-iteration
-	// order, so every config regeneration (commit / reload) could hand the
-	// same subnet a DIFFERENT subnet_id. Kea binds memfile leases
-	// (kea-leases4.csv) to subnets by the subnet_id column, so a shifted ID
-	// remaps live leases onto the wrong subnet. Iterate group names sorted
-	// lexically and pools sorted by their subnet so the SAME logical subnet
-	// always gets the SAME subnet_id across reloads of an unchanged config.
+	usedIDs := make(map[int]bool)
+	// #5041/#2668: assign Kea subnet_id from a STABLE hash of the subnet CIDR,
+	// walking a DETERMINISTIC (sorted-group, sorted-pool) order. Kea binds
+	// memfile leases (kea-leases4.csv) to subnets by the subnet_id column. The
+	// prior positional counter gave the SAME subnet a DIFFERENT id on the two
+	// HA nodes because each renders only its MASTER-filtered subset, so a
+	// synced lease misbound on the receiver (#5041). Hashing the CIDR makes the
+	// id a function of the subnet identity alone — identical on both nodes,
+	// across filtered subsets and reloads (#2668). The sorted walk keeps the
+	// rare collision probe deterministic.
 	for _, group := range stableGroups(cfg.DHCPLocalServer.Groups) {
 		for _, pool := range stablePools(group.Pools) {
+			id := stableSubnetID(pool.Subnet)
+			for usedIDs[id] {
+				id = nextSubnetID(id)
+			}
+			usedIDs[id] = true
 			sub := keaSubnet4{
-				ID:     subnetID,
+				ID:     id,
 				Subnet: pool.Subnet,
 			}
-			subnetID++
 			if pool.RangeLow != "" && pool.RangeHigh != "" {
 				sub.Pools = append(sub.Pools, keaPool{
 					Pool: fmt.Sprintf("%s - %s", pool.RangeLow, pool.RangeHigh),
@@ -980,18 +1030,23 @@ func (m *Manager) generateKea6Config(cfg *config.DHCPServerConfig) error {
 	}
 
 	var subnets []keaSubnet6
-	subnetID := 1
-	// #2668: same reload-stable subnet_id ordering as the v4 path. Kea binds
-	// kea-leases6.csv leases by subnet_id, so the randomized map-iteration
-	// order had to be replaced by a deterministic sort to keep active leases
-	// pinned to their subnet across reloads.
+	usedIDs := make(map[int]bool)
+	// #5041/#2668: same stable-hash subnet_id assignment as the v4 path. Kea
+	// binds kea-leases6.csv leases by subnet_id, so a positional counter over
+	// each node's MASTER-filtered subset gave one subnet different ids on the
+	// two nodes and misbound synced leases. Hash the CIDR so the id is stable
+	// per subnet across nodes, filtered subsets, and reloads.
 	for _, group := range stableGroups(cfg.DHCPv6LocalServer.Groups) {
 		for _, pool := range stablePools(group.Pools) {
+			id := stableSubnetID(pool.Subnet)
+			for usedIDs[id] {
+				id = nextSubnetID(id)
+			}
+			usedIDs[id] = true
 			sub := keaSubnet6{
-				ID:     subnetID,
+				ID:     id,
 				Subnet: pool.Subnet,
 			}
-			subnetID++
 			if pool.RangeLow != "" && pool.RangeHigh != "" {
 				sub.Pools = append(sub.Pools, keaPool{
 					Pool: fmt.Sprintf("%s - %s", pool.RangeLow, pool.RangeHigh),

--- a/pkg/dhcpserver/dhcpserver_test.go
+++ b/pkg/dhcpserver/dhcpserver_test.go
@@ -1139,30 +1139,12 @@ func subnetIDMap(t *testing.T, path, family string) map[string]int {
 // subnet MUST receive the SAME subnet_id on every config regeneration. The
 // assignment used to range the randomized Groups map, so reverting to that
 // makes this test flaky (a wrong mapping eventually appears across the N
-// regenerations); the sorted assignment never does. The expected mapping is
-// the golden sorted order: groups by name (alpha, mid, zeta), pools by
-// subnet within each group.
+// regenerations). Since #5041 the id is a stable hash of the subnet CIDR
+// rather than a positional counter, so we no longer pin golden positional
+// values — we capture the first regeneration's mapping and assert every
+// subsequent regeneration reproduces it exactly.
 func TestKeaSubnetIDStableAcrossRegenerations(t *testing.T) {
-	// Golden expected subnet_id, derived from the deterministic order:
-	//   alpha/10.0.1.0/25=1, alpha/10.0.1.128/25=2, mid/10.0.2.0/24=3,
-	//   zeta/10.0.3.0/24=4.
-	wantV4 := map[string]int{
-		"10.0.1.0/25":   1,
-		"10.0.1.128/25": 2,
-		"10.0.2.0/24":   3,
-		"10.0.3.0/24":   4,
-	}
-	// NOTE: stablePools sorts by the literal subnet STRING, and
-	// "2001:db8:1:8000::/65" < "2001:db8:1::/65" lexically ('8' (0x38) <
-	// ':' (0x3a) at the 4th hextet), so the 8000 half-subnet gets id 1.
-	// The exact ordering does not matter for correctness — only that it is
-	// STABLE — but the golden pins it so an accidental reorder is caught.
-	wantV6 := map[string]int{
-		"2001:db8:1:8000::/65": 1,
-		"2001:db8:1::/65":      2,
-		"2001:db8:2::/64":      3,
-		"2001:db8:3::/64":      4,
-	}
+	var wantV4, wantV6 map[string]int
 
 	const regens = 50 // enough to surface map-order randomization on revert
 	for i := 0; i < regens; i++ {
@@ -1171,8 +1153,10 @@ func TestKeaSubnetIDStableAcrossRegenerations(t *testing.T) {
 			t.Fatalf("generateKea4Config[%d]: %v", i, err)
 		}
 		got := subnetIDMap(t, mv4.confPath4, "4")
-		if !mapsEqualSI(got, wantV4) {
-			t.Fatalf("v4 regen %d: subnet_id mapping %v != golden %v", i, got, wantV4)
+		if i == 0 {
+			wantV4 = got
+		} else if !mapsEqualSI(got, wantV4) {
+			t.Fatalf("v4 regen %d: subnet_id mapping %v != first-regen %v", i, got, wantV4)
 		}
 
 		mv6, _ := testManager(t, map[string]bool{}, "")
@@ -1180,10 +1164,94 @@ func TestKeaSubnetIDStableAcrossRegenerations(t *testing.T) {
 			t.Fatalf("generateKea6Config[%d]: %v", i, err)
 		}
 		got6 := subnetIDMap(t, mv6.confPath6, "6")
-		if !mapsEqualSI(got6, wantV6) {
-			t.Fatalf("v6 regen %d: subnet_id mapping %v != golden %v", i, got6, wantV6)
+		if i == 0 {
+			wantV6 = got6
+		} else if !mapsEqualSI(got6, wantV6) {
+			t.Fatalf("v6 regen %d: subnet_id mapping %v != first-regen %v", i, got6, wantV6)
 		}
 	}
+}
+
+// TestKeaSubnetIDStableAcrossFilteredSubsets is the #5041 regression guard.
+// In an HA cluster each node renders only its MASTER-filtered subset of
+// subnets, so the SAME logical subnet lands at a DIFFERENT position on the two
+// nodes. The old positional counter therefore gave that subnet a DIFFERENT
+// subnet_id per node, and a synced lease (which carries subnet_id verbatim)
+// misbound on the receiver. The stable-hash id must be IDENTICAL for a subnet
+// whether it is rendered in the full config or in a filtered subset where its
+// position shifts.
+//
+// Fail-on-revert: reverting stableSubnetID to the positional counter makes the
+// filtered subset renumber the shared subnets (position 3/4 in full become
+// 1/2 in the {mid,zeta} subset), so this test fails.
+func TestKeaSubnetIDStableAcrossFilteredSubsets(t *testing.T) {
+	check := func(t *testing.T, family string,
+		gen func(m *Manager, cfg *config.DHCPServerConfig) error,
+		full *config.DHCPServerConfig,
+		subsetGroups map[string]*config.DHCPServerGroup,
+		sharedSubnets []string,
+	) {
+		t.Helper()
+		mFull, _ := testManager(t, map[string]bool{}, "")
+		if err := gen(mFull, full); err != nil {
+			t.Fatalf("generate full: %v", err)
+		}
+		confPath := mFull.confPath4
+		if family == "6" {
+			confPath = mFull.confPath6
+		}
+		idsFull := subnetIDMap(t, confPath, family)
+
+		// Render only a subset of the groups (as a node mastering a subset of
+		// RGs would), which shifts the surviving subnets' positions.
+		subset := &config.DHCPServerConfig{}
+		if family == "6" {
+			subset.DHCPv6LocalServer = &config.DHCPLocalServerConfig{Groups: subsetGroups}
+		} else {
+			subset.DHCPLocalServer = &config.DHCPLocalServerConfig{Groups: subsetGroups}
+		}
+		mSub, _ := testManager(t, map[string]bool{}, "")
+		if err := gen(mSub, subset); err != nil {
+			t.Fatalf("generate subset: %v", err)
+		}
+		confPathSub := mSub.confPath4
+		if family == "6" {
+			confPathSub = mSub.confPath6
+		}
+		idsSub := subnetIDMap(t, confPathSub, family)
+
+		for _, sn := range sharedSubnets {
+			if idsFull[sn] == 0 || idsSub[sn] == 0 {
+				t.Fatalf("subnet %s missing (full=%d subset=%d)", sn, idsFull[sn], idsSub[sn])
+			}
+			if idsFull[sn] != idsSub[sn] {
+				t.Errorf("subnet %s subnet_id shifted between full (%d) and filtered subset (%d) — synced leases would misbind on the peer",
+					sn, idsFull[sn], idsSub[sn])
+			}
+		}
+	}
+
+	v4Full := multiGroupV4Config()
+	check(t, "4",
+		func(m *Manager, cfg *config.DHCPServerConfig) error { return m.generateKea4Config(cfg) },
+		v4Full,
+		map[string]*config.DHCPServerGroup{
+			"mid":  v4Full.DHCPLocalServer.Groups["mid"],
+			"zeta": v4Full.DHCPLocalServer.Groups["zeta"],
+		},
+		[]string{"10.0.2.0/24", "10.0.3.0/24"},
+	)
+
+	v6Full := multiGroupV6Config()
+	check(t, "6",
+		func(m *Manager, cfg *config.DHCPServerConfig) error { return m.generateKea6Config(cfg) },
+		v6Full,
+		map[string]*config.DHCPServerGroup{
+			"mid":  v6Full.DHCPv6LocalServer.Groups["mid"],
+			"zeta": v6Full.DHCPv6LocalServer.Groups["zeta"],
+		},
+		[]string{"2001:db8:2::/64", "2001:db8:3::/64"},
+	)
 }
 
 func mapsEqualSI(a, b map[string]int) bool {

--- a/pkg/dhcpserver/lease_sync.go
+++ b/pkg/dhcpserver/lease_sync.go
@@ -475,6 +475,13 @@ func (m *Manager) seedSyncLeases(ctx context.Context, family int, leases []SyncL
 		if l.Family != family {
 			continue
 		}
+		if l.Remaining <= 0 {
+			// #4871: an aged-out lease must be DROPPED, never re-anchored to
+			// now_local+Remaining at seed (which would resurrect it past its
+			// true expiry). The standby-residence subtraction upstream
+			// (PeerDHCPLeases) normally removes these; this is the fail-safe.
+			continue
+		}
 		if err := m.seedOneLease(ctx, socket, family, l, now); err != nil {
 			errs = append(errs, err.Error())
 			continue
@@ -522,9 +529,14 @@ func (m *Manager) seedOneLease(ctx context.Context, socket string, family int, l
 // lease{4,6}-add argument record. valid-lft is set to Remaining so a renewing
 // client sees the correct remaining time, and the absolute expire matches.
 func syncLeaseToKea(l SyncLease, now time.Time) keaLeaseJSON {
+	// #4871: expired leases are DROPPED upstream (seedSyncLeases skips
+	// Remaining<=0), so rem is a genuinely-positive remaining lifetime here.
+	// The floor is now only a last-resort guard against a sub-second positive
+	// value producing a zero valid-lft (which Kea rejects) — it never revives
+	// an aged-out lease.
 	rem := l.Remaining
 	if rem < 1 {
-		rem = 1 // Kea rejects a zero/negative lifetime; floor to 1s
+		rem = 1
 	}
 	kl := keaLeaseJSON{
 		IPAddress: l.Address,
@@ -727,10 +739,10 @@ func (m *Manager) writeMemfile4(path string, leases []SyncLease, now time.Time) 
 		if l.Family != 4 {
 			continue
 		}
-		rem := l.Remaining
-		if rem < 1 {
-			rem = 1
+		if l.Remaining <= 0 {
+			continue // #4871: drop an aged-out lease rather than reviving it
 		}
+		rem := l.Remaining
 		expire := now.Unix() + int64(rem)
 		// address,hwaddr,client_id,valid_lifetime,expire,subnet_id,
 		// fqdn_fwd,fqdn_rev,hostname,state,user_context,pool_id
@@ -751,10 +763,10 @@ func (m *Manager) writeMemfile6(path string, leases []SyncLease, now time.Time) 
 		if l.Family != 6 {
 			continue
 		}
-		rem := l.Remaining
-		if rem < 1 {
-			rem = 1
+		if l.Remaining <= 0 {
+			continue // #4871: drop an aged-out lease rather than reviving it
 		}
+		rem := l.Remaining
 		expire := now.Unix() + int64(rem)
 		// Encode the v6 lease kind symmetrically with the read path
 		// (keaLeaseTypeToString) via the shared inverse so IA_NA / IA_TA / IA_PD

--- a/pkg/dhcpserver/lease_sync.go
+++ b/pkg/dhcpserver/lease_sync.go
@@ -638,6 +638,74 @@ func (m *Manager) PreSeedMemfile6(leases []SyncLease, now time.Time) error {
 	return m.writeMemfile6(m.leaseFile(6), leases, now)
 }
 
+// PreSeedMemfileMerged4 pre-seeds the Kea v4 memfile with the UNION of this
+// node's CURRENT local active leases and the held peer leases (#5040), instead
+// of overwriting it with the peer-only set.
+//
+// On a per-RG active-active takeover this node is ALREADY MASTER for one or
+// more RGs whose leases are live in the local Kea (and its persisted memfile).
+// The takeover then restarts Kea under the union config (already-mastered RG +
+// newly-taken RG). A peer-ONLY pre-seed (the pre-#5040 behavior) atomically
+// OVERWROTE the shared memfile, wiping this node's own still-mastered RG rows;
+// the restarted Kea then had no record of those in-use bindings and could
+// re-allocate their addresses to new clients (duplicate allocation). The
+// invariant: restarting Kea during one RG transition must preserve the lease
+// union for every RG that remains locally MASTER.
+//
+// The local set is read via the same socket-preferred, memfile-fallback path
+// GetSyncLeases4 uses. FAIL-CLOSED: if that read errors (an untrusted/corrupt
+// local source), we do NOT overwrite the memfile with peer-only leases — we
+// return the error and leave the existing memfile intact so the restarting Kea
+// reloads its own persisted rows, and the async post-start lease-add seed still
+// adds the peer set. A genuinely MISSING memfile with Kea down is a trusted
+// empty (a cold node with nothing to preserve), so the union degenerates to the
+// peer set and the pre-seed proceeds.
+func (m *Manager) PreSeedMemfileMerged4(ctx context.Context, peer []SyncLease, now time.Time) error {
+	local, err := m.getSyncLeases(ctx, 4, now)
+	if err != nil {
+		return fmt.Errorf("pre-seed v4: local lease read failed, not overwriting memfile: %w", err)
+	}
+	return m.writeMemfile4(m.leaseFile(4), mergeLeasesByIdentity(local, peer, 4), now)
+}
+
+// PreSeedMemfileMerged6 is the v6 counterpart of PreSeedMemfileMerged4 (#5040).
+func (m *Manager) PreSeedMemfileMerged6(ctx context.Context, peer []SyncLease, now time.Time) error {
+	local, err := m.getSyncLeases(ctx, 6, now)
+	if err != nil {
+		return fmt.Errorf("pre-seed v6: local lease read failed, not overwriting memfile: %w", err)
+	}
+	return m.writeMemfile6(m.leaseFile(6), mergeLeasesByIdentity(local, peer, 6), now)
+}
+
+// mergeLeasesByIdentity returns the union of the local and peer lease sets for
+// one family, keyed by SyncLease.IdentityKey (address + client identity). The
+// LOCAL lease WINS a conflict: for an RG this node still masters, its live
+// binding is the authoritative in-use lease, so it must never be displaced by a
+// peer copy. Peer-only identities (the RG being taken over) are appended. The
+// result is a fresh slice; inputs are not mutated.
+func mergeLeasesByIdentity(local, peer []SyncLease, family int) []SyncLease {
+	seen := make(map[string]struct{}, len(local)+len(peer))
+	out := make([]SyncLease, 0, len(local)+len(peer))
+	for _, l := range local {
+		if l.Family != family {
+			continue
+		}
+		out = append(out, l)
+		seen[l.IdentityKey()] = struct{}{}
+	}
+	for _, l := range peer {
+		if l.Family != family {
+			continue
+		}
+		if _, dup := seen[l.IdentityKey()]; dup {
+			continue // local live binding wins
+		}
+		out = append(out, l)
+		seen[l.IdentityKey()] = struct{}{}
+	}
+	return out
+}
+
 // keaMemfileHeader4 is Kea's canonical DHCPv4 memfile CSV header (Kea 2.x/3.x).
 const keaMemfileHeader4 = "address,hwaddr,client_id,valid_lifetime,expire,subnet_id,fqdn_fwd,fqdn_rev,hostname,state,user_context,pool_id"
 

--- a/pkg/dhcpserver/lease_sync_test.go
+++ b/pkg/dhcpserver/lease_sync_test.go
@@ -491,6 +491,75 @@ func TestPreSeedMemfile4_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestSeedAndPreSeed_DropExpiredLeases is the #4871 dhcpserver-side guard: an
+// aged-out lease (Remaining <= 0) must be DROPPED by both seed paths, never
+// floored to 1s and re-anchored to now_local (which would resurrect a lease
+// past its true expiry -> duplicate allocation). A still-valid lease in the
+// same set proves the drop is selective.
+//
+// Fail-on-revert: restoring the `if rem < 1 { rem = 1 }` floor (removing the
+// `Remaining <= 0` drops) makes the expired lease seed/write, failing the
+// count assertions.
+func TestSeedAndPreSeed_DropExpiredLeases(t *testing.T) {
+	localNow := time.Unix(1_700_000_000, 0)
+
+	t.Run("control-socket seed", func(t *testing.T) {
+		sock := tmpSocket(t, "k4exp.sock")
+		var added []keaLeaseJSON
+		stub := &stubKea{handler: func(cmd keaCommand) keaResponse {
+			if cmd.Command == "lease4-add" {
+				var kl keaLeaseJSON
+				b, _ := json.Marshal(cmd.Arguments)
+				_ = json.Unmarshal(b, &kl)
+				added = append(added, kl)
+				return keaResponse{Result: keaResultSuccess, Text: "added"}
+			}
+			return keaResponse{Result: keaResultError, Text: "unexpected"}
+		}}
+		dial, stop := startStubKea(t, sock, stub)
+		defer stop()
+		m := New()
+		m.SetLeaseSyncSeamsForTesting(dial, sock, "", "", "")
+
+		in := []SyncLease{
+			{Family: 4, Address: "10.0.0.5", HWAddress: "aa", SubnetID: 1, Remaining: 600, State: keaStateDefault},
+			{Family: 4, Address: "10.0.0.6", HWAddress: "bb", SubnetID: 1, Remaining: 0, State: keaStateDefault},
+			{Family: 4, Address: "10.0.0.7", HWAddress: "cc", SubnetID: 1, Remaining: -5, State: keaStateDefault},
+		}
+		n, err := m.SeedSyncLeases4(context.Background(), in, localNow)
+		if err != nil {
+			t.Fatalf("SeedSyncLeases4: %v", err)
+		}
+		if n != 1 {
+			t.Fatalf("seeded = %d, want 1 (only the valid lease)", n)
+		}
+		if len(added) != 1 || added[0].IPAddress != "10.0.0.5" {
+			t.Fatalf("expired lease was seeded (resurrection): %+v", added)
+		}
+	})
+
+	t.Run("memfile pre-seed", func(t *testing.T) {
+		dir := t.TempDir()
+		memfile := filepath.Join(dir, "kea-leases4.csv")
+		m := New()
+		m.SetLeaseSyncSeamsForTesting(nil, "", "", memfile, "")
+		in := []SyncLease{
+			{Family: 4, Address: "10.0.0.5", HWAddress: "aa", SubnetID: 1, Remaining: 600, State: keaStateDefault},
+			{Family: 4, Address: "10.0.0.6", HWAddress: "bb", SubnetID: 1, Remaining: 0, State: keaStateDefault},
+		}
+		if err := m.PreSeedMemfile4(in, localNow); err != nil {
+			t.Fatalf("PreSeedMemfile4: %v", err)
+		}
+		got, err := parseActiveLeases4(memfile, localNow)
+		if err != nil {
+			t.Fatalf("parseActiveLeases4: %v", err)
+		}
+		if len(got) != 1 || got[0].Address != "10.0.0.5" {
+			t.Fatalf("expired lease written to memfile (resurrection): %+v", got)
+		}
+	})
+}
+
 // TestPreSeedMemfileMerged4_PreservesLocalLeases is the #5040 regression guard.
 // On active-active takeover this node is ALREADY MASTER for one RG (its lease is
 // live in local Kea) and takes over a second RG (the peer's lease). The pre-seed

--- a/pkg/dhcpserver/lease_sync_test.go
+++ b/pkg/dhcpserver/lease_sync_test.go
@@ -491,6 +491,97 @@ func TestPreSeedMemfile4_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestPreSeedMemfileMerged4_PreservesLocalLeases is the #5040 regression guard.
+// On active-active takeover this node is ALREADY MASTER for one RG (its lease is
+// live in local Kea) and takes over a second RG (the peer's lease). The pre-seed
+// must write the UNION so the restarting Kea keeps the still-mastered RG's
+// in-use bindings. The pre-#5040 peer-only overwrite wiped them.
+//
+// Fail-on-revert: reverting PreSeedMemfileMerged4 to a peer-only write (or the
+// merge to peer-wins/local-drop) drops 10.0.1.50 from the memfile, failing the
+// still-mastered assertion.
+func TestPreSeedMemfileMerged4_PreservesLocalLeases(t *testing.T) {
+	localNow := time.Unix(1_700_000_000, 0)
+	sock := tmpSocket(t, "k4merge.sock")
+	// Local Kea (already mastering RG-A) reports one live lease via lease4-get-all.
+	stub := &stubKea{handler: func(cmd keaCommand) keaResponse {
+		if cmd.Command == "lease4-get-all" {
+			return leaseGetAllResponse([]keaLeaseJSON{{
+				IPAddress: "10.0.1.50", HWAddress: "aa:aa:aa:aa:aa:aa",
+				SubnetID: 1, ValidLft: 3600, CLTT: localNow.Unix() - 100,
+				State: keaStateDefault,
+			}})
+		}
+		return keaResponse{Result: keaResultError, Text: "unexpected"}
+	}}
+	dial, stop := startStubKea(t, sock, stub)
+	defer stop()
+
+	dir := t.TempDir()
+	memfile := filepath.Join(dir, "kea-leases4.csv")
+	m := New()
+	m.SetLeaseSyncSeamsForTesting(dial, sock, "", memfile, "")
+
+	// Peer set (the newly-taken RG-B): a different address/subnet.
+	peer := []SyncLease{{
+		Family: 4, Address: "10.0.2.80", HWAddress: "bb:bb:bb:bb:bb:bb",
+		SubnetID: 2, ValidLife: 3600, Remaining: 1800, State: keaStateDefault,
+	}}
+	if err := m.PreSeedMemfileMerged4(context.Background(), peer, localNow); err != nil {
+		t.Fatalf("PreSeedMemfileMerged4: %v", err)
+	}
+	got, err := parseActiveLeases4(memfile, localNow)
+	if err != nil {
+		t.Fatalf("parseActiveLeases4 on pre-seeded file: %v", err)
+	}
+	addrs := make(map[string]bool, len(got))
+	for _, l := range got {
+		addrs[l.Address] = true
+	}
+	if !addrs["10.0.1.50"] {
+		t.Errorf("still-mastered local lease 10.0.1.50 was wiped by the pre-seed (duplicate-allocation bug #5040); memfile has %v", addrs)
+	}
+	if !addrs["10.0.2.80"] {
+		t.Errorf("newly-taken peer lease 10.0.2.80 missing from pre-seed; memfile has %v", addrs)
+	}
+}
+
+// TestPreSeedMemfileMerged4_FailsClosedOnUntrustedLocal proves the #5040
+// fail-closed posture: when the local lease source cannot be read (socket down
+// AND an existing memfile is corrupt/untrusted), the pre-seed must NOT replace
+// the memfile with peer-only rows — it returns an error and leaves the file
+// intact so the restarting Kea reloads its own persisted leases (the post-start
+// lease-add seed still adds the peer set).
+func TestPreSeedMemfileMerged4_FailsClosedOnUntrustedLocal(t *testing.T) {
+	localNow := time.Unix(1_700_000_000, 0)
+	dir := t.TempDir()
+	memfile := filepath.Join(dir, "kea-leases4.csv")
+	// A present-but-headerless/mangled memfile is an untrusted local source.
+	corrupt := "garbage,not,a,valid,header,at,all\n"
+	if err := os.WriteFile(memfile, []byte(corrupt), 0644); err != nil {
+		t.Fatal(err)
+	}
+	m := New()
+	// nil dialer + a bogus socket path → socket read fails → memfile fallback →
+	// corrupt memfile → local read errors.
+	m.SetLeaseSyncSeamsForTesting(nil, filepath.Join(dir, "nope.sock"), "", memfile, "")
+
+	peer := []SyncLease{{
+		Family: 4, Address: "10.0.2.80", HWAddress: "bb", SubnetID: 2,
+		Remaining: 1800, State: keaStateDefault,
+	}}
+	if err := m.PreSeedMemfileMerged4(context.Background(), peer, localNow); err == nil {
+		t.Fatalf("expected fail-closed error on untrusted local source, got nil")
+	}
+	after, rerr := os.ReadFile(memfile)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if string(after) != corrupt {
+		t.Errorf("fail-closed must leave the memfile intact, got:\n%s", after)
+	}
+}
+
 // Test (#2268): the v6 memfile pre-seed must round-trip the lease KIND
 // symmetrically with the read path — an IA_TA (temporary-address) lease read
 // and held as IA_TA must be written back as lease_type=1 (IA_TA), never silently


### PR DESCRIPTION
Three coupled HA DHCP-server lease-sync defects (codex-review-177 / codex-175),
all in `pkg/dhcpserver` lease-sync, fixed as three separate logical commits.

> ⚠️ **HA/dhcpserver lease-sync change — the parent MUST run `make test-failover`
> before merge.** These touch the standby lease-hold, the takeover memfile
> pre-seed, and the Kea subnet-id assignment on the HA path.

## Commits

1. **`dhcpserver: derive stable Kea subnet-id from CIDR identity`** — Closes #5041
   Kea `subnet-id` was a positional counter over each node's MASTER-filtered
   subnet list, so the SAME subnet got a DIFFERENT id on the two nodes and a
   synced lease (which carries `subnet-id` verbatim) misbound on the receiver.
   Replaced with `stableSubnetID` (FNV-1a hash of the canonical CIDR folded into
   Kea's `[1, 0xFFFFFFFE]` range) plus a deterministic sorted-order probe for the
   rare same-config collision. Subsumes the #2668 reload-stability property.

2. **`dhcpserver: merge local leases into takeover pre-seed`** — Closes #5040
   The active-active takeover pre-seed passed ONLY the peer's leases to
   `PreSeedMemfile{4,6}`, which atomically OVERWROTE the shared memfile — wiping
   the leases of RGs this node still masters, so the restarted Kea could
   re-allocate their in-use addresses. New `PreSeedMemfileMerged{4,6}` reads this
   node's current local active leases and writes the UNION (local live binding
   wins), failing closed on an untrusted local source rather than replacing it.

3. **`cluster,dhcpserver: age synced DHCP leases on the standby`** — Closes #4871
   `SyncLease.Remaining` carried no observation timestamp and the standby stored
   a value copy with no receipt time, so standby residence was never subtracted
   and expired leases were re-anchored/resurrected at takeover. `SessionSync`
   now stamps a monotonic receipt time per family; `PeerDHCPLeases{4,6}` subtract
   the residence and DROP leases aged to zero (never floor to 1). The seed
   writers drop `Remaining<=0` as a fail-safe.

## Validation

- `go build ./...` clean; `go vet ./pkg/dhcpserver ./pkg/cluster ./pkg/daemon` clean; `gofmt` clean.
- `go test ./pkg/dhcpserver/... ./pkg/cluster/... ./pkg/daemon/...` green.
- Each fix carries a fail-on-revert test, each verified RED by reverting that
  commit's production change:
  - #5041 `TestKeaSubnetIDStableAcrossFilteredSubsets`
  - #5040 `TestPreSeedMemfileMerged4_PreservesLocalLeases` (+ `_FailsClosedOnUntrustedLocal`)
  - #4871 `TestPeerDHCPLeasesAged` (cluster) + `TestSeedAndPreSeed_DropExpiredLeases` (dhcpserver)

No cargo / smoke run here — the parent reviews and runs `test-failover`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi