### PR TITLE
pkg/grpcapi,pkg/cli: erase the local config archive on zeroize (#5186)

### DIFF
--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -245,6 +245,34 @@ or strand access:
   UID) is left alone — the current owner is someone else, exactly the #1944
   leave-then-rejoin-vs-recreate distinction.
 
+**Local config-archive erasure (#5186).** The three erasures above cover the
+config SSOT/rollback/journal state, the rendered service configs, and the login
+accounts — but they missed the last on-box generation of config secrets: the
+**local configuration archive** at **`/var/lib/xpf/archive`**. `writeArchive`
+drops timestamped `config-<ts>.<seq>.conf` snapshots there (Junos `system
+archival`), each a **0600 copy of the full committed config TEXT** with the same
+cleartext secret leaves as a rollback slot (IKE PSK, WireGuard private keys, SNMP
+communities, BGP-MD5). A pre-#5186 `zeroize` left the archive untouched, so a
+re-tenanted / RMA'd / resold device still handed the next owner the prior
+tenant's archived secrets — a false factory reset. `zeroize` now erases it at
+wipe time too (`configstore.FactoryResetArchiveDir`, same error-surfacing +
+final-fsync durability discipline as the config-state wipe), and **both** the
+gRPC `performZeroizeWipe` and the on-box CLI `request system zeroize` route
+through that single shared primitive so they wipe the same archive.
+
+- **Ownership guard.** Only the **xpf-owned default** path
+  (`configstore.DefaultArchiveDir` = `/var/lib/xpf/archive`) is erased. An
+  operator-configured **custom** archive directory — a remote mount, an NFS
+  export, or a compliance/audit retention store — is **NOT** xpf's to destroy;
+  blindly deleting it could wipe records the operator is required to keep. Such a
+  path cannot be proven xpf-owned, so it is **skipped with a warning** rather
+  than deleted (never a fail-closed delete). This mirrors how the config-state
+  wipe proves ownership by its fixed default appliance path and how the
+  login-account teardown refuses to touch a non-xpf-owned account.
+- **Error surfacing.** A deletion or final directory-fsync failure is surfaced
+  (folded into the wipe result / returned by the CLI), so a `zeroize` that could
+  not fully erase the archive is never reported as a clean factory reset.
+
 **Privileged-subcommand exception — `monitor traffic` (#4067).** Almost
 every command is gated on the top-level word alone, but `monitor traffic`
 spawns a **root `tcpdump` live packet capture** on a data interface, so it

--- a/pkg/cli/cli_request_system.go
+++ b/pkg/cli/cli_request_system.go
@@ -82,6 +82,18 @@ func (c *CLI) handleRequestSystem(args []string) error {
 			return fmt.Errorf("zeroize: configuration state not fully erased: %w", err)
 		}
 
+		// Erase the local config archive (#5186): /var/lib/xpf/archive holds
+		// 0600 config-<ts>.conf snapshots — full config TEXT with cleartext
+		// secret leaves (PSK/keys/community). The pre-#5186 zeroize left it
+		// behind, so a prior tenant's secrets survived a factory reset.
+		// Ownership-guarded to the xpf-owned default path (a custom, remote, or
+		// compliance archive destination is skipped with a warning, never
+		// blindly deleted). Routes through the same shared configstore primitive
+		// as the gRPC factory-reset path so both wipe exactly the same archive.
+		if err := configstore.FactoryResetArchiveDir(configstore.DefaultArchiveDir); err != nil {
+			return fmt.Errorf("zeroize: config archive not fully erased: %w", err)
+		}
+
 		// Remove BPF pins (no secret material)
 		os.RemoveAll("/sys/fs/bpf/xpf")
 

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -350,6 +350,20 @@ per-path:
   `rbRemove`/`rbSyncDir` seams so a dropped sync fails a test RED. The
   gRPC `zeroizeConfigDir` mirror in `pkg/grpcapi` carries the same
   barriers (its own `zeroizeSyncDir` seam).
+- **`FactoryResetArchiveDir` — local config-archive erasure (#5186).**
+  `zeroize` must remove EVERY on-box generation of config secrets. The
+  config archive (`<archive-dir>/config-*.conf`, 0600 full-config-text
+  with cleartext secret leaves — see the persistence-layout table above)
+  was the omitted generation: a pre-#5186 wipe left `/var/lib/xpf/archive`
+  behind, so a re-tenanted device kept the prior tenant's archived
+  secrets. `FactoryResetArchiveDir` `RemoveAll`s the archive tree and
+  fsyncs the parent (same error-surfacing + durability discipline), and
+  BOTH the on-box CLI `request system zeroize` and the gRPC
+  `performZeroizeWipe` route archive erasure through this one shared
+  primitive. **Ownership guard:** it erases ONLY the xpf-owned default
+  (`DefaultArchiveDir` = `/var/lib/xpf/archive`); a custom / remote /
+  compliance archive destination is not provably xpf-owned, so it is
+  SKIPPED with a warning rather than blindly deleted.
 - **`CommitConfirmed` ordering.** Confirm state is only touched after
   the persist succeeds: on failure the rollback timer is NOT armed and
   an existing pending confirm (timer + rollback target) is left fully

--- a/pkg/configstore/factory_reset.go
+++ b/pkg/configstore/factory_reset.go
@@ -2,10 +2,94 @@ package configstore
 
 import (
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 )
+
+// DefaultArchiveDir is the xpf-owned DEFAULT local config-archive directory —
+// the pkg/config archival compiler default (compiler_system.go) and the
+// pkg/daemon runtime fallback (daemon_apply.go). writeArchive drops timestamped
+// config-<ts>.<seq>.conf snapshots here, each a 0600 copy of the full committed
+// config TEXT with cleartext secret leaves (IKE PSK, WireGuard private keys,
+// SNMP communities, BGP MD5). It is the ONLY archive path a factory reset
+// provably owns and is therefore allowed to erase (see FactoryResetArchiveDir's
+// ownership guard).
+//
+// KEEP IN SYNC with the pkg/config archival compiler default: pkg/config cannot
+// import pkg/configstore (configstore already imports config), so the literal
+// is duplicated rather than shared. If the compiler default ever moves, this
+// must move with it or a zeroize would skip the real archive.
+//
+// It is a var, not a const, so the zeroize tests can repoint the ownership
+// guard at a throwaway tree (mirroring the grpcapi zeroize* path seams).
+// Production code must never mutate it.
+var DefaultArchiveDir = "/var/lib/xpf/archive"
+
+// FactoryResetArchiveDir erases the LOCAL configuration archive as part of a
+// factory reset (#5186) — but ONLY when archiveDir is the xpf-owned default.
+//
+// WHY the wipe must erase it: zeroize must remove EVERY on-box generation of
+// config secrets (the .configdb SSOT + master.key, the numbered text rollback
+// slots, the audit journal, the rendered service configs, and the login
+// accounts are all wiped by the sibling FactoryResetConfigDir /
+// zeroizeRenderedConfigs / zeroizeLoginAccounts). The local config archive was
+// the OMITTED generation: a pre-#5186 zeroize left /var/lib/xpf/archive
+// untouched, so a device handed to the next tenant after a factory reset still
+// carried 0600 full-config-text copies with the prior tenant's cleartext PSKs,
+// keys, and communities.
+//
+// OWNERSHIP GUARD (#5186): erase the archive ONLY when archiveDir is the
+// xpf-owned default (DefaultArchiveDir). An operator-configured CUSTOM archive
+// directory may be a remote mount, an NFS export, or a compliance/audit
+// retention store that is NOT xpf's to destroy — blindly deleting it could wipe
+// records the operator is legally required to keep. Ownership cannot be proven
+// for such a path, so it is SKIPPED with a warning rather than deleted (never
+// fail-closed-delete). This mirrors how the config-state wipe proves ownership
+// by its fixed default appliance path, and how zeroizeLoginAccounts refuses to
+// touch a non-xpf-owned account.
+//
+// Discipline mirrors FactoryResetConfigDir: os.ErrNotExist is never an error
+// (an already-absent archive is the goal); the whole archive tree is
+// RemoveAll'd; the PARENT directory is then fsynced so the removal of the
+// archive directory entry itself is durable before the completing reboot, and
+// that fsync error is PROPAGATED — a fsync failure means the erasure may not be
+// on stable storage, so it must not be reported as a clean zeroize. The
+// durability barrier routes through the rbSyncDir seam so a dropped sync fails
+// a test RED.
+func FactoryResetArchiveDir(archiveDir string) error {
+	// Ownership guard: only the xpf-owned default is provably safe to erase. A
+	// custom/remote/compliance archive destination is skipped with a warning,
+	// never blindly deleted.
+	if filepath.Clean(archiveDir) != DefaultArchiveDir {
+		slog.Warn("zeroize: skipping config archive directory with unproven "+
+			"ownership (not the xpf-owned default); a custom, remote, or "+
+			"compliance archive destination is the operator's to erase, not "+
+			"the factory reset's",
+			"dir", archiveDir, "default", DefaultArchiveDir)
+		return nil
+	}
+
+	var firstErr error
+	fail := func(err error) {
+		if err != nil && !errors.Is(err, os.ErrNotExist) && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	// Erase the whole archive tree — every config-<ts>.<seq>.conf snapshot of
+	// the prior tenant's config text. RemoveAll is nil on an absent dir.
+	fail(os.RemoveAll(archiveDir))
+
+	// fsync the PARENT so the unlink of the archive directory entry itself is
+	// durable before the reboot that completes the factory reset. A sync
+	// failure is propagated — a silently non-durable erasure must never be
+	// reported as a clean zeroize. ErrNotExist (parent absent → nothing was
+	// removed) is excluded by fail().
+	fail(rbSyncDir(filepath.Dir(archiveDir)))
+	return firstErr
+}
 
 // FactoryResetConfigDir securely erases the on-disk configuration STATE under
 // configDir as part of a factory reset (#4858). It is the single shared
@@ -52,7 +136,10 @@ import (
 // Scope: this erases the config-DB SSOT + journal + rollback state under
 // configDir. The RENDERED service configs xpfd writes OUTSIDE configDir
 // (/etc/frr/frr.conf, /etc/swanctl/conf.d, /etc/kea) and provisioned OS login
-// accounts are handled separately by the daemon's RPC factory-reset path.
+// accounts are handled separately by the daemon's RPC factory-reset path; the
+// local config archive (/var/lib/xpf/archive) — another OUTSIDE-configDir
+// generation of config secrets — is erased by the sibling FactoryResetArchiveDir
+// (#5186), which both the CLI and the gRPC wipe also call.
 func FactoryResetConfigDir(configDir, configBase string) error {
 	var firstErr error
 	fail := func(err error) {

--- a/pkg/configstore/factory_reset_archive_5186_test.go
+++ b/pkg/configstore/factory_reset_archive_5186_test.go
@@ -1,0 +1,167 @@
+package configstore
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/fsatomic"
+)
+
+// archiveSecret5186 stands in for any prior-tenant secret that lands in an
+// archived config snapshot: an IKE PSK, a WireGuard private key, an SNMP
+// community. The archive files are 0600 copies of the full committed config
+// TEXT, so they carry these leaves in cleartext.
+const archiveSecret5186 = "MARKER-SECRET-5186-ike-psk"
+
+// useTempArchiveDefault repoints the ownership-guard default at a throwaway
+// tree for the test's lifetime and returns that path. Production code never
+// mutates DefaultArchiveDir; only the zeroize tests do.
+func useTempArchiveDefault(t *testing.T) string {
+	t.Helper()
+	old := DefaultArchiveDir
+	dir := filepath.Join(t.TempDir(), "archive")
+	DefaultArchiveDir = dir
+	t.Cleanup(func() { DefaultArchiveDir = old })
+	return dir
+}
+
+// seedArchiveFile writes a 0600 archive snapshot carrying the marker secret,
+// mirroring writeArchive's config-<ts>.<seq>.conf naming and mode.
+func seedArchiveFile(t *testing.T, archiveDir string) string {
+	t.Helper()
+	if err := os.MkdirAll(archiveDir, 0o700); err != nil {
+		t.Fatalf("mkdir archive dir: %v", err)
+	}
+	path := filepath.Join(archiveDir, "config-20260101-000000.000000000.00000000000000000001.conf")
+	body := "system {\n  ike { psk \"" + archiveSecret5186 + "\"; }\n}\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("seed archive file: %v", err)
+	}
+	return path
+}
+
+// TestFactoryResetArchiveDirErasesSecrets pins the #5186 fix: a factory reset
+// must erase the xpf-owned local config archive. A pre-#5186 zeroize wiped the
+// .configdb SSOT / rollback / rendered configs / login accounts but LEFT
+// /var/lib/xpf/archive, so a re-tenanted device kept the prior tenant's
+// archived cleartext secrets — the omitted on-box generation of config secrets.
+//
+// RED on revert: neutralize the os.RemoveAll(archiveDir) line in
+// FactoryResetArchiveDir and the secret file survives, tripping the assertion
+// below (the pre-#5186 world, where no zeroize step touched the archive).
+func TestFactoryResetArchiveDirErasesSecrets(t *testing.T) {
+	dir := useTempArchiveDefault(t)
+	secretFile := seedArchiveFile(t, dir)
+
+	if err := FactoryResetArchiveDir(dir); err != nil {
+		t.Fatalf("FactoryResetArchiveDir returned error: %v", err)
+	}
+
+	if _, err := os.Stat(secretFile); !os.IsNotExist(err) {
+		t.Errorf("archive secret file still present after zeroize (stat err=%v)", err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("archive directory still present after zeroize (stat err=%v)", err)
+	}
+}
+
+// TestFactoryResetArchiveDirSkipsCustomPath pins the OWNERSHIP GUARD: an
+// operator-configured CUSTOM archive path (a remote mount, NFS export, or a
+// compliance/audit retention store) is NOT xpf's to destroy. It must survive
+// the zeroize untouched, and the skip must be SURFACED as a warning so the
+// operator knows to erase it out-of-band — never a blind fail-closed delete.
+func TestFactoryResetArchiveDirSkipsCustomPath(t *testing.T) {
+	root := t.TempDir()
+	// Default (the guard's allowlisted path) is distinct from the custom dir
+	// the operator pointed archival at.
+	old := DefaultArchiveDir
+	DefaultArchiveDir = filepath.Join(root, "default-archive")
+	t.Cleanup(func() { DefaultArchiveDir = old })
+
+	customDir := filepath.Join(root, "compliance-archive")
+	secretFile := seedArchiveFile(t, customDir)
+
+	buf := captureWarnLogs(t)
+	if err := FactoryResetArchiveDir(customDir); err != nil {
+		t.Fatalf("FactoryResetArchiveDir(custom) returned error: %v", err)
+	}
+
+	// The custom archive and its secret survive.
+	if _, err := os.Stat(secretFile); err != nil {
+		t.Errorf("custom archive secret must survive zeroize, stat err=%v", err)
+	}
+
+	// The skip is surfaced as a warning that names the skipped path.
+	logged := buf.String()
+	if !strings.Contains(logged, "unproven") || !strings.Contains(logged, customDir) {
+		t.Errorf("expected an ownership-guard warning naming the skipped custom dir; got log:\n%s", logged)
+	}
+}
+
+// TestFactoryResetArchiveDirPropagatesSyncError pins durability-error
+// surfacing: a final directory-fsync FAILURE must be returned, not swallowed —
+// a wipe whose unlink never reached stable storage must not be reported as a
+// clean factory reset. Deterministic (seam-injected), so it holds regardless of
+// the test uid.
+//
+// RED on revert: dropping the rbSyncDir(parent) barrier makes
+// FactoryResetArchiveDir return nil here.
+func TestFactoryResetArchiveDirPropagatesSyncError(t *testing.T) {
+	restoreRollbackSeams(t)
+	dir := useTempArchiveDefault(t)
+	seedArchiveFile(t, dir)
+
+	sentinel := errors.New("injected archive dir fsync failure")
+	parent := filepath.Dir(dir)
+	rbSyncDir = func(d string) error {
+		if filepath.Clean(d) == filepath.Clean(parent) {
+			return sentinel
+		}
+		return fsatomic.SyncDir(d)
+	}
+
+	err := FactoryResetArchiveDir(dir)
+	if err == nil {
+		t.Fatalf("FactoryResetArchiveDir must surface a dir-fsync failure, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("returned error = %v, want it to wrap the injected fsync failure", err)
+	}
+}
+
+// TestFactoryResetArchiveDirPropagatesRemoveError pins that a DELETION failure
+// is surfaced, not silently swallowed: with the archive directory made
+// read-only, RemoveAll cannot unlink the snapshot inside it, and that error
+// must be returned so the caller does not report a clean zeroize while a
+// secret-bearing archive file remains.
+func TestFactoryResetArchiveDirPropagatesRemoveError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: a read-only dir does not block unlinks")
+	}
+	dir := useTempArchiveDefault(t)
+	seedArchiveFile(t, dir)
+
+	// Drop write permission on the archive dir so the inner unlink fails EACCES.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod archive dir read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) }) // let t.TempDir cleanup proceed
+
+	err := FactoryResetArchiveDir(dir)
+	if err == nil {
+		t.Fatalf("FactoryResetArchiveDir must surface a deletion failure, got nil")
+	}
+}
+
+// TestFactoryResetArchiveDirAbsentIsClean is the negative control: an absent
+// archive dir (archival was never configured / never wrote a snapshot) is a
+// clean no-op — os.ErrNotExist is the goal, not an error.
+func TestFactoryResetArchiveDirAbsentIsClean(t *testing.T) {
+	dir := useTempArchiveDefault(t) // never created
+	if err := FactoryResetArchiveDir(dir); err != nil {
+		t.Fatalf("FactoryResetArchiveDir on an absent archive returned error: %v", err)
+	}
+}

--- a/pkg/grpcapi/server_diag_zeroize.go
+++ b/pkg/grpcapi/server_diag_zeroize.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/psaab/xpf/pkg/configstore"
 	"github.com/psaab/xpf/pkg/dhcpserver"
 	"github.com/psaab/xpf/pkg/frr"
 	"github.com/psaab/xpf/pkg/fsatomic"
@@ -443,6 +444,19 @@ var performZeroizeWipe = func() error {
 	// marker, #1944) so a non-xpf admin/system/operator account is NEVER touched.
 	// Also security-critical, so fold its first error into the surfaced result.
 	if e := zeroizeLoginAccounts(); e != nil && err == nil {
+		err = e
+	}
+
+	// Local config archive (#5186): /var/lib/xpf/archive holds
+	// config-<ts>.<seq>.conf snapshots — 0600 copies of the full committed
+	// config TEXT WITH cleartext secret leaves (IKE PSK, WireGuard keys, SNMP
+	// communities). It is the last on-box generation of config secrets and a
+	// pre-#5186 zeroize LEFT it behind, so a re-tenanted device kept the prior
+	// tenant's archived secrets. Ownership-guarded (FactoryResetArchiveDir):
+	// erases ONLY the xpf-owned default path, never a custom/remote/compliance
+	// archive destination. Also security-critical, so fold its first error into
+	// the surfaced result.
+	if e := configstore.FactoryResetArchiveDir(configstore.DefaultArchiveDir); e != nil && err == nil {
 		err = e
 	}
 


### PR DESCRIPTION
## Problem

`zeroize` (factory reset) must remove **every on-box generation of config
secrets**. The wipe already erases the `.configdb` SSOT + `master.key`, the
numbered text rollback slots, the audit journal, the rendered service configs
(frr/swanctl/kea), and the provisioned login accounts — but it **never touched
the local configuration archive** at `/var/lib/xpf/archive` (the `system
archival` default, `pkg/daemon/daemon_apply.go` / `pkg/config` compiler
default).

`writeArchive` drops `config-<ts>.<seq>.conf` snapshots there, each a **0600
copy of the full committed config TEXT** with the same cleartext secret leaves
as a rollback slot (IKE PSK, WireGuard private keys, SNMP communities, BGP-MD5).
So a device handed to the next tenant after a factory reset still carried the
**prior tenant's archived secrets** — a false factory reset. The archive was the
omitted generation.

## Invariant

Zeroize must remove every on-box generation of config secrets — active,
rollback, rescue, journal, rendered, **and the local archive**.

## Fix

- Add a shared `configstore.FactoryResetArchiveDir` primitive and call it from
  **BOTH** zeroize orchestrations (they previously did **not** share
  archive-erase code):
  - gRPC `performZeroizeWipe` (`pkg/grpcapi/server_diag_zeroize.go`) — folds the
    first error into the surfaced wipe result.
  - on-box CLI `request system zeroize` (`pkg/cli/cli_request_system.go`) —
    returns an error if the archive is not fully erased.
- **Ownership guard** (destructive-path safety): erase **ONLY** the xpf-owned
  default path (`DefaultArchiveDir = /var/lib/xpf/archive`). An
  operator-configured **custom** archive directory may be a remote mount, NFS
  export, or a compliance/audit retention store that is **NOT xpf's to
  destroy** — blindly deleting it could wipe records the operator is required to
  keep. Such a path cannot be proven xpf-owned, so it is **skipped with a
  warning**, never a fail-closed delete. Mirrors how the config-state wipe
  proves ownership by its fixed default appliance path and how the login-account
  teardown refuses non-xpf-owned accounts.
- **Error surfacing**: a deletion or final directory-fsync failure is surfaced
  (same `os.ErrNotExist`-tolerant + `rbSyncDir`-seam durability discipline as
  `FactoryResetConfigDir`), so a zeroize that could not fully erase the archive
  is never reported as a clean factory reset.

Note: today the archive dir is not operator-overridable (the compiler hardcodes
the default and there is no `archive-dir` schema leaf), so in practice the wipe
always erases the default; the ownership guard is defense-in-depth + future-
proofing exactly as the issue frames it.

## Tests (RED-on-revert proven)

`pkg/configstore/factory_reset_archive_5186_test.go`, secret-bearing 0600
fixture:

- default archive dir → erased;
- **custom** (non-default) path → **survives + warning surfaced** (ownership guard);
- a **deletion failure** (read-only dir) → surfaced;
- a **final-fsync failure** (seam-injected) → surfaced;
- absent archive → clean no-op.

**RED-on-revert**: neutralizing the `os.RemoveAll(archiveDir)` line leaves the
secret file present and fails the erase + deletion-error tests; restored and
re-verified green. `go build ./...`, `go vet` (touched pkgs), and
`go test ./pkg/grpcapi/... ./pkg/cli/... ./pkg/configstore/...` all pass.

## Docs

- `docs/system-login.md`: new "Local config-archive erasure (#5186)" subsection
  alongside the #4576/#4585/#4598 generations.
- `pkg/configstore/README.md`: documents `FactoryResetArchiveDir` + the
  ownership guard.

Closes #5186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LKUuK8wHPd8G47qbg45QN