### PR TITLE
config: guard sampling instance input rate at the compiler (#5244)

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -4742,7 +4742,16 @@ the value sits in a single typed slot:
     `ValidateInteger(0, maxWireU32)`. **0 is accepted** (the documented
     `0 = sample all` sentinel, `types_system.go`; Layer A normalizes
     `rate<=0 -> 1`) — EXACT Layer-A agreement, rejecting only the
-    decode-aborting `>u32max`.
+    decode-aborting `>u32max`. This typed-leaf gate hard-rejects a negative
+    rate at strict operator commit (#1979). Defense-in-depth (#5244): the
+    compiler carries a second lower-bound guard
+    (`validateSamplingInputRateStrict`, a uniform gate) so `compileSampling`
+    matches the sibling `compilePortMirroring` inline guard and the tolerant
+    load / peer-sync path (where the typed-leaf gate is downgraded to a
+    warning) still names the fail-open consequence. Strict on commit / commit-
+    check; lenient-warn on tolerant load / peer-sync (#1960) — a negative rate
+    is otherwise a silent fail-open (the exporter's `SamplingRate > 1` 1-in-N
+    gate ignores the ratio and exports every eligible flow).
   - `forwarding-options sampling … output flow-server <addr> port` —
     `ValidateInteger(1, maxWireU16)` (Rust u16 CollectorPort; Layer A skips a
     server whose port is `<1` or `>65535`). `flow-server` keeps `args:1` for

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -806,6 +806,20 @@ type compileOpts struct {
 	// ExportConfigs, so eligible flows duplicate to both instances rather than
 	// bricking the load. Same doctrine as lenientFlowServerTemplateRef.
 	lenientSamplingInstanceConflicts bool
+	// lenientSamplingInputRate (#5244) downgrades the sampling instance
+	// input-rate lower-bound gate (validateSamplingInputRateStrict) from a
+	// hard compile error to a cfg.Warnings entry. A negative
+	// `forwarding-options sampling instance <name> input rate` was previously
+	// stored unchecked: the flow exporter's 1-in-N gate (`SamplingRate > 1`)
+	// then silently ignored the configured ratio and exported every eligible
+	// flow, and the retired eBPF cast would wrap it into a huge divisor. The
+	// strict commit / commit-check path hard-rejects so the typo is operator-
+	// visible; the tolerant load / peer-sync paths warn so an already-persisted
+	// or peer-synced config authored by a pre-guard version still BOOTS (#1960)
+	// — the userspace snapshot builder clamps `rate <= 0 -> 1`, so a leniently-
+	// loaded negative rate runs safely as sample-all. Same doctrine as
+	// lenientSamplingInstanceConflicts.
+	lenientSamplingInputRate bool
 	// lenientApplicationSetMembers (#2217 Finding B) downgrades the
 	// application-set member cross-reference gate
 	// (validateApplicationSetMembersStrict) from a hard compile error to a
@@ -1732,6 +1746,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientFirewallRefs:                    true,
 		lenientFlowServerTemplateRef:           true,
 		lenientSamplingInstanceConflicts:       true,
+		lenientSamplingInputRate:               true,
 		lenientApplicationSetMembers:           true,
 		lenientPolicyMatchApplications:         true,
 		lenientNATMatchApplications:            true,
@@ -2000,6 +2015,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientFirewallRefs:                    true,
 		lenientFlowServerTemplateRef:           true,
 		lenientSamplingInstanceConflicts:       true,
+		lenientSamplingInputRate:               true,
 		lenientApplicationSetMembers:           true,
 		lenientPolicyMatchApplications:         true,
 		lenientNATMatchApplications:            true,

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -1537,6 +1537,32 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 		}
 	}
 
+	// #5244: sampling instance input-rate lower bound (compiler-side defense-
+	// in-depth). A negative `forwarding-options sampling instance <name> input
+	// rate` is a fail-open — the exporter's `SamplingRate > 1` gate is false
+	// for a negative value (every eligible flow exports, the ratio is ignored)
+	// and the retired eBPF cast wrapped it into a huge divisor. At strict
+	// operator commit this is already hard-rejected by the #1979 SchemaValidate
+	// typed-leaf gate (ValidateInteger(0, maxWireU32)), which runs before the
+	// compiler; `compileSampling` itself, however, stored the value unchecked,
+	// unlike the sibling `compilePortMirroring`, which carries its own inline
+	// guard. This gate closes that asymmetry so a negative rate reaching the
+	// compiler without the typed-leaf gate (tolerant load / peer-sync, direct
+	// CompileConfig callers, future refactors) is still caught. Strict on
+	// commit / commit-check; lenient on load / peer-sync (warn so an already-
+	// persisted or peer-synced config still boots — #1960; the userspace
+	// snapshot builder clamps rate <= 0 -> 1, so the running dataplane is
+	// safe). `0` stays valid (sample every packet). Mirrors
+	// validateSamplingInstanceConflictsStrict.
+	if err := validateSamplingInputRateStrict(cfg); err != nil {
+		if opts.lenientSamplingInputRate {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("sampling instance input rate (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #2217 Finding B: application-set member cross-reference. An
 	// `applications application-set <set>` member referencing neither a defined
 	// application (user / junos-* predefined) nor a defined nested

--- a/pkg/config/compiler_validate_strict_observability.go
+++ b/pkg/config/compiler_validate_strict_observability.go
@@ -701,3 +701,58 @@ func validateSamplingInstanceConflictsStrict(cfg *Config) error {
 	}
 	return nil
 }
+
+// validateSamplingInputRateStrict hard-rejects a `forwarding-options sampling
+// instance <name> input rate` below zero (#5244).
+//
+// The defect: compileSampling stored the parsed rate with no lower-bound check,
+// so a typo like `input rate -1` committed cleanly. A negative rate is a
+// fail-open: the 1-in-N export gate in the flow exporter
+// (ExportConfig.ShouldExport, pkg/flowexport) treats `SamplingRate > 1` as
+// false for a negative value, so the operator's intended 1-in-N ratio is
+// silently ignored (every eligible flow exports) — while the userspace
+// snapshot path defensively clamps `rate <= 0 -> 1` and the retired eBPF
+// compiler cast `uint32(InputRate)` would wrap it into a ~4.29e9 divisor. Any
+// way it lands, the configured rate is not what runs and the operator gets no
+// signal. The sibling port-mirroring path already rejects the same class
+// inline in compilePortMirroring ("input rate must not be negative"); sampling
+// was missed.
+//
+// `0` is VALID and preserved: it means "sample every packet" per Junos, matches
+// the port-mirroring sibling ("0 mirrors every packet"), and is the codebase
+// contract (SamplingInstance.InputRate doc, the `rate <= 0 -> 1` snapshot
+// clamp, and the `SamplingRate > 1` exporter gate all treat 0 as sample-all).
+// Only a strictly negative rate is rejected; there is no upper bound here
+// (the sibling has none either, and the snapshot builder already caps at the
+// Rust u32 max, #1977).
+//
+// Strict on commit / commit-check (hard reject so the typo is operator-
+// visible); lenient on load / peer-sync (the call site downgrades to a warning
+// via opts.lenientSamplingInputRate so an already-persisted or peer-synced
+// config authored by a pre-guard version still BOOTS — #1960; the snapshot
+// clamp keeps the running dataplane safe). Mirrors
+// validateSamplingInstanceConflictsStrict.
+func validateSamplingInputRateStrict(cfg *Config) error {
+	if cfg == nil || cfg.ForwardingOptions.Sampling == nil {
+		return nil
+	}
+	insts := cfg.ForwardingOptions.Sampling.Instances
+	// Deterministic instance order so the first-offender message is stable.
+	names := make([]string, 0, len(insts))
+	for name := range insts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		inst := insts[name]
+		if inst == nil {
+			continue
+		}
+		if inst.InputRate < 0 {
+			return fmt.Errorf("forwarding-options sampling instance %q: input "+
+				"rate must not be negative, got %d (a 1-in-N sampling rate must "+
+				"be >= 0; 0 samples every packet)", name, inst.InputRate)
+		}
+	}
+	return nil
+}

--- a/pkg/config/sampling_input_rate_5244_test.go
+++ b/pkg/config/sampling_input_rate_5244_test.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5244 — sampling instance input-rate lower-bound gate (compiler-side
+// defense-in-depth).
+//
+// A negative `forwarding-options sampling instance <name> input rate` is a
+// fail-open: the exporter's `SamplingRate > 1` 1-in-N gate is false for a
+// negative value (every eligible flow exports, the ratio is ignored) and the
+// retired eBPF cast wrapped it into a huge divisor. At STRICT operator commit
+// this is already hard-rejected by the #1979 SchemaValidate typed-leaf gate
+// (`ValidateInteger(0, maxWireU32)` on the rate leaf), which runs before the
+// compiler — so `compileSampling` itself never saw the value guarded, unlike
+// the sibling `compilePortMirroring`, which carries its own inline lower-bound
+// guard as defense-in-depth. This gate closes that asymmetry: a compiler-side
+// bound (validateSamplingInputRateStrict) that also fires on paths reaching the
+// compiler without the typed-leaf gate (tolerant load / peer-sync, direct
+// CompileConfig callers, future refactors). Strict on commit / commit-check;
+// tolerant load / peer-sync downgrades to a warning (#1960). `0` stays valid
+// (sample every packet, per Junos and the port-mirroring sibling).
+//
+// These tests exercise the compiler-side gate directly via CompileConfig /
+// CompileConfigLenient (which do NOT run SchemaValidate), so they isolate the
+// gate and FAIL if it is reverted.
+
+// TestSamplingNegativeInputRateRejected: a negative input rate is hard-rejected
+// at strict commit. This FAILS (negative accepted -> wrap / fail-open) if the
+// bound check is reverted.
+func TestSamplingNegativeInputRateRejected(t *testing.T) {
+	cmds := []string{
+		"set forwarding-options sampling instance s input rate -1",
+		"set forwarding-options sampling instance s family inet output flow-server 10.0.0.1 port 2055",
+	}
+	tree := buildTreeFromSet(t, cmds)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a negative sampling input rate; expected rejection")
+	}
+	for _, want := range []string{"sampling instance", "s", "negative", "-1"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+// TestSamplingZeroInputRateAccepted: 0 is a VALID rate (sample every packet)
+// per Junos and the port-mirroring sibling; it must NOT be rejected.
+func TestSamplingZeroInputRateAccepted(t *testing.T) {
+	cmds := []string{
+		"set forwarding-options sampling instance s input rate 0",
+		"set forwarding-options sampling instance s family inet output flow-server 10.0.0.1 port 2055",
+	}
+	tree := buildTreeFromSet(t, cmds)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a zero (sample-every-packet) sampling input rate: %v", err)
+	}
+}
+
+// TestSamplingValidInputRateAccepted: a normal positive 1-in-N rate compiles
+// cleanly and is stored unchanged.
+func TestSamplingValidInputRateAccepted(t *testing.T) {
+	cmds := []string{
+		"set forwarding-options sampling instance s input rate 1000",
+		"set forwarding-options sampling instance s family inet output flow-server 10.0.0.1 port 2055",
+	}
+	tree := buildTreeFromSet(t, cmds)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig rejected a valid sampling input rate: %v", err)
+	}
+	if cfg.ForwardingOptions.Sampling == nil {
+		t.Fatal("sampling config missing after compile")
+	}
+	inst := cfg.ForwardingOptions.Sampling.Instances["s"]
+	if inst == nil {
+		t.Fatal("sampling instance s missing after compile")
+	}
+	if inst.InputRate != 1000 {
+		t.Errorf("input rate = %d, want 1000 (valid rate must be stored unchanged)", inst.InputRate)
+	}
+}
+
+// TestSamplingNegativeInputRateLenientWarns: on the tolerant load / peer-sync
+// path a negative rate is downgraded to a warning so an already-persisted or
+// peer-synced config authored by a pre-guard version still boots (#1960).
+func TestSamplingNegativeInputRateLenientWarns(t *testing.T) {
+	cmds := []string{
+		"set forwarding-options sampling instance s input rate -5",
+		"set forwarding-options sampling instance s family inet output flow-server 10.0.0.1 port 2055",
+	}
+	tree := buildTreeFromSet(t, cmds)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must NOT hard-reject a negative sampling input rate: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "sampling instance input rate") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("lenient compile must emit a downgraded warning for the negative rate; warnings=%v", cfg.Warnings)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a compiler-side lower-bound guard for `forwarding-options sampling instance <name> input rate`, mirroring the sibling `compilePortMirroring` inline guard so the two flow-sampling paths enforce the same invariant. A negative sampling rate is a fail-open (the exporter's 1-in-N gate `SamplingRate > 1` is false for a negative value, silently ignoring the ratio and exporting every eligible flow; the retired eBPF cast additionally wrapped it into a ~4.29e9 divisor).

## Scope correction (important for the reviewer)

The issue's core premise — that a negative rate is **accepted at commit** and that there is **no typed leaf validator** — is **inaccurate**, verified firsthand against `origin/master`:

- The `input rate` leaf has carried `validator: ValidateInteger(0, maxWireU32)` since **#1979** (`ce7e0e039`, 2026-06-18), which is an **ancestor of the issue's own gate base `d1449fe77`** (2026-07-10).
- The strict operator-commit path (`compileTreeStrict` in `pkg/configstore/store.go`) runs `SchemaValidate` **before** the compiler, so `set forwarding-options sampling instance S input rate -1` is **already hard-rejected at commit** with: `forwarding-options sampling instance S input rate: invalid value "-1": integer out of range [0..4294967295] (got -1)`.

So this PR is **compiler-side defense-in-depth + sibling consistency**, not a fix for an operator-reachable fail-open. It catches a negative rate on paths that reach the compiler *without* the typed-leaf gate: tolerant load / peer-sync (where `SchemaValidate` is downgraded to a warning), direct `CompileConfig` callers, and future refactors. This matches why `compilePortMirroring` carries its own inline guard despite its own schema `ValidateInteger(1,16)`.

**Reviewer decision:** merge as hardening/consistency, or close #5244 as already-mitigated by #1979. I recommend merging — it removes a real asymmetry between the two sibling flow-sampling compile paths.

## Implementation

- `validateSamplingInputRateStrict` (uniform gate in `compiler_validate_strict_observability.go`, wired in `compiler_uniformgates.go`) rejects `InputRate < 0` with a deterministic first-offender message.
- Strict on commit / commit-check; downgrades to a `cfg.Warnings` entry on tolerant load / peer-sync via `opts.lenientSamplingInputRate` (#1960), matching the sibling `validateSamplingInstanceConflictsStrict`. A pre-guard persisted/synced config still boots — the userspace snapshot builder already clamps `rate <= 0 -> 1`.
- `0` stays valid ("sample every packet" per Junos and the port-mirroring sibling). No upper bound here (the sibling has none; the snapshot builder caps at the Rust u32 max, #1977). Parse/store of a valid rate is unchanged.

## Validation

- `go build ./...` — pass (build_exit=0)
- `go test ./pkg/config/...` — pass (test_exit=0)
- New `sampling_input_rate_5244_test.go`: negative rejected at strict `CompileConfig`; `0` and a valid positive accepted (stored unchanged); negative on `CompileConfigLenient` downgrades to a warning. Fail-on-revert confirmed by neutering the gate (the reject test then fails).
- Doc: `docs/config-schema.md` sampling `input rate` entry notes the compiler-side guard alongside the existing typed-leaf gate.

Provenance: ps-review-042 (Paladin full-tree), batch A3_go_config_cli_tree-b1, finding F-01.

Closes #5244

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi