### PR TITLE
snmp: hash community clients allowlist in reconcile fingerprint

### DIFF
--- a/pkg/daemon/daemon_snmp_hash_clients_5105_test.go
+++ b/pkg/daemon/daemon_snmp_hash_clients_5105_test.go
@@ -1,0 +1,65 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// snmpCfgWithClients builds a config whose sole community "public" carries the
+// given source-IP allowlist. All other fields are held constant so any hash
+// difference is attributable to the allowlist alone.
+func snmpCfgWithClients(clients []config.SNMPClient) *config.Config {
+	cfg := &config.Config{}
+	cfg.System.SNMP = &config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"public": {Name: "public", Authorization: "read-only", Clients: clients},
+		},
+	}
+	return cfg
+}
+
+// TestSNMPConfigHashIncludesClients pins #5105: the community `clients`
+// source-IP allowlist and its per-entry `restrict` (deny) bit are live
+// authorization inputs (enforced by SNMPCommunity.AllowsSource), so a day-2
+// edit that changes ONLY the allowlist — same community name + authorization —
+// MUST change snmpConfigHash. Otherwise reconcile takes the idempotent no-op
+// path and the running agent keeps the stale (possibly allow-all) source policy
+// while the commit reports success.
+//
+// Fail-on-revert: dropping Clients/Restrict from the hash makes each pair below
+// hash equal and the assertions fail.
+func TestSNMPConfigHashIncludesClients(t *testing.T) {
+	h := func(clients []config.SNMPClient) uint64 {
+		return snmpConfigHash(snmpCfgWithClients(clients))
+	}
+
+	allowAll := h(nil)
+	restricted := h([]config.SNMPClient{{Prefix: "10.0.0.0/8"}})
+	if allowAll == restricted {
+		t.Fatal("allow-all -> restricted allowlist did not change the hash — reconcile would no-op the ACL tightening")
+	}
+
+	allow := h([]config.SNMPClient{{Prefix: "10.0.0.0/8", Restrict: false}})
+	deny := h([]config.SNMPClient{{Prefix: "10.0.0.0/8", Restrict: true}})
+	if allow == deny {
+		t.Fatal("flipping the per-entry restrict (deny) bit did not change the hash")
+	}
+
+	if h([]config.SNMPClient{{Prefix: "10.0.0.0/8"}}) ==
+		h([]config.SNMPClient{{Prefix: "192.168.0.0/16"}}) {
+		t.Fatal("changing the client prefix did not change the hash")
+	}
+
+	// Removing the allowlist (restricted -> allow-all) must also be detected.
+	if restricted == allowAll {
+		t.Fatal("restricted -> allow-all (removed allowlist) did not change the hash")
+	}
+
+	// Idempotence preserved: identical config text hashes equal, so an
+	// unchanged stanza still takes the reconcile no-op path.
+	same := []config.SNMPClient{{Prefix: "10.0.0.0/8", Restrict: true}, {Prefix: "192.168.1.0/24"}}
+	if h(same) != h([]config.SNMPClient{{Prefix: "10.0.0.0/8", Restrict: true}, {Prefix: "192.168.1.0/24"}}) {
+		t.Fatal("identical SNMP allowlist produced different hashes — idempotence broken")
+	}
+}

--- a/pkg/daemon/daemon_snmp_reconcile.go
+++ b/pkg/daemon/daemon_snmp_reconcile.go
@@ -65,6 +65,27 @@ func snmpConfigHash(cfg *config.Config) uint64 {
 		write(name)
 		if c != nil {
 			write(c.Authorization)
+			// #5105: the community `clients` source-IP allowlist and its
+			// per-entry `restrict` (deny) bit are live authorization inputs
+			// enforced by SNMPCommunity.AllowsSource. A day-2 edit that changes
+			// ONLY the allowlist (same name + authorization) must NOT hash
+			// equal, or reconcile takes the idempotent no-op path and the
+			// running agent keeps the stale (possibly allow-all) source policy
+			// while the commit reports success. Hash the allowlist in DOCUMENT
+			// order (not sorted): AllowsSource resolves ties among equal-length
+			// prefixes by first-match (strict `>` on prefix bits), so element
+			// order is authorization-significant and must participate in the
+			// fingerprint. Identical config text yields identical order, so an
+			// unchanged stanza still hashes equal (no spurious reconcile).
+			write("clients")
+			for _, cl := range c.Clients {
+				write(cl.Prefix)
+				if cl.Restrict {
+					write("restrict")
+				} else {
+					write("allow")
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Problem

The SNMP reconcile idempotence hash (`snmpConfigHash`,
`pkg/daemon/daemon_snmp_reconcile.go`) wrote only the community name plus
`Authorization`, omitting the community `clients` source-IP allowlist and each
entry's `restrict` (deny) bit. Those fields are live authorization inputs
enforced by `SNMPCommunity.AllowsSource`.

A day-2 commit that added, changed, or removed a community's `clients` while
leaving name + authorization unchanged hashed **equal**, so `reconcileSNMP` took
the idempotent no-op path (`if d.snmpHashSet && h == d.snmpHash { return false }`)
and never called `Agent.UpdateConfig`. The running listener kept the old
(often allow-all) source policy while the commit reported success — a committed
source restriction silently failed to take effect, leaving SNMPv2c reachable
from unauthorized networks.

## Fix

Fold every `SNMPClient.Prefix` and its `Restrict` bit into the hash under a
`"clients"` domain separator, so any allowlist change changes the fingerprint
and triggers the in-place `UpdateConfig`.

- Hashed in **document order**, not sorted: element order is authorization-
  significant. `AllowsSource` resolves ties among equal-length prefixes by
  first match (strict `>` on prefix bits), so reordering two same-length entries
  with different `restrict` bits flips the decision. Identical config text yields
  identical order, so an unchanged stanza still hashes equal — idempotence
  preserved.
- `SNMPCommunity`'s only other field is the unexported, compiler-derived
  `clientNets` cache (not part of the config surface), so name + authorization +
  clients now covers **every** live authorization input — no other omitted field.

## Test

`TestSNMPConfigHashIncludesClients` (fail-on-revert) asserts allow-all →
restricted, a flipped `restrict` bit, a changed prefix, and restricted →
allow-all (removed allowlist) each change the hash, while an identical allowlist
hashes equal. Verified the test FAILS when the production hunk is reverted.

## Validation

- `go build ./...` — exit 0
- `go test ./pkg/daemon/... -run SNMP` — ok
- Fail-on-revert: stashed the production hunk, ran the test → FAIL
  (`allow-all -> restricted allowlist did not change the hash`), then restored → ok

No separate module doc change: the hash contract lives in the `snmpConfigHash`
doc comment, which this change extends inline.

Closes #5105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi