### PR TITLE
pkg/frr: install reject/blackhole route for static-route reject/discard (#5298)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45020,3 +45020,36 @@ top.
   pkg/flowexport/README.md #3748/#5312 sampler section.
 - **File(s)**: pkg/flowexport/ipfix.go, pkg/flowexport/ipfix_sampler_test.go,
   pkg/flowexport/README.md, _Log.md
+
+- **Timestamp**: 2026-07-10
+- **Action**: #5298 — install FRR reject/blackhole route for static-route
+  reject/discard (fix the silently-erased `reject`). The schema
+  (`schema_routing.go`) already accepted a `route <prefix> reject` leaf and
+  `isRouteInlineKeyword` already treated `reject` as a clause boundary, but
+  `StaticRoute` carried only `Discard` and neither the inline nor the
+  hierarchical action switch in `compileStaticRoutes` handled `reject` — so a
+  committed reject compiled to a no-next-hop, non-discard route, which the FRR
+  renderer (post-#3872) deliberately renders as NOTHING, letting matching
+  traffic fall through to a less-specific route (a security/vsrx-parity
+  fail-wide). Added `StaticRoute.Reject`; handled `reject` in both action
+  switches + the same-destination merge; taught `generateStaticRouteInTable`
+  to emit `ip|ipv6 route <dst> reject [<pref>] [vrf/table]` (RTN_UNREACHABLE →
+  ICMP unreachable) while `discard` keeps `Null0` (RTN_BLACKHOLE, silent).
+  Folded `Reject` into the userspace AF_XDP FIB silent-drop snapshot
+  (`buildRouteSnapshots`) so the fast path drops the prefix instead of
+  LPM-matching a less-specific route; added `reject` display parity to CLI +
+  gRPC `show route` and mirrored the `Discard` skip in daemon neighbor
+  pre-resolution. Junos vs FRR semantics: Junos reject→FRR reject (ICMP),
+  Junos discard→FRR Null0/blackhole (silent). Tests: end-to-end compile→FRR
+  render (v4+v6, reject + discard) in pkg/frr, compiler-propagation (flat-set
+  + hierarchical) in pkg/config; proved RED-on-revert (reverting the compiler
+  reject cases and the render change fails the four reject tests while the
+  discard guards stay green). Regenerated golden_4406 baseline (additive
+  `Reject:false` field only, no behavior change). Build + touched-package
+  tests green.
+- **File(s)**: pkg/config/types_routing.go, pkg/config/compiler_routing.go,
+  pkg/frr/config_render.go, pkg/dataplane/userspace/routes.go,
+  pkg/cli/cli_show_routing.go, pkg/grpcapi/server_show_routes_text.go,
+  pkg/daemon/daemon_neighbor.go, pkg/config/compiler_static_reject_5298_test.go,
+  pkg/frr/static_reject_5298_test.go, pkg/config/testdata/golden_4406.json,
+  pkg/frr/README.md, _Log.md

--- a/pkg/cli/cli_show_routing.go
+++ b/pkg/cli/cli_show_routing.go
@@ -903,6 +903,10 @@ func (c *CLI) showRoutingOptions() error {
 				fmt.Printf("  %-24s %-20s %-6s %s\n", sr.Destination, "discard", fmtPref(sr.Preference), "")
 				continue
 			}
+			if sr.Reject {
+				fmt.Printf("  %-24s %-20s %-6s %s\n", sr.Destination, "reject", fmtPref(sr.Preference), "")
+				continue
+			}
 			if sr.NextTable != "" {
 				fmt.Printf("  %-24s %-20s %-6s %s\n", sr.Destination, "next-table "+sr.NextTable, fmtPref(sr.Preference), "")
 				continue
@@ -929,6 +933,10 @@ func (c *CLI) showRoutingOptions() error {
 		for _, sr := range ro.Inet6StaticRoutes {
 			if sr.Discard {
 				fmt.Printf("  %-40s %-30s %-6s\n", sr.Destination, "discard", fmtPref(sr.Preference))
+				continue
+			}
+			if sr.Reject {
+				fmt.Printf("  %-40s %-30s %-6s\n", sr.Destination, "reject", fmtPref(sr.Preference))
 				continue
 			}
 			if sr.NextTable != "" {
@@ -1036,6 +1044,10 @@ func (c *CLI) showRoutingInstances(detail bool) error {
 			for _, sr := range ri.StaticRoutes {
 				if sr.Discard {
 					fmt.Printf("    %s -> discard\n", sr.Destination)
+					continue
+				}
+				if sr.Reject {
+					fmt.Printf("    %s -> reject\n", sr.Destination)
 					continue
 				}
 				// #4908 (C175-HC-129): a next-table static route has no

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -240,6 +240,8 @@ func compileStaticRoutes(staticNode *Node, existing []*StaticRoute) []*StaticRou
 					}
 				case "discard":
 					route.Discard = true
+				case "reject":
+					route.Reject = true
 				case "preference":
 					if i+1 < len(routeInst.node.Keys) {
 						i++
@@ -294,6 +296,8 @@ func compileStaticRoutes(staticNode *Node, existing []*StaticRoute) []*StaticRou
 				}
 			case "discard":
 				route.Discard = true
+			case "reject":
+				route.Reject = true
 			case "preference":
 				if v := nodeVal(prop); v != "" {
 					if n, err := strconv.Atoi(v); err == nil {
@@ -357,6 +361,9 @@ func compileStaticRoutes(staticNode *Node, existing []*StaticRoute) []*StaticRou
 			existingRoute.NextHops = append(existingRoute.NextHops, route.NextHops...)
 			if route.Discard {
 				existingRoute.Discard = true
+			}
+			if route.Reject {
+				existingRoute.Reject = true
 			}
 			if route.Preference != 5 {
 				existingRoute.Preference = route.Preference

--- a/pkg/config/compiler_static_reject_5298_test.go
+++ b/pkg/config/compiler_static_reject_5298_test.go
@@ -1,0 +1,76 @@
+package config
+
+import "testing"
+
+// A Junos `route <prefix> reject` must compile to a StaticRoute carrying the
+// Reject disposition (an unreachable route: drop + ICMP unreachable), distinct
+// from `discard` (a silent blackhole). Before #5298 the compiler's static-route
+// action switch handled only `discard`/`preference`, so a committed `reject`
+// (accepted by the schema) was silently dropped: no disposition, no next-hop —
+// and the FRR renderer then emitted nothing, letting matching traffic fall
+// through to a less-specific route (a fail-wide). RED-on-revert: Reject stays
+// false (the reject intent is erased end to end).
+func TestStaticRouteRejectCompiles_5298(t *testing.T) {
+	c := compileSets3870(t, []string{
+		"set routing-options static route 10.9.0.0/16 reject",
+		"set routing-options static route 2001:db8:dead::/48 reject",
+	})
+
+	v4 := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "10.9.0.0/16")
+	if !v4.Reject {
+		t.Errorf("v4 route 10.9.0.0/16: Reject=false, want true (reject erased #5298)")
+	}
+	if v4.Discard {
+		t.Errorf("v4 reject route must NOT set Discard (reject != silent blackhole)")
+	}
+	if len(v4.NextHops) != 0 {
+		t.Errorf("reject route must have no next-hops, got %+v", v4.NextHops)
+	}
+
+	v6 := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "2001:db8:dead::/48")
+	if !v6.Reject {
+		t.Errorf("v6 route 2001:db8:dead::/48: Reject=false, want true (reject erased #5298)")
+	}
+}
+
+// The hierarchical brace form must compile identically to the flat-set form.
+func TestStaticRouteRejectHierarchical_5298(t *testing.T) {
+	tree, errs := NewParser(`
+routing-options {
+    static {
+        route 172.16.0.0/12 {
+            reject;
+        }
+    }
+}
+`).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	c, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	r := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "172.16.0.0/12")
+	if !r.Reject {
+		t.Errorf("hierarchical reject route: Reject=false, want true")
+	}
+	if r.Discard {
+		t.Errorf("hierarchical reject route must NOT set Discard")
+	}
+}
+
+// `discard` must still compile to Discard (and never Reject), guarding the
+// symmetric #5298 disposition split.
+func TestStaticRouteDiscardStillDiscard_5298(t *testing.T) {
+	c := compileSets3870(t, []string{
+		"set routing-options static route 10.8.0.0/16 discard",
+	})
+	r := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "10.8.0.0/16")
+	if !r.Discard {
+		t.Errorf("discard route: Discard=false, want true")
+	}
+	if r.Reject {
+		t.Errorf("discard route must NOT set Reject (discard = silent blackhole)")
+	}
+}

--- a/pkg/config/testdata/golden_4406.json
+++ b/pkg/config/testdata/golden_4406.json
@@ -835,6 +835,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           },
@@ -851,6 +852,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           },
@@ -867,6 +869,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           }
@@ -939,6 +942,7 @@
                 }
               ],
               "Discard": false,
+              "Reject": false,
               "Preference": 5,
               "NextTable": ""
             }
@@ -2078,6 +2082,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           },
@@ -2094,6 +2099,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           },
@@ -2110,6 +2116,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           }
@@ -2182,6 +2189,7 @@
                 }
               ],
               "Discard": false,
+              "Reject": false,
               "Preference": 5,
               "NextTable": ""
             }
@@ -3320,6 +3328,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           },
@@ -3336,6 +3345,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           },
@@ -3352,6 +3362,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           }
@@ -3424,6 +3435,7 @@
                 }
               ],
               "Discard": false,
+              "Reject": false,
               "Preference": 5,
               "NextTable": ""
             }
@@ -4562,6 +4574,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           },
@@ -4578,6 +4591,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           },
@@ -4594,6 +4608,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           }
@@ -4666,6 +4681,7 @@
                 }
               ],
               "Discard": false,
+              "Reject": false,
               "Preference": 5,
               "NextTable": ""
             }
@@ -5805,6 +5821,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           },
@@ -5821,6 +5838,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           },
@@ -5837,6 +5855,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           }
@@ -5909,6 +5928,7 @@
                 }
               ],
               "Discard": false,
+              "Reject": false,
               "Preference": 5,
               "NextTable": ""
             }
@@ -7047,6 +7067,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           },
@@ -7063,6 +7084,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           },
@@ -7079,6 +7101,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           }
@@ -7151,6 +7174,7 @@
                 }
               ],
               "Discard": false,
+              "Reject": false,
               "Preference": 5,
               "NextTable": ""
             }
@@ -8125,6 +8149,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           },
@@ -8141,6 +8166,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           }
@@ -9088,6 +9114,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           },
@@ -9104,6 +9131,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           }
@@ -10050,6 +10078,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           },
@@ -10066,6 +10095,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           }
@@ -11012,6 +11042,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           },
@@ -11028,6 +11059,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           }
@@ -11975,6 +12007,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           },
@@ -11991,6 +12024,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           }
@@ -12937,6 +12971,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           },
@@ -12953,6 +12988,7 @@
               }
             ],
             "Discard": false,
+            "Reject": false,
             "Preference": 5,
             "NextTable": ""
           }

--- a/pkg/config/types_routing.go
+++ b/pkg/config/types_routing.go
@@ -225,9 +225,15 @@ type NextHopEntry struct {
 type StaticRoute struct {
 	Destination string         // CIDR: "10.0.0.0/8" or "::/0"
 	NextHops    []NextHopEntry // multiple next-hops = ECMP
-	Discard     bool           // null route (blackhole)
-	Preference  int            // route preference (admin distance), default 5
-	NextTable   string         // routing instance name for inter-VRF route leaking (e.g. "Comcast.inet.0" → "Comcast")
+	Discard     bool           // null route (blackhole): silently drop matching traffic
+	// Reject installs an unreachable route: matching traffic is dropped AND an
+	// ICMP unreachable is returned to the source (Junos `route <p> reject` →
+	// FRR `ip route <p> reject`). Distinct from Discard (Junos `discard` → FRR
+	// Null0/blackhole, a silent drop). Both suppress a next-hop; Reject and
+	// Discard are mutually exclusive per route (Junos allows only one action).
+	Reject     bool
+	Preference int    // route preference (admin distance), default 5
+	NextTable  string // routing instance name for inter-VRF route leaking (e.g. "Comcast.inet.0" → "Comcast")
 }
 
 // ProtocolsConfig holds dynamic routing protocol configuration.

--- a/pkg/daemon/daemon_neighbor.go
+++ b/pkg/daemon/daemon_neighbor.go
@@ -155,7 +155,7 @@ func (d *Daemon) collectNeighborProbeTargets(cfg *config.Config) []neighborProbe
 	allStaticRoutes = append(allStaticRoutes, cfg.RoutingOptions.StaticRoutes...)
 	allStaticRoutes = append(allStaticRoutes, cfg.RoutingOptions.Inet6StaticRoutes...)
 	for _, sr := range allStaticRoutes {
-		if sr.Discard {
+		if sr.Discard || sr.Reject {
 			continue
 		}
 		for _, nh := range sr.NextHops {
@@ -177,7 +177,7 @@ func (d *Daemon) collectNeighborProbeTargets(cfg *config.Config) []neighborProbe
 		riStaticRoutes = append(riStaticRoutes, ri.StaticRoutes...)
 		riStaticRoutes = append(riStaticRoutes, ri.Inet6StaticRoutes...)
 		for _, sr := range riStaticRoutes {
-			if sr.Discard {
+			if sr.Discard || sr.Reject {
 				continue
 			}
 			for _, nh := range sr.NextHops {

--- a/pkg/dataplane/userspace/routes.go
+++ b/pkg/dataplane/userspace/routes.go
@@ -65,9 +65,18 @@ func buildRouteSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot, ove
 				Table:       tableName,
 				Family:      familyName,
 				Destination: route.Destination,
-				Discard:     route.Discard,
-				NextTable:   route.NextTable,
-				Preference:  route.Preference,
+				// #5298: a `reject` route drops on the AF_XDP fast path the same
+				// way `discard` does. Without an entry in the userspace FIB, a
+				// reject prefix would longest-prefix-match a less-specific route
+				// (e.g. the default) and forward — the identical fail-wide the
+				// FRR/kernel reject route closes. Fold reject into the helper's
+				// silent-drop disposition (fail-closed). The ICMP-unreachable
+				// distinction (reject vs discard) is emitted by the kernel/FRR
+				// reject route today; a userspace-generated ICMP unreachable is a
+				// follow-up that would need a dedicated RouteSnapshot field.
+				Discard:    route.Discard || route.Reject,
+				NextTable:  route.NextTable,
+				Preference: route.Preference,
 			}
 			for _, nh := range route.NextHops {
 				switch {

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -168,6 +168,26 @@ also carries operator content:
   (no `preference`) therefore does NOT float: with `HasPreference == false` it
   renders at the route-level distance, equal-cost with the primary — a
   `preference` is REQUIRED to make a qualified-next-hop a floating backup.
+- **Negative routes: `discard` vs `reject` (#5298).** A static route's
+  terminal `discard` or `reject` action installs an ACTIVE no-next-hop route
+  so matching traffic is dropped instead of following a less-specific route.
+  The two differ in what the source sees: `discard` → FRR `Null0`
+  (`RTN_BLACKHOLE`, a SILENT drop), `reject` → FRR `reject`
+  (`RTN_UNREACHABLE`, drop + ICMP unreachable to the source). The compiler
+  (`compileStaticRoutes`) sets `StaticRoute.Discard` / `StaticRoute.Reject`
+  (mutually exclusive) from both the inline route-keys and hierarchical/
+  flat-set action switches, and `generateStaticRouteInTable` emits the single
+  line `ip|ipv6 route <dst> (Null0|reject) [<pref>] [vrf/table]` for either
+  BEFORE the empty-next-hops guard. Before #5298 the compiler handled only
+  `discard`; a committed `reject` (accepted by the schema leaf) was silently
+  dropped end-to-end — no disposition, no next-hop — and the renderer then
+  emitted NOTHING for the resulting no-next-hop route, so the reject prefix
+  fell through to the default (a fail-wide). The userspace AF_XDP FIB folds
+  `Reject` into its silent-drop disposition (`buildRouteSnapshots`, #5298) so
+  the fast path drops the prefix too rather than LPM-matching a less-specific
+  route; a userspace-generated ICMP unreachable (vs the kernel/FRR reject
+  route's ICMP) is a follow-up. A no-next-hop route WITHOUT `discard`/`reject`
+  still renders nothing (#3872), not a blackhole.
 - **VRRP-VIP-only subnets (#2452 secondary).** A bondless-RETH member that
   carries only a VRRP virtual address (no matching `unit.Addresses` entry)
   also contributes its VIP subnet as a connected prefix, so a static

--- a/pkg/frr/config_render.go
+++ b/pkg/frr/config_render.go
@@ -113,20 +113,30 @@ func (m *Manager) generateStaticRouteInTable(sr *config.StaticRoute, vrfName str
 		vrfPart = fmt.Sprintf(" table %d", tableID)
 	}
 
-	// Explicit discard (blackhole) route: single Null0 line.
-	if sr.Discard {
+	// Negative routes (no next-hop, single line). Junos `discard` and `reject`
+	// both install an active route so matching traffic is dropped instead of
+	// following a less-specific route, but differ in what the source sees:
+	//   - discard → FRR Null0 (RTN_BLACKHOLE): silent drop, no ICMP.
+	//   - reject  → FRR reject (RTN_UNREACHABLE): drop + ICMP unreachable.
+	// Without this, a committed reject compiled to a no-next-hop route rendered
+	// nothing (#5298) and the traffic fell through to the default — a fail-wide.
+	if sr.Discard || sr.Reject {
 		nexthop := "Null0"
+		if sr.Reject {
+			nexthop = "reject"
+		}
 		if sr.Preference > 0 {
 			return fmt.Sprintf("%s route %s %s %d%s\n", prefix, sr.Destination, nexthop, sr.Preference, vrfPart)
 		}
 		return fmt.Sprintf("%s route %s %s%s\n", prefix, sr.Destination, nexthop, vrfPart)
 	}
 
-	// A non-discard route with NO next-hops is incomplete — e.g. every gateway
-	// of an ECMP `next-hop [ a b ]` list was deleted (#3872 delete-side). Render
-	// NOTHING rather than a Null0 blackhole: silently blackholing traffic that
-	// would otherwise fall through to a default / more-specific route is a
-	// fail-wide. (An explicit `discard` above still renders Null0.)
+	// A route with NO next-hops and no discard/reject action is incomplete —
+	// e.g. every gateway of an ECMP `next-hop [ a b ]` list was deleted (#3872
+	// delete-side). Render NOTHING rather than a Null0 blackhole: silently
+	// blackholing traffic that would otherwise fall through to a default /
+	// more-specific route is a fail-wide. (An explicit `discard`/`reject`
+	// above still renders its negative-route line.)
 	if len(sr.NextHops) == 0 {
 		return ""
 	}

--- a/pkg/frr/static_reject_5298_test.go
+++ b/pkg/frr/static_reject_5298_test.go
@@ -1,0 +1,103 @@
+package frr
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// compileStaticReject5298 compiles flat-set lines to a typed *Config using the
+// ParseSetCommand + SetPath loop (NewParser merges newlines across set lines —
+// the documented parser gotcha), so the render below exercises the real
+// compile → typed → FRR lowering, not a hand-built StaticRoute.
+func compileStaticReject5298(t *testing.T, cmds []string) *config.Config {
+	t.Helper()
+	tree := &config.ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := config.ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	c, err := config.CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return c
+}
+
+func findStaticReject5298(t *testing.T, routes []*config.StaticRoute, dest string) *config.StaticRoute {
+	t.Helper()
+	for _, r := range routes {
+		if r.Destination == dest {
+			return r
+		}
+	}
+	t.Fatalf("static route %s not found in compiled config", dest)
+	return nil
+}
+
+// A committed `route <prefix> reject` must render an FRR unreachable route
+// (`ip route <prefix> reject`) so matching traffic is dropped AND the source
+// receives an ICMP unreachable — the Junos reject semantics. Before #5298 the
+// compiler dropped the reject disposition and the renderer emitted NOTHING for
+// the resulting no-next-hop route, so the reject prefix fell through to a
+// less-specific route (a fail-wide). RED-on-revert: got == "" (route erased).
+func TestStaticRejectRendersUnreachable_5298(t *testing.T) {
+	m := New()
+	c := compileStaticReject5298(t, []string{
+		"set routing-options static route 10.9.0.0/16 reject",
+		"set routing-options static route 2001:db8:dead::/48 reject",
+	})
+
+	v4 := findStaticReject5298(t, c.RoutingOptions.StaticRoutes, "10.9.0.0/16")
+	if got, want := m.generateStaticRoute(v4, "", nil, nil), "ip route 10.9.0.0/16 reject 5\n"; got != want {
+		t.Errorf("v4 reject render = %q, want %q", got, want)
+	}
+
+	v6 := findStaticReject5298(t, c.RoutingOptions.StaticRoutes, "2001:db8:dead::/48")
+	if got, want := m.generateStaticRoute(v6, "", nil, nil), "ipv6 route 2001:db8:dead::/48 reject 5\n"; got != want {
+		t.Errorf("v6 reject render = %q, want %q", got, want)
+	}
+}
+
+// A committed `discard` must still render Null0 (RTN_BLACKHOLE, silent drop) —
+// the symmetric #5298 disposition split must NOT regress discard into a reject.
+func TestStaticDiscardRendersNull0_5298(t *testing.T) {
+	m := New()
+	c := compileStaticReject5298(t, []string{
+		"set routing-options static route 10.8.0.0/16 discard",
+		"set routing-options static route 2001:db8:beef::/48 discard",
+	})
+
+	v4 := findStaticReject5298(t, c.RoutingOptions.StaticRoutes, "10.8.0.0/16")
+	if got, want := m.generateStaticRoute(v4, "", nil, nil), "ip route 10.8.0.0/16 Null0 5\n"; got != want {
+		t.Errorf("v4 discard render = %q, want %q", got, want)
+	}
+
+	v6 := findStaticReject5298(t, c.RoutingOptions.StaticRoutes, "2001:db8:beef::/48")
+	if got, want := m.generateStaticRoute(v6, "", nil, nil), "ipv6 route 2001:db8:beef::/48 Null0 5\n"; got != want {
+		t.Errorf("v6 discard render = %q, want %q", got, want)
+	}
+}
+
+// Direct render assertion (no compile) pinning the reject line shape at a
+// non-default preference and in a VRF, mirroring the discard render contract.
+func TestStaticRejectRenderShape_5298(t *testing.T) {
+	m := New()
+
+	// Default preference (0 in a hand-built route → no trailing distance).
+	sr := &config.StaticRoute{Destination: "192.0.2.0/24", Reject: true}
+	if got, want := m.generateStaticRoute(sr, "", nil, nil), "ip route 192.0.2.0/24 reject\n"; got != want {
+		t.Errorf("reject (no pref) = %q, want %q", got, want)
+	}
+
+	// Explicit preference + VRF.
+	srPref := &config.StaticRoute{Destination: "192.0.2.0/24", Reject: true, Preference: 20}
+	if got, want := m.generateStaticRoute(srPref, "blue", nil, nil), "ip route 192.0.2.0/24 reject 20 vrf blue\n"; got != want {
+		t.Errorf("reject (pref+vrf) = %q, want %q", got, want)
+	}
+}

--- a/pkg/grpcapi/server_show_routes_text.go
+++ b/pkg/grpcapi/server_show_routes_text.go
@@ -328,6 +328,10 @@ func (s *Server) showRoutingOptions(cfg *config.Config, buf *strings.Builder) {
 					fmt.Fprintf(buf, "  %-24s %-20s %s\n", sr.Destination, "discard", fmtPref(sr.Preference))
 					continue
 				}
+				if sr.Reject {
+					fmt.Fprintf(buf, "  %-24s %-20s %s\n", sr.Destination, "reject", fmtPref(sr.Preference))
+					continue
+				}
 				if sr.NextTable != "" {
 					fmt.Fprintf(buf, "  %-24s %-20s %s\n", sr.Destination, "next-table "+sr.NextTable, fmtPref(sr.Preference))
 					continue
@@ -353,6 +357,10 @@ func (s *Server) showRoutingOptions(cfg *config.Config, buf *strings.Builder) {
 			for _, sr := range ro.Inet6StaticRoutes {
 				if sr.Discard {
 					fmt.Fprintf(buf, "  %-40s %-30s %s\n", sr.Destination, "discard", fmtPref(sr.Preference))
+					continue
+				}
+				if sr.Reject {
+					fmt.Fprintf(buf, "  %-40s %-30s %s\n", sr.Destination, "reject", fmtPref(sr.Preference))
 					continue
 				}
 				if sr.NextTable != "" {
@@ -454,6 +462,10 @@ func (s *Server) showRoutingInstancesDetail(cfg *config.Config, buf *strings.Bui
 				for _, sr := range ri.StaticRoutes {
 					if sr.Discard {
 						fmt.Fprintf(buf, "    %s -> discard\n", sr.Destination)
+						continue
+					}
+					if sr.Reject {
+						fmt.Fprintf(buf, "    %s -> reject\n", sr.Destination)
 						continue
 					}
 					for _, nh := range sr.NextHops {


### PR DESCRIPTION
Closes #5298

## Problem
A Junos `routing-options static route <prefix> reject` was **silently erased**. The config schema (`schema_routing.go`) accepts the `reject` leaf and `isRouteInlineKeyword` already treats `reject` as a clause boundary, but `StaticRoute` carried only `Discard` and **neither the inline nor the hierarchical action switch** in `compileStaticRoutes` handled `reject`. So a committed reject compiled to a **no-next-hop, non-discard** route, and the FRR renderer (deliberately, post-#3872) emits **nothing** for such a route — the reject prefix then falls through to a less-specific route (e.g. the default) instead of being dropped. That is a security / vSRX-parity **fail-wide**: traffic the operator meant to block was forwarded.

Verified on current `origin/master`: `pkg/config/compiler_routing.go` action switches handle only `discard`/`preference`; `pkg/config/types_routing.go StaticRoute` had no reject disposition; `pkg/frr/config_render.go` renders `""` for a no-next-hop non-discard route.

## Junos vs FRR semantics (the crux)
| Junos action | Effect | FRR route | Kernel type |
|---|---|---|---|
| `reject`  | drop **+ ICMP unreachable** to source | `ip route <p> reject` | `RTN_UNREACHABLE` |
| `discard` | **silent** drop | `ip route <p> Null0` | `RTN_BLACKHOLE` |

`discard` already rendered `Null0` correctly; **only `reject` was broken.**

## Fix
- Add `StaticRoute.Reject` (mutually exclusive with `Discard`); set it from both action switches + the same-destination merge.
- `generateStaticRouteInTable` emits `ip|ipv6 route <dst> reject [<pref>] [vrf/table]` (v4 + v6), **before** the empty-next-hops guard; discard keeps `Null0`.
- Fold `Reject` into the userspace AF_XDP FIB silent-drop snapshot (`buildRouteSnapshots`) so the fast path drops the prefix rather than LPM-matching a less-specific route — the identical fail-wide on the dataplane side. (A userspace-generated ICMP unreachable, vs the kernel/FRR reject route's ICMP, is a follow-up needing a dedicated `RouteSnapshot` field.)
- `reject` display parity in CLI + gRPC `show route`; mirror the `Discard` skip in daemon neighbor pre-resolution.

## RED-on-revert evidence
Reverting the two compiler `reject` cases + the render change:
```
--- FAIL: TestStaticRejectRendersUnreachable_5298
--- PASS: TestStaticDiscardRendersNull0_5298          (discard unaffected)
--- FAIL: TestStaticRejectRenderShape_5298
--- FAIL: TestStaticRouteRejectCompiles_5298
--- FAIL: TestStaticRouteRejectHierarchical_5298
--- PASS: TestStaticRouteDiscardStillDiscard_5298     (discard unaffected)
```
All four reject assertions fail on revert; the discard guards stay green. Fix restored → all green.

## Validation
- `go build ./...` exit 0; `go test ./pkg/frr/... ./pkg/config/... ./pkg/dataplane/userspace/... ./pkg/grpcapi/... ./pkg/cli/... ./pkg/daemon/... ./pkg/api/...` pass; `gofmt` clean.
- Tests: end-to-end compile→FRR render (v4 + v6, reject + discard) in `pkg/frr`; compiler propagation (flat-set + hierarchical) in `pkg/config`.
- Regenerated `golden_4406.json` — diff is **only** the additive `"Reject": false` field on every static route (verified: no behavior change).
- Documented the discard-vs-reject negative-route render contract in `pkg/frr/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi