### PR TITLE
pkg/config: reserve the -xpf-chain BGP route-map suffix at commit-check (#5442)

### DIFF
--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -938,6 +938,29 @@ doctrine); as defense-in-depth the renderer's `redistAliasCollision` (invoked by
 alias still collides, so the collision cannot leak even when the strict gate was
 bypassed.
 
+**The `-xpf-chain` route-map-name suffix is reserved (#5442):** the direct
+parity sibling of the `-xpf-redist` reservation above. #5277 composes an ordered
+BGP import/export policy chain of length >= 2 into a SINGLE FRR route-map named
+`join(chain, "-") + "-xpf-chain"` (`composedChainName`, `pkg/frr`) in FRR's
+GLOBAL name-keyed route-map namespace. An operator policy-statement literally
+named `<X>-xpf-chain` lands in that reserved suffix namespace and can collide
+with a generated composed route-map — FRR MERGES two same-named route-map
+definitions, silently altering the operator's BGP filtering.
+`validatePolicyReservedChainNameStrict` (`compiler_validate_strict_routing.go`,
+constant `ReservedChainSuffix`) hard-rejects a policy-statement whose name ends
+in the reserved suffix at commit / commit-check (naming the policy and the
+suffix), making the composed-name namespace injective against operator
+policy-statements BY CONSTRUCTION. The composed-name derivation in `pkg/frr`
+re-exports the SAME `ReservedChainSuffix` constant
+(`frr.ReservedChainSuffix = config.ReservedChainSuffix`) so the two cannot drift.
+The tolerant load / peer-sync path downgrades to a warning
+(`lenientPolicyReservedChainName`) so an already-persisted or peer-synced config
+an older binary accepted still boots (#1960 no-brick doctrine); as
+defense-in-depth the renderer's `bgpComposedChainCollision` (invoked by
+`ApplyFull`) then fails the managed-section apply CLOSED if a leniently-loaded
+composed name still collides, so the collision cannot leak even when the strict
+gate was bypassed.
+
 **Policy-referenced application protocols are validated against the dataplane
 resolver (#3150 — codex-review-067 finding 067-06):** a user-defined
 `set applications application <name> protocol <token>` that is REFERENCED by a

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1590,6 +1590,22 @@ type compileOpts struct {
 	// on the tolerant path, so a leniently-loaded collision cannot leak. Same
 	// doctrine as lenientRoutingExportRef.
 	lenientPolicyReservedRedistName bool
+	// lenientPolicyReservedChainName (#5442) downgrades the reserved
+	// composed-chain route-map-suffix gate (validatePolicyReservedChainNameStrict)
+	// from a hard compile error to a cfg.Warnings entry. An operator
+	// policy-statement whose name ends in the reserved ReservedChainSuffix
+	// ("-xpf-chain") collides in FRR's global name-keyed route-map namespace with
+	// the composed BGP policy-chain route-map the renderer derives for an ordered
+	// import/export chain of length >= 2 (#5277); FRR merges same-named
+	// route-maps, which can silently alter the operator's BGP filtering. The
+	// strict commit / commit-check path hard-rejects such a name so it is
+	// operator-visible; an already-persisted or peer-synced config an older
+	// binary accepted must still BOOT (warn) per the #1960 fail-closed-on-load
+	// doctrine — the render path carries a defense-in-depth collision guard
+	// (bgpComposedChainCollision, pkg/frr) that fails the managed-section apply
+	// CLOSED on the tolerant path, so a leniently-loaded collision cannot leak.
+	// Same doctrine as lenientPolicyReservedRedistName.
+	lenientPolicyReservedChainName bool
 	// lenientVRRPVirtualAddress (#3013) downgrades the VRRP virtual-address
 	// subnet-containment gate (validateVRRPVirtualAddressSubnet) from a hard
 	// compile error to a cfg.Warnings entry. A VRRP virtual-address that does
@@ -1827,6 +1843,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientPolicyMissingMatch:              true,
 		lenientPolicyCommunityRef:              true,
 		lenientPolicyReservedRedistName:        true,
+		lenientPolicyReservedChainName:         true,
 		lenientVRRPVirtualAddress:              true,
 		lenientDNATToScope:                     true,
 		lenientNATMixedScope:                   true,
@@ -2098,6 +2115,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientPolicyMissingMatch:              true,
 		lenientPolicyCommunityRef:              true,
 		lenientPolicyReservedRedistName:        true,
+		lenientPolicyReservedChainName:         true,
 		lenientVRRPVirtualAddress:              true,
 		lenientDNATToScope:                     true,
 		lenientNATMixedScope:                   true,

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -1283,6 +1283,29 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 		}
 	}
 
+	// #5442: reserved composed-chain route-map-suffix gate. #5277 composes an
+	// ordered BGP import/export policy chain (length >= 2) into a single FRR
+	// route-map named `join(chain, "-") + "-xpf-chain"` (composedChainName,
+	// pkg/frr) in FRR's GLOBAL name-keyed route-map namespace. An operator
+	// policy-statement literally named `<X>-xpf-chain` collides with that
+	// generated composed route-map and FRR MERGES same-named route-maps,
+	// silently altering the operator's BGP filtering. Reserve the suffix: strict
+	// on commit / commit-check (hard reject so the reserved name is
+	// operator-visible), lenient on load / peer-sync (warn so an
+	// already-persisted or peer-synced config an older binary accepted still
+	// boots — #1960; the render path carries the bgpComposedChainCollision guard
+	// that fails the apply CLOSED on the tolerant path). Runs on the
+	// fully-compiled *Config so the policy-statement map is populated regardless
+	// of authoring order. Mirrors validatePolicyReservedRedistNameStrict.
+	if err := validatePolicyReservedChainNameStrict(cfg); err != nil {
+		if opts.lenientPolicyReservedChainName {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("reserved route-map suffix (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #2963: BGP neighbor peer-as gate. peer-as (remote-as) is optional in
 	// the parser/compiler, so a neighbor authored without one keeps a zero
 	// PeerAS and the FRR renderer emitted `neighbor <addr> remote-as 0`. AS 0

--- a/pkg/config/compiler_validate_strict_routing.go
+++ b/pkg/config/compiler_validate_strict_routing.go
@@ -882,3 +882,62 @@ func validatePolicyReservedRedistNameStrict(cfg *Config) error {
 	}
 	return nil
 }
+
+// ReservedChainSuffix is the route-map name suffix xpf RESERVES for the composed
+// BGP policy-chain route-maps the FRR renderer derives for an ordered
+// import/export policy list of length >= 2 (composedChainName in pkg/frr joins
+// the member policy names and appends this suffix). FRR keys route-maps by NAME
+// in a single GLOBAL namespace, so an operator policy-statement whose name ends
+// in this suffix would collide with a generated composed route-map in that
+// shared object and FRR would MERGE the two same-named definitions, silently
+// altering the operator's BGP filtering (#5277/#5442). The composed-name
+// derivation (pkg/frr) and the strict validator below MUST agree on this exact
+// string; pkg/frr re-exports this constant (frr.ReservedChainSuffix =
+// config.ReservedChainSuffix) so the two never drift.
+const ReservedChainSuffix = "-xpf-chain"
+
+// validatePolicyReservedChainNameStrict hard-rejects an operator
+// policy-statement whose name ends in the reserved ReservedChainSuffix. That
+// suffix is owned by the FRR renderer's generated composed BGP policy-chain
+// route-maps (#5277): an ordered import/export chain of length >= 2 is joined
+// and suffixed with ReservedChainSuffix (composedChainName in pkg/frr). An
+// operator name in that suffix namespace can collide with a generated composed
+// route-map in FRR's global name-keyed route-map object; FRR MERGES two
+// same-named route-map definitions, silently altering the operator's BGP
+// filtering (#5442). Reserving the suffix at commit makes the composed-name
+// namespace injective against operator policy-statements BY CONSTRUCTION — no
+// legal config can name a policy-statement into the generated slot.
+//
+// Strict on commit / commit-check (hard reject so the reserved name is
+// operator-visible); lenient on load / peer-sync (warn so an already-persisted
+// or peer-synced config an older binary accepted still boots — #1960
+// fail-closed-on-load class). The render-side defense-in-depth
+// (bgpComposedChainCollision in pkg/frr) fails the whole managed-section apply
+// CLOSED on the tolerant path, so a leniently-loaded collision cannot leak. Runs
+// on the fully-compiled *Config so the policy-statement map is populated
+// regardless of authoring order. Mirrors validatePolicyReservedRedistNameStrict.
+func validatePolicyReservedChainNameStrict(cfg *Config) error {
+	if cfg == nil || cfg.PolicyOptions.PolicyStatements == nil {
+		return nil
+	}
+	// Deterministic first-error: iterate policy-statement names in sorted order.
+	names := make([]string, 0, len(cfg.PolicyOptions.PolicyStatements))
+	for name := range cfg.PolicyOptions.PolicyStatements {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if strings.HasSuffix(name, ReservedChainSuffix) {
+			return fmt.Errorf(
+				"policy-statement %q ends in the reserved %q suffix; xpf owns "+
+					"that suffix for generated composed BGP policy-chain "+
+					"route-maps (#5277/#5442) and an operator name in that "+
+					"namespace can collide with a generated composed route-map "+
+					"in FRR's global route-map object, which FRR would merge — "+
+					"silently altering BGP route filtering — rename the "+
+					"policy-statement off the reserved suffix",
+				name, ReservedChainSuffix)
+		}
+	}
+	return nil
+}

--- a/pkg/config/policy_reserved_chain_name_5442_test.go
+++ b/pkg/config/policy_reserved_chain_name_5442_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5442: the FRR renderer composes an ordered BGP import/export policy chain of
+// length >= 2 into a SINGLE route-map named `join(chain, "-") + ReservedChainSuffix`
+// ("-xpf-chain") in FRR's GLOBAL name-keyed route-map namespace (composedChainName,
+// pkg/frr, #5277). An operator policy-statement literally named `<X>-xpf-chain`
+// lands in that reserved suffix namespace and can collide with a generated
+// composed route-map; FRR MERGES two same-named route-map definitions, silently
+// altering the operator's BGP filtering. validatePolicyReservedChainNameStrict
+// reserves the suffix: hard-reject at commit / commit-check (strict),
+// lenient-warn on load / peer-sync (#1960). This makes the composed-name
+// namespace injective against operator policy-statements by construction — the
+// commit-time parity for the `-xpf-redist` reservation (#5116) whose render-side
+// guard bgpComposedChainCollision (pkg/frr) already fails the apply CLOSED.
+//
+// These tests drive the real CompileConfig (strict) / CompileConfigLenient
+// (tolerant) paths via buildTreeFromSet (the shared flat-set helper). They FAIL
+// if the reserve gate is reverted (the reserved-suffix name is then silently
+// accepted at commit).
+
+// TestPolicyReservedChainSuffixRejected is the core: an operator
+// policy-statement whose name ends in the reserved suffix is hard-rejected at
+// commit, naming the policy, the suffix, and that it is reserved.
+func TestPolicyReservedChainSuffixRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set policy-options policy-statement A-B-xpf-chain term t1 from protocol direct",
+		"set policy-options policy-statement A-B-xpf-chain term t1 then accept",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a policy-statement ending in the reserved " +
+			"\"-xpf-chain\" suffix; expected rejection (#5442)")
+	}
+	for _, want := range []string{"A-B-xpf-chain", "-xpf-chain", "reserved"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+// TestPolicyReservedChainNormalNameAccepted is the negative control: a normal
+// policy-statement name (no reserved suffix), even when composed into a BGP
+// export chain of >= 2, still compiles — so the gate is SURGICAL and does not
+// reject the common case. It also proves the collision trigger requires the
+// exact suffix — a name merely CONTAINING "chain" is fine.
+func TestPolicyReservedChainNormalNameAccepted(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set policy-options policy-statement BLOCK-PRIVATE term t1 from protocol direct",
+		"set policy-options policy-statement BLOCK-PRIVATE term t1 then reject",
+		"set policy-options policy-statement ALLOW-CUSTOMER term t1 then accept",
+		"set protocols bgp group g type external",
+		"set protocols bgp group g peer-as 65001",
+		"set protocols bgp group g neighbor 10.0.0.2 export BLOCK-PRIVATE",
+		"set protocols bgp group g neighbor 10.0.0.2 export ALLOW-CUSTOMER",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a normal (non-reserved) policy-statement chain: %v", err)
+	}
+}
+
+// TestPolicyReservedChainSuffixLenientWarns pins the #1960 fail-closed-on-load
+// doctrine: an already-persisted or peer-synced config an older binary accepted
+// (before this gate) must still BOOT through CompileConfigLenient — the reserved
+// name is downgraded to a warning, not a hard failure. The render-side
+// bgpComposedChainCollision guard (pkg/frr) fails the actual apply closed, so
+// the leniently-loaded name still cannot leak.
+func TestPolicyReservedChainSuffixLenientWarns(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set policy-options policy-statement A-B-xpf-chain term t1 from protocol direct",
+		"set policy-options policy-statement A-B-xpf-chain term t1 then accept",
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must not hard-fail on a reserved-suffix name; must downgrade to warning: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "A-B-xpf-chain") && strings.Contains(w, "reserved") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a downgraded reserved-suffix warning naming the policy; warnings=%v", cfg.Warnings)
+	}
+}

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -443,7 +443,17 @@ also carries operator content:
      so `bgpComposedChainCollision` (called by `ApplyFull`, mirroring
      `redistAliasCollision`) fails the whole apply CLOSED if a composed name
      collides with an operator policy-statement or two distinct chains derive
-     the same name. `collectBGPRouteMapPolicies` records only SINGLE-policy
+     the same name. **Commit-time reservation (#5442):** the `-xpf-chain`
+     suffix (`config.ReservedChainSuffix`, which `frr.ReservedChainSuffix`
+     re-exports so the two cannot drift) is ALSO reserved at commit /
+     commit-check — `validatePolicyReservedChainNameStrict` (`pkg/config`,
+     mirroring `validatePolicyReservedRedistNameStrict`) hard-rejects an
+     operator policy-statement whose name ends in it (lenient-warn on
+     load/HA-sync per #1960), so an operator name collision is rejected
+     cleanly at commit instead of surfacing as a late whole-section apply
+     failure; `bgpComposedChainCollision` remains the render-side
+     defense-in-depth for the tolerant path. `collectBGPRouteMapPolicies`
+     records only SINGLE-policy
      chains into `bgpAcceptDefault` (a composed chain carries its BGP-accept
      default INTERNALLY, so its members' standalone route-maps are not the
      referenced objects). RED-on-revert covered by `bgp_policy_chain_5277_test.go`

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -265,8 +265,12 @@ func isDefinedPolicyStatement(name string, po *config.PolicyOptionsConfig) bool 
 // collided with an operator policy-statement would fuse the two objects and
 // could silently change the operator's filtering — the render-side guard
 // bgpComposedChainCollision fails the whole apply CLOSED on any collision
-// (#5277). Kept a package const so the derivation and the guard cannot drift.
-const ReservedChainSuffix = "-xpf-chain"
+// (#5277). The canonical constant lives in pkg/config (config.ReservedChainSuffix),
+// which the commit-time strict validator validatePolicyReservedChainNameStrict
+// reserves (#5442); this re-export sources the same literal so the composed-name
+// derivation here and the config gate cannot drift (mirrors the redist pattern,
+// where frr references config.ReservedRedistSuffix directly).
+const ReservedChainSuffix = config.ReservedChainSuffix
 
 // hasNonEmptyPolicy reports whether names holds at least one non-empty entry.
 // It replaces the old lastNonEmpty("") != "" idiom for "does this neighbor set
@@ -989,10 +993,12 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 		// policy-statement-name route-map-out exports: a per-neighbor
 		// export overrides the global default for that neighbor. FRR
 		// accepts a single `route-map out` per neighbor/AF, so exactly one
-		// is emitted — the neighbor's own when present, else the global
-		// default (bgpEffectiveExport). A bare-token redistribute is a
-		// GLOBAL redistribute verb, not per-neighbor, and is emitted once
-		// under `router bgp`.
+		// is emitted — the neighbor's own export chain when present, else
+		// the global export chain (bgpNeighborExportChain resolves the
+		// override; a resolved chain of >= 2 is composed into one
+		// `-xpf-chain` route-map via composedChainName/bgpRouteMapRef,
+		// #5277). A bare-token redistribute is a GLOBAL redistribute verb,
+		// not per-neighbor, and is emitted once under `router bgp`.
 		// globalExportChain is the ORDERED list of DEFINED policy-statements
 		// in `protocols bgp export` — the global export CHAIN applied as a
 		// peer-level default to neighbors with no own export. Every entry is


### PR DESCRIPTION
## Problem

#5277/#5440 compose an ordered BGP import/export policy chain of length `>= 2`
into a single FRR route-map named `join(chain, "-") + "-xpf-chain"`
(`composedChainName`, `pkg/frr`) in FRR's **GLOBAL** name-keyed route-map
namespace — shared with operator route-maps. FRR **merges** two same-named
route-map definitions, so an operator policy-statement literally named
`<X>-xpf-chain` can collide with a generated composed route-map and silently
alter the operator's BGP filtering.

#5440 guards this collision only **render-side**: `bgpComposedChainCollision`
(`pkg/frr`, run by `ApplyFull`) fails the whole managed-section apply CLOSED.

## Parity gap with `-xpf-redist`

The sibling `-xpf-redist` reserved suffix carries a **commit-time strict
validator** (`validatePolicyReservedRedistNameStrict`, #5116) **in addition to**
its render-side guard (`redistAliasCollision`). `-xpf-chain` had **no**
commit-time reservation — so an operator naming a colliding policy got a late,
opaque **whole-section apply failure** instead of a clean `commit check`
rejection.

## Fix

- **`validatePolicyReservedChainNameStrict`** (`pkg/config`), mirroring
  `validatePolicyReservedRedistNameStrict` exactly: strict hard-reject at commit
  / commit-check (reserved name operator-visible), lenient warn on load /
  peer-sync so an already-persisted or peer-synced config an older binary
  accepted still boots (#1960). The render-side `bgpComposedChainCollision`
  remains the defense-in-depth on the tolerant path. Wired into the same
  strict-gate cohort (`compiler_uniformgates.go`) with a
  `lenientPolicyReservedChainName` flag set on both lenient compile paths.
- **Shared constant, no config/frr drift:** the canonical
  `ReservedChainSuffix = "-xpf-chain"` constant now lives in `pkg/config` (next
  to `ReservedRedistSuffix`); `pkg/frr` re-exports it as
  `ReservedChainSuffix = config.ReservedChainSuffix` — matching how the redist
  path already references `config.ReservedRedistSuffix`.
- **NIT:** fixed the stale comment in `policy_render.go` that referenced the
  removed `bgpEffectiveExport` function — the effective per-neighbor export is
  now resolved by `bgpNeighborExportChain` and composed via
  `composedChainName`/`bgpRouteMapRef` (#5277).
- **Docs:** documented the `-xpf-chain` commit-time reservation in the
  `pkg/config` and `pkg/frr` module READMEs alongside `-xpf-redist`.

## Tests (RED-on-revert proven)

`pkg/config/policy_reserved_chain_name_5442_test.go`, mirroring the redist
validator's test shape:
- collision name (`A-B-xpf-chain`) → **rejected at commit** (strict), naming the
  policy + suffix + "reserved";
- same name → **downgraded to a warning** on `CompileConfigLenient` (#1960);
- normal names composed into a `>= 2` BGP export chain → still compile.

**RED-on-revert:** with the strict-gate wiring removed (validator kept),
`TestPolicyReservedChainSuffixRejected` and `...LenientWarns` FAIL (colliding
name silently accepted, no warning); restored → all pass. `go build ./...` and
`go test ./pkg/config/... ./pkg/frr/...` green.

Closes #5442

🤖 Generated with [Claude Code](https://claude.com/claude-code)