### PR TITLE
cli: raise gRPC receive cap so large configs display (#5321)

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -6,8 +6,15 @@ daemon-local CLI.
 
 ## Entry
 
-`main.go` parses flags, dials the gRPC API, and hands control to the
-shared `pkg/cli` engine.
+`main.go` parses flags, dials the gRPC API (see `dialOpts`), and hands
+control to the shared `pkg/cli` engine.
+
+The dial raises the client `MaxCallRecvMsgSize` to
+`configstore.MaxConfigSize` + 1 MiB of framing headroom
+(`maxConfigRecvBytes`), so a `show configuration` for a config up to the
+store's 16 MiB ceiling can be displayed. grpc-Go's 4 MiB default receive
+cap would otherwise truncate a large config with `ResourceExhausted`
+(#5321). Tracking the store const keeps the two bounds from drifting.
 
 ## Flags
 

--- a/cmd/cli/grpc_maxrecv_5321_test.go
+++ b/cmd/cli/grpc_maxrecv_5321_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// bigConfigServer returns a ShowConfig response whose Output is sized on
+// request, so the test can drive a payload larger than grpc-Go's 4 MiB default
+// receive cap without buffering the whole configstore machinery.
+type bigConfigServer struct {
+	pb.UnimplementedBpfrxServiceServer
+	payload string
+}
+
+func (s *bigConfigServer) ShowConfig(context.Context, *pb.ShowConfigRequest) (*pb.ShowConfigResponse, error) {
+	return &pb.ShowConfigResponse{Output: s.payload}, nil
+}
+
+// TestCLIReceivesLargeConfig pins #5321: the configstore accepts a
+// configuration up to configstore.MaxConfigSize (16 MiB), so a `show
+// configuration` for such a config produces a ShowConfig response well over
+// grpc-Go's 4 MiB default MaxCallRecvMsgSize. The CLI client must raise the
+// receive cap (dialOpts) or the response fails with ResourceExhausted and the
+// operator loses config inspection on a large appliance.
+//
+// RED-on-revert: drop grpc.WithDefaultCallOptions(MaxCallRecvMsgSize) from
+// dialOpts and this test fails — the >4 MiB payload trips the 4 MiB default
+// with codes.ResourceExhausted.
+func TestCLIReceivesLargeConfig(t *testing.T) {
+	const grpcDefaultRecv = 4 << 20 // grpc-Go defaultClientMaxReceiveMessageSize
+
+	// Payload above the 4 MiB default but within the store ceiling: a config
+	// the store would legitimately accept yet the un-tuned client cannot read.
+	payloadLen := grpcDefaultRecv + (2 << 20) // 6 MiB
+	if payloadLen > configstore.MaxConfigSize {
+		t.Fatalf("test payload %d exceeds configstore.MaxConfigSize %d", payloadLen, configstore.MaxConfigSize)
+	}
+	payload := strings.Repeat("a", payloadLen)
+
+	lis := bufconn.Listen(1 << 20)
+	srv := grpc.NewServer()
+	pb.RegisterBpfrxServiceServer(srv, &bigConfigServer{payload: payload})
+	go srv.Serve(lis)
+	defer srv.Stop()
+
+	dialer := grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+		return lis.DialContext(ctx)
+	})
+
+	// Dial with the exact production client construction plus the bufconn dialer.
+	conn, err := grpc.NewClient("passthrough:///bufnet", dialOpts(dialer)...)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	defer conn.Close()
+	client := pb.NewBpfrxServiceClient(conn)
+
+	resp, err := client.ShowConfig(context.Background(), &pb.ShowConfigRequest{
+		Format: pb.ConfigFormat_HIERARCHICAL,
+		Target: pb.ConfigTarget_ACTIVE,
+	})
+	if err != nil {
+		if status.Code(err) == codes.ResourceExhausted {
+			t.Fatalf("CLI client rejected a %d-byte config with ResourceExhausted; "+
+				"MaxCallRecvMsgSize not raised to configstore.MaxConfigSize (#5321): %v", payloadLen, err)
+		}
+		t.Fatalf("ShowConfig: %v", err)
+	}
+	if len(resp.Output) != payloadLen {
+		t.Fatalf("ShowConfig Output len = %d, want %d", len(resp.Output), payloadLen)
+	}
+}
+
+// TestDialOptsCapMatchesStoreCeiling guards the bound itself: the CLI receive
+// cap tracks configstore.MaxConfigSize (plus framing headroom) so the client
+// can always display a config the store accepts. A weaker but direct guard
+// against the two bounds drifting.
+func TestDialOptsCapMatchesStoreCeiling(t *testing.T) {
+	if maxConfigRecvBytes < configstore.MaxConfigSize {
+		t.Fatalf("maxConfigRecvBytes (%d) < configstore.MaxConfigSize (%d): CLI cannot display a config the store accepts",
+			maxConfigRecvBytes, configstore.MaxConfigSize)
+	}
+	if maxConfigRecvBytes != configstore.MaxConfigSize+(1<<20) {
+		t.Fatalf("maxConfigRecvBytes = %d, want MaxConfigSize+1MiB (%d)",
+			maxConfigRecvBytes, configstore.MaxConfigSize+(1<<20))
+	}
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -19,18 +19,42 @@ import (
 
 	"github.com/chzyer/readline"
 	"github.com/psaab/xpf/pkg/cmdtree"
+	"github.com/psaab/xpf/pkg/configstore"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 	"github.com/psaab/xpf/pkg/policymatch"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+// maxConfigRecvBytes bounds a single gRPC response the CLI will accept. The
+// configstore accepts a configuration up to configstore.MaxConfigSize (16 MiB),
+// and a ShowConfig response can carry a payload of that size, so the CLI must
+// be able to receive it. grpc-Go defaults MaxCallRecvMsgSize to 4 MiB, which
+// truncates a large `show configuration` with ResourceExhausted (#5321). Track
+// the store ceiling plus 1 MiB of gRPC/proto framing headroom so the two
+// bounds cannot drift.
+const maxConfigRecvBytes = configstore.MaxConfigSize + (1 << 20)
+
+// dialOpts returns the gRPC dial options the CLI client uses to reach xpfd.
+// Kept as a helper (rather than inline) so tests exercise the exact production
+// construction: insecure loopback transport plus the raised receive cap that
+// lets a large `show configuration` (up to configstore.MaxConfigSize) round
+// trip past grpc-Go's 4 MiB default (#5321). extra options (e.g. a bufconn
+// dialer) are appended for tests.
+func dialOpts(extra ...grpc.DialOption) []grpc.DialOption {
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxConfigRecvBytes)),
+	}
+	return append(opts, extra...)
+}
+
 func main() {
 	addr := flag.String("addr", "127.0.0.1:50051", "xpfd gRPC address")
 	cmdFlag := flag.String("c", "", "run a single command non-interactively and exit")
 	flag.Parse()
 
-	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(*addr, dialOpts()...)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cli: connect: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
## Problem

The remote CLI (`cmd/cli`) dialed xpfd with `grpc.NewClient` and **no**
`MaxCallRecvMsgSize` override, so it inherited grpc-Go's **4 MiB** default
client receive cap. Meanwhile `configstore.MaxConfigSize` accepts a
**16 MiB** configuration, and a `ShowConfig` response carries a payload of
that size. A `show configuration` for a config in the **(4 MiB, 16 MiB]**
range therefore failed with `ResourceExhausted` — a contract mismatch: the
store accepts and persists a config the shipped CLI can no longer inspect,
exactly when an operator troubleshooting a large appliance needs to read it.

## Fix

Raise the client receive cap to track the store ceiling:

- A `dialOpts` helper now builds the CLI dial options — insecure loopback
  transport plus
  `grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxConfigRecvBytes))`,
  where `maxConfigRecvBytes = configstore.MaxConfigSize + (1 << 20)`
  (16 MiB store ceiling + 1 MiB of gRPC/proto framing headroom).
- Referencing the `configstore.MaxConfigSize` const (rather than a
  hardcoded 16 MiB literal) keeps the store bound and the CLI display bound
  from drifting.
- Insecure-transport / loopback behavior is unchanged; this is purely the
  receive-size option.

### Server side — no change needed (verified)

`pkg/grpcapi/server.go` already sets `grpc.MaxRecvMsgSize(16 MiB)` and
leaves `MaxSendMsgSize` at grpc-Go's default (~2 GiB). The server can
already send a 16 MiB `ShowConfig` response — only the **client** cap was
truncating, so this is a client-only fix.

## Tests (`cmd/cli`, fail-on-revert)

- **`TestCLIReceivesLargeConfig`** (functional): stands up an in-process
  bufconn gRPC server that returns a **6 MiB** `ShowConfig` response
  (>4 MiB default, <16 MiB store ceiling), dials with the exact production
  `dialOpts` construction, and asserts the response round-trips **without**
  `ResourceExhausted`.
- **`TestDialOptsCapMatchesStoreCeiling`** (guard): pins
  `maxConfigRecvBytes >= configstore.MaxConfigSize` (+1 MiB headroom) so the
  two bounds cannot drift.

**RED-on-revert confirmed:** removing the
`grpc.WithDefaultCallOptions(MaxCallRecvMsgSize)` option makes
`TestCLIReceivesLargeConfig` fail with
`rpc error: code = ResourceExhausted desc = grpc: received message larger than max (6291461 vs. 4194304)`.

## Docs

`cmd/cli/README.md` documents the raised receive cap (`dialOpts` /
`maxConfigRecvBytes`) and the 16 MiB display support.

## Validation

- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` — exit 0
- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test -count=1 ./cmd/cli/... ./pkg/grpcapi/...` — ok
- `gofmt -l` clean on touched files
- RED-on-revert confirmed (see above)

Closes #5321

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
