### PR TITLE
grpcapi: bound sessions-top to top-K and surface iterator errors (#5319)

### DIFF
--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -192,7 +192,10 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 
 	case "sessions-top:bytes", "sessions-top:packets":
 		// #1043 Phase 5: case body extracted to server_show_flow.go
-		s.showSessionsTop(cfg, req.Topic, &buf)
+		// #5319: bounded top-K selection; surface iterator errors.
+		if err := s.showSessionsTop(cfg, req.Topic, &buf); err != nil {
+			return nil, err
+		}
 
 	case "flow-traceoptions":
 		// #1043 Phase 5: case body extracted to server_show_flow.go

--- a/pkg/grpcapi/server_show_flow.go
+++ b/pkg/grpcapi/server_show_flow.go
@@ -9,6 +9,7 @@
 package grpcapi
 
 import (
+	"container/heap"
 	"fmt"
 	"net"
 	"sort"
@@ -17,6 +18,8 @@ import (
 	"github.com/psaab/xpf/pkg/appid"
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // showFlowMonitoring renders NetFlow v9 template configuration.
@@ -192,13 +195,68 @@ func (s *Server) showFlowStatistics(buf *strings.Builder) {
 	}
 }
 
+// resolveSessionName is a package-level indirection over
+// appid.ResolveSessionName so the bounded top-K deferral in
+// showSessionsTop (enrich only the <=K survivors, never all N sessions)
+// can be asserted by a counting fake in tests. Production always binds
+// appid.ResolveSessionName.
+var resolveSessionName = appid.ResolveSessionName
+
+// topSessionsK is the fixed row count `show ... sessions-top` renders
+// (Junos-style top-20). Selection is bounded to this many survivors via
+// a min-heap so a busy firewall (up to ~10M sessions) pays O(N log K)
+// comparisons + O(K) enrichment for a read-only status call, instead of
+// O(N log N) sort + O(N) fmt.Sprintf/appid enrichment (#5319).
+const topSessionsK = 20
+
+// topCand carries only the CHEAP raw fields needed to (a) rank a session
+// by the selected metric and (b) enrich the <=K survivors afterwards. No
+// fmt.Sprintf / appid work happens until a candidate is known to be in
+// the top K.
+type topCand struct {
+	metric                               uint64 // fwdBytes+revBytes OR fwdPkts+revPkts
+	isV6                                 bool
+	srcIP, dstIP                         net.IP
+	srcPort, dstPort                     uint16 // network order, as in the key
+	proto                                uint8
+	inZone, outZone                      uint16
+	appID                                uint16
+	fwdPkts, revPkts, fwdBytes, revBytes uint64
+	created                              uint64
+}
+
+// topCandHeap is a MIN-heap on metric: the root is the smallest of the
+// current top-K, so a new candidate displaces it only when strictly
+// larger.
+type topCandHeap []topCand
+
+func (h topCandHeap) Len() int           { return len(h) }
+func (h topCandHeap) Less(i, j int) bool { return h[i].metric < h[j].metric }
+func (h topCandHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h *topCandHeap) Push(x any)        { *h = append(*h, x.(topCand)) }
+func (h *topCandHeap) Pop() any {
+	old := *h
+	n := len(old)
+	it := old[n-1]
+	*h = old[:n-1]
+	return it
+}
+
 // showSessionsTop renders the top-N (default 20) sessions sorted by
 // bytes or packets, walking both v4 and v6 session tables.
 // `topic` is "sessions-top:bytes" or "sessions-top:packets".
-func (s *Server) showSessionsTop(cfg *config.Config, topic string, buf *strings.Builder) {
+//
+// Selection is bounded (#5319): a size-K min-heap keeps only the K
+// highest-metric forward sessions while walking the tables, ranking on
+// the raw byte/packet counter (cheap, comparable) and deferring the
+// fmt.Sprintf + appid.ResolveSessionName enrichment to the <=K
+// survivors. A backend iterator error (e.g. helper restart mid-scan) is
+// surfaced as codes.Internal instead of returning a partial ranking as
+// success (the errors were previously assigned to `_`).
+func (s *Server) showSessionsTop(cfg *config.Config, topic string, buf *strings.Builder) error {
 	if s.dp == nil || !s.dp.IsLoaded() {
 		buf.WriteString("Dataplane not loaded\n")
-		return
+		return nil
 	}
 	sortByBytes := topic == "sessions-top:bytes"
 	sortLabel := "bytes"
@@ -206,12 +264,6 @@ func (s *Server) showSessionsTop(cfg *config.Config, topic string, buf *strings.
 		sortLabel = "packets"
 	}
 
-	type topEntry struct {
-		src, dst, proto, zone, app string
-		fwdPkts, revPkts           uint64
-		fwdBytes, revBytes         uint64
-		age                        int64
-	}
 	now := monotonicSeconds()
 	zoneNames := make(map[uint16]string)
 	var appNames map[uint16]string
@@ -221,93 +273,135 @@ func (s *Server) showSessionsTop(cfg *config.Config, topic string, buf *strings.
 		}
 		appNames = cr.AppNames
 	}
-	var entries []topEntry
 
-	_ = s.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+	h := &topCandHeap{}
+	total := 0
+	// consider offers a candidate to the bounded top-K. It fills the heap
+	// to K, then only displaces the current minimum when the candidate is
+	// strictly larger — so at most K entries are ever retained and no
+	// enrichment happens here.
+	consider := func(c topCand) {
+		total++
+		if h.Len() < topSessionsK {
+			heap.Push(h, c)
+			return
+		}
+		if c.metric > (*h)[0].metric {
+			(*h)[0] = c
+			heap.Fix(h, 0)
+		}
+	}
+
+	if err := s.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
 		if val.IsReverse != 0 {
 			return true
 		}
-		inZ := zoneNames[val.IngressZone]
-		outZ := zoneNames[val.EgressZone]
-		if inZ == "" {
-			inZ = fmt.Sprintf("%d", val.IngressZone)
+		metric := val.FwdBytes + val.RevBytes
+		if !sortByBytes {
+			metric = val.FwdPackets + val.RevPackets
 		}
-		if outZ == "" {
-			outZ = fmt.Sprintf("%d", val.EgressZone)
-		}
-		var age int64
-		if now > val.Created {
-			age = int64(now - val.Created)
-		}
-		entries = append(entries, topEntry{
-			src:      fmt.Sprintf("%s:%d", net.IP(key.SrcIP[:]), ntohs(key.SrcPort)),
-			dst:      fmt.Sprintf("%s:%d", net.IP(key.DstIP[:]), ntohs(key.DstPort)),
-			proto:    protoName(key.Protocol),
-			zone:     inZ + "->" + outZ,
-			app:      appid.ResolveSessionName(appNames, cfg, key.Protocol, ntohs(key.SrcPort), ntohs(key.DstPort), val.AppID),
+		srcIP := make(net.IP, len(key.SrcIP))
+		copy(srcIP, key.SrcIP[:])
+		dstIP := make(net.IP, len(key.DstIP))
+		copy(dstIP, key.DstIP[:])
+		consider(topCand{
+			metric:   metric,
+			srcIP:    srcIP,
+			dstIP:    dstIP,
+			srcPort:  key.SrcPort,
+			dstPort:  key.DstPort,
+			proto:    key.Protocol,
+			inZone:   val.IngressZone,
+			outZone:  val.EgressZone,
+			appID:    val.AppID,
 			fwdPkts:  val.FwdPackets,
 			revPkts:  val.RevPackets,
 			fwdBytes: val.FwdBytes,
 			revBytes: val.RevBytes,
-			age:      age,
+			created:  val.Created,
 		})
 		return true
-	})
+	}); err != nil {
+		return status.Errorf(codes.Internal, "v4 session iteration: %v", err)
+	}
 
-	_ = s.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+	if err := s.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
 		if val.IsReverse != 0 {
 			return true
 		}
-		inZ := zoneNames[val.IngressZone]
-		outZ := zoneNames[val.EgressZone]
-		if inZ == "" {
-			inZ = fmt.Sprintf("%d", val.IngressZone)
+		metric := val.FwdBytes + val.RevBytes
+		if !sortByBytes {
+			metric = val.FwdPackets + val.RevPackets
 		}
-		if outZ == "" {
-			outZ = fmt.Sprintf("%d", val.EgressZone)
-		}
-		var age int64
-		if now > val.Created {
-			age = int64(now - val.Created)
-		}
-		entries = append(entries, topEntry{
-			src:      fmt.Sprintf("[%s]:%d", net.IP(key.SrcIP[:]), ntohs(key.SrcPort)),
-			dst:      fmt.Sprintf("[%s]:%d", net.IP(key.DstIP[:]), ntohs(key.DstPort)),
-			proto:    protoName(key.Protocol),
-			zone:     inZ + "->" + outZ,
-			app:      appid.ResolveSessionName(appNames, cfg, key.Protocol, ntohs(key.SrcPort), ntohs(key.DstPort), val.AppID),
+		srcIP := make(net.IP, len(key.SrcIP))
+		copy(srcIP, key.SrcIP[:])
+		dstIP := make(net.IP, len(key.DstIP))
+		copy(dstIP, key.DstIP[:])
+		consider(topCand{
+			metric:   metric,
+			isV6:     true,
+			srcIP:    srcIP,
+			dstIP:    dstIP,
+			srcPort:  key.SrcPort,
+			dstPort:  key.DstPort,
+			proto:    key.Protocol,
+			inZone:   val.IngressZone,
+			outZone:  val.EgressZone,
+			appID:    val.AppID,
 			fwdPkts:  val.FwdPackets,
 			revPkts:  val.RevPackets,
 			fwdBytes: val.FwdBytes,
 			revBytes: val.RevBytes,
-			age:      age,
+			created:  val.Created,
 		})
 		return true
+	}); err != nil {
+		return status.Errorf(codes.Internal, "v6 session iteration: %v", err)
+	}
+
+	// Order the <=K survivors with the SAME descending comparator the
+	// original full sort used (metric already equals fwd+rev bytes or
+	// fwd+rev packets), then enrich only these rows.
+	survivors := []topCand(*h)
+	sort.Slice(survivors, func(i, j int) bool {
+		return survivors[i].metric > survivors[j].metric
 	})
 
-	if sortByBytes {
-		sort.Slice(entries, func(i, j int) bool {
-			return (entries[i].fwdBytes + entries[i].revBytes) > (entries[j].fwdBytes + entries[j].revBytes)
-		})
-	} else {
-		sort.Slice(entries, func(i, j int) bool {
-			return (entries[i].fwdPkts + entries[i].revPkts) > (entries[j].fwdPkts + entries[j].revPkts)
-		})
+	limit := topSessionsK
+	if limit > len(survivors) {
+		limit = len(survivors)
 	}
-
-	limit := 20
-	if limit > len(entries) {
-		limit = len(entries)
-	}
-	fmt.Fprintf(buf, "Top %d sessions by %s (of %d total):\n", limit, sortLabel, len(entries))
+	fmt.Fprintf(buf, "Top %d sessions by %s (of %d total):\n", limit, sortLabel, total)
 	fmt.Fprintf(buf, "%-5s %-22s %-22s %-5s %-20s %12s %12s %5s %s\n",
 		"#", "Source", "Destination", "Proto", "Zone", "Bytes(f/r)", "Pkts(f/r)", "Age", "App")
 	for i := 0; i < limit; i++ {
-		e := entries[i]
+		c := survivors[i]
+		inZ := zoneNames[c.inZone]
+		outZ := zoneNames[c.outZone]
+		if inZ == "" {
+			inZ = fmt.Sprintf("%d", c.inZone)
+		}
+		if outZ == "" {
+			outZ = fmt.Sprintf("%d", c.outZone)
+		}
+		var src, dst string
+		if c.isV6 {
+			src = fmt.Sprintf("[%s]:%d", c.srcIP, ntohs(c.srcPort))
+			dst = fmt.Sprintf("[%s]:%d", c.dstIP, ntohs(c.dstPort))
+		} else {
+			src = fmt.Sprintf("%s:%d", c.srcIP, ntohs(c.srcPort))
+			dst = fmt.Sprintf("%s:%d", c.dstIP, ntohs(c.dstPort))
+		}
+		var age int64
+		if now > c.created {
+			age = int64(now - c.created)
+		}
+		app := resolveSessionName(appNames, cfg, c.proto, ntohs(c.srcPort), ntohs(c.dstPort), c.appID)
 		fmt.Fprintf(buf, "%-5d %-22s %-22s %-5s %-20s %5d/%-6d %5d/%-6d %5d %s\n",
-			i+1, e.src, e.dst, e.proto, e.zone,
-			e.fwdBytes, e.revBytes, e.fwdPkts, e.revPkts, e.age, e.app)
+			i+1, src, dst, protoName(c.proto), inZ+"->"+outZ,
+			c.fwdBytes, c.revBytes, c.fwdPkts, c.revPkts, age, app)
 	}
+	return nil
 }
 
 // showFlowTraceoptions renders the flow traceoptions log file

--- a/pkg/grpcapi/sessions_top_5319_test.go
+++ b/pkg/grpcapi/sessions_top_5319_test.go
@@ -1,0 +1,256 @@
+// #5319: `show ... sessions-top:{bytes,packets}` must (a) select the top-K
+// (20) sessions with a bounded min-heap over a CHEAP metric and enrich only
+// the <=K survivors — not full-sort + full-enrich all N — and (b) surface a
+// backend iterator error instead of returning a partial ranking as success.
+//
+// FAIL-ON-REVERT:
+//   - TestSessionsTopBoundedSelectionMatchesFullSort pins that the bounded
+//     heap yields the SAME top-20 rows in the SAME order a full sort would.
+//   - TestSessionsTopSurfacesIteratorError pins the error surfacing: restoring
+//     `_ = s.dp.IterateSessions(...)` makes ShowText return a non-error partial
+//     result and the want-Internal assertion goes RED.
+//   - TestSessionsTopEnrichesOnlySurvivors pins the deferral: enriching inside
+//     the iteration loop (the pre-#5319 shape) calls resolveSessionName N times
+//     instead of <=K, turning the count assertion RED.
+package grpcapi
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/psaab/xpf/pkg/appid"
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// topFakeSession is a family-tagged synthetic session with a distinct metric.
+type topFakeSession struct {
+	isV6   bool
+	metric uint64
+	port   uint16
+}
+
+// topSessionsDP feeds a fixed set of forward sessions across the v4 and v6
+// iterators and reports the dataplane as loaded. FwdBytes == FwdPackets ==
+// metric and rev counters are 0, so the bytes and packets sort keys both
+// equal metric — the top-K is uniquely determined by the distinct metrics.
+type topSessionsDP struct {
+	*dataplane.Manager
+	sessions []topFakeSession
+}
+
+func (d *topSessionsDP) IsLoaded() bool { return true }
+
+func (d *topSessionsDP) IterateSessions(cb func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	for i, s := range d.sessions {
+		if s.isV6 {
+			continue
+		}
+		key := dataplane.SessionKey{
+			SrcIP:    [4]byte{10, 0, byte(i >> 8), byte(i)},
+			DstIP:    [4]byte{172, 16, 80, 8},
+			SrcPort:  hostToNetwork16(s.port),
+			DstPort:  hostToNetwork16(443),
+			Protocol: 6,
+		}
+		val := dataplane.SessionValue{
+			FwdBytes:   s.metric,
+			FwdPackets: s.metric,
+		}
+		if !cb(key, val) {
+			return nil
+		}
+	}
+	return nil
+}
+
+func (d *topSessionsDP) IterateSessionsV6(cb func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	for i, s := range d.sessions {
+		if !s.isV6 {
+			continue
+		}
+		key := dataplane.SessionKeyV6{
+			SrcIP:    [16]byte{0x20, 0x01, 0x05, 0x59, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, byte(i >> 8), byte(i)},
+			DstIP:    [16]byte{0x20, 0x01, 0x05, 0x59, 0x85, 0x85, 0, 0x80, 0, 0, 0, 0, 0, 0, 0x02, 0x00},
+			SrcPort:  hostToNetwork16(s.port),
+			DstPort:  hostToNetwork16(443),
+			Protocol: 6,
+		}
+		val := dataplane.SessionValueV6{
+			FwdBytes:   s.metric,
+			FwdPackets: s.metric,
+		}
+		if !cb(key, val) {
+			return nil
+		}
+	}
+	return nil
+}
+
+// buildTopSessions returns 30 sessions (6 v6, 24 v4) with 30 distinct metrics
+// scrambled out of insertion order so the min-heap actually has to reorder,
+// and with high-metric v6 sessions interleaved so the top-20 crosses BOTH
+// families (matching the current cross-family ranking).
+func buildTopSessions() []topFakeSession {
+	const n = 30
+	out := make([]topFakeSession, 0, n)
+	for i := 0; i < n; i++ {
+		// perm is a bijection over [0,n) since gcd(7,30)==1 -> distinct metrics.
+		perm := (i*7 + 11) % n
+		out = append(out, topFakeSession{
+			isV6:   i%5 == 0, // 6 v6 sessions at i = 0,5,10,15,20,25
+			metric: uint64(perm)*1000 + 500,
+			port:   uint16(10000 + i),
+		})
+	}
+	return out
+}
+
+// parseTopMetrics extracts the per-row forward byte/packet counter (== metric)
+// from `sessions-top` output, in row order, plus the "of N total" count.
+func parseTopMetrics(t *testing.T, out string) (metrics []uint64, total int) {
+	t.Helper()
+	seenHeader := false
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "sessions by") {
+			// "Top 20 sessions by bytes (of 30 total):"
+			for _, f := range strings.Fields(line) {
+				if v, err := strconv.Atoi(f); err == nil {
+					total = v // last integer on the line is the total
+				}
+			}
+			continue
+		}
+		if strings.Contains(line, "Source") && strings.Contains(line, "Destination") {
+			seenHeader = true
+			continue
+		}
+		if !seenHeader {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 6 {
+			continue
+		}
+		// field[5] == "fwdBytes/revBytes"
+		fwd := fields[5]
+		if slash := strings.IndexByte(fwd, '/'); slash >= 0 {
+			fwd = fwd[:slash]
+		}
+		v, err := strconv.ParseUint(fwd, 10, 64)
+		if err != nil {
+			continue
+		}
+		metrics = append(metrics, v)
+	}
+	return metrics, total
+}
+
+func TestSessionsTopBoundedSelectionMatchesFullSort(t *testing.T) {
+	sessions := buildTopSessions()
+
+	// Reference: full descending sort by metric, top 20.
+	ref := make([]topFakeSession, len(sessions))
+	copy(ref, sessions)
+	sort.Slice(ref, func(i, j int) bool { return ref[i].metric > ref[j].metric })
+	want := make([]uint64, 0, topSessionsK)
+	for i := 0; i < topSessionsK && i < len(ref); i++ {
+		want = append(want, ref[i].metric)
+	}
+
+	dp := &topSessionsDP{Manager: dataplane.New(), sessions: sessions}
+	s := newViewServer(t, dp)
+
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "sessions-top:bytes"})
+	if err != nil {
+		t.Fatalf("ShowText(sessions-top:bytes) error = %v", err)
+	}
+	got, total := parseTopMetrics(t, resp.GetOutput())
+
+	if total != len(sessions) {
+		t.Errorf("total = %d, want %d", total, len(sessions))
+	}
+	if len(got) != len(want) {
+		t.Fatalf("returned %d rows, want %d\noutput:\n%s", len(got), len(want), resp.GetOutput())
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("row %d metric = %d, want %d (bounded top-K must match full sort)\ngot:  %v\nwant: %v",
+				i, got[i], want[i], got, want)
+		}
+	}
+
+	// Sanity: the top-20 must include at least one v6 session, proving the
+	// ranking is across BOTH families (not v4-only). The v6 metrics are
+	// derived from i in {0,5,10,15,20,25}.
+	v6InTop := false
+	for _, se := range ref[:topSessionsK] {
+		if se.isV6 {
+			v6InTop = true
+			break
+		}
+	}
+	if !v6InTop {
+		t.Fatal("test fixture bug: expected at least one v6 session in the top-20")
+	}
+}
+
+func TestSessionsTopSurfacesIteratorError(t *testing.T) {
+	// v4 iterator error.
+	dpV4 := &viewFaultGRPCDP{
+		Manager: dataplane.New(),
+		iterErr: errors.New("helper restart: session map closed"),
+	}
+	sV4 := newViewServer(t, dpV4)
+	if _, err := sV4.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "sessions-top:bytes"}); err == nil {
+		t.Fatal("ShowText returned nil error on v4 iterator failure; want codes.Internal")
+	} else if status.Code(err) != codes.Internal {
+		t.Fatalf("v4 error code = %v, want Internal; err: %v", status.Code(err), err)
+	}
+
+	// v6 iterator error (v4 clean).
+	dpV6 := &viewFaultGRPCDP{
+		Manager:   dataplane.New(),
+		iterV6Err: errors.New("helper restart: v6 session map closed"),
+	}
+	sV6 := newViewServer(t, dpV6)
+	if _, err := sV6.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "sessions-top:packets"}); err == nil {
+		t.Fatal("ShowText returned nil error on v6 iterator failure; want codes.Internal")
+	} else if status.Code(err) != codes.Internal {
+		t.Fatalf("v6 error code = %v, want Internal; err: %v", status.Code(err), err)
+	}
+}
+
+func TestSessionsTopEnrichesOnlySurvivors(t *testing.T) {
+	sessions := buildTopSessions() // 30 sessions
+
+	var calls int
+	orig := resolveSessionName
+	resolveSessionName = func(appNames map[uint16]string, cfg *config.Config, proto uint8, srcPort, dstPort uint16, appID uint16) string {
+		calls++
+		return appid.ResolveSessionName(appNames, cfg, proto, srcPort, dstPort, appID)
+	}
+	defer func() { resolveSessionName = orig }()
+
+	dp := &topSessionsDP{Manager: dataplane.New(), sessions: sessions}
+	s := newViewServer(t, dp)
+
+	if _, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "sessions-top:bytes"}); err != nil {
+		t.Fatalf("ShowText error = %v", err)
+	}
+
+	// Deferral contract: enrich only the <=K survivors, never all N. If the
+	// enrichment moves back into the iteration loop (pre-#5319), calls == 30.
+	if calls != topSessionsK {
+		t.Fatalf("resolveSessionName called %d times, want %d (enrichment must be deferred to the <=K survivors, not run for all %d sessions)",
+			calls, topSessionsK, len(sessions))
+	}
+}


### PR DESCRIPTION
## Problem

`show ... sessions-top:{bytes,packets}` (the `ShowText` handler
`showSessionsTop` in `pkg/grpcapi/server_show_flow.go`) rendered a fixed
20-row view but did **O(N log N) + O(N)** work over the ENTIRE v4+v6
forward-session table:

- every forward session was `fmt.Sprintf`-enriched (src/dst/zone) **and**
  `appid.ResolveSessionName`-resolved (which scans the configured
  application map on the AppID-disabled fallback path), appended to a
  slice, then a full `sort.Slice` ran before `limit := 20` sliced off the
  top 20.
- On a busy firewall (up to ~10M sessions) this read-only status call
  monopolized CPU and heap.

It also **swallowed iterator errors**: `IterateSessions` /
`IterateSessionsV6` return values were assigned to `_`, so a helper
restart mid-scan silently returned a partial ranking as a *successful*
response. (#4886 explicitly excludes this handler; #3266 is a different,
logging component.)

## Fix

**1. Bounded top-K selection.** A size-K (`K = topSessionsK = 20`)
min-heap (`container/heap`, `topCandHeap`) keyed on the **cheap** raw
metric (`fwdBytes+revBytes` for `:bytes`, `fwdPackets+revPackets` for
`:packets`) retains only the K highest-metric forward sessions while
walking both families in one heap. Each candidate carries only raw fields
— no `fmt.Sprintf`/`appid` work during the walk. After the walk the
`<=K` survivors are sorted descending with the **same comparator** the
original full sort used, and only then enriched. Result is **O(N log K)
comparisons + O(K) enrichment** with **identical output** (same 20 rows,
same order, same fields, same `of N total` count).

**2. Surface iterator errors.** `showSessionsTop` now returns `error`;
iterator errors become `status.Errorf(codes.Internal, ...)` — matching
the `getSessionsLegacy` / `GetSessionSummary` contract (#2469) — instead
of a partial ranking. The `ShowText` dispatch propagates it.

Enrichment is routed through a `resolveSessionName` package indirection
(defaults to `appid.ResolveSessionName`) so the deferral is assertable by
a counting fake; production behavior is unchanged.

## Tests (`pkg/grpcapi/sessions_top_5319_test.go`, fail-on-revert)

- **TestSessionsTopBoundedSelectionMatchesFullSort** — 30 sessions
  (v4+v6) with distinct scrambled metrics; the heap-selected top-20
  equals, in order, the top-20 a full sort produces (self-checked against
  a reference sort). Asserts the top-20 crosses **both** families.
- **TestSessionsTopSurfacesIteratorError** — a v4 and a v6 iterator error
  each make `ShowText` return `codes.Internal`. **RED on revert:**
  restoring `_ = s.dp.IterateSessions(...)` returns a nil error.
- **TestSessionsTopEnrichesOnlySurvivors** — a counting
  `resolveSessionName` fake is called exactly `K = 20` times, not `N =
  30`. **RED on revert:** moving enrichment back into the iteration loop
  calls it per-session.

## Validation

- `GOCACHE=... go build ./...` — exit 0
- `GOCACHE=... go test -count=1 ./pkg/grpcapi/...` — ok
- `gofmt -l` — clean on touched files
- **RED-on-revert confirmed** for both the error-surfacing test (nil
  error when swallowed) and the enrichment-count test (50 vs 20 calls
  when enrichment is moved back into the loop).

## Docs

No dedicated design/operator doc describes the sessions-top algorithm;
`docs/phases.md` only logs the Sprint-18 feature introduction
(historical). Output is unchanged, so no doc update is warranted.

Closes #5319

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi