### PR TITLE
pkg/ddns: resolve bind interface/routing-instance to the kernel device (#5070)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,21 @@
+## 2026-07-10 — ddns: resolve bind interface/routing-instance to kernel device (#5070)
+
+- **Timestamp**: 2026-07-10
+  - **Action**: #5070 fix — `resolveBindConfig` stored the RAW
+    `RoutingInstance` / `DestinationInterface` into `bindDevice` and passed it
+    verbatim to `SO_BINDTODEVICE`, targeting a nonexistent kernel device (VRF
+    master is `vrf-<name>`; Junos `ge-0/0/2.50` is kernel `ge-0-0-2.50`). Now
+    resolve a destination-interface through `config.LinuxIfName` and a
+    routing-instance through `diagcmd.VRFDeviceName` (canonical resolvers, no
+    hand-rolled strings). Added `bindConfig.validateDevice()` (injectable
+    `netlink.LinkByName` seam) called by `newRFC2136Updater` to surface a clear
+    construction-time error when the resolved device is absent. Rewrote the two
+    bug-encoding tests (`VRF-WAN`/`ge-0-0-2` raw pass-through) and added a
+    resolution table (physical/vlan/reth/ri) + the existence-check test.
+    RED-on-revert proven. `_Log`, README updated.
+  - **File(s)**: pkg/ddns/backend_bind.go, pkg/ddns/backend_rfc2136.go,
+    pkg/ddns/backend_bind_test.go, pkg/ddns/README.md, _Log.md
+
 ## 2026-07-10 — upgrade: wire real helper-readiness gate at cutover (#5286)
 
 - **Timestamp**: 2026-07-10

--- a/_Log.md
+++ b/_Log.md
@@ -3,18 +3,29 @@
 - **Timestamp**: 2026-07-10
   - **Action**: #5070 fix — `resolveBindConfig` stored the RAW
     `RoutingInstance` / `DestinationInterface` into `bindDevice` and passed it
-    verbatim to `SO_BINDTODEVICE`, targeting a nonexistent kernel device (VRF
-    master is `vrf-<name>`; Junos `ge-0/0/2.50` is kernel `ge-0-0-2.50`). Now
-    resolve a destination-interface through `config.LinuxIfName` and a
-    routing-instance through `diagcmd.VRFDeviceName` (canonical resolvers, no
-    hand-rolled strings). Added `bindConfig.validateDevice()` (injectable
-    `netlink.LinkByName` seam) called by `newRFC2136Updater` to surface a clear
-    construction-time error when the resolved device is absent. Rewrote the two
-    bug-encoding tests (`VRF-WAN`/`ge-0-0-2` raw pass-through) and added a
-    resolution table (physical/vlan/reth/ri) + the existence-check test.
-    RED-on-revert proven. `_Log`, README updated.
+    verbatim to `SO_BINDTODEVICE`, targeting a nonexistent kernel device. Now
+    resolve a routing-instance through `diagcmd.VRFDeviceName` (→ `vrf-<name>`)
+    and a destination-interface through the committed config's SSOT resolver
+    `config.(*Config).ResolveKernelIfName` — threaded per-reconcile from the
+    daemon (DHCP path via `ReconcileOptions.InterfaceResolver`; Surface A path
+    via the trailing `SurfaceAManager.Reconcile` resolver arg, read by
+    `resolveBackend`/`CheckIPClient`; both managers hold an `ifResolver` field).
+    Review round 2 caught that the first pass used the LEAF `config.LinuxIfName`,
+    which yields FICTITIOUS devices for reth (`reth1`, no bonded device →
+    member `ge-0-0-1`), unit-0 collapse (`ge-0/0/2.0` → `ge-0-0-2`), and
+    unit≠vlan-id (`ge-0/0/2` unit 50 vlan-id 80 → `ge-0-0-2.80`) — the
+    HA-cluster WAN binding is exactly reth-with-VLAN. Added
+    `bindConfig.validateDevice()` (injectable `netlink.LinkByName` seam) called
+    by `newRFC2136Updater` for a clear construction-time error when the resolved
+    device is absent. HTTP client cache key stays raw leaves (#2956 reap
+    consistency); only the bound socket target is resolved. Rewrote the
+    bug-encoding tests; resolution table asserts REAL device names
+    (reth→member, unit-0 collapse, unit≠vlan-id, reth-VLAN→member subif) via a
+    config-backed `ResolveKernelIfName`. RED-on-revert proven. README updated.
   - **File(s)**: pkg/ddns/backend_bind.go, pkg/ddns/backend_rfc2136.go,
-    pkg/ddns/backend_bind_test.go, pkg/ddns/README.md, _Log.md
+    pkg/ddns/backend_http.go, pkg/ddns/manager.go, pkg/ddns/surface_a.go,
+    pkg/ddns/backend_bind_test.go, pkg/daemon/daemon_ddns.go,
+    pkg/daemon/daemon_ddns_surface_a.go, pkg/ddns/README.md, _Log.md
 
 ## 2026-07-10 — upgrade: wire real helper-readiness gate at cutover (#5286)
 

--- a/pkg/daemon/daemon_ddns.go
+++ b/pkg/daemon/daemon_ddns.go
@@ -166,8 +166,16 @@ func (d *Daemon) reconcileDDNSOnce(ctx context.Context) {
 //     when the node is the writer at all (the node-level short-circuit already
 //     ran): such a pool is not HA-owned, so there is no peer to double-write.
 func (d *Daemon) ddnsReconcileOptions(cfg *config.Config) ddns.ReconcileOptions {
-	if d.cluster == nil || cfg == nil {
+	if cfg == nil {
 		return ddns.ReconcileOptions{}
+	}
+	// #5070: thread the SSOT Junos→kernel interface-name resolver so a
+	// destination-interface binding on the RFC 2136 backend resolves to the
+	// local node's real kernel device (reth→member, unit-0 collapse, unit≠vlan-id)
+	// before SO_BINDTODEVICE. Applied in BOTH standalone and cluster modes.
+	base := ddns.ReconcileOptions{InterfaceResolver: cfg.ResolveKernelIfName}
+	if d.cluster == nil {
+		return base
 	}
 	subnetRG := d.buildLeaseSubnetRGMap(cfg)
 	master := d.snapshotRethMasterState()
@@ -215,7 +223,9 @@ func (d *Daemon) ddnsReconcileOptions(cfg *config.Config) ddns.ReconcileOptions 
 		}
 		return master[s.RGOwner]
 	}
-	return ddns.ReconcileOptions{Gate: gate, Resolver: resolver}
+	base.Gate = gate
+	base.Resolver = resolver
+	return base
 }
 
 // leaseSubnetRG pairs a parsed pool subnet (CIDR) with the redundancy group

--- a/pkg/daemon/daemon_ddns_surface_a.go
+++ b/pkg/daemon/daemon_ddns_surface_a.go
@@ -171,7 +171,10 @@ func (d *Daemon) reconcileSurfaceAOnce(ctx context.Context) {
 	if cfg.System.Services != nil && cfg.System.Services.DynamicDNS != nil {
 		catalog = cfg.System.Services.DynamicDNS.Providers
 	}
-	if err := d.surfaceA.mgr.Reconcile(rctx, scopes, observe, gate, catalog); err != nil {
+	// #5070: thread the SSOT Junos→kernel interface-name resolver so a
+	// per-binding destination-interface resolves to the local node's real kernel
+	// device (reth→member, unit-0 collapse, unit≠vlan-id) before SO_BINDTODEVICE.
+	if err := d.surfaceA.mgr.Reconcile(rctx, scopes, observe, gate, catalog, cfg.ResolveKernelIfName); err != nil {
 		slog.Warn("ddns surface-a: reconcile pass had errors (retrying next cycle)", "err", err)
 	}
 }

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -394,25 +394,36 @@ P1b (closes **#2663, #2664, #2665**) builds on the P1a spine:
   TCP-retry exchange). Fail-open at runtime; an invalid source-address falls the
   family back to no-op.
 - **Bind-device kernel-name resolution (#5070, `resolveBindConfig`)** —
-  `SO_BINDTODEVICE` needs the REAL kernel device name, not the Junos config
-  token. A `destination-interface` is a Junos interface name (e.g.
-  `ge-0/0/2.50`, slashes + unit); the daemon renames the kernel device to the
-  slash-substituted form (`ge-0-0-2.50`), so it is resolved through the SAME
-  canonical translator the daemon uses, `config.LinuxIfName`. A
-  `routing-instance` is realized as the kernel VRF master device `vrf-<name>`
-  (pkg/routing), so it is resolved through `diagcmd.VRFDeviceName` — the single
-  source of truth for that prefix (applied exactly once, #2143; a name already
-  typed `vrf-red` is returned unchanged). `routingInst` retains the raw name for
-  informational use only. Before #5070 the raw token went straight to
-  `SO_BINDTODEVICE`, targeting a nonexistent device so every RFC 2136 /
-  HTTP-provider / check-IP exchange over the binding hard-failed at dial. The
-  RFC 2136 constructor now also VALIDATES the resolved device exists via
-  `bindConfig.validateDevice()` (an injectable `netlink.LinkByName` seam),
-  surfacing a clear construction-time error (`bind device %q does not exist`)
-  instead of a cryptic dial failure; a transiently-absent device is retried by
-  the resolve-per-Reconcile loop. The HTTP-provider and checkip paths get the
-  same deterministic resolution (they share `resolveBindConfig`) so their dial
-  error, if any, now names a real-form device.
+  `SO_BINDTODEVICE` needs the EXACT current kernel device name, not the Junos
+  config token. A `destination-interface` is a Junos interface reference (e.g.
+  `reth0.50`, `ge-0/0/2.50`); it is resolved through the daemon's single source
+  of truth for Junos→kernel naming, `config.(*Config).ResolveKernelIfName`
+  (config/types.go), which the daemon threads in from the committed config —
+  NOT the leaf `config.LinuxIfName` (bare slash-substitution). That matters
+  because the leaf primitive produces FICTITIOUS devices for exactly the cases
+  the HA-cluster WAN binding uses: a `reth` resolves to its LOCAL physical
+  member (`reth1` → `ge-0-0-1`, there is no bonded `reth1` kernel device), a
+  unit-`0` ref collapses (`ge-0/0/2.0` → `ge-0-0-2`), and a VLAN unit is named
+  by its VLAN-ID not its unit number (`ge-0/0/2` unit 50 vlan-id 80 →
+  `ge-0-0-2.80`). The resolver is threaded per-reconcile: the DHCP-lease path
+  via `ReconcileOptions.InterfaceResolver`, the Surface A path via the trailing
+  `SurfaceAManager.Reconcile` resolver arg (read by `resolveBackend` /
+  `CheckIPClient`); both are `cfg.ResolveKernelIfName`. A `routing-instance` is
+  realized as the kernel VRF master device `vrf-<name>` (pkg/routing), resolved
+  through `diagcmd.VRFDeviceName` — the single source of truth for that prefix
+  (applied exactly once, #2143; a name already typed `vrf-red` is returned
+  unchanged). `routingInst` retains the raw name for informational use only.
+  Before #5070 the raw token went straight to `SO_BINDTODEVICE`, targeting a
+  nonexistent device so every RFC 2136 / HTTP-provider / check-IP exchange over
+  the binding hard-failed at dial. The RFC 2136 constructor now also VALIDATES
+  the resolved device exists via `bindConfig.validateDevice()` (an injectable
+  `netlink.LinkByName` seam), surfacing a clear construction-time error (`bind
+  device %q does not exist`) instead of a cryptic dial failure; a
+  transiently-absent device is retried by the resolve-per-Reconcile loop. The
+  HTTP-provider and checkip paths get the same deterministic resolution (they
+  share `resolveBindConfig`). The per-binding HTTP client cache key stays the
+  RAW binding leaves (`bindCacheKey`, #2956 reap consistency); only the bound
+  socket's `SO_BINDTODEVICE` target is resolved.
 - **Dual-stack source-bind family gate (#2901, `sourceMatchesDialFamily`)** — the
   dialer's `Control` hook applies the `unix.Bind` source-bind **only when the
   source-address family matches the dial socket's address family** (keyed off the

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -393,6 +393,26 @@ P1b (closes **#2663, #2664, #2665**) builds on the P1a spine:
   `SO_BINDTODEVICE` for the interface/VRF, working for both the UDP-first and
   TCP-retry exchange). Fail-open at runtime; an invalid source-address falls the
   family back to no-op.
+- **Bind-device kernel-name resolution (#5070, `resolveBindConfig`)** —
+  `SO_BINDTODEVICE` needs the REAL kernel device name, not the Junos config
+  token. A `destination-interface` is a Junos interface name (e.g.
+  `ge-0/0/2.50`, slashes + unit); the daemon renames the kernel device to the
+  slash-substituted form (`ge-0-0-2.50`), so it is resolved through the SAME
+  canonical translator the daemon uses, `config.LinuxIfName`. A
+  `routing-instance` is realized as the kernel VRF master device `vrf-<name>`
+  (pkg/routing), so it is resolved through `diagcmd.VRFDeviceName` — the single
+  source of truth for that prefix (applied exactly once, #2143; a name already
+  typed `vrf-red` is returned unchanged). `routingInst` retains the raw name for
+  informational use only. Before #5070 the raw token went straight to
+  `SO_BINDTODEVICE`, targeting a nonexistent device so every RFC 2136 /
+  HTTP-provider / check-IP exchange over the binding hard-failed at dial. The
+  RFC 2136 constructor now also VALIDATES the resolved device exists via
+  `bindConfig.validateDevice()` (an injectable `netlink.LinkByName` seam),
+  surfacing a clear construction-time error (`bind device %q does not exist`)
+  instead of a cryptic dial failure; a transiently-absent device is retried by
+  the resolve-per-Reconcile loop. The HTTP-provider and checkip paths get the
+  same deterministic resolution (they share `resolveBindConfig`) so their dial
+  error, if any, now names a real-form device.
 - **Dual-stack source-bind family gate (#2901, `sourceMatchesDialFamily`)** — the
   dialer's `Control` hook applies the `unix.Bind` source-bind **only when the
   source-address family matches the dial socket's address family** (keyed off the

--- a/pkg/ddns/backend_bind.go
+++ b/pkg/ddns/backend_bind.go
@@ -49,12 +49,49 @@ type bindConfig struct {
 	routingInst string     // routing-instance name (informational / VRF dev)
 }
 
+// An interface-name resolver maps a Junos interface reference (as an operator
+// types it in a destination-interface leaf, e.g. "reth0.50" or "ge-0/0/2") to
+// the ACTUAL kernel device name on the LOCAL node. Production threads the
+// committed config's SSOT resolver, config.(*Config).ResolveKernelIfName, which
+// correctly handles reth→physical-member, unit-0 collapse, unit≠vlan-id, and
+// tunnel/irb/st0 refs (config/types.go). A nil resolver falls back to the leaf
+// slash-substitution (config.LinuxIfName) — used only by callers with no
+// committed config in hand (never the daemon path). See #5070. The type is the
+// bare `func(string) string` throughout so the exported daemon-facing seams
+// (ReconcileOptions.InterfaceResolver, SurfaceAManager.Reconcile) take
+// cfg.ResolveKernelIfName without a named-type conversion.
+
+// firstResolver extracts the single OPTIONAL interface-name resolver from a
+// variadic trailing slot. The bind path threads the resolver as an optional arg
+// so the many existing no-resolver call sites (tests, direct callers) stay
+// valid while the daemon threads cfg.ResolveKernelIfName. A missing or nil
+// entry yields nil (leaf fallback).
+func firstResolver(resolveIf []func(string) string) func(string) string {
+	if len(resolveIf) > 0 {
+		return resolveIf[0]
+	}
+	return nil
+}
+
+// resolveIfKernelName maps a destination-interface Junos ref to its kernel
+// device name via the SSOT resolver, falling back to the leaf
+// slash-substitution when no resolver was threaded in.
+func resolveIfKernelName(resolve func(string) string, ref string) string {
+	if resolve != nil {
+		return resolve(ref)
+	}
+	return config.LinuxIfName(ref)
+}
+
 // resolveBindConfig builds a bindConfig from a DDNS policy's source-binding
 // leaves (#2665). An empty config yields the zero bindConfig (no binding). A
 // non-empty source-address that does not parse is a hard error so the manager
 // falls back to no-op for that family (and counts it) rather than emitting
 // UPDATEs from the wrong source.
-func resolveBindConfig(c *config.DHCPDynamicDNSConfig) (bindConfig, error) {
+//
+// resolve is the committed config's Junos→kernel interface-name resolver
+// (cfg.ResolveKernelIfName); nil ⇒ the leaf slash-substitution fallback.
+func resolveBindConfig(c *config.DHCPDynamicDNSConfig, resolve func(string) string) (bindConfig, error) {
 	if c == nil {
 		return bindConfig{}, nil
 	}
@@ -71,10 +108,14 @@ func resolveBindConfig(c *config.DHCPDynamicDNSConfig) (bindConfig, error) {
 	// destination-interface.
 	//
 	// SO_BINDTODEVICE needs the REAL kernel device name — NOT the Junos config
-	// token (#5070). A destination-interface is a Junos interface name (e.g.
-	// "ge-0/0/2.50", slashes + unit); the daemon renames the kernel device to
-	// the slash-substituted form ("ge-0-0-2.50"), so resolve it through the
-	// SAME canonical translator the daemon uses (config.LinuxIfName). A
+	// token (#5070). A destination-interface is a Junos interface reference
+	// (e.g. "reth0.50", "ge-0/0/2.50"); the daemon renames/creates the kernel
+	// device via config.(*Config).ResolveKernelIfName, which resolves
+	// reth→physical member, unit-0 collapse ("ge-0/0/2.0" → "ge-0-0-2"), and
+	// unit≠vlan-id (unit 50 / vlan-id 80 → "ge-0-0-2.80"). Resolve through that
+	// SSOT (threaded in as `resolve`), NOT the leaf slash-substitution — the
+	// latter yields fictitious devices ("reth0.100", "ge-0-0-2.50") for exactly
+	// the reth / VLAN cases the HA-cluster WAN binding targets. A
 	// routing-instance is realized as a kernel VRF master device named
 	// "vrf-<name>" (pkg/routing), so resolve it through diagcmd.VRFDeviceName —
 	// the single source of truth for that prefix (applied exactly once, #2143;
@@ -87,7 +128,7 @@ func resolveBindConfig(c *config.DHCPDynamicDNSConfig) (bindConfig, error) {
 	b.routingInst = c.RoutingInstance
 	switch {
 	case c.DestinationInterface != "":
-		b.bindDevice = config.LinuxIfName(c.DestinationInterface)
+		b.bindDevice = resolveIfKernelName(resolve, c.DestinationInterface)
 	case c.RoutingInstance != "":
 		b.bindDevice = diagcmd.VRFDeviceName(c.RoutingInstance)
 	}

--- a/pkg/ddns/backend_bind.go
+++ b/pkg/ddns/backend_bind.go
@@ -8,9 +8,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/diagcmd"
 )
 
 // backend_bind.go: source / interface / VRF binding for the RFC 2136 UPDATE
@@ -65,16 +67,57 @@ func resolveBindConfig(c *config.DHCPDynamicDNSConfig) (bindConfig, error) {
 		b.sourceAddr = a.Unmap()
 	}
 	// destination-interface is the more specific SO_BINDTODEVICE pin; a VRF
-	// (routing-instance) binds to its VRF master device, which shares the
-	// routing-instance name. Prefer the explicit destination-interface.
+	// (routing-instance) binds to its VRF master device. Prefer the explicit
+	// destination-interface.
+	//
+	// SO_BINDTODEVICE needs the REAL kernel device name — NOT the Junos config
+	// token (#5070). A destination-interface is a Junos interface name (e.g.
+	// "ge-0/0/2.50", slashes + unit); the daemon renames the kernel device to
+	// the slash-substituted form ("ge-0-0-2.50"), so resolve it through the
+	// SAME canonical translator the daemon uses (config.LinuxIfName). A
+	// routing-instance is realized as a kernel VRF master device named
+	// "vrf-<name>" (pkg/routing), so resolve it through diagcmd.VRFDeviceName —
+	// the single source of truth for that prefix (applied exactly once, #2143;
+	// a name already typed "vrf-red" is returned unchanged). Without this
+	// mapping SO_BINDTODEVICE targets a nonexistent device and every RFC 2136 /
+	// HTTP-provider / check-IP exchange hard-fails at dial.
+	//
+	// routingInst keeps the RAW routing-instance name (informational only; it
+	// is never used for the socket op — only bindDevice is).
 	b.routingInst = c.RoutingInstance
 	switch {
 	case c.DestinationInterface != "":
-		b.bindDevice = c.DestinationInterface
+		b.bindDevice = config.LinuxIfName(c.DestinationInterface)
 	case c.RoutingInstance != "":
-		b.bindDevice = c.RoutingInstance
+		b.bindDevice = diagcmd.VRFDeviceName(c.RoutingInstance)
 	}
 	return b, nil
+}
+
+// bindDeviceLinkByName is the netlink lookup used to validate that a resolved
+// SO_BINDTODEVICE target exists as a kernel device at backend construction
+// (#5070). It is a package var so tests can inject a fake without touching real
+// netlink; production uses the real netlink.LinkByName.
+var bindDeviceLinkByName = func(name string) error {
+	_, err := netlink.LinkByName(name)
+	return err
+}
+
+// validateDevice checks that the resolved bindDevice exists as a kernel device,
+// surfacing a CLEAR construction-time error instead of a cryptic
+// SO_BINDTODEVICE dial failure later (#5070). A bindConfig with no device
+// (source-address-only, or no binding at all) validates trivially. The netlink
+// lookup goes through the bindDeviceLinkByName seam so a transiently-absent
+// device (e.g. the WAN link not yet up at boot) simply fails this construction
+// pass and is retried by the reconciler's resolve-per-Reconcile loop.
+func (b bindConfig) validateDevice() error {
+	if b.bindDevice == "" {
+		return nil
+	}
+	if err := bindDeviceLinkByName(b.bindDevice); err != nil {
+		return fmt.Errorf("ddns: bind device %q does not exist: %w", b.bindDevice, err)
+	}
+	return nil
 }
 
 // isSet reports whether the bindConfig requests any binding.

--- a/pkg/ddns/backend_bind_test.go
+++ b/pkg/ddns/backend_bind_test.go
@@ -2,8 +2,10 @@ package ddns
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"net/netip"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -58,31 +60,110 @@ func TestResolveBindConfigInvalidSourceAddressRejected(t *testing.T) {
 
 func TestResolveBindConfigDestInterfaceWinsOverVRF(t *testing.T) {
 	// destination-interface is the more specific SO_BINDTODEVICE pin; when both
-	// it and a routing-instance are set, the destination-interface wins.
+	// it and a routing-instance are set, the destination-interface wins — and it
+	// resolves from Junos form ("ge-0/0/2") to the kernel device ("ge-0-0-2")
+	// via the daemon's canonical translator so SO_BINDTODEVICE targets a real
+	// device (#5070).
 	b, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{
-		DestinationInterface: "ge-0-0-2",
-		RoutingInstance:      "VRF-WAN",
+		DestinationInterface: "ge-0/0/2",
+		RoutingInstance:      "WAN",
 	})
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
 	if b.bindDevice != "ge-0-0-2" {
-		t.Fatalf("destination-interface must win for SO_BINDTODEVICE, got %q", b.bindDevice)
+		t.Fatalf("destination-interface must resolve to the kernel device for SO_BINDTODEVICE, got %q", b.bindDevice)
 	}
-	if b.routingInst != "VRF-WAN" {
-		t.Fatalf("routing-instance must be recorded, got %q", b.routingInst)
+	// routingInst keeps the RAW routing-instance name (informational only).
+	if b.routingInst != "WAN" {
+		t.Fatalf("routing-instance must be recorded (raw, informational), got %q", b.routingInst)
 	}
 }
 
 func TestResolveBindConfigVRFOnlyBindsVRFDevice(t *testing.T) {
-	b, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{RoutingInstance: "VRF-WAN"})
+	b, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{RoutingInstance: "WAN"})
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
-	// A VRF binds to its VRF master device, which shares the routing-instance
-	// name (Linux's VRF socket-binding model).
-	if b.bindDevice != "VRF-WAN" {
-		t.Fatalf("a VRF-only config must bind to the VRF device, got %q", b.bindDevice)
+	// A routing-instance binds to its kernel VRF master device "vrf-<name>"
+	// (pkg/routing), NOT the raw routing-instance name (#5070).
+	if b.bindDevice != "vrf-WAN" {
+		t.Fatalf("a VRF-only config must bind to the vrf-<name> device, got %q", b.bindDevice)
+	}
+}
+
+// TestResolveBindConfigResolvesKernelDevices is the #5070 fix-direction table:
+// a committed Junos interface / routing-instance reference MUST resolve to the
+// EXACT current kernel device name SO_BINDTODEVICE needs, across physical units,
+// VLAN units, reth, and RI-only bindings. Before the fix bindDevice held the raw
+// Junos token and the dial hard-failed on a nonexistent device.
+func TestResolveBindConfigResolvesKernelDevices(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  config.DHCPDynamicDNSConfig
+		want string
+	}{
+		{"physical-unit", config.DHCPDynamicDNSConfig{DestinationInterface: "ge-0/0/2"}, "ge-0-0-2"},
+		{"vlan-unit", config.DHCPDynamicDNSConfig{DestinationInterface: "ge-0/0/2.50"}, "ge-0-0-2.50"},
+		{"reth", config.DHCPDynamicDNSConfig{DestinationInterface: "reth1"}, "reth1"},
+		{"reth-vlan-unit", config.DHCPDynamicDNSConfig{DestinationInterface: "reth0.100"}, "reth0.100"},
+		{"ri-only", config.DHCPDynamicDNSConfig{RoutingInstance: "WAN"}, "vrf-WAN"},
+		{"ri-already-prefixed", config.DHCPDynamicDNSConfig{RoutingInstance: "vrf-red"}, "vrf-red"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := tc.cfg
+			b, err := resolveBindConfig(&cfg)
+			if err != nil {
+				t.Fatalf("resolve: %v", err)
+			}
+			if b.bindDevice != tc.want {
+				t.Fatalf("bindDevice = %q, want %q", b.bindDevice, tc.want)
+			}
+		})
+	}
+}
+
+// TestNewRFC2136UpdaterValidatesBindDeviceExists proves the #5070
+// construction-time existence check: a resolved bind device that netlink cannot
+// find fails backend construction with a CLEAR error (naming the resolved
+// kernel device) instead of a cryptic SO_BINDTODEVICE dial failure later. Uses
+// the injectable netlink seam so the test needs no real interface.
+func TestNewRFC2136UpdaterValidatesBindDeviceExists(t *testing.T) {
+	pol := policyFromConfig(&config.DHCPDynamicDNSConfig{
+		Enabled: true, Domain: "example.com", UpdateServer: "192.0.2.53:53",
+	})
+
+	// Seam: pretend only the resolved kernel device "ge-0-0-2" exists.
+	orig := bindDeviceLinkByName
+	t.Cleanup(func() { bindDeviceLinkByName = orig })
+	bindDeviceLinkByName = func(name string) error {
+		if name == "ge-0-0-2" {
+			return nil
+		}
+		return fmt.Errorf("Link not found")
+	}
+
+	// Present device (Junos "ge-0/0/2" → kernel "ge-0-0-2") → constructs.
+	ok := &config.DHCPDynamicDNSConfig{
+		Enabled: true, Domain: "example.com", UpdateServer: "192.0.2.53:53",
+		DestinationInterface: "ge-0/0/2",
+	}
+	if _, err := newRFC2136Updater(pol, ok, nil, nil, nil); err != nil {
+		t.Fatalf("a present bind device must construct, got %v", err)
+	}
+
+	// Absent device → clear construction error that names the kernel device.
+	bad := &config.DHCPDynamicDNSConfig{
+		Enabled: true, Domain: "example.com", UpdateServer: "192.0.2.53:53",
+		DestinationInterface: "ge-0/0/9",
+	}
+	_, err := newRFC2136Updater(pol, bad, nil, nil, nil)
+	if err == nil {
+		t.Fatal("an absent bind device must fail newRFC2136Updater")
+	}
+	if !strings.Contains(err.Error(), "ge-0-0-9") {
+		t.Fatalf("construction error must name the resolved kernel device, got %v", err)
 	}
 }
 

--- a/pkg/ddns/backend_bind_test.go
+++ b/pkg/ddns/backend_bind_test.go
@@ -24,7 +24,7 @@ import (
 // rfc2136 backend installs the custom dialer.
 
 func TestResolveBindConfigEmptyIsNoBinding(t *testing.T) {
-	b, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{})
+	b, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{}, nil)
 	if err != nil {
 		t.Fatalf("empty config: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestResolveBindConfigEmptyIsNoBinding(t *testing.T) {
 }
 
 func TestResolveBindConfigSourceAddress(t *testing.T) {
-	b, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{SourceAddress: "10.0.0.9"})
+	b, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{SourceAddress: "10.0.0.9"}, nil)
 	if err != nil {
 		t.Fatalf("source-address: %v", err)
 	}
@@ -53,21 +53,51 @@ func TestResolveBindConfigSourceAddress(t *testing.T) {
 }
 
 func TestResolveBindConfigInvalidSourceAddressRejected(t *testing.T) {
-	if _, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{SourceAddress: "not-an-ip"}); err == nil {
+	if _, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{SourceAddress: "not-an-ip"}, nil); err == nil {
 		t.Fatal("an invalid source-address must be rejected (the manager then falls back to no-op + counts it)")
 	}
+}
+
+// bindTestConfig builds a committed *config.Config that exercises the SSOT
+// interface-name resolver (config.ResolveKernelIfName) for the #5070 cases the
+// leaf slash-substitution gets WRONG:
+//
+//   - ge-0/0/2 has unit 0 (unit-0 collapse) and unit 50 with vlan-id 80
+//     (unit#≠vlan-id: the kernel subif is named by the VLAN ID, not the unit).
+//   - reth1's local physical member is ge-0/0/1 (there is no bonded "reth1"
+//     kernel device — SO_BINDTODEVICE must target the member).
+//   - reth0's local physical member is ge-0/0/3, and reth0 unit 100 carries
+//     vlan-id 100, so reth0.100 → the member's VLAN subif ge-0-0-3.100.
+//
+// NodeID 0 makes the slot-0 members the LOCAL-node members (RethToPhysical).
+func bindTestConfig() *config.Config {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0/0/2": {Name: "ge-0/0/2", Units: map[int]*config.InterfaceUnit{
+			0:  {Number: 0},
+			50: {Number: 50, VlanID: 80},
+		}},
+		"ge-0/0/1": {Name: "ge-0/0/1", RedundantParent: "reth1"},
+		"ge-0/0/3": {Name: "ge-0/0/3", RedundantParent: "reth0"},
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{
+			100: {Number: 100, VlanID: 100},
+		}},
+	}
+	cfg.Chassis.Cluster = &config.ClusterConfig{NodeID: 0}
+	return cfg
 }
 
 func TestResolveBindConfigDestInterfaceWinsOverVRF(t *testing.T) {
 	// destination-interface is the more specific SO_BINDTODEVICE pin; when both
 	// it and a routing-instance are set, the destination-interface wins — and it
-	// resolves from Junos form ("ge-0/0/2") to the kernel device ("ge-0-0-2")
-	// via the daemon's canonical translator so SO_BINDTODEVICE targets a real
+	// resolves from Junos form ("ge-0/0/2") to the real kernel device ("ge-0-0-2")
+	// via the committed config's SSOT resolver so SO_BINDTODEVICE targets a real
 	// device (#5070).
+	resolve := bindTestConfig().ResolveKernelIfName
 	b, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{
 		DestinationInterface: "ge-0/0/2",
 		RoutingInstance:      "WAN",
-	})
+	}, resolve)
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
@@ -81,7 +111,7 @@ func TestResolveBindConfigDestInterfaceWinsOverVRF(t *testing.T) {
 }
 
 func TestResolveBindConfigVRFOnlyBindsVRFDevice(t *testing.T) {
-	b, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{RoutingInstance: "WAN"})
+	b, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{RoutingInstance: "WAN"}, bindTestConfig().ResolveKernelIfName)
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
@@ -94,26 +124,37 @@ func TestResolveBindConfigVRFOnlyBindsVRFDevice(t *testing.T) {
 
 // TestResolveBindConfigResolvesKernelDevices is the #5070 fix-direction table:
 // a committed Junos interface / routing-instance reference MUST resolve to the
-// EXACT current kernel device name SO_BINDTODEVICE needs, across physical units,
-// VLAN units, reth, and RI-only bindings. Before the fix bindDevice held the raw
+// EXACT current kernel device name SO_BINDTODEVICE needs, via the committed
+// config's SSOT resolver — NOT the leaf slash-substitution, which produces
+// nonexistent devices for reth / VLAN-unit / unit-0 cases (the HA-cluster WAN
+// binding is exactly reth-with-VLAN). Before the fix bindDevice held the raw
 // Junos token and the dial hard-failed on a nonexistent device.
 func TestResolveBindConfigResolvesKernelDevices(t *testing.T) {
+	resolve := bindTestConfig().ResolveKernelIfName
 	cases := []struct {
 		name string
 		cfg  config.DHCPDynamicDNSConfig
 		want string
 	}{
-		{"physical-unit", config.DHCPDynamicDNSConfig{DestinationInterface: "ge-0/0/2"}, "ge-0-0-2"},
-		{"vlan-unit", config.DHCPDynamicDNSConfig{DestinationInterface: "ge-0/0/2.50"}, "ge-0-0-2.50"},
-		{"reth", config.DHCPDynamicDNSConfig{DestinationInterface: "reth1"}, "reth1"},
-		{"reth-vlan-unit", config.DHCPDynamicDNSConfig{DestinationInterface: "reth0.100"}, "reth0.100"},
+		// bare physical → slash-substituted.
+		{"physical", config.DHCPDynamicDNSConfig{DestinationInterface: "ge-0/0/2"}, "ge-0-0-2"},
+		// unit-0 collapse: ".0" is stripped (kernel has no ".0" subif).
+		{"unit-0-collapse", config.DHCPDynamicDNSConfig{DestinationInterface: "ge-0/0/2.0"}, "ge-0-0-2"},
+		// unit# ≠ vlan-id: unit 50 carries vlan-id 80, kernel subif is ".80".
+		{"unit-neq-vlanid", config.DHCPDynamicDNSConfig{DestinationInterface: "ge-0/0/2.50"}, "ge-0-0-2.80"},
+		// reth → its LOCAL physical member (no bonded "reth1" kernel device).
+		{"reth", config.DHCPDynamicDNSConfig{DestinationInterface: "reth1"}, "ge-0-0-1"},
+		// reth VLAN unit → member's VLAN subif (reth0 member ge-0/0/3, vlan-id 100).
+		{"reth-vlan-unit", config.DHCPDynamicDNSConfig{DestinationInterface: "reth0.100"}, "ge-0-0-3.100"},
+		// RI-only → vrf-<name> master (no resolver needed for this half).
 		{"ri-only", config.DHCPDynamicDNSConfig{RoutingInstance: "WAN"}, "vrf-WAN"},
+		// already vrf-prefixed → unchanged (prefix applied once, #2143).
 		{"ri-already-prefixed", config.DHCPDynamicDNSConfig{RoutingInstance: "vrf-red"}, "vrf-red"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := tc.cfg
-			b, err := resolveBindConfig(&cfg)
+			b, err := resolveBindConfig(&cfg, resolve)
 			if err != nil {
 				t.Fatalf("resolve: %v", err)
 			}
@@ -127,42 +168,45 @@ func TestResolveBindConfigResolvesKernelDevices(t *testing.T) {
 // TestNewRFC2136UpdaterValidatesBindDeviceExists proves the #5070
 // construction-time existence check: a resolved bind device that netlink cannot
 // find fails backend construction with a CLEAR error (naming the resolved
-// kernel device) instead of a cryptic SO_BINDTODEVICE dial failure later. Uses
-// the injectable netlink seam so the test needs no real interface.
+// kernel device) instead of a cryptic SO_BINDTODEVICE dial failure later. It
+// threads the SSOT resolver so a reth binding resolves to its physical member,
+// and uses the injectable netlink seam so the test needs no real interface.
 func TestNewRFC2136UpdaterValidatesBindDeviceExists(t *testing.T) {
 	pol := policyFromConfig(&config.DHCPDynamicDNSConfig{
 		Enabled: true, Domain: "example.com", UpdateServer: "192.0.2.53:53",
 	})
+	resolve := bindTestConfig().ResolveKernelIfName
 
-	// Seam: pretend only the resolved kernel device "ge-0-0-2" exists.
+	// Seam: pretend only the reth1 physical member "ge-0-0-1" exists.
 	orig := bindDeviceLinkByName
 	t.Cleanup(func() { bindDeviceLinkByName = orig })
 	bindDeviceLinkByName = func(name string) error {
-		if name == "ge-0-0-2" {
+		if name == "ge-0-0-1" {
 			return nil
 		}
 		return fmt.Errorf("Link not found")
 	}
 
-	// Present device (Junos "ge-0/0/2" → kernel "ge-0-0-2") → constructs.
+	// Present device: reth1 → member "ge-0-0-1" (resolved) → constructs.
 	ok := &config.DHCPDynamicDNSConfig{
 		Enabled: true, Domain: "example.com", UpdateServer: "192.0.2.53:53",
-		DestinationInterface: "ge-0/0/2",
+		DestinationInterface: "reth1",
 	}
-	if _, err := newRFC2136Updater(pol, ok, nil, nil, nil); err != nil {
+	if _, err := newRFC2136Updater(pol, ok, nil, nil, nil, resolve); err != nil {
 		t.Fatalf("a present bind device must construct, got %v", err)
 	}
 
-	// Absent device → clear construction error that names the kernel device.
+	// Absent device: ge-0/0/2 → "ge-0-0-2" (not in the seam) → clear error
+	// naming the resolved kernel device.
 	bad := &config.DHCPDynamicDNSConfig{
 		Enabled: true, Domain: "example.com", UpdateServer: "192.0.2.53:53",
-		DestinationInterface: "ge-0/0/9",
+		DestinationInterface: "ge-0/0/2",
 	}
-	_, err := newRFC2136Updater(pol, bad, nil, nil, nil)
+	_, err := newRFC2136Updater(pol, bad, nil, nil, nil, resolve)
 	if err == nil {
 		t.Fatal("an absent bind device must fail newRFC2136Updater")
 	}
-	if !strings.Contains(err.Error(), "ge-0-0-9") {
+	if !strings.Contains(err.Error(), "ge-0-0-2") {
 		t.Fatalf("construction error must name the resolved kernel device, got %v", err)
 	}
 }
@@ -286,7 +330,7 @@ var _ syscall.RawConn = rawConnFD(0)
 // test RED.
 func TestDialerSourceBindFamilyGate(t *testing.T) {
 	// A loopback source binds without needing the address assigned to an iface.
-	b4, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{SourceAddress: "127.0.0.1"})
+	b4, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{SourceAddress: "127.0.0.1"}, nil)
 	if err != nil {
 		t.Fatalf("resolve v4: %v", err)
 	}
@@ -309,7 +353,7 @@ func TestDialerSourceBindFamilyGate(t *testing.T) {
 		t.Fatalf("v4 source on tcp6 must not error, got %v", err)
 	}
 
-	b6, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{SourceAddress: "::1"})
+	b6, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{SourceAddress: "::1"}, nil)
 	if err != nil {
 		t.Fatalf("resolve v6: %v", err)
 	}

--- a/pkg/ddns/backend_http.go
+++ b/pkg/ddns/backend_http.go
@@ -195,8 +195,13 @@ func bindCacheKey(p *config.DDNSProvider) string {
 // every caller MUST fail CLOSED on it (skip the publish / probe) rather than
 // egress from that unbound client: the publish resolver (resolveSurfaceABackend,
 // #4437) and the checkip observer (CheckIPBound, #3733) both do.
-func (c *httpClientCache) clientFor(p *config.DDNSProvider) (*http.Client, error) {
-	b, err := resolveProviderBindConfig(p)
+// resolveIf is the OPTIONAL committed-config interface-name resolver
+// (cfg.ResolveKernelIfName) threaded from the daemon so a destination-interface
+// binding resolves to the real kernel device (#5070). The cache KEY stays the
+// raw binding leaves (bindCacheKey) so the #2956 reap stays consistent; only the
+// bound client's SO_BINDTODEVICE target is resolved.
+func (c *httpClientCache) clientFor(p *config.DDNSProvider, resolveIf ...func(string) string) (*http.Client, error) {
+	b, err := resolveProviderBindConfig(p, firstResolver(resolveIf))
 	if err != nil {
 		return newHTTPClient(), err
 	}
@@ -255,7 +260,7 @@ func (c *httpClientCache) size() int {
 // resolveBindConfig discipline so an invalid source-address is a hard error
 // (fail-open: the constructor degrades to the unbound default rather than
 // emitting from the wrong source — see the callers).
-func resolveProviderBindConfig(p *config.DDNSProvider) (bindConfig, error) {
+func resolveProviderBindConfig(p *config.DDNSProvider, resolve func(string) string) (bindConfig, error) {
 	if p == nil {
 		return bindConfig{}, nil
 	}
@@ -263,7 +268,7 @@ func resolveProviderBindConfig(p *config.DDNSProvider) (bindConfig, error) {
 		SourceAddress:        p.SourceAddress,
 		DestinationInterface: p.DestinationInterface,
 		RoutingInstance:      p.RoutingInstance,
-	})
+	}, resolve)
 }
 
 // newProviderHTTPClient builds a bound HTTP client for an HTTP backend from its
@@ -272,8 +277,8 @@ func resolveProviderBindConfig(p *config.DDNSProvider) (bindConfig, error) {
 // warning) rather than wedging the backend — matching the rfc2136 fail-open
 // posture. Returns the client and any bind-resolution error for the caller to
 // surface; on error the returned client is the unbound default.
-func newProviderHTTPClient(p *config.DDNSProvider) (*http.Client, error) {
-	b, err := resolveProviderBindConfig(p)
+func newProviderHTTPClient(p *config.DDNSProvider, resolveIf ...func(string) string) (*http.Client, error) {
+	b, err := resolveProviderBindConfig(p, firstResolver(resolveIf))
 	if err != nil {
 		return newHTTPClient(), err
 	}

--- a/pkg/ddns/backend_rfc2136.go
+++ b/pkg/ddns/backend_rfc2136.go
@@ -220,7 +220,13 @@ func normalizeUpdateServer(s string) (string, error) {
 // seam means a real *dns.Client is used. Returns an error when the policy
 // is structurally unusable (no update-server / bad TSIG) so the caller can
 // fall back to a no-op and count it rather than emit broken UPDATEs.
-func newRFC2136Updater(pol ddnsPolicy, c *config.DHCPDynamicDNSConfig, client dnsExchanger, onPTRNotAuth, onConflict func()) (*rfc2136Updater, error) {
+//
+// resolveIf is the OPTIONAL committed-config Junos→kernel interface-name
+// resolver (cfg.ResolveKernelIfName) threaded from the daemon so a
+// destination-interface binding resolves to the real kernel device before
+// SO_BINDTODEVICE (#5070). Omitted / nil ⇒ the leaf slash-substitution fallback
+// (direct + test callers with no committed config).
+func newRFC2136Updater(pol ddnsPolicy, c *config.DHCPDynamicDNSConfig, client dnsExchanger, onPTRNotAuth, onConflict func(), resolveIf ...func(string) string) (*rfc2136Updater, error) {
 	if c == nil {
 		return nil, errors.New("ddns: nil config for rfc2136 backend")
 	}
@@ -250,7 +256,7 @@ func newRFC2136Updater(pol ddnsPolicy, c *config.DHCPDynamicDNSConfig, client dn
 	// invalid source-address is a hard error (the caller falls back to no-op +
 	// counts it) so a misconfigured bind never emits UPDATEs from the wrong
 	// source.
-	bind, err := resolveBindConfig(c)
+	bind, err := resolveBindConfig(c, firstResolver(resolveIf))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ddns/backend_rfc2136.go
+++ b/pkg/ddns/backend_rfc2136.go
@@ -254,6 +254,12 @@ func newRFC2136Updater(pol ddnsPolicy, c *config.DHCPDynamicDNSConfig, client dn
 	if err != nil {
 		return nil, err
 	}
+	// #5070: fail construction with a clear error when the resolved bind device
+	// (kernel interface or vrf-<name> master) does not exist, rather than
+	// leaking a cryptic SO_BINDTODEVICE failure into every UPDATE dial later.
+	if err := bind.validateDevice(); err != nil {
+		return nil, err
+	}
 	if u.client == nil {
 		cl := &dns.Client{
 			Timeout:    u.timeout,

--- a/pkg/ddns/manager.go
+++ b/pkg/ddns/manager.go
@@ -177,6 +177,12 @@ type ReconcileOptions struct {
 	// Resolver attributes each lease to its owning scope (RG etc., #2664). Nil
 	// ⇒ leases get the zero scope for their family (standalone Surface B).
 	Resolver ScopeResolver
+	// InterfaceResolver maps a destination-interface Junos ref to the LOCAL
+	// node's kernel device name for SO_BINDTODEVICE (#5070). The daemon passes
+	// cfg.ResolveKernelIfName (the SSOT resolver). Nil ⇒ the leaf
+	// slash-substitution fallback (a routing-instance still resolves to its
+	// vrf-<name> master via diagcmd.VRFDeviceName regardless).
+	InterfaceResolver func(ref string) string
 }
 
 // policyFromConfig resolves a typed config block into a runtime policy,
@@ -296,6 +302,15 @@ type Manager struct {
 	// (nopUpdater) and enabled (rfc2136Updater) states so enabled→disabled
 	// still runs withdrawAllLocked through a live backend (plan §4.2).
 	newUpdater func(pol ddnsPolicy, c *config.DHCPDynamicDNSConfig) (DNSUpdater, error)
+
+	// ifResolver maps a destination-interface Junos ref to the LOCAL node's
+	// kernel device name for SO_BINDTODEVICE (#5070). It is refreshed at the
+	// START of each ReconcileScoped from ReconcileOptions.InterfaceResolver (the
+	// daemon threads cfg.ResolveKernelIfName), so a topology/commit change takes
+	// effect next cycle. Read by the production newUpdater closure under m.mu
+	// (set and read in the same locked pass). Nil ⇒ the leaf slash-substitution
+	// fallback (standalone tests with no committed config).
+	ifResolver func(string) string
 
 	// nodeID is the deterministic-owner-id seed (plan §5 invariant 2):
 	// the owner watermark is derived from the lease identity so EITHER HA
@@ -462,7 +477,8 @@ func NewProductionManager(parser LeaseParser, nodeID string) *Manager {
 		}
 		return newRFC2136Updater(pol, c, nil,
 			func() { m.skippedPTRNotAuth.Add(1) },
-			func() { m.skippedConflict.Add(1) })
+			func() { m.skippedConflict.Add(1) },
+			m.ifResolver) // #5070: resolve dest-interface to the kernel device
 	}
 	return m
 }
@@ -645,6 +661,12 @@ func (m *Manager) ReconcileScoped(ctx context.Context, cfg *config.DHCPServerCon
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	// #5070: refresh the interface-name resolver for THIS pass so a
+	// destination-interface binding resolves to the local node's real kernel
+	// device before SO_BINDTODEVICE (read by the production newUpdater closure,
+	// under this same lock). Nil (standalone tests) ⇒ the leaf fallback.
+	m.ifResolver = opts.InterfaceResolver
 
 	// FAIL CLOSED (#2650): the ownership state could not be loaded, so we cannot
 	// prove what records this firewall owns. Doing ANYTHING here is unsafe — a

--- a/pkg/ddns/surface_a.go
+++ b/pkg/ddns/surface_a.go
@@ -386,6 +386,14 @@ type SurfaceAManager struct {
 	// pool and dropping the entry — so the map stays bounded under binding churn.
 	httpClients *httpClientCache
 
+	// ifResolver maps a destination-interface Junos ref to the LOCAL node's
+	// kernel device name for SO_BINDTODEVICE (#5070). It is refreshed at the
+	// START of each Reconcile from the trailing resolver arg (the daemon threads
+	// cfg.ResolveKernelIfName) and read by resolveBackend + CheckIPClient during
+	// the same locked pass. Nil ⇒ the leaf slash-substitution fallback
+	// (standalone tests); a routing-instance still resolves to vrf-<name>.
+	ifResolver func(string) string
+
 	now func() time.Time
 
 	// counters (observability, plan §5.5).
@@ -484,10 +492,13 @@ func productionSurfaceABackend(p *config.DDNSProvider, fqdn string, ttl int) (DN
 // never a withdraw. When the cache is nil (a test manager) it falls back to
 // building a fresh client.
 func (m *SurfaceAManager) CheckIPClient(p *config.DDNSProvider) (*http.Client, error) {
+	// #5070: resolve a destination-interface binding to the local node's kernel
+	// device via the per-pass resolver (set at Reconcile start; the observer that
+	// calls this runs inside that same locked pass). Nil ⇒ leaf fallback.
 	if m.httpClients == nil {
-		return newProviderHTTPClient(p)
+		return newProviderHTTPClient(p, m.ifResolver)
 	}
-	return m.httpClients.clientFor(p)
+	return m.httpClients.clientFor(p, m.ifResolver)
 }
 
 // resolveBackend is the manager-bound backend resolver (#2904). It is identical
@@ -495,7 +506,9 @@ func (m *SurfaceAManager) CheckIPClient(p *config.DDNSProvider) (*http.Client, e
 // manager's cached, per-binding *http.Client so the keep-alive connection pool
 // is reused across reconcile passes instead of being rebuilt every pass.
 func (m *SurfaceAManager) resolveBackend(p *config.DDNSProvider, fqdn string, ttl int) (DNSUpdater, error) {
-	return resolveSurfaceABackend(p, fqdn, ttl, m.httpClients)
+	// #5070: thread the per-pass interface-name resolver so a destination-interface
+	// binding resolves to the local node's kernel device before SO_BINDTODEVICE.
+	return resolveSurfaceABackend(p, fqdn, ttl, m.httpClients, m.ifResolver)
 }
 
 // resolveSurfaceABackend resolves a provider-catalog entry into a live Backend.
@@ -504,7 +517,7 @@ func (m *SurfaceAManager) resolveBackend(p *config.DDNSProvider, fqdn string, tt
 // behaviour, used by productionSurfaceABackend's direct/test callers). A
 // half-configured or unknown provider degrades to the no-op (logged) exactly as
 // before.
-func resolveSurfaceABackend(p *config.DDNSProvider, fqdn string, _ int, clients *httpClientCache) (DNSUpdater, error) {
+func resolveSurfaceABackend(p *config.DDNSProvider, fqdn string, _ int, clients *httpClientCache, resolveIf ...func(string) string) (DNSUpdater, error) {
 	if p == nil {
 		return nopUpdater{}, nil
 	}
@@ -529,7 +542,7 @@ func resolveSurfaceABackend(p *config.DDNSProvider, fqdn string, _ int, clients 
 		if clients == nil {
 			return nil, nil
 		}
-		return clients.clientFor(p)
+		return clients.clientFor(p, resolveIf...)
 	}
 	// httpBackend resolves the source-bound client FIRST (fail-closed on a bind
 	// error) and only then builds the HTTP backend. Resolving the client before
@@ -552,7 +565,7 @@ func resolveSurfaceABackend(p *config.DDNSProvider, fqdn string, _ int, clients 
 		if p.UpdateServer == "" {
 			return nopUpdater{}, nil
 		}
-		return newSurfaceARFC2136(p, fqdn)
+		return newSurfaceARFC2136(p, fqdn, resolveIf...)
 	case "dyndns2":
 		return httpBackend(func(cl *http.Client) (DNSUpdater, error) { return newDyndns2Backend(p, cl) })
 	case "duckdns":
@@ -597,7 +610,7 @@ func newSurfaceAHTTP(p *config.DDNSProvider, build func() (DNSUpdater, error)) (
 // the record at its first address forever. The provider's transport binding
 // (source-address / dest-interface / VRF) is honored via the shared
 // resolveBindConfig→dialer path by reusing DHCPDynamicDNSConfig as the carrier.
-func newSurfaceARFC2136(p *config.DDNSProvider, _ string) (DNSUpdater, error) {
+func newSurfaceARFC2136(p *config.DDNSProvider, _ string, resolveIf ...func(string) string) (DNSUpdater, error) {
 	if p == nil {
 		return nil, errors.New("ddns surface-a: nil provider")
 	}
@@ -620,7 +633,7 @@ func newSurfaceARFC2136(p *config.DDNSProvider, _ string) (DNSUpdater, error) {
 		DestinationInterface: p.DestinationInterface,
 		RoutingInstance:      p.RoutingInstance,
 	}
-	u, err := newRFC2136Updater(pol, c, nil, nil, nil)
+	u, err := newRFC2136Updater(pol, c, nil, nil, nil, resolveIf...)
 	if err != nil {
 		return nil, err
 	}
@@ -716,9 +729,18 @@ func (m *SurfaceAManager) observeIO(fn func()) {
 // gate is the SAME per-RG ScopeGate the lease reconciler uses (#2664). A nil
 // gate (standalone) admits every scope. A gated-out scope is stop-writing,
 // never-withdraw (the peer RG master refreshes it).
-func (m *SurfaceAManager) Reconcile(ctx context.Context, scopes []SurfaceAScope, observe AddressObserver, gate ScopeGate, catalog map[string]*config.DDNSProvider) error {
+// resolveIf is the OPTIONAL committed-config Junos→kernel interface-name
+// resolver (the daemon threads cfg.ResolveKernelIfName) used to resolve a
+// destination-interface binding to the local node's real kernel device before
+// SO_BINDTODEVICE (#5070). Omitted (tests) ⇒ the leaf slash-substitution
+// fallback; a routing-instance still resolves to its vrf-<name> master.
+func (m *SurfaceAManager) Reconcile(ctx context.Context, scopes []SurfaceAScope, observe AddressObserver, gate ScopeGate, catalog map[string]*config.DDNSProvider, resolveIf ...func(string) string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	// #5070: refresh the per-pass interface-name resolver (read by resolveBackend
+	// + CheckIPClient under this same lock).
+	m.ifResolver = firstResolver(resolveIf)
 
 	// FAIL CLOSED (#2971, mirroring the DHCP-lease #2650 gate): the ownership
 	// state could not be loaded, so we cannot prove which router records this


### PR DESCRIPTION
## Problem

`resolveBindConfig` (pkg/ddns/backend_bind.go) stored the **raw** Junos
config token into `bindDevice` and `dialer()` passed it straight to
`SetsockoptString(SO_BINDTODEVICE, dev)`. That token is not a kernel
device name:

- a `routing-instance` "WAN" is realized as the kernel VRF master
  `vrf-WAN` (`pkg/routing`), not `WAN`;
- a `destination-interface` is Junos form `ge-0/0/2.50` (slashes + unit);
  the daemon renames the kernel device to `ge-0-0-2.50`, not `ge-0/0/2.50`.

So `SO_BINDTODEVICE` targeted a **nonexistent** device and every RFC 2136
/ HTTP-provider / check-IP exchange over the binding hard-failed at dial.

## Invariant

A committed interface / routing-instance reference MUST resolve to the
exact current kernel device (unit / reth / VRF mapping) before any
network op.

## Fix

- Reuse the **canonical resolvers** the daemon already uses — no
  hand-rolled string mapping:
  - `destination-interface` → `config.LinuxIfName` (Junos→Linux
    interface-name translator: `ge-0/0/2.50` → `ge-0-0-2.50`, reth
    unchanged).
  - `routing-instance` → `diagcmd.VRFDeviceName` (single source of truth
    for the `vrf-` prefix, applied once; `vrf-red` returned unchanged,
    #2143).
- `routingInst` keeps the raw name (informational only); only
  `bindDevice` feeds `SO_BINDTODEVICE`. All three transports share
  `resolveBindConfig`, so HTTP-provider + checkip get the same resolution.
- **Validate existence at construction:** `newRFC2136Updater` now calls
  `bindConfig.validateDevice()` (injectable `netlink.LinkByName` seam),
  surfacing a clear `bind device %q does not exist` error instead of a
  cryptic dial failure. A transiently-absent device is retried by the
  resolve-per-Reconcile loop.

## Tests (RED-on-revert proven)

- Dropped the two bug-encoding assertions (raw `VRF-WAN` / `ge-0-0-2`
  pass-through) and replaced with kernel-name expectations.
- Added `TestResolveBindConfigResolvesKernelDevices` table: physical unit
  (`ge-0/0/2`→`ge-0-0-2`), VLAN unit (`ge-0/0/2.50`→`ge-0-0-2.50`), reth,
  reth VLAN unit, RI-only (`WAN`→`vrf-WAN`), already-prefixed (`vrf-red`).
- Added `TestNewRFC2136UpdaterValidatesBindDeviceExists` (seam-injected):
  present device constructs; absent device fails with an error naming the
  resolved kernel device.
- **RED-on-revert:** reverting only the `LinuxIfName`/`VRFDeviceName`
  mapping turns the resolution + existence tests red (physical/vlan/ri-only
  assertions fail on the raw token; the construct-present case fails).
- `go build ./...`, `go vet ./pkg/ddns/...`, `go test ./pkg/ddns/...` all
  green; `gofmt` clean.

## Docs

`pkg/ddns/README.md` binding section updated with the kernel-name
resolution + construction-time validation.

Closes #5070

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HAaj8tRj5yyBbvUc7NYAts