### PR TITLE
snmp: bound the SNMPv3 authoritative EngineID to RFC 3411's 32 octets (#4917)

### DIFF
--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -167,6 +167,41 @@ requires of an authoritative engine:
   is created with `fsatomic.MkdirAllDurable`. This is slow-path (once per start),
   so per-write durability is affordable.
 
+### Authoritative EngineID derivation (RFC 3411 §5)
+
+`initEngine` derives the authoritative SNMPv3 `snmpEngineID` from the OS
+hostname via `buildEngineID`. RFC 3411 constrains `SnmpEngineID` to **5..32
+octets**; an EngineID outside that range is rejected by compliant managers,
+which breaks every v3 discovery, USM key localization, auth check, and response
+encoding that keys off the agent's identity (v2c is unaffected). The EngineID
+must also be **deterministic and stable across restarts** — a manager caches
+`(engineBoots, engineTime)` and localizes its USM keys against it.
+
+The layout is a 5-octet enterprise prefix (`0x80 0x00 0x01 0x86 0xa3` — the
+variable-length format flag over private enterprise `0x000186a3`) + a one-octet
+format selector + a payload:
+
+- **Short hostname** (`len(hostname) <= 26`, so header + hostname `<= 32`):
+  the text form `prefix || 0x04 || hostname`, where `0x04` is RFC 3411
+  "administratively assigned text". This is **bit-identical to the pre-#4917
+  construction**, so every already-deployed appliance keeps the exact EngineID
+  its USM keys and manager caches were localized against — the migration is a
+  no-op on the short path.
+- **Long hostname** (`> 26` octets): the text form would exceed 32 octets and
+  be an **invalid EngineID** (the #4917 bug — the historical code appended the
+  full unbounded hostname). It is replaced by a deterministic hashed identity
+  `prefix || 0x05 || sha256(hostname)[:26]`, exactly 32 octets. `0x05`
+  ("administratively assigned octets") honestly labels the binary hash payload
+  (`0x04` would mislabel it as text). SHA-256 over the **full** hostname keeps
+  it deterministic (same hostname → same EngineID every boot; no randomness, no
+  timestamp) and collision-resistant (distinct long hostnames → distinct
+  EngineIDs). A one-time `slog.Info` at init records the substitution so the
+  operator sees why the EngineID is not the plain hostname.
+
+The result is 5..32 octets for every input, including the empty hostname
+(6 octets) and multi-kilobyte hostnames (32 octets). Golden-vector and
+RED-on-revert coverage lives in `engineid_4917_test.go`.
+
 ## Live reconfigure (commit-time reconcile)
 
 The full SNMP subsystem is reconciled on **every** commit, not just at boot

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -2,6 +2,7 @@ package snmp
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"log/slog"
@@ -322,15 +323,98 @@ func (a *Agent) hasV3Users() bool {
 	return len(a.v3Users) > 0
 }
 
-// initEngine generates a deterministic engine ID from the hostname.
+// SNMPv3 authoritative EngineID construction (RFC 3411 §5).
+//
+// RFC 3411 constrains SnmpEngineID to 5..32 octets. An EngineID outside that
+// range is rejected by standards-compliant managers, which breaks every
+// SNMPv3 discovery, USM key localization, auth check, and response encoding
+// that depends on the agent's identity (v2c is unaffected). The historical
+// construction (a 6-octet header followed by the FULL, unbounded OS hostname)
+// silently produced an INVALID >32-octet EngineID for any hostname longer than
+// 26 bytes (#4917).
+const (
+	// snmpEngineIDMaxLen is the RFC 3411 SnmpEngineID upper bound (octets).
+	snmpEngineIDMaxLen = 32
+
+	// engineIDFormatText (RFC 3411 §5, format 3 "administratively assigned
+	// text") labels the payload as TEXT. Kept for the short-hostname form so
+	// the EngineID stays bit-identical to the pre-#4917 construction and
+	// already-localized USM keys / manager caches on deployed appliances
+	// remain valid.
+	engineIDFormatText = 0x04
+
+	// engineIDFormatOctets (RFC 3411 §5, format 4 "administratively assigned
+	// octets") labels the payload as OCTETS. Used for the hashed long-hostname
+	// form so the format octet honestly describes a binary (non-text) SHA-256
+	// payload — 0x04 would mislabel the hash as text.
+	engineIDFormatOctets = 0x05
+)
+
+// engineIDPrefix is the 5-octet enterprise header: the RFC 3411 variable-length
+// format flag (high bit 0x80 set on the first octet) over private enterprise
+// number 0x000186a3. The sixth octet — the format selector — is appended per
+// form (text vs octets) by buildEngineID. Read-only after init; buildEngineID
+// copies it (append from a fresh backing array) and never mutates it.
+var engineIDPrefix = []byte{0x80, 0x00, 0x01, 0x86, 0xa3}
+
+// buildEngineID derives a deterministic, RFC 3411-valid (5..32 octet)
+// authoritative SNMPv3 EngineID from the OS hostname. The EngineID must be
+// stable across restarts because a manager caches our (engineBoots, engineTime)
+// and localizes its USM keys against it.
+//
+//   - Short hostname (header + hostname <= 32 octets, i.e. len(hostname) <= 26):
+//     the historical TEXT form engineIDPrefix || 0x04 || hostname, returned
+//     BIT-IDENTICAL to the pre-#4917 construction. This is the migration guard:
+//     every currently-working appliance keeps the exact EngineID it localized
+//     its keys against, so no manager cache or USM key is invalidated.
+//   - Long hostname (> 26 octets): the text form would exceed 32 octets and be
+//     an INVALID EngineID (rejected by compliant managers — the #4917 bug). It
+//     is replaced by a deterministic hashed identity engineIDPrefix || 0x05 ||
+//     sha256(hostname)[:26], exactly 32 octets. SHA-256 over the FULL hostname
+//     is deterministic (same hostname -> same EngineID every boot, no
+//     randomness/timestamp) and collision-resistant (distinct long hostnames ->
+//     distinct EngineIDs). The 0x05 (octets) format honestly labels the binary
+//     payload.
+//
+// The result is 5..32 octets for ALL inputs, including empty (6 octets) and
+// multi-kilobyte (32 octets) hostnames.
+func buildEngineID(hostname string) []byte {
+	headerLen := len(engineIDPrefix) + 1 // enterprise prefix + one format octet
+	if len(hostname) <= snmpEngineIDMaxLen-headerLen {
+		id := make([]byte, 0, headerLen+len(hostname))
+		id = append(id, engineIDPrefix...)
+		id = append(id, engineIDFormatText)
+		id = append(id, hostname...)
+		return id
+	}
+	sum := sha256.Sum256([]byte(hostname))
+	hashLen := snmpEngineIDMaxLen - headerLen // 26 -> total exactly 32 octets
+	id := make([]byte, 0, snmpEngineIDMaxLen)
+	id = append(id, engineIDPrefix...)
+	id = append(id, engineIDFormatOctets)
+	id = append(id, sum[:hashLen]...)
+	return id
+}
+
+// initEngine generates a deterministic, RFC 3411-bounded engine ID from the
+// hostname (see buildEngineID). A hostname longer than 26 octets no longer
+// yields an invalid >32-octet EngineID (#4917); the hashed identity is used
+// instead, and the substitution is logged once so the operator sees why the
+// EngineID is not the plain hostname.
 func (a *Agent) initEngine() {
 	hostname, _ := os.Hostname()
 	if hostname == "" {
 		hostname = "xpf"
 	}
-	// RFC 3411 format: enterprise(4) + text(3) = 0x80 | len, enterprise OID, format byte, text.
-	// Simplified: use 0x80 0x00 0x00 0x00 0x01 (enterprise=1) + 0x04 (text) + hostname bytes.
-	a.engineID = append([]byte{0x80, 0x00, 0x01, 0x86, 0xa3, 0x04}, []byte(hostname)...)
+	a.engineID = buildEngineID(hostname)
+	if len(hostname) > snmpEngineIDMaxLen-(len(engineIDPrefix)+1) {
+		// One-time state event (allowed by the logging rules — not in a loop):
+		// the text EngineID would exceed the RFC 3411 32-octet cap, so a stable
+		// hashed identity is used. This is the startup signal the #4917 issue
+		// noted was missing.
+		slog.Info("SNMP: hostname exceeds the RFC 3411 32-octet text EngineID cap; using a stable hashed SNMPv3 EngineID",
+			"hostname_len", len(hostname), "engineid_len", len(a.engineID))
+	}
 	a.engineBoots = a.loadAndIncrementEngineBoots()
 }
 

--- a/pkg/snmp/engineid_4917_test.go
+++ b/pkg/snmp/engineid_4917_test.go
@@ -1,0 +1,115 @@
+package snmp
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"strings"
+	"testing"
+)
+
+// TestBuildEngineID_GoldenShortHost pins the EXACT byte sequence a short
+// (<=26 octet) hostname must produce: the historical text form
+// prefix(5) || 0x04 || hostname. This is the #4917 migration guard — it goes
+// RED if the short path is ever changed, because changing it would invalidate
+// every already-localized USM key and manager cache on deployed appliances.
+func TestBuildEngineID_GoldenShortHost(t *testing.T) {
+	const host = "fw1.example.net" // 15 octets, well under the 26-octet cap
+	want := []byte{
+		0x80, 0x00, 0x01, 0x86, 0xa3, // enterprise prefix
+		0x04, // format: administratively assigned text
+		'f', 'w', '1', '.', 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'n', 'e', 't',
+	}
+	got := buildEngineID(host)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("buildEngineID(%q) = % x, want % x", host, got, want)
+	}
+	if len(got) < 5 || len(got) > snmpEngineIDMaxLen {
+		t.Fatalf("golden EngineID length %d out of RFC 3411 range 5..32", len(got))
+	}
+}
+
+// TestBuildEngineID_Boundary26 verifies the largest hostname that still fits
+// the text form: 26 octets -> header(6) + 26 = 32 octets, still 0x04 text form.
+func TestBuildEngineID_Boundary26(t *testing.T) {
+	host := strings.Repeat("a", 26)
+	got := buildEngineID(host)
+	if len(got) != snmpEngineIDMaxLen {
+		t.Fatalf("26-octet hostname: EngineID length %d, want %d", len(got), snmpEngineIDMaxLen)
+	}
+	if got[5] != engineIDFormatText {
+		t.Fatalf("26-octet hostname: format octet 0x%02x, want text 0x%02x", got[5], engineIDFormatText)
+	}
+	// Still the plain-text form: prefix || 0x04 || hostname.
+	want := append(append(append([]byte{}, engineIDPrefix...), engineIDFormatText), []byte(host)...)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("26-octet hostname: EngineID % x, want text form % x", got, want)
+	}
+}
+
+// TestBuildEngineID_HashedLongHosts covers every >26-octet case. These
+// assertions go RED if buildEngineID is reverted to the unbounded
+// `prefix(6) || hostname` append: a 27-octet hostname then yields 33 octets and
+// the len <= 32 check below fails; a 64-octet hostname yields 70 octets, etc.
+func TestBuildEngineID_HashedLongHosts(t *testing.T) {
+	for _, n := range []int{27, 64, 300, 4096} {
+		host := strings.Repeat("h", n)
+		got := buildEngineID(host)
+
+		// RFC 3411 bound: 5..32 octets. len > 32 is exactly the #4917 bug and
+		// is the RED-on-revert assertion.
+		if len(got) < 5 || len(got) > snmpEngineIDMaxLen {
+			t.Fatalf("hostname len %d: EngineID length %d out of RFC 3411 range 5..32 (revert regression)", n, len(got))
+		}
+		if len(got) != snmpEngineIDMaxLen {
+			t.Fatalf("hostname len %d: hashed EngineID length %d, want exactly %d", n, len(got), snmpEngineIDMaxLen)
+		}
+		// Hashed form: prefix || 0x05 (octets) || sha256(hostname)[:26].
+		if !bytes.Equal(got[:5], engineIDPrefix) {
+			t.Fatalf("hostname len %d: prefix % x, want % x", n, got[:5], engineIDPrefix)
+		}
+		if got[5] != engineIDFormatOctets {
+			t.Fatalf("hostname len %d: format octet 0x%02x, want octets 0x%02x", n, got[5], engineIDFormatOctets)
+		}
+		sum := sha256.Sum256([]byte(host))
+		if !bytes.Equal(got[6:], sum[:snmpEngineIDMaxLen-6]) {
+			t.Fatalf("hostname len %d: payload is not sha256(hostname)[:26]", n)
+		}
+	}
+}
+
+// TestBuildEngineID_EmptyAndShortBounds verifies the lower bound holds for the
+// empty and single-octet hostnames (>= 5 octets, still text form).
+func TestBuildEngineID_EmptyAndShortBounds(t *testing.T) {
+	for _, host := range []string{"", "x"} {
+		got := buildEngineID(host)
+		if len(got) < 5 || len(got) > snmpEngineIDMaxLen {
+			t.Fatalf("hostname %q: EngineID length %d out of RFC 3411 range 5..32", host, len(got))
+		}
+		if got[5] != engineIDFormatText {
+			t.Fatalf("hostname %q: format octet 0x%02x, want text 0x%02x", host, got[5], engineIDFormatText)
+		}
+	}
+}
+
+// TestBuildEngineID_LongHostUniqueness verifies two distinct long hostnames
+// produce distinct EngineIDs (SHA-256 collision resistance), so different
+// appliances that both exceed the cap are not aliased to one identity.
+func TestBuildEngineID_LongHostUniqueness(t *testing.T) {
+	a := buildEngineID(strings.Repeat("a", 40) + "-node-alpha")
+	b := buildEngineID(strings.Repeat("a", 40) + "-node-bravo")
+	if bytes.Equal(a, b) {
+		t.Fatal("distinct long hostnames produced identical EngineIDs")
+	}
+}
+
+// TestBuildEngineID_Deterministic verifies the same long hostname yields the
+// same EngineID on every call (stable across restarts: no randomness, no
+// timestamp).
+func TestBuildEngineID_Deterministic(t *testing.T) {
+	host := strings.Repeat("determinism-check.", 20) // ~360 octets
+	first := buildEngineID(host)
+	second := buildEngineID(host)
+	if !bytes.Equal(first, second) {
+		t.Fatal("buildEngineID is not deterministic for a fixed hostname")
+	}
+}


### PR DESCRIPTION
## Problem (#4917)

`initEngine` (`pkg/snmp/agent.go`) built the authoritative SNMPv3 EngineID as a
6-octet header (`0x80 0x00 0x01 0x86 0xa3` enterprise prefix + `0x04` text
format) followed by the **full, unbounded OS hostname**:

```go
a.engineID = append([]byte{0x80,0x00,0x01,0x86,0xa3,0x04}, []byte(hostname)...)
```

SNMP-FRAMEWORK-MIB (RFC 3411 §5) constrains `SnmpEngineID` to **5..32 octets**.
Any hostname longer than 26 bytes (`6 + 26 = 32`) therefore produced an
**invalid oversized (>32-octet) EngineID**. Standards-compliant managers reject
it, so every SNMPv3 discovery, USM key localization, auth check, and response
encoding used an unusable identity and **all v3 monitoring silently failed**
(v2c kept working) — with **no startup error** explaining the incompatibility.

## Fix

`buildEngineID(hostname)` derives a deterministic, RFC 3411-valid (5..32 octet)
EngineID. The EngineID is consumed only as an opaque byte slice (USM key
localization + response/discovery encoding), so only the construction changes.

- **Short hostname (`<= 26` octets)** — the historical text form
  `prefix || 0x04 || hostname`, returned **BIT-IDENTICAL** to the pre-#4917
  construction. This is the **migration guard**: every currently-working
  appliance keeps the exact EngineID its USM keys and manager caches were
  localized against, so nothing already working is invalidated. This path is
  untouched.
- **Long hostname (`> 26` octets)** — the text form would exceed 32 octets
  (already broken today, so any compliant replacement is strictly better). It is
  replaced by a stable hashed identity `prefix || 0x05 || sha256(hostname)[:26]`,
  **exactly 32 octets**. SHA-256 over the full hostname is deterministic (same
  hostname → same EngineID every boot; no randomness/timestamp) and
  collision-resistant (distinct long hostnames → distinct EngineIDs).

### Format-octet choice (RFC 3411 §5)

The hashed form uses format `0x05` ("administratively assigned **octets**")
rather than `0x04` ("administratively assigned **text**"), so the format octet
**honestly describes the binary hash payload** instead of mislabeling it as
text.

### Startup visibility

When the hostname exceeds the cap and the hashed form is used, a **one-time**
`slog.Info` at init records the substitution — the startup signal the issue
noted was missing. It fires once (state-transition event), never in a loop.

## Tests (`pkg/snmp/engineid_4917_test.go`, fail-on-revert)

- **Golden short-host vector** — pins the exact bytes of `prefix || 0x04 ||
  "fw1.example.net"`; goes RED if the migration-safe short path is ever changed.
- **26-octet boundary** — still text form, `len == 32`.
- **27 / 64 / 300 / 4096-octet** — hashed form, `len == 32`, valid (`>= 5`),
  payload == `sha256(hostname)[:26]`.
- **Empty / 1-octet** — still `>= 5` octets, text form.
- **Uniqueness** — two distinct long hostnames → distinct EngineIDs.
- **Determinism** — same long hostname twice → identical EngineIDs.

**RED-on-revert verified:** reverting `buildEngineID` to the unbounded
`append([]byte{0x80,…,0x04}, hostname...)` turns the >26-octet cases RED — a
27-octet hostname yields length 33, failing the `len <= 32` assertion
(`hostname len 27: EngineID length 33 out of RFC 3411 range 5..32`). The golden
short-host vector stays green under the revert (it is invariant on the short
path).

## Docs

`pkg/snmp/README.md` gains an **"Authoritative EngineID derivation (RFC 3411
§5)"** section covering the 32-octet bound, the short/long forms, the
format-octet choice, and the migration-preserves-short-IDs note.

## Validation

- `go build ./...` — exit 0
- `go test -count=1 ./pkg/snmp/...` — ok
- `gofmt -l` clean on the touched Go files

Closes #4917

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi