### PR TITLE
nat: fail closed on invalid source-pool port range (#5457)

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1434,12 +1434,35 @@ The single parse authority is now `parseCanonicalPort`
 decimal digits and is used by every commit-time port-spec parser —
 `validatePortSpec` (application `source-port` / `destination-port`),
 `resolveSinglePort` (firewall-filter port leaves), `parseDNATPortList` (NAT
-`match destination-port`), and `validateDNATPoolStrict` (destination-NAT pool
-`port`). The Rust `parse_port_spec` was tightened in lock-step (`parse_port_u16`
-rejects the sign) so all three parsers agree. Fail-on-revert:
+`match destination-port`), `validateDNATPoolStrict` (destination-NAT pool
+`port`), and — since #5457 — `parseSourcePoolPortRange` (source-NAT pool `port
+[range]`). The Rust `parse_port_spec` was tightened in lock-step
+(`parse_port_u16` rejects the sign) so all three parsers agree. Fail-on-revert:
 `TestSignedPortRejectedAtCommit_3606` / `TestParseCanonicalPort_3606`
 (`pkg/config/compiler_signed_port_3606_test.go`) and
 `parse_port_spec_rejects_signed_3606` (`userspace-dp/src/policy_tests.rs`).
+
+**Source-NAT pool `port [range]` fail-closed (#5457).** Before #5457 the
+source-pool port endpoints were parsed with `strconv.Atoi` and returned
+`ok=true` with no value-range or order check, so `port range low -1 high 99999`
+became `(-1, 99999)` and `low 5000 high 100` became the inverted `(5000, 100)`.
+A non-zero out-of-range/reversed value was still caught downstream (the strict
+gate `validateSourceNATPoolStrict` and the snapshot builder both read the
+STAMPED value), but a `0`-valued endpoint slipped through the parser as the
+"unconfigured" sentinel and silently widened to the default `1024-65535` PAT
+range. `parseSourcePoolPortRange` now validates each endpoint via
+`ParseCanonicalUint` + `1..65535` + non-decreasing order and FAILS CLOSED
+(`ok=false`) on any violation, so the bad value is never stamped into
+`PortLow`/`PortHigh`. The "configured-but-invalid" fact is preserved in
+`NATPool.PortRangeInvalidSpec`, which `validateSourceNATPoolStrict` hard-rejects
+at commit (downgraded to a warning on the tolerant load / peer-sync path) and
+which the snapshot builder (`sourceNATPoolPortRange`) reads to mark the pool
+UNUSABLE — the leniently-loaded bad range installs nothing rather than
+PAT-translating over a range the operator did not configure. Fail-on-revert:
+`TestParseSourcePoolPortRange_5457` / `TestSourceNATPoolPortRangeFailClosed_5457`
+(`pkg/config/compiler_nat_source_pool_port_5457_test.go`) and
+`TestSourceNATSnapshotInvalidPortRangeUnusable_5457`
+(`pkg/dataplane/userspace/nat_source_pool_port_5457_test.go`).
 
 The `system domain-search` and `system name-server` readers
 (`compileSystem`, `compiler_system.go`) are also contract-compliant via

--- a/pkg/config/compiler_nat_source.go
+++ b/pkg/config/compiler_nat_source.go
@@ -186,17 +186,38 @@ func compileNAT64(node *Node, sec *SecurityConfig) error {
 //     this shape was accepted, so the Junos `port range <low> to <high>` was
 //     silently dropped and the pool defaulted to 1024-65535 PAT.
 //
-// A reversed (low > high) or out-of-range value parses successfully here (it is
-// carried into PortLow/PortHigh); the strict commit gate
-// (validateSourceNATPoolStrict) hard-rejects it so the operator sees the error
-// rather than the rule dropping at runtime. ok is false only when no numeric low
-// could be read (garbage tokens), leaving PortLow/PortHigh at their default.
+// Every endpoint is validated as a CANONICAL port in 1..65535 via
+// ParseCanonicalUint (which rejects a leading sign, surrounding whitespace, a
+// non-numeric token, and int overflow — the same primitive the DNAT and appid
+// port parsers use) and the range must be non-decreasing (low <= high). ok is
+// FALSE on ANY violation — a non-numeric / non-canonical token, an endpoint
+// outside 1..65535 (0 included), or a reversed range — so the malformed value
+// is NEVER stamped into PortLow/PortHigh (#5457). The caller records the raw
+// offending spec in PortRangeInvalidSpec so the strict commit gate
+// (validateSourceNATPoolStrict) hard-rejects it (operator-visible) AND the
+// snapshot builder marks the pool unusable on the tolerant load / peer-sync
+// path, rather than silently defaulting a bad range to 1024-65535 PAT.
+//
+// Before #5457 the endpoints were read with strconv.Atoi and returned ok=true
+// even for a negative low ("port range low -1 high 99999" -> (-1, 99999, true))
+// or a reversed range ("low 5000 high 100" -> (5000, 100, true)). Only the
+// downstream strict gate caught the non-zero cases (the stamped bad value), and
+// a 0-valued endpoint slipped through the parser as the "unconfigured" sentinel
+// and silently widened to the default PAT range.
 func parseSourcePoolPortRange(toks []string) (low, high int, ok bool) {
+	// parsePort validates a single token as a canonical port in 1..65535.
+	parsePort := func(s string) (int, bool) {
+		n, err := ParseCanonicalUint(s)
+		if err != nil || n < 1 || n > 65535 {
+			return 0, false
+		}
+		return n, true
+	}
 	// Legacy explicit-keyword shape: low <lo> high <hi>.
 	if len(toks) >= 4 && toks[0] == "low" && toks[2] == "high" {
-		lo, err1 := strconv.Atoi(toks[1])
-		hi, err2 := strconv.Atoi(toks[3])
-		if err1 != nil || err2 != nil {
+		lo, ok1 := parsePort(toks[1])
+		hi, ok2 := parsePort(toks[3])
+		if !ok1 || !ok2 || lo > hi {
 			return 0, 0, false
 		}
 		return lo, hi, true
@@ -205,17 +226,20 @@ func parseSourcePoolPortRange(toks []string) (low, high int, ok bool) {
 	if len(toks) == 0 {
 		return 0, 0, false
 	}
-	lo, err := strconv.Atoi(toks[0])
-	if err != nil {
+	lo, ok1 := parsePort(toks[0])
+	if !ok1 {
 		return 0, 0, false
 	}
 	hi := lo
 	if len(toks) >= 3 && toks[1] == "to" {
-		v, err2 := strconv.Atoi(toks[2])
-		if err2 != nil {
+		v, ok2 := parsePort(toks[2])
+		if !ok2 {
 			return 0, 0, false
 		}
 		hi = v
+	}
+	if lo > hi {
+		return 0, 0, false
 	}
 	return lo, hi, true
 }
@@ -324,24 +348,36 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 					return pool.Deterministic
 				}
 
+				// setPortRange stamps a validated [lo,hi] source-port range onto
+				// the pool. A malformed range (parseSourcePoolPortRange ok=false:
+				// a non-canonical token, an endpoint outside 1..65535 including 0,
+				// or a reversed low>high) is NEVER stamped — it records the raw
+				// spec in PortRangeInvalidSpec so the strict commit gate
+				// hard-rejects (operator-visible) and the snapshot builder marks
+				// the pool unusable on the tolerant load / peer-sync path, rather
+				// than silently defaulting the bad range to 1024-65535 PAT (#5457).
+				setPortRange := func(toks []string) {
+					if lo, hi, ok := parseSourcePoolPortRange(toks); ok {
+						pool.PortLow = lo
+						pool.PortHigh = hi
+					} else {
+						pool.PortRangeInvalidSpec = strings.Join(toks, " ")
+					}
+				}
+
 				// Port range / single value — flat leaf shapes
 				// (Keys=["port","range",...]/["port",N]/["port",
 				// "no-translation"]). #3906: `range` accepts both the Junos
 				// wire shape `<low> to <high>` and the legacy `low <lo> high
 				// <hi>` shape; `no-translation` preserves the source port.
 				if len(prop.Keys) >= 3 && prop.Keys[1] == "range" {
-					if lo, hi, ok := parseSourcePoolPortRange(prop.Keys[2:]); ok {
-						pool.PortLow = lo
-						pool.PortHigh = hi
-					}
+					setPortRange(prop.Keys[2:])
 				} else if len(prop.Keys) == 2 && prop.Keys[1] != "range" &&
 					prop.Keys[1] != "deterministic" &&
 					prop.Keys[1] != "no-translation" {
-					// "port N" single value.
-					if n, err := strconv.Atoi(prop.Keys[1]); err == nil {
-						pool.PortLow = n
-						pool.PortHigh = n
-					}
+					// "port N" single value — validated as a 1..65535 port via the
+					// shared parser (a single token is the [N,N] range shape).
+					setPortRange(prop.Keys[1:])
 				}
 				// no-translation may ride along on the flat-leaf keys
 				// (Keys=["port","no-translation"]).
@@ -363,22 +399,17 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 						// range <low> to <high> | range low <lo> high <hi>
 						// (#3906). pc.Keys[1:] is the token slice after the
 						// `range` keyword.
-						if lo, hi, ok := parseSourcePoolPortRange(pc.Keys[1:]); ok {
-							pool.PortLow = lo
-							pool.PortHigh = hi
-						}
+						setPortRange(pc.Keys[1:])
 					case "no-translation":
 						pool.PortNoTranslation = true
 					case "deterministic":
 						applyDeterministicChildren(ensureDet(), pc)
 					default:
 						// Bare numeric child: `port N` grouped under a
-						// modeled container becomes port { N }.
+						// modeled container becomes port { N }. Validated as a
+						// 1..65535 port via the shared parser.
 						if pc.IsLeaf && len(pc.Keys) == 1 {
-							if n, err := strconv.Atoi(pc.Keys[0]); err == nil {
-								pool.PortLow = n
-								pool.PortHigh = n
-							}
+							setPortRange(pc.Keys)
 						}
 					}
 				}

--- a/pkg/config/compiler_nat_source_pool_port_5457_test.go
+++ b/pkg/config/compiler_nat_source_pool_port_5457_test.go
@@ -1,0 +1,162 @@
+// #5457: a source-NAT pool's `port [range]` endpoints were parsed with
+// strconv.Atoi, which accepts a leading sign and imposes no value-range or
+// order check, so `port range low -1 high 99999` returned (-1, 99999, true) and
+// `port range low 5000 high 100` returned (5000, 100, true) (inverted). A
+// non-zero out-of-range/reversed value was only caught downstream (the strict
+// gate + snapshot builder read the stamped value), and a 0-valued endpoint
+// slipped through the parser as the "unconfigured" sentinel and silently widened
+// to the default 1024-65535 PAT range. On the tolerant/lenient compile path the
+// strict validator downgrades to a warning, so the malformed range must not be
+// stamped into the pool at all.
+//
+// The fix routes every source-pool port endpoint through ParseCanonicalUint and
+// enforces 1..65535 with a non-decreasing (low<=high) order check;
+// parseSourcePoolPortRange now FAILS CLOSED (ok=false) on any violation. The
+// compiler records the raw offending spec in PortRangeInvalidSpec so the strict
+// commit gate hard-rejects (operator-visible) and the snapshot builder marks the
+// pool unusable on the tolerant path — never installing the defaulted range.
+//
+// Flat-set syntax MUST be built via ParseSetCommand/SetPath, never NewParser.
+package config
+
+import "testing"
+
+// TestParseSourcePoolPortRange_5457 exercises the parser directly. RED-on-revert
+// (strconv.Atoi + no range/order check): every reject case returns ok=true.
+func TestParseSourcePoolPortRange_5457(t *testing.T) {
+	cases := []struct {
+		name   string
+		toks   []string
+		wantLo int
+		wantHi int
+		wantOK bool
+	}{
+		// Junos `<low> [to <high>]` shape.
+		{"junos-valid", []string{"1024", "to", "2048"}, 1024, 2048, true},
+		{"junos-single", []string{"8080"}, 8080, 8080, true},
+		{"junos-edge-full", []string{"1", "to", "65535"}, 1, 65535, true},
+		{"junos-reversed", []string{"5000", "to", "100"}, 0, 0, false},
+		{"junos-zero-low", []string{"0", "to", "100"}, 0, 0, false},
+		{"junos-zero-high", []string{"100", "to", "0"}, 0, 0, false},
+		{"junos-over-high", []string{"5000", "to", "70000"}, 0, 0, false},
+		{"junos-over-single", []string{"99999"}, 0, 0, false},
+		{"junos-zero-single", []string{"0"}, 0, 0, false},
+		{"junos-neg-single", []string{"-1"}, 0, 0, false},
+		{"junos-signed-plus", []string{"+80"}, 0, 0, false},
+		{"junos-nonnumeric", []string{"http"}, 0, 0, false},
+		{"junos-empty", []string{}, 0, 0, false},
+		// Legacy `low <lo> high <hi>` shape.
+		{"legacy-valid", []string{"low", "1024", "high", "2048"}, 1024, 2048, true},
+		{"legacy-reversed", []string{"low", "5000", "high", "100"}, 0, 0, false},
+		{"legacy-neg-low", []string{"low", "-1", "high", "99999"}, 0, 0, false},
+		{"legacy-over-high", []string{"low", "5000", "high", "99999"}, 0, 0, false},
+		{"legacy-zero-low", []string{"low", "0", "high", "5000"}, 0, 0, false},
+		{"legacy-zero-high", []string{"low", "5000", "high", "0"}, 0, 0, false},
+		{"legacy-nonnumeric", []string{"low", "abc", "high", "def"}, 0, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lo, hi, ok := parseSourcePoolPortRange(tc.toks)
+			if ok != tc.wantOK {
+				t.Fatalf("parseSourcePoolPortRange(%v) ok=%v, want %v (RED-on-revert: strconv.Atoi accepts these)",
+					tc.toks, ok, tc.wantOK)
+			}
+			if ok && (lo != tc.wantLo || hi != tc.wantHi) {
+				t.Fatalf("parseSourcePoolPortRange(%v) = %d/%d, want %d/%d",
+					tc.toks, lo, hi, tc.wantLo, tc.wantHi)
+			}
+		})
+	}
+}
+
+// TestSourceNATPoolPortRangeFailClosed_5457 drives the malformed ranges the
+// pre-#5457 parser accepted through the full compiler. STRICT: CompileConfig
+// hard-rejects. LENIENT: CompileConfigLenient warns, does NOT stamp the bad
+// value (PortLow/PortHigh keep the 1024/65535 default), and sets
+// PortRangeInvalidSpec.
+func TestSourceNATPoolPortRangeFailClosed_5457(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  string
+	}{
+		{"neg-low-over-high", "set security nat source pool p1 port range low -1 high 99999"},
+		{"reversed-legacy", "set security nat source pool p1 port range low 5000 high 100"},
+		{"reversed-junos", "set security nat source pool p1 port range 5000 to 100"},
+		{"zero-low-legacy", "set security nat source pool p1 port range low 0 high 5000"},
+		{"zero-high-legacy", "set security nat source pool p1 port range low 5000 high 0"},
+		{"zero-single", "set security nat source pool p1 port 0"},
+		{"over-single", "set security nat source pool p1 port 99999"},
+		{"nonnumeric-single", "set security nat source pool p1 port http"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pool := []string{
+				"set security nat source pool p1 address 203.0.113.5/32",
+				tc.cmd,
+			}
+
+			// STRICT path: hard-reject at commit.
+			tree := snatPoolTree(t, pool...)
+			if _, err := CompileConfig(tree); err == nil {
+				t.Fatalf("CompileConfig accepted malformed SNAT pool port %q (want reject)", tc.name)
+			}
+
+			// LENIENT path: warn-and-compile, malformed range SKIPPED.
+			tree = snatPoolTree(t, pool...)
+			cfg, err := CompileConfigLenient(tree)
+			if err != nil {
+				t.Fatalf("CompileConfigLenient rejected %q (want warn-and-compile): %v", tc.name, err)
+			}
+			if len(cfg.Warnings) == 0 {
+				t.Fatalf("CompileConfigLenient produced no warning for %q", tc.name)
+			}
+			p := cfg.Security.NAT.SourcePools["p1"]
+			if p == nil {
+				t.Fatalf("pool p1 missing after lenient compile of %q", tc.name)
+			}
+			if p.PortRangeInvalidSpec == "" {
+				t.Fatalf("%q: PortRangeInvalidSpec empty, want the recorded bad spec", tc.name)
+			}
+			// The bad value must NOT be stamped — the pool keeps the safe default.
+			if p.PortLow != 1024 || p.PortHigh != 65535 {
+				t.Fatalf("%q: PortLow/PortHigh = %d/%d, want default 1024/65535 (malformed range must not be stamped)",
+					tc.name, p.PortLow, p.PortHigh)
+			}
+		})
+	}
+}
+
+// TestSourceNATPoolPortValidUnaffected_5457 is the over-reject control: a valid
+// explicit range stamps unchanged on the strict path and never sets
+// PortRangeInvalidSpec (valid-range behavior preserved bit-for-bit).
+func TestSourceNATPoolPortValidUnaffected_5457(t *testing.T) {
+	cases := []struct {
+		cmd    string
+		wantLo int
+		wantHi int
+	}{
+		{"set security nat source pool p1 port range 1024 to 2048", 1024, 2048},
+		{"set security nat source pool p1 port range low 1024 high 2048", 1024, 2048},
+		{"set security nat source pool p1 port 1024", 1024, 1024},
+		{"set security nat source pool p1 port range 1 to 65535", 1, 65535},
+	}
+	for _, tc := range cases {
+		t.Run(tc.cmd, func(t *testing.T) {
+			tree := snatPoolTree(t,
+				"set security nat source pool p1 address 203.0.113.5/32",
+				tc.cmd)
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("CompileConfig rejected valid range %q: %v", tc.cmd, err)
+			}
+			p := cfg.Security.NAT.SourcePools["p1"]
+			if p.PortRangeInvalidSpec != "" {
+				t.Fatalf("valid range %q set PortRangeInvalidSpec=%q", tc.cmd, p.PortRangeInvalidSpec)
+			}
+			if p.PortLow != tc.wantLo || p.PortHigh != tc.wantHi {
+				t.Fatalf("valid range %q PortLow/PortHigh = %d/%d, want %d/%d",
+					tc.cmd, p.PortLow, p.PortHigh, tc.wantLo, tc.wantHi)
+			}
+		})
+	}
+}

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -527,6 +527,14 @@ func validateDNATPoolStrict(cfg *Config) error {
 // preserves the source port and ignores the range entirely, so its (defaulted)
 // range is not an error.
 //
+// #5457: parseSourcePoolPortRange now FAILS CLOSED on a non-canonical token, an
+// endpoint outside 1..65535 (0 included), or a reversed range — it leaves
+// PortLow/PortHigh at the default and records the raw spec in
+// PortRangeInvalidSpec. That marker (checked first below) is the primary reject
+// signal; the stamped low/high checks remain as a backstop. This closes the
+// pre-#5457 residual where a 0-valued endpoint escaped as the "unconfigured"
+// sentinel and silently widened to the default PAT range.
+//
 // Strict on commit / commit-check (hard-reject so the bad value is operator-
 // visible); the compiler downgrades this to a warning on the tolerant load /
 // peer-sync path (#1960 no-brick) — the snapshot builder independently fails
@@ -549,9 +557,30 @@ func validateSourceNATPoolStrict(cfg *Config) error {
 		if pool == nil {
 			continue
 		}
+		// #5457: an explicit `port [range]` leaf whose value the parser rejected
+		// (a non-canonical token, an endpoint outside 1..65535 including 0, or a
+		// reversed range). parseSourcePoolPortRange failed closed and left
+		// PortLow/PortHigh at their default, recording the raw offending spec
+		// here — so this is the ONLY signal a bad range survives. Hard-reject
+		// (downgraded to a warning on the tolerant path) so the operator sees the
+		// bad value instead of the pool silently PAT-translating over the
+		// defaulted 1024-65535 range; the snapshot builder independently marks the
+		// pool unusable when this is set.
+		if pool.PortRangeInvalidSpec != "" {
+			return fmt.Errorf(
+				"source-nat pool %q: port range %q is invalid; source-pool ports "+
+					"must be 1-65535 and the range non-decreasing — the rule would "+
+					"commit but the dataplane marks the pool unusable and drops it at "+
+					"runtime, silently stopping translation",
+				name, pool.PortRangeInvalidSpec)
+		}
 		// Only validate an EXPLICITLY configured range. No `port` leaf leaves
 		// PortLow/PortHigh at 0 (defaulted to 1024/65535 downstream) — the
-		// legitimate default-PAT mode, untouched.
+		// legitimate default-PAT mode, untouched. These stamped-value checks are
+		// a belt-and-suspenders backstop: after #5457 parseSourcePoolPortRange
+		// never stamps an out-of-range/reversed value (it sets
+		// PortRangeInvalidSpec above instead), so they guard only a future path
+		// that writes PortLow/PortHigh directly.
 		low := pool.PortLow
 		high := pool.PortHigh
 		if low == 0 && high == 0 {

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -807,6 +807,23 @@ type NATPool struct {
 	PortRaw  string `json:"-"`
 	PortLow  int    // source pool port range low (default 1024)
 	PortHigh int    // source pool port range high (default 65535)
+	// PortRangeInvalidSpec records that an explicit source-pool `port [range]`
+	// leaf was configured but its value violated the port invariant — a
+	// non-canonical token, an endpoint outside 1..65535 (0 included), or a
+	// reversed low>high range (#5457). parseSourcePoolPortRange fails closed
+	// (ok=false) on such input, so the bad value is NEVER stamped into
+	// PortLow/PortHigh (they keep the 1024/65535 default); this field preserves
+	// the raw offending spec so validateSourceNATPoolStrict hard-rejects at
+	// commit (operator-visible) and the snapshot builder (sourceNATPoolPortRange)
+	// marks the pool unusable on the tolerant load / peer-sync path — never
+	// silently installing the defaulted range the operator did not ask for.
+	// Before #5457 the endpoints were parsed with strconv.Atoi and stamped
+	// verbatim: a non-zero out-of-range/reversed range was caught downstream, but
+	// a 0-valued endpoint slipped through as the "unconfigured" sentinel and
+	// silently widened to the default PAT range. "" means no port leaf, or a
+	// valid range. `json:"-"`: a compile-time parse artifact recomputed on every
+	// compile, never serialized to the helper (like PortRaw above).
+	PortRangeInvalidSpec string `json:"-"`
 	// PortNoTranslation records the source-pool `port no-translation` modifier
 	// (#3906). When true the pool translates the source ADDRESS but PRESERVES
 	// the original source port (Junos 1:1 source-port behaviour) — the

--- a/pkg/dataplane/userspace/nat_source.go
+++ b/pkg/dataplane/userspace/nat_source.go
@@ -488,6 +488,14 @@ func sourceNATPoolPortRange(pool *config.NATPool) (uint16, uint16, bool) {
 	if pool == nil {
 		return 0, 0, false
 	}
+	// #5457: an explicitly-configured but invalid port range (rejected by
+	// parseSourcePoolPortRange; PortLow/PortHigh left at the default) must NOT
+	// silently install the defaulted 1024-65535 range on the tolerant load /
+	// peer-sync path. Mark the pool unusable so it installs nothing rather than
+	// translating over a range the operator did not configure.
+	if pool.PortRangeInvalidSpec != "" {
+		return 0, 0, false
+	}
 	low := pool.PortLow
 	if low == 0 {
 		low = 1024

--- a/pkg/dataplane/userspace/nat_source_pool_port_5457_test.go
+++ b/pkg/dataplane/userspace/nat_source_pool_port_5457_test.go
@@ -1,0 +1,75 @@
+// #5457: a source-NAT pool with an invalid `port [range]` (rejected by
+// parseSourcePoolPortRange) must not install the defaulted 1024-65535 range on
+// the tolerant load / peer-sync path. The compiler leaves PortLow/PortHigh at
+// the default and records PortRangeInvalidSpec; the snapshot builder
+// (sourceNATPoolPortRange) reads that marker and marks the pool UNUSABLE, so a
+// leniently-loaded bad range installs nothing rather than PAT-translating over a
+// range the operator never configured.
+//
+// RED-on-revert (snapshot builder marker check removed): the pool falls back to
+// the defaulted 1024-65535 range and PoolUnusable comes back false.
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func compileSNATPoolLenient(t *testing.T, poolCmds ...string) *config.Config {
+	t.Helper()
+	tree := &config.ConfigTree{}
+	cmds := append([]string{}, poolCmds...)
+	cmds = append(cmds,
+		"set security nat source rule-set RS from zone trust",
+		"set security nat source rule-set RS to zone untrust",
+		"set security nat source rule-set RS rule R1 match source-address 10.0.0.0/24",
+		"set security nat source rule-set RS rule R1 then source-nat pool p1",
+	)
+	for _, cmd := range cmds {
+		path, err := config.ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	// The strict path hard-rejects these ranges (validateSourceNATPoolStrict);
+	// exercise the tolerant path so a snapshot is actually built.
+	cfg, err := config.CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient: %v", err)
+	}
+	return cfg
+}
+
+func TestSourceNATSnapshotInvalidPortRangeUnusable_5457(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  string
+	}{
+		{"reversed", "set security nat source pool p1 port range low 5000 high 100"},
+		{"neg-low-over-high", "set security nat source pool p1 port range low -1 high 99999"},
+		{"zero-low", "set security nat source pool p1 port range low 0 high 5000"},
+		{"over-single", "set security nat source pool p1 port 99999"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := compileSNATPoolLenient(t,
+				"set security nat source pool p1 address 203.0.113.5/32",
+				tc.cmd)
+			snaps := buildSourceNATSnapshots(cfg, nil)
+			if len(snaps) != 1 {
+				t.Fatalf("snapshots = %d, want 1", len(snaps))
+			}
+			s := snaps[0]
+			if !s.PoolUnusable {
+				t.Fatalf("%q: PoolUnusable = false, want true (invalid range must fail closed, not default to 1024-65535)", tc.name)
+			}
+			if s.PoolUnusableReason != "invalid_port_range" {
+				t.Fatalf("%q: PoolUnusableReason = %q, want invalid_port_range", tc.name, s.PoolUnusableReason)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`parseSourcePoolPortRange` (`pkg/config/compiler_nat_source.go`) parsed source-NAT pool `port [range]` endpoints with `strconv.Atoi` and applied **no value-range and no order check**, returning `ok=true` for malformed input:

- `port range low -1 high 99999` → `(-1, 99999, true)`
- `port range low 5000 high 100` → `(5000, 100, true)` (inverted)

A non-zero out-of-range/reversed value was still caught downstream because both the strict gate (`validateSourceNATPoolStrict`) and the snapshot builder (`sourceNATPoolPortRange`) read the **stamped** value. But a **`0`-valued endpoint slipped through** as the "unconfigured" sentinel (`PortLow/PortHigh==0` defaults to `1024-65535`) and **silently widened the pool to the full default PAT range** — escaping both gates. On the tolerant load / peer-sync path (#1960 downgrade) the strict validator only warns, so the invariant (`ports are 1..65535`, ranges non-decreasing) must be enforced in the parser itself.

Closes #5457

## Fix

- `parseSourcePoolPortRange` now validates each endpoint via `ParseCanonicalUint` (rejects a leading sign, whitespace, non-numeric tokens, int overflow — the same primitive the DNAT/appid parsers use) + `1..65535` + non-decreasing `low<=high`, and **fails closed (`ok=false`)** on any violation, at **both** return paths. The `port N` single-value and bare-numeric-child stamping sites are routed through the same chokepoint.
- Because a rejected range is no longer stamped, `PortLow/PortHigh` keep the safe `1024-65535` default. The "configured-but-invalid" fact is preserved in the new `NATPool.PortRangeInvalidSpec` (`json:"-"`, a compile-time artifact like `PortRaw`). This avoids a regression: `validateSourceNATPoolStrict` hard-rejects when the marker is set (downgraded to a warning on the tolerant path), and `sourceNATPoolPortRange` marks the pool **UNUSABLE** — a leniently-loaded bad range installs nothing rather than PAT-translating over a range the operator never configured. Valid ranges are preserved bit-for-bit.

## Validation

- `go build ./...` + `go vet` clean; `go test ./pkg/config/...`, `./pkg/dataplane/userspace/...`, and config-serializing consumers (`configstore`, `grpcapi`, `api`) all pass.
- New tests: `TestParseSourcePoolPortRange_5457` (direct parser table), `TestSourceNATPoolPortRangeFailClosed_5457` (strict hard-fail + lenient warn/not-stamped/marker), `TestSourceNATPoolPortValidUnaffected_5457` (valid unchanged), `TestSourceNATSnapshotInvalidPortRangeUnusable_5457` (lenient → `PoolUnusable=invalid_port_range`).

### RED-on-revert evidence

Reverting the parser to `strconv.Atoi` (no range/order check) and re-running the `5457` tests:

- `TestParseSourcePoolPortRange_5457`: `-1`, `+80`, reversed, over-high, **and every zero case** return `ok=true` → FAIL.
- `TestSourceNATPoolPortRangeFailClosed_5457`: the **zero cases (`zero-low`, `zero-high`, `zero-single`) are accepted at commit** (`CompileConfig` returns nil) — the exact silent-widening hole this closes.
- `TestSourceNATSnapshotInvalidPortRangeUnusable_5457`: the `zero-low` case comes back `PoolUnusable=false` (defaulted to `1024-65535`).

Restored to green after the RED check.

## Docs

Extended the #3606 canonical-port contract section in `docs/config-schema.md` to list `parseSourcePoolPortRange` and document the #5457 fail-closed behavior + marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HD3QKaV4w1fHxU9mPfbZbq