### PR TITLE
grpcapi: bound the filtered ClearSessions working set

### DIFF
--- a/pkg/grpcapi/clear_sessions_bounded_5454_test.go
+++ b/pkg/grpcapi/clear_sessions_bounded_5454_test.go
@@ -18,6 +18,7 @@ package grpcapi
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -104,6 +105,11 @@ type boundedClearDP struct {
 	v4 map[dataplane.SessionKey]dataplane.SessionValue
 	v6 map[dataplane.SessionKeyV6]dataplane.SessionValueV6
 
+	// fwdNotFound models a GC race: a forward key collected during iteration
+	// returns ErrKeyNotExist by delete time (it is left in the map so the
+	// cursor still advances, mimicking "reaped just before deleteAll").
+	fwdNotFound bool
+
 	deletedDNATv4 int
 	deletedDNATv6 int
 }
@@ -131,15 +137,23 @@ func (d *boundedClearDP) IterateSessionsV6From(cursor *dataplane.SessionKeyV6, f
 }
 
 func (d *boundedClearDP) DeleteSession(key dataplane.SessionKey) error {
-	if _, ok := d.v4[key]; !ok {
+	val, ok := d.v4[key]
+	if !ok {
 		return ebpf.ErrKeyNotExist
+	}
+	if d.fwdNotFound && val.IsReverse == 0 {
+		return ebpf.ErrKeyNotExist // forward key reaped by GC before delete
 	}
 	delete(d.v4, key)
 	return nil
 }
 
 func (d *boundedClearDP) DeleteSessionV6(key dataplane.SessionKeyV6) error {
-	if _, ok := d.v6[key]; !ok {
+	val, ok := d.v6[key]
+	if !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	if d.fwdNotFound && val.IsReverse == 0 {
 		return ebpf.ErrKeyNotExist
 	}
 	delete(d.v6, key)
@@ -316,5 +330,59 @@ func TestClearSessionsFilteredContextCancel(t *testing.T) {
 	// run to completion.
 	if len(dp.v4) == 0 {
 		t.Fatalf("all v4 sessions cleared despite mid-clear cancel — not prompt")
+	}
+}
+
+// TestClearSessionsFilteredForwardNotFoundBenign covers the #5531 review MINOR:
+// a forward key that is already gone at delete time (GC reaped it, or a
+// restart-from-bucket-0 after a GC-deleted anchor re-collected a prior chunk's
+// key) must be BENIGN — not a spurious Failure, and not a re-delete that
+// regrows the failure-string buffer this fix bounds. RED-on-revert: routing the
+// forward delete back through add() (instead of addExceptNotFound) reports
+// Failures>0 for the reaped keys.
+func TestClearSessionsFilteredForwardNotFoundBenign(t *testing.T) {
+	const n = 50
+	origBatch := clearFilteredBatch
+	clearFilteredBatch = 8
+	t.Cleanup(func() { clearFilteredBatch = origBatch })
+
+	dp := seedBoundedClearDP(n)
+	dp.fwdNotFound = true // every collected forward key is already gone at delete time
+	s := newBoundedClearServer(t, dp)
+
+	resp, err := s.ClearSessions(context.Background(), &pb.ClearSessionsRequest{Protocol: "tcp"})
+	if err != nil {
+		t.Fatalf("ClearSessions RPC error: %v", err)
+	}
+	if resp.Failures != 0 {
+		t.Fatalf("forward ErrKeyNotExist inflated Failures=%d summary=%q, want 0 (benign #5531)", resp.Failures, resp.FailureSummary)
+	}
+	// The forward keys were reaped by GC, not by us -> not counted as cleared.
+	if resp.Ipv4Cleared != 0 || resp.Ipv6Cleared != 0 {
+		t.Fatalf("Ipv4Cleared=%d Ipv6Cleared=%d, want 0/0 (forward keys already gone)", resp.Ipv4Cleared, resp.Ipv6Cleared)
+	}
+	if resp.FailureSummary != "" {
+		t.Fatalf("FailureSummary=%q, want empty (no failures)", resp.FailureSummary)
+	}
+}
+
+// TestClearErrorsPartsBounded proves the failure-string buffer stays O(cap)
+// regardless of how many failures accumulate (#5531 review): count is exact but
+// parts is capped with a trailing overflow summary. RED-on-revert: without the
+// cap, parts grows to the full failure count.
+func TestClearErrorsPartsBounded(t *testing.T) {
+	var e clearErrors
+	const total = 500
+	for i := 0; i < total; i++ {
+		e.add("v4 forward delete", fmt.Errorf("EBUSY inst %d", i))
+	}
+	if e.count != total {
+		t.Fatalf("count=%d, want %d (honest total must stay exact)", e.count, total)
+	}
+	if len(e.parts) > clearErrorsPartsCap {
+		t.Fatalf("failure-string buffer grew to %d entries, want <= %d (unbounded regrowth #5531)", len(e.parts), clearErrorsPartsCap)
+	}
+	if want := total - clearErrorsPartsCap; !strings.Contains(e.summary(), fmt.Sprintf("…and %d more", want)) {
+		t.Fatalf("summary missing bounded-overflow marker: %q", e.summary())
 	}
 }

--- a/pkg/grpcapi/clear_sessions_bounded_5454_test.go
+++ b/pkg/grpcapi/clear_sessions_bounded_5454_test.go
@@ -1,0 +1,320 @@
+// #5454: the FILTERED ClearSessions gRPC path must bound its handler-goroutine
+// working set to O(batch), not O(matches). The pre-#5454 path materialized
+// every matching forward key, reverse companion, and DNAT companion into
+// unbounded slices before the first delete — an O(N) allocation (N up to the
+// full multi-million-entry session table) a fabric-reachable PSK peer could
+// weaponize into a control-plane OOM/GC-stall DoS.
+//
+// These tests drive the clear through a cursor-capable in-memory dataplane
+// (modelling the production LegacyDataPlaneAdapter, which implements
+// sessionCursorIterator) and assert (a) every matching session plus its reverse
+// and DNAT companions is deleted, (b) the collected-key chunk never exceeds
+// clearFilteredBatch (bounded working set), and (c) a mid-clear context cancel
+// stops promptly. RED-on-revert: reverting clearFilteredSessionsV4 to the
+// collect-all-then-delete path reports a single len==matches chunk, so the
+// bounded-chunk assertion fails.
+package grpcapi
+
+import (
+	"context"
+	"encoding/binary"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// v4KeyOrder returns a deterministic ordering token for a v4 session key so a
+// map-backed fake can present a STABLE iteration order with resume-after-cursor
+// semantics (modelling the kernel hash map's BPF_MAP_GET_NEXT_KEY, which the
+// real IterateSessionsFrom walks).
+func v4KeyOrder(k dataplane.SessionKey) string {
+	var b [13]byte
+	copy(b[0:4], k.SrcIP[:])
+	copy(b[4:8], k.DstIP[:])
+	binary.BigEndian.PutUint16(b[8:10], k.SrcPort)
+	binary.BigEndian.PutUint16(b[10:12], k.DstPort)
+	b[12] = k.Protocol
+	return string(b[:])
+}
+
+func v6KeyOrder(k dataplane.SessionKeyV6) string {
+	var b [37]byte
+	copy(b[0:16], k.SrcIP[:])
+	copy(b[16:32], k.DstIP[:])
+	binary.BigEndian.PutUint16(b[32:34], k.SrcPort)
+	binary.BigEndian.PutUint16(b[34:36], k.DstPort)
+	b[36] = k.Protocol
+	return string(b[:])
+}
+
+// iterateV4From iterates sessions in a stable order, resuming strictly after
+// cursor (or from the start when cursor is nil), mirroring the real cursor
+// iterator. Shared by the fakes in this package.
+func iterateV4From(sessions map[dataplane.SessionKey]dataplane.SessionValue, cursor *dataplane.SessionKey, fn func(dataplane.SessionKey, dataplane.SessionValue) bool) {
+	keys := make([]dataplane.SessionKey, 0, len(sessions))
+	for k := range sessions {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return v4KeyOrder(keys[i]) < v4KeyOrder(keys[j]) })
+	started := cursor == nil
+	for _, k := range keys {
+		if !started {
+			if k == *cursor {
+				started = true
+			}
+			continue
+		}
+		if !fn(k, sessions[k]) {
+			return
+		}
+	}
+}
+
+func iterateV6From(sessions map[dataplane.SessionKeyV6]dataplane.SessionValueV6, cursor *dataplane.SessionKeyV6, fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) {
+	keys := make([]dataplane.SessionKeyV6, 0, len(sessions))
+	for k := range sessions {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return v6KeyOrder(keys[i]) < v6KeyOrder(keys[j]) })
+	started := cursor == nil
+	for _, k := range keys {
+		if !started {
+			if k == *cursor {
+				started = true
+			}
+			continue
+		}
+		if !fn(k, sessions[k]) {
+			return
+		}
+	}
+}
+
+// boundedClearDP is a cursor-capable in-memory dataplane fake. DeleteSession
+// actually removes the key (modelling the real map), so the cursor advances and
+// the clear converges; DeleteDNATEntry records the companion delete.
+type boundedClearDP struct {
+	*dataplane.Manager
+
+	v4 map[dataplane.SessionKey]dataplane.SessionValue
+	v6 map[dataplane.SessionKeyV6]dataplane.SessionValueV6
+
+	deletedDNATv4 int
+	deletedDNATv6 int
+}
+
+func (d *boundedClearDP) IsLoaded() bool { return true }
+
+func (d *boundedClearDP) IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	iterateV4From(d.v4, nil, fn)
+	return nil
+}
+
+func (d *boundedClearDP) IterateSessionsV6(fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	iterateV6From(d.v6, nil, fn)
+	return nil
+}
+
+func (d *boundedClearDP) IterateSessionsFrom(cursor *dataplane.SessionKey, fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	iterateV4From(d.v4, cursor, fn)
+	return nil
+}
+
+func (d *boundedClearDP) IterateSessionsV6From(cursor *dataplane.SessionKeyV6, fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	iterateV6From(d.v6, cursor, fn)
+	return nil
+}
+
+func (d *boundedClearDP) DeleteSession(key dataplane.SessionKey) error {
+	if _, ok := d.v4[key]; !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	delete(d.v4, key)
+	return nil
+}
+
+func (d *boundedClearDP) DeleteSessionV6(key dataplane.SessionKeyV6) error {
+	if _, ok := d.v6[key]; !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	delete(d.v6, key)
+	return nil
+}
+
+func (d *boundedClearDP) DeleteDNATEntry(dataplane.DNATKey) error {
+	d.deletedDNATv4++
+	return nil
+}
+
+func (d *boundedClearDP) DeleteDNATEntryV6(dataplane.DNATKeyV6) error {
+	d.deletedDNATv6++
+	return nil
+}
+
+func newBoundedClearServer(t *testing.T, dp grpcRuntime) *Server {
+	t.Helper()
+	return &Server{
+		store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")),
+		dp:    dp,
+	}
+}
+
+// seedBoundedClearDP seeds n matching TCP forward sessions (half SNAT so a DNAT
+// companion delete is issued) plus each session's reverse conntrack entry.
+func seedBoundedClearDP(n int) *boundedClearDP {
+	d := &boundedClearDP{
+		Manager: dataplane.New(),
+		v4:      make(map[dataplane.SessionKey]dataplane.SessionValue),
+		v6:      make(map[dataplane.SessionKeyV6]dataplane.SessionValueV6),
+	}
+	for i := 0; i < n; i++ {
+		// Distinct v4 forward key.
+		fwd := dataplane.SessionKey{
+			Protocol: 6,
+			SrcIP:    [4]byte{10, 0, byte(i >> 8), byte(i)},
+			DstIP:    [4]byte{8, 8, 8, 8},
+			SrcPort:  uint16(0x1000 + i),
+			DstPort:  0x0050,
+		}
+		rev := dataplane.SessionKey{
+			Protocol: 6,
+			SrcIP:    [4]byte{8, 8, 8, 8},
+			DstIP:    [4]byte{203, 0, 113, byte(i)},
+			SrcPort:  0x0050,
+			DstPort:  uint16(0x2000 + i),
+		}
+		val := dataplane.SessionValue{ReverseKey: rev}
+		if i%2 == 0 {
+			val.Flags = dataplane.SessFlagSNAT // dynamic SNAT -> DNAT companion
+		}
+		d.v4[fwd] = val
+		d.v4[rev] = dataplane.SessionValue{IsReverse: 1} // reverse conntrack entry
+
+		// Distinct v6 forward key + reverse.
+		fwd6 := dataplane.SessionKeyV6{Protocol: 6, SrcPort: uint16(0x3000 + i), DstPort: 0x0050}
+		fwd6.SrcIP[0] = 0x20
+		fwd6.SrcIP[15] = byte(i)
+		fwd6.SrcIP[14] = byte(i >> 8)
+		rev6 := dataplane.SessionKeyV6{Protocol: 6, SrcPort: 0x0050, DstPort: uint16(0x4000 + i)}
+		rev6.DstIP[0] = 0x20
+		rev6.DstIP[15] = byte(i)
+		rev6.DstIP[14] = byte(i >> 8)
+		val6 := dataplane.SessionValueV6{ReverseKey: rev6}
+		if i%2 == 0 {
+			val6.Flags = dataplane.SessFlagSNAT
+		}
+		d.v6[fwd6] = val6
+		d.v6[rev6] = dataplane.SessionValueV6{IsReverse: 1}
+	}
+	return d
+}
+
+func TestClearSessionsFilteredBoundedWorkingSet(t *testing.T) {
+	const n = 50
+	const batch = 8
+
+	// Shrink the batch and install the chunk observer for this test only.
+	origBatch := clearFilteredBatch
+	origObs := clearFilteredBatchObserver
+	clearFilteredBatch = batch
+	var maxChunk, chunkCalls int
+	clearFilteredBatchObserver = func(chunkLen int) {
+		chunkCalls++
+		if chunkLen > maxChunk {
+			maxChunk = chunkLen
+		}
+	}
+	t.Cleanup(func() {
+		clearFilteredBatch = origBatch
+		clearFilteredBatchObserver = origObs
+	})
+
+	dp := seedBoundedClearDP(n)
+	s := newBoundedClearServer(t, dp)
+
+	resp, err := s.ClearSessions(context.Background(), &pb.ClearSessionsRequest{Protocol: "tcp"})
+	if err != nil {
+		t.Fatalf("ClearSessions RPC error: %v", err)
+	}
+
+	// (a) Every matching forward session cleared, count accurate.
+	if resp.Ipv4Cleared != n {
+		t.Fatalf("Ipv4Cleared=%d, want %d", resp.Ipv4Cleared, n)
+	}
+	if resp.Ipv6Cleared != n {
+		t.Fatalf("Ipv6Cleared=%d, want %d", resp.Ipv6Cleared, n)
+	}
+	// Forward AND reverse conntrack entries all removed from the table.
+	if len(dp.v4) != 0 {
+		t.Fatalf("v4 sessions remaining after clear: %d, want 0 (forward+reverse leak)", len(dp.v4))
+	}
+	if len(dp.v6) != 0 {
+		t.Fatalf("v6 sessions remaining after clear: %d, want 0", len(dp.v6))
+	}
+	// DNAT companions deleted for every SNAT session (half of n, v4 and v6).
+	if want := (n + 1) / 2; dp.deletedDNATv4 != want {
+		t.Fatalf("v4 DNAT companion deletes=%d, want %d", dp.deletedDNATv4, want)
+	}
+	if want := (n + 1) / 2; dp.deletedDNATv6 != want {
+		t.Fatalf("v6 DNAT companion deletes=%d, want %d", dp.deletedDNATv6, want)
+	}
+	if resp.Failures != 0 {
+		t.Fatalf("Failures=%d summary=%q, want 0", resp.Failures, resp.FailureSummary)
+	}
+
+	// (b) Bounded working set: no collected chunk exceeded the batch bound, and
+	// the clear was actually chunked (proving it did NOT collect all matches
+	// into one slice — the #5454 bug). RED-on-revert: the collect-all path
+	// reports a single len==n chunk, so maxChunk==n>batch here.
+	if maxChunk > batch {
+		t.Fatalf("collected chunk length %d exceeded batch bound %d — working set not bounded (#5454)", maxChunk, batch)
+	}
+	if chunkCalls < 2 {
+		t.Fatalf("clear used %d chunk(s) for %d v4 + %d v6 matches with batch %d — not chunked (collect-all regression #5454)", chunkCalls, n, n, batch)
+	}
+}
+
+func TestClearSessionsFilteredContextCancel(t *testing.T) {
+	const n = 50
+	const batch = 8
+
+	origBatch := clearFilteredBatch
+	origObs := clearFilteredBatchObserver
+	clearFilteredBatch = batch
+	t.Cleanup(func() {
+		clearFilteredBatch = origBatch
+		clearFilteredBatchObserver = origObs
+	})
+
+	dp := seedBoundedClearDP(n)
+	s := newBoundedClearServer(t, dp)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel the RPC as soon as the first chunk is collected so the clear must
+	// stop promptly instead of draining all n matches.
+	clearFilteredBatchObserver = func(int) { cancel() }
+
+	resp, err := s.ClearSessions(ctx, &pb.ClearSessionsRequest{Protocol: "tcp"})
+	if err != nil {
+		t.Fatalf("ClearSessions RPC error: %v", err)
+	}
+
+	// Prompt stop: far fewer than all n sessions cleared, and the cancellation
+	// is surfaced in the failure summary.
+	if resp.Ipv4Cleared >= n {
+		t.Fatalf("Ipv4Cleared=%d, want < %d (clear did not stop promptly on cancel)", resp.Ipv4Cleared, n)
+	}
+	if resp.Failures == 0 || !strings.Contains(resp.FailureSummary, "canceled") {
+		t.Fatalf("cancellation not surfaced: Failures=%d summary=%q", resp.Failures, resp.FailureSummary)
+	}
+	// Some v4 sessions remain (the clear was interrupted), proving it did not
+	// run to completion.
+	if len(dp.v4) == 0 {
+		t.Fatalf("all v4 sessions cleared despite mid-clear cancel — not prompt")
+	}
+}

--- a/pkg/grpcapi/clear_sessions_errors_test.go
+++ b/pkg/grpcapi/clear_sessions_errors_test.go
@@ -49,6 +49,20 @@ func (d *clearFaultGRPCDP) IterateSessionsV6(fn func(dataplane.SessionKeyV6, dat
 	return d.iterV6Err
 }
 
+// IterateSessionsFrom / IterateSessionsV6From model the cursor iterator the
+// #5454 filtered-clear path uses. Without them the embedded *dataplane.Manager
+// promotes a real (empty-map) cursor iterator that would silently iterate
+// nothing. They route through the in-memory sessions and preserve the injected
+// iterator errors.
+func (d *clearFaultGRPCDP) IterateSessionsFrom(cursor *dataplane.SessionKey, fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	iterateV4From(d.v4Sessions, cursor, fn)
+	return d.iterErr
+}
+
+func (d *clearFaultGRPCDP) IterateSessionsV6From(cursor *dataplane.SessionKeyV6, fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return d.iterV6Err
+}
+
 func (d *clearFaultGRPCDP) DeleteSession(key dataplane.SessionKey) error {
 	if _, isForward := d.v4Sessions[key]; isForward {
 		return d.fwdDelErr

--- a/pkg/grpcapi/clear_sessions_reversekey_test.go
+++ b/pkg/grpcapi/clear_sessions_reversekey_test.go
@@ -38,6 +38,17 @@ func (d *recordingClearGRPCDP) IterateSessionsV6(fn func(dataplane.SessionKeyV6,
 	return nil
 }
 
+// Cursor iterators for the #5454 filtered-clear path (the embedded
+// *dataplane.Manager would otherwise promote empty-map iterators).
+func (d *recordingClearGRPCDP) IterateSessionsFrom(cursor *dataplane.SessionKey, fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	iterateV4From(d.v4Sessions, cursor, fn)
+	return nil
+}
+
+func (d *recordingClearGRPCDP) IterateSessionsV6From(cursor *dataplane.SessionKeyV6, fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return nil
+}
+
 func (d *recordingClearGRPCDP) DeleteSession(key dataplane.SessionKey) error {
 	d.deletedV4 = append(d.deletedV4, key)
 	if d.missingV4[key] {

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -1030,88 +1030,17 @@ func (s *Server) ClearSessions(ctx context.Context, req *pb.ClearSessionsRequest
 
 	var agg clearErrors
 
-	// Clear matching IPv4 sessions
-	v4Deleted := 0
-	var v4Keys []dataplane.SessionKey
-	var v4RevKeys []dataplane.SessionKey
-	var snatDNATKeys []dataplane.DNATKey
-	// Enumeration failure must be surfaced: a partial scan means the
-	// clear silently misses sessions the operator asked to remove.
-	agg.add("v4 iterate", s.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
-		if !filter.matchV4(key, val) {
-			return true
-		}
-		v4Keys = append(v4Keys, key)
-		// The reverse companion is installed keyed on val.ReverseKey
-		// (the TRANSLATED tuple for NAT'd sessions — session_store.go
-		// PutClusterSyncedV4 / manager_ha.go), NOT a naive src/dst swap
-		// of the forward key. For a non-NAT session the two coincide;
-		// for a NAT'd session a naive swap would leave the real reverse
-		// entry behind (#2733). A zero ReverseKey (Protocol==0) means no
-		// reverse companion was installed (the needsReverse gate).
-		if val.ReverseKey.Protocol != 0 {
-			v4RevKeys = append(v4RevKeys, val.ReverseKey)
-		}
-		if val.Flags&dataplane.SessFlagSNAT != 0 &&
-			val.Flags&dataplane.SessFlagStaticNAT == 0 {
-			// Companion dnat_table key must match the write-side encoding
-			// (#2406: host-order port) or the delete silently misses.
-			snatDNATKeys = append(snatDNATKeys, dataplane.DNATKeyForSessionV4(key, val))
-		}
-		return true
-	}))
-
-	for _, key := range v4Keys {
-		if err := s.dp.DeleteSession(key); err != nil {
-			agg.add("v4 forward delete", err)
-		} else {
-			v4Deleted++
-		}
-	}
-	for _, key := range v4RevKeys {
-		agg.addExceptNotFound("v4 reverse delete", s.dp.DeleteSession(key))
-	}
-	for _, dk := range snatDNATKeys {
-		agg.addExceptNotFound("v4 DNAT companion delete", s.dp.DeleteDNATEntry(dk))
-	}
-
-	// Clear matching IPv6 sessions
-	v6Deleted := 0
-	var v6Keys []dataplane.SessionKeyV6
-	var v6RevKeys []dataplane.SessionKeyV6
-	var snatDNATKeysV6 []dataplane.DNATKeyV6
-	agg.add("v6 iterate", s.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
-		if !filter.matchV6(key, val) {
-			return true
-		}
-		v6Keys = append(v6Keys, key)
-		// Reverse companion at the TRANSLATED tuple val.ReverseKey, not a
-		// naive swap (see V4 above, #2733). Zero ReverseKey => no companion.
-		if val.ReverseKey.Protocol != 0 {
-			v6RevKeys = append(v6RevKeys, val.ReverseKey)
-		}
-		if val.Flags&dataplane.SessFlagSNAT != 0 &&
-			val.Flags&dataplane.SessFlagStaticNAT == 0 {
-			// Companion dnat_table_v6 key must match the write-side encoding
-			// (#2406: host-order port) or the delete silently misses.
-			snatDNATKeysV6 = append(snatDNATKeysV6, dataplane.DNATKeyForSessionV6(key, val))
-		}
-		return true
-	}))
-
-	for _, key := range v6Keys {
-		if err := s.dp.DeleteSessionV6(key); err != nil {
-			agg.add("v6 forward delete", err)
-		} else {
-			v6Deleted++
-		}
-	}
-	for _, key := range v6RevKeys {
-		agg.addExceptNotFound("v6 reverse delete", s.dp.DeleteSessionV6(key))
-	}
-	for _, dk := range snatDNATKeysV6 {
-		agg.addExceptNotFound("v6 DNAT companion delete", s.dp.DeleteDNATEntryV6(dk))
-	}
+	// Clear matching IPv4 + IPv6 sessions with a BOUNDED handler working set
+	// (#5454). The pre-#5454 path materialized EVERY matching forward key,
+	// reverse companion, and DNAT companion into unbounded slices before the
+	// first delete — O(N) handler-goroutine allocation where N is up to the
+	// full (multi-million entry) session table. ClearSessions is fabric-
+	// reachable (fabricAllowedUnaryMethods), so a PSK-holding peer could
+	// trigger a broad filtered clear that retained hundreds of MB and stalled
+	// the control-plane GC / OOM-killed the daemon. The helpers below hold at
+	// most O(clearFilteredBatch) keys regardless of how many sessions match.
+	v4Deleted := s.clearFilteredSessionsV4(ctx, filter, &agg)
+	v6Deleted := s.clearFilteredSessionsV6(ctx, filter, &agg)
 
 	if !forwarded {
 		agg.add("peer clear", s.clearPeerSessions(req))
@@ -1122,6 +1051,330 @@ func (s *Server) ClearSessions(ctx context.Context, req *pb.ClearSessionsRequest
 	}
 	agg.apply(resp)
 	return resp, nil
+}
+
+// clearFilteredBatch bounds the number of matching session keys the filtered
+// ClearSessions path holds in the handler goroutine at once (#5454). The
+// session table can hold millions of entries; the pre-#5454 path collected
+// every match (forward + reverse + DNAT keys) before deleting, an O(matches)
+// allocation a fabric-reachable caller could weaponize. Collection now stops at
+// this many forward keys, deletes that chunk, and resumes, so peak key-slice
+// memory is O(clearFilteredBatch), not O(matches). It is a var (not const) so a
+// test can shrink it to exercise the multi-chunk path with a small table.
+var clearFilteredBatch = 1024
+
+// clearFilteredBatchObserver, when non-nil, is invoked once per collected key
+// chunk with len(chunk) (the forward-key count). It is a test-only seam that
+// lets a unit test assert the filtered clear collects keys in bounded chunks
+// instead of one N-sized slice (#5454). A revert to the collect-all-then-delete
+// path reports a single len==matches chunk, so the bounded-working-set
+// assertion goes RED. Production leaves it nil.
+var clearFilteredBatchObserver func(chunkLen int)
+
+// clearBatchV4 accumulates one bounded chunk of matching v4 session keys plus
+// each matched session's reverse and DNAT companion keys, then deletes them.
+type clearBatchV4 struct {
+	fwd  []dataplane.SessionKey
+	rev  []dataplane.SessionKey
+	dnat []dataplane.DNATKey
+}
+
+func (b *clearBatchV4) reset() {
+	b.fwd = b.fwd[:0]
+	b.rev = b.rev[:0]
+	b.dnat = b.dnat[:0]
+}
+
+// collect appends a matched session's forward key plus its reverse and DNAT
+// companions, mirroring the exact key construction the pre-#5454 inline path
+// used: the reverse companion is keyed on the TRANSLATED tuple val.ReverseKey
+// (NOT a naive src/dst swap — #2733), skipped when ReverseKey.Protocol == 0
+// (no companion installed); the DNAT companion key uses the write-side host-
+// order encoding (#2406) and only for dynamic (non-static) SNAT sessions.
+// Returns true once the forward chunk has reached clearFilteredBatch.
+func (b *clearBatchV4) collect(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+	b.fwd = append(b.fwd, key)
+	if val.ReverseKey.Protocol != 0 {
+		b.rev = append(b.rev, val.ReverseKey)
+	}
+	if val.Flags&dataplane.SessFlagSNAT != 0 &&
+		val.Flags&dataplane.SessFlagStaticNAT == 0 {
+		b.dnat = append(b.dnat, dataplane.DNATKeyForSessionV4(key, val))
+	}
+	return len(b.fwd) >= clearFilteredBatch
+}
+
+// deleteAll deletes the collected forward keys (counting successes), reverse
+// companions, and DNAT companions, aggregating failures exactly as the
+// pre-#5454 inline path did (a benign ErrKeyNotExist on the computed reverse /
+// DNAT companion of a NAT'd session is not a failure — #2468). Returns the
+// number of forward sessions successfully deleted.
+func (b *clearBatchV4) deleteAll(s *Server, agg *clearErrors) int {
+	deleted := 0
+	for _, key := range b.fwd {
+		if err := s.dp.DeleteSession(key); err != nil {
+			agg.add("v4 forward delete", err)
+		} else {
+			deleted++
+		}
+	}
+	for _, key := range b.rev {
+		agg.addExceptNotFound("v4 reverse delete", s.dp.DeleteSession(key))
+	}
+	for _, dk := range b.dnat {
+		agg.addExceptNotFound("v4 DNAT companion delete", s.dp.DeleteDNATEntry(dk))
+	}
+	return deleted
+}
+
+// clearFilteredSessionsV4 deletes every v4 session matching filter, plus each
+// matched session's reverse and DNAT companion, while holding at most
+// O(clearFilteredBatch) keys in the handler goroutine (#5454). It returns the
+// number of forward sessions deleted and records sub-operation failures on agg.
+//
+// Iterate-delete safety: the session table is a cilium/ebpf HASH map. Deleting
+// the just-returned key from inside a live Map.Iterate() is UNSAFE — the next
+// BPF_MAP_GET_NEXT_KEY on the now-absent key restarts iteration from the first
+// bucket (kernel htab_map_get_next_key), so the iterator can repeat keys, skip
+// keys, or abort with ErrIterationAborted (see cilium/ebpf MapIterator.Next).
+// We therefore never delete during a live iterate: we collect a bounded chunk
+// of matching keys and delete it only AFTER the iterate call returns.
+//
+// To keep the whole clear a single O(N) forward pass — rather than the O(N^2)
+// a per-chunk fresh re-scan would cost when a filter matches a large fraction
+// of a multi-million-entry table, which would trade the memory DoS for a CPU-
+// stall DoS able to starve the HA watchdog (#4719) — we resume via
+// IterateSessionsFrom from a LIVE anchor: the last key of the previous chunk is
+// deliberately left undeleted so the cursor anchored on it stays valid, and it
+// is deleted one round later once the cursor has advanced past it. A dataplane
+// without cursor iteration (test/edge only — production's LegacyDataPlaneAdapter
+// always implements it, compile-asserted in pkg/dataplane/userspace) falls back
+// to a bounded fresh-rescan.
+func (s *Server) clearFilteredSessionsV4(ctx context.Context, filter *sessionFilter, agg *clearErrors) int {
+	iterDP, ok := s.dp.(sessionCursorIterator)
+	if !ok {
+		return s.clearFilteredSessionsV4Rescan(ctx, filter, agg)
+	}
+	deleted := 0
+	var a, b clearBatchV4
+	cur, prev := &a, &b
+	prevValid := false // prev holds the previous chunk, deferred for delete
+	var cursor *dataplane.SessionKey
+	for {
+		if ctx.Err() != nil {
+			if prevValid {
+				deleted += prev.deleteAll(s, agg)
+			}
+			agg.add("v4 clear canceled", ctx.Err())
+			return deleted
+		}
+		cur.reset()
+		examined := 0
+		canceled := false
+		iterErr := iterDP.IterateSessionsFrom(cursor, func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+			examined++
+			if examined&0x3ff == 0 && ctx.Err() != nil {
+				canceled = true
+				return false // long non-matching run: stop promptly on cancel
+			}
+			if !filter.matchV4(key, val) {
+				return true
+			}
+			return !cur.collect(key, val) // stop once the chunk is full
+		})
+		agg.add("v4 iterate", iterErr)
+		if clearFilteredBatchObserver != nil {
+			clearFilteredBatchObserver(len(cur.fwd))
+		}
+		// The previous chunk's anchor stayed live through this iterate (we
+		// resumed from it), so it is safe to delete now that the call returned.
+		if prevValid {
+			deleted += prev.deleteAll(s, agg)
+			prevValid = false
+		}
+		full := len(cur.fwd) >= clearFilteredBatch && iterErr == nil && !canceled
+		if !full {
+			deleted += cur.deleteAll(s, agg)
+			if canceled {
+				agg.add("v4 clear canceled", ctx.Err())
+			}
+			return deleted
+		}
+		// Carry this chunk (including its last key, the anchor) to the next
+		// round; resume from the anchor, left undeleted so the cursor stays
+		// valid. Ping-pong the two buffers so peak memory is O(chunk).
+		anchor := cur.fwd[len(cur.fwd)-1]
+		cursor = &anchor
+		cur, prev = prev, cur
+		prevValid = true
+	}
+}
+
+// clearFilteredSessionsV4Rescan is the bounded fallback for a dataplane that
+// does not implement cursor iteration (test/edge only). It collects up to
+// clearFilteredBatch matching keys via a fresh full iterate (stopping before
+// any delete, so no delete-during-iterate), deletes that chunk, then re-scans:
+// because every collected key was deleted, a fresh scan returns the next chunk,
+// so the loop converges while holding only O(chunk) keys.
+func (s *Server) clearFilteredSessionsV4Rescan(ctx context.Context, filter *sessionFilter, agg *clearErrors) int {
+	deleted := 0
+	var b clearBatchV4
+	for {
+		if ctx.Err() != nil {
+			agg.add("v4 clear canceled", ctx.Err())
+			return deleted
+		}
+		b.reset()
+		iterErr := s.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+			if !filter.matchV4(key, val) {
+				return true
+			}
+			return !b.collect(key, val)
+		})
+		agg.add("v4 iterate", iterErr)
+		if clearFilteredBatchObserver != nil {
+			clearFilteredBatchObserver(len(b.fwd))
+		}
+		if len(b.fwd) == 0 {
+			return deleted
+		}
+		deleted += b.deleteAll(s, agg)
+		// A short chunk (or an iterate error) means the scan reached the end.
+		if len(b.fwd) < clearFilteredBatch || iterErr != nil {
+			return deleted
+		}
+	}
+}
+
+// clearBatchV6 is the IPv6 analogue of clearBatchV4.
+type clearBatchV6 struct {
+	fwd  []dataplane.SessionKeyV6
+	rev  []dataplane.SessionKeyV6
+	dnat []dataplane.DNATKeyV6
+}
+
+func (b *clearBatchV6) reset() {
+	b.fwd = b.fwd[:0]
+	b.rev = b.rev[:0]
+	b.dnat = b.dnat[:0]
+}
+
+func (b *clearBatchV6) collect(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+	b.fwd = append(b.fwd, key)
+	if val.ReverseKey.Protocol != 0 {
+		b.rev = append(b.rev, val.ReverseKey)
+	}
+	if val.Flags&dataplane.SessFlagSNAT != 0 &&
+		val.Flags&dataplane.SessFlagStaticNAT == 0 {
+		b.dnat = append(b.dnat, dataplane.DNATKeyForSessionV6(key, val))
+	}
+	return len(b.fwd) >= clearFilteredBatch
+}
+
+func (b *clearBatchV6) deleteAll(s *Server, agg *clearErrors) int {
+	deleted := 0
+	for _, key := range b.fwd {
+		if err := s.dp.DeleteSessionV6(key); err != nil {
+			agg.add("v6 forward delete", err)
+		} else {
+			deleted++
+		}
+	}
+	for _, key := range b.rev {
+		agg.addExceptNotFound("v6 reverse delete", s.dp.DeleteSessionV6(key))
+	}
+	for _, dk := range b.dnat {
+		agg.addExceptNotFound("v6 DNAT companion delete", s.dp.DeleteDNATEntryV6(dk))
+	}
+	return deleted
+}
+
+// clearFilteredSessionsV6 is the IPv6 analogue of clearFilteredSessionsV4; see
+// that function for the iterate-delete-safety and bounded-cursor rationale.
+func (s *Server) clearFilteredSessionsV6(ctx context.Context, filter *sessionFilter, agg *clearErrors) int {
+	iterDP, ok := s.dp.(sessionCursorIterator)
+	if !ok {
+		return s.clearFilteredSessionsV6Rescan(ctx, filter, agg)
+	}
+	deleted := 0
+	var a, b clearBatchV6
+	cur, prev := &a, &b
+	prevValid := false
+	var cursor *dataplane.SessionKeyV6
+	for {
+		if ctx.Err() != nil {
+			if prevValid {
+				deleted += prev.deleteAll(s, agg)
+			}
+			agg.add("v6 clear canceled", ctx.Err())
+			return deleted
+		}
+		cur.reset()
+		examined := 0
+		canceled := false
+		iterErr := iterDP.IterateSessionsV6From(cursor, func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+			examined++
+			if examined&0x3ff == 0 && ctx.Err() != nil {
+				canceled = true
+				return false
+			}
+			if !filter.matchV6(key, val) {
+				return true
+			}
+			return !cur.collect(key, val)
+		})
+		agg.add("v6 iterate", iterErr)
+		if clearFilteredBatchObserver != nil {
+			clearFilteredBatchObserver(len(cur.fwd))
+		}
+		if prevValid {
+			deleted += prev.deleteAll(s, agg)
+			prevValid = false
+		}
+		full := len(cur.fwd) >= clearFilteredBatch && iterErr == nil && !canceled
+		if !full {
+			deleted += cur.deleteAll(s, agg)
+			if canceled {
+				agg.add("v6 clear canceled", ctx.Err())
+			}
+			return deleted
+		}
+		anchor := cur.fwd[len(cur.fwd)-1]
+		cursor = &anchor
+		cur, prev = prev, cur
+		prevValid = true
+	}
+}
+
+// clearFilteredSessionsV6Rescan is the bounded fallback analogue of
+// clearFilteredSessionsV4Rescan.
+func (s *Server) clearFilteredSessionsV6Rescan(ctx context.Context, filter *sessionFilter, agg *clearErrors) int {
+	deleted := 0
+	var b clearBatchV6
+	for {
+		if ctx.Err() != nil {
+			agg.add("v6 clear canceled", ctx.Err())
+			return deleted
+		}
+		b.reset()
+		iterErr := s.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+			if !filter.matchV6(key, val) {
+				return true
+			}
+			return !b.collect(key, val)
+		})
+		agg.add("v6 iterate", iterErr)
+		if clearFilteredBatchObserver != nil {
+			clearFilteredBatchObserver(len(b.fwd))
+		}
+		if len(b.fwd) == 0 {
+			return deleted
+		}
+		deleted += b.deleteAll(s, agg)
+		if len(b.fwd) < clearFilteredBatch || iterErr != nil {
+			return deleted
+		}
+	}
 }
 
 // clearPeerSessions forwards a ClearSessions request to the cluster peer.

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -1112,11 +1112,14 @@ func (b *clearBatchV4) collect(key dataplane.SessionKey, val dataplane.SessionVa
 func (b *clearBatchV4) deleteAll(s *Server, agg *clearErrors) int {
 	deleted := 0
 	for _, key := range b.fwd {
-		if err := s.dp.DeleteSession(key); err != nil {
-			agg.add("v4 forward delete", err)
-		} else {
+		err := s.dp.DeleteSession(key)
+		if err == nil {
 			deleted++
+			continue
 		}
+		// A forward key already gone is benign here (GC race / anchor-restart
+		// re-collect — see addExceptNotFound): not our delete, not a failure.
+		agg.addExceptNotFound("v4 forward delete", err)
 	}
 	for _, key := range b.rev {
 		agg.addExceptNotFound("v4 reverse delete", s.dp.DeleteSession(key))
@@ -1274,11 +1277,13 @@ func (b *clearBatchV6) collect(key dataplane.SessionKeyV6, val dataplane.Session
 func (b *clearBatchV6) deleteAll(s *Server, agg *clearErrors) int {
 	deleted := 0
 	for _, key := range b.fwd {
-		if err := s.dp.DeleteSessionV6(key); err != nil {
-			agg.add("v6 forward delete", err)
-		} else {
+		err := s.dp.DeleteSessionV6(key)
+		if err == nil {
 			deleted++
+			continue
 		}
+		// Already-gone forward key is benign here (see clearBatchV4.deleteAll).
+		agg.addExceptNotFound("v6 forward delete", err)
 	}
 	for _, key := range b.rev {
 		agg.addExceptNotFound("v6 reverse delete", s.dp.DeleteSessionV6(key))
@@ -1424,10 +1429,22 @@ func (s *Server) peerNodeIDForMsg() int {
 // deletes, and the HA peer-clear RPC each report independently so an
 // operator sees the FULL failure picture instead of a bare success
 // (#2468). nil errors (the common case) are ignored.
+//
+// The failure-STRING buffer is bounded to clearErrorsPartsCap entries with a
+// trailing "…and N more" summary (#5531 review): a filtered clear over a
+// multi-million-entry table could, in a degenerate cause (e.g. a GC race that
+// re-collects and re-deletes keys), otherwise accumulate O(matches) failure
+// strings — a residual unbounded-memory path this fix exists to close. count
+// stays exact (a cheap int) so Failures is still honest; only the string slice
+// is capped.
 type clearErrors struct {
-	count int
-	parts []string
+	count    int
+	parts    []string
+	overflow int // failures beyond clearErrorsPartsCap, summarized as a count
 }
+
+// clearErrorsPartsCap bounds the number of distinct failure strings retained.
+const clearErrorsPartsCap = 64
 
 // add records a failed sub-operation. nil errors are no-ops.
 func (e *clearErrors) add(op string, err error) {
@@ -1435,7 +1452,11 @@ func (e *clearErrors) add(op string, err error) {
 		return
 	}
 	e.count++
-	e.parts = append(e.parts, fmt.Sprintf("%s: %v", op, err))
+	if len(e.parts) < clearErrorsPartsCap {
+		e.parts = append(e.parts, fmt.Sprintf("%s: %v", op, err))
+	} else {
+		e.overflow++
+	}
 }
 
 // addExceptNotFound is add() for delete operations whose target key is
@@ -1447,9 +1468,12 @@ func (e *clearErrors) add(op string, err error) {
 // a benign idempotent not-found, NOT a clear failure — counting it would
 // make a fully-successful NAT'd-session clear spuriously report
 // Failures>0 (#2468). Any OTHER delete error (EIO/EINVAL/...) is a real
-// failure and is aggregated. The forward delete uses add() unchanged: a
-// forward key came from iteration, so a not-found there is a genuine
-// anomaly worth reporting.
+// failure and is aggregated. The bounded filtered clear (#5454/#5531) routes
+// its FORWARD delete through this path too: an enumerated forward key can be
+// legitimately gone by delete time — the GC reaped it, or a restart-from-
+// bucket-0 after a GC-deleted anchor re-collected a key a prior chunk already
+// deleted — and treating that as a failure would both inflate Failures and,
+// at O(matches) re-deletes, regrow the failure-string buffer this fix bounds.
 func (e *clearErrors) addExceptNotFound(op string, err error) {
 	if err == nil || dataplane.IsKeyNotFound(err) {
 		return
@@ -1457,9 +1481,14 @@ func (e *clearErrors) addExceptNotFound(op string, err error) {
 	e.add(op, err)
 }
 
-// summary returns a single-line description of all accumulated failures.
+// summary returns a single-line description of all accumulated failures,
+// bounded to clearErrorsPartsCap distinct entries plus a trailing overflow
+// count so the string can never grow O(matches).
 func (e *clearErrors) summary() string {
-	return strings.Join(e.parts, "; ")
+	if e.overflow == 0 {
+		return strings.Join(e.parts, "; ")
+	}
+	return fmt.Sprintf("%s; …and %d more", strings.Join(e.parts, "; "), e.overflow)
 }
 
 // apply records the accumulated failure count and summary on the


### PR DESCRIPTION
## Problem (#5454, perf / memory-DoS, fabric-reachable)

The filtered `ClearSessions` gRPC path (`pkg/grpcapi/server_sessions.go`) materialized **every** matching session key into unbounded slices — `v4Keys`, `v4RevKeys`, `snatDNATKeys` and the v6 equivalents — **before** the delete loop ran. That is O(N) handler-goroutine allocation where N is up to the full session table (multi-million entries).

`ClearSessions` is in `fabricAllowedUnaryMethods`, so a PSK-holding fabric peer can trigger a broad filtered clear that retains hundreds of MB → control-plane GC pause / OOM / DoS of the primary. The legacy clear-**ALL** path is unaffected — it already uses the bounded atomic `ClearAllSessions`; only the **filtered** path had this unbounded materialization.

**Invariant enforced:** the filtered clear's handler memory is now O(batch), not O(matches).

## Approach chosen + iterate-delete-safety finding

The session table is a **cilium/ebpf HASH map**. Deleting the just-returned key from inside a live `Map.Iterate()` is **UNSAFE** — the next `BPF_MAP_GET_NEXT_KEY` on the now-absent key restarts iteration from the first bucket (kernel `htab_map_get_next_key`), so the iterator can repeat keys, skip keys, or abort with `ErrIterationAborted` (confirmed in `cilium/ebpf` `MapIterator.Next`). **Delete-as-matched is therefore not an option** — the task's "unsafe" branch applies.

So the clear now processes **fixed-size chunks** bounded by `clearFilteredBatch` (default 1024): collect up to K matching forward keys (+ reverse + DNAT companions), delete that chunk, continue. To keep the whole clear a single **O(N) forward pass** — rather than the O(N²) a per-chunk fresh re-scan would cost when a filter matches a large fraction of the table, which would trade the memory DoS for a **CPU-stall DoS able to starve the HA watchdog (#4719)** — it resumes via `IterateSessionsFrom` from a **LIVE anchor**: the last key of each chunk is deliberately left undeleted so its cursor stays valid, and is deleted one round later once the cursor has advanced past it (ping-pong buffers keep peak memory at O(chunk)). A `ctx.Err()` check between and within chunks stops a cancelled RPC promptly.

Correctness is unchanged: every matching forward key, its reverse companion at the translated tuple (`val.ReverseKey`, #2733), and its DNAT companion (host-order key, #2406) are still deleted; the aggregated failure/count semantics (#2468) are preserved; v4 and v6 stay consistent; the clear-ALL bulk-atomic path is untouched. A dataplane without cursor iteration (test/edge only — production's `LegacyDataPlaneAdapter` always implements it, compile-asserted) falls back to a bounded fresh-rescan.

## Tests

`clear_sessions_bounded_5454_test.go`: a cursor-capable in-memory dataplane drives a 50-session v4+v6 filtered clear with the batch shrunk to 8 and asserts (a) every matching session + reverse + DNAT companion deleted (table drained, counts accurate), (b) no collected chunk exceeds the batch bound **and** the clear is actually chunked (≥2 chunks — the collect-all regression signal), and (c) a mid-clear context cancel stops promptly and surfaces the cancellation. The two existing ClearSessions fakes gained faithful sorted-cursor `IterateSessionsFrom` methods (the production path now uses the cursor iterator).

### RED-on-revert evidence
Reverting `clearFilteredSessionsV4` to the collect-all-then-delete path:
```
--- FAIL: TestClearSessionsFilteredBoundedWorkingSet (0.00s)
    clear_sessions_bounded_5454_test.go:275: collected chunk length 50 exceeded batch bound 8 — working set not bounded (#5454)
```
Restored → green.

### Validation
- `go build ./...` — clean
- `go test ./pkg/grpcapi/...` — ok (incl. `-race` on ClearSessions)
- `go vet ./pkg/grpcapi/` — clean
- `gofmt` applied

Distinct from #5303 / #5305.

Closes #5454

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJoqQo49zEDgiGJGzvgRy1