### PR TITLE
dataplane/userspace: self-heal sticky session-mirror failure (#5247)

### DIFF
--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -340,6 +340,26 @@ func (m *Manager) recordSessionMirrorFailureLocked(err error) {
 	}
 }
 
+// recordSessionMirrorSuccessLocked clears the sticky session-mirror failure
+// state after a genuinely successful mirror IPC to the helper (#5247). The
+// flag means "the helper session control socket last failed"; it is set on any
+// mirror failure and gates HA takeover-readiness (takeoverReadyLocked), but was
+// previously cleared ONLY on a helper process restart (see stopLocked). A
+// single transient control-socket failure during bulk session sync therefore
+// latched the standby "not takeover-ready" until the helper respawned. Since
+// the flag tracks socket health — not "every session is mirrored" — one proven
+// mirror is sufficient to declare the socket healthy again, so a later success
+// self-heals the state without a restart. No-op when the helper is not running:
+// syncSession{V4,V6}Locked returns nil without sending in that case, so there
+// was no real mirror to prove health (and stopLocked already cleared the flag).
+func (m *Manager) recordSessionMirrorSuccessLocked() {
+	if m.proc == nil {
+		return
+	}
+	m.sessionMirrorFailed = false
+	m.sessionMirrorErr = ""
+}
+
 func (m *Manager) hasActiveDataRGLocked() bool {
 	for _, group := range m.haGroups {
 		if group.RGID > 0 && group.Active {
@@ -937,6 +957,10 @@ func (m *Manager) SetClusterSyncedSessionV4(key dataplane.SessionKey, val datapl
 		slog.Debug("userspace: session mirror failed", "err", err)
 		return fmt.Errorf("mirror synced v4 session to userspace helper: %w", err)
 	}
+	// A successful mirror proves the helper session socket is healthy again;
+	// clear any sticky failure so the standby regains takeover-readiness
+	// without waiting for a helper restart (#5247).
+	m.recordSessionMirrorSuccessLocked()
 	return nil
 }
 
@@ -1003,6 +1027,10 @@ func (m *Manager) SetClusterSyncedSessionV6(key dataplane.SessionKeyV6, val data
 		slog.Debug("userspace: session mirror failed", "err", err)
 		return fmt.Errorf("mirror synced v6 session to userspace helper: %w", err)
 	}
+	// A successful mirror proves the helper session socket is healthy again;
+	// clear any sticky failure so the standby regains takeover-readiness
+	// without waiting for a helper restart (#5247).
+	m.recordSessionMirrorSuccessLocked()
 	return nil
 }
 

--- a/pkg/dataplane/userspace/manager_sessionsync_test.go
+++ b/pkg/dataplane/userspace/manager_sessionsync_test.go
@@ -3,8 +3,10 @@ package userspace
 import (
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -752,6 +754,86 @@ func TestSetClusterSyncedSessionV6MirrorFailureMarksHelperUnhealthy(t *testing.T
 	}
 	if m.sessionMirrorErr == "" {
 		t.Fatal("sessionMirrorErr is empty")
+	}
+}
+
+// TestSetClusterSyncedSessionV4MirrorSuccessClearsStickyFailure asserts the
+// #5247 self-heal: a transient session-mirror failure latches
+// sessionMirrorFailed (and blocks HA takeover-readiness), but a subsequent
+// SUCCESSFUL mirror through a healthy helper socket clears it without a helper
+// process restart. If the clear-on-success is reverted, the flag stays set,
+// takeoverReadyLocked never becomes ready, and this test fails.
+func TestSetClusterSyncedSessionV4MirrorSuccessClearsStickyFailure(t *testing.T) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("RemoveMemlock: %v", err)
+	}
+	dir := t.TempDir()
+	sessionSock := filepath.Join(dir, "userspace-dp-sessions.sock")
+	ln, err := net.Listen("unix", sessionSock)
+	if err != nil {
+		t.Fatalf("listen session socket: %v", err)
+	}
+	defer ln.Close()
+	// A healthy session helper that acknowledges every mirror request.
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				var req ControlRequest
+				_ = json.NewDecoder(conn).Decode(&req)
+				_ = json.NewEncoder(conn).Encode(ControlResponse{OK: true})
+			}()
+		}
+	}()
+
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: 1}}
+	m.cfg.ControlSocket = filepath.Join(dir, "control.sock")
+	injectSessionMaps(t, m)
+
+	// Every takeover-readiness gate other than the session-mirror flag is
+	// satisfied, so the sticky flag is the sole thing keeping the standby
+	// not-ready.
+	m.lastStatus = ProcessStatus{
+		Enabled:         true,
+		ForwardingArmed: true,
+		Capabilities:    UserspaceCapabilities{ForwardingSupported: true},
+	}
+	m.mode = ModeUserspaceCompat
+	m.xskLivenessProven = true
+
+	// A prior transient control-socket failure latched the sticky flag.
+	m.recordSessionMirrorFailureLocked(errors.New("transient control-socket failure"))
+	if ready, reasons := m.TakeoverReady(); ready {
+		t.Fatalf("TakeoverReady() = true while mirror failed, want false; reasons=%v", reasons)
+	}
+
+	// Drive a genuinely successful forward-session mirror through the live
+	// helper socket — no helper restart.
+	key := dataplane.SessionKey{
+		SrcIP:    [4]byte{10, 0, 61, 102},
+		DstIP:    [4]byte{172, 16, 80, 200},
+		SrcPort:  hostToNetwork16(5201),
+		DstPort:  hostToNetwork16(55340),
+		Protocol: 6,
+	}
+	val := dataplane.SessionValue{IsReverse: 0}
+	if err := m.SetClusterSyncedSessionV4(key, val); err != nil {
+		t.Fatalf("SetClusterSyncedSessionV4: %v", err)
+	}
+
+	if m.sessionMirrorFailed {
+		t.Fatal("sessionMirrorFailed = true after successful mirror, want false (#5247)")
+	}
+	if m.sessionMirrorErr != "" {
+		t.Fatalf("sessionMirrorErr = %q after successful mirror, want empty", m.sessionMirrorErr)
+	}
+	if ready, reasons := m.TakeoverReady(); !ready {
+		t.Fatalf("TakeoverReady() = false after successful mirror, want true; reasons=%v", reasons)
 	}
 }
 


### PR DESCRIPTION
## Problem

`Manager.sessionMirrorFailed` (`pkg/dataplane/userspace/manager_ha.go`) is
set on ANY session-mirror failure and gates HA takeover-readiness
(`takeoverReadyLocked`), but it was cleared ONLY on a helper **process
restart** (`stopLocked`, `process.go`) — never on a subsequent successful
mirror. A single **transient** control-socket failure during bulk session
sync therefore latched the standby "not takeover-ready" until the helper
respawned, blackholing the affected RG on failover.

CLAUDE.md explicitly warns the shared helper control socket is contended
during bulk sync (status poll + HA sync + session installs + snapshot/
forwarding sync), so a transient `requestSessionSync` failure is expected,
not exceptional. This is the sticky residual of the closed #346 (failures
are now recorded but were never un-recorded).

## Fix

The flag tracks socket **health** ("the helper session socket last
failed"), not "every session is mirrored". One subsequent successful mirror
proves the socket is healthy again, so it is the right signal to clear.

- Add `recordSessionMirrorSuccessLocked` (mirroring
  `recordSessionMirrorFailureLocked`) that clears `sessionMirrorFailed` and
  `sessionMirrorErr` under `m.mu`.
- Call it on the **success branch** of `SetClusterSyncedSessionV4`/`V6` —
  the only two sites that record the failure.
- A `m.proc == nil` no-op guard means a **skipped** mirror does not falsely
  clear the flag (`syncSession{V4,V6}Locked` returns nil without sending in
  that case).
- The failure-set path and the takeover-ready gate are **unchanged** — this
  only ADDS clear-on-success.

## HA note for the reviewer

This touches HA takeover-readiness (`manager_ha.go`). `make test-failover`
should confirm that a **transient** mirror failure no longer permanently
blocks takeover-readiness: after a transient session-sync error under
bulk-sync contention, the standby regains `takeoverReady=true` on the next
successful mirror (no helper restart), and a failover still cuts over
without blackholing the RG.

## Docs

No module doc change: the `sessionMirrorFailed` → takeover-readiness gate
is a code-level invariant, not documented in a module doc
(`docs/xdp-io-uring-userspace-dataplane.md` is a capability list, not a
readiness-gate contract). The new self-heal behavior is documented inline
on `recordSessionMirrorSuccessLocked`.

## Validation

- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` → exit 0
- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/dataplane/userspace/...` → exit 0
- New `TestSetClusterSyncedSessionV4MirrorSuccessClearsStickyFailure`:
  latches the flag via a recorded failure (asserts `takeoverReadyLocked`
  NOT ready), drives one successful mirror through a live helper socket,
  and asserts the flag clears AND `takeoverReadyLocked` becomes ready with
  no helper restart. Confirmed **fail-on-revert** — removing the clear
  fails the test with "sessionMirrorFailed = true after successful mirror".
  The test creates real BPF maps (needs memlock), so it runs under sudo and
  skips unprivileged.

Closes #5247

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi