### PR TITLE
configstore: make LoadSet/LoadMerge flat-load atomic (#5187)

### DIFF
--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -756,6 +756,21 @@ owned by the `journal/` subpackage.
     tabs as whitespace) — not only a literal space.
   - Hierarchical `LoadMerge` is unaffected — it round-trips through
     `FormatSet()`, which always emits verb-prefixed lines.
+- Flat-load request atomicity (#5187): `LoadSet` and BOTH `LoadMerge`
+  branches (flat set-format and hierarchical-via-`FormatSet`) replay every
+  edit line into a deep clone of the candidate (`ConfigTree.Clone`) and swap
+  it into `s.candidate` — setting `dirty` and refreshing the config-lock
+  lease — ONLY after ALL lines apply. On ANY line error the method returns
+  WITHOUT touching `s.candidate`, `dirty`, or the lease, so
+  `candidate_after_error == candidate_before_request` byte-for-byte. This
+  mirrors `LoadOverride`, which already parsed into a separate tree before
+  the swap. Previously all three replayed each line directly onto the live
+  candidate and returned on the first failure, leaving every EARLIER
+  set/delete line committed while the RPC/CLI reported the load FAILED — a
+  non-atomic import. The partial-delete case was fail-OPEN: replacement deny
+  lines placed AFTER the failing line were dropped, yet the candidate had
+  already advanced. (Distinct from the #3442 fix above, which addressed
+  silent-skip of a malformed line, not partial application.)
 - Commit atomicity (#846): `pkg/daemon` wraps `Commit()` together with
   `applyConfig()` under a single semaphore. Bypassing the daemon (e.g.
   using `Store` directly) loses that serialization, so concurrent CLI +

--- a/pkg/configstore/atomic_load_5187_test.go
+++ b/pkg/configstore/atomic_load_5187_test.go
@@ -1,0 +1,90 @@
+package configstore
+
+import (
+	"testing"
+	"time"
+)
+
+// #5187: LoadSet / LoadMerge must import the whole batch or nothing. Before the
+// fix both replayed each flat line directly onto the LIVE candidate and returned
+// on the first error, leaving every EARLIER set/delete line committed to the
+// candidate while the RPC/CLI reported the load FAILED — a non-atomic import. A
+// partial delete was fail-open: replacement deny lines placed AFTER the failing
+// line were dropped, yet the candidate had already advanced. The fix mirrors
+// LoadOverride: replay into a deep clone and swap it in only on complete
+// success, so a mid-body error leaves the candidate byte-identical to before the
+// request with dirty/lease state untouched.
+//
+// Both tests below are RED on revert: the pre-fix line-by-line-on-live-candidate
+// behavior mutates the candidate (host-name changed + eth0 deleted) before the
+// trailing bad line fails, so the byte-identity assertion trips.
+
+// seedForAtomicLoad enters config mode, seeds a baseline candidate the failing
+// batch will attempt to mutate, and resets dirty so a failed load's effect on
+// dirty is observable. It returns the pre-request candidate serialization, dirty
+// flag, and config-lock lease so the caller can assert none of them changed.
+func seedForAtomicLoad(t *testing.T) (s *Store, before string, beforeDirty bool, beforeLease time.Time) {
+	t.Helper()
+	s = newTestStore(t)
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := s.SetFromInput("system host-name original"); err != nil {
+		t.Fatalf("seed host-name: %v", err)
+	}
+	if err := s.SetFromInput("interfaces eth0 unit 0 family inet address 10.0.0.1/24"); err != nil {
+		t.Fatalf("seed interface: %v", err)
+	}
+	before = s.ShowCandidateSet()
+	// Clean baseline: a failed load must not dirty the candidate nor refresh the
+	// idle lease. Reading/writing the unexported fields is fine — the test is
+	// in-package and single-goroutine.
+	s.dirty = false
+	beforeDirty = s.dirty
+	beforeLease = s.configLockAt
+	return s, before, beforeDirty, beforeLease
+}
+
+// atomicBadBatch has two valid mutating lines (change the host-name, delete the
+// seeded eth0) followed by a line that errors — a delete of an interface that
+// does not exist (ErrPathNotFound). The trailing verb IS recognized, so it flows
+// through applyEditLine and fails at apply time rather than the fail-closed verb
+// gate, exercising the partial-apply path.
+const atomicBadBatch = "set system host-name changed\n" +
+	"delete interfaces eth0\n" +
+	"delete interfaces eth9"
+
+func assertCandidateUnchanged(t *testing.T, s *Store, before string, beforeDirty bool, beforeLease time.Time) {
+	t.Helper()
+	if after := s.ShowCandidateSet(); after != before {
+		t.Errorf("candidate mutated by a FAILED load (non-atomic import)\n--- before ---\n%s\n--- after ---\n%s", before, after)
+	}
+	if s.dirty != beforeDirty {
+		t.Errorf("dirty flag changed by a FAILED load: before=%v after=%v", beforeDirty, s.dirty)
+	}
+	if s.configLockAt != beforeLease {
+		t.Errorf("config-lock idle lease refreshed by a FAILED load: before=%v after=%v", beforeLease, s.configLockAt)
+	}
+}
+
+func TestLoadSet_AtomicOnMidBodyError_5187(t *testing.T) {
+	s, before, beforeDirty, beforeLease := seedForAtomicLoad(t)
+
+	count, err := s.LoadSet(atomicBadBatch)
+	if err == nil {
+		t.Fatalf("LoadSet: expected an error on the delete of a non-existent node, got nil (count=%d)", count)
+	}
+	assertCandidateUnchanged(t, s, before, beforeDirty, beforeLease)
+}
+
+func TestLoadMerge_AtomicOnMidBodyError_5187(t *testing.T) {
+	s, before, beforeDirty, beforeLease := seedForAtomicLoad(t)
+
+	// The batch begins with "set ..." lines, so LoadMerge selects the flat
+	// set-format branch (the branch that carries the fail-open partial-delete
+	// risk).
+	if err := s.LoadMerge(atomicBadBatch); err == nil {
+		t.Fatalf("LoadMerge: expected an error on the delete of a non-existent node, got nil")
+	}
+	assertCandidateUnchanged(t, s, before, beforeDirty, beforeLease)
+}

--- a/pkg/configstore/store_command.go
+++ b/pkg/configstore/store_command.go
@@ -344,6 +344,17 @@ func (s *Store) LoadMergeAs(sessionID, content string) error {
 		}
 	}
 
+	// #5187: merge into a deep clone of the candidate and swap it in only on
+	// complete success. Both branches below previously applied each line
+	// directly to s.candidate and returned on the first error, leaving every
+	// EARLIER set/delete line committed to the live candidate while the
+	// RPC/CLI reported the merge FAILED — a non-atomic import (a partial
+	// delete could drop replacement deny lines that followed the failing line
+	// = fail-open). Mirror LoadOverride's parse-into-a-separate-tree-then-swap
+	// discipline so a mid-body error leaves the candidate byte-identical to
+	// before the request (dirty/lease state untouched).
+	working := s.candidate.Clone()
+
 	if isSetFormat {
 		// #3442 M3: once flat set-format is selected, every non-comment line
 		// MUST start with a recognized verb. Otherwise ParseSetVerb treats a
@@ -360,7 +371,7 @@ func (s *Store) LoadMergeAs(sessionID, content string) error {
 			if !hasFlatVerb(trimmed) {
 				return fmt.Errorf("line %d: %q is not a set/delete/deactivate/activate command", i+1, trimmed)
 			}
-			if err := applyEditLine(s.candidate, trimmed); err != nil {
+			if err := applyEditLine(working, trimmed); err != nil {
 				return fmt.Errorf("line %d: %q: %w", i+1, trimmed, err)
 			}
 		}
@@ -381,12 +392,13 @@ func (s *Store) LoadMergeAs(sessionID, content string) error {
 			if trimmed == "" {
 				continue
 			}
-			if err := applyEditLine(s.candidate, trimmed); err != nil {
+			if err := applyEditLine(working, trimmed); err != nil {
 				return fmt.Errorf("merge: %w", err)
 			}
 		}
 	}
 
+	s.candidate = working
 	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
 	s.dirty = true
 	return nil
@@ -479,6 +491,17 @@ func (s *Store) LoadSetAs(sessionID, content string) (int, error) {
 	if s.candidate == nil {
 		return 0, fmt.Errorf("not in configuration mode")
 	}
+	// #5187: replay every line into a deep clone of the candidate and swap it
+	// in only after ALL lines apply. Applying directly to s.candidate advanced
+	// it line-by-line and, on the first failing line, left every EARLIER
+	// set/delete line committed to the live candidate while the RPC/CLI
+	// reported the load FAILED — a non-atomic import. A partial delete was
+	// fail-open: replacement deny lines that followed the failing line were
+	// dropped, yet the candidate had already advanced. Mirror LoadOverride's
+	// parse-into-a-separate-tree-then-swap discipline so a mid-body error
+	// leaves the candidate byte-identical to before the request (dirty/lease
+	// state untouched).
+	working := s.candidate.Clone()
 	count := 0
 	for i, line := range strings.Split(content, "\n") {
 		line = strings.TrimSpace(line)
@@ -493,11 +516,12 @@ func (s *Store) LoadSetAs(sessionID, content string) (int, error) {
 		if !hasFlatVerb(line) {
 			return count, fmt.Errorf("line %d: %q is not a set/delete/deactivate/activate command", i+1, line)
 		}
-		if err := applyEditLine(s.candidate, line); err != nil {
+		if err := applyEditLine(working, line); err != nil {
 			return count, fmt.Errorf("line %d: %q: %w", i+1, line, err)
 		}
 		count++
 	}
+	s.candidate = working
 	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
 	s.dirty = true
 	return count, nil


### PR DESCRIPTION
## Problem

`LoadSet` and BOTH `LoadMerge` branches replayed each flat set/delete
line directly onto the live candidate via `applyEditLine(s.candidate, ...)`
and returned on the first error. Every EARLIER set/delete line therefore
stayed committed to `s.candidate` while the RPC/CLI reported the load
FAILED — a **non-atomic import**. `dirty`/`touch` ran only on full
success, but callers do not roll back the candidate.

The partial-**delete** case was **fail-OPEN**: replacement deny lines
placed AFTER the failing line were dropped, yet the candidate had already
advanced past the earlier deletes. `LoadOverride` was already correct (it
parses into a separate tree and swaps); `LoadSet`/`LoadMerge` never cloned.

- **Locations:** `pkg/configstore/store_command.go` — `LoadSetAs`,
  `LoadMergeAs` (flat set-format branch + hierarchical-via-`FormatSet`
  branch).
- **Invariant restored:** `candidate_after_error == candidate_before_request`
  byte-for-byte; `dirty`/lease unchanged on failure.

## Fix

Mirror `LoadOverride`'s clone-then-swap discipline: replay every line into
`s.candidate.Clone()` (a verified deep copy — `cloneNodes` recurses
children and copies each node's `Keys` slice), and swap the working tree
into `s.candidate` (setting `dirty` + refreshing the config-lock lease)
ONLY after all lines apply. On any line error the method returns without
mutating `s.candidate`, `dirty`, or the lease. Success-path behavior and
per-line validation order are unchanged. Distinct from #3442, which fixed
silent-skip of a malformed line, not partial application.

## Test

`pkg/configstore/atomic_load_5187_test.go` seeds a baseline candidate,
then submits a batch whose valid set+delete lines (change host-name,
delete eth0) precede a line that errors (delete of a non-existent
interface), and asserts the load errors while the candidate
serialization, `dirty` flag, and idle lease are all unchanged. Covers
`LoadSet` and the `LoadMerge` flat set-format branch. **Verified RED on
revert**: without the clone the earlier lines mutate the live candidate
and the byte-identity assertion trips.

## Docs

`pkg/configstore/README.md` gains a "Flat-load request atomicity (#5187)"
bullet documenting the clone-then-swap contract.

## Validation

- `go build ./...` — exit 0
- `go test ./pkg/configstore/...` — exit 0
- `gofmt` clean
- RED-on-revert confirmed via a worktree-local stash of the fix

Closes #5187

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi