### PR TITLE
pkg/flowexport: make batch max-depth high-water update race-free (#5048)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -44826,3 +44826,19 @@ top.
   Added RED-on-revert tests. Updated pkg/snmp/README.md class-counter note.
 - **File(s)**: pkg/daemon/daemon_snmp_reconcile.go,
   pkg/daemon/daemon_snmp_reconcile_test.go, pkg/snmp/README.md
+
+- **Timestamp**: 2026-07-10
+- **Action**: Fix flowexport batch max-depth high-water update race (#5048).
+  The `maxDepth` high-water update in `flowBatch.add()` ran OUTSIDE `b.mu`
+  as a plain load-then-store (`if depth > maxDepth.Load() { Store(depth) }`),
+  so two concurrent adders could interleave — B stores 2, A's later store
+  of 1 clobbers it — regressing the published high-water mark. Replaced with
+  a lock-free CAS-max loop (atomic `max(old, observed)`), consistent with the
+  sibling `dropped`/`handoffDropped` atomics that also update outside mu.
+  Added a test-only `maxDepthHook` seam and a deterministic barrier test that
+  forces the reverse-order store (RED-on-revert: MaxDepth regresses 2->1) plus
+  a 256-goroutine `-race` stress test. Docs: no contract change — maxDepth was
+  already documented as a monotonic high-water mark; this only makes it correct
+  under concurrency.
+- **File(s)**: pkg/flowexport/transport.go,
+  pkg/flowexport/maxdepth_race_5048_test.go

--- a/pkg/flowexport/maxdepth_race_5048_test.go
+++ b/pkg/flowexport/maxdepth_race_5048_test.go
@@ -1,0 +1,140 @@
+package flowexport
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestFlowBatchMaxDepthMonotonicUnderConcurrentAdds proves the batch
+// high-water mark cannot regress when two adders race in the max-update
+// window (#5048).
+//
+// The high-water update runs OUTSIDE the batch mutex (like the dropped /
+// handoffDropped atomics). Before the fix it was a plain load-then-store:
+//
+//	if depth > b.maxDepth.Load() { b.maxDepth.Store(depth) }
+//
+// Two adders can interleave there: A observes depth 1 and B observes depth 2,
+// both Load 0 and pass the compare, then B stores 2 and A's later store of 1
+// clobbers it — the published maximum regresses from 2 to 1 even though a
+// depth of 2 was really reached.
+//
+// FAIL-ON-REVERT: this test uses maxDepthHook to hold BOTH updaters at the
+// point right after they Load 0, then releases the higher-depth updater first
+// and the lower-depth updater second — forcing exactly the reverse-order store
+// that regresses the mark. With the racy load-then-store the final MaxDepth()
+// is 1 and the assertion fires; with the CAS-max loop the lower store's
+// CompareAndSwap fails, it re-reads 2, and 1 <= 2 stops the loop, so the mark
+// stays 2. There is no -race data race either way (both ops are atomic); the
+// defect is a lost update, so the proof is a wrong (regressed) maximum.
+func TestFlowBatchMaxDepthMonotonicUnderConcurrentAdds(t *testing.T) {
+	const (
+		loDepth = uint64(1) // first adder to acquire mu -> len 1
+		hiDepth = uint64(2) // second adder to acquire mu -> len 2
+	)
+
+	b := &flowBatch{}
+
+	loadedLo := make(chan struct{})
+	loadedHi := make(chan struct{})
+	releaseLo := make(chan struct{})
+	releaseHi := make(chan struct{})
+	var loOnce, hiOnce sync.Once
+
+	// Gate each updater exactly once, on its FIRST pass through the CAS loop
+	// (after Load, before CompareAndSwap). Retries (which only happen on the
+	// fixed code, after a losing CAS) must NOT block, so sync.Once is used.
+	b.maxDepthHook = func(depth uint64) {
+		switch depth {
+		case hiDepth:
+			hiOnce.Do(func() {
+				close(loadedHi)
+				<-releaseHi
+			})
+		case loDepth:
+			loOnce.Do(func() {
+				close(loadedLo)
+				<-releaseLo
+			})
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); b.add(FlowRecord{}) }()
+	go func() { defer wg.Done(); b.add(FlowRecord{}) }()
+
+	// Both adders have appended under mu (so one observed depth 1 and the other
+	// depth 2) and are now parked in the CAS loop having each Loaded maxDepth==0.
+	waitClosed(t, loadedLo, "lo updater never reached the max-update barrier")
+	waitClosed(t, loadedHi, "hi updater never reached the max-update barrier")
+
+	if got := b.MaxDepth(); got != 0 {
+		t.Fatalf("MaxDepth() = %d before any store, want 0 (both updaters should still be parked)", got)
+	}
+
+	// Release the HIGHER depth first: it publishes 2.
+	close(releaseHi)
+	// Wait for the high-water to actually reach 2 so the lower store races in
+	// AFTER it — the exact reverse-order interleave the bug needs.
+	deadline := time.Now().Add(2 * time.Second)
+	for b.MaxDepth() != hiDepth {
+		if time.Now().After(deadline) {
+			t.Fatalf("hi updater never published depth %d (MaxDepth=%d)", hiDepth, b.MaxDepth())
+		}
+	}
+	// Now release the LOWER depth: a racy store would clobber 2 with 1.
+	close(releaseLo)
+
+	wg.Wait()
+
+	if got := b.MaxDepth(); got != hiDepth {
+		t.Fatalf("MaxDepth() = %d after reverse-order stores, want %d: "+
+			"the high-water mark regressed — the lower late store clobbered the higher one (#5048)",
+			got, hiDepth)
+	}
+}
+
+// TestFlowBatchMaxDepthConcurrentStress hammers the high-water path with many
+// concurrent adders (no drain) under -race. Every record is retained, so the
+// true peak equals the number of adders; MaxDepth() must equal it. This
+// exercises the real CAS-max loop under contention and, together with -race,
+// guards the update against both a lost update (wrong max) and any future data
+// race on maxDepth. It complements the deterministic barrier test above.
+func TestFlowBatchMaxDepthConcurrentStress(t *testing.T) {
+	const adders = 256
+	b := &flowBatch{capOverride: adders} // large enough that nothing is dropped
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(adders)
+	for i := 0; i < adders; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			b.add(FlowRecord{})
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := b.Dropped(); got != 0 {
+		t.Fatalf("Dropped() = %d, want 0 (cap %d should hold every record)", got, adders)
+	}
+	if got := b.depth(); got != adders {
+		t.Fatalf("depth() = %d, want %d (all records retained)", got, adders)
+	}
+	if got := b.MaxDepth(); got != adders {
+		t.Fatalf("MaxDepth() = %d, want %d: high-water regressed under concurrent adds (#5048)", got, adders)
+	}
+}
+
+func waitClosed(t *testing.T, ch <-chan struct{}, msg string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal(msg)
+	}
+}

--- a/pkg/flowexport/transport.go
+++ b/pkg/flowexport/transport.go
@@ -412,6 +412,12 @@ type flowBatch struct {
 	// the lease. It exists to deterministically exercise the retire() drain
 	// wait — production never sets it.
 	inflightHook func()
+	// maxDepthHook, when set (tests only), runs inside the high-water CAS loop
+	// after each maxDepth.Load() and before the CompareAndSwap, receiving the
+	// depth this add() observed. It exists to deterministically interleave two
+	// concurrent updaters at the load-then-store window and prove the CAS-max
+	// keeps the mark monotonic (#5048) — production never sets it.
+	maxDepthHook func(depth uint64)
 }
 
 // batchCap returns the effective per-family record cap.
@@ -473,10 +479,23 @@ func (b *flowBatch) add(fr FlowRecord) {
 	*dst = append(*dst, fr)
 	depth := uint64(len(b.v4) + len(b.v6))
 	b.mu.Unlock()
-	// maxDepth is written only here; adds are serialized by mu, so the
-	// load-then-store cannot race another writer (readers only Load()).
-	if depth > b.maxDepth.Load() {
-		b.maxDepth.Store(depth)
+	// Publish the high-water mark with a lock-free CAS-max loop. The mu
+	// section above serializes the append, but this update runs OUTSIDE mu
+	// (like the dropped/handoffDropped atomics), so a plain load-then-store
+	// would race a concurrent adder: if A computes depth 1 and B computes
+	// depth 2, both load an older value and B's store of 2 can be clobbered
+	// by A's later store of 1, regressing the published maximum. CompareAndSwap
+	// makes each update an atomic max(old, observed): retry until either our
+	// value is no longer the larger one or the swap from the value we read
+	// succeeds, so the mark is monotonic and never regresses (#5048).
+	for {
+		cur := b.maxDepth.Load()
+		if b.maxDepthHook != nil {
+			b.maxDepthHook(depth)
+		}
+		if depth <= cur || b.maxDepth.CompareAndSwap(cur, depth) {
+			break
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Closes #5048.

`flowBatch.add()` in `pkg/flowexport/transport.go` updated the batch
high-water mark (`maxDepth`) *after* `b.mu.Unlock()` with a plain
load-then-store:

```go
if depth > b.maxDepth.Load() { b.maxDepth.Store(depth) }
```

The append that computes `depth` is serialized by `b.mu`, but this
read-modify-write of `maxDepth` runs **outside** the lock. Two concurrent
adders race there: if A observes depth 1 and B observes depth 2, both can
`Load` the older value and pass the compare, then B stores 2 and A's later
store of 1 clobbers it — the published high-water mark **regresses** from 2
to 1 even though a depth of 2 was really reached. Both ops are atomic, so
`-race` reports nothing; the defect is a lost update that under-reports the
worst-case backlog surfaced by `MaxDepth()` on the live NetFlow/IPFIX export
status path.

## Fix
Replace the load-then-store with a lock-free **CAS-max loop** so every update
is an atomic `max(old, observed)`:

```go
for {
    cur := b.maxDepth.Load()
    if depth <= cur || b.maxDepth.CompareAndSwap(cur, depth) {
        break
    }
}
```

- Keeps the mark **monotonic** — a lower late store can never clobber a higher one.
- Stays **outside `b.mu`**, consistent with the sibling `dropped`/`handoffDropped`
  atomics that are also updated outside the lock; `add()`'s critical section is
  unchanged (no added lock contention on the hot flow-close path).

## Tests (RED-on-revert under `-race`)
Added `pkg/flowexport/maxdepth_race_5048_test.go`:

- **`TestFlowBatchMaxDepthMonotonicUnderConcurrentAdds`** — deterministic
  barrier test. A test-only `maxDepthHook` seam (mirroring the existing
  `inflightHook`) parks both adders at the load-then-store window after each
  has `Load`ed 0, releases the higher depth (2) first and the lower depth (1)
  second — forcing exactly the reverse-order store — and asserts the mark stays
  2.
- **`TestFlowBatchMaxDepthConcurrentStress`** — 256 concurrent adders, no
  drain; asserts `MaxDepth() == 256` under `-race`.

RED-on-revert proof (temporarily restored the racy load-then-store, kept the
hook seam):

```
--- FAIL: TestFlowBatchMaxDepthMonotonicUnderConcurrentAdds
    maxdepth_race_5048_test.go:93: MaxDepth() = 1 after reverse-order stores,
    want 2: the high-water mark regressed — the lower late store clobbered the
    higher one (#5048)
```

With the fix restored:

```
ok  github.com/psaab/xpf/pkg/flowexport   (-race, -count=1)
--- PASS: TestFlowBatchMaxDepthHighWater
--- PASS: TestFlowBatchMaxDepthMonotonicUnderConcurrentAdds
--- PASS: TestFlowBatchMaxDepthConcurrentStress
```

## Validation
- `go build ./...` — exit 0
- `go test -race ./pkg/flowexport/...` — pass
- `gofmt -l` on touched files — clean

## Docs
No documented contract changes: `maxDepth` was already documented as a
monotonic high-water mark; this only makes it correct under concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)