### PR TITLE
configstore: reject non-object top-level config body on read (#5474)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45325,3 +45325,8 @@ top.
 - **Timestamp**: 2026-07-10
 - **Action**: Extract testable top-level dispatch seam (classifyCommand) + upgrade->kernel route seam (upgradeArgsSelectKernel), add dispatch tests. Behavior-preserving; main() output byte-identical (verified vs origin/master binary across 11 dispatch paths).
 - **File(s)**: cmd/xpfd/main.go, cmd/xpfd/upgrade.go, cmd/xpfd/dispatch_test.go, cmd/xpfd/README.md
+
+## 2026-07-10 — #5474 configstore null-decode fail-open fix
+- **Timestamp**: 2026-07-10
+- **Action**: Fix #5474 fail-open on boot. readTreeMeta now requires a top-level JSON OBJECT (requireJSONObject) before decoding into *ConfigTree, so a legacy/plaintext or enveloped-but-unencrypted active body of literal `null` (which json.Unmarshal decodes to a zero-value/empty tree with no error) is rejected → Store.Load tags ErrConfigDBUnreadable → fail closed instead of booting policy-absent. `{}` and populated objects preserved; encrypted-envelope path unaffected (inner body always an object). Added regression test (RED-on-revert proven: `null` decodes empty on origin/master). Updated README.
+- **File(s)**: pkg/configstore/db.go, pkg/configstore/configstore_null_decode_5474_test.go, pkg/configstore/README.md

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -207,6 +207,21 @@ inline archive-site passwords).
   fields dropped — an EMPTY tree — booting a committed-empty config (loss of
   policy) instead of failing closed. This restores at the inner layer the same
   no-empty-load-on-unknown property the outer envelope provides.
+- **Non-object top-level body fails closed (#5474).** After the envelope is
+  stripped and any AES-GCM ciphertext decrypted, `readTreeMeta` requires the
+  final plaintext ConfigTree body to be a JSON OBJECT (`requireJSONObject`)
+  BEFORE decoding it into `*ConfigTree`. This closes a fail-OPEN gap: Go's
+  `json.Unmarshal([]byte("null"), &ConfigTree{})` returns NO error and leaves
+  the tree at its zero value, so a legacy/plaintext (or enveloped-but-
+  unencrypted) active body of literal `null` used to decode to a semantically
+  EMPTY config and `Store.Load` would compile+boot it normally — the firewall
+  coming up with policy ABSENT instead of failing closed. Top-level arrays and
+  scalars already error against the struct target, but `null` is syntactically
+  valid and decodes to zero policy; the object gate rejects all three uniformly
+  with an error `Store.Load` tags `ErrConfigDBUnreadable`. The valid empty
+  config `{}` is preserved as valid, and well-formed populated objects plus the
+  encrypted-envelope path (whose inner body always marshals from a struct to an
+  object) decode byte-for-byte as before.
 - **GCM AAD binding (A4-05) — deliberately NOT changed.** `Seal`/`Open` pass
   a nil additional-authenticated-data argument. Binding the envelope header
   (PRF/salt) as AAD is textbook defense-in-depth, but the scheme already
@@ -665,9 +680,10 @@ persistence failures on every persist path;
 `errors.Is`:
 
 - **`ErrConfigDBUnreadable` (#1917 D1)** — a PRESENT `active.json` whose
-  bytes cannot be read (JSON parse error, decrypt failure, or a too-new
-  compatibility envelope). The daemon FAILS CLOSED by exiting `Run`, so an
-  unreadable/too-new DB is never overwritten by a blind bootstrap.
+  bytes cannot be read (JSON parse error, decrypt failure, a too-new
+  compatibility envelope, or a top-level body that is not a JSON object —
+  `null`/array/scalar, #5474). The daemon FAILS CLOSED by exiting `Run`, so an
+  unreadable/too-new/non-object DB is never overwritten by a blind bootstrap.
 - **`ErrConfigCompile` (#1960)** — a PRESENT `active.json` that read+parsed
   fine but no longer COMPILES, even through the tolerant `compileTreeLenient`
   path (e.g. a committed config whose referenced apply-group was later

--- a/pkg/configstore/configstore_null_decode_5474_test.go
+++ b/pkg/configstore/configstore_null_decode_5474_test.go
@@ -1,0 +1,147 @@
+package configstore
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReadTreeMetaRejectsNonObjectBody_5474 pins the #5474 fail-open fix at the
+// DB read layer. Go's json.Unmarshal([]byte("null"), &ConfigTree{}) returns NO
+// error and leaves the tree at its zero value, so a persisted active body of
+// literal `null` used to decode to a semantically EMPTY config and boot as if
+// no policy were configured (fail-open). A body whose top-level JSON is `null`,
+// an array, or a scalar must now be REJECTED (non-nil error); the valid empty
+// config `{}` and a populated object still read back cleanly.
+//
+// Both a legacy/plaintext body (no #1917 envelope) and an
+// enveloped-but-unencrypted body reach the same decode path, so every case is
+// exercised in both framings. (`null` is the specific gap the issue targets;
+// arrays/scalars already error against the struct target — they are covered
+// here for completeness and to lock the behavior.)
+func TestReadTreeMetaRejectsNonObjectBody_5474(t *testing.T) {
+	reject := []struct {
+		name string
+		body string
+	}{
+		{"null literal", "null"},
+		{"null with whitespace", "  \n null \n"},
+		{"top-level array", "[]"},
+		{"top-level scalar number", "5"},
+		{"top-level scalar string", `"nope"`},
+		{"top-level bool", "true"},
+	}
+	accept := []struct {
+		name string
+		body string
+	}{
+		{"empty object", "{}"},
+		{"empty object with whitespace", "\n  {}\n"},
+		{"populated object", `{"Children":[{"Keys":["system"]}]}`},
+	}
+
+	// frame writes body to a fresh DB's active.json, optionally wrapped in the
+	// #1917 compatibility envelope (unencrypted), and returns the DB.
+	frame := func(t *testing.T, enveloped bool, body string) *DB {
+		t.Helper()
+		dbDir := filepath.Join(t.TempDir(), ".configdb")
+		db, err := NewDB(dbDir)
+		if err != nil {
+			t.Fatalf("NewDB: %v", err)
+		}
+		raw := []byte(body)
+		if enveloped {
+			raw = wrapEnvelope(raw, "9.9.9", true)
+		}
+		if err := os.WriteFile(db.activePath(), raw, 0600); err != nil {
+			t.Fatalf("write active.json: %v", err)
+		}
+		return db
+	}
+
+	for _, enveloped := range []bool{false, true} {
+		framing := "plaintext"
+		if enveloped {
+			framing = "enveloped"
+		}
+		for _, tc := range reject {
+			t.Run("reject/"+framing+"/"+tc.name, func(t *testing.T) {
+				db := frame(t, enveloped, tc.body)
+				tree, _, err := db.ReadActiveMeta()
+				if err == nil {
+					t.Fatalf("ReadActiveMeta(%q) returned nil error; want fail-closed (tree=%+v)", tc.body, tree)
+				}
+			})
+		}
+		for _, tc := range accept {
+			t.Run("accept/"+framing+"/"+tc.name, func(t *testing.T) {
+				db := frame(t, enveloped, tc.body)
+				tree, _, err := db.ReadActiveMeta()
+				if err != nil {
+					t.Fatalf("ReadActiveMeta(%q) errored: %v; want success", tc.body, err)
+				}
+				if tree == nil {
+					t.Fatalf("ReadActiveMeta(%q) returned nil tree; want non-nil valid tree", tc.body)
+				}
+			})
+		}
+	}
+}
+
+// TestStoreLoadNullBodyFailsClosed_5474 proves the end-to-end fail-closed
+// property: a PRESENT plaintext active.json of literal `null` is rejected with
+// ErrConfigDBUnreadable, so the daemon can make boot fatal instead of silently
+// coming up with policy absent. A `{}` body is the valid empty config and Load
+// succeeds (and boots to a non-nil tree).
+//
+// This is the RED-on-revert regression: without the requireJSONObject gate the
+// `null` subtest passes Load with no error (the boot-empty fail-open bug).
+func TestStoreLoadNullBodyFailsClosed_5474(t *testing.T) {
+	load := func(t *testing.T, body string) error {
+		t.Helper()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config")
+		dbDir := filepath.Join(dir, ".configdb")
+		if err := os.MkdirAll(dbDir, 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dbDir, "active.json"), []byte(body), 0600); err != nil {
+			t.Fatal(err)
+		}
+		return newTestStoreAt(t, path).Load()
+	}
+
+	t.Run("null fails closed", func(t *testing.T) {
+		err := load(t, "null")
+		if err == nil {
+			t.Fatal("Load accepted a `null` active.json; must fail closed (policy would be absent)")
+		}
+		if !errors.Is(err, ErrConfigDBUnreadable) {
+			t.Fatalf("Load error not tagged ErrConfigDBUnreadable: %v", err)
+		}
+	})
+	t.Run("array fails closed", func(t *testing.T) {
+		err := load(t, "[]")
+		if err == nil {
+			t.Fatal("Load accepted a `[]` active.json; must fail closed")
+		}
+		if !errors.Is(err, ErrConfigDBUnreadable) {
+			t.Fatalf("Load error not tagged ErrConfigDBUnreadable: %v", err)
+		}
+	})
+	t.Run("scalar fails closed", func(t *testing.T) {
+		err := load(t, "5")
+		if err == nil {
+			t.Fatal("Load accepted a `5` active.json; must fail closed")
+		}
+		if !errors.Is(err, ErrConfigDBUnreadable) {
+			t.Fatalf("Load error not tagged ErrConfigDBUnreadable: %v", err)
+		}
+	})
+	t.Run("empty object boots", func(t *testing.T) {
+		if err := load(t, "{}"); err != nil {
+			t.Fatalf("Load rejected `{}` (valid empty config): %v", err)
+		}
+	})
+}

--- a/pkg/configstore/db.go
+++ b/pkg/configstore/db.go
@@ -2,6 +2,7 @@
 package configstore
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -290,6 +291,30 @@ func (db *DB) readTreeMeta(path string) (*config.ConfigTree, bool, error) {
 		return nil, true, fmt.Errorf("decrypt %s: %w", path, err)
 	}
 
+	// Reject a body whose top-level JSON is not an OBJECT (#5474 fail-open).
+	// Go's json.Unmarshal([]byte("null"), &ConfigTree{}) returns NO error and
+	// leaves the tree at its zero value — a semantically EMPTY config. A
+	// legacy/plaintext (or enveloped-but-unencrypted) active body of literal
+	// `null` would therefore decode to an empty tree and Store.Load would
+	// compile+boot it normally, so the firewall comes up with policy ABSENT
+	// (fail-open) instead of failing closed. Syntactically-invalid bodies and
+	// top-level arrays/scalars already error against the struct target, but
+	// `null` is syntactically valid and decodes to zero policy — this is the
+	// specific gap. Authoritative persisted state must REJECT malformed/partial
+	// top-level JSON, so require a JSON object here.
+	//
+	// data is the FINAL plaintext ConfigTree body: the #1917 envelope has been
+	// stripped and any AES-GCM ciphertext decrypted, so this frames the check
+	// exactly where a plaintext ConfigTree JSON is about to be decoded. The
+	// encrypted-envelope path is unaffected (its inner body always marshals
+	// from a struct to an object), the valid empty config `{}` still passes,
+	// and well-formed populated objects decode byte-for-byte as before.
+	// Store.Load tags the returned error with ErrConfigDBUnreadable, so a null/
+	// array/scalar DB becomes a fatal fail-closed boot, not a blind bootstrap.
+	if err := requireJSONObject(data); err != nil {
+		return nil, true, fmt.Errorf("parse %s: %w", path, err)
+	}
+
 	tree := &config.ConfigTree{}
 	if err := json.Unmarshal(data, tree); err != nil {
 		return nil, true, fmt.Errorf("parse %s: %w", path, err)
@@ -314,6 +339,34 @@ func (db *DB) readTreeMeta(path string) (*config.ConfigTree, bool, error) {
 			"path", path, "issue", "#4579")
 	}
 	return tree, committed, nil
+}
+
+// requireJSONObject rejects a persisted config body whose top-level JSON is
+// not an OBJECT ("{...}"). It closes the #5474 fail-open gap: a top-level
+// `null` decodes into *ConfigTree without error (zero value = empty config),
+// and a top-level array or scalar, while already rejected by the struct
+// target's own decode, is caught here first with an intention-revealing error.
+// The valid empty config `{}` passes. The check inspects only the leading
+// non-whitespace byte (JSON insignificant whitespace is space/tab/CR/LF); the
+// subsequent json.Unmarshal still fully validates object well-formedness.
+func requireJSONObject(data []byte) error {
+	trimmed := bytes.TrimLeft(data, " \t\r\n")
+	if len(trimmed) == 0 {
+		return fmt.Errorf("config body is empty, not a JSON object")
+	}
+	if trimmed[0] != '{' {
+		// Surface a short prefix so a `null`/array/scalar body is identifiable
+		// in the fail-closed boot log without dumping a large or secret-bearing
+		// body.
+		snippet := trimmed
+		if len(snippet) > 16 {
+			snippet = snippet[:16]
+		}
+		return fmt.Errorf("config body is not a JSON object (top-level starts with %q); "+
+			"a null/array/scalar body decodes to an EMPTY config and would boot with "+
+			"policy absent (fail-open) — refusing", string(snippet))
+	}
+	return nil
 }
 
 // writeTree persists a config tree to a JSON file durably (#1894,


### PR DESCRIPTION
## Problem (#5474 — fail-open on boot)

`readTreeMeta` (pkg/configstore/db.go) decoded the persisted config body with:

```go
tree := &config.ConfigTree{}
json.Unmarshal(data, tree)
```

Go's `json.Unmarshal([]byte("null"), tree)` returns **no error** and leaves `tree` at its zero value. So a legacy/plaintext (or enveloped-but-unencrypted) active body of literal `null` decoded as a **semantically EMPTY config**: `Store.Load` compiled and booted it normally instead of failing closed with `ErrConfigDBUnreadable`, and the firewall came up **with policy ABSENT (fail-open)**.

Syntactically-invalid bodies and top-level arrays/scalars already error against the struct target (`ConfigTree` is a struct). `null` is the specific gap — syntactically valid, decodes to zero policy.

**Invariant:** authoritative persisted state must REJECT malformed/partial top-level JSON (null/array/scalar) rather than rely on zero-value decode.

## Fix

After the #1917 compatibility envelope is stripped and any AES-GCM ciphertext decrypted, `readTreeMeta` now calls `requireJSONObject(data)` to require a top-level JSON **object** before decoding into `*ConfigTree`. A body whose first non-whitespace byte is not `{` (literal `null`, arrays `[`, scalars) returns an error, which `Store.Load` tags with `ErrConfigDBUnreadable` (fail closed → the daemon exits `Run` rather than blind-bootstrapping).

- The check runs only on the **final plaintext ConfigTree body**, so the **encrypted-envelope path is unaffected** (its inner body always marshals from a struct to an object).
- The valid empty config `{}` is **preserved as valid**.
- Well-formed populated objects decode **byte-for-byte** as before.

## Validation

- `go build ./...` and `go test ./pkg/configstore/...` pass; `go vet` clean.
- New regression `pkg/configstore/configstore_null_decode_5474_test.go`: a `null`, `[]`, and scalar active body (in both plaintext and enveloped-unencrypted framings) → `ReadActiveMeta`/`Load` returns `ErrConfigDBUnreadable`; `{}` and a populated object still succeed.

### RED-on-revert evidence

With `requireJSONObject` disabled (fix reverted), the `null` subtests fail exactly as the fail-open bug predicts:

```
--- FAIL: TestReadTreeMetaRejectsNonObjectBody_5474/reject/plaintext/null_literal
    ReadActiveMeta("null") returned nil error; want fail-closed (tree=&{Children:[]})
--- FAIL: TestReadTreeMetaRejectsNonObjectBody_5474/reject/enveloped/null_literal
    ReadActiveMeta("null") returned nil error; want fail-closed (tree=&{Children:[]})
--- FAIL: TestStoreLoadNullBodyFailsClosed_5474/null_fails_closed
    Load accepted a `null` active.json; must fail closed (policy would be absent)
```

The array/scalar subtests still pass on revert (struct-mismatch already errors), confirming `null` is the specific fail-open gap. Restoring the gate turns all subtests green.

Docs: `pkg/configstore/README.md` documents the non-object fail-closed rule and adds it to the `ErrConfigDBUnreadable` causes.

Closes #5474

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVKM4KFcd4cRxdwLc6KZZ3