### PR TITLE
dataplane/userspace: route batch/clear session deletes to the authoritative helper (#5096)

### DIFF
--- a/pkg/dataplane/userspace/legacy_dataplane.go
+++ b/pkg/dataplane/userspace/legacy_dataplane.go
@@ -395,6 +395,44 @@ func (a *LegacyDataPlaneAdapter) DeleteSessionV6(key dataplane.SessionKeyV6) err
 	return m.DeleteSessionV6(key)
 }
 
+// BatchDeleteSessions overrides the promoted bpfShim batch delete so the
+// authoritative Rust helper is told to delete every key too (#5096). Without
+// this override Go method promotion routes policy-invalidation and cluster-
+// stale batch deletes (dataPlaneSessionStore.batchDeleteV4 -> s.dp.Batch...)
+// to the BPF mirror ONLY, leaving the helper forwarding under the revoked
+// decision until it re-publishes the mirror. The singular DeleteSession
+// override already routes per-session deletes to the helper; see
+// Manager.BatchDeleteSessions.
+func (a *LegacyDataPlaneAdapter) BatchDeleteSessions(keys []dataplane.SessionKey) (int, error) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return 0, err
+	}
+	return m.BatchDeleteSessions(keys)
+}
+
+// BatchDeleteSessionsV6 is the IPv6 analogue of BatchDeleteSessions (#5096).
+func (a *LegacyDataPlaneAdapter) BatchDeleteSessionsV6(keys []dataplane.SessionKeyV6) (int, error) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return 0, err
+	}
+	return m.BatchDeleteSessionsV6(keys)
+}
+
+// ClearAllSessions overrides the promoted bpfShim clear-all so an operator
+// `clear security flow session all` reaches the authoritative Rust helper and
+// not merely the BPF mirror (#5096). Without it the promoted bpfShim clear
+// empties the mirror only; the helper keeps forwarding under revoked decisions
+// until it re-publishes the mirror ~10s later. See Manager.ClearAllSessions.
+func (a *LegacyDataPlaneAdapter) ClearAllSessions() (int, int, error) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return 0, 0, err
+	}
+	return m.ClearAllSessions()
+}
+
 func (a *LegacyDataPlaneAdapter) SetDeferWorkers(v bool) {
 	m, err := a.managerOrErr()
 	if err != nil {

--- a/pkg/dataplane/userspace/legacy_dataplane_batchclear_5096_test.go
+++ b/pkg/dataplane/userspace/legacy_dataplane_batchclear_5096_test.go
@@ -1,0 +1,175 @@
+package userspace
+
+import (
+	"encoding/json"
+	"net"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// fakeHelperDeleteRecorder is a minimal stand-in for the Rust helper's session
+// control socket. It records every sync_session request it receives so a test
+// can assert the authoritative helper actually saw the delete (#5096).
+type fakeHelperDeleteRecorder struct {
+	ln   net.Listener
+	mu   sync.Mutex
+	reqs []SessionSyncRequest
+}
+
+func startFakeHelperDeleteRecorder(t *testing.T, sockPath string) *fakeHelperDeleteRecorder {
+	t.Helper()
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen helper session socket: %v", err)
+	}
+	r := &fakeHelperDeleteRecorder{ln: ln}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				var req ControlRequest
+				if err := json.NewDecoder(conn).Decode(&req); err == nil {
+					if req.SessionSync != nil {
+						r.mu.Lock()
+						r.reqs = append(r.reqs, *req.SessionSync)
+						r.mu.Unlock()
+					}
+				}
+				// The client blocks on this response, so by the time the
+				// adapter call returns the request above is already recorded.
+				_ = json.NewEncoder(conn).Encode(ControlResponse{OK: true})
+			}()
+		}
+	}()
+	return r
+}
+
+// deletedIP reports whether a request with the given operation and src/dst IP
+// strings was recorded.
+func (r *fakeHelperDeleteRecorder) deletedIP(op, srcIP, dstIP string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, req := range r.reqs {
+		if req.Operation == op && req.SrcIP == srcIP && req.DstIP == dstIP {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *fakeHelperDeleteRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.reqs)
+}
+
+// TestBatchAndClearRouteToHelper5096 is the fail-on-revert guard for #5096.
+//
+// The batch/clear session mutations must reach the authoritative Rust helper,
+// not just the BPF mirror. Reverting either the LegacyDataPlaneAdapter overrides
+// (so Go promotion dispatches to the embedded bpfShim only) OR the Manager's
+// helper-delete plumbing leaves the fake helper with zero recorded deletes and
+// fails this test RED — the exact partial-apply / clear-all-doesn't-clear
+// security bypass the issue describes.
+func TestBatchAndClearRouteToHelper5096(t *testing.T) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("RemoveMemlock: %v", err)
+	}
+	dir := t.TempDir()
+	controlSock := filepath.Join(dir, "control.sock")
+	sessionSock := filepath.Join(dir, "userspace-dp-sessions.sock")
+	rec := startFakeHelperDeleteRecorder(t, sessionSock)
+
+	m := New()
+	m.proc = &exec.Cmd{}
+	m.cfg.ControlSocket = controlSock
+	injectSessionMaps(t, m)
+
+	// The adapter is what dataPlaneSessionStore.s.dp resolves to on the
+	// userspace path, so exercising it reproduces the real dispatch that the
+	// promotion bug corrupts.
+	adapter := NewLegacyDataPlaneAdapter(m)
+
+	// --- BatchDeleteSessions (IPv4) ---
+	v4Key := dataplane.SessionKey{
+		SrcIP:    [4]byte{10, 0, 61, 102},
+		DstIP:    [4]byte{172, 16, 80, 200},
+		SrcPort:  hostToNetwork16(50952),
+		DstPort:  hostToNetwork16(5201),
+		Protocol: 6,
+	}
+	if err := m.bpfShim.SetSessionV4(v4Key, dataplane.SessionValue{}); err != nil {
+		t.Fatalf("seed v4 session: %v", err)
+	}
+	if _, err := adapter.BatchDeleteSessions([]dataplane.SessionKey{v4Key}); err != nil {
+		t.Fatalf("BatchDeleteSessions: %v", err)
+	}
+	if !rec.deletedIP("delete", "10.0.61.102", "172.16.80.200") {
+		t.Fatalf("BatchDeleteSessions did not send helper delete for v4 key; recorded=%d", rec.count())
+	}
+
+	// --- BatchDeleteSessionsV6 ---
+	var v6Src, v6Dst [16]byte
+	copy(v6Src[:], net.ParseIP("2001:559:8585:ef00::100").To16())
+	copy(v6Dst[:], net.ParseIP("2001:559:8585:80::200").To16())
+	v6Key := dataplane.SessionKeyV6{
+		SrcIP:    v6Src,
+		DstIP:    v6Dst,
+		SrcPort:  hostToNetwork16(40000),
+		DstPort:  hostToNetwork16(5201),
+		Protocol: 6,
+	}
+	if err := m.bpfShim.SetSessionV6(v6Key, dataplane.SessionValueV6{}); err != nil {
+		t.Fatalf("seed v6 session: %v", err)
+	}
+	if _, err := adapter.BatchDeleteSessionsV6([]dataplane.SessionKeyV6{v6Key}); err != nil {
+		t.Fatalf("BatchDeleteSessionsV6: %v", err)
+	}
+	if !rec.deletedIP("delete", "2001:559:8585:ef00::100", "2001:559:8585:80::200") {
+		t.Fatalf("BatchDeleteSessionsV6 did not send helper delete for v6 key; recorded=%d", rec.count())
+	}
+
+	// --- ClearAllSessions (v4 + v6) ---
+	clearV4 := dataplane.SessionKey{
+		SrcIP:    [4]byte{10, 0, 61, 50},
+		DstIP:    [4]byte{172, 16, 80, 201},
+		SrcPort:  hostToNetwork16(33333),
+		DstPort:  hostToNetwork16(443),
+		Protocol: 6,
+	}
+	if err := m.bpfShim.SetSessionV4(clearV4, dataplane.SessionValue{}); err != nil {
+		t.Fatalf("seed clear v4 session: %v", err)
+	}
+	var clr6Src, clr6Dst [16]byte
+	copy(clr6Src[:], net.ParseIP("2001:559:8585:ef00::200").To16())
+	copy(clr6Dst[:], net.ParseIP("2001:559:8585:80::201").To16())
+	clearV6 := dataplane.SessionKeyV6{
+		SrcIP:    clr6Src,
+		DstIP:    clr6Dst,
+		SrcPort:  hostToNetwork16(44444),
+		DstPort:  hostToNetwork16(443),
+		Protocol: 6,
+	}
+	if err := m.bpfShim.SetSessionV6(clearV6, dataplane.SessionValueV6{}); err != nil {
+		t.Fatalf("seed clear v6 session: %v", err)
+	}
+	if _, _, err := adapter.ClearAllSessions(); err != nil {
+		t.Fatalf("ClearAllSessions: %v", err)
+	}
+	if !rec.deletedIP("delete", "10.0.61.50", "172.16.80.201") {
+		t.Fatalf("ClearAllSessions did not send helper delete for v4 key; recorded=%d", rec.count())
+	}
+	if !rec.deletedIP("delete", "2001:559:8585:ef00::200", "2001:559:8585:80::201") {
+		t.Fatalf("ClearAllSessions did not send helper delete for v6 key; recorded=%d", rec.count())
+	}
+}

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -1046,6 +1046,126 @@ func (m *Manager) DeleteSessionV6(key dataplane.SessionKeyV6) error {
 	return nil
 }
 
+// sessionHelperDeleteChunk bounds how many per-session helper "delete" IPCs the
+// batch/clear session paths transmit under a single control-socket unlock so a
+// large clear stays cooperative and cannot monopolize the shared control socket
+// (#5096). syncSessionRequestsLocked drops and reacquires m.mu once per chunk,
+// giving a concurrent snapshot publish a window between chunks.
+const sessionHelperDeleteChunk = 256
+
+// BatchDeleteSessions deletes a batch of IPv4 sessions from the BPF mirror AND
+// issues an authoritative "delete" to the Rust helper for every key (#5096).
+//
+// The LegacyDataPlaneAdapter embeds the bpfShim as its dataplane.DataPlane, so
+// without this method Go promotion would dispatch a batch delete to the mirror
+// map ONLY — leaving the helper, which owns packet lookup/lifetime, forwarding
+// under the just-revoked decision until it re-publishes the mirror ~10s later.
+// The singular DeleteSession already routes per-session deletes to the helper;
+// this does the same for the batch path used by policy invalidation and the
+// cluster-stale sweep. The bpf mirror's delete count is returned unchanged so
+// caller count semantics are preserved.
+func (m *Manager) BatchDeleteSessions(keys []dataplane.SessionKey) (int, error) {
+	deleted, err := m.bpfShim.BatchDeleteSessions(keys)
+	// Attempt the helper delete for every key regardless of the mirror result:
+	// a batch where a key vanished concurrently returns ErrKeyNotExist with a
+	// partial count, and the helper delete of an already-absent key is a no-op,
+	// so skipping on error would strand the still-present helper sessions.
+	m.deleteHelperSessionsV4(keys)
+	return deleted, err
+}
+
+// BatchDeleteSessionsV6 is the IPv6 analogue of BatchDeleteSessions (#5096).
+func (m *Manager) BatchDeleteSessionsV6(keys []dataplane.SessionKeyV6) (int, error) {
+	deleted, err := m.bpfShim.BatchDeleteSessionsV6(keys)
+	m.deleteHelperSessionsV6(keys)
+	return deleted, err
+}
+
+// ClearAllSessions clears the BPF mirror AND issues an authoritative "delete" to
+// the Rust helper for every session so an operator `clear security flow session
+// all` actually stops forwarding under revoked decisions (#5096). The helper
+// exposes no bulk-clear verb (only the per-session "delete" the singular path
+// uses), so every mirror key — forward AND reverse conntrack entries — is
+// snapshotted BEFORE the mirror is emptied and then deleted on the helper.
+// Returns the bpf mirror's (v4, v6, err) counts unchanged.
+func (m *Manager) ClearAllSessions() (int, int, error) {
+	var v4Keys []dataplane.SessionKey
+	if err := m.bpfShim.BatchIterateSessions(func(key dataplane.SessionKey, _ dataplane.SessionValue) bool {
+		v4Keys = append(v4Keys, key)
+		return true
+	}); err != nil {
+		slog.Debug("userspace: enumerate v4 sessions for helper clear failed", "err", err)
+	}
+	var v6Keys []dataplane.SessionKeyV6
+	if err := m.bpfShim.BatchIterateSessionsV6(func(key dataplane.SessionKeyV6, _ dataplane.SessionValueV6) bool {
+		v6Keys = append(v6Keys, key)
+		return true
+	}); err != nil {
+		slog.Debug("userspace: enumerate v6 sessions for helper clear failed", "err", err)
+	}
+
+	v4Deleted, v6Deleted, err := m.bpfShim.ClearAllSessions()
+
+	m.deleteHelperSessionsV4(v4Keys)
+	m.deleteHelperSessionsV6(v6Keys)
+
+	return v4Deleted, v6Deleted, err
+}
+
+// deleteHelperSessionsV4 tells the Rust helper to delete every key so the batch
+// and clear session paths converge the helper's authoritative session table
+// with the BPF mirror (#5096). Requests are transmitted in bounded chunks (see
+// sessionHelperDeleteChunk) so a large clear does not monopolize the shared
+// control socket. A helper IPC error is logged inside syncSessionRequestsLocked
+// but is not fatal — mirroring the singular DeleteSession path, which likewise
+// treats the helper delete as best-effort (the periodic session sync and GC
+// delta reconcile any transient miss). A "delete" request built with a nil
+// value carries only the 5-tuple, so no snapshot read happens under m.mu.
+func (m *Manager) deleteHelperSessionsV4(keys []dataplane.SessionKey) {
+	if len(keys) == 0 {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.proc == nil {
+		return
+	}
+	for start := 0; start < len(keys); start += sessionHelperDeleteChunk {
+		end := start + sessionHelperDeleteChunk
+		if end > len(keys) {
+			end = len(keys)
+		}
+		reqs := make([]SessionSyncRequest, 0, end-start)
+		for i := start; i < end; i++ {
+			reqs = append(reqs, m.buildSessionSyncRequestV4("delete", keys[i], nil))
+		}
+		m.syncSessionRequestsLocked(reqs...)
+	}
+}
+
+// deleteHelperSessionsV6 is the IPv6 analogue of deleteHelperSessionsV4 (#5096).
+func (m *Manager) deleteHelperSessionsV6(keys []dataplane.SessionKeyV6) {
+	if len(keys) == 0 {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.proc == nil {
+		return
+	}
+	for start := 0; start < len(keys); start += sessionHelperDeleteChunk {
+		end := start + sessionHelperDeleteChunk
+		if end > len(keys) {
+			end = len(keys)
+		}
+		reqs := make([]SessionSyncRequest, 0, end-start)
+		for i := start; i < end; i++ {
+			reqs = append(reqs, m.buildSessionSyncRequestV6("delete", keys[i], nil))
+		}
+		m.syncSessionRequestsLocked(reqs...)
+	}
+}
+
 func (m *Manager) syncSessionV4Locked(op string, key dataplane.SessionKey, val *dataplane.SessionValue) error {
 	if m.proc == nil {
 		return nil


### PR DESCRIPTION
## Problem

`LegacyDataPlaneAdapter` overrode only the singular `DeleteSession`/`DeleteSessionV6` (which send the authoritative Rust-helper `sync_session delete` IPC). It did **not** override `BatchDeleteSessions`, `BatchDeleteSessionsV6`, or `ClearAllSessions`, so Go method promotion dispatched those to the embedded `bpfShim` mirror **only**.

Consequences (High severity, codex-review-177 `[A6-b1-F1]`):
- Policy invalidation (`dataPlaneSessionStore.batchDeleteV4` → `DeleteBatchKnownV4`) and operator `clear security flow session all` deleted only the BPF-map mirror rows and returned a successful count.
- The Rust helper — which owns packet lookup and session lifetime — kept forwarding under the now-revoked decision until it re-published the mirror ~10s later.
- Real fail: **clear-all does not clear; policy-tighten does not take effect** (partial-apply / security-policy bypass).

## Fix (Go-only)

The helper exposes exactly two session verbs, `upsert` and `delete` (`userspace-dp/src/server/handlers/sync_session.rs`) — no bulk-clear verb — and the singular path already proves `delete` works, so **no `userspace-dp`/Rust change is required**.

- `Manager.BatchDeleteSessions`/`BatchDeleteSessionsV6`: delete the mirror via `bpfShim` (count returned unchanged) then send a per-key helper `delete` for every key. Callers already pass forward + reverse companion keys through separate batch calls, so both reach the helper. The helper delete is attempted even on a concurrent-vanish `ErrKeyNotExist` (deleting an absent helper session is a no-op).
- `Manager.ClearAllSessions`: snapshot every mirror key (forward **and** reverse entries) via `BatchIterateSessions` **before** emptying the mirror, call `bpfShim.ClearAllSessions` (counts unchanged), then per-key helper delete for the snapshot.
- `deleteHelperSessionsV{4,6}`: transmit in bounded chunks (`sessionHelperDeleteChunk=256`) via `syncSessionRequestsLocked`, which drops/reacquires `m.mu` once per chunk so a large clear stays cooperative and does not monopolize the shared control socket. A nil-value `delete` request carries only the 5-tuple, so no snapshot read happens under the lock. Helper IPC errors are best-effort logged, mirroring the singular `DeleteSession` path.
- `LegacyDataPlaneAdapter` overrides the three ops so the userspace `SessionStore` path (`s.dp = adapter`) no longer promotes them to `bpfShim`.

No module doc change: behavior now **matches** the already-documented singular `DeleteSession` helper-routing; the gap was a method-promotion implementation detail, now documented in code comments on each override.

## Tests / validation

- `go build ./...` → `build_exit=0`
- `go test ./pkg/dataplane/...` → `test_exit=0` (unprivileged; new BPF-map test skips) and the new test **passes under BPF privileges**.
- Added `TestBatchAndClearRouteToHelper5096` — a **fail-on-revert** guard that drives all three ops through the adapter against a fake helper session socket and asserts each recorded a `delete`. Verified it goes **RED** (`recorded=0`) when the helper-delete plumbing is reverted and **GREEN** with the fix.

Closes #5096

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi