### PR TITLE
cli: resolve logical unit refs on zones-detail + show-vlans (#5325)

### DIFF
--- a/pkg/cli/cli_show_interfaces_stats.go
+++ b/pkg/cli/cli_show_interfaces_stats.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/vishvananda/netlink"
@@ -47,14 +48,31 @@ func (c *CLI) showVlans() error {
 		return nil
 	}
 
-	// Build zone lookup: interface name → zone name
-	ifZone := make(map[string]string)
+	// Build zone lookup: interface name → zone name.
+	//
+	// #5325: a zone binds a LOGICAL interface such as "ge-0/0/9.0", but the
+	// VLAN-entry loop below keys by the BASE interface name plus the unit
+	// number. Keying ifZone by the raw zone-member string and then querying
+	// it with the bare base name (ifc.Name) missed every unit-qualified
+	// binding, blanking the Zone column for a correctly zoned VLAN unit.
+	// Build ifZone with the SAME canonical "base.unit" key the query uses,
+	// and keep a base-only map for un-unit-qualified bindings (which govern
+	// every unit of the interface). Mirrors the #4908/C175-HC-116 base/unit
+	// resolution in showChassisClusterStatus.
+	ifZone := make(map[string]string)     // "base.unit" -> zone
+	ifZoneBase := make(map[string]string) // "base"      -> zone (all units)
 	for zoneName, zone := range cfg.Security.Zones {
 		if zone == nil { // #3493: tolerant/HA-sync path may carry a nil zone value
 			continue
 		}
 		for _, iface := range zone.Interfaces {
-			ifZone[iface] = zoneName
+			if parts := strings.SplitN(iface, ".", 2); len(parts) == 2 {
+				if u, err := strconv.Atoi(parts[1]); err == nil {
+					ifZone[fmt.Sprintf("%s.%d", parts[0], u)] = zoneName
+					continue
+				}
+			}
+			ifZoneBase[iface] = zoneName
 		}
 	}
 
@@ -70,7 +88,14 @@ func (c *CLI) showVlans() error {
 	for _, ifc := range cfg.Interfaces.Interfaces {
 		for unitNum, unit := range ifc.Units {
 			if unit.VlanID > 0 || ifc.VlanTagging {
-				zone := ifZone[ifc.Name]
+				// #5325: query with the SAME canonical "base.unit" key used
+				// when building ifZone; fall back to a base-only binding
+				// (which governs every unit) so a non-unit-qualified zone
+				// member still resolves.
+				zone := ifZone[fmt.Sprintf("%s.%d", ifc.Name, unitNum)]
+				if zone == "" {
+					zone = ifZoneBase[ifc.Name]
+				}
 				entries = append(entries, vlanEntry{
 					iface:  ifc.Name,
 					unit:   unitNum,

--- a/pkg/cli/cli_show_logical_unit_5325_test.go
+++ b/pkg/cli/cli_show_logical_unit_5325_test.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #5325: two policy-audit CLI surfaces keyed a LOGICAL zone-member name
+// ("ge-0/0/9.50") against the BASE-keyed cfg.Interfaces.Interfaces map (keyed
+// "ge-0/0/9") — a guaranteed miss. `show security zones detail` then rendered a
+// correctly addressed interface with NO Address/DHCP lines (looked
+// unaddressed), and `show vlans` left the Zone column blank for a correctly
+// zoned VLAN unit. Both are fixed by splitting the "<base>.<unit>" reference and
+// resolving the base interface + unit before the lookup, mirroring the
+// #4908/C175-HC-116 repair in showChassisClusterStatus.
+//
+// The fixture binds one LOGICAL member (ge-0/0/9.50 → zone trust) and one
+// BASE-only member (ge-0/0/1 → zone dmz, no unit suffix). The logical member
+// exercises the bug; the base-only member is the no-regression guard.
+func logicalUnitCLIStore(t *testing.T) *CLI {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+interfaces {
+    ge-0/0/9 {
+        unit 50 {
+            vlan-id 50;
+            family inet {
+                address 10.0.9.1/24;
+            }
+        }
+    }
+    ge-0/0/1 {
+        unit 10 {
+            vlan-id 10;
+            family inet {
+                address 10.0.1.1/24;
+            }
+        }
+    }
+}
+security {
+    zones {
+        security-zone trust {
+            interfaces {
+                ge-0/0/9.50;
+            }
+        }
+        security-zone dmz {
+            interfaces {
+                ge-0/0/1;
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return &CLI{store: store} // dp nil: skip counter reads, exercise the display walk
+}
+
+// TestShowSecurityZonesDetailLogicalUnitAddress5325 is the RED-on-revert guard
+// for `show security zones detail`. Filtering to the `trust` zone isolates the
+// logical member ge-0/0/9.50; its configured address must appear. Reverting to
+// the base-keyed `cfg.Interfaces.Interfaces[ifName]` lookup (ifName ==
+// "ge-0/0/9.50") misses the base-keyed map and drops the Address line.
+func TestShowSecurityZonesDetailLogicalUnitAddress5325(t *testing.T) {
+	c := logicalUnitCLIStore(t)
+	out := captureStdout(t, func() {
+		if err := c.showZonesDisplay(c.store.ActiveConfig(), true, "trust"); err != nil {
+			t.Fatalf("showZonesDisplay(detail, trust): %v", err)
+		}
+	})
+	if !strings.Contains(out, "ge-0/0/9.50:") {
+		t.Fatalf("interface detail header for the logical member ge-0/0/9.50 missing:\n%s", out)
+	}
+	if !strings.Contains(out, "Address: 10.0.9.1/24") {
+		t.Fatalf("logical zone member ge-0/0/9.50 address was dropped "+
+			"(#5325 — base-keyed lookup missed the unit-qualified ref):\n%s", out)
+	}
+}
+
+// TestShowSecurityZonesDetailBaseMemberNoRegression5325 proves a BASE-only zone
+// member (no unit suffix) still resolves all its units' addresses — the
+// behavior that already worked must remain byte-identical.
+func TestShowSecurityZonesDetailBaseMemberNoRegression5325(t *testing.T) {
+	c := logicalUnitCLIStore(t)
+	out := captureStdout(t, func() {
+		if err := c.showZonesDisplay(c.store.ActiveConfig(), true, "dmz"); err != nil {
+			t.Fatalf("showZonesDisplay(detail, dmz): %v", err)
+		}
+	})
+	if !strings.Contains(out, "Address: 10.0.1.1/24") {
+		t.Fatalf("base-only zone member ge-0/0/1 address dropped (regression):\n%s", out)
+	}
+}
+
+// TestShowVlansLogicalUnitZoneColumn5325 is the RED-on-revert guard for
+// `show vlans`. The Zone column of the ge-0/0/9 unit-50 VLAN row must name
+// `trust`. Reverting to the raw-member-key build + base-name query
+// (ifZone[ifc.Name]) leaves the Zone column blank for the unit-qualified
+// binding. The base-only member (ge-0/0/1 → dmz) is the no-regression guard.
+func TestShowVlansLogicalUnitZoneColumn5325(t *testing.T) {
+	c := logicalUnitCLIStore(t)
+	out := captureStdout(t, func() {
+		if err := c.showVlans(); err != nil {
+			t.Fatalf("showVlans: %v", err)
+		}
+	})
+
+	logicalLine := findVlanRow(t, out, "ge-0/0/9")
+	if !strings.Contains(logicalLine, "trust") {
+		t.Fatalf("show vlans Zone column blank for the logical unit ge-0/0/9.50 "+
+			"(#5325 — base-name query missed the logical-keyed ifZone):\nrow: %q\nfull:\n%s",
+			logicalLine, out)
+	}
+
+	// No-regression: the base-only member still resolves its zone.
+	baseLine := findVlanRow(t, out, "ge-0/0/1")
+	if !strings.Contains(baseLine, "dmz") {
+		t.Fatalf("show vlans Zone column blank for the base-only member ge-0/0/1 (regression):\nrow: %q\nfull:\n%s",
+			baseLine, out)
+	}
+}
+
+// findVlanRow returns the first `show vlans` output line containing iface.
+func findVlanRow(t *testing.T, out, iface string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, iface) {
+			return line
+		}
+	}
+	t.Fatalf("no show vlans row for %s:\n%s", iface, out)
+	return ""
+}

--- a/pkg/cli/cli_show_security_zones.go
+++ b/pkg/cli/cli_show_security_zones.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -114,17 +115,40 @@ func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone strin
 				fmt.Println("  Interface details:")
 				for _, ifName := range zone.Interfaces {
 					fmt.Printf("    %s:\n", ifName)
-					if ifc, ok := cfg.Interfaces.Interfaces[ifName]; ok {
-						for _, unit := range ifc.Units {
-							for _, addr := range unit.Addresses {
-								fmt.Printf("      Address: %s\n", addr)
-							}
-							if unit.DHCP {
-								fmt.Printf("      DHCPv4: enabled\n")
-							}
-							if unit.DHCPv6 {
-								fmt.Printf("      DHCPv6: enabled\n")
-							}
+					// #5325: a zone binds a LOGICAL interface such as
+					// "ge-0/0/9.0" or "reth0.50", but
+					// cfg.Interfaces.Interfaces is keyed by the BASE name
+					// ("ge-0/0/9" / "reth0"). The prior direct lookup missed
+					// every unit-qualified reference, so a correctly addressed
+					// interface rendered with NO Address/DHCP lines and looked
+					// unaddressed in this policy-audit surface. Split off the
+					// unit suffix, look up the base, and (when a unit was
+					// named) render only that unit's addresses/DHCP. Mirrors the
+					// #4908/C175-HC-116 repair in showChassisClusterStatus.
+					base := ifName
+					wantUnit := -1
+					if parts := strings.SplitN(ifName, ".", 2); len(parts) == 2 {
+						base = parts[0]
+						if u, err := strconv.Atoi(parts[1]); err == nil {
+							wantUnit = u
+						}
+					}
+					ifc, ok := cfg.Interfaces.Interfaces[base]
+					if !ok {
+						continue
+					}
+					for _, unit := range ifc.Units {
+						if wantUnit >= 0 && unit.Number != wantUnit {
+							continue
+						}
+						for _, addr := range unit.Addresses {
+							fmt.Printf("      Address: %s\n", addr)
+						}
+						if unit.DHCP {
+							fmt.Printf("      DHCPv4: enabled\n")
+						}
+						if unit.DHCPv6 {
+							fmt.Printf("      DHCPv6: enabled\n")
 						}
 					}
 				}


### PR DESCRIPTION
## Problem

Two policy-audit CLI surfaces keyed a **LOGICAL** zone-member name (e.g. `ge-0/0/9.50`) directly against `cfg.Interfaces.Interfaces`, which is keyed by the **BASE** interface name (`ge-0/0/9`). The lookup missed every unit-qualified binding, so a correctly zoned/addressed interface looked **UNADDRESSED / UNZONED** in the exact surfaces used for policy audit and incident response.

- **`show security zones detail`** (`showZonesDisplay`, *Interface details*): the direct `cfg.Interfaces.Interfaces[ifName]` lookup with the logical member as the key never hit the base-keyed map, so the per-interface `Address` / `DHCPv4` / `DHCPv6` lines were silently omitted.
- **`show vlans`** (`showVlans`, *Zone* column): `ifZone` was **built** keyed by the raw logical zone-member string but **queried** with the bare base name (`ifZone[ifc.Name]`) — a key-form mismatch — leaving the Zone column blank for a correctly zoned VLAN unit.

Adjacent to #4984 but different surfaces/loci.

## Fix

Resolve the `<base>.<unit>` reference before the lookup, **mirroring the #4908 / C175-HC-116 repair** in `showChassisClusterStatus` (`strings.SplitN(ref, ".", 2)` → base + unit → `cfg.Interfaces.Interfaces[base].Units[unit]`).

- **zones-detail**: split off the unit suffix, look up the base interface, and (when a unit was named) render only that unit's addresses/DHCP. A base member with no unit suffix still renders all units, so the already-correct case stays **byte-identical**.
- **show vlans**: build `ifZone` with the **SAME canonical `base.unit` key** the entry loop queries with, plus a base-only `ifZoneBase` map for un-unit-qualified bindings (which govern every unit). The query uses the `base.unit` key and falls back to the base-only map — so both the logical and the base binding resolve. This is the "consistent keys when building and querying `ifZone`" requirement.

## Tests (pkg/cli, fail-on-revert)

`cli_show_logical_unit_5325_test.go` — fixture binds one logical member (`ge-0/0/9.50` → zone `trust`, addr `10.0.9.1/24`, `vlan-id 50`) and one base-only member (`ge-0/0/1` → zone `dmz`, no unit suffix):

- `show security zones detail` (filtered to `trust`) shows `Address: 10.0.9.1/24` — **RED on revert** to the base-keyed miss (address dropped).
- `show vlans` shows `trust` in the Zone column of the `ge-0/0/9` unit-50 row — **RED on revert** to the base-name query (Zone column blank).
- base-only member `ge-0/0/1` still resolves its address (zones-detail) and its zone `dmz` (show vlans) — **no-regression** guard.

**RED-on-revert confirmed** for both surfaces by temporarily reverting each independently:
- Surface 1 reverted → `TestShowSecurityZonesDetailLogicalUnitAddress5325` FAILs (Address line dropped), base test still passes.
- Surface 2 reverted → `TestShowVlansLogicalUnitZoneColumn5325` FAILs (Zone column blank for `ge-0/0/9.50`, `dmz` still shown for the base member).

## Validation

- `go build ./...` — exit 0
- `go test -count=1 ./pkg/cli/...` — ok
- `gofmt -l` clean on all touched files

## Docs

No CLI doc describes the zone-detail *Interface details* address block or the show-vlans *Zone* column (the sibling #4908 fix carried no doc note either), so no docs change is warranted.

Closes #5325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi