### PR TITLE
pkg/snmp: fail closed on RNG error in the SNMPv3 privacy salt (#5453)

### DIFF
--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -179,6 +179,19 @@ sender learned about us via discovery, not our local clock at receive time.
 - DES (`decryptDES`/`encryptDES`, RFC 3414 §8) derives its IV from `privParams`
   XOR the pre-IV salt alone, so boots/time do not enter the DES IV.
 
+**Privacy salt fails closed on RNG error (RFC 3414 §8.2.1, #5453).** The
+per-message privacy salt (`msgPrivacyParameters`) MUST be unpredictable: an
+all-zero salt makes the DES IV a deterministic function of the long-term
+`privKey` (repeated-plaintext-prefix leakage) and makes the AES-128-CFB IV
+constant within a `(boots,time)` second (CFB IV reuse). The salt is generated
+through the injectable `randRead` seam (defaults to `crypto/rand.Read`).
+`encryptDES`/`encryptAES128` **check the `randRead` error** and return it rather
+than proceeding with a zero salt; `encryptPDU` propagates it, and
+`buildV3Response` **fails closed** — it drops the response (returns `nil`, so no
+datagram is written) instead of downgrading to a plaintext or zero-salt PDU.
+An RNG failure (getrandom `EAGAIN` at early boot, a FIPS module error) therefore
+yields *no reply* to an `authPriv` request, never an insecurely encrypted one.
+
 ### engineBoots persistence
 
 `engineBoots` is loaded, incremented, and persisted once at agent construction

--- a/pkg/snmp/agent_test.go
+++ b/pkg/snmp/agent_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 var (
-	md5New  = md5.New
-	md5Size = md5.Size
-	sha1New = sha1.New
+	md5New   = md5.New
+	md5Size  = md5.Size
+	sha1New  = sha1.New
 	sha1Size = sha1.Size
 )
 
@@ -659,9 +659,9 @@ func TestDESEncryptDecrypt(t *testing.T) {
 	// Need a 16-byte key (8 for DES + 8 for preIV).
 	key := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 	plaintext := []byte("hello world test") // 16 bytes (multiple of 8)
-	enc, pp := encryptDES(key, plaintext)
-	if enc == nil {
-		t.Fatal("encryptDES returned nil")
+	enc, pp, err := encryptDES(key, plaintext)
+	if err != nil || enc == nil {
+		t.Fatalf("encryptDES failed: %v", err)
 	}
 	dec := decryptDES(key, pp, enc)
 	if dec == nil {
@@ -678,9 +678,9 @@ func TestAES128EncryptDecrypt(t *testing.T) {
 		key[i] = byte(i + 1)
 	}
 	plaintext := []byte("test data for aes encryption roundtrip")
-	enc, pp := encryptAES128(key, plaintext, 1, 100)
-	if enc == nil {
-		t.Fatal("encryptAES128 returned nil")
+	enc, pp, err := encryptAES128(key, plaintext, 1, 100)
+	if err != nil || enc == nil {
+		t.Fatalf("encryptAES128 failed: %v", err)
 	}
 	dec := decryptAES128(key, pp, enc, 1, 100)
 	if dec == nil {
@@ -703,7 +703,7 @@ func testIfXData() []IfData {
 			IfName: "trust0", IfAlias: "Trust LAN",
 			HCInOctets: 5000000000, HCOutOctets: 3000000000,
 			HCInUcastPkts: 1000000, HCOutUcastPkts: 800000,
-			IfHighSpeed: 1000,
+			IfHighSpeed:     1000,
 			InMulticastPkts: 500, InBroadcastPkts: 100,
 			OutMulticastPkts: 200, OutBroadcastPkts: 50,
 		},

--- a/pkg/snmp/v3.go
+++ b/pkg/snmp/v3.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/binary"
+	"fmt"
 	"hash"
 	"log/slog"
 
@@ -771,10 +772,22 @@ func decryptAES128(privKey, privParams, data []byte, boots, time int) []byte {
 	return plaintext
 }
 
-// encryptPDU encrypts a scopedPDU using the user's privacy key.
-func (a *Agent) encryptPDU(user *usmUser, scopedPDU []byte) (encrypted, privParams []byte) {
+// randRead is the entropy source for the SNMPv3 per-message privacy salt. It is
+// a package variable so tests can inject an RNG failure and assert the encrypt
+// path fails closed. It defaults to crypto/rand.Read. RFC 3414 §8.2.1 requires
+// the privacy salt (msgPrivacyParameters) to be unpredictable: an all-zero or
+// otherwise deterministic salt makes the CBC/CFB IV predictable or reused, which
+// breaks the semantic security of the encrypted scopedPDU. Every salt path MUST
+// check this error and fail closed rather than proceed with a zero salt.
+var randRead = rand.Read
+
+// encryptPDU encrypts a scopedPDU using the user's privacy key. It returns an
+// error (rather than silently downgrading) when a securely-encrypted PDU cannot
+// be produced — most importantly when the RNG fails to generate the per-message
+// privacy salt — so the caller can fail closed.
+func (a *Agent) encryptPDU(user *usmUser, scopedPDU []byte) ([]byte, []byte, error) {
 	if user.privKey == nil {
-		return nil, nil
+		return nil, nil, fmt.Errorf("snmpv3: user %q has no privacy key", user.name)
 	}
 	switch user.privProto {
 	case "des":
@@ -782,19 +795,27 @@ func (a *Agent) encryptPDU(user *usmUser, scopedPDU []byte) (encrypted, privPara
 	case "aes128":
 		return encryptAES128(user.privKey, scopedPDU, a.engineBoots, a.engineTime())
 	default:
-		return nil, nil
+		return nil, nil, fmt.Errorf("snmpv3: unsupported privacy protocol %q", user.privProto)
 	}
 }
 
-// encryptDES encrypts data using DES-CBC per RFC 3414 section 8.
-func encryptDES(privKey, data []byte) ([]byte, []byte) {
+// encryptDES encrypts data using DES-CBC per RFC 3414 section 8. It fails closed
+// on an RNG error: the DES IV is the pre-IV salt XOR the per-message
+// privParams, so an all-zero privParams (the silent result of an unchecked
+// rand.Read failure) collapses the IV to a deterministic function of the
+// long-term privKey, leaking repeated-plaintext-prefix structure across
+// messages (RFC 3414 §8.2.1). On an RNG failure return the error so no PDU is
+// sent with a predictable IV.
+func encryptDES(privKey, data []byte) ([]byte, []byte, error) {
 	if len(privKey) < 16 {
-		return nil, nil
+		return nil, nil, fmt.Errorf("snmpv3: DES privacy key too short: %d bytes", len(privKey))
 	}
 	desKey := privKey[:8]
 	preIV := privKey[8:16]
 	privParams := make([]byte, 8)
-	rand.Read(privParams)
+	if _, err := randRead(privParams); err != nil {
+		return nil, nil, fmt.Errorf("snmpv3: DES privacy salt: %w", err)
+	}
 	iv := make([]byte, 8)
 	for i := range iv {
 		iv[i] = preIV[i] ^ privParams[i]
@@ -805,31 +826,38 @@ func encryptDES(privKey, data []byte) ([]byte, []byte) {
 	}
 	block, err := des.NewCipher(desKey)
 	if err != nil {
-		return nil, nil
+		return nil, nil, fmt.Errorf("snmpv3: DES cipher init: %w", err)
 	}
 	encrypted := make([]byte, len(data))
 	cipher.NewCBCEncrypter(block, iv).CryptBlocks(encrypted, data)
-	return encrypted, privParams
+	return encrypted, privParams, nil
 }
 
-// encryptAES128 encrypts data using AES-128-CFB per RFC 3826.
-func encryptAES128(privKey, data []byte, boots, time int) ([]byte, []byte) {
+// encryptAES128 encrypts data using AES-128-CFB per RFC 3826. It fails closed on
+// an RNG error: the last 8 IV bytes are the per-message privParams salt, so an
+// all-zero privParams (the silent result of an unchecked rand.Read failure)
+// makes the full IV constant for every message in the same (boots,time) second,
+// which is CFB IV reuse under a fixed key (RFC 3414 §8.2.1). On an RNG failure
+// return the error so no PDU is sent with a reused IV.
+func encryptAES128(privKey, data []byte, boots, time int) ([]byte, []byte, error) {
 	if len(privKey) < 16 {
-		return nil, nil
+		return nil, nil, fmt.Errorf("snmpv3: AES128 privacy key too short: %d bytes", len(privKey))
 	}
 	privParams := make([]byte, 8)
-	rand.Read(privParams)
+	if _, err := randRead(privParams); err != nil {
+		return nil, nil, fmt.Errorf("snmpv3: AES128 privacy salt: %w", err)
+	}
 	iv := make([]byte, 16)
 	binary.BigEndian.PutUint32(iv[0:4], uint32(boots))
 	binary.BigEndian.PutUint32(iv[4:8], uint32(time))
 	copy(iv[8:16], privParams)
 	block, err := aes.NewCipher(privKey[:16])
 	if err != nil {
-		return nil, nil
+		return nil, nil, fmt.Errorf("snmpv3: AES128 cipher init: %w", err)
 	}
 	encrypted := make([]byte, len(data))
 	cipher.NewCFBEncrypter(block, iv).XORKeyStream(encrypted, data)
-	return encrypted, privParams
+	return encrypted, privParams, nil
 }
 
 // computeAuth computes the HMAC for a v3 message (with auth params zeroed in the message).
@@ -1008,14 +1036,21 @@ func (a *Agent) buildV3Response(msgID int, reqFlags byte, user *usmUser,
 	var scopedPDUEncoded []byte
 	var privParamsVal []byte
 	if respFlags&msgFlagPriv != 0 && user.privKey != nil {
-		enc, pp := a.encryptPDU(user, scopedPDU)
-		if enc != nil {
-			scopedPDUEncoded = berEncodeTLV(tagOctetString, enc)
-			privParamsVal = pp
-		} else {
-			respFlags &^= msgFlagPriv
-			scopedPDUEncoded = scopedPDU
+		enc, pp, err := a.encryptPDU(user, scopedPDU)
+		if err != nil {
+			// Fail closed (RFC 3414 §8.2.1): the manager requested privacy but
+			// we could not produce a securely-encrypted PDU — most importantly
+			// when the RNG failed to generate the unpredictable per-message
+			// privacy salt. Never downgrade to a plaintext response and never
+			// send a PDU built from a zero/predictable salt. Returning nil here
+			// drops the response (handleV3Packet nil == no datagram), so no
+			// scopedPDU ever leaves the agent in the clear or with a weak IV.
+			slog.Warn("SNMPv3: privacy encryption failed, dropping response",
+				"user", user.name, "err", err)
+			return nil
 		}
+		scopedPDUEncoded = berEncodeTLV(tagOctetString, enc)
+		privParamsVal = pp
 	} else {
 		respFlags &^= msgFlagPriv
 		scopedPDUEncoded = scopedPDU

--- a/pkg/snmp/v3_priv_iv_test.go
+++ b/pkg/snmp/v3_priv_iv_test.go
@@ -109,9 +109,9 @@ func buildV3AuthPrivAESRequest(t *testing.T, userName string, engineID, authKey,
 	scopedPDU := berEncodeTLV(tagSequence, scopedBody)
 
 	// Encrypt as a manager would: IV from ivBoots/ivTime.
-	enc, privParams := encryptAES128(privKey, scopedPDU, ivBoots, ivTime)
-	if enc == nil {
-		t.Fatal("encryptAES128 returned nil building request")
+	enc, privParams, err := encryptAES128(privKey, scopedPDU, ivBoots, ivTime)
+	if err != nil || enc == nil {
+		t.Fatalf("encryptAES128 failed building request: %v", err)
 	}
 	encOctet := berEncodeTLV(tagOctetString, enc)
 
@@ -230,9 +230,9 @@ func TestAESDecryptIV_WrongIVFailsDecrypt(t *testing.T) {
 	}
 	plaintext := []byte("scopedPDU bytes that must survive a correct IV only")
 
-	enc, pp := encryptAES128(key, plaintext, 5, 1000)
-	if enc == nil {
-		t.Fatal("encryptAES128 returned nil")
+	enc, pp, err := encryptAES128(key, plaintext, 5, 1000)
+	if err != nil || enc == nil {
+		t.Fatalf("encryptAES128 failed: %v", err)
 	}
 	// Correct IV (matching time) recovers the plaintext.
 	if dec := decryptAES128(key, pp, enc, 5, 1000); !bytesEqual(dec, plaintext) {

--- a/pkg/snmp/v3_rand_failclosed_test.go
+++ b/pkg/snmp/v3_rand_failclosed_test.go
@@ -1,0 +1,140 @@
+package snmp
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+// #5453 — the SNMPv3 privacy encrypt paths must FAIL CLOSED on an RNG error.
+//
+// RFC 3414 §8.2.1 requires the per-message privacy salt (msgPrivacyParameters)
+// to be unpredictable. Before the fix, encryptDES/encryptAES128 ignored the
+// error from crypto/rand.Read, so an RNG failure (getrandom EAGAIN at early
+// boot, a FIPS module error) left the salt all-zero:
+//   - DES:    zero salt -> CBC IV == a deterministic function of the long-term
+//             privKey -> repeated-plaintext-prefix leakage across messages.
+//   - AES128: zero salt -> the last 8 IV bytes are constant -> CFB IV REUSE for
+//             every message in the same (boots,time) second.
+// Either way the encrypted scopedPDU loses semantic security. These tests
+// inject an RNG failure through the randRead seam and assert the encrypt path
+// returns an error with NO ciphertext, and that the response builder drops the
+// datagram (fail closed) rather than emitting a zero-salt or plaintext PDU.
+
+// failRandRead is an entropy source that always fails, simulating getrandom
+// EAGAIN / a FIPS RNG error. It writes nothing, so the caller's salt buffer
+// stays all-zero — exactly the dangerous state the fix must refuse to use.
+func failRandRead(b []byte) (int, error) {
+	return 0, errors.New("simulated RNG failure")
+}
+
+// withFailingRand swaps randRead for the duration of fn and restores it after.
+// The snmp package serves requests on a single serial goroutine and the tests
+// do not run in parallel, so swapping the package var is safe.
+func withFailingRand(t *testing.T, fn func()) {
+	t.Helper()
+	saved := randRead
+	randRead = failRandRead
+	defer func() { randRead = saved }()
+	fn()
+}
+
+func TestEncryptDES_RNGFailClosed(t *testing.T) {
+	key := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	plaintext := []byte("hello world test") // 16 bytes (multiple of 8)
+	withFailingRand(t, func() {
+		enc, pp, err := encryptDES(key, plaintext)
+		if err == nil {
+			t.Fatal("encryptDES must return an error on RNG failure (fail closed)")
+		}
+		if enc != nil {
+			t.Fatalf("encryptDES must NOT produce ciphertext on RNG failure; got %d bytes", len(enc))
+		}
+		if pp != nil {
+			t.Fatalf("encryptDES must NOT return a (zero) salt on RNG failure; got %v", pp)
+		}
+	})
+}
+
+func TestEncryptAES128_RNGFailClosed(t *testing.T) {
+	key := make([]byte, 16)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	plaintext := []byte("test data for aes encryption roundtrip")
+	withFailingRand(t, func() {
+		enc, pp, err := encryptAES128(key, plaintext, 1, 100)
+		if err == nil {
+			t.Fatal("encryptAES128 must return an error on RNG failure (fail closed)")
+		}
+		if enc != nil {
+			t.Fatalf("encryptAES128 must NOT produce ciphertext on RNG failure; got %d bytes", len(enc))
+		}
+		if pp != nil {
+			t.Fatalf("encryptAES128 must NOT return a (zero) salt on RNG failure; got %v", pp)
+		}
+	})
+}
+
+// TestEncrypt_NormalUsesNonZeroSalt is the non-regression guard: with the real
+// RNG the encrypt paths still succeed AND use a non-zero (unpredictable) salt.
+func TestEncrypt_NormalUsesNonZeroSalt(t *testing.T) {
+	key := make([]byte, 16)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	// 32 bytes (multiple of 8) so DES-CBC needs no padding and the roundtrip
+	// compares byte-for-byte; AES-128-CFB is a stream cipher and length-agnostic.
+	plaintext := []byte("aes-and-des-roundtrip-plaintext!")
+
+	encD, ppD, err := encryptDES(key, plaintext)
+	if err != nil || encD == nil {
+		t.Fatalf("encryptDES with real RNG failed: %v", err)
+	}
+	if len(ppD) != 8 || bytes.Equal(ppD, make([]byte, 8)) {
+		t.Fatalf("encryptDES produced a zero/short salt with real RNG: %v", ppD)
+	}
+	if dec := decryptDES(key, ppD, encD); !bytes.Equal(dec, plaintext) {
+		t.Fatalf("DES roundtrip failed: got %q", dec)
+	}
+
+	encA, ppA, err := encryptAES128(key, plaintext, 1, 100)
+	if err != nil || encA == nil {
+		t.Fatalf("encryptAES128 with real RNG failed: %v", err)
+	}
+	if len(ppA) != 8 || bytes.Equal(ppA, make([]byte, 8)) {
+		t.Fatalf("encryptAES128 produced a zero/short salt with real RNG: %v", ppA)
+	}
+	if dec := decryptAES128(key, ppA, encA, 1, 100); !bytes.Equal(dec, plaintext) {
+		t.Fatalf("AES128 roundtrip failed: got %q", dec)
+	}
+}
+
+// TestBuildV3Response_RNGFailClosed drives the response/send path: a manager's
+// authPriv request must NOT be answered with a plaintext or zero-salt PDU when
+// the RNG fails. buildV3Response must return nil (handleV3Packet nil == no
+// datagram written, agent.go Start's `if resp != nil` gate), so nothing leaves
+// the agent in the clear.
+func TestBuildV3Response_RNGFailClosed(t *testing.T) {
+	a, _, _, privKey := newAuthPrivAgent(t, 5, 1000)
+	user := a.v3Users["puser"]
+	reqFlags := byte(msgFlagAuth | msgFlagPriv)
+
+	// Control: with the real RNG the authPriv response is built and encrypts.
+	ctrl := a.buildV3Response(1, reqFlags, user, nil, 1, errNoError, 0, nil)
+	if ctrl == nil {
+		t.Fatal("control: authPriv response must be built with a working RNG")
+	}
+	if !decodeV3AuthPrivResponse(t, ctrl, privKey) {
+		t.Fatal("control: authPriv response must decrypt to a GetResponse")
+	}
+
+	// Fail closed: an RNG failure must drop the response entirely.
+	withFailingRand(t, func() {
+		resp := a.buildV3Response(1, reqFlags, user, nil, 1, errNoError, 0, nil)
+		if resp != nil {
+			t.Fatalf("authPriv response MUST be dropped on RNG failure (fail closed); "+
+				"got %d bytes (plaintext/zero-salt leak)", len(resp))
+		}
+	})
+}

--- a/pkg/snmp/v3_seclevel_test.go
+++ b/pkg/snmp/v3_seclevel_test.go
@@ -23,9 +23,9 @@ func buildV3PrivOnlyRequest(t *testing.T, userName string, engineID, privKey []b
 	scopedBody = append(scopedBody, berEncodeTLV(pduGetRequest, pduBody)...)
 	scopedPDU := berEncodeTLV(tagSequence, scopedBody)
 
-	enc, privParams := encryptAES128(privKey, scopedPDU, boots, reqTime)
-	if enc == nil {
-		t.Fatal("encryptAES128 returned nil building noAuthPriv request")
+	enc, privParams, err := encryptAES128(privKey, scopedPDU, boots, reqTime)
+	if err != nil || enc == nil {
+		t.Fatalf("encryptAES128 failed building noAuthPriv request: %v", err)
 	}
 	encOctet := berEncodeTLV(tagOctetString, enc)
 


### PR DESCRIPTION
## Problem (RFC 3414 §8.2.1)

`encryptDES` (~pkg/snmp/v3.go:790) and `encryptAES128` (~:816) ignored the
error return from `crypto/rand.Read` when generating the per-message
privacy salt (`msgPrivacyParameters`). If the RNG fails — `getrandom`
`EAGAIN` at early boot, a FIPS module error — `privParams` stays
**all-zero** and the encrypt path proceeded anyway, producing a
predictable/reused IV:

- **DES:** the CBC IV is `preIV XOR privParams`, so a zero salt collapses
  the IV to a deterministic function of the long-term `privKey` →
  repeated-plaintext-prefix leakage across messages.
- **AES-128-CFB:** the last 8 IV bytes are `privParams`, so a zero salt
  makes the full IV constant for every message in the same `(boots,time)`
  second → CFB IV reuse under a fixed key.

Either way the encrypted scopedPDU loses semantic security. RFC 3414
§8.2.1 requires the privacy salt to be **unpredictable**.

Worse, the caller `buildV3Response` previously *downgraded to plaintext*
when `encryptPDU` returned nil — so any encrypt failure risked emitting a
plaintext-equivalent PDU.

## Invariant

An encrypt path must **never** proceed with a zero/predictable salt. On an
RNG failure it must **fail closed** — return an error and send no PDU,
never an insecurely-encrypted (or plaintext) one.

## Fix (fail closed)

- Draw the salt through an injectable `randRead` package seam (defaults to
  `crypto/rand.Read`).
- `encryptDES` / `encryptAES128` now **check the `randRead` error** and
  return it instead of proceeding with a zero salt. Their signatures gain
  an `error` return; `encryptPDU` propagates it.
- `buildV3Response` **fails closed** on that error: it drops the response
  (returns `nil`; `handleV3Packet` nil ⇒ no datagram written — the
  `if resp != nil` gate in `agent.go`), never downgrading to a plaintext
  or zero-salt PDU. An `authPriv` request that cannot get entropy gets
  **no reply**.
- Decrypt paths derive the IV from the received `privParams` and never
  call `rand.Read` — unaffected.

## Tests (RED-on-revert)

New `pkg/snmp/v3_rand_failclosed_test.go`, driving the injected RNG seam:

- Injected RNG failure → `encryptDES` / `encryptAES128` return an error
  with **no** ciphertext and **no** (zero) salt.
- `buildV3Response` for an `authPriv` user **drops** the response on RNG
  failure (fail closed); control with a working RNG encrypts and
  round-trips to a GetResponse.
- Non-regression: the normal path encrypts with a **non-zero** salt and
  round-trips (DES + AES).

**RED-on-revert proven:** restoring the unchecked `rand.Read` +
plaintext-downgrade makes all three fail-closed tests fail — the caller
test catches a 103-byte zero-salt/plaintext leak.

`go build ./...` and `go test ./pkg/snmp/... -count=1` green; touched
files `gofmt`-clean. Updated `pkg/snmp/README.md` privacy section.

Closes #5453