### PR TITLE
pkg/flowexport: emit record-granularity sampling IEs in IPFIX (#5312)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -44929,3 +44929,24 @@ top.
   raw error to be present. Updated pkg/api/README.md /health contract.
 - **File(s)**: pkg/api/health.go, pkg/api/health_test.go,
   pkg/api/README.md, _Log.md
+
+- **Timestamp**: 2026-07-10
+- **Action**: #5312 flowexport/ipfix — emit RECORD-granularity sampling IEs.
+  ShouldExport does 1-in-N selection of whole SESSION records, but
+  encodeIPFIXOptionsSamplerDataSet advertised PSAMP PACKET-selection IEs
+  (selectorAlgorithm 304 / samplingPacketInterval 305 / samplingPacketSpace
+  306, interval=1/space=N-1). A standards collector reads that as packet
+  sampling and renormalizes each record's octet/packetDeltaCount by N —
+  inflating the already-complete per-session volume. The only guard was a
+  code comment ("must NOT multiply by N") that no wire field carried.
+  Replaced with the RFC 7014 (Flow Selection Techniques) flow-selection IEs:
+  flowSelectorAlgorithm (390, u16) = 1 (systematic count-based, IANA "Flow
+  Selector Algorithm" registry), samplingFlowInterval (396, u64) = 1,
+  samplingFlowSpacing (397, u64) = N-1. Record size 14 -> 22. A collector now
+  scales the POPULATION (flow count/aggregate) by N and leaves per-record
+  counters intact. Updated the sampler test to pin 390/396/397 + u64 widths +
+  record size 22 AND assert 304/305/306 are ABSENT; proved RED-on-revert
+  (reverting ipfix.go fails the template/data-set decode tests). Updated
+  pkg/flowexport/README.md #3748/#5312 sampler section.
+- **File(s)**: pkg/flowexport/ipfix.go, pkg/flowexport/ipfix_sampler_test.go,
+  pkg/flowexport/README.md, _Log.md

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -448,29 +448,48 @@ bidirectional accounting.** `FlowRecord.RevPackets`/`RevBytes` are populated
 for both exporters but consumed only by IPFIX. See the converged research plan
 on #3746.
 
-**#3748 (sub-part b) — IPFIX sampler Options Template + record.** Before
+**#3748 (sub-part b) / #5312 — IPFIX sampler Options Template + record.** Before
 #3748 `ipfixSetIDOptionsTemplate` (Set ID 3) was a bare constant: the IPFIX
 exporter emitted DATA templates (256/257) only and never advertised the
 sampling rate, so a collector receiving 1-in-N-sampled records could not
 learn N and could not scale the sampled record count. The exporter now emits,
 on the SAME template-refresh cadence, an **Options Template** (Set ID 3,
 template ID **258** — distinct from the 256/257 data IDs) and an **Options
-Data Record** (Set ID 258) carrying the sampling configuration as PSAMP
-systematic count-based sampling (RFC 5477 / IANA "IPFIX Entities"):
+Data Record** (Set ID 258) carrying the sampling configuration.
+
+**#5312 — describe FLOW selection, not packet sampling.** xpf samples 1-in-N at
+**SESSION-RECORD (Flow) granularity**: `ShouldExport` applies the modulo per
+SESSION_CLOSE event, selecting whole Flows, *not* 1-in-N packets in the datapath
+the way Junos jflow does. #3748 originally advertised this with the PSAMP
+**packet-selection** IEs (`selectorAlgorithm` 304 / `samplingPacketInterval` 305
+/ `samplingPacketSpace` 306), which tell a standards-based collector this is
+*packet* sampling and to renormalize each record's `octetDeltaCount` /
+`packetDeltaCount` by N — inflating the already-complete per-session volume by
+N× (bogus traffic/capacity/billing estimates). The record now carries the
+**RFC 7014 (Flow Selection Techniques) flow-selection IEs**, the flow-granularity
+analog of the PSAMP IEs, so a collector interprets the sampling correctly:
 
 | Field | IE | Len | Role | Value |
 |-------|----|----|------|-------|
 | `observationDomainId` | 149 | 4 | **scope** | the group's stable ODID (#3740) |
-| `selectorAlgorithm` | 304 | 2 | option | `1` (systematic count-based) |
-| `samplingPacketInterval` | 305 | 4 | option | `1` |
-| `samplingPacketSpace` | 306 | 4 | option | `N-1` |
+| `flowSelectorAlgorithm` | 390 | 2 | option | `1` (systematic count-based, IANA "Flow Selector Algorithm") |
+| `samplingFlowInterval` | 396 | 8 | option | `1` (Flows consecutively selected) |
+| `samplingFlowSpacing` | 397 | 8 | option | `N-1` (Flows skipped between intervals) |
+
+A collector reads flow selection as "you received 1/N of all Flows" and scales
+the **population** (flow count / aggregate volume) by N, while each exported
+record's per-session `octetDeltaCount` / `packetDeltaCount` stays complete and
+is **NOT** renormalized by N. (The `selectorIDTotalFlowsObserved` 394 /
+`selectorIDTotalFlowsSelected` 395 pair could express the same ratio with live
+counters; we use the static systematic count-based interval/spacing form because
+it is the direct analog of the fixed per-group config and needs no live state.)
 
 The record is scoped by `observationDomainId` (IE 149) — the group's #3740
 ODID, which also stamps the message header — so the sampling config binds to
 this observation domain. `encodeIPFIXOptionsTemplateSet` /
 `encodeIPFIXOptionsSamplerDataSet` build the two sets; `sendSamplerOptions`
 packages them into one IPFIX Message (template first, then its data record).
-The `ipfixOptionsSamplerRecordSize` (14) is pinned against the field slices at
+The `ipfixOptionsSamplerRecordSize` (22) is pinned against the field slices at
 build time (same discipline as the #2526 data-record pins), so a
 template/encoder drift panics at init.
 
@@ -490,22 +509,25 @@ the current cumulative count for the message header, then increments, exactly
 as `sendRecords` does. The template-only data-template refresh still carries
 the cumulative count without advancing it (#2609 unchanged).
 
-**SEMANTIC NUANCE — record-granularity sampling, not packet sampling.** xpf
-samples **1-in-N at SESSION-RECORD granularity**: `ShouldExport` applies the
-modulo per SESSION_CLOSE event, NOT 1-in-N packets in the datapath the way
-Junos jflow does. Advertising interval=1 / space=N-1 lets a collector scale
-the sampled **record COUNT** by N (correct), but each exported record already
-carries the **full per-session** `octetDeltaCount` / `packetDeltaCount`, so a
-collector must **NOT** additionally multiply the per-record volume by N —
-doing so double-counts. This is documented on `sendSamplerOptions` too.
+**SEMANTIC NUANCE — record-granularity sampling, expressed as flow selection
+(#5312).** Because the record uses the RFC 7014 flow-selection IEs, the
+semantics are unambiguous on the wire: a collector scales the **population**
+(flow count / aggregate volume across the network) by N, while each exported
+record's **full per-session** `octetDeltaCount` / `packetDeltaCount` stays
+complete and is **NOT** renormalized by N. This is the whole point of #5312 —
+the previous packet-selection IEs carried no wire signal that the per-record
+volume was already complete, so a standards collector would have double-counted
+by N. This is documented on `sendSamplerOptions` too.
 
 Fail-on-revert pins in `ipfix_sampler_test.go`:
 `TestIPFIXOptionsTemplateSetDecode` (Set ID 3, template 258, one scope field =
-IE 149, option IEs 304/305/306 with correct lengths + set-length integrity),
-`TestIPFIXOptionsSamplerDataSetDecode` (interval=1 / space=N-1 across sampled
-and degenerate rates), `TestIPFIXSamplerOptionsWireLoopback` (the real
-exporter UDP path emits the options message after the data template, scope ==
-header ODID, rate = N-1, and the record advances the sequence by one), and
+IE 149, flow-selection option IEs 390/396/397 with correct lengths + set-length
+integrity, and the packet-selection IEs 304/305/306 asserted ABSENT — #5312),
+`TestIPFIXOptionsSamplerDataSetDecode` (flowSelectorAlgorithm=1, interval=1 /
+space=N-1 across sampled and degenerate rates), `TestIPFIXSamplerOptionsWireLoopback`
+(the real exporter UDP path emits the options message after the data template,
+scope == header ODID, flow-selection rate = N-1 with no packet-selection IEs, and
+the record advances the sequence by one), and
 `TestIPFIXSamplerOptionsAbsentWhenUnsampled` (rate 0/1 emit no options
 message). Removing the sampler emission flips these RED.
 

--- a/pkg/flowexport/ipfix.go
+++ b/pkg/flowexport/ipfix.go
@@ -73,30 +73,42 @@ const ipfixReversePEN uint32 = 29305
 // of the 4-byte IANA form.
 const ipfixEnterpriseBit uint16 = 0x8000
 
-// #3748: PSAMP sampling Information Elements (RFC 5477 / the IANA "IPFIX
-// Entities" registry) carried by the Options Data Record that advertises the
-// group's 1-in-N sampling configuration to a collector.
+// #3748/#5312: RFC 7014 (Flow Selection Techniques) FLOW-selection Information
+// Elements carried by the Options Data Record that advertises the group's
+// 1-in-N sampling configuration to a collector. xpf samples at SESSION-RECORD
+// (Flow) granularity — ShouldExport applies the 1-in-N modulo per SESSION_CLOSE
+// event, selecting whole Flows, not packets. The PSAMP packet-selection IEs
+// (selectorAlgorithm 304 / samplingPacketInterval 305 / samplingPacketSpace 306)
+// would tell a standards collector this is PACKET sampling and to renormalize
+// each record's octet/packet counters by N — inflating the already-complete
+// per-session volume (#5312). The RFC 7014 flow-selection IEs describe the
+// population the sampler actually ran on: whole Flow records.
 const (
 	// observationDomainId (IE 149, unsigned32) — the SCOPE field of the
 	// sampler Options Template. Its value is the group's stable Observation
 	// Domain ID (#3740), which also stamps the message header, so the record
 	// scopes the sampling config to this observation domain.
 	ipfixObservationDomainID = 149
-	// selectorAlgorithm (IE 304, unsigned16) — the PSAMP selection method.
-	ipfixSelectorAlgorithm = 304
-	// samplingPacketInterval (IE 305, unsigned32) — number of consecutive
-	// units selected (1 for 1-in-N systematic count-based sampling).
-	ipfixSamplingPacketInterval = 305
-	// samplingPacketSpace (IE 306, unsigned32) — number of units skipped
-	// between selections (N-1 for 1-in-N).
-	ipfixSamplingPacketSpace = 306
+	// flowSelectorAlgorithm (IE 390, unsigned16, RFC 7014 §5) — the Flow
+	// selection algorithm, taken from the IANA "Flow Selector Algorithm"
+	// registry. Flow-granularity analog of PSAMP selectorAlgorithm (IE 304).
+	ipfixFlowSelectorAlgorithm = 390
+	// samplingFlowInterval (IE 396, unsigned64, RFC 7014 §5) — number of Flows
+	// consecutively selected (1 for 1-in-N systematic count-based flow sampling).
+	ipfixSamplingFlowInterval = 396
+	// samplingFlowSpacing (IE 397, unsigned64, RFC 7014 §5) — number of Flows
+	// skipped between two sampling intervals (N-1 for 1-in-N).
+	ipfixSamplingFlowSpacing = 397
 )
 
-// ipfixSelectorAlgorithmSystematicCount is the IANA "PSAMP Selection Method"
-// registry value for Systematic count-based Sampling (RFC 5476): select
-// samplingPacketInterval units, then skip samplingPacketSpace units. xpf's
-// 1-in-N is expressed as interval=1, space=N-1 (#3748).
-const ipfixSelectorAlgorithmSystematicCount uint16 = 1
+// ipfixFlowSelectorAlgorithmSystematicCount is the IANA "Flow Selector
+// Algorithm" (RFC 7014) registry value for Systematic count-based Sampling:
+// select samplingFlowInterval Flows, then skip samplingFlowSpacing Flows. It
+// shares value 1 with the PSAMP "Selection Method" registry, but the
+// surrounding RFC 7014 flow-selection IEs make a collector treat it as FLOW
+// selection, not packet selection. xpf's 1-in-N is expressed as interval=1,
+// space=N-1 (#5312).
+const ipfixFlowSelectorAlgorithmSystematicCount uint16 = 1
 
 // IPFIX Set IDs (RFC 7011 Section 3.3.2).
 const (
@@ -419,27 +431,28 @@ func encodeIPFIXTemplateSetDir(includeDir bool) []byte {
 	return b
 }
 
-// #3748: the sampler Options Template scope + option fields (RFC 7011 §4 /
-// RFC 5477). The single scope field (observationDomainId, IE 149) binds the
-// record to an Observation Domain; the option fields carry the sampling
-// configuration. All are standard IANA IEs (4-byte Template Set specifiers).
+// #3748/#5312: the sampler Options Template scope + option fields (RFC 7011 §4 /
+// RFC 7014 §5). The single scope field (observationDomainId, IE 149) binds the
+// record to an Observation Domain; the option fields carry the FLOW-selection
+// sampling configuration. All are standard IANA IEs (4-byte Template Set
+// specifiers).
 var (
 	ipfixOptionsSamplerScope = []ipfixField{
 		{ipfixObservationDomainID, 4, 0},
 	}
 	ipfixOptionsSamplerFields = []ipfixField{
-		{ipfixSelectorAlgorithm, 2, 0},
-		{ipfixSamplingPacketInterval, 4, 0},
-		{ipfixSamplingPacketSpace, 4, 0},
+		{ipfixFlowSelectorAlgorithm, 2, 0},
+		{ipfixSamplingFlowInterval, 8, 0},
+		{ipfixSamplingFlowSpacing, 8, 0},
 	}
 )
 
 // ipfixOptionsSamplerRecordSize is the byte size of the sampler Options Data
-// Record: observationDomainId(4) + selectorAlgorithm(2) + samplingPacketInterval(4)
-// + samplingPacketSpace(4) = 14. Pinned against the field slices at build time so
+// Record: observationDomainId(4) + flowSelectorAlgorithm(2) + samplingFlowInterval(8)
+// + samplingFlowSpacing(8) = 22. Pinned against the field slices at build time so
 // a template/encoder drift panics at init (#3748), mirroring the #2526 data-record
 // pins.
-const ipfixOptionsSamplerRecordSize = 14
+const ipfixOptionsSamplerRecordSize = 22
 
 var _ = func() struct{} {
 	if ipfixSumLen(ipfixOptionsSamplerScope)+ipfixSumLen(ipfixOptionsSamplerFields) != ipfixOptionsSamplerRecordSize {
@@ -484,14 +497,15 @@ func encodeIPFIXOptionsTemplateSet() []byte {
 
 // encodeIPFIXOptionsSamplerDataSet builds the sampler Options Data Set (a Data
 // Set whose Set ID equals the Options Template ID, 258). It carries one record
-// scoped to odid, advertising 1-in-N systematic count-based sampling as
-// interval=1 / space=samplingRate-1. samplingRate <= 1 (unsampled) yields
-// space=0 (1-in-1), but callers only emit this set when sampling is active (see
-// IPFIXExporter.emitSampler) (#3748).
+// scoped to odid, advertising 1-in-N FLOW (session-record) sampling as RFC 7014
+// systematic count-based flow selection: flowSelectorAlgorithm=1,
+// samplingFlowInterval=1, samplingFlowSpacing=samplingRate-1. samplingRate <= 1
+// (unsampled) yields space=0 (1-in-1), but callers only emit this set when
+// sampling is active (see IPFIXExporter.emitSampler) (#3748/#5312).
 func encodeIPFIXOptionsSamplerDataSet(odid uint32, samplingRate int) []byte {
-	var space uint32
+	var space uint64
 	if samplingRate > 1 {
-		space = uint32(samplingRate - 1)
+		space = uint64(samplingRate - 1)
 	}
 	totalLen := 4 + ipfixOptionsSamplerRecordSize
 	b := make([]byte, totalLen)
@@ -502,15 +516,16 @@ func encodeIPFIXOptionsSamplerDataSet(odid uint32, samplingRate int) []byte {
 	binary.BigEndian.PutUint16(b[off+2:off+4], uint16(totalLen))
 	off += 4
 
-	// Record: observationDomainId (scope), then the option fields.
+	// Record: observationDomainId (scope), then the RFC 7014 flow-selection
+	// option fields.
 	binary.BigEndian.PutUint32(b[off:off+4], odid)
 	off += 4
-	binary.BigEndian.PutUint16(b[off:off+2], ipfixSelectorAlgorithmSystematicCount)
+	binary.BigEndian.PutUint16(b[off:off+2], ipfixFlowSelectorAlgorithmSystematicCount)
 	off += 2
-	binary.BigEndian.PutUint32(b[off:off+4], 1) // samplingPacketInterval = 1
-	off += 4
-	binary.BigEndian.PutUint32(b[off:off+4], space) // samplingPacketSpace = N-1
-	off += 4
+	binary.BigEndian.PutUint64(b[off:off+8], 1) // samplingFlowInterval = 1
+	off += 8
+	binary.BigEndian.PutUint64(b[off:off+8], space) // samplingFlowSpacing = N-1
+	off += 8
 	return b
 }
 
@@ -982,15 +997,22 @@ func (e *IPFIXExporter) sendTemplates() {
 
 // sendSamplerOptions emits the sampler Options Template Set (Set ID 3, template
 // ID 258) followed by its Options Data Record (Set ID 258) in one IPFIX Message,
-// advertising the group's 1-in-N sampling rate as PSAMP systematic count-based
-// sampling (#3748). Called on the template-refresh cadence for sampled groups.
+// advertising the group's 1-in-N sampling rate as RFC 7014 systematic
+// count-based FLOW selection (#3748/#5312). Called on the template-refresh
+// cadence for sampled groups.
 //
-// SEMANTIC NUANCE (documented in README): xpf samples 1-in-N at SESSION-RECORD
-// granularity — ShouldExport applies the modulo per SESSION_CLOSE event, not
-// 1-in-N packets in the datapath as Junos jflow does. Advertising interval=1 /
-// space=N-1 lets a collector scale the sampled RECORD COUNT by N (correct), but
-// each exported record already carries the full per-session octet/packet volume,
-// so a collector must NOT additionally multiply octetDeltaCount by N.
+// FLOW-granularity representation (#5312): xpf samples 1-in-N at SESSION-RECORD
+// granularity — ShouldExport applies the modulo per SESSION_CLOSE event,
+// selecting whole Flows, not 1-in-N packets in the datapath as Junos jflow
+// does. The record therefore carries the RFC 7014 flow-selection IEs
+// (flowSelectorAlgorithm=1 / samplingFlowInterval=1 / samplingFlowSpacing=N-1),
+// NOT the PSAMP packet-selection IEs (selectorAlgorithm / samplingPacketInterval
+// / samplingPacketSpace). A standards collector reads flow selection as "you
+// received 1/N of all Flows" and scales the POPULATION (flow count, aggregate
+// volume) by N, while each exported record's octetDeltaCount / packetDeltaCount
+// stays the complete per-session volume and is NOT renormalized by N. The
+// packet-selection IEs would have wrongly implied the opposite — per-record
+// counter renormalization — which is the #5312 defect this replaces.
 //
 // The Options Data Record is a Data Record (it rides a Set with ID >= 256), so
 // it advances the header Sequence Number by one, consistent with the #2609

--- a/pkg/flowexport/ipfix_sampler_test.go
+++ b/pkg/flowexport/ipfix_sampler_test.go
@@ -7,14 +7,22 @@ import (
 	"time"
 )
 
-// #3748 fail-on-revert pins for the IPFIX sampler Options Template (Set ID 3,
-// template ID 258) + Options Data Record that advertises the group's 1-in-N
-// sampling configuration (PSAMP systematic count-based sampling, RFC 5477).
+// #3748/#5312 fail-on-revert pins for the IPFIX sampler Options Template (Set ID
+// 3, template ID 258) + Options Data Record that advertises the group's 1-in-N
+// sampling configuration.
 //
 // Before #3748 ipfixSetIDOptionsTemplate (Set ID 3) was a bare constant: no
 // options template and no sampler record were ever built or sent, so a
 // collector could not learn the sampling rate and could not scale the sampled
 // record count by N.
+//
+// #5312: xpf samples at SESSION-RECORD (Flow) granularity, so the record MUST
+// carry the RFC 7014 FLOW-selection IEs (flowSelectorAlgorithm 390 /
+// samplingFlowInterval 396 / samplingFlowSpacing 397), NOT the PSAMP
+// PACKET-selection IEs (selectorAlgorithm 304 / samplingPacketInterval 305 /
+// samplingPacketSpace 306). The packet-selection IEs would tell a standards
+// collector to renormalize each record's octet/packet counters by N, inflating
+// the already-complete per-session volume.
 //
 // The IE numbers/set IDs are asserted as literals independent of the package
 // constants so a typo'd constant cannot make a test agree with itself.
@@ -22,10 +30,16 @@ const (
 	wantOptionsSetID          uint16 = 3
 	wantOptionsTemplateID     uint16 = 258
 	wantObservationDomainIDIE uint16 = 149
-	wantSelectorAlgorithmIE   uint16 = 304
-	wantSamplingIntervalIE    uint16 = 305
-	wantSamplingSpaceIE       uint16 = 306
-	wantSystematicCountAlgo   uint16 = 1
+	// #5312: RFC 7014 flow-selection IEs (record granularity).
+	wantFlowSelectorAlgorithmIE uint16 = 390
+	wantSamplingFlowIntervalIE  uint16 = 396
+	wantSamplingFlowSpacingIE   uint16 = 397
+	wantSystematicCountAlgo     uint16 = 1
+	// #5312: the PSAMP packet-selection IEs that MUST NOT appear — advertising
+	// them mis-describes record sampling as packet sampling.
+	psampSelectorAlgorithmIE    uint16 = 304
+	psampSamplingPacketInterval uint16 = 305
+	psampSamplingPacketSpace    uint16 = 306
 )
 
 // decodeOptionsTemplateRecord walks an Options Template Set (Set ID 3, RFC 7011
@@ -76,8 +90,9 @@ func decodeOptionsTemplateRecord(t *testing.T, ts []byte) (tmplID, scopeCount ui
 // TestIPFIXOptionsTemplateSetDecode decodes the encoder output directly (no
 // wire) and pins the sampler Options Template shape: Set ID 3, template ID 258,
 // exactly one scope field (observationDomainId, IE 149) followed by the three
-// PSAMP option fields (selectorAlgorithm 304, samplingPacketInterval 305,
-// samplingPacketSpace 306) with the correct lengths.
+// RFC 7014 FLOW-selection option fields (flowSelectorAlgorithm 390,
+// samplingFlowInterval 396, samplingFlowSpacing 397) with the correct lengths,
+// and asserts the PSAMP PACKET-selection IEs are ABSENT (#5312).
 func TestIPFIXOptionsTemplateSetDecode(t *testing.T) {
 	ts := encodeIPFIXOptionsTemplateSet()
 	tmplID, scopeCount, specs := decodeOptionsTemplateRecord(t, ts)
@@ -93,9 +108,9 @@ func TestIPFIXOptionsTemplateSetDecode(t *testing.T) {
 	}
 	want := []ipfixSpec{
 		{elementID: wantObservationDomainIDIE, length: 4},
-		{elementID: wantSelectorAlgorithmIE, length: 2},
-		{elementID: wantSamplingIntervalIE, length: 4},
-		{elementID: wantSamplingSpaceIE, length: 4},
+		{elementID: wantFlowSelectorAlgorithmIE, length: 2},
+		{elementID: wantSamplingFlowIntervalIE, length: 8},
+		{elementID: wantSamplingFlowSpacingIE, length: 8},
 	}
 	if len(specs) != len(want) {
 		t.Fatalf("field count = %d, want %d (%v)", len(specs), len(want), specs)
@@ -103,6 +118,14 @@ func TestIPFIXOptionsTemplateSetDecode(t *testing.T) {
 	for i, w := range want {
 		if specs[i].elementID != w.elementID || specs[i].length != w.length || specs[i].enterprise != 0 {
 			t.Errorf("field[%d] = %+v, want elementID=%d length=%d enterprise=0", i, specs[i], w.elementID, w.length)
+		}
+	}
+	// #5312: the misleading PSAMP packet-selection IEs must NOT be advertised —
+	// they would tell a collector to renormalize per-record octet/packet counts
+	// by N, mis-describing record-granularity sampling as packet sampling.
+	for _, bad := range []uint16{psampSelectorAlgorithmIE, psampSamplingPacketInterval, psampSamplingPacketSpace} {
+		if _, ok := findSpec(specs, bad, 0); ok {
+			t.Errorf("options template advertises packet-selection IE %d — record-granularity sampling must use RFC 7014 flow-selection IEs (390/396/397)", bad)
 		}
 	}
 }
@@ -114,7 +137,7 @@ func TestIPFIXOptionsSamplerDataSetDecode(t *testing.T) {
 	const odid uint32 = 0xDEADBEEF
 	cases := []struct {
 		rate      int
-		wantSpace uint32
+		wantSpace uint64
 	}{
 		{rate: 100, wantSpace: 99},
 		{rate: 2, wantSpace: 1},
@@ -137,13 +160,13 @@ func TestIPFIXOptionsSamplerDataSetDecode(t *testing.T) {
 			t.Errorf("rate %d: observationDomainId scope = %#x, want %#x", c.rate, got, odid)
 		}
 		if got := binary.BigEndian.Uint16(rec[4:6]); got != wantSystematicCountAlgo {
-			t.Errorf("rate %d: selectorAlgorithm = %d, want %d (systematic count-based)", c.rate, got, wantSystematicCountAlgo)
+			t.Errorf("rate %d: flowSelectorAlgorithm = %d, want %d (systematic count-based)", c.rate, got, wantSystematicCountAlgo)
 		}
-		if got := binary.BigEndian.Uint32(rec[6:10]); got != 1 {
-			t.Errorf("rate %d: samplingPacketInterval = %d, want 1", c.rate, got)
+		if got := binary.BigEndian.Uint64(rec[6:14]); got != 1 {
+			t.Errorf("rate %d: samplingFlowInterval = %d, want 1", c.rate, got)
 		}
-		if got := binary.BigEndian.Uint32(rec[10:14]); got != c.wantSpace {
-			t.Errorf("rate %d: samplingPacketSpace = %d, want %d (N-1)", c.rate, got, c.wantSpace)
+		if got := binary.BigEndian.Uint64(rec[14:22]); got != c.wantSpace {
+			t.Errorf("rate %d: samplingFlowSpacing = %d, want %d (N-1)", c.rate, got, c.wantSpace)
 		}
 	}
 }
@@ -156,7 +179,8 @@ func TestIPFIXOptionsSamplerDataSetDecode(t *testing.T) {
 //     Record (Set ID 258);
 //   - the options record scope (observationDomainId) equals the group's ODID
 //     (== the message header ObservationID);
-//   - the advertised rate is systematic count-based, interval=1, space=N-1;
+//   - the advertised rate is systematic count-based FLOW selection (RFC 7014),
+//     samplingFlowInterval=1, samplingFlowSpacing=N-1;
 //   - the Options Data Record advances the header Sequence Number by exactly one
 //     (it is a Data Record; #2609 convention).
 //
@@ -245,9 +269,15 @@ func TestIPFIXSamplerOptionsWireLoopback(t *testing.T) {
 	if len(specs) < 1 || specs[0].elementID != wantObservationDomainIDIE {
 		t.Errorf("wire scope field = %+v, want observationDomainId (IE %d)", specs, wantObservationDomainIDIE)
 	}
-	for _, ie := range []uint16{wantSelectorAlgorithmIE, wantSamplingIntervalIE, wantSamplingSpaceIE} {
+	for _, ie := range []uint16{wantFlowSelectorAlgorithmIE, wantSamplingFlowIntervalIE, wantSamplingFlowSpacingIE} {
 		if _, ok := findSpec(specs, ie, 0); !ok {
-			t.Errorf("wire options template missing sampler IE %d", ie)
+			t.Errorf("wire options template missing flow-selection sampler IE %d", ie)
+		}
+	}
+	// #5312: the packet-selection IEs must not ride the wire template.
+	for _, bad := range []uint16{psampSelectorAlgorithmIE, psampSamplingPacketInterval, psampSamplingPacketSpace} {
+		if _, ok := findSpec(specs, bad, 0); ok {
+			t.Errorf("wire options template advertises packet-selection IE %d — must be RFC 7014 flow-selection", bad)
 		}
 	}
 
@@ -263,13 +293,13 @@ func TestIPFIXSamplerOptionsWireLoopback(t *testing.T) {
 		t.Errorf("wire options record scope ODID = %#x, want %#x", got, e.sourceID)
 	}
 	if got := binary.BigEndian.Uint16(rec[4:6]); got != wantSystematicCountAlgo {
-		t.Errorf("wire selectorAlgorithm = %d, want %d", got, wantSystematicCountAlgo)
+		t.Errorf("wire flowSelectorAlgorithm = %d, want %d", got, wantSystematicCountAlgo)
 	}
-	if got := binary.BigEndian.Uint32(rec[6:10]); got != 1 {
-		t.Errorf("wire samplingPacketInterval = %d, want 1", got)
+	if got := binary.BigEndian.Uint64(rec[6:14]); got != 1 {
+		t.Errorf("wire samplingFlowInterval = %d, want 1", got)
 	}
-	if got := binary.BigEndian.Uint32(rec[10:14]); got != rate-1 {
-		t.Errorf("wire samplingPacketSpace = %d, want %d (N-1)", got, rate-1)
+	if got := binary.BigEndian.Uint64(rec[14:22]); got != uint64(rate-1) {
+		t.Errorf("wire samplingFlowSpacing = %d, want %d (N-1)", got, rate-1)
 	}
 
 	// The Options Data Record is a Data Record: it advanced the counter by one.


### PR DESCRIPTION
Closes #5312

## Problem
`ShouldExport` samples 1-in-N at **session-record (Flow) granularity** — the modulo is applied per `SESSION_CLOSE` event, selecting whole Flows, not 1-in-N packets in the datapath (unlike Junos jflow). But the IPFIX sampler Options Data Record (#3748) advertised the **PSAMP packet-selection** Information Elements:

| IE | Name | Value |
|----|------|-------|
| 304 | `selectorAlgorithm` | 1 (Systematic count-based) |
| 305 | `samplingPacketInterval` | 1 |
| 306 | `samplingPacketSpace` | N-1 |

Per RFC 7011/5476 semantics, a standards-based collector reads that Options Record as **packet sampling** and renormalizes each record's `octetDeltaCount` / `packetDeltaCount` by N. xpf already exports the **complete per-session** octet/packet totals, so this inflates traffic/capacity/billing/anomaly estimates by N× — while the export still looks wire-compliant. The only guard was a code comment ("must NOT additionally multiply `octetDeltaCount` by N") that no wire field carried. This is the residual #5312 defect from #3748 (distinct from #4923/#5048/#5211).

## Fix — describe FLOW selection, not packet sampling
Replace the PSAMP packet-selection IEs with the **RFC 7014 (Flow Selection Techniques)** flow-selection IEs — the flow-granularity analog of the PSAMP set:

| IE | Name | Type | Value |
|----|------|------|-------|
| 149 | `observationDomainId` | u32 | group ODID (scope, #3740) |
| 390 | `flowSelectorAlgorithm` | u16 | 1 (Systematic count-based, IANA "Flow Selector Algorithm" registry) |
| 396 | `samplingFlowInterval` | u64 | 1 (Flows consecutively selected) |
| 397 | `samplingFlowSpacing` | u64 | N-1 (Flows skipped between intervals) |

### PSAMP vs Flow selection semantics
- **Packet selection (RFC 5476, IE 304/305/306):** each retained packet represents N packets → collector scales the *per-record* octet/packet counters by N. Wrong for xpf (records are already complete).
- **Flow selection (RFC 7014, IE 390/396/397):** the record is complete for the Flow it describes; the collector received 1/N of all Flows → it scales the **population** (flow count / aggregate volume) by N and leaves per-record counters intact. This is exactly xpf's record-granularity sampling.

The algorithm value stays `1` (Systematic count-based is value 1 in both the PSAMP Selection Method and the Flow Selector Algorithm registries); only the surrounding IEs change so a collector interprets it as flow selection. The Options Data Record grows 14→22 bytes (flow interval/spacing are u64 vs the packet IEs' u32); `ipfixOptionsSamplerRecordSize` and its build-time pin move to 22.

Chose the static systematic count-based interval/spacing form over the `selectorIDTotalFlowsObserved`/`selectorIDTotalFlowsSelected` (394/395) counter pair — it is the direct analog of the fixed per-group config and needs no live per-flow counters.

## RED-on-revert evidence
`ipfix_sampler_test.go` now pins the flow-selection IEs (390/396/397 with u64 widths, record size 22) **and** asserts the packet-selection IEs (304/305/306) are ABSENT from both the encoder output and the wire template. Reverting only the production `pkg/flowexport/ipfix.go` to `origin/master` (keeping the new tests):

```
--- FAIL: TestIPFIXOptionsTemplateSetDecode
    field[1] = {elementID:304 length:2}, want elementID=390 length=2
    field[2] = {elementID:305 length:4}, want elementID=396 length=8
    field[3] = {elementID:306 length:4}, want elementID=397 length=8
    options template advertises packet-selection IE 304 — record-granularity sampling must use RFC 7014 flow-selection IEs (390/396/397)
    ... (305, 306)
--- FAIL: TestIPFIXOptionsSamplerDataSetDecode
    rate 100: samplingFlowInterval = 4294967395, want 1
    panic: slice bounds out of range [:22] with capacity 14
FAIL
```

## Validation
- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` — exit 0
- `go test -count=1 ./pkg/flowexport/...` — PASS
- `gofmt -l` on touched files — clean
- Docs: updated `pkg/flowexport/README.md` #3748/#5312 sampler section (IE table, semantics, test list).

No cluster smoke (control-plane encoding change, unit-tested on the wire path via the loopback UDP collector test).