### PR TITLE
pkg/upgrade: fail the rollback preflight closed on non-ENOENT DB stat errors (#5074)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45143,3 +45143,23 @@ top.
 - **Timestamp**: 2026-07-10 (fix/5355-tunnel-apply-failclosed)
   - **Action**: #5355 fail-closed on genuine GRE/tunnel reconcile errors — mirror #5310 xfrmManager.Apply. tunnelManager.Apply now aggregates genuine create/find/up/delete failures via errors.Join and returns them (was unconditional `return nil`); helpers applyAnchorLocked/applyKernelTunnelLocked/finishTunnelLocked return errors; applyWireguardTunLocked surfaces its LinkSetUp failure. Idempotency preserved (adopt-existing, tolerate-already-gone, defer-on-transient). New RED-on-revert tests + daemon-boundary tunnel case; README fail-closed note.
   - **File(s)**: pkg/routing/tunnel.go, pkg/routing/tunnel_apply_failclosed_5355_test.go, pkg/routing/tunnel_reconcile_test.go, pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go, pkg/routing/README.md
+
+- **Timestamp**: 2026-07-10 (fix/5074-rollback-preflight-failclosed)
+  - **Action**: #5074 fail the rollback preflight closed on non-ENOENT
+    config-DB stat errors. `preflight` classified the DB dir with
+    `os.Stat(...) == nil {snapshot} else {skip}`, so ANY non-ENOENT stat
+    error (EACCES/EIO/stale mount) took the else branch, logged "no config
+    DB", left `DBSnapshotPath` empty (`AdvancedStateFloor` false) and let
+    the binary cut proceed with no restorable pre-upgrade DB. `dirSize`
+    errors during space sizing were also silently ignored. Fix: branch the
+    stat EXPLICITLY (nil -> present+snapshot; os.IsNotExist -> skip; ANY
+    OTHER -> return error, abort the pure preflight before any live
+    mutation) via an injectable `statConfigDBDir` seam; surface `dirSize`
+    failures on a PRESENT DB. Clean abort (preflight is pure — no binary
+    swap / marker / snapshot side-effect on the error path). New
+    RED-on-revert tests (present/absent/EACCES/EIO/dirSize-error +
+    Run-level no-mutation); RED proven (buggy code cuts to COMMITTED on
+    EACCES). Updated docs/in-place-upgrade.md PREFLIGHT bullet.
+  - **File(s)**: pkg/upgrade/cutover.go,
+    pkg/upgrade/preflight_dbsnap_failclosed_5074_test.go,
+    docs/in-place-upgrade.md, _Log.md

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -67,6 +67,16 @@ the running daemon and config untouched).
 - **PREFLIGHT** — check `/var` free ≥ staged size + config-DB snapshot
   size + margin; GC eligible versions if short; take the pre-upgrade
   config-DB snapshot (`.partial`+rename, never torn) for rollback.
+  The config-DB dir is classified **fail-closed** (#5074): the stat is
+  branched explicitly — `nil` ⇒ present (snapshot it), `os.IsNotExist`
+  ⇒ the ONLY legitimate skip (genuinely no DB), and ANY OTHER stat error
+  (EACCES/EIO/stale mount) ⇒ ABORT the (pure) preflight before any live
+  mutation. A transient/permission error must NOT be misread as "DB
+  absent": that would leave `DBSnapshotPath` empty (`AdvancedStateFloor`
+  false) and let the binary cut proceed with no restorable pre-upgrade
+  DB, so a later rollback could not restore the config. A `dirSize`
+  failure while sizing a PRESENT DB (e.g. EIO on a subfile) is likewise
+  surfaced, never silently sized as 0.
 - **COPY** — `staged/` → `.<ver>.partial/` + checksum + atomic rename to
   `versions/<ver>/`. A crash never leaves a half-populated version dir;
   stray `.partial` dirs are swept on re-run, and the sweep fsyncs the

--- a/pkg/upgrade/cutover.go
+++ b/pkg/upgrade/cutover.go
@@ -641,6 +641,13 @@ func firstNonNil(errs ...error) error {
 	return nil
 }
 
+// statConfigDBDir stats the pre-upgrade config-DB directory during preflight.
+// It is a package var so tests can inject a non-ENOENT stat error (EACCES/
+// EIO/stale mount) and exercise the #5074 fail-closed path deterministically
+// without root-only permission tricks. Production is os.Stat. Only preflight
+// uses this seam; the flip.go rollback-restore stats are unaffected.
+var statConfigDBDir = os.Stat
+
 // preflight checks disk space (incl. the rollback DB snapshot), GCs
 // eligible versions if short, and takes the pre-upgrade DB snapshot. Pure:
 // no live mutation.
@@ -657,7 +664,28 @@ func (r *Runner) preflight(j *Journal) error {
 	if err != nil {
 		return fmt.Errorf("size staged: %w", err)
 	}
-	dbSize, _ := dirSize(r.cfg.ConfigDBDir) // best-effort; 0 if absent
+
+	// Classify the pre-upgrade config-DB directory ONCE, FAIL-CLOSED (#5074).
+	// The DB snapshot underpins binary+DB-atomic rollback: if a transient or
+	// permission stat error (EACCES/EIO/stale mount) were misread as "DB
+	// absent", the cut would proceed with DBSnapshotPath empty and a later
+	// rollback would have no pre-upgrade DB to restore. Branch the stat
+	// EXPLICITLY: nil -> present (snapshot below); os.IsNotExist -> the only
+	// legitimate skip; ANY OTHER error -> abort the pure preflight before any
+	// live mutation.
+	var dbSize uint64
+	dbPresent := false
+	if _, serr := statConfigDBDir(r.cfg.ConfigDBDir); serr == nil {
+		dbPresent = true
+		// A present DB must be sized for the space check. A walk error here
+		// (EIO on a subfile, EACCES on a subdir) is a real storage fault and
+		// must be surfaced, never silently treated as size 0.
+		if dbSize, err = dirSize(r.cfg.ConfigDBDir); err != nil {
+			return fmt.Errorf("size config DB %s: %w", r.cfg.ConfigDBDir, err)
+		}
+	} else if !os.IsNotExist(serr) {
+		return fmt.Errorf("stat config DB %s: %w", r.cfg.ConfigDBDir, serr)
+	}
 
 	need := stagedSize + dbSize + r.cfg.DiskMarginBytes
 
@@ -688,7 +716,7 @@ func (r *Runner) preflight(j *Journal) error {
 	snapPartial := snapDir + partialSuffix
 	_ = os.RemoveAll(snapPartial)
 	_ = os.RemoveAll(snapDir)
-	if _, err := os.Stat(r.cfg.ConfigDBDir); err == nil {
+	if dbPresent {
 		if _, cerr := copyTree(r.cfg.ConfigDBDir, snapPartial); cerr != nil {
 			return fmt.Errorf("snapshot config DB: %w", cerr)
 		}

--- a/pkg/upgrade/preflight_dbsnap_failclosed_5074_test.go
+++ b/pkg/upgrade/preflight_dbsnap_failclosed_5074_test.go
@@ -1,0 +1,210 @@
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// #5074: the rollback preflight must NOT misread a transient/permission stat
+// error on the config-DB dir as "DB absent". Doing so would leave
+// DBSnapshotPath empty (AdvancedStateFloor=false) and let the binary cut
+// proceed with NO restorable pre-upgrade DB. The preflight must branch the
+// stat explicitly (nil -> snapshot; os.IsNotExist -> skip; ANY OTHER error ->
+// fail closed and abort before any live mutation) and must surface dirSize
+// failures on a present DB.
+
+// newPreflightJournal builds a fresh INIT journal that drives preflight from
+// the live staged/ tree (SourceGeneration empty => sourceDir == StagedDir,
+// which testEnv populates).
+func newPreflightJournal(fs *fakeSystem) *Journal {
+	return &Journal{State: StateInit, TargetVersion: fs.stagedVersion}
+}
+
+// injectConfigDBStat overrides the preflight stat seam for the duration of the
+// test and restores it on cleanup.
+func injectConfigDBStat(t *testing.T, err error) {
+	t.Helper()
+	orig := statConfigDBDir
+	statConfigDBDir = func(string) (os.FileInfo, error) {
+		return nil, &os.PathError{Op: "stat", Path: "config-db", Err: err}
+	}
+	t.Cleanup(func() { statConfigDBDir = orig })
+}
+
+// assertNoSnapshotSideEffect proves the aborted preflight left NO cut state:
+// no committed snapshot dir, no partial, and DBSnapshotPath still empty.
+func assertNoSnapshotSideEffect(t *testing.T, cfg Config, j *Journal) {
+	t.Helper()
+	if j.DBSnapshotPath != "" {
+		t.Errorf("DBSnapshotPath set after aborted preflight: %q", j.DBSnapshotPath)
+	}
+	if j.AdvancedStateFloor {
+		t.Errorf("AdvancedStateFloor set after aborted preflight")
+	}
+	snapDir := filepath.Join(cfg.VersionsDir, "."+j.TargetVersion+".dbsnap")
+	if _, err := os.Stat(snapDir); !os.IsNotExist(err) {
+		t.Errorf("snapshot dir exists after aborted preflight: %s (err=%v)", snapDir, err)
+	}
+	if _, err := os.Stat(snapDir + partialSuffix); !os.IsNotExist(err) {
+		t.Errorf("snapshot .partial exists after aborted preflight: %s", snapDir+partialSuffix)
+	}
+}
+
+// TestPreflight_DBPresent_SnapshotTaken is the happy path: a present config DB
+// is snapshotted, DBSnapshotPath is set, and AdvancedStateFloor is raised.
+func TestPreflight_DBPresent_SnapshotTaken(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	j := newPreflightJournal(fs)
+
+	if err := r.preflight(j); err != nil {
+		t.Fatalf("preflight on present DB: %v", err)
+	}
+	if j.DBSnapshotPath == "" {
+		t.Fatal("DBSnapshotPath empty despite present config DB")
+	}
+	if _, err := os.Stat(j.DBSnapshotPath); err != nil {
+		t.Errorf("snapshot dir missing: %v", err)
+	}
+	if !j.AdvancedStateFloor {
+		t.Errorf("AdvancedStateFloor not raised despite snapshot")
+	}
+	// The snapshot must carry the pre-upgrade DB content.
+	snap := filepath.Join(j.DBSnapshotPath, "active.json")
+	if _, err := os.Stat(snap); err != nil {
+		t.Errorf("snapshot missing active.json: %v", err)
+	}
+	_ = cfg
+}
+
+// TestPreflight_DBAbsent_SkipsSnapshot proves a GENUINELY absent DB
+// (os.IsNotExist) is the only legitimate skip: no error, no snapshot, floor
+// stays down, cut may proceed.
+func TestPreflight_DBAbsent_SkipsSnapshot(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	if err := os.RemoveAll(cfg.ConfigDBDir); err != nil {
+		t.Fatal(err)
+	}
+	j := newPreflightJournal(fs)
+
+	if err := r.preflight(j); err != nil {
+		t.Fatalf("preflight on absent DB should skip, not fail: %v", err)
+	}
+	if j.DBSnapshotPath != "" {
+		t.Errorf("DBSnapshotPath set for absent DB: %q", j.DBSnapshotPath)
+	}
+	if j.AdvancedStateFloor {
+		t.Errorf("AdvancedStateFloor raised for absent DB")
+	}
+	snapDir := filepath.Join(cfg.VersionsDir, "."+j.TargetVersion+".dbsnap")
+	if _, err := os.Stat(snapDir); !os.IsNotExist(err) {
+		t.Errorf("snapshot dir created for absent DB: %s", snapDir)
+	}
+}
+
+// TestPreflight_StatEACCES_FailsClosed proves a non-ENOENT stat error
+// (EACCES) ABORTS the preflight with NO snapshot side effect — it must NOT be
+// misread as "absent".
+func TestPreflight_StatEACCES_FailsClosed(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	injectConfigDBStat(t, syscall.EACCES)
+	j := newPreflightJournal(fs)
+
+	err := r.preflight(j)
+	if err == nil {
+		t.Fatal("preflight proceeded on EACCES stat instead of failing closed")
+	}
+	if !strings.Contains(err.Error(), "stat config DB") {
+		t.Errorf("error is not the fail-closed stat abort: %v", err)
+	}
+	assertNoSnapshotSideEffect(t, cfg, j)
+}
+
+// TestPreflight_StatEIO_FailsClosed proves the same for EIO (transient
+// storage / stale mount).
+func TestPreflight_StatEIO_FailsClosed(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	injectConfigDBStat(t, syscall.EIO)
+	j := newPreflightJournal(fs)
+
+	err := r.preflight(j)
+	if err == nil {
+		t.Fatal("preflight proceeded on EIO stat instead of failing closed")
+	}
+	if !strings.Contains(err.Error(), "stat config DB") {
+		t.Errorf("error is not the fail-closed stat abort: %v", err)
+	}
+	assertNoSnapshotSideEffect(t, cfg, j)
+}
+
+// TestPreflight_DirSizeErrorOnPresentDB_Surfaced proves a walk/size error on a
+// PRESENT config DB (an unreadable subdir) is surfaced, not silently sized as
+// 0. Uses a real permission trick, so it is skipped as root (root bypasses
+// the directory permission).
+func TestPreflight_DirSizeErrorOnPresentDB_Surfaced(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions; dirSize would not error")
+	}
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	// Make a subdir unreadable/unsearchable so filepath.Walk fails INSIDE a
+	// present config DB dir (the top-level stat still succeeds).
+	sub := filepath.Join(cfg.ConfigDBDir, "locked")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(sub, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(sub, 0o755) })
+	j := newPreflightJournal(fs)
+
+	err := r.preflight(j)
+	if err == nil {
+		t.Fatal("preflight swallowed a dirSize error on a present DB")
+	}
+	if !strings.Contains(err.Error(), "size config DB") {
+		t.Errorf("error is not the surfaced dirSize failure: %v", err)
+	}
+	assertNoSnapshotSideEffect(t, cfg, j)
+}
+
+// TestRun_PreflightStatEACCES_AbortsNoCutMutation drives the FULL cut and
+// proves a non-ENOENT DB stat error aborts before ANY live mutation: no stop,
+// no flip drop-in, no start, no copy, no verify, and current is untouched.
+func TestRun_PreflightStatEACCES_AbortsNoCutMutation(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	// Seeded host (current exists) so the cut reaches PREFLIGHT rather than
+	// the no-rollback-target INIT refuse.
+	seedInitialCurrent(t, r, cfg, "1.0.0")
+	injectConfigDBStat(t, syscall.EACCES)
+
+	err := r.Run(Options{})
+	if err == nil {
+		t.Fatal("cut proceeded on EACCES DB stat instead of aborting")
+	}
+	if !strings.Contains(err.Error(), "preflight") {
+		t.Errorf("abort is not a preflight failure: %v", err)
+	}
+	for _, c := range fs.calls {
+		if c == "stop" || c == "start" || c == "dropin" || c == "verify" || c == "copy" {
+			t.Errorf("cut-state mutation %q ran despite preflight fail-closed abort", c)
+		}
+	}
+	// current must still point at the seeded prior version (never flipped).
+	target, _ := os.Readlink(filepath.Join(cfg.VersionsDir, "current"))
+	if filepath.Base(target) != "1.0.0" {
+		t.Errorf("current moved off 1.0.0 despite preflight abort: %q", target)
+	}
+	// No target version dir was copied in.
+	if _, err := os.Stat(filepath.Join(cfg.VersionsDir, "2.0.0")); !os.IsNotExist(err) {
+		t.Errorf("versions/2.0.0 created despite preflight abort")
+	}
+}


### PR DESCRIPTION
## Problem

The rollback preflight (`pkg/upgrade/cutover.go`, `preflight`) guarded the
pre-upgrade config-DB snapshot with:

```go
if _, err := os.Stat(r.cfg.ConfigDBDir); err == nil {
    // snapshot
} else {
    r.logf("upgrade: no config DB ...; skipping DB snapshot")
}
```

ANY non-ENOENT stat error (EACCES, EIO, a stale mount) took the `else`
branch, logged "no config DB", left `DBSnapshotPath` empty (so
`AdvancedStateFloor` stayed false), and let the binary cut proceed with
**no pre-upgrade DB to restore on rollback**. `dirSize(ConfigDBDir)`
errors during space sizing were also silently ignored
(`dbSize, _ := dirSize(...)`).

This violates the binary+DB-atomic rollback / #1960 fail-closed
invariant: a TRANSIENT filesystem/permission failure must not silently
convert a recoverable upgrade into a no-snapshot cut — a later rollback
would then be unable to restore the pre-upgrade config.

## Fix

Classify the config-DB directory **once**, failing closed, and branch the
stat **explicitly**:

- `nil` → present: take the snapshot (existing behavior).
- `os.IsNotExist(err)` → the ONLY legitimate skip (genuinely absent DB).
- ANY OTHER error (EACCES/EIO/stale mount) → **return an error and ABORT**
  the cut.

A `dirSize` failure while sizing a PRESENT DB (e.g. EIO on a subfile) is
surfaced too, never sized as 0.

The abort is **clean**: `preflight` is pure (runs before COPY → STOP →
FLIP → START), so returning mutates no cut state — no binary swap, no
unit drop-in, no snapshot side-effect. The stat routes through a new
package-var `statConfigDBDir` seam so tests can inject non-ENOENT errors
deterministically; only preflight uses it (the `flip.go`
rollback-restore stats are untouched).

## Tests (RED-on-revert proven)

New `pkg/upgrade/preflight_dbsnap_failclosed_5074_test.go`:

- **present** → snapshot taken, `DBSnapshotPath` set, `AdvancedStateFloor` true.
- **genuinely absent** (`os.IsNotExist`) → skip, cut proceeds (legitimate).
- **EACCES / EIO** → preflight returns an error, aborts, **no** snapshot
  dir / `.partial` / `DBSnapshotPath` side-effect.
- **dirSize error on a present DB** → surfaced (perm trick; skipped as root).
- **Run-level EACCES** → the full cut aborts before any live mutation
  (no stop/flip/start, `current` untouched, no `versions/<ver>` copied).

RED-on-revert: reverting the source to the old `err == nil {} else {}`
form cuts all the way to `COMMITTED` on EACCES while logging
"no config DB; skipping" — the EACCES/EIO/Run-level tests fail; restoring
the fix makes them pass. `go build ./...` and `go test ./pkg/upgrade/...`
are green.

## Docs

Updated the PREFLIGHT bullet in `docs/in-place-upgrade.md` to document the
fail-closed stat classification.

Closes #5074

🤖 Generated with [Claude Code](https://claude.com/claude-code)