### PR TITLE
daemon: publish mgmtVRFInterfaces atomically to fix DHCP-callback data race

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -384,7 +384,17 @@ type Daemon struct {
 
 	// mgmtVRFInterfaces tracks interfaces bound to the management VRF (vrf-mgmt).
 	// Used by collectDHCPRoutes to exclude management routes from FRR.
-	mgmtVRFInterfaces map[string]bool
+	//
+	// Concurrency (#5113): the apply path publishes a fresh map on each commit
+	// under applySem, but the DHCP-manager lease-change callback
+	// (onDHCPAddressChange) reads it WITHOUT applySem — an unsynchronized
+	// concurrent map-pointer read/write (a real Go data race). The published
+	// maps are immutable (replaced wholesale, never mutated in place), so the
+	// field is an atomic.Pointer: apply publishes with a single Store (see
+	// publishMgmtVRFIfaces) and every reader Loads a consistent snapshot
+	// lock-free (see mgmtVRFIfaceSet). Load may return nil before the first
+	// publish — readers treat that as "no mgmt VRF interfaces yet".
+	mgmtVRFInterfaces atomic.Pointer[map[string]bool]
 
 	// rgStates tracks the unified cluster + VRRP state for each
 	// redundancy group. Both watchClusterEvents and watchVRRPEvents

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1019,8 +1019,8 @@ func (d *Daemon) applyDataplaneAndHACore(ctx context.Context, cfg *config.Config
 	// networkctl reconfigure strips VRF master bindings because networkd
 	// considers the daemon-created vrf-mgmt device "unmanaged" and ignores
 	// the VRF= directive. Re-bind here to restore VRF membership.
-	if d.routing != nil && d.mgmtVRFInterfaces != nil {
-		for ifName := range d.mgmtVRFInterfaces {
+	if mgmtSet := d.mgmtVRFIfaceSet(); d.routing != nil && len(mgmtSet) > 0 {
+		for ifName := range mgmtSet {
 			if err := d.routing.BindInterfaceToVRF(ifName, "mgmt"); err != nil {
 				slog.Warn("failed to re-bind interface to management VRF",
 					"interface", ifName, "err", err)
@@ -1485,9 +1485,14 @@ func (d *Daemon) applyVRFReconcile(ctx context.Context, cfg *config.Config) erro
 	// If reconcile errored out before vrf-mgmt could be created,
 	// downstream code (applyMgmtVRFRoutes, HA sync) would otherwise
 	// run against a non-existent VRF.
-	d.mgmtVRFInterfaces = nil
+	// Compute the final management-VRF interface set, then publish it with a
+	// single atomic Store (#5113) so a lock-free DHCP-callback reader never
+	// observes the transient nil the old two-step (= nil then = mgmtIfaces)
+	// published. mgmtSet stays nil (readers see the safe empty state) unless
+	// reconcile actually got vrf-mgmt into the managed set.
+	var mgmtSet map[string]bool
 	if d.routing != nil && len(mgmtIfaces) > 0 && d.routing.IsManagedVRF(mgmtVRFName) {
-		d.mgmtVRFInterfaces = mgmtIfaces
+		mgmtSet = mgmtIfaces
 		for ifName := range mgmtIfaces {
 			if err := d.routing.BindInterfaceToVRF(ifName, mgmtVRFName); err != nil {
 				slog.Warn("failed to bind interface to management VRF",
@@ -1495,6 +1500,7 @@ func (d *Daemon) applyVRFReconcile(ctx context.Context, cfg *config.Config) erro
 			}
 		}
 	}
+	d.publishMgmtVRFIfaces(mgmtSet)
 
 	// 0.6. Program default routes in the management VRF for DHCP leases.
 	d.applyMgmtVRFRoutes()

--- a/pkg/daemon/daemon_dhcp.go
+++ b/pkg/daemon/daemon_dhcp.go
@@ -192,8 +192,11 @@ func (d *Daemon) dhcpLeaseChangeRequiresRecompile(cfg *config.Config) bool {
 	if d.dhcp != nil && len(d.dhcp.DelegatedPrefixesForRA()) > 0 {
 		return true
 	}
-	// If management VRF bindings are unavailable, stay conservative.
-	if len(d.mgmtVRFInterfaces) == 0 {
+	// If management VRF bindings are unavailable, stay conservative. Read a
+	// single lock-free snapshot (#5113) so the whole classification runs
+	// against one consistent map, never a torn/nil-transient publication.
+	mgmtSet := d.mgmtVRFIfaceSet()
+	if len(mgmtSet) == 0 {
 		return true
 	}
 	for ifName, ifc := range cfg.Interfaces.Interfaces {
@@ -204,7 +207,7 @@ func (d *Daemon) dhcpLeaseChangeRequiresRecompile(cfg *config.Config) bool {
 			if unit == nil || (!unit.DHCP && !unit.DHCPv6) {
 				continue
 			}
-			if !d.mgmtVRFInterfaces[config.DHCPLeaseIfName(ifName, unit)] {
+			if !mgmtSet[config.DHCPLeaseIfName(ifName, unit)] {
 				return true
 			}
 		}

--- a/pkg/daemon/daemon_flow.go
+++ b/pkg/daemon/daemon_flow.go
@@ -22,6 +22,26 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+// mgmtVRFIfaceSet returns the currently-published management-VRF interface
+// set (nil before the first apply). The returned map is immutable — the apply
+// path publishes a fresh map wholesale via publishMgmtVRFIfaces and never
+// mutates it in place — so callers read it lock-free. See the
+// mgmtVRFInterfaces field doc (daemon.go) for the #5113 concurrency contract.
+func (d *Daemon) mgmtVRFIfaceSet() map[string]bool {
+	if p := d.mgmtVRFInterfaces.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// publishMgmtVRFIfaces atomically publishes m as the management-VRF interface
+// set. Called only from the apply path under applySem; the atomic Store makes
+// the field publication safe for the lock-free DHCP-callback readers (#5113).
+// m must be treated as immutable after this call.
+func (d *Daemon) publishMgmtVRFIfaces(m map[string]bool) {
+	d.mgmtVRFInterfaces.Store(&m)
+}
+
 // collectDHCPRoutes builds FRR DHCPRoute entries from active DHCP leases.
 // Interfaces bound to the management VRF are excluded — their routes are
 // programmed directly via netlink into the VRF table by applyMgmtVRFRoutes.
@@ -29,9 +49,10 @@ func (d *Daemon) collectDHCPRoutes() []frr.DHCPRoute {
 	if d.dhcp == nil {
 		return nil
 	}
+	mgmtSet := d.mgmtVRFIfaceSet()
 	var routes []frr.DHCPRoute
 	for _, lease := range d.dhcp.Leases() {
-		if d.mgmtVRFInterfaces[lease.Interface] {
+		if mgmtSet[lease.Interface] {
 			continue
 		}
 		isIPv6 := lease.Family == dhcp.AFInet6
@@ -61,7 +82,8 @@ func (d *Daemon) collectDHCPRoutes() []frr.DHCPRoute {
 // for DHCP leases on management interfaces (fxp*, fab*). These routes are
 // managed via netlink (not FRR) because FRR doesn't own the management VRF.
 func (d *Daemon) applyMgmtVRFRoutes() {
-	if d.dhcp == nil || len(d.mgmtVRFInterfaces) == 0 {
+	mgmtSet := d.mgmtVRFIfaceSet()
+	if d.dhcp == nil || len(mgmtSet) == 0 {
 		return
 	}
 	const mgmtTableID = 999
@@ -73,7 +95,7 @@ func (d *Daemon) applyMgmtVRFRoutes() {
 	defer nlh.Close()
 
 	for _, lease := range d.dhcp.Leases() {
-		if !d.mgmtVRFInterfaces[lease.Interface] {
+		if !mgmtSet[lease.Interface] {
 			continue
 		}
 		// A lease may carry a default gateway (option 3 or the option-121

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -414,7 +414,7 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 	// interface directly (handles config-only mode where applyConfig may
 	// have run but mgmtVRFInterfaces is empty due to VRF creation failure).
 	vrfDevice := ""
-	if len(d.mgmtVRFInterfaces) > 0 {
+	if len(d.mgmtVRFIfaceSet()) > 0 {
 		vrfDevice = "vrf-mgmt"
 	} else if cc.ControlInterface != "" {
 		// Control/fabric interfaces (em*, fab*) are always placed in

--- a/pkg/daemon/dhcp_recompile_test.go
+++ b/pkg/daemon/dhcp_recompile_test.go
@@ -7,11 +7,8 @@ import (
 )
 
 func TestDHCPLeaseChangeRequiresRecompile_ManagementOnlyDHCP(t *testing.T) {
-	d := &Daemon{
-		mgmtVRFInterfaces: map[string]bool{
-			"fxp0": true,
-		},
-	}
+	d := &Daemon{}
+	d.publishMgmtVRFIfaces(map[string]bool{"fxp0": true})
 	cfg := &config.Config{
 		Interfaces: config.InterfacesConfig{
 			Interfaces: map[string]*config.InterfaceConfig{
@@ -31,11 +28,8 @@ func TestDHCPLeaseChangeRequiresRecompile_ManagementOnlyDHCP(t *testing.T) {
 }
 
 func TestDHCPLeaseChangeRequiresRecompile_NonManagementDHCP(t *testing.T) {
-	d := &Daemon{
-		mgmtVRFInterfaces: map[string]bool{
-			"fxp0": true,
-		},
-	}
+	d := &Daemon{}
+	d.publishMgmtVRFIfaces(map[string]bool{"fxp0": true})
 	cfg := &config.Config{
 		Interfaces: config.InterfacesConfig{
 			Interfaces: map[string]*config.InterfaceConfig{

--- a/pkg/daemon/mgmtvrf_race_test.go
+++ b/pkg/daemon/mgmtvrf_race_test.go
@@ -1,0 +1,93 @@
+package daemon
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestMgmtVRFIfaceSetPrePublish asserts a reader before any apply/publish sees
+// the safe empty state (#5113): Load returns nil and every read helper treats
+// that as "no mgmt VRF interfaces yet" without panicking.
+func TestMgmtVRFIfaceSetPrePublish(t *testing.T) {
+	d := &Daemon{}
+
+	if got := d.mgmtVRFIfaceSet(); got != nil {
+		t.Fatalf("pre-publish mgmtVRFIfaceSet() = %v, want nil", got)
+	}
+	if got := len(d.mgmtVRFIfaceSet()); got != 0 {
+		t.Fatalf("pre-publish len(mgmtVRFIfaceSet()) = %d, want 0", got)
+	}
+	// The DHCP-callback classify path must be conservative (recompile) with no
+	// published set, and must not deref a nil map.
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"fxp0": {
+					Name:  "fxp0",
+					Units: map[int]*config.InterfaceUnit{0: {DHCP: true}},
+				},
+			},
+		},
+	}
+	if !d.dhcpLeaseChangeRequiresRecompile(cfg) {
+		t.Fatal("pre-publish classification should stay conservative (recompile)")
+	}
+}
+
+// TestMgmtVRFInterfacesConcurrentPublish exercises the atomic publication of
+// d.mgmtVRFInterfaces against the lock-free DHCP-callback read path. It runs a
+// writer that republishes a fresh immutable map (mimicking apply under
+// applySem) concurrently with readers walking the classify/snapshot path.
+//
+// Under `go test -race` this must be clean. Reverting mgmtVRFInterfaces to a
+// bare `map[string]bool` field with bare `= nil` / `= mgmtIfaces` assignments
+// reintroduces the #5113 unsynchronized concurrent map-pointer read/write and
+// this test fails under -race.
+func TestMgmtVRFInterfacesConcurrentPublish(t *testing.T) {
+	d := &Daemon{}
+
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"fxp0": {
+					Name:  "fxp0",
+					Units: map[int]*config.InterfaceUnit{0: {DHCP: true}},
+				},
+			},
+		},
+	}
+
+	const iters = 2000
+	var wg sync.WaitGroup
+
+	// Writer: republish a fresh map (and periodically an empty/nil set) each
+	// iteration, as a commit apply would.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			var m map[string]bool
+			if i%2 == 0 {
+				m = map[string]bool{"fxp0": true}
+			}
+			d.publishMgmtVRFIfaces(m)
+		}
+	}()
+
+	// Readers: the DHCP-callback classify path plus the raw snapshot accessor,
+	// both of which read the published field.
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				_ = d.dhcpLeaseChangeRequiresRecompile(cfg)
+				_ = len(d.mgmtVRFIfaceSet())
+			}
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Problem (#5113, codex-review-177 `[A7-b1-F10]`, Low/High)

Config apply republished `d.mgmtVRFInterfaces` with **bare map assignments** (`= nil` then `= mgmtIfaces`) under `applySem`, while the DHCP-manager lease-change callback (`onDHCPAddressChange`) read the field **without `applySem` or any mutex**. That is an unsynchronized concurrent map-pointer read/write — a real Go data race.

Read sites confirmed across `pkg/daemon` (the issue named the first three; the full set is converted):
- `dhcpLeaseChangeRequiresRecompile` (`daemon_dhcp.go`) — DHCP-callback path, no `applySem`
- `applyMgmtVRFRoutes` (`daemon_flow.go`) — DHCP-callback else-branch, no `applySem`
- `collectDHCPRoutes` (`daemon_flow.go`)
- the post-`networkd.Apply` VRF rebind loop (`daemon_apply.go`)
- the cluster-comms VRF probe (`daemon_ha_sync.go`)

Published maps are immutable (replaced wholesale, never mutated in place), so panic risk is low, but the read is race-detector-illegal and a callback overlapping a commit can classify against the transient `nil` the two-step publish briefly exposes and fire an unserialized management-route refresh.

## Fix — atomic publication (immutable-after-publish → lock-free reads)

- Field is now `atomic.Pointer[map[string]bool]`.
- `publishMgmtVRFIfaces(m)` does a single atomic `Store`. The apply path computes the final set first (`nil` unless `vrf-mgmt` is in the managed set) and publishes **once**, eliminating the transient-nil phase a concurrent reader could observe.
- `mgmtVRFIfaceSet()` `Load`s one consistent snapshot; a `nil` pointer (before the first publish) is treated as "no mgmt VRF interfaces yet".
- Every reader loads one snapshot and classifies against it → sees either the complete old or complete new map, never a torn/nil-transient. `applySem` still serializes the apply path; the atomic only makes field publication safe for lock-free readers.

### applySem-extension option (deliberately NOT taken)
The issue suggests *preferably* holding `applySem` across classification + management-route programming on the callback. That would make the DHCP callback contend `applySem` against every commit and could stall lease processing, so it is left out — atomic publication is the complete, sufficient fix. The concurrency contract is documented at the field declaration (`daemon.go`).

## Validation

- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` → `build_exit=0`
- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test -race ./pkg/daemon/...` → `race_test_exit=0`
- New `mgmtvrf_race_test.go`: a concurrent writer (republishing fresh maps like apply) against classify/snapshot readers. Clean under `-race` with the atomic field; **verified by a temporary revert** to fail under `-race` with a reported `DATA RACE` if the field is put back to a bare map assignment. A pre-publish reader sees the safe empty state (no panic, conservative classification).

Closes #5113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi