### PR TITLE
api: fetch userspace Status() once per metrics scrape (#5317)

### DIFF
--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -285,6 +285,16 @@ under the daemon's errgroup. Nothing else imports this package.
   with HA sync, session installs, snapshot sync, and forwarding sync.
   Adding a new caller at >1 Hz here will starve session installs during
   bulk sync (per CLAUDE.md control-socket rules).
+- A `/metrics` scrape performs at most ONE control-socket `Status()` round
+  trip. `Collect` fetches the `ProcessStatus` once (`fetchUserspaceStatus`,
+  after the dataplane gate) and shares the snapshot with BOTH the filter-term
+  hit merge (`collectFilterCounters`) and the userspace-status families
+  (`collectUserspaceStatus`). Before #5317 those two collectors each issued
+  their own `Status()`, so one scrape did two serialized `status` RPCs on the
+  contention-critical control socket (and read two A/B-skewed snapshots). On a
+  Status() failure the shared fetch returns nil once and is NOT retried — the
+  filter merge falls back to the map path and the userspace families emit
+  nothing, exactly as each collector degraded before.
 - Userspace CoS metrics are emitted from a single `Status()` snapshot per
   scrape. Queue-scoped drain-phase counters
   (`xpf_userspace_cos_drain_{guarantee,surplus}_sent_bytes_total` and

--- a/pkg/api/filter_counters_metrics_test.go
+++ b/pkg/api/filter_counters_metrics_test.go
@@ -40,7 +40,7 @@ func newFilterStore(t *testing.T, setLines []string) *configstore.Store {
 func filterHitsByTerm(t *testing.T, c *xpfCollector, dp apiRuntimeDataPlane) map[string]float64 {
 	t.Helper()
 	ch := make(chan prometheus.Metric, 64)
-	c.collectFilterCounters(ch, dp)
+	c.collectFilterCounters(ch, dp, fetchUserspaceStatus(dp))
 	close(ch)
 	out := map[string]float64{}
 	for m := range ch {

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -1059,10 +1059,21 @@ func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
+	// #5317: fetch the userspace-dp helper status ONCE per scrape and share the
+	// snapshot across collectFilterCounters (filter-term hit merge) and
+	// collectUserspaceStatus (CoS / worker-runtime / fairness / neighbor / ...
+	// families). Before this each of those collectors issued its own
+	// control-socket Status() round trip, so a single scrape did two serialized
+	// `status` RPCs — doubling contention with session installs during bulk sync
+	// (CLAUDE.md "Control socket contention"). nil = no Status() surface or a
+	// failed round trip; both collectors degrade exactly as they did on their
+	// own failed/absent fetch.
+	userspaceStatus := fetchUserspaceStatus(dp)
+
 	c.collectGlobalCounters(ch, dp)
 	c.collectInterfaceCounters(ch, dp)
 	c.collectPolicyCounters(ch, dp)
-	c.collectFilterCounters(ch, dp)
+	c.collectFilterCounters(ch, dp, userspaceStatus)
 	// #3464: emit the per-interface scrape-error counter AFTER
 	// collectInterfaceCounters has run, so a read failure this scrape is
 	// reflected in THIS scrape's xpf_interface_counter_read_errors_total. Kept
@@ -1079,7 +1090,7 @@ func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
 	c.collectDDNSMetrics(ch)
 	c.collectSurfaceADDNSMetrics(ch)
 	c.collectSystemMetrics(ch)
-	c.collectUserspaceStatus(ch, dp)
+	c.collectUserspaceStatus(ch, userspaceStatus)
 }
 
 // #709: emit per-bucket counter samples. Bucket index maps to a

--- a/pkg/api/metrics_counters.go
+++ b/pkg/api/metrics_counters.go
@@ -475,7 +475,7 @@ func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp api
 	}
 }
 
-func (c *xpfCollector) collectFilterCounters(ch chan<- prometheus.Metric, dp apiRuntimeDataPlane) {
+func (c *xpfCollector) collectFilterCounters(ch chan<- prometheus.Metric, dp apiRuntimeDataPlane, userspaceStatus *dpuserspace.ProcessStatus) {
 	cfg := c.srv.store.ActiveConfig()
 	if cfg == nil {
 		return
@@ -489,14 +489,14 @@ func (c *xpfCollector) collectFilterCounters(ch chan<- prometheus.Metric, dp api
 	// canonical metrics path reports 0/stale while the text commands show real
 	// hits. The userspace merge is independent of the eBPF apply result, so it
 	// must NOT be gated on cr/FilterIDs below.
-	var userspaceStatus *dpuserspace.ProcessStatus
-	if provider, ok := dp.(interface {
-		Status() (dpuserspace.ProcessStatus, error)
-	}); ok {
-		if status, err := provider.Status(); err == nil {
-			userspaceStatus = &status
-		}
-	}
+	//
+	// #5317: the ProcessStatus is fetched ONCE per scrape by Collect (via
+	// fetchUserspaceStatus) and shared with collectUserspaceStatus, so this no
+	// longer issues its own control-socket Status() round trip. A nil pointer —
+	// the helper exposes no Status() surface or the single round trip failed —
+	// yields an empty term index from BuildFirewallFilterTermCounterIndex, so the
+	// userspace merge is a no-op and the map path is unaffected, exactly as the
+	// prior per-collector fetch behaved on a missing/failed status.
 	userspaceCounters := dpuserspace.BuildFirewallFilterTermCounterIndex(userspaceStatus)
 
 	// The retired-eBPF/map counter path is gated on a compile result carrying

--- a/pkg/api/metrics_status_dedupe_5317_test.go
+++ b/pkg/api/metrics_status_dedupe_5317_test.go
@@ -1,0 +1,211 @@
+package api
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/psaab/xpf/pkg/conntrack"
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// #5317: the Prometheus metrics Collect() path used to call the userspace
+// helper's control-socket Status() TWICE per scrape — collectFilterCounters
+// (filter-term hit merge) and collectUserspaceStatus (CoS / worker / fairness /
+// neighbor families) each fetched it independently. The control socket is
+// contention-critical during bulk session sync (CLAUDE.md "Control socket
+// contention"), so a scrape must issue at most ONE `status` RPC. These pins
+// count the round trips a single Collect() makes and assert the shared-fetch
+// behavior on both the success and status-error paths.
+
+// statusCountingDP wraps the fully-wired descriptorCoverageDP and counts the
+// control-socket Status() round trips a scrape performs, so the #5317 dedupe is
+// directly observable. It embeds *descriptorCoverageDP for every other
+// apiRuntimeDataPlane method; the outer Status() shadows the embedded one and
+// bumps the counter.
+type statusCountingDP struct {
+	*descriptorCoverageDP
+	statusCalls int
+	statusErr   error
+}
+
+func (d *statusCountingDP) Status() (dpuserspace.ProcessStatus, error) {
+	d.statusCalls++
+	if d.statusErr != nil {
+		return dpuserspace.ProcessStatus{}, d.statusErr
+	}
+	return d.descriptorCoverageDP.status, nil
+}
+
+// newStatusCountingScrape builds a real active config + a Status()-counting
+// dataplane and returns the collector and dp ready for a full Collect().
+func newStatusCountingScrape(t *testing.T, status dpuserspace.ProcessStatus, statusErr error) (*xpfCollector, *statusCountingDP) {
+	t.Helper()
+	store := newDescriptorCoverageStore(t)
+	srv := &Server{store: store, gc: conntrack.NewGC(nil, time.Minute), startTime: time.Now()}
+	dp := &statusCountingDP{
+		descriptorCoverageDP: &descriptorCoverageDP{
+			Manager: dataplane.New(),
+			status:  status,
+			apply: &dataplane.ApplyResult{
+				ZoneIDs:   map[string]uint16{"trust": 1, "untrust": 2},
+				FilterIDs: map[string]uint32{"inet:fin": 0, "inet6:fin6": 100},
+			},
+		},
+		statusErr: statusErr,
+	}
+	srv.dp = dp
+	return newCollector(srv), dp
+}
+
+type gatheredSample struct {
+	desc   string
+	labels map[string]string
+	value  float64
+}
+
+// gatherCollect drives the REAL Collect() (production ordering) and returns
+// every emitted sample as {descriptor, labels, value}.
+func gatherCollect(t *testing.T, c *xpfCollector) []gatheredSample {
+	t.Helper()
+	ch := make(chan prometheus.Metric)
+	done := make(chan struct{})
+	var out []gatheredSample
+	go func() {
+		for m := range ch {
+			var pb dto.Metric
+			if err := m.Write(&pb); err != nil {
+				t.Errorf("metric write: %v", err)
+				continue
+			}
+			labels := make(map[string]string, len(pb.GetLabel()))
+			for _, l := range pb.GetLabel() {
+				labels[l.GetName()] = l.GetValue()
+			}
+			var v float64
+			switch {
+			case pb.Counter != nil:
+				v = pb.GetCounter().GetValue()
+			case pb.Gauge != nil:
+				v = pb.GetGauge().GetValue()
+			}
+			out = append(out, gatheredSample{desc: m.Desc().String(), labels: labels, value: v})
+		}
+		close(done)
+	}()
+	c.Collect(ch)
+	close(ch)
+	<-done
+	return out
+}
+
+func findSample(samples []gatheredSample, nameSubstr string, wantLabels map[string]string) (float64, bool) {
+	for _, s := range samples {
+		if !strings.Contains(s.desc, nameSubstr) {
+			continue
+		}
+		match := true
+		for k, v := range wantLabels {
+			if s.labels[k] != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			return s.value, true
+		}
+	}
+	return 0, false
+}
+
+// TestMetricsCollectFetchesUserspaceStatusOncePerScrape is the #5317
+// RED-on-revert pin: a single Collect()/scrape must issue exactly ONE
+// control-socket Status() round trip, and the shared snapshot must feed BOTH
+// the filter-term merge (collectFilterCounters) and the userspace-status
+// families (collectUserspaceStatus) with byte-identical values.
+//
+// FAIL-ON-REVERT: restoring a second independent Status() fetch (either
+// collector fetching on its own, or any extra fetchUserspaceStatus(dp) in
+// Collect) makes statusCalls == 2 and the count assertion goes RED.
+func TestMetricsCollectFetchesUserspaceStatusOncePerScrape(t *testing.T) {
+	status := dpuserspace.ProcessStatus{
+		// Consumed by collectFilterCounters (userspace merge into
+		// xpf_filter_hits_total).
+		FilterTermCounters: []dpuserspace.FirewallFilterTermCounterStatus{
+			{Family: "inet", FilterName: "fin", TermName: "t1", Packets: 777},
+		},
+		// Consumed ONLY by collectUserspaceStatus (emitNeighborColdStartCapture),
+		// emitted unconditionally.
+		NegNeighFastFailTotal: 42,
+	}
+	c, dp := newStatusCountingScrape(t, status, nil)
+
+	samples := gatherCollect(t, c)
+
+	if dp.statusCalls != 1 {
+		t.Fatalf("Status() called %d times in one scrape; want exactly 1 — #5317: "+
+			"collectFilterCounters and collectUserspaceStatus must SHARE one "+
+			"control-socket round trip, not each issue their own", dp.statusCalls)
+	}
+
+	// Success path: the shared status feeds the filter-term merge.
+	if got, ok := findSample(samples, "xpf_filter_hits_total",
+		map[string]string{"filter": "fin", "family": "inet", "term": "t1"}); !ok || got != 777 {
+		t.Errorf("xpf_filter_hits_total{filter=fin,family=inet,term=t1} = %v (present=%v); "+
+			"want 777 from the shared status FilterTermCounters", got, ok)
+	}
+	// Success path: the same shared status feeds the userspace-only family.
+	if got, ok := findSample(samples, "xpf_userspace_neg_neigh_fast_fail_total", nil); !ok || got != 42 {
+		t.Errorf("xpf_userspace_neg_neigh_fast_fail_total = %v (present=%v); "+
+			"want 42 from the shared status NegNeighFastFailTotal", got, ok)
+	}
+}
+
+// TestMetricsCollectStatusErrorFetchesOnceAndDegrades pins the error path: when
+// the single Status() round trip fails, the scrape must NOT retry it (still
+// exactly one call), and both dependent collectors degrade consistently — the
+// filter merge falls back to the map path (xpf_filter_hits_total = map-only
+// value, 0 here) and the userspace-status families emit nothing.
+//
+// FAIL-ON-REVERT: a "retry" second fetch (or either collector fetching on its
+// own) makes statusCalls == 2 and the count assertion goes RED.
+func TestMetricsCollectStatusErrorFetchesOnceAndDegrades(t *testing.T) {
+	// The FilterTermCounters/NegNeigh values would show through IF the error
+	// path erroneously consumed the status; they must NOT, because Status()
+	// returns an error.
+	status := dpuserspace.ProcessStatus{
+		FilterTermCounters: []dpuserspace.FirewallFilterTermCounterStatus{
+			{Family: "inet", FilterName: "fin", TermName: "t1", Packets: 777},
+		},
+		NegNeighFastFailTotal: 42,
+	}
+	c, dp := newStatusCountingScrape(t, status, errors.New("control socket unavailable"))
+
+	samples := gatherCollect(t, c)
+
+	if dp.statusCalls != 1 {
+		t.Fatalf("Status() called %d times on the status-error scrape; want exactly 1 "+
+			"— #5317: the single failed round trip must not be retried into a second "+
+			"control-socket request", dp.statusCalls)
+	}
+
+	// Filter counters degrade to the map path (ReadFilterCounters == 0 here),
+	// so the term still emits, at the map-only value (no userspace merge).
+	if got, ok := findSample(samples, "xpf_filter_hits_total",
+		map[string]string{"filter": "fin", "family": "inet", "term": "t1"}); !ok || got != 0 {
+		t.Errorf("xpf_filter_hits_total{filter=fin,family=inet,term=t1} = %v (present=%v) on "+
+			"Status() error; want 0 (map-only, no userspace merge) — the 777 helper "+
+			"counter must not leak through a failed status", got, ok)
+	}
+	// The userspace-status family must be absent (collectUserspaceStatus emits
+	// nothing on a nil/failed status), exactly as before the dedupe.
+	if got, ok := findSample(samples, "xpf_userspace_neg_neigh_fast_fail_total", nil); ok {
+		t.Errorf("xpf_userspace_neg_neigh_fast_fail_total present (=%v) despite a Status() "+
+			"error; want absent (degraded), matching the prior status-error behavior", got)
+	}
+}

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -11,21 +11,47 @@ import (
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 )
 
-// #709 + #869: single Status() call per scrape, then dispatch to
-// CoS owner profile + worker runtime collectors.  Both features need
-// the same ProcessStatus; calling Status() twice per scrape is
-// wasteful on the userspace-dp control socket.
-func (c *xpfCollector) collectUserspaceStatus(ch chan<- prometheus.Metric, dp apiRuntimeDataPlane) {
+// fetchUserspaceStatus performs the SINGLE per-scrape userspace-dp control-
+// socket Status() round trip whose result is shared by every collector that
+// consumes it (collectFilterCounters + collectUserspaceStatus). #5317: before
+// this each of those collectors issued its own Status() request, so one
+// /metrics scrape did two serialized `status` RPCs on the control socket —
+// doubling contention with session installs during bulk sync (CLAUDE.md
+// "Control socket contention"). Fetching once also gives both metric families a
+// COHERENT snapshot instead of two A/B-skewed reads.
+//
+// Returns nil when the dataplane does not expose a Status() surface OR the
+// round trip failed. Both collectors degrade to their prior no-status behavior
+// on nil — collectFilterCounters skips the userspace merge (empty term index,
+// map path unaffected), collectUserspaceStatus emits nothing — identical to when
+// each fetched Status() itself.
+func fetchUserspaceStatus(dp apiRuntimeDataPlane) *dpuserspace.ProcessStatus {
 	provider, ok := dp.(interface {
 		Status() (dpuserspace.ProcessStatus, error)
 	})
 	if !ok {
-		return
+		return nil
 	}
 	status, err := provider.Status()
 	if err != nil {
+		return nil
+	}
+	return &status
+}
+
+// #709 + #869: single Status() call per scrape, then dispatch to
+// CoS owner profile + worker runtime collectors.  Both features need
+// the same ProcessStatus; calling Status() twice per scrape is
+// wasteful on the userspace-dp control socket. #5317: the round trip is
+// now performed ONCE by Collect (via fetchUserspaceStatus) and the snapshot
+// passed in here, shared with collectFilterCounters — a nil pointer means the
+// helper exposes no Status() surface or the single round trip failed, so this
+// collector emits nothing (the prior status-error behavior).
+func (c *xpfCollector) collectUserspaceStatus(ch chan<- prometheus.Metric, statusPtr *dpuserspace.ProcessStatus) {
+	if statusPtr == nil {
 		return
 	}
+	status := *statusPtr
 	c.emitCoSOwnerProfile(ch, status)
 	c.emitCoSDrainPhaseTelemetry(ch, status)
 	c.emitCoSParkReasonTelemetry(ch, status)

--- a/pkg/api/zones_policies_counter_error_test.go
+++ b/pkg/api/zones_policies_counter_error_test.go
@@ -124,7 +124,7 @@ func filterApplyResult() *dataplane.ApplyResult {
 func countFilterSamples(t *testing.T, c *xpfCollector, dp apiRuntimeDataPlane) int {
 	t.Helper()
 	ch := make(chan prometheus.Metric, 64)
-	c.collectFilterCounters(ch, dp)
+	c.collectFilterCounters(ch, dp, fetchUserspaceStatus(dp))
 	close(ch)
 	var n int
 	for m := range ch {


### PR DESCRIPTION
## Summary

The Prometheus metrics `Collect()` path issued the userspace helper's control-socket `Status()` **twice per `/metrics` scrape**:

- `collectFilterCounters` fetched it for the filter-term hit merge (`xpf_filter_hits_total`).
- `collectUserspaceStatus` fetched it again for the CoS / worker-runtime / fairness / neighbor families.

Each `Status()` is a `requestLocked{"status"}` round trip taken under the manager mutex, so one scrape did **two serialized `status` RPCs** on the userspace-dp control socket (×3 admitted concurrent scrapes → six). That socket is contention-critical — shared by the 1 Hz status poll, HA sync, session installs, snapshot sync, and forwarding sync — and CLAUDE.md flags any >1 Hz caller as a starvation risk for session installs during bulk sync. The two independent fetches also read two A/B-skewed snapshots, so filter and CoS counters could disagree within one scrape.

## Fix

Fetch the `ProcessStatus` **once per scrape** and share it. `Collect` calls a new `fetchUserspaceStatus(dp)` helper immediately after the dataplane gate and passes the `*ProcessStatus` down to both `collectFilterCounters` and `collectUserspaceStatus`.

- `fetchUserspaceStatus` returns `nil` when the dataplane exposes no `Status()` surface **or** the single round trip fails.
- On `nil`: the filter merge builds an empty term index (map path unaffected) and the userspace-status collector emits nothing — **byte-identical** to the prior per-collector behavior on a missing/failed status.
- The single failed fetch is **not retried**, so the error path cannot reintroduce a second round trip.
- Success-path metric values and labels are unchanged; this only collapses two fetches into one shared fetch. It also gives both families a **coherent** snapshot.

## Tests (pkg/api, fail-on-revert)

A `Status()`-counting fake dataplane (`statusCountingDP` wrapping the wired `descriptorCoverageDP`) drives one full `Collect()`:

- **`TestMetricsCollectFetchesUserspaceStatusOncePerScrape`** — asserts exactly **1** `Status()` round trip, and that the shared snapshot feeds both families (`xpf_filter_hits_total` merges the helper term counter = 777; the userspace-only `xpf_userspace_neg_neigh_fast_fail_total` = 42).
- **`TestMetricsCollectStatusErrorFetchesOnceAndDegrades`** — on a `Status()` error: still exactly **1** call, the filter merge degrades to the map path (term emits map-only 0, the 777 helper value does not leak), and the userspace family is absent.

**RED-on-revert verified:** temporarily reintroducing a second `fetchUserspaceStatus(dp)` in `Collect` makes both pins fail with `Status() called 2 times ... want exactly 1`.

The two existing `collectFilterCounters` call sites (`filterHitsByTerm`, `countFilterSamples`) are updated to the new signature via `fetchUserspaceStatus(dp)`, preserving their intent.

## Docs

`pkg/api/README.md` now states a scrape performs at most one control-socket `Status()` round trip shared across the filter-term merge and the userspace-status families, including the nil/failed degrade path.

## Validation

- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` → exit 0
- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test -count=1 ./pkg/api/...` → ok
- `gofmt -l` clean on all touched files

Closes #5317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi