### PR TITLE
configstore/journal: release lock across fsync (#4829)

### DIFF
--- a/pkg/configstore/journal/journal.go
+++ b/pkg/configstore/journal/journal.go
@@ -109,6 +109,14 @@ const (
 // do NOT hold the configstore Store.mu, and without internal locking a
 // reader that opens the current segment while Log rotates it to ".1"
 // would read the same inode under both names and duplicate entries.
+//
+// Lock discipline (#4829): j.mu guards the SEGMENT STATE (rotation, the
+// current-file inode, the buffered append), NOT the per-write fsync.
+// Log holds j.mu only for rotation + open + the buffered f.Write, then
+// RELEASES it before the synchronous f.Sync/SyncDir. A concurrent Tail
+// takes the same j.mu, so it is still serialized against rotation (no
+// duplicate inode) and against the write itself (no torn read), but it
+// no longer blocks for the writer's fsync duration.
 type Journal struct {
 	mu              sync.Mutex
 	path            string
@@ -117,6 +125,11 @@ type Journal struct {
 	// migrated guards the one-time permission-repair pass (#5188) so it
 	// runs once on first use, under j.mu, and is a no-op thereafter.
 	migrated bool
+	// syncFile fsyncs a fully-written segment for durability. It is a
+	// field only so tests can inject a slow/blocking fsync and prove Tail
+	// does not stall behind it (#4829); production always uses
+	// (*os.File).Sync. Called with j.mu RELEASED.
+	syncFile func(*os.File) error
 }
 
 // Option configures a Journal.
@@ -142,6 +155,7 @@ func New(path string, opts ...Option) *Journal {
 		path:            path,
 		maxSegmentBytes: DefaultMaxSegmentBytes,
 		maxSegments:     DefaultMaxSegments,
+		syncFile:        (*os.File).Sync,
 	}
 	for _, o := range opts {
 		o(j)
@@ -220,12 +234,25 @@ func chmodOwnerOnly(path string) {
 // only audit record now that config payloads live in rollback storage,
 // and appends are operator-paced); segment creation and rotation get a
 // directory fsync so the namespace change survives power loss too.
+//
+// Lock discipline (#4829): j.mu is held ONLY for the segment-state
+// mutation — rotation, open, the torn-tail check, and the buffered
+// f.Write — inside appendLocked. The durability step (f.Sync and, on
+// create/rotate, SyncDir) runs with j.mu RELEASED, because fsync
+// provides durability, NOT visibility: the record's bytes are already in
+// the page cache once f.Write returns. A concurrent Tail takes the same
+// j.mu, so it observes the segment namespace either before appendLocked
+// acquires the lock or after it releases the lock — never mid-rotation
+// (no duplicate inode) and never mid-write (no torn read) — yet it no
+// longer stalls for the writer's fsync (hundreds of ms on a busy disk).
+// Durability is unchanged: Log returns success only after f.Sync (and,
+// when the namespace changed, SyncDir) succeed.
+//
+// Concurrent Log callers serialize on the fast in-lock write via
+// appendLocked, then fsync in parallel with j.mu released; O_APPEND makes
+// each write land atomically at EOF, and every writer fsyncs its own fd,
+// so durability holds regardless of interleaving.
 func (j *Journal) Log(entry *Entry) error {
-	j.mu.Lock()
-	defer j.mu.Unlock()
-
-	j.migratePermsLocked()
-
 	if entry.Timestamp.IsZero() {
 		entry.Timestamp = time.Now()
 	}
@@ -238,13 +265,51 @@ func (j *Journal) Log(entry *Entry) error {
 		return fmt.Errorf("marshal journal entry: %w", err)
 	}
 
-	rotated, err := j.maybeRotateLocked()
+	f, created, rotated, err := j.appendLocked(data)
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
-	created := false
-	if _, err := os.Stat(j.path); os.IsNotExist(err) {
+	// Durability with j.mu RELEASED (see the method doc). Do NOT move
+	// these back under the lock: that reintroduces #4829, where a Tail
+	// reader blocks for the writer's entire fsync duration.
+	sync := j.syncFile
+	if sync == nil {
+		sync = (*os.File).Sync
+	}
+	if err := sync(f); err != nil {
+		return fmt.Errorf("sync journal: %w", err)
+	}
+	if created || rotated {
+		if err := fsatomic.SyncDir(filepath.Dir(j.path)); err != nil {
+			return fmt.Errorf("sync journal dir: %w", err)
+		}
+	}
+	return nil
+}
+
+// appendLocked runs the lock-held part of Log: the one-time permission
+// repair, rotation when the current segment is over threshold, opening
+// the current segment, the torn-tail self-heal, and the buffered write of
+// the newline-framed record. It returns the still-open file (the caller
+// fsyncs it with j.mu released) plus whether the segment was created or
+// rotated (both need a directory fsync). j.mu is held for the whole body,
+// so the buffered f.Write completes and is visible in the page cache
+// before the lock is released — any concurrent Tail that then acquires
+// j.mu sees a complete record, never a torn one.
+func (j *Journal) appendLocked(data []byte) (f *os.File, created, rotated bool, err error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	j.migratePermsLocked()
+
+	rotated, err = j.maybeRotateLocked()
+	if err != nil {
+		return nil, false, false, err
+	}
+
+	if _, statErr := os.Stat(j.path); os.IsNotExist(statErr) {
 		created = true
 	}
 
@@ -264,38 +329,30 @@ func (j *Journal) Log(entry *Entry) error {
 	// arg only applies when O_CREATE actually creates the file; on an
 	// EXISTING inode O_APPEND ignores it, so migratePermsLocked() above
 	// is what tightens an upgraded 0644 journal (#5188).
-	f, err := os.OpenFile(j.path, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0600)
+	f, err = os.OpenFile(j.path, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
-		return fmt.Errorf("open journal: %w", err)
+		return nil, false, false, fmt.Errorf("open journal: %w", err)
 	}
-	defer f.Close()
 
 	// Torn-tail self-heal: a crash between a previous write and its
 	// fsync can leave a partial final line. Starting this record on a
 	// fresh line confines the damage to that one record (which the
 	// tail reader's parse-or-skip rule already drops).
 	buf := make([]byte, 0, len(data)+2)
-	if fi, err := f.Stat(); err == nil && fi.Size() > 0 {
+	if fi, statErr := f.Stat(); statErr == nil && fi.Size() > 0 {
 		last := make([]byte, 1)
-		if _, err := f.ReadAt(last, fi.Size()-1); err == nil && last[0] != '\n' {
+		if _, readErr := f.ReadAt(last, fi.Size()-1); readErr == nil && last[0] != '\n' {
 			buf = append(buf, '\n')
 		}
 	}
 	buf = append(buf, data...)
 	buf = append(buf, '\n')
 
-	if _, err := f.Write(buf); err != nil {
-		return fmt.Errorf("write journal entry: %w", err)
+	if _, writeErr := f.Write(buf); writeErr != nil {
+		f.Close()
+		return nil, false, false, fmt.Errorf("write journal entry: %w", writeErr)
 	}
-	if err := f.Sync(); err != nil {
-		return fmt.Errorf("sync journal: %w", err)
-	}
-	if created || rotated {
-		if err := fsatomic.SyncDir(filepath.Dir(j.path)); err != nil {
-			return fmt.Errorf("sync journal dir: %w", err)
-		}
-	}
-	return nil
+	return f, created, rotated, nil
 }
 
 // maybeRotateLocked rotates the current segment when it is at or over

--- a/pkg/configstore/journal/journal_test.go
+++ b/pkg/configstore/journal/journal_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -787,6 +788,201 @@ func TestConcurrentLogTail(t *testing.T) {
 				t.Fatalf("duplicate entry %q during concurrent rotation", e.Detail)
 			}
 			seen[e.Detail] = true
+		}
+	}
+}
+
+// TestTailNotBlockedByLogFsync (#4829) is the headline invariant: a
+// Tail() concurrent with a Log() that is parked in fsync must return
+// promptly, NOT stall for the fsync duration. The #4829 design holds j.mu
+// only for the buffered write + rotation and releases it before f.Sync;
+// Tail takes the same j.mu and so must not wait behind the fsync.
+// RED-on-revert: move f.Sync back under j.mu (the pre-#4829 body) and
+// this test fails — Tail blocks ~fsyncHold.
+func TestTailNotBlockedByLogFsync(t *testing.T) {
+	j := testJournal(t)
+
+	// Seed one entry with the default fast sync so the file exists and
+	// Tail has real content to read.
+	mustLog(t, j, &Entry{Action: "commit", Detail: "seed"})
+
+	// Install a slow fsync: the next Log parks in f.Sync for fsyncHold.
+	// syncEntered fires the instant the fsync begins — by which point,
+	// under the #4829 design, j.mu is already released.
+	const fsyncHold = 750 * time.Millisecond
+	var once sync.Once
+	syncEntered := make(chan struct{})
+	j.syncFile = func(f *os.File) error {
+		once.Do(func() { close(syncEntered) })
+		time.Sleep(fsyncHold)
+		return f.Sync()
+	}
+
+	logDone := make(chan error, 1)
+	go func() { logDone <- j.Log(&Entry{Action: "commit", Detail: "slow"}) }()
+
+	select {
+	case <-syncEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Log never reached fsync")
+	}
+
+	start := time.Now()
+	got, err := j.Tail(50)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Tail: %v", err)
+	}
+	if elapsed > fsyncHold/2 {
+		t.Fatalf("Tail blocked %v behind Log's in-progress fsync (want prompt); "+
+			"j.mu is held across fsync — #4829 regressed", elapsed)
+	}
+	// Write happens under j.mu BEFORE the fsync, so by the time the fsync
+	// is running both entries are fully in the page cache and visible to a
+	// reader — durability (fsync) is decoupled from visibility (the
+	// write). Neither may be torn.
+	for _, e := range got {
+		if e.Action == "" {
+			t.Fatalf("torn/partial entry observed during concurrent Log: %+v", e)
+		}
+	}
+	if len(got) != 2 || got[0].Detail != "seed" || got[1].Detail != "slow" {
+		t.Fatalf("Tail concurrent with in-flight fsync did not see both complete entries: %+v", got)
+	}
+
+	if err := <-logDone; err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+}
+
+// TestConcurrentLogTailNoTornOrError (#4829): many writers appending
+// while many readers Tail concurrently must never surface a read error, a
+// torn/partial/garbage entry, or a duplicate within a single Tail
+// snapshot. Exercises the write-under-lock / fsync-outside-lock split
+// under -race. RED-on-revert of the torn-tail newline framing or the
+// parse-or-skip guard would let a partial record through here.
+func TestConcurrentLogTailNoTornOrError(t *testing.T) {
+	j := testJournal(t, WithMaxSegmentBytes(4096), WithMaxSegments(3))
+
+	const writers = 4
+	const perWriter = 250
+
+	stop := make(chan struct{})
+	var readers sync.WaitGroup
+	for r := 0; r < 3; r++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				got, err := j.Tail(50)
+				if err != nil {
+					t.Errorf("Tail: %v", err)
+					return
+				}
+				seen := map[string]bool{}
+				for _, e := range got {
+					if e.Action == "" || !strings.HasPrefix(e.Detail, "w") {
+						t.Errorf("torn/garbage entry from concurrent read: %+v", e)
+						return
+					}
+					if seen[e.Detail] {
+						t.Errorf("duplicate %q within one Tail snapshot", e.Detail)
+						return
+					}
+					seen[e.Detail] = true
+				}
+			}
+		}()
+	}
+
+	var writersWG sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		writersWG.Add(1)
+		go func(w int) {
+			defer writersWG.Done()
+			for i := 0; i < perWriter; i++ {
+				if err := j.Log(&Entry{Action: "commit", Detail: fmt.Sprintf("w%d-%05d", w, i)}); err != nil {
+					t.Errorf("Log: %v", err)
+					return
+				}
+			}
+		}(w)
+	}
+	writersWG.Wait()
+	close(stop)
+	readers.Wait()
+}
+
+// TestRotationDuringSlowFsync (#4829): rotation correctness must hold when
+// the fsync runs outside j.mu. With a small segment (forced rotations)
+// and a deliberately slow fsync, concurrent Tails must still see complete,
+// non-duplicated entries, and the final retained window must be
+// contiguous and end at the newest entry.
+func TestRotationDuringSlowFsync(t *testing.T) {
+	j := testJournal(t, WithMaxSegmentBytes(400), WithMaxSegments(2))
+	// Rotation happens under j.mu; the fsync after it. A non-zero fsync
+	// delay widens the window in which a reader can race a mid-flight
+	// durability op.
+	j.syncFile = func(f *os.File) error {
+		time.Sleep(2 * time.Millisecond)
+		return f.Sync()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 300; i++ {
+			if err := j.Log(&Entry{Action: "commit", Detail: fmt.Sprintf("c%05d", i)}); err != nil {
+				t.Errorf("Log: %v", err)
+				return
+			}
+		}
+	}()
+
+loop:
+	for {
+		select {
+		case <-done:
+			break loop
+		default:
+		}
+		got, err := j.Tail(20)
+		if err != nil {
+			t.Fatalf("Tail during rotation+slow-fsync: %v", err)
+		}
+		seen := map[string]bool{}
+		for _, e := range got {
+			if e.Action == "" {
+				t.Fatalf("torn entry during rotation+slow-fsync: %+v", e)
+			}
+			if seen[e.Detail] {
+				t.Fatalf("duplicate %q during concurrent rotation", e.Detail)
+			}
+			seen[e.Detail] = true
+		}
+	}
+
+	all, err := j.Tail(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) == 0 {
+		t.Fatal("no entries survived")
+	}
+	if all[len(all)-1].Detail != "c00299" {
+		t.Fatalf("newest entry missing: %q", all[len(all)-1].Detail)
+	}
+	for i := 1; i < len(all); i++ {
+		var prev, cur int
+		fmt.Sscanf(all[i-1].Detail, "c%d", &prev)
+		fmt.Sscanf(all[i].Detail, "c%d", &cur)
+		if cur != prev+1 {
+			t.Fatalf("retained window not contiguous: %q then %q", all[i-1].Detail, all[i].Detail)
 		}
 	}
 }


### PR DESCRIPTION
Closes #4829

## Problem

`Journal.Log()` held the single `j.mu` across the synchronous `f.Sync()`
(and, on rotation/creation, `fsatomic.SyncDir()`). `Journal.Tail()` takes
the **same** `j.mu` purely to read already-written segment files. So a
commit / rollback / system-action append that is mid-`fsync` on a busy or
slow disk blocked any concurrent `show system commit` / commit-history
REST query for the full fsync duration (hundreds of ms), even though the
reader touches no writer state.

## Why a plain RWMutex is not a drop-in (the nuance the issue warns about)

- `Tail` must stay **mutually exclusive with segment rotation**: a reader
  that opens the current segment while `Log` rotates it to `.1` would read
  the same inode under both names and duplicate entries.
- An `RWMutex` that still held the **write** lock across `fsync` would
  leave `Tail` readers blocked exactly as before — it changes the mutex
  type without addressing the fsync hold.

## Fix — issue approach (b): fsync with the lock released

`Log` is split so `j.mu` is held **only** for the segment-state mutation
— the one-time perm repair, rotation, open, the torn-tail check, and the
buffered `f.Write` — in a new `appendLocked` helper. The durability step
(`f.Sync` and, on create/rotate, `SyncDir`) runs with `j.mu` **released**.

### Why it is torn-read-safe (the crux — please review hostilely)

- The `f.Write` happens **under the same `j.mu` that `Tail` takes**. A
  concurrent `Tail` therefore observes the file either *before*
  `appendLocked` acquires the lock (old state) or *after* it releases the
  lock (record fully in the page cache) — **never mid-write and never
  mid-rotation**. No duplicate inode; no torn record.
- `fsync` provides **durability, not visibility**: the record's bytes are
  already in the page cache once `f.Write` returns, so moving the fsync
  outside the lock changes nothing a reader can see.
- Newline framing + the tail reader's parse-or-skip rule remain the
  defense in depth for a genuinely torn tail (a crash between write and
  fsync).

### Why durability is preserved

`Log` still returns success **only after** `f.Sync` (and, when the
namespace changed, `SyncDir`) succeed. Concurrent `Log` callers serialize
on the fast in-lock write, then fsync in parallel with `j.mu` released;
`O_APPEND` lands each write atomically at EOF and every writer fsyncs its
own fd, so durability holds regardless of interleaving.

A `syncFile` seam (`(*os.File).Sync` in production) is added so tests can
inject a blocking fsync.

## ⚠️ Flag for the hostile concurrency review

The lock-design choice is **release `j.mu` before `f.Sync`/`SyncDir`**,
keeping rotation + the buffered write inside the lock. The correctness
argument rests on three claims, each worth attacking:
1. `f.Write` under the same lock `Tail` uses ⇒ no visibility window for a
   torn read.
2. `fsync` is durability-only ⇒ moving it out of the lock is invisible to
   readers.
3. Rotation stays under the lock ⇒ the duplicate-inode hazard the struct
   doc warns about is unchanged.

## Validation

- `go build ./...` clean.
- `go test -race ./pkg/configstore/...` green; journal concurrency tests
  run **5×** with no flake.
- New tests:
  - `TestTailNotBlockedByLogFsync` — `Tail` returns promptly while a `Log`
    is parked in a 750ms fsync, and still sees **both** complete entries
    (proving write-visible-before-fsync).
  - `TestConcurrentLogTailNoTornOrError` — writers + readers under
    `-race`: no torn/garbage/duplicate entry, no read error.
  - `TestRotationDuringSlowFsync` — rotation stays correct/contiguous with
    fsync outside the lock.
- **RED-on-revert**: moving `f.Sync` back under `j.mu` makes
  `TestTailNotBlockedByLogFsync` fail with
  `Tail blocked 751.11ms behind Log's in-progress fsync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKohbVXMtR9imT6GbrNmU6