### PR TITLE
pkg/daemon: retain host-tunable capture on failed restore (#5114)

### DIFF
--- a/pkg/daemon/host_tunables.go
+++ b/pkg/daemon/host_tunables.go
@@ -469,10 +469,13 @@ func neighRetransPaths(fs hostTunableFS) []string {
 // "omitted-becomes-default when userspace-dp in use" logic.
 //
 //   - governorIn=""          → defaultCPUGovernor if userspaceDP else ""
+//
 //   - governorIn="default"   → "" (pass-through sentinel for skip)
+//
 //   - governorIn="performance"/"schedutil"/anything else → verbatim
 //
 //   - budgetIn=0             → defaultNetdevBudget if userspaceDP else 0
+//
 //   - budgetIn>0             → verbatim
 //
 // The rationale: the #801 Step-0 audit is scoped to userspace-dp
@@ -682,6 +685,32 @@ func restoreHostTunables(p *priorHostTunables, fs hostTunableFS, execer rssExecu
 	}
 }
 
+// hostScopeRestoreResult reports the per-field outcome of
+// restoreHostScopeTunables so the runtime-disable caller can honor the
+// ownership invariant (#5114): ownership of a host-scope knob is
+// released only after its restore write SUCCEEDS. A field counts as
+// restored when its write succeeded OR the field was empty/sentinel
+// (nothing to write). Fields whose write FAILED are reported back so
+// the caller retains their captured baseline as retry debt instead of
+// silently dropping it and leaving the host pinned at xpfd's value.
+type hostScopeRestoreResult struct {
+	// failedGovernors maps cpufreq scaling_governor path → captured
+	// value for every governor whose restore write failed and must be
+	// retained. Always non-nil; empty when every governor restored.
+	failedGovernors map[string]string
+	// budgetFailed is true when the netdev_budget restore write failed;
+	// budgetValue then holds the captured value to retain.
+	budgetFailed bool
+	budgetValue  string
+}
+
+// allRestored reports whether every captured host-scope field restored
+// successfully, i.e. no retry debt remains and ownership may be
+// released (priorTunablesActive → false).
+func (r hostScopeRestoreResult) allRestored() bool {
+	return len(r.failedGovernors) == 0 && !r.budgetFailed
+}
+
 // restoreHostScopeTunables writes only the host-scope captures
 // (cpu governor + netdev_budget) back to the kernel. Used when the
 // `claim-host-tunables` opt-in flips true → false without disabling
@@ -689,14 +718,21 @@ func restoreHostTunables(p *priorHostTunables, fs hostTunableFS, execer rssExecu
 // so its captures are retained, but the operator has retracted their
 // consent to hold host-global knobs.
 //
-// Errors are logged and swallowed. Safe to call with a nil pointer
-// (no-op).
-func restoreHostScopeTunables(p *priorHostTunables, fs hostTunableFS) {
+// Returns a hostScopeRestoreResult naming the fields whose kernel write
+// FAILED (#5114). The caller must retain those captures + keep
+// priorTunablesActive true so a later reconcile retries them; a
+// transient sysfs/proc write failure must not release ownership and
+// leave the host pinned at xpfd's governor / netdev_budget after the
+// operator withdrew consent. Successful (and empty-sentinel) fields are
+// reported as restored so the caller drops them. Safe to call with a
+// nil pointer (no-op → allRestored() true).
+func restoreHostScopeTunables(p *priorHostTunables, fs hostTunableFS) hostScopeRestoreResult {
+	res := hostScopeRestoreResult{failedGovernors: map[string]string{}}
 	if p == nil {
-		return
+		return res
 	}
 	// Governor: write each captured path only if its value is
-	// non-empty (skip sentinel).
+	// non-empty (skip sentinel). Retain any path whose write fails.
 	restored := 0
 	for path, value := range p.governors {
 		if value == "" {
@@ -705,6 +741,7 @@ func restoreHostScopeTunables(p *priorHostTunables, fs hostTunableFS) {
 		if err := fs.writeFile(path, []byte(value)); err != nil {
 			slog.Warn("linksetup: host tunable restore — governor write failed",
 				"path", path, "want", value, "err", err)
+			res.failedGovernors[path] = value
 			continue
 		}
 		restored++
@@ -718,22 +755,32 @@ func restoreHostScopeTunables(p *priorHostTunables, fs hostTunableFS) {
 		if err := fs.writeFile(sysctlPathNetdevBudget, []byte(p.budget)); err != nil {
 			slog.Warn("linksetup: host tunable restore — netdev_budget write failed",
 				"want", p.budget, "err", err)
+			res.budgetFailed = true
+			res.budgetValue = p.budget
 		} else {
 			slog.Info("linksetup: netdev_budget restored to pre-xpfd value",
 				"value", p.budget)
 		}
 	}
+	return res
 }
 
 // restoreNeighRetransTime writes every captured neighbor retrans_time_ms
 // value back to the kernel (#1636). Unlike the cpu-governor / netdev
 // knobs this is restored unconditionally on daemon stop (it applies
 // unconditionally, not behind claim-host-tunables), so a co-tenant's
-// tuned value is put back when xpfd exits. Errors are logged and
-// swallowed. Safe with a nil pointer or empty map (no-op).
-func restoreNeighRetransTime(p *priorHostTunables, fs hostTunableFS) {
+// tuned value is put back when xpfd exits.
+//
+// Returns the map of captures whose kernel write FAILED — path →
+// captured value — so the runtime-disable caller retains them as retry
+// debt instead of dropping the capture and stranding the host at the
+// lowered 250ms after the dataplane that wanted it is gone (#5114). The
+// returned map is always non-nil; empty means every path restored.
+// Safe with a nil pointer or empty map (no-op → empty map).
+func restoreNeighRetransTime(p *priorHostTunables, fs hostTunableFS) map[string]string {
+	retained := map[string]string{}
 	if p == nil || len(p.neighRetrans) == 0 {
-		return
+		return retained
 	}
 	restored := 0
 	for path, value := range p.neighRetrans {
@@ -743,6 +790,7 @@ func restoreNeighRetransTime(p *priorHostTunables, fs hostTunableFS) {
 		if err := fs.writeFile(path, []byte(value)); err != nil {
 			slog.Warn("linksetup: host tunable restore — neigh retrans_time_ms write failed",
 				"path", path, "want", value, "err", err)
+			retained[path] = value
 			continue
 		}
 		restored++
@@ -751,6 +799,7 @@ func restoreNeighRetransTime(p *priorHostTunables, fs hostTunableFS) {
 		slog.Info("linksetup: neigh retrans_time_ms restored to pre-xpfd value",
 			"restored", restored, "total", len(p.neighRetrans))
 	}
+	return retained
 }
 
 // restoreMlx5Coalesce emits one `ethtool -C <iface> adaptive-rx ...
@@ -788,4 +837,3 @@ func restoreMlx5Coalesce(iface string, s mlx5CoalesceState, execer rssExecutor) 
 		"adaptive_tx", s.adaptiveTX,
 		"rx_usecs", s.rxUsecs, "tx_usecs", s.txUsecs)
 }
-

--- a/pkg/daemon/host_tunables_daemon.go
+++ b/pkg/daemon/host_tunables_daemon.go
@@ -32,7 +32,9 @@
 //	false      false      no-op (never claimed)
 //	false      true       capture + write
 //	true       true       capture-if-not-already + write (reconcile)
-//	true       false      restore (B2), discard snapshot
+//	true       false      restore (B2); drop restored captures, RETAIN
+//	                      any whose write failed + stay active to retry
+//	                      the debt next reconcile (#5114)
 //	(shutdown) *          restore (if active) on daemon Stop
 //
 // Coalescence (interface-scoped) runs on every apply with the same
@@ -55,7 +57,10 @@ import (
 //     pre-xpfd value is captured before the first write so restore can
 //     revert to the exact pre-xpfd string.
 //  3. Restore-on-disable (B2): when claim flips true → false, every
-//     captured value is written back and the snapshot is cleared.
+//     captured value is written back. A field is dropped from the
+//     snapshot only after its restore write SUCCEEDS; a failed write
+//     retains the capture + keeps priorTunablesActive true so the next
+//     reconcile retries it (#5114 retry-debt invariant).
 //
 // Never returns an error — any failure logs and continues. Tunable
 // regressions must not block commit or daemon start.
@@ -127,8 +132,14 @@ func (d *Daemon) applyStep0TunablesWith(userspaceDP, claimHostTunables bool,
 		// captures so a later re-enable re-captures cleanly. Without this
 		// the lowered values would persist for the daemon lifetime even
 		// though the dataplane that wanted them is gone.
-		restoreNeighRetransTime(prior, fs)
-		prior.neighRetrans = map[string]string{}
+		//
+		// #5114: drop only the paths whose restore write SUCCEEDED;
+		// restoreNeighRetransTime returns the failed captures, which we
+		// keep as retry debt so the next reconcile (this same branch
+		// re-fires while userspace-dp stays disabled and captures remain)
+		// retries them. A transient /proc write failure must not strand
+		// the host at the lowered 250ms.
+		prior.neighRetrans = restoreNeighRetransTime(prior, fs)
 	}
 
 	// Host-scope restore path: previously claimed, now gated off.
@@ -137,17 +148,34 @@ func (d *Daemon) applyStep0TunablesWith(userspaceDP, claimHostTunables bool,
 	// active and those are the snapshots shutdown-restore relies on.
 	if active && (!userspaceDP || !claimHostTunables) {
 		slog.Info("linksetup: claim-host-tunables disabled, restoring pre-xpfd host-scope values")
-		restoreHostScopeTunables(prior, fs)
+		res := restoreHostScopeTunables(prior, fs)
 		d.priorTunablesMu.Lock()
 		// Keep the snapshot object alive if coalescence just
-		// captured new mlx5 state; only clear host-scope fields.
-		prior.governors = map[string]string{}
-		prior.budget = ""
+		// captured new mlx5 state; only touch host-scope fields.
+		//
+		// #5114: ownership is released only after a SUCCESSFUL restore.
+		// Retain the captures whose kernel write FAILED (drop the ones
+		// that restored) and, if any remain, keep priorTunablesActive
+		// true so this same restore path re-fires on the next reconcile
+		// and retries the debt — a transient sysfs/proc write failure
+		// must not leave the host pinned at xpfd's governor /
+		// netdev_budget after the operator withdrew consent.
+		prior.governors = res.failedGovernors
+		if res.budgetFailed {
+			prior.budget = res.budgetValue
+		} else {
+			prior.budget = ""
+		}
 		d.priorTunables = prior
-		// Claim is now off but coalescence may still have captures;
-		// keep priorTunablesActive aligned with claim state so the
-		// same restore path doesn't re-fire next reconcile.
-		d.priorTunablesActive = false
+		if res.allRestored() {
+			// Claim is now off and every host-scope knob reverted;
+			// release ownership so the restore path stops firing.
+			d.priorTunablesActive = false
+		} else {
+			slog.Warn("linksetup: host-scope tunable restore incomplete, retaining capture for retry",
+				"failed_governors", len(res.failedGovernors),
+				"budget_failed", res.budgetFailed)
+		}
 		d.priorTunablesMu.Unlock()
 		return
 	}

--- a/pkg/daemon/host_tunables_restore_debt_5114_test.go
+++ b/pkg/daemon/host_tunables_restore_debt_5114_test.go
@@ -1,0 +1,197 @@
+// Retain-on-failed-restore tests for #5114.
+//
+// Invariant: ownership of a host tunable is released only after a
+// SUCCESSFUL restore write. When `claim-host-tunables` flips off (or
+// userspace-dp is withdrawn) and a captured value's sysfs/proc write
+// FAILS, the daemon MUST retain that capture + its active debt so a
+// later reconcile retries it — never wipe the snapshot and leave the
+// host pinned at xpfd's governor / netdev_budget / lowered neigh
+// retrans_time_ms.
+//
+// The write failure is injected through the fakeHostFS.writeErrs seam.
+// RED-on-revert: with the void-swallow + unconditional-clear restored,
+// the retain assertions fail because the capture is wiped despite the
+// failed write.
+package daemon
+
+import (
+	"errors"
+	"testing"
+)
+
+// errWriteDenied is a transient sysfs/proc write failure injected via
+// fakeHostFS.writeErrs to exercise the #5114 retain-on-failure path.
+var errWriteDenied = errors.New("transient write failure (test)")
+
+// TestApplyStep0_ClaimOff_RetainsFailedGovernorRestore pins the
+// host-scope retain-on-failure path: a governor whose restore write
+// fails keeps its captured baseline and priorTunablesActive stays true
+// (retry debt); the governors that restored and the budget are dropped.
+func TestApplyStep0_ClaimOff_RetainsFailedGovernorRestore(t *testing.T) {
+	const cpu0 = "/sys/cpu0/scaling_governor"
+	const cpu1 = "/sys/cpu1/scaling_governor"
+	d := &Daemon{}
+	fs := newFakeHostFS()
+	fs.cpufreqPaths = []string{cpu0, cpu1}
+	fs.files[cpu0] = []byte("schedutil") // pre-xpfd
+	fs.files[cpu1] = []byte("schedutil") // pre-xpfd
+	fs.files[sysctlPathNetdevBudget] = []byte("450")
+	execer := &fakeRSSExecutor{}
+
+	// Phase 1: claim on → capture schedutil x2 + budget 450, write
+	// performance + 600.
+	d.applyStep0TunablesWith(true, true, "performance", 600,
+		false, false, 0, 0, nil, fs, execer)
+	if !d.priorTunablesActive {
+		t.Fatal("setup: priorTunablesActive must be true after claimed apply")
+	}
+	if d.priorTunables.governors[cpu1] != "schedutil" {
+		t.Fatalf("setup: want captured cpu1=schedutil, got %q", d.priorTunables.governors[cpu1])
+	}
+
+	// Phase 2: flip claim off; inject a transient write failure on cpu1's
+	// restore. cpu0 + budget restore; cpu1 fails.
+	fs.writes = map[string]string{}
+	fs.writeOrder = nil
+	fs.writeErrs[cpu1] = errWriteDenied
+
+	d.applyStep0TunablesWith(true, false, "performance", 600,
+		false, false, 0, 0, nil, fs, execer)
+
+	// cpu0 + budget restored to pre-xpfd values.
+	if got := fs.writes[cpu0]; got != "schedutil" {
+		t.Errorf("cpu0 should restore to schedutil, got %q", got)
+	}
+	if got := fs.writes[sysctlPathNetdevBudget]; got != "450" {
+		t.Errorf("budget should restore to 450, got %q", got)
+	}
+	// cpu1 write failed → not recorded.
+	if _, ok := fs.writes[cpu1]; ok {
+		t.Errorf("cpu1 restore write should have failed, but was recorded: %v", fs.writes)
+	}
+
+	// RETAIN the failed capture; DROP the restored ones.
+	if got, ok := d.priorTunables.governors[cpu1]; !ok || got != "schedutil" {
+		t.Errorf("#5114: failed cpu1 capture must be RETAINED (got %q ok=%v)", got, ok)
+	}
+	if _, ok := d.priorTunables.governors[cpu0]; ok {
+		t.Errorf("#5114: restored cpu0 capture must be dropped, still present: %v", d.priorTunables.governors)
+	}
+	if d.priorTunables.budget != "" {
+		t.Errorf("#5114: restored budget capture must be cleared, got %q", d.priorTunables.budget)
+	}
+	// Debt remains → ownership NOT released.
+	if !d.priorTunablesActive {
+		t.Error("#5114: priorTunablesActive must stay TRUE while restore debt remains")
+	}
+
+	// Phase 3: retry — the write now succeeds → debt cleared, ownership
+	// released.
+	fs.writes = map[string]string{}
+	fs.writeOrder = nil
+	delete(fs.writeErrs, cpu1)
+
+	d.applyStep0TunablesWith(true, false, "performance", 600,
+		false, false, 0, 0, nil, fs, execer)
+
+	if got := fs.writes[cpu1]; got != "schedutil" {
+		t.Errorf("retry: cpu1 should restore to schedutil, got %q", got)
+	}
+	if len(d.priorTunables.governors) != 0 {
+		t.Errorf("retry: all governor debt must clear, got %v", d.priorTunables.governors)
+	}
+	if d.priorTunablesActive {
+		t.Error("retry: priorTunablesActive must be false once all captures restored")
+	}
+}
+
+// TestApplyStep0_ClaimOff_AllRestore_ReleasesOwnership pins the
+// all-success path: every host-scope capture restores → snapshot fully
+// cleared, priorTunablesActive=false.
+func TestApplyStep0_ClaimOff_AllRestore_ReleasesOwnership(t *testing.T) {
+	const cpu0 = "/sys/cpu0/scaling_governor"
+	d := &Daemon{}
+	fs := newFakeHostFS()
+	fs.cpufreqPaths = []string{cpu0}
+	fs.files[cpu0] = []byte("schedutil")
+	fs.files[sysctlPathNetdevBudget] = []byte("450")
+	execer := &fakeRSSExecutor{}
+
+	d.applyStep0TunablesWith(true, true, "performance", 600,
+		false, false, 0, 0, nil, fs, execer)
+	d.applyStep0TunablesWith(true, false, "performance", 600,
+		false, false, 0, 0, nil, fs, execer)
+
+	if len(d.priorTunables.governors) != 0 {
+		t.Errorf("all-restore: governor snapshot must clear, got %v", d.priorTunables.governors)
+	}
+	if d.priorTunables.budget != "" {
+		t.Errorf("all-restore: budget snapshot must clear, got %q", d.priorTunables.budget)
+	}
+	if d.priorTunablesActive {
+		t.Error("all-restore: priorTunablesActive must be false")
+	}
+}
+
+// TestApplyStep0_DPOff_RetainsFailedNeighRestore pins the neighbor
+// retrans_time_ms retain-on-failure path (#5114): when userspace-dp is
+// withdrawn and one path's restore write fails, that capture is RETAINED
+// (so the branch retries it next reconcile) while the restored paths are
+// dropped.
+func TestApplyStep0_DPOff_RetainsFailedNeighRestore(t *testing.T) {
+	v4em0 := sysctlNeighV4Dir + "/em0/retrans_time_ms"
+	v4def := sysctlNeighV4Dir + "/default/retrans_time_ms"
+	f := neighFSWithIfaces("1000", "em0")
+	d := &Daemon{}
+	execer := &fakeRSSExecutor{}
+
+	// Phase 1: userspace-dp on → capture 1000 x4, lower to 250.
+	d.applyStep0TunablesWith(true, false, "", 0, false, false, 0, 0, nil, f, execer)
+	if f.writes[v4em0] != "250" {
+		t.Fatalf("setup: em0 not lowered, got %q", f.writes[v4em0])
+	}
+	if d.priorTunables.neighRetrans[v4em0] != "1000" {
+		t.Fatalf("setup: want captured v4/em0=1000, got %q", d.priorTunables.neighRetrans[v4em0])
+	}
+
+	// Phase 2: userspace-dp off; inject a transient failure on v4/em0's
+	// restore. The other three paths restore to 1000; v4/em0 fails.
+	f.writes = map[string]string{}
+	f.writeOrder = nil
+	f.writeErrs[v4em0] = errWriteDenied
+
+	d.applyStep0TunablesWith(false, false, "", 0, false, false, 0, 0, nil, f, execer)
+
+	if got := f.writes[v4def]; got != "1000" {
+		t.Errorf("v4/default should restore to 1000, got %q", got)
+	}
+	if _, ok := f.writes[v4em0]; ok {
+		t.Errorf("v4/em0 restore write should have failed, but was recorded: %v", f.writes)
+	}
+	// RETAIN the failed capture; drop the restored ones.
+	if got, ok := d.priorTunables.neighRetrans[v4em0]; !ok || got != "1000" {
+		t.Errorf("#5114: failed v4/em0 capture must be RETAINED (got %q ok=%v)", got, ok)
+	}
+	if _, ok := d.priorTunables.neighRetrans[v4def]; ok {
+		t.Errorf("#5114: restored v4/default capture must be dropped, still present: %v",
+			d.priorTunables.neighRetrans)
+	}
+	if len(d.priorTunables.neighRetrans) != 1 {
+		t.Errorf("#5114: exactly one failed neigh capture must remain, got %v",
+			d.priorTunables.neighRetrans)
+	}
+
+	// Phase 3: retry — write now succeeds → debt cleared.
+	f.writes = map[string]string{}
+	f.writeOrder = nil
+	delete(f.writeErrs, v4em0)
+
+	d.applyStep0TunablesWith(false, false, "", 0, false, false, 0, 0, nil, f, execer)
+
+	if got := f.writes[v4em0]; got != "1000" {
+		t.Errorf("retry: v4/em0 should restore to 1000, got %q", got)
+	}
+	if len(d.priorTunables.neighRetrans) != 0 {
+		t.Errorf("retry: all neigh debt must clear, got %v", d.priorTunables.neighRetrans)
+	}
+}


### PR DESCRIPTION
## Problem

On the live runtime-disable path (`claim-host-tunables` withdrawn, or
userspace-dp withdrawn without a daemon stop), `restoreHostScopeTunables`
(`pkg/daemon/host_tunables.go`) and `restoreNeighRetransTime` were **void
and swallowed every write error**. The caller
(`host_tunables_daemon.go`) then **unconditionally** wiped the captured
`governors`/`budget`/`neighRetrans` maps and set
`priorTunablesActive=false`.

So a transient sysfs/proc write failure **lost the capture with no retry
debt** — the host stayed pinned at xpfd's governor / `netdev_budget` /
lowered neigh `retrans_time_ms` after the operator withdrew consent, with
nothing left to revert it.

## Invariant

Ownership is released only after a **successful** restore. A capture
whose write fails must be **retained**, along with the active debt, so a
later reconcile retries it.

## Fix (both scopes)

- `restoreHostScopeTunables` returns a `hostScopeRestoreResult` naming
  the governor paths + budget whose write failed; `restoreNeighRetrans
  Time` returns the map of failed neigh captures.
- The runtime-disable caller drops **only** the fields that restored and
  retains the failed captures. Host-scope keeps `priorTunablesActive`
  true whenever any field failed (`allRestored()` gates the release), so
  the same restore path re-fires on the next commit-driven reconcile and
  retries the remainder. The neigh branch naturally re-fires while
  userspace-dp stays disabled and captures remain.
- Bounded `slog.Warn` on incomplete restore (fires only on the rare
  disable event, never per-tick).

Reconcile cadence is commit-driven: `applyStep0Tunables` runs from
`applyConfig` on every commit and from `Run` at startup, so retained debt
is retried on the next commit or daemon restart. Shutdown / full-restore
callers ignore the new return values (no retry after Stop).

## Docs

The transition matrix + restore-on-disable lifecycle notes in the
`host_tunables` file headers and the restore-function doc comments now
document the retain-on-failure/retry-debt behavior. `pkg/daemon/README.md`
only references host tunables as a bootstrap-suppressed action (no
capture/restore lifecycle detail), so no README change is needed.

## Tests (RED-on-revert)

- Host-scope partial-failure retains the failed governor + stays active
  while dropping the restored governor/budget; all-success releases
  ownership; a retry with the write succeeding clears the debt and
  releases ownership.
- Same three-phase coverage for the neigh path.
- **RED-on-revert proven**: with the void-swallow + unconditional-clear
  restored (`git stash` of the production change, tests kept), the retain
  assertions fail — capture wiped despite the failed write, ownership
  released. Restored → all green.

`go build ./...` clean; `go test ./pkg/daemon/...` green.

Closes #5114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AgajCU1jK8cpLa2mzep1NE