### PR TITLE
daemon: reconcile dynamic-address feed manager on day-2 commits (#5036)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,22 @@
+## 2026-07-09 — #5036 dynamic-address feed day-2 reconcile (security)
+
+- **Timestamp**: 2026-07-09
+  **Action**: #5036. The feed manager was constructed ONLY at boot and only if
+  boot-time feed servers existed (`daemon_run.go`), and `Manager.Apply` was
+  never re-invoked — so a feed server added/removed/edited on a day-2 commit was
+  silently ignored until restart (a deny policy bound to a day-2-added feed
+  armed with zero prefixes = fail-open). Now: `ensureFeedManager` constructs the
+  manager UNCONDITIONALLY at boot; `reconcileFeeds` (hash-gated on the
+  feed-SERVER set via `feedsConfigHash`, which excludes bindings) is wired into
+  `applyConfigLocked` before the feed-overlay push, so a day-2 server change
+  re-`Apply`s (starts/joins producers) while a feed CONTENT refresh (onUpdate →
+  applyConfig) leaves the hash unchanged and does not thrash the fetchers.
+  Added `feedsMu`/`activeFeedsHash` to the Daemon struct. RED-on-revert:
+  `TestReconcileFeedsDay2` (+ `TestFeedsConfigHash`, `TestReconcileFeedsNilManagerSafe`).
+  **File(s)**: pkg/daemon/daemon.go, pkg/daemon/daemon_run.go,
+  pkg/daemon/daemon_feeds.go, pkg/daemon/daemon_apply.go,
+  pkg/daemon/daemon_feeds_reconcile_5036_test.go, pkg/feeds/README.md
+
 ## 2026-07-09 — #4908 cli/show display-fidelity cohort (partial: 6 fixed, 6 deferred)
 
 - **Timestamp**: 2026-07-09

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -120,9 +120,19 @@ type Daemon struct {
 	dhcpLeaseSync  dhcpLeaseSyncState
 	ipsecSANudgeCh chan struct{} // nudge: peer (re)connect -> IPsec SA re-advertise (#4385)
 	feeds          *feeds.Manager
-	rpm            *rpm.Manager
-	rpmMu          sync.Mutex // serializes reconcileRPM callers (#1827)
-	activeRPMHash  [32]byte   // config-hash gate for RPM re-apply (#1827)
+	// feedsMu serializes reconcileFeeds callers and guards activeFeedsHash
+	// (#5036). d.feeds itself is constructed once at boot (unconditionally,
+	// even with no feed servers) and never reassigned, so its pointer is
+	// race-free; only the day-2 reconcile bookkeeping needs the lock.
+	feedsMu sync.Mutex
+	// activeFeedsHash is the config-hash gate for the day-2 feed reconcile
+	// (#5036): d.feeds.Apply (StopAll + restart) runs only when the feed-server
+	// configuration actually changes, so a feed CONTENT update (which re-enters
+	// applyConfig via onUpdate) does not thrash the refresh goroutines.
+	activeFeedsHash [32]byte
+	rpm             *rpm.Manager
+	rpmMu           sync.Mutex // serializes reconcileRPM callers (#1827)
+	activeRPMHash   [32]byte   // config-hash gate for RPM re-apply (#1827)
 	// rpmPinsFailed records that the last probe-pin install left at
 	// least one pin unprogrammed (#1895): the install is retried
 	// (without restarting probes) on hash-gated reconcileRPM calls AND

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -732,6 +732,18 @@ func (d *Daemon) applyDataplaneAndHACore(ctx context.Context, cfg *config.Config
 		setter.SetRouteOverlay(commitOverlay)
 	}
 
+	// 1.95. Reconcile the running dynamic-address feed-producer set against
+	// this config generation BEFORE reading its overlay (#5036). This is what
+	// makes a day-2 feed-server add/remove/edit take effect: the feed manager
+	// is constructed unconditionally at boot, and this hash-gated Apply starts
+	// the replacement producers (and joins removed ones) whenever the
+	// feed-server config changes. A feed CONTENT refresh leaves the hash
+	// unchanged, so it does not restart the fetchers. Must run before the
+	// SetFeedSnapshots overlay push below so the overlay reflects the
+	// reconciled generation (the fresh snapshot lands asynchronously and its
+	// onUpdate re-applies, exactly as at boot).
+	d.reconcileFeeds(cfg)
+
 	// 1.96. Refresh the dataplane's dynamic-address feed overlay from the
 	// feed manager BEFORE the full snapshot build (#2049). The feed manager
 	// fetches threat-feed/allowlist prefixes and its onUpdate callback

--- a/pkg/daemon/daemon_feeds.go
+++ b/pkg/daemon/daemon_feeds.go
@@ -1,6 +1,111 @@
 package daemon
 
-import "github.com/psaab/xpf/pkg/config"
+import (
+	"crypto/sha256"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/feeds"
+)
+
+// ensureFeedManager lazily constructs the dynamic-address feed manager with the
+// onUpdate callback that recompiles the dataplane when a feed refresh changes
+// the prefix set (#5036). It is idempotent and, in production, is called once
+// during single-threaded startup BEFORE the gRPC/HTTP servers accept requests,
+// so d.feeds is set exactly once and never reassigned — its pointer stays
+// race-free for the concurrent AllFeeds() readers on the show paths. The
+// manager holds no refresh goroutines until Apply is called with a non-empty
+// feed-server set (reconcileFeeds).
+func (d *Daemon) ensureFeedManager() {
+	if d.feeds != nil {
+		return
+	}
+	d.feeds = feeds.New(func() {
+		slog.Info("dynamic-address feed updated, recompiling dataplane")
+		if activeCfg := d.store.ActiveConfig(); activeCfg != nil {
+			d.applyConfig(activeCfg)
+		}
+	})
+}
+
+// feedsConfigHash returns a stable hash over the feed-SERVER configuration that
+// governs the running feed-producer set (#5036). It deliberately EXCLUDES
+// AddressBindings: bindings drive the per-apply snapshot overlay
+// (feedSnapshotsForConfig), not the producer goroutines, so a binding-only
+// change must not trigger a StopAll+restart of the fetchers. FeedServers is a
+// Go map (nondeterministic iteration), so it is serialized in sorted key order
+// with each server's URL/hostname, intervals, single feed-name, and feed
+// entries (also sorted) — matching every input feeds.Apply's plan builder reads.
+func feedsConfigHash(da *config.DynamicAddressConfig) [32]byte {
+	if da == nil {
+		return sha256.Sum256(nil)
+	}
+	names := make([]string, 0, len(da.FeedServers))
+	for name := range da.FeedServers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	for _, name := range names {
+		fs := da.FeedServers[name]
+		if fs == nil {
+			continue
+		}
+		fmt.Fprintf(&b, "S|%s|%s|%s|%d|%d|%s\n",
+			name, fs.URL, fs.Hostname, fs.UpdateInterval, fs.HoldInterval, fs.FeedName)
+		entries := append([]config.FeedEntry(nil), fs.FeedEntries...)
+		sort.Slice(entries, func(i, j int) bool {
+			if entries[i].Name != entries[j].Name {
+				return entries[i].Name < entries[j].Name
+			}
+			return entries[i].Path < entries[j].Path
+		})
+		for _, fe := range entries {
+			fmt.Fprintf(&b, "E|%s|%s\n", fe.Name, fe.Path)
+		}
+	}
+	return sha256.Sum256([]byte(b.String()))
+}
+
+// reconcileFeeds brings the running dynamic-address feed-producer set into
+// correspondence with cfg on every applied config generation (#5036).
+//
+// Before this the feed manager was constructed ONCE at boot and only if
+// boot-time feed servers existed, and Manager.Apply was never re-invoked. So a
+// feed server ADDED on a later commit was silently ignored (a deny policy bound
+// to the new dynamic address armed with zero prefixes — fail-open for deny),
+// and a changed/removed server leaked its refresh goroutine and stale snapshot
+// namespace until restart.
+//
+// The manager is now constructed unconditionally at boot (ensureFeedManager),
+// so it is always non-nil here; Apply — which does StopAll and then starts the
+// desired producer set — is gated on feedsConfigHash so it runs ONLY when the
+// feed-server configuration actually changes. A feed CONTENT refresh re-enters
+// applyConfig via the onUpdate callback but leaves the hash unchanged, so it
+// does not thrash the fetchers. Callers MUST invoke this BEFORE reading the
+// feed overlay (feedSnapshotsForConfig) so the overlay reflects the reconciled
+// generation. Apply uses d.daemonCtx (daemon lifetime) so the refresh
+// goroutines outlive the request-scoped apply.
+func (d *Daemon) reconcileFeeds(cfg *config.Config) {
+	if d == nil || d.daemonCtx == nil || cfg == nil || d.feeds == nil {
+		return
+	}
+	da := &cfg.Security.DynamicAddress
+	h := feedsConfigHash(da)
+
+	d.feedsMu.Lock()
+	defer d.feedsMu.Unlock()
+	if h == d.activeFeedsHash {
+		return
+	}
+	d.feeds.Apply(d.daemonCtx, da)
+	d.activeFeedsHash = h
+	slog.Info("dynamic-address feed producers reconciled", "feed_servers", len(da.FeedServers))
+}
 
 // feedSnapshotSetter caches the dynamic-address feed-prefix overlay for the
 // next full snapshot build (#2049). Implemented by the userspace dataplane

--- a/pkg/daemon/daemon_feeds_reconcile_5036_test.go
+++ b/pkg/daemon/daemon_feeds_reconcile_5036_test.go
@@ -1,0 +1,114 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// feedCfgWith builds a minimal *config.Config carrying the given dynamic-address
+// feed servers and address bindings.
+func feedCfgWith(servers map[string]*config.FeedServer, bindings map[string]*config.AddressBinding) *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.DynamicAddress.FeedServers = servers
+	cfg.Security.DynamicAddress.AddressBindings = bindings
+	return cfg
+}
+
+// TestReconcileFeedsDay2 is the RED-on-revert guard for #5036: a daemon that
+// boots with NO feed servers must still pick up a feed server ADDED on a later
+// (day-2) config generation, and must join the producer when it is removed.
+// Before the fix the feed manager was Apply'd only at boot, so both the add
+// and the remove were ignored until restart. Neuter reconcileFeeds's Apply and
+// the day-2 add asserts 0 producers instead of 1.
+func TestReconcileFeedsDay2(t *testing.T) {
+	d := &Daemon{daemonCtx: context.Background()}
+	d.ensureFeedManager()
+	defer d.feeds.StopAll()
+
+	// Boot-equivalent: no feed servers.
+	d.reconcileFeeds(feedCfgWith(nil, nil))
+	if n := len(d.feeds.AllFeeds()); n != 0 {
+		t.Fatalf("no feed servers configured: want 0 producers, got %d", n)
+	}
+
+	// Day-2 ADD: a feed server appears on a later generation. Port 1 fails the
+	// fetch fast; we only assert the producer was registered, not that it
+	// fetched.
+	cfgAdd := feedCfgWith(map[string]*config.FeedServer{
+		"threats": {Name: "threats", URL: "http://127.0.0.1:1/threats", UpdateInterval: 3600},
+	}, nil)
+	d.reconcileFeeds(cfgAdd)
+	if n := len(d.feeds.AllFeeds()); n != 1 {
+		t.Fatalf("day-2 feed-server ADD: want 1 producer, got %d (reconcile ignored the new server — fail-open)", n)
+	}
+
+	// Day-2 REMOVE: the producer must be joined and the namespace cleared.
+	d.reconcileFeeds(feedCfgWith(nil, nil))
+	if n := len(d.feeds.AllFeeds()); n != 0 {
+		t.Fatalf("day-2 feed-server REMOVE: want 0 producers, got %d (stale producer leaked)", n)
+	}
+}
+
+// TestReconcileFeedsNilManagerSafe: reconcileFeeds must be a no-op when the
+// feed manager has not been constructed (e.g. the first boot apply, which runs
+// before ensureFeedManager) rather than panicking.
+func TestReconcileFeedsNilManagerSafe(t *testing.T) {
+	d := &Daemon{daemonCtx: context.Background()} // d.feeds == nil
+	d.reconcileFeeds(feedCfgWith(map[string]*config.FeedServer{
+		"threats": {Name: "threats", URL: "http://127.0.0.1:1/threats"},
+	}, nil))
+	if d.feeds != nil {
+		t.Fatal("reconcileFeeds must not construct the manager itself (construction is single-threaded at boot)")
+	}
+}
+
+// TestFeedsConfigHash pins the gate decision (#5036): the hash covers the
+// feed-SERVER set but not address bindings, so producers restart on a server
+// change but NOT on a binding-only change (which only re-derives the overlay).
+func TestFeedsConfigHash(t *testing.T) {
+	serverA := func() map[string]*config.FeedServer {
+		return map[string]*config.FeedServer{
+			"a": {Name: "a", URL: "https://feeds.example/a", UpdateInterval: 60, HoldInterval: 0},
+		}
+	}
+
+	base := &config.DynamicAddressConfig{FeedServers: serverA()}
+
+	// Deterministic: the same server set hashes identically (map order aside).
+	if feedsConfigHash(base) != feedsConfigHash(&config.DynamicAddressConfig{FeedServers: serverA()}) {
+		t.Fatal("identical feed-server sets produced different hashes (nondeterministic gate)")
+	}
+
+	// Binding-only change: SAME hash — bindings must not restart producers.
+	withBinding := &config.DynamicAddressConfig{
+		FeedServers:     serverA(),
+		AddressBindings: map[string]*config.AddressBinding{"name1": {}},
+	}
+	if feedsConfigHash(base) != feedsConfigHash(withBinding) {
+		t.Fatal("a binding-only change altered the producer hash (would needlessly restart fetchers)")
+	}
+
+	// Changed feed URL: DIFFERENT hash — must restart producers.
+	changed := &config.DynamicAddressConfig{FeedServers: map[string]*config.FeedServer{
+		"a": {Name: "a", URL: "https://feeds.example/b", UpdateInterval: 60},
+	}}
+	if feedsConfigHash(base) == feedsConfigHash(changed) {
+		t.Fatal("a changed feed URL did not change the hash (day-2 URL edit would be ignored)")
+	}
+
+	// Added second server: DIFFERENT hash.
+	two := &config.DynamicAddressConfig{FeedServers: map[string]*config.FeedServer{
+		"a": {Name: "a", URL: "https://feeds.example/a", UpdateInterval: 60},
+		"b": {Name: "b", URL: "https://feeds.example/bb", UpdateInterval: 60},
+	}}
+	if feedsConfigHash(base) == feedsConfigHash(two) {
+		t.Fatal("adding a second feed server did not change the hash")
+	}
+
+	// Empty vs configured differ.
+	if feedsConfigHash(&config.DynamicAddressConfig{}) == feedsConfigHash(base) {
+		t.Fatal("empty and configured feed sets hash the same")
+	}
+}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -459,15 +459,19 @@ func (d *Daemon) Run(ctx context.Context) error {
 		}
 	}
 
-	// Start dynamic address feeds if configured.
-	if cfg := d.store.ActiveConfig(); cfg != nil && len(cfg.Security.DynamicAddress.FeedServers) > 0 {
-		d.feeds = feeds.New(func() {
-			slog.Info("dynamic-address feed updated, recompiling dataplane")
-			if activeCfg := d.store.ActiveConfig(); activeCfg != nil {
-				d.applyConfig(activeCfg)
-			}
-		})
-		d.feeds.Apply(ctx, &cfg.Security.DynamicAddress)
+	// Construct the dynamic-address feed manager UNCONDITIONALLY (#5036) — even
+	// when no feed servers are configured at boot — and reconcile it against
+	// the active config. Before this the manager was built only if boot-time
+	// feed servers existed and Apply was never re-invoked, so a feed server
+	// added (or removed/edited) on a later commit was silently ignored until
+	// restart: a deny policy bound to the new feed armed with zero prefixes
+	// (fail-open). ensureFeedManager makes d.feeds non-nil so the day-2
+	// reconcile path (reconcileFeeds, wired into applyConfigLocked) can start
+	// the producers; reconcileFeeds here does the initial hash-gated Apply for
+	// a config that already declares feed servers.
+	if cfg := d.store.ActiveConfig(); cfg != nil {
+		d.ensureFeedManager()
+		d.reconcileFeeds(cfg)
 	}
 
 	// RPM probes are started by the hash-gated reconcileRPM step inside

--- a/pkg/feeds/README.md
+++ b/pkg/feeds/README.md
@@ -12,6 +12,22 @@ feed servers and triggers config recompile when the resolved set changes
 - `GetPrefixes(name)` — `feeds.go`. Returns the current enforced (last-good) snapshot.
 - `StopAll()`, `FeedInfo`, `AllFeeds()` — surfaced to `show security dynamic-address`.
 
+## Day-2 reconcile (#5036)
+
+`Manager.Apply` is destructive (`StopAll` first) and is driven by the daemon,
+not called once at boot. The daemon constructs the manager **unconditionally**
+at startup (`ensureFeedManager`, even with no feed servers) and calls
+`reconcileFeeds` on every applied config generation (wired into
+`applyConfigLocked`, before the feed-overlay push). `reconcileFeeds` is gated
+on a hash of the feed-**server** configuration (`feedsConfigHash`, which
+excludes address bindings), so `Apply` re-runs only when the server set
+actually changes — a feed **content** refresh (which re-enters `applyConfig`
+via the `onUpdate` callback) leaves the hash unchanged and does not restart the
+fetchers. Before #5036 the manager was built only if boot-time feed servers
+existed and `Apply` was never re-invoked, so a feed server added/removed/edited
+after boot was silently ignored until restart (a deny policy bound to a
+day-2-added feed armed with zero prefixes — fail-open).
+
 ## Refresh correctness & fail-safe behavior (#2050)
 
 A fetch is treated as **successful** only when the transport read completes


### PR DESCRIPTION
## Problem

The dynamic-address feed manager was constructed **only at boot** and only when boot-time feed servers existed (`pkg/daemon/daemon_run.go`), and `feeds.Manager.Apply` (destructive: `StopAll` then restart) was never re-invoked. So a feed server added/removed/edited on a later commit was silently ignored until restart:

- A daemon booted with no feed servers that later commits a feed server + address binding + a deny policy referencing the bound dynamic address armed the policy with **zero prefixes** — traffic meant to be denied matched nothing (**fail-open for deny**).
- Even with feeds present at boot, a changed/removed server leaked its refresh goroutine and stale snapshot namespace until restart.

## Fix

- **Construct the manager unconditionally at boot** (`ensureFeedManager`, even with no feed servers), so the reconcile path always has a manager to drive. `d.feeds` is set once and never reassigned → pointer stays race-free for concurrent `AllFeeds()` readers.
- **`reconcileFeeds`**, wired into `applyConfigLocked` **before** the feed-overlay push (`SetFeedSnapshots`), re-`Apply`s the manager against the incoming generation so a day-2 server change starts replacement producers (and joins removed ones).
- **Gated on `feedsConfigHash`** — a hash over the feed-**server** set (URL/hostname, intervals, feed-name, entries), deliberately excluding `AddressBindings` (which drive only the per-apply overlay). So `StopAll`+restart runs only when the producer-affecting config changes; a feed **content** refresh (onUpdate → applyConfig) leaves the hash unchanged and does not thrash the fetchers. A new `feedsMu` guards only the `activeFeedsHash` bookkeeping.

## Validation

- `TestReconcileFeedsDay2` — boots with no servers, then adds and removes a server, asserting the producer set tracks each generation. Neutering `reconcileFeeds`'s `Apply` → day-2 add sees 0 producers (RED-on-revert).
- `TestFeedsConfigHash` — server change → new hash; binding-only change → same hash.
- `TestReconcileFeedsNilManagerSafe` — the pre-construction boot apply is a safe no-op.
- `go build ./...` clean; `go vet ./pkg/daemon` clean; full `pkg/daemon` package tests green.

Closes #5036

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi