### PR TITLE
grpcapi: sweep fsatomic temps from rendered-config dirs on zeroize

### DIFF
--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -190,6 +190,22 @@ error-surfacing discipline):
   xpf-owned snippet; it is removed outright.
 - **`/etc/kea/kea-dhcp{4,6}.conf`** — xpf owns these whole files; removed outright.
 
+Beyond those exact paths, each rendered directory (`/etc/frr`,
+`/etc/swanctl/conf.d`, `/etc/kea`) is **swept for crash-leaked `fsatomic` write
+temps** (`.<base>.tmp-<rand>`, #5509) — the rendered-config sibling of the
+`/etc/xpf` sweep (#5475). All three renders are written via `pkg/fsatomic`
+(`frr.WriteFileDurable`, `ipsec.WriteFileAtomic`, `dhcpserver.WriteFileAtomic`),
+which drops a `.<base>.tmp-<rand>` temp holding the **full cleartext render**
+(routing-auth keys, IKE PSKs, Kea credentials) before its atomic rename. A
+daemon hard-killed mid-write leaves that temp behind; `fsatomic` self-heals a
+leaked temp on the *next* write to that base, but a factory reset + reboot has no
+next write, so an exact-path-only removal (`StripManagedSectionFile` /
+`os.Remove`) would let the temp — and its secrets — survive to the next tenant.
+The sweep is scoped to those xpf-owned rendered directories, matches only the
+narrow temp shape (so a legitimate service config or operator snippet in the same
+directory is untouched), and treats an absent/unmanaged directory as a clean
+no-op.
+
 This must be done by the wipe itself, not deferred to the reconcile on the
 completing reboot: a post-zeroize boot has **no committed config**, so the
 daemon enters **#1922 bootstrap mode** (or, on an HA node, a normal boot with a

--- a/pkg/grpcapi/server_diag_zeroize.go
+++ b/pkg/grpcapi/server_diag_zeroize.go
@@ -209,6 +209,23 @@ func isFsatomicTemp(name string) bool {
 //   - kea4/kea6 (/etc/kea/kea-dhcp{4,6}.conf): xpf owns these whole files, so
 //     they are removed outright.
 //
+// In ADDITION to the exact-path removals above, each rendered-config DIRECTORY
+// is swept for crash-leaked fsatomic write temps (".<base>.tmp-<rand>",
+// isFsatomicTemp), the rendered-config sibling of the #5475 configDir sweep
+// (#5509). frr.conf (frr.WriteFileDurable), the swanctl PSK snippet
+// (ipsec.WriteFileAtomic), and the Kea configs (dhcpserver.WriteFileAtomic) are
+// ALL written via pkg/fsatomic, which drops a ".<base>.tmp-<rand>" temp holding
+// the FULL cleartext render (BGP-MD5/OSPF/IS-IS routing-auth keys, IKE PSKs,
+// Kea credentials) before its atomic rename. A daemon hard-killed mid-write
+// leaves that temp behind; fsatomic self-heals a leaked temp on the NEXT write
+// to that base, but a factory reset + reboot means there is no next write, so
+// the temp — and its cleartext secrets — would otherwise SURVIVE the reset by
+// EXACT PATH (StripManagedSectionFile / os.Remove never touch the temp name).
+// The sweep covers ONLY the directories xpf writes these renders into
+// (dir(frrConf), dir(swanctlSnippet), dir(kea4/kea6) — deduplicated), matches
+// ONLY the narrow fsatomic temp shape, and treats an absent/unmanaged directory
+// as a no-op — it never reaches into unrelated system directories.
+//
 // WHY the wipe must erase these DIRECTLY rather than lean on the completing
 // reboot: a post-zeroize boot has NO committed config, so the daemon enters
 // #1922 bootstrap mode (or, on an HA node, a normal boot with a nil active
@@ -239,7 +256,47 @@ func zeroizeRenderedConfigs(frrConf, swanctlSnippet, kea4, kea6 string) error {
 	fail(os.Remove(swanctlSnippet))
 	fail(os.Remove(kea4))
 	fail(os.Remove(kea6))
+
+	// Sweep crash-leaked fsatomic write temps (#5509). The exact-path removals
+	// above miss a ".<base>.tmp-<rand>" temp a hard-killed daemon left mid-write
+	// — each temp still holds the full cleartext render. Sweep every directory
+	// xpf writes these renders into (deduplicated: kea4/kea6 share /etc/kea).
+	swept := make(map[string]bool)
+	for _, dir := range []string{
+		filepath.Dir(frrConf),
+		filepath.Dir(swanctlSnippet),
+		filepath.Dir(kea4),
+		filepath.Dir(kea6),
+	} {
+		if swept[dir] {
+			continue
+		}
+		swept[dir] = true
+		sweepFsatomicTemps(dir, fail)
+	}
 	return firstErr
+}
+
+// sweepFsatomicTemps removes crash-leaked fsatomic write temps
+// (".<base>.tmp-<rand>", isFsatomicTemp) from a single rendered-config directory
+// (#5509). It ReadDirs dir and os.Remove's only entries whose name matches the
+// narrow fsatomic temp shape, so a legitimate config file or unrelated dotfile
+// in the same directory is left untouched. An absent/unmanaged directory is a
+// clean no-op: ReadDir yields os.ErrNotExist, which fail() excludes, so a
+// directory the appliance does not run (no FRR / strongSwan / Kea installed)
+// never errors the whole zeroize. A real ReadDir error IS surfaced via fail so
+// a silently-incomplete sweep is not reported as a clean factory reset.
+func sweepFsatomicTemps(dir string, fail func(error)) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		fail(err)
+		return
+	}
+	for _, e := range entries {
+		if name := e.Name(); isFsatomicTemp(name) {
+			fail(os.Remove(filepath.Join(dir, name)))
+		}
+	}
 }
 
 // zeroize login-account teardown paths (#4598). These mirror the production

--- a/pkg/grpcapi/zeroize_rendered_temp_5509_test.go
+++ b/pkg/grpcapi/zeroize_rendered_temp_5509_test.go
@@ -1,0 +1,123 @@
+package grpcapi
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// renderedTempSecret5509 stands in for the cleartext secret a crash-leaked
+// fsatomic temp of a RENDERED service config would carry — a BGP-MD5/OSPF/IS-IS
+// routing-auth key in frr.conf, an IKE PSK in the swanctl snippet, or a Kea
+// credential. No file holding it may survive a factory reset.
+const renderedTempSecret5509 = "MARKER-SECRET-5509-rendered-crash-temp"
+
+// TestZeroizeRenderedConfigsRemovesFsatomicTemps pins #5509: zeroizeRenderedConfigs
+// must sweep crash-leaked fsatomic write temps (".<base>.tmp-<rand>",
+// isFsatomicTemp) from EVERY directory it renders cleartext into — /etc/frr,
+// /etc/swanctl/conf.d, /etc/kea — not only remove the known exact paths. Each
+// rendered config is written via pkg/fsatomic (frr.WriteFileDurable,
+// ipsec.WriteFileAtomic, dhcpserver.WriteFileAtomic), which leaves a
+// ".<base>.tmp-<rand>" temp holding the full cleartext render if the daemon is
+// hard-killed between CreateTemp and the atomic rename. A factory reset + reboot
+// has no next write to self-heal it, so without this sweep the temp — and its
+// secrets — survive to the next tenant.
+//
+// This is the rendered-config-dir sibling of #5475 (the configDir sweep),
+// distinct from #5186 (the /var/lib/xpf/archive wipe).
+//
+// RED on revert: delete the sweepFsatomicTemps loop and every temp below
+// survives the wipe — the assertAbsent checks fail.
+func TestZeroizeRenderedConfigsRemovesFsatomicTemps(t *testing.T) {
+	dir := t.TempDir()
+	marker := []byte(renderedTempSecret5509)
+
+	// The three rendered-config directories, each with its own subdir so the
+	// sweep's per-directory scoping is exercised (kea4/kea6 deliberately share
+	// /etc/kea to also exercise the directory dedup).
+	frrConf := filepath.Join(dir, "frr", "frr.conf")
+	swanctlSnippet := filepath.Join(dir, "swanctl", "xpf.conf")
+	kea4 := filepath.Join(dir, "kea", "kea-dhcp4.conf")
+	kea6 := filepath.Join(dir, "kea", "kea-dhcp6.conf")
+
+	// The normal managed renders (so the pre-existing exact-path removal keeps
+	// working alongside the new sweep). frr.conf carries an xpf managed section
+	// so StripManagedSectionFile has something to strip.
+	frrBody := "hostname r1\n" +
+		"! BEGIN BPFRX MANAGED CONFIG - do not edit this section\n" +
+		" ip ospf message-digest-key 1 md5 " + renderedTempSecret5509 + "\n" +
+		"! END BPFRX MANAGED CONFIG\n"
+	mustWriteFile(t, frrConf, []byte(frrBody))
+	mustWriteFile(t, swanctlSnippet, marker)
+	mustWriteFile(t, kea4, marker)
+	mustWriteFile(t, kea6, marker)
+
+	// Crash-leaked fsatomic temps — one per rendered base — each holding the
+	// full cleartext render. These are what the exact-path removal MISSES.
+	temps := []string{
+		filepath.Join(dir, "frr", ".frr.conf.tmp-abc123"),
+		filepath.Join(dir, "swanctl", ".xpf.conf.tmp-DEADBEEF"),
+		filepath.Join(dir, "kea", ".kea-dhcp4.conf.tmp-0f0f"),
+		filepath.Join(dir, "kea", ".kea-dhcp6.conf.tmp-1e1e"),
+	}
+	for _, p := range temps {
+		mustWriteFile(t, p, marker)
+	}
+
+	// Bystanders that must SURVIVE — the sweep is narrow (only ".<base>.tmp-*")
+	// and scoped to xpf's own rendered dirs, so it never eats a legitimate
+	// service config, an operator snippet, or a non-temp dotfile.
+	survivors := []string{
+		filepath.Join(dir, "frr", "daemons"),     // FRR's own file, non-temp
+		filepath.Join(dir, "frr", ".keepme"),     // dotfile without .tmp-
+		filepath.Join(dir, "swanctl", "op.conf"), // operator-owned snippet
+		filepath.Join(dir, "kea", "ctrl-agent.conf"),
+	}
+	for _, p := range survivors {
+		mustWriteFile(t, p, []byte("keep"))
+	}
+
+	if err := zeroizeRenderedConfigs(frrConf, swanctlSnippet, kea4, kea6); err != nil {
+		t.Fatalf("zeroizeRenderedConfigs returned error: %v", err)
+	}
+
+	// Every crash-leaked temp is gone — the leak #5509 closes.
+	for _, p := range temps {
+		assertAbsent(t, p)
+	}
+	// The exact-path removals still happened: swanctl/Kea gone, frr secret+section
+	// stripped.
+	assertAbsent(t, swanctlSnippet)
+	assertAbsent(t, kea4)
+	assertAbsent(t, kea6)
+	got, err := os.ReadFile(frrConf)
+	if err != nil {
+		t.Fatalf("read frr.conf after strip: %v", err)
+	}
+	if strings.Contains(string(got), renderedTempSecret5509) {
+		t.Errorf("frr.conf still carries the routing-auth secret after zeroize:\n%s", got)
+	}
+	// Bystanders untouched.
+	for _, p := range survivors {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("zeroize removed a bystander it must not touch %s: %v", p, err)
+		}
+	}
+}
+
+// TestZeroizeRenderedConfigsTempSweepAbsentDirNoError pins that a rendered dir
+// the appliance does not run (no FRR / strongSwan / Kea installed → the
+// directory is absent) is a clean no-op for the temp sweep, not an error: an
+// absent-directory ReadDir yields os.ErrNotExist, which the wipe excludes.
+func TestZeroizeRenderedConfigsTempSweepAbsentDirNoError(t *testing.T) {
+	dir := t.TempDir()
+	if err := zeroizeRenderedConfigs(
+		filepath.Join(dir, "no-frr", "frr.conf"),
+		filepath.Join(dir, "no-swanctl", "xpf.conf"),
+		filepath.Join(dir, "no-kea", "kea-dhcp4.conf"),
+		filepath.Join(dir, "no-kea", "kea-dhcp6.conf"),
+	); err != nil {
+		t.Fatalf("zeroizeRenderedConfigs over absent rendered dirs returned error: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #5509

## Problem
A factory reset must remove **every** on-box copy of the prior tenant's cleartext secrets. `zeroizeRenderedConfigs` erased the rendered service configs by **exact path only** (`frr.StripManagedSectionFile`, `os.Remove` of the swanctl snippet and the Kea files). It did **not** sweep crash-leaked `fsatomic` write temps, and there is no startup-sweep owner for those directories (`configstore.NewDB` sweeps only `.configdb`).

All three renders are written via `pkg/fsatomic`:
- `pkg/frr/manager.go` → `/etc/frr/frr.conf` (`WriteFileDurable`)
- `pkg/ipsec/manager.go` → `/etc/swanctl/conf.d/xpf.conf` (`WriteFileAtomic`) — a swanctl snippet carrying IKE PSKs in cleartext
- `pkg/dhcpserver/*` → `/etc/kea/kea-dhcp{4,6}.conf` (`WriteFileAtomic`)

`fsatomic` drops a `.<base>.tmp-<rand>` temp holding the **full cleartext render** before its atomic rename. A daemon hard-killed mid-write leaves that temp behind. `fsatomic` self-heals a leaked temp on the *next* write to that base, but a factory reset + reboot means there is **no next write** — so the temp, and its cleartext secrets (IKE PSKs, routing-auth keys, Kea credentials), **survive** the reset and are handed to the next tenant.

This is the **rendered-config-dir sibling of #5475** (MERGED as #5508), which added the same sweep to the `configDir` path. It is **distinct from #5186** (the `/var/lib/xpf/archive` wipe).

## Fix
After the existing exact-path removals, `zeroizeRenderedConfigs` now `ReadDir`s each rendered-config directory it touches (deduplicated — `kea4`/`kea6` share `/etc/kea`) and `os.Remove`s any entry matching the existing `isFsatomicTemp` recognizer (`.*.tmp-*`, the #5475 matcher — reused byte-for-byte since it already lives in this package). The sweep:
- covers **only** the directories xpf renders cleartext into — never reaches into unrelated system directories;
- matches **only** the narrow fsatomic temp shape, so a legitimate service config, an operator-owned snippet, or a non-temp dotfile in the same directory is left untouched;
- treats an absent/unmanaged directory as a clean no-op (`ReadDir` `ErrNotExist` is excluded by `fail()`), so an appliance without FRR/strongSwan/Kea installed does not error the whole zeroize;
- preserves all existing exact-path removal and error-surfacing discipline.

**Directories swept:** `/etc/frr`, `/etc/swanctl/conf.d`, `/etc/kea`.

## Validation
- `go build ./...` clean.
- `go test ./pkg/grpcapi/... ./pkg/configstore/...` passes.
- New regression `TestZeroizeRenderedConfigsRemovesFsatomicTemps` seeds a crash-leaked temp holding a fake secret in **each** rendered dir plus the normal managed files and bystanders; asserts every temp is removed, the exact-path removals still happen, and bystanders survive. `TestZeroizeRenderedConfigsTempSweepAbsentDirNoError` pins the absent-dir no-op.
- **RED-on-revert confirmed:** neutralizing the sweep loop leaves all four temps on disk and the test fails —
  ```
  --- FAIL: TestZeroizeRenderedConfigsRemovesFsatomicTemps
      expected .../frr/.frr.conf.tmp-abc123 to be absent after zeroize, stat err = <nil>
      expected .../swanctl/.xpf.conf.tmp-DEADBEEF to be absent after zeroize, stat err = <nil>
      expected .../kea/.kea-dhcp4.conf.tmp-0f0f to be absent after zeroize, stat err = <nil>
      expected .../kea/.kea-dhcp6.conf.tmp-1e1e to be absent after zeroize, stat err = <nil>
  ```
  Restoring the sweep makes it pass.
- `docs/system-login.md` updated with the rendered-dir temp-sweep note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)