### PR TITLE
cluster: fix hold-timer leak on RG removal (#5245) and reset-vs-failover race (#5246)

### DIFF
--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -509,6 +509,27 @@ outside the monitor loop:
   explicit operator-initiated `request chassis cluster failover`.
 - `TakeoverHoldTime` adds extra delay before election when this node would
   immediately preempt. Used to avoid election thrash on simultaneous boot.
+- **Removing an RG must stop its armed hold timer (#5245).** `SetRGReady`
+  arms a per-RG `time.AfterFunc` takeover-hold timer whose closure captures
+  the `*RedundancyGroupState` and re-runs election on expiry. `UpdateConfig`'s
+  removal loop `Stop()`s and nils `rg.holdTimer` before `delete(m.groups, id)`
+  — mirroring the `readiness.go` not-ready clear site and `Stop()`. Without
+  this the closure keeps the removed group alive and still fires, running an
+  election against removed state. Belt-and-suspenders: the closure also
+  re-checks `m.groups[rgID] == rg` after taking `m.mu` (a timer that had
+  already fired can race the teardown, since `AfterFunc.Stop()` does not
+  cancel an in-flight callback) and no-ops if the group is gone or replaced.
+- **`ManualFailover`/`ManualFailoverBatch` release `m.mu` for the pre-failover
+  hook — a racing `ResetFailover` must not be clobbered (#5246).** Both take
+  `m.mu`, mark `failoverInProgress`, then unlock to run the retryable pre-hook
+  (which may sleep up to the retry timeout), re-lock, and write
+  `State=SecondaryHold`. A `ResetFailover` in that unlocked window clears the
+  failover and re-elects, but the trailing SecondaryHold write would silently
+  overwrite it. Fix: a per-RG `failoverGen` counter — `ResetFailover` bumps it;
+  the failover path snapshots it before unlocking and abandons its trailing
+  write (single-RG returns nil; batch skips that member) if it changed. Keep
+  `failoverInProgress` cleaned up on every exit path so a superseded failover
+  cannot wedge the next one.
 - HA delete-sync callbacks fire from the GC loop. They must not block, and
   must log at `slog.Debug` — earlier `slog.Info` flooded at 15 req/s and
   drowned out real diagnostics (per CLAUDE.md logging rules).

--- a/pkg/cluster/failover.go
+++ b/pkg/cluster/failover.go
@@ -49,6 +49,11 @@ func (m *Manager) ManualFailover(rgID int) error {
 		return fmt.Errorf("failover already in progress for redundancy group %d, please wait", rgID)
 	}
 	m.failoverInProgress[rgID] = true
+	// Snapshot the per-RG failover generation before releasing m.mu for the
+	// pre-hook. A ResetFailover landing in the unlocked window bumps it, and
+	// the post-relock re-check below then abandons the trailing SecondaryHold
+	// write instead of clobbering the operator's reset (#5246).
+	failoverGen := m.failoverGen[rgID]
 	preHook := m.preManualFailoverFn
 	retryTimeout := m.preManualFailoverRetryTimeout
 	retryInterval := m.preManualFailoverRetryInterval
@@ -102,6 +107,15 @@ func (m *Manager) ManualFailover(rgID int) error {
 	rg, ok = m.groups[rgID]
 	if !ok {
 		return fmt.Errorf("redundancy group %d not found", rgID)
+	}
+	// If a ResetFailover ran during the unlocked pre-hook window it bumped
+	// this RG's failover generation. The trailing SecondaryHold write below
+	// would otherwise silently clobber the operator's reset (#5246). Detect
+	// the supersede and abandon the write, leaving the reset's restored state
+	// intact. failoverInProgress is cleared by the deferred delete above.
+	if m.failoverGen[rgID] != failoverGen {
+		slog.Info("cluster: manual failover superseded by reset, abandoning", "rg", rgID)
+		return nil
 	}
 	oldState := rg.State
 	rg.ManualFailover = true
@@ -168,6 +182,11 @@ func (m *Manager) ResetFailover(rgID int) error {
 	}
 	rg.ManualFailover = false
 	rg.ManualFailoverAt = time.Time{}
+	// Invalidate any in-flight ManualFailover / ManualFailoverBatch whose
+	// pre-failover hook released m.mu: bump the per-RG failover generation so
+	// its post-hook re-check abandons the trailing SecondaryHold write instead
+	// of clobbering this reset (#5246).
+	m.failoverGen[rgID]++
 	m.recalcWeight(rg) // restore weight from monitor state + run election
 	slog.Info("cluster: failover reset", "rg", rgID)
 	return nil
@@ -442,8 +461,13 @@ func (m *Manager) ManualFailoverBatch(rgIDs []int) error {
 			return fmt.Errorf("failover already in progress for redundancy groups %v, please wait", ids)
 		}
 	}
+	batchGen := make(map[int]uint64, len(ids))
 	for _, rgID := range ids {
 		m.failoverInProgress[rgID] = true
+		// Snapshot each member's failover generation before releasing m.mu
+		// for the pre-hook so a ResetFailover on a member during the unlocked
+		// window is detected and its reset preserved (#5246).
+		batchGen[rgID] = m.failoverGen[rgID]
 	}
 	preHook := m.preManualFailoverFn
 	retryTimeout := m.preManualFailoverRetryTimeout
@@ -504,6 +528,18 @@ func (m *Manager) ManualFailoverBatch(rgIDs []int) error {
 	now := time.Now()
 	for _, rgID := range ids {
 		rg := m.groups[rgID]
+		if rg == nil {
+			// Group was removed from config during the unlocked pre-hook
+			// window; nothing to transfer out.
+			continue
+		}
+		// A ResetFailover on this member during the unlocked window bumped
+		// its failover generation — its reset wins; skip the SecondaryHold
+		// write so we don't clobber it (#5246).
+		if m.failoverGen[rgID] != batchGen[rgID] {
+			slog.Info("cluster: manual failover batch member superseded by reset, skipping", "rg", rgID)
+			continue
+		}
 		oldState := rg.State
 		rg.ManualFailover = true
 		rg.ManualFailoverAt = now

--- a/pkg/cluster/failover_races_5245_5246_test.go
+++ b/pkg/cluster/failover_races_5245_5246_test.go
@@ -1,0 +1,160 @@
+package cluster
+
+import (
+	"testing"
+	"time"
+)
+
+// TestUpdateConfig_RemovesGroup_StopsHoldTimer covers #5245: when a redundancy
+// group is removed from config, its armed takeover-hold timer must be stopped
+// and cleared so the AfterFunc closure cannot fire an election against removed
+// state. Reverting the Stop()+nil in the group_state.go removal loop leaves
+// rg.holdTimer non-nil (armed) after removal → this test goes RED.
+func TestUpdateConfig_RemovesGroup_StopsHoldTimer(t *testing.T) {
+	m := NewManager(0, 1)
+	// A non-zero takeover-hold time is required for SetRGReady to arm the
+	// per-RG hold timer. 60s keeps the timer armed (but never firing) for the
+	// duration of this synchronous test.
+	cfg := makeConfig(
+		makeRG(0, false, map[int]int{0: 200}),
+		makeRG(1, false, map[int]int{0: 100}),
+	)
+	cfg.TakeoverHoldTime = 60_000 // ms
+	m.UpdateConfig(cfg)
+
+	// Keep a direct reference to RG1's state so we can inspect its timer field
+	// after the group is dropped from m.groups.
+	rg1 := m.groups[1]
+	if rg1 == nil {
+		t.Fatal("precondition: RG1 should exist after UpdateConfig")
+	}
+
+	// Arm RG1's hold timer via a not-ready → ready transition.
+	m.SetRGReady(1, true, nil)
+	if rg1.holdTimer == nil {
+		t.Fatal("precondition: RG1 hold timer should be armed after SetRGReady")
+	}
+
+	// Remove RG1 from config.
+	cfg2 := makeConfig(makeRG(0, false, map[int]int{0: 200}))
+	cfg2.TakeoverHoldTime = 60_000
+	m.UpdateConfig(cfg2)
+
+	if _, ok := m.groups[1]; ok {
+		t.Fatal("RG1 should be removed from m.groups")
+	}
+	// The core assertion: the removal must have stopped and cleared the armed
+	// timer so it cannot fire against removed state (#5245).
+	if rg1.holdTimer != nil {
+		t.Fatal("removed RG hold timer leaked: holdTimer is non-nil after UpdateConfig removal (#5245)")
+	}
+}
+
+// TestUpdateConfig_RemovesGroup_TimerDoesNotElect is a stronger #5245 guard: it
+// arms a SHORT hold timer, removes the group, and waits past the hold interval.
+// The stopped-and-cleared timer must not fire an election that touches state.
+// The removed RG's captured state must remain untouched (never promoted to
+// primary by a stale closure).
+func TestUpdateConfig_RemovesGroup_TimerDoesNotElect(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(
+		makeRG(0, false, map[int]int{0: 200}),
+		makeRG(1, false, map[int]int{0: 100}),
+	)
+	cfg.TakeoverHoldTime = 20 // ms — short so a leaked timer would fire quickly
+	m.UpdateConfig(cfg)
+
+	rg1 := m.groups[1]
+	if rg1 == nil {
+		t.Fatal("precondition: RG1 should exist")
+	}
+	// Drive RG1 to a known non-primary state, then arm the hold timer.
+	rg1.State = StateSecondary
+	m.SetRGReady(1, true, nil)
+	if rg1.holdTimer == nil {
+		t.Fatal("precondition: RG1 hold timer should be armed")
+	}
+
+	// Remove RG1 while its short timer is armed.
+	cfg2 := makeConfig(makeRG(0, false, map[int]int{0: 200}))
+	cfg2.TakeoverHoldTime = 20
+	m.UpdateConfig(cfg2)
+
+	// Force the captured state to a sentinel a stale election would overwrite.
+	m.mu.Lock()
+	rg1.State = StateSecondary
+	m.mu.Unlock()
+
+	// Wait well past the 20ms hold interval for any leaked timer to fire.
+	time.Sleep(120 * time.Millisecond)
+
+	m.mu.Lock()
+	leaked := rg1.holdTimer != nil
+	state := rg1.State
+	m.mu.Unlock()
+	if leaked {
+		t.Fatal("removed RG hold timer leaked after grace wait (#5245)")
+	}
+	if state != StateSecondary {
+		t.Fatalf("stale hold-timer closure mutated removed RG state to %s (#5245)", state)
+	}
+}
+
+// TestManualFailover_ResetDuringPreHookWins covers #5246: a ResetFailover that
+// lands while ManualFailover is parked in its pre-failover hook (m.mu released)
+// must win. The trailing ManualFailover SecondaryHold write must be abandoned
+// rather than clobbering the operator's reset. Reverting the failover-
+// generation re-check in ManualFailover makes the trailing write clobber the
+// reset (ManualFailover=true / State=SecondaryHold) → this test goes RED.
+func TestManualFailover_ResetDuringPreHookWins(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200}))
+	m.UpdateConfig(cfg)
+	<-m.Events() // drain the initial secondary→primary election event
+
+	if !m.IsLocalPrimary(0) {
+		t.Fatal("precondition: node should be primary for RG0")
+	}
+
+	// A pre-hook that blocks until released, holding ManualFailover in the
+	// unlocked window while ResetFailover runs.
+	hookStarted := make(chan struct{})
+	hookRelease := make(chan struct{})
+	m.SetPreManualFailoverHook(func(rgID int) error {
+		close(hookStarted)
+		<-hookRelease
+		return nil
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- m.ManualFailover(0)
+	}()
+
+	// Wait for ManualFailover to enter the pre-hook (m.mu released here).
+	<-hookStarted
+
+	// Operator resets the failover during the unlocked window. This bumps the
+	// per-RG failover generation and restores the node to primary.
+	if err := m.ResetFailover(0); err != nil {
+		t.Fatalf("ResetFailover error = %v", err)
+	}
+
+	// Release the parked pre-hook so ManualFailover re-acquires m.mu.
+	close(hookRelease)
+	if err := <-errCh; err != nil {
+		t.Fatalf("ManualFailover should return without error when superseded: %v", err)
+	}
+
+	// Final state must reflect the RESET, not the failover.
+	states := m.GroupStates()
+	if len(states) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(states))
+	}
+	if states[0].ManualFailover {
+		t.Fatal("reset was clobbered: ManualFailover=true after ResetFailover won the race (#5246)")
+	}
+	if states[0].State != StatePrimary {
+		t.Fatalf("reset was clobbered: state = %s, want primary (#5246)", states[0].State)
+	}
+}

--- a/pkg/cluster/group_state.go
+++ b/pkg/cluster/group_state.go
@@ -40,8 +40,20 @@ func (m *Manager) UpdateConfig(cfg *config.ClusterConfig) {
 	}
 
 	// Remove groups no longer in config and their monitor weights.
-	for id := range m.groups {
+	for id, rg := range m.groups {
 		if !seen[id] {
+			// Stop the armed takeover-hold timer before dropping the group
+			// so its AfterFunc closure cannot fire an election against
+			// removed state (#5245). Mirrors the readiness.go not-ready
+			// clear site and Stop(): stop + nil the field under m.mu (held
+			// here). AfterFunc's Stop() does not block on an in-flight
+			// callback; if a fired callback is already parked on m.mu it
+			// runs after we unlock, but the readiness.go closure's
+			// staleness guard makes it a no-op once the group is gone.
+			if rg.holdTimer != nil {
+				rg.holdTimer.Stop()
+				rg.holdTimer = nil
+			}
 			for k := range m.monitorWeights {
 				if k.rgID == id {
 					delete(m.monitorWeights, k)

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -276,6 +276,15 @@ type Manager struct {
 	// racing and hitting "session sync disconnected during barrier wait".
 	failoverInProgress map[int]bool
 
+	// failoverGen is a per-RG monotonic generation bumped by ResetFailover
+	// (#5246). ManualFailover / ManualFailoverBatch snapshot it under m.mu
+	// before releasing the lock to run the retryable pre-failover hook, and
+	// re-check it after re-acquiring m.mu. A ResetFailover that lands in that
+	// unlocked window bumps the generation; the re-check then detects the
+	// supersede and abandons its trailing SecondaryHold write so the
+	// operator's reset is not silently clobbered. Guarded by m.mu.
+	failoverGen map[int]uint64
+
 	// stopped is set by Stop() to mark the manager quiesced. It guards the
 	// per-RG hold-timer closure (readiness.go) so a takeover-hold timer that
 	// had already fired and is blocked on m.mu when Stop() runs cannot run an
@@ -319,6 +328,7 @@ func NewManager(nodeID, clusterID int) *Manager {
 		preManualFailoverRetryTimeout:  DefaultPreManualFailoverRetryTimeout,
 		preManualFailoverRetryInterval: DefaultPreManualFailoverRetryInterval,
 		failoverInProgress:             make(map[int]bool),
+		failoverGen:                    make(map[int]uint64),
 	}
 }
 

--- a/pkg/cluster/readiness.go
+++ b/pkg/cluster/readiness.go
@@ -44,6 +44,15 @@ func (m *Manager) SetRGReady(rgID int, ready bool, reasons []string) {
 				if m.stopped {
 					return
 				}
+				// The RG may have been removed (or replaced) from config
+				// while this timer was armed or already parked on m.mu
+				// (#5245). UpdateConfig stops+clears the timer on removal,
+				// but a timer that had already fired races that teardown;
+				// verify this is still the live group before electing so a
+				// stale closure cannot run an election against removed state.
+				if cur, ok := m.groups[rgID]; !ok || cur != rg {
+					return
+				}
 				if !rg.Ready {
 					return
 				}


### PR DESCRIPTION
Fixes two coupled correctness bugs in the `pkg/cluster` HA failover/election
state machine, both guarded by `m.mu`.

## #5245 — holdTimer leaks on RG removal

**Root cause.** `SetRGReady` arms a per-RG takeover-hold timer
(`time.AfterFunc`, `readiness.go`) whose closure captures the
`*RedundancyGroupState` and re-runs election on expiry. `UpdateConfig`'s
removal loop (`group_state.go`) `delete()`d a removed group from `m.groups`
and `m.monitorWeights` but never stopped its armed `holdTimer`. The closure
kept the removed `rg` alive and **still fired**, taking `m.mu` and running
`runElection()`/`electSingleNode()` against removed/stale state.

**Fix.** The removal loop now `Stop()`s and nils `rg.holdTimer` before
`delete(m.groups, id)`, mirroring the `readiness.go` not-ready clear site and
`Stop()`. `AfterFunc.Stop()` does **not** cancel a callback that already fired
and is parked on `m.mu`, so the closure additionally re-checks
`m.groups[rgID] == rg` after acquiring the lock (alongside the existing
`m.stopped` guard) and no-ops if the group was removed or replaced. This
staleness guard did not previously exist for the removal case; it is added as
part of this fix (the `m.stopped`-only guard covered Stop() but not RG removal).

## #5246 — ManualFailover pre-hook window races ResetFailover

**Root cause.** `ManualFailover` marks `failoverInProgress`, unlocks `m.mu` to
run the retryable pre-failover hook (which may `time.Sleep` up to the retry
timeout), re-locks, and **unconditionally** wrote `rg.ManualFailover=true` /
`State=StateSecondaryHold`. A concurrent `ResetFailover` during that unlocked
window cleared the failover, recalculated weight, and re-elected — but the
trailing `ManualFailover` write then **silently clobbered the reset**, parking
the node in `SecondaryHold` and losing the operator's reset.

**Fix.** A per-RG monotonic `failoverGen` counter (guarded by `m.mu`).
`ResetFailover` bumps it when it clears a failover. `ManualFailover` snapshots
it before unlocking for the pre-hook and, after re-locking, **abandons its
trailing write** (returns `nil`, logged at Info) if the generation changed —
leaving the reset's restored state intact. `failoverInProgress` is still
cleared on every exit path via the existing deferred `delete`, so a superseded
failover cannot wedge the next one.

`ManualFailoverBatch` shares the identical unlocked pre-hook window and the same
unconditional trailing write, so it gets the same per-member generation guard
(skip the superseded member rather than clobber it), plus a defensive nil-group
guard for a member removed from config mid-window.

## Validation

New `pkg/cluster` tests (`failover_races_5245_5246_test.go`), each confirmed
**RED on reverting its fix**:

- `TestUpdateConfig_RemovesGroup_StopsHoldTimer` / `..._TimerDoesNotElect`
  arm a group's hold timer, remove the group via `UpdateConfig`, and assert
  the timer is stopped+nil and never elects against removed state.
  **RED** when the removal-loop `Stop()`+nil is reverted (leaked non-nil timer;
  `holdTimer` assertion fires).
- `TestManualFailover_ResetDuringPreHookWins` drives a blocking pre-hook, fires
  `ResetFailover` in the unlocked window, releases the hook, and asserts the
  final state reflects the **reset** (`ManualFailover=false`, `StatePrimary`).
  **RED** when the `failoverGen` re-check is reverted (state clobbered to
  `SecondaryHold`, `ManualFailover=true`).

Local results:

- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` → exit 0
- `go test -count=1 ./pkg/cluster/...` → ok
- `go test -race -count=1` on the new tests → ok (no data races)
- `gofmt -l` on all touched files → clean

`pkg/cluster/README.md` Gotchas documents both lifecycle invariants (hold-timer
teardown on RG removal; failover-generation guard across the pre-hook window).

## Residual / notes

- `make test-failover` (loss userspace cluster) is intentionally **not** run
  here — it is gated by the parent at merge per the engineering protocol.
- The #5245 closure staleness guard (`m.groups[rgID] == rg`) is belt-and-
  suspenders for the already-fired-callback-parked-on-`m.mu` race; the primary
  fix is the `Stop()`+nil in the removal loop.

Closes #5245
Closes #5246

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi