### PR TITLE
frr: guard AF-activation and BFD against remote-as-0 neighbors

### DIFF
--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -262,7 +262,23 @@ also carries operator content:
   SKIPS a neighbor with `PeerAS == 0` entirely, so AS 0 never reaches
   frr.conf for a config that arrives via the lenient path (an older-binary
   persisted config or a peer-synced one) — keeping the rest of the reload
-  alive instead of bricking it for every other peer.
+  alive instead of bricking it for every other peer. **All three
+  neighbor-referencing render loops agree on that exclusion (#5518).**
+  `generateProtocols` computes a single `validNeighbors` slice (`PeerAS != 0`)
+  ONCE and drives the `neighbor <addr> remote-as`/`update-source`/`timers`/…
+  DECLARATION loop, the address-family ACTIVATION loop
+  (`inet4Neighbors`/`inet6Neighbors` → `neighbor <addr> activate` +
+  `route-map … in/out`), AND the BFD peer accumulator (`bfd { peer <addr> }`)
+  from it. Before #5518 only the declaration loop carried the guard: a
+  remote-as-0 neighbor was kept out of the declaration yet STILL emitted
+  `activate` / route-map / `neighbor <addr> bfd` / a `bfd` peer — and vtysh
+  rejects an `activate`/`bfd`/`peer` for a neighbor that was never declared,
+  so a single lenient remote-as-0 neighbor bricked the managed `frr-reload`
+  for every valid BGP peer. Unifying on `validNeighbors` makes the three loops
+  structurally unable to diverge. (The route-map DEFINITION collectors
+  `collectBGPRouteMapPolicies`/`bgpEffectiveChains` still iterate all
+  neighbors — they emit no `neighbor <addr>` line, only route-map objects, so
+  an unreferenced definition for a skipped neighbor is harmless valid config.)
 - **OSPF/OSPFv3 interface adjacency timers + DR priority (#4285).** The
   per-interface `hello-interval`, `dead-interval`, `retransmit-interval`, and
   `priority` leaves (schema + `OSPFInterface`/`OSPFv3Interface` structs +

--- a/pkg/frr/bgp_remoteas0_activate_bfd_5518_test.go
+++ b/pkg/frr/bgp_remoteas0_activate_bfd_5518_test.go
@@ -1,0 +1,131 @@
+package frr
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5518: the BGP declaration loop skips a remote-as-0 neighbor (the #2963
+// fail-closed guard, RFC 7607 reserved AS 0), but the address-family
+// ACTIVATION loop, the per-neighbor route-map emission, and the BFD peer
+// accumulator historically iterated bgp.Neighbors with NO PeerAS==0 guard. A
+// leniently-loaded / peer-synced neighbor with `remote-as 0` was therefore kept
+// OUT of the `neighbor <ip> remote-as ...` declaration yet STILL emitted
+// `neighbor <ip> activate` / `route-map ... out` / `neighbor <ip> bfd` / a
+// `bfd` `peer <ip>` for a neighbor that was never declared. vtysh/frr-reload
+// rejects a config that activates or attaches BFD to an undeclared neighbor, so
+// a single remote-as-0 neighbor bricked the managed frr-reload for EVERY valid
+// BGP peer on the box.
+//
+// The fix unifies all neighbor-referencing render loops on ONE validNeighbors
+// slice (PeerAS != 0). This test renders a mixed config (valid + remote-as-0,
+// both carrying family/BFD/export so an unguarded loop WOULD emit for the bad
+// neighbor) and asserts the remote-as-0 neighbor is completely absent while the
+// valid neighbor renders fully.
+//
+// RED-on-revert: revert the validNeighbors guard on the AF-activation loop
+// and/or the BFD accumulator and the rendered config gains
+// `neighbor 10.0.3.1 activate` and ` peer 10.0.3.1` for the undeclared
+// neighbor — the brick — turning both the blanket-absence assertion and the
+// self-consistency (no activate/bfd-without-declare) assertion RED.
+func TestBuildManagedSection_BGPRemoteAS0NotActivatedOrBFD(t *testing.T) {
+	fc := &FullConfig{
+		PolicyOptions: &config.PolicyOptionsConfig{
+			PolicyStatements: map[string]*config.PolicyStatement{
+				"ALLOW-ALL": {Name: "ALLOW-ALL", Terms: []*config.PolicyTerm{
+					{Name: "t1", Action: "accept"},
+				}},
+			},
+		},
+		BGP: &config.BGPConfig{
+			LocalAS:  65001,
+			RouterID: "1.1.1.1",
+			Neighbors: []*config.BGPNeighbor{
+				// Valid neighbor: fully renderable.
+				{Address: "10.0.2.1", PeerAS: 65002, FamilyInet: true, BFD: true, Export: []string{"ALLOW-ALL"}},
+				// remote-as-0 neighbor: peer-as omitted. Carries family/BFD/export
+				// so an UNGUARDED activation/BFD loop would emit for it.
+				{Address: "10.0.3.1", PeerAS: 0, FamilyInet: true, BFD: true, Export: []string{"ALLOW-ALL"}},
+			},
+		},
+	}
+	got := New().buildManagedSection(fc)
+
+	// The valid neighbor renders end-to-end: declaration, activation, per-neighbor
+	// BFD attach, route-map out, and a `bfd` peer entry.
+	for _, want := range []string{
+		"neighbor 10.0.2.1 remote-as 65002\n",
+		"neighbor 10.0.2.1 activate\n",
+		"neighbor 10.0.2.1 bfd\n",
+		"neighbor 10.0.2.1 route-map ALLOW-ALL out\n",
+		" peer 10.0.2.1\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("valid neighbor dropped: missing %q in:\n%s", want, got)
+		}
+	}
+
+	// The remote-as-0 neighbor is completely invisible — no line anywhere
+	// references its IP (declaration, activate, route-map, or bfd peer).
+	if strings.Contains(got, "10.0.3.1") {
+		t.Errorf("remote-as-0 neighbor 10.0.3.1 must not appear in ANY rendered line; output:\n%s", got)
+	}
+	// Belt-and-suspenders: the specific brick lines must be absent.
+	for _, banned := range []string{
+		"neighbor 10.0.3.1 activate",
+		"neighbor 10.0.3.1 bfd",
+		"neighbor 10.0.3.1 route-map",
+		" peer 10.0.3.1",
+	} {
+		if strings.Contains(got, banned) {
+			t.Errorf("undeclared remote-as-0 neighbor emitted %q (bricks frr-reload); output:\n%s", banned, got)
+		}
+	}
+	// Never emit the reserved remote-as 0 (RFC 7607).
+	if strings.Contains(got, "remote-as 0") {
+		t.Errorf("renderer emitted reserved 'remote-as 0'; output:\n%s", got)
+	}
+
+	// Self-consistency: every activated or BFD-attached neighbor MUST also be
+	// declared. This is exactly the invariant vtysh/frr-reload enforces — an
+	// `activate` / `bfd` / `peer` for an undeclared neighbor fails the whole
+	// managed-section reload.
+	assertNoActivateOrBFDWithoutDeclare5518(t, got)
+}
+
+var (
+	reDeclare5518  = regexp.MustCompile(`(?m)^ neighbor (\S+) remote-as \d+$`)
+	reActivate5518 = regexp.MustCompile(`(?m)^  neighbor (\S+) activate$`)
+	reNbrBFD5518   = regexp.MustCompile(`(?m)^ neighbor (\S+) bfd$`)
+	rePeer5518     = regexp.MustCompile(`(?m)^ peer (\S+)( vrf \S+)?$`)
+)
+
+// assertNoActivateOrBFDWithoutDeclare5518 verifies the rendered frr.conf never
+// activates, BFD-attaches, or emits a `bfd` peer for a BGP neighbor that was not
+// declared with `remote-as`. This mirrors the vtysh/frr-reload validity rule the
+// #5518 brick violated.
+func assertNoActivateOrBFDWithoutDeclare5518(t *testing.T, cfg string) {
+	t.Helper()
+	declared := map[string]bool{}
+	for _, m := range reDeclare5518.FindAllStringSubmatch(cfg, -1) {
+		declared[m[1]] = true
+	}
+	for _, m := range reActivate5518.FindAllStringSubmatch(cfg, -1) {
+		if !declared[m[1]] {
+			t.Errorf("neighbor %s is activated but never declared (frr-reload would reject)", m[1])
+		}
+	}
+	for _, m := range reNbrBFD5518.FindAllStringSubmatch(cfg, -1) {
+		if !declared[m[1]] {
+			t.Errorf("neighbor %s has `bfd` attached but never declared (frr-reload would reject)", m[1])
+		}
+	}
+	for _, m := range rePeer5518.FindAllStringSubmatch(cfg, -1) {
+		if !declared[m[1]] {
+			t.Errorf("bfd peer %s emitted but the neighbor was never declared (frr-reload would reject)", m[1])
+		}
+	}
+}

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -860,6 +860,32 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 		}
 	}
 
+	// #5518: compute the renderable BGP neighbor set ONCE and drive every
+	// neighbor-referencing render loop from it. A neighbor authored/loaded
+	// without a peer-as keeps a zero PeerAS; AS 0 is reserved (RFC 7607) and
+	// FRR/vtysh rejects `remote-as 0`, so the declaration loop below must skip
+	// it (the #2963 fail-closed guard). Commit-time validation
+	// (validateBGPNeighborPeerASStrict, pkg/config) rejects remote-as-0 on
+	// commit/commit-check, but the tolerant load / peer-sync path downgrades it
+	// to a warning, so a leniently-loaded remote-as-0 neighbor can reach the
+	// renderer. The declaration guard alone is not enough: the address-family
+	// activation loop and the BFD accumulator ALSO iterate the neighbors, and
+	// emitting `neighbor <ip> activate` / a route-map / `neighbor <ip> bfd` /
+	// a `bfd` peer for a neighbor that was never declared makes vtysh reject
+	// the WHOLE managed section — a single remote-as-0 neighbor would brick the
+	// frr-reload for every valid peer on the box. Building the set once here
+	// guarantees the three loops can never diverge on which neighbors render.
+	var validNeighbors []*config.BGPNeighbor
+	if bgp != nil {
+		validNeighbors = make([]*config.BGPNeighbor, 0, len(bgp.Neighbors))
+		for _, n := range bgp.Neighbors {
+			if n.PeerAS == 0 {
+				continue
+			}
+			validNeighbors = append(validNeighbors, n)
+		}
+	}
+
 	if bgp != nil && bgp.LocalAS > 0 {
 		fmt.Fprintf(&b, "router bgp %d%s\n", bgp.LocalAS, vrfSuffix)
 		if validRouterID(bgp.RouterID) {
@@ -899,19 +925,11 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 			}
 			fmt.Fprintf(&b, " bgp dampening %d %d %d %d\n", hl, reuse, suppress, maxSup)
 		}
-		for _, n := range bgp.Neighbors {
-			// Defense-in-depth (#2963): never emit `remote-as 0`. peer-as is
-			// optional in the parser/compiler, so a neighbor authored without
-			// one keeps a zero PeerAS. AS 0 is reserved (RFC 7607) and FRR/vtysh
-			// rejects `remote-as 0`, failing the whole frr-reload. Commit-time
-			// validation (validateBGPNeighborPeerASStrict, pkg/config) rejects
-			// this on commit/commit-check; on the tolerant load/peer-sync path
-			// it is downgraded to a warning, so this render guard keeps a
-			// leniently-loaded remote-as-0 neighbor out of frr.conf entirely
-			// rather than bricking the reload for every other peer.
-			if n.PeerAS == 0 {
-				continue
-			}
+		// validNeighbors excludes remote-as-0 neighbors (#2963/#5518). Every
+		// neighbor-referencing loop below (AF activation, BFD accumulator)
+		// iterates the SAME slice so an undeclared neighbor is never activated
+		// or attached to BFD — see the validNeighbors construction above.
+		for _, n := range validNeighbors {
 			fmt.Fprintf(&b, " neighbor %s remote-as %d\n", n.Address, n.PeerAS)
 			// Per-peering local-as (#4286): present a different AS than the
 			// router's own to this peer.
@@ -1053,7 +1071,11 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 		// activates those under ipv4 unicast), so route them into the
 		// ipv4 set in that case.
 		var inet4Neighbors, inet6Neighbors []*config.BGPNeighbor
-		for _, n := range bgp.Neighbors {
+		// Classify only renderable (declared) neighbors (#5518). A remote-as-0
+		// neighbor excluded from the declaration loop above must NOT be
+		// activated here — vtysh rejects `neighbor <ip> activate` for a
+		// neighbor with no `remote-as`, failing the whole managed section.
+		for _, n := range validNeighbors {
 			// A neighbor lands in the ipv4 (default) AF when it explicitly
 			// declares family inet, OR when a peer-level policy must reach it
 			// and it has not been pinned to inet6: a global export/import
@@ -1288,7 +1310,11 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 	// deferred to bfdSection.render() — either here (local fallback) or by
 	// the manager for the consolidated global block (#2550).
 	if bgp != nil {
-		for _, n := range bgp.Neighbors {
+		// Accumulate BFD peers only for renderable (declared) neighbors
+		// (#5518). A remote-as-0 neighbor skipped by the declaration loop must
+		// not emit a `bfd` peer either — validNeighbors is the shared
+		// exclusion set.
+		for _, n := range validNeighbors {
 			if n.BFD {
 				bfd.addPeer(bfdPeer{
 					address:    n.Address,


### PR DESCRIPTION
## Problem

`pkg/frr/policy_render.go` guards the BGP neighbor **declaration** loop
with `if n.PeerAS == 0 { continue }` (the #2963 fail-closed guard: AS 0
is reserved per RFC 7607 and vtysh/frr-reload rejects `remote-as 0`). But
two other loops that iterate `bgp.Neighbors` had **no** `PeerAS == 0`
guard:

- the **address-family activation** loop (`inet4Neighbors`/`inet6Neighbors`
  classification → `neighbor <ip> activate` + `route-map … in/out`), and
- the **BFD peer accumulator** (`bfd { peer <ip> }`).

A leniently-loaded / peer-synced neighbor with `remote-as 0` was kept OUT
of the `neighbor <ip> remote-as …` declaration yet STILL emitted
`activate` / route-map / `neighbor <ip> bfd` / a `bfd` peer for an
**undeclared** neighbor. vtysh/frr-reload **rejects** config that
activates or attaches BFD to a neighbor that was never declared, so a
single `remote-as 0` neighbor **bricks the managed frr-reload for every
valid BGP peer** on the box — dynamic routing goes stale on an otherwise
commit-accepted config.

## Fix

Compute one `validNeighbors` slice (`PeerAS != 0`) **once** and drive all
three neighbor-referencing loops (declaration, AF activation, BFD
accumulator) from it, so they are structurally unable to disagree on
which neighbors render. A remote-as-0 neighbor is now excluded from
activation and BFD, not just the declaration. Output for valid
(`PeerAS != 0`) neighbors is **byte-for-byte unchanged**.

The route-map DEFINITION collectors (`collectBGPRouteMapPolicies`,
`bgpEffectiveChains`) intentionally still iterate all neighbors — they
emit no `neighbor <ip>` line, only route-map objects (an unreferenced
definition is harmless valid FRR config), and guarding them would break
the established #2998 trailing-permit collection contract
(`TestCollectBGPRouteMapPolicies`).

## Loops guarded

| Loop | Emits | Before | After |
|------|-------|--------|-------|
| Declaration (`generateProtocols`) | `neighbor <ip> remote-as`/`update-source`/`timers`/`bfd`/… | guarded (#2963) | `validNeighbors` |
| AF activation | `neighbor <ip> activate` + `route-map in/out` | **unguarded** | `validNeighbors` |
| BFD accumulator | `bfd { peer <ip> }` | **unguarded** | `validNeighbors` |

## Validation

- `go build ./...` and `go test ./pkg/frr/...` pass.
- New regression `TestBuildManagedSection_BGPRemoteAS0NotActivatedOrBFD`
  renders a mixed config (valid `10.0.2.1` + remote-as-0 `10.0.3.1`, both
  carrying family/BFD/export) via the real `buildManagedSection` and
  asserts the remote-as-0 neighbor is absent from **every** line while the
  valid neighbor renders fully. A self-consistency helper verifies no
  `activate`/`bfd`/`peer` line references an undeclared neighbor.

### RED-on-revert evidence

Reverting the `validNeighbors` guard on the AF and BFD loops (back to
`range bgp.Neighbors`) makes the render emit for the **undeclared**
neighbor:

```
address-family ipv4 unicast
  neighbor 10.0.2.1 activate
  neighbor 10.0.3.1 activate            <-- undeclared (no remote-as line)
...
bfd
 peer 10.0.2.1
 peer 10.0.3.1                          <-- undeclared
```

and the test fails:

```
bgp_remoteas0_activate_bfd_5518_test.go:96: neighbor 10.0.3.1 is activated but never declared (frr-reload would reject)
bgp_remoteas0_activate_bfd_5518_test.go:96: bfd peer 10.0.3.1 emitted but the neighbor was never declared (frr-reload would reject)
```

Restoring the guard turns it green.

Closes #5518

🤖 Generated with [Claude Code](https://claude.com/claude-code)