### PR TITLE
config: make shared-umem Phase 0 audit read non-gating and deterministic (#5300)

### DIFF
--- a/docs/shared-umem-plan.md
+++ b/docs/shared-umem-plan.md
@@ -146,6 +146,27 @@ visible but non-blocking. Operators should not need to keep
 Live runtime capability and post-bind zero-copy validation decide whether a
 group is used.
 
+Because the artifact is audit-only, the config compiler treats
+`system dataplane shared-umem phase0-artifact-file` as follows (#5300):
+
+- The typed config carries only the operator-DECLARED artifact PATH, never the
+  node-local file's parsed contents. The identical committed tree therefore
+  compiles to the identical typed config on any node — a peer or a restarted
+  host that lacks or differs on the file still produces the same
+  same-tree->same-config result, preserving determinism and HA config replay.
+- The audit read is NON-GATING. A missing, unreadable, non-regular, oversized,
+  or malformed artifact becomes a commit WARNING, never a compile error, so a
+  committed config that references a node-local audit JSON always commits.
+- The audit read is NON-BLOCKING and bounded: it stats first and refuses any
+  non-regular file (directory, FIFO, socket, device), refuses an over-cap file
+  by its stat size, opens `O_NONBLOCK` as a TOCTOU backstop, and bounds the read
+  with a limited reader — a FIFO/device/huge/stalled file can never hang or OOM
+  the commit; it is treated as an audit miss (warn, continue).
+
+The audit read runs as a compile tail gate (`sharedUMEMAuditWarnings`), so the
+operator still gets the audit signal at commit/load, while the typed
+`SharedUMEMConfig` stays file-independent.
+
 The Phase 0 artifact must be machine-readable and include:
 
 - kernel release

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -815,11 +816,7 @@ func compileUserspaceDataplane(node *Node, cfg *UserspaceConfig) error {
 				cfg.PollMode = v
 			}
 		case "shared-umem":
-			shared, err := compileSharedUMEMConfig(child)
-			if err != nil {
-				return err
-			}
-			cfg.SharedUMEM = shared
+			cfg.SharedUMEM = compileSharedUMEMConfig(child)
 		case "rss-indirection":
 			// Defaults to enabled; only the string "disable" flips it off.
 			// Anything else (including "enable" and empty) leaves the
@@ -1039,7 +1036,14 @@ func userspaceRetiredKnobWarnings(cfg *Config) []string {
 	return warnings
 }
 
-func compileSharedUMEMConfig(node *Node) (*SharedUMEMConfig, error) {
+// compileSharedUMEMConfig compiles the `system dataplane shared-umem` stanza
+// into typed config. It is intentionally PURE (no file I/O): it records the
+// mode, the participating-interface filter, and the operator-DECLARED
+// phase0-artifact-file PATH only. The artifact's node-local contents are NEVER
+// embedded here — that node-local read happens non-fatally in
+// sharedUMEMAuditWarnings so the same committed tree compiles to the same typed
+// config on any node (#5300 determinism).
+func compileSharedUMEMConfig(node *Node) *SharedUMEMConfig {
 	cfg := &SharedUMEMConfig{}
 	for _, child := range node.Children {
 		switch child.Name() {
@@ -1050,22 +1054,44 @@ func compileSharedUMEMConfig(node *Node) (*SharedUMEMConfig, error) {
 				cfg.Interfaces = append(cfg.Interfaces, LinuxIfName(v))
 			}
 		case "phase0-artifact-file", "artifact-file":
-			path := nodeVal(child)
-			if path == "" {
-				continue
+			if path := nodeVal(child); path != "" {
+				cfg.Phase0ArtifactFile = path
 			}
-			artifact, err := readSharedUMEMPhase0Artifact(path)
-			if err != nil {
-				return nil, err
-			}
-			cfg.Phase0Artifact = artifact
 		}
 	}
-	return cfg, nil
+	return cfg
 }
 
-func readSharedUMEMPhase0Artifact(path string) (map[string]interface{}, error) {
-	file, err := os.Open(path)
+// readSharedUMEMPhase0ArtifactForAudit reads and validates the operator-declared
+// Phase 0 audit artifact for the AUDIT WARNING path only (#5300). It is
+// non-blocking and bounded so it can never hang or OOM a commit:
+//   - it stats first and refuses any non-regular file (directory, FIFO, socket,
+//     device) — an os.Open on a FIFO/device can block indefinitely;
+//   - it refuses an over-cap file by its stat size before opening;
+//   - it opens O_RDONLY|O_NONBLOCK (a no-op on a regular file) so a stat->open
+//     TOCTOU swap to a FIFO/device still cannot block; and
+//   - it bounds the read with a LimitReader.
+//
+// The returned artifact is used ONLY to derive an operator-visible audit
+// warning; it is never stored in the typed config, so it cannot affect
+// same-tree->same-config determinism. Every error return here is non-fatal at
+// the call site (sharedUMEMAuditWarnings turns it into a warning, not a compile
+// error).
+func readSharedUMEMPhase0ArtifactForAudit(path string) (map[string]interface{}, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("read shared-umem artifact %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("read shared-umem artifact %s: not a regular file (mode %s)", path, info.Mode().Type())
+	}
+	if info.Size() > sharedUMEMPhase0ArtifactMaxBytes {
+		return nil, fmt.Errorf("read shared-umem artifact %s: exceeds %d bytes", path, sharedUMEMPhase0ArtifactMaxBytes)
+	}
+
+	// O_NONBLOCK guards a stat->open TOCTOU swap to a FIFO/device; on a regular
+	// file it has no effect.
+	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
 	if err != nil {
 		return nil, fmt.Errorf("read shared-umem artifact %s: %w", path, err)
 	}
@@ -1090,6 +1116,43 @@ func readSharedUMEMPhase0Artifact(path string) (map[string]interface{}, error) {
 		return nil, fmt.Errorf("decode shared-umem artifact %s: %w", path, err)
 	}
 	return artifact, nil
+}
+
+// sharedUMEMAuditWarnings performs the NON-BLOCKING, NON-GATING Phase 0 audit
+// read for the operator-declared shared-umem artifact (#5300). Per
+// docs/shared-umem-plan.md ("Phase 0: Repro and Audit Evidence") the artifact
+// is audit evidence only: it does not gate runtime shared-UMEM selection, so a
+// read failure must never fail the compile and must never change the typed
+// config. Running it as a tail gate keeps the operator audit signal at commit /
+// load while keeping the read off the typed-config path:
+//
+//   - unavailable / unreadable / non-regular / oversized / malformed -> one
+//     commit WARNING (visible but non-blocking); the commit still succeeds.
+//   - a machine-readable artifact whose "passed" field is explicitly false ->
+//     a WARNING surfacing that recorded result.
+//
+// Because it only appends to cfg.Warnings (a host-local diagnostic) and never
+// touches cfg.System.UserspaceDataplane.SharedUMEM, the same committed tree
+// still compiles to the identical typed config on a peer / after restart.
+func sharedUMEMAuditWarnings(cfg *Config) []string {
+	if cfg == nil || cfg.System.UserspaceDataplane == nil ||
+		cfg.System.UserspaceDataplane.SharedUMEM == nil {
+		return nil
+	}
+	path := cfg.System.UserspaceDataplane.SharedUMEM.Phase0ArtifactFile
+	if path == "" {
+		return nil
+	}
+	artifact, err := readSharedUMEMPhase0ArtifactForAudit(path)
+	if err != nil {
+		return []string{fmt.Sprintf(
+			"system dataplane shared-umem phase0-artifact-file %s: audit artifact unavailable (%v); non-blocking, does not gate the commit or change the compiled config", path, err)}
+	}
+	if passed, ok := artifact["passed"].(bool); ok && !passed {
+		return []string{fmt.Sprintf(
+			"system dataplane shared-umem phase0-artifact-file %s: audit artifact records passed=false; shared-UMEM selection is decided at runtime by live bind validation, not this artifact", path)}
+	}
+	return nil
 }
 
 func normalizeSharedUMEMArtifactInterfaces(artifact map[string]interface{}) error {

--- a/pkg/config/compiler_tailgates.go
+++ b/pkg/config/compiler_tailgates.go
@@ -187,5 +187,15 @@ func runTailGates(cfg *Config, opts compileOpts) error {
 	// advisory instead of silently doing nothing.
 	cfg.Warnings = append(cfg.Warnings, sshHardeningAdvisoryWarnings(cfg)...)
 
+	// #5300: the shared-umem Phase 0 audit artifact is audit evidence only
+	// (docs/shared-umem-plan.md) — it does NOT gate runtime shared-UMEM
+	// selection. The read is non-blocking (stat-first, refuses non-regular
+	// files, bounded) and NON-GATING: a missing / unreadable / malformed
+	// artifact on a peer or after a restart becomes a commit WARNING, never a
+	// compile error, and its content never enters the typed config, so the same
+	// committed tree compiles to the identical typed config on every node. It
+	// runs last because it is a pure advisory read that depends on no other gate.
+	cfg.Warnings = append(cfg.Warnings, sharedUMEMAuditWarnings(cfg)...)
+
 	return nil
 }

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -3461,33 +3461,58 @@ func TestUserspaceDataplaneSharedUMEMConfig(t *testing.T) {
 	if got := strings.Join(dp.SharedUMEM.Interfaces, ","); got != "ge-0-0-1,ge-0-0-2" {
 		t.Fatalf("SharedUMEM.Interfaces = %q", got)
 	}
-	if passed, ok := dp.SharedUMEM.Phase0Artifact["passed"].(bool); !ok || !passed {
-		t.Fatalf("SharedUMEM.Phase0Artifact[passed] = %#v", dp.SharedUMEM.Phase0Artifact["passed"])
+	// #5300: the typed config carries only the operator-DECLARED path, never the
+	// node-local file's parsed content (the determinism decouple). The compile
+	// must also produce no audit warning for a well-formed, passed=true artifact.
+	if dp.SharedUMEM.Phase0ArtifactFile != artifact {
+		t.Fatalf("SharedUMEM.Phase0ArtifactFile = %q, want %q", dp.SharedUMEM.Phase0ArtifactFile, artifact)
 	}
-	if got := strings.Join(sharedUMEMArtifactStringArray(t, dp.SharedUMEM.Phase0Artifact, "selected_interfaces"), ","); got != "ge-0-0-1,ge-0-0-2" {
-		t.Fatalf("SharedUMEM.Phase0Artifact[selected_interfaces] = %q", got)
+	if hasWarningContaining(cfg.Warnings, "shared-umem phase0-artifact-file") {
+		t.Fatalf("well-formed passed=true artifact must not warn, got %#v", cfg.Warnings)
 	}
-	mtu, ok := dp.SharedUMEM.Phase0Artifact["mtu"].(map[string]interface{})
+	// The audit read (warning path) still parses + Linux-normalizes the file so
+	// the operator audit signal keeps its value; assert that content here.
+	parsed, err := readSharedUMEMPhase0ArtifactForAudit(artifact)
+	if err != nil {
+		t.Fatalf("readSharedUMEMPhase0ArtifactForAudit: %v", err)
+	}
+	if passed, ok := parsed["passed"].(bool); !ok || !passed {
+		t.Fatalf("audit artifact[passed] = %#v", parsed["passed"])
+	}
+	if got := strings.Join(sharedUMEMArtifactStringArray(t, parsed, "selected_interfaces"), ","); got != "ge-0-0-1,ge-0-0-2" {
+		t.Fatalf("audit artifact[selected_interfaces] = %q", got)
+	}
+	mtu, ok := parsed["mtu"].(map[string]interface{})
 	if !ok {
-		t.Fatalf("SharedUMEM.Phase0Artifact[mtu] = %#v", dp.SharedUMEM.Phase0Artifact["mtu"])
+		t.Fatalf("audit artifact[mtu] = %#v", parsed["mtu"])
 	}
 	if _, ok := mtu["ge-0-0-1"]; !ok {
-		t.Fatalf("SharedUMEM.Phase0Artifact[mtu] was not Linux-name normalized: %#v", mtu)
+		t.Fatalf("audit artifact[mtu] was not Linux-name normalized: %#v", mtu)
 	}
-	driverName, ok := dp.SharedUMEM.Phase0Artifact["driver_name"].(map[string]interface{})
+	driverName, ok := parsed["driver_name"].(map[string]interface{})
 	if !ok {
-		t.Fatalf("SharedUMEM.Phase0Artifact[driver_name] = %#v", dp.SharedUMEM.Phase0Artifact["driver_name"])
+		t.Fatalf("audit artifact[driver_name] = %#v", parsed["driver_name"])
 	}
 	if _, ok := driverName["ge-0-0-1"]; !ok {
-		t.Fatalf("SharedUMEM.Phase0Artifact[driver_name] was not Linux-name normalized: %#v", driverName)
+		t.Fatalf("audit artifact[driver_name] was not Linux-name normalized: %#v", driverName)
 	}
 }
 
-func TestUserspaceDataplaneSharedUMEMRejectsNullArtifact(t *testing.T) {
+// TestUserspaceDataplaneSharedUMEMNullArtifactIsNonGating proves a malformed
+// (here: JSON-null) audit artifact is NON-GATING (#5300): the audit-read helper
+// still rejects it, but the commit must SUCCEED with the failure surfaced as a
+// warning rather than propagated as a compile error.
+func TestUserspaceDataplaneSharedUMEMNullArtifactIsNonGating(t *testing.T) {
 	artifact := t.TempDir() + "/phase0.json"
 	if err := os.WriteFile(artifact, []byte(`null`), 0644); err != nil {
 		t.Fatal(err)
 	}
+	// The audit-read helper still rejects a JSON-null top-level value...
+	if _, err := readSharedUMEMPhase0ArtifactForAudit(artifact); err == nil ||
+		!strings.Contains(err.Error(), "top-level value must be a JSON object") {
+		t.Fatalf("readSharedUMEMPhase0ArtifactForAudit error = %v, want null rejection", err)
+	}
+	// ...but a malformed artifact must NOT gate the commit.
 	lines := []string{
 		"set system dataplane-type userspace",
 		"set system dataplane shared-umem mode cross-nic",
@@ -3504,9 +3529,18 @@ func TestUserspaceDataplaneSharedUMEMRejectsNullArtifact(t *testing.T) {
 			t.Fatalf("SetPath(%v): %v", path, err)
 		}
 	}
-	_, err := CompileConfig(tree)
-	if err == nil || !strings.Contains(err.Error(), "top-level value must be a JSON object") {
-		t.Fatalf("CompileConfig error = %v, want null artifact rejection", err)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig with malformed audit artifact must succeed (non-gating), got %v", err)
+	}
+	if cfg.System.UserspaceDataplane == nil || cfg.System.UserspaceDataplane.SharedUMEM == nil {
+		t.Fatal("SharedUMEM config not compiled")
+	}
+	if cfg.System.UserspaceDataplane.SharedUMEM.Phase0ArtifactFile != artifact {
+		t.Fatalf("Phase0ArtifactFile = %q, want %q", cfg.System.UserspaceDataplane.SharedUMEM.Phase0ArtifactFile, artifact)
+	}
+	if !hasWarningContaining(cfg.Warnings, "audit artifact unavailable") {
+		t.Fatalf("expected audit-unavailable warning, got %#v", cfg.Warnings)
 	}
 }
 
@@ -3522,9 +3556,9 @@ func TestUserspaceDataplaneSharedUMEMRejectsOversizedArtifact(t *testing.T) {
 	if err := file.Close(); err != nil {
 		t.Fatal(err)
 	}
-	_, err = readSharedUMEMPhase0Artifact(artifact)
+	_, err = readSharedUMEMPhase0ArtifactForAudit(artifact)
 	if err == nil || !strings.Contains(err.Error(), "exceeds") {
-		t.Fatalf("readSharedUMEMPhase0Artifact error = %v, want size rejection", err)
+		t.Fatalf("readSharedUMEMPhase0ArtifactForAudit error = %v, want size rejection", err)
 	}
 }
 
@@ -3533,9 +3567,9 @@ func TestUserspaceDataplaneSharedUMEMRejectsArtifactKeyCollision(t *testing.T) {
 	if err := os.WriteFile(artifact, []byte(`{"passed":true,"driver_name":{"ge-0/0/1":"mlx5_core","ge-0-0-1":"mlx5_core"}}`), 0644); err != nil {
 		t.Fatal(err)
 	}
-	_, err := readSharedUMEMPhase0Artifact(artifact)
+	_, err := readSharedUMEMPhase0ArtifactForAudit(artifact)
 	if err == nil || !strings.Contains(err.Error(), "duplicate driver_name key after Linux interface-name normalization: ge-0-0-1") {
-		t.Fatalf("readSharedUMEMPhase0Artifact error = %v, want normalized-key collision", err)
+		t.Fatalf("readSharedUMEMPhase0ArtifactForAudit error = %v, want normalized-key collision", err)
 	}
 }
 
@@ -3544,9 +3578,9 @@ func TestUserspaceDataplaneSharedUMEMRejectsArtifactArrayCollision(t *testing.T)
 	if err := os.WriteFile(artifact, []byte(`{"passed":true,"selected_interfaces":["ge-0/0/1","ge-0-0-1"]}`), 0644); err != nil {
 		t.Fatal(err)
 	}
-	_, err := readSharedUMEMPhase0Artifact(artifact)
+	_, err := readSharedUMEMPhase0ArtifactForAudit(artifact)
 	if err == nil || !strings.Contains(err.Error(), "duplicate selected_interfaces entry after Linux interface-name normalization: ge-0-0-1") {
-		t.Fatalf("readSharedUMEMPhase0Artifact error = %v, want normalized-array collision", err)
+		t.Fatalf("readSharedUMEMPhase0ArtifactForAudit error = %v, want normalized-array collision", err)
 	}
 }
 

--- a/pkg/config/shared_umem_audit_test.go
+++ b/pkg/config/shared_umem_audit_test.go
@@ -1,0 +1,185 @@
+package config
+
+// #5300: the `system dataplane shared-umem phase0-artifact-file` audit read
+// must be NON-GATING (a read failure never fails the commit), DETERMINISTIC
+// (the node-local file's presence/content never changes the typed config so a
+// peer / restart host compiles the identical config), and NON-BLOCKING /
+// bounded (a non-regular file such as a directory or FIFO is skipped, never
+// opened+read, so it cannot hang the commit).
+//
+// These tests use the ParseSetCommand + tree.SetPath loop (never NewParser for
+// set syntax, per CLAUDE.md).
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// hasWarningContaining is defined in vrrp_track_test.go (same package).
+
+// buildSharedUMEMTree builds a userspace + cross-nic shared-umem tree that
+// references artifactPath, via the flat-set ParseSetCommand + SetPath loop.
+func buildSharedUMEMTree(t *testing.T, artifactPath string) *ConfigTree {
+	t.Helper()
+	lines := []string{
+		"set system dataplane-type userspace",
+		"set system dataplane shared-umem mode cross-nic",
+		"set system dataplane shared-umem interface ge-0/0/1",
+		"set system dataplane shared-umem interface ge-0/0/2",
+		"set system dataplane shared-umem phase0-artifact-file " + artifactPath,
+	}
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%v): %v", path, err)
+		}
+	}
+	return tree
+}
+
+// compileWithinTimeout compiles tree in a goroutine and fails the test if the
+// compile does not return within d. This is the guard that makes the
+// non-blocking assertion a clean FAIL (not a hung suite) on a regression to the
+// old blocking os.Open of a FIFO/device.
+func compileWithinTimeout(t *testing.T, tree *ConfigTree, d time.Duration) (*Config, error) {
+	t.Helper()
+	type result struct {
+		cfg *Config
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		cfg, err := CompileConfig(tree)
+		ch <- result{cfg, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.cfg, r.err
+	case <-time.After(d):
+		t.Fatalf("CompileConfig did not return within %s — a blocking audit read hung the commit", d)
+		return nil, nil // unreachable
+	}
+}
+
+// TestSharedUMEMAuditMissingFileIsNonGating: a committed config that references
+// an audit file which does NOT exist on this node must still COMPILE. RED on a
+// revert to the blocking/gating read (which returns the os.Open error directly).
+func TestSharedUMEMAuditMissingFileIsNonGating(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.json")
+	tree := buildSharedUMEMTree(t, missing)
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig with a missing audit file must succeed (non-gating), got %v", err)
+	}
+	dp := cfg.System.UserspaceDataplane
+	if dp == nil || dp.SharedUMEM == nil {
+		t.Fatal("SharedUMEM config not compiled")
+	}
+	if dp.SharedUMEM.Mode != "cross-nic" {
+		t.Fatalf("SharedUMEM.Mode = %q, want cross-nic", dp.SharedUMEM.Mode)
+	}
+	if dp.SharedUMEM.Phase0ArtifactFile != missing {
+		t.Fatalf("Phase0ArtifactFile = %q, want %q", dp.SharedUMEM.Phase0ArtifactFile, missing)
+	}
+	if !hasWarningContaining(cfg.Warnings, "audit artifact unavailable") {
+		t.Fatalf("expected non-blocking audit-unavailable warning, got %#v", cfg.Warnings)
+	}
+}
+
+// TestSharedUMEMAuditDeterministic: the SAME committed tree must produce the
+// IDENTICAL typed SharedUMEM config whether the node-local audit file is present
+// (with content A), present with different content (B), or absent. RED on a
+// revert that embeds the parsed file content into the typed config (present vs
+// absent then differ) or that gates the compile on a missing file.
+func TestSharedUMEMAuditDeterministic(t *testing.T) {
+	// Same declared path string across all three compiles.
+	artifact := filepath.Join(t.TempDir(), "phase0.json")
+
+	compile := func() *SharedUMEMConfig {
+		t.Helper()
+		cfg, err := CompileConfig(buildSharedUMEMTree(t, artifact))
+		if err != nil {
+			t.Fatalf("CompileConfig: %v", err)
+		}
+		if cfg.System.UserspaceDataplane == nil || cfg.System.UserspaceDataplane.SharedUMEM == nil {
+			t.Fatal("SharedUMEM config not compiled")
+		}
+		return cfg.System.UserspaceDataplane.SharedUMEM
+	}
+
+	// (A) present, one content.
+	if err := os.WriteFile(artifact, []byte(`{"passed":true,"kernel_release":"kA","selected_interfaces":["ge-0/0/1","ge-0/0/2"]}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	present := compile()
+
+	// (B) present, DIFFERENT content.
+	if err := os.WriteFile(artifact, []byte(`{"passed":false,"kernel_release":"kB-totally-different","selected_interfaces":["ge-9/9/9"]}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	differentContent := compile()
+
+	// (C) absent.
+	if err := os.Remove(artifact); err != nil {
+		t.Fatal(err)
+	}
+	absent := compile()
+
+	if !reflect.DeepEqual(present, differentContent) {
+		t.Fatalf("typed SharedUMEM differs with file content:\n present=%#v\n different=%#v", present, differentContent)
+	}
+	if !reflect.DeepEqual(present, absent) {
+		t.Fatalf("typed SharedUMEM differs with file presence:\n present=%#v\n absent=%#v", present, absent)
+	}
+	// Sanity: the invariant we assert is that only the DECLARED path is carried.
+	if present.Phase0ArtifactFile != artifact {
+		t.Fatalf("Phase0ArtifactFile = %q, want %q", present.Phase0ArtifactFile, artifact)
+	}
+}
+
+// TestSharedUMEMAuditNonRegularDirectoryIsNonBlocking: a directory path is a
+// non-regular file; the audit read must skip it (stat-first) rather than open
+// it, so the compile succeeds quickly with a warning. Bounded by a timeout so a
+// regression cannot hang the suite.
+func TestSharedUMEMAuditNonRegularDirectoryIsNonBlocking(t *testing.T) {
+	dir := t.TempDir() // a directory is not a regular file
+	tree := buildSharedUMEMTree(t, dir)
+
+	cfg, err := compileWithinTimeout(t, tree, 10*time.Second)
+	if err != nil {
+		t.Fatalf("CompileConfig with a directory audit path must succeed (non-gating), got %v", err)
+	}
+	if !hasWarningContaining(cfg.Warnings, "not a regular file") {
+		t.Fatalf("expected non-regular-file audit warning, got %#v", cfg.Warnings)
+	}
+}
+
+// TestSharedUMEMAuditFIFOIsNonBlocking: a FIFO with no writer would block an
+// os.Open(O_RDONLY) indefinitely. The stat-first non-regular skip (plus the
+// O_NONBLOCK backstop) must make the compile return promptly. RED on a revert
+// to the old blocking open: the compile goroutine blocks forever and the
+// timeout guard fails the test.
+func TestSharedUMEMAuditFIFOIsNonBlocking(t *testing.T) {
+	fifo := filepath.Join(t.TempDir(), "phase0.fifo")
+	if err := syscall.Mkfifo(fifo, 0644); err != nil {
+		t.Skipf("mkfifo unsupported here: %v", err)
+	}
+	tree := buildSharedUMEMTree(t, fifo)
+
+	cfg, err := compileWithinTimeout(t, tree, 10*time.Second)
+	if err != nil {
+		t.Fatalf("CompileConfig with a FIFO audit path must succeed (non-gating), got %v", err)
+	}
+	if !hasWarningContaining(cfg.Warnings, "not a regular file") {
+		t.Fatalf("expected non-regular-file audit warning for a FIFO, got %#v", cfg.Warnings)
+	}
+}

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -153,10 +153,22 @@ type UserspaceConfig struct {
 // opportunistic cross-NIC shared UMEM and fall back per binding when the live
 // device/kernel path cannot support it. Phase 0 artifacts are audit evidence:
 // the helper logs mismatches but does not gate runtime selection on them.
+//
+// Phase0ArtifactFile is the operator-DECLARED path to the machine-readable
+// Phase 0 audit artifact (#5300). It intentionally carries only the declared
+// path, NEVER the node-local file's parsed contents: the artifact is audit
+// evidence only (docs/shared-umem-plan.md "Phase 0"), does not gate runtime
+// shared-UMEM selection, and MUST NOT make the compiled typed config depend on
+// a node-local file — otherwise the identical committed tree would compile to a
+// DIFFERENT typed config on a peer / after restart when the file is absent or
+// differs, breaking same-tree->same-config determinism and HA replay. The audit
+// read itself is performed non-fatally by sharedUMEMAuditWarnings: a missing /
+// unreadable / non-regular / oversized / malformed artifact becomes a commit
+// WARNING, never a compile error, and never changes this typed config.
 type SharedUMEMConfig struct {
-	Mode           string                 `json:"mode,omitempty"`
-	Interfaces     []string               `json:"interfaces,omitempty"`
-	Phase0Artifact map[string]interface{} `json:"phase0_artifact,omitempty"`
+	Mode               string   `json:"mode,omitempty"`
+	Interfaces         []string `json:"interfaces,omitempty"`
+	Phase0ArtifactFile string   `json:"phase0_artifact_file,omitempty"`
 }
 
 // RootAuthConfig holds root-authentication settings.


### PR DESCRIPTION
## Problem (#5300)

The shared-umem `phase0-artifact-file` audit artifact is documented as
**audit-only** evidence (`docs/shared-umem-plan.md`, "Phase 0"): it does **not**
gate runtime shared-UMEM selection, and an audit failure must be *"visible but
non-blocking"*. The config compiler (`pkg/config/compiler_system.go`) violated
that contract in three ways:

1. **Gating.** `compileSharedUMEMConfig` read the configured host path and
   returned any read/parse error **directly**, so the error propagated out of
   system compilation and **failed the commit**. A committed config referencing
   a node-local audit JSON then refuses to compile on any peer/restart host that
   lacks (or differs on) that file.
2. **Non-determinism.** The parsed file **content** was embedded into the typed
   config (`SharedUMEMConfig.Phase0Artifact`). The same committed tree compiled
   to a **different** typed config depending on the node-local file's
   presence/content — breaking the same-tree→same-config invariant and HA config
   replay.
3. **Blocking.** The read used a plain `os.Open` with no stat-first guard, so a
   FIFO/device at the configured path could **hang** the commit indefinitely.
   (Master already bounded the read *size* with a `LimitReader`, but the
   open-side blocking, the gating, and the determinism break remained.)

## Fix (per `docs/shared-umem-plan.md`)

- **Determinism decouple.** `SharedUMEMConfig` now carries only the
  operator-**declared** path (`Phase0ArtifactFile string`), never the file
  content. `compileSharedUMEMConfig` is pure (no file I/O), so the typed config
  is identical on every node regardless of the local file.
- **Non-gating.** The audit read moves to a compile tail gate
  (`sharedUMEMAuditWarnings`, registered last in `runTailGates`). A missing /
  unreadable / non-regular / oversized / malformed artifact becomes a commit
  **warning**, never a compile error; a `passed=false` artifact surfaces a
  mismatch warning. The operator still gets the audit signal at commit/load; the
  commit always succeeds. Content feeds only the warning, never the typed config.
- **Non-blocking / bounded.** `readSharedUMEMPhase0ArtifactForAudit` stats first
  and refuses any non-regular file (directory, FIFO, socket, device), refuses an
  over-cap file by its stat size before opening, opens `O_RDONLY|O_NONBLOCK` as a
  stat→open TOCTOU backstop, and bounds the read with a `LimitReader`. A
  FIFO/device/huge/stalled path is treated as an audit miss (warn, continue),
  never a hang or OOM.

Nothing downstream consumes `SharedUMEMConfig` — the daemon reads other
`UserspaceDataplane` fields, and the `protocol.go` `SharedUMEM*` fields are
helper→control **telemetry** — so dropping the embedded content is safe and does
not change runtime forwarding. The `#4406` golden tailgate-order test is
unaffected (its corpus references no `shared-umem` artifact; the new gate only
fires when a path is declared).

## Tests (`pkg/config`, fail-on-revert)

New `pkg/config/shared_umem_audit_test.go` (flat-set `ParseSetCommand` +
`tree.SetPath`, per CLAUDE.md):

- **missing audit file → compile SUCCEEDS**, typed config well-formed + warning.
- **same tree, file present(A) / present(B, different) / absent → IDENTICAL
  typed `SharedUMEMConfig`** (`reflect.DeepEqual`).
- **directory path** and a **real FIFO** (`syscall.Mkfifo`) → compile returns
  promptly under a **timeout guard**, treated as an audit miss.

Existing oversize/collision unit tests retarget the renamed audit-read helper;
the null-artifact test now asserts **non-gating** (compile succeeds + warning).

### RED-on-revert (verified)

Scratch-reverting both defects (re-embed content + gate the read) turns **all
five** shared-umem audit tests RED, then restored to green:

- `TestSharedUMEMAuditMissingFileIsNonGating` — FAIL (compile errored on the
  gating read)
- `TestSharedUMEMAuditDeterministic` — FAIL (gating on the absent case; content
  embedding diverges present-A vs present-B)
- `TestSharedUMEMAuditNonRegularDirectoryIsNonBlocking` — FAIL
- `TestSharedUMEMAuditFIFOIsNonBlocking` — FAIL
- `TestUserspaceDataplaneSharedUMEMNullArtifactIsNonGating` — FAIL

## Validation

- `go build ./...` → exit 0
- `go test -count=1 ./pkg/config/...` → ok
- `gofmt -l` clean on all touched files

## Docs

`docs/shared-umem-plan.md` "Phase 0" now records the compile-time contract:
declared-path-only typed config, non-gating commit, bounded non-blocking read.

Closes #5300

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
