### PR TITLE
nat: mint an occupancy token on the source-NAT address-only branch (#5269)

### DIFF
--- a/userspace-dp/src/nat/allocator.rs
+++ b/userspace-dp/src/nat/allocator.rs
@@ -154,6 +154,33 @@ struct LiveAllocation {
     // recycle queue). `false` for every round-robin/persistent allocation
     // (unchanged behaviour).
     deterministic: bool,
+    // #5269: an address-only occupancy token (port no-translation / port-less
+    // source NAT). No pool PORT is consumed on the occupancy bitmap — the packet
+    // keeps its own source port on the wire — so release must NOT free a port
+    // bit; instead it clears the reverse-identity entry in `address_only_owners`.
+    // `false` for every PAT / deterministic / persistent allocation.
+    address_only: bool,
+}
+
+/// #5269: reverse-identity ownership key for an address-only (port
+/// no-translation / port-less) source-NAT translation. The reverse conntrack
+/// demux keys a reply on (protocol, translated source IP, translated source
+/// port, remote IP, remote port); two forward flows that would produce the SAME
+/// reverse identity cannot coexist because their replies are indistinguishable,
+/// so the allocator grants each identity to exactly ONE flow and denies a
+/// genuinely-colliding second flow as exhaustion. `translated_port` is the
+/// PRESERVED source port for a port-bearing protocol, or 0 for a port-less
+/// protocol (GRE/ESP/AH/...). This is the address-only analogue of the PAT
+/// occupancy bit: PAT keeps `(pool_addr, port)` unique by handing out a fresh
+/// port; address-only cannot move the port, so it enforces uniqueness on the
+/// full reverse identity instead.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub(super) struct AddressOnlyReverseKey {
+    pub(super) protocol: u8,
+    pub(super) translated_ip: IpAddr,
+    pub(super) translated_port: u16,
+    pub(super) dst_ip: IpAddr,
+    pub(super) dst_port: u16,
 }
 
 /// #4559: IPv4 deterministic CGNAT (mode 1) block-allocation parameters,
@@ -411,6 +438,13 @@ pub(super) struct PortAllocatorLiveState {
     pub(super) persistent_by_source: FxHashMap<PersistentSourceKey, PersistentLease>,
     pub(super) lease_expirations: BTreeSet<(u64, PersistentSourceKey)>,
     pub(super) lease_expirations_by_addr: Vec<BTreeSet<(u64, PersistentSourceKey)>>,
+    // #5269: address-only occupancy tokens — the translated reverse identity of a
+    // `port no-translation` / port-less flow mapped to its owning FORWARD flow.
+    // Populated by `reserve_address_only` (which denies a second flow that would
+    // claim an already-owned identity) and cleared by `release_flow` /
+    // `rollback_flow` for an `address_only` `LiveAllocation`. Distinct from the
+    // per-address occupancy bitmap, which tracks PAT port ownership.
+    address_only_owners: FxHashMap<AddressOnlyReverseKey, SourceNatFlowKey>,
     gc_counter: u32,
 }
 
@@ -955,6 +989,7 @@ impl PortAllocator {
                         persistent_key: None,
                         addr_index: abs,
                         deterministic: false,
+                        address_only: false,
                     },
                 );
                 self.shared
@@ -1087,6 +1122,7 @@ impl PortAllocator {
                     persistent_key,
                     addr_index: abs,
                     deterministic: false,
+                    address_only: false,
                 },
             );
             self.shared
@@ -1160,6 +1196,7 @@ impl PortAllocator {
                     persistent_key: Some(key),
                     addr_index,
                     deterministic: false,
+                    address_only: false,
                 },
             );
             self.shared.reuses_total.fetch_add(1, Ordering::Relaxed);
@@ -1228,6 +1265,18 @@ impl PortAllocator {
                 Self::remove_lease_expiration_locked(&mut live, addr_index, old_expires_at_ns, key);
                 Self::insert_lease_expiration_locked(&mut live, addr_index, expires_at_ns, key);
             }
+        } else if existing.address_only {
+            // #5269: address-only token — no pool port bit was claimed, so free
+            // the reverse-identity owner instead. Recompute the key from the
+            // stored translated tuple + the flow's remote endpoint (the SAME key
+            // `reserve_address_only` inserted).
+            live.address_only_owners.remove(&AddressOnlyReverseKey {
+                protocol: flow.protocol,
+                translated_ip: existing.translated.ip,
+                translated_port: existing.translated.port,
+                dst_ip: flow.dst_ip,
+                dst_port: flow.dst_port,
+            });
         } else {
             // Non-persistent (or deterministic) flow owns its port outright:
             // free the bit, recycling it unless it is a deterministic block
@@ -1292,6 +1341,16 @@ impl PortAllocator {
             if let Some((addr_index, expires_at_ns)) = insert_expiry {
                 Self::insert_lease_expiration_locked(&mut live, addr_index, expires_at_ns, key);
             }
+        } else if existing.address_only {
+            // #5269: address-only token rollback — clear the reverse-identity
+            // owner (no pool port bit to free), mirroring `release_flow`.
+            live.address_only_owners.remove(&AddressOnlyReverseKey {
+                protocol: flow.protocol,
+                translated_ip: existing.translated.ip,
+                translated_port: existing.translated.port,
+                dst_ip: flow.dst_ip,
+                dst_port: flow.dst_port,
+            });
         } else {
             self.free_translated_port(
                 existing.addr_index,
@@ -1368,6 +1427,7 @@ impl PortAllocator {
                         persistent_key: None,
                         addr_index: ip_idx,
                         deterministic: true,
+                        address_only: false,
                     },
                 );
                 self.shared
@@ -1445,6 +1505,7 @@ impl PortAllocator {
                         persistent_key: None,
                         addr_index: ip_idx,
                         deterministic: true,
+                        address_only: false,
                     },
                 );
                 self.shared
@@ -1519,9 +1580,106 @@ impl PortAllocator {
                 persistent_key: None,
                 addr_index,
                 deterministic: false,
+                address_only: false,
             },
         );
         true
+    }
+
+    /// #5269: mint an ADDRESS-ONLY occupancy token for a `port no-translation`
+    /// or port-less source-NAT flow. Unlike PAT ([`allocate_translation`]) no
+    /// pool PORT is consumed — the packet keeps its own source port on the wire
+    /// — but the translated REVERSE identity (protocol, chosen pool address,
+    /// PRESERVED source port, remote endpoint) is claimed so a SECOND flow that
+    /// would map to the SAME public reverse tuple is DENIED as exhaustion
+    /// instead of silently receiving an unowned duplicate whose replies the
+    /// reverse (1:N) index cannot disambiguate.
+    ///
+    /// The FIRST flow owns the identity and succeeds; a genuinely-colliding
+    /// second flow (same pool address, same preserved port, same remote — for a
+    /// port-less protocol, same pool address + remote) fails closed, mirroring
+    /// how a full port-translating pool reports exhaustion and the vSRX
+    /// address-only / persistent capacity limit. A NON-colliding address-only
+    /// flow (different preserved port, pool address, or remote) mints its own
+    /// token and succeeds.
+    ///
+    /// The token is recorded in `live_by_flow` (flagged `address_only`) AND in
+    /// `address_only_owners`, so the EXISTING teardown path
+    /// (`release_flow`/`rollback_flow` via `release_source_nat_allocation`,
+    /// already called for every reaped or delete-synced session) frees it — no
+    /// new delete site. Idempotent: a second packet of the SAME flow returns its
+    /// existing translated tuple.
+    pub(super) fn reserve_address_only(
+        &self,
+        flow: SourceNatFlowKey,
+        translated_ip: IpAddr,
+    ) -> Result<TranslatedTuple, super::source::SourceNatFailureReason> {
+        let translated = TranslatedTuple {
+            ip: translated_ip,
+            // Port-bearing protocols preserve their source port; a port-less
+            // protocol carries 0 here. This value is NOT written to the wire
+            // (the caller leaves `rewrite_src_port` unset); it keys the reverse
+            // identity and lets the SAME `release_flow` free the token.
+            port: flow.src_port,
+        };
+        let rkey = AddressOnlyReverseKey {
+            protocol: flow.protocol,
+            translated_ip,
+            translated_port: flow.src_port,
+            dst_ip: flow.dst_ip,
+            dst_port: flow.dst_port,
+        };
+        let mut live = self.shared.live.lock().unwrap_or_else(|e| e.into_inner());
+        // Idempotent re-entry: a second packet of the same flow (racing session
+        // install) reuses its first decision rather than re-keying.
+        if let Some(existing) = live.live_by_flow.get(&flow) {
+            self.shared.reuses_total.fetch_add(1, Ordering::Relaxed);
+            return Ok(existing.translated);
+        }
+        // Collision: the reverse identity is already owned by a DIFFERENT flow.
+        // Two flows sharing one public reverse tuple cannot coexist (their
+        // replies are indistinguishable), so deny the second — the address-only
+        // capacity limit. `flow` is not in `live_by_flow` here (checked above),
+        // so any existing owner is necessarily a different flow.
+        if live.address_only_owners.contains_key(&rkey) {
+            self.shared.exhaustion_total.fetch_add(1, Ordering::Relaxed);
+            return Err(super::source::SourceNatFailureReason::AllocatorExhausted);
+        }
+        if live.live_by_flow.len() >= self.shared.max_tracked_flows {
+            self.shared.exhaustion_total.fetch_add(1, Ordering::Relaxed);
+            return Err(super::source::SourceNatFailureReason::AllocatorExhausted);
+        }
+        live.address_only_owners.insert(rkey, flow);
+        live.live_by_flow.insert(
+            flow,
+            LiveAllocation {
+                translated,
+                persistent_key: None,
+                // No pool-port bit is claimed for an address-only token, so the
+                // occupancy address index is irrelevant to its release.
+                addr_index: 0,
+                deterministic: false,
+                address_only: true,
+            },
+        );
+        self.shared
+            .allocations_total
+            .fetch_add(1, Ordering::Relaxed);
+        Ok(translated)
+    }
+
+    /// Test-only: snapshot the address-only reverse-identity ownership map so a
+    /// white-box test can assert the reverse index resolves each public tuple to
+    /// exactly one owning forward flow (#5269).
+    #[cfg(test)]
+    pub(super) fn debug_address_only_owners(
+        &self,
+    ) -> Vec<(AddressOnlyReverseKey, SourceNatFlowKey)> {
+        let live = self.shared.live.lock().unwrap_or_else(|e| e.into_inner());
+        live.address_only_owners
+            .iter()
+            .map(|(k, v)| (*k, *v))
+            .collect()
     }
 
     pub(super) fn snapshot(&self) -> PortAllocatorSnapshot {

--- a/userspace-dp/src/nat/source.rs
+++ b/userspace-dp/src/nat/source.rs
@@ -15,6 +15,25 @@
 // used by the address-only `match_source_nat` callers; it keeps its
 // historical round-robin `try_next_port` behavior (never frame-written,
 // because the rewriters gate every L4 write on `has_l4_ports`).
+//
+// #5269: the address-only branch (`port no-translation` on a port-bearing
+// protocol, or a port-less protocol) selects a pool address but PRESERVES the
+// source port on the wire, so — unlike PAT — it cannot make the translated
+// `(pool_addr, port)` unique by handing out a fresh port. It therefore MINTS an
+// occupancy token via `PortAllocator::reserve_address_only`, keyed on the
+// translated REVERSE identity (protocol, pool address, preserved source port,
+// remote endpoint). The first flow to claim an identity owns it; a genuinely-
+// colliding second flow (same identity) is DENIED as exhaustion
+// (`AllocatorExhausted` -> `SourceNatLookup::Unavailable` -> the same drop /
+// `nat_alloc_fail` path a full port-translating pool takes) rather than
+// receiving an unowned duplicate whose replies the reverse (1:N) index cannot
+// disambiguate — the vSRX address-only / persistent capacity limit. A non-
+// colliding flow (different preserved port, pool address, or remote) mints its
+// own token and succeeds. The token is freed by the SAME teardown path as a PAT
+// port (`release_source_nat_allocation`), which now derives the preserved port
+// from the flow key when the decision carried no port rewrite. The synthetic
+// `protocol == 0` wrapper mints NO token (never a real framed flow / reverse
+// session entry).
 
 use super::allocator::{
     DeterministicV4, DeterministicV6, NS_PER_SEC, PersistentSourceKey, PoolAddressFamily,
@@ -753,9 +772,14 @@ fn release_source_nat_allocation_with_mode(
     let Some(rewrite_src) = nat.rewrite_src else {
         return;
     };
-    let Some(rewrite_src_port) = nat.rewrite_src_port else {
-        return;
-    };
+    // #5269: a PAT decision carries its translated port in `rewrite_src_port`; an
+    // ADDRESS-ONLY decision (`port no-translation` / port-less) leaves it unset
+    // but minted an occupancy token keyed on the PRESERVED source port. Fall back
+    // to the flow's own source port so the SAME `release_flow` / `rollback_flow`
+    // frees that token. A non-pool address translation (interface-mode / static
+    // SNAT) also reaches here now, but owns no pool `live_by_flow` entry, so the
+    // per-rule release is a harmless no-op.
+    let rewrite_src_port = nat.rewrite_src_port.unwrap_or(key.src_port);
     let translated = TranslatedTuple {
         ip: rewrite_src,
         port: rewrite_src_port,
@@ -1249,28 +1273,61 @@ pub(crate) fn match_source_nat_result_for_tuple(
                         rule.address_persistent,
                     );
                     let pool_addr = rule.pool_addresses_v4[addr_idx];
-                    // Port-less: IP-only translation. Tuple-unknown: a
-                    // round-robin port (legacy, never frame-written).
-                    // no-translation: preserve the source port (None). #3906.
-                    let port = if tuple_unknown && !rule.no_translation {
-                        match rule.pool_allocator.try_next_port(addr_idx) {
-                            Ok(port) => Some(port),
-                            Err(reason) => {
-                                return SourceNatLookup::Unavailable(
-                                    SourceNatFailure::for_rule(rule, reason),
-                                );
+                    if tuple_unknown {
+                        // Synthetic address-only wrapper (protocol == 0, never a
+                        // framed packet): keep the historical round-robin port for
+                        // the non-no-translation case, or preserve (None) for
+                        // no-translation. No occupancy token — there is no real
+                        // flow / reverse session entry to disambiguate and the
+                        // returned port is never written to a frame.
+                        let port = if rule.no_translation {
+                            None
+                        } else {
+                            match rule.pool_allocator.try_next_port(addr_idx) {
+                                Ok(port) => Some(port),
+                                Err(reason) => {
+                                    return SourceNatLookup::Unavailable(
+                                        SourceNatFailure::for_rule(rule, reason),
+                                    );
+                                }
                             }
+                        };
+                        return SourceNatLookup::Matched(NatDecision {
+                            rewrite_src: Some(IpAddr::V4(pool_addr)),
+                            rewrite_dst: None,
+                            rewrite_src_port: port,
+                            rewrite_dst_port: None,
+                            ..NatDecision::default()
+                        });
+                    }
+                    // #5269: a REAL address-only flow (`port no-translation` on a
+                    // port-bearing protocol, or a port-less protocol). Mint an
+                    // occupancy token for the translated reverse identity so a
+                    // second flow that would collide on the same public tuple is
+                    // DENIED as exhaustion instead of receiving an unowned
+                    // duplicate the reverse (1:N) index cannot disambiguate. The
+                    // wire packet still keeps its own source port (rewrite_src_port
+                    // left None — checksum.rs preserves it; the port-less frame
+                    // rewriter is gated on `has_l4_ports`).
+                    match rule
+                        .pool_allocator
+                        .reserve_address_only(flow, IpAddr::V4(pool_addr))
+                    {
+                        Ok(translated) => {
+                            return SourceNatLookup::Matched(NatDecision {
+                                rewrite_src: Some(translated.ip),
+                                rewrite_dst: None,
+                                rewrite_src_port: None,
+                                rewrite_dst_port: None,
+                                ..NatDecision::default()
+                            });
                         }
-                    } else {
-                        None
-                    };
-                    return SourceNatLookup::Matched(NatDecision {
-                        rewrite_src: Some(IpAddr::V4(pool_addr)),
-                        rewrite_dst: None,
-                        rewrite_src_port: port,
-                        rewrite_dst_port: None,
-                        ..NatDecision::default()
-                    });
+                        Err(reason) => {
+                            return SourceNatLookup::Unavailable(SourceNatFailure::for_rule(
+                                rule, reason,
+                            ));
+                        }
+                    }
                 }
                 let translated = match rule.pool_allocator.allocate_translation(
                     flow,
@@ -1308,26 +1365,52 @@ pub(crate) fn match_source_nat_result_for_tuple(
                     );
                     let v6_idx = addr_idx - v6_offset;
                     let pool_addr = rule.pool_addresses_v6[v6_idx];
-                    // no-translation: preserve the source port (None). #3906.
-                    let port = if tuple_unknown && !rule.no_translation {
-                        match rule.pool_allocator.try_next_port(addr_idx) {
-                            Ok(port) => Some(port),
-                            Err(reason) => {
-                                return SourceNatLookup::Unavailable(
-                                    SourceNatFailure::for_rule(rule, reason),
-                                );
+                    if tuple_unknown {
+                        // Synthetic address-only wrapper (protocol == 0): historical
+                        // round-robin port (non-no-translation) or preserve (None).
+                        // No occupancy token — see the v4 branch above (#5269).
+                        let port = if rule.no_translation {
+                            None
+                        } else {
+                            match rule.pool_allocator.try_next_port(addr_idx) {
+                                Ok(port) => Some(port),
+                                Err(reason) => {
+                                    return SourceNatLookup::Unavailable(
+                                        SourceNatFailure::for_rule(rule, reason),
+                                    );
+                                }
                             }
+                        };
+                        return SourceNatLookup::Matched(NatDecision {
+                            rewrite_src: Some(IpAddr::V6(pool_addr)),
+                            rewrite_dst: None,
+                            rewrite_src_port: port,
+                            rewrite_dst_port: None,
+                            ..NatDecision::default()
+                        });
+                    }
+                    // #5269: REAL address-only flow — mint a reverse-identity
+                    // occupancy token (deny a colliding second flow as exhaustion),
+                    // symmetric with the v4 branch above.
+                    match rule
+                        .pool_allocator
+                        .reserve_address_only(flow, IpAddr::V6(pool_addr))
+                    {
+                        Ok(translated) => {
+                            return SourceNatLookup::Matched(NatDecision {
+                                rewrite_src: Some(translated.ip),
+                                rewrite_dst: None,
+                                rewrite_src_port: None,
+                                rewrite_dst_port: None,
+                                ..NatDecision::default()
+                            });
                         }
-                    } else {
-                        None
-                    };
-                    return SourceNatLookup::Matched(NatDecision {
-                        rewrite_src: Some(IpAddr::V6(pool_addr)),
-                        rewrite_dst: None,
-                        rewrite_src_port: port,
-                        rewrite_dst_port: None,
-                        ..NatDecision::default()
-                    });
+                        Err(reason) => {
+                            return SourceNatLookup::Unavailable(SourceNatFailure::for_rule(
+                                rule, reason,
+                            ));
+                        }
+                    }
                 }
                 let translated = match rule.pool_allocator.allocate_translation(
                     flow,

--- a/userspace-dp/src/nat/tests_pool.rs
+++ b/userspace-dp/src/nat/tests_pool.rs
@@ -11,7 +11,9 @@ use super::allocator::{
     PersistentSourceKey, PoolAddressFamily, TranslatedTuple, deterministic_indices_v6,
     reverse_deterministic_v4, reverse_deterministic_v6, sticky_pool_index,
 };
-use super::source::{PersistentNatPermit, SOURCE_NAT_PROTO_ANY, SourceNatFlowKey};
+use super::source::{
+    PersistentNatPermit, SOURCE_NAT_PROTO_ANY, SourceNatFailureReason, SourceNatFlowKey,
+};
 use super::destination::{PROTO_ANY, PROTO_TCP, PROTO_UDP};
 use super::*;
 use crate::ip_proto::{PROTO_ESP, PROTO_GRE, PROTO_ICMP, PROTO_ICMPV6};
@@ -511,6 +513,339 @@ fn pool_snat_no_translation_preserves_source_port() {
     assert_eq!(
         status[0].used_ports, 0,
         "no-translation must NOT allocate a pool port (source port preserved)",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #5269: address-only occupancy tokens (port no-translation / port-less).
+//
+// The address-only branch selects a pool address but must ALSO mint an
+// occupancy token keyed on the translated REVERSE identity (protocol, pool
+// address, PRESERVED source port, remote endpoint), so two internal flows behind
+// a one-address pool cannot both receive the SAME public tuple. Before the fix
+// the branch minted nothing: a second colliding flow got an identical translated
+// tuple the reverse (1:N) index could not disambiguate, stranding / mis-
+// delivering the later flow's replies under the first session. A genuinely-
+// colliding second flow is now DENIED as exhaustion (mirroring how a full port-
+// translating pool behaves and the vSRX address-only capacity limit); a non-
+// colliding flow mints its own token and succeeds.
+// ---------------------------------------------------------------------------
+
+fn addr_only_lookup(
+    rules: &[SourceNatRule],
+    src_ip: &str,
+    src_port: u16,
+    dst_ip: &str,
+    dst_port: u16,
+    protocol: u8,
+) -> SourceNatLookup {
+    let mut counter = None;
+    match_source_nat_result_for_tuple(
+        rules,
+        &NatScopeCtx::default(),
+        "lan",
+        "wan",
+        src_ip.parse().expect("src"),
+        dst_ip.parse().expect("dst"),
+        protocol,
+        src_port,
+        dst_port,
+        None,
+        None,
+        0,
+        false,
+        false,
+        &mut counter,
+    )
+}
+
+fn one_address_notrans_rule() -> Vec<SourceNatRule> {
+    parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "pool-notrans".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "my-pool".to_string(),
+        pool_addresses: vec!["203.0.113.1/32".to_string()],
+        port_low: 1024,
+        port_high: 65535,
+        pool_no_translation: true,
+        ..SourceNATRuleSnapshot::default()
+    }])
+}
+
+// #5269 FAIL-ON-REVERT: `port no-translation`, ONE rule / ONE pool / ONE
+// address. Flow A gets the public tuple AND an occupancy token; the reverse
+// index resolves the public tuple to exactly A. Flow B (a different internal
+// host, SAME preserved port + SAME remote) would collide on the identical public
+// tuple and MUST be denied as exhaustion — not handed the duplicate. Reverting
+// the fix (drop the `reserve_address_only` mint) makes B return `Matched` with
+// A's rewrite_src and `rewrite_src_port: None` — an unowned duplicate — turning
+// the `Unavailable` assertion RED.
+#[test]
+fn pool_snat_no_translation_collision_denies_second_flow_5269() {
+    let rules = one_address_notrans_rule();
+
+    let a = expect_snat_decision(addr_only_lookup(
+        &rules,
+        "10.0.1.100",
+        12345,
+        "8.8.8.8",
+        443,
+        PROTO_TCP,
+    ));
+    assert_eq!(a.rewrite_src, Some("203.0.113.1".parse().unwrap()));
+    // Wire contract (unchanged): the source port is PRESERVED, never rewritten.
+    assert_eq!(a.rewrite_src_port, None);
+
+    // The reverse index resolves the public tuple to EXACTLY flow A.
+    let flow_a = SourceNatFlowKey {
+        protocol: PROTO_TCP,
+        src_ip: "10.0.1.100".parse().unwrap(),
+        dst_ip: "8.8.8.8".parse().unwrap(),
+        src_port: 12345,
+        dst_port: 443,
+    };
+    let owners = rules[0].pool_allocator.debug_address_only_owners();
+    assert_eq!(owners.len(), 1, "flow A must mint exactly one occupancy token");
+    assert_eq!(owners[0].1, flow_a, "reverse index must resolve to flow A");
+    assert_eq!(
+        owners[0].0.translated_ip,
+        "203.0.113.1".parse::<IpAddr>().unwrap()
+    );
+    assert_eq!(owners[0].0.translated_port, 12345);
+
+    // Flow B: DIFFERENT internal host, SAME preserved port + SAME remote -> SAME
+    // public tuple (203.0.113.1:12345 -> 8.8.8.8:443). It must fail closed.
+    match addr_only_lookup(&rules, "10.0.1.101", 12345, "8.8.8.8", 443, PROTO_TCP) {
+        SourceNatLookup::Unavailable(f) => assert_eq!(
+            f.reason,
+            SourceNatFailureReason::AllocatorExhausted,
+            "colliding address-only flow must fail closed as exhaustion",
+        ),
+        other => panic!("flow B must be denied (exhaustion), got {other:?}"),
+    }
+
+    // The reverse index STILL resolves uniquely to flow A — B minted nothing.
+    let owners_after = rules[0].pool_allocator.debug_address_only_owners();
+    assert_eq!(owners_after.len(), 1, "denied flow B must not add a token");
+    assert_eq!(owners_after[0].1, flow_a);
+
+    // No pool PORT is consumed (address-only tokens are off the port bitmap).
+    let status = source_nat_pool_statuses(&rules);
+    assert_eq!(status[0].used_ports, 0);
+    assert_eq!(status[0].live_flows, 1, "only flow A is tracked");
+}
+
+// #5269: the address-only token is freed by the SAME teardown path used for PAT
+// ports (`release_source_nat_allocation`), so a colliding identity becomes
+// reusable after the first flow tears down — no leak.
+#[test]
+fn pool_snat_no_translation_token_released_on_teardown_5269() {
+    let rules = one_address_notrans_rule();
+
+    let a = expect_snat_decision(addr_only_lookup(
+        &rules,
+        "10.0.1.100",
+        12345,
+        "8.8.8.8",
+        443,
+        PROTO_TCP,
+    ));
+    assert_eq!(rules[0].pool_allocator.debug_address_only_owners().len(), 1);
+
+    // Tear down flow A. `release_source_nat_allocation` now derives the preserved
+    // port from the flow key (the decision left `rewrite_src_port` unset) and
+    // clears the reverse-identity token.
+    let key_a = session_key_from_src("10.0.1.100", 12345, "8.8.8.8", 443);
+    release_source_nat_allocation(&rules, &key_a, a, false, 1);
+    assert_eq!(
+        rules[0].pool_allocator.debug_address_only_owners().len(),
+        0,
+        "token must be freed on teardown (no leak)",
+    );
+    assert_eq!(source_nat_pool_statuses(&rules)[0].live_flows, 0);
+
+    // The previously-colliding flow B now succeeds (identity is free again).
+    let b = expect_snat_decision(addr_only_lookup(
+        &rules,
+        "10.0.1.101",
+        12345,
+        "8.8.8.8",
+        443,
+        PROTO_TCP,
+    ));
+    assert_eq!(b.rewrite_src, Some("203.0.113.1".parse().unwrap()));
+    assert_eq!(rules[0].pool_allocator.debug_address_only_owners().len(), 1);
+}
+
+// #5269 FAIL-ON-REVERT: two port-less (GRE) flows to a one-address pool. Same
+// remote -> indistinguishable reverse identity -> the second is denied as
+// exhaustion. Different remote -> distinct reverse identity -> disambiguated and
+// admitted. Either way the reverse index is unambiguous. Reverting the mint lets
+// the same-remote second flow return `Matched` with the duplicate `(pool_addr)`
+// tuple (`rewrite_src_port: None`), turning the `Unavailable` assertion RED.
+#[test]
+fn pool_snat_portless_gre_collision_and_disambiguation_5269() {
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "pool-gre".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "my-pool".to_string(),
+        pool_addresses: vec!["203.0.113.1/32".to_string()],
+        port_low: 1024,
+        port_high: 65535,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+
+    // Flow A: GRE 10.0.1.100 -> 8.8.8.8 (port-less; src/dst port 0).
+    let a = expect_snat_decision(addr_only_lookup(
+        &rules,
+        "10.0.1.100",
+        0,
+        "8.8.8.8",
+        0,
+        PROTO_GRE,
+    ));
+    assert_eq!(a.rewrite_src, Some("203.0.113.1".parse().unwrap()));
+    assert_eq!(a.rewrite_src_port, None, "port-less flow must not carry a port");
+    assert_eq!(rules[0].pool_allocator.debug_address_only_owners().len(), 1);
+
+    // Flow B: GRE from a DIFFERENT host to the SAME remote — indistinguishable on
+    // the reverse path -> denied as exhaustion (address-only capacity limit).
+    match addr_only_lookup(&rules, "10.0.1.101", 0, "8.8.8.8", 0, PROTO_GRE) {
+        SourceNatLookup::Unavailable(f) => {
+            assert_eq!(f.reason, SourceNatFailureReason::AllocatorExhausted)
+        }
+        other => panic!("colliding GRE flow must be denied, got {other:?}"),
+    }
+    assert_eq!(rules[0].pool_allocator.debug_address_only_owners().len(), 1);
+
+    // Flow C: GRE from a third host to a DIFFERENT remote — reverse identity
+    // differs by remote IP -> disambiguated and admitted.
+    let c = expect_snat_decision(addr_only_lookup(
+        &rules,
+        "10.0.1.102",
+        0,
+        "9.9.9.9",
+        0,
+        PROTO_GRE,
+    ));
+    assert_eq!(c.rewrite_src, Some("203.0.113.1".parse().unwrap()));
+    assert_eq!(c.rewrite_src_port, None);
+
+    // Two owners, each keyed by a DISTINCT remote — no two flows share a public
+    // reverse tuple, and each identity resolves to exactly one owning flow.
+    let owners = rules[0].pool_allocator.debug_address_only_owners();
+    assert_eq!(owners.len(), 2, "A (8.8.8.8) and C (9.9.9.9) own distinct identities");
+    let mut remotes: Vec<IpAddr> = owners.iter().map(|(k, _)| k.dst_ip).collect();
+    remotes.sort();
+    assert_eq!(
+        remotes,
+        vec![
+            "8.8.8.8".parse::<IpAddr>().unwrap(),
+            "9.9.9.9".parse::<IpAddr>().unwrap()
+        ],
+    );
+    let mut owning_srcs: Vec<IpAddr> = owners.iter().map(|(_, f)| f.src_ip).collect();
+    owning_srcs.sort();
+    assert_eq!(
+        owning_srcs,
+        vec![
+            "10.0.1.100".parse::<IpAddr>().unwrap(),
+            "10.0.1.102".parse::<IpAddr>().unwrap()
+        ],
+    );
+    assert_eq!(source_nat_pool_statuses(&rules)[0].used_ports, 0);
+}
+
+// #5269 (no false exhaustion): distinct preserved ports on a ONE-address pool
+// mint distinct reverse identities, so both address-only flows succeed.
+#[test]
+fn pool_snat_no_translation_distinct_ports_both_succeed_5269() {
+    let rules = one_address_notrans_rule();
+
+    let a = expect_snat_decision(addr_only_lookup(
+        &rules,
+        "10.0.1.100",
+        12345,
+        "8.8.8.8",
+        443,
+        PROTO_TCP,
+    ));
+    let b = expect_snat_decision(addr_only_lookup(
+        &rules,
+        "10.0.1.100",
+        12346,
+        "8.8.8.8",
+        443,
+        PROTO_TCP,
+    ));
+    assert_eq!(a.rewrite_src, Some("203.0.113.1".parse().unwrap()));
+    assert_eq!(b.rewrite_src, Some("203.0.113.1".parse().unwrap()));
+    assert_eq!(a.rewrite_src_port, None);
+    assert_eq!(b.rewrite_src_port, None);
+
+    let owners = rules[0].pool_allocator.debug_address_only_owners();
+    assert_eq!(owners.len(), 2, "distinct preserved ports mint distinct tokens");
+    let mut ports: Vec<u16> = owners.iter().map(|(k, _)| k.translated_port).collect();
+    ports.sort();
+    assert_eq!(ports, vec![12345, 12346]);
+    assert_eq!(source_nat_pool_statuses(&rules)[0].used_ports, 0);
+}
+
+// #5269 (no false exhaustion): a TWO-address pool round-robins two colliding-port
+// flows onto DIFFERENT pool addresses, so both address-only flows succeed with
+// distinct reverse identities.
+#[test]
+fn pool_snat_no_translation_two_address_pool_both_succeed_5269() {
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "pool-notrans2".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "my-pool".to_string(),
+        pool_addresses: vec!["203.0.113.1/32".to_string(), "203.0.113.2/32".to_string()],
+        port_low: 1024,
+        port_high: 65535,
+        pool_no_translation: true,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+
+    // Same preserved port + remote, but round-robin places the two flows on
+    // different pool addresses -> distinct identities -> both admitted.
+    let a = expect_snat_decision(addr_only_lookup(
+        &rules,
+        "10.0.1.100",
+        12345,
+        "8.8.8.8",
+        443,
+        PROTO_TCP,
+    ));
+    let b = expect_snat_decision(addr_only_lookup(
+        &rules,
+        "10.0.1.101",
+        12345,
+        "8.8.8.8",
+        443,
+        PROTO_TCP,
+    ));
+    assert_ne!(
+        a.rewrite_src, b.rewrite_src,
+        "round-robin must place the two flows on different pool addresses",
+    );
+
+    let owners = rules[0].pool_allocator.debug_address_only_owners();
+    assert_eq!(owners.len(), 2, "two-address pool mints two distinct tokens");
+    let mut ips: Vec<IpAddr> = owners.iter().map(|(k, _)| k.translated_ip).collect();
+    ips.sort();
+    assert_eq!(
+        ips,
+        vec![
+            "203.0.113.1".parse::<IpAddr>().unwrap(),
+            "203.0.113.2".parse::<IpAddr>().unwrap()
+        ],
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes **#5269** (HIGH, nat): the pool-mode source-NAT **address-only** branch minted **unowned, ambiguous public tuples**.

In `userspace-dp/src/nat/source.rs`, the address-only branch (`port no-translation` on a port-bearing protocol, or a port-less protocol such as GRE/ESP) selected a pool address but left `rewrite_src_port` unset and **never called `allocate_translation`** — so **no occupancy token was minted**. Two internal flows behind a one-address pool that map to the same translated reverse tuple (same pool address, same preserved source port, same remote — or two port-less flows to the same pool address + remote) both received **identical public tuples** with no ownership token. The reverse (1:N) index cannot disambiguate two sessions that share one reverse tuple, so the later flow's replies were **stranded or mis-delivered under the first session**. Reproduces with **ONE rule / ONE pool / ONE address**. Distinct from #5144 (separate allocator domains across overlapping pools).

## Root cause

The address-only branch is the deliberate counterpart to PAT: PAT keeps `(pool_addr, port)` unique by handing out a **fresh** port (`allocate_translation`), so it never needs to consult the destination. Address-only **cannot move the port** (it is preserved, or absent), so nothing enforced uniqueness — the missing occupancy token.

## Fix

- New `PortAllocator::reserve_address_only` mints an occupancy token keyed on the translated **reverse identity** `(protocol, pool address, preserved source port, remote IP, remote port)` — exactly the key `reverse_session_key` builds, so the token is unique **iff** the reverse session entry is.
- It consumes **no pool port** (wire contract unchanged: `rewrite_src_port` stays `None`; the #3111 port-less and #3906 no-translation `None` tests still pass). The first flow owns the identity.
- A genuinely-**colliding** second flow is **denied as exhaustion** (`AllocatorExhausted` → `SourceNatLookup::Unavailable`), routed through the **same** drop / `nat_alloc_fail` path a full port-translating pool takes — mirroring the PAT discipline and the vSRX address-only / persistent capacity limit. It never silently passes an ambiguous tuple and does not invent a new drop path.
- A **non-colliding** flow (different preserved port, pool address, or remote) mints its own token and succeeds → **no false exhaustion** on multi-address / multi-remote traffic.

### GRE / port-less handling

The reverse identity carries port 0 for a port-less flow, so two GRE flows to the **same** pool address + remote (indistinguishable on the reverse path) collide and the second is **denied**, while GRE flows to **different** remotes are **disambiguated** and both admitted. The token lives off the PAT occupancy bitmap (which only spans `[port_low, port_high]` and cannot hold an arbitrary preserved port or port 0), in a dedicated `address_only_owners` reverse-identity map.

### Release / lifecycle

The token is freed by the **same** teardown path as a PAT port. `release_source_nat_allocation` now derives the preserved port from the flow key when the decision carried no port rewrite, so `release_flow` / `rollback_flow` clear the token — **no new delete site**. Interface-mode / static SNAT (also no port rewrite) reach `release_flow` too but own no pool `live_by_flow` entry, so it is a harmless no-op.

The synthetic `protocol == 0` address-only wrapper (`match_source_nat`, never a real framed flow / reverse session entry) mints **no** token — its historical round-robin behavior is preserved.

## #5144 non-regression

The change is confined to **single-pool** address-only token minting; the overlapping-pool allocator-domain separation from #5144 is untouched.

## Tests (fail-on-revert, `nat::tests_pool`)

- `pool_snat_no_translation_collision_denies_second_flow_5269` — one rule/pool/address `port no-translation`: flow A mints a token, reverse index resolves the public tuple to A; would-collide flow B (same preserved port + remote) is denied as exhaustion, reverse index still resolves uniquely to A.
- `pool_snat_no_translation_token_released_on_teardown_5269` — teardown frees the token; the identity is reusable.
- `pool_snat_portless_gre_collision_and_disambiguation_5269` — two GRE flows to a one-address pool: denied (same remote) / disambiguated (different remote), reverse index unambiguous.
- `pool_snat_no_translation_distinct_ports_both_succeed_5269` and `pool_snat_no_translation_two_address_pool_both_succeed_5269` — non-colliding flows both succeed with distinct tokens (no false exhaustion).

**RED-on-revert verified:** neutering the mint turns all five RED (flow A records no owner; flow B is handed the duplicate tuple).

## Validation

- `cargo build --release` — exit 0.
- `cargo test --release` — exit 0, **3905 passed, 0 failed**.

## Docs

Updated the `nat/source.rs` module-header doc describing the address-only occupancy-token minting and the collision-as-exhaustion semantics.

## Out of scope

HA session-sync reservation of address-only tokens on the standby (`reserve_synced_source_nat_allocation` still skips no-port decisions, as it always has) is a separate, pre-existing gap analogous to #4388/#4512 and is not addressed here.

Closes #5269

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
