### PR TITLE
pkg/api: redact raw error from unauthenticated /health (#5031)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -44857,3 +44857,21 @@ top.
   under concurrency.
 - **File(s)**: pkg/flowexport/transport.go,
   pkg/flowexport/maxdepth_race_5048_test.go
+
+## 2026-07-10 — #5031 redact raw error from unauthenticated /health
+
+- **Timestamp**: 2026-07-10
+- **Action**: Redact raw compile/bootstrap error strings from the
+  unauthenticated `/health` payload. `/health` is unconditionally exempt
+  from authMiddleware; `healthHandler` copied `h.LastError` into
+  `compile_last_error` and `b.Error` into `bootstrap_import_error`, both
+  verbatim parser/compiler strings that can carry file paths, config
+  internals, or a secret echoed by a schema validator. Removed both
+  fields; kept status/counters/timestamps/reason codes as the health
+  signal. Full detail remains in the journal (compile WARN/ERROR) and the
+  authenticated BOOTSTRAP_IMPORT_FAILED event. Added
+  TestHealthHandler_RedactsRawErrorDetail (secret-sentinel body scan,
+  RED-on-revert) and inverted the two prior assertions that required the
+  raw error to be present. Updated pkg/api/README.md /health contract.
+- **File(s)**: pkg/api/health.go, pkg/api/health_test.go,
+  pkg/api/README.md, _Log.md

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -16,6 +16,17 @@ liveness/readiness. Prometheus metrics endpoint. SSE event streams.
 - `GET /health` — liveness/readiness. `CompileHealthFn` (#758) lets the
   daemon downgrade `/health` to 503 when a recent compile failed
   silently; without the callback it defaults to 200.
+  **Redaction (#5031):** `/health` is unconditionally unauthenticated
+  (`authMiddleware` exempts it), so it exposes only status, counters,
+  timestamps, and stable reason codes — never the raw compile/bootstrap
+  error strings. `compile_last_error` and `bootstrap_import_error` are NOT
+  emitted (those strings are copied verbatim from the parser/compiler and
+  can carry file paths, config internals, or a secret echoed by a schema
+  validator). The failure is still signalled by `compile_failure_count` /
+  `compile_last_error_unix` and `bootstrap_import_status` /
+  `bootstrap_import_failed` / `bootstrap_import_unix`; the full detail
+  stays in the journal (compile WARN/ERROR) and the authenticated in-band
+  `BOOTSTRAP_IMPORT_FAILED` event (event stream / ring buffer).
   `ConfigPersistDegradedFn` (#1799, same injection pattern) downgrades
   `/health` to 503 while the running active config failed to persist to
   disk (HA config-sync or commit-confirmed auto-rollback hit a write

--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -20,9 +20,15 @@ func (s *Server) healthHandler(w http.ResponseWriter, _ *http.Request) {
 		h := s.compileHealthFn()
 		payload["compile_ever_succeeded"] = h.EverSucceeded
 		payload["compile_failure_count"] = h.FailureCount
-		if h.LastError != "" {
-			payload["compile_last_error"] = h.LastError
-		}
+		// #5031: /health is intentionally unauthenticated (authMiddleware
+		// exempts it unconditionally). The raw compile error string
+		// (h.LastError) is copied verbatim from the compiler and can carry
+		// file paths, config internals, or a secret echoed by a schema
+		// validator that quotes the submitted value — so it MUST NOT cross
+		// into this always-public payload. Surface only the presence +
+		// timestamp of a failure (a stable, non-secret signal); the full
+		// detail stays in the journal ("failed to compile dataplane" WARN/
+		// ERROR in daemon_health.go) for authenticated operators.
 		if h.LastErrorUnixSec != 0 {
 			payload["compile_last_error_unix"] = h.LastErrorUnixSec
 		}
@@ -43,9 +49,14 @@ func (s *Server) healthHandler(w http.ResponseWriter, _ *http.Request) {
 		if b.Status != "" {
 			payload["bootstrap_import_status"] = b.Status
 			payload["bootstrap_import_failed"] = b.Failed
-			if b.Error != "" {
-				payload["bootstrap_import_error"] = b.Error
-			}
+			// #5031: b.Error is the raw import failure string — a parse/commit
+			// error that quotes the offending day-0 config, which can include a
+			// submitted secret (e.g. a `system login` password echoed by a
+			// schema validator). Do NOT emit it on the unauthenticated /health
+			// surface. The status enum, failed flag, and timestamp are the
+			// stable signal; the full detail stays in the journal and in the
+			// in-band BOOTSTRAP_IMPORT_FAILED event (authenticated event stream
+			// / ring buffer, daemon_health.go recordBootstrapImport).
 			if b.UnixSec != 0 {
 				payload["bootstrap_import_unix"] = b.UnixSec
 			}

--- a/pkg/api/health_test.go
+++ b/pkg/api/health_test.go
@@ -3,8 +3,107 @@ package api
 import (
 	"encoding/json"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
+
+// TestHealthHandler_RedactsRawErrorDetail is the #5031 fail-on-revert guard.
+// /health is unconditionally unauthenticated (authMiddleware exempts it), so a
+// raw compile/bootstrap error string — which can quote a submitted secret
+// (e.g. a `system login` password echoed by a schema validator), a file path,
+// or topology — must never appear verbatim in the response body. Each subtest
+// seeds a distinctive secret sentinel into a leak site, hits the handler, and
+// asserts the raw response bytes never contain the sentinel while the health
+// SIGNAL is preserved. RED-on-revert: restoring payload["compile_last_error"]
+// or payload["bootstrap_import_error"] puts the sentinel back in the body and
+// fails the strings.Contains check.
+func TestHealthHandler_RedactsRawErrorDetail(t *testing.T) {
+	const secret = "S3CR3T-plaintext-password-5031-do-not-leak"
+
+	// Compile leak site: a degraded compile returns 503 early, so drive it in
+	// isolation (bootstrapImportFn nil).
+	t.Run("compile", func(t *testing.T) {
+		s := &Server{
+			compileHealthFn: func() CompileHealthSnapshot {
+				return CompileHealthSnapshot{
+					EverSucceeded:    false,
+					FailureCount:     4,
+					LastError:        "compile system login: bad password " + secret,
+					LastErrorUnixSec: 1_700_000_000,
+				}
+			},
+		}
+		rr := httptest.NewRecorder()
+		s.healthHandler(rr, httptest.NewRequest("GET", "/health", nil))
+
+		if rr.Code != 503 {
+			t.Errorf("status = %d, want 503 (compile degradation must still gate the probe)", rr.Code)
+		}
+		body := rr.Body.String()
+		if strings.Contains(body, secret) {
+			t.Fatalf("unauthenticated /health body leaked the raw compile error sentinel (#5031):\n%s", body)
+		}
+		data := unmarshalHealthData(t, body)
+		if _, present := data["compile_last_error"]; present {
+			t.Error("compile_last_error must be absent from the unauthenticated /health body")
+		}
+		if st, _ := data["status"].(string); st != "degraded" {
+			t.Errorf("status = %q, want \"degraded\" (signal preserved)", st)
+		}
+		if ts, _ := data["compile_last_error_unix"].(float64); ts == 0 {
+			t.Error("compile_last_error_unix should remain so a probe still sees a failure occurred")
+		}
+	})
+
+	// Bootstrap leak site: reached only when compile is not degraded, so leave
+	// compileHealthFn nil and drive the bootstrap-failed path (non-fatal, 200).
+	t.Run("bootstrap", func(t *testing.T) {
+		s := &Server{
+			bootstrapImportFn: func() BootstrapImportSnapshot {
+				return BootstrapImportSnapshot{
+					Status:  "import-failed",
+					Error:   "commit: parse error near " + secret,
+					UnixSec: 1_700_000_000,
+					Failed:  true,
+				}
+			},
+		}
+		rr := httptest.NewRecorder()
+		s.healthHandler(rr, httptest.NewRequest("GET", "/health", nil))
+
+		body := rr.Body.String()
+		if strings.Contains(body, secret) {
+			t.Fatalf("unauthenticated /health body leaked the raw bootstrap error sentinel (#5031):\n%s", body)
+		}
+		data := unmarshalHealthData(t, body)
+		if _, present := data["bootstrap_import_error"]; present {
+			t.Error("bootstrap_import_error must be absent from the unauthenticated /health body")
+		}
+		if st, _ := data["bootstrap_import_status"].(string); st != "import-failed" {
+			t.Errorf("bootstrap_import_status = %q, want \"import-failed\" (signal preserved)", st)
+		}
+		if failed, _ := data["bootstrap_import_failed"].(bool); !failed {
+			t.Error("bootstrap_import_failed should remain true (signal preserved)")
+		}
+		if ts, _ := data["bootstrap_import_unix"].(float64); ts == 0 {
+			t.Error("bootstrap_import_unix should remain so a probe still sees when the import failed")
+		}
+	})
+}
+
+// unmarshalHealthData decodes a /health response body and returns its Data map.
+func unmarshalHealthData(t *testing.T, body string) map[string]any {
+	t.Helper()
+	var resp Response
+	if err := json.Unmarshal([]byte(body), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	data, ok := resp.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("data = %T, want map", resp.Data)
+	}
+	return data
+}
 
 // TestHealthHandler_DegradedWhenCompileNeverSucceeded pins #758: when
 // the daemon's dataplane compile has failed and never succeeded, /health
@@ -48,8 +147,15 @@ func TestHealthHandler_DegradedWhenCompileNeverSucceeded(t *testing.T) {
 	if ever, _ := data["compile_ever_succeeded"].(bool); ever {
 		t.Error("compile_ever_succeeded should be false")
 	}
-	if msg, _ := data["compile_last_error"].(string); msg == "" {
-		t.Error("compile_last_error should be populated")
+	// #5031: the raw compile error must NOT be echoed on the unauthenticated
+	// /health surface. The presence + timestamp of the failure is the stable
+	// signal instead. RED-on-revert: re-adding payload["compile_last_error"]
+	// fails this assertion.
+	if _, present := data["compile_last_error"]; present {
+		t.Error("compile_last_error must be absent from the unauthenticated /health body (#5031)")
+	}
+	if ts, _ := data["compile_last_error_unix"].(float64); ts == 0 {
+		t.Error("compile_last_error_unix should be populated so a probe still sees a failure occurred")
 	}
 }
 
@@ -241,8 +347,15 @@ func TestHealthHandler_ReportsBootstrapImportFailed(t *testing.T) {
 	if failed, _ := data["bootstrap_import_failed"].(bool); !failed {
 		t.Error("bootstrap_import_failed should be true")
 	}
-	if msg, _ := data["bootstrap_import_error"].(string); msg == "" {
-		t.Error("bootstrap_import_error should be populated")
+	// #5031: the raw bootstrap import error must NOT be echoed on the
+	// unauthenticated /health surface. The status enum + failed flag +
+	// timestamp are the stable signal instead. RED-on-revert: re-adding
+	// payload["bootstrap_import_error"] fails this assertion.
+	if _, present := data["bootstrap_import_error"]; present {
+		t.Error("bootstrap_import_error must be absent from the unauthenticated /health body (#5031)")
+	}
+	if ts, _ := data["bootstrap_import_unix"].(float64); ts == 0 {
+		t.Error("bootstrap_import_unix should be populated so a probe still sees when the import failed")
 	}
 }
 


### PR DESCRIPTION
Closes #5031

## Problem

`/health` is unconditionally exempt from `authMiddleware` (`pkg/api/auth.go`), yet `healthHandler` copied raw parser/compiler error strings straight into the always-public JSON payload:

- `compile_last_error` ← `CompileHealthSnapshot.LastError` (`pkg/api/health.go`)
- `bootstrap_import_error` ← `BootstrapImportSnapshot.Error`

Those strings are stored verbatim upstream — `d.compileLastError = err.Error()` (`pkg/daemon/daemon_health.go`) and `recordBootstrapImport(..., err.Error())` (`pkg/daemon/daemon_run.go`) — with no scrubber. A day-0 import or compile failure can therefore echo file paths, config internals, or a plaintext secret quoted by a schema validator (e.g. a bad `system login` password rendered `…got %q…`) to an **unauthenticated** caller. Bounded on the loopback default (`127.0.0.1:8080`) but a real leak once the API is rebound to a routable management interface — the same rebind class as the #4162 `/metrics` hardening.

## Fix

Keep the unauthenticated `/health` surface to status, counters, timestamps, and stable reason codes. Drop `compile_last_error` and `bootstrap_import_error` from the payload.

Health signal is preserved:
- `compile_failure_count` + `compile_last_error_unix` and the `503`/`"degraded"` status still gate the probe on a never-succeeded compile.
- `bootstrap_import_status` + `bootstrap_import_failed` + `bootstrap_import_unix` still report a failed import.

The detail is not lost: the compile error stays in the journal (WARN/ERROR in `recordCompileFailure`), and the bootstrap error stays in the journal **plus** the in-band `BOOTSTRAP_IMPORT_FAILED` event on the authenticated event stream / ring buffer.

## RED-on-revert evidence

`TestHealthHandler_RedactsRawErrorDetail` seeds a secret sentinel into both the compile and bootstrap error strings and asserts the raw `/health` body never contains it while the health signal is preserved. The two prior tests that *required* the raw error to be present are inverted to require its absence plus the surviving timestamp.

Temporarily restoring the leak (re-adding both fields) fails all three:

```
--- FAIL: TestHealthHandler_RedactsRawErrorDetail
    health_test.go:44: unauthenticated /health body leaked the raw compile error sentinel (#5031)
    health_test.go:76: unauthenticated /health body leaked the raw bootstrap error sentinel (#5031)
--- FAIL: TestHealthHandler_DegradedWhenCompileNeverSucceeded
    health_test.go:155: compile_last_error must be absent from the unauthenticated /health body (#5031)
--- FAIL: TestHealthHandler_ReportsBootstrapImportFailed
    health_test.go:355: bootstrap_import_error must be absent from the unauthenticated /health body (#5031)
```

With the fix in place all `pkg/api` tests pass.

## Validation

- `go build ./...` — exit 0
- `go test ./pkg/api/...` — pass
- `gofmt` clean on touched files
- `pkg/api/README.md` `/health` contract updated to document the redaction