### PR TITLE
image/dist: bind supply-chain provenance into signed bake + publish (#4904)

### DIFF
--- a/docs/image-validation.md
+++ b/docs/image-validation.md
@@ -42,6 +42,22 @@ sg kvm -c 'python3 scripts/image/bake.py --skip-validate'
 Artifacts land in `dist/`: `xpf-<ver>.qcow2`, `xpf-<ver>.incus-metadata.tar.gz`,
 `SHA256SUMS`, `xpf-<ver>.manifest`. Verify: `(cd dist && sha256sum -c SHA256SUMS)`.
 
+**Base-image trust anchor (#4904 B).** The Ubuntu cloud image is fetched from a
+mirror and authenticated against a repo-PINNED SHA256 (`PINNED_BASE_SHA256` in
+`bake.py`, Canonical-GPG-verified) — NOT just the `SHA256SUMS` fetched from the
+same mirror endpoint (which authenticates nothing against a compromised mirror).
+A pin mismatch aborts the bake. An UNPINNED release (e.g. an `XPF_BASE_RELEASE`
+override or `XPF_UBUNTU_AUTODISCOVER=1` with no matching pin) is refused unless
+you set `XPF_ALLOW_UNPINNED_BASE=1` (a non-publishable dev bake) or supply a
+reviewed `XPF_BASE_SHA256=<digest>`. The authenticated base digest + source URL
++ `base_image_pinned` flag are bound into the signed `xpf-<ver>.manifest`.
+
+**`--skip-validate` is marked non-publishable (#4904 A).** A `--skip-validate`
+bake still signs, but the signed `xpf-<ver>.manifest` records `validated: false`
+(a full bake records `validated: true`). `scripts/dist/publish.py` refuses any
+image whose provenance is not `validated: true`, so an unvalidated dev/emergency
+image can never carry a release signature past the fail-closed publish boundary.
+
 ---
 
 ## Tier 1 — automated first-boot gate (`validate.py`)

--- a/scripts/dist/README.md
+++ b/scripts/dist/README.md
@@ -11,7 +11,7 @@ Mechanism for a signed, hosted appliance distribution. Spec:
 | `sign.py` | minisign sign/verify + per-version manifest helpers (shared by bake/validate/deploy/publish) |
 | `build-apt-repo.sh` | builds a flat signed apt repo (default) or reprepro (opt-in) |
 | `install.sh` | Tailscale-style one-command installer (validate-all-inputs → keyring + apt source + install, with cleanup-on-failure). Ships with `%%…%%` markers baked at publish time. |
-| `publish.py` | fail-closed publish gate + `XPF_PUBLISH_CMD` dispatch. `stamp-installer` bakes the real archive key + apt base URL + channel into `install.sh` (substitute-then-sign); the gate REQUIRES a stamped+signed `install.sh` unless `--no-installer`. |
+| `publish.py` | fail-closed publish gate + `XPF_PUBLISH_CMD` dispatch. `stamp-installer` bakes the real archive key + apt base URL + channel into `install.sh` (substitute-then-sign); the gate REQUIRES a stamped+signed `install.sh` unless `--no-installer`. Also REQUIRES each image's signed `xpf-<ver>.manifest` provenance to say `validated: true` (#4904 A — a `--skip-validate` bake is refused). When an upload will happen it snapshots the tree into a private immutable staging dir and gates+dispatches ONLY that snapshot (#4904 C — the bytes gated are the bytes uploaded, closing a TOCTOU where a concurrent writer swapped an artifact/installer after the gate). |
 | `xpf-image.pub.placeholder` | PLACEHOLDER minisign public key (see below) |
 | `xpf-archive-keyring.asc.placeholder` | PLACEHOLDER OpenPGP apt archive key (see below) |
 

--- a/scripts/dist/publish.py
+++ b/scripts/dist/publish.py
@@ -6,7 +6,10 @@ artifact in the publish set is properly signed:
 
   (a) each image manifest (xpf-<ver>.SHA256SUMS) has a verifying .minisig
       against the pinned image pubkey, AND the qcow2/metadata it lists are
-      present and hash-match;
+      present and hash-match, AND its signed xpf-<ver>.manifest provenance
+      sidecar says `validated: true` (#4904 A — a --skip-validate bake binds
+      validated:false and is REFUSED: an unvalidated dev/emergency image must
+      never carry a release signature past this fail-closed boundary);
   (b) the apt InRelease verifies against the archive pubkey (when an apt tree
       is being published);
   (c) install.sh is PRESENT (required by default — the Tier-A one-liner URL
@@ -21,6 +24,12 @@ artifact in the publish set is properly signed:
 
 The bake may be fail-OPEN (a dev bake without a key still produces artifacts),
 but PUBLISH is fail-CLOSED — an unsigned dev bake can never reach the channel.
+
+To close a TOCTOU window (#4904 C), when an upload will actually happen the
+whole tree is first copied into a PRIVATE immutable staging snapshot; the gate
+hashes and the backend uploads the SAME snapshot bytes, so a concurrent writer
+replacing an artifact/sidecar/install.sh after the gate cannot swap the
+uploaded content.
 
 After the gate passes, dispatch the operator's backend exactly once per URL:
 
@@ -526,6 +535,64 @@ def gate_images(dist, require_installer=True):
     return versions, pub
 
 
+def _parse_manifest_fields(text):
+    """Parse a bake `.manifest` sidecar (key: value lines) into a dict, keys
+    verbatim. Mirrors scripts/deploy/xpf-deploy.py:_parse_image_manifest_versions
+    but keeps underscores so `validated` / `base_image_pinned` read directly."""
+    d = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+        k, v = line.split(":", 1)
+        d[k.strip()] = v.strip()
+    return d
+
+
+def gate_provenance(dist, versions, pub):
+    """#4904 A: refuse to publish an image set that did not pass the in-guest
+    verify-dataplane validation gate.
+
+    A --skip-validate bake still produces a fully signed manifest/signature set
+    that is byte-shape-indistinguishable from a validated release, so the
+    fail-closed publish gate would happily ship a dev/emergency image that never
+    booted or verified the dataplane. bake.py now binds a signed `validated:
+    true|false` provenance field into the xpf-<ver>.manifest sidecar (covered by
+    the signed xpf-<ver>.SHA256SUMS, #5042); this gate REQUIRES validated: true.
+
+    Fail-CLOSED: every version MUST carry a provenance sidecar that is (a) listed
+    in — and hash-matches — the signed manifest, and (b) says validated: true.
+    A missing sidecar, an unsigned/mismatched sidecar, or validated != true all
+    refuse the publish."""
+    for ver, sums in sorted(versions.items()):
+        sig = sums + ".minisig"
+        sidecar = os.path.join(dist, f"xpf-{ver}.manifest")
+        if not os.path.isfile(sidecar):
+            die(f"image set {ver} has no provenance sidecar xpf-{ver}.manifest "
+                f"in {dist} — cannot confirm it passed the in-guest "
+                "verify-dataplane gate. Refusing to publish (the sidecar is "
+                "written + signed by scripts/image/bake.py; re-bake).")
+        try:
+            # Verify the sidecar against the SIGNED checksum manifest and read
+            # the VERIFIED bytes (TOCTOU-safe) — the same primitive the deployer
+            # mixed-base gate uses (#5042). Fails closed if the sidecar is not
+            # covered by the signed manifest or its hash does not match.
+            data = sign.verify_listed_artifact_bytes(sidecar, sums, sig, pub)
+        except sign.SignError as e:
+            die(f"provenance sidecar xpf-{ver}.manifest failed verify against "
+                f"the signed manifest {os.path.basename(sums)}: {e}")
+        fields = _parse_manifest_fields(data.decode("utf-8", "replace"))
+        validated = fields.get("validated")
+        if validated != "true":
+            die(f"image set {ver} provenance says validated={validated!r} (not "
+                "'true') — this bake did NOT pass the in-guest verify-dataplane "
+                "gate (built with --skip-validate, or an older bake predating "
+                "the #4904 provenance field). Refusing to publish an "
+                "UNVALIDATED image with a release signature. Re-bake WITHOUT "
+                "--skip-validate.")
+        info(f"image set {ver}: provenance validated=true")
+
+
 def _gate_one_latest(dist, channel, pub, require_present):
     """Verify one channel's signed latest.json. `require_present`, when not
     None, is the set of versions the pointer's `version` MUST name (the target
@@ -692,6 +759,59 @@ def make_latest(dist, channel, version):
     info(f"wrote + signed {latest} -> {version}")
 
 
+def _fsync_tree(root):
+    """fsync every regular file and directory under `root` so the snapshot's
+    bytes are durable before dispatch (the backend may run in a separate
+    process that reopens the files)."""
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for fn in filenames:
+            p = os.path.join(dirpath, fn)
+            if os.path.islink(p):
+                continue
+            try:
+                fd = os.open(p, os.O_RDONLY)
+            except OSError:
+                continue
+            try:
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+        try:
+            dfd = os.open(dirpath, os.O_RDONLY)
+        except OSError:
+            continue
+        try:
+            os.fsync(dfd)
+        finally:
+            os.close(dfd)
+
+
+def _snapshot_dist(dist):
+    """#4904 C (TOCTOU): copy the publish tree into a PRIVATE 0700 staging dir
+    and fsync it, returning (staging_root, snapshot_dir).
+
+    gate_images hashes artifacts + verifies install.sh against the live `dist`
+    tree and returns keeping NO snapshot/lock; dispatch then hands the SAME
+    mutable path to the backend, which REOPENS the files. A concurrent
+    bake/cleanup/writer can replace an artifact, sidecar, or the Tier-A
+    install.sh AFTER the gate but BEFORE the backend reads it, so a gate-pass log
+    accompanies DIFFERENT uploaded bytes (including an unsigned installer).
+    Snapshotting first — then gating AND dispatching ONLY the snapshot — makes
+    the bytes gated the exact bytes uploaded.
+
+    Symlinks are copied AS symlinks (symlinks=True) so the gate's symlink
+    refusal still fires on them, rather than silently dereferencing a link into
+    a real file that would ride along unseen."""
+    import shutil as _sh
+    import tempfile as _tf
+    staging = _tf.mkdtemp(prefix="xpf-publish-snap-")
+    os.chmod(staging, 0o700)
+    snap = os.path.join(staging, "dist")
+    _sh.copytree(dist, snap, symlinks=True)
+    _fsync_tree(snap)
+    return staging, snap
+
+
 def dispatch(cmd, local_dir, base_url, dry):
     info(f"publish: {cmd} {local_dir} {base_url}")
     if dry:
@@ -757,29 +877,49 @@ def main(argv):
             "Drop --no-apt (gate apt too), or move dist/apt out of the publish "
             "root.")
 
-    # ── fail-closed gate ──
-    if not a.no_image:
-        versions, pub = gate_images(dist, require_installer=not a.no_installer)
-        gate_latest(dist, a.channel, versions, pub)
-    if not a.no_apt:
-        gate_apt(dist, a.channel)
-
     pubcmd = os.environ.get("XPF_PUBLISH_CMD")
-    if not pubcmd:
-        info("gate PASSED. XPF_PUBLISH_CMD unset — nothing uploaded. Set it to "
-             "the backend shim ($CMD <local-dir> <dest-base-url>) to publish.")
-        return 0
+    # #4904 C: when we will actually upload, snapshot the tree into a private
+    # immutable staging dir FIRST, then gate + dispatch ONLY the snapshot, so a
+    # concurrent writer cannot swap the uploaded bytes out from under a
+    # gate-pass. A gate-only / --dry-run run uploads nothing, so it gates the
+    # live tree directly (no full copy — the qcow2 set can be multi-GB).
+    will_dispatch = bool(pubcmd) and not a.dry_run
+    staging = None
+    try:
+        gate_dir = dist
+        if will_dispatch:
+            staging, gate_dir = _snapshot_dist(dist)
 
-    if not a.no_image:
-        img_url = os.environ.get("XPF_IMAGE_BASE_URL") or die(
-            "XPF_IMAGE_BASE_URL required to publish the image tree.")
-        dispatch(pubcmd, dist, img_url, a.dry_run)
-    if not a.no_apt:
-        apt_url = os.environ.get("XPF_APT_BASE_URL") or die(
-            "XPF_APT_BASE_URL required to publish the apt tree.")
-        dispatch(pubcmd, os.path.join(dist, "apt"), apt_url, a.dry_run)
-    info("publish complete.")
-    return 0
+        # ── fail-closed gate (against the immutable snapshot when dispatching) ──
+        if not a.no_image:
+            versions, pub = gate_images(gate_dir,
+                                        require_installer=not a.no_installer)
+            gate_provenance(gate_dir, versions, pub)
+            gate_latest(gate_dir, a.channel, versions, pub)
+        if not a.no_apt:
+            gate_apt(gate_dir, a.channel)
+
+        if not pubcmd:
+            info("gate PASSED. XPF_PUBLISH_CMD unset — nothing uploaded. Set it "
+                 "to the backend shim ($CMD <local-dir> <dest-base-url>) to "
+                 "publish.")
+            return 0
+
+        # Dispatch the SNAPSHOT (gate_dir), never the mutable `dist`.
+        if not a.no_image:
+            img_url = os.environ.get("XPF_IMAGE_BASE_URL") or die(
+                "XPF_IMAGE_BASE_URL required to publish the image tree.")
+            dispatch(pubcmd, gate_dir, img_url, a.dry_run)
+        if not a.no_apt:
+            apt_url = os.environ.get("XPF_APT_BASE_URL") or die(
+                "XPF_APT_BASE_URL required to publish the apt tree.")
+            dispatch(pubcmd, os.path.join(gate_dir, "apt"), apt_url, a.dry_run)
+        info("publish complete.")
+        return 0
+    finally:
+        if staging:
+            import shutil as _sh
+            _sh.rmtree(staging, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/scripts/dist/selftest.sh
+++ b/scripts/dist/selftest.sh
@@ -51,9 +51,16 @@ META="$OUT/xpf-$VER.incus-metadata.tar.gz"
 head -c 4096 /dev/urandom > "$QCOW"
 head -c 1024 /dev/urandom > "$META"
 MANIFEST="$OUT/xpf-$VER.SHA256SUMS"
+# #4904 A: the signed provenance sidecar (xpf-<ver>.manifest). Real bakes bind
+# `validated: true|false` here and cover it with the signed SHA256SUMS (#5042);
+# publish.py's gate_provenance REQUIRES validated: true. Model that in the
+# baseline signed set so the positive publish cases below exercise the real
+# shape (validated:false is exercised as a negative in section 8i).
+SIDECAR="$OUT/xpf-$VER.manifest"
+printf 'version: %s\nbase_image_pinned: true\nvalidated: true\n' "$VER" > "$SIDECAR"
 XPF_IMAGE_PUBKEY="$WORK/img.pub" \
   $PY "$DIST/sign.py" sign-manifest --manifest "$MANIFEST" \
-      --seckey "$WORK/img.sec" --comment "selftest" "$QCOW" "$META" >/dev/null
+      --seckey "$WORK/img.sec" --comment "selftest" "$QCOW" "$META" "$SIDECAR" >/dev/null
 [ -f "$MANIFEST.minisig" ] && ok "manifest signed" || bad "manifest not signed"
 
 verify() {  # verify <file> with pubkey; prints OK/err, returns rc
@@ -200,7 +207,7 @@ fi
 
 # Orphan image artifact NOT covered by any manifest (Codex-r2-1).
 PGO="$WORK/pgorphan"; mkdir -p "$PGO"
-cp "$QCOW" "$META" "$MANIFEST" "$MANIFEST.minisig" "$PGO/"
+cp "$QCOW" "$META" "$SIDECAR" "$MANIFEST" "$MANIFEST.minisig" "$PGO/"
 head -c 64 /dev/urandom > "$PGO/xpf-9.9.9.qcow2"   # orphan, no manifest covers it
 if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/publish.py" \
      --dist "$PGO" --channel stable --no-apt >/dev/null 2>&1; then
@@ -211,7 +218,7 @@ fi
 
 # Symlink under the image publish root (Codex-r4).
 PGS="$WORK/pgsym"; mkdir -p "$PGS"
-cp "$QCOW" "$META" "$MANIFEST" "$MANIFEST.minisig" "$PGS/"
+cp "$QCOW" "$META" "$SIDECAR" "$MANIFEST" "$MANIFEST.minisig" "$PGS/"
 ln -s /etc/passwd "$PGS/sneaky.qcow2"
 if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/publish.py" \
      --dist "$PGS" --channel stable --no-apt >/dev/null 2>&1; then
@@ -390,7 +397,7 @@ fi
 # ── 8. publish gate: install.sh mandatory + stamped + signed ────────────────
 info "8. publish gate — install.sh mandatory, stamped, signed"
 GD="$WORK/gate"; mkdir -p "$GD"
-cp "$QCOW" "$META" "$MANIFEST" "$MANIFEST.minisig" "$GD/"
+cp "$QCOW" "$META" "$SIDECAR" "$MANIFEST" "$MANIFEST.minisig" "$GD/"
 XPF_SIGN_SECKEY="$WORK/img.sec" $PY "$DIST/publish.py" make-latest \
     --channel stable --version "$VER" --dist "$GD" >/dev/null 2>&1
 # 8a. install.sh MISSING -> refuse (mandatory).
@@ -451,7 +458,7 @@ fi
 # ── 8g. HB165 H-5: default-deny sweep refuses a stray non-image file ────────
 info "8g. publish default-deny sweep refuses a stray file under dist/ (HB165 H-5)"
 GOOD="$WORK/hb165"; mkdir -p "$GOOD"
-cp "$QCOW" "$META" "$MANIFEST" "$MANIFEST.minisig" "$GOOD/"
+cp "$QCOW" "$META" "$SIDECAR" "$MANIFEST" "$MANIFEST.minisig" "$GOOD/"
 XPF_SIGN_SECKEY="$WORK/img.sec" $PY "$DIST/publish.py" make-latest \
     --channel stable --version "$VER" --dist "$GOOD" >/dev/null 2>&1
 $PY "$DIST/publish.py" stamp-installer --out "$GOOD/install.sh" \
@@ -500,6 +507,45 @@ if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/publish.py" \
     ok "publish passes when the edge latest.json is properly signed (H-13)"
 else
     bad "publish MUST pass a signed edge latest.json but FAILED (H-13)"
+fi
+
+# ── 8i. #4904 A: publish REFUSES a --skip-validate (validated:false) image ──
+info "8i. publish provenance gate — validated:false is refused"
+PROV="$WORK/prov"; mkdir -p "$PROV"
+cp "$QCOW" "$META" "$PROV/"
+# A signed image set that is byte-shape-identical to a release but whose signed
+# provenance sidecar says validated:false (a --skip-validate bake).
+printf 'version: %s\nbase_image_pinned: true\nvalidated: false\n' "$VER" \
+    > "$PROV/xpf-$VER.manifest"
+XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/sign.py" sign-manifest \
+    --manifest "$PROV/xpf-$VER.SHA256SUMS" --seckey "$WORK/img.sec" \
+    --comment "selftest-skipvalidate" "$PROV/xpf-$VER.qcow2" \
+    "$PROV/xpf-$VER.incus-metadata.tar.gz" "$PROV/xpf-$VER.manifest" >/dev/null
+XPF_SIGN_SECKEY="$WORK/img.sec" $PY "$DIST/publish.py" make-latest \
+    --channel stable --version "$VER" --dist "$PROV" >/dev/null 2>&1
+$PY "$DIST/publish.py" stamp-installer --out "$PROV/install.sh" \
+    --archive-key "$AKEY" --apt-base-url "https://dl.selftest.invalid/apt" \
+    --channel stable >/dev/null 2>&1
+minisign -S -W -s "$WORK/img.sec" -m "$PROV/install.sh" \
+    -x "$PROV/install.sh.minisig" >/dev/null 2>&1
+if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/publish.py" \
+     --dist "$PROV" --channel stable --no-apt >/dev/null 2>&1; then
+    bad "publish MUST refuse a validated:false image but PASSED (#4904 A)"
+else
+    ok "publish refuses a validated:false (--skip-validate) image (#4904 A)"
+fi
+# Positive control: flip validated -> true, re-sign the same set -> PASSES.
+printf 'version: %s\nbase_image_pinned: true\nvalidated: true\n' "$VER" \
+    > "$PROV/xpf-$VER.manifest"
+XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/sign.py" sign-manifest \
+    --manifest "$PROV/xpf-$VER.SHA256SUMS" --seckey "$WORK/img.sec" \
+    --comment "selftest-validated" "$PROV/xpf-$VER.qcow2" \
+    "$PROV/xpf-$VER.incus-metadata.tar.gz" "$PROV/xpf-$VER.manifest" >/dev/null
+if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/publish.py" \
+     --dist "$PROV" --channel stable --no-apt >/dev/null 2>&1; then
+    ok "publish passes the same set once validated:true (#4904 A control)"
+else
+    bad "publish MUST pass a validated:true image but FAILED (#4904 A control)"
 fi
 
 # ── 9. install.sh H-16: validate-before-mutate + cleanup-on-failure ─────────

--- a/scripts/dist/test_publish_provenance.py
+++ b/scripts/dist/test_publish_provenance.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Unit tests for #4904 A — publish REFUSES a --skip-validate (unvalidated)
+image.
+
+A `--skip-validate` bake still produces a fully signed manifest/signature set
+that is byte-shape-indistinguishable from a validated release, so the
+fail-closed publish gate would ship a dev/emergency image that never booted or
+verified the dataplane. bake.py now binds a signed `validated: true|false`
+field into the xpf-<ver>.manifest provenance sidecar (covered by the signed
+xpf-<ver>.SHA256SUMS); publish.gate_provenance REQUIRES validated: true.
+
+These tests build a real minisign-signed image set with a throwaway key (SKIP
+if minisign is absent) and drive publish.gate_provenance directly. On revert
+(drop the gate / accept validated:false) the negative cases go RED.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+_DIST = Path(__file__).resolve().parent
+_SPEC = importlib.util.spec_from_file_location("publish", _DIST / "publish.py")
+publish = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(publish)
+
+# sign.py sits beside publish.py; publish already puts _DIST on sys.path.
+import sign  # noqa: E402
+
+_HAVE_MINISIGN = shutil.which("minisign") is not None
+VER = "0.0.0-provtest"
+
+
+@unittest.skipUnless(_HAVE_MINISIGN, "minisign not installed")
+class GateProvenanceTests(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp(prefix="xpf-provtest-")
+        self.addCleanup(shutil.rmtree, self.dir, ignore_errors=True)
+        self.pub = os.path.join(self.dir, "img.pub")
+        self.sec = os.path.join(self.dir, "img.sec")
+        subprocess.run(["minisign", "-G", "-W", "-p", self.pub, "-s", self.sec],
+                       check=True, capture_output=True)
+        # Fake image artifacts.
+        self.qcow = os.path.join(self.dir, f"xpf-{VER}.qcow2")
+        self.meta = os.path.join(self.dir, f"xpf-{VER}.incus-metadata.tar.gz")
+        Path(self.qcow).write_bytes(b"\x00fake-qcow2\x00")
+        Path(self.meta).write_bytes(b"\x00fake-meta\x00")
+        self.sidecar = os.path.join(self.dir, f"xpf-{VER}.manifest")
+        self.sums = os.path.join(self.dir, f"xpf-{VER}.SHA256SUMS")
+
+    def _sign_set(self, validated):
+        """(Re)write the provenance sidecar with the given validated flag and
+        sign a manifest covering qcow + meta + sidecar (mirrors a real bake)."""
+        Path(self.sidecar).write_text(
+            f"version: {VER}\nbase_image_pinned: true\n"
+            f"validated: {'true' if validated else 'false'}\n")
+        sign.write_manifest(self.sums, [self.qcow, self.meta, self.sidecar])
+        sign.sign_manifest(self.sums, self.sec, comment="provtest")
+
+    def test_validated_true_passes(self):
+        self._sign_set(validated=True)
+        # Should not raise.
+        publish.gate_provenance(self.dir, {VER: self.sums}, self.pub)
+
+    def test_validated_false_refused(self):
+        self._sign_set(validated=False)
+        # RED on revert: gate_provenance gone -> no SystemExit here.
+        with self.assertRaises(SystemExit) as ctx:
+            publish.gate_provenance(self.dir, {VER: self.sums}, self.pub)
+        self.assertNotEqual(ctx.exception.code, 0)
+
+    def test_missing_sidecar_refused(self):
+        self._sign_set(validated=True)
+        os.remove(self.sidecar)
+        with self.assertRaises(SystemExit) as ctx:
+            publish.gate_provenance(self.dir, {VER: self.sums}, self.pub)
+        self.assertNotEqual(ctx.exception.code, 0)
+
+    def test_unsigned_tampered_sidecar_refused(self):
+        # Sidecar hash-covered by the signed manifest, then swapped on disk to
+        # say validated:true — verify_listed_artifact_bytes must reject the
+        # hash mismatch (TOCTOU-safe), so a post-sign flip cannot slip through.
+        self._sign_set(validated=False)
+        Path(self.sidecar).write_text(
+            f"version: {VER}\nbase_image_pinned: true\nvalidated: true\n")
+        with self.assertRaises(SystemExit) as ctx:
+            publish.gate_provenance(self.dir, {VER: self.sums}, self.pub)
+        self.assertNotEqual(ctx.exception.code, 0)
+
+
+class ParseManifestFieldsTests(unittest.TestCase):
+    def test_parse(self):
+        fields = publish._parse_manifest_fields(
+            "version: 1.2.3\n# comment\nvalidated: true\n"
+            "base_image_pinned: false\nblank\n\n")
+        self.assertEqual(fields["validated"], "true")
+        self.assertEqual(fields["base_image_pinned"], "false")
+        self.assertEqual(fields["version"], "1.2.3")
+        self.assertNotIn("# comment", fields)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/dist/test_publish_snapshot.py
+++ b/scripts/dist/test_publish_snapshot.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Unit tests for #4904 C — publish snapshots the tree before gating so the
+bytes gated are the exact bytes uploaded (TOCTOU).
+
+publish.py's gate_images hashed artifacts + verified install.sh against the
+LIVE dist tree, kept no snapshot, then handed the SAME mutable path to the
+backend, which reopened the files. A concurrent writer replacing an
+artifact/sidecar/install.sh after the gate but before the backend read it made
+a gate-pass log accompany DIFFERENT uploaded bytes (incl. an unsigned
+installer). The fix copies the tree into a private immutable staging dir and
+dispatches ONLY that snapshot.
+
+These tests are hermetic (no minisign/gpg needed): the snapshot primitive is
+tested directly, and main()'s dispatch wiring is tested with the gate functions
+patched out and a concurrent-writer race injected. On revert (dispatch the
+mutable tree) the race test uploads the REPLACED bytes and goes RED.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+
+_DIST = Path(__file__).resolve().parent
+_SPEC = importlib.util.spec_from_file_location("publish", _DIST / "publish.py")
+publish = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(publish)
+
+
+class SnapshotIsolationTests(unittest.TestCase):
+    def test_snapshot_survives_original_mutation(self):
+        src = tempfile.mkdtemp(prefix="xpf-snap-src-")
+        self.addCleanup(shutil.rmtree, src, ignore_errors=True)
+        Path(src, "a.txt").write_text("ORIG")
+        os.makedirs(os.path.join(src, "sub"))
+        Path(src, "sub", "b.txt").write_text("ORIG-B")
+
+        staging, snap = publish._snapshot_dist(src)
+        self.addCleanup(shutil.rmtree, staging, ignore_errors=True)
+
+        # A concurrent writer replaces the original files AFTER the snapshot.
+        Path(src, "a.txt").write_text("EVIL")
+        Path(src, "sub", "b.txt").write_text("EVIL-B")
+
+        # The snapshot still holds the gated bytes.
+        self.assertEqual(Path(snap, "a.txt").read_text(), "ORIG")
+        self.assertEqual(Path(snap, "sub", "b.txt").read_text(), "ORIG-B")
+
+    def test_snapshot_is_private_0700(self):
+        src = tempfile.mkdtemp(prefix="xpf-snap-src-")
+        self.addCleanup(shutil.rmtree, src, ignore_errors=True)
+        Path(src, "a.txt").write_text("x")
+        staging, snap = publish._snapshot_dist(src)
+        self.addCleanup(shutil.rmtree, staging, ignore_errors=True)
+        self.assertEqual(stat.S_IMODE(os.stat(staging).st_mode), 0o700)
+
+    def test_symlinks_copied_as_symlinks(self):
+        # copytree(symlinks=True) preserves links so the gate's symlink refusal
+        # still fires — a link must NOT be dereferenced into a real file.
+        src = tempfile.mkdtemp(prefix="xpf-snap-src-")
+        self.addCleanup(shutil.rmtree, src, ignore_errors=True)
+        Path(src, "real.txt").write_text("real")
+        os.symlink("real.txt", os.path.join(src, "link.txt"))
+        staging, snap = publish._snapshot_dist(src)
+        self.addCleanup(shutil.rmtree, staging, ignore_errors=True)
+        self.assertTrue(os.path.islink(os.path.join(snap, "link.txt")))
+
+
+class DispatchUsesSnapshotTests(unittest.TestCase):
+    """main() must dispatch the immutable snapshot, not the mutable tree, even
+    when a writer replaces a file between the snapshot and the upload."""
+
+    def setUp(self):
+        self.dist = tempfile.mkdtemp(prefix="xpf-snap-dist-")
+        self.addCleanup(shutil.rmtree, self.dist, ignore_errors=True)
+        self.record = os.path.join(self.dist + ".record")
+        self.addCleanup(lambda: os.path.exists(self.record)
+                        and os.remove(self.record))
+        Path(self.dist, "marker.txt").write_text("ORIG")
+
+        # A recorder backend: writes the marker bytes it actually sees.
+        self.cmd = os.path.join(self.dist + ".cmd")
+        self.addCleanup(lambda: os.path.exists(self.cmd)
+                        and os.remove(self.cmd))
+        Path(self.cmd).write_text(
+            "#!/bin/sh\ncat \"$1/marker.txt\" > \"%s\"\n" % self.record)
+        os.chmod(self.cmd, 0o755)
+
+        # Patch the gates out; gate_images injects the concurrent-writer race
+        # (replace the ORIGINAL marker AFTER the snapshot was taken).
+        self._saved = {}
+        dist = self.dist
+
+        def fake_gate_images(gate_dir, require_installer=True):
+            # The snapshot already happened; a racing writer clobbers the
+            # ORIGINAL tree now. gate_dir is the snapshot, not `dist`.
+            Path(dist, "marker.txt").write_text("EVIL")
+            return ({}, "pub")
+
+        for name, fn in (("gate_images", fake_gate_images),
+                         ("gate_provenance", lambda *a, **k: None),
+                         ("gate_latest", lambda *a, **k: None)):
+            self._saved[name] = getattr(publish, name)
+            setattr(publish, name, fn)
+
+        self._env = {}
+        for k, v in (("XPF_PUBLISH_CMD", self.cmd),
+                     ("XPF_IMAGE_BASE_URL", "https://images.invalid")):
+            self._env[k] = os.environ.get(k)
+            os.environ[k] = v
+
+    def tearDown(self):
+        for name, fn in self._saved.items():
+            setattr(publish, name, fn)
+        for k, v in self._env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_uploaded_bytes_are_the_gated_snapshot(self):
+        rc = publish.main(["--dist", self.dist, "--channel", "stable",
+                           "--no-apt", "--no-installer"])
+        self.assertEqual(rc, 0)
+        uploaded = Path(self.record).read_text()
+        # The original was clobbered to EVIL after the snapshot; the upload must
+        # carry the gated ORIG bytes. RED on revert (dispatch mutable tree).
+        self.assertEqual(uploaded, "ORIG",
+                         "publish uploaded the post-gate REPLACED bytes — the "
+                         "TOCTOU snapshot is not in effect (#4904 C).")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/image/bake.py
+++ b/scripts/image/bake.py
@@ -16,8 +16,10 @@ image to provision it) and exports it for both hypervisors:
                                           (only when XPF_SIGN_SECKEY is set)
 
 Pipeline: build the xpf .deb (`make deb`; no `make generate` — embeds the
-#1864 tracked shim) -> discover + SHA256-verify the latest Ubuntu cloud
-image (XPF_BASE_RELEASE pins) -> virt-resize root into a work disk ->
+#1864 tracked shim) -> discover + fetch the Ubuntu cloud image and
+authenticate it against the repo-PINNED SHA256 (a trust anchor NOT under
+the mirror's control; #4904 B — a same-endpoint checksum alone is not an
+authenticator) -> virt-resize root into a work disk ->
 virt-customize (runtime packages, linux-generic >= 6.18 with the full
 driver set, purge cloud-init/snapd/stale kernels, HOLD the kernel so apt
 cannot move the verifier floor (#1930), networkd, init_on_alloc=0,
@@ -177,6 +179,75 @@ def ensure_memlock():
 # XPF_UBUNTU_AUTODISCOVER=1 opts back into mirror-latest discovery.
 PINNED_BASE_RELEASE = "26.04"
 
+# #4904 B — supply-chain trust anchor for the Ubuntu base image. The image AND
+# its SHA256SUMS are fetched from the SAME configurable mirror endpoint
+# (base_url), so a same-endpoint checksum authenticates nothing against a
+# compromised/custom mirror or a TLS/DNS/CA compromise: the mirror can serve
+# matching malicious bytes+hash, and XPF would then sign the result with its
+# RELEASE key. The fix pins the expected base-image SHA256 in REVIEWED repo
+# metadata — a TRUST ANCHOR the mirror does not control — and verifies the
+# downloaded image against it (like the #1943 PINNED_BASE_RELEASE policy).
+#
+# Provenance of each pin: authored by fetching Canonical's SHA256SUMS +
+# SHA256SUMS.gpg from cloud-images.ubuntu.com and verifying the detached GPG
+# signature against Canonical's UEC Image Automatic Signing Key
+# (fingerprint D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81) — NOT trusting the
+# checksum on its own. A Canonical respin (new point image) changes the digest;
+# bumping the pin is then a DELIBERATE, REVIEWED commit (re-verify the GPG
+# signature first), exactly like a PINNED_BASE_RELEASE bump. Keyed by the same
+# release string discover_base_release() returns.
+PINNED_BASE_SHA256 = {
+    # ubuntu-26.04-server-cloudimg-amd64.img — Canonical-GPG-verified
+    # (UEC signing key D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81).
+    "26.04": "3ee4f67f322abb2d1d1f0fffc957f7411404ad6635dd35b026c8ff05ac6e534c",
+}
+
+
+def resolve_base_pin(rel):
+    """Return the pinned base-image SHA256 (the trust anchor) for release `rel`,
+    or None if unpinned. XPF_BASE_SHA256 is a reviewed one-off override (e.g. a
+    point respin between reviewed PINNED_BASE_SHA256 bumps, or an
+    XPF_BASE_RELEASE override) and wins over the repo constant."""
+    env = os.environ.get("XPF_BASE_SHA256")
+    if env:
+        return env.strip().lower()
+    pin = PINNED_BASE_SHA256.get(rel)
+    return pin.strip().lower() if pin else None
+
+
+def authenticate_base_digest(rel, actual):
+    """#4904 B: authenticate the downloaded base image against the repo-pinned
+    digest (a trust anchor NOT under the mirror's control). Returns True when
+    the digest matched a pin (authenticated), False when the base is unpinned
+    but the operator explicitly allowed it (XPF_ALLOW_UNPINNED_BASE=1, a
+    non-publishable dev bake). Aborts (die -> non-zero) on a pin MISMATCH or on
+    an unpinned base without that explicit escape hatch — a same-endpoint
+    checksum is never a sufficient authenticator on its own."""
+    pin = resolve_base_pin(rel)
+    if pin:
+        if actual.strip().lower() != pin:
+            die(f"base image digest {actual} does NOT match the pinned digest "
+                f"{pin} for Ubuntu {rel} — the mirror served bytes a reviewed "
+                "trust anchor does not vouch for. Refusing to bake a signed "
+                "image from an unauthenticated base (a compromised/wrong mirror, "
+                "or a stale pin after a Canonical respin: re-verify Canonical's "
+                "GPG-signed SHA256SUMS and bump PINNED_BASE_SHA256 via a "
+                "reviewed commit).")
+        return True
+    if os.environ.get("XPF_ALLOW_UNPINNED_BASE") == "1":
+        print(f"WARNING: no pinned SHA256 for Ubuntu {rel} — the base image is "
+              "authenticated ONLY by a checksum from the SAME mirror endpoint, "
+              "which is NOT a trust anchor. This image is NOT publishable as a "
+              f"release. Add PINNED_BASE_SHA256[{rel!r}] (Canonical-GPG-verified) "
+              "via a reviewed commit to authenticate it.", file=sys.stderr)
+        return False
+    die(f"no pinned base-image SHA256 for Ubuntu {rel} (PINNED_BASE_SHA256 has "
+        "no entry and XPF_BASE_SHA256 is unset). The base would be authenticated "
+        "only by a checksum from the SAME mirror endpoint as the image — not a "
+        "trust anchor. Pin it (Canonical-GPG-verified) via a reviewed commit, "
+        "set XPF_BASE_SHA256=<digest>, or pass XPF_ALLOW_UNPINNED_BASE=1 for a "
+        "non-publishable dev bake.")
+
 
 def discover_base_release():
     if os.environ.get("XPF_BASE_RELEASE"):
@@ -231,8 +302,19 @@ def fetch_base(cache_dir, work_dir):
     if expected != actual:
         os.remove(cached)
         die("base image SHA256 mismatch (cache removed — re-run)")
-    info("base image checksum verified.")
-    return rel, base_url, img, cached, actual
+    # The same-endpoint SHA256SUMS above only catches transport corruption — it
+    # is fetched from the SAME mirror as the image, so it is NOT an authenticator
+    # against a malicious mirror. #4904 B: authenticate the bytes against the
+    # repo-pinned digest (a trust anchor the mirror does not control). A mismatch
+    # (or an unpinned base without XPF_ALLOW_UNPINNED_BASE=1) aborts BEFORE the
+    # image is ever customized/signed.
+    pinned = authenticate_base_digest(rel, actual)
+    if pinned:
+        info("base image checksum verified + matches the pinned digest "
+             "(trust anchor).")
+    else:
+        info("base image checksum verified (UNPINNED base — not publishable).")
+    return rel, base_url, img, cached, actual, pinned
 
 
 def virt_customize(work_qcow, xpf_deb):
@@ -475,7 +557,8 @@ def validation_gate_step(skip_validate, qcow_out, meta_out):
     Aborts the bake (via die(), exit non-zero) if the gate FAILS, so a
     validation failure stops BEFORE signing (#4017). --skip-validate
     downgrades to a loud warning and skips the gate — the resulting
-    artifacts are marked non-publishable.
+    artifacts are marked non-publishable by the signed `validated: false`
+    provenance field in the manifest (#4904 A), which publish.py refuses.
     """
     if skip_validate:
         print("WARNING: --skip-validate — artifacts have NOT passed the in-guest "
@@ -537,6 +620,38 @@ def finalize_artifacts(*, validate_step, sign_step):
     """
     validate_step()
     sign_step()
+
+
+def build_manifest_text(*, ver, commit, base_url, base_img, rel, base_sha,
+                        base_pinned, validated, bake_date, kernel,
+                        proto_lines=""):
+    """Assemble the xpf-<ver>.manifest sidecar text (key: value lines).
+
+    Pure + unit-testable so the supply-chain PROVENANCE fields are asserted
+    without a full bake:
+      - `validated` (#4904 A): true only when the in-guest verify-dataplane gate
+        runs (a --skip-validate bake binds false). The publish gate REQUIRES
+        validated: true, so a signed-but-unvalidated dev/emergency image is no
+        longer indistinguishable from a release.
+      - `base_image_pinned` (#4904 B): whether the Ubuntu base was authenticated
+        against the repo-pinned trust-anchor digest (bound alongside the base
+        digest + source URL already recorded here).
+
+    The sidecar is covered by the signed xpf-<ver>.SHA256SUMS (#5042), so these
+    fields are authenticated once the manifest signature verifies.
+    """
+    return (
+        f"version: {ver}\n"
+        f"git_commit: {commit}\n"
+        f"base_image: {base_url}/{base_img}\n"
+        f"base_release: {rel}\n"
+        f"base_image_sha256: {base_sha}\n"
+        f"base_image_pinned: {'true' if base_pinned else 'false'}\n"
+        f"validated: {'true' if validated else 'false'}\n"
+        f"bake_date: {bake_date}\n"
+        f"bake_host_kernel: {kernel}\n"
+        + proto_lines
+    )
 
 
 def main():
@@ -615,7 +730,8 @@ def main():
                   "(in-guest gate still enforces).", file=sys.stderr)
 
         # 2. base
-        rel, base_url, base_img, cached, base_sha = fetch_base(cache_dir, work)
+        rel, base_url, base_img, cached, base_sha, base_pinned = fetch_base(
+            cache_dir, work)
 
         # 3. resize
         disk = os.environ.get("XPF_IMAGE_DISK_SIZE", "8G")
@@ -715,12 +831,16 @@ def main():
 
         manifest = os.path.join(a.out, f"xpf-{ver}.manifest")
         with open(manifest, "w") as f:
-            f.write(f"version: {ver}\ngit_commit: {commit}\n"
-                    f"base_image: {base_url}/{base_img}\nbase_release: {rel}\n"
-                    f"base_image_sha256: {base_sha}\n"
-                    f"bake_date: {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}\n"
-                    f"bake_host_kernel: {os.uname().release}\n"
-                    + proto_lines)
+            # #4904 A+B: bind the validated-provenance flag and the base-image
+            # pin-provenance flag into the sidecar (covered by the signed
+            # SHA256SUMS below). A --skip-validate bake records validated:false,
+            # which publish.py's fail-closed gate refuses.
+            f.write(build_manifest_text(
+                ver=ver, commit=commit, base_url=base_url, base_img=base_img,
+                rel=rel, base_sha=base_sha, base_pinned=base_pinned,
+                validated=not a.skip_validate,
+                bake_date=time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+                kernel=os.uname().release, proto_lines=proto_lines))
         info(f"manifest: {manifest}")
 
         # Per-version, version-named checksum manifest (#1924 §5.1): each bake

--- a/scripts/image/test_bake_base_pin.py
+++ b/scripts/image/test_bake_base_pin.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Unit tests for #4904 B — the Ubuntu base image is authenticated against a
+repo-PINNED SHA256 trust anchor, not just a checksum fetched from the SAME
+mirror endpoint as the image.
+
+`scripts/image/bake.py` fetched the cloud image AND its SHA256SUMS from the
+same configurable base_url, so a compromised/custom mirror (or a TLS/DNS/CA
+compromise) could serve matching malicious bytes+hash and XPF would sign the
+result with its release key. The fix pins the expected base-image digest in
+reviewed repo metadata (`PINNED_BASE_SHA256`, Canonical-GPG-verified) and
+enforces it in `authenticate_base_digest`, and binds the pin-provenance flag
+into the signed manifest (`build_manifest_text`).
+
+These tests are hermetic (no network, no libguestfs). On revert (drop the pin
+enforcement / return True unconditionally) the mismatch + unpinned tests go RED.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "bake", Path(__file__).with_name("bake.py")
+)
+bake = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(bake)
+
+# A distinct, syntactically-valid digest that is NOT any real pin.
+FAKE = "a" * 64
+
+
+class _EnvGuard(unittest.TestCase):
+    """Isolate the env vars this feature reads so tests never leak state."""
+
+    _KEYS = ("XPF_BASE_SHA256", "XPF_ALLOW_UNPINNED_BASE")
+
+    def setUp(self):
+        self._saved = {k: os.environ.pop(k, None) for k in self._KEYS}
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+class PinnedConstantTests(_EnvGuard):
+    """The reviewed repo pin exists for the pinned release and is a real
+    sha256. Guards against a truncated/whitespaced pin slipping in."""
+
+    def test_pinned_release_has_a_pin(self):
+        pin = bake.PINNED_BASE_SHA256.get(bake.PINNED_BASE_RELEASE)
+        self.assertIsNotNone(
+            pin, f"no PINNED_BASE_SHA256 entry for the pinned release "
+                 f"{bake.PINNED_BASE_RELEASE!r} — the default `make image` base "
+                 "would be unauthenticated against a trust anchor (#4904 B).")
+        self.assertRegex(pin.lower(), r"^[0-9a-f]{64}$",
+                         "the pinned base digest must be a bare sha256 hex.")
+
+    def test_2604_pin_matches_canonical_gpg_verified_value(self):
+        # The 26.04 pin was authored by verifying Canonical's SHA256SUMS.gpg
+        # against the UEC signing key D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81.
+        self.assertEqual(
+            bake.PINNED_BASE_SHA256.get("26.04"),
+            "3ee4f67f322abb2d1d1f0fffc957f7411404ad6635dd35b026c8ff05ac6e534c")
+
+
+class ResolveBasePinTests(_EnvGuard):
+    def test_repo_constant(self):
+        self.assertEqual(bake.resolve_base_pin("26.04"),
+                         bake.PINNED_BASE_SHA256["26.04"])
+
+    def test_unpinned_release_is_none(self):
+        self.assertIsNone(bake.resolve_base_pin("99.99"))
+
+    def test_env_override_wins_and_is_normalized(self):
+        os.environ["XPF_BASE_SHA256"] = "  " + FAKE.upper() + "  "
+        # Even for a release with a repo pin, the reviewed env override wins.
+        self.assertEqual(bake.resolve_base_pin("26.04"), FAKE)
+
+
+class AuthenticateBaseDigestTests(_EnvGuard):
+    def test_matching_pin_authenticates(self):
+        pin = bake.PINNED_BASE_SHA256["26.04"]
+        self.assertTrue(bake.authenticate_base_digest("26.04", pin))
+        # Case/whitespace-insensitive on the actual side too.
+        self.assertTrue(bake.authenticate_base_digest("26.04", pin.upper()))
+
+    def test_mismatch_aborts(self):
+        # RED on revert: without pin enforcement this would return True.
+        with self.assertRaises(SystemExit) as ctx:
+            bake.authenticate_base_digest("26.04", FAKE)
+        self.assertNotEqual(ctx.exception.code, 0)
+
+    def test_unpinned_without_escape_hatch_aborts(self):
+        with self.assertRaises(SystemExit) as ctx:
+            bake.authenticate_base_digest("99.99", FAKE)
+        self.assertNotEqual(ctx.exception.code, 0)
+
+    def test_unpinned_with_escape_hatch_returns_false(self):
+        os.environ["XPF_ALLOW_UNPINNED_BASE"] = "1"
+        # Explicit dev opt-out: proceeds but marks the base UNPINNED.
+        self.assertFalse(bake.authenticate_base_digest("99.99", FAKE))
+
+    def test_env_pin_match_and_mismatch(self):
+        os.environ["XPF_BASE_SHA256"] = FAKE
+        self.assertTrue(bake.authenticate_base_digest("99.99", FAKE))
+        with self.assertRaises(SystemExit):
+            bake.authenticate_base_digest("99.99", "b" * 64)
+
+
+class ManifestProvenanceBindingTests(_EnvGuard):
+    """#4904 A+B: the signed manifest binds `validated` and the base digest +
+    `base_image_pinned` provenance. build_manifest_text is the pure assembler
+    main() writes, so we assert the fields without a full bake."""
+
+    def _text(self, *, base_pinned, validated):
+        return bake.build_manifest_text(
+            ver="9.9.9-test", commit="deadbeef",
+            base_url="https://mirror.invalid/rel", base_img="ubuntu.img",
+            rel="26.04", base_sha=FAKE, base_pinned=base_pinned,
+            validated=validated, bake_date="2026-01-01T00:00:00Z",
+            kernel="6.18.0-test")
+
+    def test_base_digest_and_pin_bound(self):
+        t = self._text(base_pinned=True, validated=True)
+        self.assertIn(f"base_image_sha256: {FAKE}\n", t)
+        self.assertIn("base_image_pinned: true\n", t)
+        self.assertIn("base_image: https://mirror.invalid/rel/ubuntu.img\n", t)
+
+    def test_validated_true_and_false(self):
+        self.assertIn("validated: true\n",
+                      self._text(base_pinned=True, validated=True))
+        self.assertIn("validated: false\n",
+                      self._text(base_pinned=True, validated=False))
+        self.assertIn("base_image_pinned: false\n",
+                      self._text(base_pinned=False, validated=True))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/run-selftests.sh
+++ b/scripts/run-selftests.sh
@@ -135,7 +135,7 @@ fi
 
 # ── 3. python unittest self-tests (image / deploy / scripts root) ──
 hdr "python self-tests"
-for t in scripts/image/test_*.py scripts/deploy/test_*.py scripts/test_*.py; do
+for t in scripts/image/test_*.py scripts/dist/test_*.py scripts/deploy/test_*.py scripts/test_*.py; do
 	[ -f "$t" ] || continue
 	run_py "$t"
 done


### PR DESCRIPTION
Closes #4904.

Three supply-chain provenance/integrity gaps in the image bake + distribution
publish tooling. Each let unverified or unintended bytes carry a trust-bearing
XPF release signature or reach the published tree. Build/release tooling only —
no runtime packet path, no lab/cluster. Distinct from fable-review-165
H-5/H-9/H-13/H-37.

## A. `--skip-validate` still produced a signed, publishable image set (C175-HC-013)
The validation gate downgraded to a stderr warning + `return`; `finalize_artifacts`
treated that as success and signed the manifest. No durable marker distinguished
the result from a validated release, so `publish.py`'s fail-closed gate shipped a
dev/emergency image that never booted/verified the dataplane.

**Fix:** `bake.py` binds a signed `validated: true|false` provenance field into
the `xpf-<ver>.manifest` sidecar (already covered by the signed
`xpf-<ver>.SHA256SUMS`, #5042). A `--skip-validate` bake records `validated:false`.
`publish.py`'s new `gate_provenance` REQUIRES `validated:true` and reads the
sidecar via the TOCTOU-safe `verify_listed_artifact_bytes` primitive. A
signed-but-unvalidated image is now refused at the fail-closed boundary.

## B. Base image authenticated by an unsigned same-endpoint checksum (C175-HC-028)
The Ubuntu cloud image AND its `SHA256SUMS` came from the same configurable
`base_url`; a compromised/custom mirror (or TLS/DNS/CA compromise) could serve
matching malicious bytes+hash and XPF would sign the result with its release key.

**Fix (trust anchor: repo-pinned digest):** pin the expected base-image SHA256 in
reviewed repo metadata (`PINNED_BASE_SHA256`) — a trust anchor NOT under the
mirror's control, bumped via a reviewed commit like the #1943 Ubuntu-parity
policy. The `26.04` pin was authored by verifying **Canonical's GPG-signed
`SHA256SUMS.gpg` against the UEC Image Automatic Signing Key**
(`D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81`), not by trusting the mirror.
`authenticate_base_digest` enforces the pin (mismatch aborts; an unpinned release
is refused unless `XPF_ALLOW_UNPINNED_BASE=1` or a reviewed `XPF_BASE_SHA256`
override). The authenticated digest, source URL, and `base_image_pinned` flag are
bound into the signed manifest.

## C. Publish gated a mutable tree, then uploaded whatever replaced it (C175-HC-023)
`gate_images` hashed artifacts + verified `install.sh` against the live tree, kept
no snapshot, then handed the same mutable path to the backend which reopened
files. A concurrent writer could replace an artifact/sidecar/`install.sh` after
the gate → a gate-pass log accompanied different uploaded bytes (incl. an unsigned
installer).

**Fix:** when an upload will happen, snapshot the tree into a private `0700`
staging dir (symlinks preserved AS symlinks so the symlink refusal still fires),
`fsync` it, then gate AND dispatch ONLY the snapshot. The bytes gated are the
exact bytes uploaded. A gate-only / `--dry-run` run gates the live tree directly
(no multi-GB copy).

## Validation — hermetic, auto-discovered by `scripts/run-selftests.sh`
- `scripts/image/test_bake_base_pin.py` (B) — 12 tests
- `scripts/dist/test_publish_provenance.py` (A) — 5 tests (SKIP without minisign)
- `scripts/dist/test_publish_snapshot.py` (C) — 4 tests
- `selftest.sh` section 8i (validated:false refused / validated:true control) +
  the baseline set now models the signed provenance sidecar
- `run-selftests.sh` now also discovers `scripts/dist/test_*.py`

Full suite green: **36 legs, 0 failed** (selftest.sh: 41 checks). `py_compile`
clean on all touched files.

### RED-on-revert evidence (per defect)
- **A** — neuter `gate_provenance` (early `return`) → `test_publish_provenance.py`
  FAILS 3 cases (validated:false, missing sidecar, post-sign tampered sidecar).
- **B** — make `authenticate_base_digest` return `True` unconditionally →
  `test_bake_base_pin.py` FAILS 4 cases (mismatch, unpinned-no-hatch, env mismatch,
  match-path guard).
- **C** — dispatch `dist` (mutable) instead of `gate_dir` (snapshot) →
  `test_publish_snapshot.py` FAILS the race test (uploads the REPLACED bytes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZdz6Z7tX6ichvASnwhbLB