### PR TITLE
routing/pbr: scope FBF/PBR ip rules to the attached ingress interface (#5117)

### DIFF
--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -362,6 +362,13 @@ How it lands (the `instance-type forwarding` divergence fix):
   and marks the build degraded rather than widening a constrained term
   to an address-only rule that would steer traffic the operator
   excluded. The userspace fast path still enforces the term exactly.
+  Each `ip rule` is also scoped to the ingress interface the steering
+  filter is attached to via `IifName`/`FRA_IIFNAME` (#5117) — a filter
+  bound to `reth1 unit 0` only steers traffic ingressing `reth1`, so a
+  slow-path (`XDP_PASS`) packet arriving on a different interface cannot
+  match the rule and be mis-steered into the wrong uplink's VRF. A filter
+  attached to several interfaces expands to one iif-scoped rule per
+  interface rather than a single global rule.
 - **PBR build-health metrics (#4422)**: `xpf_pbr_rules_installed`
   gauges the number of kernel `ip rule` FBF entries the active config
   yields (the desired-install set), and `xpf_pbr_degraded_terms` gauges

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -148,15 +148,32 @@ delegate to the owning domain. Exported types:
   and the userspace filter path still enforces the term exactly. The
   degraded error is returned to the daemon (`daemon_apply.go` step 3d) and
   logged; the buildable rules are still installed.
+  **Per-interface iif scoping (#5117).** Junos FBF is bound to a specific
+  interface-unit input filter, so a `then routing-instance` term only steers
+  traffic INGRESSING the interface the filter is attached to. Each kernel `ip
+  rule` therefore carries an `IifName` (`FRA_IIFNAME`) resolved via
+  `cfg.ResolveKernelIfName` — the canonical Junos-ref → Linux-name mapping, so a
+  unit-0 collapse (`ge-0/0/0` → `ge-0-0-0`), an 802.1Q VLAN unit
+  (`ge-0/0/0.50`) and a RETH member (`reth0` → local physical member) all
+  resolve consistently. `collectAttachedInputFilters` preserves the ingress
+  interface per attachment (it no longer dedups a filter down to a single global
+  entry), and a filter attached to N interfaces expands to N rules — one per
+  `(filter, interface)`, each with its own `IifName`. `pbrManager.Apply` refuses
+  to install a rule with no ingress interface (fail closed, never a global rule).
+  Before #5117 the mirror set no iif selector, so a slow-path (`XDP_PASS`) packet
+  arriving on a DIFFERENT interface could match the global rule and be steered
+  into the wrong VRF (cross-WAN / tenant route-leak) — the userspace fast path
+  was always per-interface, so only the kernel fallback over-steered.
   **Contradictory deny terms are not steered (#4534).** A term that
   co-locates `then routing-instance <x>` with a terminating `then discard` /
   `then reject` is contradictory — it asks the dataplane to BOTH steer the
   packet into `<x>` AND drop it. The deny wins on BOTH forwarding paths: the
   userspace runtime returns `RouteOverride::Drop` (#4392,
   `ingress_route_table_override`) and `buildPBRFromFilter` SKIPS the steering
-  `ip rule` (records a degraded error). Without the kernel skip the global
-  `ip rule` (no `iif` selector) would fail OPEN — steering slow-path /
-  `XDP_PASS` / unfiltered-interface traffic into the VRF that userspace drops.
+  `ip rule` (records a degraded error). Without the kernel skip the mirror
+  `ip rule` would fail OPEN — steering slow-path / `XDP_PASS` traffic
+  ingressing the attached interface (even with the #5117 iif selector) into
+  the VRF that userspace drops.
   The strict commit gate (`validateFilterRoutingInstanceConflictStrict`,
   #3308) rejects such a term at commit, but is lenient on load / peer-sync
   (#1960 no-brick), so a persisted / peer-synced contradiction can still reach

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -1448,7 +1448,7 @@ func TestBuildPBRRules(t *testing.T) {
 		ops := newFakeRuleOps()
 		p := &pbrManager{ops: ops}
 		if err := p.Apply([]PBRRule{
-			{Family: unix.AF_INET, IPProto: 6, Dport: &PBRPortRange{Lo: 443, Hi: 443}, TableID: 100, Instance: "vr"},
+			{Family: unix.AF_INET, IPProto: 6, Dport: &PBRPortRange{Lo: 443, Hi: 443}, TableID: 100, Instance: "vr", IifName: "ge-0-0-0"},
 		}); err != nil {
 			t.Fatalf("Apply: %v", err)
 		}
@@ -1622,6 +1622,114 @@ func TestBuildPBRRules_OtherInterfaceUnaffected(t *testing.T) {
 	}
 }
 
+// TestBuildPBRRules_IifNameScoped is the #5117 fail-on-revert guard: every FBF
+// ip rule a filter produces must be scoped to the Linux ingress interface the
+// filter is attached to (IifName != ""), so a kernel slow-path (XDP_PASS)
+// packet arriving on a DIFFERENT interface cannot match a global rule and be
+// steered into the wrong VRF. RED on revert: dropping the IifName scoping makes
+// every rule carry an empty ingress interface (a global rule), failing here.
+func TestBuildPBRRules_IifNameScoped(t *testing.T) {
+	instances := []*config.RoutingInstanceConfig{{Name: "ATT", TableID: 101}}
+	filter := &config.FirewallFilter{
+		Name: "fbf",
+		Terms: []*config.FirewallFilterTerm{
+			{Name: "a", SourceAddresses: []string{"10.0.1.0/24"}, RoutingInstance: "ATT"},
+			{Name: "b", DestAddresses: []string{"192.168.0.0/16"}, RoutingInstance: "ATT"},
+		},
+	}
+	// pbrTestConfig attaches the filter to ge-0/0/0 unit 0 -> kernel ge-0-0-0.
+	rules, err := BuildPBRRules(pbrTestConfig("inet", filter, instances, nil))
+	if err != nil {
+		t.Fatalf("unexpected build error: %v", err)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("expected 2 rules, got %d: %+v", len(rules), rules)
+	}
+	for i := range rules {
+		if rules[i].IifName != "ge-0-0-0" {
+			t.Errorf("rule %d IifName = %q, want %q (must be scoped to the attached interface, not a global rule)",
+				i, rules[i].IifName, "ge-0-0-0")
+		}
+	}
+}
+
+// TestBuildPBRRules_IifNameVLANUnit pins that the ingress interface is resolved
+// to the VLAN sub-interface when the filter is attached to an 802.1Q-tagged
+// unit (#5117): the mirror must scope to ge-0-0-0.50, not the base ge-0-0-0.
+func TestBuildPBRRules_IifNameVLANUnit(t *testing.T) {
+	instances := []*config.RoutingInstanceConfig{{Name: "ATT", TableID: 101}}
+	filter := &config.FirewallFilter{
+		Name: "fbf",
+		Terms: []*config.FirewallFilterTerm{
+			{Name: "a", SourceAddresses: []string{"10.0.1.0/24"}, RoutingInstance: "ATT"},
+		},
+	}
+	cfg := &config.Config{RoutingInstances: instances}
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{filter.Name: filter}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*config.InterfaceUnit{
+			50: {Number: 50, VlanID: 50, FilterInputV4: "fbf"},
+		}},
+	}
+	rules, err := BuildPBRRules(cfg)
+	if err != nil {
+		t.Fatalf("unexpected build error: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d: %+v", len(rules), rules)
+	}
+	if rules[0].IifName != "ge-0-0-0.50" {
+		t.Errorf("VLAN-unit FBF rule IifName = %q, want %q (must scope to the VLAN sub-interface)",
+			rules[0].IifName, "ge-0-0-0.50")
+	}
+}
+
+// TestBuildPBRRules_IifNamePerInterface pins that a filter attached to TWO
+// interfaces yields DISTINCT per-interface rules — one per (filter, interface)
+// attachment, each carrying its own IifName — rather than one global rule
+// (#5117). RED on revert: the pre-#5117 collector deduped by filter name and
+// emitted a single iif-less rule, so this two-interface config would produce
+// one rule with an empty ingress interface.
+func TestBuildPBRRules_IifNamePerInterface(t *testing.T) {
+	instances := []*config.RoutingInstanceConfig{{Name: "ATT", TableID: 101}}
+	shared := &config.FirewallFilter{
+		Name: "shared-fbf",
+		Terms: []*config.FirewallFilterTerm{
+			{Name: "steer", SourceAddresses: []string{"10.0.1.0/24"}, RoutingInstance: "ATT"},
+		},
+	}
+	cfg := &config.Config{RoutingInstances: instances}
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{shared.Name: shared}
+	// The SAME filter is bound as the input filter on two interfaces.
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, FilterInputV4: "shared-fbf"},
+		}},
+		"ge-0/0/1": {Name: "ge-0/0/1", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, FilterInputV4: "shared-fbf"},
+		}},
+	}
+	rules, err := BuildPBRRules(cfg)
+	if err != nil {
+		t.Fatalf("unexpected build error: %v", err)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("expected 2 rules (one per attached interface), got %d: %+v", len(rules), rules)
+	}
+	gotIifs := map[string]bool{}
+	for i := range rules {
+		if rules[i].IifName == "" {
+			t.Errorf("rule %d has an empty ingress interface (global rule) — must be per-interface scoped: %+v", i, rules[i])
+		}
+		gotIifs[rules[i].IifName] = true
+	}
+	for _, want := range []string{"ge-0-0-0", "ge-0-0-1"} {
+		if !gotIifs[want] {
+			t.Errorf("expected a distinct rule scoped to %q, got iifs %v", want, gotIifs)
+		}
+	}
+}
+
 // TestPBRBuildStats pins the #4422 observability contract: PBRBuildStats returns
 // the installed ip-rule count and the count of routing-instance filter terms
 // DROPPED from the kernel FBF mirror (fail-closed under-steer), matching what
@@ -1676,18 +1784,31 @@ func TestPBRBuildStats(t *testing.T) {
 	})
 }
 
+// hasAttachment reports whether atts carries an attachment for the given filter
+// AND ingress ifname — the per-interface FBF-scoping unit (#5117).
+func hasAttachment(atts []pbrAttachment, filter, iif string) bool {
+	for _, a := range atts {
+		if a.Filter == filter && a.Iif == iif {
+			return true
+		}
+	}
+	return false
+}
+
 // TestCollectAttachedInputFilters pins the attachment-collection contract that
-// per-interface FBF scoping rests on (#4422): only interface-unit INPUT filters
-// are collected, split by family; OUTPUT filters are excluded; and the same
-// filter attached to several interfaces dedups to a single entry (it is
-// expanded once).
+// per-interface FBF scoping rests on (#4422, #5117): only interface-unit INPUT
+// filters are collected, split by family; OUTPUT filters are excluded; the
+// ingress interface identity is PRESERVED (resolved to the kernel ifname); and
+// a filter attached to several interfaces yields ONE attachment per interface
+// (NOT deduplicated to a single global entry — that was the #5117 over-steer).
 func TestCollectAttachedInputFilters(t *testing.T) {
-	ifs := &config.InterfacesConfig{
+	cfg := &config.Config{Interfaces: config.InterfacesConfig{
 		Interfaces: map[string]*config.InterfaceConfig{
 			"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*config.InterfaceUnit{
 				0: {Number: 0, FilterInputV4: "shared-v4", FilterInputV6: "only-v6"},
 			}},
-			// Same v4 input filter as ge-0/0/0 -> must dedup, not double-count.
+			// Same v4 input filter as ge-0/0/0 -> must be a SEPARATE attachment
+			// (its own iif), NOT deduped away — the pre-#5117 collapse is the bug.
 			"ge-0/0/1": {Name: "ge-0/0/1", Units: map[int]*config.InterfaceUnit{
 				0: {Number: 0, FilterInputV4: "shared-v4"},
 			}},
@@ -1696,25 +1817,38 @@ func TestCollectAttachedInputFilters(t *testing.T) {
 				0: {Number: 0, FilterInputV4: "other-v4", FilterOutputV4: "egress-not-fbf"},
 			}},
 		},
-	}
-	inet, inet6 := collectAttachedInputFilters(ifs)
+	}}
+	inet, inet6 := collectAttachedInputFilters(cfg)
 
-	if _, ok := inet["shared-v4"]; !ok {
-		t.Error("shared-v4 input filter must be collected")
+	// shared-v4 must appear once per interface it is attached to, each carrying
+	// that interface's resolved kernel ifname (#5117 — RED on revert: the old
+	// collector collapsed both into one iif-less entry).
+	if !hasAttachment(inet, "shared-v4", "ge-0-0-0") {
+		t.Errorf("shared-v4 must be attached to ge-0-0-0, got %+v", inet)
 	}
-	if _, ok := inet["other-v4"]; !ok {
-		t.Error("other-v4 input filter on ge-0/0/2 must be collected")
+	if !hasAttachment(inet, "shared-v4", "ge-0-0-1") {
+		t.Errorf("shared-v4 must ALSO be attached to ge-0-0-1 (per-interface, not deduped), got %+v", inet)
 	}
-	if len(inet) != 2 {
-		t.Errorf("inet set = %v, want exactly {shared-v4, other-v4} (dedup shared-v4 across two interfaces)", inet)
+	if !hasAttachment(inet, "other-v4", "ge-0-0-2") {
+		t.Errorf("other-v4 input filter on ge-0/0/2 must be collected as ge-0-0-2, got %+v", inet)
 	}
-	if _, ok := inet["egress-not-fbf"]; ok {
+	// Two shared-v4 attachments + one other-v4 = 3 inet attachments.
+	if len(inet) != 3 {
+		t.Errorf("inet attachments = %+v, want 3 (shared-v4@ge-0-0-0, shared-v4@ge-0-0-1, other-v4@ge-0-0-2)", inet)
+	}
+	// Every attachment must carry a resolved, non-empty ingress interface.
+	for _, a := range inet {
+		if a.Iif == "" {
+			t.Errorf("attachment %+v has an empty ingress interface (must fail closed, never global)", a)
+		}
+	}
+	if hasAttachment(inet, "egress-not-fbf", "ge-0-0-2") {
 		t.Error("OUTPUT filter egress-not-fbf must NOT be collected as FBF")
 	}
-	if _, ok := inet6["only-v6"]; !ok || len(inet6) != 1 {
-		t.Errorf("inet6 set = %v, want exactly {only-v6}", inet6)
+	if !hasAttachment(inet6, "only-v6", "ge-0-0-0") || len(inet6) != 1 {
+		t.Errorf("inet6 attachments = %+v, want exactly {only-v6@ge-0-0-0}", inet6)
 	}
-	if _, ok := inet6["shared-v4"]; ok {
+	if hasAttachment(inet6, "shared-v4", "ge-0-0-0") {
 		t.Error("v4 filter must not leak into the inet6 set (family split)")
 	}
 }

--- a/pkg/routing/rules.go
+++ b/pkg/routing/rules.go
@@ -478,6 +478,18 @@ type PBRRule struct {
 	Dport    *PBRPortRange // destination-port range, nil = no dest-port selector
 	TableID  int           // target routing table
 	Instance string        // routing instance name (for logging)
+	// IifName scopes the kernel FBF ip rule to the Linux ingress interface the
+	// firewall filter is attached to (#5117). Junos filter-based-forwarding is
+	// bound to a specific interface-unit input filter, so a `then
+	// routing-instance` term only steers traffic INGRESSING that interface. The
+	// pre-#5117 mirror set no iif selector, so a slow-path (XDP_PASS) packet
+	// arriving on a DIFFERENT interface could match the rule and be steered into
+	// the wrong VRF (cross-WAN / tenant route-leak). This carries the resolved
+	// kernel ifname (e.g. "ge-0-0-0", "ge-0-0-0.50", a RETH member) so Apply
+	// emits FRA_IIFNAME and the rule matches ONLY that interface. It is never
+	// empty for a built rule: BuildPBRRules fails closed (drops the term +
+	// degrades) rather than installing a global iif-less rule.
+	IifName string
 }
 
 // PBRPortRange is a numeric [Lo,Hi] port range for the kernel FBF ip-rule
@@ -559,6 +571,19 @@ func (p *pbrManager) Apply(rules []PBRRule) error {
 		rule.Priority = prio
 		rule.Family = pbr.Family
 
+		// Scope the rule to the ingress interface the filter is attached to
+		// (#5117) so a slow-path packet on a different interface cannot match a
+		// global rule and be steered into the wrong VRF. BuildPBRRules guarantees
+		// IifName is non-empty (it fails closed otherwise), but guard anyway so a
+		// malformed rule never installs an unscoped (global) FRA-less rule.
+		if pbr.IifName == "" {
+			errs = append(errs, fmt.Errorf(
+				"PBR rule instance %s table %d has no ingress interface; refusing to "+
+					"install a global iif-less FBF rule (#5117)", pbr.Instance, pbr.TableID))
+			continue
+		}
+		rule.IifName = pbr.IifName
+
 		// Emit a tos selector iff the term actually matched a DSCP (#3430 H2).
 		if pbr.TOSSet {
 			rule.Tos = uint(pbr.TOS)
@@ -598,7 +623,8 @@ func (p *pbrManager) Apply(rules []PBRRule) error {
 			continue
 		}
 		slog.Info("PBR rule added",
-			"instance", pbr.Instance, "tos", pbr.TOS, "tos_set", pbr.TOSSet,
+			"instance", pbr.Instance, "iif", pbr.IifName,
+			"tos", pbr.TOS, "tos_set", pbr.TOSSet,
 			"src", pbr.Src, "dst", pbr.Dst, "ipproto", pbr.IPProto,
 			"sport", pbr.Sport.String(), "dport", pbr.Dport.String(),
 			"table", pbr.TableID)
@@ -647,11 +673,17 @@ func (p *pbrManager) clear() error {
 // program a global ip rule. Output-attached filters are not FBF and are
 // ignored.
 //
-// Each attached filter is expanded once regardless of how many interfaces
-// reference it: the resulting ip rules carry no incoming-interface selector
-// (a documented widening relative to per-interface Junos FBF — adding an iif
-// selector requires the kernel ifname mapping and is a separate change), so a
-// duplicate per attachment would be redundant.
+// Each rule is scoped to the Linux ingress interface the filter is attached to
+// (#5117): a filter bound to several interfaces is expanded once PER
+// (filter, interface) attachment, and every emitted rule carries an IifName
+// (FRA_IIFNAME) resolved via cfg.ResolveKernelIfName so it matches ONLY packets
+// ingressing that interface. This mirrors per-interface Junos FBF, where a
+// `then routing-instance` term only steers traffic ingressing the interface the
+// filter is attached to. The pre-#5117 mirror emitted one iif-less rule per
+// filter, so a slow-path (XDP_PASS) packet arriving on a DIFFERENT interface
+// could match the global rule and be steered into the wrong VRF. An attachment
+// whose ingress interface cannot be resolved fails CLOSED (the term is dropped
+// and the build degraded) rather than installing a global iif-less rule.
 //
 // Kernel-mirror support matrix (#3730). An `ip rule` can only express a subset
 // of a firewall-filter term's `from` predicates, so the mirror is exact for the
@@ -689,27 +721,43 @@ func BuildPBRRules(cfg *config.Config) ([]PBRRule, error) {
 		tableIDs[inst.Name] = inst.TableID
 	}
 
-	inetAttached, inet6Attached := collectAttachedInputFilters(&cfg.Interfaces)
+	inetAttached, inet6Attached := collectAttachedInputFilters(cfg)
 	pls := cfg.PolicyOptions.PrefixLists
 
 	var rules []PBRRule
 	var errs []error
-	build := func(names []string, filters map[string]*config.FirewallFilter, family int) {
-		for _, name := range names {
-			filter := filters[name]
+	build := func(atts []pbrAttachment, filters map[string]*config.FirewallFilter, family int) {
+		for _, att := range atts {
+			filter := filters[att.Filter]
 			if filter == nil {
 				// Dangling attachment (filter named on an interface but not
 				// defined). The strict commit gate rejects this
 				// (validateFilterAttachmentReferences / warn path); skip here.
 				continue
 			}
+			if att.Iif == "" {
+				// #5117: the ingress interface could not be resolved to a kernel
+				// ifname. Fail closed — installing a global iif-less rule would
+				// over-steer traffic on every interface into the target VRF. The
+				// userspace filter path still enforces the term exactly.
+				errs = append(errs, fmt.Errorf(
+					"PBR filter %s: cannot resolve the ingress interface for FBF "+
+						"scoping; steering for this attachment is dropped (fail-safe "+
+						"under-steer) rather than installing a global iif-less rule",
+					att.Filter))
+				continue
+			}
 			r, e := buildPBRFromFilter(filter, family, tableIDs, pls)
+			// Scope every rule this attachment produced to its ingress interface.
+			for i := range r {
+				r[i].IifName = att.Iif
+			}
 			rules = append(rules, r...)
 			errs = append(errs, e...)
 		}
 	}
-	build(sortedKeys(inetAttached), fw.FiltersInet, unix.AF_INET)
-	build(sortedKeys(inet6Attached), fw.FiltersInet6, unix.AF_INET6)
+	build(inetAttached, fw.FiltersInet, unix.AF_INET)
+	build(inet6Attached, fw.FiltersInet6, unix.AF_INET6)
 
 	// M3: truncate to the priority window and report the overflow rather than
 	// silently dropping later terms' steering.
@@ -763,16 +811,45 @@ func PBRBuildStats(cfg *config.Config) (installed, degraded int) {
 	return installed, degraded
 }
 
-// collectAttachedInputFilters returns the set of filter names attached as an
-// interface-unit INPUT filter, split by family. These are the only filters
-// whose `then routing-instance` terms take effect as Junos FBF (#3430 H1).
-func collectAttachedInputFilters(ifs *config.InterfacesConfig) (inet, inet6 map[string]struct{}) {
-	inet = make(map[string]struct{})
-	inet6 = make(map[string]struct{})
-	if ifs == nil {
-		return inet, inet6
+// pbrAttachment binds a firewall filter to the Linux ingress interface it is
+// attached to as an interface-unit input filter. Carrying the interface
+// identity (not just the filter name, #5117) lets BuildPBRRules scope each
+// kernel FBF ip rule to the interface the filter is bound to — matching
+// per-interface Junos FBF instead of steering matching traffic globally.
+type pbrAttachment struct {
+	Filter string // firewall filter name
+	Iif    string // Linux ingress ifname (e.g. "ge-0-0-0", "ge-0-0-0.50")
+}
+
+// collectAttachedInputFilters returns the ordered, de-duplicated set of
+// (filter, ingress-interface) attachments for interface-unit INPUT filters,
+// split by family. These are the only filters whose `then routing-instance`
+// terms take effect as Junos FBF (#3430 H1).
+//
+// Unlike the pre-#5117 collector (which returned filter NAMES only and so
+// deduplicated a filter attached to several interfaces into a single global
+// rule), this preserves the ingress interface each attachment binds to. The
+// kernel ifname is resolved canonically via cfg.ResolveKernelIfName — the same
+// Junos-ref → Linux-name mapping the rest of routing uses, so a unit-0 collapse
+// (ge-0/0/0 → ge-0-0-0), an 802.1Q VLAN unit (ge-0/0/0.50), and a RETH member
+// (reth0 → local physical member) all resolve consistently. Entries are
+// de-duplicated by (filter, iif) so the same filter on the same interface is
+// not double-counted, and the result is sorted (filter, then iif) so emitted
+// ip-rule priorities are stable across applies despite Go map-iteration order.
+func collectAttachedInputFilters(cfg *config.Config) (inet, inet6 []pbrAttachment) {
+	if cfg == nil {
+		return nil, nil
 	}
-	for _, ifc := range ifs.Interfaces {
+	seenV4 := make(map[pbrAttachment]struct{})
+	seenV6 := make(map[pbrAttachment]struct{})
+	add := func(seen map[pbrAttachment]struct{}, list *[]pbrAttachment, a pbrAttachment) {
+		if _, dup := seen[a]; dup {
+			return
+		}
+		seen[a] = struct{}{}
+		*list = append(*list, a)
+	}
+	for _, ifc := range cfg.Interfaces.Interfaces {
 		if ifc == nil {
 			continue
 		}
@@ -780,26 +857,35 @@ func collectAttachedInputFilters(ifs *config.InterfacesConfig) (inet, inet6 map[
 			if unit == nil {
 				continue
 			}
+			if unit.FilterInputV4 == "" && unit.FilterInputV6 == "" {
+				continue
+			}
+			// Resolve the kernel ingress ifname for this interface-unit, matching
+			// how the filter binds (base / VLAN sub-interface / RETH member).
+			iif := cfg.ResolveKernelIfName(fmt.Sprintf("%s.%d", ifc.Name, unit.Number))
 			if unit.FilterInputV4 != "" {
-				inet[unit.FilterInputV4] = struct{}{}
+				add(seenV4, &inet, pbrAttachment{Filter: unit.FilterInputV4, Iif: iif})
 			}
 			if unit.FilterInputV6 != "" {
-				inet6[unit.FilterInputV6] = struct{}{}
+				add(seenV6, &inet6, pbrAttachment{Filter: unit.FilterInputV6, Iif: iif})
 			}
 		}
 	}
+	sortAttachments(inet)
+	sortAttachments(inet6)
 	return inet, inet6
 }
 
-// sortedKeys returns the map keys in deterministic (sorted) order so the
-// emitted ip-rule priorities are stable across applies.
-func sortedKeys(m map[string]struct{}) []string {
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
-	}
-	sort.Strings(out)
-	return out
+// sortAttachments orders attachments deterministically (filter name, then
+// ingress ifname) so the emitted ip-rule priorities are stable across applies
+// regardless of Go map-iteration order.
+func sortAttachments(atts []pbrAttachment) {
+	sort.Slice(atts, func(i, j int) bool {
+		if atts[i].Filter != atts[j].Filter {
+			return atts[i].Filter < atts[j].Filter
+		}
+		return atts[i].Iif < atts[j].Iif
+	})
 }
 
 // buildPBRFromFilter extracts PBR rules from a single firewall filter.
@@ -821,11 +907,11 @@ func buildPBRFromFilter(filter *config.FirewallFilter, family int, tableIDs map[
 		// userspace-dp/src/afxdp/forwarding/mod.rs) returns RouteOverride::Drop for
 		// such a term (#4392). The kernel `ip rule` mirror must match that
 		// disposition — building a steering rule here would fail OPEN, steering
-		// slow-path / XDP_PASS / unfiltered-interface traffic (the ip rule is
-		// global, no iif selector) into the target VRF that userspace drops. The
-		// strict commit gate (validateFilterRoutingInstanceConflictStrict) rejects
-		// this term, but is LENIENT on load / peer-sync (#1960 no-brick), so a
-		// contradictory term can still reach here — skip it (do NOT steer).
+		// slow-path / XDP_PASS traffic ingressing the attached interface (even
+		// with the #5117 iif selector) into the target VRF that userspace drops.
+		// The strict commit gate (validateFilterRoutingInstanceConflictStrict)
+		// rejects this term, but is LENIENT on load / peer-sync (#1960 no-brick),
+		// so a contradictory term can still reach here — skip it (do NOT steer).
 		if term.Action == "discard" || term.Action == "reject" {
 			errs = append(errs, fmt.Errorf(
 				"PBR filter %s term %s co-locates routing-instance %q with a terminating "+
@@ -948,9 +1034,11 @@ func buildPBRFromFilter(filter *config.FirewallFilter, family int, tableIDs map[
 		hasL4 := len(protos) > 0 || len(sports) > 0 || len(dports) > 0
 		if !hasDSCP && !srcConstrained && !dstConstrained && !hasL4 {
 			// A truly unconstrained `then routing-instance` term (no dscp, no
-			// address, no L4) would program `from all to all lookup <vr>`, which —
-			// the mirror has no iif selector (H03) — steers ALL traffic globally.
-			// Skip it (fail-safe under-steer), matching the pre-#3730 behavior.
+			// address, no L4) would program `from all to all iif <if> lookup <vr>`.
+			// Even with the #5117 iif selector scoping it to the attached
+			// interface, xpf conservatively declines to emit an interface-wide
+			// catch-all steer here (fail-safe under-steer), matching the pre-#3730
+			// behavior; the userspace filter path still enforces the term exactly.
 			slog.Warn("PBR: filter term has routing-instance but no ip-rule-compatible criteria (dscp, address, protocol, port)",
 				"filter", filter.Name, "term", term.Name)
 			continue

--- a/pkg/routing/rules_test.go
+++ b/pkg/routing/rules_test.go
@@ -695,9 +695,9 @@ func TestPBRRulesApply_Fake(t *testing.T) {
 	p := &pbrManager{ops: ops}
 
 	rules := []PBRRule{
-		{Family: unix.AF_INET, TOS: 46 << 2, TOSSet: true, TableID: 100, Instance: "vr-a"},
-		{Family: unix.AF_INET6, Src: "2001:db8::/32", TableID: 100, Instance: "vr-a"},
-		{Family: unix.AF_INET, Dst: "10.5.0.0/16", TableID: 101, Instance: "vr-b"},
+		{Family: unix.AF_INET, TOS: 46 << 2, TOSSet: true, TableID: 100, Instance: "vr-a", IifName: "ge-0-0-0"},
+		{Family: unix.AF_INET6, Src: "2001:db8::/32", TableID: 100, Instance: "vr-a", IifName: "ge-0-0-0"},
+		{Family: unix.AF_INET, Dst: "10.5.0.0/16", TableID: 101, Instance: "vr-b", IifName: "ge-0-0-1"},
 	}
 
 	if err := p.Apply(rules); err != nil {
@@ -723,6 +723,44 @@ func TestPBRRulesApply_Fake(t *testing.T) {
 	}
 }
 
+// TestPBRApplyScopesRuleToIif verifies pbrManager.Apply stamps the ingress
+// interface onto the installed netlink rule (FRA_IIFNAME, #5117): a PBRRule
+// carrying an IifName becomes an ip rule scoped to that interface, and a rule
+// with no IifName is REFUSED (never installed as a global iif-less rule).
+func TestPBRApplyScopesRuleToIif(t *testing.T) {
+	t.Run("iif is programmed onto the rule", func(t *testing.T) {
+		ops := newFakeRuleOps()
+		p := &pbrManager{ops: ops}
+		rules := []PBRRule{
+			{Family: unix.AF_INET, Src: "10.0.1.0/24", TableID: 101, Instance: "ATT", IifName: "ge-0-0-0"},
+		}
+		if err := p.Apply(rules); err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+		if ops.count(unix.AF_INET) != 1 {
+			t.Fatalf("expected 1 installed rule, got %d", ops.count(unix.AF_INET))
+		}
+		if got := ops.rules[unix.AF_INET][0].IifName; got != "ge-0-0-0" {
+			t.Errorf("installed rule IifName = %q, want %q (must scope to the ingress interface)", got, "ge-0-0-0")
+		}
+	})
+
+	t.Run("empty iif is refused, not installed globally", func(t *testing.T) {
+		ops := newFakeRuleOps()
+		p := &pbrManager{ops: ops}
+		rules := []PBRRule{
+			{Family: unix.AF_INET, Src: "10.0.1.0/24", TableID: 101, Instance: "ATT"}, // no IifName
+		}
+		err := p.Apply(rules)
+		if err == nil {
+			t.Fatal("Apply must return non-nil for a rule with no ingress interface (#5117 fail-closed)")
+		}
+		if ops.count(unix.AF_INET) != 0 {
+			t.Errorf("no global iif-less rule may be installed, got %d", ops.count(unix.AF_INET))
+		}
+	})
+}
+
 // TestPBRApplyAggregatesAddErrors verifies that pbrManager.Apply surfaces a
 // RuleAdd failure (#3430 H3) instead of swallowing it and reporting success
 // after the up-front clear already removed the previously-working steering.
@@ -732,7 +770,7 @@ func TestPBRApplyAggregatesAddErrors(t *testing.T) {
 	p := &pbrManager{ops: ops}
 
 	rules := []PBRRule{
-		{Family: unix.AF_INET, TOS: 46 << 2, TOSSet: true, TableID: 100, Instance: "vr-a"},
+		{Family: unix.AF_INET, TOS: 46 << 2, TOSSet: true, TableID: 100, Instance: "vr-a", IifName: "ge-0-0-0"},
 	}
 	err := p.Apply(rules)
 	if err == nil {
@@ -750,7 +788,7 @@ func TestPBRApplyCapBoundary(t *testing.T) {
 	mk := func(n int) []PBRRule {
 		out := make([]PBRRule, n)
 		for i := range out {
-			out[i] = PBRRule{Family: unix.AF_INET, Src: fmt.Sprintf("10.%d.%d.0/24", i/256, i%256), TableID: 100, Instance: "vr"}
+			out[i] = PBRRule{Family: unix.AF_INET, Src: fmt.Sprintf("10.%d.%d.0/24", i/256, i%256), TableID: 100, Instance: "vr", IifName: "ge-0-0-0"}
 		}
 		return out
 	}
@@ -794,7 +832,7 @@ func TestPBRApplyClearDelFailureSurfaced(t *testing.T) {
 	// cleared. Pre-fix the clear() RuleDel failure was debug-logged only and
 	// Apply returned nil.
 	rules := []PBRRule{
-		{Family: unix.AF_INET, Src: "10.7.0.0/16", TableID: 101, Instance: "vr-b"},
+		{Family: unix.AF_INET, Src: "10.7.0.0/16", TableID: 101, Instance: "vr-b", IifName: "ge-0-0-0"},
 	}
 	if err := p.Apply(rules); err == nil {
 		t.Fatal("Apply must return non-nil when a stale rule cannot be cleared (#3430 H3)")


### PR DESCRIPTION
## Summary

Kernel filter-based-forwarding (FBF/PBR) `ip rule`s were expanded once per firewall filter with **no incoming-interface selector**: each rule set Table/Priority/Family/Tos/Src/Dst/proto/ports but never `rule.IifName`, and the attachment collector discarded interface identity (it returned filter names only, deduplicating a filter attached to several interfaces into a single global rule).

A kernel slow-path (`XDP_PASS`) packet arriving on a **different** interface could match the global rule and be steered into the wrong VRF — unlike per-interface Junos FBF, which scopes a `then routing-instance` term to the interface the filter is bound to. Impact (Medium, security-adjacent): cross-interface spoofed or fallback traffic could bypass uplink separation (cross-WAN / tenant route-leak). The userspace fast path was always per-interface; only the kernel fallback over-steered.

## Change

- `PBRRule` gains an `IifName` field carrying the resolved kernel ingress ifname.
- `collectAttachedInputFilters` now returns per-family `[]pbrAttachment` (filter + ingress interface) instead of a filter-name set. The kernel ifname is resolved canonically via `cfg.ResolveKernelIfName` — the same Junos-ref → Linux-name mapping the rest of routing uses, so unit-0 collapse (`ge-0/0/0`→`ge-0-0-0`), an 802.1Q VLAN unit (`ge-0/0/0.50`) and a RETH member (`reth0`→local physical member) all resolve consistently. Attachments dedup by `(filter, iif)` and sort deterministically so ip-rule priorities stay stable.
- `BuildPBRRules` expands once **per `(filter, interface)` attachment** and stamps each rule's `IifName`; a filter on N interfaces yields N iif-scoped rules, not one global rule. An attachment whose ingress interface cannot be resolved **fails closed** (drop + degrade) rather than installing a global iif-less rule.
- `pbrManager.Apply` sets `rule.IifName` (`FRA_IIFNAME`) and **refuses** to install a rule with an empty ingress interface (defense in depth).
- `clear()`/reconcile is unchanged: it deletes every rule in the PBR priority window, and kernel-listed rules carry their `IifName`, so `RuleDel` matches and removes the now-interface-scoped rules.

All existing rule fields (Table/Priority/Family/Tos/Src/Dst/proto/ports) are preserved unchanged; only the `IifName` scoping is added.

## Docs

`pkg/routing/README.md` gains a "Per-interface iif scoping (#5117)" note (and its stale #4534 "no `iif` selector" clause is corrected); `docs/multi-wan.md`'s FBF composition section notes the per-interface scoping.

## Tests (fail-on-revert)

- `TestBuildPBRRules_IifNameScoped` — every rule carries `IifName == ge-0-0-0` (empty/global fails).
- `TestBuildPBRRules_IifNameVLANUnit` — VLAN sub-interface resolves to `ge-0-0-0.50`.
- `TestBuildPBRRules_IifNamePerInterface` — a filter on two interfaces yields two distinct per-interface rules (not one global rule).
- `TestPBRApplyScopesRuleToIif` — `Apply` stamps `FRA_IIFNAME` and refuses an iif-less rule.
- `TestCollectAttachedInputFilters` updated to the per-attachment contract.

## Validation

- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` → exit 0
- `go test -count=1 ./pkg/routing/...` → ok
- `gofmt` clean

Closes #5117

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi