### PR TITLE
grpcapi: fail closed on unresolved zeroize account ownership (#5496)

### DIFF
--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -233,6 +233,21 @@ too (`zeroizeLoginAccounts`, same error-surfacing discipline):
   if `userdel` fails; on a `userdel` failure the marker is **retained** so a
   retried `zeroize` re-attempts, and the failure is surfaced (the device is not
   reported safe to re-tenant while a live account remains).
+- **Ownership uncertainty fails CLOSED (#5496).** Deciding "is this the account
+  xpf provisioned?" needs two reads — the live UID (`/etc/passwd`) and the
+  recorded UID (the marker). If **either** cannot be resolved — `/etc/passwd`
+  unreadable, a **malformed UID**, or an **unreadable/unparseable marker** —
+  ownership is **UNKNOWN, not proven absent**. The teardown then makes **no**
+  destructive change, **retains** the marker (durable evidence for a safe
+  retry), and **surfaces** the error so the reset is reported **incomplete**.
+  The earlier code conflated an unresolved read/parse with proof-of-absence (or
+  a stale marker), erasing the marker and returning a clean result while a live
+  xpf-provisioned **password** account survived — now un-rediscoverable because
+  its retry marker was destroyed. A **proven UID-mismatch** is likewise reported
+  (unresolved) and its marker retained, absent an explicit durable stale-marker
+  policy. This is the factory-reset sibling of the day-2 login fail-closed rule
+  (#5493) — the same `lookupUIDGIDErr` three-state discipline at a distinct
+  locus.
 
 **Never-touch safety invariant.** The teardown must never nuke a non-xpf account
 or strand access:
@@ -243,7 +258,9 @@ or strand access:
   console/root lifeline survives the wipe (critical on bare metal).
 - An **out-of-band `userdel`+recreate** with a different UID (marker UID ≠ live
   UID) is left alone — the current owner is someone else, exactly the #1944
-  leave-then-rejoin-vs-recreate distinction.
+  leave-then-rejoin-vs-recreate distinction. Since #5496 this mismatch is also
+  **reported** and its marker **retained** (rather than silently erased with a
+  clean-reset report), so the anomaly is re-examined on a retry.
 
 **Local config-archive erasure (#5186).** The three erasures above cover the
 config SSOT/rollback/journal state, the rendered service configs, and the login

--- a/pkg/grpcapi/server_diag_zeroize.go
+++ b/pkg/grpcapi/server_diag_zeroize.go
@@ -3,6 +3,7 @@ package grpcapi
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -252,15 +253,32 @@ var (
 	}
 )
 
-// zeroizeLookupUID returns the current numeric UID for name by parsing
-// zeroizePasswdPath directly (cgo-free, mirroring pkg/daemon.lookupUID). It
-// returns (uid, true) on success and (0, false) if the file is unreadable, the
-// account is absent, or the UID field does not parse — the "not our account"
-// disposition that suppresses a userdel.
-func zeroizeLookupUID(name string) (int, bool) {
-	data, err := os.ReadFile(zeroizePasswdPath)
-	if err != nil {
-		return 0, false
+// zeroizeLookupUIDErr resolves the CURRENT numeric UID for name by parsing
+// zeroizePasswdPath directly (cgo-free, mirroring pkg/daemon.lookupUIDGIDErr,
+// #5493). It distinguishes the THREE outcomes a fail-CLOSED factory reset must
+// tell apart — the whole point of #5496:
+//
+//   - (uid, true,  nil): name found and its UID parsed — the live account.
+//   - (0,   false, nil): passwd READ OK, name genuinely ABSENT — a real
+//     out-of-band userdel. This is the ONLY outcome that proves the account is
+//     gone and therefore safe to forget (drop the marker).
+//   - (0,   false, err): passwd could NOT be read (transient mount / permission
+//     / I/O error) OR its UID field FOR name is malformed. The identity
+//     database is UNKNOWN, NOT proven absent.
+//
+// The err return is what lets zeroizeLoginAccounts fail CLOSED. The prior
+// two-state helper collapsed "unreadable / malformed" into the same
+// (0, false) as "genuinely absent", so an unreadable /etc/passwd or a garbled
+// UID looked like proof the account was gone: the wipe then erased the only
+// provenance marker and reported a clean reset while a live xpf-provisioned
+// PASSWORD account (and its marker-less, no-longer-rediscoverable credential)
+// survived — the #5496 fail-open. A malformed UID for the EXACT name is
+// reported as an error (unknown), never as genuine absence. This mirrors the
+// #5493/#5500 lookupUIDGIDErr split at the factory-reset locus.
+func zeroizeLookupUIDErr(name string) (uid int, found bool, err error) {
+	data, rerr := os.ReadFile(zeroizePasswdPath)
+	if rerr != nil {
+		return 0, false, rerr
 	}
 	for _, line := range strings.Split(string(data), "\n") {
 		if line == "" {
@@ -271,14 +289,14 @@ func zeroizeLookupUID(name string) (int, bool) {
 			continue
 		}
 		if fields[0] == name {
-			uid, err := strconv.Atoi(fields[2])
-			if err != nil {
-				return 0, false
+			u, aerr := strconv.Atoi(fields[2])
+			if aerr != nil {
+				return 0, false, fmt.Errorf("zeroize: unparseable uid for %q in %s", name, zeroizePasswdPath)
 			}
-			return uid, true
+			return u, true, nil
 		}
 	}
-	return 0, false
+	return 0, false, nil
 }
 
 // zeroizeLoginAccounts tears down the OS LOGIN accounts xpf provisioned as part
@@ -310,6 +328,20 @@ func zeroizeLookupUID(name string) (int, bool) {
 //     a different UID (marker mismatch) is left alone — exactly the #1944
 //     leave-then-rejoin vs recreate distinction, so the wipe can never nuke the
 //     wrong account or strand access.
+//
+// Ownership uncertainty FAILS CLOSED (#5496). Deciding "is this the account xpf
+// provisioned?" needs TWO reads: the live UID (/etc/passwd, zeroizeLookupUIDErr)
+// and the recorded UID (provenance marker, readProvisionedMarkerUID). If EITHER
+// cannot be resolved — /etc/passwd unreadable, a malformed UID, or an
+// unreadable/unparseable marker — the account's ownership is UNKNOWN, NOT proven
+// absent. The teardown then makes NO destructive change, RETAINS the marker
+// (durable evidence for a safe retry), and SURFACES the error so
+// performZeroizeWipe reports the reset incomplete. The prior code conflated an
+// unresolved read/parse with proof-of-absence (curOK=false → "already gone")
+// or with a stale marker, erasing the marker and returning nil while a live
+// PASSWORD account survived un-rediscoverable — the fail-open this closes. A
+// proven UID-mismatch is likewise reported (unresolved) and its marker retained,
+// absent an explicit durable stale-marker policy.
 //
 // authorized_keys is removed BEFORE userdel so the SSH-key login vector dies
 // even if userdel later fails; the marker is retained on a userdel FAILURE so a
@@ -358,20 +390,55 @@ func zeroizeLoginAccounts() error {
 		name := e.Name() // marker filename == account name (Base'd on write)
 		markerFile := filepath.Join(zeroizeProvisionedUsersDir, name)
 
-		recordedUID, uidErr := readProvisionedMarkerUID(markerFile)
-		curUID, curOK := zeroizeLookupUID(name)
+		recordedUID, markerErr := readProvisionedMarkerUID(markerFile)
+		curUID, curFound, lookupErr := zeroizeLookupUIDErr(name)
 		keysFile := filepath.Join(zeroizeHomeBase, name, ".ssh", "authorized_keys")
 
 		removeMarker := true
 		switch {
-		case !curOK:
-			// Account already absent from /etc/passwd — it cannot authenticate.
-			// Best-effort clean up any orphaned key residue; nothing to userdel.
+		case lookupErr != nil:
+			// /etc/passwd is unreadable, OR its UID field for this account is
+			// malformed: the identity database is UNKNOWN. We CANNOT prove the
+			// account is gone or resolve its live UID, so this is ownership
+			// uncertainty, not proof of absence. FAIL CLOSED (#5496): surface
+			// the error (so performZeroizeWipe reports the reset INCOMPLETE),
+			// make NO destructive change, and RETAIN the marker so a retry can
+			// re-attempt once passwd is readable again. Conflating this with
+			// genuine absence would erase the only provenance marker and leave a
+			// live xpf credential un-rediscoverable — the fail-open this closes.
+			slog.Error("zeroize: cannot resolve login account UID from passwd; retaining marker, reset incomplete",
+				"user", name, "err", lookupErr)
+			fail(lookupErr)
+			removeMarker = false
+		case markerErr != nil:
+			// The provenance marker itself is unreadable/unparseable: we cannot
+			// resolve OUR recorded UID, so we cannot decide whether the live
+			// account is the one xpf provisioned. Same ownership uncertainty →
+			// FAIL CLOSED (#5496): surface the error, no userdel, and RETAIN the
+			// marker. Erasing it would destroy the only durable evidence needed
+			// for a safe retry and could strand a live xpf credential unrecorded.
+			slog.Error("zeroize: cannot read provenance marker; retaining marker, reset incomplete",
+				"user", name, "err", markerErr)
+			fail(markerErr)
+			removeMarker = false
+		case !curFound:
+			// passwd READ OK and the account is genuinely ABSENT — a real
+			// out-of-band userdel; it cannot authenticate. Best-effort clean up
+			// any orphaned key residue; nothing to userdel; drop the stale marker.
 			fail(os.Remove(keysFile))
-		case uidErr != nil || curUID != recordedUID:
-			// Corrupt marker OR out-of-band recreate (UID changed): NOT the
-			// account xpf provisioned. Never userdel or touch its home — the
-			// current owner is someone else. Drop our stale marker only.
+		case curUID != recordedUID:
+			// Proven UID-mismatch: the live account under this name has a
+			// DIFFERENT UID than the one xpf provisioned — an out-of-band
+			// userdel+recreate. The current account belongs to someone else, so
+			// NEVER userdel it or touch its home (the #1944 leave-then-rejoin vs
+			// recreate distinction). But absent an explicit, durable stale-marker
+			// policy we also refuse to silently erase our marker and report a
+			// clean reset: surface the UNRESOLVED condition and RETAIN the marker
+			// so the anomaly is re-examined on a retry, not buried (#5496).
+			slog.Warn("zeroize: provisioned marker UID mismatch (account recreated out of band); left untouched, reset incomplete",
+				"user", name, "markerUID", recordedUID, "liveUID", curUID)
+			fail(fmt.Errorf("zeroize: login account %q live UID %d != provenance marker UID %d (out-of-band recreate); left untouched", name, curUID, recordedUID))
+			removeMarker = false
 		default:
 			// curUID == recordedUID → the exact account xpf provisioned. Kill
 			// the SSH-key vector first (survives a userdel failure), then remove
@@ -398,8 +465,10 @@ func zeroizeLoginAccounts() error {
 
 // readProvisionedMarkerUID reads a provenance marker file and returns the UID
 // it records (pkg/daemon.markProvisioned writes the account's UID as decimal
-// text). A read or parse error yields the "not our account" disposition in
-// zeroizeLoginAccounts (no userdel).
+// text). A read or parse error is OWNERSHIP UNCERTAINTY: zeroizeLoginAccounts
+// FAILS CLOSED on it (#5496) — no userdel, the marker is retained, and the
+// error is surfaced so the reset is reported incomplete. It is never treated as
+// proof the marker is stale (which would silently erase it).
 func readProvisionedMarkerUID(path string) (int, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/pkg/grpcapi/zeroize_login_4598_test.go
+++ b/pkg/grpcapi/zeroize_login_4598_test.go
@@ -48,8 +48,10 @@ func setZeroizeLoginPaths(t *testing.T, provDir, sudoersDir, homeBase, passwdPat
 // /etc/shadow hashes (via userdel), SSH authorized_keys, and
 // /etc/sudoers.d/xpf-* grants — so a re-tenanted device does not grant the
 // prior tenant interactive login + passwordless sudo. It must do so
-// marker-aware: a non-xpf operator/system account, a UID-mismatch out-of-band
-// recreate, and operator-authored sudoers drop-ins are ALL left untouched.
+// marker-aware: a non-xpf operator/system account and operator-authored sudoers
+// drop-ins are left untouched. (The UID-mismatch out-of-band recreate and the
+// #5496 fail-closed uncertainty paths have their own tests, below and in
+// zeroize_login_failclosed_5496_test.go.)
 //
 // RED on revert: before this fix performZeroizeWipe tore down no OS accounts
 // (applySystemLogin runs only inside the boot-time apply, which a post-zeroize
@@ -65,47 +67,37 @@ func TestZeroizeLoginAccountsRemovesProvisionedNotOthers(t *testing.T) {
 	passwdPath := filepath.Join(root, "passwd")
 
 	// /etc/passwd: root + a system account + an operator's OWN account (no
-	// marker) + the xpf-provisioned "alice" (UID matches its marker) + "stale"
-	// whose live UID (2001) DIFFERS from its marker (2000) — an out-of-band
-	// userdel+recreate that must NOT be nuked.
+	// marker) + the xpf-provisioned "alice" (UID matches its marker).
 	mustWriteFile(t, passwdPath, []byte(
 		"root:x:0:0:root:/root:/bin/bash\n"+
 			"daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin\n"+
 			"operator:x:1000:1000:operator:/home/operator:/bin/bash\n"+
-			"alice:x:1001:1001:alice:/home/alice:/bin/bash\n"+
-			"stale:x:2001:2001:stale:/home/stale:/bin/bash\n"))
+			"alice:x:1001:1001:alice:/home/alice:/bin/bash\n"))
 
 	// Provenance markers (content = UID at provision time). "ghost" has a
 	// marker but no /etc/passwd entry (already removed out of band).
 	aliceMarker := filepath.Join(provDir, "alice")
-	staleMarker := filepath.Join(provDir, "stale")
 	ghostMarker := filepath.Join(provDir, "ghost")
 	mustWriteFile(t, aliceMarker, []byte("1001"))
-	mustWriteFile(t, staleMarker, []byte("2000")) // != live UID 2001 → not ours
 	mustWriteFile(t, ghostMarker, []byte("3000"))
 
-	// sudoers.d: three xpf-<user> grants (all removed by the namespace sweep) +
+	// sudoers.d: two xpf-<user> grants (both removed by the namespace sweep) +
 	// one operator/system drop-in without the prefix (must survive).
 	xpfAliceSudo := filepath.Join(sudoersDir, "xpf-alice")
-	xpfStaleSudo := filepath.Join(sudoersDir, "xpf-stale")
 	xpfGhostSudo := filepath.Join(sudoersDir, "xpf-ghost")
 	operatorSudo := filepath.Join(sudoersDir, "90-cloud-init-users")
 	mustWriteFile(t, xpfAliceSudo, []byte("alice ALL=(ALL) NOPASSWD: ALL\n"))
-	mustWriteFile(t, xpfStaleSudo, []byte("stale ALL=(ALL) NOPASSWD: ALL\n"))
 	mustWriteFile(t, xpfGhostSudo, []byte("ghost ALL=(ALL) NOPASSWD: ALL\n"))
 	mustWriteFile(t, operatorSudo, []byte("operator ALL=(ALL) ALL\n"))
 
 	// authorized_keys: alice (xpf → removed), ghost (gone → residue removed),
-	// operator (own account, no marker → MUST survive), stale (not ours → MUST
-	// survive: its home belongs to the recreated account).
+	// operator (own account, no marker → MUST survive).
 	aliceKeys := filepath.Join(homeBase, "alice", ".ssh", "authorized_keys")
 	ghostKeys := filepath.Join(homeBase, "ghost", ".ssh", "authorized_keys")
 	operatorKeys := filepath.Join(homeBase, "operator", ".ssh", "authorized_keys")
-	staleKeys := filepath.Join(homeBase, "stale", ".ssh", "authorized_keys")
 	mustWriteFile(t, aliceKeys, []byte("ssh-ed25519 AAAAxpf alice\n"))
 	mustWriteFile(t, ghostKeys, []byte("ssh-ed25519 AAAAghost ghost\n"))
 	mustWriteFile(t, operatorKeys, []byte("ssh-ed25519 AAAAop operator\n"))
-	mustWriteFile(t, staleKeys, []byte("ssh-ed25519 AAAAnew newowner\n"))
 
 	deleted := setZeroizeLoginPaths(t, provDir, sudoersDir, homeBase, passwdPath)
 
@@ -124,15 +116,12 @@ func TestZeroizeLoginAccountsRemovesProvisionedNotOthers(t *testing.T) {
 	assertAbsent(t, aliceKeys)
 	assertAbsent(t, ghostKeys)
 	assertAbsent(t, xpfAliceSudo)
-	assertAbsent(t, xpfStaleSudo)
 	assertAbsent(t, xpfGhostSudo)
 	assertAbsent(t, aliceMarker)
-	assertAbsent(t, staleMarker)
 	assertAbsent(t, ghostMarker)
 
 	// Safety property: NON-xpf accounts + operator sudoers are untouched.
 	assertPresent(t, operatorKeys) // operator's own account (no marker)
-	assertPresent(t, staleKeys)    // UID-mismatch recreate (not ours)
 	assertPresent(t, operatorSudo) // operator/system drop-in (no xpf- prefix)
 
 	// The empty marker directory is cleaned up.

--- a/pkg/grpcapi/zeroize_login_failclosed_5496_test.go
+++ b/pkg/grpcapi/zeroize_login_failclosed_5496_test.go
@@ -1,0 +1,194 @@
+package grpcapi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// #5496: the login-account teardown resolves account ownership from TWO reads —
+// the live UID (/etc/passwd) and the recorded UID (provenance marker). If either
+// read/parse FAILS, ownership is UNKNOWN, not proven-absent. The prior code
+// collapsed "unreadable / malformed" into the same (0,false) as "genuinely
+// absent" (and folded an unreadable marker into the stale-marker branch), so an
+// unresolved read looked like proof the account was gone: the wipe erased the
+// only provenance marker and reported a CLEAN reset (firstErr stayed nil) while
+// a live xpf-provisioned PASSWORD account survived — now un-rediscoverable
+// because its retry marker was destroyed. These tests pin the fail-CLOSED
+// contract: on uncertainty, surface an error, RETAIN the marker, make no
+// destructive account change.
+//
+// RED on revert (all four uncertainty tests): before the fix,
+// zeroizeLoginAccounts returns nil AND removes the marker in each case below, so
+// the `err == nil` and `assertPresent(marker)` assertions both fail.
+
+// TestZeroizeLoginUnreadablePasswdFailsClosed: /etc/passwd cannot be read (here a
+// directory stands in, which os.ReadFile fails on regardless of euid). The
+// account may still exist with a live credential, so the reset must fail closed.
+func TestZeroizeLoginUnreadablePasswdFailsClosed(t *testing.T) {
+	root := t.TempDir()
+	provDir := filepath.Join(root, "provisioned-users")
+	sudoersDir := filepath.Join(root, "sudoers.d")
+	homeBase := filepath.Join(root, "home")
+	passwdPath := filepath.Join(root, "passwd")
+
+	// Make /etc/passwd unreadable: a directory at the path → os.ReadFile errors
+	// (EISDIR) even when the test runs as root, so the RED path is deterministic.
+	if err := os.MkdirAll(passwdPath, 0o755); err != nil {
+		t.Fatalf("mkdir passwd dir: %v", err)
+	}
+	carolMarker := filepath.Join(provDir, "carol")
+	mustWriteFile(t, carolMarker, []byte("1700"))
+	carolKeys := filepath.Join(homeBase, "carol", ".ssh", "authorized_keys")
+	mustWriteFile(t, carolKeys, []byte("ssh-ed25519 AAAAcarol carol\n"))
+
+	deleted := setZeroizeLoginPaths(t, provDir, sudoersDir, homeBase, passwdPath)
+
+	if err := zeroizeLoginAccounts(); err == nil {
+		t.Fatalf("zeroizeLoginAccounts with an UNREADABLE /etc/passwd returned nil; want fail-closed error")
+	}
+	if len(*deleted) != 0 {
+		t.Errorf("userdel invoked %v on an unresolved /etc/passwd; want none (no destructive change)", *deleted)
+	}
+	assertPresent(t, carolMarker) // RETAINED for a safe retry
+}
+
+// TestZeroizeLoginMalformedPasswdUIDFailsClosed: the account's /etc/passwd line
+// is present but its UID field is non-numeric. The account EXISTS (the line is
+// there) but its UID cannot be resolved → uncertainty, not absence.
+func TestZeroizeLoginMalformedPasswdUIDFailsClosed(t *testing.T) {
+	root := t.TempDir()
+	provDir := filepath.Join(root, "provisioned-users")
+	sudoersDir := filepath.Join(root, "sudoers.d")
+	homeBase := filepath.Join(root, "home")
+	passwdPath := filepath.Join(root, "passwd")
+
+	mustWriteFile(t, passwdPath, []byte(
+		"root:x:0:0:root:/root:/bin/bash\n"+
+			"carol:x:notanumber:1700:carol:/home/carol:/bin/bash\n"))
+	carolMarker := filepath.Join(provDir, "carol")
+	mustWriteFile(t, carolMarker, []byte("1700"))
+	carolKeys := filepath.Join(homeBase, "carol", ".ssh", "authorized_keys")
+	mustWriteFile(t, carolKeys, []byte("ssh-ed25519 AAAAcarol carol\n"))
+
+	deleted := setZeroizeLoginPaths(t, provDir, sudoersDir, homeBase, passwdPath)
+
+	if err := zeroizeLoginAccounts(); err == nil {
+		t.Fatalf("zeroizeLoginAccounts with a MALFORMED passwd UID returned nil; want fail-closed error")
+	}
+	if len(*deleted) != 0 {
+		t.Errorf("userdel invoked %v on a malformed passwd UID; want none", *deleted)
+	}
+	assertPresent(t, carolMarker) // RETAINED
+	assertPresent(t, carolKeys)   // no destructive change on uncertainty
+}
+
+// TestZeroizeLoginUnparseableMarkerFailsClosed: /etc/passwd is fine and the
+// account exists, but the provenance marker's content is not a UID. We cannot
+// resolve OUR recorded UID → cannot decide if the live account is ours → fail
+// closed rather than silently drop the marker.
+func TestZeroizeLoginUnparseableMarkerFailsClosed(t *testing.T) {
+	root := t.TempDir()
+	provDir := filepath.Join(root, "provisioned-users")
+	sudoersDir := filepath.Join(root, "sudoers.d")
+	homeBase := filepath.Join(root, "home")
+	passwdPath := filepath.Join(root, "passwd")
+
+	mustWriteFile(t, passwdPath, []byte("carol:x:1700:1700:carol:/home/carol:/bin/bash\n"))
+	carolMarker := filepath.Join(provDir, "carol")
+	mustWriteFile(t, carolMarker, []byte("not-a-uid\n")) // unparseable content
+	carolKeys := filepath.Join(homeBase, "carol", ".ssh", "authorized_keys")
+	mustWriteFile(t, carolKeys, []byte("ssh-ed25519 AAAAcarol carol\n"))
+
+	deleted := setZeroizeLoginPaths(t, provDir, sudoersDir, homeBase, passwdPath)
+
+	if err := zeroizeLoginAccounts(); err == nil {
+		t.Fatalf("zeroizeLoginAccounts with an UNPARSEABLE marker returned nil; want fail-closed error")
+	}
+	if len(*deleted) != 0 {
+		t.Errorf("userdel invoked %v on an unparseable marker; want none", *deleted)
+	}
+	assertPresent(t, carolMarker) // RETAINED
+	assertPresent(t, carolKeys)   // no destructive change on uncertainty
+}
+
+// TestZeroizeLoginUIDMismatchReportedNonDestructive: a PROVEN UID-mismatch (live
+// UID != marker UID) is an out-of-band userdel+recreate — the current account
+// belongs to someone else, so it is left fully intact. But absent an explicit
+// durable stale-marker policy the condition is REPORTED (unresolved) and the
+// marker RETAINED rather than silently erased with a clean-reset report.
+func TestZeroizeLoginUIDMismatchReportedNonDestructive(t *testing.T) {
+	root := t.TempDir()
+	provDir := filepath.Join(root, "provisioned-users")
+	sudoersDir := filepath.Join(root, "sudoers.d")
+	homeBase := filepath.Join(root, "home")
+	passwdPath := filepath.Join(root, "passwd")
+
+	// marker says UID 2000; the live account is a recreate at UID 2001.
+	mustWriteFile(t, passwdPath, []byte("stale:x:2001:2001:stale:/home/stale:/bin/bash\n"))
+	staleMarker := filepath.Join(provDir, "stale")
+	mustWriteFile(t, staleMarker, []byte("2000"))
+	staleKeys := filepath.Join(homeBase, "stale", ".ssh", "authorized_keys")
+	mustWriteFile(t, staleKeys, []byte("ssh-ed25519 AAAAnew newowner\n"))
+
+	deleted := setZeroizeLoginPaths(t, provDir, sudoersDir, homeBase, passwdPath)
+
+	if err := zeroizeLoginAccounts(); err == nil {
+		t.Fatalf("zeroizeLoginAccounts with a UID-mismatch returned nil; want the unresolved condition reported")
+	}
+	if len(*deleted) != 0 {
+		t.Errorf("userdel invoked %v on a UID-mismatch recreate; want none (someone else's account)", *deleted)
+	}
+	assertPresent(t, staleKeys)   // the recreated owner's home is untouched
+	assertPresent(t, staleMarker) // marker RETAINED (not silently erased)
+}
+
+// TestZeroizeLoginRetryAfterFailClosedRediscovers proves the point of retaining
+// the marker: a first reset that failed closed (unreadable passwd) leaves the
+// marker AND account intact, so a SECOND reset — once /etc/passwd is readable —
+// still rediscovers the account and completes the userdel + marker removal. If
+// the first pass had erased the marker (the fail-open bug), the account would be
+// un-rediscoverable and its credential would persist forever.
+func TestZeroizeLoginRetryAfterFailClosedRediscovers(t *testing.T) {
+	root := t.TempDir()
+	provDir := filepath.Join(root, "provisioned-users")
+	sudoersDir := filepath.Join(root, "sudoers.d")
+	homeBase := filepath.Join(root, "home")
+	passwdPath := filepath.Join(root, "passwd")
+
+	daveMarker := filepath.Join(provDir, "dave")
+	mustWriteFile(t, daveMarker, []byte("1800"))
+	daveKeys := filepath.Join(homeBase, "dave", ".ssh", "authorized_keys")
+	mustWriteFile(t, daveKeys, []byte("ssh-ed25519 AAAAdave dave\n"))
+
+	// Pass 1: /etc/passwd unreadable (directory). Fail closed.
+	if err := os.MkdirAll(passwdPath, 0o755); err != nil {
+		t.Fatalf("mkdir passwd dir: %v", err)
+	}
+	deleted := setZeroizeLoginPaths(t, provDir, sudoersDir, homeBase, passwdPath)
+
+	if err := zeroizeLoginAccounts(); err == nil {
+		t.Fatalf("pass 1 (unreadable passwd) returned nil; want fail-closed error")
+	}
+	if len(*deleted) != 0 {
+		t.Errorf("pass 1 userdel invoked %v; want none", *deleted)
+	}
+	assertPresent(t, daveMarker) // marker survives for the retry
+
+	// Pass 2: /etc/passwd now readable with the account present at the marker
+	// UID. Replace the directory with a real passwd file at the same path.
+	if err := os.RemoveAll(passwdPath); err != nil {
+		t.Fatalf("remove passwd dir: %v", err)
+	}
+	mustWriteFile(t, passwdPath, []byte("dave:x:1800:1800:dave:/home/dave:/bin/bash\n"))
+
+	if err := zeroizeLoginAccounts(); err != nil {
+		t.Fatalf("pass 2 (readable passwd) returned error: %v; want a clean completion", err)
+	}
+	got := append([]string(nil), *deleted...)
+	if len(got) != 1 || got[0] != "dave" {
+		t.Errorf("pass 2 userdel invoked %v; want exactly [dave] — the rediscovered account", got)
+	}
+	assertAbsent(t, daveKeys)   // SSH vector removed
+	assertAbsent(t, daveMarker) // marker cleared only after the successful teardown
+}


### PR DESCRIPTION
## Summary

Fixes a **fail-open** in the factory-reset (`zeroize`) login-account teardown
(`pkg/grpcapi/server_diag_zeroize.go`). The teardown decided whether an OS
account was xpf-provisioned from two reads — the live UID (`/etc/passwd`) and
the recorded UID (the provenance marker). `zeroizeLookupUID` collapsed THREE
outcomes into one boolean (found / genuinely-absent / **could-not-read-or-parse**
→ all `ok=false`), and `readProvisionedMarkerUID`'s error shared the
stale-marker branch. So an **unreadable `/etc/passwd`**, a **malformed UID**, or
an **unreadable/unparseable marker** looked exactly like proof the account was
gone: the wipe erased the marker, recorded **no** error, and returned `nil`.

Consequence: an xpf-provisioned interactive **PASSWORD** account could SURVIVE
while its only retry-provenance marker was erased. `performZeroizeWipe` then
returns `nil` and `SystemAction` reports a completed factory reset — but repeated
resets can no longer rediscover the account (marker gone), so the removed
operator's credential **persists** for the next tenant.

## Fix — ownership uncertainty fails CLOSED

Introduce `zeroizeLookupUIDErr`, a three-state resolver
(`found` / `readable-but-absent` / `read-or-parse-error`), mirroring
`lookupUIDGIDErr` from the **day-2 login sibling #5493 (merged as PR #5500)** —
same discipline, distinct locus (factory reset vs. `applyConfig` deprovision).
`zeroizeLoginAccounts` now distinguishes:

- **genuine absence** (passwd readable, name absent): unchanged — orphan-key
  cleanup, drop the stale marker;
- **read/parse ERROR** (passwd unreadable, malformed UID, unreadable/unparseable
  marker): **fail closed** — record the error (so `performZeroizeWipe` returns
  non-nil = incomplete), **retain** the marker, no destructive account change;
- **proven UID-mismatch** (out-of-band recreate): still non-destructive, now
  **reported** (unresolved) with the marker retained, absent an explicit durable
  stale-marker policy.

The genuine-absence and successful-`userdel` paths are preserved bit-for-bit.

This is the **factory-reset sibling of #5493** (day-2 login); it is a distinct
locus from #4598 (which introduced the teardown).

## Tests (`pkg/grpcapi`)

- true-absence → reset completes, marker removed;
- unreadable passwd / malformed UID / unparseable marker → fail closed (error
  surfaced, marker RETAINED, no `userdel`);
- UID-mismatch → non-destructive, reported, marker retained, home untouched;
- retry → after a fail-closed reset, a subsequent reset still finds the marker +
  account and completes the `userdel`.

### RED on revert
With the resolver/switch reverted to `origin/master` and the new tests kept, all
five fail-closed tests FAIL — `zeroizeLoginAccounts` returns `nil` and removes
the marker (the fail-open). Restored → all green.

```
--- FAIL: TestZeroizeLoginUnreadablePasswdFailsClosed
    zeroizeLoginAccounts with an UNREADABLE /etc/passwd returned nil; want fail-closed error
--- FAIL: TestZeroizeLoginMalformedPasswdUIDFailsClosed
--- FAIL: TestZeroizeLoginUnparseableMarkerFailsClosed
--- FAIL: TestZeroizeLoginUIDMismatchReportedNonDestructive
--- FAIL: TestZeroizeLoginRetryAfterFailClosedRediscovers
```

## Validation
- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` — clean
- `go test ./pkg/grpcapi/...` — ok

Docs: `docs/system-login.md` gains the #5496 fail-closed rule and updates the
UID-mismatch note.

Closes #5496

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV9EyKeSX33A4BhqZVyJTF