### PR TITLE
daemon/userspace: fix silent forwarding outage on deferred-MAC worker arm (#5134)

### DIFF
--- a/docs/reth-mac.md
+++ b/docs/reth-mac.md
@@ -67,6 +67,48 @@ also restores that function's live-address-change detection, which
 requires an UP link to distinguish `IFF_LIVE_ADDR_CHANGE` drivers from
 those that need a cycle.
 
+## Deferred AF_XDP Worker Arming After a Live MAC Change (#5134)
+
+Programming the virtual MAC can happen two ways:
+
+- **Link cycle** (`programRethMAC` had to bring the member DOWN/UP): the old
+  AF_XDP sockets die with the cycle. The daemon calls `NotifyLinkCycle()`,
+  which sends `rebind` to the helper and recreates the workers with fresh
+  sockets. This path arms the workers via the rebind, independent of the
+  published snapshot's `DeferWorkers` flag.
+- **Live MAC set** (`IFF_LIVE_ADDR_CHANGE` driver, or the fast path that sets
+  the MAC while the link is still DOWN — no cycle): the initial dataplane
+  apply of the commit ran with `SetDeferWorkers(true)` so worker startup was
+  skipped (avoids the mlx5 zero-copy double-bind EBUSY). The published
+  snapshot therefore carries `DeferWorkers=true` and is **workerless /
+  non-forwarding**. The daemon then issues a MANDATORY second `ApplyConfig`
+  (`reapplyAfterDeferredMAC`) with the correct MAC and `DeferWorkers` cleared —
+  that re-apply is what actually starts the workers.
+
+The re-apply is failure-critical. The userspace manager only advances its
+snapshot bookkeeping (`lastSnapshot` / `publishedSnapshot` / `lastSnapshotHash`)
+on a **successful** `apply_snapshot` publish. If the re-apply's publish fails
+(helper rejects it, control-socket error, resource pressure) and the daemon
+swallows the error, the manager keeps the workerless `DeferWorkers=true`
+snapshot as the published/last state, status reconciliation replays it, the
+workers never bind, and the commit still reports success — a silent forwarding
+outage on that node.
+
+**Contract:** `reapplyAfterDeferredMAC` never swallows the re-apply error. On
+failure it records **generation debt** via `RecordDeferredWorkerArmDebt()`
+(`Manager.pendingWorkerArm`). The 1 Hz status reconcile loop calls
+`retryDeferredWorkerArmLocked()`, which republishes the retained snapshot with
+`DeferWorkers=false` and a bumped generation until the workers bind, then clears
+the debt. A transient helper error self-heals without failing the commit; the
+node never terminally publishes a workerless snapshot while reporting success.
+
+| File | Function |
+|------|----------|
+| `pkg/daemon/daemon_apply.go` | `reapplyAfterDeferredMAC()` — mandatory re-apply; records debt on failure |
+| `pkg/daemon/daemon_apply.go` | `recordDataplaneWorkerArmDebt()` — routes the debt to the dataplane |
+| `pkg/dataplane/userspace/manager_worker_arm_5134.go` | `RecordDeferredWorkerArmDebt()` / `retryDeferredWorkerArmLocked()` |
+| `pkg/dataplane/userspace/process_status.go` | status loop drives the retry each tick |
+
 ## Reboot Safety
 
 - Bootstrap `.link` files (from `setup.sh`) use the physical MAC for udev rename

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1003,9 +1003,7 @@ func (d *Daemon) applyDataplaneAndHACore(ctx context.Context, cfg *config.Config
 		// MAC set live (no link cycle) but workers were deferred.
 		// Trigger a re-apply to start workers with the now-correct MAC.
 		// This is cheaper than NotifyLinkCycle (no stop_workers/rebind).
-		if _, err := d.dp.ApplyConfig(context.Background(), cfg); err != nil {
-			slog.Warn("failed to re-apply after deferred MAC", "err", err)
-		}
+		d.reapplyAfterDeferredMAC(cfg)
 	}
 
 	// NOTE: stable link-local cleanup for secondary RGs is handled by
@@ -1875,6 +1873,50 @@ func (d *Daemon) setDataplaneDeferWorkers(deferWorkers bool) {
 		return
 	}
 	d.dp.Link().SetDeferWorkers(deferWorkers)
+}
+
+// reapplyAfterDeferredMAC runs the MANDATORY dataplane re-apply that arms the
+// deferred AF_XDP workers after a live RETH virtual-MAC change with no link
+// cycle (#5134). The first apply of this commit published a workerless
+// DeferWorkers=true snapshot (worker startup was deferred so the double-bind
+// does not EBUSY on mlx5 zero-copy queues); this re-apply — now with the
+// correct MAC and DeferWorkers cleared — is what actually starts the workers.
+//
+// If the re-apply fails, the error MUST NOT be swallowed into a successful
+// commit: the userspace manager only advances its snapshot bookkeeping on a
+// successful publish, so a failed re-apply leaves the workerless snapshot as
+// the published/last state and status reconciliation replays it forever —
+// workers never bind and forwarding is silently down on this node. Record
+// generation debt so the status reconcile loop retries the DeferWorkers=false
+// publish until the workers bind, self-healing a transient helper /
+// control-socket error.
+func (d *Daemon) reapplyAfterDeferredMAC(cfg *config.Config) {
+	if d.dp == nil {
+		return
+	}
+	if _, err := d.dp.ApplyConfig(context.Background(), cfg); err != nil {
+		slog.Warn("failed to re-apply after deferred MAC; recording worker-arm debt for retry",
+			"err", err)
+		d.recordDataplaneWorkerArmDebt()
+	}
+}
+
+// recordDataplaneWorkerArmDebt records the #5134 deferred-MAC worker-arm debt on
+// the dataplane so status reconciliation retries the DeferWorkers=false publish.
+// Mirrors setDataplaneDeferWorkers: assert the recorder directly on d.dp, else
+// reach it through the link controller.
+func (d *Daemon) recordDataplaneWorkerArmDebt() {
+	if d.dp == nil {
+		return
+	}
+	type debtRecorder interface{ RecordDeferredWorkerArmDebt() }
+	if r, ok := d.dp.(debtRecorder); ok {
+		r.RecordDeferredWorkerArmDebt()
+		return
+	}
+	if r, ok := d.dp.Link().(debtRecorder); ok {
+		r.RecordDeferredWorkerArmDebt()
+	}
 }
 
 // reconcileDHCPRelay re-applies the DHCP relay config on every commit (#2348).

--- a/pkg/daemon/deferred_mac_reapply_5134_test.go
+++ b/pkg/daemon/deferred_mac_reapply_5134_test.go
@@ -1,0 +1,90 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpruntime "github.com/psaab/xpf/pkg/dataplane/runtime"
+)
+
+// deferredMACReapplyTestDP is a minimal RuntimeDataPlane whose ApplyConfig can
+// be made to fail, recording whether the daemon reacted by recording
+// deferred-MAC worker-arm debt (#5134) instead of swallowing the error.
+type deferredMACReapplyTestDP struct {
+	applyErr    error
+	applyCalls  int
+	debtRecords int
+}
+
+func (d *deferredMACReapplyTestDP) Start(context.Context) error { return nil }
+func (d *deferredMACReapplyTestDP) Close() error                { return nil }
+func (d *deferredMACReapplyTestDP) Teardown() error             { return nil }
+
+func (d *deferredMACReapplyTestDP) ApplyConfig(context.Context, *config.Config) (*dataplane.ApplyResult, error) {
+	d.applyCalls++
+	if d.applyErr != nil {
+		return nil, d.applyErr
+	}
+	return &dataplane.ApplyResult{}, nil
+}
+
+func (d *deferredMACReapplyTestDP) LastApplyResult() *dataplane.ApplyResult {
+	return &dataplane.ApplyResult{}
+}
+func (d *deferredMACReapplyTestDP) Link() dataplane.LinkController { return noopLinkController{} }
+func (d *deferredMACReapplyTestDP) HA() dataplane.HAController {
+	return dataplane.NewDataPlaneHAController(nil)
+}
+func (d *deferredMACReapplyTestDP) Sessions() dataplane.SessionStore {
+	return dataplane.SessionStoreOf(nil)
+}
+func (d *deferredMACReapplyTestDP) Telemetry() dataplane.Telemetry              { return dataplane.TelemetryOf(nil) }
+func (d *deferredMACReapplyTestDP) SessionDeltas() dpruntime.SessionDeltaSource { return nil }
+
+// RecordDeferredWorkerArmDebt is the #5134 debt-recorder the daemon reaches via
+// an optional type assertion on d.dp.
+func (d *deferredMACReapplyTestDP) RecordDeferredWorkerArmDebt() { d.debtRecords++ }
+
+// TestReapplyAfterDeferredMACRecordsDebtOnFailure is the #5134 daemon contract:
+// the MANDATORY re-apply that arms the deferred AF_XDP workers after a live
+// RETH virtual-MAC change must NOT swallow its ApplyConfig error into a
+// successful commit. On failure it records generation debt so status
+// reconciliation retries with DeferWorkers=false and eventually binds workers.
+//
+// RED-on-revert: reverting reapplyAfterDeferredMAC to the old `slog.Warn(...)`
+// (drop the error) makes debtRecords stay 0 — the workerless snapshot then
+// stays published while the commit reports success (the silent forwarding
+// outage).
+func TestReapplyAfterDeferredMACRecordsDebtOnFailure(t *testing.T) {
+	dp := &deferredMACReapplyTestDP{applyErr: errors.New("helper rejected apply_snapshot")}
+	d := &Daemon{dp: dp}
+
+	d.reapplyAfterDeferredMAC(&config.Config{})
+
+	if dp.applyCalls != 1 {
+		t.Fatalf("ApplyConfig calls = %d, want 1", dp.applyCalls)
+	}
+	if dp.debtRecords != 1 {
+		t.Fatalf("worker-arm debt records = %d, want 1 (failed re-apply must record debt, not swallow)", dp.debtRecords)
+	}
+}
+
+// TestReapplyAfterDeferredMACNoDebtOnSuccess verifies the happy path records no
+// debt: a successful re-apply arms the workers directly, so there is nothing
+// for the reconcile loop to retry.
+func TestReapplyAfterDeferredMACNoDebtOnSuccess(t *testing.T) {
+	dp := &deferredMACReapplyTestDP{}
+	d := &Daemon{dp: dp}
+
+	d.reapplyAfterDeferredMAC(&config.Config{})
+
+	if dp.applyCalls != 1 {
+		t.Fatalf("ApplyConfig calls = %d, want 1", dp.applyCalls)
+	}
+	if dp.debtRecords != 0 {
+		t.Fatalf("worker-arm debt records = %d, want 0 on a successful re-apply", dp.debtRecords)
+	}
+}

--- a/pkg/dataplane/userspace/controllers.go
+++ b/pkg/dataplane/userspace/controllers.go
@@ -18,6 +18,15 @@ func (c userspaceLinkController) SetDeferWorkers(v bool) {
 	}
 }
 
+// RecordDeferredWorkerArmDebt records the #5134 deferred-MAC worker-arm debt.
+// It is not part of the LinkController interface; the daemon reaches it via an
+// optional type assertion on d.dp.Link() (mirroring SetDeferWorkers).
+func (c userspaceLinkController) RecordDeferredWorkerArmDebt() {
+	if c.manager != nil {
+		c.manager.RecordDeferredWorkerArmDebt()
+	}
+}
+
 func (c userspaceLinkController) PrepareLinkCycle() {
 	if c.manager != nil {
 		c.manager.PrepareLinkCycle()

--- a/pkg/dataplane/userspace/legacy_dataplane.go
+++ b/pkg/dataplane/userspace/legacy_dataplane.go
@@ -441,6 +441,17 @@ func (a *LegacyDataPlaneAdapter) SetDeferWorkers(v bool) {
 	m.SetDeferWorkers(v)
 }
 
+// RecordDeferredWorkerArmDebt forwards the #5134 deferred-MAC worker-arm debt to
+// the underlying manager so the daemon can record it without swallowing the
+// failed re-apply error.
+func (a *LegacyDataPlaneAdapter) RecordDeferredWorkerArmDebt() {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return
+	}
+	m.RecordDeferredWorkerArmDebt()
+}
+
 func (a *LegacyDataPlaneAdapter) PrepareLinkCycle() {
 	m, err := a.managerOrErr()
 	if err != nil {

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -193,6 +193,19 @@ type Manager struct {
 	sessionMirrorErr    string
 	deferWorkers        bool // skip worker spawn until NotifyLinkCycle
 	xskBoundNotified    bool // OnXSKBound fired at most once
+	// pendingWorkerArm records "generation debt" from a deferred-MAC
+	// re-apply that failed to publish (#5134). After a live RETH
+	// virtual-MAC change with no link cycle, the first apply publishes a
+	// workerless DeferWorkers=true snapshot and the daemon issues a
+	// MANDATORY re-apply to arm the workers with the now-correct MAC. If
+	// that re-apply's apply_snapshot fails, the manager keeps the
+	// workerless snapshot as lastSnapshot/publishedSnapshot and the commit
+	// still reports success — a silent forwarding outage. The daemon records
+	// the debt here instead of swallowing the error; the status reconcile
+	// loop (retryDeferredWorkerArmLocked) then retries the DeferWorkers=false
+	// publish every tick until the workers bind, self-healing a transient
+	// helper / control-socket error.
+	pendingWorkerArm bool
 
 	lookupUserspaceCtrlForFailClosedHook userspaceCtrlLookupHook
 

--- a/pkg/dataplane/userspace/manager_worker_arm_5134.go
+++ b/pkg/dataplane/userspace/manager_worker_arm_5134.go
@@ -54,10 +54,14 @@ func (m *Manager) retryDeferredWorkerArmLocked() error {
 		return nil
 	}
 
+	// Compute the next generation locally and commit m.generation ONLY after
+	// the publish succeeds (mirrors UpdatePolicyScheduleState). A failed
+	// apply_snapshot must not permanently advance m.generation — otherwise
+	// each failed retry tick would burn a generation while the debt persists.
+	nextGeneration := m.generation + 1
 	next := *m.lastSnapshot
 	next.DeferWorkers = false
-	m.generation++
-	next.Generation = m.generation
+	next.Generation = nextGeneration
 	next.FIBGeneration = m.readFIBGeneration()
 	next.GeneratedAt = time.Now().UTC()
 
@@ -78,6 +82,8 @@ func (m *Manager) retryDeferredWorkerArmLocked() error {
 		return fmt.Errorf("re-arm deferred workers: %w", err)
 	}
 	m.logWgEndpointSetTransitionLocked(&publishSnap, "deferred-worker-arm")
+	// Publish succeeded — commit the generation bump now.
+	m.generation = nextGeneration
 	m.lastSnapshot = &next
 	m.rebuildNeighborIndex()
 	m.rebuildMonitoredIfindexes()

--- a/pkg/dataplane/userspace/manager_worker_arm_5134.go
+++ b/pkg/dataplane/userspace/manager_worker_arm_5134.go
@@ -1,0 +1,97 @@
+package userspace
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// RecordDeferredWorkerArmDebt marks that the MANDATORY deferred-MAC re-apply
+// failed to publish (#5134). After a live RETH virtual-MAC change with no link
+// cycle, the daemon issues a second ApplyConfig to arm the AF_XDP workers with
+// the now-correct MAC (the first apply published a workerless
+// DeferWorkers=true snapshot). When that re-apply's apply_snapshot fails, the
+// manager retains the workerless snapshot as lastSnapshot/publishedSnapshot and
+// the commit still reports success — a silent forwarding outage on that node.
+//
+// The daemon calls this instead of swallowing the ApplyConfig error. The status
+// reconcile loop (retryDeferredWorkerArmLocked) then republishes the snapshot
+// with DeferWorkers=false on every tick until the workers bind, self-healing a
+// transient helper / control-socket error without failing the commit.
+func (m *Manager) RecordDeferredWorkerArmDebt() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pendingWorkerArm = true
+}
+
+// retryDeferredWorkerArmLocked settles the #5134 deferred-worker arm debt from
+// the status loop. m.mu is held by the caller.
+//
+// The retained lastSnapshot still carries DeferWorkers=true (the failed
+// re-apply never advanced it). The config did not change between the initial
+// deferred apply and the failed re-apply, so republish the SAME snapshot
+// content with DeferWorkers=false and a bumped generation to arm the workers —
+// this is lighter than a full re-compile and mirrors the republish bookkeeping
+// used by UpdatePolicyScheduleState / syncSnapshotLocked. On success the debt
+// is cleared; a still-failing publish leaves the debt set for the next tick.
+func (m *Manager) retryDeferredWorkerArmLocked() error {
+	if !m.pendingWorkerArm {
+		return nil
+	}
+	if m.proc == nil || m.proc.Process == nil || m.lastSnapshot == nil {
+		// Helper not running / nothing published yet: there is no live
+		// workerless snapshot to re-arm. A helper (re)start replays through
+		// the normal apply path, which arms workers itself. Drop the debt so
+		// the reconcile loop does not spin.
+		m.pendingWorkerArm = false
+		return nil
+	}
+	if !m.lastSnapshot.DeferWorkers {
+		// A later full apply already published a DeferWorkers=false snapshot
+		// (workers armed). The debt is settled.
+		m.pendingWorkerArm = false
+		return nil
+	}
+
+	next := *m.lastSnapshot
+	next.DeferWorkers = false
+	m.generation++
+	next.Generation = m.generation
+	next.FIBGeneration = m.readFIBGeneration()
+	next.GeneratedAt = time.Now().UTC()
+
+	publishSnap := next
+	publishSnap.Neighbors = filterPublishableNeighbors(next.Neighbors)
+	if err := m.ensureRequiredSnapshotProtocolLocked(publishSnap.Config); err != nil {
+		if disarmErr := m.disarmSnapshotProtocolFailureLocked(err); disarmErr != nil {
+			return errors.Join(err, disarmErr)
+		}
+		return err
+	}
+	if err := m.disarmBeforeUnsupportedPublishLocked(&publishSnap); err != nil {
+		return err
+	}
+	var status ProcessStatus
+	if err := m.requestLocked(ControlRequest{Type: "apply_snapshot", Snapshot: &publishSnap}, &status); err != nil {
+		// Debt stays set — the status loop retries on the next tick.
+		return fmt.Errorf("re-arm deferred workers: %w", err)
+	}
+	m.logWgEndpointSetTransitionLocked(&publishSnap, "deferred-worker-arm")
+	m.lastSnapshot = &next
+	m.rebuildNeighborIndex()
+	m.rebuildMonitoredIfindexes()
+	m.publishedSnapshot = next.Generation
+	m.publishedPlanKey = snapshotBindingPlanKey(&next)
+	m.markAppliedSnapshotLocked()
+	if h, ok := snapshotContentHash(&next); ok {
+		m.lastSnapshotHash = h
+	}
+	m.pendingWorkerArm = false
+	slog.Info("userspace: armed deferred AF_XDP workers after deferred-MAC re-apply retry",
+		"generation", next.Generation)
+	if err := m.applyHelperStatusLocked(&status); err != nil {
+		return fmt.Errorf("sync helper status after deferred-worker arm: %w", err)
+	}
+	return nil
+}

--- a/pkg/dataplane/userspace/manager_worker_arm_5134_test.go
+++ b/pkg/dataplane/userspace/manager_worker_arm_5134_test.go
@@ -1,0 +1,170 @@
+package userspace
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestDeferredWorkerArmDebtRetainedWhileHelperDown is the #5134 core contract:
+// a deferred-MAC re-apply that FAILS must NOT be swallowed into a
+// success-with-workerless-snapshot. The daemon records generation debt
+// (RecordDeferredWorkerArmDebt); until the publish lands, the reconcile retry
+// MUST keep the debt set and MUST NOT flip the retained snapshot to
+// DeferWorkers=false (which would falsely report armed) or advance
+// publishedSnapshot.
+//
+// RED-on-revert: if the daemon reverts to swallowing the error (never records
+// debt) or the retry mechanism is removed, a workerless snapshot stays the
+// terminal published state while the commit reports success — the silent
+// forwarding outage this test guards against.
+func TestDeferredWorkerArmDebtRetainedWhileHelperDown(t *testing.T) {
+	dir := t.TempDir()
+	// A control socket with nothing listening: every apply_snapshot publish
+	// fails at dial, modeling a helper that keeps rejecting the re-arm.
+	controlSock := filepath.Join(dir, "no-listener.sock")
+
+	cfg := &config.Config{}
+
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+	m.cfg.ControlSocket = controlSock
+	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
+
+	// Simulate the state left by the first (deferred) apply: a published
+	// workerless snapshot. The failed re-apply never advanced past this.
+	snap, err := buildSnapshot(cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
+	if err != nil {
+		t.Fatalf("buildSnapshot: %v", err)
+	}
+	snap.DeferWorkers = true
+	m.lastSnapshot = snap
+	m.generation = 7
+	m.publishedSnapshot = 7
+
+	// The daemon records debt instead of swallowing the failed re-apply.
+	m.RecordDeferredWorkerArmDebt()
+	if !m.pendingWorkerArm {
+		t.Fatal("RecordDeferredWorkerArmDebt must set pendingWorkerArm (debt not recorded — daemon swallowed the failure)")
+	}
+
+	// Reconcile tick while the helper is still down: the publish fails, so
+	// the debt must persist and the retained snapshot must stay workerless.
+	m.mu.Lock()
+	retryErr := m.retryDeferredWorkerArmLocked()
+	m.mu.Unlock()
+	if retryErr == nil {
+		t.Fatal("retryDeferredWorkerArmLocked must return the publish error while the helper is down")
+	}
+	if !m.pendingWorkerArm {
+		t.Fatal("debt must remain set after a failed re-arm publish so the next tick retries")
+	}
+	if !m.lastSnapshot.DeferWorkers {
+		t.Fatal("retained snapshot must stay DeferWorkers=true after a failed re-arm (never falsely reported armed)")
+	}
+	if m.publishedSnapshot != 7 {
+		t.Fatalf("publishedSnapshot = %d, want 7 retained after a failed re-arm publish", m.publishedSnapshot)
+	}
+}
+
+// TestDeferredWorkerArmDebtArmsWorkersOnRecovery verifies the self-heal: once
+// the helper accepts apply_snapshot again, the reconcile retry republishes the
+// snapshot with DeferWorkers=false (arming the workers) and clears the debt.
+func TestDeferredWorkerArmDebtArmsWorkersOnRecovery(t *testing.T) {
+	controlSock := filepath.Join(t.TempDir(), "control.sock")
+
+	cfg := &config.Config{}
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+	m.cfg.ControlSocket = controlSock
+	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
+
+	snap, err := buildSnapshot(cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
+	if err != nil {
+		t.Fatalf("buildSnapshot: %v", err)
+	}
+	snap.DeferWorkers = true
+	m.lastSnapshot = snap
+	m.generation = 7
+	m.publishedSnapshot = 7
+	m.RecordDeferredWorkerArmDebt()
+
+	reqs := startArmControlServer(t, controlSock, 1)
+
+	m.mu.Lock()
+	// applyHelperStatusLocked writes BPF maps that are not loaded in this
+	// unit test; it returns an error AFTER the snapshot has landed and the
+	// arm bookkeeping has advanced. The publish itself (the re-arm) succeeds,
+	// which is what this test asserts.
+	_ = m.retryDeferredWorkerArmLocked()
+	m.mu.Unlock()
+
+	select {
+	case req := <-reqs:
+		if req.Type != "apply_snapshot" {
+			t.Fatalf("re-arm request type = %q, want apply_snapshot", req.Type)
+		}
+		if req.Snapshot == nil {
+			t.Fatal("re-arm request carried no snapshot")
+		}
+		if req.Snapshot.DeferWorkers {
+			t.Fatal("re-arm must publish DeferWorkers=false to start the workers")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the re-arm apply_snapshot")
+	}
+
+	if m.pendingWorkerArm {
+		t.Fatal("debt must be cleared once the re-arm publish succeeds")
+	}
+	if m.lastSnapshot.DeferWorkers {
+		t.Fatal("armed snapshot must have DeferWorkers=false after a successful re-arm")
+	}
+	if m.publishedSnapshot <= 7 {
+		t.Fatalf("publishedSnapshot = %d, want > 7 after the re-arm publish landed", m.publishedSnapshot)
+	}
+}
+
+// startArmControlServer stands up a unix control socket that replies OK to the
+// next `n` requests, returning each decoded request on the channel.
+func startArmControlServer(t *testing.T, controlSock string, n int) <-chan ControlRequest {
+	t.Helper()
+	ln, err := net.Listen("unix", controlSock)
+	if err != nil {
+		t.Fatalf("listen control socket: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	reqs := make(chan ControlRequest, n)
+	go func() {
+		defer close(reqs)
+		for i := 0; i < n; i++ {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			func() {
+				defer conn.Close()
+				var req ControlRequest
+				if err := json.NewDecoder(conn).Decode(&req); err != nil {
+					return
+				}
+				select {
+				case reqs <- req:
+				default:
+				}
+				_ = json.NewEncoder(conn).Encode(ControlResponse{
+					OK:     true,
+					Status: &ProcessStatus{PID: 4242},
+				})
+			}()
+		}
+	}()
+	return reqs
+}

--- a/pkg/dataplane/userspace/manager_worker_arm_5134_test.go
+++ b/pkg/dataplane/userspace/manager_worker_arm_5134_test.go
@@ -71,6 +71,71 @@ func TestDeferredWorkerArmDebtRetainedWhileHelperDown(t *testing.T) {
 	if m.publishedSnapshot != 7 {
 		t.Fatalf("publishedSnapshot = %d, want 7 retained after a failed re-arm publish", m.publishedSnapshot)
 	}
+	// A failed apply_snapshot must NOT burn a generation: m.generation is
+	// committed only after a successful publish. Otherwise every failed retry
+	// tick would advance the generation while the debt persists.
+	if m.generation != 7 {
+		t.Fatalf("generation = %d, want 7 unchanged after a failed re-arm publish", m.generation)
+	}
+}
+
+// TestDeferredWorkerArmDebtSettledWhenAlreadyArmed pins the settle-early(b)
+// monotonicity guard (#5169/#5171): when the debt is still set but a LATER full
+// apply has already published a DeferWorkers=false snapshot (workers armed),
+// the retry MUST clear the debt and return nil WITHOUT republishing — it must
+// not clobber the newer retained snapshot with stale content or burn a
+// generation.
+//
+// RED-on-revert: if the `!m.lastSnapshot.DeferWorkers` settle-early check is
+// removed, the retry republishes the (already-armed) snapshot — the control
+// server then receives an apply_snapshot and the generation advances, failing
+// this test.
+func TestDeferredWorkerArmDebtSettledWhenAlreadyArmed(t *testing.T) {
+	controlSock := filepath.Join(t.TempDir(), "control.sock")
+
+	cfg := &config.Config{}
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+	m.cfg.ControlSocket = controlSock
+	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
+
+	// A later full apply already armed the workers: the retained snapshot has
+	// DeferWorkers=false.
+	snap, err := buildSnapshot(cfg, config.UserspaceConfig{ControlSocket: controlSock}, 9, 0)
+	if err != nil {
+		t.Fatalf("buildSnapshot: %v", err)
+	}
+	snap.DeferWorkers = false
+	m.lastSnapshot = snap
+	m.generation = 9
+	m.publishedSnapshot = 9
+	// Stale debt from an earlier failed re-arm that the newer apply superseded.
+	m.RecordDeferredWorkerArmDebt()
+
+	reqs := startArmControlServer(t, controlSock, 1)
+
+	m.mu.Lock()
+	retryErr := m.retryDeferredWorkerArmLocked()
+	m.mu.Unlock()
+	if retryErr != nil {
+		t.Fatalf("retry must return nil when the workers are already armed, got %v", retryErr)
+	}
+	if m.pendingWorkerArm {
+		t.Fatal("debt must be cleared once a later apply already armed the workers")
+	}
+	if m.generation != 9 {
+		t.Fatalf("generation = %d, want 9 unchanged (settle-early must not republish/bump)", m.generation)
+	}
+	if m.publishedSnapshot != 9 {
+		t.Fatalf("publishedSnapshot = %d, want 9 unchanged", m.publishedSnapshot)
+	}
+	// The retained (newer) snapshot must NOT be clobbered by a stale republish:
+	// no apply_snapshot may reach the control server.
+	select {
+	case req := <-reqs:
+		t.Fatalf("settle-early must not republish; got a %q request", req.Type)
+	case <-time.After(200 * time.Millisecond):
+	}
 }
 
 // TestDeferredWorkerArmDebtArmsWorkersOnRecovery verifies the self-heal: once

--- a/pkg/dataplane/userspace/process_status.go
+++ b/pkg/dataplane/userspace/process_status.go
@@ -164,6 +164,18 @@ func (m *Manager) statusLoop(ctx context.Context) {
 						slog.Warn("userspace dataplane snapshot sync failed", "err", err)
 					}
 				}
+				// #5134: settle a deferred-MAC worker-arm debt. A live RETH
+				// virtual-MAC change with no link cycle publishes a workerless
+				// DeferWorkers=true snapshot; the daemon's mandatory re-apply
+				// arms the workers. If that re-apply failed, the daemon recorded
+				// generation debt here — retry the DeferWorkers=false publish
+				// until the workers bind, instead of leaving a non-forwarding
+				// snapshot with the commit reported successful.
+				if m.pendingWorkerArm {
+					if err := m.retryDeferredWorkerArmLocked(); err != nil {
+						slog.Warn("userspace: deferred-worker arm retry failed; will retry", "err", err)
+					}
+				}
 				helperActiveSig := activeHAGroupSignatureSlice(status.HAGroups)
 				if m.clusterHA {
 					_ = m.refreshHAStateFromMapsLocked()


### PR DESCRIPTION
## Summary

After a **live RETH virtual-MAC change with no link cycle**, the daemon's
mandatory deferred-worker re-apply swallowed its `ApplyConfig` error, and the
userspace manager only advances snapshot bookkeeping on a successful publish. A
failed re-apply therefore left the workerless `DeferWorkers=true` snapshot as
the published/last state, status reconciliation replayed it, the AF_XDP workers
never bound, and the commit still reported **success** — a silent forwarding
outage on that node.

Closes #5134.

## Root cause

1. The commit's first dataplane apply runs with `SetDeferWorkers(true)` and
   publishes a workerless `DeferWorkers=true` snapshot (deferring worker startup
   avoids the mlx5 zero-copy double-bind EBUSY).
2. The daemon issues a **mandatory** second `ApplyConfig` with the correct MAC
   and `DeferWorkers` cleared — this re-apply is what actually arms the workers.
3. That re-apply's error was `slog.Warn`'d and dropped. The manager stores
   `lastSnapshot` / `publishedSnapshot` / `lastSnapshotHash` **only after** a
   successful `apply_snapshot`, so on failure it kept the workerless snapshot,
   with `publishedSnapshot == lastSnapshot.Generation`. `syncSnapshotLocked`
   never retried; workers never bound.

## Fix

Propagate the failure as **generation debt** instead of dropping it:

- **Daemon** (`pkg/daemon/daemon_apply.go`): extract the branch into
  `reapplyAfterDeferredMAC(cfg)`. On a failed re-apply it calls
  `recordDataplaneWorkerArmDebt()` (optional type assertion on `d.dp` /
  `d.dp.Link()`, mirroring `setDataplaneDeferWorkers`) rather than swallowing.
- **Manager** (`pkg/dataplane/userspace/manager_worker_arm_5134.go`):
  `RecordDeferredWorkerArmDebt()` sets `pendingWorkerArm`. The 1 Hz status
  reconcile loop calls `retryDeferredWorkerArmLocked()`, which republishes the
  retained snapshot with `DeferWorkers=false` and a bumped generation until the
  workers bind, then clears the debt. A transient helper / control-socket error
  self-heals **without** failing the commit; a workerless snapshot is never the
  terminal published state under a reported-successful commit.

The retry republishes `lastSnapshot` (the config did not change between the
deferred apply and the re-apply), mirroring the republish bookkeeping in
`UpdatePolicyScheduleState` / `syncSnapshotLocked`. Debt is settled early if a
later full apply already published `DeferWorkers=false`, or if the helper is
gone (a restart replays through the normal apply path).

## Tests (fail-on-revert, both RED-verified)

- `pkg/daemon/deferred_mac_reapply_5134_test.go`: `reapplyAfterDeferredMAC`
  records debt on a failing fake `ApplyConfig`, records none on success.
  Reverting to the swallow leaves `debtRecords=0` → fail (verified).
- `pkg/dataplane/userspace/manager_worker_arm_5134_test.go`: debt is retained
  (snapshot stays `DeferWorkers=true`, `publishedSnapshot` unchanged) while the
  helper keeps rejecting the re-arm; once the helper recovers, the retry
  publishes `DeferWorkers=false` and clears the debt. Reverting the retry to a
  swallow makes both fail (verified).

## Docs

`docs/reth-mac.md` gains a "Deferred AF_XDP Worker Arming After a Live MAC
Change (#5134)" section documenting the link-cycle vs live-MAC arm paths and
the debt/retry contract.

## Validation

- `GOCACHE=… GOTMPDIR=… go build ./...` → exit 0
- `go test ./pkg/daemon/... ./pkg/dataplane/...` → exit 0
- `gofmt -l` clean, `go vet` clean

## HA-forwarding-critical — `make test-failover`

This touches a **failover-adjacent** path (live RETH virtual-MAC change). Please
run `make test-failover` before merge. It should confirm **no forwarding outage
after a live MAC change**: sustained iperf3 through the cluster stays up across
an RG transition that programs the RETH MAC live (no link cycle), with the
newly-active node's AF_XDP workers bound (`show`/status forwarding-armed) rather
than stuck on a workerless `DeferWorkers=true` snapshot. To exercise the failure
self-heal directly you would need to inject a transient helper `apply_snapshot`
rejection on the re-apply and confirm the status loop rebinds within a second or
two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi