### PR TITLE
cli: error on unknown `show chassis cluster` sub-arg (#5459)

### DIFF
--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -49,35 +49,17 @@ func (c *ctl) handleShow(args []string) error {
 						return c.showText("chassis-cluster-information")
 					case "statistics":
 						return c.showText("chassis-cluster-statistics")
-					case "control-plane":
-						if len(args) >= 4 && args[3] == "statistics" {
-							return c.showText("chassis-cluster-control-plane-statistics")
+					case "control-plane", "data-plane", "ip-monitoring", "fabric":
+						// #5459: an UNRECOGNIZED sub-arg must surface a
+						// usage error, not silently render the default
+						// view (mirrors the strict #1827 `show services
+						// ip-monitoring` handler). A bare subsystem with
+						// no sub-arg keeps its historical default view.
+						topic, filter, err := clusterSubsystemView(args[2], args[3:])
+						if err != nil {
+							return err
 						}
-						return c.showText("chassis-cluster-control-plane-statistics")
-					case "data-plane":
-						if len(args) >= 4 {
-							switch args[3] {
-							case "statistics":
-								return c.showText("chassis-cluster-data-plane-statistics")
-							case "interfaces":
-								return c.showText("chassis-cluster-data-plane-interfaces")
-							case "fairness":
-								return c.showText("chassis-cluster-data-plane-fairness")
-							case "flows":
-								return c.showTextFiltered("chassis-cluster-data-plane-flows", strings.Join(args[4:], " "))
-							}
-						}
-						return c.showText("chassis-cluster-data-plane-statistics")
-					case "ip-monitoring":
-						if len(args) >= 4 && args[3] == "status" {
-							return c.showText("chassis-cluster-ip-monitoring-status")
-						}
-						return c.showText("chassis-cluster-ip-monitoring-status")
-					case "fabric":
-						if len(args) >= 4 && args[3] == "statistics" {
-							return c.showText("chassis-cluster-fabric-statistics")
-						}
-						return c.showText("chassis-cluster-fabric-statistics")
+						return c.showTextFiltered(topic, filter)
 					}
 				}
 				return c.showText("chassis-cluster")
@@ -455,6 +437,56 @@ func (c *ctl) handleConfigShow(args []string) error {
 	}
 	fmt.Print(resp.Output)
 	return nil
+}
+
+// clusterSubsystemView maps a `show chassis cluster <sub> [arg ...]` request to
+// the text-proxy topic (and optional filter) to render. sub is the subsystem
+// token (args[2]); rest is everything after it (args[3:]).
+//
+// #5459 (typo suppression): historically each subsystem case fell back to its
+// default view for ANY value of rest[0], so an operator typo like
+// `show chassis cluster control-plane foobaz` rendered control-plane statistics
+// and exited 0. This mirrors the strict #1827 `show services ip-monitoring`
+// handler instead: a bare subsystem (len(rest)==0) keeps its historical default
+// view, but a present-but-unrecognized token returns a usage error naming the
+// valid subcommands. The recognized paths render exactly the same topic/filter
+// as before. An empty filter is equivalent to showText (showText delegates to
+// showTextFiltered with "").
+func clusterSubsystemView(sub string, rest []string) (topic, filter string, err error) {
+	switch sub {
+	case "control-plane":
+		if len(rest) > 0 && rest[0] != "statistics" {
+			return "", "", fmt.Errorf("unknown control-plane target: %s (expected `statistics`)", rest[0])
+		}
+		return "chassis-cluster-control-plane-statistics", "", nil
+	case "data-plane":
+		if len(rest) > 0 {
+			switch rest[0] {
+			case "statistics":
+				return "chassis-cluster-data-plane-statistics", "", nil
+			case "interfaces":
+				return "chassis-cluster-data-plane-interfaces", "", nil
+			case "fairness":
+				return "chassis-cluster-data-plane-fairness", "", nil
+			case "flows":
+				return "chassis-cluster-data-plane-flows", strings.Join(rest[1:], " "), nil
+			default:
+				return "", "", fmt.Errorf("unknown data-plane target: %s (expected `statistics`, `interfaces`, `fairness`, or `flows`)", rest[0])
+			}
+		}
+		return "chassis-cluster-data-plane-statistics", "", nil
+	case "ip-monitoring":
+		if len(rest) > 0 && rest[0] != "status" {
+			return "", "", fmt.Errorf("unknown ip-monitoring target: %s (expected `status`)", rest[0])
+		}
+		return "chassis-cluster-ip-monitoring-status", "", nil
+	case "fabric":
+		if len(rest) > 0 && rest[0] != "statistics" {
+			return "", "", fmt.Errorf("unknown fabric target: %s (expected `statistics`)", rest[0])
+		}
+		return "chassis-cluster-fabric-statistics", "", nil
+	}
+	return "", "", fmt.Errorf("unknown cluster subsystem: %s", sub)
 }
 
 func (c *ctl) showText(topic string) error {

--- a/cmd/cli/show_cluster_typo_5459_test.go
+++ b/cmd/cli/show_cluster_typo_5459_test.go
@@ -1,0 +1,94 @@
+package main
+
+import "testing"
+
+// #5459: `show chassis cluster <subsystem> <arg>` must reject an
+// UNRECOGNIZED sub-arg with a usage error instead of silently falling
+// back to the subsystem's default statistics/status view (which returned
+// a valid-looking result with exit 0 for operator typos). A bare
+// subsystem with NO sub-arg keeps its historical default view.
+//
+// clusterSubsystemView is the pure token-validation helper the remote-CLI
+// dispatch (handleShow) delegates to; asserting on it directly avoids
+// needing a live gRPC client.
+
+func TestClusterSubsystemView_UnknownArgErrors(t *testing.T) {
+	// A present-but-unrecognized token must error for every subsystem.
+	cases := []struct {
+		sub  string
+		rest []string
+	}{
+		{"control-plane", []string{"foobaz"}},
+		{"data-plane", []string{"foobaz"}},
+		{"ip-monitoring", []string{"foobaz"}},
+		{"fabric", []string{"foobaz"}},
+		// Near-miss typos of real tokens must also error.
+		{"control-plane", []string{"statisitcs"}},
+		{"data-plane", []string{"interface"}},
+		{"ip-monitoring", []string{"stat"}},
+		{"fabric", []string{"stats"}},
+	}
+	for _, tc := range cases {
+		topic, filter, err := clusterSubsystemView(tc.sub, tc.rest)
+		if err == nil {
+			t.Errorf("clusterSubsystemView(%q, %v): expected error for unknown arg, got topic=%q filter=%q nil err (typo suppression regression)",
+				tc.sub, tc.rest, topic, filter)
+		}
+	}
+}
+
+func TestClusterSubsystemView_RecognizedArgs(t *testing.T) {
+	// Recognized sub-args must render exactly the pre-#5459 topic/filter.
+	cases := []struct {
+		sub        string
+		rest       []string
+		wantTopic  string
+		wantFilter string
+	}{
+		{"control-plane", []string{"statistics"}, "chassis-cluster-control-plane-statistics", ""},
+		{"data-plane", []string{"statistics"}, "chassis-cluster-data-plane-statistics", ""},
+		{"data-plane", []string{"interfaces"}, "chassis-cluster-data-plane-interfaces", ""},
+		{"data-plane", []string{"fairness"}, "chassis-cluster-data-plane-fairness", ""},
+		{"data-plane", []string{"flows"}, "chassis-cluster-data-plane-flows", ""},
+		{"data-plane", []string{"flows", "limit", "20"}, "chassis-cluster-data-plane-flows", "limit 20"},
+		{"ip-monitoring", []string{"status"}, "chassis-cluster-ip-monitoring-status", ""},
+		{"fabric", []string{"statistics"}, "chassis-cluster-fabric-statistics", ""},
+	}
+	for _, tc := range cases {
+		topic, filter, err := clusterSubsystemView(tc.sub, tc.rest)
+		if err != nil {
+			t.Errorf("clusterSubsystemView(%q, %v): unexpected error: %v", tc.sub, tc.rest, err)
+			continue
+		}
+		if topic != tc.wantTopic || filter != tc.wantFilter {
+			t.Errorf("clusterSubsystemView(%q, %v) = (%q, %q); want (%q, %q)",
+				tc.sub, tc.rest, topic, filter, tc.wantTopic, tc.wantFilter)
+		}
+	}
+}
+
+func TestClusterSubsystemView_BareSubsystemKeepsDefault(t *testing.T) {
+	// A bare subsystem (no sub-arg) keeps its historical default view and
+	// must NOT newly error — the #5459 bug is an UNKNOWN arg, not a
+	// missing arg.
+	cases := []struct {
+		sub       string
+		wantTopic string
+	}{
+		{"control-plane", "chassis-cluster-control-plane-statistics"},
+		{"data-plane", "chassis-cluster-data-plane-statistics"},
+		{"ip-monitoring", "chassis-cluster-ip-monitoring-status"},
+		{"fabric", "chassis-cluster-fabric-statistics"},
+	}
+	for _, tc := range cases {
+		topic, filter, err := clusterSubsystemView(tc.sub, nil)
+		if err != nil {
+			t.Errorf("clusterSubsystemView(%q, nil): unexpected error for bare subsystem: %v", tc.sub, err)
+			continue
+		}
+		if topic != tc.wantTopic || filter != "" {
+			t.Errorf("clusterSubsystemView(%q, nil) = (%q, %q); want (%q, \"\")",
+				tc.sub, topic, filter, tc.wantTopic)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The remote-CLI `show chassis cluster <subsystem> <arg>` dispatch in
`cmd/cli/show.go` silently **fell back** to the subsystem's default
statistics/status view for **any** value of the sub-arg. An operator typo like:

```
show chassis cluster control-plane foobaz
```

returned the control-plane **statistics** view and **exited 0** — a valid-looking
result for a mistake. The `data-plane`, `ip-monitoring`, and `fabric` cases had
the same fall-through:

```go
case "control-plane":
    if len(args) >= 4 && args[3] == "statistics" { ... }
    return c.showText("...control-plane-statistics")   // any unknown arg -> statistics (BUG)
```

Junos parity (and the strict #1827 `show services ip-monitoring` handler) is to
**error** on an unrecognized token.

## Fix

Mirror the #1827 strict handler. A present-but-unrecognized sub-arg now returns a
usage error naming the valid subcommands; a **bare** subsystem with no sub-arg
keeps its historical default view (the bug is an UNKNOWN arg, not a missing one).

Token validation is factored into a pure `clusterSubsystemView()` helper so it is
unit-testable without a live gRPC client (the dispatch reaches the text-proxy
through `c.client`). The four buggy cases delegate to it; **recognized paths
render the exact same topic/filter as before** — `showText(topic)` ==
`showTextFiltered(topic, "")`, and the `data-plane flows` filter join is
preserved.

Valid tokens confirmed against `pkg/cmdtree/tree.go`: `control-plane`→`statistics`;
`data-plane`→`statistics`/`interfaces`/`fairness`/`flows`; `ip-monitoring`→`status`;
`fabric`→`statistics`.

## Validation

- `go build ./...` — OK
- `go test ./cmd/cli/...` — OK

**RED-on-revert:** reverting the four validation branches makes
`TestClusterSubsystemView_UnknownArgErrors` fail — `control-plane`/`data-plane`/
`ip-monitoring`/`fabric` with `foobaz` (and near-miss typos like `statisitcs`,
`interface`) silently return the default topic with `nil` err:

```
clusterSubsystemView("control-plane", [foobaz]): expected error for unknown arg,
  got topic="chassis-cluster-control-plane-statistics" filter="" nil err
... (data-plane, ip-monitoring, fabric identical) ...
--- FAIL: TestClusterSubsystemView_UnknownArgErrors
--- PASS: TestClusterSubsystemView_RecognizedArgs
--- PASS: TestClusterSubsystemView_BareSubsystemKeepsDefault
```

The recognized-arg and bare-subsystem tests stay green under the revert (proving
they aren't coupled to the validation); restoring the validation returns all green.

Docs: the `show chassis cluster` examples in `docs/` are valid invocations that
still work identically; none documented the silent-fallback behavior, so no doc
contract changes.

Closes #5459

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Epmt83ZBcGzPELqADszRrH