### PR TITLE
pkg/upgrade: fail safe on a dpkg-query error in the pre-purge loop (#5428)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45235,3 +45235,29 @@ top.
   - **File(s)**: pkg/upgrade/cutover.go,
     pkg/upgrade/preflight_dbsnap_failclosed_5074_test.go,
     docs/in-place-upgrade.md, _Log.md
+
+- **Timestamp**: 2026-07-10 (fix/5428-kernel-pkginstalled-tristate)
+  - **Action**: #5428 fail safe on a dpkg-query error in the kernel
+    pre-purge installed-set loop. #5427 made the post-purge sweep safe on
+    a purge FAILURE / partial purge, but both the PRE-purge installed-set
+    loop and the POST-purge confirmed-absent re-query used a helper that
+    returned `false` on ANY dpkg-query error, so a dpkg-DB corruption/parse
+    error (while the package IS installed) read as "not installed" ->
+    package dropped from the set -> purge SKIPPED -> the sweep deleted
+    package-owned /boot + /lib/modules files while dpkg still owned them
+    (same DB/FS divergence, reached via a query error instead of a
+    lock/maintainer-script failure). Made the pkgInstalled check TRI-STATE
+    `(bool, error)`; a query error now FAILS SAFE (possibly-installed) on
+    both sides so a real purge is attempted and the sweep stays gated
+    behind a POSITIVE confirmed-absent re-query. isPkgInstalled
+    distinguishes a genuinely-unknown package ("no packages found matching"
+    -> confirmed absent, no apt "Unable to locate package" regression) from
+    a real query failure (fail safe). New RED-on-revert tests via the
+    pkgInstalledFn seam (pre-purge + post-purge query error keeps files) +
+    dpkgQueryAbsent classification + real dpkg-query tri-state. RED proven
+    (buggy code sweeps files on a query error). Updated
+    docs/pr/1930-inc1-kernel-channel/codex-kernel-linux-impl.md.
+  - **File(s)**: pkg/upgrade/kernel_linux.go,
+    pkg/upgrade/kernel_pkgquery_5428_test.go,
+    pkg/upgrade/kernel_purge_5076_test.go,
+    docs/pr/1930-inc1-kernel-channel/codex-kernel-linux-impl.md, _Log.md

--- a/docs/pr/1930-inc1-kernel-channel/codex-kernel-linux-impl.md
+++ b/docs/pr/1930-inc1-kernel-channel/codex-kernel-linux-impl.md
@@ -30,6 +30,25 @@ Codex implemented pkg/upgrade/kernel_linux.go against the KernelSystem interface
   /lib/modules (#5076). Test seams (injectable aptGet / dpkg-query + fsRoot)
   cover the purge-failure, partial-purge, confirmed-removal, and reinstall
   paths.
+- The dpkg "is this package installed?" query is TRI-STATE — installed /
+  not-installed / query-error (#5428). #5076/#5427 made the sweep safe on a
+  purge FAILURE and a PARTIAL purge, but both the PRE-purge installed-set loop
+  and the POST-purge confirmed-absent re-query used a helper that returned
+  `false` on ANY dpkg-query error, so a dpkg-DB corruption/parse error (while
+  the package IS installed) read as "not installed" -> the package was dropped
+  from the set, the purge was skipped, and the sweep deleted package-owned
+  /boot + /lib/modules files while dpkg still owned them (the same DB/FS
+  divergence, reached via a query error instead of a lock/maintainer-script
+  failure). A query error now FAILS SAFE: the package is treated as
+  POSSIBLY-INSTALLED so a real purge is attempted and the sweep stays gated
+  behind a POSITIVE confirmed-absent re-query. isPkgInstalled distinguishes a
+  genuinely-unknown package ("no packages found matching" -> confirmed absent,
+  so a never-installed optional pkg is not pushed into the purge set and
+  apt-get does not fail with "Unable to locate package") from a real query
+  failure (DB corruption, permission, lock, missing binary -> fail safe). New
+  seam signature `pkgInstalledFn func(pkg string) (bool, error)` lets a test
+  inject a query error; the #5428 tests prove RED-on-revert (files swept
+  without the fix).
 
 Build/test: go build ./... OK; go vet ./pkg/upgrade OK; 17 kernel tests + the
 existing #1917 tests green.

--- a/pkg/upgrade/kernel_linux.go
+++ b/pkg/upgrade/kernel_linux.go
@@ -44,11 +44,14 @@ type realKernelSystem struct {
 	//
 	//   aptGetFn       overrides the apt-get invocation (purge, install).
 	//   pkgInstalledFn overrides the dpkg "is this package installed?" query.
+	//                  It is TRI-STATE (installed, queryErr): a non-nil queryErr
+	//                  means dpkg's status could not be determined and callers on
+	//                  a destructive path must fail SAFE (#5428).
 	//   fsRoot         prefixes the /boot + /lib/modules paths the prune sweep
 	//                  and the slot selector touch, so a test can assert
 	//                  against a temp-rooted filesystem.
 	aptGetFn       func(args ...string) error
-	pkgInstalledFn func(pkg string) bool
+	pkgInstalledFn func(pkg string) (bool, error)
 	fsRoot         string
 }
 
@@ -61,9 +64,14 @@ func (s *realKernelSystem) aptGetCmd(args ...string) error {
 	return aptGet(args...)
 }
 
-// pkgInstalled reports whether a package is installed, through the injected
-// seam when present, else a real dpkg-query.
-func (s *realKernelSystem) pkgInstalled(pkg string) bool {
+// pkgInstalled reports whether a package is installed AND whether the dpkg
+// query itself succeeded, through the injected seam when present, else a real
+// dpkg-query. It is TRI-STATE (installed / not-installed / query-error): a
+// non-nil error means the status could NOT be determined (dpkg-DB corruption,
+// lock, missing binary). Callers on a path that then deletes package-owned
+// files MUST treat a query error as POSSIBLY-INSTALLED and fail safe — never as
+// "removed" (#5428).
+func (s *realKernelSystem) pkgInstalled(pkg string) (bool, error) {
 	if s.pkgInstalledFn != nil {
 		return s.pkgInstalledFn(pkg)
 	}
@@ -263,7 +271,13 @@ func (s *realKernelSystem) InstallCandidateKernel(version string) (string, error
 	// (#5076).
 	anyInstalled := false
 	for _, p := range pkgs {
-		if s.pkgInstalled(p) {
+		ok, qerr := s.pkgInstalled(p)
+		// On a query error the on-disk payload is UNCERTAIN just as when the
+		// package is recorded installed, so fail safe and force --reinstall:
+		// apt then re-fetches and re-lays /boot + /lib/modules regardless
+		// (harmless when the package turns out not to be installed — apt just
+		// installs it fresh) (#5076/#5428).
+		if qerr != nil || ok {
 			anyInstalled = true
 			break
 		}
@@ -609,10 +623,20 @@ func (s *realKernelSystem) PruneInactiveSlot(slot, knownGoodUnameR, candidateVer
 		"linux-headers-" + candidateVersion,
 	}
 	// Only purge packages that are actually installed (avoid apt errors on a
-	// never-installed optional pkg like headers/modules-extra).
+	// never-installed optional pkg like headers/modules-extra). A dpkg-query
+	// ERROR here (DB corruption, lock, missing binary) must NOT be misread as
+	// "not installed": that false-negative would drop a still-owned package
+	// from the set, skip the purge, and let the sweep below delete
+	// package-owned /boot + /lib/modules files while dpkg still owns them (the
+	// #5427 divergence class, reached via DB corruption instead of a
+	// lock/maintainer-script failure). Fail SAFE: treat a query error as
+	// POSSIBLY-INSTALLED and include the package, so a real purge is attempted
+	// and the sweep stays gated behind the confirmed-absent re-query below
+	// (#5428).
 	var installed []string
 	for _, p := range candPkgs {
-		if s.pkgInstalled(p) {
+		ok, qerr := s.pkgInstalled(p)
+		if qerr != nil || ok {
 			installed = append(installed, p)
 		}
 	}
@@ -635,15 +659,18 @@ func (s *realKernelSystem) PruneInactiveSlot(slot, knownGoodUnameR, candidateVer
 		// Re-query dpkg: manual deletion of package-owned files must ONLY
 		// follow a CONFIRMED removal. If any package is still installed (a
 		// partial purge), keep its files and surface the anomaly rather than
-		// delete a still-owned payload (#5076).
+		// delete a still-owned payload (#5076). A query ERROR on the re-query
+		// is NOT a confirmed removal either — fail SAFE and treat it as
+		// still-installed so the sweep is skipped (#5428).
 		var stillInstalled []string
 		for _, p := range installed {
-			if s.pkgInstalled(p) {
+			ok, qerr := s.pkgInstalled(p)
+			if qerr != nil || ok {
 				stillInstalled = append(stillInstalled, p)
 			}
 		}
 		if len(stillInstalled) > 0 {
-			return fmt.Errorf("purge un-promoted candidate %s: still installed after purge: %s",
+			return fmt.Errorf("purge un-promoted candidate %s: still installed or unconfirmed-removed after purge: %s",
 				candidateVersion, strings.Join(stillInstalled, ", "))
 		}
 	}
@@ -666,13 +693,39 @@ func (s *realKernelSystem) PruneInactiveSlot(slot, knownGoodUnameR, candidateVer
 	return nil
 }
 
-// isPkgInstalled reports whether a dpkg package is in the "installed" state.
-func isPkgInstalled(pkg string) bool {
+// isPkgInstalled reports whether a dpkg package is in the "installed" state and
+// whether the query itself succeeded. It is TRI-STATE: (true, nil) installed,
+// (false, nil) confirmed NOT installed, (false, err) status UNKNOWN.
+//
+// dpkg-query exits non-zero in TWO very different situations, and they must not
+// be conflated (#5428):
+//   - the package is genuinely unknown to dpkg ("no packages found matching") —
+//     a never-installed optional pkg (e.g. linux-headers/-modules-extra), OR a
+//     package dpkg fully purged (purge drops it from the DB entirely). This is a
+//     legitimate confirmed-absent, returned as (false, nil). Treating it as an
+//     error would push a never-installed pkg into the purge set and make
+//     `apt-get purge` fail with "Unable to locate package" — a prune regression.
+//   - a real query failure (DB corruption/parse error, permission, lock,
+//     missing binary). The status is UNKNOWN; return the error so a destructive
+//     caller fails SAFE (possibly-installed) rather than deleting owned files.
+func isPkgInstalled(pkg string) (bool, error) {
 	out, err := captureCmd("dpkg-query", "-W", "-f=${Status}", pkg)
 	if err != nil {
-		return false
+		if dpkgQueryAbsent(err) {
+			return false, nil
+		}
+		return false, err
 	}
-	return strings.Contains(out, "install ok installed")
+	return strings.Contains(out, "install ok installed"), nil
+}
+
+// dpkgQueryAbsent reports whether a dpkg-query error means the package is
+// genuinely unknown to dpkg (a legitimate "not installed") rather than a real
+// query failure that must fail SAFE (#5428). captureCmd folds dpkg-query's
+// stderr into the returned error, so the "no packages found matching" marker is
+// visible in err.Error().
+func dpkgQueryAbsent(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "no packages found matching")
 }
 
 func (s *realKernelSystem) Now() time.Time {

--- a/pkg/upgrade/kernel_pkgquery_5428_test.go
+++ b/pkg/upgrade/kernel_pkgquery_5428_test.go
@@ -1,0 +1,157 @@
+package upgrade
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// #5428: the PRE-purge installed-set loop and the POST-purge confirmed-absent
+// re-query both use the dpkg "is this package installed?" helper, which returns
+// false on ANY dpkg-query error. A false-negative there (dpkg-DB corruption /
+// parse error / lock while the package IS actually installed) would drop a
+// still-owned package from the set, skip the purge, and let the sweep delete
+// the candidate's package-owned /boot + /lib/modules files while dpkg still
+// owns them — the same dpkg/filesystem divergence #5427 closed on the
+// lock/maintainer-script vector, now reached via a DB query error. The helper
+// is tri-state (installed / not-installed / query-error) and a query error must
+// FAIL SAFE (treat the package as POSSIBLY-INSTALLED, never delete its files).
+
+// dpkgParseErr models a genuine dpkg-query FAILURE (DB corruption) — distinct
+// from the "no packages found matching" absent verdict, so it must fail safe.
+func dpkgParseErr() error {
+	return fmt.Errorf("dpkg-query -W -f=${Status} linux-image: exit status 2 " +
+		"(output: dpkg-query: error: parsing file '/var/lib/dpkg/status' near line 42)")
+}
+
+func TestPruneInactiveSlot_PrePurgeQueryErrorFailsSafe(t *testing.T) {
+	// dpkg-query ERRORS for every candidate package in the PRE-purge loop while
+	// the packages are (unknowably) still installed. The loop must treat the
+	// query error as possibly-installed: attempt the purge and, because the
+	// error persists, leave the package-owned files intact rather than sweeping
+	// them. Reverting the fix drops the packages from the set, skips the purge,
+	// and sweeps the files — this test then fails (files gone).
+	root := t.TempDir()
+	const cand = "7.0.0-99-generic"
+	const knownGood = "7.0.0-22-generic"
+	modulesDir, bootFile := seedCandidatePayload(t, root, cand)
+
+	purgeAttempted := false
+	sys := &realKernelSystem{
+		fsRoot:         root,
+		pkgInstalledFn: func(string) (bool, error) { return false, dpkgParseErr() },
+		aptGetFn: func(args ...string) error {
+			if len(args) > 0 && args[0] == "purge" {
+				purgeAttempted = true
+			}
+			return nil
+		},
+	}
+
+	err := sys.PruneInactiveSlot("xpf-B", knownGood, cand)
+	if err == nil {
+		t.Fatal("expected a non-nil error when dpkg status cannot be determined")
+	}
+	// The pre-purge loop must have kept the query-error packages in the set, so
+	// a real purge was attempted (not skipped as if nothing were installed).
+	if !purgeAttempted {
+		t.Error("purge must be attempted when dpkg status is unknown (fail-safe possibly-installed), not skipped")
+	}
+	// Package-owned files MUST survive: a query error is not a confirmed
+	// removal, so the sweep must not run.
+	if _, statErr := os.Stat(modulesDir); statErr != nil {
+		t.Errorf("/lib/modules/%s deleted despite an unresolved dpkg-query error (%v) — dpkg/FS divergence", cand, statErr)
+	}
+	if _, statErr := os.Stat(bootFile); statErr != nil {
+		t.Errorf("/boot/vmlinuz-%s deleted despite an unresolved dpkg-query error (%v)", cand, statErr)
+	}
+	// The slot selector is still pointed at known-good regardless.
+	if sel, selErr := sys.ReadSlotSelector("xpf-B"); selErr != nil || sel != knownGood {
+		t.Errorf("slot selector = %q (err %v), want known-good %q", sel, selErr, knownGood)
+	}
+}
+
+func TestPruneInactiveSlot_PostPurgeQueryErrorKeepsFiles(t *testing.T) {
+	// The packages are confirmed installed in the PRE-purge loop and apt-get
+	// purge returns success, but the POST-purge confirmed-absent re-query
+	// ERRORS (DB became unreadable). A query error is NOT a confirmed removal,
+	// so the files must be kept and the anomaly surfaced. Reverting the fix
+	// makes the errored re-query read as "not installed" and sweeps the files.
+	root := t.TempDir()
+	const cand = "7.0.0-99-generic"
+	const knownGood = "7.0.0-22-generic"
+	modulesDir, bootFile := seedCandidatePayload(t, root, cand)
+
+	purged := false
+	sys := &realKernelSystem{
+		fsRoot: root,
+		pkgInstalledFn: func(string) (bool, error) {
+			if !purged {
+				return true, nil // installed before the purge
+			}
+			return false, dpkgParseErr() // status unverifiable after the purge
+		},
+		aptGetFn: func(args ...string) error {
+			if len(args) > 0 && args[0] == "purge" {
+				purged = true
+			}
+			return nil
+		},
+	}
+
+	err := sys.PruneInactiveSlot("xpf-B", knownGood, cand)
+	if err == nil {
+		t.Fatal("expected an error when the post-purge re-query cannot confirm removal")
+	}
+	if !strings.Contains(err.Error(), "still installed") {
+		t.Errorf("error should flag the unconfirmed removal: %v", err)
+	}
+	if _, statErr := os.Stat(modulesDir); statErr != nil {
+		t.Errorf("/lib/modules/%s deleted despite an unconfirmed post-purge removal (%v)", cand, statErr)
+	}
+	if _, statErr := os.Stat(bootFile); statErr != nil {
+		t.Errorf("/boot/vmlinuz-%s deleted despite an unconfirmed post-purge removal (%v)", cand, statErr)
+	}
+}
+
+func TestDpkgQueryAbsent(t *testing.T) {
+	// A genuinely-unknown package ("no packages found matching") is a legitimate
+	// confirmed-absent — NOT a fail-safe query error (else a never-installed
+	// optional pkg would be pushed into the purge set and apt-get would fail
+	// with "Unable to locate package").
+	notFound := fmt.Errorf("dpkg-query -W -f=${Status} linux-headers-x: exit status 1 " +
+		"(output: dpkg-query: no packages found matching linux-headers-x)")
+	if !dpkgQueryAbsent(notFound) {
+		t.Errorf("a \"no packages found matching\" error must classify as absent: %v", notFound)
+	}
+	// A real query failure (DB parse error) is NOT absent — it must fail safe.
+	if dpkgQueryAbsent(dpkgParseErr()) {
+		t.Error("a dpkg DB parse error must NOT classify as absent (must fail safe as possibly-installed)")
+	}
+	// A permission failure is likewise a query error, not an absent verdict.
+	permErr := fmt.Errorf("dpkg-query -W: exit status 2 (output: dpkg-query: cannot open '/var/lib/dpkg/status': Permission denied)")
+	if dpkgQueryAbsent(permErr) {
+		t.Error("a permission error must NOT classify as absent")
+	}
+	if dpkgQueryAbsent(nil) {
+		t.Error("nil is not an absent verdict")
+	}
+}
+
+func TestIsPkgInstalled_RealDpkgQueryTriState(t *testing.T) {
+	// End-to-end classification against the real dpkg-query: a package dpkg has
+	// never heard of must come back (false, nil) — confirmed absent, NO error —
+	// so the pre-purge loop skips it instead of pushing it into the purge set.
+	if _, err := exec.LookPath("dpkg-query"); err != nil {
+		t.Skip("dpkg-query not available")
+	}
+	installed, err := isPkgInstalled("xpf-nonexistent-package-zzz-5428")
+	if err != nil {
+		t.Errorf("an unknown package must classify as confirmed-absent (false, nil), got err %v", err)
+	}
+	if installed {
+		t.Error("an unknown package must not report installed")
+	}
+}

--- a/pkg/upgrade/kernel_purge_5076_test.go
+++ b/pkg/upgrade/kernel_purge_5076_test.go
@@ -50,7 +50,7 @@ func TestPruneInactiveSlot_PurgeFailureLeavesFiles(t *testing.T) {
 	var purgeArgs []string
 	sys := &realKernelSystem{
 		fsRoot:         root,
-		pkgInstalledFn: func(string) bool { return true }, // candidate installed
+		pkgInstalledFn: func(string) (bool, error) { return true, nil }, // candidate installed
 		aptGetFn: func(args ...string) error {
 			purgeArgs = args
 			return fmt.Errorf("dpkg: error: dpkg frontend lock held by another process")
@@ -100,7 +100,7 @@ func TestPruneInactiveSlot_PurgeSuccessSweepsFiles(t *testing.T) {
 	sys := &realKernelSystem{
 		fsRoot: root,
 		// Installed before the purge, absent after — dpkg confirms removal.
-		pkgInstalledFn: func(string) bool { return !purged },
+		pkgInstalledFn: func(string) (bool, error) { return !purged, nil },
 		aptGetFn: func(args ...string) error {
 			if len(args) > 0 && args[0] == "purge" {
 				purged = true
@@ -132,7 +132,7 @@ func TestPruneInactiveSlot_PartialPurgeKeepsFiles(t *testing.T) {
 
 	sys := &realKernelSystem{
 		fsRoot:         root,
-		pkgInstalledFn: func(string) bool { return true }, // never confirmed absent
+		pkgInstalledFn: func(string) (bool, error) { return true, nil }, // never confirmed absent
 		aptGetFn:       func(args ...string) error { return nil },
 	}
 
@@ -162,7 +162,7 @@ func TestPruneInactiveSlot_NothingInstalledSweeps(t *testing.T) {
 	purgeCalled := false
 	sys := &realKernelSystem{
 		fsRoot:         root,
-		pkgInstalledFn: func(string) bool { return false },
+		pkgInstalledFn: func(string) (bool, error) { return false, nil },
 		aptGetFn: func(args ...string) error {
 			purgeCalled = true
 			return nil


### PR DESCRIPTION
## Problem
`isPkgInstalled()` returned `false` on ANY `dpkg-query` error. #5427 hardened
the kernel prune's *post-purge* sweep against purge failures and partial
purges, but both the **PRE-purge installed-set loop** (`kernel_linux.go`, the
loop that builds the `installed` set before purging) and the **POST-purge
confirmed-absent re-query** used that same false-on-error helper.

A dpkg-DB corruption / parse error (or lock / missing binary) *while a package
is actually installed* therefore read as "not installed":

- the package was dropped from the `installed` set,
- `len(installed) == 0` → the purge was **skipped**,
- the best-effort sweep then deleted `/lib/modules/<candidate>` +
  `/boot/*-<candidate>` **while dpkg still owned them**.

Same dpkg/filesystem divergence class #5427 closed, reached via a dpkg-DB query
error instead of a lock/maintainer-script failure. A later same-version
`apt-get install` without `--reinstall` would see the package current and never
restore the deleted files → a slot holding a kernel with no modules/boot files.

## Invariant
A dpkg query-error must NOT be misread as "package removed" on a path that then
deletes package-owned files — fail SAFE (treat as possibly-installed, keep the
files).

## Fix
- Make the pkgInstalled check **tri-state** (installed / not-installed /
  query-error). The seam becomes `pkgInstalledFn func(pkg string) (bool, error)`.
- A query error **fails safe** on both sides — pre-purge (include the package so
  a real purge is attempted) and the post-purge re-query (treat as
  still-installed, skip the sweep). The sweep now only runs behind a **positive
  confirmed-absent**.
- `isPkgInstalled` distinguishes a genuinely-unknown package
  (`"no packages found matching"` → confirmed absent, so a never-installed
  optional pkg like `linux-headers`/`linux-modules-extra` is **not** pushed into
  the purge set and `apt-get purge` does not fail with "Unable to locate
  package") from a real query failure (DB corruption, permission, lock, missing
  binary → fail safe).
- `InstallCandidateKernel` forces `--reinstall` on an uncertain query too
  (payload UNCERTAIN, same as recorded-installed; harmless when not installed).
- Does **not** regress #5427: purge-failure, partial-purge, confirmed-removal,
  nothing-installed, and reinstall paths are all preserved.

## Tests (RED-on-revert proven)
Via the `pkgInstalledFn` seam (inject a query error), asserting against the
`fsRoot` temp-root #5427 added:
- **pre-purge query error** → package treated as possibly-installed, purge
  attempted, `/lib/modules` + `/boot` files **kept**, error surfaced.
- **post-purge re-query error** → files kept, "still installed or
  unconfirmed-removed" error.
- `dpkgQueryAbsent` classification (not-found → absent; parse/permission error →
  fail safe).
- real `dpkg-query` tri-state (unknown pkg → `(false, nil)`).
- not-installed (positive) and installed paths unchanged.

RED proven by reverting the call-site logic (keeping the seam so it still
compiles): both fail-safe tests fail — the sweep deletes the files. `go build
./...`, `go vet ./pkg/upgrade`, and `go test ./pkg/upgrade/...` green.

## Docs
Extended the `PruneInactiveSlot` contract note in
`docs/pr/1930-inc1-kernel-channel/codex-kernel-linux-impl.md`.

Closes #5428

🤖 Generated with [Claude Code](https://claude.com/claude-code)