### PR TITLE
syslog: restart rsyslog when the final managed drop-in is removed (#5111)

### DIFF
--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -814,20 +814,64 @@ func (d *Daemon) applySyslogFiles(cfg *config.Config) {
 		}
 	}
 
-	// Read existing xpf-managed files
+	// Reconcile the on-disk managed drop-ins against `desired`. A removal OR a
+	// (re)write flips `changed`, which gates the single restart below.
+	changed := reconcileSyslogDropins(confDir, prefix, desired)
+
+	if changed {
+		if out, err := runCommandTimeout("systemctl", "restart", "rsyslog"); err != nil {
+			slog.Error("failed to restart rsyslog",
+				"err", err, "output", strings.TrimSpace(string(out)))
+		} else {
+			slog.Info("rsyslog file configs applied", "files", len(desired))
+		}
+	}
+}
+
+// reconcileSyslogDropins removes stale xpf-managed rsyslog drop-ins (any file
+// under confDir whose name starts with prefix that is not present in desired)
+// and writes the desired drop-ins. It returns true when the on-disk managed
+// set actually changed — a file was removed OR a file was (re)written — which
+// the caller uses to gate the single `systemctl restart rsyslog`.
+//
+// #5111: a successful removal MUST count as a change, even when `desired` is
+// empty. Removing the final managed destination leaves nothing to write, so
+// the write loop cannot set `changed`; before this fix `changed` stayed false
+// and the restart was skipped, leaving rsyslog with the deleted rule still
+// loaded (logs kept flowing to a removed destination — an audit/confidentiality
+// leak). A no-op remove of an already-absent file (os.IsNotExist) does NOT count
+// so a steady-state reconcile does not spuriously restart rsyslog every apply.
+// os.Remove errors are surfaced (slog.Warn) rather than discarded, and still
+// mark a change so the restart re-reads config instead of silently stranding a
+// stale rule with no restart.
+func reconcileSyslogDropins(confDir, prefix string, desired map[string]string) bool {
+	changed := false
+
+	// Remove stale xpf-managed files.
 	entries, _ := os.ReadDir(confDir)
 	for _, e := range entries {
 		if !strings.HasPrefix(e.Name(), prefix) {
 			continue
 		}
-		if _, keep := desired[e.Name()]; !keep {
-			// Remove stale config
-			os.Remove(filepath.Join(confDir, e.Name()))
+		if _, keep := desired[e.Name()]; keep {
+			continue
 		}
+		path := filepath.Join(confDir, e.Name())
+		if err := os.Remove(path); err != nil {
+			if os.IsNotExist(err) {
+				// Already gone — nothing was actually removed, so no restart
+				// is owed for this entry.
+				continue
+			}
+			// A partial/failed removal is still a config change we want
+			// rsyslog to re-read; surface the error instead of discarding it.
+			slog.Warn("failed to remove stale rsyslog config",
+				"file", e.Name(), "err", err)
+		}
+		changed = true
 	}
 
-	// Write desired configs
-	changed := false
+	// Write desired configs.
 	for name, content := range desired {
 		path := filepath.Join(confDir, name)
 		current, _ := os.ReadFile(path)
@@ -841,14 +885,7 @@ func (d *Daemon) applySyslogFiles(cfg *config.Config) {
 		}
 	}
 
-	if changed {
-		if out, err := runCommandTimeout("systemctl", "restart", "rsyslog"); err != nil {
-			slog.Error("failed to restart rsyslog",
-				"err", err, "output", strings.TrimSpace(string(out)))
-		} else {
-			slog.Info("rsyslog file configs applied", "files", len(desired))
-		}
-	}
+	return changed
 }
 
 // applySystemLogin creates OS user accounts and SSH authorized_keys from

--- a/pkg/daemon/syslog_reconcile_5111_test.go
+++ b/pkg/daemon/syslog_reconcile_5111_test.go
@@ -1,0 +1,119 @@
+package daemon
+
+// #5111 fail-on-revert: the syslog reconcile removes stale xpf-managed rsyslog
+// drop-ins, but the `changed` flag (which gates the single `systemctl restart
+// rsyslog`) was set ONLY when a desired file was (re)written. Removing the FINAL
+// managed destination makes the desired set empty, so the write loop never runs
+// and `changed` stayed false — the restart was skipped and rsyslog kept the
+// deleted rule loaded (logs kept flowing to a removed destination). These tests
+// drive reconcileSyslogDropins directly against a temp dir and assert that a
+// real removal flips `changed` (so the restart fires) while a steady-state
+// no-op does not.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const syslogPrefix = "10-xpf-"
+
+// TestReconcileSyslogDropins_RemoveFinalDest_5111 seeds a single managed
+// drop-in and reconciles to an EMPTY desired set (final destination removed).
+// The file must be removed AND `changed` must be true so the caller fires the
+// rsyslog restart. Reverting the remove-sets-changed logic makes `changed`
+// stay false and this test fails.
+func TestReconcileSyslogDropins_RemoveFinalDest_5111(t *testing.T) {
+	dir := t.TempDir()
+	managed := filepath.Join(dir, syslogPrefix+"audit.conf")
+	if err := os.WriteFile(managed, []byte("# Managed by xpf — do not edit\n*.*\t/var/log/audit\n"), 0644); err != nil {
+		t.Fatalf("seed managed drop-in: %v", err)
+	}
+
+	changed := reconcileSyslogDropins(dir, syslogPrefix, map[string]string{})
+
+	if !changed {
+		t.Errorf("removing the final managed destination must set changed=true (so rsyslog restarts); got false")
+	}
+	if _, err := os.Stat(managed); !os.IsNotExist(err) {
+		t.Errorf("stale managed drop-in not removed: stat err = %v", err)
+	}
+}
+
+// TestReconcileSyslogDropins_NoOp_5111 reconciles a state that already matches
+// desired: nothing is removed and nothing is written, so `changed` must stay
+// false (no spurious restart every reconcile).
+func TestReconcileSyslogDropins_NoOp_5111(t *testing.T) {
+	dir := t.TempDir()
+	content := "# Managed by xpf — do not edit\n*.info\t/var/log/keep\n"
+	name := syslogPrefix + "keep.conf"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+		t.Fatalf("seed managed drop-in: %v", err)
+	}
+
+	changed := reconcileSyslogDropins(dir, syslogPrefix, map[string]string{name: content})
+
+	if changed {
+		t.Errorf("steady-state reconcile (no remove, no write) must not set changed; got true")
+	}
+	if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+		t.Errorf("matching managed drop-in must be preserved: %v", err)
+	}
+}
+
+// TestReconcileSyslogDropins_Write_5111 preserves the original behavior: when a
+// desired file is written, `changed` becomes true.
+func TestReconcileSyslogDropins_Write_5111(t *testing.T) {
+	dir := t.TempDir()
+	content := "# Managed by xpf — do not edit\n*.*\t/var/log/new\n"
+	name := syslogPrefix + "new.conf"
+
+	changed := reconcileSyslogDropins(dir, syslogPrefix, map[string]string{name: content})
+
+	if !changed {
+		t.Errorf("writing a new managed drop-in must set changed=true; got false")
+	}
+	got, err := os.ReadFile(filepath.Join(dir, name))
+	if err != nil {
+		t.Fatalf("desired drop-in not written: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("drop-in content = %q, want %q", got, content)
+	}
+}
+
+// TestReconcileSyslogDropins_RemoveOneKeepAnother_5111 removes one managed
+// destination while another remains desired: the stale file is deleted and
+// `changed` is set even though the surviving file needs no rewrite.
+func TestReconcileSyslogDropins_RemoveOneKeepAnother_5111(t *testing.T) {
+	dir := t.TempDir()
+	keepContent := "# Managed by xpf — do not edit\n*.*\t/var/log/keep\n"
+	keepName := syslogPrefix + "keep.conf"
+	staleName := syslogPrefix + "stale.conf"
+	if err := os.WriteFile(filepath.Join(dir, keepName), []byte(keepContent), 0644); err != nil {
+		t.Fatalf("seed keep drop-in: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, staleName), []byte("# Managed by xpf — do not edit\n*.*\t/var/log/stale\n"), 0644); err != nil {
+		t.Fatalf("seed stale drop-in: %v", err)
+	}
+	// A non-managed neighbor must be left untouched and must not set changed.
+	other := filepath.Join(dir, "50-default.conf")
+	if err := os.WriteFile(other, []byte("*.* /var/log/syslog\n"), 0644); err != nil {
+		t.Fatalf("seed non-managed file: %v", err)
+	}
+
+	changed := reconcileSyslogDropins(dir, syslogPrefix, map[string]string{keepName: keepContent})
+
+	if !changed {
+		t.Errorf("removing a stale managed destination must set changed=true; got false")
+	}
+	if _, err := os.Stat(filepath.Join(dir, staleName)); !os.IsNotExist(err) {
+		t.Errorf("stale drop-in not removed: stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, keepName)); err != nil {
+		t.Errorf("kept drop-in must survive: %v", err)
+	}
+	if _, err := os.Stat(other); err != nil {
+		t.Errorf("non-managed file must not be removed: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

The syslog reconcile in `applySyslogFiles` (`pkg/daemon/daemon_system.go`)
removed stale xpf-managed rsyslog drop-ins with a bare `os.Remove` but set the
`changed` flag **only** when a desired file was (re)written. `changed` was
declared *after* the removal loop and never touched by it, so removing the
**final** managed destination left the desired set empty: the write loop did
nothing, `changed` stayed `false`, and the `if changed { systemctl restart
rsyslog }` gate was skipped. rsyslog kept the deleted rule loaded, so logs kept
flowing to a destination the operator had removed — an audit/confidentiality
leak. `os.Remove` errors were also silently discarded.

## Fix

Extract the filesystem reconcile (remove stale + write desired) into a pure,
testable helper `reconcileSyslogDropins(confDir, prefix, desired)` that returns
whether the on-disk managed set actually changed, and gate the single restart
on its result.

- A **successful removal** now sets `changed` so the restart fires even when
  nothing remains to write (final destination removed).
- A **no-op remove** of an already-absent file (`os.IsNotExist`) does NOT set
  `changed` — a steady-state reconcile does not spuriously restart rsyslog every
  apply.
- `os.Remove` errors are surfaced via `slog.Warn` and still mark a change so the
  restart re-reads config rather than silently stranding a stale rule with no
  restart.
- The write path is unchanged: a (re)write still sets `changed`.

## Validation

- `go build ./...` — clean.
- `go test ./pkg/daemon/ -run 'Syslog|Rsyslog'` — passes.
- New `pkg/daemon` tests drive `reconcileSyslogDropins` against a temp dir:
  removing the final destination sets `changed=true` and deletes the file
  (**fails on revert** of the remove-sets-changed logic); a steady-state
  reconcile keeps `changed=false` (no spurious restart); a fresh write sets
  `changed=true`; a partial remove deletes only the stale managed drop-in while
  leaving the surviving managed file and a non-managed neighbor intact.

## Docs

No dedicated syslog module doc documents the reconcile restart gate (only a
passing reference in `docs/system-login.md` to the sudoers reconciler
"mirroring the networkd/rsyslog stale-file reconcilers"). The contract lives in
the helper's doc comment, which this change adds.

Closes #5111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi