### PR TITLE
ipsec: make swanctl child-section names injective (#5122)

### DIFF
--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -546,3 +546,24 @@ all files stay in `package ipsec`, so the public API is unchanged.
   rejected an embedded newline in ANY value at commit — the #4098 gate
   adds the traffic-selector-specific shape check (malformed / mis-scoped
   selector) and the render-side belt.
+- **Injective child-section naming (#5122).** Each traffic selector
+  renders one swanctl child section named `<conn>-<sanitizeChildName(ts)>`
+  (`effectiveTrafficSelectors` in `policy.go`). `sanitizeChildName` maps
+  every disallowed rune to a single `-`, so two DISTINCT selector names
+  that differ only in sanitized characters (e.g. `site/a` and `site:a`,
+  both legal Junos identifier chars) both collapse to `site-a` and used
+  to emit DUPLICATE child sections — strongSwan then rejects the config
+  or silently merges/loses one selector, a selector-specific
+  site-to-site outage. `effectiveTrafficSelectors` now detects any
+  sanitized base shared by two or more selectors and appends a stable
+  hash of the ORIGINAL selector name (`childNameDisambiguator`, fnv-1a
+  low 32 bits, 8 hex chars) to EACH colliding entry so every configured
+  selector renders a UNIQUE section. Non-colliding names (the common
+  case) are left byte-for-byte unchanged — no churn. The disambiguator
+  is a pure function of the original name, so the same config renders
+  identical section names across renders and across HA nodes, preserving
+  config-sync and idempotent commits. A residual guard extends the name
+  deterministically in the astronomically unlikely event a disambiguated
+  name still collides. Unlike the #4098 gate this does NOT reject the
+  config: two selectors with distinct legal Junos names are valid, so the
+  fix makes both render (vSRX parity) rather than failing the commit.

--- a/pkg/ipsec/childname_collision_5122_test.go
+++ b/pkg/ipsec/childname_collision_5122_test.go
@@ -1,0 +1,150 @@
+package ipsec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// childSectionNames returns the trimmed swanctl child-section header names
+// (the `<name> {` line inside the children{} block) that begin with the given
+// connection-name prefix. It returns every occurrence, so a duplicate name
+// shows up twice — the exact symptom of the #5122 collision.
+func childSectionNames(rendered, connPrefix string) []string {
+	var names []string
+	for _, line := range strings.Split(rendered, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, connPrefix+"-") {
+			continue
+		}
+		if !strings.HasSuffix(trimmed, " {") {
+			continue
+		}
+		names = append(names, strings.TrimSuffix(trimmed, " {"))
+	}
+	return names
+}
+
+// TestChildNameCollisionDisambiguated is the #5122 RED-on-revert guard. Two
+// distinct traffic-selector names that differ ONLY in a sanitized character
+// (`site/a` vs `site:a` — both legal Junos identifier chars) both sanitize to
+// the base `site-a`. Before the fix effectiveTrafficSelectors emitted TWO
+// `tun1-site-a {` child sections with identical names, so strongSwan rejected
+// the config or silently merged/lost one selector. The fix appends a stable
+// hash of the original selector name to each colliding entry, so both sections
+// render with DISTINCT names and neither selector is dropped.
+//
+// Reverting the disambiguation in policy.go makes both sections share the name
+// `tun1-site-a` and this test goes RED.
+func TestChildNameCollisionDisambiguated(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		VPNs: map[string]*config.IPsecVPN{
+			"tun1": {
+				Name:        "tun1",
+				Gateway:     "172.16.0.1",
+				IPsecPolicy: "ipsec-pol",
+				TrafficSelectors: map[string]*config.IPsecTrafficSelector{
+					"site/a": {Name: "site/a", LocalIP: "10.0.1.0/24", RemoteIP: "10.0.9.0/24"},
+					"site:a": {Name: "site:a", LocalIP: "10.0.2.0/24", RemoteIP: "10.0.9.0/24"},
+				},
+			},
+		},
+		Policies: map[string]*config.IPsecPolicyDef{
+			"ipsec-pol": {Name: "ipsec-pol", Proposals: []string{"prop1"}},
+		},
+	}
+
+	got := m.generateConfig(cfg)
+
+	names := childSectionNames(got, "tun1")
+	if len(names) != 2 {
+		t.Fatalf("expected 2 child sections for the two selectors, got %d: %v\n%s",
+			len(names), names, got)
+	}
+	if names[0] == names[1] {
+		t.Fatalf("distinct selectors site/a and site:a rendered DUPLICATE child "+
+			"section name %q (strongSwan would reject/merge one selector, #5122):\n%s",
+			names[0], got)
+	}
+	// Both selectors must survive to the render — assert each distinct local_ts
+	// prefix is present, proving neither child was overwritten/dropped.
+	if !strings.Contains(got, "local_ts = 10.0.1.0/24") {
+		t.Fatalf("selector site/a (local_ts 10.0.1.0/24) missing from render:\n%s", got)
+	}
+	if !strings.Contains(got, "local_ts = 10.0.2.0/24") {
+		t.Fatalf("selector site:a (local_ts 10.0.2.0/24) missing from render:\n%s", got)
+	}
+	// Both disambiguated names must keep the sanitized base as a prefix so the
+	// naming stays recognizable / stable-shaped.
+	for _, n := range names {
+		if !strings.HasPrefix(n, "tun1-site-a") {
+			t.Fatalf("disambiguated child section %q lost the sanitized base prefix "+
+				"tun1-site-a:\n%s", n, got)
+		}
+	}
+}
+
+// TestChildNameNonCollidingUnchanged is the no-churn negative control: two
+// selectors whose sanitized bases already differ (and a lone selector) keep
+// their plain `connName-<sanitized>` names with NO hash suffix. Only an actual
+// collision may trigger disambiguation.
+func TestChildNameNonCollidingUnchanged(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		VPNs: map[string]*config.IPsecVPN{
+			"tun1": {
+				Name:        "tun1",
+				Gateway:     "172.16.0.1",
+				IPsecPolicy: "ipsec-pol",
+				TrafficSelectors: map[string]*config.IPsecTrafficSelector{
+					"alpha": {Name: "alpha", LocalIP: "10.0.1.0/24", RemoteIP: "10.0.9.0/24"},
+					"beta":  {Name: "beta", LocalIP: "10.0.2.0/24", RemoteIP: "10.0.9.0/24"},
+				},
+			},
+		},
+		Policies: map[string]*config.IPsecPolicyDef{
+			"ipsec-pol": {Name: "ipsec-pol", Proposals: []string{"prop1"}},
+		},
+	}
+
+	got := m.generateConfig(cfg)
+	names := childSectionNames(got, "tun1")
+	want := map[string]bool{"tun1-alpha": true, "tun1-beta": true}
+	if len(names) != 2 {
+		t.Fatalf("expected 2 child sections, got %d: %v\n%s", len(names), names, got)
+	}
+	for _, n := range names {
+		if !want[n] {
+			t.Fatalf("non-colliding selector rendered unexpected/disambiguated name "+
+				"%q (want one of %v):\n%s", n, want, got)
+		}
+	}
+}
+
+// TestChildNameSingleSelectorUnchanged asserts a normal single selector renders
+// its `connName-<sanitized>` name unchanged (no disambiguator applied).
+func TestChildNameSingleSelectorUnchanged(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		VPNs: map[string]*config.IPsecVPN{
+			"tun1": {
+				Name:        "tun1",
+				Gateway:     "172.16.0.1",
+				IPsecPolicy: "ipsec-pol",
+				TrafficSelectors: map[string]*config.IPsecTrafficSelector{
+					"ts1": {Name: "ts1", LocalIP: "10.0.1.0/24", RemoteIP: "10.0.9.0/24"},
+				},
+			},
+		},
+		Policies: map[string]*config.IPsecPolicyDef{
+			"ipsec-pol": {Name: "ipsec-pol", Proposals: []string{"prop1"}},
+		},
+	}
+
+	got := m.generateConfig(cfg)
+	if !strings.Contains(got, "tun1-ts1 {\n") {
+		t.Fatalf("single selector did not render its plain child section tun1-ts1:\n%s", got)
+	}
+}

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 	"net"
 	"sort"
@@ -391,8 +392,35 @@ func effectiveTrafficSelectors(connName string, vpn *config.IPsecVPN) []childSel
 	}
 	sort.Strings(names)
 
+	// sanitizeChildName is not injective: it maps every disallowed rune to a
+	// single '-', so two distinct selector names differing only in sanitized
+	// characters (e.g. `site/a` and `site:a`, both legal Junos identifier
+	// chars) both collapse to `site-a` and render DUPLICATE swanctl child
+	// sections. strongSwan then rejects the config or silently merges/loses
+	// one child — a selector-specific site-to-site outage (#5122). Detect any
+	// base name shared by two or more selectors and append a stable hash of
+	// the ORIGINAL selector name to EACH colliding entry so every configured
+	// selector renders a UNIQUE child section. Non-colliding names are left
+	// byte-for-byte unchanged (no churn), and the disambiguator is a pure
+	// function of the original name, so the same config renders identically
+	// across renders and across HA nodes (config-sync + idempotent commit).
+	bases := make([]string, len(names))
+	counts := make(map[string]int, len(names))
+	for i, name := range names {
+		bases[i] = sanitizeChildName(name)
+		counts[bases[i]]++
+	}
+	// Reserve every non-colliding base first so a disambiguated collided name
+	// can never land on a name a distinct selector already owns.
+	used := make(map[string]bool, len(names))
+	for i := range names {
+		if counts[bases[i]] == 1 {
+			used[bases[i]] = true
+		}
+	}
+
 	children := make([]childSelector, 0, len(names))
-	for _, name := range names {
+	for i, name := range names {
 		ts := vpn.TrafficSelectors[name]
 		localTS := vpn.LocalID
 		remoteTS := vpn.RemoteID
@@ -402,13 +430,37 @@ func effectiveTrafficSelectors(connName string, vpn *config.IPsecVPN) []childSel
 		if ts.RemoteIP != "" {
 			remoteTS = ts.RemoteIP
 		}
+		childName := bases[i]
+		if counts[bases[i]] > 1 {
+			childName = bases[i] + "-" + childNameDisambiguator(name)
+			// Astronomically unlikely: the disambiguated name still collides
+			// (a hash collision, or a distinct selector literally named
+			// `<base>-<hash>`). Extend deterministically until unique so the
+			// injectivity guarantee is absolute.
+			for used[childName] {
+				childName += "x"
+			}
+			used[childName] = true
+		}
 		children = append(children, childSelector{
-			Name:     connName + "-" + sanitizeChildName(name),
+			Name:     connName + "-" + childName,
 			LocalTS:  localTS,
 			RemoteTS: remoteTS,
 		})
 	}
 	return children
+}
+
+// childNameDisambiguator returns a short, stable hash of the ORIGINAL selector
+// name, used to make colliding sanitized child-section names injective (#5122).
+// It is a deterministic pure function of the input (fnv-1a 64-bit, low 32 bits
+// as 8 hex chars), so distinct original names that sanitize to the same base
+// receive distinct suffixes, and the same config renders the same name on every
+// node — a prerequisite for HA config-sync and idempotent commits.
+func childNameDisambiguator(original string) string {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(original))
+	return fmt.Sprintf("%08x", uint32(h.Sum64()))
 }
 
 // sanitizeSwanctlValue strips ASCII control characters — the C0 set


### PR DESCRIPTION
## Problem

`sanitizeChildName` (`pkg/ipsec/policy.go`) maps every disallowed rune to
a single `-`, so two distinct traffic-selector names that differ only in
sanitized characters -- e.g. `site/a` and `site:a`, both legal Junos
identifier chars -- both collapse to the base `site-a`.
`effectiveTrafficSelectors` then rendered DUPLICATE `<conn>-site-a` child
sections under `children {}` with no collision check. strongSwan rejects
a config with two identically named child sections, or silently
merges/overwrites one -- a configured selector is lost and its subnet
blackholes, diverging from vSRX which accepts both distinct names.

## Fix (injective naming, not reject)

Two selectors with distinct legal Junos names ARE valid, so the
vSRX-parity fix makes both render rather than failing the commit.
`effectiveTrafficSelectors` now computes the sanitized base for every
selector and, for any base shared by two or more selectors, appends a
stable hash of the ORIGINAL selector name (`childNameDisambiguator`:
fnv-1a low 32 bits, 8 hex chars) to EACH colliding entry, so every
configured selector renders a UNIQUE child section.

- Non-colliding names (the common case) are left byte-for-byte unchanged
  -- no existing child name churns.
- The disambiguator is a pure function of the original name, so the same
  config renders identical section names across renders and across HA
  nodes -- config-sync and idempotent commits preserved.
- Non-colliding bases are reserved before disambiguation and a residual
  extend-until-unique guard keeps injectivity absolute even in the
  astronomically unlikely event a disambiguated name still collides.

## Tests

`pkg/ipsec/childname_collision_5122_test.go`:
- Renders a VPN with selectors `site/a` and `site:a`, asserts two
  DISTINCT child-section names with both `local_ts` prefixes present
  (neither selector dropped). RED on revert: both sections become
  `tun1-site-a`.
- No-churn control: non-colliding (`alpha`/`beta`) and single (`ts1`)
  selectors keep their plain `<conn>-<sanitized>` names with no suffix.

## Validation

- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` -> exit 0
- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/ipsec/...` -> exit 0
- RED-on-revert confirmed by forcing the old single-name path.
- `pkg/ipsec/README.md` documents the injective child-naming contract.

Closes #5122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi