### PR TITLE
userspace-dp: reject non-unicast source-IP class on RX neighbor learn (#4889)

### DIFF
--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -189,6 +189,25 @@ sync.
     the router actually owns. `local_v*` continues to drive the
     `LocalDelivery` to-self disposition unchanged — only the anti-poison
     predicate switched sets.
+  - **Illegitimate source-IP CLASS anti-poison (`#4889`, RFC 826 /
+    RFC 4861):** ALL learn paths — including the RX source-MAC path
+    (`learn_dynamic_neighbor`) — reject a learn whose learned IP falls in a
+    class that can never name a real unicast next-hop: unspecified
+    (`0.0.0.0` / `::`), loopback (`127/8` / `::1`), multicast
+    (`224/4` / `ff00::/8`), or the IPv4 limited broadcast
+    (`255.255.255.255`). The gate is the shared `neighbor_ip_is_learnable`
+    predicate (single source of truth for v4+v6, `frame/inspect.rs`),
+    applied BEFORE the cache write on the ARP-reply arm (`#2790`), the
+    NDP-NA arm (`#2790`), and — as of `#4889` — the RX source-MAC learn
+    path. That 5th path derives the neighbor identity from a LIVE transit
+    frame's L3 source (`flow.src_ip`), so a normal TCP/UDP packet with a
+    unicast source MAC but a spoofed source IP (`127.0.0.1` / `224.0.0.1` /
+    `255.255.255.255` / `::1` / `ff02::1` / `0.0.0.0`) would otherwise seed
+    an impossible `(ingress_ifindex, spoofed_ip) -> src_mac` entry. Before
+    #4889 this path validated only the source-MAC class and the own-IP
+    overlap (`#3182`), NOT the source-IP class — closing that gap brings it
+    to parity with the L2 advert paths. Rejection is do-not-learn only (the
+    packet still forwards); this is a learn-path guard, not a packet filter.
   - **STALE install + NDP Override honor (`#4475`, opus-172 H-2, RFC 4861
     §7.2.5):** the own-IP gate above only protects addresses the router
     OWNS. Every OTHER same-segment next-hop — including the WAN gateway —

--- a/userspace-dp/src/afxdp/neighbor_dispatch.rs
+++ b/userspace-dp/src/afxdp/neighbor_dispatch.rs
@@ -480,6 +480,28 @@ pub(super) fn learn_dynamic_neighbor(
     src_ip: IpAddr,
     src_mac: [u8; 6],
 ) {
+    // #4889: illegitimate source-IP CLASS gate on the #1787 RX source-MAC
+    // learn path, mirroring the #2790 unicast-only gate the ARP-reply and
+    // NDP-NA learn arms already apply in poll_stages.rs. Unlike those L2
+    // advert paths, this 5th learn path derives the neighbor identity from
+    // a LIVE transit frame's L3 source (`flow.src_ip`) — an attacker can
+    // therefore send a normal TCP/UDP packet with a unicast source MAC but
+    // a spoofed source IP whose CLASS can never name a real next-hop host
+    // (unspecified `0.0.0.0`/`::`, loopback `127/8`/`::1`, multicast
+    // `224/4`/`ff00::/8`, or the IPv4 limited broadcast
+    // `255.255.255.255`). Caching such a `(ingress_ifindex, spoofed_ip) ->
+    // src_mac` entry poisons the userspace `dynamic_neighbors` map (and,
+    // via `add_kernel_neighbor` on the ARP/NDP siblings, could feed the
+    // kernel table) with an impossible next-hop identity. Reuse the single
+    // source of truth `neighbor_ip_is_learnable` (handles v4+v6) rather
+    // than re-deriving the class checks. Runs BEFORE the own-IP gate and
+    // the `learn_pair_if_changed` insert so a rejected learn neither caches
+    // nor bumps `mac_change_epoch` (#3048/#3169). Rejection means
+    // do-not-learn only — the packet still forwards; this is a learn-path
+    // guard, not a packet filter.
+    if !neighbor_ip_is_learnable(src_ip) {
+        return;
+    }
     // #3182: anti-poisoning own-IP gate on the #1787 RX source-MAC learn
     // path, mirroring the #2851 ARP/NDP gate in poll_stages.rs. An attacker
     // can spoof a transit packet whose SOURCE IP is one of the router's own

--- a/userspace-dp/src/afxdp/poll_stages_tests.rs
+++ b/userspace-dp/src/afxdp/poll_stages_tests.rs
@@ -1381,6 +1381,90 @@ fn rx_learn_own_wan_ip_rejected_3182() {
     );
 }
 
+/// #4889 fail-on-revert (RX source-MAC learn path illegitimate source-IP
+/// CLASS anti-poison). The #1787 RX learn path (`learn_dynamic_neighbor`,
+/// reached via `stage_parse_flow_and_learn`) derives the neighbor identity
+/// from a LIVE transit frame's L3 source. Before #4889 it validated only
+/// the Ethernet source-MAC class and the own-IP overlap (#3182) — NOT the
+/// source-IP class. A packet with a unicast source MAC but a spoofed source
+/// IP whose class can never name a real next-hop (loopback / multicast /
+/// limited-broadcast / unspecified, v4 and v6) therefore seeded an
+/// impossible `(ingress_ifindex, spoofed_ip) -> src_mac` entry into the
+/// userspace `dynamic_neighbors` cache — the same poisoning the ARP-reply
+/// and NDP-NA learn arms already reject via `neighbor_ip_is_learnable`
+/// (#2790).
+///
+/// This drives each spoofed class (both address families) with a valid
+/// unicast source MAC and asserts NO entry is cached under either the
+/// physical (11) or resolved logical (12) ifindex, plus a legitimate
+/// unicast source that IS still learned (no over-rejection regression).
+///
+/// Removing the `if !neighbor_ip_is_learnable(src_ip) { return; }` guard at
+/// the top of `learn_dynamic_neighbor` makes every spoofed-class assert
+/// fail RED (the illegitimate entry would be inserted); the legitimate-learn
+/// assert keeps the guard honest against over-rejection.
+#[test]
+fn rx_learn_non_unicast_src_ip_rejected_4889() {
+    let forwarding = build_forwarding_state(&super::super::test_fixtures::nat_snapshot());
+    let neighbors = Arc::new(ShardedNeighborMap::default());
+
+    // A syntactically valid, locally-administered UNICAST source MAC —
+    // the source-MAC class gate (frame[6] & 1 == 0) accepts it, so only
+    // the source-IP class gate can stop the spoofed learn.
+    let unicast_mac = [0x02, 0x00, 0x00, 0x00, 0xba, 0xad];
+
+    // Every illegitimate source-IP class the ARP/NDP paths reject, v4 + v6:
+    //   loopback (127/8, ::1), multicast (224/4, ff00::/8),
+    //   limited broadcast (255.255.255.255), unspecified (0.0.0.0, ::).
+    let spoofed: [IpAddr; 6] = [
+        IpAddr::V4(Ipv4Addr::LOCALHOST),          // 127.0.0.1
+        IpAddr::V4(Ipv4Addr::new(224, 0, 0, 1)),  // multicast
+        IpAddr::V4(Ipv4Addr::BROADCAST),          // 255.255.255.255
+        IpAddr::V4(Ipv4Addr::UNSPECIFIED),        // 0.0.0.0
+        IpAddr::V6(Ipv6Addr::LOCALHOST),          // ::1
+        IpAddr::V6(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 1)), // ff02::1
+    ];
+
+    for src in spoofed {
+        // Physical ingress 11 + VLAN 80 resolves the logical (route-egress)
+        // ifindex 12 in this fixture — the #3182 test exercises the same
+        // key pair. A rejected learn must touch NEITHER key.
+        crate::afxdp::neighbor_dispatch::learn_dynamic_neighbor(
+            &forwarding,
+            &neighbors,
+            11,
+            80,
+            src,
+            unicast_mac,
+        );
+        assert!(
+            neighbors.get(&(11, src)).is_none() && neighbors.get(&(12, src)).is_none(),
+            "the RX learn path must reject an illegitimate source-IP class \
+             ({src}) even with a unicast source MAC (#4889)"
+        );
+    }
+
+    // A legitimate unicast source is still learned (caches under the
+    // resolved logical ifindex 12), proving the class gate does not
+    // over-reject.
+    let good = IpAddr::V4(Ipv4Addr::new(172, 16, 80, 42));
+    let good_mac = [0xde, 0xad, 0xbe, 0xef, 0x00, 0x2a];
+    crate::afxdp::neighbor_dispatch::learn_dynamic_neighbor(
+        &forwarding,
+        &neighbors,
+        11,
+        80,
+        good,
+        good_mac,
+    );
+    assert_eq!(
+        neighbors.get(&(12, good)).map(|e| e.mac),
+        Some(good_mac),
+        "a legitimate unicast RX-learned source must still cache (#4889 \
+         guard must not over-reject)"
+    );
+}
+
 // ===================================================================
 // #3021 / #3022 — the ingress ZONE lookup (zone-pair policy for
 // forwarding, and screen/SYN-cookie zone resolution) must key on the


### PR DESCRIPTION
## Root cause

The #1787 RX source-MAC learn path (`learn_dynamic_neighbor` in
`userspace-dp/src/afxdp/neighbor_dispatch.rs`, reached via
`stage_parse_flow_and_learn`) is the **5th** neighbor-write path. It derives the
neighbor identity from a **live transit frame's L3 source** (`flow.src_ip`).
It validated the Ethernet source-MAC class (reject all-zero MAC / group bit)
and the own-IP overlap (#3182), but — unlike the ARP-reply and NDP-NA learn
arms in `poll_stages.rs`, which call `neighbor_ip_is_learnable` (#2790) — it did
**not** reject illegitimate source-IP **classes**.

An attacker could send a normal TCP/UDP packet with a valid **unicast source
MAC** but a **spoofed source IP** whose class can never name a real next-hop
host, seeding an impossible `(ingress_ifindex, spoofed_ip) -> src_mac` entry
into the userspace `dynamic_neighbors` cache — neighbor-table poisoning /
next-hop spoofing.

## Fix

Add the shared `neighbor_ip_is_learnable(src_ip)` guard at the **top of
`learn_dynamic_neighbor`**, before the #3182 own-IP gate and the
`learn_pair_if_changed` insert — mirroring the established ARP/NDP pattern.

- **Chosen insertion point — inside `learn_dynamic_neighbor` (not the
  poll_stages.rs call site):** grepping all callers, the sole *production*
  caller of this 5th path is `learn_dynamic_neighbor_from_packet`; the rest are
  tests. Gating inside the function makes it a **single choke point** covering
  every caller of the 5th path.
- **Reuses the existing single source of truth** `neighbor_ip_is_learnable`
  (`frame/inspect.rs`) rather than re-deriving the class checks — it already
  handles v4 and v6 and is in scope via `use self::frame::*` (no visibility
  change needed).
- **v4 + v6 coverage:** unspecified (`0.0.0.0` / `::`), loopback
  (`127/8` / `::1`), multicast (`224/4` / `ff00::/8`), IPv4 limited broadcast
  (`255.255.255.255`).
- **Rejection = do-not-learn only.** The packet still forwards; this is a
  learn-path guard, not a packet filter.

## Test (fail-on-revert)

`rx_learn_non_unicast_src_ip_rejected_4889` (mirrors the #3182 harness) drives
each spoofed class for both families — `127.0.0.1`, `224.0.0.1`,
`255.255.255.255`, `0.0.0.0`, `::1`, `ff02::1` — with a unicast source MAC and
asserts **no** entry is cached under either the physical (11) or resolved
logical (12) ifindex, plus a legitimate unicast source (`172.16.80.42`) that
**is** still learned (no over-rejection regression).

**RED-on-revert confirmed:** neutralizing the guard makes the spoofed-class
asserts panic at the `127.0.0.1` case (`test result: FAILED. 0 passed;
1 failed`).

## Validation (full cargo suite)

- `cargo build --release` — exit **0**
- `cargo test --release` — exit **0**, **3900 passed / 0 failed / 2 ignored**
  (across 5 test binaries)

## Docs

`userspace-dp/src/afxdp/README.md` neighbor-learn section gains a `#4889` bullet
documenting the source-IP **class** anti-poison now enforced across all learn
paths including the 5th RX source-MAC path.

Closes #4889

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
