### PR TITLE
daemon: revoke credentials when a login user is removed (#5128)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,16 @@
+## 2026-07-09 — daemon: revoke credentials on login-user removal (#5128)
+
+- **Timestamp**: 2026-07-09
+  **Action**: Added `reconcileAbsentLoginUsers`/`deprovisionLoginUser` — a
+  declarative absent-user reconcile that consumes the UID-keyed provenance
+  marker to LOCK the password and REMOVE the managed `authorized_keys` of a
+  login user deleted from config (host access was retained before; only the
+  sudo grant was swept). Scoped strictly to the exact xpf-provisioned UID
+  (never an out-of-band account), fail-closed toward retry. Wired
+  unconditionally after `reconcileSudoers` in `daemon_apply.go`.
+  **File(s)**: pkg/daemon/login_password.go, pkg/daemon/daemon_apply.go,
+  pkg/daemon/login_deprovision_5128_test.go, docs/system-login.md, _Log.md
+
 ## 2026-07-09 — HA dhcpserver lease-sync trio (#5040 / #5041 / #4871)
 
 - **Timestamp**: 2026-07-09

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -416,6 +416,50 @@ left as a lockout landmine, because a single malformed file in
 `/etc/sudoers.d` breaks **all** sudo invocations. `root` is never
 granted an xpf-managed drop-in.
 
+## Removing a login user revokes its host credentials (#5128)
+
+Deleting a whole `system login user` from config — not just its
+`encrypted-password` directive — revokes that account's host access on
+the next commit. Before #5128 only the sudo grant was swept
+(`reconcileSudoers`); the account, its password, and its
+`authorized_keys` all survived, so a deprovisioned operator could still
+SSH in by password or key. `reconcileAbsentLoginUsers`
+(`pkg/daemon/login_password.go`) closes that gap and, like
+`reconcileSudoers`, runs **unconditionally** on every apply (including
+the "all users removed" case):
+
+1. Enumerate `/var/lib/xpf/provisioned-users/` — the accounts xpf
+   actually provisioned (the UID-keyed provenance markers, #1944 §5.4).
+2. For each marked username **no longer present** in
+   `system login { user ... }`, and **only** while the marker's recorded
+   UID still equals the account's current `/etc/passwd` UID
+   (`xpfProvisioned`): **lock** the password (`<user>:!` via
+   `chpasswd -e`, idempotent — skipped if already locked) and **remove**
+   the xpf-managed `/home/<user>/.ssh/authorized_keys`, then drop the
+   provenance marker so xpf forgets the account.
+
+The path is scoped and fail-closed:
+
+- An **out-of-band account** (no marker) is never enumerated, so it is
+  never touched.
+- A marker whose UID no longer matches the live account (deleted +
+  recreated out of band with a different UID) is treated as **not ours**:
+  the account is left intact and only the stale marker is cleaned.
+- On a `/etc/shadow` read error, a `chpasswd` failure, or an
+  `authorized_keys` removal failure, the marker is **retained** so the
+  next apply retries — a credential is never forgotten while it may still
+  be live.
+- `root` is never deprovisioned.
+
+Unlike the `zeroize` teardown (#4598), which `userdel -r`s the whole
+account, ordinary removal only **locks** the password and removes the
+managed key file. That fully revokes login (password and key) while
+being reversible: re-adding the user to config recreates the account and
+re-provisions it. Note the distinction from the section above: removing
+just the **`encrypted-password` directive** (user still present) locks
+the password but leaves `authorized_keys`; removing the **whole user**
+revokes both.
+
 ### Scope — only xpf-managed accounts
 
 The lock-on-removal applies **only to the exact account xpf

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1632,6 +1632,13 @@ func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, dhcpServer
 	// that must still sweep stale grants.
 	d.reconcileSudoers(cfg)
 
+	// 11c. Revoke host credentials for any xpf-provisioned login account that
+	// was removed from config (#5128). reconcileSudoers above only revokes the
+	// sudo grant; without this a deprovisioned operator keeps their password
+	// and authorized_keys and can still SSH in. Like reconcileSudoers it MUST
+	// run unconditionally — the "all users removed" case must still revoke.
+	d.reconcileAbsentLoginUsers(cfg)
+
 	// 12. Apply SSH service configuration (root-login)
 	d.applySSHConfig(cfg)
 

--- a/pkg/daemon/login_deprovision_5128_test.go
+++ b/pkg/daemon/login_deprovision_5128_test.go
@@ -1,0 +1,160 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// stageDeprovisionEnv points the login-credential databases + marker dir + home
+// base at a throwaway tree and installs a fake `chpasswd` on PATH that records
+// the stdin it receives (the `<user>:!` lock command). It returns the sentinel
+// path holding that captured stdin.
+func stageDeprovisionEnv(t *testing.T, passwdContent, shadowContent string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	shadow := filepath.Join(dir, "shadow")
+	if err := os.WriteFile(shadow, []byte(shadowContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	passwd := filepath.Join(dir, "passwd")
+	if err := os.WriteFile(passwd, []byte(passwdContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldShadow, oldPasswd, oldDir, oldHome := shadowPath, passwdPath, provisionedUsersDir, homeBaseDir
+	shadowPath = shadow
+	passwdPath = passwd
+	provisionedUsersDir = filepath.Join(dir, "provisioned-users")
+	homeBaseDir = filepath.Join(dir, "home")
+	t.Cleanup(func() {
+		shadowPath, passwdPath, provisionedUsersDir, homeBaseDir = oldShadow, oldPasswd, oldDir, oldHome
+	})
+
+	sentinel := filepath.Join(dir, "chpasswd-stdin")
+	fakeBin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Record stdin; the trailing newline in `<user>:!\n` is trimmed by the
+	// asserting test.
+	script := "#!/bin/sh\ncat > " + sentinel + "\n"
+	if err := os.WriteFile(filepath.Join(fakeBin, "chpasswd"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", fakeBin+":"+os.Getenv("PATH"))
+	return sentinel
+}
+
+// TestReconcileAbsentLoginUsersRevokesCredentials is the #5128 fail-on-revert
+// guard: a login user removed from config must have its password LOCKED and its
+// managed authorized_keys REMOVED (host access revoked), not merely lose its
+// sudo grant. Reverting reconcileAbsentLoginUsers/deprovisionLoginUser makes
+// this RED (no chpasswd lock, keys retained, marker retained).
+func TestReconcileAbsentLoginUsersRevokesCredentials(t *testing.T) {
+	sentinel := stageDeprovisionEnv(t,
+		"root:x:0:0:root:/root:/bin/bash\nalice:x:1001:1001:,,,:/home/alice:/bin/bash\n",
+		"root:$6$r$h:19000:0:99999:7:::\nalice:$6$salt$activehash:19000:0:99999:7:::\n",
+	)
+
+	// alice was provisioned at UID 1001 (matches passwd) and has managed keys.
+	if err := markProvisioned("alice", 1001); err != nil {
+		t.Fatal(err)
+	}
+	keysFile := managedAuthorizedKeysPath("alice")
+	if err := os.MkdirAll(filepath.Dir(keysFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keysFile, []byte("ssh-ed25519 AAAAC3... alice@host\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// alice removed from config entirely.
+	d := &Daemon{}
+	d.reconcileAbsentLoginUsers(&config.Config{})
+
+	// (a) chpasswd was invoked to LOCK alice.
+	got, err := os.ReadFile(sentinel)
+	if err != nil {
+		t.Fatalf("chpasswd was not invoked to lock the removed user: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != "alice:!" {
+		t.Fatalf("chpasswd stdin = %q, want %q (password lock)", strings.TrimSpace(string(got)), "alice:!")
+	}
+	// (b) the managed authorized_keys is gone (key login revoked).
+	if _, err := os.Stat(keysFile); !os.IsNotExist(err) {
+		t.Fatalf("authorized_keys for removed user still present (err=%v)", err)
+	}
+	// (c) the provenance marker is dropped (xpf forgets the account).
+	if _, err := os.Stat(markerPath("alice")); !os.IsNotExist(err) {
+		t.Fatalf("provenance marker still present after deprovision (err=%v)", err)
+	}
+}
+
+// TestReconcileAbsentLoginUsersScoping proves the deprovision is scoped: a user
+// STILL in config is untouched, and an out-of-band account whose UID no longer
+// matches its marker (deleted+recreated) is never locked or de-keyed — only the
+// stale marker is cleaned. This is the security-critical "never revoke a
+// non-xpf / still-active account" invariant.
+func TestReconcileAbsentLoginUsersScoping(t *testing.T) {
+	sentinel := stageDeprovisionEnv(t,
+		"root:x:0:0:root:/root:/bin/bash\n"+
+			"carol:x:1001:1001:,,,:/home/carol:/bin/bash\n"+ // still in config
+			"eve:x:2002:2002:,,,:/home/eve:/bin/bash\n", // recreated out of band
+		"root:$6$r$h:19000:0:99999:7:::\n"+
+			"carol:$6$c$h:19000:0:99999:7:::\n"+
+			"eve:$6$e$h:19000:0:99999:7:::\n",
+	)
+
+	// carol: provisioned, still configured → must be kept.
+	if err := markProvisioned("carol", 1001); err != nil {
+		t.Fatal(err)
+	}
+	carolKeys := managedAuthorizedKeysPath("carol")
+	if err := os.MkdirAll(filepath.Dir(carolKeys), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(carolKeys, []byte("ssh-ed25519 AAAA carol\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// eve: marker records UID 1234, but the live account is UID 2002 (out-of-band
+	// recreate) → xpfProvisioned mismatch → must NOT be touched.
+	if err := markProvisioned("eve", 1234); err != nil {
+		t.Fatal(err)
+	}
+	eveKeys := managedAuthorizedKeysPath("eve")
+	if err := os.MkdirAll(filepath.Dir(eveKeys), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(eveKeys, []byte("ssh-ed25519 AAAA eve\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Only carol is in config.
+	cfg := &config.Config{}
+	cfg.System.Login = &config.LoginConfig{Users: []*config.LoginUser{{Name: "carol"}}}
+	d := &Daemon{}
+	d.reconcileAbsentLoginUsers(cfg)
+
+	// chpasswd must NEVER have run — neither carol (kept) nor eve (not ours).
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Fatalf("chpasswd ran during a scoping-only reconcile (err=%v) — a kept/out-of-band account was locked", err)
+	}
+	// carol keeps her marker + keys.
+	if _, err := os.Stat(carolKeys); err != nil {
+		t.Fatalf("still-configured user's authorized_keys removed: %v", err)
+	}
+	if _, err := os.Stat(markerPath("carol")); err != nil {
+		t.Fatalf("still-configured user's marker removed: %v", err)
+	}
+	// eve keeps her keys (never our account); the mismatched marker is cleaned
+	// by xpfProvisioned's inline stale-marker removal.
+	if _, err := os.Stat(eveKeys); err != nil {
+		t.Fatalf("out-of-band account's authorized_keys removed — hijack: %v", err)
+	}
+}

--- a/pkg/daemon/login_password.go
+++ b/pkg/daemon/login_password.go
@@ -2,11 +2,13 @@
 package daemon
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/fsatomic"
 )
 
@@ -199,4 +201,132 @@ func xpfProvisioned(name string, curUID int) bool {
 		return false
 	}
 	return true
+}
+
+// homeBaseDir is the parent directory of per-user home directories. It is a
+// package var only so tests can point the authorized_keys reconcile at a
+// throwaway tree; production never overrides it. #5128.
+var homeBaseDir = "/home"
+
+// managedAuthorizedKeysPath returns the xpf-managed authorized_keys file for
+// name. applySystemLogin writes /home/<name>/.ssh/authorized_keys wholesale
+// from the configured SSHKeys, so the whole file is xpf-owned; the absent-user
+// reconcile removes it to revoke key-based login. filepath.Base(Clean(...))
+// keeps the join inside homeBaseDir defensively (names reaching here are
+// validated OS usernames, but never trust a name for a root-privileged
+// removal). #5128.
+func managedAuthorizedKeysPath(name string) string {
+	return filepath.Join(homeBaseDir, filepath.Base(filepath.Clean(name)), ".ssh", "authorized_keys")
+}
+
+// reconcileAbsentLoginUsers revokes the host credentials of every
+// xpf-provisioned login account that is NO LONGER present in
+// cfg.System.Login.Users (#5128). Declarative removal of a `system login user`
+// must revoke that user's host access — Junos semantics — not merely drop the
+// sudo grant (reconcileSudoers) while leaving the account, password, and
+// authorized_keys live.
+//
+// It is the removal half of the #1944 UID-keyed provenance lifecycle and the
+// mirror of reconcileSudoers: it MUST run unconditionally on every apply
+// (independent of applySystemLogin's early return) so the "all users removed"
+// case still revokes. It enumerates provisionedUsersDir — the set of accounts
+// xpf actually provisioned — and deprovisions each marker whose username no
+// longer appears in the config. An out-of-band account (no marker) is never
+// enumerated and never touched.
+func (d *Daemon) reconcileAbsentLoginUsers(cfg *config.Config) {
+	entries, err := os.ReadDir(provisionedUsersDir)
+	if err != nil {
+		// No markers yet (fresh install) or unreadable — nothing xpf
+		// provisioned, so nothing to revoke.
+		return
+	}
+
+	// The set of usernames still declared in config; these are kept.
+	desired := make(map[string]struct{})
+	if cfg.System.Login != nil {
+		for _, u := range cfg.System.Login.Users {
+			if u.Name == "" {
+				continue
+			}
+			desired[u.Name] = struct{}{}
+		}
+	}
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if name == "root" {
+			continue // root is never provisioned/deprovisioned via config
+		}
+		if _, keep := desired[name]; keep {
+			continue // still configured — leave it alone
+		}
+		d.deprovisionLoginUser(name)
+	}
+}
+
+// deprovisionLoginUser revokes one removed account's password and managed
+// authorized_keys, but ONLY when the UID-keyed provenance marker still matches
+// the account's current UID (never an out-of-band account), then drops the
+// marker so xpf forgets the account. It is fail-closed toward retry: any step
+// that cannot be completed safely leaves the marker in place so the next apply
+// retries, and it never removes a credential it did not first verify as
+// xpf-owned. #5128.
+func (d *Daemon) deprovisionLoginUser(name string) {
+	curUID, uidOK := lookupUID(name)
+	if !uidOK {
+		// The account is already gone from the host (out-of-band userdel).
+		// There is nothing to revoke; drop the stale marker so we stop
+		// revisiting it every apply.
+		_ = os.Remove(markerPath(name))
+		return
+	}
+	if !xpfProvisioned(name, curUID) {
+		// Marker missing or its UID no longer matches (the account was
+		// deleted+recreated out of band with a different UID). xpfProvisioned
+		// already cleaned a stale marker inline. NEVER touch a non-xpf account.
+		return
+	}
+
+	// Lock the password (idempotent). Fail-CLOSED on a shadow read error: we
+	// must not forget the account (drop the marker) while a live credential may
+	// still be active — retry next apply instead. Mirrors the #1944 pwLock
+	// discipline (never lock on a read error, but here that also means never
+	// prematurely stop managing the account).
+	cur, ok := currentShadowHash(name)
+	if !ok {
+		slog.Warn("skipping removed-user deprovision: cannot read shadow",
+			"user", name)
+		return // keep marker; retry next apply
+	}
+	if !isLockedShadow(cur) {
+		stdin := strings.NewReader(name + ":!\n")
+		if out, err := runCommandStdinTimeout(stdin, "chpasswd", "-e"); err != nil {
+			slog.Warn("failed to lock password for removed login user",
+				"user", name, "err", err, "output", strings.TrimSpace(string(out)))
+			return // keep marker; retry
+		}
+		slog.Info("locked password for removed login user", "user", name)
+	}
+
+	// Remove the xpf-managed authorized_keys so key-based login is revoked too
+	// (the whole file is xpf-owned — applySystemLogin writes it wholesale).
+	keysFile := managedAuthorizedKeysPath(name)
+	if err := os.Remove(keysFile); err != nil && !os.IsNotExist(err) {
+		slog.Warn("failed to remove authorized_keys for removed login user",
+			"user", name, "file", keysFile, "err", err)
+		return // keep marker; retry
+	}
+
+	// Fully revoked — drop the provenance marker so xpf no longer manages this
+	// account. If the same user is later re-added to config, applySystemLogin
+	// recreates it and re-records the marker.
+	if err := os.Remove(markerPath(name)); err != nil && !os.IsNotExist(err) {
+		slog.Warn("failed to remove provenance marker after deprovision",
+			"user", name, "err", err)
+	}
+	slog.Info("deprovisioned removed login user (password locked, keys removed)",
+		"user", name)
 }


### PR DESCRIPTION
## Problem

Removing a managed `system login user` from config did **not** revoke that
user's host credentials. The account, its `/etc/shadow` password, and its
`authorized_keys` all persisted after commit; only the sudo NOPASSWD grant was
swept by `reconcileSudoers`. A deprovisioned operator could still SSH in by
password or key — the account was declaratively deleted but host access was not.

## Fix

Add `reconcileAbsentLoginUsers`/`deprovisionLoginUser` (`pkg/daemon/login_password.go`),
the removal half of the #1944 UID-keyed provenance lifecycle and the mirror of
`reconcileSudoers`. It enumerates `/var/lib/xpf/provisioned-users` (accounts xpf
actually provisioned) and, for each marked username no longer present in config:

- **locks** the password (`<user>:!` via `chpasswd -e`, idempotent), and
- **removes** the xpf-managed `authorized_keys`,

then drops the provenance marker. Wired unconditionally after `reconcileSudoers`
in `daemon_apply.go` so the "all users removed" case still revokes.

### Scoped + fail-closed

- Acts only while the marker's recorded UID equals the account's current
  `/etc/passwd` UID (`xpfProvisioned`) — an out-of-band account (no marker) is
  never enumerated; a deleted+recreated account with a different UID is never
  touched (only its stale marker is cleaned).
- On a shadow read error / `chpasswd` failure / key-removal failure the marker
  is retained so the next apply retries — a credential is never forgotten while
  it may still be live.
- `root` is never deprovisioned. Unlike `zeroize` (#4598) which `userdel -r`s
  the account, ordinary removal only locks the password + removes the key file —
  a full but reversible revocation.

## Tests

- `TestReconcileAbsentLoginUsersRevokesCredentials` — asserts lock + key removal
  + marker drop; **RED** when `deprovisionLoginUser` is neutered.
- `TestReconcileAbsentLoginUsersScoping` — a still-configured user and an
  out-of-band (UID-mismatched) account are never touched.

`go build ./...`, `go vet ./pkg/daemon/`, `gofmt`, and the full `pkg/daemon`
suite pass. Docs updated (`docs/system-login.md`).

Closes #5128

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi