### PR TITLE
routing/xfrm: distinguish transient LinkByName errors from absence (#5461, #5495)

### DIFF
--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -79,6 +79,34 @@ stale-`if_id` delete that fails skips the recreate this cycle (avoids an
 `EEXIST` `LinkAdd`) and surfaces the error, matching the #5119 bond
 changed-signature path.
 
+**Only a genuine not-found may create or delete-gone (#5461 / #5495).**
+Both the create/adopt lookup in `Apply` and the lookup in `deleteLocked`
+used to treat **any** `LinkByName` error as "interface not present",
+conflating a transient/lookup failure (`EBUSY`, `EINVAL`, timeout, netlink
+transport) with genuine absence — the same class distinction the tunnel
+path already draws (see the WireGuard/tunnel removal notes below and
+`isLinkNotFound` in `vrf.go`).
+
+- **#5461 (create path):** on a transient lookup error for an xfrmi that
+  actually **exists**, `Apply` fell through to `LinkAdd` → `EEXIST` → a
+  spurious fail-closed commit error, leaving the interface
+  desired-but-untracked. `Apply` now only falls through to `LinkAdd` when
+  the lookup error is a genuine not-found (`isLinkNotFound`); a transient
+  error is **not** treated as absence — the entry is left tracked (retain
+  ownership) and the real lookup error is surfaced so the commit fails
+  closed on the genuine cause and the next reconcile retries.
+- **#5495 (delete path):** `deleteLocked` took the "already gone" branch
+  (drop tracking + return `nil`) on any `LinkByName` error, so a transient
+  error silently **orphaned** a live kernel xfrmi (and stale
+  routing/security state) while reporting convergence — a later `Apply`
+  then had no removed-desired entry to drive cleanup. `deleteLocked` now
+  drops tracking + reports gone **only** on a genuine not-found; a
+  transient error retains the tracking entry and surfaces the error (this
+  also covers the full-tunnel `Clear`/`clearLocked` path, which keeps the
+  retained entry rather than nil-ing the map). The #4901 hardening only
+  covered a failed `LinkDel` **after** a successful lookup; this closes the
+  predating `LinkByName`-error branch.
+
 ### Bond (fabric/ae LAG) reconcile (#5119)
 
 `bondManager.Apply` is called by `pkg/daemon` on **every** config commit

--- a/pkg/routing/iface_reuse_test.go
+++ b/pkg/routing/iface_reuse_test.go
@@ -74,13 +74,14 @@ type fakeLinkOps struct {
 	addrs map[string][]netlink.Addr
 
 	// Recorded ops.
-	setUpLinks []netlink.Link
-	addrLinks  []netlink.Link
-	delNames   []string
-	addCount   int // cumulative successful LinkAdd calls
-	noMaster   []string
-	mtuSet     map[string][]int
-	addrDels   map[string][]string
+	setUpLinks  []netlink.Link
+	addrLinks   []netlink.Link
+	delNames    []string
+	addCount    int // cumulative successful LinkAdd calls
+	addAttempts int // cumulative LinkAdd calls attempted (success OR failure)
+	noMaster    []string
+	mtuSet      map[string][]int
+	addrDels    map[string][]string
 }
 
 func newFakeLinkOps() *fakeLinkOps {
@@ -119,6 +120,7 @@ func (f *fakeLinkOps) LinkByName(name string) (netlink.Link, error) {
 }
 
 func (f *fakeLinkOps) LinkAdd(l netlink.Link) error {
+	f.addAttempts++
 	if err, ok := f.addFail[l.Attrs().Name]; ok {
 		// Genuine (non-EEXIST) create failure: the link is NOT recorded.
 		return err

--- a/pkg/routing/xfrm.go
+++ b/pkg/routing/xfrm.go
@@ -164,7 +164,24 @@ func (x *xfrmManager) Apply(vpns map[string]*config.IPsecVPN) error {
 		// "already exists, reuse" path (#1706, #2546) — taken when the
 		// interface is unchanged (commit no-op) or survived a daemon
 		// restart that lost in-memory tracking but not the kernel link.
-		if link, err := x.ops.LinkByName(ifName); err == nil {
+		link, err := x.ops.LinkByName(ifName)
+		if err != nil && !isLinkNotFound(err) {
+			// #5461: a transient/lookup error (EBUSY, EINVAL, netlink
+			// transport) is NOT proof the xfrmi is absent. Falling through to
+			// the LinkAdd create path on a device that actually EXISTS would
+			// hit EEXIST and fail the commit closed with a misleading error,
+			// leaving the interface desired-but-untracked. Retain ownership
+			// (a tracked name is already in x.xfrmis and is deliberately left
+			// untouched here), surface the real lookup error so the commit
+			// fails closed on the genuine cause, and let the next reconcile
+			// retry. Mirrors reconcileVRFs' transient-lookup retention
+			// (vrf.go). Only a genuine not-found falls through to create.
+			slog.Warn("xfrmi lookup failed; not creating, retaining for retry",
+				"name", ifName, "if_id", ifID, "tracked", tracked, "err", err)
+			errs = append(errs, fmt.Errorf("lookup xfrmi %s: %w", ifName, err))
+			continue
+		}
+		if err == nil {
 			// Verify the adopted kernel link's ACTUAL if_id matches the
 			// desired one before re-tracking it. A kernel xfrmi with the
 			// same NAME but a stale Ifid (e.g. a daemon restart after the
@@ -223,7 +240,7 @@ func (x *xfrmManager) Apply(vpns map[string]*config.IPsecVPN) error {
 			continue
 		}
 
-		link, err := x.ops.LinkByName(ifName)
+		link, err = x.ops.LinkByName(ifName)
 		if err != nil {
 			slog.Warn("failed to find xfrmi after creation",
 				"name", ifName, "err", err)
@@ -276,15 +293,31 @@ func (x *xfrmManager) clearLocked() error {
 }
 
 // deleteLocked removes a single tracked xfrmi by name and drops it from
-// tracking. Caller must hold mu. A link already gone from the kernel is
-// treated as success (the entry is still untracked). It returns a non-nil
+// tracking. Caller must hold mu. A link genuinely gone from the kernel is
+// treated as success (the entry is dropped from tracking). It returns a non-nil
 // error when the netlink LinkDel fails, in which case the name is RETAINED in
 // tracking (#4901) so the next reconcile retries instead of orphaning the link.
+//
+// #5495: only a GENUINE not-found (link-not-found errno) may drop tracking +
+// report gone. The former code took the "already gone" branch on ANY LinkByName
+// error — a transient/lookup failure (EBUSY, timeout, netlink transport) was
+// conflated with genuine absence, so it deleted tracking and returned nil-gone
+// while the xfrmi was still live in the kernel. A later Apply then had no
+// removed-desired entry to drive cleanup, silently ORPHANING the interface (and
+// leaving stale routing/security state) while reporting convergence. On a
+// transient error we now RETAIN the entry and surface the error so the caller
+// aggregates it (fail-closed) and the next reconcile retries. Mirrors
+// reconcileVRFs' transient-lookup retention (vrf.go).
 func (x *xfrmManager) deleteLocked(name string) error {
 	link, err := x.ops.LinkByName(name)
 	if err != nil {
-		delete(x.xfrmis, name)
-		return nil // already gone
+		if isLinkNotFound(err) {
+			delete(x.xfrmis, name)
+			return nil // genuinely gone
+		}
+		slog.Warn("xfrmi lookup failed during delete; retaining tracking for retry",
+			"name", name, "err", err)
+		return fmt.Errorf("lookup xfrmi %s for delete: %w", name, err)
 	}
 	if err := x.ops.LinkDel(link); err != nil {
 		// #4901: a failed LinkDel leaves the xfrmi in the kernel. Retain

--- a/pkg/routing/xfrm_linkbyname_transient_5461_5495_test.go
+++ b/pkg/routing/xfrm_linkbyname_transient_5461_5495_test.go
@@ -1,0 +1,195 @@
+package routing
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// #5461 / #5495: xfrmManager treated ANY LinkByName error as "interface not
+// present", conflating a transient/lookup failure (EBUSY, EINVAL, timeout,
+// netlink transport) with genuine absence.
+//
+//   - #5461 (Apply create path): on a transient lookup error for an xfrmi that
+//     actually EXISTS, Apply fell through to LinkAdd -> EEXIST -> a spurious
+//     fail-closed commit error, leaving the interface desired-but-untracked.
+//   - #5495 (deleteLocked / full-tunnel Clear): on ANY LinkByName error it
+//     deleted tracking and returned nil-gone. A transient error therefore
+//     silently ORPHANED a live kernel xfrmi (+ stale routing/security state)
+//     while reporting convergence — a later Apply had no removed-desired entry
+//     to drive cleanup.
+//
+// The fix mirrors reconcileVRFs (vrf.go): only a GENUINE not-found
+// (isLinkNotFound) may (a) fall through to create or (b) drop tracking + report
+// gone. A transient error retains ownership and surfaces the real error so the
+// commit fails closed and the next reconcile retries.
+//
+// The fake distinguishes the two error classes: ops.byNameHardErr[name] returns
+// a NON-not-found (transient) error, while an un-seeded name returns the
+// errLinkNotFound sentinel (isLinkNotFound == true).
+
+// TestXfrmApplyTransientLookupDoesNotCreate is the #5461 guard: a TRANSIENT
+// LinkByName error on a tracked, still-desired xfrmi that actually exists in the
+// kernel must NOT drive a LinkAdd (which would EEXIST). Apply must retain the
+// tracking entry and surface the transient error itself.
+//
+// FAIL-ON-REVERT: revert Apply to the blanket `if link, err := ...; err == nil`
+// gate and, on the transient error, `err == nil` is false so Apply falls
+// through to LinkAdd. With the device already present (ops.addExisting) that
+// LinkAdd returns "file exists" — so ops.addAttempts becomes 1 (RED at the
+// zero-attempt assertion) and the returned error wraps "file exists" rather than
+// the injected transient error (RED at errors.Is).
+func TestXfrmApplyTransientLookupDoesNotCreate(t *testing.T) {
+	ops := newFakeLinkOps()
+	ifName, ifID := config.XFRMIfNameAndID("st0.1")
+	if ifName == "" || ifID == 0 {
+		t.Fatalf("XFRMIfNameAndID returned name=%q id=%d for st0.1", ifName, ifID)
+	}
+	// Model reality: the xfrmi EXISTS in the kernel with the matching if_id,
+	// so a fall-through LinkAdd would EEXIST.
+	ops.links[ifName] = &netlink.Xfrmi{
+		LinkAttrs: netlink.LinkAttrs{Name: ifName, Index: 12},
+		Ifid:      ifID,
+	}
+	ops.addExisting = true // a fall-through LinkAdd would report EEXIST
+	injected := errors.New("injected: LinkByName EBUSY (transient)")
+	ops.byNameHardErr[ifName] = injected
+
+	// Already tracked with the matching if_id (so the delete pass leaves it and
+	// the reconcile loop takes the lookup path under test).
+	xm := &xfrmManager{ops: ops, xfrmis: map[string]uint32{ifName: ifID}}
+
+	err := xm.Apply(xfrmVPNs("st0.1"))
+	if err == nil {
+		t.Fatal("Apply must surface the transient lookup error (fail-closed); got nil")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("returned error must wrap the injected TRANSIENT lookup error "+
+			"(not a spurious EEXIST from a fall-through create), got %v", err)
+	}
+	if !strings.Contains(err.Error(), ifName) {
+		t.Errorf("returned error should name the xfrmi %q, got %v", ifName, err)
+	}
+	if ops.addAttempts != 0 {
+		t.Errorf("Apply attempted %d LinkAdd on a transient lookup error, want 0 "+
+			"(a transient error must NOT drive a create that EEXISTs)", ops.addAttempts)
+	}
+	if got, ok := xm.xfrmis[ifName]; !ok || got != ifID {
+		t.Errorf("a transiently-unlookupable xfrmi must stay TRACKED (if_id %d) for retry; "+
+			"got %d, tracked=%v", ifID, got, ok)
+	}
+}
+
+// TestXfrmApplyGenuineNotFoundStillCreates is the #5461 preserved-behavior half:
+// a GENUINE not-found (isLinkNotFound) still falls through to LinkAdd and tracks
+// the new xfrmi, exactly as before. GREEN both before and after the fix.
+func TestXfrmApplyGenuineNotFoundStillCreates(t *testing.T) {
+	ops := newFakeLinkOps() // un-seeded name -> LinkByName returns errLinkNotFound
+	ifName, ifID := config.XFRMIfNameAndID("st0.1")
+
+	xm := &xfrmManager{ops: ops}
+	if err := xm.Apply(xfrmVPNs("st0.1")); err != nil {
+		t.Fatalf("genuine not-found must create with no error, got %v", err)
+	}
+	if ops.addCount != 1 {
+		t.Errorf("genuine not-found issued %d LinkAdd, want exactly 1", ops.addCount)
+	}
+	if got, ok := xm.xfrmis[ifName]; !ok || got != ifID {
+		t.Errorf("newly-created xfrmi must be tracked with if_id %d; got %d, tracked=%v",
+			ifID, got, ok)
+	}
+}
+
+// TestXfrmDeleteLockedTransientLookupRetains is the #5495 guard: a TRANSIENT
+// LinkByName error inside deleteLocked must NOT drop tracking and must NOT
+// report success. It retains the entry (so a later Apply still has a
+// removed-desired entry to drive cleanup) and surfaces the error.
+//
+// FAIL-ON-REVERT: revert deleteLocked to the blanket `if err != nil { delete;
+// return nil }` and a transient error deletes the tracking entry and returns nil
+// — RED at both the retention and the non-nil-error assertions (the exact silent
+// orphan #5495 describes).
+func TestXfrmDeleteLockedTransientLookupRetains(t *testing.T) {
+	ops := newFakeLinkOps()
+	const name = "xfrm1"
+	seedDummy(ops, name)
+	injected := errors.New("injected: LinkByName ETIMEDOUT (transient)")
+	ops.byNameHardErr[name] = injected
+
+	xm := &xfrmManager{ops: ops, xfrmis: map[string]uint32{name: 100}}
+
+	err := xm.deleteLocked(name)
+	if err == nil {
+		t.Fatal("deleteLocked must surface the transient lookup error, not report gone " +
+			"(a transient error must not orphan a live kernel xfrmi)")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("returned error must wrap the injected transient error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), name) {
+		t.Errorf("returned error should name the xfrmi %q, got %v", name, err)
+	}
+	if _, ok := xm.xfrmis[name]; !ok {
+		t.Fatal("a transiently-unlookupable xfrmi must be RETAINED in tracking so a later " +
+			"Apply drives cleanup (do NOT delete tracking + report gone)")
+	}
+	if len(ops.delNames) != 0 {
+		t.Errorf("LinkDel must not run when the lookup failed transiently, got %v", ops.delNames)
+	}
+}
+
+// TestXfrmDeleteLockedGenuineNotFoundDropsTracking is the #5495 preserved-behavior
+// half: a GENUINE not-found still drops the tracking entry and returns nil-gone,
+// exactly as before. GREEN both before and after the fix.
+func TestXfrmDeleteLockedGenuineNotFoundDropsTracking(t *testing.T) {
+	ops := newFakeLinkOps() // un-seeded name -> errLinkNotFound
+	const name = "xfrm1"
+
+	xm := &xfrmManager{ops: ops, xfrmis: map[string]uint32{name: 100}}
+	if err := xm.deleteLocked(name); err != nil {
+		t.Fatalf("genuine not-found must be treated as already-gone (nil), got %v", err)
+	}
+	if _, ok := xm.xfrmis[name]; ok {
+		t.Error("a genuinely-absent xfrmi must be dropped from tracking")
+	}
+}
+
+// TestXfrmClearTransientLookupRetains is the #5495 full-tunnel Clear path: a
+// transient LinkByName error during Clear must RETAIN the tracked entry and
+// surface the error, while a genuinely-present peer entry is still deleted.
+//
+// FAIL-ON-REVERT: with the blanket deleteLocked, the transient "xfrm-bad" entry
+// is deleted + reported gone (Clear then sees len==0 and nils the map), so the
+// retention and non-nil-error assertions go RED.
+func TestXfrmClearTransientLookupRetains(t *testing.T) {
+	ops := newFakeLinkOps()
+	seedDummy(ops, "xfrm-bad")
+	seedDummy(ops, "xfrm-ok")
+	injected := errors.New("injected: LinkByName EBUSY (transient)")
+	ops.byNameHardErr["xfrm-bad"] = injected
+
+	xm := &xfrmManager{ops: ops, xfrmis: map[string]uint32{"xfrm-bad": 100, "xfrm-ok": 101}}
+
+	err := xm.Clear()
+	if err == nil {
+		t.Fatal("Clear must surface the transient lookup failure, not nil (orphaned xfrmi)")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("Clear error must wrap the injected transient error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "xfrm-bad") {
+		t.Errorf("Clear error should name the retained xfrmi: %v", err)
+	}
+	if _, ok := xm.xfrmis["xfrm-bad"]; !ok {
+		t.Fatal("transiently-unlookupable xfrmi must be RETAINED so the next reconcile retries")
+	}
+	if _, ok := xm.xfrmis["xfrm-ok"]; ok {
+		t.Fatal("genuinely-present xfrmi must be deleted from tracking on a successful LinkDel")
+	}
+	if !sliceHas(ops.delNames, "xfrm-ok") {
+		t.Errorf("the present xfrmi should have been LinkDel'd, delNames=%v", ops.delNames)
+	}
+}


### PR DESCRIPTION
## Summary

`xfrmManager` (`pkg/routing/xfrm.go`) treated **every** `LinkByName` error as
"interface not present", conflating a transient/lookup failure (`EBUSY`,
`EINVAL`, timeout, netlink transport) with genuine absence at two sites. Both
are the same bug pattern in the same file, fixed together here.

Closes #5461
Closes #5495

### #5461 — Apply create/adopt path
The reconcile loop used a blanket `if link, err := LinkByName(ifName); err == nil { adopt }`
gate, so ANY non-nil error fell through to `LinkAdd`. On a **transient** lookup
error for an xfrmi that actually **exists**, that `LinkAdd` hits `EEXIST` →
spurious fail-closed commit error, leaving the interface desired-but-untracked.

### #5495 — deleteLocked + full-tunnel Clear
The lookup used a blanket `if err != nil { delete(x.xfrmis, name); return nil // already gone }`,
so ANY `LinkByName` error took the same branch as genuine absence. A transient
error therefore silently **orphaned** a live kernel xfrmi (and stale
routing/security state) while reporting convergence — a later `Apply` then had
no removed-desired entry to drive cleanup. The #4901 hardening only covered a
failed `LinkDel` **after** a successful lookup; this `LinkByName`-error branch
predated it.

## Fix
Both sites now reuse `isLinkNotFound` (defined in `vrf.go`, same package). Only a
**genuine** not-found (`netlink.LinkNotFoundError` / internal sentinel) may
(a) fall through to `LinkAdd` create, or (b) drop tracking + report gone. A
transient error **retains ownership** (a tracked entry is left in `x.xfrmis`,
untouched) and **surfaces the real error** so the commit fails closed on the
genuine cause and the next reconcile retries — mirroring `reconcileVRFs`'
transient-lookup retention. The adopt (`err==nil`) and genuine-not-found paths
are behaviorally identical to before. `clearLocked` already keeps a retained
entry (it only nils the map at `len==0`), so the full-tunnel `Clear` path is
fixed by the same `deleteLocked` change.

## Validation
- New `pkg/routing` regressions (`xfrm_linkbyname_transient_5461_5495_test.go`)
  inject a **transient** `LinkByName` error via the fake's `byNameHardErr` and
  assert: (#5461) `Apply` issues **zero** `LinkAdd`, retains tracking, surfaces
  the transient error (not a spurious `EEXIST`); (#5495) `deleteLocked` retains
  tracking + surfaces the error (no orphan, no `LinkDel`); the full-tunnel
  `Clear` retains the transient entry while still deleting a genuinely-present
  peer. Two preserved-behavior tests assert a genuine not-found still
  (a) creates and (b) deletes-gone.
- **RED-on-revert proven.** Reverting both sites to the blanket
  `err==nil`/`err!=nil` checks makes the three transient tests fail:

  ```
  --- FAIL: TestXfrmApplyTransientLookupDoesNotCreate
      returned error must wrap the injected TRANSIENT lookup error
      (not a spurious EEXIST from a fall-through create),
      got create xfrmi st0.1 (if_id 2): file exists
  --- FAIL: TestXfrmDeleteLockedTransientLookupRetains
      deleteLocked must surface the transient lookup error, not report gone
      (a transient error must not orphan a live kernel xfrmi)
  --- FAIL: TestXfrmClearTransientLookupRetains
      Clear must surface the transient lookup failure, not nil (orphaned xfrmi)
  ```

  The two genuine-not-found preserved-behavior tests stay GREEN. Fix restored;
  full `pkg/routing` suite passes.
- `go build ./...` + `go vet ./pkg/routing/...` clean; `gofmt` clean.
- `pkg/routing/README.md` xfrm section documents the #5461/#5495
  transient-vs-not-found contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPPZQs7xArj3UNnUM66n1N