### PR TITLE
pkg/api,pkg/routing: render reject route disposition in REST and kernel-FIB reads (#5410)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,21 @@
+## 2026-07-10 — pkg/api,pkg/routing: render reject route disposition (#5410)
+
+- **Timestamp**: 2026-07-10 (fix/5410-reject-route-display)
+  - **Action**: #5410 — two READ paths did not distinguish an installed
+    static `reject` route (first-class since #5298, installs as
+    `RTN_UNREACHABLE` via FRR) from `discard`/directly-connected. (a) REST
+    `/routes` (`routesHandler`) lumped a reject route into the unlabeled
+    no-next-hop branch with discard; added an additive `disposition` field
+    (`reject`/`discard`/`connected`) on `RouteInfo`, backward-compatible
+    (`omitempty`). (b) the kernel-FIB reader (`routeToEntry`) mapped only
+    `RTN_BLACKHOLE`→`discard`, so a reject route rendered `direct`; added
+    `RTN_UNREACHABLE`→`reject`. Labels mirror the CLI/gRPC `show route`
+    reject/discard conventions. RED-on-revert proven for both readers.
+  - **File(s)**: pkg/api/routing.go, pkg/api/types.go,
+    pkg/api/routes_disposition_5410_test.go, pkg/routing/routes.go,
+    pkg/routing/routes_disposition_5410_test.go, pkg/api/README.md,
+    pkg/routing/README.md, _Log.md
+
 ## 2026-07-10 — cli: reject fail-open CLI tokens (5-defect cohort, #4883)
 
 - **Timestamp**: 2026-07-10 (fix/4883-cli-failopen-cohort)

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -347,6 +347,18 @@ under the daemon's errgroup. Nothing else imports this package.
   contract is pinned by `sessions_iterator_error_test.go` in this package
   and in `pkg/grpcapi` / `pkg/cli` (CLI top-talkers fails the command; NAT
   summaries print a stderr warning).
+- The static-route `/routing/routes` handler (`routesHandler`, `routing.go`)
+  renders one `RouteInfo` per next-hop for a normal route. A route with no
+  forwarding next-hop instead carries a `disposition` label distinguishing
+  `reject` (FRR `RTN_UNREACHABLE`, drop + ICMP unreachable), `discard` (FRR
+  `Null0`/`RTN_BLACKHOLE`, silent drop), and `connected` (no gateway). This
+  mirrors the `reject`/`discard` labels the CLI/gRPC `show route` text already
+  renders, closing the #5410 gap where a first-class `reject` route (#5298)
+  was lumped into the same unlabeled no-next-hop branch as `discard`. The
+  `disposition` field is additive and `omitempty`, so a route with a real
+  next-hop or a `next_table` leaks nothing new and existing consumers reading
+  `destination`/`next_hop`/`interface`/`preference`/`next_table` are
+  unaffected. Pinned by `routes_disposition_5410_test.go`.
 - Long full-table read handlers must ABORT when the client disconnects
   (#5232/#5233). The REST server cancels `r.Context()` on disconnect, so a
   handler that walks a large structure has to sample `r.Context().Err()`

--- a/pkg/api/routes_disposition_5410_test.go
+++ b/pkg/api/routes_disposition_5410_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// #5410: #5298 made static `reject` routes first-class (they install into
+// the kernel FIB as RTN_UNREACHABLE via FRR), but the REST /routes handler
+// lumped a reject route into the same no-next-hop branch as discard and
+// emitted NO disposition label — so a reject and a discard route were
+// indistinguishable, and a plain no-next-hop route carried no marker
+// either. This test injects reject / discard / connected / normal /
+// next-table static routes into the live ActiveConfig, drives
+// routesHandler, and asserts each carries the right disposition (mirroring
+// the CLI/gRPC `show route` reject/discard labels) while a real next-hop /
+// next-table route leaks nothing new (backward-compatible, additive
+// field). Reverting the routing.go disposition logic makes the reject
+// route render with an empty disposition — RED on revert.
+func routesDispositionStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	// Commit a minimal config so an ActiveConfig exists; then inject the
+	// static routes post-commit so no recompile normalizes them away.
+	if err := store.LoadOverride(`
+system {
+    host-name xpf;
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	cfg.RoutingOptions.StaticRoutes = []*config.StaticRoute{
+		{Destination: "10.1.0.0/24", Reject: true, Preference: 5},
+		{Destination: "10.2.0.0/24", Discard: true, Preference: 5},
+		{Destination: "10.3.0.0/24", Preference: 5}, // no next-hop => connected
+		{Destination: "10.4.0.0/24", Preference: 7, NextHops: []config.NextHopEntry{
+			{Address: "10.4.0.254", Interface: "ge-0-0-0"},
+		}},
+		{Destination: "10.5.0.0/24", NextTable: "Comcast", Preference: 5},
+	}
+	return store
+}
+
+func TestRoutesHandlerRejectDiscardDisposition(t *testing.T) {
+	s := &Server{store: routesDispositionStore(t)}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/routing/routes", nil)
+	s.routesHandler(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		Success bool        `json:"success"`
+		Data    []RouteInfo `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body: %s", err, rr.Body.String())
+	}
+	if !resp.Success {
+		t.Fatalf("success=false; body: %s", rr.Body.String())
+	}
+
+	byDest := map[string]RouteInfo{}
+	for _, r := range resp.Data {
+		byDest[r.Destination] = r
+	}
+
+	// reject => labeled "reject", never lumped with discard, no phantom
+	// next-hop/next-table.
+	if got := byDest["10.1.0.0/24"]; got.Disposition != "reject" ||
+		got.NextHop != "" || got.NextTable != "" {
+		t.Errorf("reject route = %+v, want disposition=reject, no next-hop/next-table", got)
+	}
+	// discard => "discard".
+	if got := byDest["10.2.0.0/24"]; got.Disposition != "discard" {
+		t.Errorf("discard route = %+v, want disposition=discard", got)
+	}
+	// connected (no next-hop, not reject/discard) => "connected".
+	if got := byDest["10.3.0.0/24"]; got.Disposition != "connected" {
+		t.Errorf("no-next-hop route = %+v, want disposition=connected", got)
+	}
+	// A normal next-hop route is unchanged: real next-hop, empty
+	// disposition (backward-compatible / additive field).
+	if got := byDest["10.4.0.0/24"]; got.NextHop != "10.4.0.254" ||
+		got.Interface != "ge-0-0-0" || got.Disposition != "" {
+		t.Errorf("next-hop route = %+v, want next-hop 10.4.0.254 via ge-0-0-0, empty disposition", got)
+	}
+	// A next-table route is unchanged: next-table set, empty disposition.
+	if got := byDest["10.5.0.0/24"]; got.NextTable != "Comcast" || got.Disposition != "" {
+		t.Errorf("next-table route = %+v, want next-table Comcast, empty disposition", got)
+	}
+}

--- a/pkg/api/routing.go
+++ b/pkg/api/routing.go
@@ -42,9 +42,32 @@ func (s *Server) routesHandler(w http.ResponseWriter, _ *http.Request) {
 			})
 			continue
 		}
-		if r.Discard || len(r.NextHops) == 0 {
+		// Routes with no forwarding next-hop carry a disposition label so
+		// this view distinguishes reject (RTN_UNREACHABLE) from discard
+		// (RTN_BLACKHOLE) from directly-connected, matching how the CLI/gRPC
+		// `show route` text renders reject/discard (#5298/#5410). Reject and
+		// Discard are mutually exclusive; check them before the no-next-hop
+		// fallthrough since a reject/discard route also carries no NextHops.
+		if r.Reject {
 			result = append(result, RouteInfo{
 				Destination: r.Destination,
+				Disposition: "reject",
+				Preference:  r.Preference,
+			})
+			continue
+		}
+		if r.Discard {
+			result = append(result, RouteInfo{
+				Destination: r.Destination,
+				Disposition: "discard",
+				Preference:  r.Preference,
+			})
+			continue
+		}
+		if len(r.NextHops) == 0 {
+			result = append(result, RouteInfo{
+				Destination: r.Destination,
+				Disposition: "connected",
 				Preference:  r.Preference,
 			})
 			continue

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -457,6 +457,15 @@ type RouteInfo struct {
 	Interface   string `json:"interface,omitempty"`
 	Preference  int    `json:"preference,omitempty"`
 	NextTable   string `json:"next_table,omitempty"`
+	// Disposition labels a route that has no forwarding next-hop with the
+	// action it takes: "reject" (return ICMP unreachable, FRR
+	// RTN_UNREACHABLE), "discard" (silent blackhole, FRR Null0), or
+	// "connected" (directly-connected, no gateway). It mirrors the
+	// reject/discard labels the CLI/gRPC `show route` text already renders
+	// (#5298/#5410). Additive and omitempty: a route with a real next-hop or
+	// a next-table leaks nothing here, so existing consumers reading
+	// destination/next_hop/interface/preference/next_table are unaffected.
+	Disposition string `json:"disposition,omitempty"`
 }
 
 // ScreenInfo holds screen profile information.

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -587,6 +587,16 @@ field consumers show a real next-hop instead of a bare "direct". A
 single-gateway, connected/direct, or discard route leaves `NextHops`
 nil and is bit-identical to before.
 
+For a no-gateway route `routeToEntry` labels the disposition from
+`route.Type`: `RTN_BLACKHOLE` → `"discard"` (silent drop), `RTN_UNREACHABLE`
+→ `"reject"` (drop + ICMP unreachable), else `"direct"` (directly-connected).
+The `reject` mapping was added in #5410 to match the kernel FIB now that
+#5298 installs a static `reject` route as `RTN_UNREACHABLE` via FRR; before
+it, an installed reject route fell through to the `"direct"` else branch and
+mis-rendered as directly-connected. The label set mirrors the `reject`/
+`discard` conventions `formatTableJunos` and the gRPC/REST readers already
+use for the config static-route view.
+
 Rendering: `formatTableJunos` (`routeformat.go`, the canonical Junos
 `show route` view used by both the local CLI and the gRPC text path)
 emits one `>  to <gw> via <if>` line per leg when `NextHops` is

--- a/pkg/routing/routes.go
+++ b/pkg/routing/routes.go
@@ -237,6 +237,13 @@ func (rr *routeReader) routeToEntry(r netlink.Route, family int) RouteEntry {
 		entry.NextHop = r.Gw.String()
 	} else if r.Type == unix.RTN_BLACKHOLE {
 		entry.NextHop = "discard"
+	} else if r.Type == unix.RTN_UNREACHABLE {
+		// A `route <p> reject` installs as RTN_UNREACHABLE in the kernel
+		// FIB (Junos reject → FRR `ip route <p> reject`, #5298). Label it
+		// "reject" so the kernel-table view distinguishes it from a
+		// silent discard (RTN_BLACKHOLE) and a directly-connected route,
+		// matching the `show route` (CLI/gRPC) reject/discard conventions.
+		entry.NextHop = "reject"
 	} else {
 		entry.NextHop = "direct"
 	}

--- a/pkg/routing/routes_disposition_5410_test.go
+++ b/pkg/routing/routes_disposition_5410_test.go
@@ -1,0 +1,49 @@
+package routing
+
+import (
+	"net"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// TestRouteToEntryRejectDiscard proves the kernel-FIB reader distinguishes
+// a `route <p> reject` (installed as RTN_UNREACHABLE by FRR, #5298) from a
+// `discard` (RTN_BLACKHOLE) and from a directly-connected route. Before
+// #5410 only RTN_BLACKHOLE mapped to "discard"; an RTN_UNREACHABLE reject
+// route fell through to the else branch and rendered as "direct" — the
+// bug. Reverting the routes.go RTN_UNREACHABLE mapping makes the reject
+// case render "direct" — RED on revert. The discard and connected cases
+// pin the existing behavior is unchanged.
+func TestRouteToEntryRejectDiscard(t *testing.T) {
+	rr := &routeReader{ops: &fakeRouteLister{byIndex: map[int]string{}}}
+
+	cases := []struct {
+		name     string
+		rtType   int
+		wantNext string
+	}{
+		{"reject", unix.RTN_UNREACHABLE, "reject"},
+		{"discard", unix.RTN_BLACKHOLE, "discard"},
+		{"connected", unix.RTN_UNICAST, "direct"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, dst, _ := net.ParseCIDR("10.7.0.0/24")
+			route := netlink.Route{
+				Dst:      dst,
+				Type:     tc.rtType,
+				Protocol: netlink.RouteProtocol(unix.RTPROT_STATIC),
+				Priority: 5,
+			}
+			entry := rr.routeToEntry(route, netlink.FAMILY_V4)
+			if entry.NextHop != tc.wantNext {
+				t.Errorf("%s route: NextHop = %q, want %q", tc.name, entry.NextHop, tc.wantNext)
+			}
+			if len(entry.NextHops) != 0 {
+				t.Errorf("%s route: NextHops = %+v, want empty", tc.name, entry.NextHops)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

#5298 made static \`reject\` routes first-class — they install into the
kernel FIB as \`RTN_UNREACHABLE\` via FRR (drop + ICMP unreachable),
distinct from \`discard\` (\`RTN_BLACKHOLE\`, silent drop). Two READ paths
did not render the disposition, so an installed reject route was
indistinguishable from — or mis-rendered against — discard / connected:

- **(a) REST \`/routes\`** (\`routesHandler\`, \`pkg/api/routing.go\`) lumped a
  reject route into the \`len(NextHops)==0\` no-next-hop branch with **no**
  disposition label; a discard route hit the same branch, so neither was
  labeled.
- **(b) kernel-FIB reader** (\`routeToEntry\`, \`pkg/routing/routes.go\`)
  mapped only \`RTN_BLACKHOLE\`→\`"discard"\`. An installed reject route is
  \`RTN_UNREACHABLE\`, so it fell through to the else branch and rendered as
  \`"direct"\` — misleading now that #5298 actually installs it into the FIB.

## Invariant

A read path that renders route disposition must distinguish **reject**
(\`RTN_UNREACHABLE\`) from **discard** (\`RTN_BLACKHOLE\`) from
**directly-connected**, consistent with how \`show route\` (CLI/gRPC text)
already renders reject/discard (\`cli_show_routing.go\` /
\`server_show_routes_text.go\`).

## Fix

- **(a)** Add an additive \`disposition\` field to \`RouteInfo\`
  (\`"reject"\` / \`"discard"\` / \`"connected"\`). Reject/Discard are checked
  **before** the no-next-hop fallthrough (both carry no NextHops). The
  field is \`omitempty\`, so a route with a real next-hop or a \`next_table\`
  is byte-identical on the wire — existing consumers reading
  \`destination\`/\`next_hop\`/\`interface\`/\`preference\`/\`next_table\` are
  unaffected (**backward-compatible**).
- **(b)** Add \`RTN_UNREACHABLE\`→\`"reject"\` alongside the existing
  \`RTN_BLACKHOLE\`→\`"discard"\`.

Labels mirror the CLI/gRPC \`show route\` reject/discard conventions.

## Tests (RED-on-revert)

- \`routes_disposition_5410_test.go\` (pkg/api): reject→\`disposition:reject\`,
  discard→\`discard\`, no-next-hop→\`connected\`; a next-hop route keeps its
  real next-hop with empty disposition, a next-table route keeps
  \`next_table\` with empty disposition (backward-compat).
- \`routes_disposition_5410_test.go\` (pkg/routing): \`RTN_UNREACHABLE\`→
  \`"reject"\`, \`RTN_BLACKHOLE\`→\`"discard"\`, \`RTN_UNICAST\`→\`"direct"\`.

Proven RED on revert: stashing the production change (keeping the tests)
makes the REST reject/discard/connected cases render **unlabeled** and the
kernel-FIB reject case render **"direct"** — the bug. Restored → GREEN.

## Docs

\`pkg/api/README.md\` and \`pkg/routing/README.md\` document the new
disposition rendering on each read path; \`_Log.md\` updated.

\`go build ./...\` + \`go test ./pkg/api/... ./pkg/routing/...\` green.

Closes #5410

🤖 Generated with [Claude Code](https://claude.com/claude-code)