### PR TITLE
configstore: keep confirm.json until rollback is durable (#5473)

### DIFF
--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -347,6 +347,33 @@ per-path:
   a crash in the microseconds between the `writeActive` syscall and the
   `confirm.json` write leaves no `confirm.json` — vastly smaller than
   the whole multi-minute window this closes.
+- **`confirm.json` removal is ordered AFTER the resolving write is
+  durable (#5473).** Resolving a pending window is a **degrade-not-fail**
+  operation at three loci — the timeout auto-rollback (`PromoteRollback`),
+  boot recovery (`recoverPendingConfirmLocked`), and an HA config-sync that
+  supersedes the window (`SyncApply`): each promotes the replacement config
+  in memory and then runs an active-config write that MAY fail (Option B —
+  the in-memory revert/apply is the safety property and always stands). The
+  removal of `confirm.json` is the **crash-recovery-lifecycle** transition
+  and must not happen until that replacement is DURABLE. Before this fix all
+  three unconditionally deleted `confirm.json` even when the write FAILED:
+  on-disk `active.json` was still the pre-rollback config `C`, and the record
+  that would re-drive the rollback to the target `A` was gone — so a crash
+  before the degraded-persist retry healed booted `C` (the exact config
+  `commit confirmed` was meant to revert) with NO recovery record. Now the
+  removal is gated on the write: on SUCCESS `confirm.json` is removed exactly
+  as before (durable transition, idempotent on the microsecond crash window);
+  on FAILURE it is RETAINED and its removal is DEFERRED
+  (`confirmResolvePendingPersist`) until the replacement lands durably — the
+  persist-retry heal or any superseding commit/sync finalizes it via
+  `clearConfirmResolutionPendingLocked`. Fail-closed: a crash while the write
+  is un-healed boots into a state that RE-RUNS the rollback to `A` (the
+  persisted deadline having passed) rather than stranding `C`. `SyncApply`
+  cancels the timer with `cancelPendingConfirmTimerLocked` (the timer-half of
+  `clearPendingConfirmLocked`) precisely so `confirm.json` removal can be
+  ordered after its degrade-not-fail write. Distinct from #4864 (which made
+  the delete itself dir-fsync-durable): #4864 fixes HOW the record is deleted,
+  #5473 fixes WHEN.
 - **Durable deletes match durable writes (#5197).** A delete of a
   secret-bearing artifact fsyncs its parent directory so the removal is
   durable, mirroring the `fsatomic.WriteFileDurable` its writer used — a

--- a/pkg/configstore/confirm_rollback_durable_5473_test.go
+++ b/pkg/configstore/confirm_rollback_durable_5473_test.go
@@ -1,0 +1,320 @@
+package configstore
+
+// #5473: a commit-confirmed recovery record (confirm.json) must NOT be removed
+// until the rollback (or authoritative replacement) it guards is DURABLE on
+// disk.
+//
+// The three resolution loci — the timeout auto-rollback (PromoteRollback), boot
+// recovery (recoverPendingConfirmLocked), and an HA config-sync that supersedes
+// a pending window (SyncApply) — used to promote the replacement in memory, run
+// a degrade-not-fail active write, and then UNCONDITIONALLY delete confirm.json.
+// On a write FAILURE the on-disk active config is still the PRE-rollback config
+// (C) while the record that would re-drive the rollback to the target (A) is
+// gone. A crash before the degraded retry heals then boots C — the exact config
+// `commit confirmed` was supposed to revert — with no recovery record.
+//
+// These tests inject an active-write failure at each locus and assert the
+// crash-recovery contract: on write FAILURE confirm.json is RETAINED and a
+// subsequent boot re-drives the rollback to A; on write SUCCESS confirm.json is
+// removed exactly as before.
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// forceConfirmDeadlinePast rewrites the persisted confirm.json deadline into the
+// past over the DB at path, so a fresh Store.Load hits the EXPIRED recovery
+// branch deterministically (the public minutes API cannot express a sub-minute
+// window). Mirrors the #4577 test's technique.
+func forceConfirmDeadlinePast(t *testing.T, path string) {
+	t.Helper()
+	s := newTestStoreAt(t, path)
+	rec, err := s.db.ReadConfirm()
+	if err != nil || rec == nil {
+		t.Fatalf("forceConfirmDeadlinePast: ReadConfirm rec=%v err=%v (record must be retained)", rec, err)
+	}
+	rec.Deadline = time.Now().Add(-2 * time.Minute)
+	if err := s.db.WriteConfirm(rec); err != nil {
+		t.Fatalf("forceConfirmDeadlinePast: WriteConfirm: %v", err)
+	}
+}
+
+// TestAutoRollback_PersistFailureRetainsConfirmRecord_5473 pins the timeout
+// auto-rollback locus (PromoteRollback). A failed rollback active write must
+// KEEP confirm.json so a crash before the degraded retry heals boots into a
+// state that RE-RUNS the rollback to the pre-confirm target (Base), not the
+// unconfirmed committed config the failed write left on disk.
+func TestAutoRollback_PersistFailureRetainsConfirmRecord_5473(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+
+	s := newTestStoreAt(t, path)
+	commitBaseline(t, s) // confirmed base A: trust only
+	baseSet := s.ShowActiveSet()
+
+	// Long backoff so the degraded retry does NOT heal during the crash
+	// simulation below — we are proving the ON-DISK recovery record, not the
+	// in-process heal.
+	s.SetPersistRetryBackoffForTesting(time.Hour, time.Hour)
+
+	// Pending confirmed commit C (persists fine; disk now holds the unconfirmed
+	// candidate + confirm.json whose rollback target is A).
+	if err := s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if err := s.SetFromInput("security zones security-zone untrust interfaces eth1.0"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := s.CommitConfirmed(1); err != nil {
+		t.Fatalf("CommitConfirmed: %v", err)
+	}
+	if rec, err := s.db.ReadConfirm(); err != nil || rec == nil {
+		t.Fatalf("armed confirm.json must exist: rec=%v err=%v", rec, err)
+	}
+	gen := s.ConfirmGenForTesting()
+
+	// Disk breaks before the timer fires.
+	s.SetWriteActiveForTesting(failingWriteActive)
+
+	// Fire the real auto-rollback timer dispatch (no executor -> performAutoRollback).
+	s.InvokeRollbackTimerForTesting(gen)
+
+	// In-memory rollback proceeded (the safety property is unconditional).
+	if got := s.ShowActiveSet(); got != baseSet {
+		t.Errorf("rollback did not revert active in memory:\nwant: %s\ngot: %s", baseSet, got)
+	}
+	if s.IsConfirmPending() {
+		t.Error("in-memory confirm window must be resolved after auto-rollback")
+	}
+	if !s.ConfigPersistDegraded() {
+		t.Fatal("degraded flag must be set after a failed rollback persist")
+	}
+
+	// #5473 core: the recovery record MUST survive a failed rollback write.
+	// (RED-on-revert: the pre-#5473 unconditional removeConfirmState deletes it.)
+	rec, err := s.db.ReadConfirm()
+	if err != nil {
+		t.Fatalf("ReadConfirm: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("confirm.json was DELETED despite the failed rollback write — a crash now " +
+			"boots the unconfirmed config with NO recovery record (#5473 regression)")
+	}
+	// The retained record's target is A (Base), so recovery re-drives the
+	// rollback to the pre-confirm config — not the unconfirmed committed config.
+	if prevSet := rec.PrevTree.FormatSet(); strings.Contains(prevSet, "untrust") {
+		t.Errorf("retained rollback target must be the pre-confirm config (A), got:\n%s", prevSet)
+	}
+
+	// Simulate a crash before the retry heals: a fresh Store over the same
+	// .configdb (its writeActive works) must re-drive the rollback to A.
+	forceConfirmDeadlinePast(t, path)
+	s2 := newTestStoreAt(t, path)
+	if err := s2.Load(); err != nil {
+		t.Fatalf("boot Load after crash: %v", err)
+	}
+	if got := s2.ShowActiveSet(); got != baseSet {
+		t.Fatalf("boot recovery did not re-drive the rollback to A:\nwant: %s\ngot: %s\n"+
+			"(the unconfirmed config became permanent — #5473)", baseSet, got)
+	}
+	if r, err := s2.db.ReadConfirm(); err != nil || r != nil {
+		t.Fatalf("confirm.json must be removed once the boot rollback is durable: rec=%v err=%v", r, err)
+	}
+}
+
+// TestAutoRollback_PersistSuccessRemovesConfirmRecord_5473 is the success
+// control: when the rollback write SUCCEEDS, confirm.json is removed exactly as
+// before the fix (the durable-transition success path is unchanged).
+func TestAutoRollback_PersistSuccessRemovesConfirmRecord_5473(t *testing.T) {
+	s := newTestStore(t)
+	commitBaseline(t, s)
+	baseSet := s.ShowActiveSet()
+
+	if err := s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if err := s.SetFromInput("security zones security-zone untrust interfaces eth1.0"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := s.CommitConfirmed(1); err != nil {
+		t.Fatalf("CommitConfirmed: %v", err)
+	}
+	gen := s.ConfirmGenForTesting()
+
+	s.InvokeRollbackTimerForTesting(gen) // writeActive succeeds (no seam)
+
+	if got := s.ShowActiveSet(); got != baseSet {
+		t.Errorf("rollback landed on the wrong config:\nwant: %s\ngot: %s", baseSet, got)
+	}
+	if s.ConfigPersistDegraded() {
+		t.Error("a successful rollback persist must not flag degraded")
+	}
+	if rec, err := s.db.ReadConfirm(); err != nil || rec != nil {
+		t.Fatalf("a durable rollback must remove confirm.json: rec=%v err=%v", rec, err)
+	}
+}
+
+// TestConfirmRecovery_PersistFailureRetainsConfirmRecord_5473 pins the boot
+// recovery locus (recoverPendingConfirmLocked). When the confirm window expired
+// during downtime and the recovery rollback's active write fails, confirm.json
+// must be RETAINED so a second crash still re-drives the rollback to A.
+func TestConfirmRecovery_PersistFailureRetainsConfirmRecord_5473(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	_ = armedConfirmStore(t, path, 10) // Base (A) confirmed, then Confirmed (C) unconfirmed
+	forceConfirmDeadlinePast(t, path)  // expired during downtime
+
+	// Boot with a broken disk AND a long retry backoff so the recovery
+	// rollback's write fails and does not heal in-process.
+	s := newTestStoreAt(t, path)
+	s.SetPersistRetryBackoffForTesting(time.Hour, time.Hour)
+	s.SetWriteActiveForTesting(failingWriteActive)
+	if err := s.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// In-memory recovery reverted to A even though the disk write failed.
+	got := s.ActiveConfig()
+	if got == nil {
+		t.Fatal("ActiveConfig is nil after recovery rollback")
+	}
+	if got.System.HostName != "Base" {
+		t.Fatalf("recovery must revert to A in memory: host-name=%q want Base", got.System.HostName)
+	}
+	if !s.ConfigPersistDegraded() {
+		t.Fatal("degraded flag must be set after a failed recovery-rollback persist")
+	}
+
+	// #5473 core: the recovery record survives the failed recovery write.
+	// (RED-on-revert: pre-#5473 deletes it, and disk active.json is still C.)
+	rec, err := s.db.ReadConfirm()
+	if err != nil {
+		t.Fatalf("ReadConfirm: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("confirm.json was DELETED despite the failed recovery write — a second crash " +
+			"would boot the unconfirmed config C permanently (#5473 regression)")
+	}
+
+	// Second crash: a fresh boot with a working disk finishes the rollback to A.
+	s2 := newTestStoreAt(t, path)
+	if err := s2.Load(); err != nil {
+		t.Fatalf("second boot Load: %v", err)
+	}
+	if hn := s2.ActiveConfig().System.HostName; hn != "Base" {
+		t.Fatalf("second boot did not complete the rollback: host-name=%q want Base "+
+			"(the unconfirmed config C survived — #5473)", hn)
+	}
+	if s2.IsConfirmPending() {
+		t.Error("no pending window must survive the completed rollback")
+	}
+	if r, err := s2.db.ReadConfirm(); err != nil || r != nil {
+		t.Fatalf("confirm.json must be removed once the rollback is durable: rec=%v err=%v", r, err)
+	}
+}
+
+// TestSyncApply_PersistFailureRetainsConfirmRecord_5473 pins the HA config-sync
+// locus (SyncApply). A sync that supersedes a pending commit-confirmed window
+// must not delete confirm.json until the synced (replacement) config is durable:
+// if the degrade-not-fail write fails, keep the record so a crash re-drives the
+// ORIGINAL commit-confirmed rollback to A (the synced config never persisted).
+func TestSyncApply_PersistFailureRetainsConfirmRecord_5473(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+
+	s := newTestStoreAt(t, path)
+	commitBaseline(t, s) // confirmed base A: trust only
+	baseSet := s.ShowActiveSet()
+	s.SetPersistRetryBackoffForTesting(time.Hour, time.Hour)
+
+	// Pending confirmed commit C with rollback target A.
+	if err := s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if err := s.SetFromInput("security zones security-zone untrust interfaces eth1.0"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := s.CommitConfirmed(1); err != nil {
+		t.Fatalf("CommitConfirmed: %v", err)
+	}
+	if rec, err := s.db.ReadConfirm(); err != nil || rec == nil {
+		t.Fatalf("armed confirm.json must exist: rec=%v err=%v", rec, err)
+	}
+
+	// Disk breaks, then the primary pushes a config sync that supersedes the
+	// pending window. Option B: SyncApply must NOT fail.
+	s.SetWriteActiveForTesting(failingWriteActive)
+	compiled, err := s.SyncApply(syncContent, nil)
+	if err != nil {
+		t.Fatalf("SyncApply must not fail on persist failure (Option B): %v", err)
+	}
+	if _, ok := compiled.Security.Zones["synced"]; !ok {
+		t.Fatal("synced zone missing from compiled config")
+	}
+	if s.IsConfirmPending() {
+		t.Error("the sync must cancel the in-memory confirm timer")
+	}
+	if !s.ConfigPersistDegraded() {
+		t.Fatal("degraded flag must be set after a failed sync persist")
+	}
+
+	// #5473 core: confirm.json survives the failed sync write. (RED-on-revert:
+	// pre-#5473 clearPendingConfirmLocked removed it up front.)
+	rec, err := s.db.ReadConfirm()
+	if err != nil {
+		t.Fatalf("ReadConfirm: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("confirm.json was DELETED despite the failed sync write — a crash would lose " +
+			"the commit-confirmed rollback and strand the unconfirmed config (#5473 regression)")
+	}
+	if prevSet := rec.PrevTree.FormatSet(); strings.Contains(prevSet, "untrust") {
+		t.Errorf("retained rollback target must be the pre-confirm config A, got:\n%s", prevSet)
+	}
+
+	// Crash: the synced config never reached disk, so a fresh boot re-drives the
+	// ORIGINAL commit-confirmed rollback to A.
+	forceConfirmDeadlinePast(t, path)
+	s2 := newTestStoreAt(t, path)
+	if err := s2.Load(); err != nil {
+		t.Fatalf("boot Load after crash: %v", err)
+	}
+	if got := s2.ShowActiveSet(); got != baseSet {
+		t.Fatalf("boot recovery did not re-drive the commit-confirmed rollback to A:\n"+
+			"want: %s\ngot: %s (the unconfirmed config C survived — #5473)", baseSet, got)
+	}
+	if r, err := s2.db.ReadConfirm(); err != nil || r != nil {
+		t.Fatalf("confirm.json must be removed once the boot rollback is durable: rec=%v err=%v", r, err)
+	}
+}
+
+// TestSyncApply_PersistSuccessRemovesConfirmRecord_5473 is the success control:
+// a sync that supersedes a pending window and persists cleanly removes
+// confirm.json, exactly as before the fix.
+func TestSyncApply_PersistSuccessRemovesConfirmRecord_5473(t *testing.T) {
+	s := newTestStore(t)
+	commitBaseline(t, s)
+
+	if err := s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if err := s.SetFromInput("security zones security-zone untrust interfaces eth1.0"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := s.CommitConfirmed(1); err != nil {
+		t.Fatalf("CommitConfirmed: %v", err)
+	}
+	if rec, err := s.db.ReadConfirm(); err != nil || rec == nil {
+		t.Fatalf("armed confirm.json must exist: rec=%v err=%v", rec, err)
+	}
+
+	if _, err := s.SyncApply(syncContent, nil); err != nil { // writeActive succeeds (no seam)
+		t.Fatalf("SyncApply: %v", err)
+	}
+	if s.ConfigPersistDegraded() {
+		t.Error("a successful sync persist must not flag degraded")
+	}
+	if rec, err := s.db.ReadConfirm(); err != nil || rec != nil {
+		t.Fatalf("a durable sync supersede must remove confirm.json: rec=%v err=%v", rec, err)
+	}
+}

--- a/pkg/configstore/confirm_rollback_durable_5473_test.go
+++ b/pkg/configstore/confirm_rollback_durable_5473_test.go
@@ -21,8 +21,12 @@ package configstore
 import (
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/fsatomic"
 )
 
 // forceConfirmDeadlinePast rewrites the persisted confirm.json deadline into the
@@ -316,5 +320,221 @@ func TestSyncApply_PersistSuccessRemovesConfirmRecord_5473(t *testing.T) {
 	}
 	if rec, err := s.db.ReadConfirm(); err != nil || rec != nil {
 		t.Fatalf("a durable sync supersede must remove confirm.json: rec=%v err=%v", rec, err)
+	}
+}
+
+// writeMode selects the injected active-write behavior for the compound
+// post-rename tests below.
+const (
+	writeModePlainFail  = 0 // pre-rename style failure: no disk write, plain error
+	writeModePostRename = 1 // post-rename dir-fsync failure: content lands, typed error
+	writeModeHeal       = 2 // healthy durable write
+)
+
+// modalWriteActive returns a writeActive seam whose behavior is switched at
+// runtime via mode. writeModePostRename writes the tree durably (the rename
+// landed) then reports the typed *fsatomic.PostRenameSyncError so the commit
+// paths take the CONVERGE branch, matching postRenameFailingWriteActive.
+func modalWriteActive(s *Store, mode *atomic.Int32) func(*config.ConfigTree) error {
+	return func(tree *config.ConfigTree) error {
+		switch mode.Load() {
+		case writeModePlainFail:
+			return errDiskFull
+		case writeModePostRename:
+			if err := s.db.WriteActive(tree); err != nil {
+				return err
+			}
+			return &fsatomic.PostRenameSyncError{Path: "active.json", Err: errPostRenameDirFsync}
+		default:
+			return s.db.WriteActive(tree)
+		}
+	}
+}
+
+// TestCommitConfirmed_PostRenameConverge_ClearsStaleDeferredRemoval_5473 pins the
+// #5503-review gap: the post-rename CONVERGE branches of CommitWithDescription /
+// CommitConfirmed promote a new active config but (before the fix) did NOT reset
+// confirmResolvePendingPersist. The compound sequence:
+//
+//	(a) commit-confirmed C times out and the rollback write FAILS
+//	    -> confirmResolvePendingPersist=true, confirm.json is a STALE record (A);
+//	(b) a NEW commit-confirmed E's write hits a POST-RENAME failure -> converge,
+//	    promote E, arm E's FRESH window, write E's confirm.json;
+//	(c) the persist-retry loop heals -> clearConfirmResolutionPendingLocked().
+//
+// Without the fix the stale flag survives (b), so the heal in (c) deletes E's
+// OWN fresh commit-confirmed record — a crash before E's timer fires then loses
+// the #4577 hatch for E permanently. With the fix, (b) finalizes the stale
+// removal and clears the flag, so the heal is a no-op and E's record survives.
+func TestCommitConfirmed_PostRenameConverge_ClearsStaleDeferredRemoval_5473(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+
+	s := newTestStoreAt(t, path)
+	commitBaseline(t, s) // confirmed base A: trust only
+	baseSet := s.ShowActiveSet()
+
+	// Fast retry so the heal in (c) lands quickly.
+	s.SetPersistRetryBackoffForTesting(time.Millisecond, 4*time.Millisecond)
+
+	var mode atomic.Int32
+	mode.Store(writeModeHeal) // healthy through the first commit-confirmed
+	s.SetWriteActiveForTesting(modalWriteActive(s, &mode))
+
+	// Pending confirmed commit C with rollback target A.
+	if err := s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if err := s.SetFromInput("security zones security-zone untrust interfaces eth1.0"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := s.CommitConfirmed(1); err != nil {
+		t.Fatalf("CommitConfirmed C: %v", err)
+	}
+	genC := s.ConfirmGenForTesting()
+
+	// (a) C times out; the rollback write FAILS (plain) -> flag set, stale record.
+	mode.Store(writeModePlainFail)
+	s.InvokeRollbackTimerForTesting(genC)
+	s.mu.Lock()
+	flagAfterA := s.confirmResolvePendingPersist
+	s.mu.Unlock()
+	if !flagAfterA {
+		t.Fatal("(a) a failed rollback write must set confirmResolvePendingPersist")
+	}
+	if rec, err := s.db.ReadConfirm(); err != nil || rec == nil {
+		t.Fatalf("(a) stale confirm.json must be retained after the failed rollback: rec=%v err=%v", rec, err)
+	}
+	if got := s.ShowActiveSet(); got != baseSet {
+		t.Fatalf("(a) rollback must revert active to A in memory:\nwant %s\ngot %s", baseSet, got)
+	}
+
+	// (b) a NEW commit-confirmed E whose write hits a POST-RENAME failure.
+	if err := s.SetFromInput("interfaces eth2 unit 0 family inet address 10.2.0.1/24"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if err := s.SetFromInput("security zones security-zone dmz interfaces eth2.0"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	mode.Store(writeModePostRename)
+	if _, err := s.CommitConfirmed(1); err != nil {
+		t.Fatalf("(b) post-rename CommitConfirmed E must converge, not fail: %v", err)
+	}
+
+	// The fresh window E must be live and its record on disk.
+	if !s.IsConfirmPending() {
+		t.Error("(b) E's fresh commit-confirmed window must be armed")
+	}
+	if !strings.Contains(s.ShowActiveSet(), "dmz") {
+		t.Error("(b) E must be promoted to active")
+	}
+	if rec, err := s.db.ReadConfirm(); err != nil || rec == nil {
+		t.Fatalf("(b) E's fresh confirm.json must exist: rec=%v err=%v", rec, err)
+	}
+	// #5473/#5503 core: the post-rename converge must have finalized the STALE
+	// deferred removal — otherwise the heal in (c) deletes E's own record.
+	s.mu.Lock()
+	flagAfterB := s.confirmResolvePendingPersist
+	s.mu.Unlock()
+	if flagAfterB {
+		t.Error("(b) post-rename converge must reset confirmResolvePendingPersist so the " +
+			"persist-retry heal does not delete E's fresh commit-confirmed record (#5503 review gap)")
+	}
+
+	// (c) heal: the persist-retry loop lands E durably. E's record must SURVIVE.
+	mode.Store(writeModeHeal)
+	waitForCondition(t, "degraded flag to clear", func() bool {
+		return !s.ConfigPersistDegraded()
+	})
+	if rec, err := s.db.ReadConfirm(); err != nil || rec == nil {
+		t.Fatalf("(c) E's fresh confirm.json must SURVIVE the persist-retry heal: rec=%v err=%v "+
+			"(the heal deleted a live window's record — #5503 review gap)", rec, err)
+	}
+
+	// End-to-end: a fresh boot re-arms E's live window (the #4577 hatch for E is
+	// intact) and keeps E active.
+	s2 := newTestStoreAt(t, path)
+	if err := s2.Load(); err != nil {
+		t.Fatalf("boot Load: %v", err)
+	}
+	if !s2.IsConfirmPending() {
+		t.Error("boot must re-arm E's still-open commit-confirmed window")
+	}
+	if !strings.Contains(s2.ShowActiveSet(), "dmz") {
+		t.Error("boot must keep E active while its window is open")
+	}
+}
+
+// TestCommit_PostRenameConverge_RemovesStaleDeferredRemoval_5473 is the plain-commit
+// analogue: a plain commit D whose write hits a post-rename failure converges
+// (D is visible on disk) and supersedes a stale from-rollback window. The
+// post-rename converge branch must remove the stale confirm.json so a crash
+// before the retry re-fsyncs D does not revert the just-committed D back to A.
+func TestCommit_PostRenameConverge_RemovesStaleDeferredRemoval_5473(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+
+	s := newTestStoreAt(t, path)
+	commitBaseline(t, s) // A: trust only
+	baseSet := s.ShowActiveSet()
+	s.SetPersistRetryBackoffForTesting(time.Hour, time.Hour) // keep the async loop dormant
+
+	var mode atomic.Int32
+	mode.Store(writeModeHeal)
+	s.SetWriteActiveForTesting(modalWriteActive(s, &mode))
+
+	// Pending confirmed commit C, then time it out with a failed rollback write.
+	if err := s.SetFromInput("interfaces eth1 unit 0 family inet address 10.1.0.1/24"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if err := s.SetFromInput("security zones security-zone untrust interfaces eth1.0"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := s.CommitConfirmed(1); err != nil {
+		t.Fatalf("CommitConfirmed C: %v", err)
+	}
+	genC := s.ConfirmGenForTesting()
+	mode.Store(writeModePlainFail)
+	s.InvokeRollbackTimerForTesting(genC)
+	s.mu.Lock()
+	staleFlag := s.confirmResolvePendingPersist
+	s.mu.Unlock()
+	if !staleFlag {
+		t.Fatal("failed rollback write must leave a stale deferred-removal flag")
+	}
+
+	// A plain commit D whose write hits a post-rename failure.
+	if err := s.SetFromInput("interfaces eth2 unit 0 family inet address 10.2.0.1/24"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if err := s.SetFromInput("security zones security-zone dmz interfaces eth2.0"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	mode.Store(writeModePostRename)
+	if _, err := s.CommitWithDescription("D"); err != nil {
+		t.Fatalf("post-rename plain commit D must converge, not fail: %v", err)
+	}
+
+	// D is visible on disk and superseded the stale window: the stale confirm.json
+	// must be gone and the flag reset, so a crash cannot revert D back to A.
+	s.mu.Lock()
+	flagAfterD := s.confirmResolvePendingPersist
+	s.mu.Unlock()
+	if flagAfterD {
+		t.Error("post-rename plain commit must reset confirmResolvePendingPersist")
+	}
+	if rec, err := s.db.ReadConfirm(); err != nil || rec != nil {
+		t.Fatalf("post-rename plain commit must remove the stale confirm.json: rec=%v err=%v "+
+			"(a lingering PrevTree=A record would revert the just-committed D on a crash — #5503 review gap)", rec, err)
+	}
+
+	// A fresh boot loads D with NO pending rollback (D stands, not reverted to A).
+	s2 := newTestStoreAt(t, path)
+	if err := s2.Load(); err != nil {
+		t.Fatalf("boot Load: %v", err)
+	}
+	if s2.IsConfirmPending() {
+		t.Error("no pending window must survive the plain commit")
+	}
+	if got := s2.ShowActiveSet(); !strings.Contains(got, "dmz") || got == baseSet {
+		t.Fatalf("boot must load the committed D (with dmz), not revert to A:\ngot %s", got)
 	}
 }

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -115,6 +115,20 @@ type Store struct {
 	// Every successful committed write resets it to true.
 	persistMarkerCommitted bool
 
+	// confirmResolvePendingPersist records that a commit-confirmed window was
+	// RESOLVED in memory (timeout auto-rollback, boot recovery, or an HA
+	// config-sync that superseded it) but the resolving active-config write
+	// FAILED, so confirm.json — the crash-recovery record that re-drives the
+	// rollback/replacement to its target — must NOT be removed yet (#5473).
+	// The durable-transition invariant: the recovery record survives until the
+	// replacement config is DURABLE on disk, so a crash before the degraded
+	// retry heals boots into a state that RE-RUNS the rollback rather than
+	// stranding the pre-rollback config with no record. Cleared (and confirm.json
+	// removed) by the next durable active write — the persist-retry heal or any
+	// superseding commit/sync — via clearConfirmResolutionPendingLocked. Default
+	// false; only the degrade-not-fail resolution paths set it.
+	confirmResolvePendingPersist bool
+
 	// Commit confirmed state. confirmGen is a generation token
 	// guarding the auto-rollback callback against staleness: a timer
 	// that has already fired and is blocked on s.mu when a nested
@@ -567,7 +581,17 @@ func (s *Store) SyncApply(content string, chassisPreserve func(*config.ConfigTre
 	// callback no-ops in PromoteRollback. This runs with the in-memory
 	// promotion (Option B: the apply stands even if the disk write below
 	// fails), matching SyncApply's degrade-not-fail contract.
-	if s.clearPendingConfirmLocked() {
+	//
+	// #5473: cancel the timer here but DO NOT remove confirm.json yet — order
+	// its removal AFTER the writeActive below so the crash-recovery record is
+	// dropped only once the synced (replacement) config is durable. If the
+	// degrade-not-fail write fails and we had removed confirm.json up front, a
+	// crash before the retry heals would boot the pre-sync config with no
+	// record; the re-armed rollback would then be lost. cancelPending returns
+	// true iff a window was actually pending, so confirm.json is touched only
+	// when there was one to resolve.
+	syncSupersededConfirm := s.cancelPendingConfirmTimerLocked()
+	if syncSupersededConfirm {
 		slog.Info("HA config-sync apply confirmed a pending commit-confirmed window")
 	}
 
@@ -589,8 +613,25 @@ func (s *Store) SyncApply(content string, chassisPreserve func(*config.ConfigTre
 	s.persistMarkerCommitted = true
 	if err := s.writeActive(s.active); err != nil {
 		s.noteActivePersistFailureLocked("config_sync", err)
+		// #5473: the synced config that supersedes the pending confirm window
+		// is NOT durable. Keep confirm.json and defer its removal until the
+		// retry lands the synced config durably — a crash before then boots
+		// into a state where the persisted rollback still fires.
+		if syncSupersededConfirm {
+			s.confirmResolvePendingPersist = true
+		}
 	} else {
 		s.persistDegraded = false
+		// The synced config is durable. Drop the confirm.json this sync
+		// superseded now that the replacement is on disk.
+		if syncSupersededConfirm {
+			s.removeConfirmState()
+		}
+		// Also finalize any removal deferred by an EARLIER failed resolution
+		// write (e.g. a prior rollback whose persist failed): the synced config
+		// is durable, so that stale window is definitively superseded too.
+		// No-op unless such a removal was pending.
+		s.clearConfirmResolutionPendingLocked()
 	}
 
 	s.journalLog(&JournalEntry{

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -152,6 +152,16 @@ func (s *Store) CommitWithDescription(description string) (*config.Config, error
 		s.everCommitted = true
 		s.persistMarkerCommitted = true
 		s.noteActivePersistFailureLocked("commit_postrename", err)
+		// #5473: this commit's config C is VISIBLE on disk (post-rename: the
+		// rename landed, only the dir-fsync is uncertain) and supersedes any
+		// commit-confirmed window whose earlier resolution write failed. Finalize
+		// the deferred (retained) confirm.json removal now — symmetric with the
+		// success branch. Without this the stale flag persists into the degraded
+		// retry, whose heal would then delete a LATER-armed window's fresh record
+		// (or, for a plain commit, a stale PrevTree=A record lingers and a crash
+		// reverts this just-committed C back to A). No-op unless a removal was
+		// deferred.
+		s.clearConfirmResolutionPendingLocked()
 	} else {
 		s.persistDegraded = false       // disk now holds the current config
 		s.everCommitted = true          // #1922 step-0: a real commit has succeeded
@@ -324,6 +334,15 @@ func (s *Store) CommitConfirmed(minutes int) (*config.Config, error) {
 		s.everCommitted = true
 		s.persistMarkerCommitted = true
 		s.noteActivePersistFailureLocked("commit_confirmed_postrename", err)
+		// #5473: E's config is VISIBLE on disk (post-rename converge) and a fresh
+		// window is about to be armed below (writeConfirmState). Finalize any
+		// confirm.json removal deferred by an earlier failed resolution write
+		// HERE — before the fresh window is written — so the stale flag does not
+		// survive to make the degraded retry's heal delete E's OWN fresh record.
+		// Symmetric with the success branch (removes STALE record; the fresh one
+		// is written afterward by writeConfirmState). No-op unless a removal was
+		// deferred.
+		s.clearConfirmResolutionPendingLocked()
 	} else {
 		s.persistDegraded = false // disk now holds the current config
 		// #1922 step-0: a commit confirmed persists the candidate as the

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -156,6 +156,12 @@ func (s *Store) CommitWithDescription(description string) (*config.Config, error
 		s.persistDegraded = false       // disk now holds the current config
 		s.everCommitted = true          // #1922 step-0: a real commit has succeeded
 		s.persistMarkerCommitted = true // #1922: degraded-retry writes committed=1
+		// #5473: this commit's config is now durable and supersedes any
+		// commit-confirmed window whose earlier resolution write failed. Drop
+		// the deferred (retained) confirm.json so a reboot does not re-drive a
+		// stale rollback that this commit has replaced. No-op unless a removal
+		// was deferred.
+		s.clearConfirmResolutionPendingLocked()
 	}
 
 	// Push current active to history with description
@@ -327,6 +333,12 @@ func (s *Store) CommitConfirmed(minutes int) (*config.Config, error) {
 		// rollback path (prevCfg==nil) re-writes the never-committed marker.
 		s.everCommitted = true
 		s.persistMarkerCommitted = true
+		// #5473: this commit's config is durable. Drop any confirm.json whose
+		// removal was deferred by an earlier failed resolution write before the
+		// fresh window below re-arms and re-writes it (clearConfirmResolution
+		// removes the STALE record; writeConfirmState writes the NEW one). No-op
+		// unless a removal was deferred.
+		s.clearConfirmResolutionPendingLocked()
 	}
 
 	if s.confirmTimer != nil {
@@ -417,6 +429,24 @@ func (s *Store) removeConfirmState() {
 	}
 }
 
+// clearConfirmResolutionPendingLocked finalizes a #5473 DEFERRED confirm.json
+// removal: it drops the crash-recovery record once the replacement config is
+// durable on disk. A commit-confirmed window that was resolved in memory
+// (timeout auto-rollback, boot recovery, or an HA config-sync supersede) but
+// whose resolving active write FAILED keeps confirm.json (fail-closed) and
+// marks the removal pending via confirmResolvePendingPersist. This is called
+// from every path that lands a DURABLE active-config write — the persist-retry
+// heal and every superseding commit/sync — so the retained record is dropped
+// exactly when the replacement it was guarding becomes durable, never before.
+// No-op unless a removal was deferred. Caller holds s.mu (write lock).
+func (s *Store) clearConfirmResolutionPendingLocked() {
+	if !s.confirmResolvePendingPersist {
+		return
+	}
+	s.confirmResolvePendingPersist = false
+	s.removeConfirmState()
+}
+
 // clearPendingConfirmLocked cancels an armed commit-confirmed rollback
 // timer and discards its rollback target, treating whatever the caller is
 // about to promote (a plain commit, an HA config-sync apply, or the
@@ -437,6 +467,40 @@ func (s *Store) removeConfirmState() {
 // original rollback target — so this only fires on a PLAIN commit / sync /
 // explicit confirm, never on a confirmed→confirmed re-arm.
 func (s *Store) clearPendingConfirmLocked() bool {
+	if !s.cancelPendingConfirmTimerLocked() {
+		return false
+	}
+	// #4577: the pending confirm is now confirmed (plain commit / HA sync /
+	// explicit confirm / demotion) — drop the persisted crash-recovery state
+	// so a later restart does not resurrect a stale rollback window. A nested
+	// confirmed re-arm does NOT pass through here (it re-writes confirm.json
+	// with the extended deadline in CommitConfirmed), so this only fires on a
+	// genuine confirmation.
+	//
+	// #5473: the callers that reach here have ALREADY made the confirming
+	// config durable (CommitWithDescription/CommitConfirmed persist-before-
+	// promote; ConfirmCommit/ConfirmPendingOnDemotion do not replace the active
+	// config at all), so removing confirm.json now is the durable transition.
+	// The degrade-not-fail sync path does NOT use this helper — it cancels the
+	// timer with cancelPendingConfirmTimerLocked and orders confirm.json removal
+	// AFTER its (possibly failing) write.
+	s.removeConfirmState()
+	return true
+}
+
+// cancelPendingConfirmTimerLocked cancels an armed commit-confirmed rollback
+// timer and discards its in-memory rollback target WITHOUT touching the
+// persisted confirm.json. Returns true iff a timer was armed. This is the
+// timer-half of clearPendingConfirmLocked; a caller that resolves the window
+// with a DEGRADE-NOT-FAIL active write (SyncApply) uses this so confirm.json
+// removal can be ordered AFTER the replacement write is durable (#5473) rather
+// than removed up front and lost if that write fails. Caller holds s.mu.
+//
+// The confirmGen bump is load-bearing (#1817): time.Timer.Stop() cannot un-fire
+// a callback that has already started and is blocked on s.mu. Bumping the
+// generation makes that already-fired-but-blocked callback a no-op in
+// PromoteRollback (gen mismatch).
+func (s *Store) cancelPendingConfirmTimerLocked() bool {
 	if s.confirmTimer == nil {
 		return false
 	}
@@ -445,13 +509,6 @@ func (s *Store) clearPendingConfirmLocked() bool {
 	s.confirmTimer = nil
 	s.confirmPrevTree = nil
 	s.confirmPrevCfg = nil
-	// #4577: the pending confirm is now confirmed (plain commit / HA sync /
-	// explicit confirm / demotion) — drop the persisted crash-recovery state
-	// so a later restart does not resurrect a stale rollback window. A nested
-	// confirmed re-arm does NOT pass through here (it re-writes confirm.json
-	// with the extended deadline in CommitConfirmed), so this only fires on a
-	// genuine confirmation.
-	s.removeConfirmState()
 	return true
 }
 
@@ -623,19 +680,29 @@ func (s *Store) PromoteRollback(gen uint64) (prevCfg *config.Config, ok bool) {
 		s.persistMarkerCommitted = true
 		perr = s.writeActive(s.active)
 	}
+	// #5473: model confirm.json removal as a DURABLE transition. The record is
+	// the crash-recovery intent that re-drives this rollback to the target
+	// (confirmPrevTree). It may be removed ONLY once that target is durable on
+	// disk — i.e. only when the writeActive above SUCCEEDED.
 	if perr != nil {
+		// The rollback to the target is NOT durable (disk still holds the
+		// pre-rollback config). Removing confirm.json here would delete the only
+		// record that would re-drive the rollback on the next boot: a crash
+		// before the degraded retry heals would then boot the pre-rollback
+		// config with NO recovery record (the #5473 crash-window loss). Instead
+		// keep confirm.json and defer its removal until the retry lands the
+		// rollback target durably (clearConfirmResolutionPendingLocked).
 		s.noteActivePersistFailureLocked("auto_rollback", perr)
+		s.confirmResolvePendingPersist = true
 	} else {
+		// The rollback target is durable — drop the crash-recovery record now.
+		// #4577: idempotent on the residual crash window between the successful
+		// writeActive above and this remove (a Load recovery re-runs the
+		// now-no-op rollback to the already-persisted target).
 		s.persistDegraded = false
+		s.confirmResolvePendingPersist = false
+		s.removeConfirmState()
 	}
-
-	// #4577: the confirm window is resolved (rolled back) — drop the persisted
-	// crash-recovery state so a restart does not re-arm/re-roll a completed
-	// window. Idempotent: a crash between the writeActive above and this
-	// remove leaves a confirm.json whose deadline has passed and whose
-	// rollback target equals the now-persisted active, so a Load recovery
-	// re-runs the rollback as a no-op.
-	s.removeConfirmState()
 
 	// Log to journal
 	s.journalLog(&JournalEntry{

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -174,15 +174,26 @@ func (s *Store) recoverPendingConfirmLocked() {
 			s.everCommitted = true
 			perr = s.writeActive(prevTree)
 		}
+		// #5473: confirm.json removal is a DURABLE transition. Remove the
+		// crash-recovery record ONLY when the boot rollback to prevTree is
+		// durable (writeActive above SUCCEEDED). On failure keep it — the
+		// degrade-not-fail retry re-drives the rollback, and if the daemon
+		// crashes again first, the NEXT boot re-reads confirm.json (deadline
+		// still past) and reverts to prevTree again. Removing it here on a
+		// failed write would boot the un-reverted config with no record.
 		if perr != nil {
 			s.noteActivePersistFailureLocked("confirm_recovery_rollback", perr)
+			s.confirmResolvePendingPersist = true
 		} else {
 			s.persistDegraded = false
+			s.confirmResolvePendingPersist = false
 		}
 		if s.candidate != nil {
 			s.candidate = s.active.Clone()
 		}
-		s.removeConfirmState()
+		if perr == nil {
+			s.removeConfirmState()
+		}
 		s.journalLog(&JournalEntry{
 			Action:     "auto_rollback",
 			Detail:     "commit-confirmed window expired during daemon downtime; reverted on boot (#4577)",
@@ -381,6 +392,13 @@ func (s *Store) persistRetryLoop(backoff, maxBackoff time.Duration) {
 		if err == nil {
 			s.persistDegraded = false
 			s.persistRetryActive = false
+			// #5473: the active config is now durable. If a commit-confirmed
+			// resolution (rollback / boot recovery / sync supersede) deferred its
+			// confirm.json removal because the resolving write failed, that
+			// replacement target is exactly what just landed durably — drop the
+			// crash-recovery record now so a later boot does not re-drive a
+			// completed rollback. No-op unless a removal was deferred.
+			s.clearConfirmResolutionPendingLocked()
 			s.journalLog(&JournalEntry{
 				Action: "persist_recovered",
 				Detail: "active config persisted after earlier write failure",


### PR DESCRIPTION
## Summary

Fixes a **commit-confirmed crash-window recovery loss** (#5473). The
timeout auto-rollback, boot recovery, and an HA config-sync that
supersedes a pending window all resolve the window with a
**degrade-not-fail** active write (Option B, #1799): they promote the
replacement config (rollback target **A**, or the synced config) in
memory, then run a `writeActive` that MAY fail — the in-memory
revert/apply is the safety property and always stands. All three then
**unconditionally deleted `confirm.json`**, the crash-recovery record
that re-drives the rollback to **A** on the next boot.

On a write **FAILURE** this deleted the recovery record while on-disk
`active.json` was still the pre-rollback config **C**. A crash before the
degraded-persist retry healed then booted **C** — the exact config
`commit confirmed` was supposed to roll back — with **no recovery
record**, silently defeating the auto-revert safety hatch. The old
idempotency comment ("a Load recovery re-runs the rollback as a no-op")
only holds when `writeActive` **succeeded** (disk == A); on failure disk
is C and the intent record is gone.

**Invariant enforced:** a pending-confirm recovery record must NOT be
removed until the rollback (or authoritative replacement) is DURABLE.

## Fix — model `confirm.json` removal as a durable transition

- New `confirmResolvePendingPersist` flag: set at each resolution locus
  when the resolving `writeActive` FAILS → `confirm.json` is retained
  (fail-closed) and its removal deferred until the replacement is durable.
- `clearConfirmResolutionPendingLocked` finalizes the deferred removal.
  Called from every path that lands a durable active write — the
  persist-retry heal and any superseding commit / commit-confirmed / sync
  — so the retained record is dropped exactly when the replacement it
  guards becomes durable, never before (and a lingering `confirm.json`
  can never revert a later config).
- **All three loci fixed:**
  - `PromoteRollback` (timeout auto-rollback, `store_commit.go`) — remove only on write success; set the pending flag on failure.
  - `recoverPendingConfirmLocked` (boot recovery, `store_persist.go`) — same.
  - `SyncApply` (`store.go`) — split the timer-cancel out of `clearPendingConfirmLocked` into `cancelPendingConfirmTimerLocked` so the sync cancels the timer up front but orders `confirm.json` removal AFTER its degrade-not-fail write.
- `clearPendingConfirmLocked` (plain commit / explicit confirm / demotion) is unchanged — those callers made the config durable before reaching it, so removing `confirm.json` there is already the durable transition.

Fail-closed result: a crash while the resolving write is un-healed boots
into a state that **RE-RUNS the rollback to A** (deadline having passed),
rather than stranding C. Success-path behavior is bit-for-bit unchanged.

**Distinct from #4864** (non-durable delete): #4864 made the delete
itself dir-fsync-durable — it fixes *how* `confirm.json` is deleted;
#5473 fixes *when*.

## Validation

- `go build ./...` + `go test ./pkg/configstore/...` green; `-race` clean.
- Dependent `pkg/daemon` + `pkg/cluster` suites green.
- **Five new regressions** inject an active-write failure via the existing `writeActive` seam at each locus (timeout auto-rollback, boot recovery, SyncApply), asserting `confirm.json` is **RETAINED** on failure and a subsequent `Load` re-drives the rollback to **A**, and **removed as before** on success.

### RED-on-revert evidence

Reintroducing the unconditional `removeConfirmState` at all three loci
fails exactly the three inject-failure tests, then restoring the ordering
makes them pass:

```
--- FAIL: TestAutoRollback_PersistFailureRetainsConfirmRecord_5473
    confirm.json was DELETED despite the failed rollback write — a crash now boots the unconfirmed config with NO recovery record (#5473 regression)
--- FAIL: TestConfirmRecovery_PersistFailureRetainsConfirmRecord_5473
    confirm.json was DELETED despite the failed recovery write — a second crash would boot the unconfirmed config C permanently (#5473 regression)
--- FAIL: TestSyncApply_PersistFailureRetainsConfirmRecord_5473
    confirm.json was DELETED despite the failed sync write — a crash would lose the commit-confirmed rollback and strand the unconfirmed config (#5473 regression)
```

Docs: updated `pkg/configstore/README.md` with the #5473 durable-ordering invariant.

Closes #5473

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUReiNxPXHRCJ8HFuijBxF