### PR TITLE
feeds: byte-bound the invalid-line sample, not just its count (#4922)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -44599,3 +44599,7 @@ top.
 - **Timestamp**: 2026-07-10
   **Action**: #4926 — security-events `limit` REST param fail-open→fail-closed. Replaced lenient `queryInt(r,"limit",50)`+silent 10000-clamp in `eventsHandler` with strict `queryIntStrict` (400 on malformed/negative/non-canonical) + explicit >10000 → HTTP 400, mirroring the sibling `zone` filter. Added fail-on-revert handler test + README fail-closed doc.
   **File(s)**: pkg/api/security.go, pkg/api/rest_events_limit_failclosed_4926_test.go, pkg/api/README.md
+
+- **Timestamp**: 2026-07-10
+  **Action**: #4922 — dynamic-address feed invalid-line sample was COUNT-bounded (maxInvalidSample=5) but not BYTE-bounded; scanner admits ~1 MiB malformed lines, so one feed could retain ~5 MiB verbatim garbage + emit multi-MB slog records. Fix: bound each retained sample entry at the retention point (parseFeed) to a strconv.Quote-escaped first-256-byte prefix + original byte-length annotation (maxInvalidSampleBytes/EntryBytes/TotalBytes); installSnapshot/AllFeeds/slog.Warn all inherit the bounded, escape-safe form. Added 6 fail-on-revert tests (all RED when reverted to verbatim append) + README byte-cap/metadata docs.
+  **File(s)**: pkg/feeds/feeds.go, pkg/feeds/feeds_samplecap_4922_test.go, pkg/feeds/feeds_test.go, pkg/feeds/README.md

--- a/pkg/feeds/README.md
+++ b/pkg/feeds/README.md
@@ -80,7 +80,7 @@ applies a *retain-last-good* policy rather than installing a partial/empty set:
   mixes valid prefixes with malformed lines still installs the valid prefixes
   (a clean body is bit-identical to before), but the skipped invalid lines are
   no longer *silent*: `parseFeed` counts every malformed (non-comment, non-CIDR,
-  non-IP) line and keeps a bounded verbatim sample (`maxInvalidSample`, 5).
+  non-IP) line and keeps a bounded sample (`maxInvalidSample`, 5).
   `FeedInfo` surfaces `InvalidLines`, `InvalidSample`, and `Degraded`
   (`InvalidLines > 0`); `show security dynamic-address` prints a `DEGRADED`
   line. A degraded install logs one `slog.Warn` on the content change (not every
@@ -90,6 +90,24 @@ applies a *retain-last-good* policy rather than installing a partial/empty set:
   published feed instead of it reporting a clean success. The markers are
   cleared when a later clean body installs, and on a `hold-interval`
   drop-to-empty.
+- **the invalid-line sample is byte-bounded, not just count-bounded (#4922).**
+  The scanner admits a malformed line up to `maxLineBytes` (1 MiB), so the
+  pre-#4922 code — which retained the first 5 offenders *verbatim* — let one
+  feed pin ~5 MiB of garbage in memory (kept in `feedState`, deep-copied by
+  `AllFeeds`) and emit multi-MB `slog.Warn` records on the degraded warning, all
+  within the advertised feed limits. Each retained sample entry is now bounded
+  at the retention point (in `parseFeed`, so `installSnapshot`/`AllFeeds`/the
+  `slog.Warn` all inherit the bounded form): the offending line is truncated to
+  its first `maxInvalidSampleBytes` (256) raw bytes, `strconv.Quote`-escaped so
+  NULs / control bytes / newlines / invalid UTF-8 render as printable `\x..`
+  escapes (never raw control bytes into a log or CLI show), and a truncated line
+  is annotated with its **original byte length** (`… (<n> bytes total)`) so an
+  operator can still triage "line was 1 MiB, starts with `<prefix>`" without
+  retaining the whole thing. A short line (< the cap) is retained
+  quoted-but-otherwise-intact. A per-entry ceiling (`maxInvalidSampleEntryBytes`)
+  and an aggregate budget (`maxInvalidSampleTotalBytes`, the count cap × the
+  per-entry cap) are the hard ceilings; the existing count bound (5) and
+  changed-degraded-only logging are unchanged.
 
 `FeedInfo` carries additive status fields (`LastSuccess`, `LastError`,
 `StaleSince`, `Hash`) alongside the legacy `URL`/`Prefixes`/`LastFetch`.
@@ -114,9 +132,13 @@ applies a *retain-last-good* policy rather than installing a partial/empty set:
 - Feed bodies are parsed line-by-line, one CIDR per line. Comment lines
   (`#`, `//`) and blanks are skipped silently. A malformed non-comment line
   is skipped but **counted** (`InvalidLines`/`InvalidSample`, marks the feed
-  `Degraded`, #2993) — it is no longer a silent drop. A *scanner-level* error
-  (overlong line / read error) is NOT skipped: it fails the whole fetch
-  (retain last-good).
+  `Degraded`, #2993) — it is no longer a silent drop. Each `InvalidSample`
+  entry is a byte-bounded, `strconv.Quote`-escaped prefix (≤
+  `maxInvalidSampleBytes` raw bytes) plus the original byte length, NOT the
+  verbatim line (#4922) — so a hostile provider serving near-1-MiB malformed
+  lines cannot pin megabytes in memory or emit multi-MB log records. A
+  *scanner-level* error (overlong line / read error) is NOT skipped: it fails
+  the whole fetch (retain last-good).
 - A successful fetch always replaces the snapshot and stamps success, but
   the `onUpdate` recompile fires only when the canonical content hash
   changes — not on every fetch and not merely on a count change.

--- a/pkg/feeds/feeds.go
+++ b/pkg/feeds/feeds.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -34,9 +35,42 @@ const maxLineBytes = 1 << 20 // 1 MiB
 
 // maxInvalidSample bounds how many distinct malformed lines are retained for
 // operator display (#2993). A degraded feed records the total invalid-line
-// count plus a small verbatim sample so an operator can identify the bad lines
-// without the sample growing unbounded for a wholesale-garbage body.
+// count plus a small sample so an operator can identify the bad lines without
+// the sample growing unbounded for a wholesale-garbage body. This is a COUNT
+// bound; each retained entry is additionally BYTE-bounded (see
+// maxInvalidSampleBytes, #4922).
 const maxInvalidSample = 5
+
+// maxInvalidSampleBytes caps the RAW byte prefix of a single malformed line
+// retained in the sample (#4922). A malformed line may be up to maxLineBytes
+// (1 MiB) long; the pre-#4922 code appended the whole line VERBATIM, so a
+// hostile/broken provider serving near-1-MiB malformed lines could pin ~5 MiB
+// of garbage in memory (retained in feedState, deep-copied by AllFeeds) and emit
+// multi-MB slog records on the degraded-feed warning — all within the advertised
+// feed limits. We now keep only the first maxInvalidSampleBytes bytes of each
+// offending line, escaped to a printable form, plus its true byte length, so an
+// operator can still triage "line was 1 MiB, starts with <prefix>" without
+// retaining the whole thing.
+const maxInvalidSampleBytes = 256
+
+// maxInvalidSampleEntryBytes is the HARD per-entry ceiling on a retained sample
+// string AFTER escaping + length annotation (#4922). strconv.Quote can expand
+// each raw byte to a 4-char \xNN escape, so a maxInvalidSampleBytes-byte prefix
+// quotes to at most 4*maxInvalidSampleBytes+2 chars; the truncation annotation
+// (" … (<n> bytes total)") adds a small bounded suffix. This constant is the
+// assertion anchor for the #4922 fail-on-revert test and the defensive final
+// clamp in boundInvalidSample.
+const maxInvalidSampleEntryBytes = 4*maxInvalidSampleBytes + 64
+
+// maxInvalidSampleTotalBytes is a belt-and-suspenders ceiling on the SUM of the
+// retained sample entry lengths across all maxInvalidSample entries (#4922).
+// The per-entry cap already bounds each string; this aggregate budget is a live
+// second guard so even a future change that loosens the per-entry cap cannot
+// grow the retained sample without bound. In the current tuning it equals the
+// count cap times the per-entry cap, so the worst legitimate case (5 fully
+// escaped 256-byte prefixes) fits exactly and the gate degrades gracefully only
+// if the per-entry cap is later raised.
+const maxInvalidSampleTotalBytes = maxInvalidSample * maxInvalidSampleEntryBytes
 
 // maxFeedBodyBytes caps the total HTTP response body a single feed fetch will
 // buffer (#3934). Without a cap, a feed server that returns a huge (or
@@ -93,8 +127,10 @@ type feedState struct {
 	// valid + invalid lines: the valid prefixes are installed but the skipped
 	// invalid lines are no longer silent. invalidLines counts every malformed
 	// line in the last successfully-installed body; invalidSample keeps up to
-	// maxInvalidSample verbatim offenders for display. Both are zero/nil for a
-	// clean body (no behaviour change) and are cleared on a drop-to-empty.
+	// maxInvalidSample offenders for display, each a byte-bounded, escaped
+	// prefix + length annotation (#4922), NOT the verbatim line. Both are
+	// zero/nil for a clean body (no behaviour change) and are cleared on a
+	// drop-to-empty.
 	invalidLines  int
 	invalidSample []string
 
@@ -421,8 +457,10 @@ type FeedInfo struct {
 
 	// Parse-quality of the installed snapshot (#2993). InvalidLines is the
 	// number of malformed lines skipped while parsing the last
-	// successfully-installed body; InvalidSample is a bounded verbatim sample
-	// of those lines. Degraded is true when InvalidLines > 0 — the feed
+	// successfully-installed body; InvalidSample is a bounded sample of those
+	// lines — each entry is a byte-bounded, escaped prefix plus the original
+	// line's byte length (#4922), safe to print (no raw control bytes) and never
+	// the full verbatim line. Degraded is true when InvalidLines > 0 — the feed
 	// installed a PARTIAL set (some published lines were dropped), which an
 	// operator should investigate even though valid prefixes are enforced.
 	InvalidLines  int
@@ -454,8 +492,8 @@ type fetchResult struct {
 	hash     [32]byte
 
 	// invalidLines counts malformed lines skipped during parse; invalidSample
-	// holds up to maxInvalidSample verbatim offenders (#2993). A clean body
-	// leaves both zero/nil.
+	// holds up to maxInvalidSample byte-bounded, escaped offenders (#2993,
+	// byte-bounded in #4922). A clean body leaves both zero/nil.
 	invalidLines  int
 	invalidSample []string
 }
@@ -533,6 +571,7 @@ func parseFeed(r io.Reader) (fetchResult, error) {
 	var prefixes []string
 	var invalidLines int
 	var invalidSample []string
+	var invalidSampleBytes int // running total of retained sample-entry lengths (#4922)
 	// Cap the total bytes buffered. Read one byte past the cap so a body that
 	// exactly fills the cap is accepted while anything larger is detected.
 	cr := &countingReader{r: io.LimitReader(r, maxFeedBodyBytes+1)}
@@ -560,9 +599,21 @@ func parseFeed(r io.Reader) (fetchResult, error) {
 			// skip it (the published valid prefixes are installed), but it is no
 			// longer silent: count it and keep a bounded sample so the fetch is
 			// observably degraded rather than reporting a clean success.
+			//
+			// #4922: retain only a BYTE-bounded, escaped prefix of each offender
+			// (not the verbatim line, which the scanner admits up to
+			// maxLineBytes = 1 MiB). Bounding here, at the retention point, means
+			// installSnapshot, AllFeeds' deep copy, and the degraded-feed
+			// slog.Warn all inherit the small, safe form — a hostile provider
+			// serving near-1-MiB garbage lines can no longer pin megabytes in
+			// memory or emit multi-MB log records. Both a COUNT cap
+			// (maxInvalidSample) and an aggregate BYTE budget
+			// (maxInvalidSampleTotalBytes) gate the append.
 			invalidLines++
-			if len(invalidSample) < maxInvalidSample {
-				invalidSample = append(invalidSample, line)
+			if len(invalidSample) < maxInvalidSample && invalidSampleBytes < maxInvalidSampleTotalBytes {
+				entry := boundInvalidSample(line)
+				invalidSample = append(invalidSample, entry)
+				invalidSampleBytes += len(entry)
 			}
 		}
 		// Entry cap: bail as soon as the parsed set exceeds the per-feed limit
@@ -597,6 +648,39 @@ func parseFeed(r io.Reader) (fetchResult, error) {
 		invalidLines:  invalidLines,
 		invalidSample: invalidSample,
 	}, nil
+}
+
+// boundInvalidSample renders a malformed feed line into the small, safe form
+// retained for the degraded-feed sample (#4922). It:
+//
+//   - truncates the line to at most maxInvalidSampleBytes RAW bytes,
+//   - escapes the (possibly truncated) prefix with strconv.Quote so NUL,
+//     newline, control bytes, and invalid UTF-8 become printable \x.. / \n
+//     escapes — never raw control bytes into a slog record or a CLI show,
+//   - annotates a truncated line with its ORIGINAL byte length so an operator
+//     can still see "this line was 1 MiB, starts with <prefix>".
+//
+// A short line (< the byte cap) is returned quoted-but-otherwise-intact, so the
+// diagnostic value for the common stray-text case is preserved. A final
+// defensive clamp guarantees the result never exceeds maxInvalidSampleEntryBytes
+// even if strconv.Quote's expansion is looser than assumed; the clamp keeps the
+// string printable (it only trims already-escaped ASCII).
+func boundInvalidSample(line string) string {
+	orig := len(line)
+	prefix := line
+	truncated := false
+	if orig > maxInvalidSampleBytes {
+		prefix = line[:maxInvalidSampleBytes]
+		truncated = true
+	}
+	out := strconv.Quote(prefix)
+	if truncated {
+		out = fmt.Sprintf("%s … (%d bytes total)", out, orig)
+	}
+	if len(out) > maxInvalidSampleEntryBytes {
+		out = out[:maxInvalidSampleEntryBytes]
+	}
+	return out
 }
 
 // canonicalize dedups and sorts the prefix list. Input prefixes are already in

--- a/pkg/feeds/feeds_samplecap_4922_test.go
+++ b/pkg/feeds/feeds_samplecap_4922_test.go
@@ -1,0 +1,206 @@
+package feeds
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// This file is the #4922 fail-on-revert suite. The dynamic-address feed
+// invalid-line sample was bounded by COUNT (maxInvalidSample = 5) but NOT by
+// BYTES: the scanner admits malformed lines up to maxLineBytes (1 MiB), parseFeed
+// retained the first 5 VERBATIM, installSnapshot/AllFeeds kept+deep-copied them,
+// and a changed degraded feed logged the full slice. One feed could therefore
+// pin ~5 MiB of verbatim garbage and emit multi-MB slog records — all within the
+// advertised feed limits. The fix caps each retained entry to a small escaped
+// prefix (maxInvalidSampleBytes) plus the original byte length, applied at the
+// retention point so every downstream copy/log inherits the bounded form.
+
+// isPrintableASCII reports whether s contains only printable ASCII (0x20-0x7e).
+// strconv.Quote output is always printable ASCII, so a correctly-escaped sample
+// entry passes even when the source line held NULs / control bytes / invalid
+// UTF-8.
+func isPrintableASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 || s[i] > 0x7e {
+			return false
+		}
+	}
+	return true
+}
+
+// bigMalformedLine builds a malformed (non-CIDR, non-IP) line of n bytes that is
+// safely under the scanner token cap (so it is admitted and reaches the sample
+// retention path rather than tripping bufio.ErrTooLong).
+func bigMalformedLine(n int) string {
+	if n >= maxLineBytes {
+		panic("bigMalformedLine would trip the scanner cap")
+	}
+	return strings.Repeat("x", n)
+}
+
+// TestInvalidSampleBigLineByteBounded is the core #4922 fail-on-revert test: a
+// near-1-MiB malformed line must be retained as a short escaped prefix, NOT the
+// verbatim ~1 MiB line. Reverting to `append(invalidSample, line)` makes the
+// entry ~1 MiB and turns the len assertion RED.
+func TestInvalidSampleBigLineByteBounded(t *testing.T) {
+	const bigLen = maxLineBytes - 1024 // ~1 MiB, safely under the scanner cap
+	body := "192.0.2.0/24\n" + bigMalformedLine(bigLen) + "\n"
+
+	res, err := parseFeed(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("parseFeed error: %v", err)
+	}
+	if res.invalidLines != 1 {
+		t.Fatalf("invalidLines = %d, want 1", res.invalidLines)
+	}
+	if len(res.invalidSample) != 1 {
+		t.Fatalf("invalidSample len = %d, want 1", len(res.invalidSample))
+	}
+	entry := res.invalidSample[0]
+	if len(entry) > maxInvalidSampleEntryBytes {
+		t.Fatalf("retained sample entry is %d bytes, want <= %d (verbatim ~%d-byte line was NOT byte-bounded)",
+			len(entry), maxInvalidSampleEntryBytes, bigLen)
+	}
+	// Sanity: the entry is dramatically smaller than the original line.
+	if len(entry) >= bigLen/10 {
+		t.Fatalf("retained entry %d bytes is not a small prefix of the %d-byte line", len(entry), bigLen)
+	}
+}
+
+// TestInvalidSampleOriginalLengthRecorded confirms the retained record carries
+// the TRUE original byte length even though only a short prefix is kept, so an
+// operator can triage "line was N bytes, starts with <prefix>".
+func TestInvalidSampleOriginalLengthRecorded(t *testing.T) {
+	const bigLen = maxLineBytes - 1024
+	body := "192.0.2.0/24\n" + bigMalformedLine(bigLen) + "\n"
+
+	res, err := parseFeed(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("parseFeed error: %v", err)
+	}
+	entry := res.invalidSample[0]
+	wantMeta := fmt.Sprintf("%d bytes total", bigLen)
+	if !strings.Contains(entry, wantMeta) {
+		t.Fatalf("retained entry %q does not record the original byte length %q", entry, wantMeta)
+	}
+}
+
+// TestInvalidSampleAggregateBounded confirms the count cap (<= 5 entries) AND the
+// aggregate byte budget both hold when a body serves many near-1-MiB malformed
+// lines, and that every individual entry is per-entry bounded.
+func TestInvalidSampleAggregateBounded(t *testing.T) {
+	const bigLen = maxLineBytes - 1024
+	var b strings.Builder
+	b.WriteString("192.0.2.0/24\n") // one valid prefix so parse succeeds
+	const garbage = 12              // more than maxInvalidSample
+	for i := 0; i < garbage; i++ {
+		b.WriteString(bigMalformedLine(bigLen))
+		b.WriteByte('\n')
+	}
+
+	res, err := parseFeed(strings.NewReader(b.String()))
+	if err != nil {
+		t.Fatalf("parseFeed error: %v", err)
+	}
+	if res.invalidLines != garbage {
+		t.Errorf("invalidLines = %d, want %d", res.invalidLines, garbage)
+	}
+	if len(res.invalidSample) > maxInvalidSample {
+		t.Fatalf("invalidSample retained %d entries, want <= %d (count cap)", len(res.invalidSample), maxInvalidSample)
+	}
+	total := 0
+	for i, s := range res.invalidSample {
+		if len(s) > maxInvalidSampleEntryBytes {
+			t.Errorf("entry %d is %d bytes, want <= %d", i, len(s), maxInvalidSampleEntryBytes)
+		}
+		total += len(s)
+	}
+	if total > maxInvalidSampleTotalBytes {
+		t.Fatalf("aggregate retained sample = %d bytes, want <= %d", total, maxInvalidSampleTotalBytes)
+	}
+}
+
+// TestInvalidSampleEscapesControlBytes confirms a malformed line carrying NULs,
+// control bytes, and invalid UTF-8 is escaped to a printable-ASCII form — no raw
+// control bytes ever reach a slog record or CLI show.
+func TestInvalidSampleEscapesControlBytes(t *testing.T) {
+	nasty := "bad\x00\x01\x02\x7f\xff\xfeline" // NUL, control, invalid UTF-8
+	body := "192.0.2.0/24\n" + nasty + "\n"
+
+	res, err := parseFeed(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("parseFeed error: %v", err)
+	}
+	if len(res.invalidSample) != 1 {
+		t.Fatalf("invalidSample len = %d, want 1", len(res.invalidSample))
+	}
+	entry := res.invalidSample[0]
+	if strings.ContainsRune(entry, 0) {
+		t.Errorf("retained entry contains a raw NUL byte: %q", entry)
+	}
+	if !isPrintableASCII(entry) {
+		t.Errorf("retained entry contains non-printable bytes: %q", entry)
+	}
+	// The escaped form should still be a valid quoted string we can round-trip.
+	if _, uerr := strconv.Unquote(entry); uerr != nil {
+		t.Errorf("retained entry is not a valid quoted string: %q (%v)", entry, uerr)
+	}
+}
+
+// TestInvalidSampleShortLinePreserved is the no-over-truncation guard: a short
+// malformed line (< the byte cap) is retained quoted-but-otherwise-intact, so the
+// diagnostic value for the common stray-text case is preserved.
+func TestInvalidSampleShortLinePreserved(t *testing.T) {
+	body := "192.0.2.0/24\nnot-an-ip-just-text\n"
+
+	res, err := parseFeed(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("parseFeed error: %v", err)
+	}
+	if len(res.invalidSample) != 1 {
+		t.Fatalf("invalidSample len = %d, want 1", len(res.invalidSample))
+	}
+	entry := res.invalidSample[0]
+	if want := strconv.Quote("not-an-ip-just-text"); entry != want {
+		t.Fatalf("short line retained as %q, want %q (no over-truncation)", entry, want)
+	}
+	// A short line carries no byte-length annotation (its size is self-evident).
+	if strings.Contains(entry, "bytes total") {
+		t.Errorf("short line unexpectedly annotated with a byte length: %q", entry)
+	}
+}
+
+// TestInvalidSampleBoundedThroughAllFeeds proves the bound is applied at the
+// retention point, so installSnapshot's store AND AllFeeds' deep copy (the paths
+// that feed the degraded slog.Warn and the `show security dynamic-address`
+// display) only ever see the small escaped form — the memory-retention half of
+// the #4922 bug, not just the log site.
+func TestInvalidSampleBoundedThroughAllFeeds(t *testing.T) {
+	const bigLen = maxLineBytes - 1024
+	srv := &bodyServer{}
+	srv.set("192.0.2.0/24\n"+bigMalformedLine(bigLen)+"\n", http.StatusOK)
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	m := New(func() {})
+	fs := m.newFeed("huge", ts.URL, time.Hour)
+	m.fetchFeed(context.Background(), fs)
+
+	info := m.AllFeeds()["huge"]
+	if !info.Degraded || info.InvalidLines != 1 {
+		t.Fatalf("feed not degraded as expected: %+v", info)
+	}
+	if len(info.InvalidSample) != 1 {
+		t.Fatalf("InvalidSample len = %d, want 1", len(info.InvalidSample))
+	}
+	if got := len(info.InvalidSample[0]); got > maxInvalidSampleEntryBytes {
+		t.Fatalf("AllFeeds surfaced a %d-byte sample entry, want <= %d (retention-point bound not inherited)",
+			got, maxInvalidSampleEntryBytes)
+	}
+}

--- a/pkg/feeds/feeds_test.go
+++ b/pkg/feeds/feeds_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -163,8 +164,11 @@ func TestMixedFeedDegradedStatus(t *testing.T) {
 	if !info.Degraded {
 		t.Error("Degraded = false despite a skipped invalid line; want true")
 	}
-	if len(info.InvalidSample) != 1 || info.InvalidSample[0] != "not-an-ip" {
-		t.Errorf("InvalidSample = %v, want [not-an-ip]", info.InvalidSample)
+	// #4922: the retained sample entry is an escaped (quoted) prefix, not the
+	// verbatim line. A short line is quoted-but-otherwise-intact.
+	wantSample := strconv.Quote("not-an-ip")
+	if len(info.InvalidSample) != 1 || info.InvalidSample[0] != wantSample {
+		t.Errorf("InvalidSample = %v, want [%s]", info.InvalidSample, wantSample)
 	}
 }
 


### PR DESCRIPTION
Closes #4922

## Root cause: count-bounded, not byte-bounded

The dynamic-address feed degraded-status sample was bounded by **count**
(`maxInvalidSample = 5`) but never by **bytes**. The line scanner admits a
malformed line up to `maxLineBytes` (1 MiB, `pkg/feeds/feeds.go`), `parseFeed`
retained the first five offenders **verbatim**, `installSnapshot` stored them
in `feedState`, `AllFeeds` deep-copied them into `FeedInfo`, and a changed
degraded feed handed the whole slice to `slog.Warn`. So a single feed could
pin **~5 MiB of verbatim garbage** in memory and emit **multi-MB log records**;
multiple feeds multiply it — all *within the advertised feed limits*. A hostile
or broken provider serving near-1-MiB malformed lines is a persistent
memory-pressure + huge-log-record vector despite the "small sample" contract.

## Fix: bound at the retention point + escape

`boundInvalidSample` is applied in `parseFeed`'s append, so
`installSnapshot`, `AllFeeds`' deep copy, and the degraded-feed `slog.Warn`
**all inherit the bounded form** — not just a log-site truncation, which would
leave the memory-retention half of the bug intact. Each entry:

- is truncated to its first `maxInvalidSampleBytes` (256) **raw** bytes;
- is `strconv.Quote`-escaped, so NULs / control bytes / newlines / invalid
  UTF-8 render as printable `\x..` escapes — **never raw control bytes** into a
  journal or CLI show;
- carries the **original byte length** when truncated (`… (<n> bytes total)`),
  so an operator can still triage "line was 1 MiB, starts with `<prefix>`"
  without retaining it;
- a **short** line (< the cap) is retained quoted-but-otherwise-intact, so the
  diagnostic value for the common stray-text case is preserved.

Two hard ceilings back this: `maxInvalidSampleEntryBytes` caps a single escaped
entry, and a running aggregate budget (`maxInvalidSampleTotalBytes` = count cap
× per-entry cap) gates the append as a belt-and-suspenders second guard. The
existing count bound (5) and the changed-degraded-only logging behaviour are
unchanged.

## Escaping

A malformed line can contain NULs, newlines, control bytes, and invalid UTF-8.
`strconv.Quote` guarantees a printable-ASCII, round-trippable result; the
`TestInvalidSampleEscapesControlBytes` test asserts no raw NUL, printable-ASCII
only, and a successful `strconv.Unquote`.

## Validation

- `go build ./...` — exit 0
- `go test -count=1 ./pkg/feeds/...` — ok
- `gofmt -l` — clean on touched files
- **RED-on-revert:** reverting the append back to the verbatim
  `append(invalidSample, line)` turns **all six** new `#4922` tests RED
  (`TestInvalidSampleBigLineByteBounded` reports a 1047552-byte entry vs the
  1088-byte cap, etc.); the suite is otherwise green. The existing
  `TestMixedFeedDegradedStatus` assertion was updated to the new escaped
  (quoted) form.

## Docs

`pkg/feeds/README.md` documents the byte cap, the length/escape metadata, and
the retention-point rationale (new `#4922` bullet + updated gotcha).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
