### PR TITLE
snmp: derive per-device-unique SNMPv3 EngineID (#5283)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-07-10 — #5283 SNMPv3 EngineID per-device uniqueness (cross-clone USM auth-bypass fix)
+- **Timestamp**: 2026-07-10 (fix/5283-snmp-engineid-unique)
+- **Action**: Fix #5283 cross-device USM auth bypass. buildEngineID/initEngine
+  derived the ENTIRE SNMPv3 EngineID from a fixed prefix + os.Hostname() with NO
+  per-device component, so two same-hostname CLONES (HA pair, factory default,
+  lab image, config restore) derived byte-identical EngineIDs → byte-identical
+  localized USM keys (USM localizes auth/priv keys against the EngineID) → an
+  authenticated SNMPv3 GET captured from firewall A was ACCEPTED by firewall B
+  (#4917/#5264 only capped the LENGTH, not uniqueness). Now buildEngineID folds a
+  per-device unique component into a mandatory 32-octet hash:
+  `prefix(5) || 0x05 || sha256(deviceID || 0x00 || hostname)[:26]`. deviceID =
+  a 16-byte crypto/rand value persisted ONCE at /var/lib/xpf/snmp-engine-id (hex,
+  0600, atomic; stable across reboots, unique per appliance) COMBINED with
+  /etc/machine-id (virt-sysprep resets it per-appliance at bake) as defense in
+  depth, so a clone must defeat BOTH to collide. All-sources-failed degrades to
+  hostname-only with a slog.Warn. Length cap (5..32) preserved for every input.
+  New NewAgentWithPaths(cfg, bootsPath, engineIDPath) seam; daemon passes
+  d.snmpEngineIDPath. bake.py virt-sysprep now strips snmp-engine-id +
+  snmp-engineboots so the golden image never ships an identical per-device
+  identity. Transition: EngineID changes ONCE on upgrade (hostname→device-unique);
+  managers re-discover (one-time, acceptable for a security fix); engineBoots
+  monotonicity unaffected (keyed by its own file). RED-on-revert proven: reverting
+  buildEngineID to hostname-only makes TestEngineID_CloneUniqueness +
+  TestEngineID_USMKeysDivergeAcrossClones collide (identical EngineID + identical
+  localized auth keys). Replay-window destination-IP binding noted as
+  out-of-scope defense-in-depth follow-up. Full pkg/snmp + pkg/daemon suites green.
+- **File(s)**: pkg/snmp/agent.go, pkg/snmp/engineid_5283_test.go,
+  pkg/snmp/engineid_4917_test.go, pkg/snmp/agent_test.go, pkg/snmp/README.md,
+  pkg/daemon/daemon.go, pkg/daemon/daemon_snmp_reconcile.go,
+  pkg/daemon/daemon_snmp_reconcile_test.go, scripts/image/bake.py, _Log.md
+
 ## 2026-07-10 — pkg/api,pkg/routing: render reject route disposition (#5410)
 
 - **Timestamp**: 2026-07-10 (fix/5410-reject-route-display)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -294,15 +294,19 @@ type Daemon struct {
 	// privileged socket (#3967, #5110).
 	snmpServe func(ctx context.Context, agent *snmp.Agent, ready chan<- error)
 	// snmpBootsPath overrides the SNMPv3 engineBoots persistence path passed
-	// to snmp.NewAgentWithBootsPath. Empty ⇒ the package default. Tests inject
+	// to snmp.NewAgentWithPaths. Empty ⇒ the package default. Tests inject
 	// a temp path so a reconcile-triggered start does not touch /var/lib/xpf
 	// (#3967).
-	snmpBootsPath   string
-	lldpMgr         *lldp.Manager
-	lldpApplied     *lldp.LLDPConfig // last effective LLDP config Apply()'d (#2372 diff-guard); nil = stopped
-	lldpApplyInit   bool             // true once reconcileLLDP has run at least once
-	scheduler       *scheduler.Scheduler
-	schedulerCancel context.CancelFunc
+	snmpBootsPath string
+	// snmpEngineIDPath overrides the per-device EngineID component persistence
+	// path (#5283). Empty ⇒ the package default. Tests inject a temp path so a
+	// reconcile-triggered start does not touch /var/lib/xpf.
+	snmpEngineIDPath string
+	lldpMgr          *lldp.Manager
+	lldpApplied      *lldp.LLDPConfig // last effective LLDP config Apply()'d (#2372 diff-guard); nil = stopped
+	lldpApplyInit    bool             // true once reconcileLLDP has run at least once
+	scheduler        *scheduler.Scheduler
+	schedulerCancel  context.CancelFunc
 	// schedulerWg tracks every policy-scheduler Run() goroutine generation so
 	// daemon shutdown can join it after cancelling, and schedulerStopped
 	// latches on shutdown so no new generation is started after the join

--- a/pkg/daemon/daemon_snmp_reconcile.go
+++ b/pkg/daemon/daemon_snmp_reconcile.go
@@ -363,7 +363,7 @@ func (d *Daemon) reconcileSNMP(cfg *config.Config) bool {
 // recorded "applied", no-oping every subsequent identical commit.
 func (d *Daemon) startSNMPLocked(cfg *config.Config) error {
 	ctx, cancel := context.WithCancel(d.daemonCtx)
-	agent := snmp.NewAgentWithBootsPath(cfg.System.SNMP, d.snmpBootsPath)
+	agent := snmp.NewAgentWithPaths(cfg.System.SNMP, d.snmpBootsPath, d.snmpEngineIDPath)
 	agent.SetIfDataFn(buildSNMPIfData)
 
 	// The serve seam binds UDP/161 and then serves for the lifetime of ctx. It

--- a/pkg/daemon/daemon_snmp_reconcile_test.go
+++ b/pkg/daemon/daemon_snmp_reconcile_test.go
@@ -164,15 +164,16 @@ func newSNMPReconcileDaemon(t *testing.T, serve func(context.Context, *snmp.Agen
 	t.Helper()
 	installFakeNetworkctl(t)
 	d := &Daemon{
-		applySem:      semaphore.NewWeighted(1),
-		dp:            &runtimeOnlyApplyTestDP{},
-		vrrpMgr:       vrrp.NewManager(),
-		store:         newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
-		opts:          Options{NoDataplane: true},
-		daemonCtx:     context.Background(),
-		snmpBootReady: true,
-		snmpServe:     serve,
-		snmpBootsPath: filepath.Join(t.TempDir(), "engineboots"),
+		applySem:         semaphore.NewWeighted(1),
+		dp:               &runtimeOnlyApplyTestDP{},
+		vrrpMgr:          vrrp.NewManager(),
+		store:            newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		opts:             Options{NoDataplane: true},
+		daemonCtx:        context.Background(),
+		snmpBootReady:    true,
+		snmpServe:        serve,
+		snmpBootsPath:    filepath.Join(t.TempDir(), "engineboots"),
+		snmpEngineIDPath: filepath.Join(t.TempDir(), "snmp-engine-id"),
 		// Keep the link-state monitor hermetic: return an established
 		// subscription that streams nothing and exits on ctx cancel, and an
 		// empty link list for the boot seed.

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -224,38 +224,78 @@ requires of an authoritative engine:
 
 ### Authoritative EngineID derivation (RFC 3411 §5)
 
-`initEngine` derives the authoritative SNMPv3 `snmpEngineID` from the OS
-hostname via `buildEngineID`. RFC 3411 constrains `SnmpEngineID` to **5..32
-octets**; an EngineID outside that range is rejected by compliant managers,
-which breaks every v3 discovery, USM key localization, auth check, and response
-encoding that keys off the agent's identity (v2c is unaffected). The EngineID
-must also be **deterministic and stable across restarts** — a manager caches
-`(engineBoots, engineTime)` and localizes its USM keys against it.
+`initEngine` derives the authoritative SNMPv3 `snmpEngineID` from the OS hostname
+**and a per-device unique component** via `buildEngineID`. RFC 3411 constrains
+`SnmpEngineID` to **5..32 octets** AND requires it to be **unique** per
+authoritative engine (unique, not secret). Both properties matter:
 
-The layout is a 5-octet enterprise prefix (`0x80 0x00 0x01 0x86 0xa3` — the
-variable-length format flag over private enterprise `0x000186a3`) + a one-octet
-format selector + a payload:
+- **Length (5..32 octets)** — an EngineID outside the range is rejected by
+  compliant managers, breaking every v3 discovery, USM key localization, auth
+  check, and response encoding that keys off the agent's identity (v2c is
+  unaffected). This is the #4917/#5264 cap.
+- **Uniqueness (per-device)** — USM localizes each user's auth/priv keys against
+  the EngineID, so two engines with the **same** EngineID derive **byte-identical
+  localized keys**. An authenticated SNMPv3 request captured from firewall A is
+  then accepted by firewall B (same username/password): cross-device telemetry
+  disclosure / auth bypass (**#5283**).
 
-- **Short hostname** (`len(hostname) <= 26`, so header + hostname `<= 32`):
-  the text form `prefix || 0x04 || hostname`, where `0x04` is RFC 3411
-  "administratively assigned text". This is **bit-identical to the pre-#4917
-  construction**, so every already-deployed appliance keeps the exact EngineID
-  its USM keys and manager caches were localized against — the migration is a
-  no-op on the short path.
-- **Long hostname** (`> 26` octets): the text form would exceed 32 octets and
-  be an **invalid EngineID** (the #4917 bug — the historical code appended the
-  full unbounded hostname). It is replaced by a deterministic hashed identity
-  `prefix || 0x05 || sha256(hostname)[:26]`, exactly 32 octets. `0x05`
-  ("administratively assigned octets") honestly labels the binary hash payload
-  (`0x04` would mislabel it as text). SHA-256 over the **full** hostname keeps
-  it deterministic (same hostname → same EngineID every boot; no randomness, no
-  timestamp) and collision-resistant (distinct long hostnames → distinct
-  EngineIDs). A one-time `slog.Info` at init records the substitution so the
-  operator sees why the EngineID is not the plain hostname.
+The historical construction derived the entire EngineID from a fixed prefix +
+`os.Hostname()` only. It had no per-device component, so two same-hostname
+**clones** (HA pair, factory default, lab image, config restore) derived
+identical EngineIDs and identical USM keys — #4917/#5264 only capped the length,
+they did not add uniqueness.
 
-The result is 5..32 octets for every input, including the empty hostname
-(6 octets) and multi-kilobyte hostnames (32 octets). Golden-vector and
-RED-on-revert coverage lives in `engineid_4917_test.go`.
+**Construction (always 32 octets):**
+
+```
+prefix(5) || 0x05 || sha256(deviceID || 0x00 || hostname)[:26]
+```
+
+- `prefix` is the 5-octet enterprise header (`0x80 0x00 0x01 0x86 0xa3`).
+- `0x05` ("administratively assigned octets") honestly labels the binary SHA-256
+  payload.
+- The result is **exactly 32 octets for every input** (empty or multi-kilobyte
+  hostname alike), so the #4917/#5264 length cap always holds.
+- A `0x00` separator between `deviceID` and `hostname` prevents boundary-shift
+  aliasing.
+
+**Per-device component (`deviceComponent`)** combines two independent per-device
+sources so a clone must defeat BOTH to collide:
+
+1. **Persisted crypto/rand** — a 16-byte value generated ONCE and persisted at
+   `/var/lib/xpf/snmp-engine-id` (hex text, `0600`), reused on every subsequent
+   boot. This is the primary source: stable across reboots of the same device,
+   unique per appliance. On read-corruption / RNG / persist failure it is
+   regenerated or skipped (never an un-persisted value served as if stable).
+2. **`/etc/machine-id`** — folded in as defense in depth. `virt-sysprep` resets
+   machine-id per-appliance at image bake, so even a mistakenly-cloned
+   persisted file still yields a distinct component (different machine-id →
+   different EngineID).
+
+If **every** source fails (no persistable random AND no machine-id — the
+catastrophic path), the EngineID degrades to the pre-#5283 hostname-only
+identity and `initEngine` logs a `slog.Warn` that it is not clone-unique.
+
+**Clone/bake requirement:** the persisted `/var/lib/xpf/snmp-engine-id` file
+MUST NOT be copied identically into cloned appliances or a golden image — that
+would re-establish the collision. It is treated exactly like `/etc/machine-id`:
+`scripts/image/bake.py` removes it (and `snmp-engineboots`) during
+`virt-sysprep` so each appliance regenerates a fresh one on first boot. The
+machine-id fold-in is the backstop if that removal is ever missed.
+
+**Transition:** on an existing appliance upgrading, the EngineID changes ONCE
+(hostname-derived → device-unique). Existing SNMPv3 managers re-discover the
+EngineID on their next poll (a one-time, standard USM discovery — acceptable for
+a security fix). `(engineBoots, engineTime)` monotonicity is unaffected: the
+boots counter is keyed by its own persisted file, not by the EngineID bytes.
+
+**Follow-up (out of scope here):** binding the USM replay window to the
+destination IP is additional defense-in-depth; the unique EngineID alone closes
+the cross-clone bypass because A's localized keys no longer equal B's.
+
+RED-on-revert and length-cap coverage lives in `engineid_4917_test.go`; the
+per-device uniqueness / reboot-stability / USM-key-divergence coverage lives in
+`engineid_5283_test.go`.
 
 ## Live reconfigure (commit-time reconcile)
 

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -2,8 +2,10 @@ package snmp
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"net"
@@ -81,6 +83,35 @@ const (
 // longer validates (the boots value advanced). /var/lib/xpf is the persistent
 // runtime-state root shared with the other xpf subsystems.
 const defaultEngineBootsPath = "/var/lib/xpf/snmp-engineboots"
+
+// defaultEngineIDPath is the on-disk location of the persisted per-device random
+// EngineID component (#5283). A 16-byte crypto/rand value is generated ONCE on
+// first agent init and reused on every subsequent boot, so the derived SNMPv3
+// EngineID is stable across reboots of THE SAME appliance yet unique per
+// appliance. This closes the cross-clone USM auth bypass: without a per-device
+// component, two same-hostname clones (HA pair, factory-default, lab, restore)
+// derived byte-identical EngineIDs, hence byte-identical localized USM keys,
+// hence firewall B accepted an authenticated SNMPv3 request captured from A.
+//
+// IMPORTANT (clone/bake): this file MUST NOT be copied identically into cloned
+// appliances or a golden image — that would re-establish the collision it
+// exists to prevent. It is treated like /etc/machine-id: the image bake
+// (scripts/image/bake.py) removes it during virt-sysprep so each appliance
+// regenerates a fresh one on first boot, and /etc/machine-id is additionally
+// folded into the component (see deviceComponent) as defense in depth so even a
+// mistakenly-copied file still yields distinct EngineIDs across clones.
+const defaultEngineIDPath = "/var/lib/xpf/snmp-engine-id"
+
+// machineIDPath is the systemd per-device identity. virt-sysprep resets it
+// per-appliance at image bake, so it differs on every cloned appliance. It is
+// folded into the EngineID device component as defense in depth against a
+// mistakenly-cloned defaultEngineIDPath file.
+const machineIDPath = "/etc/machine-id"
+
+// deviceComponentLen is the size (octets) of the persisted per-device random
+// EngineID component. 128 bits is far beyond birthday-collision range for any
+// realistic appliance fleet.
+const deviceComponentLen = 16
 
 // tagCounter32 is the ASN.1 application tag for Counter32.
 const tagCounter32 = 0x41
@@ -175,6 +206,13 @@ type Agent struct {
 	// cycle. Set before initEngine runs (NewAgent / NewAgentWithBootsPath).
 	engineBootsPath string
 
+	// engineIDPath is the persistence seam for the per-device random EngineID
+	// component (#5283). Empty means defaultEngineIDPath; tests inject a temp
+	// file to drive the generate/persist/reuse cycle and to prove two agents
+	// with DIFFERENT persisted components derive DIFFERENT EngineIDs (the
+	// anti-clone property). Set before initEngine runs.
+	engineIDPath string
+
 	// cfgMu guards the live authorization/identity configuration (cfg) and
 	// the derived USM user table (v3Users). The request-serving goroutine
 	// reads both under RLock; UpdateConfig swaps both under Lock so a commit
@@ -254,23 +292,36 @@ const trapQueueDepth = 256
 // NewAgent creates a new SNMP agent with the given configuration. The
 // SNMPv3 engineBoots counter is loaded from defaultEngineBootsPath,
 // incremented, and persisted so (engineBoots, engineTime) advances
-// monotonically across daemon restarts (RFC 3414).
+// monotonically across daemon restarts (RFC 3414). The per-device EngineID
+// component is loaded/generated at defaultEngineIDPath (#5283).
 func NewAgent(cfg *config.SNMPConfig) *Agent {
-	return NewAgentWithBootsPath(cfg, defaultEngineBootsPath)
+	return NewAgentWithPaths(cfg, defaultEngineBootsPath, defaultEngineIDPath)
 }
 
 // NewAgentWithBootsPath is NewAgent with an explicit engineBoots persistence
-// path. It is the seam used by tests to drive the load/increment/persist
-// cycle against a temp file; production code uses NewAgent. An empty path
-// falls back to defaultEngineBootsPath.
+// path and the default per-device EngineID component path. Retained for
+// existing callers/tests that only need to redirect the boots counter.
 func NewAgentWithBootsPath(cfg *config.SNMPConfig, bootsPath string) *Agent {
+	return NewAgentWithPaths(cfg, bootsPath, defaultEngineIDPath)
+}
+
+// NewAgentWithPaths is NewAgent with explicit persistence paths for the
+// engineBoots counter and the per-device EngineID component. It is the seam
+// tests use to drive both the boots load/increment/persist cycle and the
+// EngineID component generate/persist/reuse cycle against temp files without
+// touching /var/lib/xpf. An empty path falls back to the respective default.
+func NewAgentWithPaths(cfg *config.SNMPConfig, bootsPath, engineIDPath string) *Agent {
 	if bootsPath == "" {
 		bootsPath = defaultEngineBootsPath
+	}
+	if engineIDPath == "" {
+		engineIDPath = defaultEngineIDPath
 	}
 	a := &Agent{
 		cfg:             cfg,
 		startTime:       time.Now(),
 		engineBootsPath: bootsPath,
+		engineIDPath:    engineIDPath,
 		trapSender:      sendTrap,
 	}
 	a.initEngine()
@@ -325,69 +376,68 @@ func (a *Agent) hasV3Users() bool {
 
 // SNMPv3 authoritative EngineID construction (RFC 3411 §5).
 //
-// RFC 3411 constrains SnmpEngineID to 5..32 octets. An EngineID outside that
-// range is rejected by standards-compliant managers, which breaks every
-// SNMPv3 discovery, USM key localization, auth check, and response encoding
-// that depends on the agent's identity (v2c is unaffected). The historical
-// construction (a 6-octet header followed by the FULL, unbounded OS hostname)
-// silently produced an INVALID >32-octet EngineID for any hostname longer than
-// 26 bytes (#4917).
+// RFC 3411 constrains SnmpEngineID to 5..32 octets AND requires it to be UNIQUE
+// per authoritative engine (unique, not secret). An EngineID outside the length
+// range is rejected by standards-compliant managers; a NON-unique EngineID is a
+// security hole, because USM localizes each user's auth/priv keys against it —
+// two engines with the same EngineID derive byte-identical localized keys, so an
+// authenticated SNMPv3 request captured from one is accepted by the other
+// (cross-device telemetry disclosure / auth bypass, #5283).
+//
+// The historical construction derived the ENTIRE EngineID from a fixed prefix +
+// os.Hostname() (short: prefix||hostname; long: sha256(hostname)[:26]). It had
+// no per-device component, so two same-hostname CLONES (HA pair, factory
+// default, lab image, config restore) derived IDENTICAL EngineIDs and hence
+// identical USM keys (#4917/#5264 only capped the length, they did not add
+// uniqueness). The construction now folds a per-device unique component (a
+// persisted crypto/rand value + /etc/machine-id, see deviceComponent) into the
+// hash so clones diverge, while staying inside the 5..32-octet cap.
 const (
 	// snmpEngineIDMaxLen is the RFC 3411 SnmpEngineID upper bound (octets).
 	snmpEngineIDMaxLen = 32
 
-	// engineIDFormatText (RFC 3411 §5, format 3 "administratively assigned
-	// text") labels the payload as TEXT. Kept for the short-hostname form so
-	// the EngineID stays bit-identical to the pre-#4917 construction and
-	// already-localized USM keys / manager caches on deployed appliances
-	// remain valid.
-	engineIDFormatText = 0x04
-
 	// engineIDFormatOctets (RFC 3411 §5, format 4 "administratively assigned
-	// octets") labels the payload as OCTETS. Used for the hashed long-hostname
-	// form so the format octet honestly describes a binary (non-text) SHA-256
-	// payload — 0x04 would mislabel the hash as text.
+	// octets") labels the payload as OCTETS — a binary (non-text) SHA-256
+	// digest. 0x04 (text) would mislabel the hash as text.
 	engineIDFormatOctets = 0x05
 )
 
 // engineIDPrefix is the 5-octet enterprise header: the RFC 3411 variable-length
 // format flag (high bit 0x80 set on the first octet) over private enterprise
-// number 0x000186a3. The sixth octet — the format selector — is appended per
-// form (text vs octets) by buildEngineID. Read-only after init; buildEngineID
-// copies it (append from a fresh backing array) and never mutates it.
+// number 0x000186a3. The sixth octet — the format selector — is appended by
+// buildEngineID. Read-only after init; buildEngineID copies it (append from a
+// fresh backing array) and never mutates it.
 var engineIDPrefix = []byte{0x80, 0x00, 0x01, 0x86, 0xa3}
 
-// buildEngineID derives a deterministic, RFC 3411-valid (5..32 octet)
-// authoritative SNMPv3 EngineID from the OS hostname. The EngineID must be
-// stable across restarts because a manager caches our (engineBoots, engineTime)
-// and localizes its USM keys against it.
+// buildEngineID derives the authoritative SNMPv3 EngineID from the OS hostname
+// AND a per-device unique component (#5283). The EngineID must be:
 //
-//   - Short hostname (header + hostname <= 32 octets, i.e. len(hostname) <= 26):
-//     the historical TEXT form engineIDPrefix || 0x04 || hostname, returned
-//     BIT-IDENTICAL to the pre-#4917 construction. This is the migration guard:
-//     every currently-working appliance keeps the exact EngineID it localized
-//     its keys against, so no manager cache or USM key is invalidated.
-//   - Long hostname (> 26 octets): the text form would exceed 32 octets and be
-//     an INVALID EngineID (rejected by compliant managers — the #4917 bug). It
-//     is replaced by a deterministic hashed identity engineIDPrefix || 0x05 ||
-//     sha256(hostname)[:26], exactly 32 octets. SHA-256 over the FULL hostname
-//     is deterministic (same hostname -> same EngineID every boot, no
-//     randomness/timestamp) and collision-resistant (distinct long hostnames ->
-//     distinct EngineIDs). The 0x05 (octets) format honestly labels the binary
-//     payload.
+//   - RFC 3411-valid (5..32 octets): the result is ALWAYS exactly 32 octets —
+//     engineIDPrefix(5) || 0x05 (octets) || sha256(deviceID || 0x00 || hostname)[:26]
+//     — so the #4917/#5264 length cap holds for every input, empty or
+//     multi-kilobyte hostname alike.
+//   - stable across restarts of the SAME device: SHA-256 over a fixed
+//     (deviceID, hostname) pair is deterministic (no randomness/timestamp at
+//     build time — the randomness lives in the PERSISTED deviceID), so a manager
+//     that cached our (engineBoots, engineTime) and localized its keys keeps
+//     working over a restart.
+//   - UNIQUE per device: deviceID is a per-appliance value (persisted random +
+//     machine-id). Two clones with the same hostname derive DIFFERENT deviceIDs,
+//     hence different EngineIDs, hence different localized USM keys — A's
+//     authenticated packet no longer validates against B (the #5283 bypass is
+//     closed). A 0x00 separator between deviceID and hostname prevents any
+//     boundary-shift aliasing.
 //
-// The result is 5..32 octets for ALL inputs, including empty (6 octets) and
-// multi-kilobyte (32 octets) hostnames.
-func buildEngineID(hostname string) []byte {
-	headerLen := len(engineIDPrefix) + 1 // enterprise prefix + one format octet
-	if len(hostname) <= snmpEngineIDMaxLen-headerLen {
-		id := make([]byte, 0, headerLen+len(hostname))
-		id = append(id, engineIDPrefix...)
-		id = append(id, engineIDFormatText)
-		id = append(id, hostname...)
-		return id
-	}
-	sum := sha256.Sum256([]byte(hostname))
+// A nil/empty deviceID (only the catastrophic all-sources-failed path) degrades
+// to the pre-#5283 hostname-only identity — deterministic but NOT clone-unique;
+// initEngine logs that case.
+func buildEngineID(hostname string, deviceID []byte) []byte {
+	h := sha256.New()
+	h.Write(deviceID)
+	h.Write([]byte{0x00}) // domain separator: deviceID | hostname
+	h.Write([]byte(hostname))
+	sum := h.Sum(nil)
+	headerLen := len(engineIDPrefix) + 1      // enterprise prefix + one format octet
 	hashLen := snmpEngineIDMaxLen - headerLen // 26 -> total exactly 32 octets
 	id := make([]byte, 0, snmpEngineIDMaxLen)
 	id = append(id, engineIDPrefix...)
@@ -396,26 +446,103 @@ func buildEngineID(hostname string) []byte {
 	return id
 }
 
-// initEngine generates a deterministic, RFC 3411-bounded engine ID from the
-// hostname (see buildEngineID). A hostname longer than 26 octets no longer
-// yields an invalid >32-octet EngineID (#4917); the hashed identity is used
-// instead, and the substitution is logged once so the operator sees why the
-// EngineID is not the plain hostname.
+// initEngine derives the RFC 3411-bounded, per-device-unique engine ID from the
+// hostname and the per-device component (see buildEngineID / deviceComponent),
+// then loads/increments the engineBoots counter.
 func (a *Agent) initEngine() {
 	hostname, _ := os.Hostname()
 	if hostname == "" {
 		hostname = "xpf"
 	}
-	a.engineID = buildEngineID(hostname)
-	if len(hostname) > snmpEngineIDMaxLen-(len(engineIDPrefix)+1) {
-		// One-time state event (allowed by the logging rules — not in a loop):
-		// the text EngineID would exceed the RFC 3411 32-octet cap, so a stable
-		// hashed identity is used. This is the startup signal the #4917 issue
-		// noted was missing.
-		slog.Info("SNMP: hostname exceeds the RFC 3411 32-octet text EngineID cap; using a stable hashed SNMPv3 EngineID",
-			"hostname_len", len(hostname), "engineid_len", len(a.engineID))
+	deviceID := a.deviceComponent()
+	if len(deviceID) == 0 {
+		// One-time state event (not in a loop): every per-device identity source
+		// failed, so the EngineID falls back to hostname-only and is NOT unique
+		// across same-hostname clones. Surface it so the operator can provision
+		// persistent state / a machine-id.
+		slog.Warn("SNMP: no per-device EngineID component available; EngineID is derived from hostname only and is NOT unique across clones",
+			"engineid_path", a.engineIDPath)
 	}
+	a.engineID = buildEngineID(hostname, deviceID)
 	a.engineBoots = a.loadAndIncrementEngineBoots()
+}
+
+// deviceComponent returns the per-device unique EngineID component (#5283).
+//
+// It combines two independent per-device sources so a clone must defeat BOTH to
+// collide:
+//
+//  1. a 16-byte crypto/rand value persisted at a.engineIDPath, generated ONCE
+//     and reused on every boot (primary — stable per device, unique per
+//     appliance);
+//  2. /etc/machine-id, which virt-sysprep resets per-appliance at image bake
+//     (defense in depth — even a mistakenly-cloned persisted file yields a
+//     distinct component because machine-id differs).
+//
+// The returned slice is empty ONLY when the persisted random cannot be created
+// AND no machine-id exists — the catastrophic path initEngine logs.
+func (a *Agent) deviceComponent() []byte {
+	var comp []byte
+	if rnd := a.loadOrCreatePersistedComponent(); len(rnd) > 0 {
+		comp = append(comp, rnd...)
+	}
+	if mid := readMachineID(); len(mid) > 0 {
+		comp = append(comp, mid...)
+	}
+	return comp
+}
+
+// loadOrCreatePersistedComponent returns the persisted per-device random
+// component, generating and durably persisting it (0600) on first use. It
+// returns the component only when it is durably on disk (stable across
+// reboots); on any read-corruption, RNG, or persist failure it returns nil so
+// deviceComponent falls back to /etc/machine-id rather than serving an
+// un-persisted value that would change every boot (churning manager caches).
+func (a *Agent) loadOrCreatePersistedComponent() []byte {
+	path := a.engineIDPath
+	if path == "" {
+		path = defaultEngineIDPath
+	}
+	// Reuse an existing component -> stable EngineID across reboots.
+	if data, err := os.ReadFile(path); err == nil {
+		if b, derr := hex.DecodeString(strings.TrimSpace(string(data))); derr == nil && len(b) == deviceComponentLen {
+			return b
+		}
+		slog.Warn("SNMP: persisted EngineID component malformed, regenerating", "path", path)
+	} else if !os.IsNotExist(err) {
+		slog.Warn("SNMP: EngineID component read error, regenerating", "path", path, "err", err)
+	}
+	// Generate once, persist atomically with 0600 (need not be secret, but keep
+	// it consistent and not world-readable).
+	buf := make([]byte, deviceComponentLen)
+	if _, err := rand.Read(buf); err != nil {
+		slog.Warn("SNMP: EngineID component RNG failed, falling back to machine-id", "err", err)
+		return nil
+	}
+	encoded := []byte(hex.EncodeToString(buf) + "\n")
+	if err := fsatomic.MkdirAllDurable(filepath.Dir(path), 0o755); err != nil {
+		slog.Warn("SNMP: EngineID component dir create failed, falling back to machine-id", "path", path, "err", err)
+		return nil
+	}
+	if err := fsatomic.WriteFileDurable(path, encoded, 0o600); err != nil {
+		slog.Warn("SNMP: EngineID component persist failed, falling back to machine-id", "path", path, "err", err)
+		return nil
+	}
+	return buf
+}
+
+// readMachineID reads /etc/machine-id and decodes it to raw bytes. An empty
+// (uninitialized first-boot) or unparseable value is treated as absent (nil).
+func readMachineID() []byte {
+	data, err := os.ReadFile(machineIDPath)
+	if err != nil {
+		return nil
+	}
+	b, err := hex.DecodeString(strings.TrimSpace(string(data)))
+	if err != nil || len(b) == 0 {
+		return nil
+	}
+	return b
 }
 
 // loadAndIncrementEngineBoots reads the persisted engineBoots counter, returns

--- a/pkg/snmp/agent_test.go
+++ b/pkg/snmp/agent_test.go
@@ -3,6 +3,7 @@ package snmp
 import (
 	"crypto/md5"
 	"crypto/sha1"
+	"path/filepath"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -642,16 +643,20 @@ func TestV3UserDisplay(t *testing.T) {
 }
 
 func TestEngineIDGeneration(t *testing.T) {
-	a := NewAgent(&config.SNMPConfig{})
+	// #5283: the EngineID is now always the 32-octet hashed form
+	// prefix(5) || 0x05 || sha256(deviceID || 0x00 || hostname)[:26]. Use a
+	// tempdir persistence path so the test does not touch /var/lib/xpf.
+	a := newAgentWithEngineIDPath(t, &config.SNMPConfig{}, filepath.Join(t.TempDir(), "dev"))
 	if a.engineID == nil {
 		t.Fatal("engineID is nil")
 	}
-	if len(a.engineID) < 6 {
-		t.Errorf("engineID too short: %d bytes", len(a.engineID))
+	if len(a.engineID) != snmpEngineIDMaxLen {
+		t.Errorf("engineID length = %d, want %d", len(a.engineID), snmpEngineIDMaxLen)
 	}
-	// First 5 bytes should be fixed prefix, 6th byte should be 0x04 (text format).
-	if a.engineID[5] != 0x04 {
-		t.Errorf("engineID format byte = %d, want 4", a.engineID[5])
+	// First 5 bytes are the fixed enterprise prefix; the 6th byte is the octets
+	// format selector 0x05 (the binary SHA-256 payload).
+	if a.engineID[5] != engineIDFormatOctets {
+		t.Errorf("engineID format byte = %d, want %d (octets)", a.engineID[5], engineIDFormatOctets)
 	}
 }
 

--- a/pkg/snmp/engineid_4917_test.go
+++ b/pkg/snmp/engineid_4917_test.go
@@ -7,109 +7,87 @@ import (
 	"testing"
 )
 
-// TestBuildEngineID_GoldenShortHost pins the EXACT byte sequence a short
-// (<=26 octet) hostname must produce: the historical text form
-// prefix(5) || 0x04 || hostname. This is the #4917 migration guard — it goes
-// RED if the short path is ever changed, because changing it would invalidate
-// every already-localized USM key and manager cache on deployed appliances.
-func TestBuildEngineID_GoldenShortHost(t *testing.T) {
-	const host = "fw1.example.net" // 15 octets, well under the 26-octet cap
-	want := []byte{
-		0x80, 0x00, 0x01, 0x86, 0xa3, // enterprise prefix
-		0x04, // format: administratively assigned text
-		'f', 'w', '1', '.', 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'n', 'e', 't',
-	}
-	got := buildEngineID(host)
-	if !bytes.Equal(got, want) {
-		t.Fatalf("buildEngineID(%q) = % x, want % x", host, got, want)
-	}
-	if len(got) < 5 || len(got) > snmpEngineIDMaxLen {
-		t.Fatalf("golden EngineID length %d out of RFC 3411 range 5..32", len(got))
-	}
+// #4917/#5264 are the RFC 3411 length-cap guards. #5283 changed the EngineID
+// construction to fold a per-device component into a mandatory SHA-256 hash, so
+// the historical short-hostname TEXT form no longer exists (every EngineID is
+// now the 32-octet hashed form). These tests keep the length-cap RED-on-revert
+// intent: whatever the construction, the result must stay within 5..32 octets
+// for ALL hostnames, empty or multi-kilobyte.
+
+// engineHash mirrors buildEngineID's payload for assertions:
+// prefix(5) || 0x05 || sha256(deviceID || 0x00 || hostname)[:26].
+func engineHash(deviceID []byte, hostname string) []byte {
+	h := sha256.New()
+	h.Write(deviceID)
+	h.Write([]byte{0x00})
+	h.Write([]byte(hostname))
+	sum := h.Sum(nil)
+	want := append(append([]byte{}, engineIDPrefix...), engineIDFormatOctets)
+	return append(want, sum[:snmpEngineIDMaxLen-6]...)
 }
 
-// TestBuildEngineID_Boundary26 verifies the largest hostname that still fits
-// the text form: 26 octets -> header(6) + 26 = 32 octets, still 0x04 text form.
-func TestBuildEngineID_Boundary26(t *testing.T) {
-	host := strings.Repeat("a", 26)
-	got := buildEngineID(host)
+// TestBuildEngineID_AlwaysHashed32 verifies the new (#5283) construction: every
+// EngineID is exactly 32 octets — prefix(5) || 0x05 || sha256(...)[:26] — for a
+// short hostname, so the length cap holds and the format octet honestly labels
+// the binary digest.
+func TestBuildEngineID_AlwaysHashed32(t *testing.T) {
+	const host = "fw1.example.net" // 15 octets, would have been the text form pre-#5283
+	dev := []byte{0xaa, 0xbb, 0xcc, 0xdd}
+	got := buildEngineID(host, dev)
 	if len(got) != snmpEngineIDMaxLen {
-		t.Fatalf("26-octet hostname: EngineID length %d, want %d", len(got), snmpEngineIDMaxLen)
+		t.Fatalf("EngineID length %d, want exactly %d", len(got), snmpEngineIDMaxLen)
 	}
-	if got[5] != engineIDFormatText {
-		t.Fatalf("26-octet hostname: format octet 0x%02x, want text 0x%02x", got[5], engineIDFormatText)
+	if !bytes.Equal(got[:5], engineIDPrefix) {
+		t.Fatalf("prefix % x, want % x", got[:5], engineIDPrefix)
 	}
-	// Still the plain-text form: prefix || 0x04 || hostname.
-	want := append(append(append([]byte{}, engineIDPrefix...), engineIDFormatText), []byte(host)...)
-	if !bytes.Equal(got, want) {
-		t.Fatalf("26-octet hostname: EngineID % x, want text form % x", got, want)
+	if got[5] != engineIDFormatOctets {
+		t.Fatalf("format octet 0x%02x, want octets 0x%02x", got[5], engineIDFormatOctets)
+	}
+	if !bytes.Equal(got, engineHash(dev, host)) {
+		t.Fatalf("EngineID % x != expected hashed form % x", got, engineHash(dev, host))
 	}
 }
 
-// TestBuildEngineID_HashedLongHosts covers every >26-octet case. These
-// assertions go RED if buildEngineID is reverted to the unbounded
-// `prefix(6) || hostname` append: a 27-octet hostname then yields 33 octets and
-// the len <= 32 check below fails; a 64-octet hostname yields 70 octets, etc.
-func TestBuildEngineID_HashedLongHosts(t *testing.T) {
-	for _, n := range []int{27, 64, 300, 4096} {
+// TestBuildEngineID_LengthCapAllHosts covers empty, boundary, and long
+// hostnames. This is the #4917/#5264 RED-on-revert assertion: reverting to the
+// unbounded `prefix || hostname` append makes a 300/4096-octet hostname exceed
+// 32 octets and fail the len check.
+func TestBuildEngineID_LengthCapAllHosts(t *testing.T) {
+	dev := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
+	for _, n := range []int{0, 1, 15, 26, 27, 64, 300, 4096} {
 		host := strings.Repeat("h", n)
-		got := buildEngineID(host)
-
-		// RFC 3411 bound: 5..32 octets. len > 32 is exactly the #4917 bug and
-		// is the RED-on-revert assertion.
+		got := buildEngineID(host, dev)
 		if len(got) < 5 || len(got) > snmpEngineIDMaxLen {
-			t.Fatalf("hostname len %d: EngineID length %d out of RFC 3411 range 5..32 (revert regression)", n, len(got))
+			t.Fatalf("hostname len %d: EngineID length %d out of RFC 3411 range 5..32", n, len(got))
 		}
 		if len(got) != snmpEngineIDMaxLen {
 			t.Fatalf("hostname len %d: hashed EngineID length %d, want exactly %d", n, len(got), snmpEngineIDMaxLen)
 		}
-		// Hashed form: prefix || 0x05 (octets) || sha256(hostname)[:26].
-		if !bytes.Equal(got[:5], engineIDPrefix) {
-			t.Fatalf("hostname len %d: prefix % x, want % x", n, got[:5], engineIDPrefix)
-		}
-		if got[5] != engineIDFormatOctets {
-			t.Fatalf("hostname len %d: format octet 0x%02x, want octets 0x%02x", n, got[5], engineIDFormatOctets)
-		}
-		sum := sha256.Sum256([]byte(host))
-		if !bytes.Equal(got[6:], sum[:snmpEngineIDMaxLen-6]) {
-			t.Fatalf("hostname len %d: payload is not sha256(hostname)[:26]", n)
-		}
 	}
 }
 
-// TestBuildEngineID_EmptyAndShortBounds verifies the lower bound holds for the
-// empty and single-octet hostnames (>= 5 octets, still text form).
-func TestBuildEngineID_EmptyAndShortBounds(t *testing.T) {
-	for _, host := range []string{"", "x"} {
-		got := buildEngineID(host)
-		if len(got) < 5 || len(got) > snmpEngineIDMaxLen {
-			t.Fatalf("hostname %q: EngineID length %d out of RFC 3411 range 5..32", host, len(got))
-		}
-		if got[5] != engineIDFormatText {
-			t.Fatalf("hostname %q: format octet 0x%02x, want text 0x%02x", host, got[5], engineIDFormatText)
-		}
-	}
-}
-
-// TestBuildEngineID_LongHostUniqueness verifies two distinct long hostnames
-// produce distinct EngineIDs (SHA-256 collision resistance), so different
-// appliances that both exceed the cap are not aliased to one identity.
-func TestBuildEngineID_LongHostUniqueness(t *testing.T) {
-	a := buildEngineID(strings.Repeat("a", 40) + "-node-alpha")
-	b := buildEngineID(strings.Repeat("a", 40) + "-node-bravo")
+// TestBuildEngineID_HostnameUniqueness verifies two distinct hostnames with the
+// SAME device component produce distinct EngineIDs (SHA-256 collision
+// resistance).
+func TestBuildEngineID_HostnameUniqueness(t *testing.T) {
+	dev := []byte{0x11, 0x22, 0x33}
+	a := buildEngineID("node-alpha.example.net", dev)
+	b := buildEngineID("node-bravo.example.net", dev)
 	if bytes.Equal(a, b) {
-		t.Fatal("distinct long hostnames produced identical EngineIDs")
+		t.Fatal("distinct hostnames produced identical EngineIDs")
 	}
 }
 
-// TestBuildEngineID_Deterministic verifies the same long hostname yields the
-// same EngineID on every call (stable across restarts: no randomness, no
-// timestamp).
+// TestBuildEngineID_Deterministic verifies a fixed (hostname, deviceID) pair
+// yields the same EngineID on every call (stable across restarts: no
+// randomness, no timestamp at build time — randomness lives in the persisted
+// deviceID).
 func TestBuildEngineID_Deterministic(t *testing.T) {
 	host := strings.Repeat("determinism-check.", 20) // ~360 octets
-	first := buildEngineID(host)
-	second := buildEngineID(host)
+	dev := []byte{0xde, 0xad, 0xbe, 0xef}
+	first := buildEngineID(host, dev)
+	second := buildEngineID(host, dev)
 	if !bytes.Equal(first, second) {
-		t.Fatal("buildEngineID is not deterministic for a fixed hostname")
+		t.Fatal("buildEngineID is not deterministic for a fixed (hostname, deviceID)")
 	}
 }

--- a/pkg/snmp/engineid_5283_test.go
+++ b/pkg/snmp/engineid_5283_test.go
@@ -1,0 +1,148 @@
+package snmp
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5283: the SNMPv3 authoritative EngineID must carry a PER-DEVICE unique
+// component so two same-hostname clones (HA pair, factory default, lab image,
+// config restore) derive DIFFERENT EngineIDs — and therefore DIFFERENT localized
+// USM keys — closing the cross-device auth bypass where an authenticated request
+// captured from firewall A was accepted by firewall B.
+
+func newAgentWithEngineIDPath(t *testing.T, cfg *config.SNMPConfig, engineIDPath string) *Agent {
+	t.Helper()
+	// Redirect BOTH persisted paths into the test tempdir so the agent never
+	// touches /var/lib/xpf.
+	bootsPath := filepath.Join(t.TempDir(), "engineboots")
+	return NewAgentWithPaths(cfg, bootsPath, engineIDPath)
+}
+
+// TestEngineID_CloneUniqueness is the core anti-clone property: two agents on
+// the SAME host (same os.Hostname, same /etc/machine-id) with DIFFERENT
+// persisted per-device components derive DIFFERENT EngineIDs.
+//
+// RED-on-revert: revert buildEngineID to hostname-only (ignore the device
+// component) and both agents collapse to the identical hostname-derived
+// EngineID — exactly the #5283 bypass precondition — failing this test.
+func TestEngineID_CloneUniqueness(t *testing.T) {
+	dir := t.TempDir()
+	a := newAgentWithEngineIDPath(t, nil, filepath.Join(dir, "dev-a"))
+	b := newAgentWithEngineIDPath(t, nil, filepath.Join(dir, "dev-b"))
+
+	if bytes.Equal(a.engineID, b.engineID) {
+		t.Fatalf("two same-hostname clones derived IDENTICAL EngineIDs %x — cross-device USM key collision (the #5283 bypass)", a.engineID)
+	}
+}
+
+// TestEngineID_RebootStable verifies the SAME device (same persisted component
+// file) derives a STABLE EngineID across re-inits — a manager that cached our
+// (engineBoots, engineTime) and localized its keys keeps working over a reboot.
+func TestEngineID_RebootStable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dev")
+	first := newAgentWithEngineIDPath(t, nil, path)
+	// Second init reuses the component persisted by the first (simulated reboot).
+	second := newAgentWithEngineIDPath(t, nil, path)
+
+	if !bytes.Equal(first.engineID, second.engineID) {
+		t.Fatalf("EngineID not stable across re-init: %x vs %x (persisted component not reused)", first.engineID, second.engineID)
+	}
+}
+
+// TestEngineID_LengthCap keeps the #4917/#5264 RFC 3411 5..32-octet invariant at
+// the agent level: the per-device component must not push the EngineID out of
+// range.
+func TestEngineID_LengthCap(t *testing.T) {
+	a := newAgentWithEngineIDPath(t, nil, filepath.Join(t.TempDir(), "dev"))
+	if len(a.engineID) < 5 || len(a.engineID) > snmpEngineIDMaxLen {
+		t.Fatalf("EngineID length %d out of RFC 3411 range 5..32", len(a.engineID))
+	}
+}
+
+// TestEngineID_USMKeysDivergeAcrossClones is the direct proof the bypass is
+// closed: two agents with the SAME v3 user (identical username/password/proto)
+// but DIFFERENT per-device components localize DIFFERENT auth AND priv keys, so
+// clone A's authenticated packet can never validate against clone B.
+func TestEngineID_USMKeysDivergeAcrossClones(t *testing.T) {
+	mkCfg := func() *config.SNMPConfig {
+		return &config.SNMPConfig{
+			V3Users: map[string]*config.SNMPv3User{
+				"monitor": {
+					Name:         "monitor",
+					AuthProtocol: "sha256",
+					AuthPassword: config.Secret("auth-password-123"),
+					PrivProtocol: "aes128",
+					PrivPassword: config.Secret("priv-password-456"),
+				},
+			},
+		}
+	}
+	dir := t.TempDir()
+	a := newAgentWithEngineIDPath(t, mkCfg(), filepath.Join(dir, "dev-a"))
+	b := newAgentWithEngineIDPath(t, mkCfg(), filepath.Join(dir, "dev-b"))
+
+	ua := a.snapshotV3User("monitor")
+	ub := b.snapshotV3User("monitor")
+	if ua == nil || ub == nil {
+		t.Fatal("monitor user missing on one of the agents")
+	}
+	if len(ua.authKey) == 0 || len(ub.authKey) == 0 {
+		t.Fatal("auth key not localized")
+	}
+	if bytes.Equal(ua.authKey, ub.authKey) {
+		t.Fatal("same-password clones localized IDENTICAL auth keys — cross-device auth bypass NOT closed")
+	}
+	if len(ua.privKey) == 0 || len(ub.privKey) == 0 {
+		t.Fatal("priv key not localized")
+	}
+	if bytes.Equal(ua.privKey, ub.privKey) {
+		t.Fatal("same-password clones localized IDENTICAL priv keys — cross-device priv bypass NOT closed")
+	}
+}
+
+// TestPersistedComponent_FormatAndPerms verifies the persisted component is a
+// 16-byte value stored as hex text with 0600 perms, and is regenerated when the
+// file is corrupted.
+func TestPersistedComponent_FormatAndPerms(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dev")
+	first := newAgentWithEngineIDPath(t, nil, path)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("persisted component not written: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("persisted component perms %o, want 0600", perm)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read persisted component: %v", err)
+	}
+	// 16 bytes -> 32 hex chars + trailing newline.
+	if n := len(string(data)); n != deviceComponentLen*2+1 {
+		t.Fatalf("persisted component encoded length %d, want %d", n, deviceComponentLen*2+1)
+	}
+
+	// Corrupt the file -> next init regenerates a valid component and a NEW
+	// EngineID (the corrupt bytes are not silently reused).
+	if err := os.WriteFile(path, []byte("not-hex!!"), 0o600); err != nil {
+		t.Fatalf("corrupt persisted component: %v", err)
+	}
+	regen := newAgentWithEngineIDPath(t, nil, path)
+	if len(regen.engineID) < 5 || len(regen.engineID) > snmpEngineIDMaxLen {
+		t.Fatalf("regenerated EngineID length %d out of range", len(regen.engineID))
+	}
+	if bytes.Equal(first.engineID, regen.engineID) {
+		t.Fatal("regenerated EngineID equals the pre-corruption one despite a corrupt component file")
+	}
+	// And the corrupt file was replaced with a well-formed hex component.
+	data2, _ := os.ReadFile(path)
+	if n := len(string(data2)); n != deviceComponentLen*2+1 {
+		t.Fatalf("regenerated component encoded length %d, want %d", n, deviceComponentLen*2+1)
+	}
+}

--- a/scripts/image/bake.py
+++ b/scripts/image/bake.py
@@ -639,8 +639,16 @@ def main():
         run(["virt-sysprep", "-a", work_qcow, "--quiet", "--enable",
              "machine-id,ssh-hostkeys,ssh-userdir,logfiles,tmp-files,bash-history,"
              "package-manager-cache,backup-files,passwd-backups,utmp",
+             # #5283: strip the persisted per-device SNMPv3 EngineID component
+             # (and the engineBoots counter) so the golden image never ships an
+             # identical per-device identity across clones. Like /etc/machine-id
+             # (reset by the enabled virt-sysprep machine-id op above), each
+             # appliance regenerates a fresh EngineID component on first boot;
+             # otherwise every clone would derive byte-identical localized USM
+             # keys and accept each other's authenticated SNMPv3 requests.
              "--run-command", "rm -rf /etc/xpf/.configdb /etc/xpf/xpf.conf "
              "/etc/xpf/.day0-config-applied /etc/xpf/.root-grown "
+             "/var/lib/xpf/snmp-engine-id /var/lib/xpf/snmp-engineboots "
              "/var/lib/systemd/random-seed "
              "/var/lib/apt/lists/* 2>/dev/null || true"])
 


### PR DESCRIPTION
## Summary

Fixes a cross-device SNMPv3 USM authentication bypass. `buildEngineID`/`initEngine` derived the **entire** authoritative EngineID from a fixed enterprise prefix + `os.Hostname()` — short form `prefix||hostname`, long form `sha256(hostname)[:26]` — with **no per-device component**.

USM localizes each user's auth/priv keys against the EngineID (`passwordToKey(pw, a.engineID, …)` in `v3.go`), so two **same-hostname clones** (HA pair, factory default, lab image, config restore) derived **byte-identical EngineIDs → byte-identical localized USM keys**. An authenticated SNMPv3 GET captured from firewall **A** was then **accepted by firewall B** (same username/password, aligned boots/time): cross-device telemetry disclosure / auth bypass. `#4917`/`#5264` only capped the EngineID **length**, not its uniqueness.

RFC 3411 requires the EngineID to be **unique** per authoritative engine (unique, not secret).

## Fix

`buildEngineID` now folds a per-device unique component into a mandatory 32-octet hash:

```
prefix(5) || 0x05 || sha256(deviceID || 0x00 || hostname)[:26]
```

**Per-device source (`deviceComponent`)** — two independent per-device sources so a clone must defeat **both** to collide:

1. **Persisted crypto/rand** — a 16-byte value generated **once** and persisted at `/var/lib/xpf/snmp-engine-id` (hex text, `0600`, atomic durable write), reused on every subsequent boot → stable across reboots of the same device, unique per appliance. **This is the per-device source used.**
2. **`/etc/machine-id`** — folded in as defense in depth. `virt-sysprep` resets machine-id per-appliance at image bake, so even a mistakenly-cloned persisted file still yields a distinct EngineID.

If **every** source fails (no persistable random AND no machine-id) the EngineID degrades to the pre-#5283 hostname-only identity and `initEngine` logs a one-time `slog.Warn`. The result is **always exactly 32 octets**, so the `#4917`/`#5264` length cap holds for every input (empty or multi-kilobyte hostname). A `0x00` separator prevents boundary-shift aliasing.

## Clone / bake regeneration (required)

The persisted `/var/lib/xpf/snmp-engine-id` file **must not** be copied identically into cloned appliances or a golden image — that would re-establish the collision. It is treated exactly like `/etc/machine-id`: `scripts/image/bake.py` now strips `snmp-engine-id` (and `snmp-engineboots`) during `virt-sysprep`, so each appliance regenerates a fresh one on first boot. The machine-id fold-in is the backstop if that removal is ever missed.

## Transition

On upgrade the EngineID changes **once** (hostname-derived → device-unique); existing SNMPv3 managers re-discover it on their next poll (a one-time standard USM discovery — acceptable for a security fix). `engineBoots` monotonicity is unaffected — the counter is keyed by its own persisted file, not by the EngineID bytes.

## API

Adds `NewAgentWithPaths(cfg, bootsPath, engineIDPath)`; the daemon passes `d.snmpEngineIDPath` (a temp path in the reconcile test so it never touches `/var/lib/xpf`). `NewAgent` / `NewAgentWithBootsPath` retained.

## Tests

`pkg/snmp/engineid_5283_test.go`:
- **anti-clone**: two same-hostname agents with different persisted components → different EngineIDs;
- **reboot stability**: same component → stable EngineID across re-inits;
- **USM key divergence**: same-password clones localize **different auth AND priv keys** (direct proof the bypass is closed);
- length stays within 5..32;
- the persisted file is 16 bytes hex at `0600` and is regenerated on corruption.

`engineid_4917_test.go` updated to the new signature, preserving the length-cap RED-on-revert intent.

### RED-on-revert evidence

Reverting `buildEngineID` to hostname-only (ignore `deviceID`) makes the anti-clone tests fail:

```
--- FAIL: TestEngineID_CloneUniqueness (0.00s)
    engineid_5283_test.go:39: two same-hostname clones derived IDENTICAL EngineIDs
        80000186a3057426afc489d0eef99a0b438def226ad139f752350c25cf2c0490 —
        cross-device USM key collision (the #5283 bypass)
--- FAIL: TestEngineID_USMKeysDivergeAcrossClones (0.07s)
    engineid_5283_test.go:98: same-password clones localized IDENTICAL auth keys —
        cross-device auth bypass NOT closed
```

Restored → green.

## Validation

- `go build ./...` — clean
- `go vet ./pkg/snmp/...` — clean
- `go test ./pkg/snmp/... ./pkg/daemon/...` — pass
- `gofmt` clean on all touched files

## Follow-up (out of scope)

Binding the USM replay window to the destination IP (the issue's secondary point) is defense-in-depth and left as a follow-up — the unique EngineID alone closes the cross-clone bypass because A's localized keys no longer equal B's.

Closes #5283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STrnsnmjpviTj7qd3nrc3d