### PR TITLE
ipsec: tear stale SA when a VPN becomes unrenderable (#5494)

### DIFF
--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -15,7 +15,9 @@ the apply path pays no fsync (the file is regenerated on every apply).
   `/etc/swanctl/conf.d`.
 - `Apply(ipsecCfg *config.IPsecConfig) error` — `manager.go`. Generate
   config and reload strongSwan, then terminate the live SAs of any
-  connection deleted since the last Apply (#3941). **The returned error is
+  connection that departed the rendered/loaded set since the last Apply —
+  whether the operator DELETED it (#3941) or it became UNRENDERABLE and was
+  omitted from the render (#5494). **The returned error is
   load-bearing (#4433):** a render/write/`swanctl --load-all` failure leaves
   the previously-loaded strongSwan config (the OLD tunnels) active, so the
   commit path (`daemon_apply.go` step 6) MUST surface this error rather than
@@ -85,24 +87,41 @@ all files stay in `package ipsec`, so the public API is unchanged.
   config but leaves its already-established IKE/child SAs installed — the
   deleted tunnel keeps forwarding until rekey/lifetime expiry (a security
   gap: a VPN removed for a compromised peer / decommissioned site stays
-  up). `Apply` therefore remembers the previous applied connection-name
-  set (`prevConnNames`, sanitized VPN map keys) and on each apply diffs it
-  against the new set. `Apply`/`Clear` reload FIRST and only on reload
-  success advance `prevConnNames` and tear down removed SAs
-  (`promoteConnNames`, #4898) — so the removed conn is unloaded and cannot
+  up). `Apply` therefore remembers the previous LOADED connection-name
+  set (`prevConnNames`) and on each apply diffs it against the set
+  `renderConfig` actually emitted. `Apply`/`Clear` reload FIRST and only on
+  reload success advance `prevConnNames` and tear down departed SAs
+  (`promoteConnNames`, #4898) — so the departed conn is unloaded and cannot
   re-initiate before teardown, and a failed reload leaves the old set intact
   rather than forgetting a still-loaded connection or disrupting a
   still-effective tunnel. `terminateRemovedConns` then queries live SAs and
-  issues `swanctl --terminate --ike <conn>` only for a removed conn that
+  issues `swanctl --terminate --ike <conn>` only for a departed conn that
   actually has a live SA — so deleting a VPN that was never up is a clean
   no-op. If the live-SA query fails, it falls back to an unconditional
-  (idempotent) terminate. The diff keys off the VPN NAME, not renderability,
-  so a VPN that merely became unrenderable (a broken gateway reference) is not
-  treated as deleted and keeps its SAs. Modified/added connections are
-  untouched — only removals are torn down. All swanctl shell-outs route
-  through the `sc` seam so the diff→terminate path is unit-tested against
-  recording doubles (`delete_terminate_3941_test.go`,
-  `manager_reload_ordering_4898_test.go`).
+  (idempotent) terminate. Modified/added connections are untouched — only
+  departures are torn down. All swanctl shell-outs route through the `sc`
+  seam so the diff→terminate path is unit-tested against recording doubles
+  (`delete_terminate_3941_test.go`, `manager_reload_ordering_4898_test.go`).
+
+- **The diff keys off the RENDERED set, not the raw VPN name (#5494 —
+  FLIPS the prior #3941 name-keyed behavior).** `renderConfig` returns the
+  EXACT set of connection names it emitted; `Apply` diffs THAT. A VPN that
+  is still present in the config but dropped out of the render as
+  UNRENDERABLE on the tolerant persisted / peer-synced load path — an
+  unresolvable gateway reference (#2074), a broken ike-policy chain (#2270),
+  or a `protocol ah` proposal with no ESP render path (#4298) — is neither
+  loaded nor validated by `swanctl --load-all`, yet the reload SUCCEEDS.
+  Under the old name-keyed diff its live child SA kept forwarding under
+  now-unloaded (stale) selectors/credentials while the apply reported
+  convergence — a security fail-open. Such a VPN is now treated as a
+  departure and its SA is torn down. This deliberately trades a sliver of
+  availability for security: a transiently-unrenderable VPN's SA is torn
+  until its config becomes renderable again, but an unrenderable VPN is
+  already non-functional for rekey / new-SA establishment, so keeping a
+  stale authorized SA is a hole, not a real availability win. The #4898
+  reload-success gate is preserved (a FAILED reload still tears nothing —
+  the old config is still effective) and #3941 genuine-deletion teardown is
+  unchanged. Covered by `unrenderable_terminate_5494_test.go`.
 - **SA-status parsing must match the real `swanctl --list-sas` layout
   (#3937).** `GetSAStatus` shells out to `swanctl --list-sas` and feeds the
   stdout to `parseSAOutput`. The real strongSwan output is

--- a/pkg/ipsec/dhcp_rebind_test.go
+++ b/pkg/ipsec/dhcp_rebind_test.go
@@ -123,7 +123,7 @@ func TestPrepareConfigReResolvesDHCPLocalAddress(t *testing.T) {
 // error.
 func (m *Manager) renderMust(t *testing.T, prepared *config.IPsecConfig) string {
 	t.Helper()
-	got, err := m.renderConfig(prepared)
+	got, _, err := m.renderConfig(prepared)
 	if err != nil {
 		t.Fatalf("renderConfig: %v", err)
 	}

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -1170,7 +1170,7 @@ func TestGenerateConfig_JunosObfuscatedPSK(t *testing.T) {
 			"tun": {Gateway: "10.0.0.1", PSK: "$9$SpRrMLYgaZDirexdwgUDzFn9uO1RhlKW"},
 		},
 	}
-	got, err := m.renderConfig(cfg)
+	got, _, err := m.renderConfig(cfg)
 	if err != nil {
 		t.Fatalf("renderConfig() error = %v", err)
 	}
@@ -1644,7 +1644,7 @@ func TestRenderConfig_GatewayNameNeverLeaks(t *testing.T) {
 				"tun": {Gateway: "corp-gw", PSK: "k"},
 			},
 		}
-		got, err := m.renderConfig(cfg)
+		got, _, err := m.renderConfig(cfg)
 		if err != nil {
 			t.Fatalf("renderConfig() error = %v", err)
 		}
@@ -1668,7 +1668,7 @@ func TestRenderConfig_GatewayNameNeverLeaks(t *testing.T) {
 				"tun": {Gateway: "typo-gw", PSK: "k"},
 			},
 		}
-		got, err := m.renderConfig(cfg)
+		got, _, err := m.renderConfig(cfg)
 		if err != nil {
 			t.Fatalf("renderConfig() error = %v (skip should not error)", err)
 		}
@@ -1693,7 +1693,7 @@ func TestRenderConfig_GatewayNameNeverLeaks(t *testing.T) {
 				"tun": {Gateway: "bare-gw", PSK: "k"},
 			},
 		}
-		got, err := m.renderConfig(cfg)
+		got, _, err := m.renderConfig(cfg)
 		if err != nil {
 			t.Fatalf("renderConfig() error = %v", err)
 		}
@@ -1711,7 +1711,7 @@ func TestRenderConfig_GatewayNameNeverLeaks(t *testing.T) {
 				"tun": {Gateway: "vpnpeer", PSK: "k"},
 			},
 		}
-		got, err := m.renderConfig(cfg)
+		got, _, err := m.renderConfig(cfg)
 		if err != nil {
 			t.Fatalf("renderConfig() error = %v", err)
 		}
@@ -1726,7 +1726,7 @@ func TestRenderConfig_GatewayNameNeverLeaks(t *testing.T) {
 				"tun": {Gateway: "198.51.100.9", PSK: "k"},
 			},
 		}
-		got, err := m.renderConfig(cfg)
+		got, _, err := m.renderConfig(cfg)
 		if err != nil {
 			t.Fatalf("renderConfig() error = %v", err)
 		}
@@ -1741,7 +1741,7 @@ func TestRenderConfig_GatewayNameNeverLeaks(t *testing.T) {
 				"tun": {Gateway: "peer.example.com", PSK: "k"},
 			},
 		}
-		got, err := m.renderConfig(cfg)
+		got, _, err := m.renderConfig(cfg)
 		if err != nil {
 			t.Fatalf("renderConfig() error = %v", err)
 		}
@@ -1756,7 +1756,7 @@ func TestRenderConfig_GatewayNameNeverLeaks(t *testing.T) {
 				"tun": {Gateway: "", PSK: "k", BindInterface: "st0.0"},
 			},
 		}
-		got, err := m.renderConfig(cfg)
+		got, _, err := m.renderConfig(cfg)
 		if err != nil {
 			t.Fatalf("renderConfig() error = %v", err)
 		}
@@ -1782,7 +1782,7 @@ func TestRenderConfig_GatewayNameNeverLeaks(t *testing.T) {
 				"bad":  {Gateway: "missing-gw", PSK: "k2"},
 			},
 		}
-		got, err := m.renderConfig(cfg)
+		got, _, err := m.renderConfig(cfg)
 		if err != nil {
 			t.Fatalf("renderConfig() error = %v", err)
 		}

--- a/pkg/ipsec/manager.go
+++ b/pkg/ipsec/manager.go
@@ -95,20 +95,35 @@ func NewWithConfigDir(dir string) *Manager {
 
 // Apply generates swanctl config and reloads strongSwan.
 //
-// swanctl --load-all only UNLOADS the config of a connection the operator
-// deleted; it does NOT terminate that connection's already-established
-// IKE/child SAs, so a removed VPN keeps forwarding until rekey/lifetime
-// expiry (#3941). Apply therefore diffs the previous applied connection set
-// against the new one and, after the reload has unloaded the removed
-// connections, actively terminates their live SAs (terminateRemovedConns).
+// swanctl --load-all only UNLOADS the config of a connection that is no
+// longer present in the rendered config; it does NOT terminate that
+// connection's already-established IKE/child SAs, so a dropped VPN keeps
+// forwarding until rekey/lifetime expiry (#3941). Apply therefore diffs the
+// previous LOADED connection set against the set renderConfig actually
+// emitted and, after the reload has unloaded the departed connections,
+// actively terminates their live SAs (terminateRemovedConns).
+//
+// The diff keys off the RENDERED set, not the raw VPN map keys (#5494). A VPN
+// that is still present in the config but became UNRENDERABLE on the tolerant
+// load / peer-sync path — an unresolvable gateway reference (#2074), a broken
+// ike-policy chain (#2270), or a `protocol ah` proposal with no ESP render
+// path (#4298) — is OMITTED from the render, so its connection is neither
+// loaded nor validated by swanctl. Continuing to forward under that
+// connection's now-unloaded (stale) selectors/credentials is a security
+// fail-open, so such a VPN is treated as a removal and its child SA is torn
+// down. This is the fail-closed invariant: after a SUCCESSFUL apply, every
+// forwarding child SA must correspond to a connection that was actually
+// rendered and loaded, or be actively terminated.
 func (m *Manager) Apply(ipsecCfg *config.IPsecConfig) error {
-	newNames := vpnConnNameSet(ipsecCfg)
-
+	// loadedNames is the set of connections swanctl actually loaded on this
+	// apply. For the render path it is renderConfig's exact emitted set; for
+	// the empty-config clear path nothing is loaded, so it stays nil.
+	var loadedNames map[string]bool
 	var applyErr error
 	if ipsecCfg == nil || len(ipsecCfg.VPNs) == 0 {
 		applyErr = m.clearConfig()
 	} else {
-		applyErr = m.applyConfig(ipsecCfg)
+		loadedNames, applyErr = m.applyConfig(ipsecCfg)
 	}
 
 	// #4898: state promotion and SA teardown are gated on reload SUCCESS. On a
@@ -118,18 +133,22 @@ func (m *Manager) Apply(ipsecCfg *config.IPsecConfig) error {
 	// prevConnNames unchanged lets the next successful Apply/Clear recompute the
 	// diff and retry the teardown; advancing it here (the old ordering) would
 	// forget which connections are still loaded and disrupt a still-effective
-	// tunnel while reporting success.
+	// tunnel while reporting success. A render-side hard error (a non-skip
+	// failure, e.g. an unknown auth method) surfaces here the same way and
+	// tears nothing down.
 	if applyErr != nil {
 		return applyErr
 	}
 
-	// Reload succeeded: atomically advance prevConnNames to the applied set and
-	// tear down the live SAs of the connections the operator DELETED. Their
-	// config is now unloaded, so a straggler SA cannot be re-initiated from a
-	// still-loaded connection while we tear it down. Terminate is idempotent:
-	// a removed VPN with no active SA is a clean no-op (no --terminate is
-	// issued because it never shows up in --list-sas).
-	removed := m.promoteConnNames(newNames)
+	// Reload succeeded: atomically advance prevConnNames to the set that was
+	// actually loaded and tear down the live SAs of the connections that
+	// departed the loaded set — whether the operator DELETED them or they fell
+	// out of the render as unrenderable (#5494). Their config is now unloaded,
+	// so a straggler SA cannot be re-initiated from a still-loaded connection
+	// while we tear it down. Terminate is idempotent: a departed VPN with no
+	// active SA is a clean no-op (no --terminate is issued because it never
+	// shows up in --list-sas).
+	removed := m.promoteConnNames(loadedNames)
 	m.terminateRemovedConns(removed)
 	return nil
 }
@@ -149,31 +168,36 @@ func (m *Manager) Clear() error {
 }
 
 // applyConfig renders + atomically writes the swanctl snippet and reloads.
-func (m *Manager) applyConfig(ipsecCfg *config.IPsecConfig) error {
-	cfg, err := m.renderConfig(ipsecCfg)
+// On success it returns the exact set of connection names renderConfig
+// emitted into the loaded config (#5494) — the authoritative "what is loaded"
+// set Apply diffs against prevConnNames to decide which stale SAs to tear
+// down. On any error (render hard error, write failure, reload failure) it
+// returns a nil set so Apply's error path leaves prevConnNames untouched.
+func (m *Manager) applyConfig(ipsecCfg *config.IPsecConfig) (map[string]bool, error) {
+	cfg, rendered, err := m.renderConfig(ipsecCfg)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := os.MkdirAll(m.configDir, 0755); err != nil {
-		return fmt.Errorf("create config dir: %w", err)
+		return nil, fmt.Errorf("create config dir: %w", err)
 	}
 
 	// AtomicGeneratedConfig (#1894): regenerated on every apply — a
 	// torn file must never reach the strongSwan parser, but fsync is
 	// deliberately skipped on this hot apply path.
 	if err := fsatomic.WriteFileAtomic(m.configPath, []byte(cfg), 0600); err != nil {
-		return fmt.Errorf("write config: %w", err)
+		return nil, fmt.Errorf("write config: %w", err)
 	}
 
 	slog.Info("swanctl config written", "path", m.configPath)
 
 	if err := m.reload(); err != nil {
 		slog.Warn("swanctl reload failed", "err", err)
-		return err
+		return nil, err
 	}
 
-	return nil
+	return rendered, nil
 }
 
 // clearConfig removes the xpf snippet and reloads strongSwan.
@@ -200,26 +224,18 @@ func (m *Manager) reload() error {
 	return nil
 }
 
-// vpnConnNameSet returns the set of swanctl connection names (sanitized VPN
-// names, matching what renderConfig writes and what swanctl reports in
-// --list-sas) for every VPN in ipsecCfg. A nil config / empty VPN map yields
-// an empty set.
-func vpnConnNameSet(ipsecCfg *config.IPsecConfig) map[string]bool {
-	if ipsecCfg == nil || len(ipsecCfg.VPNs) == 0 {
-		return nil
-	}
-	names := make(map[string]bool, len(ipsecCfg.VPNs))
-	for name := range ipsecCfg.VPNs {
-		names[sanitizeSwanctlValue(name)] = true
-	}
-	return names
-}
-
-// promoteConnNames records newNames as the current applied connection set and
-// returns the connections that were present before but are gone now — the
-// ones an operator DELETED. The diff keys off the VPN name (map key), not
-// renderability, so a VPN that merely became unrenderable (a broken gateway
-// reference) is NOT treated as removed and keeps its SAs.
+// promoteConnNames records newNames — the set of connections that were
+// actually RENDERED+LOADED on this apply — as the current loaded connection
+// set and returns the connections that were loaded before but are gone now.
+// A prior connection is "gone" if the operator DELETED its VPN OR the VPN is
+// still configured but dropped out of the render as unrenderable (#5494):
+// either way strongSwan is no longer enforcing that connection, so a live
+// child SA still forwarding under its stale selectors/credentials is a
+// fail-open and must be torn down. The diff keys off the RENDERED set, not
+// the raw VPN map keys, precisely so an unrenderable-but-still-configured VPN
+// is caught — the security-over-availability posture this project chose for
+// an IPsec appliance (an unrenderable VPN is already non-functional for
+// rekey/new-SA, so keeping its stale SA buys no real availability).
 //
 // #4898: this is called ONLY after a successful reload, so prevConnNames always
 // reflects the last config strongSwan actually loaded — never a config whose

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -25,11 +25,23 @@ type childSelector struct {
 }
 
 func (m *Manager) generateConfig(ipsecCfg *config.IPsecConfig) string {
-	cfg, _ := m.renderConfig(ipsecCfg)
+	cfg, _, _ := m.renderConfig(ipsecCfg)
 	return cfg
 }
 
-func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
+// renderConfig renders the swanctl snippet and returns the EXACT set of
+// swanctl connection names it actually emitted (the sanitized VPN names
+// written into the connections{} block). A VPN present in ipsecCfg.VPNs but
+// OMITTED from the render — a skip class: an unrenderable gateway reference
+// (#2074), an unresolved ike-policy chain (#2270), or a `protocol ah`
+// proposal with no ESP render path (#4298) — is NOT in the returned set even
+// though renderConfig still returns success. Apply diffs THIS rendered set
+// (not the raw VPN map keys) so a previously-loaded connection that dropped
+// out of the render is treated as a removal and its stale child SA is torn
+// down (#5494). Returning the rendered set is the single source of truth for
+// "what is actually loaded", so the skip logic here can never drift from the
+// teardown diff in promoteConnNames.
+func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, map[string]bool, error) {
 	var b strings.Builder
 
 	b.WriteString("# xpf managed config - do not edit\n\n")
@@ -38,6 +50,12 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 	// (#2074) so the secrets loop below emits no orphan ike-<name> secret
 	// for a connection that was never written.
 	skipped := make(map[string]bool)
+
+	// rendered accumulates the sanitized connection name of every VPN that
+	// survives the skip checks and is emitted into connections{}. This is
+	// the authoritative "loaded connection set" Apply diffs against
+	// prevConnNames (#5494).
+	rendered := make(map[string]bool)
 
 	// Connections
 	b.WriteString("connections {\n")
@@ -85,7 +103,7 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 					"vpn", name, "ike_policy", gw.IKEPolicy)
 				continue
 			}
-			return "", fmt.Errorf("vpn %s: %w", name, err)
+			return "", nil, fmt.Errorf("vpn %s: %w", name, err)
 		}
 
 		// #4298 (V-2): a proposal with `protocol ah` (Authentication Header)
@@ -106,6 +124,12 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 				"vpn", name, "ipsec_policy", vpn.IPsecPolicy)
 			continue
 		}
+
+		// This VPN passed every skip check, so it is emitted into the
+		// loaded config. Record its sanitized connection name in the
+		// rendered set (#5494) — the same key swanctl reports in
+		// --list-sas and that promoteConnNames diffs for teardown.
+		rendered[sanitizeSwanctlValue(name)] = true
 
 		fmt.Fprintf(&b, "  %s {\n", sanitizeSwanctlValue(name))
 		espProposals, espLifetime := resolveESPSettings(ipsecCfg, vpn)
@@ -277,7 +301,7 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 		if secret != "" {
 			decoded, err := normalizePSK(secret)
 			if err != nil {
-				return "", fmt.Errorf("vpn %s: %w", name, err)
+				return "", nil, fmt.Errorf("vpn %s: %w", name, err)
 			}
 			fmt.Fprintf(&b, "  ike-%s {\n", sanitizeSwanctlValue(name))
 			// sanitizeSwanctlValue strips control chars (#1798); the
@@ -300,7 +324,7 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 	}
 	b.WriteString("}\n")
 
-	return b.String(), nil
+	return b.String(), rendered, nil
 }
 
 // resolveRemoteAddr resolves the swanctl remote_addrs value (a real IP /

--- a/pkg/ipsec/unrenderable_terminate_5494_test.go
+++ b/pkg/ipsec/unrenderable_terminate_5494_test.go
@@ -1,0 +1,264 @@
+package ipsec
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5494: a valid, established VPN whose config becomes UNRENDERABLE on the
+// tolerant persisted / peer-synced load path (a broken gateway reference, an
+// unresolved ike-policy chain, or a `protocol ah` proposal) is OMITTED from
+// the swanctl render, yet `swanctl --load-all` still SUCCEEDS. Before this
+// fix Apply diffed the applied set by raw VPN NAME (every VPN map key), so an
+// unrenderable-but-still-configured VPN looked unchanged: no removal was
+// detected, terminateRemovedConns was not called, and strongSwan's existing
+// child SA kept forwarding under stale (now-unloaded) selectors/credentials
+// while the apply reported convergence — a security fail-open.
+//
+// The invariant: after a SUCCESSFUL apply, every forwarding child SA must
+// correspond to a connection that was actually RENDERED+LOADED, or be torn
+// down. Apply now diffs the EXACT rendered connection set renderConfig
+// emitted, so a VPN that dropped out of the render is treated as a removal
+// and its live SA is terminated.
+//
+// This deliberately FLIPS the previous documented-intentional behavior (an
+// unrenderable VPN used to keep its SAs to survive TRANSIENT unrenderability).
+// The security argument wins for an IPsec appliance: an unrenderable VPN is
+// already non-functional for rekey / new-SA establishment, so keeping a stale
+// child SA authorized buys no real availability while leaving a compromised /
+// mis-synced peer forwarding under old policy.
+//
+// RED-on-revert: restore the name-keyed diff (diff the raw VPN map keys
+// instead of the rendered set) and every terminate assertion below goes RED —
+// the unrenderable target's SA is NOT torn (the fail-open this issue closes).
+
+// renderableTwoVPN builds a config with two VPNs ("target" and "sibling"),
+// both fully renderable: each names a gateway with a literal address and a
+// resolvable ike-policy chain plus a resolvable ESP policy. Per-test callers
+// break "target" one skip class at a time and assert "sibling" is untouched.
+func renderableTwoVPN() *config.IPsecConfig {
+	return &config.IPsecConfig{
+		IKEProposals: map[string]*config.IKEProposal{
+			"ikeprop": {
+				Name: "ikeprop", AuthMethod: "pre-shared-keys",
+				EncryptionAlg: "aes-256-cbc", AuthAlg: "sha-256", DHGroup: 14,
+			},
+		},
+		IKEPolicies: map[string]*config.IKEPolicy{
+			"ikepol": {Name: "ikepol", Proposals: []string{"ikeprop"}, PSK: config.Secret("ike-psk")},
+		},
+		Proposals: map[string]*config.IPsecProposal{
+			"espprop": {Name: "espprop", Protocol: "esp", EncryptionAlg: "aes-256-cbc", AuthAlg: "hmac-sha-256-128"},
+		},
+		Policies: map[string]*config.IPsecPolicyDef{
+			"esppol": {Name: "esppol", Proposals: []string{"espprop"}},
+		},
+		Gateways: map[string]*config.IPsecGateway{
+			"gw-target":  {Name: "gw-target", Address: "192.0.2.1", IKEPolicy: "ikepol"},
+			"gw-sibling": {Name: "gw-sibling", Address: "192.0.2.2", IKEPolicy: "ikepol"},
+		},
+		VPNs: map[string]*config.IPsecVPN{
+			"target":  {Name: "target", Gateway: "gw-target", IPsecPolicy: "esppol"},
+			"sibling": {Name: "sibling", Gateway: "gw-sibling", IPsecPolicy: "esppol"},
+		},
+	}
+}
+
+// applyBaselineTwoVPN applies the fully-renderable two-VPN config and asserts
+// the baseline invariants: nothing is terminated and no --list-sas probe is
+// issued (nothing departed the rendered set). After it returns both
+// connections are tracked in prevConnNames and both have live SAs staged.
+func applyBaselineTwoVPN(t *testing.T, m *Manager, rec *swanctlRecorder) {
+	t.Helper()
+	if err := m.Apply(renderableTwoVPN()); err != nil {
+		t.Fatalf("baseline Apply: %v", err)
+	}
+	if got := rec.terminateCalls(); len(got) != 0 {
+		t.Fatalf("baseline Apply must not terminate anything, got %v", got)
+	}
+	if rec.sawListSAs() {
+		t.Fatalf("baseline Apply must not query SAs (nothing departed the render)")
+	}
+	// Both connections are now up with live child SAs.
+	rec.listSAs = liveSA("target", "sibling")
+}
+
+// assertTargetTornSiblingKept drives Apply(broken) — which must SUCCEED (the
+// unrenderable VPN is SKIPPED, not a hard render error) — and asserts exactly
+// the unrenderable target's stale SA is torn while the still-renderable
+// sibling keeps its SA.
+func assertTargetTornSiblingKept(t *testing.T, m *Manager, rec *swanctlRecorder, broken *config.IPsecConfig) {
+	t.Helper()
+	if err := m.Apply(broken); err != nil {
+		t.Fatalf("Apply with an unrenderable VPN must still succeed "+
+			"(skip, not hard error): %v", err)
+	}
+	got := rec.terminateCalls()
+	if len(got) != 1 || got[0] != "target" {
+		t.Fatalf("the unrenderable target's stale SA must be torn down "+
+			"exactly once, got %v", got)
+	}
+	if m.tracks("target") {
+		t.Fatal("target must not remain tracked after it dropped out of the render")
+	}
+	if !m.tracks("sibling") {
+		t.Fatal("the still-renderable sibling must remain tracked (not torn)")
+	}
+}
+
+// TestUnrenderableGatewayRefTerminatesSA_5494: target's gateway reference
+// becomes a dangling single-label (dotless) name, so resolveRemoteAddr skips
+// the VPN (#2074) — render succeeds but omits target. Its stale SA is torn.
+func TestUnrenderableGatewayRefTerminatesSA_5494(t *testing.T) {
+	rec := &swanctlRecorder{}
+	m := newRecordingManager(t, rec)
+	applyBaselineTwoVPN(t, m, rec)
+
+	broken := renderableTwoVPN()
+	// Dangling, dotless gateway name: not a defined gateway object, not a
+	// literal IP / dotted hostname → not a usable endpoint → skipped.
+	broken.VPNs["target"].Gateway = "no-such-gateway"
+
+	assertTargetTornSiblingKept(t, m, rec, broken)
+}
+
+// TestUnrenderableAddresslessGatewayTerminatesSA_5494: target's gateway
+// object exists but loses its address (no address / hostname / responder-only),
+// the other #2074 skip branch (resolveRemoteAddr ok=false for a defined-but-
+// unroutable gateway). Render succeeds but omits target; its stale SA is torn.
+func TestUnrenderableAddresslessGatewayTerminatesSA_5494(t *testing.T) {
+	rec := &swanctlRecorder{}
+	m := newRecordingManager(t, rec)
+	applyBaselineTwoVPN(t, m, rec)
+
+	broken := renderableTwoVPN()
+	broken.Gateways["gw-target"].Address = "" // nothing routable, not responder-only
+
+	assertTargetTornSiblingKept(t, m, rec, broken)
+}
+
+// TestUnrenderableIKEChainTerminatesSA_5494: target's gateway names an
+// ike-policy whose chain does not resolve, so resolveIKESettings returns
+// errIKEChainUnresolved and renderConfig SKIPS target (#2270) rather than emit
+// a proposal-less (silently downgraded) connection. Render succeeds but omits
+// target; its stale SA is torn.
+func TestUnrenderableIKEChainTerminatesSA_5494(t *testing.T) {
+	rec := &swanctlRecorder{}
+	m := newRecordingManager(t, rec)
+	applyBaselineTwoVPN(t, m, rec)
+
+	broken := renderableTwoVPN()
+	// Point target's gateway at an ike-policy that is defined nowhere (no
+	// IKEPolicies entry, no legacy Proposals entry) → chain unresolved.
+	broken.Gateways["gw-target"].IKEPolicy = "dangling-ikepol"
+
+	assertTargetTornSiblingKept(t, m, rec, broken)
+}
+
+// TestUnrenderableAHProposalTerminatesSA_5494: target's ipsec-policy resolves
+// to a `protocol ah` proposal, which has no ESP render path, so renderConfig
+// SKIPS target (#4298) rather than fabricate an ESP cipher. Render succeeds
+// but omits target; its stale SA is torn.
+func TestUnrenderableAHProposalTerminatesSA_5494(t *testing.T) {
+	rec := &swanctlRecorder{}
+	m := newRecordingManager(t, rec)
+	applyBaselineTwoVPN(t, m, rec)
+
+	broken := renderableTwoVPN()
+	// Give target an AH proposal/policy; sibling keeps the ESP policy.
+	broken.Proposals["ah-prop"] = &config.IPsecProposal{Name: "ah-prop", Protocol: "ah", AuthAlg: "hmac-sha-256-128"}
+	broken.Policies["ah-pol"] = &config.IPsecPolicyDef{Name: "ah-pol", Proposals: []string{"ah-prop"}}
+	broken.VPNs["target"].IPsecPolicy = "ah-pol"
+
+	assertTargetTornSiblingKept(t, m, rec, broken)
+}
+
+// TestReapplyRenderableDoesNotTerminate_5494: re-applying an UNCHANGED,
+// fully-renderable config must terminate nothing. This guards against the
+// rendered-set diff over-terminating a connection that IS still loaded — the
+// precision side of the fix (do not tear SAs for connections still rendered).
+func TestReapplyRenderableDoesNotTerminate_5494(t *testing.T) {
+	rec := &swanctlRecorder{}
+	m := newRecordingManager(t, rec)
+	applyBaselineTwoVPN(t, m, rec)
+
+	if err := m.Apply(renderableTwoVPN()); err != nil {
+		t.Fatalf("re-apply of the same renderable config: %v", err)
+	}
+	if got := rec.terminateCalls(); len(got) != 0 {
+		t.Fatalf("re-applying an unchanged renderable config must not terminate, got %v", got)
+	}
+}
+
+// TestGenuineRemovalStillTerminates_5494: the #3941 behavior is preserved —
+// a VPN the operator actually DELETES (absent from the new config entirely)
+// still has its live SA torn down. Same teardown path, unchanged.
+func TestGenuineRemovalStillTerminates_5494(t *testing.T) {
+	rec := &swanctlRecorder{}
+	m := newRecordingManager(t, rec)
+	applyBaselineTwoVPN(t, m, rec)
+
+	reduced := renderableTwoVPN()
+	delete(reduced.VPNs, "target") // operator deletes target outright
+
+	if err := m.Apply(reduced); err != nil {
+		t.Fatalf("delete Apply: %v", err)
+	}
+	got := rec.terminateCalls()
+	if len(got) != 1 || got[0] != "target" {
+		t.Fatalf("a genuinely deleted VPN must still be terminated, got %v", got)
+	}
+}
+
+// TestUnrenderableWithFailedReloadDoesNotTerminate_5494: the #4898 gate is
+// preserved on the unrenderable path too. When target becomes unrenderable
+// AND `swanctl --load-all` FAILS, the previous config is still the loaded,
+// effective one — Apply must return the error, terminate NOTHING, and keep
+// prevConnNames so a later successful apply retries the teardown. The
+// fail-closed teardown fires only on a SUCCESSFULLY reloaded render.
+//
+// RED-on-revert (for the #4898 coupling): move promotion/teardown before the
+// reload-success gate and this fails — a failed reload would tear the
+// still-loaded target.
+func TestUnrenderableWithFailedReloadDoesNotTerminate_5494(t *testing.T) {
+	reloadErr := errors.New("charon vici socket refused")
+	rec := &reloadRecorder{loadErr: reloadErr}
+	m := NewWithConfigDir(t.TempDir())
+	m.swanctl = rec.run
+
+	if err := m.Apply(renderableTwoVPN()); err != nil {
+		t.Fatalf("baseline Apply: %v", err)
+	}
+	rec.listSAs = liveSA("target", "sibling")
+
+	// target becomes unrenderable, but the reload fails.
+	rec.failLoadAll = true
+	broken := renderableTwoVPN()
+	broken.VPNs["target"].Gateway = "no-such-gateway"
+	err := m.Apply(broken)
+	if err == nil {
+		t.Fatal("Apply must return the swanctl --load-all failure")
+	}
+	if !errors.Is(err, reloadErr) {
+		t.Fatalf("Apply error must wrap the reload error, got %v", err)
+	}
+	if got := rec.terminated(); len(got) != 0 {
+		t.Fatalf("a failed reload must not terminate any connection "+
+			"(target is still the loaded, effective config), got %v", got)
+	}
+	if !m.tracks("target") || !m.tracks("sibling") {
+		t.Fatal("prevConnNames must still track both connections after a failed reload " +
+			"so a later successful apply retries the teardown")
+	}
+
+	// Reload recovers; the same unrenderable apply now tears target's stale SA.
+	rec.failLoadAll = false
+	if err := m.Apply(broken); err != nil {
+		t.Fatalf("recovered Apply: %v", err)
+	}
+	if got := rec.terminated(); len(got) != 1 || got[0] != "target" {
+		t.Fatalf("the recovered apply must terminate the now-unrenderable target, got %v", got)
+	}
+}


### PR DESCRIPTION
Closes #5494

## Problem — security fail-open on the HA / tolerant-load path

`Manager.Apply` (pkg/ipsec/manager.go) diffed the applied connection set
by VPN **name** (the raw `ipsecCfg.VPNs` map key via `vpnConnNameSet`),
**not** by what `renderConfig` actually emitted.

On the tolerant persisted / peer-synced load path a valid, established
VPN can become **unrenderable** while still present in the config:

- unresolvable gateway reference (`resolveRemoteAddr` skip, #2074)
- broken ike-policy chain (`errIKEChainUnresolved` skip, #2270)
- `protocol ah` proposal with no ESP render path (`vpnUsesAHProposal` skip, #4298)

In every case `renderConfig` **omits** the connection but **returns
success**, `swanctl --load-all` **succeeds**, and the raw-name set still
contained the VPN. So `promoteConnNames` saw **no removal**,
`terminateRemovedConns` was **not** called, and strongSwan's existing
child SA kept forwarding under now-unloaded (stale) selectors/credentials
while the apply reported convergence — a **fail-open**. A stale peer stays
authorized under OLD policy. (#4898 only guards the FAILED-reload case;
here the reload SUCCEEDS.)

**Invariant restored:** after a successful apply, every forwarding child
SA must correspond to a connection actually **rendered + loaded**, or be
actively terminated.

## Fix

`renderConfig` now returns the **exact set of connection names it
emitted**; `Apply` diffs **that** rendered set against `prevConnNames`. A
previously-loaded connection absent from the new rendered set — whether
the operator **deleted** it or it was **skipped as unrenderable** — is a
departure, so its live child SA is torn down. The rendered set is the
single source of truth, so the skip logic can never drift from the
teardown diff.

## ⚠️ This FLIPS a documented-intentional behavior (for the reviewer)

The prior `promoteConnNames` comment stated a VPN that "merely became
unrenderable ... is **NOT** treated as removed and keeps its SAs" — a
deliberate #3941 choice to survive **transient** unrenderability. This PR
reverses that on purpose.

**Adjudication (security > availability for an IPsec appliance):** an
unrenderable VPN's connection is neither loaded nor validated by swanctl,
so continuing to forward under its stale policy is the fail-open a
compromised / mis-synced peer exploits — tearing the SA fails closed.

**Availability tradeoff:** a transiently-unrenderable VPN's SA is now torn
until its config becomes renderable again. Acceptable, because an
unrenderable VPN is **already** non-functional for rekey / new-SA
establishment — keeping a stale authorized SA buys no real availability
while leaving the hole open.

## What is preserved

- **#4898 reload-success gate** — a FAILED `swanctl --load-all` still
  tears **nothing** (the old config remains the loaded, effective policy);
  promotion + teardown fire only after a successful reload. A render hard
  error (non-skip) also leaves `prevConnNames` untouched.
- **#3941 explicit deletion** — a genuinely deleted VPN is still
  terminated, unchanged.
- Precision: a still-rendered connection is **never** torn (re-apply of an
  unchanged config terminates nothing).

## Tests — `pkg/ipsec/unrenderable_terminate_5494_test.go`

From a rendered+loaded starting state with a live SA (target + sibling),
break `target` via **each** skip class and assert its stale SA is torn
while the still-renderable sibling keeps its SA:

- `TestUnrenderableGatewayRefTerminatesSA_5494` (dangling gateway name)
- `TestUnrenderableAddresslessGatewayTerminatesSA_5494` (defined-but-unroutable gateway)
- `TestUnrenderableIKEChainTerminatesSA_5494` (unresolved ike-policy chain)
- `TestUnrenderableAHProposalTerminatesSA_5494` (AH proposal)
- `TestReapplyRenderableDoesNotTerminate_5494` (no false teardown for a still-loaded conn)
- `TestGenuineRemovalStillTerminates_5494` (#3941 unchanged)
- `TestUnrenderableWithFailedReloadDoesNotTerminate_5494` (#4898 gate preserved on the unrenderable path — nothing torn on failed reload, retried on recovery)

**RED-on-revert:** simulating the old name-keyed diff (mark every VPN
name rendered, including skipped ones) makes all four
unrenderable-terminate tests fail — `stale SA must be torn down exactly
once, got []` — the fail-open this fix closes. Restored; verified green.

## Validation

- `go build ./...` — clean
- `go test ./pkg/ipsec/...` — ok
- `gofmt` — clean
- Docs: `pkg/ipsec/README.md` updated (the flipped teardown contract + the
  now-corrected `promoteConnNames`/`Apply` comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KFsLx9svVJS1r3x2uUBKD