### PR TITLE
pkg/snmp: implement SNMPv1 GET/GETNEXT polling (#5049)

### DIFF
--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -1,8 +1,50 @@
 # pkg/snmp
 
-SNMPv2c and SNMPv3 agent. Responds to GET / GETNEXT / GETBULK on
+SNMPv1, SNMPv2c, and SNMPv3 agent. Responds to GET / GETNEXT (all three
+versions) and GETBULK (v2c/v3 only — GETBULK is not an SNMPv1 PDU) on
 ifTable, ifXTable, and a small set of system OIDs. Also sends link-up /
 link-down traps. ASN.1 BER encoding is hand-coded, no external library.
+
+## SNMPv1 polling (RFC 1157 / RFC 2089, #5049)
+
+The request dispatch (`handlePacketFrom`) routes the message version field:
+0 → `handleV1Packet`, 1 → `handleV2cPacket`, 3 → `handleV3Packet`. Before
+#5049 only versions 1 and 3 had a case and version 0 fell through to the
+"unsupported version" default — so the agent emitted v1 traps
+(`buildLinkTrapV1`, `set snmp trap-group … version v1`) yet silently dropped
+every v1 GET/GETNEXT/SET, and a legacy v1-only manager timed out and marked
+the device down.
+
+The v1 handlers share the v2c community frame, the `clients` source-IP
+allowlist (#4289), the per-PDU interface snapshot (#4013), the bounded MIB
+lookup (`getOIDValueSnap` / `findNextOIDSnap`), and the message-size ceiling
+(`boundGetResponseVersion` → `tooBig` on overflow). Only the response rules
+differ, per the SNMPv1 error model:
+
+- **GET of a missing/unresolvable OID** → the whole PDU fails with
+  `noSuchName` (error-status 2) and a **1-based error-index** naming the
+  offending varbind; the request varbinds are **echoed unchanged** (NULL
+  values). v1 has **no per-varbind exception values** — `noSuchObject`,
+  `noSuchInstance`, and `endOfMibView` are v2-only and never appear in a v1
+  response.
+- **GETNEXT past the end of the MIB view** → `noSuchName` with the offending
+  index (there is no `endOfMibView` in v1).
+- **Counter64 (RFC 2089)** — Counter64 is not a v1 type. A **direct GET** of a
+  Counter64-typed node (ifHCInOctets/…, ifXTable cols 6/7/10/11) returns
+  `noSuchName`; a **GETNEXT walk steps OVER** every Counter64 node
+  (`findNextV1OIDSnap`) so the walk advances to the next representable object.
+  No Counter64 octet ever reaches the wire on a v1 response.
+- **SET** — the agent exposes no writable object, and v1 lacks the `noAccess`
+  / `notWritable` statuses the v2c handler returns; per the RFC 2089 §2.1
+  SNMPv2→SNMPv1 error mapping BOTH map to `noSuchName`. So a v1 SET (whether
+  the community is read-only or read-write) returns `noSuchName` with
+  error-index 1 and the request varbinds echoed.
+
+`buildResponseVersion` (shared by v1 and v2c via `buildResponse`) writes the
+message version field explicitly; the GetResponse PDU shape is otherwise
+identical across the two versions. Coverage:
+`agent_v1_polling_5049_test.go` (RED-on-revert: stashing the dispatch case +
+handlers makes every "expect a response" assertion get nil).
 
 ## Community authorization (SET access control)
 

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -722,6 +722,8 @@ func (a *Agent) handlePacketFrom(data []byte, srcIP net.IP) []byte {
 	}
 
 	switch version {
+	case snmpVersion1:
+		return a.handleV1Packet(rest, srcIP)
 	case snmpVersion2c:
 		return a.handleV2cPacket(rest, srcIP)
 	case snmpVersion3:
@@ -795,6 +797,190 @@ func (a *Agent) handleV2cPacket(rest []byte, srcIP net.IP) []byte {
 		slog.Debug("SNMP: unsupported PDU type", "type", pduTag)
 		return nil
 	}
+}
+
+// handleV1Packet processes an SNMPv1 message (RFC 1157; version already decoded
+// as 0). It shares the community frame, the source allowlist (#4289), and the
+// bounded MIB lookup with the v2c path — the ONLY differences are the response
+// rules a v1 manager expects (#5049): a missing/unresolvable OID yields a whole-
+// PDU error-status=noSuchName(2) with a 1-based error-index and the request
+// varbinds echoed back UNCHANGED (v1 has no per-varbind exception values), and
+// no v2-only type (Counter64) ever reaches the wire.
+//
+// Before #5049 the version-0 case fell through to the default "unsupported
+// version" drop, so the agent emitted v1 traps but silently dropped every v1
+// GET/GETNEXT poll — a legacy v1 manager saw the device as down.
+func (a *Agent) handleV1Packet(rest []byte, srcIP net.IP) []byte {
+	// Decode community string (same frame as v2c).
+	community, rest, err := berDecodeOctetString(rest)
+	if err != nil {
+		slog.Debug("SNMP: failed to decode community")
+		return nil
+	}
+
+	// Verify community string and resolve its authorization level.
+	comm := a.getCommunity(string(community))
+	if comm == nil {
+		// SECURITY (#4302): never log the community string (the v1 shared
+		// secret); log only the source, symmetric with the v2c path (#4289).
+		slog.Debug("SNMP: invalid community", "src", srcIP, "known_community", false)
+		return nil
+	}
+
+	// #4289: enforce the community `clients` source-IP restriction, identical to
+	// the v2c path — a scoped community answers ONLY permitted sources.
+	if !comm.AllowsSource(srcIP) {
+		slog.Debug("SNMP: source not permitted for community",
+			"src", srcIP, "known_community", true)
+		return nil
+	}
+
+	// Decode PDU.
+	pduTag, pduBody, err := berDecodeHeader(rest)
+	if err != nil {
+		slog.Debug("SNMP: failed to decode PDU header")
+		return nil
+	}
+
+	switch pduTag {
+	case pduGetRequest:
+		return a.handleV1Get(community, pduBody)
+	case pduGetNextRequest:
+		return a.handleV1GetNext(community, pduBody)
+	case pduSetRequest:
+		return a.handleV1Set(community, comm, srcIP, pduBody)
+	default:
+		// v1 has no GETBULK (a v2c/v3 addition); any other PDU type is dropped,
+		// matching the v2c default.
+		slog.Debug("SNMP: unsupported v1 PDU type", "type", pduTag)
+		return nil
+	}
+}
+
+// echoVarbinds builds the request-echo varbind list an SNMPv1 error response
+// carries: each requested OID with a NULL value. RFC 1157 §4.1.x specifies that
+// on an error the GetResponse-PDU's variable-bindings field is that of the
+// received request — v1 never rewrites individual varbind values with exception
+// markers the way v2c does.
+func echoVarbinds(oids [][]int) []varbind {
+	vbs := make([]varbind, 0, len(oids))
+	for _, oid := range oids {
+		vbs = append(vbs, varbind{oid: oid, tag: tagNull, value: nil})
+	}
+	return vbs
+}
+
+// handleV1Get processes an SNMPv1 GET (RFC 1157 §4.1.2). All requested OIDs must
+// resolve; the first that does not fails the WHOLE PDU with noSuchName and the
+// 1-based index of the offending varbind, echoing the request varbinds. A
+// Counter64-typed object is not representable in v1 (RFC 2089), so a direct GET
+// of one is treated as a missing name → noSuchName, and no Counter64 is emitted.
+func (a *Agent) handleV1Get(community []byte, pduBody []byte) []byte {
+	requestID, _, _, oids, err := decodePDUFields(pduBody)
+	if err != nil {
+		slog.Debug("SNMP: failed to decode v1 GET PDU", "err", err)
+		return nil
+	}
+
+	// One interface snapshot for the whole PDU (#4013).
+	snap := a.newIfSnapshot()
+	varbinds := make([]varbind, 0, len(oids))
+	for i, oid := range oids {
+		val, valTag := a.getOIDValueSnap(oid, snap)
+		if val == nil || valTag == tagCounter64 {
+			// Missing name, or a v2-only Counter64 that v1 cannot carry: fail
+			// the whole PDU with noSuchName + the 1-based offending index, and
+			// echo the request varbinds unchanged.
+			return a.buildResponseVersion(snmpVersion1, community, requestID,
+				errNoSuchName, i+1, echoVarbinds(oids))
+		}
+		varbinds = append(varbinds, varbind{oid: oid, tag: valTag, value: val})
+	}
+
+	return a.boundGetResponseVersion(snmpVersion1, community, requestID, varbinds)
+}
+
+// handleV1GetNext processes an SNMPv1 GETNEXT (RFC 1157 §4.1.3). Each requested
+// OID advances lexicographically to the next served object, STEPPING OVER any
+// Counter64-typed node (RFC 2089 — a v1 walk must not surface a type it cannot
+// encode). Running off the end of the MIB view fails the PDU with noSuchName and
+// the 1-based index, echoing the request varbinds (v1 has no endOfMibView).
+func (a *Agent) handleV1GetNext(community []byte, pduBody []byte) []byte {
+	requestID, _, _, oids, err := decodePDUFields(pduBody)
+	if err != nil {
+		slog.Debug("SNMP: failed to decode v1 GETNEXT PDU", "err", err)
+		return nil
+	}
+
+	// One interface snapshot for the whole PDU (#4013).
+	snap := a.newIfSnapshot()
+	varbinds := make([]varbind, 0, len(oids))
+	for i, oid := range oids {
+		nextOID, val, valTag := a.findNextV1OIDSnap(oid, snap)
+		if nextOID == nil {
+			// End of MIB view: v1 signals this as noSuchName on the whole PDU
+			// (there is no per-varbind endOfMibView exception).
+			return a.buildResponseVersion(snmpVersion1, community, requestID,
+				errNoSuchName, i+1, echoVarbinds(oids))
+		}
+		varbinds = append(varbinds, varbind{oid: nextOID, tag: valTag, value: val})
+	}
+
+	return a.boundGetResponseVersion(snmpVersion1, community, requestID, varbinds)
+}
+
+// findNextV1OIDSnap is findNextOIDSnap for the SNMPv1 MIB view: it returns the
+// next served OID after `oid` that is representable in v1 (RFC 2089), skipping
+// any Counter64-typed node so a v1 GETNEXT/GET-walk steps over the 64-bit
+// high-capacity counters instead of stalling or emitting a type v1 cannot carry.
+// Returns (nil, nil, 0) at the end of the MIB view.
+func (a *Agent) findNextV1OIDSnap(oid []int, snap *ifSnapshot) ([]int, []byte, byte) {
+	cur := oid
+	for {
+		next := a.findNextOIDSnap(cur, snap)
+		if next == nil {
+			return nil, nil, 0
+		}
+		val, valTag := a.getOIDValueSnap(next, snap)
+		if val == nil || valTag == tagCounter64 {
+			// Not representable in v1 (Counter64) or unexpectedly empty: advance
+			// past it and keep walking.
+			cur = next
+			continue
+		}
+		return next, val, valTag
+	}
+}
+
+// handleV1Set processes an SNMPv1 SET (RFC 1157 §4.1.5). The agent serves only
+// read-only objects, and v1 has neither the noAccess nor notWritable
+// error-status the v2c handler uses; per the RFC 2089 §2.1 SNMPv2→SNMPv1 error
+// mapping BOTH map to noSuchName(2). So a SET — whether denied for a read-only
+// community or refused because no served object is writable — returns
+// noSuchName with error-index 1 and the request varbinds echoed.
+func (a *Agent) handleV1Set(community []byte, comm *config.SNMPCommunity, srcIP net.IP, pduBody []byte) []byte {
+	requestID, _, _, oids, err := decodePDUFields(pduBody)
+	if err != nil {
+		slog.Debug("SNMP: failed to decode v1 SET PDU", "err", err)
+		return nil
+	}
+
+	if !communityCanWrite(comm) {
+		// SECURITY (#4302): log the source and (non-secret) authorization level,
+		// never the community string, matching the v2c #4289 pattern.
+		slog.Debug("SNMP: v1 SET denied, community not authorized read-write",
+			"src", srcIP, "authorization", comm.Authorization)
+	}
+
+	// Read-only community OR read-write community with no writable object: both
+	// collapse to noSuchName in v1. error-index is the 1-based position of the
+	// offending varbind (the first one when any OID is present).
+	errIdx := 0
+	if len(oids) > 0 {
+		errIdx = 1
+	}
+	return a.buildResponseVersion(snmpVersion1, community, requestID,
+		errNoSuchName, errIdx, echoVarbinds(oids))
 }
 
 // communityCanWrite reports whether the community is authorized for SET
@@ -929,9 +1115,16 @@ func (a *Agent) handleGetNext(community []byte, pduBody []byte) []byte {
 // §4.2.1/§4.2.2 it is replaced with tooBig + an empty varbind list rather than
 // emitting a datagram larger than maxPacketSize.
 func (a *Agent) boundGetResponse(community []byte, requestID int, varbinds []varbind) []byte {
-	resp := a.buildResponse(community, requestID, errNoError, 0, varbinds)
+	return a.boundGetResponseVersion(snmpVersion2c, community, requestID, varbinds)
+}
+
+// boundGetResponseVersion is boundGetResponse parameterized on the message
+// version field, so the SNMPv1 GET/GETNEXT handlers (#5049) share the identical
+// size ceiling and tooBig fallback as v2c while emitting a version-0 envelope.
+func (a *Agent) boundGetResponseVersion(version int, community []byte, requestID int, varbinds []varbind) []byte {
+	resp := a.buildResponseVersion(version, community, requestID, errNoError, 0, varbinds)
 	if len(resp) > effectiveMaxSize(maxPacketSize) {
-		return a.buildResponse(community, requestID, errTooBig, 0, nil)
+		return a.buildResponseVersion(version, community, requestID, errTooBig, 0, nil)
 	}
 	return resp
 }
@@ -1402,6 +1595,19 @@ func trimToFit(vbs []varbind, maxSize int, build func([]varbind) []byte) (resp [
 
 // buildResponse constructs a complete SNMP v2c response packet.
 func (a *Agent) buildResponse(community []byte, requestID int, errorStatus int, errorIndex int, varbinds []varbind) []byte {
+	return a.buildResponseVersion(snmpVersion2c, community, requestID, errorStatus, errorIndex, varbinds)
+}
+
+// buildResponseVersion constructs a complete SNMP GetResponse packet with an
+// explicit message version field. v2c callers pass snmpVersion2c (via
+// buildResponse); the SNMPv1 handlers (#5049) pass snmpVersion1 so the response
+// carries a version-0 envelope. The PDU shape (GetResponse tag, request-id /
+// error-status / error-index / varbind-list body) is identical for v1 and v2c —
+// only the version field and the caller-chosen error-status/varbind semantics
+// differ. v1 callers never pass an exception-tag varbind (noSuchObject /
+// noSuchInstance / endOfMibView), so those v2-only markers never reach the wire
+// on a v1 response.
+func (a *Agent) buildResponseVersion(version int, community []byte, requestID int, errorStatus int, errorIndex int, varbinds []varbind) []byte {
 	// Encode varbind list.
 	var vbListBytes []byte
 	for _, vb := range varbinds {
@@ -1426,7 +1632,7 @@ func (a *Agent) buildResponse(community []byte, requestID int, errorStatus int, 
 	pduEncoded := berEncodeTLV(pduGetResponse, pduBody)
 
 	// Encode message: version, community, PDU.
-	msgBody := berEncodeIntegerTLV(snmpVersion2c)
+	msgBody := berEncodeIntegerTLV(version)
 	msgBody = append(msgBody, berEncodeTLV(tagOctetString, community)...)
 	msgBody = append(msgBody, pduEncoded...)
 

--- a/pkg/snmp/agent_v1_polling_5049_test.go
+++ b/pkg/snmp/agent_v1_polling_5049_test.go
@@ -1,0 +1,498 @@
+package snmp
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5049: the request-dispatch switch handled only v2c (version 1) and v3
+// (version 3); the version-0 (SNMPv1) case fell through to the "unsupported
+// version" default and returned nil, so the agent emitted v1 traps
+// (buildLinkTrapV1) but silently dropped every v1 GET/GETNEXT/SET poll — a
+// legacy v1 manager timed out and saw the device as down. These tests exercise
+// the v1 request path end to end and assert the v1 response rules (RFC 1157 /
+// RFC 2089): noSuchName on a missing/unresolvable name, a 1-based error-index,
+// echoed request varbinds with NO per-varbind exception value, and no v2-only
+// Counter64 on the wire. They are RED on revert: stash the agent.go dispatch
+// case + handlers and every "expect a response" assertion below gets nil.
+
+// --- v1 request/response test helpers (self-contained: they use only symbols
+// that predate #5049, so this file still compiles when the production change is
+// stashed for the RED-on-revert proof, and each test then fails with a nil
+// response rather than a build error). ---
+
+// buildV1Request builds an SNMPv1 message (version field 0) carrying the given
+// request PDU (GET 0xa0 / GETNEXT 0xa1 / SET 0xa3) over a list of OIDs, each
+// with a NULL value, exactly as a v1 manager encodes a request.
+func buildV1Request(pduTag byte, community string, requestID int, oids [][]int) []byte {
+	var vbList []byte
+	for _, oid := range oids {
+		oidBytes := berEncodeTLV(tagObjectIdentifier, berEncodeOID(oid))
+		valBytes := berEncodeTLV(tagNull, nil)
+		vbList = append(vbList, berEncodeTLV(tagSequence, append(oidBytes, valBytes...))...)
+	}
+	vbListEnc := berEncodeTLV(tagSequence, vbList)
+
+	pduBody := berEncodeIntegerTLV(requestID)
+	pduBody = append(pduBody, berEncodeIntegerTLV(0)...) // error-status (0 in a request)
+	pduBody = append(pduBody, berEncodeIntegerTLV(0)...) // error-index  (0 in a request)
+	pduBody = append(pduBody, vbListEnc...)
+	pdu := berEncodeTLV(pduTag, pduBody)
+
+	msg := berEncodeIntegerTLV(snmpVersion1) // version field 0
+	msg = append(msg, berEncodeTLV(tagOctetString, []byte(community))...)
+	msg = append(msg, pdu...)
+	return berEncodeTLV(tagSequence, msg)
+}
+
+// v1VB is a fully-decoded response varbind: OID, value tag, and value bytes, so
+// a test can assert the exact type on the wire (crucially: never Counter64, and
+// never an exception tag) and the returned value.
+type v1VB struct {
+	oid []int
+	tag byte
+	val []byte
+}
+
+// decodeV1Response walks a v1 GetResponse to completion, asserting the message
+// version field is 0 (a v1 response, not v2c), and returns the error-status,
+// error-index, and every decoded varbind.
+func decodeV1Response(t *testing.T, resp []byte) (errStatus, errIndex int, vbs []v1VB) {
+	t.Helper()
+	tag, body, err := berDecodeHeader(resp)
+	if err != nil || tag != tagSequence {
+		t.Fatalf("resp: outer SEQUENCE: tag=0x%02x err=%v", tag, err)
+	}
+	version, rest, err := berDecodeInteger(body)
+	if err != nil {
+		t.Fatalf("resp: version: %v", err)
+	}
+	if version != snmpVersion1 {
+		t.Fatalf("resp: version = %d, want %d (v1)", version, snmpVersion1)
+	}
+	_, rest, err = berDecodeOctetString(rest) // community
+	if err != nil {
+		t.Fatalf("resp: community: %v", err)
+	}
+	pduTag, pduBody, err := berDecodeHeader(rest)
+	if err != nil || pduTag != pduGetResponse {
+		t.Fatalf("resp: PDU header tag=0x%02x err=%v (want GetResponse 0x%02x)", pduTag, err, pduGetResponse)
+	}
+	_, pduRest, err := berDecodeInteger(pduBody) // request-id
+	if err != nil {
+		t.Fatalf("resp: request-id: %v", err)
+	}
+	errStatus, pduRest, err = berDecodeInteger(pduRest) // error-status
+	if err != nil {
+		t.Fatalf("resp: error-status: %v", err)
+	}
+	errIndex, pduRest, err = berDecodeInteger(pduRest) // error-index
+	if err != nil {
+		t.Fatalf("resp: error-index: %v", err)
+	}
+	return errStatus, errIndex, decodeV1Varbinds(t, pduRest)
+}
+
+// decodeV1Varbinds decodes every varbind (OID + value tag + value bytes) in an
+// encoded varbind-list SEQUENCE.
+func decodeV1Varbinds(t *testing.T, vbListTLV []byte) []v1VB {
+	t.Helper()
+	tag, vbListBody, err := berDecodeHeader(vbListTLV)
+	if err != nil || tag != tagSequence {
+		t.Fatalf("varbind list: not a SEQUENCE (tag=0x%02x err=%v)", tag, err)
+	}
+	var vbs []v1VB
+	remaining := vbListBody
+	for len(remaining) > 0 {
+		vbTotal := berEncodedLen(remaining)
+		if vbTotal <= 0 || vbTotal > len(remaining) {
+			t.Fatalf("varbind: bad length %d", vbTotal)
+		}
+		vbTag, vbBody, err := berDecodeHeader(remaining)
+		if err != nil || vbTag != tagSequence {
+			t.Fatalf("varbind: not a SEQUENCE (tag=0x%02x err=%v)", vbTag, err)
+		}
+		remaining = remaining[vbTotal:]
+
+		// OID (first element).
+		if len(vbBody) < 2 || vbBody[0] != tagObjectIdentifier {
+			t.Fatalf("varbind: first element not an OID")
+		}
+		oidLen, oidLenBytes, err := berDecodeLength(vbBody[1:])
+		if err != nil {
+			t.Fatalf("varbind: OID length: %v", err)
+		}
+		oidStart := 1 + oidLenBytes
+		oid, err := berDecodeOID(vbBody[oidStart : oidStart+oidLen])
+		if err != nil {
+			t.Fatalf("varbind: OID decode: %v", err)
+		}
+
+		// Value (second element): capture its tag and content bytes.
+		valTLV := vbBody[oidStart+oidLen:]
+		valTag, valBody, err := berDecodeHeader(valTLV)
+		if err != nil {
+			t.Fatalf("varbind: value header: %v", err)
+		}
+		vbs = append(vbs, v1VB{oid: oid, tag: valTag, val: valBody})
+	}
+	return vbs
+}
+
+func oidsEqualT(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// v1TestIfData is one interface with populated ifTable + ifXTable columns,
+// including the four Counter64 high-capacity columns (ifHCInOctets 6,
+// ifHCInUcastPkts 7, ifHCOutOctets 10, ifHCOutUcastPkts 11) a v1 walk must step
+// over.
+func v1TestIfData() []IfData {
+	return []IfData{{
+		IfIndex:          1,
+		IfDescr:          "ge-0-0-0",
+		IfType:           6,
+		IfMtu:            1500,
+		IfSpeed:          1000000000,
+		AdminStatus:      1,
+		OperStatus:       1,
+		InOctets:         12345,
+		OutOctets:        67890,
+		IfName:           "ge-0-0-0",
+		InMulticastPkts:  10,
+		InBroadcastPkts:  20,
+		OutMulticastPkts: 30,
+		OutBroadcastPkts: 40,
+		HCInOctets:       18000000000000000000, // Counter64
+		HCInUcastPkts:    17000000000000000000, // Counter64
+		HCOutOctets:      16000000000000000000, // Counter64
+		HCOutUcastPkts:   15000000000000000000, // Counter64
+		IfHighSpeed:      1000,
+		IfAlias:          "uplink",
+	}}
+}
+
+func v1Agent() *Agent {
+	a := NewAgent(&config.SNMPConfig{
+		Description: "xpf v1 test",
+		Communities: map[string]*config.SNMPCommunity{
+			"public": {Name: "public", Authorization: "read-only"},
+		},
+	})
+	a.SetIfDataFn(v1TestIfData)
+	return a
+}
+
+// TestV1Get_KnownOID_ReturnsValue: a v1 GET of a known OID (sysDescr) returns a
+// v1 GET-RESPONSE (version 0) carrying the value, not nil/timeout.
+func TestV1Get_KnownOID_ReturnsValue(t *testing.T) {
+	a := v1Agent()
+	req := buildV1Request(pduGetRequest, "public", 1, [][]int{oidSysDescr})
+	resp := a.handlePacket(req)
+	if resp == nil {
+		t.Fatal("v1 GET of sysDescr returned nil — v1 polling dropped (#5049)")
+	}
+	errStatus, errIndex, vbs := decodeV1Response(t, resp)
+	if errStatus != errNoError {
+		t.Fatalf("error-status = %d, want noError (%d)", errStatus, errNoError)
+	}
+	if errIndex != 0 {
+		t.Fatalf("error-index = %d, want 0 on success", errIndex)
+	}
+	if len(vbs) != 1 {
+		t.Fatalf("got %d varbinds, want 1", len(vbs))
+	}
+	if !oidsEqualT(vbs[0].oid, oidSysDescr) {
+		t.Fatalf("varbind OID = %v, want sysDescr %v", vbs[0].oid, oidSysDescr)
+	}
+	if vbs[0].tag != tagOctetString {
+		t.Fatalf("sysDescr value tag = 0x%02x, want OctetString 0x%02x", vbs[0].tag, tagOctetString)
+	}
+	if string(vbs[0].val) != "xpf v1 test" {
+		t.Fatalf("sysDescr value = %q, want %q", string(vbs[0].val), "xpf v1 test")
+	}
+}
+
+// TestV1GetNext_WalksAndSkipsCounter64: a v1 GETNEXT walk from before the MIB
+// start steps lexicographically through every served object, STEPS OVER all
+// four Counter64 columns (RFC 2089 — v1 cannot carry Counter64), never emits a
+// Counter64 tag or an exception tag, and finally terminates with noSuchName at
+// the end of the MIB view.
+func TestV1GetNext_WalksAndSkipsCounter64(t *testing.T) {
+	a := v1Agent()
+
+	// ifXTable Counter64 columns (must be skipped in a v1 walk).
+	c64cols := map[int]bool{6: true, 7: true, 10: true, 11: true}
+	isIfXCounter64 := func(oid []int) bool {
+		if len(oid) != len(oidIfXTablePrefix)+2 {
+			return false
+		}
+		for i := range oidIfXTablePrefix {
+			if oid[i] != oidIfXTablePrefix[i] {
+				return false
+			}
+		}
+		return c64cols[oid[len(oidIfXTablePrefix)]]
+	}
+
+	// Start below sysDescr so the first GETNEXT lands on the first served OID.
+	cur := []int{1, 3, 6, 1, 2, 1, 1, 1}
+	var walked [][]int
+	sawGauge64Col := false // did we walk PAST the Counter64 region to ifHighSpeed?
+	for steps := 0; steps < 200; steps++ {
+		req := buildV1Request(pduGetNextRequest, "public", 100+steps, [][]int{cur})
+		resp := a.handlePacket(req)
+		if resp == nil {
+			t.Fatalf("v1 GETNEXT step %d returned nil (#5049)", steps)
+		}
+		errStatus, errIndex, vbs := decodeV1Response(t, resp)
+		if errStatus == errNoSuchName {
+			// End of MIB view: v1 signals it as noSuchName, index of the OID.
+			if errIndex != 1 {
+				t.Fatalf("end-of-MIB error-index = %d, want 1", errIndex)
+			}
+			if len(vbs) != 1 {
+				t.Fatalf("end-of-MIB echo must carry the 1 request varbind, got %d", len(vbs))
+			}
+			// The echoed varbind is the request OID with a NULL value — NOT an
+			// endOfMibView (0x82) or any other exception tag.
+			if vbs[0].tag != tagNull {
+				t.Fatalf("end-of-MIB echo value tag = 0x%02x, want NULL 0x%02x (no v2 exception in v1)", vbs[0].tag, tagNull)
+			}
+			if !oidsEqualT(vbs[0].oid, cur) {
+				t.Fatalf("end-of-MIB echo OID = %v, want the request OID %v", vbs[0].oid, cur)
+			}
+			if !sawGauge64Col {
+				t.Fatal("walk ended before reaching ifHighSpeed — the Counter64 region was not traversed")
+			}
+			return // success
+		}
+		if errStatus != errNoError {
+			t.Fatalf("GETNEXT step %d error-status = %d, want noError", steps, errStatus)
+		}
+		if len(vbs) != 1 {
+			t.Fatalf("GETNEXT step %d: got %d varbinds, want 1", steps, len(vbs))
+		}
+		got := vbs[0]
+
+		// v1 rule 1: no Counter64 tag ever on the wire.
+		if got.tag == tagCounter64 {
+			t.Fatalf("GETNEXT returned a Counter64 value (tag 0x%02x) at OID %v — forbidden in v1", got.tag, got.oid)
+		}
+		// v1 rule 2: no exception tags.
+		if got.tag == tagNoSuchObject || got.tag == tagNoSuchInstance || got.tag == tagEndOfMibView {
+			t.Fatalf("GETNEXT returned a v2 exception tag 0x%02x at OID %v — forbidden in v1", got.tag, got.oid)
+		}
+		// v1 rule 3: the walk stepped OVER every Counter64 column (never named).
+		if isIfXCounter64(got.oid) {
+			t.Fatalf("GETNEXT landed ON a Counter64 column OID %v — must be skipped in v1", got.oid)
+		}
+		// Strictly increasing.
+		if len(walked) > 0 && oidCompare(got.oid, walked[len(walked)-1]) <= 0 {
+			t.Fatalf("GETNEXT not strictly increasing: %v after %v", got.oid, walked[len(walked)-1])
+		}
+		// ifHighSpeed (ifXTable col 15) sits AFTER the Counter64 columns; seeing
+		// it proves the walk crossed the Counter64 region by skipping it.
+		if len(got.oid) == len(oidIfXTablePrefix)+2 && got.oid[len(oidIfXTablePrefix)] == 15 {
+			sawGauge64Col = true
+		}
+		walked = append(walked, got.oid)
+		cur = got.oid
+	}
+	t.Fatal("v1 GETNEXT walk did not terminate within 200 steps")
+}
+
+// TestV1Get_UnknownOID_NoSuchName: a v1 GET where one requested OID is
+// unresolvable fails the whole PDU with noSuchName, the 1-based error-index of
+// the offending varbind, and the request varbinds echoed with NULL values (no
+// per-varbind exception value).
+func TestV1Get_UnknownOID_NoSuchName(t *testing.T) {
+	a := v1Agent()
+	unknown := []int{1, 3, 6, 1, 4, 1, 99999, 42, 0} // not served
+	oids := [][]int{oidSysDescr, unknown, oidSysUpTime}
+	req := buildV1Request(pduGetRequest, "public", 7, oids)
+	resp := a.handlePacket(req)
+	if resp == nil {
+		t.Fatal("v1 GET returned nil (#5049)")
+	}
+	errStatus, errIndex, vbs := decodeV1Response(t, resp)
+	if errStatus != errNoSuchName {
+		t.Fatalf("error-status = %d, want noSuchName (%d)", errStatus, errNoSuchName)
+	}
+	if errIndex != 2 {
+		t.Fatalf("error-index = %d, want 2 (the unknown OID is the 2nd varbind)", errIndex)
+	}
+	if len(vbs) != len(oids) {
+		t.Fatalf("echoed %d varbinds, want %d (the request varbinds)", len(vbs), len(oids))
+	}
+	for i, vb := range vbs {
+		if !oidsEqualT(vb.oid, oids[i]) {
+			t.Fatalf("echo varbind %d OID = %v, want %v", i, vb.oid, oids[i])
+		}
+		// No exception value and no Counter64 — v1 echoes NULLs.
+		if vb.tag != tagNull {
+			t.Fatalf("echo varbind %d tag = 0x%02x, want NULL 0x%02x (no exception value in v1)", i, vb.tag, tagNull)
+		}
+	}
+}
+
+// TestV1Get_Counter64Node_NoSuchName: a direct v1 GET of a Counter64-typed node
+// (ifHCInOctets, ifXTable col 6) is not representable in v1, so it returns
+// noSuchName — never a Counter64 on the wire (RFC 2089).
+func TestV1Get_Counter64Node_NoSuchName(t *testing.T) {
+	a := v1Agent()
+	hcInOctets := append(append([]int{}, oidIfXTablePrefix...), 6, 1) // col 6, ifIndex 1
+	req := buildV1Request(pduGetRequest, "public", 9, [][]int{hcInOctets})
+	resp := a.handlePacket(req)
+	if resp == nil {
+		t.Fatal("v1 GET of a Counter64 node returned nil (#5049)")
+	}
+	errStatus, errIndex, vbs := decodeV1Response(t, resp)
+	if errStatus != errNoSuchName {
+		t.Fatalf("error-status = %d, want noSuchName (%d) for a Counter64 GET", errStatus, errNoSuchName)
+	}
+	if errIndex != 1 {
+		t.Fatalf("error-index = %d, want 1", errIndex)
+	}
+	if len(vbs) != 1 {
+		t.Fatalf("got %d varbinds, want 1", len(vbs))
+	}
+	if vbs[0].tag == tagCounter64 {
+		t.Fatalf("v1 GET of a Counter64 node put a Counter64 (tag 0x%02x) on the wire — forbidden", vbs[0].tag)
+	}
+	if vbs[0].tag != tagNull {
+		t.Fatalf("Counter64 GET echo tag = 0x%02x, want NULL 0x%02x", vbs[0].tag, tagNull)
+	}
+}
+
+// TestV1_SourceAllowlistEnforced: the v1 path enforces the SAME community
+// `clients` source-IP allowlist (#4289) as v2c — a query from a non-permitted
+// source is dropped (nil), a query from a permitted source is served.
+func TestV1_SourceAllowlistEnforced(t *testing.T) {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"scoped": {
+				Name:          "scoped",
+				Authorization: "read-only",
+				Clients:       []config.SNMPClient{{Prefix: "10.0.0.0/24"}},
+			},
+		},
+	})
+	req := buildV1Request(pduGetRequest, "scoped", 1, [][]int{oidSysDescr})
+
+	if resp := a.handlePacketFrom(req, net.ParseIP("10.0.0.9")); resp == nil {
+		t.Fatal("v1 GET from a permitted source (10.0.0.9) was dropped; want a response")
+	}
+	if resp := a.handlePacketFrom(req, net.ParseIP("192.0.2.5")); resp != nil {
+		t.Fatal("v1 GET from a non-permitted source (192.0.2.5) was answered; source allowlist not enforced")
+	}
+}
+
+// TestV1_UnknownCommunityDropped: an unknown community is dropped on the v1
+// path exactly as on v2c (no response).
+func TestV1_UnknownCommunityDropped(t *testing.T) {
+	a := v1Agent()
+	req := buildV1Request(pduGetRequest, "wrong-community", 1, [][]int{oidSysDescr})
+	if resp := a.handlePacket(req); resp != nil {
+		t.Fatal("v1 GET with an unknown community was answered; want no response")
+	}
+}
+
+// TestV1_MalformedRejected: a truncated/malformed v1 packet is rejected (nil),
+// the same as v2c — the shared outer-SEQUENCE / version / PDU BER guards apply.
+func TestV1_MalformedRejected(t *testing.T) {
+	a := v1Agent()
+	good := buildV1Request(pduGetRequest, "public", 1, [][]int{oidSysDescr})
+
+	// Truncated packet: keep the outer header but chop the body.
+	truncated := good[:len(good)/2]
+	if resp := a.handlePacket(truncated); resp != nil {
+		t.Fatal("malformed (truncated) v1 packet was answered; want no response")
+	}
+
+	// Garbage that is not a SEQUENCE at all.
+	if resp := a.handlePacket([]byte{0x01, 0x02, 0x03}); resp != nil {
+		t.Fatal("non-SEQUENCE v1 garbage was answered; want no response")
+	}
+}
+
+// TestV1Get_OversizedReturnsTooBig: a v1 GET naming many long-valued OIDs would
+// encode a response larger than maxPacketSize. Like v2c, it is size-bounded —
+// replaced with tooBig + an empty varbind list, never emitted over-size (shared
+// boundGetResponseVersion). RED-on-revert: with v1 dropped, resp is nil.
+func TestV1Get_OversizedReturnsTooBig(t *testing.T) {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"public": {Name: "public", Authorization: "read-only"},
+		},
+	})
+	a.SetIfDataFn(func() []IfData { return manyIfData(60) })
+
+	req := buildV1Request(pduGetRequest, "public", 1, ifDescrOIDs(60))
+	resp := a.handlePacket(req)
+	if resp == nil {
+		t.Fatal("v1 GET returned nil (#5049)")
+	}
+	if len(resp) > maxPacketSize {
+		t.Fatalf("v1 GET response %d bytes exceeds maxPacketSize %d (size cap not applied)", len(resp), maxPacketSize)
+	}
+	errStatus, _, vbs := decodeV1Response(t, resp)
+	if errStatus != errTooBig {
+		t.Fatalf("error-status = %d, want tooBig (%d) for an oversized v1 GET", errStatus, errTooBig)
+	}
+	if len(vbs) != 0 {
+		t.Fatalf("tooBig response must carry an empty varbind list, got %d varbinds", len(vbs))
+	}
+}
+
+// TestV1Set_NoSuchName: the agent serves only read-only objects and v1 lacks
+// the noAccess/notWritable statuses v2c uses; per RFC 2089 both map to
+// noSuchName. A v1 SET (read-only community, or read-write with no writable
+// object) returns noSuchName with error-index 1 and the request varbinds echoed.
+func TestV1Set_NoSuchName(t *testing.T) {
+	// read-only community.
+	a := v1Agent()
+	req := buildV1Request(pduSetRequest, "public", 1, [][]int{oidSysContact})
+	resp := a.handlePacket(req)
+	if resp == nil {
+		t.Fatal("v1 SET returned nil (#5049)")
+	}
+	errStatus, errIndex, vbs := decodeV1Response(t, resp)
+	if errStatus != errNoSuchName {
+		t.Fatalf("v1 SET (read-only) error-status = %d, want noSuchName (%d)", errStatus, errNoSuchName)
+	}
+	if errIndex != 1 {
+		t.Fatalf("v1 SET error-index = %d, want 1", errIndex)
+	}
+	if len(vbs) != 1 || !oidsEqualT(vbs[0].oid, oidSysContact) || vbs[0].tag != tagNull {
+		t.Fatalf("v1 SET must echo the request varbind as NULL; got %+v", vbs)
+	}
+
+	// read-write community: still noSuchName (no writable object exists), never
+	// a v2-only notWritable(17)/noAccess(6).
+	arw := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"private": {Name: "private", Authorization: "read-write"},
+		},
+	})
+	arw.SetIfDataFn(v1TestIfData)
+	reqRW := buildV1Request(pduSetRequest, "private", 2, [][]int{oidSysContact})
+	respRW := arw.handlePacket(reqRW)
+	if respRW == nil {
+		t.Fatal("v1 SET (read-write) returned nil (#5049)")
+	}
+	errStatusRW, _, _ := decodeV1Response(t, respRW)
+	if errStatusRW != errNoSuchName {
+		t.Fatalf("v1 SET (read-write) error-status = %d, want noSuchName (%d)", errStatusRW, errNoSuchName)
+	}
+}


### PR DESCRIPTION
## Problem

The SNMP request dispatch (`handlePacketFrom`, `pkg/snmp/agent.go`) routed only
version 1 (v2c) and version 3 (v3). The **version-0 (SNMPv1)** case fell through
to the `default:` "unsupported version" branch and returned `nil`. But the trap
path already implements v1 (`buildLinkTrapV1`, trap-group `version v1`, #3948).

So the device **emitted v1 traps but silently dropped every v1 GET/GETNEXT/SET
poll** — a legacy v1-only manager timed out and marked the device down. The
invariant: every configurable protocol version must have complete
request/response semantics.

## Fix

Add a version-0 handler (`handleV1Packet` + `handleV1Get` / `handleV1GetNext` /
`handleV1Set`) that reuses the **same** machinery as v2c:

- community frame + `clients` source-IP allowlist (#4289)
- per-PDU interface snapshot (#4013)
- bounded MIB lookup (`getOIDValueSnap` / `findNextOIDSnap`)
- message-size ceiling / `tooBig` fallback

`buildResponse` / `boundGetResponse` are refactored to version-parameterized
`buildResponseVersion` / `boundGetResponseVersion` so v1 shares the exact
encoding while emitting a version-0 envelope. **v2c entry points are unchanged.**

v1 response rules (RFC 1157 / RFC 2089):

- Missing/unresolvable OID → whole-PDU `noSuchName` (2) + **1-based error-index**;
  request varbinds **echoed unchanged** (NULL). **No** v2-only per-varbind
  exception values (`noSuchObject` / `noSuchInstance` / `endOfMibView`).
- GETNEXT past end-of-MIB → `noSuchName` (v1 has no `endOfMibView`).
- **Counter64** is not a v1 type: direct GET → `noSuchName`; GETNEXT **steps
  over** every Counter64 node (`findNextV1OIDSnap`). No Counter64 on the wire.
- SET → `noSuchName` (v1 lacks `noAccess`/`notWritable`; both map to `noSuchName`
  per RFC 2089 §2.1); no served object is writable.

Unknown community / non-permitted source / malformed / oversized packets are
rejected exactly as on the v2c path (shared code).

## Tests (RED-on-revert proven)

New `pkg/snmp/agent_v1_polling_5049_test.go`:

- v1 GET of a known OID returns the value (not nil/timeout)
- v1 GETNEXT walks lexicographically and **steps over** every Counter64 node;
  no Counter64/exception tag on the wire; terminates with `noSuchName`
- v1 GET of an unknown OID → `noSuchName`, correct error-index, varbinds echoed,
  no exception value
- v1 GET of a Counter64 node → `noSuchName` (no Counter64 emitted)
- source not in the allowlist → dropped, same as v2c
- unknown community / malformed BER → dropped, same as v2c
- oversized response → `tooBig` + empty varbinds (shared bound)
- v1 SET → `noSuchName` (read-only and read-write communities)

**RED-on-revert:** `git stash push -- pkg/snmp/agent.go` (keeping the tests)
makes every "expect a response" assertion get `nil` (7 fail); the two
drop-expecting tests stay green; `git stash pop` turns the suite green.

Validation: `go build ./...`, `go vet ./pkg/snmp/...`, full `pkg/snmp` suite green.

Docs: `pkg/snmp/README.md` documents the v1 polling path + response rules.

Closes #5049