### PR TITLE
daemon: reconcile mgmt-VRF DHCP routes, delete withdrawn (#5108)

### DIFF
--- a/pkg/daemon/daemon_flow.go
+++ b/pkg/daemon/daemon_flow.go
@@ -3,6 +3,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -20,6 +21,7 @@ import (
 	"github.com/psaab/xpf/pkg/fsatomic"
 	"github.com/psaab/xpf/pkg/logging"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 // mgmtVRFIfaceSet returns the currently-published management-VRF interface
@@ -78,15 +80,40 @@ func (d *Daemon) collectDHCPRoutes() []frr.DHCPRoute {
 	return routes
 }
 
-// applyMgmtVRFRoutes programs default routes in the management VRF table
-// for DHCP leases on management interfaces (fxp*, fab*). These routes are
-// managed via netlink (not FRR) because FRR doesn't own the management VRF.
+// mgmtVRFTableID is the kernel routing table backing the management VRF.
+// Its SSOT is the ReconcileVRFs call in daemon_apply.go (mgmtTableID); it is
+// duplicated here only for the netlink route reconcile below.
+const mgmtVRFTableID = 999
+
+// applyMgmtVRFRoutes reconciles the DHCP-learned routes in the management VRF
+// table (999) against the current management-lease state. Leases on management
+// interfaces (fxp*/fab*/em*) are not owned by FRR — FRR does not manage the
+// management VRF — so their default gateway (option 3, or the option-121
+// 0.0.0.0/0 entry) and RFC 3442 classless static routes (option 121 / legacy
+// 249) are programmed directly via netlink.
+//
+// This is a full reconcile, not an append-only apply (#5108). Every route xpf
+// installs here is stamped RTPROT_DHCP so it can be distinguished from
+// operator/kernel routes sharing the table. Each apply:
+//
+//  1. Computes the DESIRED route set from the current management leases and
+//     RouteReplaces each one (idempotent add-or-update), recording its
+//     destination key.
+//  2. Lists the xpf-owned (RTPROT_DHCP) routes already in table 999 and
+//     RouteDels any whose destination is no longer desired.
+//
+// Step 2 runs UNCONDITIONALLY — including when the desired set is empty (the
+// management lease was disabled, or an option-121 route was withdrawn).
+// Early-returning on an empty desired set was the #5108 bug: a withdrawn
+// classless route or a disabled lease left a stale route in table 999 that
+// could blackhole or misdirect management/HA traffic to a prior DHCP router
+// until manual cleanup or reboot. The delete is scoped to RTPROT_DHCP routes
+// so operator-installed routes in the VRF are never touched; ESRCH (already
+// gone) is tolerated, any other RouteDel error is surfaced.
 func (d *Daemon) applyMgmtVRFRoutes() {
-	mgmtSet := d.mgmtVRFIfaceSet()
-	if d.dhcp == nil || len(mgmtSet) == 0 {
+	if d.dhcp == nil {
 		return
 	}
-	const mgmtTableID = 999
 	nlh, err := netlink.NewHandle()
 	if err != nil {
 		slog.Warn("mgmt VRF routes: failed to get netlink handle", "err", err)
@@ -94,6 +121,12 @@ func (d *Daemon) applyMgmtVRFRoutes() {
 	}
 	defer nlh.Close()
 
+	// 1. Program the desired routes and record their destination keys so the
+	//    reconcile pass below knows which xpf-owned routes to keep. When no
+	//    management interface has a route-bearing lease the desired set stays
+	//    empty and the reconcile deletes every xpf-owned route in the table.
+	mgmtSet := d.mgmtVRFIfaceSet()
+	desired := make(map[string]struct{})
 	for _, lease := range d.dhcp.Leases() {
 		if !mgmtSet[lease.Interface] {
 			continue
@@ -103,6 +136,10 @@ func (d *Daemon) applyMgmtVRFRoutes() {
 		// 121 / legacy 249). Program each into the management VRF table.
 		if !lease.Gateway.IsValid() && len(lease.ClasslessRoutes) == 0 {
 			continue
+		}
+		nlFamily := netlink.FAMILY_V4
+		if lease.Family == dhcp.AFInet6 {
+			nlFamily = netlink.FAMILY_V6
 		}
 		link, err := nlh.LinkByName(lease.Interface)
 		if err != nil {
@@ -124,14 +161,16 @@ func (d *Daemon) applyMgmtVRFRoutes() {
 				LinkIndex: linkIndex,
 				Dst:       dst,
 				Gw:        net.IP(gwSlice),
-				Table:     mgmtTableID,
+				Table:     mgmtVRFTableID,
+				Protocol:  unix.RTPROT_DHCP,
 			}
+			desired[mgmtRouteDstKey(dst, nlFamily)] = struct{}{}
 			if err := nlh.RouteReplace(route); err != nil {
 				slog.Warn("mgmt VRF route: failed to add default route",
-					"interface", lease.Interface, "gw", lease.Gateway, "table", mgmtTableID, "err", err)
+					"interface", lease.Interface, "gw", lease.Gateway, "table", mgmtVRFTableID, "err", err)
 			} else {
 				slog.Info("mgmt VRF default route installed",
-					"interface", lease.Interface, "gw", lease.Gateway, "table", mgmtTableID)
+					"interface", lease.Interface, "gw", lease.Gateway, "table", mgmtVRFTableID)
 			}
 		}
 
@@ -145,19 +184,101 @@ func (d *Daemon) applyMgmtVRFRoutes() {
 				LinkIndex: linkIndex,
 				Dst:       dst,
 				Gw:        net.IP(cr.Gateway.AsSlice()),
-				Table:     mgmtTableID,
+				Table:     mgmtVRFTableID,
+				Protocol:  unix.RTPROT_DHCP,
 			}
+			desired[mgmtRouteDstKey(dst, nlFamily)] = struct{}{}
 			if err := nlh.RouteReplace(route); err != nil {
 				slog.Warn("mgmt VRF route: failed to add classless route",
 					"interface", lease.Interface, "dst", cr.Destination, "gw", cr.Gateway,
-					"table", mgmtTableID, "err", err)
+					"table", mgmtVRFTableID, "err", err)
 			} else {
 				slog.Info("mgmt VRF classless route installed",
 					"interface", lease.Interface, "dst", cr.Destination, "gw", cr.Gateway,
-					"table", mgmtTableID)
+					"table", mgmtVRFTableID)
 			}
 		}
 	}
+
+	// 2. Delete xpf-owned routes in table 999 that are no longer desired.
+	//    Runs even when desired is empty (disabled lease / withdrawn route).
+	d.reconcileMgmtVRFRouteDeletes(nlh, mgmtVRFTableID, desired)
+}
+
+// mgmtRouteReconciler is the minimal netlink surface reconcileMgmtVRFRouteDeletes
+// needs. *netlink.Handle satisfies it in production; tests inject a fake.
+type mgmtRouteReconciler interface {
+	RouteListFiltered(family int, filter *netlink.Route, filterMask uint64) ([]netlink.Route, error)
+	RouteDel(route *netlink.Route) error
+}
+
+// reconcileMgmtVRFRouteDeletes removes xpf-owned (RTPROT_DHCP) routes from the
+// management VRF table that are not in the desired destination-key set. It lists
+// both address families (RouteListFiltered is per-family) scoped to
+// table+protocol so operator/kernel routes are never considered. ESRCH (the
+// route is already gone) is tolerated; any other delete error is surfaced.
+func (d *Daemon) reconcileMgmtVRFRouteDeletes(nlh mgmtRouteReconciler, tableID int, desired map[string]struct{}) {
+	for _, family := range []int{netlink.FAMILY_V4, netlink.FAMILY_V6} {
+		current, err := nlh.RouteListFiltered(family, &netlink.Route{
+			Table:    tableID,
+			Protocol: unix.RTPROT_DHCP,
+		}, netlink.RT_FILTER_TABLE|netlink.RT_FILTER_PROTOCOL)
+		if err != nil {
+			slog.Warn("mgmt VRF route: failed to list routes for reconcile",
+				"family", family, "table", tableID, "err", err)
+			continue
+		}
+		for _, rt := range mgmtVRFRoutesToDelete(current, desired, family) {
+			rt := rt
+			if err := nlh.RouteDel(&rt); err != nil && !errors.Is(err, unix.ESRCH) {
+				slog.Warn("mgmt VRF route: failed to delete withdrawn route",
+					"dst", rt.Dst, "table", tableID, "err", err)
+			} else {
+				slog.Info("mgmt VRF route withdrawn",
+					"dst", rt.Dst, "table", tableID)
+			}
+		}
+	}
+}
+
+// mgmtVRFRoutesToDelete returns the subset of current routes (already scoped to
+// xpf-owned RTPROT_DHCP routes in the management VRF table) whose destination is
+// not present in the desired set. Pure — the reconcile diff is unit-tested here
+// so a regression to the pre-#5108 no-delete behavior fails the test.
+func mgmtVRFRoutesToDelete(current []netlink.Route, desired map[string]struct{}, family int) []netlink.Route {
+	var del []netlink.Route
+	for i := range current {
+		if _, ok := desired[mgmtRouteDstKey(current[i].Dst, family)]; !ok {
+			del = append(del, current[i])
+		}
+	}
+	return del
+}
+
+// mgmtRouteDstKey canonicalizes a route destination into a comparable key so a
+// desired route (built from lease data) and a listed kernel route with the same
+// destination match. A nil or all-zeros /0 destination is the family default
+// route (netlink returns the default route with a nil Dst); everything else keys
+// on the masked network address and prefix length.
+func mgmtRouteDstKey(dst *net.IPNet, family int) string {
+	if dst == nil {
+		if family == netlink.FAMILY_V6 {
+			return "::/0"
+		}
+		return "0.0.0.0/0"
+	}
+	ones, bits := dst.Mask.Size()
+	if ones == 0 && bits != 0 {
+		if bits == 128 || family == netlink.FAMILY_V6 {
+			return "::/0"
+		}
+		return "0.0.0.0/0"
+	}
+	ip := dst.IP
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	return fmt.Sprintf("%s/%d", ip.Mask(dst.Mask).String(), ones)
 }
 
 // logFinalStats reads and logs global counter summary before shutdown.

--- a/pkg/daemon/mgmtvrf_route_reconcile_5108_test.go
+++ b/pkg/daemon/mgmtvrf_route_reconcile_5108_test.go
@@ -1,0 +1,226 @@
+package daemon
+
+import (
+	"net"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// fakeMgmtRouteHandle is an in-memory stand-in for the netlink surface
+// reconcileMgmtVRFRouteDeletes uses. It holds the xpf-owned (RTPROT_DHCP)
+// routes currently in the management VRF table, split by family, and records
+// deletes so a test can assert exactly which routes were withdrawn.
+type fakeMgmtRouteHandle struct {
+	v4      []netlink.Route
+	v6      []netlink.Route
+	listErr error
+	delErr  error
+	deleted []string // dst keys passed to RouteDel, in order
+}
+
+func (f *fakeMgmtRouteHandle) RouteListFiltered(family int, filter *netlink.Route, mask uint64) ([]netlink.Route, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	// The reconcile MUST scope its list to table+protocol; if it ever stops
+	// filtering on RTPROT_DHCP this fake returns nothing, and the empty-desired
+	// test (which expects deletes) fails — guarding the ownership scope.
+	if filter == nil || filter.Protocol != unix.RTPROT_DHCP ||
+		mask&netlink.RT_FILTER_PROTOCOL == 0 || mask&netlink.RT_FILTER_TABLE == 0 {
+		return nil, nil
+	}
+	switch family {
+	case netlink.FAMILY_V4:
+		return append([]netlink.Route(nil), f.v4...), nil
+	case netlink.FAMILY_V6:
+		return append([]netlink.Route(nil), f.v6...), nil
+	}
+	return nil, nil
+}
+
+func (f *fakeMgmtRouteHandle) RouteDel(route *netlink.Route) error {
+	if f.delErr != nil {
+		return f.delErr
+	}
+	// Dispatch by Family: a default route has a nil Dst, so the family is the
+	// only thing distinguishing the v4 default (0.0.0.0/0) from the v6 default
+	// (::/0). Real netlink populates Route.Family on listed routes; the seeds
+	// below set it, and the reconcile passes the listed route through unchanged.
+	fam := route.Family
+	if fam == netlink.FAMILY_V6 {
+		f.v6 = removeRouteByDst(f.v6, route.Dst, netlink.FAMILY_V6)
+	} else {
+		fam = netlink.FAMILY_V4
+		f.v4 = removeRouteByDst(f.v4, route.Dst, netlink.FAMILY_V4)
+	}
+	f.deleted = append(f.deleted, mgmtRouteDstKey(route.Dst, fam))
+	return nil
+}
+
+func removeRouteByDst(routes []netlink.Route, dst *net.IPNet, family int) []netlink.Route {
+	key := mgmtRouteDstKey(dst, family)
+	out := make([]netlink.Route, 0, len(routes))
+	for _, r := range routes {
+		if mgmtRouteDstKey(r.Dst, family) == key {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+func mustCIDRRoute(t *testing.T, cidr string) netlink.Route {
+	t.Helper()
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		t.Fatalf("ParseCIDR(%q): %v", cidr, err)
+	}
+	return netlink.Route{Dst: ipnet, Table: mgmtVRFTableID, Protocol: unix.RTPROT_DHCP, Family: netlink.FAMILY_V4}
+}
+
+// defaultV4Route mirrors how netlink returns a default route: a nil Dst.
+func defaultV4Route() netlink.Route {
+	return netlink.Route{Dst: nil, Table: mgmtVRFTableID, Protocol: unix.RTPROT_DHCP, Family: netlink.FAMILY_V4}
+}
+
+// desiredKey builds a desired-set key the same way applyMgmtVRFRoutes does.
+func desiredKeyV4Default() string {
+	return mgmtRouteDstKey(&net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)}, netlink.FAMILY_V4)
+}
+
+func desiredKeyCIDR(t *testing.T, cidr string) string {
+	t.Helper()
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		t.Fatalf("ParseCIDR(%q): %v", cidr, err)
+	}
+	return mgmtRouteDstKey(ipnet, netlink.FAMILY_V4)
+}
+
+// TestReconcileMgmtVRFRoutes_WithdrawnClasslessDeleted proves that a withdrawn
+// option-121 classless route (present in table 999 but absent from the desired
+// set) is deleted, while the still-desired default and classless routes are
+// retained. Fails (stale route remains) if the delete pass is reverted (#5108).
+func TestReconcileMgmtVRFRoutes_WithdrawnClasslessDeleted(t *testing.T) {
+	fake := &fakeMgmtRouteHandle{
+		v4: []netlink.Route{
+			defaultV4Route(),
+			mustCIDRRoute(t, "10.20.0.0/16"),
+			mustCIDRRoute(t, "192.0.2.0/24"), // withdrawn
+		},
+	}
+	desired := map[string]struct{}{
+		desiredKeyV4Default():             {},
+		desiredKeyCIDR(t, "10.20.0.0/16"): {},
+	}
+
+	var d Daemon
+	d.reconcileMgmtVRFRouteDeletes(fake, mgmtVRFTableID, desired)
+
+	if len(fake.v4) != 2 {
+		t.Fatalf("after reconcile want 2 routes remaining, got %d: %v", len(fake.v4), fake.v4)
+	}
+	// The withdrawn route (and only it) must be gone.
+	for _, r := range fake.v4 {
+		if mgmtRouteDstKey(r.Dst, netlink.FAMILY_V4) == desiredKeyCIDR(t, "192.0.2.0/24") {
+			t.Fatalf("withdrawn route 192.0.2.0/24 still present after reconcile")
+		}
+	}
+	if len(fake.deleted) != 1 || fake.deleted[0] != desiredKeyCIDR(t, "192.0.2.0/24") {
+		t.Fatalf("want exactly one delete of 192.0.2.0/24, got %v", fake.deleted)
+	}
+}
+
+// TestReconcileMgmtVRFRoutes_EmptyDesiredDeletesAll proves the disabled-lease
+// case: when the desired set is EMPTY (management lease disabled or interface
+// gone) EVERY xpf-owned route in table 999 is deleted. This is the core #5108
+// fix — the pre-fix early-return on an empty desired set skipped cleanup.
+func TestReconcileMgmtVRFRoutes_EmptyDesiredDeletesAll(t *testing.T) {
+	fake := &fakeMgmtRouteHandle{
+		v4: []netlink.Route{
+			defaultV4Route(),
+			mustCIDRRoute(t, "10.20.0.0/16"),
+		},
+		v6: []netlink.Route{
+			{Dst: nil, Table: mgmtVRFTableID, Protocol: unix.RTPROT_DHCP, Family: netlink.FAMILY_V6}, // ::/0 default
+		},
+	}
+
+	var d Daemon
+	d.reconcileMgmtVRFRouteDeletes(fake, mgmtVRFTableID, map[string]struct{}{})
+
+	if len(fake.v4) != 0 || len(fake.v6) != 0 {
+		t.Fatalf("empty desired set must delete all xpf routes; got v4=%v v6=%v", fake.v4, fake.v6)
+	}
+	if len(fake.deleted) != 3 {
+		t.Fatalf("want 3 deletes (2×v4 + 1×v6), got %d: %v", len(fake.deleted), fake.deleted)
+	}
+}
+
+// TestReconcileMgmtVRFRoutes_ESRCHTolerated confirms a delete of an
+// already-absent route (ESRCH) is not treated as fatal — the reconcile still
+// processes the remaining routes.
+func TestReconcileMgmtVRFRoutes_ESRCHTolerated(t *testing.T) {
+	fake := &fakeMgmtRouteHandle{
+		v4:     []netlink.Route{mustCIDRRoute(t, "192.0.2.0/24")},
+		delErr: unix.ESRCH,
+	}
+	var d Daemon
+	// Must not panic and must not surface ESRCH as a hard failure.
+	d.reconcileMgmtVRFRouteDeletes(fake, mgmtVRFTableID, map[string]struct{}{})
+}
+
+// TestMgmtRouteDstKey covers the destination canonicalization: a nil Dst and an
+// explicit all-zeros /0 collapse to the same family default key, and both a
+// 4-byte and a 16-byte-encoded IPv4 prefix key identically.
+func TestMgmtRouteDstKey(t *testing.T) {
+	if got := mgmtRouteDstKey(nil, netlink.FAMILY_V4); got != "0.0.0.0/0" {
+		t.Errorf("nil v4 Dst key = %q, want 0.0.0.0/0", got)
+	}
+	if got := mgmtRouteDstKey(nil, netlink.FAMILY_V6); got != "::/0" {
+		t.Errorf("nil v6 Dst key = %q, want ::/0", got)
+	}
+	zeroV4 := &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)}
+	if got := mgmtRouteDstKey(zeroV4, netlink.FAMILY_V4); got != "0.0.0.0/0" {
+		t.Errorf("explicit 0.0.0.0/0 key = %q, want 0.0.0.0/0", got)
+	}
+	zeroV6 := &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)}
+	if got := mgmtRouteDstKey(zeroV6, netlink.FAMILY_V6); got != "::/0" {
+		t.Errorf("explicit ::/0 key = %q, want ::/0", got)
+	}
+	// A 16-byte-encoded IPv4 prefix and its 4-byte parse must key identically.
+	_, parsed, _ := net.ParseCIDR("10.20.0.0/16")
+	wide := &net.IPNet{IP: net.ParseIP("10.20.0.0"), Mask: net.CIDRMask(16, 32)}
+	if a, b := mgmtRouteDstKey(parsed, netlink.FAMILY_V4), mgmtRouteDstKey(wide, netlink.FAMILY_V4); a != b {
+		t.Errorf("4-byte vs 16-byte IPv4 keys diverge: %q != %q", a, b)
+	}
+}
+
+// TestMgmtVRFRoutesToDelete exercises the pure diff directly, independent of any
+// netlink handle.
+func TestMgmtVRFRoutesToDelete(t *testing.T) {
+	current := []netlink.Route{
+		defaultV4Route(),
+		mustCIDRRoute(t, "10.20.0.0/16"),
+		mustCIDRRoute(t, "192.0.2.0/24"),
+	}
+	desired := map[string]struct{}{
+		desiredKeyV4Default():             {},
+		desiredKeyCIDR(t, "10.20.0.0/16"): {},
+	}
+	del := mgmtVRFRoutesToDelete(current, desired, netlink.FAMILY_V4)
+	if len(del) != 1 {
+		t.Fatalf("want 1 route to delete, got %d: %v", len(del), del)
+	}
+	if got := mgmtRouteDstKey(del[0].Dst, netlink.FAMILY_V4); got != desiredKeyCIDR(t, "192.0.2.0/24") {
+		t.Fatalf("want 192.0.2.0/24 to delete, got %q", got)
+	}
+
+	// Empty desired => everything deleted.
+	all := mgmtVRFRoutesToDelete(current, map[string]struct{}{}, netlink.FAMILY_V4)
+	if len(all) != len(current) {
+		t.Fatalf("empty desired must delete all %d, got %d", len(current), len(all))
+	}
+}

--- a/pkg/dhcp/README.md
+++ b/pkg/dhcp/README.md
@@ -221,7 +221,17 @@ External only: `github.com/insomniacslk/dhcp`, `github.com/vishvananda/netlink`.
   more-specific classless routes — and `applyMgmtVRFRoutes` installs them
   into the management VRF table (999) via netlink. `leaseContentChanged`
   diffs `ClasslessRoutes`, so the routes are withdrawn/re-installed in
-  lock-step with the lease on renew/expiry, like the default route.
+  lock-step with the lease on renew/expiry, like the default route. For
+  the management VRF the withdrawal is enforced by a full RECONCILE, not
+  an append-only apply (#5108): every route xpf installs in table 999 is
+  stamped `RTPROT_DHCP`, and each `applyMgmtVRFRoutes` run lists the
+  xpf-owned routes already in the table and `RouteDel`s any whose
+  destination is no longer in the current desired set — including the
+  empty-desired case (management lease disabled, or option-121 route
+  withdrawn), which the pre-#5108 early-return skipped, leaving a stale
+  route that could blackhole management traffic to a prior DHCP router.
+  The delete is scoped to `RTPROT_DHCP` so operator routes in the VRF are
+  never touched.
 - **Lease records are NOT expired by the wall clock.** During a
   *timeout-driven* failed re-acquisition (T2 rebind timed out, fresh
   DORA in progress) the lease record and the kernel address


### PR DESCRIPTION
## Problem

`applyMgmtVRFRoutes` (pkg/daemon/daemon_flow.go) programmed DHCP-learned
routes into the management VRF table (999) with `RouteReplace` only, and
returned early when no management lease/interface was desired. There was
no `RouteList`/`RouteDel` and no applied-set inventory, so a **withdrawn
option-121 classless route** or a **disabled DHCP lease** was never
removed from table 999. The stale route could blackhole or misdirect
management/HA traffic to a prior DHCP router until manual cleanup or a
reboot. FRR does not own the management VRF, so these routes cannot rely
on FRR managed-section regeneration — the netlink path must reconcile the
table itself.

## Fix

Make `applyMgmtVRFRoutes` a full reconcile:

- Stamp every route xpf installs in table 999 with `RTPROT_DHCP` so it is
  distinguishable from operator/kernel routes in the same table.
- Compute the DESIRED destination-key set from current management leases
  and `RouteReplace` each (unchanged add/update behavior).
- List the xpf-owned (`RTPROT_DHCP`) routes in table 999 for both address
  families and `RouteDel` any whose destination is no longer desired.

The delete pass runs **unconditionally**. The early return now guards
only `d.dhcp == nil`; the `len(mgmtSet)==0` short-circuit — which skipped
cleanup when the desired set was empty — is removed. An empty desired set
(disabled lease / gone interface) therefore deletes every xpf-owned route
in the table. The delete is scoped to `RTPROT_DHCP` so operator routes
are never touched; `ESRCH` (already gone) is tolerated, any other
`RouteDel` error is surfaced.

The desired-vs-current diff and destination canonicalization are factored
into pure helpers (`mgmtVRFRoutesToDelete`, `mgmtRouteDstKey`); the delete
pass takes a small `mgmtRouteReconciler` interface driven by an in-memory
fake in tests.

## Tests

New `pkg/daemon/mgmtvrf_route_reconcile_5108_test.go` asserts: a withdrawn
option-121 route is deleted while still-desired routes are retained; an
empty desired set deletes all xpf-owned routes (v4 + v6 default); `ESRCH`
is tolerated; and nil-Dst / all-zeros `/0` destinations canonicalize to
the family default key. The reconcile tests fail if the delete pass is
reverted (verified by neutering the delete loop).

## Validation

- `go build ./...` — exit 0
- `go test ./pkg/daemon/...` — exit 0
- `go vet ./pkg/daemon/` — exit 0
- fail-on-revert confirmed

Documented the management-VRF reconcile contract in `pkg/dhcp/README.md`.

Closes #5108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi