### PR TITLE
firewall-filter: fail-closed on terminal action + next-term (#5142)

### DIFF
--- a/pkg/config/compiler_validate_strict_filter.go
+++ b/pkg/config/compiler_validate_strict_filter.go
@@ -1457,26 +1457,51 @@ func validateFilterTerminalConflictStrict(cfg *Config) error {
 				continue
 			}
 			for _, term := range filter.Terms {
-				if term == nil || len(term.TerminalActions) < 2 {
+				if term == nil {
 					continue
 				}
-				// Collect distinct terminals in first-seen order so the error
-				// is stable and reads in the order the operator wrote them.
-				seen := make(map[string]bool, len(term.TerminalActions))
-				distinct := make([]string, 0, len(term.TerminalActions))
-				for _, a := range term.TerminalActions {
-					if !seen[a] {
-						seen[a] = true
-						distinct = append(distinct, a)
+				// #4375: reject MORE THAN ONE distinct terminating action.
+				if len(term.TerminalActions) >= 2 {
+					// Collect distinct terminals in first-seen order so the
+					// error is stable and reads in the order the operator
+					// wrote them.
+					seen := make(map[string]bool, len(term.TerminalActions))
+					distinct := make([]string, 0, len(term.TerminalActions))
+					for _, a := range term.TerminalActions {
+						if !seen[a] {
+							seen[a] = true
+							distinct = append(distinct, a)
+						}
+					}
+					if len(distinct) > 1 {
+						return fmt.Errorf(
+							"firewall family %s filter %q term %q: conflicting "+
+								"terminating actions %s — a term may have at most one "+
+								"terminating action (accept/reject/discard are mutually "+
+								"exclusive)",
+							family, name, term.Name, strings.Join(distinct, " and "))
 					}
 				}
-				if len(distinct) > 1 {
+				// #5142 (security, fail-CLOSED): a SINGLE terminating action
+				// (discard/reject/accept) co-located with `then next term` is a
+				// contradiction — the terminal must apply its action, but
+				// next-term asks to fall through. A fall-through bit must NEVER
+				// suppress a parsed terminal (vSRX filter semantics). Before
+				// #5142 the loop skipped every term with fewer than two
+				// terminals, so `then discard; then next term;` committed and
+				// (on the runtime) fell through, leaving the implicit Accept in
+				// place — the deny was silently dropped (fail-OPEN). Reject the
+				// contradiction here, naming the filter+term. A modifier-only
+				// next-term term (no terminating action) is a VALID fall-through
+				// (#2544/#3427) and is left untouched.
+				if term.NextTerm && len(term.TerminalActions) > 0 {
 					return fmt.Errorf(
-						"firewall family %s filter %q term %q: conflicting "+
-							"terminating actions %s — a term may have at most one "+
-							"terminating action (accept/reject/discard are mutually "+
-							"exclusive)",
-						family, name, term.Name, strings.Join(distinct, " and "))
+						"firewall family %s filter %q term %q: terminating "+
+							"action %q cannot be combined with `then next term` — "+
+							"a terminating action (accept/reject/discard) always "+
+							"terminates and must not fall through to the next term "+
+							"(remove one)",
+						family, name, term.Name, term.TerminalActions[0])
 				}
 			}
 		}

--- a/pkg/config/firewall_terminal_nextterm_5142_test.go
+++ b/pkg/config/firewall_terminal_nextterm_5142_test.go
@@ -1,0 +1,127 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5142 (security, filter fail-open): a firewall-filter term with a terminating
+// action (discard/reject/accept) co-located with `then next term` is a
+// contradiction. A terminating deny MUST terminate and apply the deny; a
+// fall-through / next-term bit must NEVER suppress it (vSRX filter semantics).
+// Before #5142, validateFilterTerminalConflictStrict skipped any term with fewer
+// than two terminals, so a SINGLE terminal + `then next term` committed cleanly
+// and (on the runtime) fell through — leaving the implicit Accept in place, i.e.
+// the deny was silently dropped (fail-OPEN). This is distinct from #4375 (two
+// DISTINCT terminals) and #2544 (empty-action modifier-only next-term).
+//
+// FAIL-ON-REVERT: restore the `then next term` reject to the pre-#5142
+// `len(term.TerminalActions) < 2 { continue }` skip and TestFilterDiscard*Next*
+// go RED — CompileConfig accepts the discard+next-term contradiction.
+
+func TestFilterDiscardPlusNextTerm_5142(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter f term t then discard",
+		"set firewall family inet filter f term t then next term",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("term with `then discard` AND `then next term` must be rejected " +
+			"at commit (#5142 — a terminating deny cannot fall through)")
+	}
+	if !strings.Contains(err.Error(), "discard") ||
+		!strings.Contains(err.Error(), "next term") {
+		t.Fatalf("error %q must name the discard action and `next term`", err)
+	}
+	if !strings.Contains(err.Error(), `filter "f"`) ||
+		!strings.Contains(err.Error(), `term "t"`) {
+		t.Fatalf("error %q must name the offending filter and term", err)
+	}
+	// Tolerant load / peer-sync path must not brick (#1960 no-brick): the
+	// last-wins Action still drives the dataplane, but the operator never
+	// reaches this state through a commit.
+	if _, lerr := CompileConfigLenient(tree); lerr != nil {
+		t.Fatalf("lenient path must not hard-fail on the discard+next-term contradiction: %v", lerr)
+	}
+}
+
+func TestFilterRejectPlusNextTerm_5142(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter f term t then reject",
+		"set firewall family inet filter f term t then next term",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("term with `then reject` AND `then next term` must be rejected at commit (#5142)")
+	}
+	if !strings.Contains(err.Error(), "reject") ||
+		!strings.Contains(err.Error(), "next term") {
+		t.Fatalf("error %q must name the reject action and `next term`", err)
+	}
+}
+
+// An `accept` terminal + next-term is equally contradictory (a terminal always
+// terminates); reject it too so the invariant is symmetric.
+func TestFilterAcceptPlusNextTerm_5142(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter f term t then accept",
+		"set firewall family inet filter f term t then next term",
+	)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("term with `then accept` AND `then next term` must be rejected at commit (#5142)")
+	}
+}
+
+// inet6 must be gated identically (the validator walks both families).
+func TestFilterDiscardPlusNextTermV6_5142(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet6 filter f6 term t then discard",
+		"set firewall family inet6 filter f6 term t then next term",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("inet6 term with discard + next-term must be rejected (#5142)")
+	}
+	if !strings.Contains(err.Error(), "inet6") {
+		t.Fatalf("error %q must name the inet6 family", err)
+	}
+}
+
+// A modifier-only next-term term (count/log + `then next term`, NO terminating
+// action) is a VALID fall-through (#2544/#3427) and must compile cleanly — the
+// #5142 gate must NOT reject a legitimate fall-through.
+func TestFilterModifierOnlyNextTermAllowed_5142(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter ok term t1 then count c1",
+		"set firewall family inet filter ok term t1 then log",
+		"set firewall family inet filter ok term t1 then next term",
+		"set firewall family inet filter ok term t2 then discard",
+	)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("modifier-only `then next term` (no terminating action) must compile: %v", err)
+	}
+}
+
+// A bare `then next term` with no other action is a valid fall-through.
+func TestFilterBareNextTermAllowed_5142(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter ok term t1 then next term",
+		"set firewall family inet filter ok term t2 then accept",
+	)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("bare `then next term` fall-through must compile: %v", err)
+	}
+}
+
+// A single terminating action WITHOUT next-term remains the ordinary case and
+// must compile (no regression on the common path).
+func TestFilterSingleTerminalNoNextTermAllowed_5142(t *testing.T) {
+	for _, action := range []string{"accept", "reject", "discard"} {
+		tree := buildFilterTree(t,
+			"set firewall family inet filter ok term t then "+action,
+		)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("single terminal %q (no next-term) must compile: %v", action, err)
+		}
+	}
+}

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -128,6 +128,26 @@ Mirrors the BPF firewall-filter pipeline in userspace.
   matched count term (the earlier fall-through count terms were silently
   under-counted on the cached path only).
 
+  **Terminal + next_term is fail-CLOSED (#5142, security).** A term with
+  a REAL terminating action (`discard`/`reject`/`accept`) MUST terminate
+  and apply that action — a `next_term` / fall-through bit must NEVER
+  suppress it (vSRX filter semantics). The Go commit gate
+  (`validateFilterTerminalConflictStrict`) now hard-rejects `then discard;
+  then next term;` (a single terminal co-located with next-term), so the
+  contradiction never reaches a snapshot through a commit. Belt-and-
+  suspenders, the Rust compiler computes `continue_term :=
+  snap.action.is_empty() && routing_instance.is_empty()` — a term FALLS
+  THROUGH only when it carries no terminating action, so even a
+  mixed-version peer-sync snapshot that sets `next_term` on a
+  discard/reject term still TERMINATES (applies the deny). Before #5142
+  the compiler read `(snap.next_term || snap.action.is_empty()) &&
+  routing_instance.is_empty()`, so a discard/reject term carrying
+  `next_term=true` fell through and left the `FilterResult::default()`
+  implicit Accept in place — the deny was silently dropped (fail-OPEN).
+  A modifier-only next-term term (empty action) still falls through, and
+  a routing-instance (PBR) term is unchanged. Distinct from #4375 (two
+  DISTINCT terminals) and #2544 (empty-action modifier-only next-term).
+
   The same accumulate-all-fall-through-terms contract applies to
   three-color policers via `CachedThreeColorPolicers`. Every matched
   fall-through term's `then policer` runtime is folded into the cached

--- a/userspace-dp/src/filter/compiler.rs
+++ b/userspace-dp/src/filter/compiler.rs
@@ -924,13 +924,26 @@ fn parse_term(
         // #2544: this term falls through (applies modifiers, continues to the
         // next term) when it carries no terminating action. The Go control
         // plane sets next_term for both the explicit `then next term` and the
-        // modifier-only case. We OR in `snap.action.is_empty()` as a belt-and-
-        // suspenders guard so an older Go control plane that omits next_term but
-        // sends an empty-action modifier-only term still falls through instead
-        // of terminating as Accept. A routing-instance (PBR) term takes its own
-        // routing decision and is NOT a fall-through even with an empty action.
-        continue_term: (snap.next_term || snap.action.is_empty())
-            && snap.routing_instance.is_empty(),
+        // modifier-only case. A term with an empty action falls through; a
+        // routing-instance (PBR) term takes its own routing decision and is
+        // NOT a fall-through even with an empty action.
+        //
+        // #5142 (fail-CLOSED): a term that carries a REAL terminating action
+        // (accept/reject/discard) MUST terminate and apply that action, EVEN IF
+        // next_term is also set. `then discard; next term;` is a contradiction:
+        // the deny is a terminal, and a fall-through bit must NEVER suppress it
+        // (vSRX filter semantics). Before #5142 this read `(snap.next_term ||
+        // snap.action.is_empty()) && routing_instance.is_empty()`, so a
+        // discard/reject term carrying next_term=true fell through and left the
+        // `FilterResult::default()` implicit Accept in place — the deny was
+        // silently dropped (fail-OPEN). The Go commit gate
+        // (validateFilterTerminalConflictStrict) now rejects that contradiction,
+        // but the tolerant peer-sync path could still deliver one, so the
+        // runtime fails closed on its own: fall through ONLY when the action is
+        // empty. An empty action stays a fall-through whether or not next_term
+        // was set (belt-and-suspenders for an older Go control plane that omits
+        // next_term but sends a modifier-only term).
+        continue_term: snap.action.is_empty() && snap.routing_instance.is_empty(),
         count: snap.count.clone(),
         has_count: !snap.count.is_empty(),
         log: snap.log,

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -6830,6 +6830,197 @@ fn fallthrough_tx_selection_applies_forwarding_class_then_discards() {
 }
 
 // ---------------------------------------------------------------------------
+// #5142 (security, filter fail-open): a term carrying a REAL terminating action
+// (discard/reject/accept) AND next_term=true is a contradiction. The runtime
+// must FAIL CLOSED — the terminating deny MUST apply, the fall-through bit must
+// NEVER suppress it (vSRX filter semantics). The Go commit gate rejects the
+// contradiction, but the tolerant peer-sync path could still deliver such a
+// snapshot, so the compiler treats a nonempty action as terminating regardless
+// of next_term (continue_term := action.is_empty() && routing_instance.empty).
+//
+// FAIL-ON-REVERT: restore `continue_term: (snap.next_term ||
+// snap.action.is_empty()) && snap.routing_instance.is_empty()` and the
+// discard/reject asserts below go RED — the term falls through and the implicit
+// default Accept survives (fail-OPEN).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn terminal_discard_with_next_term_still_discards_5142() {
+    // A single term: `then discard` AND next_term=true (the #5142 contradiction
+    // a mixed-version peer could deliver). The deny MUST apply — the fall-through
+    // bit must not suppress it. There is no later term, so a fall-through would
+    // return the implicit default Accept (the fail-OPEN bug).
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "deny".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-web".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["80".into()],
+                action: "discard".into(),
+                next_term: true, // contradiction: terminal + fall-through
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    // The compiler must NOT mark a term with a real terminal action as a
+    // fall-through, even though next_term is set.
+    let filter = state.filters.get("inet:deny").expect("filter");
+    assert!(
+        !filter.terms[0].continue_term,
+        "a term with a terminal action must terminate, not fall through (#5142)"
+    );
+    let r = evaluate_filter(
+        &state,
+        "inet:deny",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        40000,
+        80,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        r.action,
+        FilterAction::Discard,
+        "discard+next_term must apply the deny, not fall through to implicit Accept (#5142)"
+    );
+}
+
+#[test]
+fn terminal_reject_with_next_term_still_rejects_5142() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "deny".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "reject-web".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["80".into()],
+                action: "reject".into(),
+                next_term: true,
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    let r = evaluate_filter(
+        &state,
+        "inet:deny",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        40000,
+        80,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        r.action,
+        FilterAction::Reject,
+        "reject+next_term must apply the deny, not fall through (#5142)"
+    );
+}
+
+#[test]
+fn terminal_discard_with_next_term_beats_later_accept_5142() {
+    // A discard+next_term term ahead of an `accept` term for the same 5-tuple:
+    // the fail-OPEN bug would fall through term0 and ACCEPT at term1. Fail-closed
+    // the discard terminates at term0.
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "order".into(),
+            family: "inet".into(),
+            terms: vec![
+                FirewallTermSnapshot {
+                    name: "drop-web".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["80".into()],
+                    action: "discard".into(),
+                    next_term: true,
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    name: "accept-all".into(),
+                    protocols: vec!["tcp".into()],
+                    action: "accept".into(),
+                    ..Default::default()
+                },
+            ],
+        }],
+        &[],
+    );
+    let r = evaluate_filter(
+        &state,
+        "inet:order",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        40000,
+        80,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(r.action, FilterAction::Discard);
+}
+
+#[test]
+fn modifier_only_next_term_still_falls_through_5142() {
+    // The valid #2544/#3427 case must be UNCHANGED by the #5142 fix: a
+    // modifier-only term (empty action) with next_term=true falls through and a
+    // later discard term applies.
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "mo".into(),
+            family: "inet".into(),
+            terms: vec![
+                FirewallTermSnapshot {
+                    name: "count-next".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["80".into()],
+                    action: String::new(), // modifier-only — no terminal
+                    next_term: true,
+                    count: "mo-hits".into(),
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    name: "drop-web".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["80".into()],
+                    action: "discard".into(),
+                    ..Default::default()
+                },
+            ],
+        }],
+        &[],
+    );
+    let filter = state.filters.get("inet:mo").expect("filter");
+    assert!(
+        filter.terms[0].continue_term,
+        "modifier-only next-term term must still fall through (#2544/#3427)"
+    );
+    let r = evaluate_filter(
+        &state,
+        "inet:mo",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        40000,
+        80,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        r.action,
+        FilterAction::Discard,
+        "modifier-only next-term must fall through to the later discard"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // #2573: the cached TX-selection path must record EVERY matched `then count`
 // term, not just the last. With #2544 fall-through a single packet can match
 // two count terms on the same flow-cache key; the old single-Arc slot kept only


### PR DESCRIPTION
Closes #5142

## Problem (security, filter fail-open)

A firewall-filter term with a terminating action (`then discard` /
`then reject` / `then accept`) co-located with `then next term` silently
compiled to an implicit **PERMIT** (fail-open). A parsed terminal deny
MUST terminate and apply its deny — a fall-through / next-term bit must
NEVER suppress it (vSRX filter semantics).

- **Rust runtime**: `continue_term = (snap.next_term || snap.action.is_empty()) && routing_instance.is_empty()` (`userspace-dp/src/filter/compiler.rs`). A discard/reject term carrying `next_term=true` set `continue_term=true`, so `evaluate_filter_ref_counted_v4/v6` (`engine/eval.rs`) never assigned `acc.action = term.action` and the term fell through → the `FilterResult::default()` implicit Accept survived and the deny was dropped.
- **Go commit gate**: `validateFilterTerminalConflictStrict` (`pkg/config/compiler_validate_strict_filter.go`) skipped any term with `len(TerminalActions) < 2`, so a single terminal (discard/reject/accept) + NextTerm passed commit.

Distinct from **#4375** (two DISTINCT terminals) and **#2544** (empty-action modifier-only next-term).

## Fix (both sides — defense in depth)

- **Go (commit gate, reject)**: keep the existing >=2-distinct-terminal rejection (#4375); ADD a hard reject when a term carries `NextTerm` AND at least one terminal action, naming the filter+term. A modifier-only next-term term (no terminal action) stays a valid fall-through (#2544/#3427).
- **Rust (runtime, fail-closed)**: `continue_term = snap.action.is_empty() && snap.routing_instance.is_empty()` — a term falls through ONLY when it carries no terminating action, so a nonempty terminal action always terminates (applies the deny) even if `next_term` is set. Fails closed even on a mixed-version peer-sync snapshot the Go gate never saw. Modifier-only fall-through and routing-instance (PBR) semantics unchanged.

## Validation

**Go**: `go build ./...` clean; `go test ./pkg/config/...` green.
RED-on-revert: neutering the new NextTerm reject → the four
discard/reject/accept + next-term tests (incl inet6) FAIL:
```
--- FAIL: TestFilterDiscardPlusNextTerm_5142
--- FAIL: TestFilterRejectPlusNextTerm_5142
--- FAIL: TestFilterAcceptPlusNextTerm_5142
--- FAIL: TestFilterDiscardPlusNextTermV6_5142
```

**Rust**: full `cargo test --release` = **3909 passed, 0 failed**. New
filter-eval tests run 5x, no flake. RED-on-revert: restoring the old
`continue_term` →
```
thread 'filter::tests::terminal_discard_with_next_term_still_discards_5142' panicked:
a term with a terminal action must terminate, not fall through (#5142)
test result: FAILED. 0 passed; 1 failed
```
(the term falls through and the implicit default Accept survives).

**Loss-cluster forwarding smoke: DEFERRED.** The change is fail-CLOSED
(over-deny), low regression risk; `cargo test --release` covers the eval
unit behavior. #5364 constraints — the parent will record the deferred
smoke.

This is a **Go + Rust dataplane change** (cargo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKz4ZxYGAA2zKtWk4kie7s