### PR TITLE
config: merge same-name SNMP community blocks (fix #5472)

### DIFF
--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -245,6 +245,11 @@ the userspace dataplane admission boundary is in
   outside the allowlist is dropped (longest-prefix match, `restrict` denies; a
   community without `clients` is allow-all). Enforced in the agent v2c path
   (`pkg/snmp/agent.go` `handleV2cPacket` → `SNMPCommunity.AllowsSource`).
+  Same-name `community <c>` blocks MERGE (#5472): two hierarchical
+  `community public { ... }` siblings accumulate their `clients`/authorization
+  into one entry before the immutable client-prefix cache is built, so a later
+  duplicate with NO `clients` cannot overwrite an earlier block and silently
+  erase its allowlist (an empty allowlist reads as allow-all → fail-open).
 - **RPM probes**, dynamic address feeds.
 - **Dataplane buffer utilization** (`show system buffers`): AF_XDP
   UMEM/TX-ring capacity, CoS queued-byte capacity, helper-published

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -1234,32 +1234,34 @@ func compileSNMP(node *Node, sys *SystemConfig, cfg *Config, lenient bool) error
 		case "community":
 			commName := nodeVal(child)
 			if commName != "" {
-				comm := &SNMPCommunity{Name: commName}
 				commChildren := child.Children
 				if len(child.Keys) < 2 && len(child.Children) > 0 {
 					commChildren = child.Children[0].Children
 				}
+				// Parse THIS block's authorization + clients into locals first.
+				// A same-name sibling block is then MERGED into any existing
+				// entry rather than overwriting it (#5472), so a later block
+				// cannot silently drop an earlier block's source-IP allowlist.
+				var blockAuth string
+				var blockClients []SNMPClient
 				for _, prop := range commChildren {
 					switch prop.Name() {
 					case "authorization":
-						comm.Authorization = nodeVal(prop)
+						blockAuth = nodeVal(prop)
 					case "clients":
 						// #4289: Junos `clients` source-IP allowlist.
 						// parseSNMPClients handles both AST shapes and the
 						// per-entry `restrict` modifier. Accumulate so a
 						// clients block split across load-merge / flat-set
 						// replays is not dropped.
-						comm.Clients = append(comm.Clients, parseSNMPClients(prop)...)
+						blockClients = append(blockClients, parseSNMPClients(prop)...)
 					}
 				}
 				// Flat form: community public authorization read-only
 				for i := 2; i < len(child.Keys)-1; i++ {
 					if child.Keys[i] == "authorization" {
-						comm.Authorization = child.Keys[i+1]
+						blockAuth = child.Keys[i+1]
 					}
-				}
-				if comm.Authorization == "" {
-					comm.Authorization = "read-only"
 				}
 				// #4834: reject/warn on an unparseable `clients` entry before
 				// it reaches compileClientNets. See validateSNMPClients for
@@ -1267,21 +1269,53 @@ func compileSNMP(node *Node, sys *SystemConfig, cfg *Config, lenient bool) error
 				// catches a mistyped "restrict" keyword, which otherwise
 				// silently detaches from the preceding prefix and turns a
 				// deny-except entry into an unrestricted allow (fail-open).
-				clientWarnings, err := validateSNMPClients(comm.Clients, lenient)
+				// Validate only THIS block's new entries: on the merge path an
+				// earlier block's entries were already validated (and, strict,
+				// would have aborted), so re-validating the accumulated list
+				// would double-report the same warning.
+				clientWarnings, err := validateSNMPClients(blockClients, lenient)
 				if err != nil {
 					return err
 				}
 				if cfg != nil {
 					cfg.Warnings = append(cfg.Warnings, clientWarnings...)
 				}
-				// #4711: pre-parse the `clients` prefixes once now that
-				// comm.Clients is finalized, so AllowsSource does an
+				// #5472: same-name `community` blocks MERGE into one entry
+				// instead of a plain map overwrite. Junos treats two
+				// `community public { ... }` siblings as a single configuration
+				// node; the old `Communities[name] = comm` overwrite let a later
+				// duplicate with NO `clients` replace an earlier block that had
+				// an allowlist — and AllowsSource reads an empty allowlist as
+				// allow-all, so the source-IP restriction was silently erased
+				// (security fail-open: any source could then query the
+				// community). Accumulating the allowlist keeps the restriction
+				// on BOTH the strict commit and the lenient load / HA
+				// config-sync paths (a warn-and-keep-last-writer gate would
+				// still open the community on the lenient path).
+				comm := snmp.Communities[commName]
+				if comm == nil {
+					comm = &SNMPCommunity{Name: commName}
+					snmp.Communities[commName] = comm
+				}
+				comm.Clients = append(comm.Clients, blockClients...)
+				// A later block updates the authorization only when it
+				// explicitly states one; an omitted authorization must NOT
+				// clear a value an earlier block established (do not let an
+				// empty duplicate downgrade read-write back to the read-only
+				// default).
+				if blockAuth != "" {
+					comm.Authorization = blockAuth
+				}
+				if comm.Authorization == "" {
+					comm.Authorization = "read-only"
+				}
+				// #4711: (re)build the allocation-free client-prefix cache from
+				// the now-merged Clients, so AllowsSource does an
 				// allocation-free match per incoming v2c packet instead of
 				// re-parsing every prefix on every packet. Runs here, before
 				// the config is published to the SNMP agent, so the cache is
 				// set with no concurrent readers.
 				comm.clientNets = compileClientNets(comm.Clients)
-				snmp.Communities[comm.Name] = comm
 			}
 		case "trap-group":
 			tgName := nodeVal(child)

--- a/pkg/config/snmp_dup_community_5472_test.go
+++ b/pkg/config/snmp_dup_community_5472_test.go
@@ -1,0 +1,155 @@
+package config
+
+import (
+	"net"
+	"testing"
+)
+
+// #5472 (security, fail-open): compileSNMP built each `community <name>` block
+// into a fresh &SNMPCommunity and stored it with a plain map overwrite
+// (snmp.Communities[name] = comm) — no same-name merge. Two hierarchical
+// `community public { ... }` siblings where the SECOND has no `clients` meant
+// the second (empty) entry overwrote the first, dropping its source-IP
+// allowlist. AllowsSource treats an empty allowlist as allow-all, so the
+// restriction was silently erased and any source could query the community.
+//
+// The fix MERGES same-name community blocks (accumulate Clients, carry
+// authorization) before the immutable client-prefix cache is built, so a later
+// block cannot erase an earlier block's allowlist.
+//
+// RED-on-revert: with the compileSNMP merge reverted (a plain
+// snmp.Communities[name] = comm overwrite), the second empty block wins,
+// c.Clients is empty, AllowsSource returns allow-all, and the 8.8.8.8 deny
+// assertion below flips to true — the test fails.
+
+// TestSNMPDupCommunityEmptySecondBlockKeepsAllowlist is the core RED-on-revert
+// proof: block 1 carries the allowlist, block 2 (same name) carries none, and
+// the merged community must still enforce block 1's restriction.
+func TestSNMPDupCommunityEmptySecondBlockKeepsAllowlist(t *testing.T) {
+	c := communityFrom(t, parseHier(t, `
+snmp {
+    community public {
+        authorization read-only;
+        clients {
+            10.0.0.0/24;
+        }
+    }
+    community public {
+        authorization read-only;
+    }
+}
+`), "public")
+
+	if len(c.Clients) == 0 {
+		t.Fatalf("merged community lost block-1's clients allowlist: %+v", c.Clients)
+	}
+	cases := map[string]bool{
+		"10.0.0.5": true,  // inside block-1's 10.0.0.0/24 allowlist
+		"8.8.8.8":  false, // not allowlisted → must be denied (fail-open guard)
+	}
+	for src, want := range cases {
+		if got := c.AllowsSource(net.ParseIP(src)); got != want {
+			t.Errorf("AllowsSource(%s) = %v, want %v (a later empty duplicate must not erase the allowlist)", src, got, want)
+		}
+	}
+}
+
+// TestSNMPDupCommunityUnionsClients: when BOTH duplicate blocks carry clients,
+// the merged allowlist is the union of the two — neither block is dropped.
+func TestSNMPDupCommunityUnionsClients(t *testing.T) {
+	c := communityFrom(t, parseHier(t, `
+snmp {
+    community mgmt {
+        authorization read-only;
+        clients {
+            10.1.0.0/16;
+        }
+    }
+    community mgmt {
+        clients {
+            192.168.5.0/24;
+        }
+    }
+}
+`), "mgmt")
+
+	cases := map[string]bool{
+		"10.1.2.3":    true,  // block 1 prefix
+		"192.168.5.9": true,  // block 2 prefix
+		"172.16.0.1":  false, // neither → default-deny
+	}
+	for src, want := range cases {
+		if got := c.AllowsSource(net.ParseIP(src)); got != want {
+			t.Errorf("AllowsSource(%s) = %v, want %v (merged allowlist must be the union)", src, got, want)
+		}
+	}
+}
+
+// TestSNMPDupCommunityAuthorizationNotCleared: a later block that omits
+// `authorization` must not downgrade an earlier read-write to the read-only
+// default. An explicit later authorization does update.
+func TestSNMPDupCommunityAuthorizationNotCleared(t *testing.T) {
+	// Block 1 sets read-write; block 2 omits authorization entirely.
+	c := communityFrom(t, parseHier(t, `
+snmp {
+    community rw {
+        authorization read-write;
+        clients {
+            10.0.0.0/24;
+        }
+    }
+    community rw {
+        clients {
+            10.0.1.0/24;
+        }
+    }
+}
+`), "rw")
+	if c.Authorization != "read-write" {
+		t.Errorf("authorization = %q, want %q (an empty duplicate must not clear an earlier authorization)", c.Authorization, "read-write")
+	}
+
+	// An explicit later authorization DOES win (last explicit value).
+	c2 := communityFrom(t, parseHier(t, `
+snmp {
+    community upd {
+        authorization read-only;
+    }
+    community upd {
+        authorization read-write;
+    }
+}
+`), "upd")
+	if c2.Authorization != "read-write" {
+		t.Errorf("authorization = %q, want %q (an explicit later authorization updates)", c2.Authorization, "read-write")
+	}
+}
+
+// TestSNMPSingleCommunityUnchanged guards against a false merge / behavior
+// change on the common single-block case: one community with an allowlist
+// still enforces exactly as before.
+func TestSNMPSingleCommunityUnchanged(t *testing.T) {
+	c := communityFrom(t, parseHier(t, `
+snmp {
+    community solo {
+        authorization read-only;
+        clients {
+            10.0.0.0/24;
+            0.0.0.0/0 restrict;
+        }
+    }
+}
+`), "solo")
+	if c.Authorization != "read-only" {
+		t.Errorf("authorization = %q, want read-only", c.Authorization)
+	}
+	if len(c.Clients) != 2 {
+		t.Fatalf("expected 2 client entries, got %+v", c.Clients)
+	}
+	if !c.AllowsSource(net.ParseIP("10.0.0.5")) {
+		t.Error("AllowsSource(10.0.0.5) = false, want true (in 10.0.0.0/24)")
+	}
+	if c.AllowsSource(net.ParseIP("8.8.8.8")) {
+		t.Error("AllowsSource(8.8.8.8) = true, want false (only 0.0.0.0/0 restrict matches)")
+	}
+}


### PR DESCRIPTION
## Summary

`compileSNMP` (`pkg/config/compiler_system.go`) built each `community <name>`
block into a fresh `&SNMPCommunity` and stored it with a **plain map overwrite**
(`snmp.Communities[name] = comm`) — no same-name merge. Two hierarchical
`community public { ... }` siblings where the **second has no `clients`** meant
the second (empty) entry silently overwrote the first, dropping its source-IP
allowlist. `AllowsSource` treats an empty allowlist as **allow-all** (the Junos
default), so the restriction vanished and **any source could query the
community** — a security fail-open.

Closes #5472

## Fix

Same-name `community` blocks now **MERGE** into one entry:
- This block's `authorization` + `clients` are parsed into locals first.
- They are merged into any existing `Communities[name]` (create-if-absent):
  `clients` accumulate; a later block updates `authorization` **only when it
  explicitly states one** (an omitted authorization can't downgrade an earlier
  `read-write` back to the `read-only` default); a later empty block can't erase
  an earlier block's `clients`.
- The immutable #4711 client-prefix cache (`compileClientNets`) is rebuilt from
  the **merged** `Clients`, so the allowlist survives on **both** the strict
  commit and the lenient load / HA config-sync paths.

### Merge vs. reject — reasoning
There is an existing #5180 gate (`validateDuplicateNamedBlockAST`) that *rejects*
duplicate hierarchical named blocks for `groups`/`interfaces`/`screen
ids-option`, but (a) it does **not** cover `snmp community`, and (b) its lenient
path keeps *last-writer-wins* + a warning — which for a security allowlist is
**still fail-open** on load / peer-sync. **Merge (tolerant) is correct here and
strictly safer:**
- vSRX parity: Junos treats two `community public { ... }` siblings as a single
  configuration node (hierarchical duplicate identifiers merge), so tolerant
  merge — not rejection — matches Junos.
- Merge preserves the allowlist on the lenient path too, closing the fail-open a
  reject-strict/warn-lenient gate would leave open.

## Other overwrite sites in `compileSNMP` (step 4 check)
- **v3 users** (`snmp.V3Users`): already merges — it reads the existing entry
  (`user := snmp.V3Users[userName]`) and accumulates. Not vulnerable.
- **trap-group** (`snmp.TrapGroups`): same overwrite *shape*, but trap `targets`
  are **outbound** notification destinations, not an inbound source-IP allowlist
  — a different risk class (notification loss, not a security fail-open). Left
  unchanged; noted here for a possible follow-up if merge is wanted for
  robustness.

So the **allowlist-erasure fail-open is community-only**.

Single-block (non-duplicate) behavior is preserved **bit-for-bit**: for one
community, `blockClients == comm.Clients`, validation and default-auth run
identically, and `clientNets` is built on the same list.

## Tests
`pkg/config/snmp_dup_community_5472_test.go`:
- `EmptySecondBlockKeepsAllowlist` — block 1 has clients, block 2 (same name)
  has none; merged community still **denies** a non-allowlisted source
  (`8.8.8.8`) and allows an allowlisted one.
- `UnionsClients` — both blocks carry clients; merged allowlist is the union.
- `AuthorizationNotCleared` — an empty duplicate does not clear `read-write`; an
  explicit later authorization does update.
- `SingleCommunityUnchanged` — single-block sanity (no false merge).

## RED-on-revert evidence
Reverting the merge to a plain overwrite (`comm := &SNMPCommunity{...};
snmp.Communities[name] = comm`) makes the three duplicate-block tests **FAIL**:

```
--- FAIL: TestSNMPDupCommunityEmptySecondBlockKeepsAllowlist (0.00s)
    snmp_dup_community_5472_test.go:44: merged community lost block-1's clients allowlist: []
--- FAIL: TestSNMPDupCommunityUnionsClients (0.00s)
--- FAIL: TestSNMPDupCommunityAuthorizationNotCleared (0.00s)
--- PASS: TestSNMPSingleCommunityUnchanged (0.00s)
```

`SingleCommunityUnchanged` still PASSES under the revert (proving no false-merge
regression on the common case). With the fix restored, `go build ./...` is clean
and `go test ./pkg/config/...` is green.

## Docs
`docs/feature-coverage.md` SNMP section updated with the same-name merge
invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CvfE46Ldt4qkHfN1AQvX2