### PR TITLE
pkg/lldp: withdraw neighbor immediately on TTL=0 shutdown LLDPDU (#5123)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45100,3 +45100,23 @@ top.
   sections (removed the #1434 "VRF not unbound" residual).
 - **File(s)**: pkg/routing/tunnel.go,
   pkg/routing/tunnel_reconcile_test.go, pkg/routing/README.md, _Log.md
+
+- **Timestamp**: 2026-07-10
+- **Action**: #5123 pkg/lldp — withdraw a neighbor immediately on a TTL=0
+  shutdown LLDPDU. The RX path stored a TTL=0 frame like any other neighbor
+  (ExpiresAt==now), so a departed peer stayed visible in `Neighbors()` until
+  the next ~10s `expiryLoop` tick, violating IEEE 802.1AB shutdown semantics
+  (the receiver must delete the neighbor at once). `rxLoop` now computes the
+  `ifname/chassis/port` key and, when the parsed TTL is 0, calls the new
+  `withdrawNeighbor` helper — a locked delete under the same `mu` the learn
+  and expiry paths use — and does NOT cache the frame. A TTL=0 frame for an
+  unknown key is a no-op (no error, no spurious insert). The non-zero TTL
+  learn/refresh path is unchanged and the 10s reap cadence is untouched.
+  Added three fail-on-revert tests driving the real `rxLoop` through the
+  `recvFn` seam with a deterministic synchronous handshake: immediate
+  withdrawal after TTL=0, unknown-key no-insert, non-zero learn+refresh.
+  Proved RED-on-revert (the two TTL=0 tests fail on reverted source; the
+  refresh test passes both ways by design). `go test -race ./pkg/lldp/...`
+  green. Updated pkg/lldp/README.md neighbor-lifecycle + ParseTLVs notes.
+- **File(s)**: pkg/lldp/lldp.go, pkg/lldp/shutdown_ttl0_5123_test.go,
+  pkg/lldp/README.md, _Log.md

--- a/pkg/lldp/README.md
+++ b/pkg/lldp/README.md
@@ -151,7 +151,18 @@ Two properties keep this safe (#2372 review findings 3 + 6):
   is unit-tested (`TestApplyResolvesKernelIfName`, `socket_test.go`)
   without a host device present.
 - TTL countdown is per-neighbor; expired entries auto-purge from the
-  `Neighbors()` snapshot.
+  `Neighbors()` snapshot on the `expiryLoop` 10s tick.
+- **Immediate withdrawal on TTL=0 shutdown (#5123):** IEEE 802.1AB defines
+  a TTL=0 LLDPDU as an explicit shutdown — the receiver must delete the
+  neighbor at once, not age it out. `rxLoop` treats a parsed TTL of 0 as a
+  withdrawal, not an advertisement: it computes the
+  `ifname/chassis/port` key and calls `withdrawNeighbor` (`lldp.go`), which
+  deletes that entry under `mu` and does **not** cache the frame. Without
+  this, a shutdown frame was stored like any other neighbor with
+  `ExpiresAt==now`, so the departed peer stayed in `Neighbors()` until the
+  next ~10s `expiryLoop` tick. A TTL=0 frame for an unknown key is a no-op
+  (no error, no spurious insert). The fix is the immediate delete, not a
+  change to the reap cadence.
 - The neighbor map is RWMutex-guarded. `Neighbors()` returns a copy, not
   a reference, so callers can iterate without holding the lock.
 - `ParseTLVs` counts a mandatory TLV (Chassis ID, Port ID, TTL) as
@@ -161,7 +172,9 @@ Two properties keep this safe (#2372 review findings 3 + 6):
   TTL under 2 bytes) leaves the corresponding flag unset, so the frame is
   rejected rather than cached under an empty `ifname//` key with TTL 0
   (#2551). A valid 2-byte TTL of 0 is a legitimate shutdown advert and is
-  still accepted (the gate is "the TLV parsed", not "TTL != 0").
+  still accepted here (the gate is "the TLV parsed", not "TTL != 0"); the
+  RX path then acts on that parsed TTL=0 by withdrawing the neighbor
+  immediately (see the immediate-withdrawal note above, #5123).
 - **Bounded neighbor table (#4044):** LLDP is unauthenticated L2 — any
   station on the segment can flood frames carrying arbitrary (spoofed)
   chassis-id / port-id pairs, one distinct neighbor entry per distinct

--- a/pkg/lldp/lldp.go
+++ b/pkg/lldp/lldp.go
@@ -554,11 +554,25 @@ func (m *Manager) rxLoop(ctx context.Context, sess *ifSession) {
 		if neighbor == nil {
 			continue
 		}
+
+		key := fmt.Sprintf("%s/%s/%s", iface.Name, neighbor.ChassisID, neighbor.PortID)
+
+		// IEEE 802.1AB shutdown semantics: a TTL=0 LLDPDU is an explicit
+		// withdrawal, not a neighbor advertisement. Remove any existing entry
+		// for this key immediately under the neighbor lock and do NOT cache the
+		// frame. Storing it as an ordinary neighbor (as a non-zero TTL frame is)
+		// would set ExpiresAt==now and leave the departed peer visible in
+		// Neighbors() until the next ~10s expiryLoop tick — a peer that has
+		// announced its departure must disappear now, not up to 10s later
+		// (#5123).
+		if neighbor.TTL == 0 {
+			m.withdrawNeighbor(key)
+			continue
+		}
+
 		neighbor.Interface = iface.Name
 		neighbor.LastSeen = time.Now()
 		neighbor.ExpiresAt = time.Now().Add(time.Duration(neighbor.TTL) * time.Second)
-
-		key := fmt.Sprintf("%s/%s/%s", iface.Name, neighbor.ChassisID, neighbor.PortID)
 		m.learnNeighbor(key, neighbor)
 	}
 }
@@ -616,6 +630,29 @@ func (m *Manager) learnNeighbor(key string, n *Neighbor) bool {
 	}
 	m.neighbors[key] = n
 	return true
+}
+
+// withdrawNeighbor removes the neighbor identified by key, if present. It is the
+// immediate-withdrawal path for a TTL=0 shutdown LLDPDU (IEEE 802.1AB §"the
+// receiving LLDP agent shall delete the associated information"): the neighbor
+// is dropped as soon as the shutdown frame is received rather than lingering
+// until the periodic expiryLoop tick. A TTL=0 frame for a key that is not in the
+// table is a no-op — no error, no spurious insert. It takes the same m.mu the
+// learn and expiry paths use, so the delete is serialized against concurrent
+// refreshes and reaps. A shutdown is a rare per-neighbor event (not per-packet),
+// so the state-transition log mirrors expiryLoop's "expired" line.
+func (m *Manager) withdrawNeighbor(key string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n, ok := m.neighbors[key]
+	if !ok {
+		return
+	}
+	slog.Info("LLDP neighbor withdrawn (TTL=0 shutdown)",
+		"interface", n.Interface,
+		"chassis", n.ChassisID,
+		"port", n.PortID)
+	delete(m.neighbors, key)
 }
 
 // warnNeighborCapDroppedLocked logs (at most once per capDropWarnInterval per

--- a/pkg/lldp/shutdown_ttl0_5123_test.go
+++ b/pkg/lldp/shutdown_ttl0_5123_test.go
@@ -1,0 +1,250 @@
+package lldp
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestRxLoopTTL0WithdrawsNeighborImmediately_5123 is the regression test for
+// #5123. IEEE 802.1AB defines a TTL=0 LLDPDU as an explicit shutdown: the
+// receiver MUST remove the neighbor immediately. Before the fix the RX path
+// stored the shutdown frame as an ordinary neighbor with ExpiresAt==now, so a
+// departed peer stayed visible in Neighbors() until the next ~10s expiryLoop
+// tick.
+//
+// The test drives the real rxLoop through the recvFn seam with a deterministic,
+// synchronous handshake (no sleeps, no ticker wait): frame 1 is a normal
+// (TTL>0) advertisement, frame 2 is that same peer's TTL=0 shutdown. rxLoop
+// only calls recvFn for the next frame after it has fully processed the current
+// one, so blocking inside recvFn lets the test observe each post-processing
+// state exactly once.
+//
+// RED-on-revert: with the production TTL==0 branch removed, frame 2 refreshes
+// the existing key in place (ExpiresAt==now) instead of deleting it, so
+// Neighbors() still reports the peer after the shutdown and the final assertion
+// fails. expiryLoop does not run in this test, so nothing else can mask the
+// lingering entry.
+func TestRxLoopTTL0WithdrawsNeighborImmediately_5123(t *testing.T) {
+	peerMAC := net.HardwareAddr{0x02, 0, 0, 0, 0, 0x42}
+
+	learnFrame, err := BuildFrame(peerMAC, "peer0", 120, "peer-node", "")
+	if err != nil {
+		t.Fatalf("BuildFrame (learn): %v", err)
+	}
+	shutdownFrame, err := BuildFrame(peerMAC, "peer0", 0, "peer-node", "")
+	if err != nil {
+		t.Fatalf("BuildFrame (shutdown): %v", err)
+	}
+
+	var step int32
+	gotFrame1 := make(chan struct{}) // closed once rxLoop asks for frame 2 (frame 1 processed)
+	releaseFrame2 := make(chan struct{})
+	gotFrame2 := make(chan struct{}) // closed once rxLoop asks for frame 3 (frame 2 processed)
+	park := make(chan struct{})
+
+	sess := &ifSession{
+		iface: &net.Interface{Name: "test0", Index: 1},
+		recvFn: func(buf []byte) (int, int, error) {
+			switch atomic.AddInt32(&step, 1) {
+			case 1:
+				return copy(buf, learnFrame), unix.PACKET_HOST, nil
+			case 2:
+				// Reached only after frame 1 was fully processed
+				// (learnNeighbor returned). Signal, then wait for the test to
+				// verify the neighbor is present before delivering the shutdown.
+				close(gotFrame1)
+				<-releaseFrame2
+				return copy(buf, shutdownFrame), unix.PACKET_HOST, nil
+			case 3:
+				// Reached only after the TTL=0 shutdown was fully processed.
+				close(gotFrame2)
+				<-park
+				return 0, 0, unix.EBADF
+			default:
+				<-park
+				return 0, 0, unix.EBADF
+			}
+		},
+	}
+
+	m := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	loopDone := make(chan struct{})
+	go func() {
+		m.rxLoop(ctx, sess)
+		close(loopDone)
+	}()
+
+	// Frame 1 (TTL>0) must learn the neighbor.
+	select {
+	case <-gotFrame1:
+	case <-time.After(2 * time.Second):
+		t.Fatal("rxLoop did not process the learn frame")
+	}
+	if got := len(m.Neighbors()); got != 1 {
+		t.Fatalf("after TTL>0 advert: want 1 neighbor, got %d", got)
+	}
+
+	// Frame 2 (TTL=0) must withdraw it immediately — no ticker wait.
+	close(releaseFrame2)
+	select {
+	case <-gotFrame2:
+	case <-time.After(2 * time.Second):
+		t.Fatal("rxLoop did not process the shutdown frame")
+	}
+	if got := len(m.Neighbors()); got != 0 {
+		t.Fatalf("after TTL=0 shutdown: want 0 neighbors (immediate withdrawal), got %d "+
+			"(neighbor lingered — TTL=0 was cached instead of deleted)", got)
+	}
+
+	cancel()
+	close(park)
+	select {
+	case <-loopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("rxLoop did not exit after ctx cancellation")
+	}
+}
+
+// TestRxLoopTTL0UnknownNeighborNoInsert_5123 asserts a TTL=0 shutdown for a peer
+// that was never learned is a harmless no-op: it must not insert a spurious
+// (already-departed) neighbor into the table.
+//
+// RED-on-revert: without the TTL==0 branch, the shutdown frame is routed through
+// learnNeighbor and inserted as a brand-new neighbor (under the cap), so
+// Neighbors() reports 1 and the assertion fails.
+func TestRxLoopTTL0UnknownNeighborNoInsert_5123(t *testing.T) {
+	shutdownFrame, err := BuildFrame(net.HardwareAddr{0x02, 0, 0, 0, 0, 0x99}, "peer9", 0, "ghost", "")
+	if err != nil {
+		t.Fatalf("BuildFrame (shutdown): %v", err)
+	}
+
+	var step int32
+	gotFrame := make(chan struct{})
+	park := make(chan struct{})
+
+	sess := &ifSession{
+		iface: &net.Interface{Name: "test0", Index: 1},
+		recvFn: func(buf []byte) (int, int, error) {
+			switch atomic.AddInt32(&step, 1) {
+			case 1:
+				return copy(buf, shutdownFrame), unix.PACKET_HOST, nil
+			case 2:
+				close(gotFrame) // frame 1 fully processed
+				<-park
+				return 0, 0, unix.EBADF
+			default:
+				<-park
+				return 0, 0, unix.EBADF
+			}
+		},
+	}
+
+	m := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	loopDone := make(chan struct{})
+	go func() {
+		m.rxLoop(ctx, sess)
+		close(loopDone)
+	}()
+
+	select {
+	case <-gotFrame:
+	case <-time.After(2 * time.Second):
+		t.Fatal("rxLoop did not process the shutdown frame")
+	}
+	if got := len(m.Neighbors()); got != 0 {
+		t.Fatalf("TTL=0 for an unknown peer: want 0 neighbors (no spurious insert), got %d", got)
+	}
+
+	cancel()
+	close(park)
+	select {
+	case <-loopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("rxLoop did not exit after ctx cancellation")
+	}
+}
+
+// TestRxLoopNonZeroTTLStillLearnsAndRefreshes_5123 guards the non-zero TTL path
+// against regression from the #5123 change: a normal advertisement still learns
+// the neighbor, and a later re-advertisement of the same key refreshes it in
+// place (updating the TTL) without growing or dropping the table.
+func TestRxLoopNonZeroTTLStillLearnsAndRefreshes_5123(t *testing.T) {
+	peerMAC := net.HardwareAddr{0x02, 0, 0, 0, 0, 0x07}
+	frame120, err := BuildFrame(peerMAC, "peer7", 120, "peer-node", "")
+	if err != nil {
+		t.Fatalf("BuildFrame (120): %v", err)
+	}
+	frame90, err := BuildFrame(peerMAC, "peer7", 90, "peer-node", "")
+	if err != nil {
+		t.Fatalf("BuildFrame (90): %v", err)
+	}
+
+	var step int32
+	gotFrame1 := make(chan struct{})
+	releaseFrame2 := make(chan struct{})
+	gotFrame2 := make(chan struct{})
+	park := make(chan struct{})
+
+	sess := &ifSession{
+		iface: &net.Interface{Name: "test0", Index: 1},
+		recvFn: func(buf []byte) (int, int, error) {
+			switch atomic.AddInt32(&step, 1) {
+			case 1:
+				return copy(buf, frame120), unix.PACKET_HOST, nil
+			case 2:
+				close(gotFrame1)
+				<-releaseFrame2
+				return copy(buf, frame90), unix.PACKET_HOST, nil
+			case 3:
+				close(gotFrame2)
+				<-park
+				return 0, 0, unix.EBADF
+			default:
+				<-park
+				return 0, 0, unix.EBADF
+			}
+		},
+	}
+
+	m := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	loopDone := make(chan struct{})
+	go func() {
+		m.rxLoop(ctx, sess)
+		close(loopDone)
+	}()
+
+	select {
+	case <-gotFrame1:
+	case <-time.After(2 * time.Second):
+		t.Fatal("rxLoop did not process the first advert")
+	}
+	if got := m.Neighbors(); len(got) != 1 || got[0].TTL != 120 {
+		t.Fatalf("after first advert: want 1 neighbor TTL=120, got %+v", got)
+	}
+
+	close(releaseFrame2)
+	select {
+	case <-gotFrame2:
+	case <-time.After(2 * time.Second):
+		t.Fatal("rxLoop did not process the refresh advert")
+	}
+	if got := m.Neighbors(); len(got) != 1 || got[0].TTL != 90 {
+		t.Fatalf("after refresh: want 1 neighbor TTL=90 (refreshed in place), got %+v", got)
+	}
+
+	cancel()
+	close(park)
+	select {
+	case <-loopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("rxLoop did not exit after ctx cancellation")
+	}
+}


### PR DESCRIPTION
## Problem

IEEE 802.1AB defines a **TTL=0 LLDPDU as an explicit shutdown**: on receipt the LLDP agent must delete the neighbor immediately, not age it out. The RX path did not special-case TTL=0 — it stored the shutdown frame like any other advertisement, setting `ExpiresAt = now + TTL*sec = now`. The only reaper is `expiryLoop`'s **10s ticker**, so a peer that had announced its departure kept showing up in `Neighbors()` (and `show lldp neighbors`) for up to ~10s.

`pkg/lldp/lldp.go`: `rxLoop` → `learnNeighbor` (no TTL==0 case); `expiryLoop` reaps only on `10 * time.Second`.

## IEEE basis

> The receiving LLDP agent treats a received TTL of zero as a signal to delete the associated neighbor information immediately.

## Fix

In `rxLoop`, after computing the `ifname/chassis/port` key, treat a parsed TTL of 0 as a **withdrawal**: call the new `withdrawNeighbor` helper (a locked delete under the same `m.mu` the learn/expiry paths use) and **do NOT cache the frame**. A TTL=0 frame for a key not in the table is a no-op — no error, no spurious insert. The non-zero TTL learn/refresh path is unchanged, and the **10s reap cadence is untouched** — the fix is the immediate delete, not the reap interval.

`ParseTLVs` already accepts a valid 2-byte TTL of 0 (#2551), so no parser change was needed; `rxLoop` now acts on that parsed value.

## Tests (`pkg/lldp/shutdown_ttl0_5123_test.go`)

Drive the real `rxLoop` through the `recvFn` seam with a deterministic **synchronous handshake** (no sleeps, no ticker wait — `rxLoop` calls `recvFn` for the next frame only after fully processing the current one):

- **Immediate withdrawal:** a TTL>0 advert is learned; that peer's TTL=0 shutdown withdraws it **immediately** (`Neighbors()` → 0, no 10s wait).
- **Unknown key:** a TTL=0 for a never-seen key inserts nothing.
- **Refresh preserved:** a non-zero re-advert still refreshes in place (TTL updated).

**RED-on-revert proven:** with the `TTL==0` branch reverted, the two shutdown tests FAIL (neighbor lingers / spurious insert) while the refresh test passes both ways by design. Run under **`go test -race`** since it touches the neighbor map under the lock — full `pkg/lldp` suite green.

## Docs

`pkg/lldp/README.md` neighbor-lifecycle and `ParseTLVs` notes updated to document the immediate-withdrawal behavior.

Closes #5123

🤖 Generated with [Claude Code](https://claude.com/claude-code)