### PR TITLE
grpcapi: reap diag child on scanner-error path (#5060)

### DIFF
--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -243,6 +243,18 @@ contract.
   the HTTP path), both capped at the 150s `diagExecCeiling`; the same
   formulas live in `pkg/api/exec_timeout.go` for the REST siblings, and
   `streamDiagCmd` kills the child promptly when a stream send fails.
+  `streamDiagCmd` must also reap the child on the scanner-error path
+  (#5060): a combined-output line larger than the scanner token cap
+  yields `bufio.ErrTooLong`, and — exactly as on the send-failure path —
+  the scan goroutine must `cancel()` + `pr.Close()` before the waiter
+  returns, or exec.Cmd's internal copy goroutine stays wedged in
+  `pw.Write` (WaitDelay closes only the exec-owned OS pipes, not this
+  `io.Pipe`) and the RPC leaks past the deadline. The cleanup is a
+  `defer` so it fires on every scanner exit; the per-line token is a
+  deliberate `Scanner.Buffer` cap (`diagScanMaxToken`), and each
+  operator-supplied field (target/source/routing-instance) is bounded at
+  `maxDiagArgLen` at the RPC boundary so a multi-kilobyte argument is
+  rejected with `InvalidArgument` before it can reach exec.
   The argv builders (`buildPingArgv`/`buildTracerouteArgv`) place the
   user-supplied target after a `--` end-of-options separator so a
   `-`-prefixed target is an operand, not a flag (option-confusion

--- a/pkg/grpcapi/server_diag_ping.go
+++ b/pkg/grpcapi/server_diag_ping.go
@@ -17,9 +17,48 @@ import (
 
 // --- Diagnostic RPCs ---
 
+// maxDiagArgLen bounds each operator-supplied diagnostic argument
+// (target, source, routing-instance) at the RPC boundary. A DNS name is
+// capped at 253 octets (RFC 1035), an IPv6 literal at ~45, and a VRF
+// name is short, so 512 accepts every legitimate value while rejecting a
+// pathological field far below the streamDiagCmd line-scanner token cap.
+// The gRPC receive limit is 16 MiB, so without this bound a multi-kilobyte
+// target reaches exec and surfaces as a single combined-output line larger
+// than the scanner token size — the ErrTooLong leak vector fixed in
+// streamDiagCmd (#5060).
+const maxDiagArgLen = 512
+
+// checkDiagArg rejects an over-length diagnostic argument with
+// InvalidArgument so an oversized field never reaches exec or the
+// combined-output line scanner.
+func checkDiagArg(name, v string) error {
+	if len(v) > maxDiagArgLen {
+		return status.Errorf(codes.InvalidArgument,
+			"%s exceeds %d bytes (%d)", name, maxDiagArgLen, len(v))
+	}
+	return nil
+}
+
+// checkDiagArgs bounds the shared ping/traceroute fields in one pass.
+func checkDiagArgs(target, source, routingInstance string) error {
+	for _, f := range []struct{ name, val string }{
+		{"target", target},
+		{"source", source},
+		{"routing-instance", routingInstance},
+	} {
+		if err := checkDiagArg(f.name, f.val); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *Server) Ping(req *pb.PingRequest, stream grpc.ServerStreamingServer[pb.PingResponse]) error {
 	if req.Target == "" {
 		return status.Error(codes.InvalidArgument, "target required")
+	}
+	if err := checkDiagArgs(req.Target, req.Source, req.RoutingInstance); err != nil {
+		return err
 	}
 	count := int(req.Count)
 	if count <= 0 {
@@ -58,6 +97,9 @@ func (s *Server) Traceroute(req *pb.TracerouteRequest, stream grpc.ServerStreami
 	if req.Target == "" {
 		return status.Error(codes.InvalidArgument, "target required")
 	}
+	if err := checkDiagArgs(req.Target, req.Source, req.RoutingInstance); err != nil {
+		return err
+	}
 	cmd := buildTracerouteArgv(req)
 
 	return streamDiagCmd(stream.Context(), diagTracerouteTimeout, cmd, func(line string) error {
@@ -76,6 +118,18 @@ func buildTracerouteArgv(req *pb.TracerouteRequest) []string {
 		RoutingInstance: req.RoutingInstance,
 	})
 }
+
+// diagScanInitToken / diagScanMaxToken size the combined-output line
+// scanner in streamDiagCmd. The max is set explicitly (rather than
+// relying on the bufio default) to make the per-line ceiling a
+// deliberate, documented bound: a line beyond it is a controlled
+// bufio.ErrTooLong that the streamDiagCmd cleanup path reaps without
+// leaking the child or scan goroutine (#5060). Diag output lines are
+// short, so 64 KiB is generous.
+const (
+	diagScanInitToken = 4 << 10  // 4 KiB initial scanner buffer
+	diagScanMaxToken  = 64 << 10 // 64 KiB hard per-line cap
+)
 
 // streamDiagCmd runs a command and streams each line of combined output
 // via sendFn. timeout is request-sized by the caller (#1819, see the
@@ -106,21 +160,32 @@ func streamDiagCmd(ctx context.Context, timeout time.Duration, cmd []string, sen
 
 	// Scan lines and stream each one.
 	scanner := bufio.NewScanner(pr)
+	// Bound the per-line token deliberately (#5060): a combined-output
+	// line longer than diagScanMaxToken is a controlled bufio.ErrTooLong,
+	// not an unbounded allocation.
+	scanner.Buffer(make([]byte, 0, diagScanInitToken), diagScanMaxToken)
 	scanDone := make(chan error, 1)
 	go func() {
+		// Own and close BOTH pipe ends on EVERY exit path — the
+		// send-failure path AND the scanner-error/EOF path (#5060).
+		// Whenever the scanner stops reading pr (a sendFn failure, or a
+		// scanner error such as bufio.ErrTooLong from a line beyond
+		// diagScanMaxToken), exec.Cmd's internal copy goroutine can be
+		// blocked in pw.Write; WaitDelay closes only the exec-owned OS
+		// pipes, not this io.Pipe, so without pr.Close() that write
+		// never returns, c.Wait() below never returns, and the RPC plus
+		// this goroutine leak past the deadline. pr.Close() makes the
+		// blocked write return ErrClosedPipe; cancel() kills the child
+		// promptly. Both are idempotent and harmless on the normal EOF
+		// path — pr is already drained and the child already exited.
+		// (Codex review on PR #1823 established the send-failure half;
+		// #5060 extends it to the scanner-error path.)
+		defer func() {
+			cancel()
+			_ = pr.Close()
+		}()
 		for scanner.Scan() {
 			if err := sendFn(scanner.Text()); err != nil {
-				// Nobody reads the pipe after this point — kill the
-				// child now instead of letting it block on writes for
-				// the rest of the budget, AND close the read end:
-				// exec.Cmd's internal copy goroutine may already be
-				// blocked in pw.Write on a burst the scanner never
-				// consumed, and WaitDelay only closes the exec-owned
-				// OS pipes, not this io.Pipe — pr.Close makes that
-				// blocked write return ErrClosedPipe so c.Wait can
-				// finish (Codex review on PR #1823).
-				cancel()
-				pr.Close()
 				scanDone <- err
 				return
 			}

--- a/pkg/grpcapi/server_diag_scanner_leak_5060_test.go
+++ b/pkg/grpcapi/server_diag_scanner_leak_5060_test.go
@@ -1,0 +1,144 @@
+package grpcapi
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestStreamDiagCmdErrTooLongNoLeak is the #5060 fail-on-revert guard for
+// the scanner-error path. A child emits a single combined-output line
+// larger than the scanner token cap (diagScanMaxToken) with no newline
+// and then blocks — bufio.Scanner returns bufio.ErrTooLong and the scan
+// goroutine stops reading pr. Before the fix, the scanner-error branch
+// (scanDone <- scanner.Err()) closed nothing, so exec.Cmd's internal copy
+// goroutine stayed blocked in pw.Write (WaitDelay closes only the
+// exec-owned OS pipes, not this io.Pipe), c.Wait() never returned, and the
+// RPC + goroutines leaked past the deadline. The fix closes pr and cancels
+// on every scanner exit, so streamDiagCmd returns bufio.ErrTooLong
+// promptly.
+//
+// Revert the defer{cancel();pr.Close()} in streamDiagCmd and this test
+// fails: streamDiagCmd blocks until at least requestExecWaitDelay (5s) or
+// forever, tripping the 4s watchdog below.
+func TestStreamDiagCmdErrTooLongNoLeak(t *testing.T) {
+	// 80 KiB of a single character, no newline: comfortably past the
+	// 64 KiB diagScanMaxToken cap. The trailing `cat` keeps the child
+	// alive after the burst so, on a reverted build, the copy goroutine
+	// is genuinely wedged in pw.Write rather than racing a child exit.
+	const oversized = diagScanMaxToken + (16 << 10)
+	script := fmt.Sprintf("head -c %d /dev/zero | tr '\\0' a; exec cat", oversized)
+	cmd := []string{"sh", "-c", script}
+
+	baseline := runtime.NumGoroutine()
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		done <- streamDiagCmd(context.Background(), 30*time.Second, cmd,
+			func(string) error { return nil })
+	}()
+
+	// The fixed path returns in milliseconds. A revert blocks until
+	// requestExecWaitDelay (5s) at best, or forever; a 4s watchdog fails
+	// fast on revert instead of stalling the suite for the package
+	// timeout.
+	watchdog := requestExecWaitDelay - time.Second
+	select {
+	case err := <-done:
+		if !errors.Is(err, bufio.ErrTooLong) {
+			t.Fatalf("streamDiagCmd = %v, want bufio.ErrTooLong on the oversized-line path", err)
+		}
+		t.Logf("streamDiagCmd returned ErrTooLong in %v", time.Since(start))
+	case <-time.After(watchdog):
+		t.Fatalf("streamDiagCmd did not return within %v on the scanner-error path: "+
+			"child/copy goroutine leaked (pr not closed on scanner.Err())", watchdog)
+	}
+
+	// Backstop: the scan goroutine and exec copy goroutine must have
+	// exited. Poll briefly for the runtime to settle.
+	assertGoroutinesSettle(t, baseline)
+}
+
+// assertGoroutinesSettle waits (bounded) for the live goroutine count to
+// fall back to the baseline, tolerating a small amount of runtime slack.
+func assertGoroutinesSettle(t *testing.T, baseline int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		runtime.Gosched()
+		n := runtime.NumGoroutine()
+		if n <= baseline+1 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("goroutine leak on scanner-error path: baseline=%d now=%d", baseline, n)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+// TestDiagFieldLengthRejected pins the #5060 RPC-boundary bound: Ping and
+// Traceroute reject an over-length target/source/routing-instance with
+// InvalidArgument before it can reach exec or the combined-output line
+// scanner. Validation runs before the stream is touched, so a nil stream
+// is safe here. Revert the checkDiagArgs calls and this test fails.
+func TestDiagFieldLengthRejected(t *testing.T) {
+	huge := make([]byte, maxDiagArgLen+1)
+	for i := range huge {
+		huge[i] = 'a'
+	}
+	oversized := string(huge)
+	legit := "192.0.2.1"
+
+	s := &Server{}
+
+	pingCases := []struct {
+		name string
+		req  *pb.PingRequest
+	}{
+		{"target", &pb.PingRequest{Target: oversized}},
+		{"source", &pb.PingRequest{Target: legit, Source: oversized}},
+		{"routing-instance", &pb.PingRequest{Target: legit, RoutingInstance: oversized}},
+	}
+	for _, c := range pingCases {
+		t.Run("ping/"+c.name, func(t *testing.T) {
+			err := s.Ping(c.req, nil)
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("Ping oversized %s = %v, want InvalidArgument", c.name, err)
+			}
+		})
+	}
+
+	traceCases := []struct {
+		name string
+		req  *pb.TracerouteRequest
+	}{
+		{"target", &pb.TracerouteRequest{Target: oversized}},
+		{"source", &pb.TracerouteRequest{Target: legit, Source: oversized}},
+		{"routing-instance", &pb.TracerouteRequest{Target: legit, RoutingInstance: oversized}},
+	}
+	for _, c := range traceCases {
+		t.Run("traceroute/"+c.name, func(t *testing.T) {
+			err := s.Traceroute(c.req, nil)
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("Traceroute oversized %s = %v, want InvalidArgument", c.name, err)
+			}
+		})
+	}
+
+	// A legitimate short target must still pass validation (it fails
+	// later at exec, not at the bound) — assert the bound does not reject
+	// it with InvalidArgument.
+	if err := checkDiagArgs(legit, "", ""); err != nil {
+		t.Fatalf("checkDiagArgs rejected a legitimate target: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`pkg/grpcapi.streamDiagCmd` leaked an RPC and goroutines on the scanner-error path. The combined-output line scanner used the default 64 KiB bufio token with no `Scanner.Buffer`, and only the send-failure branch cancelled the context and closed the `io.Pipe` read end. The `scanner.Err()` branch (`scanDone <- scanner.Err()`) closed nothing.

`Ping` accepts any nonempty target with no length bound (gRPC recv cap 16 MiB), so a ~70 KB target yields a single ping-error line larger than 64 KiB → `bufio.ErrTooLong`. On that path the scan goroutine returned without closing `pr`, exec.Cmd's internal copy goroutine stayed blocked in `pw.Write`, and `c.Wait()` blocked on it. `CommandContext`/`WaitDelay` close only the exec-owned OS pipes, not this custom `io.Pipe`, so the RPC and goroutines leaked past the deadline.

## Fix

- **Reap on every scanner exit:** move `cancel()` + `pr.Close()` into a `defer` in the scan goroutine, so both pipe ends are closed on the send-failure path **and** the scanner-error/EOF path. `pr.Close()` makes the wedged `pw.Write` return `ErrClosedPipe` so `c.Wait()` finishes; idempotent/harmless on the normal EOF path.
- **Deliberate token cap:** `Scanner.Buffer` with an explicit 64 KiB per-line max (`diagScanMaxToken`) — an oversized line is a controlled `ErrTooLong`, not reliance on the bufio default.
- **RPC-boundary field bound:** every operator-supplied diag field (target/source/routing-instance) is capped at `maxDiagArgLen` (512 bytes) in `Ping` and `Traceroute`, rejected with `InvalidArgument` before it can reach exec or the scanner. 512 accepts any RFC 1035 hostname (253), IPv6 literal, or VRF name.

## Tests (fail-on-revert)

- `TestStreamDiagCmdErrTooLongNoLeak` — child emits an 80 KiB newline-free line then blocks; asserts `streamDiagCmd` returns `bufio.ErrTooLong` well within a 4s watchdog (below the 5s `WaitDelay`) and that goroutines settle. Verified: fixed path returns in ~3 ms; reverting the `defer` hangs the call to the 4s deadline (WaitDelay does **not** rescue the `io.Pipe`), so the test fails.
- `TestDiagFieldLengthRejected` — pins the per-field bound on both RPCs.

## Validation

- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` → exit 0
- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/grpcapi/...` → exit 0
- `pkg/grpcapi/README.md` updated with the scanner-error reap contract and the field bound.

Closes #5060

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi