### PR TITLE
pkg/cli: bind 'show firewall effective' to the acknowledged generation (#5067)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45161,3 +45161,24 @@ top.
 - **File(s)**: pkg/cli/cli_show_security_filters.go,
   pkg/cli/cli_show_effective_filter_gen_5067_test.go,
   docs/junos-cli-reference.md, _Log.md
+- **Action**: #5067 / PR #5420 review fix — relax the effective-view coherence
+  check from `==` to `>=`. The `==` check spuriously flagged "dataplane
+  generation drift / NOT enforcing" on a HEALTHY armed box after a scheduler-
+  only republish: Manager.UpdatePolicyScheduleState advances the helper's
+  snapshot generation (helper ACKs N+1) but never calls recordApplyResultLocked,
+  so LastApplyResult().Generation stays at N -> N+1 == N is false -> false-
+  positive banner until the next commit. Helper-AHEAD is benign (the republish
+  re-times policy enable/disable, same filter content). Changed
+  `coherent := ... LastSnapshotGeneration >= cr.Generation` so helper-behind
+  (acked < applied) still shows real drift while helper-at-or-ahead renders
+  live. The original #5067 disarm is caught by the `armed` predicate
+  (ForwardingArmed=false) independent of the gen compare, so `>=` does not
+  weaken it (verified in-source: UpdatePolicyScheduleState bumps m.generation +
+  m.lastSnapshot without recordApplyResultLocked). Added
+  TestShowEffectiveFirewallFiltersHelperAheadIsLive (acked=applied+1, armed ->
+  live, no banner); it is RED against the committed `==` version. Disarm/behind
+  RED-on-revert re-proven against origin/master. Updated
+  docs/junos-cli-reference.md wording to "at or ahead of".
+- **File(s)**: pkg/cli/cli_show_security_filters.go,
+  pkg/cli/cli_show_effective_filter_gen_5067_test.go,
+  docs/junos-cli-reference.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -45139,3 +45139,25 @@ top.
   chaining" section + first-hop-only Option 82 gotcha.
 - **File(s)**: pkg/dhcprelay/relay.go,
   pkg/dhcprelay/relay_chain_5071_test.go, pkg/dhcprelay/README.md, _Log.md
+- **Action**: #5067 — bind `show firewall [filter <name>] effective` to the
+  helper-acknowledged generation. The effective view compiled its snapshots
+  from ActiveConfig() and labeled them as what "the dataplane actually
+  receives" without ever consulting the apply/generation state. commitAndApply
+  promotes the active config via store.Commit() BEFORE applyAndSyncCommitted
+  runs; a required-protocol-gate apply error (applyErrSkipsPeerSync /
+  compileErrorMustAbortApply) leaves the dataplane DISARMED while ActiveConfig
+  is already the new generation, so the view falsely certified an unapplied
+  config as live. Added firewallEffectiveLiveness (dataplane loaded + helper
+  status → armed && acked-gen == last-applied-gen) and
+  printFirewallEffectiveBanner: certifies "dataplane-acknowledged (generation
+  N)" only when armed+coherent, else prints a prominent COMPILED-DESIRED /
+  disarmed-or-drift banner surfacing acked vs desired generations; a soft note
+  when no runtime is wired. Display-only — no change to apply/commit/sync.
+  Applied to both the all-filters and single-filter forms. Four tests
+  (armed-acked, disarmed-drift, generation-drift, no-runtime); RED-on-revert
+  proven (the disarmed + drift tests fail on reverted source — the compiled
+  snapshot is presented as effective with no banner). Updated
+  docs/junos-cli-reference.md with the generation-liveness banner section.
+- **File(s)**: pkg/cli/cli_show_security_filters.go,
+  pkg/cli/cli_show_effective_filter_gen_5067_test.go,
+  docs/junos-cli-reference.md, _Log.md

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -1635,17 +1635,21 @@ config is already the new generation — so the compiled-desired snapshot is NOT
 what the dataplane is enforcing. The local CLI therefore binds the view to the
 HELPER-ACKNOWLEDGED generation before rendering:
 
-- **Armed + acknowledged** (dataplane armed and the acknowledged generation
-  equals the daemon's last applied generation): the snapshots are prefixed with
-  `Effective firewall filters — dataplane-acknowledged (generation N).` and are
-  safe to read as live.
+- **Armed + acknowledged** (dataplane armed and the acknowledged generation is
+  at or ahead of the daemon's last applied generation): the snapshots are
+  prefixed with `Effective firewall filters — dataplane-acknowledged
+  (generation N).` and are safe to read as live. Helper-ahead is benign — a
+  scheduler-only republish (`Manager.UpdatePolicyScheduleState`) advances the
+  helper's snapshot generation without bumping the last recorded apply
+  generation, and it carries the same filter content, so the view is still live.
 - **Disarmed or generation drift**: the snapshots are prefixed with a prominent
   `WARNING: dataplane is NOT enforcing the active configuration.` banner that
-  labels the output `COMPILED-DESIRED`, states the reason (dataplane disarmed /
-  generation drift), and surfaces the last dataplane-acknowledged generation
-  versus the desired (active, not-yet-acknowledged) configuration. The compiled
-  snapshots are still printed under the banner so the operator can inspect the
-  desired compile, but they are never certified as live.
+  labels the output `COMPILED-DESIRED`, states the reason (dataplane disarmed, or
+  the helper is BEHIND the applied generation), and surfaces the last
+  dataplane-acknowledged generation versus the desired (active, not-yet-
+  acknowledged) configuration. The compiled snapshots are still printed under the
+  banner so the operator can inspect the desired compile, but they are never
+  certified as live.
 - **Dataplane status unavailable** (no runtime wired): a soft note records that
   the snapshots are compiled-desired and the acknowledged generation could not be
   confirmed.

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -1626,6 +1626,34 @@ where compilation transforms the term:
 The heading carries a `[effective]` tag (`Filter: demo (family inet)
 [effective]`) so the compiled view is never confused with the raw output.
 
+**Generation-liveness banner (#5067).** The effective view compiles its
+snapshots from the ACTIVE config, which `commitAndApply` promotes via
+`store.Commit()` BEFORE the dataplane apply runs. A required-protocol-gate apply
+error (`applyErrSkipsPeerSync` / `compileErrorMustAbortApply`, see
+`pkg/daemon/daemon_apply.go`) leaves the dataplane DISARMED while the active
+config is already the new generation — so the compiled-desired snapshot is NOT
+what the dataplane is enforcing. The local CLI therefore binds the view to the
+HELPER-ACKNOWLEDGED generation before rendering:
+
+- **Armed + acknowledged** (dataplane armed and the acknowledged generation
+  equals the daemon's last applied generation): the snapshots are prefixed with
+  `Effective firewall filters — dataplane-acknowledged (generation N).` and are
+  safe to read as live.
+- **Disarmed or generation drift**: the snapshots are prefixed with a prominent
+  `WARNING: dataplane is NOT enforcing the active configuration.` banner that
+  labels the output `COMPILED-DESIRED`, states the reason (dataplane disarmed /
+  generation drift), and surfaces the last dataplane-acknowledged generation
+  versus the desired (active, not-yet-acknowledged) configuration. The compiled
+  snapshots are still printed under the banner so the operator can inspect the
+  desired compile, but they are never certified as live.
+- **Dataplane status unavailable** (no runtime wired): a soft note records that
+  the snapshots are compiled-desired and the acknowledged generation could not be
+  confirmed.
+
+This applies to the local CLI (`pkg/cli`). The remote CLI's gRPC `ShowText`
+path renders the same compiled snapshots without the liveness banner; adding the
+generation-liveness context to the gRPC surface is a follow-up.
+
 Both the local and the remote (`cli`) CLI render this identically (#4967). The
 snapshot renderer is the single source of truth
 `dpuserspace.RenderFirewallFilterSnapshot`; the local CLI calls it directly and

--- a/pkg/cli/cli_show_effective_filter_gen_5067_test.go
+++ b/pkg/cli/cli_show_effective_filter_gen_5067_test.go
@@ -1,0 +1,208 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// #5067: `show firewall [filter <name>] effective` compiles its snapshots from
+// ActiveConfig(), which commitAndApply promotes via store.Commit() BEFORE the
+// dataplane apply runs. A required-protocol-gate apply error leaves the
+// dataplane DISARMED while ActiveConfig is already the new generation, so the
+// compiled-desired snapshot is NOT what the dataplane is enforcing. The
+// effective view must bind its output to the helper-acknowledged generation:
+// certify it as live only when the dataplane is armed and the acknowledged
+// generation matches the last applied generation, else flag the drift.
+
+// effectiveGenCLIDP stubs the CLI runtime with a fixed ApplyResult (the daemon's
+// last successfully-recorded apply) and a fixed helper ProcessStatus (armed
+// state + acknowledged generation). It embeds *dataplane.Manager so it satisfies
+// the full cliRuntime surface; only the accessors the effective view reads are
+// overridden.
+type effectiveGenCLIDP struct {
+	*dataplane.Manager
+	apply  *dataplane.ApplyResult
+	status dpuserspace.ProcessStatus
+}
+
+func (d *effectiveGenCLIDP) IsLoaded() bool { return true }
+
+func (d *effectiveGenCLIDP) LastApplyResult() *dataplane.ApplyResult {
+	return d.apply.Clone()
+}
+
+func (d *effectiveGenCLIDP) Status() (dpuserspace.ProcessStatus, error) {
+	return d.status, nil
+}
+
+// TestShowEffectiveFirewallFiltersArmedAcknowledged: the dataplane is armed and
+// the acknowledged generation matches the last applied generation, so the view
+// renders the compiled snapshots and certifies them as dataplane-acknowledged —
+// no drift banner.
+func TestShowEffectiveFirewallFiltersArmedAcknowledged(t *testing.T) {
+	c := &CLI{
+		store: newEffectiveFilterTestStore(t),
+		dp: &effectiveGenCLIDP{
+			Manager: dataplane.New(),
+			apply: &dataplane.ApplyResult{
+				Generation:   5,
+				Capabilities: dataplane.Capabilities{ForwardingSupported: true},
+			},
+			status: dpuserspace.ProcessStatus{
+				Enabled:                true,
+				ForwardingArmed:        true,
+				Capabilities:           dpuserspace.UserspaceCapabilities{ForwardingSupported: true},
+				LastSnapshotGeneration: 5,
+			},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := c.showEffectiveFirewallFilters(""); err != nil {
+			t.Fatalf("showEffectiveFirewallFilters() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Effective firewall filters — dataplane-acknowledged (generation 5).") {
+		t.Fatalf("output = %q, want dataplane-acknowledged generation certification", out)
+	}
+	if strings.Contains(out, "WARNING") || strings.Contains(out, "COMPILED-DESIRED") {
+		t.Fatalf("output = %q, unexpectedly flags drift on an armed+coherent dataplane", out)
+	}
+	// The compiled snapshot is still rendered.
+	if !strings.Contains(out, "Filter: demo (family inet) [effective]") {
+		t.Fatalf("output = %q, want compiled snapshot body", out)
+	}
+}
+
+// TestShowEffectiveFirewallFiltersDisarmedDrift reproduces the #5067 window:
+// ActiveConfig is the promoted config B, but a required-protocol-gate apply
+// error left the dataplane DISARMED (ForwardingArmed=false) while the last
+// recorded apply is still the previously-live generation. The view must NOT
+// certify B as live — it prints the compiled-desired snapshots under a prominent
+// disarmed/drift banner surfacing the acknowledged generation.
+//
+// RED-on-revert: with the production change reverted the banner is absent and
+// this test fails (the compiled snapshot is falsely presented as effective with
+// no drift warning).
+func TestShowEffectiveFirewallFiltersDisarmedDrift(t *testing.T) {
+	c := &CLI{
+		store: newEffectiveFilterTestStore(t),
+		dp: &effectiveGenCLIDP{
+			Manager: dataplane.New(),
+			// Last successful apply was the previous generation (config A).
+			apply: &dataplane.ApplyResult{
+				Generation:   5,
+				Capabilities: dataplane.Capabilities{ForwardingSupported: true},
+			},
+			// Helper acknowledged generation 5 but is now DISARMED after the
+			// required-protocol-gate failure while committing config B.
+			status: dpuserspace.ProcessStatus{
+				Enabled:                true,
+				ForwardingArmed:        false,
+				Capabilities:           dpuserspace.UserspaceCapabilities{ForwardingSupported: true},
+				LastSnapshotGeneration: 5,
+			},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := c.showEffectiveFirewallFilters(""); err != nil {
+			t.Fatalf("showEffectiveFirewallFilters() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "WARNING: dataplane is NOT enforcing the active configuration.") {
+		t.Fatalf("output = %q, want prominent disarmed drift banner", out)
+	}
+	if !strings.Contains(out, "COMPILED-DESIRED") {
+		t.Fatalf("output = %q, want compiled-desired labeling", out)
+	}
+	if !strings.Contains(out, "dataplane disarmed (forwarding not armed)") {
+		t.Fatalf("output = %q, want disarmed reason surfaced", out)
+	}
+	// Desired-vs-applied generations are surfaced.
+	if !strings.Contains(out, "Last dataplane-acknowledged generation: 5.") {
+		t.Fatalf("output = %q, want acknowledged generation surfaced", out)
+	}
+	if !strings.Contains(out, "Desired: active configuration (not acknowledged).") {
+		t.Fatalf("output = %q, want desired-vs-acknowledged distinction", out)
+	}
+	// It must NOT certify the config as live.
+	if strings.Contains(out, "Effective firewall filters — dataplane-acknowledged") {
+		t.Fatalf("output = %q, must NOT certify a disarmed dataplane as acknowledged", out)
+	}
+	// The compiled-desired snapshot is still shown (so the operator can inspect
+	// the desired compile) — under the banner.
+	if !strings.Contains(out, "Filter: demo (family inet) [effective]") {
+		t.Fatalf("output = %q, want compiled-desired snapshot body under the banner", out)
+	}
+}
+
+// TestShowEffectiveFirewallFiltersGenerationDrift covers the second drift class:
+// the dataplane is armed but the helper's acknowledged generation lags the
+// daemon's last applied generation (an in-flight or rejected publish). The view
+// flags the drift rather than certifying the newer applied generation as live.
+func TestShowEffectiveFirewallFiltersGenerationDrift(t *testing.T) {
+	c := &CLI{
+		store: newEffectiveFilterTestStore(t),
+		dp: &effectiveGenCLIDP{
+			Manager: dataplane.New(),
+			apply: &dataplane.ApplyResult{
+				Generation:   7,
+				Capabilities: dataplane.Capabilities{ForwardingSupported: true},
+			},
+			status: dpuserspace.ProcessStatus{
+				Enabled:                true,
+				ForwardingArmed:        true,
+				Capabilities:           dpuserspace.UserspaceCapabilities{ForwardingSupported: true},
+				LastSnapshotGeneration: 5, // helper still on the older generation
+			},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := c.showEffectiveFirewallFilters(""); err != nil {
+			t.Fatalf("showEffectiveFirewallFilters() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "dataplane generation drift") {
+		t.Fatalf("output = %q, want generation-drift reason", out)
+	}
+	if !strings.Contains(out, "Last dataplane-acknowledged generation: 5.") {
+		t.Fatalf("output = %q, want acknowledged generation 5 surfaced", out)
+	}
+	if !strings.Contains(out, "Last daemon-applied generation: 7.") {
+		t.Fatalf("output = %q, want applied generation 7 surfaced when it diverges", out)
+	}
+	if strings.Contains(out, "Effective firewall filters — dataplane-acknowledged") {
+		t.Fatalf("output = %q, must NOT certify a lagging generation as acknowledged", out)
+	}
+}
+
+// TestShowEffectiveFirewallFiltersNoRuntime: with no dataplane runtime wired the
+// view cannot confirm the acknowledged generation, so it renders compiled-desired
+// under a soft note rather than falsely certifying it as live.
+func TestShowEffectiveFirewallFiltersNoRuntime(t *testing.T) {
+	c := &CLI{store: newEffectiveFilterTestStore(t)}
+
+	out := captureStdout(t, func() {
+		if err := c.showEffectiveFirewallFilters(""); err != nil {
+			t.Fatalf("showEffectiveFirewallFilters() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "dataplane status unavailable") {
+		t.Fatalf("output = %q, want compiled-desired note when no runtime is wired", out)
+	}
+	if strings.Contains(out, "Effective firewall filters — dataplane-acknowledged") {
+		t.Fatalf("output = %q, must NOT certify as acknowledged with no runtime", out)
+	}
+	if !strings.Contains(out, "Filter: demo (family inet) [effective]") {
+		t.Fatalf("output = %q, want compiled-desired snapshot body", out)
+	}
+}

--- a/pkg/cli/cli_show_effective_filter_gen_5067_test.go
+++ b/pkg/cli/cli_show_effective_filter_gen_5067_test.go
@@ -184,6 +184,53 @@ func TestShowEffectiveFirewallFiltersGenerationDrift(t *testing.T) {
 	}
 }
 
+// TestShowEffectiveFirewallFiltersHelperAheadIsLive covers the benign helper-
+// AHEAD edge (#5420 review): a scheduler-only republish
+// (Manager.UpdatePolicyScheduleState) advances the helper's snapshot generation
+// and the helper ACKs it, but that path never calls recordApplyResultLocked — so
+// LastApplyResult().Generation lags the helper's LastSnapshotGeneration on a
+// perfectly HEALTHY, armed box. The republish carries the same filter content
+// (it only re-times policy enable/disable), so the effective view must still
+// render LIVE with NO drift banner. An `==` coherence check would spuriously
+// warn "NOT enforcing" here; `>=` accepts helper-at-or-ahead.
+func TestShowEffectiveFirewallFiltersHelperAheadIsLive(t *testing.T) {
+	c := &CLI{
+		store: newEffectiveFilterTestStore(t),
+		dp: &effectiveGenCLIDP{
+			Manager: dataplane.New(),
+			// Daemon's last recorded apply is generation 5.
+			apply: &dataplane.ApplyResult{
+				Generation:   5,
+				Capabilities: dataplane.Capabilities{ForwardingSupported: true},
+			},
+			// Armed, and the helper has moved AHEAD to generation 6 via a
+			// scheduler republish (recordApplyResultLocked was not called).
+			status: dpuserspace.ProcessStatus{
+				Enabled:                true,
+				ForwardingArmed:        true,
+				Capabilities:           dpuserspace.UserspaceCapabilities{ForwardingSupported: true},
+				LastSnapshotGeneration: 6,
+			},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := c.showEffectiveFirewallFilters(""); err != nil {
+			t.Fatalf("showEffectiveFirewallFilters() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Effective firewall filters — dataplane-acknowledged (generation 6).") {
+		t.Fatalf("output = %q, want live certification at the helper-ahead generation", out)
+	}
+	if strings.Contains(out, "WARNING") || strings.Contains(out, "COMPILED-DESIRED") {
+		t.Fatalf("output = %q, must NOT flag drift when the helper is at or ahead of the applied generation", out)
+	}
+	if !strings.Contains(out, "Filter: demo (family inet) [effective]") {
+		t.Fatalf("output = %q, want compiled snapshot body", out)
+	}
+}
+
 // TestShowEffectiveFirewallFiltersNoRuntime: with no dataplane runtime wired the
 // view cannot confirm the acknowledged generation, so it renders compiled-desired
 // under a soft note rather than falsely certifying it as live.

--- a/pkg/cli/cli_show_security_filters.go
+++ b/pkg/cli/cli_show_security_filters.go
@@ -336,15 +336,26 @@ func (c *CLI) showFirewallFilter(name, requestedFamily string) error {
 }
 
 // showEffectiveFirewallFilters renders the EFFECTIVE (compiled) firewall-filter
-// snapshots the userspace dataplane actually receives (#4422). Unlike
-// showFirewallFilters (which prints the raw typed config), this rebuilds the
-// FirewallFilterSnapshot the config compiler emits and prints the terms exactly
-// as the matcher enforces them: prefix-list references resolved to literal
-// prefixes, address/port `except` folded (positive-wins on a mixed term), DSCP
-// tokens resolved to numeric code points, TCP-flags lowered to required/
-// forbidden masks, `then next term` / modifier-only fall-through computed, and
-// any unrepresentable match marked fail-closed. It is read-only — it derives the
-// snapshot from the active config and never touches the dataplane.
+// snapshots for `show firewall effective` (#4422). Unlike showFirewallFilters
+// (which prints the raw typed config), this rebuilds the FirewallFilterSnapshot
+// the config compiler emits and prints the terms exactly as the matcher would
+// enforce them: prefix-list references resolved to literal prefixes, address/
+// port `except` folded (positive-wins on a mixed term), DSCP tokens resolved to
+// numeric code points, TCP-flags lowered to required/forbidden masks, `then next
+// term` / modifier-only fall-through computed, and any unrepresentable match
+// marked fail-closed. It is read-only — it derives the snapshot from the active
+// config and never touches the dataplane.
+//
+// #5067: the snapshots are compiled from ActiveConfig(), which commitAndApply
+// promotes via store.Commit() BEFORE applyAndSyncCommitted runs. A required-
+// protocol-gate apply error (applyErrSkipsPeerSync / compileErrorMustAbortApply,
+// pkg/daemon/daemon_apply.go) leaves the dataplane DISARMED while ActiveConfig is
+// already the new generation, so the compiled-desired snapshot is NOT what the
+// dataplane is enforcing. printFirewallEffectiveBanner binds the view to the
+// helper-acknowledged generation: it certifies the output as live only when the
+// dataplane is armed and the acknowledged generation matches the last applied
+// generation, and otherwise prints a prominent compiled-desired / drift banner
+// so the operator is not misled.
 func (c *CLI) showEffectiveFirewallFilters(family string) error {
 	cfg := c.store.ActiveConfig()
 	if cfg == nil {
@@ -357,20 +368,24 @@ func (c *CLI) showEffectiveFirewallFilters(family string) error {
 		return nil
 	}
 	snaps := dpuserspace.BuildFirewallFilterSnapshots(cfg)
-	rendered := 0
+	matched := make([]int, 0, len(snaps))
 	for i := range snaps {
 		if family != "" && snaps[i].Family != family {
 			continue
 		}
-		renderEffectiveFilterSnapshot(&snaps[i])
-		rendered++
+		matched = append(matched, i)
 	}
-	if rendered == 0 {
+	if len(matched) == 0 {
 		if family != "" {
 			fmt.Printf("No firewall filters configured (family %s)\n", family)
 		} else {
 			fmt.Println("No firewall filters configured")
 		}
+		return nil
+	}
+	c.printFirewallEffectiveBanner()
+	for _, i := range matched {
+		renderEffectiveFilterSnapshot(&snaps[i])
 	}
 	return nil
 }
@@ -390,7 +405,7 @@ func (c *CLI) showEffectiveFirewallFilter(name, family string) error {
 		return nil
 	}
 	snaps := dpuserspace.BuildFirewallFilterSnapshots(cfg)
-	found := false
+	matched := make([]int, 0, len(snaps))
 	for i := range snaps {
 		if snaps[i].Name != name {
 			continue
@@ -398,15 +413,20 @@ func (c *CLI) showEffectiveFirewallFilter(name, family string) error {
 		if family != "" && snaps[i].Family != family {
 			continue
 		}
-		renderEffectiveFilterSnapshot(&snaps[i])
-		found = true
+		matched = append(matched, i)
 	}
-	if !found {
+	if len(matched) == 0 {
 		if family != "" {
 			fmt.Printf("Filter not found: %s (family %s)\n", name, family)
 		} else {
 			fmt.Printf("Filter not found: %s\n", name)
 		}
+		return nil
+	}
+	// #5067: same generation-liveness caveat as the all-filters view.
+	c.printFirewallEffectiveBanner()
+	for _, i := range matched {
+		renderEffectiveFilterSnapshot(&snaps[i])
 	}
 	return nil
 }
@@ -417,4 +437,103 @@ func (c *CLI) showEffectiveFirewallFilter(name, family string) error {
 // emit byte-identical output.
 func renderEffectiveFilterSnapshot(snap *dpuserspace.FirewallFilterSnapshot) {
 	fmt.Print(dpuserspace.RenderFirewallFilterSnapshot(snap))
+}
+
+// firewallEffectiveLiveness records whether the compiled firewall-filter
+// snapshots rendered by the `effective` view are actually what the dataplane is
+// enforcing (#5067). The view derives its content from ActiveConfig(), but
+// commitAndApply promotes the active config via store.Commit() BEFORE
+// applyAndSyncCommitted runs the dataplane apply; a required-protocol-gate apply
+// error (applyErrSkipsPeerSync / compileErrorMustAbortApply) leaves the
+// dataplane DISARMED while ActiveConfig is already the new generation. This
+// binds the rendered content to the HELPER-ACKNOWLEDGED generation instead of
+// blindly certifying the promoted config as live.
+type firewallEffectiveLiveness struct {
+	// determined is true when a dataplane runtime is loaded AND its helper
+	// status was obtained — i.e. we can actually compare the acknowledged
+	// generation against the last applied generation. When false (no runtime,
+	// or status unavailable) the view is compiled-desired that we cannot
+	// confirm is live.
+	determined bool
+	// live is true only when the dataplane is armed AND the helper-acknowledged
+	// snapshot generation matches the daemon's last successfully-applied
+	// generation — the only state in which the compiled snapshots equal what
+	// the dataplane is enforcing.
+	live bool
+	// appliedGen is the daemon's last successfully-recorded apply generation
+	// (0 when no apply has ever been recorded).
+	appliedGen uint64
+	// ackedGen is the generation the userspace helper reports it has applied
+	// (status.LastSnapshotGeneration).
+	ackedGen uint64
+	// reason explains why the view is not live (disarmed / generation drift).
+	reason string
+}
+
+// firewallEffectiveLiveness inspects the dataplane apply-result and userspace
+// helper status to decide whether the `effective` firewall view can be
+// certified as dataplane-acknowledged (#5067).
+func (c *CLI) firewallEffectiveLiveness() firewallEffectiveLiveness {
+	var v firewallEffectiveLiveness
+	if !c.dataplaneLoaded() {
+		return v // undetermined: no runtime to confirm against
+	}
+	status, err := c.userspaceDataplaneStatus()
+	if err != nil {
+		return v // undetermined: helper status unavailable
+	}
+	v.determined = true
+	v.ackedGen = status.LastSnapshotGeneration
+	cr := c.applyResult()
+	if cr != nil {
+		v.appliedGen = cr.Generation
+	}
+	// Armed requires the helper to be enabled + forwarding-armed with forwarding
+	// supported, AND a recorded apply that itself reported forwarding supported.
+	// A required-protocol-gate disarm sets ForwardingArmed=false without
+	// advancing the recorded apply result, so this is false in the #5067 window.
+	armed := status.Enabled && status.ForwardingArmed &&
+		status.Capabilities.ForwardingSupported &&
+		cr != nil && cr.Capabilities.ForwardingSupported
+	// Coherent requires the helper's acknowledged generation to equal the
+	// daemon's last successfully-applied generation. Divergence means the helper
+	// has not caught up to (or rejected) the active configuration.
+	coherent := cr != nil && status.LastSnapshotGeneration == cr.Generation
+	switch {
+	case !armed:
+		v.reason = "dataplane disarmed (forwarding not armed)"
+	case !coherent:
+		v.reason = "dataplane generation drift (helper has not acknowledged the active configuration)"
+	default:
+		v.live = true
+	}
+	return v
+}
+
+// printFirewallEffectiveBanner prints the generation-liveness context for the
+// `effective` firewall-filter view (#5067) BEFORE the compiled snapshots, so an
+// operator is never misled into reading a compiled-desired-but-unapplied config
+// as what the dataplane is enforcing.
+func (c *CLI) printFirewallEffectiveBanner() {
+	v := c.firewallEffectiveLiveness()
+	switch {
+	case !v.determined:
+		fmt.Println("Note: dataplane status unavailable — the firewall filters below are")
+		fmt.Println("  compiled-desired; the dataplane's acknowledged generation could not be")
+		fmt.Println("  confirmed.")
+		fmt.Println()
+	case v.live:
+		fmt.Printf("Effective firewall filters — dataplane-acknowledged (generation %d).\n\n", v.ackedGen)
+	default:
+		fmt.Println("WARNING: dataplane is NOT enforcing the active configuration.")
+		fmt.Println("  The firewall filters below are COMPILED-DESIRED (what the active")
+		fmt.Println("  configuration compiles to), NOT what the dataplane is enforcing.")
+		fmt.Printf("  Reason: %s.\n", v.reason)
+		fmt.Printf("  Last dataplane-acknowledged generation: %d.\n", v.ackedGen)
+		if v.appliedGen != v.ackedGen {
+			fmt.Printf("  Last daemon-applied generation: %d.\n", v.appliedGen)
+		}
+		fmt.Println("  Desired: active configuration (not acknowledged).")
+		fmt.Println()
+	}
 }

--- a/pkg/cli/cli_show_security_filters.go
+++ b/pkg/cli/cli_show_security_filters.go
@@ -456,9 +456,10 @@ type firewallEffectiveLiveness struct {
 	// confirm is live.
 	determined bool
 	// live is true only when the dataplane is armed AND the helper-acknowledged
-	// snapshot generation matches the daemon's last successfully-applied
-	// generation — the only state in which the compiled snapshots equal what
-	// the dataplane is enforcing.
+	// snapshot generation is at or ahead of the daemon's last successfully-
+	// applied generation — the state in which the compiled snapshots equal what
+	// the dataplane is enforcing. (Helper-ahead is benign; see
+	// firewallEffectiveLiveness.)
 	live bool
 	// appliedGen is the daemon's last successfully-recorded apply generation
 	// (0 when no apply has ever been recorded).
@@ -495,15 +496,24 @@ func (c *CLI) firewallEffectiveLiveness() firewallEffectiveLiveness {
 	armed := status.Enabled && status.ForwardingArmed &&
 		status.Capabilities.ForwardingSupported &&
 		cr != nil && cr.Capabilities.ForwardingSupported
-	// Coherent requires the helper's acknowledged generation to equal the
-	// daemon's last successfully-applied generation. Divergence means the helper
-	// has not caught up to (or rejected) the active configuration.
-	coherent := cr != nil && status.LastSnapshotGeneration == cr.Generation
+	// Coherent requires the helper's acknowledged generation to be AT OR AHEAD
+	// of the daemon's last successfully-applied generation. Helper-BEHIND
+	// (acked < applied) is real drift — the helper has not caught up to (or
+	// rejected) the applied configuration. Helper-AHEAD (acked > applied) is
+	// BENIGN: a scheduler-only republish (Manager.UpdatePolicyScheduleState)
+	// advances the helper's snapshot generation WITHOUT calling
+	// recordApplyResultLocked, so LastApplyResult().Generation lags the helper
+	// on a perfectly healthy box. That republish only re-times policy
+	// enable/disable — it carries the SAME filter content — so the effective
+	// view is still live. The genuine #5067 disarm is caught by the `armed`
+	// predicate (ForwardingArmed=false) independent of this compare, so
+	// accepting helper-ahead does not weaken the original fix.
+	coherent := cr != nil && status.LastSnapshotGeneration >= cr.Generation
 	switch {
 	case !armed:
 		v.reason = "dataplane disarmed (forwarding not armed)"
 	case !coherent:
-		v.reason = "dataplane generation drift (helper has not acknowledged the active configuration)"
+		v.reason = "dataplane generation drift (helper is behind the applied configuration)"
 	default:
 		v.live = true
 	}


### PR DESCRIPTION
## Problem

`showEffectiveFirewallFilters` (`pkg/cli/cli_show_security_filters.go`) compiled
its snapshots from `c.store.ActiveConfig()` and labeled them as what "the
dataplane actually receives" — but never consulted the applied/acknowledged
generation. That certification is reachable-false:

- `commitAndApply` promotes the active config via `store.Commit()` **before**
  `applyAndSyncCommitted` runs the dataplane apply.
- A required-protocol-gate apply error (`applyErrSkipsPeerSync` /
  `compileErrorMustAbortApply`, `pkg/daemon/daemon_apply.go:255-266`) leaves the
  dataplane **DISARMED** (fail-closed) while `ActiveConfig` is already the new
  generation B and the last recorded apply is still the previously-live gen.

The `effective` view then falsely presented the promoted-but-unapplied config B
as live.

## Invariant

An "effective" view must bind rendered content to the **helper-acknowledged
generation**, or be clearly labeled compiled-desired and flag the drift.

## Fix (display-only)

- New `firewallEffectiveLiveness` inspects `c.applyResult()` (`ApplyResult.Generation`
  + `Capabilities.ForwardingSupported`) and the userspace helper `Status()`
  (`ForwardingArmed` / `Enabled` / `Capabilities.ForwardingSupported` /
  `LastSnapshotGeneration`). The view is certified live **only** when the
  dataplane is armed AND the acknowledged snapshot generation equals the
  daemon's last applied generation.
- `printFirewallEffectiveBanner` prints, before the compiled snapshots:
  - **armed + acknowledged** → `Effective firewall filters — dataplane-acknowledged (generation N).`
  - **disarmed / generation drift** → a prominent `WARNING: dataplane is NOT enforcing the active configuration.` banner labeling the output `COMPILED-DESIRED`, stating the reason, and surfacing the last acknowledged generation vs the desired (active, not-acknowledged) configuration. Snapshots are still printed under the banner so the desired compile is inspectable, but never certified as live.
  - **no runtime wired** → a soft note that the acknowledged generation could not be confirmed.
- Applied to both the all-filters and single-filter forms.
- **No** change to the apply/commit/sync mechanism; **no** per-generation
  snapshot-persistence layer (rendering the last successfully-applied snapshot
  would require one — noted as follow-up).

## Scope / follow-ups

- The remote CLI's gRPC `ShowText` path (`pkg/grpcapi/server_show_firewall.go`)
  renders the same compiled snapshots without the liveness banner; extending the
  context there is a follow-up (out of scope for this display fix).
- Persisting per-generation filter snapshots so the *last successfully applied*
  content could be rendered (instead of compiled-desired + banner) is a larger,
  separate change.

## Tests (RED-on-revert proven)

`pkg/cli/cli_show_effective_filter_gen_5067_test.go`:
- `...ArmedAcknowledged` — armed + coherent → renders, certified, no banner.
- `...DisarmedDrift` — ActiveConfig promoted to B, dataplane disarmed, last apply gen 5 → COMPILED-DESIRED disarmed banner, acked-vs-desired surfaced, **not** certified.
- `...GenerationDrift` — armed but helper acked gen lags applied gen → drift banner surfaces both generations.
- `...NoRuntime` — no dp wired → soft compiled-desired note.

RED-on-revert: with the production change stashed (tests kept), the disarmed +
drift tests FAIL — the compiled snapshot is presented as effective with no
banner. Restored → all green. `go build ./...` and `go test ./pkg/cli/...` green.

Docs: `docs/junos-cli-reference.md` gains a "Generation-liveness banner (#5067)"
section.

Closes #5067

🤖 Generated with [Claude Code](https://claude.com/claude-code)