### PR TITLE
pkg/api: abort long read handlers on client disconnect (#5232, #5233)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-07-09 — pkg/api: abort long read handlers on client disconnect (#5232/#5233)
+
+- **Timestamp**: 2026-07-09
+  - **Action**: #5232/#5233 pkg/api long full-table read handlers now abort
+    when the REST client disconnects (r.Context() cancelled), the HTTP analog
+    of the merged gRPC #5060. (#5232) bgpHandler's route-streaming loop
+    (`/routing/bgp?type=routes`) checks `r.Context().Err()` once per 1024-route
+    chunk and returns — a 900k-route internet table otherwise keeps formatting +
+    JSON-escaping every remaining route and writing to a dead connection
+    (CPU/GC waste). (#5233) the session handlers (`/sessions` offset walk,
+    `/sessions/summary`, `/sessions/zone-pair`) share a per-batch sampler
+    (`newRequestCancelSampler`, `sessionWalkCancelInterval`=1024): each
+    IterateSessions/IterateSessionsV6 callback returns false once the context
+    is cancelled, breaking the conntrack BPF-map walk and releasing the
+    per-bucket lock back to the live dataplane session-sync path instead of
+    holding it for a discarded scan. Sampled per batch (not per session) so the
+    check adds no per-entry cost and never fires on the normal path — output +
+    ordering unchanged. Tests (api_ctx_cancel_5232_5233_test.go): each handler
+    driven with an already-cancelled request context over a large synthetic
+    table asserts an early abort (bgp: <=1024 route lines emitted, no closing
+    envelope; sessions: exactly one sampling window walked) plus a non-cancelled
+    positive control (bgp byte-equal to golden; sessions walk the whole table).
+    All RED on revert of the checks (empirically verified). Validation:
+    `go build ./...` clean; `go test ./pkg/api/...` green.
+  - **File(s)**: pkg/api/routing.go, pkg/api/sessions.go,
+    pkg/api/api_ctx_cancel_5232_5233_test.go, pkg/api/README.md
+
 ## 2026-07-09 — grpcapi: enforce config-lock holder on mutators/commit (#5059)
 
 - **Timestamp**: 2026-07-09

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -326,6 +326,24 @@ under the daemon's errgroup. Nothing else imports this package.
   contract is pinned by `sessions_iterator_error_test.go` in this package
   and in `pkg/grpcapi` / `pkg/cli` (CLI top-talkers fails the command; NAT
   summaries print a stderr warning).
+- Long full-table read handlers must ABORT when the client disconnects
+  (#5232/#5233). The REST server cancels `r.Context()` on disconnect, so a
+  handler that walks a large structure has to sample `r.Context().Err()`
+  periodically and stop rather than run to completion for a response nobody
+  will read. `bgpHandler` (`/routing/bgp?type=routes`) checks once per
+  1024-route chunk in its streaming loop and returns — a full internet table
+  (900k+ routes) otherwise keeps formatting + JSON-escaping every remaining
+  route and writing to a dead connection (CPU/GC waste, #5232). The session
+  handlers (`/sessions`, `/sessions/summary`, `/sessions/zone-pair`) share a
+  per-batch sampler (`newRequestCancelSampler`, `sessionWalkCancelInterval`
+  = 1024): each `IterateSessions`/`IterateSessionsV6` callback returns
+  `false` once the context is cancelled, breaking the conntrack map walk and
+  releasing the per-bucket BPF-map lock back to the live dataplane
+  session-sync path (#5233) instead of holding it for a discarded scan. The
+  sampler probes `ctx.Err()` once per batch (not per session) so the check
+  adds no per-entry cost, and it never fires on the normal path — output and
+  ordering are unchanged. Pinned by `api_ctx_cancel_5232_5233_test.go`. This
+  is the REST analog of the gRPC `streamDiagCmd` cancellation cleanup (#5060).
 - Session-count metrics come from the LIVE dataplane session table, not
   the BPF GC sweep stats (#3929). `collectSessionGauges`
   (`metrics_sessions.go`) derives `xpf_sessions_active` (forward entries)

--- a/pkg/api/api_ctx_cancel_5232_5233_test.go
+++ b/pkg/api/api_ctx_cancel_5232_5233_test.go
@@ -1,0 +1,216 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// These tests pin the #5232 / #5233 request-context cancellation contract:
+// once the REST client disconnects (r.Context() cancelled), a handler that
+// walks a large data structure must ABORT the walk instead of running to
+// completion for a response nobody will read.
+//
+//   - #5232 bgpHandler: streaming a full internet BGP table (900k+ routes)
+//     keeps formatting + JSON-escaping every remaining route and writing to a
+//     dead connection — pure CPU/GC waste.
+//   - #5233 session handlers: walking the whole conntrack BPF map keeps
+//     holding per-bucket locks, contending with the live dataplane
+//     session-sync path.
+//
+// Each test drives the handler with an already-cancelled request context over
+// a large synthetic table and asserts the handler stops early. FAIL-ON-REVERT:
+// remove the context checks and the handler processes every entry, flipping
+// the "< N" / "no closing envelope" / "visited == N" assertions red.
+
+// cancelledRequest returns req with an already-cancelled context attached, so
+// r.Context().Err() is non-nil on the first check.
+func cancelledRequest(req *http.Request) *http.Request {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return req.WithContext(ctx)
+}
+
+// countEscapedNewlines counts the number of route lines rendered into a
+// streamed bgpHandler body. Each line is emitted as `...\n` and the trailing
+// real newline is JSON-escaped to the two-byte sequence backslash+'n'; the
+// synthetic routes contain no other escapable bytes, so this equals the number
+// of route lines flushed to the wire.
+func countEscapedNewlines(body []byte) int {
+	return bytes.Count(body, []byte(`\n`))
+}
+
+func TestBGPRoutesStreamAbortsOnCanceledContext(t *testing.T) {
+	// A table well past the 1024-route flush/check chunk so a correct abort
+	// stops far short of the full table.
+	const n = 5000
+	routes := make([][3]string, n)
+	for i := 0; i < n; i++ {
+		routes[i] = [3]string{
+			fmt.Sprintf("10.%d.%d.0/24", i/256, i%256),
+			fmt.Sprintf("192.168.%d.%d", i/256, i%256),
+			fmt.Sprintf("65000 %d i", i),
+		}
+	}
+	s := newBGPServer(t, makeFRRBGPOutput(routes))
+	parsed, err := s.frr.GetBGPRoutes()
+	if err != nil {
+		t.Fatalf("GetBGPRoutes: %v", err)
+	}
+	if len(parsed) != n {
+		t.Fatalf("parsed %d routes, want %d", len(parsed), n)
+	}
+
+	// Cancelled request: the stream must abort at the first 1024-route chunk
+	// boundary rather than rendering all 5000 routes.
+	t.Run("canceled aborts early", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := cancelledRequest(httptest.NewRequest(http.MethodGet, "/api/routing/bgp?type=routes", nil))
+		s.bgpHandler(rec, req)
+
+		body := rec.Body.Bytes()
+		emitted := countEscapedNewlines(body)
+		if emitted >= n {
+			t.Fatalf("emitted %d route lines on cancelled context, want < %d (handler did not abort the stream)", emitted, n)
+		}
+		// The abort happens at the first 1024-route chunk, so at most 1024
+		// route lines can have been formatted (and fewer flushed).
+		if emitted > 1024 {
+			t.Errorf("emitted %d route lines, want <= 1024 (abort should fire at the first chunk boundary)", emitted)
+		}
+		// The closing envelope `"}}` is only written after the loop
+		// completes; an aborted stream must not contain it (the body is a
+		// deliberately truncated write to a dead connection).
+		if bytes.Contains(body, []byte("}}")) {
+			t.Errorf("cancelled stream contains the closing envelope; handler streamed the whole table anyway")
+		}
+	})
+
+	// Positive control: an un-cancelled request over the same table is
+	// byte-for-byte the full buffered golden — the cancel check never fires
+	// on the normal path, so output and ordering are unchanged.
+	t.Run("normal path unchanged", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/routing/bgp?type=routes", nil)
+		s.bgpHandler(rec, req)
+
+		golden := bufferedBGPResponse(t, parsed)
+		if !bytes.Equal(rec.Body.Bytes(), golden) {
+			t.Fatalf("non-cancelled body != buffered golden (got %d bytes, want %d)", rec.Body.Len(), len(golden))
+		}
+		if got := countEscapedNewlines(rec.Body.Bytes()); got != n {
+			t.Errorf("non-cancelled emitted %d route lines, want %d", got, n)
+		}
+	})
+}
+
+// cancelCountDP is an apiRuntimeDataPlane that offers a fixed number of
+// synthetic forward (IsReverse==0) sessions and records how many the walk
+// actually visited before it stopped. It embeds *dataplane.Manager purely to
+// satisfy the methods the session handlers do not exercise here (GetSessionV4
+// etc. return the Manager's "map not found" error, which enrichSessionV4
+// tolerates as a no-op merge).
+type cancelCountDP struct {
+	*dataplane.Manager
+	nV4     int
+	nV6     int
+	visited int
+}
+
+func (d *cancelCountDP) IsLoaded() bool { return true }
+
+func (d *cancelCountDP) IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	for i := 0; i < d.nV4; i++ {
+		d.visited++
+		var k dataplane.SessionKey
+		var v dataplane.SessionValue // IsReverse==0 => matchV4 admits it
+		if !fn(k, v) {
+			return nil
+		}
+	}
+	return nil
+}
+
+func (d *cancelCountDP) IterateSessionsV6(fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	for i := 0; i < d.nV6; i++ {
+		d.visited++
+		var k dataplane.SessionKeyV6
+		var v dataplane.SessionValueV6
+		if !fn(k, v) {
+			return nil
+		}
+	}
+	return nil
+}
+
+func TestSessionHandlersAbortWalkOnCanceledContext(t *testing.T) {
+	// A table many sampling windows past sessionWalkCancelInterval so a
+	// correct abort visits far fewer than the full table.
+	const n = 20 * sessionWalkCancelInterval
+
+	cases := []struct {
+		name    string
+		path    string
+		handler func(*Server, *httptest.ResponseRecorder, *http.Request)
+	}{
+		{
+			name: "sessions list (offset)",
+			path: "/api/v1/sessions",
+			handler: func(s *Server, rr *httptest.ResponseRecorder, r *http.Request) {
+				s.sessionsHandler(rr, r)
+			},
+		},
+		{
+			name: "sessions summary",
+			path: "/api/v1/sessions/summary",
+			handler: func(s *Server, rr *httptest.ResponseRecorder, r *http.Request) {
+				s.sessionSummaryHandler(rr, r)
+			},
+		},
+		{
+			name: "sessions zone-pair",
+			path: "/api/v1/sessions/zone-pair",
+			handler: func(s *Server, rr *httptest.ResponseRecorder, r *http.Request) {
+				s.sessionZonePairHandler(rr, r)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Cancelled: the walk must stop within one sampling window.
+			dp := &cancelCountDP{Manager: dataplane.New(), nV4: n}
+			s := &Server{dp: dp}
+			rr := httptest.NewRecorder()
+			tc.handler(s, rr, cancelledRequest(httptest.NewRequest(http.MethodGet, tc.path, nil)))
+
+			if dp.visited >= n {
+				t.Fatalf("%s: visited %d of %d sessions on cancelled context, want < %d (walk not aborted)",
+					tc.name, dp.visited, n, n)
+			}
+			// The sampler probes ctx.Err() once per sessionWalkCancelInterval
+			// entries and latches on the first cancelled probe, so exactly one
+			// window is walked before the abort.
+			if dp.visited != sessionWalkCancelInterval {
+				t.Errorf("%s: visited %d sessions, want %d (one sampling window)",
+					tc.name, dp.visited, sessionWalkCancelInterval)
+			}
+
+			// Positive control: an un-cancelled request walks the ENTIRE
+			// table — the sampler never latches, so behavior is unchanged.
+			dp2 := &cancelCountDP{Manager: dataplane.New(), nV4: n}
+			s2 := &Server{dp: dp2}
+			rr2 := httptest.NewRecorder()
+			tc.handler(s2, rr2, httptest.NewRequest(http.MethodGet, tc.path, nil))
+			if dp2.visited != n {
+				t.Errorf("%s: non-cancelled visited %d of %d sessions, want all %d walked",
+					tc.name, dp2.visited, n, n)
+			}
+		})
+	}
+}

--- a/pkg/api/routing.go
+++ b/pkg/api/routing.go
@@ -113,6 +113,17 @@ func (s *Server) bgpHandler(w http.ResponseWriter, r *http.Request) {
 			// Periodically push bytes onto the wire so a very large table
 			// streams out instead of parking in buffers.
 			if (i+1)%1024 == 0 {
+				// Abort if the client has disconnected: a full internet
+				// table (900k+ routes) would otherwise keep formatting and
+				// JSON-escaping every remaining route and writing to a dead
+				// connection after r.Context() is cancelled — pure CPU/GC
+				// waste on a RAM-constrained firewall (#5232). Checked once
+				// per 1024-route chunk, so the abort is timely without any
+				// per-route cost. The un-flushed bufio tail and closing
+				// envelope are intentionally dropped: the connection is gone.
+				if r.Context().Err() != nil {
+					return
+				}
 				bw.Flush()
 				if f, ok := w.(http.Flusher); ok {
 					f.Flush()

--- a/pkg/api/sessions.go
+++ b/pkg/api/sessions.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
@@ -28,6 +29,42 @@ import (
 type sessionCursorIterator interface {
 	IterateSessionsFrom(*dataplane.SessionKey, func(dataplane.SessionKey, dataplane.SessionValue) bool) error
 	IterateSessionsV6From(*dataplane.SessionKeyV6, func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
+}
+
+// sessionWalkCancelInterval is how many conntrack entries a session map walk
+// visits between request-context cancellation samples. Each iter.Next holds a
+// per-bucket BPF-map lock, so a REST client that has disconnected
+// (r.Context() cancelled) should stop the full-table walk promptly to release
+// that lock back to the live dataplane session-sync path (#5233). Sampling
+// once per batch keeps the mutex-guarded ctx.Err() read off the per-session
+// hot path — probing every single entry would itself add lock traffic across a
+// multi-million-entry table.
+const sessionWalkCancelInterval = 1024
+
+// newRequestCancelSampler returns a predicate reporting whether ctx has been
+// cancelled, inspecting ctx.Err() only once per `every` calls and latching
+// true once observed. Session iterator callbacks call it at the top of each
+// invocation so a long conntrack map walk aborts (the callback returns false,
+// breaking IterateSessions) within one sampling window of a client disconnect,
+// without paying ctx.Err() per session (#5233). On the normal, non-cancelled
+// path it never returns true, so output and ordering are unchanged.
+func newRequestCancelSampler(ctx context.Context, every int) func() bool {
+	if every < 1 {
+		every = 1
+	}
+	n := 0
+	cancelled := false
+	return func() bool {
+		if cancelled {
+			return true
+		}
+		n++
+		if n >= every {
+			n = 0
+			cancelled = ctx.Err() != nil
+		}
+		return cancelled
+	}
 }
 
 func (s *Server) sessionsHandler(w http.ResponseWriter, r *http.Request) {
@@ -104,10 +141,20 @@ func (s *Server) sessionsOffset(w http.ResponseWriter, r *http.Request, q *sessi
 	all := make([]SessionEntry, 0)
 	idx := 0
 
+	// Abort the full-table walk if the client disconnects: on a
+	// multi-million-session firewall the offset scan otherwise runs to
+	// completion holding per-bucket BPF-map locks even though the response
+	// is discarded, contending with the live dataplane session-sync path
+	// (#5233). Sampled per batch so the check costs nothing per session.
+	cancelled := newRequestCancelSampler(r.Context(), sessionWalkCancelInterval)
+
 	// IPv4 sessions. A backend iterator failure (e.g. helper restart
 	// mid-scan) must fail the request rather than returning HTTP 200 with
 	// a partial/zero session list as a healthy result (#2469).
 	if err := s.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+		if cancelled() {
+			return false
+		}
 		if !q.matchV4(key, val) {
 			return true
 		}
@@ -123,6 +170,9 @@ func (s *Server) sessionsOffset(w http.ResponseWriter, r *http.Request, q *sessi
 
 	// IPv6 sessions
 	if err := s.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+		if cancelled() {
+			return false
+		}
 		if !q.matchV6(key, val) {
 			return true
 		}
@@ -452,9 +502,17 @@ func (s *Server) sessionSummaryHandler(w http.ResponseWriter, r *http.Request) {
 
 	var summary SessionSummary
 
+	// Stop the full-table walk if the client disconnects mid-scan so we do
+	// not keep holding per-bucket BPF-map locks for a summary nobody will
+	// read (#5233); sampled per batch (see newRequestCancelSampler).
+	cancelled := newRequestCancelSampler(r.Context(), sessionWalkCancelInterval)
+
 	// A partial scan yields an under-count that looks like a healthy
 	// summary — fail the request instead of publishing it (#2469).
 	if err := s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
+		if cancelled() {
+			return false
+		}
 		summary.TotalEntries++
 		if val.IsReverse == 0 {
 			summary.ForwardOnly++
@@ -476,6 +534,9 @@ func (s *Server) sessionSummaryHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+		if cancelled() {
+			return false
+		}
 		summary.TotalEntries++
 		if val.IsReverse == 0 {
 			summary.ForwardOnly++
@@ -634,9 +695,18 @@ func (s *Server) sessionZonePairHandler(w http.ResponseWriter, r *http.Request) 
 		zp.Total++
 	}
 
+	// Stop the full-table walk if the client disconnects mid-scan so the
+	// per-bucket BPF-map locks are released back to the live dataplane
+	// instead of finishing a breakdown nobody will read (#5233); sampled
+	// per batch (see newRequestCancelSampler).
+	cancelled := newRequestCancelSampler(r.Context(), sessionWalkCancelInterval)
+
 	// A partial scan produces a misleading zone-pair breakdown — fail
 	// the request rather than serving an incomplete table as OK (#2469).
 	if err := s.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+		if cancelled() {
+			return false
+		}
 		if val.IsReverse == 0 {
 			countSession(val.IngressZone, val.EgressZone, key.Protocol)
 		}
@@ -646,6 +716,9 @@ func (s *Server) sessionZonePairHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if err := s.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+		if cancelled() {
+			return false
+		}
 		if val.IsReverse == 0 {
 			countSession(val.IngressZone, val.EgressZone, key.Protocol)
 		}


### PR DESCRIPTION
## Summary

The REST server cancels `r.Context()` when a client disconnects, but two full-table read paths in `pkg/api` kept running to completion afterward — burning CPU and, worse, holding dataplane locks for a response nobody will read. This is the HTTP analog of the merged gRPC `streamDiagCmd` cleanup (#5060): periodic context-cancellation checks that abort the loop.

### #5232 — bgpHandler CPU/GC waste (`routing.go`)
The `type=routes` branch streams every route in a loop, flushing every 1024 iterations, with **no** cancel check. On a full internet table (900k+ prefixes) a client timeout left the loop formatting + JSON-escaping every remaining route and writing to a dead connection. Fix: check `r.Context().Err()` inside the existing per-1024-route chunk block and return. The abort is timely with **no per-route cost**; the un-flushed bufio tail and closing envelope are intentionally dropped (the connection is gone).

### #5233 — session-handler BPF bucket-lock contention (`sessions.go`)
`sessionsOffset`, `sessionSummaryHandler`, and `sessionZonePairHandler` walk the **entire** conntrack BPF map via `IterateSessions`/`IterateSessionsV6` with callbacks that never checked the request context. On a firewall with millions of sessions a disconnect left the full traversal running — per-bucket map locks + read syscalls — contending with the live dataplane session-sync path even though the response is discarded. Fix: a shared per-batch sampler (`newRequestCancelSampler`, `sessionWalkCancelInterval` = 1024). Each callback returns `false` once the context is cancelled, breaking the walk (`Manager.IterateSessions` loop) and releasing the per-bucket lock. Sampling `ctx.Err()` once per batch (not per session) keeps the mutex-guarded read off the per-session hot path and never fires on the normal path, so output and ordering are unchanged.

## Correctness
- Returning `false` from the iterator callback breaks `Manager.IterateSessions`'s loop (`maps_session.go`) — that is what releases the lock.
- A live, still-connected client never observes a cancelled context mid-handler, so no healthy request is ever truncated. An early/inaccurate `Total` is harmless once the client is gone.
- No behavior change on the non-cancelled path.

## Tests (`api_ctx_cancel_5232_5233_test.go`)
Each handler is driven with an already-cancelled request context over a large synthetic table and asserts an early abort — `bgpHandler` emits at most one 1024-route chunk and no closing envelope; the session handlers walk exactly one sampling window. Non-cancelled positive controls prove the normal path is unchanged (bgp body byte-equal to the buffered golden; sessions walk the whole table). **All four handler assertions were empirically confirmed to go RED when the checks are reverted.**

## Validation
- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` — clean (exit 0)
- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/api/...` — green (exit 0)
- `pkg/api/README.md` documents the new disconnect-abort contract alongside the #2469 iterator-error contract.

Closes #5232
Closes #5233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi