### PR TITLE
pkg/ra: restore sender in join-timeout reclaimer (#5094)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45020,3 +45020,28 @@ top.
   pkg/flowexport/README.md #3748/#5312 sampler section.
 - **File(s)**: pkg/flowexport/ipfix.go, pkg/flowexport/ipfix_sampler_test.go,
   pkg/flowexport/README.md, _Log.md
+
+- **Timestamp**: 2026-07-10
+- **Action**: #5094 — ra join-timeout reclaimer no longer drops the owed
+  replacement / terminal goodbye. Before the fix, when a draining sender's owner
+  wedged past `claimWaitTimeout`, `releaseDrain` handed the tombstone to a
+  detached reclaimer that merely `delete`d it once the wedged owner exited —
+  losing the changed-config replacement (`onProvenClose`) and any owed
+  standalone goodbye, so the interface could stay senderless (or lose its
+  goodbye) until an unrelated later Apply re-drove it. Extracted the
+  proven-close ordered decision (goodbye claim-once + replacement +
+  supersession re-check) into `finishDrainDecision`; both `releaseDrain`'s
+  `<-stopped` arm AND the reclaimer now run it — the reclaimer waits for
+  `<-stopped` first (restoring the happens-before + old-conn-closed
+  precondition) so all #2033 invariants hold (≤1 live conn, ordered emit,
+  claim-once, epoch/ifaceEpoch supersession, entry-identity guard). Made
+  `onProvenClose` a bare `startLocked` closure and moved the #2834
+  make-before-break `waitConnReady` into `releaseDrain` to avoid a data race
+  on Apply-local state now that the closure runs in the reclaimer goroutine.
+  Added a `joinTimedOut` flag surfaced via `Manager.Status` / `show interfaces`
+  ("draining (join timed out; reclaiming)"). RED-on-revert proven: reverting the
+  reclaimer to delete-only fails all four timeout tests (replacement conn never
+  opens; owed goodbye never emitted). `go test -race ./pkg/ra/...` green.
+- **File(s)**: pkg/ra/ra.go, pkg/ra/reclaimer_sender_5094_test.go,
+  pkg/ra/serialize_test.go, pkg/ra/README.md,
+  pkg/grpcapi/server_show_interfaces_text.go, _Log.md

--- a/pkg/grpcapi/server_show_interfaces_text.go
+++ b/pkg/grpcapi/server_show_interfaces_text.go
@@ -460,8 +460,15 @@ func (s *Server) showIPv6RouterAdvertisement(cfg *config.Config, buf *strings.Bu
 				fmt.Fprintf(buf, "Interface: %s\n", info.Interface)
 				if info.State == "draining" {
 					// A withdrawing router (emitting its lifetime-0 goodbye);
-					// no longer advertising. Report state and move on.
-					fmt.Fprintln(buf, "  State:              draining (withdrawing)")
+					// no longer advertising. Report state and move on. #5094: a
+					// join-timed-out entry is being self-healed by the reclaimer
+					// (its wedged owner has not yet released) — surface that so
+					// an operator sees a stuck drain, not a silent hang.
+					if info.JoinTimedOut {
+						fmt.Fprintln(buf, "  State:              draining (join timed out; reclaiming)")
+					} else {
+						fmt.Fprintln(buf, "  State:              draining (withdrawing)")
+					}
 					fmt.Fprintln(buf)
 					continue
 				}

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -59,18 +59,26 @@ after HA failover. To make that **structural**, not flag-defended:
       the standalone never clobbers a re-claimed master and ≤1 live conn holds.
       The tombstone IS the mutual exclusion; there is no separate check-then-act
       on `m.senders`.
-    - **Timeout never emits AND never starts a replacement (closes the
-      happens-before break AND the ≤1-conn break on the restart path):**
-      `releaseDrain` reads `goodbyeEmitted` ONLY after a successful `<-stopped`.
-      If the join times out (`claimWaitTimeout` — pathological, since owner
-      writes are bounded by `SetWriteDeadline`), it does NOT emit a standalone
-      (the read would be unordered; the owner may be live) AND does NOT start
-      the changed-config replacement (the old conn may still be live → would
-      break ≤1-conn). It LEAVES the tombstone held — so any future
+    - **Timeout DEFERS the emit/replacement to the reclaimer — it must not
+      ERASE the owed action (#5094):** `releaseDrain` reads `goodbyeEmitted` /
+      opens a replacement ONLY after a successful `<-stopped`. If the join times
+      out (`claimWaitTimeout` — pathological, since owner writes are bounded by
+      `SetWriteDeadline`), it does NOT act inline (the `goodbyeEmitted` read
+      would be unordered and the old conn may still be live → a replacement
+      would break ≤1-conn). It LEAVES the tombstone held — so any future
       `Apply`/reconcile defers, never opening a second conn — and detaches a
-      reclaimer that removes the tombstone once the wedged owner finally exits.
-      The safe degraded state is "old sender lingers, no replacement, tombstone
-      held," never two conns and never an unordered emit.
+      reclaimer, handing it the SAME `startEpoch` + `onProvenClose`. The
+      reclaimer waits for `<-stopped` (the wedged owner finally proving its conn
+      closed — restoring the happens-before AND the old-conn-closed precondition)
+      and then runs the EXACT SAME ordered decision body (`finishDrainDecision`)
+      the proven-close arm runs: emit the owed goodbye and/or start the
+      still-current replacement, re-evaluated against fresh state under `m.mu`,
+      before removing the tombstone. A timeout thus DEFERS the action, never
+      drops it — the pre-#5094 reclaimer merely `delete`d the tombstone, leaving
+      the interface senderless (or its goodbye lost) until an unrelated later
+      `Apply` re-drove it. The transient degraded state is "old sender lingers,
+      no replacement yet, tombstone held (Status shows `join timed out`)" — never
+      two conns, never an unordered emit — self-healed once the owner exits.
   Net: EXACTLY ONE goodbye per withdrawn interface — the owner's if the
   upgrade landed, otherwise one standalone — and ZERO for a pure changed-config
   replace. Because the owner closes the conn AFTER its goodbye, a racing hard
@@ -82,7 +90,14 @@ after HA failover. To make that **structural**, not flag-defended:
   removal and the changed-config **restart**) all route through it. The restart
   passes an `onProvenClose` callback that opens the replacement conn — it runs
   ONLY on the proven-closed (`<-stopped`) arm, under `m.mu`, with the tombstone
-  still held, and only if no graceful withdraw superseded the replace. There is
+  still held, and only if no graceful withdraw superseded the replace. The
+  proven-close arm's "emit goodbye and/or start replacement, then release" logic
+  lives in ONE helper, `finishDrainDecision`, which the join-timeout reclaimer
+  ALSO runs after the wedged owner finally exits (#5094) — so a timeout defers
+  that same decision instead of a divergent path dropping it. `onProvenClose` is
+  a bare `startLocked` closure that touches no `Apply`-local state, precisely so
+  the reclaimer can run it in another goroutine without a data race; the
+  make-before-break `waitConnReady` now lives inside `releaseDrain`. There is
   no divergent inline copy of these rules, so the timeout / happens-before /
   ≤1-conn class cannot reappear in a third path.
 - **Replacement decision is atomic under the act-lock (round-5).** The
@@ -245,7 +260,10 @@ never retried and the stale IPv6 default-router identity lingered on hosts
   `State == "active"`; an interface whose sender is tearing down /
   emitting its goodbye is reported with `State == "draining"` (distinct
   from active, so a withdrawing router is neither read as still
-  advertising nor silently invisible).
+  advertising nor silently invisible). A draining entry whose owner wedged
+  past the join timeout also sets `JoinTimedOut` (#5094) so the display can
+  show `draining (join timed out; reclaiming)` — a stuck drain being
+  self-healed by the reclaimer, not a silent hang.
 
 ## Callers
 

--- a/pkg/ra/ra.go
+++ b/pkg/ra/ra.go
@@ -59,6 +59,14 @@ type drainEntry struct {
 	// interface) superseded the restart. It is 0 (and unused) for removal /
 	// Clear / WithdrawOnce entries, which pass onProvenClose=nil.
 	startIfaceEpoch uint64
+
+	// joinTimedOut records that releaseDrain gave up joining this entry's owner
+	// within claimWaitTimeout and handed the tombstone to the detached reclaimer
+	// (#5094). It is set true when the reclaimer is armed and surfaced in
+	// Manager.Status so an operator sees a wedged-owner interface as "join timed
+	// out; reclaiming" rather than a plain draining that silently converges. The
+	// reclaimer, not this flag, still owns the eventual goodbye/replacement.
+	joinTimedOut bool
 }
 
 // Manager manages per-interface RA sender goroutines.
@@ -178,26 +186,74 @@ func (m *Manager) releaseDrain(name string, s *sender, startEpoch uint64, onProv
 		case <-s.stopped:
 			// proven closed — fall through to the ordered decision below.
 		case <-t.C:
-			slog.Warn("ra: timed out joining draining sender; not emitting a "+
-				"standalone goodbye and not starting a replacement (owner may "+
-				"still hold a live conn); leaving tombstone held", "interface", name)
-			m.reclaimTombstoneWhenStopped(name, s)
+			slog.Warn("ra: timed out joining draining sender; deferring the "+
+				"goodbye/replacement to the reclaimer (owner may still hold a "+
+				"live conn); leaving tombstone held", "interface", name)
+			// #5094: the timeout defers, it must NOT erase this generation's
+			// owed action. Hand the SAME startEpoch + onProvenClose (nil for a
+			// removal/withdraw) to the detached reclaimer, which re-evaluates
+			// them against fresh state once the wedged owner finally proves
+			// closed — instead of dropping the replacement/goodbye and leaving
+			// the interface senderless until an unrelated later Apply re-drives
+			// it.
+			m.reclaimTombstoneWhenStopped(name, s, startEpoch, onProvenClose)
 			return nil
 		}
 	}
 
-	// Proven closed (or s==nil). The goodbye claim and the replacement decision
-	// are made against FRESH state at the act point. Because goodbyeWanted only
-	// goes false→true and epoch only increases, we may need at most one emit
-	// pass (claim → unlock → blocking emit → re-lock); a late Withdraw that
-	// flips goodbyeWanted during that emit gap is caught on the re-lock, which
-	// re-runs the same claim-and-decide logic before acting on the replacement.
+	// Proven closed (or s==nil): run the ordered post-close decision, then
+	// make-before-break — wait UNLOCKED for any started replacement's conn to
+	// come live so Apply returns only once the replacement RA conn is up, with
+	// no observable 0-live-conn window across a config replace (#2834). The old
+	// conn was PROVEN closed before the replacement started (≤1 live conn), and
+	// waitConnReady returns promptly if the open gives up or is pre-empted.
+	repl, err := m.finishDrainDecision(name, s, startEpoch, onProvenClose)
+	if repl != nil && !repl.waitConnReady(claimWaitTimeout) {
+		slog.Warn("ra: replacement sender conn did not come up after a "+
+			"config replace", "interface", name)
+	}
+	return err
+}
+
+// finishDrainDecision runs the ordered post-close decision for a draining
+// interface whose sender has PROVEN closed (the caller observed <-s.stopped, or
+// s==nil): emit an owed standalone goodbye (claim-once, held across the emit)
+// and/or start the still-current replacement, each re-evaluated against FRESH
+// state under m.mu, then remove the tombstone. It is the single body shared by
+// releaseDrain's proven-close arm AND the join-timeout reclaimer (#5094), so
+// both apply identical goodbye-vs-replace-vs-supersession rules.
+//
+// The goodbye claim and the replacement decision are made against FRESH state
+// at the act point. Because goodbyeWanted only goes false→true and epoch only
+// increases, at most one emit pass is needed (claim → unlock → blocking emit →
+// re-lock); a late Withdraw that flips goodbyeWanted during that emit gap is
+// caught on the re-lock, which re-runs the same claim-and-decide logic before
+// acting on the replacement.
+//
+// It returns the started replacement sender (nil if none started) so the caller
+// can wait UNLOCKED for its conn to come live (the #2834 make-before-break) —
+// finishDrainDecision itself must not block on that while holding m.mu. The
+// replacement is looked up from m.senders under the SAME lock that started it,
+// so the returned pointer is never a shared mutable local (no cross-goroutine
+// data race between a synchronous caller and the detached reclaimer).
+//
+// Identity guard (matters for the reclaimer, a no-op for releaseDrain): when
+// s != nil the whole decision is gated on the live tombstone still being OURS
+// (e.sender == s). The reclaimer runs long after the timeout, so a newer
+// Apply/Withdraw may have replaced the tombstone with its own entry; if so we
+// do nothing and leave it to its new owner. releaseDrain's synchronous caller
+// installs the entry immediately before this runs, and a racing Withdraw only
+// flips fields on that SAME entry (never replaces it), so the guard always
+// holds there — the behavior is unchanged.
+func (m *Manager) finishDrainDecision(name string, s *sender, startEpoch uint64, onProvenClose func() error) (*sender, error) {
 	for {
 		m.mu.Lock()
 		e := m.draining[name]
-		if e == nil {
+		if e == nil || (s != nil && e.sender != s) {
+			// Gone, or a newer call re-claimed the interface with its own entry;
+			// that newer owner manages its own goodbye/replacement/release.
 			m.mu.Unlock()
-			return nil // defensive; owner holds it
+			return nil, nil
 		}
 
 		// Decide goodbye claim-once with FRESH goodbyeWanted/goodbyeClaimed.
@@ -228,35 +284,65 @@ func (m *Manager) releaseDrain(name string, s *sender, startEpoch uint64, onProv
 		// no interface-scoped withdraw naming this interface superseded), AND no
 		// goodbye was wanted (a withdraw overrides a replace). None can change
 		// while we hold the lock.
-		var startErr error
+		var (
+			startErr error
+			repl     *sender
+		)
 		if onProvenClose != nil && m.epoch == startEpoch &&
 			m.ifaceEpoch[name] == e.startIfaceEpoch && !e.goodbyeWanted {
 			// Old conn PROVEN closed + tombstone still held → ≤1 live conn.
-			startErr = onProvenClose()
+			if startErr = onProvenClose(); startErr == nil {
+				repl = m.senders[name]
+			}
 		}
 		delete(m.draining, name)
 		m.mu.Unlock()
-		return startErr
+		return repl, startErr
 	}
 }
 
 // reclaimTombstoneWhenStopped detaches a goroutine that waits for a wedged
-// owner to finally exit, then removes its tombstone under m.mu. This self-heals
-// the degraded "tombstone held forever after a join timeout" state without ever
-// opening a second conn while the old one may be live. No goodbye and no
-// replacement are emitted/started here — the timeout already declined both.
-func (m *Manager) reclaimTombstoneWhenStopped(name string, s *sender) {
+// owner to finally exit, then completes the SAME ordered post-close decision
+// releaseDrain would have run inline had the join not timed out (#5094): emit an
+// owed standalone goodbye and/or start the still-current replacement, then
+// remove the tombstone. This self-heals the degraded "join timed out" state
+// WITHOUT ever opening a second conn while the old one may be live — the
+// replacement is opened only after <-s.stopped proves the old conn closed, and
+// only while the tombstone is still held (≤1 live conn).
+//
+// startEpoch and onProvenClose are the caller's captured generation intent
+// (onProvenClose is nil for a removal/withdraw, which want no replacement).
+// finishDrainDecision re-evaluates them against fresh state under m.mu and its
+// identity guard leaves a newer owner's re-claimed entry untouched. It is the
+// exact same decision body the synchronous proven-close arm runs, so a
+// timeout defers the action rather than erasing it.
+func (m *Manager) reclaimTombstoneWhenStopped(name string, s *sender, startEpoch uint64, onProvenClose func() error) {
+	// Mark the still-held tombstone so Status surfaces the wedged-owner interface
+	// as "join timed out; reclaiming" rather than a plain draining (#5094).
+	m.mu.Lock()
+	if e := m.draining[name]; e != nil && e.sender == s {
+		e.joinTimedOut = true
+	}
+	m.mu.Unlock()
+
 	go func() {
 		<-s.stopped
-		m.mu.Lock()
-		// Only remove if it is still the SAME entry we left (a newer call may
-		// have replaced it; that newer owner manages its own lifecycle).
-		if e := m.draining[name]; e != nil && e.sender == s {
-			delete(m.draining, name)
-			slog.Info("ra: reclaimed tombstone after wedged owner finally exited",
-				"interface", name)
+		// The wedged owner has finally exited; its conn is now PROVEN closed.
+		repl, err := m.finishDrainDecision(name, s, startEpoch, onProvenClose)
+		if err != nil {
+			slog.Warn("ra: reclaimer replacement start failed after wedged owner "+
+				"exited", "interface", name, "err", err)
+			return
 		}
-		m.mu.Unlock()
+		// Best-effort make-before-break for the healed replacement (bounded).
+		// This path is already degraded (the old owner wedged past the join
+		// timeout, so there was an unavoidable RA gap); the wait only bounds how
+		// long the detached reclaimer lingers before logging completion.
+		if repl != nil {
+			repl.waitConnReady(claimWaitTimeout)
+		}
+		slog.Info("ra: reclaimed tombstone after wedged owner finally exited",
+			"interface", name)
 	}()
 }
 
@@ -399,37 +485,24 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 	// on the proven-closed arm while the tombstone is held (≤1 live conn) and
 	// only if a graceful withdraw did not supersede the replace. A removal
 	// passes onProvenClose=nil (no replacement).
+	//
+	// onProvenClose is a bare startLocked closure that touches NO Apply-local
+	// state: on the join-TIMEOUT path releaseDrain hands this same closure to the
+	// detached reclaimer, which runs it in another goroutine after the wedged
+	// owner finally exits (#5094). A closure that wrote back into an Apply local
+	// (e.g. the started replacement) would data-race that late reclaimer run.
+	// releaseDrain owns the #2834 make-before-break wait internally now, so Apply
+	// no longer needs the replacement handle here.
 	for _, req := range toStop {
 		name := req.name
 		var onProvenClose func() error
-		var replacement *sender // set by onProvenClose on a successful restart start
 		if cfg, isRestart := restartSet[name]; isRestart {
 			cfg := cfg // capture
-			onProvenClose = func() error {
-				// Runs under m.mu, tombstone held, old conn proven closed.
-				if err := m.startLocked(cfg); err != nil {
-					return err
-				}
-				replacement = m.senders[cfg.Interface]
-				return nil
-			}
+			// Runs under m.mu, tombstone held, old conn proven closed.
+			onProvenClose = func() error { return m.startLocked(cfg) }
 		}
 		if err := m.releaseDrain(name, req.s, epoch, onProvenClose); err != nil && firstErr == nil {
 			firstErr = err
-		}
-		// Make-before-break: the old conn was PROVEN closed before startLocked ran
-		// (releaseDrain only invokes onProvenClose on the <-stopped arm), so the
-		// replacement is the sole conn for this interface. start() opens the conn
-		// asynchronously in the owner goroutine; wait (UNLOCKED) for that open to
-		// resolve so Apply returns only once the replacement RA conn is live —
-		// there is no observable 0-live-conn window across a config replace
-		// (#2834). If the open gives up or is pre-empted, waitConnReady returns
-		// promptly (it does not block for the full timeout on a dead sender).
-		if replacement != nil {
-			if !replacement.waitConnReady(claimWaitTimeout) {
-				slog.Warn("ra: replacement sender conn did not come up after a "+
-					"config replace", "interface", name)
-			}
 		}
 	}
 
@@ -855,6 +928,11 @@ type SenderInfo struct {
 	// interface is deliberately reported as distinct from active so operators
 	// do not read a withdrawing router as still advertising.
 	State string
+	// JoinTimedOut is set on a draining entry whose owner wedged past
+	// claimWaitTimeout, so releaseDrain handed the owed goodbye/replacement to
+	// the detached reclaimer (#5094). It lets the display distinguish a normal
+	// brief drain from a stuck one that is being self-healed by the reclaimer.
+	JoinTimedOut bool
 }
 
 // Status returns information about all RA senders, including interfaces that
@@ -909,11 +987,12 @@ func (m *Manager) Status() []SenderInfo {
 
 	// Surface draining interfaces so a withdrawing router is not silently
 	// invisible (it is no longer "active" but not yet gone).
-	for name := range m.draining {
+	for name, e := range m.draining {
 		result = append(result, SenderInfo{
-			Interface: name,
-			State:     "draining",
-			LastRA:    "n/a",
+			Interface:    name,
+			State:        "draining",
+			LastRA:       "n/a",
+			JoinTimedOut: e.joinTimedOut,
 		})
 	}
 	return result

--- a/pkg/ra/reclaimer_sender_5094_test.go
+++ b/pkg/ra/reclaimer_sender_5094_test.go
@@ -1,0 +1,229 @@
+package ra
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5094: when a draining sender's owner wedges past claimWaitTimeout,
+// releaseDrain hands the tombstone to the detached reclaimer. The pre-#5094
+// reclaimer merely delete()d the tombstone once the wedged owner finally
+// exited, DROPPING the generation's owed action — the changed-config
+// replacement or the terminal goodbye. The interface could then stay senderless
+// (or lose its goodbye) until an unrelated later Apply happened to re-drive it.
+//
+// The fix: the reclaimer runs the SAME ordered post-close decision releaseDrain
+// would have run inline had the join not timed out — start the still-current
+// replacement and/or emit the owed goodbye, re-evaluated against fresh state
+// under the lock — before removing the tombstone. These tests pin both halves,
+// each RED against the pre-#5094 delete-only reclaimer.
+
+// statusJoinTimedOut reports whether Manager.Status surfaces name as a draining
+// interface whose owner wedged past the join timeout (#5094 status surface).
+func statusJoinTimedOut(m *Manager, name string) bool {
+	for _, info := range m.Status() {
+		if info.Interface == name && info.State == "draining" && info.JoinTimedOut {
+			return true
+		}
+	}
+	return false
+}
+
+// waitDrainCleared blocks until name's draining tombstone is gone (the
+// reclaimer's final act) or a generous deadline elapses.
+func waitDrainCleared(t *testing.T, m *Manager, name string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		m.mu.Lock()
+		_, draining := m.draining[name]
+		m.mu.Unlock()
+		if !draining {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("tombstone for %s never cleared", name)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// waitReplacementConn blocks until a NEW conn (distinct from old) has been
+// opened for name — i.e. the reclaimer restarted the sender and its owner
+// opened the replacement conn.
+func waitReplacementConn(t *testing.T, fl *fakeListen, name string, old *fakeConn) *fakeConn {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if c := fl.getConn(name); c != nil && c != old {
+			return c
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("replacement conn for %s never opened — the reclaimer "+
+				"dropped the deferred restart (#5094)", name)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// TestReclaimerHealsRestartAfterJoinTimeout_5094 drives the changed-config
+// restart path into a JOIN TIMEOUT (old owner wedged in conn.Close), then proves
+// that once the wedged owner finally exits the reclaimer STARTS the deferred
+// replacement — the interface is not left senderless.
+//
+// It also asserts the two invariants that must survive the fix: never two live
+// conns (the replacement opens only after the old conn is proven closed), and
+// Status surfaces the wedged interface as join-timed-out while it is stuck.
+//
+// RED on revert: against the pre-#5094 delete-only reclaimer no replacement is
+// ever started, so waitReplacementConn times out and the test fails.
+func TestReclaimerHealsRestartAfterJoinTimeout_5094(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("initial Apply: %v", err)
+	}
+	old := waitConn(t, fl.getConn, "lo")
+	waitWrites(t, old, 1)
+
+	// Wedge the old sender inside conn.Close so its `stopped` never closes and
+	// the restart join TIMES OUT. `reached` fires once the owner is parked.
+	wedge := make(chan struct{})
+	reached := make(chan struct{})
+	var once sync.Once
+	old.setBeforeClose(func() {
+		once.Do(func() { close(reached) })
+		<-wedge
+	})
+
+	orig := claimWaitTimeout
+	claimWaitTimeout = 100 * time.Millisecond
+	defer func() { claimWaitTimeout = orig }()
+
+	// Changed-config Apply (restart): hard-stops the old sender, hits the wedged
+	// join, times out, arms the reclaimer, and returns in the degraded state.
+	if err := m.Apply([]*config.RAInterfaceConfig{configChanged("lo")}); err != nil {
+		t.Fatalf("changed-config Apply: %v", err)
+	}
+	<-reached // old owner is parked in Close (its conn still live)
+
+	// Degraded window: no active sender, tombstone HELD and flagged
+	// join-timed-out, and never >1 live conn (the old is still live).
+	m.mu.Lock()
+	_, live := m.senders["lo"]
+	m.mu.Unlock()
+	if live {
+		t.Fatal("a replacement was started while the old conn may be live (≤1-conn violated)")
+	}
+	if lc := fl.liveCount(); lc != 1 {
+		t.Fatalf("live conns during the wedge = %d, want 1", lc)
+	}
+	if !statusJoinTimedOut(m, "lo") {
+		t.Fatal("Status did not surface the wedged interface as join-timed-out (#5094)")
+	}
+
+	// Release the wedge; the owner exits and the reclaimer must start the
+	// deferred replacement rather than dropping it.
+	close(wedge)
+	newC := waitReplacementConn(t, fl, "lo", old)
+	waitWrites(t, newC, 1)
+
+	m.mu.Lock()
+	_, healed := m.senders["lo"]
+	m.mu.Unlock()
+	if !healed {
+		t.Fatal("reclaimer left the interface senderless after the wedged owner " +
+			"exited — the deferred restart was dropped (#5094)")
+	}
+	if lc := fl.liveCount(); lc != 1 {
+		t.Fatalf("after heal: live conns = %d, want 1 (old closed, replacement up)", lc)
+	}
+	for _, info := range m.Status() {
+		if info.Interface == "lo" && info.State == "draining" {
+			t.Fatalf("tombstone lingered after the reclaim heal: %+v", info)
+		}
+	}
+	_ = m.Clear()
+}
+
+// TestReclaimerEmitsOwedGoodbyeAfterJoinTimeout_5094 drives the terminal-goodbye
+// half. A hard Clear parks the owner in Close (it reads modeHard and so exits
+// WITHOUT emitting a goodbye itself); its join times out and arms the reclaimer.
+// A graceful Withdraw then flips goodbyeWanted on the still-held tombstone but
+// does NOT own the release (the reclaimer does). Once the wedged owner exits the
+// reclaimer must emit the owed standalone goodbye.
+//
+// RED on revert: against the pre-#5094 delete-only reclaimer the tombstone is
+// dropped with no goodbye (the owner never emitted one; Withdraw did not own the
+// release), so goodbyeStats stays empty and the test fails.
+func TestReclaimerEmitsOwedGoodbyeAfterJoinTimeout_5094(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("initial Apply: %v", err)
+	}
+	old := waitConn(t, fl.getConn, "lo")
+	waitWrites(t, old, 1)
+
+	// Wedge the old sender in Close; `parked` fires once it is there — i.e. it
+	// has already read modeHard and decided NOT to emit a goodbye itself.
+	wedge := make(chan struct{})
+	parked := make(chan struct{})
+	var once sync.Once
+	old.setBeforeClose(func() {
+		once.Do(func() { close(parked) })
+		<-wedge
+	})
+
+	orig := claimWaitTimeout
+	claimWaitTimeout = 100 * time.Millisecond
+	defer func() { claimWaitTimeout = orig }()
+
+	// Hard Clear: installs a tombstone, signalStop(modeHard); its join blocks on
+	// the wedged owner, so run it in a goroutine.
+	clearDone := make(chan error, 1)
+	go func() { clearDone <- m.Clear() }()
+	<-parked // owner parked in Close having read modeHard (no self-goodbye)
+
+	// Wait until Clear's join timed out and armed the reclaimer.
+	deadline := time.Now().Add(3 * time.Second)
+	for !statusJoinTimedOut(m, "lo") {
+		if time.Now().After(deadline) {
+			t.Fatal("Clear never armed the join-timeout reclaimer")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// A graceful Withdraw flips goodbyeWanted on the still-held tombstone. It
+	// does NOT own the release (Clear's reclaimer does), so the owed goodbye is
+	// the reclaimer's responsibility once the owner exits.
+	_ = m.Withdraw()
+
+	// Release the wedge; the owner exits (modeHard, no goodbye) and the reclaimer
+	// must emit the owed standalone goodbye.
+	close(wedge)
+	<-clearDone
+	waitDrainCleared(t, m, "lo")
+
+	total, conns := fl.goodbyeStats("lo")
+	if conns != 1 || total == 0 {
+		t.Fatalf("reclaimer did not emit the owed goodbye after the join timeout "+
+			"(%d conns / %d writes); #5094 must not drop the terminal goodbye", conns, total)
+	}
+	m.mu.Lock()
+	_, live := m.senders["lo"]
+	m.mu.Unlock()
+	if live {
+		t.Fatal("a replacement was started for a withdrawn interface (the withdraw must win)")
+	}
+}

--- a/pkg/ra/serialize_test.go
+++ b/pkg/ra/serialize_test.go
@@ -1817,7 +1817,27 @@ func TestRestartTimeoutNoGoodbyeNoReplacement(t *testing.T) {
 	if !stillDraining {
 		t.Fatal("restart timeout removed the tombstone; it must be LEFT HELD")
 	}
-	close(wedge) // let the owner exit so the reclaimer + test can finish
+
+	// #5094: the assertions above pin the DEGRADED window (owner still wedged).
+	// Once the owner exits, the reclaimer must NOT drop the owed action: with a
+	// racing graceful Withdraw the goodbye wins over the suppressed replacement,
+	// so exactly one goodbye is emitted and no replacement is started. Let the
+	// owner exit and wait for the reclaimer to settle (its final act is removing
+	// the tombstone, after any synchronous goodbye) so the reclaimer's work
+	// completes within this test rather than racing the harness teardown.
+	close(wedge)
+	waitDrainCleared(t, m, "lo")
+	if _, conns := fl.goodbyeStats("lo"); conns != 1 {
+		t.Fatalf("after reclaim: %d conns carried a goodbye, want exactly one "+
+			"(the reclaimer must emit the owed goodbye exactly once — #5094)", conns)
+	}
+	m.mu.Lock()
+	_, healedLive := m.senders["lo"]
+	m.mu.Unlock()
+	if healedLive {
+		t.Fatal("reclaimer started a replacement despite a graceful withdraw; " +
+			"the withdraw must win (#5094)")
+	}
 }
 
 // TestRestartTimeoutNoReplacementWhenNoGoodbye (round-4 MAJOR 2): the same
@@ -1888,7 +1908,23 @@ func TestRestartTimeoutNoReplacementWhenNoGoodbye(t *testing.T) {
 	if conns != 0 || total != 0 {
 		t.Fatalf("pure restart emitted a goodbye (%d conns / %d writes); expected 0", conns, total)
 	}
+
+	// #5094: the assertions above pin the DEGRADED window (≤1 conn while the old
+	// owner is wedged). Once the owner exits, the reclaimer must START the
+	// deferred replacement rather than dropping it — the interface must not be
+	// left senderless. Wait for the replacement conn so the reclaimer's work
+	// (and its openConn) completes within this test, then quiesce.
 	close(wedge)
+	newC := waitReplacementConn(t, fl, "lo", old)
+	waitWrites(t, newC, 1)
+	m.mu.Lock()
+	_, healed := m.senders["lo"]
+	m.mu.Unlock()
+	if !healed {
+		t.Fatal("reclaimer left the interface senderless after the wedged owner " +
+			"exited — the deferred restart was dropped (#5094)")
+	}
+	_ = m.Clear()
 }
 
 // --- #2033 round-5: replacement decision is atomic under the act-lock ---


### PR DESCRIPTION
Closes #5094

## Problem
When a draining RA sender's owner wedged past `claimWaitTimeout`, `releaseDrain` handed the tombstone to a detached reclaimer (`reclaimTombstoneWhenStopped`) that merely `delete`d it once the wedged owner finally exited. That **dropped the generation's owed action**:
- the changed-config **replacement** (`onProvenClose`), leaving the interface with **no active RA sender**, and
- any owed **terminal goodbye**.

The interface could stay senderless (or lose its goodbye) until an unrelated later `Apply` re-drove it — while `Apply` returned success to the caller. A timeout may *defer* an action, but it must not *erase* this generation's owned intent.

## Fix
Extract `releaseDrain`'s proven-close ordered decision — goodbye claim-once (held across the emit) + the replacement decision re-evaluated against fresh `epoch`/`ifaceEpoch`/`goodbyeWanted` under `m.mu` — into `finishDrainDecision`. Both `releaseDrain`'s `<-stopped` arm **and** the join-timeout reclaimer now run it:

- The reclaimer waits for `<-s.stopped` **first**, so the wedged owner has proven its conn closed before the reclaimer emits (restoring the happens-before that orders the `goodbyeEmitted` read) or opens a replacement (old conn closed → **≤1 live conn** holds).
- An **entry-identity guard** (`e.sender == s`) leaves a newer owner's re-claimed tombstone untouched.
- All #2033 invariants preserved: single-owner-emit, claim-once, held-across-emit, epoch/`ifaceEpoch` (#4961) supersession, and the #2272 check-and-claim discipline.

To keep the shared closure race-free now that it also runs in the reclaimer goroutine, `onProvenClose` is a bare `startLocked` closure (no Apply-local writeback), and the #2834 make-before-break `waitConnReady` moved **into** `releaseDrain`. `finishDrainDecision` returns the started replacement (looked up under the same lock) for the caller to wait on, unlocked.

Also surfaces the degraded window: a join-timed-out tombstone sets `joinTimedOut` (`drainEntry`), reported via `Manager.Status` and shown by `show interfaces` as `draining (join timed out; reclaiming)`.

## RED-on-revert evidence
New `pkg/ra/reclaimer_sender_5094_test.go` drives both halves deterministically under `-race`, plus the two existing round-4 timeout tests now assert the heal (and wait for the reclaimer to settle within the test rather than leaking it into harness teardown). Reverting the reclaimer to delete-only fails all four:

```
--- FAIL: TestReclaimerHealsRestartAfterJoinTimeout_5094 (3.11s)
    reclaimer_sender_5094_test.go:135: replacement conn for lo never opened — the reclaimer dropped the deferred restart (#5094)
--- FAIL: TestReclaimerEmitsOwedGoodbyeAfterJoinTimeout_5094 (0.12s)
    reclaimer_sender_5094_test.go:220: reclaimer did not emit the owed goodbye after the join timeout (0 conns / 0 writes); #5094 must not drop the terminal goodbye
--- FAIL: TestRestartTimeoutNoGoodbyeNoReplacement
--- FAIL: TestRestartTimeoutNoReplacementWhenNoGoodbye
```

With the fix restored, all pass.

## Validation
- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` → exit 0
- `go test -race ./pkg/ra/...` → ok
- `go test ./pkg/grpcapi/...` → ok (touched `show interfaces` RA text)
- `go vet ./pkg/ra/... ./pkg/grpcapi/...` → clean; `gofmt` clean
- Verified the drop reproduces on current `origin/master` (delete-only reclaimer) before fixing.

Docs: updated `pkg/ra/README.md` (reclaimer contract + Status `JoinTimedOut`).