### PR TITLE
cli: authenticate peer fabric dials with the control-link PSK (#5324)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,10 +148,18 @@ editing cmdtree.
   is configured, every peer-proxied RPC must carry a time-windowed HMAC
   bearer token (`HMAC-SHA256(PSK, domain‖window)`, 30 s window ±1 for skew)
   in the `xpf-fabric-auth` metadata header, verified constant-time; the
-  local node attaches it on `dialPeer` via `fabricAuthCreds`. This closes
-  the gap where any host on the shared control segment could invoke the
-  allowlisted read/monitor/`ClearSessions`/cross-node-failover RPCs with no
-  credential. Dual-accept (mirroring the heartbeat, `fabricAuthDecision`):
+  local node attaches it on `dialPeer` via `fabricAuthCreds`. **Both**
+  fabric dialers attach the token: the daemon's own `Server.dialPeer`
+  (`server_diag.go`) and the in-process operator CLI's peer dialer
+  (`pkg/cli` `dialPeer`, which reaches the peer directly for cluster-wide
+  `show`/`clear`/`request chassis cluster` proxying) — the latter builds
+  the credential from the same live control-link PSK via the shared
+  `grpcapi.NewFabricAuthCreds` helper (#5324). Before #5324 the CLI dialer
+  used insecure creds only, so enabling the fabric PSK silently broke CLI
+  peer observability/role control with `Unauthenticated` once the guard
+  armed. This closes the gap where any host on the shared control segment
+  could invoke the allowlisted
+  read/monitor/`ClearSessions`/cross-node-failover RPCs with no credential. Dual-accept (mirroring the heartbeat, `fabricAuthDecision`):
   a node with no key configured accepts everything; once enforcement is
   armed the peer must keep signing (a tokenless call is then a downgrade
   attack and is rejected `Unauthenticated`); a tokenless call before

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -37,21 +37,21 @@ import (
 
 // CLI is the interactive command-line interface.
 type CLI struct {
-	rl                 *readline.Instance
-	store              *configstore.Store
-	dp                 cliRuntime
-	eventBuf           *logging.EventBuffer
-	eventReader        *logging.EventReader
-	routing            *routing.Manager
-	frr                *frr.Manager
-	ipsec              *ipsec.Manager
-	dhcp               *dhcp.Manager
-	dhcpRelay          *dhcprelay.Manager
-	cluster            *cluster.Manager
-	rpmResultsFn       func() []*rpm.ProbeResult
-	ipmonStatusFn      func() []ipmon.PolicyStatus
-	natPoolAlarmsFn    func() []natpoolalarm.ActiveAlarm
-	feedsFn            func() map[string]feeds.FeedInfo
+	rl              *readline.Instance
+	store           *configstore.Store
+	dp              cliRuntime
+	eventBuf        *logging.EventBuffer
+	eventReader     *logging.EventReader
+	routing         *routing.Manager
+	frr             *frr.Manager
+	ipsec           *ipsec.Manager
+	dhcp            *dhcp.Manager
+	dhcpRelay       *dhcprelay.Manager
+	cluster         *cluster.Manager
+	rpmResultsFn    func() []*rpm.ProbeResult
+	ipmonStatusFn   func() []ipmon.PolicyStatus
+	natPoolAlarmsFn func() []natpoolalarm.ActiveAlarm
+	feedsFn         func() map[string]feeds.FeedInfo
 	// feedOverlayFn returns the live dynamic-address feed-prefix overlay
 	// (#3105): an address-name -> union-of-live-feed-CIDR-strings map, the same
 	// source the REST/gRPC simulators consume (daemon SnapshotForBindings). The
@@ -107,8 +107,16 @@ type CLI struct {
 	commitConfirmedFn func(ctx context.Context, minutes int) (*config.Config, error)
 
 	// Fabric peer dialing for cluster-wide queries (fab0 + optional fab1).
-	fabricPeerAddrFn   func() []string
-	fabricVRFDevice    string
+	fabricPeerAddrFn func() []string
+	fabricVRFDevice  string
+	// fabricAuthKeyFn resolves the #4107 control-link PSK the CLI attaches to
+	// peer fabric dials (dialPeer). Nil in production, where fabricAuthKey()
+	// falls back to the cluster manager's live key; a test seam sets it
+	// directly so tests need not construct a keyed cluster.Manager (#5324).
+	fabricAuthKeyFn func() []byte
+	// fabricPeerPort overrides the peer gRPC port (default 50051 when 0). A
+	// test seam so dialPeer can target an ephemeral loopback fabric server.
+	fabricPeerPort     int
 	peerSystemActionFn func(ctx context.Context, action string) (string, error)
 
 	// Monitor security flow state (per-CLI-session).

--- a/pkg/cli/peer.go
+++ b/pkg/cli/peer.go
@@ -12,12 +12,35 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/psaab/xpf/pkg/grpcapi"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 )
+
+// fabricAuthKey resolves the #4107 control-link PSK the CLI attaches to peer
+// fabric dials. It mirrors grpcapi Server.fabricAuthKey: a test seam wins, then
+// the live cluster-manager key, else nil (unkeyed / standalone -> the dial is
+// tokenless and the peer's dual-accept grace still admits it).
+func (c *CLI) fabricAuthKey() []byte {
+	if c.fabricAuthKeyFn != nil {
+		return c.fabricAuthKeyFn()
+	}
+	if c.cluster != nil {
+		return c.cluster.ControlLinkAuthKey()
+	}
+	return nil
+}
+
+// peerPort returns the peer fabric gRPC port, defaulting to 50051.
+func (c *CLI) peerPort() int {
+	if c.fabricPeerPort != 0 {
+		return c.fabricPeerPort
+	}
+	return 50051
+}
 
 // dialPeer establishes a gRPC connection to the cluster peer, trying fab0
 // then fab1 if dual-fabric is configured. Returns nil if not in cluster mode.
@@ -30,7 +53,18 @@ func (c *CLI) dialPeer() *grpc.ClientConn {
 		return nil
 	}
 
-	dialOpts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	dialOpts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		// #5324: authenticate every RPC we dial on the peer's fabric listener
+		// with the #4107 control-link PSK, mirroring the daemon-side dialer
+		// (grpcapi Server.dialPeer). GetRequestMetadata is read per RPC so the
+		// token rotates with the auth window; an unkeyed cluster resolves an
+		// empty key -> no token -> the peer's dual-accept grace still admits the
+		// call (no unkeyed-cluster regression). Without this credential the peer
+		// rejects the tokenless CLI dial Unauthenticated once the fabric guard
+		// arms, silently breaking CLI peer observability/role control.
+		grpc.WithPerRPCCredentials(grpcapi.NewFabricAuthCreds(c.fabricAuthKey)),
+	}
 	if c.fabricVRFDevice != "" {
 		dialOpts = append(dialOpts, grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 			dialer := &net.Dialer{
@@ -46,8 +80,9 @@ func (c *CLI) dialPeer() *grpc.ClientConn {
 		}))
 	}
 
+	port := c.peerPort()
 	for _, ip := range peerIPs {
-		peerAddr := fmt.Sprintf("%s:50051", ip)
+		peerAddr := fmt.Sprintf("%s:%d", ip, port)
 		conn, err := grpc.NewClient(peerAddr, dialOpts...)
 		if err != nil {
 			continue

--- a/pkg/cli/peer_fabric_auth_5324_test.go
+++ b/pkg/cli/peer_fabric_auth_5324_test.go
@@ -1,0 +1,214 @@
+package cli
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/grpcapi"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// #5324: the CLI's peer fabric dialer (dialPeer) must attach the #4107
+// control-link PSK per-RPC credential so its cross-node fabric RPCs are accepted
+// once the peer's fabric auth guard arms. Before the fix dialPeer built
+// insecure-only dialOpts with NO WithPerRPCCredentials, so a keyed cluster's
+// fabric listener rejected every CLI peer RPC (sessions/clear/chassis-forwarding/
+// target-failover) as Unauthenticated in the secure steady state — silently,
+// because the pre-dial TCP probe still passed.
+//
+// These tests stand up a REAL loopback gRPC fabric server whose interceptor
+// enforces the same token scheme the daemon uses (via the shared
+// grpcapi.NewFabricAuthCreds oracle), then drive an RPC end-to-end through
+// dialPeer. On revert to the insecure-only dialer the keyed case goes RED: the
+// CLI sends no token and the armed server returns Unauthenticated.
+
+// fabricAuthMetadataKeyTest mirrors the unexported grpcapi.fabricAuthMetadataKey.
+// Pinned here (an external package cannot read the unexported constant); the
+// grpcapi.NewFabricAuthCreds oracle below is the source of truth for the token
+// value, so a scheme change surfaces as a mismatch, not a silent pass.
+const fabricAuthMetadataKeyTest = "xpf-fabric-auth"
+
+// fakeFabricServer is a minimal BpfrxService that answers GetStatus so a peer
+// RPC dialed through dialPeer reaches a handler.
+type fakeFabricServer struct {
+	pb.UnimplementedBpfrxServiceServer
+}
+
+func (fakeFabricServer) GetStatus(context.Context, *pb.GetStatusRequest) (*pb.GetStatusResponse, error) {
+	return &pb.GetStatusResponse{}, nil
+}
+
+// fabricEnforcingInterceptor mimics the ARMED fabric auth guard: it rejects any
+// RPC whose xpf-fabric-auth header is absent or does not match the expected
+// current-window token for serverKey. The expected token is computed with the
+// production client-cred code (grpcapi.NewFabricAuthCreds) so the server side of
+// the test cannot drift from the real scheme. On revert of dialPeer the header is
+// absent -> Unauthenticated -> RED. When serverKey is empty the server is
+// unkeyed and admits everything (dual-accept / no-regression path).
+func fabricEnforcingInterceptor(serverKey []byte) grpc.UnaryServerInterceptor {
+	oracle := grpcapi.NewFabricAuthCreds(func() []byte { return serverKey })
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if len(serverKey) == 0 {
+			return handler(ctx, req) // unkeyed: cannot enforce, dual-accept
+		}
+		want, err := oracle.GetRequestMetadata(ctx)
+		if err != nil {
+			return nil, err
+		}
+		var got string
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			if v := md.Get(fabricAuthMetadataKeyTest); len(v) > 0 {
+				got = v[0]
+			}
+		}
+		if got == "" || got != want[fabricAuthMetadataKeyTest] {
+			return nil, status.Error(codes.Unauthenticated, "fabric RPC authentication failed")
+		}
+		return handler(ctx, req)
+	}
+}
+
+// startFakeFabricServer launches a loopback gRPC fabric server with the given
+// enforcing key and returns its port plus a stop func.
+func startFakeFabricServer(t *testing.T, serverKey []byte) (port int, stop func()) {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer(grpc.UnaryInterceptor(fabricEnforcingInterceptor(serverKey)))
+	pb.RegisterBpfrxServiceServer(srv, fakeFabricServer{})
+	go func() { _ = srv.Serve(lis) }()
+	return lis.Addr().(*net.TCPAddr).Port, srv.Stop
+}
+
+// callPeerStatus dials the peer through dialPeer and issues one GetStatus,
+// returning the RPC error (nil on success).
+func callPeerStatus(t *testing.T, c *CLI) error {
+	t.Helper()
+	conn := c.dialPeer()
+	if conn == nil {
+		t.Fatal("dialPeer returned nil (peer unreachable)")
+	}
+	defer conn.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, err := pb.NewBpfrxServiceClient(conn).GetStatus(ctx, &pb.GetStatusRequest{})
+	return err
+}
+
+// TestDialPeerKeyedAttachesCredentialAcceptedByArmedFabric: with a fabric PSK
+// configured, dialPeer attaches the per-RPC credential and a peer RPC against an
+// armed (keyed, enforcing) fabric server SUCCEEDS. RED on revert to the
+// insecure-only dialer: the CLI sends no token and the server returns
+// Unauthenticated.
+func TestDialPeerKeyedAttachesCredentialAcceptedByArmedFabric(t *testing.T) {
+	key := []byte("cli-fabric-control-link-psk")
+	port, stop := startFakeFabricServer(t, key)
+	defer stop()
+
+	c := &CLI{
+		fabricPeerAddrFn: func() []string { return []string{"127.0.0.1"} },
+		fabricPeerPort:   port,
+		fabricAuthKeyFn:  func() []byte { return key },
+	}
+	if err := callPeerStatus(t, c); err != nil {
+		t.Fatalf("keyed peer RPC against armed fabric: expected success, got %v (status=%v)", err, status.Code(err))
+	}
+}
+
+// TestDialPeerInsecureOnlyRejectedByArmedFabric documents the pre-fix behavior:
+// a dialer that omits the credential (fabricAuthKeyFn returns nil so no token is
+// sent, exactly like the reverted insecure-only dialer) is rejected
+// Unauthenticated by the ARMED (keyed) fabric server. This is the failure mode
+// #5324 fixes, and pins that the enforcing server truly rejects a tokenless dial.
+func TestDialPeerInsecureOnlyRejectedByArmedFabric(t *testing.T) {
+	key := []byte("cli-fabric-control-link-psk")
+	port, stop := startFakeFabricServer(t, key)
+	defer stop()
+
+	// Build a dialer that mirrors the reverted (pre-#5324) code: transport creds
+	// only, no WithPerRPCCredentials. Dial the same armed server directly.
+	peerAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	conn, err := grpc.NewClient(peerAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if _, err := pb.NewBpfrxServiceClient(conn).GetStatus(ctx, &pb.GetStatusRequest{}); status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("tokenless dial against armed fabric: expected Unauthenticated, got %v", err)
+	}
+}
+
+// TestDialPeerUnkeyedNoRegression: with NO fabric PSK (unkeyed cluster) dialPeer
+// still works without a credential — the credential self-suppresses (empty key
+// -> no token) and the unkeyed peer admits the tokenless call. No regression to
+// today's unkeyed-cluster peer ops.
+func TestDialPeerUnkeyedNoRegression(t *testing.T) {
+	port, stop := startFakeFabricServer(t, nil) // unkeyed server: no enforcement
+	defer stop()
+
+	c := &CLI{
+		fabricPeerAddrFn: func() []string { return []string{"127.0.0.1"} },
+		fabricPeerPort:   port,
+		// no fabricAuthKeyFn and no cluster -> fabricAuthKey() returns nil
+	}
+	if c.fabricAuthKey() != nil {
+		t.Fatalf("unkeyed CLI: expected nil fabric key, got %q", c.fabricAuthKey())
+	}
+	if err := callPeerStatus(t, c); err != nil {
+		t.Fatalf("unkeyed peer RPC: expected success (no credential), got %v", err)
+	}
+}
+
+// TestDialPeerFabricCredMatchesDaemonScheme: the credential the CLI attaches
+// (from its resolved fabric key) produces the SAME token header the daemon-side
+// dialer (grpcapi.NewFabricAuthCreds over the identical key) produces — so the
+// peer's fabricAuthInterceptor, which verifies against that scheme, accepts it.
+func TestDialPeerFabricCredMatchesDaemonScheme(t *testing.T) {
+	key := []byte("shared-control-link-psk")
+	c := &CLI{fabricAuthKeyFn: func() []byte { return key }}
+
+	if got := c.fabricAuthKey(); string(got) != string(key) {
+		t.Fatalf("fabricAuthKey() = %q, want %q", got, key)
+	}
+
+	cliCreds := grpcapi.NewFabricAuthCreds(c.fabricAuthKey)
+	daemonCreds := grpcapi.NewFabricAuthCreds(func() []byte { return key })
+
+	cliMD, err := cliCreds.GetRequestMetadata(context.Background())
+	if err != nil {
+		t.Fatalf("cli GetRequestMetadata: %v", err)
+	}
+	daemonMD, err := daemonCreds.GetRequestMetadata(context.Background())
+	if err != nil {
+		t.Fatalf("daemon GetRequestMetadata: %v", err)
+	}
+	if cliMD[fabricAuthMetadataKeyTest] == "" {
+		t.Fatal("keyed CLI attached no fabric token")
+	}
+	if cliMD[fabricAuthMetadataKeyTest] != daemonMD[fabricAuthMetadataKeyTest] {
+		t.Fatalf("CLI token %q != daemon-scheme token %q",
+			cliMD[fabricAuthMetadataKeyTest], daemonMD[fabricAuthMetadataKeyTest])
+	}
+
+	// Unkeyed -> no token header (the credential self-suppresses).
+	empty := grpcapi.NewFabricAuthCreds(func() []byte { return nil })
+	md, err := empty.GetRequestMetadata(context.Background())
+	if err != nil {
+		t.Fatalf("unkeyed GetRequestMetadata: %v", err)
+	}
+	if len(md) != 0 {
+		t.Fatalf("unkeyed creds attached a token: %v", md)
+	}
+}

--- a/pkg/grpcapi/fabric_auth.go
+++ b/pkg/grpcapi/fabric_auth.go
@@ -11,6 +11,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
@@ -284,3 +285,20 @@ func (c fabricAuthCreds) GetRequestMetadata(ctx context.Context, uri ...string) 
 }
 
 func (c fabricAuthCreds) RequireTransportSecurity() bool { return false }
+
+// NewFabricAuthCreds returns the client-side per-RPC credential that attaches the
+// #4107 control-link PSK fabric token to every RPC dialed on a peer's fabric
+// listener. It is the shared-creds helper the CLI's peer dialer (pkg/cli
+// dialPeer) uses so its cross-node fabric RPCs carry the SAME time-windowed HMAC
+// token the daemon-side dialer (Server.dialPeer) already sends. Without it, once
+// the fabric auth guard arms (both nodes keyed), the peer's fabricAuthInterceptor
+// rejects the tokenless CLI dial as Unauthenticated (#5324).
+//
+// keyFn is read fresh per RPC so the token rotates with the auth window and picks
+// up a live key change; an empty key yields no token, so a not-yet-keyed / unkeyed
+// node dials tokenless and the peer's dual-accept grace still admits the call (no
+// unkeyed-cluster regression). The credential does not require transport security
+// — it rides the fabric's insecure transport, exactly like the daemon-side dialer.
+func NewFabricAuthCreds(keyFn func() []byte) credentials.PerRPCCredentials {
+	return fabricAuthCreds{keyFn: keyFn}
+}


### PR DESCRIPTION
## Summary

The operator CLI's peer fabric dialer (`pkg/cli` `dialPeer`) built its
dial options with **insecure transport credentials only** and never
attached a per-RPC credential. The cluster peer's fabric gRPC listener
authenticates every proxied RPC with the #4107 control-link PSK
(`fabricAuthUnaryInterceptor`, `enforceArmed`). #4107/#4122 gave the
credential to the **daemon-side** dialer (`grpcapi` `Server.dialPeer` in
`server_diag.go`, via `fabricAuthCreds`) but the **CLI** dialer never got
it.

So enabling the fabric PSK **silently broke** CLI peer
observability/role control: in a keyed HA cluster the fabric guard arms
within ~one heartbeat, and every CLI peer `sessions`/`clear`/
`chassis-forwarding`/`target-failover` dial to `peerIP:50051` then
returned `Unauthenticated` in the secure steady state. The pre-dial TCP
probe still passed, masking the failure. Distinct from #4909 (peer.go
IPv6-bracket).

## Root cause

`dialPeer` in `pkg/cli/peer.go`:

```go
dialOpts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
// ...no WithPerRPCCredentials -> tokenless dial -> Unauthenticated once armed
```

## How the CLI obtains the PSK + attaches the credential

The in-process CLI is constructed with the same `*cluster.Manager` the
daemon uses (`cli.New(..., d.cluster)`), so it reads the **live**
control-link PSK from the identical source the daemon-side dialer reads —
no new secret-delivery channel and no `daemon_run.go` wiring change.

- **`grpcapi.NewFabricAuthCreds(keyFn)`** — new exported shared-creds
  helper wrapping the existing unexported `fabricAuthCreds`. Additive; it
  does **not** touch any server enforcement path. This makes the CLI emit
  the byte-identical time-windowed HMAC token
  (`HMAC-SHA256(PSK, domain‖window)`, `xpf-fabric-auth` header) the
  peer's interceptor already verifies — one source of truth, no
  duplicated security crypto.
- **`dialPeer`** now appends
  `grpc.WithPerRPCCredentials(grpcapi.NewFabricAuthCreds(c.fabricAuthKey))`,
  mirroring `server_diag.go`. The credential is always attached and
  self-suppresses when unkeyed (empty key -> no token), so an **unkeyed
  cluster's peer ops are unchanged** (dual-accept grace). Transport stays
  insecure — the fabric guard is HMAC per-RPC auth, not transport
  security, matching the daemon side.
- **`fabricAuthKey()`** resolves the PSK the same way the daemon does: a
  test seam first, then `c.cluster.ControlLinkAuthKey()`, else nil
  (unkeyed/standalone). Read fresh per RPC so the token rotates with the
  window and picks up a live key change.

Scope is the CLI credential source (`peer.go` + `cli.go`) plus the one
additive `grpcapi` client-helper export; the server enforcement path
(`daemon_run.go`, the interceptors) is untouched.

## Tests (fail-on-revert)

`pkg/cli/peer_fabric_auth_5324_test.go` stands up a **real loopback gRPC
fabric server** whose interceptor enforces the same token scheme (using
`grpcapi.NewFabricAuthCreds` as the token oracle so the test's server
side cannot drift from the real scheme), then drives an RPC end-to-end
through `dialPeer`:

- **keyed cluster** -> `dialPeer` attaches the credential; the peer RPC
  against the armed (enforcing) fabric server **SUCCEEDS**.
- **tokenless dial vs armed server** -> rejected `Unauthenticated`
  (pins the pre-fix failure mode).
- **unkeyed cluster** -> `dialPeer` works with no credential (no
  regression).
- **scheme match** -> the CLI-attached credential emits the
  byte-identical token the daemon-side `NewFabricAuthCreds` emits for the
  same key.

### RED-on-revert (explicit)

Reverting `dialPeer` to the insecure-only dialer makes the keyed case go
RED — verified by hand:

```
--- FAIL: TestDialPeerKeyedAttachesCredentialAcceptedByArmedFabric
    keyed peer RPC against armed fabric: expected success, got rpc error:
    code = Unauthenticated desc = fabric RPC authentication failed (status=Unauthenticated)
```

Restored, all four tests PASS.

## Docs

`docs/architecture.md`'s #4107 fabric-auth section previously noted only
the daemon dialer attaching the token; it now records that **both**
dialers attach it (the CLI via the shared `NewFabricAuthCreds` helper) and
calls out the pre-#5324 insecure-only CLI regression.

## Validation

- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` — exit 0
- `go test -count=1 ./pkg/cli/... ./cmd/cli/...` — ok
- `go test -run FabricAuth ./pkg/grpcapi/` — ok
- `gofmt -l` clean on touched files (also normalized a pre-existing
  whitespace misalignment in the CLI struct block)

Closes #5324

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
