### PR TITLE
daemon: fail closed on passwd read error during login deprovision (#5493)

### DIFF
--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -491,6 +491,16 @@ The path is scoped and fail-closed:
 - A marker whose UID no longer matches the live account (deleted +
   recreated out of band with a different UID) is treated as **not ours**:
   the account is left intact and only the stale marker is cleaned.
+- On a `/etc/passwd` **read** error the marker is **retained** and the
+  deprovision is skipped, so the next apply retries (#5493). A transient
+  mount/permission/I/O failure reading the identity database is
+  **unknown**, not proof the account is gone — only a *readable* passwd
+  that does **not** contain the name is the genuine out-of-band `userdel`
+  that legitimately drops the marker. Distinguishing the two is what keeps
+  a read hiccup from permanently abandoning a removed user's still-live
+  password and keys: once passwd is readable again the marker would be
+  gone, so the account would never be enumerated (or revoked) again. This
+  mirrors the `/etc/shadow` fail-closed rule below.
 - On a `/etc/shadow` read error, a `chpasswd` failure, or an
   `authorized_keys` removal failure, the marker is **retained** so the
   next apply retries — a credential is never forgotten while it may still

--- a/pkg/daemon/login_passwd_failclosed_5493_test.go
+++ b/pkg/daemon/login_passwd_failclosed_5493_test.go
@@ -1,0 +1,181 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5493: deprovisionLoginUser must fail CLOSED on a transient /etc/passwd read
+// error. lookupUID/lookupUIDGID map ANY os.ReadFile(passwdPath) failure to
+// ok=false, so before the fix a mount/permission/I/O hiccup reading the
+// identity database was indistinguishable from a genuine out-of-band userdel.
+// The caller then dropped the ONLY provenance marker and returned before
+// locking the shadow password or removing managed authorized_keys — and once
+// passwd was readable again the account was no longer enumerated (marker gone),
+// so revocation was PERMANENTLY abandoned: a removed user's password and keys
+// stayed active forever. The asymmetry the fix restores: a /etc/shadow read
+// error already fails closed ("keep marker, retry"); a /etc/passwd read error
+// must too. Only a *readable* passwd that lacks the name is the real deletion
+// that legitimately drops the marker.
+
+// forceUnreadable points a *Path package var at a directory so os.ReadFile
+// fails with EISDIR deterministically regardless of euid (a chmod 0000 would be
+// bypassed when the test runs as root). The stageDeprovisionEnv cleanup restores
+// the original path.
+func forceUnreadable(t *testing.T, name string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// TestDeprovisionPasswdReadErrorFailsClosed is the #5493 fail-on-revert guard:
+// a passwd READ error during deprovision must be a no-op that RETAINS the
+// marker (revocation intent) for the next apply — it must NOT lock the shadow
+// password, remove authorized_keys, or drop the marker. Reverting the fix (the
+// old `curUID, uidOK := lookupUID(name); if !uidOK { os.Remove(markerPath); return }`
+// bool contract) makes assertion (c) RED: the marker is deleted and revocation
+// is permanently abandoned (fail-open).
+func TestDeprovisionPasswdReadErrorFailsClosed(t *testing.T) {
+	sentinel := stageDeprovisionEnv(t,
+		"root:x:0:0:root:/root:/bin/bash\ndave:x:1001:1001:,,,:/home/dave:/bin/bash\n",
+		"root:$6$r$h:19000:0:99999:7:::\ndave:$6$salt$activehash:19000:0:99999:7:::\n",
+	)
+
+	// dave was provisioned at UID 1001 (matches passwd) and has managed keys.
+	if err := markProvisioned("dave", 1001); err != nil {
+		t.Fatal(err)
+	}
+	keysFile := managedAuthorizedKeysPath("dave")
+	if err := os.MkdirAll(filepath.Dir(keysFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keysFile, []byte("ssh-ed25519 AAAA dave@host\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Force a transient /etc/passwd read failure (identity DB unavailable).
+	passwdPath = forceUnreadable(t, "passwd-is-a-dir")
+
+	// dave removed from config entirely.
+	d := &Daemon{}
+	d.reconcileAbsentLoginUsers(&config.Config{})
+
+	// (a) chpasswd was NOT invoked — the shadow password is not locked.
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Fatalf("chpasswd ran despite a passwd read error (err=%v) — must fail closed", err)
+	}
+	// (b) the managed authorized_keys is UNTOUCHED (key login not revoked yet).
+	if _, err := os.Stat(keysFile); err != nil {
+		t.Fatalf("authorized_keys removed despite a passwd read error: %v", err)
+	}
+	// (c) the provenance marker is RETAINED so the next apply retries. Dropping
+	// it here permanently abandons revocation (#5493, the fail-open bug).
+	if _, err := os.Stat(markerPath("dave")); err != nil {
+		t.Fatalf("provenance marker dropped on a passwd read error — revocation permanently abandoned (#5493): %v", err)
+	}
+}
+
+// TestDeprovisionGenuineAbsenceDropsMarker proves the genuine-deletion path is
+// UNCHANGED: when passwd is READABLE and simply does not contain the name (a
+// real out-of-band userdel), there is nothing to revoke and the stale marker is
+// dropped so xpf stops revisiting it. This is the behavior the read-error path
+// must NOT be confused with.
+func TestDeprovisionGenuineAbsenceDropsMarker(t *testing.T) {
+	sentinel := stageDeprovisionEnv(t,
+		"root:x:0:0:root:/root:/bin/bash\n", // passwd readable, "gone" absent
+		"root:$6$r$h:19000:0:99999:7:::\n",
+	)
+
+	// "gone" has a provenance marker but no live account.
+	if err := markProvisioned("gone", 1001); err != nil {
+		t.Fatal(err)
+	}
+
+	d := &Daemon{}
+	d.reconcileAbsentLoginUsers(&config.Config{})
+
+	// Nothing to revoke: chpasswd never runs, and the marker is dropped.
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Fatalf("chpasswd ran for an already-absent account (err=%v)", err)
+	}
+	if _, err := os.Stat(markerPath("gone")); !os.IsNotExist(err) {
+		t.Fatalf("marker retained for a genuinely-absent account — it should be dropped (err=%v)", err)
+	}
+}
+
+// TestDeprovisionShadowReadErrorFailsClosed pins the pre-existing #1944 shadow
+// fail-closed contract that the passwd fix mirrors: passwd is readable and
+// contains the (provisioned) user, so the account is FOUND, but /etc/shadow
+// cannot be read. The deprovision must retain the marker and keys and must not
+// lock — a read hiccup can never revoke, and never abandon revocation.
+func TestDeprovisionShadowReadErrorFailsClosed(t *testing.T) {
+	sentinel := stageDeprovisionEnv(t,
+		"root:x:0:0:root:/root:/bin/bash\nheidi:x:1001:1001:,,,:/home/heidi:/bin/bash\n",
+		"root:$6$r$h:19000:0:99999:7:::\nheidi:$6$salt$hash:19000:0:99999:7:::\n",
+	)
+
+	if err := markProvisioned("heidi", 1001); err != nil {
+		t.Fatal(err)
+	}
+	keysFile := managedAuthorizedKeysPath("heidi")
+	if err := os.MkdirAll(filepath.Dir(keysFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keysFile, []byte("ssh-ed25519 AAAA heidi\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// passwd stays readable (heidi FOUND); only /etc/shadow fails to read.
+	shadowPath = forceUnreadable(t, "shadow-is-a-dir")
+
+	d := &Daemon{}
+	d.reconcileAbsentLoginUsers(&config.Config{})
+
+	// Fail-closed: no lock, keys retained, marker retained.
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Fatalf("chpasswd ran despite a shadow read error (err=%v)", err)
+	}
+	if _, err := os.Stat(keysFile); err != nil {
+		t.Fatalf("authorized_keys removed despite a shadow read error: %v", err)
+	}
+	if _, err := os.Stat(markerPath("heidi")); err != nil {
+		t.Fatalf("marker dropped despite a shadow read error — must be retained: %v", err)
+	}
+}
+
+// TestLookupUIDGIDErrThreeState unit-checks the new 3-state helper directly: a
+// found user, a readable-but-absent user (found=false, err=nil), and an
+// unreadable passwd (found=false, err!=nil). The err return is the exact signal
+// deprovisionLoginUser uses to distinguish "unknown → retry" from "absent →
+// forget".
+func TestLookupUIDGIDErrThreeState(t *testing.T) {
+	stageDeprovisionEnv(t,
+		"root:x:0:0:root:/root:/bin/bash\nivan:x:1234:1234:,,,:/home/ivan:/bin/bash\n",
+		"root:$6$r$h:19000:0:99999:7:::\n",
+	)
+
+	// Found.
+	if uid, gid, found, err := lookupUIDGIDErr("ivan"); !found || err != nil || uid != 1234 || gid != 1234 {
+		t.Fatalf("lookupUIDGIDErr(ivan) = (%d,%d,%v,%v), want (1234,1234,true,nil)", uid, gid, found, err)
+	}
+	// Readable passwd, name absent → genuine absence (no error).
+	if _, _, found, err := lookupUIDGIDErr("nobody"); found || err != nil {
+		t.Fatalf("lookupUIDGIDErr(nobody) = (found=%v,err=%v), want (false,nil) for a readable-but-absent name", found, err)
+	}
+	// Unreadable passwd → read error (unknown), NOT genuine absence.
+	passwdPath = forceUnreadable(t, "passwd-is-a-dir")
+	if _, _, found, err := lookupUIDGIDErr("ivan"); found || err == nil {
+		t.Fatalf("lookupUIDGIDErr on unreadable passwd = (found=%v,err=%v), want (false,non-nil)", found, err)
+	}
+	// The two-state lookupUID wrapper still collapses a read error to ok=false
+	// (unchanged contract for skip-and-retry callers).
+	if _, ok := lookupUID("ivan"); ok {
+		t.Fatal("lookupUID on unreadable passwd returned ok=true; want false (unchanged bool contract)")
+	}
+}

--- a/pkg/daemon/login_password.go
+++ b/pkg/daemon/login_password.go
@@ -2,6 +2,7 @@
 package daemon
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -113,19 +114,34 @@ func currentShadowHash(name string) (string, bool) {
 	return "", false
 }
 
-// lookupUIDGID returns the numeric UID and GID for name by parsing
-// /etc/passwd directly (cgo-free, consistent with currentShadowHash —
-// the codebase deliberately avoids os/user to stay free of cgo/nsswitch).
-// /etc/passwd field 2 is the UID, field 3 is the primary GID. Returns
-// (uid, gid, true) on success, (0, 0, false) if absent or unparseable.
+// lookupUIDGIDErr parses /etc/passwd for name, distinguishing the THREE
+// outcomes a fail-closed caller must tell apart. /etc/passwd field 2 is the
+// UID, field 3 is the primary GID. It is cgo-free (consistent with
+// currentShadowHash — the codebase deliberately avoids os/user to stay free
+// of cgo/nsswitch):
 //
-// fsatomic.WithOwner uses this so a DurableState authorized_keys write
-// installs the file already owned by the target user/group at rename
-// time — no post-rename chown race that could leave root-owned keys.
-func lookupUIDGID(name string) (uid, gid int, ok bool) {
-	data, err := os.ReadFile(passwdPath)
-	if err != nil {
-		return 0, 0, false
+//   - (uid, gid, true,  nil): name found.
+//   - (0,   0,   false, nil): passwd READ OK, name genuinely ABSENT — a real
+//     out-of-band userdel. This is the only outcome that proves the account
+//     is gone.
+//   - (0,   0,   false, err): passwd could NOT be read/parsed — a transient
+//     mount/permission/I/O error, or a malformed entry FOR name. The identity
+//     database is UNKNOWN, NOT proven absent.
+//
+// The err return is what lets a fail-CLOSED caller (deprovisionLoginUser,
+// #5493) tell a genuine account deletion from a transient /etc/passwd read
+// failure. lookupUID/lookupUIDGID collapse both negatives into ok=false,
+// which is safe for callers that merely skip-and-retry on the next apply, but
+// is a fail-OPEN hazard for deprovisionLoginUser: there a read error would be
+// indistinguishable from deletion, so the caller would drop the provenance
+// marker and abandon revocation of a removed user's still-live credentials
+// once passwd became readable again. A malformed entry for the EXACT name is
+// reported as an error (unknown), never as genuine absence — never abandon
+// revocation on a corrupt identity DB.
+func lookupUIDGIDErr(name string) (uid, gid int, found bool, err error) {
+	data, rerr := os.ReadFile(passwdPath)
+	if rerr != nil {
+		return 0, 0, false, rerr
 	}
 	for _, line := range strings.Split(string(data), "\n") {
 		if line == "" {
@@ -139,12 +155,28 @@ func lookupUIDGID(name string) (uid, gid int, ok bool) {
 			u, uerr := strconv.Atoi(fields[2])
 			g, gerr := strconv.Atoi(fields[3])
 			if uerr != nil || gerr != nil {
-				return 0, 0, false
+				return 0, 0, false, fmt.Errorf("passwd: unparseable uid/gid for %q", name)
 			}
-			return u, g, true
+			return u, g, true, nil
 		}
 	}
-	return 0, 0, false
+	return 0, 0, false, nil
+}
+
+// lookupUIDGID returns the numeric UID and GID for name by parsing
+// /etc/passwd directly. It returns (uid, gid, true) on success, (0, 0, false)
+// if absent OR unreadable OR unparseable — the two-state convenience contract
+// kept for callers that skip-and-retry on any negative (a transient read
+// error simply defers their work to the next apply, retaining state). Callers
+// that must NOT treat "unreadable" as "absent" use lookupUIDGIDErr /
+// lookupUIDErr instead.
+//
+// fsatomic.WithOwner uses this so a DurableState authorized_keys write
+// installs the file already owned by the target user/group at rename
+// time — no post-rename chown race that could leave root-owned keys.
+func lookupUIDGID(name string) (uid, gid int, ok bool) {
+	u, g, found, err := lookupUIDGIDErr(name)
+	return u, g, found && err == nil
 }
 
 // lookupUID returns the numeric UID for name (the GID-less convenience
@@ -152,6 +184,15 @@ func lookupUIDGID(name string) (uid, gid int, ok bool) {
 func lookupUID(name string) (int, bool) {
 	uid, _, ok := lookupUIDGID(name)
 	return uid, ok
+}
+
+// lookupUIDErr is the 3-state, error-returning counterpart of lookupUID for
+// fail-CLOSED callers that must distinguish a transient /etc/passwd read
+// failure (unknown → retain state, retry) from a genuine account absence
+// (proven gone → safe to forget). See lookupUIDGIDErr. #5493.
+func lookupUIDErr(name string) (uid int, found bool, err error) {
+	u, _, found, err := lookupUIDGIDErr(name)
+	return u, found, err
 }
 
 // markerPath returns the provenance marker file path for name. names are
@@ -294,11 +335,26 @@ func (d *Daemon) reconcileAbsentLoginUsers(cfg *config.Config) {
 // retries, and it never removes a credential it did not first verify as
 // xpf-owned. #5128.
 func (d *Daemon) deprovisionLoginUser(name string) {
-	curUID, uidOK := lookupUID(name)
-	if !uidOK {
-		// The account is already gone from the host (out-of-band userdel).
-		// There is nothing to revoke; drop the stale marker so we stop
-		// revisiting it every apply.
+	curUID, found, err := lookupUIDErr(name)
+	if err != nil {
+		// /etc/passwd could not be READ (transient mount/permission/I/O
+		// error) — the identity database is UNKNOWN, NOT proof the account is
+		// gone. Fail CLOSED: keep the provenance marker and revocation intent,
+		// retry next apply. Dropping the marker here — as the old lookupUID
+		// bool contract silently did on any read error — would PERMANENTLY
+		// abandon revocation: once passwd is readable again the account is no
+		// longer enumerated (marker gone), so the removed user's password and
+		// keys would stay live forever (#5493). This mirrors the
+		// currentShadowHash fail-closed discipline below: identity-database
+		// uncertainty is "unknown → retry", never "absent → abandon".
+		slog.Warn("skipping removed-user deprovision: cannot read passwd",
+			"user", name, "err", err)
+		return // keep marker; retry next apply
+	}
+	if !found {
+		// passwd READ OK and name genuinely ABSENT — a real out-of-band
+		// userdel. There is nothing to revoke; drop the stale marker so we
+		// stop revisiting it every apply.
 		_ = os.Remove(markerPath(name))
 		return
 	}


### PR DESCRIPTION
## Problem

`deprovisionLoginUser` (`pkg/daemon/login_password.go`) resolved the account UID via `lookupUID`, whose bool contract (`lookupUIDGID` → `os.ReadFile(passwdPath)`) maps **any** `/etc/passwd` read failure to `ok=false`. A transient mount/permission/I/O error reading the identity database was therefore **indistinguishable from a genuine out-of-band `userdel`**.

On `!uidOK` the caller did `os.Remove(markerPath(name)); return` — deleting the **only** provenance marker **before** locking the shadow password or removing the managed `authorized_keys`. Once passwd became readable again, `reconcileAbsentLoginUsers` no longer enumerated the account (marker gone), so revocation of a config-removed user was **permanently abandoned**: the removed operator's password and SSH keys stayed active forever.

## The asymmetry (this is the intended contract)

The **same** function already fails **closed** on a `/etc/shadow` read error ("keep marker; retry next apply", the #1944 discipline) but fail-**opened** on a `/etc/passwd` read error. The invariant it violated: identity-database-loss uncertainty must be treated as **"unknown → retry"**, never **"absent → abandon"**. Only a *readable* passwd that lacks the name is the genuine deletion that may legitimately drop the marker.

## Fix

- Add `lookupUIDGIDErr` — a 3-state parse of `/etc/passwd`: **found** / **readable-but-absent** (`found=false, err=nil`) / **unreadable-or-unparseable** (`found=false, err!=nil`). A malformed entry for the exact name is reported as an error (unknown), so a corrupt identity DB also fails closed.
- `lookupUIDGID`/`lookupUID` now delegate to it and keep their **exact** old two-state bool contract (`found && err == nil`). The four skip-and-retry callers in `daemon_system.go` (marker write, `authorized_keys` owner resolve, emptied-keys revoke, `reconcileUserPassword`) are unchanged: they already retain state and defer to the next apply on `ok=false`, so a read error there is **not** fail-open.
- Add `lookupUIDErr` wrapper; `deprovisionLoginUser` uses it to **keep the marker + revocation intent** on a passwd read error, and drop the marker only on **proven** genuine absence.
- Document the new fail-closed passwd-read branch in `docs/system-login.md`.

## Validation

New `pkg/daemon/login_passwd_failclosed_5493_test.go`:
- passwd **READ error** during deprovision → marker **kept**, `chpasswd` never runs (shadow not locked), `authorized_keys` **not** removed (fail closed, retry-able).
- **genuine absence** (readable passwd, name absent) → marker still dropped (behavior unchanged).
- **shadow READ error** → still fails closed (marker + keys retained).
- `lookupUIDGIDErr` 3-state unit check + `lookupUID` bool contract intact.

**RED-on-revert:** restoring the old `curUID, uidOK := lookupUID(name); if !uidOK { os.Remove(markerPath(name)); return }` makes the passwd-read-error test FAIL:
```
login_passwd_failclosed_5493_test.go:80: provenance marker dropped on a passwd read error —
  revocation permanently abandoned (#5493): stat .../provisioned-users/dave: no such file or directory
--- FAIL: TestDeprovisionPasswdReadErrorFailsClosed
```
while the genuine-absence and shadow-read tests stay green — the failure isolates exactly the fail-open bug. Restored → all green.

`go build ./...` and `go test ./pkg/daemon/...` pass; `gofmt` clean.

## Scope note

#5496 (grpcapi zeroize's `zeroizeLookupUID`) shares this cgo-free `/etc/passwd`-parse shape but is a **distinct locus** with its own disposition; it is **not** touched here.

Closes #5493

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWpJPCWsniggxUrRurSTLG