### PR TITLE
daemon: clamp --api-addr off-loopback bind on every path (#5127)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -189,16 +189,23 @@ editing cmdtree.
     new config that binds off-loopback without api-auth (downgraded to a
     warning on the tolerant load / peer-sync path so an already-persisted
     config still boots — #1960); and (B) a **runtime fail-safe clamp**
-    (`clampBindToLoopback` in `pkg/daemon`, applied in `daemon_run.go`) that,
-    when the resolved bind is non-loopback and `apiCfg.Auth == nil`, pulls the
-    bind back to a same-family loopback (`127.0.0.1` for IPv4, `::1` for IPv6,
-    port preserved) and WARNs — so a leniently-loaded vulnerable config comes up
-    on loopback (console/SSH remain the lifeline) instead of exposed. The
-    non-loopback test (`hostIsLoopback`) treats the Go wildcard spelling
-    `:port`/`[::]:port` (an empty or unspecified host after `SplitHostPort`) and
-    any unparseable host as **non-loopback** so `--api-addr :8080` with no
-    api-auth is clamped, not left listening on every interface (#4903); only a
-    genuine loopback IP or the literal `localhost` is exempt. The bind
+    (`clampBindToLoopback` in `pkg/daemon`, applied in `resolveAPIBinds` /
+    `daemon_run.go`) that, when the resolved bind is non-loopback and
+    `apiCfg.Auth == nil`, pulls the bind back to a same-family loopback
+    (`127.0.0.1` for IPv4, `::1` for IPv6, port preserved) and WARNs — so a
+    leniently-loaded vulnerable config comes up on loopback (console/SSH remain
+    the lifeline) instead of exposed. This clamp runs **unconditionally on every
+    startup path** — `resolveAPIBinds` derives the bind/auth from the
+    web-management stanza (if any) and then always applies the clamp, so it also
+    covers a `--api-addr <routable>` flag with **no** `system services
+    web-management` block at all (#5127). Before #5127 the clamp lived inside the
+    web-management block and that flag path bound the mutating API off-loopback
+    unauthenticated. The non-loopback test (`hostIsLoopback`) treats the Go
+    wildcard spelling `:port`/`[::]:port` (an empty or unspecified host after
+    `SplitHostPort`) and any unparseable host as **non-loopback** so
+    `--api-addr :8080` with no api-auth is clamped, not left listening on every
+    interface (#4903); only a genuine loopback IP or the literal `localhost` is
+    exempt. The bind
     address is built with `net.JoinHostPort` so an IPv6 mgmt address is bracketed
     and both the clamp and `net.Listen` parse it. Adding api-auth and recommitting
     restores the off-loopback bind. HTTPS is covered by the same rule

--- a/pkg/daemon/api_bind_clamp_5127_test.go
+++ b/pkg/daemon/api_bind_clamp_5127_test.go
@@ -1,0 +1,90 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/api"
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestResolveAPIBindsClampsWithoutWebManagement pins the #5127 fix: the #4047
+// loopback fail-safe must clamp a non-loopback bind even when NO `system
+// services web-management` stanza exists — the plain `--api-addr` path. Before
+// the fix the clamp lived INSIDE the web-management block, so a config with no
+// web-management (or a nil active config) skipped the clamp and bound the
+// mutating REST/config API off-loopback UNAUTHENTICATED. resolveAPIBinds now
+// runs the clamp on every path; reverting it (clamp back inside the
+// web-management block) makes the no-web-management cases below FAIL.
+func TestResolveAPIBindsClampsWithoutWebManagement(t *testing.T) {
+	d := &Daemon{}
+	cases := []struct {
+		name     string
+		cfg      *config.Config
+		inAddr   string
+		wantAddr string
+	}{
+		{"nil config off-loopback wildcard clamps", nil, "0.0.0.0:8080", "127.0.0.1:8080"},
+		{"nil config routable v4 clamps", nil, "10.0.0.5:8080", "127.0.0.1:8080"},
+		{"empty config (no web-management) clamps", &config.Config{}, "192.168.1.1:8080", "127.0.0.1:8080"},
+		{"empty config v6 off-loopback clamps to v6 loopback", &config.Config{}, "[2001:db8::1]:8080", "[::1]:8080"},
+		{"nil config default loopback untouched", nil, "127.0.0.1:8080", "127.0.0.1:8080"},
+		{"empty config v6 loopback untouched", &config.Config{}, "[::1]:8080", "[::1]:8080"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			apiCfg := api.Config{Addr: c.inAddr}
+			d.resolveAPIBinds(&apiCfg, c.cfg)
+			if apiCfg.Addr != c.wantAddr {
+				t.Fatalf("resolveAPIBinds Addr = %q, want %q", apiCfg.Addr, c.wantAddr)
+			}
+			if apiCfg.Auth != nil {
+				t.Fatalf("Auth = %v, want nil (no web-management config)", apiCfg.Auth)
+			}
+		})
+	}
+}
+
+// TestResolveAPIBindsClampsHTTPSWithoutWebManagement pins that the HTTPS
+// listener is clamped on the no-web-management path too, so an off-loopback
+// TLS bind (set by some future flag / default) cannot serve the mutating API
+// unauthenticated either.
+func TestResolveAPIBindsClampsHTTPSWithoutWebManagement(t *testing.T) {
+	d := &Daemon{}
+	apiCfg := api.Config{
+		Addr:      "0.0.0.0:8080",
+		TLS:       true,
+		HTTPSAddr: "0.0.0.0:8443",
+	}
+	d.resolveAPIBinds(&apiCfg, nil)
+	if apiCfg.Addr != "127.0.0.1:8080" {
+		t.Fatalf("HTTP Addr = %q, want 127.0.0.1:8080", apiCfg.Addr)
+	}
+	if apiCfg.HTTPSAddr != "127.0.0.1:8443" {
+		t.Fatalf("HTTPS Addr = %q, want 127.0.0.1:8443", apiCfg.HTTPSAddr)
+	}
+}
+
+// TestResolveAPIBindsRespectsWebManagementAuth pins that an off-loopback bind
+// WITH api-auth derived from a web-management stanza is preserved
+// (authenticated off-loopback is allowed). It guards that the now-unconditional
+// clamp still derives + respects web-management api-auth, and that the
+// extraction of resolveAPIBinds kept the auth-derivation intact.
+func TestResolveAPIBindsRespectsWebManagementAuth(t *testing.T) {
+	d := &Daemon{}
+	cfg := &config.Config{}
+	cfg.System.Services = &config.SystemServicesConfig{
+		WebManagement: &config.WebManagementConfig{
+			APIAuth: &config.APIAuthConfig{
+				Users: []*config.APIAuthUser{{Username: "admin", Password: config.Secret("secret")}},
+			},
+		},
+	}
+	apiCfg := api.Config{Addr: "10.0.0.5:8080"}
+	d.resolveAPIBinds(&apiCfg, cfg)
+	if apiCfg.Addr != "10.0.0.5:8080" {
+		t.Fatalf("authenticated off-loopback Addr = %q, want it preserved", apiCfg.Addr)
+	}
+	if apiCfg.Auth == nil || apiCfg.Auth.Users["admin"] != "secret" {
+		t.Fatalf("Auth = %+v, want derived from web-management api-auth", apiCfg.Auth)
+	}
+}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1300,8 +1300,35 @@ func (d *Daemon) startHTTPServer(ctx context.Context, wg *sync.WaitGroup, eventB
 			return d.grpcSrv
 		},
 	}
-	// Resolve interface bindings from web-management config
-	if cfg := d.store.ActiveConfig(); cfg != nil && cfg.System.Services != nil &&
+	// Resolve interface bindings + api-auth from web-management config, then
+	// apply the #4047/#5127 loopback fail-safe on EVERY path (resolveAPIBinds).
+	d.resolveAPIBinds(&apiCfg, d.store.ActiveConfig())
+	srv := api.NewServer(apiCfg)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := srv.Run(ctx); err != nil {
+			slog.Error("API server error", "err", err)
+		}
+	}()
+	slog.Info("HTTP API server started", "addr", d.opts.APIAddr)
+}
+
+// resolveAPIBinds finalizes the HTTP/HTTPS listen addresses, TLS flag, and
+// api-auth on apiCfg from the active web-management config, then applies the
+// #4047/#5127 loopback fail-safe clamp. It is split out of startHTTPServer so
+// the bind/auth/clamp decision is unit-testable without opening a socket.
+//
+// cfg is the active config; it may be nil or lack a `system services
+// web-management` stanza. The KEY invariant (#5127): the loopback clamp runs
+// UNCONDITIONALLY — even when no web-management block exists — because
+// apiCfg.Addr defaults to the `--api-addr` flag, which an operator can point
+// off-loopback with no web-management stanza at all. Before #5127 the clamp
+// lived INSIDE the web-management block, so that flag path bound the mutating
+// REST/config API (set / commit / rollback / DHCP / system-action) to the
+// network UNAUTHENTICATED, defeating the #4047 fail-safe.
+func (d *Daemon) resolveAPIBinds(apiCfg *api.Config, cfg *config.Config) {
+	if cfg != nil && cfg.System.Services != nil &&
 		cfg.System.Services.WebManagement != nil {
 		wm := cfg.System.Services.WebManagement
 		// Bind HTTP to configured interface
@@ -1339,41 +1366,36 @@ func (d *Daemon) startHTTPServer(ctx context.Context, wg *sync.WaitGroup, eventB
 			apiCfg.Auth = authCfg
 			slog.Info("HTTP API authentication enabled", "users", len(wm.APIAuth.Users), "api_keys", len(wm.APIAuth.APIKeys))
 		}
-		// #4047 part B: runtime fail-safe clamp. The commit gate
-		// (validateWebManagementAuthStrict, pkg/config) rejects a NEW
-		// web-management config that binds the unauthenticated REST/config API
-		// off-loopback without api-auth, but an ALREADY-PERSISTED such config
-		// is lenient-loaded (warn, no brick — #1960) and would still bind
-		// non-loopback UNAUTHENTICATED after upgrade, exposing the mutating
-		// config endpoints (set / commit / rollback / system action) to the
-		// network. clampBindToLoopback pulls a non-loopback + no-auth bind back
-		// to a loopback of the same family and WARNs: the daemon still boots,
-		// the web API stays reachable on loopback, and the console/SSH remain
-		// the lifeline (device-map §9.6 posture) until the operator adds
-		// api-auth (which restores the non-loopback bind).
-		hasAuth := apiCfg.Auth != nil
-		if clamped, ok := clampBindToLoopback(apiCfg.Addr, hasAuth); ok {
-			slog.Warn("web-management HTTP bind is non-loopback without api-auth; clamping to loopback (add `set system services web-management api-auth` to bind off-loopback) — #4047",
-				"requested", apiCfg.Addr, "clamped", clamped)
-			apiCfg.Addr = clamped
-		}
-		if apiCfg.TLS {
-			if clamped, ok := clampBindToLoopback(apiCfg.HTTPSAddr, hasAuth); ok {
-				slog.Warn("web-management HTTPS bind is non-loopback without api-auth; clamping to loopback — #4047",
-					"requested", apiCfg.HTTPSAddr, "clamped", clamped)
-				apiCfg.HTTPSAddr = clamped
-			}
+	}
+
+	// #4047 part B / #5127: runtime fail-safe clamp, applied on EVERY path
+	// (whether or not a web-management stanza exists). The commit gate
+	// (validateWebManagementAuthStrict, pkg/config) rejects a NEW web-management
+	// config that binds the unauthenticated REST/config API off-loopback without
+	// api-auth, but an ALREADY-PERSISTED such config is lenient-loaded (warn, no
+	// brick — #1960), AND the `--api-addr` flag has no commit gate at all
+	// (#5127). Either can bind non-loopback UNAUTHENTICATED, exposing the
+	// mutating config endpoints (set / commit / rollback / DHCP / system-action)
+	// to the network. clampBindToLoopback is a no-op when the bind is already
+	// loopback OR api-auth is configured, so the default 127.0.0.1:8080 path and
+	// an authenticated off-loopback web-management bind are unaffected; it only
+	// pulls a non-loopback + no-auth bind back to a same-family loopback and
+	// WARNs. The daemon still boots and the web API stays reachable on loopback,
+	// with the console/SSH the lifeline (device-map §9.6 posture) until the
+	// operator adds api-auth (which restores the non-loopback bind).
+	hasAuth := apiCfg.Auth != nil
+	if clamped, ok := clampBindToLoopback(apiCfg.Addr, hasAuth); ok {
+		slog.Warn("HTTP API bind is non-loopback without api-auth; clamping to loopback (add `set system services web-management api-auth` to bind off-loopback) — #4047/#5127",
+			"requested", apiCfg.Addr, "clamped", clamped)
+		apiCfg.Addr = clamped
+	}
+	if apiCfg.TLS {
+		if clamped, ok := clampBindToLoopback(apiCfg.HTTPSAddr, hasAuth); ok {
+			slog.Warn("HTTPS API bind is non-loopback without api-auth; clamping to loopback — #4047/#5127",
+				"requested", apiCfg.HTTPSAddr, "clamped", clamped)
+			apiCfg.HTTPSAddr = clamped
 		}
 	}
-	srv := api.NewServer(apiCfg)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if err := srv.Run(ctx); err != nil {
-			slog.Error("API server error", "err", err)
-		}
-	}()
-	slog.Info("HTTP API server started", "addr", d.opts.APIAddr)
 }
 
 // initManagers eagerly constructs the daemon's subsystem managers (routing,


### PR DESCRIPTION
## Summary

The `#4047` runtime fail-safe (`clampBindToLoopback` — pulls a non-loopback
REST/config API bind back to a same-family loopback when no api-auth is
configured) lived **inside** the `system services web-management` branch of
`startHTTPServer`, so it only ran when a web-management stanza existed.

With **no** web-management stanza, `apiCfg.Addr` defaults to the `--api-addr`
flag (`cmd/xpfd`, default `127.0.0.1:8080`) and nothing clamped it:
`xpfd --api-addr 0.0.0.0:8080` (or any routable address) bound the mutating
endpoints (`config set/delete/commit/rollback`, DHCP, `system/action`) to the
network **UNAUTHENTICATED**. This is the `pkg/api` analog of the merged `#5170`
`clampGRPCBindToLoopback` fix for `--grpc-addr`.

## Fix

- Extract the bind/auth/clamp logic into a new `resolveAPIBinds` method. It
  derives HTTP/HTTPS addresses, TLS, and api-auth from the web-management stanza
  exactly as before (when present), then applies `clampBindToLoopback`
  **unconditionally** — outside the web-management branch — so the flag-only
  path is covered too.
- The clamp is a no-op when the bind is already loopback **or** api-auth is
  configured: the default `127.0.0.1:8080` bind and an authenticated
  off-loopback web-management bind are unaffected. HTTPS is clamped by the same
  rule.
- Splitting the decision into a socket-free method makes it unit-testable.

## Test (fail-on-revert)

`pkg/daemon/api_bind_clamp_5127_test.go` asserts a non-loopback bind with a nil
/ no-web-management config clamps to the same-family loopback (v4 and v6, HTTP
and HTTPS), a loopback bind is left untouched, and an off-loopback bind **with**
web-management api-auth is preserved. The no-web-management cases FAIL if the
clamp is reverted back inside the web-management branch, pinning the fix.

## Docs

`docs/architecture.md` (`#4047` clamp paragraph) updated to state the clamp runs
unconditionally via `resolveAPIBinds` and now covers the
`--api-addr`-with-no-web-management path.

## Validation

```
GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...        -> build_exit=0
GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/api/... -> ok
go test ./pkg/daemon/ (incl. new ResolveAPIBinds tests)        -> ok
```

Closes #5127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi