### PR TITLE
pkg/config: redact URL userinfo for schemeless URLs too (#5458)

### DIFF
--- a/pkg/config/ddns_provider_string_test.go
+++ b/pkg/config/ddns_provider_string_test.go
@@ -52,10 +52,16 @@ func TestDDNSProviderStringRedactsURLCredentials(t *testing.T) {
 	}
 }
 
-// TestRedactURL exercises RedactURL directly across the shapes #2781 cares
-// about: userinfo, query token, both, a plain hostname (rfc2136 update-server),
-// an inadyn template with %-specifiers (must not be mangled by url.Parse), and
-// empty input.
+// TestRedactURL exercises RedactURL directly across the shapes #2781 and #5458
+// care about: userinfo, query token, both, a plain hostname (rfc2136
+// update-server), an inadyn template with %-specifiers (must not be mangled by
+// url.Parse), empty input, and — the #5458 fix — SCHEMELESS URLs whose userinfo
+// must be redacted just like the scheme'd case while an '@' in the path/query
+// is left untouched.
+//
+// RED-on-revert: reverting secret.go's both-cases refactor makes the
+// "schemeless with creds" subtest observe the leaked "user:pass@" — the
+// mustNotContain assertions fail.
 func TestRedactURL(t *testing.T) {
 	cases := []struct {
 		name string
@@ -92,6 +98,39 @@ func TestRedactURL(t *testing.T) {
 			in:             "https://svc.example/nic/update?hostname=%h&myip=%i",
 			mustContain:    []string{"https://svc.example/nic/update?", "<redacted>"},
 			mustNotContain: []string{"hostname=", "%h", "%i"},
+		},
+		{
+			// #5458 core case: a SCHEMELESS credentialed URL (generic DDNS
+			// provider templates have no commit-time scheme validator) must have
+			// its userinfo AND query redacted. Pre-fix the userinfo leaked.
+			name:           "schemeless with creds",
+			in:             "user:pass@example.com/update?token=SECRET",
+			mustContain:    []string{"<redacted>@example.com/update?", "<redacted>"},
+			mustNotContain: []string{"user:", "pass", "SECRET", "token="},
+		},
+		{
+			// #5458: schemeless WITHOUT creds — host/path intact, query redacted,
+			// and NO spurious userinfo redaction (no "<redacted>@").
+			name:           "schemeless without creds",
+			in:             "example.com/x?t=S",
+			mustContain:    []string{"example.com/x?", "<redacted>"},
+			mustNotContain: []string{"<redacted>@", "t=S"},
+		},
+		{
+			// #5458 boundary: an '@' in the PATH is past the authority and must
+			// NOT trigger userinfo redaction. No query -> no redaction at all.
+			name:           "at-sign in path",
+			in:             "host/p@th",
+			mustContain:    []string{"host/p@th"},
+			mustNotContain: []string{"<redacted>"},
+		},
+		{
+			// #5458 boundary: an '@' in the QUERY is past the authority. The query
+			// is dropped wholesale; the host is untouched and not userinfo-redacted.
+			name:           "at-sign in query",
+			in:             "host?x=a@b",
+			mustContain:    []string{"host?", "<redacted>"},
+			mustNotContain: []string{"<redacted>@", "a@b"},
 		},
 		{
 			name: "empty",

--- a/pkg/config/secret.go
+++ b/pkg/config/secret.go
@@ -70,11 +70,21 @@ func (s Secret) String() string {
 // Two credential-carrying components are redacted while the scheme/host/path
 // prefix is preserved so the log line stays diagnostically useful:
 //
-//   - userinfo: a "user:pass@" (or "user@") segment between "scheme://" and the
-//     first '/', '?' or '#' becomes "<redacted>@" — operators embed creds there
-//     (e.g. https://user:token@api.example/update).
+//   - userinfo: a "user:pass@" (or "user@") segment inside the authority
+//     becomes "<redacted>@" — operators embed creds there (e.g.
+//     https://user:token@api.example/update). The authority is the network
+//     location up to the first '/', '?' or '#'; for a scheme'd URL it begins
+//     after "://", and for a SCHEMELESS URL (e.g. a generic DDNS provider
+//     template like "user:pass@host/upd?token=SECRET", which has NO commit-time
+//     scheme validator) it begins at index 0. Userinfo is redacted in BOTH
+//     cases (#5458) — before that fix a schemeless credentialed URL leaked its
+//     "user:pass@" into journald/exported logs.
 //   - query string: everything after the first '?' becomes "<redacted>" — the
 //     #2781 case is a token in the query (e.g. ...?token=SECRET&host=%h).
+//
+// The redaction is bounded to the authority: an '@' in the PATH ("host/p@th")
+// or QUERY ("host?x=a@b") is past the authority boundary and does NOT trigger
+// userinfo redaction (the query is dropped wholesale regardless).
 //
 // An empty input returns "" so absence stays distinguishable. A value with no
 // credential-bearing component is returned with the query (if any) still
@@ -86,23 +96,26 @@ func RedactURL(s string) string {
 	}
 	const redacted = "<redacted>"
 
-	// Redact userinfo: locate the authority (between "://" and the next
-	// delimiter) and replace any "...@" prefix within it.
+	// Redact userinfo: locate the authority and replace any "...@" prefix
+	// within it. The authority starts after "://" for a scheme'd URL, or at
+	// index 0 for a schemeless URL (#5458), and ends at the first '/', '?' or
+	// '#'. Bounding to the authority keeps an '@' in the path or query
+	// untouched.
+	authStart := 0
 	if i := strings.Index(s, "://"); i >= 0 {
-		authStart := i + len("://")
-		// The authority ends at the first '/', '?' or '#'.
-		authEnd := len(s)
-		for j := authStart; j < len(s); j++ {
-			if c := s[j]; c == '/' || c == '?' || c == '#' {
-				authEnd = j
-				break
-			}
+		authStart = i + len("://")
+	}
+	authEnd := len(s)
+	for j := authStart; j < len(s); j++ {
+		if c := s[j]; c == '/' || c == '?' || c == '#' {
+			authEnd = j
+			break
 		}
-		authority := s[authStart:authEnd]
-		if at := strings.LastIndex(authority, "@"); at >= 0 {
-			// Replace the whole userinfo (everything up to and including '@').
-			s = s[:authStart] + redacted + "@" + authority[at+1:] + s[authEnd:]
-		}
+	}
+	authority := s[authStart:authEnd]
+	if at := strings.LastIndex(authority, "@"); at >= 0 {
+		// Replace the whole userinfo (everything up to and including '@').
+		s = s[:authStart] + redacted + "@" + authority[at+1:] + s[authEnd:]
 	}
 
 	// Redact the query string: everything after the first '?' (preserve any


### PR DESCRIPTION
## Problem

`Secret.RedactURL` (`pkg/config/secret.go`) only redacted a `user:pass@`
userinfo segment inside the `strings.Index(s, "://") >= 0` (scheme'd)
branch. A **schemeless** credentialed URL had its userinfo left INTACT in
log output — the query string was redacted but the credentials before the
`@` leaked into journald / exported logs.

This is reachable in production: the generic DDNS backend provider URL
fields (`Server`, `URLTemplate`, `CheckIPURL`) are plain, untyped strings
with **no commit-time scheme validator**, so an operator can configure a
schemeless credentialed value such as
`user:pass@example.com/update?token=SECRET`, which is then logged via
`RedactURL` (`DDNSProvider.String`, the compiler warn validators, and the
generic-backend construction error).

## Invariant

`RedactURL` must redact `user:pass@` userinfo whether or not the URL
carries a `scheme://` prefix.

## Fix

Compute the authority-start index once — after `://` when a scheme is
present, else index 0 — then apply the userinfo redaction for **both**
cases. Redaction stays bounded to the authority (the network location up
to the first `/`, `?` or `#`):

- `@` in the **authority** → userinfo, replaced with `<redacted>@host…`.
- `@` in the **path** (`host/p@th`) or **query** (`host?x=a@b`) is past
  the authority boundary → NOT touched.

Existing scheme'd behavior and the wholesale query redaction are preserved
(same `<redacted>` sentinel, query redaction still runs).

## Tests (RED-on-revert)

Extended `TestRedactURL` (`pkg/config/ddns_provider_string_test.go`):

- **schemeless with creds** `user:pass@example.com/update?token=SECRET`
  → userinfo `<redacted>@` AND query `<redacted>` (was: userinfo leaked).
- **schemeless without creds** `example.com/x?t=S` → host intact, query
  redacted, no spurious `<redacted>@`.
- **`@` in path** `host/p@th` → untouched (no userinfo redaction).
- **`@` in query** `host?x=a@b` → query redacted, host intact, no
  userinfo redaction.
- Scheme'd-with-creds + query-token cases already present — preserved.

RED-on-revert proven: stashing the `secret.go` change (keeping tests)
makes the schemeless-with-creds subtest fail —
`RedactURL("user:pass@example.com/update?token=SECRET")` returns
`user:pass@example.com/update?<redacted>` (userinfo leaked; query still
redacted). Restored → green.

`go build ./...`, `go vet ./pkg/config/`, and `go test ./pkg/config/...`
all green. Based on current `origin/master` (rebased onto the #4845
compiler-validate-warn split).

Docs: `RedactURL`'s godoc (the module doc for this helper) is updated to
document the both-cases + authority-boundary behavior; the
`types_system.go` "strips userinfo and the query string" comment is now
strictly accurate. No other doc change needed.

Closes #5458