### PR TITLE
config: fail closed on an invalid IPsec bind-interface (#5297)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,26 @@
+## 2026-07-10 — config: fail closed on an invalid IPsec bind-interface (#5297)
+
+- **Timestamp**: 2026-07-10
+  - **Action**: #5297 — a non-canonical `security ipsec vpn <name>
+    bind-interface` (anything but `st<N>`/`st<N>.<unit>`, e.g. `secure0`)
+    committed successfully but resolved to `XFRMIfNameAndID` if_id 0, so the
+    reconciler created NO XFRM device and the route-based VPN was silently
+    DOWN. Now fail-closed at two layers (#1960 doctrine): (1) the
+    `bind-interface` schema leaf is `ValueSecureTunnelIf` +
+    `ValidateSecureTunnelBindInterface` so `SchemaValidate`/`?`-completion
+    reject it at commit-check; (2) `validateSecureTunnelBindInterfaceAST`
+    gained an invalid-name arm that hard-rejects an if_id-0 name on the strict
+    path and warns on the tolerant load/peer-sync path (catches
+    group-expanded/packed forms). The id-0 sentinel is the authoritative
+    "creates no device" signal; the message states the canonical
+    `st<N>[.unit]` requirement. Surgical — the #2909/#2933 two-VALID-alias
+    collision arm (needs a non-zero if_id) is untouched. pkg/routing "invalid
+    bind-interface name" log stays the runtime backstop.
+  - **File(s)**: pkg/config/xfrmi.go, pkg/config/value_type.go,
+    pkg/config/schema_security.go, pkg/config/compiler_ipsec_bindiface.go,
+    pkg/config/compiler_ipsec_bindiface_validate_5297_test.go,
+    docs/config-schema.md, pkg/config/README.md
+
 ## 2026-07-09 — pkg/api: abort long read handlers on client disconnect (#5232/#5233)
 
 - **Timestamp**: 2026-07-09

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -170,6 +170,51 @@ narrow and theoretical (a permit rule referencing an empty-prefix address is
 already fail-CLOSED — it matches nothing; only a deny blocklist entry could fail
 open, the same class as a typo'd address-book NAME). See #4515.
 
+### `security ipsec vpn … bind-interface` canonical-name fail-closed (#5297)
+
+`security ipsec vpn <name> bind-interface` is a free-form 1-arg string the
+runtime resolves to a Linux xfrmi device name and a stable XFRM if_id via
+`XFRMIfNameAndID` (`xfrmi.go`). Only the canonical secure-tunnel spelling
+`st<N>` or `st<N>.<unit>` (e.g. `st0`, `st0.1`) resolves; every OTHER name
+(`secure0`, a bare `st`, a physical `ge-0/0/0`) yields **if_id 0** — the
+authoritative "creates no XFRM device" sentinel. Before #5297 such a name
+committed successfully: the #2933 if_id-collision gate deliberately `continue`d
+past any if_id-0 name (out of scope for a *collision* between two VALID
+aliases), the schema leaf was untyped, and the compiler stored the string
+verbatim. At reconciliation the routing manager logged "invalid bind-interface
+name" and created no device, so the route-based VPN was silently DOWN with a
+clean commit — the #5297 vSRX-parity gap.
+
+The fix fails closed at **two layers** (the #1960 layered-defense doctrine),
+both strict-on-commit / lenient-on-load:
+
+- **Typed-leaf schema layer** — the `bind-interface` leaf (`schema_security.go`)
+  is now `valueType: ValueSecureTunnelIf` with the
+  `ValidateSecureTunnelBindInterface` validator (`xfrmi.go`). `SchemaValidate`
+  rejects a non-canonical name at commit-check with an actionable message
+  naming the value and the `st<N>`/`st<N>.<unit>` requirement, and `?`-completion
+  surfaces the placeholder + examples. The validator's decision is the
+  authoritative `XFRMIfNameAndID` if_id-0 check; only the message is lexical.
+- **Compiled-config strict gate** — `validateSecureTunnelBindInterfaceAST`
+  (`compiler_ipsec_bindiface.go`) gained a distinct invalid-name arm: a
+  NON-EMPTY bind-interface that resolves to if_id 0 is now hard-rejected on the
+  strict path (rather than silently `continue`-ing) and downgraded to a warning
+  on the tolerant load / peer-sync path. Because it is an AST pre-walk over the
+  group-expanded, inactive-pruned tree, it catches apply-groups-inherited /
+  duplicate-block forms the schema layer can miss — the reason both layers are
+  kept.
+
+The change is surgical: it fires ONLY for names resolving to if_id 0 (which are
+never valid), so the #2909/#2933 two-VALID-alias collision case (`st0` + `st0.0`,
+both if_id 1) is unchanged — still handled by the collision arm, still rejected
+naming the shared if_id. An empty bind-interface (none configured) is still
+skipped. The pkg/routing "invalid bind-interface name" guard remains the runtime
+backstop for a tolerated-but-invalid config. Covered by
+`pkg/config/compiler_ipsec_bindiface_validate_5297_test.go` (strict reject +
+valid-compiles-to-expected-if_id + tolerant-warn + schema-layer reject +
+#2933-non-regression, each RED on revert to the silent `continue` / untyped
+leaf).
+
 ## Multi-value leaves and bracketed lists (the dual-AST contract)
 
 A `multi: true` leaf with `children: nil` (e.g. `from protocol`,

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -879,6 +879,22 @@ ignored. The tolerant load/peer-sync path downgrades to a warning
 an older binary accepted still boots (#1960 no-brick doctrine) — the #2929
 routing guard stays the runtime backstop.
 
+The same gate carries a DISTINCT `bind-interface` fail-closed arm (#5297): a
+NON-EMPTY bind-interface that `XFRMIfNameAndID` resolves to **if_id 0** (any name
+that is not the canonical `st<N>` / `st<N>.<unit>`, e.g. `secure0`, a bare `st`,
+`ge-0/0/0`) creates NO XFRM device at reconciliation, so the route-based VPN
+commits cleanly but silently carries no traffic. The #2933 collision arm
+deliberately `continue`d past if_id 0 (a collision needs two VALID, non-zero
+if_ids); the #5297 arm instead hard-rejects such a name on the strict commit /
+commit-check path (naming the canonical `st<N>[.unit]` requirement) and warns on
+the tolerant load / peer-sync path. This is ALSO enforced at the typed-leaf
+schema layer — the `bind-interface` leaf is `ValueSecureTunnelIf` with the
+`ValidateSecureTunnelBindInterface` validator (`xfrmi.go`) — so commit-check and
+`?`-completion reject it early; the compiled-config gate stays as the belt for
+group-expanded / packed forms the schema layer can miss (#1960 layered defense).
+The pkg/routing "invalid bind-interface name" log is the runtime backstop for a
+tolerated invalid config.
+
 **Undefined policy community references are rejected at commit (#2881):** a
 policy-statement term's `from community <name>` (rendered FRR `match community
 <name>`) and `then community delete <name>` (the strip-by-list operation added

--- a/pkg/config/compiler_ipsec_bindiface.go
+++ b/pkg/config/compiler_ipsec_bindiface.go
@@ -30,14 +30,21 @@ import (
 // error (candidate rejected, live config untouched). The #2929 routing guard
 // stays as the runtime backstop.
 //
-// Scope — surgical: the gate fires ONLY when two DISTINCT bind-interface
-// strings derive the SAME non-zero if_id. It does NOT fire when:
-//   - the same bind-interface string is shared by multiple VPNs (that is one
-//     device, one if_id — not the ambiguous-alias case #2929 named), nor
-//   - a bind-interface XFRMIfNameAndID cannot parse as `st<N>[.unit]`
-//     (if_id 0) — out of scope here; some other path handles a bad string.
+// Scope — surgical: the if_id-collision arm fires ONLY when two DISTINCT
+// bind-interface strings derive the SAME non-zero if_id. It does NOT fire when
+// the same bind-interface string is shared by multiple VPNs (that is one
+// device, one if_id — not the ambiguous-alias case #2929 named).
 //
 // An unambiguous map (st0.0 + st0.1, or st0 + st1) commits cleanly.
+//
+// #5297 invalid-name arm: a NON-EMPTY bind-interface that XFRMIfNameAndID
+// cannot parse as `st<N>[.unit]` resolves to if_id 0 — it creates NO XFRM
+// device at reconciliation, so the route-based VPN commits but silently
+// carries no traffic. This is a DISTINCT failure from the #2933 collision
+// (which needs two VALID, non-zero if_ids): the gate now rejects such a name on
+// the strict path (naming the canonical st<N>[.unit] requirement) and warns on
+// the tolerant path, mirroring the same strict/lenient split. An empty
+// bind-interface (none configured) is still skipped.
 //
 // This is an AST pre-walk (like validateUnsupportedInterfaceStanzasAST / the other
 // reject-at-commit gates) rather than a typed-Config validator so it runs on
@@ -65,6 +72,16 @@ func validateSecureTunnelBindInterfaceAST(nodes []*Node, lenient bool) ([]string
 	byID := map[uint32]map[string]*bindRef{}
 	order := []uint32{} // first-seen if_id order for deterministic errors
 
+	// #5297: a NON-EMPTY bind-interface that XFRMIfNameAndID resolves to
+	// if_id 0 is not a canonical st<N>[.unit] secure-tunnel name. It commits
+	// but creates no XFRM device at reconciliation (pkg/routing logs "invalid
+	// bind-interface name"), so the route-based VPN is silently DOWN. Collect
+	// these here and reject (strict) / warn (lenient) after the walk, in
+	// deterministic order. Distinct from the #2933 if_id-collision gate below
+	// (two VALID aliases sharing one non-zero if_id).
+	type invalidBind struct{ vpn, iface string }
+	var invalid []invalidBind
+
 	// #3562: iterate EVERY top-level `security` node and EVERY `ipsec` sibling,
 	// not the first match at any level. parseStatements APPENDS a repeated
 	// top-level block instead of merging it (parser.go) and compileExpanded /
@@ -90,8 +107,13 @@ func validateSecureTunnelBindInterfaceAST(nodes []*Node, lenient bool) ([]string
 				}
 				_, ifID := XFRMIfNameAndID(bindIface)
 				if ifID == 0 {
-					// Not a recognizable st<N>[.unit] secure-tunnel binding;
-					// out of scope for the if_id-collision gate.
+					// #5297: not a recognizable st<N>[.unit] secure-tunnel
+					// binding — it creates no XFRM device (empty name / zero
+					// id), so the VPN silently carries no traffic. Record for a
+					// fail-closed reject (strict) / warn (lenient) after the
+					// walk. NOT the #2933 collision case (that needs a valid,
+					// non-zero if_id).
+					invalid = append(invalid, invalidBind{vpn: inst.name, iface: bindIface})
 					continue
 				}
 				group, ok := byID[ifID]
@@ -123,6 +145,31 @@ func validateSecureTunnelBindInterfaceAST(nodes []*Node, lenient bool) ([]string
 		}
 		warnings = append(warnings, msg)
 		return nil
+	}
+
+	// #5297: fail closed on any bind-interface that resolves to no XFRM
+	// device. Strict (commit / commit-check) hard-rejects with an actionable
+	// message naming the canonical st<N>[.unit] requirement; lenient (load /
+	// peer-sync) warns and skips so an already-persisted or peer-synced config
+	// an older binary silently accepted still BOOTS (#1960) — the pkg/routing
+	// reconciler stays the runtime backstop (logs the invalid name, no device).
+	// Sorted for deterministic output.
+	sort.Slice(invalid, func(i, j int) bool {
+		if invalid[i].iface != invalid[j].iface {
+			return invalid[i].iface < invalid[j].iface
+		}
+		return invalid[i].vpn < invalid[j].vpn
+	})
+	for _, bad := range invalid {
+		if err := emit(
+			"secure-tunnel bind-interface %q (security ipsec vpn %s) is not a "+
+				"valid secure-tunnel interface: it must be st<N> or st<N>.<unit> "+
+				"(e.g. st0 or st0.1). Any other name resolves to no XFRM "+
+				"interface, so the route-based VPN commits successfully but "+
+				"carries no traffic (silent tunnel down) (#5297)",
+			bad.iface, bad.vpn); err != nil {
+			return nil, err
+		}
 	}
 
 	for _, ifID := range order {

--- a/pkg/config/compiler_ipsec_bindiface_validate_5297_test.go
+++ b/pkg/config/compiler_ipsec_bindiface_validate_5297_test.go
@@ -1,0 +1,184 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for #5297: an invalid IPsec `bind-interface` name (anything but the
+// canonical secure-tunnel st<N> / st<N>.<unit>) committed successfully but
+// resolved to if_id 0 via XFRMIfNameAndID — the reconciler created NO XFRM
+// device, so the route-based VPN was silently DOWN. The if_id-collision gate
+// (#2933) deliberately `continue`d past any name yielding if_id 0, treating it
+// as out of scope, so a strict commit reported SUCCESS.
+//
+// The fix REJECTS such a name at strict commit (CompileConfig + SchemaValidate)
+// and WARNS on the tolerant load / peer-sync path (CompileConfigLenient),
+// mirroring the #1960 fail-closed-on-strict / lenient-on-load doctrine. It is
+// DISTINCT from #2909/#2933 (two VALID st aliases colliding on a non-zero
+// if_id), which must still be handled by the collision gate.
+//
+// Flat-set syntax MUST be built with ParseSetCommand/SetPath (buildBindIfaceTree
+// / flatTreeFromSets), never NewParser (CLAUDE.md "Testing flat set syntax").
+
+// TestSecureTunnelBindIfaceInvalidRejectedAtCommit proves a non-canonical
+// bind-interface is hard-rejected at strict commit with an actionable message.
+//
+// FAIL-ON-REVERT: reverting the id-0 arm in
+// validateSecureTunnelBindInterfaceAST back to a bare `continue` (dropping the
+// `invalid` append) makes these configs compile clean (no error) → this test
+// expects an error and goes RED.
+func TestSecureTunnelBindIfaceInvalidRejectedAtCommit(t *testing.T) {
+	cases := []struct {
+		name string
+		cmds []string
+		want []string // substrings expected in the commit error
+	}{
+		{
+			name: "secure0 (non-st name)",
+			cmds: []string{
+				"set security ipsec vpn V bind-interface secure0",
+			},
+			want: []string{
+				`bind-interface "secure0"`,
+				"security ipsec vpn V",
+				"st<N> or st<N>.<unit>",
+				"#5297",
+			},
+		},
+		{
+			name: "st (no index)",
+			cmds: []string{
+				"set security ipsec vpn V bind-interface st",
+			},
+			want: []string{`bind-interface "st"`, "st<N> or st<N>.<unit>"},
+		},
+		{
+			name: "stX (non-numeric index)",
+			cmds: []string{
+				"set security ipsec vpn V bind-interface stX",
+			},
+			want: []string{`bind-interface "stX"`, "st<N> or st<N>.<unit>"},
+		},
+		{
+			name: "ge-0/0/0 (physical interface, not a secure tunnel)",
+			cmds: []string{
+				"set security ipsec vpn V bind-interface ge-0/0/0",
+			},
+			want: []string{`bind-interface "ge-0/0/0"`, "carries no traffic"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildBindIfaceTree(t, tc.cmds...)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig accepted invalid bind-interface; want reject")
+			}
+			for _, sub := range tc.want {
+				if !strings.Contains(err.Error(), sub) {
+					t.Errorf("error %q missing substring %q", err.Error(), sub)
+				}
+			}
+		})
+	}
+}
+
+// TestSecureTunnelBindIfaceValidCommits proves a canonical bind-interface
+// commits cleanly and compiles to the expected XFRM device name / if_id.
+func TestSecureTunnelBindIfaceValidCommits(t *testing.T) {
+	cases := []struct {
+		name       string
+		bind       string
+		wantIfName string
+		wantIfID   uint32
+	}{
+		{name: "bare st0", bind: "st0", wantIfName: "st0", wantIfID: 1},
+		{name: "st0.1 unit", bind: "st0.1", wantIfName: "st0.1", wantIfID: 2},
+		{name: "st1.5 unit", bind: "st1.5", wantIfName: "st1.5", wantIfID: 1<<16 | 6},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildBindIfaceTree(t,
+				"set security ipsec vpn V bind-interface "+tc.bind)
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("CompileConfig rejected valid bind-interface %q: %v", tc.bind, err)
+			}
+			vpn := cfg.Security.IPsec.VPNs["V"]
+			if vpn == nil {
+				t.Fatalf("vpn V not compiled")
+			}
+			if vpn.BindInterface != tc.bind {
+				t.Fatalf("BindInterface = %q, want %q", vpn.BindInterface, tc.bind)
+			}
+			name, ifID := XFRMIfNameAndID(vpn.BindInterface)
+			if name != tc.wantIfName || ifID != tc.wantIfID {
+				t.Errorf("XFRMIfNameAndID(%q) = (%q, %d), want (%q, %d)",
+					tc.bind, name, ifID, tc.wantIfName, tc.wantIfID)
+			}
+		})
+	}
+}
+
+// TestSecureTunnelBindIfaceInvalidLenientWarns proves the tolerant
+// load/peer-sync path downgrades an invalid bind-interface to a warning and
+// still compiles — a config an older binary silently accepted must still BOOT
+// (#1960), not fail closed.
+func TestSecureTunnelBindIfaceInvalidLenientWarns(t *testing.T) {
+	tree := buildBindIfaceTree(t,
+		"set security ipsec vpn V bind-interface secure0")
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient rejected invalid bind-interface (want warn): %v", err)
+	}
+	var found bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, `bind-interface "secure0"`) && strings.Contains(w, "#5297") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient compile produced no invalid bind-interface warning; got %v", cfg.Warnings)
+	}
+}
+
+// TestSecureTunnelBindIfaceInvalidSchemaRejected proves the #1319 typed-leaf
+// commit-check layer (SchemaValidate) independently rejects a non-canonical
+// bind-interface naming the offending value, and accepts every canonical form.
+//
+// FAIL-ON-REVERT: dropping the valueType/validator from the `bind-interface`
+// schema leaf makes SchemaValidate return nil for "secure0" → RED.
+func TestSecureTunnelBindIfaceInvalidSchemaRejected(t *testing.T) {
+	bad := flatTreeFromSets(t, "set security ipsec vpn V bind-interface secure0")
+	err := SchemaValidate(bad, nil)
+	if err == nil || !strings.Contains(err.Error(), "secure0") {
+		t.Fatalf("SchemaValidate must reject invalid bind-interface naming the value, got: %v", err)
+	}
+	for _, good := range []string{"st0", "st0.1", "st1.5"} {
+		ok := flatTreeFromSets(t, "set security ipsec vpn V bind-interface "+good)
+		if err := SchemaValidate(ok, nil); err != nil {
+			t.Errorf("SchemaValidate rejected valid bind-interface %q: %v", good, err)
+		}
+	}
+}
+
+// TestSecureTunnelBindIfaceCollisionStillRejected_5297NonRegression proves the
+// #5297 invalid-name arm did NOT disturb the #2933 if_id-collision arm: two
+// VALID, distinct aliases sharing one non-zero if_id (st0 + st0.0) are still
+// hard-rejected as a collision (naming the shared if_id), not swallowed by the
+// new invalid-name path (which fires only for if_id 0).
+func TestSecureTunnelBindIfaceCollisionStillRejected_5297NonRegression(t *testing.T) {
+	tree := buildBindIfaceTree(t,
+		"set security ipsec vpn V1 bind-interface st0",
+		"set security ipsec vpn V2 bind-interface st0.0",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("CompileConfig accepted colliding valid aliases; want #2933 collision reject")
+	}
+	if !strings.Contains(err.Error(), "if_id 1") || !strings.Contains(err.Error(), "#2933") {
+		t.Errorf("collision error changed shape (#2933 regression): %q", err.Error())
+	}
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -1113,8 +1113,19 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 			}},
 		}},
 		"vpn": {desc: "IPsec VPN tunnel name", args: 1, placeholder: "<vpn-name>", children: map[string]*schemaNode{
-			"bind-interface": {desc: "XFRM tunnel interface to bind", args: 1, placeholder: "<interface-name>", children: nil},
-			"df-bit":         {desc: "Outer-header DF bit handling (copy|set|clear)", args: 1, placeholder: "<mode>", children: nil},
+			// #5297: type the leaf so a non-canonical bind-interface (anything
+			// but st<N> / st<N>.<unit>) fails closed at commit-check instead of
+			// committing and then creating no XFRM device at reconciliation
+			// (silent route-based-VPN down). The compiled-config strict gate
+			// (compiler_ipsec_bindiface.go) keeps its parallel id-0 rejection
+			// for group-expanded / packed forms the schema layer can miss
+			// (#1960 layered defense). Tolerant Load/SyncApply downgrades this
+			// to a warning (schemaValidateExpandedTree in configstore).
+			"bind-interface": {desc: "Secure-tunnel interface to bind (st<N> or st<N>.<unit>)", args: 1, placeholder: "<st-interface>",
+				valueType: ValueSecureTunnelIf, valueDesc: "IPsec secure-tunnel interface (st<N> or st<N>.<unit>)",
+				valueExamples: []string{"st0", "st0.1"},
+				validator:     ValidateSecureTunnelBindInterface, children: nil},
+			"df-bit": {desc: "Outer-header DF bit handling (copy|set|clear)", args: 1, placeholder: "<mode>", children: nil},
 			// #4301 (V-5): type the enum so a typo (`on-tarffic`) fails closed
 			// at commit instead of storing verbatim and silently degrading to
 			// on-traffic. Only `immediately` is acted on (start_action =

--- a/pkg/config/value_type.go
+++ b/pkg/config/value_type.go
@@ -97,6 +97,13 @@ const (
 	// component / absolute path / space at commit check to keep the target
 	// inside the zoneinfo root (#5011).
 	ValueTimeZone
+	// ValueSecureTunnelIf is an IPsec route-based VPN bind-interface: a
+	// canonical secure-tunnel interface st<N> or st<N>.<unit> (e.g. st0,
+	// st0.1). Validated by ValidateSecureTunnelBindInterface — any other
+	// name resolves to no XFRM device (XFRMIfNameAndID if_id 0), so the VPN
+	// commits but silently carries no traffic; the name is rejected at
+	// commit check (#5297).
+	ValueSecureTunnelIf
 )
 
 // Placeholder returns the angle-bracket placeholder name shown in `?`
@@ -141,6 +148,8 @@ func (v ValueType) Placeholder() string {
 		return "<YYYY-MM-DD>"
 	case ValueTimeZone:
 		return "<timezone>"
+	case ValueSecureTunnelIf:
+		return "<st-interface>"
 	}
 	return ""
 }

--- a/pkg/config/xfrmi.go
+++ b/pkg/config/xfrmi.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -37,4 +38,40 @@ func XFRMIfNameAndID(bindIface string) (string, uint32) {
 	}
 
 	return LinuxIfName(bindIface), ifID
+}
+
+// ValidateSecureTunnelBindInterface reports whether a `security ipsec vpn
+// <name> bind-interface` value is a canonical secure-tunnel interface — the
+// only shape the route-based-VPN datapath can bind. The accepted lexical form
+// is st<N> or st<N>.<unit> (e.g. st0, st0.1); XFRMIfNameAndID resolves every
+// other name to if_id 0, which the pkg/routing reconciler treats as "invalid
+// bind-interface name" and creates NO XFRM device for. Such a config commits
+// successfully yet the VPN is silently DOWN (#5297).
+//
+// The if_id-0 sentinel from XFRMIfNameAndID is the authoritative
+// "creates no XFRM device" signal; the message states the canonical lexical
+// requirement so the operator sees an actionable error rather than an opaque
+// id reference.
+//
+// Used both as the #1319 typed-leaf commit-check validator on the
+// `bind-interface` schema leaf (schema_security.go) and — mirrored via
+// XFRMIfNameAndID's if_id-0 check — by the compiled-config strict gate in
+// compiler_ipsec_bindiface.go, which additionally catches group-expanded /
+// packed forms the schema layer can miss (#1960 layered-defense doctrine).
+func ValidateSecureTunnelBindInterface(raw string, _ *Config) error {
+	name := strings.TrimSpace(raw)
+	if name == "" {
+		return fmt.Errorf(
+			"missing bind-interface (expected a secure-tunnel interface " +
+				"st<N> or st<N>.<unit>, e.g. st0 or st0.1)")
+	}
+	if _, ifID := XFRMIfNameAndID(name); ifID == 0 {
+		return fmt.Errorf(
+			"invalid bind-interface %q: must be a secure-tunnel interface "+
+				"st<N> or st<N>.<unit> (e.g. st0 or st0.1); any other name "+
+				"resolves to no XFRM interface, so the route-based VPN commits "+
+				"but carries no traffic (silent tunnel down)",
+			raw)
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

An invalid `security ipsec vpn <name> bind-interface` name **committed
successfully but created no XFRM interface**, leaving the route-based VPN
silently DOWN — a vSRX-parity gap.

`bind-interface` is a free-form 1-arg string the runtime resolves via
`XFRMIfNameAndID` (`pkg/config/xfrmi.go`). Only the canonical secure-tunnel
spelling `st<N>` or `st<N>.<unit>` resolves; every other name (`secure0`, a
bare `st`, a physical `ge-0/0/0`) yields the **sentinel if_id 0**. The
root cause of the silent success is threefold:

- the #2933 if_id-collision gate deliberately `continue`d past any if_id-0
  name (out of scope for a *collision* between two VALID aliases);
- the `bind-interface` schema leaf was untyped (free-form);
- the compiler stored the string verbatim.

So `set security ipsec vpn V bind-interface secure0` → `XFRMIfNameAndID` returns
if_id 0 → the collision gate `continue`s → **strict commit reports SUCCESS** → at
reconciliation the routing manager logs `invalid bind-interface name`, creates no
device → the VPN carries no traffic. Distinct from #2909/#2933 (two VALID aliases
colliding on a non-zero if_id).

## Fix — fail closed at two layers (#1960 doctrine)

Both layers are strict-reject on commit / commit-check and lenient-warn on the
tolerant load / peer-sync path.

- **Typed-leaf schema layer** — the `bind-interface` leaf (`schema_security.go`)
  is now `valueType: ValueSecureTunnelIf` with a new
  `ValidateSecureTunnelBindInterface` validator (`xfrmi.go`). `SchemaValidate`
  rejects a non-canonical name at commit-check naming the value and the
  `st<N>`/`st<N>.<unit>` requirement; `?`-completion surfaces the placeholder +
  examples. On the tolerant `Load`/`SyncApply` path (`configstore`
  `schemaValidateExpandedTree`) this downgrades to a warning.
- **Compiled-config strict gate** — `validateSecureTunnelBindInterfaceAST`
  (`compiler_ipsec_bindiface.go`) gained a distinct invalid-name arm: a NON-EMPTY
  bind-interface resolving to if_id 0 is hard-rejected on the strict path and
  warned on the tolerant path. As an AST pre-walk over the group-expanded,
  inactive-pruned tree it catches apply-groups / duplicate-block forms the schema
  layer can miss — which is why **both** layers are kept.

The `XFRMIfNameAndID` if_id-0 sentinel is the **authoritative** "creates no XFRM
device" decision; the error message is the canonical `st<N>[.unit]` **lexical**
requirement so it is actionable.

### #2909/#2933 non-regression

The change is surgical — it fires ONLY for names resolving to if_id 0 (never
valid). The two-VALID-alias collision case (`st0` + `st0.0`, both if_id 1) is
unchanged: still handled by the collision arm, still rejected naming the shared
if_id. An empty bind-interface (none configured) is still skipped. The
pkg/routing `invalid bind-interface name` guard stays the runtime backstop for a
tolerated-but-invalid config.

## Tests (`pkg/config/compiler_ipsec_bindiface_validate_5297_test.go`)

Flat-set built with `ParseSetCommand` + `SetPath` per CLAUDE.md.

- valid `st0` / `st0.1` / `st1.5` → strict commit SUCCEEDS, compiles to the
  expected XFRM name + if_id;
- invalid `secure0` / `st` / `stX` / `ge-0/0/0` → strict commit REJECTED with the
  actionable error (asserted substrings);
- invalid on the tolerant path → WARN + compile, not a hard fail;
- schema-layer reject (`SchemaValidate` naming the value) + valid names pass;
- #2933 collision (`st0` + `st0.0`) still rejected naming `if_id 1` (non-regression).

**RED-on-revert (verified):** reverting the id-0 arm to the bare `continue` and
the schema leaf to untyped turns the strict-reject, tolerant-warn, and
schema-reject tests RED, while the valid-commit and collision tests stay green.

## Validation

- `go build ./...` → exit 0
- `go test ./pkg/config/...` → ok (also `pkg/cmdtree`, `pkg/configstore` ok)
- `gofmt -l` clean on all touched files

## Docs

- `docs/config-schema.md`: new "`bind-interface` canonical-name fail-closed
  (#5297)" subsection under Strict commit-time validators.
- `pkg/config/README.md`: the #2933 section notes the new invalid-name arm.

Closes #5297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
