### PR TITLE
zeroize: revoke managed-root login in place, never userdel UID 0 (#5520)

### DIFF
--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -270,8 +270,21 @@ or strand access:
 
 - An **operator's own account** (created out of band, no xpf marker) is never
   iterated — its keys, sudoers, and login stay intact.
-- **`root` and system accounts** have no marker and are never touched — the
-  console/root lifeline survives the wipe (critical on bare metal).
+- **System accounts** (and an **unmanaged-root** appliance's `root`) have no
+  marker and are never iterated — untouched by the teardown.
+- **`root` on a managed-root appliance IS revoked (#5520).** Since #5276 the
+  daemon writes a genuine provenance marker for `root`
+  (`markProvisioned("root", 0)`), so `root` reaches the teardown. It must NOT
+  take the generic path — root's `authorized_keys` is at **`/root/.ssh`**, not
+  `/home/root/.ssh` (which the generic path would miss, leaving the prior
+  tenant's root SSH key live), and **`userdel -r root` fails on UID 0** and can
+  abort the whole reset. So `root` is special-cased and revoked **in place**
+  (`zeroizeRootLoginAccount`): remove `/root/.ssh/authorized_keys` **and** lock
+  the root password (`passwd -l root`), **never** `userdel`. Fail-closed like
+  the rest — the marker is retained and the reset reported incomplete unless
+  both revocations succeed. A factory reset MUST revoke root; a
+  decommissioned/RMA'd appliance that kept prior-operator root login would be a
+  false factory reset.
 - An **out-of-band `userdel`+recreate** with a different UID (marker UID ≠ live
   UID) is left alone — the current owner is someone else, exactly the #1944
   leave-then-rejoin-vs-recreate distinction. Since #5496 this mismatch is also

--- a/pkg/grpcapi/server_diag_zeroize.go
+++ b/pkg/grpcapi/server_diag_zeroize.go
@@ -332,11 +332,94 @@ var (
 	// entries, and its home tree (-r). It is a seam so tests can record the
 	// removal without touching real accounts. context.Background(): a client
 	// disconnect must not abort a confirmed factory reset (mirrors runTimeout's
-	// power-action rationale).
+	// power-action rationale). NEVER call this for the root account / UID 0:
+	// userdel -r root fails (you cannot delete the running superuser) and can
+	// ABORT the whole reset — root is revoked in place instead (#5520,
+	// zeroizeRootLoginAccount).
 	zeroizeUserdel = func(name string) ([]byte, error) {
 		return combinedOutputTimeout(context.Background(), "userdel", "-r", name)
 	}
+	// zeroizeRootSSHDir is the root account's .ssh directory. Root's home is
+	// /root, NOT /home/root, so its authorized_keys lives at
+	// /root/.ssh/authorized_keys — the generic /home/<name>/.ssh teardown MISSES
+	// it entirely (#5520). Mirrors pkg/daemon.rootSSHDir (not importable — the
+	// pkg/daemon → pkg/grpcapi import cycle, the same reason the other login
+	// paths are duplicated here). Package var only so a test can point the root
+	// revocation at a throwaway tree.
+	zeroizeRootSSHDir = "/root/.ssh"
+	// zeroizeLockRootPassword locks the root account password (passwd -l root
+	// prefixes the shadow field with "!", disabling password/console root login)
+	// as part of a factory reset. `passwd -l` is the same lock effect the #1944
+	// day-2 reconciler applies via `chpasswd -e` with "<name>:!"; the request
+	// path here has no stdin exec helper, so the equivalent argv-only `passwd -l`
+	// is used. It is a seam so a test can record the lock without touching the
+	// real root credential. context.Background(): a client disconnect must not
+	// abort a confirmed factory reset (mirrors zeroizeUserdel).
+	zeroizeLockRootPassword = func() ([]byte, error) {
+		return combinedOutputTimeout(context.Background(), "passwd", "-l", "root")
+	}
 )
+
+// zeroizeRootAuthorizedKeysPath returns the xpf-managed ROOT authorized_keys
+// file — /root/.ssh/authorized_keys, NOT /home/root/.ssh (#5520). applyRootAuth
+// (pkg/daemon) writes root's SSH keys there wholesale, so the whole file is
+// xpf-owned. Mirrors pkg/daemon.rootAuthorizedKeysPath.
+func zeroizeRootAuthorizedKeysPath() string {
+	return filepath.Join(zeroizeRootSSHDir, "authorized_keys")
+}
+
+// zeroizeRootLoginAccount revokes ROOT login as part of a factory reset,
+// special-cased away from the generic /home/<name> + userdel-r teardown (#5520).
+//
+// On a MANAGED-ROOT appliance the daemon writes a genuine provenance marker for
+// root (markProvisioned("root", 0), applyRootAuth in daemon_system.go), so root
+// is enumerated by zeroizeLoginAccounts just like a provisioned non-root user.
+// But the generic teardown is wrong for root two ways, and both defeat the
+// factory reset:
+//   - Root's authorized_keys is at /root/.ssh, NOT /home/root/.ssh, so the
+//     generic keysFile (filepath.Join(zeroizeHomeBase, "root", ...)) points at a
+//     path that does not exist and the prior tenant's ROOT SSH key SURVIVES a
+//     "successful" reset — a decommissioned/RMA'd/resold appliance keeps prior-
+//     operator root login, the worst re-tenant leak.
+//   - `userdel -r root` deletes UID 0; it fails/is refused (you cannot delete
+//     the running superuser) and — surfaced as the first error — can abort the
+//     whole reset. Root is the appliance's own superuser, never a disposable
+//     provisioned account, so it is revoked IN PLACE, never deleted.
+//
+// Revocation kills both root login vectors: remove /root/.ssh/authorized_keys
+// (key-based login) and lock the root password (passwd -l root — console/
+// password login). No userdel. The SSH-key removal runs FIRST so that vector
+// dies even if the password lock later fails (mirrors the generic path's
+// keys-before-userdel ordering).
+//
+// Fail CLOSED (#5496/#5493 discipline): if EITHER revocation fails, surface the
+// error (so performZeroizeWipe reports the reset INCOMPLETE) and RETAIN the
+// provenance marker so a retried zeroize re-attempts. The marker is dropped
+// (removeMarker=true) only when BOTH revocations succeeded — an already-absent
+// authorized_keys (os.ErrNotExist) is the goal, not a failure, and does not
+// block marker removal.
+func zeroizeRootLoginAccount(fail func(error)) (removeMarker bool) {
+	removeMarker = true
+	// Kill the SSH-key vector first (survives a password-lock failure). An
+	// already-absent file is the desired end state, not an error.
+	keysFile := zeroizeRootAuthorizedKeysPath()
+	if err := os.Remove(keysFile); err != nil && !errors.Is(err, os.ErrNotExist) {
+		slog.Error("zeroize: failed to remove root authorized_keys; retaining marker, reset incomplete",
+			"file", keysFile, "err", err)
+		fail(err)
+		removeMarker = false
+	}
+	// Lock the root password so console/password root login is revoked too.
+	if out, err := zeroizeLockRootPassword(); err != nil {
+		slog.Error("zeroize: failed to lock root password; retaining marker, reset incomplete",
+			"err", err, "output", strings.TrimSpace(string(out)))
+		fail(err)
+		removeMarker = false
+	} else {
+		slog.Info("zeroize: revoked root login (authorized_keys removed, password locked)")
+	}
+	return removeMarker
+}
 
 // zeroizeLookupUIDErr resolves the CURRENT numeric UID for name by parsing
 // zeroizePasswdPath directly (cgo-free, mirroring pkg/daemon.lookupUIDGIDErr,
@@ -409,10 +492,17 @@ func zeroizeLookupUIDErr(name string) (uid int, found bool, err error) {
 //   - Users: a userdel fires ONLY for an account that has a provenance marker
 //     AND whose CURRENT /etc/passwd UID still equals the marker's recorded UID.
 //     An operator's own account (no marker) is never iterated; a system account
-//     or root (no marker) is never touched; an out-of-band userdel+recreate with
-//     a different UID (marker mismatch) is left alone — exactly the #1944
+//     (no marker) is never touched; an out-of-band userdel+recreate with a
+//     different UID (marker mismatch) is left alone — exactly the #1944
 //     leave-then-rejoin vs recreate distinction, so the wipe can never nuke the
 //     wrong account or strand access.
+//   - root: a MANAGED-ROOT appliance writes a real marker for root
+//     (markProvisioned("root", 0), applyRootAuth), so root IS enumerated here —
+//     but it is special-cased away from the userdel path (#5520): its keys live
+//     at /root/.ssh (not /home/root) and userdel -r root fails on UID 0. It is
+//     revoked IN PLACE (remove /root/.ssh/authorized_keys + lock the password),
+//     never deleted. See zeroizeRootLoginAccount. A root with NO marker
+//     (unmanaged-root appliance) is not enumerated and stays untouched.
 //
 // Ownership uncertainty FAILS CLOSED (#5496). Deciding "is this the account xpf
 // provisioned?" needs TWO reads: the live UID (/etc/passwd, zeroizeLookupUIDErr)
@@ -474,6 +564,21 @@ func zeroizeLoginAccounts() error {
 		}
 		name := e.Name() // marker filename == account name (Base'd on write)
 		markerFile := filepath.Join(zeroizeProvisionedUsersDir, name)
+
+		if name == "root" {
+			// Root is the appliance's own superuser, not a disposable
+			// provisioned account. On a managed-root appliance it carries a real
+			// marker (markProvisioned("root", 0)), so it reaches this loop — but
+			// the generic /home/<name> + userdel-r path is wrong for it: root's
+			// keys live at /root/.ssh (not /home/root) and userdel -r root fails
+			// on UID 0 and can abort the reset (#5520). Revoke it IN PLACE
+			// (remove /root/.ssh/authorized_keys + lock the password); drop the
+			// marker only when the revocation fully succeeded (fail-closed).
+			if zeroizeRootLoginAccount(fail) {
+				fail(os.Remove(markerFile))
+			}
+			continue
+		}
 
 		recordedUID, markerErr := readProvisionedMarkerUID(markerFile)
 		curUID, curFound, lookupErr := zeroizeLookupUIDErr(name)

--- a/pkg/grpcapi/zeroize_login_root_5520_test.go
+++ b/pkg/grpcapi/zeroize_login_root_5520_test.go
@@ -1,0 +1,151 @@
+package grpcapi
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// setZeroizeRootPaths points the #5520 root-account revocation at a throwaway
+// tree and records the root password-lock invocation. It returns a pointer to a
+// counter incremented once per zeroizeLockRootPassword call. lockErr, when
+// non-nil, is what the recorded seam returns (to drive the fail-closed path).
+func setZeroizeRootPaths(t *testing.T, rootSSHDir string, lockErr error) *int {
+	t.Helper()
+	origDir, origLock := zeroizeRootSSHDir, zeroizeLockRootPassword
+	t.Cleanup(func() {
+		zeroizeRootSSHDir = origDir
+		zeroizeLockRootPassword = origLock
+	})
+	zeroizeRootSSHDir = rootSSHDir
+	var locks int
+	zeroizeLockRootPassword = func() ([]byte, error) {
+		locks++
+		if lockErr != nil {
+			return []byte("passwd: lock failed"), lockErr
+		}
+		return nil, nil
+	}
+	return &locks
+}
+
+// TestZeroizeRevokesManagedRootInPlace pins #5520: on a MANAGED-ROOT appliance
+// the daemon writes a genuine provenance marker for root
+// (markProvisioned("root", 0), applyRootAuth), so zeroizeLoginAccounts
+// enumerates root — but root MUST be special-cased away from the generic
+// /home/<name> + userdel teardown. Root's authorized_keys is at /root/.ssh (NOT
+// /home/root/.ssh), and userdel -r root fails on UID 0. The factory reset must
+// revoke root IN PLACE: remove /root/.ssh/authorized_keys, lock the root
+// password, and NEVER userdel root.
+//
+// RED on revert: remove the `name == "root"` special-case and root falls into
+// the generic path — keysFile becomes /home/root/.ssh/authorized_keys (the real
+// key at /root/.ssh SURVIVES), the password is never locked (no lock recorded),
+// and userdel is invoked for "root" (which on a real box fails on UID 0 and can
+// abort the reset). Every root assertion below then fails. The alice
+// assertions pin that the non-root generic path is unchanged.
+func TestZeroizeRevokesManagedRootInPlace(t *testing.T) {
+	root := t.TempDir()
+	provDir := filepath.Join(root, "provisioned-users")
+	sudoersDir := filepath.Join(root, "sudoers.d")
+	homeBase := filepath.Join(root, "home")
+	passwdPath := filepath.Join(root, "passwd")
+	rootSSHDir := filepath.Join(root, "rootssh") // stand-in for /root/.ssh
+
+	// /etc/passwd: root (UID 0) + an xpf-provisioned non-root account (alice).
+	mustWriteFile(t, passwdPath, []byte(
+		"root:x:0:0:root:/root:/bin/bash\n"+
+			"alice:x:1001:1001:alice:/home/alice:/bin/bash\n"))
+
+	// Provenance markers: root (managed-root, UID 0 — #5276) + alice (UID 1001).
+	rootMarker := filepath.Join(provDir, "root")
+	aliceMarker := filepath.Join(provDir, "alice")
+	mustWriteFile(t, rootMarker, []byte("0"))
+	mustWriteFile(t, aliceMarker, []byte("1001"))
+
+	// Root's REAL authorized_keys at /root/.ssh (the prior tenant's key). This
+	// is the artifact the generic /home/root path misses.
+	rootKeys := filepath.Join(rootSSHDir, "authorized_keys")
+	mustWriteFile(t, rootKeys, []byte("ssh-ed25519 AAAAprior prior-operator\n"))
+
+	// A DECOY at /home/root/.ssh — nothing should have written here, and root's
+	// revocation must not depend on it. It must survive (root path never touches
+	// /home/root).
+	decoyHomeRootKeys := filepath.Join(homeBase, "root", ".ssh", "authorized_keys")
+	mustWriteFile(t, decoyHomeRootKeys, []byte("ssh-ed25519 AAAAdecoy decoy\n"))
+
+	// alice's xpf-managed key + sudoers grant (the unchanged generic path).
+	aliceKeys := filepath.Join(homeBase, "alice", ".ssh", "authorized_keys")
+	mustWriteFile(t, aliceKeys, []byte("ssh-ed25519 AAAAalice alice\n"))
+	mustWriteFile(t, filepath.Join(sudoersDir, "xpf-alice"), []byte("alice ALL=(ALL) NOPASSWD: ALL\n"))
+
+	deleted := setZeroizeLoginPaths(t, provDir, sudoersDir, homeBase, passwdPath)
+	locks := setZeroizeRootPaths(t, rootSSHDir, nil)
+
+	if err := zeroizeLoginAccounts(); err != nil {
+		t.Fatalf("zeroizeLoginAccounts returned error: %v", err)
+	}
+
+	// (1) Root's REAL SSH key at /root/.ssh is removed (the core #5520 leak).
+	assertAbsent(t, rootKeys)
+	// (2) Root password lock invoked exactly once.
+	if *locks != 1 {
+		t.Errorf("root password lock invoked %d times, want exactly 1", *locks)
+	}
+	// (3) Root is NEVER userdel'd (UID 0). alice IS.
+	got := append([]string(nil), *deleted...)
+	sort.Strings(got)
+	if len(got) != 1 || got[0] != "alice" {
+		t.Errorf("userdel invoked for %v, want exactly [alice] (never root/UID 0)", got)
+	}
+	// (4) Root marker dropped (revocation fully succeeded).
+	assertAbsent(t, rootMarker)
+
+	// Non-root generic path unchanged (bit-for-bit): alice torn down.
+	assertAbsent(t, aliceKeys)
+	assertAbsent(t, filepath.Join(sudoersDir, "xpf-alice"))
+	assertAbsent(t, aliceMarker)
+}
+
+// TestZeroizeRootRevocationFailsClosed pins the fail-closed contract for root
+// (mirrors the #5496 non-root userdel-failure retention): if locking the root
+// password fails, zeroizeLoginAccounts must (a) surface the error so the
+// factory reset is not reported clean while root login may still be usable, and
+// (b) RETAIN the root marker so a retried zeroize re-attempts. The
+// authorized_keys is still removed first (best-effort defense so the SSH-key
+// vector dies even when the lock fails).
+func TestZeroizeRootRevocationFailsClosed(t *testing.T) {
+	root := t.TempDir()
+	provDir := filepath.Join(root, "provisioned-users")
+	sudoersDir := filepath.Join(root, "sudoers.d")
+	homeBase := filepath.Join(root, "home")
+	passwdPath := filepath.Join(root, "passwd")
+	rootSSHDir := filepath.Join(root, "rootssh")
+
+	mustWriteFile(t, passwdPath, []byte("root:x:0:0:root:/root:/bin/bash\n"))
+	rootMarker := filepath.Join(provDir, "root")
+	mustWriteFile(t, rootMarker, []byte("0"))
+	rootKeys := filepath.Join(rootSSHDir, "authorized_keys")
+	mustWriteFile(t, rootKeys, []byte("ssh-ed25519 AAAAprior prior-operator\n"))
+
+	setZeroizeLoginPaths(t, provDir, sudoersDir, homeBase, passwdPath)
+	locks := setZeroizeRootPaths(t, rootSSHDir, errors.New("exit status 1"))
+
+	err := zeroizeLoginAccounts()
+	if err == nil {
+		t.Fatalf("zeroizeLoginAccounts with a failing root password lock returned nil; want the failure surfaced")
+	}
+
+	// The lock was attempted.
+	if *locks != 1 {
+		t.Errorf("root password lock invoked %d times, want exactly 1", *locks)
+	}
+	// authorized_keys removed even though the lock failed (defense in depth).
+	assertAbsent(t, rootKeys)
+	// Marker RETAINED so a retried zeroize re-attempts the lock.
+	if _, statErr := os.Stat(rootMarker); statErr != nil {
+		t.Errorf("expected the root provenance marker %s to be RETAINED after a lock failure, stat err = %v", rootMarker, statErr)
+	}
+}


### PR DESCRIPTION
## Problem (#5520, security — factory-reset integrity)

The gRPC `Zeroize` (factory reset) login-account teardown
(`pkg/grpcapi/server_diag_zeroize.go`, `zeroizeLoginAccounts`) iterates every
provisioned account through a **generic** `/home/<name>/.ssh` revocation loop
followed by `userdel -r <name>`, with **no special case for `root`**.

Since #5276 a **managed-root** appliance writes a real provenance marker for
root (`markProvisioned("root", 0)`, `applyRootAuth` in
`pkg/daemon/daemon_system.go:1712`), so root **is enumerated** by the teardown —
where the generic path is wrong two ways, both of which defeat the reset:

- Root's `authorized_keys` is at **`/root/.ssh`**, NOT `/home/root/.ssh`, so the
  generic `keysFile` pointed at a non-existent path and the prior tenant's
  **ROOT SSH key SURVIVED** a "successful" factory reset — a decommissioned /
  RMA'd / resold appliance kept prior-operator root login (the worst re-tenant
  leak).
- `userdel -r root` deletes UID 0; it fails / is refused and, surfaced as the
  first error, can **abort the whole reset**.

## Fix

Special-case `name == "root"` **before** the generic teardown and revoke root
**in place** (`zeroizeRootLoginAccount`):

- remove `/root/.ssh/authorized_keys` (kills key-based root login),
- lock the root password (`passwd -l root` — kills console/password login),
- **never** `userdel` root.

The SSH-key removal runs first so that vector dies even if the lock later fails.
**Fail-closed**, mirroring the #5496/#5493 discipline already in this file: if
either revocation fails, the error is surfaced (`performZeroizeWipe` reports the
reset **incomplete**) and the provenance marker is **retained** so a retried
zeroize re-attempts; the marker is dropped only when **both** revocations
succeed. An already-absent `authorized_keys` (`ErrNotExist`) is the goal, not a
failure. **Non-root accounts take the unchanged generic path bit-for-bit.**

New seams `zeroizeRootSSHDir` / `zeroizeLockRootPassword` mirror the existing
`zeroizeHomeBase` / `zeroizeUserdel` seams so the test can point revocation at a
throwaway tree. `passwd -l` is the same lock effect the #1944 day-2 reconciler
applies via `chpasswd -e` `"<name>:!"`; the request path has no stdin exec
helper, so the argv-only `passwd -l` is used (not a new mechanism).

Docs: `docs/system-login.md` — the "root has no marker and is never touched"
safety-invariant bullet was stale post-#5276; now documents the managed-root
in-place revocation (and that an **unmanaged-root** appliance's root, no marker,
still stays untouched).

## Validation

- `go build ./...` and `go test ./pkg/grpcapi/...` pass (full package green).
- Added `TestZeroizeRevokesManagedRootInPlace` and
  `TestZeroizeRootRevocationFailsClosed`.
- **RED-on-revert** (special-case removed → root falls into the generic loop):
  ```
  --- FAIL: TestZeroizeRevokesManagedRootInPlace
      rootssh/authorized_keys to be absent ... stat err = <nil>   # /root/.ssh key SURVIVES
      root password lock invoked 0 times, want exactly 1
      userdel invoked for [alice root], want exactly [alice]      # userdel root (fails on UID 0)
  --- FAIL: TestZeroizeRootRevocationFailsClosed
      returned nil; want the failure surfaced                     # fail-open on revert
  ```
  All root assertions fail on revert; all pass with the fix restored.

Distinct locus from #5280/#5281 (config-root-path / apply-gate race); this is
the factory-reset login-teardown path.

Closes #5520

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SurMDXk8xLFHN2wQmTDVy