### PR TITLE
security: redact feed URL credentials on show/export surfaces (#5521)

### DIFF
--- a/pkg/api/show_text.go
+++ b/pkg/api/show_text.go
@@ -181,7 +181,9 @@ func (s *Server) showTextHandler(w http.ResponseWriter, r *http.Request) {
 			for _, name := range sortedKeys(cfg.Security.DynamicAddress.FeedServers) {
 				feed := cfg.Security.DynamicAddress.FeedServers[name]
 				fmt.Fprintf(&buf, "Feed server: %s\n", name)
-				fmt.Fprintf(&buf, "  URL: %s\n", feed.URL)
+				// Redact embedded userinfo / query-string credentials before
+				// rendering to the REST client (#5521).
+				fmt.Fprintf(&buf, "  URL: %s\n", config.RedactURL(feed.URL))
 				if feed.FeedName != "" {
 					fmt.Fprintf(&buf, "  Feed name: %s\n", feed.FeedName)
 				}

--- a/pkg/cli/cli_show_dynamic_address_redaction_5521_test.go
+++ b/pkg/cli/cli_show_dynamic_address_redaction_5521_test.go
@@ -1,0 +1,70 @@
+// RED-on-revert test for #5521 (third surface from the #5528 review): the
+// on-box interactive `show security dynamic-address` renderer
+// (CLI.showDynamicAddress, cli_show_security_objects.go) must route each feed's
+// URL through config.RedactURL. Dynamic-address feeds routinely carry per-tenant
+// bearer tokens in the URL, so printing it raw discloses the credential into the
+// console operator's terminal scrollback / support bundles — the same class as
+// the primary gRPC/REST bug already fixed in this PR.
+//
+// Reverting cli_show_security_objects.go back to `fmt.Printf("    URL: %s\n",
+// fs.URL)` makes this test go RED: the raw userinfo + query tokens reappear.
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+func newCLIFeedURLStore(t *testing.T, feedURL string) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure(): %v", err)
+	}
+	if _, err := store.LoadSet(`set security dynamic-address feed-server tenant-feed url "` + feedURL + `"`); err != nil {
+		t.Fatalf("LoadSet(): %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit(): %v", err)
+	}
+	return store
+}
+
+// TestShowDynamicAddressCLIRedactsFeedURLCredentials pins the on-box CLI render.
+func TestShowDynamicAddressCLIRedactsFeedURLCredentials(t *testing.T) {
+	const (
+		userInfoToken = "s3cr3t-token"
+		queryToken    = "sup3r-secret"
+	)
+	feedURL := "https://user:" + userInfoToken + "@feeds.example.com/blocklist?apikey=" + queryToken
+
+	store := newCLIFeedURLStore(t, feedURL)
+	c := &CLI{store: store}
+
+	out := captureStdout(t, func() {
+		if err := c.showDynamicAddress(); err != nil {
+			t.Fatalf("showDynamicAddress(): %v", err)
+		}
+	})
+
+	if strings.Contains(out, userInfoToken) {
+		t.Errorf("basic-auth userinfo token %q leaked into on-box CLI output:\n%s", userInfoToken, out)
+	}
+	if strings.Contains(out, queryToken) {
+		t.Errorf("query-string credential %q leaked into on-box CLI output:\n%s", queryToken, out)
+	}
+	// The non-credential structure (host) must still be shown so the console
+	// operator can identify the feed.
+	if !strings.Contains(out, "feeds.example.com") {
+		t.Errorf("redacted URL dropped the host; operator can no longer identify the feed:\n%s", out)
+	}
+	if !strings.Contains(out, "<redacted>") {
+		t.Errorf("expected redaction sentinel <redacted> in on-box CLI output:\n%s", out)
+	}
+	if !strings.Contains(out, "Feed Server: tenant-feed") {
+		t.Errorf("feed-server name label missing from output:\n%s", out)
+	}
+}

--- a/pkg/cli/cli_show_security_objects.go
+++ b/pkg/cli/cli_show_security_objects.go
@@ -237,7 +237,10 @@ func (c *CLI) showDynamicAddress() error {
 		}
 		fmt.Printf("  Feed Server: %s\n", name)
 		if fs.URL != "" {
-			fmt.Printf("    URL: %s\n", fs.URL)
+			// Redact embedded basic-auth userinfo / query-string token before
+			// printing to the on-box console — the credentialed feed URL would
+			// otherwise land in terminal scrollback / support bundles (#5521).
+			fmt.Printf("    URL: %s\n", config.RedactURL(fs.URL))
 		}
 		if fs.FeedName != "" {
 			fmt.Printf("    Feed name: %s\n", fs.FeedName)

--- a/pkg/config/compiler_validate_strict_observability.go
+++ b/pkg/config/compiler_validate_strict_observability.go
@@ -202,11 +202,16 @@ func validateDynamicAddressFeedServerEndpointStrict(cfg *Config) error {
 			if display == "" {
 				display = name
 			}
+			// Redact the echoed URL: a malformed-but-credentialed base url
+			// (e.g. "https://user:token@" with no host) would otherwise leak
+			// the embedded userinfo / query token into this operator-visible
+			// commit error and any log capturing it (#5521; matches the DDNS
+			// validation warnings that already RedactURL their server/template).
 			return fmt.Errorf("security dynamic-address feed-server %q base url "+
 				"%q is malformed (%s) — http.NewRequestWithContext fails before "+
 				"any fetch, so it registers no feeds and any address-name bound "+
 				"to it silently matches nothing; set a valid http(s) url or hostname",
-				display, feedServerResolvedBaseURL(fs), reason)
+				display, RedactURL(feedServerResolvedBaseURL(fs)), reason)
 		}
 	}
 	return nil

--- a/pkg/feeds/feeds.go
+++ b/pkg/feeds/feeds.go
@@ -177,7 +177,7 @@ func resolveBaseURL(fsCfg *config.FeedServer) string {
 func warnPlaintextFeed(name, url string) {
 	if strings.HasPrefix(strings.ToLower(url), "http://") {
 		slog.Warn("dynamic-address: feed URL is plaintext http (no integrity — a MITM can substitute the feed body); prefer https",
-			"name", name, "url", url)
+			"name", name, "url", config.RedactURL(url))
 	}
 }
 
@@ -344,7 +344,7 @@ func (m *Manager) Apply(ctx context.Context, daCfg *config.DynamicAddressConfig)
 		warnPlaintextFeed(p.name, p.url)
 		go m.refreshLoop(feedCtx, fs, p.interval)
 		slog.Info("dynamic address feed started",
-			"name", p.name, "server", p.server, "url", p.url,
+			"name", p.name, "server", p.server, "url", config.RedactURL(p.url),
 			"interval", p.interval, "hold", holdStr,
 			"carried_prefixes", len(fs.prefixes))
 	}

--- a/pkg/grpcapi/server_show_dynamic_address_redact_5521_test.go
+++ b/pkg/grpcapi/server_show_dynamic_address_redact_5521_test.go
@@ -1,0 +1,58 @@
+package grpcapi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestShowDynamicAddressRedactsFeedURLCredentials pins #5521: the
+// `show security dynamic-address` render must route each feed's URL through
+// config.RedactURL so embedded basic-auth userinfo (https://user:token@host)
+// and query-string credentials (?apikey=secret) are NOT disclosed to a
+// read-only management client (or any command-output log / support bundle).
+//
+// RED-on-revert: replace config.RedactURL(feed.URL) with feed.URL in
+// server_show_security_text.go and the raw "s3cr3t-token" / "sup3r-secret"
+// substrings reappear in the output — this test then fails.
+func TestShowDynamicAddressRedactsFeedURLCredentials(t *testing.T) {
+	const (
+		userInfoToken = "s3cr3t-token"
+		queryToken    = "sup3r-secret"
+	)
+	cfg := &config.Config{}
+	cfg.Security.DynamicAddress.FeedServers = map[string]*config.FeedServer{
+		"tenant-feed": {
+			Name: "tenant-feed",
+			URL:  "https://user:" + userInfoToken + "@feeds.example.com/blocklist?apikey=" + queryToken,
+		},
+	}
+
+	s := &Server{}
+	var buf strings.Builder
+	s.showDynamicAddress(cfg, &buf)
+	out := buf.String()
+
+	// The embedded credentials must not appear anywhere in the operator-visible
+	// render.
+	if strings.Contains(out, userInfoToken) {
+		t.Errorf("basic-auth userinfo token %q leaked into show output:\n%s", userInfoToken, out)
+	}
+	if strings.Contains(out, queryToken) {
+		t.Errorf("query-string credential %q leaked into show output:\n%s", queryToken, out)
+	}
+
+	// The non-credential structure (scheme + host + path) must still be shown so
+	// the operator can identify the feed.
+	if !strings.Contains(out, "feeds.example.com") {
+		t.Errorf("redacted URL dropped the host; operator can no longer identify the feed:\n%s", out)
+	}
+	if !strings.Contains(out, "<redacted>") {
+		t.Errorf("expected redaction sentinel <redacted> in output:\n%s", out)
+	}
+	// The feed name label must survive unchanged.
+	if !strings.Contains(out, "Feed server: tenant-feed") {
+		t.Errorf("feed-server name label missing from output:\n%s", out)
+	}
+}

--- a/pkg/grpcapi/server_show_security_text.go
+++ b/pkg/grpcapi/server_show_security_text.go
@@ -866,7 +866,11 @@ func (s *Server) showDynamicAddress(cfg *config.Config, buf *strings.Builder) {
 		}
 		for name, feed := range cfg.Security.DynamicAddress.FeedServers {
 			fmt.Fprintf(buf, "Feed server: %s\n", name)
-			fmt.Fprintf(buf, "  URL: %s\n", feed.URL)
+			// Redact any embedded basic-auth userinfo / query-string token —
+			// dynamic-address feeds routinely carry per-tenant bearer tokens in
+			// the URL, and this render reaches read-only management clients and
+			// command-output logs / support bundles (#5521).
+			fmt.Fprintf(buf, "  URL: %s\n", config.RedactURL(feed.URL))
 			if feed.FeedName != "" {
 				fmt.Fprintf(buf, "  Feed name: %s\n", feed.FeedName)
 			}


### PR DESCRIPTION
## Summary

`show security dynamic-address` rendered each dynamic-address feed's URL **verbatim**, disclosing any embedded basic-auth userinfo (`https://user:token@host/...`) or query-string credential (`?apikey=secret`) to the client. Dynamic-address feeds routinely carry per-tenant bearer tokens in the URL, so a **read-only** management client — and any command-output logging or support bundle capturing the output — received the feed credentials in cleartext.

The project already has `config.RedactURL` (`pkg/config/secret.go`) and applies it to sibling credential-bearing URLs (DDNS server/template, #2841/#5458/#5464), but these feed-URL surfaces bypassed it.

## Sites redacted (every operator-visible render / export / log)

| Site | Surface |
|------|---------|
| `pkg/grpcapi/server_show_security_text.go` (`showDynamicAddress`) | primary gRPC `show security dynamic-address` text render — the issue's evidence line (:869) |
| `pkg/api/show_text.go` | HTTP REST `dynamic-address` text render |
| `pkg/feeds/feeds.go` ×2 | journald log sites: plaintext-http warning + `dynamic address feed started` info line (same journald-leak class #5458 fixed for schemeless credentialed URLs) |
| `pkg/config/compiler_validate_strict_observability.go` | commit-time "base url malformed" error echoes the resolved URL; a malformed-but-credentialed base url (e.g. `https://user:token@`) would leak into the operator error / logs |

## Left raw (justified)

- **`pkg/daemon/daemon_feeds.go` `feedsConfigHash`** feeds the URL into a **sha256** that governs the feed-producer set. It is never displayed, logged, or exported, and MUST retain credentials so two feeds differing only by token hash distinctly.
- **No proto / struct response field carries the feed URL** — the only client-facing surfaces are the two text renders above (verified by grepping the gRPC response builders + proto; `FeedInfo` carries a URL only for internal status, never marshaled to the client).

All non-URL output is preserved bit-for-bit; `RedactURL` keeps scheme/host/path so an operator can still identify the feed. A no-credential URL (e.g. `http://example.com/feed`) is returned unchanged, so the existing golden test is unaffected.

## Validation

- New `pkg/grpcapi` test `TestShowDynamicAddressRedactsFeedURLCredentials` asserts a feed with `https://user:s3cr3t-token@feeds.example.com/blocklist?apikey=sup3r-secret` redacts **both** the userinfo token **and** the query credential, while still showing `feeds.example.com` and the `<redacted>` sentinel.
- **RED-on-revert confirmed**: restoring the raw `feed.URL` at the grpcapi render makes the test fail — raw `sup3r-secret` reappears in output:
  ```
  URL: https://user:s3cr3t-token@feeds.example.com/blocklist?apikey=sup3r-secret
  ```
  Restored to the `RedactURL` call → test passes.
- `go build ./...` and `go test ./pkg/grpcapi/... ./pkg/api/... ./pkg/feeds/... ./pkg/config/...` all pass. `gofmt` clean.

Related to #5458 / #5464 (RedactURL work).

Closes #5521

🤖 Generated with [Claude Code](https://claude.com/claude-code)