### PR TITLE
pkg/fsatomic: correct post-rename durability classification (#5234)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -44894,3 +44894,21 @@ top.
   under concurrency.
 - **File(s)**: pkg/flowexport/transport.go,
   pkg/flowexport/maxdepth_race_5048_test.go
+
+## 2026-07-10 — #5234 fsatomic/configstore post-rename durability classification coverage
+- **Timestamp**: 2026-07-10
+- **Action**: Close the #5234 test-coverage gap (follow-up to #5185/#5230).
+  The converge-to-C tests inject via the Store `writeActiveFn` seam, which
+  bypasses `db.go writeTreeMarked`'s `fmt.Errorf("persist %s: %w", …)` wrap,
+  so nothing proved `isPostRenameDurabilityFailure` (errors.As) still
+  classifies the `*PostRenameSyncError` through that `%w`. Exported the
+  unexported fsatomic post-rename seam as `SetAfterRenameSyncDirForTesting`
+  (reuses the existing `afterRenameSyncDir`/`SyncDir` primitives — no new
+  fsync path) so a configstore test can drive a REAL post-rename dir-fsync
+  failure through `db.WriteActive`. Added a focused boundary test and an
+  end-to-end converge test. Proved RED-on-revert: downgrading db.go's `%w`
+  to `%v` makes both fail (classification flattens → reject instead of
+  converge). No production behavior change.
+- **File(s)**: pkg/fsatomic/test_seams.go (new),
+  pkg/configstore/postrename_dbboundary_5234_test.go (new),
+  pkg/fsatomic/README.md, pkg/configstore/README.md, _Log.md

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -263,7 +263,15 @@ per-path:
   (`fsatomic` cannot guarantee an atomic restore), whereas C is already
   the durable content, so converging needs no further write to hold the
   invariant. A PRE-rename failure (any non-typed write error) is still a
-  clean rejection with A intact.
+  clean rejection with A intact. The classification travels through the DB
+  layer's `fmt.Errorf("persist %s: %w", …)` wrap in `db.go writeTreeMarked`;
+  `isPostRenameDurabilityFailure` (`errors.As`) sees the typed error through
+  that `%w`. A downgrade to `%v` would silently break classification, so
+  `postrename_dbboundary_5234_test.go` drives a REAL post-rename dir-fsync
+  failure through `db.WriteActive` (via fsatomic's exported
+  `SetAfterRenameSyncDirForTesting` seam) and asserts both the direct
+  classification and the end-to-end converge — FAILing RED if the wrap is
+  ever downgraded (#5234).
 - **Crash window (persist-then-promote ambiguity).** Because the disk
   write happens first, a crash after `WriteActive` succeeds but before
   the in-memory promotion completes means a restart loads the NEW tree

--- a/pkg/configstore/postrename_dbboundary_5234_test.go
+++ b/pkg/configstore/postrename_dbboundary_5234_test.go
@@ -1,0 +1,126 @@
+package configstore
+
+// #5234 — prove the #5185 post-rename durability classification survives
+// the DB layer's error-wrap boundary.
+//
+// db.go writeTreeMarked wraps every fsatomic failure as
+// fmt.Errorf("persist %s: %w", path, err). The commit paths classify a
+// post-rename durability failure with errors.As via
+// isPostRenameDurabilityFailure and CONVERGE-to-C instead of rejecting. If
+// that %w were ever downgraded to %v, errors.As would stop matching through
+// the wrap → the classification silently regresses to the original
+// plain-rejection-while-C-is-durable bug (#5185), with NO red test to catch
+// it, because the existing converge tests inject via the Store's
+// writeActiveFn seam, which BYPASSES the db.go wrap entirely.
+//
+// These tests close that gap by driving a REAL post-rename directory-fsync
+// failure through the production db.WriteActive path (fsatomic's
+// afterRenameSyncDir seam, exported for cross-package tests as
+// SetAfterRenameSyncDirForTesting). They FAIL RED if db.go's `persist %w`
+// is downgraded to %v — at that point isPostRenameDurabilityFailure returns
+// false, so db.WriteActive's error stops classifying and Commit rejects
+// instead of converging.
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/fsatomic"
+)
+
+var errDBBoundaryDirFsync = errors.New("injected: post-rename directory fsync failed")
+
+// TestDB_WriteActive_PostRenameClassifiedThroughWrap is the focused
+// boundary assertion: a real post-rename dir-fsync failure inside
+// fsatomic.WriteFileDurable, surfaced through db.WriteActive's
+// `persist %s: %w` wrap, must STILL classify as a post-rename durability
+// failure. RED if the db.go wrap is downgraded from %w to %v.
+func TestDB_WriteActive_PostRenameClassifiedThroughWrap(t *testing.T) {
+	db, err := NewDB(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+
+	restore := fsatomic.SetAfterRenameSyncDirForTesting(func(string) error {
+		return errDBBoundaryDirFsync
+	})
+	defer restore()
+
+	err = db.WriteActive(&config.ConfigTree{})
+	if err == nil {
+		t.Fatal("db.WriteActive must surface the post-rename dir-fsync failure")
+	}
+	// The classification MUST survive the db.go `persist %w` wrap. This is
+	// the exact regression (%w -> %v) the coverage gap left unguarded.
+	if !isPostRenameDurabilityFailure(err) {
+		t.Fatalf("post-rename classification must survive the db.go `persist %%w` wrap; "+
+			"got %T: %v", err, err)
+	}
+	// Confirm the error actually traversed the db.go wrap (not a bare seam).
+	if !strings.Contains(err.Error(), "persist ") {
+		t.Errorf("error should carry the db.go persist wrap: %v", err)
+	}
+	if !errors.Is(err, errDBBoundaryDirFsync) {
+		t.Errorf("wrapped error must still unwrap to the injected fsync cause: %v", err)
+	}
+	// Post-, not pre-rename: the rename already happened, so active.json is
+	// visible on disk (ReadActive returns the just-written tree, not nil).
+	got, rerr := db.ReadActive()
+	if rerr != nil {
+		t.Fatalf("ReadActive: %v", rerr)
+	}
+	if got == nil {
+		t.Error("post-rename: active.json must be visible on disk (the rename succeeded)")
+	}
+}
+
+// TestCommit_PostRenameThroughRealDBConvergesToC is the end-to-end sibling:
+// with NO writeActiveFn seam, a real post-rename dir-fsync failure drives
+// db.WriteActive -> writeTreeMarked (`persist %w`) -> WriteFileDurable ->
+// *PostRenameSyncError, and Commit must CONVERGE to C (not reject). This
+// exercises the whole chain the writeActiveFn-seam converge tests skip. RED
+// if the db.go wrap is downgraded to %v (Commit would then reject).
+func TestCommit_PostRenameThroughRealDBConvergesToC(t *testing.T) {
+	s := newTestStore(t)
+	commitBaseline(t, s)
+	// Long backoff so the degraded-retry loop does not churn the seam while
+	// the assertions run.
+	s.SetPersistRetryBackoffForTesting(time.Hour, time.Hour)
+
+	addUntrustEdit(t, s)
+
+	// Force the post-rename dir-fsync to fail inside fsatomic AFTER the
+	// baseline commit + candidate edit have already persisted normally.
+	restore := fsatomic.SetAfterRenameSyncDirForTesting(func(string) error {
+		return errDBBoundaryDirFsync
+	})
+	defer restore()
+
+	compiled, err := s.Commit()
+	if err != nil {
+		t.Fatalf("post-rename commit via the real DB must converge, not reject: %v", err)
+	}
+	if compiled == nil {
+		t.Fatal("converged commit must return the compiled config for the daemon to apply")
+	}
+	if _, ok := compiled.Security.Zones["untrust"]; !ok {
+		t.Error("compiled config must carry the committed (C) edit")
+	}
+	if !strings.Contains(s.ShowActiveSet(), "untrust") {
+		t.Error("in-memory active must converge to C after a post-rename failure")
+	}
+	if !s.ConfigPersistDegraded() {
+		t.Error("degraded flag must be set after a post-rename durability failure")
+	}
+	// The rename made C visible before the dir-fsync failed: disk holds C.
+	tree, rerr := s.db.ReadActive()
+	if rerr != nil {
+		t.Fatalf("ReadActive: %v", rerr)
+	}
+	if tree == nil || !strings.Contains(tree.FormatSet(), "untrust") {
+		t.Error("on-disk active must be C (the content the rename already made visible)")
+	}
+}

--- a/pkg/fsatomic/README.md
+++ b/pkg/fsatomic/README.md
@@ -107,6 +107,16 @@ pre/post classification: a post-rename failure is `*PostRenameSyncError`
 with the NEW content visible on disk; the pre-rename rename/temp-fsync
 failures are NOT `*PostRenameSyncError` and leave the OLD content intact.
 
+`SetAfterRenameSyncDirForTesting(fn) (restore func())` (#5234) exports that
+same post-rename seam so a DEPENDENT package's test can force the failure
+through a `WriteFileDurable` call it does not control directly. `pkg/configstore`
+uses it to drive a REAL post-rename failure through `db.WriteActive` and prove
+the `*PostRenameSyncError` classification survives the DB layer's
+`fmt.Errorf("persist %s: %w", …)` wrap (the converge-to-C tests otherwise
+inject via the Store's `writeActiveFn` seam, which bypasses that wrap). It is
+test-only — production code must never call it; it mutates a process-global
+seam and is not safe under `t.Parallel`.
+
 ## Canary (`canary_test.go`)
 
 `TestNoDirectOsWriteFile` is the writer-class enforcement test. It walks

--- a/pkg/fsatomic/test_seams.go
+++ b/pkg/fsatomic/test_seams.go
@@ -1,0 +1,33 @@
+package fsatomic
+
+// Test-only export hook for fsatomic. Lives in the production package (not
+// an _test.go file) so a DEPENDENT package's tests — configstore, which
+// cannot reach the package-private seams — can drive a REAL post-rename
+// directory-fsync failure end-to-end. Not for production callers. Mirrors
+// the pkg/configstore/test_seams.go convention.
+
+// SetAfterRenameSyncDirForTesting overrides the post-rename
+// directory-fsync seam (afterRenameSyncDir) and returns a func that
+// restores the previous value. It exists SOLELY so a cross-package test can
+// force the durability-sync failure that occurs strictly AFTER a successful
+// rename — the *PostRenameSyncError path — through a real WriteFileDurable
+// call it does not control directly (#5234).
+//
+// The motivating consumer is pkg/configstore: its converge-to-C tests
+// inject failures via the Store's writeActiveFn seam, which BYPASSES the DB
+// layer's fmt.Errorf("persist %s: %w", …) wrap, so nothing proved the
+// *PostRenameSyncError classification (errors.As in
+// isPostRenameDurabilityFailure) still survives that %w boundary. With this
+// hook a configstore test can drive db.WriteActive → writeTreeMarked →
+// WriteFileDurable and fail the real dir-fsync, exercising the whole chain.
+//
+// Passing nil is a no-op that still returns a working restore func.
+// Production code must NEVER call this; it mutates a process-global seam and
+// is not safe under t.Parallel with concurrent WriteFileDurable callers.
+func SetAfterRenameSyncDirForTesting(fn func(dir string) error) (restore func()) {
+	prev := afterRenameSyncDir
+	if fn != nil {
+		afterRenameSyncDir = fn
+	}
+	return func() { afterRenameSyncDir = prev }
+}


### PR DESCRIPTION
Closes #5234

## Problem

Follow-up to #5185/#5230. The configstore converge-to-C tests inject the
post-rename dir-fsync failure through the Store's `writeActiveFn` seam, which
**bypasses** `db.go writeTreeMarked`'s `fmt.Errorf("persist %s: %w", …)` wrap.
Because fsatomic's `afterRenameSyncDir` seam was **unexported**, no configstore
test could drive a REAL post-rename failure through `db.WriteActive`. So
nothing proved the `*fsatomic.PostRenameSyncError` classification
(`isPostRenameDurabilityFailure`, `errors.As`) still survives that DB-layer
`%w` boundary. If that `%w` were ever downgraded to `%v`, classification would
silently stop and the fix would regress to the original
plain-rejection-while-C-is-durable bug — with **no red test** to catch it.

## Fix

Export the post-rename seam as `fsatomic.SetAfterRenameSyncDirForTesting`, a
test-only hook that overrides the existing `afterRenameSyncDir` seam and returns
a `restore` func. It **reuses the existing `SyncDir`/`afterRenameSyncDir`
primitives — no new fsync path is introduced**, and no production behavior
changes. This lets a dependent package force the directory-fsync failure that
occurs strictly AFTER a successful rename, through a `WriteFileDurable` call it
does not control directly.

Two configstore tests drive the real production path end-to-end:

- **`TestDB_WriteActive_PostRenameClassifiedThroughWrap`** — a real post-rename
  dir-fsync failure surfaced through `db.WriteActive`'s `persist %w` wrap must
  still classify as post-rename, and the rename must already be visible on disk
  (post-, not pre-rename).
- **`TestCommit_PostRenameThroughRealDBConvergesToC`** — with no `writeActiveFn`
  seam, the same failure drives `db.WriteActive → writeTreeMarked →
  WriteFileDurable → *PostRenameSyncError`, and `Commit` must **converge to C**,
  not reject.

## POSIX rename+fsync durability semantics

A `rename(2)` is only durable once the **parent directory** is fsynced; a crash
between the rename and that dir-fsync can lose the just-renamed directory entry
even though the file's data was fsynced pre-rename. fsatomic already fsyncs the
parent after the rename and reports a failure there as the typed
`*PostRenameSyncError`, so configstore converges to C (the visible, durable
content a restart would load) instead of a clean rejection. This PR pins that
contract across the `db.go` error-wrap boundary; it does not change the
durability logic itself (already correct as of #5230).

## RED-on-revert evidence

Downgrading `db.go`'s `persist %s: %w` to `%v`:

```
--- FAIL: TestDB_WriteActive_PostRenameClassifiedThroughWrap
    post-rename classification must survive the db.go `persist %w` wrap;
    got *errors.errorString: persist …/active.json: fsatomic: directory fsync …
--- FAIL: TestCommit_PostRenameThroughRealDBConvergesToC
    post-rename commit via the real DB must converge, not reject:
    commit failed: persist active config: persist …/active.json: fsatomic: …
```

Restoring `%w` returns both to green. The error string in the passing run
confirms the failure traverses the `persist %s: %w` wrap.

## Validation

- `gofmt` clean on touched files
- `go build ./...` exit 0
- `go test ./pkg/fsatomic/... ./pkg/configstore/...` pass
- `go vet` clean on both packages
- Docs updated: `pkg/fsatomic/README.md` (Testing), `pkg/configstore/README.md`
  (#5185 section) note the exported seam + the new boundary coverage.