### PR TITLE
daemon: cancel + join scheduler and RPM pin-retry loops at shutdown (#5308)

### DIFF
--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -380,6 +380,29 @@ never lock an operator out of a remote box it manages.
     the teardown itself performs no `applyConfigLocked`, so the cancel aborts
     only a genuinely in-flight commit/remediation apply, never the shutdown's own
     cleanup.
+  - **Cancel + join the two daemonCtx-bound loops BEFORE dependent teardown
+    (#5308).** Because `d.daemonCtx` is never cancelled and neither the policy
+    scheduler nor the RPM probe-pin retry loop binds to the run `WaitGroup`,
+    `stop()` + `wg.Wait()` does not stop them. The shutdown sequence therefore
+    calls `stopPolicySchedulerLoop()` + `stopPinRetryLoop()` immediately after
+    `wg.Wait()` and BEFORE the subsystems they call into are torn down: the
+    scheduler republishes schedule state through the dataplane runtime
+    (`UpdatePolicyScheduleState`, closed by `dp.Close`/`dp.Teardown`), and the
+    pin-retry loop runs routing-pin syscalls through the routing/FRR manager
+    (stopped by `frr.Stop`/routing teardown). Each helper cancels its loop's
+    context (the scheduler's `schedulerCancel`; a cancellable child of
+    `d.daemonCtx` for pin-retry — it no longer binds `context.Background()`) and
+    joins the goroutine on a `WaitGroup` (`schedulerWg`/`pinRetryWg`). The
+    cancel is taken under the loop's own lock (`applySem` / `rpmMu`) but that
+    lock is RELEASED before the join — an in-flight tick blocked on that same
+    lock (`publishPolicyScheduleState` on `applySem`; `probePinRetryLoop` on
+    `rpmMu`) must be able to finish so the goroutine can observe `ctx.Done()`.
+    A `schedulerStopped`/`pinRetryStopped` latch prevents a late reconcile from
+    starting a new generation after the join (which would race the `Wait`).
+    Both helpers are idempotent / nil-safe and are ALSO registered as `defer`s
+    in `Run`, so an early-error return (or an embedded library caller whose ctx
+    cancels) that never reaches the shutdown sequence still cancels + joins both
+    loops instead of leaking them.
 - FRR reload runs with a 15 s context timeout to keep `systemctl reload
   frr` from hanging. The systemd unit has `TimeoutStopSec=20` as a safety
   net.

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -181,7 +181,20 @@ type Daemon struct {
 	// probePinApply is the test seam for probe-pin programming; nil =
 	// d.routing.ApplyProbePins (#1895).
 	probePinApply func([]routing.ProbePin) map[string]error
-	ipmon         *ipmon.Engine
+	// pinRetryCancel/pinRetryWg/pinRetryStopped scope the probePinRetryLoop
+	// lifecycle so daemon shutdown can cancel + join it BEFORE FRR/routing
+	// teardown (#5308). The loop used to bind to d.daemonCtx (never cancelled
+	// in production), so a late retry tick could run routing-pin syscalls
+	// after the routing manager was gone — and it leaked outright for library
+	// callers where Run() returns. maybeStartPinRetryLoopLocked now derives a
+	// cancellable child of d.daemonCtx and tracks the goroutine on pinRetryWg;
+	// stopPinRetryLoop cancels + joins. All three are guarded by rpmMu;
+	// pinRetryStopped latches on shutdown so no new loop can be started after
+	// the join (which would race pinRetryWg.Wait).
+	pinRetryCancel  context.CancelFunc
+	pinRetryWg      sync.WaitGroup
+	pinRetryStopped bool
+	ipmon           *ipmon.Engine
 	// natPoolAlarm is the #2079 NAT source pool-utilization-alarm monitor:
 	// a slow (10s) loop over the helper's last-applied NAT pool snapshot
 	// that raises/clears `show security alarms` entries with hysteresis and
@@ -284,12 +297,23 @@ type Daemon struct {
 	// to snmp.NewAgentWithBootsPath. Empty ⇒ the package default. Tests inject
 	// a temp path so a reconcile-triggered start does not touch /var/lib/xpf
 	// (#3967).
-	snmpBootsPath             string
-	lldpMgr                   *lldp.Manager
-	lldpApplied               *lldp.LLDPConfig // last effective LLDP config Apply()'d (#2372 diff-guard); nil = stopped
-	lldpApplyInit             bool             // true once reconcileLLDP has run at least once
-	scheduler                 *scheduler.Scheduler
-	schedulerCancel           context.CancelFunc
+	snmpBootsPath   string
+	lldpMgr         *lldp.Manager
+	lldpApplied     *lldp.LLDPConfig // last effective LLDP config Apply()'d (#2372 diff-guard); nil = stopped
+	lldpApplyInit   bool             // true once reconcileLLDP has run at least once
+	scheduler       *scheduler.Scheduler
+	schedulerCancel context.CancelFunc
+	// schedulerWg tracks every policy-scheduler Run() goroutine generation so
+	// daemon shutdown can join it after cancelling, and schedulerStopped
+	// latches on shutdown so no new generation is started after the join
+	// (#5308). Before this the scheduler goroutine was cancelled only on a
+	// config-replace, so at shutdown a late tick could republish policy
+	// schedule state through an already-torn-down runtime, and it leaked for
+	// library callers where Run() returns. schedulerCancel/schedulerWg/
+	// schedulerStopped are all mutated under applySem (the "Locked" convention
+	// for the scheduler start/reconcile path).
+	schedulerWg               sync.WaitGroup
+	schedulerStopped          bool
 	policySchedulerConfigHash [32]byte
 	policySchedulerEpoch      atomic.Uint64
 	// #3780: scheduler republish-failure observability.

--- a/pkg/daemon/daemon_goroutine_shutdown_5308_test.go
+++ b/pkg/daemon/daemon_goroutine_shutdown_5308_test.go
@@ -1,0 +1,197 @@
+package daemon
+
+// daemon_goroutine_shutdown_5308_test.go — #5308 regression coverage.
+//
+// Two daemon background loops bind to d.daemonCtx (context.Background() in
+// production, never cancelled) rather than the run WaitGroup, so wg.Wait at
+// shutdown does NOT cover them:
+//
+//   - the policy scheduler (startPolicySchedulerLoopLocked → scheduler.Run),
+//     which republishes schedule state through the dataplane runtime
+//     (UpdatePolicyScheduleState), and
+//   - the RPM probe-pin retry loop (probePinRetryLoop), which runs routing-pin
+//     syscalls through the routing/FRR manager.
+//
+// Before #5308 neither was cancelled/joined at shutdown, so a late tick could
+// run against an already-torn-down subsystem, and both leaked outright for
+// library callers where Run() returns. The shutdown sequence now cancels +
+// joins BOTH (stopPolicySchedulerLoop / stopPinRetryLoop) BEFORE the dependent
+// subsystems are torn down.
+//
+// The stop helpers are exercised in a goroutine guarded by a bounded select so
+// a revert — pin-retry rebound to the never-cancelled d.daemonCtx, or the
+// scheduler never cancelled at shutdown — turns the resulting hang into a FAST
+// t.Fatal (RED) instead of wedging the suite.
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/routing"
+	"github.com/psaab/xpf/pkg/rpm"
+	"github.com/psaab/xpf/pkg/scheduler"
+	"golang.org/x/sync/semaphore"
+)
+
+// joinWithin runs stop in a goroutine and fails the test if it does not return
+// within d. A leaked/uncancelled loop makes the join block forever; the bound
+// converts that into a fast, deterministic failure.
+func joinWithin(t *testing.T, d time.Duration, stop func(), msg string) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatal(msg)
+	}
+}
+
+// TestStopPinRetryLoopCancelsJoinsNoLateSyscall proves the RPM probe-pin retry
+// loop is cancelled + joined at shutdown and runs NO routing-pin syscall past
+// the join, even though its parent d.daemonCtx (context.Background here, as in
+// production) is never cancelled.
+//
+// RED-on-revert: rebinding maybeStartPinRetryLoopLocked's goroutine to
+// d.daemonCtx (the pre-#5308 `go d.probePinRetryLoop(d.daemonCtx)`) leaves the
+// loop listening on a context that never fires, so stopPinRetryLoop's join
+// blocks and joinWithin trips its 3s bound.
+func TestStopPinRetryLoopCancelsJoinsNoLateSyscall(t *testing.T) {
+	var mu sync.Mutex
+	calls := 0
+	joined := false // set true only after the join returns (teardown marker)
+	callsAfterJoin := 0
+
+	d := &Daemon{
+		rpm:                rpm.New(),
+		daemonCtx:          context.Background(), // production: never cancelled
+		probePinRetryEvery: 2 * time.Millisecond,
+	}
+	d.probePinApply = func(pins []routing.ProbePin) map[string]error {
+		mu.Lock()
+		calls++
+		if joined {
+			callsAfterJoin++
+		}
+		mu.Unlock()
+		// Keep failing so the loop never self-exits — only the shutdown
+		// cancel may stop it.
+		return map[string]error{pins[0].TestKey: fmt.Errorf("egress link down")}
+	}
+	defer d.rpm.StopAll()
+
+	if !d.reconcileRPM(rpmPinnedTestConfig()) {
+		t.Fatal("first reconcile must apply")
+	}
+	d.rpmMu.Lock()
+	active := d.rpmPinRetryActive
+	d.rpmMu.Unlock()
+	if !active {
+		t.Fatal("pin retry loop did not start after a failed pin install")
+	}
+
+	// Confirm the loop is genuinely ticking (not just the synchronous
+	// first install from reconcileRPM).
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mu.Lock()
+		c := calls
+		mu.Unlock()
+		if c >= 3 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("pin retry loop never ticked past the initial install (calls=%d)", c)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// Shutdown cancel + join, bounded so a revert fails fast.
+	joinWithin(t, 3*time.Second, d.stopPinRetryLoop,
+		"stopPinRetryLoop did not cancel+join the loop — leaked / bound to the never-cancelled daemonCtx")
+
+	// Mark the teardown boundary: no routing-pin syscall may run past here.
+	mu.Lock()
+	joined = true
+	mu.Unlock()
+
+	// Several retry intervals must elapse with ZERO further installer calls.
+	time.Sleep(40 * time.Millisecond)
+	mu.Lock()
+	after := callsAfterJoin
+	mu.Unlock()
+	if after != 0 {
+		t.Fatalf("pin retry loop ran %d routing-pin syscall(s) AFTER shutdown cancel+join", after)
+	}
+
+	// pinRetryStopped must latch: a late reconcile cannot restart the loop
+	// (which would race pinRetryWg.Wait).
+	d.rpmMu.Lock()
+	d.rpmPinsFailed = true
+	d.maybeStartPinRetryLoopLocked()
+	restarted := d.rpmPinRetryActive
+	d.rpmMu.Unlock()
+	if restarted {
+		t.Fatal("pin retry loop restarted after shutdown — pinRetryStopped did not latch")
+	}
+}
+
+// TestStopPolicySchedulerLoopCancelsJoins proves the policy scheduler goroutine
+// is cancelled + joined at shutdown and does not restart afterwards.
+//
+// RED-on-revert: dropping the cancel from stopPolicySchedulerLoop (the
+// pre-#5308 behavior where schedulerCancel fires only on a config-replace, not
+// at shutdown) leaves scheduler.Run parked on its 60s ticker with an
+// uncancelled ctx, so the join blocks and joinWithin trips its 3s bound.
+func TestStopPolicySchedulerLoopCancelsJoins(t *testing.T) {
+	sched, _ := scheduler.NewPrimed(map[string]*config.SchedulerConfig{
+		"always": {Name: "always"},
+	}, func(map[string]bool) error { return nil }, time.Now())
+
+	d := &Daemon{
+		scheduler: sched,
+		applySem:  semaphore.NewWeighted(1),
+		daemonCtx: context.Background(), // production: never cancelled
+	}
+	d.startPolicySchedulerLoopLocked()
+	if d.schedulerCancel == nil {
+		t.Fatal("scheduler loop did not start")
+	}
+
+	joinWithin(t, 3*time.Second, d.stopPolicySchedulerLoop,
+		"stopPolicySchedulerLoop did not cancel+join the scheduler goroutine — leaked / not cancelled at shutdown")
+
+	if d.schedulerCancel != nil {
+		t.Fatal("schedulerCancel not cleared after stop")
+	}
+
+	// schedulerStopped must latch: a late reconcile-driven start must not
+	// spin up a new generation (which would race schedulerWg.Wait).
+	d.startPolicySchedulerLoopLocked()
+	if d.schedulerCancel != nil {
+		t.Fatal("scheduler loop restarted after shutdown — schedulerStopped did not latch")
+	}
+}
+
+// TestStopLoopsIdempotentNilSafe proves both stop helpers are safe on a daemon
+// whose loops were never started (feature disabled), and safe to call twice
+// (the shutdown sequence runs them, then Run's defers run them again).
+func TestStopLoopsIdempotentNilSafe(t *testing.T) {
+	d := &Daemon{
+		applySem:  semaphore.NewWeighted(1),
+		daemonCtx: context.Background(),
+	}
+	// Never-started loops: nil cancel + empty WaitGroup must join instantly.
+	joinWithin(t, time.Second, d.stopPinRetryLoop, "stopPinRetryLoop blocked with no loop running")
+	joinWithin(t, time.Second, d.stopPolicySchedulerLoop, "stopPolicySchedulerLoop blocked with no loop running")
+	// Double-stop must not panic and must still return promptly.
+	joinWithin(t, time.Second, d.stopPinRetryLoop, "second stopPinRetryLoop blocked")
+	joinWithin(t, time.Second, d.stopPolicySchedulerLoop, "second stopPolicySchedulerLoop blocked")
+}

--- a/pkg/daemon/daemon_rpm.go
+++ b/pkg/daemon/daemon_rpm.go
@@ -286,11 +286,44 @@ func (d *Daemon) retryFailedProbePinsLocked() {
 // stays off after a reboot (AGY review on PR #1899). The loop stops
 // itself once every pin is installed. Caller holds rpmMu.
 func (d *Daemon) maybeStartPinRetryLoopLocked() {
-	if !d.rpmPinsFailed || d.rpmPinRetryActive || d.daemonCtx == nil {
+	// pinRetryStopped latches at shutdown (stopPinRetryLoop): once the loop is
+	// cancelled + joined, a late reconcileRPM must NOT start a new one — that
+	// Add would race the shutdown's pinRetryWg.Wait (#5308).
+	if d.pinRetryStopped || !d.rpmPinsFailed || d.rpmPinRetryActive || d.daemonCtx == nil {
 		return
 	}
 	d.rpmPinRetryActive = true
-	go d.probePinRetryLoop(d.daemonCtx)
+	// Bind the loop to a CANCELLABLE child of d.daemonCtx (not d.daemonCtx
+	// itself, which is never cancelled in production) so shutdown can stop it
+	// before FRR/routing teardown, and track it on pinRetryWg so shutdown can
+	// join it (#5308). Callers hold rpmMu.
+	ctx, cancel := context.WithCancel(d.daemonCtx)
+	d.pinRetryCancel = cancel
+	d.pinRetryWg.Add(1)
+	go func() {
+		defer d.pinRetryWg.Done()
+		d.probePinRetryLoop(ctx)
+	}()
+}
+
+// stopPinRetryLoop cancels the probePinRetryLoop goroutine and joins it. It is
+// called from the shutdown sequence BEFORE FRR/routing teardown so a late
+// retry tick can never run a routing-pin syscall against a torn-down routing
+// manager (#5308). rpmMu is held only to read+cancel pinRetryCancel and latch
+// pinRetryStopped, then RELEASED before the join: probePinRetryLoop takes rpmMu
+// on both its ctx.Done() and ticker branches, so holding it across the join
+// would deadlock. Idempotent / nil-safe: a loop that was never started (no pin
+// failures) joins cleanly.
+func (d *Daemon) stopPinRetryLoop() {
+	d.rpmMu.Lock()
+	d.pinRetryStopped = true
+	cancel := d.pinRetryCancel
+	d.pinRetryCancel = nil
+	d.rpmMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	d.pinRetryWg.Wait()
 }
 
 // probePinRetryLoop is the slow autonomous retry of failed probe-pin

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -174,6 +174,17 @@ func collectAppliedTunnels(cfg *config.Config) []*config.TunnelConfig {
 // Run starts the daemon and blocks until shutdown.
 func (d *Daemon) Run(ctx context.Context) error {
 	d.daemonCtx = ctx
+	// #5308: guarantee the two daemonCtx-bound background loops (policy
+	// scheduler + RPM probe-pin retry) are cancelled + joined even when Run
+	// returns WITHOUT reaching runShutdownSequence — an early-error return
+	// (config load / manager init / dataplane setup) or an embedded library
+	// caller whose ctx cancels. On the normal path runShutdownSequence has
+	// already stopped both (idempotent / nil-safe), so these defers are no-ops
+	// there; they only do real work on the return paths that skip it. Both loops
+	// may be started during initManagers' boot apply below, so registering the
+	// defers here covers every subsequent return.
+	defer d.stopPinRetryLoop()
+	defer d.stopPolicySchedulerLoop()
 	d.startPolicySchedulerLoopLocked()
 
 	// Wrap the default slog handler to support system syslog forwarding.
@@ -822,6 +833,21 @@ func (d *Daemon) runShutdownSequence(wg *sync.WaitGroup, stop func(), runErr err
 	// Cancel context to stop background goroutines, then wait for them.
 	stop()
 	wg.Wait()
+
+	// #5308: cancel + join the two long-lived loops that bind to d.daemonCtx
+	// (never cancelled in production) rather than the run WaitGroup above, so
+	// wg.Wait does NOT cover them. Both call into subsystems torn down further
+	// below and therefore MUST be stopped first: the policy scheduler
+	// republishes schedule state through the dataplane runtime
+	// (UpdatePolicyScheduleState — closed by dp.Close/dp.Teardown), and the RPM
+	// probe-pin retry loop runs routing-pin syscalls through the routing/FRR
+	// manager (stopped by frr.Stop / routing teardown). Cancelling + joining
+	// here guarantees no late scheduler tick runs against a closed runtime and
+	// no late pin-retry tick runs a syscall after routing is gone. Both helpers
+	// are idempotent / nil-safe (a never-started loop joins cleanly), so this is
+	// also the safety-net for the Run()-returns path via the defers in Run.
+	d.stopPolicySchedulerLoop()
+	d.stopPinRetryLoop()
 
 	// Stop the SNMP agent + link-state trap monitor (#3967). Their goroutines
 	// bind to d.daemonCtx (never cancelled in production) rather than the run

--- a/pkg/daemon/daemon_scheduler.go
+++ b/pkg/daemon/daemon_scheduler.go
@@ -138,12 +138,49 @@ func writePolicySchedulerHashString(h interface{ Write([]byte) (int, error) }, s
 }
 
 func (d *Daemon) startPolicySchedulerLoopLocked() {
-	if d.daemonCtx == nil || d.scheduler == nil || d.schedulerCancel != nil {
+	// schedulerStopped latches at shutdown (stopPolicySchedulerLoop): once the
+	// loop has been cancelled + joined, a late reconcile must NOT start a new
+	// generation — that Add would race the shutdown's schedulerWg.Wait (#5308).
+	if d.schedulerStopped || d.daemonCtx == nil || d.scheduler == nil || d.schedulerCancel != nil {
 		return
 	}
 	ctx, cancel := context.WithCancel(d.daemonCtx)
 	d.schedulerCancel = cancel
-	go d.scheduler.Run(ctx)
+	// Capture the scheduler pointer at start time (a config-replace reconcile
+	// may reassign d.scheduler) and track the goroutine on schedulerWg so
+	// shutdown can join every generation after cancelling.
+	sched := d.scheduler
+	d.schedulerWg.Add(1)
+	go func() {
+		defer d.schedulerWg.Done()
+		sched.Run(ctx)
+	}()
+}
+
+// stopPolicySchedulerLoop cancels the policy-scheduler Run() goroutine and
+// joins it. It is called from the shutdown sequence BEFORE the dataplane
+// runtime the scheduler republishes into (UpdatePolicyScheduleState) is torn
+// down, so a late scheduler tick can never run against a closed runtime
+// (#5308). The applySem is acquired only to read+cancel schedulerCancel under
+// the same lock that guards it, then RELEASED before the join: an in-flight
+// tick blocked in publishPolicyScheduleState on applySem.Acquire must be able
+// to complete so the goroutine can observe ctx.Done() — holding applySem
+// across the join would deadlock. Idempotent / nil-safe: a never-started loop
+// (feature disabled, or already cancelled by a config-replace) joins cleanly.
+func (d *Daemon) stopPolicySchedulerLoop() {
+	if d.applySem != nil {
+		_ = d.applySem.Acquire(context.Background(), 1)
+	}
+	d.schedulerStopped = true
+	cancel := d.schedulerCancel
+	d.schedulerCancel = nil
+	if d.applySem != nil {
+		d.applySem.Release(1)
+	}
+	if cancel != nil {
+		cancel()
+	}
+	d.schedulerWg.Wait()
 }
 
 // publishPolicyScheduleState is the scheduler's updateFn. It returns a


### PR DESCRIPTION
Closes #5308

## Root cause: two uncancelled/leaked daemon goroutines at shutdown

Two long-lived daemon background loops bind to `d.daemonCtx` — which is
`context.Background()` in production and **never cancelled** — rather than the
run `WaitGroup`, so the shutdown sequence's `stop()` + `wg.Wait()` does **not**
cover them:

- **Policy scheduler** (`startPolicySchedulerLoopLocked` → `scheduler.Run`): its
  context (`schedulerCancel`) was cancelled **only** on a config-replace
  reconcile, never at shutdown. A late 60s tick could republish schedule state
  via `UpdatePolicyScheduleState` against an already-closed dataplane runtime
  (`dp.Close`/`dp.Teardown`). The goroutine was not tracked by any `WaitGroup`.
- **RPM probe-pin retry loop** (`probePinRetryLoop`): bound directly to
  `d.daemonCtx`, so a late 30s tick could run routing-pin syscalls through the
  routing/FRR manager **after** it was torn down. `rpm.StopAll` joins only the
  RPM manager's own `WaitGroup`, not this loop.

For library callers where `Run()` returns (not just SIGTERM) both loops leaked
indefinitely. SIGTERM shutdown called only `feeds.StopAll()` / `rpm.StopAll()`,
neither of which cancels these loops before the subsystems they call into are
torn down. Distinct from #5165/#5121/#4958.

## Fix (cancel-before-dependent-teardown)

Mirrors the #3967 SNMP teardown pattern (a lifetime context + `WaitGroup` +
explicit cancel-and-join in the shutdown sequence).

- Track each scheduler `Run()` generation on `schedulerWg`; add
  `stopPolicySchedulerLoop` (cancel existing `schedulerCancel` + join). The
  pin-retry loop now binds to a **cancellable child** of `d.daemonCtx`
  (`pinRetryCancel`), tracked on `pinRetryWg`; `stopPinRetryLoop` cancels + joins.
- `runShutdownSequence` calls both helpers **immediately after `wg.Wait()` and
  BEFORE** feeds/RPM/FRR/routing/dataplane teardown, so no late scheduler tick
  runs against a closed runtime and no late pin-retry tick runs a syscall after
  routing is gone. No unrelated teardown steps are reordered.

### Ordering / deadlock safety
Each helper takes the loop's own lock (`applySem` / `rpmMu`) **only** to
read+cancel and latch the stop flag, then **releases it before the join**. An
in-flight tick blocked on that same lock (`publishPolicyScheduleState` on
`applySem`; `probePinRetryLoop` on `rpmMu`) must be able to finish so the
goroutine can observe `ctx.Done()`; holding the lock across the join would
deadlock.

### Idempotency / nil-safety
`schedulerStopped` / `pinRetryStopped` latch on shutdown so a late reconcile
cannot start a new generation and race the `Wait`; a scheduler already cancelled
by a config-replace does not double-cancel; a never-started loop (feature
disabled) joins cleanly. The config-replace `schedulerCancel` cancel+restart
behavior is preserved.

### Library-caller leak
Both helpers are also registered as `defer`s in `Run`, so an early-error return
or an embedded caller whose ctx cancels — paths that never reach
`runShutdownSequence` — still cancels + joins both loops. On the normal path the
explicit calls already ran, so the defers are no-ops.

## Tests (`pkg/daemon`, `-race`)

`daemon_goroutine_shutdown_5308_test.go`:
- Both loops are cancelled + joined with no leak (join guarded by a bounded
  select so a leak fails fast rather than hanging the suite).
- For the fast-ticking pin-retry loop: **zero** routing-pin syscalls run after
  the join (the teardown marker).
- The stop latches (`schedulerStopped`/`pinRetryStopped`) prevent a restart.
- Both helpers are idempotent / nil-safe on a never-started daemon.

**RED-on-revert confirmed:** rebinding the pin-retry loop to the uncancelled
`d.daemonCtx`, and dropping the cancel from `stopPolicySchedulerLoop`, each make
the bounded join **time out (3s)** → the tests fail fast (verified locally,
then restored).

## Docs
`pkg/daemon/README.md` shutdown gotchas now describe the cancel+join of both
loops before dependent teardown, the lock-release-before-join ordering, the stop
latches, and the `Run` defers.

## Validation
- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` → exit 0
- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test -race -count=1 ./pkg/daemon/...` → ok
- `gofmt -l` clean on touched files; `go vet ./pkg/daemon/` → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
