### PR TITLE
login: revoke authorized_keys when a retained user's last SSH key is removed

### DIFF
--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -477,6 +477,25 @@ just the **`encrypted-password` directive** (user still present) locks
 the password but leaves `authorized_keys`; removing the **whole user**
 revokes both.
 
+### Emptying a retained user's SSH keys revokes the key file (#5106)
+
+`reconcileAbsentLoginUsers` only fires for a user that has been **removed**
+from config. A user that is **retained** but has had its **last**
+`authentication ssh-rsa`/key removed (key list now empty) was NOT covered:
+`applySystemLogin` wrote `authorized_keys` only inside `if len(user.SSHKeys)
+> 0`, so an emptied key list left the stale key file installed and the
+revoked key still permitted login. `applySystemLogin` now reconciles the
+empty-key-list case in the matching `else` branch: when a configured user
+has no keys, it removes the xpf-managed
+`/home/<user>/.ssh/authorized_keys` so key-based login is revoked. The
+removal is gated on the same UID-keyed provenance marker
+(`xpfProvisioned`) as the removal path above — xpf only deletes a key file
+it wrote wholesale, never a pre-existing / out-of-band user's
+operator-installed keys — and is idempotent (an already-absent file is a
+no-op). The password directive and the SSH keys remain independent: this
+branch touches only `authorized_keys`, and removing the
+`encrypted-password` directive still only locks the password.
+
 ### Scope — only xpf-managed accounts
 
 The lock-on-removal applies **only to the exact account xpf

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -922,7 +922,8 @@ func (d *Daemon) applySystemLogin(cfg *config.Config) {
 		// when this per-user loop is skipped (Login nil / no users), which
 		// is exactly the "user removed from config" case (#3889).
 
-		// Set SSH authorized keys
+		// Set SSH authorized keys. An EMPTY configured key list takes the else
+		// branch below and REVOKES any xpf-managed authorized_keys (#5106).
 		if len(user.SSHKeys) > 0 {
 			homeDir := fmt.Sprintf("/home/%s", user.Name)
 			sshDir := homeDir + "/.ssh"
@@ -978,6 +979,29 @@ func (d *Daemon) applySystemLogin(cfg *config.Config) {
 					continue
 				}
 				slog.Info("SSH keys updated", "user", user.Name, "keys", len(user.SSHKeys))
+			}
+		} else {
+			// Empty key list on a RETAINED user: reconcile the xpf-managed
+			// authorized_keys to ABSENT so removing the last key from config
+			// actually revokes key-based login. Without this the stale key file
+			// a prior apply wrote keeps granting access — reconcileAbsentLogin-
+			// Users only covers a fully REMOVED user, not a retained user whose
+			// key list was emptied (#5106). Gate on the UID-keyed provenance
+			// marker (as deprovisionLoginUser does) so we only ever remove an
+			// authorized_keys file xpf itself wrote — never a pre-existing /
+			// out-of-band user's operator-installed keys. The whole file is
+			// xpf-owned when the marker matches (applySystemLogin writes it
+			// wholesale), so removing it is safe.
+			if uid, ok := lookupUID(user.Name); ok && xpfProvisioned(user.Name, uid) {
+				keysFile := managedAuthorizedKeysPath(user.Name)
+				switch err := os.Remove(keysFile); {
+				case err == nil:
+					slog.Info("revoked SSH keys (last key removed from config)",
+						"user", user.Name)
+				case !os.IsNotExist(err):
+					slog.Warn("failed to remove authorized_keys after key list emptied",
+						"user", user.Name, "file", keysFile, "err", err)
+				}
 			}
 		}
 	}

--- a/pkg/daemon/login_emptied_keys_5106_test.go
+++ b/pkg/daemon/login_emptied_keys_5106_test.go
@@ -1,0 +1,129 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// stageEmptiedKeysEnv points the account DBs + marker dir + home base at a
+// throwaway tree, seeds /etc/passwd and a LOCKED /etc/shadow field for name
+// (so reconcileUserPassword takes pwNoop and never execs chpasswd), and stubs
+// runCommandTimeout so `id` reports the user already EXISTS — skipping the
+// privileged useradd so the test runs cleanly unprivileged. It returns the
+// managed authorized_keys path for name. #5106.
+func stageEmptiedKeysEnv(t *testing.T, name string, uid int) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	shadow := filepath.Join(dir, "shadow")
+	// A locked ("!") field means passwordAction returns pwNoop when the config
+	// carries no encrypted-password, so no chpasswd is ever exec'd.
+	shadowContent := fmt.Sprintf("root:*:19000:0:99999:7:::\n%s:!:19000:0:99999:7:::\n", name)
+	if err := os.WriteFile(shadow, []byte(shadowContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	passwd := filepath.Join(dir, "passwd")
+	passwdContent := fmt.Sprintf(
+		"root:x:0:0:root:/root:/bin/bash\n%s:x:%d:%d:,,,:/home/%s:/bin/bash\n",
+		name, uid, uid, name)
+	if err := os.WriteFile(passwd, []byte(passwdContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	origShadow, origPasswd, origDir, origHome := shadowPath, passwdPath, provisionedUsersDir, homeBaseDir
+	shadowPath = shadow
+	passwdPath = passwd
+	provisionedUsersDir = filepath.Join(dir, "provisioned-users")
+	homeBaseDir = filepath.Join(dir, "home")
+	t.Cleanup(func() {
+		shadowPath, passwdPath, provisionedUsersDir, homeBaseDir = origShadow, origPasswd, origDir, origHome
+	})
+
+	origRun := runCommandTimeout
+	runCommandTimeout = func(cmd string, args ...string) ([]byte, error) {
+		// `id -- <name>` returning nil means "user exists" → useradd is
+		// skipped. Every other command is an inert no-op; the emptied-keys
+		// branch under test performs no external commands.
+		return nil, nil
+	}
+	t.Cleanup(func() { runCommandTimeout = origRun })
+
+	return managedAuthorizedKeysPath(name)
+}
+
+// TestApplySystemLoginRevokesEmptiedKeys is the #5106 fail-on-revert guard: a
+// RETAINED login user whose SSH key list has been emptied in config must have
+// its xpf-managed authorized_keys REMOVED so the revoked key can no longer log
+// in. Reverting the empty-key-list else branch in applySystemLogin makes this
+// RED — the stale key file survives.
+func TestApplySystemLoginRevokesEmptiedKeys(t *testing.T) {
+	keysFile := stageEmptiedKeysEnv(t, "alice", 1001)
+
+	// alice was provisioned by xpf (marker UID matches) and a prior apply wrote
+	// her managed authorized_keys.
+	if err := markProvisioned("alice", 1001); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keysFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keysFile, []byte("ssh-ed25519 AAAAC3... alice@host\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// alice is still configured, but her key list is now EMPTY.
+	d := &Daemon{}
+	d.applySystemLogin(loginCfg(&config.LoginUser{Name: "alice", Class: "operator"}))
+
+	if _, err := os.Stat(keysFile); !os.IsNotExist(err) {
+		t.Fatalf("managed authorized_keys still present after key list emptied (err=%v) — #5106 revocation missing", err)
+	}
+}
+
+// TestApplySystemLoginKeepsNonProvisionedKeys proves the emptied-keys removal
+// is scoped: a configured user with NO provenance marker (xpf never
+// provisioned the account / never wrote its keys) must keep a pre-existing
+// authorized_keys — xpf must not delete an operator-installed key file it does
+// not own.
+func TestApplySystemLoginKeepsNonProvisionedKeys(t *testing.T) {
+	keysFile := stageEmptiedKeysEnv(t, "bob", 1002)
+
+	// No markProvisioned("bob", ...) — xpf does not own this account.
+	if err := os.MkdirAll(filepath.Dir(keysFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keysFile, []byte("ssh-ed25519 AAAA bob-operator-installed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	d := &Daemon{}
+	d.applySystemLogin(loginCfg(&config.LoginUser{Name: "bob", Class: "operator"}))
+
+	if _, err := os.Stat(keysFile); err != nil {
+		t.Fatalf("non-xpf user's authorized_keys was removed (err=%v) — the emptied-keys branch must only touch xpf-owned files", err)
+	}
+}
+
+// TestApplySystemLoginEmptiedKeysIdempotent proves the emptied-keys branch is a
+// no-op when the managed authorized_keys is already absent: an xpf-provisioned
+// user configured without keys and with no key file present must not error or
+// spuriously act. (RED would be a panic/removal side effect; GREEN is a clean
+// pass with the file staying absent.)
+func TestApplySystemLoginEmptiedKeysIdempotent(t *testing.T) {
+	keysFile := stageEmptiedKeysEnv(t, "carol", 1003)
+	if err := markProvisioned("carol", 1003); err != nil {
+		t.Fatal(err)
+	}
+	// Deliberately do NOT create keysFile.
+
+	d := &Daemon{}
+	d.applySystemLogin(loginCfg(&config.LoginUser{Name: "carol", Class: "operator"}))
+
+	if _, err := os.Stat(keysFile); !os.IsNotExist(err) {
+		t.Fatalf("authorized_keys unexpectedly present after an already-absent reconcile (err=%v)", err)
+	}
+}

--- a/pkg/daemon/login_password.go
+++ b/pkg/daemon/login_password.go
@@ -210,11 +210,13 @@ var homeBaseDir = "/home"
 
 // managedAuthorizedKeysPath returns the xpf-managed authorized_keys file for
 // name. applySystemLogin writes /home/<name>/.ssh/authorized_keys wholesale
-// from the configured SSHKeys, so the whole file is xpf-owned; the absent-user
-// reconcile removes it to revoke key-based login. filepath.Base(Clean(...))
-// keeps the join inside homeBaseDir defensively (names reaching here are
-// validated OS usernames, but never trust a name for a root-privileged
-// removal). #5128.
+// from the configured SSHKeys, so the whole file is xpf-owned. Two reconciles
+// remove it to revoke key-based login: the absent-user reconcile when the user
+// is deleted from config (#5128), and applySystemLogin's own empty-key-list
+// branch when a RETAINED user's last key is removed from config (#5106).
+// filepath.Base(Clean(...)) keeps the join inside homeBaseDir defensively
+// (names reaching here are validated OS usernames, but never trust a name for
+// a root-privileged removal). #5128.
 func managedAuthorizedKeysPath(name string) string {
 	return filepath.Join(homeBaseDir, filepath.Base(filepath.Clean(name)), ".ssh", "authorized_keys")
 }


### PR DESCRIPTION
## Problem (#5106, High/High — codex-review-177 `[A7-b1-F2]`)

Deleting the last SSH key from a **retained** `system login user` left
the revoked key still able to log in. In `applySystemLogin`
(`pkg/daemon/daemon_system.go`) the managed authorized_keys write is
guarded by `if len(user.SSHKeys) > 0 { ... }`; when a retained user's
key list becomes EMPTY the whole block is skipped, so the stale
`/home/<user>/.ssh/authorized_keys` a prior apply installed is never
removed and the revoked key keeps granting login.

`reconcileAbsentLoginUsers` (#5128) does **not** cover this vector — the
user is still present/desired, not absent — so nothing revoked the key.

This PR is scoped to the **retained-user last-key-removal** vector. The
sibling **deleted-user** vector (deleting an xpf-created user, incl. the
last one) was already fixed by #5204/#5128: `applySystemLogin`
early-returns on an empty user list, but `reconcileAbsentLoginUsers`
runs unconditionally and deprovisions every marker no longer in the
desired set — that path is untouched here.

## Fix

Give the `if len(user.SSHKeys) > 0` block an `else` branch that
reconciles the xpf-managed authorized_keys to **absent** when a
configured user has no keys:

- Gated on the same UID-keyed provenance marker (`xpfProvisioned`) that
  `deprovisionLoginUser` uses, so xpf only deletes a key file **it wrote
  wholesale** — never a pre-existing / out-of-band user's
  operator-installed keys.
- Mirrors `deprovisionLoginUser`'s removal style: `os.Remove`, ignore
  `os.IsNotExist`, warn on any other error.
- Idempotent — an already-absent file is a clean no-op.
- The empty-user-list early return + unconditional
  `reconcileAbsentLoginUsers` (case a) are left intact.

## Docs

- Extended the `managedAuthorizedKeysPath` doc comment
  (`pkg/daemon/login_password.go`) to note the emptied-keys reconcile.
- Added a `docs/system-login.md` subsection describing the #5106
  emptied-keys revocation and its xpf-ownership scoping.

## Validation

- `go build ./...` — clean.
- `go test ./pkg/daemon/ -run 'Login|SSH|Key|Deprovision'` — pass.
- New fail-on-revert test `pkg/daemon/login_emptied_keys_5106_test.go`:
  - **positive** — an xpf-provisioned user whose key list is emptied has
    its managed authorized_keys removed (verified **RED** when the else
    branch is neutralized);
  - **scoping** — a non-provisioned user's pre-existing key file is left
    intact;
  - **idempotence** — an already-absent file is a no-op.
  Privileged steps are stubbed (`runCommandTimeout` id/useradd seam,
  locked shadow field) so the test runs unprivileged.

Closes #5106

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi