### PR TITLE
api: reject cross-site mutation requests (CSRF) (#5055)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,16 @@
+## 2026-07-09 — api: CSRF/cross-site guard on REST mutations (#5055)
+
+- **Timestamp**: 2026-07-09
+  **Action**: Added `mutationCrossSiteGuard` (`pkg/api/crosssite.go`) — a
+  Fetch-Metadata resource-isolation guard wrapping the mux before
+  `authMiddleware`. Rejects (403) any non-safe-method request with cross-site
+  provenance: `Sec-Fetch-Site: cross-site|same-site`, cross-host
+  `Origin`/`Referer`, or a CORS simple form content type. Closes the
+  browser-ambient-Basic CSRF vector while leaving same-origin UI + programmatic
+  (curl/CLI/Bearer/API-key) clients untouched.
+  **File(s)**: pkg/api/crosssite.go, pkg/api/server.go,
+  pkg/api/crosssite_5055_test.go, docs/architecture.md, _Log.md
+
 ## 2026-07-09 — HA dhcpserver lease-sync trio (#5040 / #5041 / #4871)
 
 - **Timestamp**: 2026-07-09

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -213,6 +213,24 @@ editing cmdtree.
     routable-interface Prometheus scraper must then present the configured
     API key / basic-auth. `/health` stays exempt (no sensitive data, no
     table walk).
+  - **Cross-site mutation guard (CSRF, #5055).** HTTP Basic auth is an
+    *ambient* browser credential (`WWW-Authenticate: Basic`) — once a browser
+    is challenged it reattaches the cached credentials to every request to the
+    origin, including a cross-site `fetch(...,{credentials:'include'})` or a
+    cross-site `<form>` POST. The same-origin policy blocks *reading* the
+    response but not *sending* the side-effecting request, so a malicious page
+    could drive a credentialed state change. `mutationCrossSiteGuard`
+    (`pkg/api/crosssite.go`) wraps the mux BEFORE `authMiddleware` and rejects
+    any non-safe-method request (403) that shows cross-site provenance:
+    `Sec-Fetch-Site: cross-site|same-site`, an `Origin`/`Referer` whose
+    host:port differs from the target, or a CORS "simple" form content type
+    (`application/x-www-form-urlencoded` / `multipart/form-data` /
+    `text/plain`). A same-origin management-UI request (Sec-Fetch-Site
+    same-origin / none, matching Origin, `application/json`) and a programmatic
+    client (curl/CLI/scraper — none of those headers, `application/json` or an
+    empty body) both pass. Header-based API-key/Bearer clients are unaffected —
+    a cross-site page cannot set `Authorization: Bearer` / `X-API-Key`. The
+    guard applies whether or not api-auth is configured.
   - The seven `xpf_sessions_*` aggregate gauges are backed by a full walk
     of the shared v4+v6 conntrack tables (up to ~10M entries). That walk is
     served from a short-TTL (`sessionGaugeTTL`, 3s), singleflight-coalesced

--- a/pkg/api/crosssite.go
+++ b/pkg/api/crosssite.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"log/slog"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// crosssite.go implements a Fetch-Metadata resource-isolation guard on the
+// REST mutation surface (#5055).
+//
+// The HTTP API accepts HTTP Basic auth and advertises `WWW-Authenticate: Basic`
+// (pkg/api/auth.go). Basic is an *ambient* browser credential: once a browser
+// has been challenged, it reattaches the cached credentials to every request to
+// that origin, including a cross-site `fetch(...,{credentials:'include'})` or a
+// cross-site HTML `<form>` POST. The same-origin policy stops the attacker page
+// from *reading* the response, but not from *sending* the side-effecting
+// request — so a malicious page can drive a credentialed state change (config
+// set/delete/commit, session clear, system reboot) with no operator intent. The
+// loopback bind does not mitigate: the victim's own browser is the confused
+// deputy. Header-based API-key / Bearer clients are NOT exposed — a cross-site
+// page cannot set `Authorization: Bearer` or `X-API-Key` (they are not simple
+// headers and are not reattached ambiently) — so this guard only ever rejects
+// the browser-driven vector while leaving programmatic clients untouched.
+//
+// The guard runs on every non-safe (state-changing) method and rejects a
+// request that shows cross-site provenance. Its signals, in order:
+//
+//   - Sec-Fetch-Site: a forbidden header the browser stamps and page JS cannot
+//     forge. cross-site / same-site are rejected; same-origin (the management UI
+//     itself) and none (a typed URL / bookmark) pass.
+//   - Origin: browsers send it on cross-origin — and on same-origin POST —
+//     requests. Rejected when present and its host:port differs from the target.
+//   - Referer: fallback for a browser that suppresses Origin; rejected only when
+//     present and cross-host (referrer-policy may strip it, so absence is no
+//     signal).
+//   - Content-Type: a cross-site `<form>` or a `no-cors` fetch can only produce
+//     the CORS "simple" content types. A JSON API mutation is always
+//     application/json (or has no body), so the three simple form types are
+//     rejected — this blocks a credentialed cross-site form POST even on a
+//     browser old enough to send neither Sec-Fetch-Site nor Origin.
+//
+// A non-browser client (curl, the CLI, a Prometheus-style scraper) sends none of
+// Sec-Fetch-Site / Origin / Referer and uses Content-Type application/json (or
+// an empty body), so it passes every check. Requiring application/json for the
+// three simple types is exactly the "non-simple content type a cross-site form
+// can't set" defense the issue calls for, without a stateful CSRF token.
+
+// isSafeHTTPMethod reports whether method is a read-only ("safe") HTTP method
+// that never changes server state and so is not cross-site guarded.
+func isSafeHTTPMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
+		return true
+	default:
+		return false
+	}
+}
+
+// mutationCrossSiteGuard wraps next so that every state-changing request
+// (non-safe HTTP method) carrying cross-site provenance is rejected with 403
+// before it reaches a handler (#5055). Safe methods pass through untouched.
+func mutationCrossSiteGuard(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isSafeHTTPMethod(r.Method) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if reason, reject := crossSiteRejectReason(r); reject {
+			slog.Warn("api: rejected cross-site mutation request",
+				"method", r.Method, "path", r.URL.Path,
+				"reason", reason, "remote", r.RemoteAddr)
+			writeError(w, http.StatusForbidden, "cross-site request forbidden")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// crossSiteRejectReason reports the first cross-site signal that disqualifies a
+// mutation request, or ("", false) when the request is same-origin /
+// programmatic and may proceed. See the file comment for the policy.
+func crossSiteRejectReason(r *http.Request) (string, bool) {
+	// (a) Sec-Fetch-Site — unforgeable browser signal.
+	switch strings.ToLower(strings.TrimSpace(r.Header.Get("Sec-Fetch-Site"))) {
+	case "cross-site", "same-site":
+		return "sec-fetch-site=" + strings.ToLower(strings.TrimSpace(r.Header.Get("Sec-Fetch-Site"))), true
+	}
+
+	// (b) Origin host must match the target.
+	if origin := r.Header.Get("Origin"); origin != "" && !strings.EqualFold(strings.TrimSpace(origin), "null") {
+		if !sameHostAs(origin, r.Host) {
+			return "origin-mismatch", true
+		}
+	}
+
+	// (c) Referer host must match when present.
+	if ref := r.Header.Get("Referer"); ref != "" {
+		if !sameHostAs(ref, r.Host) {
+			return "referer-mismatch", true
+		}
+	}
+
+	// (d) Reject the CORS "simple" form content types. application/json and an
+	// absent content type both pass, so empty-body programmatic mutations stay
+	// callable. An unparseable content type is left to the browser signals above
+	// rather than rejected here (a real JSON client never sends one).
+	if ct := r.Header.Get("Content-Type"); ct != "" {
+		if mediaType, _, err := mime.ParseMediaType(ct); err == nil {
+			switch mediaType {
+			case "application/x-www-form-urlencoded", "multipart/form-data", "text/plain":
+				return "simple-content-type=" + mediaType, true
+			}
+		}
+	}
+
+	return "", false
+}
+
+// sameHostAs reports whether rawURL (an Origin or Referer value) has the same
+// host:port as the request's Host header. A parse failure or an empty host is a
+// mismatch (fail-closed). Scheme is ignored: the Host header carries none, and
+// an http/https flip to the same host:port is not the cross-site concern this
+// guard addresses.
+func sameHostAs(rawURL, host string) bool {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || u.Host == "" {
+		return false
+	}
+	return strings.EqualFold(u.Host, host)
+}

--- a/pkg/api/crosssite_5055_test.go
+++ b/pkg/api/crosssite_5055_test.go
@@ -1,0 +1,146 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// guardedOK wraps a 200-returning handler in mutationCrossSiteGuard so a test
+// can assert whether a given request is passed through (200) or rejected (403).
+func guardedOK() http.Handler {
+	return mutationCrossSiteGuard(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeOK(w, "mutated")
+	}))
+}
+
+// TestMutationCrossSiteGuard is the #5055 fail-on-revert guard: a state-changing
+// request with cross-site provenance (Sec-Fetch-Site / Origin / form
+// content-type) must be rejected 403, while a same-origin browser request and a
+// programmatic (curl/CLI) client are passed through. Reverting
+// mutationCrossSiteGuard to a pass-through makes the reject cases return 200 →
+// RED.
+func TestMutationCrossSiteGuard(t *testing.T) {
+	const target = "http://127.0.0.1:8080/api/v1/config/set"
+	h := guardedOK()
+
+	type hdr struct{ k, v string }
+	cases := []struct {
+		name    string
+		method  string
+		headers []hdr
+		want    int
+	}{
+		{
+			name:    "cross-site fetch is rejected",
+			method:  http.MethodPost,
+			headers: []hdr{{"Sec-Fetch-Site", "cross-site"}, {"Content-Type", "application/json"}},
+			want:    http.StatusForbidden,
+		},
+		{
+			name:    "same-site fetch is rejected",
+			method:  http.MethodPost,
+			headers: []hdr{{"Sec-Fetch-Site", "same-site"}, {"Content-Type", "application/json"}},
+			want:    http.StatusForbidden,
+		},
+		{
+			name:    "cross-origin Origin is rejected",
+			method:  http.MethodPost,
+			headers: []hdr{{"Origin", "http://evil.example"}, {"Content-Type", "application/json"}},
+			want:    http.StatusForbidden,
+		},
+		{
+			name:    "cross-host Referer is rejected",
+			method:  http.MethodPost,
+			headers: []hdr{{"Referer", "http://evil.example/x"}, {"Content-Type", "application/json"}},
+			want:    http.StatusForbidden,
+		},
+		{
+			name:    "urlencoded form content-type is rejected",
+			method:  http.MethodPost,
+			headers: []hdr{{"Content-Type", "application/x-www-form-urlencoded"}},
+			want:    http.StatusForbidden,
+		},
+		{
+			name:    "multipart form content-type is rejected",
+			method:  http.MethodPost,
+			headers: []hdr{{"Content-Type", "multipart/form-data; boundary=x"}},
+			want:    http.StatusForbidden,
+		},
+		{
+			name:    "text/plain content-type is rejected",
+			method:  http.MethodPost,
+			headers: []hdr{{"Content-Type", "text/plain"}},
+			want:    http.StatusForbidden,
+		},
+		{
+			name:    "same-origin browser request passes",
+			method:  http.MethodPost,
+			headers: []hdr{{"Sec-Fetch-Site", "same-origin"}, {"Origin", "http://127.0.0.1:8080"}, {"Content-Type", "application/json"}},
+			want:    http.StatusOK,
+		},
+		{
+			name:    "user-initiated (Sec-Fetch-Site none) passes",
+			method:  http.MethodPost,
+			headers: []hdr{{"Sec-Fetch-Site", "none"}, {"Content-Type", "application/json"}},
+			want:    http.StatusOK,
+		},
+		{
+			name:    "programmatic json client passes",
+			method:  http.MethodPost,
+			headers: []hdr{{"Content-Type", "application/json"}},
+			want:    http.StatusOK,
+		},
+		{
+			name:    "programmatic empty-body mutation passes",
+			method:  http.MethodPost,
+			headers: nil,
+			want:    http.StatusOK,
+		},
+		{
+			// A GET is a safe method: cross-site headers must NOT cause a reject
+			// (read endpoints are not state-changing).
+			name:    "safe GET with cross-site headers passes",
+			method:  http.MethodGet,
+			headers: []hdr{{"Sec-Fetch-Site", "cross-site"}, {"Origin", "http://evil.example"}},
+			want:    http.StatusOK,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, target, strings.NewReader(`{"input":"x"}`))
+			for _, hh := range tc.headers {
+				req.Header.Set(hh.k, hh.v)
+			}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != tc.want {
+				t.Fatalf("%s: status = %d, want %d (body=%s)", tc.name, rec.Code, tc.want, strings.TrimSpace(rec.Body.String()))
+			}
+		})
+	}
+}
+
+// TestSameHostAs checks the host:port comparison used by the Origin/Referer
+// signals, including the fail-closed parse-error case.
+func TestSameHostAs(t *testing.T) {
+	cases := []struct {
+		raw  string
+		host string
+		want bool
+	}{
+		{"http://127.0.0.1:8080", "127.0.0.1:8080", true},
+		{"https://127.0.0.1:8080", "127.0.0.1:8080", true}, // scheme ignored
+		{"http://evil.example", "127.0.0.1:8080", false},
+		{"http://127.0.0.1:9090", "127.0.0.1:8080", false}, // port differs
+		{"::::not-a-url", "127.0.0.1:8080", false},         // parse/empty-host -> mismatch
+		{"", "127.0.0.1:8080", false},
+	}
+	for _, tc := range cases {
+		if got := sameHostAs(tc.raw, tc.host); got != tc.want {
+			t.Errorf("sameHostAs(%q,%q) = %v, want %v", tc.raw, tc.host, got, tc.want)
+		}
+	}
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -491,6 +491,13 @@ func NewServer(cfg Config) *Server {
 	mux.HandleFunc("POST /api/v1/system/action", s.systemActionHandler)
 
 	var handler http.Handler = mux
+	// #5055: guard the mutation surface against cross-site credentialed requests
+	// (CSRF via browser-ambient Basic auth). This wraps the mux BEFORE auth so it
+	// applies to every mutation route whether or not auth is configured; a
+	// request that clears auth then hits this guard, so an attacker holding
+	// ambient Basic credentials is still blocked from driving a state change from
+	// a cross-site page. Safe methods and header-key/Bearer clients are unaffected.
+	handler = mutationCrossSiteGuard(handler)
 	if cfg.Auth != nil {
 		// #4162 (auth posture): /metrics is unauthenticated by default, which
 		// is the standard Prometheus posture and safe on the loopback default
@@ -503,7 +510,7 @@ func NewServer(cfg Config) *Server {
 		// endpoint (documented in docs/architecture.md). /health stays exempt
 		// (it exposes no table walk and no sensitive data).
 		metricsRequireAuth := !isLoopbackBindAddr(cfg.Addr)
-		handler = authMiddleware(*cfg.Auth, metricsRequireAuth, mux)
+		handler = authMiddleware(*cfg.Auth, metricsRequireAuth, handler)
 	}
 
 	s.httpServer = &http.Server{


### PR DESCRIPTION
## Problem

The REST API accepts HTTP Basic auth and advertises `WWW-Authenticate: Basic`;
`decodeJSONBody` never checked request provenance, and no `Origin`/`Sec-Fetch`/
`Referer`/CSRF handling existed anywhere in `pkg/api`. Basic is an **ambient**
browser credential — after a challenge the browser reattaches the cached
credentials to every request to the origin, including a cross-site
`fetch(...,{credentials:'include'})` or a cross-site `<form>` POST. The
same-origin policy blocks *reading* the response but not *sending* the
side-effecting request, so a malicious page could drive a credentialed state
change (config set/delete/commit, session clear, system reboot). Loopback bind
does not mitigate — the victim's own browser is the confused deputy.

## Fix

Add `mutationCrossSiteGuard` (`pkg/api/crosssite.go`), a Fetch-Metadata
resource-isolation guard wrapping the mux **before** `authMiddleware` (applies
whether or not api-auth is configured). On any non-safe HTTP method it rejects
(403) a request showing cross-site provenance:

- `Sec-Fetch-Site: cross-site|same-site` — an unforgeable browser signal;
- an `Origin`/`Referer` whose host:port differs from the target;
- a CORS "simple" form content type (`application/x-www-form-urlencoded` /
  `multipart/form-data` / `text/plain`) — blocks a credentialed cross-site form
  POST even on a browser that sends no fetch metadata.

**Legitimate clients keep working:** a same-origin management-UI request
(Sec-Fetch-Site same-origin/none, matching Origin, `application/json`) and a
programmatic client (curl/CLI/scraper — none of those headers, `application/json`
or empty body) both pass. Header-based API-key/Bearer clients are unaffected — a
cross-site page cannot set `Authorization: Bearer` / `X-API-Key`.

## Tests

- `TestMutationCrossSiteGuard` — table of reject/allow cases (cross-site fetch,
  cross-origin Origin/Referer, form content types → 403; same-origin, none,
  json, empty body, safe GET → pass). **RED** when the guard is a pass-through.
- `TestSameHostAs` — fail-closed host:port comparison.

`go build ./...`, `go vet ./pkg/api/`, `gofmt`, and the full `pkg/api` suite
pass. Docs updated (`docs/architecture.md`).

Closes #5055

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi