### PR TITLE
pkg/api: gate the session aggregation handlers behind the admission limiter (#5433)

### DIFF
--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -724,8 +724,8 @@ under the daemon's errgroup. Nothing else imports this package.
   so a small paginated read cannot force unbounded full-table work per page:
   - **Admission bound.** A session list is a full conntrack-table walk that
     contends with the live session-sync path for per-bucket BPF-map locks. The
-    handler now acquires a slot from `sessionsListLimiter`
-    (`diagcmd.NewLimiter(maxConcurrentSessionLists)` = 4, the SAME fail-fast
+    handler now acquires a slot from `sessionWalkLimiter`
+    (`diagcmd.NewLimiter(maxConcurrentSessionWalks)` = 4, the SAME fail-fast
     counting-semaphore idiom the diagnostic ping/traceroute handlers use, #5057)
     BEFORE the walk and the peer fan-out, releasing on every exit path. Over-cap
     requests are rejected immediately with **HTTP 429** (`session list
@@ -733,7 +733,19 @@ under the daemon's errgroup. Nothing else imports this package.
     simultaneous walk — a scrape flood can no longer multiply lock contention.
     The #5237 disconnect-abort bounds a SINGLE client's walk once ITS connection
     drops; this bounds how many CONNECTED clients walk at once, which the
-    disconnect-abort does not.
+    disconnect-abort does not. **#5433 extends the SAME gate to the aggregation
+    siblings** `GET /security/sessions/summary` and
+    `GET /security/sessions/summary/zone-pairs`, which drive the identical full
+    v4+v6 walk. All three share ONE `sessionWalkLimiter` so the bound is on the
+    AGGREGATE walk concurrency across the scan endpoints, not one budget per
+    endpoint (they contend for the same locks). The aggregation handlers compute
+    an EXACT summary / zone-pair breakdown, so `sessionCountCap` is NOT applied —
+    an exact aggregate genuinely needs the full walk and a cap would change the
+    response contract; the admission gate alone is the fix (no response-shape
+    change). Over-cap aggregation requests return **HTTP 429** (`session scan
+    concurrency limit reached; retry shortly`). Pinned by
+    `sessions_aggregation_bound_5433_test.go` (per-handler concurrency bound +
+    shared-limiter cross-endpoint 429 + permit-release, RED-on-revert).
   - **Bounded Total.** The offset mode's exact `total` previously forced a FULL
     v4+v6 table scan on EVERY 100-row page (O(table) per page, repeated per
     poll) just to count. The walk now caps the count at `sessionCountCap`

--- a/pkg/api/sessions.go
+++ b/pkg/api/sessions.go
@@ -21,9 +21,11 @@ import (
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 )
 
-// maxConcurrentSessionLists bounds how many GET /security/sessions list
-// walks may run at once (#5318). A session list walks the whole v4+v6
-// conntrack table holding per-bucket BPF-map locks, so N concurrent
+// maxConcurrentSessionWalks bounds how many full session-table walks may
+// run at once across the session-scan REST endpoints (#5318, #5433): the
+// GET /security/sessions list, GET /security/sessions/summary, and GET
+// /security/sessions/summary/zone-pairs. Each of these walks the whole
+// v4+v6 conntrack table holding per-bucket BPF-map locks, so N concurrent
 // scrapers each drive their own full walk simultaneously — on a
 // multi-million-session firewall that multiplies contention with the live
 // dataplane session-sync path. The cap is deliberately small: legitimate
@@ -31,16 +33,19 @@ import (
 // never starve session installs. #5237 already aborts a walk when its own
 // client disconnects; this bounds how many connected clients can walk at
 // once, which the disconnect-abort does not.
-const maxConcurrentSessionLists = 4
+const maxConcurrentSessionWalks = 4
 
-// sessionsListLimiter is the admission gate for the session list handler.
-// It reuses the diagcmd fixed-capacity counting semaphore (the same
-// fail-fast idiom the diagnostic ping/traceroute handlers use, #5057):
-// Acquire is non-blocking, so an over-cap request is rejected immediately
-// with HTTP 429 rather than queued into an unbounded backlog. It is a
-// package var so a test can swap in a fresh small-capacity limiter without
-// mutating process-wide state.
-var sessionsListLimiter = diagcmd.NewLimiter(maxConcurrentSessionLists)
+// sessionWalkLimiter is the shared admission gate for the full-table
+// session-scan handlers (list, summary, zone-pairs). It reuses the diagcmd
+// fixed-capacity counting semaphore (the same fail-fast idiom the
+// diagnostic ping/traceroute handlers use, #5057): Acquire is non-blocking,
+// so an over-cap request is rejected immediately with HTTP 429 rather than
+// queued into an unbounded backlog. One shared limiter (not one per
+// endpoint) bounds the AGGREGATE walk concurrency, since all three handlers
+// contend for the same per-bucket BPF-map locks against session-sync
+// (#5433). It is a package var so a test can swap in a fresh small-capacity
+// limiter without mutating process-wide state.
+var sessionWalkLimiter = diagcmd.NewLimiter(maxConcurrentSessionWalks)
 
 // defaultSessionCountCap bounds how many matching sessions the offset list
 // walk counts before it stops and reports Total as an approximate lower
@@ -112,8 +117,9 @@ func (s *Server) sessionsHandler(w http.ResponseWriter, r *http.Request) {
 	// BPF-map locks. Acquire a slot fail-fast BEFORE the walk (and before the
 	// peer fan-out) so a concurrent-scrape flood is rejected with HTTP 429
 	// rather than each driving its own simultaneous walk. Release on every
-	// exit path via defer. This covers both the offset and cursor paths.
-	release, err := sessionsListLimiter.Acquire()
+	// exit path via defer. This covers both the offset and cursor paths. The
+	// limiter is shared with the summary/zone-pair scans (#5433).
+	release, err := sessionWalkLimiter.Acquire()
 	if err != nil {
 		writeError(w, http.StatusTooManyRequests,
 			"session list concurrency limit reached; retry shortly")
@@ -610,6 +616,23 @@ func (s *Server) sessionSummaryHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Admission bound (#5433): the summary is an EXACT aggregate over the whole
+	// v4+v6 conntrack table, so — like the list handler (#5318) — it holds
+	// per-bucket BPF-map locks that contend with the live session-sync path.
+	// An exact aggregate genuinely needs the full walk (no sessionCountCap: a
+	// capped summary would change the response contract), so the gate alone is
+	// the fix. Acquire fail-fast BEFORE the walk (and the peer fan-out); an
+	// over-cap request is rejected with HTTP 429 instead of driving its own
+	// simultaneous walk. Release on every exit path via the deferred idempotent
+	// release; nothing is released on the ErrBusy path (release is nil there).
+	release, err := sessionWalkLimiter.Acquire()
+	if err != nil {
+		writeError(w, http.StatusTooManyRequests,
+			"session scan concurrency limit reached; retry shortly")
+		return
+	}
+	defer release()
+
 	var summary SessionSummary
 
 	// Stop the full-table walk if the client disconnects mid-scan so we do
@@ -782,6 +805,24 @@ func (s *Server) sessionZonePairHandler(w http.ResponseWriter, r *http.Request) 
 		writeOK(w, ZonePairSummaryResponse{NodeID: s.nodeID(), ZonePairs: []ZonePairSessionSummary{}})
 		return
 	}
+
+	// Admission bound (#5433): the zone-pair breakdown is an EXACT aggregate
+	// over the whole v4+v6 conntrack table, holding per-bucket BPF-map locks
+	// that contend with the live session-sync path (same as the list handler,
+	// #5318). An exact breakdown needs the full walk (no sessionCountCap: a
+	// capped breakdown would change the response contract), so the gate alone
+	// is the fix. Acquire fail-fast BEFORE the walk (and the peer fan-out);
+	// over-cap requests get HTTP 429 instead of driving their own simultaneous
+	// walk. Gate after the not-loaded early return, which serves an empty
+	// breakdown without walking. Release on every exit path via the deferred
+	// idempotent release; nothing is released on the ErrBusy path.
+	release, err := sessionWalkLimiter.Acquire()
+	if err != nil {
+		writeError(w, http.StatusTooManyRequests,
+			"session scan concurrency limit reached; retry shortly")
+		return
+	}
+	defer release()
 
 	// Build zone ID -> name reverse map
 	zoneNames := make(map[uint16]string)

--- a/pkg/api/sessions_aggregation_bound_5433_test.go
+++ b/pkg/api/sessions_aggregation_bound_5433_test.go
@@ -1,0 +1,219 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/diagcmd"
+)
+
+// runSessionWalkConcurrencyBound drives cap+excess concurrent requests through
+// a full-table-walk session handler and asserts the shared sessionWalkLimiter:
+//   - admits at most `cap` walks concurrently,
+//   - rejects the `excess` requests immediately with HTTP 429 (fail-fast, not
+//     queued),
+//   - fully releases after the admitted walks drain, so a subsequent request
+//     succeeds (no permit leaked on the 429 or success paths).
+//
+// It reuses blockingSessionDP (sessions_pagination_bound_5318_test.go), whose
+// IterateSessions blocks on a gate so the test can pin `cap` handlers inside
+// their walk at once. Mirrors TestRESTSessionListConcurrencyBound for the
+// summary/zone-pair siblings (#5433).
+//
+// RED-on-revert: remove the sessionWalkLimiter.Acquire()/429 branch from the
+// handler under test and every request is admitted — the 429 count drops to 0
+// and the max-concurrency assertion fires.
+func runSessionWalkConcurrencyBound(t *testing.T, path string,
+	invoke func(*Server, http.ResponseWriter, *http.Request)) {
+	t.Helper()
+
+	const (
+		capN   = 2
+		excess = 5
+		total  = capN + excess
+	)
+
+	orig := sessionWalkLimiter
+	t.Cleanup(func() { sessionWalkLimiter = orig })
+	sessionWalkLimiter = diagcmd.NewLimiter(capN)
+
+	var (
+		inFlight    int32
+		maxObserved int32
+		attempts    int32
+	)
+	gate := make(chan struct{})         // holds each admitted walk until closed
+	allAttempted := make(chan struct{}) // closed once every request has attempted Acquire
+	var once sync.Once
+	noteAttempt := func() {
+		if atomic.AddInt32(&attempts, 1) == total {
+			once.Do(func() { close(allAttempted) })
+		}
+	}
+
+	dp := &blockingSessionDP{
+		Manager: dataplane.New(),
+		gate:    gate,
+		enter: func() {
+			cur := atomic.AddInt32(&inFlight, 1)
+			defer atomic.AddInt32(&inFlight, -1)
+			for {
+				m := atomic.LoadInt32(&maxObserved)
+				if cur <= m || atomic.CompareAndSwapInt32(&maxObserved, m, cur) {
+					break
+				}
+			}
+			noteAttempt() // admitted: reached the walk, holding a slot
+			<-gate
+		},
+	}
+	s := &Server{dp: dp}
+
+	fire := func() int {
+		rr := httptest.NewRecorder()
+		invoke(s, rr, httptest.NewRequest("GET", path, nil))
+		return rr.Code
+	}
+
+	codes := make([]int, total)
+	var wg sync.WaitGroup
+	for i := 0; i < total; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			c := fire()
+			if c == http.StatusTooManyRequests {
+				noteAttempt() // rejected: fail-fast, counts as an attempt
+			}
+			codes[idx] = c
+		}(i)
+	}
+
+	// Hold the gate until every request has attempted Acquire, so no admitted
+	// walk frees its slot before the excess have been rejected (which would let
+	// an excess request win a freed slot).
+	select {
+	case <-allAttempted:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for %d attempts; inFlight=%d attempts=%d",
+			total, atomic.LoadInt32(&inFlight), atomic.LoadInt32(&attempts))
+	}
+
+	close(gate)
+	wg.Wait()
+
+	var ok, tooMany, other int
+	for _, c := range codes {
+		switch c {
+		case http.StatusOK:
+			ok++
+		case http.StatusTooManyRequests:
+			tooMany++
+		default:
+			other++
+		}
+	}
+	if other != 0 {
+		t.Fatalf("unexpected status codes present: %v", codes)
+	}
+	if tooMany != excess {
+		t.Fatalf("429 count = %d, want %d (excess must be rejected, not queued): %v",
+			tooMany, excess, codes)
+	}
+	if ok != capN {
+		t.Fatalf("200 count = %d, want %d: %v", ok, capN, codes)
+	}
+	if m := atomic.LoadInt32(&maxObserved); m > capN {
+		t.Fatalf("max concurrent session walks = %d, want <= %d", m, capN)
+	}
+
+	// Permit release: after the 429 burst and drain, a subsequent request must
+	// succeed — proving no slot leaked on the 429 or success paths.
+	if code := fire(); code != http.StatusOK {
+		t.Fatalf("post-drain request status = %d, want 200 (limiter not released)", code)
+	}
+}
+
+// TestRESTSessionSummaryConcurrencyBound pins the #5433 admission contract for
+// the /security/sessions/summary aggregation handler: like the list sibling
+// (#5318) it walks the whole v4+v6 conntrack table, so concurrent scrapes must
+// be bounded by the shared sessionWalkLimiter rather than each driving its own
+// full walk.
+func TestRESTSessionSummaryConcurrencyBound(t *testing.T) {
+	runSessionWalkConcurrencyBound(t, "/api/v1/security/sessions/summary",
+		func(s *Server, w http.ResponseWriter, r *http.Request) {
+			s.sessionSummaryHandler(w, r)
+		})
+}
+
+// TestRESTSessionZonePairConcurrencyBound pins the #5433 admission contract for
+// the /security/sessions/summary/zone-pairs aggregation handler (same full
+// v4+v6 walk, same shared gate).
+func TestRESTSessionZonePairConcurrencyBound(t *testing.T) {
+	runSessionWalkConcurrencyBound(t, "/api/v1/security/sessions/summary/zone-pairs",
+		func(s *Server, w http.ResponseWriter, r *http.Request) {
+			s.sessionZonePairHandler(w, r)
+		})
+}
+
+// TestRESTSessionWalkLimiterShared asserts the list, summary, and zone-pair
+// handlers draw from ONE shared limiter (#5433): saturating the limiter with
+// summary walks makes a concurrent list request 429, proving the aggregate
+// bound covers all three scan endpoints rather than one budget per endpoint.
+func TestRESTSessionWalkLimiterShared(t *testing.T) {
+	orig := sessionWalkLimiter
+	t.Cleanup(func() { sessionWalkLimiter = orig })
+	sessionWalkLimiter = diagcmd.NewLimiter(1) // single slot: any second walk 429s
+
+	gate := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	dp := &blockingSessionDP{
+		Manager: dataplane.New(),
+		gate:    gate,
+		enter: func() {
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			<-gate
+		},
+	}
+	s := &Server{dp: dp}
+
+	// Hold the single slot with a summary walk.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		rr := httptest.NewRecorder()
+		s.sessionSummaryHandler(rr, httptest.NewRequest("GET",
+			"/api/v1/security/sessions/summary", nil))
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(3 * time.Second):
+		close(gate)
+		wg.Wait()
+		t.Fatal("summary walk never entered the table scan")
+	}
+
+	// The slot is held by the summary walk; a concurrent LIST request must be
+	// rejected by the SAME limiter.
+	rr := httptest.NewRecorder()
+	s.sessionsHandler(rr, httptest.NewRequest("GET", "/api/v1/security/sessions", nil))
+	if rr.Code != http.StatusTooManyRequests {
+		close(gate)
+		wg.Wait()
+		t.Fatalf("list status = %d while a summary walk holds the shared slot; want 429 (limiter not shared)",
+			rr.Code)
+	}
+
+	close(gate)
+	wg.Wait()
+}

--- a/pkg/api/sessions_pagination_bound_5318_test.go
+++ b/pkg/api/sessions_pagination_bound_5318_test.go
@@ -125,14 +125,14 @@ func (d *blockingSessionDP) IterateSessionsV6(func(dataplane.SessionKeyV6, datap
 
 // TestRESTSessionListConcurrencyBound pins the #5318 admission contract for the
 // session list handler, mirroring the #5057 diagnostic-limiter test. It swaps
-// sessionsListLimiter for a fresh small-capacity limiter and drives cap+excess
+// sessionWalkLimiter for a fresh small-capacity limiter and drives cap+excess
 // concurrent list requests through a walk that blocks on a gate. It asserts:
 //   - at most `cap` handlers run the walk concurrently,
 //   - the `excess` requests are rejected immediately with HTTP 429 (not queued),
 //   - after the admitted walks finish the limiter is fully released, so a
 //     subsequent request succeeds.
 //
-// RED-on-revert: remove the sessionsListLimiter.Acquire()/429 branch from
+// RED-on-revert: remove the sessionWalkLimiter.Acquire()/429 branch from
 // sessionsHandler and every request is admitted — the 429 count drops to 0 and
 // the max-concurrency assertion fires.
 func TestRESTSessionListConcurrencyBound(t *testing.T) {
@@ -142,9 +142,9 @@ func TestRESTSessionListConcurrencyBound(t *testing.T) {
 		total  = capN + excess
 	)
 
-	orig := sessionsListLimiter
-	t.Cleanup(func() { sessionsListLimiter = orig })
-	sessionsListLimiter = diagcmd.NewLimiter(capN)
+	orig := sessionWalkLimiter
+	t.Cleanup(func() { sessionWalkLimiter = orig })
+	sessionWalkLimiter = diagcmd.NewLimiter(capN)
 
 	var (
 		inFlight    int32


### PR DESCRIPTION
## Problem

#5318/#5431 bounded the `GET /security/sessions` **LIST** endpoint: a
per-endpoint admission semaphore (`sessionsListLimiter`) plus a
`sessionCountCap` on the exact-`Total` walk. But the sibling aggregation
handlers `sessionSummaryHandler` and `sessionZonePairHandler`
(`pkg/api/sessions.go`) still did **unbounded** full v4+v6
conntrack-table walks with **no admission gate**. A connected client
polling `/sessions/summary` or `/sessions/summary/zone-pairs` drove the
same O(v4+v6) work per request, contending with the live session-sync
path for per-bucket BPF-map locks, with no concurrency bound.

## Invariant

Same as #5318: a hot session-aggregation endpoint must not let concurrent
scrapes each drive an unbounded full walk. The #5237 disconnect-abort
only bounds a *single* client's walk once *its* connection drops — it
does not bound how many *connected* clients walk at once.

## Fix

Route both aggregation handlers through the **same** admission gate the
LIST handler uses.

- **Shared limiter.** Renamed `sessionsListLimiter` → `sessionWalkLimiter`
  (`maxConcurrentSessionLists` → `maxConcurrentSessionWalks`) to reflect
  that it now bounds every full session-table scan endpoint. **One shared
  limiter** (cap 4), not one per endpoint — the bound is on the
  **aggregate** walk concurrency, since all three handlers contend for the
  same locks (a per-endpoint budget would let 4+4+4 walks race). Acquire
  is fail-fast → **HTTP 429** on saturation; release is **deferred +
  idempotent** (`diagcmd` `sync.Once`); **nothing is released on the
  `ErrBusy` path** (release is nil there) — the LIST handler's discipline,
  mirrored exactly.

- **Gate-only vs cap — decided per handler.** Both handlers compute an
  **exact aggregate** (`sessionSummaryHandler`: total/forward/established/
  SNAT/DNAT/v4/v6 counts; `sessionZonePairHandler`: per-zone-pair
  TCP/UDP/ICMP/Other totals). An exact aggregate genuinely needs the full
  walk, so **`sessionCountCap` is NOT applied** to either — a capped
  aggregate would change the response contract. The admission **gate alone
  is the fix** and the response shape is unchanged (safer than forcing an
  approximate aggregate).

- **Disconnect-abort preserved.** The #5233 `newRequestCancelSampler`
  ctx-cancellation check in both handlers is untouched (not regressed).

## Tests (`sessions_aggregation_bound_5433_test.go`)

- **Per-handler concurrency bound** for summary and zone-pairs: cap+excess
  concurrent requests → at most `cap` walk concurrently, the excess get
  **429**, and a **post-drain request succeeds** (proves no permit leak).
- **Shared-limiter cross-endpoint**: a summary walk holding the single
  slot makes a concurrent **LIST** request 429 — proving one budget across
  all three scan endpoints.
- **RED-on-revert (verified):** removing the gate from either handler
  drops the 429 count to 0 (all 7 requests admitted) and fires the
  max-concurrency assertion:
  ```
  --- FAIL: TestRESTSessionSummaryConcurrencyBound
      429 count = 0, want 5 (excess must be rejected, not queued): [200 200 200 200 200 200 200]
  --- FAIL: TestRESTSessionZonePairConcurrencyBound
      429 count = 0, want 5 (excess must be rejected, not queued): [200 200 200 200 200 200 200]
  ```

## Docs

`pkg/api/README.md` #5318 admission-gate section updated for the rename
and the #5433 extension (shared gate + gate-only rationale).

## Validation

- `go build ./...` — clean
- `go vet ./pkg/api/...` — clean
- `go test -race ./pkg/api/...` — green
- `gofmt` — clean

Closes #5433