### PR TITLE
pkg/api: render IPv6 and per-VRF static routes in REST /routes (#5439)

### DIFF
--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -359,6 +359,21 @@ under the daemon's errgroup. Nothing else imports this package.
   next-hop or a `next_table` leaks nothing new and existing consumers reading
   `destination`/`next_hop`/`interface`/`preference`/`next_table` are
   unaffected. Pinned by `routes_disposition_5410_test.go`.
+- The same handler covers the FULL static-route set the CLI/gRPC `show route`
+  iterate, not just the global inet.0 table (#5439). It walks
+  `RoutingOptions.StaticRoutes` (inet.0), `RoutingOptions.Inet6StaticRoutes`
+  (inet6.0), AND every routing-instance's per-VRF `StaticRoutes` /
+  `Inet6StaticRoutes`, tagging each `RouteInfo` with its `family` (`inet` /
+  `inet6`) and Junos RIB `table` name (`inet.0` / `inet6.0`, or
+  `<instance>.inet.0` / `<instance>.inet6.0` for a VRF). Before #5439 it
+  iterated ONLY inet.0, so the REST view silently omitted every IPv6 static
+  route and every per-VRF static route — not even their destination — while
+  the CLI/gRPC rendered both families and every VRF. The disposition labeling
+  above applies uniformly across all four sources (an `appendStaticRoutes`
+  helper renders each table). The `family` / `table` fields are additive and
+  `omitempty`, the inet.0 rows still lead in their original order, so a legacy
+  consumer reading the pre-#5439 inet.0 subset positionally is unaffected.
+  Pinned by `routes_ipv6_vrf_5439_test.go`.
 - Long full-table read handlers must ABORT when the client disconnects
   (#5232/#5233). The REST server cancels `r.Context()` on disconnect, so a
   handler that walks a large structure has to sample `r.Context().Err()`

--- a/pkg/api/routes_ipv6_vrf_5439_test.go
+++ b/pkg/api/routes_ipv6_vrf_5439_test.go
@@ -1,0 +1,147 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// #5439: routesHandler iterated ONLY cfg.RoutingOptions.StaticRoutes
+// (inet.0), so the REST /routes view silently omitted every IPv6 static
+// route AND every per-routing-instance (VRF) static route — not even their
+// destination was rendered — while the CLI/gRPC `show route` iterate both
+// families and every VRF. This test injects inet.0 + inet6.0 global routes
+// AND per-VRF inet.0 + inet6.0 routes into the live ActiveConfig, drives
+// routesHandler, and asserts each appears tagged with its family and Junos
+// RIB table name, with the #5410 disposition labeling preserved across
+// families. Reverting the handler to iterate only StaticRoutes drops every
+// v6 and per-VRF route from the response — RED on revert.
+func routesV6VRFStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+system {
+    host-name xpf;
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	// Global inet.0 (v4): a normal next-hop route (regression check).
+	cfg.RoutingOptions.StaticRoutes = []*config.StaticRoute{
+		{Destination: "10.4.0.0/24", Preference: 7, NextHops: []config.NextHopEntry{
+			{Address: "10.4.0.254", Interface: "ge-0-0-0"},
+		}},
+	}
+	// Global inet6.0 (v6): a normal route, plus a reject and a discard route
+	// so the disposition labeling is exercised on the v6 path (#5410 compose).
+	cfg.RoutingOptions.Inet6StaticRoutes = []*config.StaticRoute{
+		{Destination: "2001:db8:1::/48", Preference: 5, NextHops: []config.NextHopEntry{
+			{Address: "2001:db8:1::1", Interface: "ge-0-0-1"},
+		}},
+		{Destination: "2001:db8:dead::/48", Reject: true, Preference: 5},
+		{Destination: "2001:db8:beef::/48", Discard: true, Preference: 5},
+	}
+	// Per-VRF (routing-instance) static routes: one v4, one v6.
+	cfg.RoutingInstances = []*config.RoutingInstanceConfig{
+		{
+			Name:         "Comcast",
+			InstanceType: "vrf",
+			StaticRoutes: []*config.StaticRoute{
+				{Destination: "192.0.2.0/24", Preference: 5, NextHops: []config.NextHopEntry{
+					{Address: "192.0.2.254"},
+				}},
+			},
+			Inet6StaticRoutes: []*config.StaticRoute{
+				{Destination: "2001:db8:c0::/48", Preference: 5, NextHops: []config.NextHopEntry{
+					{Address: "2001:db8:c0::1"},
+				}},
+			},
+		},
+	}
+	return store
+}
+
+func TestRoutesHandlerIPv6AndVRF(t *testing.T) {
+	s := &Server{store: routesV6VRFStore(t)}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/routing/routes", nil)
+	s.routesHandler(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		Success bool        `json:"success"`
+		Data    []RouteInfo `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body: %s", err, rr.Body.String())
+	}
+	if !resp.Success {
+		t.Fatalf("success=false; body: %s", rr.Body.String())
+	}
+
+	byDest := map[string]RouteInfo{}
+	for _, r := range resp.Data {
+		byDest[r.Destination] = r
+	}
+
+	// IPv4 inet.0 route still renders as before — no regression, and now
+	// tagged with family/table additively.
+	if got, ok := byDest["10.4.0.0/24"]; !ok {
+		t.Errorf("inet.0 route 10.4.0.0/24 missing from response")
+	} else if got.NextHop != "10.4.0.254" || got.Interface != "ge-0-0-0" ||
+		got.Family != "inet" || got.Table != "inet.0" || got.Disposition != "" {
+		t.Errorf("inet.0 route = %+v, want next-hop 10.4.0.254 via ge-0-0-0, family=inet, table=inet.0", got)
+	}
+
+	// IPv6 global route — WAS ABSENT before #5439.
+	if got, ok := byDest["2001:db8:1::/48"]; !ok {
+		t.Errorf("inet6.0 route 2001:db8:1::/48 missing (the #5439 bug: v6 omitted)")
+	} else if got.NextHop != "2001:db8:1::1" || got.Family != "inet6" || got.Table != "inet6.0" {
+		t.Errorf("inet6.0 route = %+v, want next-hop 2001:db8:1::1, family=inet6, table=inet6.0", got)
+	}
+
+	// IPv6 reject route — disposition labeling composes with #5410 on v6.
+	if got, ok := byDest["2001:db8:dead::/48"]; !ok {
+		t.Errorf("inet6.0 reject route missing (the #5439 bug)")
+	} else if got.Disposition != "reject" || got.Family != "inet6" || got.Table != "inet6.0" {
+		t.Errorf("inet6.0 reject route = %+v, want disposition=reject, family=inet6, table=inet6.0", got)
+	}
+	// IPv6 discard route.
+	if got, ok := byDest["2001:db8:beef::/48"]; !ok {
+		t.Errorf("inet6.0 discard route missing (the #5439 bug)")
+	} else if got.Disposition != "discard" || got.Family != "inet6" {
+		t.Errorf("inet6.0 discard route = %+v, want disposition=discard, family=inet6", got)
+	}
+
+	// Per-VRF IPv4 static route — WAS ABSENT before #5439, tagged with the
+	// instance's Junos RIB name.
+	if got, ok := byDest["192.0.2.0/24"]; !ok {
+		t.Errorf("per-VRF inet route 192.0.2.0/24 missing (the #5439 bug: per-VRF omitted)")
+	} else if got.NextHop != "192.0.2.254" || got.Family != "inet" || got.Table != "Comcast.inet.0" {
+		t.Errorf("per-VRF inet route = %+v, want next-hop 192.0.2.254, family=inet, table=Comcast.inet.0", got)
+	}
+
+	// Per-VRF IPv6 static route.
+	if got, ok := byDest["2001:db8:c0::/48"]; !ok {
+		t.Errorf("per-VRF inet6 route 2001:db8:c0::/48 missing (the #5439 bug)")
+	} else if got.NextHop != "2001:db8:c0::1" || got.Family != "inet6" || got.Table != "Comcast.inet6.0" {
+		t.Errorf("per-VRF inet6 route = %+v, want next-hop 2001:db8:c0::1, family=inet6, table=Comcast.inet6.0", got)
+	}
+}

--- a/pkg/api/routing.go
+++ b/pkg/api/routing.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/frr"
 )
 
@@ -32,59 +33,86 @@ func (s *Server) routesHandler(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
+	// Iterate the SAME static-route sources the CLI/gRPC `show route` text
+	// walks (#5439): the global inet.0 + inet6.0 tables AND every
+	// routing-instance's per-VRF inet.0 + inet6.0 tables. Before #5439 this
+	// handler rendered only cfg.RoutingOptions.StaticRoutes (inet.0), so it
+	// silently omitted every IPv6 static route and every per-VRF static
+	// route — not even their destination — making the REST view inconsistent
+	// with the CLI/gRPC. Each route is tagged with its family and Junos RIB
+	// name so a consumer can tell inet from inet6 and the default table from
+	// a VRF. The inet.0 rows still come first, in their original order, so a
+	// legacy consumer's positional reads are unchanged.
 	var result []RouteInfo
-	for _, r := range cfg.RoutingOptions.StaticRoutes {
-		if r.NextTable != "" {
-			result = append(result, RouteInfo{
-				Destination: r.Destination,
-				NextTable:   r.NextTable,
-				Preference:  r.Preference,
-			})
+	result = appendStaticRoutes(result, cfg.RoutingOptions.StaticRoutes, "inet", "inet.0")
+	result = appendStaticRoutes(result, cfg.RoutingOptions.Inet6StaticRoutes, "inet6", "inet6.0")
+	for _, ri := range cfg.RoutingInstances {
+		if ri == nil {
 			continue
 		}
-		// Routes with no forwarding next-hop carry a disposition label so
-		// this view distinguishes reject (RTN_UNREACHABLE) from discard
-		// (RTN_BLACKHOLE) from directly-connected, matching how the CLI/gRPC
-		// `show route` text renders reject/discard (#5298/#5410). Reject and
-		// Discard are mutually exclusive; check them before the no-next-hop
-		// fallthrough since a reject/discard route also carries no NextHops.
-		if r.Reject {
-			result = append(result, RouteInfo{
-				Destination: r.Destination,
-				Disposition: "reject",
-				Preference:  r.Preference,
-			})
-			continue
-		}
-		if r.Discard {
-			result = append(result, RouteInfo{
-				Destination: r.Destination,
-				Disposition: "discard",
-				Preference:  r.Preference,
-			})
-			continue
-		}
-		if len(r.NextHops) == 0 {
-			result = append(result, RouteInfo{
-				Destination: r.Destination,
-				Disposition: "connected",
-				Preference:  r.Preference,
-			})
-			continue
-		}
-		for _, nh := range r.NextHops {
-			result = append(result, RouteInfo{
-				Destination: r.Destination,
-				NextHop:     nh.Address,
-				Interface:   nh.Interface,
-				Preference:  r.Preference,
-			})
-		}
+		result = appendStaticRoutes(result, ri.StaticRoutes, "inet", ri.Name+".inet.0")
+		result = appendStaticRoutes(result, ri.Inet6StaticRoutes, "inet6", ri.Name+".inet6.0")
 	}
 	if result == nil {
 		result = []RouteInfo{}
 	}
 	writeOK(w, result)
+}
+
+// appendStaticRoutes renders each static route in routes into one or more
+// RouteInfo rows tagged with the given family ("inet"/"inet6") and Junos RIB
+// table name, appending them to result. It applies the same disposition
+// labeling the CLI/gRPC `show route` text uses (#5298/#5410): a route with no
+// forwarding next-hop carries a "reject" (RTN_UNREACHABLE), "discard"
+// (RTN_BLACKHOLE), or "connected" (directly-connected) label, while a
+// next-table route carries next_table and a normal route emits one row per
+// next-hop. Reject and Discard are mutually exclusive and are checked before
+// the no-next-hop fallthrough since a reject/discard route also carries no
+// NextHops. Shared by the global inet.0/inet6.0 tables and every per-VRF
+// table so all four sources render identically.
+func appendStaticRoutes(result []RouteInfo, routes []*config.StaticRoute, family, table string) []RouteInfo {
+	for _, r := range routes {
+		if r == nil {
+			continue
+		}
+		base := RouteInfo{
+			Destination: r.Destination,
+			Preference:  r.Preference,
+			Family:      family,
+			Table:       table,
+		}
+		if r.NextTable != "" {
+			ri := base
+			ri.NextTable = r.NextTable
+			result = append(result, ri)
+			continue
+		}
+		if r.Reject {
+			ri := base
+			ri.Disposition = "reject"
+			result = append(result, ri)
+			continue
+		}
+		if r.Discard {
+			ri := base
+			ri.Disposition = "discard"
+			result = append(result, ri)
+			continue
+		}
+		if len(r.NextHops) == 0 {
+			ri := base
+			ri.Disposition = "connected"
+			result = append(result, ri)
+			continue
+		}
+		for _, nh := range r.NextHops {
+			ri := base
+			ri.NextHop = nh.Address
+			ri.Interface = nh.Interface
+			result = append(result, ri)
+		}
+	}
+	return result
 }
 
 func (s *Server) ospfHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -466,6 +466,22 @@ type RouteInfo struct {
 	// a next-table leaks nothing here, so existing consumers reading
 	// destination/next_hop/interface/preference/next_table are unaffected.
 	Disposition string `json:"disposition,omitempty"`
+	// Family is the address family this static route lives in: "inet"
+	// (IPv4, rib inet.0) or "inet6" (IPv6, rib inet6.0). Before #5439 the
+	// REST /routes view rendered only inet.0 routes, so it silently omitted
+	// every IPv6 and per-routing-instance static route — inconsistent with
+	// the CLI/gRPC `show route`, which iterates both families and every VRF.
+	// The handler now covers v4 + v6 + per-routing-instance routes, tagging
+	// each with its Family and Table so the REST view matches show-route
+	// coverage. Additive and omitempty: a legacy consumer reading only the
+	// pre-#5439 inet.0 subset ignores these.
+	Family string `json:"family,omitempty"`
+	// Table is the Junos RIB this route belongs to: "inet.0" / "inet6.0" for
+	// the global (default) routing table, or "<instance>.inet.0" /
+	// "<instance>.inet6.0" for a per-routing-instance (VRF) static route
+	// (#5439). It encodes both the routing instance and the family, matching
+	// how the CLI/gRPC label each table. Additive and omitempty.
+	Table string `json:"table,omitempty"`
 }
 
 // ScreenInfo holds screen profile information.


### PR DESCRIPTION
## Problem
`routesHandler` (`pkg/api/routing.go`) iterated ONLY
`cfg.RoutingOptions.StaticRoutes` (the global inet.0 table). It never
touched `cfg.RoutingOptions.Inet6StaticRoutes` nor any
routing-instance's static routes. So the REST `GET /routes` view
silently omitted **every IPv6 static route AND every per-VRF static
route** — not even their destination was rendered. The CLI/gRPC
`show route` paths iterate both address families and every VRF
(`showRoutingOptions` / `showRoutingInstancesDetail` in
`pkg/grpcapi/server_show_routes_text.go`, mirrored in
`pkg/cli/cli_show_routing.go`), so REST was inconsistent. The merged
#5410/#5437 added reject/discard disposition labels but only to the
IPv4 routes REST already rendered.

## Invariant
The REST `/routes` view must match the CLI/gRPC show-route coverage
(v4 + v6 + per-routing-instance static routes), each tagged with its
family/table + disposition.

## Fix
Iterate the same static-route sources the CLI/gRPC walk:
- global inet.0 (`RoutingOptions.StaticRoutes`)
- global inet6.0 (`RoutingOptions.Inet6StaticRoutes`)
- each routing-instance's per-VRF inet.0 (`ri.StaticRoutes`) and
  inet6.0 (`ri.Inet6StaticRoutes`)

Each `RouteInfo` is tagged with `family` (`inet`/`inet6`) and the Junos
RIB `table` name (`inet.0`/`inet6.0`, or `<instance>.inet.0` /
`<instance>.inet6.0` for a VRF). The #5410 disposition labeling
(reject/discard/connected/next-table) is factored into an
`appendStaticRoutes` helper and applied uniformly to all four sources,
so a reject/discard v6 or per-VRF route renders its label too.

**Backward-compatible:** the new `family`/`table` fields are additive and
`omitempty`; the inet.0 rows still lead in their original order, so a
legacy consumer reading the pre-#5439 inet.0 subset positionally is
unaffected. Existing `destination`/`next_hop`/`interface`/`preference`/
`next_table`/`disposition` fields are unchanged.

## Tests (RED-on-revert)
`routes_ipv6_vrf_5439_test.go` injects global v4/v6 (incl. reject +
discard) and per-VRF v4/v6 static routes into the live `ActiveConfig`,
drives `routesHandler`, and asserts each appears tagged with its
family/table and correct disposition; the IPv4 inet.0 route still renders
as before (no regression). **RED-on-revert proven:** stashing the
`routing.go` change (keeping the test) drops every v6 and per-VRF route
from the response and strips the family/table tags. The existing
`routes_disposition_5410_test.go` and the full `pkg/api` suite stay green.
`pkg/api/README.md` updated for the widened coverage.

Closes #5439

🤖 Generated with [Claude Code](https://claude.com/claude-code)