### PR TITLE
config: reject NAT64 prefix with extra slash at commit

### DIFF
--- a/pkg/config/compiler_nat64_extra_slash_5517_test.go
+++ b/pkg/config/compiler_nat64_extra_slash_5517_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5517: commit-accepts / runtime-drops divergence for a NAT64 rule-set
+// `prefix` with a trailing extra slash.
+//
+// The Rust dataplane loader (Nat64State::from_snapshots,
+// userspace-dp/src/nat64.rs) splits the prefix on '/' and requires EXACTLY two
+// parts: `if parts.len() != 2 { ...; continue }` SKIPS any rule whose prefix
+// does not split into exactly two slash-separated parts. So a prefix with an
+// extra slash — "64:ff9b::/96/garbage" → ["64:ff9b::", "96", "garbage"] — is
+// silently omitted from the forwarding snapshot (the Rust regression test
+// `extra_slash_prefix_skips_rule` pins this skip).
+//
+// Pre-#5517, validateNAT64PrefixStrict used `if len(parts) >= 2` and indexed
+// parts[0]/parts[1], disregarding the rest, so it ACCEPTED "64:ff9b::/96/garbage"
+// (parts[1]=="96" parses, parts[0]=="64:ff9b::" is a valid IPv6 address). Commit
+// SUCCEEDED but the runtime dropped the rule → IPv6→IPv4 translation for that
+// rule never happened (silent blackhole, no error).
+//
+// The gate now requires `len(parts) == 2`, rejecting exactly what the runtime
+// skips. RED-on-revert: change `== 2` back to `>= 2` in
+// validateNAT64PrefixStrict and the two reject tests below go GREEN-accept
+// (commit succeeds), i.e. the tests fail.
+//
+// All tests use the production ParseSetCommand + SetPath path (buildTree),
+// never NewParser (the flat-set gotcha in CLAUDE.md).
+
+func TestNAT64PrefixRejectsExtraSlash_5517(t *testing.T) {
+	// The exact issue case: a valid-looking /96 with trailing garbage after a
+	// second slash. Rust splits into three parts and skips the rule; the strict
+	// commit gate must reject it so the two agree.
+	tree := buildTree(t, nat64Set("64:ff9b::/96/garbage"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("NAT64 prefix 64:ff9b::/96/garbage (extra slash) must be rejected at commit; the dataplane skips it (silent blackhole) otherwise")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "rs1") ||
+		!strings.Contains(msg, "64:ff9b::/96/garbage") ||
+		!strings.Contains(msg, "/96") {
+		t.Fatalf("error must name the rule-set + offending prefix + /96 requirement, got: %v", err)
+	}
+}
+
+func TestNAT64PrefixRejectsBareTrailingSlashAfterMask_5517(t *testing.T) {
+	// A bare trailing slash after the mask — "64:ff9b::/96/" splits into
+	// ["64:ff9b::", "96", ""] → three parts → the runtime skips it. Must reject
+	// at commit.
+	tree := buildTree(t, nat64Set("64:ff9b::/96/"))
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("NAT64 prefix 64:ff9b::/96/ (bare trailing slash after mask) must be rejected at commit")
+	}
+}
+
+func TestNAT64PrefixValidStillCommits_5517(t *testing.T) {
+	// Control: the exact-two-parts well-known prefix must still compile on the
+	// strict path (the tightened `== 2` split must not over-reject a valid rule).
+	tree := buildTree(t, nat64Set("64:ff9b::/96"))
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("valid 64:ff9b::/96 must still commit after the #5517 tightening, got: %v", err)
+	}
+}
+
+// Lenient path (#1960 / #1979 doctrine) must skip the extra-slash prefix
+// consistently: an already-persisted or peer-synced config with the bad prefix
+// must NOT hard-fail the compile, but MUST emit a warning naming it (mirroring
+// the runtime skip, which keeps the previous live state).
+func TestNAT64PrefixExtraSlashLenientWarns_5517(t *testing.T) {
+	for _, p := range []string{"64:ff9b::/96/garbage", "64:ff9b::/96/"} {
+		tree := buildTree(t, nat64Set(p))
+		cfg, err := CompileConfigLenient(tree)
+		if err != nil {
+			t.Fatalf("lenient compile must NOT hard-fail on extra-slash NAT64 prefix %q, got: %v", p, err)
+		}
+		found := false
+		for _, w := range cfg.Warnings {
+			if strings.Contains(w, "rs1") && strings.Contains(w, p) && strings.Contains(w, "nat64") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("lenient compile must warn naming the extra-slash NAT64 prefix %q, warnings: %v", p, cfg.Warnings)
+		}
+	}
+}

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -1372,23 +1372,33 @@ func validateNAT64PrefixStrict(cfg *Config, lenient bool) ([]string, error) {
 		if rs == nil || rs.Prefix == "" {
 			continue
 		}
-		// Mirror Nat64State::try_from_snapshots (userspace-dp/src/nat64.rs)
-		// EXACTLY. Split on '/' (Rust `split('/')`); a trailing junk field
-		// after the mask is ignored by both sides, so we index [0] and [1] and
-		// disregard the rest rather than SplitN'ing the mask.
+		// Mirror the Rust loader Nat64State::from_snapshots
+		// (userspace-dp/src/nat64.rs) EXACTLY. It splits on '/' (`split('/')`)
+		// and requires EXACTLY two parts — `<ipv6>/96`: `if parts.len() != 2 {
+		// ...; continue }` SKIPS any rule whose prefix does not split into
+		// exactly two slash-separated parts (pinned by the Rust
+		// `extra_slash_prefix_skips_rule` test). So a trailing extra slash
+		// ("64:ff9b::/96/garbage" → three parts) is NOT ignored by the runtime —
+		// the whole rule is silently dropped from the forwarding snapshot. If we
+		// accepted it here (the pre-#5517 `len(parts) >= 2` loose split, which
+		// indexed [0]/[1] and disregarded the rest), commit would SUCCEED but the
+		// NAT64 rule would never install: a silent IPv6→IPv4 blackhole with no
+		// error. Require exactly two parts so the commit gate rejects precisely
+		// what the runtime skips (#5517).
 		parts := strings.Split(rs.Prefix, "/")
 		// The token after the first '/' must parse as a decimal /96. A missing
-		// mask (no '/'), an empty mask, a non-numeric mask, or any length other
-		// than 96 is rejected — only /96 is supported by the translator.
+		// mask (no '/'), an empty mask, a non-numeric mask, an EXTRA '/' segment
+		// (more than two parts), or any length other than 96 is rejected — only
+		// an exact `<ipv6>/96` is supported by the translator.
 		mask96 := false
-		if len(parts) >= 2 {
+		if len(parts) == 2 {
 			if m, err := strconv.ParseUint(parts[1], 10, 8); err == nil && m == 96 {
 				mask96 = true
 			}
 		}
 		if !mask96 {
 			if err := emit(fmt.Sprintf(
-				"security nat nat64 rule-set %q prefix %q must be an IPv6 prefix of length /96 (RFC 6052: the well-known 64:ff9b::/96 or a /96 network-specific prefix); any other length or a missing/garbage mask is rejected by the dataplane, which aborts the entire forwarding rebuild",
+				"security nat nat64 rule-set %q prefix %q must be an IPv6 prefix of length /96 (RFC 6052: the well-known 64:ff9b::/96 or a /96 network-specific prefix); any other length, a missing/garbage mask, or an extra '/' segment is rejected by the dataplane, which aborts the entire forwarding rebuild",
 				rs.Name, rs.Prefix)); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Problem

The strict commit validator for a NAT64 rule-set `prefix`
(`validateNAT64PrefixStrict`, `pkg/config/compiler_validate_strict_nat.go`)
split the prefix on `/` and accepted any result with `len(parts) >= 2`,
indexing `parts[0]`/`parts[1]` and disregarding the rest. So a malformed
prefix with a trailing extra slash — `64:ff9b::/96/garbage` →
`["64:ff9b::", "96", "garbage"]` — passed commit (`parts[1]=="96"` parses as
/96, `parts[0]=="64:ff9b::"` is a valid IPv6 address).

The Rust dataplane loader disagrees. `Nat64State::from_snapshots`
(`userspace-dp/src/nat64.rs:752`) requires EXACTLY two `/`-split parts:
`if parts.len() != 2 { ...; continue }` **SKIPS** any rule whose prefix does
not split into exactly two parts (pinned by the Rust
`extra_slash_prefix_skips_rule` test).

**Result: a commit-accepts / runtime-drops divergence.** `commit` SUCCEEDED
but the NAT64 rule was silently omitted from the dataplane forwarding
snapshot → IPv6→IPv4 translation for that rule never happened (silent
blackhole, no error). The commit path is the correctness contract: a value
the runtime DROPS must be REJECTED at commit.

## Fix

- Require `len(parts) == 2` in `validateNAT64PrefixStrict` so the strict gate
  rejects precisely what the Rust loader skips (trailing slash, extra segment,
  any `!= 2` split).
- Name the extra-`/`-segment case in the reject message.
- Correct the stale inline comment, which claimed a trailing junk field "is
  ignored by both sides" — the runtime does not ignore it, it skips the whole
  rule.
- A valid `64:ff9b::/96` still commits; all other validation is unchanged.
  This is the only loose-split (`>= 2`) prefix pattern in the strict-NAT
  validator.

## Validation

New `pkg/config` tests (`compiler_nat64_extra_slash_5517_test.go`, production
`ParseSetCommand` + `SetPath` path, not `NewParser`) assert:
- `64:ff9b::/96/garbage` and a bare trailing slash `64:ff9b::/96/` are
  REJECTED at strict commit (mirroring the Rust `extra_slash_prefix_skips_rule`
  skip);
- a valid `64:ff9b::/96` still commits;
- the lenient path downgrades the extra-slash prefix to a warning.

**RED-on-revert (proven):** changing `== 2` back to `>= 2`:
```
--- FAIL: TestNAT64PrefixRejectsExtraSlash_5517
    64:ff9b::/96/garbage (extra slash) must be rejected at commit; the dataplane skips it (silent blackhole) otherwise
--- FAIL: TestNAT64PrefixRejectsBareTrailingSlashAfterMask_5517
    64:ff9b::/96/ (bare trailing slash after mask) must be rejected at commit
--- FAIL: TestNAT64PrefixExtraSlashLenientWarns_5517
    lenient compile must warn naming the extra-slash NAT64 prefix "64:ff9b::/96/garbage", warnings: []
```
Restoring `== 2` → all pass. `go build ./...` and `go test ./pkg/config/...`
both green.

Go-only fix — the Rust side already rejects (skips) the input, so no cargo
change is needed. Distinct from #5101.

Closes #5517

🤖 Generated with [Claude Code](https://claude.com/claude-code)