### PR TITLE
routing/bond: reconcile bonds differentially, stop flapping the LAG

### DIFF
--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -29,7 +29,7 @@ which makes each domain unit-testable with a fake (see `rules_test.go`'s
 | `xfrm.go` | `xfrmManager` | XFRM/IPsec interface lifecycle; own `mu` + tracked `name→if_id` set. `Apply` reconciles **differentially** against the tracked set (keep unchanged / create new / delete removed / recreate on `if_id` change) — it does NOT clear-all-then-rebuild, so an unrelated config commit leaves active xfrmi interfaces untouched (#2546). Refuses to create either of two distinct devices that derive the same `if_id` — fail-closed collision guard (#2909) |
 | `rules.go` | `nextTableManager` / `ribGroupManager` / `pbrManager` | policy-routing ip-rule reconcilers (`ruleOps`, stateless) |
 | `probe_pin.go` | `probePinManager` | RPM probe next-hop pin reconciler (#1827): fwmark rules in band 50-99 + pinned host routes in reserved tables 7000-7049 (`probePinOps`, stateless). `Apply` returns per-test install failures (keyed by TestKey) and rolls back the fwmark rule when the pinned route fails (best-effort — a failed rollback is swept by the next band clear; the pin reports failed either way); callers thread the failed map into `pkg/rpm` so affected tests hold state instead of probing unpinned (#1895) |
-| `bond.go` | `bondManager` | bond device lifecycle; own `mu` |
+| `bond.go` | `bondManager` | bond (fabric/ae LAG) device lifecycle; own `mu` + tracked `name→bondSig` set. `Apply` reconciles **differentially** against the tracked set (keep unchanged / create new / delete removed / recreate on signature change) — it does NOT clear-all-then-rebuild, so an unrelated config commit no longer flaps the LAG (#5119, mirroring #2546) |
 | `reth.go` | `rethManager` | stale `reth*` bond cleanup |
 | `monitor.go` | `monitorManager` | interface-monitor HA signal; own `mu`. Link health via `linkAttrsUp` reads kernel **operstate** (`OperUp` → up; `OperUnknown` → admin-flag fallback; `OperDown`/lower-layer-down → down), **not** `IFF_UP` — admin-up-but-carrier-down (cable pulled) must report DOWN so HA fails over (#2070). Mirrors `pkg/vrrp.linkAttrsUp` and `pkg/cluster/monitor.go` |
 
@@ -59,6 +59,30 @@ all and rebuilding:
 A no-op commit (identical VPN set) issues zero `LinkDel` and zero
 `LinkAdd`. `Clear()` (shutdown / full teardown) still deletes every
 tracked interface.
+
+### Bond (fabric/ae LAG) reconcile (#5119)
+
+`bondManager.Apply` is called by `pkg/daemon` on **every** config commit
+(not only when the bond/fabric config changes) so bonds for deleted
+fabric interfaces are torn down. It therefore reconciles the desired bond
+set (`name→bondSig` — mode, MTU, and the sorted resolved Linux member
+set) against the tracked set instead of clearing all and rebuilding:
+
+- **keep** a bond untouched when it is still desired with an identical
+  `bondSig` — no `LinkDel`/`LinkAdd`/`LinkSetMaster`, so an unrelated
+  policy-only commit no longer flaps the LAG (`LinkDel`→`LinkAdd`→
+  re-enslave→LACP re-converge, traffic loss on the bond);
+- **create** a newly-desired bond (also adopts a kernel bond that
+  outlived in-memory tracking, e.g. across a daemon restart);
+- **recreate** (delete+create) a bond whose signature changed — a genuine
+  member/mode/MTU change; the mode and enslavement cannot be changed in
+  place while members are attached;
+- **delete** a bond whose fabric interface was removed.
+
+A no-op commit (identical desired bond set) issues zero `LinkDel`, zero
+`LinkAdd`, and zero `LinkSetMaster`. This was the non-idempotent
+anti-pattern #2546 fixed for XFRM but not bonds. `Clear()` (shutdown /
+full teardown) still deletes every tracked bond.
 
 **Teardown retains on delete failure (#4901).** The xfrm / bond / tunnel
 teardown paths (`clearLocked`, reached via `Clear`) used to log a failed

--- a/pkg/routing/bond.go
+++ b/pkg/routing/bond.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
+	"strings"
 	"sync"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -16,113 +18,233 @@ import (
 type bondManager struct {
 	ops linkOps
 
-	mu    sync.Mutex
-	bonds []string // currently created bond interface names
+	mu sync.Mutex
+	// bonds tracks the currently created bond devices by name, each mapped
+	// to the signature (mode, MTU, resolved member set) it was realized
+	// with. The signature lets Apply detect an UNCHANGED bond and leave it
+	// untouched instead of tearing it down and rebuilding it on every
+	// commit (#5119).
+	bonds map[string]bondSig
 }
 
-// Apply creates Linux bond devices for interfaces with fabric-options
-// member-interfaces configured. Uses the bond mode from
-// InterfaceConfig.BondMode (active-backup for fabric bonds, 802.3ad for
-// ae interfaces).
+// bondSig captures the parts of a fabric/ae bond's desired config that
+// determine its kernel realization: the bond mode, the interface-level
+// MTU, and the resolved (Linux-named) member set. Two bonds with an
+// identical signature realize the same kernel device, so an unchanged
+// signature means the bond must NOT be LinkDel'd and rebuilt on an
+// unrelated commit — doing so re-enslaves members and forces LACP to
+// re-converge, flapping the LAG (#5119). bondSig is a comparable struct
+// (the member set is pre-sorted and joined into a single string) so a
+// plain == is the whole diff.
+type bondSig struct {
+	mode    string // normalized: "active-backup" or "802.3ad"
+	mtu     int    // interface-level MTU (0 = kernel default, not set)
+	members string // sorted, comma-joined resolved Linux member names
+}
+
+// bondSigOf derives the signature of the bond an interface config would
+// realize. The mode is normalized the same way Apply programs it (any
+// non-"active-backup" mode is 802.3ad), and members are resolved to their
+// Linux names and sorted so member-order or Junos-vs-Linux spelling never
+// registers as a spurious change.
+func bondSigOf(ifc *config.InterfaceConfig) bondSig {
+	mode := "802.3ad"
+	if ifc.BondMode == "active-backup" {
+		mode = "active-backup"
+	}
+	members := make([]string, 0, len(ifc.FabricMembers))
+	for _, m := range ifc.FabricMembers {
+		members = append(members, config.LinuxIfName(m))
+	}
+	sort.Strings(members)
+	return bondSig{
+		mode:    mode,
+		mtu:     ifc.MTU,
+		members: strings.Join(members, ","),
+	}
+}
+
+// Apply reconciles the Linux bond devices for interfaces with
+// fabric-options member-interfaces against the currently tracked set.
+// The bond mode comes from InterfaceConfig.BondMode (active-backup for
+// fabric bonds, 802.3ad for ae interfaces).
+//
+// Apply is invoked on EVERY config commit, not only when the bond/fabric
+// config changes (daemon_apply.go always calls ApplyBonds so bonds for
+// deleted fabric interfaces are torn down). It therefore reconciles the
+// desired bond set differentially rather than clearing and rebuilding —
+// the fix for #5119, mirroring the #2546 XFRM reconcile:
+//
+//   - KEEP a bond untouched when it is still desired with an identical
+//     signature (mode, MTU, member set) — no LinkDel/LinkAdd/LinkSetMaster,
+//     so an unrelated policy-only commit no longer flaps the LAG (LinkDel→
+//     LinkAdd→re-enslave→LACP re-converge). This was the non-idempotent
+//     anti-pattern #2546 fixed for XFRM but not bonds.
+//   - CREATE a bond that is newly desired (also adopts a kernel bond that
+//     outlived in-memory tracking, e.g. across a daemon restart).
+//   - RECREATE (delete+create) a bond whose signature changed — a genuine
+//     config change (member added/removed, mode or MTU changed). The bond
+//     mode and enslavement cannot be changed in place while members are
+//     attached, so a signature change is a delete+rebuild.
+//   - DELETE a bond that is no longer desired (its fabric interface was
+//     removed).
+//
+// A no-op commit (identical desired bond set) issues zero LinkDel, zero
+// LinkAdd, and zero LinkSetMaster calls.
 //
 // Link-creation/enslavement/bring-up failures (LinkAdd, LinkSetMaster,
 // LinkSetUp) are accumulated with errors.Join and returned instead of
-// silently swallowed (#4823): before this fix, every one of these
-// netlink failures was logged and skipped, and Apply ALWAYS returned
-// nil — so a commit whose fabric/ae bond could not be realized in the
-// kernel still reported success, with no way for the commit pipeline
-// to detect the incomplete topology. LinkSetDown (best-effort pre-
-// enslave step) and a not-yet-present member link (LinkByName on a
-// FabricMembers entry — routine during interface enumeration ordering,
-// not itself a link-creation failure) are unchanged: still log-only,
-// since failing the WHOLE bond over one not-yet-enumerated member
-// would be worse than the partial-enslavement it already tolerates.
+// silently swallowed (#4823): before that fix, every one of these netlink
+// failures was logged and skipped, and Apply ALWAYS returned nil — so a
+// commit whose fabric/ae bond could not be realized in the kernel still
+// reported success. LinkSetDown (best-effort pre-enslave step) and a
+// not-yet-present member link (LinkByName on a FabricMembers entry —
+// routine during interface enumeration ordering) remain log-only.
 func (b *bondManager) Apply(interfaces []*config.InterfaceConfig) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if err := b.clearLocked(); err != nil {
-		slog.Warn("failed to clear previous bonds", "err", err)
+
+	if b.bonds == nil {
+		b.bonds = map[string]bondSig{}
+	}
+
+	// Build the desired name -> signature set. Skip interfaces with no
+	// fabric members and vSRX single-local-member fabric-options mode
+	// (LocalFabricMember resolved via .link rename — no bond device).
+	desired := make(map[string]bondSig, len(interfaces))
+	order := make([]string, 0, len(interfaces))
+	ifcByName := make(map[string]*config.InterfaceConfig, len(interfaces))
+	for _, ifc := range interfaces {
+		if len(ifc.FabricMembers) == 0 || ifc.LocalFabricMember != "" {
+			continue
+		}
+		if _, dup := desired[ifc.Name]; dup {
+			continue
+		}
+		desired[ifc.Name] = bondSigOf(ifc)
+		order = append(order, ifc.Name)
+		ifcByName[ifc.Name] = ifc
 	}
 
 	var errs []error
-	for _, ifc := range interfaces {
-		if len(ifc.FabricMembers) == 0 {
-			continue
-		}
-		// vSRX fabric-options mode: single local member resolved via .link
-		// rename — no bond needed.
-		if ifc.LocalFabricMember != "" {
-			continue
-		}
-		bondName := ifc.Name
 
-		// Check if bond already exists
-		if existing, err := b.ops.LinkByName(bondName); err == nil {
-			// Already exists — ensure it's up and skip creation
-			if err := b.ops.LinkSetUp(existing); err != nil {
-				slog.Warn("failed to bring up existing bond", "name", bondName, "err", err)
-				errs = append(errs, fmt.Errorf("bond %s: bring up existing: %w", bondName, err))
-			}
-			b.bonds = append(b.bonds, bondName)
-			slog.Debug("bond already exists", "name", bondName)
-			continue
+	// Delete pass: remove bonds that are no longer desired OR whose
+	// signature changed. A KEPT bond (still desired, identical signature)
+	// is left untouched — no destructive link op — so an unrelated commit
+	// does not flap the LAG (#5119). #4901: a failed LinkDel retains
+	// tracking so the next reconcile retries; a changed bond whose delete
+	// failed keeps its OLD signature, so it is NOT recreated this cycle
+	// (its stale kernel device is still present) and the next reconcile
+	// retries the delete first.
+	for name, trackedSig := range b.bonds {
+		if wantSig, want := desired[name]; want && wantSig == trackedSig {
+			continue // unchanged — keep
 		}
-
-		bond := netlink.NewLinkBond(netlink.LinkAttrs{Name: bondName})
-		switch ifc.BondMode {
-		case "active-backup":
-			bond.Mode = netlink.BOND_MODE_ACTIVE_BACKUP
-		default:
-			bond.Mode = netlink.BOND_MODE_802_3AD
+		if err := b.deleteLocked(name); err != nil {
+			errs = append(errs, err)
 		}
-		if ifc.MTU > 0 {
-			bond.LinkAttrs.MTU = ifc.MTU
-		}
-		if err := b.ops.LinkAdd(bond); err != nil {
-			slog.Warn("failed to create bond", "name", bondName, "err", err)
-			errs = append(errs, fmt.Errorf("bond %s: create: %w", bondName, err))
-			continue
-		}
-
-		// Enslave member interfaces
-		bondLink, err := b.ops.LinkByName(bondName)
-		if err != nil {
-			slog.Warn("failed to find created bond", "name", bondName, "err", err)
-			errs = append(errs, fmt.Errorf("bond %s: find after create: %w", bondName, err))
-			continue
-		}
-		for _, member := range ifc.FabricMembers {
-			linuxName := config.LinuxIfName(member)
-			memberLink, err := b.ops.LinkByName(linuxName)
-			if err != nil {
-				slog.Warn("bond member not found",
-					"bond", bondName, "member", member, "linux", linuxName, "err", err)
-				continue
-			}
-			// Member must be down before enslaving
-			b.ops.LinkSetDown(memberLink)
-			if err := b.ops.LinkSetMaster(memberLink, bondLink); err != nil {
-				slog.Warn("failed to enslave member",
-					"bond", bondName, "member", member, "err", err)
-				errs = append(errs, fmt.Errorf("bond %s: enslave member %s: %w", bondName, member, err))
-				continue
-			}
-			b.ops.LinkSetUp(memberLink)
-			slog.Info("bond member added", "bond", bondName, "member", member)
-		}
-
-		if err := b.ops.LinkSetUp(bondLink); err != nil {
-			slog.Warn("failed to bring up bond", "name", bondName, "err", err)
-			errs = append(errs, fmt.Errorf("bond %s: bring up: %w", bondName, err))
-		}
-		b.bonds = append(b.bonds, bondName)
-		modeStr := "802.3ad"
-		if ifc.BondMode == "active-backup" {
-			modeStr = "active-backup"
-		}
-		slog.Info("bond created", "name", bondName,
-			"mode", modeStr, "members", ifc.FabricMembers)
 	}
+
+	// Create/reconcile pass: build bonds that are newly desired or were
+	// just deleted because their signature changed.
+	for _, name := range order {
+		sig := desired[name]
+		if trackedSig, kept := b.bonds[name]; kept {
+			// Survived the delete pass. Either:
+			//   - unchanged (signature matched) — bring it up idempotently
+			//     (a no-op on an already-up bond, matching the XFRM keep
+			//     path); zero LinkDel/LinkAdd/LinkSetMaster, so no flap.
+			//   - OR a changed bond whose LinkDel failed above (OLD sig
+			//     retained). Skip recreation this cycle to avoid an EEXIST
+			//     LinkAdd; the next reconcile retries the delete first.
+			if trackedSig == sig {
+				if link, err := b.ops.LinkByName(name); err == nil {
+					if err := b.ops.LinkSetUp(link); err != nil {
+						slog.Warn("failed to bring up existing bond", "name", name, "err", err)
+						errs = append(errs, fmt.Errorf("bond %s: bring up existing: %w", name, err))
+					}
+				}
+			}
+			continue
+		}
+		if err := b.createLocked(name, ifcByName[name], sig); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// createLocked realizes a single desired bond in the kernel: it adopts an
+// already-present kernel device of that name without tearing it down (one
+// that outlived in-memory tracking across a daemon restart, or whose prior
+// LinkDel failed), or else creates the bond, enslaves its members, and
+// brings everything up. On success the bond is tracked under sig. Netlink
+// failures are aggregated and returned (#4823) rather than swallowed; a
+// LinkAdd / find-after-create failure leaves the bond UNTRACKED so the
+// next reconcile retries. Caller must hold mu.
+func (b *bondManager) createLocked(name string, ifc *config.InterfaceConfig, sig bondSig) error {
+	// Adopt an existing kernel device without a destructive rebuild. Kernel
+	// bond internals (mode/members) are not re-read here — this matches the
+	// pre-#5119 adopt behavior; the common no-op commit path never reaches
+	// createLocked because an unchanged bond is kept in the delete pass.
+	if existing, err := b.ops.LinkByName(name); err == nil {
+		b.bonds[name] = sig
+		slog.Debug("bond already exists", "name", name)
+		if err := b.ops.LinkSetUp(existing); err != nil {
+			slog.Warn("failed to bring up existing bond", "name", name, "err", err)
+			return fmt.Errorf("bond %s: bring up existing: %w", name, err)
+		}
+		return nil
+	}
+
+	bond := netlink.NewLinkBond(netlink.LinkAttrs{Name: name})
+	if sig.mode == "active-backup" {
+		bond.Mode = netlink.BOND_MODE_ACTIVE_BACKUP
+	} else {
+		bond.Mode = netlink.BOND_MODE_802_3AD
+	}
+	if ifc.MTU > 0 {
+		bond.LinkAttrs.MTU = ifc.MTU
+	}
+	if err := b.ops.LinkAdd(bond); err != nil {
+		slog.Warn("failed to create bond", "name", name, "err", err)
+		return fmt.Errorf("bond %s: create: %w", name, err)
+	}
+
+	// Enslave member interfaces.
+	bondLink, err := b.ops.LinkByName(name)
+	if err != nil {
+		slog.Warn("failed to find created bond", "name", name, "err", err)
+		return fmt.Errorf("bond %s: find after create: %w", name, err)
+	}
+
+	var errs []error
+	for _, member := range ifc.FabricMembers {
+		linuxName := config.LinuxIfName(member)
+		memberLink, err := b.ops.LinkByName(linuxName)
+		if err != nil {
+			slog.Warn("bond member not found",
+				"bond", name, "member", member, "linux", linuxName, "err", err)
+			continue
+		}
+		// Member must be down before enslaving.
+		b.ops.LinkSetDown(memberLink)
+		if err := b.ops.LinkSetMaster(memberLink, bondLink); err != nil {
+			slog.Warn("failed to enslave member",
+				"bond", name, "member", member, "err", err)
+			errs = append(errs, fmt.Errorf("bond %s: enslave member %s: %w", name, member, err))
+			continue
+		}
+		b.ops.LinkSetUp(memberLink)
+		slog.Info("bond member added", "bond", name, "member", member)
+	}
+
+	if err := b.ops.LinkSetUp(bondLink); err != nil {
+		slog.Warn("failed to bring up bond", "name", name, "err", err)
+		errs = append(errs, fmt.Errorf("bond %s: bring up: %w", name, err))
+	}
+	b.bonds[name] = sig
+	slog.Info("bond created", "name", name, "mode", sig.mode, "members", ifc.FabricMembers)
 	return errors.Join(errs...)
 }
 
@@ -133,28 +255,44 @@ func (b *bondManager) Clear() error {
 	return b.clearLocked()
 }
 
-// clearLocked is the lock-free body of Clear. Caller must hold mu.
-// Used internally by Apply.
+// clearLocked deletes every tracked bond. Caller must hold mu. Used by
+// Clear (shutdown / full teardown). Apply no longer calls this — it
+// reconciles differentially instead (#5119).
 func (b *bondManager) clearLocked() error {
 	var errs []error
-	var retained []string
-	for _, name := range b.bonds {
-		link, err := b.ops.LinkByName(name)
-		if err != nil {
-			continue // already gone
-		}
-		if err := b.ops.LinkDel(link); err != nil {
-			// #4901: a failed LinkDel leaves the bond (and its enslaved members)
-			// in the kernel. Retain the name so the next reconcile retries the
-			// delete, and surface the error instead of returning a clean-teardown
-			// nil that loses ownership of the orphaned bond.
-			slog.Warn("failed to delete bond", "name", name, "err", err)
-			errs = append(errs, fmt.Errorf("delete bond %s: %w", name, err))
-			retained = append(retained, name)
-		} else {
-			slog.Info("bond removed", "name", name)
+	for name := range b.bonds {
+		if err := b.deleteLocked(name); err != nil {
+			errs = append(errs, err)
 		}
 	}
-	b.bonds = retained
+	// #4901: deleteLocked drops each successfully-removed name and RETAINS
+	// the ones whose LinkDel failed so the next reconcile retries — do NOT
+	// blanket-nil the map here, which would forget an orphaned bond and lose
+	// ownership while reporting a clean teardown. Only clear once every
+	// device is actually gone.
+	if len(b.bonds) == 0 {
+		b.bonds = nil
+	}
 	return errors.Join(errs...)
+}
+
+// deleteLocked removes a single tracked bond by name and drops it from
+// tracking. Caller must hold mu. A link already gone from the kernel is
+// treated as success (the entry is still untracked). It returns a non-nil
+// error when the netlink LinkDel fails, in which case the name is RETAINED
+// in tracking (#4901) so the next reconcile retries instead of orphaning
+// the bond (and its enslaved members).
+func (b *bondManager) deleteLocked(name string) error {
+	link, err := b.ops.LinkByName(name)
+	if err != nil {
+		delete(b.bonds, name)
+		return nil // already gone
+	}
+	if err := b.ops.LinkDel(link); err != nil {
+		slog.Warn("failed to delete bond", "name", name, "err", err)
+		return fmt.Errorf("delete bond %s: %w", name, err)
+	}
+	slog.Info("bond removed", "name", name)
+	delete(b.bonds, name)
+	return nil
 }

--- a/pkg/routing/bond_test.go
+++ b/pkg/routing/bond_test.go
@@ -18,9 +18,12 @@ type fakeBondLinkOps struct {
 	failLinkAdd       map[string]error // bond name -> LinkAdd error
 	failLinkSetUp     map[string]error // link name -> LinkSetUp error
 	failLinkSetMaster map[string]error // member name -> LinkSetMaster error
+	failLinkDel       map[string]error // link name -> LinkDel error
 
 	setUpCalls  []string
 	masterCalls []string
+	addCalls    []string // names passed to LinkAdd
+	delCalls    []string // names passed to LinkDel
 }
 
 func newFakeBondLinkOps() *fakeBondLinkOps {
@@ -29,7 +32,17 @@ func newFakeBondLinkOps() *fakeBondLinkOps {
 		failLinkAdd:       map[string]error{},
 		failLinkSetUp:     map[string]error{},
 		failLinkSetMaster: map[string]error{},
+		failLinkDel:       map[string]error{},
 	}
+}
+
+// reset zeroes the recorded call slices so a test can assert on the link
+// operations issued by a SECOND Apply in isolation from the first.
+func (f *fakeBondLinkOps) reset() {
+	f.setUpCalls = nil
+	f.masterCalls = nil
+	f.addCalls = nil
+	f.delCalls = nil
 }
 
 func (f *fakeBondLinkOps) LinkByName(name string) (netlink.Link, error) {
@@ -41,6 +54,7 @@ func (f *fakeBondLinkOps) LinkByName(name string) (netlink.Link, error) {
 
 func (f *fakeBondLinkOps) LinkAdd(l netlink.Link) error {
 	name := l.Attrs().Name
+	f.addCalls = append(f.addCalls, name)
 	if err, ok := f.failLinkAdd[name]; ok {
 		return err
 	}
@@ -49,7 +63,12 @@ func (f *fakeBondLinkOps) LinkAdd(l netlink.Link) error {
 }
 
 func (f *fakeBondLinkOps) LinkDel(l netlink.Link) error {
-	delete(f.links, l.Attrs().Name)
+	name := l.Attrs().Name
+	f.delCalls = append(f.delCalls, name)
+	if err, ok := f.failLinkDel[name]; ok {
+		return err
+	}
+	delete(f.links, name)
 	return nil
 }
 
@@ -190,16 +209,143 @@ func TestBondApplyContinuesPastOneFailedBond(t *testing.T) {
 	if err == nil {
 		t.Fatal("Apply() = nil error, want non-nil (bond0's LinkAdd failed)")
 	}
-	found := false
-	for _, name := range b.bonds {
-		if name == "bond1" {
-			found = true
-		}
-		if name == "bond0" {
-			t.Fatalf("bond0 tracked despite its LinkAdd failure: %+v", b.bonds)
+	if _, ok := b.bonds["bond0"]; ok {
+		t.Fatalf("bond0 tracked despite its LinkAdd failure: %+v", b.bonds)
+	}
+	if _, ok := b.bonds["bond1"]; !ok {
+		t.Fatalf("bond1 (unaffected by bond0's failure) was not created: %+v", b.bonds)
+	}
+}
+
+// contains reports whether s appears in xs.
+func contains(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
 		}
 	}
-	if !found {
-		t.Fatalf("bond1 (unaffected by bond0's failure) was not created: %+v", b.bonds)
+	return false
+}
+
+// TestBondApplyIdempotentNoFlap is the #5119 RED-on-revert guard: applying
+// the SAME fabric bond config twice must not tear down and rebuild the
+// unchanged bond. The second Apply must issue ZERO LinkDel, LinkAdd, and
+// LinkSetMaster calls — otherwise an unrelated policy-only commit flaps the
+// LAG (LinkDel->LinkAdd->re-enslave->LACP re-converge). Reverting to the
+// unconditional clearLocked()-then-rebuild fails this test.
+func TestBondApplyIdempotentNoFlap(t *testing.T) {
+	ops := newFakeBondLinkOps()
+	ops.seedMember("ge-0-0-1")
+	ops.seedMember("ge-0-0-2")
+	b := &bondManager{ops: ops}
+
+	cfg := []*config.InterfaceConfig{
+		bondFabricConfig("bond0", "ge-0-0-1", "ge-0-0-2"),
+	}
+	if err := b.Apply(cfg); err != nil {
+		t.Fatalf("first Apply() = %v, want nil", err)
+	}
+	if !contains(ops.addCalls, "bond0") {
+		t.Fatalf("first Apply did not create bond0: addCalls=%v", ops.addCalls)
+	}
+
+	// Re-apply the identical config. Nothing changed, so the bond must be
+	// left in place.
+	ops.reset()
+	if err := b.Apply(cfg); err != nil {
+		t.Fatalf("second Apply() = %v, want nil", err)
+	}
+	if len(ops.delCalls) != 0 {
+		t.Fatalf("second (identical) Apply issued LinkDel(s) %v — the "+
+			"unchanged bond was flapped", ops.delCalls)
+	}
+	if len(ops.addCalls) != 0 {
+		t.Fatalf("second (identical) Apply issued LinkAdd(s) %v — the "+
+			"unchanged bond was rebuilt", ops.addCalls)
+	}
+	if len(ops.masterCalls) != 0 {
+		t.Fatalf("second (identical) Apply re-enslaved member(s) %v — the "+
+			"unchanged bond was flapped", ops.masterCalls)
+	}
+	if _, ok := b.bonds["bond0"]; !ok {
+		t.Fatalf("bond0 dropped from tracking after idempotent re-apply: %+v", b.bonds)
+	}
+}
+
+// TestBondApplyReconcilesChangedBond asserts a GENUINE config change (a
+// member added) IS reconciled: the changed bond is deleted and rebuilt so
+// the new member set is realized. Skipping it would leave the kernel bond
+// stale.
+func TestBondApplyReconcilesChangedBond(t *testing.T) {
+	ops := newFakeBondLinkOps()
+	ops.seedMember("ge-0-0-1")
+	ops.seedMember("ge-0-0-2")
+	b := &bondManager{ops: ops}
+
+	if err := b.Apply([]*config.InterfaceConfig{
+		bondFabricConfig("bond0", "ge-0-0-1"),
+	}); err != nil {
+		t.Fatalf("first Apply() = %v, want nil", err)
+	}
+
+	// Add a second member — the signature changes, so the bond must be
+	// reconciled (delete + rebuild).
+	ops.reset()
+	if err := b.Apply([]*config.InterfaceConfig{
+		bondFabricConfig("bond0", "ge-0-0-1", "ge-0-0-2"),
+	}); err != nil {
+		t.Fatalf("second Apply() = %v, want nil", err)
+	}
+	if !contains(ops.delCalls, "bond0") {
+		t.Fatalf("changed bond0 was NOT deleted: delCalls=%v", ops.delCalls)
+	}
+	if !contains(ops.addCalls, "bond0") {
+		t.Fatalf("changed bond0 was NOT rebuilt: addCalls=%v", ops.addCalls)
+	}
+	if !contains(ops.masterCalls, "ge-0-0-2") {
+		t.Fatalf("new member ge-0-0-2 was NOT enslaved: masterCalls=%v", ops.masterCalls)
+	}
+	if _, ok := b.bonds["bond0"]; !ok {
+		t.Fatalf("bond0 dropped from tracking after reconcile: %+v", b.bonds)
+	}
+}
+
+// TestBondApplyDeletesRemovedBond asserts a bond dropped from the desired
+// set (its fabric interface was removed from config) is deleted, while an
+// UNCHANGED sibling bond in the same commit is left untouched (no flap).
+func TestBondApplyDeletesRemovedBond(t *testing.T) {
+	ops := newFakeBondLinkOps()
+	ops.seedMember("ge-0-0-1")
+	ops.seedMember("ge-0-0-2")
+	b := &bondManager{ops: ops}
+
+	if err := b.Apply([]*config.InterfaceConfig{
+		bondFabricConfig("bond0", "ge-0-0-1"),
+		bondFabricConfig("bond1", "ge-0-0-2"),
+	}); err != nil {
+		t.Fatalf("first Apply() = %v, want nil", err)
+	}
+
+	// Drop bond1; bond0 is unchanged.
+	ops.reset()
+	if err := b.Apply([]*config.InterfaceConfig{
+		bondFabricConfig("bond0", "ge-0-0-1"),
+	}); err != nil {
+		t.Fatalf("second Apply() = %v, want nil", err)
+	}
+	if !contains(ops.delCalls, "bond1") {
+		t.Fatalf("removed bond1 was NOT deleted: delCalls=%v", ops.delCalls)
+	}
+	if contains(ops.delCalls, "bond0") {
+		t.Fatalf("unchanged bond0 was deleted (flapped): delCalls=%v", ops.delCalls)
+	}
+	if contains(ops.addCalls, "bond0") {
+		t.Fatalf("unchanged bond0 was rebuilt (flapped): addCalls=%v", ops.addCalls)
+	}
+	if _, ok := b.bonds["bond1"]; ok {
+		t.Fatalf("bond1 still tracked after removal: %+v", b.bonds)
+	}
+	if _, ok := b.bonds["bond0"]; !ok {
+		t.Fatalf("bond0 dropped from tracking despite being unchanged: %+v", b.bonds)
 	}
 }

--- a/pkg/routing/teardown_linkdel_4901_test.go
+++ b/pkg/routing/teardown_linkdel_4901_test.go
@@ -66,7 +66,7 @@ func TestBondClearRetainsAndReturnsOnLinkDelFailure(t *testing.T) {
 	seedDummy(ops, "bond-ok")
 	ops.delFail["bond-bad"] = errors.New("injected EPERM")
 
-	b := &bondManager{ops: ops, bonds: []string{"bond-bad", "bond-ok"}}
+	b := &bondManager{ops: ops, bonds: map[string]bondSig{"bond-bad": {}, "bond-ok": {}}}
 
 	err := b.Clear()
 	if err == nil {
@@ -75,10 +75,10 @@ func TestBondClearRetainsAndReturnsOnLinkDelFailure(t *testing.T) {
 	if !strings.Contains(err.Error(), "bond-bad") {
 		t.Errorf("Clear error should name the failed bond: %v", err)
 	}
-	if !sliceHas(b.bonds, "bond-bad") {
+	if _, ok := b.bonds["bond-bad"]; !ok {
 		t.Fatal("failed-delete bond must be RETAINED in tracking so the next reconcile retries")
 	}
-	if sliceHas(b.bonds, "bond-ok") {
+	if _, ok := b.bonds["bond-ok"]; ok {
 		t.Fatal("successfully-deleted bond must be dropped from tracking")
 	}
 }


### PR DESCRIPTION
## Problem

`bondManager.Apply` unconditionally called `clearLocked()` first — `LinkDel`'ing every tracked bond — then rebuilt all of them, and the daemon calls `ApplyBonds` on **every** config apply with no diff gate. An unrelated policy-only commit therefore destroyed and recreated an *unchanged* fabric/ae bond (`LinkDel` → `LinkAdd` → re-enslave → LACP re-converge), **flapping the LAG** and interrupting traffic / HA links on every commit. This is the non-idempotent anti-pattern #2546 fixed for XFRM interfaces but not bonds.

## Fix

Replace the clear-and-rebuild with a differential reconcile that mirrors the established `xfrmManager.Apply` (#2546) idiom:

- Track bonds as `name → bondSig` (mode, MTU, sorted resolved Linux member set) instead of a bare name slice. `bondSig` is a comparable struct, so a plain `==` is the whole per-bond diff.
- **KEEP** a bond untouched when it is still desired with an identical signature — zero `LinkDel`/`LinkAdd`/`LinkSetMaster`, so an unrelated commit no longer flaps the LAG. The kept bond is brought up idempotently (no-op on an already-up bond), matching the XFRM keep path.
- **CREATE** a newly-desired bond (`createLocked` also adopts a kernel bond that outlived in-memory tracking, e.g. across a daemon restart).
- **RECREATE** (delete+create) a bond whose signature changed — a genuine member/mode/MTU change; mode and enslavement cannot be changed in place while members are attached.
- **DELETE** a bond whose fabric interface was removed.

The #4901 retain-on-failed-delete debt is preserved (`deleteLocked` retains a bond whose `LinkDel` failed; a changed bond whose delete failed keeps its OLD signature and is not recreated that cycle, so the next reconcile retries the delete instead of an `EEXIST` `LinkAdd`). The #4823 error aggregation (LinkAdd/enslave/bring-up failures returned via `errors.Join`, not swallowed) is preserved in `createLocked`.

## Tests

- `TestBondApplyIdempotentNoFlap` — RED-on-revert guard: a second identical `Apply` must issue **zero** `LinkDel`/`LinkAdd`/`LinkSetMaster`.
- `TestBondApplyReconcilesChangedBond` — a member added IS reconciled.
- `TestBondApplyDeletesRemovedBond` — a removed bond is deleted while an unchanged sibling is untouched.

The fake `linkOps` now records `LinkAdd`/`LinkDel` calls and supports `reset()` between the two `Apply` calls. The two existing bond tests plus the #4901 teardown test are updated to the map tracking type. Verified the no-flap test **FAILS** when `Apply` is reverted to the unconditional `clearLocked()`-then-rebuild.

## Docs

Documented the bond reconcile contract in `pkg/routing/README.md` alongside the XFRM (#2546) section and updated the manager table row.

## Validation

- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` → `build_exit=0`
- `go test -count=1 ./pkg/routing/...` → `test_exit=0` (`ok`)
- `gofmt` clean on all touched files.

Closes #5119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi