### PR TITLE
pkg/api: bound sessions pagination walk and add an admission gate (#5318)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45261,3 +45261,14 @@ top.
     pkg/upgrade/kernel_pkgquery_5428_test.go,
     pkg/upgrade/kernel_purge_5076_test.go,
     docs/pr/1930-inc1-kernel-channel/codex-kernel-linux-impl.md, _Log.md
+
+## 2026-07-10 — #5318 bound sessions pagination walk + admission gate
+- **Timestamp**: 2026-07-10
+- **Action**: Fixed #5318 (api, connected-client residual after #5237). Added a
+  per-endpoint admission semaphore (`sessionsListLimiter`, reusing
+  `diagcmd.NewLimiter`, cap 4 → HTTP 429 on saturation) to `sessionsHandler`,
+  and bounded the offset-mode Total-counting walk (`sessionCountCap` = 1,000,000;
+  exact byte-compatible Total under the cap, `total_approximate` lower bound past
+  it). #5237 disconnect-abort preserved. RED-on-revert proven for both.
+- **File(s)**: pkg/api/sessions.go, pkg/api/types.go,
+  pkg/api/sessions_pagination_bound_5318_test.go, pkg/api/README.md, _Log.md

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -719,6 +719,37 @@ under the daemon's errgroup. Nothing else imports this package.
   node-local session-map keys (opaque to clients); when the runtime
   dataplane lacks cursor iteration the handler falls back to the offset path.
   Pinned by `sessions_pagination_test.go`.
+- Bounded pagination walk + admission gate (#5318, connected-client residual
+  after the #5237 disconnect-abort). Two hardenings on `GET /security/sessions`
+  so a small paginated read cannot force unbounded full-table work per page:
+  - **Admission bound.** A session list is a full conntrack-table walk that
+    contends with the live session-sync path for per-bucket BPF-map locks. The
+    handler now acquires a slot from `sessionsListLimiter`
+    (`diagcmd.NewLimiter(maxConcurrentSessionLists)` = 4, the SAME fail-fast
+    counting-semaphore idiom the diagnostic ping/traceroute handlers use, #5057)
+    BEFORE the walk and the peer fan-out, releasing on every exit path. Over-cap
+    requests are rejected immediately with **HTTP 429** (`session list
+    concurrency limit reached; retry shortly`) rather than each driving its own
+    simultaneous walk — a scrape flood can no longer multiply lock contention.
+    The #5237 disconnect-abort bounds a SINGLE client's walk once ITS connection
+    drops; this bounds how many CONNECTED clients walk at once, which the
+    disconnect-abort does not.
+  - **Bounded Total.** The offset mode's exact `total` previously forced a FULL
+    v4+v6 table scan on EVERY 100-row page (O(table) per page, repeated per
+    poll) just to count. The walk now caps the count at `sessionCountCap`
+    (`defaultSessionCountCap` = 1,000,000) matching rows: `countCap` is
+    `max(sessionCountCap, offset+limit)` so an explicitly requested deep window
+    still fills to `limit`. UNDER the cap `total` is EXACT and the response is
+    **byte-identical** to before (`total_approximate` is `omitempty`, so it is
+    absent for normal-sized tables). PAST the cap the walk stops and `total`
+    becomes a bounded LOWER BOUND with `total_approximate: true` — only the
+    multi-million-session case degrades, and it degrades gracefully rather than
+    re-walking the whole table per page. Cursor mode (`page_size>0`) is already
+    bounded (it stops at `page_size` and reports no `total`) and is unchanged.
+    A fuller keyset/cursor-default redesign of the offset contract is a possible
+    follow-up; this fix is the minimal bounded one. Pinned by
+    `sessions_pagination_bound_5318_test.go` (RED-on-revert: the bounded-walk and
+    admission assertions both fail if either hardening is removed).
 - Session clear (`POST /api/v1/security/sessions/clear`) clears ALL local
   sessions and accepts NO parameters: a non-empty query string
   (`r.URL.RawQuery`) or request body returns HTTP 400 rather than silently

--- a/pkg/api/sessions.go
+++ b/pkg/api/sessions.go
@@ -17,8 +17,42 @@ import (
 	"github.com/psaab/xpf/pkg/appid"
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/diagcmd"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 )
+
+// maxConcurrentSessionLists bounds how many GET /security/sessions list
+// walks may run at once (#5318). A session list walks the whole v4+v6
+// conntrack table holding per-bucket BPF-map locks, so N concurrent
+// scrapers each drive their own full walk simultaneously — on a
+// multi-million-session firewall that multiplies contention with the live
+// dataplane session-sync path. The cap is deliberately small: legitimate
+// dashboards/automation poll a handful at a time, while a scrape flood must
+// never starve session installs. #5237 already aborts a walk when its own
+// client disconnects; this bounds how many connected clients can walk at
+// once, which the disconnect-abort does not.
+const maxConcurrentSessionLists = 4
+
+// sessionsListLimiter is the admission gate for the session list handler.
+// It reuses the diagcmd fixed-capacity counting semaphore (the same
+// fail-fast idiom the diagnostic ping/traceroute handlers use, #5057):
+// Acquire is non-blocking, so an over-cap request is rejected immediately
+// with HTTP 429 rather than queued into an unbounded backlog. It is a
+// package var so a test can swap in a fresh small-capacity limiter without
+// mutating process-wide state.
+var sessionsListLimiter = diagcmd.NewLimiter(maxConcurrentSessionLists)
+
+// defaultSessionCountCap bounds how many matching sessions the offset list
+// walk counts before it stops and reports Total as an approximate lower
+// bound instead of forcing a full v4+v6 table scan for an EXACT Total on
+// every page (#5318). It is set well above any realistic non-attack session
+// table so the common case keeps its exact, byte-identical Total; only a
+// multi-million-session table degrades to an approximate count.
+const defaultSessionCountCap = 1_000_000
+
+// sessionCountCap is the live cap value. A package var so a test can shrink
+// it and exercise the approximate-Total path without a million-row fixture.
+var sessionCountCap = defaultSessionCountCap
 
 // sessionCursorIterator is the optional cursor-based session iteration
 // surface. The production runtime dataplane (the userspace
@@ -72,6 +106,20 @@ func (s *Server) sessionsHandler(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusServiceUnavailable, "dataplane not loaded")
 		return
 	}
+
+	// Admission bound (#5318): a session list is a full conntrack-table walk
+	// that contends with the live dataplane session-sync path for per-bucket
+	// BPF-map locks. Acquire a slot fail-fast BEFORE the walk (and before the
+	// peer fan-out) so a concurrent-scrape flood is rejected with HTTP 429
+	// rather than each driving its own simultaneous walk. Release on every
+	// exit path via defer. This covers both the offset and cursor paths.
+	release, err := sessionsListLimiter.Acquire()
+	if err != nil {
+		writeError(w, http.StatusTooManyRequests,
+			"session list concurrency limit reached; retry shortly")
+		return
+	}
+	defer release()
 
 	view := s.buildSessionView()
 	q, errMsg := buildSessionQuery(r, view)
@@ -139,13 +187,29 @@ func (s *Server) sessionsOffset(w http.ResponseWriter, r *http.Request, q *sessi
 
 	now := monotonicSeconds()
 	all := make([]SessionEntry, 0)
-	idx := 0
+	matched := 0
+	capped := false
 
-	// Abort the full-table walk if the client disconnects: on a
-	// multi-million-session firewall the offset scan otherwise runs to
-	// completion holding per-bucket BPF-map locks even though the response
-	// is discarded, contending with the live dataplane session-sync path
-	// (#5233). Sampled per batch so the check costs nothing per session.
+	// Bound the Total-counting walk (#5318). The exact-Total contract used to
+	// force a FULL v4+v6 table walk on EVERY page just to report Total —
+	// O(table) work per 100-row page, repeated per poll, contending with the
+	// live session-sync path on a multi-million-session firewall. Cap the
+	// count: walk at most countCap matching rows. UNDER the cap Total is EXACT
+	// and the response is byte-identical to before (total_approximate omitted);
+	// past the cap the walk stops and Total is reported as an approximate lower
+	// bound (total_approximate=true). countCap is raised to cover an explicitly
+	// requested deep window (offset+limit) so a page is never truncated below
+	// the requested limit; only the count degrades on a huge table.
+	countCap := sessionCountCap
+	if need := offset + limit; need > countCap {
+		countCap = need
+	}
+
+	// Abort the walk if the client disconnects: on a multi-million-session
+	// firewall the offset scan otherwise runs holding per-bucket BPF-map
+	// locks even though the response is discarded, contending with the live
+	// dataplane session-sync path (#5237/#5233). Sampled per batch so the
+	// check costs nothing per session.
 	cancelled := newRequestCancelSampler(r.Context(), sessionWalkCancelInterval)
 
 	// IPv4 sessions. A backend iterator failure (e.g. helper restart
@@ -158,39 +222,52 @@ func (s *Server) sessionsOffset(w http.ResponseWriter, r *http.Request, q *sessi
 		if !q.matchV4(key, val) {
 			return true
 		}
-		if idx >= offset && len(all) < limit {
+		if matched >= offset && len(all) < limit {
 			all = append(all, s.enrichSessionV4(key, val, now, view))
 		}
-		idx++
+		matched++
+		// Strictly-greater so a table of EXACTLY countCap matches still
+		// completes and reports an exact Total; only countCap+1 trips the cap.
+		if matched > countCap {
+			capped = true
+			return false
+		}
 		return true
 	}); err != nil {
 		writeError(w, http.StatusInternalServerError, "iterate sessions: "+err.Error())
 		return
 	}
 
-	// IPv6 sessions
-	if err := s.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
-		if cancelled() {
-			return false
-		}
-		if !q.matchV6(key, val) {
+	// IPv6 sessions — skipped entirely once the v4 walk already hit the cap.
+	if !capped {
+		if err := s.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+			if cancelled() {
+				return false
+			}
+			if !q.matchV6(key, val) {
+				return true
+			}
+			if matched >= offset && len(all) < limit {
+				all = append(all, s.enrichSessionV6(key, val, now, view))
+			}
+			matched++
+			if matched > countCap {
+				capped = true
+				return false
+			}
 			return true
+		}); err != nil {
+			writeError(w, http.StatusInternalServerError, "iterate sessions_v6: "+err.Error())
+			return
 		}
-		if idx >= offset && len(all) < limit {
-			all = append(all, s.enrichSessionV6(key, val, now, view))
-		}
-		idx++
-		return true
-	}); err != nil {
-		writeError(w, http.StatusInternalServerError, "iterate sessions_v6: "+err.Error())
-		return
 	}
 
 	s.writeSessionList(w, r, SessionListResponse{
-		Total:    idx,
-		Limit:    limit,
-		Offset:   offset,
-		Sessions: all,
+		Total:            matched,
+		TotalApproximate: capped,
+		Limit:            limit,
+		Offset:           offset,
+		Sessions:         all,
 	})
 }
 

--- a/pkg/api/sessions_pagination_bound_5318_test.go
+++ b/pkg/api/sessions_pagination_bound_5318_test.go
@@ -1,0 +1,243 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/diagcmd"
+)
+
+// TestRESTSessionListBoundsTotalWalk pins the #5318 bounded-Total contract:
+// the default (no page_size) offset list must NOT walk the whole v4+v6 table
+// per page just to report an exact Total. It caps the count at sessionCountCap
+// matching rows — under the cap Total stays EXACT and the response is
+// byte-identical (total_approximate omitted); past the cap the walk stops and
+// Total is reported as an approximate lower bound with total_approximate=true.
+//
+// It reuses cancelCountDP (api_ctx_cancel_5232_5233_test.go), which yields a
+// fixed number of forward (IsReverse==0, so matchV4/V6-admitted) sessions and
+// records how many the walk actually visited before stopping.
+//
+// RED-on-revert: restore sessionsOffset to the unbounded idx walk (count every
+// row, always walk v6). The large-table case then visits the whole 1100-row
+// table (visited==1100, not sessionCountCap+1) and reports total_approximate
+// false, flipping both assertions red.
+func TestRESTSessionListBoundsTotalWalk(t *testing.T) {
+	origCap := sessionCountCap
+	t.Cleanup(func() { sessionCountCap = origCap })
+	sessionCountCap = 200
+
+	t.Run("large table caps the walk and flags approximate", func(t *testing.T) {
+		// nV4 (1000) alone exceeds the cap; nV6 (100) must be skipped entirely.
+		dp := &cancelCountDP{Manager: dataplane.New(), nV4: 1000, nV6: 100}
+		s := &Server{dp: dp}
+		rr := httptest.NewRecorder()
+		// limit=100, offset=0 => countCap = max(200, 100) = 200.
+		s.sessionsHandler(rr, httptest.NewRequest("GET",
+			"/api/v1/security/sessions?limit=100", nil))
+		if rr.Code != 200 {
+			t.Fatalf("status %d, want 200; body: %s", rr.Code, rr.Body.String())
+		}
+		resp := decodeSessions(t, rr.Body.Bytes())
+
+		// The walk stops one past the cap on the v4 leg; v6 is never entered.
+		if dp.visited != sessionCountCap+1 {
+			t.Fatalf("visited %d of 1100 sessions, want %d (walk not bounded to the cap)",
+				dp.visited, sessionCountCap+1)
+		}
+		if !resp.TotalApproximate {
+			t.Fatalf("total_approximate=false on a table larger than the cap; want true")
+		}
+		if resp.Total != sessionCountCap+1 {
+			t.Fatalf("Total=%d, want %d (capped lower bound)", resp.Total, sessionCountCap+1)
+		}
+		// The page must still fill to the requested limit even when capped.
+		if len(resp.Sessions) != 100 {
+			t.Fatalf("returned %d rows, want 100 (page must fill despite the cap)",
+				len(resp.Sessions))
+		}
+		if !bytes.Contains(rr.Body.Bytes(), []byte(`"total_approximate":true`)) {
+			t.Fatalf("wire body missing total_approximate flag: %s", rr.Body.String())
+		}
+	})
+
+	t.Run("small table exact Total, byte-compatible", func(t *testing.T) {
+		// 30 v4 + 10 v6 = 40 matches, well under the cap.
+		dp := &cancelCountDP{Manager: dataplane.New(), nV4: 30, nV6: 10}
+		s := &Server{dp: dp}
+		rr := httptest.NewRecorder()
+		s.sessionsHandler(rr, httptest.NewRequest("GET",
+			"/api/v1/security/sessions?limit=100", nil))
+		if rr.Code != 200 {
+			t.Fatalf("status %d, want 200; body: %s", rr.Code, rr.Body.String())
+		}
+		resp := decodeSessions(t, rr.Body.Bytes())
+
+		// A table under the cap is walked in full (exact Total).
+		if dp.visited != 40 {
+			t.Fatalf("visited %d, want 40 (small table must be walked in full)", dp.visited)
+		}
+		if resp.TotalApproximate {
+			t.Fatalf("total_approximate=true on a small table; want exact Total")
+		}
+		if resp.Total != 40 {
+			t.Fatalf("Total=%d, want 40 (exact)", resp.Total)
+		}
+		if len(resp.Sessions) != 40 {
+			t.Fatalf("returned %d rows, want 40", len(resp.Sessions))
+		}
+		// Backward compatibility: omitempty keeps total_approximate off the wire
+		// for the common case, so an existing client sees the pre-#5318 shape.
+		if bytes.Contains(rr.Body.Bytes(), []byte("total_approximate")) {
+			t.Fatalf("small-table body leaked total_approximate; want omitted: %s",
+				rr.Body.String())
+		}
+	})
+}
+
+// blockingSessionDP is an apiRuntimeDataPlane whose session walk blocks until a
+// gate is released, so a test can hold N handlers inside their walk at once and
+// observe the admission limiter. enter() runs at the top of IterateSessions
+// (before the block) to record concurrency.
+type blockingSessionDP struct {
+	*dataplane.Manager
+	enter func()
+	gate  chan struct{}
+}
+
+func (d *blockingSessionDP) IsLoaded() bool { return true }
+
+func (d *blockingSessionDP) IterateSessions(func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	d.enter()
+	<-d.gate
+	return nil
+}
+
+func (d *blockingSessionDP) IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return nil
+}
+
+// TestRESTSessionListConcurrencyBound pins the #5318 admission contract for the
+// session list handler, mirroring the #5057 diagnostic-limiter test. It swaps
+// sessionsListLimiter for a fresh small-capacity limiter and drives cap+excess
+// concurrent list requests through a walk that blocks on a gate. It asserts:
+//   - at most `cap` handlers run the walk concurrently,
+//   - the `excess` requests are rejected immediately with HTTP 429 (not queued),
+//   - after the admitted walks finish the limiter is fully released, so a
+//     subsequent request succeeds.
+//
+// RED-on-revert: remove the sessionsListLimiter.Acquire()/429 branch from
+// sessionsHandler and every request is admitted — the 429 count drops to 0 and
+// the max-concurrency assertion fires.
+func TestRESTSessionListConcurrencyBound(t *testing.T) {
+	const (
+		capN   = 2
+		excess = 5
+		total  = capN + excess
+	)
+
+	orig := sessionsListLimiter
+	t.Cleanup(func() { sessionsListLimiter = orig })
+	sessionsListLimiter = diagcmd.NewLimiter(capN)
+
+	var (
+		inFlight    int32
+		maxObserved int32
+		attempts    int32
+	)
+	gate := make(chan struct{})         // holds each admitted walk until closed
+	allAttempted := make(chan struct{}) // closed once every request has attempted Acquire
+	var once sync.Once
+	noteAttempt := func() {
+		if atomic.AddInt32(&attempts, 1) == total {
+			once.Do(func() { close(allAttempted) })
+		}
+	}
+
+	dp := &blockingSessionDP{
+		Manager: dataplane.New(),
+		gate:    gate,
+		enter: func() {
+			cur := atomic.AddInt32(&inFlight, 1)
+			defer atomic.AddInt32(&inFlight, -1)
+			for {
+				m := atomic.LoadInt32(&maxObserved)
+				if cur <= m || atomic.CompareAndSwapInt32(&maxObserved, m, cur) {
+					break
+				}
+			}
+			noteAttempt() // admitted: reached the walk, holding a slot
+			<-gate
+		},
+	}
+	s := &Server{dp: dp}
+
+	fire := func() int {
+		rr := httptest.NewRecorder()
+		s.sessionsHandler(rr, httptest.NewRequest("GET", "/api/v1/security/sessions", nil))
+		return rr.Code
+	}
+
+	codes := make([]int, total)
+	var wg sync.WaitGroup
+	for i := 0; i < total; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			c := fire()
+			if c == http.StatusTooManyRequests {
+				noteAttempt() // rejected: fail-fast, counts as an attempt
+			}
+			codes[idx] = c
+		}(i)
+	}
+
+	// Hold the gate until every request has attempted Acquire, so no admitted
+	// walk frees its slot before the excess have been rejected (which would let
+	// an excess request win a freed slot).
+	select {
+	case <-allAttempted:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for %d attempts; inFlight=%d attempts=%d",
+			total, atomic.LoadInt32(&inFlight), atomic.LoadInt32(&attempts))
+	}
+
+	close(gate)
+	wg.Wait()
+
+	var ok, tooMany, other int
+	for _, c := range codes {
+		switch c {
+		case http.StatusOK:
+			ok++
+		case http.StatusTooManyRequests:
+			tooMany++
+		default:
+			other++
+		}
+	}
+	if other != 0 {
+		t.Fatalf("unexpected status codes present: %v", codes)
+	}
+	if tooMany != excess {
+		t.Fatalf("429 count = %d, want %d (excess must be rejected, not queued): %v",
+			tooMany, excess, codes)
+	}
+	if ok != capN {
+		t.Fatalf("200 count = %d, want %d: %v", ok, capN, codes)
+	}
+	if m := atomic.LoadInt32(&maxObserved); m > capN {
+		t.Fatalf("max concurrent session walks = %d, want <= %d", m, capN)
+	}
+
+	// Limiter fully released: a subsequent request must succeed.
+	if code := fire(); code != http.StatusOK {
+		t.Fatalf("post-drain request status = %d, want 200 (limiter not released)", code)
+	}
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -328,12 +328,20 @@ type SessionEntry struct {
 //     stable cursor page; an empty NextPageToken marks the last page.
 //     Total is omitted in cursor mode (it would require a full scan).
 type SessionListResponse struct {
-	Total         int            `json:"total"`
-	Limit         int            `json:"limit"`
-	Offset        int            `json:"offset"`
-	PageSize      int            `json:"page_size,omitempty"`
-	NextPageToken string         `json:"next_page_token,omitempty"`
-	Sessions      []SessionEntry `json:"sessions"`
+	Total int `json:"total"`
+	// TotalApproximate marks Total as a bounded LOWER BOUND rather than an
+	// exact table count (#5318). On a table larger than sessionCountCap the
+	// offset list walk stops after the cap instead of forcing a full v4+v6
+	// scan per page (which contended with session-sync on a multi-million-
+	// session firewall). Omitted (false) for normal-sized tables, where Total
+	// stays exact and the response is byte-identical to the pre-#5318 shape.
+	// Absent in cursor mode (page_size>0), which does not compute a Total.
+	TotalApproximate bool           `json:"total_approximate,omitempty"`
+	Limit            int            `json:"limit"`
+	Offset           int            `json:"offset"`
+	PageSize         int            `json:"page_size,omitempty"`
+	NextPageToken    string         `json:"next_page_token,omitempty"`
+	Sessions         []SessionEntry `json:"sessions"`
 	// NodeID is the cluster node this list was observed on (0 standalone),
 	// mirroring the gRPC GetSessionsResponse.node_id. It is always present
 	// so a dashboard polling one node knows WHICH node's table it sees —


### PR DESCRIPTION
## Problem
`GET /security/sessions` with **no `page_size`** uses the offset path
(`sessionsOffset`). Its iterator callback returns `true` even after the page
fills, so it can count an **exact `Total`** — a FULL v4+v6 conntrack walk **per
100-row page**, repeated per poll, holding per-bucket BPF-map locks and
contending with the live session-sync path. On a multi-million-session table
that is O(v4+v6) work per small page. The endpoint also had **no per-request
concurrency bound**, so N concurrent scrapers each drove their own simultaneous
walk. #5237 already aborts a walk when *its* client disconnects; this is the
**connected-client residual** it does not cover.

## Invariant
A small paginated read must not force unbounded full-table work per page, and a
hot endpoint needs an admission bound.

## Fix (bounded — no pagination-API redesign)
1. **Admission gate.** `sessionsHandler` acquires a slot from
   `sessionsListLimiter` (`diagcmd.NewLimiter(maxConcurrentSessionLists)` = 4 —
   the same fail-fast counting-semaphore idiom the diagnostic ping/traceroute
   handlers already use, #5057) **before** the walk and the peer fan-out,
   releasing on every exit path. Over-cap requests get **HTTP 429** immediately
   instead of each driving a walk. Covers both the offset and cursor paths.
2. **Bounded Total.** The offset walk caps the count at `sessionCountCap`
   (`defaultSessionCountCap` = 1,000,000) matching rows; `countCap` is
   `max(sessionCountCap, offset+limit)` so an explicitly requested deep window
   still fills to `limit`. **Under the cap `total` is EXACT and the response is
   byte-identical** (`total_approximate` is `omitempty`, absent for normal
   tables). Past the cap the walk stops and `total` becomes a bounded lower
   bound with `total_approximate: true` — only the multi-million-session case
   degrades, gracefully. Cursor mode (`page_size>0`) was already bounded and is
   unchanged.

The #5237/#5233 disconnect-abort (`newRequestCancelSampler`) is **preserved** —
the cancel check still runs at the top of every iterator callback.

## Tests (RED-on-revert proven)
`pkg/api/sessions_pagination_bound_5318_test.go`:
- **Bounded walk** — a table larger than the cap stops at `sessionCountCap+1`
  rows (v6 skipped) and reports `total_approximate: true`; a small table walks
  in full with an exact `total` and **no** `total_approximate` on the wire.
- **Admission bound** — `cap+excess` concurrent requests → the `excess` get
  429, at most `cap` walk at once, limiter fully released after (post-drain
  request succeeds).
- **RED-on-revert:** reverting the bounding logic walks the whole 1100-row
  table (`visited=1100`); reverting the `Acquire` gate admits all requests (429
  count 0). Both flip red. The #5233 disconnect-abort test and the full
  `pkg/api` suite stay green.

`pkg/api/README.md` documents the Total-approximation semantics past the cap and
the concurrency bound.

## Follow-up
A fuller keyset/cursor-default redesign of the offset `total` contract is a
possible follow-up; this PR is the minimal bounded fix.

Closes #5318

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015G3pud2NbPcVdem3hnjVh7