### PR TITLE
grpcapi: enforce config-lock holder on mutators and commit (#5059)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,22 @@
+## 2026-07-09 — grpcapi: enforce config-lock holder on mutators/commit (#5059)
+
+- **Timestamp**: 2026-07-09
+  **Action**: Config mutators/commit RPCs ignored the config-lock holder — any
+  gRPC session could Set/Delete/Load/Rollback/Commit another session's shared
+  candidate. Added `ensureHolderLocked` + session-scoped `*As` store variants
+  (SetAs/DeleteAs/Load*As/RollbackAs/ConfirmCommitAs/Copy/Rename/Insert/
+  Deactivate/Activate) and exported `EnsureConfigHolder`; threaded
+  `peerSessionID(ctx)` through every gRPC config mutation/commit handler.
+  Non-holder -> `ErrConfigLockedByOther` -> `codes.PermissionDenied`. Empty
+  session ("") = internal/system bypass (local CLI, REST-stateless, HA sync,
+  tests) so existing behavior is unchanged.
+  **File(s)**: pkg/configstore/store_lock.go, pkg/configstore/store_command.go,
+  pkg/configstore/store_commit.go, pkg/configstore/envelope.go,
+  pkg/grpcapi/server_config.go,
+  pkg/configstore/config_lock_holder_5059_test.go,
+  pkg/grpcapi/config_lock_holder_5059_test.go, pkg/configstore/README.md,
+  _Log.md
+
 ## 2026-07-09 — HA dhcpserver lease-sync trio (#5040 / #5041 / #4871)
 
 - **Timestamp**: 2026-07-09

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -485,6 +485,50 @@ Boot-time `bootstrapFromFile` enters config mode first, so it too is
 governed by the same gate (a no-op there because `clusterReadOnly` is
 `false` at boot, before any RG0 transition).
 
+### Config-lock ownership gate (#5059)
+
+The candidate is intentionally **singular and shared** — `EnterConfigure*`
+records the holder session and blocks a second *enter*, but the mutating
+methods themselves used to verify only `ensureWritableLocked()` +
+`candidate != nil`. That meant a session that **never entered config mode**
+(only the *enter* was gated) could still call `Set`/`Delete`/`Load`/
+`Rollback` directly, mutate another session's pending candidate, refresh the
+true holder's idle lease (`touchConfigLockLocked`), and `Commit` it — all
+with no ownership check. Serialization under `s.mu` orders those calls; it is
+not authorization. This surface is reachable on the loopback gRPC listener
+and, more importantly, on the HA fabric listener.
+
+Ownership is now enforced atomically under `s.mu` via
+`ensureHolderLocked(sessionID)`, called inside every user mutator's critical
+section through session-scoped `*As` variants: `SetAs`,
+`SetFromInputAs`, `DeleteAs`, `DeleteFromInputAs`,
+`DeactivateFromInputAs`/`ActivateFromInputAs`, `CopyAs`, `RenameAs`,
+`InsertAs`, `LoadOverrideAs`/`LoadMergeAs`/`LoadSetAs`, `RollbackAs`, and
+`ConfirmCommitAs`. The commit-family RPCs whose mutation runs through a daemon
+callback (`Commit`, `CommitConfirmed`) call the exported `EnsureConfigHolder`
+first. The gRPC handlers thread `peerSessionID(ctx)` — the same identifier
+`EnterConfigureSession` records — into every one of these, so a second remote
+session is rejected with `ErrConfigLockedByOther` (mapped to
+`codes.PermissionDenied`).
+
+Two deliberate bypasses keep the internal paths working:
+
+- **`sessionID == ""` is the internal/system capability** — the in-process
+  CLI, the stateless REST config-enter path (no per-session holder, #4476),
+  HA sync, and tests all call the plain (non-`As`) methods, which delegate
+  with an empty session and skip the ownership check. This is why the local
+  CLI and REST behavior is bit-identical to before #5059.
+- **A lock with no recorded holder** (`effectiveHolderLocked() == ""`, i.e.
+  the internal/local `EnterConfigure()` path) is not owned by any session, so
+  a user session is not blocked from it. A remote gRPC caller always carries a
+  non-empty `peerSessionID` and records it on `EnterConfigureSession`, so it
+  cannot manufacture an empty-holder state to slip through.
+
+Like `ErrClusterReadOnly`, `ErrConfigLockedByOther` is `errors.Is`-matchable;
+it is transient (the holder commits or exits). The internal `SyncApply` /
+`PromoteRollback` convergence applies never route through the gated methods,
+so they are unaffected — same distinction as the read-only gate above.
+
 ### Step-0 committed marker (#1922 Item 2)
 
 The config-DB compatibility envelope (#1917) carries a `committed=` header

--- a/pkg/configstore/config_lock_holder_5059_test.go
+++ b/pkg/configstore/config_lock_holder_5059_test.go
@@ -1,0 +1,84 @@
+package configstore
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+// TestStoreMutatorHolderEnforcement pins the #5059 atomic holder check in the
+// session-scoped *As mutators: a non-holder session is rejected with
+// ErrConfigLockedByOther, the holder is allowed, and the internal ("") caller
+// bypasses. Reverting ensureHolderLocked to a no-op makes the non-holder cases
+// return nil → RED.
+func TestStoreMutatorHolderEnforcement(t *testing.T) {
+	store, err := New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := store.EnterConfigureSession("owner"); err != nil {
+		t.Fatalf("EnterConfigureSession: %v", err)
+	}
+
+	// Every user mutator rejects a session that is not the lock holder.
+	nonHolder := []struct {
+		name string
+		fn   func() error
+	}{
+		{"SetAs", func() error { return store.SetAs("intruder", []string{"system", "host-name", "x"}) }},
+		{"SetFromInputAs", func() error { return store.SetFromInputAs("intruder", "system host-name x") }},
+		{"DeleteAs", func() error { return store.DeleteAs("intruder", []string{"system", "host-name"}) }},
+		{"DeleteFromInputAs", func() error { return store.DeleteFromInputAs("intruder", "system host-name") }},
+		{"DeactivateFromInputAs", func() error { return store.DeactivateFromInputAs("intruder", "system host-name") }},
+		{"ActivateFromInputAs", func() error { return store.ActivateFromInputAs("intruder", "system host-name") }},
+		{"CopyAs", func() error {
+			return store.CopyAs("intruder", []string{"system", "host-name"}, []string{"system", "domain-name"})
+		}},
+		{"RenameAs", func() error {
+			return store.RenameAs("intruder", []string{"system", "host-name"}, []string{"system", "domain-name"})
+		}},
+		{"InsertAs", func() error {
+			return store.InsertAs("intruder", []string{"a"}, []string{"b"}, true)
+		}},
+		{"LoadOverrideAs", func() error { return store.LoadOverrideAs("intruder", "system { host-name x; }") }},
+		{"LoadMergeAs", func() error { return store.LoadMergeAs("intruder", "set system host-name x") }},
+		{"LoadSetAs", func() error { _, e := store.LoadSetAs("intruder", "set system host-name x"); return e }},
+		{"RollbackAs", func() error { return store.RollbackAs("intruder", 0) }},
+		{"ConfirmCommitAs", func() error { return store.ConfirmCommitAs("intruder") }},
+	}
+	for _, tc := range nonHolder {
+		if err := tc.fn(); !errors.Is(err, ErrConfigLockedByOther) {
+			t.Errorf("%s(non-holder) = %v, want ErrConfigLockedByOther", tc.name, err)
+		}
+	}
+
+	// The lock holder is allowed.
+	if err := store.SetAs("owner", []string{"system", "host-name", "ok"}); err != nil {
+		t.Errorf("SetAs(holder) = %v, want nil", err)
+	}
+
+	// The internal/system caller ("") bypasses ownership.
+	if err := store.SetAs("", []string{"system", "host-name", "internal"}); err != nil {
+		t.Errorf("SetAs(internal) = %v, want nil", err)
+	}
+}
+
+// TestEnsureConfigHolder covers the exported gate the commit-family RPCs use.
+func TestEnsureConfigHolder(t *testing.T) {
+	store, err := New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := store.EnterConfigureSession("owner"); err != nil {
+		t.Fatalf("EnterConfigureSession: %v", err)
+	}
+	if err := store.EnsureConfigHolder("intruder"); !errors.Is(err, ErrConfigLockedByOther) {
+		t.Errorf("EnsureConfigHolder(non-holder) = %v, want ErrConfigLockedByOther", err)
+	}
+	if err := store.EnsureConfigHolder("owner"); err != nil {
+		t.Errorf("EnsureConfigHolder(holder) = %v, want nil", err)
+	}
+	if err := store.EnsureConfigHolder(""); err != nil {
+		t.Errorf("EnsureConfigHolder(internal) = %v, want nil", err)
+	}
+}

--- a/pkg/configstore/envelope.go
+++ b/pkg/configstore/envelope.go
@@ -59,6 +59,20 @@ var ErrConfigLocked = errors.New("configuration is locked by another user")
 // through the gated methods, so they deliberately bypass this gate.
 var ErrClusterReadOnly = errors.New("configuration is read-only on the cluster secondary")
 
+// ErrConfigLockedByOther tags a rejected candidate mutation/commit made by a
+// session that is NOT the current config-lock holder (#5059). The candidate is
+// intentionally singular and shared, so serialization under Store.mu alone is
+// not authorization: without this gate a session that never entered config mode
+// could Set/Delete/Load/Rollback/Commit another session's pending candidate. It
+// is returned by the session-scoped *As mutators and EnsureConfigHolder when a
+// non-empty caller session differs from the recorded holder. A caller session
+// of "" is the explicit internal/system capability (daemon apply, REST-stateless
+// enter, HA sync, tests) and bypasses the gate; a lock acquired with no recorded
+// holder (the internal/local EnterConfigure path) is likewise not owned by any
+// session and is not blocked. It is a TRANSIENT condition (the holder commits or
+// exits), so deferrable callers may errors.Is + retry.
+var ErrConfigLockedByOther = errors.New("configuration candidate is held by another session")
+
 // Config-DB compatibility envelope (#1917 increment B, plan §6.4 / D1).
 //
 // The envelope is EMBEDDED in active.json as a single magic header LINE

--- a/pkg/configstore/store_command.go
+++ b/pkg/configstore/store_command.go
@@ -7,12 +7,22 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 )
 
-// Set applies a "set" command to the candidate configuration.
-func (s *Store) Set(path []string) error {
+// Set applies a "set" command to the candidate configuration. It is the
+// internal/system entry point (no session ownership check); the gRPC user path
+// uses SetAs to carry the caller's session for config-lock holder enforcement
+// (#5059).
+func (s *Store) Set(path []string) error { return s.SetAs("", path) }
+
+// SetAs is Set scoped to a config-lock holder session (#5059). sessionID == ""
+// bypasses ownership (internal/system caller).
+func (s *Store) SetAs(sessionID string, path []string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
+	if err := s.ensureHolderLocked(sessionID); err != nil {
 		return err
 	}
 	if s.candidate == nil {
@@ -28,20 +38,30 @@ func (s *Store) Set(path []string) error {
 }
 
 // SetFromInput parses a "set ..." command string and applies it.
-func (s *Store) SetFromInput(input string) error {
+func (s *Store) SetFromInput(input string) error { return s.SetFromInputAs("", input) }
+
+// SetFromInputAs is SetFromInput scoped to a config-lock holder session (#5059).
+func (s *Store) SetFromInputAs(sessionID, input string) error {
 	path, err := config.ParseSetCommand("set " + input)
 	if err != nil {
 		return err
 	}
-	return s.Set(path)
+	return s.SetAs(sessionID, path)
 }
 
-// Delete removes a node at the given path from the candidate configuration.
-func (s *Store) Delete(path []string) error {
+// Delete removes a node at the given path from the candidate configuration. The
+// internal/system entry point; the gRPC user path uses DeleteAs (#5059).
+func (s *Store) Delete(path []string) error { return s.DeleteAs("", path) }
+
+// DeleteAs is Delete scoped to a config-lock holder session (#5059).
+func (s *Store) DeleteAs(sessionID string, path []string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
+	if err := s.ensureHolderLocked(sessionID); err != nil {
 		return err
 	}
 	if s.candidate == nil {
@@ -57,12 +77,16 @@ func (s *Store) Delete(path []string) error {
 }
 
 // DeleteFromInput parses a "delete ..." command string and applies it.
-func (s *Store) DeleteFromInput(input string) error {
+func (s *Store) DeleteFromInput(input string) error { return s.DeleteFromInputAs("", input) }
+
+// DeleteFromInputAs is DeleteFromInput scoped to a config-lock holder session
+// (#5059).
+func (s *Store) DeleteFromInputAs(sessionID, input string) error {
 	path, err := config.ParseSetCommand("delete " + input)
 	if err != nil {
 		return err
 	}
-	return s.Delete(path)
+	return s.DeleteAs(sessionID, path)
 }
 
 // DeactivateFromInput marks the candidate node at the given path inactive
@@ -77,9 +101,18 @@ func (s *Store) DeleteFromInput(input string) error {
 // reaching DeactivatePath. The node must already exist; DeactivatePath on an
 // already-inactive node is idempotent (it re-sets a bool).
 func (s *Store) DeactivateFromInput(input string) error {
+	return s.DeactivateFromInputAs("", input)
+}
+
+// DeactivateFromInputAs is DeactivateFromInput scoped to a config-lock holder
+// session (#5059).
+func (s *Store) DeactivateFromInputAs(sessionID, input string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
+	if err := s.ensureHolderLocked(sessionID); err != nil {
 		return err
 	}
 	if s.candidate == nil {
@@ -98,9 +131,18 @@ func (s *Store) DeactivateFromInput(input string) error {
 // verb. Symmetric with DeactivateFromInput; ActivatePath on an already-active
 // node is idempotent.
 func (s *Store) ActivateFromInput(input string) error {
+	return s.ActivateFromInputAs("", input)
+}
+
+// ActivateFromInputAs is ActivateFromInput scoped to a config-lock holder
+// session (#5059).
+func (s *Store) ActivateFromInputAs(sessionID, input string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
+	if err := s.ensureHolderLocked(sessionID); err != nil {
 		return err
 	}
 	if s.candidate == nil {
@@ -115,10 +157,16 @@ func (s *Store) ActivateFromInput(input string) error {
 }
 
 // Copy duplicates a config subtree from srcPath to dstPath.
-func (s *Store) Copy(srcPath, dstPath []string) error {
+func (s *Store) Copy(srcPath, dstPath []string) error { return s.CopyAs("", srcPath, dstPath) }
+
+// CopyAs is Copy scoped to a config-lock holder session (#5059).
+func (s *Store) CopyAs(sessionID string, srcPath, dstPath []string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
+	if err := s.ensureHolderLocked(sessionID); err != nil {
 		return err
 	}
 	if s.candidate == nil {
@@ -133,10 +181,16 @@ func (s *Store) Copy(srcPath, dstPath []string) error {
 }
 
 // Rename moves a config subtree from srcPath to dstPath.
-func (s *Store) Rename(srcPath, dstPath []string) error {
+func (s *Store) Rename(srcPath, dstPath []string) error { return s.RenameAs("", srcPath, dstPath) }
+
+// RenameAs is Rename scoped to a config-lock holder session (#5059).
+func (s *Store) RenameAs(sessionID string, srcPath, dstPath []string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
+	if err := s.ensureHolderLocked(sessionID); err != nil {
 		return err
 	}
 	if s.candidate == nil {
@@ -153,9 +207,17 @@ func (s *Store) Rename(srcPath, dstPath []string) error {
 // Insert moves an element before or after a reference element within the
 // same parent's ordered children list.
 func (s *Store) Insert(elementPath, refPath []string, before bool) error {
+	return s.InsertAs("", elementPath, refPath, before)
+}
+
+// InsertAs is Insert scoped to a config-lock holder session (#5059).
+func (s *Store) InsertAs(sessionID string, elementPath, refPath []string, before bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
+	if err := s.ensureHolderLocked(sessionID); err != nil {
 		return err
 	}
 	if s.candidate == nil {
@@ -217,7 +279,10 @@ func (s *Store) Annotate(path []string, comment string) error {
 
 // LoadOverride replaces the entire candidate config with the parsed input.
 // The input can be hierarchical Junos config or flat "set" commands.
-func (s *Store) LoadOverride(content string) error {
+func (s *Store) LoadOverride(content string) error { return s.LoadOverrideAs("", content) }
+
+// LoadOverrideAs is LoadOverride scoped to a config-lock holder session (#5059).
+func (s *Store) LoadOverrideAs(sessionID, content string) error {
 	if err := checkConfigSize(content); err != nil {
 		return err
 	}
@@ -225,6 +290,9 @@ func (s *Store) LoadOverride(content string) error {
 	defer s.mu.Unlock()
 
 	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
+	if err := s.ensureHolderLocked(sessionID); err != nil {
 		return err
 	}
 	if s.candidate == nil {
@@ -245,7 +313,10 @@ func (s *Store) LoadOverride(content string) error {
 // LoadMerge merges the parsed input into the existing candidate config.
 // For flat "set" commands, each line is applied individually.
 // For hierarchical input, it's converted to set commands and merged.
-func (s *Store) LoadMerge(content string) error {
+func (s *Store) LoadMerge(content string) error { return s.LoadMergeAs("", content) }
+
+// LoadMergeAs is LoadMerge scoped to a config-lock holder session (#5059).
+func (s *Store) LoadMergeAs(sessionID, content string) error {
 	if err := checkConfigSize(content); err != nil {
 		return err
 	}
@@ -253,6 +324,9 @@ func (s *Store) LoadMerge(content string) error {
 	defer s.mu.Unlock()
 
 	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
+	if err := s.ensureHolderLocked(sessionID); err != nil {
 		return err
 	}
 	if s.candidate == nil {
@@ -387,13 +461,19 @@ func applyEditLine(tree *config.ConfigTree, line string) error {
 // command). The deactivate/activate verbs make `show | display set` output
 // round-trippable: previously a `deactivate <path>` line was skipped here,
 // so an inactive node reloaded ACTIVE.
-func (s *Store) LoadSet(content string) (int, error) {
+func (s *Store) LoadSet(content string) (int, error) { return s.LoadSetAs("", content) }
+
+// LoadSetAs is LoadSet scoped to a config-lock holder session (#5059).
+func (s *Store) LoadSetAs(sessionID, content string) (int, error) {
 	if err := checkConfigSize(content); err != nil {
 		return 0, err
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if err := s.ensureWritableLocked(); err != nil {
+		return 0, err
+	}
+	if err := s.ensureHolderLocked(sessionID); err != nil {
 		return 0, err
 	}
 	if s.candidate == nil {

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -401,10 +401,19 @@ func (s *Store) clearPendingConfirmLocked() bool {
 }
 
 // ConfirmCommit cancels the auto-rollback timer, confirming the config.
-func (s *Store) ConfirmCommit() error {
+func (s *Store) ConfirmCommit() error { return s.ConfirmCommitAs("") }
+
+// ConfirmCommitAs is ConfirmCommit scoped to a config-lock holder session
+// (#5059): a non-holder session must not confirm (and thereby cancel the
+// auto-rollback of) another session's pending commit-confirmed. sessionID == ""
+// bypasses ownership (internal/system caller, e.g. the confirm-on-sync path).
+func (s *Store) ConfirmCommitAs(sessionID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if err := s.ensureHolderLocked(sessionID); err != nil {
+		return err
+	}
 	if !s.clearPendingConfirmLocked() {
 		return fmt.Errorf("no pending confirmed commit")
 	}
@@ -598,7 +607,11 @@ func (s *Store) performAutoRollback(gen uint64) {
 
 // Rollback reverts the candidate to a previous configuration.
 // n=0 reverts to active; n>0 reverts to the nth previous commit.
-func (s *Store) Rollback(n int) error {
+func (s *Store) Rollback(n int) error { return s.RollbackAs("", n) }
+
+// RollbackAs is Rollback scoped to a config-lock holder session (#5059).
+// sessionID == "" bypasses ownership (internal/system caller).
+func (s *Store) RollbackAs(sessionID string, n int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -607,6 +620,11 @@ func (s *Store) Rollback(n int) error {
 	// commit-confirmed timeout revert PromoteRollback (which promotes the
 	// active config directly and is intentionally NOT gated).
 	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
+	// #5059: reject a rollback issued by a session that is not the config-lock
+	// holder — it mutates the shared candidate.
+	if err := s.ensureHolderLocked(sessionID); err != nil {
 		return err
 	}
 	if s.candidate == nil {

--- a/pkg/configstore/store_lock.go
+++ b/pkg/configstore/store_lock.go
@@ -28,6 +28,51 @@ func (s *Store) ensureWritableLocked() error {
 	return nil
 }
 
+// ensureHolderLocked enforces config-lock ownership on a user-session mutation
+// or commit (#5059). The candidate is singular and shared, so serialization
+// under s.mu is not authorization: a session that never entered config mode
+// could otherwise mutate/commit another session's candidate. It rejects a
+// non-empty caller sessionID that differs from the recorded holder. Callers
+// MUST hold s.mu.
+//
+// Two deliberate bypasses:
+//   - sessionID == "" is the internal/system capability (daemon apply, the
+//     stateless REST config-enter path, HA sync, in-process CLI, tests). These
+//     do not carry a peer session and must not be blocked.
+//   - a lock with no recorded holder (effectiveHolderLocked() == "", i.e. the
+//     internal/local EnterConfigure() path) is not owned by any session, so a
+//     user session is not blocked from it — matching pre-#5059 behavior for the
+//     local-CLI / internal acquire.
+//
+// A remote gRPC caller always carries a non-empty peerSessionID and records it
+// as the holder on EnterConfigureSession, so a second remote session is gated
+// against it — closing the exact cross-session mutation the issue describes.
+func (s *Store) ensureHolderLocked(sessionID string) error {
+	if sessionID == "" {
+		return nil // internal/system caller: explicit bypass
+	}
+	if !s.configDir {
+		return nil // not in config mode; candidate==nil is reported by the caller
+	}
+	holder := s.effectiveHolderLocked()
+	if holder == "" || holder == sessionID {
+		return nil
+	}
+	return fmt.Errorf("%w", ErrConfigLockedByOther)
+}
+
+// EnsureConfigHolder atomically verifies that sessionID owns the config lock,
+// returning ErrConfigLockedByOther otherwise (#5059). It is the exported gate
+// used by the commit-family gRPC RPCs (Commit/CommitConfirmed) whose mutation
+// runs through a daemon callback rather than a single store method, so they
+// cannot thread the holder through an *As variant. sessionID == "" bypasses
+// (internal/system caller), matching ensureHolderLocked.
+func (s *Store) EnsureConfigHolder(sessionID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ensureHolderLocked(sessionID)
+}
+
 // configLockLeaseTTL bounds how long a config lock may sit idle — with no edit
 // activity — before a new entrant may reclaim it. #4476: the REST config-enter
 // path (POST /api/v1/config/enter) is stateless and has NO disconnect hook,

--- a/pkg/grpcapi/config_lock_holder_5059_test.go
+++ b/pkg/grpcapi/config_lock_holder_5059_test.go
@@ -1,0 +1,132 @@
+package grpcapi
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+
+	"github.com/psaab/xpf/pkg/config"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// clientCtx returns a context carrying a distinct gRPC peer address, so
+// peerSessionID resolves to a distinct per-"client" session identifier.
+func clientCtx(port int) context.Context {
+	return peer.NewContext(context.Background(), &peer.Peer{
+		Addr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port},
+	})
+}
+
+func wantCode(t *testing.T, err error, want codes.Code, what string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s: got nil error, want %v", what, want)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("%s: error is not a status: %T (%v)", what, err, err)
+	}
+	if st.Code() != want {
+		t.Fatalf("%s: code = %v, want %v (%v)", what, st.Code(), want, err)
+	}
+}
+
+// TestConfigLockHolderEnforced_TwoClients is the #5059 fail-on-revert guard:
+// once client A holds the config lock, a second client B that never entered
+// config mode must be rejected (PermissionDenied) from every mutating/commit
+// RPC on A's shared candidate, while A itself keeps working. Reverting the
+// holder enforcement lets B's mutations through → RED.
+func TestConfigLockHolderEnforced_TwoClients(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	s := &Server{
+		store: store,
+		commitFn: func(context.Context, string) (*config.Config, error) {
+			return store.Commit()
+		},
+	}
+	ctxA := clientCtx(1111)
+	ctxB := clientCtx(2222)
+
+	// A takes the config lock.
+	if _, err := s.EnterConfigure(ctxA, &pb.EnterConfigureRequest{}); err != nil {
+		t.Fatalf("A EnterConfigure: %v", err)
+	}
+
+	// B never entered config mode: every mutation/commit it attempts on the
+	// shared candidate is rejected PermissionDenied.
+	_, err := s.Set(ctxB, &pb.SetRequest{Input: "system host-name evil"})
+	wantCode(t, err, codes.PermissionDenied, "B Set")
+
+	_, err = s.Delete(ctxB, &pb.DeleteRequest{Input: "system host-name"})
+	wantCode(t, err, codes.PermissionDenied, "B Delete")
+
+	_, err = s.Load(ctxB, &pb.LoadRequest{Mode: "set", Content: "set system host-name evil"})
+	wantCode(t, err, codes.PermissionDenied, "B Load set")
+
+	_, err = s.Load(ctxB, &pb.LoadRequest{Mode: "override", Content: "system { host-name evil; }"})
+	wantCode(t, err, codes.PermissionDenied, "B Load override")
+
+	_, err = s.Rollback(ctxB, &pb.RollbackRequest{N: 0})
+	wantCode(t, err, codes.PermissionDenied, "B Rollback")
+
+	_, err = s.Commit(ctxB, &pb.CommitRequest{})
+	wantCode(t, err, codes.PermissionDenied, "B Commit")
+
+	_, err = s.CommitConfirmed(ctxB, &pb.CommitConfirmedRequest{Minutes: 5})
+	wantCode(t, err, codes.PermissionDenied, "B CommitConfirmed")
+
+	// A (the holder) can mutate normally.
+	if _, err := s.Set(ctxA, &pb.SetRequest{Input: "system host-name good"}); err != nil {
+		t.Fatalf("A Set (holder): %v", err)
+	}
+
+	// None of B's rejected mutations reached the candidate; A's did.
+	got := store.ShowCandidateSetRedacted(nil)
+	if strings.Contains(got, "evil") {
+		t.Fatalf("candidate was mutated by a non-holder session: %q", got)
+	}
+	if !strings.Contains(got, "good") {
+		t.Fatalf("holder's edit missing from candidate: %q", got)
+	}
+}
+
+// TestConfigLockHolderConcurrent exercises the atomic holder check under the
+// race detector: the holder A and a non-holder B hammer Set concurrently. B must
+// never succeed and the candidate must never carry B's value. Run with -race.
+func TestConfigLockHolderConcurrent(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	s := &Server{store: store}
+	ctxA := clientCtx(1111)
+	ctxB := clientCtx(2222)
+
+	if _, err := s.EnterConfigure(ctxA, &pb.EnterConfigureRequest{}); err != nil {
+		t.Fatalf("A EnterConfigure: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_, _ = s.Set(ctxA, &pb.SetRequest{Input: "system host-name good"})
+		}()
+		go func() {
+			defer wg.Done()
+			if _, err := s.Set(ctxB, &pb.SetRequest{Input: "system host-name evil"}); err == nil {
+				t.Errorf("non-holder B Set succeeded concurrently")
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := store.ShowCandidateSetRedacted(nil); strings.Contains(got, "evil") {
+		t.Fatalf("candidate mutated by concurrent non-holder: %q", got)
+	}
+}

--- a/pkg/grpcapi/server_config.go
+++ b/pkg/grpcapi/server_config.go
@@ -7,10 +7,23 @@ import (
 	"strings"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// configMutationStatus maps a store mutation/commit error to the right gRPC
+// status code. A config-lock ownership violation (#5059,
+// configstore.ErrConfigLockedByOther) is PermissionDenied; every other error
+// (bad path, parse failure, read-only secondary, etc.) keeps the historical
+// InvalidArgument mapping so existing clients see no behavior change.
+func configMutationStatus(err error) error {
+	if errors.Is(err, configstore.ErrConfigLockedByOther) {
+		return status.Errorf(codes.PermissionDenied, "%v", err)
+	}
+	return status.Errorf(codes.InvalidArgument, "%v", err)
+}
 
 // --- Config lifecycle RPCs ---
 
@@ -47,13 +60,17 @@ func (s *Server) GetConfigModeStatus(_ context.Context, _ *pb.GetConfigModeStatu
 	}, nil
 }
 
-func (s *Server) Set(_ context.Context, req *pb.SetRequest) (*pb.SetResponse, error) {
+func (s *Server) Set(ctx context.Context, req *pb.SetRequest) (*pb.SetResponse, error) {
+	// #5059: enforce config-lock ownership. peerSessionID identifies this
+	// connection; the store rejects a mutation whose caller is not the lock
+	// holder. An empty session (unit tests / internal) bypasses.
+	sessionID := peerSessionID(ctx)
 	input := req.Input
 	if strings.HasPrefix(input, "copy ") || strings.HasPrefix(input, "rename ") {
-		return s.handleCopyRename(input)
+		return s.handleCopyRename(sessionID, input)
 	}
 	if strings.HasPrefix(input, "insert ") {
-		return s.handleInsert(input)
+		return s.handleInsert(sessionID, input)
 	}
 	// #2051: the remote CLI rides the Set RPC for activate/deactivate (no
 	// dedicated RPC). Prefix-route the verb to the store wrapper BEFORE the
@@ -76,22 +93,22 @@ func (s *Server) Set(_ context.Context, req *pb.SetRequest) (*pb.SetResponse, er
 		}
 		var err error
 		if verb == "deactivate" {
-			err = s.store.DeactivateFromInput(rest)
+			err = s.store.DeactivateFromInputAs(sessionID, rest)
 		} else {
-			err = s.store.ActivateFromInput(rest)
+			err = s.store.ActivateFromInputAs(sessionID, rest)
 		}
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+			return nil, configMutationStatus(err)
 		}
 		return &pb.SetResponse{}, nil
 	}
-	if err := s.store.SetFromInput(input); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	if err := s.store.SetFromInputAs(sessionID, input); err != nil {
+		return nil, configMutationStatus(err)
 	}
 	return &pb.SetResponse{}, nil
 }
 
-func (s *Server) handleCopyRename(input string) (*pb.SetResponse, error) {
+func (s *Server) handleCopyRename(sessionID, input string) (*pb.SetResponse, error) {
 	parts := strings.Fields(input)
 	isRename := parts[0] == "rename"
 	toIdx := -1
@@ -108,17 +125,17 @@ func (s *Server) handleCopyRename(input string) (*pb.SetResponse, error) {
 	dstPath := parts[toIdx+1:]
 	var err error
 	if isRename {
-		err = s.store.Rename(srcPath, dstPath)
+		err = s.store.RenameAs(sessionID, srcPath, dstPath)
 	} else {
-		err = s.store.Copy(srcPath, dstPath)
+		err = s.store.CopyAs(sessionID, srcPath, dstPath)
 	}
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, configMutationStatus(err)
 	}
 	return &pb.SetResponse{}, nil
 }
 
-func (s *Server) handleInsert(input string) (*pb.SetResponse, error) {
+func (s *Server) handleInsert(sessionID, input string) (*pb.SetResponse, error) {
 	parts := strings.Fields(input)
 	kwIdx := -1
 	isBefore := false
@@ -143,28 +160,29 @@ func (s *Server) handleInsert(input string) (*pb.SetResponse, error) {
 	}
 	parentPath := elemPath[:len(elemPath)-len(refTokens)]
 	refPath := append(append([]string{}, parentPath...), refTokens...)
-	if err := s.store.Insert(elemPath, refPath, isBefore); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	if err := s.store.InsertAs(sessionID, elemPath, refPath, isBefore); err != nil {
+		return nil, configMutationStatus(err)
 	}
 	return &pb.SetResponse{}, nil
 }
 
-func (s *Server) Delete(_ context.Context, req *pb.DeleteRequest) (*pb.DeleteResponse, error) {
-	if err := s.store.DeleteFromInput(req.Input); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+func (s *Server) Delete(ctx context.Context, req *pb.DeleteRequest) (*pb.DeleteResponse, error) {
+	if err := s.store.DeleteFromInputAs(peerSessionID(ctx), req.Input); err != nil {
+		return nil, configMutationStatus(err)
 	}
 	return &pb.DeleteResponse{}, nil
 }
 
-func (s *Server) Load(_ context.Context, req *pb.LoadRequest) (*pb.LoadResponse, error) {
+func (s *Server) Load(ctx context.Context, req *pb.LoadRequest) (*pb.LoadResponse, error) {
+	sessionID := peerSessionID(ctx)
 	switch req.Mode {
 	case "override":
-		if err := s.store.LoadOverride(req.Content); err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		if err := s.store.LoadOverrideAs(sessionID, req.Content); err != nil {
+			return nil, configMutationStatus(err)
 		}
 	case "merge", "":
-		if err := s.store.LoadMerge(req.Content); err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		if err := s.store.LoadMergeAs(sessionID, req.Content); err != nil {
+			return nil, configMutationStatus(err)
 		}
 	case "set":
 		// #2052: make `load set` a real service-mode op. LoadSet replays the
@@ -172,9 +190,9 @@ func (s *Server) Load(_ context.Context, req *pb.LoadRequest) (*pb.LoadResponse,
 		// `deactivate <path>` lines (emitted by `show | display set` for
 		// inactive nodes, #2008 H1) round-trips back to an inactive node.
 		// The applied-count is log-only (LoadResponse has no count field).
-		count, err := s.store.LoadSet(req.Content)
+		count, err := s.store.LoadSetAs(sessionID, req.Content)
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+			return nil, configMutationStatus(err)
 		}
 		slog.Info("load set applied", "commands", count)
 	default:
@@ -184,13 +202,21 @@ func (s *Server) Load(_ context.Context, req *pb.LoadRequest) (*pb.LoadResponse,
 }
 
 func (s *Server) Commit(ctx context.Context, req *pb.CommitRequest) (*pb.CommitResponse, error) {
+	// #5059: only the config-lock holder may commit the shared candidate. Reject
+	// a commit from a non-holder session before it can confirm/apply another
+	// session's pending work. Empty session (unit tests / internal) bypasses.
+	sessionID := peerSessionID(ctx)
+	if err := s.store.EnsureConfigHolder(sessionID); err != nil {
+		return nil, configMutationStatus(err)
+	}
+
 	// Bare commit during a pending commit-confirmed window (#4000). Confirm
 	// the pending config only when the candidate is UNCHANGED; new staged
 	// edits fall through to the normal commit below, where the daemon commitFn
 	// (CommitWithDescription, #3861) applies them AND clears the timer, so the
 	// edits are committed rather than silently dropped.
 	if s.store.IsConfirmPending() && !s.store.IsDirty() {
-		if err := s.store.ConfirmCommit(); err != nil {
+		if err := s.store.ConfirmCommitAs(sessionID); err != nil {
 			return nil, status.Errorf(codes.Internal, "%v", err)
 		}
 		return &pb.CommitResponse{}, nil
@@ -225,6 +251,10 @@ func (s *Server) CommitCheck(_ context.Context, _ *pb.CommitCheckRequest) (*pb.C
 }
 
 func (s *Server) CommitConfirmed(ctx context.Context, req *pb.CommitConfirmedRequest) (*pb.CommitConfirmedResponse, error) {
+	// #5059: only the config-lock holder may commit the shared candidate.
+	if err := s.store.EnsureConfigHolder(peerSessionID(ctx)); err != nil {
+		return nil, configMutationStatus(err)
+	}
 	if s.commitConfirmedFn == nil {
 		return nil, status.Errorf(codes.Internal, "commit-confirmed handler not wired")
 	}
@@ -242,14 +272,19 @@ func (s *Server) CommitConfirmed(ctx context.Context, req *pb.CommitConfirmedReq
 	return &pb.CommitConfirmedResponse{Warnings: configWarnings(compiled)}, nil
 }
 
-func (s *Server) ConfirmCommit(_ context.Context, _ *pb.ConfirmCommitRequest) (*pb.ConfirmCommitResponse, error) {
-	if err := s.store.ConfirmCommit(); err != nil {
+func (s *Server) ConfirmCommit(ctx context.Context, _ *pb.ConfirmCommitRequest) (*pb.ConfirmCommitResponse, error) {
+	// #5059: only the config-lock holder may confirm (and cancel the auto-
+	// rollback of) the pending commit-confirmed.
+	if err := s.store.ConfirmCommitAs(peerSessionID(ctx)); err != nil {
+		if errors.Is(err, configstore.ErrConfigLockedByOther) {
+			return nil, status.Errorf(codes.PermissionDenied, "%v", err)
+		}
 		return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
 	}
 	return &pb.ConfirmCommitResponse{}, nil
 }
 
-func (s *Server) Rollback(_ context.Context, req *pb.RollbackRequest) (*pb.RollbackResponse, error) {
+func (s *Server) Rollback(ctx context.Context, req *pb.RollbackRequest) (*pb.RollbackResponse, error) {
 	// #4589 A8-01: n==0 is the valid Junos `rollback 0` (revert to active);
 	// n>=1 selects history slot n. A negative n maps to history.Get(n-1) =
 	// history.Get(<-1>) → the opaque store error "history position -1 out of
@@ -260,8 +295,8 @@ func (s *Server) Rollback(_ context.Context, req *pb.RollbackRequest) (*pb.Rollb
 		return nil, status.Errorf(codes.InvalidArgument,
 			"invalid n %d: rollback index must be non-negative (0 = revert to active)", req.N)
 	}
-	if err := s.store.Rollback(int(req.N)); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	if err := s.store.RollbackAs(peerSessionID(ctx), int(req.N)); err != nil {
+		return nil, configMutationStatus(err)
 	}
 	return &pb.RollbackResponse{}, nil
 }


### PR DESCRIPTION
## Problem

The candidate is intentionally singular and shared. `EnterConfigure` records the
lock holder and blocks a second *enter*, but the gRPC config mutators/commit RPCs
never threaded the caller's session into the store — `Set`/`Delete`/`Load`/
`Rollback`/`Commit`/`CommitConfirmed` verified only `ensureWritableLocked` +
`candidate != nil`. A session that **never entered config mode** could therefore
mutate another session's pending candidate, refresh the true holder's idle lease,
and `Commit` it — with no ownership check. Serialization under `Store.mu` orders
those calls; it is not authorization. The surface is reachable on the loopback
gRPC listener **and** the HA fabric listener.

## Fix

Enforce ownership atomically under `Store.mu`:

- `ensureHolderLocked(sessionID)` rejects a non-empty caller session that is not
  the recorded holder with the new `ErrConfigLockedByOther` sentinel. It runs
  inside each mutator's critical section via session-scoped `*As` variants
  (`SetAs`, `SetFromInputAs`, `DeleteAs`, `DeleteFromInputAs`,
  `Deactivate/ActivateFromInputAs`, `CopyAs`, `RenameAs`, `InsertAs`,
  `LoadOverride/Merge/SetAs`, `RollbackAs`, `ConfirmCommitAs`).
- Commit-family RPCs whose mutation runs through a daemon callback (`Commit`,
  `CommitConfirmed`) call the exported `EnsureConfigHolder` first.
- Every gRPC config handler threads `peerSessionID(ctx)` — the same identifier
  `EnterConfigureSession` records — so a second remote session is rejected
  `PermissionDenied`.

**Bypasses preserve existing behavior:** `sessionID == ""` is the internal/system
capability (in-process CLI, stateless REST config-enter, HA sync, tests all call
the plain non-`As` methods), and a lock with no recorded holder (internal/local
`EnterConfigure()`) is not owned by any session. A remote caller always carries a
non-empty `peerSessionID`, so it cannot manufacture an empty-holder state.
Internal `SyncApply` / `PromoteRollback` never route through the gated methods.

## Tests

- `TestConfigLockHolderEnforced_TwoClients` — two peer-distinct gRPC clients; A
  holds the lock, B is rejected from Set/Delete/Load/Rollback/Commit/
  CommitConfirmed while A succeeds. **RED** when `ensureHolderLocked` is neutered.
- `TestConfigLockHolderConcurrent` — hammers the atomic check under **`-race`**.
- `TestStoreMutatorHolderEnforcement` / `TestEnsureConfigHolder` — store-level
  coverage of every `*As` variant plus the `""` bypass.

`go build ./...`, `go vet ./pkg/configstore/ ./pkg/grpcapi/`, `gofmt`, and the
full configstore + grpcapi suites pass with `-race`. Docs updated
(`pkg/configstore/README.md`).

Closes #5059

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi