### PR TITLE
deploy: reject non-positive xpf-deploy --lease-ttl (#5470)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45434,3 +45434,24 @@ top.
 - **Timestamp**: 2026-07-10
 - **Action**: Test-coverage-only (no production change). Added pkg/cli/chrony_test.go — a table-driven test for printChronyTracking (pkg/cli/chrony.go), the `chronyc tracking` output parser behind `show system ntp status`, which had zero unit coverage. Captures stdout via the existing captureStdout helper and asserts the rendered Junos-style block. Cases: fully-synchronised block (exact 12-line match over all 11 rendered fields in fixed order, plus omission checks that chronyc's Residual freq / Skew and the Skew value do NOT leak); unsynchronised block (Leap status "Not synchronised" verbatim); unusual leap status ("Insert second"); malformed lines with no " : " separator ignored + leading-separator empty-key line skipped by the idx>0 guard; duplicated key keeps last value (map overwrite); empty input renders only the header. Verified non-tautological: mutating the Leap-status lookup key in chrony.go turns the test RED; revert → GREEN. No production bug found — parser behaves correctly for all fed inputs (the line[idx+3:] slice is not out-of-bounds, as the issue notes). Validation: `go test ./pkg/cli/...` green; gofmt clean.
 - **File(s)**: pkg/cli/chrony_test.go, _Log.md
+
+## 2026-07-10 — #5470 xpf-deploy --lease-ttl positive-value validation
+- **Timestamp**: 2026-07-10
+- **Action**: Fixed unconstrained `type=int` on both `--lease-ttl` parsers
+  (kernel-roll + image-roll) in scripts/deploy/xpf-deploy.py. Added a shared
+  `positive_int()` argparse `type=` callable that rejects 0/negative/non-int at
+  parse time (raises argparse.ArgumentTypeError → usage error + exit 2, BEFORE
+  any remote/deploy action). A non-positive TTL made `_acquire_lease` render
+  `expires_at = now + ttl` with the strict `now < expires` guard treating the
+  lease as already-expired the instant it is written — the cross-orchestrator
+  roll mutex never held, so two drivers could drain opposite HA nodes into a
+  no-primary outage. Rejects rather than silently clamps (fail-closed). Added
+  scripts/deploy/test_xpf_deploy_lease_ttl.py (10 cases): pure `positive_int`
+  accept/reject + end-to-end parser wiring for both roll subcommands
+  (reject 0/negative w/ exit 2 and handler-not-called; accept positive w/
+  parsed lease_ttl; default 1800 unchanged). RED-on-revert PROVEN: reverting
+  either arm to `type=int` fails the 3 reject tests (SystemExit not raised).
+  Updated docs/in-place-upgrade.md with the `--lease-ttl` positivity contract.
+  Validation: `python3 -m py_compile` clean; `bash scripts/run-selftests.sh`
+  green (37 passed, 0 failed, includes the new test).
+- **File(s)**: scripts/deploy/xpf-deploy.py, scripts/deploy/test_xpf_deploy_lease_ttl.py, docs/in-place-upgrade.md, _Log.md

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -752,6 +752,18 @@ until `status` reports `promoted=<ver>` AND `uname -r` matches, then
 A reverted node boots the OLD kernel and reports `promoted!=<ver>` → the
 driver STOPS and never touches the peer (never-both-down).
 
+The reservation lease TTL is `--lease-ttl <seconds>` (default 1800). It
+MUST be a strictly-positive integer: the lease deadline is rendered as
+`expires_at = now + ttl` and the acquire guard is a strict `now <
+expires`, so a non-positive TTL yields a lease that is already expired
+the instant it is written — the cross-orchestrator mutex never holds and
+two independent drivers could each take a node's flock in turn and drain
+OPPOSITE nodes into a no-primary outage. The parser rejects `0`/negative
+at argument time (exit 2) rather than silently clamping; size the TTL to
+comfortably exceed the whole roll (`--boot-deadline` plus drain/rejoin
+margins). The same `--lease-ttl` contract applies to `image-roll`
+(#5470).
+
 The poll decides "the node rebooted" from an AFFIRMATIVE signal only — a
 CHANGED `boot_id` (`/proc/sys/kernel/random/boot_id`, recorded pre-arm) or the
 candidate kernel actually running — never from an empty status read (#4905-A).

--- a/scripts/deploy/test_xpf_deploy_lease_ttl.py
+++ b/scripts/deploy/test_xpf_deploy_lease_ttl.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Unit tests for --lease-ttl positive-value validation (#5470).
+
+The LANE-1/LANE-2 HA roll drivers (`kernel-roll` / `image-roll`) reserve BOTH
+nodes with a lease whose deadline is `expires_at = now + --lease-ttl`, and the
+acquire guard is a STRICT `now < expires`. Both `--lease-ttl` parsers used an
+unconstrained `type=int`, so `--lease-ttl 0` (or negative) was accepted and
+produced a lease that is already expired the instant it is written: the
+cross-orchestrator mutex never holds, and two independent drivers could each
+take a node's flock in turn and drain OPPOSITE HA nodes into a no-primary
+forwarding outage.
+
+The fix routes both `--lease-ttl` parsers through the shared `positive_int`
+argparse `type=` callable, which rejects 0 / negative BEFORE any remote action
+(argparse maps its `ArgumentTypeError` to a usage error + exit code 2). These
+tests cover the pure callable and the end-to-end parser wiring for both roll
+subcommands.
+
+RED on revert: change either `--lease-ttl` back to `type=int` (or make
+`positive_int` accept `n == 0`) and `test_kernel_roll_rejects_zero_ttl` /
+`test_image_roll_rejects_zero_ttl` flip — the bad TTL sails past the parser and
+dispatches into the roll handler instead of exiting non-zero.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import importlib.util
+import io
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_SPEC = importlib.util.spec_from_file_location(
+    "xpf_deploy", Path(__file__).with_name("xpf-deploy.py"))
+xpf_deploy = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(xpf_deploy)
+
+
+class PositiveIntTests(unittest.TestCase):
+    """The pure argparse `type=` callable (#5470 crux)."""
+
+    def test_accepts_positive(self):
+        self.assertEqual(xpf_deploy.positive_int("1"), 1)
+        self.assertEqual(xpf_deploy.positive_int("1800"), 1800)
+        # Already an int (argparse passes strings, but be robust).
+        self.assertEqual(xpf_deploy.positive_int(42), 42)
+
+    def test_rejects_zero(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            xpf_deploy.positive_int("0")
+
+    def test_rejects_negative(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            xpf_deploy.positive_int("-1")
+        with self.assertRaises(argparse.ArgumentTypeError):
+            xpf_deploy.positive_int("-1800")
+
+    def test_rejects_non_integer(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            xpf_deploy.positive_int("notanint")
+        with self.assertRaises(argparse.ArgumentTypeError):
+            xpf_deploy.positive_int("1.5")
+
+
+def _run_main(argv):
+    """Drive main() with a synthetic argv, swallowing argparse's stderr usage
+    text. Returns whatever main() returns (or raises SystemExit on a parse
+    error / usage exit)."""
+    with mock.patch.object(sys, "argv", ["xpf-deploy.py", *argv]), \
+            contextlib.redirect_stderr(io.StringIO()):
+        return xpf_deploy.main()
+
+
+_KERNEL_ROLL_BASE = [
+    "kernel-roll", "--node", "fw0", "--node", "fw1", "--version", "6.99.0-cand",
+]
+_IMAGE_ROLL_BASE = [
+    "image-roll", "--node", "fw0", "--node", "fw1", "--manifest", "x.manifest",
+]
+
+
+class LeaseTtlParserWiringTests(unittest.TestCase):
+    """End-to-end: the parser rejects a non-positive --lease-ttl BEFORE any
+    roll handler runs, and accepts a positive one (both roll subcommands)."""
+
+    def test_kernel_roll_rejects_zero_ttl(self):
+        with mock.patch.object(xpf_deploy, "cmd_kernel_roll") as handler:
+            with self.assertRaises(SystemExit) as cm:
+                _run_main(_KERNEL_ROLL_BASE + ["--lease-ttl", "0"])
+        self.assertEqual(cm.exception.code, 2)
+        handler.assert_not_called()   # rejected at parse time, no remote action
+
+    def test_kernel_roll_rejects_negative_ttl(self):
+        with mock.patch.object(xpf_deploy, "cmd_kernel_roll") as handler:
+            with self.assertRaises(SystemExit) as cm:
+                _run_main(_KERNEL_ROLL_BASE + ["--lease-ttl", "-5"])
+        self.assertEqual(cm.exception.code, 2)
+        handler.assert_not_called()
+
+    def test_kernel_roll_accepts_positive_ttl(self):
+        with mock.patch.object(xpf_deploy, "cmd_kernel_roll",
+                               return_value=0) as handler:
+            rc = _run_main(_KERNEL_ROLL_BASE + ["--lease-ttl", "60"])
+        self.assertEqual(rc, 0)
+        handler.assert_called_once()
+        self.assertEqual(handler.call_args.args[0].lease_ttl, 60)
+
+    def test_image_roll_rejects_zero_ttl(self):
+        with mock.patch.object(xpf_deploy, "cmd_image_roll") as handler:
+            with self.assertRaises(SystemExit) as cm:
+                _run_main(_IMAGE_ROLL_BASE + ["--lease-ttl", "0"])
+        self.assertEqual(cm.exception.code, 2)
+        handler.assert_not_called()
+
+    def test_image_roll_accepts_positive_ttl(self):
+        with mock.patch.object(xpf_deploy, "cmd_image_roll",
+                               return_value=0) as handler:
+            rc = _run_main(_IMAGE_ROLL_BASE + ["--lease-ttl", "900"])
+        self.assertEqual(rc, 0)
+        handler.assert_called_once()
+        self.assertEqual(handler.call_args.args[0].lease_ttl, 900)
+
+    def test_default_ttl_still_accepted(self):
+        # No --lease-ttl -> default 1800 flows through unchanged.
+        with mock.patch.object(xpf_deploy, "cmd_kernel_roll",
+                               return_value=0) as handler:
+            _run_main(_KERNEL_ROLL_BASE)
+        self.assertEqual(handler.call_args.args[0].lease_ttl, 1800)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/deploy/xpf-deploy.py
+++ b/scripts/deploy/xpf-deploy.py
@@ -90,6 +90,33 @@ def die(msg):
     sys.exit(f"ERROR: {msg}")
 
 
+def positive_int(value):
+    """argparse ``type=`` callable: parse a STRICTLY-positive integer (> 0).
+
+    Rejects 0 / negative (and non-integer) input at parse time — argparse maps a
+    raised ``ArgumentTypeError`` to a usage error with a clear message and exit
+    code 2, BEFORE any remote/deploy action runs. We reject rather than silently
+    clamp: a bad operator input fails closed.
+
+    This guards ``--lease-ttl`` (#5470). ``_acquire_lease`` renders the roll
+    lease deadline as ``expires_at = now + ttl`` and the acquire guard is a
+    strict ``now < expires``, so a non-positive TTL yields a lease that is
+    already expired the instant it is written. The cross-orchestrator
+    kernel/image-roll mutex then never actually holds, and two independent
+    drivers could each take a node's flock in turn and drain OPPOSITE HA nodes
+    into a no-primary forwarding outage. The TTL must be a positive integer of
+    seconds; operators should size it to comfortably exceed the whole roll
+    (``--boot-deadline`` plus drain/rejoin margins, default 1800s)."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(f"'{value}' is not an integer")
+    if n <= 0:
+        raise argparse.ArgumentTypeError(
+            f"must be a positive integer of seconds (> 0), got {n}")
+    return n
+
+
 # ── identifier / path-containment safety (#4905-B) ────────────────────
 # The appliance `name` and `image` are interpolated straight into filesystem
 # paths that this tool WRITES and REMOVES (often via sudo): the day-0 ISO in
@@ -1966,9 +1993,10 @@ def main():
                          help="cluster node-id of the FIRST --node (default 0)")
         sub.add_argument("--node1-id", type=int, default=1,
                          help="cluster node-id of the SECOND --node (default 1)")
-        sub.add_argument("--lease-ttl", type=int, default=1800,
-                         help="kernel-roll lease TTL seconds (suppresses the "
-                              "node's local self-recovery during the roll)")
+        sub.add_argument("--lease-ttl", type=positive_int, default=1800,
+                         help="kernel-roll lease TTL seconds (must be > 0; "
+                              "suppresses the node's local self-recovery during "
+                              "the roll)")
         sub.add_argument("--boot-deadline", type=int, default=600,
                          help="seconds to wait for a node to boot + promote the "
                               "candidate before STOPPING the roll")
@@ -2003,9 +2031,10 @@ def main():
                          help="cluster node-id of the FIRST --node (default 0)")
         sub.add_argument("--node1-id", type=int, default=1,
                          help="cluster node-id of the SECOND --node (default 1)")
-        sub.add_argument("--lease-ttl", type=int, default=1800,
-                         help="image-roll lease TTL seconds (cross-orchestrator "
-                              "mutex; also suppresses the node's self-recovery)")
+        sub.add_argument("--lease-ttl", type=positive_int, default=1800,
+                         help="image-roll lease TTL seconds (must be > 0; "
+                              "cross-orchestrator mutex; also suppresses the "
+                              "node's self-recovery)")
         sub.add_argument("--drain-deadline", type=int, default=30,
                          help="seconds to confirm the drain/rejoin predicate")
         sub.add_argument("--boot-deadline", type=int, default=600,


### PR DESCRIPTION
Closes #5470

## Problem
Both `--lease-ttl` parsers (`kernel-roll` and `image-roll`) in
`scripts/deploy/xpf-deploy.py` used an unconstrained `type=int`, so
`--lease-ttl 0` (or negative) was accepted. `_acquire_lease` renders the
roll reservation deadline as `expires_at = now + ttl` and the acquire guard
is a strict `now < expires`, so a non-positive TTL yields a lease that is
**already expired the instant it is written**. The cross-orchestrator
kernel/image-roll mutex then never actually holds — a second orchestrator can
take each node's flock after the first releases it, overwrite both leases,
pass its peer-ready precheck, and drain the *opposite* HA node. Two
independent drivers can produce a no-primary forwarding outage across all RGs.

## Fix
- Add a shared `positive_int()` argparse `type=` callable (near `die()`) that
  rejects `0` / negative / non-integer input. argparse maps the raised
  `ArgumentTypeError` to a usage error with a clear message and **exit code 2**,
  before any remote/deploy action runs — fail-closed on bad operator input,
  no silent clamping.
- Wire both `--lease-ttl` args (kernel-roll + image-roll) to
  `type=positive_int`.
- Floor: strictly positive (`> 0`) — the exact invariant the issue names.
  There is no documented numeric minimum for `--lease-ttl`; the doc note
  guides operators to size it above the whole roll (`--boot-deadline` plus
  drain/rejoin margins, default 1800s) rather than imposing an arbitrary
  higher clamp that would reject legitimate short test rolls.

## Test (`scripts/deploy/test_xpf_deploy_lease_ttl.py`, auto-discovered by `run-selftests.sh`)
10 cases:
- Pure `positive_int`: accepts `1`/`1800`/`42`; rejects `0`, `-1`, `-1800`,
  `notanint`, `1.5`.
- End-to-end parser wiring for **both** roll subcommands: a non-positive TTL
  exits `2` with the roll handler **never invoked** (rejected at parse time,
  before any remote action); a positive TTL flows through to the handler with
  the parsed `lease_ttl`; the default `1800` is unchanged.

**RED on revert (proven):** switching either arm back to `type=int` fails the
three reject tests (`SystemExit not raised`).

## Docs
`docs/in-place-upgrade.md` — added the `--lease-ttl` positivity contract next
to the LANE-1 kernel-roll orchestration description (applies to `image-roll`
too).

## Validation
- `python3 -m py_compile scripts/deploy/xpf-deploy.py` — clean
- `bash scripts/run-selftests.sh` — green (37 passed, 0 failed, includes the
  new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ags1cBev6G7ZdctA9eYN8N