### PR TITLE
api: redact SNMP community secret in REST show-text (#5315)

### DIFF
--- a/pkg/api/show_text.go
+++ b/pkg/api/show_text.go
@@ -75,9 +75,20 @@ func (s *Server) showTextHandler(w http.ResponseWriter, r *http.Request) {
 			}
 			if len(snmpCfg.Communities) > 0 {
 				buf.WriteString("Communities:\n")
+				// #5315: the SNMPv1/v2c community string IS the shared secret
+				// (it authorizes the request on the wire) and it is also the
+				// Communities map key. Emitting the raw key here leaked the
+				// cleartext credential over the REST show-text surface, which
+				// has no login-class authz and is loopback-open by default.
+				// Mask it with the shared raw-AST placeholder — the same token
+				// pkg/cli `show snmp` uses for a redacted community (#4111) — so
+				// this manual renderer matches the established redaction
+				// boundary. The authorization mode stays visible; only the
+				// secret is masked. Iteration still runs over the real (sorted)
+				// keys so ordering stays deterministic (#4712).
 				for _, name := range sortedKeys(snmpCfg.Communities) {
 					comm := snmpCfg.Communities[name]
-					fmt.Fprintf(&buf, "  %s: %s\n", name, comm.Authorization)
+					fmt.Fprintf(&buf, "  %s: %s\n", config.SecretDataPlaceholder, comm.Authorization)
 				}
 			}
 			if len(snmpCfg.TrapGroups) > 0 {

--- a/pkg/api/show_text_snmp_redact_5315_test.go
+++ b/pkg/api/show_text_snmp_redact_5315_test.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5315: the REST show-text `snmp` renderer emitted the raw SNMPv1/v2c
+// community string. The community string IS the shared secret (it authorizes
+// the request on the wire) and is also the Communities map key, so printing the
+// key leaked a cleartext bearer credential over a surface that has no
+// login-class authz and is loopback-open by default. The fix masks the key with
+// config.SecretDataPlaceholder — the same raw-AST redaction token pkg/cli
+// `show snmp` uses for a redacted community (#4111) — while leaving the
+// authorization mode and every non-secret field (Location, Contact, trap-group
+// targets) rendered normally.
+//
+// RED-on-revert: reverting show_text.go to `Fprintf(..., name, ...)` makes the
+// cleartext-leak assertion fail (the secret name reappears in the body and the
+// placeholder disappears).
+func TestShowTextSNMPCommunityRedacted(t *testing.T) {
+	const secretCommunity = "LEAK-SNMP-COMMUNITY"
+
+	s := stageShowTextConfig(t, []string{
+		// The community NAME (map key) is the secret.
+		"set snmp community " + secretCommunity + " authorization read-only",
+		// Non-secret fields that must still render in cleartext.
+		"set snmp location DATACENTER-RACK-42",
+		"set snmp contact NOC-TEAM",
+		"set snmp trap-group primary targets 192.0.2.10",
+	})
+
+	out := renderShowTextBody(t, s, "snmp")
+
+	// 1. The cleartext community secret must NOT appear anywhere in the body.
+	if strings.Contains(out, secretCommunity) {
+		t.Errorf("SNMP community secret %q leaked in cleartext over REST show-text:\n%s",
+			secretCommunity, out)
+	}
+
+	// 2. The redaction placeholder must be emitted in its place (matches the
+	//    pkg/cli #4111 redaction token exactly).
+	if !strings.Contains(out, config.SecretDataPlaceholder) {
+		t.Errorf("expected redaction placeholder %q in SNMP show-text output:\n%s",
+			config.SecretDataPlaceholder, out)
+	}
+
+	// 3. The community's authorization MODE is not a secret and must still be
+	//    rendered next to the masked name (structure/formatting preserved).
+	if !strings.Contains(out, config.SecretDataPlaceholder+": read-only") {
+		t.Errorf("expected masked community line %q: read-only in output:\n%s",
+			config.SecretDataPlaceholder, out)
+	}
+
+	// 4. Non-secret sibling fields in the same render must NOT be over-redacted.
+	for _, want := range []string{"DATACENTER-RACK-42", "NOC-TEAM", "192.0.2.10"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("non-secret field %q missing from SNMP show-text output (over-redaction):\n%s",
+				want, out)
+		}
+	}
+}

--- a/pkg/api/show_text_sorted_4712_test.go
+++ b/pkg/api/show_text_sorted_4712_test.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
 )
 
 // #4712: the /show-text handlers render config maps (schedulers, snmp,
@@ -149,8 +151,20 @@ func TestShowTextDeterministicSortedOrder(t *testing.T) {
 	})
 
 	t.Run("snmp", func(t *testing.T) {
+		// #5315: the community string is the shared secret AND the map key, so
+		// it is now masked with config.SecretDataPlaceholder in the render — the
+		// cleartext comm_* names no longer appear. Determinism (the #4712
+		// contract) is still exercised: iteration runs over the real sorted keys
+		// before masking, so the byte-identical-across-renders assertion below
+		// still fails RED if the sorted-iteration is reverted to a raw map range.
 		out := assertDeterministic(t, s, "snmp", renders)
-		comms := []string{"comm_alpha", "comm_bravo", "comm_charlie", "comm_delta"}
-		assertSortedEntries(t, "snmp", "Communities", out, comms)
+		for _, name := range []string{"comm_alpha", "comm_bravo", "comm_charlie", "comm_delta"} {
+			if strings.Contains(out, name) {
+				t.Errorf("snmp: community secret %q leaked in cleartext:\n%s", name, out)
+			}
+		}
+		if !strings.Contains(out, config.SecretDataPlaceholder) {
+			t.Errorf("snmp: expected redaction placeholder %q in output:\n%s", config.SecretDataPlaceholder, out)
+		}
 	})
 }


### PR DESCRIPTION
## Summary

`GET /api/v1/show-text?topic=snmp` returned the **cleartext SNMPv1/v2c
community string**. The community string IS the shared secret (it
authorizes the request on the wire) and it is also the key of the
`SNMPConfig.Communities` map, so `showTextHandler` in
`pkg/api/show_text.go` printed the secret straight out via
`Fprintf("  %s: %s", name, comm.Authorization)`.

REST auth is optional on the loopback default and there is no
login-class authz on this surface (and `web-management https` can bind
it non-loopback), so any reachable client read the cleartext community
and could reuse it for SNMP access to this or other devices.

## Root cause

`#4111`/`#4135` closed this leak only for the **`pkg/cli` `show snmp`**
renderer (which masks the community with `config.SecretDataPlaceholder`
for non-super-user login classes). This **manual REST renderer** was a
parallel code path that was missed and still emitted the raw map key.

## Fix

Route the community through the established redaction boundary. The
render now emits `config.SecretDataPlaceholder` (`##SECRET-DATA##`) in
place of the community name — the exact raw-AST redaction token
`pkg/cli` uses for a redacted community — so the CLI and REST surfaces
stay consistent. The REST path masks **unconditionally** (there is no
login-class context here to grant cleartext, unlike the CLI). The
authorization mode stays visible; only the secret is masked. Iteration
still runs over the real sorted keys, so the `#4712` determinism
guarantee is preserved.

### Other secret leaves in this renderer

The `snmp` topic is the **only** secret leaf `show_text.go` renders.
The other topics (`schedulers`, `dhcp-relay`, `firewall`, `alg`,
`dynamic-address`, `address-book`, `applications`, `flow-*`, `nat-*`)
emit no values classified as secret leaves by the `pkg/config`
redaction set (`secretIndices` in `ast_redact.go`). `show-text` does
not render the SNMPv3 USM auth/priv passwords at all. So no sibling
leak remains.

## Tests (fail-on-revert, `pkg/api`)

- **New `TestShowTextSNMPCommunityRedacted`** — stages a community named
  `LEAK-SNMP-COMMUNITY` plus non-secret fields (location, contact,
  trap-group target) and asserts: the cleartext secret is absent, the
  redaction placeholder is present next to the `read-only` authorization
  mode, and the non-secret siblings (`DATACENTER-RACK-42`, `NOC-TEAM`,
  `192.0.2.10`) are **not** over-redacted.
- **`#4712` snmp subtest updated** — it previously asserted the community
  names appear in sorted order; since the name is now masked it instead
  asserts the cleartext `comm_*` names are absent and the placeholder is
  present, while keeping the determinism check (which still exercises the
  sorted-iteration contract).

**RED-on-revert verified:** reverting the render to
`Fprintf(..., name, ...)` makes both tests FAIL — the four `comm_*`
names reappear in the body and the placeholder assertion fails.

## Validation

- `go build ./...` → exit 0
- `go test -count=1 ./pkg/api/...` → ok
- `gofmt -l` clean on all touched files

## Docs

`pkg/api/README.md` does not document the `show-text` handler, so there
is no API-doc section to annotate.

Closes #5315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
