### PR TITLE
pkg/ddns: constrain the dial to the configured source-address family (#5327)

### DIFF
--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -431,14 +431,33 @@ P1b (closes **#2663, #2664, #2665**) builds on the P1a spine:
   `udp6`). The dialer is shared by the RFC 2136 backend and, via
   `newHTTPClientBound` (#2846), every HTTP backend + checkip — those endpoints
   may resolve to both A and AAAA records, and Go's Happy-Eyeballs can dial the
-  family that does NOT match the configured `source-address`. Before the gate,
-  binding a `SockaddrInet4` on an AF_INET6 socket (or the reverse) returned
-  `EAFNOSUPPORT`/`EINVAL` and aborted the whole connection. Now the
-  mismatched-family dial proceeds with the kernel-chosen source (the operator
-  configured a source only for the matching family); the matching family still
-  egresses from the configured source. `SO_BINDTODEVICE` is family-agnostic and
-  is always applied. This is the DDNS analog of the IPsec family-selection work
-  (#2757/#2832).
+  family that does NOT match the configured `source-address`. Binding a
+  `SockaddrInet4` on an AF_INET6 socket (or the reverse) returns
+  `EAFNOSUPPORT`/`EINVAL` and aborts the connection, so the gate keeps the bind to
+  the matching family. `SO_BINDTODEVICE` is family-agnostic and is always applied.
+  This is the DDNS analog of the IPsec family-selection work (#2757/#2832). The
+  gate is now a SECONDARY guard behind the #5327 family pin (below).
+- **Source-address dial-family pin (#5327, reviewed decision, `constrainDialNetwork`)**
+  — a configured `source-address` is a multi-WAN / security egress control and MUST
+  always be honored. #2901 originally made a cross-family Happy-Eyeballs dial
+  proceed with the kernel-chosen source (SILENTLY skipping the bind) — but that let
+  a DDNS update / checkip probe egress the WRONG WAN, BYPASS a source-IP ACL, and
+  PUBLISH the wrong external address with no operator-visible error. #5327 closes
+  that hole: **whenever a `source-address` is configured, the dial is PINNED to that
+  source's address family** so Happy-Eyeballs can no longer pick the other family
+  — `cl.Net` is set to `udp4`/`udp6` for the RFC 2136 `*dns.Client` (the TCP
+  truncation retry inherits the pin), and the HTTP `Transport.DialContext` is
+  wrapped (`boundDialContext` → `constrainDialNetwork`) to force `tcp4`/`tcp6`. With
+  the pin in place the source bind ALWAYS applies. **Reviewed behaviour change:** an
+  IPv4 `source-address` makes that provider effectively IPv4 for the dial (and vice
+  versa). If the endpoint has NO address in the source family (e.g. an IPv4
+  `source-address` but an IPv6-only endpoint) the pinned dial **FAILS CLOSED** — a
+  clear "no suitable address" dial error the reconciler logs + retries — rather than
+  egressing unbound on the wrong family. This deliberately overrides #2901's
+  documented "proceed unbound on a family mismatch" behaviour: a source-address
+  egress pin must never be silently abandoned. A device-only bind (no
+  `source-address`) imposes NO family pin (SO_BINDTODEVICE is family-agnostic), so
+  its dual-stack behaviour is byte-for-byte unchanged.
 - **HTTP-transport + checkip source binding (#2846)** — originally only the RFC
   2136 backend honored the source binding; the HTTP backends
   (dyndns2/Cloudflare/Route53/generic) and the external checkip probe built a

--- a/pkg/ddns/backend_bind.go
+++ b/pkg/ddns/backend_bind.go
@@ -1,6 +1,7 @@
 package ddns
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/netip"
@@ -181,22 +182,28 @@ func (b bindConfig) isSet() bool {
 // Returns nil when no binding is requested (the *dns.Client then uses its
 // default dialer — today's behaviour byte-for-byte).
 //
-// Dual-stack family gate (#2901): the source-bind is applied only when the
-// source-address family MATCHES the dial socket's address family. The dialer is
-// shared by the RFC 2136 backend AND, via newHTTPClientBound (#2846), every HTTP
-// DDNS backend + the checkip probe — dialing endpoints that may resolve to both
-// A and AAAA records. When Go's Happy-Eyeballs dials the family that does NOT
-// match the configured source-address, calling unix.Bind with a SockaddrInet4 on
-// an AF_INET6 socket (or the reverse) fails EAFNOSUPPORT/EINVAL and aborts the
-// whole connection instead of letting it proceed. We therefore key off the
-// Dialer.Control "network" argument ("tcp4"/"tcp6"/"udp4"/"udp6") and SKIP the
-// source-bind on a family mismatch — the mismatched-family dial proceeds with
-// the kernel-chosen source rather than hard-failing. SO_BINDTODEVICE is
-// family-agnostic and is always applied. A configured source-address still
-// constrains the matching family to the operator's source; the unmatched family
-// (which the operator did not provide a source for) simply uses the default
-// source. When network is empty/unsuffixed (no family hint), the bind is applied
-// by source family as before.
+// Dual-stack family gate (#2901, refined by #5327): the source-bind is applied
+// only when the source-address family MATCHES the dial socket's address family.
+// The dialer is shared by the RFC 2136 backend AND, via newHTTPClientBound
+// (#2846), every HTTP DDNS backend + the checkip probe — dialing endpoints that
+// may resolve to both A and AAAA records. Calling unix.Bind with a SockaddrInet4
+// on an AF_INET6 socket (or the reverse) fails EAFNOSUPPORT/EINVAL and would
+// abort the whole connection, so this hook keys off the Dialer.Control "network"
+// argument ("tcp4"/"tcp6"/"udp4"/"udp6") and only binds on a family match.
+//
+// The gate is now a SECONDARY guard: whenever a source-address is configured,
+// the callers PIN the dial network to the source family upstream
+// (constrainDialNetwork — cl.Net for RFC 2136, the Transport.DialContext wrapper
+// for HTTP), so Happy-Eyeballs can no longer pick the other family. That closes
+// the #5327 hole where a cross-family dial SILENTLY SKIPPED the bind and egressed
+// from a kernel-chosen source on the WRONG WAN (bypassing a source ACL /
+// publishing the wrong address with no error). With the pin in place the network
+// here always carries the matching family suffix, so the gate always evaluates
+// true for a source-configured dial; if the endpoint has no address in the source
+// family the pinned dial FAILS CLOSED before this hook runs. The gate still
+// guards the device-only bind (no source-address → no family pin → SO_BINDTODEVICE
+// only, family-agnostic) and remains defense-in-depth against an unsuffixed
+// network. SO_BINDTODEVICE is family-agnostic and is always applied.
 func (b bindConfig) dialer(timeout time.Duration) *net.Dialer {
 	if !b.isSet() {
 		return nil
@@ -259,5 +266,71 @@ func sourceMatchesDialFamily(src netip.Addr, network string) bool {
 		return src.Is6()
 	default:
 		return true
+	}
+}
+
+// sourceDialFamily returns the address-family suffix ("4" or "6") that a
+// configured source-address pins the dial to, and whether a pin applies (#5327).
+// A pin applies ONLY when a source-address is configured: it is the operator's
+// multi-WAN / security egress control and MUST always be honored. A device-only
+// bind (SO_BINDTODEVICE) is family-agnostic and imposes no family pin, and a
+// no-binding config never reaches the constrained path.
+func (b bindConfig) sourceDialFamily() (suffix string, ok bool) {
+	if !b.sourceAddr.IsValid() {
+		return "", false
+	}
+	if b.sourceAddr.Is4() {
+		return "4", true
+	}
+	return "6", true
+}
+
+// constrainDialNetwork pins a base dial network ("tcp"/"udp") to the configured
+// source-address family (#5327). A source-address is a multi-WAN / security
+// egress pin: left dual-stack, Go's Happy-Eyeballs can pick the family the source
+// does NOT cover, the family gate in dialer() then SILENTLY SKIPS the bind, and
+// the exchange egresses from a kernel-chosen source on the wrong WAN — bypassing
+// a source ACL and/or publishing the wrong external address with no error (the
+// #2901 documented-intentional silent-skip, overridden here as a reviewed
+// decision because a configured source-address must never be silently abandoned).
+// Forcing the network to the source family guarantees the bind always applies; if
+// the endpoint has NO address in that family the pinned dial FAILS CLOSED (a clear
+// "no suitable address" dial error surfaced to the reconciler) instead of
+// egressing unbound. A network already carrying a family suffix, or a config with
+// no source-address (device-only / unbound), is returned unchanged.
+func (b bindConfig) constrainDialNetwork(base string) string {
+	suffix, ok := b.sourceDialFamily()
+	if !ok {
+		return base
+	}
+	if strings.HasSuffix(base, "4") || strings.HasSuffix(base, "6") {
+		return base
+	}
+	return base + suffix
+}
+
+// boundDialContext wraps a *net.Dialer's DialContext so the dial network is
+// pinned to the configured source-address family (#5327) before delegating. The
+// HTTP transport calls Transport.DialContext with a bare "tcp"; the rewrite forces
+// "tcp4"/"tcp6" so Happy-Eyeballs cannot pick the other family and skip the source
+// bind. With no source-address (device-only) the network is passed through
+// unchanged, so behaviour is byte-for-byte the pre-#5327 dial.
+func (b bindConfig) boundDialContext(d *net.Dialer) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		return d.DialContext(ctx, b.constrainDialNetwork(network), address)
+	}
+}
+
+// networkFamilySuffix returns the "4"/"6" family suffix carried by a dial network
+// string, or "" for a bare "tcp"/"udp". Used to carry the #5327 source-family pin
+// from the UDP dial onto the RFC 2136 TCP truncation retry.
+func networkFamilySuffix(network string) string {
+	switch {
+	case strings.HasSuffix(network, "4"):
+		return "4"
+	case strings.HasSuffix(network, "6"):
+		return "6"
+	default:
+		return ""
 	}
 }

--- a/pkg/ddns/backend_http.go
+++ b/pkg/ddns/backend_http.go
@@ -83,6 +83,13 @@ func newHTTPClient() *http.Client {
 // expose it via Transport.DialContext (the dialer is connection-typed "tcp" for
 // HTTP, so the Control-based bind — not a network-typed LocalAddr — is what keeps
 // it working across both families uniformly). httpDialTimeout bounds the connect.
+//
+// #5327: when a source-address is configured the DialContext is wrapped
+// (boundDialContext) to PIN the dial to the source family, so Happy-Eyeballs
+// cannot pick the other family and silently skip the source bind (an update that
+// then egresses the wrong WAN / bypasses a source ACL / publishes the wrong
+// address). An endpoint with no address in the source family FAILS CLOSED at the
+// dial instead of egressing unbound.
 func newHTTPClientBound(b bindConfig) *http.Client {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
@@ -97,7 +104,12 @@ func newHTTPClientBound(b bindConfig) *http.Client {
 		ExpectContinueTimeout: time.Second,
 	}
 	if d := b.dialer(httpDialTimeout); d != nil {
-		tr.DialContext = d.DialContext
+		// #5327: pin the dial to the configured source-address family via a
+		// DialContext wrapper (constrainDialNetwork) so Happy-Eyeballs cannot pick
+		// the other family and skip the source bind — which would egress the update
+		// from a kernel-chosen source on the wrong WAN. A device-only bind (no
+		// source-address) passes the network through unchanged.
+		tr.DialContext = b.boundDialContext(d)
 	}
 	return &http.Client{
 		Timeout:       httpClientTimeout,

--- a/pkg/ddns/backend_rfc2136.go
+++ b/pkg/ddns/backend_rfc2136.go
@@ -276,6 +276,16 @@ func newRFC2136Updater(pol ddnsPolicy, c *config.DHCPDynamicDNSConfig, client dn
 		// *dns.Client's default dialer (today's behaviour byte-for-byte).
 		if d := bind.dialer(u.timeout); d != nil {
 			cl.Dialer = d
+			// #5327: when a source-address is configured, PIN the UDP dial to its
+			// family (cl.Net drives the network miekg passes to the dialer). Without
+			// this, a dual-stack update-server hostname lets Go pick the other family
+			// and the family gate silently skips the source bind, so the UPDATE
+			// egresses from a kernel-chosen source on the wrong WAN. A device-only
+			// bind leaves cl.Net empty (byte-for-byte unchanged). The TCP truncation
+			// retry (exchange) carries the same family pin off cl.Net.
+			if suffix, ok := bind.sourceDialFamily(); ok {
+				cl.Net = "udp" + suffix
+			}
 		}
 		u.client = cl
 	}
@@ -1056,7 +1066,11 @@ func (u *rfc2136Updater) exchange(ctx context.Context, m *dns.Msg) (*dns.Msg, er
 		// never truncates, so this path is production-only.
 		if tc, ok := u.client.(*dns.Client); ok {
 			tcpClient := *tc
-			tcpClient.Net = "tcp"
+			// #5327: keep the source-family pin on the TCP retry. If the UDP dial
+			// was pinned to a family (cl.Net "udp4"/"udp6" for a configured
+			// source-address), the retry must dial "tcp4"/"tcp6" so the source bind
+			// still applies; an unpinned client (empty/"udp") retries plain "tcp".
+			tcpClient.Net = "tcp" + networkFamilySuffix(tc.Net)
 			// Derive the TCP retry context from the CALLER's ctx (not
 			// context.Background()) so a canceled/deadline'd reconcile pass
 			// actually cancels the retry. The per-exchange timeout is still

--- a/pkg/ddns/backend_sourcefamily_5327_test.go
+++ b/pkg/ddns/backend_sourcefamily_5327_test.go
@@ -1,0 +1,184 @@
+package ddns
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/miekg/dns"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// backend_sourcefamily_5327_test.go: FAIL-ON-REVERT coverage for #5327 — a
+// configured source-address is a multi-WAN / security egress pin and must ALWAYS
+// be honored. Before #5327 the source bind was applied only when the dial socket
+// family matched the source family; on a cross-family Happy-Eyeballs dial the
+// bind was SILENTLY SKIPPED and the exchange egressed from a kernel-chosen source
+// on the WRONG WAN (bypassing a source ACL / publishing the wrong address, with
+// no error). The fix PINS the dial to the source family (cl.Net for RFC 2136, the
+// Transport.DialContext wrapper for HTTP) so the other family can never be chosen;
+// an endpoint with no address in the source family FAILS CLOSED at the dial.
+//
+// These tests stress the cross-family case that used to silently egress unbound:
+// with the fix they FAIL CLOSED; with the fix reverted they SUCCEED via the
+// unbound wrong-family dial (RED-on-revert).
+
+// TestHTTPSourceFamilyFailsClosedCrossFamily proves the HTTP path (#2846 bound
+// client) now FAILS CLOSED when the configured source-address family cannot reach
+// the endpoint, instead of silently egressing unbound on the other family. An
+// IPv6 source-address against an IPv4-only endpoint must not connect at all.
+//
+// RED-on-revert: with the family pin removed, Happy-Eyeballs dials the endpoint's
+// IPv4 address, the family gate skips the v6 bind, the request SUCCEEDS unbound,
+// and both assertions below fail.
+func TestHTTPSourceFamilyFailsClosedCrossFamily(t *testing.T) {
+	var hit int32
+	// httptest.NewServer listens on 127.0.0.1 (IPv4 only).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.StoreInt32(&hit, 1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	c, err := newProviderHTTPClient(&config.DDNSProvider{
+		Name:          "p",
+		SourceAddress: "::1", // IPv6 source, IPv4-only endpoint
+	})
+	if err != nil {
+		t.Fatalf("newProviderHTTPClient: %v", err)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := c.Do(req)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("v6 source-address against an IPv4-only endpoint must FAIL CLOSED, " +
+			"not egress unbound on the IPv4 family")
+	}
+	if atomic.LoadInt32(&hit) != 0 {
+		t.Fatal("IPv4-only endpoint was reached — the dial was not pinned to the " +
+			"source family and egressed unbound (the #5327 silent-skip)")
+	}
+}
+
+// TestHTTPSourceV4EndpointV6OnlyFailsClosed is the issue-exact scenario: an IPv4
+// source-address against an IPv6-ONLY endpoint. The dial is pinned to IPv4, the
+// v6-only endpoint has no IPv4 address, so the update FAILS CLOSED rather than
+// egressing unbound on the v6 family. Skipped if the host has no IPv6 loopback.
+func TestHTTPSourceV4EndpointV6OnlyFailsClosed(t *testing.T) {
+	ln, err := net.Listen("tcp6", "[::1]:0")
+	if err != nil {
+		t.Skipf("no IPv6 loopback available: %v", err)
+	}
+	var hit int32
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.StoreInt32(&hit, 1)
+		_, _ = w.Write([]byte("ok"))
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	defer srv.Close()
+
+	url := "http://" + ln.Addr().String() + "/" // http://[::1]:port/
+	c, err := newProviderHTTPClient(&config.DDNSProvider{
+		Name:          "p",
+		SourceAddress: "127.0.0.2", // IPv4 source, IPv6-only endpoint
+	})
+	if err != nil {
+		t.Fatalf("newProviderHTTPClient: %v", err)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := c.Do(req)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("v4 source-address against an IPv6-only endpoint must FAIL CLOSED, " +
+			"not egress unbound on the IPv6 family")
+	}
+	if atomic.LoadInt32(&hit) != 0 {
+		t.Fatal("IPv6-only endpoint was reached — the dial was not pinned to the " +
+			"source family and egressed unbound (the #5327 silent-skip)")
+	}
+}
+
+// TestRFC2136SourceFamilyPinsNet proves the RFC 2136 backend pins the *dns.Client
+// dial network to the configured source-address family (cl.Net "udp4"/"udp6"), so
+// a dual-stack update-server hostname cannot let Happy-Eyeballs pick the other
+// family and skip the source bind. A device-only / no-source config leaves cl.Net
+// empty (today's dual-stack behaviour, byte-for-byte).
+//
+// RED-on-revert: without the pin the source cases leave cl.Net == "" and the two
+// "udp4"/"udp6" assertions fail.
+func TestRFC2136SourceFamilyPinsNet(t *testing.T) {
+	mk := func(t *testing.T, src string) *dns.Client {
+		t.Helper()
+		c := &config.DHCPDynamicDNSConfig{
+			Enabled: true, Domain: "example.com",
+			UpdateServer: "192.0.2.53:53", // TEST-NET, never dialed
+		}
+		if src != "" {
+			c.SourceAddress = src
+		}
+		u, err := newRFC2136Updater(policyFromConfig(c), c, nil, nil, nil)
+		if err != nil {
+			t.Fatalf("newRFC2136Updater(src=%q): %v", src, err)
+		}
+		dc, ok := u.client.(*dns.Client)
+		if !ok {
+			t.Fatalf("expected a real *dns.Client, got %T", u.client)
+		}
+		return dc
+	}
+
+	if dc := mk(t, "10.0.0.9"); dc.Net != "udp4" {
+		t.Errorf("v4 source: cl.Net=%q, want udp4 (dial must be pinned to IPv4)", dc.Net)
+	} else if dc.Dialer == nil {
+		t.Error("v4 source: expected a source-binding Dialer")
+	}
+	if dc := mk(t, "2001:db8::9"); dc.Net != "udp6" {
+		t.Errorf("v6 source: cl.Net=%q, want udp6 (dial must be pinned to IPv6)", dc.Net)
+	} else if dc.Dialer == nil {
+		t.Error("v6 source: expected a source-binding Dialer")
+	}
+	// No source-address: no family pin, no custom dialer — dual-stack default,
+	// unchanged from pre-#5327.
+	if dc := mk(t, ""); dc.Net != "" {
+		t.Errorf("no source: cl.Net=%q, want empty (default dual-stack dial)", dc.Net)
+	} else if dc.Dialer != nil {
+		t.Error("no source: expected no custom Dialer (default dual-stack dial)")
+	}
+}
+
+// TestRFC2136SourceFamilyFailsClosedCrossFamily drives the whole real *dns.Client
+// dial path: an IPv6 source-address against an IPv4-only update server. With the
+// family pin the exchange FAILS CLOSED (the pinned udp6 dial has no IPv4 address
+// to reach), so UpsertLease returns an error instead of silently emitting the
+// UPDATE from a kernel-chosen source on the wrong family.
+//
+// RED-on-revert: without the pin the client dials the update server over IPv4, the
+// family gate skips the v6 source bind, the UPDATE SUCCEEDS unbound, and
+// UpsertLease returns nil — the assertion below fails.
+func TestRFC2136SourceFamilyFailsClosedCrossFamily(t *testing.T) {
+	srv := newFakeDNSServer(t, nil) // listens on 127.0.0.1 (IPv4)
+	c := &config.DHCPDynamicDNSConfig{
+		Enabled: true, Domain: "example.com",
+		UpdateServer:  srv.addrUDP,
+		SourceAddress: "::1", // IPv6 source, IPv4-only server
+	}
+	u, err := newRFC2136Updater(policyFromConfig(c), c, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("newRFC2136Updater: %v", err)
+	}
+	if err := u.UpsertLease(context.Background(), recV4("laptop.example.com", "10.0.1.5", 300)); err == nil {
+		t.Fatal("v6 source-address against an IPv4-only update server must FAIL CLOSED; " +
+			"UpsertLease returned nil — the UPDATE egressed unbound on IPv4 (the #5327 " +
+			"silent-skip)")
+	}
+}


### PR DESCRIPTION
## Problem

A configured DDNS `source-address` is a **multi-WAN / security egress
control**: updates and the external checkip probe must egress from that
source IP so they leave the correct WAN and satisfy a source-IP-keyed ACL
on the authoritative server.

The #2901 dual-stack family gate (`sourceMatchesDialFamily`) applies the
`unix.Bind` source-bind **only when the dial socket family matches the
source family**. On a cross-family Happy-Eyeballs dial it **SILENTLY
SKIPPED** the bind and let the connection proceed with a kernel-chosen
source:

- `pkg/ddns/backend_bind.go` (`dialer().Control`) — the gate at
  `src.IsValid() && sourceMatchesDialFamily(src, network)`.
- `pkg/ddns/backend_http.go` — `Transport.DialContext` shares the same
  dialer.

For an endpoint that resolves to **both A and AAAA**, an IPv4
`source-address` could be abandoned on an IPv6 dial (or vice versa). The
exchange then egressed the **wrong WAN**, could **bypass the source ACL**,
and could **publish the wrong external address** — all with **no
operator-visible error**.

## Invariant

A configured source-address must NOT be silently abandoned. Either the
dial is constrained to the source-address family so the bind always
applies, or the mismatch fails closed.

## Fix

Whenever a `source-address` is configured, **pin the dial to that
source's address family** so Happy-Eyeballs can no longer pick the other
family and skip the bind:

- **RFC 2136** (`backend_bind.go` / `backend_rfc2136.go`): set `cl.Net` to
  `udp4`/`udp6` from the source family; the TCP truncation retry inherits
  the pin via `networkFamilySuffix(cl.Net)`.
- **HTTP providers + checkip** (`backend_http.go`): wrap
  `Transport.DialContext` (`boundDialContext` → `constrainDialNetwork`) to
  force `tcp4`/`tcp6`.

With the pin in place the source bind **always** applies. If the endpoint
has **no address in the source family** (e.g. an IPv4 source-address but
an IPv6-only endpoint) the pinned dial **FAILS CLOSED** — a clear "no
suitable address" dial error the reconciler logs + retries — rather than
egressing unbound on the wrong family. The #2901 gate is kept as a
secondary, defense-in-depth guard (and still governs the device-only
bind, which is family-agnostic and imposes no pin).

## Reviewed decision (tracked, as the issue asks)

This deliberately **overrides #2901's documented "proceed unbound on a
family mismatch" behaviour**. An IPv4 `source-address` now makes that
provider effectively IPv4 for the dial (and vice versa) — the correct
semantics for a source-address egress pin, which must never be silently
abandoned. A device-only / no-source config is **byte-for-byte
unchanged**. Documented in `pkg/ddns/README.md` (new #5327 bullet; the
#2901 bullet is amended to note it is now a secondary guard).

## Tests — RED-on-revert proven

`pkg/ddns/backend_sourcefamily_5327_test.go`:

- **HTTP** — IPv6 source vs IPv4-only endpoint FAILS CLOSED (server never
  reached); IPv4 source vs IPv6-only endpoint FAILS CLOSED (issue-exact
  scenario, skips if no IPv6 loopback).
- **RFC 2136** — `cl.Net` pinned to `udp4`/`udp6` for a v4/v6 source and
  empty for no source; IPv6 source vs IPv4-only update server makes
  `UpsertLease` FAIL CLOSED through the real `*dns.Client` dial path.

RED-on-revert was proven by `git stash`ing the production change (keeping
the tests) — all four tests go RED (the update succeeds unbound on the
wrong family); restored → green. The pre-existing #2901 gate tests still
pass (the gate is retained as defense-in-depth).

`go build ./...`, `go vet ./pkg/ddns/...`, and `go test ./pkg/ddns/...`
all green; `gofmt` clean.

Closes #5327

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxqJMSVMQQcDf7sqzwuvW5