### PR TITLE
cmd/xpfd: add subcommand dispatch + arg-parsing test coverage (#4825)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45302,3 +45302,8 @@ top.
   it). #5237 disconnect-abort preserved. RED-on-revert proven for both.
 - **File(s)**: pkg/api/sessions.go, pkg/api/types.go,
   pkg/api/sessions_pagination_bound_5318_test.go, pkg/api/README.md, _Log.md
+
+## #4825 cmd/xpfd dispatch test coverage
+- **Timestamp**: 2026-07-10
+- **Action**: Extract testable top-level dispatch seam (classifyCommand) + upgrade->kernel route seam (upgradeArgsSelectKernel), add dispatch tests. Behavior-preserving; main() output byte-identical (verified vs origin/master binary across 11 dispatch paths).
+- **File(s)**: cmd/xpfd/main.go, cmd/xpfd/upgrade.go, cmd/xpfd/dispatch_test.go, cmd/xpfd/README.md

--- a/cmd/xpfd/README.md
+++ b/cmd/xpfd/README.md
@@ -10,6 +10,18 @@ and exposes gRPC + HTTP REST + an interactive CLI.
 `daemon.New(opts)`. The daemon instance assembles every subsystem
 manager from `pkg/*` and runs them under an errgroup.
 
+`main()` first routes on `classifyCommand(os.Args)` — the pure,
+side-effect-free SSOT for the top-level subcommand decision (which
+subcommand runs for a given argv; `cmdDaemon` is the fall-through that
+parses the daemon flags). `xpfd upgrade` then routes on
+`upgradeArgsSelectKernel` (binary cut-over vs `upgrade kernel`). Both
+routing decisions and every subcommand arg parser
+(`parseUpgradeArgs`, `parseSeedRuntimeArgs`,
+`parsePublishGenerationArgs`, `parseCleanupArgs`,
+`validateKernelVerbArgs`) are unit-testable without `os.Exit` or the
+real upgrade/cleanup side effects (`dispatch_test.go`,
+`upgrade_args_4869_test.go`, `leftover_args_5322_test.go`).
+
 ## Flags
 
 - `-config` — config file path. Default `/etc/xpf/xpf.conf`.

--- a/cmd/xpfd/dispatch_test.go
+++ b/cmd/xpfd/dispatch_test.go
@@ -1,0 +1,75 @@
+package main
+
+import "testing"
+
+// #4825: cmd/xpfd had arg-parsing tests (parseUpgradeArgs #4869, the #5322
+// leftover-arg guards, gcProtectionForPublish #4876, buildUpgradeSystem #5286)
+// but the TOP-LEVEL subcommand DISPATCH decision — which subcommand main()
+// selects for a given argv — lived inline in main() reading os.Args and was
+// never unit-testable (every branch calls os.Exit or a real side-effecting
+// handler). classifyCommand is the extracted routing SSOT main() switches on;
+// these tests pin the routing so a mis-route (e.g. a typo'd operational verb
+// booting a second daemon, or upgrade routed to the wrong handler) is RED.
+
+// TestClassifyCommand pins the top-level `xpfd` subcommand routing decision.
+func TestClassifyCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		argv []string
+		want xpfdCommand
+	}{
+		// argv[0] is the program name; the subcommand is argv[1].
+		{"no args runs daemon", []string{"xpfd"}, cmdDaemon},
+		{"nil argv runs daemon", nil, cmdDaemon},
+		{"version", []string{"xpfd", "version"}, cmdVersion},
+		{"protocol-versions", []string{"xpfd", "protocol-versions"}, cmdProtocolVersions},
+		{"cleanup", []string{"xpfd", "cleanup"}, cmdCleanup},
+		{"cleanup with stray operand still routes to cleanup", []string{"xpfd", "cleanup", "oops"}, cmdCleanup},
+		{"upgrade", []string{"xpfd", "upgrade"}, cmdUpgrade},
+		{"upgrade rolling", []string{"xpfd", "upgrade", "--rolling"}, cmdUpgrade},
+		{"upgrade kernel routes top-level to upgrade", []string{"xpfd", "upgrade", "kernel", "arm", "6.18.0"}, cmdUpgrade},
+		{"seed-runtime", []string{"xpfd", "seed-runtime"}, cmdSeedRuntime},
+		{"publish-generation", []string{"xpfd", "publish-generation"}, cmdPublishGeneration},
+		{"verify-dataplane", []string{"xpfd", "verify-dataplane"}, cmdVerifyDataplane},
+		{"check-config", []string{"xpfd", "check-config", "/etc/xpf/xpf.conf"}, cmdCheckConfig},
+		{"unknown positional verb", []string{"xpfd", "show"}, cmdUnknown},
+		{"unknown positional verb with args", []string{"xpfd", "request", "system", "reboot"}, cmdUnknown},
+		{"leading-dash flag is daemon", []string{"xpfd", "--config", "/tmp/x.conf"}, cmdDaemon},
+		{"single-dash flag is daemon", []string{"xpfd", "-debug"}, cmdDaemon},
+		{"empty first token is daemon", []string{"xpfd", ""}, cmdDaemon},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyCommand(tt.argv); got != tt.want {
+				t.Fatalf("classifyCommand(%q) = %d, want %d", tt.argv, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestUpgradeArgsSelectKernel pins the second-level `xpfd upgrade` route:
+// only a leading "kernel" operand selects the #1930 kernel channel; everything
+// else (including the dash-less "rolling" typo) stays on the #1917 binary
+// cut-over path. This decision was previously inline in runUpgradeSubcommand
+// (untestable — the function calls os.Exit and builds a real runner).
+func TestUpgradeArgsSelectKernel(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"kernel arm", []string{"kernel", "arm", "6.18.0"}, true},
+		{"kernel bare", []string{"kernel"}, true},
+		{"empty is binary cut", nil, false},
+		{"rolling flag is binary cut", []string{"--rolling"}, false},
+		{"dashless rolling typo is binary cut", []string{"rolling"}, false},
+		{"kernel not first is binary cut", []string{"--rolling", "kernel"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := upgradeArgsSelectKernel(tt.args); got != tt.want {
+				t.Fatalf("upgradeArgsSelectKernel(%q) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/xpfd/main.go
+++ b/cmd/xpfd/main.go
@@ -26,22 +26,85 @@ var (
 	commit    = "unknown"
 )
 
+// xpfdCommand identifies which top-level `xpfd` subcommand an argv selects.
+// cmdDaemon is the fall-through (no recognized subcommand: parse the daemon
+// flags and run); cmdUnknown is a non-flag first token that matches no known
+// subcommand (a hard usage error).
+type xpfdCommand int
+
+const (
+	cmdDaemon xpfdCommand = iota
+	cmdVersion
+	cmdProtocolVersions
+	cmdCleanup
+	cmdUpgrade
+	cmdSeedRuntime
+	cmdPublishGeneration
+	cmdVerifyDataplane
+	cmdCheckConfig
+	cmdUnknown
+)
+
+// classifyCommand maps a full argv (os.Args) to the top-level subcommand it
+// selects, WITHOUT executing any side effects. It is the single source of
+// truth for main()'s routing decision, extracted so that "which subcommand
+// runs for which argv" is unit-testable without os.Exit or the real
+// upgrade/cleanup/daemon side effects. It mirrors, in order, the first-token
+// checks main() historically performed:
+//
+//   - a recognized verb ("version", "cleanup", "upgrade", ...) selects that
+//     subcommand;
+//   - a non-empty, non-flag first token that matches no verb is cmdUnknown
+//     (rejected so a typo'd `xpfd show ...` never boots a second daemon);
+//   - anything else (no args, an empty first token, or a leading '-' flag)
+//     falls through to cmdDaemon.
+func classifyCommand(argv []string) xpfdCommand {
+	if len(argv) <= 1 {
+		return cmdDaemon
+	}
+	switch argv[1] {
+	case "version":
+		return cmdVersion
+	case "protocol-versions":
+		return cmdProtocolVersions
+	case "cleanup":
+		return cmdCleanup
+	case "upgrade":
+		return cmdUpgrade
+	case "seed-runtime":
+		return cmdSeedRuntime
+	case "publish-generation":
+		return cmdPublishGeneration
+	case "verify-dataplane":
+		return cmdVerifyDataplane
+	case "check-config":
+		return cmdCheckConfig
+	}
+	// Reject unknown positional arguments — prevents accidentally starting
+	// a second daemon when running "xpfd show ..." outside the CLI. Use the
+	// "cli" binary or run xpfd interactively for show/request/configure.
+	if argv[1] != "" && argv[1][0] != '-' {
+		return cmdUnknown
+	}
+	return cmdDaemon
+}
+
 func main() {
-	if len(os.Args) > 1 && os.Args[1] == "version" {
+	switch classifyCommand(os.Args) {
+	case cmdVersion:
 		fmt.Printf("xpfd %s (commit %s, built %s)\n", version, commit, buildTime)
 		return
-	}
 
-	// `xpfd protocol-versions` emits the compile-time HA / session-sync /
-	// config-DB version constants this binary embeds, machine-parseably
-	// (key=value lines). #1930 INC-3 LANE-2: the mixed-base image-replace gate
-	// reads these from the STAGED binary (unpacked from the new image, run on
-	// the deploy host) to decide — WITHOUT booting the image — whether the new
-	// image's HA/session-sync protocol is back-compatible with the still-running
-	// peer. Pairs with the bake version manifest (a file read where the binary
-	// can't be run, e.g. cross-arch). Keep keys stable: external tooling parses
-	// them.
-	if len(os.Args) > 1 && os.Args[1] == "protocol-versions" {
+	case cmdProtocolVersions:
+		// `xpfd protocol-versions` emits the compile-time HA / session-sync /
+		// config-DB version constants this binary embeds, machine-parseably
+		// (key=value lines). #1930 INC-3 LANE-2: the mixed-base image-replace gate
+		// reads these from the STAGED binary (unpacked from the new image, run on
+		// the deploy host) to decide — WITHOUT booting the image — whether the new
+		// image's HA/session-sync protocol is back-compatible with the still-running
+		// peer. Pairs with the bake version manifest (a file read where the binary
+		// can't be run, e.g. cross-arch). Keep keys stable: external tooling parses
+		// them.
 		fmt.Printf("xpf-version=%s\n", version)
 		fmt.Printf("ha-protocol-version=%d\n", cluster.CurrentHAProtocolVersion)
 		fmt.Printf("ha-protocol-min-compat=%d\n", cluster.MinCompatHAProtocolVersion)
@@ -52,9 +115,8 @@ func main() {
 		fmt.Printf("configdb-envelope-version=%d\n", configstore.EnvelopeFormatVersion)
 		fmt.Printf("configdb-min-reader-version=%d\n", configstore.EnvelopeMinReaderVersion)
 		return
-	}
 
-	if len(os.Args) > 1 && os.Args[1] == "cleanup" {
+	case cmdCleanup:
 		// #5322: cleanup takes NO flags or positional arguments; like #4869's
 		// `xpfd upgrade`, a stray operand (e.g. a typo'd path) is a hard usage
 		// error, not silently ignored while cleanup still GCs all pinned
@@ -90,52 +152,48 @@ func main() {
 		fm.Stop()
 		fmt.Println("all pinned BPF state and managed routes removed")
 		return
-	}
 
-	// #1917 increment B in-place upgrade cut-over. `xpfd upgrade` performs
-	// the verified, atomic, rollback-capable STOP->FLIP->START cut to the
-	// dpkg-staged version; `xpfd upgrade --rolling` drives a controlled
-	// per-node HA drain so a cluster stays forwarding. Invoked from the
-	// .deb postinst (standalone) and by the operator / dogfood driver.
-	if len(os.Args) > 1 && os.Args[1] == "upgrade" {
+	case cmdUpgrade:
+		// #1917 increment B in-place upgrade cut-over. `xpfd upgrade` performs
+		// the verified, atomic, rollback-capable STOP->FLIP->START cut to the
+		// dpkg-staged version; `xpfd upgrade --rolling` drives a controlled
+		// per-node HA drain so a cluster stays forwarding. Invoked from the
+		// .deb postinst (standalone) and by the operator / dogfood driver.
 		runUpgradeSubcommand(os.Args[2:])
 		return
-	}
 
-	// #1964 mechanism A: `xpfd seed-runtime` seeds the versioned runtime
-	// layout on FIRST `.deb` install. The postinst runs this on first
-	// install ($2 empty) AFTER unpack but BEFORE #DEBHELPER# starts the
-	// unit: it copies staged/* into versions/<v>/, sets versions/current ->
-	// <v>, and repoints /usr/local/sbin/* through versions/current — giving
-	// every appliance a real, immutable rollback target before the first
-	// in-place upgrade can ever STOP the daemon. No cut/verify/stop here.
-	// Idempotent: a re-run (apt re-running the postinst) converges to the
-	// same fully-seeded state.
-	if len(os.Args) > 1 && os.Args[1] == "seed-runtime" {
+	case cmdSeedRuntime:
+		// #1964 mechanism A: `xpfd seed-runtime` seeds the versioned runtime
+		// layout on FIRST `.deb` install. The postinst runs this on first
+		// install ($2 empty) AFTER unpack but BEFORE #DEBHELPER# starts the
+		// unit: it copies staged/* into versions/<v>/, sets versions/current ->
+		// <v>, and repoints /usr/local/sbin/* through versions/current — giving
+		// every appliance a real, immutable rollback target before the first
+		// in-place upgrade can ever STOP the daemon. No cut/verify/stop here.
+		// Idempotent: a re-run (apt re-running the postinst) converges to the
+		// same fully-seeded state.
 		runSeedRuntimeSubcommand(os.Args[2:])
 		return
-	}
 
-	// #1981 Option B: `xpfd publish-generation` copies the dpkg-staged binary
-	// set into an immutable staged-gen/<genid>/ and repoints current-gen, so a
-	// later cut reads a whole, single-generation source dpkg is not rewriting
-	// (closing the dpkg-unpack vs operator-cut torn-read race). The postinst
-	// runs it after a complete unpack before the cut; an operator runs it as
-	// the deferred-publish recovery verb (when the postinst deferred the
-	// publish because the upgrade lock was busy) before `xpfd upgrade`.
-	if len(os.Args) > 1 && os.Args[1] == "publish-generation" {
+	case cmdPublishGeneration:
+		// #1981 Option B: `xpfd publish-generation` copies the dpkg-staged binary
+		// set into an immutable staged-gen/<genid>/ and repoints current-gen, so a
+		// later cut reads a whole, single-generation source dpkg is not rewriting
+		// (closing the dpkg-unpack vs operator-cut torn-read race). The postinst
+		// runs it after a complete unpack before the cut; an operator runs it as
+		// the deferred-publish recovery verb (when the postinst deferred the
+		// publish because the upgrade lock was busy) before `xpfd upgrade`.
 		runPublishGenerationSubcommand(os.Args[2:])
 		return
-	}
 
-	// #1864 deploy-time pre-flight: run the kernel BPF verifier against
-	// the shim object EMBEDDED IN THIS BINARY without touching any
-	// production state (anonymous maps, no pins, no attach, nothing
-	// detached — a running daemon's loaded program keeps forwarding).
-	// Deploy tooling pushes the NEW binary to a temp path and runs
-	// this BEFORE stopping the old daemon; a REJECT refuses the deploy
-	// instead of killing the dataplane (the 2026-06-10 incident shape).
-	if len(os.Args) > 1 && os.Args[1] == "verify-dataplane" {
+	case cmdVerifyDataplane:
+		// #1864 deploy-time pre-flight: run the kernel BPF verifier against
+		// the shim object EMBEDDED IN THIS BINARY without touching any
+		// production state (anonymous maps, no pins, no attach, nothing
+		// detached — a running daemon's loaded program keeps forwarding).
+		// Deploy tooling pushes the NEW binary to a temp path and runs
+		// this BEFORE stopping the old daemon; a REJECT refuses the deploy
+		// instead of killing the dataplane (the 2026-06-10 incident shape).
 		if err := dataplane.VerifyEmbeddedUserspaceShim(); err != nil {
 			if errors.Is(err, dataplane.ErrUserspaceShimVerifierReject) {
 				fmt.Printf("REJECT embedded userspace shim\n%v\n", err)
@@ -146,18 +204,18 @@ func main() {
 		}
 		fmt.Println("PASS embedded userspace shim (verifier accepted; no production state touched)")
 		return
-	}
 
-	// #1879 day-0 validation gate: run the REAL strict commit-check
-	// pipeline (parse → typed-leaf SchemaValidate on the expanded tree →
-	// strict compile; configstore.CheckText) against a config file
-	// without touching any daemon, store, or dataplane state. The
-	// first-boot config-drive loader (scripts/image/xpf-day0-config)
-	// validates the untrusted day-0 config with this BEFORE installing
-	// it as /etc/xpf/xpf.conf. Exit codes mirror verify-dataplane's
-	// shape: 0 PASS, 2 config rejected, 1 other error (unreadable file,
-	// oversize, bad flags).
-	if len(os.Args) > 1 && os.Args[1] == "check-config" {
+	case cmdCheckConfig:
+		// #1879 day-0 validation gate: run the REAL strict commit-check
+		// pipeline (parse → typed-leaf SchemaValidate on the expanded tree →
+		// strict compile; configstore.CheckText) against a config file
+		// without touching any daemon, store, or dataplane state. The
+		// first-boot config-drive loader (scripts/image/xpf-day0-config)
+		// validates the untrusted day-0 config with this BEFORE installing
+		// it as /etc/xpf/xpf.conf. Exit codes mirror verify-dataplane's
+		// shape: 0 PASS, 2 config rejected, 1 other error (unreadable file,
+		// oversize, bad flags).
+		//
 		// ContinueOnError, not ExitOnError: the flag package exits
 		// with status 2 on a bad flag, which would collide with this
 		// subcommand's "2 = config rejected" contract that the day-0
@@ -236,17 +294,14 @@ func main() {
 		}
 		fmt.Printf("PASS %s (strict commit-check: parse + schema + compile + device-map preflight)\n", path)
 		return
-	}
 
-	// Reject unknown positional arguments — prevents accidentally starting
-	// a second daemon when running "xpfd show ..." outside the CLI.
-	// Use the "cli" binary or run xpfd interactively for show/request/configure.
-	if len(os.Args) > 1 && os.Args[1] != "" && os.Args[1][0] != '-' {
+	case cmdUnknown:
 		fmt.Fprintf(os.Stderr, "xpfd: unknown command %q\n", os.Args[1])
 		fmt.Fprintf(os.Stderr, "  use the 'cli' binary for remote commands, or run xpfd on a TTY\n")
 		os.Exit(1)
 	}
 
+	// cmdDaemon: no recognized subcommand — parse the daemon flags and run.
 	configFile := flag.String("config", "/etc/xpf/xpf.conf", "configuration file path")
 	noDataplane := flag.Bool("no-dataplane", false, "run without a dataplane (config-only mode)")
 	apiAddr := flag.String("api-addr", "127.0.0.1:8080", "HTTP API listen address (empty to disable)")

--- a/cmd/xpfd/upgrade.go
+++ b/cmd/xpfd/upgrade.go
@@ -28,7 +28,7 @@ import (
 func runUpgradeSubcommand(args []string) {
 	// #1930: `xpfd upgrade kernel ...` is the LANE-1 verify-gated in-place
 	// kernel channel (a distinct sub-verb from the #1917 binary cut-over).
-	if len(args) > 0 && args[0] == "kernel" {
+	if upgradeArgsSelectKernel(args) {
 		runUpgradeKernelSubcommand(args[1:])
 		return
 	}
@@ -78,6 +78,16 @@ func runUpgradeSubcommand(args []string) {
 		os.Exit(1)
 	}
 	fmt.Println("upgrade complete")
+}
+
+// upgradeArgsSelectKernel reports whether `xpfd upgrade <args...>` routes to the
+// #1930 `upgrade kernel` sub-verb (verify-gated in-place kernel channel) rather
+// than the #1917 binary cut-over. The kernel route is selected iff the first
+// operand is exactly "kernel". Extracted so the second-level dispatch decision
+// is unit-testable without the os.Exit / real-runner side effects of
+// runUpgradeSubcommand.
+func upgradeArgsSelectKernel(args []string) bool {
+	return len(args) > 0 && args[0] == "kernel"
 }
 
 // newUpgradeConfig assembles the upgrade Runner Config, WIRING the post-cut


### PR DESCRIPTION
## Problem

Issue #4825 flags cmd/xpfd as having zero dispatch coverage. On CURRENT
origin/master the literal claim is stale — cmd/xpfd already has four test
files covering the subcommand **arg parsers**:

- `parseUpgradeArgs` (#4869)
- the #5322 leftover-arg guards (`parseSeedRuntimeArgs`,
  `parsePublishGenerationArgs`, `parseCleanupArgs`, `validateKernelVerbArgs`)
- `gcProtectionForPublish` (#4876)
- `buildUpgradeSystem` helper-probe wiring (#5286)

But the **actual gap #4825 points at is real and unaddressed**: the
top-level subcommand DISPATCH decision — *which subcommand `main()`
selects for a given argv* — lived inline in `main()` reading `os.Args`,
and the `upgrade`→`upgrade kernel` second-level route lived inline in
`runUpgradeSubcommand`. Both call `os.Exit` / a real side-effecting
handler, so neither routing decision was unit-testable.

## Change (testable-dispatch seam, behavior-preserving)

Two small, consumed seams:

- **`classifyCommand(argv) -> xpfdCommand`** — the pure, side-effect-free
  SSOT for the top-level subcommand decision. `main()` now switches on
  it; `cmdDaemon` is the fall-through that parses the daemon flags. The
  ladder-of-ifs became a switch; **no subcommand body changed**.
- **`upgradeArgsSelectKernel(args) bool`** — the binary-cut vs
  `upgrade kernel` route, now consumed by `runUpgradeSubcommand`.

**main() output is byte-identical.** The origin/master binary and the
refactored binary produce identical stdout/stderr **and exit codes**
across 11 observable dispatch paths (version, protocol-versions, unknown
verb, check-config bad-flag/missing-file, and the
cleanup/upgrade/seed-runtime/publish-generation leftover-arg rejections).

## Tests

`cmd/xpfd/dispatch_test.go`:

- `TestClassifyCommand` — 18 argv→command cases, including the subtle
  ones (empty / leading-dash first token → daemon, unknown positional →
  `cmdUnknown`, `upgrade kernel` routing top-level to `cmdUpgrade`).
- `TestUpgradeArgsSelectKernel` — the second-level route incl. the
  dash-less `rolling` typo staying on the binary-cut path.

Both are **RED-on-drop**: sabotaging `classifyCommand` to mis-route
`upgrade` turns `TestClassifyCommand` red (verified). Coverage of the
already-tested arg parsers was intentionally **not** duplicated.

`go build ./...`, `go vet ./cmd/xpfd/...`, and `go test ./cmd/xpfd/...`
(new + all pre-existing tests) are green; `gofmt` clean.

Docs: `cmd/xpfd/README.md` documents the routing seams.

Closes #4825

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XjdaD4hHBgqorwdx7oRHN