### PR TITLE
cmd/cli: synchronize configMode across the SIGINT and dispatch goroutines (#5053)

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -53,6 +53,28 @@ The split is pure code motion. All handlers moved verbatim; the gRPC
 call sequences and the text-proxy fallthrough are preserved so the
 remote CLI output stays bit-identical to before.
 
+## Interactive loop & signals
+
+The interactive session runs two goroutines against one `ctl`:
+
+- the **main loop** (`main.go`) reads a line, dispatches it, and owns all
+  configuration-mode transitions — `configure` enters, `exit`/`quit` and
+  EOF (Ctrl-D) leave;
+- the **SIGINT goroutine** (`runSignalLoop`) handles Ctrl-C: it cancels a
+  running command, and on a second Ctrl-C within 2 s tears the session
+  down, issuing `ExitConfigure` first if still in configuration mode so
+  the daemon-side config lock is released.
+
+Both goroutines touch `ctl.configMode`, so it is an `atomic.Bool`
+accessed only via `Load`/`Store` (#5053). A plain `bool` let the SIGINT
+read race the main loop's write; a Ctrl-C landing during a mode
+transition could observe stale state and skip the `ExitConfigure`
+cleanup. The teardown paths that run without a cancellable command
+context (SIGINT, EOF, and the post-loop exit) call `ExitConfigure`
+through `exitConfigureBounded`, whose context is time-bounded
+(`exitConfigureTimeout`) so a wedged daemon cannot hang Ctrl-C cleanup
+or block process exit.
+
 ## Operational notes
 
 - Output streams over gRPC. There's no separate SSH / Telnet layer —

--- a/cmd/cli/commit_rollback_4868_test.go
+++ b/cmd/cli/commit_rollback_4868_test.go
@@ -57,7 +57,7 @@ func TestRemoteCommitUnknownModifierNoRPC_4868(t *testing.T) {
 	for _, line := range []string{"commit confimed 10", "commit bogus", "commit synchronize"} {
 		t.Run(line, func(t *testing.T) {
 			fake := &commitRecorderClient{}
-			c := &ctl{client: fake, configMode: true}
+			c := configModeCtl(fake)
 			if err := c.dispatchConfig(line); err == nil {
 				t.Fatalf("%q: expected an error for an unknown commit modifier", line)
 			}
@@ -83,7 +83,7 @@ func TestRemoteCommitConfirmedInvalidNoRPC_4868(t *testing.T) {
 	} {
 		t.Run(line, func(t *testing.T) {
 			fake := &commitRecorderClient{}
-			c := &ctl{client: fake, configMode: true}
+			c := configModeCtl(fake)
 			if err := c.dispatchConfig(line); err == nil {
 				t.Fatalf("%q: expected an error", line)
 			}
@@ -109,7 +109,7 @@ func TestRemoteCommitConfirmedValidMinutes_4868(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.line, func(t *testing.T) {
 			fake := &commitRecorderClient{}
-			c := &ctl{client: fake, configMode: true}
+			c := configModeCtl(fake)
 			if err := c.dispatchConfig(tc.line); err != nil {
 				t.Fatalf("%q: %v", tc.line, err)
 			}
@@ -128,7 +128,7 @@ func TestRemoteRollbackInt32WrapNoRPC_4868(t *testing.T) {
 	for _, arg := range []string{"4294967296", "4294967297", "2147483648"} {
 		t.Run(arg, func(t *testing.T) {
 			fake := &rollbackRecorderClient{}
-			c := &ctl{client: fake, configMode: true}
+			c := configModeCtl(fake)
 			if err := c.dispatchConfig("rollback " + arg); err == nil {
 				t.Fatalf("rollback %q returned nil; expected out-of-range rejection", arg)
 			}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -84,10 +84,10 @@ func main() {
 		client:        client,
 		hostname:      hostname,
 		username:      username,
-		configMode:    false,
 		clusterRole:   resp.ClusterRole,
 		clusterNodeID: resp.ClusterNodeId,
 	}
+	// configMode starts false (atomic.Bool zero value).
 
 	if *cmdFlag != "" {
 		c.startCmd()
@@ -124,7 +124,7 @@ func main() {
 			resp, err := c.client.Complete(ctx, &pb.CompleteRequest{
 				Line:       text,
 				Pos:        int32(len(text)),
-				ConfigMode: c.configMode,
+				ConfigMode: c.configMode.Load(),
 			})
 			if err != nil || len(resp.Candidates) == 0 {
 				fmt.Fprintln(c.rl.Stdout(), "  (no help available)")
@@ -139,7 +139,7 @@ func main() {
 				} else if strings.Contains(text, "|") {
 					desc = pipeFilterDescs[name]
 				} else {
-					desc = remoteLookupDesc(strings.Fields(text), name, c.configMode)
+					desc = remoteLookupDesc(strings.Fields(text), name, c.configMode.Load())
 				}
 				candidates[i] = cmdtree.Candidate{Name: name, Desc: desc}
 			}
@@ -162,29 +162,11 @@ func main() {
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)
-	var lastInterrupt time.Time
-	go func() {
-		for range sigCh {
-			if c.cancelCmd() {
-				fmt.Fprintln(os.Stderr, "\n^C (command cancelled)")
-				continue
-			}
-			now := time.Now()
-			if now.Sub(lastInterrupt) < 2*time.Second {
-				if c.configMode {
-					_, _ = client.ExitConfigure(context.Background(), &pb.ExitConfigureRequest{})
-				}
-				os.Exit(0)
-			}
-			lastInterrupt = now
-			fmt.Fprintln(os.Stderr, "\n^C (press again within 2s to exit)")
-			rl.Refresh()
-		}
-	}()
+	go c.runSignalLoop(sigCh, client, rl.Refresh, func() { os.Exit(0) })
 	defer signal.Stop(sigCh)
 
 	for {
-		if c.configMode {
+		if c.configMode.Load() {
 			st, err := client.GetConfigModeStatus(context.Background(), &pb.GetConfigModeStatusRequest{})
 			if err == nil && st.ConfirmPending {
 				fmt.Println("[commit confirmed pending - issue 'commit' to confirm]")
@@ -197,10 +179,10 @@ func main() {
 				continue
 			}
 			if err == io.EOF {
-				if c.configMode {
-					c.configMode = false
+				if c.configMode.Load() {
+					c.configMode.Store(false)
 					c.editPath = nil
-					_, _ = client.ExitConfigure(context.Background(), &pb.ExitConfigureRequest{})
+					exitConfigureBounded(client)
 					rl.SetPrompt(c.operationalPrompt())
 					fmt.Println("\nExiting configuration mode")
 					continue
@@ -230,9 +212,71 @@ func main() {
 		}
 	}
 
-	if c.configMode {
-		_, _ = client.ExitConfigure(context.Background(), &pb.ExitConfigureRequest{})
+	if c.configMode.Load() {
+		exitConfigureBounded(client)
 	}
+}
+
+// exitConfigureTimeout bounds the ExitConfigure control RPC the CLI issues
+// when leaving configuration mode from a path that has no cancellable command
+// context: the SIGINT double-Ctrl-C handler, an EOF (Ctrl-D) at the prompt,
+// and the normal post-loop teardown. These previously used
+// context.Background(), so a wedged daemon could hang Ctrl-C cleanup or block
+// process exit indefinitely (#5053). A bounded context guarantees the CLI
+// still tears down and exits. Sized like the other CLI control RPCs.
+const exitConfigureTimeout = 5 * time.Second
+
+// exitConfigureBounded issues a best-effort ExitConfigure with a bounded
+// context so a hung daemon cannot wedge CLI teardown. The error is discarded:
+// this is cleanup on the way out and there is nothing left to recover.
+func exitConfigureBounded(client pb.BpfrxServiceClient) {
+	ctx, cancel := context.WithTimeout(context.Background(), exitConfigureTimeout)
+	defer cancel()
+	_, _ = client.ExitConfigure(ctx, &pb.ExitConfigureRequest{})
+}
+
+// interruptWindow is the double-Ctrl-C window: a second interrupt within this
+// span of the first exits the CLI.
+const interruptWindow = 2 * time.Second
+
+// runSignalLoop is the body of the SIGINT goroutine, extracted from main so
+// tests can drive it with an injected channel (#5053). It processes interrupts
+// until sigCh is closed: a running command is cancelled; otherwise a first
+// Ctrl-C arms a 2s window and a second within it tears down. refresh redraws
+// the prompt (rl.Refresh in production; nil in tests). onExit terminates the
+// process (os.Exit(0) in production; a recorder in tests) — it is expected not
+// to return, so the loop stops after invoking it.
+func (c *ctl) runSignalLoop(sigCh <-chan os.Signal, client pb.BpfrxServiceClient, refresh func(), onExit func()) {
+	var lastInterrupt time.Time
+	for range sigCh {
+		if c.cancelCmd() {
+			fmt.Fprintln(os.Stderr, "\n^C (command cancelled)")
+			continue
+		}
+		now := time.Now()
+		if now.Sub(lastInterrupt) < interruptWindow {
+			c.exitOnInterrupt(client, onExit)
+			return
+		}
+		lastInterrupt = now
+		fmt.Fprintln(os.Stderr, "\n^C (press again within 2s to exit)")
+		if refresh != nil {
+			refresh()
+		}
+	}
+}
+
+// exitOnInterrupt performs the double-Ctrl-C teardown: if still in
+// configuration mode, release the daemon-side config lock with a bounded
+// ExitConfigure, then invoke onExit. configMode is read atomically because the
+// main loop mutates it concurrently; a racy read here let a Ctrl-C landing
+// during a configure/exit/EOF transition observe stale state and skip the
+// ExitConfigure cleanup (#5053).
+func (c *ctl) exitOnInterrupt(client pb.BpfrxServiceClient, onExit func()) {
+	if c.configMode.Load() {
+		exitConfigureBounded(client)
+	}
+	onExit()
 }
 
 // maxConfirmedMinutes bounds `commit confirmed <minutes>` (Junos range

--- a/cmd/cli/nontty_test.go
+++ b/cmd/cli/nontty_test.go
@@ -25,6 +25,15 @@ import (
 	"google.golang.org/grpc"
 )
 
+// configModeCtl builds a *ctl already in configuration mode. configMode is an
+// atomic.Bool (#5053), so it cannot be set in a composite literal; this keeps
+// the call sites a single expression.
+func configModeCtl(client pb.BpfrxServiceClient) *ctl {
+	c := &ctl{client: client}
+	c.configMode.Store(true)
+	return c
+}
+
 // fakeBpfrxClient embeds the generated client interface so we can
 // override only the RPC methods we care about. Any method the test
 // does not override will nil-panic when called — which is exactly
@@ -164,7 +173,7 @@ func TestDispatchOperational_ConfigureNonTTYHardErrors(t *testing.T) {
 		t.Errorf("EnterConfigure RPC was issued %d times; expected 0 (no lock leak)",
 			fake.enterConfigureCalls)
 	}
-	if c.configMode {
+	if c.configMode.Load() {
 		t.Error("c.configMode = true after hard-errored configure; expected false")
 	}
 }

--- a/cmd/cli/request.go
+++ b/cmd/cli/request.go
@@ -35,7 +35,7 @@ func (c *ctl) confirmYes(prompt string) (bool, error) {
 	// Restore the correct prompt for the current mode so this
 	// helper composes with both `request system ...` (operational)
 	// and `run request system ...` (from configuration mode).
-	if c.configMode {
+	if c.configMode.Load() {
 		c.rl.SetPrompt(c.configPrompt())
 	} else {
 		c.rl.SetPrompt(c.operationalPrompt())

--- a/cmd/cli/rollback_3447_test.go
+++ b/cmd/cli/rollback_3447_test.go
@@ -41,7 +41,7 @@ func TestRemoteRollbackMalformedNoRPC(t *testing.T) {
 	for _, arg := range []string{"foo", "1x", "-1", "abc", "99999999999999999999"} {
 		t.Run(arg, func(t *testing.T) {
 			fake := &rollbackRecorderClient{}
-			c := &ctl{client: fake, configMode: true}
+			c := configModeCtl(fake)
 			err := c.dispatchConfig("rollback " + arg)
 			if err == nil {
 				t.Fatalf("rollback %q returned nil error; expected rejection", arg)
@@ -70,7 +70,7 @@ func TestRemoteRollbackValidIssuesRPC(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.line, func(t *testing.T) {
 			fake := &rollbackRecorderClient{}
-			c := &ctl{client: fake, configMode: true}
+			c := configModeCtl(fake)
 			if err := c.dispatchConfig(tc.line); err != nil {
 				t.Fatalf("%q: %v", tc.line, err)
 			}

--- a/cmd/cli/shared.go
+++ b/cmd/cli/shared.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/chzyer/readline"
@@ -35,11 +36,16 @@ var pipeFilterDescs = map[string]string{
 }
 
 type ctl struct {
-	client        pb.BpfrxServiceClient
-	rl            *readline.Instance
-	hostname      string
-	username      string
-	configMode    bool
+	client   pb.BpfrxServiceClient
+	rl       *readline.Instance
+	hostname string
+	username string
+	// configMode is read by the SIGINT goroutine (main.go) concurrently
+	// with the main loop's mode transitions, so it MUST be accessed
+	// atomically. A racy read let a Ctrl-C that landed during a
+	// configure/exit/EOF transition observe stale state and skip the
+	// explicit ExitConfigure cleanup on the way out (#5053).
+	configMode    atomic.Bool
 	editPath      []string
 	clusterRole   string // "primary", "secondary", or "" (not clustered)
 	clusterNodeID int32
@@ -102,7 +108,7 @@ func (c *ctl) dispatch(line string) error {
 		return c.dispatchWithPipe(cmd, pipeType, pipeArg)
 	}
 
-	if c.configMode {
+	if c.configMode.Load() {
 		return c.dispatchConfig(line)
 	}
 	return c.dispatchOperational(line)
@@ -262,7 +268,7 @@ func (c *ctl) dispatchOperational(line string) error {
 		if err != nil {
 			return fmt.Errorf("%v", err)
 		}
-		c.configMode = true
+		c.configMode.Store(true)
 		c.rl.SetPrompt(c.configPrompt())
 		if exclusive {
 			fmt.Println("Entering configuration mode (exclusive)")
@@ -510,7 +516,7 @@ func (c *ctl) dispatchConfig(line string) error {
 
 	case "exit", "quit":
 		_, _ = c.client.ExitConfigure(c.ctx(), &pb.ExitConfigureRequest{})
-		c.configMode = false
+		c.configMode.Store(false)
 		c.editPath = nil
 		if c.rl != nil {
 			c.rl.SetPrompt(c.operationalPrompt())
@@ -538,7 +544,7 @@ func (c *ctl) refreshPrompt() {
 	}
 	cancel()
 	if c.rl != nil {
-		if c.configMode {
+		if c.configMode.Load() {
 			c.rl.SetPrompt(c.configPrompt())
 		} else {
 			c.rl.SetPrompt(c.operationalPrompt())
@@ -604,7 +610,7 @@ func (rc *remoteCompleter) Do(line []rune, pos int) ([][]rune, int) {
 	resp, err := rc.ctl.client.Complete(ctx, &pb.CompleteRequest{
 		Line:       text,
 		Pos:        cursor,
-		ConfigMode: rc.ctl.configMode,
+		ConfigMode: rc.ctl.configMode.Load(),
 	})
 	if err != nil || len(resp.Candidates) == 0 {
 		return nil, 0
@@ -643,7 +649,7 @@ func (rc *remoteCompleter) Do(line []rune, pos int) ([][]rune, int) {
 		} else if isPipe {
 			desc = pipeFilterDescs[name]
 		} else {
-			desc = remoteLookupDesc(words, name, rc.ctl.configMode)
+			desc = remoteLookupDesc(words, name, rc.ctl.configMode.Load())
 		}
 		candidates[i] = cmdtree.Candidate{Name: name, Desc: desc}
 	}

--- a/cmd/cli/show_rollback_int32_5052_test.go
+++ b/cmd/cli/show_rollback_int32_5052_test.go
@@ -73,7 +73,7 @@ func TestShowRollbackDisplaySelectorOverflowNoRPC_5052(t *testing.T) {
 		arg := arg
 		t.Run("show system rollback/"+arg, func(t *testing.T) {
 			fake := &showRollbackRecorderClient{}
-			c := &ctl{client: fake, configMode: true}
+			c := configModeCtl(fake)
 			if err := c.dispatchOperational("show system rollback " + arg); err == nil {
 				t.Fatalf("show system rollback %q returned nil; expected rejection", arg)
 			}
@@ -84,7 +84,7 @@ func TestShowRollbackDisplaySelectorOverflowNoRPC_5052(t *testing.T) {
 		})
 		t.Run("show system rollback compare/"+arg, func(t *testing.T) {
 			fake := &showRollbackRecorderClient{}
-			c := &ctl{client: fake, configMode: true}
+			c := configModeCtl(fake)
 			if err := c.dispatchOperational("show system rollback compare " + arg); err == nil {
 				t.Fatalf("show system rollback compare %q returned nil; expected rejection", arg)
 			}
@@ -95,7 +95,7 @@ func TestShowRollbackDisplaySelectorOverflowNoRPC_5052(t *testing.T) {
 		})
 		t.Run("show | compare rollback/"+arg, func(t *testing.T) {
 			fake := &showRollbackRecorderClient{}
-			c := &ctl{client: fake, configMode: true}
+			c := configModeCtl(fake)
 			if err := c.dispatchConfig("show | compare rollback " + arg); err == nil {
 				t.Fatalf("show | compare rollback %q returned nil; expected rejection", arg)
 			}
@@ -115,7 +115,7 @@ func TestShowRollbackDisplaySelectorValidPassthrough_5052(t *testing.T) {
 
 	t.Run("show system rollback 2", func(t *testing.T) {
 		fake := &showRollbackRecorderClient{}
-		c := &ctl{client: fake, configMode: true}
+		c := configModeCtl(fake)
 		if err := c.dispatchOperational("show system rollback 2"); err != nil {
 			t.Fatal(err)
 		}
@@ -126,7 +126,7 @@ func TestShowRollbackDisplaySelectorValidPassthrough_5052(t *testing.T) {
 
 	t.Run("show system rollback MaxInt32", func(t *testing.T) {
 		fake := &showRollbackRecorderClient{}
-		c := &ctl{client: fake, configMode: true}
+		c := configModeCtl(fake)
 		if err := c.dispatchOperational("show system rollback 2147483647"); err != nil {
 			t.Fatal(err)
 		}
@@ -137,7 +137,7 @@ func TestShowRollbackDisplaySelectorValidPassthrough_5052(t *testing.T) {
 
 	t.Run("show system rollback compare 3", func(t *testing.T) {
 		fake := &showRollbackRecorderClient{}
-		c := &ctl{client: fake, configMode: true}
+		c := configModeCtl(fake)
 		if err := c.dispatchOperational("show system rollback compare 3"); err != nil {
 			t.Fatal(err)
 		}
@@ -148,7 +148,7 @@ func TestShowRollbackDisplaySelectorValidPassthrough_5052(t *testing.T) {
 
 	t.Run("show | compare rollback MaxInt32", func(t *testing.T) {
 		fake := &showRollbackRecorderClient{}
-		c := &ctl{client: fake, configMode: true}
+		c := configModeCtl(fake)
 		if err := c.dispatchConfig("show | compare rollback 2147483647"); err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/cli/signal_configmode_5053_test.go
+++ b/cmd/cli/signal_configmode_5053_test.go
@@ -1,0 +1,130 @@
+// cli is the remote CLI client for xpfd.
+//
+// Regression coverage for #5053: the SIGINT goroutine reads c.configMode
+// concurrently with the main loop's configure/exit/EOF transitions. Before the
+// fix configMode was a plain bool, so the read raced the write (a Go
+// memory-model data race) and a Ctrl-C landing during a mode transition could
+// observe stale state and SKIP the explicit ExitConfigure cleanup. configMode
+// is now an atomic.Bool and every access goes through Load/Store.
+package main
+
+import (
+	"context"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc"
+)
+
+// exitConfigureRecorderClient records ExitConfigure invocations. It embeds the
+// generated client so only ExitConfigure is stubbed; any other RPC nil-panics,
+// which is what we want from an un-stubbed call on this path.
+type exitConfigureRecorderClient struct {
+	pb.BpfrxServiceClient
+	exitConfigureCalls int32
+}
+
+func (f *exitConfigureRecorderClient) ExitConfigure(
+	_ context.Context, _ *pb.ExitConfigureRequest, _ ...grpc.CallOption,
+) (*pb.ExitConfigureResponse, error) {
+	atomic.AddInt32(&f.exitConfigureCalls, 1)
+	return &pb.ExitConfigureResponse{}, nil
+}
+
+// TestExitOnInterruptConfigModeRace_5053 drives the SIGINT goroutine's
+// configMode read (via exitOnInterrupt) concurrently with the main loop's mode
+// transitions (Store). With the atomic.Bool fix `go test -race` is clean;
+// against the pre-fix plain-bool field the two goroutines race the same word
+// and the detector flags it (RED-on-revert).
+func TestExitOnInterruptConfigModeRace_5053(t *testing.T) {
+	fake := &exitConfigureRecorderClient{}
+	c := &ctl{client: fake}
+	noExit := func() {}
+
+	const iters = 20000
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: the main loop's configure/exit/EOF transitions flip configMode.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			c.configMode.Store(i%2 == 0)
+		}
+	}()
+
+	// Reader: the SIGINT double-Ctrl-C teardown reads configMode.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			c.exitOnInterrupt(fake, noExit)
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestSignalLoopExitConfigureNotSkipped_5053 drives the real signal loop with
+// an injected channel: a double Ctrl-C while in configuration mode MUST issue
+// exactly one ExitConfigure so the daemon-side config lock is released. A
+// stale/racy configMode read on the pre-fix code could observe false here and
+// skip the cleanup.
+func TestSignalLoopExitConfigureNotSkipped_5053(t *testing.T) {
+	fake := &exitConfigureRecorderClient{}
+	c := &ctl{client: fake}
+	c.configMode.Store(true) // in configuration mode
+
+	sigCh := make(chan os.Signal, 2)
+	exited := make(chan struct{})
+	onExit := func() { close(exited) }
+
+	go c.runSignalLoop(sigCh, fake, nil, onExit)
+
+	// First interrupt arms the 2s window; the second within it triggers the
+	// teardown.
+	sigCh <- os.Interrupt
+	sigCh <- os.Interrupt
+
+	select {
+	case <-exited:
+	case <-time.After(5 * time.Second):
+		t.Fatal("signal loop did not reach the exit branch on double Ctrl-C")
+	}
+
+	if got := atomic.LoadInt32(&fake.exitConfigureCalls); got != 1 {
+		t.Fatalf("ExitConfigure called %d times on double Ctrl-C in config mode; "+
+			"want exactly 1 (Ctrl-C cleanup must not be skipped)", got)
+	}
+}
+
+// TestSignalLoopNoExitConfigureWhenOperational_5053 is the complement: a double
+// Ctrl-C in operational mode must NOT issue ExitConfigure (nothing to release),
+// proving the configMode gate is honored on the teardown path.
+func TestSignalLoopNoExitConfigureWhenOperational_5053(t *testing.T) {
+	fake := &exitConfigureRecorderClient{}
+	c := &ctl{client: fake}
+	// configMode stays false (operational).
+
+	sigCh := make(chan os.Signal, 2)
+	exited := make(chan struct{})
+	onExit := func() { close(exited) }
+
+	go c.runSignalLoop(sigCh, fake, nil, onExit)
+
+	sigCh <- os.Interrupt
+	sigCh <- os.Interrupt
+
+	select {
+	case <-exited:
+	case <-time.After(5 * time.Second):
+		t.Fatal("signal loop did not reach the exit branch on double Ctrl-C")
+	}
+
+	if got := atomic.LoadInt32(&fake.exitConfigureCalls); got != 0 {
+		t.Fatalf("ExitConfigure called %d times on double Ctrl-C in operational mode; want 0", got)
+	}
+}


### PR DESCRIPTION
## Problem

The remote CLI's SIGINT goroutine (`cmd/cli/main.go`) read `c.configMode`
**unsynchronized** while the main loop **wrote** it during the
`configure` / `exit` / EOF mode transitions. `configMode` was a plain `bool`
and `cmdMu` guarded **only** the per-command context (`cmdCtx`/`cmdCancel`),
never the mode flag.

A Ctrl-C landing concurrently with a mode transition is therefore a data race
under the Go memory model: the signal handler can observe a **stale**
`configMode` and **skip / mis-order** the explicit `ExitConfigure` cleanup on
the way out, leaking the daemon-side config lock. `go test -race ./cmd/cli`
passed before only because the tests never exercised the signal goroutine.

## Invariant (Go memory model)

Shared mutable state read across goroutines must be synchronized. A racy read
here can skip/mis-order the `ExitConfigure` cleanup on Ctrl-C.

## Fix

- **`configMode` → `atomic.Bool`.** Every read (SIGINT teardown, main-loop
  status/EOF checks, the `?`-help listener, the tab completer, `refreshPrompt`,
  the config-mode dispatch gate, the request-mode prompt restore) goes through
  `Load`; every write through `Store`. All accesses are now synchronized, with
  **no lock-order interaction** with the command-context critical section — the
  flag no longer shares `cmdMu`.
- **Bounded `ExitConfigure` teardown.** The SIGINT double-Ctrl-C handler, the
  EOF path, and the post-loop exit previously used `context.Background()`, so a
  wedged daemon could hang Ctrl-C cleanup / block process exit forever. They now
  call `exitConfigureBounded`, whose context is capped at `exitConfigureTimeout`
  (5s), matching the other CLI control RPCs.
- **Minimal extraction for testability.** The inline SIGINT goroutine became
  `ctl.runSignalLoop` (+ `ctl.exitOnInterrupt`) so the handler can be driven
  with an **injected signal channel**. Production behavior is unchanged.

## Tests (`-race`, RED-on-revert)

`cmd/cli/signal_configmode_5053_test.go`:

- `TestExitOnInterruptConfigModeRace_5053` — drives the SIGINT configMode read
  concurrently with the main loop's `Store`. Clean under `-race` with
  `atomic.Bool`; the detector fires against a plain-bool revert.
- `TestSignalLoopExitConfigureNotSkipped_5053` — feeds a double Ctrl-C through
  the real loop while in configuration mode and asserts `ExitConfigure` is
  invoked **exactly once** (cleanup not skipped).
- `TestSignalLoopNoExitConfigureWhenOperational_5053` — the operational-mode
  complement (zero `ExitConfigure` calls).

**RED-on-revert proven.** Reverting the field to a plain `bool` with bare
accesses makes the race test FAIL:

```
WARNING: DATA RACE
Write at 0x... by goroutine 9:
  ...TestExitOnInterruptConfigModeRace_5053.func2()
      cmd/cli/signal_configmode_5053_test.go:56
Previous read at 0x... by goroutine 10:
  ...(*ctl).exitOnInterrupt()
      cmd/cli/main.go:276
--- FAIL: TestExitOnInterruptConfigModeRace_5053
    testing.go:1712: race detected during execution of test
```

Restoring the `atomic.Bool` makes it green.

## Docs

`cmd/cli/README.md` gains an "Interactive loop & signals" section documenting
the two-goroutine model, the `atomic.Bool` invariant, and the bounded
`ExitConfigure` teardown.

## Validation

- `GOCACHE=/dev/shm/cache go build ./...` — clean
- `go test -race ./cmd/cli/... -count=1` — ok
- `go vet ./cmd/cli/...` — clean

Closes #5053

🤖 Generated with [Claude Code](https://claude.com/claude-code)