### PR TITLE
frr: arm retry debt on a hard reload failure from a healthy state

### DIFF
--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1223,11 +1223,19 @@ func (d *Daemon) applyRoutingRules(cfg *config.Config, commitOverlay []config.Ro
 	if d.frr != nil {
 		// The full apply path deliberately warns-and-continues on an FRR
 		// reload error (a transient FRR hiccup must not fail an
-		// otherwise-valid operator commit; a boot-time re-apply
-		// reconverges FRR). The returned error is only consumed by the
-		// ip-monitoring routes-only actuator, which must not publish a
-		// divergent snapshot on a hard failure (#3757).
-		_ = d.applyFRRConfig(d.assembleFRRConfig(cfg, commitOverlay))
+		// otherwise-valid operator commit; the in-manager degraded-retry
+		// loop reconverges FRR without waiting for a restart).
+		// applyFRRConfig returns nil on a DEGRADED reload (#1880, the new
+		// routes are already live); a non-nil return is a HARD reload
+		// failure where NOTHING was applied. We do not fail the commit on
+		// it, but we no longer discard it silently (#5109): the frr
+		// manager has marked the generation degraded and armed its retry
+		// debt (surfaced via the ReloadDegraded() health gauge), so log it
+		// and continue rather than reporting an unqualified success.
+		if err := d.applyFRRConfig(d.assembleFRRConfig(cfg, commitOverlay)); err != nil {
+			slog.Warn("FRR full apply hit a hard reload failure; commit continues, frr manager armed degraded retry debt",
+				"err", err)
+		}
 	}
 
 	// 3b. Apply next-table policy routing rules (ip rule)

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -653,3 +653,18 @@ also carries operator content:
   shutdown) cancels in-flight process groups and reaps the retry
   goroutine; `DisableDegradedRetry()` is the one-shot (`xpfd cleanup`)
   configuration.
+- Hard failure (#5109): when BOTH frr-reload.py AND the additive
+  `vtysh -f` fallback fail, `reloadLocked` returns the underlying error
+  (NOT the degraded sentinel) — nothing was applied, so live FRR keeps
+  its previous config while `frr.conf` on disk already carries the new
+  desired managed section. `noteReloadOutcomeLocked` treats this exactly
+  like a degraded reload for RECOVERY: it sets the gauge and arms the
+  same single-flight retry loop, which re-runs the primary reload against
+  the on-disk SSOT until a full diff converges — so a hard failure
+  self-heals without a restart. The error still propagates to the caller
+  (the daemon's full-apply path logs it and continues, #5109; the
+  ip-monitoring actuator uses it to avoid publishing a divergent snapshot,
+  #3757). Before #5109 a hard failure from a non-degraded state hit no
+  case in the outcome switch: the gauge stayed 0, no retry debt was armed,
+  and live FRR kept the stale forwarding state until the next commit or a
+  daemon restart while the operator's commit reported success.

--- a/pkg/frr/manager.go
+++ b/pkg/frr/manager.go
@@ -515,7 +515,9 @@ func (m *Manager) buildManagedSection(fc *FullConfig) string {
 //
 // Return contract: nil = full diff convergence; ErrFRRReloadDegraded
 // (errors.Is) = additive fallback applied, retry scheduled when
-// enabled; other errors = nothing converged.
+// enabled; other errors = HARD failure, nothing applied — the generation
+// is marked degraded and the retry is likewise scheduled when enabled
+// (#5109) so live FRR self-heals, and the error is returned.
 func (m *Manager) commitManagedSection(section string) error {
 	m.signalRetryCancel()
 	m.reloadMu.Lock()
@@ -851,18 +853,34 @@ func (m *Manager) warnPytoolsOnce(err error) {
 //     pending retry episode (AGY r3 f2: a woken redundant retry must
 //     exit without exec'ing, so its own transient failure can never
 //     spuriously re-set the gauge).
-//   - ErrFRRReloadDegraded: set the gauge and ensure a retry episode
-//     (when enabled). A pythontools-missing cause starts the retry at
-//     the slow cadence directly.
-//   - other errors: nothing was applied at all; the gauge keeps
-//     reflecting the last APPLIED reload and the error propagates to
-//     the caller (warn-and-continue at commit, loud log at cleanup).
+//   - ErrFRRReloadDegraded: the additive vtysh -f fallback applied every
+//     desired line but deferred stale-config removal — set the gauge and
+//     ensure a retry episode (when enabled). A pythontools-missing cause
+//     starts the retry at the slow cadence directly.
+//   - other errors (HARD failure, #5109): both frr-reload.py AND the
+//     additive vtysh -f fallback failed, so NOTHING was applied — live
+//     FRR keeps its previous config while frr.conf on disk already holds
+//     the new desired managed section. Treat it exactly like a degraded
+//     reload for recovery: set the gauge and arm the retry so the next
+//     reconcile re-runs the primary reload against the on-disk config and
+//     self-heals. The error still propagates to the caller (warn-and-
+//     continue at commit, loud log at cleanup). Before #5109 a hard
+//     failure from a non-degraded state hit no case here: the gauge
+//     stayed 0, no retry debt was armed, and live FRR kept the stale
+//     forwarding state until the next commit or a daemon restart while
+//     the operator's commit reported success.
 func (m *Manager) noteReloadOutcomeLocked(err error) {
 	switch {
 	case err == nil:
 		m.degraded.Store(false)
 		m.signalRetryCancel()
 	case errors.Is(err, ErrFRRReloadDegraded):
+		m.degraded.Store(true)
+		m.ensureRetryLocked(isFrrReloadPyMissing(err))
+	default:
+		// Hard reload failure: nothing converged, but frr.conf on disk is
+		// the SSOT the retry loop reloads, so arming retry debt (mirroring
+		// the degraded case) lets a later primary reload self-heal.
 		m.degraded.Store(true)
 		m.ensureRetryLocked(isFrrReloadPyMissing(err))
 	}

--- a/pkg/frr/manager_reload_test.go
+++ b/pkg/frr/manager_reload_test.go
@@ -253,6 +253,84 @@ func TestApplyFullPropagatesDegraded(t *testing.T) {
 	}
 }
 
+// TestHardFailureFromHealthyStateArmsRetry pins #5109: a commit whose
+// FIRST reload HARD-fails (both frr-reload.py AND the additive vtysh -f
+// fallback fail) from a healthy, non-degraded state must mark the
+// generation degraded AND arm the retry loop — so live FRR, which kept
+// its previous config while frr.conf on disk holds the new section,
+// self-heals on the next reload instead of staying stale forever.
+//
+// This is the gap the sibling TestHardFailureReArmsRetry does NOT cover:
+// there the manager was ALREADY degraded (commit 1) before the hard
+// failure, so commitManagedSection's re-arm guard fired off the existing
+// degraded=true. Here there is no prior degraded state, so the fix must
+// live in noteReloadOutcomeLocked's default (hard-error) arm. Reverting
+// that arm leaves degraded=false with no episode → the test fails.
+func TestHardFailureFromHealthyStateArmsRetry(t *testing.T) {
+	// BOTH legs fail on EVERY call: frr-reload.py errors, and the vtysh
+	// -f fallback also errors, so reloadLocked returns a hard (non-
+	// degraded) error from the very first commit.
+	fake := &fakeExecutor{
+		frrReloadPyErr: errors.New("primary down"),
+		vtyshLoadErr:   errors.New("vtysh also down"),
+	}
+	// Hour-long delays: the episode must exist but need not fire for this
+	// assertion; t.Cleanup(m.Stop) reaps it.
+	m := newRetryTestManager(t, fake, []time.Duration{time.Hour}, time.Hour)
+
+	err := m.Clear()
+	if err == nil || errors.Is(err, ErrFRRReloadDegraded) {
+		t.Fatalf("Clear = %v, want a hard (non-degraded) reload failure", err)
+	}
+	if !m.ReloadDegraded() {
+		t.Fatalf("ReloadDegraded() = false after a hard failure from a healthy state — no retry debt armed")
+	}
+	m.retryMu.Lock()
+	live := m.retryDone != nil && m.retryCtx != nil && m.retryCtx.Err() == nil
+	m.retryMu.Unlock()
+	if !live {
+		t.Fatalf("no live retry episode after a hard-failing commit from a healthy state — hard-error arm missing")
+	}
+}
+
+// TestHardFailureFromHealthyStateSelfHeals proves the armed retry debt
+// actually converges: after a hard failure from a healthy state (both
+// legs fail), once the primary reload starts succeeding, the retry loop
+// re-runs it against the on-disk frr.conf and clears the degraded state
+// — the end-to-end self-heal the #5109 fix restores.
+func TestHardFailureFromHealthyStateSelfHeals(t *testing.T) {
+	fake := &fakeExecutor{
+		// vtysh -f keeps failing so the FIRST commit is a hard failure
+		// (never the additive-degraded path); the primary hard-fails on
+		// call 1 then recovers, so the degraded-retry loop (primary-only)
+		// can converge.
+		vtyshLoadErr: errors.New("vtysh down"),
+	}
+	fake.frrReloadPyHook = func(call int) error {
+		if call == 1 {
+			return errors.New("primary down") // commit 1: hard failure
+		}
+		return nil // retry: primary recovers
+	}
+	m := newRetryTestManager(t, fake,
+		[]time.Duration{time.Millisecond, time.Millisecond, time.Millisecond},
+		2*time.Millisecond)
+
+	err := m.Clear()
+	if err == nil || errors.Is(err, ErrFRRReloadDegraded) {
+		t.Fatalf("Clear = %v, want a hard (non-degraded) reload failure", err)
+	}
+	if !m.ReloadDegraded() {
+		t.Fatalf("ReloadDegraded() = false right after a hard failure — no retry debt armed")
+	}
+	waitFor(t, "hard-failure retry convergence", 2*time.Second, func() bool {
+		return !m.ReloadDegraded()
+	})
+	if calls := fake.reloadPyCalls(); calls < 2 {
+		t.Errorf("FrrReloadPy calls = %d, want >= 2 (commit + at least one retry)", calls)
+	}
+}
+
 // TestHardFailureReArmsRetry pins Codex code-r1 H1: a superseding
 // commit pre-cancels the degraded-retry episode, but if that commit
 // then HARD-fails (both reload legs), it has not superseded anything —


### PR DESCRIPTION
## Problem (#5109)

The full operator-apply path discarded the FRR reload error (`_ =`). At the
manager, retry debt was scheduled only for `ErrFRRReloadDegraded`; a HARD error
(both `frr-reload.py` AND the additive `vtysh -f` fallback fail) from a
**non-degraded** state hit no switch case in `noteReloadOutcomeLocked`, so
`m.degraded` stayed false and no retry was armed. `commitManagedSection`'s
re-arm guard is gated on `m.degraded == true`, so it didn't fire either. Live
FRR kept its previous (stale) config while `frr.conf` on disk already held the
new desired managed section — and the operator's commit reported success. No
self-heal until the next commit or a daemon restart.

The existing `TestHardFailureReArmsRetry` only covered a hard failure that
followed an *already-degraded* commit (the re-arm-guard path), leaving this
healthy-state gap uncovered.

## Fix

- **`pkg/frr/manager.go`** — add a `default` (hard-error) arm to
  `noteReloadOutcomeLocked` that mirrors the degraded case exactly: set the
  `xpf_frr_reload_degraded` gauge and `ensureRetryLocked` the same single-flight
  retry episode. `frr.conf` on disk is the SSOT the retry loop reloads, so a
  later primary reload converges and self-heals. Reuses the existing
  degraded-retry machinery — no parallel path. The #1880 `frr-reload.py`-direct
  primary and the `vtysh -f` fallback logic are unchanged.
- **`pkg/daemon/daemon_apply.go`** — the full-apply path no longer discards the
  reload error with `_ =`. `applyFRRConfig` returns non-nil only on a HARD
  failure; the commit still does not fail (a transient FRR hiccup must not reject
  an otherwise-valid commit, and the in-manager retry now reconverges without a
  restart), but it is logged instead of silently dropped, and the interim state
  is surfaced via `ReloadDegraded()`.
- **`pkg/frr/README.md` + doc comments** — document the hard-failure retry-debt
  contract.

## Tests (fail-on-revert)

- `TestHardFailureFromHealthyStateArmsRetry` — first commit hard-fails from a
  healthy state; asserts `ReloadDegraded()` is set AND a live retry episode
  exists. Fails (degraded stays false, no episode) if the hard-error arm is
  reverted (verified).
- `TestHardFailureFromHealthyStateSelfHeals` — after the hard failure the
  primary recovers; asserts the armed retry converges and clears the gauge.

## Validation

- `go build ./...` -> `build_exit=0`
- `go test ./pkg/frr/... ./pkg/daemon/...` -> `test_exit=0`
- Confirmed both new tests FAIL when the hard-error arm is removed.
- `gofmt` clean on all touched files.

Closes #5109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi