### PR TITLE
sessions: surface peer-fetch completeness + dynamic max-sessions (#5320, #5323)

### DIFF
--- a/cmd/cli/show_flow.go
+++ b/cmd/cli/show_flow.go
@@ -336,6 +336,17 @@ func (c *ctl) showSessionSummary() error {
 	} else {
 		printSessionSummaryBlock(resp)
 	}
+
+	// #5320: when the cluster peer was requested but could not be reached the
+	// totals above are LOCAL-ONLY. Surface that instead of letting a peer
+	// partition masquerade as a healthy low session count.
+	if resp.GetPeerStatus() == pb.PeerFetchStatus_PEER_FETCH_STATUS_UNREACHABLE {
+		fmt.Printf("\nwarning: cluster peer unreachable; counts above are LOCAL-ONLY")
+		if e := resp.GetPeerError(); e != "" {
+			fmt.Printf(" (%s)", e)
+		}
+		fmt.Println()
+	}
 	return nil
 }
 
@@ -357,7 +368,15 @@ func printSessionSummaryBlock(resp *pb.GetSessionSummaryResponse) {
 	fmt.Printf("  Pending sessions: 0\n")
 	fmt.Printf("  Invalidated sessions: 0\n")
 	fmt.Printf("  Sessions in other states: 0\n")
-	fmt.Printf("Maximum-sessions: 10000000\n")
+	// #5323: render the dataplane's dynamic max (worker_count x per-worker
+	// capacity) the live helper publishes, not the old hardcoded 10000000. A
+	// dataplane with no userspace status attached reports 0 -> "unknown"
+	// (render the truth rather than a fabricated authoritative bound).
+	if max := resp.GetMaxSessions(); max > 0 {
+		fmt.Printf("Maximum-sessions: %d\n", max)
+	} else {
+		fmt.Printf("Maximum-sessions: unknown\n")
+	}
 }
 
 func (c *ctl) showFlowStatistics() error {

--- a/cmd/cli/show_flow_summary_5320_5323_test.go
+++ b/cmd/cli/show_flow_summary_5320_5323_test.go
@@ -1,0 +1,103 @@
+// #5323: `show security flow session summary` (remote CLI) rendered a
+// HARDCODED Maximum-sessions:10000000. #5320: an unreachable cluster peer was
+// swallowed, so the local-only counts printed as if complete. These tests pin
+// the dynamic-max render and the peer-unreachable warning.
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc"
+)
+
+// TestPrintSessionSummaryBlockDynamicMax asserts the render uses the response's
+// max_sessions, not the retired hardcoded 10000000 (#5323).
+//
+// FAIL-ON-REVERT: restoring `Maximum-sessions: 10000000` makes the 786432
+// assertion go red.
+func TestPrintSessionSummaryBlockDynamicMax(t *testing.T) {
+	out := captureStdout(t, func() {
+		printSessionSummaryBlock(&pb.GetSessionSummaryResponse{ForwardOnly: 5, MaxSessions: 786432})
+	})
+	if !strings.Contains(out, "Maximum-sessions: 786432") {
+		t.Fatalf("output missing dynamic max:\n%s", out)
+	}
+	if strings.Contains(out, "10000000") {
+		t.Fatalf("output still prints the retired hardcoded max:\n%s", out)
+	}
+}
+
+// TestPrintSessionSummaryBlockUnknownMax asserts a 0 max (no dataplane status)
+// renders "unknown" rather than a fabricated authoritative bound (#5323).
+func TestPrintSessionSummaryBlockUnknownMax(t *testing.T) {
+	out := captureStdout(t, func() {
+		printSessionSummaryBlock(&pb.GetSessionSummaryResponse{ForwardOnly: 1})
+	})
+	if !strings.Contains(out, "Maximum-sessions: unknown") {
+		t.Fatalf("output missing unknown fallback:\n%s", out)
+	}
+}
+
+// summaryFakeClient stubs GetSessionSummary so the remote showSessionSummary
+// path can be driven without a live daemon.
+type summaryFakeClient struct {
+	pb.BpfrxServiceClient
+	resp *pb.GetSessionSummaryResponse
+}
+
+func (f *summaryFakeClient) GetSessionSummary(
+	_ context.Context, _ *pb.GetSessionSummaryRequest, _ ...grpc.CallOption,
+) (*pb.GetSessionSummaryResponse, error) {
+	return f.resp, nil
+}
+
+// TestShowSessionSummaryPeerUnreachableWarning asserts the remote CLI prints a
+// LOCAL-ONLY warning when the cluster peer was requested but unreachable
+// (#5320), instead of silently showing the local counts as complete.
+//
+// FAIL-ON-REVERT: dropping the peer_status==UNREACHABLE branch in
+// showSessionSummary drops the warning line.
+func TestShowSessionSummaryPeerUnreachableWarning(t *testing.T) {
+	c := &ctl{client: &summaryFakeClient{resp: &pb.GetSessionSummaryResponse{
+		ForwardOnly: 3,
+		MaxSessions: 786432,
+		PeerStatus:  pb.PeerFetchStatus_PEER_FETCH_STATUS_UNREACHABLE,
+		PeerError:   "dial peer node 1: connection refused",
+	}}}
+
+	out := captureStdout(t, func() {
+		if err := c.showSessionSummary(); err != nil {
+			t.Fatalf("showSessionSummary: %v", err)
+		}
+	})
+	if !strings.Contains(out, "cluster peer unreachable") {
+		t.Fatalf("output missing peer-unreachable warning:\n%s", out)
+	}
+	if !strings.Contains(out, "LOCAL-ONLY") {
+		t.Fatalf("output missing LOCAL-ONLY qualifier:\n%s", out)
+	}
+	if !strings.Contains(out, "Maximum-sessions: 786432") {
+		t.Fatalf("output missing dynamic max:\n%s", out)
+	}
+}
+
+// TestShowSessionSummaryNoWarningWhenOK asserts no spurious warning when the
+// peer status is not unreachable (standalone / OK).
+func TestShowSessionSummaryNoWarningWhenOK(t *testing.T) {
+	c := &ctl{client: &summaryFakeClient{resp: &pb.GetSessionSummaryResponse{
+		ForwardOnly: 3,
+		MaxSessions: 786432,
+		PeerStatus:  pb.PeerFetchStatus_PEER_FETCH_STATUS_NOT_APPLICABLE,
+	}}}
+	out := captureStdout(t, func() {
+		if err := c.showSessionSummary(); err != nil {
+			t.Fatalf("showSessionSummary: %v", err)
+		}
+	})
+	if strings.Contains(out, "cluster peer unreachable") {
+		t.Fatalf("spurious peer-unreachable warning on a standalone summary:\n%s", out)
+	}
+}

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -179,6 +179,28 @@ Maximum-sessions: 4194304
 - Sub-items indented 2 spaces (Valid/Pending/Invalidated/Other).
 - `Maximum-sessions: 4194304` (4M max on vSRX).
 
+### xpf implementation notes (#5323 / #5320)
+
+- **`Maximum-sessions` is DYNAMIC, not a fixed literal.** xpf renders the
+  live AF_XDP helper's `max_sessions` (worker_count x per-worker capacity,
+  131072/worker) taken from the userspace `ProcessStatus`. It replaces the
+  historical hardcoded `10000000` on both the remote CLI
+  (`cmd/cli/show_flow.go`, from `GetSessionSummaryResponse.max_sessions`) and
+  the local CLI (`pkg/cli/cli_show_flow.go`, from `userspaceDataplaneStatus()`).
+  When no dataplane status is available the value renders `unknown` rather than
+  a fabricated authoritative bound.
+- **Multicast/Failed/Services-offload counters stay `0`.** The AF_XDP helper
+  publishes no multicast/failed-session counters, so those Junos rows are
+  reported as `0` for format parity (documented follow-up, not authoritative).
+- **HA completeness (`include_peer`).** `GetSessionSummary` /
+  `GetZonePairSummary` and the REST `/api/v1/security/sessions/summary`
+  [`/zone-pairs`] endpoints now carry a machine-readable peer-fetch status
+  (`peer_status` = `ok` | `unreachable` | `not-applicable`, plus `peer_error`).
+  A cluster peer that is requested but unreachable is reported as `unreachable`
+  (the totals are LOCAL-ONLY) instead of being swallowed and returned as a
+  healthy-looking standalone view; the remote CLI prints a
+  `warning: cluster peer unreachable; counts above are LOCAL-ONLY` line.
+
 ---
 
 ## Security: Flow Statistics

--- a/pkg/api/session_summary_fields_5320_5323_test.go
+++ b/pkg/api/session_summary_fields_5320_5323_test.go
@@ -1,0 +1,173 @@
+// #5320 + #5323 REST surface: the /security/sessions/summary endpoint now
+// carries max_sessions (dynamic helper capacity) and peer_status/peer_error
+// (include_peer completeness), so a peer partition is no longer served as a
+// healthy-looking local-only 200.
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"github.com/psaab/xpf/pkg/logging"
+)
+
+// statusSummaryDP is a one-session dataplane that also exposes a userspace
+// ProcessStatus carrying max_sessions (#5323).
+type statusSummaryDP struct {
+	*dataplane.Manager
+	maxSessions uint64
+}
+
+func (d *statusSummaryDP) IsLoaded() bool { return true }
+
+func (d *statusSummaryDP) IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	fn(dataplane.SessionKey{Protocol: 6}, dataplane.SessionValue{IsReverse: 0, IngressZone: 2, EgressZone: 3})
+	return nil
+}
+
+func (d *statusSummaryDP) IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return nil
+}
+
+func (d *statusSummaryDP) Status() (dpuserspace.ProcessStatus, error) {
+	return dpuserspace.ProcessStatus{MaxSessions: d.maxSessions}, nil
+}
+
+// TestRESTSessionSummaryMaxSessions asserts the REST summary surfaces the
+// dataplane's dynamic max_sessions from the helper status (#5323).
+//
+// FAIL-ON-REVERT: dropping the fetchUserspaceStatus plumbing in
+// sessionSummaryHandler leaves MaxSessions 0.
+func TestRESTSessionSummaryMaxSessions(t *testing.T) {
+	s := &Server{
+		dp:       &statusSummaryDP{Manager: dataplane.New(), maxSessions: 786432},
+		eventBuf: logging.NewEventBuffer(8),
+	}
+	rr := httptest.NewRecorder()
+	s.sessionSummaryHandler(rr, httptest.NewRequest("GET", "/api/v1/security/sessions/summary", nil))
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	sum := decodeSummary(t, rr.Body.Bytes())
+	if sum.MaxSessions != 786432 {
+		t.Fatalf("max_sessions = %d, want 786432 (dynamic helper capacity)", sum.MaxSessions)
+	}
+	// Standalone summary makes no peer claim.
+	if sum.PeerStatus != "not-applicable" {
+		t.Fatalf("peer_status = %q, want not-applicable (standalone, no include_peer)", sum.PeerStatus)
+	}
+}
+
+// TestRESTSessionSummaryPeerUnreachable asserts include_peer=true with a gRPC
+// server reporting a swallowed peer fetch surfaces peer_status=unreachable and
+// peer_error on the REST 200 (#5320) — so a peer partition is no longer served
+// as a healthy local-only view.
+//
+// FAIL-ON-REVERT: dropping the pr.GetPeerStatus()/GetPeerError() plumbing
+// leaves peer_status empty (or the pre-#5320 silent-nil path), flipping the
+// assertion.
+func TestRESTSessionSummaryPeerUnreachable(t *testing.T) {
+	fake := &fakeClusterSessionService{
+		summaryResp: &pb.GetSessionSummaryResponse{
+			NodeId:     5,
+			PeerStatus: pb.PeerFetchStatus_PEER_FETCH_STATUS_UNREACHABLE,
+			PeerError:  "dial peer node 1: connection refused",
+		},
+	}
+	s := &Server{
+		dp:               &oneSessionDP{Manager: dataplane.New()},
+		eventBuf:         logging.NewEventBuffer(8),
+		nodeIDFn:         func() int { return 5 },
+		clusterSessionFn: func() ClusterSessionService { return fake },
+	}
+	rr := httptest.NewRecorder()
+	s.sessionSummaryHandler(rr, httptest.NewRequest("GET", "/api/v1/security/sessions/summary?include_peer=true", nil))
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	sum := decodeSummary(t, rr.Body.Bytes())
+	if sum.PeerStatus != "unreachable" {
+		t.Fatalf("peer_status = %q, want unreachable (peer partition served as healthy standalone)", sum.PeerStatus)
+	}
+	if sum.PeerError == "" {
+		t.Fatal("peer_error empty on an unreachable peer")
+	}
+	if sum.Peer != nil {
+		t.Fatal("peer summary attached despite unreachable peer")
+	}
+}
+
+// TestRESTSessionSummaryPeerOK asserts a healthy peer fetch surfaces
+// peer_status=ok with the peer summary and its own max_sessions (#5320/#5323).
+func TestRESTSessionSummaryPeerOK(t *testing.T) {
+	fake := &fakeClusterSessionService{
+		summaryResp: &pb.GetSessionSummaryResponse{
+			NodeId:     5,
+			PeerStatus: pb.PeerFetchStatus_PEER_FETCH_STATUS_OK,
+			Peer: &pb.GetSessionSummaryResponse{
+				NodeId:       6,
+				TotalEntries: 3,
+				MaxSessions:  262144,
+			},
+		},
+	}
+	s := &Server{
+		dp:               &oneSessionDP{Manager: dataplane.New()},
+		eventBuf:         logging.NewEventBuffer(8),
+		nodeIDFn:         func() int { return 5 },
+		clusterSessionFn: func() ClusterSessionService { return fake },
+	}
+	rr := httptest.NewRecorder()
+	s.sessionSummaryHandler(rr, httptest.NewRequest("GET", "/api/v1/security/sessions/summary?include_peer=true", nil))
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	sum := decodeSummary(t, rr.Body.Bytes())
+	if sum.PeerStatus != "ok" {
+		t.Fatalf("peer_status = %q, want ok", sum.PeerStatus)
+	}
+	if sum.Peer == nil || sum.Peer.NodeID != 6 || sum.Peer.MaxSessions != 262144 {
+		t.Fatalf("peer summary = %+v, want node 6 max 262144", sum.Peer)
+	}
+}
+
+// TestRESTZonePairsPeerUnreachable asserts the zone-pair endpoint mirrors the
+// summary: an unreachable peer is surfaced instead of a silent local-only
+// breakdown (#5320).
+func TestRESTZonePairsPeerUnreachable(t *testing.T) {
+	fake := &fakeClusterSessionService{
+		zpResp: &pb.GetZonePairSummaryResponse{
+			NodeId:     5,
+			PeerStatus: pb.PeerFetchStatus_PEER_FETCH_STATUS_UNREACHABLE,
+			PeerError:  "peer zone-pair: deadline exceeded",
+		},
+	}
+	s := &Server{
+		dp:               &oneSessionDP{Manager: dataplane.New()},
+		eventBuf:         logging.NewEventBuffer(8),
+		nodeIDFn:         func() int { return 5 },
+		clusterSessionFn: func() ClusterSessionService { return fake },
+	}
+	rr := httptest.NewRecorder()
+	s.sessionZonePairHandler(rr, httptest.NewRequest("GET", "/api/v1/security/sessions/summary/zone-pairs?include_peer=true", nil))
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Data ZonePairSummaryResponse `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, rr.Body.String())
+	}
+	if resp.Data.PeerStatus != "unreachable" {
+		t.Fatalf("zone-pair peer_status = %q, want unreachable", resp.Data.PeerStatus)
+	}
+	if resp.Data.PeerError == "" {
+		t.Fatal("zone-pair peer_error empty on unreachable peer")
+	}
+}

--- a/pkg/api/sessions.go
+++ b/pkg/api/sessions.go
@@ -473,7 +473,9 @@ func sessionEntryFromPB(e *pb.SessionEntry) SessionEntry {
 }
 
 // sessionSummaryFromPB maps a protobuf session summary (the peer node's view)
-// onto the REST SessionSummary shape (#3423 M5).
+// onto the REST SessionSummary shape (#3423 M5). The peer carries its OWN
+// max_sessions (#5323); its peer_status is not recursed (the peer leg is
+// local-only).
 func sessionSummaryFromPB(p *pb.GetSessionSummaryResponse) *SessionSummary {
 	return &SessionSummary{
 		TotalEntries: int(p.GetTotalEntries()),
@@ -484,6 +486,24 @@ func sessionSummaryFromPB(p *pb.GetSessionSummaryResponse) *SessionSummary {
 		SNATSessions: int(p.GetSnatSessions()),
 		DNATSessions: int(p.GetDnatSessions()),
 		NodeID:       int(p.GetNodeId()),
+		MaxSessions:  p.GetMaxSessions(),
+	}
+}
+
+// peerFetchStatusString renders the protobuf PeerFetchStatus enum as the REST
+// JSON string surfaced on SessionSummary / ZonePairSummaryResponse (#5320). The
+// UNSPECIFIED zero value renders "" (omitted) so an older/absent gRPC server
+// does not fabricate a status.
+func peerFetchStatusString(s pb.PeerFetchStatus) string {
+	switch s {
+	case pb.PeerFetchStatus_PEER_FETCH_STATUS_NOT_APPLICABLE:
+		return "not-applicable"
+	case pb.PeerFetchStatus_PEER_FETCH_STATUS_OK:
+		return "ok"
+	case pb.PeerFetchStatus_PEER_FETCH_STATUS_UNREACHABLE:
+		return "unreachable"
+	default:
+		return ""
 	}
 }
 
@@ -559,16 +579,34 @@ func (s *Server) sessionSummaryHandler(w http.ResponseWriter, r *http.Request) {
 
 	summary.NodeID = s.nodeID()
 
+	// #5323: the dataplane's dynamic session-table capacity, fetched from the
+	// live helper status (0 = unknown when no userspace status surface exists).
+	if st := fetchUserspaceStatus(s.dp); st != nil {
+		summary.MaxSessions = st.MaxSessions
+	}
+
+	// Default peer-status: a summary without include_peer makes no claim about
+	// a peer (#5320). The include_peer path below overrides this with the gRPC
+	// server's authoritative classification.
+	summary.PeerStatus = "not-applicable"
+
 	// Augment with the cluster peer's summary when the operator opted in and
 	// an HA-aware service is wired (#3423 M5): the local summary alone
-	// understates total HA state. A standalone node / unreachable peer
-	// leaves Peer nil.
+	// understates total HA state. #5320: surface the peer-fetch completeness so
+	// an unreachable peer (LOCAL-ONLY totals) is distinguishable from a healthy
+	// standalone node rather than silently leaving Peer nil.
 	if includePeer {
 		if svc := s.clusterSession(); svc != nil {
-			if pr, err := svc.GetSessionSummary(r.Context(), &pb.GetSessionSummaryRequest{IncludePeer: true}); err == nil {
+			pr, err := svc.GetSessionSummary(r.Context(), &pb.GetSessionSummaryRequest{IncludePeer: true})
+			if err != nil {
+				summary.PeerStatus = "unreachable"
+				summary.PeerError = err.Error()
+			} else {
 				if peer := pr.GetPeer(); peer != nil {
 					summary.Peer = sessionSummaryFromPB(peer)
 				}
+				summary.PeerStatus = peerFetchStatusString(pr.GetPeerStatus())
+				summary.PeerError = pr.GetPeerError()
 			}
 		}
 	}
@@ -739,7 +777,7 @@ func (s *Server) sessionZonePairHandler(w http.ResponseWriter, r *http.Request) 
 		return result[i].ToZone < result[j].ToZone
 	})
 
-	resp := ZonePairSummaryResponse{NodeID: s.nodeID(), ZonePairs: result}
+	resp := ZonePairSummaryResponse{NodeID: s.nodeID(), ZonePairs: result, PeerStatus: "not-applicable"}
 
 	// Augment with the cluster peer's zone-pair breakdown when the operator
 	// opted in and an HA-aware service is wired (#3592): the local breakdown
@@ -750,10 +788,18 @@ func (s *Server) sessionZonePairHandler(w http.ResponseWriter, r *http.Request) 
 	// first-page gate.
 	if includePeer {
 		if svc := s.clusterSession(); svc != nil {
-			if pr, err := svc.GetZonePairSummary(r.Context(), &pb.GetZonePairSummaryRequest{IncludePeer: true}); err == nil {
+			pr, err := svc.GetZonePairSummary(r.Context(), &pb.GetZonePairSummaryRequest{IncludePeer: true})
+			if err != nil {
+				// #5320: a failed local RPC still leaves the breakdown
+				// incomplete — mark it unreachable rather than silently OK.
+				resp.PeerStatus = "unreachable"
+				resp.PeerError = err.Error()
+			} else {
 				if peer := pr.GetPeer(); peer != nil {
 					resp.Peer = zonePairSummaryFromPB(peer)
 				}
+				resp.PeerStatus = peerFetchStatusString(pr.GetPeerStatus())
+				resp.PeerError = pr.GetPeerError()
 			}
 		}
 	}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -361,6 +361,18 @@ type SessionSummary struct {
 	// include_peer=true and a reachable peer exists.
 	NodeID int             `json:"node_id"`
 	Peer   *SessionSummary `json:"peer,omitempty"`
+	// MaxSessions is the dataplane's dynamic session-table capacity (#5323):
+	// the live AF_XDP helper publishes worker_count x per-worker capacity.
+	// Omitted (0) when no userspace status is attached — a consumer treats
+	// that as unknown rather than a fabricated authoritative bound.
+	MaxSessions uint64 `json:"max_sessions,omitempty"`
+	// PeerStatus classifies the include_peer fan-out completeness (#5320):
+	// "ok" (peer summary attached), "unreachable" (peer requested but the
+	// fetch failed — the totals here are LOCAL-ONLY), or "not-applicable"
+	// (standalone node / include_peer not set). Empty on an older/absent
+	// server. PeerError carries the failure detail when unreachable.
+	PeerStatus string `json:"peer_status,omitempty"`
+	PeerError  string `json:"peer_error,omitempty"`
 }
 
 // EventEntry holds a single event record. The forensic fields below the
@@ -770,6 +782,12 @@ type ZonePairSummaryResponse struct {
 	// (standalone build, unreachable peer, or include_peer absent). Mirrors
 	// SessionSummary.Peer (#3592).
 	Peer *ZonePairSummaryResponse `json:"peer,omitempty"`
+	// PeerStatus / PeerError mirror SessionSummary (#5320): "ok" /
+	// "unreachable" / "not-applicable". An unreachable peer means this
+	// breakdown is LOCAL-ONLY, previously indistinguishable from a healthy
+	// standalone node (peer was silently nil).
+	PeerStatus string `json:"peer_status,omitempty"`
+	PeerError  string `json:"peer_error,omitempty"`
 }
 
 // BufferInfo holds dataplane buffer utilization information.

--- a/pkg/cli/cli_show_flow.go
+++ b/pkg/cli/cli_show_flow.go
@@ -561,7 +561,15 @@ func (c *CLI) showFlowSession(args []string) error {
 		fmt.Printf("  Pending sessions: 0\n")
 		fmt.Printf("  Invalidated sessions: 0\n")
 		fmt.Printf("  Sessions in other states: 0\n")
-		fmt.Printf("Maximum-sessions: 10000000\n")
+		// #5323: render the dataplane's dynamic max (worker_count x per-worker
+		// capacity) from the live helper status, not the old hardcoded
+		// 10000000. If no userspace status is available (max 0), render
+		// "unknown" instead of a fabricated authoritative bound.
+		if st, err := c.userspaceDataplaneStatus(); err == nil && st.MaxSessions > 0 {
+			fmt.Printf("Maximum-sessions: %d\n", st.MaxSessions)
+		} else {
+			fmt.Printf("Maximum-sessions: unknown\n")
+		}
 
 		if count > 0 {
 			fmt.Printf("\nSession distribution:\n")

--- a/pkg/cli/cli_show_flow_summary_5323_test.go
+++ b/pkg/cli/cli_show_flow_summary_5323_test.go
@@ -1,0 +1,89 @@
+// #5323: the LOCAL interactive `show security flow session summary` rendered a
+// HARDCODED Maximum-sessions:10000000. It now renders the live helper's dynamic
+// max (worker_count x per-worker capacity) via userspaceDataplaneStatus(), and
+// "unknown" when no userspace status is available.
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// summaryMaxCLIDP is an empty-session dataplane that exposes a userspace
+// ProcessStatus carrying max_sessions (satisfies cliUserspaceStatusProvider).
+type summaryMaxCLIDP struct {
+	*dataplane.Manager
+	maxSessions uint64
+}
+
+func (d *summaryMaxCLIDP) IsLoaded() bool { return true }
+
+func (d *summaryMaxCLIDP) IterateSessions(func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	return nil
+}
+
+func (d *summaryMaxCLIDP) IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return nil
+}
+
+func (d *summaryMaxCLIDP) Status() (dpuserspace.ProcessStatus, error) {
+	return dpuserspace.ProcessStatus{MaxSessions: d.maxSessions}, nil
+}
+
+// noStatusCLIDP is the same but WITHOUT a Status() surface, so
+// userspaceDataplaneStatus() fails and the render falls back to "unknown".
+type noStatusCLIDP struct {
+	*dataplane.Manager
+}
+
+func (d *noStatusCLIDP) IsLoaded() bool { return true }
+func (d *noStatusCLIDP) IterateSessions(func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	return nil
+}
+func (d *noStatusCLIDP) IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return nil
+}
+
+// TestLocalFlowSessionSummaryDynamicMax asserts the local summary renders the
+// helper's dynamic max, not the retired hardcoded 10000000 (#5323).
+//
+// FAIL-ON-REVERT: restoring `Maximum-sessions: 10000000` makes the 786432
+// assertion go red.
+func TestLocalFlowSessionSummaryDynamicMax(t *testing.T) {
+	c := &CLI{
+		store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")),
+		dp:    &summaryMaxCLIDP{Manager: dataplane.New(), maxSessions: 786432},
+	}
+	out := captureStdout(t, func() {
+		if err := c.showFlowSession([]string{"summary"}); err != nil {
+			t.Fatalf("showFlowSession summary: %v", err)
+		}
+	})
+	if !strings.Contains(out, "Maximum-sessions: 786432") {
+		t.Fatalf("local summary missing dynamic max:\n%s", out)
+	}
+	if strings.Contains(out, "10000000") {
+		t.Fatalf("local summary still prints the retired hardcoded max:\n%s", out)
+	}
+}
+
+// TestLocalFlowSessionSummaryUnknownMax asserts a dataplane with no userspace
+// status renders "unknown" instead of a fabricated authoritative bound (#5323).
+func TestLocalFlowSessionSummaryUnknownMax(t *testing.T) {
+	c := &CLI{
+		store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")),
+		dp:    &noStatusCLIDP{Manager: dataplane.New()},
+	}
+	out := captureStdout(t, func() {
+		if err := c.showFlowSession([]string{"summary"}); err != nil {
+			t.Fatalf("showFlowSession summary: %v", err)
+		}
+	})
+	if !strings.Contains(out, "Maximum-sessions: unknown") {
+		t.Fatalf("local summary missing unknown fallback:\n%s", out)
+	}
+}

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -152,6 +152,12 @@ type Server struct {
 	// dials the real peer; a unit test wires it to observe the forwarded
 	// request (x-peer-forwarded metadata) without a live peer.
 	peerZonePairSummaryFn func(ctx context.Context, req *pb.GetZonePairSummaryRequest) (*pb.GetZonePairSummaryResponse, error)
+	// peerSessionSummaryFn is the GetSessionSummary analog of
+	// peerZonePairSummaryFn (#5320). Production leaves it nil and
+	// proxyPeerSessionSummary dials the real peer; a unit test wires it to
+	// drive the peer_status classification (OK / UNREACHABLE / NOT_APPLICABLE)
+	// without a live peer.
+	peerSessionSummaryFn func(ctx context.Context) (*pb.GetSessionSummaryResponse, error)
 	// fabricAuthKeyFn is a test seam for the #4107 fabric-listener PSK auth.
 	// Production leaves it nil and fabricAuthKey() reads the live control-link
 	// key from the cluster manager; a unit test wires it to inject a key

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -733,27 +733,75 @@ func (s *Server) GetSessionSummary(ctx context.Context, req *pb.GetSessionSummar
 		return nil, status.Errorf(codes.Internal, "v6 session iteration: %v", err)
 	}
 
-	// Fetch peer summary if requested and in cluster mode.
-	if req.GetIncludePeer() && s.cluster != nil && s.cluster.PeerAlive() {
-		conn, err := s.dialPeer()
-		if err == nil {
-			defer conn.Close()
-			client := pb.NewBpfrxServiceClient(conn)
-			peerCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-			defer cancel()
-			// Do NOT set include_peer on the peer request — prevents recursion.
-			peerResp, err := client.GetSessionSummary(peerCtx, &pb.GetSessionSummaryRequest{})
-			if err != nil {
-				slog.Warn("failed to fetch peer session summary", "err", err)
-			} else {
-				resp.Peer = peerResp
-			}
-		} else {
-			slog.Warn("failed to dial peer for session summary", "err", err)
+	// max_sessions is the dataplane's dynamic session-table capacity (#5323):
+	// the live AF_XDP helper publishes worker_count x per-worker capacity. A
+	// dataplane with no userspace status surface leaves it 0 = unknown, so a
+	// consumer renders "unknown" rather than the old hardcoded 10000000.
+	if st, err := s.userspaceDataplaneStatus(); err == nil {
+		resp.MaxSessions = st.MaxSessions
+	}
+
+	// Fetch peer summary if requested (#5320). A peer-fetch failure is now
+	// classified as UNREACHABLE (visible incompleteness) instead of being
+	// logged and swallowed with peer=nil, which was indistinguishable from a
+	// healthy standalone node. The local totals are still returned — the local
+	// view is useful — but the response says whether it is complete.
+	if req.GetIncludePeer() {
+		peerResp, perr := s.proxyPeerSessionSummary(ctx)
+		switch {
+		case perr != nil:
+			slog.Warn("failed to fetch peer session summary", "err", perr)
+			resp.PeerStatus = pb.PeerFetchStatus_PEER_FETCH_STATUS_UNREACHABLE
+			resp.PeerError = perr.Error()
+		case peerResp != nil:
+			resp.Peer = peerResp
+			resp.PeerStatus = pb.PeerFetchStatus_PEER_FETCH_STATUS_OK
+		default:
+			// (nil, nil): standalone node (NOT_APPLICABLE) or a clustered node
+			// whose peer heartbeat is currently lost (UNREACHABLE — a partition,
+			// not standalone).
+			resp.PeerStatus = s.peerAbsentStatus()
 		}
+	} else {
+		resp.PeerStatus = pb.PeerFetchStatus_PEER_FETCH_STATUS_NOT_APPLICABLE
 	}
 
 	return resp, nil
+}
+
+// peerAbsentStatus classifies a (nil, nil) peer fetch (#5320): a genuinely
+// standalone node (no cluster manager) is NOT_APPLICABLE, while a cluster node
+// whose peer is currently not alive is UNREACHABLE — its summary is LOCAL-ONLY
+// and understates cluster-wide state, so the incompleteness must be visible.
+func (s *Server) peerAbsentStatus() pb.PeerFetchStatus {
+	if s.cluster != nil && !s.cluster.PeerAlive() {
+		return pb.PeerFetchStatus_PEER_FETCH_STATUS_UNREACHABLE
+	}
+	return pb.PeerFetchStatus_PEER_FETCH_STATUS_NOT_APPLICABLE
+}
+
+// proxyPeerSessionSummary forwards a session-summary request to the cluster
+// peer for the include_peer fan-out (#5320), mirroring proxyPeerZonePairSummary.
+// A wired peerSessionSummaryFn (test seam) takes precedence; otherwise it dials
+// the peer only when one is alive, returning (nil, nil) for a standalone node /
+// dead peer so the caller can classify the absence. The forwarded request
+// carries include_peer=false so the peer answers from its local table without
+// recursing back.
+func (s *Server) proxyPeerSessionSummary(ctx context.Context) (*pb.GetSessionSummaryResponse, error) {
+	if s.peerSessionSummaryFn != nil {
+		return s.peerSessionSummaryFn(ctx)
+	}
+	if s.cluster == nil || !s.cluster.PeerAlive() {
+		return nil, nil
+	}
+	conn, err := s.dialPeer()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	peerCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	return pb.NewBpfrxServiceClient(conn).GetSessionSummary(peerCtx, &pb.GetSessionSummaryRequest{})
 }
 
 // GetZonePairSummary aggregates the local session table by (ingress-zone,
@@ -791,11 +839,21 @@ func (s *Server) GetZonePairSummary(ctx context.Context, req *pb.GetZonePairSumm
 	// peer only when one is alive; a unit test wires peerZonePairSummaryFn.
 	if req.GetIncludePeer() && !peerForwardedFromContext(ctx) {
 		peerResp, perr := s.proxyPeerZonePairSummary(ctx, &pb.GetZonePairSummaryRequest{})
-		if perr != nil {
+		switch {
+		case perr != nil:
+			// #5320: surface the failure (UNREACHABLE) instead of swallowing it
+			// with peer=nil, which looked like a healthy standalone breakdown.
 			slog.Warn("failed to fetch peer zone-pair summary", "err", perr)
-		} else if peerResp != nil {
+			resp.PeerStatus = pb.PeerFetchStatus_PEER_FETCH_STATUS_UNREACHABLE
+			resp.PeerError = perr.Error()
+		case peerResp != nil:
 			resp.Peer = peerResp
+			resp.PeerStatus = pb.PeerFetchStatus_PEER_FETCH_STATUS_OK
+		default:
+			resp.PeerStatus = s.peerAbsentStatus()
 		}
+	} else {
+		resp.PeerStatus = pb.PeerFetchStatus_PEER_FETCH_STATUS_NOT_APPLICABLE
 	}
 
 	return resp, nil

--- a/pkg/grpcapi/session_summary_fields_5320_5323_test.go
+++ b/pkg/grpcapi/session_summary_fields_5320_5323_test.go
@@ -1,0 +1,223 @@
+// #5320 + #5323: the session-summary RPCs used to SWALLOW a peer-fetch failure
+// (slog.Warn then return success with peer=nil, indistinguishable from a
+// healthy standalone) and print a HARDCODED Maximum-sessions:10000000. These
+// tests pin the additive completeness (peer_status/peer_error) and dynamic
+// max_sessions fields.
+//
+// FAIL-ON-REVERT is called out per test.
+package grpcapi
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// summaryFieldsDP is an empty-session dataplane that optionally exposes a
+// userspace ProcessStatus carrying max_sessions (#5323). With hasStatus=false
+// the Status() call errors, exercising the "no dynamic max" fallback.
+type summaryFieldsDP struct {
+	*dataplane.Manager
+	hasStatus   bool
+	maxSessions uint64
+}
+
+func (d *summaryFieldsDP) IsLoaded() bool { return true }
+
+func (d *summaryFieldsDP) IterateSessions(func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	return nil
+}
+
+func (d *summaryFieldsDP) IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return nil
+}
+
+func (d *summaryFieldsDP) Status() (dpuserspace.ProcessStatus, error) {
+	if !d.hasStatus {
+		return dpuserspace.ProcessStatus{}, errors.New("no userspace status")
+	}
+	return dpuserspace.ProcessStatus{MaxSessions: d.maxSessions}, nil
+}
+
+func newSummaryFieldsServer(t *testing.T, dp grpcRuntime) *Server {
+	t.Helper()
+	return &Server{
+		store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")),
+		dp:    dp,
+	}
+}
+
+// TestGetSessionSummaryMaxSessionsFromHelper asserts the response carries the
+// dataplane's dynamic max_sessions (worker_count x per-worker capacity) from
+// the live helper status — NOT the old hardcoded 10000000 (#5323).
+//
+// FAIL-ON-REVERT: dropping the resp.MaxSessions = st.MaxSessions plumbing
+// leaves MaxSessions 0, flipping the assertion.
+func TestGetSessionSummaryMaxSessionsFromHelper(t *testing.T) {
+	s := newSummaryFieldsServer(t, &summaryFieldsDP{
+		Manager:     dataplane.New(),
+		hasStatus:   true,
+		maxSessions: 786432, // 6 workers x 131072
+	})
+
+	resp, err := s.GetSessionSummary(context.Background(), &pb.GetSessionSummaryRequest{})
+	if err != nil {
+		t.Fatalf("GetSessionSummary() error = %v", err)
+	}
+	if resp.GetMaxSessions() != 786432 {
+		t.Fatalf("max_sessions = %d, want 786432 (dynamic helper max, not hardcoded)", resp.GetMaxSessions())
+	}
+	if resp.GetMaxSessions() == 10000000 {
+		t.Fatal("max_sessions is the retired hardcoded 10000000")
+	}
+}
+
+// TestGetSessionSummaryMaxSessionsUnknownFallback asserts a dataplane whose
+// helper status is unavailable reports max_sessions 0 (rendered as "unknown"
+// downstream) rather than a fabricated authoritative bound (#5323).
+func TestGetSessionSummaryMaxSessionsUnknownFallback(t *testing.T) {
+	s := newSummaryFieldsServer(t, &summaryFieldsDP{Manager: dataplane.New(), hasStatus: false})
+
+	resp, err := s.GetSessionSummary(context.Background(), &pb.GetSessionSummaryRequest{})
+	if err != nil {
+		t.Fatalf("GetSessionSummary() error = %v", err)
+	}
+	if resp.GetMaxSessions() != 0 {
+		t.Fatalf("max_sessions = %d, want 0 (unknown fallback)", resp.GetMaxSessions())
+	}
+}
+
+// TestGetSessionSummaryPeerStatusOK asserts a successful peer fetch stamps
+// peer_status=OK and attaches the peer summary (#5320).
+//
+// FAIL-ON-REVERT: not setting PeerStatus on the success leg leaves it
+// UNSPECIFIED, flipping the OK assertion.
+func TestGetSessionSummaryPeerStatusOK(t *testing.T) {
+	s := newSummaryFieldsServer(t, &summaryFieldsDP{Manager: dataplane.New()})
+	s.peerSessionSummaryFn = func(context.Context) (*pb.GetSessionSummaryResponse, error) {
+		return &pb.GetSessionSummaryResponse{NodeId: 1, TotalEntries: 7}, nil
+	}
+
+	resp, err := s.GetSessionSummary(context.Background(), &pb.GetSessionSummaryRequest{IncludePeer: true})
+	if err != nil {
+		t.Fatalf("GetSessionSummary() error = %v", err)
+	}
+	if resp.GetPeerStatus() != pb.PeerFetchStatus_PEER_FETCH_STATUS_OK {
+		t.Fatalf("peer_status = %v, want OK", resp.GetPeerStatus())
+	}
+	if resp.GetPeer() == nil || resp.GetPeer().GetNodeId() != 1 {
+		t.Fatalf("peer summary not attached: %+v", resp.GetPeer())
+	}
+	if resp.GetPeerError() != "" {
+		t.Fatalf("peer_error = %q, want empty on OK", resp.GetPeerError())
+	}
+}
+
+// TestGetSessionSummaryPeerStatusUnreachable is the core #5320 regression: a
+// FAILING peer fetch must be distinguishable from a healthy standalone. The
+// RPC still succeeds with the local totals, but peer_status=UNREACHABLE and
+// peer_error carries the detail.
+//
+// FAIL-ON-REVERT: restoring the slog.Warn-and-swallow leaves peer_status
+// UNSPECIFIED (not UNREACHABLE) and peer_error empty — a peer partition again
+// looks like a healthy standalone.
+func TestGetSessionSummaryPeerStatusUnreachable(t *testing.T) {
+	s := newSummaryFieldsServer(t, &summaryFieldsDP{Manager: dataplane.New()})
+	s.peerSessionSummaryFn = func(context.Context) (*pb.GetSessionSummaryResponse, error) {
+		return nil, errors.New("dial peer node 1: connection refused")
+	}
+
+	resp, err := s.GetSessionSummary(context.Background(), &pb.GetSessionSummaryRequest{IncludePeer: true})
+	if err != nil {
+		t.Fatalf("GetSessionSummary() should still return the local totals, got error = %v", err)
+	}
+	if resp.GetPeerStatus() != pb.PeerFetchStatus_PEER_FETCH_STATUS_UNREACHABLE {
+		t.Fatalf("peer_status = %v, want UNREACHABLE (peer-fetch failure swallowed)", resp.GetPeerStatus())
+	}
+	if resp.GetPeer() != nil {
+		t.Fatal("peer must be nil on an unreachable fetch")
+	}
+	if resp.GetPeerError() == "" {
+		t.Fatal("peer_error empty on UNREACHABLE — the failure detail was dropped")
+	}
+}
+
+// TestGetSessionSummaryPeerStatusNotApplicable asserts a healthy standalone
+// node (no cluster, include_peer requested but no peer to fetch) reports
+// NOT_APPLICABLE — distinct from UNREACHABLE (#5320).
+func TestGetSessionSummaryPeerStatusNotApplicable(t *testing.T) {
+	s := newSummaryFieldsServer(t, &summaryFieldsDP{Manager: dataplane.New()})
+	// No cluster, no seam: proxyPeerSessionSummary returns (nil, nil).
+	resp, err := s.GetSessionSummary(context.Background(), &pb.GetSessionSummaryRequest{IncludePeer: true})
+	if err != nil {
+		t.Fatalf("GetSessionSummary() error = %v", err)
+	}
+	if resp.GetPeerStatus() != pb.PeerFetchStatus_PEER_FETCH_STATUS_NOT_APPLICABLE {
+		t.Fatalf("peer_status = %v, want NOT_APPLICABLE for a standalone node", resp.GetPeerStatus())
+	}
+
+	// include_peer unset also reports NOT_APPLICABLE (no claim about a peer).
+	resp, err = s.GetSessionSummary(context.Background(), &pb.GetSessionSummaryRequest{})
+	if err != nil {
+		t.Fatalf("GetSessionSummary() error = %v", err)
+	}
+	if resp.GetPeerStatus() != pb.PeerFetchStatus_PEER_FETCH_STATUS_NOT_APPLICABLE {
+		t.Fatalf("peer_status = %v, want NOT_APPLICABLE without include_peer", resp.GetPeerStatus())
+	}
+}
+
+// TestGetZonePairSummaryPeerStatusUnreachable asserts the zone-pair RPC also
+// classifies a failed peer fetch as UNREACHABLE instead of swallowing it
+// (#5320), mirroring GetSessionSummary.
+//
+// FAIL-ON-REVERT: reverting the switch to the old "else if peerResp != nil"
+// swallow leaves peer_status UNSPECIFIED.
+func TestGetZonePairSummaryPeerStatusUnreachable(t *testing.T) {
+	s := newZonePairServer(t, &twoZonePairDP{Manager: dataplane.New()})
+	s.peerZonePairSummaryFn = func(context.Context, *pb.GetZonePairSummaryRequest) (*pb.GetZonePairSummaryResponse, error) {
+		return nil, errors.New("peer zone-pair: deadline exceeded")
+	}
+
+	resp, err := s.GetZonePairSummary(context.Background(), &pb.GetZonePairSummaryRequest{IncludePeer: true})
+	if err != nil {
+		t.Fatalf("GetZonePairSummary() error = %v", err)
+	}
+	if resp.GetPeerStatus() != pb.PeerFetchStatus_PEER_FETCH_STATUS_UNREACHABLE {
+		t.Fatalf("peer_status = %v, want UNREACHABLE", resp.GetPeerStatus())
+	}
+	if resp.GetPeerError() == "" {
+		t.Fatal("peer_error empty on UNREACHABLE zone-pair fetch")
+	}
+}
+
+// TestGetZonePairSummaryPeerStatusOKAndNotApplicable asserts the OK (peer
+// attached) and NOT_APPLICABLE (no include_peer) classifications for the
+// zone-pair RPC (#5320).
+func TestGetZonePairSummaryPeerStatusOKAndNotApplicable(t *testing.T) {
+	s := newZonePairServer(t, &twoZonePairDP{Manager: dataplane.New()})
+	s.peerZonePairSummaryFn = func(context.Context, *pb.GetZonePairSummaryRequest) (*pb.GetZonePairSummaryResponse, error) {
+		return &pb.GetZonePairSummaryResponse{NodeId: 1}, nil
+	}
+	resp, err := s.GetZonePairSummary(context.Background(), &pb.GetZonePairSummaryRequest{IncludePeer: true})
+	if err != nil {
+		t.Fatalf("GetZonePairSummary() error = %v", err)
+	}
+	if resp.GetPeerStatus() != pb.PeerFetchStatus_PEER_FETCH_STATUS_OK {
+		t.Fatalf("peer_status = %v, want OK", resp.GetPeerStatus())
+	}
+
+	// No include_peer -> NOT_APPLICABLE.
+	resp, err = s.GetZonePairSummary(context.Background(), &pb.GetZonePairSummaryRequest{})
+	if err != nil {
+		t.Fatalf("GetZonePairSummary() error = %v", err)
+	}
+	if resp.GetPeerStatus() != pb.PeerFetchStatus_PEER_FETCH_STATUS_NOT_APPLICABLE {
+		t.Fatalf("peer_status = %v, want NOT_APPLICABLE without include_peer", resp.GetPeerStatus())
+	}
+}

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -250,6 +250,66 @@ func (HostInboundAdmissionStatus) EnumDescriptor() ([]byte, []int) {
 	return file_xpf_proto_rawDescGZIP(), []int{3}
 }
 
+// PeerFetchStatus classifies whether a summary response's cluster-peer leg was
+// successfully included, so a machine consumer can distinguish a genuine
+// standalone / no-peer-requested view (NOT_APPLICABLE) from a cluster peer that
+// was requested but could NOT be reached (UNREACHABLE). Before #5320 a peer
+// fetch failure was logged and swallowed: the response returned the LOCAL-ONLY
+// totals with peer=nil, indistinguishable from a healthy standalone node — a
+// peer partition then looked like a healthy low session count. UNREACHABLE
+// surfaces the incompleteness while still returning the (useful) local totals.
+type PeerFetchStatus int32
+
+const (
+	PeerFetchStatus_PEER_FETCH_STATUS_UNSPECIFIED    PeerFetchStatus = 0 // not evaluated / older server
+	PeerFetchStatus_PEER_FETCH_STATUS_NOT_APPLICABLE PeerFetchStatus = 1 // standalone, or include_peer not set
+	PeerFetchStatus_PEER_FETCH_STATUS_OK             PeerFetchStatus = 2 // peer requested and its data is included
+	PeerFetchStatus_PEER_FETCH_STATUS_UNREACHABLE    PeerFetchStatus = 3 // peer requested but the fetch failed; peer data omitted
+)
+
+// Enum value maps for PeerFetchStatus.
+var (
+	PeerFetchStatus_name = map[int32]string{
+		0: "PEER_FETCH_STATUS_UNSPECIFIED",
+		1: "PEER_FETCH_STATUS_NOT_APPLICABLE",
+		2: "PEER_FETCH_STATUS_OK",
+		3: "PEER_FETCH_STATUS_UNREACHABLE",
+	}
+	PeerFetchStatus_value = map[string]int32{
+		"PEER_FETCH_STATUS_UNSPECIFIED":    0,
+		"PEER_FETCH_STATUS_NOT_APPLICABLE": 1,
+		"PEER_FETCH_STATUS_OK":             2,
+		"PEER_FETCH_STATUS_UNREACHABLE":    3,
+	}
+)
+
+func (x PeerFetchStatus) Enum() *PeerFetchStatus {
+	p := new(PeerFetchStatus)
+	*p = x
+	return p
+}
+
+func (x PeerFetchStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PeerFetchStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_xpf_proto_enumTypes[4].Descriptor()
+}
+
+func (PeerFetchStatus) Type() protoreflect.EnumType {
+	return &file_xpf_proto_enumTypes[4]
+}
+
+func (x PeerFetchStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PeerFetchStatus.Descriptor instead.
+func (PeerFetchStatus) EnumDescriptor() ([]byte, []int) {
+	return file_xpf_proto_rawDescGZIP(), []int{4}
+}
+
 type EnterConfigureRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Exclusive     bool                   `protobuf:"varint,1,opt,name=exclusive,proto3" json:"exclusive,omitempty"`
@@ -3209,16 +3269,32 @@ func (x *GetSessionSummaryRequest) GetIncludePeer() bool {
 }
 
 type GetSessionSummaryResponse struct {
-	state         protoimpl.MessageState     `protogen:"open.v1"`
-	TotalEntries  int32                      `protobuf:"varint,1,opt,name=total_entries,json=totalEntries,proto3" json:"total_entries,omitempty"`
-	ForwardOnly   int32                      `protobuf:"varint,2,opt,name=forward_only,json=forwardOnly,proto3" json:"forward_only,omitempty"`
-	Established   int32                      `protobuf:"varint,3,opt,name=established,proto3" json:"established,omitempty"`
-	Ipv4Sessions  int32                      `protobuf:"varint,4,opt,name=ipv4_sessions,json=ipv4Sessions,proto3" json:"ipv4_sessions,omitempty"`
-	Ipv6Sessions  int32                      `protobuf:"varint,5,opt,name=ipv6_sessions,json=ipv6Sessions,proto3" json:"ipv6_sessions,omitempty"`
-	SnatSessions  int32                      `protobuf:"varint,6,opt,name=snat_sessions,json=snatSessions,proto3" json:"snat_sessions,omitempty"`
-	DnatSessions  int32                      `protobuf:"varint,7,opt,name=dnat_sessions,json=dnatSessions,proto3" json:"dnat_sessions,omitempty"`
-	NodeId        int32                      `protobuf:"varint,8,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"`
-	Peer          *GetSessionSummaryResponse `protobuf:"bytes,9,opt,name=peer,proto3" json:"peer,omitempty"`
+	state        protoimpl.MessageState     `protogen:"open.v1"`
+	TotalEntries int32                      `protobuf:"varint,1,opt,name=total_entries,json=totalEntries,proto3" json:"total_entries,omitempty"`
+	ForwardOnly  int32                      `protobuf:"varint,2,opt,name=forward_only,json=forwardOnly,proto3" json:"forward_only,omitempty"`
+	Established  int32                      `protobuf:"varint,3,opt,name=established,proto3" json:"established,omitempty"`
+	Ipv4Sessions int32                      `protobuf:"varint,4,opt,name=ipv4_sessions,json=ipv4Sessions,proto3" json:"ipv4_sessions,omitempty"`
+	Ipv6Sessions int32                      `protobuf:"varint,5,opt,name=ipv6_sessions,json=ipv6Sessions,proto3" json:"ipv6_sessions,omitempty"`
+	SnatSessions int32                      `protobuf:"varint,6,opt,name=snat_sessions,json=snatSessions,proto3" json:"snat_sessions,omitempty"`
+	DnatSessions int32                      `protobuf:"varint,7,opt,name=dnat_sessions,json=dnatSessions,proto3" json:"dnat_sessions,omitempty"`
+	NodeId       int32                      `protobuf:"varint,8,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"`
+	Peer         *GetSessionSummaryResponse `protobuf:"bytes,9,opt,name=peer,proto3" json:"peer,omitempty"`
+	// peer_status classifies the include_peer fan-out completeness (#5320): OK
+	// when the peer summary is present under `peer`, UNREACHABLE when the peer
+	// was requested but its fetch failed (the totals here are LOCAL-ONLY and
+	// understate cluster-wide state), NOT_APPLICABLE for a standalone node or an
+	// unset include_peer. Before #5320 a peer-fetch failure was logged and
+	// swallowed, leaving peer=nil — indistinguishable from a healthy standalone.
+	PeerStatus PeerFetchStatus `protobuf:"varint,10,opt,name=peer_status,json=peerStatus,proto3,enum=xpf.v1.PeerFetchStatus" json:"peer_status,omitempty"`
+	// peer_error carries the human-readable peer-fetch failure detail; empty
+	// unless peer_status == UNREACHABLE (#5320).
+	PeerError string `protobuf:"bytes,11,opt,name=peer_error,json=peerError,proto3" json:"peer_error,omitempty"`
+	// max_sessions is the dataplane's dynamic session-table capacity: the live
+	// AF_XDP helper publishes worker_count x per-worker capacity. 0 = unknown
+	// (no userspace status attached), so a consumer must render "unknown" rather
+	// than a fabricated authoritative bound (#5323, replaces the hardcoded
+	// 10000000 the CLI used to print).
+	MaxSessions   uint64 `protobuf:"varint,12,opt,name=max_sessions,json=maxSessions,proto3" json:"max_sessions,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3314,6 +3390,27 @@ func (x *GetSessionSummaryResponse) GetPeer() *GetSessionSummaryResponse {
 		return x.Peer
 	}
 	return nil
+}
+
+func (x *GetSessionSummaryResponse) GetPeerStatus() PeerFetchStatus {
+	if x != nil {
+		return x.PeerStatus
+	}
+	return PeerFetchStatus_PEER_FETCH_STATUS_UNSPECIFIED
+}
+
+func (x *GetSessionSummaryResponse) GetPeerError() string {
+	if x != nil {
+		return x.PeerError
+	}
+	return ""
+}
+
+func (x *GetSessionSummaryResponse) GetMaxSessions() uint64 {
+	if x != nil {
+		return x.MaxSessions
+	}
+	return 0
 }
 
 type GetNATSourceRequest struct {
@@ -7204,10 +7301,16 @@ func (x *NATRuleStats) GetHitBytes() uint64 {
 }
 
 type CompleteRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Line          string                 `protobuf:"bytes,1,opt,name=line,proto3" json:"line,omitempty"`
-	Pos           int32                  `protobuf:"varint,2,opt,name=pos,proto3" json:"pos,omitempty"`
-	ConfigMode    bool                   `protobuf:"varint,3,opt,name=config_mode,json=configMode,proto3" json:"config_mode,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Line  string                 `protobuf:"bytes,1,opt,name=line,proto3" json:"line,omitempty"`
+	// pos is a BYTE offset into line (not a rune/codepoint index): the server's
+	// Complete slices line[:pos]. Callers with a rune-indexed cursor (readline)
+	// MUST convert to the byte length of the prefix before sending, or a
+	// multibyte rune before the cursor makes pos < len(bytes) and the slice cuts
+	// a code point in half. The server rejects a pos that lands mid-rune with
+	// InvalidArgument (#4970).
+	Pos           int32 `protobuf:"varint,2,opt,name=pos,proto3" json:"pos,omitempty"`
+	ConfigMode    bool  `protobuf:"varint,3,opt,name=config_mode,json=configMode,proto3" json:"config_mode,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -7990,10 +8093,15 @@ func (x *ZonePairSessionSummary) GetTotal() int64 {
 }
 
 type GetZonePairSummaryResponse struct {
-	state         protoimpl.MessageState      `protogen:"open.v1"`
-	ZonePairs     []*ZonePairSessionSummary   `protobuf:"bytes,1,rep,name=zone_pairs,json=zonePairs,proto3" json:"zone_pairs,omitempty"`
-	NodeId        int32                       `protobuf:"varint,2,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"` // cluster node ID (0, 1, ...)
-	Peer          *GetZonePairSummaryResponse `protobuf:"bytes,3,opt,name=peer,proto3" json:"peer,omitempty"`                    // peer node breakdown (nil if standalone)
+	state     protoimpl.MessageState      `protogen:"open.v1"`
+	ZonePairs []*ZonePairSessionSummary   `protobuf:"bytes,1,rep,name=zone_pairs,json=zonePairs,proto3" json:"zone_pairs,omitempty"`
+	NodeId    int32                       `protobuf:"varint,2,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"` // cluster node ID (0, 1, ...)
+	Peer      *GetZonePairSummaryResponse `protobuf:"bytes,3,opt,name=peer,proto3" json:"peer,omitempty"`                    // peer node breakdown (nil if standalone)
+	// peer_status / peer_error mirror GetSessionSummaryResponse (#5320): a peer
+	// fetch failure is now VISIBLE (UNREACHABLE) instead of leaving peer=nil and
+	// looking like a healthy standalone breakdown.
+	PeerStatus    PeerFetchStatus `protobuf:"varint,4,opt,name=peer_status,json=peerStatus,proto3,enum=xpf.v1.PeerFetchStatus" json:"peer_status,omitempty"`
+	PeerError     string          `protobuf:"bytes,5,opt,name=peer_error,json=peerError,proto3" json:"peer_error,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -8047,6 +8155,20 @@ func (x *GetZonePairSummaryResponse) GetPeer() *GetZonePairSummaryResponse {
 		return x.Peer
 	}
 	return nil
+}
+
+func (x *GetZonePairSummaryResponse) GetPeerStatus() PeerFetchStatus {
+	if x != nil {
+		return x.PeerStatus
+	}
+	return PeerFetchStatus_PEER_FETCH_STATUS_UNSPECIFIED
+}
+
+func (x *GetZonePairSummaryResponse) GetPeerError() string {
+	if x != nil {
+		return x.PeerError
+	}
+	return ""
 }
 
 var File_xpf_proto protoreflect.FileDescriptor
@@ -8281,7 +8403,7 @@ const file_xpf_proto_rawDesc = "" +
 	"natDstPort\x12\x1b\n" +
 	"\tha_active\x18\x1d \x01(\bR\bhaActive\"=\n" +
 	"\x18GetSessionSummaryRequest\x12!\n" +
-	"\finclude_peer\x18\x01 \x01(\bR\vincludePeer\"\xe9\x02\n" +
+	"\finclude_peer\x18\x01 \x01(\bR\vincludePeer\"\xe5\x03\n" +
 	"\x19GetSessionSummaryResponse\x12#\n" +
 	"\rtotal_entries\x18\x01 \x01(\x05R\ftotalEntries\x12!\n" +
 	"\fforward_only\x18\x02 \x01(\x05R\vforwardOnly\x12 \n" +
@@ -8291,7 +8413,13 @@ const file_xpf_proto_rawDesc = "" +
 	"\rsnat_sessions\x18\x06 \x01(\x05R\fsnatSessions\x12#\n" +
 	"\rdnat_sessions\x18\a \x01(\x05R\fdnatSessions\x12\x17\n" +
 	"\anode_id\x18\b \x01(\x05R\x06nodeId\x125\n" +
-	"\x04peer\x18\t \x01(\v2!.xpf.v1.GetSessionSummaryResponseR\x04peer\"\x15\n" +
+	"\x04peer\x18\t \x01(\v2!.xpf.v1.GetSessionSummaryResponseR\x04peer\x128\n" +
+	"\vpeer_status\x18\n" +
+	" \x01(\x0e2\x17.xpf.v1.PeerFetchStatusR\n" +
+	"peerStatus\x12\x1d\n" +
+	"\n" +
+	"peer_error\x18\v \x01(\tR\tpeerError\x12!\n" +
+	"\fmax_sessions\x18\f \x01(\x04R\vmaxSessions\"\x15\n" +
 	"\x13GetNATSourceRequest\"C\n" +
 	"\x14GetNATSourceResponse\x12+\n" +
 	"\x05rules\x18\x01 \x03(\v2\x15.xpf.v1.NATSourceInfoR\x05rules\"m\n" +
@@ -8632,12 +8760,16 @@ const file_xpf_proto_rawDesc = "" +
 	"\x03udp\x18\x04 \x01(\x03R\x03udp\x12\x12\n" +
 	"\x04icmp\x18\x05 \x01(\x03R\x04icmp\x12\x14\n" +
 	"\x05other\x18\x06 \x01(\x03R\x05other\x12\x14\n" +
-	"\x05total\x18\a \x01(\x03R\x05total\"\xac\x01\n" +
+	"\x05total\x18\a \x01(\x03R\x05total\"\x85\x02\n" +
 	"\x1aGetZonePairSummaryResponse\x12=\n" +
 	"\n" +
 	"zone_pairs\x18\x01 \x03(\v2\x1e.xpf.v1.ZonePairSessionSummaryR\tzonePairs\x12\x17\n" +
 	"\anode_id\x18\x02 \x01(\x05R\x06nodeId\x126\n" +
-	"\x04peer\x18\x03 \x01(\v2\".xpf.v1.GetZonePairSummaryResponseR\x04peer*M\n" +
+	"\x04peer\x18\x03 \x01(\v2\".xpf.v1.GetZonePairSummaryResponseR\x04peer\x128\n" +
+	"\vpeer_status\x18\x04 \x01(\x0e2\x17.xpf.v1.PeerFetchStatusR\n" +
+	"peerStatus\x12\x1d\n" +
+	"\n" +
+	"peer_error\x18\x05 \x01(\tR\tpeerError*M\n" +
 	"\fConfigFormat\x12\x10\n" +
 	"\fHIERARCHICAL\x10\x00\x12\a\n" +
 	"\x03SET\x10\x01\x12\b\n" +
@@ -8659,7 +8791,12 @@ const file_xpf_proto_rawDesc = "" +
 	"+HOST_INBOUND_ADMISSION_STATUS_INDETERMINATE\x10\x01\x12/\n" +
 	"+HOST_INBOUND_ADMISSION_STATUS_GLOBAL_ACCEPT\x10\x02\x12-\n" +
 	")HOST_INBOUND_ADMISSION_STATUS_TOKEN_ADMIT\x10\x03\x12(\n" +
-	"$HOST_INBOUND_ADMISSION_STATUS_DENIED\x10\x042\xae\x1e\n" +
+	"$HOST_INBOUND_ADMISSION_STATUS_DENIED\x10\x04*\x97\x01\n" +
+	"\x0fPeerFetchStatus\x12!\n" +
+	"\x1dPEER_FETCH_STATUS_UNSPECIFIED\x10\x00\x12$\n" +
+	" PEER_FETCH_STATUS_NOT_APPLICABLE\x10\x01\x12\x18\n" +
+	"\x14PEER_FETCH_STATUS_OK\x10\x02\x12!\n" +
+	"\x1dPEER_FETCH_STATUS_UNREACHABLE\x10\x032\xae\x1e\n" +
 	"\fBpfrxService\x12O\n" +
 	"\x0eEnterConfigure\x12\x1d.xpf.v1.EnterConfigureRequest\x1a\x1e.xpf.v1.EnterConfigureResponse\x12L\n" +
 	"\rExitConfigure\x12\x1c.xpf.v1.ExitConfigureRequest\x1a\x1d.xpf.v1.ExitConfigureResponse\x12^\n" +
@@ -8728,279 +8865,282 @@ func file_xpf_proto_rawDescGZIP() []byte {
 	return file_xpf_proto_rawDescData
 }
 
-var file_xpf_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_xpf_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
 var file_xpf_proto_msgTypes = make([]protoimpl.MessageInfo, 125)
 var file_xpf_proto_goTypes = []any{
 	(ConfigFormat)(0),                         // 0: xpf.v1.ConfigFormat
 	(ConfigTarget)(0),                         // 1: xpf.v1.ConfigTarget
 	(MonitorInterfaceSummaryMode)(0),          // 2: xpf.v1.MonitorInterfaceSummaryMode
 	(HostInboundAdmissionStatus)(0),           // 3: xpf.v1.HostInboundAdmissionStatus
-	(*EnterConfigureRequest)(nil),             // 4: xpf.v1.EnterConfigureRequest
-	(*EnterConfigureResponse)(nil),            // 5: xpf.v1.EnterConfigureResponse
-	(*ExitConfigureRequest)(nil),              // 6: xpf.v1.ExitConfigureRequest
-	(*ExitConfigureResponse)(nil),             // 7: xpf.v1.ExitConfigureResponse
-	(*GetConfigModeStatusRequest)(nil),        // 8: xpf.v1.GetConfigModeStatusRequest
-	(*GetConfigModeStatusResponse)(nil),       // 9: xpf.v1.GetConfigModeStatusResponse
-	(*SetRequest)(nil),                        // 10: xpf.v1.SetRequest
-	(*SetResponse)(nil),                       // 11: xpf.v1.SetResponse
-	(*DeleteRequest)(nil),                     // 12: xpf.v1.DeleteRequest
-	(*DeleteResponse)(nil),                    // 13: xpf.v1.DeleteResponse
-	(*LoadRequest)(nil),                       // 14: xpf.v1.LoadRequest
-	(*LoadResponse)(nil),                      // 15: xpf.v1.LoadResponse
-	(*CommitRequest)(nil),                     // 16: xpf.v1.CommitRequest
-	(*CommitResponse)(nil),                    // 17: xpf.v1.CommitResponse
-	(*CommitCheckRequest)(nil),                // 18: xpf.v1.CommitCheckRequest
-	(*CommitCheckResponse)(nil),               // 19: xpf.v1.CommitCheckResponse
-	(*CommitConfirmedRequest)(nil),            // 20: xpf.v1.CommitConfirmedRequest
-	(*CommitConfirmedResponse)(nil),           // 21: xpf.v1.CommitConfirmedResponse
-	(*ConfirmCommitRequest)(nil),              // 22: xpf.v1.ConfirmCommitRequest
-	(*ConfirmCommitResponse)(nil),             // 23: xpf.v1.ConfirmCommitResponse
-	(*RollbackRequest)(nil),                   // 24: xpf.v1.RollbackRequest
-	(*RollbackResponse)(nil),                  // 25: xpf.v1.RollbackResponse
-	(*ShowConfigRequest)(nil),                 // 26: xpf.v1.ShowConfigRequest
-	(*ShowConfigResponse)(nil),                // 27: xpf.v1.ShowConfigResponse
-	(*ShowCompareRequest)(nil),                // 28: xpf.v1.ShowCompareRequest
-	(*ShowCompareResponse)(nil),               // 29: xpf.v1.ShowCompareResponse
-	(*ShowRollbackRequest)(nil),               // 30: xpf.v1.ShowRollbackRequest
-	(*ShowRollbackResponse)(nil),              // 31: xpf.v1.ShowRollbackResponse
-	(*ListHistoryRequest)(nil),                // 32: xpf.v1.ListHistoryRequest
-	(*ListHistoryResponse)(nil),               // 33: xpf.v1.ListHistoryResponse
-	(*HistoryEntry)(nil),                      // 34: xpf.v1.HistoryEntry
-	(*GetStatusRequest)(nil),                  // 35: xpf.v1.GetStatusRequest
-	(*GetStatusResponse)(nil),                 // 36: xpf.v1.GetStatusResponse
-	(*GetGlobalStatsRequest)(nil),             // 37: xpf.v1.GetGlobalStatsRequest
-	(*GetGlobalStatsResponse)(nil),            // 38: xpf.v1.GetGlobalStatsResponse
-	(*GetZonesRequest)(nil),                   // 39: xpf.v1.GetZonesRequest
-	(*GetZonesResponse)(nil),                  // 40: xpf.v1.GetZonesResponse
-	(*ZoneInfo)(nil),                          // 41: xpf.v1.ZoneInfo
-	(*InterfaceHostInbound)(nil),              // 42: xpf.v1.InterfaceHostInbound
-	(*GetPoliciesRequest)(nil),                // 43: xpf.v1.GetPoliciesRequest
-	(*GetPoliciesResponse)(nil),               // 44: xpf.v1.GetPoliciesResponse
-	(*PolicyInfo)(nil),                        // 45: xpf.v1.PolicyInfo
-	(*PolicyRule)(nil),                        // 46: xpf.v1.PolicyRule
-	(*GetSessionsRequest)(nil),                // 47: xpf.v1.GetSessionsRequest
-	(*GetSessionsResponse)(nil),               // 48: xpf.v1.GetSessionsResponse
-	(*SessionEntry)(nil),                      // 49: xpf.v1.SessionEntry
-	(*GetSessionSummaryRequest)(nil),          // 50: xpf.v1.GetSessionSummaryRequest
-	(*GetSessionSummaryResponse)(nil),         // 51: xpf.v1.GetSessionSummaryResponse
-	(*GetNATSourceRequest)(nil),               // 52: xpf.v1.GetNATSourceRequest
-	(*GetNATSourceResponse)(nil),              // 53: xpf.v1.GetNATSourceResponse
-	(*NATSourceInfo)(nil),                     // 54: xpf.v1.NATSourceInfo
-	(*GetNATDestinationRequest)(nil),          // 55: xpf.v1.GetNATDestinationRequest
-	(*GetNATDestinationResponse)(nil),         // 56: xpf.v1.GetNATDestinationResponse
-	(*NATDestInfo)(nil),                       // 57: xpf.v1.NATDestInfo
-	(*GetScreenRequest)(nil),                  // 58: xpf.v1.GetScreenRequest
-	(*GetScreenResponse)(nil),                 // 59: xpf.v1.GetScreenResponse
-	(*ScreenInfo)(nil),                        // 60: xpf.v1.ScreenInfo
-	(*GetEventsRequest)(nil),                  // 61: xpf.v1.GetEventsRequest
-	(*GetEventsResponse)(nil),                 // 62: xpf.v1.GetEventsResponse
-	(*EventEntry)(nil),                        // 63: xpf.v1.EventEntry
-	(*GetInterfacesRequest)(nil),              // 64: xpf.v1.GetInterfacesRequest
-	(*GetInterfacesResponse)(nil),             // 65: xpf.v1.GetInterfacesResponse
-	(*InterfaceInfo)(nil),                     // 66: xpf.v1.InterfaceInfo
-	(*ShowInterfacesDetailRequest)(nil),       // 67: xpf.v1.ShowInterfacesDetailRequest
-	(*ShowInterfacesDetailResponse)(nil),      // 68: xpf.v1.ShowInterfacesDetailResponse
-	(*GetDHCPLeasesRequest)(nil),              // 69: xpf.v1.GetDHCPLeasesRequest
-	(*GetDHCPLeasesResponse)(nil),             // 70: xpf.v1.GetDHCPLeasesResponse
-	(*DHCPLeaseInfo)(nil),                     // 71: xpf.v1.DHCPLeaseInfo
-	(*DHCPDelegatedPrefix)(nil),               // 72: xpf.v1.DHCPDelegatedPrefix
-	(*GetDHCPClientIdentifiersRequest)(nil),   // 73: xpf.v1.GetDHCPClientIdentifiersRequest
-	(*GetDHCPClientIdentifiersResponse)(nil),  // 74: xpf.v1.GetDHCPClientIdentifiersResponse
-	(*DHCPClientIdentifierInfo)(nil),          // 75: xpf.v1.DHCPClientIdentifierInfo
-	(*ClearDHCPClientIdentifierRequest)(nil),  // 76: xpf.v1.ClearDHCPClientIdentifierRequest
-	(*ClearDHCPClientIdentifierResponse)(nil), // 77: xpf.v1.ClearDHCPClientIdentifierResponse
-	(*GetRoutesRequest)(nil),                  // 78: xpf.v1.GetRoutesRequest
-	(*GetRoutesResponse)(nil),                 // 79: xpf.v1.GetRoutesResponse
-	(*RouteInfo)(nil),                         // 80: xpf.v1.RouteInfo
-	(*GetOSPFStatusRequest)(nil),              // 81: xpf.v1.GetOSPFStatusRequest
-	(*GetOSPFStatusResponse)(nil),             // 82: xpf.v1.GetOSPFStatusResponse
-	(*GetBGPStatusRequest)(nil),               // 83: xpf.v1.GetBGPStatusRequest
-	(*GetBGPStatusResponse)(nil),              // 84: xpf.v1.GetBGPStatusResponse
-	(*GetRIPStatusRequest)(nil),               // 85: xpf.v1.GetRIPStatusRequest
-	(*GetRIPStatusResponse)(nil),              // 86: xpf.v1.GetRIPStatusResponse
-	(*GetISISStatusRequest)(nil),              // 87: xpf.v1.GetISISStatusRequest
-	(*GetISISStatusResponse)(nil),             // 88: xpf.v1.GetISISStatusResponse
-	(*GetIPsecSARequest)(nil),                 // 89: xpf.v1.GetIPsecSARequest
-	(*GetIPsecSAResponse)(nil),                // 90: xpf.v1.GetIPsecSAResponse
-	(*PingRequest)(nil),                       // 91: xpf.v1.PingRequest
-	(*PingResponse)(nil),                      // 92: xpf.v1.PingResponse
-	(*TracerouteRequest)(nil),                 // 93: xpf.v1.TracerouteRequest
-	(*TracerouteResponse)(nil),                // 94: xpf.v1.TracerouteResponse
-	(*ClearSessionsRequest)(nil),              // 95: xpf.v1.ClearSessionsRequest
-	(*ClearSessionsResponse)(nil),             // 96: xpf.v1.ClearSessionsResponse
-	(*ClearCountersRequest)(nil),              // 97: xpf.v1.ClearCountersRequest
-	(*ClearCountersResponse)(nil),             // 98: xpf.v1.ClearCountersResponse
-	(*GetNATPoolStatsRequest)(nil),            // 99: xpf.v1.GetNATPoolStatsRequest
-	(*GetNATPoolStatsResponse)(nil),           // 100: xpf.v1.GetNATPoolStatsResponse
-	(*NATPoolStats)(nil),                      // 101: xpf.v1.NATPoolStats
-	(*NATRuleSetSessions)(nil),                // 102: xpf.v1.NATRuleSetSessions
-	(*GetVRRPStatusRequest)(nil),              // 103: xpf.v1.GetVRRPStatusRequest
-	(*GetVRRPStatusResponse)(nil),             // 104: xpf.v1.GetVRRPStatusResponse
-	(*VRRPInstanceInfo)(nil),                  // 105: xpf.v1.VRRPInstanceInfo
-	(*MatchPoliciesRequest)(nil),              // 106: xpf.v1.MatchPoliciesRequest
-	(*MatchPoliciesResponse)(nil),             // 107: xpf.v1.MatchPoliciesResponse
-	(*HostInboundAdmission)(nil),              // 108: xpf.v1.HostInboundAdmission
-	(*GetNATRuleStatsRequest)(nil),            // 109: xpf.v1.GetNATRuleStatsRequest
-	(*GetNATRuleStatsResponse)(nil),           // 110: xpf.v1.GetNATRuleStatsResponse
-	(*NATRuleStats)(nil),                      // 111: xpf.v1.NATRuleStats
-	(*CompleteRequest)(nil),                   // 112: xpf.v1.CompleteRequest
-	(*CompleteResponse)(nil),                  // 113: xpf.v1.CompleteResponse
-	(*ShowTextRequest)(nil),                   // 114: xpf.v1.ShowTextRequest
-	(*ShowTextResponse)(nil),                  // 115: xpf.v1.ShowTextResponse
-	(*GetSystemInfoRequest)(nil),              // 116: xpf.v1.GetSystemInfoRequest
-	(*GetSystemInfoResponse)(nil),             // 117: xpf.v1.GetSystemInfoResponse
-	(*SystemActionRequest)(nil),               // 118: xpf.v1.SystemActionRequest
-	(*SystemActionResponse)(nil),              // 119: xpf.v1.SystemActionResponse
-	(*MonitorPacketDropRequest)(nil),          // 120: xpf.v1.MonitorPacketDropRequest
-	(*MonitorPacketDropResponse)(nil),         // 121: xpf.v1.MonitorPacketDropResponse
-	(*MonitorInterfaceRequest)(nil),           // 122: xpf.v1.MonitorInterfaceRequest
-	(*MonitorInterfaceResponse)(nil),          // 123: xpf.v1.MonitorInterfaceResponse
-	(*GetZonePairSummaryRequest)(nil),         // 124: xpf.v1.GetZonePairSummaryRequest
-	(*ZonePairSessionSummary)(nil),            // 125: xpf.v1.ZonePairSessionSummary
-	(*GetZonePairSummaryResponse)(nil),        // 126: xpf.v1.GetZonePairSummaryResponse
-	nil,                                       // 127: xpf.v1.GetGlobalStatsResponse.ScreenDropDetailsEntry
-	nil,                                       // 128: xpf.v1.ScreenInfo.ThresholdsEntry
+	(PeerFetchStatus)(0),                      // 4: xpf.v1.PeerFetchStatus
+	(*EnterConfigureRequest)(nil),             // 5: xpf.v1.EnterConfigureRequest
+	(*EnterConfigureResponse)(nil),            // 6: xpf.v1.EnterConfigureResponse
+	(*ExitConfigureRequest)(nil),              // 7: xpf.v1.ExitConfigureRequest
+	(*ExitConfigureResponse)(nil),             // 8: xpf.v1.ExitConfigureResponse
+	(*GetConfigModeStatusRequest)(nil),        // 9: xpf.v1.GetConfigModeStatusRequest
+	(*GetConfigModeStatusResponse)(nil),       // 10: xpf.v1.GetConfigModeStatusResponse
+	(*SetRequest)(nil),                        // 11: xpf.v1.SetRequest
+	(*SetResponse)(nil),                       // 12: xpf.v1.SetResponse
+	(*DeleteRequest)(nil),                     // 13: xpf.v1.DeleteRequest
+	(*DeleteResponse)(nil),                    // 14: xpf.v1.DeleteResponse
+	(*LoadRequest)(nil),                       // 15: xpf.v1.LoadRequest
+	(*LoadResponse)(nil),                      // 16: xpf.v1.LoadResponse
+	(*CommitRequest)(nil),                     // 17: xpf.v1.CommitRequest
+	(*CommitResponse)(nil),                    // 18: xpf.v1.CommitResponse
+	(*CommitCheckRequest)(nil),                // 19: xpf.v1.CommitCheckRequest
+	(*CommitCheckResponse)(nil),               // 20: xpf.v1.CommitCheckResponse
+	(*CommitConfirmedRequest)(nil),            // 21: xpf.v1.CommitConfirmedRequest
+	(*CommitConfirmedResponse)(nil),           // 22: xpf.v1.CommitConfirmedResponse
+	(*ConfirmCommitRequest)(nil),              // 23: xpf.v1.ConfirmCommitRequest
+	(*ConfirmCommitResponse)(nil),             // 24: xpf.v1.ConfirmCommitResponse
+	(*RollbackRequest)(nil),                   // 25: xpf.v1.RollbackRequest
+	(*RollbackResponse)(nil),                  // 26: xpf.v1.RollbackResponse
+	(*ShowConfigRequest)(nil),                 // 27: xpf.v1.ShowConfigRequest
+	(*ShowConfigResponse)(nil),                // 28: xpf.v1.ShowConfigResponse
+	(*ShowCompareRequest)(nil),                // 29: xpf.v1.ShowCompareRequest
+	(*ShowCompareResponse)(nil),               // 30: xpf.v1.ShowCompareResponse
+	(*ShowRollbackRequest)(nil),               // 31: xpf.v1.ShowRollbackRequest
+	(*ShowRollbackResponse)(nil),              // 32: xpf.v1.ShowRollbackResponse
+	(*ListHistoryRequest)(nil),                // 33: xpf.v1.ListHistoryRequest
+	(*ListHistoryResponse)(nil),               // 34: xpf.v1.ListHistoryResponse
+	(*HistoryEntry)(nil),                      // 35: xpf.v1.HistoryEntry
+	(*GetStatusRequest)(nil),                  // 36: xpf.v1.GetStatusRequest
+	(*GetStatusResponse)(nil),                 // 37: xpf.v1.GetStatusResponse
+	(*GetGlobalStatsRequest)(nil),             // 38: xpf.v1.GetGlobalStatsRequest
+	(*GetGlobalStatsResponse)(nil),            // 39: xpf.v1.GetGlobalStatsResponse
+	(*GetZonesRequest)(nil),                   // 40: xpf.v1.GetZonesRequest
+	(*GetZonesResponse)(nil),                  // 41: xpf.v1.GetZonesResponse
+	(*ZoneInfo)(nil),                          // 42: xpf.v1.ZoneInfo
+	(*InterfaceHostInbound)(nil),              // 43: xpf.v1.InterfaceHostInbound
+	(*GetPoliciesRequest)(nil),                // 44: xpf.v1.GetPoliciesRequest
+	(*GetPoliciesResponse)(nil),               // 45: xpf.v1.GetPoliciesResponse
+	(*PolicyInfo)(nil),                        // 46: xpf.v1.PolicyInfo
+	(*PolicyRule)(nil),                        // 47: xpf.v1.PolicyRule
+	(*GetSessionsRequest)(nil),                // 48: xpf.v1.GetSessionsRequest
+	(*GetSessionsResponse)(nil),               // 49: xpf.v1.GetSessionsResponse
+	(*SessionEntry)(nil),                      // 50: xpf.v1.SessionEntry
+	(*GetSessionSummaryRequest)(nil),          // 51: xpf.v1.GetSessionSummaryRequest
+	(*GetSessionSummaryResponse)(nil),         // 52: xpf.v1.GetSessionSummaryResponse
+	(*GetNATSourceRequest)(nil),               // 53: xpf.v1.GetNATSourceRequest
+	(*GetNATSourceResponse)(nil),              // 54: xpf.v1.GetNATSourceResponse
+	(*NATSourceInfo)(nil),                     // 55: xpf.v1.NATSourceInfo
+	(*GetNATDestinationRequest)(nil),          // 56: xpf.v1.GetNATDestinationRequest
+	(*GetNATDestinationResponse)(nil),         // 57: xpf.v1.GetNATDestinationResponse
+	(*NATDestInfo)(nil),                       // 58: xpf.v1.NATDestInfo
+	(*GetScreenRequest)(nil),                  // 59: xpf.v1.GetScreenRequest
+	(*GetScreenResponse)(nil),                 // 60: xpf.v1.GetScreenResponse
+	(*ScreenInfo)(nil),                        // 61: xpf.v1.ScreenInfo
+	(*GetEventsRequest)(nil),                  // 62: xpf.v1.GetEventsRequest
+	(*GetEventsResponse)(nil),                 // 63: xpf.v1.GetEventsResponse
+	(*EventEntry)(nil),                        // 64: xpf.v1.EventEntry
+	(*GetInterfacesRequest)(nil),              // 65: xpf.v1.GetInterfacesRequest
+	(*GetInterfacesResponse)(nil),             // 66: xpf.v1.GetInterfacesResponse
+	(*InterfaceInfo)(nil),                     // 67: xpf.v1.InterfaceInfo
+	(*ShowInterfacesDetailRequest)(nil),       // 68: xpf.v1.ShowInterfacesDetailRequest
+	(*ShowInterfacesDetailResponse)(nil),      // 69: xpf.v1.ShowInterfacesDetailResponse
+	(*GetDHCPLeasesRequest)(nil),              // 70: xpf.v1.GetDHCPLeasesRequest
+	(*GetDHCPLeasesResponse)(nil),             // 71: xpf.v1.GetDHCPLeasesResponse
+	(*DHCPLeaseInfo)(nil),                     // 72: xpf.v1.DHCPLeaseInfo
+	(*DHCPDelegatedPrefix)(nil),               // 73: xpf.v1.DHCPDelegatedPrefix
+	(*GetDHCPClientIdentifiersRequest)(nil),   // 74: xpf.v1.GetDHCPClientIdentifiersRequest
+	(*GetDHCPClientIdentifiersResponse)(nil),  // 75: xpf.v1.GetDHCPClientIdentifiersResponse
+	(*DHCPClientIdentifierInfo)(nil),          // 76: xpf.v1.DHCPClientIdentifierInfo
+	(*ClearDHCPClientIdentifierRequest)(nil),  // 77: xpf.v1.ClearDHCPClientIdentifierRequest
+	(*ClearDHCPClientIdentifierResponse)(nil), // 78: xpf.v1.ClearDHCPClientIdentifierResponse
+	(*GetRoutesRequest)(nil),                  // 79: xpf.v1.GetRoutesRequest
+	(*GetRoutesResponse)(nil),                 // 80: xpf.v1.GetRoutesResponse
+	(*RouteInfo)(nil),                         // 81: xpf.v1.RouteInfo
+	(*GetOSPFStatusRequest)(nil),              // 82: xpf.v1.GetOSPFStatusRequest
+	(*GetOSPFStatusResponse)(nil),             // 83: xpf.v1.GetOSPFStatusResponse
+	(*GetBGPStatusRequest)(nil),               // 84: xpf.v1.GetBGPStatusRequest
+	(*GetBGPStatusResponse)(nil),              // 85: xpf.v1.GetBGPStatusResponse
+	(*GetRIPStatusRequest)(nil),               // 86: xpf.v1.GetRIPStatusRequest
+	(*GetRIPStatusResponse)(nil),              // 87: xpf.v1.GetRIPStatusResponse
+	(*GetISISStatusRequest)(nil),              // 88: xpf.v1.GetISISStatusRequest
+	(*GetISISStatusResponse)(nil),             // 89: xpf.v1.GetISISStatusResponse
+	(*GetIPsecSARequest)(nil),                 // 90: xpf.v1.GetIPsecSARequest
+	(*GetIPsecSAResponse)(nil),                // 91: xpf.v1.GetIPsecSAResponse
+	(*PingRequest)(nil),                       // 92: xpf.v1.PingRequest
+	(*PingResponse)(nil),                      // 93: xpf.v1.PingResponse
+	(*TracerouteRequest)(nil),                 // 94: xpf.v1.TracerouteRequest
+	(*TracerouteResponse)(nil),                // 95: xpf.v1.TracerouteResponse
+	(*ClearSessionsRequest)(nil),              // 96: xpf.v1.ClearSessionsRequest
+	(*ClearSessionsResponse)(nil),             // 97: xpf.v1.ClearSessionsResponse
+	(*ClearCountersRequest)(nil),              // 98: xpf.v1.ClearCountersRequest
+	(*ClearCountersResponse)(nil),             // 99: xpf.v1.ClearCountersResponse
+	(*GetNATPoolStatsRequest)(nil),            // 100: xpf.v1.GetNATPoolStatsRequest
+	(*GetNATPoolStatsResponse)(nil),           // 101: xpf.v1.GetNATPoolStatsResponse
+	(*NATPoolStats)(nil),                      // 102: xpf.v1.NATPoolStats
+	(*NATRuleSetSessions)(nil),                // 103: xpf.v1.NATRuleSetSessions
+	(*GetVRRPStatusRequest)(nil),              // 104: xpf.v1.GetVRRPStatusRequest
+	(*GetVRRPStatusResponse)(nil),             // 105: xpf.v1.GetVRRPStatusResponse
+	(*VRRPInstanceInfo)(nil),                  // 106: xpf.v1.VRRPInstanceInfo
+	(*MatchPoliciesRequest)(nil),              // 107: xpf.v1.MatchPoliciesRequest
+	(*MatchPoliciesResponse)(nil),             // 108: xpf.v1.MatchPoliciesResponse
+	(*HostInboundAdmission)(nil),              // 109: xpf.v1.HostInboundAdmission
+	(*GetNATRuleStatsRequest)(nil),            // 110: xpf.v1.GetNATRuleStatsRequest
+	(*GetNATRuleStatsResponse)(nil),           // 111: xpf.v1.GetNATRuleStatsResponse
+	(*NATRuleStats)(nil),                      // 112: xpf.v1.NATRuleStats
+	(*CompleteRequest)(nil),                   // 113: xpf.v1.CompleteRequest
+	(*CompleteResponse)(nil),                  // 114: xpf.v1.CompleteResponse
+	(*ShowTextRequest)(nil),                   // 115: xpf.v1.ShowTextRequest
+	(*ShowTextResponse)(nil),                  // 116: xpf.v1.ShowTextResponse
+	(*GetSystemInfoRequest)(nil),              // 117: xpf.v1.GetSystemInfoRequest
+	(*GetSystemInfoResponse)(nil),             // 118: xpf.v1.GetSystemInfoResponse
+	(*SystemActionRequest)(nil),               // 119: xpf.v1.SystemActionRequest
+	(*SystemActionResponse)(nil),              // 120: xpf.v1.SystemActionResponse
+	(*MonitorPacketDropRequest)(nil),          // 121: xpf.v1.MonitorPacketDropRequest
+	(*MonitorPacketDropResponse)(nil),         // 122: xpf.v1.MonitorPacketDropResponse
+	(*MonitorInterfaceRequest)(nil),           // 123: xpf.v1.MonitorInterfaceRequest
+	(*MonitorInterfaceResponse)(nil),          // 124: xpf.v1.MonitorInterfaceResponse
+	(*GetZonePairSummaryRequest)(nil),         // 125: xpf.v1.GetZonePairSummaryRequest
+	(*ZonePairSessionSummary)(nil),            // 126: xpf.v1.ZonePairSessionSummary
+	(*GetZonePairSummaryResponse)(nil),        // 127: xpf.v1.GetZonePairSummaryResponse
+	nil,                                       // 128: xpf.v1.GetGlobalStatsResponse.ScreenDropDetailsEntry
+	nil,                                       // 129: xpf.v1.ScreenInfo.ThresholdsEntry
 }
 var file_xpf_proto_depIdxs = []int32{
 	0,   // 0: xpf.v1.ShowConfigRequest.format:type_name -> xpf.v1.ConfigFormat
 	1,   // 1: xpf.v1.ShowConfigRequest.target:type_name -> xpf.v1.ConfigTarget
 	0,   // 2: xpf.v1.ShowRollbackRequest.format:type_name -> xpf.v1.ConfigFormat
-	34,  // 3: xpf.v1.ListHistoryResponse.entries:type_name -> xpf.v1.HistoryEntry
-	127, // 4: xpf.v1.GetGlobalStatsResponse.screen_drop_details:type_name -> xpf.v1.GetGlobalStatsResponse.ScreenDropDetailsEntry
-	41,  // 5: xpf.v1.GetZonesResponse.zones:type_name -> xpf.v1.ZoneInfo
-	42,  // 6: xpf.v1.ZoneInfo.interface_host_inbound:type_name -> xpf.v1.InterfaceHostInbound
-	45,  // 7: xpf.v1.GetPoliciesResponse.policies:type_name -> xpf.v1.PolicyInfo
-	46,  // 8: xpf.v1.PolicyInfo.rules:type_name -> xpf.v1.PolicyRule
-	49,  // 9: xpf.v1.GetSessionsResponse.sessions:type_name -> xpf.v1.SessionEntry
-	48,  // 10: xpf.v1.GetSessionsResponse.peer:type_name -> xpf.v1.GetSessionsResponse
-	51,  // 11: xpf.v1.GetSessionSummaryResponse.peer:type_name -> xpf.v1.GetSessionSummaryResponse
-	54,  // 12: xpf.v1.GetNATSourceResponse.rules:type_name -> xpf.v1.NATSourceInfo
-	57,  // 13: xpf.v1.GetNATDestinationResponse.rules:type_name -> xpf.v1.NATDestInfo
-	102, // 14: xpf.v1.GetNATDestinationResponse.rule_set_sessions:type_name -> xpf.v1.NATRuleSetSessions
-	60,  // 15: xpf.v1.GetScreenResponse.screens:type_name -> xpf.v1.ScreenInfo
-	128, // 16: xpf.v1.ScreenInfo.thresholds:type_name -> xpf.v1.ScreenInfo.ThresholdsEntry
-	63,  // 17: xpf.v1.GetEventsResponse.events:type_name -> xpf.v1.EventEntry
-	66,  // 18: xpf.v1.GetInterfacesResponse.interfaces:type_name -> xpf.v1.InterfaceInfo
-	71,  // 19: xpf.v1.GetDHCPLeasesResponse.leases:type_name -> xpf.v1.DHCPLeaseInfo
-	72,  // 20: xpf.v1.DHCPLeaseInfo.delegated_prefixes:type_name -> xpf.v1.DHCPDelegatedPrefix
-	75,  // 21: xpf.v1.GetDHCPClientIdentifiersResponse.identifiers:type_name -> xpf.v1.DHCPClientIdentifierInfo
-	80,  // 22: xpf.v1.GetRoutesResponse.routes:type_name -> xpf.v1.RouteInfo
-	101, // 23: xpf.v1.GetNATPoolStatsResponse.pools:type_name -> xpf.v1.NATPoolStats
-	102, // 24: xpf.v1.GetNATPoolStatsResponse.rule_set_sessions:type_name -> xpf.v1.NATRuleSetSessions
-	105, // 25: xpf.v1.GetVRRPStatusResponse.instances:type_name -> xpf.v1.VRRPInstanceInfo
-	108, // 26: xpf.v1.MatchPoliciesResponse.host_inbound:type_name -> xpf.v1.HostInboundAdmission
-	3,   // 27: xpf.v1.HostInboundAdmission.status:type_name -> xpf.v1.HostInboundAdmissionStatus
-	111, // 28: xpf.v1.GetNATRuleStatsResponse.rules:type_name -> xpf.v1.NATRuleStats
-	2,   // 29: xpf.v1.MonitorInterfaceRequest.summary_mode:type_name -> xpf.v1.MonitorInterfaceSummaryMode
-	125, // 30: xpf.v1.GetZonePairSummaryResponse.zone_pairs:type_name -> xpf.v1.ZonePairSessionSummary
-	126, // 31: xpf.v1.GetZonePairSummaryResponse.peer:type_name -> xpf.v1.GetZonePairSummaryResponse
-	4,   // 32: xpf.v1.BpfrxService.EnterConfigure:input_type -> xpf.v1.EnterConfigureRequest
-	6,   // 33: xpf.v1.BpfrxService.ExitConfigure:input_type -> xpf.v1.ExitConfigureRequest
-	8,   // 34: xpf.v1.BpfrxService.GetConfigModeStatus:input_type -> xpf.v1.GetConfigModeStatusRequest
-	10,  // 35: xpf.v1.BpfrxService.Set:input_type -> xpf.v1.SetRequest
-	12,  // 36: xpf.v1.BpfrxService.Delete:input_type -> xpf.v1.DeleteRequest
-	14,  // 37: xpf.v1.BpfrxService.Load:input_type -> xpf.v1.LoadRequest
-	16,  // 38: xpf.v1.BpfrxService.Commit:input_type -> xpf.v1.CommitRequest
-	18,  // 39: xpf.v1.BpfrxService.CommitCheck:input_type -> xpf.v1.CommitCheckRequest
-	20,  // 40: xpf.v1.BpfrxService.CommitConfirmed:input_type -> xpf.v1.CommitConfirmedRequest
-	22,  // 41: xpf.v1.BpfrxService.ConfirmCommit:input_type -> xpf.v1.ConfirmCommitRequest
-	24,  // 42: xpf.v1.BpfrxService.Rollback:input_type -> xpf.v1.RollbackRequest
-	26,  // 43: xpf.v1.BpfrxService.ShowConfig:input_type -> xpf.v1.ShowConfigRequest
-	28,  // 44: xpf.v1.BpfrxService.ShowCompare:input_type -> xpf.v1.ShowCompareRequest
-	30,  // 45: xpf.v1.BpfrxService.ShowRollback:input_type -> xpf.v1.ShowRollbackRequest
-	32,  // 46: xpf.v1.BpfrxService.ListHistory:input_type -> xpf.v1.ListHistoryRequest
-	35,  // 47: xpf.v1.BpfrxService.GetStatus:input_type -> xpf.v1.GetStatusRequest
-	37,  // 48: xpf.v1.BpfrxService.GetGlobalStats:input_type -> xpf.v1.GetGlobalStatsRequest
-	39,  // 49: xpf.v1.BpfrxService.GetZones:input_type -> xpf.v1.GetZonesRequest
-	43,  // 50: xpf.v1.BpfrxService.GetPolicies:input_type -> xpf.v1.GetPoliciesRequest
-	47,  // 51: xpf.v1.BpfrxService.GetSessions:input_type -> xpf.v1.GetSessionsRequest
-	50,  // 52: xpf.v1.BpfrxService.GetSessionSummary:input_type -> xpf.v1.GetSessionSummaryRequest
-	124, // 53: xpf.v1.BpfrxService.GetZonePairSummary:input_type -> xpf.v1.GetZonePairSummaryRequest
-	52,  // 54: xpf.v1.BpfrxService.GetNATSource:input_type -> xpf.v1.GetNATSourceRequest
-	55,  // 55: xpf.v1.BpfrxService.GetNATDestination:input_type -> xpf.v1.GetNATDestinationRequest
-	58,  // 56: xpf.v1.BpfrxService.GetScreen:input_type -> xpf.v1.GetScreenRequest
-	61,  // 57: xpf.v1.BpfrxService.GetEvents:input_type -> xpf.v1.GetEventsRequest
-	64,  // 58: xpf.v1.BpfrxService.GetInterfaces:input_type -> xpf.v1.GetInterfacesRequest
-	67,  // 59: xpf.v1.BpfrxService.ShowInterfacesDetail:input_type -> xpf.v1.ShowInterfacesDetailRequest
-	69,  // 60: xpf.v1.BpfrxService.GetDHCPLeases:input_type -> xpf.v1.GetDHCPLeasesRequest
-	73,  // 61: xpf.v1.BpfrxService.GetDHCPClientIdentifiers:input_type -> xpf.v1.GetDHCPClientIdentifiersRequest
-	78,  // 62: xpf.v1.BpfrxService.GetRoutes:input_type -> xpf.v1.GetRoutesRequest
-	81,  // 63: xpf.v1.BpfrxService.GetOSPFStatus:input_type -> xpf.v1.GetOSPFStatusRequest
-	83,  // 64: xpf.v1.BpfrxService.GetBGPStatus:input_type -> xpf.v1.GetBGPStatusRequest
-	85,  // 65: xpf.v1.BpfrxService.GetRIPStatus:input_type -> xpf.v1.GetRIPStatusRequest
-	87,  // 66: xpf.v1.BpfrxService.GetISISStatus:input_type -> xpf.v1.GetISISStatusRequest
-	89,  // 67: xpf.v1.BpfrxService.GetIPsecSA:input_type -> xpf.v1.GetIPsecSARequest
-	99,  // 68: xpf.v1.BpfrxService.GetNATPoolStats:input_type -> xpf.v1.GetNATPoolStatsRequest
-	109, // 69: xpf.v1.BpfrxService.GetNATRuleStats:input_type -> xpf.v1.GetNATRuleStatsRequest
-	103, // 70: xpf.v1.BpfrxService.GetVRRPStatus:input_type -> xpf.v1.GetVRRPStatusRequest
-	106, // 71: xpf.v1.BpfrxService.MatchPolicies:input_type -> xpf.v1.MatchPoliciesRequest
-	91,  // 72: xpf.v1.BpfrxService.Ping:input_type -> xpf.v1.PingRequest
-	93,  // 73: xpf.v1.BpfrxService.Traceroute:input_type -> xpf.v1.TracerouteRequest
-	120, // 74: xpf.v1.BpfrxService.MonitorPacketDrop:input_type -> xpf.v1.MonitorPacketDropRequest
-	122, // 75: xpf.v1.BpfrxService.MonitorInterface:input_type -> xpf.v1.MonitorInterfaceRequest
-	95,  // 76: xpf.v1.BpfrxService.ClearSessions:input_type -> xpf.v1.ClearSessionsRequest
-	97,  // 77: xpf.v1.BpfrxService.ClearCounters:input_type -> xpf.v1.ClearCountersRequest
-	76,  // 78: xpf.v1.BpfrxService.ClearDHCPClientIdentifier:input_type -> xpf.v1.ClearDHCPClientIdentifierRequest
-	114, // 79: xpf.v1.BpfrxService.ShowText:input_type -> xpf.v1.ShowTextRequest
-	116, // 80: xpf.v1.BpfrxService.GetSystemInfo:input_type -> xpf.v1.GetSystemInfoRequest
-	118, // 81: xpf.v1.BpfrxService.SystemAction:input_type -> xpf.v1.SystemActionRequest
-	112, // 82: xpf.v1.BpfrxService.Complete:input_type -> xpf.v1.CompleteRequest
-	5,   // 83: xpf.v1.BpfrxService.EnterConfigure:output_type -> xpf.v1.EnterConfigureResponse
-	7,   // 84: xpf.v1.BpfrxService.ExitConfigure:output_type -> xpf.v1.ExitConfigureResponse
-	9,   // 85: xpf.v1.BpfrxService.GetConfigModeStatus:output_type -> xpf.v1.GetConfigModeStatusResponse
-	11,  // 86: xpf.v1.BpfrxService.Set:output_type -> xpf.v1.SetResponse
-	13,  // 87: xpf.v1.BpfrxService.Delete:output_type -> xpf.v1.DeleteResponse
-	15,  // 88: xpf.v1.BpfrxService.Load:output_type -> xpf.v1.LoadResponse
-	17,  // 89: xpf.v1.BpfrxService.Commit:output_type -> xpf.v1.CommitResponse
-	19,  // 90: xpf.v1.BpfrxService.CommitCheck:output_type -> xpf.v1.CommitCheckResponse
-	21,  // 91: xpf.v1.BpfrxService.CommitConfirmed:output_type -> xpf.v1.CommitConfirmedResponse
-	23,  // 92: xpf.v1.BpfrxService.ConfirmCommit:output_type -> xpf.v1.ConfirmCommitResponse
-	25,  // 93: xpf.v1.BpfrxService.Rollback:output_type -> xpf.v1.RollbackResponse
-	27,  // 94: xpf.v1.BpfrxService.ShowConfig:output_type -> xpf.v1.ShowConfigResponse
-	29,  // 95: xpf.v1.BpfrxService.ShowCompare:output_type -> xpf.v1.ShowCompareResponse
-	31,  // 96: xpf.v1.BpfrxService.ShowRollback:output_type -> xpf.v1.ShowRollbackResponse
-	33,  // 97: xpf.v1.BpfrxService.ListHistory:output_type -> xpf.v1.ListHistoryResponse
-	36,  // 98: xpf.v1.BpfrxService.GetStatus:output_type -> xpf.v1.GetStatusResponse
-	38,  // 99: xpf.v1.BpfrxService.GetGlobalStats:output_type -> xpf.v1.GetGlobalStatsResponse
-	40,  // 100: xpf.v1.BpfrxService.GetZones:output_type -> xpf.v1.GetZonesResponse
-	44,  // 101: xpf.v1.BpfrxService.GetPolicies:output_type -> xpf.v1.GetPoliciesResponse
-	48,  // 102: xpf.v1.BpfrxService.GetSessions:output_type -> xpf.v1.GetSessionsResponse
-	51,  // 103: xpf.v1.BpfrxService.GetSessionSummary:output_type -> xpf.v1.GetSessionSummaryResponse
-	126, // 104: xpf.v1.BpfrxService.GetZonePairSummary:output_type -> xpf.v1.GetZonePairSummaryResponse
-	53,  // 105: xpf.v1.BpfrxService.GetNATSource:output_type -> xpf.v1.GetNATSourceResponse
-	56,  // 106: xpf.v1.BpfrxService.GetNATDestination:output_type -> xpf.v1.GetNATDestinationResponse
-	59,  // 107: xpf.v1.BpfrxService.GetScreen:output_type -> xpf.v1.GetScreenResponse
-	62,  // 108: xpf.v1.BpfrxService.GetEvents:output_type -> xpf.v1.GetEventsResponse
-	65,  // 109: xpf.v1.BpfrxService.GetInterfaces:output_type -> xpf.v1.GetInterfacesResponse
-	68,  // 110: xpf.v1.BpfrxService.ShowInterfacesDetail:output_type -> xpf.v1.ShowInterfacesDetailResponse
-	70,  // 111: xpf.v1.BpfrxService.GetDHCPLeases:output_type -> xpf.v1.GetDHCPLeasesResponse
-	74,  // 112: xpf.v1.BpfrxService.GetDHCPClientIdentifiers:output_type -> xpf.v1.GetDHCPClientIdentifiersResponse
-	79,  // 113: xpf.v1.BpfrxService.GetRoutes:output_type -> xpf.v1.GetRoutesResponse
-	82,  // 114: xpf.v1.BpfrxService.GetOSPFStatus:output_type -> xpf.v1.GetOSPFStatusResponse
-	84,  // 115: xpf.v1.BpfrxService.GetBGPStatus:output_type -> xpf.v1.GetBGPStatusResponse
-	86,  // 116: xpf.v1.BpfrxService.GetRIPStatus:output_type -> xpf.v1.GetRIPStatusResponse
-	88,  // 117: xpf.v1.BpfrxService.GetISISStatus:output_type -> xpf.v1.GetISISStatusResponse
-	90,  // 118: xpf.v1.BpfrxService.GetIPsecSA:output_type -> xpf.v1.GetIPsecSAResponse
-	100, // 119: xpf.v1.BpfrxService.GetNATPoolStats:output_type -> xpf.v1.GetNATPoolStatsResponse
-	110, // 120: xpf.v1.BpfrxService.GetNATRuleStats:output_type -> xpf.v1.GetNATRuleStatsResponse
-	104, // 121: xpf.v1.BpfrxService.GetVRRPStatus:output_type -> xpf.v1.GetVRRPStatusResponse
-	107, // 122: xpf.v1.BpfrxService.MatchPolicies:output_type -> xpf.v1.MatchPoliciesResponse
-	92,  // 123: xpf.v1.BpfrxService.Ping:output_type -> xpf.v1.PingResponse
-	94,  // 124: xpf.v1.BpfrxService.Traceroute:output_type -> xpf.v1.TracerouteResponse
-	121, // 125: xpf.v1.BpfrxService.MonitorPacketDrop:output_type -> xpf.v1.MonitorPacketDropResponse
-	123, // 126: xpf.v1.BpfrxService.MonitorInterface:output_type -> xpf.v1.MonitorInterfaceResponse
-	96,  // 127: xpf.v1.BpfrxService.ClearSessions:output_type -> xpf.v1.ClearSessionsResponse
-	98,  // 128: xpf.v1.BpfrxService.ClearCounters:output_type -> xpf.v1.ClearCountersResponse
-	77,  // 129: xpf.v1.BpfrxService.ClearDHCPClientIdentifier:output_type -> xpf.v1.ClearDHCPClientIdentifierResponse
-	115, // 130: xpf.v1.BpfrxService.ShowText:output_type -> xpf.v1.ShowTextResponse
-	117, // 131: xpf.v1.BpfrxService.GetSystemInfo:output_type -> xpf.v1.GetSystemInfoResponse
-	119, // 132: xpf.v1.BpfrxService.SystemAction:output_type -> xpf.v1.SystemActionResponse
-	113, // 133: xpf.v1.BpfrxService.Complete:output_type -> xpf.v1.CompleteResponse
-	83,  // [83:134] is the sub-list for method output_type
-	32,  // [32:83] is the sub-list for method input_type
-	32,  // [32:32] is the sub-list for extension type_name
-	32,  // [32:32] is the sub-list for extension extendee
-	0,   // [0:32] is the sub-list for field type_name
+	35,  // 3: xpf.v1.ListHistoryResponse.entries:type_name -> xpf.v1.HistoryEntry
+	128, // 4: xpf.v1.GetGlobalStatsResponse.screen_drop_details:type_name -> xpf.v1.GetGlobalStatsResponse.ScreenDropDetailsEntry
+	42,  // 5: xpf.v1.GetZonesResponse.zones:type_name -> xpf.v1.ZoneInfo
+	43,  // 6: xpf.v1.ZoneInfo.interface_host_inbound:type_name -> xpf.v1.InterfaceHostInbound
+	46,  // 7: xpf.v1.GetPoliciesResponse.policies:type_name -> xpf.v1.PolicyInfo
+	47,  // 8: xpf.v1.PolicyInfo.rules:type_name -> xpf.v1.PolicyRule
+	50,  // 9: xpf.v1.GetSessionsResponse.sessions:type_name -> xpf.v1.SessionEntry
+	49,  // 10: xpf.v1.GetSessionsResponse.peer:type_name -> xpf.v1.GetSessionsResponse
+	52,  // 11: xpf.v1.GetSessionSummaryResponse.peer:type_name -> xpf.v1.GetSessionSummaryResponse
+	4,   // 12: xpf.v1.GetSessionSummaryResponse.peer_status:type_name -> xpf.v1.PeerFetchStatus
+	55,  // 13: xpf.v1.GetNATSourceResponse.rules:type_name -> xpf.v1.NATSourceInfo
+	58,  // 14: xpf.v1.GetNATDestinationResponse.rules:type_name -> xpf.v1.NATDestInfo
+	103, // 15: xpf.v1.GetNATDestinationResponse.rule_set_sessions:type_name -> xpf.v1.NATRuleSetSessions
+	61,  // 16: xpf.v1.GetScreenResponse.screens:type_name -> xpf.v1.ScreenInfo
+	129, // 17: xpf.v1.ScreenInfo.thresholds:type_name -> xpf.v1.ScreenInfo.ThresholdsEntry
+	64,  // 18: xpf.v1.GetEventsResponse.events:type_name -> xpf.v1.EventEntry
+	67,  // 19: xpf.v1.GetInterfacesResponse.interfaces:type_name -> xpf.v1.InterfaceInfo
+	72,  // 20: xpf.v1.GetDHCPLeasesResponse.leases:type_name -> xpf.v1.DHCPLeaseInfo
+	73,  // 21: xpf.v1.DHCPLeaseInfo.delegated_prefixes:type_name -> xpf.v1.DHCPDelegatedPrefix
+	76,  // 22: xpf.v1.GetDHCPClientIdentifiersResponse.identifiers:type_name -> xpf.v1.DHCPClientIdentifierInfo
+	81,  // 23: xpf.v1.GetRoutesResponse.routes:type_name -> xpf.v1.RouteInfo
+	102, // 24: xpf.v1.GetNATPoolStatsResponse.pools:type_name -> xpf.v1.NATPoolStats
+	103, // 25: xpf.v1.GetNATPoolStatsResponse.rule_set_sessions:type_name -> xpf.v1.NATRuleSetSessions
+	106, // 26: xpf.v1.GetVRRPStatusResponse.instances:type_name -> xpf.v1.VRRPInstanceInfo
+	109, // 27: xpf.v1.MatchPoliciesResponse.host_inbound:type_name -> xpf.v1.HostInboundAdmission
+	3,   // 28: xpf.v1.HostInboundAdmission.status:type_name -> xpf.v1.HostInboundAdmissionStatus
+	112, // 29: xpf.v1.GetNATRuleStatsResponse.rules:type_name -> xpf.v1.NATRuleStats
+	2,   // 30: xpf.v1.MonitorInterfaceRequest.summary_mode:type_name -> xpf.v1.MonitorInterfaceSummaryMode
+	126, // 31: xpf.v1.GetZonePairSummaryResponse.zone_pairs:type_name -> xpf.v1.ZonePairSessionSummary
+	127, // 32: xpf.v1.GetZonePairSummaryResponse.peer:type_name -> xpf.v1.GetZonePairSummaryResponse
+	4,   // 33: xpf.v1.GetZonePairSummaryResponse.peer_status:type_name -> xpf.v1.PeerFetchStatus
+	5,   // 34: xpf.v1.BpfrxService.EnterConfigure:input_type -> xpf.v1.EnterConfigureRequest
+	7,   // 35: xpf.v1.BpfrxService.ExitConfigure:input_type -> xpf.v1.ExitConfigureRequest
+	9,   // 36: xpf.v1.BpfrxService.GetConfigModeStatus:input_type -> xpf.v1.GetConfigModeStatusRequest
+	11,  // 37: xpf.v1.BpfrxService.Set:input_type -> xpf.v1.SetRequest
+	13,  // 38: xpf.v1.BpfrxService.Delete:input_type -> xpf.v1.DeleteRequest
+	15,  // 39: xpf.v1.BpfrxService.Load:input_type -> xpf.v1.LoadRequest
+	17,  // 40: xpf.v1.BpfrxService.Commit:input_type -> xpf.v1.CommitRequest
+	19,  // 41: xpf.v1.BpfrxService.CommitCheck:input_type -> xpf.v1.CommitCheckRequest
+	21,  // 42: xpf.v1.BpfrxService.CommitConfirmed:input_type -> xpf.v1.CommitConfirmedRequest
+	23,  // 43: xpf.v1.BpfrxService.ConfirmCommit:input_type -> xpf.v1.ConfirmCommitRequest
+	25,  // 44: xpf.v1.BpfrxService.Rollback:input_type -> xpf.v1.RollbackRequest
+	27,  // 45: xpf.v1.BpfrxService.ShowConfig:input_type -> xpf.v1.ShowConfigRequest
+	29,  // 46: xpf.v1.BpfrxService.ShowCompare:input_type -> xpf.v1.ShowCompareRequest
+	31,  // 47: xpf.v1.BpfrxService.ShowRollback:input_type -> xpf.v1.ShowRollbackRequest
+	33,  // 48: xpf.v1.BpfrxService.ListHistory:input_type -> xpf.v1.ListHistoryRequest
+	36,  // 49: xpf.v1.BpfrxService.GetStatus:input_type -> xpf.v1.GetStatusRequest
+	38,  // 50: xpf.v1.BpfrxService.GetGlobalStats:input_type -> xpf.v1.GetGlobalStatsRequest
+	40,  // 51: xpf.v1.BpfrxService.GetZones:input_type -> xpf.v1.GetZonesRequest
+	44,  // 52: xpf.v1.BpfrxService.GetPolicies:input_type -> xpf.v1.GetPoliciesRequest
+	48,  // 53: xpf.v1.BpfrxService.GetSessions:input_type -> xpf.v1.GetSessionsRequest
+	51,  // 54: xpf.v1.BpfrxService.GetSessionSummary:input_type -> xpf.v1.GetSessionSummaryRequest
+	125, // 55: xpf.v1.BpfrxService.GetZonePairSummary:input_type -> xpf.v1.GetZonePairSummaryRequest
+	53,  // 56: xpf.v1.BpfrxService.GetNATSource:input_type -> xpf.v1.GetNATSourceRequest
+	56,  // 57: xpf.v1.BpfrxService.GetNATDestination:input_type -> xpf.v1.GetNATDestinationRequest
+	59,  // 58: xpf.v1.BpfrxService.GetScreen:input_type -> xpf.v1.GetScreenRequest
+	62,  // 59: xpf.v1.BpfrxService.GetEvents:input_type -> xpf.v1.GetEventsRequest
+	65,  // 60: xpf.v1.BpfrxService.GetInterfaces:input_type -> xpf.v1.GetInterfacesRequest
+	68,  // 61: xpf.v1.BpfrxService.ShowInterfacesDetail:input_type -> xpf.v1.ShowInterfacesDetailRequest
+	70,  // 62: xpf.v1.BpfrxService.GetDHCPLeases:input_type -> xpf.v1.GetDHCPLeasesRequest
+	74,  // 63: xpf.v1.BpfrxService.GetDHCPClientIdentifiers:input_type -> xpf.v1.GetDHCPClientIdentifiersRequest
+	79,  // 64: xpf.v1.BpfrxService.GetRoutes:input_type -> xpf.v1.GetRoutesRequest
+	82,  // 65: xpf.v1.BpfrxService.GetOSPFStatus:input_type -> xpf.v1.GetOSPFStatusRequest
+	84,  // 66: xpf.v1.BpfrxService.GetBGPStatus:input_type -> xpf.v1.GetBGPStatusRequest
+	86,  // 67: xpf.v1.BpfrxService.GetRIPStatus:input_type -> xpf.v1.GetRIPStatusRequest
+	88,  // 68: xpf.v1.BpfrxService.GetISISStatus:input_type -> xpf.v1.GetISISStatusRequest
+	90,  // 69: xpf.v1.BpfrxService.GetIPsecSA:input_type -> xpf.v1.GetIPsecSARequest
+	100, // 70: xpf.v1.BpfrxService.GetNATPoolStats:input_type -> xpf.v1.GetNATPoolStatsRequest
+	110, // 71: xpf.v1.BpfrxService.GetNATRuleStats:input_type -> xpf.v1.GetNATRuleStatsRequest
+	104, // 72: xpf.v1.BpfrxService.GetVRRPStatus:input_type -> xpf.v1.GetVRRPStatusRequest
+	107, // 73: xpf.v1.BpfrxService.MatchPolicies:input_type -> xpf.v1.MatchPoliciesRequest
+	92,  // 74: xpf.v1.BpfrxService.Ping:input_type -> xpf.v1.PingRequest
+	94,  // 75: xpf.v1.BpfrxService.Traceroute:input_type -> xpf.v1.TracerouteRequest
+	121, // 76: xpf.v1.BpfrxService.MonitorPacketDrop:input_type -> xpf.v1.MonitorPacketDropRequest
+	123, // 77: xpf.v1.BpfrxService.MonitorInterface:input_type -> xpf.v1.MonitorInterfaceRequest
+	96,  // 78: xpf.v1.BpfrxService.ClearSessions:input_type -> xpf.v1.ClearSessionsRequest
+	98,  // 79: xpf.v1.BpfrxService.ClearCounters:input_type -> xpf.v1.ClearCountersRequest
+	77,  // 80: xpf.v1.BpfrxService.ClearDHCPClientIdentifier:input_type -> xpf.v1.ClearDHCPClientIdentifierRequest
+	115, // 81: xpf.v1.BpfrxService.ShowText:input_type -> xpf.v1.ShowTextRequest
+	117, // 82: xpf.v1.BpfrxService.GetSystemInfo:input_type -> xpf.v1.GetSystemInfoRequest
+	119, // 83: xpf.v1.BpfrxService.SystemAction:input_type -> xpf.v1.SystemActionRequest
+	113, // 84: xpf.v1.BpfrxService.Complete:input_type -> xpf.v1.CompleteRequest
+	6,   // 85: xpf.v1.BpfrxService.EnterConfigure:output_type -> xpf.v1.EnterConfigureResponse
+	8,   // 86: xpf.v1.BpfrxService.ExitConfigure:output_type -> xpf.v1.ExitConfigureResponse
+	10,  // 87: xpf.v1.BpfrxService.GetConfigModeStatus:output_type -> xpf.v1.GetConfigModeStatusResponse
+	12,  // 88: xpf.v1.BpfrxService.Set:output_type -> xpf.v1.SetResponse
+	14,  // 89: xpf.v1.BpfrxService.Delete:output_type -> xpf.v1.DeleteResponse
+	16,  // 90: xpf.v1.BpfrxService.Load:output_type -> xpf.v1.LoadResponse
+	18,  // 91: xpf.v1.BpfrxService.Commit:output_type -> xpf.v1.CommitResponse
+	20,  // 92: xpf.v1.BpfrxService.CommitCheck:output_type -> xpf.v1.CommitCheckResponse
+	22,  // 93: xpf.v1.BpfrxService.CommitConfirmed:output_type -> xpf.v1.CommitConfirmedResponse
+	24,  // 94: xpf.v1.BpfrxService.ConfirmCommit:output_type -> xpf.v1.ConfirmCommitResponse
+	26,  // 95: xpf.v1.BpfrxService.Rollback:output_type -> xpf.v1.RollbackResponse
+	28,  // 96: xpf.v1.BpfrxService.ShowConfig:output_type -> xpf.v1.ShowConfigResponse
+	30,  // 97: xpf.v1.BpfrxService.ShowCompare:output_type -> xpf.v1.ShowCompareResponse
+	32,  // 98: xpf.v1.BpfrxService.ShowRollback:output_type -> xpf.v1.ShowRollbackResponse
+	34,  // 99: xpf.v1.BpfrxService.ListHistory:output_type -> xpf.v1.ListHistoryResponse
+	37,  // 100: xpf.v1.BpfrxService.GetStatus:output_type -> xpf.v1.GetStatusResponse
+	39,  // 101: xpf.v1.BpfrxService.GetGlobalStats:output_type -> xpf.v1.GetGlobalStatsResponse
+	41,  // 102: xpf.v1.BpfrxService.GetZones:output_type -> xpf.v1.GetZonesResponse
+	45,  // 103: xpf.v1.BpfrxService.GetPolicies:output_type -> xpf.v1.GetPoliciesResponse
+	49,  // 104: xpf.v1.BpfrxService.GetSessions:output_type -> xpf.v1.GetSessionsResponse
+	52,  // 105: xpf.v1.BpfrxService.GetSessionSummary:output_type -> xpf.v1.GetSessionSummaryResponse
+	127, // 106: xpf.v1.BpfrxService.GetZonePairSummary:output_type -> xpf.v1.GetZonePairSummaryResponse
+	54,  // 107: xpf.v1.BpfrxService.GetNATSource:output_type -> xpf.v1.GetNATSourceResponse
+	57,  // 108: xpf.v1.BpfrxService.GetNATDestination:output_type -> xpf.v1.GetNATDestinationResponse
+	60,  // 109: xpf.v1.BpfrxService.GetScreen:output_type -> xpf.v1.GetScreenResponse
+	63,  // 110: xpf.v1.BpfrxService.GetEvents:output_type -> xpf.v1.GetEventsResponse
+	66,  // 111: xpf.v1.BpfrxService.GetInterfaces:output_type -> xpf.v1.GetInterfacesResponse
+	69,  // 112: xpf.v1.BpfrxService.ShowInterfacesDetail:output_type -> xpf.v1.ShowInterfacesDetailResponse
+	71,  // 113: xpf.v1.BpfrxService.GetDHCPLeases:output_type -> xpf.v1.GetDHCPLeasesResponse
+	75,  // 114: xpf.v1.BpfrxService.GetDHCPClientIdentifiers:output_type -> xpf.v1.GetDHCPClientIdentifiersResponse
+	80,  // 115: xpf.v1.BpfrxService.GetRoutes:output_type -> xpf.v1.GetRoutesResponse
+	83,  // 116: xpf.v1.BpfrxService.GetOSPFStatus:output_type -> xpf.v1.GetOSPFStatusResponse
+	85,  // 117: xpf.v1.BpfrxService.GetBGPStatus:output_type -> xpf.v1.GetBGPStatusResponse
+	87,  // 118: xpf.v1.BpfrxService.GetRIPStatus:output_type -> xpf.v1.GetRIPStatusResponse
+	89,  // 119: xpf.v1.BpfrxService.GetISISStatus:output_type -> xpf.v1.GetISISStatusResponse
+	91,  // 120: xpf.v1.BpfrxService.GetIPsecSA:output_type -> xpf.v1.GetIPsecSAResponse
+	101, // 121: xpf.v1.BpfrxService.GetNATPoolStats:output_type -> xpf.v1.GetNATPoolStatsResponse
+	111, // 122: xpf.v1.BpfrxService.GetNATRuleStats:output_type -> xpf.v1.GetNATRuleStatsResponse
+	105, // 123: xpf.v1.BpfrxService.GetVRRPStatus:output_type -> xpf.v1.GetVRRPStatusResponse
+	108, // 124: xpf.v1.BpfrxService.MatchPolicies:output_type -> xpf.v1.MatchPoliciesResponse
+	93,  // 125: xpf.v1.BpfrxService.Ping:output_type -> xpf.v1.PingResponse
+	95,  // 126: xpf.v1.BpfrxService.Traceroute:output_type -> xpf.v1.TracerouteResponse
+	122, // 127: xpf.v1.BpfrxService.MonitorPacketDrop:output_type -> xpf.v1.MonitorPacketDropResponse
+	124, // 128: xpf.v1.BpfrxService.MonitorInterface:output_type -> xpf.v1.MonitorInterfaceResponse
+	97,  // 129: xpf.v1.BpfrxService.ClearSessions:output_type -> xpf.v1.ClearSessionsResponse
+	99,  // 130: xpf.v1.BpfrxService.ClearCounters:output_type -> xpf.v1.ClearCountersResponse
+	78,  // 131: xpf.v1.BpfrxService.ClearDHCPClientIdentifier:output_type -> xpf.v1.ClearDHCPClientIdentifierResponse
+	116, // 132: xpf.v1.BpfrxService.ShowText:output_type -> xpf.v1.ShowTextResponse
+	118, // 133: xpf.v1.BpfrxService.GetSystemInfo:output_type -> xpf.v1.GetSystemInfoResponse
+	120, // 134: xpf.v1.BpfrxService.SystemAction:output_type -> xpf.v1.SystemActionResponse
+	114, // 135: xpf.v1.BpfrxService.Complete:output_type -> xpf.v1.CompleteResponse
+	85,  // [85:136] is the sub-list for method output_type
+	34,  // [34:85] is the sub-list for method input_type
+	34,  // [34:34] is the sub-list for extension type_name
+	34,  // [34:34] is the sub-list for extension extendee
+	0,   // [0:34] is the sub-list for field type_name
 }
 
 func init() { file_xpf_proto_init() }
@@ -9016,7 +9156,7 @@ func file_xpf_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_xpf_proto_rawDesc), len(file_xpf_proto_rawDesc)),
-			NumEnums:      4,
+			NumEnums:      5,
 			NumMessages:   125,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -433,6 +433,22 @@ message GetSessionSummaryResponse {
   int32 dnat_sessions = 7;
   int32 node_id = 8;
   GetSessionSummaryResponse peer = 9;
+  // peer_status classifies the include_peer fan-out completeness (#5320): OK
+  // when the peer summary is present under `peer`, UNREACHABLE when the peer
+  // was requested but its fetch failed (the totals here are LOCAL-ONLY and
+  // understate cluster-wide state), NOT_APPLICABLE for a standalone node or an
+  // unset include_peer. Before #5320 a peer-fetch failure was logged and
+  // swallowed, leaving peer=nil — indistinguishable from a healthy standalone.
+  PeerFetchStatus peer_status = 10;
+  // peer_error carries the human-readable peer-fetch failure detail; empty
+  // unless peer_status == UNREACHABLE (#5320).
+  string peer_error = 11;
+  // max_sessions is the dataplane's dynamic session-table capacity: the live
+  // AF_XDP helper publishes worker_count x per-worker capacity. 0 = unknown
+  // (no userspace status attached), so a consumer must render "unknown" rather
+  // than a fabricated authoritative bound (#5323, replaces the hardcoded
+  // 10000000 the CLI used to print).
+  uint64 max_sessions = 12;
 }
 
 message GetNATSourceRequest {}
@@ -1034,4 +1050,24 @@ message GetZonePairSummaryResponse {
   repeated ZonePairSessionSummary zone_pairs = 1;
   int32 node_id = 2;                      // cluster node ID (0, 1, ...)
   GetZonePairSummaryResponse peer = 3;    // peer node breakdown (nil if standalone)
+  // peer_status / peer_error mirror GetSessionSummaryResponse (#5320): a peer
+  // fetch failure is now VISIBLE (UNREACHABLE) instead of leaving peer=nil and
+  // looking like a healthy standalone breakdown.
+  PeerFetchStatus peer_status = 4;
+  string peer_error = 5;
+}
+
+// PeerFetchStatus classifies whether a summary response's cluster-peer leg was
+// successfully included, so a machine consumer can distinguish a genuine
+// standalone / no-peer-requested view (NOT_APPLICABLE) from a cluster peer that
+// was requested but could NOT be reached (UNREACHABLE). Before #5320 a peer
+// fetch failure was logged and swallowed: the response returned the LOCAL-ONLY
+// totals with peer=nil, indistinguishable from a healthy standalone node — a
+// peer partition then looked like a healthy low session count. UNREACHABLE
+// surfaces the incompleteness while still returning the (useful) local totals.
+enum PeerFetchStatus {
+  PEER_FETCH_STATUS_UNSPECIFIED = 0;    // not evaluated / older server
+  PEER_FETCH_STATUS_NOT_APPLICABLE = 1; // standalone, or include_peer not set
+  PEER_FETCH_STATUS_OK = 2;             // peer requested and its data is included
+  PEER_FETCH_STATUS_UNREACHABLE = 3;    // peer requested but the fetch failed; peer data omitted
 }


### PR DESCRIPTION
Fixes two coupled missing-response-field gaps on the session-summary
surfaces. Both are additive, backward-compatible protobuf field additions
(regenerated bindings committed); no session-sync/failover behavior
changes, so no `test-failover` is required.

## #5320 — peer-fetch failures were SWALLOWED (security / vSRX-parity)

`GetSessionSummary` / `GetZonePairSummary` logged a `slog.Warn` on a peer
error then returned **success with `peer=nil`**, indistinguishable from a
standalone node. `include_peer=true` against an unreachable peer produced
a REST 200 carrying LOCAL-ONLY totals consumed as a complete HA view — a
peer partition looked like a healthy low session count.

Fix (response schema now carries completeness):
- New `peer_status` enum (`PeerFetchStatus`: `OK` / `UNREACHABLE` /
  `NOT_APPLICABLE`) + `peer_error` on both `GetSessionSummaryResponse`
  and `GetZonePairSummaryResponse`.
- On a peer-fetch failure the RPC still returns the useful local totals,
  but sets `UNREACHABLE` (distinct from a standalone `NOT_APPLICABLE`) so
  a consumer can tell a partition from a healthy standalone.
- `peerAbsentStatus()` distinguishes a genuinely standalone node from a
  clustered node whose peer heartbeat is lost.
- Refactored the `GetSessionSummary` peer leg into
  `proxyPeerSessionSummary` + a `peerSessionSummaryFn` test seam,
  mirroring the existing `proxyPeerZonePairSummary` (#3592). The #3592
  x-peer-forwarded recursion guard and the #2469 local-iterator hard-fail
  are preserved.
- REST `/api/v1/security/sessions/summary` [`/zone-pairs`] surface
  `peer_status`/`peer_error` (strings); a standalone request reports
  `not-applicable`.
- The remote CLI prints
  `warning: cluster peer unreachable; counts above are LOCAL-ONLY` when
  `peer_status == UNREACHABLE`.

## #5323 — hardcoded `Maximum-sessions: 10000000` (vSRX-parity)

`show security flow session summary` printed a hardcoded max plus zeroed
unsupported counters as authoritative, while the live helper publishes a
dynamic `max_sessions` (worker_count × 131072) in `ProcessStatus` that
the response had no field for.

Fix:
- New `max_sessions` (uint64) on `GetSessionSummaryResponse`, populated
  from `userspaceDataplaneStatus()`.
- Remote CLI (`cmd/cli/show_flow.go`) and local CLI
  (`pkg/cli/cli_show_flow.go`) render the real max, or `unknown` when no
  dataplane status is available — never a fabricated authoritative
  literal.
- REST `/sessions/summary` carries `max_sessions` (via
  `fetchUserspaceStatus`); the peer summary carries its own.
- Multicast/Failed/Services-offload rows stay `0` for Junos format
  parity: the AF_XDP helper publishes no such counters (documented
  follow-up), so they are a format placeholder rather than relabeled.

## Proto regen

`make proto` (protoc v3.21.12, protoc-gen-go v1.36.11). Committed in a
separate `proto:` commit from the logic. Both Go sides (server + client)
use the new fields consistently — no one-sided/wire-mismatch. The
regen is idempotent (re-running `make proto` yields no diff) and also
re-synced a pre-existing stale `CompleteRequest.pos` doc comment.

## Validation

- `make proto` first, then `go build ./...` → exit 0
- `go test ./pkg/grpcapi/... ./pkg/api/... ./cmd/cli/... ./pkg/cli/...`
  → ok
- `gofmt -l` clean on all touched files
- Cross-language wire contract: `pkg/dataplane/userspace` (incl.
  `protocol_wire_v1.json`) passes — `max_sessions` is an established
  ProcessStatus field; this change only adds gRPC protobuf fields.

### Fail-on-revert (each empirically verified RED when the fix is reverted)
- grpcapi #5320: `peer_status` OK/UNREACHABLE/NOT_APPLICABLE for both
  RPCs — reverting to the `slog.Warn`-and-swallow leaves it UNSPECIFIED.
- grpcapi #5323: `max_sessions` from a fake helper status — removing the
  plumbing yields 0.
- REST #5320: `peer_status` unreachable surfaced on a 200 — reverting
  yields `not-applicable`.
- cmd/cli #5323: dynamic-max render — reverting prints `10000000`.
- pkg/cli #5323: local dynamic-max render — reverting prints `10000000`.

Closes #5320
Closes #5323

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
