### PR TITLE
routing: surface next-table/rib-group clear() RuleDel failures (#5118)

### DIFF
--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -256,7 +256,7 @@ colliding pair; the lenient load / peer-sync path warns and
 its routes/leaks are not programmed — preserving the #1960 no-brick
 intent while guaranteeing no two VRFs ever share a table.
 
-### clear()/Apply error contract (#2273, #3430, #3731)
+### clear()/Apply error contract (#2273, #3430, #3731, #5118)
 
 Each reconciler's `Apply` is clear-then-re-add: `clear()` removes every
 rule in the manager's own priority window, then `Apply` re-installs the
@@ -293,11 +293,24 @@ desired set. `clear()` walks `[AF_INET, AF_INET6]`, calling `RuleList`
   reported success. A clean re-apply is unaffected: `clear()` removes the
   in-window rules before they are re-added, so an idempotent re-apply does
   not hit EEXIST — an already-cleared rule is re-added fresh and `Apply`
-  returns `nil`. `RuleDel` failures on individual next-table / rib-group
-  rules remain debug-logged and do not fail `Apply` — a stale rule that
-  survives one delete is swept by the next pass and re-add uses
-  `NLM_F_CREATE|NLM_F_EXCL`, so a still-desired rule stays correct (the
-  PBR `clear()` additionally aggregates its `RuleDel` failures, #3430 H3).
+  returns `nil`.
+- **Per-rule `RuleDel` failures in `clear()` are aggregated and returned,
+  never swallowed — for ALL THREE reconcilers (#3430 H3 for PBR, #5118 for
+  next-table + rib-group).** A stale route-leak rule that cannot be deleted
+  is an active cross-VRF forwarding instruction that sits BEFORE the main
+  table, so leaving it in place preserves inter-VRF reachability and can
+  override a main-table route. Before #5118 the next-table and rib-group
+  `clear()` only debug-logged a `RuleDel` failure, so `errors.Join(errs...)`
+  returned `nil` and `Apply` reported SUCCESS while the stale leak rule
+  survived until an unrelated future apply — a silent inter-VRF leak past a
+  "successful" commit. All three `clear()` paths now `errors.Join` the
+  `RuleDel` failure so it propagates through `Apply`. The ONE carve-out:
+  an ENOENT / "no such rule" delete (the rule vanished between the
+  `RuleList` dump and the delete, or an idempotent re-clear already removed
+  it) is NOT a failure — deleting an already-absent rule reaches the
+  desired end-state, so `isRuleAlreadyGone` filters it out and it is
+  debug-logged only, keeping an idempotent re-clear from spuriously failing
+  the apply.
 
 ## Tunnel reconcile-in-place (#1884)
 

--- a/pkg/routing/rules.go
+++ b/pkg/routing/rules.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -192,13 +193,43 @@ func (n *nextTableManager) clear() error {
 		for _, r := range rules {
 			if r.Priority >= nextTableRulePriority && r.Priority < nextTableRulePriority+100 {
 				if err := n.ops.RuleDel(&r); err != nil {
-					slog.Debug("failed to delete stale next-table rule",
+					if isRuleAlreadyGone(err) {
+						// The rule is already absent (ENOENT / no such
+						// rule) — a delete of a rule that is not there IS
+						// the desired end-state, not a failure. Log for
+						// diagnostics but do NOT aggregate so an idempotent
+						// re-clear does not spuriously fail the apply.
+						slog.Debug("stale next-table rule already absent",
+							"priority", r.Priority, "err", err)
+						continue
+					}
+					// #5118: a real RuleDel failure leaves a STALE next-table
+					// route-leak rule in the kernel. That rule is an active
+					// cross-VRF forwarding instruction sitting BEFORE the main
+					// table, so a silent success here would preserve an
+					// inter-VRF leak after a "successful" commit. Aggregate the
+					// error (mirroring pbrManager.clear) so Apply — and the
+					// daemon apply loop — observe the divergence instead of nil.
+					slog.Warn("failed to delete stale next-table rule",
 						"priority", r.Priority, "err", err)
+					errs = append(errs, fmt.Errorf(
+						"delete stale next-table rule prio %d: %w", r.Priority, err))
 				}
 			}
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// isRuleAlreadyGone reports whether a RuleDel error means the rule was
+// already absent (ENOENT / "no such rule"). The next-table and rib-group
+// clear() passes list-then-delete, so the kernel returning ENOENT means the
+// rule vanished between the dump and the delete (e.g. a concurrent flush or
+// an idempotent re-clear). Deleting an already-gone rule reaches the desired
+// end-state, so this MUST NOT be aggregated as an apply failure; only a rule
+// that exists but cannot be removed is a genuine stale-rule failure (#5118).
+func isRuleAlreadyGone(err error) bool {
+	return errors.Is(err, unix.ENOENT) || os.IsNotExist(err)
 }
 
 // ribGroupManager reconciles rib-group route-leak ip rules. Stateless
@@ -440,8 +471,23 @@ func (rg *ribGroupManager) clear() error {
 			inLegacy := r.Priority >= 200 && r.Priority < 300
 			if inCurrent || inOldBlanket || inLegacy {
 				if err := rg.ops.RuleDel(&r); err != nil {
-					slog.Debug("failed to delete stale rib-group rule",
+					if isRuleAlreadyGone(err) {
+						// Already absent — the desired end-state, not a
+						// failure. Log only; do not fail an idempotent
+						// re-clear (see isRuleAlreadyGone / #5118).
+						slog.Debug("stale rib-group rule already absent",
+							"priority", r.Priority, "err", err)
+						continue
+					}
+					// #5118: a real RuleDel failure leaves a STALE rib-group
+					// route-leak rule (a per-prefix connected-route leak that
+					// precedes the main table) in the kernel. Aggregate it so
+					// Apply surfaces the inter-VRF leak instead of reporting a
+					// silent success, mirroring pbrManager.clear.
+					slog.Warn("failed to delete stale rib-group rule",
 						"priority", r.Priority, "err", err)
+					errs = append(errs, fmt.Errorf(
+						"delete stale rib-group rule prio %d: %w", r.Priority, err))
 				}
 			}
 		}

--- a/pkg/routing/rules_test.go
+++ b/pkg/routing/rules_test.go
@@ -839,6 +839,98 @@ func TestPBRApplyClearDelFailureSurfaced(t *testing.T) {
 	}
 }
 
+// TestNextTableRibGroupClearDelFailureSurfaced is the #5118 fail-on-revert
+// guard. Both nextTableManager.clear and ribGroupManager.clear used to only
+// debug-log a RuleDel failure, so errors.Join returned nil and Apply reported
+// SUCCESS while a stale route-leak rule remained in the kernel. That rule is
+// an active cross-VRF forwarding instruction that PRECEDES the main table, so
+// the swallowed delete leaves a silent inter-VRF route leak that survives a
+// "successful" commit. When RuleDel returns a REAL failure (the rule EXISTS
+// but cannot be removed, e.g. EBUSY), Apply MUST return non-nil.
+//
+// Reverting either clear() to the pre-#5118 debug-log-only form makes Apply
+// return nil despite the un-deletable rule, so this test fails.
+func TestNextTableRibGroupClearDelFailureSurfaced(t *testing.T) {
+	cases := []struct {
+		name string
+		prio int
+		run  func(ops *fakeRuleOps) error
+	}{
+		{
+			name: "next-table",
+			prio: nextTableRulePriority + 3,
+			run: func(ops *fakeRuleOps) error {
+				// nil routes → no re-adds; the only activity is clear().
+				return (&nextTableManager{ops: ops}).Apply(nil, nil)
+			},
+		},
+		{
+			name: "rib-group",
+			prio: ribGroupLeakRulePriority + 3,
+			run: func(ops *fakeRuleOps) error {
+				// Empty rib-groups → early return after clear(); no re-adds.
+				return (&ribGroupManager{ops: ops}).Apply(nil, nil, nil)
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ops := newFakeRuleOps()
+			// A stale rule inside the managed window clear() scans.
+			seedRule(ops, unix.AF_INET, c.prio, 100)
+			// RuleDel returns a REAL failure: the rule exists but cannot be
+			// removed, so it lingers as an active route-leak instruction.
+			ops.delErr = errors.New("netlink EBUSY")
+			if err := c.run(ops); err == nil {
+				t.Fatalf("%s: Apply must return non-nil when a stale route-leak "+
+					"rule cannot be cleared (#5118) — got nil", c.name)
+			}
+		})
+	}
+}
+
+// TestNextTableRibGroupClearDelNotFoundIdempotent verifies the #5118 ENOENT
+// carve-out: a RuleDel that fails because the rule is ALREADY GONE (ENOENT /
+// no such rule — it vanished between the RuleList dump and the delete, or an
+// idempotent re-clear removed it) is NOT a failure. Deleting an already-absent
+// rule reaches the desired end-state, so Apply MUST return nil rather than
+// spuriously failing the apply on a benign no-op delete.
+func TestNextTableRibGroupClearDelNotFoundIdempotent(t *testing.T) {
+	cases := []struct {
+		name string
+		prio int
+		run  func(ops *fakeRuleOps) error
+	}{
+		{
+			name: "next-table",
+			prio: nextTableRulePriority + 4,
+			run: func(ops *fakeRuleOps) error {
+				return (&nextTableManager{ops: ops}).Apply(nil, nil)
+			},
+		},
+		{
+			name: "rib-group",
+			prio: ribGroupLeakRulePriority + 4,
+			run: func(ops *fakeRuleOps) error {
+				return (&ribGroupManager{ops: ops}).Apply(nil, nil, nil)
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ops := newFakeRuleOps()
+			seedRule(ops, unix.AF_INET, c.prio, 100)
+			// RuleDel reports the rule is already absent — the delete's goal
+			// (rule gone) is met, so this must NOT surface as an apply error.
+			ops.delErr = unix.ENOENT
+			if err := c.run(ops); err != nil {
+				t.Fatalf("%s: Apply must return nil when a stale rule is already "+
+					"absent (ENOENT) — got %v", c.name, err)
+			}
+		})
+	}
+}
+
 // seedRule inserts a rule at the given family/priority/table directly into
 // the fake's backing store (bypassing RuleAdd accounting) so a clear() can
 // be exercised against pre-existing kernel rules.


### PR DESCRIPTION
## Problem

Both `nextTableManager.clear` and `ribGroupManager.clear` in `pkg/routing/rules.go` only **debug-logged** a per-rule `RuleDel` failure and never appended it to the aggregated error set. `errors.Join(errs...)` therefore returned `nil` and `Apply` reported **SUCCESS** even when a stale route-leak rule could not be removed.

A next-table / rib-group route-leak `ip rule` is an active cross-VRF forwarding instruction that sits **BEFORE the main table** (priority < 32766). A failed delete leaves inter-VRF reachability in place and can override a main-table route. Because `clear()` runs during the up-front reconcile, the leftover rule survives a "successful" commit until an unrelated future apply happens to clean it — a silent, security-adjacent inter-VRF route leak with no operator signal.

The PBR reconciler already aggregates its `RuleDel` failures (#3430 H3), proving the intended invariant; next-table and rib-group diverged from it.

## Fix

- Both `clear()` paths now `errors.Join` a **real** `RuleDel` failure (mirroring `pbrManager.clear`) so it propagates through `Apply` and the daemon apply loop instead of being swallowed.
- A shared `isRuleAlreadyGone` helper carves out the one benign case: an **ENOENT / "no such rule"** delete means the rule vanished between the `RuleList` dump and the delete (a concurrent flush or idempotent re-clear already removed it). Deleting an already-absent rule reaches the desired end-state, so it is debug-logged only and NOT aggregated — an idempotent re-clear must not spuriously fail the apply.
- Success path and rule-build are unchanged; only the error accounting in `clear()` is fixed.

## Tests

- `TestNextTableRibGroupClearDelFailureSurfaced` — injects a real `RuleDel` failure (EBUSY) against a seeded in-window rule for BOTH managers; asserts `Apply` returns non-nil. Fails if either `clear()` is reverted to the debug-log-only form (verified: next-table subtest FAILS on revert).
- `TestNextTableRibGroupClearDelNotFoundIdempotent` — injects `unix.ENOENT`; asserts `Apply` returns nil (the benign carve-out).

## Docs

`pkg/routing/README.md` "clear()/Apply error contract" updated: `RuleDel` aggregation now covers all three reconcilers, and the ENOENT carve-out is documented.

## Validation

- `go build ./...` -> exit 0
- `go test ./pkg/routing/...` -> exit 0 (ok)
- `gofmt -l` on touched files -> clean

Closes #5118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi