### PR TITLE
grpcapi: gate zeroize on applySem and stop xpfd after wipe

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45434,3 +45434,46 @@ top.
 - **Timestamp**: 2026-07-10
 - **Action**: Test-coverage-only (no production change). Added pkg/cli/chrony_test.go — a table-driven test for printChronyTracking (pkg/cli/chrony.go), the `chronyc tracking` output parser behind `show system ntp status`, which had zero unit coverage. Captures stdout via the existing captureStdout helper and asserts the rendered Junos-style block. Cases: fully-synchronised block (exact 12-line match over all 11 rendered fields in fixed order, plus omission checks that chronyc's Residual freq / Skew and the Skew value do NOT leak); unsynchronised block (Leap status "Not synchronised" verbatim); unusual leap status ("Insert second"); malformed lines with no " : " separator ignored + leading-separator empty-key line skipped by the idx>0 guard; duplicated key keeps last value (map overwrite); empty input renders only the header. Verified non-tautological: mutating the Leap-status lookup key in chrony.go turns the test RED; revert → GREEN. No production bug found — parser behaves correctly for all fed inputs (the line[idx+3:] slice is not out-of-bounds, as the issue notes). Validation: `go test ./pkg/cli/...` green; gofmt clean.
 - **File(s)**: pkg/cli/chrony_test.go, _Log.md
+
+## 2026-07-10 — #5281 grpcapi zeroize goes through the apply gate and stops xpfd
+- **Timestamp**: 2026-07-10
+- **Action**: SECURITY. Fixed the gRPC `SystemAction{zeroize}` factory reset,
+  which called package-level `performZeroizeWipe` directly with no lifecycle
+  coordination and never stopped xpfd — so after a "successful" zeroize the
+  still-running daemon held the pre-wipe in-memory ActiveConfig and the next
+  reconcile / commit / HA-sync re-rendered the erased secrets (frr.conf /
+  swanctl PSKs / Kea / login accounts) and re-created the `.configdb` SSOT.
+  New daemon-owned `factoryReset` (pkg/daemon/daemon_apply.go), wired as
+  `grpcapi.Config.ZeroizeFn` (pkg/daemon/daemon_run.go), acquires the SAME
+  `applySem` commit/apply/HA-sync serialize on (draining any in-flight apply),
+  enters a TERMINAL reset generation (`d.resetting`) BEFORE the wipe, runs the
+  wipe under the gate, and on success leaves the generation set (the handler
+  stops xpfd moments later). Config writers now short-circuit on
+  `errDaemonResetting`: commitAndApply / commitConfirmedAndApply / syncAndApply
+  reject before persisting; executeConfirmedRollback skips; applyConfigLocked
+  refuses (defense-in-depth); ipsecApplyForLeaseChange refuses (periodic swanctl
+  PSK re-render). The grpcapi handler routes the wipe through `s.zeroizeFn`
+  (falling back to a direct wipe only when nil), and on a fully-successful wipe
+  schedules `scheduleStopDaemon` (`systemctl stop xpfd` after a 1s grace,
+  mirroring the local `request system zeroize` CLI). Sequence is strictly
+  gate → wipe → stop, fail-CLOSED: a wipe that does not complete returns
+  Internal and does NOT stop the daemon. #4108 action-journal write preserved
+  (before the wipe); existing RPC path unchanged otherwise. Sibling issues
+  #5280 (wrong-root) / #5278 (per-principal auth) intentionally out of scope —
+  no overlapping edits (this touches the gate/stop lifecycle, not the wipe roots
+  or auth).
+- **Tests**: pkg/grpcapi/zeroize_gate_stop_5281_test.go (gate→wipe→stop order,
+  fail-closed no-stop, no-gate fallback — RED on revert to the direct-wipe
+  handler: gate bypassed + no stop → FAIL, verified); updated
+  system_action_journal_4108_test.go to neutralize the new scheduleStopDaemon
+  seam; pkg/daemon/factory_reset_5281_test.go (gate-first acquire, terminal
+  reset generation on success, gate released, commit/HA-sync/reconcile/ipsec
+  rejected during reset, fail-closed clears the generation).
+- **Validation**: `GOCACHE=/tmp/gocache-5281 GOTMPDIR=/tmp go build ./...` green;
+  `go test -race ./pkg/grpcapi/... ./pkg/daemon/...` green; gofmt clean.
+- **File(s)**: pkg/grpcapi/server.go, pkg/grpcapi/server_diag_system_action.go,
+  pkg/grpcapi/system_action_journal_4108_test.go,
+  pkg/grpcapi/zeroize_gate_stop_5281_test.go, pkg/grpcapi/README.md,
+  pkg/daemon/daemon.go, pkg/daemon/daemon_apply.go,
+  pkg/daemon/daemon_ipsec_rebind.go, pkg/daemon/daemon_run.go,
+  pkg/daemon/factory_reset_5281_test.go, pkg/daemon/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -45521,3 +45521,36 @@ top.
 - **File(s)**: scripts/deploy/xpf-deploy.py,
   scripts/deploy/test_xpf_deploy_image_roll_identity.py,
   docs/in-place-upgrade.md, _Log.md
+
+## 2026-07-10 — #5281 review fold: gate ip-monitoring route-overlay actuator
+- **Timestamp**: 2026-07-10
+- **Action**: SECURITY (rev-5548 MERGE-NEEDS-MINOR fold). The initial #5281
+  fix gated the daemon_apply.go writers + ipsecApplyForLeaseChange on
+  isResetting(), but the ip-monitoring route-overlay actuator
+  (actuateRouteOverlayLocked, pkg/daemon/daemon_ipmon.go) was NOT gated. It
+  acquires applySem and does a FULL re-render of /etc/frr/frr.conf
+  (d.applyFRRConfig(d.assembleFRRConfig(...))) from the in-memory ActiveConfig.
+  In the ~1s wipe->stop window (or graceful-shutdown drain), a probe flap with
+  `services ip-monitoring` configured + a dirty overlay would acquire the
+  just-released applySem, read the still-resident config, and RE-WRITE frr.conf
+  — re-materializing the ERASED BGP-MD5/OSPF/IS-IS routing-auth keys into a
+  world-readable file that SURVIVES the post-zeroize reboot, defeating the wipe.
+  Added `if d.isResetting() { return false }` at the top of
+  actuateRouteOverlayLocked (the frr.conf render chokepoint; returns false so
+  the engine stays dirty — the daemon is being wiped/stopped so the retry never
+  fires), matching the isResetting gates in daemon_apply.go.
+  Audited the other ungated applySem acquirers: only ip-monitoring (frr.conf)
+  and the DHCP-lease IPsec rebind (swanctl PSK, already gated via
+  ipsecApplyForLeaseChange) re-render an erased secret. DNS writes
+  /etc/resolv.conf (not wiped), proxy-ARP writes nft, the policy scheduler +
+  NAT-pool alarm touch dataplane/in-memory state, and the host-tunables restore
+  must run on shutdown — none re-render wiped state, so they stay ungated.
+- **Tests**: pkg/daemon/daemon_ipmon_test.go — TestActuateRouteOverlaySkipsWhenResetting
+  asserts actuateRouteOverlayLocked is a no-op (returns false, RecordingExecutor
+  ReloadCalls==0 so frr.conf is NOT re-rendered, no dp publish/bump) when
+  isResetting() is true. RED-on-revert verified: removing the gate → the actuator
+  renders frr.conf (ReloadCalls=1) + publishes → test FAILS.
+- **Validation**: `GOCACHE=/tmp/gocache-5281 GOTMPDIR=/tmp go build ./...` green;
+  `go test -race ./pkg/daemon/... ./pkg/grpcapi/...` green; gofmt clean.
+- **File(s)**: pkg/daemon/daemon_ipmon.go, pkg/daemon/daemon_ipmon_test.go,
+  pkg/daemon/README.md, _Log.md

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -348,11 +348,16 @@ never lock an operator out of a remote box it manages.
   `errDaemonResetting`: `commitAndApply` / `commitConfirmedAndApply` /
   `syncAndApply` reject **before** persisting (so a racing commit/HA-sync cannot
   re-create the just-erased `.configdb` SSOT), `executeConfirmedRollback`
-  skips, `applyConfigLocked` refuses (defense-in-depth), and
+  skips, `applyConfigLocked` refuses (defense-in-depth),
   `ipsecApplyForLeaseChange` refuses (so a DHCP-lease rebind cannot re-render
-  the erased swanctl PSK snippet). It fail-CLOSES: a wipe error exits the reset
+  the erased swanctl PSK snippet), and `actuateRouteOverlayLocked` refuses (so an
+  `ip-monitoring` probe-flap sweep cannot re-render `/etc/frr/frr.conf` and
+  re-materialize the erased routing-auth keys). It fail-CLOSES: a wipe error exits the reset
   generation and releases the gate so the box stays recoverable, and the handler
-  reports the reset incomplete and does NOT stop the daemon.
+  reports the reset incomplete and does NOT stop the daemon. The other `applySem`
+  acquirers stay ungated: DNS writes `/etc/resolv.conf`, proxy-ARP writes nft,
+  the policy scheduler and NAT-pool alarm touch dataplane/in-memory state, and
+  the host-tunables restore must run on shutdown — none re-render a wiped secret.
 - **Cancellable apply at coarse boundaries (#2926, follow-up to #2914/#2868).**
   `applyConfigLocked(ctx, cfg)` checks `ctx.Err()` at three phase boundaries and
   returns the ctx error at the next one rather than completing the netlink + FRR

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -337,6 +337,22 @@ never lock an operator out of a remote box it manages.
 - `commitFn` and `commitConfirmedFn` are passed to `pkg/cli` and
   `pkg/grpcapi`; they hold the apply semaphore across the commit + apply
   pair so concurrent committers serialize.
+- **Factory-reset gate (`factoryReset`, wired as `grpcapi.Config.ZeroizeFn`,
+  #5281).** A gRPC `zeroize` no longer erases state out-of-band. `factoryReset`
+  acquires the SAME `applySem` commit/apply/HA-sync serialize on (draining any
+  in-flight apply), enters a **terminal reset generation** (`d.resetting`,
+  `isResetting`/`enterResetGeneration`/`exitResetGeneration`) BEFORE running the
+  wipe closure, and — on a successful wipe — leaves that generation set for the
+  daemon's remaining lifetime (the gRPC handler stops xpfd moments later). Once
+  set, every config writer that acquires `applySem` short-circuits on
+  `errDaemonResetting`: `commitAndApply` / `commitConfirmedAndApply` /
+  `syncAndApply` reject **before** persisting (so a racing commit/HA-sync cannot
+  re-create the just-erased `.configdb` SSOT), `executeConfirmedRollback`
+  skips, `applyConfigLocked` refuses (defense-in-depth), and
+  `ipsecApplyForLeaseChange` refuses (so a DHCP-lease rebind cannot re-render
+  the erased swanctl PSK snippet). It fail-CLOSES: a wipe error exits the reset
+  generation and releases the gate so the box stays recoverable, and the handler
+  reports the reset incomplete and does NOT stop the daemon.
 - **Cancellable apply at coarse boundaries (#2926, follow-up to #2914/#2868).**
   `applyConfigLocked(ctx, cfg)` checks `ctx.Err()` at three phase boundaries and
   returns the ctx error at the next one rather than completing the netlink + FRR

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -409,6 +409,21 @@ type Daemon struct {
 	// to the client when the lock holder is slow, instead of
 	// hanging the request indefinitely.
 	applySem *semaphore.Weighted
+	// resetting enters the TERMINAL factory-reset (zeroize) generation
+	// (#5281). A gRPC-initiated zeroize (factoryReset) sets it true while it
+	// holds applySem and erases on-disk state, and — on a successful wipe —
+	// leaves it set for the daemon's remaining lifetime (the daemon is stopped
+	// moments later). Once set, every config writer that acquires applySem
+	// (commitAndApply / commitConfirmedAndApply / syncAndApply /
+	// executeConfirmedRollback, the applyConfigLocked reconcile, and the
+	// periodic DHCP-lease IPsec rebind) short-circuits, so nothing re-persists
+	// the just-erased .configdb SSOT or re-renders the wiped secrets
+	// (frr.conf/swanctl PSKs/Kea/login accounts) in the window between the wipe
+	// and the daemon stop. Read/written only via isResetting / enterReset...
+	// exitResetGeneration (sync/atomic), so the zeroize goroutine and any
+	// concurrent apply goroutine race safely. A failed wipe clears it again so
+	// the box stays recoverable (fail-closed, see factoryReset).
+	resetting atomic.Bool
 	// applyBodyForTest, when non-nil, replaces applyConfigLocked's
 	// body. Test-only seam used by apply_serialize_test.go to
 	// exercise the semaphore contract through the real applyConfig

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -155,6 +155,65 @@ func (d *Daemon) applyCancelCtx() context.Context {
 	return context.Background()
 }
 
+// errDaemonResetting is returned by every config-write entry point once a
+// factory reset (zeroize) has entered its terminal reset generation (#5281). It
+// is not surfaced to an operator on the normal path — resetting is only ever
+// set true by factoryReset while the daemon is being wiped and stopped — so its
+// job is purely to make a racing commit / HA-sync / rollback / reconcile abort
+// instead of re-creating the just-erased state.
+var errDaemonResetting = errors.New("factory reset in progress: configuration writes are rejected")
+
+// isResetting reports whether a factory reset has entered the terminal reset
+// generation (#5281). Config writers check it under applySem to short-circuit.
+func (d *Daemon) isResetting() bool { return d.resetting.Load() }
+
+// enterResetGeneration marks the daemon as being factory-reset. Called by
+// factoryReset while it holds applySem, BEFORE the wipe, so any writer that
+// later acquires applySem re-renders nothing (#5281). It is left set for the
+// daemon's remaining lifetime on a successful wipe (the daemon is stopped
+// moments later) and cleared again only if the wipe FAILED (exitResetGeneration).
+func (d *Daemon) enterResetGeneration() { d.resetting.Store(true) }
+
+// exitResetGeneration leaves the reset generation. Called only on a FAILED wipe
+// so the box stays recoverable and normal config work resumes (#5281).
+func (d *Daemon) exitResetGeneration() { d.resetting.Store(false) }
+
+// factoryReset runs a gRPC-initiated zeroize under the SAME global writer gate
+// (d.applySem) that commit / apply / HA-sync serialize on, then enters the
+// terminal reset generation so no concurrent or subsequent config writer can
+// re-persist the erased .configdb SSOT or re-render the wiped secrets before the
+// daemon is stopped (#5281). It is wired into the gRPC server as Config.ZeroizeFn
+// and receives the pkg/grpcapi factory-reset primitive as wipe (kept there so
+// the wipe stays testable via the performZeroizeWipe seam).
+//
+// Sequence (fail-CLOSED, wipe-then-stop):
+//  1. Acquire applySem — this DRAINS any in-flight apply and BLOCKS a concurrent
+//     one for the duration of the wipe. If ctx is cancelled before acquisition
+//     (client disconnect), nothing has been erased yet, so aborting is safe.
+//  2. Enter the terminal reset generation BEFORE the wipe, so a writer that
+//     acquires applySem AFTER this returns (a periodic reconciler, a late
+//     commit, a shutdown-time apply) short-circuits on errDaemonResetting.
+//  3. Run the wipe while holding applySem.
+//     - On FAILURE: exit the reset generation and release applySem (deferred)
+//     so the half-reset box is recoverable and a retry can run, and return
+//     the error. The caller must NOT stop the daemon — a stop here would
+//     strand a box whose secrets are still on disk.
+//     - On SUCCESS: stay in the reset generation (never cleared) and return nil;
+//     the caller stops xpfd. applySem is released on return, but the resetting
+//     flag keeps every later writer from re-rendering during the stop window.
+func (d *Daemon) factoryReset(ctx context.Context, wipe func() error) error {
+	if err := d.applySem.Acquire(ctx, 1); err != nil {
+		return err
+	}
+	defer d.applySem.Release(1)
+	d.enterResetGeneration()
+	if err := wipe(); err != nil {
+		d.exitResetGeneration()
+		return err
+	}
+	return nil
+}
+
 // commitAndApply atomically promotes the candidate config and
 // applies it. Holds applySem across configstore.Commit and
 // applyConfigLocked so two concurrent committers can't interleave
@@ -202,6 +261,14 @@ func (d *Daemon) commitAndApply(ctx context.Context, comment string, syncPeer bo
 		return nil, err
 	}
 	defer d.applySem.Release(1)
+
+	// #5281: reject the commit if a factory reset is in progress. Checked under
+	// applySem and BEFORE store.Commit persists the candidate — a commit that
+	// promoted after the zeroize wipe would re-create the just-erased .configdb
+	// SSOT on disk and re-render secrets on apply.
+	if d.isResetting() {
+		return nil, errDaemonResetting
+	}
 
 	// #1956 R-8 device-map pre-flight: reject a candidate whose device-map
 	// would strand management on next boot, while the operator is still
@@ -334,6 +401,15 @@ func (d *Daemon) syncAndApply(ctx context.Context, configText string, chassisPre
 	}
 	defer d.applySem.Release(1)
 
+	// #5281: reject a peer-driven sync-apply while a factory reset is in
+	// progress. SyncApply persists the peer config as active before the
+	// reconcile, so an HA sync landing after the zeroize wipe would re-create
+	// the erased SSOT and re-render secrets. Checked under applySem, before
+	// SyncApply.
+	if d.isResetting() {
+		return nil, errDaemonResetting
+	}
+
 	// Pre-sync active config for the #4234 deletion-clear (see commitAndApply).
 	// A peer-pushed config that deletes a policy must drop that policy's synced
 	// sessions on THIS node too; the standby is not primary, so its own clear
@@ -404,6 +480,13 @@ func (d *Daemon) commitConfirmedAndApply(ctx context.Context, minutes int, syncP
 	}
 	defer d.applySem.Release(1)
 
+	// #5281: reject a commit-confirmed while a factory reset is in progress
+	// (same rationale as commitAndApply — CommitConfirmed persists the candidate
+	// and arms a rollback timer that would re-apply after the wipe).
+	if d.isResetting() {
+		return nil, errDaemonResetting
+	}
+
 	// #1956 R-8/V-3 device-map pre-flight: validate BOTH the candidate AND
 	// the rollback target (the currently-active config, restored on a
 	// confirmed-commit timeout) against present hardware. If EITHER would
@@ -448,6 +531,13 @@ func (d *Daemon) commitConfirmedAndApply(ctx context.Context, minutes int, syncP
 func (d *Daemon) executeConfirmedRollback(gen uint64) {
 	_ = d.applySem.Acquire(context.Background(), 1)
 	defer d.applySem.Release(1)
+
+	// #5281: a confirm-timeout rollback that fires after a factory reset wipe
+	// would PromoteRollback (re-persisting the SSOT) and re-apply the rolled-back
+	// config, re-rendering secrets. Skip it — the daemon is being wiped/stopped.
+	if d.isResetting() {
+		return
+	}
 
 	// Pre-rollback active config (the abandoned unconfirmed config, C2) for the
 	// #4234 deletion-clear: a rollback that removes a policy the abandoned commit
@@ -556,6 +646,17 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// explicit so a future caller cannot panic the reconcile.
 	if cfg == nil {
 		return nil
+	}
+
+	// #5281 defense-in-depth: refuse to reconcile once a factory reset has
+	// entered the terminal reset generation. The commit / sync / rollback entry
+	// points already reject before persisting, so in practice nothing reaches
+	// here during the wipe→stop window; this guards any other applyConfigLocked
+	// caller (a boot-time apply, a future path) from re-rendering the erased
+	// secrets (frr.conf/swanctl/Kea/login) from the still-resident in-memory
+	// ActiveConfig.
+	if d.isResetting() {
+		return errDaemonResetting
 	}
 
 	// Reconcile the whole SNMP subsystem FIRST (#2008 H17, Codex r2; extended

--- a/pkg/daemon/daemon_ipmon.go
+++ b/pkg/daemon/daemon_ipmon.go
@@ -267,6 +267,20 @@ func (d *Daemon) actuateRouteOverlay(ctx context.Context) bool {
 // userspace snapshot are left in a consistent, converged state; a false
 // return signals the engine to keep the state dirty and retry (#3757).
 func (d *Daemon) actuateRouteOverlayLocked(cfg *config.Config) bool {
+	// #5281: refuse to actuate once a factory reset has entered the terminal
+	// reset generation. This actuator re-renders /etc/frr/frr.conf (the WORLD-
+	// readable file that carries the xpf-managed BGP-MD5 / OSPF / IS-IS routing-
+	// auth keys) from the still-resident in-memory ActiveConfig. In the ~1s
+	// wipe→stop window (or the graceful-shutdown drain) an ip-monitoring sweep
+	// triggered by a probe flap would otherwise acquire the just-released
+	// applySem and re-materialize the ERASED routing-auth keys into a file that
+	// SURVIVES the post-zeroize reboot — defeating the wipe. Return false so the
+	// ipmon engine keeps the state dirty (no half-actuation); the daemon is
+	// being wiped/stopped, so the retry never fires.
+	if d.isResetting() {
+		return false
+	}
+
 	overlay := d.ipmonActiveOverlay()
 
 	// 1. Re-render FRR through the shared constructor. A HARD FRR reload

--- a/pkg/daemon/daemon_ipmon_test.go
+++ b/pkg/daemon/daemon_ipmon_test.go
@@ -434,6 +434,42 @@ func TestActuatorPublishesOnDegradedFRR(t *testing.T) {
 	}
 }
 
+// TestActuateRouteOverlaySkipsWhenResetting pins the #5281 review fold: once a
+// factory reset (zeroize) has entered the terminal reset generation, the
+// ip-monitoring route-overlay actuator must be a NO-OP. It re-renders
+// /etc/frr/frr.conf (the world-readable file carrying the xpf-managed BGP-MD5 /
+// OSPF / IS-IS routing-auth keys) from the still-resident in-memory
+// ActiveConfig; in the wipe→stop window a probe-flap sweep would otherwise
+// re-materialize the just-erased routing-auth keys into a file that survives the
+// post-zeroize reboot — defeating the wipe. The actuator must NOT reload FRR and
+// NOT publish/bump, and must return false (stay dirty; the daemon is being
+// wiped/stopped, so the retry never fires).
+//
+// RED on revert: removing the isResetting gate lets the actuator render frr.conf
+// (RecordingExecutor.ReloadCalls == 1) and publish (dp.calls != nil) — this test
+// then fails.
+func TestActuateRouteOverlaySkipsWhenResetting(t *testing.T) {
+	exec := &frr.RecordingExecutor{} // clean reload — the ungated path WOULD render+publish
+	dp := &fakeOverlayDP{}
+	d := &Daemon{
+		applySem: semaphore.NewWeighted(1),
+		frr:      frr.NewForTest(filepath.Join(t.TempDir(), "frr.conf"), exec),
+		dp:       dp,
+		ipmon:    failedIPMonEngine(t),
+	}
+	d.enterResetGeneration()
+
+	if ok := d.actuateRouteOverlayLocked(&config.Config{}); ok {
+		t.Fatal("actuator reported success during a factory reset; must be a no-op (false)")
+	}
+	if exec.ReloadCalls != 0 {
+		t.Fatalf("frr.conf was re-rendered during a factory reset (ReloadCalls=%d): erased routing-auth keys re-materialized", exec.ReloadCalls)
+	}
+	if len(dp.calls) != 0 {
+		t.Fatalf("dataplane actuated during a factory reset: calls = %v (must be none)", dp.calls)
+	}
+}
+
 // TestActuateRouteOverlayAbortsOnContextCancel is the #3758 regression
 // at the exact bug line: actuateRouteOverlay acquires the apply
 // semaphore with the ENGINE's actuation context (cancelled on ipmon

--- a/pkg/daemon/daemon_ipsec_rebind.go
+++ b/pkg/daemon/daemon_ipsec_rebind.go
@@ -22,6 +22,15 @@ const ipsecRebindRetryInterval = 30 * time.Second
 // time), so re-applying the same config picks up the new lease. Tests inject a
 // seam so the retry lifecycle can be driven without shelling out to swanctl.
 func (d *Daemon) ipsecApplyForLeaseChange(cfg *config.Config) error {
+	// #5281: the DHCP-lease-change rebind re-renders /etc/swanctl/conf.d/xpf.conf
+	// (IKE PSKs) from the still-resident in-memory ActiveConfig. Both callers
+	// (reapplyIPsecForLeaseChange, tryIPsecRebindRetry) run under applySem, but a
+	// factory reset that already erased that snippet must not have it recreated
+	// in the wipe→stop window — short-circuit once the terminal reset generation
+	// is entered.
+	if d.isResetting() {
+		return errDaemonResetting
+	}
 	if d.ipsecApply != nil {
 		return d.ipsecApply(cfg)
 	}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1076,9 +1076,14 @@ func (d *Daemon) startGRPCServer(ctx context.Context, wg *sync.WaitGroup, eventB
 		CommitConfirmedFn: func(ctx context.Context, minutes int) (*config.Config, error) {
 			return d.commitConfirmedAndApply(ctx, minutes, true)
 		},
-		VRRPMgr: d.vrrpMgr,
-		RAMgr:   d.ra,
-		Version: d.opts.Version,
+		// #5281: a gRPC zeroize runs the wipe under the SAME apply gate as
+		// commit/sync and enters a terminal reset generation so no concurrent
+		// or later config writer re-creates the erased state before the daemon
+		// stops. The grpcapi handler passes its performZeroizeWipe primitive.
+		ZeroizeFn: d.factoryReset,
+		VRRPMgr:   d.vrrpMgr,
+		RAMgr:     d.ra,
+		Version:   d.opts.Version,
 		FabricPeerAddrFn: func() []string {
 			var addrs []string
 			if d.syncPeerAddr != "" {

--- a/pkg/daemon/factory_reset_5281_test.go
+++ b/pkg/daemon/factory_reset_5281_test.go
@@ -1,0 +1,103 @@
+// #5281: factoryReset is the daemon-owned zeroize gate. It runs the wipe under
+// the SAME applySem commit/apply/HA-sync serialize on, and enters a TERMINAL
+// reset generation so no concurrent or subsequent config writer can re-persist
+// the erased SSOT or re-render the wiped secrets before the daemon is stopped.
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// factoryReset must Acquire applySem BEFORE wiping, enter the terminal reset
+// generation on success, release the gate afterward, and thereafter REJECT new
+// config work (commit / HA-sync).
+func TestFactoryResetGatesAndEntersResetGeneration(t *testing.T) {
+	d := &Daemon{applySem: semaphore.NewWeighted(1)}
+
+	// (1) Gate-first: hold applySem externally with a tight deadline. factoryReset
+	// must surface ctx.Err() and neither wipe nor enter the reset generation —
+	// nothing has been erased, so an aborted acquire is safe.
+	if err := d.applySem.Acquire(context.Background(), 1); err != nil {
+		t.Fatalf("setup acquire: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	wiped := false
+	err := d.factoryReset(ctx, func() error { wiped = true; return nil })
+	cancel()
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("factoryReset must surface ctx err while the gate is held; got %v", err)
+	}
+	if wiped {
+		t.Fatal("factoryReset must not wipe when it cannot acquire the gate")
+	}
+	if d.isResetting() {
+		t.Fatal("factoryReset must not enter the reset generation when the acquire failed")
+	}
+	d.applySem.Release(1)
+
+	// (2) Success: the wipe runs under the gate, the daemon stays in the terminal
+	// reset generation, and the gate is RELEASED (so shutdown-time work can still
+	// acquire it).
+	wiped = false
+	if err := d.factoryReset(context.Background(), func() error { wiped = true; return nil }); err != nil {
+		t.Fatalf("factoryReset success: %v", err)
+	}
+	if !wiped {
+		t.Fatal("factoryReset must run the wipe")
+	}
+	if !d.isResetting() {
+		t.Fatal("factoryReset must enter the terminal reset generation on a successful wipe")
+	}
+	if err := d.applySem.Acquire(context.Background(), 1); err != nil {
+		t.Fatalf("applySem must be released after a successful factoryReset; got %v", err)
+	}
+	d.applySem.Release(1)
+
+	// (3) In the reset generation, a racing commit / HA-sync must be REJECTED
+	// before it persists (which would re-create the erased .configdb SSOT). The
+	// guard sits before any nil-store access, so these return cleanly.
+	if _, err := d.commitAndApply(context.Background(), "", false); !errors.Is(err, errDaemonResetting) {
+		t.Fatalf("commitAndApply must be rejected during a factory reset; got %v", err)
+	}
+	if _, err := d.commitConfirmedAndApply(context.Background(), 1, false); !errors.Is(err, errDaemonResetting) {
+		t.Fatalf("commitConfirmedAndApply must be rejected during a factory reset; got %v", err)
+	}
+	if _, err := d.syncAndApply(context.Background(), "", nil); !errors.Is(err, errDaemonResetting) {
+		t.Fatalf("syncAndApply must be rejected during a factory reset; got %v", err)
+	}
+	// The central reconcile is also gated (defense-in-depth).
+	if err := d.applyConfigLocked(context.Background(), &config.Config{}); !errors.Is(err, errDaemonResetting) {
+		t.Fatalf("applyConfigLocked must be rejected during a factory reset; got %v", err)
+	}
+	// The periodic DHCP-lease IPsec rebind (swanctl PSK re-render) is gated too.
+	if err := d.ipsecApplyForLeaseChange(&config.Config{}); !errors.Is(err, errDaemonResetting) {
+		t.Fatalf("ipsecApplyForLeaseChange must be rejected during a factory reset; got %v", err)
+	}
+}
+
+// factoryReset must FAIL CLOSED on a wipe error: exit the reset generation and
+// release the gate so the half-reset box is recoverable and normal config work
+// resumes (the SystemAction handler then reports the reset incomplete and does
+// NOT stop the daemon).
+func TestFactoryResetFailClosedClearsResetGeneration(t *testing.T) {
+	d := &Daemon{applySem: semaphore.NewWeighted(1)}
+
+	wantErr := errors.New("wipe boom")
+	if err := d.factoryReset(context.Background(), func() error { return wantErr }); !errors.Is(err, wantErr) {
+		t.Fatalf("factoryReset must surface the wipe error; got %v", err)
+	}
+	if d.isResetting() {
+		t.Fatal("factoryReset must EXIT the reset generation on a failed wipe (fail-closed, recoverable)")
+	}
+	if err := d.applySem.Acquire(context.Background(), 1); err != nil {
+		t.Fatalf("applySem must be released after a failed factoryReset; got %v", err)
+	}
+	d.applySem.Release(1)
+}

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -92,6 +92,24 @@ contract.
 - `CommitFn` (passed in by the daemon) holds the apply semaphore across
   `Commit()` and the dataplane apply. This is the same primitive `pkg/cli`
   uses; concurrent operator commits serialize via that semaphore (#846).
+- **Zeroize goes through the apply gate AND stops xpfd (#5281).** The
+  `SystemAction{zeroize}` handler does NOT call `performZeroizeWipe`
+  directly. It routes through `ZeroizeFn` (wired by the daemon to
+  `factoryReset`), which takes the SAME apply semaphore `CommitFn` uses
+  and enters a **terminal reset generation** before erasing, so a
+  concurrent in-flight apply is drained and no later commit / HA-sync /
+  reconcile re-creates the erased `.configdb` SSOT or re-renders the wiped
+  secrets (frr.conf / swanctl PSKs / Kea / login accounts). On a
+  fully-successful wipe the handler then schedules `scheduleStopDaemon`
+  (`systemctl stop xpfd` after a 1 s grace, mirroring the local
+  `request system zeroize` CLI path in `pkg/cli`) so the daemon does not
+  keep running with the pre-wipe in-memory `ActiveConfig`. The sequence is
+  strictly **gate → wipe → stop**, fail-CLOSED: a wipe that does not
+  complete returns `Internal` and does **not** stop the daemon (stopping a
+  half-wiped box would strand prior-tenant secrets on disk). The `#4108`
+  action-journal write still happens BEFORE the wipe. `ZeroizeFn` is nil
+  only in a NoDataplane / no-daemon build, where the handler falls back to
+  an ungated direct wipe (there is no running reconcile loop to race).
 - Tab completion (`Complete` RPC) and `?` help come from `pkg/cmdtree` —
   add commands there once and they show up in every CLI surface.
 - Session show and clear share ONE matcher: `ClearSessions` builds the

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -105,12 +105,23 @@ type Config struct {
 	// (handlers translate to DeadlineExceeded/Canceled).
 	CommitFn          func(ctx context.Context, comment string) (*config.Config, error)
 	CommitConfirmedFn func(ctx context.Context, minutes int) (*config.Config, error)
-	VRRPMgr           *vrrp.Manager      // native VRRP manager
-	RAMgr             *ra.Manager        // embedded RA sender manager
-	Version           string             // software version string
-	FabricPeerAddrFn  func() []string    // returns peer fabric IPs (fab0, fab1; empty if standalone)
-	FabricVRFDevice   string             // VRF for fabric interface (e.g. "vrf-mgmt")
-	FwdSampler        *fwdstatus.Sampler // #881: 5s/1m/5m CPU windows for `show chassis forwarding`
+	// ZeroizeFn runs a factory-reset (zeroize) wipe under the daemon's apply
+	// gate (#5281). It acquires the same apply semaphore commit/sync serialize
+	// on, enters a TERMINAL reset generation so no concurrent or subsequent
+	// config writer can re-create the erased .configdb SSOT or re-render the
+	// wiped secrets, runs the passed wipe closure (the package performZeroizeWipe
+	// primitive) while quiesced, and returns nil ONLY when the wipe fully
+	// completed. On failure it fail-closes (the box stays recoverable) and
+	// returns the error, and the SystemAction handler does NOT stop the daemon.
+	// nil in NoDataplane / unit-test builds with no daemon, in which case the
+	// handler falls back to an ungated direct wipe (the pre-#5281 behavior).
+	ZeroizeFn        func(ctx context.Context, wipe func() error) error
+	VRRPMgr          *vrrp.Manager      // native VRRP manager
+	RAMgr            *ra.Manager        // embedded RA sender manager
+	Version          string             // software version string
+	FabricPeerAddrFn func() []string    // returns peer fabric IPs (fab0, fab1; empty if standalone)
+	FabricVRFDevice  string             // VRF for fabric interface (e.g. "vrf-mgmt")
+	FwdSampler       *fwdstatus.Sampler // #881: 5s/1m/5m CPU windows for `show chassis forwarding`
 }
 
 // Server implements the BpfrxService gRPC service.
@@ -140,6 +151,7 @@ type Server struct {
 	flowCollectorHealthFn func() []flowexport.ExporterCollectorHealth
 	commitFn              func(ctx context.Context, comment string) (*config.Config, error)
 	commitConfirmedFn     func(ctx context.Context, minutes int) (*config.Config, error)
+	zeroizeFn             func(ctx context.Context, wipe func() error) error
 	vrrpMgr               *vrrp.Manager
 	raMgr                 *ra.Manager
 	fwdSampler            *fwdstatus.Sampler
@@ -234,6 +246,7 @@ func NewServer(addr string, cfg Config) *Server {
 		flowCollectorHealthFn: cfg.FlowCollectorHealthFn,
 		commitFn:              cfg.CommitFn,
 		commitConfirmedFn:     cfg.CommitConfirmedFn,
+		zeroizeFn:             cfg.ZeroizeFn,
 		vrrpMgr:               cfg.VRRPMgr,
 		raMgr:                 cfg.RAMgr,
 		fwdSampler:            cfg.FwdSampler,

--- a/pkg/grpcapi/server_diag_system_action.go
+++ b/pkg/grpcapi/server_diag_system_action.go
@@ -63,6 +63,41 @@ var schedulePowerAction = func(systemctlArg string) {
 	}()
 }
 
+// scheduleStopDaemon stops xpfd after a 1s grace so the zeroize RPC response
+// reaches the client before the daemon exits (#5281). A completed factory reset
+// MUST stop the daemon: otherwise xpfd keeps running with the pre-wipe
+// in-memory ActiveConfig and re-renders the erased secrets on the next reconcile
+// / commit / HA-sync — the incomplete-wipe window this closes. It mirrors the
+// local `request system zeroize` CLI path (pkg/cli), which likewise runs
+// `systemctl stop xpfd` after the wipe. It is a package var so a test can assert
+// the stop is scheduled WITHOUT actually stopping a running daemon, and is
+// scheduled ONLY on a fully-successful wipe (never on a fail-closed partial
+// wipe). The daemon has already entered the terminal reset generation (see
+// ZeroizeFn), so the ~1s grace cannot re-render anything.
+var scheduleStopDaemon = func() {
+	go func() {
+		time.Sleep(1 * time.Second)
+		// context.Background(): a confirmed factory reset must not be cancelled
+		// by client disconnect. Error ignored (mirrors schedulePowerAction).
+		runTimeout(context.Background(), "systemctl", "stop", "xpfd")
+	}()
+}
+
+// runZeroize erases on-disk state for a factory reset. It routes through the
+// daemon-owned apply gate (ZeroizeFn) when wired (#5281): the daemon acquires
+// its apply semaphore, enters the terminal reset generation, and runs the
+// performZeroizeWipe primitive while quiesced, so no concurrent or subsequent
+// commit / HA-sync / reconcile re-creates the erased state. When ZeroizeFn is
+// nil (NoDataplane / a bare unit-test Server with no daemon), it falls back to
+// an ungated direct wipe — the pre-#5281 behavior — which is acceptable because
+// there is no running reconcile loop to race in that build.
+func (s *Server) runZeroize(ctx context.Context) error {
+	if s.zeroizeFn != nil {
+		return s.zeroizeFn(ctx, performZeroizeWipe)
+	}
+	return performZeroizeWipe()
+}
+
 func (s *Server) SystemAction(ctx context.Context, req *pb.SystemActionRequest) (*pb.SystemActionResponse, error) {
 	switch req.Action {
 	case "reboot":
@@ -95,15 +130,31 @@ func (s *Server) SystemAction(ctx context.Context, req *pb.SystemActionRequest) 
 		// log to the next tenant — #4576), superseding the earlier
 		// journal-survives-zeroize belt-and-braces.
 		s.logSystemAction("zeroize")
-		if err := performZeroizeWipe(); err != nil {
-			// A partial wipe may leave prior-tenant config/secrets on disk
-			// (#4576). Surface it instead of reporting a clean factory reset —
-			// the operator must know the erasure did not fully complete and
-			// the device is NOT safe to re-tenant.
+		// Run the wipe through the daemon apply gate (#5281): ZeroizeFn takes the
+		// same apply semaphore commit/sync serialize on and enters a terminal
+		// reset generation BEFORE erasing, so a concurrent in-flight apply is
+		// drained and no later commit / HA-sync / reconcile re-creates the erased
+		// .configdb SSOT or re-renders the wiped secrets. The pre-#5281 handler
+		// called performZeroizeWipe directly with no lifecycle coordination.
+		if err := s.runZeroize(ctx); err != nil {
+			// FAIL-CLOSED: a partial wipe may leave prior-tenant config/secrets
+			// on disk (#4576). Surface it instead of reporting a clean factory
+			// reset — the operator must know the erasure did not fully complete
+			// and the device is NOT safe to re-tenant. Do NOT stop xpfd here: the
+			// wipe did not finish, so stopping would strand a half-reset box (the
+			// daemon has already left the reset generation, so it keeps running
+			// normally until a retried zeroize succeeds).
 			slog.Error("system zeroize did not fully erase config state", "err", err)
 			return nil, status.Errorf(codes.Internal,
 				"zeroize incomplete: config state may remain on disk: %v", err)
 		}
+		// The wipe fully completed. Stop xpfd so the daemon does not keep running
+		// with the pre-wipe in-memory ActiveConfig and re-render the erased
+		// secrets on the next reconcile (#5281). Scheduled after a 1s grace so
+		// this response reaches the client; the daemon is already in the terminal
+		// reset generation, so nothing re-renders in the interim. The reboot
+		// completes the factory reset.
+		scheduleStopDaemon()
 		return &pb.SystemActionResponse{Message: "System zeroized. Configuration erased. Reboot to complete factory reset."}, nil
 
 	case "clear-config-lock":

--- a/pkg/grpcapi/system_action_journal_4108_test.go
+++ b/pkg/grpcapi/system_action_journal_4108_test.go
@@ -20,17 +20,22 @@ import (
 // RED on revert: dropping the s.logSystemAction(...) call from a case leaves no
 // journal entry for that verb and the corresponding subtest fails.
 func TestSystemActionJournalsDestructiveVerbs(t *testing.T) {
-	// Neutralize the real destructive side effects for the whole test.
+	// Neutralize the real destructive side effects for the whole test —
+	// including the #5281 post-zeroize daemon stop, which the zeroize verb now
+	// schedules on a successful wipe.
 	origPower := schedulePowerAction
 	origWipe := performZeroizeWipe
+	origStop := scheduleStopDaemon
 	t.Cleanup(func() {
 		schedulePowerAction = origPower
 		performZeroizeWipe = origWipe
+		scheduleStopDaemon = origStop
 	})
 	var poweredArg string
 	var wiped bool
 	schedulePowerAction = func(arg string) { poweredArg = arg }
 	performZeroizeWipe = func() error { wiped = true; return nil }
+	scheduleStopDaemon = func() {}
 
 	cases := []struct {
 		action      string

--- a/pkg/grpcapi/zeroize_gate_stop_5281_test.go
+++ b/pkg/grpcapi/zeroize_gate_stop_5281_test.go
@@ -1,0 +1,149 @@
+package grpcapi
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// TestZeroizeGoesThroughGateAndStopsDaemon pins the #5281 contract at the RPC
+// boundary: a gRPC `zeroize` SystemAction must (a) run the wipe THROUGH the
+// daemon apply gate (Config.ZeroizeFn / s.zeroizeFn), not call performZeroizeWipe
+// directly, and (b) STOP xpfd after a fully-successful wipe (scheduleStopDaemon)
+// so the daemon does not keep running with the pre-wipe in-memory config and
+// re-render the erased secrets.
+//
+// The destructive side effects are stubbed via the package seams, so the test
+// drives the real SystemAction dispatch without touching disk or a real daemon.
+//
+// RED on revert: restoring the pre-#5281 handler (which called
+// performZeroizeWipe directly and never stopped xpfd) makes gateUsed stay false
+// (the gate is bypassed) AND stopped stay false (no stop scheduled), so this
+// test fails.
+func TestZeroizeGoesThroughGateAndStopsDaemon(t *testing.T) {
+	origWipe := performZeroizeWipe
+	origStop := scheduleStopDaemon
+	t.Cleanup(func() {
+		performZeroizeWipe = origWipe
+		scheduleStopDaemon = origStop
+	})
+
+	// seq records the ORDER of the observable steps so the test proves the
+	// sequence is gate → wipe → stop (never stop-before-wipe, never a bypassed
+	// gate).
+	var seq []string
+	performZeroizeWipe = func() error { seq = append(seq, "wipe"); return nil }
+	scheduleStopDaemon = func() { seq = append(seq, "stop") }
+
+	var gateWipeArg func() error
+	dir := t.TempDir()
+	store := newConfigStore(t, filepath.Join(dir, "xpf.conf"))
+	s := &Server{
+		store: store,
+		// The gate fake records that the handler routed through it, captures the
+		// wipe closure the handler passed (must be performZeroizeWipe), and runs
+		// it — exactly as the real daemon factoryReset does under applySem.
+		zeroizeFn: func(_ context.Context, wipe func() error) error {
+			seq = append(seq, "gate")
+			gateWipeArg = wipe
+			return wipe()
+		},
+	}
+
+	resp, err := s.SystemAction(context.Background(), &pb.SystemActionRequest{Action: "zeroize"})
+	if err != nil {
+		t.Fatalf("SystemAction(zeroize): %v", err)
+	}
+	if resp == nil || resp.Message == "" {
+		t.Fatalf("SystemAction(zeroize) returned empty response: %+v", resp)
+	}
+
+	// The wipe ran through the gate (not directly): the handler passed
+	// performZeroizeWipe into ZeroizeFn.
+	if gateWipeArg == nil {
+		t.Fatal("zeroize did not route the wipe through the apply gate (ZeroizeFn)")
+	}
+	if reflect.ValueOf(gateWipeArg).Pointer() != reflect.ValueOf(performZeroizeWipe).Pointer() {
+		t.Fatal("zeroize passed a different wipe closure to the gate than performZeroizeWipe")
+	}
+
+	// Exact sequence: gate first, wipe under it, daemon stop last.
+	if want := []string{"gate", "wipe", "stop"}; !reflect.DeepEqual(seq, want) {
+		t.Fatalf("zeroize step sequence = %v, want %v", seq, want)
+	}
+}
+
+// TestZeroizeFailClosedDoesNotStopDaemon pins the fail-closed half of #5281: if
+// the wipe does not fully complete, the handler must surface the error AND must
+// NOT stop xpfd (stopping a half-wiped box would strand prior-tenant secrets on
+// disk while the daemon is down).
+func TestZeroizeFailClosedDoesNotStopDaemon(t *testing.T) {
+	origWipe := performZeroizeWipe
+	origStop := scheduleStopDaemon
+	t.Cleanup(func() {
+		performZeroizeWipe = origWipe
+		scheduleStopDaemon = origStop
+	})
+
+	wantErr := errors.New("configdb not fully erased")
+	performZeroizeWipe = func() error { return wantErr }
+	var stopped bool
+	scheduleStopDaemon = func() { stopped = true }
+
+	var gateUsed bool
+	dir := t.TempDir()
+	store := newConfigStore(t, filepath.Join(dir, "xpf.conf"))
+	s := &Server{
+		store: store,
+		zeroizeFn: func(_ context.Context, wipe func() error) error {
+			gateUsed = true
+			return wipe()
+		},
+	}
+
+	resp, err := s.SystemAction(context.Background(), &pb.SystemActionRequest{Action: "zeroize"})
+	if err == nil {
+		t.Fatalf("SystemAction(zeroize) with a failed wipe must return an error; got resp=%+v", resp)
+	}
+	if !gateUsed {
+		t.Fatal("zeroize must still route through the apply gate on the failure path")
+	}
+	if stopped {
+		t.Fatal("zeroize must NOT stop the daemon when the wipe did not complete (fail-closed)")
+	}
+}
+
+// TestZeroizeFallsBackToDirectWipeWithoutGate pins the NoDataplane / no-daemon
+// fallback: with ZeroizeFn unset, the handler still wipes (via performZeroizeWipe
+// directly) and still stops the daemon — the pre-#5281 behavior, preserved for a
+// build with no running reconcile loop to race.
+func TestZeroizeFallsBackToDirectWipeWithoutGate(t *testing.T) {
+	origWipe := performZeroizeWipe
+	origStop := scheduleStopDaemon
+	t.Cleanup(func() {
+		performZeroizeWipe = origWipe
+		scheduleStopDaemon = origStop
+	})
+
+	var wiped, stopped bool
+	performZeroizeWipe = func() error { wiped = true; return nil }
+	scheduleStopDaemon = func() { stopped = true }
+
+	dir := t.TempDir()
+	store := newConfigStore(t, filepath.Join(dir, "xpf.conf"))
+	s := &Server{store: store} // zeroizeFn nil
+
+	if _, err := s.SystemAction(context.Background(), &pb.SystemActionRequest{Action: "zeroize"}); err != nil {
+		t.Fatalf("SystemAction(zeroize) fallback: %v", err)
+	}
+	if !wiped {
+		t.Fatal("zeroize fallback must still run performZeroizeWipe")
+	}
+	if !stopped {
+		t.Fatal("zeroize fallback must still stop the daemon")
+	}
+}


### PR DESCRIPTION
Closes #5281

## Problem

The gRPC `SystemAction{zeroize}` handler called `performZeroizeWipe`
directly with **no lifecycle coordination** and **never stopped xpfd**.
Commit/apply/HA-sync serialize on the daemon's `applySem`, but zeroize
bypassed that gate and, after reporting a clean factory reset, left the
daemon running with the pre-wipe in-memory `ActiveConfig`. The next
reconcile / commit / HA-sync (or a concurrent in-flight apply) then
re-rendered the erased secrets (frr.conf, swanctl PSKs, Kea, provisioned
login accounts) and re-created the `.configdb` SSOT — recreating
prior-tenant state after the wipe reported success (a security-sensitive
incomplete-wipe window).

Locations (origin/master): `pkg/grpcapi/server_diag_system_action.go`
(zeroize case), `pkg/daemon/daemon_apply.go` (applySem), `pkg/daemon/daemon_run.go`
(server wiring).

## Fix — daemon-owned, sequenced wipe → stop, fail-closed

- **New `factoryReset`** (`pkg/daemon/daemon_apply.go`) acquires the SAME
  `applySem` commit/apply/HA-sync serialize on (draining any in-flight
  apply), enters a **terminal reset generation** (`d.resetting`) BEFORE
  the wipe, and runs the wipe under the gate. On success the generation
  stays set for the daemon's remaining lifetime; on a wipe error it
  **fail-closes** (exits the generation, releases the gate) so a
  half-reset box is recoverable.
- **Config writers short-circuit on `errDaemonResetting`** once the reset
  generation is entered: `commitAndApply` / `commitConfirmedAndApply` /
  `syncAndApply` reject **before persisting** (a racing commit/HA-sync
  cannot re-create the erased SSOT), `executeConfirmedRollback` skips,
  `applyConfigLocked` refuses (defense-in-depth), and
  `ipsecApplyForLeaseChange` refuses (the periodic DHCP-lease swanctl PSK
  re-render).
- **Handler routes through the gate + stops xpfd**
  (`pkg/grpcapi/server_diag_system_action.go`): `factoryReset` is wired as
  `grpcapi.Config.ZeroizeFn`; the handler runs the wipe via `s.zeroizeFn`
  (falling back to a direct wipe only when nil, i.e. NoDataplane) and, on
  a fully-successful wipe, schedules `scheduleStopDaemon`
  (`systemctl stop xpfd` after a 1s grace, mirroring the local
  `request system zeroize` CLI in `pkg/cli`). Sequence is strictly
  **gate → wipe → stop**; a wipe that does not complete returns `Internal`
  and does **not** stop the daemon.

The `#4108` action-journal write still happens **before** the wipe.

## Scope

Sibling issues **#5280** (zeroize erases the hardcoded `/etc/xpf` root,
not the configured `-config` root) and **#5278** (per-principal loopback
auth) are intentionally **out of scope** — this PR touches only the
gate/stop lifecycle, not the wipe roots or auth, so there are no
overlapping edits.

## Tests (RED on revert)

- `pkg/grpcapi/zeroize_gate_stop_5281_test.go` — asserts the
  **gate → wipe → stop** order, fail-closed **no-stop** on a failed wipe,
  and the no-gate fallback. Reverting to the pre-#5281 direct-wipe handler
  makes it fail (gate bypassed + no stop). Verified RED-on-revert.
- `pkg/daemon/factory_reset_5281_test.go` — proves the real
  `applySem`/`resetting` semantics: gate-first acquire (surfaces `ctx.Err`
  while held, no wipe, no generation), terminal generation on success with
  the gate released, commit/commit-confirmed/HA-sync/reconcile/ipsec-rebind
  all rejected during reset, and fail-closed clearing the generation.
- Updated `system_action_journal_4108_test.go` to neutralize the new
  `scheduleStopDaemon` seam.

## Validation

- `GOCACHE=/tmp/gocache-5281 GOTMPDIR=/tmp go build ./...` — green
- `go test -race ./pkg/grpcapi/... ./pkg/daemon/...` — green
- `gofmt` + `go vet` clean

Module docs updated: `pkg/grpcapi/README.md` and `pkg/daemon/README.md`
document the zeroize gate + stop contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACjfdaYEnAa8jJ6sB3RP4L