### PR TITLE
pkg/routing: fail the commit closed on genuine tunnel reconcile errors (#5355)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45139,3 +45139,7 @@ top.
   chaining" section + first-hop-only Option 82 gotcha.
 - **File(s)**: pkg/dhcprelay/relay.go,
   pkg/dhcprelay/relay_chain_5071_test.go, pkg/dhcprelay/README.md, _Log.md
+
+- **Timestamp**: 2026-07-10 (fix/5355-tunnel-apply-failclosed)
+  - **Action**: #5355 fail-closed on genuine GRE/tunnel reconcile errors — mirror #5310 xfrmManager.Apply. tunnelManager.Apply now aggregates genuine create/find/up/delete failures via errors.Join and returns them (was unconditional `return nil`); helpers applyAnchorLocked/applyKernelTunnelLocked/finishTunnelLocked return errors; applyWireguardTunLocked surfaces its LinkSetUp failure. Idempotency preserved (adopt-existing, tolerate-already-gone, defer-on-transient). New RED-on-revert tests + daemon-boundary tunnel case; README fail-closed note.
+  - **File(s)**: pkg/routing/tunnel.go, pkg/routing/tunnel_apply_failclosed_5355_test.go, pkg/routing/tunnel_reconcile_test.go, pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go, pkg/routing/README.md

--- a/pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go
+++ b/pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go
@@ -141,6 +141,45 @@ func TestApplyInterfaceReconcileSurfacesBondFailure(t *testing.T) {
 	}
 }
 
+// TestApplyInterfaceReconcileSurfacesTunnelFailure proves the tunnel sub-stage
+// is aggregated too (#5355): a genuine GRE/anchor tunnel LinkAdd failure makes
+// applyInterfaceReconcile return non-nil. Before #5355 tunnelManager.Apply
+// logged every per-tunnel create/up/delete failure and returned nil
+// UNCONDITIONALLY, so even though the #5354 tail-join already threaded
+// ApplyTunnels, there was never an error to surface — the commit reported
+// success while the tunnel interface was absent (fail-open false convergence).
+//
+// FAIL-ON-REVERT: restore tunnelManager.Apply's unconditional `return nil` and
+// this goes RED (applyInterfaceReconcile returns nil despite the tunnel create
+// having failed).
+func TestApplyInterfaceReconcileSurfacesTunnelFailure(t *testing.T) {
+	ops := newReconcileFakeLinkOps()
+	injected := errors.New("injected: tunnel LinkAdd EPERM")
+	ops.addFail["gr-0-0-0"] = injected
+
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"gr-0/0/0": {
+			Name: "gr-0/0/0",
+			Tunnel: &config.TunnelConfig{
+				Name:        "gr-0-0-0",
+				Source:      "10.0.0.1",
+				Destination: "10.0.0.2",
+			},
+		},
+	}
+
+	d := &Daemon{routing: routing.NewManagerWithLinkOpsForTest(ops)}
+	err := d.applyInterfaceReconcile(cfg)
+	if err == nil {
+		t.Fatal("applyInterfaceReconcile must surface the tunnel create failure " +
+			"(fail-closed #5355); got nil")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("returned error must wrap the injected tunnel failure, got %v", err)
+	}
+}
+
 // TestApplyInterfaceReconcileToleratesIdempotent proves a benign reconcile does
 // NOT fail the commit: the xfrmi already exists with the matching if_id (adopt
 // path) and every other sub-stage is a no-op, so applyInterfaceReconcile returns

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -483,6 +483,28 @@ when the existing kernel link is genuinely incompatible:
   the anchor path unconditionally stopped the runner, so a configured
   keepalive was accepted-but-inert on the only production dataplane.
 
+**Fail-closed on genuine create/up/delete failure (#5355).** Like
+`xfrmManager.Apply` before #5310, `tunnelManager.Apply` used to log every
+per-tunnel `LinkAdd` / `LinkSetUp` / `LinkDel` failure and return `nil`
+**unconditionally**, so a GRE/anchor/WireGuard tunnel that could not be
+realized in the kernel reported a **successful commit** while the interface
+was absent (or admin-DOWN, or a removed tunnel's device lingered) —
+fail-open false convergence. `Apply` now accumulates the **genuine**
+failures with `errors.Join` and returns them so the #5354
+`applyInterfaceReconcile` tail-join fails the commit closed. The apply
+helpers (`applyAnchorLocked` / `applyKernelTunnelLocked` /
+`applyWireguardTunLocked`) and the shared `finishTunnelLocked` tail return
+the create / replace-delete / bring-up error; the removal diff aggregates a
+removed tunnel's `LinkDel` failure. The tolerated idempotent conditions
+stay **non-errors**: a still-present compatible anchor is adopted in place
+(reuse, not a `LinkAdd`), a delete of an already-gone tunnel is a no-op
+(`isLinkNotFound`), and a **transient** `LinkByName` lookup only defers the
+reconcile (retain + retry, no error — the device state is unknown, not
+proven-broken). Config-parse issues (invalid endpoints) stay warn-only.
+Address / MTU / VRF-claim reconcile failures are NOT folded into the
+fail-closed signal — they retain+retry their own state (above) and are out
+of scope, matching #5310's create/find/up/delete boundary.
+
 ## Keepalive liveness probing (`tunnel_keepalive.go`, #1918)
 
 The keepalive performs a **real ICMP echo round-trip** — it is a

--- a/pkg/routing/tunnel.go
+++ b/pkg/routing/tunnel.go
@@ -291,6 +291,20 @@ func (t *tunnelManager) Apply(tunnels []*config.TunnelConfig) error {
 	defer t.mu.Unlock()
 	t.ensureReconcileStateLocked()
 
+	// errs accumulates GENUINE reconcile failures (a removed tunnel's
+	// LinkDel, and each per-tunnel apply's create/find/up/delete) so the
+	// commit fails closed (#5355, sibling of the #5310 xfrmManager fix).
+	// Before this Apply logged every such failure and returned nil
+	// UNCONDITIONALLY — a GRE/tunnel LinkAdd/LinkSetUp/LinkDel failure
+	// reported a SUCCESSFUL commit while the interface was absent (fail-open
+	// false convergence). Tolerated idempotent conditions never append: a
+	// still-present compatible tunnel is adopted in place (reuse, not a
+	// LinkAdd), a delete of an already-gone tunnel is a no-op, and a
+	// TRANSIENT lookup that only defers the reconcile retains+retries
+	// without erroring. The #5354 tail-join in applyInterfaceReconcile
+	// surfaces the returned error into the commit result.
+	var errs []error
+
 	desired := make(map[string]bool, len(tunnels))
 	wgDesired := map[string]bool{}
 	for _, tc := range tunnels {
@@ -351,6 +365,10 @@ func (t *tunnelManager) Apply(tunnels []*config.TunnelConfig) error {
 				slog.Warn("failed to delete removed tunnel",
 					"name", name, "err", delErr)
 				next[name] = true // retain ownership; retry next apply
+				// #5355: a genuine LinkDel failure leaves the removed
+				// tunnel's device (and its addresses) live in the kernel —
+				// fail the commit closed rather than report a clean removal.
+				errs = append(errs, fmt.Errorf("delete removed tunnel %s: %w", name, delErr))
 				continue
 			}
 			slog.Info("tunnel removed", "name", name)
@@ -461,6 +479,10 @@ func (t *tunnelManager) Apply(tunnels []*config.TunnelConfig) error {
 			if err := t.applyWireguardTunLocked(tc); err != nil {
 				slog.Warn("failed to apply wireguard tunnel",
 					"name", tc.Name, "err", err)
+				// #5355: surface the WG create/replace/bring-up failure so
+				// the commit fails closed; the sentinel-driven ownedNames
+				// re-retain below is orthogonal to the aggregation.
+				errs = append(errs, fmt.Errorf("apply wireguard tunnel %s: %w", tc.Name, err))
 				// Re-retain ownedNames ONLY when a stale NON-WG link remains
 				// under this name (incompatible same-name link whose
 				// replacement LinkDel failed — errWGIncompatibleLinkRetained).
@@ -487,13 +509,17 @@ func (t *tunnelManager) Apply(tunnels []*config.TunnelConfig) error {
 		// BOTH the plain-reuse and the LinkAdd-EEXIST paths.
 		adopting := !oldOwned[tc.Name]
 		if tc.AnchorOnly {
-			t.applyAnchorLocked(tc, adopting)
+			if err := t.applyAnchorLocked(tc, adopting); err != nil {
+				errs = append(errs, err)
+			}
 			continue
 		}
-		t.applyKernelTunnelLocked(tc)
+		if err := t.applyKernelTunnelLocked(tc); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // anchorReusable reports whether an existing link can serve as the
@@ -529,7 +555,13 @@ func anchorReusable(link netlink.Link) bool {
 // exactly like applyKernelTunnelLocked: an unchanged runner is retained
 // across applies (probe state survives commits), restarted on a config
 // change, and stopped when keepalive is removed.
-func (t *tunnelManager) applyAnchorLocked(tc *config.TunnelConfig, adopting bool) {
+//
+// #5355: returns a non-nil error on a GENUINE reconcile failure (the
+// replace LinkDel, the create LinkAdd, or the finishTunnelLocked
+// LinkSetUp) so Apply can aggregate it and fail the commit closed —
+// mirroring xfrmManager.Apply (#5310). A plain reuse/adopt of an
+// already-present compatible anchor is NOT a failure and returns nil.
+func (t *tunnelManager) applyAnchorLocked(tc *config.TunnelConfig, adopting bool) error {
 	// Drain-before-recreate + linkGen bump (#1918 §6 Axis D F7, ported to
 	// the anchor path in #4071). Decide up front whether this apply will
 	// recreate the anchor TUN. If so, CANCEL + DRAIN any existing keepalive
@@ -567,7 +599,7 @@ func (t *tunnelManager) applyAnchorLocked(tc *config.TunnelConfig, adopting bool
 			if delErr := t.ops.LinkDel(existing); delErr != nil {
 				slog.Warn("failed to replace tunnel anchor",
 					"name", tc.Name, "err", delErr)
-				return
+				return fmt.Errorf("replace tunnel anchor %s: %w", tc.Name, delErr)
 			}
 		}
 	}
@@ -589,7 +621,7 @@ func (t *tunnelManager) applyAnchorLocked(tc *config.TunnelConfig, adopting bool
 			if lkErr != nil || !anchorReusable(existingAdopt) {
 				slog.Warn("failed to create tunnel anchor",
 					"name", tc.Name, "err", addErr)
-				return
+				return fmt.Errorf("create tunnel anchor %s: %w", tc.Name, addErr)
 			}
 			slog.Info("tunnel anchor already exists as TUN, reusing",
 				"name", tc.Name)
@@ -650,7 +682,7 @@ func (t *tunnelManager) applyAnchorLocked(tc *config.TunnelConfig, adopting bool
 		runner.state.mu.Unlock()
 	}
 
-	t.finishTunnelLocked(tc, link, skipUp, "tunnel anchor")
+	finishErr := t.finishTunnelLocked(tc, link, skipUp, "tunnel anchor")
 
 	if tc.Keepalive > 0 {
 		if restartKA {
@@ -662,6 +694,7 @@ func (t *tunnelManager) applyAnchorLocked(tc *config.TunnelConfig, adopting bool
 	} else if hasRunner {
 		t.stopKeepaliveLocked(tc.Name)
 	}
+	return finishErr
 }
 
 // reconcileAnchorMTULocked applies the #1884 MTU ownership rule to a
@@ -780,13 +813,20 @@ func legacyTunnelMatches(existing, desired netlink.Link) bool {
 // path (the daemon always sets AnchorOnly). Compare-then-decide:
 // identical config-driven attrs reuse the device in place; any real
 // change is a legitimate delete+recreate. Caller MUST hold mu.
-func (t *tunnelManager) applyKernelTunnelLocked(tc *config.TunnelConfig) {
+//
+// #5355: returns a non-nil error on a GENUINE reconcile failure (the
+// replace LinkDel, the create LinkAdd, or the finishTunnelLocked
+// LinkSetUp) so Apply can aggregate it and fail the commit closed. An
+// invalid-endpoint config or a TRANSIENT lookup deferral is NOT a
+// fail-closed condition — the former is a config error (warn), the
+// latter self-heals on the next apply — so both return nil.
+func (t *tunnelManager) applyKernelTunnelLocked(tc *config.TunnelConfig) error {
 	localIP := net.ParseIP(tc.Source)
 	remoteIP := net.ParseIP(tc.Destination)
 	if localIP == nil || remoteIP == nil {
 		slog.Warn("invalid tunnel endpoints",
 			"name", tc.Name, "src", tc.Source, "dst", tc.Destination)
-		return
+		return nil
 	}
 
 	ttl := tc.TTL
@@ -824,10 +864,12 @@ func (t *tunnelManager) applyKernelTunnelLocked(tc *config.TunnelConfig) {
 		willRecreate = true
 	default:
 		// Transient lookup error: leave the runner and any live link
-		// untouched; retry on the next apply.
+		// untouched; retry on the next apply. Not a fail-closed condition
+		// (#5355) — the device state is unknown, not proven-broken, and
+		// the next apply reconciles it.
 		slog.Warn("tunnel lookup failed transiently; deferring apply",
 			"name", tc.Name, "err", lookupErr)
-		return
+		return nil
 	}
 	if willRecreate {
 		// Drain the stale runner first; bump the generation so any runner
@@ -857,7 +899,7 @@ func (t *tunnelManager) applyKernelTunnelLocked(tc *config.TunnelConfig) {
 				if tc.Keepalive > 0 {
 					t.startKeepalive(tc.Name, tc.Source, tc.Destination, tc.Keepalive, tc.KeepaliveRetry)
 				}
-				return
+				return fmt.Errorf("replace tunnel %s: %w", tc.Name, delErr)
 			}
 			slog.Info("replaced tunnel link with changed parameters",
 				"name", tc.Name, "existing_type", existing.Type())
@@ -867,7 +909,7 @@ func (t *tunnelManager) applyKernelTunnelLocked(tc *config.TunnelConfig) {
 		if addErr := t.ops.LinkAdd(desired); addErr != nil {
 			slog.Warn("failed to create tunnel",
 				"name", tc.Name, "mode", tc.Mode, "err", addErr)
-			return
+			return fmt.Errorf("create tunnel %s: %w", tc.Name, addErr)
 		}
 		link = desired
 		created = true
@@ -928,7 +970,7 @@ func (t *tunnelManager) applyKernelTunnelLocked(tc *config.TunnelConfig) {
 		runner.state.mu.Unlock()
 	}
 
-	t.finishTunnelLocked(tc, link, skipUp, "tunnel")
+	finishErr := t.finishTunnelLocked(tc, link, skipUp, "tunnel")
 
 	if tc.Keepalive > 0 {
 		if restartKA {
@@ -940,23 +982,36 @@ func (t *tunnelManager) applyKernelTunnelLocked(tc *config.TunnelConfig) {
 	} else if hasRunner {
 		t.stopKeepaliveLocked(tc.Name)
 	}
+	return finishErr
 }
 
 // finishTunnelLocked is the shared apply tail: admin-up (unless a
 // retained keepalive runner holds the tunnel down), symmetric address
 // reconciliation, VRF claim reconcile, and success tracking. Caller
 // MUST hold mu; link is the kernel-fetched (or just-created) device.
-func (t *tunnelManager) finishTunnelLocked(tc *config.TunnelConfig, link netlink.Link, skipUp bool, kind string) {
+//
+// It returns a non-nil error only on a GENUINE bring-up failure (#5355):
+// a LinkSetUp that fails leaves the tunnel device present but admin-DOWN,
+// so the commit must fail closed rather than report a converged tunnel
+// that carries no traffic. Address/VRF reconcile still run best-effort
+// (they retain+retry their own state on transient failure) and are NOT
+// folded into the fail-closed signal — matching the xfrmManager.Apply
+// scope (#5310), which surfaces only create/find/up/delete link
+// failures.
+func (t *tunnelManager) finishTunnelLocked(tc *config.TunnelConfig, link netlink.Link, skipUp bool, kind string) error {
+	var upErr error
 	if skipUp {
 		slog.Debug("skipping link up: keepalive holds tunnel down",
 			"name", tc.Name)
 	} else if err := t.ops.LinkSetUp(link); err != nil {
 		slog.Warn("failed to bring up "+kind, "name", tc.Name, "err", err)
+		upErr = fmt.Errorf("bring up %s %s: %w", kind, tc.Name, err)
 	}
 	t.appliedAddrs[tc.Name] = t.reconcileLinkAddrsLocked(
 		link, tc.Name, tc.Addresses, t.appliedAddrs[tc.Name], kind)
 	t.reconcileVRFClaimLocked(tc, link)
 	t.tunnels = append(t.tunnels, tc.Name)
+	return upErr
 }
 
 // reconcileLinkAddrsLocked symmetrically reconciles a link's addresses
@@ -1444,8 +1499,16 @@ func (t *tunnelManager) applyWireguardTunLocked(tc *config.TunnelConfig) error {
 		slog.Debug("wireguard tun reused", "name", tc.Name)
 	}
 
+	// #5355: a genuine bring-up failure on the persistent wgN device
+	// leaves it admin-DOWN, so surface it (fail closed) — but still run
+	// the address/VRF reconcile best-effort below and return the error at
+	// the tail. A plain LinkSetUp error is NOT the incompatible-link
+	// sentinel, so Apply's errWGIncompatibleLinkRetained branch stays a
+	// no-op and the healthy persistent link is not re-tracked.
+	var upErr error
 	if err := t.ops.LinkSetUp(link); err != nil {
 		slog.Warn("failed to bring up wireguard tun", "name", tc.Name, "err", err)
+		upErr = fmt.Errorf("bring up wireguard tun %s: %w", tc.Name, err)
 	}
 
 	// Symmetric address reconciliation (Copilot C5): because the device
@@ -1474,7 +1537,7 @@ func (t *tunnelManager) applyWireguardTunLocked(tc *config.TunnelConfig) error {
 	// in Apply, which shares unbindVRFClaimLocked. The wgN link is kept
 	// (S2a) but is no longer left enslaved to a stale VRF.
 	t.reconcileVRFClaimLocked(tc, link)
-	return nil
+	return upErr
 }
 
 // closeTuntapFiles closes the file descriptors returned by a Tuntap

--- a/pkg/routing/tunnel_apply_failclosed_5355_test.go
+++ b/pkg/routing/tunnel_apply_failclosed_5355_test.go
@@ -1,0 +1,180 @@
+package routing
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5355: tunnelManager.Apply used to log every per-tunnel create /
+// bring-up / delete failure and return nil UNCONDITIONALLY. A GRE/tunnel
+// LinkAdd / LinkSetUp / LinkDel that genuinely failed therefore reported a
+// SUCCESSFUL commit while the interface was absent (or admin-DOWN, or a
+// removed tunnel's device lingered) — the same fail-open false-convergence
+// that #5310 fixed for the xfrmManager. Apply now aggregates the GENUINE
+// netlink failures with errors.Join and returns them so the #5354
+// applyInterfaceReconcile tail-join fails the commit closed. The tolerated
+// idempotent conditions (adopt an already-present compatible anchor, delete
+// an already-gone tunnel) stay non-errors.
+//
+// Each fail-closed test is RED-on-revert: restoring the pre-#5355
+// unconditional `return nil` in Apply (and the void helper signatures)
+// makes the "want non-nil" assertions fail — the exact silent fail-open the
+// issue describes. The two idempotency tests are GREEN both before and
+// after the fix and pin the behavior the fix must not break.
+
+// TestTunnelApplyFailsClosedOnGenuineCreateFailure is the core #5355 guard:
+// a genuine (non-EEXIST) LinkAdd failure on a newly-desired anchor makes
+// Apply return a non-nil error that names the tunnel and wraps the netlink
+// error.
+func TestTunnelApplyFailsClosedOnGenuineCreateFailure(t *testing.T) {
+	ops := newFakeLinkOps()
+	injected := errors.New("injected: anchor LinkAdd EPERM")
+	ops.addFail["gr-0-0-0"] = injected
+	tm, _ := newReconcileManager(ops)
+
+	err := tm.Apply([]*config.TunnelConfig{anchorTC("gr-0-0-0")})
+	if err == nil {
+		t.Fatal("Apply must return the anchor create failure (fail-closed); got nil " +
+			"(the silent fail-open #5355 describes: a commit reports success while " +
+			"the tunnel interface never made it into the kernel)")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("returned error must wrap the injected netlink failure, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "gr-0-0-0") {
+		t.Errorf("returned error should name the failed tunnel, got %v", err)
+	}
+}
+
+// TestTunnelApplyFailsClosedOnBringUpFailure covers the create→bring-up
+// path: the LinkAdd succeeds but LinkSetUp on the freshly-created anchor
+// fails. Apply must surface that genuine bring-up failure (the device is
+// present but admin-DOWN — no traffic).
+func TestTunnelApplyFailsClosedOnBringUpFailure(t *testing.T) {
+	ops := newFakeLinkOps()
+	injected := errors.New("injected: LinkSetUp ENETDOWN")
+	ops.upFail["gr-0-0-0"] = injected
+	tm, _ := newReconcileManager(ops)
+
+	err := tm.Apply([]*config.TunnelConfig{anchorTC("gr-0-0-0")})
+	if err == nil {
+		t.Fatal("Apply must surface the anchor bring-up failure (fail-closed); got nil")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("returned error must wrap the injected bring-up failure, got %v", err)
+	}
+}
+
+// TestTunnelApplyFailsClosedOnRemovalDeleteFailure covers the removal diff:
+// a tunnel dropped from config whose device is still present but whose
+// LinkDel genuinely fails must fail the commit closed — the removed
+// tunnel's interface (and its addresses) linger live in the kernel.
+// Ownership is still retained so the next apply retries (existing #1884
+// behavior, exercised by TestTunnelRemovalRetriedAfterFailedDelete).
+func TestTunnelApplyFailsClosedOnRemovalDeleteFailure(t *testing.T) {
+	ops := newFakeLinkOps()
+	tm, _ := newReconcileManager(ops)
+
+	if err := tm.Apply([]*config.TunnelConfig{anchorTC("gr-0-0-0")}); err != nil {
+		t.Fatalf("seed apply (create + own): %v", err)
+	}
+
+	injected := errors.New("injected: LinkDel EBUSY")
+	ops.delFail["gr-0-0-0"] = injected
+	err := tm.Apply(nil) // remove from config
+	if err == nil {
+		t.Fatal("Apply must surface the removed-tunnel LinkDel failure (fail-closed); got nil")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("returned error must wrap the injected LinkDel failure, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "gr-0-0-0") {
+		t.Errorf("returned error should name the failed tunnel, got %v", err)
+	}
+}
+
+// TestTunnelApplyToleratesAdoptIdempotent proves the idempotency the fix
+// must preserve: an anchor TUN that already exists in the kernel and is
+// reusable is ADOPTED in place (reused + brought up, zero LinkAdd/LinkDel)
+// and Apply returns nil — a benign re-apply (unrelated commit; daemon
+// restart adopt) must NOT be turned into a commit failure. GREEN both
+// before and after the fix.
+func TestTunnelApplyToleratesAdoptIdempotent(t *testing.T) {
+	ops := newFakeLinkOps()
+	seedAnchor(ops, "gr-0-0-0", 42, 1500) // reusable NO_PI persistent TUN
+	tm, _ := newReconcileManager(ops)
+
+	if err := tm.Apply([]*config.TunnelConfig{anchorTC("gr-0-0-0")}); err != nil {
+		t.Fatalf("adopt of an already-present reusable anchor must be a no-error "+
+			"idempotent reconcile, got %v", err)
+	}
+	if ops.addCount != 0 {
+		t.Errorf("adopt path must issue zero LinkAdd, got %d", ops.addCount)
+	}
+	if len(ops.delNames) != 0 {
+		t.Errorf("adopt path must issue zero LinkDel, got %v", ops.delNames)
+	}
+}
+
+// TestTunnelApplyToleratesAlreadyGoneDelete proves the removal-side
+// idempotency: a tunnel dropped from config whose device is ALREADY GONE
+// from the kernel (manual `ip link del`, or a prior successful removal) is
+// a tolerated no-op — Apply returns nil, not a delete error. GREEN both
+// before and after the fix.
+func TestTunnelApplyToleratesAlreadyGoneDelete(t *testing.T) {
+	ops := newFakeLinkOps()
+	tm, _ := newReconcileManager(ops)
+
+	if err := tm.Apply([]*config.TunnelConfig{anchorTC("gr-0-0-0")}); err != nil {
+		t.Fatalf("seed apply (create + own): %v", err)
+	}
+	// Device vanishes out-of-band; LinkByName now reports not-found.
+	delete(ops.links, "gr-0-0-0")
+
+	if err := tm.Apply(nil); err != nil {
+		t.Fatalf("removal of an already-gone tunnel must be a tolerated no-op, got %v", err)
+	}
+}
+
+// TestTunnelApplyAggregatesMultipleFailures proves errors.Join accumulates
+// EVERY genuine per-tunnel failure in one Apply — a partial failure does
+// not mask the others, and all are surfaced to the commit.
+func TestTunnelApplyAggregatesMultipleFailures(t *testing.T) {
+	ops := newFakeLinkOps()
+	inj0 := errors.New("injected: LinkAdd gr-0-0-0")
+	inj1 := errors.New("injected: LinkAdd gr-0-0-1")
+	ops.addFail["gr-0-0-0"] = inj0
+	ops.addFail["gr-0-0-1"] = inj1
+	tm, _ := newReconcileManager(ops)
+
+	err := tm.Apply([]*config.TunnelConfig{anchorTC("gr-0-0-0"), anchorTC("gr-0-0-1")})
+	if err == nil {
+		t.Fatal("Apply must surface both create failures (fail-closed); got nil")
+	}
+	if !errors.Is(err, inj0) || !errors.Is(err, inj1) {
+		t.Fatalf("errors.Join must aggregate BOTH create failures, got %v", err)
+	}
+}
+
+// TestManagerApplyTunnelsSurfacesCreateFailure proves the *Manager façade
+// (ApplyTunnels -> tunnel.Apply) propagates the tunnel create failure —
+// this is the exact boundary daemon_apply.go's applyInterfaceReconcile
+// calls (#5354), so the error must not be dropped in the delegation.
+func TestManagerApplyTunnelsSurfacesCreateFailure(t *testing.T) {
+	ops := newFakeLinkOps()
+	injected := errors.New("injected: anchor LinkAdd ENOBUFS")
+	ops.addFail["gr-0-0-0"] = injected
+	binder := &fakeVRFBinder{ops: ops, fail: map[string]error{}}
+	m := &Manager{tunnel: &tunnelManager{
+		ops:        ops,
+		vrfBinder:  binder,
+		keepalives: map[string]*keepaliveRunner{},
+	}}
+
+	if err := m.ApplyTunnels([]*config.TunnelConfig{anchorTC("gr-0-0-0")}); err == nil || !errors.Is(err, injected) {
+		t.Fatalf("Manager.ApplyTunnels must propagate the tunnel create failure, got %v", err)
+	}
+}

--- a/pkg/routing/tunnel_reconcile_test.go
+++ b/pkg/routing/tunnel_reconcile_test.go
@@ -253,9 +253,12 @@ func TestTunnelRemovalRetriedAfterFailedDelete(t *testing.T) {
 		t.Fatalf("Apply 1: %v", err)
 	}
 
+	// #5355: the removed tunnel's LinkDel failure is now SURFACED
+	// (fail-closed) instead of swallowed, but ownership is still retained
+	// so the next apply retries — the subject of this test.
 	ops.delFail["gr-0-0-1"] = errors.New("EBUSY")
-	if err := tm.Apply(both[:1]); err != nil {
-		t.Fatalf("Apply 2: %v", err)
+	if err := tm.Apply(both[:1]); err == nil {
+		t.Fatal("Apply 2 must surface the removed-tunnel LinkDel failure (fail-closed #5355)")
 	}
 	if _, ok := ops.links["gr-0-0-1"]; !ok {
 		t.Fatal("link unexpectedly gone despite failed delete")
@@ -966,10 +969,11 @@ func TestLegacyToWireguardSameNameIncompatibleLinkDelFailureRetained(t *testing.
 		t.Fatal("gre wg0 not tracked in ownedNames")
 	}
 	// Transition to WG; WG must replace the non-TUN GRE link, but its
-	// LinkDel fails.
+	// LinkDel fails. #5355: that failure is now surfaced (fail-closed) and
+	// wraps the retain sentinel that drives the ownedNames re-retain below.
 	ops.delFail["wg0"] = errors.New("EBUSY")
-	if err := tm.Apply([]*config.TunnelConfig{wgTC("172.16.0.1/30")}); err != nil {
-		t.Fatalf("Apply 2 (transition, LinkDel fails): %v", err)
+	if err := tm.Apply([]*config.TunnelConfig{wgTC("172.16.0.1/30")}); err == nil || !errors.Is(err, errWGIncompatibleLinkRetained) {
+		t.Fatalf("Apply 2 must surface the WG incompatible-link replace failure wrapping the retain sentinel (fail-closed #5355), got %v", err)
 	}
 	// The stale GRE link could not be replaced — it must be RETAINED in
 	// ownedNames so cleanup is retried (not orphaned).
@@ -1009,11 +1013,14 @@ func TestWireguardCreateFailureDoesNotRetainOwnership(t *testing.T) {
 		t.Fatalf("Apply 1: %v", err)
 	}
 	// Next Apply (still WG): LinkByName transiently fails → mustCreate, and
-	// LinkAdd then fails. The live WG TUN still exists in the fake.
+	// LinkAdd then fails. The live WG TUN still exists in the fake. #5355:
+	// the create failure is now surfaced (fail-closed), and it must NOT be
+	// the retain sentinel — a plain create failure must not re-retain
+	// ownership (the subject of this test).
 	ops.byNameHardErr["wg0"] = errors.New("EBUSY: transient netlink error")
 	ops.addExisting = true // LinkAdd returns "file exists"
-	if err := tm.Apply([]*config.TunnelConfig{wgTC("172.16.0.1/30")}); err != nil {
-		t.Fatalf("Apply 2 (create fails): %v", err)
+	if err := tm.Apply([]*config.TunnelConfig{wgTC("172.16.0.1/30")}); err == nil || errors.Is(err, errWGIncompatibleLinkRetained) {
+		t.Fatalf("Apply 2 must surface a NON-sentinel WG create failure (fail-closed #5355), got %v", err)
 	}
 	tm.mu.Lock()
 	owned := tm.ownedNames["wg0"]
@@ -1625,12 +1632,15 @@ func TestClearTunnelsDeletesOwnershipUnion(t *testing.T) {
 
 	// Apply where the second tunnel FAILS mid-apply (non-TUN collision
 	// whose LinkDel fails): it stays in ownedNames but never reaches
-	// t.tunnels.
+	// t.tunnels. #5355: that genuine replace-LinkDel failure is now
+	// SURFACED (fail-closed) rather than swallowed — Apply returns it — but
+	// the ownership bookkeeping this test exercises is unchanged.
 	ops.links["gr-0-0-1"] = &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "gr-0-0-1", Index: 9}}
-	ops.delFail["gr-0-0-1"] = errors.New("EBUSY")
+	injected := errors.New("EBUSY")
+	ops.delFail["gr-0-0-1"] = injected
 	tcs := []*config.TunnelConfig{anchorTC("gr-0-0-0"), anchorTC("gr-0-0-1")}
-	if err := tm.Apply(tcs); err != nil {
-		t.Fatalf("Apply: %v", err)
+	if err := tm.Apply(tcs); err == nil || !errors.Is(err, injected) {
+		t.Fatalf("Apply must surface the failed anchor-replace LinkDel (fail-closed #5355), got %v", err)
 	}
 
 	// ClearTunnels must delete EVERYTHING it owns — including the


### PR DESCRIPTION
## Problem

`tunnelManager.Apply` (pkg/routing) had a single unconditional `return nil` that swallowed every per-tunnel netlink failure. A genuine GRE / anchor / WireGuard `LinkAdd` / `LinkSetUp` / `LinkDel` failure was **logged** but the commit reported **SUCCESS** while the tunnel interface was absent (or admin-DOWN, or a removed tunnel's device lingered). This is the same fail-open false-convergence that #5310 fixed for the `xfrmManager`, and the follow-up to the #5354 apply-error wiring.

## #1960 fail-closed invariant

A genuine dataplane reconcile failure must fail the commit **CLOSED**; a routine idempotent re-apply must **NOT**.

## Fix

`Apply` now accumulates the **genuine** create/find/up/delete failures with `errors.Join` and returns them, mirroring `xfrmManager.Apply`:

- `applyAnchorLocked` / `applyKernelTunnelLocked` and the shared `finishTunnelLocked` tail return the replace-`LinkDel` / create-`LinkAdd` / bring-up-`LinkSetUp` error instead of logging-and-dropping it.
- `applyWireguardTunLocked` surfaces its previously-swallowed `LinkSetUp` failure at the tail (its create/replace failures already returned).
- The removal diff aggregates a removed tunnel's `LinkDel` failure.
- `Apply` returns `errors.Join(errs...)`.

**Idempotency preserved** — a routine re-apply never fails the commit: a still-present compatible anchor is adopted in place (reuse, not a `LinkAdd`); a delete of an already-gone tunnel is a tolerated no-op (`isLinkNotFound`); a **transient** `LinkByName` lookup only defers the reconcile (retain + retry, no error); an invalid-endpoint config stays warn-only. Address / MTU / VRF-claim reconcile failures keep their existing retain+retry semantics and are out of the fail-closed scope, matching the #5310 create/find/up/delete boundary.

The #5354 tail-join in `daemon_apply.go` `applyInterfaceReconcile` already threads `ApplyTunnels` into the commit-error join, so once `Apply` returns a real error it surfaces and fails the commit closed — **no caller change needed** (verified).

## Tests (RED-on-revert proven)

Restoring the unconditional `return nil` makes every fail-closed assertion go RED (confirmed for both the routing-package and daemon-boundary tests).

- `pkg/routing/tunnel_apply_failclosed_5355_test.go`: genuine create, bring-up, and removal-delete failures each return non-nil wrapping the injected netlink error; multiple failures aggregate via `errors.Join`; the `Manager.ApplyTunnels` facade propagates; adopt-existing and delete-already-gone stay non-errors.
- Three existing #1884/#1919 ownership tests that injected a genuine failure and relied on the swallowed nil now assert the surfaced error (retention subjects unchanged).
- `pkg/daemon`: a tunnel case added to the #5310 interface-reconcile fail-closed suite proves the daemon-boundary tail-join surfaces it.

`gofmt` clean, `go build ./...` green, `go test ./pkg/routing/... ./pkg/daemon/` green. `pkg/routing/README.md` documents the tunnel Apply fail-closed contract alongside the #5310 xfrm note.

Closes #5355

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eVKSCq31JkNKYEepma2yj