### PR TITLE
pkg/upgrade: don't delete kernel package files after a failed purge (#5076)

### DIFF
--- a/docs/pr/1930-inc1-kernel-channel/codex-kernel-linux-impl.md
+++ b/docs/pr/1930-inc1-kernel-channel/codex-kernel-linux-impl.md
@@ -16,8 +16,20 @@ Codex implemented pkg/upgrade/kernel_linux.go against the KernelSystem interface
   real forward probe is wired by the promotion oneshot/caller).
 - Watchdog: WDIOC_SETTIMEOUT(60s)+keepalive arm; magic-'V' disarm; best-effort
   (D2 — BootNext is the loop-safety).
-- PruneInactiveSlot: reset selector to known-good + best-effort purge of the
-  un-promoted candidate kernel + module/boot cleanup.
+- PruneInactiveSlot: reset selector to known-good FIRST (independent of the
+  package cleanup, so the slot never points at a half-removed candidate), then
+  purge the un-promoted candidate kernel. Manual /lib/modules + /boot cleanup
+  runs ONLY after the packages are confirmed absent: on a purge FAILURE (dpkg
+  lock, held-package refusal, maintainer-script error) the package-owned files
+  are LEFT INTACT and a non-nil error is returned — deleting the payload while
+  dpkg still records the package installed would desync the DB from the FS and
+  a later same-version `apt-get install` without --reinstall would never
+  restore it. A dpkg re-query confirms removal before the sweep, and
+  InstallCandidateKernel forces `--reinstall` when a target package is already
+  installed so an uncertain-payload retry actually restores /boot +
+  /lib/modules (#5076). Test seams (injectable aptGet / dpkg-query + fsRoot)
+  cover the purge-failure, partial-purge, confirmed-removal, and reinstall
+  paths.
 
 Build/test: go build ./... OK; go vet ./pkg/upgrade OK; 17 kernel tests + the
 existing #1917 tests green.

--- a/pkg/upgrade/kernel_linux.go
+++ b/pkg/upgrade/kernel_linux.go
@@ -37,6 +37,47 @@ type realKernelSystem struct {
 	// BeaconTarget is the ForwardBeacon ping target; empty -> the IPv4 default
 	// gateway. Set via XPF_KERNEL_BEACON_TARGET for a topology-specific peer.
 	BeaconTarget string
+
+	// Test seams (#5076). All nil/"" in production; a test injects them to
+	// drive the purge-failure path deterministically without shelling out to
+	// apt/dpkg or touching the real /boot + /lib/modules.
+	//
+	//   aptGetFn       overrides the apt-get invocation (purge, install).
+	//   pkgInstalledFn overrides the dpkg "is this package installed?" query.
+	//   fsRoot         prefixes the /boot + /lib/modules paths the prune sweep
+	//                  and the slot selector touch, so a test can assert
+	//                  against a temp-rooted filesystem.
+	aptGetFn       func(args ...string) error
+	pkgInstalledFn func(pkg string) bool
+	fsRoot         string
+}
+
+// aptGetCmd runs apt-get through the injected seam when present, else the real
+// apt-get helper.
+func (s *realKernelSystem) aptGetCmd(args ...string) error {
+	if s.aptGetFn != nil {
+		return s.aptGetFn(args...)
+	}
+	return aptGet(args...)
+}
+
+// pkgInstalled reports whether a package is installed, through the injected
+// seam when present, else a real dpkg-query.
+func (s *realKernelSystem) pkgInstalled(pkg string) bool {
+	if s.pkgInstalledFn != nil {
+		return s.pkgInstalledFn(pkg)
+	}
+	return isPkgInstalled(pkg)
+}
+
+// rooted prefixes an absolute path with fsRoot (empty in production -> the path
+// is returned unchanged). Lets tests confine package-owned file operations to a
+// temp directory.
+func (s *realKernelSystem) rooted(p string) string {
+	if s.fsRoot == "" {
+		return p
+	}
+	return filepath.Join(s.fsRoot, p)
 }
 
 var _ KernelSystem = (*realKernelSystem)(nil)
@@ -213,8 +254,22 @@ func (s *realKernelSystem) InstallCandidateKernel(version string) (string, error
 	if aptPackageAvailable(headersPkg) {
 		pkgs = append(pkgs, headersPkg)
 	}
-	installArgs := append([]string{"install", "-y"}, pkgs...)
-	if err := aptGet(installArgs...); err != nil {
+	// If any candidate package is already recorded installed by dpkg, its
+	// on-disk payload is UNCERTAIN: a prior prune (or an interrupted roll)
+	// could have removed /boot + /lib/modules while dpkg still thinks the
+	// version is current. A plain `apt-get install <same-version>` would then
+	// treat the package as satisfied and never restore the files. Force
+	// --reinstall in that case so apt re-fetches and lays the payload back down
+	// (#5076).
+	anyInstalled := false
+	for _, p := range pkgs {
+		if s.pkgInstalled(p) {
+			anyInstalled = true
+			break
+		}
+	}
+	installArgs := buildInstallArgs(pkgs, anyInstalled)
+	if err := s.aptGetCmd(installArgs...); err != nil {
 		return "", err
 	}
 	if err := runCmd("update-initramfs", "-u", "-k", version); err != nil {
@@ -250,8 +305,20 @@ func (s *realKernelSystem) DefaultBootEntry() (string, error) {
 	return order[0], nil
 }
 
+// buildInstallArgs returns the apt-get argv for installing the candidate
+// packages. When any target package is already installed the payload may be
+// stale/missing, so --reinstall is required to make apt restore /boot +
+// /lib/modules even though dpkg thinks the version is current (#5076).
+func buildInstallArgs(pkgs []string, anyInstalled bool) []string {
+	args := []string{"install", "-y"}
+	if anyInstalled {
+		args = append(args, "--reinstall")
+	}
+	return append(args, pkgs...)
+}
+
 func (s *realKernelSystem) WriteSlotSelector(slot, unameR string) error {
-	dir := filepath.Join("/boot/efi/EFI", slot)
+	dir := s.rooted(filepath.Join("/boot/efi/EFI", slot))
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create slot selector dir %s: %w", dir, err)
 	}
@@ -263,7 +330,7 @@ func (s *realKernelSystem) WriteSlotSelector(slot, unameR string) error {
 }
 
 func (s *realKernelSystem) ReadSlotSelector(slot string) (string, error) {
-	path := filepath.Join("/boot/efi/EFI", slot, "xpf.selector")
+	path := s.rooted(filepath.Join("/boot/efi/EFI", slot, "xpf.selector"))
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -522,16 +589,19 @@ func (s *realKernelSystem) DisarmWatchdog() error {
 }
 
 func (s *realKernelSystem) PruneInactiveSlot(slot, knownGoodUnameR, candidateVersion string) error {
+	// Restore the inactive slot's boot selector to the KNOWN-GOOD kernel FIRST.
+	// This is the load-bearing safety step and it is independent of the package
+	// cleanup below: whatever happens to the candidate's packages, the slot
+	// selector never points at the (possibly half-removed) candidate. Doing it
+	// before any package/file mutation guarantees a later failure cannot strand
+	// the selector on the candidate (#5076).
 	if err := s.WriteSlotSelector(slot, knownGoodUnameR); err != nil {
 		return err
 	}
 	// The candidate kernel packages are HELD (InstallCandidateKernel re-holds
 	// the full set), so `apt-get purge` must be allowed to change held packages
 	// or it leaves the candidate installed-in-dpkg while we delete its files
-	// (r2 Codex High). Include linux-modules-extra (the install adds it). All
-	// best-effort: a prune failure must not block the revert (the firmware
-	// fallback is the safety), but we no longer purge a held pkg without the
-	// override and we cover the same package set the install added.
+	// (r2 Codex High). Include linux-modules-extra (the install adds it).
 	candPkgs := []string{
 		"linux-image-" + candidateVersion,
 		"linux-modules-" + candidateVersion,
@@ -542,20 +612,55 @@ func (s *realKernelSystem) PruneInactiveSlot(slot, knownGoodUnameR, candidateVer
 	// never-installed optional pkg like headers/modules-extra).
 	var installed []string
 	for _, p := range candPkgs {
-		if isPkgInstalled(p) {
+		if s.pkgInstalled(p) {
 			installed = append(installed, p)
 		}
 	}
 	if len(installed) > 0 {
 		args := append([]string{"purge", "-y", "--allow-change-held-packages"}, installed...)
-		if err := aptGet(args...); err != nil {
-			fmt.Fprintf(os.Stderr, "kernel-upgrade: WARNING purge un-promoted candidate %s: %v\n", candidateVersion, err)
+		if err := s.aptGetCmd(args...); err != nil {
+			// The purge FAILED (dpkg lock, held-package refusal, a
+			// maintainer-script error, ...). dpkg still records these packages
+			// as installed. Deleting their /boot + /lib/modules payload now
+			// would leave the package database and the filesystem
+			// inconsistent: a later `apt-get install <same-version>` WITHOUT
+			// --reinstall sees the package current and never restores the
+			// files, so the slot would hold a kernel with no modules/boot
+			// files. LEAVE the package-owned files intact and surface the
+			// failure so the caller logs it and the prune stays retryable. The
+			// selector is already pointed at known-good (above), so the box is
+			// safe regardless (#5076).
+			return fmt.Errorf("purge un-promoted candidate %s: %w", candidateVersion, err)
+		}
+		// Re-query dpkg: manual deletion of package-owned files must ONLY
+		// follow a CONFIRMED removal. If any package is still installed (a
+		// partial purge), keep its files and surface the anomaly rather than
+		// delete a still-owned payload (#5076).
+		var stillInstalled []string
+		for _, p := range installed {
+			if s.pkgInstalled(p) {
+				stillInstalled = append(stillInstalled, p)
+			}
+		}
+		if len(stillInstalled) > 0 {
+			return fmt.Errorf("purge un-promoted candidate %s: still installed after purge: %s",
+				candidateVersion, strings.Join(stillInstalled, ", "))
 		}
 	}
-	_ = os.RemoveAll(filepath.Join("/lib/modules", candidateVersion))
-	if matches, err := filepath.Glob(filepath.Join("/boot", "*-"+candidateVersion)); err == nil {
+	// The candidate packages are confirmed ABSENT (none were installed, or the
+	// purge removed them and the dpkg re-query confirms it). Any leftover
+	// /lib/modules or /boot files are now truly orphaned, so sweeping them
+	// cannot desync dpkg. This sweep is best-effort: an orphan-file removal
+	// error must not block the revert (the firmware-cleared BootNext is the
+	// safety floor), so it is logged, not returned.
+	if err := os.RemoveAll(s.rooted(filepath.Join("/lib/modules", candidateVersion))); err != nil {
+		fmt.Fprintf(os.Stderr, "kernel-upgrade: WARNING remove /lib/modules/%s: %v\n", candidateVersion, err)
+	}
+	if matches, err := filepath.Glob(s.rooted(filepath.Join("/boot", "*-"+candidateVersion))); err == nil {
 		for _, match := range matches {
-			_ = os.RemoveAll(match)
+			if err := os.RemoveAll(match); err != nil {
+				fmt.Fprintf(os.Stderr, "kernel-upgrade: WARNING remove %s: %v\n", match, err)
+			}
 		}
 	}
 	return nil

--- a/pkg/upgrade/kernel_purge_5076_test.go
+++ b/pkg/upgrade/kernel_purge_5076_test.go
@@ -1,0 +1,219 @@
+package upgrade
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #5076: on a purge FAILURE PruneInactiveSlot must NOT delete the candidate's
+// package-owned /boot + /lib/modules payload (dpkg still records the package as
+// installed; deleting the files leaves the DB and the filesystem inconsistent
+// so a later same-version `apt-get install` without --reinstall never restores
+// them). It must return a non-nil error and leave the slot selector pointed at
+// the known-good kernel. Manual file cleanup may proceed ONLY after dpkg
+// confirms the packages are actually gone.
+
+// seedCandidatePayload lays down the /boot + /lib/modules files a candidate
+// kernel owns under a temp fsRoot and returns the two paths the prune sweeps.
+func seedCandidatePayload(t *testing.T, root, cand string) (modulesDir string, bootFile string) {
+	t.Helper()
+	modulesDir = filepath.Join(root, "lib", "modules", cand)
+	if err := os.MkdirAll(modulesDir, 0755); err != nil {
+		t.Fatalf("seed modules dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(modulesDir, "modules.dep"), []byte("x"), 0644); err != nil {
+		t.Fatalf("seed modules.dep: %v", err)
+	}
+	bootDir := filepath.Join(root, "boot")
+	if err := os.MkdirAll(bootDir, 0755); err != nil {
+		t.Fatalf("seed boot dir: %v", err)
+	}
+	bootFile = filepath.Join(bootDir, "vmlinuz-"+cand)
+	if err := os.WriteFile(bootFile, []byte("x"), 0644); err != nil {
+		t.Fatalf("seed boot file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(bootDir, "initrd.img-"+cand), []byte("x"), 0644); err != nil {
+		t.Fatalf("seed initrd: %v", err)
+	}
+	return modulesDir, bootFile
+}
+
+func TestPruneInactiveSlot_PurgeFailureLeavesFiles(t *testing.T) {
+	root := t.TempDir()
+	const cand = "7.0.0-99-generic"
+	const knownGood = "7.0.0-22-generic"
+	modulesDir, bootFile := seedCandidatePayload(t, root, cand)
+
+	var purgeArgs []string
+	sys := &realKernelSystem{
+		fsRoot:         root,
+		pkgInstalledFn: func(string) bool { return true }, // candidate installed
+		aptGetFn: func(args ...string) error {
+			purgeArgs = args
+			return fmt.Errorf("dpkg: error: dpkg frontend lock held by another process")
+		},
+	}
+
+	err := sys.PruneInactiveSlot("xpf-B", knownGood, cand)
+	if err == nil {
+		t.Fatal("expected non-nil error on purge failure, got nil")
+	}
+	if !strings.Contains(err.Error(), cand) {
+		t.Errorf("error should name the candidate: %v", err)
+	}
+	// The purge was attempted with the held-package override.
+	if len(purgeArgs) == 0 || purgeArgs[0] != "purge" {
+		t.Fatalf("expected a purge attempt, got args %v", purgeArgs)
+	}
+	if !containsArg(purgeArgs, "--allow-change-held-packages") {
+		t.Errorf("purge must pass --allow-change-held-packages, got %v", purgeArgs)
+	}
+
+	// Package-owned files MUST survive the failed purge.
+	if _, statErr := os.Stat(modulesDir); statErr != nil {
+		t.Errorf("/lib/modules/%s deleted after failed purge (%v) — leaves dpkg/FS inconsistent", cand, statErr)
+	}
+	if _, statErr := os.Stat(bootFile); statErr != nil {
+		t.Errorf("/boot/vmlinuz-%s deleted after failed purge (%v)", cand, statErr)
+	}
+
+	// The slot selector must be left pointed at the known-good kernel.
+	sel, selErr := sys.ReadSlotSelector("xpf-B")
+	if selErr != nil {
+		t.Fatalf("read slot selector: %v", selErr)
+	}
+	if sel != knownGood {
+		t.Errorf("slot selector = %q, want known-good %q (must never point at a half-removed candidate)", sel, knownGood)
+	}
+}
+
+func TestPruneInactiveSlot_PurgeSuccessSweepsFiles(t *testing.T) {
+	root := t.TempDir()
+	const cand = "7.0.0-99-generic"
+	const knownGood = "7.0.0-22-generic"
+	modulesDir, bootFile := seedCandidatePayload(t, root, cand)
+
+	purged := false
+	sys := &realKernelSystem{
+		fsRoot: root,
+		// Installed before the purge, absent after — dpkg confirms removal.
+		pkgInstalledFn: func(string) bool { return !purged },
+		aptGetFn: func(args ...string) error {
+			if len(args) > 0 && args[0] == "purge" {
+				purged = true
+			}
+			return nil
+		},
+	}
+
+	if err := sys.PruneInactiveSlot("xpf-B", knownGood, cand); err != nil {
+		t.Fatalf("prune should succeed, got %v", err)
+	}
+	// dpkg confirmed the packages gone -> the orphaned files are swept.
+	if _, statErr := os.Stat(modulesDir); !os.IsNotExist(statErr) {
+		t.Errorf("/lib/modules/%s should be swept after confirmed removal (stat err=%v)", cand, statErr)
+	}
+	if _, statErr := os.Stat(bootFile); !os.IsNotExist(statErr) {
+		t.Errorf("/boot/vmlinuz-%s should be swept after confirmed removal (stat err=%v)", cand, statErr)
+	}
+}
+
+func TestPruneInactiveSlot_PartialPurgeKeepsFiles(t *testing.T) {
+	// apt-get returns success but a package is still installed afterwards
+	// (partial purge). Manual deletion must NOT proceed — a still-owned payload
+	// is never deleted.
+	root := t.TempDir()
+	const cand = "7.0.0-99-generic"
+	const knownGood = "7.0.0-22-generic"
+	modulesDir, bootFile := seedCandidatePayload(t, root, cand)
+
+	sys := &realKernelSystem{
+		fsRoot:         root,
+		pkgInstalledFn: func(string) bool { return true }, // never confirmed absent
+		aptGetFn:       func(args ...string) error { return nil },
+	}
+
+	err := sys.PruneInactiveSlot("xpf-B", knownGood, cand)
+	if err == nil {
+		t.Fatal("expected error when a package remains installed after purge")
+	}
+	if !strings.Contains(err.Error(), "still installed") {
+		t.Errorf("error should flag the partial purge: %v", err)
+	}
+	if _, statErr := os.Stat(modulesDir); statErr != nil {
+		t.Errorf("/lib/modules/%s deleted despite still-installed package (%v)", cand, statErr)
+	}
+	if _, statErr := os.Stat(bootFile); statErr != nil {
+		t.Errorf("/boot/vmlinuz-%s deleted despite still-installed package (%v)", cand, statErr)
+	}
+}
+
+func TestPruneInactiveSlot_NothingInstalledSweeps(t *testing.T) {
+	// No candidate package is installed (never installed, or already gone). The
+	// purge is skipped and any orphaned files are still swept.
+	root := t.TempDir()
+	const cand = "7.0.0-99-generic"
+	const knownGood = "7.0.0-22-generic"
+	modulesDir, bootFile := seedCandidatePayload(t, root, cand)
+
+	purgeCalled := false
+	sys := &realKernelSystem{
+		fsRoot:         root,
+		pkgInstalledFn: func(string) bool { return false },
+		aptGetFn: func(args ...string) error {
+			purgeCalled = true
+			return nil
+		},
+	}
+
+	if err := sys.PruneInactiveSlot("xpf-B", knownGood, cand); err != nil {
+		t.Fatalf("prune should succeed with nothing installed, got %v", err)
+	}
+	if purgeCalled {
+		t.Error("purge must not run when no candidate package is installed")
+	}
+	if _, statErr := os.Stat(modulesDir); !os.IsNotExist(statErr) {
+		t.Errorf("orphaned /lib/modules/%s should be swept (stat err=%v)", cand, statErr)
+	}
+	if _, statErr := os.Stat(bootFile); !os.IsNotExist(statErr) {
+		t.Errorf("orphaned /boot/vmlinuz-%s should be swept (stat err=%v)", cand, statErr)
+	}
+}
+
+// #5076: a same-version install where the packages are already recorded
+// installed must force --reinstall so apt restores /boot + /lib/modules even
+// though dpkg thinks the version is current.
+func TestBuildInstallArgs_Reinstall(t *testing.T) {
+	pkgs := []string{"linux-image-7.0.0-99-generic", "linux-modules-7.0.0-99-generic"}
+
+	fresh := buildInstallArgs(pkgs, false)
+	if containsArg(fresh, "--reinstall") {
+		t.Errorf("fresh install must NOT use --reinstall: %v", fresh)
+	}
+	if fresh[0] != "install" || fresh[1] != "-y" {
+		t.Errorf("unexpected install argv: %v", fresh)
+	}
+	if !containsArg(fresh, pkgs[0]) || !containsArg(fresh, pkgs[1]) {
+		t.Errorf("install argv must include the packages: %v", fresh)
+	}
+
+	retry := buildInstallArgs(pkgs, true)
+	if !containsArg(retry, "--reinstall") {
+		t.Errorf("same-version retry with an already-installed package MUST use --reinstall: %v", retry)
+	}
+	if !containsArg(retry, pkgs[0]) || !containsArg(retry, pkgs[1]) {
+		t.Errorf("reinstall argv must include the packages: %v", retry)
+	}
+}
+
+func containsArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Problem

`PruneInactiveSlot` (pkg/upgrade/kernel_linux.go) reset the inactive slot
selector, best-effort purged the un-promoted candidate kernel, then
**unconditionally** `os.RemoveAll`'d `/lib/modules/<candidate>` and
glob-deleted `/boot/*-<candidate>` and returned `nil` — **even when the
purge FAILED** (it only wrote a WARNING to stderr).

A dpkg-lock or maintainer-script failure leaves
`linux-image`/`linux-modules`/`linux-headers-<candidate>` **INSTALLED**
(often held) while their `/boot` + `/lib/modules` payload is deleted. The
package database and the filesystem are then inconsistent: a later
`apt-get install <same-version>` **without `--reinstall`** sees the
package current and never restores the files → the slot holds a kernel
with no modules/boot files.

## Consistency invariant

Manual deletion of package-owned files must ONLY follow a **CONFIRMED**
package removal, and a failed purge must stay retryable.

## Fix

- Restore the inactive slot selector to the **known-good** kernel FIRST,
  independent of the package cleanup — a later failure can never strand
  the selector on a half-removed candidate.
- On purge **FAILURE**: leave the package-owned files **INTACT** and
  return a non-nil error (the caller — `restoreKnownGood` — logs it)
  instead of returning `nil` after deleting them.
- After a successful purge, **re-query dpkg** and only sweep the leftover
  `/lib/modules` + `/boot` files once the packages are confirmed
  **ABSENT**; a partial purge keeps its files and surfaces the anomaly.
- The orphan-file sweep (post confirmed-absent) stays best-effort but now
  **logs** `RemoveAll` errors instead of discarding them.
- `InstallCandidateKernel` forces **`--reinstall`** when a target package
  is already installed, so a same-version retry with uncertain payload
  restores `/boot` + `/lib/modules` even though dpkg thinks it's current.

## Tests (RED-on-revert)

Added injectable seams (`aptGetFn` / `pkgInstalledFn` + an `fsRoot`
prefix on the `/boot` + `/lib/modules` paths) and
`kernel_purge_5076_test.go`:

- purge FAILS → files NOT deleted, non-nil error, selector left at
  known-good
- purge SUCCEEDS + dpkg confirms absent → orphan sweep proceeds
- partial purge (pkg still installed after purge) → files kept, error
- nothing installed → purge skipped, orphan sweep still runs
- same-version retry with an already-installed package → install argv
  contains `--reinstall`

**RED-on-revert verified:** with the old
WARN-then-unconditional-delete-then-return-`nil` body (seams kept), the
purge-failure and partial-purge tests FAIL (nil returned / files
deleted); the fix makes them pass. `go build ./...`, `go vet
./pkg/upgrade`, and `go test ./pkg/upgrade/...` are green.

Doc: updated docs/pr/1930-inc1-kernel-channel/codex-kernel-linux-impl.md
(the PruneInactiveSlot behavior contract).

Closes #5076

🤖 Generated with [Claude Code](https://claude.com/claude-code)