### PR TITLE
device-map: fail closed on unreadable NIC inventory (#5490)

### DIFF
--- a/docs/bare-metal-device-map.md
+++ b/docs/bare-metal-device-map.md
@@ -171,6 +171,29 @@ the present hardware while you are still connected:
 - `commit confirmed` validates BOTH the candidate AND the rollback target
   (the config restored on timeout), so a confirmed-commit timeout reverts to
   a known-safe config and applies it unconditionally (no split-brain).
+- **The pre-flight fails CLOSED on an unreadable NIC inventory (#5490).** If
+  the present-NIC scan (a cold-path sysfs/netlink read) fails, the commit is
+  **rejected** — the strand-management safety check cannot run, so the commit
+  is refused rather than accepted unvalidated. (Earlier this was a
+  skip-with-warning that silently accepted the commit; a candidate that moved
+  the live management NIC to a non-management name was then applied verbatim at
+  next boot — a durable lockout the confirmed-commit rollback could not undo,
+  because its rollback target was never validated either.) Re-commit once the
+  hardware inventory is readable. The #1922 lifeline guards the *live* mgmt NIC
+  but does not veto an explicit mapped rename, so it is not a substitute for
+  this gate. The same fail-closed applies to `bootstrapFromFile`: an unreadable
+  inventory leaves the daemon in the lifeline-safe bootstrap state (console +
+  fxp0 DHCP) rather than committing an unvalidated map — strictly safer than
+  coming up with an unchecked device-map.
+
+The **boot-time mapped rename re-runs the strand detector (#5490)**: before
+`enumerateAndRenameMapped` applies any mapped rename it re-validates the active
+map against the present hardware and, if the map would strand management,
+**refuses to rename** (retaining the current interface naming so management
+stays reachable) and logs loudly. This is the backstop for a candidate that was
+already committed to the store before this gate existed (or accepted under the
+old fail-open commit path): the unsafe binding is caught at the boot where it
+would first be applied, not after it has locked the operator out.
 
 The SAME pre-flight now runs on the **day-0 / bootstrap paths** (#4183):
 

--- a/pkg/daemon/device_map.go
+++ b/pkg/daemon/device_map.go
@@ -166,6 +166,32 @@ func enumerateAndRenameMapped(dm *config.DeviceMapConfig, cfg *config.Config, pr
 	if err != nil {
 		return fmt.Errorf("enumerate NICs: %w", err)
 	}
+	// #5490 boot-time re-check: re-run the strand-management detector against
+	// the now-readable hardware BEFORE performing ANY mapped rename. This closes
+	// the "already-committed candidate strands at next boot" gap — a candidate
+	// accepted at commit time (committed before this fix, or accepted under the
+	// old fail-open commit path when commit-time enumeration transiently failed)
+	// would otherwise perform its now-readable UNSAFE binding here without any
+	// re-validation, causing a durable management lockout that the #1922 lifeline
+	// does not veto (it does not block an explicit mapped rename in phase 2).
+	// If the map would strand management, FAIL CLOSED: retain the current
+	// interface naming (management stays reachable under its present name) and
+	// return an error so the one-shot retry marker is preserved and boot/config-
+	// arrival sites surface it loudly. The rename never runs, so no .link is
+	// written and no NIC is moved. The check is skipped only when there is no
+	// protected set to strand (len==0 — non-production; every real boot passes a
+	// non-empty set from resolveProtectedInterfaces), which keeps the strand
+	// detector's "empty protected == nothing to protect" contract intact.
+	if len(protected) > 0 {
+		lifelineName, _ := resolveLifelineCurrentName()
+		if reason := deviceMapStrandsManagement(cfg, nics, protected, lifelineName); reason != "" {
+			slog.Error("device-map: REFUSING to apply mapped interface renames at boot — the active "+
+				"device-map would strand management on next boot. Retaining the current interface "+
+				"naming so management stays reachable; fix the device-map and re-commit.",
+				"reason", reason)
+			return fmt.Errorf("device-map boot rename refused (fail-closed, #5490): %s", reason)
+		}
+	}
 	// renameErrs accumulates every phase-2/3 rename and phase-4 reload failure
 	// so the function fails (not launders) while still completing every phase.
 	var renameErrs []error
@@ -472,10 +498,23 @@ func (d *Daemon) deviceMapCommitPreflight(candidate, rollbackTarget *config.Conf
 	}
 	nics, err := enumeratePresentNICsFn()
 	if err != nil {
-		// Cannot enumerate hardware — do not block the commit on a
-		// transient sysfs error; the #1922 lifeline is the backstop.
-		slog.Warn("device-map pre-flight: NIC enumeration failed; skipping (lifeline still protects mgmt)", "err", err)
-		return nil
+		// #5490 FAIL CLOSED. A transient sysfs/netlink enumeration error means
+		// the strand-management safety check CANNOT run. The old behavior
+		// (slog.Warn + return nil) laundered an unvalidated device-map to a
+		// SUCCESSFUL commit: a candidate that moves the live management NIC to a
+		// non-management name (without assigning another NIC a protected name)
+		// was accepted here and then applied VERBATIM at next boot by
+		// enumerateAndRenameMapped — a durable management lockout that even a
+		// confirmed-commit rollback could not undo (its rollback target was
+		// never validated either). The #1922 lifeline guards the LIVE mgmt NIC
+		// but does NOT veto an explicit mapped rename in phase 2, so it is not a
+		// substitute for this check. Reject the commit while the operator is
+		// still connected rather than risk the lockout. Enumeration is a
+		// cold-path scan (no forwarding cost), so failing closed here is cheap.
+		return fmt.Errorf("device-map commit rejected: cannot read the present NIC inventory "+
+			"to validate that the device-map will not strand management on next boot (%w); "+
+			"refusing the commit rather than risk a durable management lockout — retry once the "+
+			"hardware inventory is readable", err)
 	}
 	// The lifeline NIC's CURRENT kernel name, resolved by its persisted
 	// IDENTITY — correct even before the rename (Codex HIGH-2).

--- a/pkg/daemon/device_map_preflight_failclosed_5490_test.go
+++ b/pkg/daemon/device_map_preflight_failclosed_5490_test.go
@@ -1,0 +1,225 @@
+package daemon
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5490: the device-map commit pre-flight and the boot-time mapped-rename must
+// both FAIL CLOSED on unknown NIC inventory. Before the fix, a transient
+// sysfs/netlink enumeration error at commit time skipped the strand-management
+// safety check and returned SUCCESS, so a management-stranding device-map was
+// accepted and then applied verbatim at next boot (durable lockout). These
+// tests pin both halves of the fix.
+
+// enumErrSeam points enumeratePresentNICsFn at a stub that ALWAYS fails, to
+// simulate a transient hardware-inventory read error, and forces the lifeline
+// record to resolve to "" so the strand detector is deterministic.
+func enumErrSeam(t *testing.T) {
+	t.Helper()
+	saved := enumeratePresentNICsFn
+	enumeratePresentNICsFn = func() ([]presentNIC, error) {
+		return nil, fmt.Errorf("simulated transient sysfs/netlink enumeration failure")
+	}
+	t.Cleanup(func() { enumeratePresentNICsFn = saved })
+	lifelineRecordFileForTest = filepath.Join(t.TempDir(), "no-lifeline")
+	t.Cleanup(func() { lifelineRecordFileForTest = "" })
+}
+
+func deviceMapCfg(entries ...config.DeviceMapEntry) *config.Config {
+	return &config.Config{Chassis: config.ChassisConfig{DeviceMap: &config.DeviceMapConfig{
+		Entries: entries,
+	}}}
+}
+
+// TestDeviceMapCommitPreflight_EnumErrorFailsClosed_5490 is the primary
+// RED-on-revert. A transient NIC-enumeration failure at commit pre-flight must
+// REJECT both a plain commit AND a confirmed commit whose candidate engages
+// device-map mode — not skip the strand check and return nil.
+//
+// Revert: change the enumeration-error branch back to `slog.Warn(...); return
+// nil` and this test goes RED (both commits accepted, fail-open).
+func TestDeviceMapCommitPreflight_EnumErrorFailsClosed_5490(t *testing.T) {
+	enumErrSeam(t)
+	d := &Daemon{}
+
+	cand := deviceMapCfg(config.DeviceMapEntry{LogicalName: "ge-0/0/3", PCIAddr: "0000:09:00.0"})
+
+	// Plain commit (no rollback target).
+	if err := d.deviceMapCommitPreflight(cand, nil); err == nil {
+		t.Fatal("plain-commit pre-flight must FAIL CLOSED when NIC enumeration fails, not skip and return nil")
+	}
+
+	// Confirmed commit (rollback target also engages device-map). Both the
+	// candidate and the rollback target must be validated; an unreadable
+	// inventory means neither can be, so the commit is rejected.
+	rb := deviceMapCfg(config.DeviceMapEntry{LogicalName: "ge-0/0/4", PCIAddr: "0000:0a:00.0"})
+	if err := d.deviceMapCommitPreflight(cand, rb); err == nil {
+		t.Fatal("confirmed-commit pre-flight must FAIL CLOSED when NIC enumeration fails")
+	}
+}
+
+// TestDeviceMapCommitPreflight_EnumErrorFastPathStillSkips_5490 guards against
+// over-gating: a candidate that does NOT engage device-map mode must still be
+// accepted even when enumeration would fail, because the fast path returns
+// before any enumeration (nothing to validate).
+func TestDeviceMapCommitPreflight_EnumErrorFastPathStillSkips_5490(t *testing.T) {
+	enumErrSeam(t)
+	d := &Daemon{}
+
+	// No device-map on either config -> fast path, never enumerates.
+	plain := &config.Config{System: config.SystemConfig{HostName: "plain"}}
+	if err := d.deviceMapCommitPreflight(plain, nil); err != nil {
+		t.Fatalf("a non-device-map commit must not be gated by the enumeration failure: %v", err)
+	}
+}
+
+// TestDeviceMapCommitPreflight_StrandingCandidateRejected_5490 pins the
+// pre-existing behavior: with READABLE NICs, a candidate whose map would strand
+// management (a different NIC steals the mgmt name) is still rejected.
+func TestDeviceMapCommitPreflight_StrandingCandidateRejected_5490(t *testing.T) {
+	saved := enumeratePresentNICsFn
+	enumeratePresentNICsFn = func() ([]presentNIC, error) {
+		return []presentNIC{
+			{Name: "fxp0", PCIAddr: "0000:05:00.0"},   // live mgmt NIC (currently fxp0)
+			{Name: "enp9s0", PCIAddr: "0000:09:00.0"}, // would become fxp0
+		}, nil
+	}
+	t.Cleanup(func() { enumeratePresentNICsFn = saved })
+	lifelineRecordFileForTest = filepath.Join(t.TempDir(), "no-lifeline")
+	t.Cleanup(func() { lifelineRecordFileForTest = "" })
+
+	// Map a DIFFERENT NIC onto the management name fxp0 -> the live mgmt NIC
+	// loses its name / a rename collision on fxp0 -> strand.
+	cand := deviceMapCfg(config.DeviceMapEntry{LogicalName: "fxp0", PCIAddr: "0000:09:00.0"})
+	d := &Daemon{}
+	if err := d.deviceMapCommitPreflight(cand, nil); err == nil {
+		t.Fatal("a management-stranding candidate must be rejected even with readable NICs")
+	}
+}
+
+// TestDeviceMapCommitPreflight_NormalPathUnaffected_5490 proves the fix does
+// not over-gate the happy path: with readable NICs and a non-stranding map
+// (mgmt NIC mapped to its own name), the commit pre-flight accepts.
+func TestDeviceMapCommitPreflight_NormalPathUnaffected_5490(t *testing.T) {
+	saved := enumeratePresentNICsFn
+	enumeratePresentNICsFn = func() ([]presentNIC, error) {
+		return []presentNIC{
+			{Name: "fxp0", PCIAddr: "0000:05:00.0"},
+			{Name: "enp9s0", PCIAddr: "0000:09:00.0"},
+		}, nil
+	}
+	t.Cleanup(func() { enumeratePresentNICsFn = saved })
+	lifelineRecordFileForTest = filepath.Join(t.TempDir(), "no-lifeline")
+	t.Cleanup(func() { lifelineRecordFileForTest = "" })
+
+	cand := deviceMapCfg(
+		config.DeviceMapEntry{LogicalName: "fxp0", PCIAddr: "0000:05:00.0"},     // mgmt NIC -> its own name
+		config.DeviceMapEntry{LogicalName: "ge-0/0/3", PCIAddr: "0000:09:00.0"}, // data NIC
+	)
+	d := &Daemon{}
+	if err := d.deviceMapCommitPreflight(cand, nil); err != nil {
+		t.Fatalf("a non-stranding readable candidate must be accepted: %v", err)
+	}
+}
+
+// TestEnumerateAndRenameMapped_BootRecheckFailsClosed_5490 pins part (b): even
+// if a stranding candidate was accepted at commit time (before this fix, or via
+// a transient commit-time enumeration failure under the old fail-open path),
+// the boot-time mapped rename must re-run the strand detector and REFUSE to
+// perform the unsafe rename — retaining current naming so management stays
+// reachable.
+//
+// Revert: remove the boot-time re-check block in enumerateAndRenameMapped and
+// this test goes RED — the stranding rename is performed and no error returns.
+func TestEnumerateAndRenameMapped_BootRecheckFailsClosed_5490(t *testing.T) {
+	withTempLinkDir(t)
+	lifelineRecordFileForTest = filepath.Join(t.TempDir(), "no-lifeline")
+	t.Cleanup(func() { lifelineRecordFileForTest = "" })
+
+	savedEnum := enumeratePresentNICsFn
+	enumeratePresentNICsFn = func() ([]presentNIC, error) {
+		return []presentNIC{
+			{Name: "fxp0", PCIAddr: "0000:05:00.0"},   // live mgmt NIC
+			{Name: "enp9s0", PCIAddr: "0000:09:00.0"}, // would become fxp0
+		}, nil
+	}
+	t.Cleanup(func() { enumeratePresentNICsFn = savedEnum })
+
+	var renameCalls int
+	savedRename := renameInterfaceFn
+	renameInterfaceFn = func(from, to string) error { renameCalls++; return nil }
+	t.Cleanup(func() { renameInterfaceFn = savedRename })
+
+	var reloadCalls int
+	savedReload := networkctlReloadFn
+	networkctlReloadFn = func() error { reloadCalls++; return nil }
+	t.Cleanup(func() { networkctlReloadFn = savedReload })
+
+	// A different NIC mapped onto fxp0 -> the map would strand management.
+	dm := &config.DeviceMapConfig{
+		Entries: []config.DeviceMapEntry{{LogicalName: "fxp0", PCIAddr: "0000:09:00.0"}},
+	}
+	cfg := &config.Config{Chassis: config.ChassisConfig{DeviceMap: dm}}
+	protected := map[string]bool{"fxp0": true}
+
+	err := enumerateAndRenameMapped(dm, cfg, protected)
+	if err == nil {
+		t.Fatal("boot re-check must FAIL CLOSED (return error) for a stranding device-map, " +
+			"not perform the unsafe rename")
+	}
+	if renameCalls != 0 {
+		t.Fatalf("boot re-check must NOT rename any interface when the map would strand "+
+			"management; got %d rename call(s)", renameCalls)
+	}
+	if reloadCalls != 0 {
+		t.Fatalf("boot re-check must NOT reload networkd on the fail-closed path; got %d reload call(s)", reloadCalls)
+	}
+}
+
+// TestEnumerateAndRenameMapped_BootRecheckAllowsSafeMap_5490 guards against
+// over-gating the boot path: with readable NICs and a non-stranding map (mgmt
+// NIC mapped to its own name, a data NIC renamed), the mapped rename proceeds
+// and the data NIC gets renamed as before.
+func TestEnumerateAndRenameMapped_BootRecheckAllowsSafeMap_5490(t *testing.T) {
+	withTempLinkDir(t)
+	lifelineRecordFileForTest = filepath.Join(t.TempDir(), "no-lifeline")
+	t.Cleanup(func() { lifelineRecordFileForTest = "" })
+
+	savedEnum := enumeratePresentNICsFn
+	enumeratePresentNICsFn = func() ([]presentNIC, error) {
+		return []presentNIC{
+			{Name: "fxp0", PCIAddr: "0000:05:00.0"},   // mgmt NIC already at fxp0
+			{Name: "enp9s0", PCIAddr: "0000:09:00.0"}, // data NIC -> ge-0-0-3
+		}, nil
+	}
+	t.Cleanup(func() { enumeratePresentNICsFn = savedEnum })
+
+	var renameCalls int
+	savedRename := renameInterfaceFn
+	renameInterfaceFn = func(from, to string) error { renameCalls++; return nil }
+	t.Cleanup(func() { renameInterfaceFn = savedRename })
+
+	savedReload := networkctlReloadFn
+	networkctlReloadFn = func() error { return nil }
+	t.Cleanup(func() { networkctlReloadFn = savedReload })
+
+	dm := &config.DeviceMapConfig{
+		Entries: []config.DeviceMapEntry{
+			{LogicalName: "fxp0", PCIAddr: "0000:05:00.0"},
+			{LogicalName: "ge-0/0/3", PCIAddr: "0000:09:00.0"},
+		},
+	}
+	cfg := &config.Config{Chassis: config.ChassisConfig{DeviceMap: dm}}
+	protected := map[string]bool{"fxp0": true}
+
+	if err := enumerateAndRenameMapped(dm, cfg, protected); err != nil {
+		t.Fatalf("a safe (non-stranding) map must proceed at boot, got error: %v", err)
+	}
+	if renameCalls == 0 {
+		t.Fatal("a safe map must still rename the data NIC (enp9s0 -> ge-0-0-3); got 0 rename calls")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #5490.

The #1956 bare-metal device-map commit pre-flight (`deviceMapCommitPreflight`, `pkg/daemon/device_map.go`) **failed open** on an unreadable NIC inventory:

```go
nics, err := enumeratePresentNICsFn()
if err != nil { slog.Warn(...); return nil }   // <- skipped the safety check, returned SUCCESS
```

A transient sysfs/netlink enumeration error laundered an unvalidated device-map to an **accepted commit** for the plain-commit, confirmed-commit, and bootstrap callers — validating neither the candidate nor the rollback target. A candidate that moves the live management NIC to a non-management name (without assigning another NIC a protected name) was accepted, then at next boot `applyStartupNamingPolicy` dispatched straight to `enumerateAndRenameMapped` and performed the now-readable **unsafe binding with no re-check → durable management lockout** (which even a confirmed-commit rollback could not undo). The #1922 lifeline guards the *live* mgmt NIC but does **not** veto an explicit mapped rename in phase 2, so it is not a substitute.

**Invariant enforced:** device-map commit/boot topology validation must fail **closed** on unknown NIC inventory (cold-path scan, no forwarding cost).

## Changes

**(a) Commit pre-flight fails closed.** On enumeration failure, `deviceMapCommitPreflight` now **rejects** the commit with an error explaining the NIC inventory is unreadable so the strand check cannot run — covering plain-commit and confirmed-commit (both candidate and rollback target validated as before when enumeration succeeds).

**(b) Boot-time re-check.** Before `enumerateAndRenameMapped` performs any mapped rename, it re-runs `deviceMapStrandsManagement` against the now-readable hardware and, if the map would strand management, **refuses to rename** (retains current interface naming so management stays reachable) and returns an error so the one-shot retry marker is preserved and boot/config-arrival sites log loudly. This closes the "already-committed candidate strands at next boot" gap even for a candidate accepted before this fix. The re-check is skipped only when the protected set is empty (`len==0`, non-production; every real boot passes a non-empty set from `resolveProtectedInterfaces`), preserving the strand detector's "empty protected == nothing to protect" contract and the enumeration-SUCCESS behavior bit-for-bit.

## Bootstrap-path adjudication

`bootstrapFromFile` routes through `deviceMapCommitPreflight`, so it now fails closed too. **This does not brick first boot.** The fallback on a rejected bootstrap is the **lifeline-safe bootstrap state** (console + fxp0 DHCP via `setupBootstrapLifeline`), which is strictly safer than committing an unvalidated device-map that could come up console-only or locked out. Failing bootstrap closed on an unreadable inventory keeps management reachable; the operator re-imports once the hardware is readable. Part (b) is the additional backstop for any candidate that reaches the store unvalidated.

`xpfd check-config` (`CheckDeviceMapStrandsManagement`) is intentionally left unchanged: it is an **off-target static pre-install** gate (built on a build host / run from a deploy host where the target's NICs are absent), so its skip-with-warning on enum error is correct and is a different code path from the on-target runtime commit gate this PR fixes.

## Tests

New `pkg/daemon/device_map_preflight_failclosed_5490_test.go`:
- transient-enum-error at commit pre-flight → plain-commit **and** confirmed-commit rejected (fail closed), not skipped;
- non-device-map commit still accepted under the enum failure (fast path, no over-gating);
- readable NICs + management-stranding candidate → still rejected;
- readable NICs + non-stranding candidate → accepted;
- boot-time: a stranding mapped candidate → `enumerateAndRenameMapped` performs **no** rename/reload and returns an error;
- boot-time: a safe map still renames the data NIC as before.

### RED-on-revert evidence

Stashing `pkg/daemon/device_map.go` (keeping the tests) and re-running:

```
--- FAIL: TestDeviceMapCommitPreflight_EnumErrorFailsClosed_5490   (fail-open: both commits accepted)
--- PASS: TestDeviceMapCommitPreflight_EnumErrorFastPathStillSkips_5490
--- PASS: TestDeviceMapCommitPreflight_StrandingCandidateRejected_5490
--- PASS: TestDeviceMapCommitPreflight_NormalPathUnaffected_5490
--- FAIL: TestEnumerateAndRenameMapped_BootRecheckFailsClosed_5490  (unsafe rename performed, no error)
--- PASS: TestEnumerateAndRenameMapped_BootRecheckAllowsSafeMap_5490
```

The two core fail-closed tests go RED without the patch; the over-gating guard tests stay green both ways. Restored → all six PASS.

## Validation

- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` — clean
- `go test ./pkg/daemon/...` — pass, except the pre-existing `TestApplyInterfaceReconcileFailsClosedOnXfrmCreateFailure`, which fails on the pristine baseline (`origin/master` @ d845c8b69) too — it needs netlink privileges the sandbox lacks (unrelated to this change; verified by stashing the patch).
- `gofmt` + `go vet ./pkg/daemon/` — clean
- `docs/bare-metal-device-map.md` updated with the fail-closed commit-preflight + boot-recheck contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gh9J9xUw4wTiwcHy7sLm8