### PR TITLE
pkg/upgrade: validate the kernel candidate version and uname segment (#5452)

### DIFF
--- a/docs/pr/1930-inc1-kernel-channel/codex-kernel-linux-impl.md
+++ b/docs/pr/1930-inc1-kernel-channel/codex-kernel-linux-impl.md
@@ -49,6 +49,26 @@ Codex implemented pkg/upgrade/kernel_linux.go against the KernelSystem interface
   seam signature `pkgInstalledFn func(pkg string) (bool, error)` lets a test
   inject a query error; the #5428 tests prove RED-on-revert (files swept
   without the fix).
+- Kernel version / uname safe-segment validation (#5452, HIGH security). The
+  candidate version and the running `uname -r` string were used RAW in
+  `filepath.Glob("/boot/*-"+ver)` -> `os.RemoveAll`, in
+  `os.RemoveAll("/lib/modules/"+ver)`, in `apt-get purge linux-image-<ver>`,
+  and in the GRUB slot-selector Sprintf — with no charset check. A
+  `candidateVersion="*"` globbed `/boot/*-*` (every dashed /boot file) into
+  RemoveAll (arbitrary /boot deletion -> unbootable) and purged
+  `linux-image-*` (every kernel package); a `".."` traversed the modules
+  RemoveAll (`/lib/modules/..` == `/lib`); a `"`/newline in the uname string
+  injected GRUB directives. `ValidateKernelSegment` (pkg/upgrade/version.go)
+  now allows ONLY the kernel-version charset `[A-Za-z0-9._+~-]`, non-empty, no
+  leading `-`, no `..` — STRICTER than `ValidateVersionSegment` (which permits
+  glob metachars, quotes, and `:`, all safe as a plain path segment but not in
+  a glob/GRUB context). It is enforced fail-CLOSED at three sites:
+  `KernelRunner.Arm` (rejects a bad candidate up front, before any mutation),
+  `WriteSlotSelector` (validates the uname before the GRUB Sprintf — covers
+  both the candidate and the known-good restore path), and `PruneInactiveSlot`
+  (validates the candidate before the purge/glob/delete). Tests prove
+  RED-on-revert (`*`/`..`/quote delete or inject without the call-site
+  validation).
 
 Build/test: go build ./... OK; go vet ./pkg/upgrade OK; 17 kernel tests + the
 existing #1917 tests green.

--- a/pkg/upgrade/kernel_linux.go
+++ b/pkg/upgrade/kernel_linux.go
@@ -332,6 +332,14 @@ func buildInstallArgs(pkgs []string, anyInstalled bool) []string {
 }
 
 func (s *realKernelSystem) WriteSlotSelector(slot, unameR string) error {
+	// The uname string is embedded verbatim in a double-quoted GRUB directive
+	// below (`set xpf_slot_kernel="vmlinuz-<unameR>"`). A `"`, backslash, or
+	// newline in it would inject arbitrary GRUB commands and corrupt the boot
+	// selector. Validate to the kernel-version charset and fail CLOSED — never
+	// write a selector built from an unvalidated segment (#5452).
+	if err := ValidateKernelSegment("kernel uname", unameR); err != nil {
+		return fmt.Errorf("write slot selector: %w", err)
+	}
 	dir := s.rooted(filepath.Join("/boot/efi/EFI", slot))
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create slot selector dir %s: %w", dir, err)
@@ -603,6 +611,17 @@ func (s *realKernelSystem) DisarmWatchdog() error {
 }
 
 func (s *realKernelSystem) PruneInactiveSlot(slot, knownGoodUnameR, candidateVersion string) error {
+	// Fail CLOSED on an unsafe candidate segment BEFORE any purge, glob, or
+	// delete (#5452). candidateVersion feeds `apt-get purge linux-image-<ver>`
+	// (a "*" would purge EVERY kernel package), filepath.Glob("/boot/*-"+ver)
+	// whose matches are handed to os.RemoveAll (a "*" globs "/boot/*-*",
+	// matching every dashed /boot file -> wipes all kernels/initrds/config),
+	// and os.RemoveAll("/lib/modules/"+ver) (a ".." traverses to "/lib"). Never
+	// run a filesystem delete keyed by an unvalidated version. knownGoodUnameR
+	// is validated by WriteSlotSelector before it reaches the GRUB script.
+	if err := ValidateKernelSegment("kernel candidate version", candidateVersion); err != nil {
+		return fmt.Errorf("kernel-upgrade prune: %w", err)
+	}
 	// Restore the inactive slot's boot selector to the KNOWN-GOOD kernel FIRST.
 	// This is the load-bearing safety step and it is independent of the package
 	// cleanup below: whatever happens to the candidate's packages, the slot

--- a/pkg/upgrade/kernel_run.go
+++ b/pkg/upgrade/kernel_run.go
@@ -78,6 +78,17 @@ func (r *KernelRunner) Arm(candidateVersion string) error {
 	if candidateVersion == "" {
 		return fmt.Errorf("kernel-upgrade: candidate version is required")
 	}
+	// Fail CLOSED on an unsafe candidate segment before ANY mutation (#5452).
+	// The version flows raw into a /boot glob + os.RemoveAll, a /lib/modules
+	// os.RemoveAll, `apt-get purge linux-image-<ver>`, and the GRUB
+	// slot-selector script — so a "*" would glob every dashed /boot file into
+	// RemoveAll (arbitrary /boot deletion -> unbootable host), a ".." would
+	// traverse the modules delete, and a quote/newline would inject GRUB
+	// directives. Reject anything outside the kernel-version charset here so an
+	// invalid segment never reaches those sites.
+	if err := ValidateKernelSegment("kernel candidate version", candidateVersion); err != nil {
+		return fmt.Errorf("kernel-upgrade: %w", err)
+	}
 	j, err := r.loadKernelJournal()
 	if err != nil {
 		return err

--- a/pkg/upgrade/kernel_version_validate_5452_test.go
+++ b/pkg/upgrade/kernel_version_validate_5452_test.go
@@ -37,6 +37,7 @@ func TestValidateKernelSegment(t *testing.T) {
 		"*",           // glob star -> /boot/*-* wildcard
 		"?",           // glob single
 		"6.18.0-[ab]", // glob class
+		".",           // lone "." -> /lib/modules/. == /lib/modules (whole-tree delete)
 		"..",          // traversal (/lib/modules/.. == /lib)
 		"../etc",      // traversal
 		"6.18/0",      // path separator
@@ -161,6 +162,34 @@ func TestPruneInactiveSlot_RejectsTraversalCandidate(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(root, "lib", "modules")); statErr != nil {
 		t.Errorf("/lib/modules removed by a \"..\" traversal prune (%v)", statErr)
+	}
+}
+
+// A lone "." candidate must be rejected before os.RemoveAll("/lib/modules/.")
+// (which resolves to "/lib/modules" itself -> deletes the WHOLE modules tree).
+// A "." is in the charset and is neither empty nor "..", so the charset scan
+// alone would let it through — hence the explicit "." guard. RED-on-revert:
+// without the guard the prune deletes every installed kernel's modules.
+func TestPruneInactiveSlot_RejectsLoneDotCandidate(t *testing.T) {
+	root := t.TempDir()
+	otherKernel := filepath.Join(root, "lib", "modules", "6.18.5-10-generic")
+	if err := os.MkdirAll(otherKernel, 0755); err != nil {
+		t.Fatalf("seed lib/modules: %v", err)
+	}
+	sys := &realKernelSystem{
+		fsRoot:         root,
+		pkgInstalledFn: func(string) (bool, error) { return false, nil },
+		aptGetFn:       func(...string) error { return nil },
+	}
+	err := sys.PruneInactiveSlot("xpf-B", "6.18.5-10-generic", ".")
+	if err == nil {
+		t.Fatal("PruneInactiveSlot(candidate=\".\") = nil, want a rejection")
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "lib", "modules")); statErr != nil {
+		t.Errorf("/lib/modules removed by a \".\" prune (%v) — whole modules tree wiped", statErr)
+	}
+	if _, statErr := os.Stat(otherKernel); statErr != nil {
+		t.Errorf("/lib/modules/6.18.5-10-generic removed by a \".\" prune (%v)", statErr)
 	}
 }
 

--- a/pkg/upgrade/kernel_version_validate_5452_test.go
+++ b/pkg/upgrade/kernel_version_validate_5452_test.go
@@ -1,0 +1,203 @@
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #5452 (HIGH security): the kernel A/B arm path used the candidate version and
+// the running kernel's `uname -r` string RAW in a /boot glob + os.RemoveAll, a
+// /lib/modules os.RemoveAll, an `apt-get purge linux-image-<ver>`, and the GRUB
+// slot-selector script — with no safe-segment validation. candidateVersion="*"
+// globbed "/boot/*-*" into RemoveAll (arbitrary /boot deletion -> unbootable),
+// a ".." traversed the modules delete, and a quote/newline in the uname string
+// injected GRUB directives. ValidateKernelSegment now fails CLOSED at Arm and
+// defensively before the delete/GRUB sites. These tests are RED-on-revert: with
+// the production validation removed, the "*"/".."/quote cases delete or inject.
+
+func TestValidateKernelSegment(t *testing.T) {
+	valid := []string{
+		"6.18.0-xpf1-amd64",
+		"6.18.5-12-generic",
+		"6.8.0-rc2-amd64",
+		"5.10.0+deb11u1-amd64",
+		"6.1.0~bpo-amd64",
+		"6.18.0_variant",
+	}
+	for _, v := range valid {
+		if err := ValidateKernelSegment("kernel version", v); err != nil {
+			t.Errorf("ValidateKernelSegment(%q) = %v, want nil (a real uname -r must pass)", v, err)
+		}
+	}
+
+	invalid := []string{
+		"",            // empty
+		"*",           // glob star -> /boot/*-* wildcard
+		"?",           // glob single
+		"6.18.0-[ab]", // glob class
+		"..",          // traversal (/lib/modules/.. == /lib)
+		"../etc",      // traversal
+		"6.18/0",      // path separator
+		"a..b",        // embedded ".."
+		"-amd64",      // leading '-' parses as an option
+		"6.18\"x",     // double quote -> GRUB injection
+		"6.18\nset x", // newline -> GRUB directive injection
+		"6.18\\x",     // backslash
+		"6.18 0",      // space
+		"6.18\t0",     // tab
+		"6.18\x00",    // NUL / control char
+	}
+	for _, v := range invalid {
+		if err := ValidateKernelSegment("kernel version", v); err == nil {
+			t.Errorf("ValidateKernelSegment(%q) = nil, want an error (unsafe segment must fail closed)", v)
+		}
+	}
+}
+
+// Arm must reject an unsafe candidate version up front — no preflight, no
+// install, no reboot. RED-on-revert: without the Arm-path validation, a "*"
+// candidate walks preflight/install/arm and reboots.
+func TestArm_RejectsUnsafeCandidateVersion(t *testing.T) {
+	for _, bad := range []string{"*", "../etc", "6.18\"x", "-amd64"} {
+		f := newFakeKernelSystem()
+		r := newKernelRunner(t, f)
+		err := r.Arm(bad)
+		if err == nil {
+			t.Fatalf("Arm(%q) = nil, want a rejection", bad)
+		}
+		if f.rebooted {
+			t.Errorf("Arm(%q) rebooted despite an unsafe candidate", bad)
+		}
+		for _, c := range f.calls {
+			if strings.HasPrefix(c, "install:") {
+				t.Errorf("Arm(%q) installed the candidate despite an unsafe segment (%q)", bad, c)
+			}
+		}
+		j, _ := r.loadKernelJournal()
+		if j.State != KernelStateInit {
+			t.Errorf("Arm(%q) advanced journal to %s, want it untouched (INIT)", bad, j.State)
+		}
+	}
+}
+
+// seedForeignBootKernels lays down /boot files for OTHER (known-good) kernels
+// under a temp fsRoot. A candidateVersion="*" glob ("/boot/*-*") would match
+// all of them; the prune must never delete them.
+func seedForeignBootKernels(t *testing.T, root string) []string {
+	t.Helper()
+	bootDir := filepath.Join(root, "boot")
+	if err := os.MkdirAll(bootDir, 0755); err != nil {
+		t.Fatalf("seed boot dir: %v", err)
+	}
+	var paths []string
+	for _, name := range []string{
+		"vmlinuz-6.18.5-10-generic",
+		"initrd.img-6.18.5-10-generic",
+		"config-6.18.5-10-generic",
+		"vmlinuz-6.18.5-9-generic",
+	} {
+		p := filepath.Join(bootDir, name)
+		if err := os.WriteFile(p, []byte("x"), 0644); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+		paths = append(paths, p)
+	}
+	return paths
+}
+
+// PruneInactiveSlot must reject a glob-metacharacter candidate before touching
+// apt or the filesystem. RED-on-revert: without the validation the "*" candidate
+// globs "/boot/*-*" and os.RemoveAll deletes every seeded kernel file.
+func TestPruneInactiveSlot_RejectsGlobCandidate(t *testing.T) {
+	root := t.TempDir()
+	const knownGood = "6.18.5-10-generic"
+	boot := seedForeignBootKernels(t, root)
+
+	aptCalled := false
+	sys := &realKernelSystem{
+		fsRoot:         root,
+		pkgInstalledFn: func(string) (bool, error) { return true, nil },
+		aptGetFn: func(...string) error {
+			aptCalled = true
+			return nil
+		},
+	}
+
+	err := sys.PruneInactiveSlot("xpf-B", knownGood, "*")
+	if err == nil {
+		t.Fatal("PruneInactiveSlot(candidate=\"*\") = nil, want a rejection")
+	}
+	if aptCalled {
+		t.Error("apt-get was invoked with an unsafe candidate (would purge linux-image-*)")
+	}
+	for _, p := range boot {
+		if _, statErr := os.Stat(p); statErr != nil {
+			t.Errorf("%s deleted by a glob-candidate prune (%v) — arbitrary /boot deletion", p, statErr)
+		}
+	}
+}
+
+// A ".." candidate must be rejected before os.RemoveAll("/lib/modules/..")
+// (which resolves to "/lib"). RED-on-revert: without the validation the prune
+// deletes the parent tree.
+func TestPruneInactiveSlot_RejectsTraversalCandidate(t *testing.T) {
+	root := t.TempDir()
+	// Seed /lib/modules and a sibling so a "/lib/modules/.." == "/lib" RemoveAll
+	// would be observable.
+	libDir := filepath.Join(root, "lib", "modules", "6.18.5-10-generic")
+	if err := os.MkdirAll(libDir, 0755); err != nil {
+		t.Fatalf("seed lib/modules: %v", err)
+	}
+	sys := &realKernelSystem{
+		fsRoot:         root,
+		pkgInstalledFn: func(string) (bool, error) { return false, nil },
+		aptGetFn:       func(...string) error { return nil },
+	}
+	err := sys.PruneInactiveSlot("xpf-B", "6.18.5-10-generic", "..")
+	if err == nil {
+		t.Fatal("PruneInactiveSlot(candidate=\"..\") = nil, want a rejection")
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "lib", "modules")); statErr != nil {
+		t.Errorf("/lib/modules removed by a \"..\" traversal prune (%v)", statErr)
+	}
+}
+
+// WriteSlotSelector must reject an injection-carrying uname string and NOT write
+// the selector. RED-on-revert: without the validation the quote/newline is
+// Sprintf'd into the GRUB directive and the .selector file is written.
+func TestWriteSlotSelector_RejectsInjection(t *testing.T) {
+	for _, bad := range []string{
+		"6.18.5-10-generic\"\nset root=(hd0)",
+		"6.18.5-10\ngeneric",
+		"*",
+	} {
+		root := t.TempDir()
+		sys := &realKernelSystem{fsRoot: root}
+		if err := sys.WriteSlotSelector("xpf-B", bad); err == nil {
+			t.Errorf("WriteSlotSelector(unameR=%q) = nil, want a rejection", bad)
+		}
+		selPath := filepath.Join(root, "boot/efi/EFI", "xpf-B", "xpf.selector")
+		if _, statErr := os.Stat(selPath); statErr == nil {
+			t.Errorf("WriteSlotSelector wrote a selector from an unsafe uname %q (GRUB injection)", bad)
+		}
+	}
+}
+
+// A valid uname string writes a selector that reads back the version.
+func TestWriteSlotSelector_ValidRoundTrips(t *testing.T) {
+	root := t.TempDir()
+	const good = "6.18.0-xpf1-amd64"
+	sys := &realKernelSystem{fsRoot: root}
+	if err := sys.WriteSlotSelector("xpf-B", good); err != nil {
+		t.Fatalf("WriteSlotSelector(valid) = %v, want nil", good)
+	}
+	got, err := sys.ReadSlotSelector("xpf-B")
+	if err != nil {
+		t.Fatalf("ReadSlotSelector: %v", err)
+	}
+	if got != good {
+		t.Errorf("selector round-trip = %q, want %q", got, good)
+	}
+}

--- a/pkg/upgrade/version.go
+++ b/pkg/upgrade/version.go
@@ -83,7 +83,9 @@ func ValidateVersionSegment(ver string) error {
 // it is NOT sufficient here. A real `uname -r` is alphanumerics plus `.`, `-`,
 // `+`, `~`, `_` (e.g. "6.18.0-xpf1-amd64"), so this validator allows ONLY that
 // charset, is non-empty, rejects a leading `-` (would parse as an apt/efi
-// option) and any ".." (traversal), and fails CLOSED on anything else.
+// option) and any "." / ".." relative element (traversal — a lone "." is in
+// the charset but resolves to the parent dir under filepath.Join), and fails
+// CLOSED on anything else.
 func ValidateKernelSegment(what, seg string) error {
 	if seg == "" {
 		return fmt.Errorf("%s is empty", what)
@@ -91,8 +93,12 @@ func ValidateKernelSegment(what, seg string) error {
 	if strings.HasPrefix(seg, "-") {
 		return fmt.Errorf("%s %q has a leading '-' (parses as a command option)", what, seg)
 	}
-	if strings.Contains(seg, "..") {
-		return fmt.Errorf("%s %q contains \"..\" (path traversal)", what, seg)
+	if seg == "." || strings.Contains(seg, "..") {
+		// A lone "." is in the charset but resolves to the parent dir under
+		// filepath.Join (filepath.Join("/lib/modules", ".") == "/lib/modules"),
+		// so a candidateVersion="." would RemoveAll the entire modules tree —
+		// same class as "..". Reject both, matching ValidateVersionSegment.
+		return fmt.Errorf("%s %q is a relative path element (\".\" / \"..\")", what, seg)
 	}
 	for _, r := range seg {
 		switch {

--- a/pkg/upgrade/version.go
+++ b/pkg/upgrade/version.go
@@ -58,3 +58,50 @@ func ValidateVersionSegment(ver string) error {
 	}
 	return nil
 }
+
+// ValidateKernelSegment rejects any kernel version / `uname -r` string that is
+// not a safe segment for the kernel A/B channel's filesystem and GRUB uses
+// (#5452). It is STRICTER than ValidateVersionSegment because the kernel path
+// consumes the string in two additional injection-prone contexts that the
+// binary-cut path does not:
+//
+//   - a glob + delete: filepath.Glob(rooted("/boot/*-"+ver)) feeds every match
+//     to os.RemoveAll, and os.RemoveAll(rooted("/lib/modules/"+ver)) deletes a
+//     module tree. A glob metacharacter (`*`, `?`, `[`, `]`) in ver widens the
+//     pattern — candidateVersion="*" globs "/boot/*-*", matching EVERY dashed
+//     /boot file, so RemoveAll wipes all kernels/initrds/config and bricks the
+//     host. It also feeds `apt-get purge linux-image-<ver>`, where "*" purges
+//     every kernel package. And ".." (even with no "/") traverses:
+//     filepath.Join("/lib/modules", "..") == "/lib".
+//   - a generated GRUB script: WriteSlotSelector Sprintf's ver into a
+//     double-quoted directive `set xpf_slot_kernel="vmlinuz-<ver>"`. A `"`,
+//     backslash, or newline injects arbitrary GRUB commands and breaks the
+//     boot selector.
+//
+// ValidateVersionSegment permits `*`, `?`, `[`, `]`, `"`, `\`, and `:` (all
+// legal in a Debian package version and harmless as a plain path segment), so
+// it is NOT sufficient here. A real `uname -r` is alphanumerics plus `.`, `-`,
+// `+`, `~`, `_` (e.g. "6.18.0-xpf1-amd64"), so this validator allows ONLY that
+// charset, is non-empty, rejects a leading `-` (would parse as an apt/efi
+// option) and any ".." (traversal), and fails CLOSED on anything else.
+func ValidateKernelSegment(what, seg string) error {
+	if seg == "" {
+		return fmt.Errorf("%s is empty", what)
+	}
+	if strings.HasPrefix(seg, "-") {
+		return fmt.Errorf("%s %q has a leading '-' (parses as a command option)", what, seg)
+	}
+	if strings.Contains(seg, "..") {
+		return fmt.Errorf("%s %q contains \"..\" (path traversal)", what, seg)
+	}
+	for _, r := range seg {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '.' || r == '_' || r == '+' || r == '~' || r == '-':
+		default:
+			return fmt.Errorf("%s %q contains an invalid character %q "+
+				"(allowed: A-Za-z0-9 . _ + ~ -)", what, seg, r)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Problem (HIGH security: arbitrary /boot deletion + GRUB injection)

The kernel A/B upgrade **arm** path used the candidate version AND the running
kernel's `uname -r` string **raw**, with no safe-segment validation anywhere on
the kernel-arm path. (The binary-cut channel validates its version via
`ValidateVersionSegment`; the kernel path did not.)

- **`PruneInactiveSlot`** — `filepath.Glob(rooted("/boot/*-"+candidateVersion))`
  feeds every match to `os.RemoveAll`; also `os.RemoveAll("/lib/modules/"+candidateVersion)`
  and `apt-get purge linux-image-<candidateVersion>`.
  - `candidateVersion="*"` → glob `/boot/*-*` matches **every** dashed /boot file
    → `RemoveAll` deletes all kernels/initrds/config → **unbootable host**; and
    the purge becomes `linux-image-*` → **every kernel package** purged.
  - `candidateVersion=".."` → `filepath.Join("/lib/modules","..")` == `/lib` →
    **path-traversal** delete.
- **`WriteSlotSelector`** — `fmt.Sprintf("set xpf_slot_kernel=\"vmlinuz-%s\"\n…", unameR, unameR)`.
  A `"` or newline in `unameR` **injects extra GRUB directives** → boot-selector break.
- **`Arm`** — checked only `candidateVersion == ""`; no charset/safe-segment check.

## Invariant

A kernel version / uname string used in a filesystem glob/delete or a generated
GRUB script MUST be validated to a safe segment (kernel-version charset only) and
**rejected (fail closed)** otherwise — never used raw.

## Fix (fail-closed validation)

- **`ValidateKernelSegment`** (`pkg/upgrade/version.go`): allow ONLY
  `[A-Za-z0-9._+~-]`, non-empty, no leading `-`, no `..`. Deliberately
  **stricter** than `ValidateVersionSegment` (which permits glob metachars,
  quotes, and `:` — safe as a plain path segment but not in a glob/GRUB context).
  A real `uname -r` (e.g. `6.18.0-xpf1-amd64`) is alnum plus `.`, `-`, `+`, `~`,
  `_`, so no legitimate kernel release is rejected.
- Enforced fail-closed at **three** sites:
  - `KernelRunner.Arm` — rejects a bad candidate **up front**, before any mutation.
  - `WriteSlotSelector` — validates the uname **before** the GRUB `Sprintf`
    (covers both the candidate selector and the known-good restore path used by
    `PruneInactiveSlot`).
  - `PruneInactiveSlot` — validates the candidate **before** the purge/glob/delete.

## Tests (RED-on-revert)

`pkg/upgrade/kernel_version_validate_5452_test.go`:
- `candidateVersion="*"` → `Arm` and `PruneInactiveSlot` **reject**; no
  `apt-get`, no seeded /boot file deleted (temp-rooted fs).
- `candidateVersion=".."` → rejected; `/lib/modules` parent not traversed/deleted.
- `unameR` with `"`/newline → `WriteSlotSelector` **rejects**; no `.selector` written.
- Valid `6.18.0-xpf1-amd64` → accepted, selector round-trips.

**RED-on-revert proven**: reverting only the call-site validation (validator
still defined) makes `Arm("*")` reboot, `PruneInactiveSlot("*"/"..")` purge/delete,
and `WriteSlotSelector(injection)` write the GRUB directive — the `*`/`..`/quote
tests fail. `go build ./...`, `go vet ./pkg/upgrade`, and the full `pkg/upgrade`
suite are green.

Closes #5452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gt7341LT9LahmaUkzudX1B