### PR TITLE
pkg/ra: gracefully withdraw senders on Router Advertisement config removal (#5092)

### DIFF
--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1103,9 +1103,13 @@ func (d *Daemon) applyServicesReconcile(cfg *config.Config) (error, error) {
 				slog.Warn("failed to apply RA config", "err", err)
 			}
 		} else if d.ra != nil {
-			// No RA configs — clear any previous RA senders.
-			if err := d.ra.Clear(); err != nil {
-				slog.Warn("failed to clear RA config", "err", err)
+			// No RA configs remain — the operator removed all RA. Gracefully
+			// WITHDRAW any previous senders (final lifetime-0 goodbye, #5092)
+			// instead of a hard Clear, so hosts drop this router immediately
+			// rather than holding the stale default route until Router Lifetime
+			// (default 1800s) expires. Withdraw is a no-op when no senders exist.
+			if err := d.ra.Withdraw(); err != nil {
+				slog.Warn("failed to withdraw RA config", "err", err)
 			}
 		}
 	}

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -145,8 +145,9 @@ after HA failover. To make that **structural**, not flag-defended:
   LIVE, so the live-conn count goes 1 → (briefly 0, internal) → 1 with no
   observable 0-conn window for callers, and never momentarily 2 (the old conn
   is gone first). This applies ONLY to a replace — it is NOT a withdrawal, so
-  it still emits no goodbye; a genuine `Withdraw`/`Clear`/removal keeps its
-  existing lifetime-0-goodbye + go-down behavior. The sender exposes
+  it still emits no goodbye; a genuine `Withdraw`/removal keeps its existing
+  lifetime-0-goodbye + go-down behavior (`Clear` is the explicit no-goodbye
+  primitive). The sender exposes
   `waitConnReady(timeout) bool`; the owner calls `signalConnReady(opened)`
   after `openConn` so a failed/pre-empted open releases the waiter promptly
   rather than blocking the full timeout on a sender that will never serve.
@@ -237,7 +238,14 @@ never retried and the stale IPv6 default-router identity lingered on hosts
 - `New()` — `ra.go`.
 - `Apply(configs []*config.RAInterfaceConfig) error` — `ra.go`.
   Starts/stops per-interface senders; defers + retries (epoch-guarded)
-  any interface that is currently draining.
+  any interface that is currently draining. A CHANGED config is a hard
+  replace (no goodbye — the router is not going away, the replacement
+  re-advertises at once). A REMOVED config — this interface dropped from a
+  non-empty desired set, OR an empty `configs` (all RA removed) — is a
+  GRACEFUL withdraw that emits a final lifetime-0 goodbye (#5092), so hosts
+  drop this router immediately instead of holding the stale default route
+  until Router Lifetime (default 1800s) expires. The empty-config branch
+  shares `Withdraw()`'s path via `collectGracefulWithdrawLocked`.
 - `Withdraw() error` — `ra.go`. Graceful goodbye + stop on every sender.
 - `ResendBurst()` — `ra.go`. Re-sends the startup burst (used after a
   link cycle) on every active sender, via the owner goroutine.
@@ -255,7 +263,10 @@ never retried and the stale IPv6 default-router identity lingered on hosts
   goodbye — the #2033 blackhole class). The tombstone is then HELD across
   the goodbye emit, so the busy state — and thus the mutual exclusion —
   extends over the whole operation, not just the install instant.
-- `Clear() error` — `ra.go`. Hard stop (no goodbye) of every sender.
+- `Clear() error` — `ra.go`. Hard stop (no goodbye) of every sender — the
+  explicit no-goodbye primitive for a forced/unsafe stop. NOTE: config-driven
+  removal no longer uses this; the daemon's standalone reconcile now withdraws
+  gracefully (`Withdraw()`) when all RA config is removed (#5092).
 - `Status()` — `ra.go`. Per-interface `SenderInfo`. A running sender has
   `State == "active"`; an interface whose sender is tearing down /
   emitting its goodbye is reported with `State == "draining"` (distinct

--- a/pkg/ra/config_removal_goodbye_5092_test.go
+++ b/pkg/ra/config_removal_goodbye_5092_test.go
@@ -1,0 +1,166 @@
+package ra
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5092: removing RA config must GRACEFULLY withdraw the affected senders — a
+// final lifetime-0 goodbye RA (RFC 4861 §6.2.5) — instead of a silent hard stop.
+// Before the fix, Apply's removal loop and the empty-config path used modeHard
+// (no goodbye), so hosts kept this firewall as their IPv6 default router until
+// the previous Router Lifetime (default 1800s) expired — an avoidable outage.
+//
+// These tests pin both removal shapes and the non-regression of the changed-
+// config restart (which correctly stays a hard replace: the router is not going
+// away, the replacement re-advertises immediately). Each removal assertion is
+// RED against the pre-#5092 hard stop, where goodbyeStats stays (0, 0).
+
+// TestConfigRemovalAllInterfacesGoodbye_5092 drives the "operator removed ALL RA
+// config" path: Apply with an empty desired set (the manager branch the daemon's
+// standalone reconcile reaches via Withdraw()). Every sender must be retired with
+// a final lifetime-0 goodbye, not a silent hard stop.
+//
+// RED on revert: the pre-#5092 empty-config branch called clearLocked (modeHard),
+// so no goodbye was emitted and goodbyeStats("lo") == (0, 0) — the test fails.
+func TestConfigRemovalAllInterfacesGoodbye_5092(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("initial Apply: %v", err)
+	}
+	loConn := waitConn(t, fl.getConn, "lo")
+	waitWrites(t, loConn, 1)
+
+	// Remove ALL RA config. releaseDrain joins the owner synchronously, so the
+	// goodbye is on the wire by the time Apply returns.
+	if err := m.Apply(nil); err != nil {
+		t.Fatalf("empty-config Apply: %v", err)
+	}
+
+	total, conns := fl.goodbyeStats("lo")
+	if conns != 1 || total == 0 {
+		t.Fatalf("empty-config Apply emitted no goodbye (%d conns / %d writes); "+
+			"removing all RA must gracefully withdraw with a final lifetime-0 RA (#5092)",
+			conns, total)
+	}
+	assertGoodbyeIsLast(t, loConn.snapshot())
+
+	m.mu.Lock()
+	remaining := len(m.senders)
+	m.mu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("senders remain after full removal: %d", remaining)
+	}
+}
+
+// TestConfigRemovalOneInterfaceGoodbye_5092 drives the "operator removed RA from
+// ONE interface while keeping another" path: Apply with a NON-empty desired set
+// that no longer contains the removed interface. The removal loop must withdraw
+// the dropped interface gracefully AND leave the kept interface untouched.
+//
+// The kept interface is a second sender injected directly into the manager
+// (startFakeSender bypasses net.InterfaceByName, so no real NIC beyond "lo" is
+// needed); a re-Apply that lists only the kept interface makes "lo" a true
+// removal without any spurious start failure.
+//
+// RED on revert: the pre-#5092 removal loop used modeHard, so goodbyeStats("lo")
+// == (0, 0) and the goodbye assertion fails.
+func TestConfigRemovalOneInterfaceGoodbye_5092(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+	m := New()
+
+	// Sender on the real "lo" interface (conn faked).
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("initial Apply: %v", err)
+	}
+	loConn := waitConn(t, fl.getConn, "lo")
+	waitWrites(t, loConn, 1)
+
+	// A second, independently-started sender for a synthetic "kept" interface,
+	// injected under m.mu. testCfg("keepif0") matches its config, so the re-Apply
+	// below classifies it as unchanged (configEqual → left running, no RA gap).
+	keep, keepConn := startFakeSender(t, fl.getConn, "keepif0")
+	waitWrites(t, keepConn, 1)
+	m.mu.Lock()
+	m.senders["keepif0"] = keep
+	m.mu.Unlock()
+
+	// Re-apply with ONLY the kept interface → "lo" is a true removal.
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("keepif0")}); err != nil {
+		t.Fatalf("removal Apply: %v", err)
+	}
+
+	// "lo" gracefully withdrawn: exactly one conn carries the lifetime-0 goodbye,
+	// emitted as the LAST RA on that conn.
+	total, conns := fl.goodbyeStats("lo")
+	if conns != 1 || total == 0 {
+		t.Fatalf("removed interface emitted no goodbye (%d conns / %d writes); a "+
+			"config removal must gracefully withdraw with a final lifetime-0 RA (#5092)",
+			conns, total)
+	}
+	assertGoodbyeIsLast(t, loConn.snapshot())
+
+	// The removed sender is gone from the active set.
+	for _, info := range m.Status() {
+		if info.Interface == "lo" && info.State == "active" {
+			t.Fatal("removed interface still reports active after withdrawal")
+		}
+	}
+
+	// The KEPT interface is untouched: still a live sender, no goodbye emitted —
+	// a partial removal must not disturb the interfaces that remain.
+	m.mu.Lock()
+	_, keptAlive := m.senders["keepif0"]
+	m.mu.Unlock()
+	if !keptAlive {
+		t.Fatal("kept interface's sender was removed by a partial-removal Apply")
+	}
+	if total, conns := fl.goodbyeStats("keepif0"); conns != 0 || total != 0 {
+		t.Fatalf("kept interface emitted a goodbye (%d conns / %d writes); a partial "+
+			"removal must not withdraw the interfaces that remain", conns, total)
+	}
+
+	_ = m.Clear()
+}
+
+// TestConfigChangeEmitsNoGoodbye_5092 is the non-regression guard: a CHANGED (not
+// removed) config is a hard replace — the router is not going away and the
+// replacement re-advertises immediately — so NO goodbye is owed on either conn.
+// The #5092 graceful-removal change must distinguish removal from replacement and
+// must not turn a restart into a withdrawal.
+func TestConfigChangeEmitsNoGoodbye_5092(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("initial Apply: %v", err)
+	}
+	old := waitConn(t, fl.getConn, "lo")
+	waitWrites(t, old, 1)
+
+	// Changed-config Apply → hard replace (stop old, start replacement). Apply
+	// waits for the replacement conn (make-before-break) before returning.
+	if err := m.Apply([]*config.RAInterfaceConfig{configChanged("lo")}); err != nil {
+		t.Fatalf("changed-config Apply: %v", err)
+	}
+
+	// No goodbye on the old (hard-stopped) conn or the fresh replacement conn.
+	if total, conns := fl.goodbyeStats("lo"); conns != 0 || total != 0 {
+		t.Fatalf("changed-config restart emitted a goodbye (%d conns / %d writes); "+
+			"a replace is not a withdrawal (#5092 must not regress the restart path)",
+			conns, total)
+	}
+
+	_ = m.Clear()
+}

--- a/pkg/ra/ra.go
+++ b/pkg/ra/ra.go
@@ -356,7 +356,10 @@ func (m *Manager) reclaimTombstoneWhenStopped(name string, s *sender, startEpoch
 // tombstone covers the whole stop→start window, so a concurrent
 // Apply/Withdraw/WithdrawOnce that sees it defers instead of opening a second
 // conn. A CHANGED config is a hard replace (no goodbye — the router is not
-// going away); a REMOVED config is a hard stop (no goodbye).
+// going away); a REMOVED config (this interface, or all of them when configs is
+// empty) is a GRACEFUL withdraw that emits a final lifetime-0 goodbye (#5092),
+// so hosts drop the router immediately rather than holding a stale default
+// route until Router Lifetime expires.
 //
 // Interfaces that are ALREADY draining when this Apply runs (a prior
 // withdraw/stop or a WithdrawOnce claim still tearing down) are NOT started in
@@ -371,9 +374,19 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 	m.bumpEpoch()
 
 	if len(configs) == 0 {
-		err := m.clearLocked()
+		// Config-driven removal of ALL RA (#5092): retire every sender with a
+		// final lifetime-0 goodbye (RFC 4861 §6.2.5) rather than a silent hard
+		// stop, so hosts drop this router immediately instead of holding the
+		// stale default route until Router Lifetime (default 1800s) expires.
+		// Same graceful path as Withdraw(); Clear() remains the explicit
+		// no-goodbye primitive for a forced/unsafe stop.
+		owned, epoch := m.collectGracefulWithdrawLocked()
 		m.mu.Unlock()
-		return err
+		for _, o := range owned {
+			// nil onProvenClose: a removal never starts a replacement.
+			m.releaseDrain(o.name, o.s, epoch, nil)
+		}
+		return nil
 	}
 
 	// Build desired map.
@@ -391,16 +404,24 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 	}
 	var toStop []stopReq
 
-	// Remove senders not in the desired set (hard stop, no goodbye — a config
-	// change must not blackhole hosts). Install a drainEntry so a concurrent
-	// WithdrawOnce/Apply defers, and a racing graceful Withdraw can flip
-	// goodbyeWanted on it (the release path then emits the standalone).
+	// Remove senders not in the desired set. A TRUE removal (the operator
+	// deleted this interface's RA config and nothing re-advertises the router)
+	// is a GRACEFUL withdraw (#5092): install a goodbyeWanted drainEntry and
+	// signalStop(modeGraceful) so the owner emits the RFC 4861 §6.2.5
+	// lifetime-0 goodbye as its final RA — hosts drop this router at once
+	// instead of holding the stale default route until Router Lifetime
+	// (default 1800s) expires. This mirrors claimGracefulLocked's active-sender
+	// branch; releaseDrain's standalone backstop covers a lost upgrade race.
+	// The changed-config RESTART path below stays a hard replace (no goodbye —
+	// the router is not going away; the replacement re-advertises immediately).
+	// The tombstone also lets a concurrent WithdrawOnce/Apply defer and a racing
+	// graceful Withdraw flip goodbyeWanted (idempotent — already true here).
 	for name, s := range m.senders {
 		if _, ok := desired[name]; !ok {
-			slog.Info("ra: removing sender", "interface", name)
+			slog.Info("ra: withdrawing removed sender (graceful goodbye)", "interface", name)
 			delete(m.senders, name)
-			m.draining[name] = &drainEntry{sender: s, cfg: s.cfg}
-			s.signalStop(modeHard)
+			m.draining[name] = &drainEntry{sender: s, cfg: s.cfg, goodbyeWanted: true}
+			s.signalStop(modeGraceful)
 			toStop = append(toStop, stopReq{name, s})
 		}
 	}
@@ -613,25 +634,38 @@ type ownedDrain struct {
 func (m *Manager) Withdraw() error {
 	m.mu.Lock()
 	m.bumpEpoch()
-	var names []string
-	for name := range m.senders {
-		names = append(names, name)
-	}
-	// Also include interfaces already DRAINING (e.g. a Clear acquired m.mu
-	// first and hard-stopped them, or a changed-config restart is mid stop->
-	// start). claimGracefulLocked flips goodbyeWanted on those entries; their
-	// existing owner's release path emits the standalone if owed.
-	for name := range m.draining {
-		names = append(names, name)
-	}
-	owned := m.claimGracefulLocked(names)
-	epoch := m.epoch
+	owned, epoch := m.collectGracefulWithdrawLocked()
 	m.mu.Unlock()
 	for _, o := range owned {
 		// nil onProvenClose: a withdraw never starts a replacement.
 		m.releaseDrain(o.name, o.s, epoch, nil)
 	}
 	return nil
+}
+
+// collectGracefulWithdrawLocked flips graceful-withdrawal intent on every active
+// sender AND every already-draining interface, returning the drains THIS caller
+// owns the join+release for plus the current fenced epoch. Callers hold m.mu
+// (and have already bumped the whole-manager epoch); they must Unlock and drive
+// releaseDrain(o.name, o.s, epoch, nil) for each returned drain. Shared by
+// Withdraw() and Apply()'s empty-config branch (config-driven removal of ALL RA,
+// #5092) so both retire senders with a final lifetime-0 goodbye — the graceful
+// terminal withdrawal RFC 4861 §6.2.5 recommends — rather than a silent hard
+// stop that strands a stale default route on hosts.
+//
+// Already-draining interfaces are included (e.g. a Clear acquired m.mu first and
+// hard-stopped them, or a changed-config restart is mid stop->start):
+// claimGracefulLocked flips goodbyeWanted on those entries so their existing
+// owner's release path emits the standalone if one is owed.
+func (m *Manager) collectGracefulWithdrawLocked() ([]ownedDrain, uint64) {
+	var names []string
+	for name := range m.senders {
+		names = append(names, name)
+	}
+	for name := range m.draining {
+		names = append(names, name)
+	}
+	return m.claimGracefulLocked(names), m.epoch
 }
 
 // WithdrawInterfaces sends goodbye RAs and stops senders only for the named

--- a/pkg/ra/serialize_test.go
+++ b/pkg/ra/serialize_test.go
@@ -818,7 +818,9 @@ func TestT5_ApplyConfigEqualKeepsSender(t *testing.T) {
 	_ = m.Clear()
 }
 
-// T6 — Clear / Apply-remove emit NO goodbye (modeHard).
+// T6 — Clear emits NO goodbye (modeHard). Clear() is the explicit no-goodbye
+// primitive for a forced/unsafe stop; config-driven removal now withdraws
+// gracefully instead (#5092, see config_removal_goodbye_5092_test.go).
 func TestT6_ClearEmitsNoGoodbye(t *testing.T) {
 	if _, err := net.InterfaceByName("lo"); err != nil {
 		t.Skip("lo interface unavailable")


### PR DESCRIPTION
## Problem

Removing RA config (from one interface, or all of them) **hard-stops** the
sender with no goodbye. Hosts retain this firewall as their IPv6 default router
until the previous Router Lifetime (default **1800s**) expires — an avoidable,
minutes-long IPv6 outage. RFC 4861 §6.2.5 recommends a final zero-lifetime RA.
The changed-config *replacement* path correctly omits a goodbye (a replacement
re-advertises immediately), but a **true removal has no replacement**, so the
router identity silently lingers on hosts.

Source: codex-review-177 `[A5-b1-F19]`, re-verified GENUINE on current
`origin/master`.

## Expected behavior

Distinguish changed-config replacement from true removal: use a **graceful
terminal withdrawal** (final lifetime-0 goodbye) for removed interfaces and for
config-driven removal of all RA, then retire — keeping the hard stop only where
sending is unsafe or another owner immediately re-advertises the router.

## Fix

- **`Apply` removal loop** — a dropped interface now installs a `goodbyeWanted`
  `drainEntry` + `signalStop(modeGraceful)` (mirrors `claimGracefulLocked`'s
  active-sender branch). The owner emits the goodbye on exit; `releaseDrain`'s
  standalone backstop covers a lost upgrade race. `onProvenClose` stays `nil`
  (no replacement).
- **`Apply` empty-config branch** (all RA removed) — withdraws every sender
  gracefully via a new shared `collectGracefulWithdrawLocked` helper (extracted
  from `Withdraw`), instead of the silent `clearLocked` hard stop.
- **Daemon standalone reconcile** (`applyServicesReconcile`) — calls
  `d.ra.Withdraw()` instead of `d.ra.Clear()` when no RA config remains.
- **`Clear()` retained** as the explicit no-goodbye primitive for a
  forced/unsafe stop; it is no longer on the config-removal path.

The changed-config restart, deferred/epoch-guarded starts, the #5094 join-
timeout reclaimer, and the #5406/#5093 goodbye error-surface conventions are all
preserved — removal simply reuses the same graceful-withdraw machinery a
`Withdraw()` already drives. The cluster paths (`applyRethServicesForRG` MASTER
apply, BACKUP `Withdraw`/`WithdrawInterfaces`) inherit the graceful removal
automatically.

## Tests — RED on revert

`pkg/ra/config_removal_goodbye_5092_test.go` (fake-conn harness):
- **full removal** via `Apply(nil)` → exactly one lifetime-0 goodbye, emitted as
  the LAST RA, senders drained;
- **partial removal** (one interface dropped, another kept) → removed interface
  gracefully withdrawn, kept sender untouched (still active, no goodbye);
- **non-regression** → a changed-config restart emits NO goodbye on either conn.

Both removal tests **fail against the pre-fix hard stop** (`0 conns / 0 writes`);
verified by stashing the production change (keeping the tests). `TestConfigChangeEmitsNoGoodbye_5092` still passes on the reverted tree.

## Validation

- `go test -race ./pkg/ra/...` — green (full package).
- `go test ./pkg/daemon/...` — green.
- `go build ./...` + `go vet` — green.
- T6's comment corrected (its body only exercises `Clear`, which stays hard).

## Docs

`pkg/ra/README.md` updated: `Apply`/`Clear` entry points and the
make-before-break note now describe graceful removal vs. the no-goodbye `Clear`
primitive.

Closes #5092

🤖 Generated with [Claude Code](https://claude.com/claude-code)