### PR TITLE
snmp: enforce trap-group categories filter (#5522)

### DIFF
--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -250,6 +250,14 @@ the userspace dataplane admission boundary is in
   into one entry before the immutable client-prefix cache is built, so a later
   duplicate with NO `clients` cannot overwrite an earlier block and silently
   erase its allowlist (an empty allowlist reads as allow-all → fail-open).
+  Trap-group `categories` ENFORCED (#5522): `snmp trap-group <g> categories
+  [ <cat> ]` scopes which notification categories a group receives — a link
+  up/down trap (category `link`) is dispatched to a group only if the group
+  lists `link` (or has no `categories` stanza = all categories, the Junos
+  default). Enforced in `pkg/snmp/traps.go` `groupWantsCategory`
+  (`sendLinkTraps` dispatch gate). Before #5522 the compiler recognized
+  `categories` but DISCARDED it, so a group scoped to exclude a category still
+  received every trap (a silent filter bypass; concrete instance under #4313).
 - **RPM probes**, dynamic address feeds.
 - **Dataplane buffer utilization** (`show system buffers`): AF_XDP
   UMEM/TX-ring capacity, CoS queued-byte capacity, helper-published

--- a/pkg/config/compiler_snmp_trapgroup_2990_test.go
+++ b/pkg/config/compiler_snmp_trapgroup_2990_test.go
@@ -202,3 +202,66 @@ func TestSNMPTrapGroup_BracketedTargets(t *testing.T) {
 		t.Fatalf("bracketed targets = %v, want 3 entries", tg)
 	}
 }
+
+// TestSNMPTrapGroup_CategoriesCarried is the config->struct half of the #5522
+// fix: a trap-group `categories` scope must land on SNMPTrapGroup.Categories so
+// pkg/snmp can enforce the filter. Before the fix the compiler recognized
+// `categories` only to dodge the unknown-key rejection but DROPPED its value,
+// so a group scoped to exclude a category still received every notification (a
+// silent filter bypass). Reverting the `tg.Categories = append(...)` line
+// leaves Categories nil here and fails these assertions.
+func TestSNMPTrapGroup_CategoriesCarried(t *testing.T) {
+	t.Run("single", func(t *testing.T) {
+		cfg, err := compileSNMPLines(t, []string{
+			"set snmp trap-group g1 targets 10.0.0.10",
+			"set snmp trap-group g1 categories link",
+		})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		tg := cfg.System.SNMP.TrapGroups["g1"]
+		if tg == nil {
+			t.Fatal("trap-group 'g1' missing from compiled config")
+		}
+		if len(tg.Categories) != 1 || tg.Categories[0] != "link" {
+			t.Fatalf("Categories = %v, want [link]", tg.Categories)
+		}
+	})
+
+	t.Run("bracketed", func(t *testing.T) {
+		cfg, err := compileSNMPLines(t, []string{
+			"set snmp trap-group g1 targets 10.0.0.10",
+			"set snmp trap-group g1 categories [ link configuration ]",
+		})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		tg := cfg.System.SNMP.TrapGroups["g1"]
+		if tg == nil {
+			t.Fatal("trap-group 'g1' missing from compiled config")
+		}
+		if len(tg.Categories) != 2 || tg.Categories[0] != "link" || tg.Categories[1] != "configuration" {
+			t.Fatalf("Categories = %v, want [link configuration]", tg.Categories)
+		}
+	})
+}
+
+// TestSNMPTrapGroup_CategoriesUnspecifiedEmpty confirms an unspecified
+// categories scope stays nil in the typed config; pkg/snmp treats nil as "all
+// categories" (the Junos default — an existing config without a categories
+// stanza must keep receiving every trap) (#5522).
+func TestSNMPTrapGroup_CategoriesUnspecifiedEmpty(t *testing.T) {
+	cfg, err := compileSNMPLines(t, []string{
+		"set snmp trap-group g1 targets 10.0.0.10",
+	})
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	tg := cfg.System.SNMP.TrapGroups["g1"]
+	if tg == nil {
+		t.Fatal("trap-group 'g1' missing from compiled config")
+	}
+	if len(tg.Categories) != 0 {
+		t.Fatalf("Categories = %v, want empty (unspecified = all)", tg.Categories)
+	}
+}

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -1341,10 +1341,18 @@ func compileSNMP(node *Node, sys *SystemConfig, cfg *Config, lenient bool) error
 						// v1-only receiver drops.
 						tg.Version = nodeVal(prop)
 					case "categories":
-						// Accepted trap-group leaf (schema-declared). Not
-						// consumed by the link-trap runtime today; recognized
-						// here so a valid key does not trip the unknown-key
-						// rejection below.
+						// #5522: retain the configured trap categories so the
+						// runtime can enforce the filter. `categories` is a
+						// schema `multi: true` leaf, so the bracketed/flat-set
+						// list collapses onto the leaf Keys and/or its children
+						// (the #2419 dual-shape) — read BOTH via
+						// firewallMatchValues. A trap-group with NO categories
+						// stanza leaves this nil, which pkg/snmp/traps.go treats
+						// as "all categories" (the Junos default). Before this
+						// the key was recognized but DISCARDED, so a group
+						// scoped to exclude `link` still received every
+						// linkUp/linkDown notification (filter bypass).
+						tg.Categories = append(tg.Categories, firewallMatchValues(prop)...)
 					default:
 						// #2990: a typoed child key (e.g. `tragets`) would
 						// otherwise be silently dropped, committing a trap

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -586,6 +586,16 @@ type SNMPTrapGroup struct {
 	// semantics); the emitter honors it in pkg/snmp/traps.go so a
 	// `version v1` group is not silently sent as v2c (#3948).
 	Version string
+	// Categories scopes which trap categories this group receives (Junos
+	// `snmp trap-group <g> categories <cat>`). A group lists the categories it
+	// WANTS; a notification is dispatched to the group only if the trap's
+	// category is in this list. An empty/nil slice means the group receives
+	// EVERY category — the Junos default for a trap-group with no `categories`
+	// stanza. Enforced in pkg/snmp/traps.go via groupWantsCategory (#5522);
+	// without this the configured category filter was parsed but discarded, so
+	// a group scoped to exclude a category (e.g. `link`) still received every
+	// linkUp/linkDown notification (a silent filter bypass).
+	Categories []string
 }
 
 // SNMPv3User defines an SNMPv3 USM user with authentication and privacy.

--- a/pkg/daemon/daemon_snmp_reconcile.go
+++ b/pkg/daemon/daemon_snmp_reconcile.go
@@ -115,6 +115,20 @@ func snmpConfigHash(cfg *config.Config) uint64 {
 			for _, t := range targets {
 				write(t)
 			}
+			// #5522: the trap-group `categories` filter is a live dispatch
+			// input enforced by pkg/snmp groupWantsCategory. A day-2 edit that
+			// changes ONLY the category scope (same name + version + targets)
+			// must NOT hash equal, or reconcile takes the idempotent no-op path
+			// and the running agent keeps sending traps in the removed category
+			// while the commit reports success. Sort so a reordered-but-
+			// equivalent list still hashes equal (dispatch is set membership,
+			// order-insensitive).
+			write("categories")
+			cats := append([]string(nil), tg.Categories...)
+			sort.Strings(cats)
+			for _, c := range cats {
+				write(c)
+			}
 		}
 	}
 

--- a/pkg/snmp/traps.go
+++ b/pkg/snmp/traps.go
@@ -6,10 +6,39 @@ import (
 	"math/rand"
 	"net"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
 )
+
+// SNMP trap categories (Junos `snmp trap-group <g> categories <cat>`). A
+// notification is dispatched to a trap-group only if the group is scoped to the
+// notification's category (or has no category scope = all). Link up/down traps
+// are tagged snmpCategoryLink; future category-tagged traps reuse the same
+// groupWantsCategory guard with their own category constant.
+const snmpCategoryLink = "link"
+
+// groupWantsCategory reports whether trap-group tg should receive a
+// notification tagged with category cat. A group with NO categories configured
+// receives EVERY category — the Junos default for a trap-group without a
+// `categories` stanza. A group scoped to specific categories receives only
+// those, so a group that omits (excludes) cat is skipped. Comparison is
+// case-insensitive to match the schema's free-form category tokens (#5522).
+func groupWantsCategory(tg *config.SNMPTrapGroup, cat string) bool {
+	if tg == nil {
+		return false
+	}
+	if len(tg.Categories) == 0 {
+		return true // no scope = all categories (Junos default)
+	}
+	for _, c := range tg.Categories {
+		if strings.EqualFold(strings.TrimSpace(c), cat) {
+			return true
+		}
+	}
+	return false
+}
 
 // SNMPv2-Trap PDU type (context-specific, constructed, tag 7).
 const pduSNMPv2Trap = 0xa7
@@ -266,6 +295,15 @@ func (a *Agent) sendLinkTraps(linkUp bool, ifindex int, ifname string) {
 	// deterministic (sorted) order so log output and dispatch ordering are
 	// stable across runs.
 	for _, tg := range sortedTrapGroups(cfg) {
+		// #5522: enforce the trap-group category filter. A link trap is in the
+		// "link" category; a group scoped to exclude link (e.g. `categories
+		// [configuration]`) must NOT receive it. A group with no `categories`
+		// stanza receives all categories (Junos default), so groupWantsCategory
+		// returns true for it. Without this gate the configured filter was
+		// silently inert — the discarded-Categories filter bypass.
+		if !groupWantsCategory(tg, snmpCategoryLink) {
+			continue
+		}
 		pkts := a.buildLinkTrapsForVersion(community, tg.Version, linkUp, ifindex, ifname)
 		for _, target := range tg.Targets {
 			for _, pkt := range pkts {

--- a/pkg/snmp/traps_categories_5522_test.go
+++ b/pkg/snmp/traps_categories_5522_test.go
@@ -1,0 +1,107 @@
+package snmp
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestGroupWantsCategory is the pure-logic guard for the #5522 trap-group
+// category filter. A group with no categories receives every category (the
+// Junos default); a scoped group receives only its listed categories, matched
+// case-insensitively.
+func TestGroupWantsCategory(t *testing.T) {
+	cases := []struct {
+		name       string
+		categories []string
+		cat        string
+		want       bool
+	}{
+		{"nil = all", nil, snmpCategoryLink, true},
+		{"empty = all", []string{}, snmpCategoryLink, true},
+		{"exact match", []string{"link"}, snmpCategoryLink, true},
+		{"case-insensitive", []string{"LINK"}, snmpCategoryLink, true},
+		{"whitespace trimmed", []string{" link "}, snmpCategoryLink, true},
+		{"one of several", []string{"configuration", "link"}, snmpCategoryLink, true},
+		{"excluded", []string{"configuration"}, snmpCategoryLink, false},
+		{"excluded multi", []string{"configuration", "routing"}, snmpCategoryLink, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tg := &config.SNMPTrapGroup{Name: "g", Categories: tc.categories}
+			if got := groupWantsCategory(tg, tc.cat); got != tc.want {
+				t.Fatalf("groupWantsCategory(%v, %q) = %v, want %v", tc.categories, tc.cat, got, tc.want)
+			}
+		})
+	}
+	if groupWantsCategory(nil, snmpCategoryLink) {
+		t.Fatal("groupWantsCategory(nil, ...) = true, want false for a nil group")
+	}
+}
+
+// linkTrapDelivered sets up a single trap group scoped to categories, fires a
+// linkDown, and reports whether the group's UDP target actually received a
+// trap within a short window. It is the end-to-end seam for the #5522 dispatch
+// gate: the group is skipped BEFORE the async enqueue, so an excluded category
+// yields a read timeout (no packet), while an included/empty scope delivers.
+func linkTrapDelivered(t *testing.T, categories []string) bool {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer pc.Close()
+	addr := pc.LocalAddr().String()
+
+	a := &Agent{
+		cfg: &config.SNMPConfig{
+			Communities: map[string]*config.SNMPCommunity{
+				"public": {Name: "public", Authorization: "read-only"},
+			},
+			TrapGroups: map[string]*config.SNMPTrapGroup{
+				"g": {Name: "g", Targets: []string{addr}, Categories: categories},
+			},
+		},
+		startTime: time.Now().Add(-10 * time.Second),
+	}
+	a.NotifyLinkDown(3, "ge-0-0-1")
+
+	buf := make([]byte, 4096)
+	pc.SetReadDeadline(time.Now().Add(750 * time.Millisecond))
+	_, _, err = pc.ReadFrom(buf)
+	return err == nil
+}
+
+// TestSendLinkTraps_CategoryFilter is the config->emit RED-on-revert guard for
+// #5522. A trap-group scoped to categories that EXCLUDE link must receive NO
+// linkUp/linkDown trap; a group scoped to include link (or with no categories =
+// all, the Junos default) must receive it. Before the fix the compiler
+// discarded `categories` and sendLinkTraps had no category guard, so the
+// excluded group still received every link trap — reverting either the
+// Categories retention or the groupWantsCategory gate delivers a trap to the
+// "excluded" case and fails it.
+func TestSendLinkTraps_CategoryFilter(t *testing.T) {
+	cases := []struct {
+		name       string
+		categories []string
+		want       bool
+	}{
+		// Positive controls prove the harness delivers within the window, so
+		// the negative assertion below is meaningful (not a flaky timeout).
+		{"no categories = all (Junos default)", nil, true},
+		{"scoped to link", []string{"link"}, true},
+		{"link among several", []string{"configuration", "link"}, true},
+		{"case-insensitive link", []string{"LINK"}, true},
+		// The bypass: a group scoped to exclude link must NOT receive it.
+		{"scoped to exclude link", []string{"configuration"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := linkTrapDelivered(t, tc.categories); got != tc.want {
+				t.Fatalf("link trap delivered=%v for categories=%v, want %v", got, tc.categories, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The compiler recognized `snmp trap-group <g> categories <cat>` in the grammar but **discarded** it: `SNMPTrapGroup` had no `Categories` field and the trap sender had no per-group category guard. A trap-group scoped to **exclude** a category (e.g. `categories [configuration]`, omitting `link`) therefore still received **every** linkUp/linkDown notification. The configured category filter was silently inert — a filter bypass (vsrx-parity / correctness).

Concrete instance under #4313.

## Fix (end-to-end)

- **`pkg/config/types_system.go`** — add `SNMPTrapGroup.Categories []string`. Empty/nil = the group receives every category, the **Junos default** for a trap-group with no `categories` stanza (preserves existing configs).
- **`pkg/config/compiler_system.go`** — retain the configured categories via `firewallMatchValues` so the bracketed/flat-set list survives **both** parser AST shapes (the #2419 multi-value-leaf contract), instead of matching `case "categories":` and dropping the value.
- **`pkg/daemon/daemon_snmp_reconcile.go`** — fold `Categories` into `snmpConfigHash` (sorted, order-insensitive) so a day-2 edit changing **only** the category scope triggers a reconcile instead of the idempotent no-op path (stale filter on the running agent).
- **`pkg/snmp/traps.go`** — gate per-group dispatch in `sendLinkTraps` on a new `groupWantsCategory(tg, cat)` helper. Link traps are tagged `snmpCategoryLink` ("link"); a group receives the trap only if its `Categories` includes link (case-insensitive) **or** is empty (= all). Helper is category-agnostic so future category-tagged traps reuse it.

## Invariant enforced

A configured trap-group category filter is enforced: a group scoped to specific categories (or excluding one) only receives notifications in its configured categories. A group with no `categories` stanza still receives all (Junos default) — existing configs unchanged.

## Validation

- **pkg/config**: `categories link` / `[ link configuration ]` land on `SNMPTrapGroup.Categories`; unspecified scope stays nil (= all).
- **pkg/snmp**: `groupWantsCategory` unit table + an end-to-end UDP-listener test — a group scoped to **exclude** link receives NO trap; groups including link, listing link among several, or with no categories (default) DO receive it.
- **RED-on-revert**: removing the `groupWantsCategory` dispatch gate delivers a link trap to the link-excluding group and fails `TestSendLinkTraps_CategoryFilter/scoped_to_exclude_link`:
  ```
  --- FAIL: TestSendLinkTraps_CategoryFilter/scoped_to_exclude_link
      traps_categories_5522_test.go:103: link trap delivered=true for categories=[configuration], want false
  ```
  Confirmed, then restored → green.
- `go build ./...` + `go test ./pkg/config/... ./pkg/snmp/...` green; gofmt clean.

Closes #5522

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBJFLjbgTeYuRdxnvZsRRu