### PR TITLE
pkg/daemon: remove managed ssh_known_hosts when desired trust is cleared (#5112)

### DIFF
--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -290,6 +290,16 @@ Special cases:
   resolved cgo-free from `/etc/passwd` (`lookupUIDGID` — never `os/user`).
 - **`WithOwner` vs `WithPreserveExisting` precedence**: if both are set,
   owner = `WithOwner`'s, mode = preserved-existing's (explicit owner wins).
+- **`ssh_known_hosts` WRITE is AtomicGeneratedConfig, but its REMOVAL
+  fsyncs the parent dir** (#5112): the write is a no-fsync
+  `WriteFileAtomic` because a lost-on-power-cut rewrite just re-renders the
+  SAME trust next apply. Clearing `security ssh-known-hosts` REMOVES the
+  xpf-owned file (`applySSHKnownHosts` → `removeManagedSSHKnownHosts`,
+  ownership-guarded on the managed header so a foreign/hand-maintained file
+  is never deleted), and that removal fsyncs the parent dir
+  (`fsatomic.SyncDir`): a lost unlink is the DANGEROUS direction — it would
+  resurrect a revoked, now-untrusted host key on reboot. Applied durable
+  trust must not outlive desired trust.
 
 Rules of thumb:
 

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -581,16 +581,33 @@ func (d *Daemon) applyKernelTuning(cfg *config.Config) {
 	}
 }
 
+// sshKnownHostsPath is the OpenSSH global known-hosts file xpfd owns and fully
+// rewrites from security { ssh-known-hosts }. Overridable in tests so the
+// write/remove side effects can be exercised against a temp dir.
+var sshKnownHostsPath = "/etc/ssh/ssh_known_hosts"
+
+// sshKnownHostsHeader marks the file as xpf-owned. Both the write path and the
+// empty-desired-state removal path key off this exact string: the daemon
+// rewrites the file only when it renders content, and removes it only when the
+// on-disk file begins with this header — never a hand-maintained/foreign
+// ssh_known_hosts.
+const sshKnownHostsHeader = "# Managed by xpfd — do not edit\n"
+
 // applySSHKnownHosts writes /etc/ssh/ssh_known_hosts from
-// security { ssh-known-hosts { host ... } } config.
+// security { ssh-known-hosts { host ... } } config. When the desired trust is
+// cleared (no configured hosts) the xpf-owned file is REMOVED, so a revoked or
+// compromised host key can never outlive the config that trusted it (#5112):
+// applied durable trust must not outlive desired trust. The removal is
+// ownership-guarded — a file lacking the managed header is left untouched.
 func (d *Daemon) applySSHKnownHosts(cfg *config.Config) {
-	const path = "/etc/ssh/ssh_known_hosts"
+	path := sshKnownHostsPath
 	if len(cfg.Security.SSHKnownHosts) == 0 {
+		removeManagedSSHKnownHosts(path)
 		return
 	}
 
 	var buf strings.Builder
-	buf.WriteString("# Managed by xpfd — do not edit\n")
+	buf.WriteString(sshKnownHostsHeader)
 	// Sort hosts for deterministic output
 	var hosts []string
 	for h := range cfg.Security.SSHKnownHosts {
@@ -631,6 +648,40 @@ func (d *Daemon) applySSHKnownHosts(cfg *config.Config) {
 		return
 	}
 	slog.Info("SSH known hosts written", "hosts", len(cfg.Security.SSHKnownHosts))
+}
+
+// removeManagedSSHKnownHosts removes the xpf-owned ssh_known_hosts file when
+// the desired trust is empty. It deletes the file ONLY when the on-disk
+// content begins with the managed header, so a hand-maintained or otherwise
+// foreign ssh_known_hosts is never touched. An absent file is a no-op.
+//
+// Unlike the write path (fsatomic.WriteFileAtomic — no fsync, because a
+// lost-on-power-cut rewrite simply re-renders the SAME trust next apply), the
+// removal is the DANGEROUS direction: a lost unlink would resurrect a revoked,
+// now-untrusted host key on reboot. So the parent directory is fsynced after
+// the unlink to make the removal durable across power loss.
+func removeManagedSSHKnownHosts(path string) {
+	current, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("failed to read ssh known hosts for removal", "path", path, "err", err)
+		}
+		return
+	}
+	if !strings.HasPrefix(string(current), sshKnownHostsHeader) {
+		// Foreign / hand-maintained file — not ours to delete.
+		return
+	}
+	if err := os.Remove(path); err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("failed to remove ssh known hosts", "path", path, "err", err)
+		}
+		return
+	}
+	if err := fsatomic.SyncDir(filepath.Dir(path)); err != nil {
+		slog.Warn("failed to fsync dir after ssh known hosts removal", "path", path, "err", err)
+	}
+	slog.Info("SSH known hosts cleared; managed file removed", "path", path)
 }
 
 // zoneinfoRoot is the directory tree a `system time-zone` value may reference.

--- a/pkg/daemon/ssh_known_hosts_clear_5112_test.go
+++ b/pkg/daemon/ssh_known_hosts_clear_5112_test.go
@@ -1,0 +1,113 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// withTempSSHKnownHostsPath points sshKnownHostsPath at a temp file for the
+// duration of a test and restores it afterward.
+func withTempSSHKnownHostsPath(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ssh_known_hosts")
+	orig := sshKnownHostsPath
+	sshKnownHostsPath = path
+	t.Cleanup(func() { sshKnownHostsPath = orig })
+	return path
+}
+
+func newTrustCfg() *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.SSHKnownHosts = map[string][]config.SSHKnownHostKey{
+		"192.168.0.253": {{Type: "ssh-ed25519-key", Key: "AAAAC3NzaC1lZDI1NTE5AAAAtestkey"}},
+	}
+	return cfg
+}
+
+// TestApplySSHKnownHostsClearRemovesManagedFile is the #5112 guard: once the
+// operator clears security ssh-known-hosts, the xpf-owned file must be removed
+// so a revoked host key does not stay trusted for outbound SSH. This is the
+// test that goes RED when the production removal path is reverted.
+func TestApplySSHKnownHostsClearRemovesManagedFile(t *testing.T) {
+	path := withTempSSHKnownHostsPath(t)
+	d := &Daemon{}
+
+	// Seed a managed file by applying non-empty desired state.
+	d.applySSHKnownHosts(newTrustCfg())
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected managed file written, read err: %v", err)
+	}
+	if !strings.HasPrefix(string(data), sshKnownHostsHeader) {
+		t.Fatalf("managed file missing header: %q", string(data))
+	}
+
+	// Clear desired state → managed file must be removed.
+	d.applySSHKnownHosts(&config.Config{})
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("managed ssh_known_hosts not removed on empty desired state (stat err=%v)", err)
+	}
+}
+
+// TestApplySSHKnownHostsClearLeavesForeignFile verifies the ownership guard: a
+// file WITHOUT the xpf managed header (hand-maintained / foreign) must never be
+// deleted, even when desired state is empty.
+func TestApplySSHKnownHostsClearLeavesForeignFile(t *testing.T) {
+	path := withTempSSHKnownHostsPath(t)
+	foreign := "10.0.0.1 ssh-ed25519 AAAAhandmaintained\n"
+	if err := os.WriteFile(path, []byte(foreign), 0644); err != nil {
+		t.Fatalf("seed foreign file: %v", err)
+	}
+
+	d := &Daemon{}
+	d.applySSHKnownHosts(&config.Config{})
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("foreign ssh_known_hosts must be preserved, read err: %v", err)
+	}
+	if string(got) != foreign {
+		t.Fatalf("foreign file mutated: got %q want %q", string(got), foreign)
+	}
+}
+
+// TestApplySSHKnownHostsWritesNonEmpty verifies the existing write path is
+// preserved: non-empty desired state renders the managed header plus a host
+// key line with the Junos→OpenSSH type mapping applied.
+func TestApplySSHKnownHostsWritesNonEmpty(t *testing.T) {
+	path := withTempSSHKnownHostsPath(t)
+	d := &Daemon{}
+	d.applySSHKnownHosts(newTrustCfg())
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	content := string(data)
+	if !strings.HasPrefix(content, sshKnownHostsHeader) {
+		t.Fatalf("missing managed header: %q", content)
+	}
+	// ssh-ed25519-key must map to OpenSSH ssh-ed25519.
+	wantLine := "192.168.0.253 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAtestkey\n"
+	if !strings.Contains(content, wantLine) {
+		t.Fatalf("expected host line %q in %q", wantLine, content)
+	}
+}
+
+// TestApplySSHKnownHostsClearAbsentFileNoError verifies that clearing desired
+// state when no file exists is a clean no-op (no panic, no file created).
+func TestApplySSHKnownHostsClearAbsentFileNoError(t *testing.T) {
+	path := withTempSSHKnownHostsPath(t)
+	d := &Daemon{}
+
+	d.applySSHKnownHosts(&config.Config{})
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("no file should exist after clear-on-absent (stat err=%v)", err)
+	}
+}


### PR DESCRIPTION
## Problem

`applySSHKnownHosts` (`pkg/daemon/daemon_system.go`) owns and fully
rewrites `/etc/ssh/ssh_known_hosts` (managed header + atomic write) but
**returned early on empty desired state** (`if len(cfg.Security.SSHKnownHosts) == 0 { return }`)
and never removed the xpf-owned file. After an operator cleared
`security ssh-known-hosts`, a **revoked or compromised host key stayed
trusted for outbound SSH** until something else rewrote the file.

## Invariant

Applied durable trust must not outlive desired trust.

## Fix

On empty desired state the daemon now REMOVES the xpf-owned file via
`removeManagedSSHKnownHosts`:

- **Ownership-guarded**: deletes only when the on-disk content begins
  with the managed header (`# Managed by xpfd — do not edit`). A
  hand-maintained / foreign `ssh_known_hosts` is never touched.
- **Absent file** → clean no-op.
- **Directory durability**: the write path is AtomicGeneratedConfig
  (`WriteFileAtomic`, no fsync) because a lost-on-power-cut *rewrite*
  just re-renders the SAME trust next apply. The *removal* is the
  DANGEROUS direction — a lost unlink would resurrect a revoked key on
  reboot — so the parent dir is fsynced (`fsatomic.SyncDir`) after the
  unlink.
- The managed-header string and the file path are now shared
  const/var (path overridable in tests, mirroring `sshdConfPath`) so
  the ownership guard can never drift from what the write path stamps.

## Tests (`pkg/daemon/ssh_known_hosts_clear_5112_test.go`)

- Managed file (with header) → REMOVED on empty desired state.
- Foreign file (no header) → PRESERVED on empty desired state.
- Non-empty desired state → still writes correctly (Junos→OpenSSH type
  mapping preserved).
- Absent file + empty desired state → no error.

**RED-on-revert proven**: neutralizing only the removal call (keeping
the shared symbols) fails `TestApplySSHKnownHostsClearRemovesManagedFile`
with `managed ssh_known_hosts not removed on empty desired state`, while
the guard / write / absent tests still pass.

## Docs

`docs/engineering-style.md` persistence table updated to document the
write-atomic / removal-durable asymmetry for `ssh_known_hosts`.

## Validation

- `go build ./...` — green
- `go test ./pkg/daemon/... -count=1` — green
- `go test ./pkg/fsatomic/... -count=1` — green (write/remove canary lint)
- `go vet ./pkg/daemon/...`, `gofmt` — clean

Closes #5112