### PR TITLE
dataplane: bound clear-all working set, drop double snapshot (#5304)

### DIFF
--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -139,6 +139,20 @@ plus a cluster smoke before merge.
   policy-scheduler rule slots, and the per-interface networkd configs.
 - Session iteration: `IterateSessions`, `BatchIterateSessions`,
   `IterateSessionsV6`, `BatchIterateSessionsV6`.
+- Full-table clear (`clear security flow session all`): `ClearAllSessions`
+  and `ClearAllSessionsChunked`. The table holds up to ~10M sessions per
+  family, so the clear is both cooperative (yields between batches — #4719)
+  and **bounded** (#5304): it collects at most `sessionClearSnapshotChunk`
+  keys, deletes that chunk (+ its dynamic DNAT entries) via chunked
+  `BPF_MAP_DELETE_BATCH`, then re-scans for the next chunk — peak key-slice
+  memory is O(chunk), not O(table). Deleting every collected key before the
+  next scan makes the loop converge (every key present at start is removed).
+  `ClearAllSessionsChunked` invokes an optional per-chunk callback so the
+  userspace wrapper (`userspace.Manager.ClearAllSessions`) can issue its
+  authoritative Rust-helper delete on each bounded chunk instead of building
+  a second full-table key snapshot of its own — the two coexisting full-table
+  snapshots (wrapper v4+v6 + shim v4+v6 + DNAT lists) were the ~1 GB RSS spike
+  that #5304 removed.
 - Session domain adapters: `SessionStoreOf`, `TelemetryOf`, and
   `NewDataPlaneSessionStore`. The generic `DataPlane` adapter preserves the
   batch-iteration fast path and centralizes cluster/GC companion ownership:

--- a/pkg/dataplane/maps_session.go
+++ b/pkg/dataplane/maps_session.go
@@ -355,67 +355,177 @@ func (m *Manager) SessionCount() (v4, v6 int) {
 // non-hot-path nil check per chunk).
 var sessionClearBatchObserver func(batchKeys int)
 
+// sessionClearSnapshotObserver, when non-nil, is invoked once per collected key
+// CHUNK with the number of keys in that chunk (bounded by
+// sessionClearSnapshotChunk). It is a test-only seam that lets a unit test
+// assert the clear collects keys in bounded chunks instead of snapshotting the
+// entire table into one N-sized slice (#5304). A revert to the collect-all
+// clear stops invoking it, so a bounded-working-set test goes RED. Production
+// leaves it nil.
+var sessionClearSnapshotObserver func(chunkKeys int)
+
+// sessionClearSnapshotChunk bounds the working set of the full-table clear. The
+// session table can hold up to ~10M entries per family; snapshotting every key
+// (v4 + v6) plus the dynamic DNAT key lists into slices before any delete
+// stacks them all in RSS at once — ~1 GB on a max-loaded table, enough for the
+// supported-max recovery command (`clear security flow session all`) to stall
+// or OOM-kill the daemon (#5304). The clear instead collects at most this many
+// keys, deletes that chunk (and its DNAT entries), then re-scans for the next
+// chunk, so peak key-slice memory is O(chunk), not O(table). It is a var (not
+// const) so a test can shrink it to exercise the multi-chunk path with a small
+// table.
+var sessionClearSnapshotChunk = 4096
+
 // ClearAllSessions deletes all IPv4 and IPv6 sessions, plus associated
 // dynamic DNAT table entries for SNAT sessions. Returns (v4_deleted, v6_deleted, err).
-//
-// The full table can hold up to ~10M sessions, so the clear must not
-// monopolize the controller goroutine — a multi-second synchronous stall can
-// starve the HA peer watchdog/heartbeat and trip a spurious failover (#4719).
-// Both phases are therefore cooperative: collection uses the batch-lookup
-// iterators (BatchIterateSessions{,V6}, which yield via runtime.Gosched between
-// batches), and deletion uses chunked BPF_MAP_DELETE_BATCH syscalls that yield
-// between chunks (clearSessionsV4/clearSessionsV6). Semantics are unchanged:
-// every session — both the forward and the reverse conntrack entry — is still
-// removed, plus the dynamic dnat_table entries for SNAT sessions.
 func (m *Manager) ClearAllSessions() (int, int, error) {
-	// IPv4: collect all keys and SNAT entries for DNAT cleanup
-	var v4Keys []SessionKey
-	var snatDNATKeys []DNATKey
-	if err := m.BatchIterateSessions(func(key SessionKey, val SessionValue) bool {
-		v4Keys = append(v4Keys, key)
-		// Track dynamic SNAT sessions for dnat_table cleanup
-		if val.IsReverse == 0 &&
-			val.Flags&SessFlagSNAT != 0 &&
-			val.Flags&SessFlagStaticNAT == 0 {
-			// Must match the write-side key encoding (#2406: host-order port).
-			snatDNATKeys = append(snatDNATKeys, dnatKeyForSessionV4(key, val))
-		}
-		return true
-	}); err != nil {
-		return 0, 0, fmt.Errorf("iterate sessions: %w", err)
-	}
-	v4Deleted := m.clearSessionsV4(v4Keys)
-	for i, dk := range snatDNATKeys {
-		m.DeleteDNATEntry(dk)
-		if (i+1)%sessionDeleteBatchSize == 0 {
-			runtime.Gosched()
-		}
-	}
+	return m.ClearAllSessionsChunked(nil, nil)
+}
 
-	// IPv6: collect all keys and SNAT entries for DNAT cleanup
-	var v6Keys []SessionKeyV6
-	var snatDNATKeysV6 []DNATKeyV6
-	if err := m.BatchIterateSessionsV6(func(key SessionKeyV6, val SessionValueV6) bool {
-		v6Keys = append(v6Keys, key)
-		if val.IsReverse == 0 &&
-			val.Flags&SessFlagSNAT != 0 &&
-			val.Flags&SessFlagStaticNAT == 0 {
-			// Must match the write-side key encoding (#2406: host-order port).
-			snatDNATKeysV6 = append(snatDNATKeysV6, dnatKeyForSessionV6(key, val))
-		}
-		return true
-	}); err != nil {
-		return v4Deleted, 0, fmt.Errorf("iterate sessions_v6: %w", err)
+// ClearAllSessionsChunked is the bounded-memory implementation of
+// ClearAllSessions. onV4Chunk / onV6Chunk, when non-nil, are invoked with each
+// deleted key chunk (bounded by sessionClearSnapshotChunk) so a caller — the
+// userspace wrapper — can issue its authoritative Rust-helper delete per chunk
+// WITHOUT building a second full-table key snapshot of its own (the #5304
+// double snapshot). The slices handed to the callbacks are valid only for the
+// duration of the call; the backing array is reused across chunks.
+//
+// The full table can hold up to ~10M sessions, so the clear must neither
+// monopolize the controller goroutine — a multi-second synchronous stall can
+// starve the HA peer watchdog/heartbeat and trip a spurious failover (#4719) —
+// nor spike RSS by snapshotting the whole table at once (#5304). Collection and
+// deletion are therefore both cooperative AND bounded: collection uses the
+// batch-lookup iterators (BatchIterateSessions{,V6}, which yield via
+// runtime.Gosched between batches) but stops at sessionClearSnapshotChunk keys
+// and re-scans for the remainder, and deletion uses chunked
+// BPF_MAP_DELETE_BATCH syscalls that yield between chunks
+// (clearSessionsV4/clearSessionsV6). Semantics are unchanged: every session —
+// both the forward and the reverse conntrack entry — present at the start is
+// still removed, plus the dynamic dnat_table entries for SNAT sessions.
+func (m *Manager) ClearAllSessionsChunked(onV4Chunk func([]SessionKey), onV6Chunk func([]SessionKeyV6)) (int, int, error) {
+	v4Deleted, err := m.clearSessionsChunkedV4(onV4Chunk)
+	if err != nil {
+		return v4Deleted, 0, err
 	}
-	v6Deleted := m.clearSessionsV6(v6Keys)
-	for i, dk := range snatDNATKeysV6 {
-		m.DeleteDNATEntryV6(dk)
-		if (i+1)%sessionDeleteBatchSize == 0 {
-			runtime.Gosched()
-		}
+	v6Deleted, err := m.clearSessionsChunkedV6(onV6Chunk)
+	if err != nil {
+		return v4Deleted, v6Deleted, err
 	}
-
 	return v4Deleted, v6Deleted, nil
+}
+
+// clearSessionsChunkedV4 drains the IPv4 session map in bounded chunks: it
+// collects up to sessionClearSnapshotChunk keys (plus the SNAT sessions' DNAT
+// keys) from a fresh batch scan, deletes that chunk and its DNAT entries, hands
+// the chunk to onChunk, then re-scans for the remainder until the map is empty.
+// Because every collected key is deleted before the next scan, a fresh scan
+// never re-returns it, so the loop converges — every key present at the start
+// is removed — while holding only O(chunk) keys in memory (#5304).
+func (m *Manager) clearSessionsChunkedV4(onChunk func([]SessionKey)) (int, error) {
+	deleted := 0
+	keys := make([]SessionKey, 0, sessionClearSnapshotChunk)
+	var snatDNATKeys []DNATKey
+	for {
+		keys = keys[:0]
+		snatDNATKeys = snatDNATKeys[:0]
+		full := false
+		if err := m.BatchIterateSessions(func(key SessionKey, val SessionValue) bool {
+			keys = append(keys, key)
+			// Track dynamic SNAT sessions for dnat_table cleanup.
+			if val.IsReverse == 0 &&
+				val.Flags&SessFlagSNAT != 0 &&
+				val.Flags&SessFlagStaticNAT == 0 {
+				// Must match the write-side key encoding (#2406: host-order port).
+				snatDNATKeys = append(snatDNATKeys, dnatKeyForSessionV4(key, val))
+			}
+			if len(keys) >= sessionClearSnapshotChunk {
+				full = true
+				return false // chunk full — stop and re-scan for the remainder
+			}
+			return true
+		}); err != nil {
+			return deleted, fmt.Errorf("iterate sessions: %w", err)
+		}
+		if len(keys) == 0 {
+			break // table drained
+		}
+		if sessionClearSnapshotObserver != nil {
+			sessionClearSnapshotObserver(len(keys))
+		}
+		before := deleted
+		deleted += m.clearSessionsV4(keys)
+		for i, dk := range snatDNATKeys {
+			m.DeleteDNATEntry(dk)
+			if (i+1)%sessionDeleteBatchSize == 0 {
+				runtime.Gosched()
+			}
+		}
+		if onChunk != nil {
+			onChunk(keys)
+		}
+		if !full {
+			break // this scan drained the remaining keys
+		}
+		if deleted == before {
+			// A full chunk that deleted nothing means these keys are
+			// un-deletable; a fresh scan would return them forever. Break
+			// rather than spin (defensive — a live map always makes progress).
+			break
+		}
+	}
+	return deleted, nil
+}
+
+// clearSessionsChunkedV6 is the IPv6 variant of clearSessionsChunkedV4.
+func (m *Manager) clearSessionsChunkedV6(onChunk func([]SessionKeyV6)) (int, error) {
+	deleted := 0
+	keys := make([]SessionKeyV6, 0, sessionClearSnapshotChunk)
+	var snatDNATKeys []DNATKeyV6
+	for {
+		keys = keys[:0]
+		snatDNATKeys = snatDNATKeys[:0]
+		full := false
+		if err := m.BatchIterateSessionsV6(func(key SessionKeyV6, val SessionValueV6) bool {
+			keys = append(keys, key)
+			if val.IsReverse == 0 &&
+				val.Flags&SessFlagSNAT != 0 &&
+				val.Flags&SessFlagStaticNAT == 0 {
+				// Must match the write-side key encoding (#2406: host-order port).
+				snatDNATKeys = append(snatDNATKeys, dnatKeyForSessionV6(key, val))
+			}
+			if len(keys) >= sessionClearSnapshotChunk {
+				full = true
+				return false
+			}
+			return true
+		}); err != nil {
+			return deleted, fmt.Errorf("iterate sessions_v6: %w", err)
+		}
+		if len(keys) == 0 {
+			break
+		}
+		if sessionClearSnapshotObserver != nil {
+			sessionClearSnapshotObserver(len(keys))
+		}
+		before := deleted
+		deleted += m.clearSessionsV6(keys)
+		for i, dk := range snatDNATKeys {
+			m.DeleteDNATEntryV6(dk)
+			if (i+1)%sessionDeleteBatchSize == 0 {
+				runtime.Gosched()
+			}
+		}
+		if onChunk != nil {
+			onChunk(keys)
+		}
+		if !full {
+			break
+		}
+		if deleted == before {
+			break
+		}
+	}
+	return deleted, nil
 }
 
 // clearSessionsV4 deletes every key in keys from the v4 session map using

--- a/pkg/dataplane/maps_session_clear_test.go
+++ b/pkg/dataplane/maps_session_clear_test.go
@@ -193,6 +193,101 @@ func TestClearAllSessionsBatchedRemovesEverything(t *testing.T) {
 	}
 }
 
+// TestClearAllSessionsBoundedSnapshot is the fail-on-revert guard for #5304:
+// the full-table clear must collect keys in bounded chunks, never one N-sized
+// snapshot of the whole table (which — combined with the userspace wrapper's
+// duplicate snapshot and the dynamic-DNAT key lists — spiked ~1 GB of RSS on a
+// max-loaded 10M/family table and could stall/OOM-kill the daemon). It shrinks
+// sessionClearSnapshotChunk, installs several chunks' worth of sessions per
+// family, and asserts (a) every session is still cleared and (b) the snapshot
+// observer fired once per bounded chunk with len(keys) <= chunk across multiple
+// chunks per family.
+//
+// fail-on-revert: reverting ClearAllSessions to the collect-all body snapshots
+// the entire table into one slice and never invokes sessionClearSnapshotObserver,
+// so chunkCalls/maxChunk stay 0 and the "bounded chunk path" assertion fails
+// RED; a variant that snapshots-all yet still reported the slice would report
+// len == N > chunk and trip the "<= chunk" assertion. The all-cleared checks
+// guard the preserved semantics (no dropped session, no orphaned reverse).
+func TestClearAllSessionsBoundedSnapshot(t *testing.T) {
+	m := newClearTestManager(t)
+
+	const chunk = 64
+	restore := sessionClearSnapshotChunk
+	sessionClearSnapshotChunk = chunk
+	t.Cleanup(func() { sessionClearSnapshotChunk = restore })
+
+	// flows forward + flows reverse per family = 2*flows entries. 2*flows is a
+	// multiple of chunk chosen to span several chunks (500/64 ~= 8 chunks).
+	const flows = 250
+	for i := uint32(0); i < flows; i++ {
+		if err := m.SetSessionV4(clearTestV4Key(i, false), SessionValue{State: 1, IsReverse: 0}); err != nil {
+			t.Fatalf("set v4 fwd %d: %v", i, err)
+		}
+		if err := m.SetSessionV4(clearTestV4Key(i, true), SessionValue{State: 1, IsReverse: 1}); err != nil {
+			t.Fatalf("set v4 rev %d: %v", i, err)
+		}
+		if err := m.SetSessionV6(clearTestV6Key(i, false), SessionValueV6{State: 1, IsReverse: 0}); err != nil {
+			t.Fatalf("set v6 fwd %d: %v", i, err)
+		}
+		if err := m.SetSessionV6(clearTestV6Key(i, true), SessionValueV6{State: 1, IsReverse: 1}); err != nil {
+			t.Fatalf("set v6 rev %d: %v", i, err)
+		}
+	}
+	const wantEntries = 2 * flows
+
+	// Snapshot seam: record the size of every collected key chunk. A revert to a
+	// single full-table snapshot never touches this observer.
+	var maxChunk, chunkCalls, observedKeys int
+	sessionClearSnapshotObserver = func(n int) {
+		chunkCalls++
+		observedKeys += n
+		if n > maxChunk {
+			maxChunk = n
+		}
+		if n > sessionClearSnapshotChunk {
+			t.Errorf("snapshot chunk %d exceeds bound %d — collect-all regression?", n, sessionClearSnapshotChunk)
+		}
+	}
+	t.Cleanup(func() { sessionClearSnapshotObserver = nil })
+
+	v4Deleted, v6Deleted, err := m.ClearAllSessions()
+	if err != nil {
+		t.Fatalf("ClearAllSessions: %v", err)
+	}
+
+	// (a) correctness: every session cleared, both families, fwd + reverse.
+	if v4Deleted != wantEntries || v6Deleted != wantEntries {
+		t.Errorf("deleted = (%d, %d), want (%d, %d)", v4Deleted, v6Deleted, wantEntries, wantEntries)
+	}
+	if got := countAllV4(t, m); got != 0 {
+		t.Errorf("post-clear v4 entries = %d, want 0 (dropped session / orphaned reverse)", got)
+	}
+	if got := countAllV6(t, m); got != 0 {
+		t.Errorf("post-clear v6 entries = %d, want 0 (dropped session / orphaned reverse)", got)
+	}
+
+	// (b) bounded working set: the chunk path fired, every chunk <= bound, and
+	// it took multiple bounded chunks per family — proving it did NOT snapshot
+	// the whole table into one slice. RED on revert (observer never fires).
+	if chunkCalls == 0 || maxChunk == 0 {
+		t.Fatalf("snapshot chunk observer never fired (chunkCalls=%d) — collect-all regression (unbounded snapshot)?", chunkCalls)
+	}
+	if maxChunk > chunk {
+		t.Errorf("max snapshot chunk = %d, want <= %d (bounded working set)", maxChunk, chunk)
+	}
+	// Each family needs at least ceil(wantEntries/chunk) chunks; both families
+	// together at least 2x that. A single N-sized snapshot would be 1/family.
+	minPerFamily := (wantEntries + chunk - 1) / chunk
+	if chunkCalls < 2*minPerFamily {
+		t.Errorf("snapshot chunkCalls = %d, want >= %d (bounded chunks, not one giant snapshot)", chunkCalls, 2*minPerFamily)
+	}
+	// Every key passes through exactly one bounded chunk (v4 + v6 = 2*wantEntries).
+	if observedKeys != 2*wantEntries {
+		t.Errorf("observed snapshot keys = %d, want %d (all keys routed through bounded chunks)", observedKeys, 2*wantEntries)
+	}
+}
+
 // TestClearAllSessionsEmptyAndSmall guards the empty-table (no panic, no batch
 // syscall) and single-session boundary cases.
 func TestClearAllSessionsEmptyAndSmall(t *testing.T) {

--- a/pkg/dataplane/userspace/clear_bounded_5304_test.go
+++ b/pkg/dataplane/userspace/clear_bounded_5304_test.go
@@ -1,0 +1,121 @@
+package userspace
+
+import (
+	"encoding/binary"
+	"net"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// TestClearAllSessionsDeliversEveryKeyToHelper5304 guards the bounded-memory
+// wrapper clear (#5304): replacing the wrapper's own full-table key snapshot
+// with the shim's per-chunk callback must still route an authoritative helper
+// "delete" for EVERY mirror session. It seeds many distinct v4 + v6 forward
+// sessions, runs the clear through the adapter (the real dispatch path), and
+// asserts (a) the mirror is emptied and (b) the fake helper recorded a delete
+// for every seeded key — no key dropped by the chunk plumbing.
+//
+// fail-on-revert: dropping the callbacks (passing nil,nil to
+// ClearAllSessionsChunked) or reverting to a mirror-only clear leaves the fake
+// helper missing deletes and fails RED — the #5096 forward-under-revoked-
+// decision bypass on a bulk clear.
+func TestClearAllSessionsDeliversEveryKeyToHelper5304(t *testing.T) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("RemoveMemlock: %v", err)
+	}
+	dir := t.TempDir()
+	controlSock := filepath.Join(dir, "control.sock")
+	sessionSock := filepath.Join(dir, "userspace-dp-sessions.sock")
+	rec := startFakeHelperDeleteRecorder(t, sessionSock)
+
+	m := New()
+	m.proc = &exec.Cmd{}
+	m.cfg.ControlSocket = controlSock
+	injectSessionMaps(t, m)
+	adapter := NewLegacyDataPlaneAdapter(m)
+
+	// Seed distinct v4 + v6 forward sessions in the mirror. injectSessionMaps
+	// caps the maps at 1024 entries, so stay well under it.
+	const n = 200
+	v4Src := make([]string, n)
+	v6Src := make([]string, n)
+	const v4Dst = "172.16.80.200"
+	const v6Dst = "2001:559:8585:80::200"
+	var v6DstB [16]byte
+	copy(v6DstB[:], net.ParseIP(v6Dst).To16())
+
+	for i := 0; i < n; i++ {
+		var s4 [4]byte
+		binary.BigEndian.PutUint32(s4[:], 0x0a000000|uint32(i+1)) // 10.x.x.x, distinct
+		k4 := dataplane.SessionKey{
+			SrcIP:    s4,
+			DstIP:    [4]byte{172, 16, 80, 200},
+			SrcPort:  hostToNetwork16(uint16(20000 + i)),
+			DstPort:  hostToNetwork16(443),
+			Protocol: 6,
+		}
+		if err := m.bpfShim.SetSessionV4(k4, dataplane.SessionValue{}); err != nil {
+			t.Fatalf("seed v4 %d: %v", i, err)
+		}
+		v4Src[i] = net.IP(s4[:]).String()
+
+		var s6 [16]byte
+		copy(s6[:], net.ParseIP("2001:559:8585:ef00::").To16())
+		binary.BigEndian.PutUint32(s6[12:], uint32(i+1))
+		k6 := dataplane.SessionKeyV6{
+			SrcIP:    s6,
+			DstIP:    v6DstB,
+			SrcPort:  hostToNetwork16(uint16(30000 + i)),
+			DstPort:  hostToNetwork16(443),
+			Protocol: 6,
+		}
+		if err := m.bpfShim.SetSessionV6(k6, dataplane.SessionValueV6{}); err != nil {
+			t.Fatalf("seed v6 %d: %v", i, err)
+		}
+		v6Src[i] = net.IP(s6[:]).String()
+	}
+
+	if v4, v6 := m.bpfShim.SessionCount(); v4 != n || v6 != n {
+		t.Fatalf("pre-clear mirror count = (%d, %d), want (%d, %d)", v4, v6, n, n)
+	}
+
+	v4Deleted, v6Deleted, err := adapter.ClearAllSessions()
+	if err != nil {
+		t.Fatalf("ClearAllSessions: %v", err)
+	}
+	if v4Deleted != n || v6Deleted != n {
+		t.Errorf("deleted = (%d, %d), want (%d, %d)", v4Deleted, v6Deleted, n, n)
+	}
+
+	// (a) mirror emptied.
+	if v4, v6 := m.bpfShim.SessionCount(); v4 != 0 || v6 != 0 {
+		t.Errorf("post-clear mirror count = (%d, %d), want (0, 0)", v4, v6)
+	}
+
+	// (b) every seeded key was delivered to the authoritative helper.
+	missing := 0
+	for i := 0; i < n; i++ {
+		if !rec.deletedIP("delete", v4Src[i], v4Dst) {
+			missing++
+			if missing <= 5 {
+				t.Errorf("v4 key %d (%s->%s) not delivered to helper", i, v4Src[i], v4Dst)
+			}
+		}
+		if !rec.deletedIP("delete", v6Src[i], v6Dst) {
+			missing++
+			if missing <= 5 {
+				t.Errorf("v6 key %d (%s->%s) not delivered to helper", i, v6Src[i], v6Dst)
+			}
+		}
+	}
+	if missing != 0 {
+		t.Errorf("%d of %d keys were not delivered to the helper (chunk plumbing dropped keys?)", missing, 2*n)
+	}
+	if got := rec.count(); got != 2*n {
+		t.Errorf("helper recorded %d delete requests, want %d (every seeded key exactly once)", got, 2*n)
+	}
+}

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -1113,31 +1113,24 @@ func (m *Manager) BatchDeleteSessionsV6(keys []dataplane.SessionKeyV6) (int, err
 // the Rust helper for every session so an operator `clear security flow session
 // all` actually stops forwarding under revoked decisions (#5096). The helper
 // exposes no bulk-clear verb (only the per-session "delete" the singular path
-// uses), so every mirror key — forward AND reverse conntrack entries — is
-// snapshotted BEFORE the mirror is emptied and then deleted on the helper.
-// Returns the bpf mirror's (v4, v6, err) counts unchanged.
+// uses), so every mirror key — forward AND reverse conntrack entries — must be
+// deleted on the helper too.
+//
+// The keys are NOT snapshotted here. Enumerating the full v4+v6 mirror into
+// wrapper-owned slices while the shim's own clear snapshots them AGAIN (plus the
+// dynamic-DNAT key lists) stacked ~1 GB of duplicate key slices in RSS on a
+// max-loaded 10M/family table — enough for the recovery command to stall or
+// OOM-kill the daemon (#5304). Instead the shim's ClearAllSessionsChunked drives
+// a per-chunk callback: it collects a bounded chunk, deletes it from the mirror,
+// and hands that same bounded chunk here for deletion on the helper, so neither
+// side ever holds more than one chunk of keys. deleteHelperSessions{V4,V6} keeps
+// the #5096 chunked-transmission behaviour (sessionHelperDeleteChunk). Returns
+// the bpf mirror's (v4, v6, err) counts unchanged.
 func (m *Manager) ClearAllSessions() (int, int, error) {
-	var v4Keys []dataplane.SessionKey
-	if err := m.bpfShim.BatchIterateSessions(func(key dataplane.SessionKey, _ dataplane.SessionValue) bool {
-		v4Keys = append(v4Keys, key)
-		return true
-	}); err != nil {
-		slog.Debug("userspace: enumerate v4 sessions for helper clear failed", "err", err)
-	}
-	var v6Keys []dataplane.SessionKeyV6
-	if err := m.bpfShim.BatchIterateSessionsV6(func(key dataplane.SessionKeyV6, _ dataplane.SessionValueV6) bool {
-		v6Keys = append(v6Keys, key)
-		return true
-	}); err != nil {
-		slog.Debug("userspace: enumerate v6 sessions for helper clear failed", "err", err)
-	}
-
-	v4Deleted, v6Deleted, err := m.bpfShim.ClearAllSessions()
-
-	m.deleteHelperSessionsV4(v4Keys)
-	m.deleteHelperSessionsV6(v6Keys)
-
-	return v4Deleted, v6Deleted, err
+	return m.bpfShim.ClearAllSessionsChunked(
+		func(keys []dataplane.SessionKey) { m.deleteHelperSessionsV4(keys) },
+		func(keys []dataplane.SessionKeyV6) { m.deleteHelperSessionsV6(keys) },
+	)
 }
 
 // deleteHelperSessionsV4 tells the Rust helper to delete every key so the batch


### PR DESCRIPTION
Closes #5304

## Problem

`clear security flow session all` on a max-loaded table (10M sessions/family) briefly held the entire key space in RSS at once (~1 GB), because **both** layers of the clear snapshotted the full table before deleting:

1. **Userspace wrapper** (`userspace.Manager.ClearAllSessions`) enumerated every v4 **and** v6 mirror key into its own slices so it could issue the authoritative per-session Rust-helper `delete` (#5096 exposes no bulk-clear verb).
2. **Shim** (`dataplane.Manager.ClearAllSessions`) then enumerated the v4 and v6 key space **again**, plus the dynamic-DNAT key lists, before deleting.

#5222/#5096 chunked the helper-delete **transmission** and #4719 chunked the `BPF_MAP_DELETE_BATCH` **transmission**, but both left the full-table key **snapshots** in place. So the wrapper's v4+v6 slices, the shim's duplicate v4+v6 slices, and the DNAT key lists all coexisted at full-table size (~560 MB outer + ~400 MB duplicate v6 + DNAT). A supported-max table made its own recovery command able to stall or OOM-kill the daemon.

## Fix — bound the working set to a chunk, not the whole table

- `ClearAllSessions` now drains each family in **bounded chunks**: collect up to `sessionClearSnapshotChunk` (4096) keys (plus their SNAT DNAT keys) from a fresh batch scan, delete that chunk via the existing chunked `BPF_MAP_DELETE_BATCH` path (`clearSessionsV4/V6`, #4719 idiom preserved) and its DNAT entries, then re-scan for the remainder. Peak key-slice memory is **O(chunk), not O(table)**.
- New exported `ClearAllSessionsChunked` drives an optional **per-chunk callback**. The wrapper passes it `deleteHelperSessionsV4/V6`, so the wrapper **no longer builds its own full-table snapshot** — it receives each bounded chunk and forwards it to the helper (still transmitted in `sessionHelperDeleteChunk`-sized batches, #5096 preserved). Neither side ever holds more than one chunk of keys — the double snapshot is gone.

### Correctness (all-cleared, safe iterate-then-delete)

BPF hash iterate-during-delete is subtle, so the loop **never deletes across a live cursor**: each round runs a **fresh** batch scan, collects a bounded chunk, deletes it, then re-scans. Because every collected key is deleted before the next scan, a fresh scan never re-returns it, so the loop converges — every session present at start (forward **and** reverse conntrack entry) is removed. A table that mutates during the clear still converges to empty for everything present at start; new inserts racing the clear are best-effort (unchanged). A defensive zero-progress guard (a full chunk that deleted nothing) prevents any infinite loop.

The public `ClearAllSessions() (int, int, error)` signature and semantics are unchanged; only the peak memory profile changes.

## Tests (fail-on-revert)

- **`pkg/dataplane` `TestClearAllSessionsBoundedSnapshot`** — shrinks the chunk to 64, installs 500 entries/family (spanning ~8 chunks), and asserts (a) **every** session is cleared (table empty, correct v4/v6 counts) and (b) a new `sessionClearSnapshotObserver` seam fires **once per bounded chunk with `len <= chunk`** across multiple chunks/family. **RED on revert:** reverting to the collect-all body never invokes the observer, so `chunkCalls == 0` → `snapshot chunk observer never fired (chunkCalls=0)` (verified).
- **`pkg/dataplane/userspace` `TestClearAllSessionsDeliversEveryKeyToHelper5304`** — seeds 200 v4 + 200 v6 sessions, clears through the real adapter dispatch, and asserts the mirror empties **and** the fake helper recorded a `delete` for **every** seeded key (no key dropped by the chunk plumbing). **RED on revert:** dropping the per-chunk callbacks (`nil,nil`) leaves the helper with zero deletes (the #5096 forward-under-revoked-decision bypass).

Existing `TestClearAllSessionsBatchedRemovesEverything` (#4719 batched delete) and `TestBatchAndClearRouteToHelper5096` (#5096 helper routing) remain green.

## Validation

- `go build ./...` — exit 0
- `go test ./pkg/dataplane/ ./pkg/dataplane/userspace/` clear-related tests (`-run 'ClearAllSessions|BatchAndClear|DeliversEveryKey'`, real BPF maps under sudo) — **ok**
- RED-on-revert demonstrated for both new tests (see above)
- `gofmt -l` clean on touched Go files
- Pre-existing environment-only failures (netlink `NTF_PROXY` pneigh, XDP-shim/map loading, over-long unix-socket paths under `/dev/shm`+sudo) were confirmed identical on a pristine `origin/master` worktree — unrelated to this change.

## Docs

`pkg/dataplane/README.md` documents the bounded-memory clear (bounded working set, convergence, per-chunk callback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
