### PR TITLE
configstore: sweep crash-leaked fsatomic temps on factory reset

### DIFF
--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -390,8 +390,16 @@ per-path:
   (the pre-#5197 code discarded it), so a non-durable wipe is never
   reported as a clean factory reset. All routes go through the
   `rbRemove`/`rbSyncDir` seams so a dropped sync fails a test RED. The
-  gRPC `zeroizeConfigDir` mirror in `pkg/grpcapi` carries the same
-  barriers (its own `zeroizeSyncDir` seam).
+  top-level sweep also removes fsatomic crash-leaked write temps
+  (`.<base>.tmp-*`, #5475) — a daemon killed between `fsatomic`'s
+  `CreateTemp` and its rename leaves a temp holding the full cleartext
+  config text it was mid-writing (xpf.conf / rescue.conf / a rollback
+  slot). `fsatomic` self-heals such a temp on the next write to that
+  base (`NewDB` sweeps the same `.*.tmp-*` glob inside `.configdb`), but
+  a factory reset + reboot means there is no next write, so an unswept
+  top-level temp — and its secrets — would survive. The gRPC
+  `zeroizeConfigDir` mirror in `pkg/grpcapi` carries the same barriers
+  (its own `zeroizeSyncDir` seam) and the same `.<base>.tmp-*` sweep.
 - **`FactoryResetArchiveDir` — local config-archive erasure (#5186).**
   `zeroize` must remove EVERY on-box generation of config secrets. The
   config archive (`<archive-dir>/config-*.conf`, 0600 full-config-text

--- a/pkg/configstore/factory_reset.go
+++ b/pkg/configstore/factory_reset.go
@@ -121,6 +121,17 @@ func FactoryResetArchiveDir(archiveDir string) error {
 //     boot, so leaving them behind allows a rollback to the prior config).
 //   - *.conf                — the live config + rescue.conf (legacy set).
 //   - rollback*             — legacy rollback naming (pre-DB set).
+//   - .<base>.tmp-*         — fsatomic crash-leaked write temps (#5475): a
+//     daemon killed between fsatomic's CreateTemp and its rename leaves a
+//     ".<base>.tmp-<rand>" file (pkg/fsatomic createTemp) still holding the FULL
+//     cleartext config text it was mid-writing (xpf.conf / rescue.conf / a
+//     numbered rollback slot) — IKE PSKs, WireGuard keys, SNMP communities.
+//     fsatomic self-heals a leaked temp on the NEXT write to that base
+//     (configstore NewDB sweeps the identical ".*.tmp-*" glob inside .configdb),
+//     but a factory reset + reboot means there is no next write, so the temp —
+//     and its secrets — would otherwise survive. Temps INSIDE .configdb are
+//     already erased by the RemoveAll above; only TOP-LEVEL configDir temps
+//     needed this sweep.
 //
 // Discipline: os.ErrNotExist is never an error (an already-absent artifact is
 // the goal); removal is best-effort past a single stubborn file, but the FIRST
@@ -177,7 +188,8 @@ func FactoryResetConfigDir(configDir, configBase string) error {
 			strings.HasPrefix(name, "rollback") ||
 			name == ".config.journal" ||
 			strings.HasPrefix(name, ".config.journal.") ||
-			isTextRollbackSlot(name, configBase) {
+			isTextRollbackSlot(name, configBase) ||
+			isFsatomicTemp(name) {
 			fail(os.Remove(filepath.Join(configDir, name)))
 		}
 	}
@@ -208,4 +220,21 @@ func isTextRollbackSlot(name, configBase string) bool {
 		}
 	}
 	return true
+}
+
+// isFsatomicTemp reports whether name is a crash-leaked fsatomic write temp —
+// the ".<base>.tmp-<random>" shape pkg/fsatomic gives every temp it creates
+// before the atomic rename (fsatomic.go createTemp: `"."+base+".tmp-"`). A
+// daemon killed between CreateTemp and the rename leaves one behind still
+// holding the FULL cleartext config text it was mid-writing (xpf.conf /
+// rescue.conf / a numbered rollback slot with IKE PSKs, WireGuard keys, SNMP
+// communities), and after a factory reset + reboot there is no next write to
+// that base to self-heal it (#5475). The glob is the exact one the configstore
+// NewDB sweep uses inside .configdb (db.go) — KEEP IN SYNC with fsatomic's temp
+// naming. It is intentionally narrow: only a dotfile that contains ".tmp-"
+// matches, so legitimate dotfiles (.config.journal, .config.journal.N) are left
+// for their own rules. The pattern is a constant, so Match never errors.
+func isFsatomicTemp(name string) bool {
+	ok, _ := filepath.Match(".*.tmp-*", name)
+	return ok
 }

--- a/pkg/configstore/factory_reset_temp_5475_test.go
+++ b/pkg/configstore/factory_reset_temp_5475_test.go
@@ -1,0 +1,123 @@
+package configstore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// zeroizeSecret5475 is a distinctive cleartext marker standing in for the IKE
+// PSK / WireGuard key / SNMP community that a crash-leaked fsatomic temp would
+// carry. It must not survive a factory reset.
+const zeroizeSecret5475 = "ZEROIZE-SECRET-5475-crash-temp-psk"
+
+// TestFactoryResetConfigDirRemovesFsatomicTemps pins #5475: the top-level sweep
+// must also delete fsatomic crash-leaked write temps (".<base>.tmp-<rand>").
+// fsatomic (pkg/fsatomic createTemp) names its pre-rename temp
+// ".<base>.tmp-<random>"; a daemon killed mid-write leaves one at the top level
+// of configDir still holding the FULL cleartext config text (xpf.conf /
+// rescue.conf / a numbered rollback slot). Before this fix none of the sweep
+// matchers (`.conf` suffix, `rollback` prefix, `.config.journal[.N]`, numbered
+// text rollback slot) matched a name ending in "-<rand>", so the temp — and its
+// secrets — survived the reset and the completing reboot.
+//
+// RED on revert: drop the `|| isFsatomicTemp(name)` clause and every temp below
+// survives — the assertAbsent checks fail.
+func TestFactoryResetConfigDirRemovesFsatomicTemps(t *testing.T) {
+	dir := t.TempDir()
+	configBase := "xpf.conf"
+	marker := []byte(zeroizeSecret5475)
+
+	// Crash-leaked fsatomic temps for every top-level base that fsatomic writes:
+	// the live config, rescue.conf, a numbered rollback slot, and the audit
+	// journal (whose base is itself ".config.journal", giving a double-dot temp).
+	temps := []string{
+		filepath.Join(dir, ".xpf.conf.tmp-abc123"),
+		filepath.Join(dir, ".rescue.conf.tmp-DEADBEEF"),
+		filepath.Join(dir, ".xpf.conf.1.tmp-0f0f"),
+		filepath.Join(dir, "..config.journal.tmp-99"),
+	}
+	for _, p := range temps {
+		if err := os.WriteFile(p, marker, 0o600); err != nil {
+			t.Fatalf("seed temp %s: %v", p, err)
+		}
+	}
+
+	// Normal artifacts handled by the pre-existing rules, to confirm they are
+	// still removed alongside the new temp sweep.
+	liveConf := filepath.Join(dir, configBase)
+	rescue := filepath.Join(dir, "rescue.conf")
+	textRollback := filepath.Join(dir, configBase+".1")
+	journal := filepath.Join(dir, ".config.journal")
+	for _, p := range []string{liveConf, rescue, textRollback, journal} {
+		if err := os.WriteFile(p, marker, 0o600); err != nil {
+			t.Fatalf("seed %s: %v", p, err)
+		}
+	}
+
+	// A legitimate non-temp dotfile must NOT be swept — isFsatomicTemp must be
+	// narrow enough to leave unrelated dotfiles alone.
+	keep := filepath.Join(dir, ".keepme")
+	if err := os.WriteFile(keep, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("seed keepme: %v", err)
+	}
+	// And a plain bystander (already guarded by the sibling test, re-asserted).
+	bystander := filepath.Join(dir, "node-id")
+	if err := os.WriteFile(bystander, []byte("0"), 0o600); err != nil {
+		t.Fatalf("seed bystander: %v", err)
+	}
+
+	if err := FactoryResetConfigDir(dir, configBase); err != nil {
+		t.Fatalf("FactoryResetConfigDir: %v", err)
+	}
+
+	// Every crash-leaked temp is gone (the fix; RED on revert).
+	for _, p := range temps {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("expected fsatomic temp %s absent after factory reset, stat err = %v", p, err)
+		}
+	}
+	// The normal artifacts are still removed by their own rules.
+	for _, p := range []string{liveConf, rescue, textRollback, journal} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("expected %s absent after factory reset, stat err = %v", p, err)
+		}
+	}
+	// Scope guards: the non-temp dotfile and the plain bystander survive.
+	if _, err := os.Stat(keep); err != nil {
+		t.Errorf("factory reset removed a legitimate non-temp dotfile %s: %v", keep, err)
+	}
+	if _, err := os.Stat(bystander); err != nil {
+		t.Errorf("factory reset removed a non-xpf file %s: %v", bystander, err)
+	}
+}
+
+// TestIsFsatomicTemp pins the crash-leaked-temp recognizer: it matches the
+// ".<base>.tmp-<rand>" shape fsatomic writes (any base, including double-dot
+// journal temps and numbered rollback-slot temps) without eating legitimate
+// dotfiles or the normal config artifacts.
+func TestIsFsatomicTemp(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{".xpf.conf.tmp-abc123", true},      // live config temp
+		{".rescue.conf.tmp-DEADBEEF", true}, // rescue temp
+		{".xpf.conf.1.tmp-0f0f", true},      // rollback-slot temp
+		{"..config.journal.tmp-99", true},   // journal temp (double dot)
+		{".xpf.conf.tmp-", true},            // empty random suffix (still a temp)
+		{"xpf.conf", false},                 // live config (no leading dot / .tmp-)
+		{"xpf.conf.1", false},               // text rollback slot
+		{".config.journal", false},          // audit journal (no .tmp-)
+		{".config.journal.1", false},        // rotated journal segment
+		{".keepme", false},                  // unrelated dotfile
+		{"node-id", false},                  // plain bystander
+		{"xpf.conf.tmp-abc", false},         // no leading dot — not an fsatomic temp
+		{".tmp-abc", false},                 // no ".tmp-" (needs a base before it)
+	}
+	for _, tc := range cases {
+		if got := isFsatomicTemp(tc.name); got != tc.want {
+			t.Errorf("isFsatomicTemp(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/pkg/grpcapi/server_diag_zeroize.go
+++ b/pkg/grpcapi/server_diag_zeroize.go
@@ -61,6 +61,15 @@ const (
 //     to — the exact leak #4576 closes
 //   - *.conf                    — the live config + rescue.conf (pre-#4576 set)
 //   - rollback*                 — legacy rollback naming (pre-#4576 set)
+//   - .<base>.tmp-*             — fsatomic crash-leaked write temps (#5475): a
+//     daemon killed between fsatomic's CreateTemp and its rename leaves a
+//     ".<base>.tmp-<rand>" file (pkg/fsatomic createTemp) still holding the FULL
+//     cleartext config text it was mid-writing (xpf.conf / rescue.conf / a
+//     rollback slot). fsatomic self-heals a leaked temp on the NEXT write to
+//     that base, but a factory reset + reboot means there is no next write, so
+//     the temp — and its secrets — would otherwise survive. Temps inside
+//     .configdb / tls are already erased by the RemoveAll calls above; only
+//     TOP-LEVEL configDir temps needed this sweep.
 //   - .config.journal[.N]       — the JSONL audit journal + rotated segments
 //     (0644, prior-tenant commit history/comments; legacy v1 fat lines may
 //     carry full config incl. secrets). This SUPERSEDES the #4108 "journal
@@ -133,7 +142,8 @@ func zeroizeConfigDir(configDir, configBase string) error {
 			strings.HasPrefix(name, "rollback") ||
 			name == ".config.journal" ||
 			strings.HasPrefix(name, ".config.journal.") ||
-			isTextRollbackFile(name, configBase) {
+			isTextRollbackFile(name, configBase) ||
+			isFsatomicTemp(name) {
 			fail(os.Remove(filepath.Join(configDir, name)))
 		}
 	}
@@ -164,6 +174,24 @@ func isTextRollbackFile(name, configBase string) bool {
 		}
 	}
 	return true
+}
+
+// isFsatomicTemp reports whether name is a crash-leaked fsatomic write temp —
+// the ".<base>.tmp-<random>" shape pkg/fsatomic gives every temp it creates
+// before the atomic rename (fsatomic.go createTemp: `"."+base+".tmp-"`). A
+// daemon killed between CreateTemp and the rename leaves one behind still
+// holding the FULL cleartext config text it was mid-writing (xpf.conf /
+// rescue.conf / a numbered rollback slot with IKE PSKs, WireGuard keys, SNMP
+// communities), and after a factory reset + reboot there is no next write to
+// that base to self-heal it (#5475). The glob is the exact one the configstore
+// NewDB sweep uses inside .configdb (configstore/db.go) — KEEP IN SYNC with
+// fsatomic's temp naming and the sibling configstore.FactoryResetConfigDir
+// sweep. It is intentionally narrow: only a dotfile that contains ".tmp-"
+// matches, so legitimate dotfiles (.config.journal, .config.journal.N) are left
+// for their own rules. The pattern is a constant, so Match never errors.
+func isFsatomicTemp(name string) bool {
+	ok, _ := filepath.Match(".*.tmp-*", name)
+	return ok
 }
 
 // zeroizeRenderedConfigs erases the RENDERED service configs xpfd writes

--- a/pkg/grpcapi/zeroize_temp_5475_test.go
+++ b/pkg/grpcapi/zeroize_temp_5475_test.go
@@ -1,0 +1,87 @@
+package grpcapi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// zeroizeTempMarker5475 stands in for the IKE PSK / WireGuard key / SNMP
+// community a crash-leaked fsatomic temp would carry; no file holding it may
+// survive a zeroize.
+const zeroizeTempMarker5475 = "MARKER-SECRET-5475-crash-temp"
+
+// TestZeroizeConfigDirRemovesFsatomicTemps pins #5475 for the gRPC factory-reset
+// path: zeroizeConfigDir's top-level sweep must also delete fsatomic
+// crash-leaked write temps (".<base>.tmp-<rand>", pkg/fsatomic createTemp). A
+// daemon killed between CreateTemp and the rename leaves one at the top level of
+// configDir still holding the FULL cleartext config text it was mid-writing.
+// Before this fix the sweep matched only `.conf` / `rollback*` /
+// `.config.journal[.N]` / numbered rollback slots, so a name ending in "-<rand>"
+// slipped through and its secrets survived the reset and the completing reboot.
+//
+// RED on revert: drop the `|| isFsatomicTemp(name)` clause and every temp below
+// survives — the assertAbsent checks fail.
+func TestZeroizeConfigDirRemovesFsatomicTemps(t *testing.T) {
+	dir := t.TempDir()
+	configBase := "xpf.conf"
+	marker := []byte(zeroizeTempMarker5475)
+
+	temps := []string{
+		filepath.Join(dir, ".xpf.conf.tmp-abc123"),
+		filepath.Join(dir, ".rescue.conf.tmp-DEADBEEF"),
+		filepath.Join(dir, ".xpf.conf.1.tmp-0f0f"),
+		filepath.Join(dir, "..config.journal.tmp-99"),
+	}
+	for _, p := range temps {
+		mustWriteFile(t, p, marker)
+	}
+
+	// A legitimate non-temp dotfile must survive — the recognizer is narrow.
+	keep := filepath.Join(dir, ".keepme")
+	mustWriteFile(t, keep, []byte("keep"))
+	bystander := filepath.Join(dir, "node-id")
+	mustWriteFile(t, bystander, []byte("0"))
+
+	if err := zeroizeConfigDir(dir, configBase); err != nil {
+		t.Fatalf("zeroizeConfigDir returned error: %v", err)
+	}
+
+	for _, p := range temps {
+		assertAbsent(t, p)
+	}
+	if _, err := os.Stat(keep); err != nil {
+		t.Errorf("zeroize removed a legitimate non-temp dotfile %s: %v", keep, err)
+	}
+	if _, err := os.Stat(bystander); err != nil {
+		t.Errorf("zeroize removed a non-xpf file %s: %v", bystander, err)
+	}
+}
+
+// TestIsFsatomicTempGRPC pins the gRPC-side recognizer (kept in sync with the
+// configstore sibling) so the two factory-reset paths sweep the identical
+// ".<base>.tmp-<rand>" shape without eating legitimate dotfiles.
+func TestIsFsatomicTempGRPC(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{".xpf.conf.tmp-abc123", true},
+		{".rescue.conf.tmp-DEADBEEF", true},
+		{".xpf.conf.1.tmp-0f0f", true},
+		{"..config.journal.tmp-99", true},
+		{"xpf.conf", false},
+		{"xpf.conf.1", false},
+		{".config.journal", false},
+		{".config.journal.1", false},
+		{".keepme", false},
+		{"node-id", false},
+		{"xpf.conf.tmp-abc", false},
+		{".tmp-abc", false},
+	}
+	for _, tc := range cases {
+		if got := isFsatomicTemp(tc.name); got != tc.want {
+			t.Errorf("isFsatomicTemp(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

A `request system zeroize` factory reset must remove **every** on-disk generation of the prior tenant's cleartext config secrets (IKE PSKs, WireGuard private keys, SNMP communities). The top-level `configDir` sweep in **both** factory-reset entry points —

- `configstore.FactoryResetConfigDir` (`pkg/configstore/factory_reset.go`, the on-box CLI path via `pkg/cli/cli_request_system.go`), and
- `grpcapi.zeroizeConfigDir` (`pkg/grpcapi/server_diag_zeroize.go`, the gRPC `performZeroizeWipe` path via `SystemAction`)

— enumerated the directory and removed only files matching a fixed set of shapes: the `.conf` suffix, the `rollback` prefix, `.config.journal[.N]`, and the numbered text rollback slots `<base>.<N>`. **None of those match a crash-leaked fsatomic write temp.**

`pkg/fsatomic` writes every file via temp-in-same-dir + rename, naming the temp `.<base>.tmp-<random>` (`fsatomic.go:311` — `createTemp(dir, "."+filepath.Base(target)+".tmp-")`). A daemon killed between `CreateTemp` and the rename leaves that temp at the top level of `configDir`, still holding the **full cleartext config text** it was mid-writing (`xpf.conf`, `rescue.conf`, or a numbered rollback slot). It ends in `-<random>`, so it fails `HasSuffix(name, ".conf")` and every other matcher, and **survives the reset**.

fsatomic self-heals a leaked temp on the *next* write to that base (`configstore.NewDB` sweeps the identical `.*.tmp-*` glob inside `.configdb`), but after a factory reset + reboot there is no next write — so the temp and its secrets persist and are handed to the next owner. Temps *inside* `.configdb` (and grpcapi's `tls/`) are already covered by the `RemoveAll` of those subtrees; only **top-level** `configDir` temps leaked.

## Fix

Extend the top-level sweep in both entry points with an `isFsatomicTemp(name)` matcher that removes any file matching the fsatomic temp shape. The matcher uses the exact `.*.tmp-*` glob the `configstore.NewDB` sweep already uses (`filepath.Match`), keeping it in sync with fsatomic's temp naming. It is intentionally narrow — only a dotfile that contains `.tmp-` matches — so legitimate dotfiles (`.config.journal`, `.config.journal.N`) and unrelated dotfiles are left alone. All existing sweep behavior is preserved.

The archive-omission sibling is already fixed by #5186; this is the residual fsatomic-temp sweep.

## Validation

- `go build ./...`; `go vet ./pkg/configstore/... ./pkg/grpcapi/...` — clean.
- `go test ./pkg/configstore/... ./pkg/grpcapi/...` — green.
- New regressions in both packages seed top-level fsatomic temps (`.xpf.conf.tmp-*`, `.rescue.conf.tmp-*`, `.xpf.conf.1.tmp-*`, and the double-dot journal temp `..config.journal.tmp-*`) plus the normal artifacts and a legitimate non-temp dotfile, then assert every temp is removed while the dotfile and a non-xpf bystander survive. A recognizer unit test pins the positive/negative shapes.

### RED-on-revert (proven)

Removing the `|| isFsatomicTemp(name)` clause in **both** files makes all four seeded temps survive → the new tests FAIL in both packages:

```
--- FAIL: TestFactoryResetConfigDirRemovesFsatomicTemps
    expected fsatomic temp .../.xpf.conf.tmp-abc123 absent after factory reset, stat err = <nil>
    expected fsatomic temp .../.rescue.conf.tmp-DEADBEEF absent after factory reset, stat err = <nil>
    expected fsatomic temp .../.xpf.conf.1.tmp-0f0f absent after factory reset, stat err = <nil>
    expected fsatomic temp .../..config.journal.tmp-99 absent after factory reset, stat err = <nil>
--- FAIL: TestZeroizeConfigDirRemovesFsatomicTemps
    expected .../.xpf.conf.tmp-abc123 to be absent after zeroize, stat err = <nil>
    ...
```

Restoring the clause returns green.

## Docs

`pkg/configstore/README.md` and both function doc comments updated to list the `.<base>.tmp-*` sweep and note that a factory reset + reboot is the one time fsatomic's self-heal never runs.

Closes #5475

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BwS3MFtDv3azeAio1VSiq