### PR TITLE
daemon: fix xfrmi reconcile test fake for #5499 not-found tightening

### DIFF
--- a/pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go
+++ b/pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go
@@ -45,7 +45,17 @@ func (f *reconcileFakeLinkOps) LinkByName(name string) (netlink.Link, error) {
 	if l, ok := f.links[name]; ok {
 		return l, nil
 	}
-	return nil, errors.New("link not found")
+	// Return the SAME type real *netlink.Handle.LinkByName returns on absence
+	// (netlink.LinkNotFoundError), so routing's isLinkNotFound (pkg/routing/
+	// vrf.go — errors.As against netlink.LinkNotFoundError) recognizes it and
+	// the create path falls through to LinkAdd. A plain errors.New("link not
+	// found") is NOT recognized after #5499 tightened Apply to distinguish a
+	// genuine absence from a transient lookup error, so it was misclassified as
+	// transient and the injected LinkAdd failure never reached (#5504). The
+	// embedded error field is unexported, so this can only be the zero value;
+	// that is safe here because no path formats/prints a recognized not-found
+	// error (isLinkNotFound uses errors.As, which never calls Error()).
+	return nil, netlink.LinkNotFoundError{}
 }
 
 func (f *reconcileFakeLinkOps) LinkAdd(l netlink.Link) error {


### PR DESCRIPTION
## Summary

`TestApplyInterfaceReconcileFailsClosedOnXfrmCreateFailure`
(`pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go`) began
FAILING on master after **#5499**. This is a **test-only** fidelity fix —
production was always correct.

## Root cause

#5499 tightened `xfrmManager.Apply` to route `LinkByName` errors through
`isLinkNotFound` (`pkg/routing/vrf.go`), which recognizes **only**
`netlink.LinkNotFoundError` / the internal `errLinkNotFound` sentinel via
`errors.As`. Any other lookup error is now treated as a **transient**
failure and surfaced, rather than as a genuine absence that falls through
to `LinkAdd`.

The `reconcileFakeLinkOps` double returned a plain
`errors.New("link not found")` for an absent link. Post-#5499
`isLinkNotFound` does not recognize that value, so `Apply` classified the
absence as transient (`lookup xfrmi st0.1: ...`) and **never reached the
injected `LinkAdd` failure** — so `errors.Is(err, injected)` failed and the
test broke.

Production is and always was correct: the real `*netlink.Handle` returns
`netlink.LinkNotFoundError` on absence, which `isLinkNotFound` recognizes.
Only the fake was unfaithful.

## Fix

Change the fake's not-found return from `errors.New("link not found")` to
`netlink.LinkNotFoundError{}` so it matches real netlink and exercises the
xfrmi create path again. The embedded `error` field is unexported, so the
zero value is the only form constructible outside the netlink package; that
is safe because no code path formats a recognized not-found error
(`isLinkNotFound` uses `errors.As`, never `Error()`). The fake's found-path
is unchanged, so the bond/tunnel/idempotent/tail siblings sharing this fake
are unaffected.

## Test result (before → after)

Before (master):
```
--- FAIL: TestApplyInterfaceReconcileFailsClosedOnXfrmCreateFailure
    ...: returned error must wrap the injected xfrmi failure, got
    apply xfrmi interfaces: lookup xfrmi st0.1: link not found
```

After:
```
ok  github.com/psaab/xpf/pkg/daemon
ok  github.com/psaab/xpf/pkg/routing
```
All five tests sharing the fake pass (FailsClosedOnXfrmCreateFailure,
SurfacesBondFailure, SurfacesTunnelFailure, ToleratesIdempotent,
TestApplyTailReconciles...), plus `go build ./...`.

## Test-only confirmation

`git diff` touches exactly one file:
`pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go`
(+11 / -1). No production code changes.

## #5310 fail-on-revert intent preserved

With the fake fix in place, temporarily reverting
`applyInterfaceReconcile`'s `ApplyXfrmi` error-aggregation to the pre-#5310
void/swallow form still turns the test **RED** — it genuinely pins the
**production** fail-closed behavior, not the fake. Restored before commit.

Closes #5504

🤖 Generated with [Claude Code](https://claude.com/claude-code)