### PR TITLE
deploy: gate image-roll rejoin on node identity + build (#5075)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45455,3 +45455,23 @@ top.
   Validation: `python3 -m py_compile` clean; `bash scripts/run-selftests.sh`
   green (37 passed, 0 failed, includes the new test).
 - **File(s)**: scripts/deploy/xpf-deploy.py, scripts/deploy/test_xpf_deploy_lease_ttl.py, docs/in-place-upgrade.md, _Log.md
+
+- **Timestamp**: 2026-07-10
+  **Action**: #5075 — image-roll post-recreate readiness now verifies node
+  IDENTITY + BUILD, not just "any responding xpfd". Added
+  `_recreated_node_matches()` (pure identity+version predicate) and
+  `_node_cluster_node_id()` (reads /etc/xpf/node-id) in
+  `scripts/deploy/xpf-deploy.py`; rewired `cmd_image_roll`'s post-recreate
+  poll to require live `xpf-version` == the AUTHENTICATED manifest's
+  xpf-version AND /etc/xpf/node-id == the assigned cluster node-id before
+  treating the node as "back". Fails CLOSED with the never-both-down leases
+  HELD on a stale-alias / old-image / wrong-node-id recreate; existing
+  retry/timeout preserved. Added
+  `scripts/deploy/test_xpf_deploy_image_roll_identity.py` (12 tests, RED on
+  revert: wrong-build + wrong-node-id recreations accepted by the old code).
+  Updated the LANE-2 image-roll section of docs/in-place-upgrade.md.
+  Validation: `python3 -m py_compile scripts/deploy/xpf-deploy.py` clean;
+  `bash scripts/run-selftests.sh` green (38 passed, 0 failed).
+- **File(s)**: scripts/deploy/xpf-deploy.py,
+  scripts/deploy/test_xpf_deploy_image_roll_identity.py,
+  docs/in-place-upgrade.md, _Log.md

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -918,9 +918,32 @@ node from a new baked image ONE AT A TIME (built on the existing per-node
    mechanics stay environment-specific). The node boots the new base,
    factory-bootstraps its config DB from the day-0 text, verifies the
    dataplane.
-4. **poll** until it is back (xpfd answers `protocol-versions`), then
-   **rejoin** + confirm sync BEFORE touching node[1] (never-both-down;
-   the INC-2 `rejoin` verb). Repeat for node[1].
+4. **poll** until it is back **as the EXPECTED node on the EXPECTED
+   build**, then **rejoin** + confirm sync BEFORE touching node[1]
+   (never-both-down; the INC-2 `rejoin` verb). Repeat for node[1].
+
+   **Identity + version gate (#5075).** "Back" is NOT merely "some xpfd
+   answers `protocol-versions`". Before #5075 the poll accepted ANY
+   responding xpfd (a non-empty `xpf-version`), so a `--recreate-hook`
+   that relaunched the OLD image, a stale alias, or the WRONG node-id
+   satisfied it — the driver rejoined the wrong/old node and rolled the
+   peer onto unintended/mixed software, a **silent deploy-integrity
+   failure**. The poll now requires the responding daemon to be BOTH:
+   - the **expected build** — its live `xpf-version` EXACTLY equals the
+     AUTHENTICATED manifest's `xpf-version` (the same signed
+     `xpf-<ver>.manifest` bytes the mixed-base gate reads, so no extra
+     trust input is introduced), AND
+   - the **expected node** — its `/etc/xpf/node-id` (the marker xpfd
+     itself keys HA identity on) equals the cluster node-id the deploy
+     assigned this node (`--node0-id` / `--node1-id`).
+
+   The existing retry/timeout is preserved (keep polling until the gate
+   passes or `--boot-deadline` elapses), but a responding-but-wrong daemon
+   is **fail-closed**: the roll ERRORS with the never-both-down leases
+   HELD (the peer stays primary, the half-rolled pair is left for the
+   operator to investigate) instead of silently proceeding. Covered by
+   `scripts/deploy/test_xpf_deploy_image_roll_identity.py` (RED on revert:
+   the old node / wrong node-id is accepted and the roll completes).
 
 When draining node[1] (the SECOND node), its peer is the already-rolled
 NEW image, so the drain's exact-equality HA precheck is relaxed with

--- a/scripts/deploy/test_xpf_deploy_image_roll_identity.py
+++ b/scripts/deploy/test_xpf_deploy_image_roll_identity.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Unit tests for the image-roll post-recreate IDENTITY + VERSION gate (#5075).
+
+In the LANE-2 HA image roll, each node is DRAINED to its peer, then RECREATED
+from the new golden image by an operator-supplied `--recreate-hook`
+(destroy + launch + day-0). The driver then polls until the node "comes back"
+before rejoining it and moving on to the peer.
+
+Before the fix, the readiness poll accepted ANY responding xpfd:
+
+    pv = _node_protocol_versions(runner, backend, node)
+    if pv.get("xpf-version"):      # <-- non-empty is enough
+        back = True
+
+so a `--recreate-hook` that relaunched the OLD image, a stale alias, or the
+WRONG node-id satisfied the poll. The driver rejoined the wrong/old node and
+proceeded to the peer with the pair on unintended/mixed software — a silent
+deploy-integrity failure (the operator believes the image rolled when it did
+not, or rolled the wrong node).
+
+The fix requires the responding xpfd to be BOTH:
+  - the EXPECTED build: its live `xpf-version` EXACTLY equals the AUTHENTICATED
+    image manifest's xpf-version (`new_img`, already verified against the signed
+    SHA256SUMS for the mixed-base gate), AND
+  - the EXPECTED node: its /etc/xpf/node-id (the marker xpfd itself keys HA
+    identity on) equals the cluster node-id the deploy assigned.
+Any mismatch FAILS CLOSED with the never-both-down leases HELD; the peer stays
+primary and the roll ERRORS instead of silently accepting.
+
+RED on revert: restore `if pv.get("xpf-version"): back = True; break` (drop the
+`_recreated_node_matches` gate) and both `test_wrong_build_recreate_rejected`
+and `test_wrong_node_id_recreate_rejected` flip GREEN->RED — the old/wrong node
+is accepted, the roll COMPLETES (rc=0) instead of raising SystemExit, and the
+peer is rolled onto unintended software.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_SPEC = importlib.util.spec_from_file_location(
+    "xpf_deploy", Path(__file__).with_name("xpf-deploy.py"))
+xpf_deploy = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(xpf_deploy)
+
+NEWVER = "2.0.0-newimage"
+OLDVER = "1.0.0-oldimage"
+
+# The AUTHENTICATED image manifest the mixed-base gate + the #5075 identity gate
+# read. Only xpf-version drives the identity gate; the ha/session-sync fields
+# keep the (separately-tested) mixed-base gate passing so the roll reaches the
+# post-recreate poll under test.
+NEW_MANIFEST = {
+    "xpf-version": NEWVER,
+    "ha-protocol-version": "3",
+    "ha-protocol-min-compat": "2",
+    "session-sync-protocol-version": "5",
+}
+
+
+def _reported(xpf_version):
+    """The `xpfd protocol-versions` a node REPORTS. ha/session-sync are held
+    identical to NEW_MANIFEST so the mixed-base gate always passes — this suite
+    targets the #5075 identity+version gate, not the mixed-base gate."""
+    return {
+        "xpf-version": xpf_version,
+        "ha-protocol-version": "3",
+        "session-sync-protocol-version": "5",
+    }
+
+
+class _Clock:
+    """Monotonic fake clock so the boot-deadline poll loop terminates fast under
+    mocked time.sleep. Each call advances `step`; with boot_deadline=40 and
+    step=15 the reject path runs ~2 iterations then the deadline elapses."""
+
+    def __init__(self, start=1000.0, step=15.0):
+        self.t = start
+        self.step = step
+
+    def __call__(self):
+        v = self.t
+        self.t += self.step
+        return v
+
+
+class _RollFake:
+    """Scripted `_node_exec` for cmd_image_roll. Each node reports its OWN
+    xpf-version and its OWN /etc/xpf/node-id, so a recreation can be driven to
+    the correct or the wrong build / node-id. Records drains and rejoins so a
+    test can assert the peer was never touched on a rejected roll."""
+
+    def __init__(self, reported, node_ids):
+        # reported: {node_name: xpf_version_or_None}  (None => xpfd not answering)
+        # node_ids: {node_name: int_or_None}          (None => /etc/xpf/node-id absent)
+        self.reported = reported
+        self.node_ids = node_ids
+        self.drained = []
+        self.rejoined = []
+
+    def __call__(self, runner, backend, node, argv, check=True):
+        # Lease acquire/clear + the drain --help feature probe all arrive as
+        # ["sh", "-c", <script>]; ACQUIRED satisfies _acquire_lease and the
+        # probe simply won't find "allow-mixed-ha" (drains without the flag).
+        if argv[:2] == ["sh", "-c"]:
+            return "ACQUIRED\n"
+        if argv == ["xpfd", "protocol-versions"]:
+            xv = self.reported.get(node)
+            d = _reported(xv) if xv is not None else {}
+            return "".join(f"{k}={v}\n" for k, v in d.items())
+        if argv == ["cat", "/etc/xpf/node-id"]:
+            nid = self.node_ids.get(node)
+            return "" if nid is None else f"{nid}\n"
+        if argv[:4] == ["xpfd", "upgrade", "kernel", "drain"]:
+            self.drained.append(node)
+            return ""
+        if argv[:4] == ["xpfd", "upgrade", "kernel", "rejoin"]:
+            self.rejoined.append(node)
+            return ""
+        return ""
+
+
+def _img_args():
+    return types.SimpleNamespace(
+        dry_run=False, backend="ssh", nodes=["fw0", "fw1"],
+        node0_id=0, node1_id=1,
+        recreate_hook="/bin/true",
+        manifest="xpf-2.0.0-newimage.manifest",
+        sha256sums=None, sig=None, pubkey=None,
+        lease_ttl=1800, drain_deadline=120, boot_deadline=40,
+        allow_session_drop=False)
+
+
+def _patches(fake):
+    """Neutralize the signature/IO/recreate machinery so the test drives ONLY
+    the post-recreate identity+version gate: the manifest verify returns the
+    authenticated NEW_MANIFEST, the manifest/sums/sig files "exist", the recreate
+    hook is a no-op, and time is faked so the poll loop terminates fast."""
+    return [
+        mock.patch.object(xpf_deploy, "_node_exec", fake),
+        mock.patch.object(xpf_deploy, "_recreate_node_from_image",
+                          lambda *a, **k: None),
+        mock.patch.object(xpf_deploy, "_verified_image_manifest_versions",
+                          lambda *a, **k: dict(NEW_MANIFEST)),
+        mock.patch.object(xpf_deploy.os.path, "isfile", lambda p: True),
+        mock.patch("time.sleep", lambda *a, **k: None),
+        mock.patch("time.time", _Clock()),
+    ]
+
+
+class RecreatedNodeMatchesTests(unittest.TestCase):
+    """The pure #5075 identity+version predicate."""
+
+    def test_matching_build_and_node_id_accepted(self):
+        ok, reason = xpf_deploy._recreated_node_matches(
+            _reported(NEWVER), NEWVER, 0, 0)
+        self.assertTrue(ok, reason)
+
+    def test_empty_live_version_is_not_back(self):
+        # xpfd not answering yet -> keep polling (never a false "back").
+        ok, _ = xpf_deploy._recreated_node_matches({}, NEWVER, None, 0)
+        self.assertFalse(ok)
+
+    def test_missing_manifest_version_fails_closed(self):
+        ok, reason = xpf_deploy._recreated_node_matches(
+            _reported(NEWVER), "", 0, 0)
+        self.assertFalse(ok)
+        self.assertIn("manifest", reason)
+
+    def test_wrong_build_rejected(self):
+        ok, reason = xpf_deploy._recreated_node_matches(
+            _reported(OLDVER), NEWVER, 0, 0)
+        self.assertFalse(ok)
+        self.assertIn(OLDVER, reason)
+        self.assertIn(NEWVER, reason)
+
+    def test_unreadable_node_id_fails_closed(self):
+        ok, reason = xpf_deploy._recreated_node_matches(
+            _reported(NEWVER), NEWVER, None, 0)
+        self.assertFalse(ok)
+        self.assertIn("node-id", reason)
+
+    def test_wrong_node_id_rejected(self):
+        ok, reason = xpf_deploy._recreated_node_matches(
+            _reported(NEWVER), NEWVER, 1, 0)
+        self.assertFalse(ok)
+        self.assertIn("WRONG node", reason)
+
+
+class NodeClusterNodeIDTests(unittest.TestCase):
+    """/etc/xpf/node-id parsing fails closed on absent/garbage content."""
+
+    def _read(self, out):
+        with mock.patch.object(xpf_deploy, "_node_exec",
+                               lambda *a, **k: out):
+            return xpf_deploy._node_cluster_node_id(
+                xpf_deploy.Runner(False), "ssh", "fw0")
+
+    def test_valid(self):
+        self.assertEqual(self._read("0\n"), 0)
+        self.assertEqual(self._read("1\n"), 1)
+
+    def test_absent_or_garbage_is_none(self):
+        self.assertIsNone(self._read(""))
+        self.assertIsNone(self._read("not-an-int\n"))
+
+
+class ImageRollIdentityGateTests(unittest.TestCase):
+    """End-to-end cmd_image_roll: the post-recreate poll must reject a
+    responding-but-wrong xpfd and accept only the expected node+build."""
+
+    def _run(self, fake):
+        stack = _patches(fake)
+        for p in stack:
+            p.start()
+        try:
+            return xpf_deploy.cmd_image_roll(_img_args())
+        finally:
+            for p in reversed(stack):
+                p.stop()
+
+    def test_wrong_build_recreate_rejected(self):
+        # fw0 is recreated but comes back on the OLD build (stale alias / old
+        # image). It must be REJECTED, the peer never touched, leases held.
+        fake = _RollFake(reported={"fw0": OLDVER, "fw1": OLDVER},
+                         node_ids={"fw0": 0, "fw1": 1})
+        with self.assertRaises(SystemExit) as cm:
+            self._run(fake)
+        msg = str(cm.exception)
+        self.assertIn(OLDVER, msg, "the wrong build must be named in the error")
+        self.assertNotIn("fw0", fake.rejoined,
+                         "a wrong-build node must NOT be rejoined")
+        self.assertEqual(fake.drained, ["fw0"],
+                         "the peer fw1 must NOT be drained after fw0 is rejected")
+
+    def test_wrong_node_id_recreate_rejected(self):
+        # fw0 comes back on the RIGHT build but with the WRONG node-id (the hook
+        # launched node-id 1 where 0 was expected). Must be REJECTED.
+        fake = _RollFake(reported={"fw0": NEWVER, "fw1": OLDVER},
+                         node_ids={"fw0": 1, "fw1": 1})
+        with self.assertRaises(SystemExit) as cm:
+            self._run(fake)
+        msg = str(cm.exception)
+        self.assertIn("WRONG node", msg)
+        self.assertNotIn("fw0", fake.rejoined)
+        self.assertEqual(fake.drained, ["fw0"])
+
+    def test_never_responding_node_times_out(self):
+        # xpfd never answers protocol-versions -> fail closed on the deadline
+        # (this path was already safe pre-fix; guard it stays safe).
+        fake = _RollFake(reported={"fw0": None, "fw1": OLDVER},
+                         node_ids={"fw0": 0, "fw1": 1})
+        with self.assertRaises(SystemExit) as cm:
+            self._run(fake)
+        self.assertIn("did NOT come back", str(cm.exception))
+        self.assertNotIn("fw0", fake.rejoined)
+
+    def test_correct_node_and_build_accepted(self):
+        # Both nodes recreate onto the NEW build with the expected node-ids ->
+        # the roll COMPLETES: both drained, both rejoined, rc=0.
+        fake = _RollFake(reported={"fw0": NEWVER, "fw1": NEWVER},
+                         node_ids={"fw0": 0, "fw1": 1})
+        rc = self._run(fake)
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.drained, ["fw0", "fw1"])
+        self.assertEqual(fake.rejoined, ["fw0", "fw1"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/deploy/xpf-deploy.py
+++ b/scripts/deploy/xpf-deploy.py
@@ -1562,6 +1562,67 @@ def _node_protocol_versions(runner, backend, node):
     return d
 
 
+def _node_cluster_node_id(runner, backend, node):
+    """Read the recreated node's cluster-identity marker /etc/xpf/node-id — the
+    SAME file xpfd keys HA identity on (pkg/daemon/daemon.go `nodeIDFile`),
+    written by the day-0 config drive during the recreate. Returns the int
+    node-id, or None if absent/unreadable/unparsable so the #5075 identity gate
+    fails CLOSED. Used to confirm an image-recreated node came back as the
+    EXPECTED node, not a wrong-id relaunch (e.g. a --recreate-hook that swapped
+    node-id 0 and 1)."""
+    out = _node_exec(runner, backend, node,
+                     ["cat", "/etc/xpf/node-id"], check=False)
+    s = (out or "").strip()
+    try:
+        return int(s)
+    except (TypeError, ValueError):
+        return None
+
+
+def _recreated_node_matches(live_versions, want_version, live_node_id, want_node_id):
+    """#5075 identity+version gate for a node recreated from the new image.
+    Returns (ok: bool, reason: str).
+
+    The post-recreate readiness poll must accept a responding xpfd ONLY when it
+    is BOTH the EXPECTED build (its live `xpf-version` equals the AUTHENTICATED
+    image manifest's xpf-version) AND the EXPECTED cluster node (its
+    /etc/xpf/node-id equals the node-id the deploy assigned). Before #5075 the
+    poll accepted ANY xpfd that merely answered with a non-empty xpf-version, so
+    a --recreate-hook that relaunched the OLD image, a stale alias, or the WRONG
+    node-id satisfied the poll and the roll proceeded to the peer with the pair
+    on unintended/mixed software — a silent deploy-integrity failure. This gate
+    fails CLOSED on every mismatch.
+
+    - live_versions: dict from `xpfd protocol-versions` on the recreated node.
+    - want_version:  xpf-version from the AUTHENTICATED image manifest.
+    - live_node_id:  int|None parsed from /etc/xpf/node-id on the node.
+    - want_node_id:  the cluster node-id the deploy assigned this node.
+
+    A still-booting node (empty xpf-version) returns (False, ...) too, so the
+    caller can simply keep polling until the gate passes or the boot deadline
+    elapses, then fail closed with the last reason."""
+    live_ver = (live_versions or {}).get("xpf-version", "")
+    if not live_ver:
+        return False, "xpfd is not answering protocol-versions yet (no xpf-version)"
+    if not want_version:
+        return (False, "the authenticated image manifest carries no xpf-version — "
+                "cannot confirm the node rolled to the expected build (#5075)")
+    if live_ver != want_version:
+        return (False, f"node is running xpf-version {live_ver!r}, but the "
+                f"authenticated manifest expects {want_version!r} — the recreate "
+                f"did NOT roll to the requested image (old image / stale alias / "
+                f"wrong build)")
+    if live_node_id is None:
+        return (False, "cannot read /etc/xpf/node-id on the recreated node — "
+                f"cannot confirm it is cluster node-id {want_node_id} (#5075)")
+    if live_node_id != want_node_id:
+        return (False, f"node reports cluster node-id {live_node_id}, not the "
+                f"expected {want_node_id} — the recreate launched the WRONG node "
+                f"identity (#5075)")
+    return (True, f"xpf-version {live_ver} and cluster node-id {live_node_id} "
+            f"match the expected new image")
+
+
 def _node_drain_supports_mixed_ha(runner, backend, node):
     """Feature-detect whether a node's RUNNING xpfd accepts the INC-3
     `--allow-mixed-ha` drain flag. An image rolled FROM a pre-INC-3 release has
@@ -1847,19 +1908,43 @@ def cmd_image_roll(args):
                 return
             _recreate_node_from_image(runner, backend, node, args)
 
-            # 3. poll until the node is back (xpfd answers protocol-versions).
+            # 3. poll until the node is back AS THE EXPECTED NODE ON THE NEW
+            #    IMAGE. #5075: accepting ANY responding xpfd (the pre-fix
+            #    `if pv.get("xpf-version")` non-empty check) let a --recreate-hook
+            #    that relaunched the OLD image / a stale alias / the WRONG node-id
+            #    satisfy the poll — the driver rejoined and proceeded to the peer
+            #    with the pair on unintended/mixed software (silent deploy-
+            #    integrity failure). Require the live xpf-version to EXACTLY match
+            #    the AUTHENTICATED manifest's xpf-version AND /etc/xpf/node-id to
+            #    match the assigned cluster node-id before treating the node as
+            #    "back". Keep polling until the gate passes or the boot deadline
+            #    elapses (existing retry/timeout preserved), then FAIL CLOSED with
+            #    the never-both-down leases HELD — a mismatch is not a successful
+            #    roll.
+            want_ver = new_img.get("xpf-version", "")
+            want_nid = node_ids[node]
             deadline = _time.time() + boot_deadline
             back = False
+            last_reason = ("did not come back within the boot deadline "
+                           "(xpfd never answered protocol-versions)")
             while _time.time() < deadline:
                 _time.sleep(10)
                 pv = _node_protocol_versions(runner, backend, node)
+                # Only read the node-id marker once xpfd is actually answering,
+                # to avoid an extra `cat` on every poll while the node is down.
+                live_nid = None
                 if pv.get("xpf-version"):
-                    back = True
+                    live_nid = _node_cluster_node_id(runner, backend, node)
+                back, last_reason = _recreated_node_matches(
+                    pv, want_ver, live_nid, want_nid)
+                if back:
                     break
             if not back:
-                die(f"{node} did not come back within {boot_deadline}s after image "
-                    f"recreate; STOPPING — {peer} stays primary. Investigate.")
-            print(f"   {node} back on the new image")
+                die(f"{node} did NOT come back as the expected node on the new "
+                    f"image within {boot_deadline}s after image recreate: "
+                    f"{last_reason}. STOPPING with the never-both-down leases HELD "
+                    f"— {peer} stays primary. Investigate the recreate (#5075).")
+            print(f"   {node} back on the new image: {last_reason}")
 
             # 4. rejoin + confirm sync BEFORE touching the peer (never-both-down).
             print(f"   rejoining {node} (confirming sync)...")


### PR DESCRIPTION
Closes #5075

## Problem

`xpf-deploy.py image-roll` (`cmd_image_roll`) recreates each HA node from
a new golden image, then polls until the node "comes back" before
rejoining it and rolling the peer. The post-recreate readiness poll
accepted **any** responding xpfd — it only checked that
`pv.get("xpf-version")` was non-empty, with no comparison to the image
being rolled:

```python
pv = _node_protocol_versions(runner, backend, node)
if pv.get("xpf-version"):      # non-empty is enough
    back = True
```

So a `--recreate-hook` that relaunched the **OLD image**, a **stale
alias**, or the **wrong node-id** satisfied the poll. The driver rejoined
the wrong/old node and proceeded to the peer with the pair on
unintended/mixed software — a **silent deploy-integrity failure** (the
operator believes the image rolled when it did not, or rolled the wrong
node).

## Fix

The post-recreate poll now requires the responding daemon to be **both**
the expected build and the expected node before treating it as "back":

- **expected build** — its live `xpf-version` must EXACTLY equal the
  **authenticated** manifest's `xpf-version`. `new_img` is the same signed
  `xpf-<ver>.manifest` the mixed-base gate already verifies against the
  signed `SHA256SUMS` (#5042), so no new trust input is introduced.
- **expected node** — its `/etc/xpf/node-id` (the marker xpfd itself keys
  HA identity on, `pkg/daemon/daemon.go`) must equal the cluster node-id
  the deploy assigned (`--node0-id` / `--node1-id`). This reuses an
  existing signal (the day-0 node-id file); **no new xpfd RPC/field** is
  added.

The existing retry/timeout is preserved — the loop keeps polling until
the gate passes or `--boot-deadline` elapses. A responding-but-wrong
daemon now **fails closed**: the roll ERRORS with the never-both-down
leases HELD (peer stays primary, half-rolled pair left for the operator)
instead of silently continuing.

New helpers:
- `_recreated_node_matches()` — pure identity+version predicate
  (`scripts/deploy/xpf-deploy.py:1582`)
- `_node_cluster_node_id()` — reads `/etc/xpf/node-id`, fail-closed on
  absent/garbage (`scripts/deploy/xpf-deploy.py:1565`)

Gate wired into the poll at `scripts/deploy/xpf-deploy.py:1924-1946`.

## Tests

New auto-discovered deploy selftest
`scripts/deploy/test_xpf_deploy_image_roll_identity.py` (12 tests):
pure-predicate cases + end-to-end `cmd_image_roll` runs asserting a
wrong-build / wrong-node-id recreation is REJECTED (leases held, peer
never drained) and the correct node+build is accepted (roll completes).

**RED-on-revert proven:** restoring the old accept-any-xpfd poll flips
`test_wrong_build_recreate_rejected` and
`test_wrong_node_id_recreate_rejected` to failure — the old/wrong node is
accepted and the roll completes (rc=0) instead of raising `SystemExit`.

## Validation

- `python3 -m py_compile scripts/deploy/xpf-deploy.py` — clean
- `bash scripts/run-selftests.sh` — green (38 passed, 0 failed)

## Docs

Updated the LANE-2 image-roll section of `docs/in-place-upgrade.md` for
the identity + version gate.
