### PR TITLE
config: classify literal url-template userinfo as a DDNS credential (#5471)

### DIFF
--- a/pkg/config/compiler_ddns_tls.go
+++ b/pkg/config/compiler_ddns_tls.go
@@ -7,8 +7,12 @@ import "strings"
 // bearer token (DuckDNS/Cloudflare), or SigV4 (Route 53). Such a backend must
 // only ever talk to an https:// endpoint (#4861); an rfc2136 backend (DNS, not
 // HTTP) and an unknown backend are false. For the generic templated backend the
-// credential may be Basic auth or an inadyn %u/%p specifier embedded in the
-// url-template.
+// credential may be Basic auth (typed username/password), an inadyn %u/%p
+// specifier embedded in the url-template, or a LITERAL "user:secret@host"
+// userinfo written directly into the template authority (#5471) — the generic
+// template validator explicitly supports a userinfo credential, so that form
+// must classify as credentialed or the http-vs-https gate would let it leak the
+// credential in cleartext.
 func ddnsBackendCarriesCredentials(p *DDNSProvider) bool {
 	switch p.Backend {
 	case "dyndns2":
@@ -19,9 +23,46 @@ func ddnsBackendCarriesCredentials(p *DDNSProvider) bool {
 		return p.AWSAccessKeyID != "" || p.AWSSecretAccessKey.Reveal() != ""
 	case "generic":
 		return p.Username != "" || p.Password.Reveal() != "" ||
-			strings.Contains(p.URLTemplate, "%u") || strings.Contains(p.URLTemplate, "%p")
+			strings.Contains(p.URLTemplate, "%u") || strings.Contains(p.URLTemplate, "%p") ||
+			ddnsTemplateAuthorityHasUserinfo(p.URLTemplate)
 	}
 	return false
+}
+
+// ddnsTemplateAuthorityHasUserinfo reports whether a generic url-template's
+// AUTHORITY carries a nonempty userinfo ("user:pass@" or "user@" before the
+// host) — a LITERAL embedded credential (#5471). The %u/%p specifier form is
+// already handled by ddnsBackendCarriesCredentials; this catches the literal
+// "user:secret@host" case, which has none of those markers.
+//
+// The authority is the network location: it begins after "://" for a scheme'd
+// template, or at index 0 for a schemeless one, and ends at the first '/', '?'
+// or '#'. Bounding the '@' scan to the authority is what keeps an '@' in a PATH
+// ("host/p@th") or QUERY ("host?x=a@b") from being misread as userinfo — the
+// same authority-bounded logic as RedactURL (#5464/#5458). The template is
+// TrimSpace'd first to stay in lockstep with the runtime gate and the other
+// template validators (which trim). Scheme/host may themselves contain inadyn
+// %h/%i specifiers; the scan is byte-based so it tolerates them.
+//
+// Only a nonempty userinfo counts: an empty userinfo ("@host", '@' at the start
+// of the authority) is not a credential.
+func ddnsTemplateAuthorityHasUserinfo(tmpl string) bool {
+	tmpl = strings.TrimSpace(tmpl)
+	authStart := 0
+	if i := strings.Index(tmpl, "://"); i >= 0 {
+		authStart = i + len("://")
+	}
+	authEnd := len(tmpl)
+	for j := authStart; j < len(tmpl); j++ {
+		if c := tmpl[j]; c == '/' || c == '?' || c == '#' {
+			authEnd = j
+			break
+		}
+	}
+	authority := tmpl[authStart:authEnd]
+	// A nonempty userinfo requires at least one character before the last '@'
+	// within the authority; '@' at index 0 (empty userinfo) does not count.
+	return strings.LastIndex(authority, "@") > 0
 }
 
 // ddnsPlaintextCredentialEndpoint reports the operator-supplied endpoint field

--- a/pkg/config/compiler_ddns_tls_4861_test.go
+++ b/pkg/config/compiler_ddns_tls_4861_test.go
@@ -100,6 +100,73 @@ func TestDDNSNonCredentialedPlaintextAccepted(t *testing.T) {
 	}
 }
 
+// #5471: a generic backend whose url-template embeds a LITERAL "user:secret@"
+// userinfo in the authority (no typed username/password, no %u/%p specifier)
+// carries the credential just as surely as the %u/%p form. It must classify as
+// credentialed so the http-vs-https gate rejects a plaintext http:// template.
+// RED-on-revert: dropping the ddnsTemplateAuthorityHasUserinfo clause from
+// ddnsBackendCarriesCredentials makes this compile clean — the leak passes
+// commit.
+func TestDDNSGenericLiteralUserinfoPlaintextRejected(t *testing.T) {
+	for _, tmpl := range []string{
+		"http://user:secret@host.example/upd?ip=%i", // user:pass literal
+		"http://alice@host.example/upd?ip=%i",       // user-only literal
+		"http://user:secret@%h/upd?ip=%i",           // host is a %h specifier
+	} {
+		t.Run(tmpl, func(t *testing.T) {
+			tree := buildTree(t, []string{
+				"set system services dynamic-dns provider p backend generic",
+				`set system services dynamic-dns provider p url-template "` + tmpl + `"`,
+			})
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("generic http:// template with literal userinfo %q compiled "+
+					"without error — plaintext credential leak passes commit (#5471)", tmpl)
+			}
+			if !strings.Contains(err.Error(), "https://") || !strings.Contains(err.Error(), "provider \"p\"") {
+				t.Fatalf("error should name the provider and require https, got: %v", err)
+			}
+		})
+	}
+}
+
+// #5471: the SAME literal-userinfo template over https:// is encrypted and must
+// compile — the gate flags only a plaintext (non-https) endpoint, so the
+// credential travels under TLS. Guards against over-rejecting an https literal
+// userinfo config.
+func TestDDNSGenericLiteralUserinfoHTTPSAccepted(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set system services dynamic-dns provider p backend generic",
+		`set system services dynamic-dns provider p url-template "https://user:secret@host.example/upd?ip=%i"`,
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("generic https:// template with literal userinfo should compile, got: %v", err)
+	}
+}
+
+// #5471: a bare '@' in the PATH or QUERY (no authority userinfo) is NOT a
+// credential and must not be misclassified — an http:// template with no real
+// userinfo still compiles. Mirrors the authority-bounded scan in RedactURL:
+// the '@' after the first '/' or '?' is past the authority boundary.
+func TestDDNSGenericAtInPathQueryNotMisclassified(t *testing.T) {
+	for _, tmpl := range []string{
+		"http://host.example/p@th?ip=%i", // '@' in the path
+		"http://host.example/upd?x=a@b",  // '@' in the query
+		"http://@host.example/upd?ip=%i", // empty userinfo (bare '@')
+	} {
+		t.Run(tmpl, func(t *testing.T) {
+			tree := buildTree(t, []string{
+				"set system services dynamic-dns provider p backend generic",
+				`set system services dynamic-dns provider p url-template "` + tmpl + `"`,
+			})
+			if _, err := CompileConfig(tree); err != nil {
+				t.Fatalf("generic http:// template %q has no authority userinfo and "+
+					"must not be misclassified as credentialed, got: %v", tmpl, err)
+			}
+		})
+	}
+}
+
 // The lenient (tolerant load / peer-sync) path WARNS instead of rejecting a
 // credentialed plaintext endpoint so an already-persisted config an older
 // binary accepted still boots (#1960).


### PR DESCRIPTION
## Summary

The #4861 http-vs-https commit gate rejects a credentialed HTTP DDNS backend
configured with a plaintext `http://` endpoint so the update credential never
travels in cleartext. Its predicate, `ddnsBackendCarriesCredentials`
(`pkg/config/compiler_ddns_tls.go`), classified a `generic` backend as
credentialed **only** when `Username`/`Password` were typed **or** the
url-template contained a `%u`/`%p` specifier.

A generic template that embeds a **literal** `http://user:secret@host/...`
userinfo has none of those markers → the predicate returned `false` →
`ddnsPlaintextCredentialEndpoint` returned `bad=false` → the gate did **not**
fire → the backend issues a plaintext HTTP request carrying the credential in
cleartext. The generic url-template validator explicitly supports a userinfo
credential (per the `ddnsPlaintextCredentialEndpoint` comment and
`docs/config-schema.md`), so this is a valid config form that passed strict
commit while leaking creds.

## Fix

In the `generic` case of `ddnsBackendCarriesCredentials`, also classify the
backend as credentialed when the url-template's **authority** carries a
nonempty userinfo. New helper `ddnsTemplateAuthorityHasUserinfo` mirrors the
authority-bounded scan used by `RedactURL` (#5464/#5458) and
`ddnsGenericURLTemplateValid`:

- authority starts after `://` (or index 0 for a schemeless template) and ends
  at the first `/`, `?` or `#`;
- only a `@` **inside** that authority is userinfo — an `@` in a path
  (`host/p@th`) or query (`host?x=a@b`) is **not** misclassified;
- byte-based scan tolerates `%h`/`%i` specifiers in the scheme/host;
- `TrimSpace`'d to stay in lockstep with the runtime gate;
- only a **nonempty** userinfo counts — an empty `@host` is not a credential.

All prior classification (typed creds, `%u`/`%p`) is preserved **bit-for-bit**;
the change is purely additive (an OR clause), so it can only flag more configs,
never fewer.

## Validation

- `go build ./...` and `go test ./pkg/config/...` pass.
- New regressions in `compiler_ddns_tls_4861_test.go`:
  - **(a)** generic `http://` template with literal `user:secret@host` (plus
    user-only and `%h`-host variants) → commit **FAILS** on the
    plaintext-credential gate, naming the provider + `https`;
  - **(b)** same over `https://` → commit **SUCCEEDS** (credential under TLS);
  - **(c)** a bare `@` in the path/query, and an empty `@host` userinfo →
    **NOT** misclassified, still compiles.
- **RED-on-revert:** removing the `ddnsTemplateAuthorityHasUserinfo` clause from
  `ddnsBackendCarriesCredentials` makes case (a) compile clean (the leak passes
  commit):
  ```
  --- FAIL: TestDDNSGenericLiteralUserinfoPlaintextRejected/http://user:secret@host.example/upd?ip=%i
      generic http:// template with literal userinfo compiled without error —
      plaintext credential leak passes commit (#5471)
  ```
  Restoring the clause turns the tests green again. Confirmed, then restored.

## Scope note

This is **distinct** from #5464 / #5458, which redacted userinfo in **log
output**. This PR fixes the **acceptance-time credential classification** that
drives the commit gate — the config never commits at all.

Closes #5471

🤖 Generated with [Claude Code](https://claude.com/claude-code)