### PR TITLE
logging: map all ten syslog severities to a filter threshold (#5314)

### DIFF
--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -18,8 +18,10 @@ package config
 //     event mode; anything else is stream mode).
 //   - syslogLogFormats: pkg/logging (syslog.go "sd-syslog" timestamp branch,
 //     ringbuf.go "binary"/"structured" branches; "syslog"/"" => RFC 3164).
-//   - syslogSeverities: pkg/logging ParseSeverity (error/warning/info map to
-//     a floor; everything else => 0 = no floor).
+//   - syslogSeverities: pkg/logging ParseSeverity (all ten Junos severities
+//     map to a MinSeverity threshold — emergency/alert/critical/error/warning/
+//     notice/info/debug plus any=>send-all and none=>send-nothing, #5314; an
+//     unknown token stays 0 = no floor).
 //   - syslogFacilities: pkg/logging ParseFacility (recognized names; every
 //     other name silently remaps to local0).
 //   - syslogCategories: pkg/logging ParseCategory (all/session/policy/screen/

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -10,7 +10,8 @@ package config
 // facility keyword itself is open-ended (a wildcard schema child), but the
 // severity is one of these names; anything else is a typo the runtime would
 // silently treat as "no severity filter" (logging.ParseSeverity returns 0
-// for unknown names). #2008.
+// for unknown names). All ten names below map to a real MinSeverity threshold
+// in logging.ParseSeverity (#5314). #2008.
 var junosSyslogSeverities = []string{
 	"any", "none", "emergency", "alert", "critical",
 	"error", "warning", "notice", "info", "debug",

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -687,6 +687,38 @@ func (d *Daemon) applyTimezone(cfg *config.Config) {
 // applySystemSyslog configures system-level syslog forwarding from
 // system { syslog { host ... } } config. This forwards daemon log
 // messages (Go slog) to remote syslog servers.
+// syslogHostMinSeverity folds the severity of every `<facility> <severity>`
+// pair of one syslog host into a single SyslogClient.MinSeverity threshold —
+// the most restrictive one, since the client carries a single filter. It
+// returns 0 (no filter / send-all) when no entry names a severity, matching
+// the SyslogClient zero value.
+//
+// ParseSeverity maps ALL ten Junos severities (#5314): emergency
+// (SeverityEmergency), alert/critical/error/warning/notice/info/debug (raw
+// RFC levels), plus any (0 = send-all) and none (SeverityNone = send-nothing).
+// The prior inline guard tested `if sev > 0`, which silently dropped
+// emergency/critical/alert/notice/debug/none (ParseSeverity returned 0 for
+// them), so `host H <facility> critical` left MinSeverity at the 0 send-all
+// sentinel and over-forwarded info/warning/error records the operator never
+// authorized.
+func syslogHostMinSeverity(facilities []config.SyslogFacility) int {
+	min := 0 // no filter (send-all) default; also the SyslogClient zero value
+	set := false
+	for _, f := range facilities {
+		if f.Severity == "" {
+			continue
+		}
+		sev := logging.ParseSeverity(f.Severity)
+		if !set {
+			min = sev
+			set = true
+			continue
+		}
+		min = logging.MoreRestrictiveMinSeverity(min, sev)
+	}
+	return min
+}
+
 func (d *Daemon) applySystemSyslog(cfg *config.Config) {
 	if d.slogHandler == nil {
 		return
@@ -718,14 +750,7 @@ func (d *Daemon) applySystemSyslog(cfg *config.Config) {
 		c.Facility = logging.FacilityDaemon
 		if len(host.Facilities) > 0 {
 			c.Facility = logging.ParseFacility(host.Facilities[0].Facility)
-			// Apply severity filter from the most restrictive facility entry
-			for _, f := range host.Facilities {
-				if sev := logging.ParseSeverity(f.Severity); sev > 0 {
-					if c.MinSeverity == 0 || sev < c.MinSeverity {
-						c.MinSeverity = sev
-					}
-				}
-			}
+			c.MinSeverity = syslogHostMinSeverity(host.Facilities)
 		}
 
 		clients = append(clients, c)

--- a/pkg/daemon/syslog_severity_5314_test.go
+++ b/pkg/daemon/syslog_severity_5314_test.go
@@ -1,0 +1,81 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/logging"
+)
+
+// TestSyslogHostMinSeverity_AnyCritical is the daemon-side #5314 regression.
+// `set system syslog host H any critical` parses to facility=any,
+// severity=critical. The old guard tested `if sev > 0`, but ParseSeverity only
+// mapped error/warning/info, so ParseSeverity("critical") returned 0 and the
+// guard left MinSeverity at the 0 send-all sentinel — the host then received
+// info/warning/error records it was never authorized for.
+//
+// This asserts the computed client filter is the critical threshold, and that a
+// SyslogClient carrying it forwards critical/alert/emergency but NOT
+// error/warning/info. On revert (3-severity ParseSeverity), MinSeverity == 0
+// and every "must NOT forward" assertion goes RED.
+func TestSyslogHostMinSeverity_AnyCritical(t *testing.T) {
+	facilities := []config.SyslogFacility{{Facility: "any", Severity: "critical"}}
+
+	min := syslogHostMinSeverity(facilities)
+	if min != logging.SyslogCritical {
+		t.Fatalf("syslogHostMinSeverity(any critical) = %d, want %d (critical)", min, logging.SyslogCritical)
+	}
+
+	c := &logging.SyslogClient{MinSeverity: min}
+	for _, sev := range []int{logging.SyslogEmergency, logging.SyslogAlert, logging.SyslogCritical} {
+		if !c.ShouldSend(sev) {
+			t.Errorf("host `any critical` should forward severity %d", sev)
+		}
+	}
+	for _, sev := range []int{logging.SyslogError, logging.SyslogWarning, logging.SyslogNotice, logging.SyslogInfo} {
+		if c.ShouldSend(sev) {
+			t.Errorf("host `any critical` MUST NOT forward severity %d — #5314 over-forward", sev)
+		}
+	}
+}
+
+// TestSyslogHostMinSeverity_EmergencyNotSendAll proves the guard no longer
+// drops emergency: `host H any emergency` must yield the emergency-only filter,
+// NOT the send-all sentinel. The old `if sev > 0` guard would also have dropped
+// emergency (its threshold code is negative), leaving MinSeverity at 0.
+func TestSyslogHostMinSeverity_EmergencyNotSendAll(t *testing.T) {
+	min := syslogHostMinSeverity([]config.SyslogFacility{{Facility: "any", Severity: "emergency"}})
+	if min != logging.SeverityEmergency {
+		t.Fatalf("syslogHostMinSeverity(any emergency) = %d, want %d (emergency)", min, logging.SeverityEmergency)
+	}
+	c := &logging.SyslogClient{MinSeverity: min}
+	if !c.ShouldSend(logging.SyslogEmergency) {
+		t.Error("host `any emergency` should forward emergency")
+	}
+	if c.ShouldSend(logging.SyslogAlert) {
+		t.Error("host `any emergency` MUST NOT forward alert (emergency != send-all)")
+	}
+}
+
+// TestSyslogHostMinSeverity_Merge folds several facility pairs into the most
+// restrictive client filter, and confirms an unspecified severity defaults to
+// send-all.
+func TestSyslogHostMinSeverity_Merge(t *testing.T) {
+	// Most restrictive of {info, critical, warning} is critical.
+	min := syslogHostMinSeverity([]config.SyslogFacility{
+		{Facility: "daemon", Severity: "info"},
+		{Facility: "kern", Severity: "critical"},
+		{Facility: "auth", Severity: "warning"},
+	})
+	if min != logging.SyslogCritical {
+		t.Errorf("merge = %d, want %d (critical, most restrictive)", min, logging.SyslogCritical)
+	}
+
+	// No facilities / no severity => 0 (send-all) default.
+	if got := syslogHostMinSeverity(nil); got != 0 {
+		t.Errorf("syslogHostMinSeverity(nil) = %d, want 0 (send-all)", got)
+	}
+	if got := syslogHostMinSeverity([]config.SyslogFacility{{Facility: "daemon"}}); got != 0 {
+		t.Errorf("syslogHostMinSeverity(no severity) = %d, want 0 (send-all)", got)
+	}
+}

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -139,6 +139,30 @@ connectionless and exempt:
   collector). The clock is cleared only on a FULLY successful reconnect
   (dial AND the retry-write both land), so the legitimate
   single-broken-pipe recovery path is unaffected.
+- **Severity filtering — complete threshold mapping (#5314).**
+  `SyslogClient.MinSeverity` encodes the Junos `host <facility> <severity>`
+  threshold: "forward this severity AND every more-severe one" (lower RFC
+  number = more severe). `ShouldSend(sev)` forwards a record iff it is at
+  least as severe as `MinSeverity`. The representation:
+  - `0` = no filter — forward everything. This is the ZERO VALUE (an
+    unconfigured client forwards all) and what Junos `any`, an unset
+    severity, and (tolerantly) an unknown token map to.
+  - `SeverityNone` (-2) = Junos `none` — forward nothing.
+  - `SeverityEmergency` (-1) = Junos `emergency` — forward ONLY emergency.
+    Emergency is RFC severity 0, which is already the send-all sentinel, so
+    the most severe level gets its own code rather than collapsing into
+    send-all.
+  - raw RFC level `alert(1)..debug(7)` — forward `severity <= MinSeverity`.
+
+  `ParseSeverity` maps all ten schema severities
+  (`junosSyslogSeverities`, pkg/config) to these codes, case-insensitively.
+  Before #5314 it mapped only error/warning/info and returned 0 for
+  everything else, so `host H <facility> critical` collapsed to the
+  send-all sentinel and a security appliance forwarded substantially more
+  syslog data than authorized — critical/notice/alert/emergency/debug/none
+  all leaked as "no filter". A syslog host that lists several
+  `<facility> <severity>` pairs is folded to one client filter via
+  `MoreRestrictiveMinSeverity` (the most restrictive pair wins).
 - **Lazy connect — receiver down at apply does not disable the stream
   (#3351).** A TCP/TLS receiver that is unreachable at config-apply or
   boot must NOT permanently silence the stream. `NewSyslogClientTransport`

--- a/pkg/logging/syslog.go
+++ b/pkg/logging/syslog.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -31,12 +32,37 @@ const (
 	defaultReconnectCooldown = 1 * time.Second
 )
 
-// Syslog severity levels (RFC 3164).
+// Syslog wire severity levels (RFC 5424 / RFC 3164 numeric PRI severity).
+// LOWER number = MORE severe. These are the on-the-wire severity codes AND
+// the values a record's severity is compared against in ShouldSend.
 const (
-	SyslogError   = 3
-	SyslogWarning = 4
-	SyslogNotice  = 5
-	SyslogInfo    = 6
+	SyslogEmergency = 0
+	SyslogAlert     = 1
+	SyslogCritical  = 2
+	SyslogError     = 3
+	SyslogWarning   = 4
+	SyslogNotice    = 5
+	SyslogInfo      = 6
+	SyslogDebug     = 7
+)
+
+// SyslogClient.MinSeverity filter sentinels (#5314). MinSeverity encodes the
+// Junos `host <facility> <severity>` threshold ("send this severity AND every
+// more-severe one"). It is NOT a wire severity code — it reuses the raw RFC
+// values above for alert(1)..debug(7), but the two extremes need dedicated
+// sentinels:
+//
+//   - 0 = "no severity filter" — forward every record. This is the ZERO VALUE,
+//     so an unconfigured client forwards everything, and it is also what Junos
+//     `any` (and an unknown/typo'd severity, tolerantly) maps to.
+//   - SeverityEmergency = -1 — forward ONLY emergency records. The most severe
+//     level cannot reuse SyslogEmergency(0) because 0 already means send-all;
+//     collapsing emergency into the send-all sentinel is exactly the #5314
+//     over-forward bug, so emergency gets its own code.
+//   - SeverityNone = -2 — forward NOTHING (Junos `none`).
+const (
+	SeverityNone      = -2
+	SeverityEmergency = -1
 )
 
 // Syslog facility codes (RFC 3164).
@@ -68,7 +94,7 @@ type SyslogClient struct {
 	protocol    string // "udp", "tcp", "tls"
 	tlsConfig   *tls.Config
 	Facility    int    // syslog facility code (default: FacilityLocal0)
-	MinSeverity int    // 0 = no filter, else SyslogError(3)/SyslogWarning(4)/SyslogInfo(6)
+	MinSeverity int    // severity threshold; 0 = no filter, SeverityEmergency(-1)/SeverityNone(-2) sentinels, else raw RFC level (see ShouldSend)
 	Format      string // "sd-syslog" for RFC 5424, "structured" for Junos RT_FLOW, "" for RFC 3164
 	Categories  uint8  // bitmask of allowed event categories (0 = all)
 
@@ -656,9 +682,59 @@ func (s *SyslogClient) writeBinaryMsg(data []byte) error {
 }
 
 // ShouldSend returns true if the event severity passes this client's filter.
-// Lower severity number = higher priority (error=3 < warning=4 < info=6).
+// Lower severity number = higher priority (emergency=0 < error=3 < info=6). A
+// record is sent iff it is at least as severe as MinSeverity — the Junos
+// "<severity> AND more severe" threshold. The two sentinels are handled
+// explicitly so the most-severe level (emergency) does not collide with the
+// send-all zero value (#5314):
+//
+//   - MinSeverity == 0 (no filter / Junos any / unset) → send everything.
+//   - MinSeverity == SeverityNone (Junos none) → send nothing.
+//   - MinSeverity == SeverityEmergency (Junos emergency) → send only emergency
+//     (SyslogEmergency==0), i.e. severity <= 0.
+//   - otherwise MinSeverity is a raw RFC level alert(1)..debug(7); send iff the
+//     record's severity is <= MinSeverity (equal or more severe).
 func (s *SyslogClient) ShouldSend(severity int) bool {
-	return s.MinSeverity == 0 || severity <= s.MinSeverity
+	switch s.MinSeverity {
+	case 0:
+		return true
+	case SeverityNone:
+		return false
+	case SeverityEmergency:
+		return severity <= SyslogEmergency
+	default:
+		return severity <= s.MinSeverity
+	}
+}
+
+// minSeverityRestrictRank ranks a MinSeverity threshold code by how much it
+// restricts forwarding: HIGHER rank = MORE restrictive (forwards fewer
+// records). Ordering, most→least restrictive: none, emergency, alert,
+// critical, error, warning, notice, info, debug, any(0). Used to merge the
+// per-facility severities of one syslog host into a single most-restrictive
+// client filter (the client holds one MinSeverity, not a per-facility map).
+func minSeverityRestrictRank(min int) int {
+	switch min {
+	case SeverityNone: // send nothing — most restrictive
+		return 100
+	case SeverityEmergency: // send only emergency
+		return 99
+	case 0: // no filter / any — least restrictive
+		return -1
+	default: // raw RFC level: alert(1)..debug(7); lower value = more restrictive
+		return 8 - min
+	}
+}
+
+// MoreRestrictiveMinSeverity returns whichever of two MinSeverity threshold
+// codes forwards the FEWER records. When a syslog host lists several
+// `<facility> <severity>` pairs the client — which carries a single
+// MinSeverity — adopts the most restrictive of them (#5314).
+func MoreRestrictiveMinSeverity(a, b int) int {
+	if minSeverityRestrictRank(b) > minSeverityRestrictRank(a) {
+		return b
+	}
+	return a
 }
 
 // ShouldSendEvent returns true if both severity and category filters pass.
@@ -732,16 +808,49 @@ func ParseSeverityStrict(name string) (int, error) {
 	}
 }
 
-// ParseSeverity converts a severity name to its numeric value.
-// Returns 0 (no filter) for unrecognized names.
+// ParseSeverity converts a Junos syslog severity name to the MinSeverity
+// threshold code used by ShouldSend. It maps ALL ten severities the config
+// schema accepts (junosSyslogSeverities in pkg/config/schema_system.go), plus
+// the two extremes as sentinels (#5314):
+//
+//	any                        -> 0                 (no filter, send all)
+//	none                       -> SeverityNone (-2) (send nothing)
+//	emergency                  -> SeverityEmergency (-1) (send only emergency)
+//	alert/critical/error/
+//	warning/notice/info/debug  -> raw RFC level 1..7
+//
+// The mapping is case-insensitive. Before #5314 only error/warning/info were
+// mapped and everything else fell through to 0 = send-all, so a legitimate
+// `host H <facility> critical` collapsed to no-filter and over-forwarded
+// info/warning/error records the operator never authorized.
+//
+// Tolerant contract (preserved): an unrecognized name returns 0 (no filter),
+// matching the historical behavior. The strict commit-time schema
+// (ValidateEnum(junosSyslogSeverities)) rejects unknown severities before they
+// reach here; ParseSeverityStrict is the fail-closed variant used by the SSE
+// surface.
 func ParseSeverity(name string) int {
-	switch name {
+	switch strings.ToLower(name) {
+	case "any":
+		return 0
+	case "none":
+		return SeverityNone
+	case "emergency":
+		return SeverityEmergency
+	case "alert":
+		return SyslogAlert
+	case "critical":
+		return SyslogCritical
 	case "error":
 		return SyslogError
 	case "warning":
 		return SyslogWarning
+	case "notice":
+		return SyslogNotice
 	case "info":
 		return SyslogInfo
+	case "debug":
+		return SyslogDebug
 	default:
 		return 0
 	}

--- a/pkg/logging/syslog_test.go
+++ b/pkg/logging/syslog_test.go
@@ -18,19 +18,147 @@ import (
 )
 
 func TestParseSeverity(t *testing.T) {
+	// #5314: ParseSeverity must map ALL ten Junos severities the config schema
+	// accepts (junosSyslogSeverities), not just error/warning/info. Before the
+	// fix, emergency/alert/critical/notice/debug/none all fell through to 0
+	// (send-all), so a `host H <facility> critical` collapsed to no-filter and
+	// over-forwarded. This table is the fail-on-revert guard for that mapping:
+	// reverting to the 3-severity switch makes critical/emergency/etc. return 0
+	// and fails the assertions below.
 	tests := []struct {
 		name string
 		want int
 	}{
+		// Sentinels / extremes.
+		{"any", 0},
+		{"none", SeverityNone},
+		{"emergency", SeverityEmergency},
+		// Raw RFC levels.
+		{"alert", SyslogAlert},
+		{"critical", SyslogCritical},
 		{"error", SyslogError},
 		{"warning", SyslogWarning},
+		{"notice", SyslogNotice},
 		{"info", SyslogInfo},
+		{"debug", SyslogDebug},
+		// Case-insensitive.
+		{"Critical", SyslogCritical},
+		{"EMERGENCY", SeverityEmergency},
+		{"None", SeverityNone},
+		// Tolerant contract preserved: unknown / empty => 0 (no filter).
 		{"unknown", 0},
 		{"", 0},
 	}
 	for _, tt := range tests {
 		if got := ParseSeverity(tt.name); got != tt.want {
 			t.Errorf("ParseSeverity(%q) = %d, want %d", tt.name, got, tt.want)
+		}
+	}
+}
+
+// TestParseSeverityCoversSchema pins ParseSeverity to the exact severity
+// vocabulary the config schema accepts, so a schema addition without a runtime
+// mapping (the #5314 class of bug: schema accepts, runtime silently
+// no-filters) fails here. "any" and unknown legitimately map to 0 (send-all);
+// every OTHER schema token must map to a non-zero threshold.
+func TestParseSeverityCoversSchema(t *testing.T) {
+	// Mirror of config.junosSyslogSeverities (kept local to avoid an import
+	// cycle; the schema comment cross-references this test).
+	schemaSeverities := []string{
+		"any", "none", "emergency", "alert", "critical",
+		"error", "warning", "notice", "info", "debug",
+	}
+	for _, name := range schemaSeverities {
+		got := ParseSeverity(name)
+		if name == "any" {
+			if got != 0 {
+				t.Errorf("ParseSeverity(%q) = %d, want 0 (send-all)", name, got)
+			}
+			continue
+		}
+		if got == 0 {
+			t.Errorf("ParseSeverity(%q) = 0 (send-all) — schema severity has no "+
+				"runtime threshold, would over-forward (#5314)", name)
+		}
+	}
+}
+
+// TestShouldSend_AnyCritical is the core #5314 regression: `host H any critical`
+// (facility=any, severity=critical) must forward critical AND more-severe
+// records, and must NOT forward the less-severe error/warning/info records. On
+// revert (ParseSeverity("critical") -> 0), MinSeverity becomes the send-all
+// sentinel and every one of the "must NOT send" assertions goes RED.
+func TestShouldSend_AnyCritical(t *testing.T) {
+	c := &SyslogClient{MinSeverity: ParseSeverity("critical")}
+
+	// critical and MORE severe -> sent.
+	for _, sev := range []int{SyslogEmergency, SyslogAlert, SyslogCritical} {
+		if !c.ShouldSend(sev) {
+			t.Errorf("critical filter should forward severity %d (critical or more severe)", sev)
+		}
+	}
+	// LESS severe than critical -> NOT sent (the leak the bug caused).
+	for _, sev := range []int{SyslogError, SyslogWarning, SyslogNotice, SyslogInfo, SyslogDebug} {
+		if c.ShouldSend(sev) {
+			t.Errorf("critical filter MUST NOT forward severity %d (less severe than critical) — #5314 over-forward", sev)
+		}
+	}
+}
+
+// TestShouldSend_Emergency proves emergency is a real, most-restrictive
+// threshold and NOT the send-all sentinel: only emergency records pass, and
+// even alert/critical (the next-most-severe levels) are suppressed.
+func TestShouldSend_Emergency(t *testing.T) {
+	c := &SyslogClient{MinSeverity: ParseSeverity("emergency")}
+	if !c.ShouldSend(SyslogEmergency) {
+		t.Error("emergency filter should forward emergency")
+	}
+	for _, sev := range []int{SyslogAlert, SyslogCritical, SyslogError, SyslogWarning, SyslogInfo} {
+		if c.ShouldSend(sev) {
+			t.Errorf("emergency filter MUST NOT forward severity %d (emergency != send-all)", sev)
+		}
+	}
+}
+
+// TestShouldSend_AnyAndNone covers the two Junos extremes: `any` forwards
+// everything, `none` forwards nothing.
+func TestShouldSend_AnyAndNone(t *testing.T) {
+	all := []int{SyslogEmergency, SyslogAlert, SyslogCritical, SyslogError,
+		SyslogWarning, SyslogNotice, SyslogInfo, SyslogDebug}
+
+	any := &SyslogClient{MinSeverity: ParseSeverity("any")}
+	for _, sev := range all {
+		if !any.ShouldSend(sev) {
+			t.Errorf("any filter should forward severity %d", sev)
+		}
+	}
+
+	none := &SyslogClient{MinSeverity: ParseSeverity("none")}
+	for _, sev := range all {
+		if none.ShouldSend(sev) {
+			t.Errorf("none filter MUST NOT forward severity %d", sev)
+		}
+	}
+}
+
+// TestMoreRestrictiveMinSeverity checks the fold used to collapse a host's
+// several `<facility> <severity>` pairs into one client filter. Ordering,
+// most→least restrictive: none, emergency, alert..debug, any.
+func TestMoreRestrictiveMinSeverity(t *testing.T) {
+	tests := []struct {
+		a, b, want int
+	}{
+		{ParseSeverity("critical"), ParseSeverity("info"), ParseSeverity("critical")}, // critical more restrictive than info
+		{ParseSeverity("info"), ParseSeverity("critical"), ParseSeverity("critical")}, // order-independent
+		{ParseSeverity("any"), ParseSeverity("info"), ParseSeverity("info")},          // any (send-all) least restrictive
+		{ParseSeverity("emergency"), ParseSeverity("critical"), ParseSeverity("emergency")},
+		{ParseSeverity("none"), ParseSeverity("emergency"), ParseSeverity("none")}, // none most restrictive
+		{ParseSeverity("any"), ParseSeverity("none"), ParseSeverity("none")},
+		{ParseSeverity("debug"), ParseSeverity("any"), ParseSeverity("debug")}, // debug edges out any
+	}
+	for _, tt := range tests {
+		if got := MoreRestrictiveMinSeverity(tt.a, tt.b); got != tt.want {
+			t.Errorf("MoreRestrictiveMinSeverity(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
## Problem (#5314, Medium — security: over-forwarding)

`ParseSeverity` mapped only `error`/`warning`/`info` and returned `0`
for everything else. `ShouldSend` treats `MinSeverity == 0` as **send
all**, and the daemon guard tested `if sev > 0`. So a legitimately
configured `set system syslog host H <facility> critical` collapsed to
the send-all sentinel:

- `ParseSeverity("critical")` returned `0`
- the `sev > 0` guard left `MinSeverity` at `0`
- `ShouldSend` treated `0` as no-filter and forwarded **info/warning/error**
  records the operator never authorized

Because `critical`/`notice`/`alert`/`emergency`/`debug`/`none` all fell
through to `0`, a **security appliance forwarded substantially more
syslog data than the configuration permitted**. The typed schema already
accepts all ten severities (`junosSyslogSeverities`), so nothing rejected
the config at commit — the gap was purely the runtime mapping.

`#4303` fixed host/file sub-statement parsing, not this runtime mapping.
`ParseSeverityStrict` already knew `notice` but is used only for the SSE
surface. Distinct from `#4484` L-4.

## Root cause: the 0-sentinel collision

RFC severity `emergency == 0`, which is exactly the `MinSeverity == 0 ==
send-all` sentinel. The most severe level could not be represented as a
real threshold without colliding with "no filter".

## Fix

The existing tests pin **two** invariants I preserved: `{MinSeverity: 0}`
means send-all, and levels use the **raw RFC** comparison
(`{MinSeverity: SyslogInfo}` → `severity <= 6`). So the only true
collision is `emergency`. Resolution:

- **`ParseSeverity`** now maps ALL ten Junos severities,
  case-insensitively:
  - `any` → `0` (send all)
  - `none` → `SeverityNone` (-2, send nothing)
  - `emergency` → `SeverityEmergency` (-1, only emergency)
  - `alert/critical/error/warning/notice/info/debug` → raw RFC `1..7`

  `emergency` and `none` get **dedicated out-of-band sentinels** so
  `emergency` is a real most-restrictive threshold that does NOT collapse
  into send-all. The tolerant contract is preserved — an unknown name
  still returns `0` (no filter), and the commit-time schema already
  rejects unknown tokens.

- **`ShouldSend`** handles the sentinels explicitly (`0` → send all,
  `SeverityNone` → send nothing, `SeverityEmergency` → `severity <= 0`,
  otherwise the raw-RFC compare). `MinSeverity == 0 == send-all` and the
  raw-RFC level comparison are unchanged, so callers that assign
  `SyslogError`/`SyslogInfo` directly keep working (e.g. the
  `eventstream` test).

- **Daemon guard** (`daemon_system.go`) is rewritten as
  `syslogHostMinSeverity`: it drops the `sev > 0` gate (which silently
  discarded `emergency/critical/alert/notice/debug/none`) and folds a
  host's several `<facility> <severity>` pairs into one most-restrictive
  client filter via `MoreRestrictiveMinSeverity`. A host that names no
  severity still defaults to `0` = send-all (the client zero value).

## Tests (fail-on-revert)

`pkg/logging`:
- full ten-severity `ParseSeverity` table + schema-coverage guard
- **core `any critical` semantics**: critical/alert/emergency **sent**;
  error/warning/info/notice/debug **NOT sent** (the leak)
- `emergency` threshold: only emergency, not alert/critical
  (proves `emergency != send-all`)
- `any` → everything; `none` → nothing
- `MoreRestrictiveMinSeverity` fold ordering

`pkg/daemon`: `syslogHostMinSeverity` for `any critical`, `any emergency`
(emergency != send-all), and the multi-pair merge + no-severity default.

**RED-on-revert (verified):** reverting `ParseSeverity` to the
3-severity map turns the over-forward assertions RED, e.g.
`critical filter MUST NOT forward severity 3/4/5/6 — #5314 over-forward`
and `ParseSeverity("critical") = 0, want 2`.

## Docs

`pkg/logging/README.md` documents the complete threshold mapping and the
`any`/`none`/`emergency` semantics; the `pkg/config` schema comments now
note all ten names map to a runtime threshold.

## Validation

- `go build ./...` → exit 0
- `go test -count=1 ./pkg/logging/... ./pkg/daemon/...` → ok
- `gofmt -l` clean on touched Go files

Closes #5314

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
