### PR TITLE
cli/monitor: gate and confine file-backed flow trace (#5038)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,17 @@
+## 2026-07-09 — cli/monitor: gate + confine file-backed flow trace (#5038)
+
+- **Timestamp**: 2026-07-09
+  **Action**: `monitor security flow file <name>` let a view-only user make the
+  root daemon open/append/rotate an arbitrary existing /var/log inode. Gated the
+  file-backed verbs (`file`/`start`) at PermControl in `requiredPermission`
+  (new `monitorSubcommandIsSecurityFlowFileWrite`, prefix-resolved) so a
+  read-only class cannot trigger the root write; and confined traces to a
+  dedicated root-owned (0700) dir `/var/log/xpf-flow-trace` (openTraceFile now
+  MkdirAll's it) instead of the shared /var/log, so a filename can never land
+  on a system-log inode.
+  **File(s)**: pkg/cli/monitor.go, pkg/cli/permissions.go,
+  pkg/cli/monitor_flow_perm_5038_test.go, docs/system-login.md, _Log.md
+
 ## 2026-07-09 — HA dhcpserver lease-sync trio (#5040 / #5041 / #4871)
 
 - **Timestamp**: 2026-07-09

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -249,15 +249,32 @@ every command is gated on the top-level word alone, but `monitor traffic`
 spawns a **root `tcpdump` live packet capture** on a data interface, so it
 is gated at the **control** level (the same bucket as the `request` /
 shell-out family) instead of the plain `view` level the rest of `monitor`
-(interface stats, security-flow trace) uses. A `read-only` / `config-viewer`
-class — intended only to VIEW config and status — is therefore **denied**
-`monitor traffic`; `operator` and `super-user` are allowed. This mirrors
-Junos, which gates `monitor traffic` behind the maintenance permission, not
-plain read-only. The exception lives in `requiredPermission`
-(`pkg/cli/permissions.go`) and resolves the subcommand with the same prefix
-matcher the dispatcher uses, so an abbreviated `monitor tr` is gated
-identically to the fully-spelled form and cannot bypass the gate. Other
-`monitor` subcommands and read-only `show` commands are unaffected.
+(interface stats, terminal-only `packet-drop`) uses. A `read-only` /
+`config-viewer` class — intended only to VIEW config and status — is
+therefore **denied** `monitor traffic`; `operator` and `super-user` are
+allowed. This mirrors Junos, which gates `monitor traffic` behind the
+maintenance permission, not plain read-only. The exception lives in
+`requiredPermission` (`pkg/cli/permissions.go`) and resolves the subcommand
+with the same prefix matcher the dispatcher uses, so an abbreviated `monitor
+tr` is gated identically to the fully-spelled form and cannot bypass the
+gate. Other `monitor` subcommands and read-only `show` commands are
+unaffected.
+
+**Privileged-subcommand exception — `monitor security flow {file,start}`
+(#5038).** The file-backed flow trace makes the **root daemon create, append
+to, and rotate a file on disk** (`openTraceFile` / `rotateTraceFile`,
+`pkg/cli/monitor.go`). At `view` level a `read-only` class could point that
+write at, and rotate-rename, an arbitrary existing regular inode — corrupting
+or displacing a privileged log. `monitor security flow file <name>` and
+`monitor security flow start` are therefore gated at the **control** level
+too (same `requiredPermission` prefix-resolved gate as `monitor traffic`), so
+a view-only class cannot trigger the root write at all. The status form (bare
+`monitor security flow`), `filter` (in-memory), `stop`, and the terminal-only
+`monitor security packet-drop` stay `view`. Defense in depth: traces are also
+confined to a dedicated root-owned (0700) directory `/var/log/xpf-flow-trace`
+rather than the shared `/var/log`, so even a control-level operator's trace
+filename can never resolve onto — or rotate/rename — a system-log inode such
+as `/var/log/auth.log`.
 
 **Filter option-injection hardening — `monitor traffic ... matching` (#4524).**
 The `matching <filter>` clause greedily consumes every token up to the next

--- a/pkg/cli/monitor.go
+++ b/pkg/cli/monitor.go
@@ -18,16 +18,23 @@ import (
 )
 
 // traceLogDir is the directory flow-trace files are written to. It is a
-// package var (not a const) only so tests can redirect it to a temp dir;
-// production always writes under /var/log.
-var traceLogDir = "/var/log"
+// dedicated, root-owned (0700) namespace UNDER /var/log rather than /var/log
+// itself (#5038): confining traces to a private directory means an
+// operator-supplied trace filename can never resolve onto — or rotate/rename —
+// an unrelated privileged system-log inode such as /var/log/auth.log, and the
+// 0700 ownership stops a non-root user from pre-planting a symlink/inode the
+// root daemon would then open. It is a package var (not a const) only so tests
+// can redirect it to a temp dir.
+var traceLogDir = "/var/log/xpf-flow-trace"
 
 // sanitizeTraceFilename validates an operator-supplied flow-trace filename.
 // The trace file always lives directly under traceLogDir, so only a bare
 // basename is accepted: path separators, "." / "..", and absolute paths are
 // rejected. Without this a "monitor security flow file ../../etc/x" command
-// resolves to /var/log/../../etc/x and the daemon appends root-written flow
-// telemetry outside the log directory (#3378 HC-01).
+// resolves to traceLogDir/../../etc/x and the daemon appends root-written flow
+// telemetry outside the trace directory (#3378 HC-01). Combined with the
+// dedicated-directory confinement (#5038) a name can neither traverse out nor
+// collide with a system-log inode.
 func sanitizeTraceFilename(name string) error {
 	if name == "" {
 		return fmt.Errorf("trace filename must not be empty")
@@ -45,14 +52,25 @@ func sanitizeTraceFilename(name string) error {
 }
 
 // openTraceFile opens the flow-trace file inside traceLogDir with restrictive
-// permissions. The name is sanitized first (basename only), the file is opened
-// O_NOFOLLOW so a pre-planted symlink under /var/log cannot redirect the
-// root-written telemetry (#3378 MC-02), the opened descriptor is verified to be
-// a regular file, and it is created mode 0600 rather than world-readable 0644
-// — flow tuples/zones/policy names are audit-grade telemetry (#3378 MC-01).
+// permissions. The dedicated 0700 trace directory is created first, the name is
+// sanitized (basename only), the file is opened O_NOFOLLOW so a pre-planted
+// symlink under the trace dir cannot redirect the root-written telemetry (#3378
+// MC-02), the opened descriptor is verified to be a regular file, and it is
+// created mode 0600 rather than world-readable 0644 — flow tuples/zones/policy
+// names are audit-grade telemetry (#3378 MC-01). The file-backed monitor verbs
+// are additionally gated at PermControl (pkg/cli/permissions.go, #5038) so a
+// view-only class cannot trigger this root-privileged write at all.
 func openTraceFile(name string) (*os.File, string, error) {
 	if err := sanitizeTraceFilename(name); err != nil {
 		return nil, "", err
+	}
+	// Ensure the dedicated, root-owned (0700) trace directory exists before
+	// opening into it (#5038). Confining traces to this private namespace — not
+	// the shared /var/log — is what prevents a trace filename from ever landing
+	// on an unrelated system-log inode, and 0700 keeps non-root users from
+	// planting anything the root daemon would open here.
+	if err := os.MkdirAll(traceLogDir, 0o700); err != nil {
+		return nil, "", fmt.Errorf("create trace dir %s: %w", traceLogDir, err)
 	}
 	path := filepath.Join(traceLogDir, name)
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|unix.O_NOFOLLOW, 0o600)

--- a/pkg/cli/monitor_flow_perm_5038_test.go
+++ b/pkg/cli/monitor_flow_perm_5038_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestMonitorSecurityFlowFileRequiresControl is the #5038 fail-on-revert guard:
+// the file-backed flow-trace verbs (`monitor security flow file|start`) drive a
+// root-privileged on-disk write, so they must require PermControl, not the
+// view-level permission the rest of `monitor` carries. Removing the gate drops
+// them back to PermView → RED.
+func TestMonitorSecurityFlowFileRequiresControl(t *testing.T) {
+	controlCases := [][]string{
+		{"monitor", "security", "flow", "file", "trace"},
+		{"monitor", "security", "flow", "start"},
+		// Abbreviated forms must gate identically (resolveCommand path). "sta"
+		// is an unambiguous prefix of "start" among the flow verbs.
+		{"monitor", "sec", "fl", "file", "trace"},
+		{"monitor", "sec", "fl", "sta"},
+	}
+	for _, parts := range controlCases {
+		if got := requiredPermission(parts); got != config.PermControl {
+			t.Errorf("requiredPermission(%v) = %v, want PermControl", parts, got)
+		}
+	}
+
+	viewCases := [][]string{
+		{"monitor", "security", "flow"},                 // status
+		{"monitor", "security", "flow", "filter", "f1"}, // filter edit (in-memory)
+		{"monitor", "security", "flow", "stop"},         // stop
+		{"monitor", "security", "packet-drop"},          // terminal-only stream
+	}
+	for _, parts := range viewCases {
+		if got := requiredPermission(parts); got != config.PermView {
+			t.Errorf("requiredPermission(%v) = %v, want PermView", parts, got)
+		}
+	}
+}
+
+// TestTraceDirIsDedicatedNamespace pins the #5038 confinement: the default
+// trace directory is a dedicated subdirectory, NOT the shared /var/log, so a
+// trace filename can never resolve onto — or rotate/rename — a system-log
+// inode. openTraceFile also creates the directory on demand.
+func TestTraceDirIsDedicatedNamespace(t *testing.T) {
+	if traceLogDir == "/var/log" || !strings.HasPrefix(traceLogDir, "/var/log/") {
+		t.Fatalf("traceLogDir = %q, want a dedicated subdirectory under /var/log (not /var/log itself)", traceLogDir)
+	}
+
+	// openTraceFile must create the (missing) dedicated dir and confine the file
+	// strictly inside it. Simulate /var/log with base and the dedicated dir with
+	// a not-yet-existing subdir.
+	base := t.TempDir()
+	sub := filepath.Join(base, "xpf-flow-trace")
+	old := traceLogDir
+	traceLogDir = sub
+	defer func() { traceLogDir = old }()
+
+	f, path, err := openTraceFile("auth.log")
+	if err != nil {
+		t.Fatalf("openTraceFile: %v", err)
+	}
+	defer f.Close()
+	if path != filepath.Join(sub, "auth.log") {
+		t.Fatalf("path = %q, want it confined under %q", path, sub)
+	}
+	if _, err := os.Stat(sub); err != nil {
+		t.Fatalf("dedicated trace dir not created on demand: %v", err)
+	}
+	// The parent (standing in for /var/log) must NOT have gained an auth.log —
+	// the name is confined to the dedicated dir, so a live system log is safe.
+	if _, err := os.Stat(filepath.Join(base, "auth.log")); err == nil {
+		t.Fatal("trace filename escaped the dedicated dir onto the parent (would clobber /var/log/auth.log)")
+	}
+}

--- a/pkg/cli/permissions.go
+++ b/pkg/cli/permissions.go
@@ -136,6 +136,18 @@ func requiredPermission(parts []string) config.LoginClassPermission {
 		return config.PermControl
 	}
 
+	// `monitor security flow {file|start}` drives a ROOT-privileged write to a
+	// trace file on disk (openTraceFile create/append + rotation rename). A
+	// view-only / read-only class must not be able to make the root daemon
+	// create/append/rotate on-disk files — even confined to the dedicated trace
+	// dir that is a privilege escalation and a disk-fill/telemetry-exposure vector
+	// — so gate the file-backed flow-trace verbs at the control level even though
+	// `monitor` is otherwise view-level (#5038). The terminal-only `monitor
+	// security packet-drop` and the flow status/filter/stop verbs stay view-level.
+	if action == "monitor" && monitorSubcommandIsSecurityFlowFileWrite(parts[1:]) {
+		return config.PermControl
+	}
+
 	// `request system {reboot,halt,power-off,zeroize}` and `request chassis
 	// cluster failover` are DESTRUCTIVE maintenance verbs. On Junos the
 	// predefined `operator` class lacks the `maintenance` permission and so
@@ -333,4 +345,45 @@ func monitorSubcommandIsTraffic(args []string) bool {
 		return false
 	}
 	return resolved == "traffic"
+}
+
+// monitorSubcommandIsSecurityFlowFileWrite reports whether the monitor
+// arguments resolve to `monitor security flow file ...` or `monitor security
+// flow start` — the two verbs that cause the root daemon to create/append/
+// rotate a trace file on disk (#5038). It uses the same prefix resolution the
+// monitor dispatcher applies (resolveCommand over the cmdtree children) so an
+// abbreviated `monitor sec fl fi trace` or `monitor sec fl sta` is gated
+// identically to the fully-spelled form and cannot bypass the gate. Bare
+// `monitor security flow` (status), `filter`, `stop`, and `monitor security
+// packet-drop` (terminal-only) resolve to false and stay view-level.
+func monitorSubcommandIsSecurityFlowFileWrite(args []string) bool {
+	// Need at least `security flow <verb>`.
+	if len(args) < 3 {
+		return false
+	}
+	monNode, ok := operationalTree["monitor"]
+	if !ok || monNode == nil {
+		return false
+	}
+	sec, err := resolveCommand(args[0], keysFromTree(monNode.Children))
+	if err != nil || sec != "security" {
+		return false
+	}
+	secNode := monNode.Children["security"]
+	if secNode == nil {
+		return false
+	}
+	flow, err := resolveCommand(args[1], keysFromTree(secNode.Children))
+	if err != nil || flow != "flow" {
+		return false
+	}
+	flowNode := secNode.Children["flow"]
+	if flowNode == nil {
+		return false
+	}
+	verb, err := resolveCommand(args[2], keysFromTree(flowNode.Children))
+	if err != nil {
+		return false
+	}
+	return verb == "file" || verb == "start"
 }


### PR DESCRIPTION
## Problem

`monitor security flow file <name>` stayed **view-level** (only `monitor traffic`
was escalated to `PermControl`), and `openTraceFile` opened any sanitized
basename directly under `/var/log` with `O_CREATE|O_APPEND`, validating only
that the target is a regular file. A **read-only** user could make the root
daemon open any pre-existing regular `/var/log` inode (e.g. `auth.log`) for
append; with `size`/`files` set, rotation renames the live audit log to `.1` and
creates a fresh one — corrupting or displacing privileged logs. A view
permission must not authorize root writes to arbitrary host log inodes.

## Fix (two layers)

**1. Permission gate.** `requiredPermission` now routes `monitor security flow
file` and `monitor security flow start` — the verbs that drive the root
create/append/rotate — through the new `monitorSubcommandIsSecurityFlowFileWrite`
helper (prefix-resolved exactly like the dispatcher, so abbreviations gate
identically) and requires `PermControl`. A read-only / config-viewer class can
no longer trigger the root write. Bare `monitor security flow` (status),
`filter`, `stop`, and terminal-only `monitor security packet-drop` stay
view-level.

**2. Dedicated namespace.** `traceLogDir` moves from the shared `/var/log` to a
dedicated root-owned (0700) `/var/log/xpf-flow-trace`, created on demand by
`openTraceFile`. A trace filename can no longer resolve onto — or rotate/rename —
an unrelated system-log inode even for a control-level operator, and 0700 stops
non-root users from planting an inode/symlink the daemon would open.

## Tests

- `TestMonitorSecurityFlowFileRequiresControl` — asserts the control/view split
  (file/start → PermControl; status/filter/stop/packet-drop → PermView). **RED**
  when the gate is removed.
- `TestTraceDirIsDedicatedNamespace` — asserts the dedicated-dir confinement +
  on-demand mkdir. **RED** when `traceLogDir` reverts to `/var/log`.

`go build ./...`, `go vet ./pkg/cli/` (only the pre-existing `cli.go:503`
unreachable-code finding, untouched), `gofmt`, and the full `pkg/cli` suite
pass. Docs updated (`docs/system-login.md`).

Closes #5038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi