### PR TITLE
pkg/cli,cmd/cli: reject fail-open CLI tokens (5-defect cohort, #4883)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-07-10 — cli: reject fail-open CLI tokens (5-defect cohort, #4883)
+
+- **Timestamp**: 2026-07-10 (fix/4883-cli-failopen-cohort)
+  - **Action**: #4883 — five CLI fail-open/footgun fixes where a missing or
+    malformed token silently BROADENED a privileged/destructive action.
+    (A) `parseMonitorTrafficArgs` rejects an empty/unrecognized `matching`
+    predicate (a stray/typo token) instead of launching an UNFILTERED
+    tcpdump capture. (B) the `monitor security flow` writer goroutine now
+    takes `monitorFlow.mu` on a writer error, clears `active/cancel/sub`
+    (guarded by subscription identity) and records `lastErr` — surfaced by
+    `show monitor security flow` — so a disk-full/rotation failure no longer
+    wedges the monitor Active. (C) `request chassis cluster failover
+    redundancy-group <N> node` with no node value now errors instead of
+    sending an untargeted `cluster-failover:<N>` (CLI-side validation only;
+    server failover untouched). (D) the `load ... terminal` read loop
+    (extracted to `readTerminalConfig`) commits ONLY on EOF (Ctrl-D);
+    ErrInterrupt (Ctrl-C) or any read error ABORTS and discards the partial
+    input. (E) `clear dhcp client-identifier` rejects a malformed selector
+    (`interface` with no name / unknown selector / stray extra) instead of
+    falling through to the empty (clear-ALL) request; a bare
+    `client-identifier` remains the intentional clear-all. One RED-on-revert
+    test per sub-fix (A-E); all proven RED on targeted revert.
+  - **File(s)**: pkg/cli/monitor_traffic.go, pkg/cli/monitor.go,
+    cmd/cli/request.go, cmd/cli/main.go, cmd/cli/clear.go,
+    pkg/cli/monitor_traffic_matching_4883_test.go,
+    pkg/cli/monitor_flow_writer_stop_4883_test.go,
+    cmd/cli/request_failover_node_4883_test.go,
+    cmd/cli/load_terminal_abort_4883_test.go,
+    cmd/cli/clear_dhcp_duid_4883_test.go, pkg/cli/README.md, _Log.md
+
 ## 2026-07-10 — ddns: resolve bind interface/routing-instance to kernel device (#5070)
 
 - **Timestamp**: 2026-07-10

--- a/cmd/cli/clear.go
+++ b/cmd/cli/clear.go
@@ -238,7 +238,22 @@ func (c *ctl) handleClearDHCP(args []string) error {
 	}
 
 	req := &pb.ClearDHCPClientIdentifierRequest{}
-	if len(args) >= 3 && args[1] == "interface" {
+	// A bare `clear dhcp client-identifier` (no selector) is the intentional
+	// clear-ALL. But a malformed selector must NOT silently degrade to it:
+	// the server branches on `Interface != ""`, so `... interface` (no name)
+	// or `... interfce ge-0/0/0` (unknown selector) used to fall through with
+	// an empty Interface and wipe EVERY DHCPv6 DUID (#4883-E). Require a
+	// well-formed `interface <name>` selector when one is typed.
+	if len(args) >= 2 {
+		if args[1] != "interface" {
+			return fmt.Errorf("usage: clear dhcp client-identifier [interface <name>]")
+		}
+		if len(args) < 3 || args[2] == "" {
+			return fmt.Errorf("clear dhcp client-identifier: 'interface' requires a name")
+		}
+		if len(args) > 3 {
+			return fmt.Errorf("clear dhcp client-identifier: unexpected argument %q after interface name", args[3])
+		}
 		req.Interface = args[2]
 	}
 

--- a/cmd/cli/clear_dhcp_duid_4883_test.go
+++ b/cmd/cli/clear_dhcp_duid_4883_test.go
@@ -1,0 +1,84 @@
+// #4883-E: `clear dhcp client-identifier` with a malformed selector —
+// `... interface` (no name) or `... interfce ge-0/0/0` (unknown selector) —
+// used to fall through with an empty Interface, which the server treats as
+// clear-ALL and wipes every DHCPv6 DUID. A malformed selector must ERROR
+// before the RPC; only a bare `client-identifier` (no selector) is the
+// intentional clear-all.
+
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc"
+)
+
+// clearDUIDRecorder records ClearDHCPClientIdentifier calls so a test can
+// assert a clear-ALL was NOT issued.
+type clearDUIDRecorder struct {
+	pb.BpfrxServiceClient
+
+	calls     int
+	lastIface string
+}
+
+func (f *clearDUIDRecorder) ClearDHCPClientIdentifier(
+	_ context.Context, in *pb.ClearDHCPClientIdentifierRequest, _ ...grpc.CallOption,
+) (*pb.ClearDHCPClientIdentifierResponse, error) {
+	f.calls++
+	f.lastIface = in.GetInterface()
+	return &pb.ClearDHCPClientIdentifierResponse{Message: "ok"}, nil
+}
+
+// A malformed selector must ERROR before any RPC — never fall through to the
+// empty (clear-ALL) request.
+//
+// Goes RED on revert: the old code sends an empty-Interface request for these
+// forms, so calls would be 1 and err nil.
+func TestClearDHCPMalformedSelectorNoRPC_4883(t *testing.T) {
+	for _, args := range [][]string{
+		{"client-identifier", "interface"},                      // interface, no name
+		{"client-identifier", "interfce", "ge-0/0/0"},           // unknown selector
+		{"client-identifier", "interface", "ge-0-0-0", "extra"}, // stray extra token
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			fake := &clearDUIDRecorder{}
+			c := &ctl{client: fake}
+			if err := c.handleClearDHCP(args); err == nil {
+				t.Fatalf("handleClearDHCP(%v) = nil; want a usage error", args)
+			}
+			if fake.calls != 0 {
+				t.Fatalf("ClearDHCPClientIdentifier issued %d times (iface=%q); expected 0 — "+
+					"a malformed selector must not wipe ALL DHCPv6 DUIDs", fake.calls, fake.lastIface)
+			}
+		})
+	}
+}
+
+// The well-formed forms still send: a bare `client-identifier` is the
+// intentional clear-all (empty Interface); `interface <name>` is scoped.
+func TestClearDHCPWellFormedStillSends_4883(t *testing.T) {
+	cases := []struct {
+		args      []string
+		wantIface string
+	}{
+		{[]string{"client-identifier"}, ""},                                  // intentional clear-all
+		{[]string{"client-identifier", "interface", "ge-0-0-0"}, "ge-0-0-0"}, // scoped
+	}
+	for _, tc := range cases {
+		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
+			fake := &clearDUIDRecorder{}
+			c := &ctl{client: fake}
+			if err := c.handleClearDHCP(tc.args); err != nil {
+				t.Fatalf("handleClearDHCP(%v) unexpected error: %v", tc.args, err)
+			}
+			if fake.calls != 1 || fake.lastIface != tc.wantIface {
+				t.Fatalf("handleClearDHCP(%v): calls=%d iface=%q; want 1 / %q",
+					tc.args, fake.calls, fake.lastIface, tc.wantIface)
+			}
+		})
+	}
+}

--- a/cmd/cli/load_terminal_abort_4883_test.go
+++ b/cmd/cli/load_terminal_abort_4883_test.go
@@ -1,0 +1,97 @@
+// #4883-D: the `load ... terminal` read loop took the same `break` for EOF
+// (the intended Ctrl-D commit), readline.ErrInterrupt (Ctrl-C), and every
+// other read error, then Loaded whatever partial lines had been collected —
+// printing "load ... complete". Aborting a paste could silently apply a valid
+// prefix while omitting later stanzas. Only EOF may commit; interrupt / read
+// error must ABORT with the partial input discarded.
+
+package main
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/chzyer/readline"
+)
+
+// A Ctrl-C (readline.ErrInterrupt) mid-collection must abort and discard the
+// partial input.
+//
+// Goes RED on revert: the old break-and-join loop returns the collected prefix
+// with a nil error, so content would be non-empty and err nil.
+func TestReadTerminalConfigAbortsOnInterrupt_4883(t *testing.T) {
+	seq := []struct {
+		line string
+		err  error
+	}{
+		{"set system host-name fw", nil},
+		{"set interfaces ge-0-0-0 unit 0 family inet address 10.0.0.1/24", nil},
+		{"", readline.ErrInterrupt},
+	}
+	i := 0
+	read := func() (string, error) {
+		s := seq[i]
+		i++
+		return s.line, s.err
+	}
+
+	content, err := readTerminalConfig(read)
+	if err == nil {
+		t.Fatal("readTerminalConfig aborted with Ctrl-C returned nil error; a partial config must not be committed")
+	}
+	if content != "" {
+		t.Fatalf("content = %q; want empty (partial input must be discarded on abort)", content)
+	}
+}
+
+// A non-EOF read error must likewise abort.
+func TestReadTerminalConfigAbortsOnReadError_4883(t *testing.T) {
+	seq := []struct {
+		line string
+		err  error
+	}{
+		{"set a", nil},
+		{"", errors.New("terminal read failure")},
+	}
+	i := 0
+	read := func() (string, error) {
+		s := seq[i]
+		i++
+		return s.line, s.err
+	}
+
+	content, err := readTerminalConfig(read)
+	if err == nil {
+		t.Fatal("readTerminalConfig with a read error returned nil error; expected an abort")
+	}
+	if content != "" {
+		t.Fatalf("content = %q; want empty on read-error abort", content)
+	}
+}
+
+// EOF (Ctrl-D) still commits the collected lines — the intended terminator.
+func TestReadTerminalConfigCommitsOnEOF_4883(t *testing.T) {
+	seq := []struct {
+		line string
+		err  error
+	}{
+		{"set a", nil},
+		{"set b", nil},
+		{"", io.EOF},
+	}
+	i := 0
+	read := func() (string, error) {
+		s := seq[i]
+		i++
+		return s.line, s.err
+	}
+
+	content, err := readTerminalConfig(read)
+	if err != nil {
+		t.Fatalf("readTerminalConfig on EOF returned error %v; EOF must commit", err)
+	}
+	if content != "set a\nset b" {
+		t.Fatalf("content = %q; want %q", content, "set a\nset b")
+	}
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -471,6 +471,34 @@ func (c *ctl) handleTraceroute(args []string) error {
 	return nil
 }
 
+// readTerminalConfig collects a pasted configuration from readLine until the
+// input is COMMITTED by Ctrl-D (io.EOF). A readline.ErrInterrupt (Ctrl-C) or
+// any other read error is an ABORT: the partial input is discarded and a
+// non-nil error is returned so handleLoad does NOT apply a truncated subset of
+// the config as if it were complete.
+//
+// Before this the read loop took the same `break` for EOF, ErrInterrupt, and
+// every read error, then joined whatever lines had been collected and Loaded
+// them — printing "load ... complete". Aborting a paste with Ctrl-C could
+// therefore silently apply a valid prefix while omitting later
+// policies/services/interfaces (#4883-D). Only EOF commits.
+func readTerminalConfig(readLine func() (string, error)) (string, error) {
+	var lines []string
+	for {
+		line, err := readLine()
+		if err != nil {
+			if err == io.EOF {
+				return strings.Join(lines, "\n"), nil
+			}
+			if err == readline.ErrInterrupt {
+				return "", fmt.Errorf("load terminal: aborted (partial input discarded)")
+			}
+			return "", fmt.Errorf("load terminal: read error: %v", err)
+		}
+		lines = append(lines, line)
+	}
+}
+
 func (c *ctl) handleLoad(args []string) error {
 	if len(args) < 2 {
 		printConfigTreeHelp("load:", "load")
@@ -487,15 +515,11 @@ func (c *ctl) handleLoad(args []string) error {
 
 	if source == "terminal" {
 		fmt.Println("[Type or paste configuration, then press Ctrl-D on an empty line]")
-		var lines []string
-		for {
-			line, err := c.rl.Readline()
-			if err != nil {
-				break
-			}
-			lines = append(lines, line)
+		var err error
+		content, err = readTerminalConfig(c.rl.Readline)
+		if err != nil {
+			return err
 		}
-		content = strings.Join(lines, "\n")
 	} else {
 		data, err := os.ReadFile(source)
 		if err != nil {

--- a/cmd/cli/request.go
+++ b/cmd/cli/request.go
@@ -210,7 +210,16 @@ func (c *ctl) handleRequestChassisClusterFailover(args []string) error {
 
 	if len(args) >= 2 && args[0] == "redundancy-group" {
 		actionSuffix := args[1]
-		if len(args) >= 4 && args[2] == "node" {
+		if len(args) >= 3 && args[2] == "node" {
+			// `node` was typed but its value is missing. The old
+			// `len(args) >= 4` gate silently dropped the bare `node` and
+			// sent an untargeted `cluster-failover:<rg>`, which the server
+			// treats as ManualFailover(<rg>) — a truncated automation token
+			// or an interactive omission triggers a REAL RG failover
+			// instead of a usage error (#4883-C). Require the node value.
+			if len(args) < 4 {
+				return fmt.Errorf("usage: request chassis cluster failover redundancy-group <N> node <node-id>")
+			}
 			actionSuffix += ":node" + args[3]
 		}
 		action := "cluster-failover:" + actionSuffix

--- a/cmd/cli/request_failover_node_4883_test.go
+++ b/cmd/cli/request_failover_node_4883_test.go
@@ -1,0 +1,74 @@
+// #4883-C: `request chassis cluster failover redundancy-group <N> node` with
+// no node value used to silently drop the bare `node` and send an untargeted
+// `cluster-failover:<N>` (ManualFailover) — a truncated automation token
+// triggered a REAL redundancy-group failover. The CLI must reject the
+// malformed command BEFORE issuing the SystemAction RPC.
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc"
+)
+
+// failoverRecorder records SystemAction calls so a test can assert an
+// untargeted failover was NOT issued.
+type failoverRecorder struct {
+	pb.BpfrxServiceClient
+
+	calls   int
+	actions []string
+}
+
+func (f *failoverRecorder) SystemAction(
+	_ context.Context, in *pb.SystemActionRequest, _ ...grpc.CallOption,
+) (*pb.SystemActionResponse, error) {
+	f.calls++
+	f.actions = append(f.actions, in.GetAction())
+	return &pb.SystemActionResponse{Message: "ok"}, nil
+}
+
+// A bare `node` (no value) must ERROR before any RPC — never fall through to
+// an untargeted cluster-failover.
+//
+// Goes RED on revert: the old `len(args) >= 4` gate skips the bare `node` and
+// sends `cluster-failover:1`, so calls would be 1 and err nil.
+func TestRequestFailoverNodeRequiresValue_4883(t *testing.T) {
+	fake := &failoverRecorder{}
+	c := &ctl{client: fake}
+
+	err := c.handleRequestChassisClusterFailover([]string{"redundancy-group", "1", "node"})
+	if err == nil {
+		t.Fatal("handleRequestChassisClusterFailover(... node) returned nil; expected a usage error")
+	}
+	if fake.calls != 0 {
+		t.Fatalf("SystemAction issued %d times (%v); expected 0 — a missing node value "+
+			"must not trigger an untargeted RG failover", fake.calls, fake.actions)
+	}
+}
+
+// The well-formed variants still send the correct action (no regression): a
+// node-scoped failover and a plain RG failover.
+func TestRequestFailoverWellFormedStillSends_4883(t *testing.T) {
+	cases := []struct {
+		args   []string
+		action string
+	}{
+		{[]string{"redundancy-group", "1", "node", "0"}, "cluster-failover:1:node0"},
+		{[]string{"redundancy-group", "1"}, "cluster-failover:1"},
+	}
+	for _, tc := range cases {
+		fake := &failoverRecorder{}
+		c := &ctl{client: fake}
+		if err := c.handleRequestChassisClusterFailover(tc.args); err != nil {
+			t.Fatalf("handleRequestChassisClusterFailover(%v) unexpected error: %v", tc.args, err)
+		}
+		if fake.calls != 1 || fake.actions[0] != tc.action {
+			t.Fatalf("handleRequestChassisClusterFailover(%v): calls=%d actions=%v; want 1 / [%s]",
+				tc.args, fake.calls, fake.actions, tc.action)
+		}
+	}
+}

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -40,6 +40,13 @@ sibling files (same package, so unexported helpers stay reachable):
 The security-sensitive `--` end-of-options separators in the diagcmd/tcpdump
 argv builders (#2084 / #4524 / #4527) moved verbatim.
 
+Fail-open hardening (#4883): `parseMonitorTrafficArgs` (`monitor_traffic.go`)
+rejects an empty/unrecognized `matching` predicate instead of launching an
+UNFILTERED capture, and the `monitor security flow` writer goroutine
+(`monitor.go`) clears `active/cancel/sub` and records `lastErr` when the trace
+writer fails — so a disk-full/rotation error no longer wedges the monitor
+Active (surfaced by `show monitor security flow`).
+
 ## `show interfaces` render files (#4654)
 
 The `show interfaces` presenters were historically one 1396-line

--- a/pkg/cli/monitor.go
+++ b/pkg/cli/monitor.go
@@ -231,6 +231,12 @@ type monitorFlowState struct {
 	active   bool
 	cancel   context.CancelFunc // cancel the active monitor goroutine
 	sub      *logging.Subscription
+	// lastErr records the reason the writer goroutine last stopped on its
+	// own (disk-full / permission / rotation failure). It is surfaced by
+	// showMonitorSecurityFlow so the operator sees WHY tracing stopped
+	// instead of silently reading Inactive, and it is cleared on each fresh
+	// start (#4883-B).
+	lastErr error
 }
 
 func newMonitorFlowState() *monitorFlowState {
@@ -610,6 +616,9 @@ func (c *CLI) handleMonitorSecurityFlowStart() error {
 	}
 
 	c.monitorFlow.active = true
+	// Clear any error recorded by a previous writer-goroutine stop so a
+	// fresh start does not surface a stale failure reason (#4883-B).
+	c.monitorFlow.lastErr = nil
 
 	// Snapshot the current filters.
 	filters := make([]*monitorFlowFilter, 0, len(c.monitorFlow.filters))
@@ -674,7 +683,21 @@ func (c *CLI) handleMonitorSecurityFlowStart() error {
 				}
 				if err := writer.writeLine(line); err != nil {
 					// Rotation or write failed; stop tracing rather than grow
-					// the active file without bound.
+					// the active file without bound. Clear the monitor state
+					// under the lock so `show ... flow` stops reporting Active
+					// and a fresh `start` is accepted — otherwise the monitor
+					// stays wedged Active (audit telemetry silently stopped
+					// while health reads green) until an operator issues
+					// `stop` (#4883-B). Guard on the subscription identity so
+					// a concurrent stop/start is not clobbered.
+					c.monitorFlow.mu.Lock()
+					if c.monitorFlow.sub == sub {
+						c.monitorFlow.active = false
+						c.monitorFlow.cancel = nil
+						c.monitorFlow.sub = nil
+						c.monitorFlow.lastErr = err
+					}
+					c.monitorFlow.mu.Unlock()
 					return
 				}
 			}
@@ -717,6 +740,12 @@ func (c *CLI) showMonitorSecurityFlow() error {
 	}
 
 	fmt.Printf("  Monitor security flow session status: %s\n", status)
+	// Surface why the writer goroutine stopped on its own (disk-full /
+	// permission / rotation) so a silently-stopped trace is visible rather
+	// than reading Inactive with no explanation (#4883-B).
+	if !c.monitorFlow.active && c.monitorFlow.lastErr != nil {
+		fmt.Printf("  Monitor security flow last error: %v\n", c.monitorFlow.lastErr)
+	}
 	if c.monitorFlow.filename != "" {
 		fmt.Printf("  Monitor security flow trace file: %s\n", filepath.Join(traceLogDir, c.monitorFlow.filename))
 	} else {

--- a/pkg/cli/monitor_flow_writer_stop_4883_test.go
+++ b/pkg/cli/monitor_flow_writer_stop_4883_test.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/logging"
+)
+
+// TestMonitorFlowWriterErrorClearsState_4883 is the #4883-B regression guard.
+// When the flow-trace writer fails (disk-full / permission / rotation), the
+// monitor goroutine used to `return` without reacquiring monitorFlow.mu to
+// clear active/cancel/sub. showMonitorSecurityFlow kept reporting Active and a
+// new `start` was rejected until an operator issued `stop` — audit telemetry
+// silently stopped while health read green.
+//
+// This drives the REAL writer goroutine to a deterministic write failure: the
+// trace file is seeded with content (so the writer rotates on the first line),
+// the trace directory is removed out from under the open fd (so the rotation's
+// rename fails), and one matching event is published. The goroutine must then
+// clear the monitor state, record the error, and accept a fresh start.
+//
+// Goes RED on revert: without the lock+clear the monitor stays Active forever
+// and the poll below times out.
+func TestMonitorFlowWriterErrorClearsState_4883(t *testing.T) {
+	origDir := traceLogDir
+	dir := t.TempDir()
+	traceLogDir = dir
+	defer func() { traceLogDir = origDir }()
+
+	// Seed the trace file so the writer's `written` counter starts > 0 and the
+	// very first line trips the size-based rotation (maxSize=1 below).
+	name := "trace"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(strings.Repeat("x", 200)), 0o600); err != nil {
+		t.Fatalf("seed trace file: %v", err)
+	}
+
+	eventBuf := logging.NewEventBuffer(64)
+	c := &CLI{eventBuf: eventBuf}
+	c.monitorFlow = newMonitorFlowState()
+	c.monitorFlow.filename = name
+	c.monitorFlow.fileSize = 1 // maxSize=1 -> the first line rotates
+	c.monitorFlow.files = 2
+	c.monitorFlow.filters["f"] = &monitorFlowFilter{Name: "f", Protocol: "tcp"}
+
+	if err := c.handleMonitorSecurityFlowStart(); err != nil {
+		t.Fatalf("initial start: %v", err)
+	}
+
+	// Remove the trace directory. The writer's fd stays valid (unlinked file),
+	// but the next rotation's rename of the active file fails deterministically.
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("remove trace dir: %v", err)
+	}
+
+	// Publish one matching event. Rotation fires on the first line, fails
+	// (dir gone), writeLine errors, and the goroutine tears the monitor down.
+	eventBuf.Add(logging.EventRecord{
+		SrcAddr:  "10.0.1.5:1234",
+		DstAddr:  "10.0.2.1:80",
+		Protocol: "TCP",
+	})
+
+	// The goroutine runs asynchronously; poll for the state to clear.
+	var active bool
+	var lastErr error
+	for i := 0; i < 300; i++ {
+		c.monitorFlow.mu.Lock()
+		active = c.monitorFlow.active
+		lastErr = c.monitorFlow.lastErr
+		c.monitorFlow.mu.Unlock()
+		if !active {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if active {
+		t.Fatal("monitor still Active after a writer error; state was not cleared " +
+			"(monitor wedges Active, silently stops tracing until an operator issues stop)")
+	}
+	if lastErr == nil {
+		t.Fatal("writer error was not recorded in monitorFlow.lastErr")
+	}
+
+	// A fresh start must now be accepted (openTraceFile recreates the dir).
+	if err := c.handleMonitorSecurityFlowStart(); err != nil {
+		t.Fatalf("subsequent start rejected after writer error cleared state: %v", err)
+	}
+	c.monitorFlow.mu.Lock()
+	le := c.monitorFlow.lastErr
+	active2 := c.monitorFlow.active
+	c.monitorFlow.mu.Unlock()
+	if le != nil {
+		t.Errorf("monitorFlow.lastErr = %v after a fresh start; want cleared", le)
+	}
+	if !active2 {
+		t.Error("monitor not Active after a successful restart")
+	}
+	_ = c.handleMonitorSecurityFlowStop()
+}

--- a/pkg/cli/monitor_traffic.go
+++ b/pkg/cli/monitor_traffic.go
@@ -81,6 +81,15 @@ func parseMonitorTrafficArgs(args []string) (iface, filter, count string, err er
 				}
 				rest = append(rest, args[j])
 			}
+			// `matching` with no filter expression — a trailing bare
+			// `matching`, or `matching` immediately followed by another
+			// grammar keyword (`matching count 20`) — previously left
+			// filter="" and launched an UNFILTERED privileged capture that
+			// exposes ALL interface traffic instead of the intended flow
+			// (#4883-A). Require an actual filter expression.
+			if len(rest) == 0 {
+				return "", "", "", fmt.Errorf("monitor traffic: 'matching' requires a filter expression")
+			}
 			i += len(rest)
 			filter = stripSurroundingQuotes(strings.Join(rest, " "))
 		case "count":
@@ -108,6 +117,14 @@ func parseMonitorTrafficArgs(args []string) (iface, filter, count string, err er
 			if n < 0 || n > 8192 {
 				return "", "", "", fmt.Errorf("monitor traffic: 'count' must be 0 (unlimited) or 1..8192, got %q", count)
 			}
+		default:
+			// Any token that is neither a grammar keyword nor a value
+			// consumed by one is a typo/stray token. A mistyped predicate
+			// like `matchng tcp port 443` used to hit no switch arm and be
+			// silently discarded, dropping the filter and starting an
+			// UNFILTERED capture (#4883-A). Reject it with a clear error
+			// instead of broadening the capture.
+			return "", "", "", fmt.Errorf("monitor traffic: unrecognized token %q", args[i])
 		}
 	}
 	return iface, filter, count, nil

--- a/pkg/cli/monitor_traffic_matching_4883_test.go
+++ b/pkg/cli/monitor_traffic_matching_4883_test.go
@@ -1,0 +1,53 @@
+package cli
+
+import "testing"
+
+// TestParseMonitorTrafficRejectsEmptyMatching is the #4883-A regression guard.
+// `monitor traffic interface ge-0-0-0 matching` (a trailing bare `matching`,
+// or `matching` immediately followed by another grammar keyword) collected an
+// empty `rest`, returned filter="", and launched tcpdump with NO BPF
+// expression — a privileged capture that exposes ALL interface traffic instead
+// of the intended flow. The parser must now reject an empty `matching`
+// predicate.
+//
+// Goes RED on revert: without the guard filter would be "" and err nil, so
+// handleMonitorTraffic would start an unfiltered capture.
+func TestParseMonitorTrafficRejectsEmptyMatching(t *testing.T) {
+	cases := [][]string{
+		{"interface", "ge-0-0-0", "matching"},                // trailing bare matching
+		{"interface", "ge-0-0-0", "matching", "count", "20"}, // keyword, no filter
+	}
+	for _, args := range cases {
+		_, filter, _, err := parseMonitorTrafficArgs(args)
+		if err == nil {
+			t.Errorf("parseMonitorTrafficArgs(%v) = filter %q, nil err; want an error (an empty matching predicate must not start an unfiltered capture)", args, filter)
+		}
+		if filter != "" {
+			t.Errorf("parseMonitorTrafficArgs(%v) set filter=%q; want empty on rejection", args, filter)
+		}
+	}
+}
+
+// TestParseMonitorTrafficRejectsTypoPredicate is the #4883-A regression guard
+// for a mistyped predicate. `monitor traffic interface ge-0-0-0 matchng tcp
+// port 443` (note the typo `matchng`) hit no switch arm, so every following
+// token was silently discarded and an UNFILTERED capture started. The parser
+// must now reject any unrecognized/stray token.
+//
+// Goes RED on revert: without the default arm the typo tokens are dropped,
+// filter stays "", err is nil, and the capture runs unfiltered.
+func TestParseMonitorTrafficRejectsTypoPredicate(t *testing.T) {
+	cases := [][]string{
+		{"interface", "ge-0-0-0", "matchng", "tcp", "port", "443"}, // typo'd matching
+		{"interface", "ge-0-0-0", "bogus"},                         // stray trailing token
+	}
+	for _, args := range cases {
+		iface, filter, _, err := parseMonitorTrafficArgs(args)
+		if err == nil {
+			t.Errorf("parseMonitorTrafficArgs(%v) = iface %q filter %q, nil err; want an error (a stray/typo token must not be discarded into an unfiltered capture)", args, iface, filter)
+		}
+		if filter != "" {
+			t.Errorf("parseMonitorTrafficArgs(%v) set filter=%q; want empty on rejection", args, filter)
+		}
+	}
+}


### PR DESCRIPTION
Fixes five distinct CLI fail-open / footgun defects where a missing or
malformed token silently BROADENS a privileged/destructive action instead
of erroring. Each fix rejects the malformed/missing token with a clear
usage error; the well-formed forms are unchanged. One RED-on-revert test
per sub-fix (A–E).

Closes #4883

## A. `monitor traffic ... matching` drops the filter (pkg/cli/monitor_traffic.go)
- **Problem:** `monitor traffic interface ge-0-0-0 matching` collected an
  empty filter and launched tcpdump with NO BPF expression; a typo
  (`matchng tcp port 443`) hit no switch arm and was silently discarded —
  both start an UNFILTERED privileged capture exposing ALL interface
  traffic.
- **Fix:** `parseMonitorTrafficArgs` rejects an empty `matching` predicate
  and any stray/typo token. The `--` separator + option-token validator
  (#4524/#4527) are unchanged.
- **Test (RED-on-revert):** `TestParseMonitorTrafficRejectsEmptyMatching` /
  `RejectsTypoPredicate` — FAIL on revert (filter="" / tokens dropped, nil
  err).

## B. Flow-trace writer failure leaves monitor Active (pkg/cli/monitor.go)
- **Problem:** on a `traceWriter.writeLine` error the goroutine `return`ed
  without reacquiring `monitorFlow.mu`, so `active/cancel/sub` stayed set;
  `show monitor security flow` kept reporting Active and a new `start` was
  rejected until `stop` — audit telemetry silently stopped while health
  read green.
- **Fix:** on a writer error the goroutine takes the lock, clears
  `active/cancel/sub` (guarded by subscription identity so a concurrent
  stop/start is not clobbered) and records the failure in a new `lastErr`
  field surfaced by `show monitor security flow`. A fresh `start` clears
  `lastErr`.
- **Test (RED-on-revert):** `TestMonitorFlowWriterErrorClearsState_4883`
  drives the real goroutine to a deterministic rotation failure and asserts
  the monitor clears + records the error + accepts a restart — wedges
  Active for 3s on revert.

## C. Missing `node` value → untargeted failover (cmd/cli/request.go)
- **Problem:** `request chassis cluster failover redundancy-group 1 node`
  (no value) fell through the `len(args) >= 4` gate and sent an untargeted
  `cluster-failover:1` → a real RG failover.
- **Fix:** reject `node` without a value before the RPC. CLI-side
  validation only — the server failover mechanism is untouched.
- **Test (RED-on-revert):** `TestRequestFailoverNodeRequiresValue_4883` —
  asserts no `SystemAction` RPC for the bare `node`.

## D. Ctrl-C / read error applies a partial `load ... terminal` (cmd/cli/main.go)
- **Problem:** the read loop took the same `break` for EOF, ErrInterrupt,
  and every read error, then Load'ed the collected prefix — aborting a
  paste silently applied a partial config.
- **Fix:** the loop moves into a `readTerminalConfig` helper that commits
  ONLY on `io.EOF`; `readline.ErrInterrupt` or any read error aborts and
  discards the partial input. The #5053 signal code (`runSignalLoop`) is a
  different function and is untouched.
- **Test (RED-on-revert):** `TestReadTerminalConfigAbortsOnInterrupt` /
  `AbortsOnReadError` / `CommitsOnEOF`.

## E. Malformed interface-scoped DUID clear → clear-all (cmd/cli/clear.go)
- **Problem:** `clear dhcp client-identifier interface` (no name) or
  `... interfce ge-0/0/0` (unknown selector) fell through with an empty
  Interface, which the server treats as clear-ALL and wipes every DHCPv6
  DUID.
- **Fix:** require a well-formed `interface <name>` selector when one is
  typed (rejecting a value-less `interface`, an unknown selector token, and
  a stray trailing argument). A bare `clear dhcp client-identifier` remains
  the intentional clear-all.
- **Test (RED-on-revert):** `TestClearDHCPMalformedSelectorNoRPC_4883` —
  asserts no `ClearDHCPClientIdentifier` RPC for the malformed forms.
- **Note:** the local interactive CLI `pkg/cli/cli_clear.go` has the same
  pattern; left out of this remote-CLI-scoped cohort and flagged for a
  follow-up.

## Docs
- `pkg/cli/README.md` documents the #4883 fail-open hardening (A + B).
  `cmd/cli/README.md` is a file-inventory that documents no command
  behavior these validation-only fixes contradict, so no update is needed
  there.

## Validation
- `go build ./...` green; `go test ./pkg/cli/... ./cmd/cli/... -count=1`
  green.
- RED-on-revert proven for EACH sub-fix (A–E) by reverting only the
  production behavior with the test kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWSG33WKMZh5V4Xn9z1ebV
