### PR TITLE
routing/bond: verify adopted bond member set, complete partial enslavement (#5261)

### DIFF
--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -120,23 +120,36 @@ set) against the tracked set instead of clearing all and rebuilding:
   policy-only commit no longer flaps the LAG (`LinkDel`→`LinkAdd`→
   re-enslave→LACP re-converge, traffic loss on the bond);
 - **create** a newly-desired bond (also adopts a kernel bond that
-  outlived in-memory tracking, e.g. across a daemon restart). The adopt
-  path enumerates the bond's **actual** enslaved member set (`LinkList`
-  by `MasterIndex`) and compares it to the desired set: a fully-realized
-  bond is tracked under the full desired sig and only brought up (no
-  flap, #5259); a bond realized with a **partial** member set (a member
-  absent at realization time — the #4823 soft error) has the missing
-  members enslaved in place if they have since appeared, and is tracked
-  under its **realized** sig — so a partial adopt is never recorded as
-  fully-realized, and the next reconcile completes (or recreates) it
-  instead of KEEP-ing a partial bond forever (#5261);
-- **recreate** (delete+create) a bond whose signature changed — a genuine
-  member/mode/MTU change; the mode and enslavement cannot be changed in
-  place while members are attached;
+  outlived in-memory tracking, e.g. across a daemon restart). Both the
+  create and adopt paths enumerate the bond's **actual** enslaved member
+  set (`LinkList` by `MasterIndex`) and track the **realized** signature,
+  never the full desired one: a fully-realized bond is tracked under the
+  full desired sig and only brought up (no flap, #5259); a bond realized
+  with a **partial** member set (a member absent at realization time — the
+  #4823 soft error) is tracked under its realized (partial) sig — so a
+  partial realization is never recorded as satisfied and does not become
+  KEEP-forever (#5261). This is symmetric: a fresh-create with an absent
+  member tracks the partial sig too, so it converges when the member
+  appears rather than staying stuck (the fresh-create analogue of #5261);
+- **complete in place** a still-desired bond whose realized member set is
+  a strict **subset** of the desired set (same mode/MTU — just missing
+  members, incl. a config member-**add**): the missing members are
+  enslaved via the adopt branch with **no `LinkDel`/`LinkAdd`**, so a live
+  (degraded) fabric/RETH bond is never flapped to grow it. Enslaving a
+  slave into an existing bond is non-disruptive to the members already
+  forwarding. This is the self-heal path for a partial realization once
+  the absent member appears (#5261) — it replaces the earlier
+  delete+recreate route, which flapped the bond on every commit;
+- **recreate** (delete+create) a bond whose **identity** changed — a
+  genuine change that is *not* a pure member addition (member removed, or
+  mode/MTU changed); the mode and existing enslavement cannot be changed
+  in place while members are attached;
 - **delete** a bond whose fabric interface was removed.
 
 A no-op commit (identical desired bond set) issues zero `LinkDel`, zero
-`LinkAdd`, and zero `LinkSetMaster`. This was the non-idempotent
+`LinkAdd`, and zero `LinkSetMaster`, and a **partial** bond issues zero
+`LinkDel`/`LinkAdd` on every reconcile (only an in-place `LinkSetMaster`
+attempt of the still-missing members). This was the non-idempotent
 anti-pattern #2546 fixed for XFRM but not bonds. `Clear()` (shutdown /
 full teardown) still deletes every tracked bond.
 

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -120,7 +120,16 @@ set) against the tracked set instead of clearing all and rebuilding:
   policy-only commit no longer flaps the LAG (`LinkDel`→`LinkAdd`→
   re-enslave→LACP re-converge, traffic loss on the bond);
 - **create** a newly-desired bond (also adopts a kernel bond that
-  outlived in-memory tracking, e.g. across a daemon restart);
+  outlived in-memory tracking, e.g. across a daemon restart). The adopt
+  path enumerates the bond's **actual** enslaved member set (`LinkList`
+  by `MasterIndex`) and compares it to the desired set: a fully-realized
+  bond is tracked under the full desired sig and only brought up (no
+  flap, #5259); a bond realized with a **partial** member set (a member
+  absent at realization time — the #4823 soft error) has the missing
+  members enslaved in place if they have since appeared, and is tracked
+  under its **realized** sig — so a partial adopt is never recorded as
+  fully-realized, and the next reconcile completes (or recreates) it
+  instead of KEEP-ing a partial bond forever (#5261);
 - **recreate** (delete+create) a bond whose signature changed — a genuine
   member/mode/MTU change; the mode and enslavement cannot be changed in
   place while members are attached;

--- a/pkg/routing/bond.go
+++ b/pkg/routing/bond.go
@@ -81,18 +81,23 @@ func bondSigOf(ifc *config.InterfaceConfig) bondSig {
 //     LinkAdd→re-enslave→LACP re-converge). This was the non-idempotent
 //     anti-pattern #2546 fixed for XFRM but not bonds.
 //   - CREATE a bond that is newly desired (also adopts a kernel bond that
-//     outlived in-memory tracking, e.g. across a daemon restart). The adopt
-//     path verifies the bond's ACTUAL enslaved member set: a bond realized
-//     with a PARTIAL member set (a member absent at realization time — #4823)
-//     is completed in place if the member has since appeared and is tracked
-//     under its realized (possibly still-partial) sig, so a follow-up
-//     reconcile finishes the enslavement instead of KEEP-ing a partial bond
-//     forever (#5261). A fully-realized adopt tracks the full desired sig and
-//     never flaps (#5259).
-//   - RECREATE (delete+create) a bond whose signature changed — a genuine
-//     config change (member added/removed, mode or MTU changed). The bond
-//     mode and enslavement cannot be changed in place while members are
-//     attached, so a signature change is a delete+rebuild.
+//     outlived in-memory tracking, e.g. across a daemon restart). Both the
+//     create and adopt paths verify the bond's ACTUAL enslaved member set and
+//     track the REALIZED signature, not the full desired one: a member absent
+//     at realization time (a #4823 soft error) yields a PARTIAL sig, never a
+//     full one recorded as satisfied (#5261). A fully-realized adopt tracks
+//     the full desired sig and never flaps (#5259).
+//   - COMPLETE a still-desired bond whose realized member set is a strict
+//     SUBSET of the desired set (same mode/MTU, just missing members) IN
+//     PLACE — the missing members are enslaved via the adopt branch with no
+//     LinkDel/LinkAdd, so a live (degraded) fabric/RETH bond is never flapped
+//     on an unrelated commit. This is the self-heal path for a partial
+//     realization once the absent member appears (#5261).
+//   - RECREATE (delete+create) a bond whose identity changed — a genuine
+//     config change that is NOT a pure member addition (member removed, mode
+//     or MTU changed). The bond mode and existing enslavement cannot be
+//     changed in place while members are attached, so such a change is a
+//     delete+rebuild.
 //   - DELETE a bond that is no longer desired (its fabric interface was
 //     removed).
 //
@@ -135,43 +140,66 @@ func (b *bondManager) Apply(interfaces []*config.InterfaceConfig) error {
 
 	var errs []error
 
-	// Delete pass: remove bonds that are no longer desired OR whose
-	// signature changed. A KEPT bond (still desired, identical signature)
-	// is left untouched — no destructive link op — so an unrelated commit
-	// does not flap the LAG (#5119). #4901: a failed LinkDel retains
+	// Delete pass: remove bonds that are no longer desired OR whose identity
+	// changed. A KEPT bond is left untouched — no destructive link op — so an
+	// unrelated commit does not flap the LAG (#5119). A bond is KEPT when it
+	// is still desired AND either:
+	//   - its signature is identical (unchanged), or
+	//   - it needs only a PARTIAL COMPLETION: same mode/MTU, and the tracked
+	//     (realized) member set is a strict subset of the desired set. Such a
+	//     bond is completed in place in the create pass (enslave the missing
+	//     members, no LinkDel/LinkAdd) instead of being delete+recreated —
+	//     never flap a live (degraded) fabric/RETH bond to add a member
+	//     (#5261).
+	// Everything else (no longer desired, or a genuine identity change: member
+	// removed, mode/MTU changed) is deleted. #4901: a failed LinkDel retains
 	// tracking so the next reconcile retries; a changed bond whose delete
-	// failed keeps its OLD signature, so it is NOT recreated this cycle
-	// (its stale kernel device is still present) and the next reconcile
-	// retries the delete first.
+	// failed keeps its OLD signature, so it is NOT recreated this cycle (its
+	// stale kernel device is still present) and the next reconcile retries the
+	// delete first.
 	for name, trackedSig := range b.bonds {
-		if wantSig, want := desired[name]; want && wantSig == trackedSig {
-			continue // unchanged — keep
+		if wantSig, want := desired[name]; want &&
+			(wantSig == trackedSig || isPartialCompletion(trackedSig, wantSig)) {
+			continue // keep — unchanged or an in-place partial completion
 		}
 		if err := b.deleteLocked(name); err != nil {
 			errs = append(errs, err)
 		}
 	}
 
-	// Create/reconcile pass: build bonds that are newly desired or were
-	// just deleted because their signature changed.
+	// Create/reconcile pass: build bonds that are newly desired or were just
+	// deleted because their identity changed, and complete partial bonds in
+	// place.
 	for _, name := range order {
 		sig := desired[name]
 		if trackedSig, kept := b.bonds[name]; kept {
-			// Survived the delete pass. Either:
-			//   - unchanged (signature matched) — bring it up idempotently
-			//     (a no-op on an already-up bond, matching the XFRM keep
-			//     path); zero LinkDel/LinkAdd/LinkSetMaster, so no flap.
-			//   - OR a changed bond whose LinkDel failed above (OLD sig
-			//     retained). Skip recreation this cycle to avoid an EEXIST
-			//     LinkAdd; the next reconcile retries the delete first.
+			// Survived the delete pass.
 			if trackedSig == sig {
+				// Unchanged — bring it up idempotently (a no-op on an
+				// already-up bond, matching the XFRM keep path); zero
+				// LinkDel/LinkAdd/LinkSetMaster, so no flap.
 				if link, err := b.ops.LinkByName(name); err == nil {
 					if err := b.ops.LinkSetUp(link); err != nil {
 						slog.Warn("failed to bring up existing bond", "name", name, "err", err)
 						errs = append(errs, fmt.Errorf("bond %s: bring up existing: %w", name, err))
 					}
 				}
+				continue
 			}
+			if isPartialCompletion(trackedSig, sig) {
+				// Same bond, missing members. Complete the enslavement IN
+				// PLACE via the adopt branch of createLocked (the kernel bond
+				// still exists — it was NOT deleted above), which enslaves the
+				// still-missing members and re-tracks the realized member set.
+				// No LinkDel/LinkAdd — the degraded bond is not flapped (#5261).
+				if err := b.createLocked(name, ifcByName[name], sig); err != nil {
+					errs = append(errs, err)
+				}
+				continue
+			}
+			// A genuine identity change whose LinkDel failed above (OLD sig
+			// retained). Skip recreation this cycle to avoid an EEXIST LinkAdd;
+			// the next reconcile retries the delete first.
 			continue
 		}
 		if err := b.createLocked(name, ifcByName[name], sig); err != nil {
@@ -214,9 +242,12 @@ func (b *bondManager) createLocked(name string, ifc *config.InterfaceConfig, sig
 	//     stay a #4823 soft error. Then track a sig derived from the ACTUAL
 	//     realized member set. If completion filled the set the tracked sig
 	//     equals the desired sig; otherwise it is a PARTIAL sig != desired, so
-	//     the NEXT reconcile detects the mismatch and recreates/completes the
-	//     bond instead of KEEP-ing a partial bond forever.
-	// No LinkDel/LinkAdd is issued on the adopt path itself.
+	//     the NEXT reconcile re-enters this branch (Apply routes a pure
+	//     partial through the KEEP path, never the delete pass) and completes
+	//     the missing enslavement IN PLACE once the member appears, instead of
+	//     KEEP-ing a partial bond forever.
+	// No LinkDel/LinkAdd is issued on the adopt path — the same code path
+	// serves both a restart adoption and an in-place partial completion.
 	if existing, err := b.ops.LinkByName(name); err == nil {
 		var errs []error
 		trackSig := sig
@@ -259,12 +290,21 @@ func (b *bondManager) createLocked(name string, ifc *config.InterfaceConfig, sig
 		return fmt.Errorf("bond %s: find after create: %w", name, err)
 	}
 
-	_, errs := b.enslaveMembers(name, bondLink, ifc.FabricMembers, nil)
+	enslaved, errs := b.enslaveMembers(name, bondLink, ifc.FabricMembers, nil)
 	if err := b.ops.LinkSetUp(bondLink); err != nil {
 		slog.Warn("failed to bring up bond", "name", name, "err", err)
 		errs = append(errs, fmt.Errorf("bond %s: bring up: %w", name, err))
 	}
-	b.bonds[name] = sig
+	// Track the ACTUAL realized member set, not the full desired set. A member
+	// absent at creation (a #4823 soft error) yields a PARTIAL sig, so a later
+	// reconcile completes the enslavement IN PLACE when the member appears
+	// (the Apply partial-completion path) instead of KEEP-ing the bond partial
+	// forever (#5261). Fully enslaved → realized == desired → this equals sig.
+	realized := make(map[string]bool, len(enslaved))
+	for _, m := range enslaved {
+		realized[m] = true
+	}
+	b.bonds[name] = sigWithMembers(sig, realized)
 	slog.Info("bond created", "name", name, "mode", sig.mode, "members", ifc.FabricMembers)
 	return errors.Join(errs...)
 }
@@ -341,6 +381,44 @@ func (b *bondManager) observedMembers(bondLink netlink.Link) (map[string]bool, b
 func membersCoverDesired(ifc *config.InterfaceConfig, observed map[string]bool) bool {
 	for _, m := range ifc.FabricMembers {
 		if !observed[config.LinuxIfName(m)] {
+			return false
+		}
+	}
+	return true
+}
+
+// isPartialCompletion reports whether a tracked bond differs from its desired
+// signature ONLY by missing members — same mode and MTU, and the tracked
+// (realized) member set is a strict subset of the desired set. Such a bond is
+// completed IN PLACE (the missing members are enslaved via createLocked's
+// adopt branch) rather than delete+recreated, so a live (degraded) fabric/RETH
+// bond is never flapped on an unrelated commit (#5261). A member removal, a
+// mode change, or an MTU change is NOT a partial completion — it changes the
+// bond identity and takes the delete+recreate path.
+func isPartialCompletion(tracked, want bondSig) bool {
+	if tracked.mode != want.mode || tracked.mtu != want.mtu {
+		return false
+	}
+	if tracked.members == want.members {
+		return false
+	}
+	return membersSubset(tracked.members, want.members)
+}
+
+// membersSubset reports whether every member in sub is present in super (both
+// are sorted, comma-joined member strings). An empty sub is a subset of
+// anything (a bond realized with zero members yet is a partial of any desired
+// member set).
+func membersSubset(sub, super string) bool {
+	if sub == "" {
+		return true
+	}
+	set := make(map[string]bool)
+	for _, m := range strings.Split(super, ",") {
+		set[m] = true
+	}
+	for _, m := range strings.Split(sub, ",") {
+		if !set[m] {
 			return false
 		}
 	}

--- a/pkg/routing/bond.go
+++ b/pkg/routing/bond.go
@@ -81,7 +81,14 @@ func bondSigOf(ifc *config.InterfaceConfig) bondSig {
 //     LinkAdd→re-enslave→LACP re-converge). This was the non-idempotent
 //     anti-pattern #2546 fixed for XFRM but not bonds.
 //   - CREATE a bond that is newly desired (also adopts a kernel bond that
-//     outlived in-memory tracking, e.g. across a daemon restart).
+//     outlived in-memory tracking, e.g. across a daemon restart). The adopt
+//     path verifies the bond's ACTUAL enslaved member set: a bond realized
+//     with a PARTIAL member set (a member absent at realization time — #4823)
+//     is completed in place if the member has since appeared and is tracked
+//     under its realized (possibly still-partial) sig, so a follow-up
+//     reconcile finishes the enslavement instead of KEEP-ing a partial bond
+//     forever (#5261). A fully-realized adopt tracks the full desired sig and
+//     never flaps (#5259).
 //   - RECREATE (delete+create) a bond whose signature changed — a genuine
 //     config change (member added/removed, mode or MTU changed). The bond
 //     mode and enslavement cannot be changed in place while members are
@@ -178,23 +185,57 @@ func (b *bondManager) Apply(interfaces []*config.InterfaceConfig) error {
 // already-present kernel device of that name without tearing it down (one
 // that outlived in-memory tracking across a daemon restart, or whose prior
 // LinkDel failed), or else creates the bond, enslaves its members, and
-// brings everything up. On success the bond is tracked under sig. Netlink
-// failures are aggregated and returned (#4823) rather than swallowed; a
-// LinkAdd / find-after-create failure leaves the bond UNTRACKED so the
-// next reconcile retries. Caller must hold mu.
+// brings everything up. On success the bond is tracked under the signature
+// of its ACTUAL realized member set (which equals sig once fully enslaved).
+// Netlink failures are aggregated and returned (#4823) rather than
+// swallowed; a LinkAdd / find-after-create failure leaves the bond
+// UNTRACKED so the next reconcile retries. Caller must hold mu.
 func (b *bondManager) createLocked(name string, ifc *config.InterfaceConfig, sig bondSig) error {
-	// Adopt an existing kernel device without a destructive rebuild. Kernel
-	// bond internals (mode/members) are not re-read here — this matches the
-	// pre-#5119 adopt behavior; the common no-op commit path never reaches
-	// createLocked because an unchanged bond is kept in the delete pass.
+	// Adopt an existing kernel device without a destructive rebuild — but
+	// verify the actual enslaved member set before accepting the KEEP.
+	//
+	// The adopt path is the common daemon-restart case: the bond outlived
+	// in-memory tracking and must NOT be flapped (LinkDel→LinkAdd→re-enslave
+	// →LACP re-converge). Tracking the FULL desired sig unconditionally,
+	// however, is wrong when the bond was realized with a PARTIAL member set
+	// (a member absent at realization time is a #4823 soft error — routine
+	// during interface enumeration ordering). If a restart then adopts that
+	// partial bond and records the full desired sig, every future reconcile
+	// sees tracked == desired and KEEPs the partial bond forever, never
+	// completing the missing enslavement (#5261).
+	//
+	// So compare the observed kernel member set to the desired set:
+	//   - COMPLETE (observed covers desired) → track the full desired sig and
+	//     only bring the bond up. Zero enslave/LinkDel/LinkAdd — no flap of a
+	//     good bond (#5259 preserved exactly).
+	//   - PARTIAL → attempt to enslave the still-missing members now (the
+	//     member may have appeared since the bond was first realized — e.g. a
+	//     restart that resolved the enumeration race); members still absent
+	//     stay a #4823 soft error. Then track a sig derived from the ACTUAL
+	//     realized member set. If completion filled the set the tracked sig
+	//     equals the desired sig; otherwise it is a PARTIAL sig != desired, so
+	//     the NEXT reconcile detects the mismatch and recreates/completes the
+	//     bond instead of KEEP-ing a partial bond forever.
+	// No LinkDel/LinkAdd is issued on the adopt path itself.
 	if existing, err := b.ops.LinkByName(name); err == nil {
-		b.bonds[name] = sig
-		slog.Debug("bond already exists", "name", name)
+		var errs []error
+		trackSig := sig
+		observed, ok := b.observedMembers(existing)
+		if ok && !membersCoverDesired(ifc, observed) {
+			enslaved, memberErrs := b.enslaveMembers(name, existing, ifc.FabricMembers, observed)
+			errs = append(errs, memberErrs...)
+			for _, m := range enslaved {
+				observed[m] = true
+			}
+			trackSig = sigWithMembers(sig, observed)
+		}
+		b.bonds[name] = trackSig
+		slog.Debug("bond already exists", "name", name, "complete", trackSig == sig)
 		if err := b.ops.LinkSetUp(existing); err != nil {
 			slog.Warn("failed to bring up existing bond", "name", name, "err", err)
-			return fmt.Errorf("bond %s: bring up existing: %w", name, err)
+			errs = append(errs, fmt.Errorf("bond %s: bring up existing: %w", name, err))
 		}
-		return nil
+		return errors.Join(errs...)
 	}
 
 	bond := netlink.NewLinkBond(netlink.LinkAttrs{Name: name})
@@ -218,9 +259,36 @@ func (b *bondManager) createLocked(name string, ifc *config.InterfaceConfig, sig
 		return fmt.Errorf("bond %s: find after create: %w", name, err)
 	}
 
-	var errs []error
-	for _, member := range ifc.FabricMembers {
+	_, errs := b.enslaveMembers(name, bondLink, ifc.FabricMembers, nil)
+	if err := b.ops.LinkSetUp(bondLink); err != nil {
+		slog.Warn("failed to bring up bond", "name", name, "err", err)
+		errs = append(errs, fmt.Errorf("bond %s: bring up: %w", name, err))
+	}
+	b.bonds[name] = sig
+	slog.Info("bond created", "name", name, "mode", sig.mode, "members", ifc.FabricMembers)
+	return errors.Join(errs...)
+}
+
+// enslaveMembers enslaves the given fabric members (Junos names) into
+// bondLink, skipping any whose resolved Linux name is already present in
+// `already` (an already-enslaved member must NOT be flapped). It returns the
+// Linux names it SUCCESSFULLY enslaved and the accumulated hard errors.
+//
+// A member not yet visible in the kernel (LinkByName miss) is a #4823 soft
+// error: logged and skipped, the bond is still realized with the members
+// that ARE present, and the caller tracks a partial sig so a later reconcile
+// completes it. A LinkSetMaster failure on a member that IS present is a hard
+// error, accumulated and returned. Caller must hold mu.
+func (b *bondManager) enslaveMembers(name string, bondLink netlink.Link, members []string, already map[string]bool) ([]string, []error) {
+	var (
+		enslaved []string
+		errs     []error
+	)
+	for _, member := range members {
 		linuxName := config.LinuxIfName(member)
+		if already[linuxName] {
+			continue // already enslaved — leave it in place, do not flap
+		}
 		memberLink, err := b.ops.LinkByName(linuxName)
 		if err != nil {
 			slog.Warn("bond member not found",
@@ -236,16 +304,62 @@ func (b *bondManager) createLocked(name string, ifc *config.InterfaceConfig, sig
 			continue
 		}
 		b.ops.LinkSetUp(memberLink)
+		enslaved = append(enslaved, linuxName)
 		slog.Info("bond member added", "bond", name, "member", member)
 	}
+	return enslaved, errs
+}
 
-	if err := b.ops.LinkSetUp(bondLink); err != nil {
-		slog.Warn("failed to bring up bond", "name", name, "err", err)
-		errs = append(errs, fmt.Errorf("bond %s: bring up: %w", name, err))
+// observedMembers returns the set of Linux interface names currently
+// enslaved to bondLink (their MasterIndex equals the bond's index). The
+// second return is false when the member set cannot be determined — a
+// LinkList failure, or a bond whose index is 0 (a real kernel bond never has
+// index 0; the fallback keeps the adopt path bit-identical to the prior
+// track-full-desired behavior rather than misclassifying the bond as
+// partial). Caller must hold mu.
+func (b *bondManager) observedMembers(bondLink netlink.Link) (map[string]bool, bool) {
+	idx := bondLink.Attrs().Index
+	if idx == 0 {
+		return nil, false
 	}
-	b.bonds[name] = sig
-	slog.Info("bond created", "name", name, "mode", sig.mode, "members", ifc.FabricMembers)
-	return errors.Join(errs...)
+	links, err := b.ops.LinkList()
+	if err != nil {
+		slog.Warn("bond adopt: LinkList failed; cannot verify member set", "err", err)
+		return nil, false
+	}
+	members := map[string]bool{}
+	for _, l := range links {
+		if l.Attrs().MasterIndex == idx {
+			members[l.Attrs().Name] = true
+		}
+	}
+	return members, true
+}
+
+// membersCoverDesired reports whether every desired fabric member (resolved
+// to its Linux name) is present in the observed enslaved-member set.
+func membersCoverDesired(ifc *config.InterfaceConfig, observed map[string]bool) bool {
+	for _, m := range ifc.FabricMembers {
+		if !observed[config.LinuxIfName(m)] {
+			return false
+		}
+	}
+	return true
+}
+
+// sigWithMembers returns a copy of base whose member set is the sorted,
+// comma-joined names in realized. When realized equals the desired member
+// set the result equals base, so a completed adopt tracks the full desired
+// sig; a still-partial adopt tracks a sig that differs from desired and thus
+// triggers a follow-up reconcile (#5261).
+func sigWithMembers(base bondSig, realized map[string]bool) bondSig {
+	names := make([]string, 0, len(realized))
+	for n := range realized {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	base.members = strings.Join(names, ",")
+	return base
 }
 
 // Clear removes all previously created bond devices.

--- a/pkg/routing/bond_test.go
+++ b/pkg/routing/bond_test.go
@@ -94,17 +94,45 @@ func (f *fakeBondLinkOps) LinkSetMaster(member, _ netlink.Link) error {
 
 func (f *fakeBondLinkOps) LinkSetNoMaster(netlink.Link) error        { return nil }
 func (f *fakeBondLinkOps) LinkSetMTU(netlink.Link, int) error        { return nil }
-func (f *fakeBondLinkOps) LinkList() ([]netlink.Link, error)         { return nil, nil }
 func (f *fakeBondLinkOps) AddrAdd(netlink.Link, *netlink.Addr) error { return nil }
 func (f *fakeBondLinkOps) AddrDel(netlink.Link, *netlink.Addr) error { return nil }
 func (f *fakeBondLinkOps) AddrList(netlink.Link, int) ([]netlink.Addr, error) {
 	return nil, nil
 }
 
+// LinkList returns every seeded link so bondManager.observedMembers can
+// enumerate a bond's enslaved members by MasterIndex (#5261).
+func (f *fakeBondLinkOps) LinkList() ([]netlink.Link, error) {
+	links := make([]netlink.Link, 0, len(f.links))
+	for _, l := range f.links {
+		links = append(links, l)
+	}
+	return links, nil
+}
+
 // seedMember pre-populates a member link so LinkByName(linuxName) in the
 // enslave loop succeeds and the test reaches LinkSetMaster.
 func (f *fakeBondLinkOps) seedMember(name string) {
 	f.links[name] = &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: name}}
+}
+
+// seedBond pre-populates an already-present kernel bond with a non-zero
+// index so observedMembers can key member enslavement off it (a real bond
+// never has index 0; index 0 makes observedMembers fall back). Models the
+// daemon-restart adopt case where the bond outlived in-memory tracking.
+func (f *fakeBondLinkOps) seedBond(name string, index int) {
+	f.links[name] = &netlink.Bond{
+		LinkAttrs: netlink.LinkAttrs{Name: name, Index: index},
+	}
+}
+
+// seedEnslavedMember pre-populates a member link already enslaved to the
+// bond whose kernel index is masterIndex (MasterIndex set), so
+// observedMembers reports it as part of the realized member set.
+func (f *fakeBondLinkOps) seedEnslavedMember(name string, masterIndex int) {
+	f.links[name] = &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{Name: name, MasterIndex: masterIndex},
+	}
 }
 
 func bondFabricConfig(name string, members ...string) *config.InterfaceConfig {
@@ -347,5 +375,141 @@ func TestBondApplyDeletesRemovedBond(t *testing.T) {
 	}
 	if _, ok := b.bonds["bond0"]; !ok {
 		t.Fatalf("bond0 dropped from tracking despite being unchanged: %+v", b.bonds)
+	}
+}
+
+// TestBondAdoptPartialMemberSetNotTrackedAsComplete is the #5261 RED-on-revert
+// guard. A daemon restart adopts a kernel bond that was realized with a
+// PARTIAL member set (one member was absent at realization time — a #4823 soft
+// error). The adopt path must NOT record the full desired signature (which
+// would make every future reconcile see "unchanged" and KEEP the partial bond
+// forever); it must track the ACTUAL realized member set so a later reconcile
+// completes the enslavement once the missing member appears. Reverting the fix
+// tracks the full desired sig → the partial bond is KEEP'd forever (RED here on
+// both the tracked-sig assertion AND the completion assertion).
+func TestBondAdoptPartialMemberSetNotTrackedAsComplete(t *testing.T) {
+	ops := newFakeBondLinkOps()
+	ops.seedBond("bond0", 10)
+	ops.seedEnslavedMember("ge-0-0-1", 10) // realized member
+	// ge-0-0-2 is absent from the kernel — the partial realization.
+	b := &bondManager{ops: ops}
+
+	cfg := []*config.InterfaceConfig{bondFabricConfig("bond0", "ge-0-0-1", "ge-0-0-2")}
+	full := bondSigOf(cfg[0])
+
+	if err := b.Apply(cfg); err != nil {
+		t.Fatalf("first Apply() (adopt) = %v, want nil", err)
+	}
+	// Adopt must not flap the good member: no LinkDel/LinkAdd, and the absent
+	// member cannot be enslaved yet (soft error), so no LinkSetMaster either.
+	if len(ops.delCalls) != 0 || len(ops.addCalls) != 0 {
+		t.Fatalf("adopt flapped the bond: delCalls=%v addCalls=%v", ops.delCalls, ops.addCalls)
+	}
+	got, ok := b.bonds["bond0"]
+	if !ok {
+		t.Fatalf("bond0 not tracked after adopt: %+v", b.bonds)
+	}
+	if got == full {
+		t.Fatalf("partial adopt tracked the FULL desired sig %+v — a subsequent "+
+			"reconcile will KEEP the partial bond forever (#5261)", got)
+	}
+	if got.members != "ge-0-0-1" {
+		t.Fatalf("adopt tracked members=%q, want %q (only the realized member)",
+			got.members, "ge-0-0-1")
+	}
+
+	// The missing member now appears in the kernel. The next reconcile must
+	// detect the tracked/desired mismatch and complete the enslavement.
+	ops.reset()
+	ops.seedMember("ge-0-0-2")
+	if err := b.Apply(cfg); err != nil {
+		t.Fatalf("second Apply() (member appeared) = %v, want nil", err)
+	}
+	if !contains(ops.masterCalls, "ge-0-0-2") {
+		t.Fatalf("missing member ge-0-0-2 was NOT enslaved on the follow-up "+
+			"reconcile: masterCalls=%v", ops.masterCalls)
+	}
+	if got := b.bonds["bond0"]; got != full {
+		t.Fatalf("after completion b.bonds[bond0]=%+v, want full desired %+v", got, full)
+	}
+}
+
+// TestBondAdoptPartialCompletesImmediatelyWhenMemberPresent covers the common
+// restart case where the previously-absent member has since appeared in the
+// kernel (the enumeration race resolved across the restart). The adopt path
+// must enslave the now-present member in place — without an intervening
+// recreate — and track the full desired sig, and it must NOT re-enslave the
+// member that was already attached (#5259 no-flap for the good member). A
+// subsequent identical reconcile is then a clean KEEP.
+func TestBondAdoptPartialCompletesImmediatelyWhenMemberPresent(t *testing.T) {
+	ops := newFakeBondLinkOps()
+	ops.seedBond("bond0", 10)
+	ops.seedEnslavedMember("ge-0-0-1", 10) // already enslaved
+	ops.seedMember("ge-0-0-2")             // present in kernel but NOT yet enslaved
+	b := &bondManager{ops: ops}
+
+	cfg := []*config.InterfaceConfig{bondFabricConfig("bond0", "ge-0-0-1", "ge-0-0-2")}
+	full := bondSigOf(cfg[0])
+
+	if err := b.Apply(cfg); err != nil {
+		t.Fatalf("Apply() (adopt+complete) = %v, want nil", err)
+	}
+	if len(ops.delCalls) != 0 || len(ops.addCalls) != 0 {
+		t.Fatalf("adopt+complete recreated the bond: delCalls=%v addCalls=%v",
+			ops.delCalls, ops.addCalls)
+	}
+	if !contains(ops.masterCalls, "ge-0-0-2") {
+		t.Fatalf("present member ge-0-0-2 was NOT enslaved at adopt: masterCalls=%v", ops.masterCalls)
+	}
+	if contains(ops.masterCalls, "ge-0-0-1") {
+		t.Fatalf("already-enslaved member ge-0-0-1 was re-enslaved (flap): masterCalls=%v", ops.masterCalls)
+	}
+	if got := b.bonds["bond0"]; got != full {
+		t.Fatalf("after in-place completion b.bonds[bond0]=%+v, want full desired %+v", got, full)
+	}
+
+	// Healed: the next identical reconcile is a pure KEEP (no ops at all).
+	ops.reset()
+	// Reflect the enslavement the fake does not model automatically so the
+	// re-adopt sees a complete member set.
+	ops.seedEnslavedMember("ge-0-0-2", 10)
+	if err := b.Apply(cfg); err != nil {
+		t.Fatalf("third Apply() = %v, want nil", err)
+	}
+	if len(ops.delCalls) != 0 || len(ops.addCalls) != 0 || len(ops.masterCalls) != 0 {
+		t.Fatalf("healed bond flapped on KEEP: delCalls=%v addCalls=%v masterCalls=%v",
+			ops.delCalls, ops.addCalls, ops.masterCalls)
+	}
+}
+
+// TestBondAdoptCompleteMemberSetNoFlap is the #5259 no-flap guarantee for the
+// adopt path: a daemon restart that adopts a FULLY-realized kernel bond (every
+// desired member already enslaved) must track the full desired sig and only
+// bring the bond up — zero LinkDel, zero LinkAdd, zero LinkSetMaster. The
+// partial-member verification must NOT tear down or re-enslave a good bond.
+func TestBondAdoptCompleteMemberSetNoFlap(t *testing.T) {
+	ops := newFakeBondLinkOps()
+	ops.seedBond("bond0", 10)
+	ops.seedEnslavedMember("ge-0-0-1", 10)
+	ops.seedEnslavedMember("ge-0-0-2", 10)
+	b := &bondManager{ops: ops}
+
+	cfg := []*config.InterfaceConfig{bondFabricConfig("bond0", "ge-0-0-1", "ge-0-0-2")}
+	full := bondSigOf(cfg[0])
+
+	if err := b.Apply(cfg); err != nil {
+		t.Fatalf("Apply() (adopt complete) = %v, want nil", err)
+	}
+	if len(ops.delCalls) != 0 {
+		t.Fatalf("fully-realized adopt issued LinkDel(s) %v — flapped a good bond", ops.delCalls)
+	}
+	if len(ops.addCalls) != 0 {
+		t.Fatalf("fully-realized adopt issued LinkAdd(s) %v — rebuilt a good bond", ops.addCalls)
+	}
+	if len(ops.masterCalls) != 0 {
+		t.Fatalf("fully-realized adopt re-enslaved member(s) %v — flapped a good bond", ops.masterCalls)
+	}
+	if got := b.bonds["bond0"]; got != full {
+		t.Fatalf("adopt tracked %+v, want full desired %+v", got, full)
 	}
 }

--- a/pkg/routing/bond_test.go
+++ b/pkg/routing/bond_test.go
@@ -13,7 +13,8 @@ import (
 // linkOps methods bond.go actually calls; failure injection is keyed by
 // link name so a single test can target exactly one netlink call.
 type fakeBondLinkOps struct {
-	links map[string]netlink.Link // name -> existing link (LinkByName hits)
+	links     map[string]netlink.Link // name -> existing link (LinkByName hits)
+	nextIndex int                     // monotonic kernel index assigner for LinkAdd
 
 	failLinkAdd       map[string]error // bond name -> LinkAdd error
 	failLinkSetUp     map[string]error // link name -> LinkSetUp error
@@ -29,6 +30,7 @@ type fakeBondLinkOps struct {
 func newFakeBondLinkOps() *fakeBondLinkOps {
 	return &fakeBondLinkOps{
 		links:             map[string]netlink.Link{},
+		nextIndex:         1000, // created bonds get 1001+, clear of small seeded indices
 		failLinkAdd:       map[string]error{},
 		failLinkSetUp:     map[string]error{},
 		failLinkSetMaster: map[string]error{},
@@ -58,6 +60,12 @@ func (f *fakeBondLinkOps) LinkAdd(l netlink.Link) error {
 	if err, ok := f.failLinkAdd[name]; ok {
 		return err
 	}
+	// A real kernel bond is assigned a non-zero index; model that so
+	// observedMembers can key enslavement off a freshly-created bond too.
+	if l.Attrs().Index == 0 {
+		f.nextIndex++
+		l.Attrs().Index = f.nextIndex
+	}
 	f.links[name] = l
 	return nil
 }
@@ -68,7 +76,16 @@ func (f *fakeBondLinkOps) LinkDel(l netlink.Link) error {
 	if err, ok := f.failLinkDel[name]; ok {
 		return err
 	}
+	idx := l.Attrs().Index
 	delete(f.links, name)
+	// Deleting the bond detaches its slaves (their MasterIndex clears).
+	if idx != 0 {
+		for _, m := range f.links {
+			if m.Attrs().MasterIndex == idx {
+				m.Attrs().MasterIndex = 0
+			}
+		}
+	}
 	return nil
 }
 
@@ -83,12 +100,15 @@ func (f *fakeBondLinkOps) LinkSetUp(l netlink.Link) error {
 
 func (f *fakeBondLinkOps) LinkSetDown(netlink.Link) error { return nil }
 
-func (f *fakeBondLinkOps) LinkSetMaster(member, _ netlink.Link) error {
+func (f *fakeBondLinkOps) LinkSetMaster(member, master netlink.Link) error {
 	name := member.Attrs().Name
 	f.masterCalls = append(f.masterCalls, name)
 	if err, ok := f.failLinkSetMaster[name]; ok {
 		return err
 	}
+	// Enslavement sets the member's MasterIndex to the bond's index so
+	// observedMembers reports it as realized on a later reconcile.
+	member.Attrs().MasterIndex = master.Attrs().Index
 	return nil
 }
 
@@ -300,11 +320,14 @@ func TestBondApplyIdempotentNoFlap(t *testing.T) {
 	}
 }
 
-// TestBondApplyReconcilesChangedBond asserts a GENUINE config change (a
-// member added) IS reconciled: the changed bond is deleted and rebuilt so
-// the new member set is realized. Skipping it would leave the kernel bond
-// stale.
-func TestBondApplyReconcilesChangedBond(t *testing.T) {
+// TestBondApplyAddedMemberCompletesInPlace asserts that ADDING a member to an
+// existing bond (the desired member set is a strict superset of the realized
+// set, same mode/MTU) is reconciled IN PLACE — the new member is enslaved with
+// no LinkDel/LinkAdd, so the live LAG is not flapped to grow it (FINDING 1 of
+// the #5533 review; enslaving a slave into an existing bond is non-disruptive
+// to the members already forwarding). The already-enslaved member is NOT
+// re-enslaved.
+func TestBondApplyAddedMemberCompletesInPlace(t *testing.T) {
 	ops := newFakeBondLinkOps()
 	ops.seedMember("ge-0-0-1")
 	ops.seedMember("ge-0-0-2")
@@ -316,25 +339,65 @@ func TestBondApplyReconcilesChangedBond(t *testing.T) {
 		t.Fatalf("first Apply() = %v, want nil", err)
 	}
 
-	// Add a second member — the signature changes, so the bond must be
-	// reconciled (delete + rebuild).
+	// Add a second member — a pure superset, so the bond is completed in
+	// place, not delete+recreated.
 	ops.reset()
+	full := bondSigOf(bondFabricConfig("bond0", "ge-0-0-1", "ge-0-0-2"))
 	if err := b.Apply([]*config.InterfaceConfig{
 		bondFabricConfig("bond0", "ge-0-0-1", "ge-0-0-2"),
 	}); err != nil {
 		t.Fatalf("second Apply() = %v, want nil", err)
 	}
-	if !contains(ops.delCalls, "bond0") {
-		t.Fatalf("changed bond0 was NOT deleted: delCalls=%v", ops.delCalls)
-	}
-	if !contains(ops.addCalls, "bond0") {
-		t.Fatalf("changed bond0 was NOT rebuilt: addCalls=%v", ops.addCalls)
+	if len(ops.delCalls) != 0 || len(ops.addCalls) != 0 {
+		t.Fatalf("member-add flapped the bond (delete+recreate): delCalls=%v addCalls=%v",
+			ops.delCalls, ops.addCalls)
 	}
 	if !contains(ops.masterCalls, "ge-0-0-2") {
-		t.Fatalf("new member ge-0-0-2 was NOT enslaved: masterCalls=%v", ops.masterCalls)
+		t.Fatalf("new member ge-0-0-2 was NOT enslaved in place: masterCalls=%v", ops.masterCalls)
 	}
-	if _, ok := b.bonds["bond0"]; !ok {
-		t.Fatalf("bond0 dropped from tracking after reconcile: %+v", b.bonds)
+	if contains(ops.masterCalls, "ge-0-0-1") {
+		t.Fatalf("already-enslaved member ge-0-0-1 was re-enslaved (flap): masterCalls=%v", ops.masterCalls)
+	}
+	if got := b.bonds["bond0"]; got != full {
+		t.Fatalf("after member-add b.bonds[bond0]=%+v, want full desired %+v", got, full)
+	}
+}
+
+// TestBondApplyRecreatesOnMemberRemoval asserts a GENUINE identity change (a
+// member REMOVED — desired is NOT a superset of the realized set) still takes
+// the delete+recreate path: a slave cannot be dropped via the in-place
+// completion path, so the bond is torn down and rebuilt with the smaller
+// member set. This guards against over-broadening in-place completion to cover
+// non-superset changes.
+func TestBondApplyRecreatesOnMemberRemoval(t *testing.T) {
+	ops := newFakeBondLinkOps()
+	ops.seedMember("ge-0-0-1")
+	ops.seedMember("ge-0-0-2")
+	b := &bondManager{ops: ops}
+
+	if err := b.Apply([]*config.InterfaceConfig{
+		bondFabricConfig("bond0", "ge-0-0-1", "ge-0-0-2"),
+	}); err != nil {
+		t.Fatalf("first Apply() = %v, want nil", err)
+	}
+
+	// Remove ge-0-0-2 — the realized set is no longer a subset of the desired
+	// set, so this is a genuine identity change → delete+recreate.
+	ops.reset()
+	want := bondSigOf(bondFabricConfig("bond0", "ge-0-0-1"))
+	if err := b.Apply([]*config.InterfaceConfig{
+		bondFabricConfig("bond0", "ge-0-0-1"),
+	}); err != nil {
+		t.Fatalf("second Apply() = %v, want nil", err)
+	}
+	if !contains(ops.delCalls, "bond0") {
+		t.Fatalf("member removal did NOT delete bond0: delCalls=%v", ops.delCalls)
+	}
+	if !contains(ops.addCalls, "bond0") {
+		t.Fatalf("member removal did NOT rebuild bond0: addCalls=%v", ops.addCalls)
+	}
+	if got := b.bonds["bond0"]; got != want {
+		t.Fatalf("after removal b.bonds[bond0]=%+v, want %+v", got, want)
 	}
 }
 
@@ -419,15 +482,23 @@ func TestBondAdoptPartialMemberSetNotTrackedAsComplete(t *testing.T) {
 	}
 
 	// The missing member now appears in the kernel. The next reconcile must
-	// detect the tracked/desired mismatch and complete the enslavement.
+	// complete the enslavement IN PLACE — no delete+recreate of the live
+	// (degraded) bond (FINDING 1 of the #5533 review).
 	ops.reset()
 	ops.seedMember("ge-0-0-2")
 	if err := b.Apply(cfg); err != nil {
 		t.Fatalf("second Apply() (member appeared) = %v, want nil", err)
 	}
+	if len(ops.delCalls) != 0 || len(ops.addCalls) != 0 {
+		t.Fatalf("partial completion flapped the bond (delete+recreate): "+
+			"delCalls=%v addCalls=%v — must complete in place", ops.delCalls, ops.addCalls)
+	}
 	if !contains(ops.masterCalls, "ge-0-0-2") {
 		t.Fatalf("missing member ge-0-0-2 was NOT enslaved on the follow-up "+
 			"reconcile: masterCalls=%v", ops.masterCalls)
+	}
+	if contains(ops.masterCalls, "ge-0-0-1") {
+		t.Fatalf("already-enslaved member ge-0-0-1 was re-enslaved (flap): masterCalls=%v", ops.masterCalls)
 	}
 	if got := b.bonds["bond0"]; got != full {
 		t.Fatalf("after completion b.bonds[bond0]=%+v, want full desired %+v", got, full)
@@ -511,5 +582,111 @@ func TestBondAdoptCompleteMemberSetNoFlap(t *testing.T) {
 	}
 	if got := b.bonds["bond0"]; got != full {
 		t.Fatalf("adopt tracked %+v, want full desired %+v", got, full)
+	}
+}
+
+// TestBondAdoptPermanentlyMissingMemberNoFlapConverges is FINDING 1/2 of the
+// #5533 review: a member that stays absent across many reconciles must NOT
+// cause a per-commit flap (the tracked partial sig must be completed IN PLACE,
+// never delete+recreated every ApplyBonds), and the bond must still CONVERGE
+// (enslave the member in place) the moment it finally appears. On master a
+// partial bond is stable-degraded (no flap); the fix must not regress that
+// while also fixing the eventual convergence.
+func TestBondAdoptPermanentlyMissingMemberNoFlapConverges(t *testing.T) {
+	ops := newFakeBondLinkOps()
+	ops.seedBond("bond0", 10)
+	ops.seedEnslavedMember("ge-0-0-1", 10)
+	// ge-0-0-2 is absent and stays absent for the first few reconciles.
+	b := &bondManager{ops: ops}
+
+	cfg := []*config.InterfaceConfig{bondFabricConfig("bond0", "ge-0-0-1", "ge-0-0-2")}
+	full := bondSigOf(cfg[0])
+
+	// Adopt + several reconciles with the member still missing: zero flap.
+	for i := 0; i < 4; i++ {
+		ops.reset()
+		if err := b.Apply(cfg); err != nil {
+			t.Fatalf("Apply() #%d (member absent) = %v, want nil", i, err)
+		}
+		if len(ops.delCalls) != 0 || len(ops.addCalls) != 0 {
+			t.Fatalf("reconcile #%d flapped a partial bond: delCalls=%v addCalls=%v — "+
+				"a permanently-missing member must NOT delete+recreate every commit",
+				i, ops.delCalls, ops.addCalls)
+		}
+		if got := b.bonds["bond0"]; got == full {
+			t.Fatalf("reconcile #%d tracked the FULL sig despite the missing member %+v", i, got)
+		}
+	}
+
+	// The member finally appears: the next reconcile completes it in place.
+	ops.reset()
+	ops.seedMember("ge-0-0-2")
+	if err := b.Apply(cfg); err != nil {
+		t.Fatalf("Apply() (member appeared) = %v, want nil", err)
+	}
+	if len(ops.delCalls) != 0 || len(ops.addCalls) != 0 {
+		t.Fatalf("convergence flapped the bond: delCalls=%v addCalls=%v", ops.delCalls, ops.addCalls)
+	}
+	if !contains(ops.masterCalls, "ge-0-0-2") {
+		t.Fatalf("member ge-0-0-2 was NOT enslaved in place once it appeared: masterCalls=%v", ops.masterCalls)
+	}
+	if got := b.bonds["bond0"]; got != full {
+		t.Fatalf("after convergence b.bonds[bond0]=%+v, want full desired %+v", got, full)
+	}
+}
+
+// TestBondFreshCreateAbsentMemberConvergesInPlace is FINDING 2 of the #5533
+// review: a bond FIRST CREATED with a member absent (a #4823 soft error) must
+// track the REALIZED (partial) sig, not the full desired sig — otherwise the
+// member is never enslaved when it appears (KEEP-forever, the fresh-create
+// analogue of #5261). With the fix, the fresh-create tracks partial, does not
+// flap on subsequent still-absent commits, and completes IN PLACE when the
+// member appears. RED on revert: a fresh-create that tracks the full sig makes
+// the tracked-partial assertion fail AND leaves ge-0-0-2 never enslaved.
+func TestBondFreshCreateAbsentMemberConvergesInPlace(t *testing.T) {
+	ops := newFakeBondLinkOps()
+	ops.seedMember("ge-0-0-1")
+	// ge-0-0-2 absent at creation time.
+	b := &bondManager{ops: ops}
+
+	cfg := []*config.InterfaceConfig{bondFabricConfig("bond0", "ge-0-0-1", "ge-0-0-2")}
+	full := bondSigOf(cfg[0])
+
+	if err := b.Apply(cfg); err != nil {
+		t.Fatalf("first Apply() (fresh create) = %v, want nil", err)
+	}
+	got, ok := b.bonds["bond0"]
+	if !ok {
+		t.Fatalf("bond0 not tracked after fresh create: %+v", b.bonds)
+	}
+	if got == full {
+		t.Fatalf("fresh-create tracked the FULL desired sig %+v despite the absent "+
+			"member — the member is never enslaved when it appears (#5261 fresh-create)", got)
+	}
+
+	// Still absent: no flap.
+	ops.reset()
+	if err := b.Apply(cfg); err != nil {
+		t.Fatalf("second Apply() (still absent) = %v, want nil", err)
+	}
+	if len(ops.delCalls) != 0 || len(ops.addCalls) != 0 {
+		t.Fatalf("still-absent reconcile flapped the bond: delCalls=%v addCalls=%v",
+			ops.delCalls, ops.addCalls)
+	}
+
+	// Member appears: completes in place.
+	ops.reset()
+	ops.seedMember("ge-0-0-2")
+	if err := b.Apply(cfg); err != nil {
+		t.Fatalf("third Apply() (member appeared) = %v, want nil", err)
+	}
+	if len(ops.delCalls) != 0 || len(ops.addCalls) != 0 {
+		t.Fatalf("convergence flapped the bond: delCalls=%v addCalls=%v", ops.delCalls, ops.addCalls)
+	}
+	if !contains(ops.masterCalls, "ge-0-0-2") {
+		t.Fatalf("absent-at-create member ge-0-0-2 was NOT enslaved when it appeared: masterCalls=%v", ops.masterCalls)
+	}
+	if got := b.bonds["bond0"]; got != full {
+		t.Fatalf("after convergence b.bonds[bond0]=%+v, want full desired %+v", got, full)
 	}
 }


### PR DESCRIPTION
## Problem

`bondManager.createLocked` (`pkg/routing/bond.go`) has an **adopt** branch: when a
bond already exists in the kernel (`LinkByName` returns no error), the #5119
differential-reconcile (PR #5259) tracks it under the **full desired** `bondSig`
and only `LinkSetUp`s it — no `LinkDel`/`LinkAdd`/re-enslave. That is correct and
deliberate for a fully-realized bond (don't flap a good LAG across a daemon
restart).

The edge (#5261): the reconcile tolerates a member not yet enumerated in the
kernel — `LinkSetMaster` of a missing member is a **soft error** (#4823), the
bond is still tracked. If a bond is realized with a **partial** member set and
the daemon then restarts with **no subsequent config change** to that bond, the
adopt path records the full desired sig even though a member is missing. From
then on `tracked == desired`, so every reconcile takes the **KEEP** path and the
bond stays partially-enslaved **forever**. The pre-#5119 clear+rebuild used to
self-heal this on the next commit.

## Fix (scoped to the adopt path — no `LinkDel`/`LinkAdd` on adopt)

On adopt, enumerate the bond's **actual** enslaved member set (`LinkList`
filtered by `MasterIndex == bond index`; `observedMembers`, with a safe fallback
for a `LinkList` failure or index 0 that preserves the prior behavior) and
compare to the desired set:

- **COMPLETE** (observed covers desired) → track the full desired sig and only
  bring the bond up. Zero enslave / `LinkDel` / `LinkAdd` — **no flap** (#5259
  preserved exactly).
- **PARTIAL** → enslave the still-missing members **in place** if they have since
  appeared (a restart that resolved the enumeration race heals immediately,
  without a recreate and without re-enslaving the already-attached member);
  members still absent remain a #4823 soft error. Track a sig derived from the
  **realized** member set — full if completion filled it, otherwise a partial sig
  `!= desired`, so the **next reconcile** detects the mismatch and completes /
  recreates the bond instead of KEEP-ing a partial bond forever.

The enslave loop is factored into `enslaveMembers` (now returns the members it
actually enslaved) and shared by the create and adopt-completion paths; it skips
already-enslaved members so the good member is never flapped.

Docs updated: `pkg/routing/bond.go` `Apply`/`createLocked` comments and the
`pkg/routing/README.md` bond-reconcile section.

## Invariant satisfied

After adopt, the tracked state reflects the **actual realized** member set — a
partially-enslaved bond is never recorded as fully-realized, so a subsequent
reconcile completes (or re-attempts) the missing enslavement rather than
KEEP-ing a partial bond forever. The fully-realized adopted bond is **not**
flapped (#5259 no-flap preserved).

## Tests (`pkg/routing/bond_test.go`)

Fake link ops extended with a real `LinkList` + `seedBond`/`seedEnslavedMember`:

- `TestBondAdoptPartialMemberSetNotTrackedAsComplete` — partial adopt must not
  track the full desired sig; once the missing member appears, a reconcile
  completes the enslavement.
- `TestBondAdoptPartialCompletesImmediatelyWhenMemberPresent` — a
  present-but-unenslaved member is enslaved **in place** at adopt (no recreate,
  the already-enslaved member is **not** re-enslaved); the next identical
  reconcile is a clean KEEP.
- `TestBondAdoptCompleteMemberSetNoFlap` — **#5259 guarantee**: a fully-realized
  adopt issues zero `LinkDel`/`LinkAdd`/`LinkSetMaster` (tracked == desired,
  KEEP, no flap).

## Validation

- `go build ./...`, `go vet ./pkg/routing/`, `go test ./pkg/routing/...` — all green; `gofmt` clean.
- **RED-on-revert**: reverting the adopt branch to the unconditional
  `b.bonds[name] = sig` fails **both** partial-adopt tests —
  `partial adopt tracked the FULL desired sig ... will KEEP the partial bond forever (#5261)`
  and `present member ge-0-0-2 was NOT enslaved at adopt` — while
  `TestBondAdoptCompleteMemberSetNoFlap` still passes (confirming the no-flap
  case is untouched). Restored → all green.

This is a pure-Go control-plane reconcile fix; it does not touch VRRP /
session-sync / failover logic. It preserves the #5259 don't-flap-a-good-bond
behavior exactly — only the partial-adopt case changes.

Closes #5261

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NthUfkXBVR4KLeP8pgSYWQ