### PR TITLE
pkg/api: fail closed on unknown match-policies selector keys (#5316)

### DIFF
--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -523,6 +523,29 @@ func hostInboundToREST(a *dpuserspace.HostInboundAdmission) *MatchPoliciesHostIn
 	}
 }
 
+// matchPoliciesSelectorKeys is the exact, ordered set of query-string
+// selectors the match-policies handler consults. It is the SINGLE source of
+// truth for BOTH the #3709 duplicate-scalar check AND the #5316 unknown-key
+// allowlist: a selector is added here (and only here), and both the reads and
+// the two validation passes derive from it, so a new dimension cannot be
+// duplicate-checked-but-not-allowlisted (or vice versa) and a caller typo can
+// never silently re-open the fail-open gap.
+var matchPoliciesSelectorKeys = []string{
+	"from_zone", "to_zone", "src_ip", "dst_ip",
+	"src_port", "dst_port", "protocol", "icmp_type", "icmp_code",
+}
+
+// isMatchPoliciesSelector reports whether key is a recognized match-policies
+// selector (a member of matchPoliciesSelectorKeys).
+func isMatchPoliciesSelector(key string) bool {
+	for _, k := range matchPoliciesSelectorKeys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 	// #3709: validate request grammar BEFORE the cfg == nil verdict so a
 	// malformed / duplicate / missing-zone query fails the SAME way during the
@@ -540,14 +563,40 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 	// tested, each certifying a verdict for a packet the operator may not have
 	// typed. There is no correct silent pick, so a repeat is a 400, matching the
 	// strict CLI/gRPC parsers (policymatch.ParseSelectorArgs / showTestPolicy).
-	for _, key := range []string{
-		"from_zone", "to_zone", "src_ip", "dst_ip",
-		"src_port", "dst_port", "protocol", "icmp_type", "icmp_code",
-	} {
+	for _, key := range matchPoliciesSelectorKeys {
 		if len(q[key]) > 1 {
 			writeError(w, http.StatusBadRequest, fmt.Sprintf("selector %q specified more than once", key))
 			return
 		}
+	}
+
+	// #5316: reject an UNKNOWN / misspelled selector key (fail closed). The
+	// handler reads ONLY matchPoliciesSelectorKeys; any other key is never
+	// examined, so a typo such as `protcol` for `protocol` silently degrades
+	// that dimension to the wildcard-any default — q.Get("protocol") returns
+	// "" — and the shared simulator can certify a broad PERMIT for a packet
+	// class the caller never intended to test. That is a FAIL-OPEN on a
+	// security-verification endpoint. Enumerate every key the caller supplied
+	// and 400 any that is not in the selector allowlist, naming the offender.
+	// The allowlist is the SAME slice the reads use, so adding a selector later
+	// cannot re-open the gap. Absent keys are unchanged: an unspecified
+	// dimension is still the intentional match-any wildcard — only UNKNOWN keys
+	// are rejected, not missing ones. Reached AFTER the duplicate check so a
+	// repeated known selector still surfaces its #3709 duplicate error, and
+	// (like the checks above) BEFORE the cfg == nil verdict so the boot window
+	// rejects an unknown key identically to the config-present path.
+	var unknown []string
+	for key := range q {
+		if !isMatchPoliciesSelector(key) {
+			unknown = append(unknown, key)
+		}
+	}
+	if len(unknown) > 0 {
+		// Sort so the reported key is deterministic when a caller supplies
+		// several unknown keys (map iteration order is randomized).
+		sort.Strings(unknown)
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown selector parameter: %s", unknown[0]))
+		return
 	}
 
 	fromZone := q.Get("from_zone")

--- a/pkg/api/security_matchpolicies_unknownkey_5316_test.go
+++ b/pkg/api/security_matchpolicies_unknownkey_5316_test.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestMatchPoliciesRESTRejectsUnknownSelector is the #5316 RED-on-revert guard.
+//
+// The match-policies handler consults only a fixed selector allowlist
+// (matchPoliciesSelectorKeys). Before #5316 it enumerated DUPLICATES among
+// that list (#3709) but never rejected an UNKNOWN/misspelled key. A typo such
+// as `protcol` for `protocol` was therefore never examined: q.Get("protocol")
+// returned "" and the shared simulator evaluated ALL protocols, so the endpoint
+// could certify a broad PERMIT for a packet class the caller never intended to
+// test — a fail-OPEN on a security-verification surface. The handler now 400s
+// any key not in the allowlist, naming the offender.
+//
+// FAIL-ON-REVERT: removing the unknown-key enumeration makes the mistyped
+// `protcol` key silently ignored, so the query returns 200 with a widened
+// verdict, flipping the want-400 / name-the-key assertions red.
+func TestMatchPoliciesRESTRejectsUnknownSelector(t *testing.T) {
+	s := &Server{store: hostInboundAPIStore(t)}
+
+	// The #5316 scenario: `protocol` misspelled as `protcol`. The two zones are
+	// valid and single-valued, so the ONLY defect is the unknown key.
+	code, body := matchStatus(t, s, "from_zone=trust&to_zone=untrust&protcol=tcp")
+	if code != 400 {
+		t.Fatalf("typo selector status = %d, want 400 (unknown selector); body: %s", code, body)
+	}
+	if !strings.Contains(body, "unknown selector parameter") || !strings.Contains(body, "protcol") {
+		t.Fatalf("body = %s, want an unknown-selector error naming \"protcol\"", body)
+	}
+
+	// A few more misspellings / stray keys, each rejected by name.
+	for _, tc := range []struct {
+		raw, key string
+	}{
+		{"from_zone=trust&to_zone=untrust&src=10.0.0.1", "src"},
+		{"from_zone=trust&to_zone=untrust&dstport=443", "dstport"},
+		{"from_zone=trust&to_zone=untrust&application=junos-http", "application"},
+		{"from_zone=trust&to_zone=untrust&format=json", "format"},
+	} {
+		t.Run(tc.key, func(t *testing.T) {
+			code, body := matchStatus(t, s, tc.raw)
+			if code != 400 {
+				t.Fatalf("unknown key %q status = %d, want 400; body: %s", tc.key, code, body)
+			}
+			if !strings.Contains(body, "unknown selector parameter") || !strings.Contains(body, tc.key) {
+				t.Fatalf("unknown key %q body = %s, want an error naming it", tc.key, body)
+			}
+		})
+	}
+}
+
+// TestMatchPoliciesRESTAcceptsAllKnownSelectors verifies the #5316 allowlist
+// does not falsely reject a request that uses EVERY recognized selector key.
+// This is the companion to the RED-on-revert test: it proves the fix rejects
+// only UNKNOWN keys, not the legitimate selector set.
+func TestMatchPoliciesRESTAcceptsAllKnownSelectors(t *testing.T) {
+	s := &Server{store: hostInboundAPIStore(t)}
+
+	// Exercise all nine selectors at once with well-formed values.
+	raw := strings.Join([]string{
+		"from_zone=trust",
+		"to_zone=untrust",
+		"src_ip=10.0.1.5",
+		"dst_ip=10.0.2.5",
+		"src_port=1024",
+		"dst_port=443",
+		"protocol=tcp",
+		"icmp_type=8",
+		"icmp_code=0",
+	}, "&")
+	code, body := matchStatus(t, s, raw)
+	if code != 200 {
+		t.Fatalf("all-known-selectors status = %d, want 200 (no false rejection); body: %s", code, body)
+	}
+}
+
+// TestMatchPoliciesRESTNoSelectorStillMatches confirms an all-absent selector
+// request (only the required zones, every other dimension the intentional
+// match-any wildcard) stays 200 — the #5316 fix rejects unknown KEYS, never
+// absent ones.
+func TestMatchPoliciesRESTNoSelectorStillMatches(t *testing.T) {
+	s := &Server{store: hostInboundAPIStore(t)}
+	code, body := matchStatus(t, s, "from_zone=trust&to_zone=untrust")
+	if code != 200 {
+		t.Fatalf("zones-only query status = %d, want 200 (absent selectors are match-any); body: %s", code, body)
+	}
+}


### PR DESCRIPTION
## Problem (fail-open on a security-verification endpoint)

The REST `match-policies` handler (`pkg/api/security.go`,
`matchPoliciesHandler`) accepted **unknown / misspelled** selector query
keys silently. The #3709 fix added a duplicate-scalar + boot-order
grammar check over a fixed 9-key list, but never enumerated keys the
handler does **not** recognize.

Because every selector dimension defaults to **wildcard-any** when its
key is absent, a mistyped key was never examined:

```
?from_zone=trust&to_zone=untrust&protcol=tcp   # typo: protcol -> protocol
```

`q.Get("protocol")` returns `""` → the shared policy simulator evaluates
**all protocols** and can certify a broad **PERMIT** for a packet class
the caller never intended to test. That is a **fail-OPEN** on an endpoint
whose entire purpose is security verification.

Distinct from #4921 (grpcapi `ShowText` duplicate last-wins) — this is
the REST surface silently ignoring *unrecognized* keys, not disagreeing
on a duplicate.

## Root cause

The handler consults exactly nine selector keys via `q.Get(...)`:
`from_zone`, `to_zone`, `src_ip`, `dst_ip`, `src_port`, `dst_port`,
`protocol`, `icmp_type`, `icmp_code`. Any other key in the query string
is never read, so a typo degrades that dimension to the match-any default
with no error.

## Fix (fail closed, allowlist derived from the handler's own selector set)

After the existing #3709 duplicate/boot-order checks and **before** the
`cfg == nil` verdict, enumerate every key present in `r.URL.Query()` and
reject with **HTTP 400** any key not in the selector allowlist, naming
the offender:

```
unknown selector parameter: protcol
```

- The 9-key `#3709` duplicate-check slice is promoted to a package-level
  SSOT (`matchPoliciesSelectorKeys`) consumed by **both** the duplicate
  check **and** the new unknown-key check. A selector added later is
  validated by both passes automatically — it cannot be
  read-but-not-allowlisted and silently re-open the gap.
- Unknown keys are sorted before reporting so the named key is
  deterministic when several are supplied (map iteration is randomized).
- **Absent keys are unchanged**: an unspecified dimension is still the
  intentional match-any wildcard. Only **unknown keys** are rejected, not
  missing ones — a zones-only request stays 200.
- Mirrors the fail-closed `writeError(w, http.StatusBadRequest, ...)`
  pattern the sibling match-policies guards already use (#2934 `dst_port`,
  #3108 `protocol`, #1711 `src_ip`/`dst_ip`, #3116 out-of-range port).

## #3709 non-regression

The duplicate-scalar/boot-order grammar (repeated known key → 400,
missing zones → 400, malformed value → 400, boot-window ordering before
`cfg == nil`) is preserved unchanged — the existing
`TestMatchPoliciesRESTRejectsDuplicate` /
`TestMatchPoliciesRESTNilConfigGrammarOrdering` suites still pass. The
unknown-key check runs **after** the duplicate check so a repeated known
selector still surfaces its #3709 duplicate error.

## Tests (pkg/api, fail-on-revert)

New `pkg/api/security_matchpolicies_unknownkey_5316_test.go`:

- **`TestMatchPoliciesRESTRejectsUnknownSelector`** — the #5316 scenario
  `?from_zone=trust&to_zone=untrust&protcol=tcp` → 400 naming `protcol`,
  plus several stray/misspelled keys (`src`, `dstport`, `application`,
  `format`) each rejected by name.
- **`TestMatchPoliciesRESTAcceptsAllKnownSelectors`** — all nine known
  selectors in one well-formed request → 200 (no false rejection).
- **`TestMatchPoliciesRESTNoSelectorStillMatches`** — zones-only
  (all-absent selector) request → 200 (absent = match-any wildcard).

**RED-on-revert (verified):** deleting the unknown-key enumeration makes
`TestMatchPoliciesRESTRejectsUnknownSelector` fail with
`status = 200, want 400` — the response body shows the widened
`"action":"permit"` verdict the typo produced. Restoring the block →
green.

## Docs

No REST API doc enumerates the match-policies query params — the selector
contract lives in the handler's code comments (as it did for the sibling
#3709/#2934/#3108/#1711 fail-closed fixes, none of which touched a doc).
The new unknown-key 400 behavior is documented in the handler comment.

## Validation

- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` — exit 0
- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test -count=1 ./pkg/api/...` — ok
- `gofmt -l` — clean on both touched files

Closes #5316

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
