### PR TITLE
logging: gate aggregator reconcile + flush pending window on teardown (#5313)

### DIFF
--- a/pkg/daemon/aggregator_flush_5313_test.go
+++ b/pkg/daemon/aggregator_flush_5313_test.go
@@ -1,0 +1,131 @@
+package daemon
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/logging"
+)
+
+// TestApplyAggregatorEqualityGateKeepsLiveAggregator is the RED-on-revert proof
+// for the #5313 equality gate. A report-enabled re-apply whose derived config is
+// UNCHANGED must keep the SAME live aggregator running — not cancel+replace it —
+// so the pending flush window (up to ~5 min of SESSION_CLOSE counters) survives.
+//
+// Revert applyAggregator to the pre-#5313 cancel+replace-on-every-call body and
+// this goes RED twice: the second apply publishes a fresh aggregator instance
+// (pointer identity changes) and the pending window is discarded (empty Flush).
+func TestApplyAggregatorEqualityGateKeepsLiveAggregator(t *testing.T) {
+	er := logging.NewEventReader(nil, nil)
+	d := &Daemon{}
+
+	cfg := &config.Config{}
+	cfg.Security.Log.Report = true
+
+	// Generation 1.
+	d.applyAggregator(er, cfg)
+	agg1 := d.aggregatorPtr.Load()
+	if agg1 == nil {
+		t.Fatal("enable must publish a live aggregator")
+	}
+
+	// Accumulate a pending window through the production callback path (the same
+	// stable callback the EventReader dispatches to).
+	d.aggregationCallback(logging.EventRecord{
+		Type:         "SESSION_CLOSE",
+		SrcAddr:      "10.0.1.5:1234",
+		DstAddr:      "10.0.2.9:80",
+		SessionBytes: 4096,
+	}, nil)
+
+	// Re-apply with byte-identical config: the equality gate must keep the live
+	// aggregator instance.
+	d.applyAggregator(er, cfg)
+	agg2 := d.aggregatorPtr.Load()
+	if agg2 != agg1 {
+		t.Fatal("unchanged report-enabled re-apply must keep the SAME live aggregator " +
+			"(equality gate); got a replacement (pre-#5313 cancel+replace-every-call)")
+	}
+
+	// And the pending window must still be there.
+	topSrc, _ := agg2.Flush()
+	if len(topSrc) != 1 || topSrc[0].IP != "10.0.1.5" {
+		t.Fatalf("pending window not preserved across unchanged re-apply: %+v "+
+			"(a replacement would start from an empty window)", topSrc)
+	}
+
+	t.Cleanup(func() {
+		if d.aggCancel != nil {
+			d.aggCancel()
+		}
+	})
+}
+
+// TestApplyAggregatorConfigChangeFlushesPendingWindow is the RED-on-revert proof
+// for the #5313 final flush, driven through the daemon teardown path. Turning
+// reporting OFF is a genuine config change: applyAggregator retires the live
+// aggregator by cancelling its context, which must trigger aggregator.Run's
+// final flush so the pending window is EMITTED before the goroutine returns.
+//
+// Revert aggregator.Run to `case <-ctx.Done(): return` (no final flush) and this
+// goes RED: the disable cancels the context and the pending SESSION_CLOSE
+// counters are silently discarded — logFn is never called and the poll times out.
+func TestApplyAggregatorConfigChangeFlushesPendingWindow(t *testing.T) {
+	er := logging.NewEventReader(nil, nil)
+	d := &Daemon{}
+
+	enabled := &config.Config{}
+	enabled.Security.Log.Report = true
+	disabled := &config.Config{} // Report defaults false
+
+	d.applyAggregator(er, enabled)
+	agg := d.aggregatorPtr.Load()
+	if agg == nil {
+		t.Fatal("enable must publish a live aggregator")
+	}
+
+	// Redirect the live aggregator's report sink to a capturing sink so the
+	// teardown flush is observable (the default sink is er.ForwardLogMsg, which
+	// goes nowhere with a client-less EventReader). SetLogFunc is mutex-guarded.
+	var mu sync.Mutex
+	var msgs []string
+	agg.SetLogFunc(func(_ int, msg string) {
+		mu.Lock()
+		msgs = append(msgs, msg)
+		mu.Unlock()
+	})
+
+	// Pending window: one SESSION_CLOSE through the production callback path.
+	d.aggregationCallback(logging.EventRecord{
+		Type:         "SESSION_CLOSE",
+		SrcAddr:      "10.0.1.5:1234",
+		DstAddr:      "10.0.2.9:80",
+		SessionBytes: 4096,
+	}, nil)
+
+	// Disable: config CHANGED -> retire the aggregator. Its ctx is cancelled,
+	// which must flush the pending window (#5313) before Run returns.
+	d.applyAggregator(er, disabled)
+	if d.aggregatorPtr.Load() != nil {
+		t.Fatal("disable must nil the published aggregator pointer")
+	}
+
+	// The teardown flush runs in the retiring Run goroutine (async). Poll for it.
+	deadline := time.After(5 * time.Second)
+	for {
+		mu.Lock()
+		got := len(msgs)
+		mu.Unlock()
+		if got > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("config change tore down the aggregator without flushing the " +
+				"pending window: the #5313 counters were discarded on ctx.Done")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -381,11 +381,17 @@ type Daemon struct {
 	// swap on the commit path; the callback reads the pointer lock-free.
 	aggregatorPtr atomic.Pointer[logging.SessionAggregator]
 	aggCancel     context.CancelFunc
-	aggCBOnce     sync.Once
-	aggReconMu    sync.Mutex
-	vrrpMgr       *vrrp.Manager
-	gc            *conntrack.GC
-	startTime     time.Time // daemon start time; used to suppress stale config sync
+	// aggSig is the derived-config signature of the live aggregator generation
+	// (#5313). applyAggregator retires+rebuilds the running aggregator ONLY when
+	// the newly-derived signature differs; an unchanged signature keeps the live
+	// aggregator — and its pending flush window — running instead of discarding
+	// ~5 min of SESSION_CLOSE counters on every report-enabled commit.
+	aggSig     aggregatorSig
+	aggCBOnce  sync.Once
+	aggReconMu sync.Mutex
+	vrrpMgr    *vrrp.Manager
+	gc         *conntrack.GC
+	startTime  time.Time // daemon start time; used to suppress stale config sync
 
 	// #846: applySem (capacity 1) serializes applyConfig + the
 	// commit→apply pair across all entry points (HTTP/gRPC commits,

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -230,34 +230,85 @@ func (d *Daemon) aggregationCallback(rec logging.EventRecord, raw []byte) {
 	agg.HandleEvent(rec, raw)
 }
 
-// applyAggregator starts or stops the session aggregation reporter. The stable
-// indirection callback (aggregationCallback) is registered on er exactly once
-// — the first time reporting is enabled — and every later call only SWAPS the
-// active aggregator, cancelling the Run goroutine of the one it replaced. So N
-// report-enabled commits leave exactly one registered callback and one live
-// aggregator (#4964). Disabling reporting stores a nil aggregator; the stable
-// callback stays but becomes a no-op.
+// aggregatorSig is the comparable, derived-config signature of one aggregator
+// generation. applyAggregator retires+rebuilds the running aggregator only when
+// the signature genuinely changes (#5313). Only `enabled` is config-driven
+// today — window/topN are fixed defaults — but folding them into the signature
+// keeps the equality gate correct if either becomes configurable later.
+type aggregatorSig struct {
+	enabled       bool
+	flushInterval time.Duration
+	topN          int
+}
+
+// Fixed defaults for the session aggregation reporter. NewSessionAggregator(0,
+// 0) resolves to these same values internally; naming them here lets the
+// equality-gate signature carry the parameters the aggregator is built from.
+const (
+	aggregatorFlushInterval = 5 * time.Minute
+	aggregatorTopN          = 10
+)
+
+// applyAggregator starts, stops, or LEAVES-RUNNING the session aggregation
+// reporter. The stable indirection callback (aggregationCallback) is registered
+// on er exactly once — the first time reporting is enabled — so N report-enabled
+// commits leave exactly one registered callback and one live aggregator (#4964).
+//
+// #5313 (equality gate + final flush): the pre-#5313 body cancelled+replaced the
+// aggregator on EVERY call with no equality check. Because aggregator.Run only
+// flushed on ticker.C and returned on ctx.Done WITHOUT flushing, any unrelated
+// report-enabled commit (a syslog-stream edit, a hostname change — anything that
+// re-runs applySyslogConfig) tore down the running aggregator and silently
+// discarded up to a full flush window (~5 min) of pending SESSION_CLOSE counters.
+// Two composed fixes close that:
+//
+//  1. Equality gate: if a live aggregator's derived signature is unchanged, keep
+//     it — and its pending window — running instead of cancel+replace.
+//  2. Final flush: aggregator.Run now flushes the pending window on ctx.Done, so
+//     a genuine replace/disable emits the retiring window as a partial report
+//     (the new generation starts from an empty window — no double count) rather
+//     than dropping it.
+//
+// Disabling reporting stores a nil aggregator; the stable callback stays but
+// becomes a no-op.
 func (d *Daemon) applyAggregator(er *logging.EventReader, cfg *config.Config) {
 	d.aggReconMu.Lock()
 	defer d.aggReconMu.Unlock()
 
-	// Stop the currently-running aggregator generation (if any). Swap the
-	// published pointer to nil FIRST so no in-flight event can enter the
-	// retired aggregator via the stable callback, THEN cancel its flush
-	// goroutine. Retiring in the other order would let HandleEvent keep
-	// feeding a cancelled aggregator whose Run no longer flushes (the #4964
-	// leak).
+	desired := aggregatorSig{
+		enabled:       cfg.Security.Log.Report,
+		flushInterval: aggregatorFlushInterval,
+		topN:          aggregatorTopN,
+	}
+
+	// Equality gate (#5313): a live aggregator whose derived config is unchanged
+	// keeps running — do NOT cancel+replace it, which would discard its pending
+	// flush window. Only a genuine change (enable/disable or a parameter change)
+	// falls through to teardown.
+	if d.aggCancel != nil && d.aggSig == desired {
+		return
+	}
+
+	// Retire the running aggregator generation (config genuinely changed, or we
+	// are disabling). Swap the published pointer to nil FIRST so no in-flight
+	// event can enter the retired aggregator via the stable callback, THEN cancel
+	// its flush goroutine. Retiring in the other order would let HandleEvent keep
+	// feeding a cancelled aggregator (the #4964 leak). Cancelling now triggers
+	// Run's final flush (#5313): the retiring generation emits its pending window
+	// as a partial report before returning, so those ~5 min of counters are not
+	// silently dropped.
 	if d.aggCancel != nil {
 		d.aggregatorPtr.Store(nil)
 		d.aggCancel()
 		d.aggCancel = nil
+		d.aggSig = aggregatorSig{}
 	}
 
-	if !cfg.Security.Log.Report {
+	if !desired.enabled {
 		return
 	}
 
-	agg := logging.NewSessionAggregator(0, 0) // defaults: 5min, top-10
+	agg := logging.NewSessionAggregator(desired.flushInterval, desired.topN)
 
 	// Wire aggregator log output to the first available syslog client or local writer
 	agg.SetLogFunc(func(severity int, msg string) {
@@ -271,6 +322,7 @@ func (d *Daemon) applyAggregator(er *logging.EventReader, cfg *config.Config) {
 	// during startup. Add accumulates immediately; Run only flushes.
 	d.aggregatorPtr.Store(agg)
 	d.aggCancel = cancel
+	d.aggSig = desired
 
 	// Register the single stable callback exactly once, the first time
 	// reporting is enabled. A boot with reporting disabled registers nothing;

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -381,6 +381,28 @@ client never reconnects once the receiver returns.
   current writer running (the flowexport #3742 keep-old-on-failure posture).
   `EventReader.CallbackCount()` is the leak witness. Pin:
   `TestFlowTraceSingleCallbackAcrossReconciles` (`pkg/daemon`).
+- **Session aggregator: equality gate keeps the live window, teardown flushes
+  it (#5313).** `applyAggregator` (`pkg/daemon/daemon_system.go`) derives a
+  comparable `aggregatorSig` (report enabled + flush interval + top-N) from the
+  active config and retires+rebuilds the running `SessionAggregator` ONLY when
+  the signature genuinely changes. An unchanged report-enabled re-apply — any
+  unrelated commit that re-runs `applySyslogConfig` (a syslog-stream edit, a
+  hostname change) — now keeps the SAME live aggregator, so its pending flush
+  window survives. Before #5313 `applyAggregator` cancelled+replaced on EVERY
+  call, and `SessionAggregator.Run` returned on `ctx.Done()` WITHOUT flushing
+  (`flushAndLog` fired only on `ticker.C`), so up to a full ~5 min window of
+  accumulated `SESSION_CLOSE` counters was silently discarded on any such
+  commit. The composed fix: (1) the equality gate above, and (2) `Run` now
+  performs a FINAL `flushAndLog` on `ctx.Done()` before returning, so a genuine
+  replace/disable/shutdown emits the retiring window as its own (partial)
+  report and the new generation starts from an empty window. `flushAndLog`
+  suppresses an all-empty report and `topAndReset` drains the window, so a
+  ticker flush immediately followed by teardown neither double-counts nor emits
+  an empty line. Pins (fail-on-revert): `TestApplyAggregatorEqualityGateKeeps-
+  LiveAggregator` + `TestApplyAggregatorConfigChangeFlushesPendingWindow`
+  (`pkg/daemon`), `TestAggregatorRunFinalFlushOnCancel` +
+  `TestAggregatorRunNoEmptyFlushOnCancel` + `TestAggregatorFlushAndLogNoDouble-
+  Emit` (`pkg/logging`).
 - **Event time is DECISION time, not receive time (#2465/#2470/#2511).**
   The on-wire RT_FLOW frame carries an absolute Unix-nanosecond timestamp
   in its first 8 bytes (LE u64), stamped by the userspace-dp producer at

--- a/pkg/logging/aggregator.go
+++ b/pkg/logging/aggregator.go
@@ -237,6 +237,16 @@ func (sa *SessionAggregator) flushWithDropped() (topSrc, topDst []AggregateEntry
 }
 
 // Run starts the periodic flush loop. Blocks until ctx is cancelled.
+//
+// On ctx cancellation Run performs a FINAL flush before returning (#5313).
+// Without it, cancelling the context — which happens on daemon shutdown AND on
+// every config-churn teardown/replace in applyAggregator — silently discarded
+// up to a full flush interval (~5 min) of accumulated SESSION_CLOSE counters:
+// the pending window was only ever emitted on ticker.C. The final flush emits
+// that window as its own (partial) report so no counters are lost. flushAndLog
+// is a no-op when there are no pending counters (empty window), so a cancel
+// that races just after a ticker flush neither double-counts nor emits an empty
+// report.
 func (sa *SessionAggregator) Run(ctx context.Context) {
 	ticker := time.NewTicker(sa.flushInterval)
 	defer ticker.Stop()
@@ -244,6 +254,8 @@ func (sa *SessionAggregator) Run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			// Graceful final flush of the pending window before teardown.
+			sa.flushAndLog()
 			return
 		case <-ticker.C:
 			sa.flushAndLog()

--- a/pkg/logging/aggregator_flush_5313_test.go
+++ b/pkg/logging/aggregator_flush_5313_test.go
@@ -1,0 +1,134 @@
+package logging
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestAggregatorRunFinalFlushOnCancel is the RED-on-revert proof for the #5313
+// final flush. aggregator.Run must emit the pending window's accumulated
+// SESSION_CLOSE counters when its context is cancelled — the path taken on every
+// daemon shutdown AND on every config-churn teardown/replace in applyAggregator.
+//
+// A long flush interval guarantees the ticker never fires inside the test, so
+// the ONLY way the counters can be emitted is the ctx.Done final flush. Revert
+// Run to `case <-ctx.Done(): return` (no flush) and this goes RED: the pending
+// window is discarded and logFn is never called.
+func TestAggregatorRunFinalFlushOnCancel(t *testing.T) {
+	sa := NewSessionAggregator(time.Hour, 10) // ticker will not fire in-test
+
+	var mu sync.Mutex
+	var msgs []string
+	sa.SetLogFunc(func(_ int, msg string) {
+		mu.Lock()
+		msgs = append(msgs, msg)
+		mu.Unlock()
+	})
+
+	sa.Add(EventRecord{
+		Type:         "SESSION_CLOSE",
+		SrcAddr:      "10.0.1.5:1234",
+		DstAddr:      "10.0.2.9:80",
+		SessionBytes: 4096,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		sa.Run(ctx)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+
+	mu.Lock()
+	got := len(msgs)
+	mu.Unlock()
+	if got == 0 {
+		t.Fatal("expected the final flush to emit the pending window on ctx.Done; " +
+			"got 0 messages (counters discarded — the #5313 no-flush teardown bug)")
+	}
+}
+
+// TestAggregatorRunNoEmptyFlushOnCancel guards the other direction: cancelling an
+// aggregator with NO pending counters must emit nothing. flushAndLog already
+// suppresses an all-empty report, so the ctx.Done final flush of an empty window
+// is a no-op — no spurious RT_FLOW_SESSION_AGGREGATE line on a quiet teardown.
+func TestAggregatorRunNoEmptyFlushOnCancel(t *testing.T) {
+	sa := NewSessionAggregator(time.Hour, 10)
+
+	var mu sync.Mutex
+	var msgs []string
+	sa.SetLogFunc(func(_ int, msg string) {
+		mu.Lock()
+		msgs = append(msgs, msg)
+		mu.Unlock()
+	})
+
+	// No events added — the window is empty.
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		sa.Run(ctx)
+		close(done)
+	}()
+
+	cancel()
+	<-done
+
+	mu.Lock()
+	got := len(msgs)
+	mu.Unlock()
+	if got != 0 {
+		t.Fatalf("empty-window teardown must emit nothing; got %d messages", got)
+	}
+}
+
+// TestAggregatorFlushAndLogNoDoubleEmit guards against a double flush: a ticker
+// flush that drains the window followed by the ctx.Done final flush must NOT
+// re-emit the window. flushAndLog resets the counters via topAndReset, so the
+// second call finds an empty window and returns without emitting. This models
+// the "ticker fired, then teardown" race directly.
+func TestAggregatorFlushAndLogNoDoubleEmit(t *testing.T) {
+	sa := NewSessionAggregator(time.Hour, 10)
+
+	var mu sync.Mutex
+	var msgs []string
+	sa.SetLogFunc(func(_ int, msg string) {
+		mu.Lock()
+		msgs = append(msgs, msg)
+		mu.Unlock()
+	})
+
+	sa.Add(EventRecord{
+		Type:         "SESSION_CLOSE",
+		SrcAddr:      "10.0.1.5:1234",
+		DstAddr:      "10.0.2.9:80",
+		SessionBytes: 4096,
+	})
+
+	sa.flushAndLog() // ticker-equivalent flush: emits and resets the window
+	mu.Lock()
+	first := len(msgs)
+	mu.Unlock()
+	if first == 0 {
+		t.Fatal("first flush emitted nothing; expected the top-N report")
+	}
+
+	sa.flushAndLog() // teardown-equivalent flush of the now-empty window
+	mu.Lock()
+	second := len(msgs)
+	mu.Unlock()
+	if second != first {
+		t.Fatalf("second flush re-emitted an already-drained window: %d -> %d messages "+
+			"(double/empty flush)", first, second)
+	}
+}


### PR DESCRIPTION
## Problem (#5313)

`applyAggregator` (`pkg/daemon/daemon_system.go`) **cancelled and REPLACED**
the session-aggregation reporter on **every** call with no equality check, and
`SessionAggregator.Run` (`pkg/logging/aggregator.go`) returned on `ctx.Done()`
**without flushing** — `flushAndLog` fired only on `ticker.C`. So any
report-enabled commit that re-ran `applySyslogConfig` (a syslog-stream edit, a
hostname change — anything unrelated) tore down the running aggregator and
**silently discarded up to a full flush window (~5 min) of pending
`SESSION_CLOSE` aggregation counters**.

`#4964` fixed only the callback/goroutine leak (single stable callback + atomic
pointer swap). It did **not** address the lost-window discard: the pending
counters had no live owner across a reconcile.

## Fix (two composed parts)

1. **Equality gate.** `applyAggregator` derives a comparable `aggregatorSig`
   (report enabled + flush interval + top-N) from the active config and
   retires+rebuilds the running aggregator **only** when that signature genuinely
   changes. An unchanged report-enabled re-apply keeps the **same** live
   aggregator — and its pending window — running instead of cancel+replace. Only
   enable/disable or a parameter change falls through to teardown. Window/top-N
   are fixed defaults today but are folded into the signature so the gate stays
   correct if either becomes configurable.

2. **Final flush.** `SessionAggregator.Run` now performs a graceful final
   `flushAndLog` on `ctx.Done()` before returning. A genuine
   replace/disable/shutdown cancels the retiring generation's context, so its
   window is emitted as its own (partial) report and the new generation starts
   from an empty window — **no double count**. `flushAndLog` suppresses an
   all-empty report and `topAndReset` drains the window, so a ticker flush
   immediately followed by teardown neither double-counts nor emits an empty
   line (**no-double/empty-flush guard**).

The two mechanisms compose cleanly with `#4964`: the single stable callback and
atomic-pointer swap are unchanged; the gate adds an early return before teardown
and the flush is emitted by the retiring `Run`.

## Tests (fail-on-revert, `-race`)

- `pkg/daemon` **TestApplyAggregatorEqualityGateKeepsLiveAggregator** — an
  unchanged re-apply keeps the same aggregator instance and preserves the
  pending window. **RED** when the gate is reverted (cancel+replace-every-call
  publishes a fresh instance / empty window).
- `pkg/daemon` **TestApplyAggregatorConfigChangeFlushesPendingWindow** —
  disabling reporting flushes the pending window through the teardown path.
  **RED** when the final flush is reverted (`ctx.Done` returns without flushing).
- `pkg/logging` **TestAggregatorRunFinalFlushOnCancel** — `Run` emits the pending
  window on ctx cancel with a non-firing ticker. **RED** when the final flush is
  reverted.
- `pkg/logging` **TestAggregatorRunNoEmptyFlushOnCancel** +
  **TestAggregatorFlushAndLogNoDoubleEmit** — empty-window teardown emits
  nothing; a drained window is not re-emitted.

### RED-on-revert (explicitly verified)

| Revert | Test | Result |
|---|---|---|
| gate disabled (`if false && …`) | `TestApplyAggregatorEqualityGateKeepsLiveAggregator` | **RED** (got a replacement) |
| `ctx.Done(): return` (no final flush) | `TestAggregatorRunFinalFlushOnCancel` | **RED** (0 messages) |
| `ctx.Done(): return` (no final flush) | `TestApplyAggregatorConfigChangeFlushesPendingWindow` | **RED** (counters lost, poll timeout) |

Both reverts were applied, the tests confirmed RED, then the fixes were restored.

## Docs

`pkg/logging/README.md` gains a lifecycle bullet describing the equality gate +
final flush alongside the existing `#4964` / flow-trace single-callback notes.

## Validation

- `go build ./...` — exit 0
- `go test -race -count=1 ./pkg/logging/... ./pkg/daemon/...` — ok
- `gofmt -l` — clean on touched files

Closes #5313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
