### PR TITLE
pkg/api: emit counter-read-errors on every scrape return path (#5045)

### DIFF
--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -428,11 +428,18 @@ under the daemon's errgroup. Nothing else imports this package.
     netlink read fails, so the descriptor Help text names every read surface
     that increments it — global, zone, policy, and filter dataplane reads
     PLUS the kernel-nftables host-inbound read (#3463), not global-only, so
-    it matches this contract. The error-counter SAMPLE is emitted LAST in
-    `Collect` (`emitCounterReadErrors`), AFTER the global/zone/policy/filter
-    sub-collectors (and the pre-gate host-inbound collector) have run, so a
-    read failure in any of them is reflected in THIS scrape's value rather
-    than lagging one scrape behind (#3462). The per-filter collector also
+    it matches this contract. The error-counter SAMPLE is emitted via a
+    `defer c.emitCounterReadErrors(ch)` established at the TOP of `Collect`
+    (#5045), so it runs at function exit — AFTER the global/zone/policy/filter
+    sub-collectors (and the pre-gate host-inbound collector) have run — on
+    EVERY return path. A read failure in any collector is reflected in THIS
+    scrape's value rather than lagging one scrape behind (#3462). Crucially the
+    deferred emit also covers the `dp == nil || !dp.IsLoaded()` early return: a
+    config-only / degraded boot with a failing pre-gate nft read previously
+    skipped the only (post-gate) emit site and carried NEITHER the data series
+    NOR the error sample — a clean absence that broke the omit-plus-error
+    contract in exactly the degraded state the pre-gate collectors observe
+    (#5045). The per-filter collector also
     merges the userspace-dp helper-published `filter_term_counters` into
     `xpf_filter_hits_total` (the same `BuildFirewallFilterTermCounterIndex`
     the CLI/gRPC text paths use), so the canonical metrics path does not

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -76,9 +76,12 @@ type xpfCollector struct {
 	// failed read SKIPS emitting that counter's sample (so a degraded counter
 	// bridge does NOT report a misleading 0); this metric is the scrape-error
 	// signal an operator alerts on. Persisted on the collector so it accumulates
-	// across scrapes like a real counter. #3462: the SAMPLE is emitted last in
-	// Collect (emitCounterReadErrors), after all collectors that can bump it, so
-	// a failure this scrape is reflected this scrape.
+	// across scrapes like a real counter. #3462/#5045: the SAMPLE is emitted via
+	// a `defer c.emitCounterReadErrors(ch)` established at the TOP of Collect, so
+	// it runs at function exit — after all collectors that can bump it — on
+	// EVERY return path (the unloaded-dataplane early return AND normal
+	// completion). A failure this scrape is reflected this scrape, and the
+	// omit-plus-error contract is never violated by an early return.
 	counterReadErrorsTotal *prometheus.Desc
 	counterReadErrors      atomic.Uint64
 
@@ -898,6 +901,27 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
+	// #5045: emit the xpf_counter_read_errors_total scrape-error sample on
+	// EVERY return path of Collect, so the #3345/#3462 omit-plus-error contract
+	// (a series OMITTED because its read failed => the SAME scrape MUST carry
+	// the error signal) holds even in a config-only / degraded boot. The
+	// pre-gate host-inbound / lo0 collectors below
+	// (collectHostInboundKernelDenies, collectHostInboundJunosHostDenies,
+	// collectHostInboundICMPNDAccepts, collectLo0Counters) bump
+	// counterReadErrors and SKIP their series on an nft read failure, then
+	// Collect hits the `dp == nil || !dp.IsLoaded()` early return. Before this,
+	// the only emit site sat AFTER that gate, so an unloaded-dataplane scrape
+	// with a failing pre-gate read carried NEITHER the data series NOR the
+	// error sample — a clean absence in exactly the degraded state those
+	// pre-gate collectors exist to observe. A defer emits the total exactly
+	// ONCE at function exit, after every collector that can bump it, on BOTH
+	// the unloaded early return and normal completion. counterReadErrors is a
+	// cumulative atomic.Uint64 (never reset per-scrape), so the deferred value
+	// reflects THIS scrape's + prior errors — identical to the loaded-path
+	// value before this change, since nothing after the former emit site
+	// (collectSessionGauges..collectUserspaceStatus) bumps it.
+	defer c.emitCounterReadErrors(ch)
+
 	// #1799: config-persist health is a control-plane signal — emit it
 	// BEFORE the dataplane gate below so the degraded state stays
 	// visible even when the dataplane is not loaded.
@@ -1081,17 +1105,15 @@ func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
 	// reflected in THIS scrape's xpf_interface_counter_read_errors_total. Kept
 	// separate from the security-counter total emitted just below.
 	c.emitInterfaceCounterReadErrors(ch)
-	// #5046: collect NAT pool metrics BEFORE emitCounterReadErrors — a
-	// ReadNATPortCounter failure bumps counterReadErrors, and the bump must be
-	// reflected in THIS scrape's xpf_counter_read_errors_total rather than
-	// lagging a scrape behind (the same #3462 ordering the other counter
-	// collectors follow).
+	// #5046: collect NAT pool metrics on the loaded path — a ReadNATPortCounter
+	// failure bumps counterReadErrors. The deferred emitCounterReadErrors at the
+	// top of Collect runs at function exit, AFTER this, so the bump is reflected
+	// in THIS scrape's xpf_counter_read_errors_total rather than lagging a scrape
+	// behind (the #3462 ordering the other counter collectors follow). #5045: the
+	// scrape-error sample is no longer emitted from an explicit call here — the
+	// deferred emit covers this normal-completion path AND the unloaded early
+	// return above with exactly one emission per scrape.
 	c.collectNATPoolMetrics(ch, dp)
-	// #3462: emit the scrape-error counter AFTER global/zone/policy/filter/NAT
-	// (and the pre-gate host-inbound collector) have run, so a read failure in
-	// any of them is reflected in THIS scrape's xpf_counter_read_errors_total
-	// rather than lagging a scrape behind.
-	c.emitCounterReadErrors(ch)
 	c.collectSessionGauges(ch, dp)
 	c.collectDHCPMetrics(ch)
 	c.collectDDNSMetrics(ch)

--- a/pkg/api/metrics_counter_read_errors_every_path_5045_test.go
+++ b/pkg/api/metrics_counter_read_errors_every_path_5045_test.go
@@ -1,0 +1,183 @@
+package api
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/psaab/xpf/pkg/conntrack"
+	"github.com/psaab/xpf/pkg/dataplane"
+	xnft "github.com/psaab/xpf/pkg/nftables"
+)
+
+// #5045: the xpf_counter_read_errors_total scrape-error sample must be emitted
+// on EVERY return path of Collect so the #3345/#3462 omit-plus-error contract
+// (a series OMITTED because its read failed => the SAME scrape MUST carry the
+// error signal) holds even in a config-only / degraded boot. Before the fix the
+// only emit site sat AFTER the `dp == nil || !dp.IsLoaded()` early return, while
+// the pre-gate host-inbound / lo0 collectors bump counterReadErrors on an nft
+// read failure BEFORE that gate — so an unloaded-dataplane scrape with a failing
+// pre-gate read carried NEITHER the data series NOR the error sample. The fix
+// establishes `defer c.emitCounterReadErrors(ch)` at the top of Collect, so the
+// sample is emitted exactly once at function exit on every path.
+
+// stubPreGateNftReads points all four pre-gate kernel-nftables read package
+// vars at controllable fakes and returns a restore func. The deny read fails
+// iff denyFails; the other three always succeed with an empty result (so they
+// never bump counterReadErrors in the sandbox, where the real netlink reads
+// would otherwise fail non-deterministically).
+func stubPreGateNftReads(t *testing.T, denyFails bool) func() {
+	t.Helper()
+	origDeny := readHostInboundDenyCounters
+	origJunos := readHostInboundJunosHostDenyCounters
+	origLo0 := readLo0Counters
+	origAccept := readHostInboundAcceptCounters
+
+	readHostInboundDenyCounters = func() ([]xnft.HostInboundDenyCount, error) {
+		if denyFails {
+			return nil, errors.New("netlink dial: permission denied")
+		}
+		return nil, nil
+	}
+	readHostInboundJunosHostDenyCounters = func() ([]xnft.HostInboundJunosHostDenyCount, error) {
+		return nil, nil
+	}
+	readLo0Counters = func() ([]xnft.Lo0Count, error) { return nil, nil }
+	readHostInboundAcceptCounters = func() ([]xnft.HostInboundAcceptCount, error) { return nil, nil }
+
+	return func() {
+		readHostInboundDenyCounters = origDeny
+		readHostInboundJunosHostDenyCounters = origJunos
+		readLo0Counters = origLo0
+		readHostInboundAcceptCounters = origAccept
+	}
+}
+
+// gatherErrTotal runs the collector through a PEDANTIC registry and returns the
+// error-total value, the number of samples in the xpf_counter_read_errors_total
+// family (exactly-once guard — a true double-emit of the same name+labels makes
+// pedantic Gather() hard-error, which t.Fatal's here), and whether the
+// kernel-deny series was emitted. Matches on the exact metric-family NAME (not a
+// substring of Desc.String()) so the xpf_INTERFACE_counter_read_errors_total
+// family — whose help text references this metric — is not miscounted.
+func gatherErrTotal(t *testing.T, s *Server) (errTotal float64, errTotalCount int, sawDenySeries bool) {
+	t.Helper()
+	reg := prometheus.NewPedanticRegistry()
+	reg.MustRegister(newCollector(s))
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, mf := range mfs {
+		switch mf.GetName() {
+		case "xpf_counter_read_errors_total":
+			errTotalCount = len(mf.GetMetric())
+			for _, m := range mf.GetMetric() {
+				errTotal = m.GetCounter().GetValue()
+			}
+		case "xpf_host_inbound_kernel_denies_total":
+			sawDenySeries = true
+		}
+	}
+	return errTotal, errTotalCount, sawDenySeries
+}
+
+// TestCounterReadErrorsEmittedWhenDataplaneUnloaded is the #5045 RED-on-revert
+// proof. With the dataplane UNLOADED (dp == nil, config-only / degraded boot)
+// AND a pre-gate nft read that FAILS, the scrape must still carry
+// xpf_counter_read_errors_total (with the bumped value) even though the failed
+// series is omitted — the omit-plus-error contract holds on the early-return
+// path.
+//
+// FAIL-ON-REVERT: move the emit back below the `dp == nil || !dp.IsLoaded()`
+// gate (drop the top-of-Collect defer, restore the post-gate explicit call) and
+// Collect returns before emitting, so xpf_counter_read_errors_total is ABSENT
+// and sawErrTotal goes false (RED).
+func TestCounterReadErrorsEmittedWhenDataplaneUnloaded(t *testing.T) {
+	defer stubPreGateNftReads(t, true)() // deny read fails -> bump + skip series
+
+	s := &Server{} // dp intentionally nil — degraded / config-only boot.
+	errTotal, errTotalCount, sawDenySeries := gatherErrTotal(t, s)
+
+	if errTotalCount == 0 {
+		t.Fatal("xpf_counter_read_errors_total ABSENT on an unloaded-dataplane " +
+			"scrape with a failed pre-gate nft read — the omit-plus-error " +
+			"contract is violated on the early-return path (#5045). The emit " +
+			"must run on EVERY return path, not only the loaded path.")
+	}
+	if errTotal < 1 {
+		t.Errorf("xpf_counter_read_errors_total = %v, want >= 1 (the failed "+
+			"pre-gate read must bump it and the bump must show THIS scrape)", errTotal)
+	}
+	if sawDenySeries {
+		t.Error("xpf_host_inbound_kernel_denies_total present despite a read " +
+			"failure — it must be OMITTED (#3345), so this scrape carries the " +
+			"error signal in its place, not the data series")
+	}
+}
+
+// TestCounterReadErrorsEmittedZeroWhenCleanUnloaded pins the healthy-unloaded
+// behavior: with NO read errors and the dataplane unloaded, the scrape still
+// carries xpf_counter_read_errors_total at 0 (the #3345 "always emitted, 0 when
+// healthy" property, now honored on the early-return path too), and no error
+// series is spuriously present.
+func TestCounterReadErrorsEmittedZeroWhenCleanUnloaded(t *testing.T) {
+	defer stubPreGateNftReads(t, false)() // all pre-gate reads succeed (empty)
+
+	s := &Server{} // dp nil.
+	errTotal, errTotalCount, sawDenySeries := gatherErrTotal(t, s)
+
+	if errTotalCount == 0 {
+		t.Fatal("xpf_counter_read_errors_total absent on a clean unloaded scrape " +
+			"— it must always be emitted (0 when healthy) for alerting (#3345)")
+	}
+	if errTotal != 0 {
+		t.Errorf("xpf_counter_read_errors_total = %v on a clean scrape, want 0", errTotal)
+	}
+	if sawDenySeries {
+		t.Error("kernel-deny series present with an empty read result — want absent")
+	}
+}
+
+// TestCounterReadErrorsEmittedExactlyOnceOnLoadedPath guards the loaded path
+// against a double-emit regression from the deferred-emit restructure. A full
+// Collect() on a LOADED dataplane with a failing pre-gate read must emit
+// xpf_counter_read_errors_total EXACTLY ONCE (the defer replaced — did not
+// duplicate — the former explicit post-gate call), and still reflect the bump.
+//
+// FAIL-ON-REVERT: reintroducing an explicit c.emitCounterReadErrors(ch) call in
+// addition to the top-of-Collect defer emits the same name+labels twice, which
+// makes the PEDANTIC registry Gather() hard-error ("collected metric ... was
+// collected before with the same name and label values") — t.Fatal in the
+// helper — so the test goes RED.
+func TestCounterReadErrorsEmittedExactlyOnceOnLoadedPath(t *testing.T) {
+	defer stubPreGateNftReads(t, true)() // deny read fails -> one bump on the pre-gate path
+
+	store := newDescriptorCoverageStore(t)
+	srv := &Server{
+		store:     store,
+		gc:        conntrack.NewGC(nil, time.Minute),
+		startTime: time.Now(),
+	}
+	srv.dp = &descriptorCoverageDP{
+		Manager: dataplane.New(),
+		apply: &dataplane.ApplyResult{
+			ZoneIDs:   map[string]uint16{"trust": 1, "untrust": 2},
+			FilterIDs: map[string]uint32{"inet:fin": 0, "inet6:fin6": 100},
+		},
+	}
+
+	errTotal, errTotalCount, _ := gatherErrTotal(t, srv)
+
+	if errTotalCount != 1 {
+		t.Fatalf("xpf_counter_read_errors_total emitted %d times in one loaded-path "+
+			"scrape; want exactly 1 (the deferred emit must REPLACE, not duplicate, "+
+			"the former post-gate call) (#5045)", errTotalCount)
+	}
+	if errTotal < 1 {
+		t.Errorf("xpf_counter_read_errors_total = %v on the loaded path with a failed "+
+			"pre-gate read, want >= 1 (the bump must be reflected this scrape)", errTotal)
+	}
+}

--- a/pkg/api/metrics_counters.go
+++ b/pkg/api/metrics_counters.go
@@ -302,11 +302,16 @@ func (c *xpfCollector) collectGlobalCounters(ch chan<- prometheus.Metric, dp api
 // alerting whether or not any read failed. #3462: this MUST run AFTER every
 // sub-collector that can bump counterReadErrors (collectHostInboundKernelDenies,
 // collectGlobalCounters, collectPolicyCounters,
-// collectFilterCounters; #3643 dropped the per-zone bumper) — Collect calls it
-// last — so a policy/filter read
-// that fails in THIS scrape is reflected in THIS scrape's value, not lagged by
-// one scrape (which it was when the sample was emitted from collectGlobalCounters
-// before those collectors ran).
+// collectFilterCounters; #3643 dropped the per-zone bumper) so a policy/filter
+// read that fails in THIS scrape is reflected in THIS scrape's value, not lagged
+// by one scrape (which it was when the sample was emitted from
+// collectGlobalCounters before those collectors ran). #5045: Collect establishes
+// this as a `defer` at the TOP of the method, so it runs at function exit — on
+// EVERY return path (including the unloaded-dataplane early return, where the
+// pre-gate host-inbound/lo0 collectors can have bumped counterReadErrors) —
+// keeping the omit-plus-error contract intact even in a config-only / degraded
+// boot. It reads only the atomic counter, so it is safe to call exactly once at
+// the end regardless of dataplane-loaded state.
 func (c *xpfCollector) emitCounterReadErrors(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(c.counterReadErrorsTotal, prometheus.CounterValue,
 		float64(c.counterReadErrors.Load()))


### PR DESCRIPTION
## Problem

The #3345/#3462 **omit-plus-error contract**: whenever a metric series is
OMITTED because its underlying read failed, the SAME scrape MUST carry the
`xpf_counter_read_errors_total` error signal — on EVERY return path — so a
missing sample is never a silent, indistinguishable absence.

`Collect` runs the pre-gate kernel collectors — `collectHostInboundKernelDenies`,
`collectHostInboundJunosHostDenies`, `collectHostInboundICMPNDAccepts`,
`collectLo0Counters` (`pkg/api/metrics_counters.go` ~:64,89,115,146) — *before*
the `dp == nil || !dp.IsLoaded()` dataplane gate (`pkg/api/metrics.go` ~:1039).
Each bumps `counterReadErrors` and SKIPS its series on an nft read failure. But
the only `emitCounterReadErrors(ch)` call sat AFTER the gate (~:1056), reached
only on the LOADED path.

So during a **degraded / config-only boot** (dataplane UNLOADED) with a failing
pre-gate nft read, the scrape took the early return and carried **NEITHER the
data series NOR the `xpf_counter_read_errors_total` sample** — a clean absence in
exactly the degraded state those pre-gate collectors exist to observe.

## Fix

Establish `defer c.emitCounterReadErrors(ch)` at the TOP of `Collect` and remove
the explicit post-gate call. The sample is now emitted **exactly once, at
function exit, on EVERY return path** (the unloaded early return AND normal
completion).

- `counterReadErrors` is a cumulative `atomic.Uint64` (never reset per-scrape),
  and the deferred emit runs after every collector that can bump it — including
  `collectNATPoolMetrics`, the last loaded-path bumper — so the **loaded-path
  value is byte-identical to before**. Nothing between the former emit site and
  function exit (`collectSessionGauges`..`collectUserspaceStatus`) bumps the
  counter, so there is no double-count and no change to what the loaded path
  reports.
- The interface-counter total (`xpf_interface_counter_read_errors_total`) is
  intentionally out of scope: it has no pre-gate bumper, so its absence on the
  unloaded path is a true zero, not an omit-plus-error violation.

## Tests (RED-on-revert proven)

New `pkg/api/metrics_counter_read_errors_every_path_5045_test.go`:

1. **Unloaded + failed pre-gate read** → pedantic-registry scrape carries
   `xpf_counter_read_errors_total` (>=1) while the kernel-deny series is omitted
   (the contract holds on the early-return path).
2. **Clean unloaded scrape** → the total is present at 0 (the always-emitted
   #3345 property, now honored on the early-return path too).
3. **Loaded path + failed pre-gate read** → the total is emitted **exactly
   once** (a double-emit hard-errors the pedantic Gather).

RED-on-revert: stashing the production change makes tests (1) and (2) FAIL
(`xpf_counter_read_errors_total` absent), reproducing the bug; test (3) is a
no-regression guard.

Validation: `go build ./...` green; `go test ./pkg/api/...` green (full suite).

## Docs

`pkg/api/README.md` counter-read-errors section updated to describe the
every-return-path deferred emit and the degraded-boot early-return case it
closes.

Closes #5045

🤖 Generated with [Claude Code](https://claude.com/claude-code)