### PR TITLE
deploy/image tooling: fix four filesystem-safety/observability defects (#4905)

### DIFF
--- a/docs/deploy-quickstart.md
+++ b/docs/deploy-quickstart.md
@@ -130,8 +130,21 @@ directory and lingers there until `destroy` removes it. That ISO embeds
 `xpf.conf` verbatim — the most secret-bearing artifact on the box
 (root-authentication hash, IKE pre-shared-keys, SNMP community, DDNS
 tokens) — so the tool never leaves it world-readable even under a lax
-umask (#4586). On a shared build/CI/jump host, run `destroy` (or delete
-the ISO) once the VM is up rather than leaving day-0 secrets on disk.
+umask (#4586). The standalone builder `scripts/image/make_config_drive.py`
+applies the same 0600 (staged copy and finished ISO), so neither day-0
+path leaves the secrets world-readable (#4905-C). On a shared
+build/CI/jump host, run `destroy` (or delete the ISO) once the VM is up
+rather than leaving day-0 secrets on disk.
+
+`name`/`image` are **validated to a single safe path component** before
+any path is built from them (#4905-B). They are interpolated into files
+the tool writes and removes — the day-0 ISO in the build dir, and the
+per-VM overlay + shared golden qcow2 under `/var/lib/libvirt/images`
+(sometimes via `sudo rm -f`) — so a value with a path separator, a `..`
+component, an absolute path, or a leading dash is rejected, and each path
+sink additionally enforces `commonpath` containment. A crafted or
+mistyped `name: ../../../../tmp/owned` can no longer redirect a write or
+delete outside the managed storage dir.
 
 `deploy` runs a **preflight** before it mutates anything — the image /
 golden qcow2, every NIC source (managed network / host bridge / PF / PCI

--- a/docs/image-validation.md
+++ b/docs/image-validation.md
@@ -54,9 +54,17 @@ sg incus-admin -c "XPFD=$PWD/xpfd python3 scripts/image/validate.py \
     --qcow2 $QCOW --metadata $META all"
 ```
 
-It imports the image into local incus and boots three throwaway VMs on a
+It imports the image into local incus and boots throwaway VMs on a
 dedicated NAT network (`xpf-image-net`); none touch the shared cluster,
-and all are deleted on exit. Scenarios:
+and all are deleted on exit. The incus alias and every scenario instance
+are **namespaced with a per-run ID** (`xpf-image-validate-<run>` /
+`xpf-image-<run>-a…e`), and every teardown is **ownership-gated**: the
+harness tags each instance it creates with `user.xpf-owner=<run>` and
+force-deletes ONLY objects carrying that tag (and only the alias it
+imported). So a concurrent bake, or an unrelated same-named VM/image, is
+never destroyed — before this the constant `xpf-image-validate` alias and
+`xpf-image-a…e` instances were force-deleted at import/launch/cleanup with
+no run-ID or ownership check (#4905-D). Scenarios:
 
 | Scenario | Proves |
 |---|---|

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -752,6 +752,20 @@ until `status` reports `promoted=<ver>` AND `uname -r` matches, then
 A reverted node boots the OLD kernel and reports `promoted!=<ver>` → the
 driver STOPS and never touches the peer (never-both-down).
 
+The poll decides "the node rebooted" from an AFFIRMATIVE signal only — a
+CHANGED `boot_id` (`/proc/sys/kernel/random/boot_id`, recorded pre-arm) or the
+candidate kernel actually running — never from an empty status read (#4905-A).
+The node-exec wrapper returns a STRUCTURED result (exit code + stderr), so a
+transient SSH/incus drop or control-socket contention is distinguished from a
+real reboot: an un-ok read is retried, not misread as a completed revert.
+Before this, ANY empty `uname -r` set `rebooted=True`, so one status blip made
+a still-drained-and-running node (e.g. an `arm` that failed its UEFI/NVRAM
+preflight WITHOUT rebooting) look like a finished revert; the `finally` then
+skipped its rejoin and left the node DRAINED + ForceSecondary with both leases
+released — a silent loss of redundancy. Rejoin is now decided from the
+confirmed drain state: a drained node that never affirmatively rebooted is
+always rejoined.
+
 If `rejoin` cannot confirm within its deadline, `RejoinAndConfirm`
 (`pkg/upgrade/kernel_drain.go`) now surfaces the last non-nil
 `PeerAlive`/`SyncEstablished` transport error in the returned error —

--- a/scripts/deploy/test_xpf_deploy_kernel_roll.py
+++ b/scripts/deploy/test_xpf_deploy_kernel_roll.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Unit tests for kernel-roll reboot detection (#4905-A).
+
+In the LANE-1 HA kernel roll, a node is DRAINED (ForceSecondary, both leases
+released to the peer), then armed to reboot into a candidate kernel. The driver
+polls until the node promotes the candidate; if the arm FAILED its preflight
+(no reboot), the node stays drained-but-running and the `finally` must REJOIN
+it so it resumes forwarding.
+
+Before the fix, `_running_kernel` returned "" on ANY transport failure (an
+SSH/incus drop, control-socket contention — the wrapper discarded the exit
+status) and the loop set `rebooted = True` on that empty read. One transient
+status blip then made the still-drained-and-running node look like a completed
+revert (`rebooted and armed=none`), so `completed=True` suppressed the
+finally-rejoin and the node was left DRAINED + ForceSecondary with its leases
+gone — a silent loss of redundancy.
+
+The fix returns STRUCTURED command results (exit code + stderr), records the
+pre-arm boot_id, and confirms a reboot ONLY from an affirmative signal (a
+CHANGED boot_id, or the candidate kernel actually running) — never from an
+empty/failed read. These tests cover both the pure predicate and the
+end-to-end loop.
+
+RED on revert: restore `if not running: rebooted = True` in the poll loop and
+`test_transient_blip_still_rejoins_drained_node` flips — the transient read
+forges a reboot, the roll dies "REVERTED", and no rejoin fires.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_SPEC = importlib.util.spec_from_file_location(
+    "xpf_deploy", Path(__file__).with_name("xpf-deploy.py"))
+xpf_deploy = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(xpf_deploy)
+
+R = xpf_deploy.NodeExecResult
+KNOWN_GOOD = "6.17.0-good"
+CANDIDATE = "6.99.0-cand"
+
+
+class RebootConfirmedTests(unittest.TestCase):
+    """The affirmative-only reboot predicate (#4905-A crux)."""
+
+    def test_transient_read_is_not_a_reboot(self):
+        # boot_id unchanged, running still known-good -> NOT a reboot.
+        self.assertFalse(
+            xpf_deploy._reboot_confirmed("AAAA", "AAAA", KNOWN_GOOD, CANDIDATE))
+
+    def test_unknown_boot_id_is_not_a_reboot(self):
+        # A failed boot_id read ("") must never be treated as a reboot.
+        self.assertFalse(
+            xpf_deploy._reboot_confirmed("AAAA", "", KNOWN_GOOD, CANDIDATE))
+        self.assertFalse(
+            xpf_deploy._reboot_confirmed("", "", "", CANDIDATE))
+
+    def test_changed_boot_id_is_a_reboot(self):
+        self.assertTrue(
+            xpf_deploy._reboot_confirmed("AAAA", "BBBB", KNOWN_GOOD, CANDIDATE))
+
+    def test_candidate_running_is_a_reboot(self):
+        self.assertTrue(
+            xpf_deploy._reboot_confirmed("AAAA", "AAAA", CANDIDATE, CANDIDATE))
+
+
+class NodeExecResultTests(unittest.TestCase):
+    """The structured wrapper preserves rc/stderr (#4905-A)."""
+
+    def test_failure_is_not_ok_and_keeps_stderr(self):
+        fake = types.SimpleNamespace(returncode=255, stdout="",
+                                     stderr="ssh: connect timeout")
+        runner = xpf_deploy.Runner(False)
+        with mock.patch.object(xpf_deploy.subprocess, "run", return_value=fake):
+            res = xpf_deploy._node_exec_result(runner, "ssh", "fw0",
+                                               ["uname", "-r"])
+        self.assertFalse(res.ok)
+        self.assertEqual(res.rc, 255)
+        self.assertIn("connect timeout", res.err)
+
+    def test_success_is_ok(self):
+        fake = types.SimpleNamespace(returncode=0, stdout=KNOWN_GOOD + "\n",
+                                     stderr="")
+        runner = xpf_deploy.Runner(False)
+        with mock.patch.object(xpf_deploy.subprocess, "run", return_value=fake):
+            res = xpf_deploy._node_exec_result(runner, "incus", "fw0",
+                                               ["uname", "-r"])
+        self.assertTrue(res.ok)
+        self.assertEqual(res.out.strip(), KNOWN_GOOD)
+
+
+class _ArmFailedFake:
+    """Scripted node backend for the arm-FAILED-plus-transient-blip scenario.
+
+    The arm preflight fails without rebooting: the node stays on the known-good
+    kernel with an unchanged boot_id and status armed=none. The FIRST `uname`
+    poll fails transiently (transport drop); the second succeeds. A correct
+    driver must NOT classify this as a reboot/revert and MUST rejoin the still-
+    drained node in the finally."""
+
+    def __init__(self):
+        self.uname_calls = 0
+        self.rejoin_calls = 0
+
+    def __call__(self, runner, backend, node, argv):
+        if argv[:3] == ["xpfd", "upgrade", "kernel"]:
+            verb = argv[3]
+            if verb == "status":
+                return R(0, f"promoted={KNOWN_GOOD} armed=none\n", "", True)
+            if verb == "rejoin":
+                self.rejoin_calls += 1
+                return R(0, "", "", True)
+            # drain (check=True) and arm (check=False) both "succeed" at the
+            # transport layer; arm not rebooting is the whole point.
+            return R(0, "", "", True)
+        if argv[:1] == ["cat"] and "boot_id" in argv[-1]:
+            return R(0, "AAAA\n", "", True)   # boot_id never changes (no reboot)
+        if argv == ["uname", "-r"]:
+            self.uname_calls += 1
+            if self.uname_calls == 1:
+                return R(255, "", "ssh: connect timeout", False)  # transient blip
+            return R(0, KNOWN_GOOD + "\n", "", True)   # back, still known-good
+        if argv[:2] == ["sh", "-c"]:
+            return R(0, "ACQUIRED\n", "", True)   # lease acquire / clear
+        return R(0, "", "", True)
+
+
+def _roll_args():
+    return types.SimpleNamespace(
+        dry_run=False, backend="ssh", nodes=["fw0", "fw1"],
+        version=CANDIDATE, node0_id=0, node1_id=1,
+        lease_ttl=1800, boot_deadline=600)
+
+
+class KernelRollTransientBlipTests(unittest.TestCase):
+    def test_transient_blip_still_rejoins_drained_node(self):
+        fake = _ArmFailedFake()
+        with mock.patch.object(xpf_deploy, "_node_exec_result", fake), \
+             mock.patch("time.sleep", return_value=None):
+            with self.assertRaises(SystemExit) as cm:
+                xpf_deploy.cmd_kernel_roll(_roll_args())
+        msg = str(cm.exception)
+        # The node never actually rebooted, so it must NOT be called a revert...
+        self.assertNotIn("REVERTED", msg,
+                         "a transient status blip was misread as a reboot/revert")
+        # ...and the drained node MUST be rejoined so it resumes forwarding.
+        self.assertGreaterEqual(
+            fake.rejoin_calls, 1,
+            "the still-drained node was left ForceSecondary (no rejoin) — #4905-A")
+        # And the second node must NOT be touched (roll stopped at node 0).
+        self.assertEqual(fake.uname_calls, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/deploy/test_xpf_deploy_pathsafety.py
+++ b/scripts/deploy/test_xpf_deploy_pathsafety.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Unit tests for appliance name/image path-containment safety (#4905-B).
+
+The appliance `name` and `image` are interpolated straight into filesystem
+paths that xpf-deploy WRITES and REMOVES (often via sudo): the day-0 ISO in
+CWD (`<name>-day0.iso`), and the per-VM overlay + shared golden qcow2 under
+/var/lib/libvirt/images (`<name>.qcow2` / `<image>.qcow2`). Before the fix a
+value bearing a path separator, a `..` component, an absolute path, or a
+leading dash was accepted verbatim, so `../../../../tmp/owned` resolved to
+`/tmp/owned.qcow2` and destroy/cleanup would `rm -f` (or `sudo rm -f`) it.
+
+These tests assert:
+  - validate_identifier() REJECTS separators, `..`, absolute paths, leading
+    dashes, and shell metacharacters, and ACCEPTS ordinary names.
+  - the sink helpers (day0_iso_path / libvirt_overlay_path / libvirt_golden_path)
+    reject a traversal-bearing identifier and keep a valid one inside its
+    managed dir.
+  - validate_appliance() fails closed on a crafted name/image.
+
+RED on revert: drop validate_identifier/contained_join (or stop calling them at
+the sinks) and the traversal cases stop raising SystemExit — the asserts flip.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "xpf_deploy", Path(__file__).with_name("xpf-deploy.py"))
+xpf_deploy = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(xpf_deploy)
+
+
+_BAD = [
+    "../../../../tmp/owned",     # classic traversal
+    "..",                        # bare parent
+    ".",                         # bare current
+    "foo/bar",                   # embedded separator
+    "foo\\bar",                  # windows-ish separator
+    "/etc/passwd",               # absolute
+    "-rf",                       # leading dash (reads as a CLI flag)
+    "a b",                       # space
+    "a;rm -rf /",                # shell metacharacters
+    "a$(whoami)",                # command substitution
+    ".hidden",                   # leading dot
+    "",                          # empty
+]
+
+_GOOD = ["fw", "xpf-appliance", "fw0", "node_1", "img.v2", "FW-Prod.01"]
+
+
+class ValidateIdentifierTests(unittest.TestCase):
+    def test_rejects_dangerous_identifiers(self):
+        for v in _BAD:
+            with self.assertRaises(SystemExit, msg=f"{v!r} should be rejected"):
+                xpf_deploy.validate_identifier(v, "name")
+
+    def test_accepts_ordinary_identifiers(self):
+        for v in _GOOD:
+            self.assertEqual(xpf_deploy.validate_identifier(v, "name"), v)
+
+
+class SinkContainmentTests(unittest.TestCase):
+    def test_day0_iso_path_rejects_traversal(self):
+        with self.assertRaises(SystemExit):
+            xpf_deploy.day0_iso_path("../../../../tmp/owned")
+
+    def test_day0_iso_path_stays_in_cwd(self):
+        p = xpf_deploy.day0_iso_path("fw")
+        self.assertEqual(os.path.dirname(os.path.abspath(p)), os.getcwd())
+        self.assertTrue(p.endswith("fw-day0.iso"))
+
+    def test_overlay_path_rejects_traversal(self):
+        with self.assertRaises(SystemExit):
+            xpf_deploy.libvirt_overlay_path("../../etc/cron.d/x")
+
+    def test_overlay_path_stays_in_images_dir(self):
+        p = xpf_deploy.libvirt_overlay_path("fw")
+        self.assertEqual(os.path.dirname(p), xpf_deploy.LIBVIRT_IMAGES)
+        self.assertTrue(p.endswith("fw.qcow2"))
+
+    def test_golden_path_rejects_traversal(self):
+        with self.assertRaises(SystemExit):
+            xpf_deploy.libvirt_golden_path("../../../tmp/owned")
+
+    def test_golden_path_stays_in_images_dir(self):
+        p = xpf_deploy.libvirt_golden_path("xpf-appliance")
+        self.assertEqual(os.path.dirname(p), xpf_deploy.LIBVIRT_IMAGES)
+
+    def test_contained_join_refuses_escape(self):
+        # Even with the identifier gate bypassed, a basename that resolves out
+        # of the managed dir is refused (defense-in-depth).
+        with self.assertRaises(SystemExit):
+            xpf_deploy.contained_join(xpf_deploy.LIBVIRT_IMAGES,
+                                      "../../tmp/escape.qcow2", "overlay")
+
+
+def _appliance(name="fw", image="xpf-appliance"):
+    return {
+        "name": name, "mode": "standalone", "node_id": None,
+        "image": image, "cpu": 2, "memory": "4G", "config": None,
+        "interfaces": [{"backing": "bridge", "source": "br0"}],
+        "base_dir": "/tmp",
+    }
+
+
+class ValidateApplianceContainmentTests(unittest.TestCase):
+    def test_crafted_name_rejected_at_load(self):
+        with self.assertRaises(SystemExit):
+            xpf_deploy.validate_appliance(
+                _appliance(name="../../../../tmp/owned"), "test.yaml")
+
+    def test_crafted_image_rejected_at_load(self):
+        with self.assertRaises(SystemExit):
+            xpf_deploy.validate_appliance(
+                _appliance(image="../../../../tmp/golden"), "test.yaml")
+
+    def test_valid_appliance_passes(self):
+        # Should not raise: a well-formed appliance validates cleanly.
+        xpf_deploy.validate_appliance(_appliance(), "test.yaml")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/deploy/xpf-deploy.py
+++ b/scripts/deploy/xpf-deploy.py
@@ -90,6 +90,69 @@ def die(msg):
     sys.exit(f"ERROR: {msg}")
 
 
+# ── identifier / path-containment safety (#4905-B) ────────────────────
+# The appliance `name` and `image` are interpolated straight into filesystem
+# paths that this tool WRITES and REMOVES (often via sudo): the day-0 ISO in
+# CWD (`<name>-day0.iso`), and the per-VM overlay + shared golden qcow2 under
+# /var/lib/libvirt/images (`<name>.qcow2` / `<image>.qcow2`). A value bearing a
+# path separator, a `..` component, an absolute path, or a leading dash would
+# redirect those write/delete sinks outside the managed storage dir — e.g.
+# `../../../../tmp/owned` resolves to `/tmp/owned.qcow2`, and destroy/cleanup
+# would `rm -f` (or `sudo rm -f`) it. Validate every identifier to a single
+# safe path component, and enforce commonpath containment at each sink as
+# defense-in-depth.
+_SAFE_IDENT = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+
+
+def validate_identifier(value, field):
+    """Reject a name/image identifier that could escape the managed dir.
+
+    Allows only a single safe path component: it must start with an
+    alphanumeric and contain only [A-Za-z0-9._-] (so no `/`, `\\`, spaces,
+    shell metacharacters, or a leading `.`/`-`). This rules out `..`, absolute
+    paths, and any embedded separator. Returns the value on success; die()s
+    with a clear message otherwise (#4905-B)."""
+    if not isinstance(value, str) or not value:
+        die(f"{field} is required and must be a non-empty string")
+    if os.path.isabs(value):
+        die(f"{field} '{value}' must not be an absolute path")
+    if "/" in value or "\\" in value or os.sep in value \
+            or (os.altsep and os.altsep in value):
+        die(f"{field} '{value}' must not contain a path separator")
+    if value.startswith("-"):
+        die(f"{field} '{value}' must not start with '-' (would be read as a "
+            "CLI flag by the hypervisor tools)")
+    if not _SAFE_IDENT.match(value):
+        die(f"{field} '{value}' is not a safe identifier — allow only "
+            "[A-Za-z0-9][A-Za-z0-9._-]* (no separators, '..', spaces, or "
+            "shell metacharacters), so it cannot escape the managed storage "
+            "directory (#4905-B)")
+    return value
+
+
+def contained_join(dirpath, basename, field):
+    """Join basename onto dirpath and assert the result stays inside dirpath.
+
+    Defense-in-depth beyond validate_identifier: even if a future caller
+    forgot to validate, a path that resolves outside `dirpath` is refused
+    rather than written/deleted (#4905-B). Returns the safe absolute-joined
+    path (not realpath-resolved, so the caller sees the intended location)."""
+    full = os.path.join(dirpath, basename)
+    real_dir = os.path.realpath(dirpath)
+    real_full = os.path.realpath(full)
+    if real_full != real_dir and \
+            os.path.commonpath([real_dir, real_full]) != real_dir:
+        die(f"refusing {field} path {full!r}: it escapes the managed "
+            f"directory {dirpath!r} (#4905-B)")
+    return full
+
+
+def day0_iso_path(name):
+    """Path of the day-0 ISO for `name`, validated + contained to CWD."""
+    validate_identifier(name, "name")
+    return contained_join(os.getcwd(), f"{name}-day0.iso", "day-0 ISO")
+
+
 def run_capture(argv, dry=False):
     """Run argv, capturing stdout+stderr. On a nonzero exit, die() with the
     command, the return code, and the captured stderr — the hypervisor tool's
@@ -213,6 +276,12 @@ def cmd_inventory(_args):
 def validate_appliance(ap, where):
     if not ap.get("name"):
         die(f"{where}: name is required")
+    # Reject a name/image that could escape the managed storage dir before we
+    # ever construct a path from it (#4905-B). The path-building helpers
+    # re-validate at each sink, but failing here gives a clear load-time error.
+    validate_identifier(ap["name"], f"{where}: name")
+    if ap.get("image"):
+        validate_identifier(ap["image"], f"{where}: image")
     if ap["mode"] not in ("standalone", "cluster"):
         die(f"{where}: mode must be standalone|cluster")
     if ap["mode"] == "cluster" and ap.get("node_id") not in (0, 1):
@@ -293,7 +362,7 @@ def build_config_drive(ap, runner):
     if not cfg:
         return None
     cfg_path = cfg if os.path.isabs(cfg) else os.path.join(ap["base_dir"], cfg)
-    iso = os.path.join(os.getcwd(), f"{ap['name']}-day0.iso")
+    iso = day0_iso_path(ap["name"])
     if runner.dry:
         print(f"==> (dry-run) would build day-0 drive {iso} from {cfg_path} "
               f"(label xpf-config, check-config validated)")
@@ -560,8 +629,19 @@ def libvirt_golden_path(image):
     """The libvirt golden qcow2 path — the SINGLE source of truth shared by
     `deploy --hypervisor libvirt` (reads it as the read-only overlay backing)
     AND `fetch --install-libvirt` (writes the verified image here). One helper
-    so the two halves can't drift (fable-165 H-30)."""
-    return os.path.join(LIBVIRT_IMAGES, f"{image}.qcow2")
+    so the two halves can't drift (fable-165 H-30). The image identifier is
+    validated + contained so a crafted `image:`/`--alias` cannot redirect the
+    install/read outside LIBVIRT_IMAGES (#4905-B)."""
+    validate_identifier(image, "image")
+    return contained_join(LIBVIRT_IMAGES, f"{image}.qcow2", "golden image")
+
+
+def libvirt_overlay_path(name):
+    """The per-VM writable overlay qcow2 path under LIBVIRT_IMAGES, validated +
+    contained so a crafted `name:` cannot redirect the overlay create/remove
+    (which destroy runs via `sudo rm -f`) outside LIBVIRT_IMAGES (#4905-B)."""
+    validate_identifier(name, "name")
+    return contained_join(LIBVIRT_IMAGES, f"{name}.qcow2", "per-VM overlay")
 
 
 def _install_libvirt_golden(srcq, image):
@@ -600,7 +680,7 @@ def libvirt_disk(ap, runner):
     out from under it.
     """
     golden = libvirt_golden_path(ap['image'])
-    overlay = os.path.join(LIBVIRT_IMAGES, f"{ap['name']}.qcow2")
+    overlay = libvirt_overlay_path(ap['name'])
     if os.path.abspath(overlay) == os.path.abspath(golden):
         die(f"VM name '{ap['name']}' collides with the golden image basename "
             f"'{ap['image']}' — the per-VM overlay would overwrite the golden "
@@ -648,7 +728,7 @@ def deploy_libvirt(ap, runner, start):
         # re-run. Undefine the domain + remove the overlay we created, then
         # re-raise the original error (SystemExit keeps its message).
         if not runner.dry:
-            overlay = os.path.join(LIBVIRT_IMAGES, f"{name}.qcow2")
+            overlay = libvirt_overlay_path(name)
             _cleanup_libvirt(name, overlay)
         raise
 
@@ -749,7 +829,7 @@ def _deploy_libvirt_inner(ap, runner, start, iso):
 def deploy(ap, args):
     runner = Runner(args.dry_run)
     if args.image:
-        ap["image"] = args.image
+        ap["image"] = validate_identifier(args.image, "--image")
     (deploy_incus if args.hypervisor == "incus" else deploy_libvirt)(
         ap, runner, not args.no_start)
 
@@ -757,7 +837,7 @@ def deploy(ap, args):
 # ── destroy (teardown for a clean re-deploy, fable-165 H-27) ───────────
 def destroy_incus(ap, runner):
     name = ap["name"]
-    iso = os.path.join(os.getcwd(), f"{name}-day0.iso")
+    iso = day0_iso_path(name)
     if runner.dry:
         runner.run(["incus", "delete", "--force", name])
     elif _incus_exists("instance", name):
@@ -772,8 +852,8 @@ def destroy_incus(ap, runner):
 
 def destroy_libvirt(ap, runner):
     name = ap["name"]
-    overlay = os.path.join(LIBVIRT_IMAGES, f"{name}.qcow2")
-    iso = os.path.join(os.getcwd(), f"{name}-day0.iso")
+    overlay = libvirt_overlay_path(name)
+    iso = day0_iso_path(name)
     if runner.dry:
         runner.run(["virsh", "destroy", name])
         runner.run(["virsh", "undefine", "--nvram", name])
@@ -802,7 +882,7 @@ def destroy_libvirt(ap, runner):
 def destroy(ap, args):
     runner = Runner(args.dry_run)
     if args.image:
-        ap["image"] = args.image
+        ap["image"] = validate_identifier(args.image, "--image")
     (destroy_incus if args.hypervisor == "incus" else destroy_libvirt)(ap, runner)
 
 
@@ -1057,8 +1137,29 @@ def cmd_fetch(args):
 # is unreachable), the driver aborts BEFORE draining the second node, so the
 # cluster never ends up with both nodes down.
 
-def _node_exec(runner, backend, node, argv, check=True):
-    """Run argv inside `node` via the chosen backend (incus|ssh)."""
+class NodeExecResult:
+    """Structured result of a node command: exit code, stdout, stderr, and an
+    `ok` flag (transport + command both succeeded).
+
+    The kernel roll needs to tell an empty-BECAUSE-the-command-succeeded read
+    apart from an empty-BECAUSE-the-transport-failed read (SSH/incus drop,
+    control-socket contention, a `uname` that never ran). The old wrapper
+    returned only stdout, collapsing both to "" — so a single transient status
+    failure was misread as a completed reboot and the drained node was left
+    ForceSecondary with its leases released (#4905-A). `ok` is the affirmative
+    signal that distinguishes the two."""
+
+    __slots__ = ("rc", "out", "err", "ok")
+
+    def __init__(self, rc, out, err, ok):
+        self.rc = rc
+        self.out = out
+        self.err = err
+        self.ok = ok
+
+
+def _node_exec_argv(backend, node, argv):
+    """Build the full host argv that runs `argv` inside `node` (incus|ssh)."""
     if backend == "ssh":
         # Non-interactive automation: never hang on a host-key / password prompt
         # or a dead host (Copilot). BatchMode disables all prompts (fail fast
@@ -1077,20 +1178,39 @@ def _node_exec(runner, backend, node, argv, check=True):
         # after it is the remote command. A literal "--" would be sent as the
         # first token of the remote command string, and the remote login shell
         # would try to run `-- <cmd>` → "--: command not found" (Copilot).
-        full = ["ssh",
+        return ["ssh",
                 "-o", "BatchMode=yes",
                 "-o", "ConnectTimeout=15",
                 node, remote]
-    else:
-        full = ["incus", "exec", node, "--"] + argv
+    return ["incus", "exec", node, "--"] + argv
+
+
+def _node_exec_result(runner, backend, node, argv):
+    """Run argv inside `node`; return a NodeExecResult (never die()s).
+
+    Unlike _node_exec, this preserves the exit code + stderr so callers can
+    distinguish a transport/command FAILURE from legitimately-empty output
+    (#4905-A reboot detection). In dry-run it prints the command and returns an
+    ok result with empty output (nothing executed)."""
+    full = _node_exec_argv(backend, node, argv)
     if runner.dry:
         print("   " + " ".join(shlex.quote(a) for a in full))
-        return ""
+        return NodeExecResult(0, "", "", True)
     r = subprocess.run(full, capture_output=True, text=True)
-    if check and r.returncode != 0:
+    return NodeExecResult(r.returncode, r.stdout, r.stderr, r.returncode == 0)
+
+
+def _node_exec(runner, backend, node, argv, check=True):
+    """Run argv inside `node` via the chosen backend (incus|ssh).
+
+    Returns stdout (string) for the many callers that only need it. Callers
+    that must distinguish a transport failure from empty output (kernel-roll
+    reboot detection) use _node_exec_result instead (#4905-A)."""
+    res = _node_exec_result(runner, backend, node, argv)
+    if check and not res.ok and not runner.dry:
         die(f"{node}: command failed ({' '.join(argv)}): "
-            f"{r.stdout.strip()} {r.stderr.strip()}")
-    return r.stdout
+            f"{res.out.strip()} {res.err.strip()}")
+    return res.out
 
 
 def _acquire_lease(runner, backend, node, target_node_id, holder, ttl_secs):
@@ -1166,8 +1286,39 @@ def _kernel_status(runner, backend, node):
     return st
 
 
-def _running_kernel(runner, backend, node):
-    return _node_exec(runner, backend, node, ["uname", "-r"], check=False).strip()
+def _running_kernel_result(runner, backend, node):
+    """(ok, release): `ok` is False on a transport/command failure (SSH/incus
+    drop, control-socket contention), True with the stripped `uname -r` output
+    otherwise. The roll loop must NOT treat an un-ok read as a reboot (#4905-A)."""
+    res = _node_exec_result(runner, backend, node, ["uname", "-r"])
+    return res.ok, (res.out.strip() if res.ok else "")
+
+
+def _boot_id(runner, backend, node):
+    """The node's boot_id (/proc/sys/kernel/random/boot_id) — a fresh UUID on
+    every boot — or "" if it could not be read. A CHANGED boot_id across the
+    arm is the affirmative reboot signal the roll uses; a transport failure
+    returns "" (unknown), which is NEVER treated as a reboot (#4905-A)."""
+    res = _node_exec_result(runner, backend, node,
+                            ["cat", "/proc/sys/kernel/random/boot_id"])
+    return res.out.strip() if res.ok else ""
+
+
+def _reboot_confirmed(pre_boot_id, cur_boot_id, running, version):
+    """Affirmative reboot test (#4905-A). A reboot is confirmed ONLY by a
+    positive signal — a CHANGED boot_id, or the candidate kernel actually
+    running — NEVER by an empty/failed status read. Returns True iff an
+    affirmative signal is present.
+
+    This is the crux of the #4905-A fix: the old loop set rebooted=True on ANY
+    empty `uname -r` read, so one transient SSH/incus blip made a
+    still-drained-and-running node look like a completed revert, and the finally
+    skipped its rejoin — leaving the node ForceSecondary with its leases gone."""
+    if cur_boot_id and pre_boot_id and cur_boot_id != pre_boot_id:
+        return True
+    if running and version and running == version:
+        return True
+    return False
 
 
 def cmd_kernel_roll(args):
@@ -1242,6 +1393,13 @@ def cmd_kernel_roll(args):
             #    distinguish the two by exit code, so the poll below detects a
             #    no-reboot (uname never changes off known-good while armed=none),
             #    and the finally REJOINS a drained node that never rebooted.
+            # Record the pre-arm boot_id (#4905-A): a CHANGED boot_id after the
+            # arm is the AFFIRMATIVE proof the node actually rebooted. Reading
+            # it here — after a confirmed drain, before arm — is on a healthy,
+            # reachable node, so it normally succeeds; if it can't be read we
+            # fall back to the running==candidate signal (a promote still sets
+            # rebooted, and an unconfirmed reboot conservatively rejoins).
+            pre_boot_id = _boot_id(runner, backend, node)
             print(f"   arming candidate {version} on {node} (will reboot)...")
             _node_exec(runner, backend, node,
                        ["xpfd", "upgrade", "kernel", "arm", version], check=False)
@@ -1253,15 +1411,24 @@ def cmd_kernel_roll(args):
             # 5. poll until back + promoted==version (or STOP on revert/timeout)
             deadline = _time.time() + poll_deadline
             promoted = False
+            running = ""   # last observed kernel ("" = never reachable)
             while _time.time() < deadline:
                 _time.sleep(10)
                 st = _kernel_status(runner, backend, node)
-                running = _running_kernel(runner, backend, node)
-                if not running:
-                    rebooted = True   # transport dropped -> the box is rebooting
-                    continue          # node still rebooting / unreachable
-                if running == version:
-                    rebooted = True   # booted the candidate kernel
+                ok, running = _running_kernel_result(runner, backend, node)
+                if not ok:
+                    # TRANSPORT failure (SSH/incus drop, control-socket
+                    # contention) — NOT a reboot. The old code set rebooted=True
+                    # on ANY empty read, so one status blip masqueraded as a
+                    # completed revert and the finally skipped rejoin, stranding
+                    # the node drained + ForceSecondary (#4905-A). Do NOT touch
+                    # `rebooted`; just retry.
+                    continue
+                # Node is reachable. Confirm a reboot ONLY from an affirmative
+                # signal: a changed boot_id, or the candidate kernel running.
+                cur_boot_id = _boot_id(runner, backend, node)
+                if _reboot_confirmed(pre_boot_id, cur_boot_id, running, version):
+                    rebooted = True
                 if st.get("promoted") == version and running == version:
                     promoted = True
                     break
@@ -1279,6 +1446,8 @@ def cmd_kernel_roll(args):
                 # signature (running==known-good, armed=none) while still drained
                 # — it must NOT be classified as a revert, or `completed=True`
                 # would suppress the finally-rejoin and strand the node drained.
+                # With the #4905-A fix, `rebooted` is now set ONLY by a confirmed
+                # boot_id change, so a transient blip can no longer forge it.
                 if (rebooted and running != version and "armed" in st
                         and st.get("armed") == "none"):
                     # node REBOOTED to a NON-candidate kernel and nothing is armed

--- a/scripts/image/make_config_drive.py
+++ b/scripts/image/make_config_drive.py
@@ -69,7 +69,11 @@ def build_config_drive(config, out=None, node_id=None, validate=True):
     stage = tempfile.mkdtemp(prefix="xpf-day0-")
     try:
         shutil.copyfile(config, os.path.join(stage, "xpf.conf"))
-        os.chmod(os.path.join(stage, "xpf.conf"), 0o644)
+        # 0o600, not 0o644: the staged xpf.conf carries every day-0 secret
+        # (root-authentication hash, IKE PSK, SNMP community, DDNS tokens).
+        # The 0700 mkdtemp already shields it, but keep the staged copy
+        # owner-only too, matching the deploy path (#4905-C / xpf-deploy.py).
+        os.chmod(os.path.join(stage, "xpf.conf"), 0o600)
         if node_id is not None:
             with open(os.path.join(stage, "node-id"), "w") as f:
                 f.write(f"{node_id}\n")
@@ -80,6 +84,14 @@ def build_config_drive(config, out=None, node_id=None, validate=True):
         else:
             argv = [tool, "-quiet", "-V", "xpf-config", "-J", "-r", "-o", out, stage]
         subprocess.run(argv, check=True)
+        # The finished ISO embeds xpf.conf — the most secret-bearing day-0
+        # artifact. xorriso/genisoimage/mkisofs writes it under the process
+        # umask (~0022 -> 0644, world-readable) and it lingers in CWD until an
+        # explicit destroy, so any co-located UID could `isoinfo -x /xpf.conf`
+        # the secrets out. Restrict it to owner-only immediately after build,
+        # matching the deploy implementation (#4905-C). The owner still reads
+        # it fine when attaching it to the VM.
+        os.chmod(out, 0o600)
     finally:
         shutil.rmtree(stage, ignore_errors=True)
     return out

--- a/scripts/image/test_make_config_drive_mode.py
+++ b/scripts/image/test_make_config_drive_mode.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Unit test for the standalone day-0 ISO file mode (#4905-C).
+
+make_config_drive.build_config_drive() writes a day-0 config ISO whose sole
+payload is xpf.conf — the most secret-bearing artifact on the box: the
+root-authentication hash, the security IKE pre-shared-key, the SNMP community,
+and the DDNS tsig/api-token/password. xorriso/genisoimage/mkisofs create that
+ISO under the process umask (a typical ~0022 yields a world-readable 0644
+file) and it lingers in CWD until an explicit destroy. Any co-located UID
+could then `isoinfo -R -x /xpf.conf` the secrets straight out of it.
+
+The deploy implementation (xpf-deploy.py:build_config_drive) already chmods the
+finished ISO 0o600; make_config_drive.py did not (#4905-C). The fix chmods the
+finished ISO 0o600 immediately after the build and stages xpf.conf 0o600 too.
+These tests assert both:
+
+  - after build_config_drive() the ISO has no group/other permission bits
+    (mode & 0o077 == 0), regardless of the umask the ISO tool ran under;
+  - the staged xpf.conf handed to the ISO builder is likewise owner-only.
+
+RED on revert: restore the 0o644 staging chmod and drop the os.chmod(out,
+0o600), and both assertions flip — the ISO comes back 0644 world-readable and
+the staged copy 0644.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_SPEC = importlib.util.spec_from_file_location(
+    "make_config_drive", Path(__file__).with_name("make_config_drive.py"))
+mcd = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(mcd)
+
+
+class MakeConfigDriveModeTests(unittest.TestCase):
+    def _build(self, staged_mode_holder):
+        """Drive build_config_drive() with the ISO builder mocked out.
+
+        The fake subprocess.run emulates xorriso: it materialises the target
+        ISO world-readable (0o644) under a lax umask — exactly the defect the
+        fix must correct. It also records the mode of the staged xpf.conf about
+        to be packed (the stage dir is rmtree'd right after build returns)."""
+
+        def fake_run(argv, check=False):
+            out = argv[argv.index("-o") + 1]
+            stage = argv[-1]  # final positional arg = staging dir
+            staged = os.path.join(stage, "xpf.conf")
+            if os.path.isfile(staged):
+                staged_mode_holder.append(os.stat(staged).st_mode & 0o777)
+            with open(out, "wb") as f:
+                f.write(b"\x00" * 2048)
+            os.chmod(out, 0o644)  # world-readable, as the real tools leave it
+
+            class _R:
+                returncode = 0
+            return _R()
+
+        with tempfile.TemporaryDirectory() as td:
+            conf = os.path.join(td, "day0.conf")
+            with open(conf, "w") as f:
+                f.write('system { root-authentication { '
+                        'encrypted-password "$6$topsecret"; } }\n')
+            out_iso = os.path.join(td, "day0-config.iso")
+            old_umask = os.umask(0o022)  # force the world-readable default
+            try:
+                with mock.patch.object(mcd, "_iso_tool",
+                                       return_value="xorriso"), \
+                     mock.patch.object(mcd.subprocess, "run",
+                                       side_effect=fake_run):
+                    iso = mcd.build_config_drive(conf, out_iso, node_id=None,
+                                                 validate=False)
+                mode = os.stat(iso).st_mode & 0o777
+            finally:
+                os.umask(old_umask)
+            return mode
+
+    def test_iso_is_owner_only(self):
+        staged = []
+        mode = self._build(staged)
+        self.assertEqual(
+            mode & 0o077, 0,
+            f"day-0 ISO must be owner-only, got {oct(mode)} (#4905-C)")
+        self.assertEqual(mode, 0o600, f"expected 0o600, got {oct(mode)}")
+
+    def test_staged_conf_is_owner_only(self):
+        staged = []
+        self._build(staged)
+        self.assertEqual(len(staged), 1,
+                         "expected exactly one staged xpf.conf")
+        self.assertEqual(
+            staged[0] & 0o077, 0,
+            f"staged xpf.conf must be owner-only, got {oct(staged[0])} (#4905-C)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/image/test_validate_ownership.py
+++ b/scripts/image/test_validate_ownership.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Unit tests for validate.py run-ID namespacing + ownership-gated deletion
+(#4905-D).
+
+validate.py boots the baked image under LOCAL incus. Before the fix the alias
+(`xpf-image-validate`) and every scenario instance (`xpf-image-a`..`e`) were
+CONSTANTS, force-deleted at import/launch/cleanup with no lock/run-ID/ownership
+tag — so a concurrent bake, or an unrelated same-named VM/image, was silently
+destroyed.
+
+The fix namespaces the alias + instances with a process-unique run-ID, tags
+every instance it creates with `user.xpf-owner=<run_id>`, and refuses to delete
+any object that does not carry THIS run's tag. These tests assert:
+
+  - alias + instance names are run-namespaced (two runs never collide);
+  - _owned_delete() DELETES an instance tagged with this run_id;
+  - _owned_delete() REFUSES an instance with a foreign tag (or no instance);
+  - launch() tags the instance with user.xpf-owner=<run_id>;
+  - cleanup() deletes the alias only when THIS run imported it, and only the
+    namespaced alias — never a bystander's `xpf-image-validate`.
+
+RED on revert: restore the constant ALIAS + unconditional `incus delete -f`
+and the foreign-tag deletion is no longer refused — the assertions flip.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_SPEC = importlib.util.spec_from_file_location(
+    "validate", Path(__file__).with_name("validate.py"))
+validate = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(validate)
+
+
+class _IncusRecorder:
+    """Records incus() calls; canned reply for `config get user.xpf-owner`."""
+
+    def __init__(self, owner_tag="", get_rc=0):
+        self.calls = []
+        self.owner_tag = owner_tag
+        self.get_rc = get_rc
+
+    def __call__(self, *args, check=True, capture=False):
+        self.calls.append(tuple(args))
+        if args[:2] == ("config", "get"):
+            return types.SimpleNamespace(returncode=self.get_rc,
+                                         stdout=self.owner_tag, stderr="")
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def deletes(self):
+        return [c for c in self.calls if c[:1] == ("delete",)]
+
+    def image_deletes(self):
+        return [c for c in self.calls if c[:2] == ("image", "delete")]
+
+    def inits(self):
+        return [c for c in self.calls if c[:1] == ("init",)]
+
+
+def _harness(keep=False):
+    return validate.Harness("img.qcow2", "meta.tar.gz", "xpf-image-net", keep)
+
+
+class NamespacingTests(unittest.TestCase):
+    def test_alias_is_run_namespaced(self):
+        h = _harness()
+        self.assertTrue(h.alias.startswith(validate.ALIAS + "-"))
+        self.assertNotEqual(h.alias, validate.ALIAS)
+
+    def test_instance_names_are_run_namespaced(self):
+        h = _harness()
+        self.assertIn(h.run_id, h.iname("a"))
+        self.assertTrue(h.iname("a").startswith("xpf-image-"))
+        self.assertNotEqual(h.iname("a"), "xpf-image-a")
+
+    def test_two_runs_do_not_collide(self):
+        self.assertNotEqual(_harness().run_id, _harness().run_id)
+
+
+class OwnedDeleteTests(unittest.TestCase):
+    def test_deletes_instance_tagged_with_this_run(self):
+        h = _harness()
+        rec = _IncusRecorder(owner_tag=h.run_id + "\n", get_rc=0)
+        with mock.patch.object(validate, "incus", rec):
+            h._owned_delete("xpf-image-x")
+        self.assertEqual(rec.deletes(), [("delete", "-f", "xpf-image-x")],
+                         "an instance carrying THIS run's tag must be deleted")
+
+    def test_refuses_foreign_tagged_instance(self):
+        h = _harness()
+        rec = _IncusRecorder(owner_tag="some-other-run\n", get_rc=0)
+        with mock.patch.object(validate, "incus", rec):
+            h._owned_delete("xpf-image-a")   # the OLD constant name
+        self.assertEqual(rec.deletes(), [],
+                         "an un-owned instance must NOT be force-deleted (#4905-D)")
+
+    def test_refuses_untagged_instance(self):
+        h = _harness()
+        rec = _IncusRecorder(owner_tag="", get_rc=0)  # tag present but empty
+        with mock.patch.object(validate, "incus", rec):
+            h._owned_delete("bystander-vm")
+        self.assertEqual(rec.deletes(), [])
+
+    def test_missing_instance_is_a_noop(self):
+        h = _harness()
+        rec = _IncusRecorder(owner_tag="", get_rc=1)  # `config get` fails => absent
+        with mock.patch.object(validate, "incus", rec):
+            h._owned_delete("does-not-exist")
+        self.assertEqual(rec.deletes(), [])
+
+
+class LaunchTagTests(unittest.TestCase):
+    def test_launch_tags_instance_with_owner(self):
+        h = _harness()
+        rec = _IncusRecorder(owner_tag="", get_rc=1)  # pre-delete finds nothing
+        name = h.iname("a")
+        with mock.patch.object(validate, "incus", rec):
+            with mock.patch.object(h, "wait_agent", return_value=None):
+                h.launch(name)
+        inits = rec.inits()
+        self.assertEqual(len(inits), 1)
+        self.assertIn(f"user.xpf-owner={h.run_id}", inits[0],
+                      "launched instance must carry this run's ownership tag")
+        self.assertIn(h.alias, inits[0],
+                      "launch must init from the run-namespaced alias")
+
+
+class CleanupTests(unittest.TestCase):
+    def test_cleanup_deletes_only_imported_namespaced_alias(self):
+        h = _harness()
+        h.imported_alias = True
+        h.instances = []
+        h.created_net = False
+        rec = _IncusRecorder()
+        with mock.patch.object(validate, "incus", rec):
+            with mock.patch.object(validate.subprocess, "run",
+                                   return_value=types.SimpleNamespace(returncode=0)):
+                h.cleanup()
+        self.assertIn(("image", "delete", h.alias), rec.image_deletes())
+        # It must NEVER delete a bystander's constant `xpf-image-validate`.
+        self.assertNotIn(("image", "delete", validate.ALIAS), rec.image_deletes())
+
+    def test_cleanup_skips_alias_it_did_not_import(self):
+        h = _harness()
+        h.imported_alias = False   # we never imported an alias this run
+        h.instances = []
+        h.created_net = False
+        rec = _IncusRecorder()
+        with mock.patch.object(validate, "incus", rec):
+            with mock.patch.object(validate.subprocess, "run",
+                                   return_value=types.SimpleNamespace(returncode=0)):
+                h.cleanup()
+        self.assertEqual(rec.image_deletes(), [],
+                         "cleanup must not delete an alias this run did not import")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/image/validate.py
+++ b/scripts/image/validate.py
@@ -39,6 +39,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import uuid
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(os.path.dirname(HERE))
@@ -140,6 +141,35 @@ class Harness:
         self.created_net = False
         self.instances = []
         self.work = tempfile.mkdtemp(prefix="xpf-validate-")
+        # Per-run ownership token (#4905-D). The alias + every instance name is
+        # namespaced with it, and every destructive op refuses to touch an
+        # object that lacks THIS run's ownership tag — so a concurrent bake or
+        # an unrelated same-named VM/image is never force-deleted. process-
+        # unique (uuid4) so two `validate.py` runs on one host never collide.
+        self.run_id = uuid.uuid4().hex[:8]
+        self.alias = f"{ALIAS}-{self.run_id}"
+        self.imported_alias = False   # True once WE imported self.alias
+
+    def iname(self, suffix):
+        """Run-namespaced instance name for a scenario slot (#4905-D)."""
+        return f"xpf-image-{self.run_id}-{suffix}"
+
+    def _owned_delete(self, name):
+        """Force-delete instance `name` ONLY if it carries THIS run's ownership
+        tag (user.xpf-owner == run_id). Refuses to delete an instance this run
+        did not create — a concurrent bake or an unrelated same-named VM
+        (#4905-D). A missing instance is a safe no-op."""
+        got = incus("config", "get", name, "user.xpf-owner",
+                    check=False, capture=True)
+        if got.returncode != 0:
+            return  # instance does not exist / not queryable — nothing to delete
+        owner = (got.stdout or "").strip()
+        if owner != self.run_id:
+            info(f"refusing to delete instance {name}: ownership tag {owner!r} "
+                 f"!= this run {self.run_id!r} (concurrent bake / unrelated VM) "
+                 "— #4905-D")
+            return
+        incus("delete", "-f", name, check=False, capture=True)
 
     # ── lifecycle ──
     def ensure_network(self):
@@ -192,14 +222,24 @@ class Harness:
 
     def import_image(self):
         self.verify_signatures()
-        incus("image", "delete", ALIAS, check=False, capture=True)
-        info(f"importing image into local incus as {ALIAS}")
-        incus("image", "import", self.metadata, self.qcow2, "--alias", ALIAS)
+        # self.alias is run-namespaced, so a concurrent bake using the default
+        # `xpf-image-validate` alias is NOT clobbered (#4905-D). The pre-delete
+        # only targets our own unique alias (idempotent within a run).
+        incus("image", "delete", self.alias, check=False, capture=True)
+        info(f"importing image into local incus as {self.alias}")
+        incus("image", "import", self.metadata, self.qcow2, "--alias", self.alias)
+        self.imported_alias = True   # cleanup may now delete THIS alias (#4905-D)
 
     def launch(self, name, iso=None, root_size=None, extra_nics=0):
-        incus("delete", "-f", name, check=False, capture=True)
-        incus("init", ALIAS, name, "--vm", "--network", self.net,
-              "-c", "limits.cpu=2", "-c", "limits.memory=2GiB", capture=True)
+        # Ownership-gated pre-delete (#4905-D): only reclaim a same-named
+        # instance if it is one WE created (it won't normally exist — the name
+        # is run-namespaced).
+        self._owned_delete(name)
+        # Tag the instance with this run's ownership token so drop()/cleanup()
+        # can prove it is ours before force-deleting (#4905-D).
+        incus("init", self.alias, name, "--vm", "--network", self.net,
+              "-c", "limits.cpu=2", "-c", "limits.memory=2GiB",
+              "-c", f"user.xpf-owner={self.run_id}", capture=True)
         if root_size:
             # Override the instance's root disk to a size LARGER than the
             # image (#1925 Scenario D). `device override root` materializes an
@@ -222,17 +262,23 @@ class Harness:
 
     def drop(self, name):
         if not self.keep:
-            incus("delete", "-f", name, check=False, capture=True)
+            self._owned_delete(name)   # ownership-gated (#4905-D)
             if name in self.instances:
                 self.instances.remove(name)
 
     def cleanup(self):
         if self.keep:
-            print(f"keeping instances {self.instances}, alias {ALIAS}, network {self.net}")
+            print(f"keeping instances {self.instances}, alias {self.alias}, "
+                  f"network {self.net}")
         else:
             for i in self.instances:
-                incus("delete", "-f", i, check=False, capture=True)
-            incus("image", "delete", ALIAS, check=False, capture=True)
+                self._owned_delete(i)   # ownership-gated (#4905-D)
+            # Only delete the alias if WE imported it this run, and only the
+            # run-namespaced name — never a bystander's `xpf-image-validate`
+            # (#4905-D).
+            if self.imported_alias:
+                incus("image", "delete", self.alias, check=False, capture=True)
+            # created_net already gates the network delete to one WE created.
             if self.created_net:
                 incus("network", "delete", self.net, check=False, capture=True)
         subprocess.run(["rm", "-rf", self.work], check=False)
@@ -261,55 +307,57 @@ class Harness:
     # ── scenarios ──
     def scenario_a(self):
         info("── Scenario A: first boot, NO config drive ──")
-        self.launch("xpf-image-a")
-        self.wait_xpfd("xpf-image-a")
-        kver = guest("xpf-image-a", "uname", "-r", capture=True).stdout.strip()
+        a = self.iname("a")   # run-namespaced instance name (#4905-D)
+        self.launch(a)
+        self.wait_xpfd(a)
+        kver = guest(a, "uname", "-r", capture=True).stdout.strip()
         info(f"guest kernel: {kver}")
         rel = kver.split("-")[0]
         if not _kver_ge(rel, (6, 18)):
             fail(f"guest kernel {kver} < 6.18")
-        if not guest_sh("xpf-image-a", 'uname -r | grep -q -- -generic'):
+        if not guest_sh(a, 'uname -r | grep -q -- -generic'):
             fail("running kernel is not the -generic flavor")
-        if not guest_sh("xpf-image-a", 'test -d "/lib/modules/$(uname -r)/kernel/drivers/net/ethernet/mellanox"'):
+        if not guest_sh(a, 'test -d "/lib/modules/$(uname -r)/kernel/drivers/net/ethernet/mellanox"'):
             fail("linux-modules-extra (mlx5/i40e driver set) missing")
-        if not guest_sh("xpf-image-a", '[ "$(ls /lib/modules | wc -l)" -eq 1 ]'):
+        if not guest_sh(a, '[ "$(ls /lib/modules | wc -l)" -eq 1 ]'):
             fail("more than one kernel in /lib/modules — stale cloudimg kernel not purged")
-        if not guest_sh("xpf-image-a", 'grep -qw init_on_alloc=0 /proc/cmdline'):
+        if not guest_sh(a, 'grep -qw init_on_alloc=0 /proc/cmdline'):
             fail("init_on_alloc=0 missing from the booted kernel cmdline")
         info("in-guest verify-dataplane (the bake gate, image kernel)...")
-        if guest("xpf-image-a", "nice", "-n", "19", "/usr/local/sbin/xpfd", "verify-dataplane",
+        if guest(a, "nice", "-n", "19", "/usr/local/sbin/xpfd", "verify-dataplane",
                  check=False).returncode != 0:
             fail("in-guest verify-dataplane REJECTED — image must not ship")
-        self.wait_fxp0_dhcp("xpf-image-a")
+        self.wait_fxp0_dhcp(a)
         # #4172: frr-pythontools (/usr/lib/frr/frr-reload.py) MUST be present
         # or every FRR reload silently degrades to the additive `vtysh -f`
         # fallback and stale-config removal never converges (a deleted route
         # keeps forwarding). It is NOT pulled in transitively by `frr`, so
         # assert presence here — package-name drift fails with a clear cause
         # rather than as the downstream "deleted route still active" symptom.
-        if not guest_sh("xpf-image-a", 'test -x /usr/lib/frr/frr-reload.py'):
+        if not guest_sh(a, 'test -x /usr/lib/frr/frr-reload.py'):
             fail("frr-reload.py missing (/usr/lib/frr/frr-reload.py) — "
                  "frr-pythontools not installed (#4172 FRR reload permanently "
                  "degraded; stale-config removal never converges)")
-        if not guest_sh("xpf-image-a", 'ss -tln | grep -q ":22 "'):
+        if not guest_sh(a, 'ss -tln | grep -q ":22 "'):
             fail("sshd not listening")
-        if not guest_sh("xpf-image-a",
+        if not guest_sh(a,
                         '/usr/sbin/sshd -T | grep -qxE "permitrootlogin (prohibit-password|without-password|no)"'):
             fail("sshd effective config does not refuse root password auth")
-        if not guest_sh("xpf-image-a", '/usr/sbin/sshd -T | grep -qx "permitemptypasswords no"'):
+        if not guest_sh(a, '/usr/sbin/sshd -T | grep -qx "permitemptypasswords no"'):
             fail("sshd effective config does not pin PermitEmptyPasswords no")
-        if guest("xpf-image-a", "test", "-e", "/etc/xpf/xpf.conf", check=False).returncode == 0:
+        if guest(a, "test", "-e", "/etc/xpf/xpf.conf", check=False).returncode == 0:
             fail("unexpected /etc/xpf/xpf.conf")
-        if guest("xpf-image-a", "test", "-e", "/etc/xpf/.day0-config-applied", check=False).returncode == 0:
+        if guest(a, "test", "-e", "/etc/xpf/.day0-config-applied", check=False).returncode == 0:
             fail("unexpected day-0 stamp")
-        if not guest_sh("xpf-image-a",
+        if not guest_sh(a,
                         'journalctl -u xpf-day0-config -b --no-pager | grep -q "no config medium found"'):
             fail("day-0 loader did not log the no-medium fallback")
         info("Scenario A PASS")
-        self.drop("xpf-image-a")
+        self.drop(a)
 
     def scenario_b(self):
         info("── Scenario B: first boot WITH valid day-0 config drive ──")
+        b = self.iname("b")   # run-namespaced instance name (#4905-D)
         conf = os.path.join(self.work, "day0-valid.conf")
         with open(conf, "w") as f:
             f.write("system {\n    host-name xpf-day0-b;\n}\n"
@@ -318,54 +366,55 @@ class Harness:
                     "            }\n        }\n    }\n}\n")
         iso = make_config_drive.build_config_drive(conf, os.path.join(self.work, "day0-valid.iso"),
                                                    validate=False)
-        self.launch("xpf-image-b", iso)
-        self.wait_xpfd("xpf-image-b")
-        if guest("xpf-image-b", "test", "-e", "/etc/xpf/.day0-config-applied", check=False).returncode != 0:
+        self.launch(b, iso)
+        self.wait_xpfd(b)
+        if guest(b, "test", "-e", "/etc/xpf/.day0-config-applied", check=False).returncode != 0:
             fail("day-0 stamp missing")
-        if guest("xpf-image-b", "test", "-s", "/etc/xpf/xpf.conf", check=False).returncode != 0:
+        if guest(b, "test", "-s", "/etc/xpf/xpf.conf", check=False).returncode != 0:
             fail("/etc/xpf/xpf.conf missing")
-        if not guest_sh("xpf-image-b",
+        if not guest_sh(b,
                         'journalctl -u xpf-day0-config -b --no-pager | grep -q "day-0 config installed"'):
             fail("day-0 loader did not log the install")
-        self._wait("xpf-image-b",
-                   lambda: guest_sh("xpf-image-b",
+        self._wait(b,
+                   lambda: guest_sh(b,
                                     'echo "show configuration" | /usr/local/sbin/cli 2>/dev/null '
                                     '| grep -q "host-name xpf-day0-b"'),
                    20, 3, "committed config does not show host-name xpf-day0-b")
-        if not guest_sh("xpf-image-b", '[ "$(hostname)" = xpf-day0-b ]'):
+        if not guest_sh(b, '[ "$(hostname)" = xpf-day0-b ]'):
             fail("hostname not applied")
-        info("rebooting xpf-image-b — second boot must NOT re-apply...")
-        incus("restart", "xpf-image-b")
-        self.wait_agent("xpf-image-b")
-        self.wait_xpfd("xpf-image-b")
-        if not guest_sh("xpf-image-b",
+        info(f"rebooting {b} — second boot must NOT re-apply...")
+        incus("restart", b)
+        self.wait_agent(b)
+        self.wait_xpfd(b)
+        if not guest_sh(b,
                         '! journalctl -u xpf-day0-config -b --no-pager | grep -q "day-0 config installed"'):
             fail("second boot re-applied the day-0 config")
-        if not guest_sh("xpf-image-b",
+        if not guest_sh(b,
                         'systemctl show -p ConditionResult xpf-day0-config | grep -q "ConditionResult=no" '
                         '|| journalctl -u xpf-day0-config -b --no-pager | grep -q "already applied"'):
             fail("second boot: day-0 loader neither condition-skipped nor stamp-skipped")
         info("Scenario B PASS")
-        self.drop("xpf-image-b")
+        self.drop(b)
 
     def scenario_c(self):
         info("── Scenario C: first boot WITH INVALID day-0 config drive ──")
+        c = self.iname("c")   # run-namespaced instance name (#4905-D)
         conf = os.path.join(self.work, "day0-invalid.conf")
         with open(conf, "w") as f:
             f.write("system {\n    host-name xpf-day0-c;\n    dataplane-type ebpf;\n}\n")
         iso = make_config_drive.build_config_drive(conf, os.path.join(self.work, "day0-invalid.iso"),
                                                    validate=False)
-        self.launch("xpf-image-c", iso)
-        self.wait_xpfd("xpf-image-c")
-        if not guest_sh("xpf-image-c",
+        self.launch(c, iso)
+        self.wait_xpfd(c)
+        if not guest_sh(c,
                         'journalctl -u xpf-day0-config -b --no-pager | grep -q "REJECTED by commit-check"'):
             fail("day-0 loader did not log the commit-check REJECT")
-        if guest("xpf-image-c", "test", "-e", "/etc/xpf/xpf.conf", check=False).returncode == 0:
+        if guest(c, "test", "-e", "/etc/xpf/xpf.conf", check=False).returncode == 0:
             fail("invalid config was installed")
-        if guest("xpf-image-c", "test", "-e", "/etc/xpf/.day0-config-applied", check=False).returncode == 0:
+        if guest(c, "test", "-e", "/etc/xpf/.day0-config-applied", check=False).returncode == 0:
             fail("stamp written on REJECT")
-        self.wait_fxp0_dhcp("xpf-image-c")
-        if not guest_sh("xpf-image-c", '[ "$(hostname)" != xpf-day0-c ]'):
+        self.wait_fxp0_dhcp(c)
+        if not guest_sh(c, '[ "$(hostname)" != xpf-day0-c ]'):
             fail("invalid config changed the hostname")
         info("Scenario C reject leg PASS (fallback reachable, boot survived)")
 
@@ -385,25 +434,25 @@ class Harness:
         good_iso = make_config_drive.build_config_drive(
             good, os.path.join(self.work, "day0-c-fixed.iso"), validate=False)
         # Replace the day0 medium in place, then reboot.
-        incus("config", "device", "remove", "xpf-image-c", "day0", capture=True)
-        incus("config", "device", "add", "xpf-image-c", "day0", "disk",
+        incus("config", "device", "remove", c, "day0", capture=True)
+        incus("config", "device", "add", c, "day0", "disk",
               f"source={os.path.realpath(good_iso)}", capture=True)
-        incus("restart", "xpf-image-c")
-        self.wait_agent("xpf-image-c")
-        self.wait_xpfd("xpf-image-c")
-        if guest("xpf-image-c", "test", "-e", "/etc/xpf/.day0-config-applied",
+        incus("restart", c)
+        self.wait_agent(c)
+        self.wait_xpfd(c)
+        if guest(c, "test", "-e", "/etc/xpf/.day0-config-applied",
                  check=False).returncode != 0:
             fail("retry: day-0 stamp missing after fix+reboot — the retry "
                  "contract is broken (a rejected first boot could never be fixed)")
-        if not guest_sh("xpf-image-c",
+        if not guest_sh(c,
                         'journalctl -u xpf-day0-config -b --no-pager | grep -q '
                         '"day-0 config installed"'):
             fail("retry: day-0 loader did not install the fixed config on reboot")
-        self._wait("xpf-image-c",
-                   lambda: guest_sh("xpf-image-c", '[ "$(hostname)" = xpf-day0-c-fixed ]'),
+        self._wait(c,
+                   lambda: guest_sh(c, '[ "$(hostname)" = xpf-day0-c-fixed ]'),
                    20, 3, "retry: fixed hostname xpf-day0-c-fixed not applied")
         info("Scenario C PASS (reject survived, fix+reboot applied — retry contract)")
-        self.drop("xpf-image-c")
+        self.drop(c)
 
     def _root_fs_gib(self, name):
         """Total size of the root filesystem in GiB (float), via df."""
@@ -423,27 +472,29 @@ class Harness:
 
     def scenario_d(self):
         info("── Scenario D: first-boot root auto-grow on a resized disk (#1925) ──")
+        d = self.iname("d")     # run-namespaced instance names (#4905-D)
+        d2 = self.iname("d2")
 
         # ── Grow case: provision a root disk LARGER than the 8 GiB bake. ──
         info("D1 grow: launching with a 20GiB root disk (bake is 8GiB)...")
-        self.launch("xpf-image-d", root_size="20GiB")
-        self.wait_xpfd("xpf-image-d")
+        self.launch(d, root_size="20GiB")
+        self.wait_xpfd(d)
         # growpart + resize2fs MUST survive the cloud-init purge + autoremove
         # (#1925); a missing tool makes the grow a permanent no-op. Assert
         # presence first so package-name drift fails here with a clear cause
         # rather than as the downstream "partition still 8GiB" symptom.
-        if not guest_sh("xpf-image-d", 'command -v growpart >/dev/null'):
+        if not guest_sh(d, 'command -v growpart >/dev/null'):
             fail("growpart missing in the image — cloud-guest-utils not installed "
                  "(#1925 grow would no-op; the cloud-init purge orphaned it)")
-        if not guest_sh("xpf-image-d", 'command -v resize2fs >/dev/null'):
+        if not guest_sh(d, 'command -v resize2fs >/dev/null'):
             fail("resize2fs missing in the image — e2fsprogs not installed (#1925)")
-        if not guest_sh("xpf-image-d", 'systemctl is-active --quiet xpf-grow-root'):
+        if not guest_sh(d, 'systemctl is-active --quiet xpf-grow-root'):
             fail("xpf-grow-root.service is not active after first boot")
-        if guest("xpf-image-d", "test", "-e", "/etc/xpf/.root-grown",
+        if guest(d, "test", "-e", "/etc/xpf/.root-grown",
                  check=False).returncode != 0:
             fail("root-grow stamp /etc/xpf/.root-grown missing after grow")
-        part = self._root_part_gib("xpf-image-d")
-        fs = self._root_fs_gib("xpf-image-d")
+        part = self._root_part_gib(d)
+        fs = self._root_fs_gib(d)
         info(f"D1 grow: root partition {part:.1f}GiB, filesystem {fs:.1f}GiB")
         # The 20GiB disk minus the small ESP/BIOS/BOOT partitions leaves the
         # root partition well above the 8GiB bake floor; assert it grew past a
@@ -453,52 +504,53 @@ class Harness:
         if fs < 15.0:
             fail(f"root filesystem only {fs:.1f}GiB on a 20GiB disk — resize2fs did not run")
         # The grow must not have disturbed the dataplane gate.
-        if guest("xpf-image-d", "nice", "-n", "19", "/usr/local/sbin/xpfd",
+        if guest(d, "nice", "-n", "19", "/usr/local/sbin/xpfd",
                  "verify-dataplane", check=False).returncode != 0:
             fail("verify-dataplane REJECTED after root grow")
         # Boot/ESP partitions intact: exactly the root partition grew, the
         # partition count is unchanged, and the ESP is still mounted.
-        if not guest_sh("xpf-image-d", 'mountpoint -q /boot/efi'):
+        if not guest_sh(d, 'mountpoint -q /boot/efi'):
             fail("ESP (/boot/efi) not mounted after grow — boot substrate disturbed")
 
         # ── Idempotency: reboot must NOT re-grow / re-stamp. ──
         info("D1 idempotency: rebooting — second boot must skip the grow...")
-        incus("restart", "xpf-image-d")
-        self.wait_agent("xpf-image-d")
-        self.wait_xpfd("xpf-image-d")
-        if not guest_sh("xpf-image-d",
+        incus("restart", d)
+        self.wait_agent(d)
+        self.wait_xpfd(d)
+        if not guest_sh(d,
                         'systemctl show -p ConditionResult xpf-grow-root | grep -q '
                         '"ConditionResult=no"'):
             fail("second boot did not condition-skip xpf-grow-root (stamp ineffective)")
-        part2 = self._root_part_gib("xpf-image-d")
+        part2 = self._root_part_gib(d)
         if abs(part2 - part) > 0.1:
             fail(f"root partition changed across reboot ({part:.1f} -> {part2:.1f}GiB)")
         info("D1 PASS (grew once, idempotent on reboot, boot substrate intact)")
-        self.drop("xpf-image-d")
+        self.drop(d)
 
         # ── Control (no-op) case: bake-size disk must boot clean, no grow. ──
         info("D2 control: launching at the exact bake size (no resize)...")
-        self.launch("xpf-image-d2")
-        self.wait_xpfd("xpf-image-d2")
+        self.launch(d2)
+        self.wait_xpfd(d2)
         # The grow ran (one-shot fired) but was a no-op: growpart NOCHANGE +
         # resize2fs no-op. The stamp is written either way (clean exit), and
         # the box boots clean with the dataplane gate green.
-        if guest("xpf-image-d2", "test", "-e", "/etc/xpf/.root-grown",
+        if guest(d2, "test", "-e", "/etc/xpf/.root-grown",
                  check=False).returncode != 0:
             fail("root-grow stamp missing on the control (no-op) boot")
-        if not guest_sh("xpf-image-d2",
+        if not guest_sh(d2,
                         'journalctl -u xpf-grow-root -b --no-pager | '
                         'grep -qiE "NOCHANGE|done"'):
             fail("control boot: xpf-grow-root did not log a no-op grow")
-        if guest("xpf-image-d2", "nice", "-n", "19", "/usr/local/sbin/xpfd",
+        if guest(d2, "nice", "-n", "19", "/usr/local/sbin/xpfd",
                  "verify-dataplane", check=False).returncode != 0:
             fail("verify-dataplane REJECTED on the control boot")
         info("D2 PASS (clean boot, grow was a no-op at bake size)")
-        self.drop("xpf-image-d2")
+        self.drop(d2)
         info("Scenario D PASS")
 
     def scenario_e(self):
         info("── Scenario E: cluster node-id day-0 drive (#4209 H-9) ──")
+        e = self.iname("e")   # run-namespaced instance name (#4905-D)
         conf = os.path.join(self.work, "day0-node1.conf")
         with open(conf, "w") as f:
             f.write("system {\n    host-name xpf-node1;\n}\n"
@@ -512,13 +564,13 @@ class Harness:
             conf, os.path.join(self.work, "day0-node1.iso"), node_id=1,
             validate=False)
         # Two extra NICs so the namer has em0 (idx 1) and ge-7/0/0 (idx 2).
-        self.launch("xpf-image-e", iso, extra_nics=2)
-        self.wait_xpfd("xpf-image-e")
-        if guest("xpf-image-e", "test", "-e", "/etc/xpf/.day0-config-applied",
+        self.launch(e, iso, extra_nics=2)
+        self.wait_xpfd(e)
+        if guest(e, "test", "-e", "/etc/xpf/.day0-config-applied",
                  check=False).returncode != 0:
             fail("node-id drive: day-0 stamp missing")
         # node-id persisted verbatim.
-        nid = guest("xpf-image-e", "sh", "-c",
+        nid = guest(e, "sh", "-c",
                     "cat /etc/xpf/node-id 2>/dev/null",
                     capture=True).stdout.strip()
         if nid != "1":
@@ -526,14 +578,14 @@ class Harness:
                  "persisted from the day-0 drive")
         # Cluster-mode naming: node 1 uses FPC 7. em0 is assigned only in
         # cluster mode (position 2); ge-7/0/0 proves the node-1 FPC branch.
-        if not guest_sh("xpf-image-e", 'ip link show em0 >/dev/null 2>&1'):
+        if not guest_sh(e, 'ip link show em0 >/dev/null 2>&1'):
             fail("em0 not present — daemon did not enter cluster naming mode "
                  "for a node-id-present image")
-        if not guest_sh("xpf-image-e", 'ip link show ge-7/0/0 >/dev/null 2>&1'):
+        if not guest_sh(e, 'ip link show ge-7/0/0 >/dev/null 2>&1'):
             fail("ge-7/0/0 not present — node-1 FPC-7 positional naming did not "
                  "run (a node-0 image would name it ge-0/0/0)")
         info("Scenario E PASS (node-id=1 persisted, cluster em0 + ge-7/0/N naming)")
-        self.drop("xpf-image-e")
+        self.drop(e)
 
     def scenario_qemu(self):
         info("── Scenario Q: libvirt/plain-QEMU bootability (#4209 H-9) ──")


### PR DESCRIPTION
Fixes four filesystem-safety / observability defects in the deploy + image
orchestration tooling (`scripts/deploy/xpf-deploy.py`, `scripts/image/`).
Tooling-only — no runtime packet path, no lab/cluster needed.

Closes #4905

## A — transient status failure misread as a reboot → skipped HA rejoin
The kernel-roll poll set `rebooted=True` on ANY empty `uname -r`, but the
node-exec wrapper discarded exit status/stderr, so an SSH/incus drop or
control-socket contention was indistinguishable from a reboot. One blip made a
still-drained-and-running node (e.g. an `arm` that failed its UEFI/NVRAM
preflight WITHOUT rebooting) look like a finished revert; the `finally` skipped
its rejoin and left the node **DRAINED + ForceSecondary with both leases
released** — silent redundancy loss.

Fix: `_node_exec` now delegates to a structured `NodeExecResult` (rc + stdout +
stderr + `ok`) without breaking the stdout-only callers; the poll records the
pre-arm `boot_id` and confirms a reboot ONLY from an affirmative signal (a
CHANGED boot_id, or the candidate kernel running) via the pure
`_reboot_confirmed()` predicate. An un-ok read is retried; rejoin is decided
from the confirmed drain state.

## B — unvalidated name/image identifiers escape the managed dirs
`name`/`image` are interpolated into paths the tool WRITES and REMOVES (often
via sudo): the day-0 ISO in CWD, and the per-VM overlay + shared golden qcow2
under `/var/lib/libvirt/images`. `../../../../tmp/owned` → `/tmp/owned.qcow2`.

Fix: `validate_identifier()` rejects separators / `..` / absolute / leading-dash
/ shell metacharacters (single safe component); `contained_join()` enforces
`commonpath` containment at every sink (`day0_iso_path` / `libvirt_overlay_path`
/ `libvirt_golden_path`) used by deploy/destroy/fetch. `validate_appliance`
fails closed at load; the `--image` CLI override is validated too.

## C — config-drive ISO left world-readable (credential disclosure)
`scripts/image/make_config_drive.py` created the day-0 ISO (password hashes, IKE
PSKs, SNMP communities, DDNS tokens) under the process umask (~0644) with no
chmod; the deploy builder already applied 0600. Fix: chmod the staged xpf.conf
and the finished ISO 0600, matching the deploy path.

## D — image validation force-deleted fixed Incus aliases/instances
`scripts/image/validate.py` force-deleted the constant alias
`xpf-image-validate` and instances `xpf-image-a..e` with no run-ID/ownership
check — a concurrent bake or an unrelated same-named VM/image was destroyed.
Fix: namespace the alias + every instance with a process-unique run-ID, tag each
created instance `user.xpf-owner=<run>`, and gate every teardown on that tag
(`_owned_delete` refuses any object this run did not create; cleanup deletes
only the alias it imported).

## Validation
New hermetic unittests (auto-discovered by `scripts/run-selftests.sh`), one per
defect, each **RED-on-revert** (reverting the fix in isolation flips its test):

| Defect | Test | RED-on-revert |
|---|---|---|
| A | `scripts/deploy/test_xpf_deploy_kernel_roll.py` | restore `if not running: rebooted=True` → transient blip forges a reboot, roll dies `REVERTED`, no rejoin → **RED** |
| B | `scripts/deploy/test_xpf_deploy_pathsafety.py` | drop `validate_identifier`/`contained_join` at sinks → traversal names accepted → **RED** |
| C | `scripts/image/test_make_config_drive_mode.py` | restore 0644 staging + drop ISO chmod → ISO comes back 0644 → **RED** |
| D | `scripts/image/test_validate_ownership.py` | restore unconditional `incus delete -f` → foreign-tagged instance deleted → **RED** |

All four RED-on-revert transitions verified programmatically.

```
make selftest        → passed=33  skipped=0  failed=0
make test-deploy-lib → 19 passed, 0 failed
py_compile           → clean on all touched files
```

Docs updated: `docs/in-place-upgrade.md` (A), `docs/deploy-quickstart.md` (B, C),
`docs/image-validation.md` (D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)