### PR TITLE
userspace: quarantine cross-zone host-inbound unit override bleed (#5489)

### DIFF
--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -389,12 +389,26 @@ silently shadowed the more-specific unit ref (fail-open, admitting a service the
 unit did not open, or fail-closed, denying one it did). The fix MERGES (unions)
 the two levels instead.
 
-**Cross-zone quarantine (#3720 M01).** The physical→unit expansion does NOT
-apply a physical override to a unit that resolves to a **different** zone. On the
-lenient / peer-synced load path an ownership conflict is downgraded to a warning
-(`compiler_validate_strict.go`), so a physical `ifN` override owned by zone
-trust could otherwise leak its tokens onto `ifN.M` owned by zone guest. The
-expansion skips any unit whose resolved zone differs from the override's zone.
+**Cross-zone quarantine (#3720 M01, #5489).** A host-inbound override must
+contribute to a unit's effective set ONLY from the unit's authoritative zone
+owner. On the lenient / peer-synced load path an ownership conflict is downgraded
+to a warning (`compiler_validate_strict.go`) and `buildInterfaceZoneMap` resolves
+the owner as the **first sorted zone** that claims the unit, so two zones can
+both name the same `ifN.M` while only one owns it. Both branches of
+`buildInterfaceHostInboundMap` (`pkg/dataplane/userspace/zones_override.go`)
+enforce the owner predicate `zoneByIface[ref] == zn`:
+
+- **physical→unit expansion (#3720 M01)** does NOT apply a physical `ifN`
+  override owned by zone trust onto `ifN.M` owned by zone guest — it skips any
+  unit whose resolved zone differs from the override's zone.
+- **exact unit-level ref (#5489)** does NOT merge a `ifN.M` override authored by
+  a **non-owner** zone into `out["ifN.M"]`. Before #5489 the exact-unit branch
+  unioned every zone's override unconditionally, so a losing zone's admission
+  token (e.g. `ssh`) bled into the winning zone's `InterfaceSnapshot` /
+  `ZoneHostInboundView` — a cross-zone host-inbound admission escalation. The
+  quarantine mirrors the physical branch exactly (same `z != "" && z != zn`
+  predicate, same skip), so a unit's effective tokens come only from its
+  authoritative owner. Single-owner (non-conflict) configs are unchanged.
 
 **Presentation parity (#3720 H05).** `ZoneConfig.InterfaceHostInboundEffective`
 (`pkg/config/host_inbound_view.go`) — used by `show interfaces <unit>`, `show

--- a/pkg/dataplane/userspace/host_inbound_owner_5489_test.go
+++ b/pkg/dataplane/userspace/host_inbound_owner_5489_test.go
@@ -1,0 +1,199 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5489: cross-zone host-inbound admission bleed on the EXACT-UNIT branch of
+// buildInterfaceHostInboundMap. The physical-expansion branch already carries a
+// #3720 cross-zone quarantine (`zoneByIface[un] != zn`), but the logical-unit
+// branch (`strings.Contains(ref, ".")`) unconditionally UNIONed the override for
+// EVERY zone that named the unit. On a tolerated duplicate ownership (a lenient
+// `load override` / peer-sync retaining two zones both claiming the same
+// reth0.100), buildInterfaceZoneMap resolves the OWNER as the first sorted zone,
+// but the override loop visited BOTH zones and merged each into out[ref], so the
+// winning zone's InterfaceSnapshot / ZoneHostInboundView received the UNION —
+// including the LOSING zone's admission tokens (e.g. SSH). These tests are
+// fail-on-revert: drop the exact-unit guard and the losing zone's ssh bleeds
+// into the owner's effective set and the assertions go RED.
+
+// hostInboundCfg5489 declares TWO zones both claiming reth0.100. The owner
+// (first sorted: "azone-owner") authors a unit override admitting ONLY ping. The
+// loser ("zzone-loser") authors a unit override admitting ssh that the owner
+// lacks. Neither zone declares a zone-level host-inbound stanza, so the
+// effective set is exactly the resolved per-interface override.
+func hostInboundCfg5489() *config.Config {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{
+			100: {Number: 100, Addresses: []string{"10.0.100.1/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"azone-owner": {
+			Name:       "azone-owner",
+			Interfaces: []string{"reth0.100"},
+			InterfaceHostInbound: map[string]*config.HostInboundTraffic{
+				"reth0.100": {SystemServices: []string{"ping"}},
+			},
+		},
+		"zzone-loser": {
+			Name:       "zzone-loser",
+			Interfaces: []string{"reth0.100"},
+			InterfaceHostInbound: map[string]*config.HostInboundTraffic{
+				"reth0.100": {SystemServices: []string{"ssh"}},
+			},
+		},
+	}
+	return cfg
+}
+
+func containsStr(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// Test_5489_OwnerZonePicksFirstSorted confirms the ownership premise: on a
+// duplicate-ownership config, buildInterfaceZoneMap resolves the unit's owner to
+// the first sorted zone, and the loser is NOT the owner.
+func Test_5489_OwnerZonePicksFirstSorted(t *testing.T) {
+	z := buildInterfaceZoneMap(hostInboundCfg5489())
+	if got := z["reth0.100"]; got != "azone-owner" {
+		t.Fatalf("buildInterfaceZoneMap owner of reth0.100 = %q, want azone-owner (first sorted)", got)
+	}
+}
+
+// Test_5489_ExactUnitNoCrossZoneLeak is the core fail-on-revert: the resolved
+// override for reth0.100 must carry ONLY the owner zone's tokens ([ping]) — the
+// losing zone's ssh admission must NOT bleed into out[ref]. Revert the exact-unit
+// guard and out["reth0.100"] becomes [ping ssh] (the union) and this goes RED.
+func Test_5489_ExactUnitNoCrossZoneLeak(t *testing.T) {
+	m := buildInterfaceHostInboundMap(hostInboundCfg5489())
+
+	ov := m["reth0.100"]
+	if ov == nil {
+		t.Fatal("reth0.100 must carry the owner zone's effective override")
+	}
+	if containsStr(ov.SystemServices, "ssh") {
+		t.Errorf("reth0.100 effective services = %v: losing zone's ssh admission bled into the owner's view (#5489)", ov.SystemServices)
+	}
+	if !eqStr(ov.SystemServices, []string{"ping"}) {
+		t.Errorf("reth0.100 effective services = %v, want [ping] (owner-only, no cross-zone union)", ov.SystemServices)
+	}
+}
+
+// Test_5489_SnapshotNoCrossZoneLeak is the end-to-end fail-on-revert through the
+// InterfaceSnapshot stamping path (buildInterfaceSnapshots): the reth0.100
+// snapshot is stamped from its OWNER zone, so its effective host-inbound set must
+// be [ping] with no ssh from the losing zone.
+func Test_5489_SnapshotNoCrossZoneLeak(t *testing.T) {
+	snaps := buildInterfaceSnapshots(hostInboundCfg5489())
+	var found bool
+	for _, s := range snaps {
+		if s.Name != "reth0.100" {
+			continue
+		}
+		found = true
+		if s.Zone != "azone-owner" {
+			t.Errorf("reth0.100 snapshot Zone = %q, want azone-owner (owner)", s.Zone)
+		}
+		if !s.HostInboundConfigured {
+			t.Errorf("reth0.100 snapshot must mark HostInboundConfigured")
+		}
+		if containsStr(s.HostInboundSystemServices, "ssh") {
+			t.Errorf("reth0.100 snapshot services = %v: losing zone's ssh bled in (#5489)", s.HostInboundSystemServices)
+		}
+		if !eqStr(s.HostInboundSystemServices, []string{"ping"}) {
+			t.Errorf("reth0.100 snapshot services = %v, want [ping]", s.HostInboundSystemServices)
+		}
+	}
+	if !found {
+		t.Fatal("no InterfaceSnapshot emitted for reth0.100")
+	}
+}
+
+// Test_5489_ViewNoCrossZoneLeak is the end-to-end fail-on-revert through
+// BuildZoneHostInboundViews: reth0.100's address lands in the owner zone's view
+// whose effective set is [ping], never the losing zone's ssh.
+func Test_5489_ViewNoCrossZoneLeak(t *testing.T) {
+	views := BuildZoneHostInboundViews(hostInboundCfg5489())
+	byAddr := map[string][]string{}
+	zoneByAddr := map[string]string{}
+	for _, v := range views {
+		for _, a := range v.V4Addrs {
+			byAddr[a] = v.SystemServices
+			zoneByAddr[a] = v.Zone
+		}
+	}
+	if z := zoneByAddr["10.0.100.1"]; z != "azone-owner" {
+		t.Errorf("reth0.100 address scoped to zone %q, want azone-owner", z)
+	}
+	if containsStr(byAddr["10.0.100.1"], "ssh") {
+		t.Errorf("reth0.100 view services = %v: losing zone's ssh bled into the owner's view (#5489)", byAddr["10.0.100.1"])
+	}
+	if !eqStr(byAddr["10.0.100.1"], []string{"ping"}) {
+		t.Errorf("reth0.100 view services = %v, want [ping]", byAddr["10.0.100.1"])
+	}
+}
+
+// Test_5489_SingleOwnerUnaffected proves the guard preserves the non-conflict
+// (single-owner) case bit-for-bit: when exactly ONE zone owns reth0.100, its own
+// unit override is applied normally (the guard's `z == zn` path is a no-op skip).
+func Test_5489_SingleOwnerUnaffected(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{
+			100: {Number: 100, Addresses: []string{"10.0.100.1/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {
+			Name:       "trust",
+			Interfaces: []string{"reth0.100"},
+			InterfaceHostInbound: map[string]*config.HostInboundTraffic{
+				"reth0.100": {SystemServices: []string{"ssh"}},
+			},
+		},
+	}
+	m := buildInterfaceHostInboundMap(cfg)
+	if ov := m["reth0.100"]; ov == nil || !eqStr(ov.SystemServices, []string{"ssh"}) {
+		t.Errorf("single-owner reth0.100 effective = %v, want [ssh] (own override applied)", ov)
+	}
+}
+
+// Test_5489_PhysicalBranchGuardStillHolds re-asserts the pre-existing #3720
+// physical-expansion quarantine survives alongside the new exact-unit guard: a
+// physical override in trust must not leak onto reth0.20 owned by guest, while
+// reth0.10 owned by trust still inherits it.
+func Test_5489_PhysicalBranchGuardStillHolds(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{
+			10: {Number: 10, Addresses: []string{"10.0.10.1/24"}},
+			20: {Number: 20, Addresses: []string{"10.0.20.1/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {
+			Name:       "trust",
+			Interfaces: []string{"reth0"},
+			InterfaceHostInbound: map[string]*config.HostInboundTraffic{
+				"reth0": {SystemServices: []string{"ping"}},
+			},
+		},
+		"guest": {Name: "guest", Interfaces: []string{"reth0.20"}},
+	}
+	m := buildInterfaceHostInboundMap(cfg)
+	if ov := m["reth0.20"]; ov != nil {
+		t.Errorf("reth0.20 (owned by guest) must NOT inherit trust's physical override, got %v", ov.SystemServices)
+	}
+	if ov := m["reth0.10"]; ov == nil || !eqStr(ov.SystemServices, []string{"ping"}) {
+		t.Errorf("reth0.10 (owned by trust) effective = %v, want [ping]", ov)
+	}
+}

--- a/pkg/dataplane/userspace/zones_override.go
+++ b/pkg/dataplane/userspace/zones_override.go
@@ -87,7 +87,11 @@ func mergeHostInboundTraffic(a, b *config.HostInboundTraffic) *config.HostInboun
 // unit ref:
 //   - A ref naming a logical unit (contains ".") is the MOST specific override.
 //     It maps ONLY itself — never a sibling unit — and is MERGED (unioned) onto
-//     whatever physical-inherited set already sits on that unit key.
+//     whatever physical-inherited set already sits on that unit key, BUT only
+//     when THIS zone is the unit's authoritative owner (#5489 quarantine — a
+//     unit-level override on a zone that lost ownership must not leak its tokens
+//     into the winning zone's effective set on the lenient multi-owner warn
+//     path). This mirrors the physical branch's #3720 cross-zone guard below.
 //   - A ref naming a physical interface (no unit suffix) expands to each of its
 //     configured units (mirroring buildInterfaceZoneMap), but NOT onto a unit
 //     resolved to a DIFFERENT zone (#3720 M01 quarantine — a physical override
@@ -131,6 +135,19 @@ func buildInterfaceHostInboundMap(cfg *config.Config) map[string]*config.HostInb
 				continue
 			}
 			if strings.Contains(ref, ".") {
+				// #5489: a unit-level override must come ONLY from the unit's
+				// authoritative zone owner. buildInterfaceZoneMap resolves the
+				// owner as the first sorted zone that claims the unit; on a
+				// tolerated duplicate ownership (lenient load / peer-sync retains
+				// two zones both claiming the same reth0.100) this loop visits
+				// BOTH zones, so without a guard the losing zone's tokens (e.g.
+				// SSH) would union into out[ref] and bleed into the winning zone's
+				// InterfaceSnapshot / ZoneHostInboundView. Quarantine the leak with
+				// the SAME predicate the physical-expansion branch uses (#3720
+				// M01): skip when a DIFFERENT zone owns this unit.
+				if z := zoneByIface[ref]; z != "" && z != zn {
+					continue
+				}
 				// Logical unit ref: the most specific override. Merge (union) it
 				// onto any physical-inherited set already on this unit key. Because
 				// refs are walked sorted and a bare physical ref sorts before its


### PR DESCRIPTION
## Summary

`buildInterfaceHostInboundMap` (`pkg/dataplane/userspace/zones_override.go`) resolves per-interface host-inbound overrides in two branches. The **physical-interface** branch already carries a #3720 M01 cross-zone quarantine (skip a unit whose resolved zone differs from the override's zone), but the **exact logical-unit** branch (`strings.Contains(ref, ".")`) unconditionally UNIONed the override for **every** zone that named the unit — with no check that this zone is the unit's authoritative owner.

## The bleed (security)

On a tolerated duplicate-ownership config — a lenient `load override`, or a peer-sync that retains two security zones both claiming the same `reth0.100`, where the ownership conflict is only downgraded to a warning — `buildInterfaceZoneMap` resolves the authoritative owner as the **first sorted zone**, but the override loop visits **both** zones and merges each into `out[ref]`. So the winning zone's `InterfaceSnapshot` / `ZoneHostInboundView` received the **UNION**, including the **losing** zone's admission tokens (e.g. SSH). A host-inbound admission intended for one zone bled into another — a cross-zone host-inbound admission escalation.

**Invariant restored:** each effective interface host-inbound token set comes ONLY from its authoritative zone owner.

## Fix

Apply the **same** owner predicate the physical branch uses (`zoneByIface[ref] != "" && zoneByIface[ref] != zn`, #3720 M01) to the exact-unit branch, **before** the merge. Quarantine (skip) the merge when a **different** zone owns the unit; the authoritative owner still merges its own override.

This is **distinct from #3720**, which guarded only the physical-expansion branch — the exact-unit branch had **no guard at all**. The single-owner (non-conflict) case and the physical branch are preserved bit-for-bit.

## Validation

New regression `pkg/dataplane/userspace/host_inbound_owner_5489_test.go`: two zones both claiming `reth0.100`, owner admits only `ping`, loser admits `ssh`. Asserts `buildInterfaceZoneMap` picks the first sorted zone as owner and that `out[ref]`, the `InterfaceSnapshot`, and the `ZoneHostInboundView` for `reth0.100` all contain ONLY `[ping]` — never the loser's `ssh`. Also asserts a single-owner config is unaffected and the #3720 physical quarantine still holds.

**RED-on-revert proof** — removing the exact-unit guard makes all three levels report `[ping ssh]` (loser's ssh bleeds in):

```
--- FAIL: Test_5489_ExactUnitNoCrossZoneLeak
    reth0.100 effective services = [ping ssh]: losing zone's ssh admission bled into the owner's view (#5489)
--- FAIL: Test_5489_SnapshotNoCrossZoneLeak
    reth0.100 snapshot services = [ping ssh]: losing zone's ssh bled in (#5489)
--- FAIL: Test_5489_ViewNoCrossZoneLeak
    reth0.100 view services = [ping ssh]: losing zone's ssh bled into the owner's view (#5489)
--- PASS: Test_5489_SingleOwnerUnaffected
--- PASS: Test_5489_PhysicalBranchGuardStillHolds
```

Guard restored → all green.

- `go build ./...` clean; `go test ./pkg/dataplane/...` passes.
- `docs/host-inbound-service-matrix.md` cross-zone-quarantine section updated to document the exact-unit owner guard (#5489) alongside the physical-expansion guard (#3720 M01).

Closes #5489

🤖 Generated with [Claude Code](https://claude.com/claude-code)