### PR TITLE
pkg/dhcprelay: preserve downstream giaddr and Option 82 on relay chaining (#5071)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45077,3 +45077,24 @@ top.
   sections (removed the #1434 "VRF not unbound" residual).
 - **File(s)**: pkg/routing/tunnel.go,
   pkg/routing/tunnel_reconcile_test.go, pkg/routing/README.md, _Log.md
+
+- **Timestamp**: 2026-07-10
+- **Action**: #5071 — preserve downstream giaddr + Option 82 on DHCP relay
+  chaining (RFC 1542 §4.1.1 / RFC 3046). The forward loop stamped its own
+  giaddr and Del/overwrote Option 82 unconditionally, even when the inbound
+  BOOTREQUEST already carried a nonzero giaddr from a downstream relay —
+  making the server pick the wrong pool, reply to the wrong relay, and
+  destroying the original circuit-id. Added `giaddrIsSet()` and captured the
+  chained condition BEFORE any mutation; on a chained request (giaddr!=0) the
+  relay now preserves BOTH giaddr and the downstream relay-agent Option 82
+  untouched and only increments the BOOTP hops field. First-hop path
+  (giaddr==0) is unchanged: stamp giaddr + insert circuit-id Option 82. The
+  RFC 1542 hop-limit check (#4309, default 16) runs for both paths. No new
+  config knob (untrusted-client Option 82 trust policy noted out of scope).
+  Three fail-on-revert tests (first-hop stamp preserved, chained
+  giaddr+Option-82 preserved with exact-byte assertions, chained hop-limit
+  drop); RED-on-revert proven (chained-preserve fails on reverted source,
+  first-hop passes both ways). Updated pkg/dhcprelay/README.md with a "Relay
+  chaining" section + first-hop-only Option 82 gotcha.
+- **File(s)**: pkg/dhcprelay/relay.go,
+  pkg/dhcprelay/relay_chain_5071_test.go, pkg/dhcprelay/README.md, _Log.md

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -48,6 +48,46 @@ The `INFORM` reply (a server-issued `ACK` with no `yiaddr` but a real
 real `ciaddr`" UDP-unicast row — the client already owns and ARP-answers for
 its address.
 
+## Relay chaining — giaddr / Option 82 ownership (#5071)
+
+The forward loop distinguishes a **first-hop** relay from an **intermediate**
+relay in a chain by inspecting the inbound BOOTREQUEST's `giaddr`
+(`GatewayIPAddr`), per RFC 1542 §4.1.1 / RFC 3046:
+
+| Inbound `giaddr` | `giaddr` action | Option 82 action | `hops` |
+|------------------|-----------------|------------------|--------|
+| `0.0.0.0` (first hop) | **stamp** this relay's interface IP | **insert** `circuit-id` = interface name | increment (after limit check) |
+| non-zero (chained) | **preserve** untouched | **preserve** the downstream option untouched (no `Del`/overwrite) | increment (after limit check) |
+
+The **first relay on the client segment owns both fields**: the server selects
+the client's address pool from the `giaddr` it sees and unicasts its
+`OFFER`/`ACK` back to `giaddr:67`, and the original `circuit-id` must survive so
+the operator's per-port Option 82 policy still applies at the server. An
+intermediate relay that overwrote `giaddr` would make the server lease from the
+wrong pool and reply to the wrong relay; overwriting Option 82 would destroy the
+downstream `circuit-id`. So on a chained request this relay changes **only** the
+BOOTP `hops` field.
+
+- The chained condition is captured **before** any mutation
+  (`giaddrIsSet(pkt.GatewayIPAddr)`), so a zero `giaddr` in either the 4-byte or
+  4-in-16 form reads as first-hop.
+- The RFC 1542 §4.1.1 hop-limit check (`overrides maximum-hop-count`, default
+  16, #4309) runs for **both** paths — it is most load-bearing on a chained
+  ring, where a misconfigured downstream relay loop would otherwise circulate a
+  request forever (`RequestsDroppedMaxHops`).
+- **Reply path.** A chained request's reply is unicast by the server directly to
+  the preserved (downstream) `giaddr:67`, so it does not return through this
+  relay's `giaddr:67`-bound server conn — the intermediate relay handles only the
+  request direction, which is RFC-correct. The reply-path Option 82 strip +
+  `giaddr` clear (below) therefore only fires for first-hop leases this relay
+  actually owns.
+- **Untrusted-client Option 82 policy is out of scope.** Junos models a
+  `trusted`/`untrusted` edge with per-port Option 82 insert/replace/keep/drop
+  actions. xpf has no such config knob today (only `relay-agent-option`,
+  accepted-only), so this fix implements the minimal RFC-correct preservation:
+  first-hop inserts, chained preserves. A future `option-82` trust-policy knob
+  can layer an explicit untrusted-client replace/drop action on top.
+
 ## Reply delivery model (#2076)
 
 Server replies (OFFER/ACK/NAK/FORCERENEW) are delivered to clients honoring the
@@ -413,8 +453,11 @@ OFFER/ACK to forward in the first place; clients still dedupe on
   upstream server lease from the wrong subnet pool. If netlink enumeration
   fails the resolver falls back to the portable lister rather than failing
   closed (a transient netlink hiccup must not strand a relay).
-- Option 82 sub-option 1 (`circuit-id`) is set to the interface name; on
-  the reply path it's stripped before forwarding to the client.
+- Option 82 sub-option 1 (`circuit-id`) is set to the interface name **on
+  first-hop requests only** (inbound `giaddr==0`); a chained request's
+  downstream Option 82 is preserved untouched (#5071, see "Relay chaining"
+  above). On the reply path Option 82 is stripped before forwarding to the
+  client.
 - Server addresses must be **literal IPs**. `Apply()` calls
   `net.ParseIP` and rejects hostnames; there is no DNS resolution
   path. To target a hostname, the operator must resolve it externally

--- a/pkg/dhcprelay/relay.go
+++ b/pkg/dhcprelay/relay.go
@@ -1138,15 +1138,29 @@ func (m *Manager) runRelaySession(ctx context.Context,
 				continue
 			}
 
-			// Set giaddr to our interface IP so the server knows where to reply.
-			pkt.GatewayIPAddr = giaddr
+			// RFC 1542 §4.1.1 / RFC 3046 relay chaining: a nonzero inbound
+			// giaddr means a DOWNSTREAM relay is the FIRST relay on the
+			// client's segment and already stamped both the giaddr and the
+			// relay-agent Option 82. That first relay OWNS them: the server
+			// selects the client's address pool from the giaddr it sees and
+			// unicasts its OFFER/ACK back to giaddr:67, and the original
+			// circuit-id must survive so the operator's per-port policy still
+			// applies. An intermediate relay MUST preserve both and only
+			// touch the BOOTP hops field (#5071). Overwriting the giaddr makes
+			// the server lease from the wrong pool and reply to the wrong
+			// relay; overwriting Option 82 destroys the downstream circuit-id.
+			// Capture the chained condition BEFORE any mutation below.
+			chained := giaddrIsSet(pkt.GatewayIPAddr)
 
 			// Enforce the RFC 1542 §4.1.1 hop limit BEFORE incrementing.
 			// HopCount is uint8: checking after a ++ lets an incoming value
 			// of 255 wrap to 0 and slip past a post-increment ">= limit"
 			// test, defeating loop protection. A request that already carries
 			// the limit has reached it and must be dropped. The limit is the
-			// group's `overrides maximum-hop-count` (default 16) — #4309.
+			// group's `overrides maximum-hop-count` (default 16) — #4309. This
+			// loop guard applies to first-hop AND chained requests; it is most
+			// load-bearing on a chained ring, where a misconfigured downstream
+			// relay loop would otherwise circulate the request forever.
 			if pkt.HopCount >= ir.maxHopCount {
 				ir.requestsDroppedMaxHops.Add(1)
 				slog.Warn("dhcp-relay: hop count exceeded, dropping",
@@ -1155,8 +1169,21 @@ func (m *Manager) runRelaySession(ctx context.Context,
 			}
 			pkt.HopCount++
 
-			// Add Option 82 (Relay Agent Information) with circuit-id sub-option.
-			addOption82(pkt, ifaceName)
+			if chained {
+				// Chained downstream relay: preserve giaddr AND the existing
+				// relay-agent Option 82 untouched (do NOT stamp our giaddr and
+				// do NOT Del/overwrite Option 82). Only the hops field above
+				// was modified.
+				slog.Debug("dhcp-relay: preserving downstream giaddr and Option 82 (relay chain)",
+					"interface", ifaceName,
+					"giaddr", pkt.GatewayIPAddr, "hops", pkt.HopCount)
+			} else {
+				// First hop (inbound giaddr == 0): stamp our interface IP so
+				// the server knows where to reply, and insert Option 82 (Relay
+				// Agent Information) with the circuit-id sub-option.
+				pkt.GatewayIPAddr = giaddr
+				addOption82(pkt, ifaceName)
+			}
 
 			// Unicast the modified packet to each server in the active group.
 			relayData := pkt.ToBytes()
@@ -1507,6 +1534,17 @@ func clientRequestRelayable(msgType dhcpv4.MessageType) bool {
 // non-6-byte chaddr falls back to broadcast (the L2 frame would be malformed).
 func l2Eligible(pkt *dhcpv4.DHCPv4) bool {
 	return pkt.HWType == iana.HWTypeEthernet && len(pkt.ClientHWAddr) == 6
+}
+
+// giaddrIsSet reports whether a BOOTP giaddr (GatewayIPAddr) field carries a
+// real relay address — i.e. a DOWNSTREAM relay already stamped it and this node
+// is an intermediate hop in a relay chain (RFC 1542 §4.1.1 / RFC 3046). A zero
+// or unset giaddr (0.0.0.0 or nil) means this relay is the first hop on the
+// client segment. Comparison is form-agnostic (net.IP.Equal handles the 4-byte
+// vs 4-in-16 form), so a zero in either representation reads as unset.
+func giaddrIsSet(ip net.IP) bool {
+	v4 := ip.To4()
+	return v4 != nil && !v4.Equal(net.IPv4zero)
 }
 
 // addOption82 inserts or replaces the Relay Agent Information option (82)

--- a/pkg/dhcprelay/relay_chain_5071_test.go
+++ b/pkg/dhcprelay/relay_chain_5071_test.go
@@ -1,0 +1,188 @@
+package dhcprelay
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/insomniacslk/dhcp/dhcpv4"
+)
+
+// downstreamOption82 builds a raw Option 82 (Relay Agent Information) value as
+// a real DOWNSTREAM relay would emit it: sub-option 1 (circuit-id) plus
+// sub-option 2 (remote-id). The two-sub-option shape is deliberate — this
+// relay's own addOption82 only ever writes sub-option 1, so if the chained
+// path accidentally rebuilt the option the sub-option 2 (remote-id) bytes
+// would disappear, making the preservation assertion catch an overwrite.
+func downstreamOption82(circuitID, remoteID string) []byte {
+	var b []byte
+	// sub-option 1: circuit-id.
+	b = append(b, suboption1CircuitID, byte(len(circuitID)))
+	b = append(b, []byte(circuitID)...)
+	// sub-option 2: remote-id (type 2).
+	b = append(b, 2, byte(len(remoteID)))
+	b = append(b, []byte(remoteID)...)
+	return b
+}
+
+// runRelayForward pushes a single BOOTREQUEST through the live runRelay loop
+// and returns the relayed datagram observed on the server conn. It fails the
+// test if nothing is relayed within the deadline.
+func runRelayForward(t *testing.T, req *dhcpv4.DHCPv4) *dhcpv4.DHCPv4 {
+	t.Helper()
+	client := newFakeConn()
+	client.pending = [][]byte{req.ToBytes()}
+	server := newFakeConn()
+	factory, _ := recordingFactory(client, server)
+	m := testManager(factory)
+	m.Apply(context.Background(), singleInterfaceConfig())
+	defer m.Stop()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for server.writeCount() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if server.writeCount() == 0 {
+		t.Fatal("request was not relayed to the server within 2s")
+	}
+	relayed, err := dhcpv4.FromBytes(server.firstWrite(t))
+	if err != nil {
+		t.Fatalf("relayed datagram does not parse: %v", err)
+	}
+	return relayed
+}
+
+// TestRunRelay_FirstHopStampsGiaddrAndOption82 pins the first-hop path
+// (inbound giaddr == 0): the relay stamps its own interface giaddr
+// (10.0.0.254, from testManager's resolver) and inserts its circuit-id
+// Option 82 (sub-option 1 == the interface name "ge-0-0-0"). This is the
+// existing behavior and MUST NOT regress when the #5071 chained-preserve
+// branch is added.
+func TestRunRelay_FirstHopStampsGiaddrAndOption82(t *testing.T) {
+	req, err := dhcpv4.New()
+	if err != nil {
+		t.Fatalf("dhcpv4.New: %v", err)
+	}
+	req.OpCode = dhcpv4.OpcodeBootRequest
+	req.ClientHWAddr = net.HardwareAddr{0x02, 0, 0, 0, 0, 1}
+	req.HopCount = 0
+	// No giaddr, no Option 82: this relay is the first hop.
+	req.UpdateOption(dhcpv4.OptMessageType(dhcpv4.MessageTypeDiscover))
+
+	relayed := runRelayForward(t, req)
+
+	if !relayed.GatewayIPAddr.Equal(net.IPv4(10, 0, 0, 254)) {
+		t.Errorf("first-hop giaddr = %v, want 10.0.0.254 (relay stamps its own)",
+			relayed.GatewayIPAddr)
+	}
+	if relayed.HopCount != 1 {
+		t.Errorf("first-hop HopCount = %d, want 1", relayed.HopCount)
+	}
+	opt := relayed.Options.Get(option82)
+	if opt == nil {
+		t.Fatal("first-hop relay did not insert Option 82")
+	}
+	if opt[0] != suboption1CircuitID {
+		t.Fatalf("Option 82 sub-option type = %d, want %d (circuit-id)",
+			opt[0], suboption1CircuitID)
+	}
+	if circuitID := string(opt[2:]); circuitID != "ge-0-0-0" {
+		t.Errorf("first-hop circuit-id = %q, want %q (interface name)",
+			circuitID, "ge-0-0-0")
+	}
+}
+
+// TestRunRelay_ChainedPreservesGiaddrAndOption82 is the #5071 RED-on-revert
+// proof. A BOOTREQUEST that arrives with a NONZERO giaddr (203.0.113.9,
+// stamped by a downstream relay) and a downstream relay-agent Option 82 must
+// be forwarded with BOTH preserved untouched — the relay only increments the
+// BOOTP hops field (RFC 1542 §4.1.1 / RFC 3046). Reverting the conditional
+// preserve makes the relay stamp its own giaddr (10.0.0.254) and overwrite
+// Option 82 with its own circuit-id, so both assertions go RED.
+func TestRunRelay_ChainedPreservesGiaddrAndOption82(t *testing.T) {
+	const downstreamGiaddr = "203.0.113.9"
+	inbound82 := downstreamOption82("down-ckt-42", "aabbccddeeff")
+
+	req, err := dhcpv4.New()
+	if err != nil {
+		t.Fatalf("dhcpv4.New: %v", err)
+	}
+	req.OpCode = dhcpv4.OpcodeBootRequest
+	req.ClientHWAddr = net.HardwareAddr{0x02, 0, 0, 0, 0, 2}
+	req.HopCount = 1 // one downstream relay already handled it
+	req.GatewayIPAddr = net.ParseIP(downstreamGiaddr)
+	req.UpdateOption(dhcpv4.OptMessageType(dhcpv4.MessageTypeDiscover))
+	req.UpdateOption(dhcpv4.OptGeneric(option82, inbound82))
+
+	relayed := runRelayForward(t, req)
+
+	// giaddr preserved: equals the downstream relay's address, NOT this
+	// relay's own giaddr (10.0.0.254).
+	if !relayed.GatewayIPAddr.Equal(net.ParseIP(downstreamGiaddr)) {
+		t.Errorf("chained giaddr = %v, want %s (downstream giaddr preserved); "+
+			"if this is 10.0.0.254 the relay overwrote it (#5071 regression)",
+			relayed.GatewayIPAddr, downstreamGiaddr)
+	}
+
+	// Option 82 preserved byte-for-byte: the downstream circuit-id AND
+	// remote-id sub-options survive untouched.
+	got := relayed.Options.Get(option82)
+	if !bytes.Equal(got, inbound82) {
+		t.Errorf("chained Option 82 = %v, want %v (downstream option preserved); "+
+			"a mismatch means the relay Del/overwrote it (#5071 regression)",
+			got, inbound82)
+	}
+
+	// hops incremented (the one field an intermediate relay may touch).
+	if relayed.HopCount != 2 {
+		t.Errorf("chained HopCount = %d, want 2 (incremented from 1)",
+			relayed.HopCount)
+	}
+}
+
+// TestRunRelay_ChainedHopLimitDrop proves the RFC 1542 §4.1.1 loop-protection
+// hop limit still applies to a chained request (nonzero giaddr). A chained
+// request whose hops field has reached the limit is dropped and counted,
+// exactly like the first-hop path — the preserve branch must not smuggle a
+// looping request past the cap.
+func TestRunRelay_ChainedHopLimitDrop(t *testing.T) {
+	req, err := dhcpv4.New()
+	if err != nil {
+		t.Fatalf("dhcpv4.New: %v", err)
+	}
+	req.OpCode = dhcpv4.OpcodeBootRequest
+	req.ClientHWAddr = net.HardwareAddr{0x02, 0, 0, 0, 0, 3}
+	req.HopCount = defaultMaxHopCount // at the default limit (16)
+	req.GatewayIPAddr = net.ParseIP("203.0.113.9")
+	req.UpdateOption(dhcpv4.OptMessageType(dhcpv4.MessageTypeDiscover))
+	req.UpdateOption(dhcpv4.OptGeneric(option82,
+		downstreamOption82("down-ckt", "aabbcc")))
+
+	client := newFakeConn()
+	client.pending = [][]byte{req.ToBytes()}
+	server := newFakeConn()
+	factory, _ := recordingFactory(client, server)
+	m := testManager(factory)
+	m.Apply(context.Background(), singleInterfaceConfig())
+	defer m.Stop()
+
+	// Wait for the loop to consume the datagram (second ReadFrom = post-drop).
+	deadline := time.Now().Add(1 * time.Second)
+	for client.readCalls.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+
+	if got := server.writeCount(); got != 0 {
+		t.Fatalf("chained request at hop limit was relayed (%d datagram(s)), "+
+			"want drop", got)
+	}
+	var dropped uint64
+	for _, s := range m.Stats() {
+		dropped += s.RequestsDroppedMaxHops
+	}
+	if dropped == 0 {
+		t.Error("chained request dropped but RequestsDroppedMaxHops stayed 0")
+	}
+}


### PR DESCRIPTION
## Problem

Per **RFC 1542 §4.1.1 / RFC 3046** the FIRST relay on a client segment owns the
BOOTP `giaddr` and the relay-agent Option 82: the DHCP server selects the
client's address pool from the `giaddr` it sees and unicasts its OFFER/ACK back
to `giaddr:67`, and the original `circuit-id` must survive so the operator's
per-port Option 82 policy still applies at the server. An intermediate relay in
a chain MUST preserve both and only touch the BOOTP `hops` field.

The forward loop (`pkg/dhcprelay/relay.go`) violated this on both fields:

- `pkt.GatewayIPAddr = giaddr` — stamped its **own** giaddr unconditionally.
- `addOption82` — `Options.Del(82)` then overwrite unconditionally.

…**even when the inbound BOOTREQUEST already carried a nonzero `giaddr` from a
downstream relay.** The result: the server leases from the wrong subnet pool,
unicasts its reply to the wrong relay, and the downstream `circuit-id` is
destroyed.

## Fix

Add `giaddrIsSet()` and capture the chained condition **before** any mutation:

| Inbound `giaddr` | `giaddr` | Option 82 | `hops` |
|------------------|----------|-----------|--------|
| `0.0.0.0` (first hop) | stamp interface IP | insert circuit-id | increment (after limit check) |
| non-zero (chained) | **preserve** | **preserve** downstream option (no Del/overwrite) | increment (after limit check) |

- First-hop path is unchanged (no regression).
- The RFC 1542 §4.1.1 hop-limit check (#4309, `overrides maximum-hop-count`,
  default 16) already ran unconditionally and continues to guard **both** paths
  — most load-bearing on a chained ring.
- A chained reply is unicast by the server directly to the preserved downstream
  `giaddr:67`, so it never returns through this relay's `giaddr:67`-bound server
  conn; the reply-path Option 82 strip + `giaddr` clear stay correct for the
  first-hop leases this relay actually owns.

## Out of scope

There is no Option 82 trust/policy config knob today (only the accepted-only
`relay-agent-option`), so this implements the **minimal RFC-correct
preservation**. An explicit untrusted-client Option 82 replace/drop policy is
noted as a follow-up in the module README.

## Tests (RED-on-revert proven)

- `TestRunRelay_FirstHopStampsGiaddrAndOption82` — first hop stamps giaddr
  (10.0.0.254) + circuit-id (`ge-0-0-0`); passes both ways (behavior preserved).
- `TestRunRelay_ChainedPreservesGiaddrAndOption82` — chained request preserves
  giaddr (203.0.113.9) AND the downstream Option 82 **byte-for-byte** (circuit-id
  + remote-id sub-options), hops incremented. **Fails on reverted source**
  (giaddr overwritten to 10.0.0.254, Option 82 rebuilt as `[1 8 103 101 45 …]`).
- `TestRunRelay_ChainedHopLimitDrop` — chained request at the hop limit is
  dropped and `RequestsDroppedMaxHops` incremented.

`go build ./...` and `go test ./pkg/dhcprelay/...` green. Docs: added a "Relay
chaining" section + first-hop-only Option 82 gotcha to `pkg/dhcprelay/README.md`.

Closes #5071

🤖 Generated with [Claude Code](https://claude.com/claude-code)