### PR TITLE
config: read all zone `interfaces` bracket-list members (#5248)

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -227,6 +227,29 @@ allowed-ips folds are covered by the `security-nat-static-multi-zone` and
 `interfaces-wireguard-allowed-ips-multi` dual-AST fixtures plus
 `TestWireguardAllowedIPsBracketList{FlatSet,Hierarchical}`.
 
+**Bracketed lists on a WILDCARD container collapse differently — a NESTED
+chain, not `Keys[1:]` (#5248).** The contract above assumes a `multi: true`
+value leaf, whose surplus bracket tokens land on ONE leaf's `Keys`. A
+bracket list whose element is instead a **wildcard container** —
+`security zones security-zone <z> interfaces [ ge-0/0/0 ge-0/0/1 ]`, where
+the interface name is `schemaNode.wildcard` with its own `host-inbound-traffic`
+child, NOT a `multi` leaf — does NOT collapse onto `Keys[1:]`. `SetPath`
+descends the wildcard for the FIRST token, then (the interface-name node has
+no wildcard of its own) nests every remaining token as a child UNDER that
+first member: `interfaces -> ge-0/0/0(container) -> ge-0/0/1(leaf)`; a 3+
+element list collapses the whole tail onto the deepest leaf's Keys
+(`interfaces -> a(container) -> leaf Keys=[b c]`). `firewallMatchValues` is
+therefore the WRONG helper here — it reads one node's `Keys[1:]` + immediate
+children and would still see only the first member. `compileZones`
+(`compiler_security_zones.go`) flattens the nested chain with the recursive
+`zoneInterfaceMembers`, which reads every key at each level and skips a
+`host-inbound-traffic` body (a bracketed member is bare membership — it cannot
+carry a per-interface host-inbound stanza). Before #5248 the reader took only
+`iface.Name()` and silently dropped every member after the first — a zone-
+membership (security boundary) loss that also hid the dropped interface from
+the strict `validateZoneInterfaceDefinedStrict` gate. Covered by
+`pkg/config/compiler_zone_interfaces_bracket_5248_test.go`.
+
 **`multi: true` ALSO prevents single-value REPLACE for repeated keyed-list
 leaves (#3984).** The `#2419` discussion above is about ONE statement with a
 bracket list. The SAME `multi: true` marker fixes a second, distinct shape:

--- a/pkg/config/compiler_security_zones.go
+++ b/pkg/config/compiler_security_zones.go
@@ -112,7 +112,26 @@ func compileZones(node *Node, sec *SecurityConfig) error {
 			switch prop.Name() {
 			case "interfaces":
 				for _, iface := range prop.Children {
-					zone.Interfaces = append(zone.Interfaces, iface.Name())
+					// #5248: accumulate EVERY interface name this member node
+					// carries, across all parser AST shapes, not just the first.
+					// A bracketed flat-set / load-override membership list
+					// `interfaces [ ge-0/0/0 ge-0/0/1 ]` arrives bracket-stripped
+					// (the lexer drops `[`/`]`, #2419). Unlike a multi:true value
+					// leaf — where the surplus tokens collapse onto ONE leaf's
+					// Keys and firewallMatchValues recovers them — the schema
+					// models the interface name as a WILDCARD container, so
+					// SetPath NESTS each surplus token under the first member
+					// (`interfaces -> ge-0/0/0(container) -> ge-0/0/1(leaf)`; a
+					// 3+ list collapses the whole tail onto the deepest leaf's
+					// Keys, e.g. `[b c]`). Reading only iface.Name() compiled just
+					// the FIRST member and SILENTLY DROPPED the rest — a zone-
+					// membership (security boundary) loss: the dropped interfaces
+					// are left unmanaged / brought DOWN or evaluated against the
+					// wrong zone, and their absence hid them from the strict
+					// zone-interface-defined gate. zoneInterfaceMembers flattens
+					// the nested chain so the hierarchical `{ a; b; }`, a single
+					// `a`, and the bracketed `[ a b c ]` all yield every member.
+					zone.Interfaces = append(zone.Interfaces, zoneInterfaceMembers(iface)...)
 					// #3362: per-interface host-inbound-traffic override
 					// (`interfaces <if> host-inbound-traffic { ... }`). Same
 					// token grammar as the zone-level stanza; parsed by the
@@ -180,4 +199,41 @@ func compileZones(node *Node, sec *SecurityConfig) error {
 		}
 	}
 	return nil
+}
+
+// zoneInterfaceMembers flattens every interface name a `security-zone`
+// `interfaces` member node carries, across BOTH parser AST shapes (#5248 — the
+// zone-membership instance of the #2419 dual-shape class):
+//
+//   - hierarchical block  `interfaces { a; b; }`  → one child leaf per name,
+//     each read at the top of the recursion (iface.Keys = ["a"], ["b"])
+//   - single membership    `interfaces a`          → iface.Keys = ["a"]
+//   - bracket list          `interfaces [ a b c ]`  → a NESTED chain, because the
+//     schema models the interface name as a WILDCARD container (not a multi:true
+//     leaf): `interfaces -> a(container) -> leaf Keys=["b","c"]`. The lexer strips
+//     the brackets (#2419) so the flat-set path is [..., interfaces, a, b, c];
+//     SetPath descends the wildcard for `a`, then — the interface-name node has
+//     no wildcard of its own — collapses every remaining token onto ONE leaf
+//     under `a` (ast_edit.go SetPath, the childSchema==nil tail).
+//
+// Reading only the member's Name() (Keys[0]) compiled just the first member and
+// silently dropped the rest (#5248). Recursing the nested chain and reading every
+// key at each level recovers all members. A `host-inbound-traffic` body under a
+// member is NOT an interface name — it is compiled separately (#3362) and skipped
+// here; a bracketed member cannot carry one (Junos: brackets are bare
+// membership), so per-interface host-inbound stays keyed on the direct child.
+func zoneInterfaceMembers(iface *Node) []string {
+	var names []string
+	for _, k := range iface.Keys {
+		if k != "" {
+			names = append(names, k)
+		}
+	}
+	for _, child := range iface.Children {
+		if child.Name() == "host-inbound-traffic" {
+			continue
+		}
+		names = append(names, zoneInterfaceMembers(child)...)
+	}
+	return names
 }

--- a/pkg/config/compiler_zone_interfaces_bracket_5248_test.go
+++ b/pkg/config/compiler_zone_interfaces_bracket_5248_test.go
@@ -1,0 +1,244 @@
+package config
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Tests for #5248: a security-zone `interfaces` bracketed / load-override
+// membership list `interfaces [ a b c ]` dropped every member but the first.
+// The #2419 dual-AST SSOT (firewallMatchValues) converts multi:true value
+// leaves, but the zone interface name is a WILDCARD container, so the bracket
+// tail does NOT collapse onto one leaf's Keys — SetPath nests each surplus
+// token under the first member (`interfaces -> a(container) -> leaf [b c]`).
+// compileZones read only iface.Name() and silently dropped the nested members,
+// a zone-membership (security boundary) loss: the dropped interfaces are left
+// unmanaged / brought DOWN or evaluated against the wrong zone, and their
+// absence hid them from the strict zone-interface-defined gate. The fix flattens
+// the nested chain via zoneInterfaceMembers so every AST shape yields all
+// members.
+//
+// Every RED-on-revert case below fails (only the first member present, or an
+// undefined member no longer rejected) if the zoneInterfaceMembers flatten is
+// reverted to iface.Name()-only.
+//
+// IMPORTANT (per CLAUDE.md): flat-set syntax is built with ParseSetCommand +
+// tree.SetPath, never NewParser; the hierarchical shape uses parseHierarchical.
+
+// compileZonesFromSet5248 builds a tree from flat-set commands and compiles just
+// the zones subtree, returning the zone membership by name. It targets
+// compileZones directly (per the #5248 repro guidance) so the assertion is on
+// the compiled zone.Interfaces slice, independent of the full-pipeline strict
+// gates.
+func compileZonesFromSet5248(t *testing.T, cmds ...string) map[string][]string {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return compileZonesMembership5248(t, tree)
+}
+
+func compileZonesMembership5248(t *testing.T, tree *ConfigTree) map[string][]string {
+	t.Helper()
+	sec := tree.FindChild("security")
+	if sec == nil {
+		t.Fatalf("no security node in tree")
+	}
+	zonesNode := sec.FindChild("zones")
+	if zonesNode == nil {
+		t.Fatalf("no security zones node in tree")
+	}
+	secCfg := &SecurityConfig{Zones: map[string]*ZoneConfig{}}
+	if err := compileZones(zonesNode, secCfg); err != nil {
+		t.Fatalf("compileZones: %v", err)
+	}
+	out := make(map[string][]string, len(secCfg.Zones))
+	for name, z := range secCfg.Zones {
+		out[name] = z.Interfaces
+	}
+	return out
+}
+
+// TestZoneInterfacesBracket5248FlatSetKeepsAllMembers is the primary
+// RED-on-revert guard: a two- and a three-member bracketed flat-set list must
+// land EVERY member. Reverting zoneInterfaceMembers to iface.Name()-only drops
+// everything after the first and this goes RED.
+func TestZoneInterfacesBracket5248FlatSetKeepsAllMembers(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  string
+		want []string
+	}{
+		{
+			name: "two-member bracket",
+			cmd:  "set security zones security-zone Z interfaces [ ge-0/0/0 ge-0/0/1 ]",
+			want: []string{"ge-0/0/0", "ge-0/0/1"},
+		},
+		{
+			name: "three-member bracket",
+			cmd:  "set security zones security-zone Z interfaces [ ge-0/0/0 ge-0/0/1 ge-0/0/2 ]",
+			want: []string{"ge-0/0/0", "ge-0/0/1", "ge-0/0/2"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := compileZonesFromSet5248(t, tc.cmd)["Z"]
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("zone Z interfaces = %v, want %v (bracket tail dropped — #5248)", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestZoneInterfacesBracket5248DualASTParity pins the documented dual-AST
+// contract: the hierarchical block and the bracketed flat-set list must compile
+// to the SAME zone membership. Before the fix the flat-set list yielded only the
+// first member while the hierarchical block yielded both — a parity break.
+func TestZoneInterfacesBracket5248DualASTParity(t *testing.T) {
+	flat := compileZonesFromSet5248(t,
+		"set security zones security-zone Z interfaces [ ge-0/0/0 ge-0/0/1 ]",
+	)["Z"]
+
+	hierTree := parseHierarchical(t, `
+security {
+    zones {
+        security-zone Z {
+            interfaces {
+                ge-0/0/0;
+                ge-0/0/1;
+            }
+        }
+    }
+}`)
+	hier := compileZonesMembership5248(t, hierTree)["Z"]
+
+	want := []string{"ge-0/0/0", "ge-0/0/1"}
+	if !reflect.DeepEqual(hier, want) {
+		t.Fatalf("hierarchical zone interfaces = %v, want %v", hier, want)
+	}
+	if !reflect.DeepEqual(flat, hier) {
+		t.Fatalf("dual-AST parity broken: flat-set %v != hierarchical %v (#5248)", flat, hier)
+	}
+}
+
+// TestZoneInterfaces5248SingleMembershipNotOverCollapsed is the negative
+// control: a single membership must yield EXACTLY one member (the flatten must
+// not invent phantom members from an empty tail).
+func TestZoneInterfaces5248SingleMembershipNotOverCollapsed(t *testing.T) {
+	got := compileZonesFromSet5248(t,
+		"set security zones security-zone Z interfaces ge-0/0/0",
+	)["Z"]
+	want := []string{"ge-0/0/0"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("single membership zone interfaces = %v, want %v (over-collapse)", got, want)
+	}
+}
+
+// TestZoneInterfaces5248PerInterfaceHostInboundPreserved confirms the flatten
+// does NOT regress the #3362 per-interface host-inbound-traffic override: the
+// interface still appears as a member AND its host-inbound stanza still keys on
+// the interface name (the flatten skips the host-inbound-traffic body, so it is
+// not mistaken for a member).
+func TestZoneInterfaces5248PerInterfaceHostInboundPreserved(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, cmd := range []string{
+		"set security zones security-zone Z interfaces ge-0/0/0 host-inbound-traffic system-services [ ssh ping ]",
+		"set security zones security-zone Z interfaces ge-0/0/1",
+	} {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	sec := tree.FindChild("security")
+	secCfg := &SecurityConfig{Zones: map[string]*ZoneConfig{}}
+	if err := compileZones(sec.FindChild("zones"), secCfg); err != nil {
+		t.Fatalf("compileZones: %v", err)
+	}
+	z := secCfg.Zones["Z"]
+	if !reflect.DeepEqual(z.Interfaces, []string{"ge-0/0/0", "ge-0/0/1"}) {
+		t.Fatalf("zone interfaces = %v, want [ge-0/0/0 ge-0/0/1]", z.Interfaces)
+	}
+	hib := z.InterfaceHostInbound["ge-0/0/0"]
+	if hib == nil {
+		t.Fatalf("per-interface host-inbound for ge-0/0/0 missing (flatten swallowed the body?)")
+	}
+	if !reflect.DeepEqual(hib.SystemServices, []string{"ssh", "ping"}) {
+		t.Fatalf("per-interface system-services = %v, want [ssh ping]", hib.SystemServices)
+	}
+	// The host-inbound-traffic body must NOT leak into the membership list.
+	for _, m := range z.Interfaces {
+		if m == "host-inbound-traffic" {
+			t.Fatalf("host-inbound-traffic leaked into zone membership: %v", z.Interfaces)
+		}
+	}
+}
+
+// TestZoneInterfacesBracket5248EndToEndCompile drives the FULL CompileConfig
+// pipeline: both bracketed members are defined under `interfaces`, so both must
+// survive into zone membership and pass the strict zone-interface-defined gate.
+func TestZoneInterfacesBracket5248EndToEndCompile(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, cmd := range []string{
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.1/24",
+		"set security zones security-zone trust interfaces [ ge-0/0/0 ge-0/0/1 ]",
+	} {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	got := cfg.Security.Zones["trust"].Interfaces
+	if !reflect.DeepEqual(got, []string{"ge-0/0/0", "ge-0/0/1"}) {
+		t.Fatalf("trust zone interfaces = %v, want [ge-0/0/0 ge-0/0/1] (#5248)", got)
+	}
+}
+
+// TestZoneInterfacesBracket5248UndefinedMemberRejected is the fail-fast
+// RED-on-revert guard mirroring #3703's unknown-token gate: a bracketed member
+// that names an UNDEFINED interface must reach the strict zone-interface-defined
+// gate and be REJECTED at commit. Before the fix the second member was dropped
+// before validation, so the config committed with the undefined interface
+// silently absent — reverting the flatten makes this compile clean and the test
+// goes RED.
+func TestZoneInterfacesBracket5248UndefinedMemberRejected(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, cmd := range []string{
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
+		"set security zones security-zone trust interfaces [ ge-0/0/0 ge-0/0/9 ]",
+	} {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("CompileConfig accepted a bracketed zone member naming an undefined interface; want a strict reject (#5248)")
+	}
+	if !strings.Contains(err.Error(), "ge-0/0/9") {
+		t.Fatalf("reject error %q does not name the undefined member ge-0/0/9", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a #2419 dual-AST-class defect: a security-zone bracketed / load-override
membership list `interfaces [ ge-0/0/0 ge-0/0/1 ]` silently dropped every
member but the first.

`compileZones` (`pkg/config/compiler_security_zones.go`) read a zone's
interface membership from `iface.Name()` on each direct child of the
`interfaces` node. The schema models a zone interface name as a **wildcard
container** (an interface-name node carrying a `host-inbound-traffic` child),
NOT a `multi: true` value leaf. The lexer strips the brackets (#2419), so the
flat-set / load-override path arrives as `[..., interfaces, ge-0/0/0,
ge-0/0/1]`. Unlike a `multi` leaf — where surplus tokens collapse onto one
leaf's `Keys` and `firewallMatchValues` recovers them — `SetPath` descends the
wildcard for the first token, then nests every remaining token as a child
**under** the first member:

```
interfaces -> ge-0/0/0(container) -> ge-0/0/1(leaf)          # [ a b ]
interfaces -> a(container)        -> leaf Keys=[b c]         # [ a b c ]
```

A compile-layer repro confirms the outcome is a **silent drop**, not a hard
reject: `SchemaValidate` accepts the bracketed form (open-world wildcard walk),
and the dropped members simply vanish. That is a zone-membership (a security
boundary) loss — the dropped interfaces are left unmanaged / brought DOWN or
evaluated against the wrong zone — and their absence also hid them from
`validateZoneInterfaceDefinedStrict`.

## Fix

Add `zoneInterfaceMembers`, a recursive flatten that reads every key at each
level of the nested member chain and skips a `host-inbound-traffic` body (a
bracketed member is bare membership and cannot carry a per-interface
host-inbound stanza, so the #3362 override stays keyed on the direct child).
`firewallMatchValues` is deliberately not reused — it reads one node's
`Keys[1:]` + immediate children and would still see only the first member on
the wildcard-container shape. Hierarchical `{ a; b; }`, single `a`, and
bracketed `[ a b c ]` now all yield every member.

`docs/config-schema.md` documents the wildcard-container collapse variant
alongside the existing multi-leaf contract.

## Validation

- `go build ./...` clean
- `go test ./pkg/config/...` green
- New RED-on-revert coverage in
  `pkg/config/compiler_zone_interfaces_bracket_5248_test.go`: flat-set two- and
  three-member brackets keep all members; hierarchical/flat-set dual-AST
  parity; single-membership negative control; #3362 per-interface host-inbound
  preserved; full-pipeline `CompileConfig` end-to-end; and a bracketed member
  naming an **undefined** interface is now rejected by the strict
  zone-interface-defined gate (before the fix the dropped member committed
  clean). Reverting the flatten to `iface.Name()`-only fails five of these.

Provenance: ps-review-042 (Paladin full-tree), batch
`A3_go_config_cli_tree-b1`, finding F-02; #2419 multi-value-leaf class.

Closes #5248

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi